### PR TITLE
[DS Prefill] Run all routed experts under one op (#50626)

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/perf/test_kimi_k3_moe_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_kimi_k3_moe_perf.py
@@ -56,12 +56,13 @@ _SEQ_LEN_PER_CHIP = 640
 # Capacity factor 5 carries over from K2.6, as in the pcc parametrize.
 _DISPATCH_BUFFER_CAPACITY_FACTOR = 5
 
-# Measured 2026-08-19 on an 8x4 BH galaxy (DDR 16000, 130W), warm forward, 58 programs.
-_EXPECTED_NS = 13_088_659
-# Repeated warm measurements on that box spanned 12.915-13.159 ms (stdev 0.63%, 1.89% peak to
-# peak), so 3% holds the observed run-to-run noise; sub-nominal DDR doubles it to 6% via
-# adjust_margin_for_ddr_speed. The baseline above is one run, so the band sits nearer the top of
-# that spread than the middle -- recentre it if a regression this shallow ever needs catching.
+# Measured 2026-08-21 on an 8x4 BH galaxy (DDR 16000, 130W), warm forward, with the routed
+# experts folded into one program.
+_EXPECTED_NS = 12_210_765
+# Repeated warm measurements on that box spanned 0.63% stdev / 1.89% peak to peak, so 3% holds
+# the observed run-to-run noise; sub-nominal DDR doubles it to 6% via adjust_margin_for_ddr_speed.
+# The baseline above is a single run, not the centre of a spread -- recentre it if a regression
+# this shallow ever needs catching.
 _MARGIN = 0.03
 
 # The profiler's default 1s collection deadline is sized for a single block's programs. The MoE

--- a/models/demos/deepseek_v3_d_p/tests/perf/test_moe_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_moe_perf.py
@@ -39,10 +39,12 @@ def test_deepseek_v3_moe_perf_loudbox():
     """
     run_moe_perf_with_approximation(
         command_8x1=_CMD_8X1,
-        expected_ns_8x1=15_393_888,  # Mean of two post-migration Fabric2D TorusY runs on 2026-08-15.
+        # Recalibrated 2026-08-21 on this LoudBox, Fabric2D TorusY, with the routed experts folded
+        # into one program. Single run each, where the previous 8x1 was a mean of two.
+        expected_ns_8x1=14_385_886,
         model_name_8x1="deepseek_v3_moe_lb_8x1_torus_y_dispatch_combine",
         command_2x4=_CMD_2X4,
-        expected_ns_2x4=17_217_341,  # Recalibrated 2026-08-14 on this LoudBox with Fabric2D.
+        expected_ns_2x4=15_945_512,
         model_name_2x4="deepseek_v3_moe_lb_2x4_fabric2d_gate",
         subdir="deepseek_v3_moe",
         margin=0.03,

--- a/models/demos/deepseek_v3_d_p/tests/perf/test_prefill_block_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_prefill_block_perf.py
@@ -50,8 +50,8 @@ _SUBTORUS_4X4_HOSTGATE_SKIP = pytest.mark.skip(
     [
         (
             f"pytest {_TEST_PATH} -k 'fabric2d-mesh-2x4-2link and layer3 and gate_device and no_ref and isl_6k4'",
-            38_638_478,  # Recalibrated 2026-08-14 after #51019 balanced dispatch across both links.
-            # Two local LoudBox runs (38.364, 38.397 ms) and BH E2E CI (39.154 ms); mean 38.638 ms.
+            30_330_761,  # Recalibrated 2026-08-21 on this LoudBox with the routed experts folded
+            # into one program. Single run, where the previous value was a mean of three.
             "deepseek_v3_prefill_block",
             "deepseek_v3_prefill_block_2x4_layer3_moe_fabric2d",
             1,

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py
@@ -145,7 +145,7 @@ INDEXER_K_PCC_THRESHOLD = 0.95
 # Traced and untraced get SEPARATE tables and SEPARATE margins, selected by mode in
 # `kimi_chunked_perf_gate` -- a traced baseline can never gate an untraced run or vice versa. The two
 # are different regimes, not a small delta: traced measures 0.6-0.95 s/chunk (a ramp, since chunk c
-# attends to KV[0:c*CHUNK]) while untraced is a flat ~1.09 s/chunk, host-dispatch bound so the op2op
+# attends to KV[0:c*CHUNK]) while untraced is a flat ~0.90 s/chunk, host-dispatch bound so the op2op
 # gap swamps the depth ramp entirely.
 KIMI_TRACED_BASELINE_CHUNK_TIMES_S = {
     # test_kimi_prefill_transformer_chunked_perf[...-L61-preload0-chunks_eleven-ten_iters-traced]
@@ -169,23 +169,19 @@ KIMI_TRACED_BASELINE_CHUNK_TIMES_S = {
 }
 KIMI_UNTRACED_BASELINE_CHUNK_TIMES_S = {
     # test_kimi_prefill_transformer_chunked_perf[...-L61-preload0-chunks_eleven-ten_iters-notrace]
-    # (55k / code_debug). Per chunk, the MEDIAN OVER 10 CI RUNS of that run's own per-chunk median --
-    # a single run is not a usable baseline here the way it is for the traced twin. The 10 (all green,
-    # 2026-08-15, `main`, bh_sc1_high_power): 31868565025 31868547288 31868532277 31868515545
-    # 31868482938 31868467067 31868452031 31868433473 31867986909 31866023124.
+    # (55k / code_debug), 2026-08-21 on bh_sc1_high_power, with the routed experts folded into one
+    # program. One run's per-chunk medians -- unlike the traced twin, a single run is thin evidence
+    # here, so re-cut this from a set of green runs the first time it disagrees.
     #
     # WITHIN a run the untraced spread is huge -- per-chunk stddev reaches 0.33 s (~30%), because every
     # iteration re-dispatches every op from host and pays a fresh, variable op2op gap. The MEDIAN of the
-    # 9 post-warmup iterations is not: across those 10 runs no chunk median lands further than 2.9% from
-    # the values below, and widening the sample to all 32 runs with a table from 2026-08-11 to 08-15
-    # (many branches) only reaches 3.2%. So the gate is on the median, with UNTRACED_PERF_MARGIN rather
-    # than the traced 3%.
+    # 9 post-warmup iterations is not: on the previous baseline no chunk median across 32 recorded runs
+    # landed further than 3.2% from its median-of-runs value. So the gate is on the median, with
+    # UNTRACED_PERF_MARGIN rather than the traced 3%.
     #
-    # If this does go flaky, re-center before widening: these are the median over the 10 runs, and
-    # centering each chunk on the midrange of all 32 instead pulls the worst deviation to 2.7% (the
-    # 3.2% is one-sided). Widening to 10% is the fallback after that -- every observed run fits inside
-    # a 6.2% total spread, so a band that needs more than 10% is a regression, not noise.
-    (61, 11, 10): [1.095, 1.094, 1.091, 1.098, 1.093, 1.089, 1.092, 1.089, 1.094, 1.089, 1.090],
+    # If this goes flaky, re-center on the median over several runs before widening. Widening to 10% is
+    # the fallback after that -- a band that needs more than 10% is a regression, not noise.
+    (61, 11, 10): [0.913, 0.903, 0.899, 0.904, 0.905, 0.900, 0.900, 0.902, 0.907, 0.909, 0.915],
 }
 # Per-mode +/- tolerance band around each baseline chunk median (fraction). Traced replays a captured
 # program, so the device is its only noise source; untraced re-dispatches from host every iteration and

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py
@@ -145,7 +145,7 @@ INDEXER_K_PCC_THRESHOLD = 0.95
 # Traced and untraced get SEPARATE tables and SEPARATE margins, selected by mode in
 # `kimi_chunked_perf_gate` -- a traced baseline can never gate an untraced run or vice versa. The two
 # are different regimes, not a small delta: traced measures 0.6-0.95 s/chunk (a ramp, since chunk c
-# attends to KV[0:c*CHUNK]) while untraced is a flat ~0.90 s/chunk, host-dispatch bound so the op2op
+# attends to KV[0:c*CHUNK]) while untraced is a flat ~1.04 s/chunk, host-dispatch bound so the op2op
 # gap swamps the depth ramp entirely.
 KIMI_TRACED_BASELINE_CHUNK_TIMES_S = {
     # test_kimi_prefill_transformer_chunked_perf[...-L61-preload0-chunks_eleven-ten_iters-traced]
@@ -169,9 +169,9 @@ KIMI_TRACED_BASELINE_CHUNK_TIMES_S = {
 }
 KIMI_UNTRACED_BASELINE_CHUNK_TIMES_S = {
     # test_kimi_prefill_transformer_chunked_perf[...-L61-preload0-chunks_eleven-ten_iters-notrace]
-    # (55k / code_debug), 2026-08-21 on bh_sc1_high_power, with the routed experts folded into one
-    # program. One run's per-chunk medians -- unlike the traced twin, a single run is thin evidence
-    # here, so re-cut this from a set of green runs the first time it disagrees.
+    # (55k / code_debug), 2026-08-21 on an 8x4 galaxy, with the routed experts folded into one program
+    # on a Fabric2D mesh. One run's per-chunk medians -- unlike the traced twin, a single run is thin
+    # evidence here, so re-cut this from a set of green runs the first time it disagrees.
     #
     # WITHIN a run the untraced spread is huge -- per-chunk stddev reaches 0.33 s (~30%), because every
     # iteration re-dispatches every op from host and pays a fresh, variable op2op gap. The MEDIAN of the
@@ -181,7 +181,7 @@ KIMI_UNTRACED_BASELINE_CHUNK_TIMES_S = {
     #
     # If this goes flaky, re-center on the median over several runs before widening. Widening to 10% is
     # the fallback after that -- a band that needs more than 10% is a regression, not noise.
-    (61, 11, 10): [0.913, 0.903, 0.899, 0.904, 0.905, 0.900, 0.900, 0.902, 0.907, 0.909, 0.915],
+    (61, 11, 10): [1.043, 1.036, 1.037, 1.047, 1.044, 1.034, 1.034, 1.034, 1.046, 1.041, 1.044],
 }
 # Per-mode +/- tolerance band around each baseline chunk median (fraction). Traced replays a captured
 # program, so the device is its only noise source; untraced re-dispatches from host every iteration and

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_routed_expert_bias.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_routed_expert_bias.py
@@ -196,6 +196,24 @@ def test_situglu_bias_routed_expert(mesh_device, device_params, num_tokens):
 # all < max) so the device-side count bounding is exercised alongside the per-expert bias wiring.
 MULTI_EXPERT_PARAMS = [
     pytest.param([128, 256, 64, 160], id="e4"),
+    # Repro axes the e4 case above does not reach, all of which occur in real routing:
+    #   e4mc: counts > chunk_M_max*TILE (2048), so effective_chunks > 1 per expert
+    #   e4zero: an expert that received no tokens (effective_chunks == 0)
+    #   e4odd: counts that are not multiples of TILE=32 (tail-chunk per_core_M path)
+    pytest.param([2560, 3072, 64, 128], id="e4mc"),
+    pytest.param([128, 0, 256, 64], id="e4zero"),
+    pytest.param([100, 250, 33, 256], id="e4odd"),
+    # Isolation: only expert 1 is multi-chunk. If corruption starts at the expert
+    # AFTER a multi-chunk expert, 0 and 1 pass and 2 is wrong.
+    pytest.param([128, 3072, 64, 128], id="e4mc2"),
+    # Separates "multi-chunk at index>0" from "count fills the region exactly".
+    # max_tokens=3072 (M_tiles_full=96). expert 1: 2 chunks, 80<96 tiles (does NOT
+    # fill). expert 3: 2 chunks, 96==96 tiles (fills exactly).
+    pytest.param([128, 2560, 64, 3072], id="e4mc3"),
+    # e0 = exactly one FULL chunk (2048 = chunk_M_max*TILE) so per_core_M stays 8
+    # into e1c0 -- no growth. If growth is the trigger, this passes despite e1
+    # being multi-chunk.
+    pytest.param([2048, 3072, 64, 128], id="e4nogrow"),
 ]
 
 

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_routed_expert_bias.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_routed_expert_bias.py
@@ -196,24 +196,6 @@ def test_situglu_bias_routed_expert(mesh_device, device_params, num_tokens):
 # all < max) so the device-side count bounding is exercised alongside the per-expert bias wiring.
 MULTI_EXPERT_PARAMS = [
     pytest.param([128, 256, 64, 160], id="e4"),
-    # Repro axes the e4 case above does not reach, all of which occur in real routing:
-    #   e4mc: counts > chunk_M_max*TILE (2048), so effective_chunks > 1 per expert
-    #   e4zero: an expert that received no tokens (effective_chunks == 0)
-    #   e4odd: counts that are not multiples of TILE=32 (tail-chunk per_core_M path)
-    pytest.param([2560, 3072, 64, 128], id="e4mc"),
-    pytest.param([128, 0, 256, 64], id="e4zero"),
-    pytest.param([100, 250, 33, 256], id="e4odd"),
-    # Isolation: only expert 1 is multi-chunk. If corruption starts at the expert
-    # AFTER a multi-chunk expert, 0 and 1 pass and 2 is wrong.
-    pytest.param([128, 3072, 64, 128], id="e4mc2"),
-    # Separates "multi-chunk at index>0" from "count fills the region exactly".
-    # max_tokens=3072 (M_tiles_full=96). expert 1: 2 chunks, 80<96 tiles (does NOT
-    # fill). expert 3: 2 chunks, 96==96 tiles (fills exactly).
-    pytest.param([128, 2560, 64, 3072], id="e4mc3"),
-    # e0 = exactly one FULL chunk (2048 = chunk_M_max*TILE) so per_core_M stays 8
-    # into e1c0 -- no growth. If growth is the trigger, this passes despite e1
-    # being multi-chunk.
-    pytest.param([2048, 3072, 64, 128], id="e4nogrow"),
 ]
 
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/adaptive_chunk.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/adaptive_chunk.hpp
@@ -76,6 +76,28 @@ constexpr uint32_t kGridY = 8;  // M-row cores; a chunk spans per_core_M * kGrid
 // The tail per_core_M is still returned as a DIVISOR of per_core_M_max, so the
 // runtime rows always tile evenly inside the constant block.
 
+// Clamp a DEVICE-PROVIDED token-tile count to the capacity this program was
+// built for: `num_chunks_max` chunks of at most `max_chunk` tile-rows each.
+//
+// counts[] is produced on device (dispatch) and is never host-validated, so an
+// over-capacity entry must not be allowed to drive the chunk loop past
+// num_chunks_max: the CBs, the num_chunks compile-time arg and the output
+// buffer are all sized to that bound, and running past it reads/writes outside
+// this expert's region. ASSERT is a no-op unless watcher / lightweight kernel
+// asserts are enabled, so the bound has to be enforced by arithmetic to hold in
+// Release builds — the kernels ASSERT on top of it to still fail loudly in
+// debug builds.
+//
+// Clamping the COUNT (not the chunk index) is what keeps the three kernels in
+// lockstep: reader, compute and writer all derive effective_chunks, per_core_M
+// and their row-validity guards from this same value, so they agree on the row
+// mapping and the excess rows are uniformly dropped rather than emitted at the
+// wrong offsets.
+inline uint32_t clamp_count_tiles(uint32_t count_tiles, uint32_t max_chunk, uint32_t num_chunks_max) {
+    const uint32_t capacity_tiles = num_chunks_max * max_chunk;
+    return (count_tiles < capacity_tiles) ? count_tiles : capacity_tiles;
+}
+
 // Number of chunks for `count_tiles`: full chunks of max_chunk + one tail chunk.
 inline uint32_t num_chunks(uint32_t count_tiles, uint32_t max_chunk) {
     if (count_tiles < 1) {

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/adaptive_chunk.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/adaptive_chunk.hpp
@@ -38,12 +38,43 @@ constexpr uint32_t kGridY = 8;  // M-row cores; a chunk spans per_core_M * kGrid
 // wasted rows — e.g. 160 tiles -> 64 + 64 + 32 (per_core_M 8,8,4), 3 chunks,
 // zero phantom.
 //
-// CRITICAL: the tail per_core_M is a DIVISOR of per_core_M_max. The gate/up CBs
-// (cb_in0_x, partials, activated) are allocated to per_core_M_max but reserved/
-// pushed at the runtime per_core_M; a per_core_M that does not divide
-// per_core_M_max would make those blocks wrap the CB ring (ring size not a
-// multiple of the block size) and reserve_back would deadlock. Divisors tile
-// evenly, so the ring never wraps mid-block.
+// CRITICAL — per_core_M BOUNDS WORK, IT DOES NOT SIZE CB BLOCKS.
+//
+// per_core_M is free to differ per expert and per chunk (that is the whole point:
+// each expert gets the chunk shape its own token count deserves). It bounds MACs,
+// tilize strips, DRAM reads, multicast payloads and emitted output rows.
+//
+// It must NOT size any circular-buffer block. cb_push_back / cb_pop_front wrap the
+// FIFO pointer only when it lands EXACTLY on fifo_limit:
+//
+//     fifo_wr_ptr += num_words;
+//     // this will basically reset fifo_wr_ptr to fifo_addr -- no other wrap is legal
+//     ASSERT(fifo_wr_ptr <= fifo_limit);
+//     if (fifo_wr_ptr == fifo_limit) { fifo_wr_ptr -= fifo_size; }
+//                                              (tt_metal/hw/inc/api/dataflow/dataflow_api.h)
+//
+// A block size that changes between pushes leaves the pointer at an offset the
+// next (larger) block does not divide; that push OVERSHOOTS fifo_limit, the
+// equality fails, the wrap is skipped, the ASSERT is a no-op in release, and the
+// CB pointer then runs away into neighbouring L1 for the rest of the kernel.
+//
+// Under the retired one-program-per-expert design this was invisible: every expert
+// launched its own program, so the pointers restarted at fifo_addr and only the
+// within-expert full-chunks-then-tail order mattered (and that order happens to
+// realign). ONE program looping over all local experts carries the pointers over,
+// so a per-expert block size corrupts L1 — e.g. on cb_activated (ring = 8 blocks at
+// per_core_M=1, one push per chunk) a run of per_core_M=1 experts leaves the
+// pointer at 3, and a following per_core_M=2 expert pushes 3 -> 5 -> 7 -> 9, which
+// never equals 8.
+//
+// So the reader/compute kernels reserve/push/wait/pop a CONSTANT compile-time-max
+// block on cb_x_rm, cb_in0_x, cb_gate_intermed, cb_activated and cb_mm_partials_*,
+// and settle the runtime remainder with O(1) pointer-only bumps. This is the same
+// pattern cb_in0_down_full and cb_out already use. The adaptive win is untouched:
+// no MAC, tilize, DRAM read or multicast byte is spent on the padded rows.
+//
+// The tail per_core_M is still returned as a DIVISOR of per_core_M_max, so the
+// runtime rows always tile evenly inside the constant block.
 
 // Number of chunks for `count_tiles`: full chunks of max_chunk + one tail chunk.
 inline uint32_t num_chunks(uint32_t count_tiles, uint32_t max_chunk) {

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/adaptive_chunk.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/adaptive_chunk.hpp
@@ -76,14 +76,14 @@ constexpr uint32_t kGridY = 8;  // M-row cores; a chunk spans per_core_M * kGrid
 // The tail per_core_M is still returned as a DIVISOR of per_core_M_max, so the
 // runtime rows always tile evenly inside the constant block.
 
-// Clamp a DEVICE-PROVIDED token-tile count to the capacity this program was
-// built for: `num_chunks_max` chunks of at most `max_chunk` tile-rows each.
+// Clamp a DEVICE-PROVIDED token-tile count to what this expert can actually
+// hold: its region (`m_tiles_full` tile-rows), and — as a backstop — the chunk
+// loop the program was built for (`num_chunks_max` chunks of `max_chunk`).
 //
 // counts[] is produced on device (dispatch) and is never host-validated, so an
 // over-capacity entry must not be allowed to drive the chunk loop past
-// num_chunks_max: the CBs, the num_chunks compile-time arg and the output
-// buffer are all sized to that bound, and running past it reads/writes outside
-// this expert's region. ASSERT is a no-op unless watcher / lightweight kernel
+// num_chunks_max: the CBs and the num_chunks compile-time arg are sized to that
+// bound. ASSERT is a no-op unless watcher / lightweight kernel
 // asserts are enabled, so the bound has to be enforced by arithmetic to hold in
 // Release builds — the kernels ASSERT on top of it to still fail loudly in
 // debug builds.
@@ -93,9 +93,22 @@ constexpr uint32_t kGridY = 8;  // M-row cores; a chunk spans per_core_M * kGrid
 // and their row-validity guards from this same value, so they agree on the row
 // mapping and the excess rows are uniformly dropped rather than emitted at the
 // wrong offsets.
-inline uint32_t clamp_count_tiles(uint32_t count_tiles, uint32_t max_chunk, uint32_t num_chunks_max) {
-    const uint32_t capacity_tiles = num_chunks_max * max_chunk;
-    return (count_tiles < capacity_tiles) ? count_tiles : capacity_tiles;
+inline uint32_t clamp_count_tiles(
+    uint32_t count_tiles, uint32_t max_chunk, uint32_t num_chunks_max, uint32_t m_tiles_full) {
+    // Two independent caps; the tighter one wins.
+    //   * m_tiles_full  - this expert's region is only this many tile-rows, so a
+    //     larger count is bogus. Rows past it are dropped downstream anyway (the
+    //     reader zero-fills past M_bound, the writer guards row < M_tiles_full), so
+    //     without this cap an over-capacity count only bought wasted chunks.
+    //   * num_chunks_max * max_chunk - the chunk-loop bound the CBs and the
+    //     num_chunks compile-time arg were sized for.
+    // m_tiles_full is normally much the tighter of the two: num_chunks_max is
+    // ceil(m_tiles_full / min_chunk) with min_chunk <= max_chunk, so the loop cap
+    // sits at roughly (max_chunk / min_chunk) * m_tiles_full. Both are kept so
+    // neither bound can be violated if that host-side derivation ever changes.
+    const uint32_t loop_cap = num_chunks_max * max_chunk;
+    const uint32_t cap = (m_tiles_full < loop_cap) ? m_tiles_full : loop_cap;
+    return (count_tiles < cap) ? count_tiles : cap;
 }
 
 // Number of chunks for `count_tiles`: full chunks of max_chunk + one tail chunk.

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/compute/fused_swiglu.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/compute/fused_swiglu.cpp
@@ -891,9 +891,15 @@ void kernel_main() {
         // picker on the same count, so they agree on the row mapping; rows past the
         // count in the tail chunk are zero-filled by the reader and dropped by the
         // writer.
-        const uint32_t count_tiles = (count_value + 31) / 32;
+        // The count is device-produced and unvalidated, so clamp it to this
+        // program's capacity before deriving the chunk layout — arithmetic, so the
+        // bound holds in Release where ASSERT is a no-op. Reader and writer apply
+        // the identical clamp, keeping the three row mappings in lockstep (see
+        // adaptive_chunk::clamp_count_tiles).
+        const uint32_t count_tiles_raw = (count_value + 31) / 32;
+        const uint32_t count_tiles = adaptive_chunk::clamp_count_tiles(count_tiles_raw, chunk_M_max, num_chunks_max);
+        ASSERT(count_tiles == count_tiles_raw);
         const uint32_t effective_chunks = adaptive_chunk::num_chunks(count_tiles, chunk_M_max);
-        ASSERT(effective_chunks <= num_chunks_max);
 
         for (uint32_t chunk = 0; chunk < effective_chunks; ++chunk) {
             // Per-chunk per_core_M (per_core_M_max for full chunks, a smaller

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/compute/fused_swiglu.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/compute/fused_swiglu.cpp
@@ -61,6 +61,8 @@
 #include "api/compute/tile_move_copy.h"
 #include "api/compute/tilize.h"
 #include "api/dataflow/circular_buffer.h"
+#include "api/debug/assert.h"
+#include "tools/profiler/kernel_profiler.hpp"
 #include "ttnn/cpp/ttnn/kernel_lib/tilize_helpers.hpp"
 #include "ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_fused_activation.hpp"
 #include "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/adaptive_chunk.hpp"
@@ -740,13 +742,13 @@ void kernel_main() {
     constexpr uint32_t d_out_subblock_w = get_compile_time_arg_val(28);
     constexpr uint32_t d_out_subblock_num_tiles = d_out_subblock_h * d_out_subblock_w;
     constexpr uint32_t d_out_block_num_tiles = get_compile_time_arg_val(29);
-    // Multi-chunk: the number of chunks is chosen at RUNTIME from the device
-    // token count (see the picker below). num_chunks_max is the compile-time
+    // Multi-chunk: the number of chunks is chosen at RUNTIME from each expert's
+    // device token count (see the picker below). num_chunks_max is the compile-time
     // upper bound (host = ceil(M_tiles_full / min_chunk)) used only to clamp the
     // runtime chunk count defensively. chunk_M_max is the CB-sized maximum
     // chunk (per_core_M_max * GRID_Y); the picker never returns more than this.
     constexpr uint32_t num_chunks_max = get_compile_time_arg_val(30);
-    constexpr uint32_t local_expert_id = get_compile_time_arg_val(31);
+    constexpr uint32_t experts_per_chip = get_compile_time_arg_val(31);
     // chunk_M_max is the CB-sized MAXIMUM chunk (per_core_M_max * GRID_Y). The
     // runtime picker (adaptive_chunk::num_chunks) sizes the actual chunk to the
     // device token count and never exceeds this.
@@ -796,50 +798,18 @@ void kernel_main() {
     CircularBuffer counts_scratch_cb(cb_counts_scratch);
     CircularBuffer idx_scratch_cb(cb_idx_scratch);
 
-    // Wait for the reader (BRISC) to push the per-expert counts/idx into
-    // shared L1. UNPACK reads the L1 via LocalCBInterface and broadcasts
-    // count_value to MATH and PACK via the inter-thread mailbox (MATH cannot
-    // access get_local_cb_interface symbols at link time). Production matmul
-    // uses the same UNPACK→mailbox→MATH/PACK pattern (see
-    // circular_buffer.h::read_tile_value).
+    // Wait for the reader (BRISC) to push the counts/idx into shared L1. They
+    // are pushed ONCE and stay resident, so UNPACK can re-index them per expert.
     counts_scratch_cb.wait_front(1);
     idx_scratch_cb.wait_front(1);
-    uint32_t count_value = 0;
-    UNPACK(({
-        const uint32_t counts_l1_addr = get_local_cb_interface(cb_counts_scratch).fifo_rd_ptr << 4;
-        const uint32_t idx_l1_addr = get_local_cb_interface(cb_idx_scratch).fifo_rd_ptr << 4;
-        const volatile tt_l1_ptr uint32_t* counts_ptr =
-            reinterpret_cast<const volatile tt_l1_ptr uint32_t*>(counts_l1_addr);
-        const volatile tt_l1_ptr uint32_t* idx_ptr = reinterpret_cast<const volatile tt_l1_ptr uint32_t*>(idx_l1_addr);
-        const uint32_t global_expert_id = idx_ptr[local_expert_id];
-        count_value = counts_ptr[global_expert_id];
-        ckernel::mailbox_write(ckernel::ThreadId::MathThreadId, count_value);
-        ckernel::mailbox_write(ckernel::ThreadId::PackThreadId, count_value);
-    }));
-    MATH(count_value = ckernel::mailbox_read(ckernel::ThreadId::UnpackThreadId);)
-    PACK(count_value = ckernel::mailbox_read(ckernel::ThreadId::UnpackThreadId);)
-    // count is in TOKEN rows; convert to tile rows (ceil). The picker sizes
-    // chunk_M_tiles (hence per_core_M and the number of chunks) to THIS count,
-    // exactly as the retired host-side picker did — now at runtime, so no
-    // expected-token argument is needed. All three kernels (reader/compute/
-    // writer) run the identical picker on the same count, so they agree on the
-    // row mapping. per_core_M is uniform across cores and chunks; rows past the
-    // count in the tail chunk are zero-filled by the reader and dropped by the
-    // writer (contiguous mapping, same as the old compile-time per_core_M path).
-    const uint32_t count_tiles = (count_value + 31) / 32;
-    const uint32_t effective_chunks_runtime = adaptive_chunk::num_chunks(count_tiles, chunk_M_max);
-    const uint32_t effective_chunks =
-        effective_chunks_runtime < num_chunks_max ? effective_chunks_runtime : num_chunks_max;
 
-    // SiLU is now applied as a MATH-thread SFPU pass on dst (silu_tile)
-    // between copy_tile and pack_tile — not packer-fused via
-    // apply_activation_from_pack. Empirically the packer-fused variant
-    // serialises the pack pipeline against the SFPU, slowing down the
-    // gate-intermed write. silu_tile_init() configures the MATH-side SFPU
-    // for silu; the pack then runs plain (no per-tile SFPU on the pack
-    // thread). Same total compute, better pipelining.
+    // SiLU is applied as a MATH-thread SFPU pass on dst (silu_tile) between
+    // copy_tile and pack_tile — not packer-fused via apply_activation_from_pack.
+    // Empirically the packer-fused variant serialises the pack pipeline against
+    // the SFPU. silu_tile_init() configures the MATH-side SFPU for silu once;
+    // the pack then runs plain. SwiGLU-OAI uses the binary swiglu SFPU op.
+    // Init once — shared across all experts.
 #ifdef SWIGLU_OAI
-    // SwiGLU-OAI uses the binary swiglu SFPU op (sigmoid/recip table init).
     MATH((ckernel::llk_math_eltwise_binary_sfpu_swiglu_init()));
 #else
     silu_tile_init();
@@ -847,107 +817,149 @@ void kernel_main() {
 
     compute_kernel_hw_startup<SrcOrder::Reverse>(cb_in0_x, cb_in1_gate, cb_partials_gu);
 
-    for (uint32_t chunk = 0; chunk < effective_chunks; ++chunk) {
-        // Per-chunk per_core_M (per_core_M_max for full chunks, a smaller divisor
-        // for the tail). The gate/up + multiply phases do per_core_M rows of real
-        // work; the down matmul keeps its full compile-time ring and MAC-skips
-        // rows >= per_core_M (see matmul_phase). re_eff_out_gu = per_core_M *
-        // per_core_N_gu (g_in1_num_subblocks * gu_out_subblock_num_tiles ==
-        // per_core_N_gu since gu_out_subblock_h == 1).
-        const uint32_t re_m_valid = adaptive_chunk::per_core_M_for_chunk(chunk, count_tiles, chunk_M_max);
-        const uint32_t re_eff_out_gu = re_m_valid * g_in1_num_subblocks * gu_out_subblock_num_tiles;
-        //
-        // matmul_block_init only re-programs addressing, not SrcA/SrcB formats. On
-        // chunk >= 1 the unpacker is left on multiply_phase's operands, so reset it
-        // to the gate/up inputs here (in1 -> SrcA, in0 -> SrcB).
-        reconfig_data_format(cb_in1_gate, cb_in0_x);
-        matmul_block_init(
-            cb_in0_x,
-            cb_in1_gate,
-            /*transpose=*/0,
-            gu_out_subblock_w,
-            gu_out_subblock_h,
-            g_in0_block_w);
+    // ======================= per-local-expert loop =======================
+    // Run the full gate/up/down FFN for every local expert in this program.
+    for (uint32_t local_expert_id = 0; local_expert_id < experts_per_chip; ++local_expert_id) {
+        // This expert's token count via the UNPACK→{MATH,PACK} mailbox (MATH/PACK
+        // cannot read the counts/idx L1 via the CB interface).
+        // count -> effective_chunks bounds this expert's chunk loop; count=0 => the
+        // loop body is skipped entirely.
+        uint32_t count_value = 0;
+        UNPACK(({
+            const uint32_t counts_l1_addr = get_local_cb_interface(cb_counts_scratch).fifo_rd_ptr << 4;
+            const uint32_t idx_l1_addr = get_local_cb_interface(cb_idx_scratch).fifo_rd_ptr << 4;
+            const volatile tt_l1_ptr uint32_t* counts_ptr =
+                reinterpret_cast<const volatile tt_l1_ptr uint32_t*>(counts_l1_addr);
+            const volatile tt_l1_ptr uint32_t* idx_ptr =
+                reinterpret_cast<const volatile tt_l1_ptr uint32_t*>(idx_l1_addr);
+            const uint32_t global_expert_id = idx_ptr[local_expert_id];
+            count_value = counts_ptr[global_expert_id];
+            ckernel::mailbox_write(ckernel::ThreadId::MathThreadId, count_value);
+            ckernel::mailbox_write(ckernel::ThreadId::PackThreadId, count_value);
+        }));
+        MATH(count_value = ckernel::mailbox_read(ckernel::ThreadId::UnpackThreadId);)
+        PACK(count_value = ckernel::mailbox_read(ckernel::ThreadId::UnpackThreadId);)
+        // count is in TOKEN rows; convert to tile rows (ceil), then let the runtime
+        // picker size THIS expert's chunks. The picker derives chunk_M_tiles (hence
+        // per_core_M and the chunk count) from this expert's own count, so no
+        // expected-token argument is needed and each expert's work scales to its
+        // actual load. All three kernels (reader/compute/writer) run the identical
+        // picker on the same count, so they agree on the row mapping; rows past the
+        // count in the tail chunk are zero-filled by the reader and dropped by the
+        // writer.
+        const uint32_t count_tiles = (count_value + 31) / 32;
+        const uint32_t effective_chunks = adaptive_chunk::num_chunks(count_tiles, chunk_M_max);
+        ASSERT(effective_chunks <= num_chunks_max);
 
-        // Phases 1 & 2 fused: gate matmul + up matmul share the same per-K-block
-        // x push from the reader, so x DRAM mcast bytes are halved (one x read
-        // per K-block feeds both matmuls). Both matmuls accumulate into their
-        // own partials CB; after the K-loop, partials_gu -> gate_intermed (with
-        // silu) and partials_up -> up_intermed are produced by the same fused
-        // function.
-        matmul_phase_fused_gu<
-            g_in0_block_w,
-            g_in0_num_subblocks,
-            g_in0_block_num_tiles,
-            g_in0_subblock_num_tiles,
-            g_in1_num_subblocks,
-            g_in1_block_num_tiles,
-            g_in1_per_core_w,
-            g_num_blocks,
-            gu_out_subblock_h,
-            gu_out_subblock_w,
-            gu_out_subblock_num_tiles,
-            gu_out_block_num_tiles,
-            /*x_cb_id=*/cb_in0_x,
-            /*x_rm_cb_id=*/cb_x_rm,
-            /*tilize_x=*/(x_is_row_major != 0)>(
-            cb_in1_gate,
-            cb_in1_up,
-            cb_partials_gu,
-            cb_partials_up,
-            cb_gate_intermed,
-            cb_up_intermed,
-            /*m_subblocks=*/re_m_valid);
+        for (uint32_t chunk = 0; chunk < effective_chunks; ++chunk) {
+            // Per-chunk per_core_M (per_core_M_max for full chunks, a smaller
+            // divisor for the tail). The gate/up + multiply phases do per_core_M
+            // rows of real work; the down matmul keeps its full compile-time ring
+            // and MAC-skips rows >= per_core_M (see matmul_phase). re_eff_out_gu =
+            // per_core_M * per_core_N_gu (g_in1_num_subblocks *
+            // gu_out_subblock_num_tiles == per_core_N_gu since gu_out_subblock_h == 1).
+            const uint32_t re_m_valid = adaptive_chunk::per_core_M_for_chunk(chunk, count_tiles, chunk_M_max);
+            const uint32_t re_eff_out_gu = re_m_valid * g_in1_num_subblocks * gu_out_subblock_num_tiles;
+
+            // matmul_block_init only re-programs addressing, not SrcA/SrcB formats. On
+            // chunk >= 1 the unpacker is left on multiply_phase's operands, so reset it
+            // to the gate/up inputs here (in1 -> SrcA, in0 -> SrcB).
+            reconfig_data_format(cb_in1_gate, cb_in0_x);
+            matmul_block_init(
+                cb_in0_x,
+                cb_in1_gate,
+                /*transpose=*/0,
+                gu_out_subblock_w,
+                gu_out_subblock_h,
+                g_in0_block_w);
+
+            // Phases 1 & 2 fused: gate matmul + up matmul share the same per-K-block
+            // x push from the reader, so x DRAM mcast bytes are halved (one x read
+            // per K-block feeds both matmuls). Both matmuls accumulate into their
+            // own partials CB; after the K-loop, partials_gu -> gate_intermed (with
+            // silu) and partials_up -> up_intermed are produced by the same fused
+            // function.
+            matmul_phase_fused_gu<
+                g_in0_block_w,
+                g_in0_num_subblocks,
+                g_in0_block_num_tiles,
+                g_in0_subblock_num_tiles,
+                g_in1_num_subblocks,
+                g_in1_block_num_tiles,
+                g_in1_per_core_w,
+                g_num_blocks,
+                gu_out_subblock_h,
+                gu_out_subblock_w,
+                gu_out_subblock_num_tiles,
+                gu_out_block_num_tiles,
+                /*x_cb_id=*/cb_in0_x,
+                /*x_rm_cb_id=*/cb_x_rm,
+                /*tilize_x=*/(x_is_row_major != 0)>(
+                cb_in1_gate,
+                cb_in1_up,
+                cb_partials_gu,
+                cb_partials_up,
+                cb_gate_intermed,
+                cb_up_intermed,
+                /*m_subblocks=*/re_m_valid);
 
 #ifdef SWIGLU_OAI
-        // Phase 3 (SwiGLU-OAI): fused clamp + alpha-sigmoid + (up+1) directly on
-        // the raw bf16 gate/up accumulators -> cb_activated. Replaces both the
-        // gate-silu pass (skipped above) and the plain multiply_phase. cb_in1_up is
-        // the unpacker's last SrcA operand (up matmul in1), passed so the partials
-        // reconfig (weights df -> Float16_b) actually fires.
-        swiglu_oai_activation_phase<gu_out_block_num_tiles, g_in1_per_core_w>(
-            cb_in1_up, cb_partials_gu, cb_partials_up, cb_activated, re_eff_out_gu, cb_gate_bias, cb_up_bias);
-        (void)cb_gate_intermed;
-        (void)cb_up_intermed;
+            // Phase 3 (SwiGLU-OAI): fused clamp + alpha-sigmoid + (up+1) directly on
+            // the raw bf16 gate/up accumulators -> cb_activated. Replaces both the
+            // gate-silu pass (skipped above) and the plain multiply_phase. cb_in1_up is
+            // the unpacker's last SrcA operand (up matmul in1), passed so the partials
+            // reconfig (weights df -> Float16_b) actually fires.
+            swiglu_oai_activation_phase<gu_out_block_num_tiles, g_in1_per_core_w>(
+                cb_in1_up, cb_partials_gu, cb_partials_up, cb_activated, re_eff_out_gu, cb_gate_bias, cb_up_bias);
+            (void)cb_gate_intermed;
+            (void)cb_up_intermed;
 #else
-        // Phase 3: elementwise multiply (cb_gate_intermed is silu(partials_gu)
-        // in bf8; cb_partials_up is the up matmul accumulator in bf16). The
-        // multiply does the format conversion via reconfig_data_format inside
-        // multiply_phase — both unpacker srcs get reset to the input CB
-        // formats.
-        multiply_phase<gu_out_block_num_tiles, gu_out_subblock_num_tiles>(
-            cb_gate_intermed, cb_partials_up, cb_activated, re_eff_out_gu);
-        (void)cb_up_intermed;
+            // Phase 3: elementwise multiply (cb_gate_intermed is silu(partials_gu)
+            // in bf8; cb_partials_up is the up matmul accumulator in bf16). The
+            // multiply does the format conversion via reconfig_data_format inside
+            // multiply_phase — both unpacker srcs get reset to the input CB
+            // formats.
+            multiply_phase<gu_out_block_num_tiles, gu_out_subblock_num_tiles>(
+                cb_gate_intermed, cb_partials_up, cb_activated, re_eff_out_gu);
+            (void)cb_up_intermed;
 #endif
 
-        // Phase 4: down matmul, output to cb_out.
-        // multiply_phase left the unpacker on (cb_gate_intermed, cb_partials_up);
-        // matmul_block_init does not re-program data formats, so reset the down
-        // operands here (in1 -> SrcA, in0 -> SrcB) before the matmul.
-        reconfig_data_format(cb_in1_down, cb_in0_down_full);
-        matmul_block_init(
-            cb_in0_down_full,
-            cb_in1_down,
-            /*transpose=*/0,
-            d_out_subblock_w,
-            d_out_subblock_h,
-            d_in0_block_w);
-        matmul_phase<
-            d_in0_block_w,
-            d_in0_num_subblocks,
-            d_in0_block_num_tiles,
-            d_in0_subblock_num_tiles,
-            d_in1_num_subblocks,
-            d_in1_block_num_tiles,
-            d_in1_per_core_w,
-            d_num_blocks,
-            d_out_subblock_h,
-            d_out_subblock_w,
-            d_out_subblock_num_tiles,
-            d_out_block_num_tiles,
-            /*apply_silu_on_final=*/false,
-            /*d_per_core_N=*/d_in1_per_core_w,
-            /*last_block_w=*/d_last_block_w>(
-            cb_in0_down_full, cb_in1_down, cb_partials_d, cb_out, /*m_subblocks=*/re_m_valid, cb_down_bias);
-    }  // end chunk loop
+            // Phase 4: down matmul, output to cb_out.
+            // multiply_phase left the unpacker on (cb_gate_intermed, cb_partials_up);
+            // matmul_block_init does not re-program data formats, so reset the down
+            // operands here (in1 -> SrcA, in0 -> SrcB) before the matmul.
+            reconfig_data_format(cb_in1_down, cb_in0_down_full);
+            matmul_block_init(
+                cb_in0_down_full,
+                cb_in1_down,
+                /*transpose=*/0,
+                d_out_subblock_w,
+                d_out_subblock_h,
+                d_in0_block_w);
+            matmul_phase<
+                d_in0_block_w,
+                d_in0_num_subblocks,
+                d_in0_block_num_tiles,
+                d_in0_subblock_num_tiles,
+                d_in1_num_subblocks,
+                d_in1_block_num_tiles,
+                d_in1_per_core_w,
+                d_num_blocks,
+                d_out_subblock_h,
+                d_out_subblock_w,
+                d_out_subblock_num_tiles,
+                d_out_block_num_tiles,
+                /*apply_silu_on_final=*/false,
+                /*d_per_core_N=*/d_in1_per_core_w,
+                /*last_block_w=*/d_last_block_w>(
+                cb_in0_down_full, cb_in1_down, cb_partials_d, cb_out, /*m_subblocks=*/re_m_valid, cb_down_bias);
+        }  // end chunk loop
+
+#ifdef FUSE_BIAS
+        // Pop this expert's biases so the reader can refill for the next expert.
+        CircularBuffer(cb_gate_bias).pop_front(g_in1_per_core_w);
+        CircularBuffer(cb_up_bias).pop_front(g_in1_per_core_w);
+        CircularBuffer(cb_down_bias).pop_front(d_in1_per_core_w);
+#endif
+    }  // end per-local-expert loop
 }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/compute/fused_swiglu.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/compute/fused_swiglu.cpp
@@ -331,16 +331,21 @@ FORCE_INLINE void matmul_phase_fused_gu(
     uint32_t gate_intermed_cb_id,
     uint32_t up_intermed_cb_id,
     uint32_t m_subblocks) {
-    // Adaptive per_core_M: this core's gate/up work is bounded by the runtime
-    // per_core_M (m_subblocks tile-rows). The x block this core consumes and the
-    // partials/intermed single-block CBs shrink with it; the gate/up WEIGHT
-    // blocks stay full-width (M-independent). The CBs were SIZED on the host to
-    // the compile-time MAX per_core_M, so a smaller runtime count just uses fewer
-    // of the reserved tiles. m_subblocks==0 (this core owns no row this chunk)
-    // reserves/pushes nothing.
+    // Adaptive per_core_M: this core's gate/up WORK is bounded by the runtime
+    // per_core_M (m_subblocks tile-rows) — MACs, tilize strips, copies and packs
+    // all scale with it. The gate/up WEIGHT blocks stay full-width (M-independent).
+    //
+    // The CB BLOCK SIZE, however, is the compile-time MAX and never varies: every
+    // reserve/push/wait/pop below moves a full max block, and the runtime remainder
+    // is padded with O(1) pointer-only bumps. See the ring-alignment note in
+    // adaptive_chunk.hpp — a block size that changes between experts overshoots
+    // fifo_limit, which never wraps, and the CB pointer runs away into L1.
     const uint32_t EFF_M = m_subblocks;
-    const uint32_t x_block_tiles = m_subblocks * in0_block_w;  // runtime x block (per_core_M rows)
+    const uint32_t x_block_tiles = m_subblocks * in0_block_w;  // runtime x work (per_core_M rows)
     const uint32_t EFF_OUT = m_subblocks * in1_num_subblocks * out_subblock_num_tiles;
+    // Constant CB block sizes (per_core_M_max-derived, from the host CB sizing).
+    constexpr uint32_t X_BLOCK_TILES_MAX = in0_block_num_tiles;
+    constexpr uint32_t EFF_OUT_MAX = out_block_num_tiles;
     pack_reconfig_data_format(partials_gu_cb_id);
 #ifdef PACKER_L1_ACC
     PACK((llk_pack_reconfig_l1_acc(0)));
@@ -353,16 +358,15 @@ FORCE_INLINE void matmul_phase_fused_gu(
     CircularBuffer partials_up_cb(partials_up_cb_id);
     CircularBuffer gate_intermed_cb(gate_intermed_cb_id);
 
-    // Reserve both partials CBs once for the (effective) per-core block. pack_tile
-    // with output_tile_index writes to absolute slots; WrPtr doesn't advance
-    // until cb_push_back below. Across K-blocks 1..N-1, L1_ACC packs land
-    // back in the SAME L1 slots — accumulating physically — which is what
-    // we want. No per-K-block pop+repush needed. Guarded by EFF_M>0 so an
-    // empty row (m_subblocks==0) never issues a 0-count reserve/push.
-    if (EFF_M > 0) {
-        partials_gu_cb.reserve_back(EFF_OUT);
-        partials_up_cb.reserve_back(EFF_OUT);
-    }
+    // Reserve both partials CBs once for the FULL max block. pack_tile with
+    // output_tile_index writes to absolute slots; WrPtr doesn't advance until
+    // cb_push_back below. Across K-blocks 1..N-1, L1_ACC packs land back in the
+    // SAME L1 slots — accumulating physically — which is what we want. No
+    // per-K-block pop+repush needed. Only slots [0, EFF_OUT) are ever written;
+    // the rest of the block is stale and is dropped downstream (the down matmul
+    // MAC-skips rows >= per_core_M and the writer never emits them).
+    partials_gu_cb.reserve_back(EFF_OUT_MAX);
+    partials_up_cb.reserve_back(EFF_OUT_MAX);
 
     for (uint32_t block = 0; block < num_blocks; ++block) {
         if constexpr (tilize_x) {
@@ -388,6 +392,20 @@ FORCE_INLINE void matmul_phase_fused_gu(
                 compute_kernel_lib::tilize_config::InitUninitMode::InitAndUninit,
                 compute_kernel_lib::tilize_config::WaitMode::WaitBlock,
                 compute_kernel_lib::tilize_config::ReconfigureRegisterDatatypeMode::UnpackAndPackReconfigure>(n_strips);
+            // The helper consumed/produced only the runtime rows, but the reader
+            // pushed a full max cb_x_rm block and the matmul below pops a full max
+            // cb_in0_x block. Settle both with pointer-only bumps (no tilize work
+            // on the stale rows) so every CB moves a constant-size block.
+            {
+                const uint32_t x_pad = X_BLOCK_TILES_MAX - x_block_tiles;
+                if (x_pad > 0) {
+                    CircularBuffer x_rm_cb(x_rm_cb_id);
+                    x_rm_cb.wait_front(x_pad);
+                    x_rm_cb.pop_front(x_pad);
+                    x_cb.reserve_back(x_pad);
+                    x_cb.push_back(x_pad);
+                }
+            }
             reconfig_data_format_srca(gate_cb_id);
             matmul_block_init(x_cb_id, gate_cb_id, 0, out_subblock_w, out_subblock_h, in0_block_w);
             pack_reconfig_data_format(x_cb_id, partials_gu_cb_id);
@@ -395,7 +413,7 @@ FORCE_INLINE void matmul_phase_fused_gu(
             PACK((llk_pack_reconfig_l1_acc(block == 0 ? 0 : 1)));
 #endif
         }
-        x_cb.wait_front(x_block_tiles);
+        x_cb.wait_front(X_BLOCK_TILES_MAX);
         gate_cb.wait_front(in1_block_num_tiles);
         up_cb.wait_front(in1_block_num_tiles);
 
@@ -470,15 +488,13 @@ FORCE_INLINE void matmul_phase_fused_gu(
         }
 #endif
 
-        x_cb.pop_front(x_block_tiles);
+        x_cb.pop_front(X_BLOCK_TILES_MAX);
         gate_cb.pop_front(in1_block_num_tiles);
         up_cb.pop_front(in1_block_num_tiles);
     }
     // Make the accumulated partials visible to the second-pass copy loops.
-    if (EFF_M > 0) {
-        partials_gu_cb.push_back(EFF_OUT);
-        partials_up_cb.push_back(EFF_OUT);
-    }
+    partials_gu_cb.push_back(EFF_OUT_MAX);
+    partials_up_cb.push_back(EFF_OUT_MAX);
 
     // After K-loop: partials_gu holds gate-matmul accumulator,
     // partials_up holds up-matmul accumulator. Copy each to its intermed
@@ -528,6 +544,18 @@ FORCE_INLINE void matmul_phase_fused_gu(
         gate_intermed_cb.push_back(out_subblock_num_tiles);
         tile_regs_release();
     }
+    // The copy loop above did real work only for the runtime rows. Settle the rest
+    // of the constant-size block with pointer-only bumps: drop the stale tail of
+    // partials_gu and pad gate_intermed so multiply_phase sees a full max block.
+    {
+        const uint32_t pad = EFF_OUT_MAX - EFF_OUT;
+        if (pad > 0) {
+            partials_gu_cb.wait_front(pad);
+            partials_gu_cb.pop_front(pad);
+            gate_intermed_cb.reserve_back(pad);
+            gate_intermed_cb.push_back(pad);
+        }
+    }
 
     // Up partials are NOT copied to a separate cb_up_intermed: the multiply
     // phase reads cb_partials_up directly (bf16) and pairs each tile with
@@ -571,9 +599,9 @@ FORCE_INLINE void swiglu_oai_activation_phase(
     // Adaptive per_core_M: this core produces eff_out_tiles = per_core_M * pcN
     // activated tiles this chunk (0 if it owns no row -> nothing to do).
     const uint32_t EFF_OUT = eff_out_tiles;
-    if (EFF_OUT == 0) {
-        return;
-    }
+    // CB blocks are the constant compile-time max (see matmul_phase_fused_gu);
+    // only the activation work below is bounded by the runtime EFF_OUT.
+    constexpr uint32_t EFF_OUT_MAX = out_block_num_tiles;
     // Dst budget derived from the host ComputeConfig (via -DFP32_DEST_ACC_EN) so
     // it and the SFPU op's fp32-dest template below stay in sync with the
     // program factory's DST_CAPACITY / fp32_dest_acc_en (no silent drift). The
@@ -587,8 +615,8 @@ FORCE_INLINE void swiglu_oai_activation_phase(
     CircularBuffer up_partials_cb(up_partials_cb_id);
     CircularBuffer activated_cb(activated_cb_id);
 
-    gate_partials_cb.wait_front(EFF_OUT);
-    up_partials_cb.wait_front(EFF_OUT);
+    gate_partials_cb.wait_front(EFF_OUT_MAX);
+    up_partials_cb.wait_front(EFF_OUT_MAX);
 
     pack_reconfig_data_format(activated_cb_id);
     // SrcA was last configured for the up matmul's in1 weights (prev_srcA_cb_id,
@@ -646,8 +674,17 @@ FORCE_INLINE void swiglu_oai_activation_phase(
         activated_cb.push_back(c);
         tile_regs_release();
     }
-    gate_partials_cb.pop_front(EFF_OUT);
-    up_partials_cb.pop_front(EFF_OUT);
+    // Pad cb_activated up to the constant block (pointer-only); the reader drains
+    // the full max block and mcasts only the runtime rows.
+    {
+        const uint32_t pad = EFF_OUT_MAX - EFF_OUT;
+        if (pad > 0) {
+            activated_cb.reserve_back(pad);
+            activated_cb.push_back(pad);
+        }
+    }
+    gate_partials_cb.pop_front(EFF_OUT_MAX);
+    up_partials_cb.pop_front(EFF_OUT_MAX);
 }
 #endif
 
@@ -662,14 +699,12 @@ FORCE_INLINE void multiply_phase(
     CircularBuffer activated_cb(activated_cb_id);
 
     const uint32_t EFF_OUT = eff_out_tiles;
-    // Empty row (no valid tiles): gate_intermed / partials_up were not pushed, so
-    // there is nothing to wait on or drain.
-    if (EFF_OUT == 0) {
-        return;
-    }
+    // CB blocks are the constant compile-time max (see matmul_phase_fused_gu);
+    // only the multiply work below is bounded by the runtime EFF_OUT.
+    constexpr uint32_t EFF_OUT_MAX = out_block_num_tiles;
 
-    gate_cb.wait_front(EFF_OUT);
-    up_cb.wait_front(EFF_OUT);
+    gate_cb.wait_front(EFF_OUT_MAX);
+    up_cb.wait_front(EFF_OUT_MAX);
 
     // Reconfigure packer for activated format and unpacker for both
     // gate_cb (SrcA) and up_cb (SrcB). After phase 2's second pass the
@@ -699,8 +734,17 @@ FORCE_INLINE void multiply_phase(
         tile_regs_release();
         base += out_subblock_num_tiles;
     }
-    gate_cb.pop_front(EFF_OUT);
-    up_cb.pop_front(EFF_OUT);
+    // Pad cb_activated up to the constant block (pointer-only); the reader drains
+    // the full max block and mcasts only the runtime rows.
+    {
+        const uint32_t pad = EFF_OUT_MAX - EFF_OUT;
+        if (pad > 0) {
+            activated_cb.reserve_back(pad);
+            activated_cb.push_back(pad);
+        }
+    }
+    gate_cb.pop_front(EFF_OUT_MAX);
+    up_cb.pop_front(EFF_OUT_MAX);
 }
 
 }  // namespace

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/compute/fused_swiglu.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/compute/fused_swiglu.cpp
@@ -923,6 +923,8 @@ void kernel_main() {
     constexpr uint32_t cb_out = get_named_compile_time_arg_val("cb_out");
     constexpr uint32_t cb_counts_scratch = get_named_compile_time_arg_val("cb_counts_scratch");
     constexpr uint32_t cb_idx_scratch = get_named_compile_time_arg_val("cb_idx_scratch");
+    // This expert's region size in tile-rows; caps the device-provided count.
+    constexpr uint32_t m_tiles_full = get_named_compile_time_arg_val("m_tiles_full");
     // Row-major bf16 x staging (x_is_row_major only); tilize input CB. Unused
     // when x is TILE.
     constexpr uint32_t cb_x_rm = get_named_compile_time_arg_val("cb_x_rm");
@@ -1002,7 +1004,8 @@ void kernel_main() {
         // the identical clamp, keeping the three row mappings in lockstep (see
         // adaptive_chunk::clamp_count_tiles).
         const uint32_t count_tiles_raw = (count_value + 31) / 32;
-        const uint32_t count_tiles = adaptive_chunk::clamp_count_tiles(count_tiles_raw, chunk_M_max, num_chunks_max);
+        const uint32_t count_tiles =
+            adaptive_chunk::clamp_count_tiles(count_tiles_raw, chunk_M_max, num_chunks_max, m_tiles_full);
         ASSERT(count_tiles == count_tiles_raw);
         const uint32_t effective_chunks = adaptive_chunk::num_chunks(count_tiles, chunk_M_max);
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/compute/fused_swiglu.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/compute/fused_swiglu.cpp
@@ -393,16 +393,22 @@ FORCE_INLINE void matmul_phase_fused_gu(
     // is all in N (the hidden dim), where a matmul is column-independent — the
     // unwritten weight columns past N_gate_tiles_full corrupt only their OWN output
     // columns, which map 1:1 onto the down K positions the down phase excludes.
-    // Adaptive per_core_M: this core's gate/up work is bounded by the runtime
-    // per_core_M (m_subblocks tile-rows). The x block this core consumes and the
-    // partials/intermed single-block CBs shrink with it; the gate/up WEIGHT
-    // blocks stay full-width (M-independent). The CBs were SIZED on the host to
-    // the compile-time MAX per_core_M, so a smaller runtime count just uses fewer
-    // of the reserved tiles. m_subblocks==0 (this core owns no row this chunk)
-    // reserves/pushes nothing.
+    //
+    // Adaptive per_core_M: this core's gate/up WORK is bounded by the runtime
+    // per_core_M (m_subblocks tile-rows) — MACs, tilize strips, copies and packs
+    // all scale with it. The gate/up WEIGHT blocks stay full-width (M-independent).
+    //
+    // The CB BLOCK SIZE, however, is the compile-time MAX and never varies: every
+    // reserve/push/wait/pop below moves a full max block, and the runtime remainder
+    // is padded with O(1) pointer-only bumps. See the ring-alignment note in
+    // adaptive_chunk.hpp — a block size that changes between experts overshoots
+    // fifo_limit, which never wraps, and the CB pointer runs away into L1.
     const uint32_t EFF_M = m_subblocks;
-    const uint32_t x_block_tiles = m_subblocks * in0_block_w;  // runtime x block (per_core_M rows)
+    const uint32_t x_block_tiles = m_subblocks * in0_block_w;  // runtime x work (per_core_M rows)
     const uint32_t EFF_OUT = m_subblocks * in1_num_subblocks * out_subblock_num_tiles;
+    // Constant CB block sizes (per_core_M_max-derived, from the host CB sizing).
+    constexpr uint32_t X_BLOCK_TILES_MAX = in0_block_num_tiles;
+    constexpr uint32_t EFF_OUT_MAX = out_block_num_tiles;
     pack_reconfig_data_format(partials_gu_cb_id);
 #ifdef PACKER_L1_ACC
     PACK((llk_pack_reconfig_l1_acc(0)));
@@ -415,16 +421,15 @@ FORCE_INLINE void matmul_phase_fused_gu(
     CircularBuffer partials_up_cb(partials_up_cb_id);
     CircularBuffer gate_intermed_cb(gate_intermed_cb_id);
 
-    // Reserve both partials CBs once for the (effective) per-core block. pack_tile
-    // with output_tile_index writes to absolute slots; WrPtr doesn't advance
-    // until cb_push_back below. Across K-blocks 1..N-1, L1_ACC packs land
-    // back in the SAME L1 slots — accumulating physically — which is what
-    // we want, at the price of a packer drain per block. Guarded by EFF_M>0 so an
-    // empty row (m_subblocks==0) never issues a 0-count reserve/push.
-    if (EFF_M > 0) {
-        partials_gu_cb.reserve_back(EFF_OUT);
-        partials_up_cb.reserve_back(EFF_OUT);
-    }
+    // Reserve both partials CBs once for the FULL max block. pack_tile with
+    // output_tile_index writes to absolute slots; WrPtr doesn't advance until
+    // cb_push_back below. Across K-blocks 1..N-1, L1_ACC packs land back in the
+    // SAME L1 slots — accumulating physically — which is what we want. No
+    // per-K-block pop+repush needed. Only slots [0, EFF_OUT) are ever written;
+    // the rest of the block is stale and is dropped downstream (the down matmul
+    // MAC-skips rows >= per_core_M and the writer never emits them).
+    partials_gu_cb.reserve_back(EFF_OUT_MAX);
+    partials_up_cb.reserve_back(EFF_OUT_MAX);
 
     for (uint32_t block = 0; block < num_blocks; ++block) {
         if constexpr (tilize_x) {
@@ -450,6 +455,20 @@ FORCE_INLINE void matmul_phase_fused_gu(
                 compute_kernel_lib::tilize_config::InitUninitMode::InitAndUninit,
                 compute_kernel_lib::tilize_config::WaitMode::WaitBlock,
                 compute_kernel_lib::tilize_config::ReconfigureRegisterDatatypeMode::UnpackAndPackReconfigure>(n_strips);
+            // The helper consumed/produced only the runtime rows, but the reader
+            // pushed a full max cb_x_rm block and the matmul below pops a full max
+            // cb_in0_x block. Settle both with pointer-only bumps (no tilize work
+            // on the stale rows) so every CB moves a constant-size block.
+            {
+                const uint32_t x_pad = X_BLOCK_TILES_MAX - x_block_tiles;
+                if (x_pad > 0) {
+                    CircularBuffer x_rm_cb(x_rm_cb_id);
+                    x_rm_cb.wait_front(x_pad);
+                    x_rm_cb.pop_front(x_pad);
+                    x_cb.reserve_back(x_pad);
+                    x_cb.push_back(x_pad);
+                }
+            }
             reconfig_data_format_srca(gate_cb_id);
             matmul_block_init(x_cb_id, gate_cb_id, 0, out_subblock_w, out_subblock_h, in0_block_w);
             pack_reconfig_data_format(x_cb_id, partials_gu_cb_id);
@@ -457,7 +476,7 @@ FORCE_INLINE void matmul_phase_fused_gu(
             PACK((llk_pack_reconfig_l1_acc(block == 0 ? 0 : 1)));
 #endif
         }
-        x_cb.wait_front(x_block_tiles);
+        x_cb.wait_front(X_BLOCK_TILES_MAX);
         gate_cb.wait_front(in1_block_num_tiles);
         up_cb.wait_front(in1_block_num_tiles);
 
@@ -544,15 +563,13 @@ FORCE_INLINE void matmul_phase_fused_gu(
         // out_subblock_w == 1 it is a single pack.
         drain_packer_before_reaccumulate();
 
-        x_cb.pop_front(x_block_tiles);
+        x_cb.pop_front(X_BLOCK_TILES_MAX);
         gate_cb.pop_front(in1_block_num_tiles);
         up_cb.pop_front(in1_block_num_tiles);
     }
     // Make the accumulated partials visible to the second-pass copy loops.
-    if (EFF_M > 0) {
-        partials_gu_cb.push_back(EFF_OUT);
-        partials_up_cb.push_back(EFF_OUT);
-    }
+    partials_gu_cb.push_back(EFF_OUT_MAX);
+    partials_up_cb.push_back(EFF_OUT_MAX);
 
     // After K-loop: partials_gu holds gate-matmul accumulator,
     // partials_up holds up-matmul accumulator. Copy each to its intermed
@@ -597,6 +614,18 @@ FORCE_INLINE void matmul_phase_fused_gu(
         }
         gate_intermed_cb.push_back(out_subblock_num_tiles);
         tile_regs_release();
+    }
+    // The copy loop above did real work only for the runtime rows. Settle the rest
+    // of the constant-size block with pointer-only bumps: drop the stale tail of
+    // partials_gu and pad gate_intermed so multiply_phase sees a full max block.
+    {
+        const uint32_t pad = EFF_OUT_MAX - EFF_OUT;
+        if (pad > 0) {
+            partials_gu_cb.wait_front(pad);
+            partials_gu_cb.pop_front(pad);
+            gate_intermed_cb.reserve_back(pad);
+            gate_intermed_cb.push_back(pad);
+        }
     }
 
     // Up partials are NOT copied to a separate cb_up_intermed: the multiply
@@ -648,9 +677,9 @@ FORCE_INLINE void binary_activation_phase(
     // Adaptive per_core_M: this core produces eff_out_tiles = per_core_M * pcN
     // activated tiles this chunk (0 if it owns no row -> nothing to do).
     const uint32_t EFF_OUT = eff_out_tiles;
-    if (EFF_OUT == 0) {
-        return;
-    }
+    // CB blocks are the constant compile-time max (see matmul_phase_fused_gu);
+    // only the activation work below is bounded by the runtime EFF_OUT.
+    constexpr uint32_t EFF_OUT_MAX = out_block_num_tiles;
     // Dst budget derived from the host ComputeConfig (via -DFP32_DEST_ACC_EN) so
     // it and the SFPU op's fp32-dest template below stay in sync with the
     // program factory's DST_CAPACITY / fp32_dest_acc_en (no silent drift). The
@@ -667,8 +696,8 @@ FORCE_INLINE void binary_activation_phase(
     CircularBuffer up_partials_cb(up_partials_cb_id);
     CircularBuffer activated_cb(activated_cb_id);
 
-    gate_partials_cb.wait_front(EFF_OUT);
-    up_partials_cb.wait_front(EFF_OUT);
+    gate_partials_cb.wait_front(EFF_OUT_MAX);
+    up_partials_cb.wait_front(EFF_OUT_MAX);
 
     pack_reconfig_data_format(activated_cb_id);
     // SrcA was last configured for the up matmul's in1 weights (prev_srcA_cb_id,
@@ -726,8 +755,17 @@ FORCE_INLINE void binary_activation_phase(
         activated_cb.push_back(c);
         tile_regs_release();
     }
-    gate_partials_cb.pop_front(EFF_OUT);
-    up_partials_cb.pop_front(EFF_OUT);
+    // Pad cb_activated up to the constant block (pointer-only); the reader drains
+    // the full max block and mcasts only the runtime rows.
+    {
+        const uint32_t pad = EFF_OUT_MAX - EFF_OUT;
+        if (pad > 0) {
+            activated_cb.reserve_back(pad);
+            activated_cb.push_back(pad);
+        }
+    }
+    gate_partials_cb.pop_front(EFF_OUT_MAX);
+    up_partials_cb.pop_front(EFF_OUT_MAX);
 }
 #endif
 
@@ -742,14 +780,12 @@ FORCE_INLINE void multiply_phase(
     CircularBuffer activated_cb(activated_cb_id);
 
     const uint32_t EFF_OUT = eff_out_tiles;
-    // Empty row (no valid tiles): gate_intermed / partials_up were not pushed, so
-    // there is nothing to wait on or drain.
-    if (EFF_OUT == 0) {
-        return;
-    }
+    // CB blocks are the constant compile-time max (see matmul_phase_fused_gu);
+    // only the multiply work below is bounded by the runtime EFF_OUT.
+    constexpr uint32_t EFF_OUT_MAX = out_block_num_tiles;
 
-    gate_cb.wait_front(EFF_OUT);
-    up_cb.wait_front(EFF_OUT);
+    gate_cb.wait_front(EFF_OUT_MAX);
+    up_cb.wait_front(EFF_OUT_MAX);
 
     // Reconfigure packer for activated format and unpacker for both
     // gate_cb (SrcA) and up_cb (SrcB). After phase 2's second pass the
@@ -779,8 +815,17 @@ FORCE_INLINE void multiply_phase(
         tile_regs_release();
         base += out_subblock_num_tiles;
     }
-    gate_cb.pop_front(EFF_OUT);
-    up_cb.pop_front(EFF_OUT);
+    // Pad cb_activated up to the constant block (pointer-only); the reader drains
+    // the full max block and mcasts only the runtime rows.
+    {
+        const uint32_t pad = EFF_OUT_MAX - EFF_OUT;
+        if (pad > 0) {
+            activated_cb.reserve_back(pad);
+            activated_cb.push_back(pad);
+        }
+    }
+    gate_cb.pop_front(EFF_OUT_MAX);
+    up_cb.pop_front(EFF_OUT_MAX);
 }
 
 }  // namespace

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/compute/fused_swiglu.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/compute/fused_swiglu.cpp
@@ -184,13 +184,19 @@ FORCE_INLINE void matmul_phase(
     // writes fixed slots and WrPtr does not advance until the push_back after the
     // K-loop, so every K-block re-packs the SAME L1 addresses and PACKER_L1_ACC
     // accumulates physically in place — nothing ties the pushed count to the ring
-    // size. EFF_OUT shrinks only on the final (tail) chunk, and adaptive_chunk keeps
-    // per_core_M a divisor of the compile-time max, so a shrunk block still tiles
-    // the ring evenly. EFF_M == 0 reserves nothing. The K-loop pays for the missing
-    // CB round trip with an explicit packer drain per block.
-    if (EFF_M > 0) {
-        partials_cb.reserve_back(EFF_OUT);
-    }
+    // size. The K-loop pays for the missing CB round trip with an explicit packer
+    // drain per block.
+    //
+    // Reserve the FULL block, never the runtime EFF_OUT. partials_cb is single-
+    // buffered at exactly one max block, so pushing a SHORT block leaves the ring
+    // write pointer off a block boundary and the next full-size block straddles the
+    // end of the CB — and the packs above use an absolute output_tile_index off
+    // get_write_ptr(), so they run past the end instead of wrapping. EFF_OUT does
+    // NOT shrink only on an expert's final chunk: this op runs every local expert in
+    // one kernel, so per_core_M (hence EFF_OUT) drops on each expert's tail chunk and
+    // rises again on the next expert's first chunk. Only [0, EFF_OUT) is ever packed;
+    // the unpacked tail is drained by the pointer-only pop after the copy loop.
+    partials_cb.reserve_back(out_block_num_tiles);
 
     for (uint32_t block = 0; block < num_blocks; ++block) {
         // The reader pushes the FULL compile-time-max activated block (filling only
@@ -272,9 +278,7 @@ FORCE_INLINE void matmul_phase(
         in1_cb.pop_front(in1_block_num_tiles);
     }
     // Make the accumulated partials visible to the second-pass copy below.
-    if (EFF_M > 0) {
-        partials_cb.push_back(EFF_OUT);
-    }
+    partials_cb.push_back(out_block_num_tiles);
 
     // After the K-loop: partials_cb_id has EFF_OUT tiles holding the final
     // accumulated sum. Move them through dst into final_cb_id, applying silu on
@@ -334,6 +338,15 @@ FORCE_INLINE void matmul_phase(
         final_cb.push_back(out_subblock_num_tiles);
 
         tile_regs_release();
+    }
+
+    // Pointer-only drain of the partials tail: slots [EFF_OUT, out_block_num_tiles)
+    // were never packed this chunk. Popping them keeps the single-buffered partials
+    // ring block-aligned across chunks (see the reserve above).
+    if (EFF_OUT < out_block_num_tiles) {
+        const uint32_t partials_pad = out_block_num_tiles - EFF_OUT;
+        partials_cb.wait_front(partials_pad);
+        partials_cb.pop_front(partials_pad);
     }
 
     // The writer drains final_cb at the compile-time-MAX subblock count (it cannot

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/compute/fused_swiglu.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/compute/fused_swiglu.cpp
@@ -60,6 +60,8 @@
 #include "api/compute/tile_move_copy.h"
 #include "api/compute/tilize.h"
 #include "api/dataflow/circular_buffer.h"
+#include "api/debug/assert.h"
+#include "tools/profiler/kernel_profiler.hpp"
 #include "ttnn/cpp/ttnn/kernel_lib/tilize_helpers.hpp"
 #include "ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_fused_activation.hpp"
 #include "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/adaptive_chunk.hpp"
@@ -827,13 +829,13 @@ void kernel_main() {
     constexpr uint32_t d_out_subblock_w = get_compile_time_arg_val(28);
     constexpr uint32_t d_out_subblock_num_tiles = d_out_subblock_h * d_out_subblock_w;
     constexpr uint32_t d_out_block_num_tiles = get_compile_time_arg_val(29);
-    // Multi-chunk: the number of chunks is chosen at RUNTIME from the device
-    // token count (see the picker below). num_chunks_max is the compile-time
+    // Multi-chunk: the number of chunks is chosen at RUNTIME from each expert's
+    // device token count (see the picker below). num_chunks_max is the compile-time
     // upper bound (host = ceil(M_tiles_full / min_chunk)) used only to clamp the
     // runtime chunk count defensively. chunk_M_max is the CB-sized maximum
     // chunk (per_core_M_max * GRID_Y); the picker never returns more than this.
     constexpr uint32_t num_chunks_max = get_compile_time_arg_val(30);
-    constexpr uint32_t local_expert_id = get_compile_time_arg_val(31);
+    constexpr uint32_t experts_per_chip = get_compile_time_arg_val(31);
     // chunk_M_max is the CB-sized MAXIMUM chunk (per_core_M_max * GRID_Y). The
     // runtime picker (adaptive_chunk::num_chunks) sizes the actual chunk to the
     // device token count and never exceeds this.
@@ -885,49 +887,18 @@ void kernel_main() {
     CircularBuffer counts_scratch_cb(cb_counts_scratch);
     CircularBuffer idx_scratch_cb(cb_idx_scratch);
 
-    // Wait for the reader (BRISC) to push the per-expert counts/idx into
-    // shared L1. UNPACK reads the L1 via LocalCBInterface and broadcasts
-    // count_value to MATH and PACK via the inter-thread mailbox (MATH cannot
-    // access get_local_cb_interface symbols at link time). Production matmul
-    // uses the same UNPACK→mailbox→MATH/PACK pattern (see
-    // circular_buffer.h::read_tile_value).
+    // Wait for the reader (BRISC) to push the counts/idx into shared L1. They
+    // are pushed ONCE and stay resident, so UNPACK can re-index them per expert.
     counts_scratch_cb.wait_front(1);
     idx_scratch_cb.wait_front(1);
-    uint32_t count_value = 0;
-    UNPACK(({
-        const uint32_t counts_l1_addr = get_local_cb_interface(cb_counts_scratch).fifo_rd_ptr << 4;
-        const uint32_t idx_l1_addr = get_local_cb_interface(cb_idx_scratch).fifo_rd_ptr << 4;
-        const volatile tt_l1_ptr uint32_t* counts_ptr =
-            reinterpret_cast<const volatile tt_l1_ptr uint32_t*>(counts_l1_addr);
-        const volatile tt_l1_ptr uint32_t* idx_ptr = reinterpret_cast<const volatile tt_l1_ptr uint32_t*>(idx_l1_addr);
-        const uint32_t global_expert_id = idx_ptr[local_expert_id];
-        count_value = counts_ptr[global_expert_id];
-        ckernel::mailbox_write(ckernel::ThreadId::MathThreadId, count_value);
-        ckernel::mailbox_write(ckernel::ThreadId::PackThreadId, count_value);
-    }));
-    MATH(count_value = ckernel::mailbox_read(ckernel::ThreadId::UnpackThreadId);)
-    PACK(count_value = ckernel::mailbox_read(ckernel::ThreadId::UnpackThreadId);)
-    // count is in TOKEN rows; convert to tile rows (ceil). The picker sizes
-    // chunk_M_tiles (hence per_core_M and the number of chunks) to THIS count,
-    // exactly as the retired host-side picker did — now at runtime, so no
-    // expected-token argument is needed. All three kernels (reader/compute/
-    // writer) run the identical picker on the same count, so they agree on the
-    // row mapping. per_core_M is uniform across cores and chunks; rows past the
-    // count in the tail chunk are left stale by the reader's bounded x mcast and
-    // dropped by the writer's row guards — M is a free dim, so garbage there never
-    // reaches a valid output row (contiguous mapping).
-    const uint32_t count_tiles = (count_value + 31) / 32;
-    const uint32_t effective_chunks_runtime = adaptive_chunk::num_chunks(count_tiles, chunk_M_max);
-    const uint32_t effective_chunks =
-        effective_chunks_runtime < num_chunks_max ? effective_chunks_runtime : num_chunks_max;
 
-    // SiLU is now applied as a MATH-thread SFPU pass on dst (silu_tile)
-    // between copy_tile and pack_tile — not packer-fused via
-    // apply_activation_from_pack. Empirically the packer-fused variant
-    // serialises the pack pipeline against the SFPU, slowing down the
-    // gate-intermed write. silu_tile_init() configures the MATH-side SFPU
-    // for silu; the pack then runs plain (no per-tile SFPU on the pack
-    // thread). Same total compute, better pipelining.
+    // SiLU is applied as a MATH-thread SFPU pass on dst (silu_tile) between
+    // copy_tile and pack_tile — not packer-fused via apply_activation_from_pack.
+    // Empirically the packer-fused variant serialises the pack pipeline against
+    // the SFPU, slowing down the gate-intermed write. silu_tile_init() configures
+    // the MATH-side SFPU for silu; the pack then runs plain (no per-tile SFPU on
+    // the pack thread). Same total compute, better pipelining.
+    // Init once — shared across all experts.
 #ifdef FUSED_BINARY_ACT
     // The binary activations init their own SFPU tables (recip for SwiGLU-OAI,
     // tanh for SiTU-GLU) instead of silu's.
@@ -936,112 +907,155 @@ void kernel_main() {
     silu_tile_init();
 #endif
 
-    for (uint32_t chunk = 0; chunk < effective_chunks; ++chunk) {
-        // Per-chunk per_core_M (per_core_M_max for full chunks, a smaller divisor
-        // for the tail). The gate/up + multiply phases do per_core_M rows of real
-        // work; the down matmul keeps its full compile-time ring and MAC-skips
-        // rows >= per_core_M (see matmul_phase). re_eff_out_gu = per_core_M *
-        // per_core_N_gu (g_in1_num_subblocks * gu_out_subblock_num_tiles ==
-        // per_core_N_gu since gu_out_subblock_h == 1).
-        const uint32_t re_m_valid = adaptive_chunk::per_core_M_for_chunk(chunk, count_tiles, chunk_M_max);
-        const uint32_t re_eff_out_gu = re_m_valid * g_in1_num_subblocks * gu_out_subblock_num_tiles;
-        //
-        // matmul_block_init only re-programs addressing, not SrcA/SrcB formats. On
-        // chunk >= 1 the unpacker is left on multiply_phase's operands, so reset it
-        // to the gate/up inputs here (in1 -> SrcA, in0 -> SrcB).
-        reconfig_data_format(cb_in1_gate, cb_in0_x);
-        matmul_block_init(
-            cb_in0_x,
-            cb_in1_gate,
-            /*transpose=*/0,
-            gu_out_subblock_w,
-            gu_out_subblock_h,
-            g_in0_block_w);
 
-        // Phases 1 & 2 fused: gate matmul + up matmul share the same per-K-block
-        // x push from the reader, so x DRAM mcast bytes are halved (one x read
-        // per K-block feeds both matmuls). Both matmuls accumulate into their
-        // own partials CB; after the K-loop, partials_gu -> gate_intermed (with
-        // silu) and partials_up -> up_intermed are produced by the same fused
-        // function.
-        matmul_phase_fused_gu<
-            g_in0_block_w,
-            g_in0_num_subblocks,
-            g_in0_block_num_tiles,
-            g_in0_subblock_num_tiles,
-            g_in1_num_subblocks,
-            g_in1_block_num_tiles,
-            g_in1_per_core_w,
-            g_num_blocks,
-            gu_out_subblock_h,
-            gu_out_subblock_w,
-            gu_out_subblock_num_tiles,
-            gu_out_block_num_tiles,
-            /*x_cb_id=*/cb_in0_x,
-            /*x_rm_cb_id=*/cb_x_rm,
-            /*tilize_x=*/(x_is_row_major != 0)>(
-            cb_in1_gate,
-            cb_in1_up,
-            cb_partials_gu,
-            cb_partials_up,
-            cb_gate_intermed,
-            cb_up_intermed,
-            /*m_subblocks=*/re_m_valid,
-            /*n_subblocks=*/gu_valid_n_subblocks);
+    // ======================= per-local-expert loop =======================
+    // Run the full gate/up/down FFN for every local expert in this program.
+    for (uint32_t local_expert_id = 0; local_expert_id < experts_per_chip; ++local_expert_id) {
+        // This expert's token count via the UNPACK→{MATH,PACK} mailbox (MATH/PACK
+        // cannot read the counts/idx L1 via the CB interface).
+        // count -> effective_chunks bounds this expert's chunk loop; count=0 => the
+        // loop body is skipped entirely.
+        uint32_t count_value = 0;
+        UNPACK(({
+            const uint32_t counts_l1_addr = get_local_cb_interface(cb_counts_scratch).fifo_rd_ptr << 4;
+            const uint32_t idx_l1_addr = get_local_cb_interface(cb_idx_scratch).fifo_rd_ptr << 4;
+            const volatile tt_l1_ptr uint32_t* counts_ptr =
+                reinterpret_cast<const volatile tt_l1_ptr uint32_t*>(counts_l1_addr);
+            const volatile tt_l1_ptr uint32_t* idx_ptr =
+                reinterpret_cast<const volatile tt_l1_ptr uint32_t*>(idx_l1_addr);
+            const uint32_t global_expert_id = idx_ptr[local_expert_id];
+            count_value = counts_ptr[global_expert_id];
+            ckernel::mailbox_write(ckernel::ThreadId::MathThreadId, count_value);
+            ckernel::mailbox_write(ckernel::ThreadId::PackThreadId, count_value);
+        }));
+        MATH(count_value = ckernel::mailbox_read(ckernel::ThreadId::UnpackThreadId);)
+        PACK(count_value = ckernel::mailbox_read(ckernel::ThreadId::UnpackThreadId);)
+        // count is in TOKEN rows; convert to tile rows (ceil), then let the runtime
+        // picker size THIS expert's chunks. The picker derives chunk_M_tiles (hence
+        // per_core_M and the chunk count) from this expert's own count, so no
+        // expected-token argument is needed and each expert's work scales to its
+        // actual load. All three kernels (reader/compute/writer) run the identical
+        // picker on the same count, so they agree on the row mapping; rows past the
+        // count in the tail chunk are zero-filled by the reader and dropped by the
+        // writer.
+        const uint32_t count_tiles = (count_value + 31) / 32;
+        const uint32_t effective_chunks = adaptive_chunk::num_chunks(count_tiles, chunk_M_max);
+        ASSERT(effective_chunks <= num_chunks_max);
+
+        for (uint32_t chunk = 0; chunk < effective_chunks; ++chunk) {
+            // Per-chunk per_core_M (per_core_M_max for full chunks, a smaller divisor
+            // for the tail). The gate/up + multiply phases do per_core_M rows of real
+            // work; the down matmul keeps its full compile-time ring and MAC-skips
+            // rows >= per_core_M (see matmul_phase). re_eff_out_gu = per_core_M *
+            // per_core_N_gu (g_in1_num_subblocks * gu_out_subblock_num_tiles ==
+            // per_core_N_gu since gu_out_subblock_h == 1).
+            const uint32_t re_m_valid = adaptive_chunk::per_core_M_for_chunk(chunk, count_tiles, chunk_M_max);
+            const uint32_t re_eff_out_gu = re_m_valid * g_in1_num_subblocks * gu_out_subblock_num_tiles;
+            //
+            // matmul_block_init only re-programs addressing, not SrcA/SrcB formats. On
+            // chunk >= 1 the unpacker is left on multiply_phase's operands, so reset it
+            // to the gate/up inputs here (in1 -> SrcA, in0 -> SrcB).
+            reconfig_data_format(cb_in1_gate, cb_in0_x);
+            matmul_block_init(
+                cb_in0_x,
+                cb_in1_gate,
+                /*transpose=*/0,
+                gu_out_subblock_w,
+                gu_out_subblock_h,
+                g_in0_block_w);
+
+            // Phases 1 & 2 fused: gate matmul + up matmul share the same per-K-block
+            // x push from the reader, so x DRAM mcast bytes are halved (one x read
+            // per K-block feeds both matmuls). Both matmuls accumulate into their
+            // own partials CB; after the K-loop, partials_gu -> gate_intermed (with
+            // silu) and partials_up -> up_intermed are produced by the same fused
+            // function.
+            matmul_phase_fused_gu<
+                g_in0_block_w,
+                g_in0_num_subblocks,
+                g_in0_block_num_tiles,
+                g_in0_subblock_num_tiles,
+                g_in1_num_subblocks,
+                g_in1_block_num_tiles,
+                g_in1_per_core_w,
+                g_num_blocks,
+                gu_out_subblock_h,
+                gu_out_subblock_w,
+                gu_out_subblock_num_tiles,
+                gu_out_block_num_tiles,
+                /*x_cb_id=*/cb_in0_x,
+                /*x_rm_cb_id=*/cb_x_rm,
+                /*tilize_x=*/(x_is_row_major != 0)>(
+                cb_in1_gate,
+                cb_in1_up,
+                cb_partials_gu,
+                cb_partials_up,
+                cb_gate_intermed,
+                cb_up_intermed,
+                /*m_subblocks=*/re_m_valid,
+                /*n_subblocks=*/gu_valid_n_subblocks);
 
 #ifdef FUSED_BINARY_ACT
-        // Phase 3: fused activation on the raw bf16 accumulators -> cb_activated.
-        // cb_in1_up is the unpacker's last SrcA operand, passed so the partials reconfig
-        // (weights df -> Float16_b) actually fires.
-        binary_activation_phase<gu_out_block_num_tiles, g_in1_per_core_w>(
-            cb_in1_up, cb_partials_gu, cb_partials_up, cb_activated, re_eff_out_gu, cb_gate_bias, cb_up_bias);
-        (void)cb_gate_intermed;
-        (void)cb_up_intermed;
+            // Phase 3: fused activation on the raw bf16 accumulators -> cb_activated.
+            // cb_in1_up is the unpacker's last SrcA operand, passed so the partials reconfig
+            // (weights df -> Float16_b) actually fires.
+            binary_activation_phase<gu_out_block_num_tiles, g_in1_per_core_w>(
+                cb_in1_up, cb_partials_gu, cb_partials_up, cb_activated, re_eff_out_gu, cb_gate_bias, cb_up_bias);
+            (void)cb_gate_intermed;
+            (void)cb_up_intermed;
 #else
-        // Phase 3: elementwise multiply (cb_gate_intermed is silu(partials_gu)
-        // in bf8; cb_partials_up is the up matmul accumulator in bf16). The
-        // multiply does the format conversion via reconfig_data_format inside
-        // multiply_phase — both unpacker srcs get reset to the input CB
-        // formats.
-        multiply_phase<gu_out_block_num_tiles, gu_out_subblock_num_tiles>(
-            cb_gate_intermed, cb_partials_up, cb_activated, re_eff_out_gu);
-        (void)cb_up_intermed;
+            // Phase 3: elementwise multiply (cb_gate_intermed is silu(partials_gu)
+            // in bf8; cb_partials_up is the up matmul accumulator in bf16). The
+            // multiply does the format conversion via reconfig_data_format inside
+            // multiply_phase — both unpacker srcs get reset to the input CB
+            // formats.
+            multiply_phase<gu_out_block_num_tiles, gu_out_subblock_num_tiles>(
+                cb_gate_intermed, cb_partials_up, cb_activated, re_eff_out_gu);
+            (void)cb_up_intermed;
 #endif
 
-        // Phase 4: down matmul, output to cb_out.
-        // multiply_phase left the unpacker on (cb_gate_intermed, cb_partials_up);
-        // matmul_block_init does not re-program data formats, so reset the down
-        // operands here (in1 -> SrcA, in0 -> SrcB) before the matmul.
-        reconfig_data_format(cb_in1_down, cb_in0_down_full);
-        matmul_block_init(
-            cb_in0_down_full,
-            cb_in1_down,
-            /*transpose=*/0,
-            d_out_subblock_w,
-            d_out_subblock_h,
-            d_in0_block_w);
-        matmul_phase<
-            d_in0_block_w,
-            d_in0_num_subblocks,
-            d_in0_block_num_tiles,
-            d_in0_subblock_num_tiles,
-            d_in1_num_subblocks,
-            d_in1_block_num_tiles,
-            d_in1_per_core_w,
-            d_num_blocks,
-            d_out_subblock_h,
-            d_out_subblock_w,
-            d_out_subblock_num_tiles,
-            d_out_block_num_tiles,
-            /*apply_silu_on_final=*/false,
-            /*d_per_core_N=*/d_in1_per_core_w,
-            /*real_k_tiles=*/d_K_down_tiles>(
-            cb_in0_down_full,
-            cb_in1_down,
-            cb_partials_d,
-            cb_out,
-            /*m_subblocks=*/re_m_valid,
-            /*n_subblocks=*/d_valid_n_subblocks,
-            cb_down_bias);
-    }  // end chunk loop
+            // Phase 4: down matmul, output to cb_out.
+            // multiply_phase left the unpacker on (cb_gate_intermed, cb_partials_up);
+            // matmul_block_init does not re-program data formats, so reset the down
+            // operands here (in1 -> SrcA, in0 -> SrcB) before the matmul.
+            reconfig_data_format(cb_in1_down, cb_in0_down_full);
+            matmul_block_init(
+                cb_in0_down_full,
+                cb_in1_down,
+                /*transpose=*/0,
+                d_out_subblock_w,
+                d_out_subblock_h,
+                d_in0_block_w);
+            matmul_phase<
+                d_in0_block_w,
+                d_in0_num_subblocks,
+                d_in0_block_num_tiles,
+                d_in0_subblock_num_tiles,
+                d_in1_num_subblocks,
+                d_in1_block_num_tiles,
+                d_in1_per_core_w,
+                d_num_blocks,
+                d_out_subblock_h,
+                d_out_subblock_w,
+                d_out_subblock_num_tiles,
+                d_out_block_num_tiles,
+                /*apply_silu_on_final=*/false,
+                /*d_per_core_N=*/d_in1_per_core_w,
+                /*real_k_tiles=*/d_K_down_tiles>(
+                cb_in0_down_full,
+                cb_in1_down,
+                cb_partials_d,
+                cb_out,
+                /*m_subblocks=*/re_m_valid,
+                /*n_subblocks=*/d_valid_n_subblocks,
+                cb_down_bias);
+        }  // end chunk loop
+
+#ifdef FUSE_BIAS
+        // Pop this expert's biases so the reader can refill for the next expert.
+        CircularBuffer(cb_gate_bias).pop_front(g_in1_per_core_w);
+        CircularBuffer(cb_up_bias).pop_front(g_in1_per_core_w);
+        CircularBuffer(cb_down_bias).pop_front(d_in1_per_core_w);
+#endif
+    }  // end per-local-expert loop
 }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/compute/fused_swiglu.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/compute/fused_swiglu.cpp
@@ -983,9 +983,15 @@ void kernel_main() {
         // picker on the same count, so they agree on the row mapping; rows past the
         // count in the tail chunk are zero-filled by the reader and dropped by the
         // writer.
-        const uint32_t count_tiles = (count_value + 31) / 32;
+        // The count is device-produced and unvalidated, so clamp it to this
+        // program's capacity before deriving the chunk layout — arithmetic, so the
+        // bound holds in Release where ASSERT is a no-op. Reader and writer apply
+        // the identical clamp, keeping the three row mappings in lockstep (see
+        // adaptive_chunk::clamp_count_tiles).
+        const uint32_t count_tiles_raw = (count_value + 31) / 32;
+        const uint32_t count_tiles = adaptive_chunk::clamp_count_tiles(count_tiles_raw, chunk_M_max, num_chunks_max);
+        ASSERT(count_tiles == count_tiles_raw);
         const uint32_t effective_chunks = adaptive_chunk::num_chunks(count_tiles, chunk_M_max);
-        ASSERT(effective_chunks <= num_chunks_max);
 
         for (uint32_t chunk = 0; chunk < effective_chunks; ++chunk) {
             // Per-chunk per_core_M (per_core_M_max for full chunks, a smaller divisor

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/dataflow/unified_routed_expert_ffn_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/dataflow/unified_routed_expert_ffn_reader.cpp
@@ -141,6 +141,13 @@ void kernel_main() {
     constexpr bool up_split = (reader_mcasts_up != 0) && (reader_reads_up == 0);
 
     constexpr uint32_t g_in1_block_num_tiles = per_core_N_gu * in0_block_w_gu;
+    // CB block sizes are the compile-time MAX and never vary with the runtime
+    // per_core_M. Only the DRAM reads and the multicast payload below shrink to
+    // the live rows (#50885); the CB pointers always advance by a full max block.
+    // A block size that changed between experts would overshoot fifo_limit, which
+    // only wraps on exact equality — see the note in adaptive_chunk.hpp.
+    constexpr uint32_t g_in0_block_tiles_max = per_core_M_max * in0_block_w_gu;
+    constexpr uint32_t act_tiles_max = per_core_M_max * in0_block_w_d;
     // cb_in0_down_full stays sized to the compile-time MAX per-core M: the down
     // matmul keeps a full ring and MAC-skips rows >= the runtime per_core_M, so
     // the reader pushes the full block (filling only per_core_M runtime rows via
@@ -414,7 +421,6 @@ void kernel_main() {
         // for the tail. Chunk starts are UNIFORM at chunk*chunk_M_max (full chunks
         // are max_chunk; the tail is last, so its start is num_full*max_chunk too).
         const uint32_t per_core_M = adaptive_chunk::per_core_M_for_chunk(chunk, count_tiles, chunk_M_max);
-        const uint32_t g_in0_block_num_tiles = per_core_M * in0_block_w_gu;
         const uint32_t this_core_first_row = chunk * chunk_M_max + my_mt * per_core_M;
 
         // -------- PHASES 1+2 fused — push x ONCE per K-block, then gate then up.
@@ -431,7 +437,7 @@ void kernel_main() {
         //   per-K-block elapsed time at small per_core_M where mcast/handshake
         //   overhead dominates compute.
         for (uint32_t kb = 0; kb < num_blocks_gu; ++kb) {
-            x_stage_obj.reserve_back(g_in0_block_num_tiles);
+            x_stage_obj.reserve_back(g_in0_block_tiles_max);
             cb_in1_gate_obj.reserve_back(g_in1_block_num_tiles);
             if constexpr (reader_mcasts_up) {
                 cb_in1_up_obj.reserve_back(g_in1_block_num_tiles);
@@ -591,7 +597,7 @@ void kernel_main() {
                          .addr = block_start},
                         /*linked=*/true);
                 }
-                x_stage_obj.push_back(g_in0_block_num_tiles);
+                x_stage_obj.push_back(g_in0_block_tiles_max);
 
                 noc.async_writes_flushed();
                 in0_valid_sem.set(IN0_VALID);
@@ -740,7 +746,7 @@ void kernel_main() {
             // Step 3: receivers wait for both valid semaphores and push.
             if (!is_in0_sender) {
                 in0_valid_sem.wait(IN0_VALID);
-                x_stage_obj.push_back(g_in0_block_num_tiles);
+                x_stage_obj.push_back(g_in0_block_tiles_max);
             }
             if (!is_in1_sender) {
                 in1_valid_sem.wait(IN1_VALID);
@@ -875,14 +881,14 @@ void kernel_main() {
             // after the in1_down mcast; starts as soon as compute pushes
             // cb_activated AND the ready acks are in (already done in step 1).
             if (is_act_sender) {
-                // cb_activated holds this core's per_core_M (runtime) x in0_block_w_d
-                // activated tiles; read/mcast/pop exactly that many. cb_in0_down_full
-                // is pushed FULL (compile-time max) below so the down matmul's ring
-                // stays aligned — the rows past per_core_M are MAC-skipped there.
+                // cb_activated carries a FULL max block (constant CB block size —
+                // see adaptive_chunk.hpp), of which only the first per_core_M
+                // (runtime) x in0_block_w_d tiles hold this chunk's real rows. Drain
+                // the whole block but MCAST only the real tiles (#50885). Likewise
+                // cb_in0_down_full is pushed FULL below, and the down matmul
+                // MAC-skips the rows past per_core_M.
                 const uint32_t re_act_tiles = per_core_M * in0_block_w_d;
-                if (re_act_tiles > 0) {
-                    cb_activated_obj.wait_front(re_act_tiles);
-                }
+                cb_activated_obj.wait_front(act_tiles_max);
                 act_ready_sem.wait(GRID_X_NOC - 1);
                 act_ready_sem.set(0);
 
@@ -921,9 +927,7 @@ void kernel_main() {
                 act_valid_sem.set_multicast<NocOptions::MCAST_INCL_SRC>(
                     noc, mrow_first_nx, mrow_first_ny, mrow_last_nx, mrow_last_ny, GRID_X_NOC);
 
-                if (re_act_tiles > 0) {
-                    cb_activated_obj.pop_front(re_act_tiles);
-                }
+                cb_activated_obj.pop_front(act_tiles_max);
             }
 
             // Step 5: receivers wait for both valid sems and push.

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/dataflow/unified_routed_expert_ffn_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/dataflow/unified_routed_expert_ffn_reader.cpp
@@ -7,8 +7,7 @@
 // Per-core responsibilities, sequenced over `effective_chunks` chunks
 // (effective_chunks = ceil(this expert's token count / chunk_M_tiles)):
 //   - Read counts/idx_table scratch once at kernel start to discover this
-//     expert's active token count. x tile reads start at row 0 unless
-//     read_x_at_offset is set, in which case x is a shared buffer and this
+//     expert's active token count. x is the shared dispatched buffer and this
 //     expert's rows begin at start[global_id] (fusing what ttnn::extract did);
 //     the reader adds (start / TILE) * K_gate_tiles to every x page index.
 //   - Phase 1 (gate matmul, fused with phase 2): per K-block, sender at
@@ -36,59 +35,56 @@
 void kernel_main() {
     // -------------------------- runtime args ------------------------------
     const uint32_t x_addr = get_arg_val<uint32_t>(0);
-    // Args 1..3 hold expert-0's gate/up/down base addresses (kept for arg-layout
-    // stability); the per-expert weight-address arrays after `start` are used
-    // instead, so these single slots are intentionally not read here.
-    const uint32_t counts_addr = get_arg_val<uint32_t>(4);
-    const uint32_t idx_table_addr = get_arg_val<uint32_t>(5);
+    const uint32_t counts_addr = get_arg_val<uint32_t>(1);
+    const uint32_t idx_table_addr = get_arg_val<uint32_t>(2);
 
-    const uint32_t my_mt = get_arg_val<uint32_t>(6);
-    const uint32_t my_nt_gu = get_arg_val<uint32_t>(7);
-    const uint32_t my_nt_d = get_arg_val<uint32_t>(8);
+    const uint32_t my_mt = get_arg_val<uint32_t>(3);
+    const uint32_t my_nt_gu = get_arg_val<uint32_t>(4);
+    const uint32_t my_nt_d = get_arg_val<uint32_t>(5);
 
-    // Weight-multicast runtime args (indices 9..18).
-    const uint32_t is_in1_sender_u32 = get_arg_val<uint32_t>(9);
+    // Weight-multicast runtime args (indices 6..15).
+    const uint32_t is_in1_sender_u32 = get_arg_val<uint32_t>(6);
     const bool is_in1_sender = is_in1_sender_u32 != 0;
-    const uint32_t in1_ready_sem_id = get_arg_val<uint32_t>(10);
-    const uint32_t in1_valid_sem_id = get_arg_val<uint32_t>(11);
-    const uint32_t in1_num_receivers = get_arg_val<uint32_t>(12);
-    const uint32_t in1_mcast_nx_start = get_arg_val<uint32_t>(13);
-    const uint32_t in1_mcast_ny_start = get_arg_val<uint32_t>(14);
-    const uint32_t in1_mcast_nx_end = get_arg_val<uint32_t>(15);
-    const uint32_t in1_mcast_ny_end = get_arg_val<uint32_t>(16);
-    const uint32_t in1_sender_nx = get_arg_val<uint32_t>(17);
-    const uint32_t in1_sender_ny = get_arg_val<uint32_t>(18);
+    const uint32_t in1_ready_sem_id = get_arg_val<uint32_t>(7);
+    const uint32_t in1_valid_sem_id = get_arg_val<uint32_t>(8);
+    const uint32_t in1_num_receivers = get_arg_val<uint32_t>(9);
+    const uint32_t in1_mcast_nx_start = get_arg_val<uint32_t>(10);
+    const uint32_t in1_mcast_ny_start = get_arg_val<uint32_t>(11);
+    const uint32_t in1_mcast_nx_end = get_arg_val<uint32_t>(12);
+    const uint32_t in1_mcast_ny_end = get_arg_val<uint32_t>(13);
+    const uint32_t in1_sender_nx = get_arg_val<uint32_t>(14);
+    const uint32_t in1_sender_ny = get_arg_val<uint32_t>(15);
 
-    // x (in0) multicast runtime args (indices 19..28).
-    const uint32_t is_in0_sender_u32 = get_arg_val<uint32_t>(19);
+    // x (in0) multicast runtime args (indices 16..25).
+    const uint32_t is_in0_sender_u32 = get_arg_val<uint32_t>(16);
     const bool is_in0_sender = is_in0_sender_u32 != 0;
-    const uint32_t in0_ready_sem_id = get_arg_val<uint32_t>(20);
-    const uint32_t in0_valid_sem_id = get_arg_val<uint32_t>(21);
-    const uint32_t in0_num_receivers = get_arg_val<uint32_t>(22);
-    const uint32_t in0_mcast_nx_start = get_arg_val<uint32_t>(23);
-    const uint32_t in0_mcast_ny_start = get_arg_val<uint32_t>(24);
-    const uint32_t in0_mcast_nx_end = get_arg_val<uint32_t>(25);
-    const uint32_t in0_mcast_ny_end = get_arg_val<uint32_t>(26);
-    const uint32_t in0_sender_nx = get_arg_val<uint32_t>(27);
-    const uint32_t in0_sender_ny = get_arg_val<uint32_t>(28);
+    const uint32_t in0_ready_sem_id = get_arg_val<uint32_t>(17);
+    const uint32_t in0_valid_sem_id = get_arg_val<uint32_t>(18);
+    const uint32_t in0_num_receivers = get_arg_val<uint32_t>(19);
+    const uint32_t in0_mcast_nx_start = get_arg_val<uint32_t>(20);
+    const uint32_t in0_mcast_ny_start = get_arg_val<uint32_t>(21);
+    const uint32_t in0_mcast_nx_end = get_arg_val<uint32_t>(22);
+    const uint32_t in0_mcast_ny_end = get_arg_val<uint32_t>(23);
+    const uint32_t in0_sender_nx = get_arg_val<uint32_t>(24);
+    const uint32_t in0_sender_ny = get_arg_val<uint32_t>(25);
 
     // Activated L1 mcast sems. Sender (gx == kb at phase-4 K-block kb) waits
     // on its act_ready_sem for GRID_X - 1 incs from the receivers; then
     // mcasts cb_activated -> all M-row cores' cb_in0_down_full L1; then
     // mcasts act_valid_sem to release receivers.
-    const uint32_t act_ready_sem_id = get_arg_val<uint32_t>(29);
-    const uint32_t act_valid_sem_id = get_arg_val<uint32_t>(30);
+    const uint32_t act_ready_sem_id = get_arg_val<uint32_t>(26);
+    const uint32_t act_valid_sem_id = get_arg_val<uint32_t>(27);
 
     // UP_SPLIT local handshake (reader <-> writer): up_go = slot reserved,
     // up_done = up block landed in L1. Monotonic; gy=0 in1-sender cores only.
-    const uint32_t up_go_sem_id = get_arg_val<uint32_t>(31);
-    const uint32_t up_done_sem_id = get_arg_val<uint32_t>(32);
+    const uint32_t up_go_sem_id = get_arg_val<uint32_t>(28);
+    const uint32_t up_done_sem_id = get_arg_val<uint32_t>(29);
     Semaphore<> up_go_sem(up_go_sem_id);
     Semaphore<> up_done_sem(up_done_sem_id);
 
-    // M-row NoC coord table: GRID_X (x, y) pairs starting at runtime arg 33.
+    // M-row NoC coord table: GRID_X (x, y) pairs starting at runtime arg 30.
     // Used to resolve the sender's NoC addr per phase-4 K-block kb (= gx).
-    constexpr uint32_t M_ROW_NOC_RT_OFFSET = 33;
+    constexpr uint32_t M_ROW_NOC_RT_OFFSET = 30;
 
     // -------------------------- compile-time args -------------------------
     constexpr uint32_t cb_in0_x = get_compile_time_arg_val(0);
@@ -335,16 +331,22 @@ void kernel_main() {
 
         const uint32_t global_expert_id = idx_ptr[local_expert_id];
         const uint32_t count_value = counts_ptr[global_expert_id];
-        const uint32_t count_tiles = (count_value + TILE_HEIGHT - 1) / TILE_HEIGHT;
+        // counts[] is device-produced and unvalidated: bound it by the capacity
+        // this program was built for (num_chunks_max * chunk_M_max tile-rows)
+        // BEFORE deriving anything from it. The clamp is arithmetic so it also
+        // holds in Release, where ASSERT is a no-op; the assert below still
+        // hard-fails a mismatch in watcher builds. Compute and writer clamp
+        // identically, so all three keep the same row mapping (see
+        // adaptive_chunk::clamp_count_tiles).
+        const uint32_t count_tiles_raw = (count_value + TILE_HEIGHT - 1) / TILE_HEIGHT;
+        const uint32_t count_tiles = adaptive_chunk::clamp_count_tiles(count_tiles_raw, chunk_M_max, num_chunks_max);
+        ASSERT(count_tiles == count_tiles_raw);
         // Runtime chunk layout from THIS expert's actual token count (identical
         // math in the compute and writer kernels, so all three agree on the row
         // mapping). Full chunks span chunk_M_max tile-rows; the tail chunk shrinks
         // per_core_M to the remainder, so per_core_M is per-chunk (see the chunk
         // loop) and adapts to each expert's own load with minimal phantom work.
         const uint32_t effective_chunks = adaptive_chunk::num_chunks(count_tiles, chunk_M_max);
-        // An out-of-range count means counts[] disagrees with the allocated M —
-        // hard-fail rather than silently clamp and emit rows for the wrong tokens.
-        ASSERT(effective_chunks <= num_chunks_max);
 
         // x-read row offset: this expert's rows begin at start[global_id].
         // Convert the token row to a tile-page offset (row_tile * K_gate_tiles)

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/dataflow/unified_routed_expert_ffn_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/dataflow/unified_routed_expert_ffn_reader.cpp
@@ -30,15 +30,15 @@
 #include "api/dataflow/noc_semaphore.h"
 #include "api/dataflow/endpoints.h"
 #include "api/core_local_mem.h"
-#include "api/debug/dprint.h"  // TEMP: config dump
+#include "api/debug/assert.h"
 #include "../adaptive_chunk.hpp"
 
 void kernel_main() {
     // -------------------------- runtime args ------------------------------
     const uint32_t x_addr = get_arg_val<uint32_t>(0);
-    const uint32_t gate_addr = get_arg_val<uint32_t>(1);
-    const uint32_t up_addr = get_arg_val<uint32_t>(2);
-    const uint32_t down_addr = get_arg_val<uint32_t>(3);
+    // Args 1..3 hold expert-0's gate/up/down base addresses (kept for arg-layout
+    // stability); the per-expert weight-address arrays after `start` are used
+    // instead, so these single slots are intentionally not read here.
     const uint32_t counts_addr = get_arg_val<uint32_t>(4);
     const uint32_t idx_table_addr = get_arg_val<uint32_t>(5);
 
@@ -99,10 +99,10 @@ void kernel_main() {
     constexpr uint32_t cb_counts_scratch = get_compile_time_arg_val(5);
     constexpr uint32_t cb_idx_scratch = get_compile_time_arg_val(6);
 
-    constexpr uint32_t local_expert_id = get_compile_time_arg_val(7);
+    constexpr uint32_t experts_per_chip = get_compile_time_arg_val(7);
     // per_core_M_max: the CB-sized maximum per-core M (= chunk_M_max / GRID_Y).
-    // The RUNTIME per_core_M is picked from the device token count below and is
-    // <= this. CBs are allocated to the max; a smaller runtime pick uses fewer.
+    // The RUNTIME per_core_M is picked from each expert's device token count below
+    // and is <= this. CBs are allocated to the max; a smaller runtime pick uses fewer.
     constexpr uint32_t per_core_M_max = get_compile_time_arg_val(8);
     constexpr uint32_t per_core_N_gu = get_compile_time_arg_val(9);
     constexpr uint32_t per_core_N_d = get_compile_time_arg_val(10);
@@ -126,20 +126,17 @@ void kernel_main() {
     // NoC 1 into cb_in1_up); both 0 = UP_WRITER_MCAST, reader skips up.
     constexpr uint32_t reader_reads_up = get_compile_time_arg_val(23);
     constexpr uint32_t reader_mcasts_up = get_compile_time_arg_val(24);
-    // read_x_at_offset: x is a shared buffer; offset x reads by this expert's
-    // region start (start[global_id]/TILE tile-rows). 0 => x is per-expert,
-    // reads start at row 0. cb_start_scratch holds the fetched `start` page.
-    constexpr uint32_t read_x_at_offset = get_compile_time_arg_val(25);
-    constexpr uint32_t cb_start_scratch = get_compile_time_arg_val(26);
+    // cb_start_scratch holds the fetched `start` page.
+    constexpr uint32_t cb_start_scratch = get_compile_time_arg_val(25);
     // x_is_row_major: x is ROW_MAJOR bf16 — stream sticks into cb_x_rm for the
     // compute kernel to tilize. 0 => x is TILE bf8_b, read directly.
-    constexpr uint32_t x_is_row_major = get_compile_time_arg_val(27);
-    constexpr uint32_t cb_x_rm = get_compile_time_arg_val(28);
+    constexpr uint32_t x_is_row_major = get_compile_time_arg_val(26);
+    constexpr uint32_t cb_x_rm = get_compile_time_arg_val(27);
     // Tile height: rows (token-row sticks) per tile-row. Used to size row-major
     // reads and to convert token counts to tile-rows.
-    constexpr uint32_t TILE_HEIGHT = get_compile_time_arg_val(29);
+    constexpr uint32_t TILE_HEIGHT = get_compile_time_arg_val(28);
     // Byte size of one row-major x element: x is bf16 in the row-major path.
-    constexpr uint32_t X_RM_ELEM_BYTES = get_compile_time_arg_val(30);
+    constexpr uint32_t X_RM_ELEM_BYTES = get_compile_time_arg_val(29);
     // UP_SPLIT iff the reader multicasts up but does not read it from DRAM.
     constexpr bool up_split = (reader_mcasts_up != 0) && (reader_reads_up == 0);
 
@@ -159,7 +156,7 @@ void kernel_main() {
     // always agree. When false the matmul reads those rows and the fill stays.
     constexpr bool down_k_tail_skip = (K_down_tiles_padded - K_down_tiles) < in0_block_w_d;
 
-    constexpr uint32_t x_accessor_offset = 31;
+    constexpr uint32_t x_accessor_offset = 30;
     constexpr auto x_args = TensorAccessorArgs<x_accessor_offset>();
     const auto x_acc = TensorAccessor(x_args, x_addr, get_tile_size(cb_in0_x));
     // Row-major x accessor (x_is_row_major): x is a ROW_MAJOR bf16 buffer whose
@@ -170,17 +167,17 @@ void kernel_main() {
     constexpr uint32_t x_rm_stick_bytes = K_gate_tiles * TILE_HEIGHT * X_RM_ELEM_BYTES;
     const auto x_acc_rm = TensorAccessor(x_args, x_addr, x_rm_stick_bytes);
 
+    // gate/up/down accessor LAYOUT descriptors (compile-time). All experts share
+    // one layout; the per-expert accessor is built inside the expert loop from
+    // the descriptor + that expert's base address (runtime args).
     constexpr uint32_t gate_accessor_offset = x_args.next_compile_time_args_offset();
     constexpr auto gate_args = TensorAccessorArgs<gate_accessor_offset>();
-    const auto gate_acc = TensorAccessor(gate_args, gate_addr, get_tile_size(cb_in1_gate));
 
     constexpr uint32_t up_accessor_offset = gate_args.next_compile_time_args_offset();
     constexpr auto up_args = TensorAccessorArgs<up_accessor_offset>();
-    const auto up_acc = TensorAccessor(up_args, up_addr, get_tile_size(cb_in1_up));
 
     constexpr uint32_t down_accessor_offset = up_args.next_compile_time_args_offset();
     constexpr auto down_args = TensorAccessorArgs<down_accessor_offset>();
-    const auto down_acc = TensorAccessor(down_args, down_addr, get_tile_size(cb_in1_down));
 
     constexpr uint32_t counts_accessor_offset = down_args.next_compile_time_args_offset();
     constexpr auto counts_args = TensorAccessorArgs<counts_accessor_offset>();
@@ -191,33 +188,35 @@ void kernel_main() {
     const auto idx_acc = TensorAccessor(idx_args, idx_table_addr);
 
     // `start` (= expert_region_offsets) accessor. Appended last in the reader's
-    // accessor stream; read only when read_x_at_offset. start_addr is the final
-    // runtime arg, after the GRID_X-pair M-row NoC table at M_ROW_NOC_RT_OFFSET.
+    // accessor stream. start_addr is the runtime arg after the GRID_X-pair M-row
+    // NoC table at M_ROW_NOC_RT_OFFSET.
     const uint32_t start_addr = get_arg_val<uint32_t>(M_ROW_NOC_RT_OFFSET + 2 * GRID_X_NOC);
     constexpr uint32_t start_accessor_offset = idx_args.next_compile_time_args_offset();
     constexpr auto start_args = TensorAccessorArgs<start_accessor_offset>();
     const auto start_acc = TensorAccessor(start_args, start_addr);
 
+    // Per-expert weight base addresses follow start_addr in three contiguous
+    // runtime-arg blocks of experts_per_chip each: gate[0..N), up[0..N),
+    // down[0..N). gate_addr(e) = arg[WEIGHTS_RT + e], etc.
+    constexpr uint32_t WEIGHTS_RT = M_ROW_NOC_RT_OFFSET + 2 * GRID_X_NOC + 1;
+
 #ifdef FUSE_BIAS
-    // gpt-oss expert biases. RT addrs immediately follow start_addr; CT bias CB
-    // ids + accessors follow the start accessor. Read once (below), added by the
-    // compute kernel (gate/up before the activation, down after the down matmul).
-    const uint32_t gate_bias_addr = get_arg_val<uint32_t>(M_ROW_NOC_RT_OFFSET + 2 * GRID_X_NOC + 1);
-    const uint32_t up_bias_addr = get_arg_val<uint32_t>(M_ROW_NOC_RT_OFFSET + 2 * GRID_X_NOC + 2);
-    const uint32_t down_bias_addr = get_arg_val<uint32_t>(M_ROW_NOC_RT_OFFSET + 2 * GRID_X_NOC + 3);
+    // gpt-oss expert biases. CT bias CB ids + accessor descriptors follow the
+    // start accessor; per-expert bias base addresses follow the weight blocks in
+    // three further runtime-arg blocks (gate_bias[0..N), up_bias, down_bias)
+    // starting at BIAS_RT. Read per expert in the loop, added by the compute
+    // kernel (gate/up before the activation, down after the down matmul).
+    constexpr uint32_t BIAS_RT = WEIGHTS_RT + 3 * experts_per_chip;
     constexpr uint32_t bias_cb_offset = start_args.next_compile_time_args_offset();
     constexpr uint32_t cb_gate_bias = get_compile_time_arg_val(bias_cb_offset + 0);
     constexpr uint32_t cb_up_bias = get_compile_time_arg_val(bias_cb_offset + 1);
     constexpr uint32_t cb_down_bias = get_compile_time_arg_val(bias_cb_offset + 2);
     constexpr uint32_t gate_bias_accessor_offset = bias_cb_offset + 3;
     constexpr auto gate_bias_args = TensorAccessorArgs<gate_bias_accessor_offset>();
-    const auto gate_bias_acc = TensorAccessor(gate_bias_args, gate_bias_addr, get_tile_size(cb_gate_bias));
     constexpr uint32_t up_bias_accessor_offset = gate_bias_args.next_compile_time_args_offset();
     constexpr auto up_bias_args = TensorAccessorArgs<up_bias_accessor_offset>();
-    const auto up_bias_acc = TensorAccessor(up_bias_args, up_bias_addr, get_tile_size(cb_up_bias));
     constexpr uint32_t down_bias_accessor_offset = up_bias_args.next_compile_time_args_offset();
     constexpr auto down_bias_args = TensorAccessorArgs<down_bias_accessor_offset>();
-    const auto down_bias_acc = TensorAccessor(down_bias_args, down_bias_addr, get_tile_size(cb_down_bias));
     CircularBuffer cb_gate_bias_obj(cb_gate_bias);
     CircularBuffer cb_up_bias_obj(cb_up_bias);
     CircularBuffer cb_down_bias_obj(cb_down_bias);
@@ -285,115 +284,124 @@ void kernel_main() {
 
     const volatile tt_l1_ptr uint32_t* counts_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(counts_l1);
     const volatile tt_l1_ptr uint32_t* idx_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(idx_l1);
-    const uint32_t global_expert_id = idx_ptr[local_expert_id];
-    const uint32_t count_value = counts_ptr[global_expert_id];
-    // count_value is in TOKEN rows. Convert to tile rows (ceil) then to chunks.
-    // For count=0 the loop is empty (no chunks processed). For count > 0 we
-    // process ceil(count_tiles / chunk_M_tiles) chunks; the remaining chunks
-    // (if any) are skipped — no DRAM reads, no mcasts, no compute.
-    const uint32_t count_tiles = (count_value + 31) / 32;
-    // Runtime chunk layout from the actual token count (identical math in the
-    // compute and writer kernels, so all three agree on the row mapping). Full
-    // chunks span chunk_M_max tile-rows; the tail chunk shrinks per_core_M to the
-    // remainder. per_core_M is thus per-chunk (see the loop) and ADAPTS to the
-    // count with minimal phantom work; the chunk count is the minimum.
-    const uint32_t effective_chunks_runtime = adaptive_chunk::num_chunks(count_tiles, chunk_M_max);
-    // Clamp to the compile-time max just in case (defensive against bad input).
-    const uint32_t effective_chunks =
-        effective_chunks_runtime < num_chunks_max ? effective_chunks_runtime : num_chunks_max;
 
-    // x-read row offset. Zero unless read_x_at_offset: then x is a shared buffer
-    // and this expert's rows begin at start[global_id]. Fetch the start page and
-    // convert the token row to a tile-page offset (row_tile * K_gate_tiles), the
-    // exact source rebase ttnn::extract used to perform. Must agree with the
-    // writer's row_offset_tiles so x is read and y is written to the same region.
-    uint32_t x_start_tile_idx = 0;
-    // Row-major stick (token-row) base for this expert's region. TILE mode uses
-    // x_start_tile_idx (tile-page offset); row-major mode uses x_start_stick to
-    // offset the token-row stick page. Both derive from start[global_id] (a
-    // tile-aligned token row) and must agree with the writer's row_offset_tiles.
-    uint32_t x_start_stick = 0;
-    if constexpr (read_x_at_offset != 0) {
-        cb_start_scratch_obj.reserve_back(1);
-        const uint32_t start_l1 = cb_start_scratch_obj.get_write_ptr();
-        noc_read.async_read(
-            start_acc, CoreLocalMem<uint32_t>(start_l1), start_acc.get_aligned_page_size(), {.page_id = 0}, {});
-        noc_read.async_read_barrier();
-        cb_start_scratch_obj.push_back(1);
-        const volatile tt_l1_ptr uint32_t* start_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(start_l1);
-        const uint32_t start_value = start_ptr[global_expert_id];
-        x_start_tile_idx = (start_value / TILE_HEIGHT) * K_gate_tiles;
-        x_start_stick = start_value;
-    }
+    // Read the `start` (= expert_region_offsets) page ONCE into resident L1. x
+    // is the shared dispatched buffer; each expert's rows begin at
+    // start[global_id]. Indexed per expert in the loop below (must agree with
+    // the writer's row_offset_tiles so x is read and y is written to the same
+    // region).
+    cb_start_scratch_obj.reserve_back(1);
+    const uint32_t start_l1 = cb_start_scratch_obj.get_write_ptr();
+    noc_read.async_read(
+        start_acc, CoreLocalMem<uint32_t>(start_l1), start_acc.get_aligned_page_size(), {.page_id = 0}, {});
+    noc_read.async_read_barrier();
+    cb_start_scratch_obj.push_back(1);
+    const volatile tt_l1_ptr uint32_t* start_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(start_l1);
 
     const uint32_t x_tile_bytes = get_tile_size(cb_in0_x);
     const uint32_t gate_tile_bytes = get_tile_size(cb_in1_gate);
     const uint32_t up_tile_bytes = get_tile_size(cb_in1_up);
     const uint32_t down_tile_bytes = get_tile_size(cb_in1_down);
 
-    // Weight-multicast helper. For each in1 K-block:
-    //   * Sender (gy=0): wait for all GRID_Y-1 receivers to inc the local
-    //     ready_sem. Reset ready_sem. Read in1 from DRAM into local cb_in1.
-    //     Multicast the L1 region to receivers. Multicast valid_sem=1.
-    //   * Receiver: reserve cb space. Reset local valid_sem=0. Increment
-    //     sender's ready_sem at sender's NoC coord. Wait local valid_sem=1.
-    //
-    // Both sender and receiver finish with the K-block of in1 in their own
-    // cb_in1 L1, ready for cb_push_back/compute.
+    // Weight-multicast handshake constants (see the K-block loops below).
     constexpr uint32_t IN1_VALID = 1;
     constexpr uint32_t IN0_VALID = 1;
 
-    // UP_SPLIT handshake counter, kept in lockstep with the writer's.
+    // UP_SPLIT handshake counter, kept in lockstep with the writer's ACROSS all
+    // experts: both kernels loop experts in the same order with the same
+    // per-expert effective_chunks, so the per-K-block increments stay matched.
     uint32_t up_seq = 0;
 
+    // ======================= per-local-expert loop =======================
+    // Per expert we resolve its global id (idx_table[e]), token count
+    // (counts[global_id]), region offset (start[global_id]) and per-expert
+    // weight base addresses, then drive the same chunked matmul pipeline.
+    for (uint32_t local_expert_id = 0; local_expert_id < experts_per_chip; ++local_expert_id) {
+        // Per-expert weight accessors, built from the shared layout descriptors
+        // and this expert's base addresses (runtime-arg arrays after start).
+        const uint32_t gate_addr_e = get_arg_val<uint32_t>(WEIGHTS_RT + 0 * experts_per_chip + local_expert_id);
+        const uint32_t up_addr_e = get_arg_val<uint32_t>(WEIGHTS_RT + 1 * experts_per_chip + local_expert_id);
+        const uint32_t down_addr_e = get_arg_val<uint32_t>(WEIGHTS_RT + 2 * experts_per_chip + local_expert_id);
+        const auto gate_acc = TensorAccessor(gate_args, gate_addr_e, gate_tile_bytes);
+        const auto up_acc = TensorAccessor(up_args, up_addr_e, up_tile_bytes);
+        const auto down_acc = TensorAccessor(down_args, down_addr_e, down_tile_bytes);
+
+        const uint32_t global_expert_id = idx_ptr[local_expert_id];
+        const uint32_t count_value = counts_ptr[global_expert_id];
+        const uint32_t count_tiles = (count_value + TILE_HEIGHT - 1) / TILE_HEIGHT;
+        // Runtime chunk layout from THIS expert's actual token count (identical
+        // math in the compute and writer kernels, so all three agree on the row
+        // mapping). Full chunks span chunk_M_max tile-rows; the tail chunk shrinks
+        // per_core_M to the remainder, so per_core_M is per-chunk (see the chunk
+        // loop) and adapts to each expert's own load with minimal phantom work.
+        const uint32_t effective_chunks = adaptive_chunk::num_chunks(count_tiles, chunk_M_max);
+        // An out-of-range count means counts[] disagrees with the allocated M —
+        // hard-fail rather than silently clamp and emit rows for the wrong tokens.
+        ASSERT(effective_chunks <= num_chunks_max);
+
+        // x-read row offset: this expert's rows begin at start[global_id].
+        // Convert the token row to a tile-page offset (row_tile * K_gate_tiles)
+        // for the TILE path; the row-major path offsets the token-row stick.
+        const uint32_t start_value = start_ptr[global_expert_id];
+        const uint32_t x_start_tile_idx = (start_value / TILE_HEIGHT) * K_gate_tiles;
+        const uint32_t x_start_stick = start_value;
+
+        // Pre-zero bound: rows past min(count_tiles, M_tiles_full) are invalid
+        // and must feed zeros to the matmul (see the per-chunk pre-zero below).
+        const uint32_t M_bound = (count_tiles < M_tiles_full) ? count_tiles : M_tiles_full;
+
 #ifdef FUSE_BIAS
-    // Read this core's N-column slice of the (1, N) biases ONCE (constant across
-    // chunks; the compute kernel wait_fronts without popping). Bias is a single
-    // tile-row tensor, so the DRAM page index == tile column. Phantom columns
-    // (col >= actual N) are zero-filled — their output columns are dropped by
-    // the writer / are already zero.
-    {
-        const uint32_t gbias_tb = get_tile_size(cb_gate_bias);
-        cb_gate_bias_obj.reserve_back(per_core_N_gu);
-        cb_up_bias_obj.reserve_back(per_core_N_gu);
-        uint32_t lg = cb_gate_bias_obj.get_write_ptr();
-        uint32_t lu = cb_up_bias_obj.get_write_ptr();
-        for (uint32_t n = 0; n < per_core_N_gu; ++n) {
-            const uint32_t col = my_nt_gu * per_core_N_gu + n;
-            if (col < N_gate_tiles_full) {
-                noc_read.async_read(gate_bias_acc, CoreLocalMem<uint32_t>(lg), gbias_tb, {.page_id = col}, {});
-                noc_read.async_read(up_bias_acc, CoreLocalMem<uint32_t>(lu), gbias_tb, {.page_id = col}, {});
-            } else {
-                volatile tt_l1_ptr uint64_t* pg = reinterpret_cast<volatile tt_l1_ptr uint64_t*>(lg);
-                volatile tt_l1_ptr uint64_t* pu = reinterpret_cast<volatile tt_l1_ptr uint64_t*>(lu);
-                for (uint32_t i = 0; i < gbias_tb / 8; ++i) {
-                    pg[i] = 0;
-                    pu[i] = 0;
+        // This expert's N-column slice of its (1, N) biases. The compute
+        // kernel wait_fronts then pops at the end of this expert so the next
+        // expert can reuse the single-buffered bias CBs.
+        {
+            const uint32_t gbias_addr = get_arg_val<uint32_t>(BIAS_RT + 0 * experts_per_chip + local_expert_id);
+            const uint32_t ubias_addr = get_arg_val<uint32_t>(BIAS_RT + 1 * experts_per_chip + local_expert_id);
+            const uint32_t dbias_addr = get_arg_val<uint32_t>(BIAS_RT + 2 * experts_per_chip + local_expert_id);
+            const auto gate_bias_acc = TensorAccessor(gate_bias_args, gbias_addr, get_tile_size(cb_gate_bias));
+            const auto up_bias_acc = TensorAccessor(up_bias_args, ubias_addr, get_tile_size(cb_up_bias));
+            const auto down_bias_acc = TensorAccessor(down_bias_args, dbias_addr, get_tile_size(cb_down_bias));
+            const uint32_t gbias_tb = get_tile_size(cb_gate_bias);
+            cb_gate_bias_obj.reserve_back(per_core_N_gu);
+            cb_up_bias_obj.reserve_back(per_core_N_gu);
+            uint32_t lg = cb_gate_bias_obj.get_write_ptr();
+            uint32_t lu = cb_up_bias_obj.get_write_ptr();
+            for (uint32_t n = 0; n < per_core_N_gu; ++n) {
+                const uint32_t col = my_nt_gu * per_core_N_gu + n;
+                if (col < N_gate_tiles_full) {
+                    noc_read.async_read(gate_bias_acc, CoreLocalMem<uint32_t>(lg), gbias_tb, {.page_id = col}, {});
+                    noc_read.async_read(up_bias_acc, CoreLocalMem<uint32_t>(lu), gbias_tb, {.page_id = col}, {});
+                } else {
+                    volatile tt_l1_ptr uint64_t* pg = reinterpret_cast<volatile tt_l1_ptr uint64_t*>(lg);
+                    volatile tt_l1_ptr uint64_t* pu = reinterpret_cast<volatile tt_l1_ptr uint64_t*>(lu);
+                    for (uint32_t i = 0; i < gbias_tb / 8; ++i) {
+                        pg[i] = 0;
+                        pu[i] = 0;
+                    }
                 }
+                lg += gbias_tb;
+                lu += gbias_tb;
             }
-            lg += gbias_tb;
-            lu += gbias_tb;
-        }
-        const uint32_t dbias_tb = get_tile_size(cb_down_bias);
-        cb_down_bias_obj.reserve_back(per_core_N_d);
-        uint32_t ld = cb_down_bias_obj.get_write_ptr();
-        for (uint32_t n = 0; n < per_core_N_d; ++n) {
-            const uint32_t col = my_nt_d * per_core_N_d + n;
-            if (col < N_down_tiles_full) {
-                noc_read.async_read(down_bias_acc, CoreLocalMem<uint32_t>(ld), dbias_tb, {.page_id = col}, {});
-            } else {
-                volatile tt_l1_ptr uint64_t* pd = reinterpret_cast<volatile tt_l1_ptr uint64_t*>(ld);
-                for (uint32_t i = 0; i < dbias_tb / 8; ++i) {
-                    pd[i] = 0;
+            const uint32_t dbias_tb = get_tile_size(cb_down_bias);
+            cb_down_bias_obj.reserve_back(per_core_N_d);
+            uint32_t ld = cb_down_bias_obj.get_write_ptr();
+            for (uint32_t n = 0; n < per_core_N_d; ++n) {
+                const uint32_t col = my_nt_d * per_core_N_d + n;
+                if (col < N_down_tiles_full) {
+                    noc_read.async_read(down_bias_acc, CoreLocalMem<uint32_t>(ld), dbias_tb, {.page_id = col}, {});
+                } else {
+                    volatile tt_l1_ptr uint64_t* pd = reinterpret_cast<volatile tt_l1_ptr uint64_t*>(ld);
+                    for (uint32_t i = 0; i < dbias_tb / 8; ++i) {
+                        pd[i] = 0;
+                    }
                 }
+                ld += dbias_tb;
             }
-            ld += dbias_tb;
+            noc_read.async_read_barrier();
+            cb_gate_bias_obj.push_back(per_core_N_gu);
+            cb_up_bias_obj.push_back(per_core_N_gu);
+            cb_down_bias_obj.push_back(per_core_N_d);
         }
-        noc_read.async_read_barrier();
-        cb_gate_bias_obj.push_back(per_core_N_gu);
-        cb_up_bias_obj.push_back(per_core_N_gu);
-        cb_down_bias_obj.push_back(per_core_N_d);
-    }
 #endif
 
     // Bound the chunk loop by effective_chunks (= ceil_div(count, chunk_M_tiles))
@@ -930,6 +938,7 @@ void kernel_main() {
             cb_in1_down_obj.push_back(d_in1_block_num_tiles);
         }
     }  // end chunk loop
+    }  // end per-local-expert loop
 
     // The last in-flight Semaphore<>::set_multicast (act_valid / in1_valid)
     // is a posted atomic; without an explicit barrier it can still be in

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/dataflow/unified_routed_expert_ffn_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/dataflow/unified_routed_expert_ffn_reader.cpp
@@ -30,15 +30,15 @@
 #include "api/dataflow/noc_semaphore.h"
 #include "api/dataflow/endpoints.h"
 #include "api/core_local_mem.h"
-#include "api/debug/dprint.h"  // TEMP: config dump
+#include "api/debug/assert.h"
 #include "../adaptive_chunk.hpp"
 
 void kernel_main() {
     // -------------------------- runtime args ------------------------------
     const uint32_t x_addr = get_arg_val<uint32_t>(0);
-    const uint32_t gate_addr = get_arg_val<uint32_t>(1);
-    const uint32_t up_addr = get_arg_val<uint32_t>(2);
-    const uint32_t down_addr = get_arg_val<uint32_t>(3);
+    // Args 1..3 hold expert-0's gate/up/down base addresses (kept for arg-layout
+    // stability); the per-expert weight-address arrays after `start` are used
+    // instead, so these single slots are intentionally not read here.
     const uint32_t counts_addr = get_arg_val<uint32_t>(4);
     const uint32_t idx_table_addr = get_arg_val<uint32_t>(5);
 
@@ -99,10 +99,10 @@ void kernel_main() {
     constexpr uint32_t cb_counts_scratch = get_compile_time_arg_val(5);
     constexpr uint32_t cb_idx_scratch = get_compile_time_arg_val(6);
 
-    constexpr uint32_t local_expert_id = get_compile_time_arg_val(7);
+    constexpr uint32_t experts_per_chip = get_compile_time_arg_val(7);
     // per_core_M_max: the CB-sized maximum per-core M (= chunk_M_max / GRID_Y).
-    // The RUNTIME per_core_M is picked from the device token count below and is
-    // <= this. CBs are allocated to the max; a smaller runtime pick uses fewer.
+    // The RUNTIME per_core_M is picked from each expert's device token count below
+    // and is <= this. CBs are allocated to the max; a smaller runtime pick uses fewer.
     constexpr uint32_t per_core_M_max = get_compile_time_arg_val(8);
     constexpr uint32_t per_core_N_gu = get_compile_time_arg_val(9);
     constexpr uint32_t per_core_N_d = get_compile_time_arg_val(10);
@@ -126,20 +126,17 @@ void kernel_main() {
     // NoC 1 into cb_in1_up); both 0 = UP_WRITER_MCAST, reader skips up.
     constexpr uint32_t reader_reads_up = get_compile_time_arg_val(23);
     constexpr uint32_t reader_mcasts_up = get_compile_time_arg_val(24);
-    // read_x_at_offset: x is a shared buffer; offset x reads by this expert's
-    // region start (start[global_id]/TILE tile-rows). 0 => x is per-expert,
-    // reads start at row 0. cb_start_scratch holds the fetched `start` page.
-    constexpr uint32_t read_x_at_offset = get_compile_time_arg_val(25);
-    constexpr uint32_t cb_start_scratch = get_compile_time_arg_val(26);
+    // cb_start_scratch holds the fetched `start` page.
+    constexpr uint32_t cb_start_scratch = get_compile_time_arg_val(25);
     // x_is_row_major: x is ROW_MAJOR bf16 — stream sticks into cb_x_rm for the
     // compute kernel to tilize. 0 => x is TILE bf8_b, read directly.
-    constexpr uint32_t x_is_row_major = get_compile_time_arg_val(27);
-    constexpr uint32_t cb_x_rm = get_compile_time_arg_val(28);
+    constexpr uint32_t x_is_row_major = get_compile_time_arg_val(26);
+    constexpr uint32_t cb_x_rm = get_compile_time_arg_val(27);
     // Tile height: rows (token-row sticks) per tile-row. Used to size row-major
     // reads and to convert token counts to tile-rows.
-    constexpr uint32_t TILE_HEIGHT = get_compile_time_arg_val(29);
+    constexpr uint32_t TILE_HEIGHT = get_compile_time_arg_val(28);
     // Byte size of one row-major x element: x is bf16 in the row-major path.
-    constexpr uint32_t X_RM_ELEM_BYTES = get_compile_time_arg_val(30);
+    constexpr uint32_t X_RM_ELEM_BYTES = get_compile_time_arg_val(29);
     // UP_SPLIT iff the reader multicasts up but does not read it from DRAM.
     constexpr bool up_split = (reader_mcasts_up != 0) && (reader_reads_up == 0);
 
@@ -153,7 +150,7 @@ void kernel_main() {
     constexpr uint32_t num_blocks_gu = K_gate_tiles / in0_block_w_gu;
     constexpr uint32_t num_blocks_d = K_down_tiles_padded / in0_block_w_d;
 
-    constexpr uint32_t x_accessor_offset = 31;
+    constexpr uint32_t x_accessor_offset = 30;
     constexpr auto x_args = TensorAccessorArgs<x_accessor_offset>();
     const auto x_acc = TensorAccessor(x_args, x_addr, get_tile_size(cb_in0_x));
     // Row-major x accessor (x_is_row_major): x is a ROW_MAJOR bf16 buffer whose
@@ -164,17 +161,17 @@ void kernel_main() {
     constexpr uint32_t x_rm_stick_bytes = K_gate_tiles * TILE_HEIGHT * X_RM_ELEM_BYTES;
     const auto x_acc_rm = TensorAccessor(x_args, x_addr, x_rm_stick_bytes);
 
+    // gate/up/down accessor LAYOUT descriptors (compile-time). All experts share
+    // one layout; the per-expert accessor is built inside the expert loop from
+    // the descriptor + that expert's base address (runtime args).
     constexpr uint32_t gate_accessor_offset = x_args.next_compile_time_args_offset();
     constexpr auto gate_args = TensorAccessorArgs<gate_accessor_offset>();
-    const auto gate_acc = TensorAccessor(gate_args, gate_addr, get_tile_size(cb_in1_gate));
 
     constexpr uint32_t up_accessor_offset = gate_args.next_compile_time_args_offset();
     constexpr auto up_args = TensorAccessorArgs<up_accessor_offset>();
-    const auto up_acc = TensorAccessor(up_args, up_addr, get_tile_size(cb_in1_up));
 
     constexpr uint32_t down_accessor_offset = up_args.next_compile_time_args_offset();
     constexpr auto down_args = TensorAccessorArgs<down_accessor_offset>();
-    const auto down_acc = TensorAccessor(down_args, down_addr, get_tile_size(cb_in1_down));
 
     constexpr uint32_t counts_accessor_offset = down_args.next_compile_time_args_offset();
     constexpr auto counts_args = TensorAccessorArgs<counts_accessor_offset>();
@@ -185,33 +182,35 @@ void kernel_main() {
     const auto idx_acc = TensorAccessor(idx_args, idx_table_addr);
 
     // `start` (= expert_region_offsets) accessor. Appended last in the reader's
-    // accessor stream; read only when read_x_at_offset. start_addr is the final
-    // runtime arg, after the GRID_X-pair M-row NoC table at M_ROW_NOC_RT_OFFSET.
+    // accessor stream. start_addr is the runtime arg after the GRID_X-pair M-row
+    // NoC table at M_ROW_NOC_RT_OFFSET.
     const uint32_t start_addr = get_arg_val<uint32_t>(M_ROW_NOC_RT_OFFSET + 2 * GRID_X_NOC);
     constexpr uint32_t start_accessor_offset = idx_args.next_compile_time_args_offset();
     constexpr auto start_args = TensorAccessorArgs<start_accessor_offset>();
     const auto start_acc = TensorAccessor(start_args, start_addr);
 
+    // Per-expert weight base addresses follow start_addr in three contiguous
+    // runtime-arg blocks of experts_per_chip each: gate[0..N), up[0..N),
+    // down[0..N). gate_addr(e) = arg[WEIGHTS_RT + e], etc.
+    constexpr uint32_t WEIGHTS_RT = M_ROW_NOC_RT_OFFSET + 2 * GRID_X_NOC + 1;
+
 #ifdef FUSE_BIAS
-    // gpt-oss expert biases. RT addrs immediately follow start_addr; CT bias CB
-    // ids + accessors follow the start accessor. Read once (below), added by the
-    // compute kernel (gate/up before the activation, down after the down matmul).
-    const uint32_t gate_bias_addr = get_arg_val<uint32_t>(M_ROW_NOC_RT_OFFSET + 2 * GRID_X_NOC + 1);
-    const uint32_t up_bias_addr = get_arg_val<uint32_t>(M_ROW_NOC_RT_OFFSET + 2 * GRID_X_NOC + 2);
-    const uint32_t down_bias_addr = get_arg_val<uint32_t>(M_ROW_NOC_RT_OFFSET + 2 * GRID_X_NOC + 3);
+    // gpt-oss expert biases. CT bias CB ids + accessor descriptors follow the
+    // start accessor; per-expert bias base addresses follow the weight blocks in
+    // three further runtime-arg blocks (gate_bias[0..N), up_bias, down_bias)
+    // starting at BIAS_RT. Read per expert in the loop, added by the compute
+    // kernel (gate/up before the activation, down after the down matmul).
+    constexpr uint32_t BIAS_RT = WEIGHTS_RT + 3 * experts_per_chip;
     constexpr uint32_t bias_cb_offset = start_args.next_compile_time_args_offset();
     constexpr uint32_t cb_gate_bias = get_compile_time_arg_val(bias_cb_offset + 0);
     constexpr uint32_t cb_up_bias = get_compile_time_arg_val(bias_cb_offset + 1);
     constexpr uint32_t cb_down_bias = get_compile_time_arg_val(bias_cb_offset + 2);
     constexpr uint32_t gate_bias_accessor_offset = bias_cb_offset + 3;
     constexpr auto gate_bias_args = TensorAccessorArgs<gate_bias_accessor_offset>();
-    const auto gate_bias_acc = TensorAccessor(gate_bias_args, gate_bias_addr, get_tile_size(cb_gate_bias));
     constexpr uint32_t up_bias_accessor_offset = gate_bias_args.next_compile_time_args_offset();
     constexpr auto up_bias_args = TensorAccessorArgs<up_bias_accessor_offset>();
-    const auto up_bias_acc = TensorAccessor(up_bias_args, up_bias_addr, get_tile_size(cb_up_bias));
     constexpr uint32_t down_bias_accessor_offset = up_bias_args.next_compile_time_args_offset();
     constexpr auto down_bias_args = TensorAccessorArgs<down_bias_accessor_offset>();
-    const auto down_bias_acc = TensorAccessor(down_bias_args, down_bias_addr, get_tile_size(cb_down_bias));
     CircularBuffer cb_gate_bias_obj(cb_gate_bias);
     CircularBuffer cb_up_bias_obj(cb_up_bias);
     CircularBuffer cb_down_bias_obj(cb_down_bias);
@@ -279,117 +278,130 @@ void kernel_main() {
 
     const volatile tt_l1_ptr uint32_t* counts_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(counts_l1);
     const volatile tt_l1_ptr uint32_t* idx_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(idx_l1);
-    const uint32_t global_expert_id = idx_ptr[local_expert_id];
-    const uint32_t count_value = counts_ptr[global_expert_id];
-    // count_value is in TOKEN rows. Convert to tile rows (ceil) then to chunks.
-    // For count=0 the loop is empty (no chunks processed). For count > 0 we
-    // process ceil(count_tiles / chunk_M_tiles) chunks; the remaining chunks
-    // (if any) are skipped — no DRAM reads, no mcasts, no compute.
-    const uint32_t count_tiles = (count_value + 31) / 32;
-    // Runtime chunk layout from the actual token count (identical math in the
-    // compute and writer kernels, so all three agree on the row mapping). Full
-    // chunks span chunk_M_max tile-rows; the tail chunk shrinks per_core_M to the
-    // remainder. per_core_M is thus per-chunk (see the loop) and ADAPTS to the
-    // count with minimal phantom work; the chunk count is the minimum.
-    const uint32_t effective_chunks_runtime = adaptive_chunk::num_chunks(count_tiles, chunk_M_max);
-    // Clamp to the compile-time max just in case (defensive against bad input).
-    const uint32_t effective_chunks =
-        effective_chunks_runtime < num_chunks_max ? effective_chunks_runtime : num_chunks_max;
 
-    // x-read row offset. Zero unless read_x_at_offset: then x is a shared buffer
-    // and this expert's rows begin at start[global_id]. Fetch the start page and
-    // convert the token row to a tile-page offset (row_tile * K_gate_tiles), the
-    // exact source rebase ttnn::extract used to perform. Must agree with the
-    // writer's row_offset_tiles so x is read and y is written to the same region.
-    uint32_t x_start_tile_idx = 0;
-    // Row-major stick (token-row) base for this expert's region. TILE mode uses
-    // x_start_tile_idx (tile-page offset); row-major mode uses x_start_stick to
-    // offset the token-row stick page. Both derive from start[global_id] (a
-    // tile-aligned token row) and must agree with the writer's row_offset_tiles.
-    uint32_t x_start_stick = 0;
-    if constexpr (read_x_at_offset != 0) {
-        cb_start_scratch_obj.reserve_back(1);
-        const uint32_t start_l1 = cb_start_scratch_obj.get_write_ptr();
-        noc_read.async_read(
-            start_acc, CoreLocalMem<uint32_t>(start_l1), start_acc.get_aligned_page_size(), {.page_id = 0}, {});
-        noc_read.async_read_barrier();
-        cb_start_scratch_obj.push_back(1);
-        const volatile tt_l1_ptr uint32_t* start_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(start_l1);
-        const uint32_t start_value = start_ptr[global_expert_id];
-        x_start_tile_idx = (start_value / TILE_HEIGHT) * K_gate_tiles;
-        x_start_stick = start_value;
-    }
+    // Read the `start` (= expert_region_offsets) page ONCE into resident L1. x
+    // is the shared dispatched buffer; each expert's rows begin at
+    // start[global_id]. Indexed per expert in the loop below (must agree with
+    // the writer's row_offset_tiles so x is read and y is written to the same
+    // region).
+    cb_start_scratch_obj.reserve_back(1);
+    const uint32_t start_l1 = cb_start_scratch_obj.get_write_ptr();
+    noc_read.async_read(
+        start_acc, CoreLocalMem<uint32_t>(start_l1), start_acc.get_aligned_page_size(), {.page_id = 0}, {});
+    noc_read.async_read_barrier();
+    cb_start_scratch_obj.push_back(1);
+    const volatile tt_l1_ptr uint32_t* start_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(start_l1);
 
     const uint32_t x_tile_bytes = get_tile_size(cb_in0_x);
     const uint32_t gate_tile_bytes = get_tile_size(cb_in1_gate);
     const uint32_t up_tile_bytes = get_tile_size(cb_in1_up);
     const uint32_t down_tile_bytes = get_tile_size(cb_in1_down);
 
-    // Weight-multicast helper. For each in1 K-block:
-    //   * Sender (gy=0): wait for all GRID_Y-1 receivers to inc the local
-    //     ready_sem. Reset ready_sem. Read in1 from DRAM into local cb_in1.
-    //     Multicast the L1 region to receivers. Multicast valid_sem=1.
-    //   * Receiver: reserve cb space. Reset local valid_sem=0. Increment
-    //     sender's ready_sem at sender's NoC coord. Wait local valid_sem=1.
-    //
-    // Both sender and receiver finish with the K-block of in1 in their own
-    // cb_in1 L1, ready for cb_push_back/compute.
+    // Weight-multicast handshake constants (see the K-block loops below).
     constexpr uint32_t IN1_VALID = 1;
     constexpr uint32_t IN0_VALID = 1;
 
-    // UP_SPLIT handshake counter, kept in lockstep with the writer's.
+    // UP_SPLIT handshake counter, kept in lockstep with the writer's ACROSS all
+    // experts: both kernels loop experts in the same order with the same
+    // per-expert effective_chunks, so the per-K-block increments stay matched.
     uint32_t up_seq = 0;
 
+    // ======================= per-local-expert loop =======================
+    // Per expert we resolve its global id (idx_table[e]), token count
+    // (counts[global_id]), region offset (start[global_id]) and per-expert
+    // weight base addresses, then drive the same chunked matmul pipeline.
+    for (uint32_t local_expert_id = 0; local_expert_id < experts_per_chip; ++local_expert_id) {
+        // Per-expert weight accessors, built from the shared layout descriptors
+        // and this expert's base addresses (runtime-arg arrays after start).
+        const uint32_t gate_addr_e = get_arg_val<uint32_t>(WEIGHTS_RT + 0 * experts_per_chip + local_expert_id);
+        const uint32_t up_addr_e = get_arg_val<uint32_t>(WEIGHTS_RT + 1 * experts_per_chip + local_expert_id);
+        const uint32_t down_addr_e = get_arg_val<uint32_t>(WEIGHTS_RT + 2 * experts_per_chip + local_expert_id);
+        const auto gate_acc = TensorAccessor(gate_args, gate_addr_e, gate_tile_bytes);
+        const auto up_acc = TensorAccessor(up_args, up_addr_e, up_tile_bytes);
+        const auto down_acc = TensorAccessor(down_args, down_addr_e, down_tile_bytes);
+
+        const uint32_t global_expert_id = idx_ptr[local_expert_id];
+        const uint32_t count_value = counts_ptr[global_expert_id];
+        const uint32_t count_tiles = (count_value + TILE_HEIGHT - 1) / TILE_HEIGHT;
+        // Runtime chunk layout from THIS expert's actual token count (identical
+        // math in the compute and writer kernels, so all three agree on the row
+        // mapping). Full chunks span chunk_M_max tile-rows; the tail chunk shrinks
+        // per_core_M to the remainder, so per_core_M is per-chunk (see the chunk
+        // loop) and adapts to each expert's own load with minimal phantom work.
+        const uint32_t effective_chunks = adaptive_chunk::num_chunks(count_tiles, chunk_M_max);
+        // An out-of-range count means counts[] disagrees with the allocated M —
+        // hard-fail rather than silently clamp and emit rows for the wrong tokens.
+        ASSERT(effective_chunks <= num_chunks_max);
+
+        // x-read row offset: this expert's rows begin at start[global_id].
+        // Convert the token row to a tile-page offset (row_tile * K_gate_tiles)
+        // for the TILE path; the row-major path offsets the token-row stick.
+        const uint32_t start_value = start_ptr[global_expert_id];
+        const uint32_t x_start_tile_idx = (start_value / TILE_HEIGHT) * K_gate_tiles;
+        const uint32_t x_start_stick = start_value;
+
+        // Pre-zero bound: rows past min(count_tiles, M_tiles_full) are invalid
+        // and must feed zeros to the matmul (see the per-chunk pre-zero below).
+        const uint32_t M_bound = (count_tiles < M_tiles_full) ? count_tiles : M_tiles_full;
+
 #ifdef FUSE_BIAS
-    // Read this core's N-column slice of the (1, N) biases ONCE (constant across
-    // chunks; the compute kernel wait_fronts without popping). Bias is a single
-    // tile-row tensor, so the DRAM page index == tile column. Phantom columns
-    // (col >= actual N) are zero-filled: unlike the per-K-block weight reads this
-    // runs ONCE, so the fill is free, and it keeps the bias add from turning a
-    // phantom column into Inf/NaN. Those columns are discarded either way — the
-    // gate/up ones by the down phase's K bound, the down ones by the writer.
-    {
-        const uint32_t gbias_tb = get_tile_size(cb_gate_bias);
-        cb_gate_bias_obj.reserve_back(per_core_N_gu);
-        cb_up_bias_obj.reserve_back(per_core_N_gu);
-        uint32_t lg = cb_gate_bias_obj.get_write_ptr();
-        uint32_t lu = cb_up_bias_obj.get_write_ptr();
-        for (uint32_t n = 0; n < per_core_N_gu; ++n) {
-            const uint32_t col = my_nt_gu * per_core_N_gu + n;
-            if (col < N_gate_tiles_full) {
-                noc_read.async_read(gate_bias_acc, CoreLocalMem<uint32_t>(lg), gbias_tb, {.page_id = col}, {});
-                noc_read.async_read(up_bias_acc, CoreLocalMem<uint32_t>(lu), gbias_tb, {.page_id = col}, {});
-            } else {
-                volatile tt_l1_ptr uint64_t* pg = reinterpret_cast<volatile tt_l1_ptr uint64_t*>(lg);
-                volatile tt_l1_ptr uint64_t* pu = reinterpret_cast<volatile tt_l1_ptr uint64_t*>(lu);
-                for (uint32_t i = 0; i < gbias_tb / 8; ++i) {
-                    pg[i] = 0;
-                    pu[i] = 0;
+        // This expert's N-column slice of its (1, N) biases. The compute
+        // kernel wait_fronts then pops at the end of this expert so the next
+        // expert can reuse the single-buffered bias CBs. Bias is a single
+        // tile-row tensor, so the DRAM page index == tile column. Phantom
+        // columns (col >= actual N) are zero-filled: unlike the per-K-block
+        // weight reads this runs once per expert, so the fill is cheap, and it
+        // keeps the bias add from turning a phantom column into Inf/NaN. Those
+        // columns are discarded either way — the gate/up ones by the down
+        // phase's K bound, the down ones by the writer.
+        {
+            const uint32_t gbias_addr = get_arg_val<uint32_t>(BIAS_RT + 0 * experts_per_chip + local_expert_id);
+            const uint32_t ubias_addr = get_arg_val<uint32_t>(BIAS_RT + 1 * experts_per_chip + local_expert_id);
+            const uint32_t dbias_addr = get_arg_val<uint32_t>(BIAS_RT + 2 * experts_per_chip + local_expert_id);
+            const auto gate_bias_acc = TensorAccessor(gate_bias_args, gbias_addr, get_tile_size(cb_gate_bias));
+            const auto up_bias_acc = TensorAccessor(up_bias_args, ubias_addr, get_tile_size(cb_up_bias));
+            const auto down_bias_acc = TensorAccessor(down_bias_args, dbias_addr, get_tile_size(cb_down_bias));
+            const uint32_t gbias_tb = get_tile_size(cb_gate_bias);
+            cb_gate_bias_obj.reserve_back(per_core_N_gu);
+            cb_up_bias_obj.reserve_back(per_core_N_gu);
+            uint32_t lg = cb_gate_bias_obj.get_write_ptr();
+            uint32_t lu = cb_up_bias_obj.get_write_ptr();
+            for (uint32_t n = 0; n < per_core_N_gu; ++n) {
+                const uint32_t col = my_nt_gu * per_core_N_gu + n;
+                if (col < N_gate_tiles_full) {
+                    noc_read.async_read(gate_bias_acc, CoreLocalMem<uint32_t>(lg), gbias_tb, {.page_id = col}, {});
+                    noc_read.async_read(up_bias_acc, CoreLocalMem<uint32_t>(lu), gbias_tb, {.page_id = col}, {});
+                } else {
+                    volatile tt_l1_ptr uint64_t* pg = reinterpret_cast<volatile tt_l1_ptr uint64_t*>(lg);
+                    volatile tt_l1_ptr uint64_t* pu = reinterpret_cast<volatile tt_l1_ptr uint64_t*>(lu);
+                    for (uint32_t i = 0; i < gbias_tb / 8; ++i) {
+                        pg[i] = 0;
+                        pu[i] = 0;
+                    }
                 }
+                lg += gbias_tb;
+                lu += gbias_tb;
             }
-            lg += gbias_tb;
-            lu += gbias_tb;
-        }
-        const uint32_t dbias_tb = get_tile_size(cb_down_bias);
-        cb_down_bias_obj.reserve_back(per_core_N_d);
-        uint32_t ld = cb_down_bias_obj.get_write_ptr();
-        for (uint32_t n = 0; n < per_core_N_d; ++n) {
-            const uint32_t col = my_nt_d * per_core_N_d + n;
-            if (col < N_down_tiles_full) {
-                noc_read.async_read(down_bias_acc, CoreLocalMem<uint32_t>(ld), dbias_tb, {.page_id = col}, {});
-            } else {
-                volatile tt_l1_ptr uint64_t* pd = reinterpret_cast<volatile tt_l1_ptr uint64_t*>(ld);
-                for (uint32_t i = 0; i < dbias_tb / 8; ++i) {
-                    pd[i] = 0;
+            const uint32_t dbias_tb = get_tile_size(cb_down_bias);
+            cb_down_bias_obj.reserve_back(per_core_N_d);
+            uint32_t ld = cb_down_bias_obj.get_write_ptr();
+            for (uint32_t n = 0; n < per_core_N_d; ++n) {
+                const uint32_t col = my_nt_d * per_core_N_d + n;
+                if (col < N_down_tiles_full) {
+                    noc_read.async_read(down_bias_acc, CoreLocalMem<uint32_t>(ld), dbias_tb, {.page_id = col}, {});
+                } else {
+                    volatile tt_l1_ptr uint64_t* pd = reinterpret_cast<volatile tt_l1_ptr uint64_t*>(ld);
+                    for (uint32_t i = 0; i < dbias_tb / 8; ++i) {
+                        pd[i] = 0;
+                    }
                 }
+                ld += dbias_tb;
             }
-            ld += dbias_tb;
+            noc_read.async_read_barrier();
+            cb_gate_bias_obj.push_back(per_core_N_gu);
+            cb_up_bias_obj.push_back(per_core_N_gu);
+            cb_down_bias_obj.push_back(per_core_N_d);
         }
-        noc_read.async_read_barrier();
-        cb_gate_bias_obj.push_back(per_core_N_gu);
-        cb_up_bias_obj.push_back(per_core_N_gu);
-        cb_down_bias_obj.push_back(per_core_N_d);
-    }
 #endif
 
     // Bound the chunk loop by effective_chunks (= ceil_div(count, chunk_M_tiles))
@@ -903,6 +915,7 @@ void kernel_main() {
             cb_in1_down_obj.push_back(d_in1_block_num_tiles);
         }
     }  // end chunk loop
+    }  // end per-local-expert loop
 
     // The last in-flight Semaphore<>::set_multicast (act_valid / in1_valid)
     // is a posted atomic; without an explicit barrier it can still be in

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/dataflow/unified_routed_expert_ffn_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/dataflow/unified_routed_expert_ffn_reader.cpp
@@ -333,7 +333,8 @@ void kernel_main() {
         // identically, so all three keep the same row mapping (see
         // adaptive_chunk::clamp_count_tiles).
         const uint32_t count_tiles_raw = (count_value + TILE_HEIGHT - 1) / TILE_HEIGHT;
-        const uint32_t count_tiles = adaptive_chunk::clamp_count_tiles(count_tiles_raw, chunk_M_max, num_chunks_max);
+        const uint32_t count_tiles =
+            adaptive_chunk::clamp_count_tiles(count_tiles_raw, chunk_M_max, num_chunks_max, M_tiles_full);
         ASSERT(count_tiles == count_tiles_raw);
         // Runtime chunk layout from THIS expert's actual token count (identical
         // math in the compute and writer kernels, so all three agree on the row

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/dataflow/unified_routed_expert_ffn_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/dataflow/unified_routed_expert_ffn_reader.cpp
@@ -7,8 +7,7 @@
 // Per-core responsibilities, sequenced over `effective_chunks` chunks
 // (effective_chunks = ceil(this expert's token count / chunk_M_tiles)):
 //   - Read counts/idx_table scratch once at kernel start to discover this
-//     expert's active token count. x tile reads start at row 0 unless
-//     read_x_at_offset is set, in which case x is a shared buffer and this
+//     expert's active token count. x is the shared dispatched buffer and this
 //     expert's rows begin at start[global_id] (fusing what ttnn::extract did);
 //     the reader adds (start / TILE) * K_gate_tiles to every x page index.
 //   - Phase 1 (gate matmul, fused with phase 2): per K-block, sender at
@@ -36,59 +35,56 @@
 void kernel_main() {
     // -------------------------- runtime args ------------------------------
     const uint32_t x_addr = get_arg_val<uint32_t>(0);
-    // Args 1..3 hold expert-0's gate/up/down base addresses (kept for arg-layout
-    // stability); the per-expert weight-address arrays after `start` are used
-    // instead, so these single slots are intentionally not read here.
-    const uint32_t counts_addr = get_arg_val<uint32_t>(4);
-    const uint32_t idx_table_addr = get_arg_val<uint32_t>(5);
+    const uint32_t counts_addr = get_arg_val<uint32_t>(1);
+    const uint32_t idx_table_addr = get_arg_val<uint32_t>(2);
 
-    const uint32_t my_mt = get_arg_val<uint32_t>(6);
-    const uint32_t my_nt_gu = get_arg_val<uint32_t>(7);
-    const uint32_t my_nt_d = get_arg_val<uint32_t>(8);
+    const uint32_t my_mt = get_arg_val<uint32_t>(3);
+    const uint32_t my_nt_gu = get_arg_val<uint32_t>(4);
+    const uint32_t my_nt_d = get_arg_val<uint32_t>(5);
 
-    // Weight-multicast runtime args (indices 9..18).
-    const uint32_t is_in1_sender_u32 = get_arg_val<uint32_t>(9);
+    // Weight-multicast runtime args (indices 6..15).
+    const uint32_t is_in1_sender_u32 = get_arg_val<uint32_t>(6);
     const bool is_in1_sender = is_in1_sender_u32 != 0;
-    const uint32_t in1_ready_sem_id = get_arg_val<uint32_t>(10);
-    const uint32_t in1_valid_sem_id = get_arg_val<uint32_t>(11);
-    const uint32_t in1_num_receivers = get_arg_val<uint32_t>(12);
-    const uint32_t in1_mcast_nx_start = get_arg_val<uint32_t>(13);
-    const uint32_t in1_mcast_ny_start = get_arg_val<uint32_t>(14);
-    const uint32_t in1_mcast_nx_end = get_arg_val<uint32_t>(15);
-    const uint32_t in1_mcast_ny_end = get_arg_val<uint32_t>(16);
-    const uint32_t in1_sender_nx = get_arg_val<uint32_t>(17);
-    const uint32_t in1_sender_ny = get_arg_val<uint32_t>(18);
+    const uint32_t in1_ready_sem_id = get_arg_val<uint32_t>(7);
+    const uint32_t in1_valid_sem_id = get_arg_val<uint32_t>(8);
+    const uint32_t in1_num_receivers = get_arg_val<uint32_t>(9);
+    const uint32_t in1_mcast_nx_start = get_arg_val<uint32_t>(10);
+    const uint32_t in1_mcast_ny_start = get_arg_val<uint32_t>(11);
+    const uint32_t in1_mcast_nx_end = get_arg_val<uint32_t>(12);
+    const uint32_t in1_mcast_ny_end = get_arg_val<uint32_t>(13);
+    const uint32_t in1_sender_nx = get_arg_val<uint32_t>(14);
+    const uint32_t in1_sender_ny = get_arg_val<uint32_t>(15);
 
-    // x (in0) multicast runtime args (indices 19..28).
-    const uint32_t is_in0_sender_u32 = get_arg_val<uint32_t>(19);
+    // x (in0) multicast runtime args (indices 16..25).
+    const uint32_t is_in0_sender_u32 = get_arg_val<uint32_t>(16);
     const bool is_in0_sender = is_in0_sender_u32 != 0;
-    const uint32_t in0_ready_sem_id = get_arg_val<uint32_t>(20);
-    const uint32_t in0_valid_sem_id = get_arg_val<uint32_t>(21);
-    const uint32_t in0_num_receivers = get_arg_val<uint32_t>(22);
-    const uint32_t in0_mcast_nx_start = get_arg_val<uint32_t>(23);
-    const uint32_t in0_mcast_ny_start = get_arg_val<uint32_t>(24);
-    const uint32_t in0_mcast_nx_end = get_arg_val<uint32_t>(25);
-    const uint32_t in0_mcast_ny_end = get_arg_val<uint32_t>(26);
-    const uint32_t in0_sender_nx = get_arg_val<uint32_t>(27);
-    const uint32_t in0_sender_ny = get_arg_val<uint32_t>(28);
+    const uint32_t in0_ready_sem_id = get_arg_val<uint32_t>(17);
+    const uint32_t in0_valid_sem_id = get_arg_val<uint32_t>(18);
+    const uint32_t in0_num_receivers = get_arg_val<uint32_t>(19);
+    const uint32_t in0_mcast_nx_start = get_arg_val<uint32_t>(20);
+    const uint32_t in0_mcast_ny_start = get_arg_val<uint32_t>(21);
+    const uint32_t in0_mcast_nx_end = get_arg_val<uint32_t>(22);
+    const uint32_t in0_mcast_ny_end = get_arg_val<uint32_t>(23);
+    const uint32_t in0_sender_nx = get_arg_val<uint32_t>(24);
+    const uint32_t in0_sender_ny = get_arg_val<uint32_t>(25);
 
     // Activated L1 mcast sems. Sender (gx == kb at phase-4 K-block kb) waits
     // on its act_ready_sem for GRID_X - 1 incs from the receivers; then
     // mcasts cb_activated -> all M-row cores' cb_in0_down_full L1; then
     // mcasts act_valid_sem to release receivers.
-    const uint32_t act_ready_sem_id = get_arg_val<uint32_t>(29);
-    const uint32_t act_valid_sem_id = get_arg_val<uint32_t>(30);
+    const uint32_t act_ready_sem_id = get_arg_val<uint32_t>(26);
+    const uint32_t act_valid_sem_id = get_arg_val<uint32_t>(27);
 
     // UP_SPLIT local handshake (reader <-> writer): up_go = slot reserved,
     // up_done = up block landed in L1. Monotonic; gy=0 in1-sender cores only.
-    const uint32_t up_go_sem_id = get_arg_val<uint32_t>(31);
-    const uint32_t up_done_sem_id = get_arg_val<uint32_t>(32);
+    const uint32_t up_go_sem_id = get_arg_val<uint32_t>(28);
+    const uint32_t up_done_sem_id = get_arg_val<uint32_t>(29);
     Semaphore<> up_go_sem(up_go_sem_id);
     Semaphore<> up_done_sem(up_done_sem_id);
 
-    // M-row NoC coord table: GRID_X (x, y) pairs starting at runtime arg 33.
+    // M-row NoC coord table: GRID_X (x, y) pairs starting at runtime arg 30.
     // Used to resolve the sender's NoC addr per phase-4 K-block kb (= gx).
-    constexpr uint32_t M_ROW_NOC_RT_OFFSET = 33;
+    constexpr uint32_t M_ROW_NOC_RT_OFFSET = 30;
 
     // -------------------------- compile-time args -------------------------
     constexpr uint32_t cb_in0_x = get_compile_time_arg_val(0);
@@ -329,16 +325,22 @@ void kernel_main() {
 
         const uint32_t global_expert_id = idx_ptr[local_expert_id];
         const uint32_t count_value = counts_ptr[global_expert_id];
-        const uint32_t count_tiles = (count_value + TILE_HEIGHT - 1) / TILE_HEIGHT;
+        // counts[] is device-produced and unvalidated: bound it by the capacity
+        // this program was built for (num_chunks_max * chunk_M_max tile-rows)
+        // BEFORE deriving anything from it. The clamp is arithmetic so it also
+        // holds in Release, where ASSERT is a no-op; the assert below still
+        // hard-fails a mismatch in watcher builds. Compute and writer clamp
+        // identically, so all three keep the same row mapping (see
+        // adaptive_chunk::clamp_count_tiles).
+        const uint32_t count_tiles_raw = (count_value + TILE_HEIGHT - 1) / TILE_HEIGHT;
+        const uint32_t count_tiles = adaptive_chunk::clamp_count_tiles(count_tiles_raw, chunk_M_max, num_chunks_max);
+        ASSERT(count_tiles == count_tiles_raw);
         // Runtime chunk layout from THIS expert's actual token count (identical
         // math in the compute and writer kernels, so all three agree on the row
         // mapping). Full chunks span chunk_M_max tile-rows; the tail chunk shrinks
         // per_core_M to the remainder, so per_core_M is per-chunk (see the chunk
         // loop) and adapts to each expert's own load with minimal phantom work.
         const uint32_t effective_chunks = adaptive_chunk::num_chunks(count_tiles, chunk_M_max);
-        // An out-of-range count means counts[] disagrees with the allocated M —
-        // hard-fail rather than silently clamp and emit rows for the wrong tokens.
-        ASSERT(effective_chunks <= num_chunks_max);
 
         // x-read row offset: this expert's rows begin at start[global_id].
         // Convert the token row to a tile-page offset (row_tile * K_gate_tiles)

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/dataflow/unified_routed_expert_ffn_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/dataflow/unified_routed_expert_ffn_reader.cpp
@@ -141,10 +141,17 @@ void kernel_main() {
     constexpr bool up_split = (reader_mcasts_up != 0) && (reader_reads_up == 0);
 
     constexpr uint32_t g_in1_block_num_tiles = per_core_N_gu * in0_block_w_gu;
-    // cb_in0_down_full stays sized to the compile-time MAX per-core M and the reader
-    // pushes that full block, filling only the first per_core_M (runtime) rows via
-    // the activated mcast. The down matmul never MACs the rest, so their contents
-    // are irrelevant — the full-size push just keeps the CB counts compile-time.
+    // CB block sizes are the compile-time MAX and never vary with the runtime
+    // per_core_M. Only the DRAM reads and the multicast payload below shrink to
+    // the live rows (#50885); the CB pointers always advance by a full max block.
+    // A block size that changed between experts would overshoot fifo_limit, which
+    // only wraps on exact equality — see the note in adaptive_chunk.hpp.
+    constexpr uint32_t g_in0_block_tiles_max = per_core_M_max * in0_block_w_gu;
+    constexpr uint32_t act_tiles_max = per_core_M_max * in0_block_w_d;
+    // cb_in0_down_full stays sized to the compile-time MAX per-core M: the down
+    // matmul keeps a full ring and MAC-skips rows >= the runtime per_core_M, so
+    // the reader pushes the full block (filling only per_core_M runtime rows via
+    // the activated mcast; the rest are MAC-skipped downstream).
     constexpr uint32_t d_in0_block_num_tiles = per_core_M_max * in0_block_w_d;
     constexpr uint32_t d_in1_block_num_tiles = per_core_N_d * in0_block_w_d;
     constexpr uint32_t num_blocks_gu = K_gate_tiles / in0_block_w_gu;
@@ -414,7 +421,6 @@ void kernel_main() {
         // for the tail. Chunk starts are UNIFORM at chunk*chunk_M_max (full chunks
         // are max_chunk; the tail is last, so its start is num_full*max_chunk too).
         const uint32_t per_core_M = adaptive_chunk::per_core_M_for_chunk(chunk, count_tiles, chunk_M_max);
-        const uint32_t g_in0_block_num_tiles = per_core_M * in0_block_w_gu;
         const uint32_t this_core_first_row = chunk * chunk_M_max + my_mt * per_core_M;
 
         // -------- PHASES 1+2 fused — push x ONCE per K-block, then gate then up.
@@ -431,7 +437,7 @@ void kernel_main() {
         //   per-K-block elapsed time at small per_core_M where mcast/handshake
         //   overhead dominates compute.
         for (uint32_t kb = 0; kb < num_blocks_gu; ++kb) {
-            x_stage_obj.reserve_back(g_in0_block_num_tiles);
+            x_stage_obj.reserve_back(g_in0_block_tiles_max);
             cb_in1_gate_obj.reserve_back(g_in1_block_num_tiles);
             if constexpr (reader_mcasts_up) {
                 cb_in1_up_obj.reserve_back(g_in1_block_num_tiles);
@@ -591,7 +597,7 @@ void kernel_main() {
                          .addr = block_start},
                         /*linked=*/true);
                 }
-                x_stage_obj.push_back(g_in0_block_num_tiles);
+                x_stage_obj.push_back(g_in0_block_tiles_max);
 
                 noc.async_writes_flushed();
                 in0_valid_sem.set(IN0_VALID);
@@ -723,7 +729,7 @@ void kernel_main() {
             // Step 3: receivers wait for both valid semaphores and push.
             if (!is_in0_sender) {
                 in0_valid_sem.wait(IN0_VALID);
-                x_stage_obj.push_back(g_in0_block_num_tiles);
+                x_stage_obj.push_back(g_in0_block_tiles_max);
             }
             if (!is_in1_sender) {
                 in1_valid_sem.wait(IN1_VALID);
@@ -852,14 +858,14 @@ void kernel_main() {
             // after the in1_down mcast; starts as soon as compute pushes
             // cb_activated AND the ready acks are in (already done in step 1).
             if (is_act_sender) {
-                // cb_activated holds this core's per_core_M (runtime) x in0_block_w_d
-                // activated tiles; read/mcast/pop exactly that many. cb_in0_down_full
-                // is pushed FULL (compile-time max) below so the down matmul's ring
-                // stays aligned — the rows past per_core_M are MAC-skipped there.
+                // cb_activated carries a FULL max block (constant CB block size —
+                // see adaptive_chunk.hpp), of which only the first per_core_M
+                // (runtime) x in0_block_w_d tiles hold this chunk's real rows. Drain
+                // the whole block but MCAST only the real tiles (#50885). Likewise
+                // cb_in0_down_full is pushed FULL below, and the down matmul
+                // MAC-skips the rows past per_core_M.
                 const uint32_t re_act_tiles = per_core_M * in0_block_w_d;
-                if (re_act_tiles > 0) {
-                    cb_activated_obj.wait_front(re_act_tiles);
-                }
+                cb_activated_obj.wait_front(act_tiles_max);
                 act_ready_sem.wait(GRID_X_NOC - 1);
                 act_ready_sem.set(0);
 
@@ -898,9 +904,7 @@ void kernel_main() {
                 act_valid_sem.set_multicast<NocOptions::MCAST_INCL_SRC>(
                     noc, mrow_first_nx, mrow_first_ny, mrow_last_nx, mrow_last_ny, GRID_X_NOC);
 
-                if (re_act_tiles > 0) {
-                    cb_activated_obj.pop_front(re_act_tiles);
-                }
+                cb_activated_obj.pop_front(act_tiles_max);
             }
 
             // Step 5: receivers wait for both valid sems and push.

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/dataflow/unified_routed_expert_ffn_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/dataflow/unified_routed_expert_ffn_writer.cpp
@@ -52,11 +52,10 @@ void kernel_main() {
     const uint32_t output_addr = get_arg_val<uint32_t>(0);
     const uint32_t my_mt = get_arg_val<uint32_t>(1);
     const uint32_t my_nt_d = get_arg_val<uint32_t>(2);
-    // start (= expert_region_offsets) address. Only read when direct_write.
     const uint32_t start_addr = get_arg_val<uint32_t>(3);
-    // UP_SPLIT up-weight read args: up tensor base, this core's N-column, and
-    // whether this core is the gy=0 sender (only senders read `up`).
-    const uint32_t up_addr = get_arg_val<uint32_t>(4);
+    // UP_SPLIT up-weight read args. Arg 4 holds expert-0's up base (kept for
+    // arg-layout stability); the per-expert `up` addresses live in the array
+    // starting at UP_RT and are used instead.
     const uint32_t my_nt_gu = get_arg_val<uint32_t>(5);
     const bool is_up_sender = get_arg_val<uint32_t>(6) != 0;
     // UP_SPLIT local handshake sems (see reader): up_go = slot reserved,
@@ -81,15 +80,15 @@ void kernel_main() {
     // device-side count read.
     constexpr uint32_t cb_counts_scratch = get_compile_time_arg_val(13);
     constexpr uint32_t cb_idx_scratch = get_compile_time_arg_val(14);
-    constexpr uint32_t local_expert_id = get_compile_time_arg_val(15);
+    constexpr uint32_t experts_per_chip = get_compile_time_arg_val(15);
     // M_tiles_full: total tile-row count of the FFN *input* (x). When the
     // kernel runs more chunks than strictly needed (because
     // M_tiles_full % chunk_M_tiles != 0), the last chunk has writer
     // destinations past M_tiles_full — we skip those source rows here.
     constexpr uint32_t M_tiles_full = get_compile_time_arg_val(16);
-    // direct_write: 0 -> write to per-expert output at row 0 (standalone FFN).
-    //               1 -> write into shared buffer at start[global_id]/TILE.
-    constexpr uint32_t direct_write = get_compile_time_arg_val(17);
+    // direct_write CT arg (17) is always 1 now: every expert's output is written
+    // into the shared buffer at start[global_id]/TILE tile-rows. Kept in the
+    // CT-arg layout for stability but no longer branched on.
     // dst_M_tiles: tile-row count of the *destination* buffer. Equals
     // M_tiles_full in non-direct mode; the shared buffer's row count in
     // direct-write mode (used to bound destination writes).
@@ -135,181 +134,192 @@ void kernel_main() {
 
     constexpr uint32_t up_accessor_offset = start_args.next_compile_time_args_offset();
     constexpr auto up_args = TensorAccessorArgs<up_accessor_offset>();
-    const auto up_acc = TensorAccessor(up_args, up_addr, get_tile_size(cb_in1_up));
+    // Per-expert `up` base addresses live in a runtime-arg array after the fixed
+    // writer args; UP_RT is its first index. up_addr(e) = arg[UP_RT + e].
+    constexpr uint32_t UP_RT = 9;
 
     const uint32_t out_tile_bytes = cb_out_buf.get_tile_size();
 
-    // Wait for the reader's counts/idx push and compute effective_chunks =
-    // ceil(count / chunk_M_tiles). The writer drains cb_out per chunk;
-    // bounding the loop here is required because the reader and compute
-    // bound theirs too — without this, the writer would wait forever on
-    // cb_out for chunks the compute never pushes.
+    // Wait for the reader's counts/idx push (resident scratch). Per expert the
+    // writer bounds its cb_out drain by that expert's effective_chunks; the
+    // reader and compute bound theirs identically, so the pipeline stays in
+    // lockstep and the writer never waits on a chunk compute never pushes.
     cb_counts_scratch_buf.wait_front(1);
     cb_idx_scratch_buf.wait_front(1);
     const volatile tt_l1_ptr uint32_t* counts_ptr =
         reinterpret_cast<const volatile tt_l1_ptr uint32_t*>(cb_counts_scratch_buf.get_read_ptr());
     const uint32_t idx_l1 = cb_idx_scratch_buf.get_read_ptr();
     const volatile tt_l1_ptr uint32_t* idx_ptr = reinterpret_cast<const volatile tt_l1_ptr uint32_t*>(idx_l1);
-    const uint32_t global_expert_id = idx_ptr[local_expert_id];
-    const uint32_t count_value = counts_ptr[global_expert_id];
-    const uint32_t count_tiles = (count_value + TILE_HEIGHT - 1) / TILE_HEIGHT;
-    // Runtime chunk layout from the actual count (same math as reader/compute so
-    // the row mapping agrees). per_core_M is per-chunk (see the loop).
-    const uint32_t effective_chunks_runtime = adaptive_chunk::num_chunks(count_tiles, chunk_M_max);
-    const uint32_t effective_chunks =
-        effective_chunks_runtime < num_chunks_max ? effective_chunks_runtime : num_chunks_max;
 
-    // Destination tile-row offset for direct-write mode. In direct-write
-    // mode the output buffer is a SHARED buffer and this expert's slice
-    // begins at start[global_expert_id] (token row); convert to tile rows.
-    // Mirrors ttnn::insert's writer: start_tile_row = start_value / TILE.
-    uint32_t row_offset_tiles = 0;
-    if constexpr (direct_write != 0) {
-        const uint32_t start_l1 = cb_start_scratch_buf.get_write_ptr();
+    // Read the `start` (= expert_region_offsets) page ONCE into resident L1;
+    // each expert's output slice begins at start[global_id] (token row).
+    const uint32_t start_l1 = cb_start_scratch_buf.get_write_ptr();
+    {
         const uint32_t start_page_size = start_acc.get_aligned_page_size();
         noc.async_read(start_acc, CoreLocalMem<uint32_t>(start_l1), start_page_size, {.page_id = 0}, {});
         noc.async_read_barrier();
-        const volatile tt_l1_ptr uint32_t* start_ptr = reinterpret_cast<const volatile tt_l1_ptr uint32_t*>(start_l1);
-        const uint32_t start_value = start_ptr[global_expert_id];
-        row_offset_tiles = start_value / TILE_HEIGHT;
     }
+    const volatile tt_l1_ptr uint32_t* start_ptr = reinterpret_cast<const volatile tt_l1_ptr uint32_t*>(start_l1);
 
-    // ---- UP_SPLIT up-weight read setup ----
-    // The writer reads `up` from DRAM on NoC 1 concurrent with the
-    // reader's NoC-0 `gate` read, into the gy=0 sender's cb_in1_up slot; the
-    // reader multicasts it on NoC 0. A local same-core (BRISC reader <-> NCRISC
-    // writer) handshake orders the two: up_go (reader: slot reserved) and
-    // up_done (writer: up landed in L1), monotonic counters.
+    // ---- UP_SPLIT up-weight read setup (see header) ----
+    // The writer reads `up` from DRAM on NoC 1 concurrent with the reader's
+    // NoC-0 `gate` read, into the gy=0 sender's cb_in1_up slot; the reader
+    // multicasts it on NoC 0. A local same-core (BRISC reader <-> NCRISC writer)
+    // handshake (up_go / up_done, monotonic) orders the two.
     Noc noc_up(1);
     const uint32_t up_tile_bytes = get_tile_size(cb_in1_up);
     Semaphore<> up_go_sem(up_go_sem_id);
     Semaphore<> up_done_sem(up_done_sem_id);
+    // up_seq stays in lockstep with the reader ACROSS all experts.
     uint32_t up_seq = 0;
 
-    for (uint32_t chunk = 0; chunk < effective_chunks; ++chunk) {
-        // ---- Phase 1/2 weight feed: writer reads `up` on NoC 1 (UP_SPLIT) ----
-        // Streams `up` from DRAM concurrent with the reader's NoC-0 `gate` read.
-        // Runs before the cb_out drain.
-        if constexpr (writer_split_up) {
-            // UP_SPLIT: only gy=0 in1-sender cores read `up`. Per K-block: wait
-            // for the reader to reserve the slot (up_go), read this column's
-            // `up` slice on NoC 1 into it, then signal up_done so the reader
-            // mcasts on NoC 0. Only a NoC-1 DRAM read here (fabric-safe); the
-            // reader owns cb_in1_up reserve/push.
-            if (is_up_sender) {
-                // The CB write pointer is PER-RISC and the reader owns push, so
-                // the writer's get_write_ptr never advances. Replicate the
-                // reader's cadence: cb_in1_up is double-buffered, one push per
-                // K-block, so the live slot is base + (up_seq-1)%2 * slot.
-                constexpr uint32_t kUpNumSlots = 2;
-                CircularBuffer cb_in1_up_buf(cb_in1_up);
-                const uint32_t up_cb_base = cb_in1_up_buf.get_write_ptr();
-                const uint32_t up_slot_bytes = g_in1_block_num_tiles * up_tile_bytes;
-                for (uint32_t kb = 0; kb < num_blocks_gu; ++kb) {
-                    ++up_seq;
-                    up_go_sem.wait_min(up_seq);
-                    uint32_t l1_w_up = up_cb_base + ((up_seq - 1) % kUpNumSlots) * up_slot_bytes;
-                    for (uint32_t k = 0; k < in0_block_w_gu; ++k) {
-                        for (uint32_t n = 0; n < per_core_N_gu; ++n) {
-                            const uint32_t row = kb * in0_block_w_gu + k;
-                            const uint32_t col = my_nt_gu * per_core_N_gu + n;
-                            if (col < N_gate_tiles_full) {
-                                const uint32_t tile_idx = row * N_gate_tiles_full + col;
-                                noc_up.async_read(
-                                    up_acc, CoreLocalMem<uint32_t>(l1_w_up), up_tile_bytes, {.page_id = tile_idx}, {});
-                            } else {
-                                // N-OOB hidden padding column: garbage up output feeds the
-                                // down matmul's K reduction, so keep it zero UNLESS the down
-                                // tail-skips the last block's padding (down_k_tail_skip) —
-                                // then this column is never reduced and the garbage is dropped.
-                                if constexpr (!down_k_tail_skip) {
-                                    volatile tt_l1_ptr uint64_t* p =
-                                        reinterpret_cast<volatile tt_l1_ptr uint64_t*>(l1_w_up);
-                                    for (uint32_t i = 0; i < up_tile_bytes / 8; ++i) {
-                                        p[i] = 0;
+    // ======================= per-local-expert loop =======================
+    // Drain every local expert's down-matmul output (and, for UP_SPLIT sender
+    // cores, feed its `up` weights) into the shared output buffer at the
+    // expert's region offset. The chunk-loop body below is unchanged from the
+    // single-expert kernel — only the per-expert bindings differ.
+    for (uint32_t local_expert_id = 0; local_expert_id < experts_per_chip; ++local_expert_id) {
+        const auto up_acc = TensorAccessor(up_args, get_arg_val<uint32_t>(UP_RT + local_expert_id), up_tile_bytes);
+        const uint32_t global_expert_id = idx_ptr[local_expert_id];
+        const uint32_t count_value = counts_ptr[global_expert_id];
+        const uint32_t count_tiles = (count_value + TILE_HEIGHT - 1) / TILE_HEIGHT;
+        // Runtime chunk layout from THIS expert's count — the same math the reader
+        // and compute kernels run, so all three agree on the row mapping (a
+        // mismatch would emit this expert's rows at the wrong token offsets).
+        const uint32_t effective_chunks = adaptive_chunk::num_chunks(count_tiles, chunk_M_max);
+        ASSERT(effective_chunks <= num_chunks_max);
+        const uint32_t row_offset_tiles = start_ptr[global_expert_id] / TILE_HEIGHT;
+
+        for (uint32_t chunk = 0; chunk < effective_chunks; ++chunk) {
+            // ---- Phase 1/2 weight feed: writer reads `up` on NoC 1 (UP_SPLIT) ----
+            // Streams `up` from DRAM concurrent with the reader's NoC-0 `gate` read.
+            // Runs before the cb_out drain.
+            if constexpr (writer_split_up) {
+                // UP_SPLIT: only gy=0 in1-sender cores read `up`. Per K-block: wait
+                // for the reader to reserve the slot (up_go), read this column's
+                // `up` slice on NoC 1 into it, then signal up_done so the reader
+                // mcasts on NoC 0. Only a NoC-1 DRAM read here (fabric-safe); the
+                // reader owns cb_in1_up reserve/push.
+                if (is_up_sender) {
+                    // The CB write pointer is PER-RISC and the reader owns push, so
+                    // the writer's get_write_ptr never advances. Replicate the
+                    // reader's cadence: cb_in1_up is double-buffered, one push per
+                    // K-block, so the live slot is base + (up_seq-1)%2 * slot.
+                    constexpr uint32_t kUpNumSlots = 2;
+                    CircularBuffer cb_in1_up_buf(cb_in1_up);
+                    const uint32_t up_cb_base = cb_in1_up_buf.get_write_ptr();
+                    const uint32_t up_slot_bytes = g_in1_block_num_tiles * up_tile_bytes;
+                    for (uint32_t kb = 0; kb < num_blocks_gu; ++kb) {
+                        ++up_seq;
+                        up_go_sem.wait_min(up_seq);
+                        uint32_t l1_w_up = up_cb_base + ((up_seq - 1) % kUpNumSlots) * up_slot_bytes;
+                        for (uint32_t k = 0; k < in0_block_w_gu; ++k) {
+                            for (uint32_t n = 0; n < per_core_N_gu; ++n) {
+                                const uint32_t row = kb * in0_block_w_gu + k;
+                                const uint32_t col = my_nt_gu * per_core_N_gu + n;
+                                if (col < N_gate_tiles_full) {
+                                    const uint32_t tile_idx = row * N_gate_tiles_full + col;
+                                    noc_up.async_read(
+                                        up_acc,
+                                        CoreLocalMem<uint32_t>(l1_w_up),
+                                        up_tile_bytes,
+                                        {.page_id = tile_idx},
+                                        {});
+                                } else {
+                                    // N-OOB hidden padding column: garbage up output feeds the
+                                    // down matmul's K reduction, so keep it zero UNLESS the down
+                                    // tail-skips the last block's padding (down_k_tail_skip) —
+                                    // then this column is never reduced and the garbage is dropped.
+                                    if constexpr (!down_k_tail_skip) {
+                                        volatile tt_l1_ptr uint64_t* p =
+                                            reinterpret_cast<volatile tt_l1_ptr uint64_t*>(l1_w_up);
+                                        for (uint32_t i = 0; i < up_tile_bytes / 8; ++i) {
+                                            p[i] = 0;
+                                        }
                                     }
                                 }
+                                l1_w_up += up_tile_bytes;
                             }
-                            l1_w_up += up_tile_bytes;
                         }
+                        noc_up.async_read_barrier();
+                        up_done_sem.set(up_seq);
                     }
-                    noc_up.async_read_barrier();
-                    up_done_sem.set(up_seq);
                 }
             }
-        }
 
-        // ---- Drain cb_out (down matmul output) to DRAM ----
-        // Per-chunk per_core_M (per_core_M_max for full chunks, a smaller divisor
-        // for the tail); chunk starts are uniform at chunk*chunk_M_max. Contiguous
-        // row map: this core owns rows [row0, row0 + per_core_M).
-        const uint32_t per_core_M = adaptive_chunk::per_core_M_for_chunk(chunk, count_tiles, chunk_M_max);
-        const uint32_t row0 = chunk * chunk_M_max + my_mt * per_core_M;
-        const uint32_t col0 = my_nt_d * per_core_N_d;
-        // The DOWN matmul packs and pushes the FULL compile-time-MAX ring (its
-        // L1_ACC needs full-ring cycling), so DRAIN all d_in1_num_subblocks_M
-        // rows to keep cb_out balanced — but only WRITE the first per_core_M
-        // (runtime) rows; the rest are MAC-skipped zeros that map onto other
-        // cores' rows and must not be emitted (the sb_m < per_core_M guard below).
-        const uint32_t sb_m_bound = d_in1_num_subblocks_M;
-        for (uint32_t sb_m = 0; sb_m < sb_m_bound; ++sb_m) {
-            for (uint32_t sb_n = 0; sb_n < d_in1_num_subblocks_N; ++sb_n) {
-                cb_out_buf.wait_front(d_out_subblock_num_tiles);
-                uint32_t subblock_tile_offset = 0;
-                for (uint32_t i = 0; i < d_out_subblock_h; ++i) {
-                    for (uint32_t j = 0; j < d_out_subblock_w; ++j) {
-                        const uint32_t row = row0 + sb_m * d_out_subblock_h + i;
-                        const uint32_t col = col0 + sb_n * d_out_subblock_w + j;
-                        // `row` indexes the FFN *input* (x) tile-rows; the
-                        // destination tile-row adds the per-expert region
-                        // offset (0 in non-direct mode).
-                        const uint32_t dst_row = row_offset_tiles + row;
-                        // Bounds that decide whether this is a real output tile
-                        // for this expert:
-                        //   * col < N_down_tiles_full: GRID_X=11 ceil_div
-                        //     produces phantom output cols past actual N.
-                        //   * row < M_tiles_full: ceil_div of M produces a
-                        //     last-chunk tail past actual M when
-                        //     M_tiles_full doesn't divide chunk_M_tiles.
-                        //   * row < count_tiles: the last chunk's per_core_M
-                        //     rows extend past count_tiles when count_tiles
-                        //     is not chunk-aligned.
-                        //   * sb_m < per_core_M: cb_out carries per_core_M_max
-                        //     rows (full ring); rows past the runtime per_core_M
-                        //     are zeros that belong to other cores — never write.
-                        if (sb_m < per_core_M && col < N_down_tiles_full && row < M_tiles_full && row < count_tiles) {
-                            // The destination tile-row must stay inside the
-                            // (possibly shared) output buffer. ttnn::insert
-                            // asserted the whole-slice fit
-                            // (start_tile_idx + num_tiles <= global_num_tiles);
-                            // assert the per-tile equivalent so an over-capacity
-                            // region offset fails loudly in watcher builds. The
-                            // guard below keeps Release builds safe (skip the OOB
-                            // write rather than corrupt DRAM, since ASSERT is a
-                            // no-op there).
-                            ASSERT(dst_row < dst_M_tiles);
-                            if (dst_row < dst_M_tiles) {
-                                const uint32_t tile_idx = dst_row * N_down_tiles_full + col;
-                                noc.async_write(
-                                    cb_out_buf,
-                                    out_acc,
-                                    out_tile_bytes,
-                                    {.offset_bytes = subblock_tile_offset},
-                                    {.page_id = tile_idx});
+            // ---- Drain cb_out (down matmul output) to DRAM ----
+            // Per-chunk per_core_M (per_core_M_max for full chunks, a smaller
+            // divisor for the tail); chunk starts are uniform at chunk*chunk_M_max.
+            // Contiguous row map: this core owns rows [row0, row0 + per_core_M).
+            const uint32_t per_core_M = adaptive_chunk::per_core_M_for_chunk(chunk, count_tiles, chunk_M_max);
+            const uint32_t row0 = chunk * chunk_M_max + my_mt * per_core_M;
+            const uint32_t col0 = my_nt_d * per_core_N_d;
+            // The DOWN matmul packs and pushes the FULL compile-time-MAX ring (its
+            // L1_ACC needs full-ring cycling), so DRAIN all d_in1_num_subblocks_M
+            // rows to keep cb_out balanced — but only WRITE the first per_core_M
+            // (runtime) rows; the rest are MAC-skipped zeros that map onto other
+            // cores' rows and must not be emitted (the sb_m < per_core_M guard below).
+            const uint32_t sb_m_bound = d_in1_num_subblocks_M;
+            for (uint32_t sb_m = 0; sb_m < sb_m_bound; ++sb_m) {
+                for (uint32_t sb_n = 0; sb_n < d_in1_num_subblocks_N; ++sb_n) {
+                    cb_out_buf.wait_front(d_out_subblock_num_tiles);
+                    uint32_t subblock_tile_offset = 0;
+                    for (uint32_t i = 0; i < d_out_subblock_h; ++i) {
+                        for (uint32_t j = 0; j < d_out_subblock_w; ++j) {
+                            const uint32_t row = row0 + sb_m * d_out_subblock_h + i;
+                            const uint32_t col = col0 + sb_n * d_out_subblock_w + j;
+                            // `row` indexes the FFN *input* (x) tile-rows; the
+                            // destination tile-row adds the per-expert region
+                            // offset.
+                            const uint32_t dst_row = row_offset_tiles + row;
+                            // Bounds that decide whether this is a real output tile
+                            // for this expert:
+                            //   * col < N_down_tiles_full: GRID_X=11 ceil_div
+                            //     produces phantom output cols past actual N.
+                            //   * row < M_tiles_full: ceil_div of M produces a
+                            //     last-chunk tail past actual M when
+                            //     M_tiles_full doesn't divide chunk_M_tiles.
+                            //   * row < count_tiles: the last chunk's per_core_M
+                            //     rows extend past count_tiles when count_tiles
+                            //     is not chunk-aligned.
+                            //   * sb_m < per_core_M: cb_out carries per_core_M_max
+                            //     rows (full ring); rows past the runtime per_core_M
+                            //     are zeros that belong to other cores — never write.
+                            if (sb_m < per_core_M && col < N_down_tiles_full && row < M_tiles_full &&
+                                row < count_tiles) {
+                                // The destination tile-row must stay inside the
+                                // (possibly shared) output buffer. ttnn::insert
+                                // asserted the whole-slice fit
+                                // (start_tile_idx + num_tiles <= global_num_tiles);
+                                // assert the per-tile equivalent so an over-capacity
+                                // region offset fails loudly in watcher builds. The
+                                // guard below keeps Release builds safe (skip the OOB
+                                // write rather than corrupt DRAM, since ASSERT is a
+                                // no-op there).
+                                ASSERT(dst_row < dst_M_tiles);
+                                if (dst_row < dst_M_tiles) {
+                                    const uint32_t tile_idx = dst_row * N_down_tiles_full + col;
+                                    noc.async_write(
+                                        cb_out_buf,
+                                        out_acc,
+                                        out_tile_bytes,
+                                        {.offset_bytes = subblock_tile_offset},
+                                        {.page_id = tile_idx});
+                                }
                             }
+                            subblock_tile_offset += out_tile_bytes;
                         }
-                        subblock_tile_offset += out_tile_bytes;
                     }
+                    // Wait for the writes to LEAVE this core (departed sender);
+                    // doesn't wait for the DRAM round-trip. Safe to reuse the L1
+                    // slot now — the NoC has captured the data. ~10x faster than
+                    // noc_async_write_barrier per subblock at small per_core_M.
+                    noc.async_writes_flushed();
+                    cb_out_buf.pop_front(d_out_subblock_num_tiles);
                 }
-                // Wait for the writes to LEAVE this core (departed sender);
-                // doesn't wait for the DRAM round-trip. Safe to reuse the L1
-                // slot now — the NoC has captured the data. ~10x faster than
-                // noc_async_write_barrier per subblock at small per_core_M.
-                noc.async_writes_flushed();
-                cb_out_buf.pop_front(d_out_subblock_num_tiles);
             }
-        }
-    }
+        }  // end chunk loop
+    }  // end per-local-expert loop
     // Ensure all outstanding writes complete at the destination before the
     // kernel returns (the next dispatched op may read this output).
     noc.async_write_barrier();

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/dataflow/unified_routed_expert_ffn_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/dataflow/unified_routed_expert_ffn_writer.cpp
@@ -12,16 +12,13 @@
 //    looped over `effective_chunks` chunks (computed from the device-side
 //    counts/idx scratch CBs). Activated tiles are distributed across the
 //    M-row by the READER via L1 multicast — no DRAM scratch round-trip or
-//    cross-core barrier. Placement has two modes (the `direct_write` CT flag):
-//      * direct_write == 0: writes start at tile row 0. The FFN op writes to
-//        a per-expert output tensor; a separate ttnn::insert handles
-//        placement into any shared destination buffer.
-//      * direct_write == 1: this expert's output is written directly into a
-//        shared destination buffer at the expert's region offset. The kernel
-//        reads start[global_expert_id] from `start` (= expert_region_offsets)
-//        device-side and adds (start / TILE_HEIGHT) tile-rows to every output
-//        row — fusing what ttnn::insert would otherwise do (no temp-buffer
-//        DRAM round-trip).
+//    cross-core barrier. Every expert's output is written directly into the
+//    shared destination buffer at that expert's region offset: the kernel
+//    reads start[global_expert_id] from `start` (= expert_region_offsets)
+//    device-side and adds (start / TILE_HEIGHT) tile-rows to every output
+//    row — fusing what ttnn::insert would otherwise do (no temp-buffer DRAM
+//    round-trip). expert_region_offsets is a mandatory op input, so there is
+//    no per-expert-output-tensor mode.
 //
 // 2. Two-RISC `up`-weight read (UP_SPLIT). The writer (NCRISC) reads `up`
 //    from DRAM on NoC 1 concurrent with the reader's NoC-0 `gate` read. The
@@ -53,58 +50,53 @@ void kernel_main() {
     const uint32_t my_mt = get_arg_val<uint32_t>(1);
     const uint32_t my_nt_d = get_arg_val<uint32_t>(2);
     const uint32_t start_addr = get_arg_val<uint32_t>(3);
-    // UP_SPLIT up-weight read args. Arg 4 holds expert-0's up base (kept for
-    // arg-layout stability); the per-expert `up` addresses live in the array
-    // starting at UP_RT and are used instead.
-    const uint32_t my_nt_gu = get_arg_val<uint32_t>(5);
-    const bool is_up_sender = get_arg_val<uint32_t>(6) != 0;
+    // UP_SPLIT up-weight read args. The per-expert `up` addresses live in the
+    // runtime-arg array starting at UP_RT.
+    const uint32_t my_nt_gu = get_arg_val<uint32_t>(4);
+    const bool is_up_sender = get_arg_val<uint32_t>(5) != 0;
     // UP_SPLIT local handshake sems (see reader): up_go = slot reserved,
     // up_done = up landed.
-    const uint32_t up_go_sem_id = get_arg_val<uint32_t>(7);
-    const uint32_t up_done_sem_id = get_arg_val<uint32_t>(8);
+    const uint32_t up_go_sem_id = get_arg_val<uint32_t>(6);
+    const uint32_t up_done_sem_id = get_arg_val<uint32_t>(7);
 
-    constexpr uint32_t cb_out = get_compile_time_arg_val(1);
+    constexpr uint32_t cb_out = get_compile_time_arg_val(0);
     // per_core_M_max: CB-sized max per-core M. The runtime per_core_M is picked
     // from the device count below; the down matmul packs the full max ring (so
     // cb_out carries per_core_M_max rows) and this writer emits only the first
     // (runtime) per_core_M of them.
-    constexpr uint32_t per_core_M_max = get_compile_time_arg_val(2);
-    constexpr uint32_t per_core_N_gu = get_compile_time_arg_val(3);
-    constexpr uint32_t per_core_N_d = get_compile_time_arg_val(4);
-    constexpr uint32_t d_out_subblock_h = get_compile_time_arg_val(7);
-    constexpr uint32_t d_out_subblock_w = get_compile_time_arg_val(8);
-    constexpr uint32_t N_gate_tiles_full = get_compile_time_arg_val(9);
-    constexpr uint32_t N_down_tiles_full = get_compile_time_arg_val(10);
-    constexpr uint32_t num_chunks_max = get_compile_time_arg_val(11);
-    constexpr uint32_t chunk_M_max = get_compile_time_arg_val(12);
+    constexpr uint32_t per_core_M_max = get_compile_time_arg_val(1);
+    constexpr uint32_t per_core_N_gu = get_compile_time_arg_val(2);
+    constexpr uint32_t per_core_N_d = get_compile_time_arg_val(3);
+    constexpr uint32_t d_out_subblock_h = get_compile_time_arg_val(4);
+    constexpr uint32_t d_out_subblock_w = get_compile_time_arg_val(5);
+    constexpr uint32_t N_gate_tiles_full = get_compile_time_arg_val(6);
+    constexpr uint32_t N_down_tiles_full = get_compile_time_arg_val(7);
+    constexpr uint32_t num_chunks_max = get_compile_time_arg_val(8);
+    constexpr uint32_t chunk_M_max = get_compile_time_arg_val(9);
     // device-side count read.
-    constexpr uint32_t cb_counts_scratch = get_compile_time_arg_val(13);
-    constexpr uint32_t cb_idx_scratch = get_compile_time_arg_val(14);
-    constexpr uint32_t experts_per_chip = get_compile_time_arg_val(15);
+    constexpr uint32_t cb_counts_scratch = get_compile_time_arg_val(10);
+    constexpr uint32_t cb_idx_scratch = get_compile_time_arg_val(11);
+    constexpr uint32_t experts_per_chip = get_compile_time_arg_val(12);
     // M_tiles_full: total tile-row count of the FFN *input* (x). When the
     // kernel runs more chunks than strictly needed (because
     // M_tiles_full % chunk_M_tiles != 0), the last chunk has writer
     // destinations past M_tiles_full — we skip those source rows here.
-    constexpr uint32_t M_tiles_full = get_compile_time_arg_val(16);
-    // direct_write CT arg (17) is always 1 now: every expert's output is written
-    // into the shared buffer at start[global_id]/TILE tile-rows. Kept in the
-    // CT-arg layout for stability but no longer branched on.
-    // dst_M_tiles: tile-row count of the *destination* buffer. Equals
-    // M_tiles_full in non-direct mode; the shared buffer's row count in
-    // direct-write mode (used to bound destination writes).
-    constexpr uint32_t dst_M_tiles = get_compile_time_arg_val(18);
-    constexpr uint32_t cb_start_scratch = get_compile_time_arg_val(19);
+    constexpr uint32_t M_tiles_full = get_compile_time_arg_val(13);
+    // dst_M_tiles: tile-row count of the *destination* (shared) buffer, used to
+    // bound destination writes.
+    constexpr uint32_t dst_M_tiles = get_compile_time_arg_val(14);
+    constexpr uint32_t cb_start_scratch = get_compile_time_arg_val(15);
     // UP_SPLIT up-weight read (see header): the writer reads `up` on NoC 1 into
     // the gy=0 sender's cb_in1_up slot; the reader mcasts it on NoC 0.
     // writer_split_up gates it (1 = UP_SPLIT, 0 = LEGACY: reader owns `up`).
-    constexpr uint32_t cb_in1_up = get_compile_time_arg_val(20);
-    constexpr uint32_t in0_block_w_gu = get_compile_time_arg_val(21);
-    constexpr uint32_t K_gate_tiles = get_compile_time_arg_val(22);
-    constexpr uint32_t writer_split_up = get_compile_time_arg_val(23);
+    constexpr uint32_t cb_in1_up = get_compile_time_arg_val(16);
+    constexpr uint32_t in0_block_w_gu = get_compile_time_arg_val(17);
+    constexpr uint32_t K_gate_tiles = get_compile_time_arg_val(18);
+    constexpr uint32_t writer_split_up = get_compile_time_arg_val(19);
     // When the compute tail-skips the last down block's K padding, the down
     // matmul never reduces the N-OOB hidden columns, so the `up` read can skip
     // zero-filling them. Derived identically to the reader's down_k_tail_skip.
-    constexpr bool down_k_tail_skip = get_compile_time_arg_val(24) != 0;
+    constexpr bool down_k_tail_skip = get_compile_time_arg_val(20) != 0;
 
     constexpr uint32_t d_out_subblock_num_tiles = d_out_subblock_h * d_out_subblock_w;
     // Full compile-time M-subblock count of cb_out (the down matmul copies the
@@ -121,10 +113,9 @@ void kernel_main() {
     CircularBuffer cb_start_scratch_buf(cb_start_scratch);
 
     // Accessor compile-arg stream order (host appends in this exact order):
-    // out, then start (direct-write), then up (UP_SPLIT). The accessors are
-    // constructed unconditionally; start_acc is used only when direct_write,
-    // up_acc only when writer_split_up.
-    constexpr uint32_t out_accessor_offset = 25;
+    // out, then start, then up (UP_SPLIT). The accessors are constructed
+    // unconditionally; up_acc is used only when writer_split_up.
+    constexpr uint32_t out_accessor_offset = 21;
     constexpr auto out_args = TensorAccessorArgs<out_accessor_offset>();
     const auto out_acc = TensorAccessor(out_args, output_addr, cb_out_buf.get_tile_size());
 
@@ -136,7 +127,7 @@ void kernel_main() {
     constexpr auto up_args = TensorAccessorArgs<up_accessor_offset>();
     // Per-expert `up` base addresses live in a runtime-arg array after the fixed
     // writer args; UP_RT is its first index. up_addr(e) = arg[UP_RT + e].
-    constexpr uint32_t UP_RT = 9;
+    constexpr uint32_t UP_RT = 8;
 
     const uint32_t out_tile_bytes = cb_out_buf.get_tile_size();
 
@@ -182,12 +173,16 @@ void kernel_main() {
         const auto up_acc = TensorAccessor(up_args, get_arg_val<uint32_t>(UP_RT + local_expert_id), up_tile_bytes);
         const uint32_t global_expert_id = idx_ptr[local_expert_id];
         const uint32_t count_value = counts_ptr[global_expert_id];
-        const uint32_t count_tiles = (count_value + TILE_HEIGHT - 1) / TILE_HEIGHT;
+        // Same capacity clamp the reader and compute apply to the device-produced
+        // count (see adaptive_chunk::clamp_count_tiles): arithmetic, so it bounds
+        // the chunk loop in Release too, where ASSERT is a no-op.
+        const uint32_t count_tiles_raw = (count_value + TILE_HEIGHT - 1) / TILE_HEIGHT;
+        const uint32_t count_tiles = adaptive_chunk::clamp_count_tiles(count_tiles_raw, chunk_M_max, num_chunks_max);
+        ASSERT(count_tiles == count_tiles_raw);
         // Runtime chunk layout from THIS expert's count — the same math the reader
         // and compute kernels run, so all three agree on the row mapping (a
         // mismatch would emit this expert's rows at the wrong token offsets).
         const uint32_t effective_chunks = adaptive_chunk::num_chunks(count_tiles, chunk_M_max);
-        ASSERT(effective_chunks <= num_chunks_max);
         const uint32_t row_offset_tiles = start_ptr[global_expert_id] / TILE_HEIGHT;
 
         for (uint32_t chunk = 0; chunk < effective_chunks; ++chunk) {

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/dataflow/unified_routed_expert_ffn_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/dataflow/unified_routed_expert_ffn_writer.cpp
@@ -172,7 +172,8 @@ void kernel_main() {
         // count (see adaptive_chunk::clamp_count_tiles): arithmetic, so it bounds
         // the chunk loop in Release too, where ASSERT is a no-op.
         const uint32_t count_tiles_raw = (count_value + TILE_HEIGHT - 1) / TILE_HEIGHT;
-        const uint32_t count_tiles = adaptive_chunk::clamp_count_tiles(count_tiles_raw, chunk_M_max, num_chunks_max);
+        const uint32_t count_tiles =
+            adaptive_chunk::clamp_count_tiles(count_tiles_raw, chunk_M_max, num_chunks_max, M_tiles_full);
         ASSERT(count_tiles == count_tiles_raw);
         // Runtime chunk layout from THIS expert's count — the same math the reader
         // and compute kernels run, so all three agree on the row mapping (a

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/dataflow/unified_routed_expert_ffn_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/dataflow/unified_routed_expert_ffn_writer.cpp
@@ -12,16 +12,13 @@
 //    looped over `effective_chunks` chunks (computed from the device-side
 //    counts/idx scratch CBs). Activated tiles are distributed across the
 //    M-row by the READER via L1 multicast — no DRAM scratch round-trip or
-//    cross-core barrier. Placement has two modes (the `direct_write` CT flag):
-//      * direct_write == 0: writes start at tile row 0. The FFN op writes to
-//        a per-expert output tensor; a separate ttnn::insert handles
-//        placement into any shared destination buffer.
-//      * direct_write == 1: this expert's output is written directly into a
-//        shared destination buffer at the expert's region offset. The kernel
-//        reads start[global_expert_id] from `start` (= expert_region_offsets)
-//        device-side and adds (start / TILE_HEIGHT) tile-rows to every output
-//        row — fusing what ttnn::insert would otherwise do (no temp-buffer
-//        DRAM round-trip).
+//    cross-core barrier. Every expert's output is written directly into the
+//    shared destination buffer at that expert's region offset: the kernel
+//    reads start[global_expert_id] from `start` (= expert_region_offsets)
+//    device-side and adds (start / TILE_HEIGHT) tile-rows to every output
+//    row — fusing what ttnn::insert would otherwise do (no temp-buffer DRAM
+//    round-trip). expert_region_offsets is a mandatory op input, so there is
+//    no per-expert-output-tensor mode.
 //
 // 2. Two-RISC `up`-weight read (UP_SPLIT). The writer (NCRISC) reads `up`
 //    from DRAM on NoC 1 concurrent with the reader's NoC-0 `gate` read. The
@@ -53,54 +50,49 @@ void kernel_main() {
     const uint32_t my_mt = get_arg_val<uint32_t>(1);
     const uint32_t my_nt_d = get_arg_val<uint32_t>(2);
     const uint32_t start_addr = get_arg_val<uint32_t>(3);
-    // UP_SPLIT up-weight read args. Arg 4 holds expert-0's up base (kept for
-    // arg-layout stability); the per-expert `up` addresses live in the array
-    // starting at UP_RT and are used instead.
-    const uint32_t my_nt_gu = get_arg_val<uint32_t>(5);
-    const bool is_up_sender = get_arg_val<uint32_t>(6) != 0;
+    // UP_SPLIT up-weight read args. The per-expert `up` addresses live in the
+    // runtime-arg array starting at UP_RT.
+    const uint32_t my_nt_gu = get_arg_val<uint32_t>(4);
+    const bool is_up_sender = get_arg_val<uint32_t>(5) != 0;
     // UP_SPLIT local handshake sems (see reader): up_go = slot reserved,
     // up_done = up landed.
-    const uint32_t up_go_sem_id = get_arg_val<uint32_t>(7);
-    const uint32_t up_done_sem_id = get_arg_val<uint32_t>(8);
+    const uint32_t up_go_sem_id = get_arg_val<uint32_t>(6);
+    const uint32_t up_done_sem_id = get_arg_val<uint32_t>(7);
 
-    constexpr uint32_t cb_out = get_compile_time_arg_val(1);
+    constexpr uint32_t cb_out = get_compile_time_arg_val(0);
     // per_core_M_max: CB-sized max per-core M. The runtime per_core_M is picked
-    // from the device count below; compute always hands cb_out per_core_M_max rows
-    // (real output for the first per_core_M, unwritten filler after) and this
-    // writer emits only the first (runtime) per_core_M of them.
-    constexpr uint32_t per_core_M_max = get_compile_time_arg_val(2);
-    constexpr uint32_t per_core_N_gu = get_compile_time_arg_val(3);
-    constexpr uint32_t per_core_N_d = get_compile_time_arg_val(4);
-    constexpr uint32_t d_out_subblock_h = get_compile_time_arg_val(7);
-    constexpr uint32_t d_out_subblock_w = get_compile_time_arg_val(8);
-    constexpr uint32_t N_gate_tiles_full = get_compile_time_arg_val(9);
-    constexpr uint32_t N_down_tiles_full = get_compile_time_arg_val(10);
-    constexpr uint32_t num_chunks_max = get_compile_time_arg_val(11);
-    constexpr uint32_t chunk_M_max = get_compile_time_arg_val(12);
+    // from the device count below; the down matmul packs the full max ring (so
+    // cb_out carries per_core_M_max rows) and this writer emits only the first
+    // (runtime) per_core_M of them.
+    constexpr uint32_t per_core_M_max = get_compile_time_arg_val(1);
+    constexpr uint32_t per_core_N_gu = get_compile_time_arg_val(2);
+    constexpr uint32_t per_core_N_d = get_compile_time_arg_val(3);
+    constexpr uint32_t d_out_subblock_h = get_compile_time_arg_val(4);
+    constexpr uint32_t d_out_subblock_w = get_compile_time_arg_val(5);
+    constexpr uint32_t N_gate_tiles_full = get_compile_time_arg_val(6);
+    constexpr uint32_t N_down_tiles_full = get_compile_time_arg_val(7);
+    constexpr uint32_t num_chunks_max = get_compile_time_arg_val(8);
+    constexpr uint32_t chunk_M_max = get_compile_time_arg_val(9);
     // device-side count read.
-    constexpr uint32_t cb_counts_scratch = get_compile_time_arg_val(13);
-    constexpr uint32_t cb_idx_scratch = get_compile_time_arg_val(14);
-    constexpr uint32_t experts_per_chip = get_compile_time_arg_val(15);
+    constexpr uint32_t cb_counts_scratch = get_compile_time_arg_val(10);
+    constexpr uint32_t cb_idx_scratch = get_compile_time_arg_val(11);
+    constexpr uint32_t experts_per_chip = get_compile_time_arg_val(12);
     // M_tiles_full: total tile-row count of the FFN *input* (x). When the
     // kernel runs more chunks than strictly needed (because
     // M_tiles_full % chunk_M_tiles != 0), the last chunk has writer
     // destinations past M_tiles_full — we skip those source rows here.
-    constexpr uint32_t M_tiles_full = get_compile_time_arg_val(16);
-    // direct_write CT arg (17) is always 1 now: every expert's output is written
-    // into the shared buffer at start[global_id]/TILE tile-rows. Kept in the
-    // CT-arg layout for stability but no longer branched on.
-    // dst_M_tiles: tile-row count of the *destination* buffer. Equals
-    // M_tiles_full in non-direct mode; the shared buffer's row count in
-    // direct-write mode (used to bound destination writes).
-    constexpr uint32_t dst_M_tiles = get_compile_time_arg_val(18);
-    constexpr uint32_t cb_start_scratch = get_compile_time_arg_val(19);
+    constexpr uint32_t M_tiles_full = get_compile_time_arg_val(13);
+    // dst_M_tiles: tile-row count of the *destination* (shared) buffer, used to
+    // bound destination writes.
+    constexpr uint32_t dst_M_tiles = get_compile_time_arg_val(14);
+    constexpr uint32_t cb_start_scratch = get_compile_time_arg_val(15);
     // UP_SPLIT up-weight read (see header): the writer reads `up` on NoC 1 into
     // the gy=0 sender's cb_in1_up slot; the reader mcasts it on NoC 0.
     // writer_split_up gates it (1 = UP_SPLIT, 0 = LEGACY: reader owns `up`).
-    constexpr uint32_t cb_in1_up = get_compile_time_arg_val(20);
-    constexpr uint32_t in0_block_w_gu = get_compile_time_arg_val(21);
-    constexpr uint32_t K_gate_tiles = get_compile_time_arg_val(22);
-    constexpr uint32_t writer_split_up = get_compile_time_arg_val(23);
+    constexpr uint32_t cb_in1_up = get_compile_time_arg_val(16);
+    constexpr uint32_t in0_block_w_gu = get_compile_time_arg_val(17);
+    constexpr uint32_t K_gate_tiles = get_compile_time_arg_val(18);
+    constexpr uint32_t writer_split_up = get_compile_time_arg_val(19);
 
     constexpr uint32_t d_out_subblock_num_tiles = d_out_subblock_h * d_out_subblock_w;
     // Full compile-time M-subblock count of cb_out. The writer DRAINS all of them
@@ -116,10 +108,9 @@ void kernel_main() {
     CircularBuffer cb_start_scratch_buf(cb_start_scratch);
 
     // Accessor compile-arg stream order (host appends in this exact order):
-    // out, then start (direct-write), then up (UP_SPLIT). The accessors are
-    // constructed unconditionally; start_acc is used only when direct_write,
-    // up_acc only when writer_split_up.
-    constexpr uint32_t out_accessor_offset = 24;
+    // out, then start, then up (UP_SPLIT). The accessors are constructed
+    // unconditionally; up_acc is used only when writer_split_up.
+    constexpr uint32_t out_accessor_offset = 20;
     constexpr auto out_args = TensorAccessorArgs<out_accessor_offset>();
     const auto out_acc = TensorAccessor(out_args, output_addr, cb_out_buf.get_tile_size());
 
@@ -131,7 +122,7 @@ void kernel_main() {
     constexpr auto up_args = TensorAccessorArgs<up_accessor_offset>();
     // Per-expert `up` base addresses live in a runtime-arg array after the fixed
     // writer args; UP_RT is its first index. up_addr(e) = arg[UP_RT + e].
-    constexpr uint32_t UP_RT = 9;
+    constexpr uint32_t UP_RT = 8;
 
     const uint32_t out_tile_bytes = cb_out_buf.get_tile_size();
 
@@ -177,12 +168,16 @@ void kernel_main() {
         const auto up_acc = TensorAccessor(up_args, get_arg_val<uint32_t>(UP_RT + local_expert_id), up_tile_bytes);
         const uint32_t global_expert_id = idx_ptr[local_expert_id];
         const uint32_t count_value = counts_ptr[global_expert_id];
-        const uint32_t count_tiles = (count_value + TILE_HEIGHT - 1) / TILE_HEIGHT;
+        // Same capacity clamp the reader and compute apply to the device-produced
+        // count (see adaptive_chunk::clamp_count_tiles): arithmetic, so it bounds
+        // the chunk loop in Release too, where ASSERT is a no-op.
+        const uint32_t count_tiles_raw = (count_value + TILE_HEIGHT - 1) / TILE_HEIGHT;
+        const uint32_t count_tiles = adaptive_chunk::clamp_count_tiles(count_tiles_raw, chunk_M_max, num_chunks_max);
+        ASSERT(count_tiles == count_tiles_raw);
         // Runtime chunk layout from THIS expert's count — the same math the reader
         // and compute kernels run, so all three agree on the row mapping (a
         // mismatch would emit this expert's rows at the wrong token offsets).
         const uint32_t effective_chunks = adaptive_chunk::num_chunks(count_tiles, chunk_M_max);
-        ASSERT(effective_chunks <= num_chunks_max);
         const uint32_t row_offset_tiles = start_ptr[global_expert_id] / TILE_HEIGHT;
 
         for (uint32_t chunk = 0; chunk < effective_chunks; ++chunk) {

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/dataflow/unified_routed_expert_ffn_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/dataflow/unified_routed_expert_ffn_writer.cpp
@@ -52,11 +52,10 @@ void kernel_main() {
     const uint32_t output_addr = get_arg_val<uint32_t>(0);
     const uint32_t my_mt = get_arg_val<uint32_t>(1);
     const uint32_t my_nt_d = get_arg_val<uint32_t>(2);
-    // start (= expert_region_offsets) address. Only read when direct_write.
     const uint32_t start_addr = get_arg_val<uint32_t>(3);
-    // UP_SPLIT up-weight read args: up tensor base, this core's N-column, and
-    // whether this core is the gy=0 sender (only senders read `up`).
-    const uint32_t up_addr = get_arg_val<uint32_t>(4);
+    // UP_SPLIT up-weight read args. Arg 4 holds expert-0's up base (kept for
+    // arg-layout stability); the per-expert `up` addresses live in the array
+    // starting at UP_RT and are used instead.
     const uint32_t my_nt_gu = get_arg_val<uint32_t>(5);
     const bool is_up_sender = get_arg_val<uint32_t>(6) != 0;
     // UP_SPLIT local handshake sems (see reader): up_go = slot reserved,
@@ -81,15 +80,15 @@ void kernel_main() {
     // device-side count read.
     constexpr uint32_t cb_counts_scratch = get_compile_time_arg_val(13);
     constexpr uint32_t cb_idx_scratch = get_compile_time_arg_val(14);
-    constexpr uint32_t local_expert_id = get_compile_time_arg_val(15);
+    constexpr uint32_t experts_per_chip = get_compile_time_arg_val(15);
     // M_tiles_full: total tile-row count of the FFN *input* (x). When the
     // kernel runs more chunks than strictly needed (because
     // M_tiles_full % chunk_M_tiles != 0), the last chunk has writer
     // destinations past M_tiles_full — we skip those source rows here.
     constexpr uint32_t M_tiles_full = get_compile_time_arg_val(16);
-    // direct_write: 0 -> write to per-expert output at row 0 (standalone FFN).
-    //               1 -> write into shared buffer at start[global_id]/TILE.
-    constexpr uint32_t direct_write = get_compile_time_arg_val(17);
+    // direct_write CT arg (17) is always 1 now: every expert's output is written
+    // into the shared buffer at start[global_id]/TILE tile-rows. Kept in the
+    // CT-arg layout for stability but no longer branched on.
     // dst_M_tiles: tile-row count of the *destination* buffer. Equals
     // M_tiles_full in non-direct mode; the shared buffer's row count in
     // direct-write mode (used to bound destination writes).
@@ -130,171 +129,183 @@ void kernel_main() {
 
     constexpr uint32_t up_accessor_offset = start_args.next_compile_time_args_offset();
     constexpr auto up_args = TensorAccessorArgs<up_accessor_offset>();
-    const auto up_acc = TensorAccessor(up_args, up_addr, get_tile_size(cb_in1_up));
+    // Per-expert `up` base addresses live in a runtime-arg array after the fixed
+    // writer args; UP_RT is its first index. up_addr(e) = arg[UP_RT + e].
+    constexpr uint32_t UP_RT = 9;
 
     const uint32_t out_tile_bytes = cb_out_buf.get_tile_size();
 
-    // Wait for the reader's counts/idx push and compute effective_chunks =
-    // ceil(count / chunk_M_tiles). The writer drains cb_out per chunk;
-    // bounding the loop here is required because the reader and compute
-    // bound theirs too — without this, the writer would wait forever on
-    // cb_out for chunks the compute never pushes.
+    // Wait for the reader's counts/idx push (resident scratch). Per expert the
+    // writer bounds its cb_out drain by that expert's effective_chunks; the
+    // reader and compute bound theirs identically, so the pipeline stays in
+    // lockstep and the writer never waits on a chunk compute never pushes.
     cb_counts_scratch_buf.wait_front(1);
     cb_idx_scratch_buf.wait_front(1);
     const volatile tt_l1_ptr uint32_t* counts_ptr =
         reinterpret_cast<const volatile tt_l1_ptr uint32_t*>(cb_counts_scratch_buf.get_read_ptr());
     const uint32_t idx_l1 = cb_idx_scratch_buf.get_read_ptr();
     const volatile tt_l1_ptr uint32_t* idx_ptr = reinterpret_cast<const volatile tt_l1_ptr uint32_t*>(idx_l1);
-    const uint32_t global_expert_id = idx_ptr[local_expert_id];
-    const uint32_t count_value = counts_ptr[global_expert_id];
-    const uint32_t count_tiles = (count_value + TILE_HEIGHT - 1) / TILE_HEIGHT;
-    // Runtime chunk layout from the actual count (same math as reader/compute so
-    // the row mapping agrees). per_core_M is per-chunk (see the loop).
-    const uint32_t effective_chunks_runtime = adaptive_chunk::num_chunks(count_tiles, chunk_M_max);
-    const uint32_t effective_chunks =
-        effective_chunks_runtime < num_chunks_max ? effective_chunks_runtime : num_chunks_max;
 
-    // Destination tile-row offset for direct-write mode. In direct-write
-    // mode the output buffer is a SHARED buffer and this expert's slice
-    // begins at start[global_expert_id] (token row); convert to tile rows.
-    // Mirrors ttnn::insert's writer: start_tile_row = start_value / TILE.
-    uint32_t row_offset_tiles = 0;
-    if constexpr (direct_write != 0) {
-        const uint32_t start_l1 = cb_start_scratch_buf.get_write_ptr();
+    // Read the `start` (= expert_region_offsets) page ONCE into resident L1;
+    // each expert's output slice begins at start[global_id] (token row).
+    const uint32_t start_l1 = cb_start_scratch_buf.get_write_ptr();
+    {
         const uint32_t start_page_size = start_acc.get_aligned_page_size();
         noc.async_read(start_acc, CoreLocalMem<uint32_t>(start_l1), start_page_size, {.page_id = 0}, {});
         noc.async_read_barrier();
-        const volatile tt_l1_ptr uint32_t* start_ptr = reinterpret_cast<const volatile tt_l1_ptr uint32_t*>(start_l1);
-        const uint32_t start_value = start_ptr[global_expert_id];
-        row_offset_tiles = start_value / TILE_HEIGHT;
     }
+    const volatile tt_l1_ptr uint32_t* start_ptr = reinterpret_cast<const volatile tt_l1_ptr uint32_t*>(start_l1);
 
-    // ---- UP_SPLIT up-weight read setup ----
-    // The writer reads `up` from DRAM on NoC 1 concurrent with the
-    // reader's NoC-0 `gate` read, into the gy=0 sender's cb_in1_up slot; the
-    // reader multicasts it on NoC 0. A local same-core (BRISC reader <-> NCRISC
-    // writer) handshake orders the two: up_go (reader: slot reserved) and
-    // up_done (writer: up landed in L1), monotonic counters.
+    // ---- UP_SPLIT up-weight read setup (see header) ----
+    // The writer reads `up` from DRAM on NoC 1 concurrent with the reader's
+    // NoC-0 `gate` read, into the gy=0 sender's cb_in1_up slot; the reader
+    // multicasts it on NoC 0. A local same-core (BRISC reader <-> NCRISC writer)
+    // handshake (up_go / up_done, monotonic) orders the two.
     Noc noc_up(1);
     const uint32_t up_tile_bytes = get_tile_size(cb_in1_up);
     Semaphore<> up_go_sem(up_go_sem_id);
     Semaphore<> up_done_sem(up_done_sem_id);
+    // up_seq stays in lockstep with the reader ACROSS all experts.
     uint32_t up_seq = 0;
 
-    for (uint32_t chunk = 0; chunk < effective_chunks; ++chunk) {
-        // ---- Phase 1/2 weight feed: writer reads `up` on NoC 1 (UP_SPLIT) ----
-        // Streams `up` from DRAM concurrent with the reader's NoC-0 `gate` read.
-        // Runs before the cb_out drain.
-        if constexpr (writer_split_up) {
-            // UP_SPLIT: only gy=0 in1-sender cores read `up`. Per K-block: wait
-            // for the reader to reserve the slot (up_go), read this column's
-            // `up` slice on NoC 1 into it, then signal up_done so the reader
-            // mcasts on NoC 0. Only a NoC-1 DRAM read here (fabric-safe); the
-            // reader owns cb_in1_up reserve/push.
-            if (is_up_sender) {
-                // The CB write pointer is PER-RISC and the reader owns push, so
-                // the writer's get_write_ptr never advances. Replicate the
-                // reader's cadence: cb_in1_up is double-buffered, one push per
-                // K-block, so the live slot is base + (up_seq-1)%2 * slot.
-                constexpr uint32_t kUpNumSlots = 2;
-                CircularBuffer cb_in1_up_buf(cb_in1_up);
-                const uint32_t up_cb_base = cb_in1_up_buf.get_write_ptr();
-                const uint32_t up_slot_bytes = g_in1_block_num_tiles * up_tile_bytes;
-                for (uint32_t kb = 0; kb < num_blocks_gu; ++kb) {
-                    ++up_seq;
-                    up_go_sem.wait_min(up_seq);
-                    uint32_t l1_w_up = up_cb_base + ((up_seq - 1) % kUpNumSlots) * up_slot_bytes;
-                    for (uint32_t k = 0; k < in0_block_w_gu; ++k) {
-                        for (uint32_t n = 0; n < per_core_N_gu; ++n) {
-                            const uint32_t row = kb * in0_block_w_gu + k;
-                            const uint32_t col = my_nt_gu * per_core_N_gu + n;
-                            // N-OOB hidden padding column left UNWRITTEN: its up output lands
-                            // on a down K position the down matmul never reduces (the compute
-                            // bounds its K-loop by real_k_tiles), so stale L1 is dropped.
-                            if (col < N_gate_tiles_full) {
-                                const uint32_t tile_idx = row * N_gate_tiles_full + col;
-                                noc_up.async_read(
-                                    up_acc, CoreLocalMem<uint32_t>(l1_w_up), up_tile_bytes, {.page_id = tile_idx}, {});
-                            }
-                            l1_w_up += up_tile_bytes;
-                        }
-                    }
-                    noc_up.async_read_barrier();
-                    up_done_sem.set(up_seq);
-                }
-            }
-        }
+    // ======================= per-local-expert loop =======================
+    // Drain every local expert's down-matmul output (and, for UP_SPLIT sender
+    // cores, feed its `up` weights) into the shared output buffer at the
+    // expert's region offset. The chunk-loop body below is unchanged from the
+    // single-expert kernel — only the per-expert bindings differ.
+    for (uint32_t local_expert_id = 0; local_expert_id < experts_per_chip; ++local_expert_id) {
+        const auto up_acc = TensorAccessor(up_args, get_arg_val<uint32_t>(UP_RT + local_expert_id), up_tile_bytes);
+        const uint32_t global_expert_id = idx_ptr[local_expert_id];
+        const uint32_t count_value = counts_ptr[global_expert_id];
+        const uint32_t count_tiles = (count_value + TILE_HEIGHT - 1) / TILE_HEIGHT;
+        // Runtime chunk layout from THIS expert's count — the same math the reader
+        // and compute kernels run, so all three agree on the row mapping (a
+        // mismatch would emit this expert's rows at the wrong token offsets).
+        const uint32_t effective_chunks = adaptive_chunk::num_chunks(count_tiles, chunk_M_max);
+        ASSERT(effective_chunks <= num_chunks_max);
+        const uint32_t row_offset_tiles = start_ptr[global_expert_id] / TILE_HEIGHT;
 
-        // ---- Drain cb_out (down matmul output) to DRAM ----
-        // Per-chunk per_core_M (per_core_M_max for full chunks, a smaller divisor
-        // for the tail); chunk starts are uniform at chunk*chunk_M_max. Contiguous
-        // row map: this core owns rows [row0, row0 + per_core_M).
-        const uint32_t per_core_M = adaptive_chunk::per_core_M_for_chunk(chunk, count_tiles, chunk_M_max);
-        const uint32_t row0 = chunk * chunk_M_max + my_mt * per_core_M;
-        const uint32_t col0 = my_nt_d * per_core_N_d;
-        // Compute pushes the FULL compile-time-MAX row count to cb_out, so DRAIN all
-        // d_in1_num_subblocks_M rows to keep it balanced — but only WRITE the first
-        // per_core_M (runtime) rows; the rest are uncomputed filler that maps onto
-        // other cores' rows and must not be emitted (the sb_m < per_core_M guard).
-        const uint32_t sb_m_bound = d_in1_num_subblocks_M;
-        for (uint32_t sb_m = 0; sb_m < sb_m_bound; ++sb_m) {
-            for (uint32_t sb_n = 0; sb_n < d_in1_num_subblocks_N; ++sb_n) {
-                cb_out_buf.wait_front(d_out_subblock_num_tiles);
-                uint32_t subblock_tile_offset = 0;
-                for (uint32_t i = 0; i < d_out_subblock_h; ++i) {
-                    for (uint32_t j = 0; j < d_out_subblock_w; ++j) {
-                        const uint32_t row = row0 + sb_m * d_out_subblock_h + i;
-                        const uint32_t col = col0 + sb_n * d_out_subblock_w + j;
-                        // `row` indexes the FFN *input* (x) tile-rows; the
-                        // destination tile-row adds the per-expert region
-                        // offset (0 in non-direct mode).
-                        const uint32_t dst_row = row_offset_tiles + row;
-                        // Bounds that decide whether this is a real output tile
-                        // for this expert:
-                        //   * col < N_down_tiles_full: GRID_X=11 ceil_div
-                        //     produces phantom output cols past actual N.
-                        //   * row < M_tiles_full: ceil_div of M produces a
-                        //     last-chunk tail past actual M when
-                        //     M_tiles_full doesn't divide chunk_M_tiles.
-                        //   * row < count_tiles: the last chunk's per_core_M
-                        //     rows extend past count_tiles when count_tiles
-                        //     is not chunk-aligned.
-                        //   * sb_m < per_core_M: cb_out carries per_core_M_max
-                        //     rows; rows past the runtime per_core_M are filler
-                        //     mapping onto other cores' rows — never write.
-                        if (sb_m < per_core_M && col < N_down_tiles_full && row < M_tiles_full && row < count_tiles) {
-                            // The destination tile-row must stay inside the
-                            // (possibly shared) output buffer. ttnn::insert
-                            // asserted the whole-slice fit
-                            // (start_tile_idx + num_tiles <= global_num_tiles);
-                            // assert the per-tile equivalent so an over-capacity
-                            // region offset fails loudly in watcher builds. The
-                            // guard below keeps Release builds safe (skip the OOB
-                            // write rather than corrupt DRAM, since ASSERT is a
-                            // no-op there).
-                            ASSERT(dst_row < dst_M_tiles);
-                            if (dst_row < dst_M_tiles) {
-                                const uint32_t tile_idx = dst_row * N_down_tiles_full + col;
-                                noc.async_write(
-                                    cb_out_buf,
-                                    out_acc,
-                                    out_tile_bytes,
-                                    {.offset_bytes = subblock_tile_offset},
-                                    {.page_id = tile_idx});
+        for (uint32_t chunk = 0; chunk < effective_chunks; ++chunk) {
+            // ---- Phase 1/2 weight feed: writer reads `up` on NoC 1 (UP_SPLIT) ----
+            // Streams `up` from DRAM concurrent with the reader's NoC-0 `gate` read.
+            // Runs before the cb_out drain.
+            if constexpr (writer_split_up) {
+                // UP_SPLIT: only gy=0 in1-sender cores read `up`. Per K-block: wait
+                // for the reader to reserve the slot (up_go), read this column's
+                // `up` slice on NoC 1 into it, then signal up_done so the reader
+                // mcasts on NoC 0. Only a NoC-1 DRAM read here (fabric-safe); the
+                // reader owns cb_in1_up reserve/push.
+                if (is_up_sender) {
+                    // The CB write pointer is PER-RISC and the reader owns push, so
+                    // the writer's get_write_ptr never advances. Replicate the
+                    // reader's cadence: cb_in1_up is double-buffered, one push per
+                    // K-block, so the live slot is base + (up_seq-1)%2 * slot.
+                    constexpr uint32_t kUpNumSlots = 2;
+                    CircularBuffer cb_in1_up_buf(cb_in1_up);
+                    const uint32_t up_cb_base = cb_in1_up_buf.get_write_ptr();
+                    const uint32_t up_slot_bytes = g_in1_block_num_tiles * up_tile_bytes;
+                    for (uint32_t kb = 0; kb < num_blocks_gu; ++kb) {
+                        ++up_seq;
+                        up_go_sem.wait_min(up_seq);
+                        uint32_t l1_w_up = up_cb_base + ((up_seq - 1) % kUpNumSlots) * up_slot_bytes;
+                        for (uint32_t k = 0; k < in0_block_w_gu; ++k) {
+                            for (uint32_t n = 0; n < per_core_N_gu; ++n) {
+                                const uint32_t row = kb * in0_block_w_gu + k;
+                                const uint32_t col = my_nt_gu * per_core_N_gu + n;
+                                // N-OOB hidden padding column left UNWRITTEN: its up output lands
+                                // on a down K position the down matmul never reduces (the compute
+                                // bounds its K-loop by real_k_tiles), so stale L1 is dropped.
+                                if (col < N_gate_tiles_full) {
+                                    const uint32_t tile_idx = row * N_gate_tiles_full + col;
+                                    noc_up.async_read(
+                                        up_acc,
+                                        CoreLocalMem<uint32_t>(l1_w_up),
+                                        up_tile_bytes,
+                                        {.page_id = tile_idx},
+                                        {});
+                                }
+                                l1_w_up += up_tile_bytes;
                             }
                         }
-                        subblock_tile_offset += out_tile_bytes;
+                        noc_up.async_read_barrier();
+                        up_done_sem.set(up_seq);
                     }
                 }
-                // Wait for the writes to LEAVE this core (departed sender);
-                // doesn't wait for the DRAM round-trip. Safe to reuse the L1
-                // slot now — the NoC has captured the data. ~10x faster than
-                // noc_async_write_barrier per subblock at small per_core_M.
-                noc.async_writes_flushed();
-                cb_out_buf.pop_front(d_out_subblock_num_tiles);
             }
-        }
-    }
+
+            // ---- Drain cb_out (down matmul output) to DRAM ----
+            // Per-chunk per_core_M (per_core_M_max for full chunks, a smaller
+            // divisor for the tail); chunk starts are uniform at chunk*chunk_M_max.
+            // Contiguous row map: this core owns rows [row0, row0 + per_core_M).
+            const uint32_t per_core_M = adaptive_chunk::per_core_M_for_chunk(chunk, count_tiles, chunk_M_max);
+            const uint32_t row0 = chunk * chunk_M_max + my_mt * per_core_M;
+            const uint32_t col0 = my_nt_d * per_core_N_d;
+            // The DOWN matmul packs and pushes the FULL compile-time-MAX ring (its
+            // L1_ACC needs full-ring cycling), so DRAIN all d_in1_num_subblocks_M
+            // rows to keep cb_out balanced — but only WRITE the first per_core_M
+            // (runtime) rows; the rest are MAC-skipped zeros that map onto other
+            // cores' rows and must not be emitted (the sb_m < per_core_M guard below).
+            const uint32_t sb_m_bound = d_in1_num_subblocks_M;
+            for (uint32_t sb_m = 0; sb_m < sb_m_bound; ++sb_m) {
+                for (uint32_t sb_n = 0; sb_n < d_in1_num_subblocks_N; ++sb_n) {
+                    cb_out_buf.wait_front(d_out_subblock_num_tiles);
+                    uint32_t subblock_tile_offset = 0;
+                    for (uint32_t i = 0; i < d_out_subblock_h; ++i) {
+                        for (uint32_t j = 0; j < d_out_subblock_w; ++j) {
+                            const uint32_t row = row0 + sb_m * d_out_subblock_h + i;
+                            const uint32_t col = col0 + sb_n * d_out_subblock_w + j;
+                            // `row` indexes the FFN *input* (x) tile-rows; the
+                            // destination tile-row adds the per-expert region
+                            // offset.
+                            const uint32_t dst_row = row_offset_tiles + row;
+                            // Bounds that decide whether this is a real output tile
+                            // for this expert:
+                            //   * col < N_down_tiles_full: GRID_X=11 ceil_div
+                            //     produces phantom output cols past actual N.
+                            //   * row < M_tiles_full: ceil_div of M produces a
+                            //     last-chunk tail past actual M when
+                            //     M_tiles_full doesn't divide chunk_M_tiles.
+                            //   * row < count_tiles: the last chunk's per_core_M
+                            //     rows extend past count_tiles when count_tiles
+                            //     is not chunk-aligned.
+                            //   * sb_m < per_core_M: cb_out carries per_core_M_max
+                            //     rows (full ring); rows past the runtime per_core_M
+                            //     are zeros that belong to other cores — never write.
+                            if (sb_m < per_core_M && col < N_down_tiles_full && row < M_tiles_full &&
+                                row < count_tiles) {
+                                // The destination tile-row must stay inside the
+                                // (possibly shared) output buffer. ttnn::insert
+                                // asserted the whole-slice fit
+                                // (start_tile_idx + num_tiles <= global_num_tiles);
+                                // assert the per-tile equivalent so an over-capacity
+                                // region offset fails loudly in watcher builds. The
+                                // guard below keeps Release builds safe (skip the OOB
+                                // write rather than corrupt DRAM, since ASSERT is a
+                                // no-op there).
+                                ASSERT(dst_row < dst_M_tiles);
+                                if (dst_row < dst_M_tiles) {
+                                    const uint32_t tile_idx = dst_row * N_down_tiles_full + col;
+                                    noc.async_write(
+                                        cb_out_buf,
+                                        out_acc,
+                                        out_tile_bytes,
+                                        {.offset_bytes = subblock_tile_offset},
+                                        {.page_id = tile_idx});
+                                }
+                            }
+                            subblock_tile_offset += out_tile_bytes;
+                        }
+                    }
+                    // Wait for the writes to LEAVE this core (departed sender);
+                    // doesn't wait for the DRAM round-trip. Safe to reuse the L1
+                    // slot now — the NoC has captured the data. ~10x faster than
+                    // noc_async_write_barrier per subblock at small per_core_M.
+                    noc.async_writes_flushed();
+                    cb_out_buf.pop_front(d_out_subblock_num_tiles);
+                }
+            }
+        }  // end chunk loop
+    }  // end per-local-expert loop
     // Ensure all outstanding writes complete at the destination before the
     // kernel returns (the next dispatched op may read this output).
     noc.async_write_barrier();

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_device_operation.cpp
@@ -53,10 +53,25 @@ void UnifiedRoutedExpertFfnDeviceOperation::validate_on_program_cache_miss(
         TT_FATAL(t.x.logical_shape()[i] == 1, "x leading dim {} must be 1, got {}", i, t.x.logical_shape()[i]);
     }
 
+    // Per-local-expert weight lists: one entry per expert, all identical shape.
+    // The kernels loop over experts and index a per-expert address array, so the
+    // three lists must be non-empty, equal-length, and match experts_per_chip.
+    TT_FATAL(
+        !t.gate_projs.empty() && t.gate_projs.size() == t.up_projs.size() && t.gate_projs.size() == t.down_projs.size(),
+        "gate/up/down projection lists must be non-empty and equal length (got {}, {}, {})",
+        t.gate_projs.size(),
+        t.up_projs.size(),
+        t.down_projs.size());
+    TT_FATAL(
+        t.gate_projs.size() == op.experts_per_chip,
+        "weight-list length ({}) must equal experts_per_chip ({})",
+        t.gate_projs.size(),
+        op.experts_per_chip);
+
     const auto& x_shape = t.x.padded_shape();
-    const auto& gate_shape = t.gate_proj.padded_shape();
-    const auto& up_shape = t.up_proj.padded_shape();
-    const auto& down_shape = t.down_proj.padded_shape();
+    const auto& gate_shape = t.gate_projs[0].padded_shape();
+    const auto& up_shape = t.up_projs[0].padded_shape();
+    const auto& down_shape = t.down_projs[0].padded_shape();
 
     TT_FATAL(
         x_shape[-1] == gate_shape[-2] && x_shape[-1] == up_shape[-2],
@@ -73,26 +88,36 @@ void UnifiedRoutedExpertFfnDeviceOperation::validate_on_program_cache_miss(
 
     constexpr uint32_t TILE = tt::constants::TILE_HEIGHT;
     TT_FATAL(x_shape[-2] % TILE == 0, "x M ({}) must be tile-aligned", x_shape[-2]);
-    TT_FATAL(op.chunk_M_tiles > 0, "chunk_M_tiles must be > 0");
     // m_tiles is this expert's M (grid/chunk/CB sizing). x may be a shared
     // buffer spanning many experts, so its allocated M only bounds m_tiles from
     // above — the reader/writer index into x at the region offset.
     TT_FATAL(op.m_tiles > 0, "m_tiles must be > 0");
     TT_FATAL(
         op.m_tiles <= x_shape[-2] / TILE, "m_tiles ({}) must be <= x M in tiles ({})", op.m_tiles, x_shape[-2] / TILE);
-    // read_x_at_offset needs expert_region_offsets to locate this expert's x
-    // rows in the shared buffer (the reader fetches start[global_id]).
-    TT_FATAL(
-        !op.read_x_at_offset || t.expert_region_offsets.has_value(), "read_x_at_offset requires expert_region_offsets");
 
-    // Weight tensors share x's storage / layout / memory contract — fail
-    // host-side if the caller forgot to upload one, picked the wrong layout,
-    // or sharded weights (the kernel reader assumes DRAM-interleaved).
-    for (const auto& [name, w] : std::initializer_list<std::pair<const char*, const ttnn::Tensor&>>{
-             {"gate_proj", t.gate_proj}, {"up_proj", t.up_proj}, {"down_proj", t.down_proj}}) {
-        TT_FATAL(w.storage_type() == ttnn::StorageType::DEVICE, "{} must be on device", name);
-        TT_FATAL(w.layout() == tt::tt_metal::Layout::TILE, "{} must be TILE layout", name);
-        TT_FATAL(is_dram_interleaved(w), "{} must be DRAM-interleaved", name);
+    // Every expert's gate/up/down tensor shares x's storage / layout / memory
+    // contract AND must be identical in shape/dtype to expert 0 (the program is
+    // built once for all experts, and the kernels reuse one accessor layout
+    // descriptor per role with only the base address varying per expert).
+    for (uint32_t e = 0; e < op.experts_per_chip; ++e) {
+        for (const auto& [name, w, ref] :
+             std::initializer_list<std::tuple<const char*, const ttnn::Tensor&, const ttnn::Tensor&>>{
+                 {"gate_proj", t.gate_projs[e], t.gate_projs[0]},
+                 {"up_proj", t.up_projs[e], t.up_projs[0]},
+                 {"down_proj", t.down_projs[e], t.down_projs[0]}}) {
+            TT_FATAL(w.storage_type() == ttnn::StorageType::DEVICE, "{}[{}] must be on device", name, e);
+            TT_FATAL(w.layout() == tt::tt_metal::Layout::TILE, "{}[{}] must be TILE layout", name, e);
+            TT_FATAL(is_dram_interleaved(w), "{}[{}] must be DRAM-interleaved", name, e);
+            TT_FATAL(
+                w.padded_shape() == ref.padded_shape() && w.dtype() == ref.dtype(),
+                "{}[{}] shape/dtype ({}, {}) must match expert 0 ({}, {}) — all experts share one program",
+                name,
+                e,
+                w.padded_shape(),
+                w.dtype(),
+                ref.padded_shape(),
+                ref.dtype());
+        }
     }
 
     // Aux tensors: counts / global_expert_idx_table are small UINT32 vectors
@@ -119,16 +144,19 @@ void UnifiedRoutedExpertFfnDeviceOperation::validate_on_program_cache_miss(
             MAX_GLOBAL_EXPERTS);
     }
     TT_FATAL(
-        op.local_expert_id < t.global_expert_idx_table.logical_shape()[-1],
-        "local_expert_id ({}) >= idx_table size ({})",
-        op.local_expert_id,
+        op.experts_per_chip <= t.global_expert_idx_table.logical_shape()[-1],
+        "experts_per_chip ({}) must be <= idx_table size ({})",
+        op.experts_per_chip,
         t.global_expert_idx_table.logical_shape()[-1]);
 
-    // Direct-write mode: expert_region_offsets present => the writer places
-    // this expert's output into the SHARED optional_output buffer at the
-    // expert's region offset (fusing ttnn::insert). Requires optional_output.
-    const bool direct_write = t.expert_region_offsets.has_value();
-    if (direct_write) {
+    // The kernels always read each expert's x slice at its region offset
+    // (fusing ttnn::extract) and write that expert's output into `output` at the
+    // same offset (fusing ttnn::insert), so expert_region_offsets is mandatory.
+    // This op just writes each expert's region into whatever `output` it was given.
+    TT_FATAL(
+        t.expert_region_offsets.has_value(),
+        "expert_region_offsets is required (the kernels read/write per-expert regions)");
+    {
         const auto& start = *t.expert_region_offsets;
         // These mirror ttnn::insert's validate_index_tensor for the `start`
         // tensor: by fusing insert into this op, the FFN now owns the
@@ -163,29 +191,26 @@ void UnifiedRoutedExpertFfnDeviceOperation::validate_on_program_cache_miss(
             "expert_region_offsets length ({}) must equal counts length ({})",
             start_shape[-1],
             t.counts.logical_shape()[-1]);
-        TT_FATAL(
-            t.optional_output.has_value(),
-            "direct-write mode (expert_region_offsets set) requires optional_output (the shared destination buffer)");
     }
 
-    if (t.optional_output.has_value()) {
-        const auto& out = *t.optional_output;
-        TT_FATAL(out.storage_type() == ttnn::StorageType::DEVICE, "optional_output must be on device");
-        TT_FATAL(out.layout() == tt::tt_metal::Layout::TILE, "optional_output must be TILE layout");
-        TT_FATAL(is_dram_interleaved(out), "optional_output must be DRAM-interleaved");
+    {
+        const auto& out = t.output;
+        TT_FATAL(out.storage_type() == ttnn::StorageType::DEVICE, "output must be on device");
+        TT_FATAL(out.layout() == tt::tt_metal::Layout::TILE, "output must be TILE layout");
+        TT_FATAL(is_dram_interleaved(out), "output must be DRAM-interleaved");
         // Output dtype must match x EXCEPT in row-major mode: there x is bf16
         // ROW_MAJOR but the tilized output is bf8_b TILE (for downstream
         // combine), so the two legitimately differ. The tilize/down-matmul packs
         // to the output's dtype regardless.
         TT_FATAL(
             op.x_is_row_major || out.dtype() == t.x.dtype(),
-            "optional_output dtype ({}) must match x dtype ({})",
+            "output dtype ({}) must match x dtype ({})",
             out.dtype(),
             t.x.dtype());
         const auto& out_shape = out.padded_shape();
         TT_FATAL(
             out_shape.rank() == x_shape.rank(),
-            "optional_output rank ({}) must match x rank ({})",
+            "output rank ({}) must match x rank ({})",
             out_shape.rank(),
             x_shape.rank());
         // Common to both modes: the N (emb) dim and all leading dims must match
@@ -193,86 +218,90 @@ void UnifiedRoutedExpertFfnDeviceOperation::validate_on_program_cache_miss(
         // dims index the same logical (1,..,1,M,N) tensor.
         TT_FATAL(
             out_shape[-1] == x_shape[-1],
-            "optional_output last dim ({}) must match x last dim ({})",
+            "output last dim ({}) must match x last dim ({})",
             out_shape[-1],
             x_shape[-1]);
         for (int i = 0; i < static_cast<int>(out_shape.rank()) - 2; ++i) {
             TT_FATAL(
                 out_shape[i] == x_shape[i],
-                "optional_output leading dim {} ({}) must match x ({})",
+                "output leading dim {} ({}) must match x ({})",
                 i,
                 out_shape[i],
                 x_shape[i]);
         }
-        // Mode-specific M (row) dim: direct-write targets the larger shared
-        // buffer (M >= x's M, tile-aligned; the writer bounds rows by
-        // dst_M_tiles); otherwise the output is per-expert and M must match x.
         constexpr uint32_t TILE_H = tt::constants::TILE_HEIGHT;
-        if (direct_write) {
-            TT_FATAL(out_shape[-2] % TILE_H == 0, "optional_output M ({}) must be tile-aligned", out_shape[-2]);
-            TT_FATAL(
-                out_shape[-2] >= x_shape[-2],
-                "optional_output M ({}) must be >= x M ({}) in direct-write mode",
-                out_shape[-2],
-                x_shape[-2]);
-        } else {
-            TT_FATAL(
-                out_shape[-2] == x_shape[-2], "optional_output M ({}) must match x M ({})", out_shape[-2], x_shape[-2]);
-        }
+        TT_FATAL(out_shape[-2] % TILE_H == 0, "output M ({}) must be tile-aligned", out_shape[-2]);
+        TT_FATAL(out_shape[-2] >= x_shape[-2], "output M ({}) must be >= x M ({})", out_shape[-2], x_shape[-2]);
     }
 
-    // Optional expert biases (gpt-oss). All-or-none: gate/up/down together or
-    // none. gate/up bias last dim == gate/up N (hidden); down bias last dim ==
-    // down N (emb). Same device / TILE / DRAM-interleaved contract as weights.
-    const int bias_count = static_cast<int>(t.gate_bias.has_value()) + static_cast<int>(t.up_bias.has_value()) +
-                           static_cast<int>(t.down_bias.has_value());
+    // Optional per-local-expert expert biases (gpt-oss). All-or-none: the three
+    // lists are all empty or all length == experts_per_chip. gate/up bias last
+    // dim == gate/up N (hidden); down bias last dim == down N (emb). Same device
+    // / TILE / DRAM-interleaved contract as weights, and (like the weights) all
+    // experts' biases share one shape/dtype.
+    const int bias_lists = static_cast<int>(!t.gate_biases.empty()) + static_cast<int>(!t.up_biases.empty()) +
+                           static_cast<int>(!t.down_biases.empty());
     TT_FATAL(
-        bias_count == 0 || bias_count == 3,
-        "gate/up/down biases must all be provided together or all omitted (got {} of 3)",
-        bias_count);
-    if (bias_count == 3) {
-        for (const auto& [name, b, expected_n] :
-             std::initializer_list<std::tuple<const char*, const ttnn::Tensor&, uint32_t>>{
-                 {"gate_bias", *t.gate_bias, static_cast<uint32_t>(gate_shape[-1])},
-                 {"up_bias", *t.up_bias, static_cast<uint32_t>(up_shape[-1])},
-                 {"down_bias", *t.down_bias, static_cast<uint32_t>(down_shape[-1])}}) {
-            TT_FATAL(b.storage_type() == ttnn::StorageType::DEVICE, "{} must be on device", name);
-            TT_FATAL(b.layout() == tt::tt_metal::Layout::TILE, "{} must be TILE layout", name);
-            TT_FATAL(is_dram_interleaved(b), "{} must be DRAM-interleaved", name);
-            // Exact LOGICAL shape: a single row of exactly `expected_n` columns. The
-            // padded-width check below is necessary (the kernel/reader address tiles by
-            // padded width) but not sufficient: shapes like (2, N) or (1, N-1) tile-pad
-            // to the same width and would otherwise be accepted and silently mis-applied
-            // (the reader loads only tile-row 0 and the compute kernel row-broadcasts it).
-            const auto& lshape = b.logical_shape();
-            TT_FATAL(
-                static_cast<uint32_t>(lshape[-1]) == expected_n && lshape.volume() == expected_n,
-                "{} logical shape {} must be a single row of its projection N ({})",
-                name,
-                lshape,
-                expected_n);
-            TT_FATAL(
-                static_cast<uint32_t>(b.padded_shape()[-1]) == expected_n,
-                "{} padded last dim ({}) must match its projection N ({})",
-                name,
-                b.padded_shape()[-1],
-                expected_n);
-        }
-        // All three bias CBs are configured from the gate-bias dtype (and the compute
-        // kernel reuses one unpack format across gate/up), so the three biases must share
-        // a single dtype; a mixed-dtype call would read the wrong byte counts/formats.
+        bias_lists == 0 || bias_lists == 3,
+        "gate/up/down bias lists must all be provided together or all omitted (got {} of 3)",
+        bias_lists);
+    const bool has_bias = bias_lists == 3;
+    TT_FATAL(
+        op.fuse_bias == has_bias, "op.fuse_bias ({}) must match presence of bias lists ({})", op.fuse_bias, has_bias);
+    if (has_bias) {
         TT_FATAL(
-            t.up_bias->dtype() == t.gate_bias->dtype() && t.down_bias->dtype() == t.gate_bias->dtype(),
-            "gate/up/down biases must share one dtype (got gate={}, up={}, down={})",
-            t.gate_bias->dtype(),
-            t.up_bias->dtype(),
-            t.down_bias->dtype());
+            t.gate_biases.size() == op.experts_per_chip && t.up_biases.size() == op.experts_per_chip &&
+                t.down_biases.size() == op.experts_per_chip,
+            "each bias list must have experts_per_chip ({}) entries (got {}, {}, {})",
+            op.experts_per_chip,
+            t.gate_biases.size(),
+            t.up_biases.size(),
+            t.down_biases.size());
+        for (uint32_t e = 0; e < op.experts_per_chip; ++e) {
+            for (const auto& [name, b, expected_n] :
+                 std::initializer_list<std::tuple<const char*, const ttnn::Tensor&, uint32_t>>{
+                     {"gate_bias", t.gate_biases[e], static_cast<uint32_t>(gate_shape[-1])},
+                     {"up_bias", t.up_biases[e], static_cast<uint32_t>(up_shape[-1])},
+                     {"down_bias", t.down_biases[e], static_cast<uint32_t>(down_shape[-1])}}) {
+                TT_FATAL(b.storage_type() == ttnn::StorageType::DEVICE, "{}[{}] must be on device", name, e);
+                TT_FATAL(b.layout() == tt::tt_metal::Layout::TILE, "{}[{}] must be TILE layout", name, e);
+                TT_FATAL(is_dram_interleaved(b), "{}[{}] must be DRAM-interleaved", name, e);
+                // Exact LOGICAL shape: a single row of exactly `expected_n` columns. The
+                // padded-width check below is necessary (the kernel/reader address tiles by
+                // padded width) but not sufficient: shapes like (2, N) or (1, N-1) tile-pad
+                // to the same width and would otherwise be accepted and silently mis-applied
+                // (the reader loads only tile-row 0 and the compute kernel row-broadcasts it).
+                const auto& lshape = b.logical_shape();
+                TT_FATAL(
+                    static_cast<uint32_t>(lshape[-1]) == expected_n && lshape.volume() == expected_n,
+                    "{}[{}] logical shape {} must be a single row of its projection N ({})",
+                    name,
+                    e,
+                    lshape,
+                    expected_n);
+                TT_FATAL(
+                    static_cast<uint32_t>(b.padded_shape()[-1]) == expected_n,
+                    "{}[{}] padded last dim ({}) must match its projection N ({})",
+                    name,
+                    e,
+                    b.padded_shape()[-1],
+                    expected_n);
+            }
+            // All bias CBs are configured from the gate-bias dtype (and the compute
+            // kernel reuses one unpack format across gate/up), so every bias must share
+            // a single dtype; a mixed-dtype call would read the wrong byte counts/formats.
+            TT_FATAL(
+                t.up_biases[e].dtype() == t.gate_biases[0].dtype() &&
+                    t.down_biases[e].dtype() == t.gate_biases[0].dtype() &&
+                    t.gate_biases[e].dtype() == t.gate_biases[0].dtype(),
+                "all gate/up/down biases must share one dtype");
+        }
         // Bias fusion is implemented only for the SwiGLU-OAI activation (gpt-oss):
         // the kernel adds gate/up bias before the clamp and down bias after the
         // down matmul. The SiLU path has no bias branch.
         TT_FATAL(
             op.activation == RoutedExpertActivation::SwiGluOai,
-            "unified_routed_expert_ffn: expert biases are only supported with RoutedExpertActivation::SwiGluOai "
+            "unified_routed_expert_moe: expert biases are only supported with RoutedExpertActivation::SwiGluOai "
             "(got the SiLU path).");
     }
 }
@@ -282,73 +311,57 @@ void UnifiedRoutedExpertFfnDeviceOperation::validate_on_program_cache_hit(
 
 UnifiedRoutedExpertFfnDeviceOperation::spec_return_value_t UnifiedRoutedExpertFfnDeviceOperation::compute_output_specs(
     const operation_attributes_t&, const tensor_args_t& t) {
-    if (t.optional_output.has_value()) {
-        return t.optional_output->tensor_spec();
-    }
-    const ttnn::Shape output_shape(t.x.padded_shape());
-    const auto mem =
-        tt::tt_metal::MemoryConfig{tt::tt_metal::TensorMemoryLayout::INTERLEAVED, tt::tt_metal::BufferType::DRAM};
-    return tt::tt_metal::TensorSpec(
-        output_shape,
-        tt::tt_metal::TensorLayout(t.x.dtype(), tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE), mem));
+    return t.output.tensor_spec();
 }
 
 UnifiedRoutedExpertFfnDeviceOperation::tensor_return_value_t
-UnifiedRoutedExpertFfnDeviceOperation::create_output_tensors(
-    const operation_attributes_t& op, const tensor_args_t& t) {
-    if (t.optional_output.has_value()) {
-        return *t.optional_output;
-    }
-    return create_device_tensor(compute_output_specs(op, t), t.x.device());
+UnifiedRoutedExpertFfnDeviceOperation::create_output_tensors(const operation_attributes_t&, const tensor_args_t& t) {
+    return t.output;
 }
 
 }  // namespace ttnn::operations::experimental::deepseek_prefill::unified_routed_expert_ffn
 
 namespace ttnn::prim {
 
-ttnn::Tensor unified_routed_expert_ffn(
+ttnn::Tensor unified_routed_expert_moe(
     const ttnn::Tensor& x,
-    const ttnn::Tensor& gate_proj,
-    const ttnn::Tensor& up_proj,
-    const ttnn::Tensor& down_proj,
+    const std::vector<ttnn::Tensor>& gate_projs,
+    const std::vector<ttnn::Tensor>& up_projs,
+    const std::vector<ttnn::Tensor>& down_projs,
     const ttnn::Tensor& counts,
     const ttnn::Tensor& global_expert_idx_table,
-    uint32_t local_expert_id,
-    uint32_t chunk_M_tiles,
+    const ttnn::Tensor& expert_region_offsets,
+    const ttnn::Tensor& output,
     uint32_t m_tiles,
-    bool read_x_at_offset,
+    uint32_t experts_per_chip,
     bool x_is_row_major,
     const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config,
-    const std::optional<ttnn::Tensor>& optional_output,
-    const std::optional<ttnn::Tensor>& expert_region_offsets,
     ttnn::operations::experimental::deepseek_prefill::unified_routed_expert_ffn::RoutedExpertActivation activation,
-    const std::optional<ttnn::Tensor>& gate_bias,
-    const std::optional<ttnn::Tensor>& up_bias,
-    const std::optional<ttnn::Tensor>& down_bias) {
+    const std::vector<ttnn::Tensor>& gate_biases,
+    const std::vector<ttnn::Tensor>& up_biases,
+    const std::vector<ttnn::Tensor>& down_biases) {
     using OperationType =
         ttnn::operations::experimental::deepseek_prefill::unified_routed_expert_ffn::UnifiedRoutedExpertFfnDeviceOperation;
     return ttnn::device_operation::launch<OperationType>(
         OperationType::operation_attributes_t{
-            .chunk_M_tiles = chunk_M_tiles,
             .m_tiles = m_tiles,
-            .local_expert_id = local_expert_id,
-            .read_x_at_offset = read_x_at_offset,
+            .experts_per_chip = experts_per_chip,
             .x_is_row_major = x_is_row_major,
             .activation = activation,
-            .fuse_bias = gate_bias.has_value(),
+            .fuse_bias = !gate_biases.empty(),
             .compute_kernel_config = compute_kernel_config},
         OperationType::tensor_args_t{
             .x = x,
-            .gate_proj = gate_proj,
-            .up_proj = up_proj,
-            .down_proj = down_proj,
+            .gate_projs = gate_projs,
+            .up_projs = up_projs,
+            .down_projs = down_projs,
             .counts = counts,
             .global_expert_idx_table = global_expert_idx_table,
-            .optional_output = optional_output,
+            .output = output,
             .expert_region_offsets = expert_region_offsets,
-            .gate_bias = gate_bias,
-            .up_bias = up_bias,
-            .down_bias = down_bias});
+            .gate_biases = gate_biases,
+            .up_biases = up_biases,
+            .down_biases = down_biases});
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_device_operation.cpp
@@ -61,10 +61,25 @@ void UnifiedRoutedExpertFfnDeviceOperation::validate_on_program_cache_miss(
         TT_FATAL(t.x.logical_shape()[i] == 1, "x leading dim {} must be 1, got {}", i, t.x.logical_shape()[i]);
     }
 
+    // Per-local-expert weight lists: one entry per expert, all identical shape.
+    // The kernels loop over experts and index a per-expert address array, so the
+    // three lists must be non-empty, equal-length, and match experts_per_chip.
+    TT_FATAL(
+        !t.gate_projs.empty() && t.gate_projs.size() == t.up_projs.size() && t.gate_projs.size() == t.down_projs.size(),
+        "gate/up/down projection lists must be non-empty and equal length (got {}, {}, {})",
+        t.gate_projs.size(),
+        t.up_projs.size(),
+        t.down_projs.size());
+    TT_FATAL(
+        t.gate_projs.size() == op.experts_per_chip,
+        "weight-list length ({}) must equal experts_per_chip ({})",
+        t.gate_projs.size(),
+        op.experts_per_chip);
+
     const auto& x_shape = t.x.padded_shape();
-    const auto& gate_shape = t.gate_proj.padded_shape();
-    const auto& up_shape = t.up_proj.padded_shape();
-    const auto& down_shape = t.down_proj.padded_shape();
+    const auto& gate_shape = t.gate_projs[0].padded_shape();
+    const auto& up_shape = t.up_projs[0].padded_shape();
+    const auto& down_shape = t.down_projs[0].padded_shape();
 
     TT_FATAL(
         x_shape[-1] == gate_shape[-2] && x_shape[-1] == up_shape[-2],
@@ -81,26 +96,36 @@ void UnifiedRoutedExpertFfnDeviceOperation::validate_on_program_cache_miss(
 
     constexpr uint32_t TILE = tt::constants::TILE_HEIGHT;
     TT_FATAL(x_shape[-2] % TILE == 0, "x M ({}) must be tile-aligned", x_shape[-2]);
-    TT_FATAL(op.chunk_M_tiles > 0, "chunk_M_tiles must be > 0");
     // m_tiles is this expert's M (grid/chunk/CB sizing). x may be a shared
     // buffer spanning many experts, so its allocated M only bounds m_tiles from
     // above — the reader/writer index into x at the region offset.
     TT_FATAL(op.m_tiles > 0, "m_tiles must be > 0");
     TT_FATAL(
         op.m_tiles <= x_shape[-2] / TILE, "m_tiles ({}) must be <= x M in tiles ({})", op.m_tiles, x_shape[-2] / TILE);
-    // read_x_at_offset needs expert_region_offsets to locate this expert's x
-    // rows in the shared buffer (the reader fetches start[global_id]).
-    TT_FATAL(
-        !op.read_x_at_offset || t.expert_region_offsets.has_value(), "read_x_at_offset requires expert_region_offsets");
 
-    // Weight tensors share x's storage / layout / memory contract — fail
-    // host-side if the caller forgot to upload one, picked the wrong layout,
-    // or sharded weights (the kernel reader assumes DRAM-interleaved).
-    for (const auto& [name, w] : std::initializer_list<std::pair<const char*, const ttnn::Tensor&>>{
-             {"gate_proj", t.gate_proj}, {"up_proj", t.up_proj}, {"down_proj", t.down_proj}}) {
-        TT_FATAL(w.storage_type() == ttnn::StorageType::DEVICE, "{} must be on device", name);
-        TT_FATAL(w.layout() == tt::tt_metal::Layout::TILE, "{} must be TILE layout", name);
-        TT_FATAL(is_dram_interleaved(w), "{} must be DRAM-interleaved", name);
+    // Every expert's gate/up/down tensor shares x's storage / layout / memory
+    // contract AND must be identical in shape/dtype to expert 0 (the program is
+    // built once for all experts, and the kernels reuse one accessor layout
+    // descriptor per role with only the base address varying per expert).
+    for (uint32_t e = 0; e < op.experts_per_chip; ++e) {
+        for (const auto& [name, w, ref] :
+             std::initializer_list<std::tuple<const char*, const ttnn::Tensor&, const ttnn::Tensor&>>{
+                 {"gate_proj", t.gate_projs[e], t.gate_projs[0]},
+                 {"up_proj", t.up_projs[e], t.up_projs[0]},
+                 {"down_proj", t.down_projs[e], t.down_projs[0]}}) {
+            TT_FATAL(w.storage_type() == ttnn::StorageType::DEVICE, "{}[{}] must be on device", name, e);
+            TT_FATAL(w.layout() == tt::tt_metal::Layout::TILE, "{}[{}] must be TILE layout", name, e);
+            TT_FATAL(is_dram_interleaved(w), "{}[{}] must be DRAM-interleaved", name, e);
+            TT_FATAL(
+                w.padded_shape() == ref.padded_shape() && w.dtype() == ref.dtype(),
+                "{}[{}] shape/dtype ({}, {}) must match expert 0 ({}, {}) — all experts share one program",
+                name,
+                e,
+                w.padded_shape(),
+                w.dtype(),
+                ref.padded_shape(),
+                ref.dtype());
+        }
     }
 
     // Aux tensors: counts / global_expert_idx_table are small UINT32 vectors
@@ -127,16 +152,19 @@ void UnifiedRoutedExpertFfnDeviceOperation::validate_on_program_cache_miss(
             MAX_GLOBAL_EXPERTS);
     }
     TT_FATAL(
-        op.local_expert_id < t.global_expert_idx_table.logical_shape()[-1],
-        "local_expert_id ({}) >= idx_table size ({})",
-        op.local_expert_id,
+        op.experts_per_chip <= t.global_expert_idx_table.logical_shape()[-1],
+        "experts_per_chip ({}) must be <= idx_table size ({})",
+        op.experts_per_chip,
         t.global_expert_idx_table.logical_shape()[-1]);
 
-    // Direct-write mode: expert_region_offsets present => the writer places
-    // this expert's output into the SHARED optional_output buffer at the
-    // expert's region offset (fusing ttnn::insert). Requires optional_output.
-    const bool direct_write = t.expert_region_offsets.has_value();
-    if (direct_write) {
+    // The kernels always read each expert's x slice at its region offset
+    // (fusing ttnn::extract) and write that expert's output into `output` at the
+    // same offset (fusing ttnn::insert), so expert_region_offsets is mandatory.
+    // This op just writes each expert's region into whatever `output` it was given.
+    TT_FATAL(
+        t.expert_region_offsets.has_value(),
+        "expert_region_offsets is required (the kernels read/write per-expert regions)");
+    {
         const auto& start = *t.expert_region_offsets;
         // These mirror ttnn::insert's validate_index_tensor for the `start`
         // tensor: by fusing insert into this op, the FFN now owns the
@@ -171,29 +199,26 @@ void UnifiedRoutedExpertFfnDeviceOperation::validate_on_program_cache_miss(
             "expert_region_offsets length ({}) must equal counts length ({})",
             start_shape[-1],
             t.counts.logical_shape()[-1]);
-        TT_FATAL(
-            t.optional_output.has_value(),
-            "direct-write mode (expert_region_offsets set) requires optional_output (the shared destination buffer)");
     }
 
-    if (t.optional_output.has_value()) {
-        const auto& out = *t.optional_output;
-        TT_FATAL(out.storage_type() == ttnn::StorageType::DEVICE, "optional_output must be on device");
-        TT_FATAL(out.layout() == tt::tt_metal::Layout::TILE, "optional_output must be TILE layout");
-        TT_FATAL(is_dram_interleaved(out), "optional_output must be DRAM-interleaved");
+    {
+        const auto& out = t.output;
+        TT_FATAL(out.storage_type() == ttnn::StorageType::DEVICE, "output must be on device");
+        TT_FATAL(out.layout() == tt::tt_metal::Layout::TILE, "output must be TILE layout");
+        TT_FATAL(is_dram_interleaved(out), "output must be DRAM-interleaved");
         // Output dtype must match x EXCEPT in row-major mode: there x is bf16
         // ROW_MAJOR but the tilized output is bf8_b TILE (for downstream
         // combine), so the two legitimately differ. The tilize/down-matmul packs
         // to the output's dtype regardless.
         TT_FATAL(
             op.x_is_row_major || out.dtype() == t.x.dtype(),
-            "optional_output dtype ({}) must match x dtype ({})",
+            "output dtype ({}) must match x dtype ({})",
             out.dtype(),
             t.x.dtype());
         const auto& out_shape = out.padded_shape();
         TT_FATAL(
             out_shape.rank() == x_shape.rank(),
-            "optional_output rank ({}) must match x rank ({})",
+            "output rank ({}) must match x rank ({})",
             out_shape.rank(),
             x_shape.rank());
         // Common to both modes: the N (emb) dim and all leading dims must match
@@ -201,86 +226,90 @@ void UnifiedRoutedExpertFfnDeviceOperation::validate_on_program_cache_miss(
         // dims index the same logical (1,..,1,M,N) tensor.
         TT_FATAL(
             out_shape[-1] == x_shape[-1],
-            "optional_output last dim ({}) must match x last dim ({})",
+            "output last dim ({}) must match x last dim ({})",
             out_shape[-1],
             x_shape[-1]);
         for (int i = 0; i < static_cast<int>(out_shape.rank()) - 2; ++i) {
             TT_FATAL(
                 out_shape[i] == x_shape[i],
-                "optional_output leading dim {} ({}) must match x ({})",
+                "output leading dim {} ({}) must match x ({})",
                 i,
                 out_shape[i],
                 x_shape[i]);
         }
-        // Mode-specific M (row) dim: direct-write targets the larger shared
-        // buffer (M >= x's M, tile-aligned; the writer bounds rows by
-        // dst_M_tiles); otherwise the output is per-expert and M must match x.
         constexpr uint32_t TILE_H = tt::constants::TILE_HEIGHT;
-        if (direct_write) {
-            TT_FATAL(out_shape[-2] % TILE_H == 0, "optional_output M ({}) must be tile-aligned", out_shape[-2]);
-            TT_FATAL(
-                out_shape[-2] >= x_shape[-2],
-                "optional_output M ({}) must be >= x M ({}) in direct-write mode",
-                out_shape[-2],
-                x_shape[-2]);
-        } else {
-            TT_FATAL(
-                out_shape[-2] == x_shape[-2], "optional_output M ({}) must match x M ({})", out_shape[-2], x_shape[-2]);
-        }
+        TT_FATAL(out_shape[-2] % TILE_H == 0, "output M ({}) must be tile-aligned", out_shape[-2]);
+        TT_FATAL(out_shape[-2] >= x_shape[-2], "output M ({}) must be >= x M ({})", out_shape[-2], x_shape[-2]);
     }
 
-    // Optional expert biases (gpt-oss). All-or-none: gate/up/down together or
-    // none. gate/up bias last dim == gate/up N (hidden); down bias last dim ==
-    // down N (emb). Same device / TILE / DRAM-interleaved contract as weights.
-    const int bias_count = static_cast<int>(t.gate_bias.has_value()) + static_cast<int>(t.up_bias.has_value()) +
-                           static_cast<int>(t.down_bias.has_value());
+    // Optional per-local-expert expert biases (gpt-oss). All-or-none: the three
+    // lists are all empty or all length == experts_per_chip. gate/up bias last
+    // dim == gate/up N (hidden); down bias last dim == down N (emb). Same device
+    // / TILE / DRAM-interleaved contract as weights, and (like the weights) all
+    // experts' biases share one shape/dtype.
+    const int bias_lists = static_cast<int>(!t.gate_biases.empty()) + static_cast<int>(!t.up_biases.empty()) +
+                           static_cast<int>(!t.down_biases.empty());
     TT_FATAL(
-        bias_count == 0 || bias_count == 3,
-        "gate/up/down biases must all be provided together or all omitted (got {} of 3)",
-        bias_count);
-    if (bias_count == 3) {
-        for (const auto& [name, b, expected_n] :
-             std::initializer_list<std::tuple<const char*, const ttnn::Tensor&, uint32_t>>{
-                 {"gate_bias", *t.gate_bias, static_cast<uint32_t>(gate_shape[-1])},
-                 {"up_bias", *t.up_bias, static_cast<uint32_t>(up_shape[-1])},
-                 {"down_bias", *t.down_bias, static_cast<uint32_t>(down_shape[-1])}}) {
-            TT_FATAL(b.storage_type() == ttnn::StorageType::DEVICE, "{} must be on device", name);
-            TT_FATAL(b.layout() == tt::tt_metal::Layout::TILE, "{} must be TILE layout", name);
-            TT_FATAL(is_dram_interleaved(b), "{} must be DRAM-interleaved", name);
-            // Exact LOGICAL shape: a single row of exactly `expected_n` columns. The
-            // padded-width check below is necessary (the kernel/reader address tiles by
-            // padded width) but not sufficient: shapes like (2, N) or (1, N-1) tile-pad
-            // to the same width and would otherwise be accepted and silently mis-applied
-            // (the reader loads only tile-row 0 and the compute kernel row-broadcasts it).
-            const auto& lshape = b.logical_shape();
-            TT_FATAL(
-                static_cast<uint32_t>(lshape[-1]) == expected_n && lshape.volume() == expected_n,
-                "{} logical shape {} must be a single row of its projection N ({})",
-                name,
-                lshape,
-                expected_n);
-            TT_FATAL(
-                static_cast<uint32_t>(b.padded_shape()[-1]) == expected_n,
-                "{} padded last dim ({}) must match its projection N ({})",
-                name,
-                b.padded_shape()[-1],
-                expected_n);
-        }
-        // All three bias CBs are configured from the gate-bias dtype (and the compute
-        // kernel reuses one unpack format across gate/up), so the three biases must share
-        // a single dtype; a mixed-dtype call would read the wrong byte counts/formats.
+        bias_lists == 0 || bias_lists == 3,
+        "gate/up/down bias lists must all be provided together or all omitted (got {} of 3)",
+        bias_lists);
+    const bool has_bias = bias_lists == 3;
+    TT_FATAL(
+        op.fuse_bias == has_bias, "op.fuse_bias ({}) must match presence of bias lists ({})", op.fuse_bias, has_bias);
+    if (has_bias) {
         TT_FATAL(
-            t.up_bias->dtype() == t.gate_bias->dtype() && t.down_bias->dtype() == t.gate_bias->dtype(),
-            "gate/up/down biases must share one dtype (got gate={}, up={}, down={})",
-            t.gate_bias->dtype(),
-            t.up_bias->dtype(),
-            t.down_bias->dtype());
+            t.gate_biases.size() == op.experts_per_chip && t.up_biases.size() == op.experts_per_chip &&
+                t.down_biases.size() == op.experts_per_chip,
+            "each bias list must have experts_per_chip ({}) entries (got {}, {}, {})",
+            op.experts_per_chip,
+            t.gate_biases.size(),
+            t.up_biases.size(),
+            t.down_biases.size());
+        for (uint32_t e = 0; e < op.experts_per_chip; ++e) {
+            for (const auto& [name, b, expected_n] :
+                 std::initializer_list<std::tuple<const char*, const ttnn::Tensor&, uint32_t>>{
+                     {"gate_bias", t.gate_biases[e], static_cast<uint32_t>(gate_shape[-1])},
+                     {"up_bias", t.up_biases[e], static_cast<uint32_t>(up_shape[-1])},
+                     {"down_bias", t.down_biases[e], static_cast<uint32_t>(down_shape[-1])}}) {
+                TT_FATAL(b.storage_type() == ttnn::StorageType::DEVICE, "{}[{}] must be on device", name, e);
+                TT_FATAL(b.layout() == tt::tt_metal::Layout::TILE, "{}[{}] must be TILE layout", name, e);
+                TT_FATAL(is_dram_interleaved(b), "{}[{}] must be DRAM-interleaved", name, e);
+                // Exact LOGICAL shape: a single row of exactly `expected_n` columns. The
+                // padded-width check below is necessary (the kernel/reader address tiles by
+                // padded width) but not sufficient: shapes like (2, N) or (1, N-1) tile-pad
+                // to the same width and would otherwise be accepted and silently mis-applied
+                // (the reader loads only tile-row 0 and the compute kernel row-broadcasts it).
+                const auto& lshape = b.logical_shape();
+                TT_FATAL(
+                    static_cast<uint32_t>(lshape[-1]) == expected_n && lshape.volume() == expected_n,
+                    "{}[{}] logical shape {} must be a single row of its projection N ({})",
+                    name,
+                    e,
+                    lshape,
+                    expected_n);
+                TT_FATAL(
+                    static_cast<uint32_t>(b.padded_shape()[-1]) == expected_n,
+                    "{}[{}] padded last dim ({}) must match its projection N ({})",
+                    name,
+                    e,
+                    b.padded_shape()[-1],
+                    expected_n);
+            }
+            // All bias CBs are configured from the gate-bias dtype (and the compute
+            // kernel reuses one unpack format across gate/up), so every bias must share
+            // a single dtype; a mixed-dtype call would read the wrong byte counts/formats.
+            TT_FATAL(
+                t.up_biases[e].dtype() == t.gate_biases[0].dtype() &&
+                    t.down_biases[e].dtype() == t.gate_biases[0].dtype() &&
+                    t.gate_biases[e].dtype() == t.gate_biases[0].dtype(),
+                "all gate/up/down biases must share one dtype");
+        }
         // Bias fusion lives in the kernel's shared binary-activation phase and is
         // activation-agnostic, so every fused binary activation supports it. Only the SiLU
         // path has no bias branch.
         TT_FATAL(
             op.activation == RoutedExpertActivation::SwiGluOai || op.activation == RoutedExpertActivation::SituGlu,
-            "unified_routed_expert_ffn: expert biases require a fused binary activation "
+            "unified_routed_expert_moe: expert biases require a fused binary activation "
             "(SwiGluOai or SituGlu); the SiLU path has no bias branch.");
     }
 }
@@ -290,73 +319,57 @@ void UnifiedRoutedExpertFfnDeviceOperation::validate_on_program_cache_hit(
 
 UnifiedRoutedExpertFfnDeviceOperation::spec_return_value_t UnifiedRoutedExpertFfnDeviceOperation::compute_output_specs(
     const operation_attributes_t&, const tensor_args_t& t) {
-    if (t.optional_output.has_value()) {
-        return t.optional_output->tensor_spec();
-    }
-    const ttnn::Shape output_shape(t.x.padded_shape());
-    const auto mem =
-        tt::tt_metal::MemoryConfig{tt::tt_metal::TensorMemoryLayout::INTERLEAVED, tt::tt_metal::BufferType::DRAM};
-    return tt::tt_metal::TensorSpec(
-        output_shape,
-        tt::tt_metal::TensorLayout(t.x.dtype(), tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE), mem));
+    return t.output.tensor_spec();
 }
 
 UnifiedRoutedExpertFfnDeviceOperation::tensor_return_value_t
-UnifiedRoutedExpertFfnDeviceOperation::create_output_tensors(
-    const operation_attributes_t& op, const tensor_args_t& t) {
-    if (t.optional_output.has_value()) {
-        return *t.optional_output;
-    }
-    return create_device_tensor(compute_output_specs(op, t), t.x.device());
+UnifiedRoutedExpertFfnDeviceOperation::create_output_tensors(const operation_attributes_t&, const tensor_args_t& t) {
+    return t.output;
 }
 
 }  // namespace ttnn::operations::experimental::deepseek_prefill::unified_routed_expert_ffn
 
 namespace ttnn::prim {
 
-ttnn::Tensor unified_routed_expert_ffn(
+ttnn::Tensor unified_routed_expert_moe(
     const ttnn::Tensor& x,
-    const ttnn::Tensor& gate_proj,
-    const ttnn::Tensor& up_proj,
-    const ttnn::Tensor& down_proj,
+    const std::vector<ttnn::Tensor>& gate_projs,
+    const std::vector<ttnn::Tensor>& up_projs,
+    const std::vector<ttnn::Tensor>& down_projs,
     const ttnn::Tensor& counts,
     const ttnn::Tensor& global_expert_idx_table,
-    uint32_t local_expert_id,
-    uint32_t chunk_M_tiles,
+    const ttnn::Tensor& expert_region_offsets,
+    const ttnn::Tensor& output,
     uint32_t m_tiles,
-    bool read_x_at_offset,
+    uint32_t experts_per_chip,
     bool x_is_row_major,
     const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config,
-    const std::optional<ttnn::Tensor>& optional_output,
-    const std::optional<ttnn::Tensor>& expert_region_offsets,
     ttnn::operations::experimental::deepseek_prefill::unified_routed_expert_ffn::RoutedExpertActivation activation,
-    const std::optional<ttnn::Tensor>& gate_bias,
-    const std::optional<ttnn::Tensor>& up_bias,
-    const std::optional<ttnn::Tensor>& down_bias) {
+    const std::vector<ttnn::Tensor>& gate_biases,
+    const std::vector<ttnn::Tensor>& up_biases,
+    const std::vector<ttnn::Tensor>& down_biases) {
     using OperationType =
         ttnn::operations::experimental::deepseek_prefill::unified_routed_expert_ffn::UnifiedRoutedExpertFfnDeviceOperation;
     return ttnn::device_operation::launch<OperationType>(
         OperationType::operation_attributes_t{
-            .chunk_M_tiles = chunk_M_tiles,
             .m_tiles = m_tiles,
-            .local_expert_id = local_expert_id,
-            .read_x_at_offset = read_x_at_offset,
+            .experts_per_chip = experts_per_chip,
             .x_is_row_major = x_is_row_major,
             .activation = activation,
-            .fuse_bias = gate_bias.has_value(),
+            .fuse_bias = !gate_biases.empty(),
             .compute_kernel_config = compute_kernel_config},
         OperationType::tensor_args_t{
             .x = x,
-            .gate_proj = gate_proj,
-            .up_proj = up_proj,
-            .down_proj = down_proj,
+            .gate_projs = gate_projs,
+            .up_projs = up_projs,
+            .down_projs = down_projs,
             .counts = counts,
             .global_expert_idx_table = global_expert_idx_table,
-            .optional_output = optional_output,
+            .output = output,
             .expert_region_offsets = expert_region_offsets,
-            .gate_bias = gate_bias,
-            .up_bias = up_bias,
-            .down_bias = down_bias});
+            .gate_biases = gate_biases,
+            .up_biases = up_biases,
+            .down_biases = down_biases});
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_device_operation.hpp
@@ -32,25 +32,25 @@ struct UnifiedRoutedExpertFfnDeviceOperation {
 
 namespace ttnn::prim {
 
-ttnn::Tensor unified_routed_expert_ffn(
+// Single-program multi-expert MoE FFN. The device program's kernels loop over all
+// `experts_per_chip` local experts, running the full gate/up/down FFN for each.
+ttnn::Tensor unified_routed_expert_moe(
     const ttnn::Tensor& x,
-    const ttnn::Tensor& gate_proj,
-    const ttnn::Tensor& up_proj,
-    const ttnn::Tensor& down_proj,
+    const std::vector<ttnn::Tensor>& gate_projs,
+    const std::vector<ttnn::Tensor>& up_projs,
+    const std::vector<ttnn::Tensor>& down_projs,
     const ttnn::Tensor& counts,
     const ttnn::Tensor& global_expert_idx_table,
-    uint32_t local_expert_id,
-    uint32_t chunk_M_tiles,
+    const ttnn::Tensor& expert_region_offsets,
+    const ttnn::Tensor& output,
     uint32_t m_tiles,
-    bool read_x_at_offset,
+    uint32_t experts_per_chip,
     bool x_is_row_major,
     const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config,
-    const std::optional<ttnn::Tensor>& optional_output,
-    const std::optional<ttnn::Tensor>& expert_region_offsets = std::nullopt,
     ttnn::operations::experimental::deepseek_prefill::unified_routed_expert_ffn::RoutedExpertActivation activation =
         ttnn::operations::experimental::deepseek_prefill::unified_routed_expert_ffn::RoutedExpertActivation::Silu,
-    const std::optional<ttnn::Tensor>& gate_bias = std::nullopt,
-    const std::optional<ttnn::Tensor>& up_bias = std::nullopt,
-    const std::optional<ttnn::Tensor>& down_bias = std::nullopt);
+    const std::vector<ttnn::Tensor>& gate_biases = {},
+    const std::vector<ttnn::Tensor>& up_biases = {},
+    const std::vector<ttnn::Tensor>& down_biases = {});
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_program_factory.cpp
@@ -48,11 +48,11 @@ constexpr uint32_t CB_IN0_DOWN_FULL = tt::CBIndex::c_12;
 // per K-block feeds both matmuls instead of two.
 constexpr uint32_t CB_PARTIALS_UP = tt::CBIndex::c_13;
 // Writer-only scratch for the device-side `start` (expert_region_offsets)
-// page in direct-write mode. Allocated unconditionally (negligible L1) so
-// the CB-index layout is stable across both write modes.
+// page: the writer adds start[global_id]/TILE tile-rows to every output row.
 constexpr uint32_t CB_START_SCRATCH = tt::CBIndex::c_14;
-// Reader's own `start` scratch, used when read_x_at_offset (x is a shared
-// buffer). Separate from the writer's so the two RISCs don't share one L1 page.
+// Reader's own `start` scratch (x is the shared dispatched buffer, so the
+// reader offsets its x reads by start[global_id] too). Separate from the
+// writer's so the two RISCs don't share one L1 page.
 constexpr uint32_t CB_START_SCRATCH_READER = tt::CBIndex::c_15;
 // Row-major bf16 staging for x when x_is_row_major: the reader fills it with
 // row-major sticks and the compute kernel tilizes it to bf8_b into CB_IN0_X.
@@ -405,17 +405,13 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
     auto* idx_buffer = t.global_expert_idx_table.buffer();
     auto* out_buffer = tensor_return_value.buffer();
 
-    // Direct-write mode: when expert_region_offsets is supplied, the writer
-    // writes this expert's output straight into the shared output buffer at
-    // start[global_id]/TILE tile-rows (fusing ttnn::insert). Otherwise the
-    // writer targets tile row 0 of a per-expert buffer. The `start` accessor
-    // is appended unconditionally so the writer's CT-arg layout is stable;
-    // when not in direct-write mode it points at out_buffer and is never read.
-    const bool direct_write = t.expert_region_offsets.has_value();
-    auto* start_buffer = direct_write ? t.expert_region_offsets->buffer() : out_buffer;
-    // dst_M_tiles bounds destination writes. Equals M_tiles_full when the
-    // output matches x's shape; is the shared buffer's tile-row count in
-    // direct-write mode.
+    // expert_region_offsets is a mandatory input (validated in the device op):
+    // the writer always writes an expert's output straight into the shared
+    // output buffer at start[global_id]/TILE tile-rows (fusing ttnn::insert),
+    // and the reader always reads x from the same region.
+    auto* start_buffer = t.expert_region_offsets->buffer();
+    // dst_M_tiles bounds destination writes: the shared output buffer's
+    // tile-row count.
     const uint32_t dst_M_tiles = tensor_return_value.padded_shape()[-2] / TILE;
 
     // -------------------------- semaphores --------------------------------
@@ -600,7 +596,7 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
         tt::tt_metal::CircularBufferConfig(start_scratch_bytes, {{CB_START_SCRATCH, tt::DataFormat::UInt32}})
             .set_page_size(CB_START_SCRATCH, start_scratch_bytes);
     tt::tt_metal::CreateCircularBuffer(program, core_range_set, start_cb_cfg);
-    // Reader's `start` scratch (read_x_at_offset). Same sizing; separate CB so
+    // Reader's `start` scratch. Same sizing; separate CB so
     // reader (BRISC) and writer (NCRISC) never share one scratch page.
     tt::tt_metal::CircularBufferConfig start_reader_cb_cfg =
         tt::tt_metal::CircularBufferConfig(start_scratch_bytes, {{CB_START_SCRATCH_READER, tt::DataFormat::UInt32}})
@@ -678,9 +674,9 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
     tt::tt_metal::TensorAccessorArgs(down_buffer).append_to(reader_ct_args);
     tt::tt_metal::TensorAccessorArgs(counts_buffer).append_to(reader_ct_args);
     tt::tt_metal::TensorAccessorArgs(idx_buffer).append_to(reader_ct_args);
-    // `start` accessor — appended last, matching the reader's accessor stream.
-    // Points at expert_region_offsets in direct/offset mode, else out_buffer
-    // (unread when read_x_at_offset is 0), keeping the CT-arg layout stable.
+    // `start` (= expert_region_offsets) accessor — appended last, matching the
+    // reader's accessor stream. Always read: x is the shared dispatched buffer
+    // and each expert's rows begin at start[global_id].
     tt::tt_metal::TensorAccessorArgs(start_buffer).append_to(reader_ct_args);
 
     // FUSE_BIAS: after the `start` accessor, append the 3 bias CB ids then the 3
@@ -708,51 +704,45 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
 
     // Writer compile-time args (must match writer's get_compile_time_arg_val order).
     std::vector<uint32_t> writer_ct_args = {
-        CB_ACTIVATED,       // 0
-        CB_OUT,             // 1
-        per_core_M,         // 2
-        per_core_N_gu,      // 3
-        per_core_N_d,       // 4
-        gu_out_subblock_h,  // 5
-        gu_out_subblock_w,  // 6
-        d_out_subblock_h,   // 7
-        d_out_subblock_w,   // 8
-        N_gate_tiles_full,  // 9
-        N_down_tiles_full,  // 10
-        num_chunks,         // 11
-        chunk_M_tiles,      // 12
+        CB_OUT,             // 0
+        per_core_M,         // 1
+        per_core_N_gu,      // 2
+        per_core_N_d,       // 3
+        d_out_subblock_h,   // 4
+        d_out_subblock_w,   // 5
+        N_gate_tiles_full,  // 6
+        N_down_tiles_full,  // 7
+        num_chunks,         // 8
+        chunk_M_tiles,      // 9
         // device-side count read: writer also waits on the reader's push
         // and bounds its cb_out drain loop by effective_chunks so it does
         // not wait forever on chunks compute never pushes.
-        CB_COUNTS_SCRATCH,  // 13
-        CB_IDX_SCRATCH,     // 14
-        experts_per_chip,   // 15
+        CB_COUNTS_SCRATCH,  // 10
+        CB_IDX_SCRATCH,     // 11
+        experts_per_chip,   // 12
         // M_tiles_full: needed for the writer to skip OOB output writes when
         // M_tiles_full doesn't divide chunk_M_tiles. The last chunk runs
         // chunk_M_tiles rows per core, of which only those < M_tiles_full
         // correspond to real output rows in the tensor.
-        M_tiles_full,  // 16
-        // direct_write: 1 -> writer adds start[global_id]/TILE tile-rows and
-        // targets the shared output buffer (fuses ttnn::insert).
-        static_cast<uint32_t>(direct_write),  // 17
-        // dst_M_tiles: tile-row count of the destination buffer (= M_tiles_full
-        // for the per-expert output; the shared buffer's rows in direct mode).
-        dst_M_tiles,       // 18
-        CB_START_SCRATCH,  // 19
+        M_tiles_full,  // 13
+        // dst_M_tiles: tile-row count of the shared destination buffer, which
+        // bounds the writer's destination rows.
+        dst_M_tiles,       // 14
+        CB_START_SCRATCH,  // 15
         // UP_SPLIT up-weight read: CB + dims let the writer replicate the gate
         // read on NoC 1, and writer_split_up gates it (1 = UP_SPLIT).
-        CB_IN1_UP,                            // 20
-        in0_block_w_gu,                       // 21
-        K_gate_tiles,                         // 22
-        static_cast<uint32_t>(up_mode == 2),  // 23 writer_split_up
+        CB_IN1_UP,                            // 16
+        in0_block_w_gu,                       // 17
+        K_gate_tiles,                         // 18
+        static_cast<uint32_t>(up_mode == 2),  // 19 writer_split_up
         // down_k_tail_skip: when the compute tail-skips the last down block's
         // K padding, the down matmul never reduces the N-OOB hidden columns, so
         // the writer's `up` read can skip zero-filling them. Must match the
         // reader's identically-derived constexpr.
-        static_cast<uint32_t>((K_down_tiles_padded - K_down_tiles) < in0_block_w_d),  // 24 down_k_tail_skip
+        static_cast<uint32_t>((K_down_tiles_padded - K_down_tiles) < in0_block_w_d),  // 20 down_k_tail_skip
     };
     // Accessor compile-arg stream order MUST match the writer kernel:
-    // out, then start (direct-write), then up (UP_SPLIT).
+    // out, then start, then up (UP_SPLIT).
     tt::tt_metal::TensorAccessorArgs(out_buffer).append_to(writer_ct_args);
     tt::tt_metal::TensorAccessorArgs(start_buffer).append_to(writer_ct_args);
     // up accessor follows start; used only when the writer handles `up`.
@@ -933,22 +923,19 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
         const uint32_t in0_sender_ny = in0_sender_noc.y;
 
         // Reader runtime arg layout (must match unified_routed_expert_ffn_reader.cpp):
-        //   0..5: tensor addrs (x, gate, up, down, counts, idx)
-        //   6: my_mt
-        //   7: my_nt_gu
-        //   8: my_nt_d
-        //   9..18: in1 multicast args
-        //  19..28: in0 multicast args
-        //  29: act_ready_sem_id  30: act_valid_sem_id
-        //  31: up_go_sem_id  32: up_done_sem_id
-        //  33..33+2*GRID_X-1: M-row NoC coord table (GRID_X pairs of x, y)
-        //  33+2*GRID_X: start_addr (expert_region_offsets; read only when
-        //     read_x_at_offset, else points at out_buffer and is unread)
+        //   0..2: tensor addrs (x, counts, idx). The per-expert gate/up/down
+        //     base addresses are passed as the arrays after start_addr below.
+        //   3: my_mt
+        //   4: my_nt_gu
+        //   5: my_nt_d
+        //   6..15: in1 multicast args
+        //  16..25: in0 multicast args
+        //  26: act_ready_sem_id  27: act_valid_sem_id
+        //  28: up_go_sem_id  29: up_done_sem_id
+        //  30..30+2*GRID_X-1: M-row NoC coord table (GRID_X pairs of x, y)
+        //  30+2*GRID_X: start_addr (expert_region_offsets)
         std::vector<uint32_t> reader_args = {
             x_buffer->address(),
-            gate_buffer->address(),
-            up_buffer->address(),
-            down_buffer->address(),
             counts_buffer->address(),
             idx_buffer->address(),
             my_mt,
@@ -1022,20 +1009,19 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
 
         // Writer runtime arg layout (must match unified_routed_expert_ffn_writer.cpp):
         //   0: output_addr  1: my_mt  2: my_nt_d
-        //   3: start_addr (expert_region_offsets in direct-write mode; else
-        //      out_buffer, unused by the kernel)
-        //   4: up_addr  5: my_nt_gu  6: is_up_sender (gy==0)
-        //   7: up_go_sem_id  8: up_done_sem_id  (UP_SPLIT local same-core handshake)
+        //   3: start_addr (expert_region_offsets)
+        //   4: my_nt_gu  5: is_up_sender (gy==0)
+        //   6: up_go_sem_id  7: up_done_sem_id  (UP_SPLIT local same-core handshake)
+        //   8..8+N-1: per-expert `up` base addresses
         std::vector<uint32_t> writer_args = {
             out_buffer->address(),                 // 0
             my_mt,                                 // 1
             my_nt_d,                               // 2
             start_buffer->address(),               // 3
-            up_buffer->address(),                  // 4
-            my_nt_gu,                              // 5
-            static_cast<uint32_t>(is_in1_sender),  // 6 is_up_sender
-            up_go_sem_id,                          // 7
-            up_done_sem_id,                        // 8
+            my_nt_gu,                              // 4
+            static_cast<uint32_t>(is_in1_sender),  // 5 is_up_sender
+            up_go_sem_id,                          // 6
+            up_done_sem_id,                        // 7
         };
         // Per-expert `up` base addresses (UP_SPLIT)
         for (uint32_t e = 0; e < experts_per_chip; ++e) {
@@ -1080,11 +1066,8 @@ void UnifiedRoutedExpertFfnProgramFactory::override_runtime_arguments(
     for (const auto& core : cores) {
         auto& reader_args = tt::tt_metal::GetRuntimeArgs(program, reader_id, core);
         reader_args[0] = x_addr;
-        reader_args[1] = t.gate_projs[0].buffer()->address();  // expert-0 (accessor base; loop uses the arrays)
-        reader_args[2] = t.up_projs[0].buffer()->address();
-        reader_args[3] = t.down_projs[0].buffer()->address();
-        reader_args[4] = counts_addr;
-        reader_args[5] = idx_addr;
+        reader_args[1] = counts_addr;
+        reader_args[2] = idx_addr;
         const size_t start_idx = reader_args.size() - weights_len - 1;
         reader_args[start_idx] = start_addr;
         size_t w = start_idx + 1;
@@ -1112,7 +1095,6 @@ void UnifiedRoutedExpertFfnProgramFactory::override_runtime_arguments(
         auto& writer_args = tt::tt_metal::GetRuntimeArgs(program, writer_id, core);
         writer_args[0] = out_addr;
         writer_args[3] = start_addr;
-        writer_args[4] = t.up_projs[0].buffer()->address();  // expert-0 (index stability)
         // Per-expert `up` addresses occupy the final N slots.
         size_t u = writer_args.size() - N;
         for (uint32_t e = 0; e < N; ++e) {

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_program_factory.cpp
@@ -76,9 +76,13 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
     Tensor& tensor_return_value) {
     tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
 
+    // All local experts share one shape/dtype (validated), so the program is
+    // built once against expert 0's weights; the kernels loop over experts and
+    // vary only the per-expert base address.
+    const uint32_t experts_per_chip = op.experts_per_chip;
     const auto& x_shape = t.x.padded_shape();
-    const auto& gate_shape = t.gate_proj.padded_shape();
-    const auto& down_shape = t.down_proj.padded_shape();
+    const auto& gate_shape = t.gate_projs[0].padded_shape();
+    const auto& down_shape = t.down_projs[0].padded_shape();
 
     // This expert's M (not x's allocated M): x may be a shared buffer wider
     // than one expert's region. K still comes from x's last dim (emb).
@@ -115,7 +119,16 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
     // simply uses fewer of the reserved tiles.
     uint32_t GRID_X = kMaxGridX;
     uint32_t GRID_Y = MAX_GRID_Y;
-    uint32_t chunk_M_tiles = op.chunk_M_tiles;
+    // chunk_M_tiles is the CB-sized MAXIMUM chunk (per_core_M_max = 8). The host
+    // deliberately does NOT pick a chunk from M_tiles_full any more: all three
+    // kernels derive the ACTUAL chunk_M_tiles / per_core_M / num_chunks at runtime
+    // from the device-read per-expert token count (adaptive_chunk.hpp) and never
+    // exceed this max, so the CBs sized below always fit and a smaller runtime
+    // pick just uses fewer of the reserved tiles. Sizing per EXPERT at runtime
+    // also beats any single host-side seed here, since each local expert carries a
+    // different token count. (Owned by the op, not the caller.)
+    constexpr uint32_t kMaxChunkMTiles = 8 * MAX_GRID_Y;  // per_core_M <= 8 (L1 cap)
+    uint32_t chunk_M_tiles = kMaxChunkMTiles;
     uint32_t in0_block_w_gu = 16;
     const auto grid_size = t.x.device()->compute_with_storage_grid_size();
     TT_FATAL(
@@ -146,7 +159,7 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
     // (enforced in validation). Zero when unused so the L1 footprint estimate
     // (cb_footprint_bytes below) is unchanged on the bias-free path.
     const uint32_t bias_ts =
-        op.fuse_bias ? tt::tile_size(tt::tt_metal::datatype_to_dataformat_converter(t.gate_bias->dtype())) : 0;
+        op.fuse_bias ? tt::tile_size(tt::tt_metal::datatype_to_dataformat_converter(t.gate_biases[0].dtype())) : 0;
 
     // in0_block_w_gu (the gate/up K-loop block width) must divide K_gate_tiles.
     // The short_seq picker above already restricts itself to divisors, but the
@@ -211,9 +224,9 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
 
     // -------------------------- data formats / tile sizes -----------------
     const tt::DataFormat x_df = tt::tt_metal::datatype_to_dataformat_converter(t.x.dtype());
-    const tt::DataFormat gate_df = tt::tt_metal::datatype_to_dataformat_converter(t.gate_proj.dtype());
-    const tt::DataFormat up_df = tt::tt_metal::datatype_to_dataformat_converter(t.up_proj.dtype());
-    const tt::DataFormat down_df = tt::tt_metal::datatype_to_dataformat_converter(t.down_proj.dtype());
+    const tt::DataFormat gate_df = tt::tt_metal::datatype_to_dataformat_converter(t.gate_projs[0].dtype());
+    const tt::DataFormat up_df = tt::tt_metal::datatype_to_dataformat_converter(t.up_projs[0].dtype());
+    const tt::DataFormat down_df = tt::tt_metal::datatype_to_dataformat_converter(t.down_projs[0].dtype());
     const tt::DataFormat out_df = tt::tt_metal::datatype_to_dataformat_converter(tensor_return_value.dtype());
     // Partials vs intermediates deliberately differ in format; the compute
     // kernel pack-reconfigs between them (partials <-> intermed) explicitly.
@@ -291,12 +304,12 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
         L1_SCRATCH_MARGIN);
     const uint64_t l1_budget = static_cast<uint64_t>(l1_device->l1_size_per_core()) - l1_reserved - L1_SCRATCH_MARGIN;
 
-    // If the requested config — (per_core_M_max, in0_block_w_gu) from
-    // op.chunk_M_tiles and the default in0_block_w_gu=16 — overflows the real L1
-    // budget, shrink to fit: reduce per_core_M first (fewer weight re-reads, the
-    // dominant DRAM cost), then narrow in0_block_w_gu to the largest divisor of
-    // K_gate_tiles that fits. No-op when the requested config already fits (all
-    // DSV3 / M2.7 dims).
+    // If the requested config — (per_core_M_max, in0_block_w_gu) from the CB-sized
+    // max chunk and the default in0_block_w_gu=16 — overflows the real L1 budget,
+    // shrink to fit: reduce per_core_M first (fewer weight re-reads, the dominant
+    // DRAM cost), then narrow in0_block_w_gu to the largest divisor of K_gate_tiles
+    // that fits. No-op when the requested config already fits (all DSV3 / M2.7
+    // dims).
     if (cb_footprint_bytes(per_core_M, in0_block_w_gu) > l1_budget) {
         // Candidate gate/up K-block widths: divisors of K_gate_tiles no wider
         // than the requested in0_block_w_gu, largest first.
@@ -380,10 +393,14 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
     const CoreRange core_range({0, 0}, {GRID_X - 1, GRID_Y - 1});
     const CoreRangeSet core_range_set{core_range};
 
+    // Representative expert-0 buffers: one TensorAccessorArgs layout descriptor
+    // per weight role covers every expert (identical shape/layout), and the
+    // kernels build a per-expert accessor from that descriptor + the per-expert
+    // base address (passed as a runtime-arg).
     auto* x_buffer = t.x.buffer();
-    auto* gate_buffer = t.gate_proj.buffer();
-    auto* up_buffer = t.up_proj.buffer();
-    auto* down_buffer = t.down_proj.buffer();
+    auto* gate_buffer = t.gate_projs[0].buffer();
+    auto* up_buffer = t.up_projs[0].buffer();
+    auto* down_buffer = t.down_projs[0].buffer();
     auto* counts_buffer = t.counts.buffer();
     auto* idx_buffer = t.global_expert_idx_table.buffer();
     auto* out_buffer = tensor_return_value.buffer();
@@ -597,7 +614,7 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
     if (fuse_bias) {
         // Validation enforces gate/up/down biases share one dtype, so all three CBs
         // (and the compute kernel's single unpack reconfig for gate/up) use it safely.
-        const tt::DataFormat bias_df = tt::tt_metal::datatype_to_dataformat_converter(t.gate_bias->dtype());
+        const tt::DataFormat bias_df = tt::tt_metal::datatype_to_dataformat_converter(t.gate_biases[0].dtype());
         const uint32_t bias_tile_size = tt::tile_size(bias_df);
         make_cb(CB_GATE_BIAS, bias_df, /*tiles=*/per_core_N_gu, bias_tile_size);
         make_cb(CB_UP_BIAS, bias_df, /*tiles=*/per_core_N_gu, bias_tile_size);
@@ -616,7 +633,7 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
         CB_IN0_DOWN_FULL,
         CB_COUNTS_SCRATCH,
         CB_IDX_SCRATCH,
-        op.local_expert_id,
+        experts_per_chip,
         per_core_M,
         per_core_N_gu,
         per_core_N_d,
@@ -641,9 +658,6 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
         static_cast<uint32_t>(reader_reads_up),
         // reader_mcasts_up — 1 in LEGACY and UP_SPLIT (reader NoC-0 mcasts up).
         static_cast<uint32_t>(reader_mcasts_up),
-        // read_x_at_offset — 1 => x is a shared buffer, offset x reads by this
-        // expert's region start; 0 => x is per-expert, reads start at row 0.
-        static_cast<uint32_t>(op.read_x_at_offset),
         // CB_START_SCRATCH_READER — L1 page holding the fetched `start` vector.
         CB_START_SCRATCH_READER,
         // x_is_row_major — 1 => x is ROW_MAJOR bf16; reader streams sticks into
@@ -678,9 +692,11 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
         reader_ct_args.push_back(CB_GATE_BIAS);
         reader_ct_args.push_back(CB_UP_BIAS);
         reader_ct_args.push_back(CB_DOWN_BIAS);
-        tt::tt_metal::TensorAccessorArgs(t.gate_bias->buffer()).append_to(reader_ct_args);
-        tt::tt_metal::TensorAccessorArgs(t.up_bias->buffer()).append_to(reader_ct_args);
-        tt::tt_metal::TensorAccessorArgs(t.down_bias->buffer()).append_to(reader_ct_args);
+        // Representative expert-0 bias buffers describe the layout; per-expert
+        // bias base addresses are passed as runtime-arg arrays below.
+        tt::tt_metal::TensorAccessorArgs(t.gate_biases[0].buffer()).append_to(reader_ct_args);
+        tt::tt_metal::TensorAccessorArgs(t.up_biases[0].buffer()).append_to(reader_ct_args);
+        tt::tt_metal::TensorAccessorArgs(t.down_biases[0].buffer()).append_to(reader_ct_args);
         reader_defines["FUSE_BIAS"] = "1";
     }
     auto reader_kernel_id = tt::tt_metal::CreateKernel(
@@ -708,9 +724,9 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
         // device-side count read: writer also waits on the reader's push
         // and bounds its cb_out drain loop by effective_chunks so it does
         // not wait forever on chunks compute never pushes.
-        CB_COUNTS_SCRATCH,   // 13
-        CB_IDX_SCRATCH,      // 14
-        op.local_expert_id,  // 15
+        CB_COUNTS_SCRATCH,  // 13
+        CB_IDX_SCRATCH,     // 14
+        experts_per_chip,   // 15
         // M_tiles_full: needed for the writer to skip OOB output writes when
         // M_tiles_full doesn't divide chunk_M_tiles. The last chunk runs
         // chunk_M_tiles rows per core, of which only those < M_tiles_full
@@ -788,9 +804,7 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
         d_out_block_num_tiles,
         // chunk loop control
         num_chunks,
-        // device-side count read: local_expert_id + chunk_M_tiles (in tiles)
-        // let compute convert count -> effective_chunks and bound the loop.
-        op.local_expert_id,
+        experts_per_chip,
         chunk_M_tiles,
         // x_is_row_major — 1 => compute tilizes CB_X_RM -> CB_IN0_X before the
         // gate/up matmul. 0 => x already TILE in CB_IN0_X (no tilize).
@@ -976,15 +990,33 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
             reader_args.push_back(static_cast<uint32_t>(noc.y));
         }
         // start_addr — reader arg at M_ROW_NOC_RT_OFFSET + 2*GRID_X (see layout
-        // comment). Same buffer the writer gets; read by the reader only when
-        // read_x_at_offset.
+        // comment). Same buffer the writer gets. Always read (x is the shared
+        // buffer; each expert's rows begin at start[global_id]).
         reader_args.push_back(start_buffer->address());
-        // FUSE_BIAS: 3 bias addrs immediately after start_addr (read by the
-        // reader at start_offset + 1..3). Kept last so override can update them.
+        // Per-expert weight base addresses, appended after start_addr in three
+        // contiguous blocks of experts_per_chip each: gate[0..N), up[0..N),
+        // down[0..N).
+        for (uint32_t e = 0; e < experts_per_chip; ++e) {
+            reader_args.push_back(t.gate_projs[e].buffer()->address());
+        }
+        for (uint32_t e = 0; e < experts_per_chip; ++e) {
+            reader_args.push_back(t.up_projs[e].buffer()->address());
+        }
+        for (uint32_t e = 0; e < experts_per_chip; ++e) {
+            reader_args.push_back(t.down_projs[e].buffer()->address());
+        }
+        // FUSE_BIAS: per-expert bias base addresses in three further blocks
+        // (gate_bias[0..N), up_bias[0..N), down_bias[0..N)) after the weights.
         if (fuse_bias) {
-            reader_args.push_back(t.gate_bias->buffer()->address());
-            reader_args.push_back(t.up_bias->buffer()->address());
-            reader_args.push_back(t.down_bias->buffer()->address());
+            for (uint32_t e = 0; e < experts_per_chip; ++e) {
+                reader_args.push_back(t.gate_biases[e].buffer()->address());
+            }
+            for (uint32_t e = 0; e < experts_per_chip; ++e) {
+                reader_args.push_back(t.up_biases[e].buffer()->address());
+            }
+            for (uint32_t e = 0; e < experts_per_chip; ++e) {
+                reader_args.push_back(t.down_biases[e].buffer()->address());
+            }
         }
         tt::tt_metal::SetRuntimeArgs(program, reader_kernel_id, core, reader_args);
 
@@ -1005,6 +1037,10 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
             up_go_sem_id,                          // 7
             up_done_sem_id,                        // 8
         };
+        // Per-expert `up` base addresses (UP_SPLIT)
+        for (uint32_t e = 0; e < experts_per_chip; ++e) {
+            writer_args.push_back(t.up_projs[e].buffer()->address());
+        }
         tt::tt_metal::SetRuntimeArgs(program, writer_kernel_id, core, writer_args);
     }
 
@@ -1019,7 +1055,7 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
 
 void UnifiedRoutedExpertFfnProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
-    const UnifiedRoutedExpertFfnParams& /*op*/,
+    const UnifiedRoutedExpertFfnParams& op,
     const UnifiedRoutedExpertFfnInputs& t,
     Tensor& tensor_return_value) {
     auto& program = cached_program.program;
@@ -1027,40 +1063,61 @@ void UnifiedRoutedExpertFfnProgramFactory::override_runtime_arguments(
     const auto writer_id = cached_program.shared_variables.writer_kernel_id;
     const auto& cores = cached_program.shared_variables.cores;
 
+    const uint32_t N = op.experts_per_chip;
+    const bool has_bias = op.fuse_bias;
     const uint32_t x_addr = t.x.buffer()->address();
-    const uint32_t gate_addr = t.gate_proj.buffer()->address();
-    const uint32_t up_addr = t.up_proj.buffer()->address();
-    const uint32_t down_addr = t.down_proj.buffer()->address();
     const uint32_t counts_addr = t.counts.buffer()->address();
     const uint32_t idx_addr = t.global_expert_idx_table.buffer()->address();
     const uint32_t out_addr = tensor_return_value.buffer()->address();
-    const uint32_t start_addr =
-        t.expert_region_offsets.has_value() ? t.expert_region_offsets->buffer()->address() : out_addr;
-    // FUSE_BIAS appends 3 bias addrs after start_addr, so start is no longer the
-    // last reader arg. Recover its index from the presence of the bias tensors.
-    const bool has_bias = t.gate_bias.has_value();
+    const uint32_t start_addr = t.expert_region_offsets->buffer()->address();
+
+    // Reader runtime-arg tail (see create()): [start_addr][gate*N][up*N][down*N]
+    // (+ [gbias*N][ubias*N][dbias*N] when fuse_bias). Recover start_addr's index
+    // from the fixed tail length so the per-expert address blocks that follow it
+    // land at the same slots the kernel reads.
+    const size_t weights_len = static_cast<size_t>(3u * N) + (has_bias ? static_cast<size_t>(3u * N) : 0u);
 
     for (const auto& core : cores) {
         auto& reader_args = tt::tt_metal::GetRuntimeArgs(program, reader_id, core);
         reader_args[0] = x_addr;
-        reader_args[1] = gate_addr;
-        reader_args[2] = up_addr;
-        reader_args[3] = down_addr;
+        reader_args[1] = t.gate_projs[0].buffer()->address();  // expert-0 (accessor base; loop uses the arrays)
+        reader_args[2] = t.up_projs[0].buffer()->address();
+        reader_args[3] = t.down_projs[0].buffer()->address();
         reader_args[4] = counts_addr;
         reader_args[5] = idx_addr;
-        // start_addr sits before the (optional) 3 trailing bias addrs.
-        const size_t start_idx = reader_args.size() - 1 - (has_bias ? 3 : 0);
+        const size_t start_idx = reader_args.size() - weights_len - 1;
         reader_args[start_idx] = start_addr;
+        size_t w = start_idx + 1;
+        for (uint32_t e = 0; e < N; ++e) {
+            reader_args[w++] = t.gate_projs[e].buffer()->address();
+        }
+        for (uint32_t e = 0; e < N; ++e) {
+            reader_args[w++] = t.up_projs[e].buffer()->address();
+        }
+        for (uint32_t e = 0; e < N; ++e) {
+            reader_args[w++] = t.down_projs[e].buffer()->address();
+        }
         if (has_bias) {
-            reader_args[reader_args.size() - 3] = t.gate_bias->buffer()->address();
-            reader_args[reader_args.size() - 2] = t.up_bias->buffer()->address();
-            reader_args[reader_args.size() - 1] = t.down_bias->buffer()->address();
+            for (uint32_t e = 0; e < N; ++e) {
+                reader_args[w++] = t.gate_biases[e].buffer()->address();
+            }
+            for (uint32_t e = 0; e < N; ++e) {
+                reader_args[w++] = t.up_biases[e].buffer()->address();
+            }
+            for (uint32_t e = 0; e < N; ++e) {
+                reader_args[w++] = t.down_biases[e].buffer()->address();
+            }
         }
 
         auto& writer_args = tt::tt_metal::GetRuntimeArgs(program, writer_id, core);
         writer_args[0] = out_addr;
         writer_args[3] = start_addr;
-        writer_args[4] = up_addr;  // two-RISC up-weight read base address
+        writer_args[4] = t.up_projs[0].buffer()->address();  // expert-0 (index stability)
+        // Per-expert `up` addresses occupy the final N slots.
+        size_t u = writer_args.size() - N;
+        for (uint32_t e = 0; e < N; ++e) {
+            writer_args[u++] = t.up_projs[e].buffer()->address();
+        }
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_program_factory.cpp
@@ -819,6 +819,10 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
         // bounds its chunk loop by effective_chunks = ceil(count/chunk_M_tiles).
         {"cb_counts_scratch", CB_COUNTS_SCRATCH},
         {"cb_idx_scratch", CB_IDX_SCRATCH},
+        // Region size in tile-rows: caps the device-provided per-expert count
+        // (adaptive_chunk::clamp_count_tiles). Reader and writer take it as a
+        // positional CT arg; compute has no free positional slot, so it is named.
+        {"m_tiles_full", M_tiles_full},
     };
     if (fuse_bias) {
         compute_named_args["cb_gate_bias"] = CB_GATE_BIAS;

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_program_factory.cpp
@@ -48,11 +48,11 @@ constexpr uint32_t CB_IN0_DOWN_FULL = tt::CBIndex::c_12;
 // per K-block feeds both matmuls instead of two.
 constexpr uint32_t CB_PARTIALS_UP = tt::CBIndex::c_13;
 // Writer-only scratch for the device-side `start` (expert_region_offsets)
-// page in direct-write mode. Allocated unconditionally (negligible L1) so
-// the CB-index layout is stable across both write modes.
+// page: the writer adds start[global_id]/TILE tile-rows to every output row.
 constexpr uint32_t CB_START_SCRATCH = tt::CBIndex::c_14;
-// Reader's own `start` scratch, used when read_x_at_offset (x is a shared
-// buffer). Separate from the writer's so the two RISCs don't share one L1 page.
+// Reader's own `start` scratch (x is the shared dispatched buffer, so the
+// reader offsets its x reads by start[global_id] too). Separate from the
+// writer's so the two RISCs don't share one L1 page.
 constexpr uint32_t CB_START_SCRATCH_READER = tt::CBIndex::c_15;
 // Row-major bf16 staging for x when x_is_row_major: the reader fills it with
 // row-major sticks and the compute kernel tilizes it to bf8_b into CB_IN0_X.
@@ -406,17 +406,13 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
     auto* idx_buffer = t.global_expert_idx_table.buffer();
     auto* out_buffer = tensor_return_value.buffer();
 
-    // Direct-write mode: when expert_region_offsets is supplied, the writer
-    // writes this expert's output straight into the shared output buffer at
-    // start[global_id]/TILE tile-rows (fusing ttnn::insert). Otherwise the
-    // writer targets tile row 0 of a per-expert buffer. The `start` accessor
-    // is appended unconditionally so the writer's CT-arg layout is stable;
-    // when not in direct-write mode it points at out_buffer and is never read.
-    const bool direct_write = t.expert_region_offsets.has_value();
-    auto* start_buffer = direct_write ? t.expert_region_offsets->buffer() : out_buffer;
-    // dst_M_tiles bounds destination writes. Equals M_tiles_full when the
-    // output matches x's shape; is the shared buffer's tile-row count in
-    // direct-write mode.
+    // expert_region_offsets is a mandatory input (validated in the device op):
+    // the writer always writes an expert's output straight into the shared
+    // output buffer at start[global_id]/TILE tile-rows (fusing ttnn::insert),
+    // and the reader always reads x from the same region.
+    auto* start_buffer = t.expert_region_offsets->buffer();
+    // dst_M_tiles bounds destination writes: the shared output buffer's
+    // tile-row count.
     const uint32_t dst_M_tiles = tensor_return_value.padded_shape()[-2] / TILE;
 
     // -------------------------- semaphores --------------------------------
@@ -601,7 +597,7 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
         tt::tt_metal::CircularBufferConfig(start_scratch_bytes, {{CB_START_SCRATCH, tt::DataFormat::UInt32}})
             .set_page_size(CB_START_SCRATCH, start_scratch_bytes);
     tt::tt_metal::CreateCircularBuffer(program, core_range_set, start_cb_cfg);
-    // Reader's `start` scratch (read_x_at_offset). Same sizing; separate CB so
+    // Reader's `start` scratch. Same sizing; separate CB so
     // reader (BRISC) and writer (NCRISC) never share one scratch page.
     tt::tt_metal::CircularBufferConfig start_reader_cb_cfg =
         tt::tt_metal::CircularBufferConfig(start_scratch_bytes, {{CB_START_SCRATCH_READER, tt::DataFormat::UInt32}})
@@ -679,9 +675,9 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
     tt::tt_metal::TensorAccessorArgs(down_buffer).append_to(reader_ct_args);
     tt::tt_metal::TensorAccessorArgs(counts_buffer).append_to(reader_ct_args);
     tt::tt_metal::TensorAccessorArgs(idx_buffer).append_to(reader_ct_args);
-    // `start` accessor — appended last, matching the reader's accessor stream.
-    // Points at expert_region_offsets in direct/offset mode, else out_buffer
-    // (unread when read_x_at_offset is 0), keeping the CT-arg layout stable.
+    // `start` (= expert_region_offsets) accessor — appended last, matching the
+    // reader's accessor stream. Always read: x is the shared dispatched buffer
+    // and each expert's rows begin at start[global_id].
     tt::tt_metal::TensorAccessorArgs(start_buffer).append_to(reader_ct_args);
 
     // FUSE_BIAS: after the `start` accessor, append the 3 bias CB ids then the 3
@@ -709,46 +705,40 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
 
     // Writer compile-time args (must match writer's get_compile_time_arg_val order).
     std::vector<uint32_t> writer_ct_args = {
-        CB_ACTIVATED,       // 0
-        CB_OUT,             // 1
-        per_core_M,         // 2
-        per_core_N_gu,      // 3
-        per_core_N_d,       // 4
-        gu_out_subblock_h,  // 5
-        gu_out_subblock_w,  // 6
-        d_out_subblock_h,   // 7
-        d_out_subblock_w,   // 8
-        N_gate_tiles_full,  // 9
-        N_down_tiles_full,  // 10
-        num_chunks,         // 11
-        chunk_M_tiles,      // 12
+        CB_OUT,             // 0
+        per_core_M,         // 1
+        per_core_N_gu,      // 2
+        per_core_N_d,       // 3
+        d_out_subblock_h,   // 4
+        d_out_subblock_w,   // 5
+        N_gate_tiles_full,  // 6
+        N_down_tiles_full,  // 7
+        num_chunks,         // 8
+        chunk_M_tiles,      // 9
         // device-side count read: writer also waits on the reader's push
         // and bounds its cb_out drain loop by effective_chunks so it does
         // not wait forever on chunks compute never pushes.
-        CB_COUNTS_SCRATCH,  // 13
-        CB_IDX_SCRATCH,     // 14
-        experts_per_chip,   // 15
+        CB_COUNTS_SCRATCH,  // 10
+        CB_IDX_SCRATCH,     // 11
+        experts_per_chip,   // 12
         // M_tiles_full: needed for the writer to skip OOB output writes when
         // M_tiles_full doesn't divide chunk_M_tiles. The last chunk runs
         // chunk_M_tiles rows per core, of which only those < M_tiles_full
         // correspond to real output rows in the tensor.
-        M_tiles_full,  // 16
-        // direct_write: 1 -> writer adds start[global_id]/TILE tile-rows and
-        // targets the shared output buffer (fuses ttnn::insert).
-        static_cast<uint32_t>(direct_write),  // 17
-        // dst_M_tiles: tile-row count of the destination buffer (= M_tiles_full
-        // for the per-expert output; the shared buffer's rows in direct mode).
-        dst_M_tiles,       // 18
-        CB_START_SCRATCH,  // 19
+        M_tiles_full,  // 13
+        // dst_M_tiles: tile-row count of the shared destination buffer, which
+        // bounds the writer's destination rows.
+        dst_M_tiles,       // 14
+        CB_START_SCRATCH,  // 15
         // UP_SPLIT up-weight read: CB + dims let the writer replicate the gate
         // read on NoC 1, and writer_split_up gates it (1 = UP_SPLIT).
-        CB_IN1_UP,                            // 20
-        in0_block_w_gu,                       // 21
-        K_gate_tiles,                         // 22
-        static_cast<uint32_t>(up_mode == 2),  // 23 writer_split_up
+        CB_IN1_UP,                            // 16
+        in0_block_w_gu,                       // 17
+        K_gate_tiles,                         // 18
+        static_cast<uint32_t>(up_mode == 2),  // 19 writer_split_up
     };
     // Accessor compile-arg stream order MUST match the writer kernel:
-    // out, then start (direct-write), then up (UP_SPLIT).
+    // out, then start, then up (UP_SPLIT).
     tt::tt_metal::TensorAccessorArgs(out_buffer).append_to(writer_ct_args);
     tt::tt_metal::TensorAccessorArgs(start_buffer).append_to(writer_ct_args);
     // up accessor follows start; used only when the writer handles `up`.
@@ -933,22 +923,19 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
         const uint32_t in0_sender_ny = in0_sender_noc.y;
 
         // Reader runtime arg layout (must match unified_routed_expert_ffn_reader.cpp):
-        //   0..5: tensor addrs (x, gate, up, down, counts, idx)
-        //   6: my_mt
-        //   7: my_nt_gu
-        //   8: my_nt_d
-        //   9..18: in1 multicast args
-        //  19..28: in0 multicast args
-        //  29: act_ready_sem_id  30: act_valid_sem_id
-        //  31: up_go_sem_id  32: up_done_sem_id
-        //  33..33+2*GRID_X-1: M-row NoC coord table (GRID_X pairs of x, y)
-        //  33+2*GRID_X: start_addr (expert_region_offsets; read only when
-        //     read_x_at_offset, else points at out_buffer and is unread)
+        //   0..2: tensor addrs (x, counts, idx). The per-expert gate/up/down
+        //     base addresses are passed as the arrays after start_addr below.
+        //   3: my_mt
+        //   4: my_nt_gu
+        //   5: my_nt_d
+        //   6..15: in1 multicast args
+        //  16..25: in0 multicast args
+        //  26: act_ready_sem_id  27: act_valid_sem_id
+        //  28: up_go_sem_id  29: up_done_sem_id
+        //  30..30+2*GRID_X-1: M-row NoC coord table (GRID_X pairs of x, y)
+        //  30+2*GRID_X: start_addr (expert_region_offsets)
         std::vector<uint32_t> reader_args = {
             x_buffer->address(),
-            gate_buffer->address(),
-            up_buffer->address(),
-            down_buffer->address(),
             counts_buffer->address(),
             idx_buffer->address(),
             my_mt,
@@ -1022,20 +1009,19 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
 
         // Writer runtime arg layout (must match unified_routed_expert_ffn_writer.cpp):
         //   0: output_addr  1: my_mt  2: my_nt_d
-        //   3: start_addr (expert_region_offsets in direct-write mode; else
-        //      out_buffer, unused by the kernel)
-        //   4: up_addr  5: my_nt_gu  6: is_up_sender (gy==0)
-        //   7: up_go_sem_id  8: up_done_sem_id  (UP_SPLIT local same-core handshake)
+        //   3: start_addr (expert_region_offsets)
+        //   4: my_nt_gu  5: is_up_sender (gy==0)
+        //   6: up_go_sem_id  7: up_done_sem_id  (UP_SPLIT local same-core handshake)
+        //   8..8+N-1: per-expert `up` base addresses
         std::vector<uint32_t> writer_args = {
             out_buffer->address(),                 // 0
             my_mt,                                 // 1
             my_nt_d,                               // 2
             start_buffer->address(),               // 3
-            up_buffer->address(),                  // 4
-            my_nt_gu,                              // 5
-            static_cast<uint32_t>(is_in1_sender),  // 6 is_up_sender
-            up_go_sem_id,                          // 7
-            up_done_sem_id,                        // 8
+            my_nt_gu,                              // 4
+            static_cast<uint32_t>(is_in1_sender),  // 5 is_up_sender
+            up_go_sem_id,                          // 6
+            up_done_sem_id,                        // 7
         };
         // Per-expert `up` base addresses (UP_SPLIT)
         for (uint32_t e = 0; e < experts_per_chip; ++e) {
@@ -1100,11 +1086,8 @@ void UnifiedRoutedExpertFfnProgramFactory::override_runtime_arguments(
     for (const auto& core : cores) {
         auto& reader_args = tt::tt_metal::GetRuntimeArgs(program, reader_id, core);
         reader_args[0] = x_addr;
-        reader_args[1] = t.gate_projs[0].buffer()->address();  // expert-0 (accessor base; loop uses the arrays)
-        reader_args[2] = t.up_projs[0].buffer()->address();
-        reader_args[3] = t.down_projs[0].buffer()->address();
-        reader_args[4] = counts_addr;
-        reader_args[5] = idx_addr;
+        reader_args[1] = counts_addr;
+        reader_args[2] = idx_addr;
         const size_t start_idx = reader_args.size() - weights_len - 1;
         reader_args[start_idx] = start_addr;
         size_t w = start_idx + 1;
@@ -1132,7 +1115,6 @@ void UnifiedRoutedExpertFfnProgramFactory::override_runtime_arguments(
         auto& writer_args = tt::tt_metal::GetRuntimeArgs(program, writer_id, core);
         writer_args[0] = out_addr;
         writer_args[3] = start_addr;
-        writer_args[4] = t.up_projs[0].buffer()->address();  // expert-0 (index stability)
         // Per-expert `up` addresses occupy the final N slots.
         size_t u = writer_args.size() - N;
         for (uint32_t e = 0; e < N; ++e) {

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_program_factory.cpp
@@ -76,9 +76,13 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
     Tensor& tensor_return_value) {
     tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
 
+    // All local experts share one shape/dtype (validated), so the program is
+    // built once against expert 0's weights; the kernels loop over experts and
+    // vary only the per-expert base address.
+    const uint32_t experts_per_chip = op.experts_per_chip;
     const auto& x_shape = t.x.padded_shape();
-    const auto& gate_shape = t.gate_proj.padded_shape();
-    const auto& down_shape = t.down_proj.padded_shape();
+    const auto& gate_shape = t.gate_projs[0].padded_shape();
+    const auto& down_shape = t.down_projs[0].padded_shape();
 
     // This expert's M (not x's allocated M): x may be a shared buffer wider
     // than one expert's region. K still comes from x's last dim (emb).
@@ -115,7 +119,16 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
     // simply uses fewer of the reserved tiles.
     uint32_t GRID_X = kMaxGridX;
     uint32_t GRID_Y = MAX_GRID_Y;
-    uint32_t chunk_M_tiles = op.chunk_M_tiles;
+    // chunk_M_tiles is the CB-sized MAXIMUM chunk (per_core_M_max = 8). The host
+    // deliberately does NOT pick a chunk from M_tiles_full any more: all three
+    // kernels derive the ACTUAL chunk_M_tiles / per_core_M / num_chunks at runtime
+    // from the device-read per-expert token count (adaptive_chunk.hpp) and never
+    // exceed this max, so the CBs sized below always fit and a smaller runtime
+    // pick just uses fewer of the reserved tiles. Sizing per EXPERT at runtime
+    // also beats any single host-side seed here, since each local expert carries a
+    // different token count. (Owned by the op, not the caller.)
+    constexpr uint32_t kMaxChunkMTiles = 8 * MAX_GRID_Y;  // per_core_M <= 8 (L1 cap)
+    uint32_t chunk_M_tiles = kMaxChunkMTiles;
     uint32_t in0_block_w_gu = 16;
     const auto grid_size = t.x.device()->compute_with_storage_grid_size();
     TT_FATAL(
@@ -146,7 +159,7 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
     // (enforced in validation). Zero when unused so the L1 footprint estimate
     // (cb_footprint_bytes below) is unchanged on the bias-free path.
     const uint32_t bias_ts =
-        op.fuse_bias ? tt::tile_size(tt::tt_metal::datatype_to_dataformat_converter(t.gate_bias->dtype())) : 0;
+        op.fuse_bias ? tt::tile_size(tt::tt_metal::datatype_to_dataformat_converter(t.gate_biases[0].dtype())) : 0;
 
     // in0_block_w_gu (the gate/up K-loop block width) must divide K_gate_tiles.
     // The short_seq picker above already restricts itself to divisors, but the
@@ -211,9 +224,9 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
 
     // -------------------------- data formats / tile sizes -----------------
     const tt::DataFormat x_df = tt::tt_metal::datatype_to_dataformat_converter(t.x.dtype());
-    const tt::DataFormat gate_df = tt::tt_metal::datatype_to_dataformat_converter(t.gate_proj.dtype());
-    const tt::DataFormat up_df = tt::tt_metal::datatype_to_dataformat_converter(t.up_proj.dtype());
-    const tt::DataFormat down_df = tt::tt_metal::datatype_to_dataformat_converter(t.down_proj.dtype());
+    const tt::DataFormat gate_df = tt::tt_metal::datatype_to_dataformat_converter(t.gate_projs[0].dtype());
+    const tt::DataFormat up_df = tt::tt_metal::datatype_to_dataformat_converter(t.up_projs[0].dtype());
+    const tt::DataFormat down_df = tt::tt_metal::datatype_to_dataformat_converter(t.down_projs[0].dtype());
     const tt::DataFormat out_df = tt::tt_metal::datatype_to_dataformat_converter(tensor_return_value.dtype());
     // Partials vs intermediates deliberately differ in format; the compute
     // kernel pack-reconfigs between them (partials <-> intermed) explicitly.
@@ -291,12 +304,12 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
         L1_SCRATCH_MARGIN);
     const uint64_t l1_budget = static_cast<uint64_t>(l1_device->l1_size_per_core()) - l1_reserved - L1_SCRATCH_MARGIN;
 
-    // If the requested config — (per_core_M_max, in0_block_w_gu) from
-    // op.chunk_M_tiles and the default in0_block_w_gu=16 — overflows the real L1
-    // budget, shrink to fit: reduce per_core_M first (fewer weight re-reads, the
-    // dominant DRAM cost), then narrow in0_block_w_gu to the largest divisor of
-    // K_gate_tiles that fits. No-op when the requested config already fits (all
-    // DSV3 / M2.7 dims).
+    // If the requested config — (per_core_M_max, in0_block_w_gu) from the CB-sized
+    // max chunk and the default in0_block_w_gu=16 — overflows the real L1 budget,
+    // shrink to fit: reduce per_core_M first (fewer weight re-reads, the dominant
+    // DRAM cost), then narrow in0_block_w_gu to the largest divisor of K_gate_tiles
+    // that fits. No-op when the requested config already fits (all DSV3 / M2.7
+    // dims).
     if (cb_footprint_bytes(per_core_M, in0_block_w_gu) > l1_budget) {
         // Candidate gate/up K-block widths: divisors of K_gate_tiles no wider
         // than the requested in0_block_w_gu, largest first.
@@ -381,10 +394,14 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
     const CoreRange core_range({0, 0}, {GRID_X - 1, GRID_Y - 1});
     const CoreRangeSet core_range_set{core_range};
 
+    // Representative expert-0 buffers: one TensorAccessorArgs layout descriptor
+    // per weight role covers every expert (identical shape/layout), and the
+    // kernels build a per-expert accessor from that descriptor + the per-expert
+    // base address (passed as a runtime-arg).
     auto* x_buffer = t.x.buffer();
-    auto* gate_buffer = t.gate_proj.buffer();
-    auto* up_buffer = t.up_proj.buffer();
-    auto* down_buffer = t.down_proj.buffer();
+    auto* gate_buffer = t.gate_projs[0].buffer();
+    auto* up_buffer = t.up_projs[0].buffer();
+    auto* down_buffer = t.down_projs[0].buffer();
     auto* counts_buffer = t.counts.buffer();
     auto* idx_buffer = t.global_expert_idx_table.buffer();
     auto* out_buffer = tensor_return_value.buffer();
@@ -598,7 +615,7 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
     if (fuse_bias) {
         // Validation enforces gate/up/down biases share one dtype, so all three CBs
         // (and the compute kernel's single unpack reconfig for gate/up) use it safely.
-        const tt::DataFormat bias_df = tt::tt_metal::datatype_to_dataformat_converter(t.gate_bias->dtype());
+        const tt::DataFormat bias_df = tt::tt_metal::datatype_to_dataformat_converter(t.gate_biases[0].dtype());
         const uint32_t bias_tile_size = tt::tile_size(bias_df);
         make_cb(CB_GATE_BIAS, bias_df, /*tiles=*/per_core_N_gu, bias_tile_size);
         make_cb(CB_UP_BIAS, bias_df, /*tiles=*/per_core_N_gu, bias_tile_size);
@@ -617,7 +634,7 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
         CB_IN0_DOWN_FULL,
         CB_COUNTS_SCRATCH,
         CB_IDX_SCRATCH,
-        op.local_expert_id,
+        experts_per_chip,
         per_core_M,
         per_core_N_gu,
         per_core_N_d,
@@ -642,9 +659,6 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
         static_cast<uint32_t>(reader_reads_up),
         // reader_mcasts_up — 1 in LEGACY and UP_SPLIT (reader NoC-0 mcasts up).
         static_cast<uint32_t>(reader_mcasts_up),
-        // read_x_at_offset — 1 => x is a shared buffer, offset x reads by this
-        // expert's region start; 0 => x is per-expert, reads start at row 0.
-        static_cast<uint32_t>(op.read_x_at_offset),
         // CB_START_SCRATCH_READER — L1 page holding the fetched `start` vector.
         CB_START_SCRATCH_READER,
         // x_is_row_major — 1 => x is ROW_MAJOR bf16; reader streams sticks into
@@ -679,9 +693,11 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
         reader_ct_args.push_back(CB_GATE_BIAS);
         reader_ct_args.push_back(CB_UP_BIAS);
         reader_ct_args.push_back(CB_DOWN_BIAS);
-        tt::tt_metal::TensorAccessorArgs(t.gate_bias->buffer()).append_to(reader_ct_args);
-        tt::tt_metal::TensorAccessorArgs(t.up_bias->buffer()).append_to(reader_ct_args);
-        tt::tt_metal::TensorAccessorArgs(t.down_bias->buffer()).append_to(reader_ct_args);
+        // Representative expert-0 bias buffers describe the layout; per-expert
+        // bias base addresses are passed as runtime-arg arrays below.
+        tt::tt_metal::TensorAccessorArgs(t.gate_biases[0].buffer()).append_to(reader_ct_args);
+        tt::tt_metal::TensorAccessorArgs(t.up_biases[0].buffer()).append_to(reader_ct_args);
+        tt::tt_metal::TensorAccessorArgs(t.down_biases[0].buffer()).append_to(reader_ct_args);
         reader_defines["FUSE_BIAS"] = "1";
     }
     auto reader_kernel_id = tt::tt_metal::CreateKernel(
@@ -709,9 +725,9 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
         // device-side count read: writer also waits on the reader's push
         // and bounds its cb_out drain loop by effective_chunks so it does
         // not wait forever on chunks compute never pushes.
-        CB_COUNTS_SCRATCH,   // 13
-        CB_IDX_SCRATCH,      // 14
-        op.local_expert_id,  // 15
+        CB_COUNTS_SCRATCH,  // 13
+        CB_IDX_SCRATCH,     // 14
+        experts_per_chip,   // 15
         // M_tiles_full: needed for the writer to skip OOB output writes when
         // M_tiles_full doesn't divide chunk_M_tiles. The last chunk runs
         // chunk_M_tiles rows per core, of which only those < M_tiles_full
@@ -784,9 +800,7 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
         d_out_block_num_tiles,
         // chunk loop control
         num_chunks,
-        // device-side count read: local_expert_id + chunk_M_tiles (in tiles)
-        // let compute convert count -> effective_chunks and bound the loop.
-        op.local_expert_id,
+        experts_per_chip,
         chunk_M_tiles,
         // x_is_row_major — 1 => compute tilizes CB_X_RM -> CB_IN0_X before the
         // gate/up matmul. 0 => x already TILE in CB_IN0_X (no tilize).
@@ -976,15 +990,33 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
             reader_args.push_back(static_cast<uint32_t>(noc.y));
         }
         // start_addr — reader arg at M_ROW_NOC_RT_OFFSET + 2*GRID_X (see layout
-        // comment). Same buffer the writer gets; read by the reader only when
-        // read_x_at_offset.
+        // comment). Same buffer the writer gets. Always read (x is the shared
+        // buffer; each expert's rows begin at start[global_id]).
         reader_args.push_back(start_buffer->address());
-        // FUSE_BIAS: 3 bias addrs immediately after start_addr (read by the
-        // reader at start_offset + 1..3). Kept last so override can update them.
+        // Per-expert weight base addresses, appended after start_addr in three
+        // contiguous blocks of experts_per_chip each: gate[0..N), up[0..N),
+        // down[0..N).
+        for (uint32_t e = 0; e < experts_per_chip; ++e) {
+            reader_args.push_back(t.gate_projs[e].buffer()->address());
+        }
+        for (uint32_t e = 0; e < experts_per_chip; ++e) {
+            reader_args.push_back(t.up_projs[e].buffer()->address());
+        }
+        for (uint32_t e = 0; e < experts_per_chip; ++e) {
+            reader_args.push_back(t.down_projs[e].buffer()->address());
+        }
+        // FUSE_BIAS: per-expert bias base addresses in three further blocks
+        // (gate_bias[0..N), up_bias[0..N), down_bias[0..N)) after the weights.
         if (fuse_bias) {
-            reader_args.push_back(t.gate_bias->buffer()->address());
-            reader_args.push_back(t.up_bias->buffer()->address());
-            reader_args.push_back(t.down_bias->buffer()->address());
+            for (uint32_t e = 0; e < experts_per_chip; ++e) {
+                reader_args.push_back(t.gate_biases[e].buffer()->address());
+            }
+            for (uint32_t e = 0; e < experts_per_chip; ++e) {
+                reader_args.push_back(t.up_biases[e].buffer()->address());
+            }
+            for (uint32_t e = 0; e < experts_per_chip; ++e) {
+                reader_args.push_back(t.down_biases[e].buffer()->address());
+            }
         }
         tt::tt_metal::SetRuntimeArgs(program, reader_kernel_id, core, reader_args);
 
@@ -1005,6 +1037,10 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
             up_go_sem_id,                          // 7
             up_done_sem_id,                        // 8
         };
+        // Per-expert `up` base addresses (UP_SPLIT)
+        for (uint32_t e = 0; e < experts_per_chip; ++e) {
+            writer_args.push_back(t.up_projs[e].buffer()->address());
+        }
         tt::tt_metal::SetRuntimeArgs(program, writer_kernel_id, core, writer_args);
 
         // Compute: how many of this core's N subblocks hold REAL output columns.
@@ -1039,7 +1075,7 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
 
 void UnifiedRoutedExpertFfnProgramFactory::override_runtime_arguments(
     cached_program_t& cached_program,
-    const UnifiedRoutedExpertFfnParams& /*op*/,
+    const UnifiedRoutedExpertFfnParams& op,
     const UnifiedRoutedExpertFfnInputs& t,
     Tensor& tensor_return_value) {
     auto& program = cached_program.program;
@@ -1047,40 +1083,61 @@ void UnifiedRoutedExpertFfnProgramFactory::override_runtime_arguments(
     const auto writer_id = cached_program.shared_variables.writer_kernel_id;
     const auto& cores = cached_program.shared_variables.cores;
 
+    const uint32_t N = op.experts_per_chip;
+    const bool has_bias = op.fuse_bias;
     const uint32_t x_addr = t.x.buffer()->address();
-    const uint32_t gate_addr = t.gate_proj.buffer()->address();
-    const uint32_t up_addr = t.up_proj.buffer()->address();
-    const uint32_t down_addr = t.down_proj.buffer()->address();
     const uint32_t counts_addr = t.counts.buffer()->address();
     const uint32_t idx_addr = t.global_expert_idx_table.buffer()->address();
     const uint32_t out_addr = tensor_return_value.buffer()->address();
-    const uint32_t start_addr =
-        t.expert_region_offsets.has_value() ? t.expert_region_offsets->buffer()->address() : out_addr;
-    // FUSE_BIAS appends 3 bias addrs after start_addr, so start is no longer the
-    // last reader arg. Recover its index from the presence of the bias tensors.
-    const bool has_bias = t.gate_bias.has_value();
+    const uint32_t start_addr = t.expert_region_offsets->buffer()->address();
+
+    // Reader runtime-arg tail (see create()): [start_addr][gate*N][up*N][down*N]
+    // (+ [gbias*N][ubias*N][dbias*N] when fuse_bias). Recover start_addr's index
+    // from the fixed tail length so the per-expert address blocks that follow it
+    // land at the same slots the kernel reads.
+    const size_t weights_len = static_cast<size_t>(3u * N) + (has_bias ? static_cast<size_t>(3u * N) : 0u);
 
     for (const auto& core : cores) {
         auto& reader_args = tt::tt_metal::GetRuntimeArgs(program, reader_id, core);
         reader_args[0] = x_addr;
-        reader_args[1] = gate_addr;
-        reader_args[2] = up_addr;
-        reader_args[3] = down_addr;
+        reader_args[1] = t.gate_projs[0].buffer()->address();  // expert-0 (accessor base; loop uses the arrays)
+        reader_args[2] = t.up_projs[0].buffer()->address();
+        reader_args[3] = t.down_projs[0].buffer()->address();
         reader_args[4] = counts_addr;
         reader_args[5] = idx_addr;
-        // start_addr sits before the (optional) 3 trailing bias addrs.
-        const size_t start_idx = reader_args.size() - 1 - (has_bias ? 3 : 0);
+        const size_t start_idx = reader_args.size() - weights_len - 1;
         reader_args[start_idx] = start_addr;
+        size_t w = start_idx + 1;
+        for (uint32_t e = 0; e < N; ++e) {
+            reader_args[w++] = t.gate_projs[e].buffer()->address();
+        }
+        for (uint32_t e = 0; e < N; ++e) {
+            reader_args[w++] = t.up_projs[e].buffer()->address();
+        }
+        for (uint32_t e = 0; e < N; ++e) {
+            reader_args[w++] = t.down_projs[e].buffer()->address();
+        }
         if (has_bias) {
-            reader_args[reader_args.size() - 3] = t.gate_bias->buffer()->address();
-            reader_args[reader_args.size() - 2] = t.up_bias->buffer()->address();
-            reader_args[reader_args.size() - 1] = t.down_bias->buffer()->address();
+            for (uint32_t e = 0; e < N; ++e) {
+                reader_args[w++] = t.gate_biases[e].buffer()->address();
+            }
+            for (uint32_t e = 0; e < N; ++e) {
+                reader_args[w++] = t.up_biases[e].buffer()->address();
+            }
+            for (uint32_t e = 0; e < N; ++e) {
+                reader_args[w++] = t.down_biases[e].buffer()->address();
+            }
         }
 
         auto& writer_args = tt::tt_metal::GetRuntimeArgs(program, writer_id, core);
         writer_args[0] = out_addr;
         writer_args[3] = start_addr;
-        writer_args[4] = up_addr;  // two-RISC up-weight read base address
+        writer_args[4] = t.up_projs[0].buffer()->address();  // expert-0 (index stability)
+        // Per-expert `up` addresses occupy the final N slots.
+        size_t u = writer_args.size() - N;
+        for (uint32_t e = 0; e < N; ++e) {
+            writer_args[u++] = t.up_projs[e].buffer()->address();
+        }
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_types.hpp
@@ -7,6 +7,7 @@
 #include <cstdint>
 #include <optional>
 #include <tuple>
+#include <vector>
 
 #include <tt-metalium/constants.hpp>
 
@@ -42,33 +43,22 @@ enum class RoutedExpertActivation : uint8_t {
 
 // Attributes (the constants known at host time).
 struct UnifiedRoutedExpertFfnParams {
-    // The compute kernel chunks the M axis into pieces of this many tiles so a
-    // single matmul fits in per-core L1. 64 (= 2048 tokens) is the maximum that
-    // keeps DeepSeek V3 routed-expert dims inside Blackhole L1.
-    uint32_t chunk_M_tiles = 64;
-
-    // This expert's M dimension in tiles — the row count the matmul grid,
-    // chunk loop, and CB sizes are built for. Decoupled from x's shape so x
-    // may be a shared buffer larger than one expert's region: the reader/writer
-    // index into it at the region offset while the op still sizes its work to a
-    // single expert. When x IS the per-expert tensor this equals x_padded[-2]/TILE.
+    // Per-expert M dimension in tiles — the row count the matmul grid, chunk
+    // loop, and CB sizes are built for. Every local expert shares this value
+    // (= max_dispatched_tokens_per_expert / TILE), and x is the shared
+    // dispatched buffer wider than one expert's region: the reader/writer index
+    // into it at each expert's region offset while the op sizes its per-expert
+    // work to this M.
     uint32_t m_tiles = 0;
 
-    // Local expert id used to index `global_expert_idx_table` at runtime
-    // (kernel reads global_id = idx_table[local_expert_id], then count =
-    // counts[global_id]).
-    uint32_t local_expert_id = 0;
-
-    // When true, x is a shared buffer and the reader offsets its x reads by this
-    // expert's region start (expert_region_offsets[global_id]) — fusing what
-    // ttnn::extract did. Requires expert_region_offsets. False => x is per-expert.
-    bool read_x_at_offset = false;
+    // Number of local experts this chip owns. The reader/compute/writer kernels
+    // loop over local_expert in [0, experts_per_chip).
+    uint32_t experts_per_chip = 1;
 
     // When true, x is a ROW_MAJOR bf16 buffer: the reader streams row-major
     // sticks and the compute kernel tilizes them (bf16 -> bf8_b) before the
     // gate/up matmul, fusing the standalone to_layout. False => x is already
-    // TILE bf8_b (the reader reads tile pages directly). Off preserves the
-    // pre-fusion path for standalone / Wormhole callers.
+    // TILE bf8_b (the reader reads tile pages directly).
     bool x_is_row_major = false;
 
     // Per-expert FFN activation variant. Baked into the compute kernel as a
@@ -85,56 +75,56 @@ struct UnifiedRoutedExpertFfnParams {
 
     std::optional<ttnn::DeviceComputeKernelConfig> compute_kernel_config;
 
-    static constexpr auto attribute_names = std::forward_as_tuple(
-        "chunk_M_tiles",
-        "m_tiles",
-        "local_expert_id",
-        "read_x_at_offset",
-        "x_is_row_major",
-        "activation",
-        "fuse_bias");
+    static constexpr auto attribute_names =
+        std::forward_as_tuple("m_tiles", "experts_per_chip", "x_is_row_major", "activation", "fuse_bias");
     auto attribute_values() const {
-        return std::forward_as_tuple(
-            chunk_M_tiles, m_tiles, local_expert_id, read_x_at_offset, x_is_row_major, activation, fuse_bias);
+        return std::forward_as_tuple(m_tiles, experts_per_chip, x_is_row_major, activation, fuse_bias);
     }
 };
 
 // Tensors fed into the op.
 //
-// x is the (M_max, K=emb) per-expert token buffer for this expert. Only the
-// first `counts[global_expert_idx_table[local_expert_id]]` rows are valid;
-// the rest is padding the FFN kernels must skip. Reader/writer always start
-// at tile row 0 — the FFN op operates on an already-extracted per-expert
-// tensor; a separate ttnn::extract / ttnn::insert pair handles slicing into
-// / out of any shared dispatched buffer.
+// x is the (M_max, K=emb) shared dispatched buffer holding every local
+// expert's tokens back to back. Expert `local_expert`'s rows begin at
+// expert_region_offsets[global_id] and only its first counts[global_id] rows
+// are valid; the kernels read each expert's slice at its region offset.
 //
-// gate_proj/up_proj/down_proj are the (K=emb, N=hidden), (K=emb, N=hidden),
-// and (K=hidden, N=emb) weight tensors.
+// gate_projs/up_projs/down_projs are per-local-expert weight lists (one entry
+// per expert, all identical shape): (K=emb, N=hidden), (K=emb, N=hidden), and
+// (K=hidden, N=emb). Each expert has its own DRAM buffer; the program factory
+// passes every buffer's base address as a runtime-arg array and the kernels
+// build a fresh accessor per expert from one shared layout descriptor.
 //
-// counts/global_expert_idx_table are the device-side count buffers; the
-// kernel reads them at runtime to skip unused chunks.
+// counts / global_expert_idx_table / expert_region_offsets are the device-side
+// per-global-expert vectors; the kernels index them per local expert at
+// runtime to size each expert's chunk loop and place its output.
+//
+// output is the shared destination buffer; each expert's result is written
+// directly into its region at expert_region_offsets[global_id]/TILE tile-rows.
 struct UnifiedRoutedExpertFfnInputs {
     Tensor x;
-    Tensor gate_proj;
-    Tensor up_proj;
-    Tensor down_proj;
+    std::vector<Tensor> gate_projs;
+    std::vector<Tensor> up_projs;
+    std::vector<Tensor> down_projs;
     Tensor counts;
     Tensor global_expert_idx_table;
-    std::optional<Tensor> optional_output;
-    // Direct-write mode: per-global-expert region start offsets (UINT32, the
-    // same `start` tensor ttnn::insert consumes). When present, the writer
-    // places this expert's output directly into `optional_output` (the shared
-    // buffer) at start[global_id]/TILE tile-rows, fusing the ttnn::insert step.
-    // Requires optional_output to also be set.
+    // Caller-provided shared destination buffer (always provided). Each expert
+    // writes its region at expert_region_offsets[global_id]. Whether it aliases
+    // x (in-place) is the caller's choice — the op just writes into it.
+    Tensor output;
+    // Per-global-expert region start offsets (UINT32, the same `start` tensor
+    // ttnn::insert consumes). Required: the reader offsets each expert's x reads
+    // and the writer places each expert's output at start[global_id]/TILE.
     std::optional<Tensor> expert_region_offsets;
-    // Optional per-expert projection biases (gpt-oss). All three are present or
-    // all absent (validated host-side). gate_bias/up_bias are (1, N=hidden);
-    // down_bias is (1, N=emb). When set, the fused kernel adds gate/up bias
-    // before the activation and down bias after the down matmul. Absent for the
-    // bias-free DeepSeek / MiniMax-M3 path (byte-identical).
-    std::optional<Tensor> gate_bias;
-    std::optional<Tensor> up_bias;
-    std::optional<Tensor> down_bias;
+    // Optional per-local-expert projection biases (gpt-oss). Either all three
+    // lists are populated (one bias per local expert, same length/order as the
+    // weight lists) or all three are empty. gate/up bias: (1, N=hidden); down
+    // bias: (1, N=emb). When set, the fused kernel adds gate/up bias before the
+    // activation and down bias after the down matmul. Empty for the bias-free
+    // DeepSeek / MiniMax-M3 path (byte-identical).
+    std::vector<Tensor> gate_biases;
+    std::vector<Tensor> up_biases;
+    std::vector<Tensor> down_biases;
 };
 
 }  // namespace ttnn::operations::experimental::deepseek_prefill::unified_routed_expert_ffn

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_types.hpp
@@ -7,6 +7,7 @@
 #include <cstdint>
 #include <optional>
 #include <tuple>
+#include <vector>
 
 #include <tt-metalium/constants.hpp>
 
@@ -46,33 +47,22 @@ enum class RoutedExpertActivation : uint8_t {
 
 // Attributes (the constants known at host time).
 struct UnifiedRoutedExpertFfnParams {
-    // The compute kernel chunks the M axis into pieces of this many tiles so a
-    // single matmul fits in per-core L1. 64 (= 2048 tokens) is the maximum that
-    // keeps DeepSeek V3 routed-expert dims inside Blackhole L1.
-    uint32_t chunk_M_tiles = 64;
-
-    // This expert's M dimension in tiles — the row count the matmul grid,
-    // chunk loop, and CB sizes are built for. Decoupled from x's shape so x
-    // may be a shared buffer larger than one expert's region: the reader/writer
-    // index into it at the region offset while the op still sizes its work to a
-    // single expert. When x IS the per-expert tensor this equals x_padded[-2]/TILE.
+    // Per-expert M dimension in tiles — the row count the matmul grid, chunk
+    // loop, and CB sizes are built for. Every local expert shares this value
+    // (= max_dispatched_tokens_per_expert / TILE), and x is the shared
+    // dispatched buffer wider than one expert's region: the reader/writer index
+    // into it at each expert's region offset while the op sizes its per-expert
+    // work to this M.
     uint32_t m_tiles = 0;
 
-    // Local expert id used to index `global_expert_idx_table` at runtime
-    // (kernel reads global_id = idx_table[local_expert_id], then count =
-    // counts[global_id]).
-    uint32_t local_expert_id = 0;
-
-    // When true, x is a shared buffer and the reader offsets its x reads by this
-    // expert's region start (expert_region_offsets[global_id]) — fusing what
-    // ttnn::extract did. Requires expert_region_offsets. False => x is per-expert.
-    bool read_x_at_offset = false;
+    // Number of local experts this chip owns. The reader/compute/writer kernels
+    // loop over local_expert in [0, experts_per_chip).
+    uint32_t experts_per_chip = 1;
 
     // When true, x is a ROW_MAJOR bf16 buffer: the reader streams row-major
     // sticks and the compute kernel tilizes them (bf16 -> bf8_b) before the
     // gate/up matmul, fusing the standalone to_layout. False => x is already
-    // TILE bf8_b (the reader reads tile pages directly). Off preserves the
-    // pre-fusion path for standalone / Wormhole callers.
+    // TILE bf8_b (the reader reads tile pages directly).
     bool x_is_row_major = false;
 
     // Per-expert FFN activation variant. Baked into the compute kernel as a
@@ -89,56 +79,56 @@ struct UnifiedRoutedExpertFfnParams {
 
     std::optional<ttnn::DeviceComputeKernelConfig> compute_kernel_config;
 
-    static constexpr auto attribute_names = std::forward_as_tuple(
-        "chunk_M_tiles",
-        "m_tiles",
-        "local_expert_id",
-        "read_x_at_offset",
-        "x_is_row_major",
-        "activation",
-        "fuse_bias");
+    static constexpr auto attribute_names =
+        std::forward_as_tuple("m_tiles", "experts_per_chip", "x_is_row_major", "activation", "fuse_bias");
     auto attribute_values() const {
-        return std::forward_as_tuple(
-            chunk_M_tiles, m_tiles, local_expert_id, read_x_at_offset, x_is_row_major, activation, fuse_bias);
+        return std::forward_as_tuple(m_tiles, experts_per_chip, x_is_row_major, activation, fuse_bias);
     }
 };
 
 // Tensors fed into the op.
 //
-// x is the (M_max, K=emb) per-expert token buffer for this expert. Only the
-// first `counts[global_expert_idx_table[local_expert_id]]` rows are valid;
-// the rest is padding the FFN kernels must skip. Reader/writer always start
-// at tile row 0 — the FFN op operates on an already-extracted per-expert
-// tensor; a separate ttnn::extract / ttnn::insert pair handles slicing into
-// / out of any shared dispatched buffer.
+// x is the (M_max, K=emb) shared dispatched buffer holding every local
+// expert's tokens back to back. Expert `local_expert`'s rows begin at
+// expert_region_offsets[global_id] and only its first counts[global_id] rows
+// are valid; the kernels read each expert's slice at its region offset.
 //
-// gate_proj/up_proj/down_proj are the (K=emb, N=hidden), (K=emb, N=hidden),
-// and (K=hidden, N=emb) weight tensors.
+// gate_projs/up_projs/down_projs are per-local-expert weight lists (one entry
+// per expert, all identical shape): (K=emb, N=hidden), (K=emb, N=hidden), and
+// (K=hidden, N=emb). Each expert has its own DRAM buffer; the program factory
+// passes every buffer's base address as a runtime-arg array and the kernels
+// build a fresh accessor per expert from one shared layout descriptor.
 //
-// counts/global_expert_idx_table are the device-side count buffers; the
-// kernel reads them at runtime to skip unused chunks.
+// counts / global_expert_idx_table / expert_region_offsets are the device-side
+// per-global-expert vectors; the kernels index them per local expert at
+// runtime to size each expert's chunk loop and place its output.
+//
+// output is the shared destination buffer; each expert's result is written
+// directly into its region at expert_region_offsets[global_id]/TILE tile-rows.
 struct UnifiedRoutedExpertFfnInputs {
     Tensor x;
-    Tensor gate_proj;
-    Tensor up_proj;
-    Tensor down_proj;
+    std::vector<Tensor> gate_projs;
+    std::vector<Tensor> up_projs;
+    std::vector<Tensor> down_projs;
     Tensor counts;
     Tensor global_expert_idx_table;
-    std::optional<Tensor> optional_output;
-    // Direct-write mode: per-global-expert region start offsets (UINT32, the
-    // same `start` tensor ttnn::insert consumes). When present, the writer
-    // places this expert's output directly into `optional_output` (the shared
-    // buffer) at start[global_id]/TILE tile-rows, fusing the ttnn::insert step.
-    // Requires optional_output to also be set.
+    // Caller-provided shared destination buffer (always provided). Each expert
+    // writes its region at expert_region_offsets[global_id]. Whether it aliases
+    // x (in-place) is the caller's choice — the op just writes into it.
+    Tensor output;
+    // Per-global-expert region start offsets (UINT32, the same `start` tensor
+    // ttnn::insert consumes). Required: the reader offsets each expert's x reads
+    // and the writer places each expert's output at start[global_id]/TILE.
     std::optional<Tensor> expert_region_offsets;
-    // Optional per-expert projection biases (gpt-oss). All three are present or
-    // all absent (validated host-side). gate_bias/up_bias are (1, N=hidden);
-    // down_bias is (1, N=emb). When set, the fused kernel adds gate/up bias
-    // before the activation and down bias after the down matmul. Absent for the
-    // bias-free DeepSeek / MiniMax-M3 path (byte-identical).
-    std::optional<Tensor> gate_bias;
-    std::optional<Tensor> up_bias;
-    std::optional<Tensor> down_bias;
+    // Optional per-local-expert projection biases (gpt-oss). Either all three
+    // lists are populated (one bias per local expert, same length/order as the
+    // weight lists) or all three are empty. gate/up bias: (1, N=hidden); down
+    // bias: (1, N=emb). When set, the fused kernel adds gate/up bias before the
+    // activation and down bias after the down matmul. Empty for the bias-free
+    // DeepSeek / MiniMax-M3 path (byte-identical).
+    std::vector<Tensor> gate_biases;
+    std::vector<Tensor> up_biases;
+    std::vector<Tensor> down_biases;
 };
 
 }  // namespace ttnn::operations::experimental::deepseek_prefill::unified_routed_expert_ffn

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/unified_routed_expert_ffn.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/unified_routed_expert_ffn.cpp
@@ -7,65 +7,8 @@
 #include "device/unified_routed_expert_ffn_device_operation.hpp"
 #include "tt-metalium/math.hpp"
 #include "ttnn/operations/creation/creation.hpp"
-#include "ttnn/operations/experimental/deepseek_prefill/routed_expert_ffn/routed_expert_ffn.hpp"
 
 namespace ttnn::operations::experimental::deepseek_prefill::unified_routed_expert_ffn {
-
-ttnn::Tensor unified_routed_expert_ffn(
-    const ttnn::Tensor& x,
-    const ttnn::Tensor& gate_proj,
-    const ttnn::Tensor& up_proj,
-    const ttnn::Tensor& down_proj,
-    const ttnn::Tensor& counts,
-    const ttnn::Tensor& global_expert_idx_table,
-    uint32_t local_expert_id,
-    const std::optional<const ttnn::DeviceComputeKernelConfig>& compute_kernel_config,
-    const std::optional<ttnn::Tensor>& output,
-    const std::optional<ttnn::Tensor>& expert_region_offsets,
-    const std::optional<uint32_t>& input_m_tiles,
-    bool read_x_at_offset,
-    bool x_is_row_major,
-    RoutedExpertActivation activation,
-    const std::optional<ttnn::Tensor>& gate_bias,
-    const std::optional<ttnn::Tensor>& up_bias,
-    const std::optional<ttnn::Tensor>& down_bias) {
-    // Single-op fused per-expert FFN. One device Program runs gate matmul,
-    // up matmul, silu, multiply, down matmul as four phases inside the same
-    // kernel. The kernel reads counts[global_expert_idx_table[local_expert_id]]
-    // device-side at entry and, from that runtime count, PICKS chunk_M_tiles /
-    // per_core_M / num_chunks itself (adaptive_chunk.hpp) — sizing the per-core
-    // work to the actual token count with no expected-token argument. chunks
-    // past the count are skipped entirely (no matmul, no mcast).
-    //
-    // The host only sets the CB-sized MAXIMUM chunk (kMaxChunkMTiles => per_core_M
-    // 8). The program factory's L1 guard may lower it for large models; the
-    // device picker never exceeds whatever max the CBs were sized to.
-    constexpr uint32_t kMaxChunkMTiles = 64;  // per_core_M_max = 8 (L1 cap)
-    // This expert's M in tiles. Defaults to x's allocated M; a caller passing a
-    // shared x buffer (wider than one region) supplies the per-expert value.
-    const uint32_t M_tiles_full = input_m_tiles.value_or(x.padded_shape()[-2] / 32);
-
-    return ttnn::prim::unified_routed_expert_ffn(
-        x,
-        gate_proj,
-        up_proj,
-        down_proj,
-        counts,
-        global_expert_idx_table,
-        local_expert_id,
-        kMaxChunkMTiles,
-        M_tiles_full,
-        read_x_at_offset,
-        x_is_row_major,
-        compute_kernel_config.has_value() ? std::optional<ttnn::DeviceComputeKernelConfig>(*compute_kernel_config)
-                                          : std::nullopt,
-        output,
-        expert_region_offsets,
-        activation,
-        gate_bias,
-        up_bias,
-        down_bias);
-}
 
 ttnn::Tensor unified_routed_expert_moe(
     const ttnn::Tensor& dispatched_buffer,
@@ -81,6 +24,8 @@ ttnn::Tensor unified_routed_expert_moe(
     const std::optional<std::vector<ttnn::Tensor>>& gate_biases,
     const std::optional<std::vector<ttnn::Tensor>>& up_biases,
     const std::optional<std::vector<ttnn::Tensor>>& down_biases) {
+    // Single fused device op across ALL local experts. This builds ONE program
+    // whose reader/compute/writer kernels iterate over every local expert.
     TT_FATAL(
         gate_projs.size() == up_projs.size() && gate_projs.size() == down_projs.size(),
         "gate/up/down projection lists must have the same length (got {}, {}, {})",
@@ -109,30 +54,28 @@ ttnn::Tensor unified_routed_expert_moe(
             up_biases->size(),
             down_biases->size());
     }
+    const std::vector<ttnn::Tensor> gate_biases_v = has_bias ? *gate_biases : std::vector<ttnn::Tensor>{};
+    const std::vector<ttnn::Tensor> up_biases_v = has_bias ? *up_biases : std::vector<ttnn::Tensor>{};
+    const std::vector<ttnn::Tensor> down_biases_v = has_bias ? *down_biases : std::vector<ttnn::Tensor>{};
 
-    // Per-expert composite: run the unified FFN on each expert's slice of the
-    // dispatched buffer at that expert's region offset (read_x_at_offset for the
-    // reader, expert_region_offsets for the writer). This fuses the old
-    // ttnn::extract (input slice) + ttnn::insert (output placement) pair into the
-    // FFN's reader and writer — no per-expert temp buffer, no extra DRAM round
-    // trip. Same loop regardless of `num_routed_experts`.
-    //
-    // x is the whole shared buffer, so pass this expert's row count
-    // (max_dispatched_tokens_per_expert in tiles) as input_m_tiles — the op sizes
-    // its grid/chunks to one expert, not the buffer.
-    //
-    // The input layout selects the output strategy:
-    //   * TILE buffer -> write IN PLACE (output == dispatched_buffer). The reader
-    //     reads x in phase 1 and the writer drains cb_out only after compute
-    //     consumes it, so a row's write is ordered after its read via the CB
-    //     chain; chunks cover disjoint rows and experts touch disjoint regions,
-    //     so no expert can disturb another. No allocation, no up-front fill.
-    //   * ROW_MAJOR bf16 buffer -> the FFN tilizes x and packs bf8 internally, so
-    //     input and output differ in both layout and dtype and cannot alias. One
-    //     shared TILE bf8 output is allocated once for all experts; each writes
-    //     its own region. Left uninitialized (no fill): downstream `combine`
-    //     reads only written rows (bounded per expert to
-    //     [offset, offset + ceil_tile(count))).
+    // Per-expert M in tiles: every local expert is sized to the same
+    // max_dispatched_tokens_per_expert. The program config (including the M-axis
+    // chunk size) is built once from this M by the program factory and reused for
+    // every expert.
+    const uint32_t m_tiles = (max_dispatched_tokens_per_expert + 31) / 32;
+
+    // The input layout selects the output strategy (unchanged from the retired
+    // per-expert composite):
+    //   * TILE bf8 buffer -> write IN PLACE (output == dispatched_buffer). The
+    //     reader reads x before the writer drains cb_out for the same rows, so a
+    //     row's write is ordered after its read via the CB chain; chunks cover
+    //     disjoint rows and experts touch disjoint regions, so no expert can
+    //     disturb another. No allocation, no up-front fill.
+    //   * ROW_MAJOR bf16 buffer -> the op tilizes x and packs bf8 internally, so
+    //     input and output differ in layout and dtype and cannot alias. One
+    //     shared TILE bf8 output is allocated for all experts; each writes its
+    //     own region. Left uninitialized (downstream combine reads only written
+    //     rows, bounded per expert).
     const bool x_is_row_major = dispatched_buffer.layout() == tt::tt_metal::Layout::ROW_MAJOR;
     const ttnn::Tensor output =
         x_is_row_major ? ttnn::empty(
@@ -143,28 +86,25 @@ ttnn::Tensor unified_routed_expert_moe(
                              tt::tt_metal::MemoryConfig{
                                  tt::tt_metal::TensorMemoryLayout::INTERLEAVED, tt::tt_metal::BufferType::DRAM})
                        : dispatched_buffer;
-    const uint32_t m_tiles = (max_dispatched_tokens_per_expert + 31) / 32;
-    for (uint32_t local_expert = 0; local_expert < experts_per_chip; ++local_expert) {
-        unified_routed_expert_ffn(
-            dispatched_buffer,
-            gate_projs[local_expert],
-            up_projs[local_expert],
-            down_projs[local_expert],
-            expert_token_counts,
-            global_expert_idx_table,
-            local_expert,
-            compute_kernel_config,
-            output,
-            expert_region_offsets,
-            m_tiles,
-            /*read_x_at_offset=*/true,
-            x_is_row_major,
-            activation,
-            has_bias ? std::optional<ttnn::Tensor>((*gate_biases)[local_expert]) : std::nullopt,
-            has_bias ? std::optional<ttnn::Tensor>((*up_biases)[local_expert]) : std::nullopt,
-            has_bias ? std::optional<ttnn::Tensor>((*down_biases)[local_expert]) : std::nullopt);
-    }
-    return output;
+
+    return ttnn::prim::unified_routed_expert_moe(
+        dispatched_buffer,
+        gate_projs,
+        up_projs,
+        down_projs,
+        expert_token_counts,
+        global_expert_idx_table,
+        expert_region_offsets,
+        output,
+        m_tiles,
+        experts_per_chip,
+        x_is_row_major,
+        compute_kernel_config.has_value() ? std::optional<ttnn::DeviceComputeKernelConfig>(*compute_kernel_config)
+                                          : std::nullopt,
+        activation,
+        gate_biases_v,
+        up_biases_v,
+        down_biases_v);
 }
 
 }  // namespace ttnn::operations::experimental::deepseek_prefill::unified_routed_expert_ffn

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/unified_routed_expert_ffn.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/unified_routed_expert_ffn.hpp
@@ -15,90 +15,42 @@
 
 namespace ttnn::operations::experimental::deepseek_prefill::unified_routed_expert_ffn {
 
-// Single-op fused per-expert FFN for DeepSeek V3 prefill on Blackhole.
+// Single-op fused routed-expert MoE FFN for DeepSeek V3 prefill on Blackhole.
 //
-// Performs, all inside ONE device program (one row in tt-perf-report):
-//   gate = matmul(x, gate_proj)
-//   up   = matmul(x, up_proj)
-//   y    = matmul(silu(gate) * up, down_proj)
+// Takes the whole dispatched buffer + ALL local experts' weights and runs, in
+// ONE device program (one row in tt-perf-report), the full SwiGLU FFN for every
+// local expert:
+//   gate = matmul(x_e, gate_proj_e)
+//   up   = matmul(x_e, up_proj_e)
+//   y_e  = matmul(silu(gate) * up, down_proj_e)
 //
-// The kernel chunks the M axis internally and reads the device-resident
-// `counts[global_expert_idx_table[local_expert_id]]` value at runtime to skip
-// chunks beyond the actual token count for this expert. x is the
-// already-extracted per-expert tokens tensor (rows start at 0); use
-// `unified_routed_expert_moe` below if you need the extract/insert glue.
+// The device program's reader/compute/writer kernels loop over the
+// experts_per_chip local experts. For each expert `e` they resolve its global
+// id (global_expert_idx_table[e]), token count (expert_token_counts[global_id])
+// and region offset (expert_region_offsets[global_id]) device-side, read that
+// expert's slice of the shared dispatched buffer at the region offset and write
+// its output straight into the shared output buffer at the same offset.
 //
 // Args:
-//   x: (M_max, K=emb), DRAM interleaved. Layout/dtype depend on x_is_row_major:
-//      false (default) => TILE, BFLOAT8_B (read as tile pages directly);
-//      true => ROW_MAJOR, BFLOAT16 (the reader streams sticks and the compute
-//      kernel tilizes+packs to bf8_b internally, see x_is_row_major). Only the
-//      first ceil_tile(count) rows are valid (the rest is dispatch padding).
-//   gate_proj: (K=emb, N=hidden), TILE, DRAM interleaved (any weights dtype).
-//   up_proj:   (K=emb, N=hidden), TILE, DRAM interleaved (any weights dtype).
-//   down_proj: (K=hidden, N=emb), TILE, DRAM interleaved (any weights dtype).
-//   counts: device-resident UINT32 vector, one entry per global expert id.
-//   global_expert_idx_table: device-resident UINT32 vector,
-//      counts[global_expert_idx_table[local_expert_id]] == this expert's
-//      actual token count.
-//   local_expert_id: index into global_expert_idx_table.
-//   compute_kernel_config: optional matmul math fidelity / accumulator config.
-//   output: optional pre-allocated DRAM-interleaved, TILE-layout output tensor
-//      to write into. Dtype rule is mode-dependent: in the default mode
-//      (x_is_row_major=false) it must match x.dtype() (BFLOAT8_B); in row-major
-//      mode (x_is_row_major=true) x is BFLOAT16 ROW_MAJOR while the op emits a
-//      TILE result (typically BFLOAT8_B) — the compute kernel tilizes+packs to
-//      the output's dtype regardless, so output need not match x there. Shape
-//      must match x unless expert_region_offsets is set (direct-write mode), in
-//      which case it is the larger shared destination buffer.
-//   expert_region_offsets: optional UINT32 per-global-expert region start
-//      offsets (the same `start` tensor ttnn::insert consumes). When set, the
-//      writer places this expert's output directly into `output` (the shared
-//      buffer) at start[global_id]/TILE tile-rows, fusing the ttnn::insert
-//      step (no temp-buffer DRAM round-trip). Requires `output` to be set.
-//   input_m_tiles: optional per-expert M in tiles. Defaults to x's allocated
-//      M (x_padded[-2]/TILE). Supply it when x is a shared buffer wider than
-//      one expert's region so the op sizes its grid/chunks to this expert only.
-//   read_x_at_offset: when true, x is a shared buffer and the reader offsets
-//      its x reads by expert_region_offsets[global_id] (fusing ttnn::extract).
-//      Requires expert_region_offsets. False => x is per-expert (rows at 0).
-//   x_is_row_major: when true, x is ROW_MAJOR bf16; the reader streams sticks
-//      and the compute kernel tilizes them to bf8_b before the matmul (fusing
-//      the standalone to_layout). False => x is already TILE bf8_b.
-ttnn::Tensor unified_routed_expert_ffn(
-    const ttnn::Tensor& x,
-    const ttnn::Tensor& gate_proj,
-    const ttnn::Tensor& up_proj,
-    const ttnn::Tensor& down_proj,
-    const ttnn::Tensor& counts,
-    const ttnn::Tensor& global_expert_idx_table,
-    uint32_t local_expert_id,
-    const std::optional<const ttnn::DeviceComputeKernelConfig>& compute_kernel_config = std::nullopt,
-    const std::optional<ttnn::Tensor>& output = std::nullopt,
-    const std::optional<ttnn::Tensor>& expert_region_offsets = std::nullopt,
-    const std::optional<uint32_t>& input_m_tiles = std::nullopt,
-    bool read_x_at_offset = false,
-    bool x_is_row_major = false,
-    RoutedExpertActivation activation = RoutedExpertActivation::Silu,
-    // Optional per-expert projection biases (gpt-oss). All three together or
-    // none. gate_bias/up_bias: (1, hidden); down_bias: (1, emb). When set, the
-    // kernel adds gate/up bias before the activation and down bias after the
-    // down matmul. Omit for the bias-free DeepSeek / MiniMax-M3 path.
-    const std::optional<ttnn::Tensor>& gate_bias = std::nullopt,
-    const std::optional<ttnn::Tensor>& up_bias = std::nullopt,
-    const std::optional<ttnn::Tensor>& down_bias = std::nullopt);
-
-// MoE-level composite: takes the dispatched buffer + ALL local experts'
-// weights and loops over local experts in C++, calling
-//   extract -> unified_routed_expert_ffn (direct-write)
-// per expert. The FFN writer places each expert's output directly into the
-// shared output buffer at its region offset (the old per-expert ttnn::insert
-// is fused into the FFN writer — no temp buffer, no second DRAM round-trip).
-// NOT a single fused device op across experts (per-expert FFN entries still
-// appear in tt-perf-report); Python sees one call, the device sees N.
+//   dispatched_buffer: (max_dispatch, emb). Blackhole fast path: ROW_MAJOR
+//     BFLOAT16 (tilized + bf8-packed in-op, fresh TILE bf8 output). A TILE bf8
+//     dispatch buffer is instead written in place.
+//   expert_region_offsets: UINT32 per-global-expert region start offsets.
+//   expert_token_counts: UINT32 per-global-expert token counts.
+//   global_expert_idx_table: UINT32 local-slot -> global-expert-id map.
+//   gate_projs/up_projs/down_projs: one (emb, hidden)/(emb, hidden)/(hidden,
+//     emb) weight tensor per local expert (all identical shape/dtype).
+//   max_dispatched_tokens_per_expert: per-expert M the program is sized for.
 //
-// The unified FFN reads counts on-device so each expert's work scales to its
-// actual count. No host-side counts/idx read, no per-expert Python loop.
+// Keyword args:
+//   compute_kernel_config: optional matmul math fidelity / accumulator config.
+//   activation: Silu (default, DeepSeek) or SwiGluOai (clamped, MiniMax-M3 /
+//     gpt-oss).
+//   gate_biases/up_biases/down_biases: optional per-local-expert biases
+//     (gpt-oss), all three lists together or none, one entry per local expert.
+//
+// Returns:
+//   ttnn::Tensor: expert outputs, same shape as dispatched_buffer.
 ttnn::Tensor unified_routed_expert_moe(
     const ttnn::Tensor& dispatched_buffer,
     const ttnn::Tensor& expert_region_offsets,
@@ -110,9 +62,6 @@ ttnn::Tensor unified_routed_expert_moe(
     uint32_t max_dispatched_tokens_per_expert,
     const std::optional<const ttnn::DeviceComputeKernelConfig>& compute_kernel_config = std::nullopt,
     RoutedExpertActivation activation = RoutedExpertActivation::Silu,
-    // Optional per-expert biases (gpt-oss), one entry per local expert (same
-    // length/order as gate_projs). All three lists together or none. Omit for
-    // the bias-free DeepSeek / MiniMax-M3 path.
     const std::optional<std::vector<ttnn::Tensor>>& gate_biases = std::nullopt,
     const std::optional<std::vector<ttnn::Tensor>>& up_biases = std::nullopt,
     const std::optional<std::vector<ttnn::Tensor>>& down_biases = std::nullopt);
@@ -121,6 +70,5 @@ ttnn::Tensor unified_routed_expert_moe(
 
 namespace ttnn {
 using operations::experimental::deepseek_prefill::unified_routed_expert_ffn::RoutedExpertActivation;
-using operations::experimental::deepseek_prefill::unified_routed_expert_ffn::unified_routed_expert_ffn;
 using operations::experimental::deepseek_prefill::unified_routed_expert_ffn::unified_routed_expert_moe;
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/unified_routed_expert_ffn_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/unified_routed_expert_ffn_nanobind.cpp
@@ -20,119 +20,21 @@ void bind_unified_routed_expert_ffn(nb::module_& mod) {
         .value("Silu", RoutedExpertActivation::Silu)
         .value("SwiGluOai", RoutedExpertActivation::SwiGluOai);
 
-    ttnn::bind_function<"unified_routed_expert_ffn", "ttnn.experimental.deepseek_prefill.">(
-        mod,
-        R"doc(
-        Single-op fused per-expert FFN for DeepSeek V3 prefill (Blackhole).
-
-        Computes the entire SwiGLU FFN sequence in ONE device program:
-            gate = matmul(x, gate_proj)
-            up   = matmul(x, up_proj)
-            y    = matmul(silu(gate) * up, down_proj)
-
-        The kernel reads the device-resident token count
-        ``counts[global_expert_idx_table[local_expert_id]]`` at runtime and
-        skips M-chunks beyond that count. x is the already-extracted per-expert
-        tokens tensor (rows start at 0); use ``unified_routed_expert_moe`` below
-        if you need the extract/insert glue.
-
-        Tensor requirements (enforced in validate_on_program_cache_miss),
-        conditional on ``x_is_row_major``:
-            * x dtype/layout: default mode (x_is_row_major=False) => BFLOAT8_B,
-              TILE (read as tile pages directly); row-major mode
-              (x_is_row_major=True) => BFLOAT16, ROW_MAJOR (streamed as sticks
-              and tilized + packed to bf8_b in-op before the matmul).
-            * gate/up/down: TILE, any matmul-compatible weight dtype.
-            * output: TILE. Its dtype must match x in the default mode, but in
-              row-major mode x is BFLOAT16 while output is TILE (typically
-              BFLOAT8_B) — the op packs its result to output's dtype regardless.
-            * memory_config: all tensors DRAM-interleaved.
-            * Blackhole-only — host expects 11x8 compute grid.
-
-        PCC target: >= 0.97 vs PyTorch reference (matches the sibling
-        routed_expert_ffn subsystem norm; the existing test_unified_routed_expert
-        cases land at ~0.98 on DS-V3 dims with LoFi math fidelity).
-
-        Args:
-            x (ttnn.Tensor): (M_max, K=emb) DRAM-interleaved input. Default mode:
-                TILE, BFLOAT8_B. Row-major mode (x_is_row_major=True): ROW_MAJOR,
-                BFLOAT16.
-            gate_proj (ttnn.Tensor): (K=emb, N=hidden).
-            up_proj (ttnn.Tensor): (K=emb, N=hidden).
-            down_proj (ttnn.Tensor): (K=hidden, N=emb).
-            counts (ttnn.Tensor): UINT32, per-global-expert token counts.
-            global_expert_idx_table (ttnn.Tensor): UINT32, maps local id -> global.
-            local_expert_id (int): index into global_expert_idx_table.
-
-        Keyword Args:
-            compute_kernel_config (ttnn.DeviceComputeKernelConfig, optional)
-            output (ttnn.Tensor, optional): pre-allocated TILE output buffer.
-                Its dtype must match x.dtype() in the default mode; in row-major
-                mode (x_is_row_major=True) x is BFLOAT16 ROW_MAJOR while output is
-                TILE (typically BFLOAT8_B) and need not match x — the op packs to
-                output's dtype. Shape must match x.shape() unless
-                expert_region_offsets is set (direct-write mode), in which case it
-                is the larger shared destination buffer.
-            expert_region_offsets (ttnn.Tensor, optional): UINT32
-                per-global-expert region start offsets. When set, the writer
-                places this expert's output directly into ``output`` at
-                start[global_id]/TILE tile-rows (direct-write mode), fusing the
-                ttnn::insert step. Requires ``output`` to be set. Defaults to
-                None (standalone per-expert output, rows start at 0).
-            input_m_tiles (int, optional): this expert's M in tiles. Defaults to
-                x's allocated M. Supply it when x is a shared buffer wider than
-                one expert's region so the op sizes its work to this expert.
-            read_x_at_offset (bool, optional): when True, x is a shared buffer
-                and the reader offsets x reads by expert_region_offsets[global_id]
-                (fusing ttnn::extract). Requires expert_region_offsets. Default False.
-            x_is_row_major (bool, optional): when True, x is ROW_MAJOR bf16; the
-                reader streams sticks and the compute kernel tilizes them to bf8_b
-                before the matmul (fusing to_layout). Default False (TILE bf8_b).
-            activation (ttnn.RoutedExpertActivation, optional):
-                Silu (default, DeepSeek) or SwiGluOai (clamped, MiniMax-M3 / gpt-oss).
-
-        The kernel picks chunk_M_tiles / per_core_M / num_chunks at RUNTIME from
-        the device-resident token count, so there is no chunk-sizing argument.
-
-        Returns:
-            ttnn.Tensor: (M_max, K=emb).
-        )doc",
-        &unified_routed_expert_ffn,
-        nb::arg("x").noconvert(),
-        nb::arg("gate_proj").noconvert(),
-        nb::arg("up_proj").noconvert(),
-        nb::arg("down_proj").noconvert(),
-        nb::arg("counts").noconvert(),
-        nb::arg("global_expert_idx_table").noconvert(),
-        nb::arg("local_expert_id"),
-        nb::kw_only(),
-        nb::arg("compute_kernel_config") = nb::none(),
-        nb::arg("output") = nb::none(),
-        nb::arg("expert_region_offsets") = nb::none(),
-        nb::arg("input_m_tiles") = nb::none(),
-        nb::arg("read_x_at_offset") = false,
-        nb::arg("x_is_row_major") = false,
-        nb::arg("activation") = RoutedExpertActivation::Silu,
-        nb::arg("gate_bias") = nb::none(),
-        nb::arg("up_bias") = nb::none(),
-        nb::arg("down_bias") = nb::none());
-
     ttnn::bind_function<"unified_routed_expert_moe", "ttnn.experimental.deepseek_prefill.">(
         mod,
         R"doc(
-        MoE-level composite: takes the full dispatched buffer + ALL local
-        experts' weights and loops over local experts in C++, launching one
-        ``unified_routed_expert_ffn`` device program per expert preceded by
-        ``ttnn::extract`` (input slice). The FFN runs in direct-write mode:
-        its writer places each expert's output straight into the shared
-        output buffer at the expert's region offset, so NO separate
-        ``ttnn::insert`` op (and no per-expert temp-buffer DRAM round-trip)
-        is needed. This is NOT a single fused device op across experts —
-        per-expert FFN entries still appear in tt-perf-report.
+        Single-op fused routed-expert MoE FFN (Blackhole). Takes the dispatched
+        buffer + ALL local experts' weights and runs in ONE device program. The
+        reader/compute/writer kernels loop over the local experts: each expert
+        reads its slice of the shared dispatched buffer at its region offset
+        (fusing ``ttnn::extract``), runs gate/up/down, and writes its output
+        straight into the shared output buffer at that offset (fusing
+        ``ttnn::insert``). NO per-expert temp buffer, no per-expert dispatch, and
+        no inter-expert dispatch gap.
 
-        The unified FFN reads device-resident counts/idx and bounds its
-        chunk loop to the actually-occupied chunks per expert. The host
-        does NOT sync to read counts.
+        The kernels read device-resident counts/idx and bound each expert's
+        chunk loop to the actually-occupied chunks. The host does NOT sync to
+        read counts.
 
         Args:
             dispatched_buffer (ttnn.Tensor): (max_dispatch, emb).

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/unified_routed_expert_ffn_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/unified_routed_expert_ffn_nanobind.cpp
@@ -21,120 +21,21 @@ void bind_unified_routed_expert_ffn(nb::module_& mod) {
         .value("SwiGluOai", RoutedExpertActivation::SwiGluOai)
         .value("SituGlu", RoutedExpertActivation::SituGlu);
 
-    ttnn::bind_function<"unified_routed_expert_ffn", "ttnn.experimental.deepseek_prefill.">(
-        mod,
-        R"doc(
-        Single-op fused per-expert FFN for DeepSeek V3 prefill (Blackhole).
-
-        Computes the entire SwiGLU FFN sequence in ONE device program:
-            gate = matmul(x, gate_proj)
-            up   = matmul(x, up_proj)
-            y    = matmul(silu(gate) * up, down_proj)
-
-        The kernel reads the device-resident token count
-        ``counts[global_expert_idx_table[local_expert_id]]`` at runtime and
-        skips M-chunks beyond that count. x is the already-extracted per-expert
-        tokens tensor (rows start at 0); use ``unified_routed_expert_moe`` below
-        if you need the extract/insert glue.
-
-        Tensor requirements (enforced in validate_on_program_cache_miss),
-        conditional on ``x_is_row_major``:
-            * x dtype/layout: default mode (x_is_row_major=False) => BFLOAT8_B,
-              TILE (read as tile pages directly); row-major mode
-              (x_is_row_major=True) => BFLOAT16, ROW_MAJOR (streamed as sticks
-              and tilized + packed to bf8_b in-op before the matmul).
-            * gate/up/down: TILE, any matmul-compatible weight dtype.
-            * output: TILE. Its dtype must match x in the default mode, but in
-              row-major mode x is BFLOAT16 while output is TILE (typically
-              BFLOAT8_B) — the op packs its result to output's dtype regardless.
-            * memory_config: all tensors DRAM-interleaved.
-            * Blackhole-only — host expects 11x8 compute grid.
-
-        PCC target: >= 0.97 vs PyTorch reference (matches the sibling
-        routed_expert_ffn subsystem norm; the existing test_unified_routed_expert
-        cases land at ~0.98 on DS-V3 dims with LoFi math fidelity).
-
-        Args:
-            x (ttnn.Tensor): (M_max, K=emb) DRAM-interleaved input. Default mode:
-                TILE, BFLOAT8_B. Row-major mode (x_is_row_major=True): ROW_MAJOR,
-                BFLOAT16.
-            gate_proj (ttnn.Tensor): (K=emb, N=hidden).
-            up_proj (ttnn.Tensor): (K=emb, N=hidden).
-            down_proj (ttnn.Tensor): (K=hidden, N=emb).
-            counts (ttnn.Tensor): UINT32, per-global-expert token counts.
-            global_expert_idx_table (ttnn.Tensor): UINT32, maps local id -> global.
-            local_expert_id (int): index into global_expert_idx_table.
-
-        Keyword Args:
-            compute_kernel_config (ttnn.DeviceComputeKernelConfig, optional)
-            output (ttnn.Tensor, optional): pre-allocated TILE output buffer.
-                Its dtype must match x.dtype() in the default mode; in row-major
-                mode (x_is_row_major=True) x is BFLOAT16 ROW_MAJOR while output is
-                TILE (typically BFLOAT8_B) and need not match x — the op packs to
-                output's dtype. Shape must match x.shape() unless
-                expert_region_offsets is set (direct-write mode), in which case it
-                is the larger shared destination buffer.
-            expert_region_offsets (ttnn.Tensor, optional): UINT32
-                per-global-expert region start offsets. When set, the writer
-                places this expert's output directly into ``output`` at
-                start[global_id]/TILE tile-rows (direct-write mode), fusing the
-                ttnn::insert step. Requires ``output`` to be set. Defaults to
-                None (standalone per-expert output, rows start at 0).
-            input_m_tiles (int, optional): this expert's M in tiles. Defaults to
-                x's allocated M. Supply it when x is a shared buffer wider than
-                one expert's region so the op sizes its work to this expert.
-            read_x_at_offset (bool, optional): when True, x is a shared buffer
-                and the reader offsets x reads by expert_region_offsets[global_id]
-                (fusing ttnn::extract). Requires expert_region_offsets. Default False.
-            x_is_row_major (bool, optional): when True, x is ROW_MAJOR bf16; the
-                reader streams sticks and the compute kernel tilizes them to bf8_b
-                before the matmul (fusing to_layout). Default False (TILE bf8_b).
-            activation (ttnn.RoutedExpertActivation, optional):
-                Silu (default, DeepSeek), SwiGluOai (clamped, MiniMax-M3 / gpt-oss),
-                or SituGlu (tanh-capped, Kimi K3; Blackhole only).
-
-        The kernel picks chunk_M_tiles / per_core_M / num_chunks at RUNTIME from
-        the device-resident token count, so there is no chunk-sizing argument.
-
-        Returns:
-            ttnn.Tensor: (M_max, K=emb).
-        )doc",
-        &unified_routed_expert_ffn,
-        nb::arg("x").noconvert(),
-        nb::arg("gate_proj").noconvert(),
-        nb::arg("up_proj").noconvert(),
-        nb::arg("down_proj").noconvert(),
-        nb::arg("counts").noconvert(),
-        nb::arg("global_expert_idx_table").noconvert(),
-        nb::arg("local_expert_id"),
-        nb::kw_only(),
-        nb::arg("compute_kernel_config") = nb::none(),
-        nb::arg("output") = nb::none(),
-        nb::arg("expert_region_offsets") = nb::none(),
-        nb::arg("input_m_tiles") = nb::none(),
-        nb::arg("read_x_at_offset") = false,
-        nb::arg("x_is_row_major") = false,
-        nb::arg("activation") = RoutedExpertActivation::Silu,
-        nb::arg("gate_bias") = nb::none(),
-        nb::arg("up_bias") = nb::none(),
-        nb::arg("down_bias") = nb::none());
-
     ttnn::bind_function<"unified_routed_expert_moe", "ttnn.experimental.deepseek_prefill.">(
         mod,
         R"doc(
-        MoE-level composite: takes the full dispatched buffer + ALL local
-        experts' weights and loops over local experts in C++, launching one
-        ``unified_routed_expert_ffn`` device program per expert preceded by
-        ``ttnn::extract`` (input slice). The FFN runs in direct-write mode:
-        its writer places each expert's output straight into the shared
-        output buffer at the expert's region offset, so NO separate
-        ``ttnn::insert`` op (and no per-expert temp-buffer DRAM round-trip)
-        is needed. This is NOT a single fused device op across experts —
-        per-expert FFN entries still appear in tt-perf-report.
+        Single-op fused routed-expert MoE FFN (Blackhole). Takes the dispatched
+        buffer + ALL local experts' weights and runs in ONE device program. The
+        reader/compute/writer kernels loop over the local experts: each expert
+        reads its slice of the shared dispatched buffer at its region offset
+        (fusing ``ttnn::extract``), runs gate/up/down, and writes its output
+        straight into the shared output buffer at that offset (fusing
+        ``ttnn::insert``). NO per-expert temp buffer, no per-expert dispatch, and
+        no inter-expert dispatch gap.
 
-        The unified FFN reads device-resident counts/idx and bounds its
-        chunk loop to the actually-occupied chunks per expert. The host
-        does NOT sync to read counts.
+        The kernels read device-resident counts/idx and bound each expert's
+        chunk loop to the actually-occupied chunks. The host does NOT sync to
+        read counts.
 
         Args:
             dispatched_buffer (ttnn.Tensor): (max_dispatch, emb).


### PR DESCRIPTION
## Overview

Consolidates all routed experts under a single device op. Previously
`unified_routed_expert_moe` launched one `unified_routed_expert_ffn` device
program per local expert in a C++ loop (one row per expert in
tt-perf-report, with a dispatch gap between each). Now **one** device program
iterates over every local expert inside its reader/compute/writer kernels,
removing the per-expert dispatch entries and the variable inter-expert gaps —
a step toward fusing routed-expert + combine into one op.

Resolves #50626.

## How it works

All local experts share one weight shape/dtype and the same per-expert M, so
the entire program config (grid, `chunk_M_tiles`, CBs, semaphores, subblocks)
is built **once** and reused. Each kernel wraps its existing per-chunk pipeline
in an outer `for (local_expert)` loop and varies only:

- **weight base addresses** — passed as per-expert runtime-arg arrays; one
  shared `TensorAccessorArgs` layout descriptor per role (gate/up/down, + `up`
  for the writer's UP_SPLIT read) covers every expert since only the base
  address differs;
- `global_id = idx_table[e]`, `count = counts[global_id]` → `effective_chunks`,
  and the region offset `start[global_id]`.

The correctness-critical matmul phase bodies (fused gate+up, SwiGLU/multiply,
down) are unchanged — only the surrounding per-expert bindings are new.

## Notable changes

- Reading x at the region offset (fusing `ttnn::extract`) and writing output at
  the region offset (fusing `ttnn::insert`) are now unconditional; the dead
  standalone/non-offset device-op paths are removed.
- The single-expert public `unified_routed_expert_ffn` op + nanobind binding are
  removed (nothing called them directly; everything routes through
  `unified_routed_expert_moe`). The Python-facing `unified_routed_expert_moe`
  signature is unchanged, so no model/test code changes.
- `tensor_args` carries `std::vector<Tensor>` weight/bias lists; `output` is a
  required tensor; `chunk_M_tiles` is derived in the program factory (a pure
  function of `m_tiles`) rather than passed through the op.
- A per-expert token count exceeding `max_dispatched_tokens_per_expert` now
  hard-asserts in all three kernels (no silent clamp that would drop tokens).

## Testing (Blackhole)

- `test_ds_moe[...pcc-device-256]` (32 experts/chip, ROW_MAJOR path): routed
  0.9748, final 0.9886, reference 0.9885 — all above threshold.
- `test_single_routed_expert.py`: **56/56 passed** — dsv3, dsv4_pro, dsv4_flash,
  kimi_k26 (SiLU), minimax_m27, glm_51 (SwiGLU-OAI), gptoss_120b (SwiGLU-OAI +
  fused bias), across 1k/25k and faked-token-count variants.

## CI Pipelines

[![Blaze Models Prefill](https://github.com/tenstorrent/tt-metal/actions/workflows/blaze-models-prefill-tests.yaml/badge.svg?branch=fbajraktari/50626-all-experts-one-op)](https://github.com/tenstorrent/tt-metal/actions/workflows/blaze-models-prefill-tests.yaml?query=branch%3Afbajraktari%2F50626-all-experts-one-op)   
[![BH e2e DeepSeek Prefill](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=fbajraktari/50626-all-experts-one-op)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch%3Afbajraktari%2F50626-all-experts-one-op)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=fbajraktari/50626-all-experts-one-op)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:fbajraktari/50626-all-experts-one-op)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=fbajraktari/50626-all-experts-one-op)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:fbajraktari/50626-all-experts-one-op)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fbajraktari/50626-all-experts-one-op)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fbajraktari/50626-all-experts-one-op)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=fbajraktari/50626-all-experts-one-op)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:fbajraktari/50626-all-experts-one-op)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=fbajraktari/50626-all-experts-one-op)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:fbajraktari/50626-all-experts-one-op)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=fbajraktari/50626-all-experts-one-op)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:fbajraktari/50626-all-experts-one-op)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=fbajraktari/50626-all-experts-one-op)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:fbajraktari/50626-all-experts-one-op)