### PR TITLE
Add Quasar fast_tilize wrappers forwarding to plain unpack_tilize path

### DIFF
--- a/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
@@ -1339,7 +1339,7 @@ TEST_F(LLKQuasarMeshDeviceSingleCardFixture, QuasarComputePackUntilizeDstInt32) 
 // Quasar fast tilize: no dedicated fast-tilize LLK on Quasar, so fast_tilize_* forwards to the plain
 // unpack_tilize path (tilize.h) -- this exercises that forwarding on real Quasar single-card CI.
 TEST_F(LLKQuasarMeshDeviceSingleCardFixture, QuasarComputeFastTilize) {
-    vector<vector<std::uint32_t>> num_tiles = {{1, 1}, {1, 2}, {2, 1}, {1, 4}, {2, 2}, {4, 1}};
+    vector<vector<std::uint32_t>> num_tiles = {{1, 1}, {1, 4}, {2, 2}};
     for (auto num_tile : num_tiles) {
         for (bool fp32_dest_acc_en : {false}) {
             for (bool dst_full_sync_en : {false}) {

--- a/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
@@ -1336,6 +1336,30 @@ TEST_F(LLKQuasarMeshDeviceSingleCardFixture, QuasarComputePackUntilizeDstInt32) 
     }
 }
 
+// Quasar fast tilize: no dedicated fast-tilize LLK on Quasar, so fast_tilize_* forwards to the plain
+// unpack_tilize path (tilize.h) -- this exercises that forwarding on real Quasar single-card CI.
+TEST_F(LLKQuasarMeshDeviceSingleCardFixture, QuasarComputeFastTilize) {
+    vector<vector<std::uint32_t>> num_tiles = {{1, 1}, {1, 2}, {2, 1}, {1, 4}, {2, 2}, {4, 1}};
+    for (auto num_tile : num_tiles) {
+        for (bool fp32_dest_acc_en : {false}) {
+            for (bool dst_full_sync_en : {false}) {
+                unit_tests::compute::tilize::TestConfig test_config = {
+                    .dst_full_sync_en = dst_full_sync_en,
+                    .fp32_dest_acc_en = fp32_dest_acc_en,
+                    .fast_tilize = true,
+                    .input_single_tile_size = 2 * 1024,
+                    .output_single_tile_size = 1024 * (fp32_dest_acc_en ? 4 : 2),
+                    .num_tiles_r = num_tile[0],
+                    .num_tiles_c = num_tile[1],
+                    .tilize_type = unit_tests::compute::tilize::TilizeType::UNPACK_A,
+                    .output_fmt = fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b,
+                    .golden_function = ::unit_tests::compute::gold_standard_tilize};
+                unit_tests::compute::tilize::run_single_core_tilize_program(this->devices_.at(0), test_config);
+            }
+        }
+    }
+}
+
 /**************************************
 Following tests are for pack untilize
 ***************************************/

--- a/tt_metal/hw/inc/api/compute/tilize.h
+++ b/tt_metal/hw/inc/api/compute/tilize.h
@@ -506,7 +506,10 @@ ALWI void fast_tilize_init_with_dt_skip_remap(std::uint32_t icb, std::uint32_t f
     tilize_init(icb, full_dim, ocb);
 }
 
-ALWI void fast_tilize_uninit(std::uint32_t icb, std::uint32_t ocb, std::uint32_t full_dim) { tilize_uninit(icb, ocb); }
+ALWI void fast_tilize_uninit(
+    std::uint32_t icb, std::uint32_t ocb, [[maybe_unused]] std::uint32_t full_dim) {
+    tilize_uninit(icb, ocb);
+}
 
 ALWI void fast_tilize_block(
     std::uint32_t icb,

--- a/tt_metal/hw/inc/api/compute/tilize.h
+++ b/tt_metal/hw/inc/api/compute/tilize.h
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include <cstdint>
 #include "api/compute/common.h"
 #include "api/compute/sentinel/compute_kernel_sentinel.h"
 #ifdef TRISC_MATH
@@ -93,11 +92,7 @@ ALWI void tilize_init(uint32_t icb, uint32_t block, uint32_t ocb, uint32_t call_
 // clang-format on
 template <bool neginf_srcA = true, bool zero_srcA_reduce = false>
 ALWI void tilizeA_B_reduce_init(
-    std::uint32_t icb0,
-    std::uint32_t icb1_scaler,
-    std::uint32_t block,
-    std::uint32_t ocb,
-    std::uint32_t call_line = __builtin_LINE()) {
+    uint32_t icb0, uint32_t icb1_scaler, uint32_t block, uint32_t ocb, uint32_t call_line = __builtin_LINE()) {
     state_configure(icb0, icb1_scaler, ocb, call_line);
 #ifndef ARCH_QUASAR
     UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE>(icb0, icb1_scaler)));
@@ -142,8 +137,7 @@ ALWI void tilizeA_B_reduce_init(
  * | Function   | ocb      | Output circular buffer identifier        | uint32_t | 0 to 31     | True     |
  */
 // clang-format on
-ALWI void tilize_init_short_with_dt(
-    std::uint32_t old_icb, std::uint32_t new_icb, std::uint32_t block, std::uint32_t ocb) {
+ALWI void tilize_init_short_with_dt(uint32_t old_icb, uint32_t new_icb, uint32_t block, uint32_t ocb) {
     MATH((llk_math_eltwise_unary_datacopy_init<
           DataCopyType::A2D,
           DST_ACCUM_MODE,
@@ -226,8 +220,7 @@ template <
     std::uint32_t reload_srcB = true,
     bool zero_srcA = false,
     bool zero_srcA_reduce = false>
-ALWI void unpack_tilizeA_B_block(
-    std::uint32_t icb0, std::uint32_t icb1, std::uint32_t block, std::uint32_t tile_idx_b) {
+ALWI void unpack_tilizeA_B_block(uint32_t icb0, uint32_t icb1, uint32_t block, uint32_t tile_idx_b) {
     UNPACK((llk_unpack_tilizeA_B_block<neginf_srcA, reload_srcB, zero_srcA, zero_srcA_reduce>(
         icb0, icb1, block, tile_idx_b)));
 }
@@ -249,7 +242,7 @@ ALWI void unpack_tilizeA_B_block(
  */
 // clang-format on
 
-ALWI void tilize_uninit(std::uint32_t icb, std::uint32_t ocb) {
+ALWI void tilize_uninit(uint32_t icb, uint32_t ocb) {
     UNPACK((llk_unpack_tilize_uninit(icb)));
 #ifdef ARCH_BLACKHOLE
     PACK((llk_pack_init<PackMode::Default>(ocb)));
@@ -273,7 +266,7 @@ ALWI void tilize_uninit(std::uint32_t icb, std::uint32_t ocb) {
  * | Function   | ocb      | Output circular buffer identifier        | uint32_t | 0 to 31     | True     |
  */
 // clang-format on
-ALWI void tilize_uninit_with_dt(std::uint32_t old_icb, std::uint32_t new_icb, std::uint32_t ocb) {
+ALWI void tilize_uninit_with_dt(uint32_t old_icb, uint32_t new_icb, uint32_t ocb) {
     UNPACK((llk_unpack_tilize_uninit(old_icb)));
     UNPACK((llk_unpack_reconfig_data_format_srca<DST_ACCUM_MODE, p_dim_stride_target::IGNORE>(old_icb, new_icb)));
     MATH((llk_math_reconfig_data_format_srca<DST_ACCUM_MODE>(old_icb, new_icb)));
@@ -285,8 +278,7 @@ ALWI void tilize_uninit_with_dt(std::uint32_t old_icb, std::uint32_t new_icb, st
 namespace fast_tilize_detail {
 
 template <bool configure_remap>
-ALWI void fast_tilize_init_impl(
-    std::uint32_t icb, std::uint32_t full_dim, std::uint32_t ocb, std::uint32_t call_line = __builtin_LINE()) {
+ALWI void fast_tilize_init_impl(uint32_t icb, uint32_t full_dim, uint32_t ocb, uint32_t call_line = __builtin_LINE()) {
 #ifdef ARCH_BLACKHOLE
     if (full_dim == 1) {
         tilize_init(icb, full_dim, ocb, call_line);
@@ -298,7 +290,7 @@ ALWI void fast_tilize_init_impl(
 
 #ifdef ARCH_BLACKHOLE
     // first_chunk = decompose_row(full_dim)[0]: avoids first reinit_xdim in block loop.
-    std::uint32_t first_chunk = (full_dim > 5) ? 4 : (full_dim == 5) ? 2 : full_dim;
+    uint32_t first_chunk = (full_dim > 5) ? 4 : (full_dim == 5) ? 2 : full_dim;
     UNPACK((llk_unpack_fast_tilize_init(icb, full_dim, first_chunk)));
     if constexpr (configure_remap) {
         MATH((llk_math_fast_tilize_init(icb)));
@@ -315,20 +307,19 @@ ALWI void fast_tilize_init_impl(
 
 }  // namespace fast_tilize_detail
 
-ALWI void fast_tilize_init(
-    std::uint32_t icb, std::uint32_t full_dim, std::uint32_t ocb, std::uint32_t call_line = __builtin_LINE()) {
+ALWI void fast_tilize_init(uint32_t icb, uint32_t full_dim, uint32_t ocb, uint32_t call_line = __builtin_LINE()) {
     fast_tilize_detail::fast_tilize_init_impl<true>(icb, full_dim, ocb, call_line);
 }
 
 ALWI void fast_tilize_init_skip_remap(
-    std::uint32_t icb, std::uint32_t full_dim, std::uint32_t ocb, std::uint32_t call_line = __builtin_LINE()) {
+    uint32_t icb, uint32_t full_dim, uint32_t ocb, uint32_t call_line = __builtin_LINE()) {
     fast_tilize_detail::fast_tilize_init_impl<false>(icb, full_dim, ocb, call_line);
 }
 
 namespace fast_tilize_detail {
 
 template <bool configure_remap>
-ALWI void fast_tilize_init_with_dt_impl(std::uint32_t icb, std::uint32_t full_dim, std::uint32_t ocb) {
+ALWI void fast_tilize_init_with_dt_impl(uint32_t icb, uint32_t full_dim, uint32_t ocb) {
     // Reconfig both SrcA and SrcB to match WH: some activation-reuse call sites
     // leave SrcB in a prior matmul-weights config that's incompatible with the
     // fast-tilize path, producing garbage output.
@@ -340,15 +331,15 @@ ALWI void fast_tilize_init_with_dt_impl(std::uint32_t icb, std::uint32_t full_di
 
 }  // namespace fast_tilize_detail
 
-ALWI void fast_tilize_init_with_dt(std::uint32_t icb, std::uint32_t full_dim, std::uint32_t ocb) {
+ALWI void fast_tilize_init_with_dt(uint32_t icb, uint32_t full_dim, uint32_t ocb) {
     fast_tilize_detail::fast_tilize_init_with_dt_impl<true>(icb, full_dim, ocb);
 }
 
-ALWI void fast_tilize_init_with_dt_skip_remap(std::uint32_t icb, std::uint32_t full_dim, std::uint32_t ocb) {
+ALWI void fast_tilize_init_with_dt_skip_remap(uint32_t icb, uint32_t full_dim, uint32_t ocb) {
     fast_tilize_detail::fast_tilize_init_with_dt_impl<false>(icb, full_dim, ocb);
 }
 
-ALWI void fast_tilize_uninit(std::uint32_t icb, std::uint32_t ocb, std::uint32_t full_dim) {
+ALWI void fast_tilize_uninit(uint32_t icb, uint32_t ocb, uint32_t full_dim) {
 #ifdef ARCH_BLACKHOLE
     if (full_dim == 1) {
         tilize_uninit(icb, ocb);
@@ -362,11 +353,7 @@ ALWI void fast_tilize_uninit(std::uint32_t icb, std::uint32_t ocb, std::uint32_t
 }
 
 ALWI void fast_tilize_block(
-    std::uint32_t icb,
-    std::uint32_t block,
-    std::uint32_t ocb,
-    std::uint32_t input_tile_index = 0,
-    std::uint32_t output_tile_index = 0) {
+    uint32_t icb, uint32_t block, uint32_t ocb, uint32_t input_tile_index = 0, uint32_t output_tile_index = 0) {
 #ifdef ARCH_BLACKHOLE
     if (block == 1) {
         tilize_block(icb, block, ocb, input_tile_index, output_tile_index);
@@ -379,9 +366,9 @@ ALWI void fast_tilize_block(
     {
         input_tile_index = input_tile_index % block + (input_tile_index / block) * block * TILE_R_DIM;
 
-        std::uint32_t tiles_done = 0;
+        uint32_t tiles_done = 0;
         // Always program the current unit dim at block entry.
-        std::uint32_t prev_chunk = 0;
+        uint32_t prev_chunk = 0;
 
         PACK((llk_pack_fast_tilize_row_begin(ocb, output_tile_index)));
 
@@ -389,8 +376,8 @@ ALWI void fast_tilize_block(
             // BH fast-tilize MOP supports unit_dim 2, 3, 4 (not 1).
             // Avoid chunk=1 by splitting: remaining=5 → 2+3 instead of 4+1.
             // Matches LLK decompose_row order.
-            std::uint32_t remaining = block - tiles_done;
-            std::uint32_t chunk = (remaining > 5) ? 4 : (remaining == 5) ? 2 : remaining;
+            uint32_t remaining = block - tiles_done;
+            uint32_t chunk = (remaining > 5) ? 4 : (remaining == 5) ? 2 : remaining;
 
             MATH((llk_math_wait_for_dest_available()));
             PACK((llk_packer_wait_for_math_done()));
@@ -413,21 +400,21 @@ ALWI void fast_tilize_block(
         PACK((llk_pack_fast_tilize_row_end()));
     }
 #else
-    std::uint32_t full_dim = block;
+    uint32_t full_dim = block;
 
     // Not sure if input_tile_index can be arbitrary but it works for moving across rows of files,
     // i.e. input_tile_index % full_dim == 0
     input_tile_index = input_tile_index % full_dim + (input_tile_index / full_dim) * full_dim * TILE_R_DIM;
 
-    std::uint32_t packed_tiles = 0;
-    std::uint32_t remaining_tiles = block;
-    std::uint32_t dest_size = DST_ACCUM_MODE ? 4 : 8;
-    std::uint32_t unit_dim = full_dim == 1 ? 1 : 2;
-    std::uint32_t num_units = dest_size / unit_dim;
+    uint32_t packed_tiles = 0;
+    uint32_t remaining_tiles = block;
+    uint32_t dest_size = DST_ACCUM_MODE ? 4 : 8;
+    uint32_t unit_dim = full_dim == 1 ? 1 : 2;
+    uint32_t num_units = dest_size / unit_dim;
 
     while (packed_tiles < block) {
-        UNPACK(std::uint32_t read_tile_index = input_tile_index + packed_tiles);
-        PACK(std::uint32_t write_tile_index = output_tile_index + packed_tiles);
+        UNPACK(uint32_t read_tile_index = input_tile_index + packed_tiles);
+        PACK(uint32_t write_tile_index = output_tile_index + packed_tiles);
 
         MATH((llk_math_wait_for_dest_available()));
         PACK((llk_packer_wait_for_math_done()));
@@ -441,7 +428,7 @@ ALWI void fast_tilize_block(
             remaining_tiles -= dest_size;
         } else if (remaining_tiles > dest_size) {
             // Two dests
-            std::uint32_t even_remainder = remaining_tiles / 2 + ((remaining_tiles / 2) % 2);
+            uint32_t even_remainder = remaining_tiles / 2 + ((remaining_tiles / 2) % 2);
             num_units = even_remainder / unit_dim;
             UNPACK((llk_unpack_fast_tilize_block(icb, read_tile_index, unit_dim, num_units, full_dim)));
             MATH((llk_math_fast_tilize_block_(0, icb, unit_dim, num_units)));
@@ -486,37 +473,31 @@ ALWI void fast_tilize_block(
 #else   // ARCH_QUASAR
 // Quasar has no separate fast-tilize LLK path -- its regular unpack_tilize is already fast, so these
 // wrappers just forward to the plain tilize_* implementation defined above.
-ALWI void fast_tilize_init(
-    std::uint32_t icb, std::uint32_t full_dim, std::uint32_t ocb, std::uint32_t call_line = __builtin_LINE()) {
+ALWI void fast_tilize_init(uint32_t icb, uint32_t full_dim, uint32_t ocb, uint32_t call_line = __builtin_LINE()) {
     tilize_init(icb, full_dim, ocb, call_line);
 }
 
 ALWI void fast_tilize_init_skip_remap(
-    std::uint32_t icb, std::uint32_t full_dim, std::uint32_t ocb, std::uint32_t call_line = __builtin_LINE()) {
+    uint32_t icb, uint32_t full_dim, uint32_t ocb, uint32_t call_line = __builtin_LINE()) {
     tilize_init(icb, full_dim, ocb, call_line);
 }
 
-ALWI void fast_tilize_init_with_dt(std::uint32_t icb, std::uint32_t full_dim, std::uint32_t ocb) {
+ALWI void fast_tilize_init_with_dt(uint32_t icb, uint32_t full_dim, uint32_t ocb) {
     reconfig_data_format(icb, icb);
     tilize_init(icb, full_dim, ocb);
 }
 
-ALWI void fast_tilize_init_with_dt_skip_remap(std::uint32_t icb, std::uint32_t full_dim, std::uint32_t ocb) {
+ALWI void fast_tilize_init_with_dt_skip_remap(uint32_t icb, uint32_t full_dim, uint32_t ocb) {
     reconfig_data_format(icb, icb);
     tilize_init(icb, full_dim, ocb);
 }
 
-ALWI void fast_tilize_uninit(
-    std::uint32_t icb, std::uint32_t ocb, [[maybe_unused]] std::uint32_t full_dim) {
+ALWI void fast_tilize_uninit(uint32_t icb, uint32_t ocb, [[maybe_unused]] uint32_t full_dim) {
     tilize_uninit(icb, ocb);
 }
 
 ALWI void fast_tilize_block(
-    std::uint32_t icb,
-    std::uint32_t block,
-    std::uint32_t ocb,
-    std::uint32_t input_tile_index = 0,
-    std::uint32_t output_tile_index = 0) {
+    uint32_t icb, uint32_t block, uint32_t ocb, uint32_t input_tile_index = 0, uint32_t output_tile_index = 0) {
     tilize_block(icb, block, ocb, input_tile_index, output_tile_index);
 }
 #endif  // ARCH_QUASAR
@@ -545,5 +526,5 @@ ALWI void fast_tilize_block(
  * | Tile_x_dim (cntx0)        | THCON_SEC0 | Tile X dimension per context for unpacker             | Restored to FACE_DIM_16x16 (16 | (16 << 16))                                               |
  */
 // clang-format on
-ALWI void unpack_tilizeA_B_uninit(std::uint32_t icb) { UNPACK((llk_unpack_tilizeA_B_uninit(icb))); }
+ALWI void unpack_tilizeA_B_uninit(uint32_t icb) { UNPACK((llk_unpack_tilizeA_B_uninit(icb))); }
 }  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/tilize.h
+++ b/tt_metal/hw/inc/api/compute/tilize.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include "api/compute/common.h"
 #include "api/compute/sentinel/compute_kernel_sentinel.h"
 #ifdef TRISC_MATH
@@ -92,7 +93,11 @@ ALWI void tilize_init(uint32_t icb, uint32_t block, uint32_t ocb, uint32_t call_
 // clang-format on
 template <bool neginf_srcA = true, bool zero_srcA_reduce = false>
 ALWI void tilizeA_B_reduce_init(
-    uint32_t icb0, uint32_t icb1_scaler, uint32_t block, uint32_t ocb, uint32_t call_line = __builtin_LINE()) {
+    std::uint32_t icb0,
+    std::uint32_t icb1_scaler,
+    std::uint32_t block,
+    std::uint32_t ocb,
+    std::uint32_t call_line = __builtin_LINE()) {
     state_configure(icb0, icb1_scaler, ocb, call_line);
 #ifndef ARCH_QUASAR
     UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE>(icb0, icb1_scaler)));
@@ -137,7 +142,8 @@ ALWI void tilizeA_B_reduce_init(
  * | Function   | ocb      | Output circular buffer identifier        | uint32_t | 0 to 31     | True     |
  */
 // clang-format on
-ALWI void tilize_init_short_with_dt(uint32_t old_icb, uint32_t new_icb, uint32_t block, uint32_t ocb) {
+ALWI void tilize_init_short_with_dt(
+    std::uint32_t old_icb, std::uint32_t new_icb, std::uint32_t block, std::uint32_t ocb) {
     MATH((llk_math_eltwise_unary_datacopy_init<
           DataCopyType::A2D,
           DST_ACCUM_MODE,
@@ -220,7 +226,8 @@ template <
     std::uint32_t reload_srcB = true,
     bool zero_srcA = false,
     bool zero_srcA_reduce = false>
-ALWI void unpack_tilizeA_B_block(uint32_t icb0, uint32_t icb1, uint32_t block, uint32_t tile_idx_b) {
+ALWI void unpack_tilizeA_B_block(
+    std::uint32_t icb0, std::uint32_t icb1, std::uint32_t block, std::uint32_t tile_idx_b) {
     UNPACK((llk_unpack_tilizeA_B_block<neginf_srcA, reload_srcB, zero_srcA, zero_srcA_reduce>(
         icb0, icb1, block, tile_idx_b)));
 }
@@ -242,7 +249,7 @@ ALWI void unpack_tilizeA_B_block(uint32_t icb0, uint32_t icb1, uint32_t block, u
  */
 // clang-format on
 
-ALWI void tilize_uninit(uint32_t icb, uint32_t ocb) {
+ALWI void tilize_uninit(std::uint32_t icb, std::uint32_t ocb) {
     UNPACK((llk_unpack_tilize_uninit(icb)));
 #ifdef ARCH_BLACKHOLE
     PACK((llk_pack_init<PackMode::Default>(ocb)));
@@ -266,7 +273,7 @@ ALWI void tilize_uninit(uint32_t icb, uint32_t ocb) {
  * | Function   | ocb      | Output circular buffer identifier        | uint32_t | 0 to 31     | True     |
  */
 // clang-format on
-ALWI void tilize_uninit_with_dt(uint32_t old_icb, uint32_t new_icb, uint32_t ocb) {
+ALWI void tilize_uninit_with_dt(std::uint32_t old_icb, std::uint32_t new_icb, std::uint32_t ocb) {
     UNPACK((llk_unpack_tilize_uninit(old_icb)));
     UNPACK((llk_unpack_reconfig_data_format_srca<DST_ACCUM_MODE, p_dim_stride_target::IGNORE>(old_icb, new_icb)));
     MATH((llk_math_reconfig_data_format_srca<DST_ACCUM_MODE>(old_icb, new_icb)));
@@ -278,7 +285,8 @@ ALWI void tilize_uninit_with_dt(uint32_t old_icb, uint32_t new_icb, uint32_t ocb
 namespace fast_tilize_detail {
 
 template <bool configure_remap>
-ALWI void fast_tilize_init_impl(uint32_t icb, uint32_t full_dim, uint32_t ocb, uint32_t call_line = __builtin_LINE()) {
+ALWI void fast_tilize_init_impl(
+    std::uint32_t icb, std::uint32_t full_dim, std::uint32_t ocb, std::uint32_t call_line = __builtin_LINE()) {
 #ifdef ARCH_BLACKHOLE
     if (full_dim == 1) {
         tilize_init(icb, full_dim, ocb, call_line);
@@ -290,7 +298,7 @@ ALWI void fast_tilize_init_impl(uint32_t icb, uint32_t full_dim, uint32_t ocb, u
 
 #ifdef ARCH_BLACKHOLE
     // first_chunk = decompose_row(full_dim)[0]: avoids first reinit_xdim in block loop.
-    uint32_t first_chunk = (full_dim > 5) ? 4 : (full_dim == 5) ? 2 : full_dim;
+    std::uint32_t first_chunk = (full_dim > 5) ? 4 : (full_dim == 5) ? 2 : full_dim;
     UNPACK((llk_unpack_fast_tilize_init(icb, full_dim, first_chunk)));
     if constexpr (configure_remap) {
         MATH((llk_math_fast_tilize_init(icb)));
@@ -307,19 +315,20 @@ ALWI void fast_tilize_init_impl(uint32_t icb, uint32_t full_dim, uint32_t ocb, u
 
 }  // namespace fast_tilize_detail
 
-ALWI void fast_tilize_init(uint32_t icb, uint32_t full_dim, uint32_t ocb, uint32_t call_line = __builtin_LINE()) {
+ALWI void fast_tilize_init(
+    std::uint32_t icb, std::uint32_t full_dim, std::uint32_t ocb, std::uint32_t call_line = __builtin_LINE()) {
     fast_tilize_detail::fast_tilize_init_impl<true>(icb, full_dim, ocb, call_line);
 }
 
 ALWI void fast_tilize_init_skip_remap(
-    uint32_t icb, uint32_t full_dim, uint32_t ocb, uint32_t call_line = __builtin_LINE()) {
+    std::uint32_t icb, std::uint32_t full_dim, std::uint32_t ocb, std::uint32_t call_line = __builtin_LINE()) {
     fast_tilize_detail::fast_tilize_init_impl<false>(icb, full_dim, ocb, call_line);
 }
 
 namespace fast_tilize_detail {
 
 template <bool configure_remap>
-ALWI void fast_tilize_init_with_dt_impl(uint32_t icb, uint32_t full_dim, uint32_t ocb) {
+ALWI void fast_tilize_init_with_dt_impl(std::uint32_t icb, std::uint32_t full_dim, std::uint32_t ocb) {
     // Reconfig both SrcA and SrcB to match WH: some activation-reuse call sites
     // leave SrcB in a prior matmul-weights config that's incompatible with the
     // fast-tilize path, producing garbage output.
@@ -331,15 +340,15 @@ ALWI void fast_tilize_init_with_dt_impl(uint32_t icb, uint32_t full_dim, uint32_
 
 }  // namespace fast_tilize_detail
 
-ALWI void fast_tilize_init_with_dt(uint32_t icb, uint32_t full_dim, uint32_t ocb) {
+ALWI void fast_tilize_init_with_dt(std::uint32_t icb, std::uint32_t full_dim, std::uint32_t ocb) {
     fast_tilize_detail::fast_tilize_init_with_dt_impl<true>(icb, full_dim, ocb);
 }
 
-ALWI void fast_tilize_init_with_dt_skip_remap(uint32_t icb, uint32_t full_dim, uint32_t ocb) {
+ALWI void fast_tilize_init_with_dt_skip_remap(std::uint32_t icb, std::uint32_t full_dim, std::uint32_t ocb) {
     fast_tilize_detail::fast_tilize_init_with_dt_impl<false>(icb, full_dim, ocb);
 }
 
-ALWI void fast_tilize_uninit(uint32_t icb, uint32_t ocb, uint32_t full_dim) {
+ALWI void fast_tilize_uninit(std::uint32_t icb, std::uint32_t ocb, std::uint32_t full_dim) {
 #ifdef ARCH_BLACKHOLE
     if (full_dim == 1) {
         tilize_uninit(icb, ocb);
@@ -353,7 +362,11 @@ ALWI void fast_tilize_uninit(uint32_t icb, uint32_t ocb, uint32_t full_dim) {
 }
 
 ALWI void fast_tilize_block(
-    uint32_t icb, uint32_t block, uint32_t ocb, uint32_t input_tile_index = 0, uint32_t output_tile_index = 0) {
+    std::uint32_t icb,
+    std::uint32_t block,
+    std::uint32_t ocb,
+    std::uint32_t input_tile_index = 0,
+    std::uint32_t output_tile_index = 0) {
 #ifdef ARCH_BLACKHOLE
     if (block == 1) {
         tilize_block(icb, block, ocb, input_tile_index, output_tile_index);
@@ -366,9 +379,9 @@ ALWI void fast_tilize_block(
     {
         input_tile_index = input_tile_index % block + (input_tile_index / block) * block * TILE_R_DIM;
 
-        uint32_t tiles_done = 0;
+        std::uint32_t tiles_done = 0;
         // Always program the current unit dim at block entry.
-        uint32_t prev_chunk = 0;
+        std::uint32_t prev_chunk = 0;
 
         PACK((llk_pack_fast_tilize_row_begin(ocb, output_tile_index)));
 
@@ -376,8 +389,8 @@ ALWI void fast_tilize_block(
             // BH fast-tilize MOP supports unit_dim 2, 3, 4 (not 1).
             // Avoid chunk=1 by splitting: remaining=5 → 2+3 instead of 4+1.
             // Matches LLK decompose_row order.
-            uint32_t remaining = block - tiles_done;
-            uint32_t chunk = (remaining > 5) ? 4 : (remaining == 5) ? 2 : remaining;
+            std::uint32_t remaining = block - tiles_done;
+            std::uint32_t chunk = (remaining > 5) ? 4 : (remaining == 5) ? 2 : remaining;
 
             MATH((llk_math_wait_for_dest_available()));
             PACK((llk_packer_wait_for_math_done()));
@@ -400,21 +413,21 @@ ALWI void fast_tilize_block(
         PACK((llk_pack_fast_tilize_row_end()));
     }
 #else
-    uint32_t full_dim = block;
+    std::uint32_t full_dim = block;
 
     // Not sure if input_tile_index can be arbitrary but it works for moving across rows of files,
     // i.e. input_tile_index % full_dim == 0
     input_tile_index = input_tile_index % full_dim + (input_tile_index / full_dim) * full_dim * TILE_R_DIM;
 
-    uint32_t packed_tiles = 0;
-    uint32_t remaining_tiles = block;
-    uint32_t dest_size = DST_ACCUM_MODE ? 4 : 8;
-    uint32_t unit_dim = full_dim == 1 ? 1 : 2;
-    uint32_t num_units = dest_size / unit_dim;
+    std::uint32_t packed_tiles = 0;
+    std::uint32_t remaining_tiles = block;
+    std::uint32_t dest_size = DST_ACCUM_MODE ? 4 : 8;
+    std::uint32_t unit_dim = full_dim == 1 ? 1 : 2;
+    std::uint32_t num_units = dest_size / unit_dim;
 
     while (packed_tiles < block) {
-        UNPACK(uint32_t read_tile_index = input_tile_index + packed_tiles);
-        PACK(uint32_t write_tile_index = output_tile_index + packed_tiles);
+        UNPACK(std::uint32_t read_tile_index = input_tile_index + packed_tiles);
+        PACK(std::uint32_t write_tile_index = output_tile_index + packed_tiles);
 
         MATH((llk_math_wait_for_dest_available()));
         PACK((llk_packer_wait_for_math_done()));
@@ -428,7 +441,7 @@ ALWI void fast_tilize_block(
             remaining_tiles -= dest_size;
         } else if (remaining_tiles > dest_size) {
             // Two dests
-            uint32_t even_remainder = remaining_tiles / 2 + ((remaining_tiles / 2) % 2);
+            std::uint32_t even_remainder = remaining_tiles / 2 + ((remaining_tiles / 2) % 2);
             num_units = even_remainder / unit_dim;
             UNPACK((llk_unpack_fast_tilize_block(icb, read_tile_index, unit_dim, num_units, full_dim)));
             MATH((llk_math_fast_tilize_block_(0, icb, unit_dim, num_units)));
@@ -470,7 +483,40 @@ ALWI void fast_tilize_block(
 #endif
 }
 
-#endif  // !ARCH_QUASAR
+#else   // ARCH_QUASAR
+// Quasar has no separate fast-tilize LLK path -- its regular unpack_tilize is already fast, so these
+// wrappers just forward to the plain tilize_* implementation defined above.
+ALWI void fast_tilize_init(
+    std::uint32_t icb, std::uint32_t full_dim, std::uint32_t ocb, std::uint32_t call_line = __builtin_LINE()) {
+    tilize_init(icb, full_dim, ocb, call_line);
+}
+
+ALWI void fast_tilize_init_skip_remap(
+    std::uint32_t icb, std::uint32_t full_dim, std::uint32_t ocb, std::uint32_t call_line = __builtin_LINE()) {
+    tilize_init(icb, full_dim, ocb, call_line);
+}
+
+ALWI void fast_tilize_init_with_dt(std::uint32_t icb, std::uint32_t full_dim, std::uint32_t ocb) {
+    reconfig_data_format(icb, icb);
+    tilize_init(icb, full_dim, ocb);
+}
+
+ALWI void fast_tilize_init_with_dt_skip_remap(std::uint32_t icb, std::uint32_t full_dim, std::uint32_t ocb) {
+    reconfig_data_format(icb, icb);
+    tilize_init(icb, full_dim, ocb);
+}
+
+ALWI void fast_tilize_uninit(std::uint32_t icb, std::uint32_t ocb, std::uint32_t full_dim) { tilize_uninit(icb, ocb); }
+
+ALWI void fast_tilize_block(
+    std::uint32_t icb,
+    std::uint32_t block,
+    std::uint32_t ocb,
+    std::uint32_t input_tile_index = 0,
+    std::uint32_t output_tile_index = 0) {
+    tilize_block(icb, block, ocb, input_tile_index, output_tile_index);
+}
+#endif  // ARCH_QUASAR
 
 // clang-format off
 /**
@@ -496,5 +542,5 @@ ALWI void fast_tilize_block(
  * | Tile_x_dim (cntx0)        | THCON_SEC0 | Tile X dimension per context for unpacker             | Restored to FACE_DIM_16x16 (16 | (16 << 16))                                               |
  */
 // clang-format on
-ALWI void unpack_tilizeA_B_uninit(uint32_t icb) { UNPACK((llk_unpack_tilizeA_B_uninit(icb))); }
+ALWI void unpack_tilizeA_B_uninit(std::uint32_t icb) { UNPACK((llk_unpack_tilizeA_B_uninit(icb))); }
 }  // namespace ckernel


### PR DESCRIPTION
Quasar has no dedicated fast-tilize LLK -- its regular unpack_tilize path is already fast -- so fast_tilize_init/_skip_remap/_with_dt/ _with_dt_skip_remap/_uninit/_block now forward to the existing plain tilize_init/tilize_block/tilize_uninit on ARCH_QUASAR instead of being undefined, which also fixes compilation of the Quasar-only conv2d/pool kernels that already call these symbols and lets
TensixComputeFastTilize (LLKMeshDeviceFixture) run on Quasar.

#49299

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=rtawfik/quasar-fast-tilize-wrappers)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:rtawfik/quasar-fast-tilize-wrappers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=rtawfik/quasar-fast-tilize-wrappers)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:rtawfik/quasar-fast-tilize-wrappers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=rtawfik/quasar-fast-tilize-wrappers)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:rtawfik/quasar-fast-tilize-wrappers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=rtawfik/quasar-fast-tilize-wrappers)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:rtawfik/quasar-fast-tilize-wrappers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=rtawfik/quasar-fast-tilize-wrappers)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:rtawfik/quasar-fast-tilize-wrappers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=rtawfik/quasar-fast-tilize-wrappers)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:rtawfik/quasar-fast-tilize-wrappers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=rtawfik/quasar-fast-tilize-wrappers)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:rtawfik/quasar-fast-tilize-wrappers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=rtawfik/quasar-fast-tilize-wrappers)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:rtawfik/quasar-fast-tilize-wrappers)