### PR TITLE
Test Only: Add Quasar coverage to LLK perf workflow

### DIFF
--- a/.github/scripts/utils/find-changed-files.sh
+++ b/.github/scripts/utils/find-changed-files.sh
@@ -85,7 +85,7 @@ while IFS= read -r FILE; do
         tt_metal/tt-llk/tests/**)
             LLK_TESTS_CHANGED=true
             ;;
-        .github/workflows/llk-*.yaml|.github/scripts/llk-*.sh|tests/pipeline_reorg/llk_unit_tests.yaml|tests/pipeline_reorg/llk_merge_gate_tests.yaml)
+        .github/workflows/llk-*.yaml|.github/workflows/build-quasar-perf.yml|.github/scripts/llk-*.sh|tests/pipeline_reorg/llk_unit_tests.yaml|tests/pipeline_reorg/llk_merge_gate_tests.yaml)
             LLK_CI_CHANGED=true
             ;;
         tt_metal/**/*.@(h|hpp|c|cpp|cc|py))

--- a/.github/workflows/_auto-retry-nightly-workflows.yaml
+++ b/.github/workflows/_auto-retry-nightly-workflows.yaml
@@ -21,6 +21,7 @@ on:
       - "(Runtime) Sanity Tests"
       - "(Runtime) Performance Tests"
       - "Blaze Models Prefill tests"
+      - "LLK perf"
     types:
       - completed
 

--- a/.github/workflows/build-quasar-perf.yml
+++ b/.github/workflows/build-quasar-perf.yml
@@ -71,7 +71,5 @@ jobs:
         if: always()
         with:
           report_paths: ${{ env.LLK_PATH }}/tests/python_tests/pytest-report-quasar-compile.xml
-          check_name: Quasar Performance Compile Tests
-          detailed_summary: true
           include_passed: true
-          fail_on_failure: false
+          annotate_only: true

--- a/.github/workflows/build-quasar-perf.yml
+++ b/.github/workflows/build-quasar-perf.yml
@@ -19,7 +19,6 @@ on:
         type: number
 
 permissions:
-  checks: write
   contents: read
   packages: read
 
@@ -67,9 +66,8 @@ jobs:
           path: ${{ env.LLK_PATH }}/tests/python_tests/pytest-report-quasar-compile.xml
 
       - name: Publish Test Results
-        uses: mikepenz/action-junit-report@v5
+        uses: mikepenz/action-junit-report@3585e9575db828022551b4231f165eb59a0e74e3 # v5.6.2
         if: always()
         with:
           report_paths: ${{ env.LLK_PATH }}/tests/python_tests/pytest-report-quasar-compile.xml
-          include_passed: true
           annotate_only: true

--- a/.github/workflows/build-quasar-perf.yml
+++ b/.github/workflows/build-quasar-perf.yml
@@ -1,0 +1,77 @@
+name: "Compile Quasar performance tests"
+
+on:
+  workflow_call:
+    inputs:
+      docker_image:
+        description: "Docker image containing the LLK build environment"
+        required: true
+        type: string
+      runs_on:
+        description: "Runner used to compile the tests"
+        required: false
+        default: tt-ubuntu-2204-large-stable
+        type: string
+      timeout_minutes:
+        description: "Timeout in minutes for the compile job"
+        required: false
+        default: 30
+        type: number
+
+permissions:
+  checks: write
+  contents: read
+  packages: read
+
+env:
+  LLK_PATH: tt_metal/tt-llk
+
+jobs:
+  compile-quasar-perf:
+    runs-on: ${{ inputs.runs_on }}
+    timeout-minutes: ${{ inputs.timeout_minutes }}
+    container:
+      image: ${{ inputs.docker_image }}
+    name: "Quasar perf compile"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        timeout-minutes: 20
+
+      - name: Install SFPI
+        shell: bash
+        working-directory: ${{ env.LLK_PATH }}
+        run: |
+          cd tests
+          CHIP_ARCH=quasar ./setup_testing_env.sh
+          cd ..
+
+      - name: Compile Quasar performance tests
+        shell: bash
+        working-directory: ${{ env.LLK_PATH }}/tests/python_tests
+        run: |
+          export CHIP_ARCH=quasar
+          echo "CHIP_ARCH=$CHIP_ARCH" >> "$GITHUB_ENV"
+
+          pytest -q --compile-producer -n 40 \
+            -m "perf and quasar" \
+            --override-ini="addopts=-v" --tb=short --timeout=60 \
+            --junitxml=pytest-report-${CHIP_ARCH}-compile.xml \
+            quasar/perf_*_quasar.py
+
+      - name: Upload JUnit report
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        if: always()
+        with:
+          name: perf-junit-report-quasar-compile
+          path: ${{ env.LLK_PATH }}/tests/python_tests/pytest-report-quasar-compile.xml
+
+      - name: Publish Test Results
+        uses: mikepenz/action-junit-report@v5
+        if: always()
+        with:
+          report_paths: ${{ env.LLK_PATH }}/tests/python_tests/pytest-report-quasar-compile.xml
+          check_name: Quasar Performance Compile Tests
+          detailed_summary: true
+          include_passed: true
+          fail_on_failure: false

