### PR TITLE
Runtime Test: tensor_accessor: add full-chip address-calc CI microbenchmark (#46305)

### DIFF
--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -267,9 +267,12 @@ runtime:
     # measured, budgeted at 10 min in runtime_perf_tests.yaml).
     wh_n300_civ2: 65
     bh_p150_perf: 50
+  # Profiler-build runtime perf jobs (runtime_perf_op_to_op_latency +
+  # runtime_perf_tensor_accessor), each a single profiler benchmark with a 5-min per-SKU
+  # timeout; budget is the sum of the two (5 + 5 = 10).
   perf_profiler:
-    wh_n300_civ2: 5
-    bh_p150_perf: 5
+    wh_n300_civ2: 10
+    bh_p150_perf: 10
 
 triage:
   merge_gate:

--- a/tests/pipeline_reorg/runtime_perf_profiler_tests.yaml
+++ b/tests/pipeline_reorg/runtime_perf_profiler_tests.yaml
@@ -47,3 +47,32 @@
       timeout: 5
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
   team: runtime
+
+# --- TensorAccessor full-chip address-calculation microbenchmark ---
+# Runs the accessor benchmark gtest (unit_tests_ttnn_accessor,
+# AccessorFullChipBenchmarks.GetNocAddr) with the device profiler: the get_noc_addr
+# address-calc kernel runs on the full Tensix grid for every supported tensor topology
+# (interleaved L1/DRAM, 1D/2D/ND sharded L1, sharded DRAM). It then post-processes the
+# per-topology average device cycles and gates them against the per-arch golden. The
+# metric comes only from the standard device profiler so it behaves identically on
+# Wormhole and Blackhole. Goldens are armed from the scheduled CI baseline per arch.
+- name: runtime_perf_tensor_accessor
+  cmd: |
+    export TT_METAL_DEVICE_PROFILER=1
+    GOLDEN=tests/tt_metal/tt_metal/perf_microbenchmark/tensor_accessor/accessor_golden.json
+    if [ "$ARCH_NAME" = "blackhole" ]; then
+      GOLDEN=tests/tt_metal/tt_metal/perf_microbenchmark/tensor_accessor/accessor_blackhole_golden.json
+    fi
+    # The post-proc imports the profiler team's parser (tracy.process_device_log /
+    # device_post_proc_config), which lives under tools/. Put tools/ (plus repo root)
+    # on PYTHONPATH so it resolves.
+    export PYTHONPATH="${TT_METAL_HOME}/tools:${TT_METAL_HOME}${PYTHONPATH:+:${PYTHONPATH}}"
+    python3 tests/tt_metal/tt_metal/perf_microbenchmark/tensor_accessor/accessor_postprocess.py \
+      --golden "$GOLDEN"
+  skus:
+    wh_n300_civ2:
+      timeout: 5
+    bh_p150_perf:
+      timeout: 5
+  owner_id: U099A7FMKL2 # Manish Sudumbrekar
+  team: runtime

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/tensor_accessor/README.md
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/tensor_accessor/README.md
@@ -1,0 +1,124 @@
+# `tensor_accessor` — CI microbenchmark
+
+Tracks the **on-device `TensorAccessor` address-calculation cost across all supported
+tensor topologies** over time in CI, as part of extending the runtime microbenchmark
+suite ([issue #46305](https://github.com/tenstorrent/tt-metal/issues/46305)).
+
+Goal: capture the perf of address calculation (`get_noc_addr`) for every supported
+`TensorAccessor` topology — **interleaved L1, interleaved DRAM, 1D/2D/ND sharded L1,
+sharded DRAM** — as **full-chip** tests (the kernel runs on every Tensix core).
+
+This is the CI/regression packaging of the accessor benchmark gtests
+(built as `unit_tests_ttnn_accessor`). It runs the benchmarks with the device profiler,
+post-processes the profiler output in Python, and gates one metric per topology
+against a per-arch golden.
+
+## What is measured
+
+The `AccessorFullChipBenchmarks.GetNocAddr` gtest runs the `get_noc_addr(page_id)`
+kernel (`kernels/accessor_get_noc_addr_page_id_benchmark.cpp`) on the **full Tensix
+compute grid** for one pinned all-static arg config per topology, wrapping each call in
+`DeviceZoneScopedN`. The standard device profiler records the per-core zone cycle cost;
+the post-processor averages across cores.
+
+`get_noc_addr` is the address-calculation hot path (page → bank/NOC address). The
+metric is `average device cycles`, keyed by `GetNocAddr.<topology>`, and comes only
+from the standard device profiler, so it behaves identically on Wormhole and Blackhole.
+
+The **realtime profiler is intentionally not used** here (unlike parts of the op-to-op
+latency flow): the metric is a device-cycle count from the standard `{BRISC}-KERNEL`-style
+`DeviceZoneScopedN` zone, which is portable across all single-card platforms, whereas the
+RT profiler is unsupported on some WH setups. The CI command sets only
+`TT_METAL_DEVICE_PROFILER=1` (no RT flag, no `TT_METAL_PROFILER_ACCUMULATE`).
+
+### Topologies covered (full chip)
+
+| Topology (`<topology>`) | Layout | Buffer | Rank |
+|-------------------------|--------|--------|------|
+| `interleaved_l1`   | interleaved | L1   | 2D |
+| `interleaved_dram` | interleaved | DRAM | 2D |
+| `sharded_l1_1d`    | sharded     | L1   | 1D |
+| `sharded_l1_2d`    | sharded     | L1   | 2D |
+| `sharded_l1_nd`    | sharded     | L1   | ND (5) |
+| `sharded_dram_2d`  | sharded     | DRAM | 2D |
+| `sharded_dram_nd`  | sharded     | DRAM | ND (5) |
+
+Sharded DRAM buffers shard across DRAM banks (grid derived from
+`mesh_device->dram_grid_size()` at runtime). Interleaved accessors have no `dspec()`,
+so the kernel reads the page count from a trailing compile-time arg (`INTERLEAVED_LAYOUT`
+path). The single-core, per-arg-config micro-suites (`Constructor`, `GetNocAddr` over the
+15 static/dynamic configs, iterator suites) still exist in the same gtest for local
+characterization; only the full-chip `GetNocAddr` suite is wired into this CI gate.
+
+## Files
+
+```
+accessor_postprocess.py          runs the full-chip suite + parses profiler CSVs into
+                                 per-topology average cycles; with --golden it gates
+accessor_golden.json             Wormhole golden (record mode until populated)
+accessor_blackhole_golden.json   Blackhole golden (record mode until populated)
+```
+
+The benchmark sources are the accessor gtests (built as `unit_tests_ttnn_accessor`). The
+parse reuses the same official tracy parser (`tracy.process_device_log` /
+`tracy.device_post_proc_config`) as the pre-existing accessor benchmark Python wrapper, so
+it stays robust to profiler CSV schema changes.
+
+## Gating
+
+Every measured topology is printed for trending, and the gate fails the job if a
+populated metric drifts outside its golden band (`tolerance_pct`). A metric whose golden
+value is `null` is in **record mode** (printed, not gated), so new topologies can be
+added and armed one at a time.
+
+> **Goldens are armed** from the (Runtime) Performance Tests scheduled runs, per arch
+> (`get_noc_addr` cycles are hardware-specific). Two consecutive scheduled runs agreed to
+> <0.05% on every metric, so `tolerance_pct` is 15% — ample headroom for board-to-board /
+> firmware drift while still catching real regressions. See "Populating / updating the
+> golden" below.
+
+## Where it runs
+
+On the **(Runtime) Performance Tests** pipeline
+(`.github/workflows/runtime-perf-tests.yaml`, job `runtime-perf-profiler-tests`), via
+`tests/pipeline_reorg/runtime_perf_profiler_tests.yaml` (entry
+`runtime_perf_tensor_accessor`). That job uses a dedicated profiler build
+(`ENABLE_TRACY=ON`), the same as the op-to-op latency microbenchmark. SKUs:
+`wh_n300_civ2`, `bh_p150_perf`. Budget subheading: `perf_profiler`.
+
+## Run locally
+
+Needs a Tracy-enabled build (default; i.e. do **not** pass
+`build_metal.sh --disable-profiler`) with tests:
+
+```bash
+export TT_METAL_HOME=$(pwd)
+cmake --build build --target unit_tests_ttnn_accessor -j
+
+# tools/ must be on PYTHONPATH so the profiler parser resolves
+export PYTHONPATH="${TT_METAL_HOME}/tools:${TT_METAL_HOME}:${PYTHONPATH}"
+
+# run the full-chip suite + print per-topology metrics (no gate)
+TT_METAL_DEVICE_PROFILER=1 \
+  python3 tests/tt_metal/tt_metal/perf_microbenchmark/tensor_accessor/accessor_postprocess.py
+
+# run + gate against the golden (compares each populated metric within tolerance_pct)
+TT_METAL_DEVICE_PROFILER=1 \
+  python3 tests/tt_metal/tt_metal/perf_microbenchmark/tensor_accessor/accessor_postprocess.py \
+  --golden tests/tt_metal/tt_metal/perf_microbenchmark/tensor_accessor/accessor_golden.json
+
+# only parse existing result dirs (skip the run)
+python3 tests/tt_metal/tt_metal/perf_microbenchmark/tensor_accessor/accessor_postprocess.py --no-run
+```
+
+## Populating / updating the golden
+
+The golden files ship with `null` values ("record mode"): until a key is populated the
+post-proc only prints the measured value and skips its gate (passes).
+
+To enable a gate:
+1. Run the post-proc on the target SKU and read the printed `GetNocAddr.<topology>`
+   average cycles.
+2. Copy the measured value into the matching golden file's `golden` block
+   (WH → `accessor_golden.json`, BH → `accessor_blackhole_golden.json`).
+3. Tune `golden.tolerance_pct` (start loose, tighten once run-to-run spread is known).

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/tensor_accessor/accessor_blackhole_golden.json
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/tensor_accessor/accessor_blackhole_golden.json
@@ -1,0 +1,15 @@
+{
+  "arch": "blackhole",
+  "description": "TensorAccessor full-chip address-calculation (get_noc_addr) CI golden (Blackhole, bh_p150_perf). Metric = average device cycles for get_noc_addr across the full Tensix grid, one pinned all-static config per tensor topology, keyed by GetNocAddr.<topology>. Baseline captured from the (Runtime) Performance Tests scheduled runs on bh_p150_perf; two consecutive scheduled runs agreed to <0.05% on every metric, so tolerance_pct is set to 15% (ample headroom for board-to-board / firmware drift while still catching real regressions).",
+  "pinned_config": "unit_tests_ttnn_accessor AccessorFullChipBenchmarks.GetNocAddr, full compute grid, all-static config per topology, device profiler",
+  "golden": {
+    "GetNocAddr.interleaved_l1": 20.00,
+    "GetNocAddr.interleaved_dram": 20.00,
+    "GetNocAddr.sharded_l1_1d": 20.00,
+    "GetNocAddr.sharded_l1_2d": 27.01,
+    "GetNocAddr.sharded_l1_nd": 260.96,
+    "GetNocAddr.sharded_dram_2d": 33.22,
+    "GetNocAddr.sharded_dram_nd": 264.92,
+    "tolerance_pct": 15.0
+  }
+}

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/tensor_accessor/accessor_golden.json
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/tensor_accessor/accessor_golden.json
@@ -1,0 +1,15 @@
+{
+  "arch": "wormhole_b0",
+  "description": "TensorAccessor full-chip address-calculation (get_noc_addr) CI golden (Wormhole, wh_n300_civ2). Metric = average device cycles for get_noc_addr across the full Tensix grid, one pinned all-static config per tensor topology, keyed by GetNocAddr.<topology>. Baseline captured from the (Runtime) Performance Tests scheduled runs on wh_n300_civ2; two consecutive scheduled runs agreed to <0.05% on every metric, so tolerance_pct is set to 15% (ample headroom for board-to-board / firmware drift while still catching real regressions).",
+  "pinned_config": "unit_tests_ttnn_accessor AccessorFullChipBenchmarks.GetNocAddr, full compute grid, all-static config per topology, device profiler",
+  "golden": {
+    "GetNocAddr.interleaved_l1": 29.13,
+    "GetNocAddr.interleaved_dram": 29.13,
+    "GetNocAddr.sharded_l1_1d": 20.02,
+    "GetNocAddr.sharded_l1_2d": 27.12,
+    "GetNocAddr.sharded_l1_nd": 256.04,
+    "GetNocAddr.sharded_dram_2d": 38.04,
+    "GetNocAddr.sharded_dram_nd": 273.98,
+    "tolerance_pct": 15.0
+  }
+}

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/tensor_accessor/accessor_postprocess.py
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/tensor_accessor/accessor_postprocess.py
@@ -1,0 +1,338 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Run + post-process the TensorAccessor on-device microbenchmark for CI.
+
+This is the CI/regression packaging of the existing accessor benchmark gtests
+(built as unit_tests_ttnn_accessor), part of extending the runtime microbenchmark
+suite (issue #46305).
+
+It runs exactly one gtest case — AccessorTests/AccessorFullChipBenchmarks.GetNocAddr —
+which measures the accessor address-calculation hot path (get_noc_addr) on the full
+Tensix grid for one pinned all-static config per supported tensor topology (interleaved
+L1/DRAM, 1D/2D/ND sharded L1, sharded DRAM). Each topology case wraps the measured call
+in a DeviceZoneScopedN("SHARDED_ACCESSOR_<bits>") zone and writes its own profiler dir,
+so the standard device profiler records the per-core cycle cost per topology.
+
+This module:
+  1. runs the full-chip benchmark suite once with the device profiler enabled
+     (unless --no-run, in which case it just parses whatever result dirs exist),
+  2. parses each per-topology profiler CSV through the official parser
+     (tracy.process_device_log / device_post_proc_config), reproducing the parse
+     used by the pre-existing accessor benchmark Python wrapper, and
+  3. reduces each topology to one scalar metric = whole-chip average cycles, then
+     gates it against a per-arch golden.
+
+The device-profiler cycle metric behaves identically on Wormhole and Blackhole
+(no realtime profiler dependency). Goldens are armed from the scheduled CI baseline
+per arch; any metric left null is in record mode (printed and skipped, passes), so
+new topologies can be added and armed one metric at a time.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# Full-chip address-calculation (get_noc_addr) benchmark. The gtest
+# (AccessorFullChipBenchmarks.GetNocAddr) runs the kernel on the whole Tensix grid for
+# one pinned all-static config per tensor topology, writing one profiler dir per
+# topology (SetDeviceProfilerDir(res_path + "/" + test_name)). Each CSV holds a single
+# DeviceZoneScopedN zone whose bitmask encodes the layout: 0000000 = interleaved,
+# 0000001 = sharded (the Sharded bit; IsDram is not part of the zone name).
+SUITES = {
+    "GetNocAddr": {
+        "gtest_suite": "AccessorTests/AccessorFullChipBenchmarks.GetNocAddr",
+        "res_dir": "accessor_full_chip_get_noc_addr_benchmarks",
+    },
+}
+
+# Topology profiler-dir name -> the SHARDED_ACCESSOR_<bits> zone the kernel emits for it.
+# (Kept only for documentation; the parser probes both candidate zones so new topologies
+# added to the gtest are picked up automatically.)
+FULL_CHIP_TOPOLOGIES = {
+    "interleaved_l1": "0000000",
+    "interleaved_dram": "0000000",
+    "sharded_l1_1d": "0000001",
+    "sharded_l1_2d": "0000001",
+    "sharded_l1_nd": "0000001",
+    "sharded_dram_2d": "0000001",
+    "sharded_dram_nd": "0000001",
+}
+
+# Candidate zone bitmasks probed per topology dir (interleaved vs sharded all-static).
+ZONE_CANDIDATES = ["0000000", "0000001"]
+
+
+# The repository root is derived from this file's own location (module-controlled), never
+# from the TT_METAL_HOME environment variable, so no external/user-defined value is ever
+# incorporated into the benchmark subprocess command below (Cycode SAST: unsanitized input
+# in OS command). Layout: <root>/tests/tt_metal/tt_metal/perf_microbenchmark/tensor_accessor/.
+_REPO_ROOT = Path(__file__).resolve().parents[5]
+
+
+def _binary_path() -> Path:
+    return _REPO_ROOT / "build" / "test" / "ttnn" / "unit_tests_ttnn_accessor"
+
+
+def _natural_key(name: str):
+    return [int(part) if part.isdigit() else part for part in re.split(r"(\d+)", name)]
+
+
+# gtest filters are built only from the fixed, in-source SUITES table below (never from
+# external input or another process' output), and must match this conservative allowlist
+# before use. Combined with the list argument form (never shell=True), the accessor
+# binary is invoked with fully controlled, non-injectable arguments.
+_VALID_GTEST_ID = re.compile(r"\A[A-Za-z0-9_./*-]+\Z")
+
+
+def _validate_gtest_id(value: str) -> str:
+    if not _VALID_GTEST_ID.match(value):
+        raise SystemExit(f"ERROR: refusing to run unexpected gtest filter: {value!r}")
+    return value
+
+
+# --------------------------------------------------------------------------- #
+# Running the gtest benchmark suites
+# --------------------------------------------------------------------------- #
+def run_suites(suites: list[str]) -> None:
+    """Run each full-chip benchmark suite once under the device profiler.
+
+    Each suite is a single parametrized gtest case (…/GetNocAddr). Its per-topology
+    instances each call SetDeviceProfilerDir()/FreshProfilerDeviceLog() internally, so a
+    single process run emits one profiler dir per topology — no per-test fan-out (and no
+    parsing of the binary's own output back into a command) is needed. The result dirs are
+    written under the repo root (subprocess cwd), where parse_suite() reads them back.
+    """
+    binary = _binary_path()
+    if not binary.exists():
+        raise SystemExit(
+            f"ERROR: accessor benchmark binary not found: {binary}\n"
+            "Build it with: cmake --build build --target unit_tests_ttnn_accessor -j"
+        )
+    env = os.environ.copy()
+    env["TT_METAL_DEVICE_PROFILER"] = "1"
+    # Each topology case flushes its own profiler dir; MID_RUN_DUMP dumps between them.
+    env["TT_METAL_PROFILER_MID_RUN_DUMP"] = "1"
+
+    for suite in suites:
+        # Fixed constant from SUITES (not external input), validated before use and passed
+        # via the list form (no shell), so no argument can be shell-interpreted or injected.
+        gtest_filter = _validate_gtest_id(f"{SUITES[suite]['gtest_suite']}/*")
+        print(f"Running {gtest_filter}")
+        result = subprocess.run([str(binary), f"--gtest_filter={gtest_filter}"], cwd=_REPO_ROOT, env=env)
+        # Fail loudly on a crashing/failing gtest instead of silently post-processing
+        # whatever (stale/partial) profiler dirs happen to be on disk.
+        if result.returncode != 0:
+            raise SystemExit(
+                f"ERROR: benchmark suite '{suite}' ({gtest_filter}) exited with code "
+                f"{result.returncode}; aborting before post-processing."
+            )
+
+
+# --------------------------------------------------------------------------- #
+# Parsing profiler CSVs -> per-(suite, topology) whole-chip average cycles
+# --------------------------------------------------------------------------- #
+def _load_setup(zone_names: list[str]):
+    """Build a device_post_proc_config setup that measures each zone's average
+    cycle cost, identical to the pre-existing accessor benchmark Python wrapper."""
+    try:
+        import tracy.device_post_proc_config as device_post_proc_config
+    except ImportError as exc:  # pragma: no cover - env guard
+        raise SystemExit(
+            "Could not import tracy.device_post_proc_config; run under the tt-metal "
+            f"profiler environment (PYTHONPATH must include tools/). Original error: {exc}"
+        )
+    setup = device_post_proc_config.default_setup()
+    setup.timerAnalysis = {
+        zone: {
+            "across": "core",
+            "type": "adjacent",
+            "start": {"risc": "BRISC", "zone_name": zone},
+            "end": {"risc": "BRISC", "zone_name": zone},
+        }
+        for zone in zone_names
+    }
+    return setup
+
+
+def parse_suite(suite: str) -> dict:
+    """Return {metric_key: average_cycles} for one full-chip suite, per topology.
+
+    metric_key = "<suite>.<topology>", e.g. "GetNocAddr.sharded_dram_nd". The topology
+    is the profiler-dir name; the average is taken across all Tensix cores (the parser
+    aggregates "across": "core"). Missing dirs/zones are skipped (record-mode
+    robustness), not fatal.
+    """
+    try:
+        from tracy.process_device_log import import_log_run_stats
+    except ImportError as exc:  # pragma: no cover - env guard
+        raise SystemExit(
+            "Could not import tracy.process_device_log; run under the tt-metal "
+            f"profiler environment (PYTHONPATH must include tools/). Original error: {exc}"
+        )
+
+    cfg = SUITES[suite]
+    zone_names = [f"SHARDED_ACCESSOR_{c}" for c in ZONE_CANDIDATES]
+    setup = _load_setup(zone_names)
+
+    results_dir = _REPO_ROOT / cfg["res_dir"]
+    metrics: dict[str, float] = {}
+    if not results_dir.is_dir():
+        print(f"WARNING: no results dir for suite {suite}: {results_dir}", file=sys.stderr)
+        return metrics
+
+    for test_dir in sorted((p for p in results_dir.iterdir() if p.is_dir()), key=lambda p: _natural_key(p.name)):
+        topology = test_dir.name
+        csv_path = test_dir / "profile_log_device.csv"
+        if not csv_path.exists():
+            print(f"WARNING: missing profiler CSV: {csv_path}", file=sys.stderr)
+            continue
+        setup.deviceInputLog = csv_path
+        stats = import_log_run_stats(setup)
+        # Read the cross-core weighted average that generate_device_level_summary stores
+        # under the synthetic "DEVICE" core (cores["DEVICE"]["analysis"][zone]["stats"]).
+        # This is the whole-chip number for a full-chip run; the per-core stats live under
+        # cores[<core>]["riscs"]["TENSIX"]["analysis"] instead.
+        try:
+            device_analysis = stats["devices"][0]["cores"]["DEVICE"].get("analysis", {})
+        except (KeyError, IndexError, AttributeError):
+            print(f"WARNING: no DEVICE-level analysis in {csv_path}", file=sys.stderr)
+            continue
+        # One zone per topology dir; probe both candidate layouts and take whichever exists.
+        for zone in zone_names:
+            zstats = device_analysis.get(zone)
+            if zstats and "stats" in zstats:
+                metrics[f"{suite}.{topology}"] = float(zstats["stats"]["Average"])
+                break
+    return metrics
+
+
+# --------------------------------------------------------------------------- #
+# Gating vs golden (record-mode semantics shared with op_to_op_postprocess.py)
+# --------------------------------------------------------------------------- #
+def _fmt(v) -> str:
+    try:
+        return f"{float(v):.2f}"
+    except (TypeError, ValueError):
+        return str(v)
+
+
+def gate_against_golden(metrics: dict, golden_path: Path, gate_metrics, tolerance_override) -> int:
+    """Compare measured metrics against a golden JSON. Gates every non-null value
+    in the golden's 'golden' block (or only `gate_metrics` if provided). A metric
+    whose golden value is null is in record mode (printed, skipped). Returns:
+      0  every populated gate passes (or all null -> record mode)
+      1  any gated metric regresses, or a gated measurement is missing/NaN
+    """
+    if not golden_path.exists():
+        print(f"ERROR: golden file not found: {golden_path}", file=sys.stderr)
+        return 1
+
+    golden = json.loads(golden_path.read_text())
+    golden_block = golden.get("golden", {})
+    tol = tolerance_override if tolerance_override is not None else golden_block.get("tolerance_pct", 15.0)
+
+    keys = list(gate_metrics) if gate_metrics else [k for k in golden_block if k != "tolerance_pct"]
+    if not keys:
+        print(f"ERROR: golden {golden_path.name} defines no gate metrics", file=sys.stderr)
+        return 1
+
+    failed = False
+    for key in keys:
+        golden_value = golden_block.get(key)
+        measured = metrics.get(key)
+        # A missing/NaN measurement is always a failure — even in record mode — so a
+        # parser regression or absent CSV can never leave this job green with no data.
+        if measured is None or measured != measured:  # None or NaN
+            print(f"gate: FAIL — measured {key} is missing/NaN (no samples extracted)", file=sys.stderr)
+            failed = True
+            continue
+        if golden_value is None:
+            print(
+                f"[record mode] golden '{key}' not populated in {golden_path.name}; "
+                f"measured={_fmt(measured)} cycles. Populate it to enable this gate. Passing."
+            )
+            continue
+        lo = golden_value * (1.0 - tol / 100.0)
+        hi = golden_value * (1.0 + tol / 100.0)
+        status = "PASS" if lo <= measured <= hi else "FAIL"
+        line = (
+            f"gate: {key} measured={measured:.2f} golden={golden_value:.2f} "
+            f"allowed=[{lo:.2f}, {hi:.2f}] (+/-{tol}%) -> {status}"
+        )
+        if status == "PASS":
+            print(line)
+        else:
+            print(line, file=sys.stderr)
+            failed = True
+
+    return 1 if failed else 0
+
+
+# --------------------------------------------------------------------------- #
+# Entry point
+# --------------------------------------------------------------------------- #
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Run + post-process the TensorAccessor on-device CI microbenchmark.")
+    ap.add_argument(
+        "--suites",
+        nargs="+",
+        default=list(SUITES.keys()),
+        choices=list(SUITES.keys()),
+        help="benchmark suites to run/parse (default: all pinned suites)",
+    )
+    ap.add_argument(
+        "--no-run",
+        action="store_true",
+        help="skip running the gtest; only parse existing result dirs under the repo root",
+    )
+    ap.add_argument("--out-json", type=Path, default=None, help="write the full metrics JSON to this path")
+    ap.add_argument(
+        "--golden",
+        type=Path,
+        default=None,
+        help="golden JSON to gate against. Null gated values are in record mode (printed, not gated).",
+    )
+    ap.add_argument("--gate-metric", nargs="+", default=None, help="restrict gating to these metric keys")
+    ap.add_argument(
+        "--tolerance-pct", type=float, default=None, help="regression tolerance percent (overrides golden's)"
+    )
+    args = ap.parse_args()
+
+    if not args.no_run:
+        run_suites(args.suites)
+
+    metrics: dict[str, float] = {}
+    for suite in args.suites:
+        metrics.update(parse_suite(suite))
+
+    if metrics:
+        width = max(len(k) for k in metrics)
+        print("tensor_accessor benchmark metrics (average cycles):")
+        for k in sorted(metrics, key=_natural_key):
+            print(f"  {k:<{width}} : {metrics[k]:.2f}")
+    else:
+        print("WARNING: no accessor benchmark metrics were extracted", file=sys.stderr)
+
+    if args.out_json is not None:
+        args.out_json.parent.mkdir(parents=True, exist_ok=True)
+        args.out_json.write_text(json.dumps(metrics, indent=2))
+        print(f"wrote {args.out_json}")
+
+    if args.golden is not None:
+        return gate_against_golden(metrics, args.golden, args.gate_metric, args.tolerance_pct)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/ttnn/unit_tests/gtests/accessor/kernels/accessor_get_noc_addr_page_id_benchmark.cpp
+++ b/tests/ttnn/unit_tests/gtests/accessor/kernels/accessor_get_noc_addr_page_id_benchmark.cpp
@@ -22,9 +22,17 @@ void kernel_main() {
      *     * You can verify by inserting a dummy marker or removing the volatile since compiler will optimize out the
      * calls
      */
+#if INTERLEAVED_LAYOUT
+    // Interleaved accessors have no dspec(); the host pushes the page count as the
+    // compile-time arg right after the accessor args.
+    const uint32_t tensor_volume = get_compile_time_arg_val(args.next_compile_time_args_offset());
+#else
+    // Sharded layout: page count is known from the distribution spec.
+    const uint32_t tensor_volume = tensor_accessor.dspec().tensor_volume();
+#endif
     constexpr size_t loop_count = 125;
     for (size_t i = 0; i < loop_count; ++i) {
-        auto page_id = i % tensor_accessor.dspec().tensor_volume();
+        auto page_id = i % tensor_volume;
         {
             DeviceZoneScopedN(ACCESSOR_CONFIG_NAME);
             volatile auto _ = tensor_accessor.get_noc_addr(page_id);

--- a/tests/ttnn/unit_tests/gtests/accessor/test_accessor_benchmarks.cpp
+++ b/tests/ttnn/unit_tests/gtests/accessor/test_accessor_benchmarks.cpp
@@ -17,6 +17,8 @@
 
 #include <tt-metalium/tensor_accessor_args.hpp>
 
+#include "impl/profiler/profiler_state.hpp"
+
 namespace accessor_benchmarks {
 
 // TODO: Very similar to test_buffer_distribution_spec.cpp; refactor to common header?
@@ -26,6 +28,10 @@ struct InputBufferParams {
     tt::tt_metal::Shape2D page_shape;
     float bytes_per_element;
     tt::DataFormat data_format;  // Used for setting up CBs
+
+    // When true the buffer is interleaved (no distribution spec); the shard-spec
+    // fields below are ignored except for buffer_type.
+    bool is_interleaved = false;
 
     struct DistributionSpecParams {
         tt::tt_metal::Shape physical_shard_shape;
@@ -50,11 +56,20 @@ std::shared_ptr<tt::tt_metal::distributed::MeshBuffer> create_replicated_input_m
     if (is_interleaved) {
         input_buffer_distribution_spec = std::nullopt;
     } else {
+        // For sharded DRAM the shards are distributed across DRAM banks, whose logical
+        // grid (bank_id, 0) differs per arch, so derive it from the device rather than
+        // the (worker-core) grid baked into the test params. Only the first DRAM row is
+        // used since higher y coordinates can be NOC-port replicas of the same banks.
+        tt::tt_metal::CoreRangeSet grid = inputs.input_shard_spec.grid;
+        if (inputs.input_shard_spec.buffer_type == tt::tt_metal::BufferType::DRAM) {
+            const auto dram_grid_size = mesh_device->dram_grid_size();
+            grid = tt::tt_metal::CoreRangeSet(tt::tt_metal::CoreRange({0, 0}, {dram_grid_size.x - 1, 0}));
+        }
         input_buffer_distribution_spec = tt::tt_metal::BufferDistributionSpec::from_shard_spec(
             inputs.physical_tensor_shape,
             inputs.input_shard_spec.physical_shard_shape,
             inputs.page_shape,
-            inputs.input_shard_spec.grid,
+            grid,
             inputs.input_shard_spec.shard_orientation);
     }
     const tt::tt_metal::distributed::DeviceLocalBufferConfig input_device_local_config{
@@ -166,6 +181,83 @@ void benchmark_all_args_combinations_single_core(
     benchmark_args_combinations_single_core(params, mesh_device_, res_path, kernel_path, all_args_combinations);
 }
 
+// Full-chip get_noc_addr (address-calculation) benchmark: run the address-calc kernel
+// on EVERY Tensix worker core simultaneously for one pinned all-static arg config, so
+// the measured per-core zone reflects address calculation under full-chip occupancy.
+// Used to capture the cost across all supported tensor topologies (interleaved L1/DRAM,
+// 1D/2D/ND sharded L1, sharded DRAM); the topology is fully described by `params`
+// (is_interleaved + buffer_type + shapes). The profiler records one zone per core and
+// the post-processor averages across cores.
+void benchmark_get_noc_addr_full_chip(
+    const InputBufferParams& params,
+    const std::shared_ptr<tt::tt_metal::distributed::MeshDevice>& mesh_device_,
+    const std::string& res_path) {
+    using tensor_accessor::ArgConfig;
+    using tensor_accessor::ArgsConfig;
+
+    const bool is_interleaved = params.is_interleaved;
+    const auto input_mesh_buffer =
+        create_replicated_input_mesh_buffer_from_inputs(params, mesh_device_.get(), is_interleaved);
+
+    const tt::tt_metal::distributed::MeshCoordinate mesh_coordinate{0, 0};
+    auto* const input_device_buffer = input_mesh_buffer->get_device_buffer(mesh_coordinate);
+
+    auto profiler_dir = res_path + "/" + params.test_name;
+    tt::tt_metal::detail::SetDeviceProfilerDir(profiler_dir);
+    log_info(tt::LogTest, "Setting profiler dir to: {}", profiler_dir);
+    tt::tt_metal::detail::FreshProfilerDeviceLog();
+
+    // Pinned all-static config for the buffer's layout (interleaved: no bits set;
+    // sharded: only the Sharded bit set). The IsDram bit is derived from the buffer.
+    ArgsConfig arg_config = is_interleaved ? ArgsConfig{} : ArgsConfig{ArgConfig::Sharded};
+    auto args_bitmask = arg_config.raw();
+    std::string crta_config_str = fmt::format("\"SHARDED_ACCESSOR_{:07b}\"", args_bitmask);
+
+    // Run the address-calc kernel across the entire Tensix compute grid.
+    const auto grid_size = mesh_device_->compute_with_storage_grid_size();
+    const tt::tt_metal::CoreRangeSet all_cores(tt::tt_metal::CoreRange({0, 0}, {grid_size.x - 1, grid_size.y - 1}));
+    log_info(
+        tt::LogTest,
+        "Full-chip get_noc_addr benchmark ({}): grid {}x{}, config {}",
+        params.test_name,
+        grid_size.x,
+        grid_size.y,
+        crta_config_str);
+
+    auto program = CreateProgram();
+
+    const auto accessor_args = TensorAccessorArgs(*input_device_buffer, arg_config);
+    auto cta = accessor_args.get_compile_time_args();
+    // Interleaved accessors have no dspec(); the kernel reads the page count from this
+    // trailing compile-time arg (INTERLEAVED_LAYOUT path). Harmless for sharded.
+    cta.push_back(input_device_buffer->num_pages());
+
+    std::map<std::string, std::string> defines{{"ACCESSOR_CONFIG_NAME", crta_config_str}};
+    defines["INTERLEAVED_LAYOUT"] = is_interleaved ? "1" : "0";
+
+    KernelHandle reader_kernel_id = CreateKernel(
+        program,
+        "tests/ttnn/unit_tests/gtests/accessor/kernels/accessor_get_noc_addr_page_id_benchmark.cpp",
+        all_cores,
+        DataMovementConfig{
+            .processor = DataMovementProcessor::RISCV_0,
+            .noc = NOC::RISCV_0_default,
+            .compile_args = cta,
+            .defines = defines});
+
+    SetCommonRuntimeArgs(program, reader_kernel_id, accessor_args.get_common_runtime_args());
+
+    auto mesh_work_load = tt::tt_metal::distributed::MeshWorkload();
+    mesh_work_load.add_program((tt::tt_metal::distributed::MeshCoordinateRange)mesh_coordinate, std::move(program));
+    EnqueueMeshWorkload(mesh_device_->mesh_command_queue(), mesh_work_load, false);
+
+    log_info(tt::LogTest, "Program launched!");
+    Finish(mesh_device_->mesh_command_queue());
+    log_info(tt::LogTest, "Program finished!");
+
+    tt::tt_metal::ReadMeshDeviceProfilerResults(*mesh_device_);
+}
+
 TEST_P(AccessorBenchmarks, GetNocAddr) {
     benchmark_all_args_combinations_single_core(
         GetParam(),
@@ -231,6 +323,134 @@ TEST_P(AccessorBenchmarks, PagesIteratorInterleaved) {
         static_interleaved_args_combinations,
         true);  // is_interleaved = true
 }
+
+// Full-chip address-calculation (get_noc_addr) benchmark across all supported tensor
+// topologies. One pinned all-static config per topology, kernel run on the full Tensix
+// grid. Captures the address-calc cost for: interleaved L1, interleaved DRAM, 1D/2D/ND
+// sharded L1, and sharded DRAM.
+class AccessorFullChipBenchmarks : public GenericMeshDeviceFixture,
+                                   public ::testing::WithParamInterface<InputBufferParams> {};
+
+TEST_P(AccessorFullChipBenchmarks, GetNocAddr) {
+    // These are perf benchmarks whose only output is device-profiler timing. Skip them
+    // unless the profiler is actually enabled so they never run (and can never fail) in
+    // the non-profiler functional gates that run this whole binary unfiltered
+    // (ops_unit_tests.yaml, t3000 unit tests) — they run only in the profiler-build
+    // Runtime Performance Tests pipeline.
+    if (!getDeviceProfilerState()) {
+        GTEST_SKIP() << "TensorAccessor full-chip benchmarks require the device profiler "
+                        "(ENABLE_TRACY build + TT_METAL_DEVICE_PROFILER=1); skipping in non-profiler run.";
+    }
+    benchmark_get_noc_addr_full_chip(GetParam(), mesh_device_, "accessor_full_chip_get_noc_addr_benchmarks");
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    AccessorTests,
+    AccessorFullChipBenchmarks,
+    ::testing::Values(
+        // --- Interleaved ---
+        InputBufferParams{
+            .test_name = "interleaved_l1",
+            .physical_tensor_shape = tt::tt_metal::Shape{320, 320},
+            .page_shape = tt::tt_metal::Shape2D{32, 32},
+            .bytes_per_element = 2,
+            .data_format = tt::DataFormat::Float16,
+            .is_interleaved = true,
+            .input_shard_spec =
+                InputBufferParams::DistributionSpecParams{
+                    .physical_shard_shape = tt::tt_metal::Shape{320, 320},  // ignored for interleaved
+                    .grid = CoreRangeSet(CoreRange({0, 0}, {0, 0})),        // ignored for interleaved
+                    .shard_orientation = ShardOrientation::ROW_MAJOR,
+                    .buffer_type = BufferType::L1,
+                },
+        },
+        InputBufferParams{
+            .test_name = "interleaved_dram",
+            .physical_tensor_shape = tt::tt_metal::Shape{320, 320},
+            .page_shape = tt::tt_metal::Shape2D{32, 32},
+            .bytes_per_element = 2,
+            .data_format = tt::DataFormat::Float16,
+            .is_interleaved = true,
+            .input_shard_spec =
+                InputBufferParams::DistributionSpecParams{
+                    .physical_shard_shape = tt::tt_metal::Shape{320, 320},  // ignored for interleaved
+                    .grid = CoreRangeSet(CoreRange({0, 0}, {0, 0})),        // ignored for interleaved
+                    .shard_orientation = ShardOrientation::ROW_MAJOR,
+                    .buffer_type = BufferType::DRAM,
+                },
+        },
+        // --- Sharded L1: 1D / 2D / ND ---
+        InputBufferParams{
+            .test_name = "sharded_l1_1d",
+            .physical_tensor_shape = tt::tt_metal::Shape{2048},
+            .page_shape = tt::tt_metal::Shape2D{1, 32},
+            .bytes_per_element = 2,
+            .data_format = tt::DataFormat::Float16,
+            .input_shard_spec =
+                InputBufferParams::DistributionSpecParams{
+                    .physical_shard_shape = tt::tt_metal::Shape{512},
+                    .grid = CoreRangeSet(CoreRange({0, 0}, {3, 3})),
+                    .shard_orientation = ShardOrientation::ROW_MAJOR,
+                    .buffer_type = BufferType::L1,
+                },
+        },
+        InputBufferParams{
+            .test_name = "sharded_l1_2d",
+            .physical_tensor_shape = tt::tt_metal::Shape{320, 320},
+            .page_shape = tt::tt_metal::Shape2D{32, 32},
+            .bytes_per_element = 2,
+            .data_format = tt::DataFormat::Float16,
+            .input_shard_spec =
+                InputBufferParams::DistributionSpecParams{
+                    .physical_shard_shape = tt::tt_metal::Shape{96, 96},
+                    .grid = CoreRangeSet(CoreRange({0, 0}, {3, 3})),
+                    .shard_orientation = ShardOrientation::ROW_MAJOR,
+                    .buffer_type = BufferType::L1,
+                },
+        },
+        InputBufferParams{
+            .test_name = "sharded_l1_nd",
+            .physical_tensor_shape = tt::tt_metal::Shape{5, 5, 5, 160, 160},
+            .page_shape = tt::tt_metal::Shape2D{32, 32},
+            .bytes_per_element = 2,
+            .data_format = tt::DataFormat::Float16,
+            .input_shard_spec =
+                InputBufferParams::DistributionSpecParams{
+                    .physical_shard_shape = tt::tt_metal::Shape{3, 3, 3, 96, 96},
+                    .grid = CoreRangeSet(CoreRange({0, 0}, {3, 3})),
+                    .shard_orientation = ShardOrientation::ROW_MAJOR,
+                    .buffer_type = BufferType::L1,
+                },
+        },
+        // --- Sharded DRAM: 2D / ND (grid derived from dram_grid_size at runtime) ---
+        InputBufferParams{
+            .test_name = "sharded_dram_2d",
+            .physical_tensor_shape = tt::tt_metal::Shape{320, 320},
+            .page_shape = tt::tt_metal::Shape2D{32, 32},
+            .bytes_per_element = 2,
+            .data_format = tt::DataFormat::Float16,
+            .input_shard_spec =
+                InputBufferParams::DistributionSpecParams{
+                    .physical_shard_shape = tt::tt_metal::Shape{96, 96},
+                    .grid = CoreRangeSet(CoreRange({0, 0}, {3, 3})),  // overridden by dram_grid_size for DRAM
+                    .shard_orientation = ShardOrientation::ROW_MAJOR,
+                    .buffer_type = BufferType::DRAM,
+                },
+        },
+        InputBufferParams{
+            .test_name = "sharded_dram_nd",
+            .physical_tensor_shape = tt::tt_metal::Shape{5, 5, 5, 160, 160},
+            .page_shape = tt::tt_metal::Shape2D{32, 32},
+            .bytes_per_element = 2,
+            .data_format = tt::DataFormat::Float16,
+            .input_shard_spec =
+                InputBufferParams::DistributionSpecParams{
+                    .physical_shard_shape = tt::tt_metal::Shape{3, 3, 3, 96, 96},
+                    .grid = CoreRangeSet(CoreRange({0, 0}, {3, 3})),  // overridden by dram_grid_size for DRAM
+                    .shard_orientation = ShardOrientation::ROW_MAJOR,
+                    .buffer_type = BufferType::DRAM,
+                },
+        }));
 
 INSTANTIATE_TEST_SUITE_P(
     AccessorTests,


### PR DESCRIPTION
## Summary
Extends the runtime microbenchmark suite (#46305) with an on-device **TensorAccessor address-calculation** microbenchmark that runs `get_noc_addr` across the **full Tensix grid** for every supported tensor topology, then post-processes per-topology device cycles and gates them against per-arch goldens.

Topologies covered (`AccessorFullChipBenchmarks.GetNocAddr`):
- Interleaved L1, Interleaved DRAM
- 1D / 2D / ND sharded L1
- 2D / ND sharded DRAM

## What's included
- **gtest** (`test_accessor_benchmarks.cpp`): new `AccessorFullChipBenchmarks` suite (7 pinned topologies), DRAM-aware buffer creation (sharded-DRAM grid derived from `dram_grid_size()`), and full-compute-grid kernel launch. Guarded by `GTEST_SKIP()` unless the device profiler is enabled, so it can't fail non-profiler gates.
- **kernel** (`accessor_get_noc_addr_page_id_benchmark.cpp`): reads `tensor_volume` from a CTA for the interleaved path (no `dspec()`).
- **CI packaging**: `accessor_postprocess.py` (runs suites under the profiler, parses CSVs via `tracy.process_device_log`, extracts whole-chip average cycles, gates vs golden), per-arch goldens (WH + BH, record mode), and a README.
- **CI wiring**: `runtime_perf_tensor_accessor` job in `runtime_perf_profiler_tests.yaml` (profiler build), profiler build/impl workflows, and `time_budget.yaml` entry (10 min, wh_n300_civ2 + bh_p150_perf).

No realtime profiler is used — the metric comes only from the standard device profiler, so it behaves identically on Wormhole and Blackhole.

## Test plan
- [x] Builds + links (`unit_tests_ttnn_accessor`, ENABLE_TRACY=ON)
- [x] Runs on Blackhole hardware; all 7 topologies execute the kernel across the full grid
- [x] Profiler → CSV → parser → metric pipeline verified end-to-end; postprocess exits 0
- [x] `GTEST_SKIP` guard confirmed in non-profiler build (all cases skip cleanly)
- [x] Gate logic verified (record-mode goldens print + pass)
- [x] Populate per-arch goldens from CI on-silicon runs, then arm the gate (currently `null`)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=msudumbrekar/tensor-accessor-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:msudumbrekar/tensor-accessor-ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=msudumbrekar/tensor-accessor-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:msudumbrekar/tensor-accessor-ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=msudumbrekar/tensor-accessor-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:msudumbrekar/tensor-accessor-ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=msudumbrekar/tensor-accessor-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:msudumbrekar/tensor-accessor-ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=msudumbrekar/tensor-accessor-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:msudumbrekar/tensor-accessor-ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=msudumbrekar/tensor-accessor-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:msudumbrekar/tensor-accessor-ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=msudumbrekar/tensor-accessor-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:msudumbrekar/tensor-accessor-ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=msudumbrekar/tensor-accessor-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:msudumbrekar/tensor-accessor-ci)