### PR TITLE
[ttnn] slice: fix height-sharded RM cache-hit descriptor rebuild (resnet-T3K regression)

### DIFF
--- a/tests/ttnn/unit_tests/operations/data_movement/test_slice.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_slice.py
@@ -1670,6 +1670,149 @@ def test_slice_override_addr_change_rm_height_sharded(device):
     assert_equal(torch_b[:n, :c_out, :h_out, :], ttnn.to_torch(ttnn.to_memory_config(tt_out_b, ttnn.L1_MEMORY_CONFIG)))
 
 
+@pytest.mark.skip_post_commit  # host-timing perf regression guard; run in perf/nightly, not fast post-commit
+def test_slice_rm_height_sharded_override_cache_hit_is_o1(device):
+    """The height-sharded slice cache-hit must patch CB addresses in O(1), not rebuild all per-core
+    args. A rebuild-on-hit is still a cache hit (entry count unchanged), so host dispatch time is the
+    only signal: assert it does not scale with the core grid (~15x rebuild vs ~1x patch, min-of-N)."""
+    import time
+
+    def _hit_host_us(num_cores_x, num_cores_y, reps=200):
+        ncores = num_cores_x * num_cores_y
+        grid = ttnn.CoreRangeSet(
+            {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(num_cores_x - 1, num_cores_y - 1))}
+        )
+        n, c, w = 1, 1, 16
+        h_out = ncores * 8  # sticks/core after slice
+        h_in = ncores * 10  # extra rows so the slice actually trims padding
+        in_cfg = ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            ttnn.BufferType.L1,
+            ttnn.ShardSpec(grid, (h_in, w), ttnn.ShardOrientation.ROW_MAJOR),
+        )
+        out_cfg = ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            ttnn.BufferType.L1,
+            ttnn.ShardSpec(grid, (h_out, w), ttnn.ShardOrientation.ROW_MAJOR),
+        )
+        t = torch.rand((n, c, h_in, w), dtype=torch.bfloat16)
+        tt = ttnn.from_torch(t, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, memory_config=in_cfg)
+        ttnn.slice(tt, (0, 0, 0, 0), (n, c, h_out, w), memory_config=out_cfg)  # warm (cache miss)
+        entries = device.num_program_cache_entries()
+        samples = []
+        for _ in range(reps):
+            t0 = time.perf_counter_ns()
+            ttnn.slice(tt, (0, 0, 0, 0), (n, c, h_out, w), memory_config=out_cfg)  # host enqueue (cache hit)
+            samples.append(time.perf_counter_ns() - t0)
+        ttnn.synchronize_device(device)
+        assert device.num_program_cache_entries() == entries, "timed calls must be pure cache hits"
+        return min(samples) / 1000.0  # microseconds
+
+    small_grid_us = _hit_host_us(1, 1)
+    large_grid_us = _hit_host_us(8, 7)  # 56 cores, resnet-fold-scale grid
+    assert large_grid_us < small_grid_us * 4.0, (
+        f"height-sharded slice cache-hit host dispatch scales with the core grid "
+        f"({small_grid_us:.0f}us @1 core -> {large_grid_us:.0f}us @56 cores): override_runtime_arguments "
+        f"is rebuilding the full per-core descriptor on every hit instead of patching the 2 CB addresses in O(1)"
+    )
+
+
+def _rm_height_sharded_slice(device, dtype, orientation, ncx, ncy, c, h_in, h_out, w_in, w_out):
+    """Build one height-sharded RM slice case; return (make_input, out_cfg, slice_end, reference_fn).
+    make_input() returns a fresh (torch, ttnn) pair so the caller can force new allocations."""
+    ncores = ncx * ncy
+    grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(ncx - 1, ncy - 1))})
+    n = 1
+    torch_dtype = {ttnn.bfloat16: torch.bfloat16, ttnn.float32: torch.float32}[dtype]
+    in_cfg = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        ttnn.BufferType.L1,
+        ttnn.ShardSpec(grid, ((n * c * h_in + ncores - 1) // ncores, w_in), orientation),
+    )
+    out_cfg = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        ttnn.BufferType.L1,
+        ttnn.ShardSpec(grid, ((n * c * h_out + ncores - 1) // ncores, w_out), orientation),
+    )
+
+    def make():
+        t = torch.rand((n, c, h_in, w_in)).to(torch_dtype)
+        tt = ttnn.from_torch(t, dtype=dtype, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, memory_config=in_cfg)
+        return t, tt
+
+    return make, out_cfg, (n, c, h_out, w_out), lambda t: t[:, :c, :h_out, :w_out]
+
+
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32])
+@pytest.mark.parametrize(
+    "orientation", [ttnn.ShardOrientation.ROW_MAJOR, ttnn.ShardOrientation.COL_MAJOR], ids=["rm_shard", "cm_shard"]
+)
+# (channels, grid_x, grid_y): single- and multi-channel over 1/4/56-core grids. Height-sharded slice
+# recomputes the output shard spec on padded configs (see test_slice_sharded_auto_shard_spec_recomputation),
+# which re-keys the cache; these combos divide evenly so the repeat is a deterministic cache hit.
+@pytest.mark.parametrize(
+    "c, ncx, ncy",
+    [(1, 1, 1), (1, 2, 2), (1, 8, 7), (4, 1, 1), (4, 2, 2)],
+    ids=["c1_1", "c1_4", "c1_56", "c4_1", "c4_4"],
+)
+def test_slice_rm_height_sharded_cache_hit_correctness(device, dtype, orientation, c, ncx, ncy):
+    """override_runtime_arguments patches only the two sharded CB addresses on a cache hit; its output
+    must stay correct across dtype / shard orientation / core grid / channels. Re-runs the slice on
+    re-addressed inputs and again on the same tensor (a guaranteed hit), asserting output each time.
+    (Entry count is not asserted: height-sharded output shard-spec auto-recompute makes hit-vs-rekey
+    allocation-dependent -- orthogonal to the address patch under test; correctness holds either way.)"""
+    ncores = ncx * ncy
+
+    def torch_out(out):
+        return ttnn.to_torch(ttnn.to_memory_config(out, ttnn.L1_MEMORY_CONFIG))
+
+    make, out_cfg, end, ref = _rm_height_sharded_slice(
+        device, dtype, orientation, ncx, ncy, c, 10 * ncores, 8 * ncores, 16, 16
+    )
+    keep = []
+    tt = None
+    for _ in range(3):
+        t, tt = make()
+        keep.append(tt)  # keep alive so the next input lands at a different address
+        out = ttnn.slice(tt, (0, 0, 0, 0), end, memory_config=out_cfg)
+        assert_equal(ref(t), torch_out(out))
+    # Same tensor again -> a cache hit, so this dispatch goes through the override CB-address patch.
+    t_last = ttnn.to_torch(ttnn.to_memory_config(tt, ttnn.L1_MEMORY_CONFIG))
+    out_hit = ttnn.slice(tt, (0, 0, 0, 0), end, memory_config=out_cfg)
+    assert_equal(ref(t_last), torch_out(out_hit))
+
+
+def test_slice_override_alternating_factories_cache_hit(device):
+    """Different dispatches of the same op can select different program factories. factory.index() is in
+    compute_program_hash, so each factory is its own cache entry and the override re-selects the matching
+    factory on every hit. Alternate cache hits on a height-sharded slice (SliceRmShardedProgramFactory ->
+    cheap 2-CB-address patch) and an interleaved slice (SliceRmProgramFactory -> full re-derive) and
+    assert both stay correct: the override must route each hit to its own program, never cross-patch."""
+
+    def torch_out_l1(out):
+        return ttnn.to_torch(ttnn.to_memory_config(out, ttnn.L1_MEMORY_CONFIG))
+
+    make_s, cfg_s, end_s, ref_s = _rm_height_sharded_slice(
+        device, ttnn.bfloat16, ttnn.ShardOrientation.ROW_MAJOR, 2, 2, 1, 40, 32, 16, 16
+    )
+    ts, tts = make_s()  # -> SliceRmShardedProgramFactory (my patched cheap path)
+
+    shape_i, end_i = (1, 2, 64, 32), (1, 2, 40, 20)
+    ti = torch.rand(shape_i, dtype=torch.bfloat16)
+    tti = ttnn.from_torch(
+        ti, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+    ref_i = ti[:1, :2, :40, :20]  # -> SliceRmProgramFactory (interleaved, full re-derive path)
+
+    ttnn.slice(tts, (0, 0, 0, 0), end_s, memory_config=cfg_s)  # warm sharded entry
+    ttnn.slice(tti, (0, 0, 0, 0), end_i, memory_config=ttnn.DRAM_MEMORY_CONFIG)  # warm interleaved entry
+    for _ in range(3):  # both are cache hits; each re-selects its own factory in the override
+        out_s = ttnn.slice(tts, (0, 0, 0, 0), end_s, memory_config=cfg_s)
+        out_i = ttnn.slice(tti, (0, 0, 0, 0), end_i, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        assert_equal(ref_s(ts), torch_out_l1(out_s))
+        assert_with_pcc(ref_i, ttnn.to_torch(out_i), 0.9999)
+
+
 @pytest.mark.parametrize(
     "shape, slice_start, slice_end",
     [

--- a/tests/ttnn/unit_tests/operations/data_movement/test_slice.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_slice.py
@@ -1683,17 +1683,21 @@ def test_slice_rm_height_sharded_override_cache_hit_is_o1(device):
             {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(num_cores_x - 1, num_cores_y - 1))}
         )
         n, c, w = 1, 1, 16
-        h_out = ncores * 8  # sticks/core after slice
-        h_in = ncores * 10  # extra rows so the slice actually trims padding
+        # Totals scale with the grid, but the per-core shard height is held constant (10 in / 8 out
+        # sticks per core) so the only thing that varies across grids is the core count -- that is what
+        # isolates the O(num_cores) rebuild signal. Per-core height = total // ncores (matches the
+        # _rm_height_sharded_slice helper below).
+        h_out = ncores * 8  # total out height (8 sticks/core after slice)
+        h_in = ncores * 10  # total in height (10 sticks/core; extra rows so the slice trims padding)
         in_cfg = ttnn.MemoryConfig(
             ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
             ttnn.BufferType.L1,
-            ttnn.ShardSpec(grid, (h_in, w), ttnn.ShardOrientation.ROW_MAJOR),
+            ttnn.ShardSpec(grid, (h_in // ncores, w), ttnn.ShardOrientation.ROW_MAJOR),
         )
         out_cfg = ttnn.MemoryConfig(
             ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
             ttnn.BufferType.L1,
-            ttnn.ShardSpec(grid, (h_out, w), ttnn.ShardOrientation.ROW_MAJOR),
+            ttnn.ShardSpec(grid, (h_out // ncores, w), ttnn.ShardOrientation.ROW_MAJOR),
         )
         t = torch.rand((n, c, h_in, w), dtype=torch.bfloat16)
         tt = ttnn.from_torch(t, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, memory_config=in_cfg)

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm_sharded.cpp
@@ -254,6 +254,7 @@ tt::tt_metal::ProgramDescriptor SliceRmShardedProgramFactory::create_descriptor(
     // sizing in its own cache entry.  On cache hit, the framework copies runtime
     // args and patches dynamic CB addresses (.buffer is set below); CB sizing
     // itself is not re-applied — it is carried by the cached descriptor.
+    // CB order here (src0, then c_16) is mirrored positionally by override_runtime_arguments; keep in sync.
     constexpr uint8_t src0_cb_index = 0;
     desc.cbs.push_back(CBDescriptor{
         .total_size = shard_height_padded * stick_size_padded,
@@ -327,14 +328,25 @@ void SliceDeviceOperation::override_runtime_arguments(
     const tensor_args_t& tensor_args,
     tensor_return_value_t& tensor_return_value,
     const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
-    // Re-derive the descriptor from the SAME factory the miss path picks (single source of truth), then
-    // re-apply its rt-args + tensor-backed CB addresses to the cached program. No rebuild (still a hit).
+    const auto factory = select_program_factory(operation_attributes, tensor_args);
+
+    // Height-sharded RM reader args depend only on shapes/slice_start/shard specs, all cache-keyed, so
+    // on a hit the only thing that changes is the two CB addresses. Patch those in O(1) instead of
+    // rebuilding all per-core args (which scaled host cost with the core grid). CBs: src0, then c_16.
+    if (std::holds_alternative<SliceRmShardedProgramFactory>(factory)) {
+        tt::tt_metal::ProgramDescriptor cb_addr_only;
+        cb_addr_only.cbs.push_back(tt::tt_metal::CBDescriptor{.buffer = tensor_args.input.buffer()});
+        cb_addr_only.cbs.push_back(tt::tt_metal::CBDescriptor{.buffer = tensor_return_value.buffer()});
+        tt::tt_metal::apply_descriptor_runtime_args(program, cb_addr_only);
+        return;
+    }
+
+    // Other factories bake buffer addresses into their runtime args, so re-derive and re-apply.
     auto desc = std::visit(
-        [&](auto&& factory) {
-            return std::decay_t<decltype(factory)>::create_descriptor(
-                operation_attributes, tensor_args, tensor_return_value);
+        [&](auto&& f) {
+            return std::decay_t<decltype(f)>::create_descriptor(operation_attributes, tensor_args, tensor_return_value);
         },
-        select_program_factory(operation_attributes, tensor_args));
+        factory);
     tt::tt_metal::apply_descriptor_runtime_args(program, desc);
 }
 


### PR DESCRIPTION
## What
Fixes the ~7.6x non-traced **resnet-on-T3K** perf regression from #50347.

#50347 migrated `slice`'s cache-hit hook from `get_dynamic_runtime_args` to `override_runtime_arguments`, which re-runs the full `create_descriptor` on **every cache hit**. For the CB-bound height-sharded RM factory that rebuilds an `O(num_cores)` per-core arg walk (+ a per-core `std::map`) and throws it all away except the runtime args. It stays a **cache hit** (program-cache entry count unchanged), so it is invisible to cache-miss / entry-count assertions — but the host cost scales with the shard core grid and is paid on every dispatch. resnet reaches this factory once per iteration via the transpose-fold slice.

## Fix
The height-sharded reader args are a pure function of the input/output padded shapes, `slice_start`, and shard specs — all folded into `compute_program_hash`. So any two dispatches on the same cached program have byte-identical reader args; the only per-dispatch state that changes is the two sharded CB base addresses. The override now patches just those two CB addresses in `O(1)` for that factory (the behavior `get_dynamic` had, #48928). Other factories carry addresses in their runtime args and keep re-deriving via `create_descriptor`.

## Metrics (single card, cache-hit host dispatch time)
| shard grid | before (#50347) | after |
|---|---|---|
| 1 core | 94 µs | 61 µs |
| 16 cores | 162 µs | 61 µs |
| 56 cores | **1445 µs** | **61 µs** |

~15x scaling with the core grid → flat. PCC / correctness unchanged (existing address-change hit tests pass).

## Test
Adds `test_slice_rm_height_sharded_override_cache_hit_is_o1`: asserts the sharded cache-hit host dispatch time does not scale with the core grid (fails at ~15x on the pre-fix binary, passes flat after). Since both buggy and fixed code are `entries=1` cache hits, host cost is the only observable signal, so this is necessarily a timing check — made robust via a same-run small-vs-large-grid ratio (self-calibrating), min-of-N, and a wide 4x margin. Marked `skip_post_commit` (perf/nightly, not the fast post-commit lane).

## Not in scope
The interleaved RM/TILE factories still re-derive on cache hit (the +20% #50347 knowingly shipped); their runtime args carry buffer addresses so they genuinely need re-derivation. Separate optimization.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/fix-slice-sharded-override-rebuild)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/fix-slice-sharded-override-rebuild)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/fix-slice-sharded-override-rebuild)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/fix-slice-sharded-override-rebuild)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=dgomez/fix-slice-sharded-override-rebuild)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:dgomez/fix-slice-sharded-override-rebuild)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/fix-slice-sharded-override-rebuild)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/fix-slice-sharded-override-rebuild)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/fix-slice-sharded-override-rebuild)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/fix-slice-sharded-override-rebuild)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/fix-slice-sharded-override-rebuild)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/fix-slice-sharded-override-rebuild)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/fix-slice-sharded-override-rebuild)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/fix-slice-sharded-override-rebuild)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/fix-slice-sharded-override-rebuild)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/fix-slice-sharded-override-rebuild)