### PR TITLE
[deepseek_v3_b1] Flush partial/gather write before the credit inc in matmul senders

### DIFF
--- a/models/demos/deepseek_v3_b1/unified_kernels/matmul_expert_compressed_dram.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/matmul_expert_compressed_dram.hpp
@@ -575,6 +575,9 @@ struct MatmulExpertCompressedDRAM {
                         noc_async_write_one_packet(src_addr, dst_noc, output_bytes);
                         uint64_t sem_noc =
                             get_noc_addr(CTArgs::next_core_noc_x, CTArgs::next_core_noc_y, CTArgs::partial_sem_addr);
+                        // Drain the partial write out of L1 before the credit so the reducer's
+                        // partial_sem poll can't unblock ahead of the data (idiom: all_gather.hpp).
+                        noc_async_writes_flushed();
                         noc_semaphore_inc(sem_noc, 1);
 
                         // Pop out from the ncrisc side because it needs to perform wait front. Otherwise there is a
@@ -608,6 +611,9 @@ struct MatmulExpertCompressedDRAM {
                         noc_async_write_one_packet(src_addr, dst_noc, output_bytes);
                         uint64_t sem_noc =
                             get_noc_addr(CTArgs::next_core_noc_x, CTArgs::next_core_noc_y, CTArgs::partial_sem_addr);
+                        // Drain the gather write out of L1 before the credit so the receiver's
+                        // partial_sem poll can't unblock ahead of the data (idiom: all_gather.hpp).
+                        noc_async_writes_flushed();
                         noc_semaphore_inc(sem_noc, 1);
                         // Reset to 0 so the next loop iter starts fresh.
                         unified_kernels::sem_atomic_dec(CTArgs::gather_sync_sem_addr, 1);


### PR DESCRIPTION
### Problem
The reduction sender and gather sender in `matmul_expert_compressed_dram.hpp` both do `noc_async_write_one_packet(src -> receiver slot)` immediately followed by `noc_semaphore_inc(receiver partial_sem)` with nothing between. The write and the atomic-inc are independent NoC transactions, so the credit can reach the receiver before the data write lands; the receiver polls `partial_sem` (`sem_atomic_load`) and then reads the slot, so it can consume a not-yet-landed partial.

### Fix / grounding
Every other cross-core handoff in this directory guards this edge — `all_gather.hpp`, `reduce_to_all_b1.hpp`, `broadcast.hpp` all do `noc_async_write` → `noc_async_writes_flushed()` → `noc_semaphore_inc`. These two senders are the only sites that skip the flush. Add `noc_async_writes_flushed()` before each credit inc to match: the write departs L1 (and, being same-VC/same-dest, lands ahead of the later inc) before the credit is sent.

Deliberately grounded in the sibling idiom, **not** the "different command buffer ⇒ unordered on same VC" reasoning flagged as suspect in #48586.

Fixes #50812. Item 7 (b-actual sub-claim) of #48586.

### Verification — needs owner confirmation
Multi-device deepseek_v3_b1 kernel; not reproducible on single-box hardware here. Requesting owner confirmation that the flush is the intended guard (consistent with the sibling kernels) before merge. The pre-existing comment about a back-to-back-launch overwrite race is a separate concern, not addressed here.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amahmud/fix-deepseek-v3-matmul-sender-flush)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amahmud/fix-deepseek-v3-matmul-sender-flush)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amahmud/fix-deepseek-v3-matmul-sender-flush)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amahmud/fix-deepseek-v3-matmul-sender-flush)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=amahmud/fix-deepseek-v3-matmul-sender-flush)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:amahmud/fix-deepseek-v3-matmul-sender-flush)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amahmud/fix-deepseek-v3-matmul-sender-flush)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amahmud/fix-deepseek-v3-matmul-sender-flush)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amahmud/fix-deepseek-v3-matmul-sender-flush)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amahmud/fix-deepseek-v3-matmul-sender-flush)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amahmud/fix-deepseek-v3-matmul-sender-flush)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amahmud/fix-deepseek-v3-matmul-sender-flush)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amahmud/fix-deepseek-v3-matmul-sender-flush)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amahmud/fix-deepseek-v3-matmul-sender-flush)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amahmud/fix-deepseek-v3-matmul-sender-flush)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amahmud/fix-deepseek-v3-matmul-sender-flush)