### PR TITLE
[Feature] DIIM-260 - Allow Exabox recovery when versions cannot be read

### DIFF
--- a/tools/scaleout/exabox/recover.sh
+++ b/tools/scaleout/exabox/recover.sh
@@ -50,9 +50,12 @@ Required Options:
 
 Optional:
     --config <4x32|8x16>                    Mesh configuration (default: 4x32)
-    --use-docker [docker-image]             Run validation via mpi-docker. If an image is given, uses it;
-                                            if the flag is passed with no image, uses the default:
-                                            $DOCKER_IMAGE_DEFAULT
+    --use-docker [docker-image]             Run validation via mpi-docker. Accepts:
+                                              <image>   use the given image
+                                              default   (or no value) use the default image:
+                                                        $DOCKER_IMAGE_DEFAULT
+                                              none      use plain mpirun with local build
+                                                        (same as omitting --use-docker)
                                             (if the flag is omitted entirely, uses plain mpirun with local build)
     --num-iterations <number>               Number of validation iterations (default: 5)
                                             This is the inner per-run validation loop.
@@ -122,7 +125,7 @@ EOF
 HOSTS=""
 CONFIG="4x32"
 DOCKER_IMAGE=""
-DOCKER_IMAGE_DEFAULT="ghcr.io/tenstorrent/tt-metal/upstream-tests-bh-glx:v0.74.0-dev20260620-6-gd9d52dfe7b6"
+DOCKER_IMAGE_DEFAULT="ghcr.io/tenstorrent/tt-metal/upstream-tests-bh-glx:v0.76.0-dev20260721-30-g9dca5ec435f"
 NUM_ITERATIONS=5
 MAX_ATTEMPTS=1
 SLEEP_DURATION=5
