### PR TITLE
[LLK][Feature] Add SFPU causal conv1d + SiLU LLK

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
@@ -4600,6 +4600,40 @@ class TernarySFPUGolden:
 
 
 @register_golden
+class CausalConv1dSiluGolden:
+    """Golden for the fused causal conv1d + SiLU op (ckernel_sfpu_causal_conv1d_silu.h),
+    the KDA (Kimi Delta Attention) conv1d node from tt-blaze#2388/#2429.
+
+    Per channel: new_cache = a*x + b*y + c*z + d*w (a 4-tap weighted sum where every tap
+    weight is itself a per-channel tensor, not a scalar), then one output is
+    SiLU(new_cache) and the other is the 3-wide causal-cache shift [new_cache, x, y].
+    Returned in the same order the kernel packs its four Res tiles: (new_cache, x, y,
+    silu_out).
+    """
+
+    def __call__(self, wa, wb, wc, wd, x, y, z, w, data_format):
+        wa = wa.flatten().to(torch.float32)
+        wb = wb.flatten().to(torch.float32)
+        wc = wc.flatten().to(torch.float32)
+        wd = wd.flatten().to(torch.float32)
+        x = x.flatten().to(torch.float32)
+        y = y.flatten().to(torch.float32)
+        z = z.flatten().to(torch.float32)
+        w = w.flatten().to(torch.float32)
+
+        new_cache = wa * x + wb * y + wc * z + wd * w
+        silu_out = new_cache * torch.sigmoid(new_cache)
+
+        torch_format = format_dict[data_format]
+        return (
+            new_cache.to(torch_format).flatten(),
+            x.to(torch_format).flatten(),
+            y.to(torch_format).flatten(),
+            silu_out.to(torch_format).flatten(),
+        )
+
+
+@register_golden
 class ScalarBinopGolden:
     """Golden for the float unary-with-scalar binops in binop_with_unary.h
     (add / sub / mul / div / rsub).

--- a/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
@@ -4607,8 +4607,9 @@ class CausalConv1dSiluGolden:
     Per channel: new_cache = a*x + b*y + c*z + d*w (a 4-tap weighted sum where every tap
     weight is itself a per-channel tensor, not a scalar), then one output is
     SiLU(new_cache) and the other is the 3-wide causal-cache shift [new_cache, x, y].
-    Returned in the same order the kernel packs its four Res tiles: (new_cache, x, y,
-    silu_out).
+    Returns a single tensor holding the kernel's four Res tiles concatenated in pack
+    order (new_cache, x, y, silu_out) -- matching the single-tensor golden convention of
+    WhereGolden/TernarySFPUGolden so the compile-producer's dummy golden stays compatible.
     """
 
     def __call__(self, wa, wb, wc, wd, x, y, z, w, data_format):
@@ -4625,11 +4626,13 @@ class CausalConv1dSiluGolden:
         silu_out = new_cache * torch.sigmoid(new_cache)
 
         torch_format = format_dict[data_format]
