### PR TITLE
Fix tilize hang under col-pass dispatch on Wormhole (#48776)

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/tilize.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/tilize.cpp
@@ -88,6 +88,33 @@ ttnn::Tensor tilize(
                 use_low_perf,
                 tile,
                 sub_core_grids);
+            // For L1-sharded targets the shard grid directly names worker
+            // cores.  Under a non-default dispatch axis some of those cores
+            // may be reserved for dispatch (e.g. column x=7 under COL
+            // dispatch on Wormhole).  to_memory_config onto such cores hangs
+            // the device.  Fall back to interleaved output when the L1 shard
+            // grid exceeds the compute grid.
+            // DRAM-sharded grids enumerate DRAM banks, not worker cores, so
+            // the check does not apply to them.
+            if (target_memory_config.is_sharded() && (target_memory_config.buffer_type() == BufferType::L1 ||
+                                                      target_memory_config.buffer_type() == BufferType::L1_SMALL)) {
+                const auto& shard_grid = target_memory_config.shard_spec().has_value()
+                                             ? target_memory_config.shard_spec()->grid
+                                             : target_memory_config.nd_shard_spec()->grid;
+                auto bb = shard_grid.bounding_box();
+                auto compute_grid = input_tensor.device()->compute_with_storage_grid_size();
+                if (bb.end_coord.x >= compute_grid.x || bb.end_coord.y >= compute_grid.y) {
+                    log_warning(
+                        tt::LogOp,
+                        "ttnn::tilize: target L1 shard grid ({},{}) exceeds compute grid ({},{}), "
+                        "returning DRAM interleaved output instead of hanging (#48776)",
+                        bb.end_coord.x,
+                        bb.end_coord.y,
+                        compute_grid.x,
+                        compute_grid.y);
+                    return interleaved_tile;
+                }
+            }
             return ttnn::to_memory_config(interleaved_tile, target_memory_config);
         }
         return ttnn::prim::tilize(


### PR DESCRIPTION
## Summary

- Fixes #48776: `tilize_model_traced` hangs on N300 Wormhole when `TTNN_DISPATCH_AXIS=col`
- The `#45331` workaround in `tilize.cpp` reroutes wide sharded inputs through interleaved DRAM, then re-shards via `to_memory_config` using the original shard grid. Under column dispatch, that grid may include cores reserved for dispatch (e.g. x=7), causing the device to hang in the RISC-V idle loop.
- Adds a guard that checks whether the target shard grid's bounding box fits within the compute grid. When it does not, the interleaved result is returned instead of attempting the re-shard.

## Test plan

- [x] Run the failing sweep from #48776 with `TTNN_DISPATCH_AXIS=col` on N300 to confirm the hang is resolved
- [ ] Run existing tilize tests to verify no regression on default (row) dispatch
- [ ] Verify on Wormhole with harvested rows to confirm no false positives from the bounding-box check

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=msudumbrekar/fix-tilize-col-dispatch-hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:msudumbrekar/fix-tilize-col-dispatch-hang)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=msudumbrekar/fix-tilize-col-dispatch-hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:msudumbrekar/fix-tilize-col-dispatch-hang)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=msudumbrekar/fix-tilize-col-dispatch-hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:msudumbrekar/fix-tilize-col-dispatch-hang)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=msudumbrekar/fix-tilize-col-dispatch-hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:msudumbrekar/fix-tilize-col-dispatch-hang)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=msudumbrekar/fix-tilize-col-dispatch-hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:msudumbrekar/fix-tilize-col-dispatch-hang)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=msudumbrekar/fix-tilize-col-dispatch-hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:msudumbrekar/fix-tilize-col-dispatch-hang)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=msudumbrekar/fix-tilize-col-dispatch-hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:msudumbrekar/fix-tilize-col-dispatch-hang)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=msudumbrekar/fix-tilize-col-dispatch-hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:msudumbrekar/fix-tilize-col-dispatch-hang)