### PR TITLE
quasar sfpu: binary div uses renamed _init_reciprocal_

### DIFF
--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_binary.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_binary.h
@@ -119,7 +119,7 @@ inline void calculate_sfpu_binary(
 template <[[maybe_unused]] bool APPROXIMATION_MODE, BinaryOp BINOP>
 inline void sfpu_binary_init() {
     if constexpr (BINOP == BinaryOp::DIV) {
-        _init_sfpu_reciprocal_<APPROXIMATION_MODE>();
+        _init_reciprocal_<APPROXIMATION_MODE>();
     }
 }
 


### PR DESCRIPTION
`sfpu_binary_init` (`BinaryOp::DIV`) now calls `_init_reciprocal_`, renamed from
`_init_sfpu_reciprocal_` in the reciprocal PR.

**Stacking note:** depends on the reciprocal PR (#50887), which performs the
`_init_sfpu_reciprocal_` → `_init_reciprocal_` rename. Targeted at `main` for early review;
won't compile until recip merges (the renamed symbol lands there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=quasar-sfpu-binary)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:quasar-sfpu-binary)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=quasar-sfpu-binary)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:quasar-sfpu-binary)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=quasar-sfpu-binary)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:quasar-sfpu-binary)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=quasar-sfpu-binary)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:quasar-sfpu-binary)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=quasar-sfpu-binary)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:quasar-sfpu-binary)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=quasar-sfpu-binary)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:quasar-sfpu-binary)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=quasar-sfpu-binary)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:quasar-sfpu-binary)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=quasar-sfpu-binary)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:quasar-sfpu-binary)