### PR TITLE
[Cleanup] Provides alternatives to `shared_ptr` based `MeshBuffer` APIs

### DIFF
--- a/tests/tt_metal/distributed/test_mesh_buffer.cpp
+++ b/tests/tt_metal/distributed/test_mesh_buffer.cpp
@@ -728,8 +728,8 @@ TEST_F(MeshBufferTestSuite, MultiShardReadWrite) {
                 output_shards.push_back(distributed::ShardDataTransfer{coord}.host_data(dst_vec[coord].data()));
             }
 
-            mesh_device_->mesh_command_queue().enqueue_write_shards(mesh_buffer, input_shards, false);
-            mesh_device_->mesh_command_queue().enqueue_read_shards(output_shards, mesh_buffer, true);
+            mesh_device_->mesh_command_queue().enqueue_write_shards(*mesh_buffer, input_shards, false);
+            mesh_device_->mesh_command_queue().enqueue_read_shards(output_shards, *mesh_buffer, true);
 
             for (auto& dst : dst_vec) {
                 EXPECT_EQ(dst.second, src_vec);
@@ -789,8 +789,8 @@ TEST_F(MeshBufferTestSuite, MultiShardReadWriteMultiThread) {
                         output_shards.push_back(distributed::ShardDataTransfer{coord}.host_data(dst_vec[coord].data()));
                     }
 
-                    mesh_device_->mesh_command_queue().enqueue_write_shards(mesh_buffer, input_shards, false);
-                    mesh_device_->mesh_command_queue().enqueue_read_shards(output_shards, mesh_buffer, true);
+                    mesh_device_->mesh_command_queue().enqueue_write_shards(*mesh_buffer, input_shards, false);
+                    mesh_device_->mesh_command_queue().enqueue_read_shards(output_shards, *mesh_buffer, true);
 
                     for (auto& dst : dst_vec) {
                         EXPECT_EQ(dst.second, src_vec);
@@ -830,7 +830,7 @@ TEST_F(MeshBufferTestSuite, EnqueueReadShardsWithPinnedMemoryFullRange) {
     auto write_transfer = distributed::ShardDataTransfer{coord}
                               .host_data(static_cast<void*>(const_cast<uint32_t*>(src.data())))
                               .region(BufferRegion(0, bytes_per_device));
-    mesh_device_->mesh_command_queue().enqueue_write_shards(mesh_buffer, {write_transfer}, /*blocking=*/true);
+    mesh_device_->mesh_command_queue().enqueue_write_shards(*mesh_buffer, {write_transfer}, /*blocking=*/true);
 
     // Prepare destination buffer and pin the entire destination range for the target shard
     auto dst = std::make_shared<vector_aligned<uint32_t>>(bytes_per_device / sizeof(uint32_t), 0);
@@ -853,7 +853,7 @@ TEST_F(MeshBufferTestSuite, EnqueueReadShardsWithPinnedMemoryFullRange) {
                              .host_data(static_cast<void*>(dst_ptr_aligned))
                              .region(BufferRegion(0, bytes_per_device));
     experimental::ShardDataTransferSetPinnedMemory(read_transfer, pinned_shared);
-    mesh_device_->mesh_command_queue().enqueue_read_shards({read_transfer}, mesh_buffer, /*blocking=*/true);
+    mesh_device_->mesh_command_queue().enqueue_read_shards({read_transfer}, *mesh_buffer, /*blocking=*/true);
 
     std::vector<uint32_t> dst_aligned(dst_ptr_aligned, dst_ptr_aligned + (bytes_per_device / sizeof(uint32_t)));
 
@@ -886,7 +886,7 @@ TEST_F(MeshBufferTestSuite, EnqueueReadWithDistributedHostBufferAndPinnedMemory)
     auto write_transfer = distributed::ShardDataTransfer{coord}
                               .host_data(static_cast<void*>(const_cast<uint32_t*>(src.data())))
                               .region(BufferRegion(0, bytes_per_device));
-    mesh_device_->mesh_command_queue().enqueue_write_shards(mesh_buffer, {write_transfer}, /*blocking=*/true);
+    mesh_device_->mesh_command_queue().enqueue_write_shards(*mesh_buffer, {write_transfer}, /*blocking=*/true);
 
     // Prepare destination buffer and pin the entire destination range for the target shard
     auto dst = std::make_shared<vector_aligned<uint32_t>>(bytes_per_device / sizeof(uint32_t), 0);
@@ -909,7 +909,7 @@ TEST_F(MeshBufferTestSuite, EnqueueReadWithDistributedHostBufferAndPinnedMemory)
 
     // Read back using enqueue_read with DistributedHostBuffer
     mesh_device_->mesh_command_queue().enqueue_read(
-        mesh_buffer, distributed_host_buffer, std::nullopt, /*blocking=*/true);
+        *mesh_buffer, distributed_host_buffer, std::nullopt, /*blocking=*/true);
 
     std::vector<uint32_t> dst_aligned(dst_ptr_aligned, dst_ptr_aligned + (bytes_per_device / sizeof(uint32_t)));
 
@@ -1047,7 +1047,7 @@ TEST_F(MeshBufferTestSuite, EnqueueReadShardsWithPinnedMemoryFullRangeUnaligned)
     distributed::MeshCoordinate coord(0, 0);
     auto write_transfer =
         distributed::ShardDataTransfer{coord}.host_data(src.data()).region(BufferRegion(0, bytes_per_device));
-    mesh_device_->mesh_command_queue().enqueue_write_shards(mesh_buffer, {write_transfer}, /*blocking=*/true);
+    mesh_device_->mesh_command_queue().enqueue_write_shards(*mesh_buffer, {write_transfer}, /*blocking=*/true);
 
     constexpr size_t unaligned_shift = 3;
     // Prepare destination buffer and pin the entire destination range for the target shard
@@ -1068,7 +1068,7 @@ TEST_F(MeshBufferTestSuite, EnqueueReadShardsWithPinnedMemoryFullRangeUnaligned)
     auto read_transfer = distributed::ShardDataTransfer{coord}
                              .host_data(static_cast<void*>(dst_ptr_unaligned))
                              .region(BufferRegion(0, bytes_per_device));
-    mesh_device_->mesh_command_queue().enqueue_read_shards({read_transfer}, mesh_buffer, /*blocking=*/true);
+    mesh_device_->mesh_command_queue().enqueue_read_shards({read_transfer}, *mesh_buffer, /*blocking=*/true);
 
     std::vector<uint8_t> dst_aligned(dst_ptr_unaligned, dst_ptr_unaligned + bytes_per_device);
 
@@ -1119,14 +1119,14 @@ TEST_F(MeshBufferTestSuite, EnqueueWriteShardsWithPinnedMemoryFullRange) {
         log_info(tt::LogTest, "Testing writing from pinned memory to shard at coord {}", coord);
         auto distributed_host_buffer = DistributedHostBuffer::create(mesh_device_->shape());
         distributed_host_buffer.emplace_shard(coord, [&host_buffer]() { return host_buffer; });
-        mesh_device_->mesh_command_queue().enqueue_write(mesh_buffer, distributed_host_buffer, /*blocking=*/false);
+        mesh_device_->mesh_command_queue().enqueue_write(*mesh_buffer, distributed_host_buffer, /*blocking=*/false);
 
         // Read back via hugepage
         std::fill(dst.begin(), dst.end(), 0);
         auto read_transfer = distributed::ShardDataTransfer{coord}
                                  .host_data(static_cast<void*>(dst.data()))
                                  .region(BufferRegion(0, bytes_per_device));
-        mesh_device_->mesh_command_queue().enqueue_read_shards({read_transfer}, mesh_buffer, /*blocking=*/true);
+        mesh_device_->mesh_command_queue().enqueue_read_shards({read_transfer}, *mesh_buffer, /*blocking=*/true);
         EXPECT_EQ(*src, dst);
         // Pinned memory should have been used, so locking may block.
         EXPECT_TRUE(pinned_shared->lock_may_block());
@@ -1174,7 +1174,7 @@ TEST_F(MeshBufferTestSuite, EnqueueWriteShardsWithPinnedMemoryWaitsOnClose) {
 
         auto distributed_host_buffer = DistributedHostBuffer::create(mesh_device_->shape());
         distributed_host_buffer.emplace_shard(coord, [&host_buffer]() { return host_buffer; });
-        mesh_device_->mesh_command_queue().enqueue_write(mesh_buffer, distributed_host_buffer, /*blocking=*/false);
+        mesh_device_->mesh_command_queue().enqueue_write(*mesh_buffer, distributed_host_buffer, /*blocking=*/false);
 
         EXPECT_TRUE(pinned_shared->lock_may_block());
     }
@@ -1182,7 +1182,7 @@ TEST_F(MeshBufferTestSuite, EnqueueWriteShardsWithPinnedMemoryWaitsOnClose) {
     auto read_transfer = distributed::ShardDataTransfer{coord}
                              .host_data(static_cast<void*>(dst.data()))
                              .region(BufferRegion(0, bytes_per_device));
-    mesh_device_->mesh_command_queue().enqueue_read_shards({read_transfer}, mesh_buffer, /*blocking=*/true);
+    mesh_device_->mesh_command_queue().enqueue_read_shards({read_transfer}, *mesh_buffer, /*blocking=*/true);
     EXPECT_EQ(*src, dst);
 }
 
@@ -1232,14 +1232,14 @@ TEST_F(MeshBufferTestSuite, EnqueueWriteShardsWithPinnedMemoryFullRangeLargePage
         auto distributed_host_buffer = DistributedHostBuffer::create(mesh_device_->shape());
         distributed_host_buffer.emplace_shard(coord, [&host_buffer]() { return host_buffer; });
 
-        mesh_device_->mesh_command_queue().enqueue_write(mesh_buffer, distributed_host_buffer, /*blocking=*/false);
+        mesh_device_->mesh_command_queue().enqueue_write(*mesh_buffer, distributed_host_buffer, /*blocking=*/false);
 
         // Read back via hugepage
         std::fill(dst.begin(), dst.end(), 0);
         auto read_transfer = distributed::ShardDataTransfer{coord}
                                  .host_data(static_cast<void*>(dst.data()))
                                  .region(BufferRegion(0, bytes_per_device));
-        mesh_device_->mesh_command_queue().enqueue_read_shards({read_transfer}, mesh_buffer, /*blocking=*/true);
+        mesh_device_->mesh_command_queue().enqueue_read_shards({read_transfer}, *mesh_buffer, /*blocking=*/true);
         EXPECT_EQ(*src, dst);
         // Pinned memory should have been used, so locking may block.
         EXPECT_TRUE(pinned_shared->lock_may_block());
@@ -1331,16 +1331,16 @@ TEST_F(MeshBufferTest1x2MultiCQ, EnqueueWriteShardsWithRemotePinnedMemoryAndAlig
                              .host_data(static_cast<void*>(traffic_src->data()))
                              .region(BufferRegion(0, bytes_per_device));
     auto& traffic_cq = mesh_device_->mesh_command_queue(1);
-    traffic_cq.enqueue_write_shards(traffic_buffer, {traffic_write}, /*blocking=*/false);
+    traffic_cq.enqueue_write_shards(*traffic_buffer, {traffic_write}, /*blocking=*/false);
 
-    mesh_device_->mesh_command_queue().enqueue_write_shards(mesh_buffer, write_transfers, /*blocking=*/false);
+    mesh_device_->mesh_command_queue().enqueue_write_shards(*mesh_buffer, write_transfers, /*blocking=*/false);
     EXPECT_TRUE(pinned_sources.at(remote_source_index.value())->lock_may_block());
 
     AlignedByteVector dst(bytes_per_device, 0);
     auto read_transfer = distributed::ShardDataTransfer{remote_coord}
                              .host_data(static_cast<void*>(dst.data()))
                              .region(BufferRegion(0, bytes_per_device));
-    mesh_device_->mesh_command_queue().enqueue_read_shards({read_transfer}, mesh_buffer, /*blocking=*/true);
+    mesh_device_->mesh_command_queue().enqueue_read_shards({read_transfer}, *mesh_buffer, /*blocking=*/true);
     traffic_cq.finish();
 
     const uint8_t* src_shifted = source_storage.at(remote_source_index.value())->data() + aligned_byte_shift;
@@ -1408,14 +1408,14 @@ TEST_F(MeshBufferTestSuite, EnqueueWriteShardsWithPinnedMemoryFullRangeUnaligned
             log_info(tt::LogTest, "Testing writing from pinned memory to shard at coord {}", coord);
             auto distributed_host_buffer = DistributedHostBuffer::create(mesh_device_->shape());
             distributed_host_buffer.emplace_shard(coord, [&host_buffer]() { return host_buffer; });
-            mesh_device_->mesh_command_queue().enqueue_write(mesh_buffer, distributed_host_buffer, /*blocking=*/false);
+            mesh_device_->mesh_command_queue().enqueue_write(*mesh_buffer, distributed_host_buffer, /*blocking=*/false);
 
             // Read back via hugepage
             std::fill(dst.begin(), dst.end(), 0);
             auto read_transfer = distributed::ShardDataTransfer{coord}
                                      .host_data(static_cast<void*>(dst.data()))
                                      .region(BufferRegion(0, bytes_per_device));
-            mesh_device_->mesh_command_queue().enqueue_read_shards({read_transfer}, mesh_buffer, /*blocking=*/true);
+            mesh_device_->mesh_command_queue().enqueue_read_shards({read_transfer}, *mesh_buffer, /*blocking=*/true);
             EXPECT_EQ(src_vector, dst);
             if (aligned_byte_shift % 16 == 0) {
                 // Pinned memory should have been used, so locking may block.
@@ -1513,7 +1513,7 @@ TEST_F(MeshBufferTestSuite, EnqueueProgramAfterPinnedMemoryWriteRerunsCorrectly)
 
     auto distributed_host_buffer = DistributedHostBuffer::create(mesh_device_->shape());
     distributed_host_buffer.emplace_shard(test_coord, [&host_buffer]() { return host_buffer; });
-    mesh_device_->mesh_command_queue().enqueue_write(pinned_write_buffer, distributed_host_buffer, /*blocking=*/true);
+    mesh_device_->mesh_command_queue().enqueue_write(*pinned_write_buffer, distributed_host_buffer, /*blocking=*/true);
 
     auto& program_after_first_run = workload.get_programs().at(all_devices);
     auto& rtas = GetRuntimeArgs(program_after_first_run, kernel);
@@ -1587,7 +1587,7 @@ TEST_F(MeshBufferTestSuite, EnqueueWriteDeviceLocalShardedBufferWithPinnedMemory
         auto distributed_host_buffer = DistributedHostBuffer::create(mesh_device_->shape());
         std::function<HostBuffer()> produce_buffer = [&host_buffer]() { return host_buffer; };
         distributed_host_buffer.emplace_shard(coord, produce_buffer);
-        mesh_device_->mesh_command_queue().enqueue_write(buf, distributed_host_buffer, /*blocking=*/false);
+        mesh_device_->mesh_command_queue().enqueue_write(*buf, distributed_host_buffer, /*blocking=*/false);
         EXPECT_TRUE(pinned_shared->lock_may_block());
 
         // Read back and verify
@@ -1666,7 +1666,7 @@ TEST_F(MeshBufferTestSuite, EnqueueWriteDeviceLocalWidthShardedBufferWithPinnedM
 
     auto distributed_host_buffer = DistributedHostBuffer::create(mesh_device_->shape());
     distributed_host_buffer.emplace_shard(coord, [&host_buffer]() { return host_buffer; });
-    mesh_device_->mesh_command_queue().enqueue_write(buf, distributed_host_buffer, /*blocking=*/false);
+    mesh_device_->mesh_command_queue().enqueue_write(*buf, distributed_host_buffer, /*blocking=*/false);
     EXPECT_TRUE(pinned_shared->lock_may_block());
 
     std::vector<uint32_t> dst;
@@ -1744,11 +1744,11 @@ TEST_F(MeshBufferTestSuite, EnqueueWriteWithNullFilterIsEquivalent) {
 
     DistributedHostBuffer dhb_a = DistributedHostBuffer::create(mesh_device_->shape());
     dhb_a.emplace_shard(coord, [src_vec]() { return HostBuffer(src_vec); });
-    mesh_device_->mesh_command_queue().enqueue_write(buf_explicit, dhb_a, /*blocking=*/true);
+    mesh_device_->mesh_command_queue().enqueue_write(*buf_explicit, dhb_a, /*blocking=*/true);
 
     DistributedHostBuffer dhb_b = DistributedHostBuffer::create(mesh_device_->shape());
     dhb_b.emplace_shard(coord, [src_vec]() { return HostBuffer(src_vec); });
-    mesh_device_->mesh_command_queue().enqueue_write(buf_default, dhb_b, /*blocking=*/true);
+    mesh_device_->mesh_command_queue().enqueue_write(*buf_default, dhb_b, /*blocking=*/true);
 
     std::vector<uint32_t> out_a;
     std::vector<uint32_t> out_b;

--- a/tests/tt_metal/distributed/test_mesh_buffer.cpp
+++ b/tests/tt_metal/distributed/test_mesh_buffer.cpp
@@ -42,6 +42,7 @@
 #include <tt-metalium/mesh_coord.hpp>
 #include <tt-metalium/mesh_workload.hpp>
 #include <tt-metalium/experimental/core_subset_write/mesh_command_queue.hpp>
+#include <tt-metalium/experimental/mesh_buffer_allocation.hpp>
 #include <tt-metalium/mesh_device.hpp>
 #include <tt-metalium/program.hpp>
 #include <tt-metalium/runtime_args_data.hpp>
@@ -244,6 +245,27 @@ TEST_F(MeshBufferTest2x4, ReplicatedBufferInitialization) {
     EXPECT_EQ(replicated_buffer->size(), 16 << 10);
     EXPECT_EQ(replicated_buffer->global_layout(), MeshBufferLayout::REPLICATED);
     EXPECT_EQ(replicated_buffer->device_local_size(), 16 << 10);
+}
+
+TEST_F(MeshBufferTest2x4, AllocateMeshBufferByValue) {
+    const DeviceLocalBufferConfig device_local_config{
+        .page_size = 1024, .buffer_type = BufferType::DRAM, .bottom_up = false};
+    const ShardedBufferConfig buffer_config{
+        .global_size = 16 << 10, .global_buffer_shape = {64, 128}, .shard_shape = {32, 32}};
+
+    // The experimental API returns a MeshBuffer by value, leaving ownership to the caller.
+    MeshBuffer sharded_buffer =
+        experimental::allocate_mesh_buffer(buffer_config, device_local_config, mesh_device_.get());
+    EXPECT_TRUE(sharded_buffer.is_allocated());
+    EXPECT_EQ(sharded_buffer.size(), 16 << 10);
+    EXPECT_EQ(sharded_buffer.global_layout(), MeshBufferLayout::SHARDED);
+    EXPECT_EQ(sharded_buffer.device_local_size(), 2 << 10);
+
+    // The caller can choose its own ownership -- e.g. move the value into a unique_ptr.
+    const DeviceAddr address = sharded_buffer.address();
+    auto owned = std::make_unique<MeshBuffer>(std::move(sharded_buffer));
+    EXPECT_TRUE(owned->is_allocated());
+    EXPECT_EQ(owned->address(), address);
 }
 
 TEST_F(MeshBufferTestSuite, EnqueueWriteMeshBufferValidSrcSize) {

--- a/tests/tt_metal/distributed/test_mesh_events.cpp
+++ b/tests/tt_metal/distributed/test_mesh_events.cpp
@@ -309,7 +309,7 @@ TEST_F(MeshEventsTestSuite, MultiCQNonBlockingReads) {
         write_events.push_back(write_cq.enqueue_record_event_to_host());
         // Wait for write to complete before reading
         read_cq.enqueue_wait_for_event(write_events.back());
-        read_cq.enqueue_read_shards(read_shards[i], buffer, false);
+        read_cq.enqueue_read_shards(read_shards[i], *buffer, false);
         read_events.push_back(read_cq.enqueue_record_event_to_host());
     }
 

--- a/tests/tt_metal/tt_metal/api/tensor/test_tensor_nd_sharding.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_tensor_nd_sharding.cpp
@@ -1271,8 +1271,8 @@ TEST_P(NDShardingTests, RegionWriteReadTest) {
             distributed::ShardDataTransfer{distributed::MeshCoordinate(0, 0)}
                 .host_data(reinterpret_cast<std::byte*>(partial_readback_data.data()) + region_offset)
                 .region(buffer_region);
-        mesh_device_->mesh_command_queue().enqueue_write_shards(shared_mesh_buffer, {write_shard_data_transfer}, true);
-        mesh_device_->mesh_command_queue().enqueue_read_shards({read_shard_data_transfer}, shared_mesh_buffer, true);
+        mesh_device_->mesh_command_queue().enqueue_write_shards(*shared_mesh_buffer, {write_shard_data_transfer}, true);
+        mesh_device_->mesh_command_queue().enqueue_read_shards({read_shard_data_transfer}, *shared_mesh_buffer, true);
     }
     EXPECT_EQ(tensor_data, partial_readback_data);
 

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
@@ -271,7 +271,7 @@ void EnqueueWriteMeshSubBuffer(
                                    .host_data(static_cast<void*>(const_cast<uint32_t*>(src.data())))
                                    .region(region);
 
-    cq.enqueue_write_shards(buffer, {shard_data_transfer}, blocking);
+    cq.enqueue_write_shards(*buffer, {shard_data_transfer}, blocking);
 }
 
 void EnqueueReadMeshSubBuffer(
@@ -283,7 +283,7 @@ void EnqueueReadMeshSubBuffer(
     auto shard_data_transfer =
         distributed::ShardDataTransfer{distributed::MeshCoordinate(0, 0)}.host_data(dst.data()).region(region);
 
-    cq.enqueue_read_shards({shard_data_transfer}, buffer, blocking);
+    cq.enqueue_read_shards({shard_data_transfer}, *buffer, blocking);
 }
 
 template <bool cq_dispatch_only = false>

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_large_mesh_buffer.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_large_mesh_buffer.cpp
@@ -207,8 +207,8 @@ TEST_P(InterleavedMeshBufferTestSuite, NIGHTLY_DRAMReadback) {
         output_shards.emplace_back(distributed::ShardDataTransfer{coord}.host_data(dst_vec[coord].data()));
     }
 
-    mesh_device_->mesh_command_queue().enqueue_write_shards(mesh_buffer, input_shards, false);
-    mesh_device_->mesh_command_queue().enqueue_read_shards(output_shards, mesh_buffer, true);
+    mesh_device_->mesh_command_queue().enqueue_write_shards(*mesh_buffer, input_shards, false);
+    mesh_device_->mesh_command_queue().enqueue_read_shards(output_shards, *mesh_buffer, true);
 
     for (auto& dst : dst_vec) {
         std::string context =
@@ -442,8 +442,8 @@ TEST_P(ShardedMeshBufferTestSuite, NIGHTLY_DRAMReadback) {
         output_shards.emplace_back(distributed::ShardDataTransfer{coord}.host_data(dst_vec[coord].data()));
     }
 
-    mesh_device_->mesh_command_queue().enqueue_write_shards(mesh_buffer, input_shards, false);
-    mesh_device_->mesh_command_queue().enqueue_read_shards(output_shards, mesh_buffer, true);
+    mesh_device_->mesh_command_queue().enqueue_write_shards(*mesh_buffer, input_shards, false);
+    mesh_device_->mesh_command_queue().enqueue_read_shards(output_shards, *mesh_buffer, true);
 
     for (auto& dst : dst_vec) {
         std::string context =

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/benchmark_rw_buffer.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/benchmark_rw_buffer.cpp
@@ -158,7 +158,7 @@ static void BM_write_pinned_memory(benchmark::State& state, const std::shared_pt
 
     for ([[maybe_unused]] auto _ : state) {
         bool blocking = true;
-        mesh_device->mesh_command_queue().enqueue_write_shards(device_buffer, {write_transfer}, blocking);
+        mesh_device->mesh_command_queue().enqueue_write_shards(*device_buffer, {write_transfer}, blocking);
     }
 
     state.SetBytesProcessed(transfer_size * state.iterations());
@@ -270,7 +270,7 @@ static void BM_write_sharded(benchmark::State& state, const std::shared_ptr<Mesh
                               .region(BufferRegion(0, static_cast<std::size_t>(actual_buf_size)));
 
     for ([[maybe_unused]] auto _ : state) {
-        mesh_device->mesh_command_queue().enqueue_write_shards(device_buffer, {write_transfer}, /*blocking=*/true);
+        mesh_device->mesh_command_queue().enqueue_write_shards(*device_buffer, {write_transfer}, /*blocking=*/true);
     }
 
     state.SetBytesProcessed(actual_buf_size * state.iterations());
@@ -323,7 +323,7 @@ static void BM_write_pinned_memory_sharded(benchmark::State& state, const std::s
 
     bool used_pinned_memory = false;
     for ([[maybe_unused]] auto _ : state) {
-        mesh_device->mesh_command_queue().enqueue_write_shards(device_buffer, {write_transfer}, /*blocking=*/false);
+        mesh_device->mesh_command_queue().enqueue_write_shards(*device_buffer, {write_transfer}, /*blocking=*/false);
         used_pinned_memory = pinned_mem->lock_may_block();
         mesh_device->mesh_command_queue().finish();
     }
@@ -402,7 +402,7 @@ static void BM_read_pinned_memory(benchmark::State& state, const std::shared_ptr
     experimental::ShardDataTransferSetPinnedMemory(read_transfer, pinned_mem);
 
     for ([[maybe_unused]] auto _ : state) {
-        mesh_device->mesh_command_queue().enqueue_read_shards({read_transfer}, device_buffer, /*blocking=*/true);
+        mesh_device->mesh_command_queue().enqueue_read_shards({read_transfer}, *device_buffer, /*blocking=*/true);
     }
 
     state.SetBytesProcessed(transfer_size * state.iterations());

--- a/tt_metal/api/tt-metalium/distributed.hpp
+++ b/tt_metal/api/tt-metalium/distributed.hpp
@@ -43,7 +43,7 @@ void WriteShard(
     const MeshCoordinate& coord,
     bool blocking = false) {
     std::vector<ShardDataTransfer> shard_data_transfers = {ShardDataTransfer{coord}.host_data(src.data())};
-    mesh_cq.enqueue_write_shards(mesh_buffer, shard_data_transfers, blocking);
+    mesh_cq.enqueue_write_shards(*mesh_buffer, shard_data_transfers, blocking);
 }
 
 template <typename DType>
@@ -64,7 +64,7 @@ void ReadShard(
     auto* shard = mesh_buffer->get_device_buffer(coord);
     dst.resize(shard->page_size() * shard->num_pages() / sizeof(DType));
     std::vector<ShardDataTransfer> shard_data_transfers = {ShardDataTransfer{coord}.host_data(dst.data())};
-    mesh_cq.enqueue_read_shards(shard_data_transfers, mesh_buffer, blocking);
+    mesh_cq.enqueue_read_shards(shard_data_transfers, *mesh_buffer, blocking);
 }
 
 template <typename DType>
@@ -79,7 +79,7 @@ void EnqueueWriteMeshBuffer(
         src.size(),
         sizeof(DType));
 
-    mesh_cq.enqueue_write_mesh_buffer(mesh_buffer, src.data(), blocking);
+    mesh_cq.enqueue_write_mesh_buffer(*mesh_buffer, src.data(), blocking);
 }
 
 template <typename DType>
@@ -95,7 +95,7 @@ void EnqueueReadMeshBuffer(
     } else {
         dst.resize(mesh_buffer->size() / sizeof(DType));
     }
-    mesh_cq.enqueue_read_mesh_buffer(dst.data(), mesh_buffer, blocking);
+    mesh_cq.enqueue_read_mesh_buffer(dst.data(), *mesh_buffer, blocking);
 }
 
 // Make the current thread block until the event is recorded by the associated MeshCommandQueue.

--- a/tt_metal/api/tt-metalium/experimental/mesh_buffer_allocation.hpp
+++ b/tt_metal/api/tt-metalium/experimental/mesh_buffer_allocation.hpp
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <optional>
+
+#include <tt-metalium/hal_types.hpp>
+#include <tt-metalium/mesh_buffer.hpp>
+
+namespace tt::tt_metal::experimental {
+
+// Allocates a `MeshBuffer` and returns it by value.
+//
+// Unlike `MeshBuffer::create`, which returns a `std::shared_ptr<MeshBuffer>`, this API hands back an owning value.
+// The caller decides how the buffer is owned -- keep it on the stack, move it into a member, or wrap it in
+// `std::unique_ptr`/`std::shared_ptr` -- rather than being forced into shared ownership by the creation API. See
+// issue #38691.
+//
+// The allocation semantics are identical to `MeshBuffer::create`.
+distributed::MeshBuffer allocate_mesh_buffer(
+    const distributed::MeshBufferConfig& mesh_buffer_config,
+    const distributed::DeviceLocalBufferConfig& device_local_config,
+    distributed::MeshDevice* mesh_device,
+    std::optional<DeviceAddr> address = std::nullopt);
+
+}  // namespace tt::tt_metal::experimental

--- a/tt_metal/api/tt-metalium/mesh_command_queue.hpp
+++ b/tt_metal/api/tt-metalium/mesh_command_queue.hpp
@@ -92,6 +92,9 @@ public:
         const MeshCoordinateRange& device_range,
         bool blocking,
         std::optional<BufferRegion> region = std::nullopt) = 0;
+    virtual void enqueue_write_mesh_buffer(const MeshBuffer& buffer, const void* host_data, bool blocking) = 0;
+    // Overload retained for callers that hold the MeshBuffer via shared_ptr; the buffer is not retained, so prefer the
+    // reference overload above.
     virtual void enqueue_write_mesh_buffer(
         const std::shared_ptr<MeshBuffer>& buffer, const void* host_data, bool blocking) = 0;
     // If PinnedMemory is attached to a HostBuffer used within the enqueue_write, the contents of the memory must not be
@@ -101,6 +104,8 @@ public:
     // * calling finish() on the MeshCommandQueue
     // * calling enqueue_record_event_to_host() and then waiting for the event to complete on the host.
     virtual void enqueue_write(
+        const MeshBuffer& mesh_buffer, const DistributedHostBuffer& host_buffer, bool blocking) = 0;
+    virtual void enqueue_write(
         const std::shared_ptr<MeshBuffer>& mesh_buffer, const DistributedHostBuffer& host_buffer, bool blocking) = 0;
     // If PinnedMemory is set on a ShardDataTransfer, the contents of the memory must not be modified until the
     // enqueue_write has completed on the device. This may be checked by any of
@@ -108,6 +113,10 @@ public:
     // * setting the blocking parameter to true
     // * calling finish() on the MeshCommandQueue
     // * calling enqueue_record_event_to_host() and then waiting for the event to complete on the host.
+    virtual void enqueue_write_shards(
+        const MeshBuffer& mesh_buffer,
+        const std::vector<distributed::ShardDataTransfer>& shard_data_transfers,
+        bool blocking) = 0;
     virtual void enqueue_write_shards(
         const std::shared_ptr<MeshBuffer>& mesh_buffer,
         const std::vector<distributed::ShardDataTransfer>& shard_data_transfers,
@@ -131,13 +140,25 @@ public:
 #endif
 
     // MeshBuffer Read APIs
+    virtual void enqueue_read_mesh_buffer(void* host_data, const MeshBuffer& buffer, bool blocking) = 0;
+    // Overload retained for callers that hold the MeshBuffer via shared_ptr; the buffer is not retained, so prefer the
+    // reference overload above.
     virtual void enqueue_read_mesh_buffer(
         void* host_data, const std::shared_ptr<MeshBuffer>& buffer, bool blocking) = 0;
+    virtual void enqueue_read_shards(
+        const std::vector<distributed::ShardDataTransfer>& shard_data_transfers,
+        const MeshBuffer& mesh_buffer,
+        bool blocking) = 0;
     virtual void enqueue_read_shards(
         const std::vector<distributed::ShardDataTransfer>& shard_data_transfers,
         const std::shared_ptr<MeshBuffer>& mesh_buffer,
         bool blocking) = 0;
     // TODO: does "enqueue" make sense anymore? Return the object by value instead.
+    virtual void enqueue_read(
+        const MeshBuffer& mesh_buffer,
+        DistributedHostBuffer& host_buffer,
+        const std::optional<std::unordered_set<MeshCoordinate>>& shards,
+        bool blocking) = 0;
     virtual void enqueue_read(
         const std::shared_ptr<MeshBuffer>& mesh_buffer,
         DistributedHostBuffer& host_buffer,

--- a/tt_metal/api/tt-metalium/mesh_command_queue.hpp
+++ b/tt_metal/api/tt-metalium/mesh_command_queue.hpp
@@ -93,8 +93,7 @@ public:
         bool blocking,
         std::optional<BufferRegion> region = std::nullopt) = 0;
     virtual void enqueue_write_mesh_buffer(const MeshBuffer& buffer, const void* host_data, bool blocking) = 0;
-    // Overload retained for callers that hold the MeshBuffer via shared_ptr; the buffer is not retained, so prefer the
-    // reference overload above.
+    [[deprecated("Use the const MeshBuffer& overload instead.")]]
     virtual void enqueue_write_mesh_buffer(
         const std::shared_ptr<MeshBuffer>& buffer, const void* host_data, bool blocking) = 0;
     // If PinnedMemory is attached to a HostBuffer used within the enqueue_write, the contents of the memory must not be
@@ -105,6 +104,7 @@ public:
     // * calling enqueue_record_event_to_host() and then waiting for the event to complete on the host.
     virtual void enqueue_write(
         const MeshBuffer& mesh_buffer, const DistributedHostBuffer& host_buffer, bool blocking) = 0;
+    [[deprecated("Use the const MeshBuffer& overload instead.")]]
     virtual void enqueue_write(
         const std::shared_ptr<MeshBuffer>& mesh_buffer, const DistributedHostBuffer& host_buffer, bool blocking) = 0;
     // If PinnedMemory is set on a ShardDataTransfer, the contents of the memory must not be modified until the
@@ -117,6 +117,7 @@ public:
         const MeshBuffer& mesh_buffer,
         const std::vector<distributed::ShardDataTransfer>& shard_data_transfers,
         bool blocking) = 0;
+    [[deprecated("Use the const MeshBuffer& overload instead.")]]
     virtual void enqueue_write_shards(
         const std::shared_ptr<MeshBuffer>& mesh_buffer,
         const std::vector<distributed::ShardDataTransfer>& shard_data_transfers,
@@ -141,14 +142,14 @@ public:
 
     // MeshBuffer Read APIs
     virtual void enqueue_read_mesh_buffer(void* host_data, const MeshBuffer& buffer, bool blocking) = 0;
-    // Overload retained for callers that hold the MeshBuffer via shared_ptr; the buffer is not retained, so prefer the
-    // reference overload above.
+    [[deprecated("Use the const MeshBuffer& overload instead.")]]
     virtual void enqueue_read_mesh_buffer(
         void* host_data, const std::shared_ptr<MeshBuffer>& buffer, bool blocking) = 0;
     virtual void enqueue_read_shards(
         const std::vector<distributed::ShardDataTransfer>& shard_data_transfers,
         const MeshBuffer& mesh_buffer,
         bool blocking) = 0;
+    [[deprecated("Use the const MeshBuffer& overload instead.")]]
     virtual void enqueue_read_shards(
         const std::vector<distributed::ShardDataTransfer>& shard_data_transfers,
         const std::shared_ptr<MeshBuffer>& mesh_buffer,
@@ -159,6 +160,7 @@ public:
         DistributedHostBuffer& host_buffer,
         const std::optional<std::unordered_set<MeshCoordinate>>& shards,
         bool blocking) = 0;
+    [[deprecated("Use the const MeshBuffer& overload instead.")]]
     virtual void enqueue_read(
         const std::shared_ptr<MeshBuffer>& mesh_buffer,
         DistributedHostBuffer& host_buffer,

--- a/tt_metal/distributed/mesh_command_queue_base.cpp
+++ b/tt_metal/distributed/mesh_command_queue_base.cpp
@@ -114,7 +114,7 @@ void MeshCommandQueueBase::write_sharded_buffer(const MeshBuffer& buffer, const 
     }
 }
 
-void MeshCommandQueueBase::read_sharded_buffer(MeshBuffer& buffer, void* dst) {
+void MeshCommandQueueBase::read_sharded_buffer(const MeshBuffer& buffer, void* dst) {
     const auto& [height_replicated, width_replicated] = buffer.replicated_dims();
     TT_FATAL(
         not(height_replicated or width_replicated), "Cannot read a MeshBuffer that is replicated along any dimension.");
@@ -203,33 +203,41 @@ void MeshCommandQueueBase::enqueue_write_shard_to_sub_grid(
     }
 }
 
-void MeshCommandQueueBase::enqueue_write_mesh_buffer(
-    const std::shared_ptr<MeshBuffer>& buffer, const void* host_data, bool blocking) {
-    MeshCoordinateRange mesh_device_extent(buffer->device()->shape());
-    this->enqueue_write_shard_to_sub_grid(*buffer, host_data, mesh_device_extent, blocking);
+void MeshCommandQueueBase::enqueue_write_mesh_buffer(const MeshBuffer& buffer, const void* host_data, bool blocking) {
+    MeshCoordinateRange mesh_device_extent(buffer.device()->shape());
+    this->enqueue_write_shard_to_sub_grid(buffer, host_data, mesh_device_extent, blocking);
 }
 
-void MeshCommandQueueBase::enqueue_read_mesh_buffer(
-    void* host_data, const std::shared_ptr<MeshBuffer>& buffer, bool blocking) {
+void MeshCommandQueueBase::enqueue_write_mesh_buffer(
+    const std::shared_ptr<MeshBuffer>& buffer, const void* host_data, bool blocking) {
+    this->enqueue_write_mesh_buffer(*buffer, host_data, blocking);
+}
+
+void MeshCommandQueueBase::enqueue_read_mesh_buffer(void* host_data, const MeshBuffer& buffer, bool blocking) {
     TT_FATAL(
-        (buffer->global_layout() == MeshBufferLayout::SHARDED) || (buffer->device()->num_devices() == 1),
+        (buffer.global_layout() == MeshBufferLayout::SHARDED) || (buffer.device()->num_devices() == 1),
         "Can only read a Sharded MeshBuffer from a MeshDevice or a Replicated MeshBuffer from a Unit-Mesh.");
     TT_FATAL(
         blocking, "Non-Blocking reads are not supported through {}. Use enqueue_read_shards_instead.", __FUNCTION__);
-    if (buffer->global_layout() == MeshBufferLayout::SHARDED) {
+    if (buffer.global_layout() == MeshBufferLayout::SHARDED) {
         auto lock = lock_api_function_();
-        this->read_sharded_buffer(*buffer, host_data);
+        this->read_sharded_buffer(buffer, host_data);
     } else {
         std::vector<distributed::ShardDataTransfer> shard_data_transfers = {
-            distributed::ShardDataTransfer{MeshCoordinate::zero_coordinate(buffer->device()->shape().dims())}.host_data(
+            distributed::ShardDataTransfer{MeshCoordinate::zero_coordinate(buffer.device()->shape().dims())}.host_data(
                 host_data)};
         // enqueue_read_shards will call lock_api_function_(), no need to call it here
         this->enqueue_read_shards(shard_data_transfers, buffer, blocking);
     }
 }
 
+void MeshCommandQueueBase::enqueue_read_mesh_buffer(
+    void* host_data, const std::shared_ptr<MeshBuffer>& buffer, bool blocking) {
+    this->enqueue_read_mesh_buffer(host_data, *buffer, blocking);
+}
+
 void MeshCommandQueueBase::enqueue_write_shards_nolock(
-    MeshBuffer& buffer,
+    const MeshBuffer& buffer,
     const std::vector<distributed::ShardDataTransfer>& shard_data_transfers,
     bool blocking,
     const tt::tt_metal::CoreRangeSet* logical_core_filter) {
@@ -286,20 +294,32 @@ void MeshCommandQueueBase::enqueue_write_shards_nolock(
 }
 
 void MeshCommandQueueBase::enqueue_write_shards(
-    const std::shared_ptr<MeshBuffer>& mesh_buffer,
+    const MeshBuffer& mesh_buffer,
     const std::vector<distributed::ShardDataTransfer>& shard_data_transfers,
     bool blocking) {
     auto lock = lock_api_function_();
-    this->enqueue_write_shards_nolock(*mesh_buffer, shard_data_transfers, blocking, nullptr);
+    this->enqueue_write_shards_nolock(mesh_buffer, shard_data_transfers, blocking, nullptr);
+}
+
+void MeshCommandQueueBase::enqueue_write_shards(
+    const std::shared_ptr<MeshBuffer>& mesh_buffer,
+    const std::vector<distributed::ShardDataTransfer>& shard_data_transfers,
+    bool blocking) {
+    this->enqueue_write_shards(*mesh_buffer, shard_data_transfers, blocking);
+}
+
+void MeshCommandQueueBase::enqueue_write(
+    const MeshBuffer& mesh_buffer, const DistributedHostBuffer& host_buffer, bool blocking) {
+    this->enqueue_write_with_core_filter(mesh_buffer, host_buffer, blocking, nullptr);
 }
 
 void MeshCommandQueueBase::enqueue_write(
     const std::shared_ptr<MeshBuffer>& mesh_buffer, const DistributedHostBuffer& host_buffer, bool blocking) {
-    this->enqueue_write_with_core_filter(*mesh_buffer, host_buffer, blocking, nullptr);
+    this->enqueue_write(*mesh_buffer, host_buffer, blocking);
 }
 
 void MeshCommandQueueBase::enqueue_write_with_core_filter(
-    MeshBuffer& mesh_buffer,
+    const MeshBuffer& mesh_buffer,
     const DistributedHostBuffer& host_buffer,
     bool blocking,
     const tt::tt_metal::CoreRangeSet* logical_core_filter) {
@@ -323,7 +343,7 @@ void MeshCommandQueueBase::enqueue_write_with_core_filter(
 
 void MeshCommandQueueBase::enqueue_read_shards_nolock(
     const std::vector<distributed::ShardDataTransfer>& shard_data_transfers,
-    const std::shared_ptr<MeshBuffer>& buffer,
+    const MeshBuffer& buffer,
     bool blocking,
     std::vector<MemoryPin> memory_pins) {
     // TODO: #17215 - this API is used by TTNN, as it currently implements rich ND sharding API for multi-devices.
@@ -335,7 +355,7 @@ void MeshCommandQueueBase::enqueue_read_shards_nolock(
             auto pinned_memory = experimental::ShardDataTransferGetPinnedMemory(shard_data_transfer);
             has_pinned_memory = has_pinned_memory || pinned_memory != nullptr;
             this->read_shard_from_device(
-                *buffer,
+                buffer,
                 shard_data_transfer.shard_coord(),
                 shard_data_transfer.host_data(),
                 pinned_memory,
@@ -360,14 +380,21 @@ void MeshCommandQueueBase::enqueue_read_shards_nolock(
 
 void MeshCommandQueueBase::enqueue_read_shards(
     const std::vector<distributed::ShardDataTransfer>& shard_data_transfers,
-    const std::shared_ptr<MeshBuffer>& mesh_buffer,
+    const MeshBuffer& mesh_buffer,
     bool blocking) {
     auto lock = lock_api_function_();
     this->enqueue_read_shards_nolock(shard_data_transfers, mesh_buffer, blocking);
 }
 
+void MeshCommandQueueBase::enqueue_read_shards(
+    const std::vector<distributed::ShardDataTransfer>& shard_data_transfers,
+    const std::shared_ptr<MeshBuffer>& mesh_buffer,
+    bool blocking) {
+    this->enqueue_read_shards(shard_data_transfers, *mesh_buffer, blocking);
+}
+
 void MeshCommandQueueBase::enqueue_read(
-    const std::shared_ptr<MeshBuffer>& buffer,
+    const MeshBuffer& buffer,
     DistributedHostBuffer& host_buffer,
     const std::optional<std::unordered_set<MeshCoordinate>>& shards,
     bool blocking) {
@@ -378,7 +405,7 @@ void MeshCommandQueueBase::enqueue_read(
     // (fixes use-after-free, issue #43638). For blocking reads finish_nolock()
     // ensures the copy is complete before we return, so no pin is needed.
     std::vector<MemoryPin> memory_pins;
-    for (const auto& coord : MeshCoordinateRange(buffer->device()->shape())) {
+    for (const auto& coord : MeshCoordinateRange(buffer.device()->shape())) {
         if (shards.has_value() && !shards->contains(coord)) {
             continue;
         }
@@ -397,6 +424,14 @@ void MeshCommandQueueBase::enqueue_read(
     }
 
     this->enqueue_read_shards_nolock(shard_data_transfers, buffer, blocking, std::move(memory_pins));
+}
+
+void MeshCommandQueueBase::enqueue_read(
+    const std::shared_ptr<MeshBuffer>& buffer,
+    DistributedHostBuffer& host_buffer,
+    const std::optional<std::unordered_set<MeshCoordinate>>& shards,
+    bool blocking) {
+    this->enqueue_read(*buffer, host_buffer, shards, blocking);
 }
 
 void MeshCommandQueue::enqueue_write_shards(

--- a/tt_metal/distributed/mesh_command_queue_base.cpp
+++ b/tt_metal/distributed/mesh_command_queue_base.cpp
@@ -445,7 +445,7 @@ void MeshCommandQueue::enqueue_write_shards(
                                                        .host_data(shard_data_transfer.host_data)
                                                        .region(shard_data_transfer.region));
     }
-    this->enqueue_write_shards(mesh_buffer, distributed_shard_data_transfers, blocking);
+    this->enqueue_write_shards(*mesh_buffer, distributed_shard_data_transfers, blocking);
 }
 
 void MeshCommandQueue::enqueue_read_shards(
@@ -459,7 +459,7 @@ void MeshCommandQueue::enqueue_read_shards(
                                                        .host_data(shard_data_transfer.host_data)
                                                        .region(shard_data_transfer.region));
     }
-    this->enqueue_read_shards(distributed_shard_data_transfers, mesh_buffer, blocking);
+    this->enqueue_read_shards(distributed_shard_data_transfers, *mesh_buffer, blocking);
 }
 
 }  // namespace tt::tt_metal::distributed

--- a/tt_metal/distributed/mesh_command_queue_base.hpp
+++ b/tt_metal/distributed/mesh_command_queue_base.hpp
@@ -66,23 +66,23 @@ protected:
 private:
     // Helper functions for read and write entire Sharded-MeshBuffers
     void write_sharded_buffer(const MeshBuffer& buffer, const void* src);
-    void read_sharded_buffer(MeshBuffer& buffer, void* dst);
+    void read_sharded_buffer(const MeshBuffer& buffer, void* dst);
 
     // Must be called with lock_api_function_() held.
     void enqueue_read_shards_nolock(
         const std::vector<distributed::ShardDataTransfer>& shard_data_transfers,
-        const std::shared_ptr<MeshBuffer>& mesh_buffer,
+        const MeshBuffer& mesh_buffer,
         bool blocking,
         std::vector<MemoryPin> memory_pins = {});
     // Must be called with lock_api_function_() held.
     void enqueue_write_shards_nolock(
-        MeshBuffer& mesh_buffer,
+        const MeshBuffer& mesh_buffer,
         const std::vector<distributed::ShardDataTransfer>& shard_data_transfers,
         bool blocking,
         const tt::tt_metal::CoreRangeSet* logical_core_filter = nullptr);
 
     void enqueue_write_with_core_filter(
-        MeshBuffer& mesh_buffer,
+        const MeshBuffer& mesh_buffer,
         const DistributedHostBuffer& host_buffer,
         bool blocking,
         const tt::tt_metal::CoreRangeSet* logical_core_filter);
@@ -110,22 +110,39 @@ public:
         const MeshCoordinateRange& device_range,
         bool blocking,
         std::optional<BufferRegion> region = std::nullopt) override;
+    void enqueue_write_mesh_buffer(const MeshBuffer& buffer, const void* host_data, bool blocking) override;
     void enqueue_write_mesh_buffer(
         const std::shared_ptr<MeshBuffer>& buffer, const void* host_data, bool blocking) override;
+    void enqueue_write_shards(
+        const MeshBuffer& mesh_buffer,
+        const std::vector<distributed::ShardDataTransfer>& shard_data_transfers,
+        bool blocking) override;
     void enqueue_write_shards(
         const std::shared_ptr<MeshBuffer>& mesh_buffer,
         const std::vector<distributed::ShardDataTransfer>& shard_data_transfers,
         bool blocking) override;
+    void enqueue_write(
+        const MeshBuffer& mesh_buffer, const DistributedHostBuffer& host_buffer, bool blocking) override;
     void enqueue_write(
         const std::shared_ptr<MeshBuffer>& mesh_buffer,
         const DistributedHostBuffer& host_buffer,
         bool blocking) override;
 
     // MeshBuffer Read APIs
+    void enqueue_read_mesh_buffer(void* host_data, const MeshBuffer& buffer, bool blocking) override;
     void enqueue_read_mesh_buffer(void* host_data, const std::shared_ptr<MeshBuffer>& buffer, bool blocking) override;
     void enqueue_read_shards(
         const std::vector<distributed::ShardDataTransfer>& shard_data_transfers,
+        const MeshBuffer& mesh_buffer,
+        bool blocking) override;
+    void enqueue_read_shards(
+        const std::vector<distributed::ShardDataTransfer>& shard_data_transfers,
         const std::shared_ptr<MeshBuffer>& mesh_buffer,
+        bool blocking) override;
+    void enqueue_read(
+        const MeshBuffer& mesh_buffer,
+        DistributedHostBuffer& host_buffer,
+        const std::optional<std::unordered_set<MeshCoordinate>>& shards,
         bool blocking) override;
     void enqueue_read(
         const std::shared_ptr<MeshBuffer>& mesh_buffer,

--- a/tt_metal/distributed/mesh_command_queue_base.hpp
+++ b/tt_metal/distributed/mesh_command_queue_base.hpp
@@ -111,18 +111,21 @@ public:
         bool blocking,
         std::optional<BufferRegion> region = std::nullopt) override;
     void enqueue_write_mesh_buffer(const MeshBuffer& buffer, const void* host_data, bool blocking) override;
+    [[deprecated("Use the const MeshBuffer& overload instead.")]]
     void enqueue_write_mesh_buffer(
         const std::shared_ptr<MeshBuffer>& buffer, const void* host_data, bool blocking) override;
     void enqueue_write_shards(
         const MeshBuffer& mesh_buffer,
         const std::vector<distributed::ShardDataTransfer>& shard_data_transfers,
         bool blocking) override;
+    [[deprecated("Use the const MeshBuffer& overload instead.")]]
     void enqueue_write_shards(
         const std::shared_ptr<MeshBuffer>& mesh_buffer,
         const std::vector<distributed::ShardDataTransfer>& shard_data_transfers,
         bool blocking) override;
     void enqueue_write(
         const MeshBuffer& mesh_buffer, const DistributedHostBuffer& host_buffer, bool blocking) override;
+    [[deprecated("Use the const MeshBuffer& overload instead.")]]
     void enqueue_write(
         const std::shared_ptr<MeshBuffer>& mesh_buffer,
         const DistributedHostBuffer& host_buffer,
@@ -130,11 +133,13 @@ public:
 
     // MeshBuffer Read APIs
     void enqueue_read_mesh_buffer(void* host_data, const MeshBuffer& buffer, bool blocking) override;
+    [[deprecated("Use the const MeshBuffer& overload instead.")]]
     void enqueue_read_mesh_buffer(void* host_data, const std::shared_ptr<MeshBuffer>& buffer, bool blocking) override;
     void enqueue_read_shards(
         const std::vector<distributed::ShardDataTransfer>& shard_data_transfers,
         const MeshBuffer& mesh_buffer,
         bool blocking) override;
+    [[deprecated("Use the const MeshBuffer& overload instead.")]]
     void enqueue_read_shards(
         const std::vector<distributed::ShardDataTransfer>& shard_data_transfers,
         const std::shared_ptr<MeshBuffer>& mesh_buffer,
@@ -144,6 +149,7 @@ public:
         DistributedHostBuffer& host_buffer,
         const std::optional<std::unordered_set<MeshCoordinate>>& shards,
         bool blocking) override;
+    [[deprecated("Use the const MeshBuffer& overload instead.")]]
     void enqueue_read(
         const std::shared_ptr<MeshBuffer>& mesh_buffer,
         DistributedHostBuffer& host_buffer,

--- a/tt_metal/impl/experimental/mesh_buffer.cpp
+++ b/tt_metal/impl/experimental/mesh_buffer.cpp
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <tt-metalium/experimental/mesh_buffer_allocation.hpp>
+
+#include <memory>
+#include <utility>
+
+#include <tt-metalium/mesh_buffer.hpp>
+
+namespace tt::tt_metal::experimental {
+
+distributed::MeshBuffer allocate_mesh_buffer(
+    const distributed::MeshBufferConfig& mesh_buffer_config,
+    const distributed::DeviceLocalBufferConfig& device_local_config,
+    distributed::MeshDevice* mesh_device,
+    std::optional<DeviceAddr> address) {
+    // Allocate through the existing factory and move the buffer out of the returned shared_ptr, handing the caller
+    // an owning value. The moved-from MeshBuffer left behind is deallocated (a no-op destructor) when the temporary
+    // shared_ptr goes out of scope.
+    auto mesh_buffer = distributed::MeshBuffer::create(mesh_buffer_config, device_local_config, mesh_device, address);
+    return std::move(*mesh_buffer);
+}
+
+}  // namespace tt::tt_metal::experimental

--- a/tt_metal/impl/sources.cmake
+++ b/tt_metal/impl/sources.cmake
@@ -1,6 +1,7 @@
 set(IMPL_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/experimental/core_subset_write/mesh_command_queue.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/experimental/core_subset_write/tensor.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/experimental/mesh_buffer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/internal/disaggregation/kv_chunk_address_table.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/internal/disaggregation/umd_dram_reader.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/host_api/temp_quasar_api.cpp

--- a/tt_metal/impl/tensor/tensor_apis.cpp
+++ b/tt_metal/impl/tensor/tensor_apis.cpp
@@ -84,7 +84,7 @@ HostTensor enqueue_read_tensor(distributed::MeshCommandQueue& cq, const MeshTens
         },
         DistributedHostBuffer::ProcessShardExecutionPolicy::PARALLEL);
 
-    cq.enqueue_read(mesh_buffer, distributed_host_buffer, /*shards=*/std::nullopt, blocking);
+    cq.enqueue_read(*mesh_buffer, distributed_host_buffer, /*shards=*/std::nullopt, blocking);
 
     return HostTensor::from_buffer(
         std::move(distributed_host_buffer), device_tensor.tensor_spec(), device_tensor.tensor_topology());
@@ -156,7 +156,7 @@ void enqueue_read_tensor(
         });
     }
 
-    cq.enqueue_read(mesh_buffer, dst_distributed_host_buffer, /*shards=*/std::nullopt, blocking);
+    cq.enqueue_read(*mesh_buffer, dst_distributed_host_buffer, /*shards=*/std::nullopt, blocking);
     host_tensor.update_tensor_topology(device_tensor.tensor_topology());
 }
 
@@ -221,12 +221,12 @@ void enqueue_write_tensor(distributed::MeshCommandQueue& cq, const HostTensor& h
             }
         }
         if (any_pinned) {
-            cq.enqueue_write_shards(mesh_buffer, transfers, /*blocking=*/true);
+            cq.enqueue_write_shards(*mesh_buffer, transfers, /*blocking=*/true);
         } else {
-            cq.enqueue_write(mesh_buffer, distributed_host_buffer, /*blocking=*/false);
+            cq.enqueue_write(*mesh_buffer, distributed_host_buffer, /*blocking=*/false);
         }
     } else {
-        cq.enqueue_write(mesh_buffer, distributed_host_buffer, /*blocking=*/false);
+        cq.enqueue_write(*mesh_buffer, distributed_host_buffer, /*blocking=*/false);
     }
 
     device_tensor = MeshTensor::from_buffer(
@@ -256,7 +256,7 @@ void enqueue_read_tensor(
         distributed::ShardDataTransfer{*distributed::MeshCoordinateRange(queue.device()->shape()).begin()}
             .host_data(dst)
             .region(region)};
-    queue.enqueue_read_shards(shard_data_transfers, device_tensor.impl().raw_mesh_buffer(), blocking);
+    queue.enqueue_read_shards(shard_data_transfers, device_tensor.impl().mesh_buffer(), blocking);
 }
 
 void enqueue_write_tensor(
@@ -269,7 +269,7 @@ void enqueue_write_tensor(
         distributed::ShardDataTransfer{*distributed::MeshCoordinateRange(queue.device()->shape()).begin()}
             .host_data(const_cast<std::byte*>(src))
             .region(region)};
-    queue.enqueue_write_shards(device_tensor.impl().raw_mesh_buffer(), shard_data_transfers, false);
+    queue.enqueue_write_shards(device_tensor.impl().mesh_buffer(), shard_data_transfers, false);
 }
 
 // ======================================================================================
@@ -334,7 +334,7 @@ void enqueue_read_tensor(
     }
 
     std::unordered_set<distributed::MeshCoordinate> shard_set(coords.begin(), coords.end());
-    cq.enqueue_read(device_tensor.impl().raw_mesh_buffer(), dst_distributed_host_buffer, shard_set, blocking);
+    cq.enqueue_read(device_tensor.impl().mesh_buffer(), dst_distributed_host_buffer, shard_set, blocking);
 
     host_tensor = HostTensor::from_buffer(
         std::move(dst_distributed_host_buffer), device_tensor.tensor_spec(), device_tensor.tensor_topology());
@@ -416,12 +416,12 @@ void h2d_as_replicate_tensor_on_1x1_mesh(
                 experimental::ShardDataTransferSetPinnedMemory(xfer, pinned_memory);
                 transfers.push_back(std::move(xfer));
             }
-            command_queue.enqueue_write_shards(mesh_buffer, transfers, /*blocking=*/true);
+            command_queue.enqueue_write_shards(*mesh_buffer, transfers, /*blocking=*/true);
         } else {
-            command_queue.enqueue_write_mesh_buffer(mesh_buffer, data_to_write.data(), /*blocking=*/false);
+            command_queue.enqueue_write_mesh_buffer(*mesh_buffer, data_to_write.data(), /*blocking=*/false);
         }
     } else {
-        command_queue.enqueue_write_mesh_buffer(mesh_buffer, data_to_write.data(), /*blocking=*/false);
+        command_queue.enqueue_write_mesh_buffer(*mesh_buffer, data_to_write.data(), /*blocking=*/false);
     }
 
     const auto& mesh_device_shape = mesh_buffer->device()->shape();
@@ -514,12 +514,12 @@ std::vector<distributed::MeshCoordinate> enqueue_write_tensor(
             }
         }
         if (any_pinned) {
-            cq.enqueue_write_shards(mesh_buffer, transfers, /*blocking=*/true);
+            cq.enqueue_write_shards(*mesh_buffer, transfers, /*blocking=*/true);
         } else {
-            cq.enqueue_write(mesh_buffer, distributed_host_buffer, /*blocking=*/false);
+            cq.enqueue_write(*mesh_buffer, distributed_host_buffer, /*blocking=*/false);
         }
     } else {
-        cq.enqueue_write(mesh_buffer, distributed_host_buffer, /*blocking=*/false);
+        cq.enqueue_write(*mesh_buffer, distributed_host_buffer, /*blocking=*/false);
     }
 
     // DistributedHostBuffer may not cover the entire MeshDevice, must preserve coords here.

--- a/tt_metal/sources.cmake
+++ b/tt_metal/sources.cmake
@@ -58,6 +58,7 @@ set(TT_METAL_PUBLIC_API
     api/tt-metalium/experimental/lightmetal/lightmetal_binary.hpp
     api/tt-metalium/experimental/lightmetal/lightmetal_capture_utils.hpp
     api/tt-metalium/experimental/lightmetal/lightmetal_replay.hpp
+    api/tt-metalium/experimental/mesh_buffer_allocation.hpp
     api/tt-metalium/experimental/mesh_program_descriptor.hpp
     api/tt-metalium/experimental/metal2_host_api/advanced_options.hpp
     api/tt-metalium/experimental/metal2_host_api/compute_hardware_config.hpp

--- a/ttnn/cpp/ttnn-nanobind/pytensor.cpp
+++ b/ttnn/cpp/ttnn-nanobind/pytensor.cpp
@@ -1672,7 +1672,7 @@ void pytensor_module(nb::module_& mod) {
             transfer.host_data(host_buffer->view_bytes().data());
             transfer.region(BufferRegion(0, host_buffer->view_bytes().size()));
 
-            mesh_device->mesh_command_queue().enqueue_write_shards(mesh_buffer, {transfer}, /*blocking=*/true);
+            mesh_device->mesh_command_queue().enqueue_write_shards(*mesh_buffer, {transfer}, /*blocking=*/true);
 
             tt::tt_metal::TensorTopology topology(
                 tt::tt_metal::distributed::MeshShape(1, 1),


### PR DESCRIPTION
### PR Category
Cleanup

### Summary

`MeshBuffer` is passed around as `std::shared_ptr<MeshBuffer>` by default, even though ownership is almost never actually shared. As #38691 notes, this over-specifies the interface: it implies callers may share ownership of, or mutate, a `MeshBuffer` when they only need to read it. 

This PR adds overloads to `MeshCommandQueue` to existing read/write functions with `const MeshBuffer&` alternatives. And adds a `allocate_mesh_buffer` free function into the experimental folder that allocates a `MeshBuffer` and returns by value instead of `shared_ptr`.

Fix #38691

### Notes for reviewers
- Use sites has been allocated with a deprecation warning on the prior overloads
- Writing to a `const MeshBuffer&` is correct as `MeshBuffer` carrys pointer-like const semantics, and writing to a MeshBuffer does not deallocate or update the input MeshBuffer's address.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=riverwu/mesh-cq-buffer-ref)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:riverwu/mesh-cq-buffer-ref)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=riverwu/mesh-cq-buffer-ref)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:riverwu/mesh-cq-buffer-ref)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=riverwu/mesh-cq-buffer-ref)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:riverwu/mesh-cq-buffer-ref)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=riverwu/mesh-cq-buffer-ref)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:riverwu/mesh-cq-buffer-ref)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=riverwu/mesh-cq-buffer-ref)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:riverwu/mesh-cq-buffer-ref)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=riverwu/mesh-cq-buffer-ref)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:riverwu/mesh-cq-buffer-ref)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=riverwu/mesh-cq-buffer-ref)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:riverwu/mesh-cq-buffer-ref)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=riverwu/mesh-cq-buffer-ref)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:riverwu/mesh-cq-buffer-ref)

