### PR TITLE
Bump peft 0.18.1 → 0.19.1 to match transformers 5.12.1

### DIFF
--- a/tt_metal/python_env/requirements-dev.txt
+++ b/tt_metal/python_env/requirements-dev.txt
@@ -69,7 +69,7 @@ timm>=1.0.0
 opencv-python-headless==4.8.1.78
 diffusers==0.38.0
 accelerate==1.7.0
-peft==0.18.1
+peft==0.19.1
 ftfy==6.1.1
 gitpython==3.1.50
 einops==0.6.1


### PR DESCRIPTION
Bumps `peft` from `0.18.1` to `0.19.1` in `requirements-dev.txt`.

### Why
transformers (bumped to 5.10.2 in #47218, now 5.12.1 on main) calls `peft.utils.save_and_load._maybe_shard_state_dict_for_tp` in its `load_adapter` path. That function was added in peft **0.19.0**, so it doesn't exist in the pinned 0.18.1. Any code that loads a LoRA adapter into a text encoder via transformers/diffusers therefore fails with `ImportError`. The transformers bump raised the effective peft floor without moving our pin.

### Impact / blast radius
Low and self-contained:
- No code in the repo imports `peft` directly — it's used only transitively through diffusers/transformers.
- The only peft-backed LoRA consumer is `stable_diffusion_xl_base`; tt_dit's LoRA is a custom tensor-level implementation that doesn't touch peft.
- peft 0.19.0 has no breaking changes affecting our LoRA loading (only a niche weight-tying `requires_grad` fix and removal of the unused Bone method).

### Testing
Verified locally that diffusers 0.38.0 + transformers 5.1x + peft 0.19.1 loads and injects SDXL LoRA into both text encoders without error (the 0.18.1 combo raises `ImportError` first).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=stisi/bump-peft-0.19.1)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:stisi/bump-peft-0.19.1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=stisi/bump-peft-0.19.1)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:stisi/bump-peft-0.19.1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=stisi/bump-peft-0.19.1)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:stisi/bump-peft-0.19.1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=stisi/bump-peft-0.19.1)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:stisi/bump-peft-0.19.1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=stisi/bump-peft-0.19.1)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:stisi/bump-peft-0.19.1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=stisi/bump-peft-0.19.1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:stisi/bump-peft-0.19.1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=stisi/bump-peft-0.19.1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:stisi/bump-peft-0.19.1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=stisi/bump-peft-0.19.1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:stisi/bump-peft-0.19.1)