### PR TITLE
[layernorm] Fix second-stage-reader CB credit/layout in pre_allgather receiver (defensive)

### DIFF
--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_receiver_unary_sharded_ln_pre_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_receiver_unary_sharded_ln_pre_allgather.cpp
@@ -178,22 +178,27 @@ void kernel_main() {
                             reduce_second_stage_sem.set(0);
                         }
                         // read data from other cores - second stage reduce
-
+                        // Mirror the sender and the first-stage block above: reserve/read/push
+                        // num_tiles_per_partial_result tiles per block (E[x] and E[x^2] interleaved),
+                        // not one -- the compute consumer pops num_tiles_per_partial_result * num_blocks_reduce.
+                        dfb_external_obj.reserve_back(num_tiles_per_partial_result * (num_blocks_second_stage - 1));
                         write_offset = 0;
                         for (uint32_t block = 0; block < num_blocks_second_stage - 1; ++block) {
-                            noc.async_read<NocOptions::DEFAULT, NOC_MAX_BURST_SIZE>(
-                                remote_ep,
-                                dfb_external_obj,
-                                single_tile_size_bytes,
-                                {.noc_x = remote_coords_second_stage[block + 1].x,
-                                 .noc_y = remote_coords_second_stage[block + 1].y,
-                                 .addr = l1_read_addr_ex},
-                                {.offset_bytes = write_offset});
-                            write_offset += single_tile_size_bytes;
+                            for (uint32_t tile_idx = 0; tile_idx < num_tiles_per_partial_result; ++tile_idx) {
+                                noc.async_read<NocOptions::DEFAULT, NOC_MAX_BURST_SIZE>(
+                                    remote_ep,
+                                    dfb_external_obj,
+                                    single_tile_size_bytes,
+                                    {.noc_x = remote_coords_second_stage[block + 1].x,
+                                     .noc_y = remote_coords_second_stage[block + 1].y,
+                                     .addr = l1_read_addr_ex + tile_idx * single_tile_size_bytes},
+                                    {.offset_bytes = write_offset});
+                                write_offset += single_tile_size_bytes;
+                            }
                         }
                         l1_read_addr_ex += single_tile_size_bytes;
                         noc.async_read_barrier();
-                        dfb_external_obj.push_back(static_cast<uint16_t>(num_blocks_second_stage - 1));
+                        dfb_external_obj.push_back(num_tiles_per_partial_result * (num_blocks_second_stage - 1));
                     }
                 }
             }


### PR DESCRIPTION
Fixes #50816. Item 2 of #48586. **Defensive / dead-by-design — see verification.**

