### PR TITLE
Commit local reduction contribution before release in all_reduce_create_qkv_heads

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/transformer/all_reduce_create_qkv_heads/device/kernels/dataflow/worker_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/all_reduce_create_qkv_heads/device/kernels/dataflow/worker_writer.cpp
@@ -134,6 +134,14 @@ void kernel_main() {
         }
     }
 
+    // Commit this chip's own contribution to the local reduction workers' reduction_input CB
+    // before releasing them. The payload writes above only noc_async_writes_flushed (sent, not
+    // landed), and the reduction_semaphore mcast release below is on a different NoC VC than the
+    // unicast payload write (no cross-VC ordering on Wormhole), so without this barrier a
+    // reduction worker can be released and read stale reduction_input. The exit barrier is too
+    // late (it runs after the release).
+    noc_async_write_barrier();
+
     // 2. mcast output ready semaphore
     auto* pkt_hdr = reinterpret_cast<PACKET_HEADER_TYPE*>(packet_header_buffer_seminc);
     uint64_t out_ready_sem_noc_addr_in_pkt =


### PR DESCRIPTION
### Problem

In `all_reduce_create_qkv_heads`, `worker_writer` writes this chip's own slice into the local reduction workers' `reduction_input` CB, then releases those workers via `noc_semaphore_set_multicast`. The local contribution is not committed before that release:

- The fabric-write helper (`minimal_ccl_common.hpp:130-155`) ends with `noc_async_writes_flushed()` — sent, not landed.
- The kernel's only `noc_async_write_barrier()` is at exit, after the release.
- On Wormhole the unicast payload write and the multicast release are on different NoC VCs, and same-VC ordering does not apply — so a reduction worker can be released and read stale `reduction_input`.

The fabric path already gives the remote reduction slots a committed-before-credit guarantee; the local slot lacked it.

Fixes #50796. Finding #24 of #50154.

### Fix

Add `noc_async_write_barrier()` after the payload loop, before the ready-semaphore increment and the reduction-worker release, so this chip's own contribution has landed before the workers are signaled.

### Verification status — needs Galaxy/TG validation

**Not reproduced on hardware.** `all_reduce_create_qkv_heads` is a Galaxy/TG op; its test (`test_qkv_all_reduce_minimal.py`) uses `cluster_shape = (8, 4)` = 32 chips (`set_tg_attention_config`, llama3_70b_galaxy) and cannot run on the 8-chip t3000 available to me. The fix is grounded in: the committed-before-credit invariant, the confirmed flushed-not-landed helper (`minimal_ccl_common.hpp:153`), the exit-barrier-too-late placement, and the Wormhole cross-VC gap; it mirrors the guarantee the fabric path already provides for the remote reduction slots. Requesting Galaxy/TG owner + CI validation before merge.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amahmud/fix-all-reduce-qkv-heads-reduction-commit-before-release)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amahmud/fix-all-reduce-qkv-heads-reduction-commit-before-release)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amahmud/fix-all-reduce-qkv-heads-reduction-commit-before-release)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amahmud/fix-all-reduce-qkv-heads-reduction-commit-before-release)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=amahmud/fix-all-reduce-qkv-heads-reduction-commit-before-release)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:amahmud/fix-all-reduce-qkv-heads-reduction-commit-before-release)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amahmud/fix-all-reduce-qkv-heads-reduction-commit-before-release)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amahmud/fix-all-reduce-qkv-heads-reduction-commit-before-release)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amahmud/fix-all-reduce-qkv-heads-reduction-commit-before-release)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amahmud/fix-all-reduce-qkv-heads-reduction-commit-before-release)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amahmud/fix-all-reduce-qkv-heads-reduction-commit-before-release)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amahmud/fix-all-reduce-qkv-heads-reduction-commit-before-release)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amahmud/fix-all-reduce-qkv-heads-reduction-commit-before-release)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amahmud/fix-all-reduce-qkv-heads-reduction-commit-before-release)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amahmud/fix-all-reduce-qkv-heads-reduction-commit-before-release)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amahmud/fix-all-reduce-qkv-heads-reduction-commit-before-release)