-        return (
-            new_cache.to(torch_format).flatten(),
-            x.to(torch_format).flatten(),
-            y.to(torch_format).flatten(),
-            silu_out.to(torch_format).flatten(),
+        return torch.cat(
+            [
+                new_cache.to(torch_format).flatten(),
+                x.to(torch_format).flatten(),
+                y.to(torch_format).flatten(),
+                silu_out.to(torch_format).flatten(),
+            ]
         )
 
 

--- a/tt_metal/tt-llk/tests/python_tests/test_causal_conv1d_silu.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_causal_conv1d_silu.py
@@ -1,0 +1,119 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+from helpers.format_config import DataFormat
+from helpers.golden_generators import CausalConv1dSiluGolden, get_golden_generator
+from helpers.llk_params import DestAccumulation, format_dict
+from helpers.param_config import input_output_formats, parametrize
+from helpers.stimuli_config import StimuliConfig
+from helpers.stimuli_generator import StimuliSpec, generate_stimuli
+from helpers.test_config import TestConfig
+from helpers.test_variant_parameters import DISABLE_SRC_ZERO_FLAG
+from helpers.utils import passed_test
+
+# Tile-count layout matches sfpu_causal_conv1d_silu_test.cpp:
+#   buffer_A tiles: [wa, wb, wc, wd]  (4 per-channel conv weights)
+#   buffer_B tiles: [x, y, z, w]      (3 cache entries + 1 matmul-produced sample)
+#   buffer_Res tiles: [new_cache, x, y, silu_out]
+_NUM_WEIGHT_TILES = 4
+_NUM_DATA_TILES = 4
+_NUM_RES_TILES = 4
+
+
+def _run_causal_conv1d_silu(formats, dest_acc):
+    spec = StimuliSpec.uniform(low=-1.0, high=1.0)
+
+    # 8 independent single-tile operands, generated one pair at a time so the
+    # tile order inside the concatenated buffers is fully under our control
+    # (avoids relying on generate_stimuli's internal multi-tile layout).
+    wa, _, wb, _ = generate_stimuli(
+        stimuli_format_A=formats.input_format,
+        stimuli_format_B=formats.input_format,
+        spec_A=spec,
+        spec_B=spec,
+    )
+    wc, _, wd, _ = generate_stimuli(
+        stimuli_format_A=formats.input_format,
+        stimuli_format_B=formats.input_format,
+        spec_A=spec,
+        spec_B=spec,
+    )
+    x, _, y, _ = generate_stimuli(
+        stimuli_format_A=formats.input_format,
+        stimuli_format_B=formats.input_format,
+        spec_A=spec,
+        spec_B=spec,
+    )
+    z, _, w, _ = generate_stimuli(
+        stimuli_format_A=formats.input_format,
+        stimuli_format_B=formats.input_format,
+        spec_A=spec,
+        spec_B=spec,
+    )
+
+    buffer_A = torch.cat([t.flatten() for t in (wa, wb, wc, wd)])
+    buffer_B = torch.cat([t.flatten() for t in (x, y, z, w)])
+
+    golden_generator = get_golden_generator(CausalConv1dSiluGolden)
+    new_cache_g, x_g, y_g, silu_g = golden_generator(
+        wa, wb, wc, wd, x, y, z, w, formats.output_format
+    )
+    golden = torch.cat([new_cache_g, x_g, y_g, silu_g])
+
+    configuration = TestConfig(
+        "sources/sfpu_causal_conv1d_silu_test.cpp",
+        formats,
+        templates=[DISABLE_SRC_ZERO_FLAG(True)],
+        runtimes=[],
+        variant_stimuli=StimuliConfig(
+            buffer_A,
+            formats.input_format,
+            buffer_B,
+            formats.input_format,
+            formats.output_format,
+            tile_count_A=_NUM_WEIGHT_TILES,
+            tile_count_B=_NUM_DATA_TILES,
+            tile_count_res=_NUM_RES_TILES,
+        ),
+        unpack_to_dest=formats.input_format.is_32_bit(),
+        dest_acc=dest_acc,
+        compile_time_formats=True,
+    )
+
+    res_from_L1 = configuration.run().result
+
+    assert len(res_from_L1) == len(
+        golden
+    ), "Result tensor and golden tensor are not of the same length"
+
+    torch_format = format_dict[formats.output_format]
+    golden_tensor = torch.tensor(golden, dtype=torch_format).flatten()
+    res_tensor = torch.tensor(res_from_L1, dtype=torch_format).flatten()
+
+    assert passed_test(
+        golden_tensor, res_tensor, formats.output_format
+    ), "Assert against golden failed"
+
+
+@parametrize(
+    formats=input_output_formats(
+        [
+            DataFormat.Float16_b,
+            DataFormat.Float32,
+        ],
+        same=True,
+    ),
+    dest_acc=[DestAccumulation.No, DestAccumulation.Yes],
+)
+def test_causal_conv1d_silu(formats, dest_acc):
+    if formats.input_format == DataFormat.Float32 and dest_acc == DestAccumulation.No:
+        pytest.skip("Float32 inputs with dest_acc=No are not supported")
+    if (
+        formats.input_format == DataFormat.Float16_b
+        and dest_acc == DestAccumulation.Yes
+    ):
+        pytest.skip("Float16_b inputs with dest_acc=Yes are not required for this op")
+
+    _run_causal_conv1d_silu(formats, dest_acc)

--- a/tt_metal/tt-llk/tests/python_tests/test_causal_conv1d_silu.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_causal_conv1d_silu.py
@@ -3,6 +3,7 @@
 
 import pytest
 import torch
+from conftest import skip_for_quasar, skip_for_wormhole
 from helpers.format_config import DataFormat
 from helpers.golden_generators import CausalConv1dSiluGolden, get_golden_generator
 from helpers.llk_params import DestAccumulation, format_dict
@@ -57,10 +58,7 @@ def _run_causal_conv1d_silu(formats, dest_acc):
     buffer_B = torch.cat([t.flatten() for t in (x, y, z, w)])
 
     golden_generator = get_golden_generator(CausalConv1dSiluGolden)
-    new_cache_g, x_g, y_g, silu_g = golden_generator(
-        wa, wb, wc, wd, x, y, z, w, formats.output_format
-    )
-    golden = torch.cat([new_cache_g, x_g, y_g, silu_g])
+    golden = golden_generator(wa, wb, wc, wd, x, y, z, w, formats.output_format)
 
     configuration = TestConfig(
         "sources/sfpu_causal_conv1d_silu_test.cpp",
@@ -97,6 +95,11 @@ def _run_causal_conv1d_silu(formats, dest_acc):
     ), "Assert against golden failed"
 
 
+# The C++ source includes ckernel_sfpu_causal_conv1d_silu.h, which only exists under
+# tt_llk_blackhole; TestConfig compiles against the active arch's include roots, so Wormhole and
+# Quasar would fail to compile rather than skip. This op is Blackhole-only for now.
+@skip_for_wormhole
+@skip_for_quasar
 @parametrize(
     formats=input_output_formats(
         [

--- a/tt_metal/tt-llk/tests/sources/sfpu_causal_conv1d_silu_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/sfpu_causal_conv1d_silu_test.cpp
@@ -1,0 +1,175 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <algorithm>
+#include <cstdint>
+#include <type_traits>
+
+#include "ckernel.h"
+#include "ckernel_debug.h"
+#include "llk_defs.h"
+
+// Globals
+std::uint32_t unp_cfg_context          = 0;
+std::uint32_t pack_sync_tile_dst_ptr   = 0;
+std::uint32_t math_sync_tile_dst_index = 0;
+
+// This test hand-rolls its own unpack/math/pack sequence (like ttnn_where_test.cpp) instead of
+// going through the generic SfpuType-templated ternary dispatch, since the new op takes 8
+// input tiles + 2 computed outputs -- more operands than that shared 3-in/1-out dispatch
+// supports. See ckernel_sfpu_causal_conv1d_silu.h for the op itself.
+//
+// Layout (all full 32x32 tiles):
+//   buffer_A: [wa, wb, wc, wd]   -- 4 per-channel conv weights (tiles 0-3)
+//   buffer_B: [x, y, z, w]      -- 3 cache entries + 1 matmul-produced sample (tiles 0-3)
+//   buffer_Res: [new_cache, x, y, silu_out] -- updated 3-wide cache (new_cache,x,y) + SiLU output
+//
+// DST tile indices 0-7 hold the 8 inputs (wa,wb,wc,wd,x,y,z,w). The two computed outputs reuse
+// wa's slot (0) and wb's slot (1) -- both fully consumed into registers by
+// ckernel_sfpu_causal_conv1d_silu.h before its first store -- so the whole op stays inside
+// DstSync::SyncHalf's proven 8-tile budget, matching the exact `dst_index_out == dst_index_in0`
+// reuse `calculate_addcmul()`/`calculate_where()` already rely on in production.
+//
+// NOTE: an earlier revision of this test failed against golden on ttsim (x/y passthrough, which
+// this op never touches, always matched; only the two computed outputs were wrong). The root
+// cause was that _calculate_causal_conv1d_silu_() was invoked directly, once, covering only
+// ITERATIONS=8 rows -- a single 16x16 face's worth, not the full 32x32 tile. Every other SFPU op
+// in this codebase runs through _llk_math_eltwise_sfpu_apply_vector_mode_ (VectorMode::RC), which
+// calls the op 4 times -- once per face -- advancing the dest face address between calls; this
+// test now does that explicitly below.
+
+static constexpr std::uint8_t resolve_format(std::uint8_t in)
+{
+    switch (static_cast<DataFormat>(in))
+    {
+        case DataFormat::Float32:
+        case DataFormat::Float16_b:
+            return in;
+        default:
+            return static_cast<std::uint8_t>(DataFormat::Float16_b);
+    }
+}
+
+#ifdef LLK_TRISC_UNPACK
+
+#include "llk_unpack_A.h"
+#include "llk_unpack_common.h"
+#include "params.h"
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+    const std::uint8_t UNPACK_FMT = resolve_format(UNPACK_A_IN);
+
+    _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
+        UNPACK_FMT, UNPACK_FMT, UNPACK_FMT, UNPACK_FMT, FACE_R_DIM, FACE_R_DIM, 4 /* num_faces */, 4 /* num_faces */);
+    _llk_unpack_A_init_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
+        0 /* transpose_of_faces */, 0 /* within_face_16x16_transpose */, ckernel::DEFAULT_TENSOR_SHAPE, UNPACK_FMT, UNPACK_FMT);
+
+    // weights a,b,c,d
+    _llk_unpack_A_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(L1_ADDRESS(params.buffer_A[0]), UNPACK_FMT, UNPACK_FMT);
+    _llk_unpack_A_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(L1_ADDRESS(params.buffer_A[1]), UNPACK_FMT, UNPACK_FMT);
+    _llk_unpack_A_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(L1_ADDRESS(params.buffer_A[2]), UNPACK_FMT, UNPACK_FMT);
+    _llk_unpack_A_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(L1_ADDRESS(params.buffer_A[3]), UNPACK_FMT, UNPACK_FMT);
+
+    // cache x,y,z + matmul-produced sample w
+    _llk_unpack_A_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(L1_ADDRESS(params.buffer_B[0]), UNPACK_FMT, UNPACK_FMT);
+    _llk_unpack_A_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(L1_ADDRESS(params.buffer_B[1]), UNPACK_FMT, UNPACK_FMT);
+    _llk_unpack_A_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(L1_ADDRESS(params.buffer_B[2]), UNPACK_FMT, UNPACK_FMT);
+    _llk_unpack_A_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(L1_ADDRESS(params.buffer_B[3]), UNPACK_FMT, UNPACK_FMT);
+}
+
+#endif
+
+#ifdef LLK_TRISC_MATH
+
+#include "ckernel_sfpu.h"
+#include "ckernel_sfpu_causal_conv1d_silu.h"
+#include "llk_lib_math_wrappers.h"
+#include "params.h"
+
+using namespace ckernel;
+
+static constexpr ckernel::DstSync DST_SYNC_MODE = ckernel::DstSync::SyncHalf;
+
+#include "llk_math_eltwise_unary_sfpu.h"
+
+void run_kernel(RUNTIME_PARAMETERS)
+{
+    const std::uint8_t MATH_FMT  = resolve_format(UNPACK_A_IN);
+    constexpr bool is_int_fpu_en = false;
+
+    _llk_math_pack_sync_init_<DST_SYNC_MODE, is_fp32_dest_acc_en>();
+    _llk_math_hw_configure_<is_fp32_dest_acc_en>(MATH_FMT, MATH_FMT);
+    _llk_math_eltwise_unary_datacopy_init_wrapper_<DataCopyType::A2D, is_fp32_dest_acc_en, BroadcastType::NONE, is_int_fpu_en, PackMode::Default>(
+        4 /* num_faces */, MATH_FMT);
+    _llk_math_wait_for_dest_available_<DST_SYNC_MODE>();
+
+    // Copy the 8 unpacked input tiles (SrcA) into DST tiles 0-7, in the same order they were
+    // unpacked: 0=wa 1=wb 2=wc 3=wd 4=x 5=y 6=z 7=w.
+    for (std::uint32_t dst_index = 0; dst_index < 8; ++dst_index)
+    {
+        _llk_math_eltwise_unary_datacopy_<DataCopyType::A2D, DST_SYNC_MODE, is_fp32_dest_acc_en, BroadcastType::NONE, unpack_to_dest>(
+            dst_index, MATH_FMT, MATH_FMT);
+    }
+    // _llk_math_eltwise_unary_datacopy_uninit_() is a no-op (see llk_math_eltwise_unary_datacopy.h);
+    // the real "start a fresh sfpi dst_reg addressing pass at tile-0 base" reset -- with the
+    // required STALLWAIT for the preceding datacopies to drain -- is _llk_math_eltwise_sfpu_start_,
+    // the same primitive the generic ternary/unary SFPU dispatch (llk_math_eltwise_*_sfpu_params.h)
+    // uses ahead of any sfpi-based compute.
+    _llk_math_eltwise_sfpu_start_(0);
+
+    // A 32x32 tile is 4 faces of 16x16; each call below advances only ITERATIONS=8 rows within
+    // the current face's addressing window, so it must run once per face (matching how
+    // _llk_math_eltwise_sfpu_apply_vector_mode_(..., VectorMode::RC) drives every other SFPU op
+    // in this codebase), advancing the dest face address between calls.
+    constexpr int kIterations = 8;
+#pragma GCC unroll 4
+    for (std::uint32_t face = 0; face < TILE_NUM_FACES; ++face)
+    {
+        ckernel::sfpu::_calculate_causal_conv1d_silu_<false /*APPROXIMATION_MODE*/, is_fp32_dest_acc_en, kIterations>(
+            0 /*wa*/,
+            1 /*wb*/,
+            2 /*wc*/,
+            3 /*wd*/,
+            4 /*x*/,
+            5 /*y*/,
+            6 /*z*/,
+            7 /*w*/,
+            0 /*cache_out, reuses dead wa slot*/,
+            1 /*silu_out, reuses dead wb slot*/);
+        _llk_math_eltwise_sfpu_inc_dst_face_addr_();
+    }
+    _llk_math_eltwise_sfpu_done_();
+
+    _llk_math_dest_section_done_<DST_SYNC_MODE, is_fp32_dest_acc_en>();
+}
+
+#endif
+
+#ifdef LLK_TRISC_PACK
+
+#include "llk_lib_pack_wrappers.h"
+#include "llk_pack_common.h"
+#include "params.h"
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+    const std::uint8_t PACK_FMT = resolve_format(UNPACK_A_IN);
+
+    _llk_pack_hw_configure_wrapper_<is_fp32_dest_acc_en, PackMode::Default>(PACK_FMT, PACK_FMT, 16 * 16 * 4 /* tile_size */);
+    _llk_pack_init_wrapper_<PackMode::Default, false /* zero_output */>(PACK_FMT);
+    _llk_pack_dest_init_wrapper_<DstSync::SyncHalf, is_fp32_dest_acc_en, PackMode::Default>();
+
+    _llk_packer_wait_for_math_done_();
+    // Res[0]=new_cache (dst 0, == wa's slot), Res[1]=x unchanged (dst 4), Res[2]=y unchanged
+    // (dst 5), Res[3]=silu_out (dst 1, == wb's slot) -- matches the issue's outB=[new_cache,x,y],
+    // outA=SiLU(new_cache).
+    _llk_pack_<DstSync::SyncHalf, is_fp32_dest_acc_en, ckernel::PackMode::Default>(0, L1_ADDRESS(params.buffer_Res[0]));
+    _llk_pack_<DstSync::SyncHalf, is_fp32_dest_acc_en, ckernel::PackMode::Default>(4, L1_ADDRESS(params.buffer_Res[1]));
+    _llk_pack_<DstSync::SyncHalf, is_fp32_dest_acc_en, ckernel::PackMode::Default>(5, L1_ADDRESS(params.buffer_Res[2]));
+    _llk_pack_<DstSync::SyncHalf, is_fp32_dest_acc_en, ckernel::PackMode::Default>(1, L1_ADDRESS(params.buffer_Res[3]));
+    _llk_pack_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+}
+
+#endif

