### PR TITLE
#47299: Enable native path for RM HEIGHT-sharded sub-NoC-aligned sticks in TM ops

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_gather.py
+++ b/tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_gather.py
@@ -498,10 +498,11 @@ def test_gather_rm_sharded_in_sharded_no_spec_out(device):
 # ────────────────────────────────────────────────────────────────────────────────
 
 
-# NoC-aligned shapes only. W=97 deferred pending the cross-op helper fix in #47299.
+# shape_32x97 is the sub-NoC-aligned stick case that regressed on the pages_per_row helper (#47299).
 _IRREGULAR_SHAPES = [
     pytest.param((1, 1, 65, 96), (1, 1, 65, 48), id="shape_65x96"),
     pytest.param((1, 1, 33, 64), (1, 1, 33, 32), id="shape_33x64"),
+    pytest.param((1, 1, 32, 97), (1, 1, 32, 49), id="shape_32x97"),
 ]
 
 
@@ -532,7 +533,7 @@ def test_gather_irregular_shapes_interleaved(input_shape, index_shape, layout, d
 )
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT], ids=["TILE", "RM"])
 def test_gather_irregular_shapes_sharded(input_shape, index_shape, shard_factory, layout, device):
-    """2 shapes × 3 shard layouts × 2 element layouts; RM B/W-sharded routes via composite arm."""
+    """3 shapes × 3 shard layouts × 2 element layouts; RM B/W-sharded routes via composite arm."""
     # block_sharded helper has no num_cores arg.
     if shard_factory is _block_sharded:
         in_mc = shard_factory(input_shape, device, layout=layout)
@@ -549,6 +550,44 @@ def test_gather_irregular_shapes_sharded(input_shape, index_shape, shard_factory
         idx_mc,
         L1_INTERLEAVED,
         ttnn.bfloat16,
+        device,
+    )
+
+
+# f32 regression for the newly-native RM HEIGHT-sh sub-NoC-aligned stick (#47299).
+def test_gather_rm_height_sub_noc_aligned_stick_float32(device):
+    input_shape, index_shape = (1, 1, 32, 97), (1, 1, 32, 49)
+    in_mc = _height_sharded(input_shape, device, num_cores=4, layout=ttnn.ROW_MAJOR_LAYOUT)
+    idx_mc = _height_sharded(index_shape, device, num_cores=4, layout=ttnn.ROW_MAJOR_LAYOUT)
+    _run_gather(
+        input_shape,
+        index_shape,
+        -1,
+        ttnn.ROW_MAJOR_LAYOUT,
+        in_mc,
+        idx_mc,
+        L1_INTERLEAVED,
+        ttnn.float32,
+        device,
+    )
+
+
+# WIDTH-sh split-branch lock-down: pages_per_row = 4 (W=128, shard_W=32) exercises
+# sharded_src_id = src_id * pages_per_row + offset / page_size under the new div_up formula.
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32], ids=["bf16", "f32"])
+def test_gather_rm_width_sharded_split_branch_stride(dtype, device):
+    input_shape, index_shape = (1, 1, 32, 128), (1, 1, 32, 64)
+    in_mc = _width_sharded(input_shape, device, num_cores=4, layout=ttnn.ROW_MAJOR_LAYOUT)
+    idx_mc = _width_sharded(index_shape, device, num_cores=4, layout=ttnn.ROW_MAJOR_LAYOUT)
+    _run_gather(
+        input_shape,
+        index_shape,
+        -1,
+        ttnn.ROW_MAJOR_LAYOUT,
+        in_mc,
+        idx_mc,
+        L1_INTERLEAVED,
+        dtype,
         device,
     )
 

--- a/tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_permute.py
+++ b/tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_permute.py
@@ -584,6 +584,8 @@ _IRREGULAR_SHAPES = [
     ((2, 3, 71, 79), (0, 1, 3, 2)),
     ((1, 13, 47, 64), (0, 2, 1, 3)),
     ((3, 5, 32, 64), (1, 0, 2, 3)),
+    # Sub-NoC-aligned stick (W·E % 16 != 0) — guards HEIGHT-sh RM native path (#47299).
+    ((1, 1, 32, 97), (0, 1, 3, 2)),
 ]
 
 
@@ -601,6 +603,8 @@ def test_permute_irregular_shapes_interleaved(shape, dims, input_layout, device)
         pytest.param((2, 3, 71, 79), (0, 1, 3, 2), _height_shard_config, id="71x79_height"),
         pytest.param((1, 13, 47, 64), (0, 2, 1, 3), _width_shard_config, id="47x64_width"),
         pytest.param((3, 5, 32, 64), (1, 0, 2, 3), _block_shard_config, id="32x64_block"),
