### PR TITLE
[point_to_point] Flush per-packet payload before reusing single-slot packet_cb

### DIFF
--- a/ttnn/cpp/ttnn/operations/point_to_point/device/kernels/dataflow/writer_send.cpp
+++ b/ttnn/cpp/ttnn/operations/point_to_point/device/kernels/dataflow/writer_send.cpp
@@ -89,7 +89,10 @@ void kernel_main() {
             if (packet_page_idx >= curr_pages_per_packet) {
                 tt::tt_fabric::linear::to_noc_unicast_write(
                     align(payload_size_bytes, alignment), packet_header_ptr, packet_idx, dst_buffer);
-                perform_payload_send(connection_direction, packet_base_addr, payload_size_bytes, packet_header_ptr);
+                // blocking+flush: drain the payload out of packet_base_addr before the next tt_memmove
+                // reuses the single-slot packet_cb (the default overload leaves the source read in flight).
+                perform_payload_send<true, true>(
+                    connection_direction, packet_base_addr, payload_size_bytes, packet_header_ptr);
 
                 // reset counters
                 packet_page_idx = 0;


### PR DESCRIPTION
### Problem
`writer_send` coalesces each packet into `packet_base_addr` (the single slot of `packet_cb`) via `tt_memmove`, then sends it with the default `perform_payload_send(...)` = `<blocking=false, flush=true>`. That template sends both the payload (`send_payload_without_header_non_blocking_from_address`) and header (`send_payload_flush_non_blocking_from_address`) **NON_BLOCKING** — `send_chunk_from_address<NON_BLOCKING>` issues a bare `noc_async_write` with no flush. So on return the payload write reading **from** `packet_base_addr` is still outstanding on the weak WH/BH NoC.

`packet_page_idx` resets to 0 each packet boundary, so the next `tt_memmove` writes back into `packet_base_addr` — the exact L1 the in-flight write is still reading (WAR). Multi-packet transfers are common (`num_pages > max_pages_per_packet`, or page segmentation). `wait_for_empty_write_slot()` only polls EDM remote-slot credits, not the local source read-out.

### Fix
Use `perform_payload_send<true, true>(...)`, which routes the header through `send_chunk_from_address<FLUSH_BLOCKING>` → `noc_async_writes_flushed()` — the payload and header depart L1 before the next `tt_memmove`. Flush (departed) is the correct minimum for source reuse; it matches the flush-blocking send already used for the final semaphore inc in this kernel.

Fixes #50811. Item 3 of #48586 (Vuk-confirmed real).

### Verification
Fabric/multi-device op; not reproducible on single-box hardware here. Grounded in the source-reuse-before-departure mechanism and the kernel's own flush-blocking idiom. Requesting fabric-owner review.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amahmud/fix-point-to-point-writer-send-flush)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amahmud/fix-point-to-point-writer-send-flush)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amahmud/fix-point-to-point-writer-send-flush)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amahmud/fix-point-to-point-writer-send-flush)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=amahmud/fix-point-to-point-writer-send-flush)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:amahmud/fix-point-to-point-writer-send-flush)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amahmud/fix-point-to-point-writer-send-flush)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amahmud/fix-point-to-point-writer-send-flush)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amahmud/fix-point-to-point-writer-send-flush)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amahmud/fix-point-to-point-writer-send-flush)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amahmud/fix-point-to-point-writer-send-flush)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amahmud/fix-point-to-point-writer-send-flush)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amahmud/fix-point-to-point-writer-send-flush)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amahmud/fix-point-to-point-writer-send-flush)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amahmud/fix-point-to-point-writer-send-flush)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amahmud/fix-point-to-point-writer-send-flush)