### PR TITLE
Add token count aware decompression path to fp8 decompression operator

### DIFF
--- a/tests/pipeline_reorg/ops_unit_tests.yaml
+++ b/tests/pipeline_reorg/ops_unit_tests.yaml
@@ -91,7 +91,7 @@
 
 - name: ttnn nightly experimental tests (blackhole)
   # Host-IOMMU tests are selected by the viommu job below and excluded from these non-IOMMU SKUs.
-  cmd: 'pytest tests/ttnn/nightly/unit_tests/operations/experimental -xv -k "not performance" -m "not requires_host_iommu" --timeout=600'
+  cmd: 'pytest tests/ttnn/nightly/unit_tests/operations/experimental -v -k "not performance" -m "not requires_host_iommu" --timeout=600'
   skus:
     bh_p100:
       timeout: 60

--- a/tests/pipeline_reorg/ops_unit_tests.yaml
+++ b/tests/pipeline_reorg/ops_unit_tests.yaml
@@ -91,7 +91,7 @@
 
 - name: ttnn nightly experimental tests (blackhole)
   # Host-IOMMU tests are selected by the viommu job below and excluded from these non-IOMMU SKUs.
-  cmd: 'pytest tests/ttnn/nightly/unit_tests/operations/experimental -v -k "not performance" -m "not requires_host_iommu" --timeout=600'
+  cmd: 'pytest tests/ttnn/nightly/unit_tests/operations/experimental -xv -k "not performance" -m "not requires_host_iommu" --timeout=600'
   skus:
     bh_p100:
       timeout: 60

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_deepseek_prefill_per_token_cast.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_deepseek_prefill_per_token_cast.py
@@ -307,3 +307,128 @@ def test_round_trip_random(device, dtype, shape, input_layout):
 
     # fp8 quantization (~12% worst-case relative error) bounds the reconstruction.
     assert_quality(y, x_in, pcc_threshold=0.999, rtol=0.1, atol=0.2, label=f"roundtrip {dtype} shape={shape}")
