### PR TITLE
[Bug fix] Fix Blackhole E2E QuietBox time budget

### DIFF
--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -299,7 +299,7 @@ models:
     bh_p150b_civ2: 8
     bh_p300: 20
     bh_loudbox: 193
-    bh_quietbox_2: 80
+    bh_quietbox_2: 90
     bh_sc1: 20 # single galaxy MLA chunked prefill
   # Per-tier e2e budgets, consumed by the tiered model pipelines;
   # The plain `e2e` key is used for the non-tiered pipelines (blackhole-e2e, t3000-e2e).


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

Blackhole E2E matrix validation regressed after [#49874](https://github.com/tenstorrent/tt-metal/pull/49874) added `bh-qb2-deepseek-d2d-socket-sync` with a 10-minute `bh_quietbox_2` timeout. That PR was merged, but the corresponding `models.e2e.bh_quietbox_2` budget was left at 80 minutes.

The QuietBox entries therefore total 90 minutes (20 + 60 + 10), causing `load-test-matrix` validation to fail before any test jobs start. Raise the budget to 90 minutes to match the scheduled test set.

### Notes for reviewers

Config-only change. Verified with:

`python3 .github/scripts/utils/verify_time_budget.py tests/pipeline_reorg/blackhole_e2e_tests.yaml .github/time_budget.yaml e2e`