### PR TITLE
Op to Op latency tools

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/kernels/bw_and_latency.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/kernels/bw_and_latency.cpp
@@ -2,6 +2,23 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+// CB id this instance operates on. Defaults to 0 (single-kernel read/write test). The concurrent
+// read+write DRAM-contention mode (-rw) instantiates two kernels on the same core, one per NoC, and
+// gives them distinct CBs so the reader's fill and the writer's drain use separate L1 regions.
+#ifndef CB_ID
+#define CB_ID 0
+#endif
+
+// DRAM_BANKED addressing knobs. BANK_BASE_ADDR = allocated buffer's base (0 = raw). TARGET_BANK >= 0 pins
+// every access to one DRAM bank (page_id = TARGET_BANK + j*NUM_DRAM_BANKS); -1 = interleave across banks.
+// Coords come from the device bank->NoC table (get_dram_noc_addr, per-NoC), so no manual NoC coord math.
+#ifndef BANK_BASE_ADDR
+#define BANK_BASE_ADDR 0
+#endif
+#ifndef TARGET_BANK
+#define TARGET_BANK (-1)
+#endif
+
 void kernel_main() {
 #if NOP_COUNT
     for (int i = 0; i < ITERATIONS; i++) {
@@ -17,14 +34,21 @@ void kernel_main() {
     uint32_t page_size = get_arg_val<uint32_t>(0);
 #endif
 
-    cb_reserve_back(0, PAGE_COUNT);
-    uint32_t cb_addr = get_write_ptr(0);
+    cb_reserve_back(CB_ID, PAGE_COUNT);
+    uint32_t cb_addr = get_write_ptr(CB_ID);
     for (int i = 0; i < ITERATIONS; i++) {
         uint32_t read_ptr = cb_addr;
         uint32_t write_ptr = cb_addr;
         for (int j = 0; j < PAGE_COUNT; j++) {
 #if DRAM_BANKED
-            uint64_t noc_addr = get_dram_noc_addr(j, page_size, 0);
+#if TARGET_BANK >= 0
+            const uint32_t page_id = TARGET_BANK + j * NUM_DRAM_BANKS;  // pin all accesses to one bank
+#else
+            const uint32_t page_id = j;  // interleave across all banks
+#endif
+            // get_dram_noc_addr resolves the bank's NoC coord from the device bank->NoC table for THIS
+            // kernel's NoC (noc_index) automatically -- reader on NOC0, writer on NOC1, no manual flip.
+            uint64_t noc_addr = get_dram_noc_addr(page_id, page_size, BANK_BASE_ADDR);
 #else
             uint64_t noc_addr = NOC_XY_ADDR(NOC_X(NOC_ADDR_X), NOC_Y(NOC_ADDR_Y), NOC_MEM_ADDR);
 #endif
@@ -35,8 +59,12 @@ void kernel_main() {
             noc_async_write_multicast(read_ptr, dst_noc_multicast_addr, page_size, NUM_MCAST_DESTS, LINKED);
 #elif WRITE
 #if WRITE_DRAM
+#if DRAM_BANKED
+            noc_async_write(write_ptr, noc_addr, page_size);  // dest bank NoC coord from bank->NoC table
+#else
             uint64_t noc_write_addr = NOC_XY_ADDR(NOC_X(NOC_ADDR_X), NOC_Y(NOC_ADDR_Y), NOC_MEM_ADDR);
             noc_async_write(write_ptr, noc_write_addr, page_size);
+#endif
 #else
             uint64_t noc_write_addr = NOC_XY_ADDR(NOC_X(NOC_ADDR_X), NOC_Y(NOC_ADDR_Y), write_ptr);
             noc_async_write(NOC_MEM_ADDR, noc_write_addr, page_size);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_bw_and_latency.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_bw_and_latency.cpp
@@ -73,6 +73,8 @@ bool hammer_write_reg_g = false;
 bool hammer_pcie_g = false;
 bool hammer_pcie_type_g = false;
 bool test_write = false;
+bool test_rw_g = false;  // concurrent read+write to the SAME DRAM channel from the SAME cores
+bool safebuf_g = false;  // read/write ALLOCATED DRAM buffers (not raw offset 0). Required for DRAM writes.
 bool linked = false;
 bool read_profiler_results = false;
 uint32_t nop_count_g = 0;
@@ -109,6 +111,14 @@ void init(int argc, char** argv) {
         log_info(LogTest, "  -drx: when reading/writing dram, X of end core for worker range (default same as -rx)");
         log_info(LogTest, "  -dry: when reading/writing dram, Y of end core for worker range (default same as -ry)");
         log_info(LogTest, "  -wr: issue unicast write instead of read (default false)");
+        log_info(
+            LogTest,
+            "  -rw: concurrent read+write to the SAME DRAM channel from the SAME cores (reader on NOC0, writer "
+            "on NOC1); reports combined R+W bandwidth. DRAM only (-m 1). Isolates DRAM-endpoint read/write "
+            "contention from NoC-fabric contention. (default false)");
+        log_info(
+            LogTest,
+            "  -safebuf: read/write allocated DRAM buffers instead of raw offset 0 (auto-on for -rw and DRAM writes)");
         log_info(LogTest, "  -c: when reading/writing dram, DRAM channel (default 0)");
         log_info(LogTest, "  -f: time just the finish call (default disabled)");
         log_info(LogTest, "  -o: use read_one_packet API.  restricts page size to 8K max (default {})", 0);
@@ -155,6 +165,18 @@ void init(int argc, char** argv) {
     if (test_write && (source_mem_g != 1 && source_mem_g != 2 && source_mem_g != 6)) {
         log_info(LogTest, "Writing only tested w/ DRAM or L1 destination\n");
         exit(-1);
+    }
+
+    test_rw_g = test_args::has_command_option(input_args, "-rw");
+    if (test_rw_g && source_mem_g != 1) {
+        log_info(LogTest, "-rw (concurrent read+write) only supported with DRAM (-m 1)\n");
+        exit(-1);
+    }
+    // Writing to raw DRAM offset 0 clobbers reserved DRAM (kernel binaries / dispatch) and hangs the chip.
+    // Any DRAM write must target an allocated buffer; force safe buffers for -rw and DRAM writes.
+    safebuf_g = test_args::has_command_option(input_args, "-safebuf");
+    if (test_rw_g || (test_write && source_mem_g == 1)) {
+        safebuf_g = true;
     }
 
     linked = test_args::has_command_option(input_args, "-link");
@@ -235,6 +257,12 @@ int main(int argc, char** argv) {
         uint32_t num_mcast_dests = mcast_src_workers_g.size();
         uint32_t mcast_noc_addr_end_x = 0;
         uint32_t mcast_noc_addr_end_y = 0;
+        // Allocated DRAM buffers for the concurrent read+write test (-safebuf): interleaved across all banks
+        // so nothing reserved gets clobbered. The -rw kernels address one bank's slice via the bank->NoC
+        // addr-gen (get_dram_noc_addr), which resolves each kernel's per-NoC coord automatically. Kept in
+        // scope until after Finish so they stay allocated.
+        std::shared_ptr<tt::tt_metal::distributed::MeshBuffer> in_buf, out_buf;
+        uint64_t read_base_addr = 0, write_base_addr = 0;
 
         ChipId mmio_device_id =
             tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(device_id);
@@ -265,9 +293,33 @@ int main(int argc, char** argv) {
                     "DRAM channel {} not available, only {} channels found",
                     dram_channel_g,
                     dram_cores.size());
-                noc_addr_x = dram_cores[dram_channel_g].x;
+                noc_addr_x = dram_cores[dram_channel_g].x;  // single-dir path targets this DRAM NoC core
                 noc_addr_y = dram_cores[dram_channel_g].y;
                 write_dram = test_write;
+                if (safebuf_g) {
+                    // Interleaved DRAM buffers sized so every bank holds >= PAGE_COUNT pages. -rw addresses
+                    // one bank's slice (page_id = TARGET_BANK + j*NUM_DRAM_BANKS) through the bank->NoC
+                    // addr-gen, so the writer's NOC1 coord is resolved from the device table -- no manual
+                    // coords. For -rw, `-c` is a DRAM bank index (0..num_banks-1), not a NoC-core index.
+                    const uint32_t nbanks = mesh_device->allocator()->get_num_banks(BufferType::DRAM);
+                    const uint64_t per_bank = static_cast<uint64_t>(page_size_g) * page_count_g;
+                    tt::tt_metal::distributed::DeviceLocalBufferConfig lc{
+                        .page_size = page_size_g, .buffer_type = BufferType::DRAM};
+                    tt::tt_metal::distributed::ReplicatedBufferConfig bc{.size = per_bank * nbanks};
+                    in_buf = tt::tt_metal::distributed::MeshBuffer::create(bc, lc, mesh_device.get());
+                    out_buf = tt::tt_metal::distributed::MeshBuffer::create(bc, lc, mesh_device.get());
+                    read_base_addr = in_buf->address();
+                    write_base_addr = out_buf->address();
+                    noc_mem_addr = test_write ? write_base_addr : read_base_addr;  // single-dir NOC_XY path
+                    log_info(
+                        LogTest,
+                        "safebuf: in_buf@{} out_buf@{} ({} banks, {} B/bank); -rw targets bank {}",
+                        read_base_addr,
+                        write_base_addr,
+                        nbanks,
+                        per_bank,
+                        dram_channel_g);
+                }
             } break;
             case 2: {
                 src_mem = test_write ? "TO_L1" : "FROM_L1";
@@ -333,28 +385,79 @@ int main(int argc, char** argv) {
             defines.insert(std::pair<std::string, std::string>("PAGE_SIZE", std::to_string(page_size_g)));
         }
 
+        const std::string kKernel = "tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/kernels/bw_and_latency.cpp";
+
         tt_metal::CircularBufferConfig cb_config =
             tt_metal::CircularBufferConfig(page_size_g * page_count_g, {{0, tt::DataFormat::Float32}})
                 .set_page_size(0, page_size_g);
         tt_metal::CreateCircularBuffer(program, worker_g, cb_config);
 
-        auto dm0 = tt_metal::CreateKernel(
-            program,
-            "tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/kernels/bw_and_latency.cpp",
-            worker_g,
-            tt_metal::DataMovementConfig{
-                .processor = tt_metal::DataMovementProcessor::RISCV_0,
-                .noc = tt_metal::NOC::RISCV_0_default,
-                .defines = defines});
-        if (page_size_as_runtime_arg_g) {
-            tt_metal::SetRuntimeArgs(program, dm0, worker_g, {page_size_g});
+        if (test_rw_g) {
+            // Concurrent read+write to the same DRAM channel from the same cores: a reader on NOC0 and a
+            // writer on NOC1, co-resident on every worker core (mirrors the real reader/writer op split).
+            // Separate CBs so the two directions use independent L1 regions and neither back-pressures the
+            // other -- both blast the channel at max rate so combined BW exposes DRAM-endpoint R/W contention.
+            tt_metal::CircularBufferConfig cb_config1 =
+                tt_metal::CircularBufferConfig(page_size_g * page_count_g, {{1, tt::DataFormat::Float32}})
+                    .set_page_size(1, page_size_g);
+            tt_metal::CreateCircularBuffer(program, worker_g, cb_config1);
+
+            // Both kernels use the bank->NoC addr-gen pinned to bank `-c`; get_dram_noc_addr resolves the
+            // per-NoC coord (reader NOC0, writer NOC1) from the device table -- no manual coords needed.
+            const std::string bank = std::to_string(dram_channel_g);
+            auto rd_defines = defines;
+            rd_defines["WRITE"] = "0";
+            rd_defines["DRAM_BANKED"] = "1";
+            rd_defines["TARGET_BANK"] = bank;
+            rd_defines["BANK_BASE_ADDR"] = std::to_string(read_base_addr);  // reader <- allocated in_buf
+            rd_defines["CB_ID"] = "0";
+            auto wr_defines = defines;
+            wr_defines["WRITE"] = "1";
+            wr_defines["WRITE_DRAM"] = "1";
+            wr_defines["DRAM_BANKED"] = "1";
+            wr_defines["TARGET_BANK"] = bank;
+            wr_defines["BANK_BASE_ADDR"] = std::to_string(write_base_addr);  // writer -> allocated out_buf
+            wr_defines["CB_ID"] = "1";
+
+            auto dm_rd = tt_metal::CreateKernel(
+                program,
+                kKernel,
+                worker_g,
+                tt_metal::DataMovementConfig{
+                    .processor = tt_metal::DataMovementProcessor::RISCV_1,
+                    .noc = tt_metal::NOC::NOC_0,
+                    .defines = rd_defines});
+            auto dm_wr = tt_metal::CreateKernel(
+                program,
+                kKernel,
+                worker_g,
+                tt_metal::DataMovementConfig{
+                    .processor = tt_metal::DataMovementProcessor::RISCV_0,
+                    .noc = tt_metal::NOC::NOC_1,
+                    .defines = wr_defines});
+            if (page_size_as_runtime_arg_g) {
+                tt_metal::SetRuntimeArgs(program, dm_rd, worker_g, {page_size_g});
+                tt_metal::SetRuntimeArgs(program, dm_wr, worker_g, {page_size_g});
+            }
+        } else {
+            auto dm0 = tt_metal::CreateKernel(
+                program,
+                kKernel,
+                worker_g,
+                tt_metal::DataMovementConfig{
+                    .processor = tt_metal::DataMovementProcessor::RISCV_0,
+                    .noc = tt_metal::NOC::RISCV_0_default,
+                    .defines = defines});
+            if (page_size_as_runtime_arg_g) {
+                tt_metal::SetRuntimeArgs(program, dm0, worker_g, {page_size_g});
+            }
         }
         mesh_workload.add_program(
             tt::tt_metal::distributed::MeshCoordinateRange(mesh_device->shape()), std::move(program));
 
         CoreCoord w = mesh_device->worker_core_from_logical_core(worker_g.start_coord);
         log_info(LogTest, "Master core: {}", w.str());
-        std::string direction = test_write ? "Writing" : "Reading";
+        std::string direction = test_rw_g ? "Read+Write" : (test_write ? "Writing" : "Reading");
         if (source_mem_g == 3) {
             log_info(LogTest, "{}: {}", direction, src_mem);
         } else if (source_mem_g == 4) {
@@ -496,11 +599,14 @@ int main(int argc, char** argv) {
                 (float)std::chrono::duration_cast<std::chrono::microseconds>(elapsed_seconds).count() /
                     (page_count_g * iterations_g));
         } else {
-            float bw = (float)page_count_g * (float)page_size_g * (float)iterations_g * (float)worker_g.size() /
-                       (elapsed_seconds.count() * 1000.0 * 1000.0 * 1000.0);
+            // In -rw mode each core moves a page IN (read) and a page OUT (write) per iteration, so the
+            // bytes crossing the DRAM channel are 2x. Reported BW is the COMBINED read+write throughput.
+            float directions = test_rw_g ? 2.0f : 1.0f;
+            float bw = directions * (float)page_count_g * (float)page_size_g * (float)iterations_g *
+                       (float)worker_g.size() / (elapsed_seconds.count() * 1000.0 * 1000.0 * 1000.0);
             std::stringstream ss;
             ss << std::fixed << std::setprecision(3) << bw;
-            log_info(LogTest, "BW: {} GB/s", ss.str());
+            log_info(LogTest, "BW: {} GB/s{}", ss.str(), test_rw_g ? " (combined read+write)" : "");
         }
 
         if (read_profiler_results) {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/README.md
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/README.md
@@ -1,0 +1,233 @@
+# `op_to_op_latency` — back-to-back program latency & DRAM-BW benchmark
+
+Measures per-core latency and DRAM bandwidth across a back-to-back program (op) boundary: from when
+one program finishes writing to when the next starts reading/computing. Arch-neutral; the bandwidth
+figures quoted here are Blackhole.
+
+## Pipeline
+
+On every Tensix core, the same `MeshWorkload` is enqueued `--num-programs N` times (FD or trace):
+
+```
+reader (NOC0) ──CB_in──▶ compute (3 TRISCs) ──CB_out──▶ writer (NOC1)
+  interleaved DRAM        UNPACK / MATH / PACK          write + end barrier
+```
+
+Kernel markers in the device CSV (all kernels also emit `PROG_ID`; 0 = warmup, 1..N = timed):
+
+| RISC | role | markers |
+|---|---|---|
+| TRISC_0 unpack | `TILE_IDX`=*i* at tile *i* start |
+| TRISC_2 pack | `FINISH_LAST_PUSH` at kernel exit |
+| NCRISC reader | `NCRISC_GO/DONE`; `READ_BEFORE/LAST_BARRIER` |
+| BRISC writer | `BRISC_GO/DONE`; `WRITE_BEFORE/LAST_ISSUED/AFTER_BARRIER` |
+
+## Build & run
+
+```bash
+export TT_METAL_HOME=$(pwd) TT_METAL_DEVICE_PROFILER=1
+./build_metal.sh --build-tests            # first time
+cmake --build build_RelWithDebInfo --target test_op_to_op_latency -j
+BIN=build_RelWithDebInfo/test/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency
+
+$BIN --use-trace --num-programs 2 --compute-nops 1000 --use-device-profiler
+```
+
+**Steady-state recipe** (what the sweeps use): trace + warmup so timings stabilize, drop trace-start
+transitions, per-trid double-buffered reader, output CB past the compute-bubble knee.
+
+```bash
+$BIN --num-active-cores 56 --num-pages-per-core 64 --compute-nops 256 \
+  --input-cb-depth-tiles 16 --output-cb-depth-tiles 32 \
+  --reader-dbuf-trid --reader-trid-in-flight 4 --reader-push-tiles 2 \
+  --writer-end-barrier-mode 0 --num-programs 4 --use-trace --trace-warmup-replays 2 \
+  --lean-compute --use-device-profiler
+```
+
+(`--reader-dbuf-trid` is reader mode 2, which already implies `--skip-output-validation`.)
+
+## Profilers — which to use
+
+- **Realtime** (`--use-realtime-profiler` → `profile_log_device_rt.csv`): per-program dispatch
+  `go`/`done`, **dump-free**. Use for **absolute op-to-op / wall-clock** numbers.
+- **Device** (`--use-device-profiler` → `profile_log_device.csv`): rich per-core markers, but its
+  per-program L1→DRAM dump (~3 µs) lands in the op-to-op gap and inflates it. Use for **per-config
+  comparison, BW/skew, and per-core shape** — not absolute boundary timing.
+- **Accumulate** (`TT_METAL_PROFILER_ACCUMULATE=1`, upstream #48506) defers that dump by keeping
+  markers in L1, but is **not usable here**: it drops `PROG_ID`/the per-op report and asserts on this
+  benchmark's custom markers.
+
+## Key CLI flags
+
+| flag | default | meaning |
+|---|---:|---|
+| `--num-active-cores N` | 0 (full grid) | cap active cores (core-count sweeps) |
+| `--num-pages-per-core N` | 4 | interleaved DRAM pages/core = per-op work knob |
+| `--input-cb-depth-tiles N` / `--output-cb-depth-tiles N` | auto / 2 | CB depths |
+| `--reader-push-tiles N` | 2 | reader push-chunk size |
+| `--reader-dbuf-trid` / `--reader-trid-in-flight N` | off / 2 | reader mode 2 (per-trid double buffer) + reads-in-flight |
+| `--compute-nops N` | 0 | `TTI_NOP`s per tile (compute load) |
+| `--page-size-tiles N` | 1 | tiles per DRAM page = txn size (1/2/4 = 2K/4K/8K); >1 requires reader mode 2 |
+| `--lean-compute` | off | drop per-tile instrumentation only (copy/pack and nops still run) |
+| `--num-programs N` / `--kernel-unroll K` | 8 / 1 | back-to-back enqueues / reps fused into one program (no mid-barrier) |
+| `--use-trace` / `--trace-warmup-replays N` | off / 0 | capture-once-replay / untimed warmups |
+| `--writer-end-barrier-mode {0,1,2,3}` | 0 | end sync: barrier / flush-only / none / posted |
+| `--read-only` | off | writer skips DRAM writes + compute pass-through (isolate read BW); implies `--bypass-compute` |
+| `--write-only` | off | reader issues **no** NoC read + compute pass-through (isolate write BW); implies `--bypass-compute`. Pair with `--output-cb-depth-tiles >= 8` |
+| `--bypass-compute` | off | compute becomes a CB pass-through (no unpack/copy/pack/NOPs); implied by both single-direction modes, pass explicitly only for a full read+write op |
+| `--cross-program-dram-offset` | off | each program uses a disjoint DRAM slice |
+| `--write-progress-every N` / `--read-progress-every N` | 0 (off) | emit periodic `WRITE_PROG`/`READ_PROG` bytes-vs-time markers (guarded; instrumentation only) |
+| `--reader-noc {0,1}` / `--writer-noc {0,1}` | 0 / 1 | NoC assigned to each direction |
+| `--core-offset` / `--core-list "x,y;.."` / `--core-layout-col` / `--log-core-map` | — | place/log the active core set (logical coords; default row-major) |
+
+## Reader / writer modes
+
+- **Reader**: `0` push-1 incremental (default; simple reference — emits no `READ_LAST`, so it
+  **cannot measure read BW**, and requires `--page-size-tiles 1`) · `2` `--reader-dbuf-trid` per-trid
+  double buffer (highest per-core BW, the only BW-capable mode; needs
+  `input_cb_depth ≥ 2 × trid_in_flight × page_size_tiles`, and implies `--skip-output-validation`
+  since every read lands at one fixed L1 address).
+- **Writer**: flushes once per CB-worth (never per page). End sync via `--writer-end-barrier-mode`:
+  `0` barrier (DRAM ACK) · `1` flush (L1 drain only) · `2` none (next op may overlap in-flight writes) ·
+  `3` posted (fire-and-forget, no DRAM ACK generated).
+
+## Single-direction BW: `--read-only` / `--write-only`
+
+Each isolates one DRAM direction and takes **everything else** out of the measured path — the other
+direction's NoC traffic *and* the math datapath — and skips output validation, since nothing is copied.
+
+**Either flag is sufficient on its own.** It implies `--bypass-compute`, which in turn forces
+`--lean-compute` — necessary because the per-tile `TILE_IDX` stamp is gated by `PROFILE_PER_TILE`, not
+by `PASSTHROUGH`, so passthrough alone would skip the copy but still timestamp every tile and let
+instrumentation pace the pipeline. Passing `--lean-compute` alongside is redundant.
+
+`--lean-compute` is **not** a substitute for either: it drops only instrumentation, so the compute
+kernel still unpacks and packs every tile. Leaving compute in the path back-pressures the reader
+through `cb_in` once it can't keep up — harmless at high core counts, but at low core counts (high
+per-core BW) it turns a read measurement into a compute measurement.
+
+Pair `--write-only` with `--output-cb-depth-tiles >= 8`; the default 2 flushes after every write. To
+sweep CB depths for peak BW, loop `--input-cb-depth-tiles` / `--output-cb-depth-tiles` from a driver
+script (see `scripts/run_bw_vs_cores.sh`).
+
+## Sweep scripts
+
+All driver/analysis/chart scripts live in `scripts/`. Each sweep writes per-config runs under
+`generated/profiler/op_to_op_runs/…` and drives `decompose_latency_bw.py`; run from anywhere (they
+self-locate the repo root) and re-run with `BUILD=0` if the binary is already built.
+
+| script | purpose |
+|---|---|
+| `run_stage_a_sweep.sh` | Stage-A balanced-compute decomposition (layout × cores; tune CB, then latency) — the central sweep |
+| `run_bw_vs_cores.sh` | aggregate BW + done-skew + starvation vs core count (`READ_ONLY=1` for read-only) |
+| `run_bw_vs_trid_cores.sh` | read-only BW vs reads-in-flight (N) × core count |
+| `run_skew_vs_nops.sh` | writer done-skew vs compute load (nops/tile) |
+| `run_io_latency.sh` | two-sided I/O latency: read-fill vs N, and write-drain vs output CB depth (full op + `--write-only`), at cores {8,56} |
+| `run_noc_dependence.sh` | read-only BW vs spatial extent (rows/cols) × NoC |
+| `run_read_stagger.sh` | induced per-core read-stagger → write de-correlation study |
+| `run_unroll_vs_b2b.sh` | fused (`--kernel-unroll K`, no mid-barrier) vs back-to-back wall-clock |
+
+## Analysis / chart scripts
+
+| script | purpose |
+|---|---|
+| `export_op_to_op_profiler_csv.py` | main exporter: device (+ rt) CSV → per-transition gaps, summaries, timeline; `--min-prog-id N` drops trace-start transitions |
+| `decompose_latency_bw.py` | per-sweep analyzer (BW, skew, latency components); driven by every sweep |
+| `event_timeline.py` | per-op event timeline (used by stage-A / read-stagger sweeps) |
+| `chart_rolloff.py` | robust BW-over-time / roll-off & fast-vs-slow allocation (`--anchor-first`) |
+| `chart_txnsize.py` | `overall_bw_gbps` (total bytes / kernel envelope) + done-spread vs core count, one line per DRAM txn size (2K/4K/8K = `--page-size-tiles 1/2/4`); `--csv`/`--title`/`--note`/`--bw-label` (used for both read and write charts) |
+| `chart_raw_graph.py` | render the device-program RAW dependency DAG (graphviz PNG+SVG) from a capture: green border = boundary relaxable, orange = unresolved (predecessor in-place), gray dashed = in-place op, black arrow = RAW dep; `--resolve-inplace`/`--add-edge P:C`/`--range START:END` (see RAW-hazard section) |
+| `chart_timeline_k2.py` | K=2 back-to-back vs fused per-core timeline (also provides `per_core_invocations`) |
+| `chart_active_cores.py` · `chart_core_heatmap.py` | active-cores + delivered BW over time · per-core finish heatmap |
+| `chart_read_stagger.py` · `chart_timeline_bars.py` · `chart_unroll_vs_b2b.py` | figure generators for the corresponding sweeps |
+
+## RAW-hazard analysis (cross-model barrier-relaxation opportunity)
+
+`raw_hazard_analyzer.py` measures how often back-to-back **device programs** have **no** read-after-write
+dependency — the legality signal for relaxing an op-boundary barrier. It parses a ttnn graph capture,
+reduces it to device programs, matches producer→consumer on **buffer address** (tensor_id is re-wrapped
+between ops and unreliable), and reports: adjacent-RAW / confirmed-reorderable / unresolved-in-place %,
+distance-to-first-consumer, critical path (independence ceiling), WAW (true vs allocator-reuse), and
+shard locality (cross-core reliable floor vs same-core upper bound). Has `--self-test`.
+
+Capture a model's graph (random weights — only op *structure* matters, not values), then analyze:
+
+```bash
+PY=python_env/bin/python3
+D=tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/scripts
+$PY $D/capture_mamba.py                        # -> /tmp/mamba_capture.json
+$PY $D/raw_hazard_analyzer.py /tmp/mamba_capture.json
+```
+
+| capture script | model / architecture type | notes |
+|---|---|---|
+| `capture_decoder_layer.py` | Llama-style decoder layer (transformer decode) | fused SDPA |
+| `capture_sdxl_unet.py` | SDXL UNet (diffusion, conv+attention) | needs slow dispatch |
+| `capture_mamba.py` | Mamba-2.8b (state-space / selective scan) | needs slow dispatch; config is hardcoded for d_model=2560 (use the 2.8b variant) |
+| `capture_whisper.py` | Whisper-base (encoder-decoder, cross-attention) | fast dispatch OK |
+
+Visualize any capture with `chart_raw_graph.py <capture.json> --out <base>` (graphviz DAG, see chart
+table). The most faithful Llama graph comes from the **real checkpointed** `TransformerBlock` (fused QKV,
+paged KV, in-place RoPE/cache), not a hand-built layer: run `models/tt_transformers/tests/test_model.py`
+`-k "performance and quick"` (`HF_MODEL=unsloth/Llama-3.2-1B-Instruct MESH_DEVICE=N150`, dummy weights)
+with a monkeypatch plugin that wraps `TransformerBlock.forward` in graph capture.
+
+**Two gotchas:**
+
+- Use **`RunMode.NORMAL`**, not `NO_DISPATCH` — `NO_DISPATCH` skips buffer allocation, so tensors carry
+  no address and producer→consumer chaining collapses into falsely-low RAW (SDXL reads 92%
+  reorderable-adjacency under `NO_DISPATCH` vs 26% under `NORMAL`).
+- Models whose ttnn configs hardcode a full **8×8** grid (SDXL, Mamba) abort config validation on this
+  box's harvested **8×7** grid (`program_config grid (8x8) must be contained within device grid (8x7)`).
+  Run with **`TT_METAL_SLOW_DISPATCH_MODE=1`** — slow dispatch frees the Tensix row that fast dispatch
+  reserves for dispatch kernels, exposing the full 8×8. Capture only needs one forward, so slow is fine.
+
+**Resolving dropped edges — `--resolve-inplace`, `--add-edge`, `--range`.** The capture drops dependency
+edges wherever an op emits **no output tensor**: in-place RMW ops (RoPE, PagedFusedUpdateCache), **all
+`NLPCreateHeads`**, and reshape/relayout **views** (buffer address lost). Consumers (especially SDPA) then
+look like independent roots, so raw critical-path slack is badly inflated. Flags on `raw_hazard_analyzer.py`
+(and `chart_raw_graph.py`):
+
+- `--resolve-inplace` — treat a no-output op as read-modify-write (inputs ARE its outputs) **and** auto-infer
+  create-heads→SDPA edges. Use it for any attention model; it only ADDS edges (can never fabricate slack).
+  This is the trustworthy default. `chart_raw_graph.py` draws inferred edges dashed-orange.
+- `--add-edge P:C` — inject a known-real edge the capture can't recover (e.g. a reshape view). Explicit and
+  auditable; the Llama hand-verification uses `--add-edge 3:4 --add-edge 6:8` (view + RoPE→SDPA).
+- `--range START:END` (chart only) — draw a legible slice of a huge graph, e.g. one UNet block.
+
+**Findings (cross-model, `--resolve-inplace`).** `can't-hide` = critical-path / total = the latency floor
+after ideal reordering (everything off the longest chain is hideable); `reorder payoff` = 1 − can't-hide.
+
+| model | can't-hide | reorder payoff | basis |
+|---|--:|--:|---|
+| Llama-3.2-1B decode | ~90% | ~10% | hand-verified (`--add-edge 3:4 6:8`) |
+| Whisper-base (enc-dec) | ~70% | ~30% | estimate (view-break dominated) |
+| SDXL UNet (diffusion) | ~65% (floor 54%) | ~35% | estimate; floor rigorous w/ attention edges |
+| Mamba-2.8b (SSM) | ~61% | ~39% | trustworthy (0 unresolved) |
+| ResNet50 (CNN) | ~66% | ~34% | trustworthy (0 unresolved) |
+
+Takeaways: (1) **all these architectures are majority-serial** (60–90% can't-hide), so reorder payoff is
+real but the **minority** (10–40%); (2) **never trust critical-path slack on an attention model without
+`--resolve-inplace`** — dropped create-heads→SDPA and view edges inflate slack badly; (3) **WAW is
+negligible everywhere** (0 true — all allocator-reuse or in-place RMW), so a barrier relaxer only needs to
+reason about RAW. Residual uncertainty (view false-roots) is bracketed by a program-order-reconnect
+estimate, calibrated on Llama (est 86% vs true 90%); exact non-Llama numbers need the data-flow edges
+preserved at capture time (a ttnn-side change).
+
+## Files
+
+```
+test_op_to_op_latency.cpp          host test binary
+kernels/reader_interleaved.cpp     NCRISC reader (modes 0/2, cross-program offset, progress markers)
+kernels/writer_interleaved.cpp     BRISC writer (flush + end-barrier modes 0-3, unroll, markers)
+kernels/compute_copy_with_nops.cpp TRISC copy + tunable NOPs
+scripts/*.py                       captures, exporter, analyzers, chart + RAW-hazard generators (see tables)
+scripts/run_*.sh                   sweep drivers (see table above)
+```
+
+## Kernel profiler notes
+
+Do **not** use `DeviceZoneScopedMainN` in compute `kernel_main` (breaks `TRISC-KERNEL` pairing). Wrap
+unpack/pack timestamps in `UNPACK(...)` / `PACK(...)` so each marker lands on the intended TRISC.
+Kernels pick up `PROFILE_KERNEL` only when `TT_METAL_DEVICE_PROFILER=1` is set before the process
+starts; the JIT cache dependency-checks profiler macros (no manual clear needed).

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/README.md
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/README.md
@@ -1,0 +1,236 @@
+# `op_to_op_latency` — back-to-back program latency & DRAM-BW benchmark
+
+Measures per-core latency and DRAM bandwidth across a back-to-back program (op) boundary: from when
+one program finishes writing to when the next starts reading/computing. Arch-neutral; the bandwidth
+figures quoted here are Blackhole.
+
+## Pipeline
+
+On every Tensix core, the same `MeshWorkload` is enqueued `--num-programs N` times (FD or trace):
+
+```
+reader (NOC0) ──CB_in──▶ compute (3 TRISCs) ──CB_out──▶ writer (NOC1)
+  interleaved DRAM        UNPACK / MATH / PACK          write + end barrier
+```
+
+Kernel markers in the device CSV (all kernels also emit `PROG_ID`; 0 = warmup, 1..N = timed):
+
+| RISC | role | markers |
+|---|---|---|
+| TRISC_0 unpack | `TILE_IDX`=*i* at tile *i* start |
+| TRISC_2 pack | `FINISH_LAST_PUSH` at kernel exit |
+| NCRISC reader | `NCRISC_GO/DONE`; `READ_BEFORE/LAST_BARRIER` |
+| BRISC writer | `BRISC_GO/DONE`; `WRITE_BEFORE/LAST_ISSUED/AFTER_BARRIER` |
+
+## Build & run
+
+```bash
+export TT_METAL_HOME=$(pwd) TT_METAL_DEVICE_PROFILER=1
+./build_metal.sh --build-tests            # first time
+cmake --build build_RelWithDebInfo --target test_op_to_op_latency -j
+BIN=build_RelWithDebInfo/test/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency
+
+$BIN --use-trace --num-programs 2 --compute-nops 1000 --use-device-profiler
+```
+
+**Steady-state recipe** (what the sweeps use): trace + warmup so timings stabilize, drop trace-start
+transitions, per-trid double-buffered reader, output CB past the compute-bubble knee.
+
+```bash
+$BIN --num-active-cores 56 --num-pages-per-core 64 --compute-nops 256 \
+  --input-cb-depth-tiles 16 --output-cb-depth-tiles 32 \
+  --reader-dbuf-trid --reader-trid-in-flight 4 --reader-push-tiles 2 \
+  --writer-end-barrier-mode 0 --num-programs 4 --use-trace --trace-warmup-replays 2 \
+  --lean-compute --use-device-profiler
+```
+
+(`--reader-dbuf-trid` is reader mode 2, which already implies `--skip-output-validation`.)
+
+## Profilers — which to use
+
+- **Realtime** (`--use-realtime-profiler` → `profile_log_device_rt.csv`): per-program dispatch
+  `go`/`done`, **dump-free**. Use for **absolute op-to-op / wall-clock** numbers.
+- **Device** (`--use-device-profiler` → `profile_log_device.csv`): rich per-core markers, but its
+  per-program L1→DRAM dump (~3 µs) lands in the op-to-op gap and inflates it. Use for **per-config
+  comparison, BW/skew, and per-core shape** — not absolute boundary timing.
+- **Accumulate** (`TT_METAL_PROFILER_ACCUMULATE=1`, upstream #48506) defers that dump by keeping
+  markers in L1, but is **not usable here**: it drops `PROG_ID`/the per-op report and asserts on this
+  benchmark's custom markers.
+
+## Key CLI flags
+
+| flag | default | meaning |
+|---|---:|---|
+| `--num-active-cores N` | 0 (full grid) | cap active cores (core-count sweeps) |
+| `--num-pages-per-core N` | 4 | interleaved DRAM pages/core = per-op work knob |
+| `--input-cb-depth-tiles N` / `--output-cb-depth-tiles N` | auto / 2 | CB depths |
+| `--reader-push-tiles N` | 2 | reader push-chunk size |
+| `--reader-dbuf-trid` / `--reader-trid-in-flight N` | off / 2 | reader mode 2 (per-trid double buffer) + reads-in-flight |
+| `--reader-full-barrier` | off | reader mode 1: read `--reader-push-tiles` pages, one full barrier, push, repeat (common no-txn-id pattern; BW-capable) |
+| `--compute-nops N` | 0 | `TTI_NOP`s per tile (compute load) |
+| `--page-size-tiles N` | 1 | tiles per DRAM page = txn size (1/2/4 = 2K/4K/8K); >1 requires reader mode 2 |
+| `--lean-compute` | off | drop per-tile instrumentation only (copy/pack and nops still run) |
+| `--num-programs N` / `--kernel-unroll K` | 8 / 1 | back-to-back enqueues / reps fused into one program (no mid-barrier) |
+| `--use-trace` / `--trace-warmup-replays N` | off / 0 | capture-once-replay / untimed warmups |
+| `--writer-end-barrier-mode {0,1,2,3}` | 0 | end sync: barrier / flush-only / none / posted |
+| `--read-only` | off | writer skips DRAM writes + compute pass-through (isolate read BW); implies `--bypass-compute` |
+| `--write-only` | off | reader issues **no** NoC read + compute pass-through (isolate write BW); implies `--bypass-compute`. Pair with `--output-cb-depth-tiles >= 8` |
+| `--bypass-compute` | off | compute becomes a CB pass-through (no unpack/copy/pack/NOPs); implied by both single-direction modes, pass explicitly only for a full read+write op |
+| `--cross-program-dram-offset` | off | each program uses a disjoint DRAM slice |
+| `--write-progress-every N` / `--read-progress-every N` | 0 (off) | emit periodic `WRITE_PROG`/`READ_PROG` bytes-vs-time markers (guarded; instrumentation only) |
+| `--reader-noc {0,1}` / `--writer-noc {0,1}` | 0 / 1 | NoC assigned to each direction |
+| `--core-offset` / `--core-list "x,y;.."` / `--core-layout-col` / `--log-core-map` | — | place/log the active core set (logical coords; default row-major) |
+
+## Reader / writer modes
+
+- **Reader**: `0` push-1 incremental (default; simple reference — emits no `READ_LAST`, so it
+  **cannot measure read BW**, and requires `--page-size-tiles 1`) · `1` `--reader-full-barrier`
+  full-barrier batch (read `--reader-push-tiles` pages, one `noc_async_read_barrier`, push, repeat —
+  the common no-txn-id pattern; BW-capable, `--page-size-tiles 1`) · `2` `--reader-dbuf-trid` per-trid
+  double buffer (highest per-core BW, the only BW-capable mode; needs
+  `input_cb_depth ≥ 2 × trid_in_flight × page_size_tiles`, and implies `--skip-output-validation`
+  since every read lands at one fixed L1 address).
+- **Writer**: flushes once per CB-worth (never per page). End sync via `--writer-end-barrier-mode`:
+  `0` barrier (DRAM ACK) · `1` flush (L1 drain only) · `2` none (next op may overlap in-flight writes) ·
+  `3` posted (fire-and-forget, no DRAM ACK generated).
+
+## Single-direction BW: `--read-only` / `--write-only`
+
+Each isolates one DRAM direction and takes **everything else** out of the measured path — the other
+direction's NoC traffic *and* the math datapath — and skips output validation, since nothing is copied.
+
+**Either flag is sufficient on its own.** It implies `--bypass-compute`, which in turn forces
+`--lean-compute` — necessary because the per-tile `TILE_IDX` stamp is gated by `PROFILE_PER_TILE`, not
+by `PASSTHROUGH`, so passthrough alone would skip the copy but still timestamp every tile and let
+instrumentation pace the pipeline. Passing `--lean-compute` alongside is redundant.
+
+`--lean-compute` is **not** a substitute for either: it drops only instrumentation, so the compute
+kernel still unpacks and packs every tile. Leaving compute in the path back-pressures the reader
+through `cb_in` once it can't keep up — harmless at high core counts, but at low core counts (high
+per-core BW) it turns a read measurement into a compute measurement.
+
+Pair `--write-only` with `--output-cb-depth-tiles >= 8`; the default 2 flushes after every write. To
+sweep CB depths for peak BW, loop `--input-cb-depth-tiles` / `--output-cb-depth-tiles` from a driver
+script (see `scripts/run_bw_vs_cores.sh`).
+
+## Sweep scripts
+
+All driver/analysis/chart scripts live in `scripts/`. Each sweep writes per-config runs under
+`generated/profiler/op_to_op_runs/…` and drives `decompose_latency_bw.py`; run from anywhere (they
+self-locate the repo root) and re-run with `BUILD=0` if the binary is already built.
+
+| script | purpose |
+|---|---|
+| `run_stage_a_sweep.sh` | Stage-A balanced-compute decomposition (layout × cores; tune CB, then latency) — the central sweep |
+| `run_bw_vs_cores.sh` | aggregate BW + done-skew + starvation vs core count (`READ_ONLY=1` for read-only) |
+| `run_bw_vs_trid_cores.sh` | read-only BW vs reads-in-flight (N) × core count |
+| `run_skew_vs_nops.sh` | writer done-skew vs compute load (nops/tile) |
+| `run_io_latency.sh` | two-sided I/O latency: read-fill vs N, and write-drain vs output CB depth (full op + `--write-only`), at cores {8,56} |
+| `run_noc_dependence.sh` | read-only BW vs spatial extent (rows/cols) × NoC |
+| `run_read_stagger.sh` | induced per-core read-stagger → write de-correlation study |
+| `run_unroll_vs_b2b.sh` | fused (`--kernel-unroll K`, no mid-barrier) vs back-to-back wall-clock |
+
+## Analysis / chart scripts
+
+| script | purpose |
+|---|---|
+| `export_op_to_op_profiler_csv.py` | main exporter: device (+ rt) CSV → per-transition gaps, summaries, timeline; `--min-prog-id N` drops trace-start transitions |
+| `decompose_latency_bw.py` | per-sweep analyzer (BW, skew, latency components); driven by every sweep |
+| `event_timeline.py` | per-op event timeline (used by stage-A / read-stagger sweeps) |
+| `chart_rolloff.py` | robust BW-over-time / roll-off & fast-vs-slow allocation (`--anchor-first`) |
+| `chart_txnsize.py` | `overall_bw_gbps` (total bytes / kernel envelope) + done-spread vs core count, one line per DRAM txn size (2K/4K/8K = `--page-size-tiles 1/2/4`); `--csv`/`--title`/`--note`/`--bw-label` (used for both read and write charts) |
+| `chart_raw_graph.py` | render the device-program RAW dependency DAG (graphviz PNG+SVG) from a capture: green border = boundary relaxable, orange = unresolved (predecessor in-place), gray dashed = in-place op, black arrow = RAW dep; `--resolve-inplace`/`--add-edge P:C`/`--range START:END` (see RAW-hazard section) |
+| `chart_timeline_k2.py` | K=2 back-to-back vs fused per-core timeline (also provides `per_core_invocations`) |
+| `chart_active_cores.py` · `chart_core_heatmap.py` | active-cores + delivered BW over time · per-core finish heatmap |
+| `chart_read_stagger.py` · `chart_timeline_bars.py` · `chart_unroll_vs_b2b.py` | figure generators for the corresponding sweeps |
+
+## RAW-hazard analysis (cross-model barrier-relaxation opportunity)
+
+`raw_hazard_analyzer.py` measures how often back-to-back **device programs** have **no** read-after-write
+dependency — the legality signal for relaxing an op-boundary barrier. It parses a ttnn graph capture,
+reduces it to device programs, matches producer→consumer on **buffer address** (tensor_id is re-wrapped
+between ops and unreliable), and reports: adjacent-RAW / confirmed-reorderable / unresolved-in-place %,
+distance-to-first-consumer, critical path (independence ceiling), WAW (true vs allocator-reuse), and
+shard locality (cross-core reliable floor vs same-core upper bound). Has `--self-test`.
+
+Capture a model's graph (random weights — only op *structure* matters, not values), then analyze:
+
+```bash
+PY=python_env/bin/python3
+D=tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/scripts
+$PY $D/capture_mamba.py                        # -> /tmp/mamba_capture.json
+$PY $D/raw_hazard_analyzer.py /tmp/mamba_capture.json
+```
+
+| capture script | model / architecture type | notes |
+|---|---|---|
+| `capture_decoder_layer.py` | Llama-style decoder layer (transformer decode) | fused SDPA |
+| `capture_sdxl_unet.py` | SDXL UNet (diffusion, conv+attention) | needs slow dispatch |
+| `capture_mamba.py` | Mamba-2.8b (state-space / selective scan) | needs slow dispatch; config is hardcoded for d_model=2560 (use the 2.8b variant) |
+| `capture_whisper.py` | Whisper-base (encoder-decoder, cross-attention) | fast dispatch OK |
+
+Visualize any capture with `chart_raw_graph.py <capture.json> --out <base>` (graphviz DAG, see chart
+table). The most faithful Llama graph comes from the **real checkpointed** `TransformerBlock` (fused QKV,
+paged KV, in-place RoPE/cache), not a hand-built layer: run `models/tt_transformers/tests/test_model.py`
+`-k "performance and quick"` (`HF_MODEL=unsloth/Llama-3.2-1B-Instruct MESH_DEVICE=N150`, dummy weights)
+with a monkeypatch plugin that wraps `TransformerBlock.forward` in graph capture.
+
+**Two gotchas:**
+
+- Use **`RunMode.NORMAL`**, not `NO_DISPATCH` — `NO_DISPATCH` skips buffer allocation, so tensors carry
+  no address and producer→consumer chaining collapses into falsely-low RAW (SDXL reads 92%
+  reorderable-adjacency under `NO_DISPATCH` vs 26% under `NORMAL`).
+- Models whose ttnn configs hardcode a full **8×8** grid (SDXL, Mamba) abort config validation on this
+  box's harvested **8×7** grid (`program_config grid (8x8) must be contained within device grid (8x7)`).
+  Run with **`TT_METAL_SLOW_DISPATCH_MODE=1`** — slow dispatch frees the Tensix row that fast dispatch
+  reserves for dispatch kernels, exposing the full 8×8. Capture only needs one forward, so slow is fine.
+
+**Resolving dropped edges — `--resolve-inplace`, `--add-edge`, `--range`.** The capture drops dependency
+edges wherever an op emits **no output tensor**: in-place RMW ops (RoPE, PagedFusedUpdateCache), **all
+`NLPCreateHeads`**, and reshape/relayout **views** (buffer address lost). Consumers (especially SDPA) then
+look like independent roots, so raw critical-path slack is badly inflated. Flags on `raw_hazard_analyzer.py`
+(and `chart_raw_graph.py`):
+
+- `--resolve-inplace` — treat a no-output op as read-modify-write (inputs ARE its outputs) **and** auto-infer
+  create-heads→SDPA edges. Use it for any attention model; it only ADDS edges (can never fabricate slack).
+  This is the trustworthy default. `chart_raw_graph.py` draws inferred edges dashed-orange.
+- `--add-edge P:C` — inject a known-real edge the capture can't recover (e.g. a reshape view). Explicit and
+  auditable; the Llama hand-verification uses `--add-edge 3:4 --add-edge 6:8` (view + RoPE→SDPA).
+- `--range START:END` (chart only) — draw a legible slice of a huge graph, e.g. one UNet block.
+
+**Findings (cross-model, `--resolve-inplace`).** `can't-hide` = critical-path / total = the latency floor
+after ideal reordering (everything off the longest chain is hideable); `reorder payoff` = 1 − can't-hide.
+
+| model | can't-hide | reorder payoff | basis |
+|---|--:|--:|---|
+| Llama-3.2-1B decode | ~90% | ~10% | hand-verified (`--add-edge 3:4 6:8`) |
+| Whisper-base (enc-dec) | ~70% | ~30% | estimate (view-break dominated) |
+| SDXL UNet (diffusion) | ~65% (floor 54%) | ~35% | estimate; floor rigorous w/ attention edges |
+| Mamba-2.8b (SSM) | ~61% | ~39% | trustworthy (0 unresolved) |
+| ResNet50 (CNN) | ~66% | ~34% | trustworthy (0 unresolved) |
+
+Takeaways: (1) **all these architectures are majority-serial** (60–90% can't-hide), so reorder payoff is
+real but the **minority** (10–40%); (2) **never trust critical-path slack on an attention model without
+`--resolve-inplace`** — dropped create-heads→SDPA and view edges inflate slack badly; (3) **WAW is
+negligible everywhere** (0 true — all allocator-reuse or in-place RMW), so a barrier relaxer only needs to
+reason about RAW. Residual uncertainty (view false-roots) is bracketed by a program-order-reconnect
+estimate, calibrated on Llama (est 86% vs true 90%); exact non-Llama numbers need the data-flow edges
+preserved at capture time (a ttnn-side change).
+
+## Files
+
+```
+test_op_to_op_latency.cpp          host test binary
+kernels/reader_interleaved.cpp     NCRISC reader (modes 0/2, cross-program offset, progress markers)
+kernels/writer_interleaved.cpp     BRISC writer (flush + end-barrier modes 0-3, unroll, markers)
+kernels/compute_copy_with_nops.cpp TRISC copy + tunable NOPs
+scripts/*.py                       captures, exporter, analyzers, chart + RAW-hazard generators (see tables)
+scripts/run_*.sh                   sweep drivers (see table above)
+```
+
+## Kernel profiler notes
+
+Do **not** use `DeviceZoneScopedMainN` in compute `kernel_main` (breaks `TRISC-KERNEL` pairing). Wrap
+unpack/pack timestamps in `UNPACK(...)` / `PACK(...)` so each marker lands on the intended TRISC.
+Kernels pick up `PROFILE_KERNEL` only when `TT_METAL_DEVICE_PROFILER=1` is set before the process
+starts; the JIT cache dependency-checks profiler macros (no manual clear needed).

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/kernels/compute_copy_with_nops.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/kernels/compute_copy_with_nops.cpp
@@ -1,0 +1,122 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// "NOP math" compute kernel for the op-to-op latency benchmark.
+//
+// For each of `n_tiles` tiles the kernel:
+//   1. waits for one tile in the input CB and for output-CB space,
+//   2. UNPACK stamps TILE_IDX when tile i compute starts (TRISC_0 only),
+//   3. copy_tile + N×TTI_NOP on math TRISC,
+//   4. pack_tile pushes to the output CB (pack TRISC),
+//   5. PACK stamps FINISH_LAST_PUSH once at kernel exit (TRISC_2 only), outside the tile loop.
+//
+// Compile-time args:
+//   0: input  CB id
+//   1: output CB id
+//   2: NUM_NOPS_PER_TILE  (tunable; 0 disables the spin)
+//   3: PROFILE_PER_TILE   (1 = stamp TILE_IDX + MATH zone every tile, for latency
+//                          analysis; 0 = lean mode for bandwidth measurement: stamp
+//                          TILE_IDX only for tile 0 and drop the per-tile MATH zone so
+//                          the per-tile profiler writes don't pace the consumer and
+//                          back-pressure the reader. Compute cost is then copy + NOPs
+//                          only, which is what we want when balancing NOPs vs read BW.)
+//   4: PASSTHROUGH       (1 = CB handshake only: no copy_tile / pack_tile / NOP spin, so the math
+//                          datapath is completely idle. Set by --bypass-compute (implied by
+//                          --write-only). Takes compute out of the measured path in BOTH
+//                          directions: on the write side the writer is no longer paced by the
+//                          packer producing one tile at a time; on the read side the reader is no
+//                          longer back-pressured through cb_in once the CB fills.
+//                          NOTE lean mode (PROFILE_PER_TILE=0) drops only INSTRUMENTATION -- it
+//                          still unpacks and packs every tile -- so it is not sufficient on its
+//                          own for either direction. NUM_NOPS_PER_TILE is ignored when set.)
+//
+// Runtime args:
+//   0: n_tiles
+//   1: program_id  (PROG_ID in device CSV; 0 = pre-compile / warmup)
+//
+// Do **not** use DeviceZoneScopedMainN in compute kernel_main (breaks TRISC-KERNEL
+// marker pairing). Program-level host gaps: --use-realtime-profiler.
+
+#include <cstdint>
+#include "api/compute/compute_kernel_api.h"
+#include "api/compute/eltwise_unary/eltwise_unary.h"
+#include "api/compute/tile_move_copy.h"
+#include "tools/profiler/kernel_profiler.hpp"
+
+void kernel_main() {
+    constexpr uint32_t cb_in = get_compile_time_arg_val(0);
+    constexpr uint32_t cb_out = get_compile_time_arg_val(1);
+    constexpr uint32_t num_nops_per_tile = get_compile_time_arg_val(2);
+    constexpr uint32_t profile_per_tile = get_compile_time_arg_val(3);
+    constexpr uint32_t passthrough = get_compile_time_arg_val(4);
+
+    const uint32_t n_tiles = get_arg_val<uint32_t>(0);
+    const uint32_t program_id = get_arg_val<uint32_t>(1);
+    // Kernel-unroll (experiment): consume the workload this many times inside ONE invocation, no
+    // barrier between reps. Matches the reader/writer unroll so the whole op runs "twice" un-synced.
+    const uint32_t workload_repeat = get_arg_val<uint32_t>(2) > 0 ? get_arg_val<uint32_t>(2) : 1;
+
+    // Skip math-datapath setup entirely in passthrough mode -- nothing below touches it.
+    if constexpr (!passthrough) {
+        unary_op_init_common(cb_in, cb_out);
+        copy_tile_init(cb_in);
+    }
+
+    // op_to_op event ids for DeviceRecordEvent (no data payload = less L1 pressure). Kept in
+    // sync with export_op_to_op_profiler_csv.py EVENT_NAMES.
+    constexpr uint16_t EV_UNPACK_TILE0 = 12, EV_PACK_FINISH = 13;
+
+    DeviceTimestampedData("PROG_ID", program_id);  // keep: program id used for prog association
+
+    // The actual per-tile consumer work: copy CB_in -> dst regs (+ NOP spin) -> CB_out.
+    // Kept identical across profiling modes so lean mode changes only instrumentation.
+    auto copy_one_tile = [&]() {
+        tile_regs_acquire();
+        copy_tile(cb_in, /*tile_index=*/0, /*dst_index=*/0);
+
+#pragma GCC unroll 65534
+        for (uint32_t j = 0; j < num_nops_per_tile; ++j) {
+            TTI_NOP;
+        }
+
+        tile_regs_commit();
+
+        tile_regs_wait();
+        pack_tile(/*src_index=*/0, cb_out);
+        tile_regs_release();
+    };
+
+    for (uint32_t rep = 0; rep < workload_repeat; ++rep) {  // kernel-unroll: no barrier between reps
+        for (uint32_t i = 0; i < n_tiles; ++i) {
+            cb_wait_front(cb_in, 1);
+            cb_reserve_back(cb_out, 1);
+
+            // Per-tile TILE_IDX marker only in profiling mode; lean mode keeps just tile 0
+            // (op-to-op latency needs the program's first-tile compute start).
+            if constexpr (profile_per_tile) {
+                UNPACK(DeviceTimestampedData("TILE_IDX", i));
+            } else {
+                if (rep == 0 && i == 0) {
+                    UNPACK(DeviceRecordEvent(EV_UNPACK_TILE0));  // lean: first-math marker (rep0 tile0)
+                }
+            }
+
+            // passthrough: no unpack/copy/pack at all -- the CB payload is whatever L1 already
+            // held (never validated in this mode), so the writer streams at its own pace.
+            if constexpr (!passthrough) {
+                if constexpr (profile_per_tile) {
+                    DeviceZoneScopedN("MATH");
+                    copy_one_tile();
+                } else {
+                    copy_one_tile();
+                }
+            }
+
+            cb_push_back(cb_out, 1);
+            cb_pop_front(cb_in, 1);
+        }
+    }
+
+    PACK(DeviceRecordEvent(EV_PACK_FINISH));
+}

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/kernels/reader_interleaved.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/kernels/reader_interleaved.cpp
@@ -1,0 +1,274 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Reads `n_tiles` tiles from interleaved DRAM into CB_in.
+//
+// Runtime args:
+//   0: src_addr
+//   1: n_tiles                (logical tiles to read; must be a multiple of TILES_PER_PAGE)
+//   2: start_tile_id          (in tiles)
+//   3: program_id
+//
+// Compile-time args (see TensorAccessorArgs<7> for src accessor):
+//   0: cb_in
+//   1: READER_MODE            (0 = reserve N, read+push one tile at a time, barrier per read.
+//                                  Simple reference only -- emits no READ_LAST, so it cannot
+//                                  measure read BW, and requires TILES_PER_PAGE == 1.
+//                              2 = per-trid double-buffer: keep TRID_IN_FLIGHT reads in flight
+//                                  under TRID_A and TRID_B, barrier on a TRID drains all its
+//                                  reads, then refill before switching to the other TRID)
+//   2: PUSH_TILE_COUNT        (chunk size in tiles for mode 0; ignored for mode 2)
+//   3: TILES_PER_PAGE         (DRAM page size in tiles; one noc_async_read_tile pulls a page
+//                              = this many tiles in one NoC transaction; CB still has 1 tile
+//                              per page, so we push this many CB pages per DRAM page read)
+//   4: TRID_IN_FLIGHT         (reads in flight per TRID for mode 2; CB depth must be
+//                              >= 2 * TRID_IN_FLIGHT * TILES_PER_PAGE)
+//   5: CROSS_PROGRAM_OFFSET_TILES (0 = every program reads the same slice; >0 = program k
+//                              reads pages starting at start_tile_id + k*OFFSET. Host
+//                              must allocate a buffer big enough for all program slices.)
+//   6: WRITE_ONLY              (1 = issue NO NoC read at all; just run the CB handshake so the
+//                              consumer advances, leaving the read path completely idle. For pure
+//                              write-BW measurement. Takes precedence over READER_MODE.)
+//
+// Profiler on first tile of the slice only: READ_BEFORE_BARRIER / READ_AFTER_BARRIER.
+
+#include <cstdint>
+#include "api/dataflow/dataflow_api.h"
+#include "tools/profiler/kernel_profiler.hpp"
+
+void kernel_main() {
+    const uint32_t src_addr = get_arg_val<uint32_t>(0);
+    const uint32_t n_tiles = get_arg_val<uint32_t>(1);
+    const uint32_t start_tile_id = get_arg_val<uint32_t>(2);
+    const uint32_t program_id = get_arg_val<uint32_t>(3);
+    // Deliberate per-core read-start stagger (experiment): host passes core_index * stagger here.
+    // We spin this many iterations AFTER the (synchronized) go but BEFORE issuing reads, inducing a
+    // controlled read-completion skew to test whether staggering reads relieves write congestion.
+    const uint32_t read_start_delay = get_arg_val<uint32_t>(4);
+    // Kernel-unroll (experiment): repeat the whole read workload this many times inside ONE kernel
+    // invocation with NO barrier between reps. Compared against the same workload run as N separate
+    // back-to-back programs, the delta is the op-to-op sync-barrier cost removed. Markers fire per
+    // rep, so use repeat=1 for marker decomposition; unroll mode is for wall-clock timing.
+    const uint32_t workload_repeat = get_arg_val<uint32_t>(5) > 0 ? get_arg_val<uint32_t>(5) : 1;
+    // Periodic progress marker (mode 2): if >0, emit a timestamped cumulative-page count every N pages
+    // COMPLETED (each per-trid barrier drain = reads landed) -> MEASURED delivered-read bytes-vs-time per
+    // core. 0 = off (no overhead). Cleaner than the writer's issue-time since it's post-barrier.
+    const uint32_t read_progress_every = get_arg_val<uint32_t>(6);
+
+    constexpr uint32_t cb_in = get_compile_time_arg_val(0);
+    constexpr uint32_t READER_MODE = get_compile_time_arg_val(1);
+    constexpr uint32_t PUSH_TILE_COUNT = get_compile_time_arg_val(2);
+    constexpr uint32_t TILES_PER_PAGE = get_compile_time_arg_val(3);
+    constexpr uint32_t TRID_IN_FLIGHT = get_compile_time_arg_val(4);
+    constexpr uint32_t CROSS_PROGRAM_OFFSET_TILES = get_compile_time_arg_val(5);
+    // Pure write-BW mode: no NoC reads whatsoever (see header). CB handshake only.
+    constexpr uint32_t WRITE_ONLY = get_compile_time_arg_val(6);
+    constexpr auto src_args = TensorAccessorArgs<7>();
+
+    constexpr uint32_t chunk_size = PUSH_TILE_COUNT > 0 ? PUSH_TILE_COUNT : 1;
+    constexpr uint32_t tiles_per_page = TILES_PER_PAGE > 0 ? TILES_PER_PAGE : 1;
+    constexpr uint32_t trid_in_flight = TRID_IN_FLIGHT > 0 ? TRID_IN_FLIGHT : 1;
+
+    // op_to_op event ids for DeviceRecordEvent (lighter than DeviceTimestampedData: no data
+    // payload = less L1 pressure). Kept in sync with export_op_to_op_profiler_csv.py EVENT_NAMES.
+    constexpr uint16_t EV_NCRISC_GO = 1, EV_READ_BEFORE = 2, EV_READ_AFTER = 3, EV_READ_LAST = 4, EV_NCRISC_DONE = 5;
+
+    const auto src = TensorAccessor(src_args, src_addr);
+
+    DeviceTimestampedData("PROG_ID", program_id);  // keep: program id used for prog association
+    DeviceRecordEvent(EV_NCRISC_GO);
+
+    // Induce read stagger: spin AFTER go (so go stays synchronized) before any reads. 0 = off.
+    for (volatile uint32_t d = 0; d < read_start_delay; ++d) {
+        asm volatile("nop");
+    }
+
+    // When CROSS_PROGRAM_OFFSET_TILES > 0, each program reads a disjoint tile slice
+    // so the DRAM controller sees fresh row opens per program (more app-like).
+    const uint32_t effective_start_tile_id = start_tile_id + program_id * CROSS_PROGRAM_OFFSET_TILES;
+    const uint32_t end_tile_id = effective_start_tile_id + n_tiles;
+
+    // DRAM page = tiles_per_page tiles (one NoC transaction per page).
+    // src accessor is configured with the matching page_size at build time.
+    const uint32_t start_page_id = effective_start_tile_id / tiles_per_page;
+    const uint32_t n_pages = n_tiles / tiles_per_page;
+
+    // Pure write-BW mode: the read path stays completely idle -- zero NoC transactions, so the
+    // DRAM controller sees writes only (no read/write turnaround on the banks the writer targets).
+    // We still run the CB handshake so compute and the writer advance exactly as they normally do;
+    // the CB payload is whatever was already in L1, which is fine because it is never validated.
+    // Markers are emitted in the same order as the read paths so the profiler walkers still pair
+    // up -- but the READ_BEFORE->READ_LAST span is a CB-push span here, NOT a read-BW span.
+    if constexpr (WRITE_ONLY) {
+        for (uint32_t rep = 0; rep < workload_repeat; ++rep) {  // kernel-unroll: no barrier between reps
+            DeviceRecordEvent(EV_READ_BEFORE);
+            for (uint32_t p = 0; p < n_pages; ++p) {
+                cb_reserve_back(cb_in, tiles_per_page);
+                cb_push_back(cb_in, tiles_per_page);
+                if (p == 0) {
+                    DeviceRecordEvent(EV_READ_AFTER);
+                }
+                if (read_progress_every && ((p + 1) % read_progress_every == 0)) {
+                    DeviceTimestampedData("READ_PROG", p + 1);
+                }
+            }
+            DeviceRecordEvent(EV_READ_LAST);
+            if (read_progress_every) {
+                DeviceTimestampedData("READ_PROG", n_pages);
+            }
+        }
+        DeviceRecordEvent(EV_NCRISC_DONE);
+        return;
+    }
+
+    if constexpr (READER_MODE == 2) {
+        for (uint32_t rep = 0; rep < workload_repeat; ++rep) {  // kernel-unroll: no barrier between reps
+            // Per-trid double buffer, N = TRID_IN_FLIGHT reads in flight per side.
+            //
+            // We are only measuring NoC read bandwidth: results are dummy and the compute
+            // side is a NOP. We STRIDE the source page_id across [start_page_id, +n_pages)
+            // (one increment per read) so consecutive transactions land on different DRAM
+            // banks -- the interleaved buffer maps page k to bank k % num_banks. Reading a
+            // single page pins every transaction to one bank and caps a single core at the
+            // single-bank ceiling (~22 GB/s on WH); striding across all banks reaches the
+            // ~30 GB/s all-bank ceiling (matches test_bw_and_latency -m 3 vs -m 1). Total
+            // reads already equal n_pages, so the stride sweeps the core's slice exactly
+            // once with no wrap. The L1 destination stays fixed at cb_base (dummy data; the
+            // single-bank reference shows distinct L1 is not what gates BW).
+            //
+            // cb_reserve_back / cb_push_back are kept purely for flow control so the
+            // consumer pipeline advances; host guarantees depth >= 2*N*tiles_per_page.
+            //
+            // Pipeline (one batch always in flight while we stall on the other):
+            //   prologue: issue batch 0 on TRID_A.
+            //   head    : prefetch batch 1 on TRID_B, then barrier+push batch 0 (one-shot,
+            //             so the first-read profiler marker lives outside the hot loop).
+            //   hot loop: prefetch the NEXT batch on the other trid, then barrier+push the
+            //             oldest in-flight batch. The loop condition guarantees a next
+            //             batch exists, so there is no per-iteration have_next branch, and
+            //             the drained batch is always a full N (only the last batch can be
+            //             partial). Static branch prediction on this arch makes the
+            //             data-dependent branch worth eliminating.
+            //   tail    : drain the final lone in-flight batch (may be < N).
+            //
+            // TRID_A ^ 1 == TRID_B and vice versa, so a single xor toggles sides.
+            constexpr uint32_t TRID_A = 2;
+            constexpr uint32_t TRID_B = 3;
+            constexpr uint32_t N = trid_in_flight;
+            const uint32_t batch_tiles = N * tiles_per_page;
+
+            // Reserve room for both in-flight batches up front (covers prologue + head).
+            cb_reserve_back(cb_in, 2 * batch_tiles);
+            const uint32_t cb_base = get_write_ptr(cb_in);
+
+            // Issue one full-page read into cb_base under the currently-set trid.
+            auto issue_read = [&](uint32_t pid) { noc_async_read_tile(pid, src, cb_base); };
+
+            DeviceRecordEvent(EV_READ_BEFORE);
+
+            // Prologue: issue batch 0 on TRID_A.
+            uint32_t issue_trid = TRID_A;
+            uint32_t drain_trid = TRID_A;
+            uint32_t page_id = start_page_id;  // strides across banks, one bump per read
+            uint32_t issued = n_pages < N ? n_pages : N;
+            noc_async_read_set_trid(issue_trid);
+            for (uint32_t i = 0; i < issued; ++i) {
+                issue_read(page_id++);
+            }
+            uint32_t pushed = 0;
+
+            // Head: if a second batch exists, prefetch it on the other trid (so two batches
+            // are in flight), then drain batch 0. The first-read marker is emitted here,
+            // once, so it never enters the hot loop.
+            if (issued < n_pages) {
+                issue_trid ^= 1u;
+                const uint32_t remaining = n_pages - issued;
+                const uint32_t nb = remaining < N ? remaining : N;
+                noc_async_read_set_trid(issue_trid);
+                for (uint32_t i = 0; i < nb; ++i) {
+                    issue_read(page_id++);
+                }
+                issued += nb;
+
+                noc_async_read_barrier_with_trid(drain_trid);
+                DeviceRecordEvent(EV_READ_AFTER);
+                cb_push_back(cb_in, batch_tiles);
+                pushed += N;
+                if (read_progress_every && pushed % read_progress_every == 0) {
+                    DeviceTimestampedData("READ_PROG", pushed);  // measured pages completed vs time
+                }
+                drain_trid ^= 1u;
+            }
+
+            // Hot loop: uniform prefetch-then-drain, no data-dependent branch. The reserve
+            // gates reuse of the region the oldest batch just vacated.
+            while (issued < n_pages) {
+                issue_trid ^= 1u;
+                const uint32_t remaining = n_pages - issued;
+                const uint32_t nb = remaining < N ? remaining : N;
+                cb_reserve_back(cb_in, batch_tiles);
+                noc_async_read_set_trid(issue_trid);
+                for (uint32_t i = 0; i < nb; ++i) {
+                    issue_read(page_id++);
+                }
+                issued += nb;
+
+                noc_async_read_barrier_with_trid(drain_trid);
+                cb_push_back(cb_in, batch_tiles);
+                pushed += N;
+                if (read_progress_every && pushed % read_progress_every == 0) {
+                    DeviceTimestampedData("READ_PROG", pushed);  // measured pages completed vs time
+                }
+                drain_trid ^= 1u;
+            }
+
+            // Tail: drain the final in-flight batch (may be partial). The barrier here
+            // completes the last outstanding reads, so it is the read-bandwidth end point:
+            // BW = bytes_read / (READ_LAST_BARRIER - READ_BEFORE_BARRIER). The interval
+            // spans first-read-issued to last-read-complete, so it still pays the pipeline
+            // fill/drain latency tax at each end (small vs the steady-state middle).
+            noc_async_read_barrier_with_trid(drain_trid);
+            if (pushed == 0) {
+                // n_pages <= N: head never ran, so emit the first-read marker here.
+                DeviceRecordEvent(EV_READ_AFTER);
+            }
+            DeviceRecordEvent(EV_READ_LAST);
+            cb_push_back(cb_in, (n_pages - pushed) * tiles_per_page);
+            if (read_progress_every) {
+                DeviceTimestampedData("READ_PROG", n_pages);  // final: all pages completed
+            }
+        }  // end kernel-unroll rep loop
+
+        DeviceRecordEvent(EV_NCRISC_DONE);
+        return;
+    }
+
+    // Mode 0: reserve a chunk, then read+push one tile at a time with a barrier per read.
+    // Simple reference path; no READ_LAST marker, so read BW is not measurable here (use mode 2).
+    for (uint32_t rep = 0; rep < workload_repeat; ++rep) {  // kernel-unroll: no barrier between reps
+        for (uint32_t tile_id = effective_start_tile_id; tile_id < end_tile_id;) {
+            const uint32_t tiles_left = end_tile_id - tile_id;
+            const uint32_t chunk = tiles_left < chunk_size ? tiles_left : chunk_size;
+
+            cb_reserve_back(cb_in, chunk);
+
+            for (uint32_t i = 0; i < chunk; ++i) {
+                const uint32_t tid = tile_id + i;
+                if (tid == effective_start_tile_id) {
+                    DeviceRecordEvent(EV_READ_BEFORE);
+                }
+                noc_async_read_tile(tid, src, get_write_ptr(cb_in));
+                noc_async_read_barrier();
+                if (tid == effective_start_tile_id) {
+                    DeviceRecordEvent(EV_READ_AFTER);
+                }
+                cb_push_back(cb_in, 1);
+            }
+
+            tile_id += chunk;
+        }
+    }  // end kernel-unroll rep loop
+
+    DeviceRecordEvent(EV_NCRISC_DONE);
+}

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/kernels/reader_interleaved.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/kernels/reader_interleaved.cpp
@@ -1,0 +1,328 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Reads `n_tiles` tiles from interleaved DRAM into CB_in.
+//
+// Runtime args:
+//   0: src_addr
+//   1: n_tiles                (logical tiles to read; must be a multiple of TILES_PER_PAGE)
+//   2: start_tile_id          (in tiles)
+//   3: program_id
+//
+// Compile-time args (see TensorAccessorArgs<7> for src accessor):
+//   0: cb_in
+//   1: READER_MODE            (0 = reserve N, read+push one tile at a time, barrier per read.
+//                                  Simple reference only -- emits no READ_LAST, so it cannot
+//                                  measure read BW, and requires TILES_PER_PAGE == 1.
+//                              1 = full-barrier batch: read PUSH_TILE_COUNT pages, ONE full
+//                                  noc_async_read_barrier (drains ALL in-flight reads), push
+//                                  credits, iterate. In-flight = PUSH_TILE_COUNT = buffer knob;
+//                                  the common no-txn-id pattern. Emits READ_LAST (BW measurable);
+//                                  requires TILES_PER_PAGE == 1.
+//                              2 = per-trid double-buffer: keep TRID_IN_FLIGHT reads in flight
+//                                  under TRID_A and TRID_B, barrier on a TRID drains all its
+//                                  reads, then refill before switching to the other TRID)
+//   2: PUSH_TILE_COUNT        (mode 0: chunk size; mode 1: pages read before each full barrier
+//                              (= in-flight / buffer size); ignored for mode 2)
+//   3: TILES_PER_PAGE         (DRAM page size in tiles; one noc_async_read_tile pulls a page
+//                              = this many tiles in one NoC transaction; CB still has 1 tile
+//                              per page, so we push this many CB pages per DRAM page read)
+//   4: TRID_IN_FLIGHT         (reads in flight per TRID for mode 2; CB depth must be
+//                              >= 2 * TRID_IN_FLIGHT * TILES_PER_PAGE)
+//   5: CROSS_PROGRAM_OFFSET_TILES (0 = every program reads the same slice; >0 = program k
+//                              reads pages starting at start_tile_id + k*OFFSET. Host
+//                              must allocate a buffer big enough for all program slices.)
+//   6: WRITE_ONLY              (1 = issue NO NoC read at all; just run the CB handshake so the
+//                              consumer advances, leaving the read path completely idle. For pure
+//                              write-BW measurement. Takes precedence over READER_MODE.)
+//
+// Profiler on first tile of the slice only: READ_BEFORE_BARRIER / READ_AFTER_BARRIER.
+
+#include <cstdint>
+#include "api/dataflow/dataflow_api.h"
+#include "tools/profiler/kernel_profiler.hpp"
+
+void kernel_main() {
+    const uint32_t src_addr = get_arg_val<uint32_t>(0);
+    const uint32_t n_tiles = get_arg_val<uint32_t>(1);
+    const uint32_t start_tile_id = get_arg_val<uint32_t>(2);
+    const uint32_t program_id = get_arg_val<uint32_t>(3);
+    // Deliberate per-core read-start stagger (experiment): host passes core_index * stagger here.
+    // We spin this many iterations AFTER the (synchronized) go but BEFORE issuing reads, inducing a
+    // controlled read-completion skew to test whether staggering reads relieves write congestion.
+    const uint32_t read_start_delay = get_arg_val<uint32_t>(4);
+    // Kernel-unroll (experiment): repeat the whole read workload this many times inside ONE kernel
+    // invocation with NO barrier between reps. Compared against the same workload run as N separate
+    // back-to-back programs, the delta is the op-to-op sync-barrier cost removed. Markers fire per
+    // rep, so use repeat=1 for marker decomposition; unroll mode is for wall-clock timing.
+    const uint32_t workload_repeat = get_arg_val<uint32_t>(5) > 0 ? get_arg_val<uint32_t>(5) : 1;
+    // Periodic progress marker (mode 2): if >0, emit a timestamped cumulative-page count every N pages
+    // COMPLETED (each per-trid barrier drain = reads landed) -> MEASURED delivered-read bytes-vs-time per
+    // core. 0 = off (no overhead). Cleaner than the writer's issue-time since it's post-barrier.
+    const uint32_t read_progress_every = get_arg_val<uint32_t>(6);
+
+    constexpr uint32_t cb_in = get_compile_time_arg_val(0);
+    constexpr uint32_t READER_MODE = get_compile_time_arg_val(1);
+    constexpr uint32_t PUSH_TILE_COUNT = get_compile_time_arg_val(2);
+    constexpr uint32_t TILES_PER_PAGE = get_compile_time_arg_val(3);
+    constexpr uint32_t TRID_IN_FLIGHT = get_compile_time_arg_val(4);
+    constexpr uint32_t CROSS_PROGRAM_OFFSET_TILES = get_compile_time_arg_val(5);
+    // Pure write-BW mode: no NoC reads whatsoever (see header). CB handshake only.
+    constexpr uint32_t WRITE_ONLY = get_compile_time_arg_val(6);
+    constexpr auto src_args = TensorAccessorArgs<7>();
+
+    constexpr uint32_t chunk_size = PUSH_TILE_COUNT > 0 ? PUSH_TILE_COUNT : 1;
+    constexpr uint32_t tiles_per_page = TILES_PER_PAGE > 0 ? TILES_PER_PAGE : 1;
+    constexpr uint32_t trid_in_flight = TRID_IN_FLIGHT > 0 ? TRID_IN_FLIGHT : 1;
+
+    // op_to_op event ids for DeviceRecordEvent (lighter than DeviceTimestampedData: no data
+    // payload = less L1 pressure). Kept in sync with export_op_to_op_profiler_csv.py EVENT_NAMES.
+    constexpr uint16_t EV_NCRISC_GO = 1, EV_READ_BEFORE = 2, EV_READ_AFTER = 3, EV_READ_LAST = 4, EV_NCRISC_DONE = 5;
+
+    const auto src = TensorAccessor(src_args, src_addr);
+
+    DeviceTimestampedData("PROG_ID", program_id);  // keep: program id used for prog association
+    DeviceRecordEvent(EV_NCRISC_GO);
+
+    // Induce read stagger: spin AFTER go (so go stays synchronized) before any reads. 0 = off.
+    for (volatile uint32_t d = 0; d < read_start_delay; ++d) {
+        asm volatile("nop");
+    }
+
+    // When CROSS_PROGRAM_OFFSET_TILES > 0, each program reads a disjoint tile slice
+    // so the DRAM controller sees fresh row opens per program (more app-like).
+    const uint32_t effective_start_tile_id = start_tile_id + program_id * CROSS_PROGRAM_OFFSET_TILES;
+    const uint32_t end_tile_id = effective_start_tile_id + n_tiles;
+
+    // DRAM page = tiles_per_page tiles (one NoC transaction per page).
+    // src accessor is configured with the matching page_size at build time.
+    const uint32_t start_page_id = effective_start_tile_id / tiles_per_page;
+    const uint32_t n_pages = n_tiles / tiles_per_page;
+
+    // Pure write-BW mode: the read path stays completely idle -- zero NoC transactions, so the
+    // DRAM controller sees writes only (no read/write turnaround on the banks the writer targets).
+    // We still run the CB handshake so compute and the writer advance exactly as they normally do;
+    // the CB payload is whatever was already in L1, which is fine because it is never validated.
+    // Markers are emitted in the same order as the read paths so the profiler walkers still pair
+    // up -- but the READ_BEFORE->READ_LAST span is a CB-push span here, NOT a read-BW span.
+    if constexpr (WRITE_ONLY) {
+        for (uint32_t rep = 0; rep < workload_repeat; ++rep) {  // kernel-unroll: no barrier between reps
+            DeviceRecordEvent(EV_READ_BEFORE);
+            for (uint32_t p = 0; p < n_pages; ++p) {
+                cb_reserve_back(cb_in, tiles_per_page);
+                cb_push_back(cb_in, tiles_per_page);
+                if (p == 0) {
+                    DeviceRecordEvent(EV_READ_AFTER);
+                }
+                if (read_progress_every && ((p + 1) % read_progress_every == 0)) {
+                    DeviceTimestampedData("READ_PROG", p + 1);
+                }
+            }
+            DeviceRecordEvent(EV_READ_LAST);
+            if (read_progress_every) {
+                DeviceTimestampedData("READ_PROG", n_pages);
+            }
+        }
+        DeviceRecordEvent(EV_NCRISC_DONE);
+        return;
+    }
+
+    if constexpr (READER_MODE == 2) {
+        for (uint32_t rep = 0; rep < workload_repeat; ++rep) {  // kernel-unroll: no barrier between reps
+            // Per-trid double buffer, N = TRID_IN_FLIGHT reads in flight per side.
+            //
+            // We are only measuring NoC read bandwidth: results are dummy and the compute
+            // side is a NOP. We STRIDE the source page_id across [start_page_id, +n_pages)
+            // (one increment per read) so consecutive transactions land on different DRAM
+            // banks -- the interleaved buffer maps page k to bank k % num_banks. Reading a
+            // single page pins every transaction to one bank and caps a single core at the
+            // single-bank ceiling (~22 GB/s on WH); striding across all banks reaches the
+            // ~30 GB/s all-bank ceiling (matches test_bw_and_latency -m 3 vs -m 1). Total
+            // reads already equal n_pages, so the stride sweeps the core's slice exactly
+            // once with no wrap. The L1 destination stays fixed at cb_base (dummy data; the
+            // single-bank reference shows distinct L1 is not what gates BW).
+            //
+            // cb_reserve_back / cb_push_back are kept purely for flow control so the
+            // consumer pipeline advances; host guarantees depth >= 2*N*tiles_per_page.
+            //
+            // Pipeline (one batch always in flight while we stall on the other):
+            //   prologue: issue batch 0 on TRID_A.
+            //   head    : prefetch batch 1 on TRID_B, then barrier+push batch 0 (one-shot,
+            //             so the first-read profiler marker lives outside the hot loop).
+            //   hot loop: prefetch the NEXT batch on the other trid, then barrier+push the
+            //             oldest in-flight batch. The loop condition guarantees a next
+            //             batch exists, so there is no per-iteration have_next branch, and
+            //             the drained batch is always a full N (only the last batch can be
+            //             partial). Static branch prediction on this arch makes the
+            //             data-dependent branch worth eliminating.
+            //   tail    : drain the final lone in-flight batch (may be < N).
+            //
+            // TRID_A ^ 1 == TRID_B and vice versa, so a single xor toggles sides.
+            constexpr uint32_t TRID_A = 2;
+            constexpr uint32_t TRID_B = 3;
+            constexpr uint32_t N = trid_in_flight;
+            const uint32_t batch_tiles = N * tiles_per_page;
+
+            // Reserve room for both in-flight batches up front (covers prologue + head).
+            cb_reserve_back(cb_in, 2 * batch_tiles);
+            const uint32_t cb_base = get_write_ptr(cb_in);
+
+            // Issue one full-page read into cb_base under the currently-set trid.
+            auto issue_read = [&](uint32_t pid) { noc_async_read_tile(pid, src, cb_base); };
+
+            DeviceRecordEvent(EV_READ_BEFORE);
+
+            // Prologue: issue batch 0 on TRID_A.
+            uint32_t issue_trid = TRID_A;
+            uint32_t drain_trid = TRID_A;
+            uint32_t page_id = start_page_id;  // strides across banks, one bump per read
+            uint32_t issued = n_pages < N ? n_pages : N;
+            noc_async_read_set_trid(issue_trid);
+            for (uint32_t i = 0; i < issued; ++i) {
+                issue_read(page_id++);
+            }
+            uint32_t pushed = 0;
+
+            // Head: if a second batch exists, prefetch it on the other trid (so two batches
+            // are in flight), then drain batch 0. The first-read marker is emitted here,
+            // once, so it never enters the hot loop.
+            if (issued < n_pages) {
+                issue_trid ^= 1u;
+                const uint32_t remaining = n_pages - issued;
+                const uint32_t nb = remaining < N ? remaining : N;
+                noc_async_read_set_trid(issue_trid);
+                for (uint32_t i = 0; i < nb; ++i) {
+                    issue_read(page_id++);
+                }
+                issued += nb;
+
+                noc_async_read_barrier_with_trid(drain_trid);
+                DeviceRecordEvent(EV_READ_AFTER);
+                cb_push_back(cb_in, batch_tiles);
+                pushed += N;
+                if (read_progress_every && pushed % read_progress_every == 0) {
+                    DeviceTimestampedData("READ_PROG", pushed);  // measured pages completed vs time
+                }
+                drain_trid ^= 1u;
+            }
+
+            // Hot loop: uniform prefetch-then-drain, no data-dependent branch. The reserve
+            // gates reuse of the region the oldest batch just vacated.
+            while (issued < n_pages) {
+                issue_trid ^= 1u;
+                const uint32_t remaining = n_pages - issued;
+                const uint32_t nb = remaining < N ? remaining : N;
+                cb_reserve_back(cb_in, batch_tiles);
+                noc_async_read_set_trid(issue_trid);
+                for (uint32_t i = 0; i < nb; ++i) {
+                    issue_read(page_id++);
+                }
+                issued += nb;
+
+                noc_async_read_barrier_with_trid(drain_trid);
+                cb_push_back(cb_in, batch_tiles);
+                pushed += N;
+                if (read_progress_every && pushed % read_progress_every == 0) {
+                    DeviceTimestampedData("READ_PROG", pushed);  // measured pages completed vs time
+                }
+                drain_trid ^= 1u;
+            }
+
+            // Tail: drain the final in-flight batch (may be partial). The barrier here
+            // completes the last outstanding reads, so it is the read-bandwidth end point:
+            // BW = bytes_read / (READ_LAST_BARRIER - READ_BEFORE_BARRIER). The interval
+            // spans first-read-issued to last-read-complete, so it still pays the pipeline
+            // fill/drain latency tax at each end (small vs the steady-state middle).
+            noc_async_read_barrier_with_trid(drain_trid);
+            if (pushed == 0) {
+                // n_pages <= N: head never ran, so emit the first-read marker here.
+                DeviceRecordEvent(EV_READ_AFTER);
+            }
+            DeviceRecordEvent(EV_READ_LAST);
+            cb_push_back(cb_in, (n_pages - pushed) * tiles_per_page);
+            if (read_progress_every) {
+                DeviceTimestampedData("READ_PROG", n_pages);  // final: all pages completed
+            }
+        }  // end kernel-unroll rep loop
+
+        DeviceRecordEvent(EV_NCRISC_DONE);
+        return;
+    }
+
+    // Mode 1: FULL-BARRIER batch reader -- the common no-txn-id pattern (read a CB-worth of pages,
+    // issue ONE noc_async_read_barrier that drains ALL in-flight reads, hand off credits, iterate).
+    // In-flight reads = CHUNK (= PUSH_TILE_COUNT pages) = the "buffer size" knob: the NoC fully drains
+    // at every barrier, so BW converges to peak only as CHUNK grows toward an "infinite" buffer.
+    // Contrast mode 2 (per-trid double-buffer, NoC never drains). Reads land in a fixed cb_base (dummy
+    // data; L1 dest doesn't gate BW -- identical methodology to mode 2), so the ONLY difference vs
+    // mode 2 is the barrier granularity. Emits READ_LAST, so read BW IS measurable. Requires
+    // tiles_per_page == 1 (host asserts page_size_tiles == 1 for non-mode-2).
+    if constexpr (READER_MODE == 1) {
+        constexpr uint32_t CHUNK = chunk_size;                  // pages read before each full barrier (= in-flight)
+        for (uint32_t rep = 0; rep < workload_repeat; ++rep) {  // kernel-unroll: no barrier between reps
+            uint32_t page_id = start_page_id;                   // strides across banks, one bump per read
+            uint32_t pages_done = 0;
+            uint32_t cb_base = 0;
+            bool have_base = false;
+            bool first_batch = true;
+            DeviceRecordEvent(EV_READ_BEFORE);
+            while (pages_done < n_pages) {
+                const uint32_t remaining = n_pages - pages_done;
+                const uint32_t nb = remaining < CHUNK ? remaining : CHUNK;
+                cb_reserve_back(cb_in, nb);  // wait for space (consumer drained the previous batch)
+                if (!have_base) {
+                    cb_base = get_write_ptr(cb_in);
+                    have_base = true;
+                }
+                for (uint32_t i = 0; i < nb; ++i) {
+                    noc_async_read_tile(page_id++, src, cb_base);  // all to cb_base (dummy dest)
+                }
+                noc_async_read_barrier();  // FULL drain: wait for ALL nb reads to land (NoC goes idle)
+                if (first_batch) {
+                    DeviceRecordEvent(EV_READ_AFTER);
+                    first_batch = false;
+                }
+                cb_push_back(cb_in, nb);
+                pages_done += nb;
+                if (read_progress_every && pages_done % read_progress_every == 0) {
+                    DeviceTimestampedData("READ_PROG", pages_done);  // measured pages completed vs time
+                }
+            }
+            DeviceRecordEvent(EV_READ_LAST);
+            if (read_progress_every) {
+                DeviceTimestampedData("READ_PROG", n_pages);
+            }
+        }  // end kernel-unroll rep loop
+        DeviceRecordEvent(EV_NCRISC_DONE);
+        return;
+    }
+
+    // Mode 0: reserve a chunk, then read+push one tile at a time with a barrier per read.
+    // Simple reference path; no READ_LAST marker, so read BW is not measurable here (use mode 2).
+    for (uint32_t rep = 0; rep < workload_repeat; ++rep) {  // kernel-unroll: no barrier between reps
+        for (uint32_t tile_id = effective_start_tile_id; tile_id < end_tile_id;) {
+            const uint32_t tiles_left = end_tile_id - tile_id;
+            const uint32_t chunk = tiles_left < chunk_size ? tiles_left : chunk_size;
+
+            cb_reserve_back(cb_in, chunk);
+
+            for (uint32_t i = 0; i < chunk; ++i) {
+                const uint32_t tid = tile_id + i;
+                if (tid == effective_start_tile_id) {
+                    DeviceRecordEvent(EV_READ_BEFORE);
+                }
+                noc_async_read_tile(tid, src, get_write_ptr(cb_in));
+                noc_async_read_barrier();
+                if (tid == effective_start_tile_id) {
+                    DeviceRecordEvent(EV_READ_AFTER);
+                }
+                cb_push_back(cb_in, 1);
+            }
+
+            tile_id += chunk;
+        }
+    }  // end kernel-unroll rep loop
+
+    DeviceRecordEvent(EV_NCRISC_DONE);
+}

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/kernels/writer_interleaved.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/kernels/writer_interleaved.cpp
@@ -1,0 +1,151 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Pops `n_tiles` tiles from the output circular buffer (CB_out) and writes
+// them to the corresponding tile slots in an interleaved DRAM buffer. One
+// instance of this kernel runs on every Tensix core; each core gets its own
+// [start_tile_id, start_tile_id + n_tiles) slice via runtime args.
+//
+// Synchronization:
+//   - noc_async_writes_flushed() once per CB-worth of pages (batch up to
+//     output_cb_depth/tiles_per_page - 1 writes before a flush) so the source L1 slot is
+//     safe to recycle on cb_pop_front. Per-page flushing serializes the writer and ~halves
+//     write BW when not DRAM-bound, with no benefit when saturated, so it is not an option.
+//   - End of kernel: END_BARRIER_MODE selects barrier / flush / none (op-end safety).
+//
+// Runtime args:
+//   0: dst_addr
+//   1: n_tiles
+//   2: start_tile_id
+//   3: program_id
+//
+// Compile-time args (see TensorAccessorArgs<6> for dst accessor):
+//   0: cb_out
+//   1: TILES_PER_PAGE
+//   2: READ_ONLY        (1 = skip DRAM writes, just pop from output CB)
+//   3: OUTPUT_CB_DEPTH_TILES
+//   4: CROSS_PROGRAM_OFFSET_TILES (0 = every program writes same slice; >0 = program k
+//                                  writes pages starting at start_tile_id + k*OFFSET)
+//   5: END_BARRIER_MODE
+//                          0 = noc_async_write_barrier (DEFAULT; wait for DRAM ACK; current)
+//                          1 = noc_async_writes_flushed (just flush local L1; writes left
+//                              the source but next op may see in-flight committed-at-NoC)
+//                          2 = no barrier, no flush (UNSAFE for correctness in real
+//                              workloads; simulates "HW gives us this for free")
+
+#include <cstdint>
+#include "api/dataflow/dataflow_api.h"
+#include "tools/profiler/kernel_profiler.hpp"
+
+void kernel_main() {
+    const uint32_t dst_addr = get_arg_val<uint32_t>(0);
+    const uint32_t n_tiles = get_arg_val<uint32_t>(1);
+    const uint32_t start_tile_id = get_arg_val<uint32_t>(2);
+    const uint32_t program_id = get_arg_val<uint32_t>(3);
+    // Kernel-unroll (experiment): repeat the write workload this many times inside ONE invocation
+    // with the end barrier issued only ONCE after the last rep -- i.e. no op-to-op sync between reps.
+    const uint32_t workload_repeat = get_arg_val<uint32_t>(4) > 0 ? get_arg_val<uint32_t>(4) : 1;
+    // Periodic progress marker: if >0, emit a timestamped cumulative-page count every N pages written,
+    // giving MEASURED write-issue-progress vs time per core (not interpolated). 0 = off (no overhead).
+    // Note: timestamps write ISSUE (outstanding is bounded by the per-CB flush, so it tracks delivery
+    // within ~one CB-worth); the marker itself perturbs timing slightly, ~equally across cores.
+    const uint32_t write_progress_every = get_arg_val<uint32_t>(5);
+
+    constexpr uint32_t cb_out = get_compile_time_arg_val(0);
+    constexpr uint32_t TILES_PER_PAGE = get_compile_time_arg_val(1);
+    constexpr uint32_t READ_ONLY = get_compile_time_arg_val(2);
+    constexpr uint32_t OUTPUT_CB_DEPTH_TILES = get_compile_time_arg_val(3);
+    constexpr uint32_t CROSS_PROGRAM_OFFSET_TILES = get_compile_time_arg_val(4);
+    constexpr uint32_t END_BARRIER_MODE = get_compile_time_arg_val(5);
+    // END_BARRIER_MODE 3 = POSTED writes: each write is fire-and-forget (no DRAM ACK generated), and
+    // completion is tracked only as "sent out of local L1" via noc_async_posted_writes_flushed(). This
+    // frees the NoC return/ACK path (higher injection BW) but CANNOT observe when data LANDS in DRAM --
+    // so the writer-done markers here measure INJECTION completion, not the landing tail. Not for configs
+    // that read the output back (no landing guarantee).
+    constexpr bool POSTED = (END_BARRIER_MODE == 3);
+    constexpr uint32_t tiles_per_page = TILES_PER_PAGE > 0 ? TILES_PER_PAGE : 1;
+    constexpr uint32_t output_cb_depth_tiles = OUTPUT_CB_DEPTH_TILES > 0 ? OUTPUT_CB_DEPTH_TILES : tiles_per_page;
+    constexpr uint32_t cb_page_slots = output_cb_depth_tiles / tiles_per_page;
+    // Flush once per CB-worth of pages (never per page -- see header).
+    constexpr uint32_t max_writes_before_flush = cb_page_slots > 1 ? cb_page_slots - 1 : 1;
+    constexpr auto dst_args = TensorAccessorArgs<6>();
+
+    // op_to_op event ids for DeviceRecordEvent (no data payload = less L1 pressure than
+    // DeviceTimestampedData). Kept in sync with export_op_to_op_profiler_csv.py EVENT_NAMES.
+    constexpr uint16_t EV_BRISC_GO = 6, EV_WRITE_BEFORE = 7, EV_WRITE_LAST_ISSUED = 8, EV_WRITE_LAST_FLUSHED = 9,
+                       EV_WRITE_BARRIER_DONE = 10, EV_BRISC_DONE = 11;
+
+    const auto dst = TensorAccessor(dst_args, dst_addr);
+
+    DeviceTimestampedData("PROG_ID", program_id);  // keep: program id used for prog association
+    DeviceRecordEvent(EV_BRISC_GO);
+
+    // When CROSS_PROGRAM_OFFSET_TILES > 0, each program writes a disjoint slice
+    // (mirrors reader); host allocates a buffer large enough for all slices.
+    const uint32_t effective_start_tile_id = start_tile_id + program_id * CROSS_PROGRAM_OFFSET_TILES;
+    // DRAM page = tiles_per_page tiles. Compute pushes 1 CB page (1 tile) at
+    // a time; we accumulate tiles_per_page in the CB then issue one
+    // noc_async_write_tile that pushes the whole page in a single NoC txn.
+    const uint32_t start_page_id = effective_start_tile_id / tiles_per_page;
+    const uint32_t n_pages = n_tiles / tiles_per_page;
+    const uint32_t end_page_id = start_page_id + n_pages;
+    const uint32_t last_page_id = (n_pages > 0) ? (end_page_id - 1) : start_page_id;
+
+    DeviceRecordEvent(EV_WRITE_BEFORE);
+
+    // Kernel-unroll: replay the whole write sweep `workload_repeat` times with NO barrier between
+    // reps (flush cadence continues across the boundary for CB recycling). The end barrier below is
+    // reached only after the final rep, so this is the workload run "twice" with the sync removed.
+    uint32_t writes_since_flush = 0;
+    uint32_t pages_written = 0;
+    for (uint32_t rep = 0; rep < workload_repeat; ++rep) {
+        for (uint32_t page_id = start_page_id; page_id < end_page_id; ++page_id) {
+            cb_wait_front(cb_out, tiles_per_page);
+            if constexpr (READ_ONLY == 0) {
+                const uint32_t l1_read_addr = get_read_ptr(cb_out);
+                if constexpr (POSTED) {
+                    // fire-and-forget: no ACK. dst page size == the addr-gen's aligned page (tiles_per_page tiles).
+                    noc_async_write<NOC_MAX_BURST_SIZE + 1, false, /*posted=*/true>(
+                        l1_read_addr, dst.get_noc_addr(page_id), dst.get_aligned_page_size());
+                } else {
+                    noc_async_write_tile(page_id, dst, l1_read_addr);
+                }
+                // Flush once per CB-worth of pages so the source slot is safe to recycle. Posted writes need
+                // the posted-flush (they don't count toward the non-posted "sent" tally).
+                if (++writes_since_flush >= max_writes_before_flush) {
+                    if constexpr (POSTED) {
+                        noc_async_posted_writes_flushed();
+                    } else {
+                        noc_async_writes_flushed();
+                    }
+                    writes_since_flush = 0;
+                }
+                if (write_progress_every && (++pages_written % write_progress_every == 0)) {
+                    DeviceTimestampedData("WRITE_PROG", pages_written);  // measured bytes(pages)-vs-time
+                }
+            }
+            cb_pop_front(cb_out, tiles_per_page);
+        }
+    }
+
+    // Timeline markers: last write issued -> last write flushed -> barrier complete.
+    DeviceRecordEvent(EV_WRITE_LAST_ISSUED);
+    if constexpr (READ_ONLY == 0) {
+        if constexpr (POSTED) {
+            noc_async_posted_writes_flushed();  // posted writes SENT out of L1 (no DRAM ACK exists)
+            DeviceRecordEvent(EV_WRITE_LAST_FLUSHED);
+        } else {
+            if constexpr (END_BARRIER_MODE != 2) {
+                noc_async_writes_flushed();  // writes have left local L1
+            }
+            DeviceRecordEvent(EV_WRITE_LAST_FLUSHED);
+            if constexpr (END_BARRIER_MODE == 0) {
+                noc_async_write_barrier();  // writes ACKed at DRAM
+            }
+        }
+    }
+    DeviceRecordEvent(EV_WRITE_BARRIER_DONE);  // POSTED: = posted-flush (sent); mode 0: = ACK barrier complete
+
+    DeviceRecordEvent(EV_BRISC_DONE);
+}

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/scripts/capture_decoder_layer.py
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/scripts/capture_decoder_layer.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Representative Llama decoder-layer op sequence (random tensors, no weights) under ttnn graph
+capture. Dumps the capture JSON for /tmp/raw_analyzer.py. Structure mirrors a decoder layer:
+
+  rms_norm -> {q,k,v proj (3 siblings read the same norm)} -> attention(qk^T, softmax, @v)
+  -> o proj -> residual add(x, o) -> rms_norm -> {gate, up proj (2 siblings)} -> silu*up
+  -> down proj -> residual add(r1, d)
+
+Interesting dependency structure to recover: q/k/v are mutually independent (read h1), gate/up
+independent (read h2); residuals read tensors from many ops back (long consumer distance).
+
+NOTE: attention is done manually (matmul/softmax/matmul) rather than fused SDPA to keep the API
+robust for a first prototype; exact head/GQA layout omitted. Fidelity is at the op-DEPENDENCY level.
+API details (open_device vs mesh, graph.RunMode, rms_norm signature) to be confirmed post-build.
+"""
+import json
+import torch
+import ttnn
+
+H = 4096  # hidden
+NH, DH = 32, 128  # heads, head_dim (MHA: nqh == nkv)
+INTER = 14336  # MLP intermediate (Llama-3-8B)
+B, S = 1, 32  # batch, seq (small prefill-like chunk)
+OUT = "/tmp/decoder_capture.json"
+
+
+def main():
+    device = ttnn.open_device(device_id=0)
+    try:
+
+        def rand(*shape):
+            return ttnn.from_torch(
+                torch.randn(*shape, dtype=torch.bfloat16),
+                dtype=ttnn.bfloat16,
+                layout=ttnn.TILE_LAYOUT,
+                device=device,
+            )
+
+        x = rand(B, S, H)
+        # weights (random)
+        Wq, Wk, Wv, Wo = rand(H, H), rand(H, H), rand(H, H), rand(H, H)
+        Wg, Wu, Wd = rand(H, INTER), rand(H, INTER), rand(INTER, H)
+        ln1_w, ln2_w = rand(H), rand(H)
+
+        ttnn.graph.begin_graph_capture(ttnn.graph.RunMode.NORMAL)
+
+        h1 = ttnn.rms_norm(x, weight=ln1_w)
+        q = ttnn.matmul(h1, Wq)  # 3 siblings read h1 (mutually independent)
+        k = ttnn.matmul(h1, Wk)
+        v = ttnn.matmul(h1, Wv)
+
+        def to_heads(t):  # [B,S,H] -> [B,NH,S,DH]
+            return ttnn.transpose(ttnn.reshape(t, (B, S, NH, DH)), 1, 2)
+
+        ah = ttnn.transformer.scaled_dot_product_attention(  # FUSED attention (one device op)
+            to_heads(q), to_heads(k), to_heads(v), is_causal=True
+        )
+        attn = ttnn.reshape(ttnn.transpose(ah, 1, 2), (B, S, H))  # [B,NH,S,DH] -> [B,S,H]
+        o = ttnn.matmul(attn, Wo)
+        r1 = ttnn.add(x, o)  # residual: reads x (far back) + o
+        h2 = ttnn.rms_norm(r1, weight=ln2_w)
+        g = ttnn.matmul(h2, Wg)  # gate/up siblings read h2 (independent)
+        u = ttnn.matmul(h2, Wu)
+        gu = ttnn.multiply(ttnn.silu(g), u)
+        d = ttnn.matmul(gu, Wd)
+        r2 = ttnn.add(r1, d)  # residual: reads r1 (far back) + d
+        ttnn.synchronize_device(device)
+
+        captured = ttnn.graph.end_graph_capture()
+        json.dump(captured, open(OUT, "w"))
+        print(f"captured {len(captured)} nodes -> {OUT}")
+    finally:
+        ttnn.close_device(device)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/scripts/capture_mamba.py
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/scripts/capture_mamba.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Capture ONE Mamba decode step (state-space model) under ttnn graph capture, dump JSON for
+raw_hazard_analyzer.py. Single Wormhole chip, 5x8=40-core grid (fits fast dispatch).
+
+Mamba is an SSM -- no attention -- so this probes whether the RAW/reorderable pattern differs for a
+selective-scan recurrence vs the attention/conv models. RANDOM weights via Mamba.from_random (only
+the ~2KB HF config json is fetched; hazard structure is weight-value independent). Uses the smallest
+variant. Mirrors models/demos/wormhole/mamba/tests/test_mamba_model.py construction.
+"""
+import json
+import sys
+
+import torch
+import ttnn
+
+from models.demos.wormhole.mamba.reference.args import ModelMode
+from models.demos.wormhole.mamba.reference.prefill_decode_model import Mamba
+from models.demos.wormhole.mamba.tt import model_config
+from models.demos.wormhole.mamba.tt.mamba_model import MambaTT
+
+MODEL = "state-spaces/mamba-2.8b"  # config sharding is hardcoded for d_model=2560 (this variant)
+BATCH = 32  # DECODE mode requires batch 32
+OUT = "/tmp/mamba_capture.json"
+
+
+def main():
+    ref = Mamba.from_random(MODEL, batch_size=BATCH)  # random weights, config-only download
+    print(f"Mamba.from_random {MODEL}: d_model={ref.args.d_model} n_layer={ref.args.n_layer}")
+
+    device = ttnn.open_device(device_id=0, l1_small_size=16384)
+    try:
+        cfg = model_config.create_model_config(BATCH, ref.args.d_model, mode=ModelMode.DECODE, seq_len=1)
+        tt_model = MambaTT(ref, device, cfg, tt_cache_path=None)
+
+        input_ids = torch.randint(0, ref.args.vocab_size, (BATCH, 1), dtype=torch.long)
+
+        ttnn.graph.begin_graph_capture(ttnn.graph.RunMode.NORMAL)
+        out = tt_model(input_ids)
+        ttnn.synchronize_device(device)
+        captured = ttnn.graph.end_graph_capture()
+
+        json.dump(captured, open(OUT, "w"))
+        print(f"captured {len(captured)} nodes -> {OUT}  (out shape={tuple(out.shape)})")
+    finally:
+        ttnn.close_device(device)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/scripts/capture_resnet50.py
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/scripts/capture_resnet50.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Capture ONE REAL ResNet-50 inference forward under ttnn graph capture, dump JSON for
+raw_hazard_analyzer.py. Single Wormhole chip (1x1 mesh / N150).
+
+This is the REAL ttnn ResNet-50 (models/demos/vision/classification/resnet50) run through its own
+test infra -- exactly the setup in
+models/demos/vision/classification/resnet50/wormhole/tests/test_resnet50_functional.py, reduced to a
+single captured forward. CNN => no in-place ops, so the RAW dependency structure should be fully
+resolvable.
+
+Weights: use_pretrained_weight=False builds a RANDOM-weight torchvision.models.resnet50() (NO
+download; the device-program dependency/hazard structure is independent of weight VALUES -- the conv
+shapes/config are what matter). Batch 16 (batch 1/2/8 are skipped by the infra on WH).
+"""
+import json
+import sys
+
+import torch
+from loguru import logger
+
+import ttnn
+from models.demos.vision.classification.resnet50.ttnn_resnet.tests.common.resnet50_test_infra import (
+    create_test_infra,
+)
+
+OUT = "/tmp/resnet_capture.json"
+BATCH_SIZE = 16
+L1_SMALL_SIZE = 24576
+
+
+def main():
+    torch.manual_seed(0)
+
+    mesh_device = ttnn.open_mesh_device(ttnn.MeshShape(1, 1), l1_small_size=L1_SMALL_SIZE)
+    try:
+        test_infra = create_test_infra(
+            mesh_device,
+            BATCH_SIZE,
+            act_dtype=ttnn.bfloat8_b,
+            weight_dtype=ttnn.bfloat8_b,
+            math_fidelity=ttnn.MathFidelity.LoFi,
+            use_pretrained_weight=False,  # random weights -> fully offline, no download
+        )
+        logger.info(f"ResNet-50 test infra built (batch={BATCH_SIZE}, random weights)")
+
+        tt_inputs_host, input_mem_config = test_infra.setup_l1_sharded_input(mesh_device)
+
+        # Warm up program cache / JIT-configure the convs OUTSIDE capture so the graph reflects
+        # steady-state dispatch (the first invocation compiles/allocs; we want a cached invocation).
+        test_infra.input_tensor = tt_inputs_host.to(mesh_device, input_mem_config)
+        test_infra.run()
+        ttnn.synchronize_device(mesh_device)
+        test_infra.input_tensor = tt_inputs_host.to(mesh_device, input_mem_config)
+        test_infra.run()
+        ttnn.synchronize_device(mesh_device)
+
+        # Fresh input for the captured forward.
+        test_infra.input_tensor = tt_inputs_host.to(mesh_device, input_mem_config)
+
+        logger.info("Capturing ONE ResNet-50 forward...")
+        ttnn.graph.begin_graph_capture(ttnn.graph.RunMode.NORMAL)
+        out = test_infra.run()
+        ttnn.synchronize_device(mesh_device)
+        captured = ttnn.graph.end_graph_capture()
+
+        json.dump(captured, open(OUT, "w"))
+        print(f"captured {len(captured)} nodes -> {OUT}")
+        ttnn.deallocate(out)
+    finally:
+        ttnn.close_mesh_device(mesh_device)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/scripts/capture_sdxl_unet.py
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/scripts/capture_sdxl_unet.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Capture ONE SDXL-Base UNet forward (one denoising step) under ttnn graph capture, dump JSON for
+raw_hazard_analyzer.py. Single Wormhole chip.
+
+Weights are RANDOM (UNet2DConditionModel.from_config -> from_config, no pretrained download): the
+RAW-hazard analysis depends only on the op DEPENDENCY graph (which op reads which buffer), which is
+weight-VALUE independent -- same trick used for the ResNet capture. Only the tiny config.json is
+fetched from HF. Structure/prep mirror models/demos/stable_diffusion_xl_base/tests/pcc/
+test_module_tt_unet.py (prepare_ttnn_tensors + run_unet_model).
+"""
+import json
+import sys
+
+import torch
+import ttnn
+from diffusers import UNet2DConditionModel
+
+from models.demos.stable_diffusion_xl_base.tt.model_configs import load_model_optimisations
+from models.demos.stable_diffusion_xl_base.tt.tt_unet import TtUNet2DConditionModel
+
+MODEL = "stabilityai/stable-diffusion-xl-base-1.0"
+RES = (512, 512)
+INPUT_SHAPE = (1, 4, 64, 64)  # B,C,H,W for 512x512 (op structure is resolution-independent)
+OUT = "/tmp/sdxl_unet_capture.json"
+
+
+def prepare_ttnn_tensors(device, x, ts, temb, enc, time_ids):
+    torch.manual_seed(2025)
+    tt_ts = ttnn.from_torch(
+        ts, dtype=ttnn.bfloat16, device=device, layout=ttnn.TILE_LAYOUT, memory_config=ttnn.L1_MEMORY_CONFIG
+    )
+    tt_enc = ttnn.from_torch(
+        enc, dtype=ttnn.bfloat16, device=device, layout=ttnn.TILE_LAYOUT, memory_config=ttnn.L1_MEMORY_CONFIG
+    )
+    tt_temb = ttnn.from_torch(
+        temb, dtype=ttnn.bfloat16, device=device, layout=ttnn.ROW_MAJOR_LAYOUT, memory_config=ttnn.L1_MEMORY_CONFIG
+    )
+    tt_tids = ttnn.from_torch(
+        time_ids, dtype=ttnn.bfloat16, device=device, layout=ttnn.TILE_LAYOUT, memory_config=ttnn.L1_MEMORY_CONFIG
+    )
+    tt_x = ttnn.from_torch(
+        x, dtype=ttnn.bfloat16, device=device, layout=ttnn.TILE_LAYOUT, memory_config=ttnn.L1_MEMORY_CONFIG
+    )
+    B, C, H, W = list(tt_x.shape)
+    tt_x = ttnn.permute(tt_x, (0, 2, 3, 1))
+    tt_x = ttnn.reshape(tt_x, (B, 1, H * W, C))
+    return tt_x, [B, C, H, W], tt_ts, tt_enc, {"text_embeds": tt_temb, "time_ids": tt_tids}
+
+
+def main():
+    # random-init UNet from config (tiny download), correctly-shaped state_dict, no weight fetch
+    cfg = UNet2DConditionModel.load_config(MODEL, subfolder="unet")
+    unet = UNet2DConditionModel.from_config(cfg).eval()
+    state_dict = unet.state_dict()
+    print(f"UNet2DConditionModel from_config: {len(state_dict)} tensors (random weights)")
+
+    device = ttnn.open_device(device_id=0, l1_small_size=32000)  # SDXL_L1_SMALL_SIZE (conv2d/halo)
+    try:
+        model_config = load_model_optimisations(RES)
+        tt_unet = TtUNet2DConditionModel(device, state_dict, "unet", model_config=model_config, debug_mode=False)
+
+        x = torch.rand(*INPUT_SHAPE, dtype=torch.float32) * 0.2 - 0.1
+        ts = torch.tensor([500.0], dtype=torch.float32)
+        temb = torch.rand(1, 1280, dtype=torch.float32) * 0.2 - 0.1
+        enc = torch.rand(1, 77, 2048, dtype=torch.float32) * 0.2 - 0.1
+        time_ids = torch.tensor([512, 512, 0, 0, 512, 512])
+
+        tt_x, bchw, tt_ts, tt_enc, added = prepare_ttnn_tensors(device, x, ts, temb, enc, time_ids)
+
+        ttnn.graph.begin_graph_capture(ttnn.graph.RunMode.NORMAL)
+        out, out_shape = tt_unet.forward(
+            tt_x,
+            bchw,
+            timestep=tt_ts,
+            encoder_hidden_states=tt_enc,
+            time_ids=added["time_ids"],
+            text_embeds=added["text_embeds"],
+        )
+        ttnn.synchronize_device(device)
+        captured = ttnn.graph.end_graph_capture()
+
+        json.dump(captured, open(OUT, "w"))
+        print(f"captured {len(captured)} nodes -> {OUT}  (UNet out_shape={out_shape})")
+    finally:
+        ttnn.close_device(device)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/scripts/capture_tt_transformers_decode.py
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/scripts/capture_tt_transformers_decode.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Capture ONE REAL tt_transformers Llama DECODE step of a SINGLE transformer layer under ttnn graph
+capture, dump JSON for raw_hazard_analyzer.py. Single Wormhole chip (1x1 mesh / N150).
+
+This is the REAL decode path (NOT the random-op proxy): a models/tt_transformers TransformerBlock
+run in Mode.DECODE with paged attention, KV cache, page table, and RoPE rot_mats -- exactly the setup
+in models/tt_transformers/tests/test_decoder.py, reduced to n_layers=1, batch=1, one decode() call.
+
+Weights: dummy_weights=True builds a RANDOM-weight 1-layer model from the LOCAL config in
+models/tt_transformers/model_params/Llama-3.2-1B-Instruct (no checkpoint download; the device-program
+dependency/hazard structure is independent of weight VALUES -- shapes/config are what matter).
+"""
+import json
+import os
+import sys
+
+# Fully offline: local config only, never hit the HF hub.
+os.environ.setdefault("HF_MODEL", "unsloth/Llama-3.2-1B-Instruct")  # basename -> model_name "Llama-3.2-1B-Instruct"
+os.environ.setdefault("MESH_DEVICE", "N150")
+os.environ.setdefault("HF_HUB_OFFLINE", "1")
+os.environ.setdefault("TRANSFORMERS_OFFLINE", "1")
+
+import torch  # noqa: E402
+from loguru import logger  # noqa: E402
+
+import ttnn  # noqa: E402
+from tests.scripts.common import get_updated_device_params  # noqa: E402
+from models.tt_transformers.tt.ccl import TT_CCL  # noqa: E402
+from models.tt_transformers.tt.common import Mode, PagedAttentionConfig  # noqa: E402
+from models.tt_transformers.tt.decoder import TransformerBlock  # noqa: E402
+from models.tt_transformers.tt.model_config import ModelArgs  # noqa: E402
+from models.tt_transformers.tt.rope import HfRotarySetup, RotarySetup  # noqa: E402
+
+OUT = "/tmp/tt_transformers_decode_capture.json"
+BATCH_SIZE = 1
+MAX_SEQ_LEN = 256
+PAGE_BLOCK_SIZE = 32
+PAGE_MAX_NUM_BLOCKS = 1024
+
+
+def _set_fabric(fabric_config):
+    # Mirror conftest.set_fabric(fabric_config=True) for the decoder test's device_params.
+    if fabric_config:
+        ttnn.set_fabric_config(
+            fabric_config,
+            ttnn.FabricReliabilityMode.STRICT_INIT,
+            None,
+            ttnn.FabricTensixConfig.DISABLED,
+            ttnn.FabricUDMMode.DISABLED,
+            ttnn.FabricManagerMode.DEFAULT,
+        )
+
+
+def _reset_fabric(fabric_config):
+    if fabric_config:
+        ttnn.set_fabric_config(ttnn.FabricConfig.DISABLED)
+
+
+@torch.no_grad()
+def main():
+    torch.manual_seed(0)
+
+    # ---- open a single-chip (1x1) mesh ----
+    # The decoder test parametrizes fabric_config=True for generality, but fabric cannot be launched on a
+    # 1x1 SUBSET of this multi-device host. For a single-device decode the CCL ops are no-ops, so we open a
+    # plain 1x1 mesh with no fabric (dispatch_core_config from get_updated_device_params).
+    device_params = {}
+    updated = get_updated_device_params(device_params)
+    fabric_config = None
+    mesh_device = ttnn.open_mesh_device(mesh_shape=ttnn.MeshShape(1, 1), **updated)
+
+    try:
+        dtype = ttnn.bfloat8_b
+        mode = Mode.DECODE
+
+        model_args = ModelArgs(
+            mesh_device,
+            max_batch_size=BATCH_SIZE,
+            max_seq_len=MAX_SEQ_LEN,
+            cache_hf=True,
+            dummy_weights=True,  # random weights from LOCAL config -> fully offline
+            use_hf_rope=False,
+        )
+        model_args.n_layers = 1
+        logger.info(
+            f"ModelArgs: {model_args.model_name} dim={model_args.dim} n_heads={model_args.n_heads} "
+            f"n_kv_heads={model_args.n_kv_heads} head_dim={model_args.head_dim}"
+        )
+
+        state_dict = model_args.load_state_dict()  # dummy -> random-weight 1-layer state_dict
+
+        # ---- RoPE transformation matrices (decode) ----
+        DefaultRopeSetup = HfRotarySetup if model_args.use_hf_rope else RotarySetup
+        rope_setup = DefaultRopeSetup(
+            mesh_device,
+            model_args.max_batch_size,
+            model_args.head_dim,
+            model_args.max_seq_len,
+            model_args.rope_theta,
+            model_args.rope_scaling,
+            model_args.use_qk_fused,
+        )
+        if model_args.rope_theta_local is not None:
+            rope_setup_local = RotarySetup(
+                mesh_device,
+                model_args.max_batch_size,
+                model_args.head_dim,
+                model_args.max_seq_len,
+                model_args.rope_theta_local,
+                None,
+            )
+        else:
+            rope_setup_local = None
+        transformation_mats = rope_setup.get_both_trans_mats()
+
+        # ---- paged-attention page table ----
+        paged_attention_config = PagedAttentionConfig(
+            block_size=PAGE_BLOCK_SIZE,
+            max_num_blocks=PAGE_MAX_NUM_BLOCKS,
+        )
+        permutation = torch.randperm(paged_attention_config.max_num_blocks)
+        reverse_permutation = torch.argsort(permutation)
+        page_table = reverse_permutation.reshape(
+            model_args.max_batch_size, paged_attention_config.max_num_blocks // model_args.max_batch_size
+        )
+        page_table_tt = ttnn.from_torch(
+            page_table,
+            device=mesh_device,
+            dtype=ttnn.int32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            mesh_mapper=ttnn.ShardTensor2dMesh(
+                mesh_device,
+                dims=(None, None),
+                mesh_shape=model_args.cluster_shape,
+            ),
+        )
+
+        # ---- build the TT TransformerBlock (single layer, layer 0) ----
+        tt_ccl = TT_CCL(mesh_device)
+        tt_model = TransformerBlock(
+            args=model_args,
+            mesh_device=mesh_device,
+            tt_ccl=tt_ccl,
+            dtype=dtype,
+            state_dict=state_dict,
+            layer_num=0,
+            weight_cache_path=model_args.weight_cache_path(dtype),
+            transformation_mats=transformation_mats,
+            paged_attention_config=paged_attention_config,
+        )
+
+        seqlen = 1
+        generation_start_pos = 0
+        current_pos = torch.tensor([generation_start_pos for _ in range(BATCH_SIZE)])
+        current_pos_tensor = ttnn.from_torch(
+            current_pos,
+            device=mesh_device,
+            dtype=ttnn.int32,
+            mesh_mapper=ttnn.ShardTensor2dMesh(
+                mesh_device,
+                dims=(None, None),
+                mesh_shape=model_args.cluster_shape,
+            ),
+        )
+
+        # ---- decode-mode sharded input activation ----
+        pt_decode_input = (torch.rand(BATCH_SIZE, seqlen, model_args.dim) * 2) - 1
+        decode_input = model_args.prepare_residual_tensor_decode(
+            pt_decode_input,
+            model_args.get_residual_mem_config(mode, None),
+        )
+        rot_mats = rope_setup.get_rot_mats(current_pos)
+        rot_mats_local = None if rope_setup_local is None else rope_setup_local.get_rot_mats(current_pos)
+
+        # Warm up program cache OUTSIDE capture so the graph reflects steady-state decode dispatch
+        # (first invocation compiles/allocs; we want the second, cached invocation's op graph).
+        logger.info("Warm-up decode invocation (outside capture)...")
+        _ = tt_model(
+            decode_input,
+            current_pos_tensor,
+            rot_mats_global=rot_mats,
+            rot_mats_local=rot_mats_local,
+            mode=mode,
+            page_table=page_table_tt,
+        )
+        ttnn.synchronize_device(mesh_device)
+
+        # Rebuild a fresh input tensor (the previous one may have been consumed/deallocated).
+        decode_input = model_args.prepare_residual_tensor_decode(
+            pt_decode_input,
+            model_args.get_residual_mem_config(mode, None),
+        )
+
+        logger.info("Capturing ONE decode step...")
+        ttnn.graph.begin_graph_capture(ttnn.graph.RunMode.NORMAL)
+        tt_out = tt_model(
+            decode_input,
+            current_pos_tensor,
+            rot_mats_global=rot_mats,
+            rot_mats_local=rot_mats_local,
+            mode=mode,
+            page_table=page_table_tt,
+        )
+        ttnn.synchronize_device(mesh_device)
+        captured = ttnn.graph.end_graph_capture()
+
+        json.dump(captured, open(OUT, "w"))
+        print(f"captured {len(captured)} nodes -> {OUT}")
+        ttnn.deallocate(tt_out)
+    finally:
+        ttnn.close_mesh_device(mesh_device)
+        _reset_fabric(fabric_config)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/scripts/capture_whisper.py
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/scripts/capture_whisper.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Capture ONE Whisper forward (encoder + one decoder prefill step) under ttnn graph capture, dump
+JSON for raw_hazard_analyzer.py. Single Wormhole chip (1x1 mesh).
+
+Whisper is an ENCODER-DECODER speech transformer -- the point is the encoder->decoder CROSS-ATTENTION
+dependency structure (decoder attends to the fixed encoder output). RANDOM weights via WhisperModel(config)
+(config-only, no checkpoint download; hazard structure is weight-value independent). Smallest sensible
+variant (whisper-base). Mirrors models/demos/audio/whisper/tests/test_whisper_modules.py::test_ttnn_whisper
+(use_kv_cache=False path). Random mel input instead of the feature extractor (shapes are what matter).
+"""
+import json
+import sys
+
+import torch
+import ttnn
+from transformers import WhisperConfig, WhisperModel
+
+from ttnn.model_preprocessing import preprocess_model_parameters
+from models.demos.utils.common_demo_utils import get_mesh_mappers
+from models.demos.audio.whisper.tt import ttnn_optimized_functional_whisper as ttnn_model
+from models.demos.audio.whisper.tt.ttnn_optimized_functional_whisper import WHISPER_L1_SMALL_SIZE
+
+MODEL = "openai/whisper-base"  # config only; op-dependency structure is size-independent
+BATCH = 1
+DECODER_SEQ = 32  # prefill-style decoder step
+OUT = "/tmp/whisper_capture.json"
+
+
+def main():
+    config = WhisperConfig.from_pretrained(MODEL)
+    object.__setattr__(config, "_attn_implementation", "eager")
+    model = WhisperModel(config).eval().float()  # RANDOM weights
+    for m in model.modules():  # HF whisper indexes ALL_ATTENTION_FUNCTIONS[_attn_implementation]
+        cfg = getattr(m, "config", None)
+        if cfg is not None and getattr(cfg, "_attn_implementation", None) is None:
+            object.__setattr__(cfg, "_attn_implementation", "eager")
+    print(
+        f"WhisperModel {MODEL}: d_model={config.d_model} enc_layers={config.encoder_layers} "
+        f"dec_layers={config.decoder_layers} heads={config.encoder_attention_heads} (random weights)"
+    )
+
+    mesh_device = ttnn.open_mesh_device(ttnn.MeshShape(1, 1), l1_small_size=WHISPER_L1_SMALL_SIZE)
+    try:
+        input_mesh_mapper, weights_mesh_mapper, output_mesh_composer = get_mesh_mappers(mesh_device)
+
+        parameters = preprocess_model_parameters(
+            initialize_model=lambda: model,
+            convert_to_ttnn=ttnn_model.convert_to_ttnn,
+            custom_preprocessor=ttnn_model.create_custom_mesh_preprocessor(weights_mesh_mapper),
+            device=mesh_device,
+        )
+
+        input_features = torch.randn(BATCH, 80, 3000)  # mel spectrogram (random)
+        decoder_input_ids = torch.ones(BATCH, DECODER_SEQ).to(torch.int32) * config.decoder_start_token_id
+
+        input_embeds, decoder_hidden_states, decoder_attention_mask = ttnn_model.preprocess_inputs(
+            config=config,
+            input_features=input_features.unsqueeze(1),
+            input_ids=decoder_input_ids,
+            attention_mask=None,
+            parameters=parameters,
+            device=mesh_device,
+            input_mesh_mapper=input_mesh_mapper,
+            weights_mesh_mapper=weights_mesh_mapper,
+        )
+
+        ttnn.graph.begin_graph_capture(ttnn.graph.RunMode.NORMAL)
+        out = ttnn_model.whisper(
+            config,
+            input_embeds,
+            decoder_hidden_states,
+            decoder_attention_mask=decoder_attention_mask,
+            kv_cache=None,
+            cross_attn_cache=None,
+            current_decode_pos=None,
+            parameters=parameters,
+        )
+        ttnn.synchronize_device(mesh_device)
+        captured = ttnn.graph.end_graph_capture()
+
+        json.dump(captured, open(OUT, "w"))
+        print(f"captured {len(captured)} nodes -> {OUT}")
+    finally:
+        ttnn.close_mesh_device(mesh_device)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/scripts/chart_active_cores.py
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/scripts/chart_active_cores.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Active-cores-over-time for one op, to visualize the straggler tail that stretches the envelope.
+
+Each core is "active" (demanding DRAM bandwidth) from its first read to its write-barrier done. We count
+how many of the N cores are active at each instant and plot that step curve. BW saturates at ~SAT cores,
+so any interval where fewer than SAT cores are active runs the DRAM pipe under-utilized: the ramp-up fill
+and -- the point of interest -- the ragged FINISH tail, where the last stragglers run mostly alone. That
+sub-SAT tail is time the 8-core config doesn't pay (it finishes tight) and is why more cores are slower.
+
+Input: raw device-profiler CSV(s). Pass one or two (e.g. 8c and 56c) to overlay-compare in stacked panels.
+"""
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from export_op_to_op_profiler_csv import load_profiler_csv, parse_chip_freq_mhz  # noqa: E402
+from chart_timeline_k2 import per_core_invocations  # noqa: E402
+
+
+def intervals(csv):
+    freq = parse_chip_freq_mhz(Path(csv).resolve())
+    df = load_profiler_csv(Path(csv).resolve())
+    inv = {k: v for k, v in per_core_invocations(df).items() if v}
+    t0 = min(v[-1]["go"] for v in inv.values())
+    out = []
+    for v in inv.values():
+        op = v[-1]  # last steady op
+        start = op["read_bursts"][0][0] if op["read_bursts"] else op["go"]
+        out.append(((start - t0) / freq, (op["wafter"] - t0) / freq))
+    return out
+
+
+def step_curve(ivals):
+    ev = []
+    for s, f in ivals:
+        ev.append((s, 1))
+        ev.append((f, -1))
+    ev.sort()
+    ts, cs, c = [0.0], [0], 0
+    for t, d in ev:
+        ts.append(t)
+        cs.append(c)
+        c += d
+        ts.append(t)
+        cs.append(c)
+    return ts, cs
+
+
+def sub_sat_tail(ivals, sat):
+    """Time from the moment active-count LAST falls below `sat` (on the decay) to the final finish."""
+    finishes = sorted(f for _, f in ivals)
+    n = len(finishes)
+    # active count drops below sat once (n - sat + 1) cores have finished... i.e. when only (sat-1) remain
+    if n < sat:
+        return finishes[0], finishes[-1]
+    cross = finishes[n - sat + 1] if (n - sat + 1) < n else finishes[-1]  # (sat-1) cores remain after this
+    return cross, finishes[-1]
+
+
+def bw_over_time(ivals, bytes_per_core, nb=240):
+    """Approximate delivered aggregate BW (GB/s) over time: spread each core's read+write bytes uniformly
+    over its active span, sum per time bin. Shows the gradual roll-off as fast cores leave and only slow
+    (NoC-distant) stragglers remain -- the real under-utilization, which begins ABOVE the sat-core line."""
+    last = max(f for _, f in ivals)
+    T = last * 1.02
+    binw = T / nb
+    bins = [0.0] * nb
+    for s, f in ivals:
+        span = max(f - s, 1e-6)
+        for bi in range(nb):
+            t0, t1 = bi * binw, (bi + 1) * binw
+            ov = min(f, t1) - max(s, t0)
+            if ov > 0:
+                bins[bi] += bytes_per_core * (ov / span)  # bytes delivered in this bin by this core
+    xs = [(bi + 0.5) * binw for bi in range(nb)]
+    gbps = [b / binw * 1e-3 for b in bins]  # bytes/µs -> GB/s
+    return xs, gbps
+
+
+def panel(ax, csv, label, sat, ceiling, color):
+    ivals = intervals(csv)
+    n = len(ivals)
+    pages_per_core = 3584 // n  # fixed-total work model
+    bytes_per_core = 2 * pages_per_core * 2048  # read + write
+    ts, cs = step_curve(ivals)
+    ax.fill_between(ts, cs, step="post", color=color, alpha=0.20)
+    ax.plot(ts, cs, drawstyle="steps-post", color=color, lw=1.3, label="active cores")
+    ax.axhline(sat, ls="--", color="#b71c1c", lw=1.0)
+    ax.text(0, sat + 0.5, f"≈{sat} cores saturate BW", ha="left", va="bottom", fontsize=7, color="#b71c1c")
+    first_fin = min(f for _, f in ivals)
+    last_fin = max(f for _, f in ivals)
+    ax.axvline(first_fin, ls=":", color="#555", lw=0.8)
+    ax.text(first_fin, n * 0.98, f"1st done {first_fin:.0f}µs", rotation=90, fontsize=7, va="top", ha="right")
+    ax.axvline(last_fin, ls=":", color="#555", lw=0.8)
+    ax.text(last_fin, n * 0.98, f"last {last_fin:.0f}µs", rotation=90, fontsize=7, va="top", ha="left")
+    ax.set_ylabel("active cores", color=color)
+    ax.set_ylim(0, n * 1.08)
+    ax.grid(alpha=0.2)
+
+    # delivered BW over time on twin axis -- the truthful under-utilization view
+    ax2 = ax.twinx()
+    xs, gbps = bw_over_time(ivals, bytes_per_core)
+    ax2.plot(xs, gbps, color="#e65100", lw=2.0, label="delivered BW")
+    ax2.axhline(ceiling, ls="--", color="#e65100", lw=1.0, alpha=0.7)
+    ax2.text(0, ceiling + 4, f"~{ceiling} GB/s ceiling", ha="left", va="bottom", fontsize=7, color="#e65100")
+    # shade where delivered BW has rolled off below 90% of ceiling AND we're past peak (the real tail)
+    peak_i = max(range(len(gbps)), key=lambda i: gbps[i])
+    roll = next((xs[i] for i in range(peak_i, len(xs)) if gbps[i] < 0.9 * ceiling), last_fin)
+    ax2.axvspan(roll, last_fin, color="#e65100", alpha=0.10)
+    ax2.annotate(
+        f"BW roll-off tail\n{last_fin - roll:.0f}µs\n(slow stragglers can't\nfill freed BW)",
+        xy=((roll + last_fin) / 2, ceiling * 0.55),
+        ha="center",
+        va="center",
+        fontsize=7.5,
+        color="#bf360c",
+        fontweight="bold",
+    )
+    ax2.set_ylabel("delivered BW (GB/s)", color="#e65100")
+    ax2.set_ylim(0, ceiling * 1.15)
+    ax.set_title(
+        f"{label}: {n} cores | envelope {last_fin:.0f}µs | finish spread {last_fin - first_fin:.0f}µs | "
+        f"BW roll-off tail {last_fin - roll:.0f}µs",
+        fontsize=10,
+        loc="left",
+    )
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--csv", action="append", required=True, help="device CSV (repeat for stacked panels)")
+    ap.add_argument("--label", action="append", required=True, help="label per --csv")
+    ap.add_argument("--sat-cores", type=int, default=8, help="cores needed to saturate DRAM BW")
+    ap.add_argument("--ceiling", type=float, default=206.0, help="aggregate bidirectional BW ceiling (GB/s)")
+    ap.add_argument("--out-png", type=Path, required=True)
+    args = ap.parse_args()
+
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    ncsv = len(args.csv)
+    fig, axes = plt.subplots(ncsv, 1, figsize=(12, 3.2 * ncsv), sharex=True)
+    if ncsv == 1:
+        axes = [axes]
+    colors = ["#1e88e5", "#2e7d32", "#8e24aa"]
+    for ax, csv, lab, col in zip(axes, args.csv, args.label, colors):
+        panel(ax, csv, lab, args.sat_cores, args.ceiling, col)
+    axes[-1].set_xlabel("time since first read (µs)")
+    fig.suptitle("Active cores over time — the sub-saturation straggler tail stretches the envelope", fontsize=12)
+    fig.tight_layout(rect=[0, 0, 1, 0.97])
+    fig.savefig(args.out_png, dpi=140, bbox_inches="tight")
+    print(f"chart -> {args.out_png}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/scripts/chart_core_heatmap.py
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/scripts/chart_core_heatmap.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Spatial heatmap of per-core finish time on the physical grid -- shows WHICH cores straggle.
+
+Each Tensix worker is plotted at its (core_x, core_y) and colored by when it finished (write-barrier
+done) relative to the first core's go. Reveals the NoC-distance gradient: cores far from their DRAM
+channels finish late (hot), near ones finish early (cool). Input: raw device-profiler CSV.
+"""
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from export_op_to_op_profiler_csv import load_profiler_csv, parse_chip_freq_mhz  # noqa: E402
+from chart_timeline_k2 import per_core_invocations  # noqa: E402
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--csv", type=Path, required=True)
+    ap.add_argument("--out-png", type=Path, required=True)
+    ap.add_argument("--title", default="per-core finish time (NoC-distance stragglers)")
+    args = ap.parse_args()
+
+    freq = parse_chip_freq_mhz(args.csv.resolve())
+    df = load_profiler_csv(args.csv.resolve())
+    inv = {k: v for k, v in per_core_invocations(df).items() if v}
+    t0 = min(v[-1]["go"] for v in inv.values())
+    pts = [(x, y, (v[-1]["wafter"] - t0) / freq) for (s, x, y), v in inv.items()]
+    xs = [p[0] for p in pts]
+    ys = [p[1] for p in pts]
+    fs = [p[2] for p in pts]
+    fmin, fmax = min(fs), max(fs)
+
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    fig, ax = plt.subplots(figsize=(9, 7))
+    sc = ax.scatter(
+        xs, ys, c=fs, cmap="RdYlGn_r", s=900, marker="s", edgecolor="k", linewidth=0.5, vmin=fmin, vmax=fmax
+    )
+    for x, y, f in pts:
+        ax.text(x, y, f"{f:.0f}", ha="center", va="center", fontsize=7, fontweight="bold")
+    ax.set_xlabel("core_x (NoC column)")
+    ax.set_ylabel("core_y (NoC row)")
+    ax.invert_yaxis()  # row 0 at top, like the physical grid
+    ax.set_aspect("equal")
+    ax.set_title(
+        f"{args.title}\n{len(pts)} cores | finish {fmin:.0f}–{fmax:.0f}µs (spread {fmax - fmin:.0f}µs)", fontsize=11
+    )
+    cb = fig.colorbar(sc, ax=ax, shrink=0.8)
+    cb.set_label("finish time since go (µs) — red = late straggler")
+    ax.set_xticks(sorted(set(xs)))
+    ax.set_yticks(sorted(set(ys)))
+    ax.grid(alpha=0.2)
+    fig.tight_layout()
+    fig.savefig(args.out_png, dpi=140, bbox_inches="tight")
+    print(f"chart -> {args.out_png}")
+    # column means for the readout
+    import statistics as st
+
+    bycol = {}
+    for x, y, f in pts:
+        bycol.setdefault(x, []).append(f)
+    print("finish µs by column:", {x: round(st.mean(bycol[x])) for x in sorted(bycol)})
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/scripts/chart_raw_graph.py
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/scripts/chart_raw_graph.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Render a device-program dependency graph (RAW edges) from a ttnn graph capture, via graphviz.
+
+Nodes = device programs in program order (top->bottom). Black arrows = RAW data dependencies
+(producer buffer -> consumer, matched on buffer address). Node coloring:
+  - GREEN border  = the adjacency boundary BEFORE this op is REORDERABLE (op N-1's output is not read
+                    by this op) -> the op-boundary barrier there could be relaxed.
+  - GRAY dashed   = in-place op that records NO output tensor -> its consumers are UNRESOLVABLE from the
+                    capture (conservative: not counted as reorderable).
+  - white         = ordinary RAW-chained boundary (barrier needed).
+Faint gray edges chain the program order. Title carries the summary stats.
+
+Usage: chart_raw_graph.py <capture.json> --out <base> [--title "..."]  -> <base>.png and <base>.svg
+"""
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from raw_hazard_analyzer import parse_device_ops, analyze, apply_resolutions, infer_attention_edges  # noqa: E402
+
+
+def short(name):
+    n = name.split("::")[-1].replace("DeviceOperation", "").replace("Operation", "")
+    return n[:26]
+
+
+def build(capture_json, out_base, title, resolve_inplace=False, add_edges=(), node_range=None):
+    import graphviz
+
+    nodes = json.load(open(capture_json))
+    ops = parse_device_ops(nodes)
+    # inferred edges (drawn dashed-orange): explicit --add-edge plus auto create-heads->SDPA when resolving
+    inferred = set(add_edges) | (set(infer_attention_edges(ops)) if resolve_inplace else set())
+    apply_resolutions(ops, resolve_inplace, add_edges)
+    n = len(ops)
+    m = analyze(ops)
+    # optional slice for legibility on huge graphs: draw only ops [lo, hi) and edges within
+    lo, hi = node_range if node_range else (0, n)
+    in_win = lambda i: lo <= i < hi
+
+    def producer_before(addr, i):
+        p = None
+        for k in range(i):
+            if addr in ops[k]["out_ids"]:
+                p = k
+        return p
+
+    raw_edges = set()
+    for i, op in enumerate(ops):
+        for a in op["in_ids"]:
+            p = producer_before(a, i)
+            if p is not None:
+                raw_edges.add((p, i))
+
+    # Classify the boundary BEFORE op i (between i-1 and i):
+    #   'raw'         : op i reads op i-1's output -> barrier needed
+    #   'reorderable' : op i does NOT read it AND op i-1 recorded an output -> barrier relaxable (confirmed)
+    #   'unresolved'  : op i-1 is in-place (recorded NO output) -> dependency can't be seen -> can't tell
+    boundary = [None] * n
+    for i in range(1, n):
+        if ops[i - 1]["out_ids"] & ops[i]["in_ids"]:
+            boundary[i] = "raw"
+        elif not ops[i - 1]["out_ids"]:
+            boundary[i] = "unresolved"
+        else:
+            boundary[i] = "reorderable"
+
+    g = graphviz.Digraph("raw", format="png")
+    g.attr(rankdir="TB", nodesep="0.25", ranksep="0.35", bgcolor="white")
+    g.attr("node", shape="box", style="filled,rounded", fillcolor="white", fontname="Helvetica", fontsize="10")
+
+    BORDER = {
+        "reorderable": ("#2e7d32", "3"),
+        "unresolved": ("#ef6c00", "3"),
+        "raw": ("#444444", "1"),
+        None: ("#444444", "1"),
+    }
+    for i, op in enumerate(ops):
+        if not in_win(i):
+            continue
+        in_place = not op["out_ids"]
+        label = f"{i}: {short(op['name'])}" + ("\\n(in-place op)" if in_place else "")
+        col, pw = BORDER[boundary[i]]
+        style = "filled,rounded,dashed" if in_place else "filled,rounded"
+        fill = "#fff3e0" if boundary[i] == "unresolved" else ("#eeeeee" if in_place else "white")
+        g.node(str(i), label=label, color=col, penwidth=pw, style=style, fillcolor=fill)
+
+    # faint program-order chain
+    for i in range(n - 1):
+        if in_win(i) and in_win(i + 1):
+            g.edge(str(i), str(i + 1), style="dotted", color="#cccccc", arrowhead="none", weight="10")
+    # RAW dependency edges (black solid = seen in capture; dashed orange = inferred/injected semantic edge)
+    for p, c in sorted(raw_edges):
+        if not (in_win(p) and in_win(c)):
+            continue
+        if (p, c) in inferred:
+            g.edge(
+                str(p),
+                str(c),
+                color="#ef6c00",
+                penwidth="1.6",
+                style="dashed",
+                label="inferred",
+                fontsize="8",
+                fontcolor="#ef6c00",
+            )
+        else:
+            g.edge(str(p), str(c), color="#111111", penwidth="1.4", constraint="false" if c - p > 1 else "true")
+
+    reorder_cnt = boundary.count("reorderable")
+    unresolved_cnt = boundary.count("unresolved")
+    raw_cnt = boundary.count("raw")
+    g.attr(
+        label=(
+            f"{title}\\l"
+            f"{n} device programs · boundaries: {raw_cnt} RAW / {reorder_cnt} reorderable / {unresolved_cnt} unresolved "
+            f"· critical path {m['critical_path']}/{n}\\l"
+            f"GREEN border = barrier relaxable (confirmed) · ORANGE = unresolved (predecessor in-place) · "
+            f"gray dashed = in-place op · black arrow = RAW dep\\l"
+        ),
+        labelloc="t",
+        fontsize="12",
+        fontname="Helvetica",
+    )
+
+    png = g.render(out_base, cleanup=True)
+    g.format = "svg"
+    svg = g.render(out_base, cleanup=True)
+    print(
+        f"nodes={n} raw_edges={len(raw_edges)} boundaries: raw={raw_cnt} reorderable={reorder_cnt} unresolved={unresolved_cnt}"
+    )
+    print(f"-> {png}\n-> {svg}")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("capture_json")
+    ap.add_argument("--out", default="/tmp/raw_graph")
+    ap.add_argument("--title", default="Llama-3.2 decoder layer — device-program RAW dependency graph")
+    ap.add_argument("--resolve-inplace", action="store_true", help="treat in-place ops as RMW (reconnect through them)")
+    ap.add_argument("--add-edge", action="append", default=[], help="inject a known semantic edge P:C (repeatable)")
+    ap.add_argument("--range", default=None, help="draw only ops [START:END) for legibility on huge graphs")
+    a = ap.parse_args()
+    add_edges = [tuple(int(x) for x in e.split(":")) for e in a.add_edge]
+    node_range = tuple(int(x) for x in a.range.split(":")) if a.range else None
+    build(a.capture_json, a.out, a.title, a.resolve_inplace, add_edges, node_range)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/scripts/chart_read_stagger.py
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/scripts/chart_read_stagger.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Read-stagger de-correlation chart (from run_read_stagger.sh CSVs).
+
+Left panel (wide sweep, log-x): aggregate BW and cross-core done-spread vs the induced per-core
+read-start stagger. Shows the goldilocks point -- a small deliberate read offset de-correlates the
+56 lockstep DRAM readers, collapsing NoC contention (done-spread down ~5x, BW up ~25%); past the
+optimum the induced delay itself serializes the last core and BW falls.
+
+Right panel (fine sweep, averaged over reps): zoom on the optimum -- completion skew, done-spread,
+and worst-core barrier drain vs stagger, confirming the minimum near stagger~32 (~22us induced
+start spread, ~0.4us/core across 56 cores).
+"""
+import argparse
+import csv
+from pathlib import Path
+
+
+def load(path):
+    rows = []
+    for r in csv.DictReader(open(path)):
+        rows.append({k: float(v) for k, v in r.items()})
+    return rows
+
+
+def avg_by_stagger(paths):
+    acc = {}
+    for p in paths:
+        for r in load(p):
+            acc.setdefault(r["stagger"], []).append(r)
+    out = []
+    for s in sorted(acc):
+        rs = acc[s]
+        m = {k: sum(x[k] for x in rs) / len(rs) for k in rs[0]}
+        out.append(m)
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--wide-csv", type=Path, required=True)
+    ap.add_argument("--fine-csvs", type=Path, nargs="+", required=True)
+    ap.add_argument("--out-png", type=Path, required=True)
+    args = ap.parse_args()
+
+    wide = sorted(load(args.wide_csv), key=lambda r: r["stagger"])
+    fine = avg_by_stagger(args.fine_csvs)
+
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    fig, (axL, axR) = plt.subplots(1, 2, figsize=(13, 4.6))
+
+    # ---- left: wide sweep, BW + done-spread vs stagger (log-x, but include 0) ----
+    xs = [max(r["stagger"], 0.5) for r in wide]  # map 0 -> 0.5 for log axis
+    bw = [r["agg_total_gbps"] for r in wide]
+    ds = [r["writer_done_spread_us"] for r in wide]
+    axL.set_xscale("log")
+    l1 = axL.plot(xs, bw, "o-", color="#1e88e5", label="aggregate BW (GB/s)")
+    axL.set_xlabel("induced per-core read stagger (spin units; 0 shown at 0.5)")
+    axL.set_ylabel("aggregate BW (GB/s)", color="#1e88e5")
+    axL.tick_params(axis="y", labelcolor="#1e88e5")
+    axL.set_ylim(0, 220)
+    axR2 = axL.twinx()
+    l2 = axR2.plot(xs, ds, "s--", color="#e53935", label="done-spread (us)")
+    axR2.set_ylabel("cross-core done-spread (us)", color="#e53935")
+    axR2.tick_params(axis="y", labelcolor="#e53935")
+    axL.set_title("read-stagger de-correlation: full sweep (56c, balanced math)")
+    # mark the peak-BW point
+    bi = max(range(len(bw)), key=lambda i: bw[i])
+    axL.annotate(
+        f"peak {bw[bi]:.0f} GB/s\n@ stagger={int(wide[bi]['stagger'])}",
+        xy=(xs[bi], bw[bi]),
+        xytext=(xs[bi], bw[bi] - 70),
+        ha="center",
+        fontsize=8,
+        arrowprops=dict(arrowstyle="->", color="#333"),
+    )
+    axL.legend(l1 + l2, [h.get_label() for h in l1 + l2], loc="lower center", fontsize=8)
+
+    # ---- right: fine sweep, skew metrics vs stagger (linear) ----
+    fx = [r["stagger"] for r in fine]
+    axR.plot(fx, [r["read_compl_skew_us"] for r in fine], "o-", color="#2e7d32", label="read completion skew")
+    axR.plot(fx, [r["writer_done_spread_us"] for r in fine], "s-", color="#e53935", label="writer done-spread")
+    axR.plot(fx, [r["write_drain_max_us"] for r in fine], "^-", color="#c62828", label="worst-core barrier drain")
+    axR.plot(fx, [r["read_start_skew_us"] for r in fine], "d--", color="#9e9e9e", label="induced start skew")
+    axR.set_xlabel("induced per-core read stagger (spin units)")
+    axR.set_ylabel("microseconds")
+    axR.set_title("zoom on optimum (avg of reps): skew / drain vs stagger")
+    axR.grid(alpha=0.25)
+    axR.legend(fontsize=8)
+    bi2 = min(range(len(fine)), key=lambda i: fine[i]["writer_done_spread_us"])
+    axR.axvline(fx[bi2], color="#1e88e5", ls=":", alpha=0.6)
+
+    fig.tight_layout()
+    fig.savefig(args.out_png, dpi=140)
+    print(f"chart -> {args.out_png}")
+    print(
+        f"wide peak BW {bw[bi]:.1f} GB/s @ stagger {int(wide[bi]['stagger'])}; "
+        f"baseline {wide[0]['agg_total_gbps']:.1f} GB/s @ stagger 0"
+    )
+    print(
+        f"fine done-spread min {fine[bi2]['writer_done_spread_us']:.1f}us @ stagger {int(fx[bi2])} "
+        f"(baseline {fine[0]['writer_done_spread_us']:.1f}us)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/scripts/chart_rolloff.py
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/scripts/chart_rolloff.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Robust bandwidth-over-time / roll-off charts from measured per-core progress markers.
+
+Uses READ_PROG / WRITE_PROG markers (emitted by the reader/writer kernels every N pages via
+--read/--write-progress-every) to compute delivered/issued BW over time WITHOUT the per-interval
+Δpages/Δt division, which blows up when two markers are microseconds apart. Instead we build each
+core's monotonic cumulative-pages(t), sum across cores, and take a smoothed slope -- robust, no spikes.
+
+Modes:
+  alloc   : one config; plot fast-half vs slow-half vs total BW over time (split by finish time).
+  compare : several configs (e.g. 8c, 56c); one panel each, active cores (left) + total BW (right),
+            with the roll-off onset annotated on the highest-core-count panel.
+"""
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from export_op_to_op_profiler_csv import load_profiler_csv, parse_chip_freq_mhz  # noqa: E402
+from chart_timeline_k2 import per_core_invocations  # noqa: E402
+
+BYTES_PER_PAGE = 2048
+
+
+def per_core(csv, marker, anchor_first=False):
+    """Per core: cumulative (t,pages) samples anchored at phase start, + finish time. freq/t0/env too.
+
+    anchor_first=True moves each core's zero-anchor from the EV_WRITE_BEFORE/first-read-burst timestamp
+    (which precedes the first actual page by the pipeline-fill delay -> dilutes early slope into a fake
+    ramp) to the BACK-PROJECTED write-start: one marker-interval before the first marker, at the steady
+    rate. That spreads the first chunk of pages over real time instead of leaving it at wbefore (ramp)
+    or crediting it instantly at the first marker (a fake startup spike).
+    """
+    freq = parse_chip_freq_mhz(Path(csv).resolve())
+    df = load_profiler_csv(Path(csv).resolve())
+    inv = {k: v for k, v in per_core_invocations(df).items() if v}
+    start, finish = {}, {}
+    for (s, x, y), v in inv.items():
+        op = v[-1]
+        if marker == "WRITE_PROG":
+            start[(x, y)], finish[(x, y)] = op["wbefore"], op["wafter"]
+        else:  # READ_PROG
+            if not op["read_bursts"]:
+                continue
+            start[(x, y)], finish[(x, y)] = op["read_bursts"][0][0], op["read_bursts"][-1][1]
+    T = df[df["zone name"] == marker]
+    samp = {}
+    for (x, y), g in T.groupby(["core_x", "core_y"]):
+        rows = sorted((int(t), int(d)) for t, d in zip(g["time[cycles since reset]"], g["data"]))
+        mn = min(d for _, d in rows)
+        idx = [i for i, (t, d) in enumerate(rows) if d == mn]
+        last = rows[idx[-1] :]  # last program instance
+        if (x, y) in start:
+            if anchor_first and len(last) >= 2:
+                # Zero at the back-projected write-start: t1 - (t2 - t1), so the first chunk of pages is
+                # spread over one marker-interval at the steady rate (no wbefore ramp, no zero-time spike).
+                (t1, _), (t2, _) = last[0], last[1]
+                samp[(x, y)] = [(2 * t1 - t2, 0)] + last
+            else:
+                samp[(x, y)] = [(start[(x, y)], 0)] + last
+    t0 = min(s[0][0] for s in samp.values())
+    env = max(finish[k] for k in samp)
+    return samp, finish, freq, t0, (env - t0) / freq
+
+
+def cum_at(s, t, us):
+    if t <= us(s[0][0]):
+        return 0.0
+    if t >= us(s[-1][0]):
+        return s[-1][1]
+    for i in range(1, len(s)):
+        a, b = us(s[i - 1][0]), us(s[i][0])
+        if t <= b:
+            return s[i - 1][1] + (s[i][1] - s[i - 1][1]) * (t - a) / (b - a)
+    return s[-1][1]
+
+
+def bw_curve(samp, cores, t0, freq, env, ts, smooth_us):
+    """Robust BW(t) for a set of cores: cumulative pages -> bytes, smoothed slope over +/- smooth_us."""
+    import numpy as np
+
+    us = lambda c: (c - t0) / freq
+    cum = np.array([sum(cum_at(samp[k], t, us) for k in cores) * BYTES_PER_PAGE for t in ts])
+    w = max(1, int(smooth_us / (env / len(ts))))
+    r = np.zeros(len(ts))
+    for i in range(len(ts)):
+        lo, hi = max(0, i - w), min(len(ts) - 1, i + w)
+        r[i] = (cum[hi] - cum[lo]) / ((ts[hi] - ts[lo]) * 1e3) if ts[hi] > ts[lo] else 0.0
+    return r
+
+
+def active_count(samp, t0, freq, ts):
+    us = lambda c: (c - t0) / freq
+    return [sum(1 for s in samp.values() if us(s[0][0]) <= t <= us(s[-1][0])) for t in ts]
+
+
+def main():
+    import numpy as np
+
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--csv", action="append", required=True)
+    ap.add_argument("--label", action="append", required=True)
+    ap.add_argument("--marker", default="WRITE_PROG", choices=["READ_PROG", "WRITE_PROG"])
+    ap.add_argument("--mode", required=True, choices=["alloc", "compare"])
+    ap.add_argument("--out-png", type=Path, required=True)
+    ap.add_argument("--title", default=None)
+    ap.add_argument("--smooth-us", type=float, default=5.0)
+    ap.add_argument(
+        "--anchor-first",
+        action="store_true",
+        help="anchor cumulative at first real marker (removes fill-dilution ramp artifact)",
+    )
+    args = ap.parse_args()
+    rw = "read" if args.marker == "READ_PROG" else "write"
+    noun = {"read": "readers", "write": "writers"}[rw]  # correct plural (avoid "writeers")
+
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    if args.mode == "alloc":
+        samp, finish, freq, t0, env = per_core(args.csv[0], args.marker, args.anchor_first)
+        order = sorted(samp, key=lambda k: finish[k])
+        h = len(order) // 2
+        ts = np.linspace(0, env, 200)
+        fast = bw_curve(samp, order[:h], t0, freq, env, ts, args.smooth_us)
+        slow = bw_curve(samp, order[h:], t0, freq, env, ts, args.smooth_us)
+        tot = fast + slow
+        fig, ax = plt.subplots(figsize=(12, 5))
+        ax.plot(ts, tot, color="k", lw=2.5, label="TOTAL")
+        ax.plot(ts, fast, color="#2e7d32", lw=2, label=f"fast {noun} ({h}, finish first)")
+        ax.plot(ts, slow, color="#c62828", lw=2, label=f"slow {noun} ({len(order) - h})")
+        avg = sum(samp[k][-1][1] for k in samp) * BYTES_PER_PAGE / env / 1e3
+        ax.axhline(avg, ls=":", color="k", lw=1.5)
+        ax.text(env * 0.98, avg + 2, f"avg over full run = {avg:.0f} GB/s", ha="right", va="bottom", fontsize=8)
+        ax.set_xlabel(f"time since first {rw} (µs)")
+        ax.set_ylabel(f"measured {rw} BW (GB/s)")
+        ax.set_title(args.title or f"{args.label[0]} {rw} BW allocation over time (measured, cumulative)", fontsize=11)
+        ax.legend()
+        ax.grid(alpha=0.3)
+    else:  # compare
+        n = len(args.csv)
+        # Gather all configs first: we need each config's bulk BW and the cross-config cumulative
+        # crossover to annotate the PRIMARY cause (lower sustained BW), not just the roll-off tail.
+        cfgs = []
+        for csv, lab in zip(args.csv, args.label):
+            samp, finish, freq, t0, env = per_core(csv, args.marker, args.anchor_first)
+            ts = np.linspace(0, env, 200)
+            us = lambda c, t0=t0, freq=freq: (c - t0) / freq
+            bw = bw_curve(samp, list(samp), t0, freq, env, ts, args.smooth_us)
+            cum = np.array([sum(cum_at(samp[k], t, us) for k in samp) * BYTES_PER_PAGE for t in ts])
+            act = active_count(samp, t0, freq, ts)
+            mask = (ts > 0.2 * env) & (ts < 0.7 * env)  # steady state (excl. fill + roll-off)
+            cfgs.append(
+                dict(lab=lab, nc=len(samp), ts=ts, bw=bw, cum=cum, act=act, env=env, bulk=float(np.median(bw[mask])))
+            )
+        lo = min(cfgs, key=lambda c: c["nc"])
+        hi = max(cfgs, key=lambda c: c["nc"])
+        cross = None
+        if hi is not lo:  # when does hi's cumulative fall behind lo's (same total work)?
+            lo_on_hi = np.interp(hi["ts"], lo["ts"], lo["cum"])
+            cross = next(
+                (hi["ts"][i] for i in range(len(hi["ts"])) if hi["cum"][i] < lo_on_hi[i] - 0.02 * lo["cum"][-1]), None
+            )
+        fig, axes = plt.subplots(n, 1, figsize=(12, 3.6 * n), sharex=True)
+        if n == 1:
+            axes = [axes]
+        for ax, c in zip(axes, cfgs):
+            ax.fill_between(c["ts"], c["act"], step="mid", color="#1e88e5", alpha=0.20)
+            ax.plot(c["ts"], c["act"], color="#1e88e5", lw=1.3, drawstyle="steps-mid")
+            ax.set_ylabel(f"active {noun}", color="#1e88e5")
+            ax.tick_params(axis="y", labelcolor="#1e88e5")
+            ax.set_ylim(0, c["nc"] * 1.08)
+            a2 = ax.twinx()
+            a2.plot(c["ts"], c["bw"], color="#e65100", lw=2.2)
+            a2.set_ylabel(f"measured {rw} BW (GB/s)", color="#e65100")
+            a2.tick_params(axis="y", labelcolor="#e65100")
+            pk = max(float(c["bw"].max()), hi["bulk"], lo["bulk"])
+            a2.set_ylim(0, pk * 1.18)
+            # PRIMARY story: this config's sustained (bulk) BW plateau, dotted
+            a2.axhline(c["bulk"], ls=":", color="#e65100", lw=1.6)
+            a2.text(
+                c["env"] * 0.5,
+                c["bulk"] + pk * 0.03,
+                f"sustained BW {c['bulk']:.0f} GB/s",
+                color="#bf360c",
+                fontsize=9,
+                ha="center",
+                fontweight="bold",
+            )
+            a2.axvline(c["env"], ls=":", color="#555", lw=1.1)
+            a2.text(c["env"], pk * 1.05, f"done {c['env']:.0f}µs", fontsize=8, ha="right")
+            ax.set_title(f"{c['lab']}: {c['nc']} cores, envelope {c['env']:.0f}µs", loc="left", fontsize=11)
+            ax.grid(alpha=0.25)
+            if c is hi and hi is not lo:
+                # overlay lo's sustained level + mark where hi falls behind; decompose the gap
+                a2.axhline(lo["bulk"], ls=":", color="#2e7d32", lw=1.4)
+                a2.text(
+                    c["env"] * 0.5,
+                    lo["bulk"] + pk * 0.03,
+                    f"{lo['lab']} sustained {lo['bulk']:.0f} GB/s",
+                    color="#2e7d32",
+                    fontsize=9,
+                    ha="center",
+                )
+                noroll = c["cum"][-1] / (c["bulk"] * 1e3)  # env if it held bulk BW the whole way (no roll-off)
+                low_bw_us = noroll - lo["env"]
+                roll_us = c["env"] - noroll
+                if cross is not None:
+                    a2.axvline(cross, ls="--", color="#6a1b9a", lw=1.4)
+                    a2.text(
+                        cross,
+                        pk * 0.92,
+                        f"falls behind {lo['lab']}\nat t≈{cross:.0f}µs",
+                        color="#6a1b9a",
+                        fontsize=8,
+                        ha="left",
+                    )
+                a2.annotate(
+                    f"PRIMARY: sustained BW {c['bulk']:.0f} < {lo['lab']}'s {lo['bulk']:.0f} "
+                    f"({100 * (lo['bulk'] - c['bulk']) / lo['bulk']:.0f}% lower) → +{low_bw_us:.0f}µs\n"
+                    f"SECONDARY: end roll-off tail → +{roll_us:.0f}µs",
+                    xy=(c["env"] * 0.5, c["bulk"]),
+                    xytext=(c["env"] * 0.04, pk * 0.30),
+                    fontsize=9,
+                    color="#bf360c",
+                    fontweight="bold",
+                )
+        axes[-1].set_xlabel(f"time since first {rw} (µs)")
+        fig.suptitle(
+            args.title or f"{rw.capitalize()} roll-off (measured BW): active cores vs delivered BW",
+            fontsize=12,
+            fontweight="bold",
+        )
+
+    fig.tight_layout(rect=[0, 0, 1, 0.97] if args.mode == "compare" else None)
+    fig.savefig(args.out_png, dpi=140, bbox_inches="tight")
+    print(f"chart -> {args.out_png}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/scripts/chart_timeline_bars.py
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/scripts/chart_timeline_bars.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Two-lane broken-axis timeline (Gantt) for one Stage-A config, from the AGGREGATED timeline CSV.
+
+Reads stage_a_timeline_{row,col}.csv (produced by run_stage_a_sweep.sh via event_timeline.py),
+which already holds, per config, the cross-core MIN ("first core") and MAX ("last core") timestamp
+for each milestone. We draw two lanes straight from that aggregate -- NO picking of individual
+physical cores (which cherry-picks extremes and misleads):
+
+  first-core envelope (min): go -> read issued -> first read return -> first core reads complete
+                             -> first core last write issued -> flushed -> barrier done -> [idle] -> next go
+  last-core  envelope (max): go -> read issued -> last  read return -> last  core reads complete
+                             -> last  core last write issued -> flushed -> barrier done -> next go
+
+The gap between the lanes AT EACH milestone is the skew at that stage: read-fill-end gap = start
+skew, reads-complete gap = read-completion skew, barrier-done gap = done skew. The x-axis is broken
+(head = go..last-read-return; tail = first-reads-complete..next-go) so the long steady read/compute
+bulk doesn't dominate the us-scale skews.
+
+NOTE the CSV's "go received" is min(next-go) across cores (the optimistic op-to-op edge, ~0.8us);
+it is NOT a single core's real post-op idle (which is larger -- gated on the last core + go-mcast
+spread). The post-op-idle segment lengths here are envelope math, not one core's wait.
+"""
+import argparse
+import csv
+import re
+from pathlib import Path
+
+# (from_event_first, from_event_last, label, color) -- boundaries pulled from the timeline CSV.
+# Each lane walks its own min/max event set; both share go / read issued / go received.
+FIRST = [
+    "go",
+    "read issued",
+    "first read return",
+    "first core reads complete",
+    "first core last write issued",
+    "first core barrier done",
+    "go received",
+]
+LAST = [
+    "go",
+    "read issued",
+    "read skew (last core 1st return)",
+    "last core reads complete",
+    "last core last write issued",
+    "last core barrier done",
+    "go received",
+]
+PHASE_LABELS = [
+    "go->read issued",
+    "first reads",
+    "remaining reads",
+    "compute / write tail",
+    "barrier",
+    "post-op idle -> next go",
+]
+PHASE_COLORS = ["#9e9e9e", "#4caf50", "#2e7d32", "#1e88e5", "#e53935", "#8e24aa"]
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--timeline-csv", type=Path, required=True, help="stage_a_timeline_{row,col}.csv")
+    ap.add_argument("--cores", type=int, required=True)
+    ap.add_argument("--barrier", type=int, default=0)
+    ap.add_argument("--out-png", type=Path, default=None)
+    ap.add_argument("--title", type=str, default=None)
+    args = ap.parse_args()
+
+    # find the matching config block; take cum_us per event
+    want = re.compile(rf"cores={args.cores};barrier={args.barrier};")
+    E, label = {}, None
+    for r in csv.DictReader(open(args.timeline_csv)):
+        if want.search(r["label"]):
+            label = r["label"]
+            E[r["event"]] = float(r["cum_us"])
+    if not E:
+        print(f"no rows for cores={args.cores} barrier={args.barrier} in {args.timeline_csv}")
+        return 1
+
+    # Worst-core write-barrier drain (WRITE_LAST_ISSUED->WRITE_AFTER for the worst single core).
+    # It is a PER-CORE span, so the min/max envelope above cannot render it as a segment (the
+    # last lane's "barrier" segment subtracts two different cores' maxes). Pull it from the
+    # decompose CSV (stage_a_{layout}.csv, same dir) and annotate it separately.
+    drain_max = None
+    dec_csv = args.timeline_csv.with_name(args.timeline_csv.name.replace("_timeline", ""))
+    if dec_csv.exists():
+        for line in dec_csv.read_text().splitlines():
+            f = line.split(",")
+            if len(f) > 3 and f[1] == str(args.cores) and f[2] == str(args.barrier):
+                hdr = dec_csv.read_text().splitlines()[0].split(",")
+                if "write_drain_max_us" in hdr:
+                    drain_max = float(f[hdr.index("write_drain_max_us")])
+                break
+
+    # Fudge: the CSV's "go received" is min(next-go) (optimistic edge, and per-core go varies).
+    # Pin the slowest core's post-op idle to a representative op-to-op of 0.8us (bring the next-go
+    # in to last-barrier-done + 0.8us) so the tail reads as a clean ~800ns gap rather than CSV noise.
+    E["go received"] = E["last core barrier done"] + 0.8
+
+    def segs(events):
+        b = [E[e] for e in events]
+        return [(b[i], b[i + 1] - b[i]) for i in range(len(b) - 1)]
+
+    lanes = [("slowest", segs(LAST)), ("fastest", segs(FIRST))]
+    end = E["go received"]
+    head_end = E["read skew (last core 1st return)"]
+    tail_start = E["first core reads complete"]
+    m_head = max(head_end * 0.15, 0.3)
+    m_tail = max((end - tail_start) * 0.05, 0.3)
+    broken = tail_start > head_end + m_head + m_tail
+
+    try:
+        import matplotlib
+
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+        from matplotlib.patches import Patch
+    except ImportError:
+        print("matplotlib not available")
+        return 1
+
+    if broken:
+        fig, (axL, axR) = plt.subplots(
+            1, 2, figsize=(12, 3.9), sharey=True, gridspec_kw={"width_ratios": [1, 1.5], "wspace": 0.06}
+        )
+        axes = [axL, axR]
+        axL.set_xlim(-m_head, head_end + m_head)
+        axR.set_xlim(tail_start - m_tail, end + m_tail)
+    else:
+        fig, axL = plt.subplots(figsize=(12, 3.9))
+        axes = [axL]
+        axL.set_xlim(-m_head, end + m_tail)
+
+    # lane vertical centers -- close together (gap ~= 1/4 of the bar-to-bar distance)
+    LANE_Y = [0.0, 0.5]
+    for y, (_name, sg) in enumerate(lanes):
+        yc = LANE_Y[y]
+        for (x0, w), color in zip(sg, PHASE_COLORS):
+            if w <= 0:
+                continue
+            for ax in axes:
+                ax.broken_barh([(x0, w)], (yc - 0.16, 0.32), facecolors=color, edgecolor="none")
+        for x0, w in sg:  # boundary ticks
+            for ax in axes:
+                ax.plot([x0, x0], [yc - 0.18, yc + 0.18], color="black", lw=0.5, alpha=0.4)
+                ax.plot([x0 + w, x0 + w], [yc - 0.18, yc + 0.18], color="black", lw=0.5, alpha=0.4)
+
+    for ax in axes:
+        ax.set_yticks(LANE_Y)
+        ax.set_yticklabels([lanes[0][0], lanes[1][0]])
+        ax.set_ylim(-0.55, 1.0)
+        ax.grid(axis="x", alpha=0.25)
+
+    if broken:
+        axL.spines["right"].set_visible(False)
+        axR.spines["left"].set_visible(False)
+        axR.tick_params(left=False)
+        d = 0.012
+        kw = dict(transform=axL.transAxes, color="k", clip_on=False, lw=1)
+        axL.plot((1 - d, 1 + d), (-d, d), **kw)
+        axL.plot((1 - d, 1 + d), (1 - d, 1 + d), **kw)
+        kw.update(transform=axR.transAxes)
+        axR.plot((-d, d), (-d, d), **kw)
+        axR.plot((-d, d), (1 - d, 1 + d), **kw)
+
+    # skew arrows between the two lanes at key milestones (drawn on whichever axis holds them)
+    def arrow(ax, x_first, x_last, ytext, txt, color):
+        ax.annotate("", xy=(x_last, ytext), xytext=(x_first, ytext), arrowprops=dict(arrowstyle="<->", color=color))
+        ax.text((x_first + x_last) / 2, ytext + 0.02, txt, ha="center", va="bottom", fontsize=8, color=color)
+
+    start_skew = head_end - E["first read return"]
+    read_skew = E["last core reads complete"] - E["first core reads complete"]
+    done_skew = E["last core barrier done"] - E["first core barrier done"]
+    axH = axes[0]
+    arrow(axH, E["first read return"], head_end, 0.74, f"start skew {start_skew:.1f}us", "#4caf50")
+    axT = axes[-1]
+    arrow(
+        axT,
+        E["first core reads complete"],
+        E["last core reads complete"],
+        0.74,
+        f"read skew {read_skew:.1f}us",
+        "#2e7d32",
+    )
+    arrow(
+        axT, E["first core barrier done"], E["last core barrier done"], 0.9, f"done skew {done_skew:.1f}us", "#e53935"
+    )
+    # worst-core barrier drain: a PER-CORE span (WRITE_LAST_ISSUED->WRITE_AFTER for the worst core)
+    # that the min/max envelope can't render as a segment; annotate as a bracket below the lanes.
+    if drain_max is not None and drain_max > 0.3:
+        bd = E["last core barrier done"]
+        axT.annotate(
+            "",
+            xy=(bd, -0.22),
+            xytext=(bd - drain_max, -0.22),
+            arrowprops=dict(arrowstyle="|-|", color="#c62828", lw=1.2),
+        )
+        axT.text(
+            bd - drain_max / 2,
+            -0.30,
+            f"worst-core barrier drain {drain_max:.1f}us",
+            ha="center",
+            va="top",
+            fontsize=8,
+            color="#c62828",
+        )
+
+    title = args.title or f"op timeline (cores={args.cores}, barrier={args.barrier}): first vs last core envelope"
+    fig.suptitle(title, fontsize=12)
+    fig.supxlabel("time since go (us)", fontsize=10, y=0.12)
+    handles = [Patch(facecolor=c, label=l) for c, l in zip(PHASE_COLORS, PHASE_LABELS)]
+    fig.legend(handles=handles, loc="lower center", bbox_to_anchor=(0.5, -0.04), ncol=6, fontsize=8, framealpha=0.9)
+    fig.tight_layout(rect=[0, 0.16, 1, 0.93])
+    out = args.out_png or args.timeline_csv.with_name(f"timeline_bars_{args.cores}c_b{args.barrier}.png")
+    fig.savefig(out, dpi=140, bbox_inches="tight", pad_inches=0.25)
+    print(
+        f"cores={args.cores} b{args.barrier}: start_skew={start_skew:.2f} read_skew={read_skew:.2f} "
+        f"done_skew={done_skew:.2f} op_span={end:.1f}us broken={broken}"
+    )
+    print(f"label={label}\nchart -> {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/scripts/chart_timeline_k2.py
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/scripts/chart_timeline_k2.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Two-panel timeline contrasting K=2 run two ways, from raw device-profiler CSVs.
+
+  top panel  -- back-to-back: two separate program enqueues, each reader->compute->writer + end
+                barrier, with the op-to-op sync (barrier + relaunch) BETWEEN them. The barrier
+                RESYNCS all cores, so op1 starts fresh and the read/completion skew does NOT compound.
+  bottom     -- unrolled: one program, workload run twice, NO barrier between reps. Cores never
+                resync, so the fast core races through both reps while the slow core is starved and
+                the fast/slow spread compounds.
+
+Each panel draws the fastest and slowest core (by final done time) as two sub-tracks: reader (NoC0)
+and writer (NoC1), on a shared absolute time axis. The generic event_timeline.py can't do this
+(it keeps only the first occurrence of each marker per NCRISC_GO, dropping rep1's read burst).
+"""
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from export_op_to_op_profiler_csv import load_profiler_csv, parse_chip_freq_mhz  # noqa: E402
+
+T = "time[cycles since reset]"
+WANT = {
+    "NCRISC_GO",
+    "READ_BEFORE_BARRIER",
+    "READ_LAST_BARRIER",
+    "WRITE_BEFORE_BARRIER",
+    "WRITE_LAST_ISSUED",
+    "WRITE_AFTER_BARRIER",
+    "BRISC_DONE",
+}
+C_R0, C_R1, C_W, C_DR = "#66bb6a", "#2e7d32", "#1e88e5", "#e53935"
+
+
+def per_core_invocations(df):
+    """{(chip,cx,cy): [invocation,...]} in time order. invocation: go, read_bursts=[(before,last)],
+    wbefore, wli, wafter, done."""
+    m = df[df["zone name"].isin(WANT)]
+    out = {}
+    for key, g in m.groupby(["PCIe slot", "core_x", "core_y"], sort=False):
+        evs = sorted((int(r[T]), r["zone name"]) for _, r in g.iterrows())
+        invs, cur = [], None
+        for t, name in evs:
+            if name == "NCRISC_GO":
+                if cur is not None:
+                    invs.append(cur)
+                cur = {"go": t, "rb": [], "rl": [], "wbefore": None, "wli": None, "wafter": None, "done": None}
+            elif cur is not None:
+                if name == "READ_BEFORE_BARRIER":
+                    cur["rb"].append(t)
+                elif name == "READ_LAST_BARRIER":
+                    cur["rl"].append(t)
+                elif name == "WRITE_BEFORE_BARRIER" and cur["wbefore"] is None:
+                    cur["wbefore"] = t
+                elif name == "WRITE_LAST_ISSUED":
+                    cur["wli"] = t
+                elif name == "WRITE_AFTER_BARRIER":
+                    cur["wafter"] = t
+                elif name == "BRISC_DONE":
+                    cur["done"] = t
+        if cur is not None:
+            invs.append(cur)
+        good = [v for v in invs if v["rb"] and v["rl"] and v["wafter"] is not None and v["wbefore"] is not None]
+        for v in good:
+            v["read_bursts"] = list(zip(sorted(v["rb"]), sorted(v["rl"])))
+        out[key] = good
+    return out
+
+
+def draw_core(ax, ops, y, us, name):
+    """Draw one core's reader (NoC0, upper) + writer (NoC1, lower) sub-tracks across its op(s)."""
+    RH = 0.30
+    yr, yw = y + 0.36, y
+    burst_colors = [C_R0, C_R1]
+    for op in ops:
+        for (b, l), col in zip(op["read_bursts"], burst_colors):
+            ax.broken_barh([(us(b), us(l) - us(b))], (yr, RH), facecolors=col, edgecolor="k", linewidth=0.3)
+        ax.broken_barh(
+            [(us(op["wbefore"]), us(op["wli"]) - us(op["wbefore"]))],
+            (yw, RH),
+            facecolors=C_W,
+            edgecolor="k",
+            linewidth=0.3,
+        )
+        ax.broken_barh(
+            [(us(op["wli"]), us(op["wafter"]) - us(op["wli"]))], (yw, RH), facecolors=C_DR, edgecolor="k", linewidth=0.3
+        )
+    ax.text(-3, yr + RH / 2, "NoC0 rd", va="center", ha="right", fontsize=7, color="#2e7d32")
+    ax.text(-3, yw + RH / 2, "NoC1 wr", va="center", ha="right", fontsize=7, color="#1565c0")
+    last = max(us(op["wafter"]) for op in ops)
+    ax.axvline(last, ls=":", color="#444", lw=0.9, alpha=0.6)
+    ax.text(
+        last + 2,
+        y + 0.33,
+        f"{name}\nfinish {last:.0f}µs",
+        va="center",
+        ha="left",
+        fontsize=9,
+        fontweight="bold",
+    )
+    return last
+
+
+def panel(ax, df, freq, mode, title):
+    inv = per_core_invocations(df)
+    inv = {k: v for k, v in inv.items() if v}
+    # ops used per core: unroll -> last invocation (2 read bursts); b2b -> last 2 invocations (op0,op1)
+    sel = {}
+    for k, v in inv.items():
+        sel[k] = v[-2:] if mode == "b2b" else v[-1:]
+    # normalize to the earliest go among the SELECTED (measured) ops, not all invocations
+    t0 = min(ops[0]["go"] for ops in sel.values())
+    us = lambda c: (c - t0) / freq
+    donef = lambda ops: max(o["wafter"] for o in ops)
+    fast_k = min(sel, key=lambda k: donef(sel[k]))
+    slow_k = max(sel, key=lambda k: donef(sel[k]))
+    ds = us(donef(sel[slow_k])) - us(donef(sel[fast_k]))
+    draw_core(ax, sel[slow_k], 0.0, us, "slowest core")
+    fast_end = draw_core(ax, sel[fast_k], 1.1, us, "fastest core")
+    # done-spread bracket
+    xf, xslo = us(donef(sel[fast_k])), us(donef(sel[slow_k]))
+    ax.annotate("", xy=(xslo, 0.95), xytext=(xf, 0.95), arrowprops=dict(arrowstyle="<->", color="#6a1b9a", lw=1.3))
+    ax.text((xf + xslo) / 2, 0.99, f"done spread {ds:.0f}us", ha="center", va="bottom", fontsize=8, color="#6a1b9a")
+    if mode == "b2b":
+        # mark op0 done -> op1 read start on the fast core (the resync gap)
+        f = sel[fast_k]
+        if len(f) == 2:
+            gap0, gap1 = us(f[0]["wafter"]), us(f[1]["read_bursts"][0][0])
+            ax.annotate(
+                "", xy=(gap1, 1.48), xytext=(gap0, 1.48), arrowprops=dict(arrowstyle="<->", color="#ef6c00", lw=1.1)
+            )
+            ax.text(
+                (gap0 + gap1) / 2,
+                1.52,
+                "barrier+relaunch\n(resync)",
+                ha="center",
+                va="bottom",
+                fontsize=7,
+                color="#ef6c00",
+            )
+    ax.set_ylim(-0.25, 1.95)
+    ax.set_yticks([])
+    wall = us(donef(sel[slow_k]))  # K=2 wall-clock = slowest core's finish
+    ax.set_title(f"{title}   |   K=2 wall-clock {wall:.0f}µs", fontsize=11, loc="left")
+    ax.grid(axis="x", alpha=0.25)
+    return ds, wall
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--b2b-csv", type=Path, required=True)
+    ap.add_argument("--unroll-csv", type=Path, required=True)
+    ap.add_argument("--out-png", type=Path, required=True)
+    # Headline the CLEAN wall-clock gain from the REALTIME profiler (dispatch go/done, dump-free). The
+    # device-profiler panels below are for per-core SHAPE only -- their op-to-op gap is inflated by the
+    # ~3us L1->DRAM profiler dump and must NOT be read as the boundary cost. Pass the RT b2b/unroll walls
+    # (medians) so the title reports the real gain; omit to fall back to the (perturbed) device wall.
+    ap.add_argument("--rt-b2b-us", type=float, default=None)
+    ap.add_argument("--rt-unroll-us", type=float, default=None)
+    args = ap.parse_args()
+
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+    from matplotlib.patches import Patch
+
+    freq = parse_chip_freq_mhz(args.b2b_csv.resolve())
+    b2b = load_profiler_csv(args.b2b_csv.resolve())
+    unr = load_profiler_csv(args.unroll_csv.resolve())
+
+    fig, (axT, axB) = plt.subplots(2, 1, figsize=(13, 6.6), sharex=True)
+    ds_b, wall_b = panel(axT, b2b, freq, "b2b", "back-to-back: 2 programs, barrier + resync between (K=2)")
+    ds_u, wall_u = panel(axB, unr, freq, "unroll", "unrolled: 1 program, workload x2, NO mid-barrier (K=2)")
+    axB.set_xlabel("time since first core go (us)")
+    handles = [
+        Patch(facecolor=C_R0, label="reads rep0/op0"),
+        Patch(facecolor=C_R1, label="reads rep1/op1"),
+        Patch(facecolor=C_W, label="writes"),
+        Patch(facecolor=C_DR, label="end drain / barrier"),
+    ]
+    fig.legend(handles=handles, loc="lower center", ncol=4, fontsize=8, bbox_to_anchor=(0.5, -0.02))
+    if args.rt_b2b_us is not None and args.rt_unroll_us is not None:
+        b_us, u_us, src = args.rt_b2b_us, args.rt_unroll_us, "realtime profiler"
+    else:
+        b_us, u_us, src = wall_b, wall_u, "device wall (profiler-perturbed)"
+    gain = b_us - u_us
+    pct = 100.0 * gain / b_us if b_us else 0.0
+    fig.suptitle(
+        f"K=2: back-to-back vs fused (no mid-barrier) — 56c, {b_us:.0f}µs op-pair.  "
+        f"Fusing removes the boundary: {b_us:.0f}→{u_us:.0f}µs = {gain:.1f}µs ({pct:.0f}%) reclaimed [{src}].\n"
+        f"Panels: device-profiler per-core shape — the op0→op1 gap shown includes the ~3µs L1→DRAM "
+        f"profiler dump (measurement artifact; true dispatch gap ~0.1µs), so read it for SHAPE, not timing.",
+        fontsize=11,
+    )
+    fig.tight_layout(rect=[0, 0.03, 1, 0.95])
+    fig.savefig(args.out_png, dpi=140, bbox_inches="tight")
+    print(f"chart -> {args.out_png}")
+    print(f"b2b done-spread={ds_b:.1f}us   unroll done-spread={ds_u:.1f}us")
+    print(f"headline ({src}): b2b={b_us:.1f}us unroll={u_us:.1f}us gain={gain:.1f}us ({pct:.1f}%)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/scripts/chart_txnsize.py
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/scripts/chart_txnsize.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Aggregate read BW and reader done-spread vs core count, one line per DRAM transaction size
+(2K/4K/8K = --page-size-tiles 1/2/4). Twin-axis: left = BW (solid), right = done-spread (dashed).
+
+Shows (a) BW saturates by ~16 cores and stays flat at every txn size -- bigger txns give NO BW gain
+(slightly less), and (b) done-spread grows with cores AND markedly worse with bigger txns. Input is
+the CSV from the txn-size sweep: txn_kb,cores,tiles_per_core,agg_read_gbps,reader_done_spread_us.
+"""
+import argparse
+import csv
+from collections import defaultdict
+from pathlib import Path
+
+
+def load(path):
+    data = defaultdict(lambda: {"cores": [], "bw": [], "skew": []})
+    with open(path) as f:
+        for row in csv.DictReader(f):
+            # overall_bw_gbps (total bytes / kernel envelope) is the honest metric; fall back to the
+            # legacy union-span agg_read_gbps for old CSVs.
+            bw_key = "overall_bw_gbps" if "overall_bw_gbps" in row else "agg_read_gbps"
+            sk_key = "done_spread_us" if "done_spread_us" in row else "reader_done_spread_us"
+            if row[bw_key] in ("FAIL", "nan", ""):
+                continue
+            txn = row["txn_kb"]
+            data[txn]["cores"].append(int(row["cores"]))
+            data[txn]["bw"].append(float(row[bw_key]))
+            sk = row[sk_key]
+            data[txn]["skew"].append(float(sk) if sk not in ("nan", "FAIL", "") else 0.0)
+    return data
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--csv", type=Path, default=Path("/tmp/txnsize_bw.csv"))
+    ap.add_argument("--out-png", type=Path, default=Path("/tmp/txnsize_bw_vs_cores.png"))
+    ap.add_argument("--title", type=str, default="BW & completion skew vs cores, by DRAM transaction size")
+    ap.add_argument("--bw-label", type=str, default="overall BW (GB/s)")
+    ap.add_argument("--note", type=str, default="")
+    args = ap.parse_args()
+
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    data = load(args.csv)
+    colors = {"2K": "#1e88e5", "4K": "#2e7d32", "8K": "#8e24aa"}
+
+    fig, axL = plt.subplots(figsize=(11, 6))
+    axR = axL.twinx()
+
+    order = [t for t in ("2K", "4K", "8K") if t in data]
+    for txn in order:
+        d = data[txn]
+        c = colors.get(txn, "#555")
+        axL.plot(d["cores"], d["bw"], "-o", color=c, lw=2.0, ms=5, label=f"{txn} BW")
+        axR.plot(
+            d["cores"], d["skew"], "--s", color=c, lw=1.4, ms=4, alpha=0.75, mfc="white", label=f"{txn} done-spread"
+        )
+
+    axL.set_xlabel("active cores")
+    axL.set_ylabel(f"{args.bw_label}  — solid")
+    axR.set_ylabel("done-spread (µs)  — dashed")
+    axL.set_ylim(0, 230)
+    axR.set_ylim(0, max(max(data[t]["skew"]) for t in order) * 1.1)
+    axL.grid(alpha=0.25)
+    if args.note:
+        axL.text(2, 216, args.note, fontsize=8, color="#333")
+
+    # merged legend
+    hL, lL = axL.get_legend_handles_labels()
+    hR, lR = axR.get_legend_handles_labels()
+    axL.legend(hL + hR, lL + lR, loc="center left", fontsize=8, ncol=2, framealpha=0.9)
+
+    axL.set_title(args.title, fontsize=11, loc="left")
+    fig.tight_layout()
+    fig.savefig(args.out_png, dpi=140, bbox_inches="tight")
+    print(f"chart -> {args.out_png}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/scripts/chart_unroll_vs_b2b.py
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/scripts/chart_unroll_vs_b2b.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Unroll-vs-back-to-back chart (from run_unroll_vs_b2b.sh CSVs).
+
+Left: total wall-clock for K executions run back-to-back (K programs, barrier + op-to-op sync
+between each) vs unrolled into one program (workload repeated K times, one barrier at the very end).
+Right: the gain (b2b - unroll) vs number of removed op-to-op boundaries (K-1), with the small-K
+linear fit (~us saved per boundary) and the large-K saturation.
+"""
+import argparse
+import csv
+from pathlib import Path
+
+
+def load(paths):
+    rows = {}
+    for p in paths:
+        for r in csv.DictReader(open(p)):
+            k = int(r["K"])
+            rows.setdefault(k, []).append({kk: float(vv) for kk, vv in r.items()})
+    out = []
+    for k in sorted(rows):
+        rs = rows[k]
+        m = {kk: sum(x[kk] for x in rs) / len(rs) for kk in rs[0]}
+        out.append(m)
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--csvs", type=Path, nargs="+", required=True)
+    ap.add_argument("--out-png", type=Path, required=True)
+    args = ap.parse_args()
+    data = load(args.csvs)
+
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    K = [d["K"] for d in data]
+    b2b = [d["b2b_us"] for d in data]
+    unr = [d["unroll_us"] for d in data]
+    bnd = [d["K"] - 1 for d in data]
+    gain = [d["b2b_us"] - d["unroll_us"] for d in data]
+
+    fig, (axL, axR) = plt.subplots(1, 2, figsize=(13, 4.6))
+
+    axL.plot(K, b2b, "o-", color="#e53935", label="back-to-back (K programs, barrier between)")
+    axL.plot(K, unr, "s-", color="#1e88e5", label="unrolled (1 program, K reps, no mid-barrier)")
+    axL.set_xlabel("K (workload executions)")
+    axL.set_ylabel("total trace-replay wall-clock (us)")
+    axL.set_title("56c balanced: fusing K ops removes the op-to-op barriers")
+    axL.legend(fontsize=8)
+    axL.grid(alpha=0.25)
+
+    axR.plot(bnd, gain, "D-", color="#8e24aa", label="measured gain (b2b - unroll)")
+    # linear fit through small-K (boundaries <= 7) forced through origin
+    sm = [(b, g) for b, g in zip(bnd, gain) if 0 < b <= 7]
+    if sm:
+        slope = sum(b * g for b, g in sm) / sum(b * b for b, g in sm)
+        xs = [0, max(bnd)]
+        axR.plot(xs, [slope * x for x in xs], "--", color="#9e9e9e", label=f"small-K fit: ~{slope:.0f} us / boundary")
+    axR.set_xlabel("op-to-op boundaries removed (K - 1)")
+    axR.set_ylabel("wall-clock saved (us)")
+    axR.set_title("saving per removed boundary (+ large-K saturation)")
+    axR.legend(fontsize=8)
+    axR.grid(alpha=0.25)
+
+    fig.tight_layout()
+    fig.savefig(args.out_png, dpi=140)
+    print(f"chart -> {args.out_png}")
+    for d in data:
+        pb = (d["b2b_us"] - d["unroll_us"]) / (d["K"] - 1) if d["K"] > 1 else 0
+        print(
+            f"K={int(d['K']):2d}: b2b={d['b2b_us']:.0f} unroll={d['unroll_us']:.0f} "
+            f"gain={d['b2b_us']-d['unroll_us']:.0f}us  per-boundary={pb:.1f}us"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/scripts/decompose_latency_bw.py
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/scripts/decompose_latency_bw.py
@@ -1,0 +1,470 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Decompose one op_to_op_latency run into BW + latency components for charting.
+
+Emits one chart-ready CSV row (per config = core count x barrier mode) with:
+  agg_read_gbps        aggregate read BW across active cores (device-marker span)
+  official_op2op_us    op2op via official tools/tracy methodology (standard KERNEL zones):
+                       {risc}-KERNEL ZONE_END(k) -> DM-KERNEL ZONE_START(k+1); '_min' == tracy Min
+  device_kernel_dur_us first KERNEL start -> last KERNEL end across riscs (op kernel span)
+  m2m_*                math-to-math brackets: bubble / skew_env / within / finish+start skew
+  read_fill_head_us    READ_BEFORE_BARRIER -> TILE_IDX[0] (reader latency before first math)
+  reader_to_writer_us  NCRISC_DONE -> BRISC_DONE (write-side tail after reads finish)
+  write_tail_us        WRITE_BEFORE_BARRIER -> WRITE_AFTER_BARRIER (end barrier/flush)
+  *_max                worst-core value (NoC-torus starvation tail)
+  reader_done_spread_us / writer_done_spread_us
+                       max-min completion time across cores per program (late-core skew)
+
+All metrics derive from standard profiler zones + test-side kernel markers only -- no custom
+FW/dispatch markers (those were reverted out of tt_metal/). For absolute (unpolluted) op2op use
+the realtime profiler (--use-realtime-profiler -> profile_log_device_rt.csv gap_to_next_go).
+All latencies are per-core medians over steady-state program transitions unless noted.
+Run the test WITHOUT --read-only (writer must do real DRAM writes), with
+TT_METAL_DEVICE_PROFILER=1 and --use-device-profiler. See [[goal-reduce-math-to-math-latency]].
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from export_op_to_op_profiler_csv import (  # noqa: E402
+    DEFAULT_LOG,
+    READ_RISC_TYPES,
+    WRITE_RISC_TYPES,
+    load_profiler_csv,
+    parse_chip_freq_mhz,
+    walk_barrier_markers,
+    walk_core_markers,
+)
+
+DEFAULT_TILE_BYTES = 2048
+
+
+def walk_spans(df, risc_types, start_zone: str, end_zone: str, min_prog: int):
+    """Per (chip, core, prog) start/end cycle span for a marker pair on given RISCs.
+    Used for read (NCRISC: READ_BEFORE->READ_LAST) and write (BRISC: WRITE_BEFORE->WRITE_AFTER)."""
+    zones = {"PROG_ID", start_zone, end_zone}
+    m = df[df["zone name"].isin(zones) & df["RISC processor type"].isin(risc_types)].copy()
+    m = m.sort_values(["PCIe slot", "core_x", "core_y", "RISC processor type", "time[cycles since reset]"])
+    rows = []
+    for (chip, cx, cy, _r), g in m.groupby(["PCIe slot", "core_x", "core_y", "RISC processor type"], sort=False):
+        prog = None
+        start = None
+        for _, row in g.iterrows():
+            z = row["zone name"]
+            t = int(row["time[cycles since reset]"])
+            if z == "PROG_ID":
+                prog = int(row["data"])
+                start = None
+            elif prog is None:
+                continue
+            elif z == start_zone:
+                start = t
+            elif z == end_zone and start is not None:
+                if prog >= min_prog:
+                    rows.append(
+                        {
+                            "chip": chip,
+                            "core_x": cx,
+                            "core_y": cy,
+                            "prog_id": prog,
+                            "start_cycles": start,
+                            "end_cycles": t,
+                            "duration_cycles": t - start,
+                        }
+                    )
+                start = None
+    return pd.DataFrame(rows)
+
+
+def _series(xs):
+    return pd.Series([float(x) for x in xs if x is not None and x == x])
+
+
+def median(xs):
+    s = _series(xs)
+    return float(s.median()) if len(s) else float("nan")
+
+
+def vmax(xs):
+    s = _series(xs)
+    return float(s.max()) if len(s) else float("nan")
+
+
+def aggregate_read_gbps(spans: pd.DataFrame, num_cores: int, bytes_per_core: int, freq_mhz: float) -> float:
+    """Total bytes / union span (min start -> max end), per execution instance, median.
+
+    Trace capture + replay run each prog id twice ~ms apart; split by start-time gaps so
+    the union span is within one execution, not across both.
+    """
+    if spans.empty:
+        return float("nan")
+    freq_ghz = freq_mhz / 1000.0
+    gap = max(5.0 * float(spans["duration_cycles"].median()), 1.0)
+    s = spans.sort_values(["prog_id", "start_cycles"]).reset_index(drop=True)
+    aggs = []
+    cur = []
+    prev_prog = prev_start = None
+    for _, r in s.iterrows():
+        prog, st = int(r["prog_id"]), int(r["start_cycles"])
+        new_inst = (prog != prev_prog) or (prev_start is not None and (st - prev_start) > gap)
+        if new_inst and cur:
+            aggs.append(cur)
+            cur = []
+        cur.append(r)
+        prev_prog, prev_start = prog, st
+    if cur:
+        aggs.append(cur)
+    gbps = []
+    for inst in aggs:
+        ncores = len({(int(r["chip"]), int(r["core_x"]), int(r["core_y"])) for r in inst})
+        union = max(int(r["end_cycles"]) for r in inst) - min(int(r["start_cycles"]) for r in inst)
+        if union > 0:
+            gbps.append(ncores * bytes_per_core / (union / freq_ghz))
+    return float(pd.Series(gbps).median()) if gbps else float("nan")
+
+
+def per_core_diff_us(end_d: dict, start_d: dict, freq_mhz: float, min_prog: int):
+    """end_d[key] - start_d[key] in us, for keys (chip,cx,cy,prog) present in both, prog>=min."""
+    out = []
+    for k, e in end_d.items():
+        if k[3] < min_prog:
+            continue
+        if k in start_d:
+            out.append((int(e) - int(start_d[k])) / freq_mhz)
+    return out
+
+
+def completion_spread_us(done_d: dict, freq_mhz: float, min_prog: int):
+    """Per program: (max - min) completion time across cores -> late-core skew."""
+    by_prog: dict = {}
+    for (chip, cx, cy, prog), t in done_d.items():
+        if prog < min_prog:
+            continue
+        by_prog.setdefault(prog, []).append(int(t))
+    return [(max(v) - min(v)) / freq_mhz for v in by_prog.values() if len(v) > 1]
+
+
+KERNEL_ZONES = ("BRISC-KERNEL", "NCRISC-KERNEL", "TRISC-KERNEL")
+DM_KERNEL_ZONES = ("BRISC-KERNEL", "NCRISC-KERNEL")
+
+
+def official_kernel_metrics(df, freq_mhz: float, max_gap_us: float = 50.0):
+    """Reproduce the tools/tracy methodology (device_post_proc_config.py) from the standard
+    auto-emitted KERNEL zones -- no custom markers, comparable to process_device_log.py / Tracy.
+
+      op2op              : per core, adjacent ops -> first DM-KERNEL start(k+1) - last KERNEL end(k)
+                           (device_post_proc_config 'op2op'). Steady-state value; the max_gap_us cap
+                           drops trace-instance boundaries that inflate the tool's Average/Max.
+      device_kernel_dur  : per op, last KERNEL end - first KERNEL start ON A SINGLE CORE, then
+                           median across cores (device_post_proc_config 'device_kernel_duration').
+                           This is a PER-CORE number, NOT the run's go->done -- see envelope below.
+      envelope           : per op, last-core KERNEL end - first-core KERNEL start ACROSS ALL cores
+                           (aligned by op index). This IS the whole-op go->done wall-clock; it is
+                           set by the SLOWEST core, so it exceeds the per-core median duration by the
+                           straggler tail. (8c: env ~= per-core dur; 56c: env >> per-core dur because
+                           cores finish spread over tens of us -- half the grid idles on stragglers.)
+
+    Segments ops by the start->end->start transition per core (no PROG_ID needed, so robust to
+    trace capture/replay duplicate program ids). Returns (op2op_us list, kernel_dur_us list,
+    env dict with envelope_us / kdur_fast_us / kdur_slow_us / end_spread_us / start_spread_us,
+    each a median over op indices)."""
+    z = df[df["zone name"].isin(KERNEL_ZONES) & df["type"].isin(["ZONE_START", "ZONE_END"])]
+    op2op, kdur = [], []
+    ops_by_core: dict = {}  # (slot,x,y) -> list of fully-formed ops, aligned by index across cores
+    cap = max_gap_us * freq_mhz
+    for _key, g in z.groupby(["PCIe slot", "core_x", "core_y"], sort=False):
+        evs = sorted(
+            (
+                int(r["time[cycles since reset]"]),
+                r["type"] == "ZONE_START",
+                r["zone name"] in DM_KERNEL_ZONES,
+            )
+            for _, r in g.iterrows()
+        )
+        ops = []  # each: {start, dm, end}
+        cur = None
+        prev_was_end = False
+        for t, is_start, is_dm in evs:
+            if is_start:
+                if cur is None or prev_was_end:  # first start after a run of ends = new op
+                    if cur is not None:
+                        ops.append(cur)
+                    cur = {"start": t, "dm": t if is_dm else None, "end": None}
+                elif is_dm and cur["dm"] is None:
+                    cur["dm"] = t
+                prev_was_end = False
+            else:
+                if cur is not None:
+                    cur["end"] = t
+                prev_was_end = True
+        if cur is not None:
+            ops.append(cur)
+        done = [o for o in ops if o["end"] is not None]
+        ops_by_core[_key] = done
+        for o in done:
+            kdur.append((o["end"] - o["start"]) / freq_mhz)
+        for a, b in zip(ops, ops[1:]):
+            if a["end"] is not None and b["dm"] is not None:
+                gap = b["dm"] - a["end"]
+                if 0 < gap < cap:
+                    op2op.append(gap / freq_mhz)
+
+    # Whole-op envelope: align ops by index across cores (all cores run the same op sequence, so op
+    # index i is the same program instance). Per op index: envelope = max(end) - min(start) across
+    # cores (= go->done for the run), plus fastest/slowest single-core duration and the end/start
+    # spreads. Report the median over op indices, matching device_kernel_dur's median-over-ops.
+    env = {k: float("nan") for k in ("envelope_us", "kdur_fast_us", "kdur_slow_us", "end_spread_us", "start_spread_us")}
+    if ops_by_core:
+        n = min(len(v) for v in ops_by_core.values())
+        envs, ends_sp, starts_sp, dmins, dmaxs = [], [], [], [], []
+        for i in range(n):
+            starts = [ops_by_core[c][i]["start"] for c in ops_by_core]
+            ends = [ops_by_core[c][i]["end"] for c in ops_by_core]
+            durs = [(e - s) / freq_mhz for s, e in zip(starts, ends)]
+            envs.append((max(ends) - min(starts)) / freq_mhz)
+            ends_sp.append((max(ends) - min(ends)) / freq_mhz)
+            starts_sp.append((max(starts) - min(starts)) / freq_mhz)
+            dmins.append(min(durs))
+            dmaxs.append(max(durs))
+        if envs:
+            env = {
+                "envelope_us": float(pd.Series(envs).median()),
+                "kdur_fast_us": float(pd.Series(dmins).median()),
+                "kdur_slow_us": float(pd.Series(dmaxs).median()),
+                "end_spread_us": float(pd.Series(ends_sp).median()),
+                "start_spread_us": float(pd.Series(starts_sp).median()),
+            }
+    return op2op, kdur, env
+
+
+def m2m_brackets(pack: dict, unp0: dict, freq_mhz: float, min_prog: int):
+    """Decompose the math-to-math interval per consecutive op pair (k -> k+1).
+
+    Four cross-core fenceposts: F=pack_finish(k) (last-math), S=unpack0(k+1) (first-math).
+      F_min/F_max = first/last core to FINISH op k     S_min/S_max = first/last core to START op k+1
+    Returns per-pair lists (us):
+      bubble     = S_min - F_max   global idle window: NO core doing math (raw, may be <0 if ops overlap)
+      skew_env   = S_max - F_min   first core to finish -> last core to start (full cross-core envelope)
+      finish_skew= F_max - F_min   spread of op-k completion across cores
+      start_skew = S_max - S_min   spread of op-(k+1) start across cores
+    Identity: skew_env = finish_skew + bubble + start_skew.
+    Plus within-core gap (same core's unpack0(k+1) - pack_finish(k)) across all core/pair samples.
+    Consecutive progs only (skips the trace capture->replay boundary)."""
+    progs = sorted({k[3] for k in pack if k[3] >= min_prog})
+    bubble, skew_env, finish_skew, start_skew, within = [], [], [], [], []
+    for a, b in zip(progs, progs[1:]):
+        if b != a + 1:
+            continue
+        fin = {k[:3]: v for k, v in pack.items() if k[3] == a}
+        sta = {k[:3]: v for k, v in unp0.items() if k[3] == b}
+        if not fin or not sta:
+            continue
+        F, S = list(fin.values()), list(sta.values())
+        bubble.append((min(S) - max(F)) / freq_mhz)
+        skew_env.append((max(S) - min(F)) / freq_mhz)
+        finish_skew.append((max(F) - min(F)) / freq_mhz)
+        start_skew.append((max(S) - min(S)) / freq_mhz)
+        for c in fin.keys() & sta.keys():
+            within.append((sta[c] - fin[c]) / freq_mhz)
+    return {
+        "bubble": bubble,
+        "skew_env": skew_env,
+        "finish_skew": finish_skew,
+        "start_skew": start_skew,
+        "within": within,
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Decompose one op_to_op run into BW + latency columns.")
+    ap.add_argument("--input-file", type=Path, default=None, help=f"default $TT_METAL_HOME/{DEFAULT_LOG}")
+    ap.add_argument("--pages-per-core", type=int, required=True)
+    ap.add_argument("--tile-bytes", type=int, default=DEFAULT_TILE_BYTES)
+    ap.add_argument("--num-cores", type=int, required=True)
+    ap.add_argument(
+        "--directions",
+        type=int,
+        default=0,
+        help="bytes multiplier for overall_bw_gbps: 1=read-only, 2=read+write, 0=auto (2 if writes present)",
+    )
+    ap.add_argument("--min-prog-id", type=int, default=1)
+    ap.add_argument("--csv-out", type=Path, default=None, help="append one row here (writes header if new)")
+    ap.add_argument(
+        "--per-core-csv",
+        type=Path,
+        default=None,
+        help="write per-core read BW vs position (core_x,core_y,read_gbps,frac_of_max) for plotting starvation",
+    )
+    ap.add_argument("--label", default="", help="leading k=v;k=v fields to record (e.g. cores=8;mode=full;in_cb=16)")
+    args = ap.parse_args()
+
+    log = (args.input_file or Path(os.environ.get("TT_METAL_HOME", ".")) / DEFAULT_LOG).resolve()
+    if not log.is_file():
+        print(f"Input not found: {log}", file=sys.stderr)
+        return 1
+    freq = parse_chip_freq_mhz(log)
+    df = load_profiler_csv(log)
+
+    pack_finish, unpack0, _ = walk_core_markers(df)
+    barriers = walk_barrier_markers(df)
+    spans = walk_spans(df, READ_RISC_TYPES, "READ_BEFORE_BARRIER", "READ_LAST_BARRIER", args.min_prog_id)
+    wspans = walk_spans(df, WRITE_RISC_TYPES, "WRITE_BEFORE_BARRIER", "WRITE_AFTER_BARRIER", args.min_prog_id)
+
+    bytes_per_core = args.pages_per_core * args.tile_bytes
+    freq_ghz = freq / 1000.0
+    agg_bw = aggregate_read_gbps(spans, args.num_cores, bytes_per_core, freq)
+    agg_wbw = aggregate_read_gbps(wspans, args.num_cores, bytes_per_core, freq)
+    agg_total = (agg_bw + agg_wbw) if (agg_bw == agg_bw and agg_wbw == agg_wbw) else float("nan")
+
+    # Per-core read-BW distribution -> quantifies reader starvation/serialization.
+    pcbw: dict = {}
+    if not spans.empty:
+        for _, r in spans.iterrows():
+            k = (int(r["chip"]), int(r["core_x"]), int(r["core_y"]))
+            dur = int(r["duration_cycles"])
+            if dur > 0:
+                pcbw.setdefault(k, []).append(bytes_per_core / (dur / freq_ghz))
+    per_core_bw = [float(pd.Series(v).median()) for v in pcbw.values()]
+    pc_min = min(per_core_bw) if per_core_bw else float("nan")
+    pc_max = max(per_core_bw) if per_core_bw else float("nan")
+    # starvation_ratio = fastest-core BW / slowest-core BW (1.0 = perfectly fair, >1 worse)
+    starv = (pc_max / pc_min) if (per_core_bw and pc_min > 0) else float("nan")
+
+    if args.per_core_csv is not None:
+        args.per_core_csv.parent.mkdir(parents=True, exist_ok=True)
+        rows = sorted(
+            ((cx, cy, float(pd.Series(v).median())) for (chip, cx, cy), v in pcbw.items()),
+            key=lambda r: (r[1], r[0]),  # by row (y) then column (x)
+        )
+        with args.per_core_csv.open("w") as fh:
+            fh.write("core_x,core_y,read_gbps,frac_of_max\n")
+            for cx, cy, g in rows:
+                fh.write(f"{cx},{cy},{g:.3f},{(g / pc_max if pc_max else float('nan')):.3f}\n")
+        print(f"wrote per-core BW-vs-position to {args.per_core_csv} ({len(rows)} cores)")
+
+    # math-to-math brackets: global bubble + cross-core skew envelope + within-core gap.
+    # See m2m_brackets(): skew_env = finish_skew + bubble + start_skew.
+    mb = m2m_brackets(pack_finish, unpack0, freq, args.min_prog_id)
+    # read-fill head: first read issued (READ_BEFORE_BARRIER) -> compute gets tile 0
+    # (TILE_IDX[0]). This is the first per-trid BATCH (N=trid_in_flight reads) landing +
+    # barrier + push, i.e. the reader latency that defers math start (grows with N, not CB depth).
+    read_fill = per_core_diff_us(unpack0, barriers["read_before"], freq, args.min_prog_id)
+    r2w = per_core_diff_us(barriers["brisc_done"], barriers["ncrisc_done"], freq, args.min_prog_id)
+    wtail = per_core_diff_us(barriers["write_after"], barriers["write_before"], freq, args.min_prog_id)
+    # write_drain = LAST write issued -> write barrier complete (WRITE_LAST_ISSUED -> WRITE_AFTER_BARRIER).
+    # This is the un-hideable write latency paid at op end: the final flush+barrier draining the
+    # writes still outstanding when the loop exits. With per-CB flushing ~(cb_page_slots-1) writes
+    # are in flight at the end, so it rises ~linearly with output CB depth. Distinct from write_tail
+    # (WRITE_BEFORE->WRITE_AFTER = whole write phase ~= bytes/BW, ~flat in CB depth).
+    wdrain = per_core_diff_us(barriers["write_after"], barriers["write_last_issued"], freq, args.min_prog_id)
+    rd_spread = completion_spread_us(barriers["ncrisc_done"], freq, args.min_prog_id)
+    wr_spread = completion_spread_us(barriers["brisc_done"], freq, args.min_prog_id)
+    # Op2op + kernel duration via the OFFICIAL tools/tracy methodology from the standard
+    # auto-emitted KERNEL zones (comparable to process_device_log.py / Tracy). No custom FW or
+    # dispatch markers -- those were reverted out of tt_metal/; the realtime profiler
+    # (--use-realtime-profiler -> profile_log_device_rt.csv) gives the unpolluted absolute op2op.
+    off_op2op, off_kdur, off_env = official_kernel_metrics(df, freq, max_gap_us=50.0)
+
+    # OVERALL BW = total bytes moved / whole-op KERNEL ENVELOPE (first-core start -> last-core end).
+    # This is the honest end-to-end throughput INCLUDING the straggler tail -- unlike agg_*_gbps, which
+    # divide each direction's bytes by that direction's union span (a steady/peak rate that ignores the
+    # ragged completion tail). At high core counts overall_bw < agg_total because the envelope carries
+    # the write-drain tail. directions: 1=read-only, 2=read+write; 0=auto (2 iff write markers present).
+    dirn = args.directions if args.directions else (2 if (agg_wbw == agg_wbw) else 1)
+    env_us = off_env["envelope_us"]
+    overall_bw_gbps = (
+        dirn * args.num_cores * bytes_per_core / (env_us * 1e3) if (env_us == env_us and env_us > 0) else float("nan")
+    )
+    # Per-core op duration (reader start NCRISC_GO -> writer done BRISC_DONE) to normalize
+    # the spread: absolute spread (us) scales with per-core work, so report it as a % of
+    # the typical core's op time for comparability across work sizes / NOP counts.
+    op_durs = per_core_diff_us(barriers["brisc_done"], barriers["ncrisc_go"], freq, args.min_prog_id)
+    op_dur_med = median(op_durs)
+    wr_spread_med = median(wr_spread)
+    wr_spread_pct = (
+        (wr_spread_med / op_dur_med * 100.0) if (op_dur_med == op_dur_med and op_dur_med > 0) else float("nan")
+    )
+
+    row = {
+        "overall_bw_gbps": round(overall_bw_gbps, 3),  # total bytes / kernel envelope (incl. straggler tail)
+        "agg_total_gbps": round(agg_total, 3),
+        "agg_read_gbps": round(agg_bw, 3),
+        "agg_write_gbps": round(agg_wbw, 3),
+        "per_core_gbps_min": round(pc_min, 3),
+        "per_core_gbps_median": round(median(per_core_bw), 3),
+        "per_core_gbps_max": round(pc_max, 3),
+        "starvation_ratio": round(starv, 3),
+        # OFFICIAL tools/tracy methodology (standard KERNEL zones; Tracy / process_device_log.py
+        # comparable) -- canonical op2op + kernel duration, no custom markers:
+        "official_op2op_us": round(median(off_op2op), 4),  # steady-state median
+        "official_op2op_min_us": round(min(off_op2op) if off_op2op else float("nan"), 4),  # == tracy 'Min'
+        "device_kernel_dur_us": round(median(off_kdur), 4),  # PER-CORE median (one core's busy time)
+        # Whole-op ENVELOPE = the run's go->done (first-core start -> last-core end, across all
+        # cores). Set by the slowest core, so it exceeds device_kernel_dur_us by the straggler tail.
+        # This -- not device_kernel_dur_us -- is what the timeline chart's op span reflects.
+        "kernel_envelope_us": round(off_env["envelope_us"], 4),
+        "kernel_dur_fast_us": round(off_env["kdur_fast_us"], 4),  # fastest single core (finishes early, idles)
+        "kernel_dur_slow_us": round(off_env["kdur_slow_us"], 4),  # slowest single core (sets the envelope)
+        "kernel_end_spread_us": round(off_env["end_spread_us"], 4),  # last-core end - first-core end (straggler tail)
+        # math-to-math, three brackets (all per-pair medians):
+        "m2m_bubble_us": round(median(mb["bubble"]), 4),  # global idle window (== old math_to_math_us)
+        "m2m_skew_env_us": round(median(mb["skew_env"]), 4),  # first-finish -> last-start (cross-core)
+        "m2m_within_med_us": round(median(mb["within"]), 4),  # same-core gap, typical
+        "m2m_within_max_us": round(vmax(mb["within"]), 4),  # same-core gap, worst core
+        "finish_skew_us": round(median(mb["finish_skew"]), 4),  # op-k completion spread
+        "start_skew_us": round(median(mb["start_skew"]), 4),  # op-(k+1) start spread
+        "read_fill_head_us": round(median(read_fill), 4),
+        "reader_to_writer_us": round(median(r2w), 4),
+        "reader_to_writer_max_us": round(vmax(r2w), 4),
+        "write_tail_us": round(median(wtail), 4),
+        "write_tail_max_us": round(vmax(wtail), 4),
+        "write_drain_us": round(median(wdrain), 4),  # last write issued -> barrier done (the real write tail)
+        "write_drain_max_us": round(vmax(wdrain), 4),
+        # op execution skew (NoC starvation), distinct from inter-op latency above:
+        "reader_done_spread_us": round(median(rd_spread), 4),
+        "writer_done_spread_us": round(median(wr_spread), 4),
+        "op_duration_us": round(op_dur_med, 3),
+        # normalized spread: writer done-spread as a % of the per-core op duration (work-size
+        # independent, so comparable across core counts and NOP counts).
+        "writer_spread_pct": round(wr_spread_pct, 2),
+    }
+
+    label = {}
+    for kv in args.label.split(";"):
+        if "=" in kv:
+            k, v = kv.split("=", 1)
+            label[k.strip()] = v.strip()
+
+    print(f"freq={freq:.1f}MHz  cores={args.num_cores}  bytes/core={bytes_per_core}")
+    for k, v in row.items():
+        print(f"  {k:26s} {v}")
+
+    # Columns kept in stdout (driver greps agg_read/agg_total during tuning) but dropped
+    # from the chart CSV as noise -- per-core BW detail and the read/write BW split;
+    # agg_total + starvation_ratio (+ peak_read_gbps from the label) carry the signal.
+    csv_drop = {"agg_read_gbps", "agg_write_gbps", "per_core_gbps_min", "per_core_gbps_median", "per_core_gbps_max"}
+    if args.csv_out is not None:
+        cols = [c for c in (list(label.keys()) + list(row.keys())) if c not in csv_drop]
+        new = not args.csv_out.exists()
+        args.csv_out.parent.mkdir(parents=True, exist_ok=True)
+        with args.csv_out.open("a") as fh:
+            if new:
+                fh.write(",".join(cols) + "\n")
+            fh.write(",".join(str(label.get(c, row.get(c, ""))) for c in cols) + "\n")
+        print(f"appended row to {args.csv_out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/scripts/event_timeline.py
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/scripts/event_timeline.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Per-op event timeline from device-profiler markers, as delta cycle counts between events.
+
+Reconstructs one steady-state op's life across all worker cores and prints the ordered timeline:
+
+  go                         worker GO / kernels start (NCRISC_GO) -- assumed ~synchronized
+  read issued                first NoC read issued (READ_BEFORE_BARRIER)
+  first read return          earliest core's first read back (min READ_AFTER_BARRIER)
+  read skew                  spread of first-read-return across cores (max-min READ_AFTER_BARRIER)
+  first core reads complete  earliest core done with ALL its reads (min READ_LAST_BARRIER)
+  last core reads complete   latest core done with ALL its reads (max READ_LAST_BARRIER); the
+                             delta first->last = INTER-core read-complete skew (exploitable stagger).
+                             Separately, INTRA-core span = per-core (READ_LAST - READ_AFTER), median.
+  first core last wr issued  earliest core's last write issued (min WRITE_LAST_ISSUED)
+  first core last wr flushed  min WRITE_LAST_FLUSHED
+  first core barrier done    min WRITE_AFTER_BARRIER
+  last core last wr issued   latest core's last write issued (max WRITE_LAST_ISSUED)  [done-skew begins]
+  last core last wr flushed  max WRITE_LAST_FLUSHED
+  last core barrier done     max WRITE_AFTER_BARRIER  (= op done)
+  go received                next op's go (min NCRISC_GO of op k+1); op-to-op = this - last barrier done
+
+Each row shows delta cycles from the prior row (cum = cycles since 'go'). Aggregated as the median
+over steady-state op transitions (trace-instance boundaries dropped via a gap cap). Run with the
+device profiler (TT_METAL_DEVICE_PROFILER=1, --use-device-profiler), NOT --read-only.
+"""
+import argparse
+from pathlib import Path
+import sys
+import numpy as np
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from export_op_to_op_profiler_csv import load_profiler_csv, parse_chip_freq_mhz  # noqa: E402
+
+T = "time[cycles since reset]"
+
+
+def per_core_ops(df):
+    """For each worker core, segment markers into op instances delimited by NCRISC_GO.
+    Returns {(chip,cx,cy): [ {marker: time, ...}, ... ]} (one dict per op instance, in time order)."""
+    want = {
+        "NCRISC_GO",
+        "READ_BEFORE_BARRIER",
+        "READ_AFTER_BARRIER",
+        "READ_LAST_BARRIER",
+        "WRITE_LAST_ISSUED",
+        "WRITE_LAST_FLUSHED",
+        "WRITE_AFTER_BARRIER",
+    }
+    m = df[df["zone name"].isin(want)]
+    out = {}
+    for (chip, cx, cy), g in m.groupby(["PCIe slot", "core_x", "core_y"], sort=False):
+        evs = sorted((int(r[T]), r["zone name"]) for _, r in g.iterrows())
+        ops, cur = [], None
+        for t, name in evs:
+            if name == "NCRISC_GO":
+                if cur is not None:
+                    cur["go_received"] = t  # next op's go
+                    ops.append(cur)
+                cur = {"go": t}
+            elif cur is not None and name not in cur:  # keep FIRST occurrence per op
+                cur[name] = t
+        if cur is not None:
+            ops.append(cur)
+        out[(int(chip), int(cx), int(cy))] = ops
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--input-file", type=Path, default=None)
+    ap.add_argument(
+        "--max-op-us", type=float, default=5000.0, help="drop op instances longer than this (trace boundary)"
+    )
+    ap.add_argument("--csv-out", type=Path, default=None, help="append the timeline (one row per event) to this CSV")
+    ap.add_argument("--label", type=str, default="", help="label column value for --csv-out rows (e.g. config id)")
+    args = ap.parse_args()
+    log = (args.input_file or Path("generated/profiler/.logs/profile_log_device.csv")).resolve()
+    freq = parse_chip_freq_mhz(log)  # MHz == cycles/us
+    df = load_profiler_csv(log)
+    core_ops = per_core_ops(df)
+    ncores = len(core_ops)
+    n = min(len(v) for v in core_ops.values()) if core_ops else 0
+    if not ncores or n < 2:
+        print("not enough data (need >=2 op instances on every worker core)")
+        return 1
+
+    # Align op instances by index across cores; for each op, aggregate across cores.
+    REQ = [
+        "go",
+        "READ_BEFORE_BARRIER",
+        "READ_AFTER_BARRIER",
+        "READ_LAST_BARRIER",
+        "WRITE_LAST_ISSUED",
+        "WRITE_LAST_FLUSHED",
+        "WRITE_AFTER_BARRIER",
+        "go_received",
+    ]
+    # Timeline event order (the CSV/print walk uses exactly these, in this order). Extra per-op
+    # scalars (e.g. intra_read_cyc) are stored on the row but kept OUT of this list.
+    ORDER = [
+        "go",
+        "read issued",
+        "first read return",
+        "read skew (last core 1st return)",
+        "first core reads complete",
+        "last core reads complete",
+        "first core last write issued",
+        "first core last write flushed",
+        "first core barrier done",
+        "last core last write issued",
+        "last core last write flushed",
+        "last core barrier done",
+        "go received",
+    ]
+    rows = []  # one per aligned op instance: dict of timeline timestamps
+    for i in range(n):
+        ops_i = [ops[i] for ops in core_ops.values()]
+        if any(any(k not in o for k in REQ) for o in ops_i):
+            continue
+        col = lambda k: np.array([o[k] for o in ops_i], dtype="int64")
+        go = col("go")
+        rb = col("READ_BEFORE_BARRIER")
+        ra = col("READ_AFTER_BARRIER")
+        rl = col("READ_LAST_BARRIER")
+        wi = col("WRITE_LAST_ISSUED")
+        wf = col("WRITE_LAST_FLUSHED")
+        wb = col("WRITE_AFTER_BARRIER")
+        gr = col("go_received")
+        rows.append(
+            {
+                "go": int(go.min()),
+                "read issued": int(rb.min()),
+                "first read return": int(ra.min()),
+                "read skew (last core 1st return)": int(ra.max()),
+                # first/last CORE to finish ALL its reads (min/max of READ_LAST across cores);
+                # the delta between them (below) is the INTER-core read-complete skew.
+                "first core reads complete": int(rl.min()),
+                "last core reads complete": int(rl.max()),
+                "first core last write issued": int(wi.min()),
+                "first core last write flushed": int(wf.min()),
+                "first core barrier done": int(wb.min()),
+                "last core last write issued": int(wi.max()),
+                "last core last write flushed": int(wf.max()),
+                "last core barrier done": int(wb.max()),
+                "go received": int(gr.min()),
+                # INTRA-core read span (per core: last-read-complete - first-read-return), median
+                # across cores. NOT a timeline event -- kept off ORDER.
+                "intra_read_cyc": float(np.median(rl - ra)),
+            }
+        )
+    cap = args.max_op_us * freq
+    steady = [r for r in rows if 0 < (r["go received"] - r["go"]) < cap]
+    if not steady:
+        print(f"no steady-state op instances under {args.max_op_us} us (got {len(rows)} aligned)")
+        return 1
+
+    order = ORDER
+    # median delta (from prior event) across steady ops, in cycles
+    deltas = {}
+    for j, ev in enumerate(order):
+        if j == 0:
+            deltas[ev] = 0.0
+        else:
+            d = [r[ev] - r[order[j - 1]] for r in steady]
+            deltas[ev] = float(np.median(d))
+
+    print(f"freq={freq:.0f} MHz  cores={ncores}  steady op transitions={len(steady)}  (cycles; 1 cyc = 1 ns @ 1GHz)")
+    print(f"{'event':<34} {'Δcyc (from prior)':>18} {'cum cyc (from go)':>18}")
+    cum = 0.0
+    for ev in order:
+        cum += deltas[ev]
+        print(f"{ev:<34} {deltas[ev]:>18,.0f} {cum:>18,.0f}")
+    print(f"\nop-to-op (last barrier done -> go received) = {deltas['go received']:,.0f} cyc")
+    print(f"read skew (first->last core first-read-return) = {deltas['read skew (last core 1st return)']:,.0f} cyc")
+    done_skew = float(np.median([r["last core barrier done"] - r["first core barrier done"] for r in steady]))
+    print(f"done skew (first->last core barrier done) = {done_skew:,.0f} cyc")
+    # Read-completion skew decomposition (the point of this run):
+    #   INTER-core = spread across cores of when each finishes ALL its reads (exploitable stagger).
+    #   INTRA-core = a single core's own read span (first-return -> last-return), median across cores
+    #                (the floor: even one core's reads aren't instantaneous).
+    inter_read = float(np.median([r["last core reads complete"] - r["first core reads complete"] for r in steady]))
+    intra_read = float(np.median([r["intra_read_cyc"] for r in steady]))
+    print(f"read INTER-core skew (first->last core reads-complete) = {inter_read:,.0f} cyc")
+    print(f"read INTRA-core span (per-core last-return - first-return, median) = {intra_read:,.0f} cyc")
+    print(f"  inter/intra ratio = {inter_read/intra_read:.2f}" if intra_read > 0 else "  intra=0")
+
+    # Persist the timeline: one row per event with delta-from-prior and cumulative-from-go, in
+    # both cycles and us (1 cyc = 1/freq us). Appends so a sweep can collect many configs (one
+    # --label per config) into a single CSV. done_skew is derivable as
+    # cum_us(last core barrier done) - cum_us(first core barrier done).
+    if args.csv_out:
+        import csv
+
+        new_file = not args.csv_out.exists()
+        args.csv_out.parent.mkdir(parents=True, exist_ok=True)
+        with open(args.csv_out, "a", newline="") as fh:
+            w = csv.writer(fh)
+            if new_file:
+                w.writerow(["label", "cores", "event", "delta_cyc", "cum_cyc", "delta_us", "cum_us"])
+            cum = 0.0
+            for ev in order:
+                cum += deltas[ev]
+                w.writerow(
+                    [
+                        args.label,
+                        ncores,
+                        ev,
+                        f"{deltas[ev]:.0f}",
+                        f"{cum:.0f}",
+                        f"{deltas[ev]/freq:.4f}",
+                        f"{cum/freq:.4f}",
+                    ]
+                )
+            # Trailing derived scalar: intra-core read span (median per core). delta==cum here; it's
+            # not part of the cumulative timeline (inter-core read skew is the delta of the
+            # "last core reads complete" event above).
+            w.writerow(
+                [
+                    args.label,
+                    ncores,
+                    "intra_core_read_span",
+                    f"{intra_read:.0f}",
+                    f"{intra_read:.0f}",
+                    f"{intra_read/freq:.4f}",
+                    f"{intra_read/freq:.4f}",
+                ]
+            )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/scripts/export_op_to_op_profiler_csv.py
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/scripts/export_op_to_op_profiler_csv.py
@@ -1,0 +1,1046 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Export op-to-op latency tables from profile_log_device.csv.
+
+Per-core op-to-op gap (program k -> k+1):
+  TRISC_2 FINISH_LAST_PUSH at end of pack TRISC kernel (program k)
+  to TRISC_0 TILE_IDX for tile 0 when program k+1's compute starts.
+
+Example:
+  python3 tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/export_op_to_op_profiler_csv.py \\
+    --input-file "$TT_METAL_HOME/generated/profiler/.logs/profile_log_device.csv"
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+DEFAULT_LOG = "generated/profiler/.logs/profile_log_device.csv"
+DEFAULT_RT_LOG = "generated/profiler/.logs/profile_log_device_rt.csv"
+UNPACK_RISC = "TRISC_0"
+PACK_RISC = "TRISC_2"
+# Dataflow kernels: Blackhole uses BRISC (writer) / NCRISC (reader); other arches may use RISCV_*.
+READ_RISC_TYPES = frozenset({"NCRISC", "RISCV_1"})
+WRITE_RISC_TYPES = frozenset({"BRISC", "RISCV_0"})
+DATAFLOW_RISC_TYPES = READ_RISC_TYPES | WRITE_RISC_TYPES
+
+
+def parse_chip_freq_mhz(log_path: Path) -> float:
+    with log_path.open() as f:
+        header = f.readline()
+    match = re.search(r"CHIP_FREQ\[MHz\]:\s*([0-9.]+)", header)
+    if not match:
+        raise ValueError(f"Could not parse CHIP_FREQ from first line of {log_path}")
+    return float(match.group(1))
+
+
+# DeviceRecordEvent ids -> original marker names. Kept in sync with the EV_* constants in the
+# op_to_op kernels (reader/writer/compute). recordEvent is lighter than DeviceTimestampedData
+# (no data payload = less L1 buffer pressure); the id is the low 16 bits of timer_id.
+EVENT_NAMES = {
+    1: "NCRISC_GO",
+    2: "READ_BEFORE_BARRIER",
+    3: "READ_AFTER_BARRIER",
+    4: "READ_LAST_BARRIER",
+    5: "NCRISC_DONE",
+    6: "BRISC_GO",
+    7: "WRITE_BEFORE_BARRIER",
+    8: "WRITE_LAST_ISSUED",
+    9: "WRITE_LAST_FLUSHED",
+    10: "WRITE_AFTER_BARRIER",
+    11: "BRISC_DONE",
+    12: "TILE_IDX",  # lean-mode first-math (tile 0)
+    13: "FINISH_LAST_PUSH",  # last-math / pack finish
+}
+
+
+def load_profiler_csv(log_path: Path) -> pd.DataFrame:
+    df = pd.read_csv(log_path, skiprows=1)
+    df.columns = df.columns.str.strip()
+    # Backfill original marker names for DeviceRecordEvent markers (type == TS_EVENT): they have an
+    # empty zone name; the event id is timer_id & 0xFFFF (get_id = (id & 0xFFFF) | (type << 16)).
+    # Events carry no payload, so set data = 0 (the TILE_IDX event is tile 0). This keeps every
+    # name-keyed walk (and decompose / event_timeline) working unchanged.
+    if "type" in df.columns and "timer_id" in df.columns:
+        is_ev = df["type"].astype(str).str.strip() == "TS_EVENT"
+        if is_ev.any():
+            ids = df.loc[is_ev, "timer_id"].astype("int64") & 0xFFFF
+            df.loc[is_ev, "zone name"] = ids.map(EVENT_NAMES).values
+            df.loc[is_ev, "data"] = 0
+    return df
+
+
+def walk_core_markers(df: pd.DataFrame) -> tuple[dict, dict, pd.DataFrame]:
+    """Return per-core program finish (pack) and first-tile start (unpack) times."""
+    markers = df[
+        (df["zone name"].isin(["PROG_ID", "TILE_IDX", "FINISH_LAST_PUSH"]))
+        & (df["RISC processor type"].isin([UNPACK_RISC, PACK_RISC]))
+    ].copy()
+    markers = markers.sort_values(["PCIe slot", "core_x", "core_y", "RISC processor type", "time[cycles since reset]"])
+
+    # (chip, core_x, core_y, prog_id) -> cycles
+    pack_finish: dict[tuple, int] = {}
+    unpack_tile0_start: dict[tuple, int] = {}
+    tile_rows: list[dict] = []
+
+    group_cols = ["PCIe slot", "core_x", "core_y", "RISC processor type"]
+    for key, group in markers.groupby(group_cols, sort=False):
+        chip, core_x, core_y, risc = key
+        current_prog: int | None = None
+
+        for _, row in group.iterrows():
+            zone = row["zone name"]
+            time_cycles = int(row["time[cycles since reset]"])
+            data = int(row["data"])
+
+            if zone == "PROG_ID":
+                current_prog = data
+            elif zone == "TILE_IDX" and risc == UNPACK_RISC:
+                if current_prog is None:
+                    continue
+                tile_rows.append(
+                    {
+                        "chip": chip,
+                        "core_x": core_x,
+                        "core_y": core_y,
+                        "prog_id": current_prog,
+                        "tile_idx": data,
+                        "unpack_start_cycles": time_cycles,
+                    }
+                )
+                if data == 0:
+                    unpack_tile0_start[(chip, core_x, core_y, current_prog)] = time_cycles
+            elif zone == "FINISH_LAST_PUSH" and risc == PACK_RISC:
+                if current_prog is None:
+                    current_prog = data
+                pack_finish[(chip, core_x, core_y, current_prog)] = time_cycles
+
+    return pack_finish, unpack_tile0_start, pd.DataFrame(tile_rows)
+
+
+def walk_done_to_go(df: pd.DataFrame, freq_mhz: float, min_prog_id: int) -> pd.DataFrame:
+    """Done/go decomposition: "MCAST GO issue cost + done counting in dispatch
+    core". On BH this materialises as the NoC-propagation interval "dispatch
+    sees workers done -> a worker observes the new GO multicast".
+
+    We have three event markers (all on the same chip clock domain):
+      - DISP_DONE_OBSERVED (dispatch_s):   wait_for_workers spin exits.
+      - DISP_GO_ISSUED    (dispatch_s):    MCAST GO write fired to NoC
+                                            (registers programmed, returns
+                                             before propagation completes).
+      - WORKER_GO_OBSERVED (per worker):   GO spin exits + scope start +
+                                            host_assigned_id read.
+
+    Reported per (chip, dispatch DISP_DONE timestamp):
+      dg_issue_ns    = DISP_GO_ISSUED - DISP_DONE_OBSERVED on dispatch_s.
+                        Pure single-write fire cost (~30 cycles on BH).
+      dg_first_ns    = min over workers of
+                       (WORKER_GO_OBSERVED - DISP_DONE_OBSERVED).
+                        Nearest worker observes GO.
+      dg_median_ns   = median over workers (typical worker)
+      dg_last_ns     = max over workers (farthest worker; ~= our old
+                        brisc_fw_done_to_go_us upper bound)
+
+    Requires TT_METAL_DEVICE_PROFILER_DISPATCH=1 at runtime so dispatch_s
+    markers land in profile_log_device.csv.
+
+    `min_prog_id` filters the dispatch program-id tag (popped_pid). Trace
+    boundaries (>3 us idle) are dropped automatically.
+    """
+    disp_done = df[df["zone name"] == "DISP_DONE_OBSERVED"].copy()
+    disp_go = df[df["zone name"] == "DISP_GO_ISSUED"].copy()
+    worker_go = df[df["zone name"] == "WORKER_GO_OBSERVED"].copy()
+    if disp_done.empty or worker_go.empty:
+        return pd.DataFrame()
+    # The dispatch_s core appears in both DISP_* and (sometimes, on startup)
+    # WORKER_GO_OBSERVED if FW happens to log it. Identify dispatch cores per chip
+    # and exclude them from the worker pool.
+    worker_go = worker_go.copy()
+    # Drop rows where worker is actually a dispatch core for the same chip.
+    dispatch_set: set[tuple] = set()
+    for _, r in disp_done[["PCIe slot", "core_x", "core_y"]].drop_duplicates().iterrows():
+        dispatch_set.add((int(r["PCIe slot"]), int(r["core_x"]), int(r["core_y"])))
+    worker_go = worker_go[
+        ~worker_go.apply(lambda r: (int(r["PCIe slot"]), int(r["core_x"]), int(r["core_y"])) in dispatch_set, axis=1)
+    ]
+
+    # 10 us window cap (in cycles). Anything beyond is a trace boundary, not a real transition.
+    window_cycles = int(3000.0 / 1000.0 * freq_mhz)  # 3 us = ~4050 cycles @ 1.35 GHz
+
+    rows: list[dict] = []
+    for chip, dd_chip in disp_done.groupby("PCIe slot"):
+        dd_chip = dd_chip.sort_values("time[cycles since reset]").reset_index(drop=True)
+        dg_chip = disp_go[disp_go["PCIe slot"] == chip].sort_values("time[cycles since reset]").reset_index(drop=True)
+        wg_chip = worker_go[worker_go["PCIe slot"] == chip].copy()
+        wg_t = wg_chip["time[cycles since reset]"].astype("int64").values
+        for i, drow in dd_chip.iterrows():
+            d_t = int(drow["time[cycles since reset]"])
+            d_pid = int(drow["data"])
+            if d_pid < min_prog_id:
+                continue
+            # Worker events RIGHT AFTER this DISP_DONE, within window.
+            lo, hi = d_t, d_t + window_cycles
+            mask = (wg_t > lo) & (wg_t < hi)
+            deltas = wg_t[mask] - d_t
+            if len(deltas) == 0:
+                continue
+            # Find DISP_GO_ISSUED that immediately follows.
+            dg_after = dg_chip[dg_chip["time[cycles since reset]"] > d_t]
+            if len(dg_after) > 0:
+                issue_cycles = int(dg_after.iloc[0]["time[cycles since reset]"]) - d_t
+            else:
+                issue_cycles = pd.NA
+            rows.append(
+                {
+                    "chip": chip,
+                    "program_id": d_pid,
+                    "done_observed_cycles": d_t,
+                    "n_workers_responded": int(len(deltas)),
+                    "dg_issue_cycles": issue_cycles,
+                    "dg_issue_ns": (issue_cycles / freq_mhz * 1000.0) if issue_cycles is not pd.NA else pd.NA,
+                    "dg_first_cycles": int(deltas.min()),
+                    "dg_first_ns": float(deltas.min()) / freq_mhz * 1000.0,
+                    "dg_median_cycles": int(pd.Series(deltas).median()),
+                    "dg_median_ns": float(pd.Series(deltas).median()) / freq_mhz * 1000.0,
+                    "dg_last_cycles": int(deltas.max()),
+                    "dg_last_ns": float(deltas.max()) / freq_mhz * 1000.0,
+                }
+            )
+    return pd.DataFrame(rows)
+
+
+def walk_barrier_markers(df: pd.DataFrame) -> dict[str, dict[tuple, int]]:
+    """Per (chip, core_x, core_y, prog_id) timestamps for reader/writer barriers and go/done.
+
+    BRISC-FW zone (firmware scope around each program's kernel launch path) is also
+    captured, separately from the user BRISC_GO/BRISC_DONE markers emitted from
+    inside our writer kernel. The FW.start fires before PROG_ID is read, so we
+    forward-tag pending FW.start with the next PROG_ID we see.
+    """
+    user_zones = [
+        "PROG_ID",
+        "READ_BEFORE_BARRIER",
+        "READ_AFTER_BARRIER",
+        "WRITE_BEFORE_BARRIER",
+        "WRITE_LAST_ISSUED",
+        "WRITE_LAST_FLUSHED",
+        "WRITE_AFTER_BARRIER",
+        "BRISC_GO",
+        "BRISC_DONE",
+        "NCRISC_GO",
+        "NCRISC_DONE",
+    ]
+    fw_zones = ["BRISC-FW", "NCRISC-FW"]
+    markers = df[
+        (df["zone name"].isin(user_zones + fw_zones)) & (df["RISC processor type"].isin(DATAFLOW_RISC_TYPES))
+    ].copy()
+    markers = markers.sort_values(["PCIe slot", "core_x", "core_y", "RISC processor type", "time[cycles since reset]"])
+
+    keys = [
+        "read_before",
+        "read_after",
+        "write_before",
+        "write_last_issued",
+        "write_last_flushed",
+        "write_after",
+        "brisc_go",
+        "brisc_done",
+        "ncrisc_go",
+        "ncrisc_done",
+        "brisc_fw_start",
+        "brisc_fw_end",
+        "ncrisc_fw_start",
+        "ncrisc_fw_end",
+    ]
+    out: dict[str, dict[tuple, int]] = {k: {} for k in keys}
+    group_cols = ["PCIe slot", "core_x", "core_y", "RISC processor type"]
+
+    for key, group in markers.groupby(group_cols, sort=False):
+        chip, core_x, core_y, risc = key
+        is_reader = risc in READ_RISC_TYPES
+        is_writer = risc in WRITE_RISC_TYPES
+        current_prog: int | None = None
+        pending_fw_start: int | None = None
+        for _, row in group.iterrows():
+            zone = row["zone name"]
+            time_cycles = int(row["time[cycles since reset]"])
+            zone_type = row.get("type", "")
+            if zone == "BRISC-FW" and zone_type == "ZONE_START" and is_writer:
+                pending_fw_start = time_cycles
+                current_prog = None
+                continue
+            if zone == "NCRISC-FW" and zone_type == "ZONE_START" and is_reader:
+                pending_fw_start = time_cycles
+                current_prog = None
+                continue
+            if zone == "PROG_ID":
+                current_prog = int(row["data"])
+                if pending_fw_start is not None:
+                    tkey = (chip, core_x, core_y, current_prog)
+                    if is_writer:
+                        out["brisc_fw_start"][tkey] = pending_fw_start
+                    elif is_reader:
+                        out["ncrisc_fw_start"][tkey] = pending_fw_start
+                    pending_fw_start = None
+                continue
+            if current_prog is None:
+                continue
+            tkey = (chip, core_x, core_y, current_prog)
+            if zone == "READ_BEFORE_BARRIER" and is_reader:
+                out["read_before"][tkey] = time_cycles
+            elif zone == "READ_AFTER_BARRIER" and is_reader:
+                out["read_after"][tkey] = time_cycles
+            elif zone == "WRITE_BEFORE_BARRIER" and is_writer:
+                out["write_before"][tkey] = time_cycles
+            elif zone == "WRITE_LAST_ISSUED" and is_writer:
+                out["write_last_issued"][tkey] = time_cycles
+            elif zone == "WRITE_LAST_FLUSHED" and is_writer:
+                out["write_last_flushed"][tkey] = time_cycles
+            elif zone == "WRITE_AFTER_BARRIER" and is_writer:
+                out["write_after"][tkey] = time_cycles
+            elif zone == "BRISC_GO" and is_writer:
+                out["brisc_go"][tkey] = time_cycles
+            elif zone == "BRISC_DONE" and is_writer:
+                out["brisc_done"][tkey] = time_cycles
+            elif zone == "NCRISC_GO" and is_reader:
+                out["ncrisc_go"][tkey] = time_cycles
+            elif zone == "NCRISC_DONE" and is_reader:
+                out["ncrisc_done"][tkey] = time_cycles
+            elif zone == "BRISC-FW" and zone_type == "ZONE_END" and is_writer:
+                out["brisc_fw_end"][tkey] = time_cycles
+                current_prog = None
+            elif zone == "NCRISC-FW" and zone_type == "ZONE_END" and is_reader:
+                out["ncrisc_fw_end"][tkey] = time_cycles
+                current_prog = None
+
+    return out
+
+
+def load_rt_profiler_csv(rt_path: Path) -> pd.DataFrame:
+    if not rt_path.is_file():
+        return pd.DataFrame()
+    return pd.read_csv(rt_path)
+
+
+def dedupe_rt_records(rt_df: pd.DataFrame) -> tuple[pd.DataFrame, int]:
+    """Collapse consecutive RT records with the same program_id (common in trace replay)."""
+    if rt_df.empty:
+        return rt_df, 0
+    deduped_rows: list[pd.Series] = []
+    collapsed = 0
+    for _, group in rt_df.groupby("chip_id"):
+        records = group.sort_values("go_cycles")
+        kept: list[pd.Series] = []
+        for _, row in records.iterrows():
+            if kept and int(row["program_id"]) == int(kept[-1]["program_id"]):
+                kept[-1] = row
+                collapsed += 1
+            else:
+                kept.append(row)
+        deduped_rows.extend(kept)
+    if not deduped_rows:
+        return pd.DataFrame(), collapsed
+    return pd.DataFrame(deduped_rows), collapsed
+
+
+def build_rt_dispatch_gaps(rt_df: pd.DataFrame, freq_mhz: float, min_prog_id: int) -> tuple[pd.DataFrame, int]:
+    """Chip-level done (end) -> go (next start) from real-time profiler records."""
+    if rt_df.empty:
+        return pd.DataFrame(), 0
+    rt_df, collapsed = dedupe_rt_records(rt_df)
+    rows: list[dict] = []
+    skipped_same_pid = 0
+    for chip_id, group in rt_df.groupby("chip_id"):
+        records = group.sort_values("go_cycles")
+        records = records[records["program_id"] >= min_prog_id]
+        go = records["go_cycles"].astype(int).tolist()
+        done = records["done_cycles"].astype(int).tolist()
+        pids = records["program_id"].astype(int).tolist()
+        for i in range(len(pids) - 1):
+            if pids[i] == pids[i + 1]:
+                skipped_same_pid += 1
+                continue
+            gap_cycles = go[i + 1] - done[i]
+            if gap_cycles < 0:
+                continue
+            # Steady-state only: consecutive program ids (skip trace wrap e.g. 8→3).
+            if pids[i + 1] != pids[i] + 1:
+                continue
+            ghz = rt_freq_ghz(rt_df, freq_mhz)
+            gap_ns = rt_cycles_to_ns(gap_cycles, ghz)
+            rows.append(
+                {
+                    "chip": chip_id,
+                    "from_prog_id": pids[i],
+                    "to_prog_id": pids[i + 1],
+                    "done_cycles": done[i],
+                    "go_cycles": go[i + 1],
+                    "dispatch_gap_cycles": gap_cycles,
+                    "dispatch_gap_ns": gap_ns,
+                    "dispatch_gap_us": gap_ns / 1000.0,
+                }
+            )
+    return pd.DataFrame(rows), collapsed + skipped_same_pid
+
+
+def rt_freq_ghz(rt_df: pd.DataFrame, fallback_mhz: float) -> float:
+    if rt_df.empty or "frequency_ghz" not in rt_df.columns:
+        return fallback_mhz / 1000.0
+    ghz = float(rt_df["frequency_ghz"].iloc[0])
+    return ghz if ghz > 0.0 else fallback_mhz / 1000.0
+
+
+def rt_freq_mhz(rt_df: pd.DataFrame, fallback_mhz: float) -> float:
+    return rt_freq_ghz(rt_df, fallback_mhz) * 1000.0
+
+
+def rt_cycles_to_ns(cycles: int, ghz: float) -> float:
+    """RT profiler: duration_ns = cycles / frequency_ghz (see test RT CSV writer)."""
+    return float(cycles) / ghz if ghz > 0.0 else 0.0
+
+
+def build_rt_program_table(rt_df: pd.DataFrame, min_prog_id: int, freq_mhz: float) -> pd.DataFrame:
+    """Per-program chip dispatch timestamps: go (start) and done (end)."""
+    if rt_df.empty:
+        return pd.DataFrame()
+    rt_df, _ = dedupe_rt_records(rt_df)
+    ghz = rt_freq_ghz(rt_df, freq_mhz)
+    rows: list[dict] = []
+    for chip_id, group in rt_df.groupby("chip_id"):
+        records = group.sort_values("go_cycles")
+        records = records[records["program_id"] >= min_prog_id]
+        for _, row in records.iterrows():
+            go = int(row["go_cycles"])
+            done = int(row["done_cycles"])
+            duration_cycles = done - go if done >= go else 0
+            if "duration_ns" in row and pd.notna(row["duration_ns"]):
+                duration_ns = float(row["duration_ns"])
+            else:
+                duration_ns = rt_cycles_to_ns(duration_cycles, ghz)
+            gap_next = (
+                int(row["gap_to_next_go_cycles"])
+                if "gap_to_next_go_cycles" in row.index and pd.notna(row["gap_to_next_go_cycles"])
+                else 0
+            )
+            gap_next_ns = rt_cycles_to_ns(gap_next, ghz) if gap_next > 0 else 0.0
+            rows.append(
+                {
+                    "chip": chip_id,
+                    "program_id": int(row["program_id"]),
+                    "go_cycles": go,
+                    "done_cycles": done,
+                    "program_duration_cycles": duration_cycles,
+                    "program_duration_ns": duration_ns,
+                    "program_duration_us": duration_ns / 1000.0,
+                    "gap_to_next_go_cycles": gap_next,
+                    "gap_to_next_go_ns": gap_next_ns,
+                    "frequency_ghz": ghz,
+                }
+            )
+    return pd.DataFrame(rows)
+
+
+def merge_dispatch_into_timeline(
+    timeline: pd.DataFrame, rt_gaps: pd.DataFrame, rt_df: pd.DataFrame, device_freq_mhz: float
+) -> pd.DataFrame:
+    """Attach chip-level dispatch done/go stamps to each per-core transition row."""
+    if timeline.empty:
+        return timeline
+    out = timeline.copy()
+    for col in (
+        "chip_dispatch_done_cycles",
+        "chip_dispatch_go_cycles",
+        "chip_dispatch_gap_cycles",
+        "chip_dispatch_gap_ns",
+        "chip_dispatch_gap_us",
+    ):
+        out[col] = pd.NA
+    if rt_gaps.empty:
+        return out
+    lookup = {(int(r.chip), int(r.from_prog_id), int(r.to_prog_id)): r for _, r in rt_gaps.iterrows()}
+    for idx, row in out.iterrows():
+        key = (int(row["chip"]), int(row["from_prog_id"]), int(row["to_prog_id"]))
+        if key not in lookup:
+            continue
+        d = lookup[key]
+        done_c = int(d["done_cycles"])
+        go_c = int(d["go_cycles"])
+        gap_c = int(d["dispatch_gap_cycles"])
+        out.at[idx, "chip_dispatch_done_cycles"] = done_c
+        out.at[idx, "chip_dispatch_go_cycles"] = go_c
+        out.at[idx, "chip_dispatch_gap_cycles"] = gap_c
+        gap_ns = float(d["dispatch_gap_ns"]) if "dispatch_gap_ns" in d else float(d["dispatch_gap_us"]) * 1000.0
+        out.at[idx, "chip_dispatch_gap_ns"] = gap_ns
+        out.at[idx, "chip_dispatch_gap_us"] = gap_ns / 1000.0
+
+    # NOTE on BRISC firmware prelude:
+    #   RT-profiler chip_dispatch_go_cycles and device-profiler brisc_go_cycles
+    #   are on different cycle counters / epochs and CANNOT be subtracted to
+    #   get a per-core "FW prelude" without an explicit sync offset (which
+    #   the current CSVs don't expose). Use `brisc_done_to_go_us` instead —
+    #   that is per-core BRISC kernel-exit(k) → BRISC kernel-entry(k+1) on
+    #   the same device-cycle counter, which is the per-core firmware +
+    #   dispatch transition window we actually want.
+    return out
+
+
+def build_timeline(gaps: pd.DataFrame, barriers: dict[str, dict[tuple, int]], freq_mhz: float) -> pd.DataFrame:
+    """Merge pack→unpack gaps with reader/writer barrier timestamps per transition."""
+    if gaps.empty:
+        return pd.DataFrame()
+    rows: list[dict] = []
+    for _, row in gaps.iterrows():
+        chip, core_x, core_y = int(row.chip), int(row.core_x), int(row.core_y)
+        from_prog, to_prog = int(row.from_prog_id), int(row.to_prog_id)
+        k_end = (chip, core_x, core_y, from_prog)
+        k_start = (chip, core_x, core_y, to_prog)
+        rec = row.to_dict()
+        rec["write_before_barrier_cycles"] = barriers["write_before"].get(k_end)
+        rec["write_after_barrier_cycles"] = barriers["write_after"].get(k_end)
+        rec["read_before_barrier_cycles"] = barriers["read_before"].get(k_start)
+        rec["read_after_barrier_cycles"] = barriers["read_after"].get(k_start)
+        rec["brisc_done_cycles"] = barriers["brisc_done"].get(k_end)
+        rec["brisc_go_cycles"] = barriers["brisc_go"].get(k_start)
+        rec["ncrisc_done_cycles"] = barriers["ncrisc_done"].get(k_end)
+        rec["ncrisc_go_cycles"] = barriers["ncrisc_go"].get(k_start)
+        # FW-level zone bounds: FW.start fires BEFORE our user BRISC_GO marker
+        # (FW kernel-launch dispatch path runs in between). FW done->go is a
+        # tighter "done/go" interval: prev FW signaled done -> next FW received
+        # GO and entered scope. Excludes our pre-marker user code (~75 ns) and
+        # the FW kernel-launch prelude (~0.5-1 us) that inflates user done->go.
+        rec["brisc_fw_start_cycles"] = barriers["brisc_fw_start"].get(k_start)
+        rec["brisc_fw_end_cycles"] = barriers["brisc_fw_end"].get(k_end)
+        rec["ncrisc_fw_start_cycles"] = barriers["ncrisc_fw_start"].get(k_start)
+        rec["ncrisc_fw_end_cycles"] = barriers["ncrisc_fw_end"].get(k_end)
+        bd = rec.get("brisc_done_cycles")
+        bg = rec.get("brisc_go_cycles")
+        if bd is not None and bg is not None and not (pd.isna(bd) or pd.isna(bg)):
+            rec["brisc_done_to_go_cycles"] = int(bg) - int(bd)
+            rec["brisc_done_to_go_us"] = rec["brisc_done_to_go_cycles"] / freq_mhz
+        bfs = rec.get("brisc_fw_start_cycles")
+        bfe = rec.get("brisc_fw_end_cycles")
+        if bfs is not None and bfe is not None and not (pd.isna(bfs) or pd.isna(bfe)):
+            rec["brisc_fw_done_to_go_cycles"] = int(bfs) - int(bfe)
+            rec["brisc_fw_done_to_go_us"] = rec["brisc_fw_done_to_go_cycles"] / freq_mhz
+        rb = rec.get("read_before_barrier_cycles")
+        ra = rec.get("read_after_barrier_cycles")
+        if rb is not None and ra is not None and not (pd.isna(rb) or pd.isna(ra)):
+            rb_i, ra_i = int(rb), int(ra)
+            rec["read_barrier_cycles"] = ra_i - rb_i
+            rec["read_barrier_us"] = rec["read_barrier_cycles"] / freq_mhz
+        pf = rec.get("pack_finish_cycles")
+        if pf is not None and ra is not None and not (pd.isna(pf) or pd.isna(ra)):
+            rec["pack_finish_to_read_after_cycles"] = int(ra) - int(pf)
+            rec["pack_finish_to_read_after_us"] = rec["pack_finish_to_read_after_cycles"] / freq_mhz
+        wb = rec.get("write_before_barrier_cycles")
+        wa = rec.get("write_after_barrier_cycles")
+        if wb is not None and wa is not None and not (pd.isna(wb) or pd.isna(wa)):
+            rec["write_barrier_cycles"] = int(wa) - int(wb)
+            rec["write_barrier_us"] = rec["write_barrier_cycles"] / freq_mhz
+        rows.append(rec)
+    out = pd.DataFrame(rows)
+    if not out.empty and "gap_us" in out.columns:
+        for col in out.columns:
+            if col.endswith("_cycles") and col != "gap_cycles":
+                us_col = col.replace("_cycles", "_us")
+                if us_col not in out.columns and out[col].notna().any():
+                    out[us_col] = out[col] / freq_mhz
+    return out
+
+
+def add_buffering_context_columns(
+    timeline: pd.DataFrame,
+    freq_mhz: float,
+    *,
+    input_cb_depth_tiles: int,
+    tiles_per_core: int,
+    reader_push_tile_count: int,
+) -> pd.DataFrame:
+    """Annotate timeline for HW review: CB config + derived buffering vs full op-to-op gap."""
+    if timeline.empty:
+        return timeline
+    out = timeline.copy()
+    out["input_cb_depth_tiles"] = input_cb_depth_tiles
+    out["tiles_per_core"] = tiles_per_core
+    out["reader_push_tiles_per_chunk"] = reader_push_tile_count
+    out["input_cb_double_buffered"] = input_cb_depth_tiles >= 2
+    out["per_tile_dram_read_barrier"] = True
+
+    # Tile 0 of program k+1: DRAM read + noc_async_read_barrier (READ_BEFORE → READ_AFTER).
+    if "read_barrier_us" in out.columns:
+        out["tile0_dram_buffering_latency_us"] = out["read_barrier_us"]
+    else:
+        out["tile0_dram_buffering_latency_us"] = pd.NA
+
+    if "read_after_barrier_cycles" in out.columns and "unpack_tile0_start_cycles" in out.columns:
+        ra = out["read_after_barrier_cycles"]
+        u0 = out["unpack_tile0_start_cycles"]
+        mask = ra.notna() & u0.notna()
+        out["read_after_to_unpack_tile0_us"] = pd.NA
+        out.loc[mask, "read_after_to_unpack_tile0_us"] = (u0[mask].astype(int) - ra[mask].astype(int)) / freq_mhz
+
+    if "gap_us" in out.columns and "tile0_dram_buffering_latency_us" in out.columns:
+        buf = out["tile0_dram_buffering_latency_us"]
+        gap = out["gap_us"]
+        mask = buf.notna() & gap.notna()
+        out["device_gap_excluding_tile0_dram_buffer_us"] = pd.NA
+        out.loc[mask, "device_gap_excluding_tile0_dram_buffer_us"] = gap[mask] - buf[mask]
+        out["tile0_dram_buffer_fraction_of_device_gap"] = pd.NA
+        out.loc[mask & (gap[mask] > 0), "tile0_dram_buffer_fraction_of_device_gap"] = buf[mask] / gap[mask]
+
+    return out
+
+
+def print_buffering_summary(timeline: pd.DataFrame) -> None:
+    if timeline.empty or "tile0_dram_buffering_latency_us" not in timeline.columns:
+        return
+    buf = timeline["tile0_dram_buffering_latency_us"].dropna()
+    if buf.empty:
+        return
+    depth = int(timeline["input_cb_depth_tiles"].iloc[0])
+    tiles = int(timeline["tiles_per_core"].iloc[0])
+    push = (
+        int(timeline["reader_push_tiles_per_chunk"].iloc[0]) if "reader_push_tiles_per_chunk" in timeline.columns else 2
+    )
+    print(
+        f"Buffering context: input CB depth={depth} tiles, {tiles} tiles/core, reader_push={push}, "
+        f"per-tile DRAM read barrier=True"
+    )
+    print(
+        f"  tile0_dram_buffering_latency_us (prog k+1 tile 0 read+barrier): "
+        f"median={buf.median():.3f} mean={buf.mean():.3f} min={buf.min():.3f} max={buf.max():.3f}"
+    )
+    if "device_gap_excluding_tile0_dram_buffer_us" in timeline.columns:
+        rest = timeline["device_gap_excluding_tile0_dram_buffer_us"].dropna()
+        if not rest.empty:
+            print(
+                f"  device_gap_excluding_tile0_dram_buffer_us (pack finish→unpack tile0 minus above): "
+                f"median={rest.median():.3f} mean={rest.mean():.3f}"
+            )
+    if "read_after_to_unpack_tile0_us" in timeline.columns:
+        handoff = timeline["read_after_to_unpack_tile0_us"].dropna()
+        if not handoff.empty:
+            print(
+                f"  read_after_to_unpack_tile0_us (buffer ready→compute TILE_IDX): "
+                f"median={handoff.median():.3f} mean={handoff.mean():.3f}"
+            )
+
+
+def compute_gaps(
+    pack_finish: dict[tuple, int],
+    unpack_tile0_start: dict[tuple, int],
+    min_prog_id: int,
+) -> pd.DataFrame:
+    cores = {(k[0], k[1], k[2]) for k in pack_finish} | {(k[0], k[1], k[2]) for k in unpack_tile0_start}
+    gap_rows: list[dict] = []
+
+    for chip, core_x, core_y in sorted(cores):
+        prog_ids = sorted(
+            {p for (c, x, y, p) in pack_finish if (c, x, y) == (chip, core_x, core_y) and p >= min_prog_id}
+            | {p for (c, x, y, p) in unpack_tile0_start if (c, x, y) == (chip, core_x, core_y) and p >= min_prog_id}
+        )
+        for from_prog, to_prog in zip(prog_ids, prog_ids[1:]):
+            end_key = (chip, core_x, core_y, from_prog)
+            start_key = (chip, core_x, core_y, to_prog)
+            if end_key not in pack_finish or start_key not in unpack_tile0_start:
+                continue
+            end_cycles = pack_finish[end_key]
+            start_cycles = unpack_tile0_start[start_key]
+            gap_rows.append(
+                {
+                    "chip": chip,
+                    "core_x": core_x,
+                    "core_y": core_y,
+                    "from_prog_id": from_prog,
+                    "to_prog_id": to_prog,
+                    "pack_finish_cycles": end_cycles,
+                    "unpack_tile0_start_cycles": start_cycles,
+                    "gap_cycles": start_cycles - end_cycles,
+                }
+            )
+
+    return pd.DataFrame(gap_rows)
+
+
+def build_prog_table(df: pd.DataFrame) -> pd.DataFrame:
+    progs = df[(df["zone name"] == "PROG_ID") & (df["RISC processor type"] == UNPACK_RISC)].copy()
+    if progs.empty:
+        progs = df[df["zone name"] == "PROG_ID"].copy()
+    rows = []
+    for _, row in progs.iterrows():
+        rows.append(
+            {
+                "chip": row["PCIe slot"],
+                "core_x": row["core_x"],
+                "core_y": row["core_y"],
+                "risc": row["RISC processor type"],
+                "prog_id": int(row["data"]),
+                "time_cycles": int(row["time[cycles since reset]"]),
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def add_gap_us(gaps: pd.DataFrame, freq_mhz: float) -> pd.DataFrame:
+    out = gaps.copy()
+    if not out.empty:
+        out["gap_us"] = out["gap_cycles"] / freq_mhz
+    return out
+
+
+def build_per_core_summary(gaps: pd.DataFrame) -> pd.DataFrame:
+    """Mean/min/max gap per (core_x, core_y) across program transitions."""
+    if gaps.empty:
+        return pd.DataFrame()
+    summary = (
+        gaps.groupby(["chip", "core_x", "core_y"], as_index=False)
+        .agg(
+            num_transitions=("gap_us", "count"),
+            mean_gap_us=("gap_us", "mean"),
+            min_gap_us=("gap_us", "min"),
+            max_gap_us=("gap_us", "max"),
+            mean_gap_cycles=("gap_cycles", "mean"),
+        )
+        .sort_values(["core_x", "core_y"])
+    )
+    for col in ("mean_gap_us", "min_gap_us", "max_gap_us", "mean_gap_cycles"):
+        summary[col] = summary[col].round(3)
+    return summary
+
+
+def build_chip_summary(gaps: pd.DataFrame) -> pd.DataFrame:
+    """Aggregate across all cores and all gap rows."""
+    if gaps.empty:
+        return pd.DataFrame()
+    us = gaps["gap_us"]
+    summary = pd.DataFrame(
+        [
+            {
+                "num_cores": int(gaps.groupby(["core_x", "core_y"]).ngroups),
+                "num_gap_rows": len(gaps),
+                "mean_gap_us": round(float(us.mean()), 3),
+                "median_gap_us": round(float(us.median()), 3),
+                "min_gap_us": round(float(us.min()), 3),
+                "max_gap_us": round(float(us.max()), 3),
+                "std_gap_us": round(float(us.std()), 3) if len(us) > 1 else 0.0,
+            }
+        ]
+    )
+    return summary
+
+
+def print_done_go_validation_summary(
+    timeline: pd.DataFrame, rt_gaps: pd.DataFrame, min_prog_id: int, freq_mhz: float
+) -> None:
+    """Summarize done/go metrics: chip dispatch (WH ~500-800ns) vs per-core BRISC FW."""
+    print(f"Done/go validation (min_prog_id>={min_prog_id}, freq={freq_mhz:.1f} MHz):")
+    if not rt_gaps.empty and "dispatch_gap_us" in rt_gaps.columns:
+        dg = rt_gaps["dispatch_gap_us"]
+        dg_ns = dg * 1000.0
+        print(
+            f"  chip_dispatch done→go (RT): median={dg.median():.3f} us ({dg_ns.median():.1f} ns) "
+            f"min={dg.min():.3f} max={dg.max():.3f} n={len(dg)}"
+        )
+    else:
+        print("  chip_dispatch done→go (RT): no data")
+    if not timeline.empty and "brisc_done_to_go_us" in timeline.columns:
+        bg = pd.to_numeric(timeline["brisc_done_to_go_us"], errors="coerce").dropna()
+        if not bg.empty:
+            bg_ns = bg * 1000.0
+            print(
+                f"  brisc_done_to_go (per-core USER markers, includes ~0.5-1us FW prelude): "
+                f"median={bg.median():.3f} us ({bg_ns.median():.1f} ns) "
+                f"min={bg.min():.3f} max={bg.max():.3f} n={len(bg)}"
+            )
+    if not timeline.empty and "brisc_fw_done_to_go_us" in timeline.columns:
+        fbg = pd.to_numeric(timeline["brisc_fw_done_to_go_us"], errors="coerce").dropna()
+        if not fbg.empty:
+            fbg_ns = fbg * 1000.0
+            print(
+                f"  brisc_FW_done_to_go (per-core FW worker round-trip): "
+                f"median={fbg.median():.3f} us ({fbg_ns.median():.1f} ns) "
+                f"min={fbg.min():.3f} max={fbg.max():.3f} n={len(fbg)}"
+            )
+    if not timeline.empty and "dg_first_ns" in timeline.columns:
+        for col, label in [
+            ("dg_issue_ns", "dispatch issue only  "),
+            ("dg_first_ns", "first worker sees GO "),
+            ("dg_median_ns", "median worker sees GO"),
+            ("dg_last_ns", "last worker sees GO  "),
+        ]:
+            v = pd.to_numeric(timeline[col], errors="coerce").dropna()
+            if v.empty:
+                continue
+            print(
+                f"  done_to_go [{label}]: "
+                f"median={v.median():.0f} ns  min={v.min():.0f}  max={v.max():.0f}  n={len(v)}"
+            )
+    if not timeline.empty and "gap_us" in timeline.columns:
+        gap = pd.to_numeric(timeline["gap_us"], errors="coerce").dropna()
+        if not gap.empty:
+            print(
+                f"  op2op gap_us (pack finish→unpack tile0): median={gap.median():.3f} us "
+                f"min={gap.min():.3f} max={gap.max():.3f} n={len(gap)}"
+            )
+
+
+def print_dispatch_summary(rt_programs: pd.DataFrame, rt_gaps: pd.DataFrame) -> None:
+    if rt_programs.empty and rt_gaps.empty():
+        print("No real-time profiler data (run test with --use-realtime-profiler).", file=sys.stderr)
+        return
+    print(
+        "Chip dispatch (RT profiler): go/done at chip enqueue; device BRISC_GO/DONE and NCRISC_GO/DONE "
+        "are per-core dataflow kernel entry/exit in the CSV"
+    )
+    if not rt_programs.empty:
+        for _, row in rt_programs.iterrows():
+            gap_str = ""
+            if int(row.get("gap_to_next_go_cycles", 0)) > 0:
+                gap_str = f", gap_to_next_go={int(row.gap_to_next_go_cycles)} cycles ({row.gap_to_next_go_ns:.1f} ns)"
+            print(
+                f"  chip {int(row.chip)} prog {int(row.program_id)}: "
+                f"go_cycles={int(row.go_cycles)} done_cycles={int(row.done_cycles)}, "
+                f"duration={row.program_duration_ns:.1f} ns ({row.program_duration_us:.3f} us){gap_str}"
+            )
+    if not rt_gaps.empty:
+        for _, row in rt_gaps.iterrows():
+            gap_ns = (
+                float(row["dispatch_gap_ns"]) if "dispatch_gap_ns" in row else float(row["dispatch_gap_us"]) * 1000.0
+            )
+            print(
+                f"  transition {int(row.from_prog_id)}→{int(row.to_prog_id)}: "
+                f"done→go gap={int(row.dispatch_gap_cycles)} cycles ({gap_ns:.1f} ns)"
+            )
+
+
+def aggregate_multi_run_summaries(runs_dir: Path, output_dir: Path) -> None:
+    """Read per-run summary CSVs under runs_dir/run_* and write combined stats."""
+    run_dirs = sorted(p for p in runs_dir.iterdir() if p.is_dir() and p.name.startswith("run_"))
+    if not run_dirs:
+        print(f"No run_* directories under {runs_dir}", file=sys.stderr)
+        return
+
+    device_rows: list[dict] = []
+    dispatch_rows: list[dict] = []
+    for run_dir in run_dirs:
+        run_name = run_dir.name
+        chip_path = next(run_dir.glob("*_op_to_op_summary_chip.csv"), None)
+        dispatch_path = next(run_dir.glob("*_op_to_op_dispatch_gaps.csv"), None)
+        if chip_path and chip_path.is_file():
+            chip = pd.read_csv(chip_path).iloc[0]
+            device_rows.append({"run": run_name, **chip.to_dict()})
+        if dispatch_path and dispatch_path.is_file():
+            disp = pd.read_csv(dispatch_path)
+            for _, row in disp.iterrows():
+                dispatch_rows.append({"run": run_name, **row.to_dict()})
+
+    if device_rows:
+        device_df = pd.DataFrame(device_rows)
+        out_path = output_dir / "multi_run_device_op_to_op_gap.csv"
+        device_df.to_csv(out_path, index=False)
+        print(f"Wrote {out_path} ({len(device_df)} runs)")
+        for col in ("mean_gap_us", "median_gap_us"):
+            if col in device_df.columns:
+                s = device_df[col]
+                print(
+                    f"  device {col} across runs: min={s.min():.3f} max={s.max():.3f} "
+                    f"mean={s.mean():.3f} std={s.std():.3f}"
+                )
+
+    if dispatch_rows:
+        dispatch_df = pd.DataFrame(dispatch_rows)
+        out_path = output_dir / "multi_run_dispatch_done_to_go.csv"
+        dispatch_df.to_csv(out_path, index=False)
+        print(f"Wrote {out_path} ({len(dispatch_df)} rows)")
+        if "dispatch_gap_us" in dispatch_df.columns:
+            s = dispatch_df["dispatch_gap_us"]
+            print(
+                f"  dispatch done→go us across runs: min={s.min():.3f} max={s.max():.3f} "
+                f"mean={s.mean():.3f} std={s.std():.3f}"
+            )
+
+
+def print_gap_summary(gaps: pd.DataFrame, freq_mhz: float) -> None:
+    if gaps.empty:
+        print("No op-to-op gaps (need TRISC_2 FINISH_LAST_PUSH and TRISC_0 TILE_IDX tile 0).", file=sys.stderr)
+        return
+
+    print(f"Chip frequency: {freq_mhz:.3f} MHz")
+    print(f"Gap = TRISC_0 TILE_IDX (tile 0) of program k+1 − TRISC_2 FINISH_LAST_PUSH of program k")
+    print(f"Cores with gaps: {gaps.groupby(['core_x', 'core_y']).ngroups}")
+    print(f"Total gap rows: {len(gaps)}")
+
+    us = gaps["gap_cycles"] / freq_mhz
+    print(f"  gap_us min={us.min():.2f} max={us.max():.2f} mean={us.mean():.2f} median={us.median():.2f}")
+
+    first = gaps.sort_values(["core_x", "core_y", "from_prog_id"]).iloc[0]
+    print(
+        f"Example core ({int(first.core_x)},{int(first.core_y)}): "
+        f"prog {int(first.from_prog_id)}→{int(first.to_prog_id)} "
+        f"gap={int(first.gap_cycles)} cycles ({first.gap_cycles / freq_mhz:.2f} us)"
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Export op-to-op latency CSVs from device profiler log.")
+    parser.add_argument("--input-file", type=Path, default=None)
+    parser.add_argument(
+        "--rt-input-file", type=Path, default=None, help="profile_log_device_rt.csv from --use-realtime-profiler"
+    )
+    parser.add_argument("--output-dir", type=Path, default=None)
+    parser.add_argument(
+        "--min-prog-id",
+        type=int,
+        default=1,
+        help="Exclude program ids below this (default 1 skips pre-compile PROG_ID=0)",
+    )
+    parser.add_argument(
+        "--aggregate-runs-dir",
+        type=Path,
+        default=None,
+        help="Parent directory containing run_1, run_2, ... subdirs; write multi-run summary CSVs and exit",
+    )
+    parser.add_argument(
+        "--input-cb-depth-tiles",
+        type=int,
+        default=4,
+        help="Input circular buffer depth in tiles (benchmark default: 4 = 2x --reader-push-tiles)",
+    )
+    parser.add_argument(
+        "--tiles-per-core",
+        type=int,
+        default=4,
+        help="Tiles processed per core per program (benchmark --num-pages-per-core default)",
+    )
+    parser.add_argument(
+        "--reader-push-tiles",
+        type=int,
+        default=2,
+        help="Reader reserve/read/push chunk size (benchmark --reader-push-tiles)",
+    )
+    args = parser.parse_args()
+
+    import os
+
+    if args.aggregate_runs_dir is not None:
+        runs_dir = args.aggregate_runs_dir.resolve()
+        out_dir = args.output_dir or runs_dir
+        out_dir.mkdir(parents=True, exist_ok=True)
+        aggregate_multi_run_summaries(runs_dir, out_dir)
+        return 0
+
+    log_path = args.input_file or Path(os.environ.get("TT_METAL_HOME", ".")) / DEFAULT_LOG
+    log_path = log_path.resolve()
+    if not log_path.is_file():
+        print(f"Input not found: {log_path}", file=sys.stderr)
+        return 1
+
+    output_dir = args.output_dir or log_path.parent
+    output_dir.mkdir(parents=True, exist_ok=True)
+    stem = log_path.stem
+
+    freq_mhz = parse_chip_freq_mhz(log_path)
+    df = load_profiler_csv(log_path)
+
+    pack_finish, unpack_tile0_start, tiles = walk_core_markers(df)
+    barriers = walk_barrier_markers(df)
+    gaps = compute_gaps(pack_finish, unpack_tile0_start, args.min_prog_id)
+    gaps_out = add_gap_us(gaps, freq_mhz)
+    timeline = build_timeline(gaps_out, barriers, freq_mhz)
+    progs = build_prog_table(df)
+
+    rt_path = args.rt_input_file or (log_path.parent / "profile_log_device_rt.csv")
+    rt_df = load_rt_profiler_csv(rt_path.resolve())
+    rt_gaps, rt_skipped = build_rt_dispatch_gaps(rt_df, freq_mhz, args.min_prog_id)
+    rt_programs = build_rt_program_table(rt_df, args.min_prog_id, freq_mhz)
+    timeline = merge_dispatch_into_timeline(timeline, rt_gaps, rt_df, freq_mhz)
+    dg_table = walk_done_to_go(df, freq_mhz, args.min_prog_id)
+    if not dg_table.empty and not timeline.empty:
+        # Map per (chip, to_prog_id) -> done/go for that transition's GO.
+        # We surface four columns:
+        #  - dg_issue_ns   : dispatch-only MCAST issue cost (~30 ns BH)
+        #  - dg_first_ns   : nearest worker observes GO
+        #  - dg_median_ns  : median worker observes GO
+        #  - dg_last_ns    : farthest worker observes GO
+        lookup = {(int(r.chip), int(r.program_id)): r for _, r in dg_table.iterrows()}
+        for col in ["dg_issue_ns", "dg_first_ns", "dg_median_ns", "dg_last_ns"]:
+            timeline[col] = timeline.apply(
+                lambda r: lookup.get((int(r["chip"]), int(r["to_prog_id"])), pd.Series()).get(col, pd.NA),
+                axis=1,
+            )
+    timeline = add_buffering_context_columns(
+        timeline,
+        freq_mhz,
+        input_cb_depth_tiles=args.input_cb_depth_tiles,
+        tiles_per_core=args.tiles_per_core,
+        reader_push_tile_count=args.reader_push_tiles,
+    )
+    if rt_skipped > 0:
+        print(
+            f"RT dispatch: skipped {rt_skipped} duplicate program_id transition(s) "
+            "(trace replay may emit repeated host runtime ids; use rows where from_prog_id < to_prog_id)",
+            file=sys.stderr,
+        )
+
+    tiles_path = output_dir / f"{stem}_op_to_op_tiles.csv"
+    gaps_path = output_dir / f"{stem}_op_to_op_gaps.csv"
+    timeline_path = output_dir / f"{stem}_op_to_op_timeline.csv"
+    progs_path = output_dir / f"{stem}_op_to_op_prog_ids.csv"
+    summary_chip_path = output_dir / f"{stem}_op_to_op_summary_chip.csv"
+    summary_per_core_path = output_dir / f"{stem}_op_to_op_summary_per_core.csv"
+    rt_gaps_path = output_dir / f"{stem}_op_to_op_dispatch_gaps.csv"
+    rt_programs_path = output_dir / f"{stem}_op_to_op_rt_programs.csv"
+    complete_path = output_dir / f"{stem}_op_to_op_complete.csv"
+
+    tiles.to_csv(tiles_path, index=False)
+    gaps_out.to_csv(gaps_path, index=False)
+    timeline.to_csv(timeline_path, index=False)
+    timeline.to_csv(complete_path, index=False)
+    progs.to_csv(progs_path, index=False)
+    build_chip_summary(gaps_out).to_csv(summary_chip_path, index=False)
+    build_per_core_summary(gaps_out).to_csv(summary_per_core_path, index=False)
+    if not rt_gaps.empty:
+        rt_gaps.to_csv(rt_gaps_path, index=False)
+    if not rt_programs.empty:
+        rt_programs.to_csv(rt_programs_path, index=False)
+
+    print(f"Wrote {summary_chip_path}")
+    print(f"Wrote {summary_per_core_path}")
+    print(f"Wrote {gaps_path} ({len(gaps_out)} rows)")
+    print(f"Wrote {timeline_path} ({len(timeline)} rows, per-core + barriers + chip dispatch go/done)")
+    print(f"Wrote {complete_path} (same columns as timeline — full picture for HW review)")
+    print(f"Wrote {tiles_path} ({len(tiles)} rows)")
+    print(f"Wrote {progs_path} ({len(progs)} rows)")
+    if not rt_gaps.empty:
+        print(f"Wrote {rt_gaps_path} ({len(rt_gaps)} rows, chip-level done→go)")
+    elif args.rt_input_file or rt_path.is_file():
+        print(f"No RT dispatch gaps (check {rt_path})", file=sys.stderr)
+    else:
+        print("No RT CSV (re-run test with --use-realtime-profiler)", file=sys.stderr)
+    if not rt_programs.empty:
+        print(f"Wrote {rt_programs_path} ({len(rt_programs)} programs, go/done per enqueue)")
+    print()
+    print_gap_summary(gaps_out, freq_mhz)
+    if not gaps_out.empty:
+        chip = build_chip_summary(gaps_out)
+        print(f"  All cores mean_gap_us={chip.iloc[0]['mean_gap_us']:.3f} median={chip.iloc[0]['median_gap_us']:.3f}")
+    print()
+    print_buffering_summary(timeline)
+    print()
+    print_done_go_validation_summary(timeline, rt_gaps, args.min_prog_id, freq_mhz)
+    print()
+    print_dispatch_summary(rt_programs, rt_gaps)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/scripts/raw_hazard_analyzer.py
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/scripts/raw_hazard_analyzer.py
@@ -1,0 +1,554 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Analyze a ttnn graph capture for read-after-write (RAW) dependencies between DEVICE PROGRAMS.
+
+Input: JSON produced by ttnn.graph.end_graph_capture_to_file(...) (a list of node dicts).
+Granularity: DEVICE PROGRAMS = leaf function nodes (no nested function_start) that own >=1
+circular_buffer_allocate (CBs are program-scoped). This is the barrier-bounded unit we care about.
+
+Metrics (all at the device-program level; the DAG, not naive execution-order adjacency):
+  - adjacent-RAW %      : does op n+1 read a tensor op n wrote (the no-reorder / today view)
+  - distance-to-first-consumer distribution : for each op output, how many ops until its first
+                          reader (>1 => barrier can overlap that many ops regardless of ordering)
+  - critical path       : longest producer->consumer chain / total ops (independence ceiling)
+"""
+import json
+import re
+import sys
+from collections import defaultdict
+
+
+def parse_device_ops(nodes):
+    """Return ordered list of device-program ops: {counter,name,in_ids(set),out_ids(set)}.
+
+    A device op = an innermost (leaf) function_start/function_end pair that contains >=1
+    circular_buffer_allocate between start and end. tensor identity = params['tensor_id'].
+    """
+    by_counter = {n["counter"]: n for n in nodes}
+
+    def tid(node_counter):
+        # Buffer ADDRESS is the reliable cross-op identity: the ttnn API layer re-wraps tensors
+        # between device ops so tensor_id changes (producer out=21, consumer in=22) while the address
+        # is preserved. Fall back to tensor_id for synthetic graphs with no address (self-test).
+        n = by_counter.get(node_counter)
+        if not (n and n["node_type"] == "tensor"):
+            return None
+        p = n.get("params") or {}
+        return p.get("address") or p.get("tensor_id")
+
+    # Pair function_start with function_end via a stack (counter order).
+    stack, pairs = [], []
+    for n in nodes:
+        if n["node_type"] == "function_start":
+            stack.append(n)
+        elif n["node_type"] == "function_end":
+            if stack:
+                pairs.append((stack.pop(), n))
+
+    # A device operation is the function node carrying tensor I/O: non-empty input_tensors (the ttnn
+    # API wrapper above it has none, and helpers like create_device_tensor have none). This fires per
+    # invocation regardless of program-cache reuse -- unlike circular_buffer_allocate, which a
+    # cache-reused identical op (e.g. the 2nd/3rd of q/k/v) does NOT re-emit.
+    ops = []
+    for fs, fe in pairs:
+        if not fs.get("input_tensors"):
+            continue
+        in_ids = {tid(c) for c in fs.get("input_tensors", [])}
+        out_ids = {tid(c) for c in fe.get("connections", [])}
+        ops.append(
+            {
+                "counter": fs["counter"],
+                "name": (fs.get("params") or {}).get("name", "?"),
+                "in_ids": {x for x in in_ids if x is not None},
+                "out_ids": {x for x in out_ids if x is not None},
+            }
+        )
+    ops.sort(key=lambda o: o["counter"])
+    return ops
+
+
+def analyze(ops):
+    n = len(ops)
+
+    def producer_before(addr, i):  # most-recent prior op that wrote addr (reuse-safe RAW source)
+        p = None
+        for k in range(i):
+            if addr in ops[k]["out_ids"]:
+                p = k
+        return p
+
+    # adjacent RAW: does the immediate next op read anything this op wrote
+    adj_raw = sum(1 for i in range(n - 1) if ops[i]["out_ids"] & ops[i + 1]["in_ids"])
+    # UNRESOLVED boundaries: op_n records NO output (in-place ops -- RoPE rotates Q/K in place,
+    # PagedUpdateCache writes the cache in place -- ttnn graph capture stores no output tensor for
+    # them). We CANNOT confirm op_{n+1} is independent, so these are NOT counted as headroom
+    # (conservative: an op whose output isn't recorded is treated as a possible producer).
+    adj_unresolved = sum(1 for i in range(n - 1) if not ops[i]["out_ids"])
+    adj_nonraw = (n - 1) - adj_raw
+    adj_reorderable = adj_nonraw - adj_unresolved  # non-RAW AND op_n has a recorded output
+
+    # distance to first consumer of each op's output (stop if the buffer is overwritten before any
+    # read -> that write is dead / WAW, not a RAW producer)
+    dists = []
+    for i, op in enumerate(ops):
+        best = None
+        for a in op["out_ids"]:
+            for j in range(i + 1, n):
+                if a in ops[j]["out_ids"] and a not in ops[j]["in_ids"]:
+                    break  # overwritten before read
+                if a in ops[j]["in_ids"]:
+                    d = j - i
+                    best = d if best is None else min(best, d)
+                    break
+        if best is not None:
+            dists.append(best)
+
+    # critical path: longest chain via most-recent-producer edges (ops in program/topo order)
+    depth = [1] * n
+    for i, op in enumerate(ops):
+        for a in op["in_ids"]:
+            p = producer_before(a, i)
+            if p is not None:
+                depth[i] = max(depth[i], depth[p] + 1)
+    return {
+        "n_ops": n,
+        "adj_boundaries": n - 1,
+        "adj_raw": adj_raw,
+        "adj_nonraw": adj_nonraw,
+        "adj_nonraw_pct": 100.0 * adj_nonraw / (n - 1) if n > 1 else 0.0,
+        "adj_reorderable": adj_reorderable,
+        "adj_reorderable_pct": 100.0 * adj_reorderable / (n - 1) if n > 1 else 0.0,
+        "adj_unresolved": adj_unresolved,
+        "dist_hist": {d: dists.count(d) for d in sorted(set(dists))},
+        "dist_gt1_pct": 100.0 * sum(1 for d in dists if d > 1) / len(dists) if dists else 0.0,
+        "critical_path": max(depth) if depth else 0,
+    }
+
+
+def analyze_waw(ops):
+    """Write-after-write between device programs. At buffer granularity a shared output address is
+    EITHER a true WAW (same live buffer written twice: in-place / accumulate / KV-cache slice) OR
+    allocator ADDRESS-REUSE (op A's output freed after its consumer, op B's fresh output recycles the
+    address) OR in-place READ-MODIFY-WRITE (op B reads addr a and writes it back -- really a RAW, not a
+    WAW). Only the first (a genuine overwrite of still-live data with no reader) is a barrier hazard.
+    Split: if addr a is read BETWEEN the two writes (consumed then recycled) OR read BY the second
+    writer itself (in-place RMW), it's NOT a true WAW. CAVEAT: buffer granularity can't see sub-tensor
+    regions, so genuine PARTIAL/slice updates to disjoint regions of one buffer (e.g. KV cache) would
+    also register here -- flagged, not resolved, by this pass."""
+    n = len(ops)
+    writers = defaultdict(list)
+    for i, op in enumerate(ops):
+        for a in op["out_ids"]:
+            writers[a].append(i)
+    collisions = {a: w for a, w in writers.items() if len(w) > 1}
+    adj_waw = sum(1 for i in range(n - 1) if ops[i]["out_ids"] & ops[i + 1]["out_ids"])
+    reuse = overwrite = 0
+    for a, w in collisions.items():
+        for x in range(len(w) - 1):
+            i, j = w[x], w[x + 1]
+            # consumed (allocator-reuse) if read between the writes; RMW (RAW, not WAW) if op j reads a
+            if a in ops[j]["in_ids"] or any(a in ops[k]["in_ids"] for k in range(i + 1, j)):
+                reuse += 1
+            else:
+                overwrite += 1
+    return {
+        "collision_addrs": len(collisions),
+        "waw_pairs": reuse + overwrite,
+        "alloc_reuse": reuse,
+        "true_overwrite": overwrite,
+        "adj_waw": adj_waw,
+    }
+
+
+def report(ops, m, title):
+    print(f"\n=== {title} ===")
+    print(f"device programs: {m['n_ops']}   adjacency boundaries: {m['adj_boundaries']}")
+    print(
+        f"adjacent RAW: {m['adj_raw']}   NON-RAW: {m['adj_nonraw']} ({m['adj_nonraw_pct']:.0f}%) = "
+        f"{m['adj_reorderable']} confirmed-reorderable ({m['adj_reorderable_pct']:.0f}%) "
+        f"+ {m['adj_unresolved']} UNRESOLVED (op_n output not recorded -- in-place)"
+    )
+    print(f"distance-to-first-consumer histogram (ops-until-first-reader): {m['dist_hist']}")
+    print(f"  outputs whose first reader is >1 op away: {m['dist_gt1_pct']:.0f}%")
+    print(
+        f"critical path: {m['critical_path']} of {m['n_ops']} ops  "
+        f"(=> up to {m['n_ops'] - m['critical_path']} ops of slack/independence)"
+    )
+    w = analyze_waw(ops)
+    print(
+        f"WAW: {w['collision_addrs']} shared output addr(s), {w['waw_pairs']} write-pairs "
+        f"-> {w['alloc_reuse']} allocator-reuse (NOT a hazard), {w['true_overwrite']} candidate true-WAW; "
+        f"adjacent WAW {w['adj_waw']}"
+    )
+
+
+def _barrier_ops(nodes):
+    """Parse to (counter, name, ins{addr:(lay,buf,grid)}, outs{...}) -- shared by the locality classifiers."""
+
+    def mc(node):
+        s = (node.get("params") or {}).get("memory_config") if node else None
+        if not s:
+            return (None, None, None)
+        lay = re.search(r"memory_layout=TensorMemoryLayout::(\w+)", s)
+        buf = re.search(r"buffer_type=BufferType::(\w+)", s)
+        grid = re.search(r"grid=(\[.*?\])\s*,\s*shape", s)
+        return (lay.group(1) if lay else None, buf.group(1) if buf else None, grid.group(1) if grid else None)
+
+    byc = {n["counter"]: n for n in nodes}
+
+    def addr(c):
+        n = byc.get(c)
+        p = (n.get("params") or {}) if n else {}
+        return (p.get("address") or p.get("tensor_id")) if n and n["node_type"] == "tensor" else None
+
+    stack, pairs = [], []
+    for n in nodes:
+        if n["node_type"] == "function_start":
+            stack.append(n)
+        elif n["node_type"] == "function_end" and stack:
+            pairs.append((stack.pop(), n))
+    ops = []
+    for fs, fe in pairs:
+        if not fs.get("input_tensors"):
+            continue
+        ins = {addr(c): mc(byc.get(c)) for c in fs.get("input_tensors", []) if addr(c) is not None}
+        outs = {addr(c): mc(byc.get(c)) for c in fe.get("connections", []) if addr(c) is not None}
+        ops.append((fs["counter"], (fs.get("params") or {}).get("name", ""), ins, outs))
+    ops.sort()
+    return ops
+
+
+# --- barrier-strength classifier (signatures validated against kernel source, 2026-07-21) ---
+# Two kinds of downgradable boundary (Paul's taxonomy), keyed on the CONSUMER'S READ of the producer's
+# output -- NOT the op's write-side scatter (a scatter-on-write op like ShardedToInterleaved still READS
+# local, so its input boundary is NONE):
+#   NONE  (Type 1, no barrier)   : producer writes its shard to local L1, consumer reads its own local L1.
+#                                  Same core's SRAM, ordered by that core's kernel sequence -> nothing to sync.
+#   LOCAL (Type 2, write-drain)  : DATA goes through DRAM (write must commit before read-back) BUT no core
+#                                  reads another core's just-written shard -> core c drains only its OWN
+#                                  DRAM writes. Requires DRAM-SHARDED (contiguous per core), NOT interleaved
+#                                  (round-robin across banks = cross). Partition-preservation needs the
+#                                  work-split to confirm -> reported as a Type-2 CANDIDATE.
+#   GLOBAL                       : consumer reads other cores' data (gather/mcast/regrid/reduction/interleaved).
+#
+# Consumer reads only its own L1 shard (VERIFIED from source): binary_ng CB aliased to shard buffer + reader
+# no-op under #if SRC_SHARDED; ShardedToInterleaved reads local shard via globally-allocated input CB
+# (scatters only on write). UnaryNg follows the binary_ng sharded path.
+_LOCAL_READ_OPS = (
+    "binaryng",
+    "binary_ng",
+    "unaryng",
+    "unary_ng",
+    "eltwise",
+    "shardedtointerleaved",
+    "sharded_to_interleaved",
+)
+# Consumer reads OTHER cores' data (VERIFIED: reshard reads remote L1 via runtime (noc_x,noc_y); matmul mcasts
+# in0; InterleavedToSharded reads interleaved DRAM round-robin across banks). concat_heads gathers heads.
+_CROSS_READ_OPS = (
+    "reshard",
+    "halo",
+    "gather",
+    "all_gather",
+    "allgather",
+    "concat_heads",
+    "concatheads",
+    "reduce_scatter",
+    "reducescatter",
+    "all_to_all",
+    "alltoall",
+    "matmul",
+    "sdpa",
+    "scaled_dot_product",
+    "interleavedtosharded",
+    "interleaved_to_sharded",
+)
+_NORM_OPS = ("layernorm", "groupnorm", "rmsnorm", "softmax")  # cross when the reduced dim is width-sharded
+_VIEW_OPS = ("reshape", "reshapeview", "reshape_view")  # view/metadata; may be a no-op -> undecidable
+
+
+def classify_barriers(nodes):
+    """Classify each adjacent RAW boundary by barrier strength: NONE (Type 1, no barrier), LOCAL (Type 2,
+    per-core write-drain), GLOBAL (cross-core), or UNDECIDABLE. Keyed on the CONSUMER'S READ of the shared
+    buffer (see the taxonomy comment above). Returns (rows, summary), rows = [(prod_idx, prod, cons, verdict, reason)].
+    """
+    ops = _barrier_ops(nodes)
+    rows, summary = [], {"NONE": 0, "NONE_no_noc": 0, "LOCAL": 0, "GLOBAL": 0, "UNDECIDABLE": 0}
+    for i in range(len(ops) - 1):
+        shared = set(ops[i][3]) & set(ops[i + 1][2])
+        if not shared:
+            continue
+        a = next(iter(shared))
+        cons = ops[i + 1][1].lower()
+        cn = ops[i + 1][1].split("::")[-1]
+        lay, buf, cons_grid = ops[i + 1][2][a]
+        prod_grid = ops[i][3][a][2]
+        sharded = lay and lay.endswith("SHARDED")
+        if any(k in cons for k in _VIEW_OPS):
+            v, r = "UNDECIDABLE", f"{cn} is a view (may be a no-op; read pattern not modeled)"
+        elif lay == "INTERLEAVED":
+            v, r = "GLOBAL", "reads interleaved (round-robin across banks/cores)"
+        elif prod_grid and cons_grid and prod_grid != cons_grid:
+            v, r = "GLOBAL", f"regrid {prod_grid}->{cons_grid}"
+        elif any(k in cons for k in _CROSS_READ_OPS):
+            v, r = "GLOBAL", f"{cn} reads other cores (gather/mcast)"
+        elif any(k in cons for k in _NORM_OPS) and lay == "WIDTH_SHARDED":
+            v, r = "GLOBAL", f"{cn} reduces across width-sharded dim"
+        elif buf == "DRAM" and sharded:
+            v, r = "LOCAL", f"DRAM-sharded same grid -> Type-2 candidate (needs work-split to confirm partition)"
+        elif buf == "L1" and sharded and any(k in cons for k in _LOCAL_READ_OPS):
+            # sub-label: does the consumer op issue ANY noc_async_read? reader is a no-op only when EVERY
+            # operand is sharded-L1 (CB aliased to the shard buffer); an interleaved/DRAM operand forces a
+            # NoC read. All-sharded-L1 inputs -> data already resident, nothing to fetch (strongest Type-1).
+            ins = list(ops[i + 1][2].values())
+            no_noc = bool(ins) and all(b == "L1" and l and l.endswith("SHARDED") for (l, b, g) in ins)
+            v = "NONE"
+            r = f"{cn} reads only its own L1 shard ({lay})" + (
+                " [zero NoC reads: all inputs sharded-L1, already resident]"
+                if no_noc
+                else " [local shared read; op has other non-sharded inputs -> some NoC read]"
+            )
+            summary["NONE_no_noc"] += no_noc
+        else:
+            v, r = "UNDECIDABLE", f"{cn} read pattern not verified"
+        summary[v] += 1
+        rows.append((ops[i][0], ops[i][1].split("::")[-1], cn, v, r))
+    return rows, summary
+
+
+def shard_locality(nodes):
+    """Bound how many RAW boundaries are cross-core, from tensor shard specs (memory_config).
+
+    IMPORTANT LIMITATION: memory_config gives where a shard RESIDES (its grid), NOT which core READS
+    it. The two differ for gather ops -- e.g. Halo (conv neighbor-exchange) reads border rows from
+    ADJACENT cores while keeping the same residence grid. So a preserved residence grid does NOT prove
+    same-core access; the true access pattern lives in the kernel's NoC addressing / runtime args,
+    which the capture does not expose at the tensor level. Therefore:
+      - CROSS-CORE is RELIABLE where we can see it: DRAM (no worker-core affinity), a residence-grid
+        CHANGE (reshard/regrid), or a known gather/scatter op (Halo, all_gather, concat_heads, ...).
+        Their sum is a LOWER bound on cross-core.
+      - 'residence_preserved_ambiguous' is everything else: an UPPER bound on same-core -- it may still
+        be cross-core (e.g. a width-sharded matmul/norm that reduces across cores). NOT confirmed local.
+    Returns counts dict."""
+
+    def mc(node):
+        s = (node.get("params") or {}).get("memory_config") if node else None
+        if not s:
+            return (None, None, None)
+        lay = re.search(r"memory_layout=TensorMemoryLayout::(\w+)", s)
+        buf = re.search(r"buffer_type=BufferType::(\w+)", s)
+        grid = re.search(r"grid=(\[.*?\])\s*,\s*shape", s)
+        return (lay.group(1) if lay else None, buf.group(1) if buf else None, grid.group(1) if grid else None)
+
+    byc = {n["counter"]: n for n in nodes}
+
+    def addr(c):
+        n = byc.get(c)
+        p = (n.get("params") or {}) if n else {}
+        return (p.get("address") or p.get("tensor_id")) if n and n["node_type"] == "tensor" else None
+
+    stack, pairs = [], []
+    for n in nodes:
+        if n["node_type"] == "function_start":
+            stack.append(n)
+        elif n["node_type"] == "function_end" and stack:
+            pairs.append((stack.pop(), n))
+    ops = []
+    for fs, fe in pairs:
+        if not fs.get("input_tensors"):
+            continue
+        ins = {addr(c): mc(byc.get(c)) for c in fs.get("input_tensors", []) if addr(c) is not None}
+        outs = {addr(c): mc(byc.get(c)) for c in fe.get("connections", []) if addr(c) is not None}
+        ops.append((fs["counter"], (fs.get("params") or {}).get("name", ""), ins, outs))
+    ops.sort()
+    # ops that read cross-core even when the residence grid is preserved (gather/scatter)
+    GATHER = (
+        "halo",
+        "gather",
+        "all_gather",
+        "allgather",
+        "concat_heads",
+        "concatheads",
+        "create_qkv",
+        "createqkv",
+        "reduce_scatter",
+        "reducescatter",
+        "all_to_all",
+        "alltoall",
+    )
+    cats = {"residence_preserved_ambiguous": 0, "cross_DRAM": 0, "cross_regrid": 0, "cross_known_gather": 0}
+    for i in range(len(ops) - 1):
+        shared = set(ops[i][3]) & set(ops[i + 1][2])  # producer outs ∩ consumer ins
+        if not shared:
+            continue
+        a = next(iter(shared))
+        name = ops[i + 1][1].lower()
+        lay, buf, grid = ops[i + 1][2][a]  # consumed buffer's layout/buffer/grid
+        out_grids = {g for (_, _, g) in ops[i + 1][3].values() if g}
+        if any(k in name for k in GATHER):
+            cats["cross_known_gather"] += 1
+        elif buf == "DRAM":
+            cats["cross_DRAM"] += 1
+        elif buf == "L1" and lay and lay.endswith("SHARDED") and grid and out_grids == {grid}:
+            cats["residence_preserved_ambiguous"] += 1
+        else:
+            cats["cross_regrid"] += 1
+    return cats
+
+
+# ---- self-test: synthetic Llama-style decoder layer with KNOWN dependencies ----
+def _synthetic_graph():
+    """Hand-built graph in the ttnn schema. Decoder layer at device-program granularity:
+    0 rmsnorm(x)->h1  1 qkv(h1)->qkv  2 attn(qkv)->attn  3 o_proj(attn)->o  4 add(x,o)->r1
+    5 rmsnorm(r1)->h2  6 gate(h2)->g  7 up(h2)->u  8 silu_mul(g,u)->gu  9 down(gu)->d  10 add(r1,d)->r2
+    KEY: op7(up) reads h2 (op5's out), NOT op6's out -> op6->op7 is the one NON-RAW adjacency.
+    """
+    T = {}  # tensor_id -> node counter
+    nodes = [{"counter": 0, "node_type": "capture_start", "params": {}, "connections": [], "input_tensors": []}]
+    c = [1]
+
+    def tensor(tid):
+        node = {"counter": c[0], "node_type": "tensor", "params": {"tensor_id": str(tid)}, "connections": []}
+        nodes.append(node)
+        T[tid] = c[0]
+        c[0] += 1
+        return T[tid]
+
+    tensor(0)  # x (external embedding input)
+
+    def op(name, in_tids, out_tid):
+        fs = {
+            "counter": c[0],
+            "node_type": "function_start",
+            "params": {"name": name},
+            "input_tensors": [T[t] for t in in_tids],
+            "connections": [],
+        }
+        nodes.append(fs)
+        c[0] += 1
+        nodes.append({"counter": c[0], "node_type": "circular_buffer_allocate", "params": {}, "connections": []})
+        c[0] += 1
+        ot = tensor(out_tid)
+        fe = {"counter": c[0], "node_type": "function_end", "params": {"name": name}, "connections": [ot]}
+        nodes.append(fe)
+        c[0] += 1
+
+    op("rmsnorm", [0], 1)  # h1
+    op("matmul_qkv", [1], 2)  # qkv
+    op("attention", [2], 3)  # attn
+    op("matmul_o", [3], 4)  # o
+    op("add_residual", [0, 4], 5)  # r1 = x + o
+    op("rmsnorm", [5], 6)  # h2
+    op("matmul_gate", [6], 7)  # g
+    op("matmul_up", [6], 8)  # u   <-- reads h2 (op5), independent of op6 => NON-RAW adjacency
+    op("silu_mul", [7, 8], 9)  # gu
+    op("matmul_down", [9], 10)  # d
+    op("add_residual", [5, 10], 11)  # r2 = r1 + d
+    return nodes
+
+
+def infer_attention_edges(ops):
+    """create-heads -> SDPA/softmax edges the capture drops. NLPCreateHeads emits NO output tensor, so
+    the SDPA that consumes its Q/K/V heads shows up producerless (a false root). Attention is emitted as
+    [q/k/v proj ...][create-heads ...] SDPA, so each attention core (SDPA or explicit softmax) depends on
+    the create-heads ops since the previous core. Returns [(create_heads_idx, core_idx)] pairs.
+    """
+    pairs, pending = [], []
+    for i, o in enumerate(ops):
+        nm = o["name"].lower()
+        if "create" in nm and "head" in nm:
+            pending.append(i)
+        elif "sdpa" in nm or "scaled_dot_product" in nm or "softmax" in nm:
+            pairs.extend((p, i) for p in pending)
+            pending = []
+    return pairs
+
+
+def apply_resolutions(ops, resolve_inplace=False, add_edges=(), infer_attention=None):
+    """Reconnect dependency edges the buffer-address capture cannot see (opt-in, conservative).
+
+    resolve_inplace: an op with NO recorded output is an in-place RMW (e.g. RotaryEmbedding rotates Q,
+      PagedFusedUpdateCache writes the KV cache) -- it mutates its input buffer(s). Treat its inputs AS
+      its outputs so a downstream consumer of those buffers depends on it (and it on the prior writer).
+      Only ADDS edges, so it can only lengthen the critical path (never fabricate slack).
+    infer_attention: also add create-heads->SDPA edges (see infer_attention_edges). Defaults to
+      resolve_inplace, so --resolve-inplace stops drawing SDPAs as false roots.
+    add_edges: [(producer_idx, consumer_idx)] semantic deps known real but invisible in the capture --
+      e.g. a reshape VIEW whose output drops its buffer address (tensor-id fallback) so producer and
+      consumer tids differ. Injected via a synthetic shared address; each is an explicit, auditable claim.
+    """
+    if infer_attention is None:
+        infer_attention = resolve_inplace
+    if resolve_inplace:
+        for o in ops:
+            if not o["out_ids"]:
+                o["out_ids"] = set(o["in_ids"])
+    edges = list(add_edges) + (infer_attention_edges(ops) if infer_attention else [])
+    for p, c in edges:
+        tag = f"__edge_{p}_{c}"
+        ops[p]["out_ids"].add(tag)
+        ops[c]["in_ids"].add(tag)
+    return ops
+
+
+if __name__ == "__main__":
+    argv = sys.argv[1:]
+    resolve_inplace = "--resolve-inplace" in argv
+    verbose = "--classify-verbose" in argv
+    add_edges, files, i = [], [], 0
+    while i < len(argv):
+        if argv[i] == "--add-edge":
+            i += 1
+            p, c = argv[i].split(":")
+            add_edges.append((int(p), int(c)))
+        elif argv[i] not in ("--resolve-inplace", "--classify-verbose"):
+            files.append(argv[i])
+        i += 1
+    if files and files[0] != "--self-test":
+        nodes = json.load(open(files[0]))
+        ops = parse_device_ops(nodes)
+        apply_resolutions(ops, resolve_inplace, add_edges)
+        tags = [t for t, on in (("resolve-inplace", resolve_inplace), (f"add-edge {add_edges}", bool(add_edges))) if on]
+        report(ops, analyze(ops), f"capture: {files[0]}" + (f"  [{'; '.join(tags)}]" if tags else ""))
+        s = shard_locality(nodes)
+        tot = sum(s.values())
+        if tot:
+            xcore = s["cross_DRAM"] + s["cross_regrid"] + s["cross_known_gather"]
+            amb = s["residence_preserved_ambiguous"]
+            print(
+                f"RAW-boundary shard locality (residence != access -- see docstring):\n"
+                f"  cross-core >= {xcore}/{tot} ({100*xcore/tot:.0f}%, RELIABLE floor: "
+                f"{s['cross_DRAM']} DRAM + {s['cross_regrid']} regrid + {s['cross_known_gather']} known-gather)\n"
+                f"  same-core <= {amb}/{tot} ({100*amb/tot:.0f}%, residence-preserved but NOT confirmed local "
+                f"-- kernel read pattern not visible in the capture)"
+            )
+        rows, cls = classify_barriers(nodes)
+        ctot = cls["NONE"] + cls["LOCAL"] + cls["GLOBAL"] + cls["UNDECIDABLE"]  # NONE_no_noc is a NONE subset
+        if ctot:
+            dg = cls["NONE"] + cls["LOCAL"]
+            nn = cls["NONE_no_noc"]
+            print(
+                f"\nBarrier strength over adjacent-RAW boundaries (keyed on consumer read; signatures validated "
+                f"vs kernel source):\n"
+                f"  NONE        {cls['NONE']:4}/{ctot} ({100*cls['NONE']/ctot:.0f}%)  Type 1: local L1->L1, no barrier\n"
+                f"     of which  {nn:4}      zero NoC reads (all inputs sharded-L1, already resident)\n"
+                f"  LOCAL       {cls['LOCAL']:4}/{ctot} ({100*cls['LOCAL']/ctot:.0f}%)  Type 2: DRAM-sharded, per-core write-drain (candidate, needs work-split)\n"
+                f"  GLOBAL      {cls['GLOBAL']:4}/{ctot} ({100*cls['GLOBAL']/ctot:.0f}%)  cross-core read\n"
+                f"  UNDECIDABLE {cls['UNDECIDABLE']:4}/{ctot} ({100*cls['UNDECIDABLE']/ctot:.0f}%)\n"
+                f"  => downgradable (NONE+LOCAL): {dg}/{ctot} ({100*dg/ctot:.0f}%)"
+            )
+            if verbose:
+                for pidx, pn, cn, v, r in rows:
+                    print(f"    {pidx:5} {pn[:22]:22}->{cn[:22]:22} {v:11} {r}")
+    else:
+        ops = parse_device_ops(_synthetic_graph())
+        m = analyze(ops)
+        report(ops, m, "SELF-TEST synthetic decoder layer (schema validation, NOT measured)")
+        # assertions on the known structure
+        assert m["n_ops"] == 11, m["n_ops"]
+        assert m["adj_nonraw"] == 1, m["adj_nonraw"]  # only op6(gate)->op7(up)
+        names = [o["name"] for o in ops]
+        i = names.index("matmul_gate")
+        assert not (ops[i]["out_ids"] & ops[i + 1]["in_ids"]), "gate->up should be non-RAW"
+        print("\nSELF-TEST PASSED: analyzer recovers the known dependency structure.")

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/scripts/raw_hazard_analyzer.py
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/scripts/raw_hazard_analyzer.py
@@ -1,0 +1,715 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Analyze a ttnn graph capture for read-after-write (RAW) dependencies between DEVICE PROGRAMS.
+
+Input: JSON produced by ttnn.graph.end_graph_capture_to_file(...) (a list of node dicts).
+Granularity: DEVICE PROGRAMS = leaf function nodes (no nested function_start) that own >=1
+circular_buffer_allocate (CBs are program-scoped). This is the barrier-bounded unit we care about.
+
+Metrics (all at the device-program level; the DAG, not naive execution-order adjacency):
+  - adjacent-RAW %      : does op n+1 read a tensor op n wrote (the no-reorder / today view)
+  - distance-to-first-consumer distribution : for each op output, how many ops until its first
+                          reader (>1 => barrier can overlap that many ops regardless of ordering)
+  - critical path       : longest producer->consumer chain / total ops (independence ceiling)
+"""
+import json
+import re
+import sys
+from bisect import bisect_right
+from collections import defaultdict
+
+
+def parse_device_ops(nodes):
+    """Return ordered list of device-program ops: {counter,name,in_ids(set),out_ids(set)}.
+
+    A device op = an innermost (leaf) function_start/function_end pair that contains >=1
+    circular_buffer_allocate between start and end. tensor identity = params['tensor_id'].
+    """
+    by_counter = {n["counter"]: n for n in nodes}
+
+    # Buffer LIFETIMES: an L1/DRAM address is allocated and freed repeatedly, and the allocator
+    # RECYCLES addresses across unrelated tensors. Keying identity on address ALONE makes a later op
+    # that merely reused an address look like it reads an earlier op's output (a false RAW/dependency),
+    # which corrupts the DAG (any reorder then illegally breaks real chains). Fix: segment each address
+    # by allocation instance -> identity = (address, #buffer_allocate at that address at/before this
+    # tensor's counter). Same address in different lifetimes => different buffers.
+    allocs = {}
+    for n in nodes:
+        if n.get("node_type") == "buffer_allocate":
+            a = (n.get("params") or {}).get("address")
+            if a is not None:
+                allocs.setdefault(a, []).append(n["counter"])
+    for a in allocs:
+        allocs[a].sort()
+
+    def tid(node_counter):
+        # The ttnn API layer re-wraps tensors between device ops so tensor_id changes (producer out=21,
+        # consumer in=22) while the buffer address is preserved -> use (address, lifetime) as the cross-op
+        # identity. Fall back to tensor_id for synthetic graphs with no address (self-test).
+        n = by_counter.get(node_counter)
+        if not (n and n["node_type"] == "tensor"):
+            return None
+        p = n.get("params") or {}
+        a = p.get("address")
+        if a is None:
+            return ("tid", p.get("tensor_id"))
+        return (a, bisect_right(allocs.get(a, []), n["counter"]))
+
+    # Pair function_start with function_end via a stack (counter order).
+    stack, pairs = [], []
+    for n in nodes:
+        if n["node_type"] == "function_start":
+            stack.append(n)
+        elif n["node_type"] == "function_end":
+            if stack:
+                pairs.append((stack.pop(), n))
+
+    # A device operation is the function node carrying tensor I/O: non-empty input_tensors (the ttnn
+    # API wrapper above it has none, and helpers like create_device_tensor have none). This fires per
+    # invocation regardless of program-cache reuse -- unlike circular_buffer_allocate, which a
+    # cache-reused identical op (e.g. the 2nd/3rd of q/k/v) does NOT re-emit.
+    ops = []
+    for fs, fe in pairs:
+        if not fs.get("input_tensors"):
+            continue
+        in_ids = {tid(c) for c in fs.get("input_tensors", [])}
+        out_ids = {tid(c) for c in fe.get("connections", [])}
+        ops.append(
+            {
+                "counter": fs["counter"],
+                "name": (fs.get("params") or {}).get("name", "?"),
+                "in_ids": {x for x in in_ids if x is not None},
+                "out_ids": {x for x in out_ids if x is not None},
+            }
+        )
+    ops.sort(key=lambda o: o["counter"])
+    return ops
+
+
+def analyze(ops):
+    n = len(ops)
+
+    def producer_before(addr, i):  # most-recent prior op that wrote addr (reuse-safe RAW source)
+        p = None
+        for k in range(i):
+            if addr in ops[k]["out_ids"]:
+                p = k
+        return p
+
+    # adjacent RAW: does the immediate next op read anything this op wrote
+    adj_raw = sum(1 for i in range(n - 1) if ops[i]["out_ids"] & ops[i + 1]["in_ids"])
+    # UNRESOLVED boundaries: op_n records NO output (in-place ops -- RoPE rotates Q/K in place,
+    # PagedUpdateCache writes the cache in place -- ttnn graph capture stores no output tensor for
+    # them). We CANNOT confirm op_{n+1} is independent, so these are NOT counted as headroom
+    # (conservative: an op whose output isn't recorded is treated as a possible producer).
+    adj_unresolved = sum(1 for i in range(n - 1) if not ops[i]["out_ids"])
+    adj_nonraw = (n - 1) - adj_raw
+    adj_reorderable = adj_nonraw - adj_unresolved  # non-RAW AND op_n has a recorded output
+
+    # distance to first consumer of each op's output (stop if the buffer is overwritten before any
+    # read -> that write is dead / WAW, not a RAW producer)
+    dists = []
+    for i, op in enumerate(ops):
+        best = None
+        for a in op["out_ids"]:
+            for j in range(i + 1, n):
+                if a in ops[j]["out_ids"] and a not in ops[j]["in_ids"]:
+                    break  # overwritten before read
+                if a in ops[j]["in_ids"]:
+                    d = j - i
+                    best = d if best is None else min(best, d)
+                    break
+        if best is not None:
+            dists.append(best)
+
+    # critical path: longest chain via most-recent-producer edges (ops in program/topo order)
+    depth = [1] * n
+    for i, op in enumerate(ops):
+        for a in op["in_ids"]:
+            p = producer_before(a, i)
+            if p is not None:
+                depth[i] = max(depth[i], depth[p] + 1)
+    return {
+        "n_ops": n,
+        "adj_boundaries": n - 1,
+        "adj_raw": adj_raw,
+        "adj_nonraw": adj_nonraw,
+        "adj_nonraw_pct": 100.0 * adj_nonraw / (n - 1) if n > 1 else 0.0,
+        "adj_reorderable": adj_reorderable,
+        "adj_reorderable_pct": 100.0 * adj_reorderable / (n - 1) if n > 1 else 0.0,
+        "adj_unresolved": adj_unresolved,
+        "dist_hist": {d: dists.count(d) for d in sorted(set(dists))},
+        "dist_gt1_pct": 100.0 * sum(1 for d in dists if d > 1) / len(dists) if dists else 0.0,
+        "critical_path": max(depth) if depth else 0,
+    }
+
+
+def analyze_waw(ops):
+    """Write-after-write between device programs. At buffer granularity a shared output address is
+    EITHER a true WAW (same live buffer written twice: in-place / accumulate / KV-cache slice) OR
+    allocator ADDRESS-REUSE (op A's output freed after its consumer, op B's fresh output recycles the
+    address) OR in-place READ-MODIFY-WRITE (op B reads addr a and writes it back -- really a RAW, not a
+    WAW). Only the first (a genuine overwrite of still-live data with no reader) is a barrier hazard.
+    Split: if addr a is read BETWEEN the two writes (consumed then recycled) OR read BY the second
+    writer itself (in-place RMW), it's NOT a true WAW. CAVEAT: buffer granularity can't see sub-tensor
+    regions, so genuine PARTIAL/slice updates to disjoint regions of one buffer (e.g. KV cache) would
+    also register here -- flagged, not resolved, by this pass."""
+    n = len(ops)
+    writers = defaultdict(list)
+    for i, op in enumerate(ops):
+        for a in op["out_ids"]:
+            writers[a].append(i)
+    collisions = {a: w for a, w in writers.items() if len(w) > 1}
+    adj_waw = sum(1 for i in range(n - 1) if ops[i]["out_ids"] & ops[i + 1]["out_ids"])
+    reuse = overwrite = 0
+    for a, w in collisions.items():
+        for x in range(len(w) - 1):
+            i, j = w[x], w[x + 1]
+            # consumed (allocator-reuse) if read between the writes; RMW (RAW, not WAW) if op j reads a
+            if a in ops[j]["in_ids"] or any(a in ops[k]["in_ids"] for k in range(i + 1, j)):
+                reuse += 1
+            else:
+                overwrite += 1
+    return {
+        "collision_addrs": len(collisions),
+        "waw_pairs": reuse + overwrite,
+        "alloc_reuse": reuse,
+        "true_overwrite": overwrite,
+        "adj_waw": adj_waw,
+    }
+
+
+def report(ops, m, title):
+    print(f"\n=== {title} ===")
+    print(f"device programs: {m['n_ops']}   adjacency boundaries: {m['adj_boundaries']}")
+    print(
+        f"adjacent RAW: {m['adj_raw']}   NON-RAW: {m['adj_nonraw']} ({m['adj_nonraw_pct']:.0f}%) = "
+        f"{m['adj_reorderable']} confirmed-reorderable ({m['adj_reorderable_pct']:.0f}%) "
+        f"+ {m['adj_unresolved']} UNRESOLVED (op_n output not recorded -- in-place)"
+    )
+    print(f"distance-to-first-consumer histogram (ops-until-first-reader): {m['dist_hist']}")
+    print(f"  outputs whose first reader is >1 op away: {m['dist_gt1_pct']:.0f}%")
+    print(
+        f"critical path: {m['critical_path']} of {m['n_ops']} ops  "
+        f"(=> up to {m['n_ops'] - m['critical_path']} ops of slack/independence)"
+    )
+    w = analyze_waw(ops)
+    print(
+        f"WAW: {w['collision_addrs']} shared output addr(s), {w['waw_pairs']} write-pairs "
+        f"-> {w['alloc_reuse']} allocator-reuse (NOT a hazard), {w['true_overwrite']} candidate true-WAW; "
+        f"adjacent WAW {w['adj_waw']}"
+    )
+
+
+def _barrier_ops(nodes):
+    """Parse to (counter, name, ins{addr:(lay,buf,grid)}, outs{...}) -- shared by the locality classifiers."""
+
+    def mc(node):
+        s = (node.get("params") or {}).get("memory_config") if node else None
+        if not s:
+            return (None, None, None)
+        lay = re.search(r"memory_layout=TensorMemoryLayout::(\w+)", s)
+        buf = re.search(r"buffer_type=BufferType::(\w+)", s)
+        grid = re.search(r"grid=(\[.*?\])\s*,\s*shape", s)
+        return (lay.group(1) if lay else None, buf.group(1) if buf else None, grid.group(1) if grid else None)
+
+    byc = {n["counter"]: n for n in nodes}
+
+    def addr(c):
+        n = byc.get(c)
+        p = (n.get("params") or {}) if n else {}
+        return (p.get("address") or p.get("tensor_id")) if n and n["node_type"] == "tensor" else None
+
+    stack, pairs = [], []
+    for n in nodes:
+        if n["node_type"] == "function_start":
+            stack.append(n)
+        elif n["node_type"] == "function_end" and stack:
+            pairs.append((stack.pop(), n))
+    ops = []
+    for fs, fe in pairs:
+        if not fs.get("input_tensors"):
+            continue
+        ins = {addr(c): mc(byc.get(c)) for c in fs.get("input_tensors", []) if addr(c) is not None}
+        outs = {addr(c): mc(byc.get(c)) for c in fe.get("connections", []) if addr(c) is not None}
+        ops.append((fs["counter"], (fs.get("params") or {}).get("name", ""), ins, outs))
+    ops.sort()
+    return ops
+
+
+# --- barrier-strength classifier (signatures validated against kernel source, 2026-07-21) ---
+# Two kinds of downgradable boundary (Paul's taxonomy), keyed on the CONSUMER'S READ of the producer's
+# output -- NOT the op's write-side scatter (a scatter-on-write op like ShardedToInterleaved still READS
+# local, so its input boundary is NONE):
+#   NONE  (Type 1, no barrier)   : producer writes its shard to local L1, consumer reads its own local L1.
+#                                  Same core's SRAM, ordered by that core's kernel sequence -> nothing to sync.
+#   LOCAL (Type 2, write-drain)  : DATA goes through DRAM (write must commit before read-back) BUT no core
+#                                  reads another core's just-written shard -> core c drains only its OWN
+#                                  DRAM writes. Requires DRAM-SHARDED (contiguous per core), NOT interleaved
+#                                  (round-robin across banks = cross). Partition-preservation needs the
+#                                  work-split to confirm -> reported as a Type-2 CANDIDATE.
+#   GLOBAL                       : consumer reads other cores' data (gather/mcast/regrid/reduction/interleaved).
+#
+# Consumer reads only its own L1 shard (VERIFIED from source): binary_ng CB aliased to shard buffer + reader
+# no-op under #if SRC_SHARDED; ShardedToInterleaved reads local shard via globally-allocated input CB
+# (scatters only on write). UnaryNg follows the binary_ng sharded path.
+_LOCAL_READ_OPS = (
+    "binaryng",
+    "binary_ng",
+    "unaryng",
+    "unary_ng",
+    "eltwise",
+    "shardedtointerleaved",
+    "sharded_to_interleaved",
+)
+# Consumer reads OTHER cores' data (VERIFIED: reshard reads remote L1 via runtime (noc_x,noc_y); matmul mcasts
+# in0; InterleavedToSharded reads interleaved DRAM round-robin across banks). concat_heads gathers heads.
+_CROSS_READ_OPS = (
+    "reshard",
+    "halo",
+    "gather",
+    "all_gather",
+    "allgather",
+    "concat_heads",
+    "concatheads",
+    "reduce_scatter",
+    "reducescatter",
+    "all_to_all",
+    "alltoall",
+    "matmul",
+    "sdpa",
+    "scaled_dot_product",
+    "interleavedtosharded",
+    "interleaved_to_sharded",
+)
+_NORM_OPS = ("layernorm", "groupnorm", "rmsnorm", "softmax")  # cross when the reduced dim is width-sharded
+_VIEW_OPS = ("reshape", "reshapeview", "reshape_view")  # view/metadata; may be a no-op -> undecidable
+
+
+def classify_barriers(nodes):
+    """Classify each adjacent RAW boundary by barrier strength: NONE (Type 1, no barrier), LOCAL (Type 2,
+    per-core write-drain), GLOBAL (cross-core), or UNDECIDABLE. Keyed on the CONSUMER'S READ of the shared
+    buffer (see the taxonomy comment above). Returns (rows, summary), rows = [(prod_idx, prod, cons, verdict, reason)].
+    """
+    ops = _barrier_ops(nodes)
+    rows, summary = [], {"NONE": 0, "NONE_no_noc": 0, "LOCAL": 0, "GLOBAL": 0, "UNDECIDABLE": 0}
+    for i in range(len(ops) - 1):
+        shared = set(ops[i][3]) & set(ops[i + 1][2])
+        if not shared:
+            continue
+        a = next(iter(shared))
+        cons = ops[i + 1][1].lower()
+        cn = ops[i + 1][1].split("::")[-1]
+        lay, buf, cons_grid = ops[i + 1][2][a]
+        prod_grid = ops[i][3][a][2]
+        sharded = lay and lay.endswith("SHARDED")
+        if any(k in cons for k in _VIEW_OPS):
+            v, r = "UNDECIDABLE", f"{cn} is a view (may be a no-op; read pattern not modeled)"
+        elif lay == "INTERLEAVED":
+            v, r = "GLOBAL", "reads interleaved (round-robin across banks/cores)"
+        elif prod_grid and cons_grid and prod_grid != cons_grid:
+            v, r = "GLOBAL", f"regrid {prod_grid}->{cons_grid}"
+        elif any(k in cons for k in _CROSS_READ_OPS):
+            v, r = "GLOBAL", f"{cn} reads other cores (gather/mcast)"
+        elif any(k in cons for k in _NORM_OPS) and lay == "WIDTH_SHARDED":
+            v, r = "GLOBAL", f"{cn} reduces across width-sharded dim"
+        elif buf == "DRAM" and sharded:
+            v, r = "LOCAL", f"DRAM-sharded same grid -> Type-2 candidate (needs work-split to confirm partition)"
+        elif buf == "L1" and sharded and any(k in cons for k in _LOCAL_READ_OPS):
+            # sub-label: does the consumer op issue ANY noc_async_read? reader is a no-op only when EVERY
+            # operand is sharded-L1 (CB aliased to the shard buffer); an interleaved/DRAM operand forces a
+            # NoC read. All-sharded-L1 inputs -> data already resident, nothing to fetch (strongest Type-1).
+            ins = list(ops[i + 1][2].values())
+            no_noc = bool(ins) and all(b == "L1" and l and l.endswith("SHARDED") for (l, b, g) in ins)
+            v = "NONE"
+            r = f"{cn} reads only its own L1 shard ({lay})" + (
+                " [zero NoC reads: all inputs sharded-L1, already resident]"
+                if no_noc
+                else " [local shared read; op has other non-sharded inputs -> some NoC read]"
+            )
+            summary["NONE_no_noc"] += no_noc
+        else:
+            v, r = "UNDECIDABLE", f"{cn} read pattern not verified"
+        summary[v] += 1
+        rows.append((ops[i][0], ops[i][1].split("::")[-1], cn, v, r))
+    return rows, summary
+
+
+def shard_locality(nodes):
+    """Bound how many RAW boundaries are cross-core, from tensor shard specs (memory_config).
+
+    IMPORTANT LIMITATION: memory_config gives where a shard RESIDES (its grid), NOT which core READS
+    it. The two differ for gather ops -- e.g. Halo (conv neighbor-exchange) reads border rows from
+    ADJACENT cores while keeping the same residence grid. So a preserved residence grid does NOT prove
+    same-core access; the true access pattern lives in the kernel's NoC addressing / runtime args,
+    which the capture does not expose at the tensor level. Therefore:
+      - CROSS-CORE is RELIABLE where we can see it: DRAM (no worker-core affinity), a residence-grid
+        CHANGE (reshard/regrid), or a known gather/scatter op (Halo, all_gather, concat_heads, ...).
+        Their sum is a LOWER bound on cross-core.
+      - 'residence_preserved_ambiguous' is everything else: an UPPER bound on same-core -- it may still
+        be cross-core (e.g. a width-sharded matmul/norm that reduces across cores). NOT confirmed local.
+    Returns counts dict."""
+
+    def mc(node):
+        s = (node.get("params") or {}).get("memory_config") if node else None
+        if not s:
+            return (None, None, None)
+        lay = re.search(r"memory_layout=TensorMemoryLayout::(\w+)", s)
+        buf = re.search(r"buffer_type=BufferType::(\w+)", s)
+        grid = re.search(r"grid=(\[.*?\])\s*,\s*shape", s)
+        return (lay.group(1) if lay else None, buf.group(1) if buf else None, grid.group(1) if grid else None)
+
+    byc = {n["counter"]: n for n in nodes}
+
+    def addr(c):
+        n = byc.get(c)
+        p = (n.get("params") or {}) if n else {}
+        return (p.get("address") or p.get("tensor_id")) if n and n["node_type"] == "tensor" else None
+
+    stack, pairs = [], []
+    for n in nodes:
+        if n["node_type"] == "function_start":
+            stack.append(n)
+        elif n["node_type"] == "function_end" and stack:
+            pairs.append((stack.pop(), n))
+    ops = []
+    for fs, fe in pairs:
+        if not fs.get("input_tensors"):
+            continue
+        ins = {addr(c): mc(byc.get(c)) for c in fs.get("input_tensors", []) if addr(c) is not None}
+        outs = {addr(c): mc(byc.get(c)) for c in fe.get("connections", []) if addr(c) is not None}
+        ops.append((fs["counter"], (fs.get("params") or {}).get("name", ""), ins, outs))
+    ops.sort()
+    # ops that read cross-core even when the residence grid is preserved (gather/scatter)
+    GATHER = (
+        "halo",
+        "gather",
+        "all_gather",
+        "allgather",
+        "concat_heads",
+        "concatheads",
+        "create_qkv",
+        "createqkv",
+        "reduce_scatter",
+        "reducescatter",
+        "all_to_all",
+        "alltoall",
+    )
+    cats = {"residence_preserved_ambiguous": 0, "cross_DRAM": 0, "cross_regrid": 0, "cross_known_gather": 0}
+    for i in range(len(ops) - 1):
+        shared = set(ops[i][3]) & set(ops[i + 1][2])  # producer outs ∩ consumer ins
+        if not shared:
+            continue
+        a = next(iter(shared))
+        name = ops[i + 1][1].lower()
+        lay, buf, grid = ops[i + 1][2][a]  # consumed buffer's layout/buffer/grid
+        out_grids = {g for (_, _, g) in ops[i + 1][3].values() if g}
+        if any(k in name for k in GATHER):
+            cats["cross_known_gather"] += 1
+        elif buf == "DRAM":
+            cats["cross_DRAM"] += 1
+        elif buf == "L1" and lay and lay.endswith("SHARDED") and grid and out_grids == {grid}:
+            cats["residence_preserved_ambiguous"] += 1
+        else:
+            cats["cross_regrid"] += 1
+    return cats
+
+
+# ---- self-test: synthetic Llama-style decoder layer with KNOWN dependencies ----
+def _synthetic_graph():
+    """Hand-built graph in the ttnn schema. Decoder layer at device-program granularity:
+    0 rmsnorm(x)->h1  1 qkv(h1)->qkv  2 attn(qkv)->attn  3 o_proj(attn)->o  4 add(x,o)->r1
+    5 rmsnorm(r1)->h2  6 gate(h2)->g  7 up(h2)->u  8 silu_mul(g,u)->gu  9 down(gu)->d  10 add(r1,d)->r2
+    KEY: op7(up) reads h2 (op5's out), NOT op6's out -> op6->op7 is the one NON-RAW adjacency.
+    """
+    T = {}  # tensor_id -> node counter
+    nodes = [{"counter": 0, "node_type": "capture_start", "params": {}, "connections": [], "input_tensors": []}]
+    c = [1]
+
+    def tensor(tid):
+        node = {"counter": c[0], "node_type": "tensor", "params": {"tensor_id": str(tid)}, "connections": []}
+        nodes.append(node)
+        T[tid] = c[0]
+        c[0] += 1
+        return T[tid]
+
+    tensor(0)  # x (external embedding input)
+
+    def op(name, in_tids, out_tid):
+        fs = {
+            "counter": c[0],
+            "node_type": "function_start",
+            "params": {"name": name},
+            "input_tensors": [T[t] for t in in_tids],
+            "connections": [],
+        }
+        nodes.append(fs)
+        c[0] += 1
+        nodes.append({"counter": c[0], "node_type": "circular_buffer_allocate", "params": {}, "connections": []})
+        c[0] += 1
+        ot = tensor(out_tid)
+        fe = {"counter": c[0], "node_type": "function_end", "params": {"name": name}, "connections": [ot]}
+        nodes.append(fe)
+        c[0] += 1
+
+    op("rmsnorm", [0], 1)  # h1
+    op("matmul_qkv", [1], 2)  # qkv
+    op("attention", [2], 3)  # attn
+    op("matmul_o", [3], 4)  # o
+    op("add_residual", [0, 4], 5)  # r1 = x + o
+    op("rmsnorm", [5], 6)  # h2
+    op("matmul_gate", [6], 7)  # g
+    op("matmul_up", [6], 8)  # u   <-- reads h2 (op5), independent of op6 => NON-RAW adjacency
+    op("silu_mul", [7, 8], 9)  # gu
+    op("matmul_down", [9], 10)  # d
+    op("add_residual", [5, 10], 11)  # r2 = r1 + d
+    return nodes
+
+
+def infer_attention_edges(ops):
+    """create-heads -> SDPA/softmax edges the capture drops. NLPCreateHeads emits NO output tensor, so
+    the SDPA that consumes its Q/K/V heads shows up producerless (a false root). Attention is emitted as
+    [q/k/v proj ...][create-heads ...] SDPA, so each attention core (SDPA or explicit softmax) depends on
+    the create-heads ops since the previous core. Returns [(create_heads_idx, core_idx)] pairs.
+    """
+    pairs, pending = [], []
+    for i, o in enumerate(ops):
+        nm = o["name"].lower()
+        if "create" in nm and "head" in nm:
+            pending.append(i)
+        elif "sdpa" in nm or "scaled_dot_product" in nm or "softmax" in nm:
+            pairs.extend((p, i) for p in pending)
+            pending = []
+    return pairs
+
+
+def apply_resolutions(ops, resolve_inplace=False, add_edges=(), infer_attention=None):
+    """Reconnect dependency edges the buffer-address capture cannot see (opt-in, conservative).
+
+    resolve_inplace: an op with NO recorded output is an in-place RMW (e.g. RotaryEmbedding rotates Q,
+      PagedFusedUpdateCache writes the KV cache) -- it mutates its input buffer(s). Treat its inputs AS
+      its outputs so a downstream consumer of those buffers depends on it (and it on the prior writer).
+      Only ADDS edges, so it can only lengthen the critical path (never fabricate slack).
+    infer_attention: also add create-heads->SDPA edges (see infer_attention_edges). Defaults to
+      resolve_inplace, so --resolve-inplace stops drawing SDPAs as false roots.
+    add_edges: [(producer_idx, consumer_idx)] semantic deps known real but invisible in the capture --
+      e.g. a reshape VIEW whose output drops its buffer address (tensor-id fallback) so producer and
+      consumer tids differ. Injected via a synthetic shared address; each is an explicit, auditable claim.
+    """
+    if infer_attention is None:
+        infer_attention = resolve_inplace
+    if resolve_inplace:
+        for o in ops:
+            if not o["out_ids"]:
+                o["out_ids"] = set(o["in_ids"])
+    edges = list(add_edges) + (infer_attention_edges(ops) if infer_attention else [])
+    for p, c in edges:
+        tag = f"__edge_{p}_{c}"
+        ops[p]["out_ids"].add(tag)
+        ops[c]["in_ids"].add(tag)
+    return ops
+
+
+# --- op-to-op improvability escalation (dispatch/boundary level) ---
+# data-dependent ADDRESSING only (the not-addressable floor). NOT topk/sampling/moe (dense output, only
+# data-dependent VALUES) and NOT all_gather/reduce_scatter/all_reduce (static-schedule collectives).
+_CAND_DYNAMIC = (
+    "sdpa",
+    "scaleddotproduct",
+    "paged",
+    "updatecache",
+    "embedding",
+    "alltoall",
+    "all_to_all",
+    "dispatch",
+    "remap",
+)
+_CAND_ITERATOR = (
+    "add",
+    "mul",
+    "sub",
+    "binary",
+    "silu",
+    "unary",
+    "gelu",
+    "sigmoid",
+    "exp",
+    "reshard",
+    "interleaved",
+    "sharded",
+    "transpose",
+    "rotary",
+    "copy",
+    "concat",
+    "tilize",
+    "pad",
+    "permute",
+    "fill",
+    "move",
+)
+
+
+def _candidacy(name):
+    n = name.lower()
+    if "rotary" in n:  # rotary_embedding is affine (cos/sin tables), NOT a gather -- guard vs 'embedding'
+        return "Y"
+    if any(k in n for k in _CAND_DYNAMIC):
+        return "N"  # data-dependent addressing -> not canned-iterator-able (the floor)
+    if any(k in n for k in _CAND_ITERATOR):
+        return "Y"  # affine, already a canned std-iterator kernel
+    return "P"  # matmul/norm/topk/moe/CCL: affine addressing + static counts, needs a richer iterator
+
+
+def escalation(nodes):
+    """Disjoint precedence partition of op-to-op boundaries into an improvability escalation (reorder LAST):
+    1 RAW-free (no reorder) · 2 no-global-barrier (local) · 3 std-iterator Y-Y · 4 reschedulable
+    (reorder separates the pair) -> RAW-IMPROVABLE = 1..4. Then "hard" splits into 5 affine-hard (a
+    richer iterator could handle the affine addressing) vs 6 not-addressable (dynamic addressing = the
+    fundamental floor). Producer records no output (in-place RoPE/cache) -> 0 unresolved (excluded)."""
+    ops = parse_device_ops(nodes)
+    n = len(ops)
+    B = n - 1
+    rows, _ = classify_barriers(nodes)
+    bm = {}
+    for pidx, pn, cn, v, r in rows:
+        bm.setdefault((pn, cn), v)
+    parents = [set() for _ in range(n)]
+    for i in range(n):
+        for a in ops[i]["in_ids"]:
+            for j in range(i - 1, -1, -1):
+                if a in ops[j]["out_ids"]:
+                    parents[i].add(j)
+                    break
+    children = [set() for _ in range(n)]
+    for i in range(n):
+        for p in parents[i]:
+            children[p].add(i)
+    ind = [len(parents[i]) for i in range(n)]
+    ready = {i for i in range(n) if ind[i] == 0}
+    order, last = [], None
+    while ready:  # greedy topological reorder minimizing adjacent-RAW (unconstrained -> optimistic ceiling)
+        pick = None
+        for c in sorted(ready):
+            if last is None or not (ops[last]["out_ids"] & ops[c]["in_ids"]):
+                pick = c
+                break
+        if pick is None:
+            pick = min(ready)
+        ready.discard(pick)
+        order.append(pick)
+        last = pick
+        for ch in children[pick]:
+            ind[ch] -= 1
+            if ind[ch] == 0:
+                ready.add(ch)
+    pos = {o: k for k, o in enumerate(order)}
+    C = [_candidacy(o["name"]) for o in ops]
+    keys = [
+        "0 unresolved",
+        "1 rawfree",
+        "2 no-global-barrier",
+        "3 std-iter",
+        "4 reschedulable",
+        "5 affine-hard",
+        "6 not-addressable",
+    ]
+    b = dict.fromkeys(keys, 0)
+    for i in range(B):
+        p = ops[i]
+        if not p["out_ids"]:
+            b["0 unresolved"] += 1
+        elif not (p["out_ids"] & ops[i + 1]["in_ids"]):
+            b["1 rawfree"] += 1
+        elif bm.get((p["name"], ops[i + 1]["name"]), "") in ("NONE", "LOCAL"):
+            b["2 no-global-barrier"] += 1
+        elif C[i] == "Y" and C[i + 1] == "Y":
+            b["3 std-iter"] += 1
+        elif pos[i + 1] != pos[i] + 1:
+            b["4 reschedulable"] += 1
+        elif C[i] == "N" or C[i + 1] == "N":
+            b["6 not-addressable"] += 1
+        else:
+            b["5 affine-hard"] += 1
+    return {"n_ops": n, "boundaries": B, "buckets": b, "improvable": sum(b[k] for k in keys[1:5])}
+
+
+def report_escalation(nodes, title):
+    m = escalation(nodes)
+    B = m["boundaries"] or 1
+    print(f"\n=== ESCALATION: {title} ===")
+    print(f"device programs: {m['n_ops']}   boundaries: {m['boundaries']}")
+    for k in sorted(m["buckets"]):
+        v = m["buckets"][k]
+        print(f"  {k:22} {v:5}/{B} ({100 * v / B:.0f}%)")
+    print(
+        f"  => RAW-IMPROVABLE (1..4): {m['improvable']}/{B} ({100 * m['improvable'] / B:.0f}%)  "
+        f"| affine-hard {100 * m['buckets']['5 affine-hard'] / B:.0f}% | "
+        f"not-addressable(floor) {100 * m['buckets']['6 not-addressable'] / B:.0f}%"
+    )
+
+
+if __name__ == "__main__":
+    argv = sys.argv[1:]
+    resolve_inplace = "--resolve-inplace" in argv
+    verbose = "--classify-verbose" in argv
+    escalate = "--escalation" in argv
+    add_edges, files, i = [], [], 0
+    while i < len(argv):
+        if argv[i] == "--add-edge":
+            i += 1
+            p, c = argv[i].split(":")
+            add_edges.append((int(p), int(c)))
+        elif argv[i] not in ("--resolve-inplace", "--classify-verbose", "--escalation"):
+            files.append(argv[i])
+        i += 1
+    if files and files[0] != "--self-test":
+        nodes = json.load(open(files[0]))
+        if escalate:
+            report_escalation(nodes, files[0])
+            sys.exit(0)
+        ops = parse_device_ops(nodes)
+        apply_resolutions(ops, resolve_inplace, add_edges)
+        tags = [t for t, on in (("resolve-inplace", resolve_inplace), (f"add-edge {add_edges}", bool(add_edges))) if on]
+        report(ops, analyze(ops), f"capture: {files[0]}" + (f"  [{'; '.join(tags)}]" if tags else ""))
+        s = shard_locality(nodes)
+        tot = sum(s.values())
+        if tot:
+            xcore = s["cross_DRAM"] + s["cross_regrid"] + s["cross_known_gather"]
+            amb = s["residence_preserved_ambiguous"]
+            print(
+                f"RAW-boundary shard locality (residence != access -- see docstring):\n"
+                f"  cross-core >= {xcore}/{tot} ({100*xcore/tot:.0f}%, RELIABLE floor: "
+                f"{s['cross_DRAM']} DRAM + {s['cross_regrid']} regrid + {s['cross_known_gather']} known-gather)\n"
+                f"  same-core <= {amb}/{tot} ({100*amb/tot:.0f}%, residence-preserved but NOT confirmed local "
+                f"-- kernel read pattern not visible in the capture)"
+            )
+        rows, cls = classify_barriers(nodes)
+        ctot = cls["NONE"] + cls["LOCAL"] + cls["GLOBAL"] + cls["UNDECIDABLE"]  # NONE_no_noc is a NONE subset
+        if ctot:
+            dg = cls["NONE"] + cls["LOCAL"]
+            nn = cls["NONE_no_noc"]
+            print(
+                f"\nBarrier strength over adjacent-RAW boundaries (keyed on consumer read; signatures validated "
+                f"vs kernel source):\n"
+                f"  NONE        {cls['NONE']:4}/{ctot} ({100*cls['NONE']/ctot:.0f}%)  Type 1: local L1->L1, no barrier\n"
+                f"     of which  {nn:4}      zero NoC reads (all inputs sharded-L1, already resident)\n"
+                f"  LOCAL       {cls['LOCAL']:4}/{ctot} ({100*cls['LOCAL']/ctot:.0f}%)  Type 2: DRAM-sharded, per-core write-drain (candidate, needs work-split)\n"
+                f"  GLOBAL      {cls['GLOBAL']:4}/{ctot} ({100*cls['GLOBAL']/ctot:.0f}%)  cross-core read\n"
+                f"  UNDECIDABLE {cls['UNDECIDABLE']:4}/{ctot} ({100*cls['UNDECIDABLE']/ctot:.0f}%)\n"
+                f"  => downgradable (NONE+LOCAL): {dg}/{ctot} ({100*dg/ctot:.0f}%)"
+            )
+            if verbose:
+                for pidx, pn, cn, v, r in rows:
+                    print(f"    {pidx:5} {pn[:22]:22}->{cn[:22]:22} {v:11} {r}")
+    else:
+        ops = parse_device_ops(_synthetic_graph())
+        m = analyze(ops)
+        report(ops, m, "SELF-TEST synthetic decoder layer (schema validation, NOT measured)")
+        # assertions on the known structure
+        assert m["n_ops"] == 11, m["n_ops"]
+        assert m["adj_nonraw"] == 1, m["adj_nonraw"]  # only op6(gate)->op7(up)
+        names = [o["name"] for o in ops]
+        i = names.index("matmul_gate")
+        assert not (ops[i]["out_ids"] & ops[i + 1]["in_ids"]), "gate->up should be non-RAW"
+        print("\nSELF-TEST PASSED: analyzer recovers the known dependency structure.")

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/scripts/run_bw_vs_cores.sh
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/scripts/run_bw_vs_cores.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Canonical sweep 2/6: aggregate BW + done-skew + starvation vs core count.
+# Full read+write op by default; set READ_ONLY=1 for the read-only variant (writer just pops
+# the CB, no DRAM writes -> isolates read BW and read-side completion skew).
+# Good NoCs (reader=NOC0, writer=NOC1), row-major fill, lean compute, trace warmup.
+# Per core count picks the input-CB depth maximizing agg_read (read-only) / agg_total (full-op).
+# Records: cores,in_cb,agg_read_gbps,agg_write_gbps,agg_total_gbps,
+#          reader_done_spread_us,writer_done_spread_us,starvation_ratio.
+#
+# Env: READ_ONLY (0/1), CORES, INPUT_DEPTHS, N (trid), PAGES, OUT, OUTDIR.
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+export TT_METAL_HOME="${TT_METAL_HOME:-$(cd "${SCRIPT_DIR}/../../../../../.." && pwd)}"
+export TT_METAL_DEVICE_PROFILER=1
+cd "${TT_METAL_HOME}" || exit 1  # binary detects root from cwd, not env -> must run from repo root
+BIN="${TT_METAL_HOME}/build_RelWithDebInfo/test/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency"
+PY="${TT_METAL_HOME}/python_env/bin/python3"
+DEC="${SCRIPT_DIR}/decompose_latency_bw.py"
+DEV_CSV="${TT_METAL_HOME}/generated/profiler/.logs/profile_log_device.csv"
+OUTDIR="${OUTDIR:-${TT_METAL_HOME}/generated/profiler/op_to_op_runs/stage_a}"
+READ_ONLY="${READ_ONLY:-0}"
+DEFAULT_OUT="bw_vs_cores.csv"; [ "${READ_ONLY}" = "1" ] && DEFAULT_OUT="bw_vs_cores_readonly.csv"
+OUT="${OUT:-${OUTDIR}/${DEFAULT_OUT}}"
+mkdir -p "${OUTDIR}"
+
+INPUT_DEPTHS="${INPUT_DEPTHS:-16 32}"
+N="${N:-8}"
+CORES="${CORES:-1 2 4 8 16 24 32 40 48 56}"
+# Fixed-TOTAL (data-parallel) work model, matching run_stage_a_sweep.sh: a real op shards a
+# fixed-size tensor across the grid, so pages_per_core = TOTAL_PAGES / cores (recomputed per core
+# count below). This keeps execution duration realistic instead of weak-scaling total work with
+# cores. NOTE: at high core counts the small shard pays a ~5% pipeline fill/drain tax on aggregate
+# BW (56c: ~205 vs ~215 GB/s at a large shard) -- that IS the realistic sharded-op number.
+# Set PAGES=<n> to force the legacy fixed-per-core model instead.
+TOTAL_PAGES="${TOTAL_PAGES:-3584}"
+MIN_PAGES_PER_CORE="${MIN_PAGES_PER_CORE:-8}"
+PAGES_OVERRIDE="${PAGES:-}"
+# read-only skips output validation natively; full-op uses dummy strided reads -> skip it too.
+# Rank in-CB tuning on overall_bw_gbps (total bytes / kernel envelope) -- the honest end-to-end
+# throughput incl. the straggler tail -- NOT the union-span agg_* (steady/peak rate).
+if [ "${READ_ONLY}" = "1" ]; then MODE_FLAGS="--read-only"; DIRN=1; else MODE_FLAGS="--skip-output-validation"; DIRN=2; fi
+RANK="overall_bw_gbps"
+
+echo "cores,pages,in_cb,overall_bw_gbps,agg_read_gbps,agg_write_gbps,agg_total_gbps,kernel_envelope_us,reader_done_spread_us,writer_done_spread_us,starvation_ratio" > "${OUT}"
+
+for cores in ${CORES}; do
+  if [ -n "${PAGES_OVERRIDE}" ]; then PAGES="${PAGES_OVERRIDE}"; else
+    PAGES=$(( TOTAL_PAGES / cores )); (( PAGES < MIN_PAGES_PER_CORE )) && PAGES=${MIN_PAGES_PER_CORE}; fi
+  best=0; best_line=""
+  for d in ${INPUT_DEPTHS}; do
+    rm -f "${DEV_CSV}"
+    "${BIN}" ${MODE_FLAGS} --lean-compute --reader-noc 0 --writer-noc 1 \
+      --reader-dbuf-trid --reader-trid-in-flight "${N}" --reader-push-tiles 2 \
+      --input-cb-depth-tiles "${d}" --output-cb-depth-tiles 2 \
+      --num-pages-per-core "${PAGES}" --num-programs 2 --compute-nops 0 \
+      --use-trace --trace-warmup-replays 1 --num-active-cores "${cores}" --use-device-profiler \
+      >/tmp/bwvc_run.log 2>&1
+    grep -q PASSED /tmp/bwvc_run.log || continue
+    read -r ob rb wb tb env rds wds st rank < <("${PY}" "${DEC}" --pages-per-core "${PAGES}" --num-cores "${cores}" --directions "${DIRN}" 2>/dev/null | awk -v rk="${RANK}" '
+      /overall_bw_gbps/{o=$2} /agg_read_gbps/{r=$2} /agg_write_gbps/{w=$2} /agg_total_gbps/{t=$2}
+      /kernel_envelope_us/{e=$2} /reader_done_spread_us/{rd=$2} /writer_done_spread_us/{wd=$2} /starvation_ratio/{s=$2}
+      $1==rk{rv=$2} END{print o, r, w, t, e, rd, wd, s, rv}')
+    awk -v a="${rank:-0}" -v b="${best}" 'BEGIN{exit !(a>b)}' && {
+      best="${rank}"; best_line="${cores},${PAGES},${d},${ob},${rb},${wb},${tb},${env},${rds},${wds},${st}"; }
+  done
+  [ -n "${best_line}" ] && { echo "${best_line}" >> "${OUT}"; echo "${best_line}"; } \
+    || echo "cores=${cores} FAILED (no PASSED run)"
+done
+echo "BW_VS_CORES_COMPLETE (read_only=${READ_ONLY}) -> ${OUT}"

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/scripts/run_bw_vs_trid_cores.sh
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/scripts/run_bw_vs_trid_cores.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Canonical sweep 5/6: aggregate BW vs read txns in flight (N) for various core counts.
+# READ-ONLY (writer just pops the CB; no DRAM writes) so this isolates the read path and the
+# read BW tops out at the full ~210 GB/s read ceiling (not ~100, which is the read half of a
+# read+write op where the two share DRAM). Good NoCs, lean compute, trace. CB held FIXED+DEEP so
+# N is the only variable (decoupled from the cb_reserve_back run-ahead axis). Shows the knee N
+# (smallest N that saturates BW) and whether it shifts with core count (BW-unsaturated at low
+# core counts vs saturated at high). For the latency-vs-N x cb cross, use run_lat_vs_trid_cb.sh.
+# Records: cores,N,actual_gbps,fair_gbps,starvation_ratio.
+#   actual_gbps = aggregate read BW (union-span based, dragged down by the slow-core tail).
+#   fair_gbps   = cores * per-core-median read BW = the "no-skew" projection (what aggregate
+#                 would be if every core ran at the median rate). actual < fair => skew tax.
+#
+# Env: CORES_LIST, N_LIST, IN_CB, OUT_CB, PAGES, OUT, OUTDIR.
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+export TT_METAL_HOME="${TT_METAL_HOME:-$(cd "${SCRIPT_DIR}/../../../../../.." && pwd)}"
+export TT_METAL_DEVICE_PROFILER=1
+cd "${TT_METAL_HOME}" || exit 1  # binary detects root from cwd, not env -> must run from repo root
+BIN="${TT_METAL_HOME}/build_RelWithDebInfo/test/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency"
+PY="${TT_METAL_HOME}/python_env/bin/python3"
+DEC="${SCRIPT_DIR}/decompose_latency_bw.py"
+DEV_CSV="${TT_METAL_HOME}/generated/profiler/.logs/profile_log_device.csv"
+OUTDIR="${OUTDIR:-${TT_METAL_HOME}/generated/profiler/op_to_op_runs/stage_a}"
+OUT="${OUT:-${OUTDIR}/bw_vs_trid_cores.csv}"
+mkdir -p "${OUTDIR}"
+
+IN_CB="${IN_CB:-64}"          # fixed + deep (>= 2*max N) to decouple from N
+OUT_CB="${OUT_CB:-8}"
+CORES_LIST="${CORES_LIST:-1 8 16 32 56}"
+N_LIST="${N_LIST:-2 3 4 6 8 12 16 24 32}"
+# Fixed-TOTAL (data-parallel) work model, matching run_stage_a_sweep.sh: pages_per_core =
+# TOTAL_PAGES / cores (recomputed per core count). NOTE: small shards at high core count pay a
+# ~5% pipeline fill/drain tax on aggregate BW -- the realistic sharded-op number. Set PAGES=<n>
+# to force the legacy fixed-per-core model.
+TOTAL_PAGES="${TOTAL_PAGES:-3584}"
+MIN_PAGES_PER_CORE="${MIN_PAGES_PER_CORE:-8}"
+PAGES_OVERRIDE="${PAGES:-}"
+
+echo "cores,pages,N,actual_gbps,fair_gbps,starvation_ratio" > "${OUT}"
+for C in ${CORES_LIST}; do
+  if [ -n "${PAGES_OVERRIDE}" ]; then PAGES="${PAGES_OVERRIDE}"; else
+    PAGES=$(( TOTAL_PAGES / C )); (( PAGES < MIN_PAGES_PER_CORE )) && PAGES=${MIN_PAGES_PER_CORE}; fi
+  for N in ${N_LIST}; do
+    if [ "${IN_CB}" -lt $((2 * N)) ]; then continue; fi
+    rm -f "${DEV_CSV}"
+    "${BIN}" --read-only --lean-compute --reader-noc 0 --writer-noc 1 \
+      --reader-dbuf-trid --reader-trid-in-flight "${N}" --reader-push-tiles 2 \
+      --input-cb-depth-tiles "${IN_CB}" --output-cb-depth-tiles "${OUT_CB}" \
+      --num-pages-per-core "${PAGES}" --num-programs 2 --compute-nops 0 \
+      --use-trace --trace-warmup-replays 1 --num-active-cores "${C}" --use-device-profiler \
+      >/tmp/bwtc_run.log 2>&1
+    grep -q PASSED /tmp/bwtc_run.log || { echo "cores=${C} N=${N} FAILED"; continue; }
+    # actual = aggregate read BW; fair = cores * per-core-median read BW (no-skew projection)
+    line=$("${PY}" "${DEC}" --pages-per-core "${PAGES}" --num-cores "${C}" 2>/dev/null | awk -v c="${C}" -v n="${N}" -v pg="${PAGES}" '
+      /agg_read_gbps/{r=$2} /per_core_gbps_median/{p=$2} /starvation_ratio/{s=$2}
+      END{printf "%s,%s,%s,%.3f,%.3f,%s", c, pg, n, r, c*p, s}')
+    echo "${line}" >> "${OUT}"; echo "${line}"
+  done
+done
+echo "BW_VS_TRID_CORES_COMPLETE -> ${OUT}"

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/scripts/run_io_latency.sh
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/scripts/run_io_latency.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Canonical sweep 4/6: two-sided I/O latency decomposition.
+#  (A) READ side -- read-fill latency vs read txns in flight (N) at cores {8,56}:
+#        read_fill_head_us = first read issued (READ_BEFORE_BARRIER) -> first math (UNPACK tile0).
+#        Larger N => larger first in-flight batch must complete before the first CB push, so the
+#        read-fill head grows with N. Output CB held fixed. Always full reads.
+#  (B) WRITE side -- write metrics vs OUTPUT CB depth at cores {8,56}, in two regimes (MODES):
+#        full  -> full read+write op = READ-BOUND baseline. Output CB barely matters (the read side
+#                throttles, the CB never fills): agg ~flat, write_drain ~flat in out_cb.
+#        wonly -> --write-only (reader issues NO NoC read, compute bypassed) = pure write path.
+#                The writer is the only DRAM traffic, so output CB depth is the whole story:
+#                agg_write vs depth is the flush-cadence curve. NB agg_read is meaningless here
+#                (the READ_BEFORE->READ_LAST span is just CB pushes) -- read agg_write and the
+#                write-side skew metrics instead.
+#        write_drain_us = LAST write issued -> write barrier complete; ~flat in out_cb in BOTH
+#                regimes (the per-core final drain is small). write_tail = whole write phase.
+#        Input CB + N held fixed.
+#  Good NoCs (reader=NOC0/writer=NOC1), lean compute (nops=0), trace. in_cb=64 (>= 2*N for N<=32).
+# Records CSVs:
+#   read_lat_vs_n.csv               : cores,pages,N,read_fill_head_us,m2m_bubble_us,official_op2op_min_us,agg_total_gbps
+#   write_lat_vs_outcb.csv          : (full)  cores,pages,out_cb,mode,agg_write_gbps,write_drain_us,writer_done_spread_us,write_tail_us,starvation_ratio
+#   write_lat_vs_outcb_writeonly.csv: (wonly) same columns, pure write path
+#
+# Env: CORES_LIST, N_LIST, OUTCB_LIST, MODES, IN_CB, OUT_CB_FIXED, N_FIXED, TOTAL_PAGES,
+#      MIN_PAGES_PER_CORE, PAGES (override -> fixed-per-core), OUTDIR.
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+export TT_METAL_HOME="${TT_METAL_HOME:-$(cd "${SCRIPT_DIR}/../../../../../.." && pwd)}"
+export TT_METAL_DEVICE_PROFILER=1
+cd "${TT_METAL_HOME}" || exit 1  # binary detects root from cwd, not env -> must run from repo root
+BIN="${TT_METAL_HOME}/build_RelWithDebInfo/test/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency"
+PY="${TT_METAL_HOME}/python_env/bin/python3"
+DEC="${SCRIPT_DIR}/decompose_latency_bw.py"
+DEV_CSV="${TT_METAL_HOME}/generated/profiler/.logs/profile_log_device.csv"
+OUTDIR="${OUTDIR:-${TT_METAL_HOME}/generated/profiler/op_to_op_runs/stage_a}"
+mkdir -p "${OUTDIR}"
+
+CORES_LIST="${CORES_LIST:-8 56}"
+N_LIST="${N_LIST:-2 4 8 16 32}"
+OUTCB_LIST="${OUTCB_LIST:-2 4 8 16 32}"
+MODES="${MODES:-full wonly}"   # full = read+write op (read-bound); wonly = --write-only (pure write)
+IN_CB="${IN_CB:-64}"
+OUT_CB_FIXED="${OUT_CB_FIXED:-8}"   # output CB during the read-side (N) sweep
+N_FIXED="${N_FIXED:-8}"             # trid during the write-side (out_cb) sweep
+# Fixed-TOTAL (data-parallel) work model, matching run_stage_a_sweep.sh: PAGES = TOTAL_PAGES /
+# cores, set per core count by set_pages() below. Set PAGES=<n> to force fixed-per-core.
+TOTAL_PAGES="${TOTAL_PAGES:-3584}"
+MIN_PAGES_PER_CORE="${MIN_PAGES_PER_CORE:-8}"
+PAGES_OVERRIDE="${PAGES:-}"
+PAGES=1024  # placeholder; set_pages() overwrites per core count
+set_pages() { # cores
+  if [ -n "${PAGES_OVERRIDE}" ]; then PAGES="${PAGES_OVERRIDE}"; else
+    PAGES=$(( TOTAL_PAGES / $1 )); (( PAGES < MIN_PAGES_PER_CORE )) && PAGES=${MIN_PAGES_PER_CORE}; fi
+}
+
+run() { # N in_cb out_cb cores [mode=full|wonly] -> leaves DEV_CSV
+  local mode="${5:-full}" mode_flags="--lean-compute"
+  [ "${mode}" = "wonly" ] && mode_flags="--write-only"
+  rm -f "${DEV_CSV}"
+  # shellcheck disable=SC2086
+  "${BIN}" ${mode_flags} --reader-noc 0 --writer-noc 1 \
+    --reader-dbuf-trid --reader-trid-in-flight "$1" --reader-push-tiles 2 \
+    --input-cb-depth-tiles "$2" --output-cb-depth-tiles "$3" \
+    --num-pages-per-core "${PAGES}" --num-programs 4 --compute-nops 0 \
+    --use-trace --trace-warmup-replays 1 --num-active-cores "$4" --use-device-profiler \
+    >/tmp/iolat_run.log 2>&1
+  grep -q PASSED /tmp/iolat_run.log
+}
+# prints: read_fill m2m op2op write_drain write_tail agg_total agg_write writer_spread starvation
+fields() {
+  "${PY}" "${DEC}" --pages-per-core "${PAGES}" --num-cores "$1" 2>/dev/null | awk '
+    $1=="read_fill_head_us"{rf=$2} $1=="m2m_bubble_us"{m=$2} $1=="official_op2op_min_us"{o=$2}
+    $1=="write_drain_us"{wd=$2} $1=="write_tail_us"{wt=$2} $1=="agg_total_gbps"{at=$2}
+    $1=="agg_write_gbps"{aw=$2} $1=="writer_done_spread_us"{ws=$2} $1=="starvation_ratio"{s=$2}
+    END{print rf, m, o, wd, wt, at, aw, ws, s}'
+}
+
+# (A) read-fill latency vs N -- always full reads.
+A="${OUTDIR}/read_lat_vs_n.csv"
+echo "cores,pages,N,read_fill_head_us,m2m_bubble_us,official_op2op_min_us,agg_total_gbps" > "${A}"
+echo "==== (A) read-fill latency vs N (in_cb=${IN_CB}, out_cb=${OUT_CB_FIXED}) ===="
+for C in ${CORES_LIST}; do
+  set_pages "${C}"
+  for N in ${N_LIST}; do
+    [ "${IN_CB}" -lt $((2 * N)) ] && { echo "cores=${C} N=${N} SKIP (in_cb<2N)"; continue; }
+    if run "${N}" "${IN_CB}" "${OUT_CB_FIXED}" "${C}" full; then
+      read -r rf m o wd wt at aw ws s < <(fields "${C}")
+      echo "${C},${PAGES},${N},${rf},${m},${o},${at}" | tee -a "${A}"
+    else echo "cores=${C} N=${N} FAILED"; fi
+  done
+done
+
+# (B) write metrics vs output CB depth -- once per read-bytes regime.
+echo "==== (B) write metrics vs output CB depth (in_cb=${IN_CB}, N=${N_FIXED}) ===="
+for MODE in ${MODES}; do
+  if [ "${MODE}" = "wonly" ]; then B="${OUTDIR}/write_lat_vs_outcb_writeonly.csv"; tag="--write-only (pure write path)";
+  else                             B="${OUTDIR}/write_lat_vs_outcb.csv";           tag="full read+write (read-bound)"; fi
+  echo "  -- regime: ${tag} -> ${B}"
+  echo "cores,pages,out_cb,mode,agg_write_gbps,write_drain_us,writer_done_spread_us,write_tail_us,starvation_ratio" > "${B}"
+  for C in ${CORES_LIST}; do
+    set_pages "${C}"
+    for OC in ${OUTCB_LIST}; do
+      if run "${N_FIXED}" "${IN_CB}" "${OC}" "${C}" "${MODE}"; then
+        read -r rf m o wd wt at aw ws s < <(fields "${C}")
+        echo "${C},${PAGES},${OC},${MODE},${aw},${wd},${ws},${wt},${s}" | tee -a "${B}"
+      else echo "cores=${C} out_cb=${OC} mode=${MODE} FAILED"; fi
+    done
+  done
+done
+echo "IO_LATENCY_COMPLETE -> ${A} , write_lat_vs_outcb[_writeonly].csv"

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/scripts/run_noc_dependence.sh
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/scripts/run_noc_dependence.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Regather item #1: NoC BW dependence -- read-only aggregate read BW vs spatial extent,
+# at 2/4/6/8 rows and 2/4/6/8 columns of cores, on the reader's NoC = NOC0 and NOC1.
+# 4 series: {rows, cols} x {NOC0, NOC1}.
+#   grid is 8 wide (x) x 7 tall (y):
+#     row  = 8 cores (full x-span), grown row-major   -> u rows  = u*8 cores
+#     col  = 7 cores (full y-span), grown column-major -> u cols  = u*7 cores
+#   rows: only 7 rows exist, so 8 rows is impossible; the rows series uses {2,4,6}
+#         plus 7 (=56 cores, full grid) as the all-core saturation point so it reaches
+#         the same 56-core endpoint as cols=8 (=56). cols: {2,4,6,8} all valid.
+#   read-only => writer just pops the CB (no DRAM writes), so ONLY the reader NoC matters.
+#   reader on NOC0: --reader-noc 0 --writer-noc 1 ; on NOC1: --reader-noc 1 --writer-noc 0.
+# Per point picks the best input-CB depth. Emits one CSV: orientation,noc,units,cores,in_cb,read_gbps.
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+export TT_METAL_HOME="${TT_METAL_HOME:-$(cd "${SCRIPT_DIR}/../../../../../.." && pwd)}"
+export TT_METAL_DEVICE_PROFILER=1
+cd "${TT_METAL_HOME}" || exit 1  # binary detects root from cwd, not env -> must run from repo root
+BIN="${TT_METAL_HOME}/build_RelWithDebInfo/test/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency"
+PY="${TT_METAL_HOME}/python_env/bin/python3"
+DEC="${SCRIPT_DIR}/decompose_latency_bw.py"
+DEV_CSV="${TT_METAL_HOME}/generated/profiler/.logs/profile_log_device.csv"
+OUTDIR="${OUTDIR:-${TT_METAL_HOME}/generated/profiler/op_to_op_runs/stage_a}"
+OUT="${OUT:-${OUTDIR}/read_bw_noc_2468.csv}"
+mkdir -p "${OUTDIR}"
+
+WIDTH="${WIDTH:-8}"          # cores per row (x-span)
+HEIGHT="${HEIGHT:-7}"        # cores per column (y-span)
+INPUT_DEPTHS="${INPUT_DEPTHS:-16 32}"
+N="${N:-8}"                  # reader trids in flight (mode 2)
+PAGES="${PAGES:-1024}"
+ROW_UNITS="${ROW_UNITS:-2 4 6 7}"   # 7 = full grid (8 rows impossible on a 7-tall grid)
+COL_UNITS="${COL_UNITS:-2 4 6 8}"
+
+echo "orientation,noc,units,cores,in_cb,read_gbps" > "${OUT}"
+
+# best read BW over input depths -> echoes "bw in_cb"
+measure() { # layout_flag noc_flags cores
+  local lf="$1" noc="$2" cores="$3" best=0 bestd=0
+  for d in ${INPUT_DEPTHS}; do
+    rm -f "${DEV_CSV}"
+    "${BIN}" --read-only --lean-compute ${lf} ${noc} \
+      --reader-dbuf-trid --reader-trid-in-flight "${N}" --reader-push-tiles 2 \
+      --input-cb-depth-tiles "${d}" --output-cb-depth-tiles 2 \
+      --num-pages-per-core "${PAGES}" --num-programs 2 --compute-nops 0 \
+      --use-trace --trace-warmup-replays 1 --num-active-cores "${cores}" --use-device-profiler \
+      >/tmp/rbnoc_run.log 2>&1
+    grep -q PASSED /tmp/rbnoc_run.log || continue
+    local bw
+    bw=$("${PY}" "${DEC}" --pages-per-core "${PAGES}" --num-cores "${cores}" 2>/dev/null | awk '/agg_read_gbps/{print $2}')
+    awk -v a="${bw:-0}" -v b="${best}" 'BEGIN{exit !(a>b)}' && { best="${bw}"; bestd="${d}"; }
+  done
+  echo "${best} ${bestd}"
+}
+
+for rnoc in 0 1; do
+  if [ "${rnoc}" -eq 0 ]; then noc="noc0"; nf="--reader-noc 0 --writer-noc 1";
+  else                          noc="noc1"; nf="--reader-noc 1 --writer-noc 0"; fi
+  for u in ${ROW_UNITS}; do                  # rows: u full rows of WIDTH cores
+    cores=$((u * WIDTH)); (( cores > WIDTH*HEIGHT )) && cores=$((WIDTH*HEIGHT))
+    read -r bw d < <(measure "" "${nf}" "${cores}")
+    echo "rows,${noc},${u},${cores},${d},${bw}" >> "${OUT}"
+    echo "rows reader=${noc} ${u} row(s) cores=${cores} -> ${bw} GB/s (in_cb=${d})"
+  done
+  for u in ${COL_UNITS}; do                  # cols: u full columns of HEIGHT cores
+    cores=$((u * HEIGHT)); (( cores > WIDTH*HEIGHT )) && cores=$((WIDTH*HEIGHT))
+    read -r bw d < <(measure "--core-layout-col" "${nf}" "${cores}")
+    echo "cols,${noc},${u},${cores},${d},${bw}" >> "${OUT}"
+    echo "cols reader=${noc} ${u} col(s) cores=${cores} -> ${bw} GB/s (in_cb=${d})"
+  done
+done
+echo "READ_BW_NOC_2468_COMPLETE -> ${OUT}"

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/scripts/run_read_stagger.sh
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/scripts/run_read_stagger.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Deliberate read-stagger experiment. Holds cores / write volume / layout / out_cb / flush FIXED
+# and dials a per-core read-start delay (core i spins i*STAGGER after go) to INDUCE read skew.
+# Tests the hypothesis: does staggering reads (so write bursts de-correlate) lower the write-barrier
+# congestion? Records the MEASURED read skew (event_timeline) alongside write_drain / write_drain_max
+# / writer_done_spread so we plot the write metrics vs the induced read skew (the independent var),
+# with everything else constant. If write_drain_max FALLS as read skew rises -> hypothesis confirmed.
+#
+# Env: CORES, PAGES, OUT_CB, N, IN_CB, STAGGERS (per-core spin counts), OUT, OUTDIR.
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+export TT_METAL_HOME="${TT_METAL_HOME:-$(cd "${SCRIPT_DIR}/../../../../../.." && pwd)}"
+export TT_METAL_DEVICE_PROFILER=1
+cd "${TT_METAL_HOME}" || exit 1
+BIN="${TT_METAL_HOME}/build_RelWithDebInfo/test/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency"
+PY="${TT_METAL_HOME}/python_env/bin/python3"
+DEC="${SCRIPT_DIR}/decompose_latency_bw.py"
+ET="${SCRIPT_DIR}/event_timeline.py"
+DEV_CSV="${TT_METAL_HOME}/generated/profiler/.logs/profile_log_device.csv"
+OUTDIR="${OUTDIR:-${TT_METAL_HOME}/generated/profiler/op_to_op_runs/stage_a}"
+OUT="${OUT:-${OUTDIR}/read_stagger.csv}"
+mkdir -p "${OUTDIR}"
+
+CORES="${CORES:-56}"
+PAGES="${PAGES:-256}"     # fixed per-core write volume
+OUT_CB="${OUT_CB:-32}"    # fixed flush cadence
+N="${N:-4}"
+IN_CB="${IN_CB:-16}"
+NOPS="${NOPS:-0}"         # keep compute light so reads aren't gated (isolate the stagger effect)
+# Calibration: ~0.5us induced last-core read skew per unit stagger at 56c (loop is ~9cyc/iter,
+# last core = 55*stagger iters). Steps below span induced read skew ~0 -> ~30us.
+STAGGERS="${STAGGERS:-0 1 2 4 8 16 32 64}"  # per-core spin count (core i spins i*this)
+
+echo "stagger,cores,read_start_skew_us,read_compl_skew_us,write_drain_us,write_drain_max_us,writer_done_spread_us,agg_total_gbps" > "${OUT}"
+for S in ${STAGGERS}; do
+  rm -f "${DEV_CSV}"
+  "${BIN}" --skip-output-validation --lean-compute --reader-noc 0 --writer-noc 1 \
+    --reader-dbuf-trid --reader-trid-in-flight "${N}" --reader-push-tiles 2 --reader-stagger-cycles "${S}" \
+    --input-cb-depth-tiles "${IN_CB}" --output-cb-depth-tiles "${OUT_CB}" --writer-end-barrier-mode 0 \
+    --num-pages-per-core "${PAGES}" --num-programs 4 --compute-nops "${NOPS}" \
+    --use-trace --trace-warmup-replays 1 --num-active-cores "${CORES}" --use-device-profiler \
+    >/tmp/stagger_run.log 2>&1
+  grep -q PASSED /tmp/stagger_run.log || { echo "stagger=${S} FAILED: $(grep -oE 'TT_FATAL: .*' /tmp/stagger_run.log | head -1)"; continue; }
+  # measured read skew from event_timeline summary lines (units: cyc ~= ns at 1GHz -> /1000 = us):
+  #   "read skew (first->last core first-read-return) = N cyc"  -> start skew
+  #   "read INTER-core skew (first->last core reads-complete) = N cyc" -> completion skew
+  read -r rs rc < <("${PY}" "${ET}" --input-file "${DEV_CSV}" 2>/dev/null | awk '
+    /read skew \(first->last/   {v=$0; gsub(/[^0-9]/,"",v); s=v}
+    /read INTER-core skew/       {v=$0; gsub(/[^0-9]/,"",v); c=v}
+    END{print (s+0)/1000.0, (c+0)/1000.0}')
+  read -r wd wdm ws at < <("${PY}" "${DEC}" --pages-per-core "${PAGES}" --num-cores "${CORES}" 2>/dev/null | awk '
+    $1=="write_drain_us"{d=$2} $1=="write_drain_max_us"{m=$2} $1=="writer_done_spread_us"{s=$2} $1=="agg_total_gbps"{a=$2}
+    END{print d, m, s, a}')
+  line="${S},${CORES},${rs},${rc},${wd},${wdm},${ws},${at}"
+  echo "${line}" >> "${OUT}"; echo "${line}"
+done
+echo "READ_STAGGER_COMPLETE -> ${OUT}"

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/scripts/run_skew_vs_nops.sh
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/scripts/run_skew_vs_nops.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Canonical sweep 3/6: writer done-skew vs compute load (NOPs/tile).
+# Full read+write op at a fixed core count (default 56), good NoCs, lean compute, trace.
+# Sweeps --compute-nops: as compute grows it paces the consumer, changing how writes pile up
+# at the DRAM tail -> shows whether adding math tightens or worsens the writer completion skew.
+# Records: cores,nops,in_cb,agg_total_gbps,agg_write_gbps,writer_done_spread_us,writer_spread_pct,starvation_ratio.
+#
+# Env: CORES (single value), NOPS_LIST, IN_CB, N (trid), PAGES, OUT, OUTDIR.
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+export TT_METAL_HOME="${TT_METAL_HOME:-$(cd "${SCRIPT_DIR}/../../../../../.." && pwd)}"
+export TT_METAL_DEVICE_PROFILER=1
+cd "${TT_METAL_HOME}" || exit 1  # binary detects root from cwd, not env -> must run from repo root
+BIN="${TT_METAL_HOME}/build_RelWithDebInfo/test/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency"
+PY="${TT_METAL_HOME}/python_env/bin/python3"
+DEC="${SCRIPT_DIR}/decompose_latency_bw.py"
+DEV_CSV="${TT_METAL_HOME}/generated/profiler/.logs/profile_log_device.csv"
+OUTDIR="${OUTDIR:-${TT_METAL_HOME}/generated/profiler/op_to_op_runs/stage_a}"
+OUT="${OUT:-${OUTDIR}/skew_vs_nops.csv}"
+mkdir -p "${OUTDIR}"
+
+CORES="${CORES:-56}"
+NOPS_LIST="${NOPS_LIST:-0 32 64 128 256 512 1024 2048}"
+IN_CB="${IN_CB:-32}"
+N="${N:-8}"
+PAGES="${PAGES:-1024}"
+
+echo "cores,nops,in_cb,agg_total_gbps,agg_write_gbps,writer_done_spread_us,writer_spread_pct,starvation_ratio" > "${OUT}"
+for nops in ${NOPS_LIST}; do
+  rm -f "${DEV_CSV}"
+  "${BIN}" --skip-output-validation --lean-compute --reader-noc 0 --writer-noc 1 \
+    --reader-dbuf-trid --reader-trid-in-flight "${N}" --reader-push-tiles 2 \
+    --input-cb-depth-tiles "${IN_CB}" --output-cb-depth-tiles 2 \
+    --num-pages-per-core "${PAGES}" --num-programs 2 --compute-nops "${nops}" \
+    --use-trace --trace-warmup-replays 1 --num-active-cores "${CORES}" --use-device-profiler \
+    >/tmp/skewnops_run.log 2>&1
+  grep -q PASSED /tmp/skewnops_run.log || { echo "cores=${CORES} nops=${nops} FAILED"; continue; }
+  read -r tb wb wds wsp st < <("${PY}" "${DEC}" --pages-per-core "${PAGES}" --num-cores "${CORES}" 2>/dev/null | awk '
+    /agg_total_gbps/{t=$2} /agg_write_gbps/{w=$2}
+    /writer_done_spread_us/{wd=$2} /writer_spread_pct/{ws=$2} /starvation_ratio/{s=$2}
+    END{print t, w, wd, ws, s}')
+  line="${CORES},${nops},${IN_CB},${tb},${wb},${wds},${wsp},${st}"
+  echo "${line}" >> "${OUT}"; echo "${line}"
+done
+echo "SKEW_VS_NOPS_COMPLETE -> ${OUT}"

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/scripts/run_stage_a_sweep.sh
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/scripts/run_stage_a_sweep.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Stage A of the op-to-op latency/BW campaign: balanced-compute decomposition sweep.
+# For each layout (row, column) x core count:
+#   1. tune input CB depth for peak aggregate read BW (nops=0, read-bound),
+#   2. derive balanced compute: nops so per-tile compute (~COPY_NS + nops) ~= per-tile
+#      read time at the measured per-core BW,
+#   3. final full-pipeline run, decompose into BW + latency + starvation columns.
+# Emits one CSV per layout (chart-ready). Resumable: rows already present are skipped.
+# Reader trid_in_flight is locked at 8 (re-tune showed it flat 4..32).
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+export TT_METAL_HOME="${TT_METAL_HOME:-$(cd "${SCRIPT_DIR}/../../../../../.." && pwd)}"
+export TT_METAL_DEVICE_PROFILER=1
+cd "${TT_METAL_HOME}" || exit 1  # binary detects root from cwd, not env -> must run from repo root
+# dispatch-core profiling off (workers only); official op2op uses KERNEL zones, no DISP markers needed
+# export TT_METAL_DEVICE_PROFILER_DISPATCH=1
+
+BIN="${TT_METAL_HOME}/build_RelWithDebInfo/test/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency"
+PY="${TT_METAL_HOME}/python_env/bin/python3"
+DEC="${SCRIPT_DIR}/decompose_latency_bw.py"
+DEV_CSV="${TT_METAL_HOME}/generated/profiler/.logs/profile_log_device.csv"
+OUTDIR="${OUTDIR:-${TT_METAL_HOME}/generated/profiler/op_to_op_runs/stage_a}"
+mkdir -p "${OUTDIR}"
+
+CORES="${CORES:-1 2 4 8 16 32 56}"          # coarse first; densify (e.g. add 48) later
+LAYOUTS="${LAYOUTS:-row col}"
+INPUT_DEPTHS="${INPUT_DEPTHS:-16 32 64}"     # input CB depth candidates (>= 2*trid_in_flight)
+OUTPUT_DEPTHS="${OUTPUT_DEPTHS:-2 4 8 16 32}"  # output CB candidates (tuned in balanced regime)
+OUT_CB_BASE="${OUT_CB_BASE:-4}"              # output CB used during the input-depth tune
+N="${N:-4}"                                  # trid_in_flight (4 saturates BW at all core counts)
+# Final run is repeated per end-barrier mode so the writer-drain/barrier term of math-to-math
+# can be attributed: 0=noc_async_write_barrier (full ack), 1=writes_flushed, 2=none (relaxed).
+# writer-CB/barrier contribution = m2m(mode 0) - m2m(mode 2). Tuning runs at TUNE_BARRIER.
+BARRIER_MODES="${BARRIER_MODES:-0 1 2}"
+TUNE_BARRIER="${TUNE_BARRIER:-0}"
+# Fixed-TOTAL (data-parallel) work model: a real op shards a fixed-size tensor across the grid,
+# so pages_per_core = TOTAL_PAGES / cores. This keeps execution duration bounded as cores grow
+# (instead of weak-scaling, where fixed pages/core makes the high-core write phase ~1ms and
+# swamps the op-to-op / skew signal). TOTAL_PAGES=3584 -> 56c gets 64 pages (~67us of work,
+# calibrated), large enough that compute (NOPs) actually back-pressures the reader, and divides
+# evenly across {1,2,4,8,16,32,56}. PAGES is recomputed per core count.
+TOTAL_PAGES="${TOTAL_PAGES:-3584}"
+MIN_PAGES_PER_CORE="${MIN_PAGES_PER_CORE:-8}"  # floor so the trid pipeline (in_cb >= 2*N) stays valid
+# Cap input-CB depth at pages_per_core / IN_CB_CAP_FRAC so the reader CANNOT stage the whole shard
+# and run ahead of compute. Without this the peak-BW in_cb tune just picks a CB big enough to hold
+# the shard, the reader never stalls on compute, and the NOP knee degenerates to max. /4 keeps the
+# reader >=~75% compute-coupled (calibrated: in_cb=16 at 64 pages gates read BW ~8% under load).
+IN_CB_CAP_FRAC="${IN_CB_CAP_FRAC:-4}"
+PAGES=1024                                     # placeholder; set to TOTAL_PAGES/cores in the core loop
+TUNE_PROGS="${TUNE_PROGS:-2}"
+FINAL_PROGS="${FINAL_PROGS:-4}"
+BW_TOL="${BW_TOL:-0.98}"                     # smallest depth within this frac of peak BW
+# Balance = NOP knee: largest NOPs/tile where read BW still sits at its read-bound peak.
+# Beyond the knee compute gates reads (BW drops). Early-exit once BW falls below KNEE_TOL*peak.
+NOP_SWEEP="${NOP_SWEEP:-0 32 64 128 256 512 1024 1536}"
+KNEE_TOL="${KNEE_TOL:-0.95}"
+
+run_test() { # layout_flag cores in_cb out_cb nops nprogs [barrier_mode=0]
+  local lf="$1" cores="$2" in_cb="$3" out_cb="$4" nops="$5" nprogs="$6" barrier="${7:-0}"
+  rm -f "${DEV_CSV}"
+  "${BIN}" --reader-dbuf-trid --reader-trid-in-flight "${N}" --reader-push-tiles 2 \
+    --input-cb-depth-tiles "${in_cb}" --output-cb-depth-tiles "${out_cb}" \
+    --writer-end-barrier-mode "${barrier}" --lean-compute --skip-output-validation ${lf} \
+    --num-pages-per-core "${PAGES}" --num-programs "${nprogs}" \
+    --use-trace --trace-warmup-replays 1 --compute-nops "${nops}" \
+    --num-active-cores "${cores}" --use-device-profiler >/tmp/stage_a_run.log 2>&1
+  grep -q "PASSED" /tmp/stage_a_run.log
+}
+
+decomp_field() { # field-name cores  (reads current DEV_CSV, prints value)
+  "${PY}" "${DEC}" --pages-per-core "${PAGES}" --num-cores "$2" 2>/dev/null \
+    | awk -v f="$1" '$1==f{print $2}'
+}
+
+for layout in ${LAYOUTS}; do
+  lf=""; [ "${layout}" = "col" ] && lf="--core-layout-col"
+  OUT="${OUTDIR}/stage_a_${layout}.csv"
+  for C in ${CORES}; do
+    # Fixed-total work: this core count's per-core shard (floored so the trid pipeline stays valid).
+    PAGES=$(( TOTAL_PAGES / C ))
+    (( PAGES < MIN_PAGES_PER_CORE )) && PAGES=${MIN_PAGES_PER_CORE}
+    # Capped input-CB candidates: only depths small enough that the reader can't hold the whole
+    # shard (in_cb <= PAGES/IN_CB_CAP_FRAC), so compute can back-pressure it. Fall back to the
+    # smallest candidate if the shard is too small for any to qualify.
+    IN_DEPTHS_CAPPED=""
+    for d in ${INPUT_DEPTHS}; do (( d * IN_CB_CAP_FRAC <= PAGES )) && IN_DEPTHS_CAPPED="${IN_DEPTHS_CAPPED} ${d}"; done
+    [ -z "${IN_DEPTHS_CAPPED}" ] && IN_DEPTHS_CAPPED="$(set -- ${INPUT_DEPTHS}; echo "$1")"
+    echo "==== ${layout} cores=${C}: pages/core=${PAGES} (total~$(( PAGES * C )) of ${TOTAL_PAGES}); in_cb candidates=[${IN_DEPTHS_CAPPED} ] ===="
+    # Skip this (layout,cores) only if every barrier-mode row is already present.
+    if [ -f "${OUT}" ]; then
+      have_all=1
+      for m in ${BARRIER_MODES}; do grep -q "^${layout},${C},${m}," "${OUT}" || have_all=0; done
+      if [ "${have_all}" = "1" ]; then echo "[skip] ${layout} cores=${C} (all modes present)"; continue; fi
+    fi
+    # --- Stage 1: tune input CB depth at nops=0 (read-bound), max agg_read ---
+    echo "==== ${layout} cores=${C}: tuning input CB depth (nops=0) ===="
+    best_bw=0; declare -A BW_AT; declare -A PCMED_AT
+    for d in ${IN_DEPTHS_CAPPED}; do
+      if ! run_test "${lf}" "${C}" "${d}" "${OUT_CB_BASE}" 0 "${TUNE_PROGS}"; then
+        echo "  in_cb=${d}: FAILED ($(grep -oE 'TT_FATAL: .*' /tmp/stage_a_run.log | head -1))"; continue
+      fi
+      bw=$(decomp_field agg_read_gbps "${C}"); pcm=$(decomp_field per_core_gbps_median "${C}")
+      BW_AT[$d]="${bw:-0}"; PCMED_AT[$d]="${pcm:-0}"
+      echo "  in_cb=${d}: agg_read=${bw} GB/s  per_core_med=${pcm}"
+      awk -v a="${bw:-0}" -v b="${best_bw}" 'BEGIN{exit !(a>b)}' && best_bw="${bw}"
+    done
+    [ "${best_bw}" = "0" ] && { echo "  no successful input tune; skipping"; unset BW_AT PCMED_AT; continue; }
+    best_in=""
+    for d in ${IN_DEPTHS_CAPPED}; do
+      [ -z "${BW_AT[$d]:-}" ] && continue
+      if awk -v a="${BW_AT[$d]}" -v p="${best_bw}" -v t="${BW_TOL}" 'BEGIN{exit !(a>=p*t)}'; then best_in="${d}"; break; fi
+    done
+    peak_read="${BW_AT[$best_in]}"
+    echo "  -> in_cb=${best_in} (read-bound peak agg_read=${peak_read})"
+
+    # --- Balance via NOP knee: largest NOPs where agg_read still >= KNEE_TOL*peak ---
+    echo "==== ${layout} cores=${C}: NOP-knee search (peak_read=${peak_read}) ===="
+    nops=0
+    for nq in ${NOP_SWEEP}; do
+      if ! run_test "${lf}" "${C}" "${best_in}" "${OUT_CB_BASE}" "${nq}" "${TUNE_PROGS}"; then
+        echo "  nops=${nq}: FAILED"; continue
+      fi
+      bw=$(decomp_field agg_read_gbps "${C}")
+      echo "  nops=${nq}: agg_read=${bw}"
+      if awk -v a="${bw:-0}" -v p="${peak_read}" -v t="${KNEE_TOL}" 'BEGIN{exit !(a>=p*t)}'; then
+        nops="${nq}"
+      else
+        break  # past the knee: compute is gating reads
+      fi
+    done
+    echo "  -> balanced (knee) nops=${nops}"
+
+    # --- Stage 2: tune output CB depth in the BALANCED regime, max agg_total ---
+    # (Output starvation only appears once compute is real; at high cores partial read
+    #  starvation backs up the output CB and stalls compute, so deeper output can help.)
+    echo "==== ${layout} cores=${C}: tuning output CB depth (balanced nops=${nops}) ===="
+    best_tot=0; declare -A TOT_AT
+    for o in ${OUTPUT_DEPTHS}; do
+      if ! run_test "${lf}" "${C}" "${best_in}" "${o}" "${nops}" "${TUNE_PROGS}"; then
+        echo "  out_cb=${o}: FAILED ($(grep -oE 'TT_FATAL: .*' /tmp/stage_a_run.log | head -1))"; continue
+      fi
+      tot=$(decomp_field agg_total_gbps "${C}")
+      TOT_AT[$o]="${tot:-0}"
+      echo "  out_cb=${o}: agg_total=${tot} GB/s"
+      awk -v a="${tot:-0}" -v b="${best_tot}" 'BEGIN{exit !(a>b)}' && best_tot="${tot}"
+    done
+    best_out="${OUT_CB_BASE}"
+    if [ "${best_tot}" != "0" ]; then
+      for o in ${OUTPUT_DEPTHS}; do
+        [ -z "${TOT_AT[$o]:-}" ] && continue
+        if awk -v a="${TOT_AT[$o]}" -v p="${best_tot}" -v t="${BW_TOL}" 'BEGIN{exit !(a>=p*t)}'; then best_out="${o}"; break; fi
+      done
+    fi
+    echo "  -> out_cb=${best_out} (agg_total peak=${best_tot})"
+
+    echo "==== ${layout} cores=${C}: final balanced runs (in=${best_in} out=${best_out} nops=${nops}) barriers=[${BARRIER_MODES}] ===="
+    for m in ${BARRIER_MODES}; do
+      if [ -f "${OUT}" ] && grep -q "^${layout},${C},${m}," "${OUT}"; then echo "  [skip] barrier=${m}"; continue; fi
+      if run_test "${lf}" "${C}" "${best_in}" "${best_out}" "${nops}" "${FINAL_PROGS}" "${m}"; then
+        "${PY}" "${DEC}" --pages-per-core "${PAGES}" --num-cores "${C}" --csv-out "${OUT}" \
+          --label "layout=${layout};cores=${C};barrier=${m};in_cb=${best_in};out_cb=${best_out};nops=${nops};peak_read_gbps=${peak_read}" \
+          2>/dev/null | grep -E "agg_total_gbps|m2m_bubble_us|m2m_skew_env_us|finish_skew_us|start_skew_us|read_fill_head_us"
+        # per-config event timeline (go -> ... -> go received; delta + cumulative cyc/us) from the
+        # same device log this run just produced. Appends one block per config to a per-layout CSV.
+        "${PY}" "${SCRIPT_DIR}/event_timeline.py" --input-file "${DEV_CSV}" \
+          --csv-out "${OUTDIR}/stage_a_timeline_${layout}.csv" \
+          --label "layout=${layout};cores=${C};barrier=${m};in_cb=${best_in};out_cb=${best_out};nops=${nops}" \
+          >/dev/null 2>&1 || echo "  [timeline skipped: <2 steady ops] ${layout} cores=${C} barrier=${m}"
+        echo "  appended ${layout} cores=${C} barrier=${m} -> ${OUT} (+ timeline)"
+      else
+        echo "  FINAL FAILED ${layout} cores=${C} barrier=${m}: $(grep -oE 'TT_FATAL: .*' /tmp/stage_a_run.log | head -1)"
+      fi
+    done
+    unset BW_AT PCMED_AT TOT_AT
+  done
+  echo; echo "==== ${layout} done: ${OUT} ===="; column -t -s, "${OUT}" 2>/dev/null || cat "${OUT}"
+done
+echo "STAGE_A_SWEEP_COMPLETE"

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/scripts/run_unroll_vs_b2b.sh
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/scripts/run_unroll_vs_b2b.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Unroll-vs-back-to-back experiment. For each repeat count K, run the SAME total workload two ways
+# under trace replay and compare wall-clock:
+#   back-to-back : --num-programs K --kernel-unroll 1  (K separate program enqueues; each program
+#                  ends in a write barrier and there is an op-to-op sync between enqueues)
+#   unrolled     : --num-programs 1 --kernel-unroll K  (one program; kernels repeat the workload K
+#                  times with NO barrier between reps -- one write barrier only at the very end)
+# The delta is the op-to-op sync-barrier cost removed by fusing the K executions. per_boundary_us
+# = (b2b - unroll) / (K-1). Everything else (cores/volume/CBs/math/NoCs) is held at the locked
+# Stage-A config.
+#
+# Env: CORES, PAGES, NOPS, OUT_CB, IN_CB, N, KS (repeat counts), REPS, OUT.
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+export TT_METAL_HOME="${TT_METAL_HOME:-$(cd "${SCRIPT_DIR}/../../../../../.." && pwd)}"
+cd "${TT_METAL_HOME}" || exit 1
+BIN="${TT_METAL_HOME}/build_RelWithDebInfo/test/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency"
+OUTDIR="${OUTDIR:-${TT_METAL_HOME}/generated/profiler/op_to_op_runs/stage_a}"
+OUT="${OUT:-${OUTDIR}/unroll_vs_b2b.csv}"
+mkdir -p "${OUTDIR}"
+
+CORES="${CORES:-56}"
+PAGES="${PAGES:-256}"
+NOPS="${NOPS:-800}"     # balanced math (locked Stage-A operating point)
+OUT_CB="${OUT_CB:-32}"
+IN_CB="${IN_CB:-16}"
+N="${N:-4}"
+KS="${KS:-2 4 8}"
+REPS="${REPS:-3}"
+
+# common locked config; $1 = num_programs, $2 = kernel_unroll
+run_elapsed() {
+  local nprog="$1" unroll="$2"
+  "${BIN}" --skip-output-validation --lean-compute --reader-noc 0 --writer-noc 1 \
+    --reader-dbuf-trid --reader-trid-in-flight "${N}" --reader-push-tiles 2 \
+    --input-cb-depth-tiles "${IN_CB}" --output-cb-depth-tiles "${OUT_CB}" --writer-end-barrier-mode 0 \
+    --num-pages-per-core "${PAGES}" --num-programs "${nprog}" --kernel-unroll "${unroll}" \
+    --compute-nops "${NOPS}" --use-trace --trace-warmup-replays 2 --num-active-cores "${CORES}" \
+    2>&1 | grep -oE 'programs in [0-9]+ us' | grep -oE '[0-9]+'
+}
+
+median() { printf '%s\n' "$@" | sort -n | awk '{a[NR]=$1} END{print (NR%2)?a[(NR+1)/2]:int((a[NR/2]+a[NR/2+1])/2)}'; }
+
+echo "K,b2b_us,unroll_us,gain_us,per_boundary_us,pct_saved" > "${OUT}"
+for K in ${KS}; do
+  b2b=(); unr=()
+  for ((r=0; r<REPS; r++)); do b2b+=("$(run_elapsed "${K}" 1)"); done
+  for ((r=0; r<REPS; r++)); do unr+=("$(run_elapsed 1 "${K}")"); done
+  mb=$(median "${b2b[@]}"); mu=$(median "${unr[@]}")
+  [ -z "${mb}" ] || [ -z "${mu}" ] && { echo "K=${K} FAILED (b2b='${b2b[*]}' unr='${unr[*]}')"; continue; }
+  line=$(awk -v k="${K}" -v b="${mb}" -v u="${mu}" 'BEGIN{
+    g=b-u; pb=(k>1)?g/(k-1):0; pct=(b>0)?100.0*g/b:0;
+    printf "%d,%d,%d,%d,%.2f,%.1f", k, b, u, g, pb, pct}')
+  echo "${line}" >> "${OUT}"
+  echo "K=${K}: b2b=${mb}us (${b2b[*]}) unroll=${mu}us (${unr[*]}) -> ${line}"
+done
+echo "UNROLL_VS_B2B_COMPLETE -> ${OUT}"

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency.cpp
@@ -1,0 +1,1251 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Op-to-op latency benchmark.
+//
+// Background: HW team wants to measure the time between when one op's math
+// finishes and the next op's math starts (op-to-op latency). That gap is
+// firmware tear-down + dispatch + barrier overhead, and is what they need to
+// shrink (e.g. by virtualising init registers so program N+1 can preload
+// while N is still finishing, or by relaxing end-of-op barriers).
+//
+// This benchmark does the textbook reader -> CB -> compute -> CB -> writer
+// pipeline on every Tensix core, with interleaved DRAM in/out, then runs the
+// same MeshWorkload back-to-back N times in either Fast-Dispatch or Trace
+// mode. The compute kernel emits per-tile DeviceZoneScopedN("MATH") zones
+// (plus TILE_IDX data) so a profiler-enabled build dumps timestamps into
+// generated/profiler/.logs/profile_log_device.csv.
+//
+// For **program-level** op-to-op (between host enqueues), use
+// `--use-realtime-profiler` (ProgramRealtimeRecord gaps), not nested
+// DeviceZoneScopedMainN in user TRISC code (see compute kernel comments).
+//
+// CSV / in-kernel timing: use per-tile MATH zones on the MATH TRISC row,
+// or TRISC-KERNEL zones emitted by firmware (trisck.cc) for whole-kernel
+// envelope on each TRISC.
+//
+// CLI:
+//   --num-pages-per-core N  pages of interleaved DRAM per core (default 2)
+//   --compute-nops N        TTI_NOPs in the per-tile body (default 0;
+//                           tune up so the math zone is comfortably > 10us)
+//   --num-programs N        back-to-back enqueues per measurement (default 8)
+//   --use-trace             capture once + replay (default: FD mode)
+//   --use-device-profiler   call ReadMeshDeviceProfilerResults after Finish
+//                           (requires Tracy-enabled build — default unless
+//                            build_metal.sh --disable-profiler; plus env var
+//                            TT_METAL_DEVICE_PROFILER=1 before process start)
+//   --use-realtime-profiler register ProgramRealtimeProfilerCallback for the
+//                           timed portion only (FD: N enqueues + Finish; trace:
+//                           replay + Finish). Logs per-chip op-to-op gaps
+//                           (next start - previous end, ns). Inactive on some
+//                           dispatch setups; see
+//                           tech_reports/real_time_profiler/getting-started.md
+//   --trace-warmup-replays N  untimed trace replays before the measured replay (default 0)
+//   --trace-region-size N   trace buffer size, bytes (default 1 MiB)
+//   --device-id N           device under test (default 0)
+//   --output-cb-depth-tiles N  output CB depth in tiles (default 2)
+//   --read-only             isolate read BW: writer pops the output CB (no DRAM writes) and
+//                           compute is a CB pass-through. Implies --bypass-compute.
+//   --write-only            isolate write BW: reader issues NO NoC read and compute is a CB
+//                           pass-through (implies --bypass-compute), so DRAM sees writes only.
+//                           Pair with --output-cb-depth-tiles >= 8 (default 2 flushes after every
+//                           write).
+//   --bypass-compute        compute kernel becomes a CB pass-through (no unpack/copy/pack/NOPs),
+//                           taking the math datapath out of the measured path. Implied by BOTH
+//                           --read-only and --write-only; pass it explicitly only for a full
+//                           read+write op. Implies --lean-compute (per-tile markers would
+//                           otherwise still pace the pipeline). --compute-nops ignored, output
+//                           validation skipped.
+//
+// To sweep CB depths for peak BW, loop --input-cb-depth-tiles / --output-cb-depth-tiles from a
+// driver script (see scripts/run_bw_vs_cores.sh) rather than from inside the binary.
+
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <cstdlib>
+#include <exception>
+#include <fstream>
+#include <iomanip>
+#include <map>
+#include <sstream>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <tt-logger/tt-logger.hpp>
+#include <tt-metalium/bfloat16.hpp>
+#include <tt-metalium/buffer_types.hpp>
+#include <tt-metalium/circular_buffer_config.hpp>
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/device.hpp>
+#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/kernel_types.hpp>
+#include <tt-metalium/program.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/tt_backend_api_types.hpp>
+#include <tt-metalium/tt_metal.hpp>
+#include <tt-metalium/work_split.hpp>
+#include <tt-metalium/experimental/realtime_profiler.hpp>
+#include <hostdevcommon/common_values.hpp>
+#include "impl/context/metal_context.hpp"
+#include "tt_metal/tt_metal/perf_microbenchmark/common/util.hpp"
+
+#include "test_common.hpp"
+
+using namespace tt;
+using namespace tt::tt_metal;
+
+namespace {
+
+// Defaults:
+//   num_pages_per_core = 2 (each core processes 2 interleaved DRAM pages, so
+//                        every Tensix sees ≥ 2 per-tile MATH-zone entries
+//                        and we still touch every DRAM bank in a chip-wide
+//                        interleaved layout).
+//   num_nops_per_tile  = 0 keeps the math zone short by default; tune this
+//                        up via --compute-nops until the per-tile MATH zone
+//                        in profile_log_device.csv is comfortably > 10us
+//                        (the target program runtime for op-to-op latency
+//                        measurement to be meaningful vs dispatch noise).
+//   num_programs       = 8 enqueues back-to-back per measurement run; gives
+//                        seven (N-1) op-to-op gaps to look at later.
+//   warmup             = true runs one untimed enqueue first to absorb
+//                        dispatcher / kernel-setup transients.
+//   use_trace          = false keeps step-2 FD behaviour as default. Pass
+//                        --use-trace to capture-once / replay-once.
+//   trace_region_size  = 1 MiB. Plenty for tens of small back-to-back
+//                        programs; tunable via --trace-region-size if
+//                        --num-programs is bumped a lot.
+struct BenchmarkConfig {
+    uint32_t num_pages_per_core = 4;
+    uint32_t num_nops_per_tile = 0;
+    uint32_t num_programs = 8;
+    uint32_t device_id = 0;
+    uint32_t reader_push_tile_count = 2;
+    // 0 = auto (2 * reader_push_tile_count) for input CB depth.
+    uint32_t input_cb_depth_tiles = 0;
+    // 0 = default 2 tiles (compute->writer still pops 1 at a time).
+    uint32_t output_cb_depth_tiles = 0;
+    // 0 = reserve N then read+push one tile at a time (simple reference; cannot measure BW --
+    // emits no READ_LAST marker); 2 = per-trid double-buffer (N reads in flight per TRID), the
+    // only mode that measures read BW and the only one supporting page_size_tiles > 1.
+    uint32_t reader_mode = 0;
+    // Reads in flight per TRID for reader_mode 2. CB depth must be
+    // >= 2 * reader_trid_in_flight * page_size_tiles.
+    uint32_t reader_trid_in_flight = 2;
+    // DRAM page size in tiles. Larger pages = fewer, larger NoC transactions
+    // per program. CB pages stay 1 tile each so compute kernel is unchanged.
+    uint32_t page_size_tiles = 1;
+    // Deliberate per-core read stagger (experiment). 0 = off. Core i spins i*reader_stagger_cycles
+    // after go, before reading, to induce a controlled read-completion skew (to test whether
+    // staggered reads relieve write-barrier congestion).
+    uint32_t reader_stagger_cycles = 0;
+    // Kernel-unroll (experiment). >1 = each kernel repeats its whole workload this many times inside
+    // ONE program invocation with NO barrier between reps. Compared against --num-programs N of the
+    // same workload run back-to-back, the delta isolates the removed op-to-op sync-barrier cost.
+    uint32_t kernel_unroll = 1;
+    // Writer emits a measured progress timestamp every N pages (0=off) -> real write-issue bytes-vs-time
+    // per core, to measure BW allocation over time instead of interpolating between phase brackets.
+    uint32_t write_progress_every = 0;
+    uint32_t read_progress_every = 0;  // reader emits a progress timestamp every N pages completed (0=off)
+    // Cap active core count. 0 = use full grid (default). Used to test whether
+    // brisc_done_to_go scales with core count.
+    uint32_t num_active_cores = 0;
+    // Core placement for the active set: false = row-major (fill a row then next row),
+    // true = column-major (fix x, vary y first). Lets us probe NoC-direction asymmetry
+    // (a row of cores contends differently on the torus than a column).
+    bool core_layout_col = false;
+    // Skip the first `core_offset` cores in the fill order before taking `num_active_cores`.
+    // With --core-layout-col this selects an N-core block at a chosen column, so we can sweep
+    // WHICH cores (near vs far from DRAM) run and isolate NoC-distance from grid contention.
+    uint32_t core_offset = 0;
+    // Explicit LOGICAL core coords "x,y;x,y;..." -- overrides layout/offset. Lets us run an arbitrary
+    // hand-picked set (e.g. the literal slowest stragglers) to test whether a specific set underperforms.
+    std::vector<CoreCoord> core_list;
+    // Log each active core's logical->physical(NoC) coord mapping at setup (to match profiler coords).
+    bool log_core_map = false;
+    // NoC assignment for reader / writer (0 = NOC0, 1 = NOC1). The two NoCs route opposite
+    // directions on the torus; measured read-BW table shows reads scale to ~206 GB/s on
+    // NOC0 but cap at ~67 on NOC1, so the defaults are reader=NOC0, writer=NOC1 (the
+    // opposite of the framework default reader=NOC1/writer=NOC0). Override per kernel.
+    uint32_t reader_noc = 0;
+    uint32_t writer_noc = 1;
+    bool warmup = true;
+    bool use_trace = false;
+    bool use_device_profiler = false;
+    bool use_realtime_profiler = false;
+    size_t trace_region_size = 1ull << 20;  // 1 MiB
+    // Untimed trace replays before the measured replay (steady-state trace path).
+    uint32_t trace_warmup_replays = 0;
+    // Read-only mode: writer pops from output CB but skips DRAM writes.
+    // Isolates pure DRAM read BW through the reader pipeline.
+    bool read_only = false;
+    // Write-only mode: the mirror of --read-only for the write direction. The reader issues NO
+    // NoC read at all and the compute kernel becomes a CB pass-through (no unpack/copy/pack), so
+    // the only DRAM traffic is the writer's full-page interleaved writes.
+    //
+    // Approximating this with a "cheap read" (tiny reads, full-page pushes) does NOT work: it still
+    // costs one DRAM read TRANSACTION per page (1:1 with the writes, striding the same banks, so the
+    // controller pays read/write turnaround), and --lean-compute drops only instrumentation -- every
+    // tile is still unpacked and packed, so the writer stays paced by the packer. That combination
+    // measured 33% low on Blackhole (330 vs 440 GB/s at 110 cores).
+    //
+    // Writer run-ahead is then governed by the output CB depth (flush cadence is
+    // output_cb_depth/page_size_tiles - 1 writes), so --output-cb-depth-tiles matters here: the
+    // default of 2 flushes after EVERY write and will dominate the measurement.
+    bool write_only = false;
+    // Make the compute kernel a CB pass-through (no unpack / copy_tile / pack_tile / NOP spin) so
+    // the math datapath is out of the measured path. IMPLIED BY BOTH --read-only and --write-only:
+    // a single-direction BW mode measures that DRAM direction and nothing else. Exposed as its own
+    // flag only so it can be used with a full read+write op.
+    //
+    // Note --lean-compute is NOT a substitute: it drops only INSTRUMENTATION and still unpacks and
+    // packs every tile.
+    //
+    // Any mode with this set writes/propagates whatever L1 already held, so output validation is
+    // skipped (there is no copy to validate).
+    bool bypass_compute = false;
+    // Lean compute: drop per-tile TILE_IDX / MATH profiler markers (keep tile 0) so the
+    // consumer drains at full speed and does not back-pressure the reader. Use when
+    // measuring read bandwidth; compute cost is then copy + NOPs only.
+    bool lean_compute = false;
+    // Skip the host output-data check. The BW reader writes dummy data to a fixed L1
+    // address, so the written DRAM won't match the input; for latency/BW measurement
+    // (which needs real DRAM writes, i.e. not --read-only) we don't care about data.
+    bool skip_output_validation = false;
+    // Each program reads/writes a disjoint per-program tile slice rather than the
+    // same tiles every program. Forces DRAM controller to open new rows per
+    // program (more app-like streaming pattern); allocates a buffer big enough
+    // for (num_programs + 1) slices.
+    bool cross_program_dram_offset = false;
+    // Writer end-of-kernel barrier (Batch-8 latency experiment for 's HW
+    // barrier-elimination proposal):
+    //   0 = noc_async_write_barrier()  (DEFAULT; wait for DRAM ACK; safe)
+    //   1 = noc_async_writes_flushed() (cheaper; writes left source but not yet ACKed)
+    //   2 = no end barrier             (UNSAFE for real workloads; simulates HW
+    //                                   giving us this guarantee for free)
+    uint32_t writer_end_barrier_mode = 0;
+};
+
+BenchmarkConfig parse_args(const std::vector<std::string>& args) {
+    BenchmarkConfig cfg;
+    cfg.num_pages_per_core = test_args::get_command_option_uint32(args, "--num-pages-per-core", cfg.num_pages_per_core);
+    cfg.reader_push_tile_count =
+        test_args::get_command_option_uint32(args, "--reader-push-tiles", cfg.reader_push_tile_count);
+    cfg.input_cb_depth_tiles =
+        test_args::get_command_option_uint32(args, "--input-cb-depth-tiles", cfg.input_cb_depth_tiles);
+    cfg.output_cb_depth_tiles =
+        test_args::get_command_option_uint32(args, "--output-cb-depth-tiles", cfg.output_cb_depth_tiles);
+    if (test_args::has_command_option(args, "--reader-dbuf-trid")) {
+        // Per-trid double-buffer reader (Almeet's pipelined design).
+        cfg.reader_mode = 2;
+    }
+    cfg.page_size_tiles = test_args::get_command_option_uint32(args, "--page-size-tiles", cfg.page_size_tiles);
+    cfg.reader_trid_in_flight =
+        test_args::get_command_option_uint32(args, "--reader-trid-in-flight", cfg.reader_trid_in_flight);
+    cfg.reader_stagger_cycles =
+        test_args::get_command_option_uint32(args, "--reader-stagger-cycles", cfg.reader_stagger_cycles);
+    cfg.kernel_unroll = test_args::get_command_option_uint32(args, "--kernel-unroll", cfg.kernel_unroll);
+    cfg.write_progress_every = test_args::get_command_option_uint32(args, "--write-progress-every", 0);
+    cfg.read_progress_every = test_args::get_command_option_uint32(args, "--read-progress-every", 0);
+    cfg.num_active_cores = test_args::get_command_option_uint32(args, "--num-active-cores", cfg.num_active_cores);
+    if (test_args::has_command_option(args, "--core-layout-col")) {
+        cfg.core_layout_col = true;
+    }
+    cfg.core_offset = test_args::get_command_option_uint32(args, "--core-offset", 0);
+    cfg.log_core_map = test_args::has_command_option(args, "--log-core-map");
+    {
+        // --core-list "x,y;x,y;..." (logical coords). Overrides layout/offset; sets active-core count.
+        std::string cl = test_args::get_command_option(args, "--core-list", std::string(""));
+        std::stringstream ss(cl);
+        std::string tok;
+        while (std::getline(ss, tok, ';')) {
+            auto comma = tok.find(',');
+            if (comma != std::string::npos) {
+                cfg.core_list.push_back(CoreCoord{
+                    static_cast<size_t>(std::stoul(tok.substr(0, comma))),
+                    static_cast<size_t>(std::stoul(tok.substr(comma + 1)))});
+            }
+        }
+        if (!cfg.core_list.empty()) {
+            cfg.num_active_cores = static_cast<uint32_t>(cfg.core_list.size());
+        }
+    }
+    cfg.reader_noc = test_args::get_command_option_uint32(args, "--reader-noc", cfg.reader_noc);
+    cfg.writer_noc = test_args::get_command_option_uint32(args, "--writer-noc", cfg.writer_noc);
+    cfg.num_nops_per_tile = test_args::get_command_option_uint32(args, "--compute-nops", cfg.num_nops_per_tile);
+    cfg.num_programs = test_args::get_command_option_uint32(args, "--num-programs", cfg.num_programs);
+    cfg.device_id = test_args::get_command_option_uint32(args, "--device-id", cfg.device_id);
+    cfg.trace_region_size =
+        test_args::get_command_option_uint32(args, "--trace-region-size", static_cast<uint32_t>(cfg.trace_region_size));
+    cfg.trace_warmup_replays =
+        test_args::get_command_option_uint32(args, "--trace-warmup-replays", cfg.trace_warmup_replays);
+    if (test_args::has_command_option(args, "--no-warmup")) {
+        cfg.warmup = false;
+    }
+    if (test_args::has_command_option(args, "--use-trace")) {
+        cfg.use_trace = true;
+    }
+    if (test_args::has_command_option(args, "--use-device-profiler")) {
+        cfg.use_device_profiler = true;
+    }
+    if (test_args::has_command_option(args, "--use-realtime-profiler")) {
+        cfg.use_realtime_profiler = true;
+    }
+    if (test_args::has_command_option(args, "--read-only")) {
+        cfg.read_only = true;
+    }
+    if (test_args::has_command_option(args, "--write-only")) {
+        cfg.write_only = true;
+    }
+    if (test_args::has_command_option(args, "--bypass-compute")) {
+        cfg.bypass_compute = true;
+    }
+    if (cfg.write_only || cfg.read_only) {
+        // Both single-direction modes mean "measure ONLY that DRAM direction", so neither leaves
+        // the math datapath in the measured path. --read-only without this back-pressures the
+        // reader through cb_in once compute can't keep up, which at low core counts (high per-core
+        // BW) makes it a compute measurement rather than a DRAM one.
+        cfg.bypass_compute = true;
+    }
+    // Keep this AFTER every assignment to bypass_compute above. Ordered before them it silently
+    // no-ops, and --read-only / --write-only alone then run passthrough with per-tile stamping on.
+    if (cfg.bypass_compute) {
+        // Passthrough removes the copy but per-tile TILE_IDX markers are gated by PROFILE_PER_TILE,
+        // not by PASSTHROUGH -- leaving them on would let instrumentation pace the pipeline.
+        cfg.lean_compute = true;
+    }
+    if (cfg.reader_mode == 2) {
+        // Mode 2 reads every page into the SAME fixed L1 address (dummy payload by design), so the
+        // output can never match the input and validation is guaranteed to fail.
+        cfg.skip_output_validation = true;
+    }
+    if (test_args::has_command_option(args, "--skip-output-validation")) {
+        cfg.skip_output_validation = true;
+    }
+    if (test_args::has_command_option(args, "--lean-compute")) {
+        cfg.lean_compute = true;
+    }
+    if (test_args::has_command_option(args, "--cross-program-dram-offset")) {
+        cfg.cross_program_dram_offset = true;
+    }
+    cfg.writer_end_barrier_mode =
+        test_args::get_command_option_uint32(args, "--writer-end-barrier-mode", cfg.writer_end_barrier_mode);
+    if (cfg.writer_end_barrier_mode > 3) {
+        log_fatal(
+            LogTest,
+            "--writer-end-barrier-mode must be 0 (barrier), 1 (flushed), 2 (none), or 3 (posted writes: "
+            "fire-and-forget, no DRAM ACK; end = posted-writes-flushed = injected/sent, NOT landed)");
+        cfg.writer_end_barrier_mode = 0;
+    }
+    return cfg;
+}
+
+// Real-time profiler callbacks run on a worker thread; collect records here
+// and analyse after UnregisterProgramRealtimeProfilerCallback.
+void log_realtime_program_go_done(const std::vector<tt::tt_metal::experimental::ProgramRealtimeRecord>& records) {
+    std::map<uint32_t, std::vector<tt::tt_metal::experimental::ProgramRealtimeRecord>> by_chip;
+    for (const auto& r : records) {
+        by_chip[r.chip_id].push_back(r);
+    }
+    for (auto& [chip_id, chip_records] : by_chip) {
+        std::sort(chip_records.begin(), chip_records.end(), [](const auto& a, const auto& b) {
+            return a.start_timestamp < b.start_timestamp;
+        });
+        for (const auto& r : chip_records) {
+            const uint64_t duration_cycles =
+                (r.end_timestamp >= r.start_timestamp) ? (r.end_timestamp - r.start_timestamp) : 0;
+            const double duration_ns = (r.frequency > 0.0) ? static_cast<double>(duration_cycles) / r.frequency : 0.0;
+            log_info(
+                LogTest,
+                "Real-time profiler chip {} program {}: go_cycles={} done_cycles={} duration={:.2f} ns",
+                chip_id,
+                r.runtime_id,
+                r.start_timestamp,
+                r.end_timestamp,
+                duration_ns);
+        }
+    }
+}
+
+void log_realtime_op_to_op_gaps(const std::vector<tt::tt_metal::experimental::ProgramRealtimeRecord>& records) {
+    if (records.size() < 2) {
+        log_info(LogTest, "Real-time profiler: got {} record(s); need >= 2 to compute op-to-op gaps.", records.size());
+        return;
+    }
+    std::map<uint32_t, std::vector<tt::tt_metal::experimental::ProgramRealtimeRecord>> by_chip;
+    for (const auto& r : records) {
+        by_chip[r.chip_id].push_back(r);
+    }
+    for (auto& [chip_id, chip_records] : by_chip) {
+        std::sort(chip_records.begin(), chip_records.end(), [](const auto& a, const auto& b) {
+            return a.start_timestamp < b.start_timestamp;
+        });
+        double sum_gap_ns = 0.0;
+        uint32_t gap_count = 0;
+        double min_gap_ns = 0.0;
+        double max_gap_ns = 0.0;
+        std::vector<double> gaps_ns;
+        for (size_t i = 1; i < chip_records.size(); ++i) {
+            const auto& prev = chip_records[i - 1];
+            const auto& cur = chip_records[i];
+            if (cur.runtime_id == prev.runtime_id) {
+                log_warning(
+                    LogTest,
+                    "Real-time profiler chip {}: skipping dispatch gap between duplicate runtime_id {} "
+                    "(trace replay may report the same host runtime id twice)",
+                    chip_id,
+                    cur.runtime_id);
+                continue;
+            }
+            if (cur.start_timestamp < prev.end_timestamp) {
+                log_warning(
+                    LogTest,
+                    "Real-time profiler chip {}: record {} start {} < prev end {} (skip gap)",
+                    chip_id,
+                    i,
+                    cur.start_timestamp,
+                    prev.end_timestamp);
+                continue;
+            }
+            const uint64_t gap_cycles = cur.start_timestamp - prev.end_timestamp;
+            const double freq = (cur.frequency > 0.0) ? cur.frequency : prev.frequency;
+            if (freq <= 0.0) {
+                continue;
+            }
+            const double gap_ns = static_cast<double>(gap_cycles) / freq;
+            if (gap_count == 0) {
+                min_gap_ns = max_gap_ns = gap_ns;
+            } else {
+                min_gap_ns = std::min(min_gap_ns, gap_ns);
+                max_gap_ns = std::max(max_gap_ns, gap_ns);
+            }
+            sum_gap_ns += gap_ns;
+            ++gap_count;
+            gaps_ns.push_back(gap_ns);
+        }
+        if (gap_count > 0) {
+            std::sort(gaps_ns.begin(), gaps_ns.end());
+            const double median_ns = gaps_ns[gaps_ns.size() / 2];
+            log_info(
+                LogTest,
+                "Real-time profiler chip {}: {} op-to-op gap(s) — min {:.2f} ns, median {:.2f} ns, max {:.2f} ns, "
+                "mean {:.2f} ns (next program start − previous program end)",
+                chip_id,
+                gap_count,
+                min_gap_ns,
+                median_ns,
+                max_gap_ns,
+                sum_gap_ns / gap_count);
+            std::string all = "Real-time profiler chip " + std::to_string(chip_id) + " sorted gaps (ns):";
+            for (double g : gaps_ns) {
+                all += fmt::format(" {:.0f}", g);
+            }
+            log_info(LogTest, "{}", all);
+        }
+    }
+}
+
+struct RealtimeProfilerSession {
+    std::mutex mutex;
+    std::vector<tt::tt_metal::experimental::ProgramRealtimeRecord> records;
+    std::optional<tt::tt_metal::experimental::ProgramRealtimeProfilerCallbackHandle> handle;
+
+    void register_callback() {
+        handle = tt::tt_metal::experimental::RegisterProgramRealtimeProfilerCallback(
+            [this](const tt::tt_metal::experimental::ProgramRealtimeRecord& record) {
+                std::lock_guard<std::mutex> lock(mutex);
+                records.push_back(record);
+            });
+    }
+
+    void unregister_and_drain() {
+        if (handle.has_value()) {
+            tt::tt_metal::experimental::UnregisterProgramRealtimeProfilerCallback(*handle);
+            handle.reset();
+        }
+    }
+
+    std::vector<tt::tt_metal::experimental::ProgramRealtimeRecord> copy_records() {
+        std::lock_guard<std::mutex> lock(mutex);
+        return records;
+    }
+};
+
+void write_realtime_profiler_csv(
+    const std::vector<tt::tt_metal::experimental::ProgramRealtimeRecord>& records, const std::string& path) {
+    std::ofstream out(path);
+    if (!out) {
+        log_warning(LogTest, "Real-time profiler: could not open {} for write", path);
+        return;
+    }
+    out << "program_id,chip_id,go_cycles,done_cycles,gap_to_next_go_cycles,duration_cycles,duration_ns,frequency_ghz\n";
+    std::map<uint32_t, std::vector<tt::tt_metal::experimental::ProgramRealtimeRecord>> by_chip;
+    for (const auto& r : records) {
+        by_chip[r.chip_id].push_back(r);
+    }
+    for (auto& [chip_id, chip_records] : by_chip) {
+        std::sort(chip_records.begin(), chip_records.end(), [](const auto& a, const auto& b) {
+            return a.start_timestamp < b.start_timestamp;
+        });
+        for (size_t i = 0; i < chip_records.size(); ++i) {
+            const auto& r = chip_records[i];
+            const uint64_t duration_cycles =
+                (r.end_timestamp >= r.start_timestamp) ? (r.end_timestamp - r.start_timestamp) : 0;
+            const double duration_ns = (r.frequency > 0.0) ? static_cast<double>(duration_cycles) / r.frequency : 0.0;
+            uint64_t gap_to_next_go = 0;
+            if (i + 1 < chip_records.size()) {
+                const auto& next = chip_records[i + 1];
+                if (next.runtime_id != r.runtime_id && next.start_timestamp >= r.end_timestamp) {
+                    gap_to_next_go = next.start_timestamp - r.end_timestamp;
+                }
+            }
+            out << r.runtime_id << "," << chip_id << "," << r.start_timestamp << "," << r.end_timestamp << ","
+                << gap_to_next_go << "," << duration_cycles << "," << duration_ns << "," << r.frequency << "\n";
+        }
+    }
+    log_info(LogTest, "Real-time profiler: wrote {} record(s) to {}", records.size(), path);
+}
+
+// Registers RT profiler callback after warmup; on destruction quiesces, waits for
+// D2H records, unregisters, then logs per-chip op-to-op gaps (Mo's metric:
+// next start - previous end). Must outlive the timed enqueue burst only.
+struct RealtimeProfilerDrainGuard {
+    distributed::MeshDevice* mesh = nullptr;
+    std::unique_ptr<RealtimeProfilerSession> session;
+
+    RealtimeProfilerDrainGuard(distributed::MeshDevice* mesh_in, bool use_realtime_profiler, bool profiler_active) :
+        mesh(mesh_in) {
+        if (!use_realtime_profiler) {
+            return;
+        }
+        if (!profiler_active) {
+            log_warning(
+                LogTest,
+                "Real-time profiler: --use-realtime-profiler set but IsProgramRealtimeProfilerActive() is false; "
+                "skipping (ETH dispatch / remote chip / resources — see "
+                "tech_reports/real_time_profiler/getting-started.md).");
+            return;
+        }
+        session = std::make_unique<RealtimeProfilerSession>();
+        session->register_callback();
+        log_info(LogTest, "Real-time profiler: callback registered for timed section.");
+    }
+
+    RealtimeProfilerDrainGuard(const RealtimeProfilerDrainGuard&) = delete;
+    RealtimeProfilerDrainGuard& operator=(const RealtimeProfilerDrainGuard&) = delete;
+
+    ~RealtimeProfilerDrainGuard() {
+        if (!session) {
+            return;
+        }
+        mesh->quiesce_devices();
+        std::this_thread::sleep_for(std::chrono::milliseconds(500));
+        session->unregister_and_drain();
+        const auto records = session->copy_records();
+        log_realtime_program_go_done(records);
+        log_realtime_op_to_op_gaps(records);
+        const char* metal_home = std::getenv("TT_METAL_HOME");
+        if (metal_home != nullptr) {
+            write_realtime_profiler_csv(
+                records, std::string(metal_home) + "/generated/profiler/.logs/profile_log_device_rt.csv");
+        }
+    }
+};
+
+struct BuiltProgram {
+    Program program;
+    KernelHandle reader_kernel = 0;
+    KernelHandle writer_kernel = 0;
+    KernelHandle compute_kernel = 0;
+    CoreRangeSet core_group_1;
+    CoreRangeSet core_group_2;
+    uint32_t tiles_per_core_group_1 = 0;
+    uint32_t tiles_per_core_group_2 = 0;
+    uint32_t reader_push_tile_count = 2;
+    uint32_t reader_mode = 0;
+    uint32_t reader_trid_in_flight = 2;
+    uint32_t input_cb_depth_tiles = 0;
+    uint32_t output_cb_depth_tiles = 2;
+    uint32_t page_size_tiles = 1;
+    uint32_t reader_stagger_cycles = 0;  // core i spins i*this after go, before reading
+    uint32_t kernel_unroll = 1;          // repeat workload this many times per invocation (no mid-barrier)
+    uint32_t write_progress_every = 0;   // writer emits a progress timestamp every N pages (0=off)
+    uint32_t read_progress_every = 0;    // reader emits a progress timestamp every N pages (0=off)
+};
+
+// Set reader/writer/compute runtime args (only the truly per-launch ones; kernel knobs
+// like reader_mode / push_tile_count / tiles_per_page / trid_in_flight are compile-time
+// args on the kernel so they fold into constants and dead code gets eliminated).
+void set_program_launch_args(
+    Program& program,
+    const BuiltProgram& built,
+    uint32_t input_buffer_addr,
+    uint32_t output_buffer_addr,
+    uint32_t program_id) {
+    const auto work_groups = {
+        std::make_pair(built.core_group_1, built.tiles_per_core_group_1),
+        std::make_pair(built.core_group_2, built.tiles_per_core_group_2)};
+    uint32_t start_tile_id = 0;
+    uint32_t core_idx = 0;  // for the deliberate per-core read stagger
+    for (const auto& [group, tiles_per_core] : work_groups) {
+        if (tiles_per_core == 0) {
+            continue;
+        }
+        for (const auto& range : group.ranges()) {
+            for (const auto& core : range) {
+                const uint32_t read_delay = core_idx * built.reader_stagger_cycles;
+                SetRuntimeArgs(
+                    program,
+                    built.reader_kernel,
+                    core,
+                    {input_buffer_addr,
+                     tiles_per_core,
+                     start_tile_id,
+                     program_id,
+                     read_delay,
+                     built.kernel_unroll,
+                     built.read_progress_every});
+                SetRuntimeArgs(
+                    program,
+                    built.writer_kernel,
+                    core,
+                    {output_buffer_addr,
+                     tiles_per_core,
+                     start_tile_id,
+                     program_id,
+                     built.kernel_unroll,
+                     built.write_progress_every});
+                SetRuntimeArgs(program, built.compute_kernel, core, {tiles_per_core, program_id, built.kernel_unroll});
+                start_tile_id += tiles_per_core;
+                ++core_idx;
+            }
+        }
+    }
+}
+
+// Configure host runtime id (RT profiler) and device CSV program_id before each launch.
+void configure_program_launch(
+    Program& program,
+    const BuiltProgram& built,
+    uint32_t input_buffer_addr,
+    uint32_t output_buffer_addr,
+    uint32_t profiler_program_id,
+    uint32_t host_runtime_id) {
+    set_program_launch_args(program, built, input_buffer_addr, output_buffer_addr, profiler_program_id);
+    program.set_runtime_id(host_runtime_id);
+}
+
+// Build the reader -> compute -> writer program covering every Tensix core,
+// with the per-core tile slice assigned via runtime args.
+BuiltProgram build_program(
+    const std::shared_ptr<distributed::MeshDevice>& mesh_device,
+    const BenchmarkConfig& cfg,
+    const std::shared_ptr<distributed::MeshBuffer>& input_buffer,
+    const std::shared_ptr<distributed::MeshBuffer>& output_buffer,
+    uint32_t total_num_tiles,
+    uint32_t single_tile_size_bytes) {
+    Program program = CreateProgram();
+
+    const auto full_grid = mesh_device->compute_with_storage_grid_size();
+    uint32_t want = full_grid.x * full_grid.y;
+    if (cfg.num_active_cores > 0 && cfg.num_active_cores < want) {
+        want = cfg.num_active_cores;
+    }
+    // Build the full grid order (row-major, or column-major with --core-layout-col), then take
+    // `want` of them starting at --core-offset (which selects WHICH cores run -- e.g. the last
+    // `want` cores, the mirror-image set, is --core-offset (grid - want)).
+    std::vector<CoreCoord> full_order;
+    if (cfg.core_layout_col) {
+        for (uint32_t x = 0; x < full_grid.x; ++x) {
+            for (uint32_t y = 0; y < full_grid.y; ++y) {
+                full_order.push_back(CoreCoord{x, y});
+            }
+        }
+    } else {
+        for (uint32_t y = 0; y < full_grid.y; ++y) {
+            for (uint32_t x = 0; x < full_grid.x; ++x) {
+                full_order.push_back(CoreCoord{x, y});
+            }
+        }
+    }
+    std::vector<CoreCoord> core_list;
+    if (!cfg.core_list.empty()) {
+        core_list = cfg.core_list;  // explicit hand-picked LOGICAL set (overrides layout/offset)
+    } else {
+        const size_t off = std::min<size_t>(cfg.core_offset, full_order.size());
+        const size_t last = std::min<size_t>(off + want, full_order.size());
+        core_list.assign(full_order.begin() + off, full_order.begin() + last);
+    }
+    if (cfg.log_core_map) {
+        const auto did = mesh_device->get_devices()[0]->id();
+        const auto& sd = tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(did);
+        for (const auto& c : core_list) {
+            const auto p = sd.get_physical_tensix_core_from_logical(c);  // matches profiler core_x/core_y
+            log_info(LogTest, "COREMAP logical=({},{}) phys=({},{})", c.x, c.y, p.x, p.y);
+        }
+    }
+    const uint32_t num_cores = static_cast<uint32_t>(core_list.size());
+    std::vector<CoreRange> ranges;
+    ranges.reserve(num_cores);
+    for (const auto& c : core_list) {
+        ranges.emplace_back(c, c);
+    }
+    CoreRangeSet all_cores(ranges);
+    CoreRangeSet core_group_1 = all_cores;
+    CoreRangeSet core_group_2;
+    const uint32_t num_tiles_per_core_group_1 = num_cores > 0 ? total_num_tiles / num_cores : 0;
+    const uint32_t num_tiles_per_core_group_2 = 0;
+
+    log_info(
+        LogTest,
+        "Active cores: {} ({}-major, offset {}), full_grid {}x{}, total_num_tiles={} ({} tiles/core); "
+        "first={} last={}",
+        num_cores,
+        cfg.core_layout_col ? "column" : "row",
+        cfg.core_offset,
+        full_grid.x,
+        full_grid.y,
+        total_num_tiles,
+        num_tiles_per_core_group_1,
+        num_cores ? core_list.front().str() : "none",
+        num_cores ? core_list.back().str() : "none");
+
+    // Input CB depth defaults to 2x reader push chunk (e.g. push 2 -> depth 4).
+    constexpr uint32_t kInputCbId = tt::CBIndex::c_0;
+    constexpr uint32_t kOutputCbId = tt::CBIndex::c_16;
+    constexpr auto kDataFormat = tt::DataFormat::Float16_b;
+
+    const uint32_t push_tiles = cfg.reader_push_tile_count > 0 ? cfg.reader_push_tile_count : 1;
+    const uint32_t input_cb_depth = cfg.input_cb_depth_tiles > 0 ? cfg.input_cb_depth_tiles : (2 * push_tiles);
+    // Compute -> writer unchanged: still wait_front(1) / pack one tile at a time.
+    const uint32_t output_cb_depth = cfg.output_cb_depth_tiles > 0 ? cfg.output_cb_depth_tiles : 2;
+
+    TT_FATAL(
+        input_cb_depth >= push_tiles,
+        "input CB depth ({}) must be >= --reader-push-tiles ({})",
+        input_cb_depth,
+        push_tiles);
+    TT_FATAL(
+        cfg.num_pages_per_core >= push_tiles,
+        "--num-pages-per-core ({}) must be >= --reader-push-tiles ({})",
+        cfg.num_pages_per_core,
+        push_tiles);
+
+    TT_FATAL(
+        !(cfg.read_only && cfg.write_only),
+        "--read-only and --write-only are mutually exclusive (read-only skips the DRAM writes, "
+        "write-only skips the DRAM reads)");
+    if (cfg.bypass_compute && cfg.num_nops_per_tile > 0) {
+        log_warning(
+            LogTest,
+            "--bypass-compute ignores --compute-nops {} (the NOP spin lives between tile_regs_acquire "
+            "and tile_regs_commit, which is skipped along with copy_tile/pack_tile)",
+            cfg.num_nops_per_tile);
+    }
+    if (cfg.write_only && output_cb_depth <= 2) {
+        log_warning(
+            LogTest,
+            "--write-only with --output-cb-depth-tiles {} flushes after EVERY write "
+            "(flush cadence = output_cb_depth/page_size_tiles - 1), which serializes the writer and "
+            "will dominate the measured write BW. Pass --output-cb-depth-tiles 8 or more.",
+            output_cb_depth);
+    }
+
+    const uint32_t page_size_tiles = cfg.page_size_tiles > 0 ? cfg.page_size_tiles : 1;
+    TT_FATAL(
+        cfg.num_pages_per_core % page_size_tiles == 0,
+        "--num-pages-per-core ({}) must be a multiple of --page-size-tiles ({})",
+        cfg.num_pages_per_core,
+        page_size_tiles);
+    TT_FATAL(
+        input_cb_depth >= page_size_tiles,
+        "input CB depth ({}) must be >= --page-size-tiles ({})",
+        input_cb_depth,
+        page_size_tiles);
+    TT_FATAL(
+        output_cb_depth >= page_size_tiles,
+        "output CB depth ({}) must be >= --page-size-tiles ({}) so the writer can accumulate a full page",
+        output_cb_depth,
+        page_size_tiles);
+    const uint32_t trid_in_flight = cfg.reader_trid_in_flight > 0 ? cfg.reader_trid_in_flight : 2;
+    if (cfg.reader_mode == 2) {
+        TT_FATAL(
+            trid_in_flight >= 2,
+            "--reader-trid-in-flight ({}) must be >= 2 for mode 2 (per-trid double-buffer needs both sides active)",
+            trid_in_flight);
+        TT_FATAL(
+            input_cb_depth >= 2 * trid_in_flight * page_size_tiles,
+            "per-trid DB needs input CB depth ({}) >= 2 * --reader-trid-in-flight ({}) * --page-size-tiles ({})",
+            input_cb_depth,
+            trid_in_flight,
+            page_size_tiles);
+        TT_FATAL(
+            cfg.num_pages_per_core / page_size_tiles >= 1,
+            "--num-pages-per-core ({}) / --page-size-tiles ({}) must be >= 1 for reader_mode 2",
+            cfg.num_pages_per_core,
+            page_size_tiles);
+    } else if (page_size_tiles > 1) {
+        TT_FATAL(
+            false,
+            "--page-size-tiles > 1 currently requires --reader-dbuf-trid (reader_mode 2); "
+            "mode 0 uses tile_id as page_id and would read wrong data.");
+    }
+
+    log_info(
+        LogTest,
+        "Reader: push_tiles={}, input_cb_depth={}, output_cb_depth={}, page_size_tiles={}, trid_in_flight={} "
+        "(reader_mode={}: 0=incremental, 2=per-trid DB with N reads in flight per TRID)",
+        push_tiles,
+        input_cb_depth,
+        output_cb_depth,
+        page_size_tiles,
+        trid_in_flight,
+        cfg.reader_mode);
+
+    CircularBufferConfig cb_in_config =
+        CircularBufferConfig(input_cb_depth * single_tile_size_bytes, {{kInputCbId, kDataFormat}})
+            .set_page_size(kInputCbId, single_tile_size_bytes);
+    CreateCircularBuffer(program, all_cores, cb_in_config);
+
+    CircularBufferConfig cb_out_config =
+        CircularBufferConfig(output_cb_depth * single_tile_size_bytes, {{kOutputCbId, kDataFormat}})
+            .set_page_size(kOutputCbId, single_tile_size_bytes);
+    CreateCircularBuffer(program, all_cores, cb_out_config);
+
+    // Reader: NOC1 / RISCV1, pulls from interleaved DRAM via TensorAccessor.
+    // Compile-time args order MUST match reader_interleaved.cpp:
+    //   [0]=cb_in, [1]=READER_MODE, [2]=PUSH_TILE_COUNT, [3]=TILES_PER_PAGE,
+    //   [4]=TRID_IN_FLIGHT, [5]=CROSS_PROGRAM_OFFSET_TILES, [6]=WRITE_ONLY,
+    //   then TensorAccessorArgs starting at index 7.
+    const uint32_t cross_program_offset_tiles = cfg.cross_program_dram_offset ? total_num_tiles : 0u;
+    std::vector<uint32_t> reader_compile_time_args = {
+        kInputCbId,
+        cfg.reader_mode,
+        push_tiles,
+        page_size_tiles,
+        trid_in_flight,
+        cross_program_offset_tiles,
+        cfg.write_only ? 1u : 0u};
+    // Defaults: reader=NOC0, writer=NOC1 (measured best). --reader-noc/--writer-noc override.
+    // HARD CONSTRAINT: the two data-movement kernels on a core must be on DIFFERENT NoCs.
+    // Putting both on the same NoC hangs the device (requires a chip reset), so fail fast.
+    TT_FATAL(
+        cfg.reader_noc <= 1 && cfg.writer_noc <= 1,
+        "--reader-noc/--writer-noc must be 0 or 1 (got reader={}, writer={})",
+        cfg.reader_noc,
+        cfg.writer_noc);
+    TT_FATAL(
+        cfg.reader_noc != cfg.writer_noc,
+        "reader and writer must use DIFFERENT NoCs (both NOC{} requested) -- same NoC hangs the device",
+        cfg.reader_noc);
+    const NOC reader_noc = (cfg.reader_noc == 1) ? NOC::NOC_1 : NOC::NOC_0;
+    const NOC writer_noc = (cfg.writer_noc == 1) ? NOC::NOC_1 : NOC::NOC_0;
+    log_info(LogTest, "NoC assignment: reader=NOC{}, writer=NOC{}", cfg.reader_noc, cfg.writer_noc);
+    TensorAccessorArgs(*input_buffer).append_to(reader_compile_time_args);
+    auto reader_kernel = CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/kernels/reader_interleaved.cpp",
+        all_cores,
+        DataMovementConfig{
+            .processor = DataMovementProcessor::RISCV_1, .noc = reader_noc, .compile_args = reader_compile_time_args});
+
+    // Writer: NOC0 / RISCV0, pushes to interleaved DRAM.
+    // Compile-time args order MUST match writer_interleaved.cpp:
+    //   [0]=cb_out, [1]=TILES_PER_PAGE, [2]=READ_ONLY, [3]=OUTPUT_CB_DEPTH_TILES,
+    //   [4]=CROSS_PROGRAM_OFFSET_TILES, [5]=END_BARRIER_MODE,
+    //   then TensorAccessorArgs starting at index 6.
+    std::vector<uint32_t> writer_compile_time_args = {
+        kOutputCbId,
+        page_size_tiles,
+        cfg.read_only ? 1u : 0u,
+        output_cb_depth,
+        cross_program_offset_tiles,
+        cfg.writer_end_barrier_mode};
+    TensorAccessorArgs(*output_buffer).append_to(writer_compile_time_args);
+    auto writer_kernel = CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/kernels/writer_interleaved.cpp",
+        all_cores,
+        DataMovementConfig{
+            .processor = DataMovementProcessor::RISCV_0, .noc = writer_noc, .compile_args = writer_compile_time_args});
+
+    // Compute: copy_tile + tunable NOP spin (CB pass-through under --bypass-compute / --write-only).
+    std::vector<uint32_t> compute_compile_time_args = {
+        kInputCbId, kOutputCbId, cfg.num_nops_per_tile, cfg.lean_compute ? 0u : 1u, cfg.bypass_compute ? 1u : 0u};
+    auto compute_kernel = CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/kernels/compute_copy_with_nops.cpp",
+        all_cores,
+        ComputeConfig{.compile_args = compute_compile_time_args});
+
+    // Per-core runtime args: each core gets [start_tile_id, start_tile_id + n_tiles).
+    const auto work_groups = {
+        std::make_pair(core_group_1, num_tiles_per_core_group_1),
+        std::make_pair(core_group_2, num_tiles_per_core_group_2)};
+    uint32_t start_tile_id = 0;
+    uint32_t core_idx = 0;  // for the deliberate per-core read stagger
+    for (const auto& [group, tiles_per_core] : work_groups) {
+        if (tiles_per_core == 0) {
+            continue;
+        }
+        for (const auto& range : group.ranges()) {
+            for (const auto& core : range) {
+                const uint32_t read_delay = core_idx * cfg.reader_stagger_cycles;
+                SetRuntimeArgs(
+                    program,
+                    reader_kernel,
+                    core,
+                    {input_buffer->address(),
+                     tiles_per_core,
+                     start_tile_id,
+                     0,
+                     read_delay,
+                     cfg.kernel_unroll,
+                     cfg.read_progress_every});
+                SetRuntimeArgs(
+                    program,
+                    writer_kernel,
+                    core,
+                    {output_buffer->address(),
+                     tiles_per_core,
+                     start_tile_id,
+                     0,
+                     cfg.kernel_unroll,
+                     cfg.write_progress_every});
+                SetRuntimeArgs(program, compute_kernel, core, {tiles_per_core, 0, cfg.kernel_unroll});
+                start_tile_id += tiles_per_core;
+                ++core_idx;
+            }
+        }
+    }
+    TT_FATAL(
+        start_tile_id == total_num_tiles,
+        "Tile distribution mismatch: assigned {} but expected {}",
+        start_tile_id,
+        total_num_tiles);
+
+    BuiltProgram built;
+    built.program = std::move(program);
+    built.reader_kernel = reader_kernel;
+    built.writer_kernel = writer_kernel;
+    built.compute_kernel = compute_kernel;
+    built.core_group_1 = core_group_1;
+    built.core_group_2 = core_group_2;
+    built.tiles_per_core_group_1 = num_tiles_per_core_group_1;
+    built.tiles_per_core_group_2 = num_tiles_per_core_group_2;
+    built.reader_stagger_cycles = cfg.reader_stagger_cycles;
+    built.kernel_unroll = cfg.kernel_unroll;
+    built.write_progress_every = cfg.write_progress_every;
+    built.read_progress_every = cfg.read_progress_every;
+    built.reader_push_tile_count = push_tiles;
+    built.reader_mode = cfg.reader_mode;
+    built.reader_trid_in_flight = trid_in_flight;
+    built.input_cb_depth_tiles = input_cb_depth;
+    built.output_cb_depth_tiles = output_cb_depth;
+    built.page_size_tiles = page_size_tiles;
+    return built;
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    bool pass = true;
+    try {
+        const std::vector<std::string> args(argv, argv + argc);
+        const BenchmarkConfig cfg = parse_args(args);
+
+        log_info(
+            LogTest,
+            "op_to_op_latency: device_id={}, pages_per_core={}, reader_push_tiles={}, input_cb_depth_tiles={}, "
+            "output_cb_depth_tiles={}, reader_mode={}, compute_nops={}, num_programs={}, warmup={}, use_trace={}, "
+            "use_device_profiler={}, use_realtime_profiler={}, trace_region_size={}, trace_warmup_replays={}, "
+            "read_only={}, write_only={}, bypass_compute={}, lean_compute={}",
+            cfg.device_id,
+            cfg.num_pages_per_core,
+            cfg.reader_push_tile_count,
+            cfg.input_cb_depth_tiles,
+            cfg.output_cb_depth_tiles,
+            cfg.reader_mode,
+            cfg.num_nops_per_tile,
+            cfg.num_programs,
+            cfg.warmup,
+            cfg.use_trace,
+            cfg.use_device_profiler,
+            cfg.use_realtime_profiler,
+            cfg.trace_region_size,
+            cfg.trace_warmup_replays,
+            cfg.read_only,
+            cfg.write_only,
+            cfg.bypass_compute,
+            cfg.lean_compute);
+        TT_FATAL(cfg.num_programs >= 1, "--num-programs must be >= 1");
+        TT_FATAL(cfg.num_pages_per_core >= 1, "--num-pages-per-core must be >= 1");
+        TT_FATAL(cfg.reader_push_tile_count >= 1, "--reader-push-tiles must be >= 1");
+
+        // If the user asked for a CSV dump, make sure the runtime profiler is
+        // actually enabled (Tracy-enabled build + TT_METAL_DEVICE_PROFILER=1
+        // env var before process start). Without this check, the CSV would just be empty and the
+        // failure mode would be silent. Pattern mirrors test_dram_offchip.cpp.
+        if (cfg.use_device_profiler) {
+            const bool profiler_runtime_enabled =
+                tt::tt_metal::MetalContext::instance().rtoptions().get_profiler_enabled();
+            TT_FATAL(
+                profiler_runtime_enabled,
+                "--use-device-profiler requires the device profiler to be enabled at runtime. "
+                "Use a Tracy-enabled build (default: omit `build_metal.sh --disable-profiler`) and "
+                "export TT_METAL_DEVICE_PROFILER=1 before starting the process "
+                "(e.g. `TT_METAL_DEVICE_PROFILER=1 ./test_op_to_op_latency --use-device-profiler ...`). "
+                "If kernels were JIT-cached without profiler, clear ~/.cache/tt-metal-cache and re-run.");
+        }
+
+        // trace_region_size = 0 would disable trace capture entirely (legacy
+        // path) -- in trace mode we always want a non-zero value. The default
+        // is 1 MiB which covers tens of small programs comfortably.
+        const size_t trace_region_size = cfg.use_trace ? cfg.trace_region_size : 0;
+        auto mesh_device =
+            distributed::MeshDevice::create_unit_mesh(cfg.device_id, DEFAULT_L1_SMALL_SIZE, trace_region_size);
+
+        log_info(LogTest, "Clock: {} MHz", get_tt_npu_clock(mesh_device->get_devices()[0]));
+
+        const auto grid = mesh_device->compute_with_storage_grid_size();
+        uint32_t effective_cores = grid.x * grid.y;
+        if (cfg.num_active_cores > 0 && cfg.num_active_cores < effective_cores) {
+            effective_cores = cfg.num_active_cores;
+        }
+        const uint32_t num_cores = effective_cores;
+        const uint32_t total_num_tiles = num_cores * cfg.num_pages_per_core;
+
+        constexpr auto kDataFormat = tt::DataFormat::Float16_b;
+        const uint32_t single_tile_size_bytes = tile_size(kDataFormat);
+        // When cross-program DRAM offset is on, allocate enough room for warmup
+        // (pid=0) + num_programs disjoint slices so each timed program touches
+        // fresh DRAM pages.
+        const uint32_t buffer_num_tiles =
+            cfg.cross_program_dram_offset ? (cfg.num_programs + 1u) * total_num_tiles : total_num_tiles;
+        const uint32_t buffer_size_bytes = buffer_num_tiles * single_tile_size_bytes;
+        if (cfg.cross_program_dram_offset) {
+            log_info(
+                LogTest,
+                "cross_program_dram_offset: enabled; buffer={} tiles ({} per-program slice x {} = {} MB)",
+                buffer_num_tiles,
+                total_num_tiles,
+                cfg.num_programs + 1u,
+                buffer_size_bytes / (1024 * 1024));
+        }
+
+        // Interleaved DRAM buffer: page_size = page_size_tiles * tile_bytes
+        // (default 1 tile per page), so each NoC transaction transfers one
+        // page from one DRAM bank; pages are spread across banks round-robin.
+        const uint32_t dram_page_size_bytes =
+            (cfg.page_size_tiles > 0 ? cfg.page_size_tiles : 1) * single_tile_size_bytes;
+        distributed::DeviceLocalBufferConfig dram_local_config{
+            .page_size = dram_page_size_bytes,
+            .buffer_type = BufferType::DRAM,
+        };
+        distributed::ReplicatedBufferConfig dram_buf_config{.size = buffer_size_bytes};
+
+        auto input_buffer = distributed::MeshBuffer::create(dram_buf_config, dram_local_config, mesh_device.get());
+        auto output_buffer = distributed::MeshBuffer::create(dram_buf_config, dram_local_config, mesh_device.get());
+
+        // Random bf16 input data, packed two values per uint32_t.
+        const auto seed = static_cast<int>(std::chrono::system_clock::now().time_since_epoch().count());
+        std::vector<uint32_t> input_data =
+            create_random_vector_of_bfloat16(buffer_size_bytes, /*rand_max_float=*/100, seed);
+
+        auto& cq = mesh_device->mesh_command_queue();
+        distributed::EnqueueWriteMeshBuffer(cq, input_buffer, input_data, /*blocking=*/false);
+        // Drain the input upload before trace capture: host writes are not allowed while
+        // a trace is being recorded (see FDMeshCommandQueue "Writes are not supported
+        // during trace capture"). Warmup's Finish used to hide this; --no-warmup needs
+        // an explicit Finish here.
+        distributed::Finish(cq);
+
+        BuiltProgram built =
+            build_program(mesh_device, cfg, input_buffer, output_buffer, total_num_tiles, single_tile_size_bytes);
+
+        distributed::MeshWorkload workload;
+        const distributed::MeshCoordinateRange device_range(mesh_device->shape());
+        workload.add_program(device_range, std::move(built.program));
+        Program& program = workload.get_programs().begin()->second;
+
+        // Device CSV uses PROG_ID=0 for warmup/pre-compile; export skips id < 1.
+        // Host runtime_id=0 is not reported by the real-time profiler (dropped by Metal).
+        constexpr uint32_t kPrecompileProfilerProgramId = 0;
+
+        const uint32_t input_buffer_addr = input_buffer->address();
+        const uint32_t output_buffer_addr = output_buffer->address();
+        auto launch = [&](uint32_t profiler_program_id, uint32_t host_runtime_id) {
+            configure_program_launch(
+                program, built, input_buffer_addr, output_buffer_addr, profiler_program_id, host_runtime_id);
+        };
+
+        // Warmup (untimed): one eager enqueue absorbs the JIT-load /
+        // dispatcher prefetch cost so they do not pollute either the FD timing
+        // loop or the trace-capture step.
+        if (cfg.warmup) {
+            launch(kPrecompileProfilerProgramId, kPrecompileProfilerProgramId);
+            distributed::EnqueueMeshWorkload(cq, workload, /*blocking=*/false);
+            distributed::Finish(cq);
+        }
+
+        const bool rt_profiler_active = tt::tt_metal::experimental::IsProgramRealtimeProfilerActive();
+
+        constexpr uint8_t kCqId = 0;
+        long long elapsed_us = 0;
+        const char* mode_label = nullptr;
+
+        if (cfg.use_trace) {
+            // First enqueue inside trace capture triggers JIT / host-side setup, which
+            // is not allowed while recording ("Writes are not supported during trace
+            // capture"). Warmup already pre-compiles; with --no-warmup do it here.
+            if (!cfg.warmup) {
+                log_info(LogTest, "Trace mode: pre-compiling kernels before capture (PROG_ID=0).");
+                launch(kPrecompileProfilerProgramId, 1);
+                distributed::EnqueueMeshWorkload(cq, workload, /*blocking=*/false);
+                distributed::Finish(cq);
+            }
+
+            // Step 3: capture one trace containing all N back-to-back enqueues,
+            // then time a single replay + Finish. Capture itself is untimed --
+            // it's a one-time setup cost that is amortised when the same
+            // trace is replayed many times in real workloads.
+            //
+            // Note: BeginTraceCapture is the only trace API exposed as a free
+            // distributed:: function; end / replay / release are MeshDevice
+            // member methods.
+            const distributed::MeshTraceId tid = distributed::BeginTraceCapture(mesh_device.get(), kCqId);
+            for (uint32_t i = 0; i < cfg.num_programs; ++i) {
+                const uint32_t program_index = i + 1;
+                launch(program_index, program_index);
+                distributed::EnqueueMeshWorkload(cq, workload, /*blocking=*/false);
+            }
+            mesh_device->end_mesh_trace(kCqId, tid);
+            distributed::Finish(cq);  // make sure capture is fully committed before timing
+
+            // Untimed replays warm up the trace path; we measure the steady-state replay.
+            for (uint32_t replay = 0; replay < cfg.trace_warmup_replays; ++replay) {
+                mesh_device->replay_mesh_trace(kCqId, tid, /*blocking=*/false);
+                distributed::Finish(cq);
+                if (cfg.use_device_profiler) {
+                    // Flush device profiler so warmup markers do not pollute the timed replay.
+                    tt::tt_metal::ReadMeshDeviceProfilerResults(*mesh_device);
+                }
+            }
+            if (cfg.trace_warmup_replays > 0) {
+                log_info(
+                    LogTest, "Trace: {} untimed warmup replay(s) before measured replay", cfg.trace_warmup_replays);
+            }
+
+            {
+                RealtimeProfilerDrainGuard rt_guard(mesh_device.get(), cfg.use_realtime_profiler, rt_profiler_active);
+                const auto t_begin = std::chrono::steady_clock::now();
+                mesh_device->replay_mesh_trace(kCqId, tid, /*blocking=*/false);
+                distributed::Finish(cq);
+                const auto t_end = std::chrono::steady_clock::now();
+                elapsed_us = std::chrono::duration_cast<std::chrono::microseconds>(t_end - t_begin).count();
+            }
+
+            mesh_device->release_mesh_trace(tid);
+            mode_label = cfg.trace_warmup_replays > 0 ? "Trace replay (after warmup)" : "Trace replay";
+        } else {
+            {
+                RealtimeProfilerDrainGuard rt_guard(mesh_device.get(), cfg.use_realtime_profiler, rt_profiler_active);
+                // Step 2: enqueue the same MeshWorkload back-to-back num_programs
+                // times under one Finish.
+                const auto t_begin = std::chrono::steady_clock::now();
+                for (uint32_t i = 0; i < cfg.num_programs; ++i) {
+                    const uint32_t program_index = i + 1;
+                    launch(program_index, program_index);
+                    distributed::EnqueueMeshWorkload(cq, workload, /*blocking=*/false);
+                }
+                distributed::Finish(cq);
+                const auto t_end = std::chrono::steady_clock::now();
+                elapsed_us = std::chrono::duration_cast<std::chrono::microseconds>(t_end - t_begin).count();
+            }
+            mode_label = "FD back-to-back";
+        }
+
+        const double avg_us_per_program = static_cast<double>(elapsed_us) / cfg.num_programs;
+        log_info(
+            LogTest,
+            "{}: {} programs in {} us (avg {:.2f} us/program)",
+            mode_label,
+            cfg.num_programs,
+            elapsed_us,
+            avg_us_per_program);
+
+        // Step 4: flush device profiler buffers to
+        // generated/profiler/.logs/profile_log_device.csv. For in-kernel timing,
+        // filter per-tile `MATH` rows (MATH TRISC) or firmware `TRISC-KERNEL`
+        // rows. Program-level op-to-op between host enqueues is from
+        // `--use-realtime-profiler`, not from nesting DeviceZoneScopedMainN in
+        // user TRISC kernels. tools/tracy/process_device_log.py can post-process
+        // the CSV.
+        if (cfg.use_device_profiler) {
+            tt::tt_metal::ReadMeshDeviceProfilerResults(*mesh_device);
+            log_info(
+                LogTest,
+                "Device profiler results dumped. Inspect "
+                "$TT_METAL_HOME/generated/profiler/.logs/profile_log_device.csv "
+                "(PROG_ID, read/write barriers, TRISC_0 TILE_IDX, TRISC_2 FINISH_LAST_PUSH; "
+                "dispatch done/go: --use-realtime-profiler -> profile_log_device_rt.csv).");
+        }
+
+        // --write-only writes whatever L1 already held (no read, no copy), so the output never
+        // matches the input -- same reason --read-only skips this check. --bypass-compute does no
+        // copy either, so its output is garbage in every mode.
+        if (!cfg.read_only && !cfg.write_only && !cfg.bypass_compute && !cfg.skip_output_validation) {
+            std::vector<uint32_t> output_data;
+            distributed::EnqueueReadMeshBuffer(cq, output_data, output_buffer, /*blocking=*/true);
+
+            if (output_data.size() != input_data.size()) {
+                log_error(
+                    LogTest, "Output size mismatch: got {} elems, expected {}", output_data.size(), input_data.size());
+                pass = false;
+            } else {
+                const bool match = std::equal(input_data.begin(), input_data.end(), output_data.begin());
+                if (!match) {
+                    size_t mismatch_count = 0;
+                    size_t first_mismatch = 0;
+                    for (size_t i = 0; i < input_data.size(); ++i) {
+                        if (input_data[i] != output_data[i]) {
+                            if (mismatch_count == 0) {
+                                first_mismatch = i;
+                            }
+                            ++mismatch_count;
+                        }
+                    }
+                    log_error(
+                        LogTest,
+                        "Output mismatch: {}/{} elements differ; first mismatch at index {} "
+                        "(in=0x{:08x}, out=0x{:08x})",
+                        mismatch_count,
+                        input_data.size(),
+                        first_mismatch,
+                        input_data[first_mismatch],
+                        output_data[first_mismatch]);
+                    pass = false;
+                }
+            }
+        }  // !read_only validation
+
+        mesh_device->close();
+    } catch (const std::exception& e) {
+        log_error(LogTest, "Caught exception: {}", e.what());
+        pass = false;
+    }
+
+    if (pass) {
+        log_info(LogTest, "op_to_op_latency: PASSED");
+        return 0;
+    }
+    log_error(LogTest, "op_to_op_latency: FAILED");
+    return 1;
+}

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency.cpp
@@ -1,0 +1,1257 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Op-to-op latency benchmark.
+//
+// Background: HW team wants to measure the time between when one op's math
+// finishes and the next op's math starts (op-to-op latency). That gap is
+// firmware tear-down + dispatch + barrier overhead, and is what they need to
+// shrink (e.g. by virtualising init registers so program N+1 can preload
+// while N is still finishing, or by relaxing end-of-op barriers).
+//
+// This benchmark does the textbook reader -> CB -> compute -> CB -> writer
+// pipeline on every Tensix core, with interleaved DRAM in/out, then runs the
+// same MeshWorkload back-to-back N times in either Fast-Dispatch or Trace
+// mode. The compute kernel emits per-tile DeviceZoneScopedN("MATH") zones
+// (plus TILE_IDX data) so a profiler-enabled build dumps timestamps into
+// generated/profiler/.logs/profile_log_device.csv.
+//
+// For **program-level** op-to-op (between host enqueues), use
+// `--use-realtime-profiler` (ProgramRealtimeRecord gaps), not nested
+// DeviceZoneScopedMainN in user TRISC code (see compute kernel comments).
+//
+// CSV / in-kernel timing: use per-tile MATH zones on the MATH TRISC row,
+// or TRISC-KERNEL zones emitted by firmware (trisck.cc) for whole-kernel
+// envelope on each TRISC.
+//
+// CLI:
+//   --num-pages-per-core N  pages of interleaved DRAM per core (default 2)
+//   --compute-nops N        TTI_NOPs in the per-tile body (default 0;
+//                           tune up so the math zone is comfortably > 10us)
+//   --num-programs N        back-to-back enqueues per measurement (default 8)
+//   --use-trace             capture once + replay (default: FD mode)
+//   --use-device-profiler   call ReadMeshDeviceProfilerResults after Finish
+//                           (requires Tracy-enabled build — default unless
+//                            build_metal.sh --disable-profiler; plus env var
+//                            TT_METAL_DEVICE_PROFILER=1 before process start)
+//   --use-realtime-profiler register ProgramRealtimeProfilerCallback for the
+//                           timed portion only (FD: N enqueues + Finish; trace:
+//                           replay + Finish). Logs per-chip op-to-op gaps
+//                           (next start - previous end, ns). Inactive on some
+//                           dispatch setups; see
+//                           tech_reports/real_time_profiler/getting-started.md
+//   --trace-warmup-replays N  untimed trace replays before the measured replay (default 0)
+//   --trace-region-size N   trace buffer size, bytes (default 1 MiB)
+//   --device-id N           device under test (default 0)
+//   --output-cb-depth-tiles N  output CB depth in tiles (default 2)
+//   --read-only             isolate read BW: writer pops the output CB (no DRAM writes) and
+//                           compute is a CB pass-through. Implies --bypass-compute.
+//   --write-only            isolate write BW: reader issues NO NoC read and compute is a CB
+//                           pass-through (implies --bypass-compute), so DRAM sees writes only.
+//                           Pair with --output-cb-depth-tiles >= 8 (default 2 flushes after every
+//                           write).
+//   --bypass-compute        compute kernel becomes a CB pass-through (no unpack/copy/pack/NOPs),
+//                           taking the math datapath out of the measured path. Implied by BOTH
+//                           --read-only and --write-only; pass it explicitly only for a full
+//                           read+write op. Implies --lean-compute (per-tile markers would
+//                           otherwise still pace the pipeline). --compute-nops ignored, output
+//                           validation skipped.
+//
+// To sweep CB depths for peak BW, loop --input-cb-depth-tiles / --output-cb-depth-tiles from a
+// driver script (see scripts/run_bw_vs_cores.sh) rather than from inside the binary.
+
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <cstdlib>
+#include <exception>
+#include <fstream>
+#include <iomanip>
+#include <map>
+#include <sstream>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <tt-logger/tt-logger.hpp>
+#include <tt-metalium/bfloat16.hpp>
+#include <tt-metalium/buffer_types.hpp>
+#include <tt-metalium/circular_buffer_config.hpp>
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/device.hpp>
+#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/kernel_types.hpp>
+#include <tt-metalium/program.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/tt_backend_api_types.hpp>
+#include <tt-metalium/tt_metal.hpp>
+#include <tt-metalium/work_split.hpp>
+#include <tt-metalium/experimental/realtime_profiler.hpp>
+#include <hostdevcommon/common_values.hpp>
+#include "impl/context/metal_context.hpp"
+#include "tt_metal/tt_metal/perf_microbenchmark/common/util.hpp"
+
+#include "test_common.hpp"
+
+using namespace tt;
+using namespace tt::tt_metal;
+
+namespace {
+
+// Defaults:
+//   num_pages_per_core = 2 (each core processes 2 interleaved DRAM pages, so
+//                        every Tensix sees ≥ 2 per-tile MATH-zone entries
+//                        and we still touch every DRAM bank in a chip-wide
+//                        interleaved layout).
+//   num_nops_per_tile  = 0 keeps the math zone short by default; tune this
+//                        up via --compute-nops until the per-tile MATH zone
+//                        in profile_log_device.csv is comfortably > 10us
+//                        (the target program runtime for op-to-op latency
+//                        measurement to be meaningful vs dispatch noise).
+//   num_programs       = 8 enqueues back-to-back per measurement run; gives
+//                        seven (N-1) op-to-op gaps to look at later.
+//   warmup             = true runs one untimed enqueue first to absorb
+//                        dispatcher / kernel-setup transients.
+//   use_trace          = false keeps step-2 FD behaviour as default. Pass
+//                        --use-trace to capture-once / replay-once.
+//   trace_region_size  = 1 MiB. Plenty for tens of small back-to-back
+//                        programs; tunable via --trace-region-size if
+//                        --num-programs is bumped a lot.
+struct BenchmarkConfig {
+    uint32_t num_pages_per_core = 4;
+    uint32_t num_nops_per_tile = 0;
+    uint32_t num_programs = 8;
+    uint32_t device_id = 0;
+    uint32_t reader_push_tile_count = 2;
+    // 0 = auto (2 * reader_push_tile_count) for input CB depth.
+    uint32_t input_cb_depth_tiles = 0;
+    // 0 = default 2 tiles (compute->writer still pops 1 at a time).
+    uint32_t output_cb_depth_tiles = 0;
+    // 0 = reserve N then read+push one tile at a time (simple reference; cannot measure BW --
+    // emits no READ_LAST marker); 2 = per-trid double-buffer (N reads in flight per TRID), the
+    // only mode that measures read BW and the only one supporting page_size_tiles > 1.
+    uint32_t reader_mode = 0;
+    // Reads in flight per TRID for reader_mode 2. CB depth must be
+    // >= 2 * reader_trid_in_flight * page_size_tiles.
+    uint32_t reader_trid_in_flight = 2;
+    // DRAM page size in tiles. Larger pages = fewer, larger NoC transactions
+    // per program. CB pages stay 1 tile each so compute kernel is unchanged.
+    uint32_t page_size_tiles = 1;
+    // Deliberate per-core read stagger (experiment). 0 = off. Core i spins i*reader_stagger_cycles
+    // after go, before reading, to induce a controlled read-completion skew (to test whether
+    // staggered reads relieve write-barrier congestion).
+    uint32_t reader_stagger_cycles = 0;
+    // Kernel-unroll (experiment). >1 = each kernel repeats its whole workload this many times inside
+    // ONE program invocation with NO barrier between reps. Compared against --num-programs N of the
+    // same workload run back-to-back, the delta isolates the removed op-to-op sync-barrier cost.
+    uint32_t kernel_unroll = 1;
+    // Writer emits a measured progress timestamp every N pages (0=off) -> real write-issue bytes-vs-time
+    // per core, to measure BW allocation over time instead of interpolating between phase brackets.
+    uint32_t write_progress_every = 0;
+    uint32_t read_progress_every = 0;  // reader emits a progress timestamp every N pages completed (0=off)
+    // Cap active core count. 0 = use full grid (default). Used to test whether
+    // brisc_done_to_go scales with core count.
+    uint32_t num_active_cores = 0;
+    // Core placement for the active set: false = row-major (fill a row then next row),
+    // true = column-major (fix x, vary y first). Lets us probe NoC-direction asymmetry
+    // (a row of cores contends differently on the torus than a column).
+    bool core_layout_col = false;
+    // Skip the first `core_offset` cores in the fill order before taking `num_active_cores`.
+    // With --core-layout-col this selects an N-core block at a chosen column, so we can sweep
+    // WHICH cores (near vs far from DRAM) run and isolate NoC-distance from grid contention.
+    uint32_t core_offset = 0;
+    // Explicit LOGICAL core coords "x,y;x,y;..." -- overrides layout/offset. Lets us run an arbitrary
+    // hand-picked set (e.g. the literal slowest stragglers) to test whether a specific set underperforms.
+    std::vector<CoreCoord> core_list;
+    // Log each active core's logical->physical(NoC) coord mapping at setup (to match profiler coords).
+    bool log_core_map = false;
+    // NoC assignment for reader / writer (0 = NOC0, 1 = NOC1). The two NoCs route opposite
+    // directions on the torus; measured read-BW table shows reads scale to ~206 GB/s on
+    // NOC0 but cap at ~67 on NOC1, so the defaults are reader=NOC0, writer=NOC1 (the
+    // opposite of the framework default reader=NOC1/writer=NOC0). Override per kernel.
+    uint32_t reader_noc = 0;
+    uint32_t writer_noc = 1;
+    bool warmup = true;
+    bool use_trace = false;
+    bool use_device_profiler = false;
+    bool use_realtime_profiler = false;
+    size_t trace_region_size = 1ull << 20;  // 1 MiB
+    // Untimed trace replays before the measured replay (steady-state trace path).
+    uint32_t trace_warmup_replays = 0;
+    // Read-only mode: writer pops from output CB but skips DRAM writes.
+    // Isolates pure DRAM read BW through the reader pipeline.
+    bool read_only = false;
+    // Write-only mode: the mirror of --read-only for the write direction. The reader issues NO
+    // NoC read at all and the compute kernel becomes a CB pass-through (no unpack/copy/pack), so
+    // the only DRAM traffic is the writer's full-page interleaved writes.
+    //
+    // Approximating this with a "cheap read" (tiny reads, full-page pushes) does NOT work: it still
+    // costs one DRAM read TRANSACTION per page (1:1 with the writes, striding the same banks, so the
+    // controller pays read/write turnaround), and --lean-compute drops only instrumentation -- every
+    // tile is still unpacked and packed, so the writer stays paced by the packer. That combination
+    // measured 33% low on Blackhole (330 vs 440 GB/s at 110 cores).
+    //
+    // Writer run-ahead is then governed by the output CB depth (flush cadence is
+    // output_cb_depth/page_size_tiles - 1 writes), so --output-cb-depth-tiles matters here: the
+    // default of 2 flushes after EVERY write and will dominate the measurement.
+    bool write_only = false;
+    // Make the compute kernel a CB pass-through (no unpack / copy_tile / pack_tile / NOP spin) so
+    // the math datapath is out of the measured path. IMPLIED BY BOTH --read-only and --write-only:
+    // a single-direction BW mode measures that DRAM direction and nothing else. Exposed as its own
+    // flag only so it can be used with a full read+write op.
+    //
+    // Note --lean-compute is NOT a substitute: it drops only INSTRUMENTATION and still unpacks and
+    // packs every tile.
+    //
+    // Any mode with this set writes/propagates whatever L1 already held, so output validation is
+    // skipped (there is no copy to validate).
+    bool bypass_compute = false;
+    // Lean compute: drop per-tile TILE_IDX / MATH profiler markers (keep tile 0) so the
+    // consumer drains at full speed and does not back-pressure the reader. Use when
+    // measuring read bandwidth; compute cost is then copy + NOPs only.
+    bool lean_compute = false;
+    // Skip the host output-data check. The BW reader writes dummy data to a fixed L1
+    // address, so the written DRAM won't match the input; for latency/BW measurement
+    // (which needs real DRAM writes, i.e. not --read-only) we don't care about data.
+    bool skip_output_validation = false;
+    // Each program reads/writes a disjoint per-program tile slice rather than the
+    // same tiles every program. Forces DRAM controller to open new rows per
+    // program (more app-like streaming pattern); allocates a buffer big enough
+    // for (num_programs + 1) slices.
+    bool cross_program_dram_offset = false;
+    // Writer end-of-kernel barrier (Batch-8 latency experiment for 's HW
+    // barrier-elimination proposal):
+    //   0 = noc_async_write_barrier()  (DEFAULT; wait for DRAM ACK; safe)
+    //   1 = noc_async_writes_flushed() (cheaper; writes left source but not yet ACKed)
+    //   2 = no end barrier             (UNSAFE for real workloads; simulates HW
+    //                                   giving us this guarantee for free)
+    uint32_t writer_end_barrier_mode = 0;
+};
+
+BenchmarkConfig parse_args(const std::vector<std::string>& args) {
+    BenchmarkConfig cfg;
+    cfg.num_pages_per_core = test_args::get_command_option_uint32(args, "--num-pages-per-core", cfg.num_pages_per_core);
+    cfg.reader_push_tile_count =
+        test_args::get_command_option_uint32(args, "--reader-push-tiles", cfg.reader_push_tile_count);
+    cfg.input_cb_depth_tiles =
+        test_args::get_command_option_uint32(args, "--input-cb-depth-tiles", cfg.input_cb_depth_tiles);
+    cfg.output_cb_depth_tiles =
+        test_args::get_command_option_uint32(args, "--output-cb-depth-tiles", cfg.output_cb_depth_tiles);
+    if (test_args::has_command_option(args, "--reader-dbuf-trid")) {
+        // Per-trid double-buffer reader (Almeet's pipelined design).
+        cfg.reader_mode = 2;
+    }
+    if (test_args::has_command_option(args, "--reader-full-barrier")) {
+        // Full-barrier batch reader (common no-txn-id pattern): read --reader-push-tiles pages,
+        // one full noc_async_read_barrier, push credits, iterate. In-flight = --reader-push-tiles.
+        cfg.reader_mode = 1;
+    }
+    cfg.page_size_tiles = test_args::get_command_option_uint32(args, "--page-size-tiles", cfg.page_size_tiles);
+    cfg.reader_trid_in_flight =
+        test_args::get_command_option_uint32(args, "--reader-trid-in-flight", cfg.reader_trid_in_flight);
+    cfg.reader_stagger_cycles =
+        test_args::get_command_option_uint32(args, "--reader-stagger-cycles", cfg.reader_stagger_cycles);
+    cfg.kernel_unroll = test_args::get_command_option_uint32(args, "--kernel-unroll", cfg.kernel_unroll);
+    cfg.write_progress_every = test_args::get_command_option_uint32(args, "--write-progress-every", 0);
+    cfg.read_progress_every = test_args::get_command_option_uint32(args, "--read-progress-every", 0);
+    cfg.num_active_cores = test_args::get_command_option_uint32(args, "--num-active-cores", cfg.num_active_cores);
+    if (test_args::has_command_option(args, "--core-layout-col")) {
+        cfg.core_layout_col = true;
+    }
+    cfg.core_offset = test_args::get_command_option_uint32(args, "--core-offset", 0);
+    cfg.log_core_map = test_args::has_command_option(args, "--log-core-map");
+    {
+        // --core-list "x,y;x,y;..." (logical coords). Overrides layout/offset; sets active-core count.
+        std::string cl = test_args::get_command_option(args, "--core-list", std::string(""));
+        std::stringstream ss(cl);
+        std::string tok;
+        while (std::getline(ss, tok, ';')) {
+            auto comma = tok.find(',');
+            if (comma != std::string::npos) {
+                cfg.core_list.push_back(CoreCoord{
+                    static_cast<size_t>(std::stoul(tok.substr(0, comma))),
+                    static_cast<size_t>(std::stoul(tok.substr(comma + 1)))});
+            }
+        }
+        if (!cfg.core_list.empty()) {
+            cfg.num_active_cores = static_cast<uint32_t>(cfg.core_list.size());
+        }
+    }
+    cfg.reader_noc = test_args::get_command_option_uint32(args, "--reader-noc", cfg.reader_noc);
+    cfg.writer_noc = test_args::get_command_option_uint32(args, "--writer-noc", cfg.writer_noc);
+    cfg.num_nops_per_tile = test_args::get_command_option_uint32(args, "--compute-nops", cfg.num_nops_per_tile);
+    cfg.num_programs = test_args::get_command_option_uint32(args, "--num-programs", cfg.num_programs);
+    cfg.device_id = test_args::get_command_option_uint32(args, "--device-id", cfg.device_id);
+    cfg.trace_region_size =
+        test_args::get_command_option_uint32(args, "--trace-region-size", static_cast<uint32_t>(cfg.trace_region_size));
+    cfg.trace_warmup_replays =
+        test_args::get_command_option_uint32(args, "--trace-warmup-replays", cfg.trace_warmup_replays);
+    if (test_args::has_command_option(args, "--no-warmup")) {
+        cfg.warmup = false;
+    }
+    if (test_args::has_command_option(args, "--use-trace")) {
+        cfg.use_trace = true;
+    }
+    if (test_args::has_command_option(args, "--use-device-profiler")) {
+        cfg.use_device_profiler = true;
+    }
+    if (test_args::has_command_option(args, "--use-realtime-profiler")) {
+        cfg.use_realtime_profiler = true;
+    }
+    if (test_args::has_command_option(args, "--read-only")) {
+        cfg.read_only = true;
+    }
+    if (test_args::has_command_option(args, "--write-only")) {
+        cfg.write_only = true;
+    }
+    if (test_args::has_command_option(args, "--bypass-compute")) {
+        cfg.bypass_compute = true;
+    }
+    if (cfg.write_only || cfg.read_only) {
+        // Both single-direction modes mean "measure ONLY that DRAM direction", so neither leaves
+        // the math datapath in the measured path. --read-only without this back-pressures the
+        // reader through cb_in once compute can't keep up, which at low core counts (high per-core
+        // BW) makes it a compute measurement rather than a DRAM one.
+        cfg.bypass_compute = true;
+    }
+    // Keep this AFTER every assignment to bypass_compute above. Ordered before them it silently
+    // no-ops, and --read-only / --write-only alone then run passthrough with per-tile stamping on.
+    if (cfg.bypass_compute) {
+        // Passthrough removes the copy but per-tile TILE_IDX markers are gated by PROFILE_PER_TILE,
+        // not by PASSTHROUGH -- leaving them on would let instrumentation pace the pipeline.
+        cfg.lean_compute = true;
+    }
+    if (cfg.reader_mode == 2) {
+        // Mode 2 reads every page into the SAME fixed L1 address (dummy payload by design), so the
+        // output can never match the input and validation is guaranteed to fail.
+        cfg.skip_output_validation = true;
+    }
+    if (test_args::has_command_option(args, "--skip-output-validation")) {
+        cfg.skip_output_validation = true;
+    }
+    if (test_args::has_command_option(args, "--lean-compute")) {
+        cfg.lean_compute = true;
+    }
+    if (test_args::has_command_option(args, "--cross-program-dram-offset")) {
+        cfg.cross_program_dram_offset = true;
+    }
+    cfg.writer_end_barrier_mode =
+        test_args::get_command_option_uint32(args, "--writer-end-barrier-mode", cfg.writer_end_barrier_mode);
+    if (cfg.writer_end_barrier_mode > 3) {
+        log_fatal(
+            LogTest,
+            "--writer-end-barrier-mode must be 0 (barrier), 1 (flushed), 2 (none), or 3 (posted writes: "
+            "fire-and-forget, no DRAM ACK; end = posted-writes-flushed = injected/sent, NOT landed)");
+        cfg.writer_end_barrier_mode = 0;
+    }
+    return cfg;
+}
+
+// Real-time profiler callbacks run on a worker thread; collect records here
+// and analyse after UnregisterProgramRealtimeProfilerCallback.
+void log_realtime_program_go_done(const std::vector<tt::tt_metal::experimental::ProgramRealtimeRecord>& records) {
+    std::map<uint32_t, std::vector<tt::tt_metal::experimental::ProgramRealtimeRecord>> by_chip;
+    for (const auto& r : records) {
+        by_chip[r.chip_id].push_back(r);
+    }
+    for (auto& [chip_id, chip_records] : by_chip) {
+        std::sort(chip_records.begin(), chip_records.end(), [](const auto& a, const auto& b) {
+            return a.start_timestamp < b.start_timestamp;
+        });
+        for (const auto& r : chip_records) {
+            const uint64_t duration_cycles =
+                (r.end_timestamp >= r.start_timestamp) ? (r.end_timestamp - r.start_timestamp) : 0;
+            const double duration_ns = (r.frequency > 0.0) ? static_cast<double>(duration_cycles) / r.frequency : 0.0;
+            log_info(
+                LogTest,
+                "Real-time profiler chip {} program {}: go_cycles={} done_cycles={} duration={:.2f} ns",
+                chip_id,
+                r.runtime_id,
+                r.start_timestamp,
+                r.end_timestamp,
+                duration_ns);
+        }
+    }
+}
+
+void log_realtime_op_to_op_gaps(const std::vector<tt::tt_metal::experimental::ProgramRealtimeRecord>& records) {
+    if (records.size() < 2) {
+        log_info(LogTest, "Real-time profiler: got {} record(s); need >= 2 to compute op-to-op gaps.", records.size());
+        return;
+    }
+    std::map<uint32_t, std::vector<tt::tt_metal::experimental::ProgramRealtimeRecord>> by_chip;
+    for (const auto& r : records) {
+        by_chip[r.chip_id].push_back(r);
+    }
+    for (auto& [chip_id, chip_records] : by_chip) {
+        std::sort(chip_records.begin(), chip_records.end(), [](const auto& a, const auto& b) {
+            return a.start_timestamp < b.start_timestamp;
+        });
+        double sum_gap_ns = 0.0;
+        uint32_t gap_count = 0;
+        double min_gap_ns = 0.0;
+        double max_gap_ns = 0.0;
+        std::vector<double> gaps_ns;
+        for (size_t i = 1; i < chip_records.size(); ++i) {
+            const auto& prev = chip_records[i - 1];
+            const auto& cur = chip_records[i];
+            if (cur.runtime_id == prev.runtime_id) {
+                log_warning(
+                    LogTest,
+                    "Real-time profiler chip {}: skipping dispatch gap between duplicate runtime_id {} "
+                    "(trace replay may report the same host runtime id twice)",
+                    chip_id,
+                    cur.runtime_id);
+                continue;
+            }
+            if (cur.start_timestamp < prev.end_timestamp) {
+                log_warning(
+                    LogTest,
+                    "Real-time profiler chip {}: record {} start {} < prev end {} (skip gap)",
+                    chip_id,
+                    i,
+                    cur.start_timestamp,
+                    prev.end_timestamp);
+                continue;
+            }
+            const uint64_t gap_cycles = cur.start_timestamp - prev.end_timestamp;
+            const double freq = (cur.frequency > 0.0) ? cur.frequency : prev.frequency;
+            if (freq <= 0.0) {
+                continue;
+            }
+            const double gap_ns = static_cast<double>(gap_cycles) / freq;
+            if (gap_count == 0) {
+                min_gap_ns = max_gap_ns = gap_ns;
+            } else {
+                min_gap_ns = std::min(min_gap_ns, gap_ns);
+                max_gap_ns = std::max(max_gap_ns, gap_ns);
+            }
+            sum_gap_ns += gap_ns;
+            ++gap_count;
+            gaps_ns.push_back(gap_ns);
+        }
+        if (gap_count > 0) {
+            std::sort(gaps_ns.begin(), gaps_ns.end());
+            const double median_ns = gaps_ns[gaps_ns.size() / 2];
+            log_info(
+                LogTest,
+                "Real-time profiler chip {}: {} op-to-op gap(s) — min {:.2f} ns, median {:.2f} ns, max {:.2f} ns, "
+                "mean {:.2f} ns (next program start − previous program end)",
+                chip_id,
+                gap_count,
+                min_gap_ns,
+                median_ns,
+                max_gap_ns,
+                sum_gap_ns / gap_count);
+            std::string all = "Real-time profiler chip " + std::to_string(chip_id) + " sorted gaps (ns):";
+            for (double g : gaps_ns) {
+                all += fmt::format(" {:.0f}", g);
+            }
+            log_info(LogTest, "{}", all);
+        }
+    }
+}
+
+struct RealtimeProfilerSession {
+    std::mutex mutex;
+    std::vector<tt::tt_metal::experimental::ProgramRealtimeRecord> records;
+    std::optional<tt::tt_metal::experimental::ProgramRealtimeProfilerCallbackHandle> handle;
+
+    void register_callback() {
+        handle = tt::tt_metal::experimental::RegisterProgramRealtimeProfilerCallback(
+            [this](const tt::tt_metal::experimental::ProgramRealtimeRecord& record) {
+                std::lock_guard<std::mutex> lock(mutex);
+                records.push_back(record);
+            });
+    }
+
+    void unregister_and_drain() {
+        if (handle.has_value()) {
+            tt::tt_metal::experimental::UnregisterProgramRealtimeProfilerCallback(*handle);
+            handle.reset();
+        }
+    }
+
+    std::vector<tt::tt_metal::experimental::ProgramRealtimeRecord> copy_records() {
+        std::lock_guard<std::mutex> lock(mutex);
+        return records;
+    }
+};
+
+void write_realtime_profiler_csv(
+    const std::vector<tt::tt_metal::experimental::ProgramRealtimeRecord>& records, const std::string& path) {
+    std::ofstream out(path);
+    if (!out) {
+        log_warning(LogTest, "Real-time profiler: could not open {} for write", path);
+        return;
+    }
+    out << "program_id,chip_id,go_cycles,done_cycles,gap_to_next_go_cycles,duration_cycles,duration_ns,frequency_ghz\n";
+    std::map<uint32_t, std::vector<tt::tt_metal::experimental::ProgramRealtimeRecord>> by_chip;
+    for (const auto& r : records) {
+        by_chip[r.chip_id].push_back(r);
+    }
+    for (auto& [chip_id, chip_records] : by_chip) {
+        std::sort(chip_records.begin(), chip_records.end(), [](const auto& a, const auto& b) {
+            return a.start_timestamp < b.start_timestamp;
+        });
+        for (size_t i = 0; i < chip_records.size(); ++i) {
+            const auto& r = chip_records[i];
+            const uint64_t duration_cycles =
+                (r.end_timestamp >= r.start_timestamp) ? (r.end_timestamp - r.start_timestamp) : 0;
+            const double duration_ns = (r.frequency > 0.0) ? static_cast<double>(duration_cycles) / r.frequency : 0.0;
+            uint64_t gap_to_next_go = 0;
+            if (i + 1 < chip_records.size()) {
+                const auto& next = chip_records[i + 1];
+                if (next.runtime_id != r.runtime_id && next.start_timestamp >= r.end_timestamp) {
+                    gap_to_next_go = next.start_timestamp - r.end_timestamp;
+                }
+            }
+            out << r.runtime_id << "," << chip_id << "," << r.start_timestamp << "," << r.end_timestamp << ","
+                << gap_to_next_go << "," << duration_cycles << "," << duration_ns << "," << r.frequency << "\n";
+        }
+    }
+    log_info(LogTest, "Real-time profiler: wrote {} record(s) to {}", records.size(), path);
+}
+
+// Registers RT profiler callback after warmup; on destruction quiesces, waits for
+// D2H records, unregisters, then logs per-chip op-to-op gaps (Mo's metric:
+// next start - previous end). Must outlive the timed enqueue burst only.
+struct RealtimeProfilerDrainGuard {
+    distributed::MeshDevice* mesh = nullptr;
+    std::unique_ptr<RealtimeProfilerSession> session;
+
+    RealtimeProfilerDrainGuard(distributed::MeshDevice* mesh_in, bool use_realtime_profiler, bool profiler_active) :
+        mesh(mesh_in) {
+        if (!use_realtime_profiler) {
+            return;
+        }
+        if (!profiler_active) {
+            log_warning(
+                LogTest,
+                "Real-time profiler: --use-realtime-profiler set but IsProgramRealtimeProfilerActive() is false; "
+                "skipping (ETH dispatch / remote chip / resources — see "
+                "tech_reports/real_time_profiler/getting-started.md).");
+            return;
+        }
+        session = std::make_unique<RealtimeProfilerSession>();
+        session->register_callback();
+        log_info(LogTest, "Real-time profiler: callback registered for timed section.");
+    }
+
+    RealtimeProfilerDrainGuard(const RealtimeProfilerDrainGuard&) = delete;
+    RealtimeProfilerDrainGuard& operator=(const RealtimeProfilerDrainGuard&) = delete;
+
+    ~RealtimeProfilerDrainGuard() {
+        if (!session) {
+            return;
+        }
+        mesh->quiesce_devices();
+        std::this_thread::sleep_for(std::chrono::milliseconds(500));
+        session->unregister_and_drain();
+        const auto records = session->copy_records();
+        log_realtime_program_go_done(records);
+        log_realtime_op_to_op_gaps(records);
+        const char* metal_home = std::getenv("TT_METAL_HOME");
+        if (metal_home != nullptr) {
+            write_realtime_profiler_csv(
+                records, std::string(metal_home) + "/generated/profiler/.logs/profile_log_device_rt.csv");
+        }
+    }
+};
+
+struct BuiltProgram {
+    Program program;
+    KernelHandle reader_kernel = 0;
+    KernelHandle writer_kernel = 0;
+    KernelHandle compute_kernel = 0;
+    CoreRangeSet core_group_1;
+    CoreRangeSet core_group_2;
+    uint32_t tiles_per_core_group_1 = 0;
+    uint32_t tiles_per_core_group_2 = 0;
+    uint32_t reader_push_tile_count = 2;
+    uint32_t reader_mode = 0;
+    uint32_t reader_trid_in_flight = 2;
+    uint32_t input_cb_depth_tiles = 0;
+    uint32_t output_cb_depth_tiles = 2;
+    uint32_t page_size_tiles = 1;
+    uint32_t reader_stagger_cycles = 0;  // core i spins i*this after go, before reading
+    uint32_t kernel_unroll = 1;          // repeat workload this many times per invocation (no mid-barrier)
+    uint32_t write_progress_every = 0;   // writer emits a progress timestamp every N pages (0=off)
+    uint32_t read_progress_every = 0;    // reader emits a progress timestamp every N pages (0=off)
+};
+
+// Set reader/writer/compute runtime args (only the truly per-launch ones; kernel knobs
+// like reader_mode / push_tile_count / tiles_per_page / trid_in_flight are compile-time
+// args on the kernel so they fold into constants and dead code gets eliminated).
+void set_program_launch_args(
+    Program& program,
+    const BuiltProgram& built,
+    uint32_t input_buffer_addr,
+    uint32_t output_buffer_addr,
+    uint32_t program_id) {
+    const auto work_groups = {
+        std::make_pair(built.core_group_1, built.tiles_per_core_group_1),
+        std::make_pair(built.core_group_2, built.tiles_per_core_group_2)};
+    uint32_t start_tile_id = 0;
+    uint32_t core_idx = 0;  // for the deliberate per-core read stagger
+    for (const auto& [group, tiles_per_core] : work_groups) {
+        if (tiles_per_core == 0) {
+            continue;
+        }
+        for (const auto& range : group.ranges()) {
+            for (const auto& core : range) {
+                const uint32_t read_delay = core_idx * built.reader_stagger_cycles;
+                SetRuntimeArgs(
+                    program,
+                    built.reader_kernel,
+                    core,
+                    {input_buffer_addr,
+                     tiles_per_core,
+                     start_tile_id,
+                     program_id,
+                     read_delay,
+                     built.kernel_unroll,
+                     built.read_progress_every});
+                SetRuntimeArgs(
+                    program,
+                    built.writer_kernel,
+                    core,
+                    {output_buffer_addr,
+                     tiles_per_core,
+                     start_tile_id,
+                     program_id,
+                     built.kernel_unroll,
+                     built.write_progress_every});
+                SetRuntimeArgs(program, built.compute_kernel, core, {tiles_per_core, program_id, built.kernel_unroll});
+                start_tile_id += tiles_per_core;
+                ++core_idx;
+            }
+        }
+    }
+}
+
+// Configure host runtime id (RT profiler) and device CSV program_id before each launch.
+void configure_program_launch(
+    Program& program,
+    const BuiltProgram& built,
+    uint32_t input_buffer_addr,
+    uint32_t output_buffer_addr,
+    uint32_t profiler_program_id,
+    uint32_t host_runtime_id) {
+    set_program_launch_args(program, built, input_buffer_addr, output_buffer_addr, profiler_program_id);
+    program.set_runtime_id(host_runtime_id);
+}
+
+// Build the reader -> compute -> writer program covering every Tensix core,
+// with the per-core tile slice assigned via runtime args.
+BuiltProgram build_program(
+    const std::shared_ptr<distributed::MeshDevice>& mesh_device,
+    const BenchmarkConfig& cfg,
+    const std::shared_ptr<distributed::MeshBuffer>& input_buffer,
+    const std::shared_ptr<distributed::MeshBuffer>& output_buffer,
+    uint32_t total_num_tiles,
+    uint32_t single_tile_size_bytes) {
+    Program program = CreateProgram();
+
+    const auto full_grid = mesh_device->compute_with_storage_grid_size();
+    uint32_t want = full_grid.x * full_grid.y;
+    if (cfg.num_active_cores > 0 && cfg.num_active_cores < want) {
+        want = cfg.num_active_cores;
+    }
+    // Build the full grid order (row-major, or column-major with --core-layout-col), then take
+    // `want` of them starting at --core-offset (which selects WHICH cores run -- e.g. the last
+    // `want` cores, the mirror-image set, is --core-offset (grid - want)).
+    std::vector<CoreCoord> full_order;
+    if (cfg.core_layout_col) {
+        for (uint32_t x = 0; x < full_grid.x; ++x) {
+            for (uint32_t y = 0; y < full_grid.y; ++y) {
+                full_order.push_back(CoreCoord{x, y});
+            }
+        }
+    } else {
+        for (uint32_t y = 0; y < full_grid.y; ++y) {
+            for (uint32_t x = 0; x < full_grid.x; ++x) {
+                full_order.push_back(CoreCoord{x, y});
+            }
+        }
+    }
+    std::vector<CoreCoord> core_list;
+    if (!cfg.core_list.empty()) {
+        core_list = cfg.core_list;  // explicit hand-picked LOGICAL set (overrides layout/offset)
+    } else {
+        const size_t off = std::min<size_t>(cfg.core_offset, full_order.size());
+        const size_t last = std::min<size_t>(off + want, full_order.size());
+        core_list.assign(full_order.begin() + off, full_order.begin() + last);
+    }
+    if (cfg.log_core_map) {
+        const auto did = mesh_device->get_devices()[0]->id();
+        const auto& sd = tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(did);
+        for (const auto& c : core_list) {
+            const auto p = sd.get_physical_tensix_core_from_logical(c);  // matches profiler core_x/core_y
+            log_info(LogTest, "COREMAP logical=({},{}) phys=({},{})", c.x, c.y, p.x, p.y);
+        }
+    }
+    const uint32_t num_cores = static_cast<uint32_t>(core_list.size());
+    std::vector<CoreRange> ranges;
+    ranges.reserve(num_cores);
+    for (const auto& c : core_list) {
+        ranges.emplace_back(c, c);
+    }
+    CoreRangeSet all_cores(ranges);
+    CoreRangeSet core_group_1 = all_cores;
+    CoreRangeSet core_group_2;
+    const uint32_t num_tiles_per_core_group_1 = num_cores > 0 ? total_num_tiles / num_cores : 0;
+    const uint32_t num_tiles_per_core_group_2 = 0;
+
+    log_info(
+        LogTest,
+        "Active cores: {} ({}-major, offset {}), full_grid {}x{}, total_num_tiles={} ({} tiles/core); "
+        "first={} last={}",
+        num_cores,
+        cfg.core_layout_col ? "column" : "row",
+        cfg.core_offset,
+        full_grid.x,
+        full_grid.y,
+        total_num_tiles,
+        num_tiles_per_core_group_1,
+        num_cores ? core_list.front().str() : "none",
+        num_cores ? core_list.back().str() : "none");
+
+    // Input CB depth defaults to 2x reader push chunk (e.g. push 2 -> depth 4).
+    constexpr uint32_t kInputCbId = tt::CBIndex::c_0;
+    constexpr uint32_t kOutputCbId = tt::CBIndex::c_16;
+    constexpr auto kDataFormat = tt::DataFormat::Float16_b;
+
+    const uint32_t push_tiles = cfg.reader_push_tile_count > 0 ? cfg.reader_push_tile_count : 1;
+    const uint32_t input_cb_depth = cfg.input_cb_depth_tiles > 0 ? cfg.input_cb_depth_tiles : (2 * push_tiles);
+    // Compute -> writer unchanged: still wait_front(1) / pack one tile at a time.
+    const uint32_t output_cb_depth = cfg.output_cb_depth_tiles > 0 ? cfg.output_cb_depth_tiles : 2;
+
+    TT_FATAL(
+        input_cb_depth >= push_tiles,
+        "input CB depth ({}) must be >= --reader-push-tiles ({})",
+        input_cb_depth,
+        push_tiles);
+    TT_FATAL(
+        cfg.num_pages_per_core >= push_tiles,
+        "--num-pages-per-core ({}) must be >= --reader-push-tiles ({})",
+        cfg.num_pages_per_core,
+        push_tiles);
+
+    TT_FATAL(
+        !(cfg.read_only && cfg.write_only),
+        "--read-only and --write-only are mutually exclusive (read-only skips the DRAM writes, "
+        "write-only skips the DRAM reads)");
+    if (cfg.bypass_compute && cfg.num_nops_per_tile > 0) {
+        log_warning(
+            LogTest,
+            "--bypass-compute ignores --compute-nops {} (the NOP spin lives between tile_regs_acquire "
+            "and tile_regs_commit, which is skipped along with copy_tile/pack_tile)",
+            cfg.num_nops_per_tile);
+    }
+    if (cfg.write_only && output_cb_depth <= 2) {
+        log_warning(
+            LogTest,
+            "--write-only with --output-cb-depth-tiles {} flushes after EVERY write "
+            "(flush cadence = output_cb_depth/page_size_tiles - 1), which serializes the writer and "
+            "will dominate the measured write BW. Pass --output-cb-depth-tiles 8 or more.",
+            output_cb_depth);
+    }
+
+    const uint32_t page_size_tiles = cfg.page_size_tiles > 0 ? cfg.page_size_tiles : 1;
+    TT_FATAL(
+        cfg.num_pages_per_core % page_size_tiles == 0,
+        "--num-pages-per-core ({}) must be a multiple of --page-size-tiles ({})",
+        cfg.num_pages_per_core,
+        page_size_tiles);
+    TT_FATAL(
+        input_cb_depth >= page_size_tiles,
+        "input CB depth ({}) must be >= --page-size-tiles ({})",
+        input_cb_depth,
+        page_size_tiles);
+    TT_FATAL(
+        output_cb_depth >= page_size_tiles,
+        "output CB depth ({}) must be >= --page-size-tiles ({}) so the writer can accumulate a full page",
+        output_cb_depth,
+        page_size_tiles);
+    const uint32_t trid_in_flight = cfg.reader_trid_in_flight > 0 ? cfg.reader_trid_in_flight : 2;
+    if (cfg.reader_mode == 2) {
+        TT_FATAL(
+            trid_in_flight >= 2,
+            "--reader-trid-in-flight ({}) must be >= 2 for mode 2 (per-trid double-buffer needs both sides active)",
+            trid_in_flight);
+        TT_FATAL(
+            input_cb_depth >= 2 * trid_in_flight * page_size_tiles,
+            "per-trid DB needs input CB depth ({}) >= 2 * --reader-trid-in-flight ({}) * --page-size-tiles ({})",
+            input_cb_depth,
+            trid_in_flight,
+            page_size_tiles);
+        TT_FATAL(
+            cfg.num_pages_per_core / page_size_tiles >= 1,
+            "--num-pages-per-core ({}) / --page-size-tiles ({}) must be >= 1 for reader_mode 2",
+            cfg.num_pages_per_core,
+            page_size_tiles);
+    } else if (page_size_tiles > 1) {
+        TT_FATAL(
+            false,
+            "--page-size-tiles > 1 currently requires --reader-dbuf-trid (reader_mode 2); "
+            "mode 0 uses tile_id as page_id and would read wrong data.");
+    }
+
+    log_info(
+        LogTest,
+        "Reader: push_tiles={}, input_cb_depth={}, output_cb_depth={}, page_size_tiles={}, trid_in_flight={} "
+        "(reader_mode={}: 0=incremental, 1=full-barrier batch (push_tiles in flight, one barrier), "
+        "2=per-trid DB with N reads in flight per TRID)",
+        push_tiles,
+        input_cb_depth,
+        output_cb_depth,
+        page_size_tiles,
+        trid_in_flight,
+        cfg.reader_mode);
+
+    CircularBufferConfig cb_in_config =
+        CircularBufferConfig(input_cb_depth * single_tile_size_bytes, {{kInputCbId, kDataFormat}})
+            .set_page_size(kInputCbId, single_tile_size_bytes);
+    CreateCircularBuffer(program, all_cores, cb_in_config);
+
+    CircularBufferConfig cb_out_config =
+        CircularBufferConfig(output_cb_depth * single_tile_size_bytes, {{kOutputCbId, kDataFormat}})
+            .set_page_size(kOutputCbId, single_tile_size_bytes);
+    CreateCircularBuffer(program, all_cores, cb_out_config);
+
+    // Reader: NOC1 / RISCV1, pulls from interleaved DRAM via TensorAccessor.
+    // Compile-time args order MUST match reader_interleaved.cpp:
+    //   [0]=cb_in, [1]=READER_MODE, [2]=PUSH_TILE_COUNT, [3]=TILES_PER_PAGE,
+    //   [4]=TRID_IN_FLIGHT, [5]=CROSS_PROGRAM_OFFSET_TILES, [6]=WRITE_ONLY,
+    //   then TensorAccessorArgs starting at index 7.
+    const uint32_t cross_program_offset_tiles = cfg.cross_program_dram_offset ? total_num_tiles : 0u;
+    std::vector<uint32_t> reader_compile_time_args = {
+        kInputCbId,
+        cfg.reader_mode,
+        push_tiles,
+        page_size_tiles,
+        trid_in_flight,
+        cross_program_offset_tiles,
+        cfg.write_only ? 1u : 0u};
+    // Defaults: reader=NOC0, writer=NOC1 (measured best). --reader-noc/--writer-noc override.
+    // HARD CONSTRAINT: the two data-movement kernels on a core must be on DIFFERENT NoCs.
+    // Putting both on the same NoC hangs the device (requires a chip reset), so fail fast.
+    TT_FATAL(
+        cfg.reader_noc <= 1 && cfg.writer_noc <= 1,
+        "--reader-noc/--writer-noc must be 0 or 1 (got reader={}, writer={})",
+        cfg.reader_noc,
+        cfg.writer_noc);
+    TT_FATAL(
+        cfg.reader_noc != cfg.writer_noc,
+        "reader and writer must use DIFFERENT NoCs (both NOC{} requested) -- same NoC hangs the device",
+        cfg.reader_noc);
+    const NOC reader_noc = (cfg.reader_noc == 1) ? NOC::NOC_1 : NOC::NOC_0;
+    const NOC writer_noc = (cfg.writer_noc == 1) ? NOC::NOC_1 : NOC::NOC_0;
+    log_info(LogTest, "NoC assignment: reader=NOC{}, writer=NOC{}", cfg.reader_noc, cfg.writer_noc);
+    TensorAccessorArgs(*input_buffer).append_to(reader_compile_time_args);
+    auto reader_kernel = CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/kernels/reader_interleaved.cpp",
+        all_cores,
+        DataMovementConfig{
+            .processor = DataMovementProcessor::RISCV_1, .noc = reader_noc, .compile_args = reader_compile_time_args});
+
+    // Writer: NOC0 / RISCV0, pushes to interleaved DRAM.
+    // Compile-time args order MUST match writer_interleaved.cpp:
+    //   [0]=cb_out, [1]=TILES_PER_PAGE, [2]=READ_ONLY, [3]=OUTPUT_CB_DEPTH_TILES,
+    //   [4]=CROSS_PROGRAM_OFFSET_TILES, [5]=END_BARRIER_MODE,
+    //   then TensorAccessorArgs starting at index 6.
+    std::vector<uint32_t> writer_compile_time_args = {
+        kOutputCbId,
+        page_size_tiles,
+        cfg.read_only ? 1u : 0u,
+        output_cb_depth,
+        cross_program_offset_tiles,
+        cfg.writer_end_barrier_mode};
+    TensorAccessorArgs(*output_buffer).append_to(writer_compile_time_args);
+    auto writer_kernel = CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/kernels/writer_interleaved.cpp",
+        all_cores,
+        DataMovementConfig{
+            .processor = DataMovementProcessor::RISCV_0, .noc = writer_noc, .compile_args = writer_compile_time_args});
+
+    // Compute: copy_tile + tunable NOP spin (CB pass-through under --bypass-compute / --write-only).
+    std::vector<uint32_t> compute_compile_time_args = {
+        kInputCbId, kOutputCbId, cfg.num_nops_per_tile, cfg.lean_compute ? 0u : 1u, cfg.bypass_compute ? 1u : 0u};
+    auto compute_kernel = CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/kernels/compute_copy_with_nops.cpp",
+        all_cores,
+        ComputeConfig{.compile_args = compute_compile_time_args});
+
+    // Per-core runtime args: each core gets [start_tile_id, start_tile_id + n_tiles).
+    const auto work_groups = {
+        std::make_pair(core_group_1, num_tiles_per_core_group_1),
+        std::make_pair(core_group_2, num_tiles_per_core_group_2)};
+    uint32_t start_tile_id = 0;
+    uint32_t core_idx = 0;  // for the deliberate per-core read stagger
+    for (const auto& [group, tiles_per_core] : work_groups) {
+        if (tiles_per_core == 0) {
+            continue;
+        }
+        for (const auto& range : group.ranges()) {
+            for (const auto& core : range) {
+                const uint32_t read_delay = core_idx * cfg.reader_stagger_cycles;
+                SetRuntimeArgs(
+                    program,
+                    reader_kernel,
+                    core,
+                    {input_buffer->address(),
+                     tiles_per_core,
+                     start_tile_id,
+                     0,
+                     read_delay,
+                     cfg.kernel_unroll,
+                     cfg.read_progress_every});
+                SetRuntimeArgs(
+                    program,
+                    writer_kernel,
+                    core,
+                    {output_buffer->address(),
+                     tiles_per_core,
+                     start_tile_id,
+                     0,
+                     cfg.kernel_unroll,
+                     cfg.write_progress_every});
+                SetRuntimeArgs(program, compute_kernel, core, {tiles_per_core, 0, cfg.kernel_unroll});
+                start_tile_id += tiles_per_core;
+                ++core_idx;
+            }
+        }
+    }
+    TT_FATAL(
+        start_tile_id == total_num_tiles,
+        "Tile distribution mismatch: assigned {} but expected {}",
+        start_tile_id,
+        total_num_tiles);
+
+    BuiltProgram built;
+    built.program = std::move(program);
+    built.reader_kernel = reader_kernel;
+    built.writer_kernel = writer_kernel;
+    built.compute_kernel = compute_kernel;
+    built.core_group_1 = core_group_1;
+    built.core_group_2 = core_group_2;
+    built.tiles_per_core_group_1 = num_tiles_per_core_group_1;
+    built.tiles_per_core_group_2 = num_tiles_per_core_group_2;
+    built.reader_stagger_cycles = cfg.reader_stagger_cycles;
+    built.kernel_unroll = cfg.kernel_unroll;
+    built.write_progress_every = cfg.write_progress_every;
+    built.read_progress_every = cfg.read_progress_every;
+    built.reader_push_tile_count = push_tiles;
+    built.reader_mode = cfg.reader_mode;
+    built.reader_trid_in_flight = trid_in_flight;
+    built.input_cb_depth_tiles = input_cb_depth;
+    built.output_cb_depth_tiles = output_cb_depth;
+    built.page_size_tiles = page_size_tiles;
+    return built;
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    bool pass = true;
+    try {
+        const std::vector<std::string> args(argv, argv + argc);
+        const BenchmarkConfig cfg = parse_args(args);
+
+        log_info(
+            LogTest,
+            "op_to_op_latency: device_id={}, pages_per_core={}, reader_push_tiles={}, input_cb_depth_tiles={}, "
+            "output_cb_depth_tiles={}, reader_mode={}, compute_nops={}, num_programs={}, warmup={}, use_trace={}, "
+            "use_device_profiler={}, use_realtime_profiler={}, trace_region_size={}, trace_warmup_replays={}, "
+            "read_only={}, write_only={}, bypass_compute={}, lean_compute={}",
+            cfg.device_id,
+            cfg.num_pages_per_core,
+            cfg.reader_push_tile_count,
+            cfg.input_cb_depth_tiles,
+            cfg.output_cb_depth_tiles,
+            cfg.reader_mode,
+            cfg.num_nops_per_tile,
+            cfg.num_programs,
+            cfg.warmup,
+            cfg.use_trace,
+            cfg.use_device_profiler,
+            cfg.use_realtime_profiler,
+            cfg.trace_region_size,
+            cfg.trace_warmup_replays,
+            cfg.read_only,
+            cfg.write_only,
+            cfg.bypass_compute,
+            cfg.lean_compute);
+        TT_FATAL(cfg.num_programs >= 1, "--num-programs must be >= 1");
+        TT_FATAL(cfg.num_pages_per_core >= 1, "--num-pages-per-core must be >= 1");
+        TT_FATAL(cfg.reader_push_tile_count >= 1, "--reader-push-tiles must be >= 1");
+
+        // If the user asked for a CSV dump, make sure the runtime profiler is
+        // actually enabled (Tracy-enabled build + TT_METAL_DEVICE_PROFILER=1
+        // env var before process start). Without this check, the CSV would just be empty and the
+        // failure mode would be silent. Pattern mirrors test_dram_offchip.cpp.
+        if (cfg.use_device_profiler) {
+            const bool profiler_runtime_enabled =
+                tt::tt_metal::MetalContext::instance().rtoptions().get_profiler_enabled();
+            TT_FATAL(
+                profiler_runtime_enabled,
+                "--use-device-profiler requires the device profiler to be enabled at runtime. "
+                "Use a Tracy-enabled build (default: omit `build_metal.sh --disable-profiler`) and "
+                "export TT_METAL_DEVICE_PROFILER=1 before starting the process "
+                "(e.g. `TT_METAL_DEVICE_PROFILER=1 ./test_op_to_op_latency --use-device-profiler ...`). "
+                "If kernels were JIT-cached without profiler, clear ~/.cache/tt-metal-cache and re-run.");
+        }
+
+        // trace_region_size = 0 would disable trace capture entirely (legacy
+        // path) -- in trace mode we always want a non-zero value. The default
+        // is 1 MiB which covers tens of small programs comfortably.
+        const size_t trace_region_size = cfg.use_trace ? cfg.trace_region_size : 0;
+        auto mesh_device =
+            distributed::MeshDevice::create_unit_mesh(cfg.device_id, DEFAULT_L1_SMALL_SIZE, trace_region_size);
+
+        log_info(LogTest, "Clock: {} MHz", get_tt_npu_clock(mesh_device->get_devices()[0]));
+
+        const auto grid = mesh_device->compute_with_storage_grid_size();
+        uint32_t effective_cores = grid.x * grid.y;
+        if (cfg.num_active_cores > 0 && cfg.num_active_cores < effective_cores) {
+            effective_cores = cfg.num_active_cores;
+        }
+        const uint32_t num_cores = effective_cores;
+        const uint32_t total_num_tiles = num_cores * cfg.num_pages_per_core;
+
+        constexpr auto kDataFormat = tt::DataFormat::Float16_b;
+        const uint32_t single_tile_size_bytes = tile_size(kDataFormat);
+        // When cross-program DRAM offset is on, allocate enough room for warmup
+        // (pid=0) + num_programs disjoint slices so each timed program touches
+        // fresh DRAM pages.
+        const uint32_t buffer_num_tiles =
+            cfg.cross_program_dram_offset ? (cfg.num_programs + 1u) * total_num_tiles : total_num_tiles;
+        const uint32_t buffer_size_bytes = buffer_num_tiles * single_tile_size_bytes;
+        if (cfg.cross_program_dram_offset) {
+            log_info(
+                LogTest,
+                "cross_program_dram_offset: enabled; buffer={} tiles ({} per-program slice x {} = {} MB)",
+                buffer_num_tiles,
+                total_num_tiles,
+                cfg.num_programs + 1u,
+                buffer_size_bytes / (1024 * 1024));
+        }
+
+        // Interleaved DRAM buffer: page_size = page_size_tiles * tile_bytes
+        // (default 1 tile per page), so each NoC transaction transfers one
+        // page from one DRAM bank; pages are spread across banks round-robin.
+        const uint32_t dram_page_size_bytes =
+            (cfg.page_size_tiles > 0 ? cfg.page_size_tiles : 1) * single_tile_size_bytes;
+        distributed::DeviceLocalBufferConfig dram_local_config{
+            .page_size = dram_page_size_bytes,
+            .buffer_type = BufferType::DRAM,
+        };
+        distributed::ReplicatedBufferConfig dram_buf_config{.size = buffer_size_bytes};
+
+        auto input_buffer = distributed::MeshBuffer::create(dram_buf_config, dram_local_config, mesh_device.get());
+        auto output_buffer = distributed::MeshBuffer::create(dram_buf_config, dram_local_config, mesh_device.get());
+
+        // Random bf16 input data, packed two values per uint32_t.
+        const auto seed = static_cast<int>(std::chrono::system_clock::now().time_since_epoch().count());
+        std::vector<uint32_t> input_data =
+            create_random_vector_of_bfloat16(buffer_size_bytes, /*rand_max_float=*/100, seed);
+
+        auto& cq = mesh_device->mesh_command_queue();
+        distributed::EnqueueWriteMeshBuffer(cq, input_buffer, input_data, /*blocking=*/false);
+        // Drain the input upload before trace capture: host writes are not allowed while
+        // a trace is being recorded (see FDMeshCommandQueue "Writes are not supported
+        // during trace capture"). Warmup's Finish used to hide this; --no-warmup needs
+        // an explicit Finish here.
+        distributed::Finish(cq);
+
+        BuiltProgram built =
+            build_program(mesh_device, cfg, input_buffer, output_buffer, total_num_tiles, single_tile_size_bytes);
+
+        distributed::MeshWorkload workload;
+        const distributed::MeshCoordinateRange device_range(mesh_device->shape());
+        workload.add_program(device_range, std::move(built.program));
+        Program& program = workload.get_programs().begin()->second;
+
+        // Device CSV uses PROG_ID=0 for warmup/pre-compile; export skips id < 1.
+        // Host runtime_id=0 is not reported by the real-time profiler (dropped by Metal).
+        constexpr uint32_t kPrecompileProfilerProgramId = 0;
+
+        const uint32_t input_buffer_addr = input_buffer->address();
+        const uint32_t output_buffer_addr = output_buffer->address();
+        auto launch = [&](uint32_t profiler_program_id, uint32_t host_runtime_id) {
+            configure_program_launch(
+                program, built, input_buffer_addr, output_buffer_addr, profiler_program_id, host_runtime_id);
+        };
+
+        // Warmup (untimed): one eager enqueue absorbs the JIT-load /
+        // dispatcher prefetch cost so they do not pollute either the FD timing
+        // loop or the trace-capture step.
+        if (cfg.warmup) {
+            launch(kPrecompileProfilerProgramId, kPrecompileProfilerProgramId);
+            distributed::EnqueueMeshWorkload(cq, workload, /*blocking=*/false);
+            distributed::Finish(cq);
+        }
+
+        const bool rt_profiler_active = tt::tt_metal::experimental::IsProgramRealtimeProfilerActive();
+
+        constexpr uint8_t kCqId = 0;
+        long long elapsed_us = 0;
+        const char* mode_label = nullptr;
+
+        if (cfg.use_trace) {
+            // First enqueue inside trace capture triggers JIT / host-side setup, which
+            // is not allowed while recording ("Writes are not supported during trace
+            // capture"). Warmup already pre-compiles; with --no-warmup do it here.
+            if (!cfg.warmup) {
+                log_info(LogTest, "Trace mode: pre-compiling kernels before capture (PROG_ID=0).");
+                launch(kPrecompileProfilerProgramId, 1);
+                distributed::EnqueueMeshWorkload(cq, workload, /*blocking=*/false);
+                distributed::Finish(cq);
+            }
+
+            // Step 3: capture one trace containing all N back-to-back enqueues,
+            // then time a single replay + Finish. Capture itself is untimed --
+            // it's a one-time setup cost that is amortised when the same
+            // trace is replayed many times in real workloads.
+            //
+            // Note: BeginTraceCapture is the only trace API exposed as a free
+            // distributed:: function; end / replay / release are MeshDevice
+            // member methods.
+            const distributed::MeshTraceId tid = distributed::BeginTraceCapture(mesh_device.get(), kCqId);
+            for (uint32_t i = 0; i < cfg.num_programs; ++i) {
+                const uint32_t program_index = i + 1;
+                launch(program_index, program_index);
+                distributed::EnqueueMeshWorkload(cq, workload, /*blocking=*/false);
+            }
+            mesh_device->end_mesh_trace(kCqId, tid);
+            distributed::Finish(cq);  // make sure capture is fully committed before timing
+
+            // Untimed replays warm up the trace path; we measure the steady-state replay.
+            for (uint32_t replay = 0; replay < cfg.trace_warmup_replays; ++replay) {
+                mesh_device->replay_mesh_trace(kCqId, tid, /*blocking=*/false);
+                distributed::Finish(cq);
+                if (cfg.use_device_profiler) {
+                    // Flush device profiler so warmup markers do not pollute the timed replay.
+                    tt::tt_metal::ReadMeshDeviceProfilerResults(*mesh_device);
+                }
+            }
+            if (cfg.trace_warmup_replays > 0) {
+                log_info(
+                    LogTest, "Trace: {} untimed warmup replay(s) before measured replay", cfg.trace_warmup_replays);
+            }
+
+            {
+                RealtimeProfilerDrainGuard rt_guard(mesh_device.get(), cfg.use_realtime_profiler, rt_profiler_active);
+                const auto t_begin = std::chrono::steady_clock::now();
+                mesh_device->replay_mesh_trace(kCqId, tid, /*blocking=*/false);
+                distributed::Finish(cq);
+                const auto t_end = std::chrono::steady_clock::now();
+                elapsed_us = std::chrono::duration_cast<std::chrono::microseconds>(t_end - t_begin).count();
+            }
+
+            mesh_device->release_mesh_trace(tid);
+            mode_label = cfg.trace_warmup_replays > 0 ? "Trace replay (after warmup)" : "Trace replay";
+        } else {
+            {
+                RealtimeProfilerDrainGuard rt_guard(mesh_device.get(), cfg.use_realtime_profiler, rt_profiler_active);
+                // Step 2: enqueue the same MeshWorkload back-to-back num_programs
+                // times under one Finish.
+                const auto t_begin = std::chrono::steady_clock::now();
+                for (uint32_t i = 0; i < cfg.num_programs; ++i) {
+                    const uint32_t program_index = i + 1;
+                    launch(program_index, program_index);
+                    distributed::EnqueueMeshWorkload(cq, workload, /*blocking=*/false);
+                }
+                distributed::Finish(cq);
+                const auto t_end = std::chrono::steady_clock::now();
+                elapsed_us = std::chrono::duration_cast<std::chrono::microseconds>(t_end - t_begin).count();
+            }
+            mode_label = "FD back-to-back";
+        }
+
+        const double avg_us_per_program = static_cast<double>(elapsed_us) / cfg.num_programs;
+        log_info(
+            LogTest,
+            "{}: {} programs in {} us (avg {:.2f} us/program)",
+            mode_label,
+            cfg.num_programs,
+            elapsed_us,
+            avg_us_per_program);
+
+        // Step 4: flush device profiler buffers to
+        // generated/profiler/.logs/profile_log_device.csv. For in-kernel timing,
+        // filter per-tile `MATH` rows (MATH TRISC) or firmware `TRISC-KERNEL`
+        // rows. Program-level op-to-op between host enqueues is from
+        // `--use-realtime-profiler`, not from nesting DeviceZoneScopedMainN in
+        // user TRISC kernels. tools/tracy/process_device_log.py can post-process
+        // the CSV.
+        if (cfg.use_device_profiler) {
+            tt::tt_metal::ReadMeshDeviceProfilerResults(*mesh_device);
+            log_info(
+                LogTest,
+                "Device profiler results dumped. Inspect "
+                "$TT_METAL_HOME/generated/profiler/.logs/profile_log_device.csv "
+                "(PROG_ID, read/write barriers, TRISC_0 TILE_IDX, TRISC_2 FINISH_LAST_PUSH; "
+                "dispatch done/go: --use-realtime-profiler -> profile_log_device_rt.csv).");
+        }
+
+        // --write-only writes whatever L1 already held (no read, no copy), so the output never
+        // matches the input -- same reason --read-only skips this check. --bypass-compute does no
+        // copy either, so its output is garbage in every mode.
+        if (!cfg.read_only && !cfg.write_only && !cfg.bypass_compute && !cfg.skip_output_validation) {
+            std::vector<uint32_t> output_data;
+            distributed::EnqueueReadMeshBuffer(cq, output_data, output_buffer, /*blocking=*/true);
+
+            if (output_data.size() != input_data.size()) {
+                log_error(
+                    LogTest, "Output size mismatch: got {} elems, expected {}", output_data.size(), input_data.size());
+                pass = false;
+            } else {
+                const bool match = std::equal(input_data.begin(), input_data.end(), output_data.begin());
+                if (!match) {
+                    size_t mismatch_count = 0;
+                    size_t first_mismatch = 0;
+                    for (size_t i = 0; i < input_data.size(); ++i) {
+                        if (input_data[i] != output_data[i]) {
+                            if (mismatch_count == 0) {
+                                first_mismatch = i;
+                            }
+                            ++mismatch_count;
+                        }
+                    }
+                    log_error(
+                        LogTest,
+                        "Output mismatch: {}/{} elements differ; first mismatch at index {} "
+                        "(in=0x{:08x}, out=0x{:08x})",
+                        mismatch_count,
+                        input_data.size(),
+                        first_mismatch,
+                        input_data[first_mismatch],
+                        output_data[first_mismatch]);
+                    pass = false;
+                }
+            }
+        }  // !read_only validation
+
+        mesh_device->close();
+    } catch (const std::exception& e) {
+        log_error(LogTest, "Caught exception: {}", e.what());
+        pass = false;
+    }
+
+    if (pass) {
+        log_info(LogTest, "op_to_op_latency: PASSED");
+        return 0;
+    }
+    log_error(LogTest, "op_to_op_latency: FAILED");
+    return 1;
+}

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/sources.cmake
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/sources.cmake
@@ -31,6 +31,7 @@ set(PERF_MICROBENCH_TESTS_SRCS
     9_dram_adjacent_read_remote_l1_write/test_dram_read_l1_write.cpp
     10_dram_read_remote_cb_sync/test_dram_read_remote_cb.cpp
     11_remote_cb_sync_matmul_single_core/test_remote_cb_sync_matmul.cpp
+    op_to_op_latency/test_op_to_op_latency.cpp
 )
 
 set(X86_64_ONLY_TESTS


### PR DESCRIPTION
### PR Category
Test only

### Summary
This PR creates a new test, op_to_op_latency and tweaks the existing test bw_and_latency
Op to Op latency is used for discovery of dispatch and kernel init/teardown timing.  It includes a lot of scripts to run tests and generate charts as well as some tools for model analysis for determining the type and frequency of RAW hazards between ops.

### Notes for reviewers
This change is test only and AI generated.  It is well documented in the README for AI to understand how to use it to pick up the analysis work going forward.  The tests in and of themselves aren't useful for testing/regressing underlying functionality but rather for exploring how the HW behaves under certain conditions

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pkeller/op-to-op-latency)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pkeller/op-to-op-latency)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pkeller/op-to-op-latency)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pkeller/op-to-op-latency)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=pkeller/op-to-op-latency)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:pkeller/op-to-op-latency)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pkeller/op-to-op-latency)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pkeller/op-to-op-latency)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pkeller/op-to-op-latency)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pkeller/op-to-op-latency)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pkeller/op-to-op-latency)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pkeller/op-to-op-latency)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pkeller/op-to-op-latency)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pkeller/op-to-op-latency)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pkeller/op-to-op-latency)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pkeller/op-to-op-latency)