### PR TITLE
mcast_pipe: fix Blackhole multicast fan-out (use host active-core count, not rect area)

### DIFF
--- a/ttnn/cpp/ttnn/kernel_lib/mcast_pipe.inl
+++ b/ttnn/cpp/ttnn/kernel_lib/mcast_pipe.inl
@@ -43,11 +43,13 @@ SenderPipe<NOC_ID, DATA_READY_SEM_ID, PRE_HANDSHAKE, CONSUMER_READY_SEM_ID, DATA
     // and the rect are both constant), so compute it ONCE here rather than per send().
     in_rect_ = my_x[NOC_ID] >= dest_.xlo() && my_x[NOC_ID] <= dest_.xhi() && my_y[NOC_ID] >= dest_.ylo() &&
                my_y[NOC_ID] <= dest_.yhi();
-    // Fan-out, derived from the rect area (num_dests == area ± source) — precomputed so send()
-    // branch-selects between two constants with no arithmetic:
-    //   * EXCLUDE-source count: area minus self if this sender is in its own box;
-    //   * INCLUDE-source (loopback) count: +1 for the sender's own self-copy.
-    num_dests_excl_ = dest_.area() - (in_rect_ ? 1u : 0u);
+    // EXCLUDE-source multicast fan-out. On Blackhole the worker grid is non-contiguous, so a dense
+    // line's bounding box straddles non-worker columns and dest_.area() overcounts the real tensix
+    // destinations — the non-posted signal would then wait for acks from cores that do not exist and
+    // hang. So prefer the host-supplied active-core count (num_active on the wire); fall back to the
+    // rect geometry only for by-hand callers that pass ACK_EQUALS_FANOUT (exact on a gap-free grid).
+    num_dests_excl_ = (consumer_ack_count == ACK_EQUALS_FANOUT) ? (dest_.area() - (in_rect_ ? 1u : 0u))
+                                                                : consumer_ack_count;
     num_dests_incl_ = num_dests_excl_ + 1u;
     // Degenerate self-only box (a 1x1 rect that IS the sender): no receivers, send() does a local
     // copy. (`area==1 && in_rect` => excl==0.)


### PR DESCRIPTION
## Problem

`SenderPipe` derived its EXCLUDE-source multicast fan-out (`num_dests_excl_`) from the destination rectangle's geometric `area()`. That equals the true receiver count **only on a gap-free worker grid**.

On **Blackhole** the worker grid is non-contiguous in virtual coordinates — an 8-wide logical row maps to virtual-x `[1,2,3,4,5,6,7,10]` (columns 8,9 are non-worker DRAM/PCIe columns). A dense line's bounding box then straddles those non-worker columns, so `area()` **overcounts** the real tensix destinations. The sender's non-posted multicast waits for acks from cores that don't exist → **dispatch timeout / hang** on the trailing workers.

This is invisible on **Wormhole** (contiguous worker columns → `area() == num_active`), which is why it passed there.

## Fix

Use the host-supplied active-core count (`num_active`, already on the wire and passed into the ctor as `consumer_ack_count`) as the fan-out. Fall back to rect geometry only for by-hand callers that pass the `ACK_EQUALS_FANOUT` sentinel.

This mirrors what reference mcast ops already do (e.g. `ring_joint_sdpa_program_factory.cpp` passes the real receiver count, never the rectangle area). Rectangle multicast is preserved — no splitting into sub-rects.

```cpp
num_dests_excl_ = (consumer_ack_count == ACK_EQUALS_FANOUT)
                      ? (dest_.area() - (in_rect_ ? 1u : 0u))   // by-hand: rect geometry (gap-free only)
                      : consumer_ack_count;                      // host: true active-core count
```

## Test

`tests/ttnn/unit_tests/kernel_lib/test_mcast_pipe.py` on Blackhole (P150, 11×10):
- **Before:** 60 passed, 7 failed (all `grid_cols=8,grid_rows=4`, `span=8`, `diagonal_wraparound`)
- **After:** **67 passed, 0 failed** (157s w/ timeouts → 28s)

Wormhole behavior unchanged (`area() == num_active`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dnijemcevic/mcast-bh-fanout)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dnijemcevic/mcast-bh-fanout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dnijemcevic/mcast-bh-fanout)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dnijemcevic/mcast-bh-fanout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=dnijemcevic/mcast-bh-fanout)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:dnijemcevic/mcast-bh-fanout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dnijemcevic/mcast-bh-fanout)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dnijemcevic/mcast-bh-fanout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dnijemcevic/mcast-bh-fanout)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dnijemcevic/mcast-bh-fanout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dnijemcevic/mcast-bh-fanout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dnijemcevic/mcast-bh-fanout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dnijemcevic/mcast-bh-fanout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dnijemcevic/mcast-bh-fanout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dnijemcevic/mcast-bh-fanout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dnijemcevic/mcast-bh-fanout)