### PR TITLE
Add Quasar cache-write performance test (test 912): uncached port vs L2 cache+flush

### DIFF
--- a/tests/tt_metal/tt_metal/data_movement/python/plotter.py
+++ b/tests/tt_metal/tt_metal/data_movement/python/plotter.py
@@ -290,18 +290,29 @@ class Plotter:
             ybase=10,
         )
 
-    # Quasar Cache Write: Total Data Size vs Write Duration (one line per path)
+    # Quasar Cache Write: Total Data Size vs amortized per-write Duration (one line per mode).
+    # The timed zone repeats the write num_transactions (=iteration count) times, so the
+    # per-write duration is duration_cycles / num_transactions.
     def plot_quasar_cache_write_duration(self, ax, data):
+        per_iter_data = {}
+        for riscv, runs in data.items():
+            new_runs = []
+            for run in runs:
+                r = run.copy()
+                iters = run.get("num_transactions", 1) or 1
+                r["per_iter_duration"] = run["duration_cycles"] / iters
+                new_runs.append(r)
+            per_iter_data[riscv] = new_runs
         self._plot_series(
             ax=ax,
-            data=data,
-            x_key="transaction_size",  # holds total bytes written (N)
-            y_key="duration_cycles",
+            data=per_iter_data,
+            x_key="transaction_size",  # holds total bytes written per iteration (N)
+            y_key="per_iter_duration",
             series_keys=["write_path"],
             label_format=lambda combo, keys: f"{combo[0]}",
-            title="Data Size vs Write Duration",
+            title="Data Size vs Write Duration (amortized)",
             xlabel="Total Data Size (bytes)",
-            ylabel="Duration (cycles)",
+            ylabel="Duration per write (cycles)",
             xscale="log",
             xbase=2,
         )
@@ -311,8 +322,8 @@ class Plotter:
         self._plot_series(
             ax=ax,
             data=data,
-            x_key="transaction_size",  # holds total bytes written (N)
-            y_key="bandwidth",  # num_transactions(=1) * size / duration = bytes/cycle
+            x_key="transaction_size",  # holds total bytes written per iteration (N)
+            y_key="bandwidth",  # num_transactions * size / duration = per-iteration bytes/cycle
             series_keys=["write_path"],
             label_format=lambda combo, keys: f"{combo[0]}",
             title="Data Size vs Bandwidth",

--- a/tests/tt_metal/tt_metal/data_movement/python/plotter.py
+++ b/tests/tt_metal/tt_metal/data_movement/python/plotter.py
@@ -53,6 +53,10 @@ class Plotter:
             # For direct write tests, use one plot (1x1 grid)
             config["nrows_per_figure"] = 1
             config["ncols_per_figure"] = 1
+        if "Quasar Cache Write" in test_name:
+            # Single duration-vs-size plot (two path series); avoid a blank second panel
+            config["nrows_per_figure"] = 1
+            config["ncols_per_figure"] = 1
         return config
 
     def get_bandwidth_mode(self, test_id):

--- a/tests/tt_metal/tt_metal/data_movement/python/plotter.py
+++ b/tests/tt_metal/tt_metal/data_movement/python/plotter.py
@@ -54,9 +54,9 @@ class Plotter:
             config["nrows_per_figure"] = 1
             config["ncols_per_figure"] = 1
         if "Quasar Cache Write" in test_name:
-            # Single duration-vs-size plot (two path series); avoid a blank second panel
+            # Two panels: duration vs size and bandwidth vs size (one line per write mode)
             config["nrows_per_figure"] = 1
-            config["ncols_per_figure"] = 1
+            config["ncols_per_figure"] = 2
         return config
 
     def get_bandwidth_mode(self, test_id):
@@ -167,6 +167,7 @@ class Plotter:
                 self.plot_num_transactions_vs_total_cycles(axes[1], plot_data[test_id])
             elif "Quasar Cache Write" in test_name:
                 self.plot_quasar_cache_write_duration(axes[0], plot_data[test_id])
+                self.plot_quasar_cache_write_bandwidth(axes[1], plot_data[test_id])
             else:  # Packet Sizes
                 self.plot_durations(axes[0], plot_data[test_id])
                 self.plot_data_size_vs_bandwidth(
@@ -301,6 +302,22 @@ class Plotter:
             title="Data Size vs Write Duration",
             xlabel="Total Data Size (bytes)",
             ylabel="Duration (cycles)",
+            xscale="log",
+            xbase=2,
+        )
+
+    # Quasar Cache Write: Total Data Size vs Bandwidth (bytes/cycle, one line per write mode)
+    def plot_quasar_cache_write_bandwidth(self, ax, data):
+        self._plot_series(
+            ax=ax,
+            data=data,
+            x_key="transaction_size",  # holds total bytes written (N)
+            y_key="bandwidth",  # num_transactions(=1) * size / duration = bytes/cycle
+            series_keys=["write_path"],
+            label_format=lambda combo, keys: f"{combo[0]}",
+            title="Data Size vs Bandwidth",
+            xlabel="Total Data Size (bytes)",
+            ylabel="Bandwidth (bytes/cycle)",
             xscale="log",
             xbase=2,
         )

--- a/tests/tt_metal/tt_metal/data_movement/python/plotter.py
+++ b/tests/tt_metal/tt_metal/data_movement/python/plotter.py
@@ -2,12 +2,13 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-import os
-import matplotlib.pyplot as plt
-from matplotlib.gridspec import GridSpec
 import itertools
+import os
+
+import matplotlib.pyplot as plt
 import matplotlib.ticker as mticker
 from loguru import logger  # type: ignore
+from matplotlib.gridspec import GridSpec
 
 from tests.tt_metal.tt_metal.data_movement.python.constants import *
 
@@ -160,6 +161,8 @@ class Plotter:
                 # For NOC API Latency tests, plot cycles per transaction
                 self.plot_transaction_size_vs_cycles_per_transaction(axes[0], plot_data[test_id])
                 self.plot_num_transactions_vs_total_cycles(axes[1], plot_data[test_id])
+            elif "Quasar Cache Write" in test_name:
+                self.plot_quasar_cache_write_duration(axes[0], plot_data[test_id])
             else:  # Packet Sizes
                 self.plot_durations(axes[0], plot_data[test_id])
                 self.plot_data_size_vs_bandwidth(
@@ -280,6 +283,22 @@ class Plotter:
             xbase=2,
             yscale="log",
             ybase=10,
+        )
+
+    # Quasar Cache Write: Total Data Size vs Write Duration (one line per path)
+    def plot_quasar_cache_write_duration(self, ax, data):
+        self._plot_series(
+            ax=ax,
+            data=data,
+            x_key="transaction_size",  # holds total bytes written (N)
+            y_key="duration_cycles",
+            series_keys=["write_path"],
+            label_format=lambda combo, keys: f"{combo[0]}",
+            title="Data Size vs Write Duration",
+            xlabel="Total Data Size (bytes)",
+            ylabel="Duration (cycles)",
+            xscale="log",
+            xbase=2,
         )
 
     # Packet Sizes: Transaction Size vs Bandwidth

--- a/tests/tt_metal/tt_metal/data_movement/python/stats_collector.py
+++ b/tests/tt_metal/tt_metal/data_movement/python/stats_collector.py
@@ -13,11 +13,12 @@ from tests.tt_metal.tt_metal.data_movement.python.constants import *
 
 
 class StatsCollector:
-    def __init__(self, file_path, test_id_to_name, test_type_attributes, verbose=False):
+    def __init__(self, file_path, test_id_to_name, test_type_attributes, verbose=False, arch=None):
         self.file_path = file_path
         self.verbose = verbose
         self.test_id_to_name = test_id_to_name
         self.test_type_attributes = test_type_attributes
+        self.arch = arch
         # Map each RISC-V processor to its corresponding analysis/event key
         self.riscv_to_analysis_event = {
             "riscv_1": {"analysis": "riscv_1_analysis", "events": "riscv_1_events"},
@@ -34,6 +35,7 @@ class StatsCollector:
             if (
                 "BRISC" in stats["devices"][0]["cores"][key]["riscs"]
                 or "NCRISC" in stats["devices"][0]["cores"][key]["riscs"]
+                or any(str(r).startswith("QUASAR_DM") for r in stats["devices"][0]["cores"][key]["riscs"])
             )
             and key != "DEVICE"
         ]
@@ -111,7 +113,10 @@ class StatsCollector:
             }
 
             # Add events configuration
