### PR TITLE
[Cleanup] remove deprecated global-namespace CoreCoord alias

### DIFF
--- a/tests/scale_out/4x_bh_quietbox/test_sanity.cpp
+++ b/tests/scale_out/4x_bh_quietbox/test_sanity.cpp
@@ -97,7 +97,7 @@ TEST(Sanity, ReportIntermeshLinks) {
             for (const auto& [channel, remote_connection] : links) {
                 tt::umd::CoreCoord eth_core =
                     cluster.get_soc_desc(chip_id).get_eth_core_for_channel(channel, CoordSystem::LOGICAL);
-                log_info(tt::LogTest, "  Channel {} at {}", channel, CoreCoord{eth_core.x, eth_core.y}.str());
+                log_info(tt::LogTest, "  Channel {} at {}", channel, tt::tt_metal::CoreCoord{eth_core.x, eth_core.y}.str());
             }
         }
     }

--- a/tests/tt_eager/ops/test_sfpu.cpp
+++ b/tests/tt_eager/ops/test_sfpu.cpp
@@ -102,7 +102,7 @@ bool run_sfpu_test(const std::string& sfpu_name, int tile_factor = 1, bool use_D
         ////////////////////////////////////////////////////////////////////////////
         tt_metal::Program program = tt_metal::CreateProgram();
 
-        CoreCoord core = {0, 0};
+        tt::tt_metal::CoreCoord core = {0, 0};
 
         uint32_t single_tile_size = 2 * 1024;
         uint32_t num_tiles = 1;

--- a/tests/tt_metal/multihost/fabric_tests/intermesh_routing_test_utils.cpp
+++ b/tests/tt_metal/multihost/fabric_tests/intermesh_routing_test_utils.cpp
@@ -54,7 +54,7 @@ WorkerMemMap generate_worker_mem_map(const std::shared_ptr<tt_metal::distributed
 std::shared_ptr<tt_metal::Program> create_receiver_program(
     const std::vector<uint32_t>& compile_time_args,
     const std::vector<uint32_t>& runtime_args,
-    const CoreCoord& logical_core) {
+    const tt::tt_metal::CoreCoord& logical_core) {
     auto recv_program = std::make_shared<tt_metal::Program>();
     auto recv_kernel = tt_metal::CreateKernel(
         *recv_program,
@@ -98,8 +98,8 @@ void run_unicast_sender_step(BaseFabricFixture* fixture, tt::tt_metal::distribut
     const auto& worker_grid_size = sender_device->compute_with_storage_grid_size();
     auto sender_x = std::uniform_int_distribution<uint32_t>(0, worker_grid_size.x - 2)(global_rng);
     auto sender_y = std::uniform_int_distribution<uint32_t>(0, worker_grid_size.y - 2)(global_rng);
-    CoreCoord sender_logical_core = {sender_x, sender_y};
-    CoreCoord receiver_logical_core = {0, 0};
+    tt::tt_metal::CoreCoord sender_logical_core = {sender_x, sender_y};
+    tt::tt_metal::CoreCoord receiver_logical_core = {0, 0};
 
     // Request randomized logical core from the receiver host
     distributed_context->recv(
@@ -118,7 +118,7 @@ void run_unicast_sender_step(BaseFabricFixture* fixture, tt::tt_metal::distribut
     log_debug(tt::LogTest, "Src MeshId {} ChipId {}", *(src_fabric_node_id.mesh_id), src_fabric_node_id.chip_id);
     log_debug(tt::LogTest, "Dst MeshId {} ChipId {}", *(dst_fabric_node_id.mesh_id), dst_fabric_node_id.chip_id);
 
-    CoreCoord receiver_virtual_core = sender_device->worker_core_from_logical_core(receiver_logical_core);
+    tt::tt_metal::CoreCoord receiver_virtual_core = sender_device->worker_core_from_logical_core(receiver_logical_core);
     auto receiver_noc_encoding =
         tt::tt_metal::MetalContext::instance().hal().noc_xy_encoding(receiver_virtual_core.x, receiver_virtual_core.y);
 
@@ -219,7 +219,7 @@ void run_unicast_recv_step(BaseFabricFixture* fixture, tt::tt_metal::distributed
     // Randomly select an rx core
     const auto& worker_grid_size = receiver_device->compute_with_storage_grid_size();
     auto recv_x = std::uniform_int_distribution<uint32_t>(0, worker_grid_size.x - 2)(global_rng);
-    CoreCoord receiver_logical_core = {recv_x, recv_x};
+    tt::tt_metal::CoreCoord receiver_logical_core = {recv_x, recv_x};
 
     // Send the randomized rx core to the sender host, so it can send packets to the correct destination
     distributed_context->send(
@@ -311,17 +311,17 @@ void run_mcast_sender_step(
     // Randomly select a mcast sender core
     auto sender_x = std::uniform_int_distribution<uint32_t>(0, worker_grid_size.x - 2)(global_rng);
     auto sender_y = std::uniform_int_distribution<uint32_t>(0, worker_grid_size.y - 2)(global_rng);
-    CoreCoord sender_logical_core = {sender_x, sender_y};
+    tt::tt_metal::CoreCoord sender_logical_core = {sender_x, sender_y};
 
     // Request randomized logical core from the receiver host
-    CoreCoord receiver_logical_core = {0, 0};
+    tt::tt_metal::CoreCoord receiver_logical_core = {0, 0};
     distributed_context->recv(
         ttsl::Span<std::byte>(reinterpret_cast<std::byte*>(&receiver_logical_core), sizeof(receiver_logical_core)),
         tt::tt_metal::distributed::multihost::Rank{recv_rank},  // receive from receiver host
         tt::tt_metal::distributed::multihost::Tag{0}            // exchange logical core over tag 0
     );
 
-    CoreCoord receiver_virtual_core = sender_device->worker_core_from_logical_core(receiver_logical_core);
+    tt::tt_metal::CoreCoord receiver_virtual_core = sender_device->worker_core_from_logical_core(receiver_logical_core);
     auto receiver_noc_encoding =
         tt::tt_metal::MetalContext::instance().hal().noc_xy_encoding(receiver_virtual_core.x, receiver_virtual_core.y);
 
@@ -427,7 +427,7 @@ void run_mcast_recv_step(
     // Randomly select an mcast receiver core
     const auto& worker_grid_size = mcast_start_device->compute_with_storage_grid_size();
     auto recv_x = std::uniform_int_distribution<uint32_t>(0, worker_grid_size.x - 2)(global_rng);
-    CoreCoord receiver_logical_core = {recv_x, recv_x};
+    tt::tt_metal::CoreCoord receiver_logical_core = {recv_x, recv_x};
 
     // Send the randomized receiver core to the sender host, so it can send packets to the correct destination
     distributed_context->send(

--- a/tests/tt_metal/multihost/fabric_tests/socket_send_recv.cpp
+++ b/tests/tt_metal/multihost/fabric_tests/socket_send_recv.cpp
@@ -325,8 +325,8 @@ std::vector<tt_metal::distributed::SocketConnection> generate_random_socket_conn
     tt_fabric::MeshId recv_mesh_id) {
     std::mt19937 gen = std::mt19937(sync_seed_across_ranks(sender_mesh_id, recv_mesh_id));
     auto mesh_device_shape = mesh_device->shape();
-    auto sender_core = CoreCoord(0, 0);
-    auto recv_core = CoreCoord(0, 0);
+    auto sender_core = tt::tt_metal::CoreCoord(0, 0);
+    auto recv_core = tt::tt_metal::CoreCoord(0, 0);
 
     std::set<MeshCoordinate> generated_sender_device_coords;
     std::set<MeshCoordinate> generated_recv_device_coords;

--- a/tests/tt_metal/tt_fabric/common/fabric_command_interface.cpp
+++ b/tests/tt_metal/tt_fabric/common/fabric_command_interface.cpp
@@ -27,7 +27,7 @@ void FabricCommandInterface::issue_command_to_routers(RouterCommand router_comma
         const auto& router_cores = get_all_router_cores();
         for (const auto& [fabric_node_id, channel_id] : router_cores) {
             ChipId physical_chip_id = control_plane.get_physical_chip_id_from_fabric_node_id(fabric_node_id);
-            CoreCoord eth_core = cluster.get_virtual_eth_core_from_channel(physical_chip_id, channel_id);
+            tt::tt_metal::CoreCoord eth_core = cluster.get_virtual_eth_core_from_channel(physical_chip_id, channel_id);
 
             cluster.write_core(
             &router_command,
@@ -116,7 +116,7 @@ RouterState FabricCommandInterface::read_router_state(
         tt::tt_metal::HalProgrammableCoreType::ACTIVE_ETH, tt::tt_metal::HalL1MemAddrType::ROUTER_STATE);
 
     ChipId physical_chip_id = control_plane.get_physical_chip_id_from_fabric_node_id(fabric_node_id);
-    CoreCoord eth_core = cluster.get_virtual_eth_core_from_channel(physical_chip_id, channel_id);
+    tt::tt_metal::CoreCoord eth_core = cluster.get_virtual_eth_core_from_channel(physical_chip_id, channel_id);
 
     RouterState state;
     cluster.read_core(

--- a/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
+++ b/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
@@ -422,7 +422,7 @@ void UDMFabricUnicastCommon(
         std::tuple<RoutingDirection, uint32_t /*num_hops*/>,
         std::tuple<uint32_t /*src_node*/, uint32_t /*dest_node*/>>& routing_info,
     std::optional<RoutingDirection> override_initial_direction = std::nullopt,
-    std::optional<std::vector<std::pair<CoreCoord, CoreCoord>>> worker_coords_list = std::nullopt,
+    std::optional<std::vector<std::pair<tt::tt_metal::CoreCoord, tt::tt_metal::CoreCoord>>> worker_coords_list = std::nullopt,
     bool dual_risc = false);
 
 void UDMFabricUnicastAllToAllCommon(BaseFabricFixture* fixture, NocPacketType noc_packet_type, bool dual_risc = false);

--- a/tests/tt_metal/tt_fabric/common/fabric_worker_kernel_helpers.cpp
+++ b/tests/tt_metal/tt_fabric/common/fabric_worker_kernel_helpers.cpp
@@ -48,7 +48,7 @@ WorkerMemoryLayout allocate_worker_memory() {
 
 std::shared_ptr<tt_metal::Program> create_traffic_generator_program(
     const std::shared_ptr<tt_metal::distributed::MeshDevice>& device,
-    const CoreCoord& logical_core,
+    const tt::tt_metal::CoreCoord& logical_core,
     const FabricNodeId& dest_fabric_node,
     const WorkerMemoryLayout& mem_layout) {
 
@@ -60,7 +60,7 @@ std::shared_ptr<tt_metal::Program> create_traffic_generator_program(
     auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
     FabricNodeId src_fabric_node = control_plane.get_fabric_node_id_from_physical_chip_id(src_physical_device->id());
     // Target core on remote chip for traffic destination
-    CoreCoord remote_logical_core(0, 0);
+    tt::tt_metal::CoreCoord remote_logical_core(0, 0);
 
     // Get remote buffer address from HAL (use unreserved L1 space on remote core)
     const auto& hal = tt::tt_metal::MetalContext::instance().hal();
@@ -121,7 +121,7 @@ std::shared_ptr<tt_metal::Program> create_traffic_generator_program(
 
 void signal_worker_teardown(
     const std::shared_ptr<tt_metal::distributed::MeshDevice>& mesh_device,
-    const CoreCoord& logical_core,
+    const tt::tt_metal::CoreCoord& logical_core,
     uint32_t teardown_signal_address) {
 
     // Write WORKER_TEARDOWN (1) to the teardown signal mailbox in L1

--- a/tests/tt_metal/tt_fabric/common/fabric_worker_kernel_helpers.hpp
+++ b/tests/tt_metal/tt_fabric/common/fabric_worker_kernel_helpers.hpp
@@ -28,14 +28,14 @@ WorkerMemoryLayout allocate_worker_memory();
 // FR-2: Launch worker kernel
 std::shared_ptr<tt_metal::Program> create_traffic_generator_program(
     const std::shared_ptr<tt_metal::distributed::MeshDevice>& device,
-    const CoreCoord& logical_core,
+    const tt::tt_metal::CoreCoord& logical_core,
     const FabricNodeId& dest_fabric_node,
     const WorkerMemoryLayout& mem_layout);
 
 // FR-8: Signal teardown to worker kernel
 void signal_worker_teardown(
     const std::shared_ptr<tt_metal::distributed::MeshDevice>& device,
-    const CoreCoord& logical_core,
+    const tt::tt_metal::CoreCoord& logical_core,
     uint32_t teardown_signal_address);
 
 

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
@@ -102,7 +102,7 @@ std::vector<uint32_t> get_random_numbers_from_range(uint32_t start, uint32_t end
 std::shared_ptr<tt_metal::Program> create_receiver_program(
     const std::vector<uint32_t>& compile_time_args,
     const std::vector<uint32_t>& runtime_args,
-    const CoreCoord& logical_core) {
+    const tt::tt_metal::CoreCoord& logical_core) {
     auto recv_program = std::make_shared<tt_metal::Program>();
     auto recv_kernel = tt_metal::CreateKernel(
         *recv_program,
@@ -218,8 +218,8 @@ void RunTestLineMcast(BaseFabricFixture* fixture, const std::vector<McastRouting
         }
     }
 
-    CoreCoord sender_logical_core = {0, 0};    // This core on the sender (remote chip) will make the mcast request
-    CoreCoord receiver_logical_core = {1, 0};  // Data will be forwarded to this core on al chips in the mcast group
+    tt::tt_metal::CoreCoord sender_logical_core = {0, 0};    // This core on the sender (remote chip) will make the mcast request
+    tt::tt_metal::CoreCoord receiver_logical_core = {1, 0};  // Data will be forwarded to this core on al chips in the mcast group
 
     const auto& fabric_context = control_plane.get_fabric_context();
     const auto& edm_config = fabric_context.get_builder_context().get_fabric_router_config();
@@ -233,7 +233,7 @@ void RunTestLineMcast(BaseFabricFixture* fixture, const std::vector<McastRouting
         mcast_group_devices.push_back(fixture->get_device(id));
     }
 
-    CoreCoord receiver_virtual_core = mcast_start_device->worker_core_from_logical_core(receiver_logical_core);
+    tt::tt_metal::CoreCoord receiver_virtual_core = mcast_start_device->worker_core_from_logical_core(receiver_logical_core);
 
     auto receiver_noc_encoding =
         tt::tt_metal::MetalContext::instance().hal().noc_xy_encoding(receiver_virtual_core.x, receiver_virtual_core.y);
@@ -347,8 +347,8 @@ void RunTestLineMcast(BaseFabricFixture* fixture, const std::vector<McastRouting
 }
 
 void RunTestUnicastRaw(BaseFabricFixture* fixture, uint32_t num_hops, RoutingDirection direction) {
-    CoreCoord sender_logical_core = {0, 0};
-    CoreCoord receiver_logical_core = {1, 0};
+    tt::tt_metal::CoreCoord sender_logical_core = {0, 0};
+    tt::tt_metal::CoreCoord receiver_logical_core = {1, 0};
 
     auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
 
@@ -432,7 +432,7 @@ void RunTestUnicastRaw(BaseFabricFixture* fixture, uint32_t num_hops, RoutingDir
 
     auto sender_device = fixture->get_device(src_physical_device_id);
     auto receiver_device = fixture->get_device(dst_physical_device_id);
-    CoreCoord receiver_virtual_core = receiver_device->worker_core_from_logical_core(receiver_logical_core);
+    tt::tt_metal::CoreCoord receiver_virtual_core = receiver_device->worker_core_from_logical_core(receiver_logical_core);
 
     // test parameters
     auto worker_mem_map = fixture->generate_worker_mem_map(sender_device, topology);
@@ -545,8 +545,8 @@ void run_unicast_test_bw_chips(
     ChipId dst_physical_device_id,
     uint32_t num_hops,
     bool use_dram_dst = false) {
-    CoreCoord sender_logical_core = {0, 0};
-    CoreCoord receiver_logical_core = {1, 0};
+    tt::tt_metal::CoreCoord sender_logical_core = {0, 0};
+    tt::tt_metal::CoreCoord receiver_logical_core = {1, 0};
 
     const auto& control_plane= tt::tt_metal::MetalContext::instance().get_control_plane();
     auto src_fabric_node_id = control_plane.get_fabric_node_id_from_physical_chip_id(src_physical_device_id);
@@ -554,7 +554,7 @@ void run_unicast_test_bw_chips(
 
     auto sender_device = fixture->get_device(src_physical_device_id);
     auto receiver_device = fixture->get_device(dst_physical_device_id);
-    CoreCoord receiver_virtual_core = receiver_device->worker_core_from_logical_core(receiver_logical_core);
+    tt::tt_metal::CoreCoord receiver_virtual_core = receiver_device->worker_core_from_logical_core(receiver_logical_core);
 
     const auto topology = control_plane.get_fabric_context().get_fabric_topology();
     uint32_t is_2d_fabric = topology == Topology::Mesh;
@@ -864,8 +864,8 @@ void RunTestMCastConnAPI(
     uint32_t fwd_hops,
     RoutingDirection bwd_dir,
     uint32_t bwd_hops) {
-    CoreCoord sender_logical_core = {0, 0};
-    CoreCoord receiver_logical_core = {1, 0};
+    tt::tt_metal::CoreCoord sender_logical_core = {0, 0};
+    tt::tt_metal::CoreCoord receiver_logical_core = {1, 0};
     std::vector<tt_metal::Program> receiver_programs;
 
     auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
@@ -929,7 +929,7 @@ void RunTestMCastConnAPI(
     auto left_fabric_node_id = end_fabric_node_ids_by_dir[fwd_dir][fwd_hops - 1];
     auto right_fabric_node_id = end_fabric_node_ids_by_dir[bwd_dir][bwd_hops - 1];
 
-    CoreCoord receiver_virtual_core = left_recv_device->worker_core_from_logical_core(receiver_logical_core);
+    tt::tt_metal::CoreCoord receiver_virtual_core = left_recv_device->worker_core_from_logical_core(receiver_logical_core);
 
     // test parameters
     auto worker_mem_map = fixture->generate_worker_mem_map(sender_device, topology);
@@ -1120,8 +1120,8 @@ void RunTest2DMCastConnAPI(
     uint32_t south_branch_east_hops = east_hops;
     uint32_t south_branch_west_hops = west_hops;
 
-    CoreCoord sender_logical_core = {0, 0};
-    CoreCoord receiver_logical_core = {1, 0};
+    tt::tt_metal::CoreCoord sender_logical_core = {0, 0};
+    tt::tt_metal::CoreCoord receiver_logical_core = {1, 0};
     std::vector<tt_metal::Program> receiver_programs;
 
     auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
@@ -1371,7 +1371,7 @@ void RunTest2DMCastConnAPI(
     auto sender_device = fixture->get_device(src_phys_chip_id);
     auto dst_recv_device = fixture->get_device(dst_recv_phys_chip_id);
 
-    CoreCoord receiver_virtual_core = dst_recv_device->worker_core_from_logical_core(receiver_logical_core);
+    tt::tt_metal::CoreCoord receiver_virtual_core = dst_recv_device->worker_core_from_logical_core(receiver_logical_core);
 
     auto receiver_noc_encoding =
         tt::tt_metal::MetalContext::instance().hal().noc_xy_encoding(receiver_virtual_core.x, receiver_virtual_core.y);
@@ -1653,8 +1653,8 @@ void RunTest2DMCastConnAPI(
 }
 
 void RunTestChipMCast1D(BaseFabricFixture* fixture, RoutingDirection dir, uint32_t start_distance, uint32_t range) {
-    CoreCoord sender_logical_core = {0, 0};
-    CoreCoord receiver_logical_core = {1, 0};
+    tt::tt_metal::CoreCoord sender_logical_core = {0, 0};
+    tt::tt_metal::CoreCoord receiver_logical_core = {1, 0};
     std::vector<tt_metal::Program> receiver_programs;
 
     auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
@@ -1718,7 +1718,7 @@ void RunTestChipMCast1D(BaseFabricFixture* fixture, RoutingDirection dir, uint32
     auto first_recv_fabric_node_id = end_fabric_node_ids_by_dir[dir][0];
     auto last_recv_fabric_node_id = end_fabric_node_ids_by_dir[dir][range - 1];
 
-    CoreCoord receiver_virtual_core =
+    tt::tt_metal::CoreCoord receiver_virtual_core =
         last_recv_device->worker_core_from_logical_core(receiver_logical_core);
 
     // test parameters
@@ -1959,7 +1959,7 @@ void RunEDMConnectionStressTest(
             auto worker_logical_cores_vec = corerange_to_cores(worker_logical_cores, std::nullopt, false);
 
             // Map logical to virtual cores
-            std::vector<CoreCoord> worker_virtual_cores;
+            std::vector<tt::tt_metal::CoreCoord> worker_virtual_cores;
             worker_virtual_cores.reserve(worker_logical_cores_vec.size());
             for (const auto& logical_core : worker_logical_cores_vec) {
                 worker_virtual_cores.push_back(sender_device->worker_core_from_logical_core(logical_core));
@@ -2113,8 +2113,8 @@ void FabricUnicastCommon(
     const std::vector<std::tuple<RoutingDirection, uint32_t>>& pair_ordered_dirs,
     FabricApiType api_type,
     bool with_state) {
-    CoreCoord sender_logical_core = {0, 0};
-    CoreCoord receiver_logical_core = {1, 0};
+    tt::tt_metal::CoreCoord sender_logical_core = {0, 0};
+    tt::tt_metal::CoreCoord receiver_logical_core = {1, 0};
     uint32_t num_packets = 10;
     uint32_t time_seed = std::chrono::system_clock::now().time_since_epoch().count();
 
@@ -2172,7 +2172,7 @@ void FabricUnicastCommon(
         dest_fabric_node_ids.push_back(tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(dst_physical_device_id));
     }
     auto sender_device = fixture->get_device(src_physical_device_id);
-    CoreCoord receiver_virtual_core = receiver_devices.back()->worker_core_from_logical_core(receiver_logical_core);
+    tt::tt_metal::CoreCoord receiver_virtual_core = receiver_devices.back()->worker_core_from_logical_core(receiver_logical_core);
 
     tt_metal::Program sender_program = tt_metal::CreateProgram();
 
@@ -2296,14 +2296,14 @@ void UDMFabricUnicastCommon(
         std::tuple<RoutingDirection, uint32_t /*num_hops*/>,
         std::tuple<uint32_t /*src_node*/, uint32_t /*dest_node*/>>& routing_info,
     std::optional<RoutingDirection> override_initial_direction,
-    std::optional<std::vector<std::pair<CoreCoord, CoreCoord>>> worker_coords_list,
+    std::optional<std::vector<std::pair<tt::tt_metal::CoreCoord, tt::tt_metal::CoreCoord>>> worker_coords_list,
     bool dual_risc) {
     // Build list of worker coordinate pairs - default to single pair (0,0) -> (1,0)
-    std::vector<std::pair<CoreCoord, CoreCoord>> worker_pairs;
+    std::vector<std::pair<tt::tt_metal::CoreCoord, tt::tt_metal::CoreCoord>> worker_pairs;
     if (worker_coords_list.has_value()) {
         worker_pairs = worker_coords_list.value();
     } else {
-        worker_pairs.push_back({CoreCoord{0, 0}, CoreCoord{1, 0}});
+        worker_pairs.push_back({tt::tt_metal::CoreCoord{0, 0}, tt::tt_metal::CoreCoord{1, 0}});
     }
     uint32_t num_packets = 10;
     uint32_t time_seed = std::chrono::system_clock::now().time_since_epoch().count();
@@ -2434,7 +2434,7 @@ void UDMFabricUnicastCommon(
             : "tests/tt_metal/tt_fabric/fabric_data_movement/kernels/test_udm_receiver.cpp";
 
     // Build CoreRangeSets for all sender and receiver cores
-    std::vector<CoreCoord> sender_cores, receiver_cores;
+    std::vector<tt::tt_metal::CoreCoord> sender_cores, receiver_cores;
     for (const auto& [sender_logical_core, receiver_logical_core] : worker_pairs) {
         sender_cores.push_back(sender_logical_core);
         receiver_cores.push_back(receiver_logical_core);
@@ -2550,8 +2550,8 @@ void UDMFabricUnicastCommon(
 
     // Set per-core runtime args (receiver/sender coords + fabric connection)
     for (const auto& [sender_logical_core, receiver_logical_core] : worker_pairs) {
-        CoreCoord sender_virtual_core = sender_device->worker_core_from_logical_core(sender_logical_core);
-        CoreCoord receiver_virtual_core = receiver_device->worker_core_from_logical_core(receiver_logical_core);
+        tt::tt_metal::CoreCoord sender_virtual_core = sender_device->worker_core_from_logical_core(sender_logical_core);
+        tt::tt_metal::CoreCoord receiver_virtual_core = receiver_device->worker_core_from_logical_core(receiver_logical_core);
 
         // Sender runtime args: receiver coords first, then fabric connection
         std::vector<uint32_t> sender_runtime_args = {receiver_virtual_core.x, receiver_virtual_core.y};
@@ -2597,8 +2597,8 @@ void UDMFabricUnicastCommon(
     fixture->WaitForSingleProgramDone(receiver_device, receiver_program);
 
     // Helper lambda to check test results for a given RISC
-    auto check_risc_results = [&](const CoreCoord& sender_core,
-                                  const CoreCoord& receiver_core,
+    auto check_risc_results = [&](const tt::tt_metal::CoreCoord& sender_core,
+                                  const tt::tt_metal::CoreCoord& receiver_core,
                                   const WorkerMemMap& mem_map,
                                   const std::string& risc_name) {
         std::vector<uint32_t> sender_status;
@@ -2829,8 +2829,8 @@ void UDMFabricUnicastAllToAllCommon(BaseFabricFixture* fixture, NocPacketType no
             this_device_idx};                           // receiver_device_idx (skip this slot)
 
         // Collect all sender-receiver core pairs (top half senders, bottom half receivers)
-        std::vector<CoreCoord> sender_logical_cores;
-        std::vector<CoreCoord> receiver_logical_cores;
+        std::vector<tt::tt_metal::CoreCoord> sender_logical_cores;
+        std::vector<tt::tt_metal::CoreCoord> receiver_logical_cores;
         for (uint32_t i = 0; i < num_core_pairs; i++) {
             uint32_t x = i % grid_size.x;
             uint32_t sender_y = i / grid_size.x;
@@ -2883,8 +2883,8 @@ void UDMFabricUnicastAllToAllCommon(BaseFabricFixture* fixture, NocPacketType no
         // Set runtime args per sender core
         // Each sender sends to the corresponding receiver on ALL other devices
         for (uint32_t core_idx = 0; core_idx < num_core_pairs; core_idx++) {
-            CoreCoord sender_logical_core = sender_logical_cores[core_idx];
-            CoreCoord receiver_logical_core = receiver_logical_cores[core_idx];
+            tt::tt_metal::CoreCoord sender_logical_core = sender_logical_cores[core_idx];
+            tt::tt_metal::CoreCoord receiver_logical_core = receiver_logical_cores[core_idx];
 
             // Runtime args: for each destination: (noc_x, noc_y, dst_dev_id, dst_mesh_id)
             std::vector<uint32_t> sender_runtime_args;
@@ -2894,7 +2894,7 @@ void UDMFabricUnicastAllToAllCommon(BaseFabricFixture* fixture, NocPacketType no
                 }
                 const auto& dest_fabric_node_id = fabric_node_ids[dest_idx];
                 const auto& dest_device_ptr = device_ptrs[dest_idx];
-                CoreCoord receiver_virtual_core = dest_device_ptr->worker_core_from_logical_core(receiver_logical_core);
+                tt::tt_metal::CoreCoord receiver_virtual_core = dest_device_ptr->worker_core_from_logical_core(receiver_logical_core);
 
                 sender_runtime_args.push_back(receiver_virtual_core.x);
                 sender_runtime_args.push_back(receiver_virtual_core.y);
@@ -2952,8 +2952,8 @@ void UDMFabricUnicastAllToAllCommon(BaseFabricFixture* fixture, NocPacketType no
         // Runtime args: (noc_x, noc_y, dst_dev_id, dst_mesh_id) for each reader
         if (is_read) {
             for (uint32_t core_idx = 0; core_idx < num_core_pairs; core_idx++) {
-                CoreCoord sender_logical_core = sender_logical_cores[core_idx];
-                CoreCoord receiver_logical_core = receiver_logical_cores[core_idx];
+                tt::tt_metal::CoreCoord sender_logical_core = sender_logical_cores[core_idx];
+                tt::tt_metal::CoreCoord receiver_logical_core = receiver_logical_cores[core_idx];
 
                 std::vector<uint32_t> receiver_runtime_args;
                 for (size_t reader_idx = 0; reader_idx < num_active_devices; reader_idx++) {
@@ -2963,7 +2963,7 @@ void UDMFabricUnicastAllToAllCommon(BaseFabricFixture* fixture, NocPacketType no
                     const auto& reader_fabric_node_id = fabric_node_ids[reader_idx];
                     const auto& reader_device_ptr = device_ptrs[reader_idx];
                     // The reader's sender core at the same position reads from this receiver
-                    CoreCoord reader_sender_virtual_core =
+                    tt::tt_metal::CoreCoord reader_sender_virtual_core =
                         reader_device_ptr->worker_core_from_logical_core(sender_logical_core);
 
                     receiver_runtime_args.push_back(reader_sender_virtual_core.x);
@@ -2984,7 +2984,7 @@ void UDMFabricUnicastAllToAllCommon(BaseFabricFixture* fixture, NocPacketType no
         if (noc_packet_type == NocPacketType::NOC_UNICAST_ATOMIC_INC) {
             uint32_t total_l1_to_clear = static_cast<uint32_t>(num_active_devices) * per_sender_l1_size;
             for (uint32_t core_idx = 0; core_idx < num_core_pairs; core_idx++) {
-                CoreCoord receiver_logical_core = receiver_logical_cores[core_idx];
+                tt::tt_metal::CoreCoord receiver_logical_core = receiver_logical_cores[core_idx];
                 std::vector<uint32_t> zeros(total_l1_to_clear / sizeof(uint32_t), 0);
                 tt_metal::detail::WriteToDeviceL1(
                     device_ptr->get_devices()[0],
@@ -3028,8 +3028,8 @@ void UDMFabricUnicastAllToAllCommon(BaseFabricFixture* fixture, NocPacketType no
                 uint32_t x = core_idx % grid_size.x;
                 uint32_t sender_y = core_idx / grid_size.x;
                 uint32_t receiver_y = receiver_y_start + sender_y;
-                CoreCoord sender_logical_core = {x, sender_y};
-                CoreCoord receiver_logical_core = {x, receiver_y};
+                tt::tt_metal::CoreCoord sender_logical_core = {x, sender_y};
+                tt::tt_metal::CoreCoord receiver_logical_core = {x, receiver_y};
 
                 // Check sender status
                 std::vector<uint32_t> sender_status;
@@ -3097,8 +3097,8 @@ void Fabric2DMulticastCommon(
     NocPacketType noc_packet_type,
     const std::vector<std::vector<std::tuple<RoutingDirection, uint32_t, uint32_t>>>& connection_configs,
     bool with_state) {
-    CoreCoord sender_logical_core = {0, 0};
-    CoreCoord receiver_logical_core = {1, 0};
+    tt::tt_metal::CoreCoord sender_logical_core = {0, 0};
+    tt::tt_metal::CoreCoord receiver_logical_core = {1, 0};
     uint32_t num_packets = 10;
     uint32_t time_seed = std::chrono::system_clock::now().time_since_epoch().count();
 
@@ -3270,7 +3270,7 @@ void Fabric2DMulticastCommon(
     }
     auto last_recv_phys_chip_id = *receiver_device_ids.begin();
     auto last_recv_device = fixture->get_device(last_recv_phys_chip_id);
-    CoreCoord receiver_virtual_core = last_recv_device->worker_core_from_logical_core(receiver_logical_core);
+    tt::tt_metal::CoreCoord receiver_virtual_core = last_recv_device->worker_core_from_logical_core(receiver_logical_core);
 
     if (noc_packet_type == NocPacketType::NOC_UNICAST_INLINE_WRITE) {
         worker_mem_map.packet_payload_size_bytes = 4;
@@ -3395,8 +3395,8 @@ void FabricMulticastCommon(
     NocPacketType noc_packet_type,
     const std::vector<std::tuple<RoutingDirection, uint32_t, uint32_t>>& pair_ordered_dir_configs,
     bool with_state) {
-    CoreCoord sender_logical_core = {0, 0};
-    CoreCoord receiver_logical_core = {1, 0};
+    tt::tt_metal::CoreCoord sender_logical_core = {0, 0};
+    tt::tt_metal::CoreCoord receiver_logical_core = {1, 0};
     uint32_t num_packets = 10;
     uint32_t time_seed = std::chrono::system_clock::now().time_since_epoch().count();
 
@@ -3458,7 +3458,7 @@ void FabricMulticastCommon(
     }
     auto last_recv_phys_chip_id = physical_end_device_ids_by_dir[first_dir].back();
     auto last_recv_device = fixture->get_device(last_recv_phys_chip_id);
-    CoreCoord receiver_virtual_core = last_recv_device->worker_core_from_logical_core(receiver_logical_core);
+    tt::tt_metal::CoreCoord receiver_virtual_core = last_recv_device->worker_core_from_logical_core(receiver_logical_core);
 
     if (noc_packet_type == NocPacketType::NOC_UNICAST_INLINE_WRITE) {
         worker_mem_map.packet_payload_size_bytes = 4;
@@ -3684,8 +3684,8 @@ TEST_F(NightlyFabric1DFixture, TestLinearFabricUnicastNocFusedScatterWriteAtomic
 
 void FabricSparseMulticastCommon(
     BaseFabricFixture* fixture, const std::vector<std::tuple<RoutingDirection, uint16_t>>& pair_ordered_dir_configs) {
-    CoreCoord sender_logical_core = {0, 0};
-    CoreCoord receiver_logical_core = {1, 0};
+    tt::tt_metal::CoreCoord sender_logical_core = {0, 0};
+    tt::tt_metal::CoreCoord receiver_logical_core = {1, 0};
     uint32_t num_packets = 10;
     uint32_t time_seed = std::chrono::system_clock::now().time_since_epoch().count();
 
@@ -3753,7 +3753,7 @@ void FabricSparseMulticastCommon(
     }
 
     auto sender_device = fixture->get_device(src_physical_device_id);
-    CoreCoord receiver_virtual_core = sender_device->worker_core_from_logical_core(receiver_logical_core);
+    tt::tt_metal::CoreCoord receiver_virtual_core = sender_device->worker_core_from_logical_core(receiver_logical_core);
 
     tt_metal::Program sender_program = tt_metal::CreateProgram();
 

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_apis.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_apis.cpp
@@ -79,7 +79,7 @@ std::shared_ptr<tt_metal::distributed::MeshBuffer> PrepareBuffer(
 }
 
 void RunGetNextHopRouterDirectionTest(BaseFabricFixture* fixture, bool is_multi_mesh = false) {
-    CoreCoord logical_core = {0, 0};
+    tt::tt_metal::CoreCoord logical_core = {0, 0};
     const auto& devices = fixture->get_devices();
     const size_t NUM_DEVICES = devices.size();
     bool invalid_test_scenario = !is_multi_mesh && NUM_DEVICES < 2;
@@ -181,7 +181,7 @@ void RunSetUnicastRouteTest(
     }
 
     // Select appropriate logical core based on core type - this will be device-specific
-    std::vector<CoreCoord> logical_cores(NUM_DEVICES);
+    std::vector<tt::tt_metal::CoreCoord> logical_cores(NUM_DEVICES);
     for (size_t dev_idx = 0; dev_idx < NUM_DEVICES; dev_idx++) {
         if (core_type == HalProgrammableCoreType::IDLE_ETH) {
             // Use first available IDLE_ETH core for each device
@@ -926,11 +926,11 @@ TEST_F(NightlyFabric2DUDMModeFixture, TestUDMFabricUnicastReadFromNode7) {
 }
 
 // Helper to generate all worker coordinate pairs in the compute grid (sender coord == receiver coord)
-std::vector<std::pair<CoreCoord, CoreCoord>> GetAllWorkerCoordPairs(CoreCoord grid_size) {
-    std::vector<std::pair<CoreCoord, CoreCoord>> pairs;
+std::vector<std::pair<tt::tt_metal::CoreCoord, tt::tt_metal::CoreCoord>> GetAllWorkerCoordPairs(tt::tt_metal::CoreCoord grid_size) {
+    std::vector<std::pair<tt::tt_metal::CoreCoord, tt::tt_metal::CoreCoord>> pairs;
     for (size_t x = 0; x < grid_size.x; x++) {
         for (size_t y = 0; y < grid_size.y; y++) {
-            CoreCoord coord{x, y};
+            tt::tt_metal::CoreCoord coord{x, y};
             pairs.push_back({coord, coord});
         }
     }

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_mux.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_mux.cpp
@@ -80,7 +80,7 @@ struct WorkerMemoryMap {
 
 struct WorkerTestConfig {
     WorkerMemoryMap* memory_map = nullptr;
-    CoreCoord worker_logical_core;
+    tt::tt_metal::CoreCoord worker_logical_core;
     uint8_t worker_id = 0;
     tt::tt_fabric::FabricMuxChannelType channel_type = tt::tt_fabric::FabricMuxChannelType::FULL_SIZE_CHANNEL;
     uint32_t num_buffers = 0;
@@ -88,7 +88,7 @@ struct WorkerTestConfig {
     uint8_t num_hops = 0;
     std::shared_ptr<tt_metal::distributed::MeshDevice> dest_device = nullptr;
     std::string_view kernel_src = sender_kernel_src;
-    CoreCoord termination_master_logical_core;
+    tt::tt_metal::CoreCoord termination_master_logical_core;
 };
 
 WorkerMemoryMap create_worker_memory_map(const uint32_t base_l1_address) {
@@ -234,13 +234,13 @@ std::vector<ChipId> get_physical_chip_sequence(uint32_t num_seq_chips) {
     return chip_seq;
 }
 
-uint32_t get_sender_id(CoreCoord logical_core) { return logical_core.x << 16 || logical_core.y; }
+uint32_t get_sender_id(tt::tt_metal::CoreCoord logical_core) { return logical_core.x << 16 || logical_core.y; }
 
 void create_kernel(
     tt::tt_metal::IDevice* device,
     tt::tt_metal::Program& program_handle,
     const std::string& kernel_src,
-    const CoreCoord& logical_core,
+    const tt::tt_metal::CoreCoord& logical_core,
     const std::vector<uint32_t>& ct_args,
     const std::vector<uint32_t>& rt_args,
     const std::vector<std::pair<size_t, size_t>>& addresses_to_clear) {
@@ -263,7 +263,7 @@ void create_kernel(
 
 void create_mux_kernel(
     const tt::tt_fabric::FabricMuxConfig& mux_kernel_config,
-    const CoreCoord& mux_logical_core,
+    const tt::tt_metal::CoreCoord& mux_logical_core,
     const std::shared_ptr<tt_metal::distributed::MeshDevice>& device,
     const std::shared_ptr<tt_metal::distributed::MeshDevice>& dest_device,
     tt::tt_metal::Program& program_handle) {
@@ -296,16 +296,16 @@ void create_worker_kernel(
     const TestConfig& test_config,
     const WorkerTestConfig& worker_test_config,
     const tt::tt_fabric::FabricMuxConfig& mux_kernel_config,
-    const CoreCoord& mux_virtual_core,
+    const tt::tt_metal::CoreCoord& mux_virtual_core,
     const std::shared_ptr<tt_metal::distributed::MeshDevice>& device,
     tt::tt_metal::Program& program_handle) {
     auto* worker_memory_map = worker_test_config.memory_map;
-    CoreCoord worker_logical_core = worker_test_config.worker_logical_core;
+    tt::tt_metal::CoreCoord worker_logical_core = worker_test_config.worker_logical_core;
     auto channel_type = worker_test_config.channel_type;
     auto worker_id = worker_test_config.worker_id;
 
-    CoreCoord termination_master_logical_core = worker_test_config.termination_master_logical_core;
-    CoreCoord termination_master_virtual_core = device->worker_core_from_logical_core(termination_master_logical_core);
+    tt::tt_metal::CoreCoord termination_master_logical_core = worker_test_config.termination_master_logical_core;
+    tt::tt_metal::CoreCoord termination_master_virtual_core = device->worker_core_from_logical_core(termination_master_logical_core);
     uint32_t termination_master_noc_xy_encoding = tt_metal::MetalContext::instance().hal().noc_xy_encoding(
         termination_master_virtual_core.x, termination_master_virtual_core.y);
     const bool is_termination_master = termination_master_logical_core == worker_logical_core;
@@ -329,7 +329,7 @@ void create_worker_kernel(
 
     // virtual coordinates will be the same for the receiver device
     // hence, we can use the noc encoding derived using current device
-    CoreCoord worker_virtual_core = device->worker_core_from_logical_core(worker_logical_core);
+    tt::tt_metal::CoreCoord worker_virtual_core = device->worker_core_from_logical_core(worker_logical_core);
     uint32_t receiver_noc_xy_encoding =
         tt_metal::MetalContext::instance().hal().noc_xy_encoding(worker_virtual_core.x, worker_virtual_core.y);
 
@@ -435,9 +435,9 @@ void run_mux_test_variant(FabricMuxBaseFixture* fixture, TestConfig test_config)
 
     // [device] -> {(logical_core, hops)}
     // keeps track of which logical cores will talk to each other and are how many hops away
-    std::unordered_map<std::shared_ptr<tt_metal::distributed::MeshDevice>, std::vector<std::pair<CoreCoord, uint8_t>>>
+    std::unordered_map<std::shared_ptr<tt_metal::distributed::MeshDevice>, std::vector<std::pair<tt::tt_metal::CoreCoord, uint8_t>>>
         device_senders_map;
-    std::unordered_map<std::shared_ptr<tt_metal::distributed::MeshDevice>, std::vector<std::pair<CoreCoord, uint8_t>>>
+    std::unordered_map<std::shared_ptr<tt_metal::distributed::MeshDevice>, std::vector<std::pair<tt::tt_metal::CoreCoord, uint8_t>>>
         device_receivers_map;
 
     // number of senders/receivers starting 2nd device in the sequence if uniformly distributed
@@ -455,11 +455,11 @@ void run_mux_test_variant(FabricMuxBaseFixture* fixture, TestConfig test_config)
         offset = 1;
     }
 
-    std::vector<CoreCoord> worker_logical_cores;
+    std::vector<tt::tt_metal::CoreCoord> worker_logical_cores;
     auto grid_size = devices[0]->compute_with_storage_grid_size();
     for (auto i = 0; i < grid_size.x; i++) {
         for (auto j = 0; j < grid_size.y; j++) {
-            worker_logical_cores.push_back(CoreCoord({i, j}));
+            worker_logical_cores.push_back(tt::tt_metal::CoreCoord({i, j}));
         }
     }
 
@@ -531,8 +531,8 @@ void run_mux_test_variant(FabricMuxBaseFixture* fixture, TestConfig test_config)
         program_handles[i] = tt_metal::CreateProgram();
 
         // use logical core (0,0) for the mux kernel
-        CoreCoord mux_logical_core = worker_logical_cores[0];
-        CoreCoord mux_virtual_core = devices[i]->worker_core_from_logical_core(mux_logical_core);
+        tt::tt_metal::CoreCoord mux_logical_core = worker_logical_cores[0];
+        tt::tt_metal::CoreCoord mux_virtual_core = devices[i]->worker_core_from_logical_core(mux_logical_core);
 
         auto num_full_size_channels = device_senders_map[devices[i]].size();
         auto num_header_only_channels = device_receivers_map[devices[i]].size();
@@ -602,7 +602,7 @@ void run_mux_test_variant(FabricMuxBaseFixture* fixture, TestConfig test_config)
     }
 
     if (!test_config.terminate_from_kernel) {
-        auto wait_for_worker_completion = [&](tt::tt_metal::IDevice* device, const CoreCoord& core) {
+        auto wait_for_worker_completion = [&](tt::tt_metal::IDevice* device, const tt::tt_metal::CoreCoord& core) {
             std::vector<uint32_t> worker_status(1, 0);
             while ((worker_status[0] & 0xFFFF) == 0) {
                 tt_metal::detail::ReadFromDeviceL1(
@@ -640,7 +640,7 @@ void run_mux_test_variant(FabricMuxBaseFixture* fixture, TestConfig test_config)
         fixture->WaitForSingleProgramDone(devices[i], program_handles[i]);
     }
 
-    auto validate_worker_results = [&](tt::tt_metal::IDevice* device, const CoreCoord& core) {
+    auto validate_worker_results = [&](tt::tt_metal::IDevice* device, const tt::tt_metal::CoreCoord& core) {
         std::vector<uint32_t> worker_status;
         tt_metal::detail::ReadFromDeviceL1(
             device, core, worker_memory_map.test_results_address, test_results_size_bytes, worker_status);

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_mux_v2.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_mux_v2.cpp
@@ -103,8 +103,8 @@ struct RemoteReceiverDevice {
     tt::tt_fabric::FabricNodeId fabric_node_id;
     tt::tt_fabric::FabricNodeId anchor_dst_fabric_node_id;
     MeshDevicePtr device;
-    CoreCoord receiver_mux_logical_core;
-    std::vector<CoreCoord> receiver_logical_cores;
+    tt::tt_metal::CoreCoord receiver_mux_logical_core;
+    std::vector<tt::tt_metal::CoreCoord> receiver_logical_cores;
     uint32_t linear_num_hops = 0;
 };
 
@@ -112,21 +112,21 @@ struct RoutingSelection {
     tt::tt_fabric::FabricNodeId src_fabric_node_id;
     MeshDevicePtr sender_device;
     tt::tt_fabric::FabricNodeId sender_anchor_dst_fabric_node_id;
-    CoreCoord sender_mux_logical_core;
-    std::vector<CoreCoord> sender_logical_cores;
+    tt::tt_metal::CoreCoord sender_mux_logical_core;
+    std::vector<tt::tt_metal::CoreCoord> sender_logical_cores;
     std::vector<RemoteReceiverDevice> remote_devices;
 };
 
 struct ReceiverEndpoint {
     tt::tt_fabric::FabricNodeId fabric_node_id;
     MeshDevicePtr device;
-    CoreCoord logical_core;
+    tt::tt_metal::CoreCoord logical_core;
     uint32_t linear_num_hops = 0;
 };
 
 struct SenderReceiverAssignment {
     uint8_t sender_logical_channel_id = 0;
-    CoreCoord sender_logical_core;
+    tt::tt_metal::CoreCoord sender_logical_core;
     ReceiverEndpoint receiver;
     uint32_t seed = 0;
 };
@@ -146,7 +146,7 @@ struct TestRuntimeConfig {
 struct MuxDeployment {
     MeshDevicePtr device;
     std::shared_ptr<tt::tt_metal::Program> program;
-    CoreCoord mux_virtual_core;
+    tt::tt_metal::CoreCoord mux_virtual_core;
     std::unique_ptr<tt::tt_fabric::FabricMuxV2Config> mux_config;
     uint8_t next_logical_channel_id = 0;
 };
@@ -210,13 +210,13 @@ TestRuntimeConfig build_test_runtime_config(const TestCaseConfig& test_case) {
     };
 }
 
-std::vector<CoreCoord> enumerate_worker_cores(const MeshDevicePtr& device) {
+std::vector<tt::tt_metal::CoreCoord> enumerate_worker_cores(const MeshDevicePtr& device) {
     const auto grid_size = device->compute_with_storage_grid_size();
-    std::vector<CoreCoord> worker_cores;
+    std::vector<tt::tt_metal::CoreCoord> worker_cores;
     worker_cores.reserve(static_cast<size_t>(grid_size.x) * static_cast<size_t>(grid_size.y));
     for (std::size_t y = 0; y < grid_size.y; ++y) {
         for (std::size_t x = 0; x < grid_size.x; ++x) {
-            worker_cores.push_back(CoreCoord{static_cast<std::size_t>(x), static_cast<std::size_t>(y)});
+            worker_cores.push_back(tt::tt_metal::CoreCoord{static_cast<std::size_t>(x), static_cast<std::size_t>(y)});
         }
     }
     return worker_cores;
@@ -473,7 +473,7 @@ std::unordered_map<ChipId, uint8_t> get_sender_count_by_receiver_device(
 tt::tt_metal::KernelHandle create_worker_kernel(
     tt::tt_metal::Program& program,
     const char* kernel_src,
-    const CoreCoord& logical_core,
+    const tt::tt_metal::CoreCoord& logical_core,
     std::vector<uint32_t> compile_args) {
     std::map<std::string, std::string> defines = {};
     if (is_2d_fabric()) {
@@ -496,7 +496,7 @@ std::optional<MuxDeployment> create_mux_deployment(
     const MeshDevicePtr& device,
     const tt::tt_fabric::FabricNodeId& src_fabric_node_id,
     const tt::tt_fabric::FabricNodeId& anchor_dst_fabric_node_id,
-    const CoreCoord& mux_logical_core,
+    const tt::tt_metal::CoreCoord& mux_logical_core,
     uint8_t num_channels,
     uint8_t num_buffers_per_channel,
     uint32_t channel_buffer_size_bytes,
@@ -598,7 +598,7 @@ std::vector<uint32_t> make_common_compile_args(
 
 void bind_worker_to_mux_channel(
     MuxDeployment& mux_deployment,
-    const CoreCoord& worker_logical_core,
+    const tt::tt_metal::CoreCoord& worker_logical_core,
     tt::tt_metal::KernelHandle kernel,
     std::vector<uint32_t>& runtime_args) {
     const auto flow_control_sem_id = tt::tt_metal::CreateSemaphore(*mux_deployment.program, worker_logical_core, 0);
@@ -620,7 +620,7 @@ std::vector<uint32_t> make_receiver_runtime_args(
     const SenderReceiverAssignment& assignment,
     const RoutingSelection& routing_selection,
     const ReceiverMemoryLayout& receiver_memory,
-    const CoreCoord& sender_virtual_core) {
+    const tt::tt_metal::CoreCoord& sender_virtual_core) {
     return {
         receiver_memory.packet_header_buffer_address,
         test_runtime_config.packet_payload_size_bytes,
@@ -641,7 +641,7 @@ std::vector<uint32_t> make_sender_runtime_args(
     const TestRuntimeConfig& test_runtime_config,
     const SenderReceiverAssignment& assignment,
     const SenderMemoryLayout& sender_memory,
-    const CoreCoord& receiver_virtual_core) {
+    const tt::tt_metal::CoreCoord& receiver_virtual_core) {
     const uint32_t effective_stage_count = std::min(
         {test_case.stage_count, test_case.num_packets, static_cast<uint32_t>(test_case.num_buffers_per_channel)});
 
@@ -668,7 +668,7 @@ uint64_t read_word_count(const std::vector<uint32_t>& worker_status) {
 }
 
 std::vector<uint32_t> read_worker_status(
-    const MeshDevicePtr& device, const CoreCoord& logical_core, uint32_t test_results_address) {
+    const MeshDevicePtr& device, const tt::tt_metal::CoreCoord& logical_core, uint32_t test_results_address) {
     std::vector<uint32_t> worker_status;
     tt::tt_metal::detail::ReadFromDeviceL1(
         device->get_devices()[0],

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_smoke.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_smoke.cpp
@@ -34,8 +34,8 @@
 namespace tt::tt_fabric::fabric_router_tests {
 
 void RunTestUnicastSmoke(BaseFabricFixture* fixture) {
-    CoreCoord sender_logical_core = {0, 0};
-    CoreCoord receiver_logical_core = {1, 0};
+    tt::tt_metal::CoreCoord sender_logical_core = {0, 0};
+    tt::tt_metal::CoreCoord receiver_logical_core = {1, 0};
 
     auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
     const auto& devices = fixture->get_devices();
@@ -55,7 +55,7 @@ void RunTestUnicastSmoke(BaseFabricFixture* fixture) {
     auto src_fabric_node_id = control_plane.get_fabric_node_id_from_physical_chip_id(src_physical_device_id);
     auto dst_fabric_node_id = control_plane.get_fabric_node_id_from_physical_chip_id(dst_physical_device_id);
 
-    CoreCoord receiver_virtual_core = receiver_device->worker_core_from_logical_core(receiver_logical_core);
+    tt::tt_metal::CoreCoord receiver_virtual_core = receiver_device->worker_core_from_logical_core(receiver_logical_core);
 
     // Get fabric context and topology
     const auto& fabric_context = control_plane.get_fabric_context();

--- a/tests/tt_metal/tt_fabric/fabric_router/test_channel_trimming_capture.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_channel_trimming_capture.cpp
@@ -67,7 +67,7 @@ using CaptureResults =
 // ============================================================================
 struct EthCoreCaptureResult {
     ChipId physical_chip_id;
-    CoreCoord logical_eth_core;
+    tt::tt_metal::CoreCoord logical_eth_core;
     chan_id_t channel_id;
     CaptureResults capture;
 };
@@ -76,18 +76,18 @@ struct EthCoreCaptureResult {
 // Helper: Enumerate the ETH cores/channels that participate in the configured
 // fabric topology for a physical chip.
 // ============================================================================
-std::vector<std::pair<CoreCoord, chan_id_t>> get_active_fabric_capture_cores(ChipId physical_chip_id) {
+std::vector<std::pair<tt::tt_metal::CoreCoord, chan_id_t>> get_active_fabric_capture_cores(ChipId physical_chip_id) {
     const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
     const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
     const auto& soc_desc = cluster.get_soc_desc(physical_chip_id);
     const auto fabric_node_id = control_plane.get_fabric_node_id_from_physical_chip_id(physical_chip_id);
     const auto active_channels = control_plane.get_active_fabric_eth_channels(fabric_node_id);
 
-    std::vector<std::pair<CoreCoord, chan_id_t>> capture_cores;
+    std::vector<std::pair<tt::tt_metal::CoreCoord, chan_id_t>> capture_cores;
     capture_cores.reserve(active_channels.size());
     for (const auto& [channel_id, _] : active_channels) {
         auto logical_eth_core = soc_desc.get_eth_core_for_channel(channel_id, CoordSystem::LOGICAL);
-        capture_cores.emplace_back(CoreCoord(logical_eth_core.x, logical_eth_core.y), channel_id);
+        capture_cores.emplace_back(tt::tt_metal::CoreCoord(logical_eth_core.x, logical_eth_core.y), channel_id);
     }
     return capture_cores;
 }
@@ -231,8 +231,8 @@ UnicastTrafficResult run_unicast_traffic_bw_nodes(
     FabricNodeId dst_fabric_node_id,
     uint32_t num_hops,
     uint32_t num_packets = 10) {
-    CoreCoord sender_logical_core = {0, 0};
-    CoreCoord receiver_logical_core = {1, 0};
+    tt::tt_metal::CoreCoord sender_logical_core = {0, 0};
+    tt::tt_metal::CoreCoord receiver_logical_core = {1, 0};
 
     const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
 
@@ -270,7 +270,7 @@ UnicastTrafficResult run_unicast_traffic_bw_nodes(
 
     auto sender_device = fixture->get_device(src_physical);
     auto receiver_device = fixture->get_device(dst_physical);
-    CoreCoord receiver_virtual_core = receiver_device->worker_core_from_logical_core(receiver_logical_core);
+    tt::tt_metal::CoreCoord receiver_virtual_core = receiver_device->worker_core_from_logical_core(receiver_logical_core);
 
     const auto topology = control_plane.get_fabric_context().get_fabric_topology();
     uint32_t is_2d_fabric = topology == Topology::Mesh;

--- a/tests/tt_metal/tt_fabric/test_infra/tt_fabric_test_common.hpp
+++ b/tests/tt_metal/tt_fabric/test_infra/tt_fabric_test_common.hpp
@@ -304,19 +304,19 @@ public:
         return mesh_graph.chip_to_coordinate(node_id.mesh_id, node_id.chip_id);
     }
 
-    uint32_t get_worker_noc_encoding(const CoreCoord logical_core) const override {
+    uint32_t get_worker_noc_encoding(const tt::tt_metal::CoreCoord logical_core) const override {
         const auto virtual_core = mesh_device_->worker_core_from_logical_core(logical_core);
         return tt_metal::MetalContext::instance().hal().noc_xy_encoding(virtual_core.x, virtual_core.y);
     }
 
-    CoreCoord get_virtual_core_from_logical_core(CoreCoord logical_core) const override {
+    tt::tt_metal::CoreCoord get_virtual_core_from_logical_core(tt::tt_metal::CoreCoord logical_core) const override {
         return mesh_device_->worker_core_from_logical_core(logical_core);
     }
 
-    CoreCoord get_worker_grid_size() const override { return mesh_device_->compute_with_storage_grid_size(); }
+    tt::tt_metal::CoreCoord get_worker_grid_size() const override { return mesh_device_->compute_with_storage_grid_size(); }
 
-    std::vector<CoreCoord> get_available_worker_cores() const override {
-        std::vector<CoreCoord> all_cores;
+    std::vector<tt::tt_metal::CoreCoord> get_available_worker_cores() const override {
+        std::vector<tt::tt_metal::CoreCoord> all_cores;
         tt::tt_metal::CoreCoord worker_grid = get_worker_grid_size();
         all_cores.reserve(worker_grid.x * worker_grid.y);
         for (uint32_t x = 0; x < worker_grid.x; ++x) {
@@ -327,7 +327,7 @@ public:
         return all_cores;
     }
 
-    uint32_t get_worker_id(const FabricNodeId& node_id, CoreCoord logical_core) const override {
+    uint32_t get_worker_id(const FabricNodeId& node_id, tt::tt_metal::CoreCoord logical_core) const override {
         return (*node_id.mesh_id << 12) | (node_id.chip_id << 8) | (logical_core.x << 4) | (logical_core.y);
     }
 
@@ -476,7 +476,7 @@ public:
     }
 
     std::shared_ptr<MeshBuffer> create_mesh_buffer_helper(
-        const std::vector<CoreCoord>& cores, uint32_t address, uint32_t size_bytes) const {
+        const std::vector<tt::tt_metal::CoreCoord>& cores, uint32_t address, uint32_t size_bytes) const {
         std::set<CoreRange> all_cores_set;
         for (const auto& core : cores) {
             all_cores_set.insert(CoreRange(core));
@@ -521,7 +521,7 @@ public:
     // Start non-blocking read operation
     ReadBufferOperation initiate_read_buffer_from_cores(
         const MeshCoordinate& device_coord,
-        const std::vector<CoreCoord>& cores,
+        const std::vector<tt::tt_metal::CoreCoord>& cores,
         uint32_t address,
         uint32_t size_bytes) const {
         auto mesh_buffer = create_mesh_buffer_helper(cores, address, size_bytes);
@@ -548,10 +548,10 @@ public:
     }
 
     // Process results after barrier_reads() has been called
-    std::unordered_map<CoreCoord, std::vector<uint32_t>> complete_read_buffer_from_cores(
+    std::unordered_map<tt::tt_metal::CoreCoord, std::vector<uint32_t>> complete_read_buffer_from_cores(
         const ReadBufferOperation& op) const {
         // Process results (existing splice logic)
-        std::unordered_map<CoreCoord, std::vector<uint32_t>> results;
+        std::unordered_map<tt::tt_metal::CoreCoord, std::vector<uint32_t>> results;
         auto num_words_per_core = op.size_bytes / sizeof(uint32_t);
 
         for (auto i = 0; i < op.buffer_page_mapping.all_cores.size(); i++) {
@@ -574,9 +574,9 @@ public:
     }
 
     // Data reading helpers - preserve backward compatibility
-    std::unordered_map<CoreCoord, std::vector<uint32_t>> read_buffer_from_cores(
+    std::unordered_map<tt::tt_metal::CoreCoord, std::vector<uint32_t>> read_buffer_from_cores(
         const MeshCoordinate& device_coord,
-        const std::vector<CoreCoord>& cores,
+        const std::vector<tt::tt_metal::CoreCoord>& cores,
         uint32_t address,
         uint32_t size_bytes) const override {
         auto op = initiate_read_buffer_from_cores(device_coord, cores, address, size_bytes);
@@ -587,11 +587,11 @@ public:
     // When blocking is enabled, results_out must be pre-allocated for each core
     void read_buffer_from_ethernet_cores(
         const MeshCoordinate& device_coord,
-        const std::vector<CoreCoord>& cores,
+        const std::vector<tt::tt_metal::CoreCoord>& cores,
         uint32_t address,
         uint32_t size_bytes,
         bool blocking,
-        std::unordered_map<CoreCoord, std::vector<uint32_t>>& results_out) const {
+        std::unordered_map<tt::tt_metal::CoreCoord, std::vector<uint32_t>>& results_out) const {
         auto* device = mesh_device_->impl().get_device(device_coord);
         auto num_elements = tt::align(size_bytes, sizeof(uint32_t));
         for (const auto& logical_core : cores) {
@@ -619,7 +619,7 @@ public:
 
     void write_buffer_to_ethernet_cores(
         const MeshCoordinate& device_coord,
-        const std::vector<CoreCoord>& cores,
+        const std::vector<tt::tt_metal::CoreCoord>& cores,
         uint32_t address,
         const std::vector<uint8_t>& data) const {
         auto* device = mesh_device_->impl().get_device(device_coord);
@@ -638,7 +638,7 @@ public:
 
     void zero_out_buffer_on_cores(
         const MeshCoordinate& device_coord,
-        const std::vector<CoreCoord>& cores,
+        const std::vector<tt::tt_metal::CoreCoord>& cores,
         uint32_t address,
         uint32_t size_bytes) const override {
         auto mesh_buffer = create_mesh_buffer_helper(cores, address, size_bytes);
@@ -652,7 +652,7 @@ public:
     // Local runtime args function - writes args to local args buffer instead of using SetRuntimeArgs
     void write_data_to_core(
         const MeshCoordinate& device_coord,
-        const CoreCoord& core,
+        const tt::tt_metal::CoreCoord& core,
         uint32_t local_args_address,
         const std::vector<uint32_t>& args) const override {
         auto mesh_buffer = create_mesh_buffer_helper({core}, local_args_address, args.size() * sizeof(uint32_t));

--- a/tests/tt_metal/tt_fabric/test_infra/tt_fabric_test_common_types.hpp
+++ b/tests/tt_metal/tt_fabric/test_infra/tt_fabric_test_common_types.hpp
@@ -86,7 +86,7 @@ struct ParsedSenderConfig {
 // Resolved structures (after resolution) - use FabricNodeId
 struct DestinationConfig {
     std::optional<FabricNodeId> device;
-    std::optional<CoreCoord> core;
+    std::optional<tt::tt_metal::CoreCoord> core;
     std::optional<std::unordered_map<RoutingDirection, uint32_t>> hops;
     std::optional<uint32_t> target_address;
     std::optional<uint32_t> atomic_inc_address;
@@ -116,7 +116,7 @@ struct TrafficPatternConfig {
 
 struct SenderConfig {
     FabricNodeId device = FabricNodeId(MeshId{0}, 0);
-    std::optional<CoreCoord> core;
+    std::optional<tt::tt_metal::CoreCoord> core;
     std::optional<tt::tt_metal::NOC> noc_id;
     std::vector<TrafficPatternConfig> patterns;
     uint32_t link_id = 0;          // Link ID for multi-link tests

--- a/tests/tt_metal/tt_fabric/test_infra/tt_fabric_test_device_setup.cpp
+++ b/tests/tt_metal/tt_fabric/test_infra/tt_fabric_test_device_setup.cpp
@@ -13,7 +13,7 @@ namespace tt::tt_fabric::fabric_tests {
 // ====================================
 
 void FabricConnectionManager::register_client(
-    const CoreCoord& core, TestWorkerType worker_type, const ConnectionKey& key, const FabricNodeId& next_hop_dst) {
+    const tt::tt_metal::CoreCoord& core, TestWorkerType worker_type, const ConnectionKey& key, const FabricNodeId& next_hop_dst) {
     auto [it, inserted] = connections_.try_emplace(key);
     auto& conn = it->second;
 
@@ -145,8 +145,8 @@ std::unordered_map<RoutingDirection, std::set<uint32_t>> FabricConnectionManager
 }
 
 std::vector<ConnectionKey> FabricConnectionManager::get_connection_keys_for_core(
-    const CoreCoord& core, TestWorkerType worker_type) const {
-    const auto* map = [&]() -> const std::unordered_map<CoreCoord, std::set<ConnectionKey>>* {
+    const tt::tt_metal::CoreCoord& core, TestWorkerType worker_type) const {
+    const auto* map = [&]() -> const std::unordered_map<tt::tt_metal::CoreCoord, std::set<ConnectionKey>>* {
         switch (worker_type) {
             case TestWorkerType::SENDER: return &sender_core_to_keys_;
             case TestWorkerType::RECEIVER: return &receiver_core_to_keys_;
@@ -165,13 +165,13 @@ std::vector<ConnectionKey> FabricConnectionManager::get_connection_keys_for_core
     return {};
 }
 
-size_t FabricConnectionManager::get_connection_count_for_core(const CoreCoord& core, TestWorkerType worker_type) const {
+size_t FabricConnectionManager::get_connection_count_for_core(const tt::tt_metal::CoreCoord& core, TestWorkerType worker_type) const {
     auto keys = get_connection_keys_for_core(core, worker_type);
     return keys.size();
 }
 
 uint32_t FabricConnectionManager::get_connection_array_index_for_key(
-    const CoreCoord& core, TestWorkerType worker_type, const ConnectionKey& key) const {
+    const tt::tt_metal::CoreCoord& core, TestWorkerType worker_type, const ConnectionKey& key) const {
     auto keys = get_connection_keys_for_core(core, worker_type);
 
     for (size_t i = 0; i < keys.size(); i++) {
@@ -183,12 +183,12 @@ uint32_t FabricConnectionManager::get_connection_array_index_for_key(
     return UINT32_MAX;  // Not found
 }
 
-bool FabricConnectionManager::is_mux_client(const CoreCoord& core) const {
+bool FabricConnectionManager::is_mux_client(const tt::tt_metal::CoreCoord& core) const {
     return all_mux_client_cores_.contains(core);
 }
 
 std::vector<uint32_t> FabricConnectionManager::generate_mux_termination_local_args_for_core(
-    const CoreCoord& core, const std::shared_ptr<IDeviceInfoProvider>& device_info_provider) const {
+    const tt::tt_metal::CoreCoord& core, const std::shared_ptr<IDeviceInfoProvider>& device_info_provider) const {
     // Not a mux client? Return empty vector
     if (!is_mux_client(core)) {
         return {};
@@ -222,7 +222,7 @@ std::vector<uint32_t> FabricConnectionManager::generate_mux_termination_local_ar
 }
 
 std::vector<uint32_t> FabricConnectionManager::generate_connection_args_for_core(
-    const CoreCoord& core,
+    const tt::tt_metal::CoreCoord& core,
     TestWorkerType worker_type,
     const std::shared_ptr<IDeviceInfoProvider>& device_info_provider,
     const FabricNodeId& fabric_node_id,
@@ -260,7 +260,7 @@ std::vector<uint32_t> FabricConnectionManager::generate_connection_args_for_core
                 "Mux core not found for connection dir={} link={}",
                 static_cast<int>(key.direction),
                 key.link_idx);
-            const CoreCoord& mux_core = mux_core_it->second;
+            const tt::tt_metal::CoreCoord& mux_core = mux_core_it->second;
 
             // Get the stored mux config using the mux core as key
             auto mux_config_it = mux_configs_.find(mux_core);
@@ -346,7 +346,7 @@ void FabricConnectionManager::assign_and_validate_channels(Connection& conn, con
 // ====================================
 
 TestWorker::TestWorker(
-    CoreCoord logical_core, TestDevice* test_device_ptr, std::optional<std::string_view> kernel_src) :
+    tt::tt_metal::CoreCoord logical_core, TestDevice* test_device_ptr, std::optional<std::string_view> kernel_src) :
     logical_core_(logical_core), test_device_ptr_(test_device_ptr) {
     if (kernel_src.has_value()) {
         this->kernel_src_ = std::string(kernel_src.value());
@@ -399,7 +399,7 @@ void TestWorker::create_kernel(
 // ====================================
 
 TestSender::TestSender(
-    CoreCoord logical_core, TestDevice* test_device_ptr, std::optional<std::string_view> kernel_src) :
+    tt::tt_metal::CoreCoord logical_core, TestDevice* test_device_ptr, std::optional<std::string_view> kernel_src) :
     TestWorker(logical_core, test_device_ptr, kernel_src) {
     // TODO: init mem map?
 }
@@ -471,7 +471,7 @@ bool TestSender::validate_results(std::vector<uint32_t>& data) const {
 // ====================================
 
 TestReceiver::TestReceiver(
-    CoreCoord logical_core, TestDevice* test_device_ptr, std::optional<std::string_view> kernel_src) :
+    tt::tt_metal::CoreCoord logical_core, TestDevice* test_device_ptr, std::optional<std::string_view> kernel_src) :
     TestWorker(logical_core, test_device_ptr, kernel_src) {
     // TODO: init mem map?
 }
@@ -531,7 +531,7 @@ bool TestReceiver::validate_results(std::vector<uint32_t>& data) const {
 // TestSync Implementation
 // ====================================
 
-TestSync::TestSync(CoreCoord logical_core, TestDevice* test_device_ptr, std::optional<std::string_view> kernel_src) :
+TestSync::TestSync(tt::tt_metal::CoreCoord logical_core, TestDevice* test_device_ptr, std::optional<std::string_view> kernel_src) :
     TestWorker(logical_core, test_device_ptr, kernel_src) {
     // TODO: init mem map?
 }
@@ -565,7 +565,7 @@ bool TestSync::validate_results(std::vector<uint32_t>& /*data*/) const {
 // TestMux Implementation
 // ====================================
 
-TestMux::TestMux(CoreCoord logical_core, TestDevice* test_device_ptr, std::optional<std::string_view> kernel_src) :
+TestMux::TestMux(tt::tt_metal::CoreCoord logical_core, TestDevice* test_device_ptr, std::optional<std::string_view> kernel_src) :
     TestWorker(logical_core, test_device_ptr, kernel_src) {}
 
 void TestMux::set_config(FabricMuxConfig* mux_config, ConnectionKey connection_key, FabricNodeId next_hop_dst) {
@@ -598,8 +598,8 @@ tt::tt_metal::Program& TestDevice::get_program_handle() { return this->program_h
 
 const FabricNodeId& TestDevice::get_node_id() const { return this->fabric_node_id_; }
 
-void TestDevice::add_worker(TestWorkerType worker_type, CoreCoord logical_core) {
-    auto core_already_occupied = [this](TestWorkerType worker_type, CoreCoord logical_core) {
+void TestDevice::add_worker(TestWorkerType worker_type, tt::tt_metal::CoreCoord logical_core) {
+    auto core_already_occupied = [this](TestWorkerType worker_type, tt::tt_metal::CoreCoord logical_core) {
         switch (worker_type) {
             case TestWorkerType::SENDER: return senders_.contains(logical_core);
             case TestWorkerType::RECEIVER: return receivers_.contains(logical_core);
@@ -634,7 +634,7 @@ void TestDevice::add_worker(TestWorkerType worker_type, CoreCoord logical_core) 
 }
 
 ConnectionKey TestDevice::register_fabric_connection(
-    CoreCoord logical_core,
+    tt::tt_metal::CoreCoord logical_core,
     TestWorkerType worker_type,
     FabricConnectionManager& connection_mgr,
     RoutingDirection outgoing_direction,
@@ -698,7 +698,7 @@ ConnectionKey TestDevice::register_fabric_connection(
     return connection_key;
 }
 
-void TestDevice::add_sender_traffic_config(CoreCoord logical_core, TestTrafficSenderConfig config) {
+void TestDevice::add_sender_traffic_config(tt::tt_metal::CoreCoord logical_core, TestTrafficSenderConfig config) {
     if (!this->senders_.contains(logical_core)) {
         this->add_worker(TestWorkerType::SENDER, logical_core);
     }
@@ -706,7 +706,7 @@ void TestDevice::add_sender_traffic_config(CoreCoord logical_core, TestTrafficSe
     this->senders_.at(logical_core).add_config(std::move(config));
 }
 
-void TestDevice::add_sender_sync_config(CoreCoord logical_core, TestTrafficSyncConfig sync_config) {
+void TestDevice::add_sender_sync_config(tt::tt_metal::CoreCoord logical_core, TestTrafficSyncConfig sync_config) {
     if (!this->sync_workers_.contains(logical_core)) {
         this->add_worker(TestWorkerType::SYNC, logical_core);
     }
@@ -714,7 +714,7 @@ void TestDevice::add_sender_sync_config(CoreCoord logical_core, TestTrafficSyncC
     this->sync_workers_.at(logical_core).add_config(std::move(sync_config));
 }
 
-void TestDevice::add_receiver_traffic_config(CoreCoord logical_core, const TestTrafficReceiverConfig& config) {
+void TestDevice::add_receiver_traffic_config(tt::tt_metal::CoreCoord logical_core, const TestTrafficReceiverConfig& config) {
     if (!this->receivers_.contains(logical_core)) {
         this->add_worker(TestWorkerType::RECEIVER, logical_core);
     }
@@ -723,7 +723,7 @@ void TestDevice::add_receiver_traffic_config(CoreCoord logical_core, const TestT
 }
 
 void TestDevice::add_mux_worker_config(
-    CoreCoord logical_core, FabricMuxConfig* mux_config, ConnectionKey connection_key, FabricNodeId next_hop_dst) {
+    tt::tt_metal::CoreCoord logical_core, FabricMuxConfig* mux_config, ConnectionKey connection_key, FabricNodeId next_hop_dst) {
     if (!this->muxes_.contains(logical_core)) {
         this->add_worker(TestWorkerType::MUX, logical_core);
     }
@@ -1217,7 +1217,7 @@ TestDevice::ValidationReadOps TestDevice::initiate_results_readback() const {
     ValidationReadOps ops;
 
     // Get sender cores
-    std::vector<CoreCoord> sender_cores;
+    std::vector<tt::tt_metal::CoreCoord> sender_cores;
     sender_cores.reserve(this->senders_.size());
     for (const auto& [core, _] : this->senders_) {
         sender_cores.push_back(core);
@@ -1236,7 +1236,7 @@ TestDevice::ValidationReadOps TestDevice::initiate_results_readback() const {
     }
 
     // Get receiver cores
-    std::vector<CoreCoord> receiver_cores;
+    std::vector<tt::tt_metal::CoreCoord> receiver_cores;
     receiver_cores.reserve(this->receivers_.size());
     for (const auto& [core, _] : this->receivers_) {
         receiver_cores.push_back(core);
@@ -1280,7 +1280,7 @@ void TestDevice::validate_results_after_readback(const ValidationReadOps& ops) c
 }
 
 void TestDevice::validate_sender_results() const {
-    std::vector<CoreCoord> sender_cores;
+    std::vector<tt::tt_metal::CoreCoord> sender_cores;
     sender_cores.reserve(this->senders_.size());
     for (const auto& [core, _] : this->senders_) {
         sender_cores.push_back(core);
@@ -1305,7 +1305,7 @@ void TestDevice::validate_sender_results() const {
 }
 
 void TestDevice::validate_receiver_results() const {
-    std::vector<CoreCoord> receiver_cores;
+    std::vector<tt::tt_metal::CoreCoord> receiver_cores;
     receiver_cores.reserve(this->receivers_.size());
     for (const auto& [core, _] : this->receivers_) {
         receiver_cores.push_back(core);
@@ -1331,7 +1331,7 @@ void TestDevice::validate_receiver_results() const {
 
 void TestDevice::set_local_runtime_args_for_core(
     const MeshCoordinate& device_coord,
-    CoreCoord logical_core,
+    tt::tt_metal::CoreCoord logical_core,
     uint32_t local_args_address,
     const std::vector<uint32_t>& args) const {
     device_info_provider_->write_data_to_core(device_coord, logical_core, local_args_address, args);
@@ -1351,12 +1351,12 @@ size_t TestDevice::get_latency_receive_buffer_address(uint32_t payload_size) con
 }
 
 void TestDevice::create_latency_sender_kernel(
-    CoreCoord core,
+    tt::tt_metal::CoreCoord core,
     FabricNodeId dest_node,
     uint32_t payload_size,
     uint32_t num_samples,
     NocSendType noc_send_type,
-    CoreCoord responder_virtual_core) {
+    tt::tt_metal::CoreCoord responder_virtual_core) {
     log_debug(tt::LogTest, "Creating latency sender kernel on node: {}", fabric_node_id_);
 
     // Use static memory map address for semaphore (same as bandwidth tests)
@@ -1449,14 +1449,14 @@ void TestDevice::create_latency_sender_kernel(
 }
 
 void TestDevice::create_latency_responder_kernel(
-    CoreCoord core,
+    tt::tt_metal::CoreCoord core,
     FabricNodeId sender_node,
     uint32_t payload_size,
     uint32_t num_samples,
     NocSendType noc_send_type,
     uint32_t sender_send_buffer_address,
     uint32_t sender_receive_buffer_address,
-    CoreCoord sender_virtual_core) {
+    tt::tt_metal::CoreCoord sender_virtual_core) {
     log_debug(tt::LogTest, "Creating latency responder kernel on node: {}", fabric_node_id_);
 
     // Use static memory map address for semaphore (same as bandwidth tests)
@@ -1552,14 +1552,14 @@ void TestDevice::create_latency_responder_kernel(
 }
 
 // Set kernel source for specific workers (used by latency tests to override default kernels)
-void TestDevice::set_sender_kernel_src(CoreCoord core, const std::string& kernel_src) {
+void TestDevice::set_sender_kernel_src(tt::tt_metal::CoreCoord core, const std::string& kernel_src) {
     auto it = senders_.find(core);
     if (it != senders_.end()) {
         it->second.set_kernel_src(kernel_src);
     }
 }
 
-void TestDevice::set_receiver_kernel_src(CoreCoord core, const std::string& kernel_src) {
+void TestDevice::set_receiver_kernel_src(tt::tt_metal::CoreCoord core, const std::string& kernel_src) {
     auto it = receivers_.find(core);
     if (it != receivers_.end()) {
         it->second.set_kernel_src(kernel_src);

--- a/tests/tt_metal/tt_fabric/test_infra/tt_fabric_test_device_setup.hpp
+++ b/tests/tt_metal/tt_fabric/test_infra/tt_fabric_test_device_setup.hpp
@@ -84,11 +84,11 @@ struct Connection {
     // of the eth chan (resolved via the control plane).
     FabricNodeId next_hop_dst{MeshId{0}, 0};
 
-    std::set<CoreCoord> sender_cores;           // Data senders (full-size channels)
-    std::set<CoreCoord> receiver_cores;         // Credit senders (header-only channels)
-    std::set<CoreCoord> sync_cores;             // Sync senders (header-only channels)
-    std::map<CoreCoord, uint32_t> channel_map;  // Core -> channel assignment
-    std::map<CoreCoord, TestWorkerType> core_worker_types;  // Core -> worker type mapping
+    std::set<tt::tt_metal::CoreCoord> sender_cores;           // Data senders (full-size channels)
+    std::set<tt::tt_metal::CoreCoord> receiver_cores;         // Credit senders (header-only channels)
+    std::set<tt::tt_metal::CoreCoord> sync_cores;             // Sync senders (header-only channels)
+    std::map<tt::tt_metal::CoreCoord, uint32_t> channel_map;  // Core -> channel assignment
+    std::map<tt::tt_metal::CoreCoord, TestWorkerType> core_worker_types;  // Core -> worker type mapping
     bool needs_mux = false;
 };
 
@@ -99,20 +99,20 @@ struct TestDevice;
 // Takes ownership of pristine cores and pops them on-demand
 class LocalDeviceCoreAllocator {
 public:
-    explicit LocalDeviceCoreAllocator(std::vector<CoreCoord>&& available_cores) :
+    explicit LocalDeviceCoreAllocator(std::vector<tt::tt_metal::CoreCoord>&& available_cores) :
         available_cores_(std::move(available_cores)) {}
 
-    std::optional<CoreCoord> allocate_core() {
+    std::optional<tt::tt_metal::CoreCoord> allocate_core() {
         if (available_cores_.empty()) {
             return std::nullopt;
         }
-        CoreCoord allocated = available_cores_.back();
+        tt::tt_metal::CoreCoord allocated = available_cores_.back();
         available_cores_.pop_back();
         return allocated;
     }
 
 private:
-    std::vector<CoreCoord> available_cores_;
+    std::vector<tt::tt_metal::CoreCoord> available_cores_;
 };
 
 // FabricConnectionManager: Centralized connection tracking and management
@@ -143,7 +143,7 @@ public:
     // and is recorded once on the Connection on first registration (it must be invariant
     // for a given key).
     void register_client(
-        const CoreCoord& core, TestWorkerType worker_type, const ConnectionKey& key, const FabricNodeId& next_hop_dst);
+        const tt::tt_metal::CoreCoord& core, TestWorkerType worker_type, const ConnectionKey& key, const FabricNodeId& next_hop_dst);
 
     // Processing: Call once at start of create_kernels()
     // local_alloc: allocator for on-demand mux core allocation
@@ -158,17 +158,17 @@ public:
     std::unordered_map<RoutingDirection, std::set<uint32_t>> get_used_fabric_links() const;
 
     // Get all connection keys for a specific core (fast lookup via reverse map)
-    std::vector<ConnectionKey> get_connection_keys_for_core(const CoreCoord& core, TestWorkerType worker_type) const;
+    std::vector<ConnectionKey> get_connection_keys_for_core(const tt::tt_metal::CoreCoord& core, TestWorkerType worker_type) const;
 
     // Get number of fabric connections for a specific core
-    size_t get_connection_count_for_core(const CoreCoord& core, TestWorkerType worker_type) const;
+    size_t get_connection_count_for_core(const tt::tt_metal::CoreCoord& core, TestWorkerType worker_type) const;
 
     // Get the array index for a connection key in the core's connection list
     uint32_t get_connection_array_index_for_key(
-        const CoreCoord& core, TestWorkerType worker_type, const ConnectionKey& key) const;
+        const tt::tt_metal::CoreCoord& core, TestWorkerType worker_type, const ConnectionKey& key) const;
 
     // Check if a core is a mux client
-    bool is_mux_client(const CoreCoord& core) const;
+    bool is_mux_client(const tt::tt_metal::CoreCoord& core) const;
 
     // Get the number of muxes to terminate (for compile-time arg)
     uint32_t get_num_muxes_to_terminate() const { return static_cast<uint32_t>(mux_configs_.size()); }
@@ -176,13 +176,13 @@ public:
     // Generate mux termination local args for a core
     // Returns empty vector if core is not a mux client
     std::vector<uint32_t> generate_mux_termination_local_args_for_core(
-        const CoreCoord& core, const std::shared_ptr<IDeviceInfoProvider>& device_info_provider) const;
+        const tt::tt_metal::CoreCoord& core, const std::shared_ptr<IDeviceInfoProvider>& device_info_provider) const;
 
     // Generate all fabric connection args for a specific core
     // Returns rt_args to append (includes is_mux flag + connection args for each connection)
     // Parameters are passed in from TestDevice since it has all the context
     std::vector<uint32_t> generate_connection_args_for_core(
-        const CoreCoord& core,
+        const tt::tt_metal::CoreCoord& core,
         TestWorkerType worker_type,
         const std::shared_ptr<IDeviceInfoProvider>& device_info_provider,
         const FabricNodeId& fabric_node_id,
@@ -190,20 +190,20 @@ public:
 
 private:
     std::unordered_map<ConnectionKey, Connection, ConnectionKeyHash> connections_;
-    std::unordered_map<CoreCoord, std::set<ConnectionKey>> sender_core_to_keys_;
-    std::unordered_map<CoreCoord, std::set<ConnectionKey>> receiver_core_to_keys_;
-    std::unordered_map<CoreCoord, std::set<ConnectionKey>> sync_core_to_keys_;
-    std::unordered_map<CoreCoord, ConnectionKey> mux_core_to_key_;
+    std::unordered_map<tt::tt_metal::CoreCoord, std::set<ConnectionKey>> sender_core_to_keys_;
+    std::unordered_map<tt::tt_metal::CoreCoord, std::set<ConnectionKey>> receiver_core_to_keys_;
+    std::unordered_map<tt::tt_metal::CoreCoord, std::set<ConnectionKey>> sync_core_to_keys_;
+    std::unordered_map<tt::tt_metal::CoreCoord, ConnectionKey> mux_core_to_key_;
 
     // Mux state (populated during process())
     // One mux per connection key (each fabric link has its own mux)
-    std::unordered_map<ConnectionKey, CoreCoord, ConnectionKeyHash> mux_cores_;  // connection key -> mux core location
-    std::unordered_map<CoreCoord, std::unique_ptr<FabricMuxConfig>>
+    std::unordered_map<ConnectionKey, tt::tt_metal::CoreCoord, ConnectionKeyHash> mux_cores_;  // connection key -> mux core location
+    std::unordered_map<tt::tt_metal::CoreCoord, std::unique_ptr<FabricMuxConfig>>
         mux_configs_;  // mux core -> mux config (1:1 with mux_cores_)
 
     // Mux termination state (populated during process())
-    std::set<CoreCoord> all_mux_client_cores_;  // All cores that use mux connections
-    CoreCoord global_termination_master_;       // First mux client (in deterministic order)
+    std::set<tt::tt_metal::CoreCoord> all_mux_client_cores_;  // All cores that use mux connections
+    tt::tt_metal::CoreCoord global_termination_master_;       // First mux client (in deterministic order)
 
     static constexpr uint32_t MAX_FULL_SIZE_CHANNELS = 8;
     static constexpr uint32_t MAX_HEADER_ONLY_CHANNELS = 64;
@@ -216,7 +216,7 @@ private:
 struct TestWorker {
 public:
     virtual ~TestWorker() = default;
-    TestWorker(CoreCoord logical_core, TestDevice* test_device_ptr, std::optional<std::string_view> kernel_src);
+    TestWorker(tt::tt_metal::CoreCoord logical_core, TestDevice* test_device_ptr, std::optional<std::string_view> kernel_src);
     void set_kernel_src(const std::string_view& kernel_src);
     void create_kernel(
         const MeshCoordinate& device_coord,
@@ -231,7 +231,7 @@ public:
     void dump_results();
 
 protected:
-    CoreCoord logical_core_;
+    tt::tt_metal::CoreCoord logical_core_;
     uint32_t worker_id_{};
     std::string kernel_src_;
     TestDevice* test_device_ptr_;
@@ -240,14 +240,14 @@ protected:
 struct TestSender : TestWorker {
 public:
     ~TestSender() override = default;
-    TestSender(CoreCoord logical_core, TestDevice* test_device_ptr, std::optional<std::string_view> kernel_src);
+    TestSender(tt::tt_metal::CoreCoord logical_core, TestDevice* test_device_ptr, std::optional<std::string_view> kernel_src);
     void add_config(TestTrafficSenderConfig config);
     bool validate_results(std::vector<uint32_t>& data) const override;
 
     const std::vector<std::pair<TestTrafficSenderConfig, ConnectionKey>>& get_configs() const { return configs_; }
 
     // Accessors for progress monitoring
-    CoreCoord get_core() const { return logical_core_; }
+    tt::tt_metal::CoreCoord get_core() const { return logical_core_; }
     uint64_t get_total_packets() const;  // Defined out-of-line
 
     // stores traffic config and the corresponding fabric connection key
@@ -257,7 +257,7 @@ public:
 
 struct TestReceiver : TestWorker {
 public:
-    TestReceiver(CoreCoord logical_core, TestDevice* test_device_ptr, std::optional<std::string_view> kernel_src);
+    TestReceiver(tt::tt_metal::CoreCoord logical_core, TestDevice* test_device_ptr, std::optional<std::string_view> kernel_src);
     void add_config(TestTrafficReceiverConfig config);
     bool validate_results(std::vector<uint32_t>& data) const override;
 
@@ -268,7 +268,7 @@ public:
 
 struct TestSync : TestWorker {
 public:
-    TestSync(CoreCoord logical_core, TestDevice* test_device_ptr, std::optional<std::string_view> kernel_src);
+    TestSync(tt::tt_metal::CoreCoord logical_core, TestDevice* test_device_ptr, std::optional<std::string_view> kernel_src);
     void add_config(TestTrafficSyncConfig config);
     bool validate_results(std::vector<uint32_t>& data) const override;
 
@@ -279,7 +279,7 @@ public:
 
 struct TestMux : TestWorker {
 public:
-    TestMux(CoreCoord logical_core, TestDevice* test_device_ptr, std::optional<std::string_view> kernel_src);
+    TestMux(tt::tt_metal::CoreCoord logical_core, TestDevice* test_device_ptr, std::optional<std::string_view> kernel_src);
     void set_config(FabricMuxConfig* config, ConnectionKey connection_key, FabricNodeId next_hop_dst);
     bool validate_results(std::vector<uint32_t>& /*data*/) const override { return true; }  // Mux doesn't validate
 
@@ -306,41 +306,41 @@ public:
         const ReceiverMemoryMap* receiver_memory_map = nullptr);
     tt::tt_metal::Program& get_program_handle();
     const FabricNodeId& get_node_id() const;
-    void add_sender_traffic_config(CoreCoord logical_core, TestTrafficSenderConfig config);
-    void add_sender_sync_config(CoreCoord logical_core, TestTrafficSyncConfig sync_config);
-    void add_receiver_traffic_config(CoreCoord logical_core, const TestTrafficReceiverConfig& config);
+    void add_sender_traffic_config(tt::tt_metal::CoreCoord logical_core, TestTrafficSenderConfig config);
+    void add_sender_sync_config(tt::tt_metal::CoreCoord logical_core, TestTrafficSyncConfig sync_config);
+    void add_receiver_traffic_config(tt::tt_metal::CoreCoord logical_core, const TestTrafficReceiverConfig& config);
     void add_mux_worker_config(
-        CoreCoord logical_core, FabricMuxConfig* config, ConnectionKey connection_key, FabricNodeId next_hop_dst);
+        tt::tt_metal::CoreCoord logical_core, FabricMuxConfig* config, ConnectionKey connection_key, FabricNodeId next_hop_dst);
     void create_kernels();
 
     // Latency test kernel creation (called directly by TestContext)
     // Uses static memory map addresses for semaphores (same as bandwidth tests)
     void create_latency_sender_kernel(
-        CoreCoord core,
+        tt::tt_metal::CoreCoord core,
         FabricNodeId dest_node,
         uint32_t payload_size,
         uint32_t num_samples,
         NocSendType noc_send_type,
-        CoreCoord responder_virtual_core);
+        tt::tt_metal::CoreCoord responder_virtual_core);
 
     void create_latency_responder_kernel(
-        CoreCoord core,
+        tt::tt_metal::CoreCoord core,
         FabricNodeId sender_node,
         uint32_t payload_size,
         uint32_t num_samples,
         NocSendType noc_send_type,
         uint32_t sender_send_buffer_address,
         uint32_t sender_receive_buffer_address,
-        CoreCoord sender_virtual_core);
+        tt::tt_metal::CoreCoord sender_virtual_core);
 
     void set_benchmark_mode(bool benchmark_mode) { benchmark_mode_ = benchmark_mode; }
     void set_global_sync(bool global_sync) { global_sync_ = global_sync; }
     void set_progress_monitoring_enabled(bool enabled) { progress_monitoring_enabled_ = enabled; }
-    void set_pristine_cores(std::vector<CoreCoord>&& cores) { pristine_cores_ = std::move(cores); }
+    void set_pristine_cores(std::vector<tt::tt_metal::CoreCoord>&& cores) { pristine_cores_ = std::move(cores); }
 
     // Set kernel source for specific workers (used by latency tests to override default kernels)
-    void set_sender_kernel_src(CoreCoord core, const std::string& kernel_src);
-    void set_receiver_kernel_src(CoreCoord core, const std::string& kernel_src);
+    void set_sender_kernel_src(tt::tt_metal::CoreCoord core, const std::string& kernel_src);
+    void set_receiver_kernel_src(tt::tt_metal::CoreCoord core, const std::string& kernel_src);
 
     RoutingDirection get_forwarding_direction(const std::unordered_map<RoutingDirection, uint32_t>& hops) const;
     RoutingDirection get_forwarding_direction(const FabricNodeId& src_node_id, const FabricNodeId& dst_node_id) const;
@@ -361,10 +361,10 @@ public:
 
     // Original validation method for backward compatibility
     void validate_results() const;
-    void set_sync_core(CoreCoord coord) { sync_core_coord_ = coord; };
+    void set_sync_core(tt::tt_metal::CoreCoord coord) { sync_core_coord_ = coord; };
     void set_local_runtime_args_for_core(
         const MeshCoordinate& device_coord,
-        CoreCoord logical_core,
+        tt::tt_metal::CoreCoord logical_core,
         uint32_t local_args_address,
         const std::vector<uint32_t>& args) const;
 
@@ -373,8 +373,8 @@ public:
     }
 
     // Method to access sender and receiver configurations for traffic analysis
-    const std::unordered_map<CoreCoord, TestSender>& get_senders() const { return senders_; }
-    const std::unordered_map<CoreCoord, TestReceiver>& get_receivers() const { return receivers_; }
+    const std::unordered_map<tt::tt_metal::CoreCoord, TestSender>& get_senders() const { return senders_; }
+    const std::unordered_map<tt::tt_metal::CoreCoord, TestReceiver>& get_receivers() const { return receivers_; }
 
     std::unordered_map<RoutingDirection, std::set<uint32_t>> get_used_fabric_connections() const {
         return connection_manager_.get_used_fabric_links();
@@ -408,7 +408,7 @@ public:
     size_t get_latency_receive_buffer_address(uint32_t payload_size) const;
 
 private:
-    void add_worker(TestWorkerType worker_type, CoreCoord logical_core);
+    void add_worker(TestWorkerType worker_type, tt::tt_metal::CoreCoord logical_core);
     void create_sender_kernels();
     void create_receiver_kernels();
     void validate_sender_results() const;
@@ -423,7 +423,7 @@ private:
     // part of the dedup key, so multiple traffic configs with different final dsts that
     // share the same physical link collapse to one ConnectionKey.
     ConnectionKey register_fabric_connection(
-        CoreCoord logical_core,
+        tt::tt_metal::CoreCoord logical_core,
         TestWorkerType worker_type,
         FabricConnectionManager& connection_mgr,
         RoutingDirection outgoing_direction,
@@ -440,18 +440,18 @@ private:
 
     tt_metal::Program program_handle_;
 
-    std::unordered_map<CoreCoord, TestSender> senders_;
-    std::unordered_map<CoreCoord, TestReceiver> receivers_;
-    std::unordered_map<CoreCoord, TestSync> sync_workers_;  // Separate sync cores
-    std::unordered_map<CoreCoord, TestMux> muxes_;          // Mux workers
+    std::unordered_map<tt::tt_metal::CoreCoord, TestSender> senders_;
+    std::unordered_map<tt::tt_metal::CoreCoord, TestReceiver> receivers_;
+    std::unordered_map<tt::tt_metal::CoreCoord, TestSync> sync_workers_;  // Separate sync cores
+    std::unordered_map<tt::tt_metal::CoreCoord, TestMux> muxes_;          // Mux workers
 
     bool benchmark_mode_ = false;
     bool global_sync_ = false;
-    CoreCoord sync_core_coord_;
+    tt::tt_metal::CoreCoord sync_core_coord_;
     bool progress_monitoring_enabled_ = false;
 
     // Pristine cores for mux allocation (transferred from allocator)
-    std::vector<CoreCoord> pristine_cores_;
+    std::vector<tt::tt_metal::CoreCoord> pristine_cores_;
 
     bool use_unified_connection_manager_ = false;
 };

--- a/tests/tt_metal/tt_fabric/test_infra/tt_fabric_test_interfaces.hpp
+++ b/tests/tt_metal/tt_fabric/test_infra/tt_fabric_test_interfaces.hpp
@@ -39,11 +39,11 @@ public:
     virtual FabricNodeId get_fabric_node_id(const MeshCoordinate& device_coord) const = 0;
     virtual FabricNodeId get_fabric_node_id(MeshId mesh_id, const MeshCoordinate& device_coord) const = 0;
     virtual MeshCoordinate get_device_coord(const FabricNodeId& node_id) const = 0;
-    virtual uint32_t get_worker_noc_encoding(CoreCoord logical_core) const = 0;
-    virtual CoreCoord get_virtual_core_from_logical_core(CoreCoord logical_core) const = 0;
-    virtual CoreCoord get_worker_grid_size() const = 0;
-    virtual std::vector<CoreCoord> get_available_worker_cores() const = 0;
-    virtual uint32_t get_worker_id(const FabricNodeId& node_id, CoreCoord logical_core) const = 0;
+    virtual uint32_t get_worker_noc_encoding(tt::tt_metal::CoreCoord logical_core) const = 0;
+    virtual tt::tt_metal::CoreCoord get_virtual_core_from_logical_core(tt::tt_metal::CoreCoord logical_core) const = 0;
+    virtual tt::tt_metal::CoreCoord get_worker_grid_size() const = 0;
+    virtual std::vector<tt::tt_metal::CoreCoord> get_available_worker_cores() const = 0;
+    virtual uint32_t get_worker_id(const FabricNodeId& node_id, tt::tt_metal::CoreCoord logical_core) const = 0;
     virtual std::vector<FabricNodeId> get_local_node_ids() const = 0;
     virtual std::vector<FabricNodeId> get_global_node_ids() const = 0;
     virtual bool is_local_fabric_node_id(const FabricNodeId& id) const = 0;
@@ -60,19 +60,19 @@ public:
     virtual uint32_t get_max_connections_per_device() const = 0;
 
     // Data reading helpers
-    virtual std::unordered_map<CoreCoord, std::vector<uint32_t>> read_buffer_from_cores(
+    virtual std::unordered_map<tt::tt_metal::CoreCoord, std::vector<uint32_t>> read_buffer_from_cores(
         const MeshCoordinate& device_coord,
         const std::vector<CoreCoord>& cores,
         uint32_t address,
         uint32_t size_bytes) const = 0;
     virtual void zero_out_buffer_on_cores(
         const MeshCoordinate& device_coord,
-        const std::vector<CoreCoord>& cores,
+        const std::vector<tt::tt_metal::CoreCoord>& cores,
         uint32_t address,
         uint32_t size_bytes) const = 0;
     virtual void write_data_to_core(
         const MeshCoordinate& device_coord,
-        const CoreCoord& cores,
+        const tt::tt_metal::CoreCoord& cores,
         uint32_t local_args_address,
         const std::vector<uint32_t>& args) const = 0;
 };

--- a/tests/tt_metal/tt_fabric/test_infra/tt_fabric_test_interfaces.hpp
+++ b/tests/tt_metal/tt_fabric/test_infra/tt_fabric_test_interfaces.hpp
@@ -62,7 +62,7 @@ public:
     // Data reading helpers
     virtual std::unordered_map<tt::tt_metal::CoreCoord, std::vector<uint32_t>> read_buffer_from_cores(
         const MeshCoordinate& device_coord,
-        const std::vector<CoreCoord>& cores,
+        const std::vector<tt::tt_metal::CoreCoord>& cores,
         uint32_t address,
         uint32_t size_bytes) const = 0;
     virtual void zero_out_buffer_on_cores(

--- a/tests/tt_metal/tt_fabric/test_infra/tt_fabric_test_progress_monitor.hpp
+++ b/tests/tt_metal/tt_fabric/test_infra/tt_fabric_test_progress_monitor.hpp
@@ -69,7 +69,7 @@ enum class EndpointRole : uint8_t { Sender, Receiver };
 struct EndpointId {
     EndpointRole role = EndpointRole::Sender;
     FabricNodeId node_id{MeshId{0}, 0};
-    CoreCoord logical_core;
+    tt::tt_metal::CoreCoord logical_core;
     uint16_t config_idx = 0;
 
     bool operator==(const EndpointId&) const = default;
@@ -217,11 +217,11 @@ private:
     void process_sender_read_results(
         FabricNodeId node_id,
         const TestDevice& test_device,
-        const std::unordered_map<CoreCoord, std::vector<uint32_t>>& core_data);
+        const std::unordered_map<tt::tt_metal::CoreCoord, std::vector<uint32_t>>& core_data);
     void process_receiver_read_results(
         FabricNodeId node_id,
         const TestDevice& test_device,
-        const std::unordered_map<CoreCoord, std::vector<uint32_t>>& core_data);
+        const std::unordered_map<tt::tt_metal::CoreCoord, std::vector<uint32_t>>& core_data);
     void check_for_hung_endpoints();
     void display_granular_progress(std::chrono::duration<double> elapsed);
     bool all_endpoints_resolved() const;

--- a/tests/tt_metal/tt_fabric/test_infra/tt_fabric_test_traffic.hpp
+++ b/tests/tt_metal/tt_fabric/test_infra/tt_fabric_test_traffic.hpp
@@ -16,10 +16,10 @@ using FlowUid = uint32_t;
 
 struct FlowDescriptor {
     FabricNodeId src_node_id;
-    CoreCoord src_logical_core;
+    tt::tt_metal::CoreCoord src_logical_core;
 
     std::vector<FabricNodeId> dst_node_ids;
-    CoreCoord dst_logical_core;
+    tt::tt_metal::CoreCoord dst_logical_core;
 
     uint32_t link_id = 0;
     uint8_t vc_id = 0;
@@ -270,8 +270,8 @@ struct TestTrafficConfig {
     FabricNodeId src_node_id;
     std::optional<std::vector<FabricNodeId>> dst_node_ids;
     std::optional<std::unordered_map<RoutingDirection, uint32_t>> hops;
-    std::optional<CoreCoord> src_logical_core;
-    std::optional<CoreCoord> dst_logical_core;
+    std::optional<tt::tt_metal::CoreCoord> src_logical_core;
+    std::optional<tt::tt_metal::CoreCoord> dst_logical_core;
     std::optional<uint32_t> target_address;
     std::optional<uint32_t> atomic_inc_address;
     uint32_t link_id = 0;  // Link ID for multi-link tests
@@ -290,7 +290,7 @@ struct TestTrafficConfig {
 struct ReceiverCreditInfo {
     FabricNodeId receiver_node_id;
     FabricNodeId sender_node_id;
-    CoreCoord sender_logical_core;
+    tt::tt_metal::CoreCoord sender_logical_core;
     uint32_t sender_noc_encoding;
     uint32_t credit_return_address;
 
@@ -306,7 +306,7 @@ struct TestTrafficSenderConfig {
     std::vector<FabricNodeId> dst_node_ids;
     std::optional<std::unordered_map<RoutingDirection, uint32_t>> hops;
     std::optional<FabricNodeId> mcast_start_node_id;
-    CoreCoord dst_logical_core;
+    tt::tt_metal::CoreCoord dst_logical_core;
     size_t target_address;
     std::optional<size_t> atomic_inc_address;
     uint32_t dst_noc_encoding;     // TODO: decide if we should keep it here or not

--- a/tests/tt_metal/tt_metal/api/buffer_test_utils.hpp
+++ b/tests/tt_metal/tt_metal/api/buffer_test_utils.hpp
@@ -13,13 +13,13 @@
 
 namespace tt::test::buffer::detail {
 inline void writeL1Backdoor(
-    tt::tt_metal::IDevice* device, CoreCoord coord, uint32_t address, std::vector<uint32_t>& data) {
+    tt::tt_metal::IDevice* device, tt::tt_metal::CoreCoord coord, uint32_t address, std::vector<uint32_t>& data) {
     log_info(tt::LogTest, "{} -- coord={} address={}", __FUNCTION__, coord.str(), address);
     tt_metal::detail::WriteToDeviceL1(device, coord, address, data);
 }
 inline void writeL1Backdoor(
     const std::shared_ptr<tt::tt_metal::distributed::MeshDevice>& mesh_device,
-    CoreCoord coord,
+    tt::tt_metal::CoreCoord coord,
     uint32_t address,
     std::vector<uint32_t>& data) {
     log_info(tt::LogTest, "{} -- coord={} address={}", __FUNCTION__, coord.str(), address);
@@ -27,20 +27,20 @@ inline void writeL1Backdoor(
 }
 inline void writeL1Backdoor(
     const std::shared_ptr<tt::tt_metal::distributed::MeshDevice>& mesh_device,
-    CoreCoord coord,
+    tt::tt_metal::CoreCoord coord,
     uint32_t address,
     std::span<const uint8_t> data) {
     log_info(tt::LogTest, "{} -- coord={} address={}", __FUNCTION__, coord.str(), address);
     tt_metal::detail::WriteToDeviceL1(mesh_device->get_devices()[0], coord, address, data);
 }
 inline void readL1Backdoor(
-    tt::tt_metal::IDevice* device, CoreCoord coord, uint32_t address, uint32_t byte_size, std::vector<uint32_t>& data) {
+    tt::tt_metal::IDevice* device, tt::tt_metal::CoreCoord coord, uint32_t address, uint32_t byte_size, std::vector<uint32_t>& data) {
     log_info(tt::LogTest, "{} -- coord={} address={} byte_size={}", __FUNCTION__, coord.str(), address, byte_size);
     tt_metal::detail::ReadFromDeviceL1(device, coord, address, byte_size, data);
 }
 inline void readL1Backdoor(
     const std::shared_ptr<tt::tt_metal::distributed::MeshDevice>& mesh_device,
-    CoreCoord coord,
+    tt::tt_metal::CoreCoord coord,
     uint32_t address,
     uint32_t byte_size,
     std::vector<uint32_t>& data) {
@@ -49,7 +49,7 @@ inline void readL1Backdoor(
 }
 inline void readL1Backdoor(
     const std::shared_ptr<tt::tt_metal::distributed::MeshDevice>& mesh_device,
-    CoreCoord coord,
+    tt::tt_metal::CoreCoord coord,
     uint32_t address,
     std::span<uint8_t> data) {
     log_info(tt::LogTest, "{} -- coord={} address={} byte_size={}", __FUNCTION__, coord.str(), address, data.size());

--- a/tests/tt_metal/tt_metal/api/compile_program_with_kernel_path_env_var_fixture.hpp
+++ b/tests/tt_metal/tt_metal/api/compile_program_with_kernel_path_env_var_fixture.hpp
@@ -33,7 +33,7 @@ protected:
     }
 
     void create_kernel(const std::string& kernel_file) {
-        CoreCoord core(0, 0);
+        tt::tt_metal::CoreCoord core(0, 0);
         tt::tt_metal::CreateKernel(
             this->program_,
             kernel_file,

--- a/tests/tt_metal/tt_metal/api/core_coord/test_CoreRange_iterator.cpp
+++ b/tests/tt_metal/tt_metal/api/core_coord/test_CoreRange_iterator.cpp
@@ -13,46 +13,46 @@ using std::vector;
 namespace basic_tests::CoreRange {
 
 TEST_F(CoreCoordFixture, TestCoreRangeIterator) {
-    vector<CoreCoord> cores_in_core_range;
+    vector<tt::tt_metal::CoreCoord> cores_in_core_range;
 
-    vector<CoreCoord> cores_iterated;
-    for (CoreCoord& core : this->cr1) {
+    vector<tt::tt_metal::CoreCoord> cores_iterated;
+    for (tt::tt_metal::CoreCoord& core : this->cr1) {
         cores_iterated.push_back(core);
     }
-    cores_in_core_range = {CoreCoord(0, 0), CoreCoord(1, 0), CoreCoord(0, 1), CoreCoord(1, 1)};
+    cores_in_core_range = {tt::tt_metal::CoreCoord(0, 0), tt::tt_metal::CoreCoord(1, 0), tt::tt_metal::CoreCoord(0, 1), tt::tt_metal::CoreCoord(1, 1)};
     EXPECT_EQ(cores_iterated, cores_in_core_range);
 
     cores_iterated.clear();
-    for (CoreCoord& core : this->cr2) {
+    for (tt::tt_metal::CoreCoord& core : this->cr2) {
         cores_iterated.push_back(core);
     }
     cores_in_core_range = {
-        CoreCoord(3, 3), CoreCoord(4, 3), CoreCoord(5, 3), CoreCoord(3, 4), CoreCoord(4, 4), CoreCoord(5, 4)};
+        tt::tt_metal::CoreCoord(3, 3), tt::tt_metal::CoreCoord(4, 3), tt::tt_metal::CoreCoord(5, 3), tt::tt_metal::CoreCoord(3, 4), tt::tt_metal::CoreCoord(4, 4), tt::tt_metal::CoreCoord(5, 4)};
     EXPECT_EQ(cores_iterated, cores_in_core_range);
 
     cores_iterated.clear();
-    for (CoreCoord& core : this->cr3) {
+    for (tt::tt_metal::CoreCoord& core : this->cr3) {
         cores_iterated.push_back(core);
     }
-    cores_in_core_range = {CoreCoord(1, 2), CoreCoord(2, 2)};
+    cores_in_core_range = {tt::tt_metal::CoreCoord(1, 2), tt::tt_metal::CoreCoord(2, 2)};
     EXPECT_EQ(cores_iterated, cores_in_core_range);
 
     cores_iterated.clear();
-    for (CoreCoord& core : this->cr15) {
+    for (tt::tt_metal::CoreCoord& core : this->cr15) {
         cores_iterated.push_back(core);
     }
-    cores_in_core_range = {CoreCoord(0, 1), CoreCoord(0, 2)};
+    cores_in_core_range = {tt::tt_metal::CoreCoord(0, 1), tt::tt_metal::CoreCoord(0, 2)};
     EXPECT_EQ(cores_iterated, cores_in_core_range);
 
     cores_iterated.clear();
-    for (CoreCoord& core : this->cr17) {
+    for (tt::tt_metal::CoreCoord& core : this->cr17) {
         cores_iterated.push_back(core);
     }
-    cores_in_core_range = {CoreCoord(2, 3)};
+    cores_in_core_range = {tt::tt_metal::CoreCoord(2, 3)};
     EXPECT_EQ(cores_iterated, cores_in_core_range);
 
     cores_iterated.clear();
-    for (CoreCoord& core : this->cr18) {
+    for (tt::tt_metal::CoreCoord& core : this->cr18) {
         cores_iterated.push_back(core);
     }
     cores_in_core_range = {CoreCoord(3, 1), CoreCoord(3, 2), CoreCoord(3, 3)};

--- a/tests/tt_metal/tt_metal/api/core_coord/test_CoreRange_iterator.cpp
+++ b/tests/tt_metal/tt_metal/api/core_coord/test_CoreRange_iterator.cpp
@@ -55,7 +55,7 @@ TEST_F(CoreCoordFixture, TestCoreRangeIterator) {
     for (tt::tt_metal::CoreCoord& core : this->cr18) {
         cores_iterated.push_back(core);
     }
-    cores_in_core_range = {CoreCoord(3, 1), CoreCoord(3, 2), CoreCoord(3, 3)};
+    cores_in_core_range = {tt::tt_metal::CoreCoord(3, 1), tt::tt_metal::CoreCoord(3, 2), tt::tt_metal::CoreCoord(3, 3)};
     EXPECT_EQ(cores_iterated, cores_in_core_range);
 }
 }  // namespace basic_tests::CoreRange

--- a/tests/tt_metal/tt_metal/api/distribution_spec/test_buffer_distribution_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/distribution_spec/test_buffer_distribution_spec.cpp
@@ -74,7 +74,7 @@ struct BufferDistributionSpecInputs {
 };
 
 struct MeshBufferAllocationExpected {
-    std::vector<CoreCoord> cores;
+    std::vector<tt::tt_metal::CoreCoord> cores;
     size_t num_cores;
     size_t num_dev_pages;
     size_t aligned_size;

--- a/tests/tt_metal/tt_metal/api/test_core_local_mem_api.cpp
+++ b/tests/tt_metal/tt_metal/api/test_core_local_mem_api.cpp
@@ -27,7 +27,7 @@
 namespace {
 
 void RunTest(tt::tt_metal::distributed::MeshDevice* mesh_device) {
-    const CoreCoord core = {0, 0};
+    const tt::tt_metal::CoreCoord core = {0, 0};
     tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
     tt::tt_metal::distributed::MeshWorkload workload;
 
@@ -49,7 +49,7 @@ void RunTest(tt::tt_metal::distributed::MeshDevice* mesh_device) {
     uint32_t num_iterations = 1000;
 
     // Try using the memory API with the NoC API to send random data to the neighbor core
-    CoreCoord neighbor_core{core.x + 1, core.y};
+    tt::tt_metal::CoreCoord neighbor_core{core.x + 1, core.y};
     auto neighbor_virtual_core = mesh_device->worker_core_from_logical_core(neighbor_core);
 
     std::random_device rd;

--- a/tests/tt_metal/tt_metal/deployment/deployment_common.hpp
+++ b/tests/tt_metal/tt_metal/deployment/deployment_common.hpp
@@ -71,7 +71,7 @@ static inline uint32_t l1_alloc(struct l1_allocator* alloc, uint32_t size, uint3
 }
 
 [[maybe_unused]]
-static uint32_t read_l1_u32(tt::tt_metal::IDevice* const device, const CoreCoord& core, uint64_t l1_addr) {
+static uint32_t read_l1_u32(tt::tt_metal::IDevice* const device, const tt::tt_metal::CoreCoord& core, uint64_t l1_addr) {
     auto delta_vec = tt::tt_metal::MetalContext::instance().get_cluster().read_core<uint32_t>(
         device->id(), device->worker_core_from_logical_core(core), l1_addr, sizeof(uint32_t));
 
@@ -79,7 +79,7 @@ static uint32_t read_l1_u32(tt::tt_metal::IDevice* const device, const CoreCoord
 }
 
 [[maybe_unused]]
-static uint64_t read_l1_u64(tt::tt_metal::IDevice* const device, const CoreCoord& core, uint64_t l1_addr) {
+static uint64_t read_l1_u64(tt::tt_metal::IDevice* const device, const tt::tt_metal::CoreCoord& core, uint64_t l1_addr) {
     auto delta_vec = tt::tt_metal::MetalContext::instance().get_cluster().read_core<uint32_t>(
         device->id(), device->worker_core_from_logical_core(core), l1_addr, 2 * sizeof(uint32_t));
 
@@ -87,7 +87,7 @@ static uint64_t read_l1_u64(tt::tt_metal::IDevice* const device, const CoreCoord
 }
 
 [[maybe_unused]]
-static uint32_t read_eth_l1_u32(tt::tt_metal::IDevice* const device, const CoreCoord& core, uint64_t l1_addr) {
+static uint32_t read_eth_l1_u32(tt::tt_metal::IDevice* const device, const tt::tt_metal::CoreCoord& core, uint64_t l1_addr) {
     auto delta_vec = tt::tt_metal::MetalContext::instance().get_cluster().read_core<uint32_t>(
         device->id(), device->ethernet_core_from_logical_core(core), l1_addr, sizeof(uint32_t));
 
@@ -95,7 +95,7 @@ static uint32_t read_eth_l1_u32(tt::tt_metal::IDevice* const device, const CoreC
 }
 
 [[maybe_unused]]
-static uint64_t read_eth_l1_u64(tt::tt_metal::IDevice* const device, const CoreCoord& core, uint64_t l1_addr) {
+static uint64_t read_eth_l1_u64(tt::tt_metal::IDevice* const device, const tt::tt_metal::CoreCoord& core, uint64_t l1_addr) {
     auto delta_vec = tt::tt_metal::MetalContext::instance().get_cluster().read_core<uint32_t>(
         device->id(), device->ethernet_core_from_logical_core(core), l1_addr, 2 * sizeof(uint32_t));
 
@@ -123,7 +123,7 @@ public:
 [[maybe_unused]]
 static bool bandwidth_check(
     tt::tt_metal::IDevice* const send_device,
-    const CoreCoord& send_core,
+    const tt::tt_metal::CoreCoord& send_core,
     uint32_t send_delta_addr,
     uint64_t total_transferred,
     double threshold) {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_all_ethernet_links.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_all_ethernet_links.cpp
@@ -70,8 +70,8 @@ struct SenderReceiverPair {
     tt_cxy_pair receiver;
 
     // In test modes where receiver writes results to tensix we
-    std::optional<CoreCoord> sender_tensix = std::nullopt;
-    std::optional<CoreCoord> receiver_tensix = std::nullopt;
+    std::optional<tt::tt_metal::CoreCoord> sender_tensix = std::nullopt;
+    std::optional<tt::tt_metal::CoreCoord> receiver_tensix = std::nullopt;
 
     std::shared_ptr<tt_metal::distributed::MeshBuffer> sender_buffer = nullptr;
     std::shared_ptr<tt_metal::distributed::MeshBuffer> receiver_buffer = nullptr;
@@ -92,10 +92,10 @@ struct SenderReceiverPair {
         }
         // this and other are diff
         // this sender before the other sender means less then
-        auto sender_coord = CoreCoord(sender.x, sender.y);
-        auto receiver_coord = CoreCoord(receiver.x, receiver.y);
-        auto other_sender_coord = CoreCoord(other.sender.x, other.sender.y);
-        auto other_receiver_coord = CoreCoord(other.receiver.x, other.receiver.y);
+        auto sender_coord = tt::tt_metal::CoreCoord(sender.x, sender.y);
+        auto receiver_coord = tt::tt_metal::CoreCoord(receiver.x, receiver.y);
+        auto other_sender_coord = tt::tt_metal::CoreCoord(other.sender.x, other.sender.y);
+        auto other_receiver_coord = tt::tt_metal::CoreCoord(other.receiver.x, other.receiver.y);
 
         // Order based on sender
         bool result = (sender.chip < other.sender.chip) ||
@@ -172,22 +172,22 @@ public:
 
 private:
     // NOLINTBEGIN(readability-make-member-function-const)
-    std::pair<std::optional<CoreCoord>, std::shared_ptr<tt_metal::distributed::MeshBuffer>>
+    std::pair<std::optional<tt::tt_metal::CoreCoord>, std::shared_ptr<tt_metal::distributed::MeshBuffer>>
     assign_tensix_and_allocate_buffer(const TestParams& params, const tt_cxy_pair& logical_eth_core) {
         if (params.benchmark_type != BenchmarkType::EthEthTensixUniDir and
             params.benchmark_type != BenchmarkType::EthEthTensixBiDir) {
             return {std::nullopt, nullptr};
         }
-        static std::unordered_map<ChipId, std::unordered_set<CoreCoord>> assigned_tensix_per_chip;
+        static std::unordered_map<ChipId, std::unordered_set<tt::tt_metal::CoreCoord>> assigned_tensix_per_chip;
         auto& assigned_phys_tensix = assigned_tensix_per_chip[logical_eth_core.chip];
         const auto& soc_d = tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(logical_eth_core.chip);
 
         auto physical_eth_core =
-            soc_d.get_physical_ethernet_core_from_logical(CoreCoord{logical_eth_core.x, logical_eth_core.y});
+            soc_d.get_physical_ethernet_core_from_logical(tt::tt_metal::CoreCoord{logical_eth_core.x, logical_eth_core.y});
 
         const std::vector<tt::umd::CoreCoord>& tensix_cores = soc_d.get_cores(CoreType::TENSIX, CoordSystem::NOC0);
 
-        std::optional<CoreCoord> closest_phys_tensix = std::nullopt;
+        std::optional<tt::tt_metal::CoreCoord> closest_phys_tensix = std::nullopt;
         for (auto phys_tensix : tensix_cores) {
             if (assigned_phys_tensix.contains(phys_tensix)) {
                 continue;
@@ -393,19 +393,19 @@ std::vector<tt_metal::Program> build(const ConnectedDevicesHelper& device_helper
             sender_program,
             "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/"
             "ethernet_write_worker_latency_ubench_sender.cpp",
-            CoreCoord(link.sender.x, link.sender.y),
+            tt::tt_metal::CoreCoord(link.sender.x, link.sender.y),
             tt_metal::EthernetConfig{.noc = tt_metal::NOC::RISCV_0_default, .compile_args = eth_ct_args});
         tt_metal::SetRuntimeArgs(
-            sender_program, sender_kernel, CoreCoord(link.sender.x, link.sender.y), eth_sender_rt_args);
+            sender_program, sender_kernel, tt::tt_metal::CoreCoord(link.sender.x, link.sender.y), eth_sender_rt_args);
 
         auto receiver_kernel = tt_metal::CreateKernel(
             receiver_program,
             "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/erisc/"
             "ethernet_write_worker_latency_ubench_receiver.cpp",
-            CoreCoord(link.receiver.x, link.receiver.y),
+            tt::tt_metal::CoreCoord(link.receiver.x, link.receiver.y),
             tt_metal::EthernetConfig{.noc = tt_metal::NOC::RISCV_0_default, .compile_args = eth_ct_args});
         tt_metal::SetRuntimeArgs(
-            receiver_program, receiver_kernel, CoreCoord(link.receiver.x, link.receiver.y), eth_receiver_rt_args);
+            receiver_program, receiver_kernel, tt::tt_metal::CoreCoord(link.receiver.x, link.receiver.y), eth_receiver_rt_args);
     }
 
     // Compile all programs
@@ -443,9 +443,9 @@ void validation(
         "Mismatch between chips");
 
     auto sender_virtual =
-        sender_device->virtual_core_from_logical_core(CoreCoord(link.sender.x, link.sender.y), CoreType::ETH);
+        sender_device->virtual_core_from_logical_core(tt::tt_metal::CoreCoord(link.sender.x, link.sender.y), CoreType::ETH);
     auto receiver_virtual =
-        receiver_device->virtual_core_from_logical_core(CoreCoord(link.receiver.x, link.receiver.y), CoreType::ETH);
+        receiver_device->virtual_core_from_logical_core(tt::tt_metal::CoreCoord(link.receiver.x, link.receiver.y), CoreType::ETH);
 
     if (read_buffer) {
         auto buffer_to_validate = validate_receiver ? link.receiver_buffer : link.sender_buffer;
@@ -506,9 +506,9 @@ void dump_eth_link_stats(
         auto* sender_device = find_device_with_id(device_helper.devices, link.sender.chip);
         auto* receiver_device = find_device_with_id(device_helper.devices, link.receiver.chip);
         auto sender_virtual =
-            sender_device->virtual_core_from_logical_core(CoreCoord(link.sender.x, link.sender.y), CoreType::ETH);
+            sender_device->virtual_core_from_logical_core(tt::tt_metal::CoreCoord(link.sender.x, link.sender.y), CoreType::ETH);
         auto receiver_virtual =
-            receiver_device->virtual_core_from_logical_core(CoreCoord(link.receiver.x, link.receiver.y), CoreType::ETH);
+            receiver_device->virtual_core_from_logical_core(tt::tt_metal::CoreCoord(link.receiver.x, link.receiver.y), CoreType::ETH);
 
         tt::tt_metal::MetalContext::instance().get_cluster().read_core(
             link_stats.data(),

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_bidirectional_bandwidth_no_edm.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_bidirectional_bandwidth_no_edm.cpp
@@ -81,15 +81,15 @@ private:
 };
 
 struct ChipSenderReceiverEthCore {
-    CoreCoord sender_core;
-    CoreCoord receiver_core;
+    tt::tt_metal::CoreCoord sender_core;
+    tt::tt_metal::CoreCoord receiver_core;
 };
 
 std::tuple<tt_metal::Program, tt_metal::Program> build(
     const std::shared_ptr<tt::tt_metal::distributed::MeshDevice>& /*device0*/,
     const std::shared_ptr<tt::tt_metal::distributed::MeshDevice>& /*device1*/,
-    CoreCoord eth_sender_core,
-    CoreCoord eth_receiver_core,
+    tt::tt_metal::CoreCoord eth_sender_core,
+    tt::tt_metal::CoreCoord eth_receiver_core,
     std::size_t /*num_samples*/,
     std::size_t /*sample_page_size*/,
     std::size_t /*max_channels_per_direction*/,
@@ -125,8 +125,8 @@ void run(
     tt_metal::KernelHandle local_kernel,
     tt_metal::KernelHandle remote_kernel,
 
-    CoreCoord eth_sender_core,
-    CoreCoord eth_receiver_core,
+    tt::tt_metal::CoreCoord eth_sender_core,
+    tt::tt_metal::CoreCoord eth_receiver_core,
     std::size_t num_samples,
     std::size_t sample_page_size,
     std::size_t max_channels_per_direction) {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_link_ping_latency_no_edm.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_ethernet_link_ping_latency_no_edm.cpp
@@ -89,15 +89,15 @@ private:
 };
 
 struct ChipSenderReceiverEthCore {
-    CoreCoord sender_core;
-    CoreCoord receiver_core;
+    tt::tt_metal::CoreCoord sender_core;
+    tt::tt_metal::CoreCoord receiver_core;
 };
 
 std::tuple<tt_metal::Program, tt_metal::Program> build(
     const std::shared_ptr<tt::tt_metal::distributed::MeshDevice>& /*device0*/,
     const std::shared_ptr<tt::tt_metal::distributed::MeshDevice>& /*device1*/,
-    CoreCoord eth_sender_core,
-    CoreCoord eth_receiver_core,
+    tt::tt_metal::CoreCoord eth_sender_core,
+    tt::tt_metal::CoreCoord eth_receiver_core,
     std::size_t num_samples,
     std::size_t sample_page_size,
     std::size_t num_channels,
@@ -141,8 +141,8 @@ void run(
     tt_metal::KernelHandle local_kernel,
     tt_metal::KernelHandle remote_kernel,
 
-    CoreCoord eth_sender_core,
-    CoreCoord eth_receiver_core,
+    tt::tt_metal::CoreCoord eth_sender_core,
+    tt::tt_metal::CoreCoord eth_receiver_core,
     std::size_t num_samples,
     std::size_t sample_page_size,
     std::size_t /*max_channels_per_direction*/) {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/noc/test_noc_unicast_vs_multicast_to_single_core_latency.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/noc/test_noc_unicast_vs_multicast_to_single_core_latency.cpp
@@ -29,9 +29,9 @@ void measure_latency(const std::string& kernel_name) {
 
     uint16_t channel =
         tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(device->id());
-    CoreCoord producer_logical_core =
+    tt::tt_metal::CoreCoord producer_logical_core =
         tt_metal::MetalContext::instance().get_dispatch_core_manager().prefetcher_core(device->id(), channel, 0);
-    CoreCoord consumer_logical_core =
+    tt::tt_metal::CoreCoord consumer_logical_core =
         tt_metal::MetalContext::instance().get_dispatch_core_manager().dispatcher_core(device->id(), channel, 0);
 
     TT_FATAL(

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/fabric_mux_v2_benchmark_program.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/fabric_mux_v2_benchmark_program.cpp
@@ -45,7 +45,7 @@ constexpr uint32_t kStandaloneDownstreamFreeSlotsStreamId =
     tt::tt_fabric::connection_interface::sender_channel_0_free_slots_stream_id;
 
 struct SenderExecutionContext {
-    CoreCoord logical_core;
+    tt::tt_metal::CoreCoord logical_core;
     uint32_t test_results_address = 0;
 };
 
@@ -78,20 +78,20 @@ uint32_t get_worker_l1_end_address() {
         hal.get_dev_size(tt::tt_metal::HalProgrammableCoreType::TENSIX, tt::tt_metal::HalL1MemAddrType::BASE));
 }
 
-std::vector<CoreCoord> enumerate_worker_cores(const MeshDevicePtr& device) {
+std::vector<tt::tt_metal::CoreCoord> enumerate_worker_cores(const MeshDevicePtr& device) {
     const auto grid_size = device->compute_with_storage_grid_size();
-    std::vector<CoreCoord> worker_cores;
+    std::vector<tt::tt_metal::CoreCoord> worker_cores;
     worker_cores.reserve(static_cast<size_t>(grid_size.x) * static_cast<size_t>(grid_size.y));
     for (std::size_t y = 0; y < grid_size.y; ++y) {
         for (std::size_t x = 0; x < grid_size.x; ++x) {
-            worker_cores.push_back(CoreCoord{static_cast<std::size_t>(x), static_cast<std::size_t>(y)});
+            worker_cores.push_back(tt::tt_metal::CoreCoord{static_cast<std::size_t>(x), static_cast<std::size_t>(y)});
         }
     }
     return worker_cores;
 }
 
 void write_zero_words_to_device(
-    tt::tt_metal::IDevice* device, const CoreCoord& logical_core, size_t address, size_t size_bytes) {
+    tt::tt_metal::IDevice* device, const tt::tt_metal::CoreCoord& logical_core, size_t address, size_t size_bytes) {
     TT_FATAL(
         (size_bytes % sizeof(uint32_t)) == 0,
         "Zero-init region size {} must be a multiple of {}",
@@ -103,7 +103,7 @@ void write_zero_words_to_device(
 }
 
 void write_word_to_device(
-    tt::tt_metal::IDevice* device, const CoreCoord& logical_core, size_t address, uint32_t value) {
+    tt::tt_metal::IDevice* device, const tt::tt_metal::CoreCoord& logical_core, size_t address, uint32_t value) {
     std::vector<uint32_t> word_buffer{value};
     tt::tt_metal::detail::WriteToDeviceL1(
         device, logical_core, to_uint32_checked(address, "word_init_address"), word_buffer);
@@ -111,7 +111,7 @@ void write_word_to_device(
 
 void initialize_sender_start_barrier_state(
     tt::tt_metal::IDevice* device,
-    const CoreCoord& sender_logical_core,
+    const tt::tt_metal::CoreCoord& sender_logical_core,
     uint32_t start_signal_address,
     uint32_t ready_count_address,
     uint32_t initial_ready_count) {
@@ -120,7 +120,7 @@ void initialize_sender_start_barrier_state(
 }
 
 std::vector<uint32_t> build_sender_noc_xy_encodings(
-    const MeshDevicePtr& sender_device, const std::vector<CoreCoord>& sender_logical_cores) {
+    const MeshDevicePtr& sender_device, const std::vector<tt::tt_metal::CoreCoord>& sender_logical_cores) {
     const auto& hal = tt::tt_metal::MetalContext::instance().hal();
     std::vector<uint32_t> sender_noc_xy_encodings;
     sender_noc_xy_encodings.reserve(sender_logical_cores.size());
@@ -149,7 +149,7 @@ std::vector<uint32_t> build_peer_sender_noc_xy_encodings(
 void create_data_movement_kernel(
     tt::tt_metal::Program& program,
     const std::string& kernel_path,
-    const CoreCoord& logical_core,
+    const tt::tt_metal::CoreCoord& logical_core,
     const std::vector<uint32_t>& compile_args,
     const std::vector<uint32_t>& runtime_args,
     tt::tt_metal::NOC noc = tt::tt_metal::NOC::RISCV_0_default) {
@@ -378,7 +378,7 @@ void validate_sender_memory_map(const SenderMemoryMap& memory_map) {
 
 void initialize_drainer_state(
     tt::tt_metal::IDevice* device,
-    const CoreCoord& drainer_logical_core,
+    const tt::tt_metal::CoreCoord& drainer_logical_core,
     const StandaloneMuxV2DrainerLayout& drainer_layout) {
     write_zero_words_to_device(device, drainer_logical_core, drainer_layout.get_status_address(), sizeof(uint32_t));
     write_zero_words_to_device(
@@ -395,8 +395,8 @@ void initialize_drainer_state(
 std::vector<uint32_t> build_mux_downstream_sender_rt_args(
     tt::tt_metal::IDevice* device,
     tt::tt_metal::Program& program,
-    const CoreCoord& mux_logical_core,
-    const CoreCoord& drainer_virtual_core,
+    const tt::tt_metal::CoreCoord& mux_logical_core,
+    const tt::tt_metal::CoreCoord& drainer_virtual_core,
     const StandaloneMuxV2DrainerLayout& drainer_layout) {
     const auto worker_teardown_semaphore_id = tt::tt_metal::CreateSemaphore(program, mux_logical_core, 0);
     const auto worker_buffer_index_semaphore_id = tt::tt_metal::CreateSemaphore(program, mux_logical_core, 0);
@@ -427,7 +427,7 @@ std::vector<uint32_t> build_mux_downstream_sender_rt_args(
 
 void create_drainer_kernel(
     tt::tt_metal::Program& program,
-    const CoreCoord& drainer_logical_core,
+    const tt::tt_metal::CoreCoord& drainer_logical_core,
     uint64_t expected_total_packets,
     const StandaloneMuxV2DrainerLayout& drainer_layout) {
     const std::vector<uint32_t> compile_args = {
@@ -449,11 +449,11 @@ void create_drainer_kernel(
 
 void create_sender_kernel(
     tt::tt_metal::Program& program,
-    const CoreCoord& sender_logical_core,
-    const CoreCoord& drainer_virtual_core,
+    const tt::tt_metal::CoreCoord& sender_logical_core,
+    const tt::tt_metal::CoreCoord& drainer_virtual_core,
     const SenderMemoryMap& sender_memory_map,
     const tt::tt_fabric::FabricMuxV2Config& mux_config,
-    const CoreCoord& mux_virtual_core,
+    const tt::tt_metal::CoreCoord& mux_virtual_core,
     const StandaloneMuxV2DrainerLayout& drainer_layout,
     uint32_t logical_channel_id,
     uint32_t num_packets,
@@ -583,23 +583,23 @@ bool FabricMuxV2BenchmarkContext::can_support_case(
     return true;
 }
 
-CoreCoord FabricMuxV2BenchmarkContext::get_mux_logical_core() const {
+tt::tt_metal::CoreCoord FabricMuxV2BenchmarkContext::get_mux_logical_core() const {
     TT_FATAL(!worker_cores_.empty(), "No worker cores are available for the standalone mux benchmark");
     return worker_cores_.at(0);
 }
 
-CoreCoord FabricMuxV2BenchmarkContext::get_drainer_logical_core() const {
+tt::tt_metal::CoreCoord FabricMuxV2BenchmarkContext::get_drainer_logical_core() const {
     TT_FATAL(worker_cores_.size() >= 2, "No drainer core is available for the standalone mux benchmark");
     return worker_cores_.at(1);
 }
 
-std::vector<CoreCoord> FabricMuxV2BenchmarkContext::get_sender_logical_cores(
+std::vector<tt::tt_metal::CoreCoord> FabricMuxV2BenchmarkContext::get_sender_logical_cores(
     const MuxV2ThroughputCase& benchmark_case) const {
     TT_FATAL(
         worker_cores_.size() >= static_cast<std::size_t>(benchmark_case.num_senders + 2),
         "Not enough worker cores to satisfy sender-core request");
 
-    return std::vector<CoreCoord>(
+    return std::vector<tt::tt_metal::CoreCoord>(
         worker_cores_.begin() + 2, worker_cores_.begin() + 2 + static_cast<std::ptrdiff_t>(benchmark_case.num_senders));
 }
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/fabric_mux_v2_benchmark_program.hpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/fabric_mux_v2_benchmark_program.hpp
@@ -50,16 +50,16 @@ public:
 
     const std::shared_ptr<tt::tt_metal::distributed::MeshDevice>& get_mesh_device() const { return mesh_device_; }
     tt::tt_metal::IDevice* get_device() const { return device_; }
-    const std::vector<CoreCoord>& get_worker_cores() const { return worker_cores_; }
+    const std::vector<tt::tt_metal::CoreCoord>& get_worker_cores() const { return worker_cores_; }
 
-    CoreCoord get_mux_logical_core() const;
-    CoreCoord get_drainer_logical_core() const;
-    std::vector<CoreCoord> get_sender_logical_cores(const MuxV2ThroughputCase& benchmark_case) const;
+    tt::tt_metal::CoreCoord get_mux_logical_core() const;
+    tt::tt_metal::CoreCoord get_drainer_logical_core() const;
+    std::vector<tt::tt_metal::CoreCoord> get_sender_logical_cores(const MuxV2ThroughputCase& benchmark_case) const;
 
 private:
     std::shared_ptr<tt::tt_metal::distributed::MeshDevice> mesh_device_;
     tt::tt_metal::IDevice* device_ = nullptr;
-    std::vector<CoreCoord> worker_cores_;
+    std::vector<tt::tt_metal::CoreCoord> worker_cores_;
 };
 
 struct StandaloneMuxV2BenchmarkRunResult {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/tensix/test_gathering.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/tensix/test_gathering.cpp
@@ -19,9 +19,9 @@ namespace tt_metal = tt::tt_metal;
 int main() {
     int device_id = 0;
     auto device = tt_metal::distributed::MeshDevice::create_unit_mesh(device_id);
-    CoreCoord compute_with_storage_size = device->compute_with_storage_grid_size();
-    CoreCoord start_core = {0, 0};
-    CoreCoord end_core = {compute_with_storage_size.x - 1, compute_with_storage_size.y - 1};
+    tt::tt_metal::CoreCoord compute_with_storage_size = device->compute_with_storage_grid_size();
+    tt::tt_metal::CoreCoord start_core = {0, 0};
+    tt::tt_metal::CoreCoord end_core = {compute_with_storage_size.x - 1, compute_with_storage_size.y - 1};
     CoreRange all_cores(start_core, end_core);
 
     std::map<std::string, std::string> kernel_defines = {

--- a/tests/ttnn/benchmark/cpp/matmul/test_matmul_benchmark.cpp
+++ b/tests/ttnn/benchmark/cpp/matmul/test_matmul_benchmark.cpp
@@ -232,7 +232,7 @@ void RunMatmulBenchmark(
         in0_sharded ? ttnn::operations::data_movement::create_sharded_memory_config(
                           ttnn::Shape{1, 1, m, k},
                           ttnn::CoreRangeSet(ttnn::CoreRange(
-                              CoreCoord(0, 0), ttnn::CoreCoord(grid_size.height() - 1, grid_size.width() - 1))),
+                              tt::tt_metal::CoreCoord(0, 0), ttnn::CoreCoord(grid_size.height() - 1, grid_size.width() - 1))),
                           ttnn::operations::data_movement::ShardStrategy::BLOCK,
                           tt::tt_metal::ShardOrientation::ROW_MAJOR)
                     : ttnn::DRAM_MEMORY_CONFIG;

--- a/tests/ttnn/unit_tests/gtests/tensor/test_h2d_stream_service.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_h2d_stream_service.cpp
@@ -119,8 +119,8 @@ tt::tt_metal::distributed::MeshWorkload build_worker_workload(
         auto* device = mesh_device->get_device(coord);
 
         // Service-core physical NoC coords and consumed-counter address both vary per device.
-        const CoreCoord service_logical = service.get_service_core(coord);
-        const CoreCoord service_phys = device->worker_core_from_logical_core(service_logical);
+        const tt::tt_metal::CoreCoord service_logical = service.get_service_core(coord);
+        const tt::tt_metal::CoreCoord service_phys = device->worker_core_from_logical_core(service_logical);
         const uint32_t consumed_counter_addr =
             static_cast<uint32_t>(service.get_consumed_counter_addr(coord));
 
@@ -159,7 +159,7 @@ tt::tt_metal::distributed::MeshWorkload build_worker_workload(
         uint32_t worker_idx = 0;
         for (uint32_t y = worker_cores.start_coord.y; y <= worker_cores.end_coord.y; ++y) {
             for (uint32_t x = worker_cores.start_coord.x; x <= worker_cores.end_coord.x; ++x) {
-                const CoreCoord core{x, y};
+                const tt::tt_metal::CoreCoord core{x, y};
                 const uint32_t start_page = worker_idx * pages_per_worker;
                 const uint32_t end_page = start_page + pages_per_worker;
                 tt::tt_metal::SetRuntimeArgs(
@@ -320,7 +320,7 @@ void run_h2d_stream_service_case(
                 // Read from the worker-owned output region, not the service-owned input region.
                 for (uint32_t y = worker_cores->start_coord.y; y <= worker_cores->end_coord.y; ++y) {
                     for (uint32_t x = worker_cores->start_coord.x; x <= worker_cores->end_coord.x; ++x) {
-                        const CoreCoord worker_logical{x, y};
+                        const tt::tt_metal::CoreCoord worker_logical{x, y};
                         std::vector<uint8_t> meta_readback(cs.metadata_size_bytes);
                         tt::tt_metal::detail::ReadFromDeviceL1(
                             d,
@@ -541,16 +541,16 @@ TEST_F(H2DStreamServiceTest, Replicated_WorkerSync_Sweep) {
         const char* label;
     };
     const Row rows[] = {
-        {640, 16, CoreRange{CoreCoord{0, 0}, CoreCoord{3, 0}}, 20, 0, "4_workers_row"},
+        {640, 16, CoreRange{tt::tt_metal::CoreCoord{0, 0}, tt::tt_metal::CoreCoord{3, 0}}, 20, 0, "4_workers_row"},
         // Single worker exercises the num_workers==1 degenerate-multicast path.
-        {640, 16, CoreRange{CoreCoord{0, 0}, CoreCoord{0, 0}}, 20, 0, "1_worker"},
+        {640, 16, CoreRange{tt::tt_metal::CoreCoord{0, 0}, tt::tt_metal::CoreCoord{0, 0}}, 20, 0, "1_worker"},
         // Full 12x10 grid = 120 cores; N bumped to 120 to keep divisibility.
-        {640, 120, CoreRange{CoreCoord{0, 0}, CoreCoord{11, 9}}, 100, 0, "120_workers_full_grid"},
+        {640, 120, CoreRange{tt::tt_metal::CoreCoord{0, 0}, tt::tt_metal::CoreCoord{11, 9}}, 100, 0, "120_workers_full_grid"},
 
-        {640, 16, CoreRange{CoreCoord{0, 0}, CoreCoord{3, 0}}, 20, 16, "4_workers_meta_16B"},
-        {640, 16, CoreRange{CoreCoord{0, 0}, CoreCoord{3, 0}}, 20, 256, "4_workers_meta_256B"},
+        {640, 16, CoreRange{tt::tt_metal::CoreCoord{0, 0}, tt::tt_metal::CoreCoord{3, 0}}, 20, 16, "4_workers_meta_16B"},
+        {640, 16, CoreRange{tt::tt_metal::CoreCoord{0, 0}, tt::tt_metal::CoreCoord{3, 0}}, 20, 256, "4_workers_meta_256B"},
         // Just under socket_page_size=2560 in max_coalesce_pages=1: host pads only 16 B of zeros.
-        {640, 16, CoreRange{CoreCoord{0, 0}, CoreCoord{3, 0}}, 20, 2544, "4_workers_meta_near_page"},
+        {640, 16, CoreRange{tt::tt_metal::CoreCoord{0, 0}, tt::tt_metal::CoreCoord{3, 0}}, 20, 2544, "4_workers_meta_near_page"},
     };
     const Chunking chunkings[] = {
         {1, 1, "cb1_fifo1"},
@@ -612,15 +612,15 @@ TEST_F(H2DStreamServiceTest, Sharded_WorkerSync_Sweep) {
         const char* label;
     };
     const Row rows[] = {
-        Row{640, 16, CoreRange{CoreCoord{0, 0}, CoreCoord{3, 0}}, 0, "4_workers_row"},
+        Row{640, 16, CoreRange{tt::tt_metal::CoreCoord{0, 0}, tt::tt_metal::CoreCoord{3, 0}}, 0, "4_workers_row"},
         // Single worker exercises the num_workers==1 degenerate-multicast path.
-        Row{640, 16, CoreRange{CoreCoord{0, 0}, CoreCoord{0, 0}}, 0, "1_worker"},
+        Row{640, 16, CoreRange{tt::tt_metal::CoreCoord{0, 0}, tt::tt_metal::CoreCoord{0, 0}}, 0, "1_worker"},
         // Full 12x10 grid = 120 cores; N bumped to 120 to keep divisibility.
-        Row{640, 120, CoreRange{CoreCoord{0, 0}, CoreCoord{11, 9}}, 0, "120_workers_full_grid"},
+        Row{640, 120, CoreRange{tt::tt_metal::CoreCoord{0, 0}, tt::tt_metal::CoreCoord{11, 9}}, 0, "120_workers_full_grid"},
 
-        Row{640, 16, CoreRange{CoreCoord{0, 0}, CoreCoord{3, 0}}, 16, "4_workers_meta_16B"},
-        Row{640, 16, CoreRange{CoreCoord{0, 0}, CoreCoord{3, 0}}, 256, "4_workers_meta_256B"},
-        Row{640, 16, CoreRange{CoreCoord{0, 0}, CoreCoord{3, 0}}, 2544, "4_workers_meta_near_page"},
+        Row{640, 16, CoreRange{tt::tt_metal::CoreCoord{0, 0}, tt::tt_metal::CoreCoord{3, 0}}, 16, "4_workers_meta_16B"},
+        Row{640, 16, CoreRange{tt::tt_metal::CoreCoord{0, 0}, tt::tt_metal::CoreCoord{3, 0}}, 256, "4_workers_meta_256B"},
+        Row{640, 16, CoreRange{tt::tt_metal::CoreCoord{0, 0}, tt::tt_metal::CoreCoord{3, 0}}, 2544, "4_workers_meta_near_page"},
     };
     const Chunking chunkings[] = {
         {1, 1, "cb1_fifo1"},
@@ -730,7 +730,7 @@ TEST_F(H2DStreamServiceTest, MultiThreadedHostPush_Sweep) {
     }
 
     // 4 workers; N=16 is divisible by 4.
-    const CoreRange worker_row{CoreCoord{0, 0}, CoreCoord{3, 0}};
+    const CoreRange worker_row{tt::tt_metal::CoreCoord{0, 0}, tt::tt_metal::CoreCoord{3, 0}};
     struct Scenario {
         std::optional<CoreRange> workers;
         uint32_t metadata_size_bytes;

--- a/tests/ttnn/unit_tests/gtests/test_convert_to_hwc_gather.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_convert_to_hwc_gather.cpp
@@ -20,8 +20,8 @@ protected:
     void TearDown() override {}
 
     // Helper to create core coordinate vectors
-    std::vector<CoreCoord> make_cores(uint32_t num_cores) {
-        std::vector<CoreCoord> cores;
+    std::vector<tt::tt_metal::CoreCoord> make_cores(uint32_t num_cores) {
+        std::vector<tt::tt_metal::CoreCoord> cores;
         cores.reserve(num_cores);
         for (uint32_t i = 0; i < num_cores; i++) {
             cores.emplace_back(i, 0);  // Simple linear arrangement
@@ -213,8 +213,8 @@ std::vector<std::vector<float>> gather_with_blocked_transfers(
     uint32_t B,
     uint32_t C,
     uint32_t HW,
-    const std::vector<CoreCoord>& input_cores,
-    const std::vector<CoreCoord>& output_cores,
+    const std::vector<tt::tt_metal::CoreCoord>& input_cores,
+    const std::vector<tt::tt_metal::CoreCoord>& output_cores,
     const std::vector<std::vector<float>>& input_shards,
     uint32_t block_size) {
     uint32_t num_input_cores = input_cores.size();
@@ -330,8 +330,8 @@ void gather_with_blocked_transfers_generic(
     uint32_t B,
     uint32_t C,
     uint32_t HW,
-    const std::vector<CoreCoord>& input_cores,
-    const std::vector<CoreCoord>& output_cores,
+    const std::vector<tt::tt_metal::CoreCoord>& input_cores,
+    const std::vector<tt::tt_metal::CoreCoord>& output_cores,
     uint32_t block_size) {
     // First, precompute transfers (element-based, size-agnostic)
     auto transfers = precompute_gather_transfers(B, C, HW, input_cores, output_cores);

--- a/tests/ttnn/unit_tests/gtests/test_to_and_from_json.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_to_and_from_json.cpp
@@ -48,7 +48,7 @@ INSTANTIATE_TEST_SUITE_P(
                 tt::tt_metal::TensorMemoryLayout::WIDTH_SHARDED,
                 ttnn::BufferType::DRAM,
                 tt::tt_metal::ShardSpec(
-                    CoreRangeSet{std::set<CoreRange>{CoreRange{CoreCoord{1, 2}, CoreCoord{7, 4}}}},
+                    CoreRangeSet{std::set<CoreRange>{CoreRange{tt::tt_metal::CoreCoord{1, 2}, tt::tt_metal::CoreCoord{7, 4}}}},
                     {32, 128},
                     tt::tt_metal::ShardOrientation::ROW_MAJOR
                 )
@@ -60,7 +60,7 @@ INSTANTIATE_TEST_SUITE_P(
 
 TEST(TEST_JSON_CONVERSION, TEST_MATMUL_CONFIG) {
     auto matmul_multi_core_reuse_program_config =
-        ttnn::operations::matmul::MatmulMultiCoreReuseProgramConfig{CoreCoord{2, 3}, 32, 64, 48, 128, 96};
+        ttnn::operations::matmul::MatmulMultiCoreReuseProgramConfig{tt::tt_metal::CoreCoord{2, 3}, 32, 64, 48, 128, 96};
     auto matmul_program_config = ttnn::operations::matmul::MatmulProgramConfig{matmul_multi_core_reuse_program_config};
 
     auto json_object = ttsl::json::to_json(matmul_program_config);

--- a/tt_metal/api/tt-metalium/core_coord.hpp
+++ b/tt_metal/api/tt-metalium/core_coord.hpp
@@ -210,7 +210,6 @@ bool operator!=(const CoreRangeSet& a, const CoreRangeSet& b);
 }  // namespace tt::tt_metal
 
 // Adding to tt::tt_metal namespace as we transition to moving this out of global namespace eventually.
-using CoreCoord [[deprecated("Use tt::tt_metal::CoreCoord")]] = tt::tt_metal::CoreCoord;
 using CoreRange [[deprecated("Use tt::tt_metal::CoreRange")]] = tt::tt_metal::CoreRange;
 using CoreRangeSet [[deprecated("Use tt::tt_metal::CoreRangeSet")]] = tt::tt_metal::CoreRangeSet;
 
@@ -218,31 +217,31 @@ using CoreRangeSet [[deprecated("Use tt::tt_metal::CoreRangeSet")]] = tt::tt_met
 // template to depriorize the wrappers in overloading to avoid ambiguous selection from compiler.
 
 template <bool _compiler_deprioritize_this = true>
-[[deprecated("Use tt::tt_metal::corerange_to_cores")]] inline std::vector<CoreCoord> corerange_to_cores(
+[[deprecated("Use tt::tt_metal::corerange_to_cores")]] inline std::vector<tt::tt_metal::CoreCoord> corerange_to_cores(
     const CoreRangeSet& crs, std::optional<uint32_t> max_cores = std::nullopt, bool row_wise = false) {
     return tt::tt_metal::corerange_to_cores(crs, max_cores, row_wise);
 }
 
 template <bool _compiler_deprioritize_this = true>
-[[deprecated("Use tt::tt_metal::grid_to_cores")]] inline std::vector<CoreCoord> grid_to_cores(
+[[deprecated("Use tt::tt_metal::grid_to_cores")]] inline std::vector<tt::tt_metal::CoreCoord> grid_to_cores(
     uint32_t num_cores, uint32_t grid_size_x, uint32_t grid_size_y, bool row_wise = false) {
     return tt::tt_metal::grid_to_cores(num_cores, grid_size_x, grid_size_y, row_wise);
 }
 
 template <bool _compiler_deprioritize_this = true>
-[[deprecated("Use tt::tt_metal::grid_to_cores")]] inline std::vector<CoreCoord> grid_to_cores(
-    CoreCoord start, CoreCoord end, bool row_wise = false) {
+[[deprecated("Use tt::tt_metal::grid_to_cores")]] inline std::vector<tt::tt_metal::CoreCoord> grid_to_cores(
+    tt::tt_metal::CoreCoord start, tt::tt_metal::CoreCoord end, bool row_wise = false) {
     return tt::tt_metal::grid_to_cores(start, end, row_wise);
 }
 
 template <bool _compiler_deprioritize_this = true>
-[[deprecated("Use tt::tt_metal::grid_to_cores_with_noop")]] inline std::vector<CoreCoord> grid_to_cores_with_noop(
+[[deprecated("Use tt::tt_metal::grid_to_cores_with_noop")]] inline std::vector<tt::tt_metal::CoreCoord> grid_to_cores_with_noop(
     uint32_t bbox_x, uint32_t bbox_y, uint32_t grid_size_x, uint32_t grid_size_y, bool row_wise = false) {
     return tt::tt_metal::grid_to_cores_with_noop(bbox_x, bbox_y, grid_size_x, grid_size_y, row_wise);
 }
 
 template <bool _compiler_deprioritize_this = true>
-[[deprecated("Use tt::tt_metal::grid_to_cores_with_noop")]] inline std::vector<CoreCoord> grid_to_cores_with_noop(
+[[deprecated("Use tt::tt_metal::grid_to_cores_with_noop")]] inline std::vector<tt::tt_metal::CoreCoord> grid_to_cores_with_noop(
     const CoreRangeSet& used_cores, const CoreRangeSet& all_cores, bool row_wise = false) {
     return tt::tt_metal::grid_to_cores_with_noop(used_cores, all_cores, row_wise);
 }

--- a/tt_metal/api/tt-metalium/experimental/fabric/control_plane.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/control_plane.hpp
@@ -262,8 +262,8 @@ public:
     // intended for users to grab available eth cores for testing
     // `skip_reserved_cores` is ignored on BH because there are no ethernet cores used for Fast Dispatch
     // tunneling
-    std::unordered_set<CoreCoord> get_active_ethernet_cores(ChipId chip_id, bool skip_reserved_cores = false) const;
-    std::unordered_set<CoreCoord> get_inactive_ethernet_cores(ChipId chip_id) const;
+    std::unordered_set<tt::tt_metal::CoreCoord> get_active_ethernet_cores(ChipId chip_id, bool skip_reserved_cores = false) const;
+    std::unordered_set<tt::tt_metal::CoreCoord> get_inactive_ethernet_cores(ChipId chip_id) const;
 
     // Collect router port directions map from all hosts via MPI and merge into local map
     void collect_and_merge_router_port_directions_from_all_hosts();
@@ -457,7 +457,7 @@ private:
         const FabricNodeId& fabric_node_id, chan_id_t chan_id, RoutingDirection direction);
 
     void assign_direction_to_fabric_eth_core(
-        const FabricNodeId& fabric_node_id, const CoreCoord& eth_core, RoutingDirection direction);
+        const FabricNodeId& fabric_node_id, const tt::tt_metal::CoreCoord& eth_core, RoutingDirection direction);
 
     // Initialize the local mesh binding from the environment variables
     // Returns std::nullopt if not in multi-host context

--- a/tt_metal/api/tt-metalium/experimental/fabric/fabric.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/fabric.hpp
@@ -326,7 +326,7 @@ public:
         size_t base_l1_address);
 
     void append_client_connection_rt_args(
-        const CoreCoord& mux_virtual_core,
+        const tt::tt_metal::CoreCoord& mux_virtual_core,
         uint8_t logical_channel_id,
         const ClientSemaphores& client_semaphores,
         std::vector<uint32_t>& worker_args) const;
@@ -338,13 +338,13 @@ private:
     friend void add_fabric_mux_v2_to_program(
         tt::tt_metal::Program& program,
         const FabricMuxV2Config& config,
-        const CoreCoord& mux_logical_core,
+        const tt::tt_metal::CoreCoord& mux_logical_core,
         const std::vector<uint32_t>& downstream_sender_rt_args,
         tt::tt_metal::NOC forwarder_noc);
     friend void add_fabric_mux_v2_to_program(
         tt::tt_metal::Program& program,
         const FabricMuxV2Config& config,
-        const CoreCoord& mux_logical_core,
+        const tt::tt_metal::CoreCoord& mux_logical_core,
         const FabricNodeId& src_fabric_node_id,
         const FabricNodeId& dst_fabric_node_id,
         uint32_t link_idx,
@@ -387,14 +387,14 @@ private:
 void add_fabric_mux_v2_to_program(
     tt::tt_metal::Program& program,
     const FabricMuxV2Config& config,
-    const CoreCoord& mux_logical_core,
+    const tt::tt_metal::CoreCoord& mux_logical_core,
     const std::vector<uint32_t>& downstream_sender_rt_args,
     tt::tt_metal::NOC forwarder_noc = tt::tt_metal::NOC::RISCV_0_default);
 
 void add_fabric_mux_v2_to_program(
     tt::tt_metal::Program& program,
     const FabricMuxV2Config& config,
-    const CoreCoord& mux_logical_core,
+    const tt::tt_metal::CoreCoord& mux_logical_core,
     const FabricNodeId& src_fabric_node_id,
     const FabricNodeId& dst_fabric_node_id,
     uint32_t link_idx,

--- a/tt_metal/common/core_coord.cpp
+++ b/tt_metal/common/core_coord.cpp
@@ -646,7 +646,7 @@ bool operator!=(const CoreRangeSet& a, const CoreRangeSet& b) { return !(a == b)
 
 }  // namespace tt::tt_metal
 
-auto fmt::formatter<CoreCoord>::format(const CoreCoord& core_coord, format_context& ctx) const
+auto fmt::formatter<tt::tt_metal::CoreCoord>::format(const tt::tt_metal::CoreCoord& core_coord, format_context& ctx) const
     -> format_context::iterator {
     std::stringstream ss;
     ss << core_coord.str();
@@ -703,11 +703,11 @@ std::size_t hash<CoreRangeSet>::operator()(const CoreRangeSet& core_range_set) c
 
 namespace ttsl::json {
 
-nlohmann::json to_json_t<CoreCoord>::operator()(const CoreCoord& core_coord) noexcept {
+nlohmann::json to_json_t<tt::tt_metal::CoreCoord>::operator()(const tt::tt_metal::CoreCoord& core_coord) noexcept {
     return {{"x", to_json(core_coord.x)}, {"y", to_json(core_coord.y)}};
 }
 
-CoreCoord from_json_t<CoreCoord>::operator()(const nlohmann::json& json) noexcept {
+tt::tt_metal::CoreCoord from_json_t<tt::tt_metal::CoreCoord>::operator()(const nlohmann::json& json) noexcept {
     return {from_json<uint32_t>(json.at("x")), from_json<uint32_t>(json.at("y"))};
 }
 
@@ -726,7 +726,7 @@ nlohmann::json to_json_t<CoreRange>::operator()(const CoreRange& core_range) noe
 }
 
 CoreRange from_json_t<CoreRange>::operator()(const nlohmann::json& json) noexcept {
-    return {from_json<CoreCoord>(json.at("start")), from_json<CoreCoord>(json.at("end"))};
+    return {from_json<tt::tt_metal::CoreCoord>(json.at("start")), from_json<tt::tt_metal::CoreCoord>(json.at("end"))};
 }
 
 nlohmann::json to_json_t<CoreRangeSet>::operator()(const CoreRangeSet& core_range_set) noexcept {

--- a/tt_metal/fabric/builder/connection_writer_adapter.hpp
+++ b/tt_metal/fabric/builder/connection_writer_adapter.hpp
@@ -15,7 +15,7 @@ namespace tt::tt_fabric {
 
 // Local tensix (relay) connection info for UDM mode
 struct LocalTensixRelayConnectionInfo {
-    CoreCoord noc_xy = {0, 0};
+    tt::tt_metal::CoreCoord noc_xy = {0, 0};
     size_t buffer_base_address = 0;
     size_t worker_registration_address = 0;
     size_t worker_location_info_address = 0;
@@ -57,7 +57,7 @@ public:
         uint32_t inbound_vc_idx,
         uint32_t sender_channel_idx,
         eth_chan_directions downstream_direction,
-        CoreCoord downstream_noc_xy,
+        tt::tt_metal::CoreCoord downstream_noc_xy,
         bool is_2D_routing) = 0;
 
     virtual void pack_inbound_channel_rt_args(uint32_t vc_idx, std::vector<uint32_t>& args_out) const = 0;
@@ -65,7 +65,7 @@ public:
     virtual void emit_ct_args(std::vector<uint32_t>& ct_args_out, size_t num_fwd_paths) const = 0;
 
     // Add connection to local tensix (relay in UDM mode)
-    virtual void add_local_tensix_connection(const SenderWorkerAdapterSpec&, eth_chan_directions, CoreCoord) = 0;
+    virtual void add_local_tensix_connection(const SenderWorkerAdapterSpec&, eth_chan_directions, tt::tt_metal::CoreCoord) = 0;
 
     // Get the number of downstream EDMs connected for a specific VC
     virtual uint32_t get_downstream_edm_count_for_vc(uint32_t vc_idx) const = 0;
@@ -101,13 +101,13 @@ public:
         uint32_t inbound_vc_idx,
         uint32_t sender_channel_idx,
         eth_chan_directions downstream_direction,
-        CoreCoord downstream_noc_xy,
+        tt::tt_metal::CoreCoord downstream_noc_xy,
         bool is_2D_routing) override;
 
     void add_local_tensix_connection(
         const SenderWorkerAdapterSpec& adapter_spec,
         eth_chan_directions tensix_direction,
-        CoreCoord tensix_noc_xy) override;
+        tt::tt_metal::CoreCoord tensix_noc_xy) override;
 
     void pack_inbound_channel_rt_args(uint32_t vc_idx, std::vector<uint32_t>& args_out) const override;
     void pack_adaptor_to_relay_rt_args(std::vector<uint32_t>& args_out) const override;
@@ -134,17 +134,17 @@ private:
     uint32_t pack_downstream_noc_x_rt_arg(uint32_t vc_idx) const;
     uint32_t encode_noc_ord_for_2d(
         const std::array<
-            std::vector<std::pair<eth_chan_directions, CoreCoord>>,
+            std::vector<std::pair<eth_chan_directions, tt::tt_metal::CoreCoord>>,
             builder_config::num_max_receiver_channels>& downstream_edms_connected_by_vc,
         uint32_t vc_idx,
-        const std::function<uint32_t(CoreCoord)>& get_noc_ord) const;
+        const std::function<uint32_t(tt::tt_metal::CoreCoord)>& get_noc_ord) const;
 
     void emit_ct_args(std::vector<uint32_t>& ct_args_out, size_t num_fwd_paths) const override;
 
     std::unordered_set<uint32_t> downstream_edms_connected_by_vc_set;
 
     // holds which downstream cores a given receiver/inbound channel VC can feed into
-    std::array<std::vector<std::pair<eth_chan_directions, CoreCoord>>, builder_config::num_max_receiver_channels>
+    std::array<std::vector<std::pair<eth_chan_directions, tt::tt_metal::CoreCoord>>, builder_config::num_max_receiver_channels>
         downstream_edms_connected_by_vc = {};
 
     // holds the number of buffer slots per downstream sender channel

--- a/tt_metal/fabric/builder/static_sized_channel_connection_writer_adapter.cpp
+++ b/tt_metal/fabric/builder/static_sized_channel_connection_writer_adapter.cpp
@@ -23,11 +23,11 @@ void StaticSizedChannelConnectionWriterAdapter::add_downstream_connection(
     uint32_t inbound_vc_idx,
     uint32_t /*sender_channel_idx*/,
     eth_chan_directions downstream_direction,
-    CoreCoord downstream_noc_xy,
+    tt::tt_metal::CoreCoord downstream_noc_xy,
     bool is_2D_routing) {
     // Track connections per VC for packing
     downstream_edms_connected_by_vc.at(inbound_vc_idx)
-        .push_back({downstream_direction, CoreCoord(downstream_noc_xy.x, downstream_noc_xy.y)});
+        .push_back({downstream_direction, tt::tt_metal::CoreCoord(downstream_noc_xy.x, downstream_noc_xy.y)});
 
     if (is_2D_routing) {
         // Calculate compact index based on downstream_direction relative to my_direction
@@ -69,7 +69,7 @@ void StaticSizedChannelConnectionWriterAdapter::add_downstream_connection(
 }
 
 void StaticSizedChannelConnectionWriterAdapter::add_local_tensix_connection(
-    const SenderWorkerAdapterSpec& adapter_spec, eth_chan_directions /*tensix_direction*/, CoreCoord tensix_noc_xy) {
+    const SenderWorkerAdapterSpec& adapter_spec, eth_chan_directions /*tensix_direction*/, tt::tt_metal::CoreCoord tensix_noc_xy) {
     this->relay_connection_info.noc_xy = tensix_noc_xy;
     this->relay_connection_info.buffer_base_address = adapter_spec.edm_buffer_base_addr;
     this->relay_connection_info.worker_registration_address = adapter_spec.edm_connection_handshake_addr;
@@ -270,10 +270,10 @@ uint32_t StaticSizedChannelConnectionWriterAdapter::pack_downstream_noc_x_rt_arg
  * X and Y have separate uint32s
  */
 uint32_t StaticSizedChannelConnectionWriterAdapter::encode_noc_ord_for_2d(
-    const std::array<std::vector<std::pair<eth_chan_directions, CoreCoord>>, builder_config::num_max_receiver_channels>&
+    const std::array<std::vector<std::pair<eth_chan_directions, tt::tt_metal::CoreCoord>>, builder_config::num_max_receiver_channels>&
         downstream_edms_connected_by_vc,
     uint32_t vc_idx,
-    const std::function<uint32_t(CoreCoord)>& get_noc_ord) const {
+    const std::function<uint32_t(tt::tt_metal::CoreCoord)>& get_noc_ord) const {
     if (!is_2D_routing) {
         // 1D routing: single downstream connection
         if (downstream_edms_connected_by_vc[vc_idx].empty()) {

--- a/tt_metal/fabric/ccl/ccl_common.cpp
+++ b/tt_metal/fabric/ccl/ccl_common.cpp
@@ -49,7 +49,7 @@ tt::tt_metal::KernelHandle generate_erisc_datamover_kernel(const FabricEriscData
 tt::tt_metal::KernelHandle generate_edm_kernel(
     tt::tt_metal::Program& program,
     const tt::tt_fabric::FabricEriscDatamoverBuilder& edm_builder,
-    const CoreCoord& eth_core,
+    const tt::tt_metal::CoreCoord& eth_core,
     const tt::tt_metal::DataMovementProcessor risc_id,
     tt::tt_metal::NOC noc_id) {
     edm_builder.dump_to_log();

--- a/tt_metal/fabric/ccl/ccl_common.hpp
+++ b/tt_metal/fabric/ccl/ccl_common.hpp
@@ -16,7 +16,7 @@ namespace tt::tt_fabric {
 tt::tt_metal::KernelHandle generate_edm_kernel(
     tt::tt_metal::Program& program,
     const tt::tt_fabric::FabricEriscDatamoverBuilder& edm_builder,
-    const CoreCoord& eth_core,
+    const tt::tt_metal::CoreCoord& eth_core,
     tt::tt_metal::DataMovementProcessor risc_id,
     tt::tt_metal::NOC noc_id);
 

--- a/tt_metal/fabric/compute_mesh_router_builder.cpp
+++ b/tt_metal/fabric/compute_mesh_router_builder.cpp
@@ -628,7 +628,7 @@ void ComputeMeshRouterBuilder::connect_to_local_tensix_builder(FabricTensixDatam
     auto* adapter_ptr = erisc_builder_->receiver_channel_to_downstream_adapter.get();
     const auto tensix_noc_x = tensix_builder.get_noc_x();
     const auto tensix_noc_y = tensix_builder.get_noc_y();
-    adapter_ptr->add_local_tensix_connection(adapter_spec, local_tensix_dir, CoreCoord(tensix_noc_x, tensix_noc_y));
+    adapter_ptr->add_local_tensix_connection(adapter_spec, local_tensix_dir, tt::tt_metal::CoreCoord(tensix_noc_x, tensix_noc_y));
 
     // Provide router NOC coordinates to relay kernel for sending packets back to router
     tensix_builder.append_relay_router_noc_xy(erisc_builder_->get_noc_x(), erisc_builder_->get_noc_y());

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -1604,8 +1604,8 @@ void write_to_worker_or_fabric_tensix_cores(
         control_plane.get_fabric_tensix_config() != tt::tt_fabric::FabricTensixConfig::DISABLED;
 
     // Get pre-computed translated fabric mux cores from tensix config
-    std::unordered_set<CoreCoord> fabric_mux_cores_translated;
-    std::unordered_set<CoreCoord> dispatch_mux_cores_translated;
+    std::unordered_set<tt::tt_metal::CoreCoord> fabric_mux_cores_translated;
+    std::unordered_set<tt::tt_metal::CoreCoord> dispatch_mux_cores_translated;
     if (tensix_config_enabled) {
         const auto& fabric_context = control_plane.get_fabric_context();
         const auto& tensix_config = fabric_context.get_builder_context().get_tensix_config();
@@ -1615,7 +1615,7 @@ void write_to_worker_or_fabric_tensix_cores(
 
     enum class CoreType { Worker, FabricTensixExtension, DispatcherMux };
 
-    auto get_core_type = [&](const CoreCoord& core_coord) -> CoreType {
+    auto get_core_type = [&](const tt::tt_metal::CoreCoord& core_coord) -> CoreType {
         if (fabric_mux_cores_translated.contains(core_coord)) {
             return CoreType::FabricTensixExtension;
         }
@@ -1647,7 +1647,7 @@ void write_to_worker_or_fabric_tensix_cores(
     };
 
     for (const auto& tensix_core : all_tensix_cores) {
-        CoreCoord core_coord(tensix_core.x, tensix_core.y);
+        tt::tt_metal::CoreCoord core_coord(tensix_core.x, tensix_core.y);
         CoreType core_type = get_core_type(core_coord);
         const void* data_to_write = select_data(core_type);
 
@@ -1692,24 +1692,24 @@ static void write_to_all_cores(
                 cluster.write_core(
                     data,
                     size,
-                    tt_cxy_pair(physical_chip_id, CoreCoord(tensix_core.x, tensix_core.y)),
+                    tt_cxy_pair(physical_chip_id, tt::tt_metal::CoreCoord(tensix_core.x, tensix_core.y)),
                     hal.get_dev_addr(core_type, addr_type));
             }
             break;
         }
         case tt::tt_metal::HalProgrammableCoreType::IDLE_ETH:
         case tt::tt_metal::HalProgrammableCoreType::ACTIVE_ETH: {
-            std::unordered_set<CoreCoord> logical_eth_cores =
+            std::unordered_set<tt::tt_metal::CoreCoord> logical_eth_cores =
                 (core_type == tt::tt_metal::HalProgrammableCoreType::IDLE_ETH)
                     ? control_plane.get_inactive_ethernet_cores(physical_chip_id)
                     : control_plane.get_active_ethernet_cores(physical_chip_id);
-            for (const CoreCoord& logical_eth_core : logical_eth_cores) {
-                CoreCoord virtual_eth_core = cluster.get_virtual_coordinate_from_logical_coordinates(
+            for (const tt::tt_metal::CoreCoord& logical_eth_core : logical_eth_cores) {
+                tt::tt_metal::CoreCoord virtual_eth_core = cluster.get_virtual_coordinate_from_logical_coordinates(
                     physical_chip_id, logical_eth_core, CoreType::ETH);
                 cluster.write_core(
                     data,
                     size,
-                    tt_cxy_pair(physical_chip_id, CoreCoord(virtual_eth_core.x, virtual_eth_core.y)),
+                    tt_cxy_pair(physical_chip_id, tt::tt_metal::CoreCoord(virtual_eth_core.x, virtual_eth_core.y)),
                     hal.get_dev_addr(core_type, addr_type));
             }
             break;
@@ -2054,7 +2054,7 @@ void ControlPlane::write_fabric_telemetry_to_all_chips(const FabricNodeId& fabri
         // auto routing_direction = get_eth_chan_direction(fabric_node_id, chan_id);
         // static_view.direction() = static_cast<std::uint8_t>(routing_direction);
 
-        CoreCoord virtual_eth_core = this->cluster_.get().get_virtual_eth_core_from_channel(physical_chip_id, chan_id);
+        tt::tt_metal::CoreCoord virtual_eth_core = this->cluster_.get().get_virtual_eth_core_from_channel(physical_chip_id, chan_id);
         this->cluster_.get().write_core(
             telemetry.data(),
             telemetry.size(),
@@ -2184,10 +2184,10 @@ bool ControlPlane::is_cross_host_eth_link(ChipId chip_id, chan_id_t chan_id) con
     return this->physical_system_descriptor_->is_cross_host_eth_link(tt::tt_metal::AsicID{asic_id}, chan_id);
 }
 
-std::unordered_set<CoreCoord> ControlPlane::get_active_ethernet_cores(ChipId chip_id, bool skip_reserved_cores) const {
+std::unordered_set<tt::tt_metal::CoreCoord> ControlPlane::get_active_ethernet_cores(ChipId chip_id, bool skip_reserved_cores) const {
     const auto& cluster = this->cluster_.get();
 
-    std::unordered_set<CoreCoord> active_ethernet_cores;
+    std::unordered_set<tt::tt_metal::CoreCoord> active_ethernet_cores;
     const auto& cluster_desc = cluster.get_cluster_desc();
     const auto& soc_desc = cluster.get_soc_desc(chip_id);
 
@@ -2204,7 +2204,7 @@ std::unordered_set<CoreCoord> ControlPlane::get_active_ethernet_cores(ChipId chi
         for (auto logical_active_eth_channel : logical_active_eth_channels) {
             tt::umd::CoreCoord logical_active_eth =
                 soc_desc.get_eth_core_for_channel(logical_active_eth_channel, CoordSystem::LOGICAL);
-            active_ethernet_cores.insert(CoreCoord(logical_active_eth.x, logical_active_eth.y));
+            active_ethernet_cores.insert(tt::tt_metal::CoreCoord(logical_active_eth.x, logical_active_eth.y));
         }
     } else {
         std::set<uint32_t> logical_active_eth_channels = cluster_desc->get_active_eth_channels(chip_id);
@@ -2245,10 +2245,10 @@ std::unordered_set<CoreCoord> ControlPlane::get_active_ethernet_cores(ChipId chi
     return active_ethernet_cores;
 }
 
-std::unordered_set<CoreCoord> ControlPlane::get_inactive_ethernet_cores(ChipId chip_id) const {
+std::unordered_set<tt::tt_metal::CoreCoord> ControlPlane::get_inactive_ethernet_cores(ChipId chip_id) const {
     const auto& cluster = this->cluster_.get();
-    std::unordered_set<CoreCoord> active_ethernet_cores = this->get_active_ethernet_cores(chip_id);
-    std::unordered_set<CoreCoord> inactive_ethernet_cores;
+    std::unordered_set<tt::tt_metal::CoreCoord> active_ethernet_cores = this->get_active_ethernet_cores(chip_id);
+    std::unordered_set<tt::tt_metal::CoreCoord> inactive_ethernet_cores;
 
     for (const auto& [eth_core, chan] : cluster.get_soc_desc(chip_id).logical_eth_core_to_chan_map) {
         if (!active_ethernet_cores.contains(eth_core)) {
@@ -2278,7 +2278,7 @@ void ControlPlane::assign_direction_to_fabric_eth_chan(
 }
 
 void ControlPlane::assign_direction_to_fabric_eth_core(
-    const FabricNodeId& fabric_node_id, const CoreCoord& eth_core, RoutingDirection direction) {
+    const FabricNodeId& fabric_node_id, const tt::tt_metal::CoreCoord& eth_core, RoutingDirection direction) {
     auto physical_chip_id = this->logical_mesh_chip_id_to_physical_chip_id_mapping_.at(fabric_node_id);
     auto chan_id = this->cluster_.get().get_soc_desc(physical_chip_id).logical_eth_core_to_chan_map.at(eth_core);
     this->assign_direction_to_fabric_eth_chan(fabric_node_id, chan_id, direction);
@@ -2402,7 +2402,7 @@ ControlPlane::get_global_logical_bindings() const {
 // Helper function to fill connection info with common fields for fabric router configs
 void fill_connection_info_fields(
     tt::tt_fabric::fabric_connection_info_t& connection_info,
-    const CoreCoord& virtual_core,
+    const tt::tt_metal::CoreCoord& virtual_core,
     const FabricEriscDatamoverConfig& config,
     uint32_t sender_channel,
     uint16_t worker_free_slots_stream_id) {
@@ -2426,7 +2426,7 @@ void fill_connection_info_fields(
 // Helper function to fill tensix connection info with tensix-specific configuration
 void fill_tensix_connection_info_fields(
     tt::tt_fabric::fabric_connection_info_t& connection_info,
-    const CoreCoord& mux_core_virtual,
+    const tt::tt_metal::CoreCoord& mux_core_virtual,
     const tt::tt_fabric::FabricTensixDatamoverConfig& tensix_config,
     uint32_t sender_channel,
     tt::tt_fabric::FabricTensixCoreType core_id) {
@@ -2462,7 +2462,7 @@ void ControlPlane::populate_fabric_connection_info(
     // Always populate fabric router config for normal workers
     const auto& edm_config = builder_context.get_fabric_router_config(
         fabric_tensix_config, static_cast<eth_chan_directions>(sender_channel));
-    CoreCoord fabric_router_virtual_core = cluster.get_virtual_eth_core_from_channel(physical_chip_id, eth_channel_id);
+    tt::tt_metal::CoreCoord fabric_router_virtual_core = cluster.get_virtual_eth_core_from_channel(physical_chip_id, eth_channel_id);
 
     fill_connection_info_fields(
         worker_connection_info, fabric_router_virtual_core, edm_config, sender_channel, WORKER_FREE_SLOTS_STREAM_ID);
@@ -2479,8 +2479,8 @@ void ControlPlane::populate_fabric_connection_info(
             WORKER_FREE_SLOTS_STREAM_ID);
 
         const auto& tensix_config = builder_context.get_tensix_config();
-        CoreCoord mux_core_logical = tensix_config.get_core_for_channel(physical_chip_id, eth_channel_id);
-        CoreCoord mux_core_virtual = cluster.get_virtual_coordinate_from_logical_coordinates(
+        tt::tt_metal::CoreCoord mux_core_logical = tensix_config.get_core_for_channel(physical_chip_id, eth_channel_id);
+        tt::tt_metal::CoreCoord mux_core_virtual = cluster.get_virtual_coordinate_from_logical_coordinates(
             physical_chip_id, mux_core_logical, CoreType::WORKER);
         // Get the RISC ID that handles this ethernet channel
         auto core_id = tensix_config.get_core_id_for_channel(physical_chip_id, eth_channel_id);
@@ -2505,8 +2505,8 @@ void ControlPlane::write_udm_fabric_connections_to_tensix_cores(
     const auto& tensix_config = fabric_context.get_builder_context().get_tensix_config();
 
     // Get mux and dispatcher cores
-    std::unordered_set<CoreCoord> fabric_mux_cores_translated = tensix_config.get_translated_fabric_mux_cores();
-    std::unordered_set<CoreCoord> dispatch_mux_cores_translated = tensix_config.get_translated_dispatch_mux_cores();
+    std::unordered_set<tt::tt_metal::CoreCoord> fabric_mux_cores_translated = tensix_config.get_translated_fabric_mux_cores();
+    std::unordered_set<tt::tt_metal::CoreCoord> dispatch_mux_cores_translated = tensix_config.get_translated_dispatch_mux_cores();
 
     const auto& soc_desc = cluster.get_soc_desc(physical_chip_id);
     const std::vector<tt::umd::CoreCoord>& all_tensix_cores =
@@ -2514,7 +2514,7 @@ void ControlPlane::write_udm_fabric_connections_to_tensix_cores(
 
     // Build per-worker connection info and write to each worker core
     for (const auto& tensix_core : all_tensix_cores) {
-        CoreCoord core_coord(tensix_core.x, tensix_core.y);
+        tt::tt_metal::CoreCoord core_coord(tensix_core.x, tensix_core.y);
 
         // Determine core type
         const void* data_to_write = nullptr;

--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -572,7 +572,7 @@ void append_worker_to_fabric_edm_sender_rt_args(
     chan_id_t eth_channel =
         tt::tt_metal::MetalContext::instance()
             .get_cluster()
-            .get_logical_ethernet_core_from_virtual(chip_id, CoreCoord(connection.edm_noc_x, connection.edm_noc_y))
+            .get_logical_ethernet_core_from_virtual(chip_id, tt::tt_metal::CoreCoord(connection.edm_noc_x, connection.edm_noc_y))
             .y;
 
     // copy "only" connections[eth_channel] to L1, not the whole tensix_fabric_connections_l1_info_t
@@ -600,9 +600,9 @@ void append_worker_to_fabric_edm_sender_rt_args(
     size_t connection_offset = offsetof(tt::tt_fabric::tensix_fabric_connections_l1_info_t, read_only) +
                                (eth_channel * sizeof(tt::tt_fabric::fabric_connection_info_t));
     // Write to Tensix cores
-    std::vector<CoreCoord> worker_core_coords = corerange_to_cores(worker_cores, std::nullopt, true);
+    std::vector<tt::tt_metal::CoreCoord> worker_core_coords = corerange_to_cores(worker_cores, std::nullopt, true);
     for (const auto& logical_core : worker_core_coords) {
-        CoreCoord tensix_core =
+        tt::tt_metal::CoreCoord tensix_core =
             tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_coordinate_from_logical_coordinates(
                 chip_id, logical_core, CoreType::WORKER);
         tt::tt_metal::MetalContext::instance().get_cluster().write_core(
@@ -647,7 +647,7 @@ size_t log_worker_to_fabric_edm_sender_rt_args(
 }
 
 FabricEriscDatamoverBuilder::FabricEriscDatamoverBuilder(
-    const CoreCoord& my_eth_core_logical,
+    const tt::tt_metal::CoreCoord& my_eth_core_logical,
     size_t my_noc_x,
     size_t my_noc_y,
     const FabricNodeId& local_fabric_node_id,
@@ -1495,7 +1495,7 @@ std::vector<uint32_t> FabricEriscDatamoverBuilder::get_runtime_args() const {
 FabricEriscDatamoverBuilder FabricEriscDatamoverBuilder::build(
     tt::tt_metal::IDevice* device,
     tt::tt_metal::Program& program,
-    const CoreCoord& ethernet_core,
+    const tt::tt_metal::CoreCoord& ethernet_core,
     ChipId local_physical_chip_id,
     ChipId peer_physical_chip_id,
     const FabricEriscDatamoverConfig& config,
@@ -1537,7 +1537,7 @@ FabricEriscDatamoverBuilder FabricEriscDatamoverBuilder::build(
 FabricEriscDatamoverBuilder FabricEriscDatamoverBuilder::build(
     tt::tt_metal::IDevice* device,
     tt::tt_metal::Program& /*program*/,
-    const CoreCoord& ethernet_core,
+    const tt::tt_metal::CoreCoord& ethernet_core,
     const FabricNodeId& local_fabric_node_id,
     const FabricNodeId& peer_fabric_node_id,
     const FabricEriscDatamoverConfig& config,
@@ -1751,7 +1751,7 @@ void FabricEriscDatamoverBuilder::setup_downstream_vc_connection(
     auto* adapter_ptr = this->receiver_channel_to_downstream_adapter.get();
     TT_FATAL(adapter_ptr != nullptr, "Adapter is not set. Failed to build TT-Fabric router. Internal error.");
     adapter_ptr->add_downstream_connection(
-        adapter_spec, upstream_vc_idx, absolute_channel_id, ds_dir, CoreCoord(ds_noc_x, ds_noc_y), is_2D_routing);
+        adapter_spec, upstream_vc_idx, absolute_channel_id, ds_dir, tt::tt_metal::CoreCoord(ds_noc_x, ds_noc_y), is_2D_routing);
 }
 
 size_t FabricEriscDatamoverBuilder::get_configured_risc_count() const { return this->config.risc_configs.size(); }
@@ -1773,7 +1773,7 @@ void FabricEriscDatamoverBuilder::teardown_from_host(
     std::vector<uint32_t> val(1, termination_signal);
     tt::tt_metal::detail::WriteToDeviceL1(
         d,
-        d->logical_core_from_ethernet_core(CoreCoord(this->noc_x_, this->noc_y_)),
+        d->logical_core_from_ethernet_core(tt::tt_metal::CoreCoord(this->noc_x_, this->noc_y_)),
         config.termination_signal_address,
         val,
         CoreType::ETH);

--- a/tt_metal/fabric/erisc_datamover_builder.hpp
+++ b/tt_metal/fabric/erisc_datamover_builder.hpp
@@ -482,7 +482,7 @@ public:
     static size_t get_max_packet_payload_size_for_arch(tt::ARCH arch);
 
     FabricEriscDatamoverBuilder(
-        const CoreCoord& my_eth_core_logical,
+        const tt::tt_metal::CoreCoord& my_eth_core_logical,
         size_t my_noc_x,
         size_t my_noc_y,
         const FabricNodeId& local_fabric_node_id,
@@ -511,7 +511,7 @@ public:
     static FabricEriscDatamoverBuilder build(
         tt::tt_metal::IDevice* device,
         tt::tt_metal::Program& program,
-        const CoreCoord& ethernet_core,
+        const tt::tt_metal::CoreCoord& ethernet_core,
         const FabricNodeId& local_fabric_node_id,
         const FabricNodeId& peer_fabric_node_id,
         const FabricEriscDatamoverConfig& config,
@@ -529,7 +529,7 @@ public:
     static FabricEriscDatamoverBuilder build(
         tt::tt_metal::IDevice* device,
         tt::tt_metal::Program& program,
-        const CoreCoord& ethernet_core,
+        const tt::tt_metal::CoreCoord& ethernet_core,
         ChipId local_physical_chip_id,
         ChipId peer_physical_chip_id,
         const FabricEriscDatamoverConfig& config,
@@ -587,7 +587,7 @@ public:
     bool is_first_level_ack_enabled() const { return this->enable_first_level_ack; }
 
     //    protected:
-    CoreCoord my_eth_core_logical;
+    tt::tt_metal::CoreCoord my_eth_core_logical;
     chan_id_t my_eth_channel;
 
     FabricEriscDatamoverConfig config;

--- a/tt_metal/fabric/fabric.cpp
+++ b/tt_metal/fabric/fabric.cpp
@@ -107,7 +107,7 @@ void append_fabric_connection_rt_args(
     const FabricNodeId& dst_fabric_node_id,
     const uint32_t link_idx,
     ProgramOrDescriptor& worker_program_or_desc,
-    const CoreCoord& worker_core,
+    const tt::tt_metal::CoreCoord& worker_core,
     std::vector<uint32_t>& worker_args,
     CoreType core_type) {
     TT_FATAL(
@@ -231,7 +231,7 @@ void append_fabric_connection_rt_args(
         // src_chip_id is still required to get the fabric_router_virtual_core from tt_cluster
         ChipId src_chip_id = control_plane.get_physical_chip_id_from_fabric_node_id(src_fabric_node_id);
 
-        CoreCoord fabric_router_virtual_core =
+        tt::tt_metal::CoreCoord fabric_router_virtual_core =
             tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_eth_core_from_channel(
                 src_chip_id, fabric_router_channel);
 
@@ -301,7 +301,7 @@ uint32_t append_routing_plane_connection_manager_rt_args(
     const std::vector<uint32_t>& connection_link_indices,
     ProgramOrDescriptor& worker_program_or_desc,
     tt::tt_metal::KernelHandle& kernel_id,
-    const CoreCoord& worker_core,
+    const tt::tt_metal::CoreCoord& worker_core,
     std::vector<uint32_t>& worker_args,
     FabricApiType api_type,
     CoreType core_type) {
@@ -379,7 +379,7 @@ void append_routing_plane_connection_manager_rt_args_impl(
     const std::vector<FabricNodeId>& dst_nodes,
     const std::vector<uint32_t>& connection_link_indices,
     ProgramOrDescriptor& worker_program_or_desc,
-    const CoreCoord& worker_core,
+    const tt::tt_metal::CoreCoord& worker_core,
     std::vector<uint32_t>& worker_args,
     CoreType core_type) {
     // 1) append tag (like direction) and fabric connection info for each route
@@ -462,7 +462,7 @@ void append_routing_plane_connection_manager_rt_args(
     const std::vector<uint32_t>& connection_link_indices,
     ProgramOrDescriptor& worker_program_or_desc,
     tt::tt_metal::KernelHandle& kernel_id,
-    const CoreCoord& worker_core,
+    const tt::tt_metal::CoreCoord& worker_core,
     std::vector<uint32_t>& worker_args,
     FabricApiType api_type,
     CoreType core_type) {
@@ -585,7 +585,7 @@ template void append_fabric_connection_rt_args<tt::tt_metal::Program>(
     const FabricNodeId&,
     const uint32_t,
     tt::tt_metal::Program&,
-    const CoreCoord&,
+    const tt::tt_metal::CoreCoord&,
     std::vector<uint32_t>&,
     CoreType);
 
@@ -594,7 +594,7 @@ template void append_fabric_connection_rt_args<tt::tt_metal::ProgramDescriptor>(
     const FabricNodeId&,
     const uint32_t,
     tt::tt_metal::ProgramDescriptor&,
-    const CoreCoord&,
+    const tt::tt_metal::CoreCoord&,
     std::vector<uint32_t>&,
     CoreType);
 
@@ -604,7 +604,7 @@ template uint32_t append_routing_plane_connection_manager_rt_args<tt::tt_metal::
     const std::vector<uint32_t>&,
     tt::tt_metal::ProgramDescriptor&,
     tt::tt_metal::KernelHandle&,
-    const CoreCoord&,
+    const tt::tt_metal::CoreCoord&,
     std::vector<uint32_t>&,
     FabricApiType,
     CoreType);
@@ -615,7 +615,7 @@ template uint32_t append_routing_plane_connection_manager_rt_args<tt::tt_metal::
     const std::vector<uint32_t>&,
     tt::tt_metal::Program&,
     tt::tt_metal::KernelHandle&,
-    const CoreCoord&,
+    const tt::tt_metal::CoreCoord&,
     std::vector<uint32_t>&,
     FabricApiType,
     CoreType);
@@ -626,7 +626,7 @@ template void append_routing_plane_connection_manager_rt_args<tt::tt_metal::Prog
     const std::vector<uint32_t>&,
     tt::tt_metal::ProgramDescriptor&,
     tt::tt_metal::KernelHandle&,
-    const CoreCoord&,
+    const tt::tt_metal::CoreCoord&,
     std::vector<uint32_t>&,
     FabricApiType,
     CoreType);
@@ -637,7 +637,7 @@ template void append_routing_plane_connection_manager_rt_args<tt::tt_metal::Prog
     const std::vector<uint32_t>&,
     tt::tt_metal::Program&,
     tt::tt_metal::KernelHandle&,
-    const CoreCoord&,
+    const tt::tt_metal::CoreCoord&,
     std::vector<uint32_t>&,
     FabricApiType,
     CoreType);

--- a/tt_metal/fabric/fabric_mux_config.cpp
+++ b/tt_metal/fabric/fabric_mux_config.cpp
@@ -260,7 +260,7 @@ std::vector<uint32_t> FabricMuxConfig::get_fabric_mux_run_time_args(
     const FabricNodeId& dst_fabric_node_id,
     uint32_t link_idx,
     ProgramOrDescriptor& mux_program_or_desc,
-    const CoreCoord& mux_logical_core) const {
+    const tt::tt_metal::CoreCoord& mux_logical_core) const {
     std::vector<uint32_t> args;
 
     auto regions_to_clear = get_memory_regions_to_clear();
@@ -279,10 +279,10 @@ std::vector<uint32_t> FabricMuxConfig::get_fabric_mux_run_time_args(
 }
 
 template std::vector<uint32_t> FabricMuxConfig::get_fabric_mux_run_time_args<tt::tt_metal::Program>(
-    const FabricNodeId&, const FabricNodeId&, uint32_t, tt::tt_metal::Program&, const CoreCoord&) const;
+    const FabricNodeId&, const FabricNodeId&, uint32_t, tt::tt_metal::Program&, const tt::tt_metal::CoreCoord&) const;
 
 template std::vector<uint32_t> FabricMuxConfig::get_fabric_mux_run_time_args<tt::tt_metal::ProgramDescriptor>(
-    const FabricNodeId&, const FabricNodeId&, uint32_t, tt::tt_metal::ProgramDescriptor&, const CoreCoord&) const;
+    const FabricNodeId&, const FabricNodeId&, uint32_t, tt::tt_metal::ProgramDescriptor&, const tt::tt_metal::CoreCoord&) const;
 
 uint8_t FabricMuxConfig::get_num_buffers(FabricMuxChannelType channel_type) const {
     return channel_type == FabricMuxChannelType::FULL_SIZE_CHANNEL ? num_buffers_full_size_channel_

--- a/tt_metal/fabric/fabric_mux_v2_config.cpp
+++ b/tt_metal/fabric/fabric_mux_v2_config.cpp
@@ -186,7 +186,7 @@ FabricMuxV2Config::FabricMuxV2Config(
 }
 
 void FabricMuxV2Config::append_client_connection_rt_args(
-    const CoreCoord& mux_virtual_core,
+    const tt::tt_metal::CoreCoord& mux_virtual_core,
     uint8_t logical_channel_id,
     const ClientSemaphores& client_semaphores,
     std::vector<uint32_t>& worker_args) const {
@@ -241,7 +241,7 @@ std::unordered_map<std::string, uint32_t> FabricMuxV2Config::get_fabric_mux_v2_n
 void add_fabric_mux_v2_to_program(
     tt::tt_metal::Program& program,
     const FabricMuxV2Config& config,
-    const CoreCoord& mux_logical_core,
+    const tt::tt_metal::CoreCoord& mux_logical_core,
     const std::vector<uint32_t>& downstream_sender_rt_args,
     tt::tt_metal::NOC forwarder_noc) {
     const auto manager_noc = get_manager_noc_from_forwarder_noc(forwarder_noc);
@@ -274,7 +274,7 @@ void add_fabric_mux_v2_to_program(
 void add_fabric_mux_v2_to_program(
     tt::tt_metal::Program& program,
     const FabricMuxV2Config& config,
-    const CoreCoord& mux_logical_core,
+    const tt::tt_metal::CoreCoord& mux_logical_core,
     const FabricNodeId& src_fabric_node_id,
     const FabricNodeId& dst_fabric_node_id,
     uint32_t link_idx,

--- a/tt_metal/fabric/fabric_tensix_builder.cpp
+++ b/tt_metal/fabric/fabric_tensix_builder.cpp
@@ -271,8 +271,8 @@ void FabricTensixDatamoverConfig::track_missing_directions_for_udm(
             direction_to_core_index_[dev_id][routing_plane_id][missing_dir] = core_index;
 
             // Also populate fabric_tensix_noc_coords_map_ for missing directions
-            CoreCoord logical_core = logical_fabric_mux_cores_[core_index];
-            CoreCoord translated_core = device->worker_core_from_logical_core(logical_core);
+            tt::tt_metal::CoreCoord logical_core = logical_fabric_mux_cores_[core_index];
+            tt::tt_metal::CoreCoord translated_core = device->worker_core_from_logical_core(logical_core);
             fabric_tensix_noc_coords_map_[fabric_node_id][routing_plane_id][missing_dir] = {
                 translated_core.x, translated_core.y};
 
@@ -315,12 +315,12 @@ bool FabricTensixDatamoverConfig::initialize_channel_mappings() {
     auto* device = tt_metal::MetalContext::instance().device_manager()->get_active_device(device_id);
     TT_FATAL(device != nullptr, "Device {} not found in DeviceManager", device_id);
     for (const auto& logical_core : logical_fabric_mux_cores_) {
-        CoreCoord translated_core = device->worker_core_from_logical_core(logical_core);
+        tt::tt_metal::CoreCoord translated_core = device->worker_core_from_logical_core(logical_core);
         translated_fabric_or_dispatch_mux_cores_.insert(translated_core);
         translated_fabric_mux_cores_.insert(translated_core);
     }
     for (const auto& logical_core : logical_dispatch_mux_cores_) {
-        CoreCoord translated_core = device->worker_core_from_logical_core(logical_core);
+        tt::tt_metal::CoreCoord translated_core = device->worker_core_from_logical_core(logical_core);
         translated_fabric_or_dispatch_mux_cores_.insert(translated_core);
         translated_dispatch_mux_cores_.insert(translated_core);
     }
@@ -367,19 +367,19 @@ bool FabricTensixDatamoverConfig::initialize_channel_mappings() {
 }
 
 // UDM mode helper: builds list of workers sorted by column (x first, then y within each column)
-std::vector<CoreCoord> FabricTensixDatamoverConfig::build_workers_by_column(tt_metal::IDevice* device) const {
+std::vector<tt::tt_metal::CoreCoord> FabricTensixDatamoverConfig::build_workers_by_column(tt_metal::IDevice* device) const {
     auto compute_grid = device->compute_with_storage_grid_size();
     uint32_t total_workers = compute_grid.x * compute_grid.y;
 
-    std::vector<CoreCoord> workers_by_column(total_workers);
+    std::vector<tt::tt_metal::CoreCoord> workers_by_column(total_workers);
 
     // Sort by column: x first (outer loop), then y within each column (inner loop)
     // This ensures workers in the same column are contiguous and get assigned to the same tensix
     size_t idx = 0;
     for (uint32_t x = 0; x < compute_grid.x; x++) {
         for (uint32_t y = 0; y < compute_grid.y; y++) {
-            CoreCoord logical_worker(x, y);
-            CoreCoord translated_worker = device->worker_core_from_logical_core(logical_worker);
+            tt::tt_metal::CoreCoord logical_worker(x, y);
+            tt::tt_metal::CoreCoord translated_worker = device->worker_core_from_logical_core(logical_worker);
             workers_by_column[idx++] = translated_worker;
         }
     }
@@ -388,30 +388,30 @@ std::vector<CoreCoord> FabricTensixDatamoverConfig::build_workers_by_column(tt_m
 }
 
 // UDM mode helper: gets unique tensix cores for worker assignment
-std::vector<CoreCoord> FabricTensixDatamoverConfig::get_tensix_cores_for_workers(tt_metal::IDevice* device) const {
+std::vector<tt::tt_metal::CoreCoord> FabricTensixDatamoverConfig::get_tensix_cores_for_workers(tt_metal::IDevice* device) const {
     const auto& control_plane = tt_metal::MetalContext::instance().get_control_plane();
     auto fabric_node_id = control_plane.get_fabric_node_id_from_physical_chip_id(device->id());
 
     const auto& node_map = fabric_tensix_noc_coords_map_.at(fabric_node_id);
 
     // Collect unique tensix cores across all routing planes and directions
-    std::set<CoreCoord> unique_tensix_cores;
+    std::set<tt::tt_metal::CoreCoord> unique_tensix_cores;
     for (const auto& [routing_plane_id, direction_map] : node_map) {
         for (const auto& [direction, noc_coords] : direction_map) {
             const auto& [noc_x, noc_y] = noc_coords;
-            unique_tensix_cores.insert(CoreCoord(noc_x, noc_y));
+            unique_tensix_cores.insert(tt::tt_metal::CoreCoord(noc_x, noc_y));
         }
     }
 
     // Convert set to vector (maintains sorted order)
-    return std::vector<CoreCoord>(unique_tensix_cores.begin(), unique_tensix_cores.end());
+    return std::vector<tt::tt_metal::CoreCoord>(unique_tensix_cores.begin(), unique_tensix_cores.end());
 }
 
 // UDM mode helper: assigns workers to tensix cores in contiguous chunks
 void FabricTensixDatamoverConfig::assign_workers_to_tensix_cores(
     ChipId device_id,
-    const std::vector<CoreCoord>& workers_by_column,
-    const std::vector<CoreCoord>& tensix_cores_for_workers,
+    const std::vector<tt::tt_metal::CoreCoord>& workers_by_column,
+    const std::vector<tt::tt_metal::CoreCoord>& tensix_cores_for_workers,
     uint32_t num_worker_channels) {
     auto& info_map = worker_to_tensix_info_map_[device_id];
     info_map.clear();
@@ -423,7 +423,7 @@ void FabricTensixDatamoverConfig::assign_workers_to_tensix_cores(
             "tensix_idx {} exceeds tensix_cores_for_workers size {}",
             tensix_idx,
             tensix_cores_for_workers.size());
-        CoreCoord tensix_core = tensix_cores_for_workers[tensix_idx];
+        tt::tt_metal::CoreCoord tensix_core = tensix_cores_for_workers[tensix_idx];
         uint32_t channel_index = i % num_worker_channels;
         // Store tensix core and channel index together
         info_map[workers_by_column[i]] = WorkerTensixInfo{tensix_core, channel_index};
@@ -625,8 +625,8 @@ size_t FabricTensixDatamoverConfig::get_base_l1_address(FabricTensixCoreType cor
 
 std::pair<uint32_t, uint32_t> FabricTensixDatamoverConfig::get_noc_xy(
     tt_metal::IDevice* device, uint32_t eth_chan_id) const {
-    CoreCoord core = get_core_for_channel(device->id(), eth_chan_id);
-    CoreCoord physical_core = device->worker_core_from_logical_core(core);
+    tt::tt_metal::CoreCoord core = get_core_for_channel(device->id(), eth_chan_id);
+    tt::tt_metal::CoreCoord physical_core = device->worker_core_from_logical_core(core);
     return {physical_core.x, physical_core.y};
 }
 
@@ -654,7 +654,7 @@ FabricTensixCoreType FabricTensixDatamoverConfig::get_core_id_for_channel(
     return it->second;
 }
 
-CoreCoord FabricTensixDatamoverConfig::get_core_for_channel(ChipId device_id, uint32_t eth_chan_id) const {
+tt::tt_metal::CoreCoord FabricTensixDatamoverConfig::get_core_for_channel(ChipId device_id, uint32_t eth_chan_id) const {
     auto device_it = eth_chan_to_core_index_.find(device_id);
     TT_FATAL(device_it != eth_chan_to_core_index_.end(), "Device {} not found in core mapping", device_id);
 
@@ -825,7 +825,7 @@ size_t FabricTensixDatamoverConfig::get_core_index_for_direction(
     return dir_it->second;
 }
 
-CoreCoord FabricTensixDatamoverConfig::get_core_for_direction(
+tt::tt_metal::CoreCoord FabricTensixDatamoverConfig::get_core_for_direction(
     ChipId device_id, routing_plane_id_t routing_plane_id, eth_chan_directions direction) const {
     size_t core_index = get_core_index_for_direction(device_id, routing_plane_id, direction);
     TT_FATAL(
@@ -838,13 +838,13 @@ CoreCoord FabricTensixDatamoverConfig::get_core_for_direction(
 
 std::pair<uint32_t, uint32_t> FabricTensixDatamoverConfig::get_noc_xy_for_direction(
     tt_metal::IDevice* device, routing_plane_id_t routing_plane_id, eth_chan_directions direction) const {
-    CoreCoord logical_core = get_core_for_direction(device->id(), routing_plane_id, direction);
-    CoreCoord translated_core = device->worker_core_from_logical_core(logical_core);
+    tt::tt_metal::CoreCoord logical_core = get_core_for_direction(device->id(), routing_plane_id, direction);
+    tt::tt_metal::CoreCoord translated_core = device->worker_core_from_logical_core(logical_core);
     return {translated_core.x, translated_core.y};
 }
 
 FabricTensixDatamoverConfig::WorkerTensixInfo FabricTensixDatamoverConfig::get_worker_tensix_info(
-    ChipId device_id, const CoreCoord& worker_coord) const {
+    ChipId device_id, const tt::tt_metal::CoreCoord& worker_coord) const {
     auto device_it = worker_to_tensix_info_map_.find(device_id);
     TT_FATAL(device_it != worker_to_tensix_info_map_.end(), "Device {} not found in worker tensix info map", device_id);
     auto worker_it = device_it->second.find(worker_coord);
@@ -862,7 +862,7 @@ template <typename BuilderType, typename ConfigType>
 std::unique_ptr<BuilderType> FabricTensixDatamoverBuilder::create_builder(
     FabricTensixCoreType core_type,
     const FabricTensixDatamoverConfig& tensix_config,
-    const CoreCoord& my_core_logical,
+    const tt::tt_metal::CoreCoord& my_core_logical,
     tt::tt_fabric::FabricNodeId local_fabric_node_id,
     tt::tt_fabric::FabricNodeId remote_fabric_node_id,
     uint32_t ethernet_channel_id,
@@ -899,7 +899,7 @@ std::unique_ptr<BuilderType> FabricTensixDatamoverBuilder::create_builder(
 FabricTensixDatamoverBuilder::FabricTensixDatamoverBuilder(
     std::unique_ptr<FabricTensixDatamoverMuxBuilder> mux_builder,
     std::unique_ptr<FabricTensixDatamoverRelayBuilder> relay_builder,
-    const CoreCoord& logical_core,
+    const tt::tt_metal::CoreCoord& logical_core,
     tt::tt_fabric::FabricNodeId local_fabric_node_id,
     tt::tt_fabric::FabricNodeId remote_fabric_node_id,
     uint32_t noc_x,
@@ -928,7 +928,7 @@ FabricTensixDatamoverBuilder FabricTensixDatamoverBuilder::build(
     auto fabric_tensix_config = tt_metal::MetalContext::instance().get_fabric_tensix_config();
 
     // Get core for this ethernet channel
-    CoreCoord my_core_logical = tensix_config.get_core_for_channel(device->id(), ethernet_channel_id);
+    tt::tt_metal::CoreCoord my_core_logical = tensix_config.get_core_for_channel(device->id(), ethernet_channel_id);
 
     // Get NOC coordinates
     auto [noc_x, noc_y] = tensix_config.get_noc_xy(device, ethernet_channel_id);
@@ -1003,7 +1003,7 @@ FabricTensixDatamoverBuilder FabricTensixDatamoverBuilder::build_for_missing_dir
         "build_for_missing_direction is only valid in UDM mode");
 
     // Get core for this (routing_plane_id, direction) pair (assigned in initialize_channel_mappings)
-    CoreCoord my_core_logical = tensix_config.get_core_for_direction(device->id(), routing_plane_id, direction);
+    tt::tt_metal::CoreCoord my_core_logical = tensix_config.get_core_for_direction(device->id(), routing_plane_id, direction);
 
     // Get NOC coordinates for this (routing_plane_id, direction) pair
     auto [noc_x, noc_y] = tensix_config.get_noc_xy_for_direction(device, routing_plane_id, direction);

--- a/tt_metal/fabric/fabric_tensix_builder.hpp
+++ b/tt_metal/fabric/fabric_tensix_builder.hpp
@@ -64,7 +64,7 @@ public:
     FabricTensixCoreType get_core_id_for_channel(ChipId device_id, uint32_t eth_chan_id) const;
 
     // Get the core for a given ethernet channel on a specific device
-    CoreCoord get_core_for_channel(ChipId device_id, uint32_t eth_chan_id) const;
+    tt::tt_metal::CoreCoord get_core_for_channel(ChipId device_id, uint32_t eth_chan_id) const;
 
     // Get the config for a specific core type (returns base config pointer)
     std::shared_ptr<FabricTensixDatamoverBaseConfig> get_config(FabricTensixCoreType core_id) const;
@@ -73,15 +73,15 @@ public:
     bool is_core_id_active(FabricTensixCoreType core_id) const;
 
     // Get translated fabric mux cores
-    const std::unordered_set<CoreCoord>& get_translated_fabric_or_dispatch_mux_cores() const {
+    const std::unordered_set<tt::tt_metal::CoreCoord>& get_translated_fabric_or_dispatch_mux_cores() const {
         return translated_fabric_or_dispatch_mux_cores_;
     }
 
-    const std::unordered_set<CoreCoord>& get_translated_fabric_mux_cores() const {
+    const std::unordered_set<tt::tt_metal::CoreCoord>& get_translated_fabric_mux_cores() const {
         return translated_fabric_mux_cores_;
     }
 
-    const std::unordered_set<CoreCoord>& get_translated_dispatch_mux_cores() const {
+    const std::unordered_set<tt::tt_metal::CoreCoord>& get_translated_dispatch_mux_cores() const {
         return translated_dispatch_mux_cores_;
     }
 
@@ -124,7 +124,7 @@ public:
         ChipId device_id, routing_plane_id_t routing_plane_id, eth_chan_directions direction) const;
 
     // Get core for a (routing_plane_id, direction) pair on a device
-    CoreCoord get_core_for_direction(
+    tt::tt_metal::CoreCoord get_core_for_direction(
         ChipId device_id, routing_plane_id_t routing_plane_id, eth_chan_directions direction) const;
 
     // Get NOC coordinates for a (routing_plane_id, direction) pair on a device
@@ -133,19 +133,19 @@ public:
 
     // UDM mode: Worker assignment info
     struct WorkerTensixInfo {
-        CoreCoord tensix_core;     // The tensix mux core assigned to this worker (virtual coordinate)
+        tt::tt_metal::CoreCoord tensix_core;     // The tensix mux core assigned to this worker (virtual coordinate)
         uint32_t channel_index{};  // The channel index on that tensix mux core
     };
 
     // Get worker assignment info (tensix core + channel index) for a specific worker (UDM mode only)
-    WorkerTensixInfo get_worker_tensix_info(ChipId device_id, const CoreCoord& worker_coord) const;
+    WorkerTensixInfo get_worker_tensix_info(ChipId device_id, const tt::tt_metal::CoreCoord& worker_coord) const;
 
 private:
-    std::vector<CoreCoord> logical_fabric_mux_cores_;
-    std::vector<CoreCoord> logical_dispatch_mux_cores_;
-    std::unordered_set<CoreCoord> translated_fabric_mux_cores_;
-    std::unordered_set<CoreCoord> translated_dispatch_mux_cores_;
-    std::unordered_set<CoreCoord> translated_fabric_or_dispatch_mux_cores_;
+    std::vector<tt::tt_metal::CoreCoord> logical_fabric_mux_cores_;
+    std::vector<tt::tt_metal::CoreCoord> logical_dispatch_mux_cores_;
+    std::unordered_set<tt::tt_metal::CoreCoord> translated_fabric_mux_cores_;
+    std::unordered_set<tt::tt_metal::CoreCoord> translated_dispatch_mux_cores_;
+    std::unordered_set<tt::tt_metal::CoreCoord> translated_fabric_or_dispatch_mux_cores_;
 
     // based on the number of channels used, get the number of risc needed per tensix
     size_t num_used_riscs_per_tensix_{};
@@ -216,7 +216,7 @@ private:
 
     // [device_id][worker coord] -> [WorkerTensixInfo] mapping for UDM mode
     // Maps each worker to its assigned tensix mux core and channel index
-    std::unordered_map<ChipId, std::map<CoreCoord, WorkerTensixInfo>> worker_to_tensix_info_map_;
+    std::unordered_map<ChipId, std::map<tt::tt_metal::CoreCoord, WorkerTensixInfo>> worker_to_tensix_info_map_;
 
     // Helper methods for initialization
 
@@ -276,16 +276,16 @@ private:
         const std::vector<tt_metal::IDevice*>& all_active_devices);
 
     // UDM mode helper: builds list of workers sorted by column (y first, then x)
-    std::vector<CoreCoord> build_workers_by_column(tt::tt_metal::IDevice* device) const;
+    std::vector<tt::tt_metal::CoreCoord> build_workers_by_column(tt::tt_metal::IDevice* device) const;
 
     // UDM mode helper: gets unique tensix cores for worker assignment (excludes dispatch routing plane)
-    std::vector<CoreCoord> get_tensix_cores_for_workers(tt::tt_metal::IDevice* device) const;
+    std::vector<tt::tt_metal::CoreCoord> get_tensix_cores_for_workers(tt::tt_metal::IDevice* device) const;
 
     // UDM mode helper: assigns workers to tensix cores in contiguous chunks
     void assign_workers_to_tensix_cores(
         ChipId device_id,
-        const std::vector<CoreCoord>& workers_by_column,
-        const std::vector<CoreCoord>& tensix_cores_for_workers,
+        const std::vector<tt::tt_metal::CoreCoord>& workers_by_column,
+        const std::vector<tt::tt_metal::CoreCoord>& tensix_cores_for_workers,
         uint32_t num_worker_channels);
 };
 
@@ -343,7 +343,7 @@ private:
     FabricTensixDatamoverBuilder(
         std::unique_ptr<FabricTensixDatamoverMuxBuilder> mux_builder,
         std::unique_ptr<FabricTensixDatamoverRelayBuilder> relay_builder,
-        const CoreCoord& logical_core,
+        const tt::tt_metal::CoreCoord& logical_core,
         tt::tt_fabric::FabricNodeId local_fabric_node_id,
         tt::tt_fabric::FabricNodeId remote_fabric_node_id,
         uint32_t noc_x,
@@ -355,7 +355,7 @@ private:
     static std::unique_ptr<BuilderType> create_builder(
         FabricTensixCoreType core_type,
         const FabricTensixDatamoverConfig& tensix_config,
-        const CoreCoord& my_core_logical,
+        const tt::tt_metal::CoreCoord& my_core_logical,
         tt::tt_fabric::FabricNodeId local_fabric_node_id,
         tt::tt_fabric::FabricNodeId remote_fabric_node_id,
         uint32_t ethernet_channel_id,
@@ -370,7 +370,7 @@ private:
     std::unique_ptr<FabricTensixDatamoverRelayBuilder> relay_builder_;  // Only in UDM mode
 
     // Common properties shared by both mux and relay builders
-    CoreCoord logical_core_;
+    tt::tt_metal::CoreCoord logical_core_;
     tt::tt_fabric::FabricNodeId local_fabric_node_id_;
     tt::tt_fabric::FabricNodeId remote_fabric_node_id_;
 };

--- a/tt_metal/fabric/fabric_tensix_builder_impl.cpp
+++ b/tt_metal/fabric/fabric_tensix_builder_impl.cpp
@@ -299,7 +299,7 @@ std::vector<uint32_t> FabricTensixDatamoverBaseConfig::get_run_time_args(
     const FabricNodeId& dst_fabric_node_id,
     uint32_t link_idx,
     tt::tt_metal::Program& program,
-    const CoreCoord& logical_core) const {
+    const tt::tt_metal::CoreCoord& logical_core) const {
     std::vector<uint32_t> args;
 
     auto regions_to_clear = get_memory_regions_to_clear();
@@ -854,7 +854,7 @@ std::vector<uint32_t> FabricTensixDatamoverRelayConfig::get_compile_time_args(
 // ==================================================================================================
 
 FabricTensixDatamoverMuxBuilder::FabricTensixDatamoverMuxBuilder(
-    const CoreCoord& my_core_logical,
+    const tt::tt_metal::CoreCoord& my_core_logical,
     tt::tt_fabric::FabricNodeId local_fabric_node_id,
     tt::tt_fabric::FabricNodeId remote_fabric_node_id,
     uint32_t ethernet_channel_id,
@@ -1140,7 +1140,7 @@ std::vector<uint32_t> FabricTensixDatamoverMuxBuilder::get_runtime_args(tt::tt_m
 // ==================================================================================================
 
 FabricTensixDatamoverRelayBuilder::FabricTensixDatamoverRelayBuilder(
-    const CoreCoord& my_core_logical,
+    const tt::tt_metal::CoreCoord& my_core_logical,
     tt::tt_fabric::FabricNodeId local_fabric_node_id,
     tt::tt_fabric::FabricNodeId remote_fabric_node_id,
     uint32_t ethernet_channel_id,

--- a/tt_metal/fabric/fabric_tensix_builder_impl.hpp
+++ b/tt_metal/fabric/fabric_tensix_builder_impl.hpp
@@ -169,7 +169,7 @@ public:
         const FabricNodeId& dst_fabric_node_id,
         uint32_t link_idx,
         tt::tt_metal::Program& program,
-        const CoreCoord& logical_core) const;
+        const tt::tt_metal::CoreCoord& logical_core) const;
 
 protected:
     static constexpr size_t default_num_buffers = 8;
@@ -419,7 +419,7 @@ class FabricTensixDatamoverMuxBuilder : public FabricDatamoverBuilderBase {
 
 public:
     FabricTensixDatamoverMuxBuilder(
-        const CoreCoord& my_core_logical,
+        const tt::tt_metal::CoreCoord& my_core_logical,
         tt::tt_fabric::FabricNodeId local_fabric_node_id,
         tt::tt_fabric::FabricNodeId remote_fabric_node_id,
         uint32_t ethernet_channel_id,
@@ -437,7 +437,7 @@ public:
     tt::tt_fabric::SenderWorkerAdapterSpec build_connection_to_fabric_channel(uint32_t channel_id) const override;
 
     // Getters
-    const CoreCoord& get_logical_core() const { return my_core_logical_; }
+    const tt::tt_metal::CoreCoord& get_logical_core() const { return my_core_logical_; }
     tt::tt_fabric::FabricNodeId get_local_fabric_node_id() const { return local_fabric_node_id_; }
     tt::tt_fabric::FabricNodeId get_remote_fabric_node_id() const { return remote_fabric_node_id_; }
     uint32_t get_ethernet_channel_id() const { return ethernet_channel_id_; }
@@ -455,7 +455,7 @@ private:
     std::vector<uint32_t> get_persistent_channels_flags(ChannelTypes channel_type) const;
 
     // Core and fabric configuration
-    CoreCoord my_core_logical_;
+    tt::tt_metal::CoreCoord my_core_logical_;
     tt::tt_fabric::FabricNodeId local_fabric_node_id_;
     tt::tt_fabric::FabricNodeId remote_fabric_node_id_;
     uint32_t ethernet_channel_id_;
@@ -488,7 +488,7 @@ class FabricTensixDatamoverRelayBuilder : public FabricDatamoverBuilderBase {
 
 public:
     FabricTensixDatamoverRelayBuilder(
-        const CoreCoord& my_core_logical,
+        const tt::tt_metal::CoreCoord& my_core_logical,
         tt::tt_fabric::FabricNodeId local_fabric_node_id,
         tt::tt_fabric::FabricNodeId remote_fabric_node_id,
         uint32_t ethernet_channel_id,
@@ -506,7 +506,7 @@ public:
     tt::tt_fabric::SenderWorkerAdapterSpec build_connection_to_fabric_channel(uint32_t channel_id) const override;
 
     // Getters
-    const CoreCoord& get_logical_core() const { return my_core_logical_; }
+    const tt::tt_metal::CoreCoord& get_logical_core() const { return my_core_logical_; }
     tt::tt_fabric::FabricNodeId get_local_fabric_node_id() const { return local_fabric_node_id_; }
     tt::tt_fabric::FabricNodeId get_remote_fabric_node_id() const { return remote_fabric_node_id_; }
     uint32_t get_ethernet_channel_id() const { return ethernet_channel_id_; }
@@ -520,7 +520,7 @@ private:
     std::vector<uint32_t> get_runtime_args(tt::tt_metal::Program&) const;
 
     // Core and fabric configuration
-    CoreCoord my_core_logical_;
+    tt::tt_metal::CoreCoord my_core_logical_;
     tt::tt_fabric::FabricNodeId local_fabric_node_id_;
     tt::tt_fabric::FabricNodeId remote_fabric_node_id_;
     uint32_t ethernet_channel_id_;

--- a/tt_metal/fabric/fabric_vc2_connection.cpp
+++ b/tt_metal/fabric/fabric_vc2_connection.cpp
@@ -33,7 +33,7 @@ void append_fabric_vc2_connection_rt_args(
     const FabricNodeId& dst_fabric_node_id,
     const uint32_t link_idx,
     ProgramOrDescriptor& worker_program_or_desc,
-    const CoreCoord& worker_core,
+    const tt::tt_metal::CoreCoord& worker_core,
     std::vector<uint32_t>& worker_args) {
     TT_FATAL(
         src_fabric_node_id != dst_fabric_node_id,
@@ -143,7 +143,7 @@ void append_fabric_vc2_connection_rt_args(
     const auto router_direction = control_plane.routing_direction_to_eth_direction(forwarding_direction.value());
 
     ChipId src_chip_id = control_plane.get_physical_chip_id_from_fabric_node_id(src_fabric_node_id);
-    CoreCoord fabric_router_virtual_core =
+    tt::tt_metal::CoreCoord fabric_router_virtual_core =
         tt::tt_metal::MetalContext::instance().get_cluster().get_virtual_eth_core_from_channel(
             src_chip_id, fabric_router_channel);
 
@@ -259,7 +259,7 @@ template void append_fabric_vc2_connection_rt_args<tt::tt_metal::Program>(
     const FabricNodeId&,
     uint32_t,
     tt::tt_metal::Program&,
-    const CoreCoord&,
+    const tt::tt_metal::CoreCoord&,
     std::vector<uint32_t>&);
 
 template void append_fabric_vc2_connection_rt_args<tt::tt_metal::ProgramDescriptor>(
@@ -267,7 +267,7 @@ template void append_fabric_vc2_connection_rt_args<tt::tt_metal::ProgramDescript
     const FabricNodeId&,
     uint32_t,
     tt::tt_metal::ProgramDescriptor&,
-    const CoreCoord&,
+    const tt::tt_metal::CoreCoord&,
     std::vector<uint32_t>&);
 
 }  // namespace tt::tt_fabric

--- a/tt_metal/fabric/fabric_vc2_connection.hpp
+++ b/tt_metal/fabric/fabric_vc2_connection.hpp
@@ -21,7 +21,7 @@ void append_fabric_vc2_connection_rt_args(
     const FabricNodeId& dst_fabric_node_id,
     uint32_t link_idx,
     ProgramOrDescriptor& worker_program_or_desc,
-    const CoreCoord& worker_core,
+    const tt::tt_metal::CoreCoord& worker_core,
     std::vector<uint32_t>& worker_args);
 
 }  // namespace tt::tt_fabric

--- a/tt_metal/impl/debug/dprint_server.cpp
+++ b/tt_metal/impl/debug/dprint_server.cpp
@@ -96,7 +96,7 @@ string GetRiscName(
     const umd::CoreDescriptor& logical_core,
     int risc_id,
     bool abbreviated = false) {
-    CoreCoord virtual_core =
+    tt::tt_metal::CoreCoord virtual_core =
         cluster.get_virtual_coordinate_from_logical_coordinates(device_id, logical_core.coord, logical_core.type);
     auto programmable_core_type = llrt::get_core_type(device_id, virtual_core);
     return hal.get_processor_class_name(programmable_core_type, risc_id, abbreviated);
@@ -121,7 +121,7 @@ std::ostream null_stream(&null_buffer);
 void WriteInitMagic(
     tt::Cluster& cluster,
     ChipId device_id,
-    const CoreCoord& virtual_core,
+    const tt::tt_metal::CoreCoord& virtual_core,
     const tt::tt_metal::DPrintBufferInfo& buffer_info,
     bool enabled) {
     // TODO(AP): this could use a cleanup - need a different mechanism to know if a kernel is running on device.
@@ -609,7 +609,7 @@ bool DPrintServer::Impl::poll_one_core(
 
 void DPrintServer::Impl::init_print_buffers_for_core(ChipId device_id, const umd::CoreDescriptor& logical_core) {
     auto& cluster = env_.get_cluster();
-    CoreCoord virtual_core =
+    tt::tt_metal::CoreCoord virtual_core =
         cluster.get_virtual_coordinate_from_logical_coordinates(device_id, logical_core.coord, logical_core.type);
     for (auto& buffer_info : get_core_buffers(device_id, logical_core)) {
         WriteInitMagic(cluster, device_id, virtual_core, buffer_info, false);
@@ -618,7 +618,7 @@ void DPrintServer::Impl::init_print_buffers_for_core(ChipId device_id, const umd
 
 void DPrintServer::Impl::enable_print_buffers_for_core(ChipId device_id, const umd::CoreDescriptor& logical_core) {
     auto& cluster = env_.get_cluster();
-    CoreCoord virtual_core =
+    tt::tt_metal::CoreCoord virtual_core =
         cluster.get_virtual_coordinate_from_logical_coordinates(device_id, logical_core.coord, logical_core.type);
     auto programmable_core_type = llrt::get_core_type(device_id, virtual_core);
     for (auto& buffer_info : get_core_buffers(device_id, logical_core)) {
@@ -1107,14 +1107,14 @@ void DPrintServer::Impl::attach_device(ChipId device_id) {
                 tt::tt_metal::get_core_type_name(core_type));
         } else {
             // No "all cores" option provided, which means print from the cores specified by the user
-            const std::vector<CoreCoord>& print_cores =
+            const std::vector<tt::tt_metal::CoreCoord>& print_cores =
                 rtoptions.get_feature_cores(tt::llrt::RunTimeDebugFeatureDprint).at(core_type);
 
             // We should also validate that the cores the user specified are valid worker cores.
             for (const auto& logical_core : print_cores) {
                 // Need to convert user-specified logical cores to virtual cores, this can throw
                 // if the user gave bad coords.
-                CoreCoord virtual_core;
+                tt::tt_metal::CoreCoord virtual_core;
                 bool valid_logical_core = true;
                 try {
                     virtual_core = env_.get_cluster().get_virtual_coordinate_from_logical_coordinates(

--- a/tt_metal/impl/device/firmware/dispatch_kernel_initializer.cpp
+++ b/tt_metal/impl/device/firmware/dispatch_kernel_initializer.cpp
@@ -20,7 +20,7 @@
 
 namespace tt::llrt::internal_ {
 void wait_until_cores_done(
-    ChipId device_id, int run_state, std::unordered_set<CoreCoord>& not_done_phys_cores, int timeout_ms);
+    ChipId device_id, int run_state, std::unordered_set<tt::tt_metal::CoreCoord>& not_done_phys_cores, int timeout_ms);
 }  // namespace tt::llrt::internal_
 
 namespace tt::tt_metal {

--- a/tt_metal/impl/dispatch/dispatch_query_manager.cpp
+++ b/tt_metal/impl/dispatch/dispatch_query_manager.cpp
@@ -58,11 +58,11 @@ tt_cxy_pair dispatch_core(
     return dispatch_core;
 }
 
-std::vector<CoreCoord> get_consistent_logical_cores(
+std::vector<tt::tt_metal::CoreCoord> get_consistent_logical_cores(
     tt::tt_metal::MetalEnv& env, uint8_t num_hw_cqs, const tt::tt_metal::DispatchCoreConfig& dispatch_core_config) {
     auto user_chips = tt::tt_metal::MetalEnvAccessor(env).impl().get_cluster().user_exposed_chip_ids();
-    std::vector<CoreCoord> first_core_set;
-    std::vector<CoreCoord> current_cores;
+    std::vector<tt::tt_metal::CoreCoord> first_core_set;
+    std::vector<tt::tt_metal::CoreCoord> current_cores;
 
     for (auto chip : user_chips) {
         current_cores = tt::get_logical_dispatch_cores(
@@ -76,7 +76,7 @@ std::vector<CoreCoord> get_consistent_logical_cores(
     return current_cores;
 }
 
-std::vector<CoreCoord> populate_all_logical_dispatch_cores(
+std::vector<tt::tt_metal::CoreCoord> populate_all_logical_dispatch_cores(
     tt::tt_metal::MetalEnv& env, uint8_t num_hw_cqs, const tt::tt_metal::DispatchCoreConfig& dispatch_core_config) {
     return get_consistent_logical_cores(env, num_hw_cqs, dispatch_core_config);
 }
@@ -118,11 +118,11 @@ void DispatchQueryManager::reset(DispatchCoreConfig& dispatch_core_config, uint8
         populate_all_logical_dispatch_cores(env_, num_hw_cqs_, dispatch_core_config_);
 }
 
-const std::vector<CoreCoord>& DispatchQueryManager::get_logical_dispatch_cores(uint32_t device_id) const {
+const std::vector<tt::tt_metal::CoreCoord>& DispatchQueryManager::get_logical_dispatch_cores(uint32_t device_id) const {
     return tt::get_logical_dispatch_cores(MetalEnvAccessor(env_).impl(), device_id, num_hw_cqs_, dispatch_core_config_);
 }
 
-const std::vector<CoreCoord>& DispatchQueryManager::get_logical_dispatch_cores_on_user_chips() const {
+const std::vector<tt::tt_metal::CoreCoord>& DispatchQueryManager::get_logical_dispatch_cores_on_user_chips() const {
     return logical_dispatch_cores_on_user_chips_;
 }
 

--- a/tt_metal/llrt/core_descriptor.cpp
+++ b/tt_metal/llrt/core_descriptor.cpp
@@ -209,7 +209,7 @@ const core_descriptor_t& get_core_descriptor_config(
     size_t start_x = compute_with_storage_start[0].as<size_t>();
     size_t start_y = compute_with_storage_start[1].as<size_t>();
 
-    CoreCoord compute_grid_size;
+    tt::tt_metal::CoreCoord compute_grid_size;
     // When slow dispatch is on, use full logical grid (no dispatch cores to reserve)
     if (!fast_dispatch && !env.get_rtoptions().is_simulator_or_emulated()) {
         compute_grid_size = env.get_cluster().get_soc_desc(device_id).get_grid_size(CoreType::TENSIX);
@@ -219,7 +219,7 @@ const core_descriptor_t& get_core_descriptor_config(
             compute_grid_size.x,
             compute_grid_size.y);
     } else {
-        compute_grid_size = CoreCoord((end_x - start_x) + 1, (end_y - start_y) + 1);
+        compute_grid_size = tt::tt_metal::CoreCoord((end_x - start_x) + 1, (end_y - start_y) + 1);
     }
 
     std::vector<RelativeCoreCoord> compute_cores;
@@ -236,9 +236,9 @@ const core_descriptor_t& get_core_descriptor_config(
         dispatch_cores_string = "tg_dispatch_cores";
     }
 
-    CoreCoord grid_size = env.get_cluster().get_soc_desc(device_id).get_grid_size(CoreType::TENSIX);
+    tt::tt_metal::CoreCoord grid_size = env.get_cluster().get_soc_desc(device_id).get_grid_size(CoreType::TENSIX);
     // For mock devices, control plane doesn't exist, use empty set
-    std::unordered_set<CoreCoord> logical_active_eth_cores;
+    std::unordered_set<tt::tt_metal::CoreCoord> logical_active_eth_cores;
     if (!env.get_cluster().is_mock_or_emulated()) {
         logical_active_eth_cores = env.get_control_plane().get_active_ethernet_cores(device_id);
     }
@@ -277,7 +277,7 @@ const core_descriptor_t& get_core_descriptor_config(
         }
     }
 
-    std::vector<CoreCoord> logical_compute_cores;
+    std::vector<tt::tt_metal::CoreCoord> logical_compute_cores;
     logical_compute_cores.reserve(compute_cores.size());
     std::transform(
         compute_cores.cbegin(),
@@ -285,7 +285,7 @@ const core_descriptor_t& get_core_descriptor_config(
         std::back_inserter(logical_compute_cores),
         [&grid_size](RelativeCoreCoord rel_coord) { return get_core_coord_from_relative(rel_coord, grid_size); });
 
-    std::vector<CoreCoord> logical_dispatch_cores;
+    std::vector<tt::tt_metal::CoreCoord> logical_dispatch_cores;
     // In slow dispatch mode, no cores are reserved for dispatch
     if (fast_dispatch) {
         logical_dispatch_cores.reserve(dispatch_cores.size());
@@ -297,7 +297,7 @@ const core_descriptor_t& get_core_descriptor_config(
     }
 
     // Convert fabric mux cores to logical coordinates
-    std::vector<CoreCoord> logical_fabric_mux_cores;
+    std::vector<tt::tt_metal::CoreCoord> logical_fabric_mux_cores;
     logical_fabric_mux_cores.reserve(fabric_mux_cores.size());
     std::transform(
         fabric_mux_cores.cbegin(),
@@ -318,7 +318,7 @@ const core_descriptor_t& get_core_descriptor_config(
     return config_by_num_cqs[num_hw_cqs].at(fast_dispatch);
 }
 
-std::vector<CoreCoord> get_logical_fabric_mux_cores_wh_b0_worker_fabric_mux_yaml_overlay(
+std::vector<tt::tt_metal::CoreCoord> get_logical_fabric_mux_cores_wh_b0_worker_fabric_mux_yaml_overlay(
     tt::tt_metal::MetalEnvImpl& env,
     ChipId device_id,
     uint8_t num_hw_cqs,
@@ -381,8 +381,8 @@ std::vector<CoreCoord> get_logical_fabric_mux_cores_wh_b0_worker_fabric_mux_yaml
         return {};
     }
 
-    CoreCoord grid_size = env.get_cluster().get_soc_desc(device_id).get_grid_size(CoreType::TENSIX);
-    std::vector<CoreCoord> logical_fabric_mux_cores;
+    tt::tt_metal::CoreCoord grid_size = env.get_cluster().get_soc_desc(device_id).get_grid_size(CoreType::TENSIX);
+    std::vector<tt::tt_metal::CoreCoord> logical_fabric_mux_cores;
     for (const auto& core_node : desc_yaml["fabric_mux_cores"]) {
         if (!core_node.IsSequence()) {
             continue;
@@ -418,9 +418,9 @@ const std::tuple<uint32_t, CoreRange>& get_physical_worker_grid_config(
         const metal_SocDescriptor& soc_desc = env.get_cluster().get_soc_desc(device_id);
         // Get physical compute grid range based on SOC Desc and Logical Coords
         // Logical Worker Coords start at 0,0
-        CoreCoord tensix_worker_start_phys = soc_desc.get_physical_tensix_core_from_logical(CoreCoord(0, 0));
-        CoreCoord tensix_worker_end_phys = soc_desc.get_physical_tensix_core_from_logical(
-            CoreCoord(tensix_num_worker_cols - 1, tensix_num_worker_rows - 1));
+        tt::tt_metal::CoreCoord tensix_worker_start_phys = soc_desc.get_physical_tensix_core_from_logical(tt::tt_metal::CoreCoord(0, 0));
+        tt::tt_metal::CoreCoord tensix_worker_end_phys = soc_desc.get_physical_tensix_core_from_logical(
+            tt::tt_metal::CoreCoord(tensix_num_worker_cols - 1, tensix_num_worker_rows - 1));
         CoreRange tensix_worker_physical_grid = CoreRange(tensix_worker_start_phys, tensix_worker_end_phys);
         physical_grid_config_cache.insert(
             {config_hash, std::make_tuple(tensix_num_worker_cores, tensix_worker_physical_grid)});

--- a/tt_metal/llrt/core_descriptor.hpp
+++ b/tt_metal/llrt/core_descriptor.hpp
@@ -23,14 +23,14 @@
 namespace tt {
 
 struct core_descriptor_t {
-    CoreCoord compute_grid_size;
+    tt::tt_metal::CoreCoord compute_grid_size;
     std::vector<tt_metal::RelativeCoreCoord> relative_compute_cores;
     std::vector<tt_metal::RelativeCoreCoord> relative_dispatch_cores;
     std::vector<tt_metal::RelativeCoreCoord> relative_fabric_mux_cores;
 
-    std::vector<CoreCoord> logical_compute_cores;
-    std::vector<CoreCoord> logical_dispatch_cores;
-    std::vector<CoreCoord> logical_fabric_mux_cores;
+    std::vector<tt::tt_metal::CoreCoord> logical_compute_cores;
+    std::vector<tt::tt_metal::CoreCoord> logical_dispatch_cores;
+    std::vector<tt::tt_metal::CoreCoord> logical_fabric_mux_cores;
 };
 
 inline const std::string& get_product_name(tt::ARCH arch, uint32_t num_harvested_on_axis) {
@@ -54,7 +54,7 @@ const std::tuple<uint32_t, CoreRange>& get_physical_worker_grid_config(
     uint8_t num_hw_cqs,
     const tt_metal::DispatchCoreConfig& dispatch_core_config);
 
-inline const CoreCoord& get_compute_grid_size(
+inline const tt::tt_metal::CoreCoord& get_compute_grid_size(
     tt::tt_metal::MetalEnvImpl& env,
     ChipId device_id,
     const uint8_t num_hw_cqs,
@@ -63,7 +63,7 @@ inline const CoreCoord& get_compute_grid_size(
     return core_desc.compute_grid_size;
 }
 
-inline const std::vector<CoreCoord>& get_logical_compute_cores(
+inline const std::vector<tt::tt_metal::CoreCoord>& get_logical_compute_cores(
     tt::tt_metal::MetalEnvImpl& env,
     ChipId device_id,
     const uint8_t num_hw_cqs,
@@ -72,7 +72,7 @@ inline const std::vector<CoreCoord>& get_logical_compute_cores(
     return core_desc.logical_compute_cores;
 }
 
-inline const std::vector<CoreCoord>& get_logical_dispatch_cores(
+inline const std::vector<tt::tt_metal::CoreCoord>& get_logical_dispatch_cores(
     tt::tt_metal::MetalEnvImpl& env,
     ChipId device_id,
     const uint8_t num_hw_cqs,
@@ -81,7 +81,7 @@ inline const std::vector<CoreCoord>& get_logical_dispatch_cores(
     return core_desc.logical_dispatch_cores;
 }
 
-inline const std::vector<CoreCoord>& get_logical_fabric_mux_cores(
+inline const std::vector<tt::tt_metal::CoreCoord>& get_logical_fabric_mux_cores(
     tt::tt_metal::MetalEnvImpl& env,
     ChipId device_id,
     const uint8_t num_hw_cqs,
@@ -93,7 +93,7 @@ inline const std::vector<CoreCoord>& get_logical_fabric_mux_cores(
 // When FabricTensix is DISABLED, wormhole_b0_80_arch.yaml omits fabric_mux_cores, but the same tensix
 // locations are still reserved for fabric mux on boards that use the fabric-mux descriptor layout.
 // Used for heuristics (e.g. real-time profiler spare-core selection) that must not collide with mux rows/columns.
-std::vector<CoreCoord> get_logical_fabric_mux_cores_wh_b0_worker_fabric_mux_yaml_overlay(
+std::vector<tt::tt_metal::CoreCoord> get_logical_fabric_mux_cores_wh_b0_worker_fabric_mux_yaml_overlay(
     tt::tt_metal::MetalEnvImpl& env,
     ChipId device_id,
     uint8_t num_hw_cqs,

--- a/tt_metal/llrt/llrt.cpp
+++ b/tt_metal/llrt/llrt.cpp
@@ -79,12 +79,12 @@ const ll_api::memory& get_risc_binary(
 // CoreCoord core --> NOC coordinates ("functional workers" from the SOC descriptor)
 // NOC coord is also synonymous to routing / physical coord
 // dram_channel id (0..7) for GS is also mapped to NOC coords in the SOC descriptor
-CoreCoord logical_core_from_ethernet_core(tt::ChipId chip_id, const CoreCoord& ethernet_core) {
+tt::tt_metal::CoreCoord logical_core_from_ethernet_core(tt::ChipId chip_id, const tt::tt_metal::CoreCoord& ethernet_core) {
     return tt::tt_metal::MetalContext::instance().get_cluster().get_logical_ethernet_core_from_virtual(
         chip_id, ethernet_core);
 }
 
-tt_metal::HalProgrammableCoreType get_core_type(tt::ChipId chip_id, const CoreCoord& virtual_core) {
+tt_metal::HalProgrammableCoreType get_core_type(tt::ChipId chip_id, const tt::tt_metal::CoreCoord& virtual_core) {
     bool is_eth_core = tt::tt_metal::MetalContext::instance().get_cluster().is_ethernet_core(virtual_core, chip_id);
     bool is_active_eth_core = false;
     bool is_inactive_eth_core = false;
@@ -113,7 +113,7 @@ tt_metal::HalProgrammableCoreType get_core_type(tt::ChipId chip_id, const CoreCo
     return tt_metal::HalProgrammableCoreType::TENSIX;
 }
 
-void send_reset_go_signal(tt::ChipId chip, const CoreCoord& virtual_core) {
+void send_reset_go_signal(tt::ChipId chip, const tt::tt_metal::CoreCoord& virtual_core) {
     tt_metal::HalProgrammableCoreType dispatch_core_type = get_core_type(chip, virtual_core);
     const auto& hal = tt_metal::MetalContext::instance().hal();
     const auto& cluster = tt_metal::MetalContext::instance().get_cluster();
@@ -132,7 +132,7 @@ void send_reset_go_signal(tt::ChipId chip, const CoreCoord& virtual_core) {
 
 void write_launch_msg_to_core(
     tt::ChipId chip,
-    CoreCoord core,
+    tt::tt_metal::CoreCoord core,
     tt_metal::dev_msgs::launch_msg_t::View msg,
     tt_metal::dev_msgs::go_msg_t::ConstView go_msg,
     bool send_go) {
@@ -153,7 +153,7 @@ void write_launch_msg_to_core(
 }
 
 ll_api::memory read_mem_from_core(
-    tt::ChipId chip, const CoreCoord& core, const ll_api::memory& mem, uint64_t local_init_addr) {
+    tt::ChipId chip, const tt::tt_metal::CoreCoord& core, const ll_api::memory& mem, uint64_t local_init_addr) {
     ll_api::memory read_mem;
     read_mem.fill_from_mem_template(mem, [&](std::vector<uint32_t>::iterator mem_ptr, uint64_t addr, uint32_t len) {
         uint64_t relo_addr = tt::tt_metal::MetalContext::instance().hal().relocate_dev_addr(addr, local_init_addr);
@@ -166,7 +166,7 @@ ll_api::memory read_mem_from_core(
 bool test_load_write_read_risc_binary(
     const ll_api::memory& mem,
     tt::ChipId chip_id,
-    const CoreCoord& core,
+    const tt::tt_metal::CoreCoord& core,
     uint32_t core_type_idx,
     uint32_t processor_class_idx,
     uint32_t processor_type_idx) {
@@ -210,8 +210,8 @@ bool test_load_write_read_risc_binary(
 bool test_load_multicast_write_risc_binary(
     const ll_api::memory& mem,
     tt::ChipId chip_id,
-    const CoreCoord& start_core,
-    const CoreCoord& end_core,
+    const tt::tt_metal::CoreCoord& start_core,
+    const tt::tt_metal::CoreCoord& end_core,
     uint32_t core_type_idx,
     uint32_t processor_class_idx,
     uint32_t processor_type_idx) {
@@ -242,7 +242,7 @@ bool test_load_multicast_write_risc_binary(
     return true;
 }
 
-void write_binary_to_address(const ll_api::memory& mem, tt::ChipId chip_id, const CoreCoord& core, uint32_t address) {
+void write_binary_to_address(const ll_api::memory& mem, tt::ChipId chip_id, const tt::tt_metal::CoreCoord& core, uint32_t address) {
     log_debug(tt::LogLLRuntime, "vec size = {}, size_in_bytes = {}", mem.size(), mem.size() * sizeof(uint32_t));
     mem.process_spans([&](std::vector<uint32_t>::const_iterator mem_ptr, uint64_t /*addr*/, uint32_t len_words) {
         tt::tt_metal::MetalContext::instance().get_cluster().write_core(
@@ -254,7 +254,7 @@ namespace internal_ {
 
 namespace {
 
-bool check_if_riscs_on_specified_core_done(tt::ChipId chip_id, const CoreCoord& core, int run_state) {
+bool check_if_riscs_on_specified_core_done(tt::ChipId chip_id, const tt::tt_metal::CoreCoord& core, int run_state) {
     tt_metal::HalProgrammableCoreType dispatch_core_type = get_core_type(chip_id, core);
     const auto& hal = tt_metal::MetalContext::instance().hal();
     auto dev_msgs_factory = hal.get_dev_msgs_factory(dispatch_core_type);
@@ -284,7 +284,7 @@ bool check_if_riscs_on_specified_core_done(tt::ChipId chip_id, const CoreCoord& 
     return get_mailbox_is_done(go_msg_addr);
 }
 
-void print_aerisc_training_status(tt::ChipId device_id, const CoreCoord& virtual_core) {
+void print_aerisc_training_status(tt::ChipId device_id, const tt::tt_metal::CoreCoord& virtual_core) {
     const auto& hal = tt::tt_metal::MetalContext::instance().hal();
     if (!hal.get_dispatch_feature_enabled(tt::tt_metal::DispatchFeature::ETH_MAILBOX_API)) {
         return;
@@ -367,7 +367,7 @@ void throw_if_watcher_tripped_in_test_mode(ChipId device_id) {
 }
 
 void wait_until_cores_done(
-    tt::ChipId device_id, int run_state, std::unordered_set<CoreCoord>& not_done_phys_cores, int timeout_ms) {
+    tt::ChipId device_id, int run_state, std::unordered_set<tt::tt_metal::CoreCoord>& not_done_phys_cores, int timeout_ms) {
     // poll the cores until the set of not done cores is empty
     [[maybe_unused]] int loop_count = 1;
     auto start = std::chrono::high_resolution_clock::now();
@@ -434,8 +434,8 @@ void wait_until_cores_done(
     }
 }
 
-void wait_for_idle(ChipId device_id, const std::vector<std::vector<CoreCoord>>& logical_cores) {
-    std::unordered_set<CoreCoord> not_done_cores;
+void wait_for_idle(ChipId device_id, const std::vector<std::vector<tt::tt_metal::CoreCoord>>& logical_cores) {
+    std::unordered_set<tt::tt_metal::CoreCoord> not_done_cores;
     const auto& hal = tt::tt_metal::MetalContext::instance().hal();
     const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
     for (uint32_t index = 0; index < hal.get_programmable_core_type_count(); index++) {
@@ -452,7 +452,7 @@ void wait_for_idle(ChipId device_id, const std::vector<std::vector<CoreCoord>>& 
 
 void send_msg_to_eth_mailbox(
     tt::ChipId device_id,
-    const CoreCoord& virtual_core,
+    const tt::tt_metal::CoreCoord& virtual_core,
     tt_metal::FWMailboxMsg msg_type,
     int mailbox_index,
     std::vector<uint32_t> args,
@@ -551,7 +551,7 @@ void send_msg_to_eth_mailbox(
 }
 
 void return_to_base_firmware_and_wait_for_heartbeat(
-    tt::ChipId device_id, const CoreCoord& virtual_core, int timeout_ms) {
+    tt::ChipId device_id, const tt::tt_metal::CoreCoord& virtual_core, int timeout_ms) {
     const auto& hal = tt::tt_metal::MetalContext::instance().hal();
     if (!hal.get_dispatch_feature_enabled(tt::tt_metal::DispatchFeature::ETH_MAILBOX_API)) {
         TT_THROW("Ethernet mailbox API not supported on device {}", device_id);
@@ -593,7 +593,7 @@ void return_to_base_firmware_and_wait_for_heartbeat(
     }
 }
 
-void set_metal_eth_fw_run_flag(tt::ChipId device_id, const CoreCoord& virtual_core, bool enable) {
+void set_metal_eth_fw_run_flag(tt::ChipId device_id, const tt::tt_metal::CoreCoord& virtual_core, bool enable) {
     constexpr auto k_CoreType = tt_metal::HalProgrammableCoreType::ACTIVE_ETH;
     const auto& hal = tt::tt_metal::MetalContext::instance().hal();
     if (!hal.get_dispatch_feature_enabled(tt::tt_metal::DispatchFeature::ETH_MAILBOX_API)) {

--- a/tt_metal/llrt/llrt.hpp
+++ b/tt_metal/llrt/llrt.hpp
@@ -31,15 +31,15 @@ const ll_api::memory& get_risc_binary(
     ll_api::memory::Loading loading = ll_api::memory::Loading::DISCRETE,
     const std::function<void(ll_api::memory&)>& update_callback = nullptr);
 
-CoreCoord logical_core_from_ethernet_core(ChipId chip_id, CoreCoord& ethernet_core);
+tt::tt_metal::CoreCoord logical_core_from_ethernet_core(ChipId chip_id, tt::tt_metal::CoreCoord& ethernet_core);
 
-tt_metal::HalProgrammableCoreType get_core_type(ChipId chip_id, const CoreCoord& virtual_core);
+tt_metal::HalProgrammableCoreType get_core_type(ChipId chip_id, const tt::tt_metal::CoreCoord& virtual_core);
 
-void send_reset_go_signal(ChipId chip, const CoreCoord& virtual_core);
+void send_reset_go_signal(ChipId chip, const tt::tt_metal::CoreCoord& virtual_core);
 
 void write_launch_msg_to_core(
     ChipId chip,
-    CoreCoord core,
+    tt::tt_metal::CoreCoord core,
     tt_metal::dev_msgs::launch_msg_t::View msg,
     tt_metal::dev_msgs::go_msg_t::ConstView go_msg,
     bool send_go = true);
@@ -47,7 +47,7 @@ void write_launch_msg_to_core(
 bool test_load_write_read_risc_binary(
     const ll_api::memory& mem,
     ChipId chip_id,
-    const CoreCoord& core,
+    const tt::tt_metal::CoreCoord& core,
     uint32_t core_type_idx,
     uint32_t processor_class_idx,
     uint32_t processor_type_idx);
@@ -55,20 +55,20 @@ bool test_load_write_read_risc_binary(
 bool test_load_multicast_write_risc_binary(
     const ll_api::memory& mem,
     tt::ChipId chip_id,
-    const CoreCoord& start_core,
-    const CoreCoord& end_core,
+    const tt::tt_metal::CoreCoord& start_core,
+    const tt::tt_metal::CoreCoord& end_core,
     uint32_t core_type_idx,
     uint32_t processor_class_idx,
     uint32_t processor_type_idx);
 
-void write_binary_to_address(const ll_api::memory& mem, ChipId chip_id, const CoreCoord& core, uint32_t address);
+void write_binary_to_address(const ll_api::memory& mem, ChipId chip_id, const tt::tt_metal::CoreCoord& core, uint32_t address);
 
 namespace internal_ {
 
 void wait_until_cores_done(
-    ChipId device_id, int run_state, std::unordered_set<CoreCoord>& not_done_phys_cores, int timeout_ms = 0);
+    ChipId device_id, int run_state, std::unordered_set<tt::tt_metal::CoreCoord>& not_done_phys_cores, int timeout_ms = 0);
 
-void wait_for_idle(ChipId device_id, const std::vector<std::vector<CoreCoord>>& logical_cores);
+void wait_for_idle(ChipId device_id, const std::vector<std::vector<tt::tt_metal::CoreCoord>>& logical_cores);
 
 // In test mode, return a watcher fault message if one was recorded, so host waits can unwind.
 std::optional<std::string> get_watcher_error_message_in_test_mode(ChipId device_id);
@@ -81,7 +81,7 @@ void throw_if_watcher_tripped_in_test_mode(ChipId device_id);
 // Maximum number of args depends on the architecture. Args not provided will be set to zero.
 void send_msg_to_eth_mailbox(
     ChipId device_id,
-    const CoreCoord& virtual_core,
+    const tt::tt_metal::CoreCoord& virtual_core,
     tt_metal::FWMailboxMsg msg_type,
     int mailbox_index,
     std::vector<uint32_t> args,
@@ -91,9 +91,9 @@ void send_msg_to_eth_mailbox(
 // Return to base firmware and wait for a heartbeat from the active ethernet core, if supported
 // Default timeout time empirically chosen to be 20 seconds to avoid timeouts
 void return_to_base_firmware_and_wait_for_heartbeat(
-    ChipId device_id, const CoreCoord& virtual_core, int timeout_ms = 20000);
+    ChipId device_id, const tt::tt_metal::CoreCoord& virtual_core, int timeout_ms = 20000);
 
-void set_metal_eth_fw_run_flag(ChipId device_id, const CoreCoord& virtual_core, bool enable);
+void set_metal_eth_fw_run_flag(ChipId device_id, const tt::tt_metal::CoreCoord& virtual_core, bool enable);
 
 }  // namespace internal_
 

--- a/tt_metal/llrt/metal_soc_descriptor.cpp
+++ b/tt_metal/llrt/metal_soc_descriptor.cpp
@@ -30,7 +30,7 @@ size_t harvested_before(uint32_t dram_harvesting_mask, size_t channel) {
 }
 }  // namespace
 
-CoreCoord metal_SocDescriptor::get_preferred_worker_core_for_dram_view(int dram_view, uint8_t noc) const {
+tt::tt_metal::CoreCoord metal_SocDescriptor::get_preferred_worker_core_for_dram_view(int dram_view, uint8_t noc) const {
     TT_ASSERT(
         dram_view < this->dram_view_worker_cores.size(),
         "dram_view={} must be within range of dram_view_worker_cores.size={}",
@@ -40,7 +40,7 @@ CoreCoord metal_SocDescriptor::get_preferred_worker_core_for_dram_view(int dram_
     return this->dram_view_worker_cores.at(dram_view).at(noc);
 };
 
-bool metal_SocDescriptor::is_noc0_dram_endpoint(const CoreCoord& translated_coord) const {
+bool metal_SocDescriptor::is_noc0_dram_endpoint(const tt::tt_metal::CoreCoord& translated_coord) const {
     // dram_view_worker_cores (and thus get_preferred_worker_core_for_dram_view) holds TRANSLATED
     // coords, so this compares like-for-like against a TRANSLATED argument. See the header note.
     for (size_t dram_view = 0; dram_view < this->dram_view_worker_cores.size(); ++dram_view) {
@@ -51,12 +51,12 @@ bool metal_SocDescriptor::is_noc0_dram_endpoint(const CoreCoord& translated_coor
     return false;
 }
 
-std::vector<CoreCoord> metal_SocDescriptor::get_metal_dram_cores(tt::CoordSystem coord_system) const {
+std::vector<tt::tt_metal::CoreCoord> metal_SocDescriptor::get_metal_dram_cores(tt::CoordSystem coord_system) const {
     // Blackhole reserves each DRAM view's NOC0 worker endpoint for the syseng firmware; no other
     // architecture has that restriction (and future ones won't), so the exclusion is confined to this
     // one spot rather than every DRAM loop in Metal.
     const bool exclude_noc0_endpoints = (this->arch == tt::ARCH::BLACKHOLE);
-    std::vector<CoreCoord> dram_cores;
+    std::vector<tt::tt_metal::CoreCoord> dram_cores;
     for (const tt::umd::CoreCoord& core : get_cores(tt::CoreType::DRAM, coord_system)) {
         if (exclude_noc0_endpoints) {
             const tt::umd::CoreCoord translated = translate_coord_to(core, tt::CoordSystem::TRANSLATED);
@@ -69,7 +69,7 @@ std::vector<CoreCoord> metal_SocDescriptor::get_metal_dram_cores(tt::CoordSystem
     return dram_cores;
 }
 
-CoreCoord metal_SocDescriptor::get_preferred_eth_core_for_dram_view(int dram_view, uint8_t noc) const {
+tt::tt_metal::CoreCoord metal_SocDescriptor::get_preferred_eth_core_for_dram_view(int dram_view, uint8_t noc) const {
     TT_ASSERT(
         dram_view < this->dram_view_eth_cores.size(),
         "dram_view={} must be within range of dram_view_eth_cores.size={}",
@@ -79,14 +79,14 @@ CoreCoord metal_SocDescriptor::get_preferred_eth_core_for_dram_view(int dram_vie
     return this->dram_view_eth_cores.at(dram_view).at(noc);
 };
 
-CoreCoord metal_SocDescriptor::get_logical_core_for_dram_view(int dram_view) const {
+tt::tt_metal::CoreCoord metal_SocDescriptor::get_logical_core_for_dram_view(int dram_view) const {
     const uint32_t num_dram_views = this->get_num_dram_views();
     TT_FATAL(
         dram_view < num_dram_views,
         "dram_view={} must be within range of num_dram_views={}",
         dram_view,
         num_dram_views);
-    return CoreCoord(dram_view, 0);
+    return tt::tt_metal::CoreCoord(dram_view, 0);
 }
 
 size_t metal_SocDescriptor::get_address_offset(int dram_view) const {
@@ -120,7 +120,7 @@ size_t metal_SocDescriptor::get_channel_for_dram_view(int dram_view) const {
 
 size_t metal_SocDescriptor::get_num_dram_views() const { return this->dram_view_eth_cores.size(); }
 
-int metal_SocDescriptor::get_dram_channel_from_logical_core(const CoreCoord& logical_coord) const {
+int metal_SocDescriptor::get_dram_channel_from_logical_core(const tt::tt_metal::CoreCoord& logical_coord) const {
     const uint32_t num_dram_views = this->get_num_dram_views();
     TT_FATAL(
         logical_coord.x < num_dram_views &&

--- a/tt_metal/llrt/metal_soc_descriptor.cpp
+++ b/tt_metal/llrt/metal_soc_descriptor.cpp
@@ -132,25 +132,25 @@ int metal_SocDescriptor::get_dram_channel_from_logical_core(const tt::tt_metal::
     return logical_coord.x;
 }
 
-CoreCoord metal_SocDescriptor::get_physical_ethernet_core_from_logical(const CoreCoord& logical_coord) const {
+tt::tt_metal::CoreCoord metal_SocDescriptor::get_physical_ethernet_core_from_logical(const tt::tt_metal::CoreCoord& logical_coord) const {
     tt::umd::CoreCoord physical_coord =
         translate_coord_to({logical_coord, tt::CoreType::ETH, tt::CoordSystem::LOGICAL}, tt::CoordSystem::NOC0);
     return {physical_coord.x, physical_coord.y};
 }
 
-CoreCoord metal_SocDescriptor::get_logical_ethernet_core_from_physical(const CoreCoord& physical_coord) const {
+tt::tt_metal::CoreCoord metal_SocDescriptor::get_logical_ethernet_core_from_physical(const tt::tt_metal::CoreCoord& physical_coord) const {
     tt::umd::CoreCoord logical_coord =
         translate_coord_to({physical_coord, tt::CoreType::ETH, tt::CoordSystem::NOC0}, tt::CoordSystem::LOGICAL);
     return {logical_coord.x, logical_coord.y};
 }
 
-CoreCoord metal_SocDescriptor::get_physical_tensix_core_from_logical(const CoreCoord& logical_coord) const {
+tt::tt_metal::CoreCoord metal_SocDescriptor::get_physical_tensix_core_from_logical(const tt::tt_metal::CoreCoord& logical_coord) const {
     tt::umd::CoreCoord physical_coord =
         translate_coord_to({logical_coord, tt::CoreType::TENSIX, tt::CoordSystem::LOGICAL}, tt::CoordSystem::NOC0);
     return {physical_coord.x, physical_coord.y};
 }
 
-CoreCoord metal_SocDescriptor::get_physical_dram_core_from_logical(const CoreCoord& logical_coord) const {
+tt::tt_metal::CoreCoord metal_SocDescriptor::get_physical_dram_core_from_logical(const tt::tt_metal::CoreCoord& logical_coord) const {
     TT_FATAL(
         logical_coord.x < dram_bank_endpoint_coords.size() &&
             logical_coord.y < dram_bank_endpoint_coords[logical_coord.x].size(),
@@ -161,10 +161,10 @@ CoreCoord metal_SocDescriptor::get_physical_dram_core_from_logical(const CoreCoo
     return dram_bank_endpoint_coords[logical_coord.x][logical_coord.y];
 }
 
-CoreCoord metal_SocDescriptor::get_logical_dram_core_for_subchannel(int dram_view, int subchannel) const {
+tt::tt_metal::CoreCoord metal_SocDescriptor::get_logical_dram_core_for_subchannel(int dram_view, int subchannel) const {
     const int channel = static_cast<int>(get_channel_for_dram_view(dram_view));
     const tt::umd::CoreCoord phys_umd = get_dram_core_for_channel(channel, subchannel, tt::CoordSystem::TRANSLATED);
-    const CoreCoord phys{phys_umd.x, phys_umd.y};
+    const tt::tt_metal::CoreCoord phys{phys_umd.x, phys_umd.y};
     TT_FATAL(
         dram_view >= 0 && static_cast<size_t>(dram_view) < dram_bank_endpoint_coords.size(),
         "dram_view {} out of range (num_views={})",
@@ -173,7 +173,7 @@ CoreCoord metal_SocDescriptor::get_logical_dram_core_for_subchannel(int dram_vie
     const auto& endpoints = dram_bank_endpoint_coords[static_cast<size_t>(dram_view)];
     for (size_t idx = 0; idx < endpoints.size(); ++idx) {
         if (endpoints[idx] == phys) {
-            return CoreCoord{static_cast<uint32_t>(dram_view), static_cast<uint32_t>(idx)};
+            return tt::tt_metal::CoreCoord{static_cast<uint32_t>(dram_view), static_cast<uint32_t>(idx)};
         }
     }
     TT_THROW(
@@ -184,8 +184,8 @@ CoreCoord metal_SocDescriptor::get_logical_dram_core_for_subchannel(int dram_vie
         phys.y);
 }
 
-CoreCoord metal_SocDescriptor::get_physical_core_from_logical_core(
-    const CoreCoord& logical_coord, const tt::CoreType& core_type) const {
+tt::tt_metal::CoreCoord metal_SocDescriptor::get_physical_core_from_logical_core(
+    const tt::tt_metal::CoreCoord& logical_coord, const tt::CoreType& core_type) const {
     switch (core_type) {
         case tt::CoreType::ETH: return this->get_physical_ethernet_core_from_logical(logical_coord);
         case tt::CoreType::WORKER: return this->get_physical_tensix_core_from_logical(logical_coord);
@@ -194,10 +194,10 @@ CoreCoord metal_SocDescriptor::get_physical_core_from_logical_core(
     }
 }
 
-CoreCoord metal_SocDescriptor::get_dram_grid_size() const { return CoreCoord(this->get_num_dram_views(), 1); }
+tt::tt_metal::CoreCoord metal_SocDescriptor::get_dram_grid_size() const { return tt::tt_metal::CoreCoord(this->get_num_dram_views(), 1); }
 
-CoreCoord metal_SocDescriptor::get_dram_compute_grid_size() const {
-    return CoreCoord(this->get_num_dram_views(), get_grid_size(tt::CoreType::DRAM).y);
+tt::tt_metal::CoreCoord metal_SocDescriptor::get_dram_compute_grid_size() const {
+    return tt::tt_metal::CoreCoord(this->get_num_dram_views(), get_grid_size(tt::CoreType::DRAM).y);
 }
 
 void metal_SocDescriptor::load_dram_metadata_from_device_descriptor() {
@@ -223,7 +223,7 @@ void metal_SocDescriptor::load_dram_metadata_from_device_descriptor() {
         }
         size_t address_offset = dram_view["address_offset"].as<size_t>();
 
-        std::vector<CoreCoord> eth_dram_cores;
+        std::vector<tt::tt_metal::CoreCoord> eth_dram_cores;
         std::vector<size_t> eth_endpoints;
         for (int eth_endpoint : dram_view["eth_endpoint"].as<std::vector<int>>()) {
             if (eth_endpoint >= get_grid_size(tt::CoreType::DRAM).y) {
@@ -238,7 +238,7 @@ void metal_SocDescriptor::load_dram_metadata_from_device_descriptor() {
             eth_endpoints.push_back(eth_endpoint);
         }
 
-        std::vector<CoreCoord> worker_dram_cores;
+        std::vector<tt::tt_metal::CoreCoord> worker_dram_cores;
         std::vector<size_t> worker_endpoints;
         for (int worker_endpoint : dram_view["worker_endpoint"].as<std::vector<int>>()) {
             if (worker_endpoint >= get_grid_size(tt::CoreType::DRAM).y) {
@@ -261,7 +261,7 @@ void metal_SocDescriptor::load_dram_metadata_from_device_descriptor() {
 
         size_t num_subchannels = get_grid_size(tt::CoreType::DRAM).y;
         size_t preferred_subchannel = worker_endpoints[0];
-        std::vector<CoreCoord> bank_endpoints;
+        std::vector<tt::tt_metal::CoreCoord> bank_endpoints;
         bank_endpoints.reserve(num_subchannels);
         auto preferred_coord =
             get_dram_core_for_channel(logical_channel, preferred_subchannel, tt::CoordSystem::TRANSLATED);
@@ -286,11 +286,11 @@ void metal_SocDescriptor::generate_logical_eth_coords_mapping() {
 void metal_SocDescriptor::generate_physical_routing_to_profiler_flat_id() {
 #if defined(TRACY_ENABLE)
     for (auto& core : get_cores(tt::CoreType::TENSIX, tt::CoordSystem::NOC0)) {
-        this->physical_routing_to_profiler_flat_id.emplace((CoreCoord){core.x, core.y}, 0);
+        this->physical_routing_to_profiler_flat_id.emplace((tt::tt_metal::CoreCoord){core.x, core.y}, 0);
     }
 
     for (auto& core : this->get_cores(tt::CoreType::ETH, tt::CoordSystem::NOC0)) {
-        this->physical_routing_to_profiler_flat_id.emplace((CoreCoord){core.x, core.y}, 0);
+        this->physical_routing_to_profiler_flat_id.emplace((tt::tt_metal::CoreCoord){core.x, core.y}, 0);
     }
 
     int flat_id = 0;

--- a/tt_metal/llrt/metal_soc_descriptor.hpp
+++ b/tt_metal/llrt/metal_soc_descriptor.hpp
@@ -24,24 +24,24 @@
 struct metal_SocDescriptor : public tt::umd::SocDescriptor {
 public:
     std::vector<size_t> dram_view_channels;
-    std::vector<std::vector<CoreCoord>>
+    std::vector<std::vector<tt::tt_metal::CoreCoord>>
         dram_view_worker_cores;                               // per dram view preferred worker endpoints for each noc
-    std::vector<std::vector<CoreCoord>> dram_view_eth_cores;  // per dram view preferred eth endpoints for each noc
+    std::vector<std::vector<tt::tt_metal::CoreCoord>> dram_view_eth_cores;  // per dram view preferred eth endpoints for each noc
     std::vector<size_t> dram_view_address_offsets;            // starting address offset
 
     // Per bank, ordered endpoint translated coordinates.
     // Index 0 = preferred worker endpoint (NOC 0), indices 1..N = remaining endpoints on the same bank.
-    std::vector<std::vector<CoreCoord>> dram_bank_endpoint_coords;
+    std::vector<std::vector<tt::tt_metal::CoreCoord>> dram_bank_endpoint_coords;
 
     uint64_t dram_core_size{};
     uint64_t dram_view_size{};
 
-    std::map<CoreCoord, int> logical_eth_core_to_chan_map;
+    std::map<tt::tt_metal::CoreCoord, int> logical_eth_core_to_chan_map;
 
     metal_SocDescriptor(const SocDescriptor& other, const tt::BoardType& board_type);
 
-    CoreCoord get_preferred_worker_core_for_dram_view(int dram_view, uint8_t noc) const;
-    CoreCoord get_preferred_eth_core_for_dram_view(int dram_view, uint8_t noc) const;
+    tt::tt_metal::CoreCoord get_preferred_worker_core_for_dram_view(int dram_view, uint8_t noc) const;
+    tt::tt_metal::CoreCoord get_preferred_eth_core_for_dram_view(int dram_view, uint8_t noc) const;
 
     // The DRAM cores Metal may place kernels/firmware on, in the requested coordinate system. This is
     // the single source of truth for "usable DRAM cores": every DRAM loop in Metal (firmware init,
@@ -50,29 +50,29 @@ public:
     // endpoint, which is owned by the syseng firmware (CMFW DRAM telemetry, SYS-1419) and runs no
     // DRISC firmware. Hardware without that restriction returns all DRAM cores -- callers never need
     // to special-case it.
-    std::vector<CoreCoord> get_metal_dram_cores(tt::CoordSystem coord_system) const;
-    CoreCoord get_logical_core_for_dram_view(int dram_view) const;
+    std::vector<tt::tt_metal::CoreCoord> get_metal_dram_cores(tt::CoordSystem coord_system) const;
+    tt::tt_metal::CoreCoord get_logical_core_for_dram_view(int dram_view) const;
     size_t get_address_offset(int dram_view) const;
     size_t get_channel_for_dram_view(int dram_view) const;
     size_t get_num_dram_views() const;
 
-    int get_dram_channel_from_logical_core(const CoreCoord& logical_coord) const;
+    int get_dram_channel_from_logical_core(const tt::tt_metal::CoreCoord& logical_coord) const;
 
-    CoreCoord get_physical_ethernet_core_from_logical(const CoreCoord& logical_coord) const;
-    CoreCoord get_logical_ethernet_core_from_physical(const CoreCoord& physical_coord) const;
-    CoreCoord get_physical_tensix_core_from_logical(const CoreCoord& logical_coord) const;
-    CoreCoord get_physical_dram_core_from_logical(const CoreCoord& logical_coord) const;
+    tt::tt_metal::CoreCoord get_physical_ethernet_core_from_logical(const tt::tt_metal::CoreCoord& logical_coord) const;
+    tt::tt_metal::CoreCoord get_logical_ethernet_core_from_physical(const tt::tt_metal::CoreCoord& physical_coord) const;
+    tt::tt_metal::CoreCoord get_physical_tensix_core_from_logical(const tt::tt_metal::CoreCoord& logical_coord) const;
+    tt::tt_metal::CoreCoord get_physical_dram_core_from_logical(const tt::tt_metal::CoreCoord& logical_coord) const;
     // Map a DRAM view + hardware subchannel to the logical CoreCoord used by CreateKernel(DramConfig).
     // logical.y indexes dram_bank_endpoint_coords (worker endpoint first), not the raw subchannel id.
-    CoreCoord get_logical_dram_core_for_subchannel(int dram_view, int subchannel) const;
-    CoreCoord get_physical_core_from_logical_core(const CoreCoord& logical_coord, const tt::CoreType& core_type) const;
+    tt::tt_metal::CoreCoord get_logical_dram_core_for_subchannel(int dram_view, int subchannel) const;
+    tt::tt_metal::CoreCoord get_physical_core_from_logical_core(const tt::tt_metal::CoreCoord& logical_coord, const tt::CoreType& core_type) const;
 
-    CoreCoord get_dram_grid_size() const;
-    CoreCoord get_dram_compute_grid_size() const;
+    tt::tt_metal::CoreCoord get_dram_grid_size() const;
+    tt::tt_metal::CoreCoord get_dram_compute_grid_size() const;
 
     // Number of cores per DRAM bank ceiled to nearest integer
     int profiler_ceiled_core_count_perf_dram_bank = 0;
-    std::map<CoreCoord, int32_t> physical_routing_to_profiler_flat_id;
+    std::map<tt::tt_metal::CoreCoord, int32_t> physical_routing_to_profiler_flat_id;
 
 private:
     // Physical DRAM channel (device-descriptor numbering, with harvested-channel gaps) for a dram
@@ -83,7 +83,7 @@ private:
     // True if `translated_coord` is any DRAM view's NOC0 worker endpoint (the subchannel a NOC0 DRAM
     // access routes to) -- the syseng-owned endpoint excluded by get_metal_dram_cores on Blackhole.
     // Argument must be a TRANSLATED (UMD) coord; a metal-logical {view, subchannel} coord never matches.
-    bool is_noc0_dram_endpoint(const CoreCoord& translated_coord) const;
+    bool is_noc0_dram_endpoint(const tt::tt_metal::CoreCoord& translated_coord) const;
 
     void load_dram_metadata_from_device_descriptor();
     void generate_logical_eth_coords_mapping();

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -1885,7 +1885,7 @@ void RunTimeOptions::ParseFeatureEnv(RunTimeDebugFeatures feature, const tt_meta
 void RunTimeOptions::ParseFeatureCoreRange(
     RunTimeDebugFeatures feature, const std::string& env_var, CoreType core_type) {
     char* str = std::getenv(env_var.c_str());
-    std::vector<CoreCoord> cores;
+    std::vector<tt::tt_metal::CoreCoord> cores;
 
     // Check if "all" is specified, rather than a range of cores.
     feature_targets[feature].all_cores[core_type] = RunTimeDebugClassNoneSpecified;
@@ -1908,7 +1908,7 @@ void RunTimeOptions::ParseFeatureCoreRange(
         } else if (str[0] == '(') {
             if (strchr(str, '-')) {
                 // Assume this is a range
-                CoreCoord start, end;
+                tt::tt_metal::CoreCoord start, end;
                 if (sscanf(str, "(%zu,%zu)", &start.x, &start.y) != 2) {
                     TT_THROW("Invalid {}", env_var);
                 }

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -80,7 +80,7 @@ extern const char* RunTimeDebugClassNames[RunTimeDebugClassCount];
 // TargetSelection stores the targets for a given debug feature. I.e. for which chips, cores, harts
 // to enable the feature.
 struct TargetSelection {
-    std::map<CoreType, std::vector<CoreCoord>> cores;
+    std::map<CoreType, std::vector<tt::tt_metal::CoreCoord>> cores;
     std::map<CoreType, int> all_cores;
     bool enabled{};
     std::vector<int> chip_ids;
@@ -505,10 +505,10 @@ public:
     bool get_feature_enabled(RunTimeDebugFeatures feature) const { return feature_targets[feature].enabled; }
     void set_feature_enabled(RunTimeDebugFeatures feature, bool enabled) { feature_targets[feature].enabled = enabled; }
     // Note: dprint cores are logical
-    const std::map<CoreType, std::vector<CoreCoord>>& get_feature_cores(RunTimeDebugFeatures feature) const {
+    const std::map<CoreType, std::vector<tt::tt_metal::CoreCoord>>& get_feature_cores(RunTimeDebugFeatures feature) const {
         return feature_targets[feature].cores;
     }
-    void set_feature_cores(RunTimeDebugFeatures feature, std::map<CoreType, std::vector<CoreCoord>> cores) {
+    void set_feature_cores(RunTimeDebugFeatures feature, std::map<CoreType, std::vector<tt::tt_metal::CoreCoord>> cores) {
         feature_targets[feature].cores = std::move(cores);
     }
     // An alternative to setting cores by range, a flag to enable all.
@@ -519,8 +519,8 @@ public:
         return feature_targets[feature].all_cores.at(core_type);
     }
     // Note: core range is inclusive
-    void set_feature_core_range(RunTimeDebugFeatures feature, CoreCoord start, CoreCoord end, CoreType core_type) {
-        feature_targets[feature].cores[core_type] = std::vector<CoreCoord>();
+    void set_feature_core_range(RunTimeDebugFeatures feature, tt::tt_metal::CoreCoord start, tt::tt_metal::CoreCoord end, CoreType core_type) {
+        feature_targets[feature].cores[core_type] = std::vector<tt::tt_metal::CoreCoord>();
         for (uint32_t x = start.x; x <= end.x; x++) {
             for (uint32_t y = start.y; y <= end.y; y++) {
                 feature_targets[feature].cores[core_type].push_back({x, y});

--- a/tt_metal/llrt/sanitize_noc_host.hpp
+++ b/tt_metal/llrt/sanitize_noc_host.hpp
@@ -31,9 +31,9 @@ namespace tt {
             HAL_MEM_DRAM_L1_SIZE))) ||                                                                                \
      (DEBUG_VALID_REG_ADDR(a) && (l) == 4))
 
-static bool coord_found_p(const std::vector<tt::umd::CoreCoord>& coords, CoreCoord core) {
+static bool coord_found_p(const std::vector<tt::umd::CoreCoord>& coords, tt::tt_metal::CoreCoord core) {
     for (const tt::umd::CoreCoord& core_coord : coords) {
-        CoreCoord item = {core_coord.x, core_coord.y};
+        tt::tt_metal::CoreCoord item = {core_coord.x, core_coord.y};
         if (item == core) {
             return true;
         }
@@ -41,9 +41,9 @@ static bool coord_found_p(const std::vector<tt::umd::CoreCoord>& coords, CoreCoo
     return false;
 }
 
-static bool coord_found_p(const std::unordered_set<CoreCoord>& coords, CoreCoord core) { return coords.contains(core); }
+static bool coord_found_p(const std::unordered_set<tt::tt_metal::CoreCoord>& coords, tt::tt_metal::CoreCoord core) { return coords.contains(core); }
 
-static std::string noc_address(CoreCoord core, uint64_t a, uint32_t l) {
+static std::string noc_address(tt::tt_metal::CoreCoord core, uint64_t a, uint32_t l) {
     std::stringstream ss;
     ss << "noc{" << core.str() << ", 0x" << std::setfill('0') << std::setw(8) << std::hex << a << ", " << std::dec << l
        << "}";
@@ -70,12 +70,12 @@ static void print_stack_trace() {
 static void watcher_sanitize_host_noc(
     const char* what,
     const metal_SocDescriptor& soc_d,
-    const std::unordered_set<CoreCoord>& virtual_worker_cores,
-    const std::unordered_set<CoreCoord>& virtual_eth_cores,
-    const std::unordered_set<CoreCoord>& virtual_pcie_cores,
-    const std::unordered_set<CoreCoord>& virtual_dram_cores,
-    const std::unordered_set<CoreCoord>& virtual_dram_hw_cores,
-    const CoreCoord& core,
+    const std::unordered_set<tt::tt_metal::CoreCoord>& virtual_worker_cores,
+    const std::unordered_set<tt::tt_metal::CoreCoord>& virtual_eth_cores,
+    const std::unordered_set<tt::tt_metal::CoreCoord>& virtual_pcie_cores,
+    const std::unordered_set<tt::tt_metal::CoreCoord>& virtual_dram_cores,
+    const std::unordered_set<tt::tt_metal::CoreCoord>& virtual_dram_hw_cores,
+    const tt::tt_metal::CoreCoord& core,
     uint64_t addr,
     uint32_t lbytes) {
     const auto& hal = tt::tt_metal::MetalContext::instance().hal();
@@ -127,12 +127,12 @@ static void watcher_sanitize_host_noc(
 
 inline void watcher_sanitize_host_noc_read(
     const metal_SocDescriptor& soc_d,
-    const std::unordered_set<CoreCoord>& virtual_worker_cores,
-    const std::unordered_set<CoreCoord>& virtual_eth_cores,
-    const std::unordered_set<CoreCoord>& virtual_pcie_cores,
-    const std::unordered_set<CoreCoord>& virtual_dram_cores,
-    const std::unordered_set<CoreCoord>& virtual_dram_hw_cores,
-    const CoreCoord& core,
+    const std::unordered_set<tt::tt_metal::CoreCoord>& virtual_worker_cores,
+    const std::unordered_set<tt::tt_metal::CoreCoord>& virtual_eth_cores,
+    const std::unordered_set<tt::tt_metal::CoreCoord>& virtual_pcie_cores,
+    const std::unordered_set<tt::tt_metal::CoreCoord>& virtual_dram_cores,
+    const std::unordered_set<tt::tt_metal::CoreCoord>& virtual_dram_hw_cores,
+    const tt::tt_metal::CoreCoord& core,
     uint64_t addr,
     uint32_t lbytes) {
     watcher_sanitize_host_noc(
@@ -150,12 +150,12 @@ inline void watcher_sanitize_host_noc_read(
 
 inline void watcher_sanitize_host_noc_write(
     const metal_SocDescriptor& soc_d,
-    const std::unordered_set<CoreCoord>& virtual_worker_cores,
-    const std::unordered_set<CoreCoord>& virtual_eth_cores,
-    const std::unordered_set<CoreCoord>& virtual_pcie_cores,
-    const std::unordered_set<CoreCoord>& virtual_dram_cores,
-    const std::unordered_set<CoreCoord>& virtual_dram_hw_cores,
-    const CoreCoord& core,
+    const std::unordered_set<tt::tt_metal::CoreCoord>& virtual_worker_cores,
+    const std::unordered_set<tt::tt_metal::CoreCoord>& virtual_eth_cores,
+    const std::unordered_set<tt::tt_metal::CoreCoord>& virtual_pcie_cores,
+    const std::unordered_set<tt::tt_metal::CoreCoord>& virtual_dram_cores,
+    const std::unordered_set<tt::tt_metal::CoreCoord>& virtual_dram_hw_cores,
+    const tt::tt_metal::CoreCoord& core,
     uint64_t addr,
     uint32_t lbytes) {
     watcher_sanitize_host_noc(
@@ -173,9 +173,9 @@ inline void watcher_sanitize_host_noc_write(
 
 inline void watcher_sanitize_host_noc_multicast_write(
     const metal_SocDescriptor& soc_d,
-    const std::unordered_set<CoreCoord>& virtual_worker_cores,
-    const CoreCoord& core_start,
-    const CoreCoord& core_end,
+    const std::unordered_set<tt::tt_metal::CoreCoord>& virtual_worker_cores,
+    const tt::tt_metal::CoreCoord& core_start,
+    const tt::tt_metal::CoreCoord& core_end,
     uint64_t addr,
     uint32_t lbytes) {
     // NoC torus architectures (WH/BH) support wrap-around multicasts where end < start,

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -385,7 +385,7 @@ void Cluster::get_metal_desc_from_tt_desc() {
     }
 }
 
-const std::unordered_map<CoreCoord, int32_t>& Cluster::get_virtual_routing_to_profiler_flat_id(ChipId chip_id) const {
+const std::unordered_map<tt::tt_metal::CoreCoord, int32_t>& Cluster::get_virtual_routing_to_profiler_flat_id(ChipId chip_id) const {
     return this->virtual_routing_to_profiler_flat_id_.at(this->get_board_type(chip_id));
 }
 
@@ -642,28 +642,28 @@ void Cluster::generate_virtual_to_profiler_flat_id_mapping() {
 #endif
 }
 
-bool Cluster::is_worker_core(const CoreCoord& core, ChipId chip_id) const {
+bool Cluster::is_worker_core(const tt::tt_metal::CoreCoord& core, ChipId chip_id) const {
     return this->virtual_worker_cores_.at(chip_id).contains(core);
 }
 
-bool Cluster::is_ethernet_core(const CoreCoord& core, ChipId chip_id) const {
+bool Cluster::is_ethernet_core(const tt::tt_metal::CoreCoord& core, ChipId chip_id) const {
     return this->virtual_eth_cores_.contains(chip_id) and this->virtual_eth_cores_.at(chip_id).contains(core);
 }
 
-bool Cluster::is_dram_core(const CoreCoord& core, ChipId chip_id) const {
+bool Cluster::is_dram_core(const tt::tt_metal::CoreCoord& core, ChipId chip_id) const {
     return this->virtual_dram_hw_cores_.contains(chip_id) and this->virtual_dram_hw_cores_.at(chip_id).contains(core);
 }
 
-const std::unordered_set<CoreCoord>& Cluster::get_virtual_worker_cores(ChipId chip_id) const {
+const std::unordered_set<tt::tt_metal::CoreCoord>& Cluster::get_virtual_worker_cores(ChipId chip_id) const {
     return this->virtual_worker_cores_.at(chip_id);
 }
 
-const std::unordered_set<CoreCoord>& Cluster::get_virtual_eth_cores(ChipId chip_id) const {
+const std::unordered_set<tt::tt_metal::CoreCoord>& Cluster::get_virtual_eth_cores(ChipId chip_id) const {
     return this->virtual_eth_cores_.at(chip_id);
 }
 
-CoreCoord Cluster::get_virtual_coordinate_from_logical_coordinates(
-    ChipId chip_id, CoreCoord logical_coord, const CoreType& core_type) const {
+tt::tt_metal::CoreCoord Cluster::get_virtual_coordinate_from_logical_coordinates(
+    ChipId chip_id, tt::tt_metal::CoreCoord logical_coord, const CoreType& core_type) const {
     // TBD: Remove when all WORKER are rewritten to TENSIX
     CoreType core_type_to_use = core_type;
     if (core_type_to_use == CoreType::WORKER) {
@@ -688,18 +688,18 @@ CoreCoord Cluster::get_virtual_coordinate_from_logical_coordinates(
 tt_cxy_pair Cluster::get_virtual_coordinate_from_logical_coordinates(
     tt_cxy_pair logical_coordinate, const CoreType& core_type) const {
     auto xy_virtual_coord = this->get_virtual_coordinate_from_logical_coordinates(
-        logical_coordinate.chip, CoreCoord(logical_coordinate.x, logical_coordinate.y), core_type);
+        logical_coordinate.chip, tt::tt_metal::CoreCoord(logical_coordinate.x, logical_coordinate.y), core_type);
     return tt_cxy_pair(logical_coordinate.chip, xy_virtual_coord);
 }
-CoreCoord Cluster::get_virtual_coordinate_from_physical_coordinates(ChipId chip_id, CoreCoord physical_coord) const {
+tt::tt_metal::CoreCoord Cluster::get_virtual_coordinate_from_physical_coordinates(ChipId chip_id, tt::tt_metal::CoreCoord physical_coord) const {
     const auto& soc_desc = this->get_soc_desc(chip_id);
     tt::umd::CoreCoord translated_coord =
         soc_desc.translate_coord_to(physical_coord, CoordSystem::NOC0, CoordSystem::TRANSLATED);
     return {translated_coord.x, translated_coord.y};
 }
 
-CoreCoord Cluster::get_physical_coordinate_from_logical_coordinates(
-    ChipId chip_id, CoreCoord logical_coord, const CoreType& core_type, bool no_warn) const {
+tt::tt_metal::CoreCoord Cluster::get_physical_coordinate_from_logical_coordinates(
+    ChipId chip_id, tt::tt_metal::CoreCoord logical_coord, const CoreType& core_type, bool no_warn) const {
     if (!no_warn) {
         log_warning(
             tt::LogDevice,
@@ -710,7 +710,7 @@ CoreCoord Cluster::get_physical_coordinate_from_logical_coordinates(
     return soc_desc.get_physical_core_from_logical_core(logical_coord, core_type);
 }
 
-CoreCoord Cluster::get_logical_ethernet_core_from_virtual(ChipId chip, CoreCoord core) const {
+tt::tt_metal::CoreCoord Cluster::get_logical_ethernet_core_from_virtual(ChipId chip, tt::tt_metal::CoreCoord core) const {
     tt::umd::CoreCoord logical_core =
         get_soc_desc(chip).translate_coord_to(core, CoordSystem::TRANSLATED, CoordSystem::LOGICAL);
     return {logical_core.x, logical_core.y};
@@ -801,7 +801,7 @@ void Cluster::write_dram_vec(
         dram_view,
         desc_to_use.get_num_dram_views());
 
-    CoreCoord dram_core_coord = desc_to_use.get_preferred_worker_core_for_dram_view(dram_view, tt_metal::NOC::NOC_0);
+    tt::tt_metal::CoreCoord dram_core_coord = desc_to_use.get_preferred_worker_core_for_dram_view(dram_view, tt_metal::NOC::NOC_0);
     tt_cxy_pair dram_core = tt_cxy_pair(device_id, dram_core_coord.x, dram_core_coord.y);
     size_t offset = desc_to_use.get_address_offset(dram_view);
     write_core(mem_ptr, sz_in_bytes, tt_cxy_pair(device_id, dram_core.x, dram_core.y), addr + offset);
@@ -815,7 +815,7 @@ void Cluster::read_dram_vec(void* mem_ptr, uint32_t sz_in_bytes, ChipId device_i
         dram_view,
         desc_to_use.get_num_dram_views());
 
-    CoreCoord dram_core_coord = desc_to_use.get_preferred_worker_core_for_dram_view(dram_view, tt_metal::NOC::NOC_0);
+    tt::tt_metal::CoreCoord dram_core_coord = desc_to_use.get_preferred_worker_core_for_dram_view(dram_view, tt_metal::NOC::NOC_0);
     tt_cxy_pair dram_core = tt_cxy_pair(device_id, dram_core_coord.x, dram_core_coord.y);
     size_t offset = desc_to_use.get_address_offset(dram_view);
     read_core(mem_ptr, sz_in_bytes, tt_cxy_pair(device_id, dram_core.x, dram_core.y), addr + offset);
@@ -977,7 +977,7 @@ void Cluster::noc_multicast_write(
 }
 
 void Cluster::noc_multicast_write(
-    const void* mem_ptr, uint32_t sz_in_bytes, ChipId chip_id, CoreCoord core_start, CoreCoord core_end, uint64_t addr)
+    const void* mem_ptr, uint32_t sz_in_bytes, ChipId chip_id, tt::tt_metal::CoreCoord core_start, tt::tt_metal::CoreCoord core_end, uint64_t addr)
     const {
     const metal_SocDescriptor& soc_desc = this->get_soc_desc(chip_id);
 
@@ -1104,9 +1104,9 @@ const std::unordered_set<ChipId>& Cluster::get_devices_controlled_by_mmio_device
     return llrt::get_devices_controlled_by_mmio_device(cluster_desc, mmio_device_id);
 }
 
-std::unordered_map<ChipId, std::vector<CoreCoord>> Cluster::get_ethernet_cores_grouped_by_connected_chips(
+std::unordered_map<ChipId, std::vector<tt::tt_metal::CoreCoord>> Cluster::get_ethernet_cores_grouped_by_connected_chips(
     ChipId chip_id) const {
-    std::unordered_map<ChipId, std::vector<CoreCoord>> connected_chips;
+    std::unordered_map<ChipId, std::vector<tt::tt_metal::CoreCoord>> connected_chips;
     const auto& all_eth_connections = this->get_cluster_desc()->get_ethernet_connections();
     if (!all_eth_connections.contains(chip_id)) {
         return {};
@@ -1114,7 +1114,7 @@ std::unordered_map<ChipId, std::vector<CoreCoord>> Cluster::get_ethernet_cores_g
     for (const auto& [eth_chan, connected_chip_chan] : all_eth_connections.at(chip_id)) {
         const auto& other_chip_id = std::get<0>(connected_chip_chan);
         if (!connected_chips.contains(other_chip_id)) {
-            std::vector<CoreCoord> active_ethernet_cores;
+            std::vector<tt::tt_metal::CoreCoord> active_ethernet_cores;
 
             for (const auto& channel_pair :
                  this->get_cluster_desc()->get_directly_connected_ethernet_channels_between_chips(chip_id, other_chip_id)) {
@@ -1364,8 +1364,8 @@ std::set<tt_fabric::chan_id_t> Cluster::get_fabric_ethernet_channels(
     return fabric_ethernet_channels;
 }
 
-std::vector<CoreCoord> Cluster::get_fabric_ethernet_routers_between_src_and_dest(ChipId src_id, ChipId dst_id) const {
-    std::vector<CoreCoord> fabric_ethernet_channels;
+std::vector<tt::tt_metal::CoreCoord> Cluster::get_fabric_ethernet_routers_between_src_and_dest(ChipId src_id, ChipId dst_id) const {
+    std::vector<tt::tt_metal::CoreCoord> fabric_ethernet_channels;
     const auto& connected_chips = this->get_ethernet_cores_grouped_by_connected_chips(src_id);
     TT_FATAL(connected_chips.contains(dst_id), "Dst Chip {} is not connected to Src Chip {}", dst_id, src_id);
     for (const auto& eth_core : connected_chips.at(dst_id)) {
@@ -1376,13 +1376,13 @@ std::vector<CoreCoord> Cluster::get_fabric_ethernet_routers_between_src_and_dest
     return fabric_ethernet_channels;
 }
 
-bool Cluster::is_ethernet_link_up(ChipId chip_id, const CoreCoord& logical_core) const {
+bool Cluster::is_ethernet_link_up(ChipId chip_id, const tt::tt_metal::CoreCoord& logical_core) const {
     const auto& soc_desc = get_soc_desc(chip_id);
     EthernetChannel eth_chan = soc_desc.logical_eth_core_to_chan_map.at(logical_core);
     return this->get_cluster_desc()->ethernet_core_has_active_ethernet_link(chip_id, eth_chan);
 }
 
-std::tuple<ChipId, CoreCoord> Cluster::get_connected_ethernet_core(std::tuple<ChipId, CoreCoord> eth_core) const {
+std::tuple<ChipId, tt::tt_metal::CoreCoord> Cluster::get_connected_ethernet_core(std::tuple<ChipId, tt::tt_metal::CoreCoord> eth_core) const {
     const auto& soc_desc = get_soc_desc(std::get<0>(eth_core));
     EthernetChannel eth_chan = soc_desc.logical_eth_core_to_chan_map.at(std::get<1>(eth_core));
     TT_FATAL(
@@ -1405,8 +1405,8 @@ std::tuple<ChipId, CoreCoord> Cluster::get_connected_ethernet_core(std::tuple<Ch
 }
 
 // TODO: unify uint64_t with ChipUID
-std::tuple<uint64_t, CoreCoord> Cluster::get_connected_ethernet_core_to_remote_mmio_device(
-    std::tuple<ChipId, CoreCoord> eth_core) const {
+std::tuple<uint64_t, tt::tt_metal::CoreCoord> Cluster::get_connected_ethernet_core_to_remote_mmio_device(
+    std::tuple<ChipId, tt::tt_metal::CoreCoord> eth_core) const {
     const auto& soc_desc = get_soc_desc(std::get<0>(eth_core));
     EthernetChannel eth_chan = soc_desc.logical_eth_core_to_chan_map.at(std::get<1>(eth_core));
     TT_FATAL(
@@ -1430,7 +1430,7 @@ std::tuple<uint64_t, CoreCoord> Cluster::get_connected_ethernet_core_to_remote_m
         soc_desc.get_eth_core_for_channel(std::get<1>(connected_eth_core), CoordSystem::LOGICAL));
 }
 
-std::vector<CoreCoord> Cluster::get_ethernet_sockets(ChipId local_chip, ChipId remote_chip) const {
+std::vector<tt::tt_metal::CoreCoord> Cluster::get_ethernet_sockets(ChipId local_chip, ChipId remote_chip) const {
     const auto& local_ethernet_sockets = this->ethernet_sockets_.at(local_chip);
     TT_FATAL(
         local_ethernet_sockets.contains(remote_chip),
@@ -1440,12 +1440,12 @@ std::vector<CoreCoord> Cluster::get_ethernet_sockets(ChipId local_chip, ChipId r
     return local_ethernet_sockets.at(remote_chip);
 }
 
-CoreCoord Cluster::ethernet_core_from_logical_core(ChipId chip_id, const CoreCoord& logical_core) const {
+tt::tt_metal::CoreCoord Cluster::ethernet_core_from_logical_core(ChipId chip_id, const tt::tt_metal::CoreCoord& logical_core) const {
     const metal_SocDescriptor& soc_desc = get_soc_desc(chip_id);
     return soc_desc.get_physical_ethernet_core_from_logical(logical_core);
 }
 
-CoreCoord Cluster::get_virtual_eth_core_from_channel(ChipId chip_id, int channel) const {
+tt::tt_metal::CoreCoord Cluster::get_virtual_eth_core_from_channel(ChipId chip_id, int channel) const {
     tt::umd::CoreCoord logical_coord =
         this->get_soc_desc(chip_id).get_eth_core_for_channel(channel, CoordSystem::LOGICAL);
     return this->get_virtual_coordinate_from_logical_coordinates(
@@ -1528,7 +1528,7 @@ std::uint32_t Cluster::get_ubb_asic_id(ChipId physical_chip_id) const {
     return ((unique_chip_id >> 56) & 0xFF);
 }
 
-bool Cluster::is_external_cable(ChipId physical_chip_id, CoreCoord eth_core) const {
+bool Cluster::is_external_cable(ChipId physical_chip_id, tt::tt_metal::CoreCoord eth_core) const {
     auto chan_id = this->get_soc_desc(physical_chip_id).logical_eth_core_to_chan_map.at(eth_core);
     bool is_external_cable = false;
     auto board_type = this->get_board_type(physical_chip_id);

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -174,7 +174,7 @@ public:
 
     // Write vector to core
     template <typename DType>
-    void write_core(ChipId device_id, const CoreCoord& core, const std::vector<DType>& hex_vec, uint64_t addr) const {
+    void write_core(ChipId device_id, const tt::tt_metal::CoreCoord& core, const std::vector<DType>& hex_vec, uint64_t addr) const {
         write_core(hex_vec.data(), hex_vec.size() * sizeof(DType), tt_cxy_pair(device_id, core), addr);
     }
 
@@ -183,7 +183,7 @@ public:
     void read_core(std::vector<uint32_t>& data, uint32_t size_in_bytes, tt_cxy_pair core, uint64_t addr) const;
 
     template <typename DType = uint32_t>
-    [[nodiscard]] std::vector<DType> read_core(ChipId chip, const CoreCoord& core, uint64_t addr, uint32_t size) const {
+    [[nodiscard]] std::vector<DType> read_core(ChipId chip, const tt::tt_metal::CoreCoord& core, uint64_t addr, uint32_t size) const {
         std::vector<DType> read_hex_vec;
         read_core(read_hex_vec, size, tt_cxy_pair(chip, core), addr);
         return read_hex_vec;
@@ -196,8 +196,8 @@ public:
         const void* mem_ptr,
         uint32_t sz_in_bytes,
         ChipId chip_id,
-        CoreCoord core_start,
-        CoreCoord core_end,
+        tt::tt_metal::CoreCoord core_start,
+        tt::tt_metal::CoreCoord core_end,
         uint64_t addr) const;
 
     std::optional<std::tuple<uint32_t, uint32_t>> get_tlb_data(const tt_cxy_pair& target) const {
@@ -276,24 +276,24 @@ public:
 
     // Returns whether `logical_core` has an eth link to a core on a connected chip
     // Cores that connect to another cluster will show up as connected
-    bool is_ethernet_link_up(ChipId chip_id, const CoreCoord& logical_core) const;
+    bool is_ethernet_link_up(ChipId chip_id, const tt::tt_metal::CoreCoord& logical_core) const;
 
     // Returns connected ethernet core on the other chip
     // If the core is connected to a device not accessible through this Cluster, it will assert
-    std::tuple<ChipId, CoreCoord> get_connected_ethernet_core(std::tuple<ChipId, CoreCoord> eth_core) const;
+    std::tuple<ChipId, tt::tt_metal::CoreCoord> get_connected_ethernet_core(std::tuple<ChipId, tt::tt_metal::CoreCoord> eth_core) const;
 
     // Returns connected ethernet core on the other chip that is not managed by this Cluster
-    std::tuple<uint64_t, CoreCoord> get_connected_ethernet_core_to_remote_mmio_device(
-        std::tuple<ChipId, CoreCoord> eth_core) const;
+    std::tuple<uint64_t, tt::tt_metal::CoreCoord> get_connected_ethernet_core_to_remote_mmio_device(
+        std::tuple<ChipId, tt::tt_metal::CoreCoord> eth_core) const;
 
     // Returns a ethernet sockets between local chip and remote chip
     // get_ethernet_sockets(a, b)[0] is connected to get_ethernet_sockets(b, a)[0]
-    std::vector<CoreCoord> get_ethernet_sockets(ChipId local_chip, ChipId remote_chip) const;
+    std::vector<tt::tt_metal::CoreCoord> get_ethernet_sockets(ChipId local_chip, ChipId remote_chip) const;
     // Converts logical ethernet core coord to physical ethernet core coord
-    CoreCoord ethernet_core_from_logical_core(ChipId chip_id, const CoreCoord& logical_core) const;
+    tt::tt_metal::CoreCoord ethernet_core_from_logical_core(ChipId chip_id, const tt::tt_metal::CoreCoord& logical_core) const;
 
     // Returns virtual eth coord from channel
-    CoreCoord get_virtual_eth_core_from_channel(ChipId chip_id, int channel) const;
+    tt::tt_metal::CoreCoord get_virtual_eth_core_from_channel(ChipId chip_id, int channel) const;
 
     // Internal routing for SD and FD enables launching user ethernet kernels and FD tunneling for all devices in the
     // cluster. When using multiple devices in a cluster, this should be the flow:
@@ -332,7 +332,7 @@ public:
     const std::unordered_set<ChipId>& get_devices_controlled_by_mmio_device(ChipId mmio_device_id) const;
 
     // Returns map of connected chip ids to active ethernet cores
-    std::unordered_map<ChipId, std::vector<CoreCoord>> get_ethernet_cores_grouped_by_connected_chips(
+    std::unordered_map<ChipId, std::vector<tt::tt_metal::CoreCoord>> get_ethernet_cores_grouped_by_connected_chips(
         ChipId chip_id) const;
 
     // Returns vector of unique tunnels originating from mmio device.
@@ -383,28 +383,28 @@ public:
         const tt::tt_fabric::ControlPlane& control_plane, ChipId chip_id) const;
 
     // Get fabric ethernet cores connecting src to dst
-    std::vector<CoreCoord> get_fabric_ethernet_routers_between_src_and_dest(ChipId src_id, ChipId dst_id) const;
+    std::vector<tt::tt_metal::CoreCoord> get_fabric_ethernet_routers_between_src_and_dest(ChipId src_id, ChipId dst_id) const;
 
-    bool is_worker_core(const CoreCoord& core, ChipId chip_id) const;
-    bool is_ethernet_core(const CoreCoord& core, ChipId chip_id) const;
-    bool is_dram_core(const CoreCoord& core, ChipId chip_id) const;
-    CoreCoord get_logical_ethernet_core_from_virtual(ChipId chip, CoreCoord core) const;
+    bool is_worker_core(const tt::tt_metal::CoreCoord& core, ChipId chip_id) const;
+    bool is_ethernet_core(const tt::tt_metal::CoreCoord& core, ChipId chip_id) const;
+    bool is_dram_core(const tt::tt_metal::CoreCoord& core, ChipId chip_id) const;
+    tt::tt_metal::CoreCoord get_logical_ethernet_core_from_virtual(ChipId chip, tt::tt_metal::CoreCoord core) const;
 
     // These two functions should be removed in favor of direct translation.
     std::unordered_map<int, int> get_worker_logical_to_virtual_x(ChipId chip_id) const;
     std::unordered_map<int, int> get_worker_logical_to_virtual_y(ChipId chip_id) const;
 
-    const std::unordered_map<CoreCoord, int32_t>& get_virtual_routing_to_profiler_flat_id(ChipId chip_id) const;
+    const std::unordered_map<tt::tt_metal::CoreCoord, int32_t>& get_virtual_routing_to_profiler_flat_id(ChipId chip_id) const;
 
     std::uint32_t get_ubb_asic_id(ChipId physical_chip_id) const;
 
     // TODO: move to separate system descriptor class
     // return enum for connection type, Internal, QSFP, Other, Unknown
-    bool is_external_cable(ChipId physical_chip_id, CoreCoord eth_core) const;
+    bool is_external_cable(ChipId physical_chip_id, tt::tt_metal::CoreCoord eth_core) const;
 
     uint32_t get_alignment_requirements(ChipId chip_id, uint32_t size_in_bytes) const;
 
-    const std::unordered_set<CoreCoord>& get_eth_cores_with_frequent_retraining(ChipId chip_id) const {
+    const std::unordered_set<tt::tt_metal::CoreCoord>& get_eth_cores_with_frequent_retraining(ChipId chip_id) const {
         return this->frequent_retrain_cores_.at(chip_id);
     }
 
@@ -412,7 +412,7 @@ public:
     // Call after link retraining to allow continued operation without restarting the process.
     void rediscover_ethernet_links();
 
-    const std::unordered_map<CoreCoord, EthRouterMode>& get_eth_routing_info(ChipId chip_id) const {
+    const std::unordered_map<tt::tt_metal::CoreCoord, EthRouterMode>& get_eth_routing_info(ChipId chip_id) const {
         return this->device_eth_routing_info_.at(chip_id);
     }
 
@@ -460,13 +460,13 @@ private:
 
     // Data Structures Tracking Virtual Coordinates
     std::unordered_map<tt_cxy_pair, tt_cxy_pair> virtual_to_umd_coord_mapping_;
-    std::unordered_map<ChipId, std::unordered_set<CoreCoord>> virtual_worker_cores_;
-    std::unordered_map<ChipId, std::unordered_set<CoreCoord>> virtual_eth_cores_;
-    std::unordered_map<ChipId, std::unordered_set<CoreCoord>> virtual_dram_cores_;
-    std::unordered_map<ChipId, std::unordered_set<CoreCoord>> virtual_dram_hw_cores_;
-    std::unordered_map<ChipId, std::unordered_set<CoreCoord>> virtual_pcie_cores_;
-    std::unordered_map<BoardType, std::unordered_map<CoreCoord, int32_t>> virtual_routing_to_profiler_flat_id_;
-    std::unordered_map<ChipId, std::unordered_set<CoreCoord>> frequent_retrain_cores_;
+    std::unordered_map<ChipId, std::unordered_set<tt::tt_metal::CoreCoord>> virtual_worker_cores_;
+    std::unordered_map<ChipId, std::unordered_set<tt::tt_metal::CoreCoord>> virtual_eth_cores_;
+    std::unordered_map<ChipId, std::unordered_set<tt::tt_metal::CoreCoord>> virtual_dram_cores_;
+    std::unordered_map<ChipId, std::unordered_set<tt::tt_metal::CoreCoord>> virtual_dram_hw_cores_;
+    std::unordered_map<ChipId, std::unordered_set<tt::tt_metal::CoreCoord>> virtual_pcie_cores_;
+    std::unordered_map<BoardType, std::unordered_map<tt::tt_metal::CoreCoord, int32_t>> virtual_routing_to_profiler_flat_id_;
+    std::unordered_map<ChipId, std::unordered_set<tt::tt_metal::CoreCoord>> frequent_retrain_cores_;
     // Flag to tell whether we are on a TG type of system.
     // If any device has to board type of GALAXY, we are on a TG cluster.
     tt::tt_metal::ClusterType cluster_type_ = tt::tt_metal::ClusterType::INVALID;
@@ -492,9 +492,9 @@ private:
     std::unordered_map<ChipId, uint16_t> device_to_host_mem_channel_;
 
     // Mapping of each devices' ethernet routing mode
-    std::unordered_map<ChipId, std::unordered_map<CoreCoord, EthRouterMode>> device_eth_routing_info_;
+    std::unordered_map<ChipId, std::unordered_map<tt::tt_metal::CoreCoord, EthRouterMode>> device_eth_routing_info_;
 
-    std::unordered_map<ChipId, std::unordered_map<ChipId, std::vector<CoreCoord>>> ethernet_sockets_;
+    std::unordered_map<ChipId, std::unordered_map<ChipId, std::vector<tt::tt_metal::CoreCoord>>> ethernet_sockets_;
 
     uint32_t routing_info_addr_ = 0;
     uint32_t retrain_count_addr_ = 0;

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -116,15 +116,15 @@ public:
     ARCH arch() const { return this->arch_; }
 
     const metal_SocDescriptor& get_soc_desc(ChipId chip) const;
-    CoreCoord get_virtual_coordinate_from_logical_coordinates(
-        ChipId chip_id, CoreCoord logical_coord, const CoreType& core_type) const;
-    CoreCoord get_virtual_coordinate_from_physical_coordinates(ChipId chip_id, CoreCoord physical_coord) const;
+    tt::tt_metal::CoreCoord get_virtual_coordinate_from_logical_coordinates(
+        ChipId chip_id, tt::tt_metal::CoreCoord logical_coord, const CoreType& core_type) const;
+    tt::tt_metal::CoreCoord get_virtual_coordinate_from_physical_coordinates(ChipId chip_id, tt::tt_metal::CoreCoord physical_coord) const;
     tt_cxy_pair get_virtual_coordinate_from_logical_coordinates(
         tt_cxy_pair logical_coordinate, const CoreType& core_type) const;
-    CoreCoord get_physical_coordinate_from_logical_coordinates(
-        ChipId chip_id, CoreCoord logical_coord, const CoreType& core_type, bool no_warn = false) const;
-    const std::unordered_set<CoreCoord>& get_virtual_worker_cores(ChipId chip_id) const;
-    const std::unordered_set<CoreCoord>& get_virtual_eth_cores(ChipId chip_id) const;
+    tt::tt_metal::CoreCoord get_physical_coordinate_from_logical_coordinates(
+        ChipId chip_id, tt::tt_metal::CoreCoord logical_coord, const CoreType& core_type, bool no_warn = false) const;
+    const std::unordered_set<tt::tt_metal::CoreCoord>& get_virtual_worker_cores(ChipId chip_id) const;
+    const std::unordered_set<tt::tt_metal::CoreCoord>& get_virtual_eth_cores(ChipId chip_id) const;
 
     uint32_t get_harvesting_mask(ChipId chip) const {
         return this->driver_->get_soc_descriptor(chip).harvesting_masks.tensix_harvesting_mask;
@@ -155,20 +155,20 @@ public:
     // Write to core without effects of write combining
     template <typename DType>
     void write_core_immediate(
-        ChipId device_id, const CoreCoord& core, const std::span<DType>& hex_vec, uint64_t addr) const {
+        ChipId device_id, const tt::tt_metal::CoreCoord& core, const std::span<DType>& hex_vec, uint64_t addr) const {
         write_core_immediate(hex_vec.data(), hex_vec.size() * sizeof(DType), tt_cxy_pair(device_id, core), addr);
     }
 
     // Write to core without effects of write combining
     template <typename DType>
     void write_core_immediate(
-        ChipId device_id, const CoreCoord& core, const std::vector<DType>& hex_vec, uint64_t addr) const {
+        ChipId device_id, const tt::tt_metal::CoreCoord& core, const std::vector<DType>& hex_vec, uint64_t addr) const {
         write_core_immediate(hex_vec.data(), hex_vec.size() * sizeof(DType), tt_cxy_pair(device_id, core), addr);
     }
 
     // Write span to core
     template <typename DType>
-    void write_core(ChipId device_id, const CoreCoord& core, const std::span<DType>& hex_vec, uint64_t addr) const {
+    void write_core(ChipId device_id, const tt::tt_metal::CoreCoord& core, const std::span<DType>& hex_vec, uint64_t addr) const {
         write_core(hex_vec.data(), hex_vec.size() * sizeof(DType), tt_cxy_pair(device_id, core), addr);
     }
 

--- a/ttnn/core/reports.cpp
+++ b/ttnn/core/reports.cpp
@@ -136,7 +136,7 @@ std::vector<BufferPageInfo> get_buffer_pages(const std::vector<tt::tt_metal::dis
                 uint32_t bank_id = 0;
                 for (uint32_t page_index = 0; page_index < num_pages; page_index++) {
                     auto page_address = buffer->page_address(bank_id, page_index);
-                    CoreCoord core = buffer->allocator()->get_logical_core_from_bank_id(bank_id);
+                    tt::tt_metal::CoreCoord core = buffer->allocator()->get_logical_core_from_bank_id(bank_id);
                     bank_id = (bank_id + 1) % num_banks;
 
                     buffer_page_infos.push_back(BufferPageInfo{

--- a/ttnn/core/tensor/flatbuffer/tensor_spec_flatbuffer.cpp
+++ b/ttnn/core/tensor/flatbuffer/tensor_spec_flatbuffer.cpp
@@ -10,7 +10,7 @@ CoreRangeSet from_flatbuffer(const flatbuffer::CoreRangeSet* core_range_set) {
     std::vector<CoreRange> ranges;
     for (const auto* range : *core_range_set->ranges()) {
         ranges.emplace_back(
-            CoreCoord{range->start()->x(), range->start()->y()}, CoreCoord{range->end()->x(), range->end()->y()});
+            tt::tt_metal::CoreCoord{range->start()->x(), range->start()->y()}, tt::tt_metal::CoreCoord{range->end()->x(), range->end()->y()});
     }
     return CoreRangeSet{ranges};
 }

--- a/ttnn/cpp/ttnn-nanobind/d2h_stream_service.cpp
+++ b/ttnn/cpp/ttnn-nanobind/d2h_stream_service.cpp
@@ -42,7 +42,7 @@ void py_module_types(nb::module_& mod) {
                std::unique_ptr<ttnn::distributed::TensorToMesh> mapper,
                std::optional<tt::tt_metal::distributed::MeshComposerConfig> composer_config,
                std::optional<CoreRange> worker_cores,
-               std::optional<CoreCoord> metadata_master_core,
+               std::optional<tt::tt_metal::CoreCoord> metadata_master_core,
                uint32_t metadata_size_bytes,
                bool parallel_host_read,
                uint32_t host_read_thread_count) {

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_op_fusion.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_op_fusion.hpp
@@ -13,11 +13,11 @@
 namespace ttnn::experimental::ccl {
 
 struct CoreSemPair {
-    CoreCoord core = {0, 0};
+    tt::tt_metal::CoreCoord core = {0, 0};
     uint32_t sem_id = 0;
 
     CoreSemPair() = default;
-    CoreSemPair(CoreCoord core, uint32_t sem_id) : core(core), sem_id(sem_id) {}
+    CoreSemPair(tt::tt_metal::CoreCoord core, uint32_t sem_id) : core(core), sem_id(sem_id) {}
 };
 
 enum class FusedOpSignalerMode {
@@ -31,12 +31,12 @@ enum class FusedOpSignalerMode {
 
 struct AllGatherFusedOpSignaler {
     uint32_t num_fused_op_cores_to_signal = 0;
-    std::vector<CoreCoord> fused_op_receiver_cores_noc;
+    std::vector<tt::tt_metal::CoreCoord> fused_op_receiver_cores_noc;
     std::vector<uint32_t> fused_op_receiver_signal_semaphores;
     FusedOpSignalerMode fused_op_signaler_mode = FusedOpSignalerMode::MULTI;
 
     /* All Gather specific */
-    std::vector<CoreCoord> all_gather_worker_cores_noc;
+    std::vector<tt::tt_metal::CoreCoord> all_gather_worker_cores_noc;
     uint32_t all_gather_worker_sync_semaphore = 0;
 
     bool initialized_fused_op = false;
@@ -45,7 +45,7 @@ struct AllGatherFusedOpSignaler {
     AllGatherFusedOpSignaler() = default;
 
     void init_fused_op(
-        const std::vector<CoreCoord>& fused_op_receiver_cores_noc,
+        const std::vector<tt::tt_metal::CoreCoord>& fused_op_receiver_cores_noc,
         const std::vector<uint32_t>& fused_op_receiver_signal_semaphores,
         FusedOpSignalerMode fused_op_signaler_mode = FusedOpSignalerMode::MULTI);
 
@@ -54,7 +54,7 @@ struct AllGatherFusedOpSignaler {
         const tt::tt_metal::IDevice* device,
 
         const CoreRangeSet& all_gather_workers,
-        std::vector<CoreCoord>& all_gather_worker_cores);
+        std::vector<tt::tt_metal::CoreCoord>& all_gather_worker_cores);
 
     void push_all_gather_fused_op_rt_args(
         std::vector<uint32_t>& out_rt_args,
@@ -66,12 +66,12 @@ struct AllGatherFusedOpSignaler {
 
 struct StridedAllGatherFusedOpSignaler {
     uint32_t num_fused_op_cores_to_signal = 0;
-    std::vector<CoreCoord> fused_op_receiver_cores_noc;
+    std::vector<tt::tt_metal::CoreCoord> fused_op_receiver_cores_noc;
     std::vector<uint32_t> fused_op_receiver_signal_semaphores;
     FusedOpSignalerMode fused_op_signaler_mode = FusedOpSignalerMode::MULTI;
 
     /* All Gather specific */
-    std::vector<CoreCoord> all_gather_worker_cores_noc;
+    std::vector<tt::tt_metal::CoreCoord> all_gather_worker_cores_noc;
     uint32_t all_gather_worker_sync_semaphore = 0;
 
     bool initialized_fused_op = false;
@@ -80,7 +80,7 @@ struct StridedAllGatherFusedOpSignaler {
     StridedAllGatherFusedOpSignaler() = default;
 
     void init_fused_op(
-        const std::vector<CoreCoord>& fused_op_receiver_cores_noc,
+        const std::vector<tt::tt_metal::CoreCoord>& fused_op_receiver_cores_noc,
         const std::vector<uint32_t>& fused_op_receiver_signal_semaphores,
         FusedOpSignalerMode fused_op_signaler_mode = FusedOpSignalerMode::MULTI);
 
@@ -89,7 +89,7 @@ struct StridedAllGatherFusedOpSignaler {
         const tt::tt_metal::IDevice* device,
 
         const CoreRangeSet& all_gather_workers,
-        std::vector<CoreCoord>& all_gather_worker_cores);
+        std::vector<tt::tt_metal::CoreCoord>& all_gather_worker_cores);
 
     void push_all_gather_fused_op_rt_args(
         std::vector<uint32_t>& out_rt_args,
@@ -102,7 +102,7 @@ struct StridedAllGatherFusedOpSignaler {
 // Used to propagate semaphore information from matmul to reduce scatter in matmul_reduce_scatter op
 struct ReduceScatterFusedOpSignaler {
     uint32_t num_fused_op_cores_to_signal = 1;
-    std::vector<CoreCoord> fused_op_receiver_cores_noc;
+    std::vector<tt::tt_metal::CoreCoord> fused_op_receiver_cores_noc;
     std::vector<uint32_t> fused_op_receiver_signal_semaphores;
     FusedOpSignalerMode fused_op_signaler_mode = FusedOpSignalerMode::SINGLE;
 
@@ -133,7 +133,7 @@ struct MatmulFusedOpSignaler {
 
     /* Matmul info for All Gather */
     uint32_t num_fused_op_cores_to_signal = 0;
-    std::vector<CoreCoord> fused_op_receiver_cores_noc;
+    std::vector<tt::tt_metal::CoreCoord> fused_op_receiver_cores_noc;
     std::vector<uint32_t> fused_op_receiver_signal_semaphores;  // [dir0, dir1]
     FusedOpSignalerMode fused_op_signaler_mode = FusedOpSignalerMode::MULTI;
 
@@ -148,8 +148,8 @@ struct MatmulFusedOpSignaler {
     uint32_t weight_output_page_offset = 0;
 
     /* Matmul info for Reduce Scatter */
-    std::vector<CoreCoord> matmul_worker_cores_noc;
-    std::vector<CoreCoord> matmul_worker_cores;
+    std::vector<tt::tt_metal::CoreCoord> matmul_worker_cores_noc;
+    std::vector<tt::tt_metal::CoreCoord> matmul_worker_cores;
     uint32_t matmul_worker_sync_semaphore = 0;
 
     /* Info for Llama Reduce Scatter*/
@@ -157,8 +157,8 @@ struct MatmulFusedOpSignaler {
     uint32_t rs_semaphore = 0;
     uint32_t matmul_semaphore_target = 0;
     CoreRangeSet rs_cores;
-    CoreCoord privilaged_core;
-    CoreCoord privilaged_core_physical;
+    tt::tt_metal::CoreCoord privilaged_core;
+    tt::tt_metal::CoreCoord privilaged_core_physical;
 
     /* Info for Llama All Gather*/
     uint32_t start_cb_index = 0;
@@ -192,7 +192,7 @@ struct MatmulFusedOpSignaler {
         uint32_t start_cb_index);
 
     void init_reduce_scatter(
-        const std::vector<CoreCoord>& fused_op_receiver_cores_noc,
+        const std::vector<tt::tt_metal::CoreCoord>& fused_op_receiver_cores_noc,
         const std::vector<uint32_t>& fused_op_receiver_signal_semaphores,
         FusedOpSignalerMode fused_op_signaler_mode);
 
@@ -209,7 +209,7 @@ struct MatmulFusedOpSignaler {
     // First core to run this is the privileged core
     void push_llama_rs_rt_args_for_mm(
         std::vector<uint32_t>& out_rt_args,
-        CoreCoord current_core,
+        tt::tt_metal::CoreCoord current_core,
         tt::tt_metal::NOC writer_noc,
         const tt::tt_metal::IDevice* device) const;
 
@@ -217,7 +217,7 @@ struct MatmulFusedOpSignaler {
         tt::tt_metal::Program& program,
         const tt::tt_metal::IDevice* device,
         const CoreRange& matmul_workers,
-        const std::vector<CoreCoord>& matmul_worker_cores);
+        const std::vector<tt::tt_metal::CoreCoord>& matmul_worker_cores);
 
     void init_fused_op(
         tt::tt_metal::Program& program,
@@ -239,7 +239,7 @@ struct MatmulFusedOpSignaler {
 struct MinimalMatmulFusedOpSignaler {
     /* Matmul info for All Gather */
     uint32_t num_fused_op_cores_to_signal = 0;
-    std::vector<CoreCoord> fused_op_receiver_cores_noc;
+    std::vector<tt::tt_metal::CoreCoord> fused_op_receiver_cores_noc;
     std::vector<uint32_t> fused_op_receiver_signal_semaphores;  // [dir0, dir1]
     FusedOpSignalerMode fused_op_signaler_mode = FusedOpSignalerMode::MULTI;
 
@@ -283,7 +283,7 @@ struct MinimalMatmulFusedOpSignaler {
 // so the matmul master knows which cores and semaphore to signal.
 struct StridedReduceScatterFusedOpSignaler {
     uint32_t num_fused_op_cores_to_signal = 0;
-    std::vector<CoreCoord> fused_op_receiver_cores_noc;
+    std::vector<tt::tt_metal::CoreCoord> fused_op_receiver_cores_noc;
     uint32_t fused_op_receiver_signal_semaphore = 0;
 
     bool initialized = false;

--- a/ttnn/cpp/ttnn/operations/ccl/common/types/ccl_types_args_emitters.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/types/ccl_types_args_emitters.hpp
@@ -51,7 +51,7 @@ args_list_t legacy_emit_address_generator_runtime_args(const tt::tt_metal::IDevi
 args_list_t emit_address_generator_compile_time_args(const ttnn::Tensor& t);
 args_list_t legacy_emit_address_generator_compile_time_args(const ttnn::Tensor& tensor);
 
-std::pair<CoreCoord, CoreCoord> shard_grid_from_shard_spec(const tt::tt_metal::ShardSpec& shard_spec);
+std::pair<tt::tt_metal::CoreCoord, tt::tt_metal::CoreCoord> shard_grid_from_shard_spec(const tt::tt_metal::ShardSpec& shard_spec);
 
 struct ShardedAddrGenArgBuilder {
     static bool shard_grid_is_transposed(const ttnn::Tensor& t);

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_device_operation_types.hpp
@@ -181,14 +181,14 @@ struct Conv2dConfig {
 enum class Conv2dOpParallelizationStrategy { MULTI_CORE, MULTI_CORE_REUSE, MULTI_CORE_REUSE_MCAST, SINGLE_CORE };
 
 struct Conv2dParallelizationConfig {
-    CoreCoord grid_size;  // (x,y)
+    tt::tt_metal::CoreCoord grid_size;  // (x,y)
     uint32_t num_cores_nhw = 1;
     uint32_t num_cores_c_in = 1;
     uint32_t num_cores_c_out = 1;
     uint32_t per_core_out_matrix_height_ntile = 1;
     uint32_t per_core_out_matrix_width_ntile = 1;
 
-    CoreCoord get_grid_size() const { return this->grid_size; }
+    tt::tt_metal::CoreCoord get_grid_size() const { return this->grid_size; }
 };
 
 struct Conv2dBlockConfig {

--- a/ttnn/cpp/ttnn/operations/core/work_split/work_split_tilize.hpp
+++ b/ttnn/cpp/ttnn/operations/core/work_split/work_split_tilize.hpp
@@ -245,7 +245,7 @@ inline BlockSplitWH split_blocks_for_tilize_wh(
 }
 
 inline BlockSplitWH split_blocks_for_tilize_wh(
-    CoreCoord grid_size,
+    tt::tt_metal::CoreCoord grid_size,
     uint32_t nblocks,
     uint32_t width_tiles,
     uint32_t height_tiles,
@@ -278,7 +278,7 @@ inline BlockSplitWH split_blocks_for_tilize_wh(
     uint32_t i_x = 0;
     uint32_t i_y = 0;
     auto addCore = [&](std::set<CoreRange>& targetSet) {
-        CoreRange range{CoreCoord{i_x, i_y}, CoreCoord{i_x, i_y}};
+        CoreRange range{tt::tt_metal::CoreCoord{i_x, i_y}, tt::tt_metal::CoreCoord{i_x, i_y}};
         targetSet.insert(range);
         all_cores.insert(range);
         // Update core coordinates in a cyclic row-wise manner.
@@ -339,7 +339,7 @@ inline BlockSplit split_blocks_for_tilize(const CoreRangeSet& grid, uint32_t nbl
     const uint32_t ncores_no_cliff = nblocks_per_core_cliff == 0 ? ncores : ncores - 1;
 
     std::set<CoreRange> core_range, cliff_core_range;
-    std::optional<CoreCoord> cliff_core;
+    std::optional<tt::tt_metal::CoreCoord> cliff_core;
 
     // Top non-cliff range
     for (uint32_t core_id = 0; core_id < ncores_no_cliff; core_id++) {
@@ -363,7 +363,7 @@ inline BlockSplit split_blocks_for_tilize(const CoreRangeSet& grid, uint32_t nbl
     return BlockSplit{ncores, all_cores, core_range, cliff_core_range, nblocks_per_core, nblocks_per_core_cliff};
 }
 
-inline BlockSplit split_blocks_for_tilize(CoreCoord grid_size, uint32_t nblocks) {
+inline BlockSplit split_blocks_for_tilize(tt::tt_metal::CoreCoord grid_size, uint32_t nblocks) {
     size_t grid_area = grid_size.x * grid_size.y;
     auto [ncores, nblocks_per_core] = compute_ncores(grid_area, nblocks);
     const uint32_t nblocks_per_core_cliff = nblocks_per_core == 0 ? 0 : nblocks % nblocks_per_core;
@@ -372,27 +372,27 @@ inline BlockSplit split_blocks_for_tilize(CoreCoord grid_size, uint32_t nblocks)
     const uint32_t ncores_x_cliff = ncores - ((ncores_y - 1) * ncores_x);
 
     std::set<CoreRange> core_range, cliff_core_range;
-    std::optional<CoreCoord> cliff_core;
+    std::optional<tt::tt_metal::CoreCoord> cliff_core;
 
     // Top non-cliff range (full rows)
     const uint32_t top_range_end_y = ncores_y - (ncores_x_cliff < ncores_x || nblocks_per_core_cliff > 0);
 
     if (top_range_end_y > 0) {
-        auto range = CoreRange{CoreCoord{0, 0}, CoreCoord{ncores_x - 1, top_range_end_y - 1}};
+        auto range = CoreRange{tt::tt_metal::CoreCoord{0, 0}, tt::tt_metal::CoreCoord{ncores_x - 1, top_range_end_y - 1}};
         core_range.insert(range);
     }
 
     if (ncores_x_cliff < ncores_x && nblocks_per_core_cliff == 0) {
         // Last partial row (non-cliff)
-        auto range = CoreRange{CoreCoord{0, ncores_y - 1}, CoreCoord{ncores_x_cliff - 1, ncores_y - 1}};
+        auto range = CoreRange{tt::tt_metal::CoreCoord{0, ncores_y - 1}, tt::tt_metal::CoreCoord{ncores_x_cliff - 1, ncores_y - 1}};
         core_range.insert(range);
     } else if (nblocks_per_core_cliff > 0) {
         // Last partial row (excluding last core) and single cliff core
         if (ncores_x_cliff > 1) {  // Add range only if there are cores before the cliff core
-            auto range = CoreRange{CoreCoord{0, ncores_y - 1}, CoreCoord{ncores_x_cliff - 2, ncores_y - 1}};
+            auto range = CoreRange{tt::tt_metal::CoreCoord{0, ncores_y - 1}, tt::tt_metal::CoreCoord{ncores_x_cliff - 2, ncores_y - 1}};
             core_range.insert(range);
         }
-        cliff_core = CoreCoord{ncores_x_cliff - 1, ncores_y - 1};
+        cliff_core = tt::tt_metal::CoreCoord{ncores_x_cliff - 1, ncores_y - 1};
     }
 
     std::set<CoreRange> all_cores = core_range;

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_common.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_common.cpp
@@ -31,8 +31,8 @@ std::tuple<std::vector<std::vector<WidthShardingReshardSegment>>, uint32_t, uint
 compute_width_sharding_reshard_segments(
     const std::array<uint32_t, 2>& local_shard_shape,
     const std::array<uint32_t, 2>& remote_shard_shape,
-    const std::vector<CoreCoord>& local_cores,
-    const std::vector<CoreCoord>& remote_cores,
+    const std::vector<tt::tt_metal::CoreCoord>& local_cores,
+    const std::vector<tt::tt_metal::CoreCoord>& remote_cores,
     const tt::tt_metal::BufferType& remote_buffer_type,
     const tt::CoreType& /*remote_core_type*/,
     tt::tt_metal::IDevice* device,

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_common.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_common.hpp
@@ -25,8 +25,8 @@ std::tuple<std::vector<std::vector<WidthShardingReshardSegment>>, uint32_t, uint
 compute_width_sharding_reshard_segments(
     const std::array<uint32_t, 2>& local_shard_shape,
     const std::array<uint32_t, 2>& remote_shard_shape,
-    const std::vector<CoreCoord>& local_cores,
-    const std::vector<CoreCoord>& remote_cores,
+    const std::vector<tt::tt_metal::CoreCoord>& local_cores,
+    const std::vector<tt::tt_metal::CoreCoord>& remote_cores,
     const tt::tt_metal::BufferType& remote_buffer_type,
     const tt::CoreType& remote_core_type,
     tt::tt_metal::IDevice* device,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul_async/device/all_gather_matmul_async_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_matmul_async/device/all_gather_matmul_async_device_operation.cpp
@@ -149,7 +149,7 @@ ttnn::experimental::prim::AllGatherMatmulAsyncDeviceOperation::tensor_return_val
     const std::optional<ttnn::Tensor>& persistent_output_buffer,
     const uint32_t dim,
     const std::vector<GlobalSemaphore>& multi_device_global_semaphore,
-    const CoreCoord all_gather_core_grid_offset,
+    const tt::tt_metal::CoreCoord all_gather_core_grid_offset,
     const std::optional<const Tensor>& bias,
     const uint32_t num_links,
     const std::optional<MemoryConfig>& memory_config_ag,
@@ -199,9 +199,9 @@ ttnn::experimental::prim::AllGatherMatmulAsyncDeviceOperation::tensor_return_val
 
     /* Matmul setup */
     bool user_run_batched = ttnn::operations::matmul::detail::is_input_batched(weight_tensor.logical_shape());
-    std::optional<CoreCoord> user_core_coord;
+    std::optional<tt::tt_metal::CoreCoord> user_core_coord;
     if (core_grid.has_value()) {
-        user_core_coord = CoreCoord(core_grid->x, core_grid->y);
+        user_core_coord = tt::tt_metal::CoreCoord(core_grid->x, core_grid->y);
     }
 
     auto matmul_struct = ttnn::prim::create_matmul_attributes(

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/all_gather_minimal_matmul_async_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/all_gather_minimal_matmul_async_program_factory.cpp
@@ -41,14 +41,14 @@ static inline std::tuple<uint32_t, uint32_t, uint32_t, uint32_t, uint32_t> deter
 }
 
 // Build a linear order of cores along one axis for data movement, plus index of the current core
-static inline std::pair<std::vector<CoreCoord>, uint32_t> build_core_order_for_axis(
-    const CoreCoord& core,
+static inline std::pair<std::vector<tt::tt_metal::CoreCoord>, uint32_t> build_core_order_for_axis(
+    const tt::tt_metal::CoreCoord& core,
     bool transpose_core_grid,
     uint32_t axis_length,
     tt::tt_metal::NOC noc,
     bool axis_is_x_when_not_transposed,
-    const CoreCoord& initial_endpoint) {
-    std::vector<CoreCoord> order;
+    const tt::tt_metal::CoreCoord& initial_endpoint) {
+    std::vector<tt::tt_metal::CoreCoord> order;
     order.reserve(axis_length);
     order.push_back(initial_endpoint);
 
@@ -61,7 +61,7 @@ static inline std::pair<std::vector<CoreCoord>, uint32_t> build_core_order_for_a
 
     uint32_t index_of_current = 0;  // default to 0 if axis_length == 1
     for (uint32_t worker_idx = 1; worker_idx < axis_length; ++worker_idx) {
-        CoreCoord worker_core = core;
+        tt::tt_metal::CoreCoord worker_core = core;
         size_t& coord_to_modify = transpose_core_grid ? (axis_is_x_when_not_transposed ? worker_core.y : worker_core.x)
                                                       : (axis_is_x_when_not_transposed ? worker_core.x : worker_core.y);
 
@@ -74,11 +74,11 @@ static inline std::pair<std::vector<CoreCoord>, uint32_t> build_core_order_for_a
     return {order, index_of_current};
 }
 
-static inline CoreCoord clamped_prev(const std::vector<CoreCoord>& order, uint32_t index) {
+static inline tt::tt_metal::CoreCoord clamped_prev(const std::vector<tt::tt_metal::CoreCoord>& order, uint32_t index) {
     return order.at(index == 0 ? 0 : index - 1);
 }
 
-static inline CoreCoord clamped_next(const std::vector<CoreCoord>& order, uint32_t index) {
+static inline tt::tt_metal::CoreCoord clamped_next(const std::vector<tt::tt_metal::CoreCoord>& order, uint32_t index) {
     const uint32_t last = static_cast<uint32_t>(order.size() - 1);
     return order.at(index >= last ? last : index + 1);
 }
@@ -101,12 +101,12 @@ void fabric_mux_connection_rt_args(
     const bool mux_connection_valid,
     const bool is_termination_master,
     const tt::tt_fabric::FabricMuxChannelType channel_type,
-    const CoreCoord& mux_virtual_core,
+    const tt::tt_metal::CoreCoord& mux_virtual_core,
     const uint32_t worker_id,
-    const CoreCoord& worker_logical_core,
+    const tt::tt_metal::CoreCoord& worker_logical_core,
     const tt::tt_fabric::FabricMuxConfig& mux_kernel_config,
     tt::tt_metal::Program& program,
-    CoreCoord termination_master_virtual_core,
+    tt::tt_metal::CoreCoord termination_master_virtual_core,
     uint32_t num_mux_clients,
     uint32_t termination_sync_id,
     std::vector<uint32_t>& worker_rt_args) {
@@ -392,16 +392,16 @@ all_gather_minimal_matmul_async_factory_helper(
     uint32_t interm_cb_num_tiles = out_block_num_tiles;  // not double buffered
     uint32_t in2_cb_num_tiles = in2_block_num_tiles;     // not double buffered
 
-    auto core_0_0 = CoreCoord{0, 0};
-    auto core_0_1 = CoreCoord{0, 1};
-    auto core_1_0 = CoreCoord{1, 0};
-    auto core_endx_0 = CoreCoord{grid_size.x - 1, 0};
-    auto core_0_endy = CoreCoord{0, grid_size.y - 1};
-    auto core_endx_endy = CoreCoord{grid_size.x - 1, grid_size.y - 1};
-    auto core_endx_2_endy = CoreCoord{grid_size.x - 3, grid_size.y - 1};
-    auto core_endx_endy_2 = CoreCoord{grid_size.x - 1, grid_size.y - 3};
-    auto core_0_endy_1 = CoreCoord{0, grid_size.y - 2};
-    auto core_endx_1_0 = CoreCoord{grid_size.x - 2, 0};
+    auto core_0_0 = tt::tt_metal::CoreCoord{0, 0};
+    auto core_0_1 = tt::tt_metal::CoreCoord{0, 1};
+    auto core_1_0 = tt::tt_metal::CoreCoord{1, 0};
+    auto core_endx_0 = tt::tt_metal::CoreCoord{grid_size.x - 1, 0};
+    auto core_0_endy = tt::tt_metal::CoreCoord{0, grid_size.y - 1};
+    auto core_endx_endy = tt::tt_metal::CoreCoord{grid_size.x - 1, grid_size.y - 1};
+    auto core_endx_2_endy = tt::tt_metal::CoreCoord{grid_size.x - 3, grid_size.y - 1};
+    auto core_endx_endy_2 = tt::tt_metal::CoreCoord{grid_size.x - 1, grid_size.y - 3};
+    auto core_0_endy_1 = tt::tt_metal::CoreCoord{0, grid_size.y - 2};
+    auto core_endx_1_0 = tt::tt_metal::CoreCoord{grid_size.x - 2, 0};
 
     auto in0_sender_cores = CoreRange(core_0_0, transpose_core_grid ? core_endx_0 : core_0_endy);
     auto in0_receiver_cores_no_fabric =

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/all_gather_minimal_matmul_async_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/all_gather_minimal_matmul_async_program_factory.cpp
@@ -534,29 +534,29 @@ all_gather_minimal_matmul_async_factory_helper(
         "Scheme-4 single-row mux interleave assumes num_workers_per_link==2 (got {})",
         num_workers_per_link);
     const uint32_t single_mux_row = full_grid_size.y - 1;
-    const auto in0_mux_logical = [&](uint32_t link, uint32_t dir) -> CoreCoord {
+    const auto in0_mux_logical = [&](uint32_t link, uint32_t dir) -> tt::tt_metal::CoreCoord {
         if (single_row_muxes) {
-            return CoreCoord(num_workers_per_link * link + 1, single_mux_row);  // odd col 2g+1 (NOC_0 +x-aligned)
+            return tt::tt_metal::CoreCoord(num_workers_per_link * link + 1, single_mux_row);  // odd col 2g+1 (NOC_0 +x-aligned)
         }
         uint32_t x = (num_workers_per_link * (link + 1)) - (1 - dir);
         if (x >= full_grid_size.x) {
             x -= full_grid_size.x;
         }
-        return CoreCoord(x, full_grid_size.y - 1);
+        return tt::tt_metal::CoreCoord(x, full_grid_size.y - 1);
     };
-    const auto fsdp_mux_logical = [&](uint32_t link, uint32_t dir) -> CoreCoord {
+    const auto fsdp_mux_logical = [&](uint32_t link, uint32_t dir) -> tt::tt_metal::CoreCoord {
         if (single_row_muxes) {
-            return CoreCoord(num_workers_per_link * link, single_mux_row);  // even col 2g
+            return tt::tt_metal::CoreCoord(num_workers_per_link * link, single_mux_row);  // even col 2g
         }
         if (fsdp_mux_in_column) {
-            return CoreCoord(full_grid_size.x - 1, fsdp_mux_col_row(link, dir));
+            return tt::tt_metal::CoreCoord(full_grid_size.x - 1, fsdp_mux_col_row(link, dir));
         }
         uint32_t x = (num_workers_per_link * (link + 1)) - (1 - dir);
         if (x >= full_grid_size.x) {
             x -= full_grid_size.x;
         }
         x = (x == 0) ? (full_grid_size.x - 1) : (x - 1);
-        return CoreCoord(x, full_grid_size.y - 2);
+        return tt::tt_metal::CoreCoord(x, full_grid_size.y - 2);
     };
 
     // Uni-ring (Linear): each device relays through exactly ONE mux direction — rank>0 (has a
@@ -1109,7 +1109,7 @@ all_gather_minimal_matmul_async_factory_helper(
             if (fsdp_mux_connection_valid(dir)) {
                 uint32_t link = mux_id / 2;
                 // Match the create-loop placement via the shared helper.
-                CoreCoord fsdp_mux_logical_core = fsdp_mux_logical(link, dir);
+                tt::tt_metal::CoreCoord fsdp_mux_logical_core = fsdp_mux_logical(link, dir);
 
                 std::vector<uint32_t> fsdp_mux_rt_args;
                 const auto src_node_id = device->get_fabric_node_id(sender_device_coord);
@@ -1191,13 +1191,13 @@ all_gather_minimal_matmul_async_factory_helper(
     }
 
     for (uint32_t core_id = 0; core_id < num_cores; ++core_id) {
-        CoreCoord core = cores.at(core_id);
-        CoreCoord virtual_core = device->worker_core_from_logical_core(core);
+        tt::tt_metal::CoreCoord core = cores.at(core_id);
+        tt::tt_metal::CoreCoord virtual_core = device->worker_core_from_logical_core(core);
         uint32_t in0_idx = transpose_core_grid ? core.x : core.y;
         uint32_t in1_idx = transpose_core_grid ? core.y : core.x;
 
-        CoreCoord left_core = {(std::size_t)0, (std::size_t)core.y};
-        CoreCoord top_core = {(std::size_t)core.x, (std::size_t)0};
+        tt::tt_metal::CoreCoord left_core = {(std::size_t)0, (std::size_t)core.y};
+        tt::tt_metal::CoreCoord top_core = {(std::size_t)core.x, (std::size_t)0};
 
         auto [in0_core_order, in0_core_order_index] = build_core_order_for_axis(
             core,
@@ -1286,13 +1286,13 @@ all_gather_minimal_matmul_async_factory_helper(
             const bool is_in0_backward_sender = (in0_core_order_index == (in0_core_order.size() - 2));
             if (is_in0_backward_sender) {
                 auto termination_master_logical_core_backward =
-                    transpose_core_grid ? CoreCoord(in0_idx - worker_idx, last_in0_core.y - 1)
-                                        : CoreCoord(last_in0_core.x - 1, in0_idx - worker_idx);
-                CoreCoord termination_master_virtual_core_backward =
+                    transpose_core_grid ? tt::tt_metal::CoreCoord(in0_idx - worker_idx, last_in0_core.y - 1)
+                                        : tt::tt_metal::CoreCoord(last_in0_core.x - 1, in0_idx - worker_idx);
+                tt::tt_metal::CoreCoord termination_master_virtual_core_backward =
                     device->worker_core_from_logical_core(termination_master_logical_core_backward);
 
                 auto mux_logical_core_backward = in0_mux_logical(in0_idx / num_workers_per_link, /*dir=*/0);
-                CoreCoord mux_virtual_core_backward = device->worker_core_from_logical_core(mux_logical_core_backward);
+                tt::tt_metal::CoreCoord mux_virtual_core_backward = device->worker_core_from_logical_core(mux_logical_core_backward);
                 fabric_mux_connection_rt_args(
                     mux_connection_valid(0),
                     !(in0_idx % num_workers_per_link),  // termination master at worker_idx 0
@@ -1309,13 +1309,13 @@ all_gather_minimal_matmul_async_factory_helper(
             } else {
                 // Forward fabric sender (in0_core_order_index == size - 1).
                 auto termination_master_logical_core_forward = transpose_core_grid
-                                                                   ? CoreCoord(in0_idx - worker_idx, last_in0_core.y)
-                                                                   : CoreCoord(last_in0_core.x, in0_idx - worker_idx);
-                CoreCoord termination_master_virtual_core_forward =
+                                                                   ? tt::tt_metal::CoreCoord(in0_idx - worker_idx, last_in0_core.y)
+                                                                   : tt::tt_metal::CoreCoord(last_in0_core.x, in0_idx - worker_idx);
+                tt::tt_metal::CoreCoord termination_master_virtual_core_forward =
                     device->worker_core_from_logical_core(termination_master_logical_core_forward);
 
                 auto mux_logical_core_forward = in0_mux_logical(in0_idx / num_workers_per_link, /*dir=*/1);
-                CoreCoord mux_virtual_core_forward = device->worker_core_from_logical_core(mux_logical_core_forward);
+                tt::tt_metal::CoreCoord mux_virtual_core_forward = device->worker_core_from_logical_core(mux_logical_core_forward);
                 fabric_mux_connection_rt_args(
                     mux_connection_valid(1),
                     !(in0_idx % num_workers_per_link),  // termination master at worker_idx 0
@@ -1434,7 +1434,7 @@ all_gather_minimal_matmul_async_factory_helper(
                 // The termination master is the group's worker-0 client — the backward sender of the
                 // group-base row, which sits in the chain-tail column on the in1 axis.
                 auto second_last_in1_core = in1_core_order[in1_core_order.size() - 2];
-                CoreCoord fsdp_mux_logical_backward = fsdp_mux_logical(in1_idx / num_workers_per_link, /*dir=*/0);
+                tt::tt_metal::CoreCoord fsdp_mux_logical_backward = fsdp_mux_logical(in1_idx / num_workers_per_link, /*dir=*/0);
                 // Term master = the group's worker-0 client. The layout follows the GRID orientation,
                 // not the mux placement: a transpose grid (in1 chain along X) indexes the client by its
                 // chain-tail column + group-base row; non-transpose swaps the axes. Gating on
@@ -1443,13 +1443,13 @@ all_gather_minimal_matmul_async_factory_helper(
                 // never terminated. Mirror the in0 term-master, which already gates on transpose.
                 // Scheme 3: clients now sit in the mux's column (not the chain tail), so the
                 // worker-0 term master is the column-matched core at the group-base row.
-                CoreCoord fsdp_term_master_logical_backward =
+                tt::tt_metal::CoreCoord fsdp_term_master_logical_backward =
                     single_row_muxes
-                        ? CoreCoord(num_workers_per_link * (in1_idx / num_workers_per_link), in1_idx - worker_idx)
-                    : transpose_core_grid ? CoreCoord(second_last_in1_core.x, in1_idx - worker_idx)
-                                          : CoreCoord(in1_idx - worker_idx, second_last_in1_core.y);
-                CoreCoord fsdp_mux_virtual_backward = device->worker_core_from_logical_core(fsdp_mux_logical_backward);
-                CoreCoord fsdp_term_master_virtual_backward =
+                        ? tt::tt_metal::CoreCoord(num_workers_per_link * (in1_idx / num_workers_per_link), in1_idx - worker_idx)
+                    : transpose_core_grid ? tt::tt_metal::CoreCoord(second_last_in1_core.x, in1_idx - worker_idx)
+                                          : tt::tt_metal::CoreCoord(in1_idx - worker_idx, second_last_in1_core.y);
+                tt::tt_metal::CoreCoord fsdp_mux_virtual_backward = device->worker_core_from_logical_core(fsdp_mux_logical_backward);
+                tt::tt_metal::CoreCoord fsdp_term_master_virtual_backward =
                     device->worker_core_from_logical_core(fsdp_term_master_logical_backward);
                 fabric_mux_connection_rt_args(
                     fsdp_mux_connection_valid(0),
@@ -1469,14 +1469,14 @@ all_gather_minimal_matmul_async_factory_helper(
                 // Transpose: mux in the last column at the group's forward row ((group)*2 + 1).
                 // Non-transpose: original bottom-row mux with the -1 shift. Term master = the group's
                 // worker-0 forward sender (chain tail) at the group-base row.
-                CoreCoord fsdp_mux_logical_forward = fsdp_mux_logical(in1_idx / num_workers_per_link, /*dir=*/1);
-                CoreCoord fsdp_term_master_logical_forward =
+                tt::tt_metal::CoreCoord fsdp_mux_logical_forward = fsdp_mux_logical(in1_idx / num_workers_per_link, /*dir=*/1);
+                tt::tt_metal::CoreCoord fsdp_term_master_logical_forward =
                     single_row_muxes
-                        ? CoreCoord(num_workers_per_link * (in1_idx / num_workers_per_link), in1_idx - worker_idx)
-                    : transpose_core_grid ? CoreCoord(last_in1_core.x, in1_idx - worker_idx)
-                                          : CoreCoord(in1_idx - worker_idx, last_in1_core.y);
-                CoreCoord fsdp_mux_virtual_forward = device->worker_core_from_logical_core(fsdp_mux_logical_forward);
-                CoreCoord fsdp_term_master_virtual_forward =
+                        ? tt::tt_metal::CoreCoord(num_workers_per_link * (in1_idx / num_workers_per_link), in1_idx - worker_idx)
+                    : transpose_core_grid ? tt::tt_metal::CoreCoord(last_in1_core.x, in1_idx - worker_idx)
+                                          : tt::tt_metal::CoreCoord(in1_idx - worker_idx, last_in1_core.y);
+                tt::tt_metal::CoreCoord fsdp_mux_virtual_forward = device->worker_core_from_logical_core(fsdp_mux_logical_forward);
+                tt::tt_metal::CoreCoord fsdp_term_master_virtual_forward =
                     device->worker_core_from_logical_core(fsdp_term_master_logical_forward);
                 fabric_mux_connection_rt_args(
                     fsdp_mux_connection_valid(1),

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_common.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_common.cpp
@@ -24,7 +24,7 @@ CoreRangeSet get_custom_cores(uint32_t num_workers, bool row_wise) {
     return worker_cores;
 }
 
-std::tuple<CoreRangeSet, std::vector<CoreCoord>> get_custom_worker_core_placement(uint32_t num_links) {
+std::tuple<CoreRangeSet, std::vector<tt::tt_metal::CoreCoord>> get_custom_worker_core_placement(uint32_t num_links) {
     CoreRangeSet cores = get_custom_cores(num_links);
     return {cores, corerange_to_cores(cores)};
 }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_common.hpp
@@ -11,6 +11,6 @@ namespace llama_specific {
 
 CoreRangeSet get_custom_cores(uint32_t num_workers, bool row_wise = true);
 
-std::tuple<CoreRangeSet, std::vector<CoreCoord>> get_custom_worker_core_placement(uint32_t num_links);
+std::tuple<CoreRangeSet, std::vector<tt::tt_metal::CoreCoord>> get_custom_worker_core_placement(uint32_t num_links);
 
 }  // namespace llama_specific

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_program_factory.cpp
@@ -51,15 +51,15 @@ uint32_t get_num_rows_st(const ttnn::Tensor& tensor) {
 }
 
 std::tuple<
-    std::vector<CoreCoord>,  // T cores
-    std::vector<CoreCoord>,  // MM cores
+    std::vector<tt::tt_metal::CoreCoord>,  // T cores
+    std::vector<tt::tt_metal::CoreCoord>,  // MM cores
     CoreRangeSet,            // T CoreRangeSet
     CoreRangeSet,            // MM CoreRangeSet
     CoreRangeSet,            // T + MM CoreRangeSet
     CoreRangeSet,            // Combine CoreRangeSet
     CoreRangeSet,            // C + MM CoreRangeSet
     CoreRangeSet,            // All worker cores (T + MM + C)
-    std::vector<CoreCoord>,  // Combine vector of CoreCoord
+    std::vector<tt::tt_metal::CoreCoord>,  // Combine vector of CoreCoord
     CoreRange,               // T bounding box
     CoreRange>               // MM bounding box
 get_cores(

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/moe_core_placement.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/moe_core_placement.cpp
@@ -28,7 +28,7 @@ constexpr uint32_t kMoEComputeMaxTilizeCores = 4;
 // Legacy moe_compute combine pool was 2 columns wide (e.g. x=5,6 on WH).
 constexpr uint32_t kMoEComputeCombineStripWidth = 2;
 
-CoreCoordPairSet core_coords_to_pair_set(const std::vector<CoreCoord>& cores) {
+CoreCoordPairSet core_coords_to_pair_set(const std::vector<tt::tt_metal::CoreCoord>& cores) {
     CoreCoordPairSet result;
     for (const auto& core : cores) {
         result.insert({core.x, core.y});
@@ -36,15 +36,15 @@ CoreCoordPairSet core_coords_to_pair_set(const std::vector<CoreCoord>& cores) {
     return result;
 }
 
-std::vector<CoreCoord> pick_worker_cores_row_major_avoiding(
-    const CoreCoordPairSet& avoid, const CoreCoord& worker_grid, uint32_t num_cores, uint32_t max_y_inclusive) {
-    std::vector<CoreCoord> picked;
+std::vector<tt::tt_metal::CoreCoord> pick_worker_cores_row_major_avoiding(
+    const CoreCoordPairSet& avoid, const tt::tt_metal::CoreCoord& worker_grid, uint32_t num_cores, uint32_t max_y_inclusive) {
+    std::vector<tt::tt_metal::CoreCoord> picked;
     picked.reserve(num_cores);
 
     const uint32_t y_limit = std::min(max_y_inclusive + 1, static_cast<uint32_t>(worker_grid.y));
     for (uint32_t y = 0; y < y_limit && picked.size() < num_cores; ++y) {
         for (uint32_t x = 0; x < worker_grid.x && picked.size() < num_cores; ++x) {
-            CoreCoord candidate(x, y);
+            tt::tt_metal::CoreCoord candidate(x, y);
             if (!avoid.contains({candidate.x, candidate.y})) {
                 picked.push_back(candidate);
             }
@@ -54,14 +54,14 @@ std::vector<CoreCoord> pick_worker_cores_row_major_avoiding(
     return picked;
 }
 
-std::vector<CoreCoord> pick_tilize_cores_in_upper_rows(
-    const CoreCoordPairSet& avoid, const CoreCoord& worker_grid, uint32_t num_cores, uint32_t min_y) {
-    std::vector<CoreCoord> picked;
+std::vector<tt::tt_metal::CoreCoord> pick_tilize_cores_in_upper_rows(
+    const CoreCoordPairSet& avoid, const tt::tt_metal::CoreCoord& worker_grid, uint32_t num_cores, uint32_t min_y) {
+    std::vector<tt::tt_metal::CoreCoord> picked;
     picked.reserve(num_cores);
 
     for (int y = static_cast<int>(worker_grid.y) - 1; y >= static_cast<int>(min_y) && picked.size() < num_cores; --y) {
         for (int x = static_cast<int>(worker_grid.x) - 1; x >= 0 && picked.size() < num_cores; --x) {
-            CoreCoord candidate(static_cast<uint32_t>(x), static_cast<uint32_t>(y));
+            tt::tt_metal::CoreCoord candidate(static_cast<uint32_t>(x), static_cast<uint32_t>(y));
             if (!avoid.contains({candidate.x, candidate.y})) {
                 picked.push_back(candidate);
             }
@@ -72,7 +72,7 @@ std::vector<CoreCoord> pick_tilize_cores_in_upper_rows(
 }
 
 std::optional<CoreRange> find_combine_strip_avoiding(
-    const CoreCoordPairSet& avoid, const CoreCoord& worker_grid, uint32_t strip_height, uint32_t max_y_inclusive) {
+    const CoreCoordPairSet& avoid, const tt::tt_metal::CoreCoord& worker_grid, uint32_t strip_height, uint32_t max_y_inclusive) {
     if (kMoEComputeCombineStripWidth > worker_grid.x || strip_height == 0) {
         return std::nullopt;
     }
@@ -100,12 +100,12 @@ std::optional<CoreRange> find_combine_strip_avoiding(
     return std::nullopt;
 }
 
-std::vector<CoreCoord> pick_combine_cores_from_strip(const CoreRange& strip, uint32_t num_cores) {
+std::vector<tt::tt_metal::CoreCoord> pick_combine_cores_from_strip(const CoreRange& strip, uint32_t num_cores) {
     const CoreRangeSet strip_range_set(strip);
     return corerange_to_cores(strip_range_set, num_cores, /*row_wise=*/true);
 }
 
-std::optional<CoreRange> find_tilize_2x2_block_avoiding(const CoreCoordPairSet& avoid, const CoreCoord& worker_grid) {
+std::optional<CoreRange> find_tilize_2x2_block_avoiding(const CoreCoordPairSet& avoid, const tt::tt_metal::CoreCoord& worker_grid) {
     constexpr uint32_t kTilizeBlockWidth = 2;
     constexpr uint32_t kTilizeBlockHeight = 2;
 
@@ -134,15 +134,15 @@ std::optional<CoreRange> find_tilize_2x2_block_avoiding(const CoreCoordPairSet& 
     return std::nullopt;
 }
 
-std::vector<CoreCoord> pick_tilize_cores_from_2x2_legacy_order(const CoreRange& block, uint32_t num_cores) {
+std::vector<tt::tt_metal::CoreCoord> pick_tilize_cores_from_2x2_legacy_order(const CoreRange& block, uint32_t num_cores) {
     const uint32_t sx = block.start_coord.x;
     const uint32_t sy = block.start_coord.y;
 
-    const std::vector<CoreCoord> legacy_order = {
-        CoreCoord(sx + 1, sy + 1),
-        CoreCoord(sx + 1, sy),
-        CoreCoord(sx, sy + 1),
-        CoreCoord(sx, sy),
+    const std::vector<tt::tt_metal::CoreCoord> legacy_order = {
+        tt::tt_metal::CoreCoord(sx + 1, sy + 1),
+        tt::tt_metal::CoreCoord(sx + 1, sy),
+        tt::tt_metal::CoreCoord(sx, sy + 1),
+        tt::tt_metal::CoreCoord(sx, sy),
     };
 
     TT_FATAL(
@@ -151,7 +151,7 @@ std::vector<CoreCoord> pick_tilize_cores_from_2x2_legacy_order(const CoreRange& 
         num_cores,
         legacy_order.size());
 
-    return std::vector<CoreCoord>(legacy_order.begin(), legacy_order.begin() + num_cores);
+    return std::vector<tt::tt_metal::CoreCoord>(legacy_order.begin(), legacy_order.begin() + num_cores);
 }
 
 uint32_t compute_moe_compute_tilize_num_cores(uint32_t hidden_tiles) {
@@ -191,7 +191,7 @@ void add_bbox_cells(CoreCoordPairSet& avoid, const CoreRange& bbox) {
 // gives the best locality. When it collides with mux or leaves no disjoint combine/tilize room, the
 // caller relocates matmul to build_compact_matmul_cores() instead (see its note: the compact ring must
 // stay column-0-anchored, established experimentally — [3,0]-[9,1] hangs while [0,0]-[9,1] passes).
-std::vector<CoreCoord> build_matmul_ring_cores(
+std::vector<tt::tt_metal::CoreCoord> build_matmul_ring_cores(
     ttnn::MeshDevice* mesh_device, uint32_t ring_size, const CoreCoordPairSet& mux_pairs) {
     auto cores = mesh_device->get_optimal_dram_bank_to_logical_worker_assignment(tt::tt_metal::NOC::RISCV_0_default);
     const uint32_t num_banks = static_cast<uint32_t>(cores.size());
@@ -212,7 +212,7 @@ std::vector<CoreCoord> build_matmul_ring_cores(
     const auto try_add = [&](uint32_t x, uint32_t y) {
         const std::pair<uint32_t, uint32_t> p{x, y};
         if (!used.contains(p) && !mux_pairs.contains(p)) {
-            cores.push_back(CoreCoord(x, y));
+            cores.push_back(tt::tt_metal::CoreCoord(x, y));
             used.insert(p);
         }
     };
@@ -252,9 +252,9 @@ std::vector<CoreCoord> build_matmul_ring_cores(
 // [3,0]-[9,1] hangs, while [0,0]-[9,1] and [0,3]-[9,4] pass). We therefore only use rows whose
 // leftmost (x=0) cell is mux-free (skipping a whole row otherwise); mux cells in non-leftmost columns
 // are left as gaps inside the bbox (mux inside the matmul bbox is benign, verified).
-std::vector<CoreCoord> build_compact_matmul_cores(
-    const CoreCoord& worker_grid, uint32_t ring_size, const CoreCoordPairSet& mux_pairs, uint32_t y_start) {
-    std::vector<CoreCoord> cores;
+std::vector<tt::tt_metal::CoreCoord> build_compact_matmul_cores(
+    const tt::tt_metal::CoreCoord& worker_grid, uint32_t ring_size, const CoreCoordPairSet& mux_pairs, uint32_t y_start) {
+    std::vector<tt::tt_metal::CoreCoord> cores;
     cores.reserve(ring_size);
 
     const uint32_t x_limit = worker_grid.x > kMoEComputeCombineStripWidth
@@ -271,7 +271,7 @@ std::vector<CoreCoord> build_compact_matmul_cores(
         }
         for (uint32_t x = 0; x < x_limit && cores.size() < ring_size; ++x) {
             if (!mux_pairs.contains({x, y})) {
-                cores.push_back(CoreCoord(x, y));
+                cores.push_back(tt::tt_metal::CoreCoord(x, y));
             }
         }
     }
@@ -280,8 +280,8 @@ std::vector<CoreCoord> build_compact_matmul_cores(
 }
 
 struct PlacedWorkers {
-    std::vector<CoreCoord> combine_cores;
-    std::vector<CoreCoord> tilize_cores;
+    std::vector<tt::tt_metal::CoreCoord> combine_cores;
+    std::vector<tt::tt_metal::CoreCoord> tilize_cores;
     CoreRange combine_bounding_box;
     CoreRange tilize_bounding_box;
 };
@@ -301,7 +301,7 @@ struct PlacedWorkers {
 // value that is not a divisor. The divisibility check below skips those, ensuring the first
 // accepted count is always a divisor of hidden_tiles. 1 always divides, so the loop always succeeds.
 std::optional<PlacedWorkers> place_combine_and_tilize(
-    const CoreCoord& worker_grid,
+    const tt::tt_metal::CoreCoord& worker_grid,
     const CoreRange& matmul_bounding_box,
     const CoreCoordPairSet& mux_pairs,
     uint32_t num_combine_cores,
@@ -318,7 +318,7 @@ std::optional<PlacedWorkers> place_combine_and_tilize(
     const uint32_t combine_strip_height =
         (num_combine_cores + kMoEComputeCombineStripWidth - 1) / kMoEComputeCombineStripWidth;
 
-    std::vector<CoreCoord> combine_cores;
+    std::vector<tt::tt_metal::CoreCoord> combine_cores;
     const auto combine_strip_opt =
         find_combine_strip_avoiding(base_avoid, worker_grid, combine_strip_height, combine_max_y);
     if (combine_strip_opt.has_value()) {
@@ -346,7 +346,7 @@ std::optional<PlacedWorkers> place_combine_and_tilize(
         if (hidden_tiles % tilize_num_cores != 0) {
             continue;
         }
-        std::vector<CoreCoord> tilize_cores;
+        std::vector<tt::tt_metal::CoreCoord> tilize_cores;
         const auto tilize_block_opt = find_tilize_2x2_block_avoiding(tilize_avoid, worker_grid);
         if (tilize_block_opt.has_value()) {
             tilize_cores = pick_tilize_cores_from_2x2_legacy_order(tilize_block_opt.value(), tilize_num_cores);
@@ -430,7 +430,7 @@ MoEComputeCoreSelection select_moe_compute_cores(
             ring_size);
     }
 
-    const CoreCoord worker_grid = mesh_device->compute_with_storage_grid_size();
+    const tt::tt_metal::CoreCoord worker_grid = mesh_device->compute_with_storage_grid_size();
     const uint32_t num_combine_cores = combine_token_parallel_cores * combine_data_parallel_cores;
     const uint32_t target_tilize_num_cores = compute_moe_compute_tilize_num_cores(hidden_tiles);
 
@@ -441,11 +441,11 @@ MoEComputeCoreSelection select_moe_compute_cores(
 
     // Prefer the DRAM-bank-adjacent ring; fall back to a column-0-anchored compact ring when it
     // collides with mux or leaves no disjoint combine/tilize room (WH ROW dispatch spans the grid).
-    std::vector<CoreCoord> matmul_cores;
+    std::vector<tt::tt_metal::CoreCoord> matmul_cores;
     std::optional<PlacedWorkers> placed;
     bool used_compact_matmul = false;
 
-    const std::vector<CoreCoord> dram_ring = build_matmul_ring_cores(mesh_device, ring_size, mux_pairs);
+    const std::vector<tt::tt_metal::CoreCoord> dram_ring = build_matmul_ring_cores(mesh_device, ring_size, mux_pairs);
     bool dram_ring_hits_mux = false;
     for (const auto& c : dram_ring) {
         if (mux_pairs.contains({c.x, c.y})) {
@@ -472,9 +472,9 @@ MoEComputeCoreSelection select_moe_compute_cores(
         // for a wide row-major combine group on short grids (WH 8x9 + deepseek's 16 combine cores),
         // which is the only way to get a combine bbox disjoint from the matmul bbox there. Keep the
         // first y_start that yields a fully-disjoint combine/tilize layout.
-        std::vector<CoreCoord> compact_ring;
+        std::vector<tt::tt_metal::CoreCoord> compact_ring;
         for (uint32_t y_start = 0; y_start < static_cast<uint32_t>(worker_grid.y); ++y_start) {
-            std::vector<CoreCoord> candidate = build_compact_matmul_cores(worker_grid, ring_size, mux_pairs, y_start);
+            std::vector<tt::tt_metal::CoreCoord> candidate = build_compact_matmul_cores(worker_grid, ring_size, mux_pairs, y_start);
             if (candidate.size() != ring_size) {
                 // Higher y_start can only fit fewer cores, so no point continuing.
                 break;
@@ -506,8 +506,8 @@ MoEComputeCoreSelection select_moe_compute_cores(
         used_compact_matmul = true;
     }
 
-    std::vector<CoreCoord> combine_cores = std::move(placed->combine_cores);
-    std::vector<CoreCoord> tilize_cores = std::move(placed->tilize_cores);
+    std::vector<tt::tt_metal::CoreCoord> combine_cores = std::move(placed->combine_cores);
+    std::vector<tt::tt_metal::CoreCoord> tilize_cores = std::move(placed->tilize_cores);
     const CoreRange combine_bounding_box = placed->combine_bounding_box;
     const CoreRange tilize_bounding_box = placed->tilize_bounding_box;
 
@@ -526,7 +526,7 @@ MoEComputeCoreSelection select_moe_compute_cores(
     // not hit mux, else compact ring skips mux cells; combine/tilize routed around mux), so this should
     // always hold — assert defensively so a bad layout fails loudly instead of hanging on device.
     if (!mux_pairs.empty()) {
-        const auto assert_disjoint_from_mux = [&](const std::vector<CoreCoord>& cs, const char* group) {
+        const auto assert_disjoint_from_mux = [&](const std::vector<tt::tt_metal::CoreCoord>& cs, const char* group) {
             for (const auto& c : cs) {
                 TT_FATAL(
                     !mux_pairs.contains({c.x, c.y}),

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/moe_core_placement.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/moe_core_placement.hpp
@@ -13,15 +13,15 @@
 namespace ttnn::operations::ccl::common {
 
 struct MoEComputeCoreSelection {
-    std::vector<CoreCoord> tilize_cores;
-    std::vector<CoreCoord> matmul_cores;
+    std::vector<tt::tt_metal::CoreCoord> tilize_cores;
+    std::vector<tt::tt_metal::CoreCoord> matmul_cores;
     CoreRangeSet tilize_core_range_set;
     CoreRangeSet matmul_core_range_set;
     CoreRangeSet tilize_matmul_core_range_set;
     CoreRangeSet combine_core_range_set;
     CoreRangeSet combine_matmul_core_range_set;
     CoreRangeSet all_worker_cores_range_set;
-    std::vector<CoreCoord> combine_cores;
+    std::vector<tt::tt_metal::CoreCoord> combine_cores;
     CoreRange tilize_bounding_box;
     CoreRange matmul_bounding_box;
 };

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/moe_gpt_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/moe_gpt_program_factory.cpp
@@ -27,7 +27,7 @@ uint32_t get_num_pages(const ttnn::Tensor& t) { return (uint32_t)t.buffer()->num
 uint32_t get_page_size(const ttnn::Tensor& t) { return (uint32_t)t.buffer()->page_size(); }
 uint32_t get_aligned_page_size(const ttnn::Tensor& t) { return (uint32_t)t.buffer()->aligned_page_size(); }
 
-std::string serialize_physical_core_coords(const std::vector<CoreCoord>& cores, tt::tt_metal::IDevice* device) {
+std::string serialize_physical_core_coords(const std::vector<tt::tt_metal::CoreCoord>& cores, tt::tt_metal::IDevice* device) {
     std::vector<uint32_t> flat_physical_core_coords;
     flat_physical_core_coords.reserve(2 * cores.size());
 

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/gather.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/gather.cpp
@@ -21,8 +21,8 @@ inline void append_or_extend_transfer(
     std::vector<GatherTransfer>& transfers,
     uint32_t input_core_idx,
     uint32_t output_core_idx,
-    const std::vector<CoreCoord>& input_cores,
-    const std::vector<CoreCoord>& output_cores,
+    const std::vector<tt::tt_metal::CoreCoord>& input_cores,
+    const std::vector<tt::tt_metal::CoreCoord>& output_cores,
     uint32_t input_offset_within_shard,
     uint32_t output_offset_within_shard,
     uint32_t channel,
@@ -57,8 +57,8 @@ std::vector<GatherTransfer> generate_gather_transfers(
     uint32_t B,
     uint32_t C,
     uint32_t HW,
-    const std::vector<CoreCoord>& input_cores,
-    const std::vector<CoreCoord>& output_cores,
+    const std::vector<tt::tt_metal::CoreCoord>& input_cores,
+    const std::vector<tt::tt_metal::CoreCoord>& output_cores,
     std::optional<uint32_t> output_shard_width_override) {
     std::vector<GatherTransfer> transfers;
     const uint32_t num_input_cores = input_cores.size();
@@ -132,8 +132,8 @@ std::vector<GatherTransfer> precompute_gather_transfers(
     uint32_t B,
     uint32_t C,
     uint32_t HW,
-    const std::vector<CoreCoord>& input_cores,
-    const std::vector<CoreCoord>& output_cores) {
+    const std::vector<tt::tt_metal::CoreCoord>& input_cores,
+    const std::vector<tt::tt_metal::CoreCoord>& output_cores) {
     return generate_gather_transfers(B, C, HW, input_cores, output_cores, std::nullopt);
 }
 
@@ -142,8 +142,8 @@ std::vector<GatherTransfer> precompute_gather_transfers(
     uint32_t B,
     uint32_t C,
     uint32_t HW,
-    const std::vector<CoreCoord>& input_cores,
-    const std::vector<CoreCoord>& output_cores,
+    const std::vector<tt::tt_metal::CoreCoord>& input_cores,
+    const std::vector<tt::tt_metal::CoreCoord>& output_cores,
     uint32_t output_shard_width_override) {
     return generate_gather_transfers(
         B, C, HW, input_cores, output_cores, std::optional<uint32_t>(output_shard_width_override));
@@ -154,7 +154,7 @@ std::vector<LowLevelGatherTransfer> lower_gather_transfers(
     uint32_t /*B*/,
     uint32_t C,
     uint32_t HW,
-    const std::vector<CoreCoord>& input_cores,
+    const std::vector<tt::tt_metal::CoreCoord>& input_cores,
     uint32_t /*num_output_cores*/,
     uint32_t element_size_bytes,
     uint32_t output_shard_width) {
@@ -208,7 +208,7 @@ BlockedTransfersWithCount group_transfers_by_output_column_blocks(
     uint32_t B,
     uint32_t C,
     uint32_t HW,
-    const std::vector<CoreCoord>& input_cores,
+    const std::vector<tt::tt_metal::CoreCoord>& input_cores,
     uint32_t num_output_cores,
     uint32_t element_size_bytes,
     uint32_t block_size,
@@ -407,7 +407,7 @@ std::vector<BlockedTransferGroup> coalesce_contiguous_transfers(
 }
 
 std::vector<GatherTransfer> precompute_gather_transfers(
-    const Tensor& input, const std::vector<CoreCoord>& output_cores) {
+    const Tensor& input, const std::vector<tt::tt_metal::CoreCoord>& output_cores) {
     // Extract tensor properties
     const auto& input_shape = input.logical_shape();
     uint32_t B = input_shape[1];   // Batch size
@@ -419,7 +419,7 @@ std::vector<GatherTransfer> precompute_gather_transfers(
 
     const auto& shard_spec = input.shard_spec().value();
     const auto& core_grid = shard_spec.grid;
-    std::vector<CoreCoord> input_cores = corerange_to_cores(
+    std::vector<tt::tt_metal::CoreCoord> input_cores = corerange_to_cores(
         core_grid, std::nullopt, shard_spec.orientation == tt::tt_metal::ShardOrientation::ROW_MAJOR);
 
     // Call the original implementation

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/gather.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/gather.hpp
@@ -24,8 +24,8 @@ namespace ttnn::experimental::prim {
 struct GatherTransfer {
     uint32_t src_core_idx;
     uint32_t dst_core_idx;
-    CoreCoord src_core_coord;
-    CoreCoord dst_core_coord;
+    tt::tt_metal::CoreCoord src_core_coord;
+    tt::tt_metal::CoreCoord dst_core_coord;
     uint32_t src_offset;  // Offset within source shard (in elements)
     uint32_t dst_offset;  // Offset within destination shard (in elements)
     uint32_t length;      // Number of elements to transfer
@@ -35,8 +35,8 @@ struct GatherTransfer {
     GatherTransfer(
         uint32_t sc_idx,
         uint32_t dc_idx,
-        const CoreCoord& sc_coord,
-        const CoreCoord& dc_coord,
+        const tt::tt_metal::CoreCoord& sc_coord,
+        const tt::tt_metal::CoreCoord& dc_coord,
         uint32_t s_off,
         uint32_t d_off,
         uint32_t len,
@@ -148,16 +148,16 @@ std::vector<GatherTransfer> precompute_gather_transfers(
     uint32_t B,
     uint32_t C,
     uint32_t HW,
-    const std::vector<CoreCoord>& input_cores,
-    const std::vector<CoreCoord>& output_cores);
+    const std::vector<tt::tt_metal::CoreCoord>& input_cores,
+    const std::vector<tt::tt_metal::CoreCoord>& output_cores);
 
 // Variant that allows overriding the per-output-core width (useful for uneven output sharding)
 std::vector<GatherTransfer> precompute_gather_transfers(
     uint32_t B,
     uint32_t C,
     uint32_t HW,
-    const std::vector<CoreCoord>& input_cores,
-    const std::vector<CoreCoord>& output_cores,
+    const std::vector<tt::tt_metal::CoreCoord>& input_cores,
+    const std::vector<tt::tt_metal::CoreCoord>& output_cores,
     uint32_t output_shard_width_override);
 
 /**
@@ -180,7 +180,7 @@ std::vector<LowLevelGatherTransfer> lower_gather_transfers(
     uint32_t B,
     uint32_t C,
     uint32_t HW,
-    const std::vector<CoreCoord>& input_cores,
+    const std::vector<tt::tt_metal::CoreCoord>& input_cores,
     uint32_t num_output_cores,
     uint32_t element_size_bytes,
     uint32_t output_shard_width);
@@ -209,7 +209,7 @@ BlockedTransfersWithCount group_transfers_by_output_column_blocks(
     uint32_t B,
     uint32_t C,
     uint32_t HW,
-    const std::vector<CoreCoord>& input_cores,
+    const std::vector<tt::tt_metal::CoreCoord>& input_cores,
     uint32_t num_output_cores,
     uint32_t element_size_bytes,
     uint32_t block_size,
@@ -226,7 +226,7 @@ BlockedTransfersWithCount group_transfers_by_output_column_blocks(
  * @return Vector of GatherTransfer objects sorted by source for optimal cache access
  */
 std::vector<GatherTransfer> precompute_gather_transfers(
-    const Tensor& input, const std::vector<CoreCoord>& output_cores);
+    const Tensor& input, const std::vector<tt::tt_metal::CoreCoord>& output_cores);
 
 /**
  * @brief Tensor-based interface for blocked transfer grouping
@@ -300,10 +300,10 @@ inline uint32_t elements_to_bytes(uint32_t element_count, uint32_t element_size)
 inline void serialize_low_level_transfer(
     const LowLevelGatherTransfer& transfer,
     std::vector<uint32_t>& output,
-    const std::vector<CoreCoord>& input_cores,
-    const std::function<CoreCoord(const CoreCoord&)>& logical_to_worker_core) {
+    const std::vector<tt::tt_metal::CoreCoord>& input_cores,
+    const std::function<tt::tt_metal::CoreCoord(const tt::tt_metal::CoreCoord&)>& logical_to_worker_core) {
     // Convert logical core coordinates to worker core coordinates
-    CoreCoord logical_core = input_cores[transfer.src_shard_idx];
+    tt::tt_metal::CoreCoord logical_core = input_cores[transfer.src_shard_idx];
     auto worker_core = logical_to_worker_core(logical_core);
 
     // Kernel pulls data from input so only source core x/y is required
@@ -319,8 +319,8 @@ inline void serialize_low_level_transfer(
 
 inline std::vector<uint32_t> serialize_blocked_transfer_groups(
     const std::vector<BlockedTransferGroup>& groups,
-    const std::vector<CoreCoord>& input_cores,
-    const std::function<CoreCoord(const CoreCoord&)>& logical_to_worker_core) {
+    const std::vector<tt::tt_metal::CoreCoord>& input_cores,
+    const std::function<tt::tt_metal::CoreCoord(const tt::tt_metal::CoreCoord&)>& logical_to_worker_core) {
     std::vector<uint32_t> output;
     const uint32_t number_of_blocks = groups.size();
     output.push_back(number_of_blocks);

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_device_operation_types.hpp
@@ -24,7 +24,7 @@ struct Conv3dConfig {
         uint32_t C_in_block_ = 0,
         std::array<uint32_t, 3> dilation_ = {1, 1, 1},
         uint32_t alignment_ = 32,
-        CoreCoord compute_with_storage_grid_size_ = {1, 1}) :
+        tt::tt_metal::CoreCoord compute_with_storage_grid_size_ = {1, 1}) :
         weights_dtype(weights_dtype_),
         output_layout(output_layout_),
         T_out_block(T_out_block_),
@@ -45,7 +45,7 @@ struct Conv3dConfig {
     uint32_t C_in_block;
     std::array<uint32_t, 3> dilation;
     uint32_t alignment;
-    CoreCoord compute_with_storage_grid_size;
+    tt::tt_metal::CoreCoord compute_with_storage_grid_size;
 
     static constexpr auto attribute_names = std::make_tuple(
         "weights_dtype",

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/inbound_socket_service_sync/device/inbound_socket_service_sync_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/inbound_socket_service_sync/device/inbound_socket_service_sync_device_operation_types.hpp
@@ -23,7 +23,7 @@ struct InboundSocketServiceSyncParams {
     uint32_t scratch_cb_index = 0;
     uint32_t metadata_size_bytes = 0;  // 0 disables the metadata path
     tt::tt_metal::DeviceAddr metadata_l1_addr = 0;
-    CoreRange worker_cores{CoreCoord{0, 0}, CoreCoord{0, 0}};
+    CoreRange worker_cores{tt::tt_metal::CoreCoord{0, 0}, tt::tt_metal::CoreCoord{0, 0}};
 
     // Per-mesh-coordinate state, indexed row-major as (row * mesh_num_cols + col).
     // The service core (and thus the consumed-counter address) may differ per

--- a/ttnn/cpp/ttnn/operations/experimental/fusion/device/fusion_dispatch_op_helpers.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/fusion/device/fusion_dispatch_op_helpers.hpp
@@ -60,7 +60,7 @@ inline std::vector<std::pair<uint32_t, uint32_t>> compute_cb_io_tensor_map(
 /// Slot: a per-core runtime arg that holds an IO tensor address.
 struct PerCoreRTArgSlot {
     std::uint32_t kernel_idx;
-    CoreCoord core;
+    tt::tt_metal::CoreCoord core;
     std::uint32_t arg_idx;
     std::uint32_t io_tensor_index;
 };
@@ -83,7 +83,7 @@ struct CBSlot {
 /// at dispatch time (order matches the build-time allocation order).
 struct SemaphoreRTArgSlot {
     std::uint32_t kernel_idx;
-    CoreCoord core;
+    tt::tt_metal::CoreCoord core;
     std::uint32_t arg_idx;
     std::uint32_t sem_index;
 };

--- a/ttnn/cpp/ttnn/operations/experimental/matmul/attn_matmul/device/attn_matmul_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/matmul/attn_matmul/device/attn_matmul_device_operation_types.hpp
@@ -12,7 +12,7 @@ namespace ttnn::experimental::prim {
 struct AttnMatmulParams {
     const std::optional<const uint32_t> num_tokens;
     const std::optional<const bool> transpose_hw;
-    const CoreCoord compute_with_storage_grid_size;
+    const tt::tt_metal::CoreCoord compute_with_storage_grid_size;
     const tt::tt_metal::MemoryConfig output_mem_config;
     const tt::tt_metal::DataType output_dtype;
     const ttnn::DeviceComputeKernelConfig compute_kernel_config;

--- a/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/device/group_attn_matmul_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/device/group_attn_matmul_device_operation_types.hpp
@@ -13,7 +13,7 @@ struct GroupAttnMatmulParams {
     std::optional<const uint32_t> num_tokens;
     std::optional<const bool> transpose_hw;
     const uint32_t out_subblock_w;
-    CoreCoord compute_with_storage_grid_size;
+    tt::tt_metal::CoreCoord compute_with_storage_grid_size;
     tt::tt_metal::MemoryConfig output_mem_config;
     tt::tt_metal::DataType output_dtype;
     const bool row_major;  // Specifies how work is distributed across cores

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/config/matmul_program_config.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/config/matmul_program_config.hpp
@@ -24,7 +24,7 @@ MatmulProgramConfig create_simple_matmul_program_config(
     bool transpose_b,
     uint32_t bias_single_tile_size,
     const std::optional<const ttnn::DeviceComputeKernelConfig>& compute_kernel_config,
-    const CoreCoord& compute_with_storage_grid_size,
+    const tt::tt_metal::CoreCoord& compute_with_storage_grid_size,
     const tt::tt_metal::MemoryConfig& mem_config,
     tt::tt_metal::DataType output_dtype);
 

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/config/matmul_program_config_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/config/matmul_program_config_types.hpp
@@ -13,7 +13,7 @@ namespace ttnn::operations::experimental::quasar::matmul {
 // TODO: Uplift this to support bcast batch for in1; currently, only allows B=1
 // for in1 iff B=1 for in0 (ie. single core)
 struct MatmulMultiCoreReuseProgramConfig {
-    CoreCoord compute_with_storage_grid_size;
+    tt::tt_metal::CoreCoord compute_with_storage_grid_size;
     std::size_t in0_block_w{};
     std::size_t out_subblock_h{};
     std::size_t out_subblock_w{};
@@ -23,7 +23,7 @@ struct MatmulMultiCoreReuseProgramConfig {
 };
 
 struct MatmulMultiCoreReuseMultiCastProgramConfig {
-    CoreCoord compute_with_storage_grid_size;
+    tt::tt_metal::CoreCoord compute_with_storage_grid_size;
     std::size_t in0_block_w{};
     std::size_t out_subblock_h{};
     std::size_t out_subblock_w{};
@@ -50,7 +50,7 @@ struct MatmulMultiCoreReuseMultiCastProgramConfig {
 // When `gather_in0 == true`, `compute_with_storage_grid_size` is ignored and the gather path
 // can run on any sub-device worker layout, including non-rectangular ones.
 struct MatmulMultiCoreReuseMultiCast1DProgramConfig {
-    CoreCoord compute_with_storage_grid_size;
+    tt::tt_metal::CoreCoord compute_with_storage_grid_size;
     std::size_t in0_block_w{};
     std::size_t out_subblock_h{};
     std::size_t out_subblock_w{};
@@ -99,9 +99,9 @@ using MatmulProgramConfig = std::variant<
 // synthesized from compute_with_storage_grid_size (or from the device grid for
 // MatmulMultiCoreProgramConfig).  After this call, factories can read
 // config.allowed_worker_cores.value() unconditionally.
-inline void normalize_program_config(MatmulProgramConfig& config, const CoreCoord& device_grid) {
-    auto make_crs = [](const CoreCoord& grid) {
-        return CoreRangeSet(CoreRange(CoreCoord(0, 0), CoreCoord(grid.x - 1, grid.y - 1)));
+inline void normalize_program_config(MatmulProgramConfig& config, const tt::tt_metal::CoreCoord& device_grid) {
+    auto make_crs = [](const tt::tt_metal::CoreCoord& grid) {
+        return CoreRangeSet(CoreRange(tt::tt_metal::CoreCoord(0, 0), tt::tt_metal::CoreCoord(grid.x - 1, grid.y - 1)));
     };
     std::visit(
         [&](auto& c) {

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/matmul_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/matmul_device_operation_types.hpp
@@ -19,7 +19,7 @@ struct MatmulParams {
     std::optional<tt::tt_metal::DataType> output_dtype = std::nullopt;
     std::optional<ttnn::DeviceComputeKernelConfig> compute_kernel_config = std::nullopt;
     bool untilize_out = false;
-    std::optional<CoreCoord> user_core_coord = std::nullopt;
+    std::optional<tt::tt_metal::CoreCoord> user_core_coord = std::nullopt;
     std::optional<ttnn::operations::unary::UnaryWithParam> user_fused_activation = std::nullopt;
     bool user_run_batched = false;
     bool transpose_a = false;

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/sparse/sparse_matmul_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/sparse/sparse_matmul_device_operation_types.hpp
@@ -20,7 +20,7 @@ struct SparseMatmulParams {
     tt::tt_metal::MemoryConfig output_mem_config = tt::tt_metal::operation::DEFAULT_OUTPUT_MEMORY_CONFIG;
     std::optional<tt::tt_metal::DataType> output_dtype = std::nullopt;
     std::optional<DeviceComputeKernelConfig> compute_kernel_config = std::nullopt;
-    std::optional<const CoreCoord> user_core_coord = std::nullopt;
+    std::optional<const tt::tt_metal::CoreCoord> user_core_coord = std::nullopt;
     std::optional<const tt::tt_metal::Tile> output_tile;
     std::optional<const tt::tt_metal::experimental::GlobalCircularBuffer> global_cb;
     std::optional<tt::tt_metal::SubDeviceId> sub_device_id;

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/utilities/matmul_utilities.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/utilities/matmul_utilities.cpp
@@ -362,21 +362,21 @@ void get_max_page_size_and_num_pages(
     num_pages = total_size / page_size;
 }
 
-void move_common_entries(std::vector<CoreCoord>& v1, std::vector<CoreCoord>& v2, std::vector<CoreCoord>& commons) {
-    for (const CoreCoord& item : v2) {
+void move_common_entries(std::vector<tt::tt_metal::CoreCoord>& v1, std::vector<tt::tt_metal::CoreCoord>& v2, std::vector<tt::tt_metal::CoreCoord>& commons) {
+    for (const tt::tt_metal::CoreCoord& item : v2) {
         if (std::find(v1.begin(), v1.end(), item) != v1.end()) {
             commons.push_back(item);
         }
     }
 
-    for (const CoreCoord& item : commons) {
+    for (const tt::tt_metal::CoreCoord& item : commons) {
         v2.erase(std::remove(v2.begin(), v2.end(), item), v2.end());
     }
 }
 
 void get_optimal_dram_bank_to_reader_assignment(
     tt::tt_metal::IDevice* device,
-    std::vector<CoreCoord>& all_worker_cores_ordered,
+    std::vector<tt::tt_metal::CoreCoord>& all_worker_cores_ordered,
     CoreRangeSet& all_worker_cores,
     tt::tt_metal::NOC noc) {
     all_worker_cores_ordered = device->get_optimal_dram_bank_to_logical_worker_assignment(noc);

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/utilities/matmul_utilities.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/utilities/matmul_utilities.hpp
@@ -352,11 +352,11 @@ tt::tt_metal::IDevice* get_device_for_dram_banks(const ttnn::Tensor& a, const tt
 void get_max_page_size_and_num_pages(
     tt::tt_metal::IDevice* device, uint32_t num_tiles, uint32_t tile_size, uint32_t& page_size, uint32_t& num_pages);
 
-void move_common_entries(std::vector<CoreCoord>& v1, std::vector<CoreCoord>& v2, std::vector<CoreCoord>& commons);
+void move_common_entries(std::vector<tt::tt_metal::CoreCoord>& v1, std::vector<tt::tt_metal::CoreCoord>& v2, std::vector<tt::tt_metal::CoreCoord>& commons);
 
 void get_optimal_dram_bank_to_reader_assignment(
     tt::tt_metal::IDevice* device,
-    std::vector<CoreCoord>& all_worker_cores_ordered,
+    std::vector<tt::tt_metal::CoreCoord>& all_worker_cores_ordered,
     CoreRangeSet& all_worker_cores,
     tt::tt_metal::NOC noc);
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/split_query_key_value_and_split_heads/device/split_query_key_value_and_split_heads_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/split_query_key_value_and_split_heads/device/split_query_key_value_and_split_heads_device_operation_types.hpp
@@ -12,7 +12,7 @@
 namespace ttnn::experimental::prim {
 
 struct SplitQueryKeyValueAndSplitHeadsParams {
-    CoreCoord compute_with_storage_grid_size;
+    tt::tt_metal::CoreCoord compute_with_storage_grid_size;
     tt::tt_metal::MemoryConfig output_mem_config;
     uint32_t num_heads{};
 };

--- a/ttnn/cpp/ttnn/operations/matmul/device/config/matmul_program_config.hpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/config/matmul_program_config.hpp
@@ -24,7 +24,7 @@ MatmulProgramConfig create_simple_matmul_program_config(
     bool transpose_b,
     uint32_t bias_single_tile_size,
     const std::optional<const ttnn::DeviceComputeKernelConfig>& compute_kernel_config,
-    const CoreCoord& compute_with_storage_grid_size,
+    const tt::tt_metal::CoreCoord& compute_with_storage_grid_size,
     const tt::tt_metal::MemoryConfig& mem_config,
     tt::tt_metal::DataType output_dtype);
 

--- a/ttnn/cpp/ttnn/operations/matmul/device/config/matmul_program_config_types.hpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/config/matmul_program_config_types.hpp
@@ -13,7 +13,7 @@ namespace ttnn::operations::matmul {
 // TODO: Uplift this to support bcast batch for in1; currently, only allows B=1
 // for in1 iff B=1 for in0 (ie. single core)
 struct MatmulMultiCoreReuseProgramConfig {
-    CoreCoord compute_with_storage_grid_size;
+    tt::tt_metal::CoreCoord compute_with_storage_grid_size;
     std::size_t in0_block_w{};
     std::size_t out_subblock_h{};
     std::size_t out_subblock_w{};
@@ -23,7 +23,7 @@ struct MatmulMultiCoreReuseProgramConfig {
 };
 
 struct MatmulMultiCoreReuseMultiCastProgramConfig {
-    CoreCoord compute_with_storage_grid_size;
+    tt::tt_metal::CoreCoord compute_with_storage_grid_size;
     std::size_t in0_block_w{};
     std::size_t out_subblock_h{};
     std::size_t out_subblock_w{};
@@ -50,7 +50,7 @@ struct MatmulMultiCoreReuseMultiCastProgramConfig {
 // When `gather_in0 == true`, `compute_with_storage_grid_size` is ignored and the gather path
 // can run on any sub-device worker layout, including non-rectangular ones.
 struct MatmulMultiCoreReuseMultiCast1DProgramConfig {
-    CoreCoord compute_with_storage_grid_size;
+    tt::tt_metal::CoreCoord compute_with_storage_grid_size;
     std::size_t in0_block_w{};
     std::size_t out_subblock_h{};
     std::size_t out_subblock_w{};
@@ -106,9 +106,9 @@ using MatmulProgramConfig = std::variant<
 // synthesized from compute_with_storage_grid_size (or from the device grid for
 // MatmulMultiCoreProgramConfig).  After this call, factories can read
 // config.allowed_worker_cores.value() unconditionally.
-inline void normalize_program_config(MatmulProgramConfig& config, const CoreCoord& device_grid) {
-    auto make_crs = [](const CoreCoord& grid) {
-        return CoreRangeSet(CoreRange(CoreCoord(0, 0), CoreCoord(grid.x - 1, grid.y - 1)));
+inline void normalize_program_config(MatmulProgramConfig& config, const tt::tt_metal::CoreCoord& device_grid) {
+    auto make_crs = [](const tt::tt_metal::CoreCoord& grid) {
+        return CoreRangeSet(CoreRange(tt::tt_metal::CoreCoord(0, 0), tt::tt_metal::CoreCoord(grid.x - 1, grid.y - 1)));
     };
     std::visit(
         [&](auto& c) {

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation_types.hpp
@@ -19,7 +19,7 @@ struct MatmulParams {
     std::optional<tt::tt_metal::DataType> output_dtype = std::nullopt;
     std::optional<ttnn::DeviceComputeKernelConfig> compute_kernel_config = std::nullopt;
     bool untilize_out = false;
-    std::optional<CoreCoord> user_core_coord = std::nullopt;
+    std::optional<tt::tt_metal::CoreCoord> user_core_coord = std::nullopt;
     std::optional<ttnn::operations::unary::UnaryWithParam> user_fused_activation = std::nullopt;
     bool user_run_batched = false;
     bool transpose_a = false;

--- a/ttnn/cpp/ttnn/operations/matmul/device/sparse/sparse_matmul_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/sparse/sparse_matmul_device_operation_types.hpp
@@ -20,7 +20,7 @@ struct SparseMatmulParams {
     tt::tt_metal::MemoryConfig output_mem_config = tt::tt_metal::operation::DEFAULT_OUTPUT_MEMORY_CONFIG;
     std::optional<tt::tt_metal::DataType> output_dtype = std::nullopt;
     std::optional<DeviceComputeKernelConfig> compute_kernel_config = std::nullopt;
-    std::optional<const CoreCoord> user_core_coord = std::nullopt;
+    std::optional<const tt::tt_metal::CoreCoord> user_core_coord = std::nullopt;
     std::optional<const tt::tt_metal::Tile> output_tile;
     std::optional<const tt::tt_metal::experimental::GlobalCircularBuffer> global_cb;
     std::optional<tt::tt_metal::SubDeviceId> sub_device_id;

--- a/ttnn/cpp/ttnn/operations/matmul/device/utilities/matmul_utilities.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/utilities/matmul_utilities.cpp
@@ -366,21 +366,21 @@ void get_max_page_size_and_num_pages(
     num_pages = total_size / page_size;
 }
 
-void move_common_entries(std::vector<CoreCoord>& v1, std::vector<CoreCoord>& v2, std::vector<CoreCoord>& commons) {
-    for (const CoreCoord& item : v2) {
+void move_common_entries(std::vector<tt::tt_metal::CoreCoord>& v1, std::vector<tt::tt_metal::CoreCoord>& v2, std::vector<tt::tt_metal::CoreCoord>& commons) {
+    for (const tt::tt_metal::CoreCoord& item : v2) {
         if (std::find(v1.begin(), v1.end(), item) != v1.end()) {
             commons.push_back(item);
         }
     }
 
-    for (const CoreCoord& item : commons) {
+    for (const tt::tt_metal::CoreCoord& item : commons) {
         v2.erase(std::remove(v2.begin(), v2.end(), item), v2.end());
     }
 }
 
 void get_optimal_dram_bank_to_reader_assignment(
     tt::tt_metal::IDevice* device,
-    std::vector<CoreCoord>& all_worker_cores_ordered,
+    std::vector<tt::tt_metal::CoreCoord>& all_worker_cores_ordered,
     CoreRangeSet& all_worker_cores,
     tt::tt_metal::NOC noc) {
     all_worker_cores_ordered = device->get_optimal_dram_bank_to_logical_worker_assignment(noc);

--- a/ttnn/cpp/ttnn/operations/matmul/device/utilities/matmul_utilities.hpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/utilities/matmul_utilities.hpp
@@ -358,11 +358,11 @@ tt::tt_metal::IDevice* get_device_for_dram_banks(const ttnn::Tensor& a, const tt
 void get_max_page_size_and_num_pages(
     tt::tt_metal::IDevice* device, uint32_t num_tiles, uint32_t tile_size, uint32_t& page_size, uint32_t& num_pages);
 
-void move_common_entries(std::vector<CoreCoord>& v1, std::vector<CoreCoord>& v2, std::vector<CoreCoord>& commons);
+void move_common_entries(std::vector<tt::tt_metal::CoreCoord>& v1, std::vector<tt::tt_metal::CoreCoord>& v2, std::vector<tt::tt_metal::CoreCoord>& commons);
 
 void get_optimal_dram_bank_to_reader_assignment(
     tt::tt_metal::IDevice* device,
-    std::vector<CoreCoord>& all_worker_cores_ordered,
+    std::vector<tt::tt_metal::CoreCoord>& all_worker_cores_ordered,
     CoreRangeSet& all_worker_cores,
     tt::tt_metal::NOC noc);
 

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_program_factory.cpp
@@ -26,7 +26,7 @@ void populate_runtime_arguments(
     tt::tt_metal::KernelDescriptor& reader_desc,
     tt::tt_metal::KernelDescriptor& writer_desc,
     tt::tt_metal::KernelDescriptor& compute_desc,
-    CoreCoord compute_with_storage_grid_size,
+    tt::tt_metal::CoreCoord compute_with_storage_grid_size,
     bool any_float32,
     const BatchNormOperation::operation_attributes_t& operation_attributes,
     const BatchNormOperation::tensor_args_t& tensor_args,

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/running_statistics_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/running_statistics_program_factory.cpp
@@ -26,7 +26,7 @@ void populate_runtime_arguments(
     tt::tt_metal::KernelDescriptor& reader_desc,
     tt::tt_metal::KernelDescriptor& writer_desc,
     tt::tt_metal::KernelDescriptor& compute_desc,
-    CoreCoord compute_with_storage_grid_size,
+    tt::tt_metal::CoreCoord compute_with_storage_grid_size,
     bool any_float32,
     const RunningStatistics::operation_attributes_t& operation_attributes,
     const RunningStatistics::tensor_args_t& tensor_args,

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_device_operation_types.hpp
@@ -14,7 +14,7 @@ namespace ttnn::prim {
 
 // Program config types
 struct GroupNormMultiCoreProgramConfig {
-    CoreCoord compute_with_storage_grid_size;
+    tt::tt_metal::CoreCoord compute_with_storage_grid_size;
     tt::tt_metal::DataType im_data_format{tt::tt_metal::DataType::INVALID};
     tt::tt_metal::DataType out_data_format{tt::tt_metal::DataType::INVALID};
     bool inplace{};
@@ -29,7 +29,7 @@ struct GroupNormMultiCoreProgramConfig {
 };
 
 struct GroupNormShardedMultiCoreProgramConfig {
-    CoreCoord compute_with_storage_grid_size;
+    tt::tt_metal::CoreCoord compute_with_storage_grid_size;
     tt::tt_metal::DataType im_data_format{tt::tt_metal::DataType::INVALID};
     tt::tt_metal::DataType out_data_format{tt::tt_metal::DataType::INVALID};
     bool inplace{};

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_program_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_program_utils.cpp
@@ -22,7 +22,7 @@ int get_max_subblock(uint32_t n, uint32_t max_subblock_w) {
     return 1;
 }
 
-bool is_rectangle_grid(const std::vector<CoreCoord>& core_coords) {
+bool is_rectangle_grid(const std::vector<tt::tt_metal::CoreCoord>& core_coords) {
     if (core_coords.empty()) {
         return true;
     }
@@ -43,17 +43,17 @@ bool is_rectangle_grid(const std::vector<CoreCoord>& core_coords) {
 }
 
 void split_and_form_rectangle_grids(
-    std::vector<CoreCoord>& group,
-    std::vector<CoreCoord>& mcast_group_first,
-    std::vector<CoreCoord>& mcast_group_mid,
-    std::vector<CoreCoord>& mcast_group_last) {
+    std::vector<tt::tt_metal::CoreCoord>& group,
+    std::vector<tt::tt_metal::CoreCoord>& mcast_group_first,
+    std::vector<tt::tt_metal::CoreCoord>& mcast_group_mid,
+    std::vector<tt::tt_metal::CoreCoord>& mcast_group_last) {
     size_t remove_front = 0;
     size_t remove_back = 0;
     size_t min_total_removal = group.size();
 
     for (size_t front = 0; front <= group.size(); ++front) {
         for (size_t back = 0; front + back <= group.size(); ++back) {
-            if (is_rectangle_grid(std::vector<CoreCoord>(group.begin() + front, group.end() - back))) {
+            if (is_rectangle_grid(std::vector<tt::tt_metal::CoreCoord>(group.begin() + front, group.end() - back))) {
                 size_t total_removal = front + back;
                 if (total_removal < min_total_removal) {
                     min_total_removal = total_removal;

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_program_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_program_utils.hpp
@@ -15,13 +15,13 @@ enum class GroupNormMode : uint32_t { LEGACY = 0, WELFORD_NATIVE = 1, WELFORD_RE
 
 int get_max_subblock(uint32_t n, uint32_t max_subblock_w);
 
-bool is_rectangle_grid(const std::vector<CoreCoord>& core_coords);
+bool is_rectangle_grid(const std::vector<tt::tt_metal::CoreCoord>& core_coords);
 
 void split_and_form_rectangle_grids(
-    std::vector<CoreCoord>& group,
-    std::vector<CoreCoord>& mcast_group_first,
-    std::vector<CoreCoord>& mcast_group_mid,
-    std::vector<CoreCoord>& mcast_group_last);
+    std::vector<tt::tt_metal::CoreCoord>& group,
+    std::vector<tt::tt_metal::CoreCoord>& mcast_group_first,
+    std::vector<tt::tt_metal::CoreCoord>& mcast_group_mid,
+    std::vector<tt::tt_metal::CoreCoord>& mcast_group_last);
 
 std::pair<uint32_t, uint32_t> find_max_tile_span(uint32_t W, uint32_t group_size, uint32_t tile_width = 32);
 

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_types.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_types.hpp
@@ -22,7 +22,7 @@ struct LayerNormDefaultProgramConfig {
     bool use_welford = false;
 };
 struct LayerNormShardedMultiCoreProgramConfig {
-    CoreCoord compute_with_storage_grid_size;
+    tt::tt_metal::CoreCoord compute_with_storage_grid_size;
     std::size_t subblock_w{};
     std::size_t block_h{};
     std::size_t block_w{};

--- a/ttnn/cpp/ttnn/operations/normalization/shard_spec_validation.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/shard_spec_validation.hpp
@@ -30,6 +30,6 @@ namespace ttnn::operations::normalization::detail {
 // known to support shard widths that are not a multiple of the tile width
 // (currently: groupnorm).
 void validate_sharded_input(
-    const ttnn::Tensor& tensor, const CoreCoord& program_grid_size, bool require_shard_width_tile_aligned = true);
+    const ttnn::Tensor& tensor, const tt::tt_metal::CoreCoord& program_grid_size, bool require_shard_width_tile_aligned = true);
 
 }  // namespace ttnn::operations::normalization::detail

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_operation_types.hpp
@@ -15,7 +15,7 @@ namespace ttnn {
 // Softmax program configuration structs
 struct SoftmaxDefaultProgramConfig {};
 struct SoftmaxShardedMultiCoreProgramConfig {
-    CoreCoord compute_with_storage_grid_size;
+    tt::tt_metal::CoreCoord compute_with_storage_grid_size;
     std::size_t subblock_w{};
     std::size_t block_h{};
     std::size_t block_w{};

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/device/ema_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/device/ema_device_operation_types.hpp
@@ -12,7 +12,7 @@ namespace ttnn::prim {
 
 struct EmaParams {
     float alpha{};
-    CoreCoord grid_size;
+    tt::tt_metal::CoreCoord grid_size;
     tt::tt_metal::MemoryConfig output_mem_config;
     DeviceComputeKernelConfig compute_kernel_config;
 };

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_fusion.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_fusion.hpp
@@ -13,7 +13,7 @@ namespace ttnn::prim {
 
 struct RingSDPAFusedOpSignaler {
     uint32_t num_fused_op_cores_to_signal = 0;
-    std::vector<CoreCoord> fused_op_receiver_cores_noc;
+    std::vector<tt::tt_metal::CoreCoord> fused_op_receiver_cores_noc;
     std::vector<uint32_t> fused_op_receiver_signal_semaphores;  // [dir0, dir1]
     ttnn::experimental::ccl::FusedOpSignalerMode fused_op_signaler_mode =
         ttnn::experimental::ccl::FusedOpSignalerMode::MULTI;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_config.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_config.hpp
@@ -12,7 +12,7 @@
 namespace ttnn::operations::transformer {
 
 struct SDPAProgramConfig {
-    CoreCoord compute_with_storage_grid_size;
+    tt::tt_metal::CoreCoord compute_with_storage_grid_size;
     std::optional<CoreRangeSet> sub_core_grids;
     std::size_t q_chunk_size;
     std::size_t k_chunk_size;

--- a/ttnn/cpp/ttnn/operations/transformer/transformer_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/transformer_nanobind.cpp
@@ -25,7 +25,7 @@ namespace ttnn::operations::transformer {
 void py_module(nb::module_& mod) {
     nb::class_<SDPAProgramConfig>(mod, "SDPAProgramConfig")
         .def(
-            nb::init<CoreCoord, std::optional<CoreRangeSet>, std::size_t, std::size_t, std::optional<bool>, uint32_t>(),
+            nb::init<tt::tt_metal::CoreCoord, std::optional<CoreRangeSet>, std::size_t, std::size_t, std::optional<bool>, uint32_t>(),
             nb::kw_only(),
             nb::arg("compute_with_storage_grid_size"),
             nb::arg("sub_core_grids") = nb::none(),


### PR DESCRIPTION
### Summary

In #31746 , `CoreCoord` in global namespace is deprecated in preference to `tt::tt_metal::CoreCoord`.
This PR removes remaining usages of global namespace `CoreCoord` and updates it to the fully-qualified counterpart to reduce the amount of deprecation warning in the build logs.

The global namespace `CoreCoord` have been removed.
This removal is safe because the deprecation was put in on 2025-11-07 (#31746), which is 257 days ago.

Clang-tidy run based on this PR: https://github.com/tenstorrent/tt-metal/actions/runs/29974357410

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=riverwu/remove-corecoord-global-alias)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:riverwu/remove-corecoord-global-alias)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=riverwu/remove-corecoord-global-alias)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:riverwu/remove-corecoord-global-alias)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=riverwu/remove-corecoord-global-alias)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:riverwu/remove-corecoord-global-alias)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=riverwu/remove-corecoord-global-alias)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:riverwu/remove-corecoord-global-alias)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=riverwu/remove-corecoord-global-alias)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:riverwu/remove-corecoord-global-alias)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=riverwu/remove-corecoord-global-alias)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:riverwu/remove-corecoord-global-alias)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=riverwu/remove-corecoord-global-alias)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:riverwu/remove-corecoord-global-alias)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=riverwu/remove-corecoord-global-alias)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:riverwu/remove-corecoord-global-alias)

