### PR TITLE
Add GLM-5.2 chunked-prefill CI jobs and rebalance bh_sc1 timeouts

### DIFF
--- a/.github/workflows/blaze-models-prefill-tests.yaml
+++ b/.github/workflows/blaze-models-prefill-tests.yaml
@@ -11,7 +11,7 @@ on:
           Comma-separated stages to run, e.g. "mla,prefill_block,kimi_moe".
           Empty or "all" runs every stage. Valid stages: moe_gate, mla, mla_chunked,
           kv_cache_table, prefill_block, prefill_transformer, kimi_mla, kimi_moe,
-          kimi_prefill_block, kimi_chunked, dsa_mla, dsa_mla_glm, glm_moe, glm_prefill_block, prefill_block_determinism,
+          kimi_prefill_block, kimi_chunked, glm_chunked, dsa_mla, dsa_mla_glm, glm_moe, glm_prefill_block, glm_chunked_accuracy, prefill_block_determinism,
           prefill_transformer_determinism.
           The "module" group also runs every stage; the "sdpa_perf" group runs the
           ring joint SDPA perf checks.

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py
@@ -112,12 +112,11 @@ LAYER_PCC_THRESHOLD = 0.88
 # Deepest config whose per-layer PCC is asserted; deeper runs (L61) stay record-only until their
 # accumulation headroom is pinned.
 GATED_LAYER_DEPTH = 10
-# Record-only warn floors for the deep KV / indexer-K cache PCC: a WARNING, never a test stop. Set at the
-# observed L78 minimum (not below it) so a future regression trips the warning. KVPE nope bottoms ~0.86
-# (glm_5_2 @L75); indexer-K nope 0.952 (glm_5_1 @L52; glm_5_1 captures all 78 layers, glm_5_2's
-# 0-2+every-4th subsample only reaches 0.980).
-KV_CACHE_PCC_WARN_THRESHOLD = 0.85
-INDEXER_K_PCC_WARN_THRESHOLD = 0.95
+# Floors for the deep KV / indexer-K cache PCC. Set at the observed L78 minimum (not below it) so a
+# future regression fails the test. KVPE nope bottoms ~0.86 (glm_5_2 @L75); indexer-K nope 0.952
+# (glm_5_1 @L52; glm_5_1 captures all 78 layers, glm_5_2's 0-2+every-4th subsample only reaches 0.980).
+KV_CACHE_PCC_THRESHOLD = 0.85
+INDEXER_K_PCC_THRESHOLD = 0.95
 
 # Per-chunk baseline medians (seconds) for the no-PCC perf gate, pulled from a known-good CI run. Keyed
 # by (num_layers, n_chunks, num_iters) so only the exact config we have a CI number for is gated; every