+        # HEIGHT-sh route for the sub-NoC-aligned stick (native RM after #47299).
+        pytest.param((1, 1, 32, 97), (0, 1, 3, 2), _height_shard_config, id="32x97_height"),
     ],
 )
 @pytest.mark.parametrize("input_layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT])
@@ -611,6 +615,19 @@ def test_permute_irregular_shapes_sharded(shape, dims, shard_factory, input_layo
         device,
         input_layout=input_layout,
         input_mem_config=shard_factory(shape, device, layout=input_layout),
+    )
+
+
+# f32 sibling for the newly-native RM HEIGHT-sh sub-NoC-aligned stick (#47299).
+def test_permute_rm_height_sharded_sub_noc_aligned_stick_float32(device):
+    shape = (1, 1, 32, 49)  # W·E = 49·4 = 196 bytes → 196 % 16 = 4
+    run_permute_test(
+        shape,
+        (0, 1, 3, 2),
+        device,
+        input_layout=ttnn.ROW_MAJOR_LAYOUT,
+        input_mem_config=_height_shard_config(shape, device, layout=ttnn.ROW_MAJOR_LAYOUT),
+        dtype=ttnn.float32,
     )
 
 

--- a/tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_slice.py
+++ b/tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_slice.py
@@ -554,6 +554,20 @@ def test_slice_irregular_shapes_sharded(shape, begins, ends, step, shard_factory
     )
 
 
+# RM HEIGHT-sh in + interleaved out: routes SliceRmProgramFactory whose reader uses
+# noc_async_read_sharded — the fast-path enabled by #47299 for sub-NoC-aligned sticks (W·E % 16 ≠ 0).
+@pytest.mark.parametrize(
+    "shape, begins, ends, step, dtype",
+    [
+        pytest.param((1, 1, 32, 97), (0, 0, 0, 0), (1, 1, 32, 49), (1, 1, 1, 1), ttnn.bfloat16, id="bf16_W97"),
+        pytest.param((1, 1, 32, 49), (0, 0, 0, 0), (1, 1, 32, 33), (1, 1, 1, 1), ttnn.float32, id="f32_W49"),
+    ],
+)
+def test_slice_rm_height_sharded_sub_noc_aligned_stick(shape, begins, ends, step, dtype, device):
+    in_mc = _height_sharded(shape, device, num_cores=4, layout=ttnn.ROW_MAJOR_LAYOUT)
+    _run_slice(shape, begins, ends, step, ttnn.ROW_MAJOR_LAYOUT, in_mc, L1_INTERLEAVED, dtype, device)
+
+
 # ────────────────────────────────────────────────────────────────────────────────
 # Group F: Sharded inputs with explicit grids/shapes — irregular logical dims, uneven splits.
 # ────────────────────────────────────────────────────────────────────────────────

--- a/tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_tranpose.py
+++ b/tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_tranpose.py
@@ -511,6 +511,8 @@ _IRREGULAR_SHAPES = [
     ((1, 13, 47, 64), 1, 2),
     ((1, 7, 33, 96), 1, 2),
     ((3, 5, 32, 64), 0, 1),
+    # Sub-NoC-aligned stick (W·E % 16 != 0) — guards HEIGHT-sh RM native path (#47299).
+    ((1, 1, 32, 97), 2, 3),
 ]
 
 
@@ -538,6 +540,20 @@ def test_transpose_irregular_shapes_sharded(shape, dim0, dim1, shard_factory, in
         device,
         input_layout=input_layout,
         input_mem_config=shard_factory(shape, device, layout=input_layout),
+    )
+
+
+# f32 sibling for the newly-native RM HEIGHT-sh sub-NoC-aligned stick (#47299).
+def test_transpose_rm_height_sharded_sub_noc_aligned_stick_float32(device):
+    shape = (1, 1, 32, 49)  # W·E = 49·4 = 196 bytes → 196 % 16 = 4
+    run_transpose_test(
+        shape,
+        2,
+        3,
+        device,
+        input_layout=ttnn.ROW_MAJOR_LAYOUT,
+        input_mem_config=_height_shard_config(shape, device, layout=ttnn.ROW_MAJOR_LAYOUT),
+        dtype=ttnn.float32,
     )
 
 

--- a/ttnn/cpp/ttnn/operations/data_movement/common/common.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/common/common.cpp
@@ -719,4 +719,17 @@ uint32_t get_num_pages(const ttnn::Tensor& tensor) {
     return tt::div_up(tensor.padded_shape().volume(), tile_shape[0] * tile_shape[1]);
 }
 
+uint32_t per_shard_page_size_bytes(const ttnn::Tensor& t, uint32_t row_bytes) {
+    const auto& mc = t.memory_config();
+    if (mc.is_sharded() && (mc.memory_layout() == tt::tt_metal::TensorMemoryLayout::BLOCK_SHARDED ||
+                            mc.memory_layout() == tt::tt_metal::TensorMemoryLayout::WIDTH_SHARDED)) {
+        const auto& spec = mc.shard_spec().value();
+        return spec.shape[1] * t.element_size();
+    }
+    if (mc.is_sharded()) {
+        return static_cast<uint32_t>(t.buffer()->aligned_page_size());
+    }
+    return row_bytes;
+}
+
 }  // namespace ttnn::operations::data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/common/common.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/common/common.hpp