--- a/tt_metal/tt-llk/tests/sources/sfpu_causal_conv1d_silu_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/sfpu_causal_conv1d_silu_test.cpp
@@ -26,10 +26,17 @@ std::uint32_t math_sync_tile_dst_index = 0;
 //   buffer_Res: [new_cache, x, y, silu_out] -- updated 3-wide cache (new_cache,x,y) + SiLU output
 //
 // DST tile indices 0-7 hold the 8 inputs (wa,wb,wc,wd,x,y,z,w). The two computed outputs reuse
-// wa's slot (0) and wb's slot (1) -- both fully consumed into registers by
-// ckernel_sfpu_causal_conv1d_silu.h before its first store -- so the whole op stays inside
-// DstSync::SyncHalf's proven 8-tile budget, matching the exact `dst_index_out == dst_index_in0`
-// reuse `calculate_addcmul()`/`calculate_where()` already rely on in production.
+// wa's slot (0) and wb's slot (1): ckernel_sfpu_causal_conv1d_silu.h stores each row only after
+// that row's inputs have been loaded into registers, so reusing a dead weight slot for an output
+// is safe -- the same `dst_index_out == dst_index_in0` reuse `calculate_addcmul()`/
+// `calculate_where()` already rely on in production.
+//
+// Sync mode: 8 simultaneously-live DST tiles only fit under DstSync::SyncHalf for 16-bit dest
+// (get_dest_max_tiles<SyncHalf, /*accum=*/false, Tile32x32>() == 8). With fp32 dest-accumulation
+// SyncHalf's budget halves to 4 (get_dest_max_tiles<SyncHalf, /*accum=*/true, ...>() == 4), so
+// tiles 4-7 would spill past the half. This test therefore runs under DstSync::SyncFull, whose
+// fp32 budget is exactly 8 (and 16 for bf16), covering both formats safely -- the same choice
+// reduce_sfpu_unary.cpp makes when an op needs more than SyncHalf's slots.
 //
 // NOTE: an earlier revision of this test failed against golden on ttsim (x/y passthrough, which
 // this op never touches, always matched; only the two computed outputs were wrong). The root