@@ -178,10 +177,10 @@ def _ref_layer_slice(trace_dir: Path, layout: str, layer: int, start: int, end: 
 def _record_kv_cache_pcc(
     trace_dir, layout, tt_kvpe_cache, mesh_device, sp, num_layers, seq_len_cache, total_len, kv_lora
 ):
-    """Record-only: gather the device KV cache, un-rotate the block-cyclic layout, and PCC each layer's
-    valid region [:total_len] against the golden kv_post_transform trace ([nope | pe], the pe half re-based
-    to the device Meta interleave via cache_half_pccs). Per-layer cache — slot == layer. Does NOT assert."""
-    logger.info("Device KV cache vs golden kv_post_transform (record-only):")
+    """Gather the device KV cache, un-rotate the block-cyclic layout, and PCC each layer's valid region
+    [:total_len] against the golden kv_post_transform trace ([nope | pe], the pe half re-based to the
+    device Meta interleave via cache_half_pccs). Per-layer cache — slot == layer."""
+    logger.info("Device KV cache vs golden kv_post_transform:")
     cache_full = gather_cache_tp0(tt_kvpe_cache, mesh_device)  # [num_layers, seq_len_cache, kvpe]
     p = blockcyclic_positions(sp, CHUNK, seq_len_cache)
     cache_min_pcc = {}
@@ -191,29 +190,25 @@ def _record_kv_cache_pcc(
         pcc_nope, pcc_pe = cache_half_pccs(g_post, dev_cache, kv_lora, pe_interleave=True)
         cache_min_pcc[i] = min(pcc_nope, pcc_pe)
         logger.info(f"  cache layer {i} PCC: nope={pcc_nope:.6f} pe(interleaved)={pcc_pe:.6f}")
-        if cache_min_pcc[i] < KV_CACHE_PCC_WARN_THRESHOLD:
-            logger.warning(
-                f"  KV cache layer {i} PCC {cache_min_pcc[i]:.6f} below warn floor "
-                f"{KV_CACHE_PCC_WARN_THRESHOLD} (record-only, not asserted)"
-            )
+        if cache_min_pcc[i] < KV_CACHE_PCC_THRESHOLD:
+            logger.warning(f"  KV cache layer {i} PCC {cache_min_pcc[i]:.6f} below {KV_CACHE_PCC_THRESHOLD}")
     kv_min = min(cache_min_pcc.values())
     logger.info(f"KV cache min PCC across layers: {kv_min:.6f}")
-    if kv_min < KV_CACHE_PCC_WARN_THRESHOLD:
-        logger.warning(f"KV cache min PCC {kv_min:.6f} below warn floor {KV_CACHE_PCC_WARN_THRESHOLD} (record-only)")
+    assert kv_min >= KV_CACHE_PCC_THRESHOLD, f"KV cache min PCC {kv_min:.6f} < {KV_CACHE_PCC_THRESHOLD}"
 
 
 def _record_indexer_k_cache_pcc(
     trace_dir, layout, tt_index_kv_cache, mesh_device, sp, num_layers, seq_len_cache, total_len, config
 ):
-    """Record-only: gather the device DSA indexer-K cache, un-rotate the block-cyclic layout, and PCC
-    each captured layer's valid region [:total_len] against the golden dsa/indexer_k trace. The
-    index_head_dim key is [rope | nope] (rope = first half, indexed-RoPE; nope = second half, no rope);
-    BOTH compare directly because GLM's indexer RoPE is natively interleaved and the vLLM golden stores
-    that same basis (verified on device: the half-split reindex gives ~0 PCC, direct gives ~0.9999).
-    Same gather/un-rotate as the KVPE cache (caller-owned tensor, ConcatMesh2dToTensor dims=(2,1),
-    blockcyclic_positions). indexer_k is captured for a subset of layers (glm_5_1: all; glm_5_2: 0-2 +
-    every 4th) — layers without a golden are skipped. Does NOT assert; GLM DSA variants only."""
-    logger.info("Device indexer-K cache vs golden dsa/indexer_k (record-only):")
+    """Gather the device DSA indexer-K cache, un-rotate the block-cyclic layout, and PCC each captured
+    layer's valid region [:total_len] against the golden dsa/indexer_k trace. The index_head_dim key is
+    [rope | nope] (rope = first half, indexed-RoPE; nope = second half, no rope); BOTH compare directly
+    because GLM's indexer RoPE is natively interleaved and the vLLM golden stores that same basis
+    (verified on device: the half-split reindex gives ~0 PCC, direct gives ~0.9999). Same gather/un-rotate
+    as the KVPE cache (caller-owned tensor, ConcatMesh2dToTensor dims=(2,1), blockcyclic_positions).
+    indexer_k is captured for a subset of layers (glm_5_1: all; glm_5_2: 0-2 + every 4th) — layers without
+    a golden are skipped. GLM DSA variants only."""
+    logger.info("Device indexer-K cache vs golden dsa/indexer_k:")
     cache_full = gather_cache_tp0(tt_index_kv_cache, mesh_device)  # [num_full_indexer_layers or num_layers, T, D]
     layers = [i for i in range(num_layers) if (trace_dir / "dsa" / f"indexer_k_layer_{i}").exists()]
     if not layers:
@@ -230,17 +225,11 @@ def _record_indexer_k_cache_pcc(
         pcc_rope, pcc_nope = cache_half_pccs(g, dev_cache, rope, pe_interleave=False)
         idx_min_pcc[i] = min(pcc_nope, pcc_rope)
         logger.info(f"  indexer cache layer {i} PCC: nope={pcc_nope:.6f} rope={pcc_rope:.6f}")
-        if idx_min_pcc[i] < INDEXER_K_PCC_WARN_THRESHOLD:
-            logger.warning(
-                f"  indexer-K cache layer {i} PCC {idx_min_pcc[i]:.6f} below warn floor "
-                f"{INDEXER_K_PCC_WARN_THRESHOLD} (record-only, not asserted)"
-            )
+        if idx_min_pcc[i] < INDEXER_K_PCC_THRESHOLD:
+            logger.warning(f"  indexer-K cache layer {i} PCC {idx_min_pcc[i]:.6f} below {INDEXER_K_PCC_THRESHOLD}")
     idx_min = min(idx_min_pcc.values())
     logger.info(f"Indexer-K cache min PCC across {len(layers)} captured layers: {idx_min:.6f}")
-    if idx_min < INDEXER_K_PCC_WARN_THRESHOLD:
-        logger.warning(
-            f"Indexer-K cache min PCC {idx_min:.6f} below warn floor {INDEXER_K_PCC_WARN_THRESHOLD} (record-only)"
-        )
+    assert idx_min >= INDEXER_K_PCC_THRESHOLD, f"Indexer-K cache min PCC {idx_min:.6f} < {INDEXER_K_PCC_THRESHOLD}"
 
 
 def _preload_kvpe_prefix_from_trace(
@@ -557,6 +546,7 @@ def run_chunked_transformer(
     num_links,
     topology,
     routing_use_l1_small_for_semaphores=False,
+    preload_isl=0,
 ):
     if weight_cache_path is None:
         pytest.skip(f"pretrained weights unavailable (set {variant.ttnn_cache_env} + {variant.env_var})")
@@ -575,8 +565,12 @@ def run_chunked_transformer(
     assert (sp, tp) == (8, 4), f"this test targets mesh-8x4, got {mesh_shape}"
 
     chunk_local = CHUNK // sp  # 640
-    total_len = n_chunks * CHUNK
-    assert total_len <= SEQ_CACHE, f"{n_chunks} chunks ({total_len}) exceed cache {SEQ_CACHE}"
+    assert preload_isl % CHUNK == 0, f"preload_isl ({preload_isl}) must be a multiple of CHUNK ({CHUNK})"
+    measured_len = n_chunks * CHUNK
+    total_len = preload_isl + measured_len
+    assert (
+        total_len <= SEQ_CACHE
+    ), f"preload_isl {preload_isl} + {n_chunks} chunks ({measured_len}) = {total_len} exceed cache {SEQ_CACHE}"
 
     emb_dim = config.hidden_size
     kvpe_dim = config.qk_rope_head_dim + config.kv_lora_rank
@@ -584,7 +578,7 @@ def run_chunked_transformer(
 
     logger.info(
         f"chunked transformer: num_layers={num_layers} mesh={mesh_shape} n_chunks={n_chunks} "
-        f"total_len={total_len} cache={SEQ_CACHE} chunk={CHUNK}"
+        f"preload_isl={preload_isl} total_len={total_len} cache={SEQ_CACHE} chunk={CHUNK}"
     )
 
     token_ids_full = _load_metadata_token_ids(trace_dir, total_len)
@@ -667,6 +661,40 @@ def run_chunked_transformer(
             dtype=ttnn.bfloat8_b,
         )
 
+    if preload_isl > 0:
+        trace_native_len = token_ids_full.numel()
+        _preload_kvpe_prefix_from_trace(
+            tt_kvpe_cache,
+            trace_dir,
+            layout,
+            num_layers,
+            preload_isl,
+            trace_native_len,
+            sp,
+            SEQ_CACHE,
+            kvpe_dim,
+            config.kv_lora_rank,
+            mesh_device,
+            sp_axis,
+            kvpe_dtype_layout.get("dtype", ttnn.bfloat8_b),
+            kvpe_dtype_layout.get("layout", ttnn.TILE_LAYOUT),
+        )
+        if tt_index_kv_cache is not None:
+            _preload_indexer_k_prefix_from_trace(
+                tt_index_kv_cache,
+                trace_dir,
+                layout,
+                config,
+                num_layers,
+                preload_isl,
+                trace_native_len,
+                sp,
+                SEQ_CACHE,
+                config.index_head_dim,
+                mesh_device,
+                sp_axis,
+            )
+
     mesh_device.enable_program_cache()
 
     # min PCC per layer across chunks (for the summary)
@@ -674,7 +702,7 @@ def run_chunked_transformer(
 
     profiler.start("tt_forward")
     for c in range(n_chunks):
-        kv_actual = c * CHUNK  # chunk-aligned -> rotation degenerates
+        kv_actual = preload_isl + c * CHUNK  # chunk-aligned -> rotation degenerates
         positions = rotated_chip_positions(kv_actual, sp, chunk_local)
         flat = torch.tensor([positions[ch][r] for ch in range(sp) for r in range(chunk_local)], dtype=torch.long)
         local_pos = flat - kv_actual  # permutation of [0, CHUNK)
@@ -714,11 +742,9 @@ def run_chunked_transformer(
             ref = _ref_layer_slice(trace_dir, layout, i, kv_actual, kv_actual + CHUNK)
             _, pcc = comp_pcc(ref, natural)
             layer_min_pcc[i] = min(layer_min_pcc[i], pcc)
-            # Record-only mode: log every per-layer/per-chunk PCC, do not assert (deep-layer
-            # accumulation profiling). Flag sub-threshold values as warnings instead of failing.
             logger.info(f"  chunk {c} layer {i} PCC: {pcc:.6f}")
             if pcc < LAYER_PCC_THRESHOLD:
-                logger.warning(f"  chunk {c} layer {i} PCC {pcc:.6f} below {LAYER_PCC_THRESHOLD} (not asserted)")
+                logger.warning(f"  chunk {c} layer {i} PCC {pcc:.6f} below {LAYER_PCC_THRESHOLD}")
         logger.info(f"  chunk {c} done ({num_layers} layers)")
     profiler.end("tt_forward")
 
@@ -726,11 +752,8 @@ def run_chunked_transformer(
     for i in range(num_layers):
         logger.info(f"  layer {i}: {layer_min_pcc[i]:.6f}")
 
-    # Gate the shallow configs (measured >=0.99) so a real regression fails CI; the full-depth run's
-    # accumulation headroom is not yet pinned, so it stays record-only.
     overall_min = min(layer_min_pcc.values())
-    if num_layers <= GATED_LAYER_DEPTH:
-        assert overall_min >= LAYER_PCC_THRESHOLD, f"min per-layer PCC {overall_min:.6f} < {LAYER_PCC_THRESHOLD}"
+    assert overall_min >= LAYER_PCC_THRESHOLD, f"min per-layer PCC {overall_min:.6f} < {LAYER_PCC_THRESHOLD}"
 
     _record_kv_cache_pcc(
         trace_dir,
@@ -984,7 +1007,11 @@ def test_kimi_prefill_transformer_chunked_padded(
 # override with PREFILL_TRACE_DIR).
 
 
-@pytest.mark.parametrize("n_chunks", [11], ids=["chunks11"])
+@pytest.mark.parametrize(
+    "n_chunks, preload_isl",
+    [(1, 10 * CHUNK), (11, 0)],
+    ids=["warm_cache", "cold_cache"],
+)
 @pytest.mark.parametrize("num_layers", [1, 10, 78], ids=["L1", "L10", "L78"])
 @pytest.mark.parametrize(
     "mesh_device, device_params, num_links, topology",
@@ -1017,6 +1044,7 @@ def test_glm_prefill_transformer_chunked(
     weight_cache_path,
     num_layers,
     n_chunks,
+    preload_isl,
     num_links,
     topology,
 ):
@@ -1031,6 +1059,7 @@ def test_glm_prefill_transformer_chunked(
         num_links,
         topology,
         routing_use_l1_small_for_semaphores=True,
+        preload_isl=preload_isl,
     )
 
 

--- a/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
+++ b/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
@@ -30,7 +30,7 @@
   test_group: module
   skus:
     bh_sc1:
-      timeout: 20
+      timeout: 8
   owner_id: U08RL15T4N8
   team: models
   sp_config: sc1
@@ -53,7 +53,7 @@
   test_group: module
   skus:
     bh_sc1:
-      timeout: 20
+      timeout: 16
   owner_id: U08RL15T4N8
   team: models
   sp_config: sc1
@@ -70,7 +70,7 @@
   test_group: module
   skus:
     bh_sc1:
-      timeout: 30
+      timeout: 10
   owner_id: U07N3CUUN05  # Iva Potkonjak
   team: models
   sp_config: sc1
@@ -155,7 +155,7 @@
   test_group: module
   skus:
     bh_sc1:
-      timeout: 15
+      timeout: 7
   owner_id: U08RL15T4N8
   team: models
   sp_config: sc1
@@ -175,7 +175,7 @@
   test_group: module
   skus:
     bh_sc1:
-      timeout: 35
+      timeout: 15
   owner_id: U07N3CUUN05  # Iva Potkonjak
   team: models
   sp_config: sc1
@@ -298,7 +298,7 @@
   test_group: module
   skus:
     bh_sc1:
-      timeout: 35
+      timeout: 15
   owner_id: U08RL15T4N8
   team: models
   sp_config: sc1
@@ -378,5 +378,45 @@
       # Job takes under 20 minutes; 40 minute timeout provides buffer for variance and machines with less power.
       timeout: 40
   owner_id: U08RL15T4N8
+  team: models
+  sp_config: sc1
+
+- name: "Blaze - Chunked GLM (code_debug 55k)"
+  cmd: |
+    export MESH_DEVICE=TG
+    export LOGURU_LEVEL=INFO
+    export GLM52_HF_MODEL=/mnt/models/deepseek-prefill-cache/GLM-5.2-FP8
+    export TT_GLM52_PREFILL_TTNN_CACHE=/mnt/models/deepseek-prefill-cache/glm52_ttnn_cache
+    export PREFILL_TRACE_DIR=/mnt/models/deepseek-prefill-cache/glm-traces/vllm-glm52-indexer-kcache-55k
+    mpirun --bind-to none --pernode --tag-output bash -lc '
+      export OMP_NUM_THREADS=$(nproc)
+      python3 -m pytest models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py::test_glm_prefill_transformer_chunked_no_pcc[blackhole-glm52-mesh-8x4-L78-preload0-chunks_eleven-ten_iters] -xvs
+    '
+  test_type: glm_chunked
+  test_group: module
+  skus:
+    bh_sc1:
+      timeout: 45
+  owner_id: U07N3CUUN05  # Iva Potkonjak
+  team: models
+  sp_config: sc1
+
+- name: "Blaze - Chunked GLM Accuracy (code_debug 55k)"
+  cmd: |
+    export MESH_DEVICE=TG
+    export LOGURU_LEVEL=INFO
+    export GLM52_HF_MODEL=/mnt/models/deepseek-prefill-cache/GLM-5.2-FP8
+    export TT_GLM52_PREFILL_TTNN_CACHE=/mnt/models/deepseek-prefill-cache/glm52_ttnn_cache
+    export PREFILL_TRACE_DIR=/mnt/models/deepseek-prefill-cache/glm-traces/vllm-glm52-indexer-kcache-55k
+    mpirun --bind-to none --pernode --tag-output bash -lc '
+      export OMP_NUM_THREADS=$(nproc)
+      python3 -m pytest models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py::test_glm_prefill_transformer_chunked -k "glm52 and 8x4 and L78 and warm_cache" -xvs
+    '
+  test_type: glm_chunked_accuracy
+  test_group: module
+  skus:
+    bh_sc1:
+      timeout: 40
+  owner_id: U07N3CUUN05  # Iva Potkonjak
   team: models
   sp_config: sc1


### PR DESCRIPTION
## Summary
Resolves #50600
- Adds two chunked-prefill CI jobs for GLM-5.2 (mirroring the existing Kimi chunked job): a no-PCC perf/smoke job driving the full 55k `code_debug` trace end to end, and a warm-cache accuracy job that PCC-checks a single chunk against golden KV/indexer-K preloaded from the trace instead of rebuilding the cache from scratch.
- Wires both into `workflow_dispatch` (`glm_chunked`, `glm_chunked_accuracy`).
- Rebalances `bh_sc1` job timeouts (MLA, DSA MLA V3.2, Prefill Block Determinism, MoE Gate, MLA Chunked, Kimi MLA) to absorb the new jobs' timeout budget instead of raising `.github/time_budget.yaml`.

## Test plan
- [x] [![blaze-models-prefill-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blaze-models-prefill-tests.yaml/badge.svg?branch=ipotkonjak/ci-glm-chunked-prefill)](https://github.com/tenstorrent/tt-metal/actions/workflows/blaze-models-prefill-tests.yaml?query=branch:ipotkonjak/ci-glm-chunked-prefill)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ipotkonjak/ci-glm-chunked-prefill)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ipotkonjak/ci-glm-chunked-prefill)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ipotkonjak/ci-glm-chunked-prefill)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ipotkonjak/ci-glm-chunked-prefill)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ipotkonjak/ci-glm-chunked-prefill)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ipotkonjak/ci-glm-chunked-prefill)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ipotkonjak/ci-glm-chunked-prefill)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ipotkonjak/ci-glm-chunked-prefill)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ipotkonjak/ci-glm-chunked-prefill)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ipotkonjak/ci-glm-chunked-prefill)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ipotkonjak/ci-glm-chunked-prefill)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ipotkonjak/ci-glm-chunked-prefill)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ipotkonjak/ci-glm-chunked-prefill)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ipotkonjak/ci-glm-chunked-prefill)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ipotkonjak/ci-glm-chunked-prefill)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ipotkonjak/ci-glm-chunked-prefill)