-            marker_risc = "NCRISC" if risc == "riscv_1" else "BRISC"
+            if self.arch == "quasar":
+                marker_risc = "QUASAR_DM2" if risc == "riscv_1" else "QUASAR_DM0"
+            else:
+                marker_risc = "NCRISC" if risc == "riscv_1" else "BRISC"
             timer_analysis[events_key] = {
                 "across": "device",
                 "type": "event",

--- a/tests/tt_metal/tt_metal/data_movement/python/test_data_movement.py
+++ b/tests/tt_metal/tt_metal/data_movement/python/test_data_movement.py
@@ -45,7 +45,7 @@ def run_dm_tests(profile, verbose, gtest_filter, plot, report, arch_name):
         profile_dm_tests(verbose=verbose, gtest_filter=gtest_filter)
 
     # Gather analysis stats
-    stats_collector = StatsCollector(log_file_path, test_id_to_name, test_type_attributes, verbose=verbose)
+    stats_collector = StatsCollector(log_file_path, test_id_to_name, test_type_attributes, verbose=verbose, arch=arch)
     stats = stats_collector.gather_stats_from_csv()
     if not stats.get("devices"):
         logger.info("No profiling data available.")

--- a/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_information.yaml
+++ b/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_information.yaml
@@ -1024,6 +1024,15 @@ tests:
   911:
     name: "Quasar IDMA - 1D Strided"
 
+  912:
+    name: "Quasar Cache Write Sizes"
+    comment: |
+      Compares single-DM-core write performance to Tensix L1 via the uncached
+      port (+4MB alias) versus cacheable writes followed by flush_l2_cache_range.
+      Swept over total data size (1B..2KB). Uncached avoids flush cost but pays
+      full TL1 latency per access; cached+flush amortizes writes but pays
+      ceil(N/64) line flushes.
+
   1012:
     name: "1D Matmul Test 1012 - 2x2 K=2 Subblock K Sweep"
     bandwidth_mode: "combined"

--- a/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_type_attributes.yaml
+++ b/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_type_attributes.yaml
@@ -55,3 +55,10 @@ noc_estimator:
     "Loopback":
       0: false
       1: true
+quasar_cache_write:
+  attributes:
+    "Write path": "write_path"
+  value_mappings:
+    "Write path":
+      0: "Uncached"
+      1: "Cached+Flush"

--- a/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_type_attributes.yaml
+++ b/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_type_attributes.yaml
@@ -60,6 +60,7 @@ quasar_cache_write:
     "Write path": "write_path"
   value_mappings:
     "Write path":
-      0: "Uncached (1B)"
-      1: "Uncached (8B)"
-      2: "Cached+Flush (8B)"
+      0: "Uncached (1B stores)"
+      1: "Uncached (8B stores)"
+      2: "Cached + flush (fence per line)"
+      3: "Cached + flush (single fence)"

--- a/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_type_attributes.yaml
+++ b/tests/tt_metal/tt_metal/data_movement/python/test_mappings/test_type_attributes.yaml
@@ -60,5 +60,6 @@ quasar_cache_write:
     "Write path": "write_path"
   value_mappings:
     "Write path":
-      0: "Uncached"
-      1: "Cached+Flush"
+      0: "Uncached (1B)"
+      1: "Uncached (8B)"
+      2: "Cached+Flush (8B)"

--- a/tests/tt_metal/tt_metal/data_movement/quasar_cache_perf/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_cache_perf/README.md
@@ -35,3 +35,22 @@ pytest tests/tt_metal/tt_metal/data_movement/python/test_data_movement.py \
 
 Output: `data/quasar/Quasar Cache Write Sizes.png` — duration (cycles) vs total
 data size, one line per path.
+
+## Known limitation on the 1x3 emulator (slow dispatch)
+
+The `emu-quasar-1x3` target has no fast-dispatch cores, so tests must run in
+slow-dispatch mode (`TT_METAL_SLOW_DISPATCH_MODE=1`). Under slow dispatch the
+profiler does not increment `run host ID` — every one of the 24 sweep runs is
+stamped `run_host_id = 0`. Because `stats_collector.aggregate_performance`
+groups runs by `run_host_id`, all runs collapse into a single aggregated point,
+so the auto-generated PNG shows one point rather than the two 12-point curves.
+
+The per-run data is still fully captured in
+`generated/profiler/.logs/profile_log_device.csv`: each `RISCV1` `ZONE_START`/
+`ZONE_END` pair is immediately followed, in order, by that run's
+`Transaction size in bytes` and `Write path` stamps. The correct per-run tuples
+can be reconstructed by walking the CSV in order. A proper fix (an order-based
+aggregation fallback when `run_host_id`s collide, or incrementing `run_host_id`
+under slow dispatch) is deferred until this runs on hardware / a fast-dispatch
+grid, where `run_host_id` increments normally and the shared pipeline plots the
+two curves directly.

--- a/tests/tt_metal/tt_metal/data_movement/quasar_cache_perf/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_cache_perf/README.md
@@ -1,16 +1,23 @@
 # Quasar Cache-Write Performance Test (test id 912)
 
-Measures single-DM-core write performance to Tensix L1 on Quasar via two paths,
-swept over total data size (1B .. 2KB, powers of two):
+Measures single-DM-core write performance to Tensix L1 on Quasar, swept over
+total data size (1B .. 2KB, powers of two), for three write modes:
 
-- **Uncached** — stores to `base + MEM_L1_UNCACHED_BASE` (+4MB alias); straight
-  to TL1, no flush.
-- **Cached+Flush** — stores to the cacheable window (`0..4MB`), then
+- **Uncached (1B)** — `base + MEM_L1_UNCACHED_BASE` (+4MB alias), byte-at-a-time
+  stores; straight to TL1, no flush.
+- **Uncached (8B)** — same uncached port, but 64-bit stores (the natural DM-core
+  store width) with a byte tail for sub-8B sizes.
+- **Cached+Flush (8B)** — 64-bit stores to the cacheable window (`0..4MB`), then
   `flush_l2_cache_range(base, N)` (flushes `ceil(N/64)` 64B lines).
+
+Comparing Uncached (1B) vs Uncached (8B) isolates the effect of store width on the
+uncached port; comparing Uncached (8B) vs Cached+Flush (8B) isolates the cache +
+flush effect at a fixed store width.
 
 The kernel times each `write(+flush)` region with `DeviceZoneScopedN` and stamps
 `Test id`, `Number of transactions` (=1), `Transaction size in bytes` (=N), and
-`Write path` (0=uncached, 1=cached+flush).
+`Write path` (the mode: 0=Uncached 1B, 1=Uncached 8B, 2=Cached+Flush 8B). Results
+are plotted as both duration (cycles) and bandwidth (bytes/cycle) vs data size.
 
 ## Requirements
 

--- a/tests/tt_metal/tt_metal/data_movement/quasar_cache_perf/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_cache_perf/README.md
@@ -1,38 +1,44 @@
 # Quasar Cache-Write Performance Test (test id 912)
 
-Measures single-DM-core write performance to Tensix L1 on Quasar, swept over
-total data size (1B .. 2KB, powers of two), for three write modes:
+Measures single-DM-core write performance to Tensix L1 on Quasar, swept over total
+data size (8B .. 2KB, multiples of 8), for four write modes (stamped as `Write path`):
 
-- **Uncached (1B)** — `base + MEM_L1_UNCACHED_BASE` (+4MB alias), byte-at-a-time
-  stores; straight to TL1, no flush.
-- **Uncached (8B)** — same uncached port, but 64-bit stores (the natural DM-core
-  store width) with a byte tail for sub-8B sizes.
-- **Cached+Flush (8B)** — 64-bit stores to the cacheable window (`0..4MB`), then
-  `flush_l2_cache_range(base, N)` (flushes `ceil(N/64)` 64B lines).
+- **0 — Uncached (1B stores)** — `base + MEM_L1_UNCACHED_BASE` (+4MB alias), written
+  one byte at a time; straight to TL1, no flush.
+- **1 — Uncached (8B stores)** — same uncached port, 64-bit stores (the natural
+  DM-core store width).
+- **2 — Cached + flush (fence per line)** — 64-bit stores to the cacheable window,
+  then `flush_l2_cache_range(base, N)`, the library range flush, which fences twice
+  per 64B line. This is the exact method used by the earlier standalone measurement.
+- **3 — Cached + flush (single fence)** — identical cacheable 64-bit stores, then the
+  touched 64B lines are flushed with bare flush-register writes (no per-line fence)
+  and a single completion fence after all iterations. This is the efficient flush.
 
-Comparing Uncached (1B) vs Uncached (8B) isolates the effect of store width on the
-uncached port; comparing Uncached (8B) vs Cached+Flush (8B) isolates the cache +
-flush effect at a fixed store width.
+What the comparisons isolate: **0 vs 1** = store width on the uncached port; **1 vs 2**
+= uncached vs cache+flush as originally measured; **2 vs 3** = the flush fencing cost.
 
 ## When to use which (write-only to L1)
 
-- **Fire-and-forget writes, any size → uncached port with 8-byte stores.** Fastest
-  at every size in the sweep; cache+flush is never faster for write-only traffic.
-- **< 8 bytes → uncached** (store width is irrelevant below 8B). Cache+flush pays a
-  ~160-cycle `flush_l2_cache_range` floor, 3–10x worse at these sizes.
-- **Cache + flush → only with reuse.** Worth its flush cost when the data is
-  subsequently read back by the core, or when many scattered sub-64B updates
-  coalesce in cache before one flush — cases this write-only test does not measure.
+- **Fire-and-forget writes, any size → uncached port with 8-byte stores.** Fastest at
+  every size in the sweep.
+- **Cache + flush → use the single-fence flush, not `flush_l2_cache_range`.** The
+  library per-line fencing is much slower for multi-line ranges (e.g. ~4400 vs ~3900
+  cyc at 2KB). Even optimized, cache+flush does not beat uncached-8B for write-only,
+  no-reuse traffic — it pays off only when the data is subsequently read back, or when
+  many scattered sub-64B updates coalesce in cache before one flush (not measured here).
 
-To measure steady-state (not one-shot) cost, the kernel repeats the timed
-`write(+flush)` region `num_iterations` times (default 100) inside a single
-`DeviceZoneScopedN`, and the host divides the zone duration by the iteration
-count. This amortizes fixed per-run overhead (zone entry/exit, prologue, cold
-pipeline), matching the April two-phase measurement method. It stamps `Test id`,
-`Number of transactions` (= iteration count), `Transaction size in bytes` (=N),
-and `Write path` (the mode: 0=Uncached 1B, 1=Uncached 8B, 2=Cached+Flush 8B).
-Results are plotted as amortized per-write duration (cycles) and bandwidth
-(bytes/cycle) vs data size.
+## Measurement method
+
+To measure steady-state (not one-shot) cost, each mode repeats its write(+flush)
+region `num_iterations` times (default 100) inside a single `DeviceZoneScopedN`, and
+the host divides the zone duration by the iteration count to get the amortized
+per-write cost. Fencing discipline: the uncached modes (0/1) fence every iteration
+(matching the standalone `DirectSram` baseline); mode 2 uses the library per-line
+flush; mode 3 issues a single fence after all iterations. Sizes are multiples of 8 so
+the 8-byte modes do exactly `N/8` stores with no sub-8B tail. The kernel stamps
+`Test id`, `Number of transactions` (= iteration count), `Transaction size in bytes`,
+and `Write path` (mode). Results are plotted as amortized per-write duration (cycles)
+and bandwidth (bytes/cycle) vs data size.
 
 ## Requirements
 
@@ -62,10 +68,11 @@ data size, one line per path.
 
 The `emu-quasar-1x3` target has no fast-dispatch cores, so tests must run in
 slow-dispatch mode (`TT_METAL_SLOW_DISPATCH_MODE=1`). Under slow dispatch the
-profiler does not increment `run host ID` — every one of the 24 sweep runs is
-stamped `run_host_id = 0`. Because `stats_collector.aggregate_performance`
-groups runs by `run_host_id`, all runs collapse into a single aggregated point,
-so the auto-generated PNG shows one point rather than the two 12-point curves.
+profiler does not increment `run host ID` — every one of the 40 sweep runs
+(4 modes x 10 sizes) is stamped `run_host_id = 0`. Because
+`stats_collector.aggregate_performance` groups runs by `run_host_id`, all runs
+collapse into a single aggregated point, so the auto-generated PNG shows one point
+rather than the four per-mode curves.
 
 The per-run data is still fully captured in
 `generated/profiler/.logs/profile_log_device.csv`: each `RISCV1` `ZONE_START`/

--- a/tests/tt_metal/tt_metal/data_movement/quasar_cache_perf/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_cache_perf/README.md
@@ -1,0 +1,37 @@
+# Quasar Cache-Write Performance Test (test id 912)
+
+Measures single-DM-core write performance to Tensix L1 on Quasar via two paths,
+swept over total data size (1B .. 2KB, powers of two):
+
+- **Uncached** — stores to `base + MEM_L1_UNCACHED_BASE` (+4MB alias); straight
+  to TL1, no flush.
+- **Cached+Flush** — stores to the cacheable window (`0..4MB`), then
+  `flush_l2_cache_range(base, N)` (flushes `ceil(N/64)` 64B lines).
+
+The kernel times each `write(+flush)` region with `DeviceZoneScopedN` and stamps
+`Test id`, `Number of transactions` (=1), `Transaction size in bytes` (=N), and
+`Write path` (0=uncached, 1=cached+flush).
+
+## Requirements
+
+Quasar emulator: `ARCH_NAME=quasar` and `TT_METAL_SIMULATOR` pointing at an
+`emu-quasar-*` build (do NOT set it to `1` — it is a path). The 1x3 emu has no
+fast-dispatch cores, so slow dispatch is required.
+
+## Running
+
+Functional (read-back correctness):
+```bash
+TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/unit_tests_data_movement \
+  --gtest_filter="*QuasarCacheWrite*"
+```
+
+Performance + plot:
+```bash
+export TT_METAL_SLOW_DISPATCH_MODE=1
+pytest tests/tt_metal/tt_metal/data_movement/python/test_data_movement.py \
+  --plot --report --arch=quasar --gtest-filter="*QuasarCacheWrite*"
+```
+
+Output: `data/quasar/Quasar Cache Write Sizes.png` — duration (cycles) vs total
+data size, one line per path.

--- a/tests/tt_metal/tt_metal/data_movement/quasar_cache_perf/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_cache_perf/README.md
@@ -48,9 +48,17 @@ so the auto-generated PNG shows one point rather than the two 12-point curves.
 The per-run data is still fully captured in
 `generated/profiler/.logs/profile_log_device.csv`: each `RISCV1` `ZONE_START`/
 `ZONE_END` pair is immediately followed, in order, by that run's
-`Transaction size in bytes` and `Write path` stamps. The correct per-run tuples
-can be reconstructed by walking the CSV in order. A proper fix (an order-based
-aggregation fallback when `run_host_id`s collide, or incrementing `run_host_id`
-under slow dispatch) is deferred until this runs on hardware / a fast-dispatch
-grid, where `run_host_id` increments normally and the shared pipeline plots the
-two curves directly.
+`Transaction size in bytes` and `Write path` stamps.
+
+Stopgap — reconstruct the correct plot from the CSV order:
+```bash
+python tests/tt_metal/tt_metal/data_movement/quasar_cache_perf/plot_cache_write_from_csv.py
+```
+This walks the CSV in order (independent of `run_host_id`), recovers each run's
+(size, path, duration) tuple, and writes a two-panel PNG (full range + a zoom on
+the small-size crossover region) to `data/quasar/Quasar Cache Write Sizes.png`.
+
+A proper fix (an order-based aggregation fallback when `run_host_id`s collide, or
+incrementing `run_host_id` under slow dispatch) is deferred until this runs on
+hardware / a fast-dispatch grid, where `run_host_id` increments normally and the
+shared `--plot` pipeline plots the two curves directly.

--- a/tests/tt_metal/tt_metal/data_movement/quasar_cache_perf/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_cache_perf/README.md
@@ -14,6 +14,16 @@ Comparing Uncached (1B) vs Uncached (8B) isolates the effect of store width on t
 uncached port; comparing Uncached (8B) vs Cached+Flush (8B) isolates the cache +
 flush effect at a fixed store width.
 
+## When to use which (write-only to L1)
+
+- **Fire-and-forget writes, any size → uncached port with 8-byte stores.** Fastest
+  at every size in the sweep; cache+flush is never faster for write-only traffic.
+- **< 8 bytes → uncached** (store width is irrelevant below 8B). Cache+flush pays a
+  ~160-cycle `flush_l2_cache_range` floor, 3–10x worse at these sizes.
+- **Cache + flush → only with reuse.** Worth its flush cost when the data is
+  subsequently read back by the core, or when many scattered sub-64B updates
+  coalesce in cache before one flush — cases this write-only test does not measure.
+
 To measure steady-state (not one-shot) cost, the kernel repeats the timed
 `write(+flush)` region `num_iterations` times (default 100) inside a single
 `DeviceZoneScopedN`, and the host divides the zone duration by the iteration

--- a/tests/tt_metal/tt_metal/data_movement/quasar_cache_perf/README.md
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_cache_perf/README.md
@@ -14,10 +14,15 @@ Comparing Uncached (1B) vs Uncached (8B) isolates the effect of store width on t
 uncached port; comparing Uncached (8B) vs Cached+Flush (8B) isolates the cache +
 flush effect at a fixed store width.
 
-The kernel times each `write(+flush)` region with `DeviceZoneScopedN` and stamps
-`Test id`, `Number of transactions` (=1), `Transaction size in bytes` (=N), and
-`Write path` (the mode: 0=Uncached 1B, 1=Uncached 8B, 2=Cached+Flush 8B). Results
-are plotted as both duration (cycles) and bandwidth (bytes/cycle) vs data size.
+To measure steady-state (not one-shot) cost, the kernel repeats the timed
+`write(+flush)` region `num_iterations` times (default 100) inside a single
+`DeviceZoneScopedN`, and the host divides the zone duration by the iteration
+count. This amortizes fixed per-run overhead (zone entry/exit, prologue, cold
+pipeline), matching the April two-phase measurement method. It stamps `Test id`,
+`Number of transactions` (= iteration count), `Transaction size in bytes` (=N),
+and `Write path` (the mode: 0=Uncached 1B, 1=Uncached 8B, 2=Cached+Flush 8B).
+Results are plotted as amortized per-write duration (cycles) and bandwidth
+(bytes/cycle) vs data size.
 
 ## Requirements
 

--- a/tests/tt_metal/tt_metal/data_movement/quasar_cache_perf/kernels/cache_write_perf.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_cache_perf/kernels/cache_write_perf.cpp
@@ -3,64 +3,123 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Quasar DM-core cache-write performance kernel.
-// Writes `size_bytes` to Tensix L1 and times the region, in one of three modes
+// Writes `size_bytes` to Tensix L1 and times the region, in one of four modes
 // (the "Write path" arg):
-//   0 = Uncached, 1-byte stores   -> uncached port (+4MB alias), byte-at-a-time
-//   1 = Uncached, 8-byte stores   -> uncached port, 64-bit stores + byte tail
-//   2 = Cached+Flush, 8-byte      -> cacheable write (64-bit) then flush_l2_cache_range
-// Modes 1 and 2 use the natural 64-bit DM-core store width (8B) for the bulk with
-// a byte tail for any sub-8B remainder (sizes 1/2/4). Stores are volatile so the
-// compiler cannot coalesce/reorder them.
+//   0 = Uncached (1B stores)             -> uncached port (+4MB alias), byte-at-a-time
+//   1 = Uncached (8B stores)             -> uncached port, 64-bit stores
+//   2 = Cached + flush (fence per line)  -> cacheable 64-bit write, then flush_l2_cache_range
+//                                           (library: 2 fences per 64B line; April's method)
+//   3 = Cached + flush (single fence)    -> cacheable 64-bit write, then bare flush-reg writes
+//                                           over the touched lines, one fence after all iters
 //
-// The write(+flush) region is repeated `num_iterations` times INSIDE the timed
-// DeviceZoneScopedN, and the host divides the zone duration by num_iterations
-// (stamped as "Number of transactions"). This amortizes fixed per-run overhead
-// (zone entry/exit, prologue, cold pipeline) so the reported value is the
-// steady-state per-write cost, matching the April two-phase measurement method.
+// size_bytes is assumed to be a multiple of 8 (the host sweep only uses such sizes),
+// so the 8-byte modes write exactly size_bytes/8 words with no sub-8B tail.
+//
+// Each mode repeats its write(+flush) region `num_iterations` times inside the timed
+// DeviceZoneScopedN; the host divides the zone duration by num_iterations (stamped as
+// "Number of transactions") to get the amortized per-write cost. Fencing discipline:
+//   - Modes 0/1 (uncached) fence EVERY iteration, matching the April DirectSram kernel.
+//   - Mode 2 flushes with the library flush_l2_cache_range every iteration (April method).
+//   - Mode 3 applies the HW-guided flush optimization: bare flush-reg writes with NO
+//     per-line/per-iteration fence, and a SINGLE completion fence after all iterations.
+// Stores are volatile so the compiler cannot coalesce/reorder them.
 
 #include <cstdint>
 #include "api/dataflow/dataflow_api.h"  // pulls in DeviceZoneScopedN / DeviceTimestampedData
 #include "dev_mem_map.h"                // MEM_L1_UNCACHED_BASE
 #include "experimental/kernel_args.h"   // get_arg(args::name)
-#include "risc_common.h"                // flush_l2_cache_range
+#include "risc_common.h"                // flush_l2_cache_range, L2_FLUSH_ADDR
+
+namespace {
+constexpr std::uint64_t kFillWord = 0x5A5A5A5A5A5A5A5AULL;
+constexpr std::uint8_t kFillByte = 0x5A;
+
+// Write num_words 64-bit words.
+inline __attribute__((always_inline)) void store_words(volatile std::uint64_t* dst64, std::uint32_t num_words) {
+    for (std::uint32_t i = 0; i < num_words; i++) {
+        dst64[i] = kFillWord;
+    }
+}
+
+// Mode 0: uncached, byte-at-a-time stores; per-iteration completion fence (April-faithful).
+inline __attribute__((always_inline)) void write_uncached_1b(
+    volatile std::uint8_t* dst8, std::uint32_t size_bytes, std::uint32_t num_iterations) {
+    for (std::uint32_t iter = 0; iter < num_iterations; iter++) {
+        for (std::uint32_t i = 0; i < size_bytes; i++) {
+            dst8[i] = kFillByte;
+        }
+        __asm__ __volatile__("fence" ::: "memory");
+    }
+}
+
+// Mode 1: uncached, 8-byte stores; per-iteration completion fence (April-faithful DirectSRAM).
+inline __attribute__((always_inline)) void write_uncached_8b(
+    volatile std::uint64_t* dst64, std::uint32_t num_words, std::uint32_t num_iterations) {
+    for (std::uint32_t iter = 0; iter < num_iterations; iter++) {
+        store_words(dst64, num_words);
+        __asm__ __volatile__("fence" ::: "memory");
+    }
+}
+
+// Mode 2: cached 8-byte stores + library range flush (2 fences per 64B line). April's method.
+inline __attribute__((always_inline)) void write_cached_range_flush(
+    volatile std::uint64_t* dst64,
+    std::uint32_t num_words,
+    std::uint32_t base_addr,
+    std::uint32_t size_bytes,
+    std::uint32_t num_iterations) {
+    for (std::uint32_t iter = 0; iter < num_iterations; iter++) {
+        store_words(dst64, num_words);
+        flush_l2_cache_range(base_addr, size_bytes);
+    }
+}
+
+// Mode 3: cached 8-byte stores + HW-optimal flush (bare flush-reg writes over the touched
+// 64B lines, no per-line/per-iteration fence; single completion fence after all iters).
+inline __attribute__((always_inline)) void write_cached_fast_flush(
+    volatile std::uint64_t* dst64,
+    std::uint32_t num_words,
+    std::uint32_t flush_start,
+    std::uint32_t flush_end,
+    std::uint32_t num_iterations) {
+    volatile std::uint64_t* flush_reg = (volatile std::uint64_t*)L2_FLUSH_ADDR;
+    for (std::uint32_t iter = 0; iter < num_iterations; iter++) {
+        store_words(dst64, num_words);
+        for (std::uint32_t a = flush_start; a < flush_end; a += 64) {
+            *flush_reg = (std::uint64_t)a;
+        }
+    }
+    __asm__ __volatile__("fence" ::: "memory");
+}
+}  // namespace
 
 void kernel_main() {
     std::uint32_t base_addr = get_arg(args::base_addr);
     std::uint32_t size_bytes = get_arg(args::size_bytes);
-    std::uint32_t mode = get_arg(args::write_path);  // 0=uncached 1B, 1=uncached 8B, 2=cached+flush 8B
+    std::uint32_t mode = get_arg(args::write_path);  // 0=unc 1B, 1=unc 8B, 2=cached range, 3=cached fast
     std::uint32_t num_iterations = get_arg(args::num_iterations);
     std::uint32_t test_id = get_arg(args::test_id);
 
-    bool cached = (mode == 2);
-    bool wide = (mode != 0);  // 8-byte stores for modes 1 and 2
+    bool cached = (mode == 2 || mode == 3);
     std::uint32_t dst_addr = cached ? base_addr : (base_addr + MEM_L1_UNCACHED_BASE);
 
     volatile std::uint64_t* dst64 = (volatile std::uint64_t*)(uintptr_t)dst_addr;
     volatile std::uint8_t* dst8 = (volatile std::uint8_t*)(uintptr_t)dst_addr;
-    const std::uint64_t fill_word = 0x5A5A5A5A5A5A5A5AULL;
-    const std::uint8_t fill_byte = 0x5A;
 
-    std::uint32_t num_words = size_bytes >> 3;  // full 8-byte stores
-    std::uint32_t tail_start = num_words << 3;
+    std::uint32_t num_words = size_bytes >> 3;  // 8-byte stores (size_bytes is a multiple of 8)
+    std::uint32_t flush_start = base_addr & ~(std::uint32_t)63;
+    std::uint32_t flush_end = base_addr + size_bytes;
 
     {
         DeviceZoneScopedN("RISCV1");
-        for (std::uint32_t iter = 0; iter < num_iterations; iter++) {
-            if (wide) {
-                for (std::uint32_t i = 0; i < num_words; i++) {
-                    dst64[i] = fill_word;
-                }
-                for (std::uint32_t i = tail_start; i < size_bytes; i++) {
-                    dst8[i] = fill_byte;
-                }
-            } else {
-                for (std::uint32_t i = 0; i < size_bytes; i++) {
-                    dst8[i] = fill_byte;
-                }
-            }
-            if (cached) {
-                flush_l2_cache_range(base_addr, size_bytes);
-            }
+        if (mode == 0) {
+            write_uncached_1b(dst8, size_bytes, num_iterations);
+        } else if (mode == 1) {
+            write_uncached_8b(dst64, num_words, num_iterations);
+        } else if (mode == 2) {
+            write_cached_range_flush(dst64, num_words, base_addr, size_bytes, num_iterations);
+        } else {
+            write_cached_fast_flush(dst64, num_words, flush_start, flush_end, num_iterations);
         }
     }
 

--- a/tests/tt_metal/tt_metal/data_movement/quasar_cache_perf/kernels/cache_write_perf.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_cache_perf/kernels/cache_write_perf.cpp
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Quasar DM-core cache-write performance kernel.
+// Writes `size_bytes` to Tensix L1 either via the uncached port (+4MB alias)
+// or via cacheable memory followed by flush_l2_cache_range, timing the region.
+
+#include <cstdint>
+#include "api/dataflow/dataflow_api.h"  // pulls in DeviceZoneScopedN / DeviceTimestampedData
+#include "dev_mem_map.h"                // MEM_L1_UNCACHED_BASE
+#include "experimental/kernel_args.h"   // get_arg(args::name)
+#include "risc_common.h"                // flush_l2_cache_range
+
+void kernel_main() {
+    std::uint32_t base_addr = get_arg(args::base_addr);
+    std::uint32_t size_bytes = get_arg(args::size_bytes);
+    std::uint32_t write_path = get_arg(args::write_path);  // 0=uncached, 1=cached+flush
+    std::uint32_t test_id = get_arg(args::test_id);
+
+    std::uint32_t dst_addr = (write_path == 0) ? (base_addr + MEM_L1_UNCACHED_BASE) : base_addr;
+    volatile std::uint8_t* dst = (volatile std::uint8_t*)(uintptr_t)dst_addr;
+
+    {
+        DeviceZoneScopedN("RISCV1");
+        for (std::uint32_t i = 0; i < size_bytes; i++) {
+            dst[i] = (std::uint8_t)(i & 0xFF);
+        }
+        if (write_path == 1) {
+            flush_l2_cache_range(base_addr, size_bytes);
+        }
+    }
+
+    DeviceTimestampedData("Test id", test_id);
+    DeviceTimestampedData("Number of transactions", 1);
+    DeviceTimestampedData("Transaction size in bytes", size_bytes);
+    DeviceTimestampedData("Write path", write_path);
+}

--- a/tests/tt_metal/tt_metal/data_movement/quasar_cache_perf/kernels/cache_write_perf.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_cache_perf/kernels/cache_write_perf.cpp
@@ -11,6 +11,12 @@
 // Modes 1 and 2 use the natural 64-bit DM-core store width (8B) for the bulk with
 // a byte tail for any sub-8B remainder (sizes 1/2/4). Stores are volatile so the
 // compiler cannot coalesce/reorder them.
+//
+// The write(+flush) region is repeated `num_iterations` times INSIDE the timed
+// DeviceZoneScopedN, and the host divides the zone duration by num_iterations
+// (stamped as "Number of transactions"). This amortizes fixed per-run overhead
+// (zone entry/exit, prologue, cold pipeline) so the reported value is the
+// steady-state per-write cost, matching the April two-phase measurement method.
 
 #include <cstdint>
 #include "api/dataflow/dataflow_api.h"  // pulls in DeviceZoneScopedN / DeviceTimestampedData
@@ -22,6 +28,7 @@ void kernel_main() {
     std::uint32_t base_addr = get_arg(args::base_addr);
     std::uint32_t size_bytes = get_arg(args::size_bytes);
     std::uint32_t mode = get_arg(args::write_path);  // 0=uncached 1B, 1=uncached 8B, 2=cached+flush 8B
+    std::uint32_t num_iterations = get_arg(args::num_iterations);
     std::uint32_t test_id = get_arg(args::test_id);
 
     bool cached = (mode == 2);
@@ -33,29 +40,34 @@ void kernel_main() {
     const std::uint64_t fill_word = 0x5A5A5A5A5A5A5A5AULL;
     const std::uint8_t fill_byte = 0x5A;
 
+    std::uint32_t num_words = size_bytes >> 3;  // full 8-byte stores
+    std::uint32_t tail_start = num_words << 3;
+
     {
         DeviceZoneScopedN("RISCV1");
-        if (wide) {
-            std::uint32_t num_words = size_bytes >> 3;  // 8-byte stores
-            std::uint32_t tail_start = num_words << 3;
-            for (std::uint32_t i = 0; i < num_words; i++) {
-                dst64[i] = fill_word;
+        for (std::uint32_t iter = 0; iter < num_iterations; iter++) {
+            if (wide) {
+                for (std::uint32_t i = 0; i < num_words; i++) {
+                    dst64[i] = fill_word;
+                }
+                for (std::uint32_t i = tail_start; i < size_bytes; i++) {
+                    dst8[i] = fill_byte;
+                }
+            } else {
+                for (std::uint32_t i = 0; i < size_bytes; i++) {
+                    dst8[i] = fill_byte;
+                }
             }
-            for (std::uint32_t i = tail_start; i < size_bytes; i++) {
-                dst8[i] = fill_byte;
+            if (cached) {
+                flush_l2_cache_range(base_addr, size_bytes);
             }
-        } else {
-            for (std::uint32_t i = 0; i < size_bytes; i++) {
-                dst8[i] = fill_byte;
-            }
-        }
-        if (cached) {
-            flush_l2_cache_range(base_addr, size_bytes);
         }
     }
 
     DeviceTimestampedData("Test id", test_id);
-    DeviceTimestampedData("Number of transactions", 1);
+    // "Number of transactions" = iteration count; host divides zone duration by this
+    // to get the amortized per-write cost, and bandwidth = N * size / duration.
+    DeviceTimestampedData("Number of transactions", num_iterations);
     DeviceTimestampedData("Transaction size in bytes", size_bytes);
     DeviceTimestampedData("Write path", mode);
 }

--- a/tests/tt_metal/tt_metal/data_movement/quasar_cache_perf/kernels/cache_write_perf.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_cache_perf/kernels/cache_write_perf.cpp
@@ -3,8 +3,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Quasar DM-core cache-write performance kernel.
-// Writes `size_bytes` to Tensix L1 either via the uncached port (+4MB alias)
-// or via cacheable memory followed by flush_l2_cache_range, timing the region.
+// Writes `size_bytes` to Tensix L1 and times the region, in one of three modes
+// (the "Write path" arg):
+//   0 = Uncached, 1-byte stores   -> uncached port (+4MB alias), byte-at-a-time
+//   1 = Uncached, 8-byte stores   -> uncached port, 64-bit stores + byte tail
+//   2 = Cached+Flush, 8-byte      -> cacheable write (64-bit) then flush_l2_cache_range
+// Modes 1 and 2 use the natural 64-bit DM-core store width (8B) for the bulk with
+// a byte tail for any sub-8B remainder (sizes 1/2/4). Stores are volatile so the
+// compiler cannot coalesce/reorder them.
 
 #include <cstdint>
 #include "api/dataflow/dataflow_api.h"  // pulls in DeviceZoneScopedN / DeviceTimestampedData
@@ -15,18 +21,35 @@
 void kernel_main() {
     std::uint32_t base_addr = get_arg(args::base_addr);
     std::uint32_t size_bytes = get_arg(args::size_bytes);
-    std::uint32_t write_path = get_arg(args::write_path);  // 0=uncached, 1=cached+flush
+    std::uint32_t mode = get_arg(args::write_path);  // 0=uncached 1B, 1=uncached 8B, 2=cached+flush 8B
     std::uint32_t test_id = get_arg(args::test_id);
 
-    std::uint32_t dst_addr = (write_path == 0) ? (base_addr + MEM_L1_UNCACHED_BASE) : base_addr;
-    volatile std::uint8_t* dst = (volatile std::uint8_t*)(uintptr_t)dst_addr;
+    bool cached = (mode == 2);
+    bool wide = (mode != 0);  // 8-byte stores for modes 1 and 2
+    std::uint32_t dst_addr = cached ? base_addr : (base_addr + MEM_L1_UNCACHED_BASE);
+
+    volatile std::uint64_t* dst64 = (volatile std::uint64_t*)(uintptr_t)dst_addr;
+    volatile std::uint8_t* dst8 = (volatile std::uint8_t*)(uintptr_t)dst_addr;
+    const std::uint64_t fill_word = 0x5A5A5A5A5A5A5A5AULL;
+    const std::uint8_t fill_byte = 0x5A;
 
     {
         DeviceZoneScopedN("RISCV1");
-        for (std::uint32_t i = 0; i < size_bytes; i++) {
-            dst[i] = (std::uint8_t)(i & 0xFF);
+        if (wide) {
+            std::uint32_t num_words = size_bytes >> 3;  // 8-byte stores
+            std::uint32_t tail_start = num_words << 3;
+            for (std::uint32_t i = 0; i < num_words; i++) {
+                dst64[i] = fill_word;
+            }
+            for (std::uint32_t i = tail_start; i < size_bytes; i++) {
+                dst8[i] = fill_byte;
+            }
+        } else {
+            for (std::uint32_t i = 0; i < size_bytes; i++) {
+                dst8[i] = fill_byte;
+            }
         }
-        if (write_path == 1) {
+        if (cached) {
             flush_l2_cache_range(base_addr, size_bytes);
         }
     }
@@ -34,5 +57,5 @@ void kernel_main() {
     DeviceTimestampedData("Test id", test_id);
     DeviceTimestampedData("Number of transactions", 1);
     DeviceTimestampedData("Transaction size in bytes", size_bytes);
-    DeviceTimestampedData("Write path", write_path);
+    DeviceTimestampedData("Write path", mode);
 }

--- a/tests/tt_metal/tt_metal/data_movement/quasar_cache_perf/plot_cache_write_from_csv.py
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_cache_perf/plot_cache_write_from_csv.py
@@ -78,6 +78,8 @@ def reconstruct_runs(csv_path):
             val = int(r[COL_DATA])
             if zone == "Transaction size in bytes":
                 cur["size"] = val
+            elif zone == "Number of transactions":
+                cur["iters"] = val
             elif zone == "Write path":
                 cur["mode"] = val
             elif zone == "Test id":
@@ -90,10 +92,15 @@ def reconstruct_runs(csv_path):
 
 
 def series_by_mode(runs):
-    """{mode: {'sizes':[...], 'dur':[...], 'bw':[...]}} for each write mode present."""
+    """{mode: {'sizes':[...], 'dur':[...], 'bw':[...]}} for each write mode present.
+
+    ``dur`` is the amortized per-iteration duration (zone total / iteration count),
+    and ``bw`` is bytes/cycle = size / per-iteration duration."""
     by_mode = {}
     for r in runs:
-        by_mode.setdefault(r["mode"], {})[r["size"]] = r["dur"]
+        iters = r.get("iters", 1) or 1
+        per_iter_dur = r["dur"] / iters
+        by_mode.setdefault(r["mode"], {})[r["size"]] = per_iter_dur
     out = {}
     for mode, size_to_dur in by_mode.items():
         sizes = sorted(size_to_dur)
@@ -136,15 +143,9 @@ def main():
     series = series_by_mode(runs)
 
     fig, axes = plt.subplots(2, 2, figsize=(15, 11))
-    _draw(axes[0][0], series, "dur", lambda s: True, "Duration - full range", "Duration (cycles)")
-    _draw(
-        axes[0][1],
-        series,
-        "dur",
-        lambda s: s <= args.zoom_max,
-        f"Duration - zoom <= {args.zoom_max}B",
-        "Duration (cycles)",
-    )
+    dur_label = "Duration per write (cycles, amortized)"
+    _draw(axes[0][0], series, "dur", lambda s: True, "Duration - full range", dur_label)
+    _draw(axes[0][1], series, "dur", lambda s: s <= args.zoom_max, f"Duration - zoom <= {args.zoom_max}B", dur_label)
     _draw(axes[1][0], series, "bw", lambda s: True, "Bandwidth - full range", "Bandwidth (bytes/cycle)")
     _draw(
         axes[1][1],
@@ -155,7 +156,9 @@ def main():
         "Bandwidth (bytes/cycle)",
     )
     fig.suptitle(
-        f"Quasar Cache Write Sizes (test {TEST_ID}) - uncached 1B vs uncached 8B vs cached+flush", fontweight="bold"
+        f"Quasar Cache Write Sizes (test {TEST_ID}) - amortized over {runs[0].get('iters', '?')} iters "
+        f"- uncached 1B vs uncached 8B vs cached+flush",
+        fontweight="bold",
     )
 
     os.makedirs(os.path.dirname(args.out), exist_ok=True)

--- a/tests/tt_metal/tt_metal/data_movement/quasar_cache_perf/plot_cache_write_from_csv.py
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_cache_perf/plot_cache_write_from_csv.py
@@ -1,0 +1,146 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Reconstruct and plot Quasar cache-write results (test id 912) directly from the
+profiler device CSV, without relying on ``run_host_id``.
+
+Why this exists
+---------------
+On the ``emu-quasar-1x3`` target there are no fast-dispatch cores, so the test
+runs in slow-dispatch mode. Under slow dispatch the profiler does not increment
+``run host ID`` -- every sweep run is stamped ``run_host_id = 0``. The shared dm
+harness (``stats_collector.aggregate_performance``) groups runs by
+``run_host_id``, so all runs collapse into a single point and the normal
+``--plot`` output is unusable.
+
+The per-run data is still fully present in the CSV, in execution order: each
+``RISCV1`` ``ZONE_START``/``ZONE_END`` pair is immediately followed by that run's
+``Transaction size in bytes`` and ``Write path`` stamps. This script walks the
+CSV in order to recover each run's (size, path, duration) tuple and plots the two
+paths overlaid, plus a zoomed panel over the small-size region where the
+crossover occurs.
+
+This is a stopgap for the emulator. Once this runs on hardware / a fast-dispatch
+grid (where ``run_host_id`` increments), the standard
+``test_data_movement.py --plot --arch=quasar`` pipeline plots the curves
+directly and this script is no longer needed.
+
+Usage
+-----
+    python tests/tt_metal/tt_metal/data_movement/quasar_cache_perf/plot_cache_write_from_csv.py \
+        [--csv generated/profiler/.logs/profile_log_device.csv] \
+        [--out "tests/tt_metal/tt_metal/data_movement/data/quasar/Quasar Cache Write Sizes.png"] \
+        [--zoom-max 64]
+"""
+
+import argparse
+import os
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import matplotlib.ticker as mticker
+
+TEST_ID = 912
+PATH_LABELS = {0: "Uncached", 1: "Cached+Flush"}
+
+# CSV column indices (0-based), per the tracy device-log header:
+# PCIe, core_x, core_y, RISC type, timer_id, time, data, run host ID, trace id,
+# trace id counter, zone name, type, source line, source file, meta
+COL_TIME = 5
+COL_DATA = 6
+COL_ZONE = 10
+COL_TYPE = 11
+
+
+def reconstruct_runs(csv_path):
+    """Return a list of {'dur','size','path','test_id'} dicts, one per RISCV1 run,
+    recovered from CSV order (independent of run_host_id)."""
+    with open(csv_path) as f:
+        rows = [line.rstrip("\n").split(",") for line in f]
+    runs = []
+    cur = {}
+    start = None
+    for r in rows:
+        if len(r) <= COL_TYPE:
+            continue
+        zone, typ = r[COL_ZONE], r[COL_TYPE]
+        if typ == "ZONE_START" and zone == "RISCV1":
+            start = int(r[COL_TIME])
+        elif typ == "ZONE_END" and zone == "RISCV1" and start is not None:
+            cur = {"dur": int(r[COL_TIME]) - start}
+            start = None
+        elif typ == "TS_DATA" and cur:
+            val = int(r[COL_DATA])
+            if zone == "Transaction size in bytes":
+                cur["size"] = val
+            elif zone == "Write path":
+                cur["path"] = val
+            elif zone == "Test id":
+                cur["test_id"] = val
+            # "Write path" is stamped last per run -> flush the run.
+            if zone == "Write path":
+                runs.append(cur)
+                cur = {}
+    return [r for r in runs if r.get("test_id", TEST_ID) == TEST_ID and "size" in r and "path" in r]
+
+
+def series_by_path(runs):
+    """{path: (sorted_sizes, durations)} for each write path present."""
+    by_path = {}
+    for r in runs:
+        by_path.setdefault(r["path"], {})[r["size"]] = r["dur"]
+    out = {}
+    for path, size_to_dur in by_path.items():
+        sizes = sorted(size_to_dur)
+        out[path] = (sizes, [size_to_dur[s] for s in sizes])
+    return out
+
+
+def _draw(ax, series, size_filter, title):
+    for path in sorted(series):
+        sizes, durs = series[path]
+        pts = [(s, d) for s, d in zip(sizes, durs) if size_filter(s)]
+        if not pts:
+            continue
+        xs, ys = zip(*pts)
+        ax.plot(xs, ys, marker="o", label=PATH_LABELS.get(path, f"path {path}"))
+        ax.set_xticks(xs)
+    ax.set_xscale("log", base=2)
+    ax.xaxis.set_major_formatter(mticker.FuncFormatter(lambda x, _: f"{int(x)}"))
+    ax.set_xlabel("Total Data Size (bytes)")
+    ax.set_ylabel("Duration (cycles)")
+    ax.set_title(title)
+    ax.grid(True)
+    ax.legend()
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--csv", default="generated/profiler/.logs/profile_log_device.csv")
+    parser.add_argument(
+        "--out", default="tests/tt_metal/tt_metal/data_movement/data/quasar/Quasar Cache Write Sizes.png"
+    )
+    parser.add_argument("--zoom-max", type=int, default=64, help="upper size (bytes) for the zoomed panel")
+    args = parser.parse_args()
+
+    runs = reconstruct_runs(args.csv)
+    if not runs:
+        raise SystemExit(f"No test {TEST_ID} runs reconstructed from {args.csv}")
+    series = series_by_path(runs)
+
+    fig, (ax_full, ax_zoom) = plt.subplots(1, 2, figsize=(14, 6))
+    _draw(ax_full, series, lambda s: True, "Full range")
+    _draw(ax_zoom, series, lambda s: s <= args.zoom_max, f"Zoom: <= {args.zoom_max}B (crossover region)")
+    fig.suptitle(f"Data Size vs Write Duration (QUASAR) - test {TEST_ID}", fontweight="bold")
+
+    os.makedirs(os.path.dirname(args.out), exist_ok=True)
+    fig.tight_layout()
+    fig.savefig(args.out, dpi=110)
+    print(f"Reconstructed {len(runs)} runs. Saved plot: {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tt_metal/tt_metal/data_movement/quasar_cache_perf/plot_cache_write_from_csv.py
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_cache_perf/plot_cache_write_from_csv.py
@@ -46,7 +46,12 @@ import matplotlib.ticker as mticker
 
 TEST_ID = 912
 # Write modes stamped as "Write path" by the kernel.
-MODE_LABELS = {0: "Uncached (1B)", 1: "Uncached (8B)", 2: "Cached+Flush (8B)"}
+MODE_LABELS = {
+    0: "Uncached (1B stores)",
+    1: "Uncached (8B stores)",
+    2: "Cached + flush (fence per line)",
+    3: "Cached + flush (single fence)",
+}
 
 # CSV column indices (0-based), per the tracy device-log header:
 # PCIe, core_x, core_y, RISC type, timer_id, time, data, run host ID, trace id,
@@ -157,7 +162,7 @@ def main():
     )
     fig.suptitle(
         f"Quasar Cache Write Sizes (test {TEST_ID}) - amortized over {runs[0].get('iters', '?')} iters "
-        f"- uncached 1B vs uncached 8B vs cached+flush",
+        f"- uncached (1B/8B stores) vs cached+flush (fence per line / single fence)",
         fontweight="bold",
     )
 

--- a/tests/tt_metal/tt_metal/data_movement/quasar_cache_perf/plot_cache_write_from_csv.py
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_cache_perf/plot_cache_write_from_csv.py
@@ -23,14 +23,9 @@ harness (``stats_collector.aggregate_performance``) groups runs by
 The per-run data is still fully present in the CSV, in execution order: each
 ``RISCV1`` ``ZONE_START``/``ZONE_END`` pair is immediately followed by that run's
 ``Transaction size in bytes`` and ``Write path`` stamps. This script walks the
-CSV in order to recover each run's (size, path, duration) tuple and plots the two
-paths overlaid, plus a zoomed panel over the small-size region where the
-crossover occurs.
-
-This is a stopgap for the emulator. Once this runs on hardware / a fast-dispatch
-grid (where ``run_host_id`` increments), the standard
-``test_data_movement.py --plot --arch=quasar`` pipeline plots the curves
-directly and this script is no longer needed.
+CSV in order to recover each run's (size, mode, duration) tuple and plots all
+three write modes overlaid, as both duration (cycles) and bandwidth
+(bytes/cycle), with a zoomed panel over the small-size crossover region.
 
 Usage
 -----
@@ -50,7 +45,8 @@ import matplotlib.pyplot as plt
 import matplotlib.ticker as mticker
 
 TEST_ID = 912
-PATH_LABELS = {0: "Uncached", 1: "Cached+Flush"}
+# Write modes stamped as "Write path" by the kernel.
+MODE_LABELS = {0: "Uncached (1B)", 1: "Uncached (8B)", 2: "Cached+Flush (8B)"}
 
 # CSV column indices (0-based), per the tracy device-log header:
 # PCIe, core_x, core_y, RISC type, timer_id, time, data, run host ID, trace id,
@@ -62,7 +58,7 @@ COL_TYPE = 11
 
 
 def reconstruct_runs(csv_path):
-    """Return a list of {'dur','size','path','test_id'} dicts, one per RISCV1 run,
+    """Return a list of {'dur','size','mode','test_id'} dicts, one per RISCV1 run,
     recovered from CSV order (independent of run_host_id)."""
     with open(csv_path) as f:
         rows = [line.rstrip("\n").split(",") for line in f]
@@ -83,41 +79,43 @@ def reconstruct_runs(csv_path):
             if zone == "Transaction size in bytes":
                 cur["size"] = val
             elif zone == "Write path":
-                cur["path"] = val
+                cur["mode"] = val
             elif zone == "Test id":
                 cur["test_id"] = val
             # "Write path" is stamped last per run -> flush the run.
             if zone == "Write path":
                 runs.append(cur)
                 cur = {}
-    return [r for r in runs if r.get("test_id", TEST_ID) == TEST_ID and "size" in r and "path" in r]
+    return [r for r in runs if r.get("test_id", TEST_ID) == TEST_ID and "size" in r and "mode" in r]
 
 
-def series_by_path(runs):
-    """{path: (sorted_sizes, durations)} for each write path present."""
-    by_path = {}
+def series_by_mode(runs):
+    """{mode: {'sizes':[...], 'dur':[...], 'bw':[...]}} for each write mode present."""
+    by_mode = {}
     for r in runs:
-        by_path.setdefault(r["path"], {})[r["size"]] = r["dur"]
+        by_mode.setdefault(r["mode"], {})[r["size"]] = r["dur"]
     out = {}
-    for path, size_to_dur in by_path.items():
+    for mode, size_to_dur in by_mode.items():
         sizes = sorted(size_to_dur)
-        out[path] = (sizes, [size_to_dur[s] for s in sizes])
+        durs = [size_to_dur[s] for s in sizes]
+        bw = [s / d if d else 0 for s, d in zip(sizes, durs)]
+        out[mode] = {"sizes": sizes, "dur": durs, "bw": bw}
     return out
 
 
-def _draw(ax, series, size_filter, title):
-    for path in sorted(series):
-        sizes, durs = series[path]
-        pts = [(s, d) for s, d in zip(sizes, durs) if size_filter(s)]
+def _draw(ax, series, ykey, size_filter, title, ylabel):
+    for mode in sorted(series):
+        s = series[mode]
+        pts = [(x, y) for x, y in zip(s["sizes"], s[ykey]) if size_filter(x)]
         if not pts:
             continue
         xs, ys = zip(*pts)
-        ax.plot(xs, ys, marker="o", label=PATH_LABELS.get(path, f"path {path}"))
+        ax.plot(xs, ys, marker="o", label=MODE_LABELS.get(mode, f"mode {mode}"))
         ax.set_xticks(xs)
     ax.set_xscale("log", base=2)
     ax.xaxis.set_major_formatter(mticker.FuncFormatter(lambda x, _: f"{int(x)}"))
     ax.set_xlabel("Total Data Size (bytes)")
-    ax.set_ylabel("Duration (cycles)")
+    ax.set_ylabel(ylabel)
     ax.set_title(title)
     ax.grid(True)
     ax.legend()
@@ -129,18 +127,36 @@ def main():
     parser.add_argument(
         "--out", default="tests/tt_metal/tt_metal/data_movement/data/quasar/Quasar Cache Write Sizes.png"
     )
-    parser.add_argument("--zoom-max", type=int, default=64, help="upper size (bytes) for the zoomed panel")
+    parser.add_argument("--zoom-max", type=int, default=64, help="upper size (bytes) for the zoomed panels")
     args = parser.parse_args()
 
     runs = reconstruct_runs(args.csv)
     if not runs:
         raise SystemExit(f"No test {TEST_ID} runs reconstructed from {args.csv}")
-    series = series_by_path(runs)
+    series = series_by_mode(runs)
 
-    fig, (ax_full, ax_zoom) = plt.subplots(1, 2, figsize=(14, 6))
-    _draw(ax_full, series, lambda s: True, "Full range")
-    _draw(ax_zoom, series, lambda s: s <= args.zoom_max, f"Zoom: <= {args.zoom_max}B (crossover region)")
-    fig.suptitle(f"Data Size vs Write Duration (QUASAR) - test {TEST_ID}", fontweight="bold")
+    fig, axes = plt.subplots(2, 2, figsize=(15, 11))
+    _draw(axes[0][0], series, "dur", lambda s: True, "Duration - full range", "Duration (cycles)")
+    _draw(
+        axes[0][1],
+        series,
+        "dur",
+        lambda s: s <= args.zoom_max,
+        f"Duration - zoom <= {args.zoom_max}B",
+        "Duration (cycles)",
+    )
+    _draw(axes[1][0], series, "bw", lambda s: True, "Bandwidth - full range", "Bandwidth (bytes/cycle)")
+    _draw(
+        axes[1][1],
+        series,
+        "bw",
+        lambda s: s <= args.zoom_max,
+        f"Bandwidth - zoom <= {args.zoom_max}B",
+        "Bandwidth (bytes/cycle)",
+    )
+    fig.suptitle(
+        f"Quasar Cache Write Sizes (test {TEST_ID}) - uncached 1B vs uncached 8B vs cached+flush", fontweight="bold"
+    )
 
     os.makedirs(os.path.dirname(args.out), exist_ok=True)
     fig.tight_layout()

--- a/tests/tt_metal/tt_metal/data_movement/quasar_cache_perf/plot_cache_write_from_csv.py
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_cache_perf/plot_cache_write_from_csv.py
@@ -5,6 +5,12 @@
 """Reconstruct and plot Quasar cache-write results (test id 912) directly from the
 profiler device CSV, without relying on ``run_host_id``.
 
+TEMPORARY: this is a stopgap script. Its CSV-order reconstruction is meant to be
+folded into the shared dm pipeline (``stats_collector.aggregate_performance``) as
+an order-based fallback for when ``run_host_id`` collides, at which point
+``test_data_movement.py --plot`` plots these curves directly and this standalone
+script should be removed.
+
 Why this exists
 ---------------
 On the ``emu-quasar-1x3`` target there are no fast-dispatch cores, so the test

--- a/tests/tt_metal/tt_metal/data_movement/quasar_cache_perf/test_quasar_cache_perf.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_cache_perf/test_quasar_cache_perf.cpp
@@ -83,11 +83,21 @@ bool run_cache_write(
 
 class QuasarCacheWrite : public QuasarMeshDeviceSingleCardFixture {};
 
-TEST_F(QuasarCacheWrite, SpikeSingleRun) {
+namespace unit_tests::dm::quasar_cache_perf {
+static const std::vector<std::uint32_t> kSizesBytes = {1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048};
+}  // namespace unit_tests::dm::quasar_cache_perf
+
+TEST_F(QuasarCacheWrite, SizeSweep) {
     if (unit_tests::dm::quasar_cache_perf::should_skip_test()) {
         GTEST_SKIP() << "Test requires Quasar simulator";
     }
-    EXPECT_TRUE(unit_tests::dm::quasar_cache_perf::run_cache_write(devices_[0], 256, /*uncached*/ 0));
+    bool pass = true;
+    for (std::uint32_t write_path : {0u, 1u}) {  // 0=uncached, 1=cached+flush
+        for (std::uint32_t size_bytes : unit_tests::dm::quasar_cache_perf::kSizesBytes) {
+            pass &= unit_tests::dm::quasar_cache_perf::run_cache_write(devices_[0], size_bytes, write_path);
+        }
+    }
+    EXPECT_TRUE(pass);
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/data_movement/quasar_cache_perf/test_quasar_cache_perf.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_cache_perf/test_quasar_cache_perf.cpp
@@ -88,7 +88,9 @@ bool run_cache_write(
 class QuasarCacheWrite : public QuasarMeshDeviceSingleCardFixture {};
 
 namespace unit_tests::dm::quasar_cache_perf {
-static const std::vector<std::uint32_t> kSizesBytes = {1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048};
+// Sizes are multiples of 8 (kernel does 8-byte stores, no sub-8B tail). 24 = 3x uint64
+// stores, the direct comparison point against the April descriptor-write baseline.
+static const std::vector<std::uint32_t> kSizesBytes = {8, 16, 24, 32, 64, 128, 256, 512, 1024, 2048};
 }  // namespace unit_tests::dm::quasar_cache_perf
 
 TEST_F(QuasarCacheWrite, SizeSweep) {
@@ -96,8 +98,8 @@ TEST_F(QuasarCacheWrite, SizeSweep) {
         GTEST_SKIP() << "Test requires Quasar simulator";
     }
     bool pass = true;
-    // mode: 0=uncached 1B stores, 1=uncached 8B stores, 2=cached+flush 8B stores
-    for (std::uint32_t mode : {0u, 1u, 2u}) {
+    // mode: 0=uncached 1B, 1=uncached 8B, 2=cached+range flush (April), 3=cached+fast flush
+    for (std::uint32_t mode : {0u, 1u, 2u, 3u}) {
         for (std::uint32_t size_bytes : unit_tests::dm::quasar_cache_perf::kSizesBytes) {
             pass &= unit_tests::dm::quasar_cache_perf::run_cache_write(devices_[0], size_bytes, mode);
         }

--- a/tests/tt_metal/tt_metal/data_movement/quasar_cache_perf/test_quasar_cache_perf.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_cache_perf/test_quasar_cache_perf.cpp
@@ -20,6 +20,9 @@ namespace unit_tests::dm::quasar_cache_perf {
 
 constexpr std::uint32_t QUASAR_CACHE_WRITE_TEST_ID = 912;
 constexpr std::uint32_t BASE_ADDR = 100 * 1024;
+// Repeat the timed write(+flush) region this many times per run and divide the
+// zone duration by it, to amortize fixed per-run overhead (April used 100).
+constexpr std::uint32_t NUM_ITERATIONS = 100;
 
 bool should_skip_test() { return std::getenv("TT_METAL_SIMULATOR") == nullptr; }
 
@@ -42,7 +45,7 @@ bool run_cache_write(
         .num_threads = 1,
         .runtime_arg_schema =
             {
-                .runtime_arg_names = {"base_addr", "size_bytes", "write_path", "test_id"},
+                .runtime_arg_names = {"base_addr", "size_bytes", "write_path", "num_iterations", "test_id"},
             },
         .hw_config = experimental::DataMovementGen2Config{},
     };
@@ -58,6 +61,7 @@ bool run_cache_write(
             {{"base_addr", BASE_ADDR},
              {"size_bytes", size_bytes},
              {"write_path", write_path},
+             {"num_iterations", NUM_ITERATIONS},
              {"test_id", QUASAR_CACHE_WRITE_TEST_ID}}),
     }};
     experimental::SetProgramRunArgs(program, params);

--- a/tests/tt_metal/tt_metal/data_movement/quasar_cache_perf/test_quasar_cache_perf.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_cache_perf/test_quasar_cache_perf.cpp
@@ -1,0 +1,93 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Quasar DM-core cache-write performance test (test id 912).
+
+#include <tt-logger/tt-logger.hpp>
+#include "device_fixture.hpp"
+#include "dm_common.hpp"
+#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program.hpp>
+#include <cstdint>
+
+namespace tt::tt_metal {
+
+using namespace std;
+using namespace tt::test_utils;
+
+namespace unit_tests::dm::quasar_cache_perf {
+
+constexpr std::uint32_t QUASAR_CACHE_WRITE_TEST_ID = 912;
+constexpr std::uint32_t BASE_ADDR = 100 * 1024;
+
+bool should_skip_test() { return std::getenv("TT_METAL_SIMULATOR") == nullptr; }
+
+// Runs one write pass of `size_bytes` via `write_path` (0=uncached,1=cached+flush)
+// on a single DM core, then reads back and verifies the byte pattern landed.
+bool run_cache_write(
+    const std::shared_ptr<distributed::MeshDevice>& mesh_device, std::uint32_t size_bytes, std::uint32_t write_path) {
+    IDevice* device = mesh_device->get_devices()[0];
+    constexpr CoreCoord core = {0, 0};
+    const experimental::NodeCoord node{0, 0};
+
+    // Pre-fill destination with a sentinel so a no-op run fails the read-back.
+    std::vector<std::uint32_t> init_data((size_bytes + 3) / 4, 0xA5A5A5A5);
+    tt_metal::detail::WriteToDeviceL1(device, core, BASE_ADDR, init_data);
+
+    const experimental::KernelSpecName DM_KERNEL{"cache_write_perf"};
+    experimental::KernelSpec dm_kernel_spec{
+        .unique_id = DM_KERNEL,
+        .source = "tests/tt_metal/tt_metal/data_movement/quasar_cache_perf/kernels/cache_write_perf.cpp",
+        .num_threads = 1,
+        .runtime_arg_schema =
+            {
+                .runtime_arg_names = {"base_addr", "size_bytes", "write_path", "test_id"},
+            },
+        .hw_config = experimental::DataMovementGen2Config{},
+    };
+    experimental::WorkUnitSpec main_wu{.name = "main", .kernels = {DM_KERNEL}, .target_nodes = node};
+    experimental::ProgramSpec spec{.name = "cache_write_perf", .kernels = {dm_kernel_spec}, .work_units = {main_wu}};
+    Program program = experimental::MakeProgramFromSpec(*mesh_device, spec);
+
+    experimental::ProgramRunArgs params;
+    params.kernel_run_args = {experimental::ProgramRunArgs::KernelRunArgs{
+        .kernel = DM_KERNEL,
+        .runtime_arg_values = experimental::MakeRuntimeArgsForSingleNode(
+            node,
+            {{"base_addr", BASE_ADDR},
+             {"size_bytes", size_bytes},
+             {"write_path", write_path},
+             {"test_id", QUASAR_CACHE_WRITE_TEST_ID}}),
+    }};
+    experimental::SetProgramRunArgs(program, params);
+
+    distributed::MeshWorkload workload;
+    distributed::MeshCoordinateRange device_range(mesh_device->shape());
+    workload.add_program(device_range, std::move(program));
+    distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), workload, /*blocking=*/true);
+
+    std::vector<std::uint32_t> out;
+    tt_metal::detail::ReadFromDeviceL1(device, core, BASE_ADDR, ((size_bytes + 3) / 4) * 4, out);
+    const std::uint8_t* bytes = reinterpret_cast<const std::uint8_t*>(out.data());
+    for (std::uint32_t i = 0; i < size_bytes; i++) {
+        if (bytes[i] != static_cast<std::uint8_t>(i & 0xFF)) {
+            log_error(tt::LogTest, "path {} size {} mismatch at {}: got 0x{:02x}", write_path, size_bytes, i, bytes[i]);
+            return false;
+        }
+    }
+    return true;
+}
+
+}  // namespace unit_tests::dm::quasar_cache_perf
+
+class QuasarCacheWrite : public QuasarMeshDeviceSingleCardFixture {};
+
+TEST_F(QuasarCacheWrite, SpikeSingleRun) {
+    if (unit_tests::dm::quasar_cache_perf::should_skip_test()) {
+        GTEST_SKIP() << "Test requires Quasar simulator";
+    }
+    EXPECT_TRUE(unit_tests::dm::quasar_cache_perf::run_cache_write(devices_[0], 256, /*uncached*/ 0));
+}
+
+}  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/data_movement/quasar_cache_perf/test_quasar_cache_perf.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_cache_perf/test_quasar_cache_perf.cpp
@@ -71,8 +71,8 @@ bool run_cache_write(
     tt_metal::detail::ReadFromDeviceL1(device, core, BASE_ADDR, ((size_bytes + 3) / 4) * 4, out);
     const std::uint8_t* bytes = reinterpret_cast<const std::uint8_t*>(out.data());
     for (std::uint32_t i = 0; i < size_bytes; i++) {
-        if (bytes[i] != static_cast<std::uint8_t>(i & 0xFF)) {
-            log_error(tt::LogTest, "path {} size {} mismatch at {}: got 0x{:02x}", write_path, size_bytes, i, bytes[i]);
+        if (bytes[i] != 0x5A) {
+            log_error(tt::LogTest, "mode {} size {} mismatch at {}: got 0x{:02x}", write_path, size_bytes, i, bytes[i]);
             return false;
         }
     }
@@ -92,9 +92,10 @@ TEST_F(QuasarCacheWrite, SizeSweep) {
         GTEST_SKIP() << "Test requires Quasar simulator";
     }
     bool pass = true;
-    for (std::uint32_t write_path : {0u, 1u}) {  // 0=uncached, 1=cached+flush
+    // mode: 0=uncached 1B stores, 1=uncached 8B stores, 2=cached+flush 8B stores
+    for (std::uint32_t mode : {0u, 1u, 2u}) {
         for (std::uint32_t size_bytes : unit_tests::dm::quasar_cache_perf::kSizesBytes) {
-            pass &= unit_tests::dm::quasar_cache_perf::run_cache_write(devices_[0], size_bytes, write_path);
+            pass &= unit_tests::dm::quasar_cache_perf::run_cache_write(devices_[0], size_bytes, mode);
         }
     }
     EXPECT_TRUE(pass);

--- a/tests/tt_metal/tt_metal/data_movement/sources.cmake
+++ b/tests/tt_metal/tt_metal/data_movement/sources.cmake
@@ -35,6 +35,7 @@ set(UNIT_TESTS_DATA_MOVEMENT_SRC
     matmul/test_matmul_1d_v2.cpp
     matmul/test_matmul_2d.cpp
     quasar_cache/test_quasar_cache.cpp
+    quasar_cache_perf/test_quasar_cache_perf.cpp
     quasar_examples/quasar_addrgen/test_addrgen_example.cpp
     quasar_examples/quasar_im2col/test_im2col_example.cpp
     quasar_examples/quasar_idma/test_idma_example.cpp


### PR DESCRIPTION
## What

Quasar-only dm performance test (**test id 912**, `QuasarCacheWrite.SizeSweep`): single-DM-core write to Tensix L1, swept 8B–2KB (multiples of 8), across **four write modes**, amortized over 100 iterations inside a profiler zone (per-write cost = zone duration / iterations):

- **Uncached (1B stores)** — uncached port (+4MB alias), byte-at-a-time.
- **Uncached (8B stores)** — uncached port, 64-bit stores.
- **Cached + flush (fence per line)** — cacheable stores + `flush_l2_cache_range` (library; 2 fences per 64B line).
- **Cached + flush (single fence)** — cacheable stores + bare flush-reg writes over touched lines, one fence after all iterations.

## Result (emu-quasar-1x3, amortized cycles/write)

| size (B) | Unc 1B | Unc 8B | Cached (fence/line) | Cached (single fence) |
|---:|---:|---:|---:|---:|
| 24 | 371 | 80 | 169 | 99 |
| 64 | 889 | 141 | 189 | 177 |
| 256 | 3107 | 446 | 603 | 560 |
| 2048 | 24305 | 3428 | 4405 | 3904 |

- **Store width dominates the uncached port** (~13–14 cyc/8B-store; byte-at-a-time ~8x worse).
- **Flush fencing matters**: single-fence flush is much cheaper than the library per-line-fenced flush (2KB: 3904 vs 4405).
- Cache+flush still doesn't beat uncached-8B for write-only, no-reuse traffic; it pays off only with read-back / coalesced sub-line updates.

## Changes
- New `quasar_cache_perf/` (kernel, host sweep, README, temporary CSV-order plot helper), registered in `sources.cmake`.
- Metadata (`test_information.yaml`, `test_type_attributes.yaml`, 4 descriptive mode labels).
- `plotter.py`: amortized per-write duration + bandwidth panels, one line per mode.
- **Shared dm parser support for Quasar** (`stats_collector.py`, `test_data_movement.py`), arch-gated / additive — Wormhole/Blackhole unchanged.

## Known limitation (deferred)
`emu-quasar-1x3` has no fast-dispatch cores → slow dispatch → profiler doesn't increment `run_host_id`, so the shared `--plot` aggregation collapses runs; the temporary `plot_cache_write_from_csv.py` reconstructs per-run data from CSV order. Deferred to hardware / fast dispatch.

## Test plan
`TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/unit_tests_data_movement --gtest_filter="*QuasarCacheWrite*"` → **40/40 read-backs pass** (4 modes × 10 sizes, 100 iters).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
