### PR TITLE
[bug fix]: widen ring_size field for compute side dfb structs to address available l1 in quasar

### DIFF
--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_configs.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_configs.cpp
@@ -1067,8 +1067,8 @@ TEST_F(MeshDeviceFixture, DFBReentryNumEntriesViolatesTxnDivisorFails) {
             ::testing::HasSubstr("num_entries override 3 is not divisible by")));
 }
 
-// An entry_size override that pushes the TRISC ring extent past the uint16 L1-aligned-unit limit is
-// rejected by the ring-extent re-validation.
+// Ring extent past Tensix unreserved L1 is rejected. entry_size stays within the TRISC uint16
+// L1-unit field so this hits the L1 check rather than the entry_size width check.
 TEST_F(MeshDeviceFixture, DFBReentryEntrySizeRingExtentFails) {
     if (devices_.at(0)->arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "DFB ring-extent check requires Quasar";
@@ -1079,12 +1079,31 @@ TEST_F(MeshDeviceFixture, DFBReentryEntrySizeRingExtentFails) {
     program.impl().finalize_dataflow_buffer_configs();
 
     auto params = MakeMinimalRunArgs(node);
-    params.dfb_run_overrides.push_back({.dfb = experimental::DFBSpecName{"dfb_0"}, .entry_size = 64u * 1024u * 1024u});
+    // 64 KiB * 128 entries = 8 MiB ring > Quasar unreserved L1 (~4 MiB).
+    params.dfb_run_overrides.push_back(
+        {.dfb = experimental::DFBSpecName{"dfb_0"}, .entry_size = 64u * 1024u, .num_entries = 128u});
 
     EXPECT_THAT(
         [&] { experimental::SetProgramRunArgs(program, params); },
-        ::testing::ThrowsMessage<std::runtime_error>(
-            ::testing::HasSubstr("exceeds uint16_t; reduce capacity, stride, or entry_size")));
+        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("exceeds Tensix unreserved L1 size")));
+}
+
+// TRISC stores entry_size in uint16 L1 units; 1 MiB is 65536 units and must fail before init truncates.
+TEST_F(MeshDeviceFixture, DFBReentryEntrySizeExceedsUint16Fails) {
+    if (devices_.at(0)->arch() != ARCH::QUASAR) {
+        GTEST_SKIP() << "DFB TRISC entry_size check requires Quasar";
+    }
+    const experimental::NodeCoord node{0, 0};
+    experimental::ProgramSpec spec = experimental::test_helpers::MakeMinimalValidProgramSpec();
+    Program program = experimental::MakeProgramFromSpec(*devices_.at(0), spec);
+    program.impl().finalize_dataflow_buffer_configs();
+
+    auto params = MakeMinimalRunArgs(node);
+    params.dfb_run_overrides.push_back({.dfb = experimental::DFBSpecName{"dfb_0"}, .entry_size = 1024u * 1024u});
+
+    EXPECT_THAT(
+        [&] { experimental::SetProgramRunArgs(program, params); },
+        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("TRISC entry_size")));
 }
 
 // capacity (num_entries / max(producers, consumers)) is stored as uint16_t (the tile-counter register

--- a/tt_metal/hw/ckernels/quasar/metal/llk_io/llk_io.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_io/llk_io.h
@@ -11,37 +11,26 @@
 #if defined(COMPILE_FOR_TRISC) && (defined(UCK_CHLKC_PACK) || defined(UCK_CHLKC_UNPACK))
 // Used by pack and unpack to advance DFB rd/wr tile offsets and the tile counter pointer
 //