@@ -229,4 +229,7 @@ std::pair<uint32_t, std::array<uint32_t, 2>> tensor_coord_to_height_sharded_coor
 
 uint32_t get_num_pages(const ttnn::Tensor& tensor);
 
+// B/W-sh → shard_W*E (feeds split branch); other sharded → buffer->aligned_page_size() (16-aligned L1 stride).
+uint32_t per_shard_page_size_bytes(const ttnn::Tensor& tensor, uint32_t row_bytes);
+
 }  // namespace ttnn::operations::data_movement

--- a/ttnn/cpp/ttnn/operations/data_movement/common/kernels/common.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/common/kernels/common.hpp
@@ -286,10 +286,8 @@ struct ByteSizeAddressType<Size, typename std::enable_if<Size == 4>::type> {
 // buffers, HEIGHT-sharded RM (whole row stays on one core), and shards whose width covers
 // the full row.
 //
-// dest_id is a logical row index; pages_per_row converts it to the starting page index in
-// the destination buffer. pages_per_row is the last (W) axis of dspec.tensor_shape() after
-// squeeze — equivalent to (and now generalized from) the prior tensor_shape()[1] indexing,
-// which assumed a fully-squeezed 2D dspec and so misread the C dim for 4D NCHW inputs.
+// pages_per_row = ceil(tensor_W_pages / shard_W_pages); HEIGHT-sh collapses to 1 for any W·E.
+// Split-branch stride is exact iff shard_W_pages == 1 (RM B/W-sh: one shard-row = one page).
 template <typename AddrGenType>
 FORCE_INLINE void noc_async_write_sharded(
     Noc noc, uint32_t l1_addr, AddrGenType tensor, uint32_t dest_id, uint32_t offset, uint32_t size) {
@@ -299,7 +297,8 @@ FORCE_INLINE void noc_async_write_sharded(
     } else {
         const auto& dspec = tensor.dspec();
         const uint32_t r = dspec.rank();
-        const uint32_t pages_per_row = (r > 1) ? dspec.tensor_shape()[r - 1] : 1u;
+        const uint32_t shard_W = (r >= 1) ? dspec.shard_shape()[r - 1] : 1u;
+        const uint32_t pages_per_row = (r > 1 && shard_W > 0) ? div_up(dspec.tensor_shape()[r - 1], shard_W) : 1u;
         if (pages_per_row <= 1) {
             noc.async_write(
                 CoreLocalMem<uint32_t>(l1_addr), tensor, size, {}, {.page_id = dest_id, .offset_bytes = offset});
@@ -344,7 +343,8 @@ FORCE_INLINE void noc_async_read_sharded(
     } else {
         const auto& dspec = tensor.dspec();
         const uint32_t r = dspec.rank();
-        const uint32_t pages_per_row = (r > 1) ? dspec.tensor_shape()[r - 1] : 1u;
+        const uint32_t shard_W = (r >= 1) ? dspec.shard_shape()[r - 1] : 1u;
+        const uint32_t pages_per_row = (r > 1 && shard_W > 0) ? div_up(dspec.tensor_shape()[r - 1], shard_W) : 1u;
         if (pages_per_row <= 1) {
             noc.async_read(
                 tensor, CoreLocalMem<uint32_t>(l1_addr), size, {.page_id = src_id, .offset_bytes = offset}, {});

--- a/ttnn/cpp/ttnn/operations/data_movement/gather/device/gather_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/gather/device/gather_program_factory.cpp
@@ -7,9 +7,11 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/work_split.hpp>
+#include "ttnn/operations/data_movement/common/common.hpp"
 
 namespace ttnn::prim {
 using namespace tt::tt_metal;
+using ttnn::operations::data_movement::per_shard_page_size_bytes;
 
 namespace {
 
@@ -33,17 +35,6 @@ constexpr const char* kReaderRmMulti =
 constexpr const char* kWriterRmMulti =
     "ttnn/cpp/ttnn/operations/data_movement/gather/device/kernels/dataflow/"
     "gather_writer_rm_single_row_multi_core.cpp";
-
-// Per-shard page size for noc_async_*_sharded: shard_W * elem_size on B/W, full row otherwise.
-uint32_t per_shard_page_size_bytes(const Tensor& t, uint32_t row_bytes) {
-    const auto& mc = t.memory_config();
-    if (mc.is_sharded() && (mc.memory_layout() == TensorMemoryLayout::BLOCK_SHARDED ||
-                            mc.memory_layout() == TensorMemoryLayout::WIDTH_SHARDED)) {
-        const auto& spec = mc.shard_spec().value();
-        return spec.shape[1] * t.element_size();
-    }
-    return row_bytes;
-}
 
 }  // namespace
 

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm.cpp
@@ -97,17 +97,6 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
     uint32_t misalignment = begins_bytes % src_buffer_alignment;
     uint32_t unpadded_row_size_bytes_offset = tt::round_up(unpadded_row_size_bytes, alignment);
 
-    // shard_W * elem_size for B/W-sharded (splits row across shards); full row otherwise.
-    // Fallback is padded for the reader tensor, unpadded for the writer tensor.
-    const auto per_shard_page_size_bytes = [&](const Tensor& t, uint32_t row_bytes) -> uint32_t {
-        const auto& mc = t.memory_config();
-        if (mc.is_sharded() && (mc.memory_layout() == TensorMemoryLayout::BLOCK_SHARDED ||
-                                mc.memory_layout() == TensorMemoryLayout::WIDTH_SHARDED)) {
-            const auto& spec = mc.shard_spec().value();
-            return spec.shape[1] * t.element_size();
-        }
-        return row_bytes;
-    };
     const uint32_t reader_page_size = per_shard_page_size_bytes(input_tensor, padded_row_size_bytes);
 
     std::vector<uint32_t> common_reader_kernel_args = {


### PR DESCRIPTION
### Ticket
Link to Github Issue #47299

### Problem
RM HEIGHT-sharded `gather` / `slice` / `transpose` / `permute` hang on sub-NoC-aligned sticks (`W · elem_size % 16 ≠ 0`): `noc_async_{read,write}_sharded` misreads `pages_per_row` from an unsqueezed dspec, and `per_shard_page_size_bytes` returns an unpadded row size that diverges from L1's 16-aligned stride.

### What this PR does
- **Derive `pages_per_row` from shard geometry** in `noc_async_{read,write}_sharded` — `ceil(tensor_W_pages / shard_W_pages)`. HEIGHT-sh collapses to 1 for any `W · E`, taking the single-shot fast path.
- **HEIGHT-sh page size = `buffer()->aligned_page_size()`** in `gather_program_factory` and `slice_program_factory_rm` — aligns the accessor's stride with L1's padded row layout.
- **Centralize `per_shard_page_size_bytes`** in `data_movement/common/common.{hpp,cpp}` — one source of truth for gather + slice (replaces two local copies).
- **Regression tests** — `(1, 1, 32, 97)` HEIGHT-sh sub-NoC-aligned coverage across gather / slice / transpose / permute (bf16 + f32) + WIDTH-sh split-branch stride lock-down in gather.

### Tests
Wormhole B0 (N150):
- `test_universal_input_tm_gather.py::test_gather_irregular_shapes_*[shape_32x97]` × 8 — **PASSED**
- `test_universal_input_tm_gather.py::test_gather_rm_width_sharded_split_branch_stride[bf16, f32]` — **PASSED**
- `test_universal_input_tm_slice.py::test_slice_rm_height_sharded_sub_noc_aligned_stick[bf16_W97, f32_W49]` — **PASSED**
- `test_universal_input_tm_tranpose.py::test_transpose_rm_height_sharded_sub_noc_aligned_stick_float32` — **PASSED**
- `test_universal_input_tm_permute.py::test_permute_irregular_shapes_sharded[32x97_height]` × 2 + `test_permute_rm_height_sharded_sub_noc_aligned_stick_float32` — **PASSED**


### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mouliraj/optimize_tm_ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mouliraj/optimize_tm_ops)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mouliraj/optimize_tm_ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mouliraj/optimize_tm_ops)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mouliraj/optimize_tm_ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mouliraj/optimize_tm_ops)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mouliraj/optimize_tm_ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mouliraj/optimize_tm_ops)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mouliraj/optimize_tm_ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mouliraj/optimize_tm_ops)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mouliraj/optimize_tm_ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mouliraj/optimize_tm_ops)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mouliraj/optimize_tm_ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mouliraj/optimize_tm_ops)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mouliraj/optimize_tm_ops)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mouliraj/optimize_tm_ops)
