### PR TITLE
[Bug fix] [Quasar] Assert SFPU destination indices

### DIFF
--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_macros.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/llk_math_eltwise_binary_sfpu_macros.h
@@ -11,20 +11,23 @@
 #include "llk_math_eltwise_binary_sfpu.h"
 #include "llk_math_eltwise_binary_sfpu_init.h"
 
-/*
- * Quasar keeps the same macro surface as BH/WH. DST_SYNC and DST_ACCUM are
- * unused until Quasar has an equivalent of get_dest_max_tiles<...>. Binary
- * macro calls are limited to VectorMode::RC for now.
- */
+// Quasar keeps the same macro surface as BH/WH. Binary macro calls are limited
+// to VectorMode::RC for now.
 
 namespace ckernel {
 
-template <DstSync /*DST_SYNC*/, bool /*DST_ACCUM*/>
+template <DstSync DST_SYNC, bool DST_ACCUM>
 inline __attribute__((always_inline)) void _sfpu_binary_check_(
-    [[maybe_unused]] std::uint32_t dst_index_in0,
-    [[maybe_unused]] std::uint32_t dst_index_in1,
-    [[maybe_unused]] std::uint32_t dst_index_out,
-    VectorMode vector_mode) {
+    std::uint32_t dst_index_in0, std::uint32_t dst_index_in1, std::uint32_t dst_index_out, VectorMode vector_mode) {
+    LLK_ASSERT(
+        (dst_index_in0 < trisc::get_dest_max_tiles<DST_SYNC, DST_ACCUM, trisc::DstTileShape::Tile32x32>()),
+        "dst_index_in0 exceeds max dest tiles");
+    LLK_ASSERT(
+        (dst_index_in1 < trisc::get_dest_max_tiles<DST_SYNC, DST_ACCUM, trisc::DstTileShape::Tile32x32>()),
+        "dst_index_in1 exceeds max dest tiles");
+    LLK_ASSERT(
+        (dst_index_out < trisc::get_dest_max_tiles<DST_SYNC, DST_ACCUM, trisc::DstTileShape::Tile32x32>()),
+        "dst_index_out exceeds max dest tiles");
     LLK_ASSERT(vector_mode == VectorMode::RC, "Quasar currently only supports vector mode RC");
 }
 

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/llk_math_eltwise_ternary_sfpu_macros.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/llk_math_eltwise_ternary_sfpu_macros.h
@@ -11,21 +11,30 @@
 #include "llk_math_eltwise_ternary_sfpu.h"
 #include "llk_math_eltwise_ternary_sfpu_init.h"
 
-/*
- * Quasar keeps the same macro surface as BH/WH. DST_SYNC and DST_ACCUM are
- * unused until Quasar has an equivalent of get_dest_max_tiles<...>. Ternary
- * macro calls are limited to VectorMode::RC for now.
- */
+// Quasar keeps the same macro surface as BH/WH. Ternary macro calls are limited
+// to VectorMode::RC for now.
 
 namespace ckernel {
 
-template <DstSync /*DST_SYNC*/, bool /*DST_ACCUM*/>
+template <DstSync DST_SYNC, bool DST_ACCUM>
 inline __attribute__((always_inline)) void _sfpu_ternary_check_(
-    [[maybe_unused]] std::uint32_t dst_index_in0,
-    [[maybe_unused]] std::uint32_t dst_index_in1,
-    [[maybe_unused]] std::uint32_t dst_index_in2,
-    [[maybe_unused]] std::uint32_t dst_index_out,
+    std::uint32_t dst_index_in0,
+    std::uint32_t dst_index_in1,
+    std::uint32_t dst_index_in2,
+    std::uint32_t dst_index_out,
     VectorMode vector_mode) {
+    LLK_ASSERT(
+        (dst_index_in0 < trisc::get_dest_max_tiles<DST_SYNC, DST_ACCUM, trisc::DstTileShape::Tile32x32>()),
+        "dst_index_in0 exceeds max dest tiles");
+    LLK_ASSERT(
+        (dst_index_in1 < trisc::get_dest_max_tiles<DST_SYNC, DST_ACCUM, trisc::DstTileShape::Tile32x32>()),
+        "dst_index_in1 exceeds max dest tiles");
+    LLK_ASSERT(
+        (dst_index_in2 < trisc::get_dest_max_tiles<DST_SYNC, DST_ACCUM, trisc::DstTileShape::Tile32x32>()),
+        "dst_index_in2 exceeds max dest tiles");
+    LLK_ASSERT(
+        (dst_index_out < trisc::get_dest_max_tiles<DST_SYNC, DST_ACCUM, trisc::DstTileShape::Tile32x32>()),
+        "dst_index_out exceeds max dest tiles");
     LLK_ASSERT(vector_mode == VectorMode::RC, "Quasar currently only supports vector mode RC");
 }
 

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_macros.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/llk_math_eltwise_unary_sfpu_macros.h
@@ -10,14 +10,15 @@
 #include "llk_math_eltwise_unary_sfpu_init.h"
 #include "llk_math_eltwise_unary_sfpu.h"
 
-// Quasar keeps the same macro surface as BH/WH. DST_SYNC and DST_ACCUM are
-// unused until Quasar has an equivalent of get_dest_max_tiles<...>.
+// Quasar keeps the same macro surface as BH/WH.
 
 namespace ckernel {
 
-template <DstSync /*DST_SYNC*/, bool /*DST_ACCUM*/>
-inline __attribute__((always_inline)) void _sfpu_check_(
-    [[maybe_unused]] std::uint32_t dst_index, VectorMode vector_mode) {
+template <DstSync DST_SYNC, bool DST_ACCUM>
+inline __attribute__((always_inline)) void _sfpu_check_(std::uint32_t dst_index, VectorMode vector_mode) {
+    LLK_ASSERT(
+        (dst_index < trisc::get_dest_max_tiles<DST_SYNC, DST_ACCUM, trisc::DstTileShape::Tile32x32>()),
+        "dst_index exceeds max dest tiles");
     LLK_ASSERT(
         vector_mode == VectorMode::R || vector_mode == VectorMode::C || vector_mode == VectorMode::RC ||
             vector_mode == VectorMode::None || vector_mode == VectorMode::RC_custom,

--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/ckernel_trisc_common.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/ckernel_trisc_common.h
@@ -174,6 +174,22 @@ enum class DstTileShape : std::uint8_t
 };
 
 /**
+ * @brief Calculates the maximum number of tiles that fit in the math destination region.
+ *
+ * DstTileShape values encode the log2 destination-address footprint of each
+ * supported tile shape.
+ */
+template <ckernel::DstSync SYNC_MODE, bool ACCUM_MODE, DstTileShape TILE_SHAPE>
+constexpr std::uint32_t get_dest_max_tiles()
+{
+    constexpr std::uint32_t DEST_REGISTER_SIZE = SYNC_MODE == ckernel::DstSync::SyncHalf
+                                                     ? (ACCUM_MODE ? DEST_REGISTER_HALF_SIZE >> 1 : DEST_REGISTER_HALF_SIZE)
+                                                     : (ACCUM_MODE ? DEST_REGISTER_FULL_SIZE >> 1 : DEST_REGISTER_FULL_SIZE);
+
+    return DEST_REGISTER_SIZE >> ckernel::to_underlying(TILE_SHAPE);
+}
+
+/**
  * @brief Sets the destination register base address, each Trisc0/1/2/3 has separate
  * registers for setting dest base address.
  * @tparam TRISC_ID: Trisc core which is executing this function, values = [0, 1, 2, 3]

--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/ckernel_trisc_common.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/ckernel_trisc_common.h
@@ -176,17 +176,25 @@ enum class DstTileShape : std::uint8_t
 /**
  * @brief Calculates the maximum number of tiles that fit in the math destination region.
  *
- * DstTileShape values encode the log2 destination-address footprint of each
- * supported tile shape.
+ * Destination addressing uses a minimum 16-row footprint for tile shapes smaller
+ * than 32x16.
+ *
+ * @tparam SYNC_MODE: Destination synchronization mode, values = <SyncHalf/SyncFull>
+ * @tparam ACCUM_MODE: Accumulation mode, true for 32-bit and false for 16-bit
+ * @tparam TILE_SHAPE: Destination tile shape
+ * @return Maximum number of destination tiles.
  */
 template <ckernel::DstSync SYNC_MODE, bool ACCUM_MODE, DstTileShape TILE_SHAPE>
 constexpr std::uint32_t get_dest_max_tiles()
 {
-    constexpr std::uint32_t DEST_REGISTER_SIZE = SYNC_MODE == ckernel::DstSync::SyncHalf
-                                                     ? (ACCUM_MODE ? DEST_REGISTER_HALF_SIZE >> 1 : DEST_REGISTER_HALF_SIZE)
-                                                     : (ACCUM_MODE ? DEST_REGISTER_FULL_SIZE >> 1 : DEST_REGISTER_FULL_SIZE);
+    constexpr std::uint32_t DEST_REGISTER_SIZE  = SYNC_MODE == ckernel::DstSync::SyncHalf
+                                                      ? (ACCUM_MODE ? DEST_REGISTER_HALF_SIZE >> 1 : DEST_REGISTER_HALF_SIZE)
+                                                      : (ACCUM_MODE ? DEST_REGISTER_FULL_SIZE >> 1 : DEST_REGISTER_FULL_SIZE);
+    constexpr std::uint32_t DEST_TILE_SIZE_LOG2 = ckernel::to_underlying(TILE_SHAPE) < ckernel::to_underlying(DstTileShape::Tile32x8)
+                                                      ? ckernel::to_underlying(DstTileShape::Tile32x8)
+                                                      : ckernel::to_underlying(TILE_SHAPE);
 
-    return DEST_REGISTER_SIZE >> ckernel::to_underlying(TILE_SHAPE);
+    return DEST_REGISTER_SIZE >> DEST_TILE_SIZE_LOG2;
 }
 
 /**


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Closes #43839

Adds Quasar destination-tile bounds checking to unary, binary, and ternary SFPU macro call helpers. Implements `get_dest_max_tiles()` for Quasar using the destination sync mode, accumulation width, and encoded tile footprint, then validates every input and output destination index before dispatch.

### Notes for reviewers
Please focus on the Quasar `get_dest_max_tiles()` calculation in `ckernel_trisc_common.h` and its parity with the Wormhole/Blackhole checks. For 32x32 tiles, the limits are 8/16 tiles in 16-bit half/full sync mode and 4/8 tiles in 32-bit accumulation mode.

Validation: focused Quasar unary, binary, and ternary SFPU compile matrix — 318 passed. `git diff --check` and Cursor lints also pass.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ndivnic/add_dst_index_assert_checks_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ndivnic/add_dst_index_assert_checks_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ndivnic/add_dst_index_assert_checks_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ndivnic/add_dst_index_assert_checks_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ndivnic/add_dst_index_assert_checks_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ndivnic/add_dst_index_assert_checks_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ndivnic/add_dst_index_assert_checks_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ndivnic/add_dst_index_assert_checks_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ndivnic/add_dst_index_assert_checks_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ndivnic/add_dst_index_assert_checks_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ndivnic/add_dst_index_assert_checks_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ndivnic/add_dst_index_assert_checks_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ndivnic/add_dst_index_assert_checks_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ndivnic/add_dst_index_assert_checks_quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ndivnic/add_dst_index_assert_checks_quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ndivnic/add_dst_index_assert_checks_quasar)