### PR TITLE
tt-transformers: Fix garbled token outputs on P100

### DIFF
--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -1667,7 +1667,7 @@ class ModelArgs:
                     in0_block_w=1,  # FIXME: optimize this config for prefill, careful use DI_DT_WORKAROUND if necessary
                     out_subblock_h=1,  # Must be divisible by per_core_M
                     out_subblock_w=1,  # Must be divisible by per_core_N, out_subblock_w * out_subblock_h <= 4
-                    per_core_M=7
+                    per_core_M=1  # workaround for issue #50656
                     if self.device_name == "P100"
                     else (
                         max(  # NOTE: P100 runs OOM in L1 with 8 per_core_M


### PR DESCRIPTION
### PR Category
Fixes issue https://github.com/tenstorrent/tt-metal/issues/50656, which likely affects lots of models.

### Summary
Currently there is a matmul constant `per_core_M=7` in the base ModelArgs class that's used by almost all models in tt-transformers.
The value of 7 is incorrect when the prompt is padded to 128 tokens, producing wrong outputs.

This PR updates the constant to 1.

### Example

Model: `meta-llama/llama-3.2-1b-instruct`
Hardware: single P100

Question:
```
<|begin_of_text|><|start_header_id|>system<|end_header_id|>

Cutting Knowledge Date: December 2023
Today Date: 22 Jul 2026

You are a concise assistant that outputs short sentences. Print Yes or No in the first sentence. Make sure your Yes/No answer is factually correct.<|eot_id|><|start_header_id|>user<|end_header_id|>

Question: can root 2 be written as a fraction? Context: As a good rational approximation for the square root of two, with a reasonable small denominator, the fraction 99/70 (≈ 1.4142857) is sometimes used.<|eot_id|><|start_header_id|>assistant<|end_header_id|>
```

#### Output before fix
`This is my ‘(My) South’ – a place I can be, to  the 3  (from  the 1  (R)  the  (My  (The  (My  (The  (My  (The  (My  (My  (My  (My`

#### Output after fix
`Yes`

### Notes for reviewers
The value `per_core_M=1` might not be the optimal for performance. This PR provides a fast & suboptimal fix for garbled outputs for lots of models.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ichovpan/fix-ttt-garbled-outputs)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ichovpan/fix-ttt-garbled-outputs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ichovpan/fix-ttt-garbled-outputs)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ichovpan/fix-ttt-garbled-outputs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ichovpan/fix-ttt-garbled-outputs)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ichovpan/fix-ttt-garbled-outputs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ichovpan/fix-ttt-garbled-outputs)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ichovpan/fix-ttt-garbled-outputs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ichovpan/fix-ttt-garbled-outputs)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ichovpan/fix-ttt-garbled-outputs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ichovpan/fix-ttt-garbled-outputs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ichovpan/fix-ttt-garbled-outputs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ichovpan/fix-ttt-garbled-outputs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ichovpan/fix-ttt-garbled-outputs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ichovpan/fix-ttt-garbled-outputs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ichovpan/fix-ttt-garbled-outputs)