@@ -90,7 +97,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
 using namespace ckernel;
 
-static constexpr ckernel::DstSync DST_SYNC_MODE = ckernel::DstSync::SyncHalf;
+static constexpr ckernel::DstSync DST_SYNC_MODE = ckernel::DstSync::SyncFull;
 
 #include "llk_math_eltwise_unary_sfpu.h"
 
@@ -112,11 +119,17 @@ void run_kernel(RUNTIME_PARAMETERS)
         _llk_math_eltwise_unary_datacopy_<DataCopyType::A2D, DST_SYNC_MODE, is_fp32_dest_acc_en, BroadcastType::NONE, unpack_to_dest>(
             dst_index, MATH_FMT, MATH_FMT);
     }
-    // _llk_math_eltwise_unary_datacopy_uninit_() is a no-op (see llk_math_eltwise_unary_datacopy.h);
-    // the real "start a fresh sfpi dst_reg addressing pass at tile-0 base" reset -- with the
-    // required STALLWAIT for the preceding datacopies to drain -- is _llk_math_eltwise_sfpu_start_,
-    // the same primitive the generic ternary/unary SFPU dispatch (llk_math_eltwise_*_sfpu_params.h)
-    // uses ahead of any sfpi-based compute.
+    // SFPU init, mirroring what the generic unary/ternary SFPU dispatch runs ahead of any
+    // sfpi-based compute (llk_math_eltwise_*_sfpu_params.h -> _llk_math_eltwise_*_sfpu_init_):
+    // program the SFPU config register (SFPCONFIG) and the zero-increment ADDR_MOD_7 that this
+    // op's sfpi::dst_reg[] loads/stores address through. Left at reset defaults these happen to
+    // be zero on a fresh boot, so skipping this "works" once but is fragile on silicon and after
+    // any op that leaves ADDR_MOD_7/SFPCONFIG dirty.
+    _llk_math_eltwise_unary_sfpu_init_once_();
+
+    // _llk_math_eltwise_sfpu_start_ is NOT the SFPU init: it only sets the dst write address for
+    // tile 0 and issues the STALLWAIT that drains the preceding datacopies (see
+    // llk_math_eltwise_sfpu_common.h). It must run after the init above and before the compute.
     _llk_math_eltwise_sfpu_start_(0);
 
     // A 32x32 tile is 4 faces of 16x16; each call below advances only ITERATIONS=8 rows within