--- a/.github/workflows/build-quasar-perf.yml
+++ b/.github/workflows/build-quasar-perf.yml
@@ -55,7 +55,7 @@ jobs:
 
           pytest -q --compile-producer -n 40 \
             -m "perf and quasar" \
-            --override-ini="addopts=-v" --tb=short --timeout=60 \
+            --override-ini="log_cli=false" --tb=short --timeout=60 \
             --junitxml=pytest-report-${CHIP_ARCH}-compile.xml \
             quasar/perf_*_quasar.py
 

--- a/.github/workflows/build-quasar-perf.yml
+++ b/.github/workflows/build-quasar-perf.yml
@@ -52,7 +52,7 @@ jobs:
           export CHIP_ARCH=quasar
           echo "CHIP_ARCH=$CHIP_ARCH" >> "$GITHUB_ENV"
 
-          pytest -q --compile-producer -n 40 \
+          pytest -q --compile-producer -n 8 \
             -m "perf and quasar" \
             --override-ini="log_cli=false" --tb=short --timeout=60 \
             --junitxml=pytest-report-${CHIP_ARCH}-compile.xml \

--- a/.github/workflows/llk-perf-impl.yaml
+++ b/.github/workflows/llk-perf-impl.yaml
@@ -5,7 +5,7 @@ on:
   workflow_call:
     inputs:
       architecture:
-        description: "Architecture to run: all, wormhole, or blackhole"
+        description: "Architecture to run: all, wormhole, blackhole, or quasar"
         required: false
         default: all
         type: string
@@ -25,6 +25,7 @@ jobs:
     secrets: inherit
 
   load-test-matrix:
+    if: ${{ inputs.architecture != 'quasar' }}
     runs-on: ubuntu-slim
     needs: [build-images]
     outputs:
@@ -76,9 +77,16 @@ jobs:
             ./.github/sku_config.yaml \
             "${SKU_ALLOWLIST_ARGS[@]}"
 
+  compile-quasar-perf:
+    if: ${{ inputs.architecture == 'all' || inputs.architecture == 'quasar' }}
+    needs: [build-images]
+    uses: ./.github/workflows/build-quasar-perf.yml
+    with:
+      docker_image: ${{ needs.build-images.outputs.llk-ci-tag }}
+
   llk-perf-exec:
     needs: [load-test-matrix, build-images]
-    if: ${{ needs.load-test-matrix.outputs.matrix != '[]' }}
+    if: ${{ inputs.architecture != 'quasar' && needs.load-test-matrix.outputs.matrix != '[]' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/llk-perf-impl.yaml
+++ b/.github/workflows/llk-perf-impl.yaml
@@ -57,13 +57,13 @@ jobs:
         run: |
           case "$ARCHITECTURE" in
             all)
-              SKU_ALLOWLIST_ARGS=()
+              ENABLED_SKUS="ALL_SKUS_IN_TESTS"
               ;;
             wormhole)
-              SKU_ALLOWLIST_ARGS=(--sku-allowlist "wh_n150_civ2")
+              ENABLED_SKUS="wh_n150_civ2"
               ;;
             blackhole)
-              SKU_ALLOWLIST_ARGS=(--sku-allowlist "bh_p150b_civ2")
+              ENABLED_SKUS="bh_p150b_civ2"
               ;;
             *)
               echo "::error::Unsupported architecture '$ARCHITECTURE'"
