### PR TITLE
[metal] Add ProgramDescriptor::core_partition (cached work-split)

### DIFF
--- a/tt_metal/api/tt-metalium/program_descriptors.hpp
+++ b/tt_metal/api/tt-metalium/program_descriptors.hpp
@@ -209,6 +209,21 @@ struct KernelDescriptor {
     void emplace_common_runtime_args(const RTArgList& args);
 };
 
+// The work-split produced by split_work_to_cores(): which cores run the kernels and how many
+// units each group handles.  When create_descriptor() records it on ProgramDescriptor, the framework
+// caches it at cache miss and hands it back to override_runtime_arguments() on every cache hit, so an
+// op re-applies its per-dispatch args against the cached split WITHOUT re-deriving it -- the
+// descriptor-model equivalent of what legacy shared_variables_t cached.
+struct CorePartition {
+    uint32_t num_cores = 0;
+    CoreRangeSet all_cores;
+    CoreRangeSet core_group_1;
+    CoreRangeSet core_group_2;
+    uint32_t units_per_core_group_1 = 0;
+    uint32_t units_per_core_group_2 = 0;
+    std::vector<CoreCoord> cores;
+};
+
 struct ProgramDescriptor {
     using KernelDescriptors = ttsl::SmallVector<KernelDescriptor, 3>;
     using SemaphoreDescriptors = ttsl::SmallVector<SemaphoreDescriptor, 3>;
@@ -218,6 +233,10 @@ struct ProgramDescriptor {
     SemaphoreDescriptors semaphores;
     CBDescriptors cbs;
     std::optional<std::uint64_t> custom_program_hash;
+
+    // Optional cached work-split (see CorePartition).  When set, the framework stashes it at cache miss
+    // and provides it on cache hits, so the op skips re-deriving the split when re-applying dynamic args.
+    std::optional<CorePartition> core_partition;
 
     std::optional<uint32_t> find_available_semaphore_id(const CoreCoord& core, CoreType core_type) const;
 };


### PR DESCRIPTION
## What
Adds `CorePartition` (the `split_work_to_cores()` result — cores + work groups + units per group) and an optional `ProgramDescriptor::core_partition`.

**Pure data addition. No behavior change — no framework code reads it yet.** This is the metal half of a 3-PR split; it lands the descriptor field so the ttnn side can build on it.

## Why
Descriptor ops that re-apply hash-excluded per-dispatch runtime args on a cache hit (RNG seeds, packed scalars, cache indices, per-core offsets) currently either re-run `create_descriptor()` (rebuilds the whole descriptor — a measured ~2× cache-hit dispatch regression) or lean on `get_dynamic_runtime_args` + `resolve_bindings` (the shim, with its aliasing/validate-on-hit edge cases).

Caching the work-split on the descriptor lets a factory's `override_runtime_arguments()` re-apply its per-dispatch args **in place over the cached split** — no rebuild, no split re-derivation, no `resolve_bindings` — which is exactly what legacy `shared_variables_t` did.

## Follow-ups
- **ttnn PR:** `MeshDeviceOperationAdapter` caches `core_partition` at cache miss and hands it to `override_runtime_arguments(..., core_partition)` on a cache hit.
- **op PR(s):** ternary (reference) + the ~20 descriptor ops that re-apply dynamic scalars adopt the pattern.

Draft until the descriptor's planned move into ttnn; opening now so the metal-API addition can be reviewed in isolation.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/descriptor-core-partition-metal)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/descriptor-core-partition-metal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/descriptor-core-partition-metal)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/descriptor-core-partition-metal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=dgomez/descriptor-core-partition-metal)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:dgomez/descriptor-core-partition-metal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/descriptor-core-partition-metal)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/descriptor-core-partition-metal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/descriptor-core-partition-metal)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/descriptor-core-partition-metal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/descriptor-core-partition-metal)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/descriptor-core-partition-metal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/descriptor-core-partition-metal)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/descriptor-core-partition-metal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/descriptor-core-partition-metal)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/descriptor-core-partition-metal)