@@ -127,7 +140,7 @@ void run_kernel(RUNTIME_PARAMETERS)
 #pragma GCC unroll 4
     for (std::uint32_t face = 0; face < TILE_NUM_FACES; ++face)
     {
-        ckernel::sfpu::_calculate_causal_conv1d_silu_<false /*APPROXIMATION_MODE*/, is_fp32_dest_acc_en, kIterations>(
+        ckernel::sfpu::_calculate_causal_conv1d_silu_<true /*APPROXIMATION_MODE*/, is_fp32_dest_acc_en, kIterations>(
             0 /*wa*/,
             1 /*wb*/,
             2 /*wc*/,
@@ -159,17 +172,17 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     _llk_pack_hw_configure_wrapper_<is_fp32_dest_acc_en, PackMode::Default>(PACK_FMT, PACK_FMT, 16 * 16 * 4 /* tile_size */);
     _llk_pack_init_wrapper_<PackMode::Default, false /* zero_output */>(PACK_FMT);
-    _llk_pack_dest_init_wrapper_<DstSync::SyncHalf, is_fp32_dest_acc_en, PackMode::Default>();
+    _llk_pack_dest_init_wrapper_<DstSync::SyncFull, is_fp32_dest_acc_en, PackMode::Default>();
 
     _llk_packer_wait_for_math_done_();
     // Res[0]=new_cache (dst 0, == wa's slot), Res[1]=x unchanged (dst 4), Res[2]=y unchanged
     // (dst 5), Res[3]=silu_out (dst 1, == wb's slot) -- matches the issue's outB=[new_cache,x,y],
-    // outA=SiLU(new_cache).
-    _llk_pack_<DstSync::SyncHalf, is_fp32_dest_acc_en, ckernel::PackMode::Default>(0, L1_ADDRESS(params.buffer_Res[0]));
-    _llk_pack_<DstSync::SyncHalf, is_fp32_dest_acc_en, ckernel::PackMode::Default>(4, L1_ADDRESS(params.buffer_Res[1]));
-    _llk_pack_<DstSync::SyncHalf, is_fp32_dest_acc_en, ckernel::PackMode::Default>(5, L1_ADDRESS(params.buffer_Res[2]));
-    _llk_pack_<DstSync::SyncHalf, is_fp32_dest_acc_en, ckernel::PackMode::Default>(1, L1_ADDRESS(params.buffer_Res[3]));
-    _llk_pack_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+    // outA=SiLU(new_cache). SyncFull to match the math thread (see the sync-mode note up top).
+    _llk_pack_<DstSync::SyncFull, is_fp32_dest_acc_en, ckernel::PackMode::Default>(0, L1_ADDRESS(params.buffer_Res[0]));
+    _llk_pack_<DstSync::SyncFull, is_fp32_dest_acc_en, ckernel::PackMode::Default>(4, L1_ADDRESS(params.buffer_Res[1]));
+    _llk_pack_<DstSync::SyncFull, is_fp32_dest_acc_en, ckernel::PackMode::Default>(5, L1_ADDRESS(params.buffer_Res[2]));
+    _llk_pack_<DstSync::SyncFull, is_fp32_dest_acc_en, ckernel::PackMode::Default>(1, L1_ADDRESS(params.buffer_Res[3]));
+    _llk_pack_dest_section_done_<DstSync::SyncFull, is_fp32_dest_acc_en>();
 }
 
 #endif

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_causal_conv1d_silu.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_causal_conv1d_silu.h
@@ -1,0 +1,132 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+#include "ckernel_sfpu_silu.h"
+#include "llk_assert.h"
+#include "sfpi.h"
+
+namespace ckernel::sfpu
+{
+
+/**
+ * @brief Fused per-channel causal conv1d (4-tap weighted sum) + SiLU.
+ *
+ * @tparam APPROXIMATION_MODE Selects the approximate math path for the SiLU half (unused by
+ *   the FMA half, kept for signature symmetry with other SFPU ops).
+ * @tparam is_fp32_dest_acc_en When false, both outputs are rounded to bf16 on store (matches
+ *   the `calculate_addcmul()`/`calculate_lerp()` convention); when true, both outputs are
+ *   stored at full fp32 precision.
+ * @tparam ITERATIONS Number of 32-lane rows to process *within one face* (one row per loop
+ *   iteration). A full 32x32 tile is 4 faces of 16x16; the caller must invoke this function once
+ *   per face (e.g. via `_llk_math_eltwise_sfpu_apply_vector_mode_(..., VectorMode::RC)`, or an
+ *   explicit 4x loop with `_llk_math_eltwise_sfpu_inc_dst_face_addr_()` between calls) to cover
+ *   the whole tile -- a single call only ever advances within the current face's window.
+ * @param dst_index_wa Tile holding per-channel weight `a` (multiplies `x`).
+ * @param dst_index_wb Tile holding per-channel weight `b` (multiplies `y`).
+ * @param dst_index_wc Tile holding per-channel weight `c` (multiplies `z`).
+ * @param dst_index_wd Tile holding per-channel weight `d` (multiplies `w`).
+ * @param dst_index_x Oldest-but-one cache entry.
+ * @param dst_index_y Middle cache entry.
+ * @param dst_index_z Newest cache entry (about to be evicted from the 3-wide cache).
+ * @param dst_index_w Newest sample, already produced by a preceding matmul.
+ * @param dst_index_cache_out Output tile for `new_cache = a*x + b*y + c*z + d*w`. May safely
+ *   equal any of `dst_index_wa/wb/wc/wd` (all 4 weight tiles are fully consumed into local
+ *   registers before this function's first store), matching the `dst_index_out ==
+ *   dst_index_in0` reuse convention `calculate_addcmul()`/`calculate_where()` already rely on.
+ * @param dst_index_silu_out Output tile for `SiLU(new_cache)`; same reuse rule as
+ *   `dst_index_cache_out`, and must differ from it.
+ *
+ * @note Implements the KDA (Kimi Delta Attention) conv1d node from
+ *   tt-blaze#2388/tt-blaze#2429: `new_cache` is the updated causal-conv accumulator (per
+ *   channel: `a*x + b*y + c*z + d*w`, all four operands are per-channel BF16 tensors, not
+ *   scalars); one output is `SiLU(new_cache)`, the other is the 3-wide cache shift
+ *   `[new_cache, x, y]`. This function computes only the two values that require new math
+ *   (`new_cache`, `SiLU(new_cache)`); the caller re-packs `x`/`y` unchanged to assemble the
+ *   3-wide shifted cache, since that half of the update is a pure data-movement concern, not
+ *   an SFPU compute one. All operands are expected already resident in Dest (unpacked/copied by
+ *   the caller), following the same `sfpi::dst_reg[dst_index*32 + row]` explicit-addressing
+ *   idiom as `calculate_addcmul()`/`calculate_lerp()`; unlike `addcmul`'s scalar `value`, every
+ *   weight here is a full per-channel tensor, so all four taps are genuine tensor*tensor FMAs,
+ *   accumulated once in registers (a single load of each of the 8 inputs, no intermediate Dest
+ *   round-trips) before the two final stores. @ref _sigmoid_piecewise_linear_positive_ is
+ *   reused unmodified for the SiLU half.
+ */
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
+inline void _calculate_causal_conv1d_silu_(
+    const std::uint32_t dst_index_wa,
+    const std::uint32_t dst_index_wb,
+    const std::uint32_t dst_index_wc,
+    const std::uint32_t dst_index_wd,
+    const std::uint32_t dst_index_x,
+    const std::uint32_t dst_index_y,
+    const std::uint32_t dst_index_z,
+    const std::uint32_t dst_index_w,
+    const std::uint32_t dst_index_cache_out,
+    const std::uint32_t dst_index_silu_out)
+{
+    LLK_ASSERT(dst_index_cache_out != dst_index_silu_out, "dst_index_cache_out and dst_index_silu_out must be distinct Dest tiles");
+
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
+
+    const std::uint32_t off_wa = dst_index_wa * dst_tile_size_sfpi;
+    const std::uint32_t off_wb = dst_index_wb * dst_tile_size_sfpi;
+    const std::uint32_t off_wc = dst_index_wc * dst_tile_size_sfpi;
+    const std::uint32_t off_wd = dst_index_wd * dst_tile_size_sfpi;
+    const std::uint32_t off_x  = dst_index_x * dst_tile_size_sfpi;
+    const std::uint32_t off_y  = dst_index_y * dst_tile_size_sfpi;
+    const std::uint32_t off_z  = dst_index_z * dst_tile_size_sfpi;
+    const std::uint32_t off_w  = dst_index_w * dst_tile_size_sfpi;
+
+    const std::uint32_t off_cache_out = dst_index_cache_out * dst_tile_size_sfpi;
+    const std::uint32_t off_silu_out  = dst_index_silu_out * dst_tile_size_sfpi;
+
+    for (int d = 0; d < ITERATIONS; d++)
+    {
+        const sfpi::vFloat wa = sfpi::dst_reg[off_wa];
+        const sfpi::vFloat wb = sfpi::dst_reg[off_wb];
+        const sfpi::vFloat wc = sfpi::dst_reg[off_wc];
+        const sfpi::vFloat wd = sfpi::dst_reg[off_wd];
+        const sfpi::vFloat x  = sfpi::dst_reg[off_x];
+        const sfpi::vFloat y  = sfpi::dst_reg[off_y];
+        const sfpi::vFloat z  = sfpi::dst_reg[off_z];
+        const sfpi::vFloat w  = sfpi::dst_reg[off_w];
+
+        // new_cache = a*x + b*y + c*z + d*w -- three chained tensor*tensor FMAs, entirely in
+        // registers (every operand is a per-channel tensor; unlike addcmul's scalar `value`, no
+        // term here is uniform across lanes).
+        sfpi::vFloat new_cache = wa * x;
+        new_cache              = wb * y + new_cache;
+        new_cache              = wc * z + new_cache;
+        new_cache              = wd * w + new_cache;
+
+        // SiLU(new_cache) = new_cache * sigmoid(new_cache), reusing the existing
+        // piecewise-linear sigmoid approximation unchanged.
+        sfpi::vFloat sig = _sigmoid_piecewise_linear_positive_(sfpi::abs(new_cache));
+        v_if (new_cache < 0.0f)
+        {
+            sig = 1.0f - sig;
+        }
+        v_endif;
+        const sfpi::vFloat silu_result = new_cache * sig;
+
+        if constexpr (!is_fp32_dest_acc_en)
+        {
+            sfpi::dst_reg[off_cache_out] = sfpi::convert<sfpi::vFloat16b>(new_cache, sfpi::RoundMode::Nearest);
+            sfpi::dst_reg[off_silu_out]  = sfpi::convert<sfpi::vFloat16b>(silu_result, sfpi::RoundMode::Nearest);
+        }
+        else
+        {
+            sfpi::dst_reg[off_cache_out] = new_cache;
+            sfpi::dst_reg[off_silu_out]  = silu_result;
+        }
+
+        sfpi::dst_reg++;
+    }
+}
+
+} // namespace ckernel::sfpu

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_causal_conv1d_silu.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_causal_conv1d_silu.h
@@ -16,45 +16,55 @@ namespace ckernel::sfpu
 /**
  * @brief Fused per-channel causal conv1d (4-tap weighted sum) + SiLU.
  *
- * @tparam APPROXIMATION_MODE Selects the approximate math path for the SiLU half (unused by
- *   the FMA half, kept for signature symmetry with other SFPU ops).
- * @tparam is_fp32_dest_acc_en When false, both outputs are rounded to bf16 on store (matches
+ * @tparam APPROXIMATION_MODE: Retained for signature symmetry with the other SFPU ops; the SiLU
+ *   half always evaluates the fast piecewise-linear sigmoid (@ref _sigmoid_piecewise_linear_positive_),
+ *   exactly as the shipping @ref _calculate_silu_ does on Blackhole and Wormhole. No separate
+ *   higher-accuracy path is offered: the accurate LUT sigmoid (@ref _calculate_sigmoid_) pins
+ *   LReg0-2/4-6, which cannot coexist with this op's four-tap tensor FMA inside Blackhole's usable
+ *   LReg0-6 budget, and the exp-based `_sfpu_sigmoid_` lives only in the Layer-2 metal stack.
+ * @tparam is_fp32_dest_acc_en: When false, both outputs are rounded to bf16 on store (matches
  *   the `calculate_addcmul()`/`calculate_lerp()` convention); when true, both outputs are
  *   stored at full fp32 precision.
- * @tparam ITERATIONS Number of 32-lane rows to process *within one face* (one row per loop
+ * @tparam ITERATIONS: Number of 32-lane rows to process *within one face* (one row per loop
  *   iteration). A full 32x32 tile is 4 faces of 16x16; the caller must invoke this function once
  *   per face (e.g. via `_llk_math_eltwise_sfpu_apply_vector_mode_(..., VectorMode::RC)`, or an
  *   explicit 4x loop with `_llk_math_eltwise_sfpu_inc_dst_face_addr_()` between calls) to cover
  *   the whole tile -- a single call only ever advances within the current face's window.
- * @param dst_index_wa Tile holding per-channel weight `a` (multiplies `x`).
- * @param dst_index_wb Tile holding per-channel weight `b` (multiplies `y`).
- * @param dst_index_wc Tile holding per-channel weight `c` (multiplies `z`).
- * @param dst_index_wd Tile holding per-channel weight `d` (multiplies `w`).
- * @param dst_index_x Oldest-but-one cache entry.
- * @param dst_index_y Middle cache entry.
- * @param dst_index_z Newest cache entry (about to be evicted from the 3-wide cache).
- * @param dst_index_w Newest sample, already produced by a preceding matmul.
- * @param dst_index_cache_out Output tile for `new_cache = a*x + b*y + c*z + d*w`. May safely
- *   equal any of `dst_index_wa/wb/wc/wd` (all 4 weight tiles are fully consumed into local
- *   registers before this function's first store), matching the `dst_index_out ==
- *   dst_index_in0` reuse convention `calculate_addcmul()`/`calculate_where()` already rely on.
- * @param dst_index_silu_out Output tile for `SiLU(new_cache)`; same reuse rule as
+ * @param dst_index_wa: Tile holding per-channel weight `a` (multiplies `x`).
+ * @param dst_index_wb: Tile holding per-channel weight `b` (multiplies `y`).
+ * @param dst_index_wc: Tile holding per-channel weight `c` (multiplies `z`).
+ * @param dst_index_wd: Tile holding per-channel weight `d` (multiplies `w`).
+ * @param dst_index_x: Newest prior cache entry -- retained by the shift `[new_cache, x, y]`.
+ * @param dst_index_y: Middle cache entry -- retained by the shift `[new_cache, x, y]`.
+ * @param dst_index_z: Oldest cache entry -- evicted by the shift `[new_cache, x, y]`.
+ * @param dst_index_w: Newest sample, already produced by a preceding matmul.
+ * @param dst_index_cache_out: Output tile for `new_cache = a*x + b*y + c*z + d*w`. May safely
+ *   equal any of `dst_index_wa/wb/wc/wd`: each loop iteration loads one row from every input
+ *   operand and consumes it into registers before storing that same row's output, so a weight
+ *   slot reused for an output is only overwritten after that row's weight has already been read --
+ *   the same `dst_index_out == dst_index_in0` reuse convention
+ *   `calculate_addcmul()`/`calculate_where()` already rely on.
+ * @param dst_index_silu_out: Output tile for `SiLU(new_cache)`; same reuse rule as
  *   `dst_index_cache_out`, and must differ from it.
  *
  * @note Implements the KDA (Kimi Delta Attention) conv1d node from
  *   tt-blaze#2388/tt-blaze#2429: `new_cache` is the updated causal-conv accumulator (per
  *   channel: `a*x + b*y + c*z + d*w`, all four operands are per-channel BF16 tensors, not
  *   scalars); one output is `SiLU(new_cache)`, the other is the 3-wide cache shift
- *   `[new_cache, x, y]`. This function computes only the two values that require new math
- *   (`new_cache`, `SiLU(new_cache)`); the caller re-packs `x`/`y` unchanged to assemble the
- *   3-wide shifted cache, since that half of the update is a pure data-movement concern, not
- *   an SFPU compute one. All operands are expected already resident in Dest (unpacked/copied by
- *   the caller), following the same `sfpi::dst_reg[dst_index*32 + row]` explicit-addressing
- *   idiom as `calculate_addcmul()`/`calculate_lerp()`; unlike `addcmul`'s scalar `value`, every
- *   weight here is a full per-channel tensor, so all four taps are genuine tensor*tensor FMAs,
- *   accumulated once in registers (a single load of each of the 8 inputs, no intermediate Dest
- *   round-trips) before the two final stores. @ref _sigmoid_piecewise_linear_positive_ is
- *   reused unmodified for the SiLU half.
+ *   `[new_cache, x, y]` -- which retains `x`/`y` and evicts the oldest entry `z`. This function
+ *   computes only the two values that require new math (`new_cache`, `SiLU(new_cache)`); the
+ *   caller re-packs `x`/`y` unchanged to assemble the 3-wide shifted cache, since that half of the
+ *   update is a pure data-movement concern, not an SFPU compute one. All operands are expected
+ *   already resident in Dest (unpacked/copied by the caller), following the same
+ *   `sfpi::dst_reg[dst_index*32 + row]` explicit-addressing idiom as
+ *   `calculate_addcmul()`/`calculate_lerp()`; unlike `addcmul`'s scalar `value`, every weight
+ *   here is a full per-channel tensor, so all four taps are genuine tensor*tensor FMAs,
+ *   accumulated in registers one row at a time (no intermediate Dest round-trips) before that
+ *   row's two stores.
+ * @note SFPU init contract: like every other SFPU op, the caller must have run the invariant SFPU
+ *   init (SFPU config register + zero-increment `ADDR_MOD_7`, e.g.
+ *   `_llk_math_eltwise_unary_sfpu_init_once_()`) before this function; the piecewise SiLU path
+ *   needs no additional LUT/immediate setup of its own.
  */
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
 inline void _calculate_causal_conv1d_silu_(
@@ -87,6 +97,8 @@ inline void _calculate_causal_conv1d_silu_(
 
     for (int d = 0; d < ITERATIONS; d++)
     {
+        // One row of every operand, read before any output for this row is stored -- this is what
+        // lets dst_index_cache_out/silu_out safely alias a weight slot.
         const sfpi::vFloat wa = sfpi::dst_reg[off_wa];
         const sfpi::vFloat wb = sfpi::dst_reg[off_wb];
         const sfpi::vFloat wc = sfpi::dst_reg[off_wc];
@@ -104,8 +116,8 @@ inline void _calculate_causal_conv1d_silu_(
         new_cache              = wc * z + new_cache;
         new_cache              = wd * w + new_cache;
 
-        // SiLU(new_cache) = new_cache * sigmoid(new_cache), reusing the existing
-        // piecewise-linear sigmoid approximation unchanged.
+        // SiLU(new_cache) = new_cache * sigmoid(new_cache), reusing the piecewise-linear sigmoid
+        // approximation unchanged.
         sfpi::vFloat sig = _sigmoid_piecewise_linear_positive_(sfpi::abs(new_cache));
         v_if (new_cache < 0.0f)
         {

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_causal_conv1d_silu.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_causal_conv1d_silu.h
@@ -95,26 +95,25 @@ inline void _calculate_causal_conv1d_silu_(
     const std::uint32_t off_cache_out = dst_index_cache_out * dst_tile_size_sfpi;
     const std::uint32_t off_silu_out  = dst_index_silu_out * dst_tile_size_sfpi;
 
+#pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++)
     {
-        // One row of every operand, read before any output for this row is stored -- this is what
-        // lets dst_index_cache_out/silu_out safely alias a weight slot.
-        const sfpi::vFloat wa = sfpi::dst_reg[off_wa];
-        const sfpi::vFloat wb = sfpi::dst_reg[off_wb];
-        const sfpi::vFloat wc = sfpi::dst_reg[off_wc];
-        const sfpi::vFloat wd = sfpi::dst_reg[off_wd];
-        const sfpi::vFloat x  = sfpi::dst_reg[off_x];
-        const sfpi::vFloat y  = sfpi::dst_reg[off_y];
-        const sfpi::vFloat z  = sfpi::dst_reg[off_z];
-        const sfpi::vFloat w  = sfpi::dst_reg[off_w];
-
-        // new_cache = a*x + b*y + c*z + d*w -- three chained tensor*tensor FMAs, entirely in
-        // registers (every operand is a per-channel tensor; unlike addcmul's scalar `value`, no
-        // term here is uniform across lanes).
-        sfpi::vFloat new_cache = wa * x;
-        new_cache              = wb * y + new_cache;
-        new_cache              = wc * z + new_cache;
-        new_cache              = wd * w + new_cache;
+        // new_cache = a*x + b*y + c*z + d*w -- four chained tensor*tensor FMAs (every operand is a
+        // per-channel tensor; unlike addcmul's scalar `value`, no term here is uniform across
+        // lanes). Each operand is read inline into a short-lived vFloat as its FMA consumes it,
+        // rather than hoisting all eight inputs into up-front vFloats, so only the accumulator plus
+        // the current term's operand pair need be live at once.
+        //
+        // This ordering also keeps the alias-safety invariant self-evident: all four weights are
+        // read (across the four FMAs below) before this row's outputs are stored, so
+        // dst_index_cache_out / dst_index_silu_out may reuse a weight slot without ever clobbering
+        // a value still needed this iteration. The `#pragma GCC unroll 8` above matches the
+        // convention of the other SFPU ITERATIONS loops (where.h, comp.h, ...) and adds no register
+        // pressure of its own.
+        sfpi::vFloat new_cache = sfpi::vFloat(sfpi::dst_reg[off_wa]) * sfpi::vFloat(sfpi::dst_reg[off_x]);
+        new_cache              = sfpi::vFloat(sfpi::dst_reg[off_wb]) * sfpi::vFloat(sfpi::dst_reg[off_y]) + new_cache;
+        new_cache              = sfpi::vFloat(sfpi::dst_reg[off_wc]) * sfpi::vFloat(sfpi::dst_reg[off_z]) + new_cache;
+        new_cache              = sfpi::vFloat(sfpi::dst_reg[off_wd]) * sfpi::vFloat(sfpi::dst_reg[off_w]) + new_cache;
 
         // SiLU(new_cache) = new_cache * sigmoid(new_cache), reusing the piecewise-linear sigmoid
         // approximation unchanged.


### PR DESCRIPTION
### PR Category

Feature

### Summary

Kimi K3 needs a fused SFPU op that combines a per-element weighted sum of 4 BF16 weights with 3 cache entries and a matmul-produced DST value, updates the cache, and applies SiLU to the result. This adds a new ckernel_sfpu_causal_conv1d_silu LLK implementing that fused multiply-accumulate-and-activate operation for the Blackhole SFPU, along with the corresponding golden generator and python/C++ tests.

Fixes tenstorrent/tt-blaze#2429

### Notes for reviewers

Check the golden generator in golden_generators.py matches the intended new_cache = ax+by+cz+wd and outB = [new_cache, x, y] semantics from the issue, and that sfpu_causal_conv1d_silu_test.cpp covers the DST/cache layout assumptions.

Diffstat: 4 files changed, 460 insertions(+).

<sub>Opened by the LLK issue-triage board (AI-assisted, draft) — please review the diff before merging.</sub>

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=llk_code_gen/issue-2429-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:llk_code_gen/issue-2429-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=llk_code_gen/issue-2429-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:llk_code_gen/issue-2429-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=llk_code_gen/issue-2429-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:llk_code_gen/issue-2429-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=llk_code_gen/issue-2429-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:llk_code_gen/issue-2429-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=llk_code_gen/issue-2429-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:llk_code_gen/issue-2429-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=llk_code_gen/issue-2429-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:llk_code_gen/issue-2429-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=llk_code_gen/issue-2429-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:llk_code_gen/issue-2429-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=llk_code_gen/issue-2429-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:llk_code_gen/issue-2429-v2)