### PR TITLE
validate producer/runner KV against a prompt-generated reference

### DIFF
--- a/models/demos/common/prefill/adapter.py
+++ b/models/demos/common/prefill/adapter.py
@@ -246,7 +246,10 @@ class PrefillModelAdapter(ABC):
 # model is one line here (plus the adapter class in that model's package). Keeping
 # these as strings means importing this common module never imports a model's
 # device/runtime stack — only the selected model is imported, at get_adapter time.
-DEFAULT_MODEL = "deepseek_v3_d_p"
+# Kimi's reference forward is chunked-SDPA (host RAM bounded); the deepseek_v3_d_p reference
+# materializes the full score matrix and OOMs past one chunk, so it can't back the prompt-KV
+# reference generator. Kimi is the default so the unset-PREFILL_MODEL path is memory-safe.
+DEFAULT_MODEL = "kimi_k2_7"
 
 ADAPTER_PATHS = {
     "deepseek_v3_d_p": "models.demos.deepseek_v3_d_p.tt.runners.adapters.deepseek_v3:DeepSeekV3Adapter",

--- a/models/demos/common/prefill/adapter.py
+++ b/models/demos/common/prefill/adapter.py
@@ -246,9 +246,6 @@ class PrefillModelAdapter(ABC):
 # model is one line here (plus the adapter class in that model's package). Keeping
 # these as strings means importing this common module never imports a model's
 # device/runtime stack — only the selected model is imported, at get_adapter time.
-# Kimi's reference forward is chunked-SDPA (host RAM bounded); the deepseek_v3_d_p reference
-# materializes the full score matrix and OOMs past one chunk, so it can't back the prompt-KV
-# reference generator. Kimi is the default so the unset-PREFILL_MODEL path is memory-safe.
 DEFAULT_MODEL = "kimi_k2_7"
 
 ADAPTER_PATHS = {

--- a/models/demos/common/prefill/tests/test_producer_runner_e2e.py
+++ b/models/demos/common/prefill/tests/test_producer_runner_e2e.py
@@ -281,11 +281,18 @@ def test_producer_runner_pcc(scenario, tmp_path):
     prod_log = os.path.join(_REPORT_DIR, f"ci_producer_{scenario}.log")
     trace_env = {}
     if "prompt_file" in sc:
-        trace_dir = str(tmp_path / "prompt_trace")
-        # Generate the host reference at exactly the pushed depth (isl == chunks * CHUNK_SIZE). The
-        # reference forward is chunked-SDPA so RAM stays bounded at any depth; runtime is still O(seq^2),
-        # which the per-test timeout accounts for.
-        _generate_prompt_trace(trace_dir, sc["isl"], sc["prompt_file"])
+        # A pre-built reference (PREFILL_REUSE_TRACE_DIR) lets an A/B across device builds compare the
+        # device KV against one byte-identical golden — the host reference is device-independent, so
+        # regenerating it per build would only add float-order noise to the comparison.
+        reuse_dir = os.environ.get("PREFILL_REUSE_TRACE_DIR")
+        if reuse_dir and os.path.exists(os.path.join(reuse_dir, "metadata.json")):
+            trace_dir = reuse_dir
+        else:
+            trace_dir = str(tmp_path / "prompt_trace")
+            # Generate the host reference at exactly the pushed depth (isl == chunks * CHUNK_SIZE). The
+            # reference forward is chunked-SDPA so RAM stays bounded at any depth; runtime is still O(seq^2),
+            # which the per-test timeout accounts for.
+            _generate_prompt_trace(trace_dir, sc["isl"], sc["prompt_file"])
         trace_env["PREFILL_TRACE_DIR"] = trace_dir
     with _running_runner(scenario, sc["users"], sc["max_seq_len"], **trace_env) as runner_log:
         env = _transport_env(

--- a/models/demos/common/prefill/tests/test_producer_runner_e2e.py
+++ b/models/demos/common/prefill/tests/test_producer_runner_e2e.py
@@ -240,7 +240,7 @@ def _running_runner(tag: str, num_users: int, max_seq_len: int, **extra):
         _cleanup_ipc()
 
 
-def _generate_prompt_trace(out_dir: str, isl: int, prompt_file: str) -> None:
+def _generate_prompt_trace(out_dir: str, isl: int, prompt_file: str, model: str) -> None:
     """Host-only pre-step: build a reference-KV trace dir from a prompt (no device). Raises with the
     generator's output on failure so a bad reference is not silently mistaken for a device PCC failure."""
     os.makedirs(_REPORT_DIR, exist_ok=True)
@@ -251,6 +251,8 @@ def _generate_prompt_trace(out_dir: str, isl: int, prompt_file: str) -> None:
                 sys.executable,
                 "-m",
                 _GEN_TRACE_MODULE,
+                "--model",
+                model,
                 "--prompt-file",
                 prompt_file,
                 "--isl",
@@ -281,6 +283,11 @@ def test_producer_runner_pcc(scenario, tmp_path):
     prod_log = os.path.join(_REPORT_DIR, f"ci_producer_{scenario}.log")
     trace_env = {}
     if "prompt_file" in sc:
+        # The reference forward is memory-bounded only for a model whose reference uses chunked-SDPA;
+        # deepseek_v3_d_p's reference OOMs past one chunk, so default this scenario to Kimi. Pin it into
+        # trace_env so the runner + producer select the SAME adapter that generated the golden.
+        model = os.environ.get("PREFILL_MODEL", "kimi_k2_7")
+        trace_env["PREFILL_MODEL"] = model
         # A pre-built reference (PREFILL_REUSE_TRACE_DIR) lets an A/B across device builds compare the
         # device KV against one byte-identical golden — the host reference is device-independent, so
         # regenerating it per build would only add float-order noise to the comparison.
@@ -292,7 +299,7 @@ def test_producer_runner_pcc(scenario, tmp_path):
             # Generate the host reference at exactly the pushed depth (isl == chunks * CHUNK_SIZE). The
             # reference forward is chunked-SDPA so RAM stays bounded at any depth; runtime is still O(seq^2),
             # which the per-test timeout accounts for.
-            _generate_prompt_trace(trace_dir, sc["isl"], sc["prompt_file"])
+            _generate_prompt_trace(trace_dir, sc["isl"], sc["prompt_file"], model)
         trace_env["PREFILL_TRACE_DIR"] = trace_dir
     with _running_runner(scenario, sc["users"], sc["max_seq_len"], **trace_env) as runner_log:
         env = _transport_env(

--- a/models/demos/common/prefill/tests/test_producer_runner_e2e.py
+++ b/models/demos/common/prefill/tests/test_producer_runner_e2e.py
@@ -33,7 +33,6 @@ _REPORT_DIR = os.path.join(os.environ.get("TT_METAL_HOME", os.getcwd()), "genera
 
 _RUNNER_MODULE = "models.demos.common.prefill.runners.prefill_runner"
 _PRODUCER_MODULE = "models.demos.common.prefill.runners.prefill_producer"
-_GEN_TRACE_MODULE = "models.demos.deepseek_v3_d_p.tt.runners.generate_prompt_trace"
 
 _READY_TIMEOUT_S = int(os.environ.get("PREFILL_CI_RUNNER_READY_TIMEOUT_S", "1200"))  # 20 min for load + JIT
 _PRODUCER_TIMEOUT_S = int(os.environ.get("PREFILL_CI_PRODUCER_TIMEOUT_S", "900"))
@@ -241,35 +240,14 @@ def _running_runner(tag: str, num_users: int, max_seq_len: int, **extra):
 
 
 def _generate_prompt_trace(out_dir: str, isl: int, prompt_file: str, model: str) -> None:
-    """Host-only pre-step: build a reference-KV trace dir from a prompt (no device). Raises with the
-    generator's output on failure so a bad reference is not silently mistaken for a device PCC failure."""
-    os.makedirs(_REPORT_DIR, exist_ok=True)
-    log_path = os.path.join(_REPORT_DIR, "ci_gen_trace.log")
-    with open(log_path, "w") as log:
-        result = subprocess.run(
-            [
-                sys.executable,
-                "-m",
-                _GEN_TRACE_MODULE,
-                "--model",
-                model,
-                "--prompt-file",
-                prompt_file,
-                "--isl",
-                str(isl),
-                "--num-layers",
-                str(NUM_LAYERS),
-                "--out",
-                out_dir,
-            ],
-            env=dict(os.environ),
-            stdout=log,
-            stderr=subprocess.STDOUT,
-            timeout=_PRODUCER_TIMEOUT_S,
-        )
-    _emit_log_group("reference trace generation", log_path)
-    if result.returncode != 0:
-        raise RuntimeError(f"reference trace generation failed (rc={result.returncode}):\n{_tail(log_path)}")
+    """Host-only pre-step: build a reference-KV trace dir from a prompt. The generator is device-free,
+    so it runs in-process — no subprocess / OS command. A bad prompt or model surfaces as the
+    generator's own exception, so a bad reference is never mistaken for a device PCC failure."""
+    # Lazy import: the generator pulls in torch / transformers / the reference model, which must not
+    # load at test-collection time.
+    from models.demos.deepseek_v3_d_p.tt.runners.generate_prompt_trace import _load_prompt_text, generate
+
+    generate(model, _load_prompt_text(None, prompt_file), isl, NUM_LAYERS, out_dir)
 
 
 @pytest.mark.timeout(_READY_TIMEOUT_S + 2 * _PRODUCER_TIMEOUT_S + 300)

--- a/models/demos/common/prefill/tests/test_producer_runner_e2e.py
+++ b/models/demos/common/prefill/tests/test_producer_runner_e2e.py
@@ -130,7 +130,9 @@ _PROMPT_FILE = os.environ.get("PREFILL_PROMPT_FILE")
 if _PROMPT_FILE:
     SCENARIOS["prompt_single_user"] = {
         "users": 1,
-        "max_seq_len": CHUNK_SIZE,
+        # A 2-chunk cache though only one chunk is prefilled: the chunked-attention SDPA gate
+        # requires Q.seq < cache-width, so max_seq_len must exceed chunk_size even for a single chunk.
+        "max_seq_len": 2 * CHUNK_SIZE,
         "producer": {"PREFILL_PRODUCER_CHUNKS": "1", "PREFILL_PRODUCER_MAX_REQUESTS": "1"},
         "prompt_file": _PROMPT_FILE,
     }
@@ -264,6 +266,9 @@ def _generate_prompt_trace(out_dir: str, isl: int, prompt_file: str) -> None:
         raise RuntimeError(f"reference trace generation failed (rc={result.returncode}):\n{_tail(log_path)}")
 
 
+# The in-test waits (reference-trace gen + runner startup + producer) run to _READY_TIMEOUT_S +
+# two _PRODUCER_TIMEOUT_S, far past pytest.ini's global 300s; override so those bounds govern instead.
+@pytest.mark.timeout(_READY_TIMEOUT_S + 2 * _PRODUCER_TIMEOUT_S + 300)
 @pytest.mark.parametrize("scenario", list(SCENARIOS))
 def test_producer_runner_pcc(scenario, tmp_path):
     """Spin up a fresh runner for the scenario, drive it with the producer, and require the per-slot
@@ -273,7 +278,9 @@ def test_producer_runner_pcc(scenario, tmp_path):
     trace_env = {}
     if "prompt_file" in sc:
         trace_dir = str(tmp_path / "prompt_trace")
-        _generate_prompt_trace(trace_dir, sc["max_seq_len"], sc["prompt_file"])
+        # The prompt is one chunk deep; max_seq_len only sizes the device cache. Generate the reference
+        # at CHUNK_SIZE so the host O(seq^2) forward stays cheap and its length matches what's pushed.
+        _generate_prompt_trace(trace_dir, CHUNK_SIZE, sc["prompt_file"])
         trace_env["PREFILL_TRACE_DIR"] = trace_dir
     with _running_runner(scenario, sc["users"], sc["max_seq_len"], **trace_env) as runner_log:
         env = _transport_env(

--- a/models/demos/common/prefill/tests/test_producer_runner_e2e.py
+++ b/models/demos/common/prefill/tests/test_producer_runner_e2e.py
@@ -272,8 +272,6 @@ def _generate_prompt_trace(out_dir: str, isl: int, prompt_file: str, model: str)
         raise RuntimeError(f"reference trace generation failed (rc={result.returncode}):\n{_tail(log_path)}")
 
 
-# The in-test waits (reference-trace gen + runner startup + producer) run to _READY_TIMEOUT_S +
-# two _PRODUCER_TIMEOUT_S, far past pytest.ini's global 300s; override so those bounds govern instead.
 @pytest.mark.timeout(_READY_TIMEOUT_S + 2 * _PRODUCER_TIMEOUT_S + 300)
 @pytest.mark.parametrize("scenario", list(SCENARIOS))
 def test_producer_runner_pcc(scenario, tmp_path):
@@ -283,22 +281,13 @@ def test_producer_runner_pcc(scenario, tmp_path):
     prod_log = os.path.join(_REPORT_DIR, f"ci_producer_{scenario}.log")
     trace_env = {}
     if "prompt_file" in sc:
-        # The reference forward is memory-bounded only for a model whose reference uses chunked-SDPA;
-        # deepseek_v3_d_p's reference OOMs past one chunk, so default this scenario to Kimi. Pin it into
-        # trace_env so the runner + producer select the SAME adapter that generated the golden.
         model = os.environ.get("PREFILL_MODEL", "kimi_k2_7")
         trace_env["PREFILL_MODEL"] = model
-        # A pre-built reference (PREFILL_REUSE_TRACE_DIR) lets an A/B across device builds compare the
-        # device KV against one byte-identical golden — the host reference is device-independent, so
-        # regenerating it per build would only add float-order noise to the comparison.
         reuse_dir = os.environ.get("PREFILL_REUSE_TRACE_DIR")
         if reuse_dir and os.path.exists(os.path.join(reuse_dir, "metadata.json")):
             trace_dir = reuse_dir
         else:
             trace_dir = str(tmp_path / "prompt_trace")
-            # Generate the host reference at exactly the pushed depth (isl == chunks * CHUNK_SIZE). The
-            # reference forward is chunked-SDPA so RAM stays bounded at any depth; runtime is still O(seq^2),
-            # which the per-test timeout accounts for.
             _generate_prompt_trace(trace_dir, sc["isl"], sc["prompt_file"], model)
         trace_env["PREFILL_TRACE_DIR"] = trace_dir
     with _running_runner(scenario, sc["users"], sc["max_seq_len"], **trace_env) as runner_log:

--- a/models/demos/common/prefill/tests/test_producer_runner_e2e.py
+++ b/models/demos/common/prefill/tests/test_producer_runner_e2e.py
@@ -33,6 +33,7 @@ _REPORT_DIR = os.path.join(os.environ.get("TT_METAL_HOME", os.getcwd()), "genera
 
 _RUNNER_MODULE = "models.demos.common.prefill.runners.prefill_runner"
 _PRODUCER_MODULE = "models.demos.common.prefill.runners.prefill_producer"
+_GEN_TRACE_MODULE = "models.demos.deepseek_v3_d_p.tt.runners.generate_prompt_trace"
 
 _READY_TIMEOUT_S = int(os.environ.get("PREFILL_CI_RUNNER_READY_TIMEOUT_S", "1200"))  # 20 min for load + JIT
 _PRODUCER_TIMEOUT_S = int(os.environ.get("PREFILL_CI_PRODUCER_TIMEOUT_S", "900"))
@@ -121,6 +122,19 @@ SCENARIOS = {
     },
 }
 
+# Opt-in prompt-driven scenario: instead of a recorded golden trace, generate the reference KV from a
+# user prompt on the host (device-less pre-step) and validate device KV against it. Enabled by pointing
+# PREFILL_PROMPT_FILE at a prompt JSON. One chunk deep (host torch reference is O(seq^2), so full-depth
+# is infeasible here) — this is the correctness gate for arbitrary prompts, not a depth/breadth stress.
+_PROMPT_FILE = os.environ.get("PREFILL_PROMPT_FILE")
+if _PROMPT_FILE:
+    SCENARIOS["prompt_single_user"] = {
+        "users": 1,
+        "max_seq_len": CHUNK_SIZE,
+        "producer": {"PREFILL_PRODUCER_CHUNKS": "1", "PREFILL_PRODUCER_MAX_REQUESTS": "1"},
+        "prompt_file": _PROMPT_FILE,
+    }
+
 
 def _transport_env(num_users: int, max_seq_len: int, **extra) -> dict:
     """Inherit the CI/dev env (weights cache, HF, golden trace) and add the shared orchestration knobs
@@ -179,13 +193,13 @@ def _emit_log_group(title: str, path: str, n: int = _LOG_TAIL_LINES) -> None:
 
 
 @contextlib.contextmanager
-def _running_runner(tag: str, num_users: int, max_seq_len: int):
+def _running_runner(tag: str, num_users: int, max_seq_len: int, **extra):
     """Spin up ONE runner (mock-migration, request mode) for a scenario and tear it down. Yields once
     it has published the H2D descriptor + KV table + device map (i.e. it is serving)."""
     os.makedirs(_REPORT_DIR, exist_ok=True)
     log_path = os.path.join(_REPORT_DIR, f"ci_runner_{tag}.log")
     _cleanup_ipc()  # a stale table/descriptor from a prior scenario would make the readiness poll pass early
-    env = _transport_env(num_users, max_seq_len, PREFILL_MOCK_MIGRATION="1")
+    env = _transport_env(num_users, max_seq_len, PREFILL_MOCK_MIGRATION="1", **extra)
     mode = _launch_mode()
     if mode == "ci":
         print(
@@ -220,14 +234,51 @@ def _running_runner(tag: str, num_users: int, max_seq_len: int):
         _cleanup_ipc()
 
 
+def _generate_prompt_trace(out_dir: str, isl: int, prompt_file: str) -> None:
+    """Host-only pre-step: build a reference-KV trace dir from a prompt (no device). Raises with the
+    generator's output on failure so a bad reference is not silently mistaken for a device PCC failure."""
+    os.makedirs(_REPORT_DIR, exist_ok=True)
+    log_path = os.path.join(_REPORT_DIR, "ci_gen_trace.log")
+    with open(log_path, "w") as log:
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                _GEN_TRACE_MODULE,
+                "--prompt-file",
+                prompt_file,
+                "--isl",
+                str(isl),
+                "--num-layers",
+                str(NUM_LAYERS),
+                "--out",
+                out_dir,
+            ],
+            env=dict(os.environ),
+            stdout=log,
+            stderr=subprocess.STDOUT,
+            timeout=_PRODUCER_TIMEOUT_S,
+        )
+    _emit_log_group("reference trace generation", log_path)
+    if result.returncode != 0:
+        raise RuntimeError(f"reference trace generation failed (rc={result.returncode}):\n{_tail(log_path)}")
+
+
 @pytest.mark.parametrize("scenario", list(SCENARIOS))
-def test_producer_runner_pcc(scenario):
+def test_producer_runner_pcc(scenario, tmp_path):
     """Spin up a fresh runner for the scenario, drive it with the producer, and require the per-slot
     KV PCC gate to pass (the producer exits non-zero if any resident slot is below threshold)."""
     sc = SCENARIOS[scenario]
     prod_log = os.path.join(_REPORT_DIR, f"ci_producer_{scenario}.log")
-    with _running_runner(scenario, sc["users"], sc["max_seq_len"]) as runner_log:
-        env = _transport_env(sc["users"], sc["max_seq_len"], PREFILL_PRODUCER_CHECK_PCC="1", **sc["producer"])
+    trace_env = {}
+    if "prompt_file" in sc:
+        trace_dir = str(tmp_path / "prompt_trace")
+        _generate_prompt_trace(trace_dir, sc["max_seq_len"], sc["prompt_file"])
+        trace_env["PREFILL_TRACE_DIR"] = trace_dir
+    with _running_runner(scenario, sc["users"], sc["max_seq_len"], **trace_env) as runner_log:
+        env = _transport_env(
+            sc["users"], sc["max_seq_len"], PREFILL_PRODUCER_CHECK_PCC="1", **trace_env, **sc["producer"]
+        )
         try:
             with open(prod_log, "w") as f:
                 result = subprocess.run(

--- a/models/demos/common/prefill/tests/test_producer_runner_e2e.py
+++ b/models/demos/common/prefill/tests/test_producer_runner_e2e.py
@@ -124,17 +124,21 @@ SCENARIOS = {
 
 # Opt-in prompt-driven scenario: instead of a recorded golden trace, generate the reference KV from a
 # user prompt on the host (device-less pre-step) and validate device KV against it. Enabled by pointing
-# PREFILL_PROMPT_FILE at a prompt JSON. One chunk deep (host torch reference is O(seq^2), so full-depth
-# is infeasible here) — this is the correctness gate for arbitrary prompts, not a depth/breadth stress.
+# PREFILL_PROMPT_FILE at a prompt JSON. The host reference forward uses chunked-SDPA MLA, so its memory
+# stays bounded and PREFILL_PROMPT_CHUNKS chunks (default 1) can be validated — the correctness gate for
+# arbitrary prompts. Runtime is still O(seq^2) in the sequence length, so deeper runs take longer.
 _PROMPT_FILE = os.environ.get("PREFILL_PROMPT_FILE")
 if _PROMPT_FILE:
+    _PROMPT_CHUNKS = int(os.environ.get("PREFILL_PROMPT_CHUNKS", "1"))
     SCENARIOS["prompt_single_user"] = {
         "users": 1,
-        # A 2-chunk cache though only one chunk is prefilled: the chunked-attention SDPA gate
-        # requires Q.seq < cache-width, so max_seq_len must exceed chunk_size even for a single chunk.
-        "max_seq_len": 2 * CHUNK_SIZE,
-        "producer": {"PREFILL_PRODUCER_CHUNKS": "1", "PREFILL_PRODUCER_MAX_REQUESTS": "1"},
+        # Cache width must exceed the deepest single push (Q.seq == CHUNK_SIZE): the chunked-attention
+        # SDPA gate requires Q.seq < cache-width, so a 1-chunk prompt still needs a 2-chunk cache. For
+        # N>=2 the accumulated fill N*CHUNK_SIZE already exceeds one chunk, so N*CHUNK_SIZE suffices.
+        "max_seq_len": max(2, _PROMPT_CHUNKS) * CHUNK_SIZE,
+        "producer": {"PREFILL_PRODUCER_CHUNKS": str(_PROMPT_CHUNKS), "PREFILL_PRODUCER_MAX_REQUESTS": "1"},
         "prompt_file": _PROMPT_FILE,
+        "isl": _PROMPT_CHUNKS * CHUNK_SIZE,
     }
 
 
@@ -278,9 +282,10 @@ def test_producer_runner_pcc(scenario, tmp_path):
     trace_env = {}
     if "prompt_file" in sc:
         trace_dir = str(tmp_path / "prompt_trace")
-        # The prompt is one chunk deep; max_seq_len only sizes the device cache. Generate the reference
-        # at CHUNK_SIZE so the host O(seq^2) forward stays cheap and its length matches what's pushed.
-        _generate_prompt_trace(trace_dir, CHUNK_SIZE, sc["prompt_file"])
+        # Generate the host reference at exactly the pushed depth (isl == chunks * CHUNK_SIZE). The
+        # reference forward is chunked-SDPA so RAM stays bounded at any depth; runtime is still O(seq^2),
+        # which the per-test timeout accounts for.
+        _generate_prompt_trace(trace_dir, sc["isl"], sc["prompt_file"])
         trace_env["PREFILL_TRACE_DIR"] = trace_dir
     with _running_runner(scenario, sc["users"], sc["max_seq_len"], **trace_env) as runner_log:
         env = _transport_env(

--- a/models/demos/deepseek_v3_d_p/README.md
+++ b/models/demos/deepseek_v3_d_p/README.md
@@ -7,7 +7,7 @@ This directory will contain the implementation of prefill stage for DeepSeek V3 
 The prefill runner is a model-agnostic engine in the common package
 (`models/demos/common/prefill/`). It drives any model through a `PrefillModelAdapter`; the
 DeepSeek-V3 family's concrete adapters live here in `tt/runners/adapters/`, selected by the
-**`PREFILL_MODEL`** env var (default `kimi_k2_7`; DeepSeek-V3 is `deepseek_v3_d_p`). To integrate a new
+**`PREFILL_MODEL`** env var (default `kimi_k2_7`). To integrate a new
 model, see
 [models/demos/common/prefill/docs/ADDING_A_PREFILL_MODEL.md](../common/prefill/docs/ADDING_A_PREFILL_MODEL.md).
 

--- a/models/demos/deepseek_v3_d_p/README.md
+++ b/models/demos/deepseek_v3_d_p/README.md
@@ -7,13 +7,13 @@ This directory will contain the implementation of prefill stage for DeepSeek V3 
 The prefill runner is a model-agnostic engine in the common package
 (`models/demos/common/prefill/`). It drives any model through a `PrefillModelAdapter`; the
 DeepSeek-V3 family's concrete adapters live here in `tt/runners/adapters/`, selected by the
-**`PREFILL_MODEL`** env var (default `deepseek_v3_d_p`; Kimi is `kimi_k2_6`). To integrate a new
+**`PREFILL_MODEL`** env var (default `kimi_k2_7`; DeepSeek-V3 is `deepseek_v3_d_p`). To integrate a new
 model, see
 [models/demos/common/prefill/docs/ADDING_A_PREFILL_MODEL.md](../common/prefill/docs/ADDING_A_PREFILL_MODEL.md).
 
 ## Environment Variables
 
-- **`PREFILL_MODEL`** — Which model adapter the runner / producers use (`deepseek_v3_d_p` | `kimi_k2_6`). Defaults to `deepseek_v3_d_p`. Replaces the former `PREFILL_MODEL_VARIANT`.
+- **`PREFILL_MODEL`** — Which model adapter the runner / producers use (`deepseek_v3_d_p` | `kimi_k2_6` | `kimi_k2_7` | …). Defaults to `kimi_k2_7`. Replaces the former `PREFILL_MODEL_VARIANT`.
 
 - **`DEEPSEEK_V3_HF_MODEL`** — Path to DeepSeek-R1-0528 weights directory. Falls back to `models/demos/deepseek_v3/reference/` then `/proj_sw/user_dev/deepseek-ai/DeepSeek-R1-0528`.
 - **`TT_DS_PREFILL_TTNN_CACHE`** — Directory for cached TTNN weight tensors (`.tensorbin` files). First run writes cache, subsequent runs load directly. Defaults to `{model_path}/tensor_cache_{arch}_{num_devices}dev/`.

--- a/models/demos/deepseek_v3_d_p/reference/kimi_k2_6/modeling_deepseek.py
+++ b/models/demos/deepseek_v3_d_p/reference/kimi_k2_6/modeling_deepseek.py
@@ -747,25 +747,48 @@ class DeepseekV3Attention(nn.Module):
             ).flatten(-2)
             past_key_value.update(key_latent, torch.empty((*key_latent.shape[:-1], 0)), self.layer_idx, cache_kwargs)
 
-        attn_weights = torch.matmul(query_states, key_states.transpose(2, 3)) * self.softmax_scale
+        # The full score matrix is [num_heads, q_len, kv_seq_len] — the sole O(seq^2) host-memory term,
+        # which OOMs long prefill prompts. When the returned weights are not needed (the prefill KV
+        # reference), compute attention in head+query-sequence tiles so peak memory is bounded by
+        # HEAD_CHUNK * SEQ_CHUNK * kv_seq_len rather than num_heads * q_len * kv_seq_len. Gated on
+        # q_len > SEQ_CHUNK so shorter prompts keep the exact original path. Numerically equal up to
+        # float accumulation order; the KVPE cache is already written above, so it is unaffected either way.
+        SEQ_CHUNK = 4096
+        HEAD_CHUNK = 16
+        if not output_attentions and q_len > SEQ_CHUNK:
+            assert attention_mask is not None
+            attn_output = query_states.new_empty(bsz, self.num_heads, q_len, self.v_head_dim)
+            for h in range(0, self.num_heads, HEAD_CHUNK):
+                he = min(h + HEAD_CHUNK, self.num_heads)
+                k_h = key_states[:, h:he]
+                v_h = value_states[:, h:he]
+                for s in range(0, q_len, SEQ_CHUNK):
+                    e = min(s + SEQ_CHUNK, q_len)
+                    scores = torch.matmul(query_states[:, h:he, s:e], k_h.transpose(2, 3)) * self.softmax_scale
+                    scores = scores + attention_mask[:, :, s:e, :]
+                    scores = nn.functional.softmax(scores, dim=-1, dtype=torch.float32).to(query_states.dtype)
+                    attn_output[:, h:he, s:e] = torch.matmul(scores, v_h)
+            attn_weights = None
+        else:
+            attn_weights = torch.matmul(query_states, key_states.transpose(2, 3)) * self.softmax_scale
 
-        if attn_weights.size() != (bsz, self.num_heads, q_len, kv_seq_len):
-            raise ValueError(
-                f"Attention weights should be of size {(bsz, self.num_heads, q_len, kv_seq_len)}, but is"
-                f" {attn_weights.size()}"
-            )
-        assert attention_mask is not None
-        if attention_mask is not None:
-            if attention_mask.size() != (bsz, 1, q_len, kv_seq_len):
+            if attn_weights.size() != (bsz, self.num_heads, q_len, kv_seq_len):
                 raise ValueError(
-                    f"Attention mask should be of size {(bsz, 1, q_len, kv_seq_len)}, but is {attention_mask.size()}"
+                    f"Attention weights should be of size {(bsz, self.num_heads, q_len, kv_seq_len)}, but is"
+                    f" {attn_weights.size()}"
                 )
-            attn_weights = attn_weights + attention_mask
+            assert attention_mask is not None
+            if attention_mask is not None:
+                if attention_mask.size() != (bsz, 1, q_len, kv_seq_len):
+                    raise ValueError(
+                        f"Attention mask should be of size {(bsz, 1, q_len, kv_seq_len)}, but is {attention_mask.size()}"
+                    )
+                attn_weights = attn_weights + attention_mask
 
-        # upcast attention to fp32
-        attn_weights = nn.functional.softmax(attn_weights, dim=-1, dtype=torch.float32).to(query_states.dtype)
-        attn_weights = nn.functional.dropout(attn_weights, p=self.attention_dropout, training=self.training)
-        attn_output = torch.matmul(attn_weights, value_states)
+            # upcast attention to fp32
+            attn_weights = nn.functional.softmax(attn_weights, dim=-1, dtype=torch.float32).to(query_states.dtype)
+            attn_weights = nn.functional.dropout(attn_weights, p=self.attention_dropout, training=self.training)
+            attn_output = torch.matmul(attn_weights, value_states)
 
         if attn_output.size() != (bsz, self.num_heads, q_len, self.v_head_dim):
             raise ValueError(

--- a/models/demos/deepseek_v3_d_p/reference/kimi_k2_6/modeling_deepseek.py
+++ b/models/demos/deepseek_v3_d_p/reference/kimi_k2_6/modeling_deepseek.py
@@ -750,20 +750,25 @@ class DeepseekV3Attention(nn.Module):
         # The full score matrix is [num_heads, q_len, kv_seq_len] — the sole O(seq^2) host-memory term,
         # which OOMs long prefill prompts. When the returned weights are not needed (the prefill KV
         # reference), compute attention in head+query-sequence tiles so peak memory is bounded by
-        # HEAD_CHUNK * SEQ_CHUNK * kv_seq_len rather than num_heads * q_len * kv_seq_len. Gated on
-        # q_len > SEQ_CHUNK so shorter prompts keep the exact original path. Numerically equal up to
-        # float accumulation order; the KVPE cache is already written above, so it is unaffected either way.
-        SEQ_CHUNK = 4096
-        HEAD_CHUNK = 16
-        if not output_attentions and q_len > SEQ_CHUNK:
-            assert attention_mask is not None
+        # HEAD_TILE * Q_SEQ_TILE * kv_seq_len rather than num_heads * q_len * kv_seq_len. These are private
+        # host-RAM tiling sizes (a speed/memory trade), unrelated to the prefill CHUNK_SIZE. Gated on
+        # q_len > Q_SEQ_TILE so shorter prompts keep the exact original path. Numerically equal up to float
+        # accumulation order (dropout is a no-op on this eval reference, so eliding it is safe); the KVPE
+        # cache is already written above, so it is unaffected either way.
+        Q_SEQ_TILE = 4096
+        HEAD_TILE = 16
+        if not output_attentions and q_len > Q_SEQ_TILE:
+            assert attention_mask is not None and attention_mask.shape[-2:] == (
+                q_len,
+                kv_seq_len,
+            ), f"attention_mask {tuple(attention_mask.shape)} incompatible with (q_len={q_len}, kv={kv_seq_len})"
             attn_output = query_states.new_empty(bsz, self.num_heads, q_len, self.v_head_dim)
-            for h in range(0, self.num_heads, HEAD_CHUNK):
-                he = min(h + HEAD_CHUNK, self.num_heads)
+            for h in range(0, self.num_heads, HEAD_TILE):
+                he = min(h + HEAD_TILE, self.num_heads)
                 k_h = key_states[:, h:he]
                 v_h = value_states[:, h:he]
-                for s in range(0, q_len, SEQ_CHUNK):
-                    e = min(s + SEQ_CHUNK, q_len)
+                for s in range(0, q_len, Q_SEQ_TILE):
+                    e = min(s + Q_SEQ_TILE, q_len)
                     scores = torch.matmul(query_states[:, h:he, s:e], k_h.transpose(2, 3)) * self.softmax_scale
                     scores = scores + attention_mask[:, :, s:e, :]
                     scores = nn.functional.softmax(scores, dim=-1, dtype=torch.float32).to(query_states.dtype)

--- a/models/demos/deepseek_v3_d_p/tt/runners/generate_prompt_trace.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/generate_prompt_trace.py
@@ -1,0 +1,145 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+"""Generate a prefill golden "trace dir" from a user prompt, host-only (no device).
+
+The prefill producer reads its input tokens and golden KV cache from one trace dir
+(``metadata.json["token_ids"]`` + ``kv_cache/layer_N.safetensors``). Recorded traces
+come from vLLM; this builds an equivalent one from an arbitrary prompt by running the
+torch/HF reference forward, so ``PREFILL_TRACE_DIR`` can point at it and the runner +
+producer validate device KV against a reference generated for that exact prompt.
+
+MLA models only (DeepSeek / Kimi): the golden is the compressed KVPE
+``[seq, KV_LORA_RANK + QK_ROPE_HEAD_DIM]`` per layer.
+"""
+
+import argparse
+import json
+import os
+from copy import deepcopy
+from pathlib import Path
+
+import torch
+from loguru import logger
+from safetensors.torch import save_file
+from transformers import AutoConfig, AutoTokenizer
+
+from models.demos.common.prefill.adapter import DEFAULT_MODEL, get_adapter
+from models.demos.deepseek_v3_d_p.utils.transformer_helpers import (
+    load_and_compute_layer_by_layer,
+    tokenize_prompt_to_isl,
+)
+
+
+def _resolve_model_path(variant) -> Path:
+    """First of the variant's env var / local / shared path that holds an HF safetensors dir."""
+    candidates = [os.environ.get(variant.env_var), variant.default_local_path, variant.shared_path]
+    for c in candidates:
+        if c and Path(c).exists():
+            return Path(c)
+    raise SystemExit(
+        f"No model dir found for {variant.name}: set {variant.env_var} to the HF safetensors dir "
+        f"(tried {variant.env_var}={os.environ.get(variant.env_var)!r}, "
+        f"{variant.default_local_path!r}, {variant.shared_path!r})"
+    )
+
+
+def _load_config(model_path: Path, isl: int):
+    config = AutoConfig.from_pretrained(str(model_path), trust_remote_code=True)
+    # Kimi ships a multimodal wrapper; the MLA reference wants the text sub-config.
+    if hasattr(config, "text_config") and hasattr(config.text_config, "hidden_size"):
+        config = config.text_config
+    config = deepcopy(config)
+    # AutoConfig does not populate this; the reference forward path expects it set.
+    config.max_seq_len = isl
+    return config
+
+
+def _load_prompt_text(prompt: str | None, prompt_file: str | None) -> str:
+    if prompt is not None:
+        return prompt
+    if prompt_file is not None:
+        data = json.loads(Path(prompt_file).read_text())
+        if isinstance(data, dict):
+            data = data.get("prompts", data)
+        item = data[0] if isinstance(data, list) else data
+        return item["prompt"] if isinstance(item, dict) else item
+    raise SystemExit("provide --prompt or --prompt-file")
+
+
+def _meta_pe_to_hf(pe: torch.Tensor) -> torch.Tensor:
+    """De-interleave rope "pe" from the reference's Meta frame to HF half-split.
+
+    The producer re-interleaves HF->Meta on load (stack(halves).reshape); writing the
+    reference (Meta) directly would double-apply the swap. This is that transform's inverse:
+    Meta ``[a0,b0,a1,b1,...]`` -> HF ``[a0,a1,...,b0,b1,...]``.
+    """
+    return torch.cat([pe[:, 0::2], pe[:, 1::2]], dim=-1)
+
+
+def write_trace_dir(out_dir: Path, token_ids: torch.Tensor, ref_kvpe_list, kv_lora_rank: int) -> Path:
+    out_dir = Path(out_dir)
+    (out_dir / "kv_cache").mkdir(parents=True, exist_ok=True)
+    (out_dir / "metadata.json").write_text(json.dumps({"token_ids": token_ids[0].tolist()}))
+
+    for i, kvpe in enumerate(ref_kvpe_list):
+        # ref_kvpe_list[i] is the HF DynamicCache key cache for the layer, [1, 1, seq, head_dim].
+        t = kvpe
+        while t.dim() > 2:
+            t = t[0]
+        t = t.to(torch.float32)
+        nope = t[:, :kv_lora_rank]  # compared directly by the producer, written as-is
+        pe = _meta_pe_to_hf(t[:, kv_lora_rank:])
+        row = torch.cat([nope, pe], dim=-1).contiguous()
+        save_file({f"kv_post_transform_layer_{i}": row}, str(out_dir / "kv_cache" / f"layer_{i}.safetensors"))
+    return out_dir
+
+
+def generate(model: str, prompt_text: str, isl: int, num_layers: int, out_dir: Path) -> Path:
+    variant = get_adapter(model)
+    model_path = _resolve_model_path(variant)
+    config = _load_config(model_path, isl)
+    tokenizer = AutoTokenizer.from_pretrained(
+        str(model_path), use_fast=True, trust_remote_code=variant.tokenizer_trust_remote_code
+    )
+    tokenizer.padding_side = "right"
+
+    token_ids, attention_mask, _ = tokenize_prompt_to_isl(tokenizer, max_isl=isl, prompt_text=prompt_text)
+    logger.info(f"[gen-trace] model={model} isl={isl} num_layers={num_layers} tokens={token_ids.shape}")
+
+    result = load_and_compute_layer_by_layer(
+        variant=variant,
+        model_path=model_path,
+        config=config,
+        num_layers=num_layers,
+        token_ids=token_ids,
+        attention_mask=attention_mask,
+        compute_reference=True,
+        build_ttnn_cache=False,  # host-only; no mesh_device / weight_cache_path needed
+        seq_len=isl,
+    )
+
+    kv_lora_rank = variant.model_config.KV_LORA_RANK
+    out = write_trace_dir(out_dir, token_ids, result.ref_kvpe_list, kv_lora_rank)
+    logger.success(f"[gen-trace] wrote {num_layers}-layer golden trace to {out}")
+    return out
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--model", default=os.environ.get("PREFILL_MODEL", DEFAULT_MODEL))
+    p.add_argument("--prompt", default=None, help="raw prompt text")
+    p.add_argument("--prompt-file", default=None, help='JSON prompt file ([{"prompt": ...}] or {"prompts": [...]})')
+    p.add_argument("--isl", type=int, default=int(os.environ.get("PREFILL_MAX_SEQ_LEN", "1024")))
+    p.add_argument("--num-layers", type=int, default=int(os.environ.get("PREFILL_NUM_LAYERS", "2")))
+    p.add_argument("--out", required=True, help="output trace dir")
+    args = p.parse_args()
+
+    prompt_text = _load_prompt_text(args.prompt, args.prompt_file)
+    out = generate(args.model, prompt_text, args.isl, args.num_layers, Path(args.out))
+    # last stdout line: the trace dir, for a caller to capture
+    print(str(out))
+
+
+if __name__ == "__main__":
+    main()

--- a/models/demos/deepseek_v3_d_p/tt/runners/generate_prompt_trace.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/generate_prompt_trace.py
@@ -32,15 +32,24 @@ from models.demos.deepseek_v3_d_p.utils.transformer_helpers import (
 
 
 def _resolve_model_path(variant) -> Path:
-    """First of the variant's env var / local / shared path that holds an HF safetensors dir."""
-    candidates = [os.environ.get(variant.env_var), variant.default_local_path, variant.shared_path]
-    for c in candidates:
-        if c and Path(c).exists():
-            return Path(c)
+    """Resolve the same checkpoint the runner loads: ``PREFILL_HF_MODEL`` then the adapter's
+    ``hf_model_default`` (mirrors ``MLAPrefillAdapter.load_hf_config``), so the golden is generated
+    from the exact weights the device run validates against.
+
+    The runner reads only the config from this dir and pulls weights from the TTNN cache, so its
+    ``hf_model_default`` may be a config-only in-tree dir (kimi_k2_6, deepseek_v3). The golden runs
+    the torch/HF reference forward and needs real weights — require safetensors here and point the
+    user at PREFILL_HF_MODEL instead of failing deep in the weight load.
+    """
+    env = os.environ.get("PREFILL_HF_MODEL")
+    model_path = env or variant.hf_model_default
+    if model_path and Path(model_path).is_dir() and any(Path(model_path).glob("*.safetensors")):
+        return Path(model_path)
+    src = "PREFILL_HF_MODEL" if env else "hf_model_default"
     raise SystemExit(
-        f"No model dir found for {variant.name}: set {variant.env_var} to the HF safetensors dir "
-        f"(tried {variant.env_var}={os.environ.get(variant.env_var)!r}, "
-        f"{variant.default_local_path!r}, {variant.shared_path!r})"
+        f"No HF safetensors checkpoint for {variant.name} (tried {src}={model_path!r}): the "
+        f"prompt-trace golden needs real weights. Set PREFILL_HF_MODEL to an HF safetensors dir "
+        f"(hf_model_default may be a config-only in-tree dir whose weights live in the TTNN cache)."
     )
 
 

--- a/models/demos/deepseek_v3_d_p/tt/runners/generate_prompt_trace.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/generate_prompt_trace.py
@@ -57,14 +57,31 @@ def _load_config(model_path: Path, isl: int):
 
 def _load_prompt_text(prompt: str | None, prompt_file: str | None) -> str:
     if prompt is not None:
-        return prompt
-    if prompt_file is not None:
+        text = prompt
+    elif prompt_file is not None:
         data = json.loads(Path(prompt_file).read_text())
         if isinstance(data, dict):
             data = data.get("prompts", data)
-        item = data[0] if isinstance(data, list) else data
-        return item["prompt"] if isinstance(item, dict) else item
-    raise SystemExit("provide --prompt or --prompt-file")
+        if isinstance(data, list):
+            if not data:
+                raise SystemExit(f"no prompts in {prompt_file}")
+            # The reference forward validates one prompt; a multi-prompt file would silently drop the rest.
+            if len(data) > 1:
+                logger.warning(f"[gen-trace] {prompt_file} holds {len(data)} prompts; using index 0 only")
+            item = data[0]
+        else:
+            item = data
+        if isinstance(item, dict):
+            if "prompt" not in item:
+                raise SystemExit(f'prompt entry missing "prompt" key: {item!r}')
+            text = item["prompt"]
+        else:
+            text = item
+    else:
+        raise SystemExit("provide --prompt or --prompt-file")
+    if not isinstance(text, str) or not text.strip():
+        raise SystemExit("prompt is empty; provide non-empty prompt text")
+    return text
 
 
 def _meta_pe_to_hf(pe: torch.Tensor) -> torch.Tensor:
@@ -97,6 +114,11 @@ def write_trace_dir(out_dir: Path, token_ids: torch.Tensor, ref_kvpe_list, kv_lo
 
 def generate(model: str, prompt_text: str, isl: int, num_layers: int, out_dir: Path) -> Path:
     variant = get_adapter(model)
+    # Sparse/DSA models also keep an index-key cache (config 1); the producer's validation reads its
+    # golden from the trace dir, but this generator writes only the KVPE cache — so reject them loudly
+    # rather than emitting an incomplete golden that crashes downstream on missing index shards.
+    if hasattr(variant.model_config, "INDEX_HEAD_DIM"):
+        raise SystemExit(f"{model} is a sparse/DSA model; prompt-trace generation supports dense-KVPE MLA only")
     model_path = _resolve_model_path(variant)
     config = _load_config(model_path, isl)
     tokenizer = AutoTokenizer.from_pretrained(
@@ -105,6 +127,9 @@ def generate(model: str, prompt_text: str, isl: int, num_layers: int, out_dir: P
     tokenizer.padding_side = "right"
 
     token_ids, attention_mask, _ = tokenize_prompt_to_isl(tokenizer, max_isl=isl, prompt_text=prompt_text)
+    # A prompt that tokenizes to all padding produces a meaningless all-pad golden that still "passes" PCC.
+    if int(attention_mask.sum()) == 0:
+        raise SystemExit("prompt tokenized to zero real tokens (all padding)")
     logger.info(f"[gen-trace] model={model} isl={isl} num_layers={num_layers} tokens={token_ids.shape}")
 
     result = load_and_compute_layer_by_layer(


### PR DESCRIPTION
Add a device-less generator that builds a golden trace dir (token_ids + per-layer kv_post_transform) from a user prompt via the torch/HF reference, and an opt-in e2e scenario (PREFILL_PROMPT_FILE) that validates device KV against it.

this is useful when debugging issues that come up in disaggregated prefill so localize the issue quicker

make Kimi2.7 the default model for prefill runner/producer 

[![](https://github.com/tenstorrent/tt-metal/actions/workflows/blaze-models-prefill-tests.yaml/badge.svg?branch=worktree-prefill-prompt-kv-validation-50867)](https://github.com/tenstorrent/tt-metal/actions/runs/30360601330)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=worktree-prefill-prompt-kv-validation-50867)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:worktree-prefill-prompt-kv-validation-50867)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=worktree-prefill-prompt-kv-validation-50867)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:worktree-prefill-prompt-kv-validation-50867)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=worktree-prefill-prompt-kv-validation-50867)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:worktree-prefill-prompt-kv-validation-50867)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=worktree-prefill-prompt-kv-validation-50867)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:worktree-prefill-prompt-kv-validation-50867)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=worktree-prefill-prompt-kv-validation-50867)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:worktree-prefill-prompt-kv-validation-50867)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=worktree-prefill-prompt-kv-validation-50867)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:worktree-prefill-prompt-kv-validation-50867)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=worktree-prefill-prompt-kv-validation-50867)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:worktree-prefill-prompt-kv-validation-50867)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=worktree-prefill-prompt-kv-validation-50867)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:worktree-prefill-prompt-kv-validation-50867)