### PR TITLE
Fix rotary_embedding token_idx freeze on program-cache hit

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_rotary_embedding_program_cache.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_rotary_embedding_program_cache.py
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import pytest
+from loguru import logger
+
+import ttnn
+from models.common.utility_functions import comp_pcc
+
+
+def rotate_half(x):
+    x1 = x[..., : x.shape[-1] // 2]
+    x2 = x[..., x.shape[-1] // 2 :]
+    return torch.cat((-x2, x1), dim=-1)
+
+
+def apply_rotary_pos_emb(x, cos_cached, sin_cached, token_idx):
+    cos = cos_cached[:, :, token_idx : token_idx + 1, ...]
+    sin = sin_cached[:, :, token_idx : token_idx + 1, ...]
+    return (x * cos) + (rotate_half(x) * sin)
+
+
+@pytest.mark.parametrize("cache_size", [2048])
+@pytest.mark.parametrize("head_dim", [64])
+def test_rotary_embedding_decode_program_cache_reuse(cache_size, head_dim, device):
+    # Regression: token_idx's value is excluded from the hash, so decode positions hit the same cached
+    # program and the token_idx-derived args must be re-applied each hit or they freeze. The existing
+    # decode test runs each token_idx in isolation (cache miss), so it can't catch this.
+    torch.manual_seed(0)
+    input_shape = [1, 1, 32, head_dim]
+    sin_cos_shape = [1, 1, cache_size, head_dim]
+    cos_cached = torch.randn(sin_cos_shape).bfloat16().float()
+    sin_cached = torch.randn(sin_cos_shape).bfloat16().float()
+    cost = ttnn.Tensor(cos_cached, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
+    sint = ttnn.Tensor(sin_cached, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
+
+    # Positions that move both within a tile (cos_sin_offset) and across tiles (cos_sin_start_id).
+    for token_idx in [0, 1, 31, 32, 33, 128, 1025]:
+        x = torch.randn(input_shape).bfloat16().float()
+        xt = ttnn.Tensor(x, ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
+        xtt = ttnn.experimental.rotary_embedding(xt, cost, sint, token_idx)
+        tt_out = xtt.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
+        pt_out = apply_rotary_pos_emb(x, cos_cached, sin_cached, token_idx)
+        passing, out = comp_pcc(pt_out, tt_out)
+        logger.info(f"token_idx={token_idx}: {out}")
+        assert passing, f"rotary_embedding wrong at token_idx={token_idx} (program-cache freeze)"
+
+        # Force the next input to a fresh address so the cache-hit path must also re-patch addresses.
+        _dummy = ttnn.Tensor(torch.randn(input_shape), ttnn.bfloat16).to(ttnn.TILE_LAYOUT).to(device)
+
+    # token_idx is excluded from the hash, so every position reused ONE program (no per-token recompile).
+    assert (
+        device.num_program_cache_entries() == 1
+    ), f"expected 1 cached program, got {device.num_program_cache_entries()}"

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_rotary_embedding_program_cache.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_rotary_embedding_program_cache.py
@@ -23,7 +23,8 @@ def apply_rotary_pos_emb(x, cos_cached, sin_cached, token_idx):
 
 
 @pytest.mark.parametrize("cache_size", [2048])
-@pytest.mark.parametrize("head_dim", [64])
+# head_dim 32 exercises the single-tile (Wt == 1) descriptor variant, 64 the multi-tile one.
+@pytest.mark.parametrize("head_dim", [32, 64])
 def test_rotary_embedding_decode_program_cache_reuse(cache_size, head_dim, device):
     # Regression: token_idx's value is excluded from the hash, so decode positions hit the same cached
     # program and the token_idx-derived args must be re-applied each hit or they freeze. The existing

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/rotary_embedding_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/rotary_embedding_device_operation.cpp
@@ -145,8 +145,15 @@ Tensor RotaryEmbeddingDeviceOperation::create_output_tensors(
 
 ttsl::hash::hash_t RotaryEmbeddingDeviceOperation::compute_program_hash(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    // Key token_idx.has_value() (it selects the program structure) but not its value, so decode reuses
+    // one program; the value-derived runtime args are re-applied per hit in override_runtime_arguments.
     tt::tt_metal::operation::Hash hash = tt::tt_metal::operation::hash_operation<RotaryEmbeddingDeviceOperation>(
-        args.seq_len, args.output_mem_config, tensor_args.input, tensor_args.cos, tensor_args.sin);
+        args.seq_len,
+        args.token_idx.has_value(),
+        args.output_mem_config,
+        tensor_args.input,
+        tensor_args.cos,
+        tensor_args.sin);
     return hash;
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/rotary_embedding_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/rotary_embedding_device_operation.cpp
@@ -151,6 +151,7 @@ ttsl::hash::hash_t RotaryEmbeddingDeviceOperation::compute_program_hash(
         args.seq_len,
         args.token_idx.has_value(),
         args.output_mem_config,
+        args.compute_kernel_config,
         tensor_args.input,
         tensor_args.cos,
         tensor_args.sin);

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/rotary_embedding_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/rotary_embedding_program_factory.cpp
@@ -880,4 +880,16 @@ ProgramDescriptor RotaryEmbeddingProgramFactory::create_descriptor(
     return create_multi_tile_descriptor(operation_attributes, tensor_args, tensor_return_value);
 }
 
+void RotaryEmbeddingProgramFactory::override_runtime_arguments(
+    tt::tt_metal::Program& program,
+    const RotaryEmbeddingParams& operation_attributes,
+    const RotaryEmbeddingInputs& tensor_args,
+    Tensor& tensor_return_value,
+    const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
+    // token_idx's value is excluded from the hash, so decode hits the cache; re-derive from
+    // create_descriptor and re-apply runtime args + CB addresses so cos_sin_offset/start_id can't freeze.
+    auto desc = create_descriptor(operation_attributes, tensor_args, tensor_return_value);
+    tt::tt_metal::apply_descriptor_runtime_args(program, desc);
+}
+
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/rotary_embedding_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/rotary_embedding_program_factory.cpp
@@ -8,8 +8,13 @@
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program.hpp>
+#include <tt-metalium/circular_buffer.hpp>
 #include <tt-metalium/program_descriptors.hpp>
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+
+#include <variant>
+#include <vector>
 
 namespace ttnn::experimental::prim {
 
@@ -18,6 +23,133 @@ using namespace tt::constants;
 using namespace tt::tt_metal;
 
 namespace {
+
+// Work distribution, shared by create_*_descriptor (cache miss) and override_runtime_arguments
+// (cache hit) so the hit path targets exactly the cores the miss path emitted args for.
+// `Wt` is the per-row tile count (1 on the single-tile path).
+struct RotaryWorkSplit {
+    bool row_major = true;
+    uint32_t num_cores = 0;
+    uint32_t num_cores_x = 0;
+    uint32_t num_cores_y = 0;
+    uint32_t num_rows_per_core_group_1 = 0;
+    uint32_t num_rows_per_core_group_2 = 0;
+    CoreRangeSet all_cores;
+    CoreRangeSet core_group_1;
+    CoreRangeSet core_group_2;
+    bool in_sharded = false;
+    bool out_sharded = false;
+    uint32_t num_input_tiles = 0;
+    uint32_t num_output_tiles = 0;
+};
+
+RotaryWorkSplit compute_rotary_work_split(const Tensor& input, const Tensor& output, uint32_t Wt) {
+    RotaryWorkSplit w;
+    w.in_sharded = input.shard_spec().has_value();
+    w.out_sharded = output.shard_spec().has_value();
+    std::optional<ShardSpec> shard_spec = w.in_sharded ? input.shard_spec() : output.shard_spec();
+
+    auto compute_with_storage_grid_size = input.device()->compute_with_storage_grid_size();
+    w.num_cores_x = compute_with_storage_grid_size.x;
+    w.num_cores_y = compute_with_storage_grid_size.y;
+
+    if (shard_spec.has_value()) {
+        w.row_major = shard_spec.value().orientation == ShardOrientation::ROW_MAJOR;
+        w.all_cores = shard_spec.value().grid;
+        w.num_cores = w.all_cores.num_cores();
+        w.core_group_1 = w.all_cores;
+        w.core_group_2 = CoreRangeSet();
+        w.num_rows_per_core_group_1 = shard_spec.value().shape[0] / TILE_HEIGHT;
+        w.num_rows_per_core_group_2 = 0;
+        w.num_input_tiles = w.in_sharded ? shard_spec.value().shape[0] * shard_spec.value().shape[1] / TILE_HW : 2 * Wt;
+        w.num_output_tiles =
+            w.out_sharded ? shard_spec.value().shape[0] * shard_spec.value().shape[1] / TILE_HW : 2 * Wt;
+        auto bbox = w.all_cores.bounding_box();
+        w.num_cores_x = bbox.end_coord.x + 1;
+        w.num_cores_y = bbox.end_coord.y + 1;
+    } else {
+        uint32_t num_rows = input.physical_volume() / input.padded_shape()[-1] / TILE_HEIGHT;
+        w.row_major = true;
+        std::tie(
+            w.num_cores,
+            w.all_cores,
+            w.core_group_1,
+            w.core_group_2,
+            w.num_rows_per_core_group_1,
+            w.num_rows_per_core_group_2) =
+            tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_rows, w.row_major);
+        w.num_input_tiles = 2 * Wt;
+        w.num_output_tiles = w.num_input_tiles;
+    }
+    return w;
+}
+
+// One core's reader/writer runtime args. Buffer* slots are buffer base addresses (registered as
+// bindings by emplace_runtime_args on a miss, written as the current address on a hit); uint32_t
+// slots are plain values.
+using RotaryRtArgs = std::vector<std::variant<uint32_t, Buffer*>>;
+
+struct RotaryPerCoreArgs {
+    std::vector<CoreCoord> cores;
+    std::vector<RotaryRtArgs> reader;
+    std::vector<RotaryRtArgs> writer;
+};
+
+// SINGLE SOURCE OF TRUTH for the per-core reader/writer runtime args. Both descriptor variants use
+// the same arg layout, and both create_*_descriptor (cache miss) and override_runtime_arguments
+// (cache hit) go through here -- so the re-applied values cannot drift from the built layout and no
+// arg index is hard-coded on the hit path.
+RotaryPerCoreArgs build_rotary_runtime_args(
+    const RotaryEmbeddingParams& operation_attributes,
+    const RotaryEmbeddingInputs& tensor_args,
+    const Tensor& output,
+    const RotaryWorkSplit& work,
+    uint32_t Wt) {
+    const auto& input = tensor_args.input;
+    const auto& token_idx = operation_attributes.token_idx;
+
+    uint32_t Ht = input.padded_shape()[-2] / TILE_HEIGHT;
+    uint32_t HtWt = Ht * Wt;
+    uint32_t Wbytes = input.padded_shape()[-1] * sizeof(bfloat16);
+
+    // Decode mode derives both cos/sin offsets from token_idx, whose value compute_program_hash
+    // excludes; prefill derives cos_sin_start_id from the (hashed) shapes instead.
+    uint32_t cos_sin_offset = token_idx.has_value() ? token_idx.value() % TILE_HEIGHT * Wbytes : 0;
+
+    auto* src_buffer = input.buffer();
+    auto* cos_buffer = tensor_args.cos.buffer();
+    auto* sin_buffer = tensor_args.sin.buffer();
+    auto* dst_buffer = output.buffer();
+
+    RotaryPerCoreArgs result;
+    result.cores = grid_to_cores(work.num_cores, work.num_cores_x, work.num_cores_y, work.row_major);
+    result.reader.reserve(result.cores.size());
+    result.writer.reserve(result.cores.size());
+
+    uint32_t g1_numcores = work.core_group_1.num_cores();
+    for (uint32_t i = 0, num_tiles_written = 0; i < work.num_cores; ++i) {
+        uint32_t num_rows_per_core = i < g1_numcores ? work.num_rows_per_core_group_1 : work.num_rows_per_core_group_2;
+        uint32_t cos_sin_start_id =
+            token_idx.has_value() ? token_idx.value() / TILE_HEIGHT * Wt : num_tiles_written % HtWt;
+
+        if (work.in_sharded) {
+            result.reader.push_back(
+                {cos_buffer, sin_buffer, num_rows_per_core, num_tiles_written / Wt % Ht, cos_sin_start_id});
+        } else {
+            result.reader.push_back(
+                {src_buffer,
+                 cos_buffer,
+                 sin_buffer,
+                 num_rows_per_core,
+                 num_tiles_written,
+                 num_tiles_written / Wt % Ht,
+                 cos_sin_start_id});
+        }
+        result.writer.push_back({dst_buffer, num_rows_per_core * Wt, num_tiles_written, cos_sin_offset, Wt, Wbytes});
+        num_tiles_written += num_rows_per_core * Wt;
+    }
+    return result;
+}
 
 // Single-tile (Wt == 1) path. The Wt >= 2 path implements HF rotate_half via
 // inter-tile half-swap + scalar negation, which collapses when Wt == 1 (half_Wt
@@ -53,51 +185,24 @@ ProgramDescriptor create_single_tile_descriptor(
     uint32_t output_single_tile_size = tt::tile_size(output_cb_data_format);
 
     constexpr uint32_t Wt = 1;
-    uint32_t num_rows = input.physical_volume() / input.padded_shape()[-1] / TILE_HEIGHT;
     uint32_t Ht = input.padded_shape()[-2] / TILE_HEIGHT;
     uint32_t HtWt = Ht * Wt;
-    uint32_t Wbytes = input.padded_shape()[-1] * sizeof(bfloat16);
 
     tt::tt_metal::IDevice* device = input.device();
 
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(device->arch(), operation_attributes.compute_kernel_config);
 
-    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
-    uint32_t num_cores_x = compute_with_storage_grid_size.x;
-    uint32_t num_cores_y = compute_with_storage_grid_size.y;
-
-    bool row_major;
-    uint32_t num_cores, num_rows_per_core_group_1, num_rows_per_core_group_2;
-    CoreRangeSet all_cores, core_group_1, core_group_2;
-
-    bool in_sharded = input.shard_spec().has_value();
-    bool out_sharded = output.shard_spec().has_value();
-    std::optional<ShardSpec> shard_spec = in_sharded ? input.shard_spec() : output.shard_spec();
-
-    uint32_t num_input_tiles, num_output_tiles;
-
-    if (shard_spec.has_value()) {
-        row_major = shard_spec.value().orientation == ShardOrientation::ROW_MAJOR;
-        all_cores = shard_spec.value().grid;
-        num_cores = all_cores.num_cores();
-        core_group_1 = all_cores;
-        core_group_2 = CoreRangeSet();
-        num_rows_per_core_group_1 = shard_spec.value().shape[0] / TILE_HEIGHT;
-        num_rows_per_core_group_2 = 0;
-        num_input_tiles = in_sharded ? shard_spec.value().shape[0] * shard_spec.value().shape[1] / TILE_HW : 2 * Wt;
-        num_output_tiles = out_sharded ? shard_spec.value().shape[0] * shard_spec.value().shape[1] / TILE_HW : 2 * Wt;
-        auto bbox = all_cores.bounding_box();
-        num_cores_x = bbox.end_coord.x + 1;
-        num_cores_y = bbox.end_coord.y + 1;
-    } else {
-        row_major = true;
-        std::tie(
-            num_cores, all_cores, core_group_1, core_group_2, num_rows_per_core_group_1, num_rows_per_core_group_2) =
-            tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_rows, row_major);
-        num_input_tiles = 2 * Wt;
-        num_output_tiles = num_input_tiles;
-    }
+    const auto work = compute_rotary_work_split(input, output, Wt);
+    const bool in_sharded = work.in_sharded;
+    const bool out_sharded = work.out_sharded;
+    const CoreRangeSet& all_cores = work.all_cores;
+    const CoreRangeSet& core_group_1 = work.core_group_1;
+    const CoreRangeSet& core_group_2 = work.core_group_2;
+    const uint32_t num_rows_per_core_group_1 = work.num_rows_per_core_group_1;
+    const uint32_t num_rows_per_core_group_2 = work.num_rows_per_core_group_2;
+    const uint32_t num_input_tiles = work.num_input_tiles;
+    const uint32_t num_output_tiles = work.num_output_tiles;
 
     constexpr uint8_t input_cb_index = tt::CBIndex::c_0;
     desc.cbs.push_back(CBDescriptor{
@@ -382,45 +487,18 @@ ProgramDescriptor create_single_tile_descriptor(
         compute_desc_g2 = std::move(g2);
     }
 
-    uint32_t cos_sin_offset = 0;
-    uint32_t cos_sin_start_id = 0;
-    if (token_idx.has_value()) {
-        cos_sin_offset = token_idx.value() % TILE_HEIGHT * Wbytes;
-        cos_sin_start_id = token_idx.value() / TILE_HEIGHT * Wt;
+    // Built via the shared builder so create_descriptor (cache miss) and
+    // override_runtime_arguments (cache hit) stay byte-identical.
+    const auto per_core = build_rotary_runtime_args(operation_attributes, tensor_args, output, work, Wt);
+    reader_desc.runtime_args.reserve(per_core.cores.size());
+    writer_desc.runtime_args.reserve(per_core.cores.size());
+    for (size_t i = 0; i < per_core.cores.size(); ++i) {
+        reader_desc.emplace_runtime_args(per_core.cores[i], per_core.reader[i]);
+        writer_desc.emplace_runtime_args(per_core.cores[i], per_core.writer[i]);
     }
 
-    uint32_t g1_numcores = core_group_1.num_cores();
-    const auto& cores = grid_to_cores(num_cores, num_cores_x, num_cores_y, row_major);
-
-    reader_desc.runtime_args.reserve(num_cores);
-    writer_desc.runtime_args.reserve(num_cores);
-
-    for (uint32_t i = 0, num_tiles_written = 0; i < num_cores; ++i) {
-        const CoreCoord& core = cores.at(i);
-        uint32_t num_rows_per_core = i < g1_numcores ? num_rows_per_core_group_1 : num_rows_per_core_group_2;
-        if (!token_idx.has_value()) {
-            cos_sin_start_id = num_tiles_written % HtWt;
-        }
-        if (in_sharded) {
-            reader_desc.emplace_runtime_args(
-                core, {cos_buffer, sin_buffer, num_rows_per_core, num_tiles_written / Wt % Ht, cos_sin_start_id});
-        } else {
-            reader_desc.emplace_runtime_args(
-                core,
-                {src_buffer,
-                 cos_buffer,
-                 sin_buffer,
-                 num_rows_per_core,
-                 num_tiles_written,
-                 num_tiles_written / Wt % Ht,
-                 cos_sin_start_id});
-        }
-
-        writer_desc.emplace_runtime_args(
-            core, {dst_buffer, num_rows_per_core * Wt, num_tiles_written, cos_sin_offset, Wt, Wbytes});
-        num_tiles_written += num_rows_per_core * Wt;
-    }
-
+    // Kernel push order: reader (0), writer (1), compute (2[, 3]) -- override_runtime_arguments
+    // patches by these indices.
     desc.kernels.push_back(std::move(reader_desc));
     desc.kernels.push_back(std::move(writer_desc));
     desc.kernels.push_back(std::move(compute_desc_g1));
@@ -458,54 +536,26 @@ ProgramDescriptor create_multi_tile_descriptor(
     tt::DataFormat output_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
     uint32_t output_single_tile_size = tt::tile_size(output_cb_data_format);
 
-    uint32_t num_rows = input.physical_volume() / input.padded_shape()[-1] / TILE_HEIGHT;
     uint32_t Ht = input.padded_shape()[-2] / TILE_HEIGHT;
     uint32_t Wt = input.padded_shape()[-1] / TILE_WIDTH;
     uint32_t half_Wt = Wt / 2;
     uint32_t HtWt = Ht * Wt;
-    uint32_t Wbytes = input.padded_shape()[-1] * sizeof(bfloat16);
 
     tt::tt_metal::IDevice* device = input.device();
 
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(device->arch(), operation_attributes.compute_kernel_config);
 
-    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
-    uint32_t num_cores_x = compute_with_storage_grid_size.x;
-    uint32_t num_cores_y = compute_with_storage_grid_size.y;
-
-    bool row_major;
-    uint32_t num_cores, num_rows_per_core_group_1, num_rows_per_core_group_2;
-
-    CoreRangeSet all_cores, core_group_1, core_group_2;
-
-    bool in_sharded = input.shard_spec().has_value();
-    bool out_sharded = output.shard_spec().has_value();
-    std::optional<ShardSpec> shard_spec = in_sharded ? input.shard_spec() : output.shard_spec();
-
-    uint32_t num_input_tiles, num_output_tiles;
-
-    if (shard_spec.has_value()) {
-        row_major = shard_spec.value().orientation == ShardOrientation::ROW_MAJOR;
-        all_cores = shard_spec.value().grid;
-        num_cores = all_cores.num_cores();
-        core_group_1 = all_cores;
-        core_group_2 = CoreRangeSet();
-        num_rows_per_core_group_1 = shard_spec.value().shape[0] / TILE_HEIGHT;
-        num_rows_per_core_group_2 = 0;
-        num_input_tiles = in_sharded ? shard_spec.value().shape[0] * shard_spec.value().shape[1] / TILE_HW : 2 * Wt;
-        num_output_tiles = out_sharded ? shard_spec.value().shape[0] * shard_spec.value().shape[1] / TILE_HW : 2 * Wt;
-        auto bbox = all_cores.bounding_box();
-        num_cores_x = bbox.end_coord.x + 1;
-        num_cores_y = bbox.end_coord.y + 1;
-    } else {
-        row_major = true;
-        std::tie(
-            num_cores, all_cores, core_group_1, core_group_2, num_rows_per_core_group_1, num_rows_per_core_group_2) =
-            tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_rows, row_major);
-        num_input_tiles = 2 * Wt;
-        num_output_tiles = num_input_tiles;
-    }
+    const auto work = compute_rotary_work_split(input, output, Wt);
+    const bool in_sharded = work.in_sharded;
+    const bool out_sharded = work.out_sharded;
+    const CoreRangeSet& all_cores = work.all_cores;
+    const CoreRangeSet& core_group_1 = work.core_group_1;
+    const CoreRangeSet& core_group_2 = work.core_group_2;
+    const uint32_t num_rows_per_core_group_1 = work.num_rows_per_core_group_1;
+    const uint32_t num_rows_per_core_group_2 = work.num_rows_per_core_group_2;
+    const uint32_t num_input_tiles = work.num_input_tiles;
+    const uint32_t num_output_tiles = work.num_output_tiles;
 
     constexpr uint8_t input_cb_index = tt::CBIndex::c_0;
     desc.cbs.push_back(CBDescriptor{
@@ -812,52 +862,18 @@ ProgramDescriptor create_multi_tile_descriptor(
         compute_desc_g2 = std::move(g2);
     }
 
-    uint32_t cos_sin_offset = 0;
-    uint32_t cos_sin_start_id = 0;
-    if (token_idx.has_value()) {
-        cos_sin_offset = token_idx.value() % TILE_HEIGHT * Wbytes;
-        cos_sin_start_id = token_idx.value() / TILE_HEIGHT * Wt;
+    // Built via the shared builder so create_descriptor (cache miss) and
+    // override_runtime_arguments (cache hit) stay byte-identical.
+    const auto per_core = build_rotary_runtime_args(operation_attributes, tensor_args, output, work, Wt);
+    reader_desc.runtime_args.reserve(per_core.cores.size());
+    writer_desc.runtime_args.reserve(per_core.cores.size());
+    for (size_t i = 0; i < per_core.cores.size(); ++i) {
+        reader_desc.emplace_runtime_args(per_core.cores[i], per_core.reader[i]);
+        writer_desc.emplace_runtime_args(per_core.cores[i], per_core.writer[i]);
     }
 
-    uint32_t g1_numcores = core_group_1.num_cores();
-
-    const auto& cores = grid_to_cores(num_cores, num_cores_x, num_cores_y, row_major);
-
-    reader_desc.runtime_args.reserve(num_cores);
-    writer_desc.runtime_args.reserve(num_cores);
-
-    for (uint32_t i = 0, num_tiles_written = 0; i < num_cores; ++i) {
-        const CoreCoord& core = cores.at(i);
-        uint32_t num_rows_per_core = 0;
-        if (i < g1_numcores) {
-            num_rows_per_core = num_rows_per_core_group_1;
-        } else {
-            num_rows_per_core = num_rows_per_core_group_2;
-        }
-
-        if (!token_idx.has_value()) {
-            cos_sin_start_id = num_tiles_written % HtWt;
-        }
-        if (in_sharded) {
-            reader_desc.emplace_runtime_args(
-                core, {cos_buffer, sin_buffer, num_rows_per_core, num_tiles_written / Wt % Ht, cos_sin_start_id});
-        } else {
-            reader_desc.emplace_runtime_args(
-                core,
-                {src_buffer,
-                 cos_buffer,
-                 sin_buffer,
-                 num_rows_per_core,
-                 num_tiles_written,
-                 num_tiles_written / Wt % Ht,
-                 cos_sin_start_id});
-        }
-
-        writer_desc.emplace_runtime_args(
-            core, {dst_buffer, num_rows_per_core * Wt, num_tiles_written, cos_sin_offset, Wt, Wbytes});
-        num_tiles_written += num_rows_per_core * Wt;
-    }
-
+    // Kernel push order: reader (0), writer (1), compute (2[, 3]) -- override_runtime_arguments
+    // patches by these indices.
     desc.kernels.push_back(std::move(reader_desc));
     desc.kernels.push_back(std::move(writer_desc));
     desc.kernels.push_back(std::move(compute_desc_g1));
@@ -886,10 +902,55 @@ void RotaryEmbeddingProgramFactory::override_runtime_arguments(
     const RotaryEmbeddingInputs& tensor_args,
     Tensor& tensor_return_value,
     const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
-    // token_idx's value is excluded from the hash, so decode hits the cache; re-derive from
-    // create_descriptor and re-apply runtime args + CB addresses so cos_sin_offset/start_id can't freeze.
-    auto desc = create_descriptor(operation_attributes, tensor_args, tensor_return_value);
-    tt::tt_metal::apply_descriptor_runtime_args(program, desc);
+    // Patch the cached program in place; never rebuild the descriptor here (this runs on EVERY cache
+    // hit, so a rebuild would pay the cache-miss host cost -- work split, CoreRangeSet, arch queries,
+    // TensorAccessorArgs, kernel sources -- on every dispatch).
+    //
+    // Two classes of state must be re-applied.  (1) token_idx's VALUE is excluded from
+    // compute_program_hash so successive decode positions reuse one program; cos_sin_offset and
+    // cos_sin_start_id derive from it and would otherwise stay frozen at the first token, silently
+    // reading the wrong cos/sin rows.  (2) The override supersedes resolve_bindings, so every buffer
+    // address is ours to re-apply too.  Everything else (per-core row counts, Wt, Wbytes, Ht, HtWt) is
+    // derived from shapes/memory configs the hash includes and is therefore identical on a hit.
+    const auto& input = tensor_args.input;
+    // Matches create_descriptor's variant selection: Wt == 1 is the single-tile path.
+    const uint32_t Wt = input.padded_shape()[-1] / TILE_WIDTH;
+    const auto work = compute_rotary_work_split(input, tensor_return_value, Wt);
+    const auto per_core = build_rotary_runtime_args(operation_attributes, tensor_args, tensor_return_value, work, Wt);
+
+    // Kernel push order in both descriptor variants: reader (0), writer (1), compute (2[, 3]).  The
+    // compute kernels take no runtime args, so there is nothing to patch on them.
+    constexpr uint32_t kReaderKernelIdx = 0;
+    constexpr uint32_t kWriterKernelIdx = 1;
+
+    auto apply = [&program](uint32_t kernel_idx, const CoreCoord& core, const RotaryRtArgs& args) {
+        auto& data = tt::tt_metal::GetRuntimeArgs(program, kernel_idx, core);
+        for (uint32_t arg_idx = 0; arg_idx < static_cast<uint32_t>(args.size()); ++arg_idx) {
+            const auto& slot = args[arg_idx];
+            data[arg_idx] = std::holds_alternative<Buffer*>(slot)
+                                ? static_cast<uint32_t>(std::get<Buffer*>(slot)->address())
+                                : std::get<uint32_t>(slot);
+        }
+    };
+
+    for (size_t i = 0; i < per_core.cores.size(); ++i) {
+        apply(kReaderKernelIdx, per_core.cores[i], per_core.reader[i]);
+        apply(kWriterKernelIdx, per_core.cores[i], per_core.writer[i]);
+    }
+
+    // The only globally-allocated CBs are the sharded input (c_0) and sharded output (c_16); re-point
+    // them at the current buffers, whose base addresses move with reallocation.
+    for (const auto& cb : program.circular_buffers()) {
+        if (!cb->globally_allocated()) {
+            continue;
+        }
+        const auto& indices = cb->buffer_indices();
+        if (indices.contains(static_cast<uint8_t>(tt::CBIndex::c_0))) {
+            UpdateDynamicCircularBufferAddress(program, cb->id(), *input.buffer());
+        } else if (indices.contains(static_cast<uint8_t>(tt::CBIndex::c_16))) {
+            UpdateDynamicCircularBufferAddress(program, cb->id(), *tensor_return_value.buffer());
+        }
+    }
 }
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/rotary_embedding_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/rotary_embedding_program_factory.hpp
@@ -19,6 +19,14 @@ struct RotaryEmbeddingProgramFactory {
         const RotaryEmbeddingParams& operation_attributes,
         const RotaryEmbeddingInputs& tensor_args,
         Tensor& tensor_return_value);
+
+    // Re-applies the token_idx-derived runtime args on every cache hit (the value is excluded from the hash).
+    static void override_runtime_arguments(
+        tt::tt_metal::Program& program,
+        const RotaryEmbeddingParams& operation_attributes,
+        const RotaryEmbeddingInputs& tensor_args,
+        Tensor& tensor_return_value,
+        const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate = std::nullopt);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/rotary_embedding_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding/device/rotary_embedding_program_factory.hpp
@@ -11,16 +11,16 @@
 namespace ttnn::experimental::prim {
 
 struct RotaryEmbeddingProgramFactory {
-    // Contract (1): single ProgramDescriptor.  Sharded variants set CBDescriptor::buffer
-    // so the framework patches dynamic CB addresses on cache hit; per-core runtime args
-    // and CB total_sizes (which depend on input shape) are re-applied via
-    // apply_descriptor_runtime_args.
+    // Contract (1): single ProgramDescriptor.  Two variants: single-tile (Wt == 1) and multi-tile.
+    // Sharded variants set CBDescriptor::buffer for the globally-allocated input/output CBs.
     static tt::tt_metal::ProgramDescriptor create_descriptor(
         const RotaryEmbeddingParams& operation_attributes,
         const RotaryEmbeddingInputs& tensor_args,
         Tensor& tensor_return_value);
 
-    // Re-applies the token_idx-derived runtime args on every cache hit (the value is excluded from the hash).
+    // Patches the cached program in place on every cache hit: the token_idx-derived cos/sin offsets
+    // (its value is excluded from the hash) plus every buffer address and globally-allocated CB
+    // address, since this hook supersedes resolve_bindings.  Does NOT rebuild the descriptor.
     static void override_runtime_arguments(
         tt::tt_metal::Program& program,
         const RotaryEmbeddingParams& operation_attributes,


### PR DESCRIPTION
## Problem
`experimental/transformer/rotary_embedding`'s `compute_program_hash` keys on `seq_len` + tensor specs and **excludes `token_idx`**, but the program factory bakes `token_idx`-derived per-core runtime args into the reader/writer kernels:

```cpp
cos_sin_offset   = token_idx.value() % TILE_HEIGHT * Wbytes;   // writer rt-arg
cos_sin_start_id = token_idx.value() / TILE_HEIGHT * Wt;       // reader rt-arg
```

On a program-cache **hit**, the descriptor fast path (`resolve_bindings`) re-patches buffer/CB **addresses** but does not re-derive **scalars**. So two decode calls with the same shapes but different `token_idx` reuse the cached program with the **first-miss `token_idx` frozen** → every position after the first reads the wrong cos/sin tiles.

Regressed in #45070 (migration to ProgramDescriptor): the pre-migration op keyed the whole attribute struct (incl. `token_idx`), so each position was a cache miss. Reachable today from `models/demos/gemma4` (variable `token_index`) and the unit tests.

## Fix
- **Hash**: add `token_idx.has_value()` (it selects the program *structure* — `num_cos_sin_tiles`, extra CBs, kernel defines) while keeping the *value* out, so decode reuses one program instead of recompiling per position.
- **Re-apply**: add `RotaryEmbeddingDeviceOperation::override_runtime_arguments`, which re-runs `create_descriptor` for the current `token_idx` and `apply_descriptor_runtime_args` (the same pattern as `unary`/`binary_ng`). No rebuild; supersedes `get_dynamic`/`resolve_bindings`.

## Test
`test_rotary_embedding_decode_program_cache_reuse` drives several `token_idx` values through **one cache-enabled session** and asserts per-position correctness **and** single-program reuse (`num_program_cache_entries() == 1`). The existing `test_rotary_embedding_decode` parametrizes `token_idx` as separate runs (cache miss each time), so it never observes the freeze.

## Verification status
⚠️ **Not yet built/run on hardware** — opening as draft for review of the approach. Next: build with `-DTT_DESCRIPTOR_PATCHING_PARITY_CHECK` and run the new test (before fix: PCC fails at `token_idx > 0`; after: passes with 1 cache entry).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/rotary-embedding-token-idx-override)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/rotary-embedding-token-idx-override)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/rotary-embedding-token-idx-override)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/rotary-embedding-token-idx-override)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=dgomez/rotary-embedding-token-idx-override)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:dgomez/rotary-embedding-token-idx-override)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/rotary-embedding-token-idx-override)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/rotary-embedding-token-idx-override)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/rotary-embedding-token-idx-override)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/rotary-embedding-token-idx-override)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/rotary-embedding-token-idx-override)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/rotary-embedding-token-idx-override)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/rotary-embedding-token-idx-override)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/rotary-embedding-token-idx-override)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/rotary-embedding-token-idx-override)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/rotary-embedding-token-idx-override)