@@ -73,9 +73,8 @@ jobs:
 
           python3 .github/scripts/utils/prepare_test_matrix.py \
             ${{ env.TESTS_YAML_PATH }} \
-            "ALL_SKUS_IN_TESTS" \
-            ./.github/sku_config.yaml \
-            "${SKU_ALLOWLIST_ARGS[@]}"
+            "$ENABLED_SKUS" \
+            ./.github/sku_config.yaml
 
   compile-quasar-perf:
     if: ${{ inputs.architecture == 'all' || inputs.architecture == 'quasar' }}

--- a/.github/workflows/llk-perf-impl.yaml
+++ b/.github/workflows/llk-perf-impl.yaml
@@ -3,6 +3,12 @@ name: "LLK perf impl"
 
 on:
   workflow_call:
+    inputs:
+      architecture:
+        description: "Architecture to run: all, wormhole, or blackhole"
+        required: false
+        default: all
+        type: string
 
 permissions:
   checks: write
@@ -45,11 +51,30 @@ jobs:
             "perf"
       - name: Build test matrix
         id: build-matrix
+        env:
+          ARCHITECTURE: ${{ inputs.architecture }}
         run: |
+          case "$ARCHITECTURE" in
+            all)
+              SKU_ALLOWLIST_ARGS=()
+              ;;
+            wormhole)
+              SKU_ALLOWLIST_ARGS=(--sku-allowlist "wh_n150_civ2")
+              ;;
+            blackhole)
+              SKU_ALLOWLIST_ARGS=(--sku-allowlist "bh_p150b_civ2")
+              ;;
+            *)
+              echo "::error::Unsupported architecture '$ARCHITECTURE'"
+              exit 1
+              ;;
+          esac
+
           python3 .github/scripts/utils/prepare_test_matrix.py \
             ${{ env.TESTS_YAML_PATH }} \
             "ALL_SKUS_IN_TESTS" \
-            ./.github/sku_config.yaml
+            ./.github/sku_config.yaml \
+            "${SKU_ALLOWLIST_ARGS[@]}"
 
   llk-perf-exec:
     needs: [load-test-matrix, build-images]

