### PR TITLE
Fix WAR on output_l1 mapping scratch in moe_expert_token_remap writer

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/moe_expert_token_remap/device/kernels/dataflow/writer_moe_expert_token_remap.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/moe_expert_token_remap/device/kernels/dataflow/writer_moe_expert_token_remap.cpp
@@ -93,6 +93,9 @@ void kernel_main() {
             output_mapping_page_size_bytes,
             {.offset_bytes = 0},
             {.page_id = bs, .offset_bytes = 0});
+        // Drain the mapping write's source read before the next iteration's fill_with_val
+        // reuses output_l1_addr (WAR); mirrors the reduced-buffer path below.
+        noc.async_write_barrier();
 
         if (found) {
             data_dfb.pop_front(1);

--- a/ttnn/cpp/ttnn/operations/data_movement/moe_expert_token_remap/device/kernels/dataflow/writer_moe_expert_token_remap.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/moe_expert_token_remap/device/kernels/dataflow/writer_moe_expert_token_remap.cpp
@@ -93,9 +93,11 @@ void kernel_main() {
             output_mapping_page_size_bytes,
             {.offset_bytes = 0},
             {.page_id = bs, .offset_bytes = 0});
-        // Drain the mapping write's source read before the next iteration's fill_with_val
-        // reuses output_l1_addr (WAR); mirrors the reduced-buffer path below.
-        noc.async_write_barrier();
+        // WAR: the next iteration's fill_with_val overwrites output_l1_addr, so the mapping write
+        // must finish reading it as source first. A flush (departed) guarantees the source has been
+        // read into the NoC and preserves remote-completion overlap; landing is drained once after
+        // the loop. Mirrors the reduced-buffer path below.
+        noc.async_writes_flushed();
 
         if (found) {
             data_dfb.pop_front(1);
@@ -110,12 +112,17 @@ void kernel_main() {
                 output_reduced_page_size_bytes,
                 {.offset_bytes = 0},
                 {.page_id = reduce_idx++, .offset_bytes = 0});
-            noc.async_write_barrier();
+            // WAR on reduced_l1_addr, same as the mapping path: flush (source read) is enough here,
+            // final landing is drained after the loop.
+            noc.async_writes_flushed();
             tt::data_movement::common::fill_with_val<uint16_t>(reduced_l1_addr, num_local_experts, 0u);
             reduction_count = 0;
         }
 
         metadata_dfb.pop_front(1);
     }
+    // Final drain: the per-iteration guards above only flush (depart); land all mapping/reduced
+    // writes before the kernel returns so the downstream op can't read not-yet-landed output.
+    noc.async_write_barrier();
     local_experts_dfb.pop_front(1);
 }


### PR DESCRIPTION
### Problem

The `moe_expert_token_remap` writer kernel ships the per-core mapping scratch (`output_l1_addr`) out with a non-posted `noc.async_write` (lines 90–95), then reuses that same buffer on the next loop iteration via `fill_with_val` (line 69) / `tt_memmove` (lines 83–84) with no write-completion point in between. On the 15/16 iterations that do not hit the reduction boundary, the only barrier (line 110, on the reduced-buffer path) is skipped, so the RISC overwrite can clobber the still-in-flight write's L1 source read and corrupt the emitted `output_mapping` page (WAR).

Fixes #50784. Finding #4 of #50154.

### Fix

The WAR only requires the NoC to finish reading the L1 *source*, so a per-iteration `noc.async_writes_flushed()` (departed, source read into the NoC) is sufficient and preserves remote-completion overlap — no full round-trip barrier per page. Applied to both the mapping and reduced write guards. With the per-iteration barriers gone, a single `noc.async_write_barrier()` is added after the loop to land the final writes before the kernel returns (so a downstream op can't read not-yet-landed output / trip the Watcher NOC-idle check). Net: N round-trip barriers → N flushes + 1 trailing barrier. (Was `noc.async_write_barrier()` per iteration; switched per review — Copilot thread.)

```cpp
        noc.async_write(map_src, output_mapping_addrgen, ...);
        // WAR: flush the source read (departed) before the next iteration's
        // fill_with_val reuses output_l1_addr; landing drained once after the loop.
        noc.async_writes_flushed();
        ...
    }
    noc.async_write_barrier();  // land the final mapping/reduced writes before return
```

### Test / verification

Verified on a t3000 (8× Wormhole B0, mesh 2×4) with `tests/nightly/t3000/ccl/test_moe_expert_token_remap.py::test_moe_expert_token_remaps`.

The race is latent (the natural test passes on buggy code), so it was forced with a collapse-the-margin perturbation — a `fill_with_val(output_l1_addr, ..., 0x7F7F)` injected right after the mapping `async_write` (stand-in for the next iteration's fill landing instantly). This perturbation is a diagnostic only and is **not** included in this PR.

Re-verified for the `async_writes_flushed()` version (guard line toggled, same perturbation):

| Run | Kernel | Result |
|-----|--------|--------|
| Baseline | buggy, no perturbation | PASS (latent) |
| Prove hazard | buggy + clobber | FAIL — `assert_with_pcc(mapping)` |
| Prove fix | **`async_writes_flushed()`** + same clobber | PASS |
| Final | flush ×2 + trailing barrier (this PR) | 4/4 PASS (all params) |

Same perturbation, the single `async_writes_flushed()` line flips FAIL↔PASS — confirming the flush (not just the old barrier) is load-bearing for the WAR. The trailing barrier is a separate guard (downstream landing / Watcher), not exercised by this PCC test.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amahmud/fix-moe-expert-token-remap-mapping-war)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amahmud/fix-moe-expert-token-remap-mapping-war)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amahmud/fix-moe-expert-token-remap-mapping-war)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amahmud/fix-moe-expert-token-remap-mapping-war)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=amahmud/fix-moe-expert-token-remap-mapping-war)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:amahmud/fix-moe-expert-token-remap-mapping-war)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amahmud/fix-moe-expert-token-remap-mapping-war)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amahmud/fix-moe-expert-token-remap-mapping-war)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amahmud/fix-moe-expert-token-remap-mapping-war)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amahmud/fix-moe-expert-token-remap-mapping-war)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amahmud/fix-moe-expert-token-remap-mapping-war)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amahmud/fix-moe-expert-token-remap-mapping-war)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amahmud/fix-moe-expert-token-remap-mapping-war)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amahmud/fix-moe-expert-token-remap-mapping-war)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amahmud/fix-moe-expert-token-remap-mapping-war)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amahmud/fix-moe-expert-token-remap-mapping-war)