@@ -179,6 +182,14 @@ while [[ $# -gt 0 ]]; do
                 # No value provided: fall back to the default image.
                 DOCKER_IMAGE="$DOCKER_IMAGE_DEFAULT"
                 shift
+            elif [[ "$2" == "default" ]]; then
+                # Explicit "default": use the default image.
+                DOCKER_IMAGE="$DOCKER_IMAGE_DEFAULT"
+                shift 2
+            elif [[ "$2" == "none" ]]; then
+                # "none": use the local build, same as omitting --use-docker.
+                DOCKER_IMAGE=""
+                shift 2
             else
                 DOCKER_IMAGE="$2"
                 shift 2
@@ -458,21 +469,14 @@ echo "Regenerate on failure: $REGENERATE_ON_FAILURE"
 echo "=========================================="
 echo ""
 
-# Step 0: assert minimum tt-smi / KMD / firmware versions on every host (see check_cluster_versions
+# Step 0: assert minimum tt-smi / KMD / firmware versions on every host (see run_version_check_gate
 # in utils/host_utils.sh). These are host-level (independent of --use-docker), so the check always
-# runs via plain mpirun.
+# runs via plain mpirun. A version below the minimum aborts; versions that can't be read only warn
+# and continue. `if !` suspends `set -e` so we handle the abort case here.
 if [[ "$SKIP_VERSION_CHECK" == false ]]; then
-    echo "Checking tt-smi/KMD/firmware versions on all hosts..."
-    # `if !` suspends `set -e`, so a failing rank is handled here instead of aborting abruptly.
-    if ! check_cluster_versions "$HOSTS" "$MPI_IF" "${MPI_EXTRA_ARGS[@]}"; then
-        echo ""
-        echo "Error: version check failed on one or more hosts (see above)."
-        echo "       Required: tt-smi >= $TT_SMI_MIN_VERSION, KMD >= $KMD_MIN_VERSION, firmware >= $FW_MIN_VERSION."
-        echo "       Re-run with --skip-version-check to bypass."
+    if ! run_version_check_gate "$HOSTS" "$MPI_IF" "${MPI_EXTRA_ARGS[@]}"; then
         exit 1
     fi
-    echo "Version check passed on all hosts."
-    echo ""
 else
     echo "Skipping version check (--skip-version-check)"
     echo ""

--- a/tools/scaleout/exabox/run_validation.sh
+++ b/tools/scaleout/exabox/run_validation.sh
@@ -415,18 +415,12 @@ fi
 echo ""
 
 # Assert minimum tt-smi / KMD / firmware versions on every host before validation (see
-# check_cluster_versions in utils/host_utils.sh). Host-level check, always via plain mpirun.
+# run_version_check_gate in utils/host_utils.sh). Host-level check, always via plain mpirun. A
+# version below the minimum aborts; versions that can't be read only warn and continue.
 if [[ "$SKIP_VERSION_CHECK" == false ]]; then
-    echo "Checking tt-smi/KMD/firmware versions on all hosts..."
-    if ! check_cluster_versions "$HOSTS" "$MPI_IF" "${MPI_EXTRA_ARGS[@]}"; then
-        echo ""
-        echo "Error: version check failed on one or more hosts (see above)."
-        echo "       Required: tt-smi >= $TT_SMI_MIN_VERSION, KMD >= $KMD_MIN_VERSION, firmware >= $FW_MIN_VERSION."
-        echo "       Re-run with --skip-version-check to bypass."
+    if ! run_version_check_gate "$HOSTS" "$MPI_IF" "${MPI_EXTRA_ARGS[@]}"; then
         exit 1
     fi
-    echo "Version check passed on all hosts."
-    echo ""
 fi
 
 # Create output directory if it doesn't exist and resolve to an absolute path so

--- a/tools/scaleout/exabox/utils/host_utils.sh
+++ b/tools/scaleout/exabox/utils/host_utils.sh
@@ -150,8 +150,10 @@ run_version_check_gate() {
     rc=$?
     printf '%s\n' "$out"
 
-    # A genuine version-below-minimum is always a hard failure.
-    if printf '%s\n' "$out" | grep -q '< required'; then
+    # A genuine version-below-minimum is always a hard failure. Use a bash pattern match rather than
+    # a `... | grep -q` pipeline: under `set -o pipefail`, grep can close the pipe on an early match,
+    # the upstream printf gets SIGPIPE, and the pipeline returns non-zero, masking the match.
+    if [[ "$out" == *"< required"* ]]; then
         echo ""
         echo "Error: version check failed on one or more hosts (see above)."
         echo "       Required: tt-smi >= $TT_SMI_MIN_VERSION, KMD >= $KMD_MIN_VERSION, firmware >= $FW_MIN_VERSION."

--- a/tools/scaleout/exabox/utils/host_utils.sh
+++ b/tools/scaleout/exabox/utils/host_utils.sh
@@ -125,3 +125,52 @@ VERSION_CHECK_CMD
         "${mpi_extra_args[@]}" \
         bash -c "$version_check_cmd" _ "$TT_SMI_MIN_VERSION" "$KMD_MIN_VERSION" "$FW_MIN_VERSION"
 }
+
+# Runs check_cluster_versions and prints standard status messages, deciding whether the caller
+# should proceed. Distinguishes two failure modes from the check output:
+#   - a version below the required minimum  -> hard failure (return 1: caller should abort)
+#   - versions could not be read at all     -> can't verify, but don't block (yellow warning, return 0)
+# This keeps recovery/validation running when e.g. tt_fw_bundle_ver is transiently unreadable
+# (device busy) instead of failing the whole procedure. Returns 0 to proceed, 1 to abort.
+#
+# Usage: run_version_check_gate "$HOSTS" "$MPI_IF" [mpi_extra_args...]
+run_version_check_gate() {
+    local hosts="$1"
+    local mpi_if="$2"
+    shift 2
+    local mpi_extra_args=("$@")
+
+    local yellow=$'\033[1;33m'
+    local reset=$'\033[0m'
+
+    echo "Checking tt-smi/KMD/firmware versions on all hosts..."
+
+    local out rc
+    out=$(check_cluster_versions "$hosts" "$mpi_if" "${mpi_extra_args[@]}" 2>&1)
+    rc=$?
+    printf '%s\n' "$out"
+
+    # A genuine version-below-minimum is always a hard failure.
+    if printf '%s\n' "$out" | grep -q '< required'; then
+        echo ""
+        echo "Error: version check failed on one or more hosts (see above)."
+        echo "       Required: tt-smi >= $TT_SMI_MIN_VERSION, KMD >= $KMD_MIN_VERSION, firmware >= $FW_MIN_VERSION."
+        echo "       Re-run with --skip-version-check to bypass."
+        return 1
+    fi
+
+    # Otherwise a non-zero result means some version could not be read (e.g. tt_fw_bundle_ver busy).
+    # We can't verify the versions, but don't block the run — warn (yellow) and continue.
+    if [[ $rc -ne 0 ]]; then
+        printf '%s\n' ""
+        printf '%sWarning: could not read tool/driver/firmware versions on one or more hosts (see above).%s\n' "$yellow" "$reset"
+        printf '%s         Skipping the version check and continuing to the tests.%s\n' "$yellow" "$reset"
+        printf '%s         Pass --skip-version-check to skip this check explicitly.%s\n' "$yellow" "$reset"
+        printf '%s\n' ""
+        return 0
+    fi
+
+    echo "Version check passed on all hosts."
+    echo ""
+    return 0
+}


### PR DESCRIPTION
### Ticket

[DIIM-260]()

### Summary

- Version check no longer hard-fails when versions are unreadable. Introduced `run_version_check_gate()` in `utils/host_utils.sh` which distinguishes two cases:
  - a version *below the required minimum* → hard failure, aborts as before
  - versions that *can't be read* (e.g. `tt_fw_bundle_ver` busy) → yellow warning and continue, so a transient read failure no longer blocks recovery/validation
- **`recover.sh` and `run_validation.sh`** now call the shared `run_version_check_gate()` instead of inlining the check/error handling, removing duplicated logic.
- **`--use-docker` now accepts explicit `default` and `none` values** (`none` = local build, same as omitting the flag), with updated `--help` text.
- **Bumped the default docker image** to `v0.76.0-dev20260721-30-g9dca5ec435f`.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=DIIM-260-Recover-version-check-update)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:DIIM-260-Recover-version-check-update)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=DIIM-260-Recover-version-check-update)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:DIIM-260-Recover-version-check-update)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=DIIM-260-Recover-version-check-update)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:DIIM-260-Recover-version-check-update)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=DIIM-260-Recover-version-check-update)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:DIIM-260-Recover-version-check-update)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=DIIM-260-Recover-version-check-update)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:DIIM-260-Recover-version-check-update)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=DIIM-260-Recover-version-check-update)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:DIIM-260-Recover-version-check-update)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=DIIM-260-Recover-version-check-update)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:DIIM-260-Recover-version-check-update)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=DIIM-260-Recover-version-check-update)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:DIIM-260-Recover-version-check-update)