### PR TITLE
Fix cross-batch out_ready_sem reset race in strided_reduce_scatter reader

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_reduce_scatter_async/device/kernels/minimal_ring_strided_reduce_scatter_async_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_reduce_scatter_async/device/kernels/minimal_ring_strided_reduce_scatter_async_reader.cpp
@@ -373,9 +373,11 @@ void kernel_main() {
                 }
             }
         }
-        // Reset between batches so the counter doesn't overflow across batches.
-        noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem), 0);
-        out_ready_sem_target = 0;
+        // out_ready_sem is NOT reset per batch: the upstream writer's fabric atomic-inc
+        // accumulates monotonically and a local reset here races that inbound inc (lost
+        // signal). Keep out_ready_sem_target growing across batches and reset only once at
+        // kernel exit, matching the strided_all_gather reader. Overflow is not a concern for
+        // realistic batch counts.
 
 #ifdef FUSE_MM_OP_SIGNALER
         mm_op_ready_sem.set(0);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_reduce_scatter_async/device/kernels/minimal_ring_strided_reduce_scatter_async_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_reduce_scatter_async/device/kernels/minimal_ring_strided_reduce_scatter_async_reader.cpp
@@ -373,11 +373,8 @@ void kernel_main() {
                 }
             }
         }
-        // out_ready_sem is NOT reset per batch: the upstream writer's fabric atomic-inc
-        // accumulates monotonically and a local reset here races that inbound inc (lost
-        // signal). Keep out_ready_sem_target growing across batches and reset only once at
-        // kernel exit, matching the strided_all_gather reader. Overflow is not a concern for
-        // realistic batch counts.
+        // No per-batch reset: a local reset races the writer's monotonic fabric atomic-inc
+        // (lost signal). Target grows across batches; reset once at kernel exit. See #50793.
 
 #ifdef FUSE_MM_OP_SIGNALER
         mm_op_ready_sem.set(0);


### PR DESCRIPTION
### Problem

The `strided_reduce_scatter_async` reader resets `out_ready_sem` to 0 at the end of every batch. That reset is a local RISC store with no ordering against the upstream (D-1) writer's inbound fabric atomic-inc of the same semaphore, which accumulates monotonically and is never reset on the writer side. When D-1 crosses the batch barrier and issues the next batch's inc before D's reader performs its per-batch reset, the reset wipes that increment; the reader's `wait_min` for the next batch then never completes and the op hangs (lost signal).

Fixes #50793. Finding #15 of #50154.

### Fix

Drop the per-batch reset and let `out_ready_sem_target` grow monotonically across batches, resetting `out_ready_sem` only once at kernel exit — matching the `strided_all_gather` reader (which already uses a monotonic target + single exit reset). The reduce-scatter writer already accumulates `out_ready_sem` monotonically, so the two sides stay consistent. Overflow is negligible for realistic batch counts.

### Test / verification

Verified on a t3000 (8× Wormhole B0, mesh 1×8) with `tests/nightly/t3000/ccl/test_strided_reduce_scatter_async.py` (batch sizes 2–8).

The race is latent (natural test passes on buggy code), so it was forced with a collapse-the-margin perturbation: a fixed busy-delay inserted immediately before the per-batch reset, widening the window for D-1's next-batch inc to land first. The delay is **held constant** across both variants; only the reset differs. This perturbation is a diagnostic only and is **not** included in this PR.

| Variant | delay | per-batch reset | Result |
|---------|-------|-----------------|--------|
| buggy | 30M nops | present | HANG (deadlock, 120s timeout) |
| fixed | 30M nops (same) | removed | PASS (3.8s) |

Since the delay is identical in both, the reset alone flips hang↔pass, confirming the per-batch reset is the cause.

Broad regression (fix applied, no perturbation): the default-runnable cases plus a spread of otherwise manual-only cases (toy_4x2/2x4/4x4, 4x4_2x8_mm_grid, partial_M_block, non_divisible_slice_Ht, non_div_Wt, minimal_2x2) all pass.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amahmud/fix-strided-reduce-scatter-out-ready-sem-reset)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amahmud/fix-strided-reduce-scatter-out-ready-sem-reset)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amahmud/fix-strided-reduce-scatter-out-ready-sem-reset)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amahmud/fix-strided-reduce-scatter-out-ready-sem-reset)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=amahmud/fix-strided-reduce-scatter-out-ready-sem-reset)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:amahmud/fix-strided-reduce-scatter-out-ready-sem-reset)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amahmud/fix-strided-reduce-scatter-out-ready-sem-reset)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amahmud/fix-strided-reduce-scatter-out-ready-sem-reset)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amahmud/fix-strided-reduce-scatter-out-ready-sem-reset)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amahmud/fix-strided-reduce-scatter-out-ready-sem-reset)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amahmud/fix-strided-reduce-scatter-out-ready-sem-reset)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amahmud/fix-strided-reduce-scatter-out-ready-sem-reset)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amahmud/fix-strided-reduce-scatter-out-ready-sem-reset)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amahmud/fix-strided-reduce-scatter-out-ready-sem-reset)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amahmud/fix-strided-reduce-scatter-out-ready-sem-reset)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amahmud/fix-strided-reduce-scatter-out-ready-sem-reset)