-// Pack updates wr_entry_idx / wr_offset
-// Unpack updates rd_entry_idx / rd_offset
-inline void dfb_advance_slot(
-    LocalDFBInterface& intf,
-    DFBTCSlot& slot,
-    std::uint32_t num_tiles) {
-    const std::uint32_t num_words = num_tiles * intf.stride_size;
-
+// Pack updates wr_entry_idx (cursor byte-offset derived via dfb_slot_cursor_offset_units)
+// Unpack updates rd_entry_idx
+inline void dfb_advance_slot(LocalDFBInterface& intf, DFBTCSlot& slot, std::uint32_t num_tiles) {
     std::uint32_t entry_idx;
-    std::uint32_t offset;
 #if defined(UCK_CHLKC_PACK)
     entry_idx = slot.wr_entry_idx;
-    offset = slot.wr_offset;
 #elif defined(UCK_CHLKC_UNPACK)
     entry_idx = slot.rd_entry_idx;
-    offset = slot.rd_offset;
 #endif
 
     entry_idx += num_tiles * static_cast<std::uint32_t>(intf.stride_size_tiles);
-    offset += num_words;
+    const std::uint32_t offset = dfb_slot_cursor_offset_units(intf, slot, entry_idx);
     if (offset >= slot.ring_size) {
-        offset = 0;
         entry_idx = slot.base_entry_idx;
     }
 
 #if defined(UCK_CHLKC_PACK)
     slot.wr_entry_idx = static_cast<std::uint16_t>(entry_idx);
-    slot.wr_offset = static_cast<std::uint16_t>(offset);
 #elif defined(UCK_CHLKC_UNPACK)
     slot.rd_entry_idx = static_cast<std::uint16_t>(entry_idx);
-    slot.rd_offset = static_cast<std::uint16_t>(offset);
 #endif
 
     intf.tc_idx = (intf.tc_idx + 1) % intf.num_tcs_to_rr;

--- a/tt_metal/hw/inc/api/compute/cb_api.h
+++ b/tt_metal/hw/inc/api/compute/cb_api.h
@@ -142,7 +142,7 @@ ALWI uint32_t get_tile_l1_byte_address(uint32_t operand_id, uint32_t tile_index)
 #ifdef ARCH_QUASAR
     LocalDFBInterface& local_dfb = get_local_dfb_interface(operand_id);
     const auto& slot = local_dfb.tc_slots[local_dfb.tc_idx];
-    uint32_t base_address = slot.base_addr + slot.rd_offset;
+    uint32_t base_address = slot.base_addr + dfb_slot_cursor_offset_units(local_dfb, slot, slot.rd_entry_idx);
     // Per-tile spacing is stride_size, not entry_size (matches pop_front/push_back).
     uint32_t offset_address = static_cast<uint32_t>(local_dfb.stride_size) * tile_index;
 #else

--- a/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer.inl
+++ b/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer.inl
@@ -283,8 +283,10 @@ inline uint32_t DataflowBuffer::get_write_ptr_impl() const {
 #if DFB_IS_COMPUTE_MATH
     return 0;
 #elif defined(COMPILE_FOR_TRISC) && defined(UCK_CHLKC_PACK)
-    return local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].base_addr +
-           local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].wr_offset;
+    {
+        const auto& slot = local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx];
+        return slot.base_addr + dfb_slot_cursor_offset_units(local_dfb_interface_, slot, slot.wr_entry_idx);
+    }
 #elif !defined(COMPILE_FOR_TRISC)
     return local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].wr_ptr;
 #else
@@ -298,8 +300,10 @@ inline uint32_t DataflowBuffer::get_read_ptr_impl() const {
 #if DFB_IS_COMPUTE_MATH
     return 0;
 #elif defined(COMPILE_FOR_TRISC) && defined(UCK_CHLKC_UNPACK)
-    return local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].base_addr +
-           local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].rd_offset;
+    {
+        const auto& slot = local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx];
+        return slot.base_addr + dfb_slot_cursor_offset_units(local_dfb_interface_, slot, slot.rd_entry_idx);
+    }
 #elif !defined(COMPILE_FOR_TRISC)
     return local_dfb_interface_.tc_slots[local_dfb_interface_.tc_idx].rd_ptr;
 #else