--- a/.github/workflows/llk-perf.yaml
+++ b/.github/workflows/llk-perf.yaml
@@ -23,8 +23,8 @@ permissions:
   packages: write
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref_protected && github.run_id ||
-    github.ref }}
+  group: ${{ github.workflow }}-${{ inputs.architecture || 'all' }}-${{
+    github.ref_protected && github.run_id || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/llk-perf.yaml
+++ b/.github/workflows/llk-perf.yaml
@@ -5,6 +5,16 @@ on:
     # Run every night at 3AM UTC
     - cron: '0 3 * * *'
   workflow_dispatch:
+    inputs:
+      architecture:
+        description: "Architecture to run performance tests on"
+        required: true
+        default: all
+        type: choice
+        options:
+          - all
+          - wormhole
+          - blackhole
 
 permissions:
   checks: write
@@ -20,6 +30,9 @@ jobs:
   llk-perf-tests:
     name: "LLK perf tests"
     uses: ./.github/workflows/llk-perf-impl.yaml
+    with:
+      # Scheduled runs have no dispatch inputs, so retain the existing behavior.
+      architecture: ${{ inputs.architecture || 'all' }}
     secrets: inherit
 
   llk-perf-summary:

--- a/.github/workflows/llk-perf.yaml
+++ b/.github/workflows/llk-perf.yaml
@@ -15,6 +15,7 @@ on:
           - all
           - wormhole
           - blackhole
+          - quasar
 
 permissions:
   checks: write

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -102,6 +102,8 @@ jobs:
       llk-blackhole-changed: ${{ steps.find-changes.outputs.llk-blackhole-changed }}
       llk-common-changed: ${{ steps.find-changes.outputs.llk-common-changed }}
       llk-sfpi-changed: ${{ steps.find-changes.outputs.llk-sfpi-changed }}
+      llk-quasar-changed: ${{ steps.find-changes.outputs.llk-quasar-changed }}
+      llk-perf-changed: ${{ steps.find-changes.outputs.llk-perf-changed }}
       llk-unit-tests-changed: ${{ steps.find-changes.outputs.llk-unit-tests-changed }}
       llk-ci-changed: ${{ steps.find-changes.outputs.llk-ci-changed }}
       tt-train-changed: ${{ steps.find-changes.outputs.tt-train-changed }}
@@ -246,6 +248,14 @@ jobs:
     with:
       harbor-prefix: ${{ needs.check-harbor.outputs.harbor-prefix }}
       dev-docker-image: ${{ needs.build-asan.outputs.dev-docker-image }}
+
+  resolve-docker-pull-refs-llk:
+    if: github.event.action != 'destroyed' && github.event_name != 'pull_request'
+    needs: [check-harbor, docker-images]
+    uses: ./.github/workflows/resolve-docker-pull-refs.yaml
+    with:
+      harbor-prefix: ${{ needs.check-harbor.outputs.harbor-prefix }}
+      llk-ci-docker-image: ${{ needs.docker-images.outputs.llk-ci-tag }}
 
   # ===========================================================================
   # Team: runtime
@@ -453,6 +463,25 @@ jobs:
   # SKU coverage is narrowed via sku-allowlist from find-changes. L2 nightly uses
   # tests/pipeline_reorg/llk_unit_tests.yaml. merge_group prio routing is via
   # prepare_test_matrix --event + sku_config merge_queue_sku.
+  llk-build-quasar-perf:
+    name: Build Quasar Perf
+    needs: [docker-images, resolve-docker-pull-refs-llk, find-changes]
+    if: ${{
+        github.event.action != 'destroyed' &&
+        github.event_name != 'pull_request' &&
+        (github.ref_name == 'main' ||
+         needs.find-changes.outputs.llk-quasar-changed == 'true' ||
+         needs.find-changes.outputs.llk-common-changed == 'true' ||
+         needs.find-changes.outputs.llk-sfpi-changed == 'true' ||
+         needs.find-changes.outputs.llk-perf-changed == 'true' ||
+         needs.find-changes.outputs.llk-ci-changed == 'true')
+      }}
+    uses: ./.github/workflows/build-quasar-perf.yml
+    with:
+      docker_image: ${{ needs.resolve-docker-pull-refs-llk.outputs.llk-ci-docker-image }}
+      runs_on: ${{ github.event_name == 'merge_group' && 'tt-ubuntu-2204-large-prio-stable' || 'tt-ubuntu-2204-large-stable' }}
+      timeout_minutes: 15
+
   llk-unit-tests:
     needs: [build, resolve-docker-pull-refs, find-changes]
     if: ${{
@@ -516,14 +545,14 @@ jobs:
         contains(join(needs.*.result, ','), 'failure')
       }}
 
-    needs: [static-checks, docker-images, find-changes, build, build-tsan, build-sweeps, runtime-smoke-tests, runtime-basic-tests, triage-tests, ttnn-smoke-tests, ttnn-basic-tests, ttnn-merge-gate-tests, models-smoke-tests, train-merge-gate-tests, scaleout-unit-tests, llk-unit-tests]
+    needs: [static-checks, docker-images, find-changes, build, build-tsan, build-sweeps, runtime-smoke-tests, runtime-basic-tests, triage-tests, ttnn-smoke-tests, ttnn-basic-tests, ttnn-merge-gate-tests, models-smoke-tests, train-merge-gate-tests, scaleout-unit-tests, llk-build-quasar-perf, llk-unit-tests]
     runs-on: ubuntu-slim
     steps:
       - name: Check if all jobs passed
         uses: tenstorrent/tt-metal/.github/actions/workflow-status@main
         with:
           required-jobs: "static-checks, find-changes"
-          optional-jobs: "build, build-tsan, build-sweeps, runtime-smoke-tests, runtime-basic-tests, triage-tests, ttnn-smoke-tests, ttnn-basic-tests, ttnn-merge-gate-tests, models-smoke-tests, train-merge-gate-tests, scaleout-unit-tests, llk-unit-tests"
+          optional-jobs: "build, build-tsan, build-sweeps, runtime-smoke-tests, runtime-basic-tests, triage-tests, ttnn-smoke-tests, ttnn-basic-tests, ttnn-merge-gate-tests, models-smoke-tests, train-merge-gate-tests, scaleout-unit-tests, llk-build-quasar-perf, llk-unit-tests"
         env:
           NEEDS_CONTEXT: "${{ toJSON(needs) }}"
       - if: (failure() && contains(join(needs.*.result, ','), 'failure') && github.event_name == 'merge_group')

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -249,14 +249,6 @@ jobs:
       harbor-prefix: ${{ needs.check-harbor.outputs.harbor-prefix }}
       dev-docker-image: ${{ needs.build-asan.outputs.dev-docker-image }}
 
-  resolve-docker-pull-refs-llk:
-    if: github.event.action != 'destroyed' && github.event_name != 'pull_request'
-    needs: [check-harbor, docker-images]
-    uses: ./.github/workflows/resolve-docker-pull-refs.yaml
-    with:
-      harbor-prefix: ${{ needs.check-harbor.outputs.harbor-prefix }}
-      llk-ci-docker-image: ${{ needs.docker-images.outputs.llk-ci-tag }}
-
   # ===========================================================================
   # Team: runtime
   # test list: runtime_validation_merge_gate_tests.yaml,
@@ -463,6 +455,14 @@ jobs:
   # SKU coverage is narrowed via sku-allowlist from find-changes. L2 nightly uses
   # tests/pipeline_reorg/llk_unit_tests.yaml. merge_group prio routing is via
   # prepare_test_matrix --event + sku_config merge_queue_sku.
+  resolve-docker-pull-refs-llk:
+    if: github.event.action != 'destroyed' && github.event_name != 'pull_request'
+    needs: [check-harbor, docker-images]
+    uses: ./.github/workflows/resolve-docker-pull-refs.yaml
+    with:
+      harbor-prefix: ${{ needs.check-harbor.outputs.harbor-prefix }}
+      llk-ci-docker-image: ${{ needs.docker-images.outputs.llk-ci-tag }}
+
   llk-build-quasar-perf:
     name: Build Quasar Perf
     needs: [docker-images, resolve-docker-pull-refs-llk, find-changes]


### PR DESCRIPTION
### PR Category
Test Only

### Summary
Increase LLK performance CI coverage by adding compile-time validation for Quasar performance tests.

- Add manual architecture selection for `all`, `wormhole`, `blackhole`, and `quasar`.
- Keep nightly runs targeting all architectures.
- Add a reusable Quasar performance compile workflow for `perf_*_quasar.py` tests.
- Prevent architecture-specific manual runs from cancelling one another.
- Add LLK perf to the nightly automatic retry workflow with a three-attempt limit.
- Publish Quasar JUnit results as annotations without creating phantom checks on WH/BH-only runs.

Closes #50878

### Notes for reviewers
Quasar coverage is compile-only; it does not run benchmarks or collect Quasar performance measurements.

Validation runs:

- [Quasar](https://github.com/tenstorrent/tt-metal/actions/runs/30006790535) — completed successfully.
- [Wormhole](https://github.com/tenstorrent/tt-metal/actions/runs/30006790364) — selected only the five Wormhole groups and successfully set up the requested runners.
- [Blackhole](https://github.com/tenstorrent/tt-metal/actions/runs/30006790571) — selected only the five Blackhole groups and successfully set up the requested runners.
- [All architectures](https://github.com/tenstorrent/tt-metal/actions/runs/30006790382) — selected both silicon matrices and successfully completed the Quasar compile job.

The Wormhole, Blackhole, and all-architecture runs were intentionally cancelled after runner/matrix validation to avoid wasting CI resources on redundant full performance executions.

Made with [Cursor](https://cursor.com)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ndivnic/llk_perf_infra)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ndivnic/llk_perf_infra)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ndivnic/llk_perf_infra)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ndivnic/llk_perf_infra)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ndivnic/llk_perf_infra)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ndivnic/llk_perf_infra)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ndivnic/llk_perf_infra)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ndivnic/llk_perf_infra)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ndivnic/llk_perf_infra)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ndivnic/llk_perf_infra)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ndivnic/llk_perf_infra)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ndivnic/llk_perf_infra)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ndivnic/llk_perf_infra)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ndivnic/llk_perf_infra)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ndivnic/llk_perf_infra)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ndivnic/llk_perf_infra)