### PR TITLE
[Performance] Fabric: use stranded Mesh/Torus slots for worker injection

### DIFF
--- a/tests/tt_metal/tt_fabric/fabric_router/test_static_sized_channels_allocator.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_static_sized_channels_allocator.cpp
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <array>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "tt_metal/fabric/builder/fabric_static_sized_channels_allocator.hpp"
+
+namespace tt::tt_fabric {
+namespace {
+
+TEST(FabricStaticSizedChannelsAllocatorTest, MeshAssignsStrandedSlotsToLocalWorkerInjection) {
+    constexpr size_t channel_buffer_size = 14432;
+    constexpr size_t available_space = 365248;
+    constexpr std::array<size_t, builder_config::MAX_NUM_VCS> sender_channels = {4, 3, 0};
+    constexpr std::array<size_t, builder_config::MAX_NUM_VCS> receiver_channels = {1, 1, 0};
+    const std::vector<MemoryRegion> memory_regions = {{0, available_space}};
+
+    for (const auto topology : {Topology::Mesh, Topology::Torus}) {
+        const FabricStaticSizedChannelsAllocator allocator(
+            topology,
+            FabricEriscDatamoverOptions{},
+            sender_channels,
+            receiver_channels,
+            channel_buffer_size,
+            available_space,
+            memory_regions);
+
+        EXPECT_EQ(allocator.get_sender_channel_number_of_slots(0, 0), 7);
+        for (size_t channel = 1; channel < sender_channels[0]; ++channel) {
+            EXPECT_EQ(allocator.get_sender_channel_number_of_slots(0, channel), 2);
+        }
+        for (size_t channel = 0; channel < sender_channels[1]; ++channel) {
+            EXPECT_EQ(allocator.get_sender_channel_number_of_slots(1, channel), 2);
+        }
+        EXPECT_EQ(allocator.get_receiver_channel_number_of_slots(0, 0), 4);
+        EXPECT_EQ(allocator.get_receiver_channel_number_of_slots(1, 0), 2);
+
+        size_t allocated_slots = 0;
+        for (size_t vc = 0; vc < builder_config::MAX_NUM_VCS; ++vc) {
+            for (size_t channel = 0; channel < sender_channels[vc]; ++channel) {
+                allocated_slots += allocator.get_sender_channel_number_of_slots(vc, channel);
+            }
+            for (size_t channel = 0; channel < receiver_channels[vc]; ++channel) {
+                allocated_slots += allocator.get_receiver_channel_number_of_slots(vc, channel);
+            }
+        }
+        EXPECT_EQ(allocated_slots, available_space / channel_buffer_size);
+    }
+}
+
+TEST(FabricStaticSizedChannelsAllocatorTest, RingKeepsUniformChannelDepth) {
+    constexpr size_t channel_buffer_size = 14384;
+    constexpr size_t available_space = 366656;
+    constexpr std::array<size_t, builder_config::MAX_NUM_VCS> sender_channels = {2, 0, 0};
+    constexpr std::array<size_t, builder_config::MAX_NUM_VCS> receiver_channels = {1, 0, 0};
+    const std::vector<MemoryRegion> memory_regions = {{0, available_space}};
+
+    const FabricStaticSizedChannelsAllocator allocator(
+        Topology::Ring,
+        FabricEriscDatamoverOptions{},
+        sender_channels,
+        receiver_channels,
+        channel_buffer_size,
+        available_space,
+        memory_regions);
+
+    EXPECT_EQ(allocator.get_sender_channel_number_of_slots(0, 0), 8);
+    EXPECT_EQ(allocator.get_sender_channel_number_of_slots(0, 1), 8);
+    EXPECT_EQ(allocator.get_receiver_channel_number_of_slots(0, 0), 8);
+}
+
+}  // namespace
+}  // namespace tt::tt_fabric