cc @vsureshTT (this item is assigned to you per #48586; opening a ready-to-merge fix rather than a duplicate sub-issue — take it or leave it).

> **Rebased onto current main.** #49173 (`CircularBuffer` → `DataflowBuffer` migration) rewrote this file — `cb_*` → `dfb_*`, and it added a `static_cast<uint16_t>` on the very `push_back` line this PR rewrites — so the original commit conflicted. The rebased hunk is the same three changes against `dfb_external_obj`; the cast is gone because the expression changed, matching the sender's uncast `push_back(num_tiles_per_partial_result * (num_blocks_second_stage - 1))` and the first-stage siblings in this same file. Kernels build `-Wall -Werror` (`tt_metal/jit_build/build.cpp:162`) and this one compiles clean.

### Problem
In the two-stage reduce, the receiver's second-stage-reader block reads and pushes `(num_blocks_second_stage - 1)` tiles into `c_13` with a single `block` loop and no `reserve_back` — **not** scaled by `num_tiles_per_partial_result` (npr=2 for LayerNorm, 1 for RMS). Three places pin the intended contract and all three disagree with it:

- the compute consumer (`layernorm_sharded_pre_allgather.cpp`) pops `npr * num_blocks_reduce` = `npr * (num_blocks_first_stage + num_blocks_second_stage - 1)` via `wait_front(1)`;
- the CB is sized for exactly that — `ex_external_CB_size = (nbfs + nbss - 1) * pre_all_gather_stats_block_tiles` (`sharded_layernorm_factory_helpers.cpp`);
- the sender kernel already does it correctly, as does the non-pre-allgather receiver (`reader_mcast_receiver_unary_sharded_ln.cpp`).

For LayerNorm the block under-pushes by `(npr-1)*(num_blocks_second_stage-1)` per row → the consumer's `wait_front` starves (hang); it also fetches only one of the npr interleaved tiles per second-stage block, and without `reserve_back` can clobber first-stage tiles the consumer hasn't popped. RMS (npr=1) masks the count, but not the missing `reserve_back`.

### Fix
Mirror the sender's second-stage block and the receiver's own correct first-stage block: `reserve_back(npr*(nbss-1))`, an inner `tile_idx` loop reading npr tiles per block, and `push_back(npr*(nbss-1))`.

### Verification — dead code by design, no test possible
A receiver core only sees `is_second_stage_reader=1` when `num_cores_all_to_all_first_stage >= 2`, i.e. `block_ht >= 2`. Every supported pre-allgather config uses `block_ht=1`, so `is_second_stage_reader` is true only for `width_index 0` — which runs the already-correct **sender** kernel. Every test and program config in-tree passes `block_h=1`.

`block_ht >= 2` *is* constructible (`validate()` only pins `padded_shape[-2]==32`, so M can exceed 32 via a leading dim) but it cannot work, for a reason upstream of this patch: on a second-stage reader the compute kernel routes its reduction output to `c_16`, which the pre-allgather factory allocates **only on `sender_cores`**, and `compute_output_specs` pins the pre-allgather output shard grid to a single core. The design therefore admits exactly **one** second-stage reader — the sender.

Confirmed on n150 (`block_h=2`, `(1,2,32,2048)` width-sharded 8×4, two-stage active):

| config | unmodified main |
|---|---|
| `block_h=1` LayerNorm / RMSNorm | PASS |
| `block_h=2` LayerNorm | HANG |
| `block_h=2` RMSNorm (npr=1, where this patch's credit math is already correct) | HANG |

RMSNorm hanging too is the tell that the `block_ht>=2` hang is *not* this bug. Watcher confirms: one stuck core, `(x=1,y=0)` — precisely the second-stage-reader receiver — BRISC in `CWFW` waiting on `c_12`, every other core at `GW`.

So there is no fail-without-fix test to add. Taking this as correctness hardening that matches the sender and keeps the block correct if the single-output-core constraint is ever relaxed. `block_h=1` LayerNorm and RMSNorm both still pass with the patch applied.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amahmud/fix-layernorm-pre-allgather-second-stage-cb)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amahmud/fix-layernorm-pre-allgather-second-stage-cb)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amahmud/fix-layernorm-pre-allgather-second-stage-cb)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amahmud/fix-layernorm-pre-allgather-second-stage-cb)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=amahmud/fix-layernorm-pre-allgather-second-stage-cb)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:amahmud/fix-layernorm-pre-allgather-second-stage-cb)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amahmud/fix-layernorm-pre-allgather-second-stage-cb)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amahmud/fix-layernorm-pre-allgather-second-stage-cb)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amahmud/fix-layernorm-pre-allgather-second-stage-cb)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amahmud/fix-layernorm-pre-allgather-second-stage-cb)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amahmud/fix-layernorm-pre-allgather-second-stage-cb)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amahmud/fix-layernorm-pre-allgather-second-stage-cb)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amahmud/fix-layernorm-pre-allgather-second-stage-cb)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amahmud/fix-layernorm-pre-allgather-second-stage-cb)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amahmud/fix-layernorm-pre-allgather-second-stage-cb)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amahmud/fix-layernorm-pre-allgather-second-stage-cb)