--- a/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_init.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_init.h
@@ -143,18 +143,17 @@ FORCE_INLINE void setup_local_dfb_interfaces(uint32_t tt_l1_ptr* dfb_config_base
                 uint32_t limit_s = per_risc_ptr->limit[i] >> cb_addr_shift;
                 // ring_size (TRISC): linear span limit_s - base for this TC—the same bound legacy wr_ptr/rd_ptr used.
                 // In STRIDED layouts that span includes other producers' interleaved entries between this TC's tiles.
+                // uint32 L1 units (full Quasar L1). Cursor byte-offset is derived from *_entry_idx (not stored).
 #if defined(COMPILE_FOR_TRISC) && defined(UCK_CHLKC_PACK)
                 dfb_interface.tc_slots[i].base_addr = base;
-                dfb_interface.tc_slots[i].wr_offset = 0;
-                dfb_interface.tc_slots[i].ring_size = static_cast<uint16_t>(limit_s - base);
+                dfb_interface.tc_slots[i].ring_size = limit_s - base;
                 dfb_interface.tc_slots[i].packed_tile_counter = per_risc_ptr->packed_tile_counter[i];
                 dfb_interface.tc_slots[i].base_entry_idx = static_cast<uint16_t>(
                     (base - dfb_interface.tc_slots[0].base_addr) / dfb_interface.entry_size);
                 dfb_interface.tc_slots[i].wr_entry_idx = dfb_interface.tc_slots[i].base_entry_idx;
 #elif defined(COMPILE_FOR_TRISC)
                 dfb_interface.tc_slots[i].base_addr = base;
-                dfb_interface.tc_slots[i].rd_offset = 0;
-                dfb_interface.tc_slots[i].ring_size = static_cast<uint16_t>(limit_s - base);
+                dfb_interface.tc_slots[i].ring_size = limit_s - base;
                 dfb_interface.tc_slots[i].packed_tile_counter = per_risc_ptr->packed_tile_counter[i];
                 dfb_interface.tc_slots[i].base_entry_idx = static_cast<uint16_t>(
                     (base - dfb_interface.tc_slots[0].base_addr) / dfb_interface.entry_size);

--- a/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_interface.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_interface.h
@@ -29,10 +29,13 @@ extern overlay::RemapperAPI g_remapper_configurator;
 
 #if defined(COMPILE_FOR_TRISC) && defined(UCK_CHLKC_PACK)
 
+// ring_size is uint32 L1-aligned units so a DFB can span full Quasar L1 (~4 MB).
+// Cursor byte-offset is not stored: it is derived from wr_entry_idx (advances in lockstep
+// with stride_size / stride_size_tiles). That keeps sizeof(LocalDFBInterface)==89 so
+// g_dfb_interface[16] + logical map fit in pack TLS (2048) with the required 256B stack.
 struct DFBTCSlot {
     uint32_t base_addr;
-    uint16_t wr_offset;
-    uint16_t ring_size;
+    uint32_t ring_size;
     uint16_t wr_entry_idx;
     uint16_t base_entry_idx;
     dfb::PackedTileCounter packed_tile_counter;
@@ -54,10 +57,10 @@ static_assert(sizeof(LocalDFBInterface) == 89, "LocalDFBInterface (pack TRISC) s
 
 #elif defined(COMPILE_FOR_TRISC)
 
+// Same compact layout as pack: uint32 ring_size, cursor offset derived from rd_entry_idx.
 struct DFBTCSlot {
     uint32_t base_addr;
-    uint16_t rd_offset;
-    uint16_t ring_size;
+    uint32_t ring_size;
     uint16_t rd_entry_idx;
     uint16_t base_entry_idx;
     dfb::PackedTileCounter packed_tile_counter;
@@ -111,6 +114,18 @@ struct LocalDFBInterface {
 static_assert(sizeof(DFBTCSlot) == 17, "DFBTCSlot size is incorrect");
 static_assert(sizeof(LocalDFBInterface) == 123, "LocalDFBInterface size is incorrect");
 
+#endif
+
+#if defined(COMPILE_FOR_TRISC)
+// Byte-offset (L1 units) of the current FIFO cursor from slot.base_addr.
+// wr/rd_entry_idx and the former wr/rd_offset advance in lockstep:
+//   entry += n * stride_size_tiles;  offset += n * stride_size;
+// so offset is recoverable without storing it (saves 4B/slot on pack TLS).
+inline __attribute__((always_inline)) uint32_t
+dfb_slot_cursor_offset_units(const LocalDFBInterface& intf, const DFBTCSlot& slot, uint32_t entry_idx) {
+    const uint32_t delta_entries = entry_idx - static_cast<uint32_t>(slot.base_entry_idx);
+    return (delta_entries / static_cast<uint32_t>(intf.stride_size_tiles)) * static_cast<uint32_t>(intf.stride_size);
+}
 #endif
 
 inline LocalDFBInterface& get_local_dfb_interface(uint32_t logical_dfb_id) {

--- a/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
+++ b/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
@@ -614,8 +614,6 @@ static void validate_ring_extent(const DataflowBufferImpl& dfb) {
     const uint16_t capacity = dfb.capacity;
     const uint32_t stride_in_entries = dfb.stride_in_entries;
     const uint32_t id = dfb.id;
-    // TRISC pack/unpack store the ring extent in uint16_t L1-aligned units; only Quasar (tile-counter
-    // hardware) has this constraint, and only when a Tensix RISC participates in the DFB.
     if (!MetalContext::instance().hal().has_tile_counter_registers()) {
         return;
     }
@@ -624,13 +622,36 @@ static void validate_ring_extent(const DataflowBufferImpl& dfb) {
         return;
     }
     const uint64_t ring_bytes = static_cast<uint64_t>(config.entry_size) * (stride_in_entries * (capacity - 1U) + 1U);
-    const uint32_t l1_align = MetalContext::instance().hal().get_alignment(HalMemType::L1);
+    const auto& hal = MetalContext::instance().hal();
+    const uint32_t l1_align = hal.get_alignment(HalMemType::L1);
+    const uint32_t unreserved_l1_size =
+        hal.get_dev_size(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::DEFAULT_UNRESERVED);
     TT_FATAL(
         ring_bytes % l1_align == 0,
         "DFB {}: ring size in bytes ({}) must be a multiple of L1 alignment ({})",
         id,
         ring_bytes,
         l1_align);
+    const uint64_t entry_size_trisc_units = static_cast<uint64_t>(config.entry_size) / l1_align;
+    TT_FATAL(
+        entry_size_trisc_units <= std::numeric_limits<uint16_t>::max(),
+        "DFB {}: TRISC entry_size ({} L1 units of {} bytes) exceeds uint16_t; reduce entry_size",
+        id,
+        entry_size_trisc_units,
+        l1_align);
+    const uint64_t stride_size_trisc_units = entry_size_trisc_units * stride_in_entries;
+    TT_FATAL(
+        stride_size_trisc_units <= std::numeric_limits<uint16_t>::max(),
+        "DFB {}: TRISC stride_size ({} L1 units of {} bytes) exceeds uint16_t; reduce entry_size or stride",
+        id,
+        stride_size_trisc_units,
+        l1_align);
+    TT_FATAL(
+        stride_in_entries <= std::numeric_limits<uint8_t>::max(),
+        "DFB {}: stride_in_entries ({}) exceeds uint8_t (TRISC stride_size_tiles); reduce producers/consumers",
+        id,
+        stride_in_entries);
+
     const uint64_t ring_trisc_units = ring_bytes / l1_align;
     TT_FATAL(
         ring_trisc_units > 0U,
@@ -639,12 +660,19 @@ static void validate_ring_extent(const DataflowBufferImpl& dfb) {
         ring_bytes,
         l1_align);
     TT_FATAL(
-        ring_trisc_units < 65536U,
-        "DFB {}: TRISC ring extent ({} L1 units of {} bytes) exceeds uint16_t; reduce capacity, stride, or "
+        ring_trisc_units <= std::numeric_limits<uint32_t>::max(),
+        "DFB {}: TRISC ring extent ({} L1 units of {} bytes) exceeds uint32_t; reduce capacity, stride, or "
         "entry_size",
         id,
         ring_trisc_units,
         l1_align);
+    TT_FATAL(
+        ring_bytes <= unreserved_l1_size,
+        "DFB {}: ring size ({} bytes) exceeds Tensix unreserved L1 size ({} bytes); reduce capacity, stride, or "
+        "entry_size",
+        id,
+        ring_bytes,
+        unreserved_l1_size);
 }
 
 static dfb_txn_id_descriptor_t make_txn_descriptor(
@@ -1083,7 +1111,7 @@ void ProgramImpl::finalize_single_dfb_config(
             "(different Neos). Un-scoped Tensix-to-Tensix DFBs are not allowed.");
     }
 
-    // TRISC pack/unpack store ring extent in uint16_t L1-aligned units; host must reject oversized rings.
+    // TRISC pack/unpack store ring extent in uint32_t L1-aligned units; host rejects rings > L1 / uint32.
     validate_ring_extent(*dfb);
 
     dfb->risc_mask = config.producer_risc_mask | config.consumer_risc_mask;


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
We were unnecessarily shortening the `ring_size` field on DFB interface. This increases it to store as uint32_t. To avoid growing beyond available local mem space dropped stored wr_offset/rd_offset and derive the FIFO cursor from *_entry_idx (lockstep with stride_size / stride_size_tiles) so pack LocalDFBInterface stays 89 B 
FYI @bbradelTT

verified with Watcher on DFB tests that we don't exceed local mem

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=abhullar/16-bit)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:abhullar/16-bit)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=abhullar/16-bit)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:abhullar/16-bit)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=abhullar/16-bit)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:abhullar/16-bit)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=abhullar/16-bit)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:abhullar/16-bit)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=abhullar/16-bit)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:abhullar/16-bit)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=abhullar/16-bit)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:abhullar/16-bit)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=abhullar/16-bit)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:abhullar/16-bit)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=abhullar/16-bit)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:abhullar/16-bit)