--- a/tests/tt_metal/tt_fabric/fabric_router/test_static_sized_channels_allocator.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_static_sized_channels_allocator.cpp
@@ -14,7 +14,7 @@ namespace {
 
 TEST(FabricStaticSizedChannelsAllocatorTest, MeshAssignsStrandedSlotsToLocalWorkerInjection) {
     constexpr size_t channel_buffer_size = 14432;
-    constexpr size_t available_space = 365248;
+    constexpr size_t available_space = 360800;
     constexpr std::array<size_t, builder_config::MAX_NUM_VCS> sender_channels = {4, 3, 0};
     constexpr std::array<size_t, builder_config::MAX_NUM_VCS> receiver_channels = {1, 1, 0};
     const std::vector<MemoryRegion> memory_regions = {{0, available_space}};

--- a/tests/tt_metal/tt_fabric/sources.cmake
+++ b/tests/tt_metal/tt_fabric/sources.cmake
@@ -28,6 +28,7 @@ set(UNIT_TESTS_FABRIC_SRC
     fabric_router/test_fabric_topology_helpers.cpp
     fabric_router/test_fabric_opt_level.cpp
     fabric_router/test_channel_trimming_capture.cpp
+    fabric_router/test_static_sized_channels_allocator.cpp
     disaggregation/test_kv_chunk_address_table_protobuf.cpp
     fabric_data_movement/test_basic_fabric_apis.cpp
     fabric_data_movement/test_basic_1d_fabric.cpp

--- a/tt_metal/fabric/builder/fabric_static_sized_channels_allocator.cpp
+++ b/tt_metal/fabric/builder/fabric_static_sized_channels_allocator.cpp
@@ -468,8 +468,7 @@ void FabricStaticSizedChannelsAllocator::configure_buffer_slots_helper(
             vc0_vc2_mesh_buffer_slot_options);
         static ttsl::Indestructible<std::vector<std::vector<PerVcBufferSlots>>> vc0_vc1_vc2_mesh_slots(
             vc0_vc1_vc2_mesh_buffer_slot_options);
-        static ttsl::Indestructible<std::vector<std::vector<PerVcBufferSlots>>> other_slots(
-            other_buffer_slot_options);
+        static ttsl::Indestructible<std::vector<std::vector<PerVcBufferSlots>>> other_slots(other_buffer_slot_options);
 
         if (topology == Topology::Mesh || topology == Topology::Torus) {
             // Select table based on which VCs are actually active
@@ -688,6 +687,32 @@ void FabricStaticSizedChannelsAllocator::configure_buffer_slots_helper(
     num_remote_sender_buffer_slots_per_vc[2].fill(vc2_sender_buffer_slots);
     num_receiver_buffer_slots_per_vc[2].fill(vc2_receiver_buffer_slots);
     num_remote_receiver_buffer_slots_per_vc[2].fill(vc2_receiver_buffer_slots);
+
+    // Mesh allocation uses one conservative depth for every channel in a VC,
+    // which can leave whole packet slots unused. Give those slots to the live
+    // local-worker injection channel; forwarding and receive depths stay
+    // unchanged.
+    if ((topology == Topology::Mesh || topology == Topology::Torus) &&
+        options.fabric_tensix_config == tt::tt_fabric::FabricTensixConfig::DISABLED &&
+        num_used_sender_channels_per_vc[0] > 0) {
+        size_t allocated_slots = 0;
+        for (size_t vc = 0; vc < builder_config::MAX_NUM_VCS; ++vc) {
+            allocated_slots += std::accumulate(
+                num_sender_buffer_slots_per_vc[vc].begin(),
+                num_sender_buffer_slots_per_vc[vc].begin() + num_used_sender_channels_per_vc[vc],
+                size_t{0});
+            allocated_slots += std::accumulate(
+                num_receiver_buffer_slots_per_vc[vc].begin(),
+                num_receiver_buffer_slots_per_vc[vc].begin() + num_used_receiver_channels_per_vc[vc],
+                size_t{0});
+        }
+        const size_t slot_capacity = available_channel_buffering_space / channel_buffer_size_bytes;
+        TT_FATAL(allocated_slots <= slot_capacity, "Fabric channel allocation exceeds its slot capacity");
+        const size_t spare_slots = slot_capacity - allocated_slots;
+        const uint32_t worker_channel = get_worker_connected_sender_channel();
+        num_sender_buffer_slots_per_vc[0][worker_channel] += spare_slots;
+        num_remote_sender_buffer_slots_per_vc[0][worker_channel] += spare_slots;
+    }
 }
 
 void FabricStaticSizedChannelsAllocator::emit_ct_args(std::vector<uint32_t>& ct_args) const {

--- a/tt_metal/fabric/builder/fabric_static_sized_channels_allocator.cpp
+++ b/tt_metal/fabric/builder/fabric_static_sized_channels_allocator.cpp
@@ -270,7 +270,7 @@ FabricStaticSizedChannelsAllocator::FabricStaticSizedChannelsAllocator(
         total_size,
         this->available_channel_buffering_space);
     TT_FATAL(
-        buffer_addr_end < this->max_l1_loading_size,
+        buffer_addr_end <= this->max_l1_loading_size,
         "Internal error - channel buffers spilled past the end of usable L1 region.");
 }
 
@@ -693,8 +693,7 @@ void FabricStaticSizedChannelsAllocator::configure_buffer_slots_helper(
     // local-worker injection channel; forwarding and receive depths stay
     // unchanged.
     if ((topology == Topology::Mesh || topology == Topology::Torus) &&
-        options.fabric_tensix_config == tt::tt_fabric::FabricTensixConfig::DISABLED &&
-        num_used_sender_channels_per_vc[0] > 0) {
+        options.fabric_tensix_config == tt::tt_fabric::FabricTensixConfig::DISABLED) {
         size_t allocated_slots = 0;
         for (size_t vc = 0; vc < builder_config::MAX_NUM_VCS; ++vc) {
             allocated_slots += std::accumulate(


### PR DESCRIPTION
### PR Category
Performance

### Summary
Mesh/Torus static channel allocation chooses a conservative uniform buffer depth for each active VC. Because the result is quantized to whole packet slots, it can leave usable L1 slots unallocated while VC0 local-worker injection is still credit-limited. This is especially visible for high-rate Fabric2D CCL traffic.

This change gives only the stranded remainder to the live VC0 local-worker sender when Fabric Tensix muxing is disabled. It preserves forwarding and receiver depths, mirrors the sender depth for the remote view, and asserts that the total allocation remains within the existing slot capacity. Fabric1D Ring keeps its uniform allocation.

On the 8-device, two-link Fabric2D high-bandwidth all-gather workload that motivated this work, worker injection depth increases from 2 to 7 slots. BF16 effective receive bandwidth improved from 82.95 to 93.90 GB/s (6.371 to 5.628 ms); scaled FP8 improved from 83.07 to 93.27 GB/s (3.888 to 3.463 ms).

### Mesh ubench A/B: Blackhole P150x8
I ran the Fabric2D Mesh ubench with Fabric Tensix disabled, topology.Mesh, and fixed seed 424242 on the same eight-device P150 host (firmware 19.10.99). Each revision was run twice: baseline `b2761707eda` and this PR `5895b344935`; all four runs passed 106/106 executed cases.

The two-run aggregate bandwidth result is -0.15% (geometric mean), with Mesh multicast and custom-packet multicast flat (within about 0.23% and 0.04%, respectively). The focused single-sender unicast workload has a repeatable NOC-mode tradeoff:
- NOC unicast write: -2.04%
- NOC scatter write: -2.68%
- NOC fused atomic increment: +3.66%

Average latency was +0.16% (changed/baseline; higher is worse), which is within the observed run-to-run variation. This validates that there is no broad Fabric2D Mesh ubench regression, but it also quantifies the expected non-power-of-two-path tradeoff for the write/scatter cases. This ubench is complementary to, not a replacement for, the targeted CCL all-gather result above.

### Triggered CI
All links show runs for this branch.

[![TM-Fabric](https://github.com/tenstorrent/tt-metal/actions/workflows/tm-fabric-tests.yaml/badge.svg?branch=pjosipovic%2Ffabric-worker-injection-spare-slots)](https://github.com/tenstorrent/tt-metal/actions/workflows/tm-fabric-tests.yaml?query=branch%3Apjosipovic%2Ffabric-worker-injection-spare-slots) [![Fabric microbenchmarks](https://github.com/tenstorrent/tt-metal/actions/workflows/metal-run-microbenchmarks.yaml/badge.svg?branch=pjosipovic%2Ffabric-worker-injection-spare-slots)](https://github.com/tenstorrent/tt-metal/actions/workflows/metal-run-microbenchmarks.yaml?query=branch%3Apjosipovic%2Ffabric-worker-injection-spare-slots) [![Galaxy Fabric2D Torus](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic%2Ffabric-worker-injection-spare-slots)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch%3Apjosipovic%2Ffabric-worker-injection-spare-slots)
[![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic%2Ffabric-worker-injection-spare-slots)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch%3Apjosipovic%2Ffabric-worker-injection-spare-slots) [![Blackhole sanity](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=pjosipovic%2Ffabric-worker-injection-spare-slots)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch%3Apjosipovic%2Ffabric-worker-injection-spare-slots)

### Notes for reviewers
- Scope is intentionally narrow: Mesh/Torus only, VC0 worker injection only, and only when Fabric Tensix muxing is disabled.
- No new L1 capacity is consumed; the change redistributes capacity that the uniform allocation left unused.
- New allocator unit coverage checks that Mesh/Torus consumes the available slots and that Ring allocation is unchanged.
- Local validation: the focused allocator gtest passed; the Blackhole P150x8 2x2 Fabric ubench completed. This host has no matching checked-in P150x8 golden, so the local ubench records measurements rather than a golden pass/fail comparison.

### Required validation
- Explicitly run `FabricStaticSizedChannelsAllocatorTest.*`. The default Fabric CI scripts currently filter it out, so this needs an explicit CI entry or command.
- Blackhole Fabric2D functional coverage and the Blackhole 2x2 Fabric BW/latency ubench with Fabric Tensix disabled.
- T3K Fabric BW/latency ubench with Fabric Tensix disabled, as cross-architecture regression coverage.

Mux bandwidth tests are not a direct requirement for this change: the altered allocation is gated to Fabric Tensix disabled.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/fabric-worker-injection-spare-slots)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/fabric-worker-injection-spare-slots)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/fabric-worker-injection-spare-slots)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/fabric-worker-injection-spare-slots)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=pjosipovic/fabric-worker-injection-spare-slots)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:pjosipovic/fabric-worker-injection-spare-slots)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/fabric-worker-injection-spare-slots)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/fabric-worker-injection-spare-slots)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/fabric-worker-injection-spare-slots)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/fabric-worker-injection-spare-slots)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/fabric-worker-injection-spare-slots)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/fabric-worker-injection-spare-slots)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/fabric-worker-injection-spare-slots)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/fabric-worker-injection-spare-slots)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/fabric-worker-injection-spare-slots)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/fabric-worker-injection-spare-slots)