+
+
+MASKED_CASES = [
+    ("dense", [130, 74, 200, 96, 41]),
+    ("zeros_middle", [130, 0, 0, 74, 200]),
+    ("zeros_leading", [0, 0, 130, 74, 200]),
+    ("zeros_trailing", [130, 74, 200, 0, 0]),
+]
+
+
+def _ceil_tile(n):
+    return ((n + ttnn.TILE_SIZE - 1) // ttnn.TILE_SIZE) * ttnn.TILE_SIZE
+
+
+def create_u32_tensor(device, values):
+    return ttnn.from_torch(
+        torch.tensor(values, dtype=torch.int32),
+        dtype=ttnn.uint32,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+
+MAX_DISPATCH_BUFFER_TOKENS = 5 * 1024 * 8
+
+# Metadata scale path: the dispatch metadata row is [METADATA_HEADER routing ints][H/128 fp32-bit scales].
+METADATA_HEADER = 5
+
+
+def _pack_scale_metadata(input_scale):
+    """Bit-store fp32 per-token scales in the tail of an int32 dispatch-metadata row (the metadata scale
+    path). Leading header columns are filled with a sentinel the kernel must ignore."""
+    M, blocks = input_scale.shape
+    meta = torch.full((M, METADATA_HEADER + blocks), 0x0BADF00D, dtype=torch.int32)
+    meta[:, METADATA_HEADER:] = input_scale.contiguous().view(torch.int32)
+    return meta
+
+
+@pytest.mark.parametrize("output_dtype", [ttnn.bfloat16, ttnn.float32])
+@pytest.mark.parametrize("scales_from_metadata", [False, True])
+@pytest.mark.parametrize("label, counts", MASKED_CASES, ids=[c[0] for c in MASKED_CASES])
+def test_masked_cast_back(device, label, counts, scales_from_metadata, output_dtype):
+    torch.manual_seed(0)
+    H = 1024
+
+    experts_per_chip = len(counts)
+    # This chip owns non-contiguous global ids (odd slots) out of a wider routed-expert space.
+    num_routed_experts = 2 * experts_per_chip
+    global_expert_idx_table = [2 * s + 1 for s in range(experts_per_chip)]
+
+    # Packed region layout for this chip's experts; other global ids stay zero (never read).
+    expert_region_offsets = [0] * num_routed_experts
+    expert_token_counts = [0] * num_routed_experts
+    running_offset = 0
+    for local_slot, token_count in enumerate(counts):
+        global_id = global_expert_idx_table[local_slot]
+        expert_region_offsets[global_id] = running_offset
+        expert_token_counts[global_id] = token_count
+        running_offset += _ceil_tile(token_count)
+    total_valid_rows = running_offset
+    capacity = MAX_DISPATCH_BUFFER_TOKENS  # fixed flat buffer; [total_valid_rows, capacity) is untouched tail
+
+    input_e4m3 = (torch.randn(capacity, H) * 3.0).clamp(-E4M3_MAX, E4M3_MAX).to(torch.float8_e4m3fn)
+    input_scale = torch.rand(capacity, H // BLOCK_W) * 4.0 - 2.0
+
+    e4m3_tt = _make_e4m3_from_torch(input_e4m3, device=device)
+    # Feed the scales either as a plain (M, H/128) fp32 tensor or packed into the int32 metadata tail;
+    # both drive the same math, so the golden is identical.
+    if scales_from_metadata:
+        scale_tt = None
+        metadata_tt = ttnn.from_torch(
+            _pack_scale_metadata(input_scale),
+            dtype=ttnn.uint32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            device=device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+    else:
+        metadata_tt = None
+        scale_tt = ttnn.from_torch(
+            input_scale,
+            dtype=ttnn.float32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            device=device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+    expert_region_offsets_tt = create_u32_tensor(device, expert_region_offsets)
+    expert_token_counts_tt = create_u32_tensor(device, expert_token_counts)
+    global_expert_idx_table_tt = create_u32_tensor(device, global_expert_idx_table)
+
+    out_tt = ttnn.experimental.deepseek_prefill.per_token_cast_back(
+        e4m3_tt,
+        scale_tt,
+        token_count_aware=True,
+        expert_region_offsets=expert_region_offsets_tt,
+        expert_token_counts=expert_token_counts_tt,
+        global_expert_idx_table=global_expert_idx_table_tt,
+        experts_per_chip=experts_per_chip,
+        output_dtype=output_dtype,
+        metadata=metadata_tt,
+    )
+    out = ttnn.to_torch(out_tt).float()
+
+    assert tuple(out_tt.shape) == (capacity, H)
+    assert out_tt.dtype == output_dtype
+
+    golden = input_e4m3.float() * input_scale.repeat_interleave(BLOCK_W, dim=-1)
+    # A bf16 output rounds the result at the packer; fp32 output stays full fp32.
+    if output_dtype == ttnn.bfloat16:
+        golden = golden.to(torch.bfloat16).float()
+
+    # The op sweeps [0, total_valid_rows) contiguously (valid tokens + end-of-region tile padding), so
+    # every written row must equal e4m3 * scale; the tail beyond total_valid_rows is left untouched.
+    prefix_out = out[:total_valid_rows]
+    prefix_golden = golden[:total_valid_rows]
+    normal = input_e4m3.float()[:total_valid_rows].abs() > 2.0**-6
+    assert_quality(
+        prefix_out[normal],
+        prefix_golden[normal],
+        pcc_threshold=0.999,
+        rtol=1e-2,
+        atol=1e-3,
+        label=f"masked cast back {label} metadata={scales_from_metadata} out={output_dtype}",
+    )

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_deepseek_prefill_per_token_cast.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_deepseek_prefill_per_token_cast.py
@@ -16,6 +16,7 @@ import ttnn
 from loguru import logger
 
 from models.common.utility_functions import is_blackhole
+from models.demos.deepseek_v3_d_p.reference.kimi_k2_6_config import KimiK26Config
 from tests.ttnn.utils_for_testing import comp_pcc, assert_equal
 
 pytestmark = pytest.mark.use_module_device
@@ -310,10 +311,17 @@ def test_round_trip_random(device, dtype, shape, input_layout):
 
 
 TOKEN_COUNT_AWARE_CASES = [
+    # dense - each expert has tokens
     ("dense", [130, 74, 200, 96, 41]),
+    # zeros_middle, zeros_leading, zeros_trailing - some expert have no tokens
+    # we test if those tokens are skipped correctly and if the operator
+    # correctly handles the case where some experts have no tokens
     ("zeros_middle", [130, 0, 0, 74, 200]),
     ("zeros_leading", [0, 0, 130, 74, 200]),
     ("zeros_trailing", [130, 74, 200, 0, 0]),
+    # overflow - the packed regions run past the flat buffer; the op must clamp to capacity, drop the
+    # out-of-bounds tokens, and never hang.
+    ("overflow", [9000, 9000, 9000, 9000, 9000]),
 ]
 
 
@@ -334,7 +342,8 @@ def create_u32_tensor(device, values):
 MAX_DISPATCH_BUFFER_TOKENS = 5 * 1024 * 8
 
 # Metadata scale path: the dispatch metadata row is [METADATA_HEADER routing ints][H/128 fp32-bit scales].
-METADATA_HEADER = 5
+METADATA_HEADER = 3  # This may change in the future, but the actual number is not important for the test
+# The number is just used to set the starting offset when reading the scales from the metadata row
 
 
 def _pack_scale_metadata(input_scale):
@@ -351,7 +360,7 @@ def _pack_scale_metadata(input_scale):
 @pytest.mark.parametrize("label, counts", TOKEN_COUNT_AWARE_CASES, ids=[c[0] for c in TOKEN_COUNT_AWARE_CASES])
 def test_token_count_aware_cast_back(device, label, counts, scales_from_metadata, output_dtype):
     torch.manual_seed(0)
-    H = 1024
+    H = KimiK26Config.EMB_SIZE
 
     experts_per_chip = len(counts)
     # This chip owns non-contiguous global ids (odd slots) out of a wider routed-expert space.
@@ -367,8 +376,9 @@ def test_token_count_aware_cast_back(device, label, counts, scales_from_metadata
         expert_region_offsets[global_id] = running_offset
         expert_token_counts[global_id] = token_count
         running_offset += _ceil_tile(token_count)
-    total_valid_rows = running_offset
     capacity = MAX_DISPATCH_BUFFER_TOKENS  # fixed flat buffer; [total_valid_rows, capacity) is untouched tail
+    # The op clamps its swept region to the buffer capacity, so rows past it are dropped (overflow case).
+    total_valid_rows = min(running_offset, capacity)
 
     input_e4m3 = (torch.randn(capacity, H) * 3.0).clamp(-E4M3_MAX, E4M3_MAX).to(torch.float8_e4m3fn)
     input_scale = torch.rand(capacity, H // BLOCK_W) * 4.0 - 2.0

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_deepseek_prefill_per_token_cast.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_deepseek_prefill_per_token_cast.py
@@ -309,7 +309,7 @@ def test_round_trip_random(device, dtype, shape, input_layout):
     assert_quality(y, x_in, pcc_threshold=0.999, rtol=0.1, atol=0.2, label=f"roundtrip {dtype} shape={shape}")
 
 
-MASKED_CASES = [
+TOKEN_COUNT_AWARE_CASES = [
     ("dense", [130, 74, 200, 96, 41]),
     ("zeros_middle", [130, 0, 0, 74, 200]),
     ("zeros_leading", [0, 0, 130, 74, 200]),
@@ -348,8 +348,8 @@ def _pack_scale_metadata(input_scale):
 
 @pytest.mark.parametrize("output_dtype", [ttnn.bfloat16, ttnn.float32])
 @pytest.mark.parametrize("scales_from_metadata", [False, True])
-@pytest.mark.parametrize("label, counts", MASKED_CASES, ids=[c[0] for c in MASKED_CASES])
-def test_masked_cast_back(device, label, counts, scales_from_metadata, output_dtype):
+@pytest.mark.parametrize("label, counts", TOKEN_COUNT_AWARE_CASES, ids=[c[0] for c in TOKEN_COUNT_AWARE_CASES])
+def test_token_count_aware_cast_back(device, label, counts, scales_from_metadata, output_dtype):
     torch.manual_seed(0)
     H = 1024
 
@@ -430,5 +430,5 @@ def test_masked_cast_back(device, label, counts, scales_from_metadata, output_dt
         pcc_threshold=0.999,
         rtol=1e-2,
         atol=1e-3,
-        label=f"masked cast back {label} metadata={scales_from_metadata} out={output_dtype}",
+        label=f"token-count-aware cast back {label} metadata={scales_from_metadata} out={output_dtype}",
     )

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_deepseek_prefill_per_token_cast.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_deepseek_prefill_per_token_cast.py
@@ -310,6 +310,9 @@ def test_round_trip_random(device, dtype, shape, input_layout):
     assert_quality(y, x_in, pcc_threshold=0.999, rtol=0.1, atol=0.2, label=f"roundtrip {dtype} shape={shape}")
 
 
+# Each number inside the list is how much tokens does each expert on a single chip have
+# The length of the list is num_experts_per_chip
+# Example: [130, 74, 200, 96, 41] means that we have 5 experts per chip, where the first expert has 130 tokens, etc...
 TOKEN_COUNT_AWARE_CASES = [
     # dense - each expert has tokens
     ("dense", [130, 74, 200, 96, 41]),

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_back/device/kernels/compute/compute_per_token_cast_back.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_back/device/kernels/compute/compute_per_token_cast_back.cpp
@@ -16,6 +16,11 @@
 //   Phase 2a: tilize fp32 RM input -> tile  (cb_in_tile)
 //   Phase 2c: cb_out_tile = cb_in_tile * bcast(scale)
 //   Phase 3 : untilize cb_out_tile -> row-major output
+//
+// num_blocks source (TOKEN_COUNT_AWARE define):
+//   * plain             : passed as a runtime arg.
+//   * token_count_aware : delivered by the reader via the cb_loop_count mailbox (read_tile_value
+//                         distributes the UNPACK read to MATH/PACK so all three threads agree).
 
 #include <cstdint>
 
@@ -43,6 +48,7 @@ void kernel_main() {
     // Tile dims from the tensor's tile spec.
     constexpr uint32_t tile_h = get_compile_time_arg_val(6);
     constexpr uint32_t tile_w = get_compile_time_arg_val(7);
+    constexpr uint32_t cb_loop_count_id = get_compile_time_arg_val(8);
     constexpr uint32_t block_w = 128;                // BlockW
     constexpr uint32_t block_wt = block_w / tile_w;  // BlockWt
     constexpr uint32_t block_ht = 1;                 // BlockHt
@@ -50,9 +56,18 @@ void kernel_main() {
 
     constexpr uint32_t IDST0 = 0;
 
-    uint32_t num_blocks = get_arg_val<uint32_t>(0);  // tile_h x 128 blocks for this core
-
     compute_kernel_hw_startup(cb_input_e4m3_id, cb_out_fp32_id);
+
+#ifdef TOKEN_COUNT_AWARE
+    // num_blocks is computed by the reader and delivered via the loop-count mailbox.
+    CircularBuffer cb_loop_count(cb_loop_count_id);
+    cb_loop_count.wait_front(1);
+    uint32_t num_blocks = cb_loop_count.read_tile_value(0, 0);
+    cb_loop_count.pop_front(1);
+#else
+    (void)cb_loop_count_id;
+    uint32_t num_blocks = get_arg_val<uint32_t>(0);  // tile_h x 128 blocks for this core
+#endif
 
     for (uint32_t blk = 0; blk < num_blocks; ++blk) {
         {

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_back/device/kernels/compute/compute_per_token_cast_back.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_back/device/kernels/compute/compute_per_token_cast_back.cpp
@@ -65,7 +65,6 @@ void kernel_main() {
     uint32_t num_blocks = cb_loop_count.read_tile_value(0, 0);
     cb_loop_count.pop_front(1);
 #else
-    (void)cb_loop_count_id;
     uint32_t num_blocks = get_arg_val<uint32_t>(0);  // tile_h x 128 blocks for this core
 #endif
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_back/device/kernels/dataflow/reader_per_token_cast_back.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_back/device/kernels/dataflow/reader_per_token_cast_back.cpp
@@ -27,7 +27,6 @@
 #include "api/dataflow/circular_buffer.h"
 #include "api/dataflow/noc.h"
 #include "api/tensor/noc_traits.h"
-#include "api/debug/assert.h"
 
 void kernel_main() {
     uint32_t input_e4m3_addr = get_arg_val<uint32_t>(0);
@@ -66,9 +65,6 @@ void kernel_main() {
     // Element offset of the scale tail within each scale-source row. 0 for a plain (M, H/128) scale
     // tensor; = metadata_len - H/128 (skip the routing header) for the metadata path.
     constexpr uint32_t scale_col_offset = get_compile_time_arg_val(16);
-    // Bounds used by the metadata sanity-check asserts below.
-    constexpr uint32_t num_routed_experts = get_compile_time_arg_val(17);  // length of region/counts vectors
-    constexpr uint32_t input_num_rows = get_compile_time_arg_val(18);      // M: input buffer row capacity
     constexpr uint32_t ACCESSOR_CT_BASE = 19;
 #else
     // Plain path: the scale is a FLOAT32 (M, H/128) tensor read from column 0.
@@ -129,7 +125,6 @@ void kernel_main() {
     uint32_t total_valid_rows = 0;
     for (uint32_t local_slot = 0; local_slot < experts_per_chip; ++local_slot) {
         const uint32_t global_expert_id = table_ptr[local_slot];
-        ASSERT(global_expert_id < num_routed_experts);
         const uint32_t token_count = counts_ptr[global_expert_id];
         const uint32_t token_count_ceil = ((token_count + tile_h - 1) / tile_h) * tile_h;
         const uint32_t region_end = region_ptr[global_expert_id] + token_count_ceil;
@@ -137,7 +132,6 @@ void kernel_main() {
             total_valid_rows = region_end;
         }
     }
-    ASSERT(total_valid_rows <= input_num_rows);
 
     // Split the work across the cores: this core takes a contiguous slice of the flattened compute-block space.
     const uint32_t total_tile_rows = total_valid_rows / tile_h;

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_back/device/kernels/dataflow/reader_per_token_cast_back.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_back/device/kernels/dataflow/reader_per_token_cast_back.cpp
@@ -3,8 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Reader for per_token_cast_back. Streams the core's rows as a flat sequence of 128-element scale
-// blocks; a block is tile_h consecutive scale blocks (tiles_per_block tiles after tilize).
-// Per block:
+// blocks; a block is tile_h consecutive scale blocks (tiles_per_block tiles after tilize). Per block:
 //   - input_e4m3: read each bank-contiguous run of scale blocks into cb_input_e4m3 with a single
 //     NoC async read (mirrors the writer);
 //   - scale: read the (few) tokens spanned by the block as full, page-aligned scale rows into a
@@ -12,6 +11,14 @@
 //     64-aligned DRAM page), then build the single bcast operand tile whose column 0 row r = the
 //     scale of block row r = scale[token_r][block_r] (face-aware). The compute multiplies each
 //     block row by its column-0 scale.
+//
+// The core's block range is chosen two ways (TOKEN_COUNT_AWARE define):
+//   * plain  : the host passes start_row / num_rows / num_blocks as runtime args.
+//   * token_count_aware : this kernel reads the per-expert region offsets / token counts / global-expert-idx
+//              table from DRAM, computes the valid prefix length total_valid_rows, derives its own
+//              balanced tile-row slice from (core_id, num_cores), and publishes num_blocks to the
+//              compute kernel via the cb_loop_count mailbox. The scale may be read from the int32 metadata
+//              tail (scale_col_offset).
 
 #include <cstdint>
 
@@ -20,15 +27,23 @@
 #include "api/dataflow/circular_buffer.h"
 #include "api/dataflow/noc.h"
 #include "api/tensor/noc_traits.h"
-#include "tools/profiler/kernel_profiler.hpp"
+#include "api/debug/assert.h"
 
 void kernel_main() {
     uint32_t input_e4m3_addr = get_arg_val<uint32_t>(0);
     uint32_t scale_addr = get_arg_val<uint32_t>(1);
+#ifdef TOKEN_COUNT_AWARE
+    uint32_t region_addr = get_arg_val<uint32_t>(2);
+    uint32_t counts_addr = get_arg_val<uint32_t>(3);
+    uint32_t table_addr = get_arg_val<uint32_t>(4);
+    uint32_t core_id = get_arg_val<uint32_t>(5);
+    uint32_t width = get_arg_val<uint32_t>(6);  // H (elements per row)
+#else
     uint32_t num_blocks = get_arg_val<uint32_t>(2);
     uint32_t start_row = get_arg_val<uint32_t>(3);  // absolute first row of this core's stream
     uint32_t num_rows = get_arg_val<uint32_t>(4);   // rows owned by this core
     uint32_t width = get_arg_val<uint32_t>(5);      // H (elements per row)
+#endif
 
     constexpr uint32_t cb_input_e4m3 = get_compile_time_arg_val(0);
     constexpr uint32_t cb_scale_bcast = get_compile_time_arg_val(1);
@@ -41,17 +56,36 @@ void kernel_main() {
     constexpr uint32_t tile_w = get_compile_time_arg_val(7);
     constexpr uint32_t face_h = get_compile_time_arg_val(8);
     constexpr uint32_t face_w = get_compile_time_arg_val(9);
+#ifdef TOKEN_COUNT_AWARE
+    constexpr uint32_t cb_loop_count = get_compile_time_arg_val(10);
+    constexpr uint32_t cb_region_scratch = get_compile_time_arg_val(11);
+    constexpr uint32_t cb_counts_scratch = get_compile_time_arg_val(12);
+    constexpr uint32_t cb_table_scratch = get_compile_time_arg_val(13);
+    constexpr uint32_t num_cores = get_compile_time_arg_val(14);
+    constexpr uint32_t experts_per_chip = get_compile_time_arg_val(15);
+    // Element offset of the scale tail within each scale-source row. 0 for a plain (M, H/128) scale
+    // tensor; = metadata_len - H/128 (skip the routing header) for the metadata path.
+    constexpr uint32_t scale_col_offset = get_compile_time_arg_val(16);
+    // Bounds used by the metadata sanity-check asserts below.
+    constexpr uint32_t num_routed_experts = get_compile_time_arg_val(17);  // length of region/counts vectors
+    constexpr uint32_t input_num_rows = get_compile_time_arg_val(18);      // M: input buffer row capacity
+    constexpr uint32_t ACCESSOR_CT_BASE = 19;
+#else
+    // Plain path: the scale is a FLOAT32 (M, H/128) tensor read from column 0.
+    constexpr uint32_t scale_col_offset = 0;
+    constexpr uint32_t ACCESSOR_CT_BASE = 10;
+#endif
     constexpr uint32_t block_w = 128;
     constexpr uint32_t tiles_per_block = block_w / tile_w;
-    constexpr uint32_t face_elems = face_h * face_w;                // fp32 per face
-    constexpr uint32_t faces_per_row = tile_w / face_w;             // face columns per tile
+    constexpr uint32_t face_elems = face_h * face_w;                                        // fp32 per face
+    constexpr uint32_t faces_per_row = tile_w / face_w;                                     // face columns per tile
     constexpr uint32_t FACE_ROWS = tile_h / face_h;                                         // face rows per tile
     constexpr uint32_t FACE_ROW_STRIDE_BYTES = faces_per_row * face_elems * sizeof(float);  // per face row
     constexpr uint32_t FACE_W_BYTES = face_w * sizeof(float);                               // per in-face row
 
     (void)block_ht;  // kept as a compile-time layout arg for tensor accessor offset stability
 
-    constexpr auto input_e4m3_accessor_args = TensorAccessorArgs<10>();
+    constexpr auto input_e4m3_accessor_args = TensorAccessorArgs<ACCESSOR_CT_BASE>();
     constexpr auto scale_args = TensorAccessorArgs<input_e4m3_accessor_args.next_compile_time_args_offset()>();
     const auto input_e4m3 = TensorAccessor(input_e4m3_accessor_args, input_e4m3_addr);
     const auto scale = TensorAccessor(scale_args, scale_addr);
@@ -60,18 +94,84 @@ void kernel_main() {
     CircularBuffer cb_scale_bcast_obj(cb_scale_bcast);
     CircularBuffer cb_scale_scratch_obj(cb_scale_scratch);
 
+    const uint32_t blocks_per_row = width >> 7;  // H / 128 (block_w = 128); one-time shift
+
+#ifdef TOKEN_COUNT_AWARE
+    constexpr auto region_args = TensorAccessorArgs<scale_args.next_compile_time_args_offset()>();
+    constexpr auto counts_args = TensorAccessorArgs<region_args.next_compile_time_args_offset()>();
+    constexpr auto table_args = TensorAccessorArgs<counts_args.next_compile_time_args_offset()>();
+    const auto region = TensorAccessor(region_args, region_addr);
+    const auto counts = TensorAccessor(counts_args, counts_addr);
+    const auto table = TensorAccessor(table_args, table_addr);
+    CircularBuffer cb_loop_count_obj(cb_loop_count);
+    CircularBuffer cb_region_scratch_obj(cb_region_scratch);
+    CircularBuffer cb_counts_scratch_obj(cb_counts_scratch);
+    CircularBuffer cb_table_scratch_obj(cb_table_scratch);
+
+    // --- Read the three metadata vectors (small, 1 page each) into private L1 scratch. ---
+    cb_region_scratch_obj.reserve_back(1);
+    cb_counts_scratch_obj.reserve_back(1);
+    cb_table_scratch_obj.reserve_back(1);
+    noc.async_read(region, cb_region_scratch_obj, region.get_aligned_page_size(), {.page_id = 0}, {.offset_bytes = 0});
+    noc.async_read(counts, cb_counts_scratch_obj, counts.get_aligned_page_size(), {.page_id = 0}, {.offset_bytes = 0});
+    noc.async_read(table, cb_table_scratch_obj, table.get_aligned_page_size(), {.page_id = 0}, {.offset_bytes = 0});
+    noc.async_read_barrier();
+
+    const volatile tt_l1_ptr uint32_t* region_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb_region_scratch_obj.get_write_ptr());
+    const volatile tt_l1_ptr uint32_t* counts_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb_counts_scratch_obj.get_write_ptr());
+    const volatile tt_l1_ptr uint32_t* table_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb_table_scratch_obj.get_write_ptr());
+
+    // Valid prefix length = max over local expert slots of (region_ptr[g] + ceil_tile(counts_ptr[g])),
+    // where g = table_ptr[local_slot].
+    uint32_t total_valid_rows = 0;
+    for (uint32_t local_slot = 0; local_slot < experts_per_chip; ++local_slot) {
+        const uint32_t global_expert_id = table_ptr[local_slot];
+        ASSERT(global_expert_id < num_routed_experts);
+        const uint32_t token_count = counts_ptr[global_expert_id];
+        const uint32_t token_count_ceil = ((token_count + tile_h - 1) / tile_h) * tile_h;
+        const uint32_t region_end = region_ptr[global_expert_id] + token_count_ceil;
+        if (region_end > total_valid_rows) {
+            total_valid_rows = region_end;
+        }
+    }
+    ASSERT(total_valid_rows <= input_num_rows);
+
+    // Split the work across the cores: this core takes a contiguous slice of the flattened compute-block space.
+    const uint32_t total_tile_rows = total_valid_rows / tile_h;
+    const uint32_t total_compute_blocks = total_tile_rows * blocks_per_row;
+    const uint32_t cb_start = (total_compute_blocks * core_id) / num_cores;
+    const uint32_t cb_end = (total_compute_blocks * (core_id + 1)) / num_cores;
+    const uint32_t num_blocks = cb_end - cb_start;
+    // Flattened scale-block indices (tile_h scale-blocks per compute-block). One-time div/mod only.
+    const uint32_t start_flat = cb_start * tile_h;
+    const uint32_t end_flat = cb_end * tile_h;  // exclusive
+    const uint32_t start_row = start_flat / blocks_per_row;
+    const uint32_t start_col = start_flat % blocks_per_row;
+    const uint32_t end_row = (end_flat == 0) ? 0 : ((end_flat - 1) / blocks_per_row) + 1;
+    const uint32_t total_blocks = num_blocks * tile_h;  // per-core scale-blocks (exact multiple of tile_h)
+
+    // Publish num_blocks to the compute kernel (read via read_tile_value on the TRISCs).
+    cb_loop_count_obj.reserve_back(1);
+    reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb_loop_count_obj.get_write_ptr())[0] = num_blocks;
+    cb_loop_count_obj.push_back(1);
+#else
+    // num_blocks / start_row / num_rows come from the host runtime args read above.
+    const uint32_t start_col = 0;
+    const uint32_t total_blocks = num_rows * blocks_per_row;
+    const uint32_t end_row = start_row + num_rows;
+#endif
+
     // Reader-private scratch: up to tile_h tokens' full scale rows (one slot per token in a block).
     cb_scale_scratch_obj.reserve_back(1);
     const uint32_t scratch = cb_scale_scratch_obj.get_write_ptr();
 
-    const uint32_t blocks_per_row = width >> 7;  // H / 128 (block_w = 128); one-time shift
-    const uint32_t total_blocks = num_rows * blocks_per_row;
-    const uint32_t end_row = start_row + num_rows;
-
     // Persistent (row, block_idx) cursor over the flat block stream: no per-block div/mod (expensive
     // on the Baby RISC-V); advance block_idx by the run and reset to the next row with a conditional.
     uint32_t current_row = start_row;
-    uint32_t block_idx_in_row = 0;
+    uint32_t block_idx_in_row = start_col;
 
     for (uint32_t blk = 0; blk < num_blocks; ++blk) {
         const uint32_t base = blk * tile_h;
@@ -125,23 +225,19 @@ void kernel_main() {
         cb_scale_bcast_obj.reserve_back(1);
         CoreLocalMem<volatile uint32_t> scratch_mem(scratch);
         CoreLocalMem<volatile uint32_t> page(cb_scale_bcast_obj.get_write_ptr());
-        {
-            DeviceZoneScopedN("build_bcast_operand");
-            uint32_t tok_off = 0;  // (token - block_start_row) * scale_aligned_page_bytes
-            uint32_t block_idx_b = block_start_idx;
-            uint32_t s = 0;
-            uint32_t face_base_off = 0;
-            for (uint32_t fr = 0; fr < FACE_ROWS; ++fr) {
-                uint32_t col0_off = face_base_off;
-                for (uint32_t r = 0; r < face_h; ++r) {
-                    if (s < real_in_block) {
-                        uint32_t val = scratch_mem[(tok_off >> 2) + block_idx_b];
-                        page[col0_off >> 2] = val;
-                        ++block_idx_b;
-                        if (block_idx_b >= blocks_per_row) {
-                            block_idx_b = 0;
-                            tok_off += scale_aligned_page_bytes;
-                        }
+        uint32_t tok_off = 0;  // (token - block_start_row) * scale_aligned_page_bytes
+        uint32_t block_idx_b = block_start_idx;
+        uint32_t s = 0;
+        uint32_t face_base_off = 0;
+        for (uint32_t fr = 0; fr < FACE_ROWS; ++fr) {
+            uint32_t col0_off = face_base_off;
+            for (uint32_t r = 0; r < face_h; ++r) {
+                if (s < real_in_block) {
+                    page[col0_off >> 2] = scratch_mem[(tok_off >> 2) + scale_col_offset + block_idx_b];
+                    ++block_idx_b;
+                    if (block_idx_b >= blocks_per_row) {
+                        block_idx_b = 0;
+                        tok_off += scale_aligned_page_bytes;
                     }
                     col0_off += FACE_W_BYTES;
                     ++s;

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_back/device/kernels/dataflow/reader_per_token_cast_back.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_back/device/kernels/dataflow/reader_per_token_cast_back.cpp
@@ -238,11 +238,11 @@ void kernel_main() {
                         block_idx_b = 0;
                         tok_off += scale_aligned_page_bytes;
                     }
-                    col0_off += FACE_W_BYTES;
-                    ++s;
                 }
-                face_base_off += FACE_ROW_STRIDE_BYTES;
+                col0_off += FACE_W_BYTES;
+                ++s;
             }
+            face_base_off += FACE_ROW_STRIDE_BYTES;
         }
         cb_scale_bcast_obj.push_back(1);
         cb_input_e4m3_obj.push_back(tiles_per_block);

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_back/device/kernels/dataflow/reader_per_token_cast_back.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_back/device/kernels/dataflow/reader_per_token_cast_back.cpp
@@ -65,6 +65,7 @@ void kernel_main() {
     // Element offset of the scale tail within each scale-source row. 0 for a plain (M, H/128) scale
     // tensor; = metadata_len - H/128 (skip the routing header) for the metadata path.
     constexpr uint32_t scale_col_offset = get_compile_time_arg_val(16);
+    constexpr uint32_t max_dispatch_buffer_tokens = get_compile_time_arg_val(18);
     constexpr uint32_t ACCESSOR_CT_BASE = 19;
 #else
     // Plain path: the scale is a FLOAT32 (M, H/128) tensor read from column 0.
@@ -131,6 +132,10 @@ void kernel_main() {
         if (region_end > total_valid_rows) {
             total_valid_rows = region_end;
         }
+    }
+
+    if (total_valid_rows > max_dispatch_buffer_tokens) {
+        total_valid_rows = max_dispatch_buffer_tokens;
     }
 
     // Split the work across the cores: this core takes a contiguous slice of the flattened compute-block space.

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_back/device/kernels/dataflow/writer_per_token_cast_back.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_back/device/kernels/dataflow/writer_per_token_cast_back.cpp
@@ -20,7 +20,6 @@
 #include "api/dataflow/circular_buffer.h"
 #include "api/dataflow/noc.h"
 #include "api/tensor/noc_traits.h"
-#include "api/debug/assert.h"
 
 void kernel_main() {
     uint32_t dst_addr = get_arg_val<uint32_t>(0);
@@ -47,9 +46,6 @@ void kernel_main() {
     constexpr uint32_t cb_table_scratch = get_compile_time_arg_val(6);
     constexpr uint32_t num_cores = get_compile_time_arg_val(7);
     constexpr uint32_t experts_per_chip = get_compile_time_arg_val(8);
-    // Bounds used by the metadata sanity-check asserts below.
-    constexpr uint32_t num_routed_experts = get_compile_time_arg_val(9);  // length of region/counts vectors
-    constexpr uint32_t input_num_rows = get_compile_time_arg_val(10);     // M: output buffer row capacity
     constexpr uint32_t ACCESSOR_CT_BASE = 11;
 #else
     constexpr uint32_t ACCESSOR_CT_BASE = 4;
@@ -94,7 +90,6 @@ void kernel_main() {
     uint32_t total_valid_rows = 0;
     for (uint32_t local_slot = 0; local_slot < experts_per_chip; ++local_slot) {
         const uint32_t global_expert_id = table_ptr[local_slot];
-        ASSERT(global_expert_id < num_routed_experts);
         const uint32_t token_count = counts_ptr[global_expert_id];
         const uint32_t token_count_ceil = ((token_count + tile_h - 1) / tile_h) * tile_h;
         const uint32_t region_end = region_ptr[global_expert_id] + token_count_ceil;
@@ -102,7 +97,6 @@ void kernel_main() {
             total_valid_rows = region_end;
         }
     }
-    ASSERT(total_valid_rows <= input_num_rows);
 
     // Balanced split over the FLATTENED compute-block space (identical formula to the reader), so the
     // reader/compute/writer on the same core agree on the exact (start_row, start_col) .. flattened range.

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_back/device/kernels/dataflow/writer_per_token_cast_back.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_back/device/kernels/dataflow/writer_per_token_cast_back.cpp
@@ -6,6 +6,13 @@
 // [tile_h scale-block rows x 128] row-major output (tiles_per_block tiles). The writer walks the
 // same flat scale-block stream as the reader and writes each bank-contiguous run back to its row at
 // the current block column offset with one NoC async write.
+//
+// The core's block range is chosen two ways (TOKEN_COUNT_AWARE define):
+//   * plain  : the host passes start_row / num_rows / num_blocks as runtime args.
+//   * token_count_aware : this kernel reads the per-expert region offsets / token counts / global-expert-idx
+//              table, computes total_valid_rows, and takes the same balanced tile-row slice as the
+//              reader (identical (core_id, num_cores) formula), so its output CB is drained by exactly
+//              its own writer. Only the valid prefix rows are written; the garbage tail is left untouched.
 
 #include <cstdint>
 
@@ -13,32 +20,115 @@
 #include "api/dataflow/circular_buffer.h"
 #include "api/dataflow/noc.h"
 #include "api/tensor/noc_traits.h"
+#include "api/debug/assert.h"
 
 void kernel_main() {
     uint32_t dst_addr = get_arg_val<uint32_t>(0);
+#ifdef TOKEN_COUNT_AWARE
+    uint32_t region_addr = get_arg_val<uint32_t>(1);
+    uint32_t counts_addr = get_arg_val<uint32_t>(2);
+    uint32_t table_addr = get_arg_val<uint32_t>(3);
+    uint32_t core_id = get_arg_val<uint32_t>(4);
+    uint32_t width = get_arg_val<uint32_t>(5);  // H (elements per row)
+#else
     uint32_t num_blocks = get_arg_val<uint32_t>(1);
     uint32_t start_row = get_arg_val<uint32_t>(2);  // absolute first row of this core's stream
     uint32_t num_rows = get_arg_val<uint32_t>(3);   // rows owned by this core
     uint32_t width = get_arg_val<uint32_t>(4);      // H (elements per row)
+#endif
 
     constexpr uint32_t cb_out_fp32 = get_compile_time_arg_val(0);
     constexpr uint32_t out_block_bytes = get_compile_time_arg_val(1);  // 128 * out_elem_size
     constexpr uint32_t tile_h = get_compile_time_arg_val(2);
     constexpr uint32_t tiles_per_block = get_compile_time_arg_val(3);  // tiles per block (= 4 for 32-wide tiles)
-    constexpr auto dst_args = TensorAccessorArgs<4>();
+#ifdef TOKEN_COUNT_AWARE
+    constexpr uint32_t cb_region_scratch = get_compile_time_arg_val(4);
+    constexpr uint32_t cb_counts_scratch = get_compile_time_arg_val(5);
+    constexpr uint32_t cb_table_scratch = get_compile_time_arg_val(6);
+    constexpr uint32_t num_cores = get_compile_time_arg_val(7);
+    constexpr uint32_t experts_per_chip = get_compile_time_arg_val(8);
+    // Bounds used by the metadata sanity-check asserts below.
+    constexpr uint32_t num_routed_experts = get_compile_time_arg_val(9);  // length of region/counts vectors
+    constexpr uint32_t input_num_rows = get_compile_time_arg_val(10);     // M: output buffer row capacity
+    constexpr uint32_t ACCESSOR_CT_BASE = 11;
+#else
+    constexpr uint32_t ACCESSOR_CT_BASE = 4;
+#endif
 
+    constexpr auto dst_args = TensorAccessorArgs<ACCESSOR_CT_BASE>();
     const auto dst = TensorAccessor(dst_args, dst_addr);
     Noc noc;
     CircularBuffer cb_out_fp32_obj(cb_out_fp32);
 
     const uint32_t blocks_per_row = width >> 7;  // H / 128; one-time shift
+
+#ifdef TOKEN_COUNT_AWARE
+    constexpr auto region_args = TensorAccessorArgs<dst_args.next_compile_time_args_offset()>();
+    constexpr auto counts_args = TensorAccessorArgs<region_args.next_compile_time_args_offset()>();
+    constexpr auto table_args = TensorAccessorArgs<counts_args.next_compile_time_args_offset()>();
+    const auto region = TensorAccessor(region_args, region_addr);
+    const auto counts = TensorAccessor(counts_args, counts_addr);
+    const auto table = TensorAccessor(table_args, table_addr);
+    CircularBuffer cb_region_scratch_obj(cb_region_scratch);
+    CircularBuffer cb_counts_scratch_obj(cb_counts_scratch);
+    CircularBuffer cb_table_scratch_obj(cb_table_scratch);
+
+    // --- Read the three metadata vectors (small, 1 page each) into private L1 scratch. ---
+    cb_region_scratch_obj.reserve_back(1);
+    cb_counts_scratch_obj.reserve_back(1);
+    cb_table_scratch_obj.reserve_back(1);
+    noc.async_read(region, cb_region_scratch_obj, region.get_aligned_page_size(), {.page_id = 0}, {.offset_bytes = 0});
+    noc.async_read(counts, cb_counts_scratch_obj, counts.get_aligned_page_size(), {.page_id = 0}, {.offset_bytes = 0});
+    noc.async_read(table, cb_table_scratch_obj, table.get_aligned_page_size(), {.page_id = 0}, {.offset_bytes = 0});
+    noc.async_read_barrier();
+
+    const volatile tt_l1_ptr uint32_t* region_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb_region_scratch_obj.get_write_ptr());
+    const volatile tt_l1_ptr uint32_t* counts_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb_counts_scratch_obj.get_write_ptr());
+    const volatile tt_l1_ptr uint32_t* table_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb_table_scratch_obj.get_write_ptr());
+
+    // Valid prefix length = max over local expert slots of (region_ptr[g] + ceil_tile(counts_ptr[g])),
+    // where g = table_ptr[local_slot].
+    uint32_t total_valid_rows = 0;
+    for (uint32_t local_slot = 0; local_slot < experts_per_chip; ++local_slot) {
+        const uint32_t global_expert_id = table_ptr[local_slot];
+        ASSERT(global_expert_id < num_routed_experts);
+        const uint32_t token_count = counts_ptr[global_expert_id];
+        const uint32_t token_count_ceil = ((token_count + tile_h - 1) / tile_h) * tile_h;
+        const uint32_t region_end = region_ptr[global_expert_id] + token_count_ceil;
+        if (region_end > total_valid_rows) {
+            total_valid_rows = region_end;
+        }
+    }
+    ASSERT(total_valid_rows <= input_num_rows);
+
+    // Balanced split over the FLATTENED compute-block space (identical formula to the reader), so the
+    // reader/compute/writer on the same core agree on the exact (start_row, start_col) .. flattened range.
+    const uint32_t total_tile_rows = total_valid_rows / tile_h;
+    const uint32_t total_compute_blocks = total_tile_rows * blocks_per_row;
+    const uint32_t cb_start = (total_compute_blocks * core_id) / num_cores;
+    const uint32_t cb_end = (total_compute_blocks * (core_id + 1)) / num_cores;
+    const uint32_t num_blocks = cb_end - cb_start;
+    // Flattened scale-block indices (tile_h scale-blocks per compute-block). One-time div/mod only.
+    const uint32_t start_flat = cb_start * tile_h;
+    const uint32_t end_flat = cb_end * tile_h;  // exclusive
+    const uint32_t start_row = start_flat / blocks_per_row;
+    const uint32_t start_col = start_flat % blocks_per_row;
+    const uint32_t end_row = (end_flat == 0) ? 0 : ((end_flat - 1) / blocks_per_row) + 1;
+    const uint32_t total_blocks = num_blocks * tile_h;  // per-core scale-blocks (exact multiple of tile_h)
+#else
+    // num_blocks / start_row / num_rows come from the host runtime args read above.
+    const uint32_t start_col = 0;
     const uint32_t total_blocks = num_rows * blocks_per_row;
     const uint32_t end_row = start_row + num_rows;
+#endif
 
     // Persistent (row, block_idx) cursor over the flat block stream: no per-run div/mod (expensive on
     // the Baby RISC-V); advance block_idx by the run and reset to the next row with a conditional.
     uint32_t current_row = start_row;
-    uint32_t block_idx_in_row = 0;
+    uint32_t block_idx_in_row = start_col;
 
     for (uint32_t blk = 0; blk < num_blocks; ++blk) {
         const uint32_t base = blk * tile_h;

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_back/device/kernels/dataflow/writer_per_token_cast_back.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_back/device/kernels/dataflow/writer_per_token_cast_back.cpp
@@ -46,6 +46,7 @@ void kernel_main() {
     constexpr uint32_t cb_table_scratch = get_compile_time_arg_val(6);
     constexpr uint32_t num_cores = get_compile_time_arg_val(7);
     constexpr uint32_t experts_per_chip = get_compile_time_arg_val(8);
+    constexpr uint32_t max_dispatch_buffer_tokens = get_compile_time_arg_val(10);
     constexpr uint32_t ACCESSOR_CT_BASE = 11;
 #else
     constexpr uint32_t ACCESSOR_CT_BASE = 4;
@@ -96,6 +97,10 @@ void kernel_main() {
         if (region_end > total_valid_rows) {
             total_valid_rows = region_end;
         }
+    }
+
+    if (total_valid_rows > max_dispatch_buffer_tokens) {
+        total_valid_rows = max_dispatch_buffer_tokens;
     }
 
     // Balanced split over the FLATTENED compute-block space (identical formula to the reader), so the

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_back/device/per_token_cast_back_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_back/device/per_token_cast_back_device_operation.cpp
@@ -81,6 +81,22 @@ void PerTokenCastBackDeviceOperation::validate_on_program_cache_miss(
         validate_index_tensor(*expert_region_offsets, "per_token_cast_back: expert_region_offsets");
         validate_index_tensor(*expert_token_counts, "per_token_cast_back: expert_token_counts");
         validate_index_tensor(*global_expert_idx_table, "per_token_cast_back: global_expert_idx_table");
+        // The kernels run on input_e4m3's device and read the metadata buffers by raw address, so all three
+        // must live on that same device (a cross-device buffer would be read as an unrelated local address).
+        auto* input_device = input_e4m3.device();
+        TT_FATAL(
+            expert_region_offsets->device() == input_device && expert_token_counts->device() == input_device &&
+                global_expert_idx_table->device() == input_device,
+            "per_token_cast_back: expert_region_offsets, expert_token_counts and global_expert_idx_table must be on "
+            "the same device as input_e4m3");
+        // The kernels index both region offsets and token counts by the same global expert id (bounded by
+        // num_routed_experts = expert_region_offsets last dim), so the two vectors must be the same length;
+        // a shorter counts vector would read past its L1 scratch.
+        TT_FATAL(
+            expert_token_counts->logical_shape()[-1] == expert_region_offsets->logical_shape()[-1],
+            "per_token_cast_back: expert_token_counts last dim ({}) must equal expert_region_offsets last dim ({})",
+            expert_token_counts->logical_shape()[-1],
+            expert_region_offsets->logical_shape()[-1]);
         TT_FATAL(attrs.experts_per_chip > 0, "per_token_cast_back: experts_per_chip must be > 0");
         TT_FATAL(
             attrs.experts_per_chip <= global_expert_idx_table->logical_shape()[-1],
@@ -212,29 +228,19 @@ PerTokenCastBackDeviceOperation::tensor_return_value_t PerTokenCastBackDeviceOpe
 
 ttsl::hash::hash_t PerTokenCastBackDeviceOperation::compute_program_hash(
     const operation_attributes_t& attrs, const tensor_args_t& tensor_args) {
-    const auto tile_shape = tensor_args.input_e4m3.tensor_spec().tile().get_tile_shape();
-    const auto face_shape = tensor_args.input_e4m3.tensor_spec().tile().get_face_shape();
-    // Token-count-aware metadata tensors, when present, contribute their memory configs. Their absence
-    // (plain path) is already distinguished by attrs.token_count_aware, which hash_operation folds in via `attrs`.
-    const auto opt_mem_config = [](const std::optional<Tensor>& t) {
-        return t.has_value() ? std::optional<tt::tt_metal::MemoryConfig>(t->memory_config()) : std::nullopt;
+    // Hash each tensor's full TensorSpec (shape + dtype + layout + tile + memory config) rather than
+    // cherry-picking fields, so nothing that changes program structure is missed. The token-count-aware
+    // metadata tensors are optional (absent on the plain path, which attrs.token_count_aware distinguishes).
+    const auto opt_spec = [](const std::optional<Tensor>& t) {
+        return t.has_value() ? std::optional<tt::tt_metal::TensorSpec>(t->tensor_spec()) : std::nullopt;
     };
     return tt::tt_metal::operation::hash_operation<PerTokenCastBackDeviceOperation>(
         attrs,
-        tensor_args.input_e4m3.dtype(),
-        // Scale source dtype (fp32 vs int32/uint32 metadata) affects the reader.
-        tensor_args.input_scale.dtype(),
-        tensor_args.input_e4m3.memory_config(),
-        tensor_args.input_scale.memory_config(),
-        opt_mem_config(tensor_args.expert_region_offsets),
-        opt_mem_config(tensor_args.expert_token_counts),
-        opt_mem_config(tensor_args.global_expert_idx_table),
-        tensor_args.input_e4m3.logical_shape(),
-        tensor_args.input_scale.logical_shape(),
-        tile_shape[0],
-        tile_shape[1],
-        face_shape[0],
-        face_shape[1]);
+        tensor_args.input_e4m3.tensor_spec(),
+        tensor_args.input_scale.tensor_spec(),
+        opt_spec(tensor_args.expert_region_offsets),
+        opt_spec(tensor_args.expert_token_counts),
+        opt_spec(tensor_args.global_expert_idx_table));
 }
 
 }  // namespace ttnn::experimental::prim::per_token_cast_back

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_back/device/per_token_cast_back_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_back/device/per_token_cast_back_device_operation.cpp
@@ -30,6 +30,16 @@ void validate_tensor_specs(const Tensor& tensor, const std::string& name) {
     TT_FATAL(is_dram_interleaved(tensor.memory_config()), "{} must be DRAM interleaved", name);
 }
 
+void validate_index_tensor(const Tensor& tensor, const std::string& name) {
+    validate_tensor_specs(tensor, name);
+    TT_FATAL(tensor.dtype() == tt::tt_metal::DataType::UINT32, "{} must be UINT32, got {}", name, tensor.dtype());
+    const auto& shape = tensor.logical_shape();
+    const auto rank = shape.rank();
+    const bool valid_1d = rank == 1;
+    const bool valid_2d = rank == 2 && shape[0] == 1;
+    TT_FATAL(valid_1d || valid_2d, "{} must be 1D or 2D with first dimension == 1, got shape {}", name, shape);
+}
+
 }  // namespace
 
 PerTokenCastBackDeviceOperation::program_factory_t PerTokenCastBackDeviceOperation::select_program_factory(
@@ -41,6 +51,8 @@ void PerTokenCastBackDeviceOperation::validate_on_program_cache_miss(
     const operation_attributes_t& attrs, const tensor_args_t& tensor_args) {
     const auto& input_e4m3 = tensor_args.input_e4m3;
     const auto& input_scale = tensor_args.input_scale;
+    const bool token_count_aware = attrs.token_count_aware;
+    const bool scales_from_metadata = attrs.scales_from_metadata;
 
     validate_tensor_specs(input_e4m3, "per_token_cast_back: input_e4m3");
     validate_tensor_specs(input_scale, "per_token_cast_back: input_scale");
@@ -57,9 +69,48 @@ void PerTokenCastBackDeviceOperation::validate_on_program_cache_miss(
     TT_FATAL(
         input_e4m3.dtype() == tt::tt_metal::DataType::FP8_E4M3,
         "per_token_cast_back: input_e4m3 dtype must be FP8_E4M3");
-    TT_FATAL(
-        input_scale.dtype() == tt::tt_metal::DataType::FLOAT32,
-        "per_token_cast_back: input_scale dtype must be FLOAT32");
+
+    if (token_count_aware) {
+        const auto& expert_region_offsets = tensor_args.expert_region_offsets;
+        const auto& expert_token_counts = tensor_args.expert_token_counts;
+        const auto& global_expert_idx_table = tensor_args.global_expert_idx_table;
+        TT_FATAL(
+            expert_region_offsets.has_value() && expert_token_counts.has_value() && global_expert_idx_table.has_value(),
+            "per_token_cast_back: token_count_aware path requires expert_region_offsets, expert_token_counts and "
+            "global_expert_idx_table");
+        validate_index_tensor(*expert_region_offsets, "per_token_cast_back: expert_region_offsets");
+        validate_index_tensor(*expert_token_counts, "per_token_cast_back: expert_token_counts");
+        validate_index_tensor(*global_expert_idx_table, "per_token_cast_back: global_expert_idx_table");
+        TT_FATAL(attrs.experts_per_chip > 0, "per_token_cast_back: experts_per_chip must be > 0");
+        TT_FATAL(
+            attrs.experts_per_chip <= global_expert_idx_table->logical_shape()[-1],
+            "per_token_cast_back: experts_per_chip ({}) must be <= global_expert_idx_table last dim ({})",
+            attrs.experts_per_chip,
+            global_expert_idx_table->logical_shape()[-1]);
+        // Scale source dtype: scales are always fp32. The plain scale path requires FLOAT32; the metadata
+        // path carries the fp32 scales bit-stored in the int32 metadata tail, so UINT32/INT32 are accepted there.
+        if (scales_from_metadata) {
+            const auto sdt = input_scale.dtype();
+            TT_FATAL(
+                sdt == tt::tt_metal::DataType::FLOAT32 || sdt == tt::tt_metal::DataType::UINT32 ||
+                    sdt == tt::tt_metal::DataType::INT32,
+                "per_token_cast_back: metadata scale source dtype must be FLOAT32/UINT32/INT32, got {}",
+                sdt);
+        } else {
+            TT_FATAL(
+                input_scale.dtype() == tt::tt_metal::DataType::FLOAT32,
+                "per_token_cast_back: input_scale dtype must be FLOAT32, got {}",
+                input_scale.dtype());
+        }
+    } else {
+        TT_FATAL(
+            !attrs.scales_from_metadata,
+            "per_token_cast_back: scales_from_metadata is only valid on the token_count_aware path");
+        TT_FATAL(
+            input_scale.dtype() == tt::tt_metal::DataType::FLOAT32,
+            "per_token_cast_back: input_scale dtype must be FLOAT32");
+    }
+
     const auto tile_shape = input_e4m3.tensor_spec().tile().get_tile_shape();
     const uint32_t tile_h = tile_shape[0];
     const uint32_t tile_w = tile_shape[1];
@@ -101,14 +152,30 @@ void PerTokenCastBackDeviceOperation::validate_on_program_cache_miss(
 
     const uint32_t H = static_cast<uint32_t>(e4m3_shape[-1]);
     const uint32_t H_scale = static_cast<uint32_t>(scale_shape[-1]);
-    // M and H are arbitrary (the kernels zero-pad the partial last tile-row / column-block). The
-    // e4m3 width must equal scale_width * 128, which keeps H a multiple of the block width.
-    TT_FATAL(
-        H == H_scale * fp8::BLOCK_W,
-        "per_token_cast_back: e4m3 last dim ({}) must equal scale last dim ({}) * BLOCK_W ({})",
-        H,
-        H_scale,
-        fp8::BLOCK_W);
+    if (token_count_aware && scales_from_metadata) {
+        // Metadata row = [routing fields ...][H/BLOCK_W fp32 scales]. Require H % BLOCK_W == 0 and that the
+        // row is wide enough to hold the H/BLOCK_W scale tail after the leading routing columns.
+        TT_FATAL(
+            H % fp8::BLOCK_W == 0,
+            "per_token_cast_back: e4m3 last dim ({}) must be a multiple of BLOCK_W ({})",
+            H,
+            fp8::BLOCK_W);
+        const uint32_t blocks_per_row = H / fp8::BLOCK_W;
+        TT_FATAL(
+            H_scale >= blocks_per_row,
+            "per_token_cast_back: metadata last dim ({}) must be >= H/BLOCK_W ({}) to hold the scale tail",
+            H_scale,
+            blocks_per_row);
+    } else {
+        // M and H are arbitrary (the kernels zero-pad the partial last tile-row / column-block). The
+        // e4m3 width must equal scale_width * 128, which keeps H a multiple of the block width.
+        TT_FATAL(
+            H == H_scale * fp8::BLOCK_W,
+            "per_token_cast_back: e4m3 last dim ({}) must equal scale last dim ({}) * BLOCK_W ({})",
+            H,
+            H_scale,
+            fp8::BLOCK_W);
+    }
 
     uint64_t folded_M = 1;
     for (size_t i = 0; i + 1 < rank; ++i) {
@@ -147,11 +214,21 @@ ttsl::hash::hash_t PerTokenCastBackDeviceOperation::compute_program_hash(
     const operation_attributes_t& attrs, const tensor_args_t& tensor_args) {
     const auto tile_shape = tensor_args.input_e4m3.tensor_spec().tile().get_tile_shape();
     const auto face_shape = tensor_args.input_e4m3.tensor_spec().tile().get_face_shape();
+    // Token-count-aware metadata tensors, when present, contribute their memory configs. Their absence
+    // (plain path) is already distinguished by attrs.token_count_aware, which hash_operation folds in via `attrs`.
+    const auto opt_mem_config = [](const std::optional<Tensor>& t) {
+        return t.has_value() ? std::optional<tt::tt_metal::MemoryConfig>(t->memory_config()) : std::nullopt;
+    };
     return tt::tt_metal::operation::hash_operation<PerTokenCastBackDeviceOperation>(
         attrs,
         tensor_args.input_e4m3.dtype(),
+        // Scale source dtype (fp32 vs int32/uint32 metadata) affects the reader.
+        tensor_args.input_scale.dtype(),
         tensor_args.input_e4m3.memory_config(),
         tensor_args.input_scale.memory_config(),
+        opt_mem_config(tensor_args.expert_region_offsets),
+        opt_mem_config(tensor_args.expert_token_counts),
+        opt_mem_config(tensor_args.global_expert_idx_table),
         tensor_args.input_e4m3.logical_shape(),
         tensor_args.input_scale.logical_shape(),
         tile_shape[0],
@@ -168,11 +245,26 @@ ttnn::Tensor per_token_cast_back(
     const Tensor& input_e4m3,
     const Tensor& input_scale,
     tt::tt_metal::DataType output_dtype,
-    const tt::tt_metal::MemoryConfig& output_memory_config) {
+    const tt::tt_metal::MemoryConfig& output_memory_config,
+    bool token_count_aware,
+    const std::optional<Tensor>& expert_region_offsets,
+    const std::optional<Tensor>& expert_token_counts,
+    const std::optional<Tensor>& global_expert_idx_table,
+    uint32_t experts_per_chip,
+    bool scales_from_metadata) {
     using OperationType = ttnn::experimental::prim::per_token_cast_back::PerTokenCastBackDeviceOperation;
     auto operation_attributes = OperationType::operation_attributes_t{
-        .output_dtype = output_dtype, .output_memory_config = output_memory_config};
-    auto tensor_args = OperationType::tensor_args_t{.input_e4m3 = input_e4m3, .input_scale = input_scale};
+        .output_dtype = output_dtype,
+        .output_memory_config = output_memory_config,
+        .token_count_aware = token_count_aware,
+        .experts_per_chip = experts_per_chip,
+        .scales_from_metadata = scales_from_metadata};
+    auto tensor_args = OperationType::tensor_args_t{
+        .input_e4m3 = input_e4m3,
+        .input_scale = input_scale,
+        .expert_region_offsets = expert_region_offsets,
+        .expert_token_counts = expert_token_counts,
+        .global_expert_idx_table = global_expert_idx_table};
     return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_back/device/per_token_cast_back_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_back/device/per_token_cast_back_device_operation.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <cstdint>
+#include <optional>
 #include <variant>
 
 #include "per_token_cast_back_device_operation_types.hpp"
@@ -17,6 +19,8 @@ struct PerTokenCastBackDeviceOperation {
     using tensor_args_t = PerTokenCastBackInputs;
     using spec_return_value_t = tt::tt_metal::TensorSpec;
     using tensor_return_value_t = Tensor;
+    // A single program factory serves both the plain and the masked (token-count-aware) paths; it
+    // branches internally on operation_attributes.masked (kernels are shared, toggled by a MASKED define).
     using program_factory_t = std::variant<PerTokenCastBackProgramFactory>;
 
     static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
@@ -30,9 +34,18 @@ struct PerTokenCastBackDeviceOperation {
 }  // namespace ttnn::experimental::prim::per_token_cast_back
 
 namespace ttnn::prim {
+// Single decompression entry point. token_count_aware == false runs the plain whole-buffer path; when
+// true, only the valid contiguously-packed prefix of the dispatch buffer is dequantized (the row range
+// is derived on-device from the per-expert counts / region offsets in the expert_* tensors).
 ttnn::Tensor per_token_cast_back(
     const Tensor& input_e4m3,
     const Tensor& input_scale,
     tt::tt_metal::DataType output_dtype,
-    const tt::tt_metal::MemoryConfig& output_memory_config);
+    const tt::tt_metal::MemoryConfig& output_memory_config,
+    bool token_count_aware = false,
+    const std::optional<Tensor>& expert_region_offsets = std::nullopt,
+    const std::optional<Tensor>& expert_token_counts = std::nullopt,
+    const std::optional<Tensor>& global_expert_idx_table = std::nullopt,
+    uint32_t experts_per_chip = 0,
+    bool scales_from_metadata = false);
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_back/device/per_token_cast_back_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_back/device/per_token_cast_back_device_operation.hpp
@@ -19,8 +19,9 @@ struct PerTokenCastBackDeviceOperation {
     using tensor_args_t = PerTokenCastBackInputs;
     using spec_return_value_t = tt::tt_metal::TensorSpec;
     using tensor_return_value_t = Tensor;
-    // A single program factory serves both the plain and the masked (token-count-aware) paths; it
-    // branches internally on operation_attributes.masked (kernels are shared, toggled by a MASKED define).
+    // A single program factory serves both the plain and the token-count-aware paths; it branches
+    // internally on operation_attributes.token_count_aware (kernels are shared, toggled by a
+    // TOKEN_COUNT_AWARE define).
     using program_factory_t = std::variant<PerTokenCastBackProgramFactory>;
 
     static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_back/device/per_token_cast_back_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_back/device/per_token_cast_back_device_operation_types.hpp
@@ -4,6 +4,9 @@
 
 #pragma once
 
+#include <cstdint>
+#include <optional>
+
 #include "ttnn/tensor/tensor.hpp"
 
 namespace ttnn::experimental::prim::per_token_cast_back {
@@ -11,11 +14,24 @@ namespace ttnn::experimental::prim::per_token_cast_back {
 struct PerTokenCastBackParams {
     tt::tt_metal::DataType output_dtype;
     tt::tt_metal::MemoryConfig output_memory_config;
+
+    bool token_count_aware = false;
+    // Number of local experts hosted on this chip (token-count-aware path only).
+    uint32_t experts_per_chip = 0;
+    // When true, `input_scale` is the dispatch metadata tensor: per-token fp32 scales are read from its
+    // row tail (bit-stored as int32) instead of a plain FLOAT32 (M, H/128) scale tensor.
+    bool scales_from_metadata = false;
 };
 
 struct PerTokenCastBackInputs {
     const Tensor& input_e4m3;
+    // Plain path: FLOAT32 (M, H/128) scale tensor. Token-count-aware metadata path: the int32/uint32
+    // dispatch metadata tensor whose row tail holds the per-token fp32 scales.
     const Tensor& input_scale;
+    // Token-count-aware path only: per-expert region offsets / token counts / global-expert-idx table (UINT32).
+    std::optional<Tensor> expert_region_offsets;
+    std::optional<Tensor> expert_token_counts;
+    std::optional<Tensor> global_expert_idx_table;
 };
 
 }  // namespace ttnn::experimental::prim::per_token_cast_back

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_back/device/per_token_cast_back_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_back/device/per_token_cast_back_program_factory.cpp
@@ -399,7 +399,7 @@ PerTokenCastBackProgramFactory::cached_program_t PerTokenCastBackProgramFactory:
 
 void PerTokenCastBackProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
-    const PerTokenCastBackParams& /*operation_attributes*/,
+    const PerTokenCastBackParams& operation_attributes,
     const PerTokenCastBackInputs& tensor_args,
     Tensor& tensor_return_value) {
     auto& program = cached_program.program;
@@ -408,7 +408,7 @@ void PerTokenCastBackProgramFactory::override_runtime_arguments(
     uint32_t src_e4m3_addr = tensor_args.input_e4m3.buffer()->address();
     uint32_t src_scale_addr = tensor_args.input_scale.buffer()->address();
     uint32_t dst_addr = tensor_return_value.buffer()->address();
-    const bool token_count_aware = tensor_args.expert_region_offsets.has_value();
+    const bool token_count_aware = operation_attributes.token_count_aware;
 
     if (token_count_aware) {
         const uint32_t region_addr = tensor_args.expert_region_offsets->buffer()->address();

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_back/device/per_token_cast_back_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_back/device/per_token_cast_back_program_factory.cpp
@@ -98,7 +98,7 @@ PerTokenCastBackProgramFactory::cached_program_t PerTokenCastBackProgramFactory:
     const uint32_t out_tile_bytes = tile_h * tile_w * out_elem_bytes;  // cb_out page = one output tile
     const uint32_t scale_aligned_page_bytes = input_scale.buffer()->aligned_page_size();
 
-    // Masked-only metadata tensors (unset on the plain path).
+    // Token-count-aware-only metadata tensors (unset on the plain path).
     const Tensor* expert_region_offsets = token_count_aware ? &tensor_args.expert_region_offsets.value() : nullptr;
     const Tensor* expert_token_counts = token_count_aware ? &tensor_args.expert_token_counts.value() : nullptr;
     const Tensor* global_expert_idx_table = token_count_aware ? &tensor_args.global_expert_idx_table.value() : nullptr;

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_back/device/per_token_cast_back_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_back/device/per_token_cast_back_program_factory.cpp
@@ -4,11 +4,15 @@
 
 #include "per_token_cast_back_program_factory.hpp"
 
+#include <tuple>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/math.hpp>
+#include <tt-metalium/circular_buffer_constants.h>
+#include <tt-metalium/hal.hpp>
+#include <tt-metalium/tt_align.hpp>
 
 #include "ttnn/operations/experimental/deepseek_prefill/per_token_cast_to_fp8/per_token_cast_to_fp8.hpp"
 
@@ -16,6 +20,13 @@
 // Implementation requires row-major inputs and outputs.
 // Internally, it relies on intermediate CBs for tilization / untilization, as well as for conversion.
 // To efficiently perform this tilization, we use a block-based approach with a [32, 128] circular buffer ( = 4 tiles).
+//
+// Two paths share this single program factory (and, via a TOKEN_COUNT_AWARE compile-time define, the same reader /
+// writer / compute kernels):
+//   * plain  (operation_attributes.token_count_aware == false): dequantize the whole [M, H] buffer; the rows are
+//            split across the grid host-side (split_work_to_cores).
+//   * token_count_aware (== true): from the per-expert token counts, each core works out on-device how
+//            many rows of the buffer are valid and dequantizes only that leading part of the tensor.
 
 namespace ttnn::experimental::prim::per_token_cast_back {
 
@@ -55,6 +66,8 @@ PerTokenCastBackProgramFactory::cached_program_t PerTokenCastBackProgramFactory:
     using namespace tt;
     using namespace tt::tt_metal;
 
+    const bool token_count_aware = operation_attributes.token_count_aware;
+
     const auto& input_e4m3 = tensor_args.input_e4m3;
     const auto& input_scale = tensor_args.input_scale;
     auto& output = tensor_return_value;
@@ -74,7 +87,6 @@ PerTokenCastBackProgramFactory::cached_program_t PerTokenCastBackProgramFactory:
     // pages, and the reader fills the [tile_h x 128] block as one contiguous run.
     constexpr uint32_t block_w = fp8::BLOCK_W;  // BlockW: 128 elements
 
-    const uint32_t TILE_BYTES = tile_h * tile_w * sizeof(float);
     const uint32_t block_wt = block_w / tile_w;  // BlockWt: tiles across the 128-wide block
     constexpr uint32_t block_ht = 1;             // BlockHt: one tile-height batch
     const uint32_t tiles_per_block = block_ht * block_wt;
@@ -86,30 +98,77 @@ PerTokenCastBackProgramFactory::cached_program_t PerTokenCastBackProgramFactory:
     const uint32_t out_tile_bytes = tile_h * tile_w * out_elem_bytes;  // cb_out page = one output tile
     const uint32_t scale_aligned_page_bytes = input_scale.buffer()->aligned_page_size();
 
+    // Masked-only metadata tensors (unset on the plain path).
+    const Tensor* expert_region_offsets = token_count_aware ? &tensor_args.expert_region_offsets.value() : nullptr;
+    const Tensor* expert_token_counts = token_count_aware ? &tensor_args.expert_token_counts.value() : nullptr;
+    const Tensor* global_expert_idx_table = token_count_aware ? &tensor_args.global_expert_idx_table.value() : nullptr;
+
+    // Length of the region/counts vectors; the token_count_aware kernels assert every table entry stays within it.
+    const uint32_t num_routed_experts =
+        token_count_aware ? static_cast<uint32_t>(expert_region_offsets->logical_shape()[-1]) : 0;
+
+    // Offset (in elements) from the start of each metadata entry to that token's H/128 scales.
+    // Plain scale tensor -> 0. Metadata entry -> skip the leading routing header:
+    //   entry = [ x x x s1 s2 ... sn ]   (x = routing data, not ours; s = scales)
+    //   scales_start_offset = scale_entry_length - scales_per_token   (n scales in the tail)
+    const uint32_t scales_per_token = H / block_w;  // H/128
+    const uint32_t scale_entry_length = static_cast<uint32_t>(input_scale.logical_shape()[-1]);
+    const uint32_t scales_start_offset =
+        (token_count_aware && operation_attributes.scales_from_metadata) ? (scale_entry_length - scales_per_token) : 0;
+
+    // The whole datapath is fp32; the scale is always fp32 (plain fp32 tensor or the int32-backed metadata tail).
+    const uint32_t TILE_BYTES = tile_h * tile_w * sizeof(float);
+    const DataFormat fp8_df = DataFormat::Fp8_e4m3;
+    const DataFormat fp32_df = DataFormat::Float32;
+    const DataFormat output_df = datatype_to_dataformat_converter(operation_attributes.output_dtype);
+
     auto* src_e4m3_buffer = input_e4m3.buffer();
     auto* src_scale_buffer = input_scale.buffer();
     auto* dst_buffer = output.buffer();
+    auto* region_buffer = token_count_aware ? expert_region_offsets->buffer() : nullptr;
+    auto* counts_buffer = token_count_aware ? expert_token_counts->buffer() : nullptr;
+    auto* table_buffer = token_count_aware ? global_expert_idx_table->buffer() : nullptr;
 
     Program program{};
 
     auto* device = input_e4m3.device();
     auto compute_grid = device->compute_with_storage_grid_size();
-    // Split on rows (not tile-rows) so horizontal tensors (small M, large H) use the whole grid;
-    // the op is DRAM/NoC-bound, so spreading rows across more cores spreads the data movement. Each
-    // core's contiguous row range need not be tile-aligned (kernels address by absolute DRAM page).
-    auto [num_cores, all_cores, core_range_set_1, core_range_set_2, rows_per_core_g1, rows_per_core_g2] =
-        split_work_to_cores(compute_grid, M);
 
-    const DataFormat fp8_df = DataFormat::Fp8_e4m3;
-    const DataFormat fp32_df = DataFormat::Float32;
-    const DataFormat output_df = datatype_to_dataformat_converter(operation_attributes.output_dtype);
+    // Split the work across the cores.
+    uint32_t num_cores = 0;
+    CoreRangeSet all_cores;
+    CoreRangeSet core_range_set_1;
+    CoreRangeSet core_range_set_2;
+    uint32_t rows_per_core_g1 = 0;
+    uint32_t rows_per_core_g2 = 0;
+    if (token_count_aware) {
+        // Light up the whole grid; the host commits no per-core work here. Each core decides at runtime,
+        // while the kernels run, how much of the work it takes on (from the device-side token counts).
+        num_cores = compute_grid.x * compute_grid.y;
+        all_cores = CoreRangeSet{CoreRange{{0, 0}, {compute_grid.x - 1, compute_grid.y - 1}}};
+    } else {
+        // Split on rows (not tile-rows) so horizontal tensors (small M, large H) use the whole grid;
+        // the op is DRAM/NoC-bound, so spreading rows across more cores spreads the data movement. Each
+        // core's contiguous row range need not be tile-aligned (kernels address by absolute DRAM page).
+        // std::tie unpacks the returned tuple into these already-declared variables (a structured
+        // binding `auto [...]` can only declare fresh ones, not assign existing).
+        std::tie(num_cores, all_cores, core_range_set_1, core_range_set_2, rows_per_core_g1, rows_per_core_g2) =
+            split_work_to_cores(compute_grid, M);
+    }
 
     constexpr uint32_t cb_input_e4m3_idx = CBIndex::c_0;
     constexpr uint32_t cb_in_rm_idx = CBIndex::c_1;
     constexpr uint32_t cb_in_tile_idx = CBIndex::c_2;
+    constexpr uint32_t cb_loop_count_idx = CBIndex::c_3;  // token_count_aware: reader -> compute num_blocks mailbox
     constexpr uint32_t cb_scale_bcast_idx = CBIndex::c_4;
     constexpr uint32_t cb_out_tile_idx = CBIndex::c_5;
     constexpr uint32_t cb_scale_scratch_idx = CBIndex::c_6;
+    constexpr uint32_t cb_region_scratch_r_idx = CBIndex::c_7;   // token_count_aware only
+    constexpr uint32_t cb_counts_scratch_r_idx = CBIndex::c_8;   // token_count_aware only
+    constexpr uint32_t cb_table_scratch_r_idx = CBIndex::c_9;    // token_count_aware only
+    constexpr uint32_t cb_region_scratch_w_idx = CBIndex::c_10;  // token_count_aware only
+    constexpr uint32_t cb_counts_scratch_w_idx = CBIndex::c_11;  // token_count_aware only
+    constexpr uint32_t cb_table_scratch_w_idx = CBIndex::c_12;   // token_count_aware only
     constexpr uint32_t cb_out_idx = CBIndex::c_16;
 
     auto make_fp32_tile_cb = [&](uint32_t cb_idx, uint32_t num_tiles) {
@@ -118,7 +177,7 @@ PerTokenCastBackProgramFactory::cached_program_t PerTokenCastBackProgramFactory:
         CreateCircularBuffer(program, all_cores, cfg);
     };
 
-    // cb_input_e4m3: input_e4m3, one tile per page; tiles_per_block pages = one block,
+    // cb_input_e4m3: input_e4m3, one tile per page; tiles_per_block pages = one block, double-buffered.
     // double-buffered. The reader fills the [tile_h x 128] block contiguously across these pages.
     CircularBufferConfig cb_input_e4m3_cfg =
         CircularBufferConfig(2 * tiles_per_block * input_e4m3_tile_bytes, {{cb_input_e4m3_idx, fp8_df}})
@@ -144,7 +203,45 @@ PerTokenCastBackProgramFactory::cached_program_t PerTokenCastBackProgramFactory:
             .set_page_size(cb_scale_scratch_idx, scale_scratch_bytes);
     CreateCircularBuffer(program, all_cores, cb_scale_scratch_cfg);
 
-    // Reader (RISCV_1): input_e4m3 blocks + builds column-0 scale broadcast operands.
+    uint32_t region_aligned_page_bytes = 0;
+    uint32_t counts_aligned_page_bytes = 0;
+    uint32_t table_aligned_page_bytes = 0;
+    if (token_count_aware) {
+        region_aligned_page_bytes = region_buffer->aligned_page_size();
+        counts_aligned_page_bytes = counts_buffer->aligned_page_size();
+        table_aligned_page_bytes = table_buffer->aligned_page_size();
+
+        const DataFormat idx_df = datatype_to_dataformat_converter(expert_token_counts->dtype());
+        auto make_index_scratch_cb = [&](uint32_t cb_idx, uint32_t page_bytes) {
+            CircularBufferConfig cfg =
+                CircularBufferConfig(page_bytes, {{cb_idx, idx_df}}).set_page_size(cb_idx, page_bytes);
+            CreateCircularBuffer(program, all_cores, cfg);
+        };
+
+        // cb_loop_count: reader -> compute mailbox for the device-computed num_blocks (see read_tile_value).
+        // one uint32 (num_blocks), rounded up to the L1 alignment
+        const uint32_t loop_count_page_bytes = tt::align(sizeof(uint32_t), hal::get_l1_alignment());
+        CircularBufferConfig cb_loop_count_cfg =
+            CircularBufferConfig(loop_count_page_bytes, {{cb_loop_count_idx, fp32_df}})
+                .set_page_size(cb_loop_count_idx, loop_count_page_bytes);
+        CreateCircularBuffer(program, all_cores, cb_loop_count_cfg);
+
+        // Per-kernel private scratch for the three metadata vectors (reader and writer each read them).
+        make_index_scratch_cb(cb_region_scratch_r_idx, region_aligned_page_bytes);
+        make_index_scratch_cb(cb_counts_scratch_r_idx, counts_aligned_page_bytes);
+        make_index_scratch_cb(cb_table_scratch_r_idx, table_aligned_page_bytes);
+        make_index_scratch_cb(cb_region_scratch_w_idx, region_aligned_page_bytes);
+        make_index_scratch_cb(cb_counts_scratch_w_idx, counts_aligned_page_bytes);
+        make_index_scratch_cb(cb_table_scratch_w_idx, table_aligned_page_bytes);
+    }
+
+    const std::map<std::string, std::string> token_count_aware_defines =
+        token_count_aware ? std::map<std::string, std::string>{{"TOKEN_COUNT_AWARE", "1"}}
+                          : std::map<std::string, std::string>{};
+
+    // Reader (RISCV_1): input_e4m3 blocks + builds the column-0 scale broadcast operands. On the token_count_aware
+    // path it first works out how many compute-blocks it must process, then publishes that count (num_blocks) to
+    // compute.
     std::vector<uint32_t> reader_ct_args = {
         cb_input_e4m3_idx,
         cb_scale_bcast_idx,
@@ -156,28 +253,70 @@ PerTokenCastBackProgramFactory::cached_program_t PerTokenCastBackProgramFactory:
         tile_w,
         face_h,
         face_w};
+    if (token_count_aware) {
+        reader_ct_args.insert(
+            reader_ct_args.end(),
+            {cb_loop_count_idx,
+             cb_region_scratch_r_idx,
+             cb_counts_scratch_r_idx,
+             cb_table_scratch_r_idx,
+             num_cores,
+             operation_attributes.experts_per_chip,
+             scales_start_offset,
+             num_routed_experts,
+             M});
+    }
     TensorAccessorArgs(src_e4m3_buffer).append_to(reader_ct_args);
     TensorAccessorArgs(src_scale_buffer).append_to(reader_ct_args);
+    if (token_count_aware) {
+        TensorAccessorArgs(region_buffer).append_to(reader_ct_args);
+        TensorAccessorArgs(counts_buffer).append_to(reader_ct_args);
+        TensorAccessorArgs(table_buffer).append_to(reader_ct_args);
+    }
     KernelHandle reader_kernel_id = CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_back/device/kernels/dataflow/"
         "reader_per_token_cast_back.cpp",
         all_cores,
         DataMovementConfig{
-            .processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default, .compile_args = reader_ct_args});
+            .processor = DataMovementProcessor::RISCV_1,
+            .noc = NOC::RISCV_1_default,
+            .compile_args = reader_ct_args,
+            .defines = token_count_aware_defines});
 
-    // Writer (RISCV_0): column-block-major writes of the row-major output.
+    // Writer (RISCV_0): column-block-major writes of the row-major output. On the token_count_aware path it derives
+    // the same slice as the reader (identical (core_id, num_cores) formula).
     std::vector<uint32_t> writer_ct_args = {cb_out_idx, out_block_bytes, tile_h, tiles_per_block};
+    if (token_count_aware) {
+        writer_ct_args.insert(
+            writer_ct_args.end(),
+            {cb_region_scratch_w_idx,
+             cb_counts_scratch_w_idx,
+             cb_table_scratch_w_idx,
+             num_cores,
+             operation_attributes.experts_per_chip,
+             num_routed_experts,
+             M});
+    }
     TensorAccessorArgs(dst_buffer).append_to(writer_ct_args);
+    if (token_count_aware) {
+        TensorAccessorArgs(region_buffer).append_to(writer_ct_args);
+        TensorAccessorArgs(counts_buffer).append_to(writer_ct_args);
+        TensorAccessorArgs(table_buffer).append_to(writer_ct_args);
+    }
     KernelHandle writer_kernel_id = CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_back/device/kernels/dataflow/"
         "writer_per_token_cast_back.cpp",
         all_cores,
         DataMovementConfig{
-            .processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default, .compile_args = writer_ct_args});
+            .processor = DataMovementProcessor::RISCV_0,
+            .noc = NOC::RISCV_0_default,
+            .compile_args = writer_ct_args,
+            .defines = token_count_aware_defines});
 
     // Compute (TRISC): input_e4m3 -> fp32 RM -> tilize -> scale bcast multiply -> untilize to output.
+    // Plain: num_blocks arrives as a runtime arg. Token-count-aware: num_blocks arrives via cb_loop_count.
     std::vector<uint32_t> compute_ct_args = {
         cb_input_e4m3_idx,
         cb_in_rm_idx,
@@ -186,7 +325,8 @@ PerTokenCastBackProgramFactory::cached_program_t PerTokenCastBackProgramFactory:
         cb_out_tile_idx,
         cb_out_idx,
         tile_h,
-        tile_w};
+        tile_w,
+        cb_loop_count_idx};
     // fp32_dest_acc_en=True required (input_e4m3 CB on core); HiFi4 (the ComputeConfig default) keeps the
     // broadcast multiply precise.
     KernelHandle compute_kernel_id = CreateKernel(
@@ -194,34 +334,63 @@ PerTokenCastBackProgramFactory::cached_program_t PerTokenCastBackProgramFactory:
         "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_back/device/kernels/compute/"
         "compute_per_token_cast_back.cpp",
         all_cores,
-        ComputeConfig{.fp32_dest_acc_en = true, .compile_args = compute_ct_args});
+        ComputeConfig{.fp32_dest_acc_en = true, .compile_args = compute_ct_args, .defines = token_count_aware_defines});
 
-    // Each core's rows form a flat stream of 128-element scale blocks read/written in tile_h-block batches.
-    const uint32_t scale_blocks_per_row = H / fp8::BLOCK_W;  // H / 128
     auto all_cores_vec = corerange_to_cores(all_cores, num_cores, true);
-    uint32_t row_offset = 0;
-    for (uint32_t i = 0; i < num_cores; ++i) {
-        const auto& core = all_cores_vec[i];
-        const uint32_t rows_for_core =
-            rows_for_core_from_split(core, core_range_set_1, core_range_set_2, rows_per_core_g1, rows_per_core_g2);
-        const uint32_t total_scale_blocks = rows_for_core * scale_blocks_per_row;
-        const uint32_t num_blocks = tt::div_up(total_scale_blocks, tile_h);  // last block may be partial
+    if (token_count_aware) {
+        for (uint32_t i = 0; i < num_cores; ++i) {
+            const auto& core = all_cores_vec[i];
+            SetRuntimeArgs(
+                program,
+                reader_kernel_id,
+                core,
+                {src_e4m3_buffer->address(),
+                 src_scale_buffer->address(),
+                 region_buffer->address(),
+                 counts_buffer->address(),
+                 table_buffer->address(),
+                 i,
+                 H});
+            SetRuntimeArgs(
+                program,
+                writer_kernel_id,
+                core,
+                {dst_buffer->address(),
+                 region_buffer->address(),
+                 counts_buffer->address(),
+                 table_buffer->address(),
+                 i,
+                 H});
+            // Compute reads num_blocks from the reader via cb_loop_count; no per-core runtime args needed.
+            SetRuntimeArgs(program, compute_kernel_id, core, {});
+        }
+    } else {
+        // Each core's rows form a flat stream of 128-element scale blocks read/written in tile_h-block batches.
+        const uint32_t scale_blocks_per_row = H / fp8::BLOCK_W;  // H / 128
+        uint32_t row_offset = 0;
+        for (uint32_t i = 0; i < num_cores; ++i) {
+            const auto& core = all_cores_vec[i];
+            const uint32_t rows_for_core =
+                rows_for_core_from_split(core, core_range_set_1, core_range_set_2, rows_per_core_g1, rows_per_core_g2);
+            const uint32_t total_scale_blocks = rows_for_core * scale_blocks_per_row;
+            const uint32_t num_blocks = tt::div_up(total_scale_blocks, tile_h);  // last block may be partial
 
-        TT_FATAL(
-            num_blocks == tt::div_up(rows_for_core * scale_blocks_per_row, tile_h),
-            "per_token_cast_back: num_blocks invariant violated on a core");
+            TT_FATAL(
+                num_blocks == tt::div_up(rows_for_core * scale_blocks_per_row, tile_h),
+                "per_token_cast_back: num_blocks invariant violated on a core");
 
-        // Pass num_blocks to the (unchanged) compute as (num_tile_rows = num_blocks, num_col_blocks
-        // = 1) so its for-tr/for-c loop runs exactly num_blocks times.
-        SetRuntimeArgs(
-            program,
-            reader_kernel_id,
-            core,
-            {src_e4m3_buffer->address(), src_scale_buffer->address(), num_blocks, row_offset, rows_for_core, H});
-        SetRuntimeArgs(
-            program, writer_kernel_id, core, {dst_buffer->address(), num_blocks, row_offset, rows_for_core, H});
-        SetRuntimeArgs(program, compute_kernel_id, core, {num_blocks});
-        row_offset += rows_for_core;
+            // Pass num_blocks to the (unchanged) compute as (num_tile_rows = num_blocks, num_col_blocks
+            // = 1) so its for-tr/for-c loop runs exactly num_blocks times.
+            SetRuntimeArgs(
+                program,
+                reader_kernel_id,
+                core,
+                {src_e4m3_buffer->address(), src_scale_buffer->address(), num_blocks, row_offset, rows_for_core, H});
+            SetRuntimeArgs(
+                program, writer_kernel_id, core, {dst_buffer->address(), num_blocks, row_offset, rows_for_core, H});
+            SetRuntimeArgs(program, compute_kernel_id, core, {num_blocks});
+            row_offset += rows_for_core;
+        }
     }
 
     return cached_program_t{
@@ -239,13 +408,34 @@ void PerTokenCastBackProgramFactory::override_runtime_arguments(
     uint32_t src_e4m3_addr = tensor_args.input_e4m3.buffer()->address();
     uint32_t src_scale_addr = tensor_args.input_scale.buffer()->address();
     uint32_t dst_addr = tensor_return_value.buffer()->address();
+    const bool token_count_aware = tensor_args.expert_region_offsets.has_value();
 
-    for (const auto& core : shared.all_cores_vec) {
-        auto& reader_args = tt::tt_metal::GetRuntimeArgs(program, shared.reader_kernel_id, core);
-        reader_args[0] = src_e4m3_addr;
-        reader_args[1] = src_scale_addr;
-        auto& writer_args = tt::tt_metal::GetRuntimeArgs(program, shared.writer_kernel_id, core);
-        writer_args[0] = dst_addr;
+    if (token_count_aware) {
+        const uint32_t region_addr = tensor_args.expert_region_offsets->buffer()->address();
+        const uint32_t counts_addr = tensor_args.expert_token_counts->buffer()->address();
+        const uint32_t table_addr = tensor_args.global_expert_idx_table->buffer()->address();
+        for (const auto& core : shared.all_cores_vec) {
+            auto& reader_args = tt::tt_metal::GetRuntimeArgs(program, shared.reader_kernel_id, core);
+            reader_args[0] = src_e4m3_addr;
+            reader_args[1] = src_scale_addr;
+            reader_args[2] = region_addr;
+            reader_args[3] = counts_addr;
+            reader_args[4] = table_addr;
+
+            auto& writer_args = tt::tt_metal::GetRuntimeArgs(program, shared.writer_kernel_id, core);
+            writer_args[0] = dst_addr;
+            writer_args[1] = region_addr;
+            writer_args[2] = counts_addr;
+            writer_args[3] = table_addr;
+        }
+    } else {
+        for (const auto& core : shared.all_cores_vec) {
+            auto& reader_args = tt::tt_metal::GetRuntimeArgs(program, shared.reader_kernel_id, core);
+            reader_args[0] = src_e4m3_addr;
+            reader_args[1] = src_scale_addr;
+            auto& writer_args = tt::tt_metal::GetRuntimeArgs(program, shared.writer_kernel_id, core);
+            writer_args[0] = dst_addr;
+        }
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_back/per_token_cast_back.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_back/per_token_cast_back.cpp
@@ -3,20 +3,59 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "per_token_cast_back.hpp"
+
+#include <tt_stl/assert.hpp>
 #include "device/per_token_cast_back_device_operation.hpp"
 
 namespace ttnn::operations::experimental::deepseek_prefill::per_token_cast_back {
 
 ttnn::Tensor per_token_cast_back(
     const ttnn::Tensor& input_e4m3,
-    const ttnn::Tensor& input_scale,
+    const std::optional<ttnn::Tensor>& input_scale,
     const std::optional<tt::tt_metal::DataType>& output_dtype,
-    const std::optional<tt::tt_metal::MemoryConfig>& memory_config) {
+    const std::optional<tt::tt_metal::MemoryConfig>& memory_config,
+    bool token_count_aware,
+    const std::optional<ttnn::Tensor>& expert_region_offsets,
+    const std::optional<ttnn::Tensor>& expert_token_counts,
+    const std::optional<ttnn::Tensor>& global_expert_idx_table,
+    uint32_t experts_per_chip,
+    const std::optional<ttnn::Tensor>& metadata) {
+    const auto dtype = output_dtype.value_or(tt::tt_metal::DataType::BFLOAT16);
+    const auto mem_config = memory_config.value_or(input_e4m3.memory_config());
+
+    if (!token_count_aware) {
+        TT_FATAL(
+            input_scale.has_value(),
+            "per_token_cast_back: input_scale is required (unless token_count_aware with metadata)");
+        TT_FATAL(
+            !metadata.has_value() && !expert_region_offsets.has_value() && !expert_token_counts.has_value() &&
+                !global_expert_idx_table.has_value(),
+            "per_token_cast_back: metadata / expert_* tensors are only valid when token_count_aware=true");
+        return ttnn::prim::per_token_cast_back(input_e4m3, *input_scale, dtype, mem_config);
+    }
+
+    // Token-count-aware path. Exactly one scale source: either a plain fp32 (M, H/128) scale tensor, or
+    // the dispatch metadata tensor whose row tail holds the per-token fp32 scales.
+    TT_FATAL(
+        input_scale.has_value() != metadata.has_value(),
+        "per_token_cast_back: provide exactly one of `input_scale` or `metadata`");
+    TT_FATAL(
+        expert_region_offsets.has_value() && expert_token_counts.has_value() && global_expert_idx_table.has_value(),
+        "per_token_cast_back: token_count_aware=true requires expert_region_offsets, expert_token_counts and "
+        "global_expert_idx_table");
+    const bool scales_from_metadata = metadata.has_value();
+    const ttnn::Tensor& scale_source = scales_from_metadata ? *metadata : *input_scale;
     return ttnn::prim::per_token_cast_back(
         input_e4m3,
-        input_scale,
-        output_dtype.value_or(tt::tt_metal::DataType::BFLOAT16),
-        memory_config.value_or(input_e4m3.memory_config()));
+        scale_source,
+        dtype,
+        mem_config,
+        /*token_count_aware=*/true,
+        expert_region_offsets,
+        expert_token_counts,
+        global_expert_idx_table,
+        experts_per_chip,
+        scales_from_metadata);
 }
 
 }  // namespace ttnn::operations::experimental::deepseek_prefill::per_token_cast_back

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_back/per_token_cast_back.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_back/per_token_cast_back.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <optional>
 
 #include "ttnn/tensor/tensor.hpp"
@@ -11,11 +12,28 @@
 
 namespace ttnn::operations::experimental::deepseek_prefill::per_token_cast_back {
 
+// Inverse of per_token_cast_to_fp8: recover a BFLOAT16/FLOAT32 tensor from an FP8_E4M3 tensor and its
+// per-token per-128-block scale (out = decode(e4m3) * scale).
+//
+// token_count_aware selects between two behaviors that share this single op:
+//   * false (default): dequantize the whole [..., M, H] buffer. Only input_scale is used.
+//   * true           : dequantize only the valid, contiguously-packed prefix of a MoE dispatch buffer.
+//                      The valid-row count is derived on-device from the per-expert token counts /
+//                      region offsets, so expert_region_offsets / expert_token_counts /
+//                      global_expert_idx_table / experts_per_chip are required. The scale may be given
+//                      either as input_scale (plain FLOAT32 (M, H/128) tensor) or as `metadata` (the
+//                      int32/uint32 dispatch metadata whose row tail holds the fp32 scales) — exactly one.
 ttnn::Tensor per_token_cast_back(
     const ttnn::Tensor& input_e4m3,
-    const ttnn::Tensor& input_scale,
+    const std::optional<ttnn::Tensor>& input_scale = std::nullopt,
     const std::optional<tt::tt_metal::DataType>& output_dtype = std::nullopt,
-    const std::optional<tt::tt_metal::MemoryConfig>& memory_config = std::nullopt);
+    const std::optional<tt::tt_metal::MemoryConfig>& memory_config = std::nullopt,
+    bool token_count_aware = false,
+    const std::optional<ttnn::Tensor>& expert_region_offsets = std::nullopt,
+    const std::optional<ttnn::Tensor>& expert_token_counts = std::nullopt,
+    const std::optional<ttnn::Tensor>& global_expert_idx_table = std::nullopt,
+    uint32_t experts_per_chip = 0,
+    const std::optional<ttnn::Tensor>& metadata = std::nullopt);
 
 }  // namespace ttnn::operations::experimental::deepseek_prefill::per_token_cast_back
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_back/per_token_cast_back_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_back/per_token_cast_back_nanobind.cpp
@@ -58,15 +58,15 @@ void bind_experimental_per_token_cast_back_operation(nb::module_& mod) {
         )doc",
         &per_token_cast_back,
         nb::arg("input_e4m3").noconvert(),
-        nb::arg("input_scale").noconvert() = std::nullopt,
+        nb::arg("input_scale") = nb::none(),
         nb::arg("output_dtype") = std::nullopt,
         nb::arg("memory_config") = std::nullopt,
         nb::arg("token_count_aware") = false,
-        nb::arg("expert_region_offsets").noconvert() = std::nullopt,
-        nb::arg("expert_token_counts").noconvert() = std::nullopt,
-        nb::arg("global_expert_idx_table").noconvert() = std::nullopt,
+        nb::arg("expert_region_offsets") = nb::none(),
+        nb::arg("expert_token_counts") = nb::none(),
+        nb::arg("global_expert_idx_table") = nb::none(),
         nb::arg("experts_per_chip") = 0,
-        nb::arg("metadata").noconvert() = std::nullopt);
+        nb::arg("metadata") = nb::none());
 }
 
 }  // namespace ttnn::operations::experimental::deepseek_prefill::per_token_cast_back::detail

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_back/per_token_cast_back_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_back/per_token_cast_back_nanobind.cpp
@@ -38,7 +38,7 @@ void bind_experimental_per_token_cast_back_operation(nb::module_& mod) {
                 * :attr:`output_dtype`: BFLOAT16 (default) or FLOAT32.
                 * :attr:`memory_config`: optional DRAM interleaved output memory config
                   (default: same as input_e4m3).
-                * :attr:`token_count_aware`: enable the masked MoE-dispatch prefix path (default False).
+                * :attr:`token_count_aware`: enable the token-count-aware MoE-dispatch prefix path (default False).
                 * :attr:`expert_region_offsets`: UINT32 ROW_MAJOR DRAM interleaved, (1, num_routed_experts).
                   Required when token_count_aware=True.
                 * :attr:`expert_token_counts`: UINT32 ROW_MAJOR DRAM interleaved, (1, num_routed_experts).

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_back/per_token_cast_back_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_back/per_token_cast_back_nanobind.cpp
@@ -19,22 +19,54 @@ void bind_experimental_per_token_cast_back_operation(nb::module_& mod) {
             recover a BFLOAT16/FLOAT32 tensor: out = decode(e4m3) * scale, where each scale applies
             to its 128-element block of the token (the scale's last dim is H/128).
 
+            ``token_count_aware`` selects between two behaviors of this single op:
+
+            * ``False`` (default): dequantize the whole [..., M, H] buffer. Only ``input_scale`` is used.
+            * ``True``: dequantize only the valid, contiguously-packed prefix of a MoE dispatch buffer.
+              The number of valid rows is computed device-side from the per-expert token counts and region
+              offsets, and the work is balanced across the whole Tensix grid (no host<->device sync). The
+              valid prefix length is
+              ``max over local expert slots s of (expert_region_offsets[g] + ceil_tile(expert_token_counts[g]))``
+              where ``g = global_expert_idx_table[s]``; rows beyond it are left untouched (garbage tail).
+
             Args:
                 * :attr:`input_e4m3`: FP8_E4M3 ROW_MAJOR tensor of shape [..., M, H]. Requires
                   H % 128 == 0, DRAM interleaved memory, and Blackhole hardware.
                 * :attr:`input_scale`: FLOAT32 ROW_MAJOR DRAM interleaved tensor of shape [..., M, H/128].
+                  Required on the plain path; on the token-count-aware path provide either this OR
+                  `metadata` (exactly one).
                 * :attr:`output_dtype`: BFLOAT16 (default) or FLOAT32.
                 * :attr:`memory_config`: optional DRAM interleaved output memory config
                   (default: same as input_e4m3).
+                * :attr:`token_count_aware`: enable the masked MoE-dispatch prefix path (default False).
+                * :attr:`expert_region_offsets`: UINT32 ROW_MAJOR DRAM interleaved, (1, num_routed_experts).
+                  Required when token_count_aware=True.
+                * :attr:`expert_token_counts`: UINT32 ROW_MAJOR DRAM interleaved, (1, num_routed_experts).
+                  Required when token_count_aware=True.
+                * :attr:`global_expert_idx_table`: UINT32 ROW_MAJOR DRAM interleaved, (experts_per_chip,).
+                  Required when token_count_aware=True.
+                * :attr:`experts_per_chip`: number of local experts hosted on this device
+                  (token_count_aware=True).
+                * :attr:`metadata`: optional dispatch metadata tensor [..., M, metadata_len] (int32/uint32)
+                  whose row tail (columns [metadata_len - H/128, metadata_len)) holds the per-token fp32
+                  scales bit-stored as int32. When given (token_count_aware=True), scales are read from
+                  here instead of `input_scale`.
 
             Returns:
-                A ROW_MAJOR tensor of the same logical shape as input_e4m3, dtype = output_dtype.
+                A ROW_MAJOR tensor of the same logical shape as input_e4m3, dtype = output_dtype. On the
+                token-count-aware path only the valid prefix rows are written.
         )doc",
         &per_token_cast_back,
         nb::arg("input_e4m3").noconvert(),
-        nb::arg("input_scale").noconvert(),
+        nb::arg("input_scale").noconvert() = std::nullopt,
         nb::arg("output_dtype") = std::nullopt,
-        nb::arg("memory_config") = std::nullopt);
+        nb::arg("memory_config") = std::nullopt,
+        nb::arg("token_count_aware") = false,
+        nb::arg("expert_region_offsets").noconvert() = std::nullopt,
+        nb::arg("expert_token_counts").noconvert() = std::nullopt,
+        nb::arg("global_expert_idx_table").noconvert() = std::nullopt,
+        nb::arg("experts_per_chip") = 0,
+        nb::arg("metadata").noconvert() = std::nullopt);
 }
 
 }  // namespace ttnn::operations::experimental::deepseek_prefill::per_token_cast_back::detail


### PR DESCRIPTION
This PR adds a **token-count-aware** decompression path to the fp8 decompression operator (`per_token_cast_back`), for MoE models.

The MoE dispatch buffer is sized `FULL_ISL * dispatch_buffer_capacity`, so the tensor can be very large — but in practice it is not fully populated: only a leading, contiguously-packed prefix holds real tokens, and the rest is unused garbage. Instead of dequantizing the whole buffer, this path uses the per-expert token counts to work out on-device how many rows are actually valid, and dequantizes only that prefix — skipping the garbage.

It is exposed as a `token_count_aware=True` flag on `per_token_cast_back`, so both paths share one op, one program factory, and one set of kernels.

Example dispatch buffer layout:

```text
|<----------- valid, contiguous prefix  ------>|<---- unused ---->|
+-------------------+-------------------+-----+-----------------------+
| Expert 0 (+ pad)  | Expert 1 (+ pad)  | ... |        Garbage        |
+-------------------+-------------------+-----+-----------------------+
```

where each expert region contains:

```text
| token_0 | token_1 | ... | token_N | padding_to_32 |
```

Previously, `per_token_cast_back` dequantized the entire dispatch buffer, including the unused garbage region. With `token_count_aware=True`, the operator computes the length of the valid prefix from the per-expert token counts and dequantizes only that prefix, skipping the unused portion.

### Performance

Device kernel time on Blackhole (mean of 10 iterations). Hidden size `H = 7168`.
- **Non-masked**: plain decompression of an `[active_tokens, 7168]` buffer (`M = active_tokens`).
- **Masked** (token-count-aware): fixed dispatch buffer of `M = 40960` rows, only `active_tokens` valid rows decompressed.

| Active tokens | Non-masked (µs) | Masked (µs) |
|--------------:|----------------:|------------:|
| 128           |           18.00 |       16.16 |
| 256           |           33.09 |       29.27 |
| 512           |           56.97 |       58.82 |
| 1024          |          116.21 |      111.79 |
| 2048          |          216.63 |      214.99 |

> For reference, decompressing the full `M = 40960` buffer without token-count-awareness takes **4409 µs** — the work the masked path avoids.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nostojic/token_count_aware_decompression)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nostojic/token_count_aware_decompression)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nostojic/token_count_aware_decompression)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nostojic/token_count_aware_decompression)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=nostojic/token_count_aware_decompression)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:nostojic/token_count_aware_decompression)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nostojic/token_count_aware_decompression)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nostojic/token_count_aware_decompression)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nostojic/token_count_aware_decompression)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nostojic/token_count_aware_decompression)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nostojic/token_count_aware_decompression)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nostojic/token_count_aware_decompression)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nostojic/token_count_aware_decompression)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nostojic/token_count_aware_decompression)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nostojic/token_count_aware_decompression)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nostojic/token_count_aware_decompression)