### PR TITLE
[Feature][Profiler] Bringup `DeviceZoneScopedN` on Quasar 

### DIFF
--- a/tests/tt_metal/tools/profiler/test_device_profiler.py
+++ b/tests/tt_metal/tools/profiler/test_device_profiler.py
@@ -290,6 +290,11 @@ def test_full_buffer():
     OP_COUNT = 23
     RISC_COUNT = 5
     ZONE_COUNT = 125
+
+    # Quasar only run 1 OP to saturate the L1 buffer
+    QUASAR_OP_COUNT = 1
+    QUASAR_RISC_COUNT = 6 + 4 * 4  # DM2-7 + Neo0-3 * TRISC0-3
+    QUASAR_ZONE_COUNT = 125
     REF_COUNT_DICT = {
         "wormhole_b0": [
             72 * OP_COUNT * RISC_COUNT * ZONE_COUNT,
@@ -301,13 +306,23 @@ def test_full_buffer():
             120 * OP_COUNT * RISC_COUNT * ZONE_COUNT,
             110 * OP_COUNT * RISC_COUNT * ZONE_COUNT,
         ],
+        # Note: using emu-quasar-2x3_DISPATCH for both dispatch modes
+        "quasar": [
+            2 * QUASAR_OP_COUNT * QUASAR_RISC_COUNT * QUASAR_ZONE_COUNT,
+        ],
+    }
+    TEST_BIN_DICT = {
+        "wormhole_b0": "build/test/tt_metal/tools/profiler/test_full_buffer",
+        "blackhole": "build/test/tt_metal/tools/profiler/test_full_buffer",
+        "quasar": "build/programming_examples/profiler/test_full_buffer",
     }
 
     ENV_VAR_ARCH_NAME = os.getenv("ARCH_NAME")
     assert ENV_VAR_ARCH_NAME in REF_COUNT_DICT.keys()
 
     devicesData = run_device_profiler_test(
-        testName="build/test/tt_metal/tools/profiler/test_full_buffer", setupAutoExtract=True
+        testName=TEST_BIN_DICT[ENV_VAR_ARCH_NAME],
+        setupAutoExtract=True,
     )
 
     stats = devicesData["data"]["devices"]["0"]["cores"]["DEVICE"]["analysis"]

--- a/tests/tt_metal/tools/profiler/test_device_profiler.py
+++ b/tests/tt_metal/tools/profiler/test_device_profiler.py
@@ -291,7 +291,7 @@ def test_full_buffer():
     RISC_COUNT = 5
     ZONE_COUNT = 125
 
-    # Quasar only run 1 OP to saturate the L1 buffer
+    # Quasar runs only 1 OP to saturate the L1 buffer
     QUASAR_OP_COUNT = 1
     QUASAR_RISC_COUNT = 6 + 4 * 4  # DM2-7 + Neo0-3 * TRISC0-3
     QUASAR_ZONE_COUNT = 125

--- a/tt_metal/hw/firmware/src/tt-2xx/dispatch_dm.cc
+++ b/tt_metal/hw/firmware/src/tt-2xx/dispatch_dm.cc
@@ -15,6 +15,16 @@
 #include "tools/profiler/kernel_profiler.hpp"
 #include "api/kernel_thread_globals.h"
 
+#if defined(PROFILE_KERNEL)
+namespace kernel_profiler {
+thread_local uint32_t wIndex __attribute__((used));
+thread_local uint32_t stackSize __attribute__((used));
+thread_local uint32_t sums[SUM_COUNT] __attribute__((used));
+thread_local uint32_t sumIDs[SUM_COUNT] __attribute__((used));
+uint32_t traceCount __attribute__((used));
+}  // namespace kernel_profiler
+#endif
+
 uint8_t noc_index;
 constexpr uint8_t noc_mode = DM_DEDICATED_NOC;
 

--- a/tt_metal/hw/firmware/src/tt-2xx/dm.cc
+++ b/tt_metal/hw/firmware/src/tt-2xx/dm.cc
@@ -18,10 +18,10 @@
 
 #if defined(PROFILE_KERNEL)
 namespace kernel_profiler {
-uint32_t wIndex __attribute__((used));
-uint32_t stackSize __attribute__((used));
-uint32_t sums[SUM_COUNT] __attribute__((used));
-uint32_t sumIDs[SUM_COUNT] __attribute__((used));
+thread_local uint32_t wIndex __attribute__((used));
+thread_local uint32_t stackSize __attribute__((used));
+thread_local uint32_t sums[SUM_COUNT] __attribute__((used));
+thread_local uint32_t sumIDs[SUM_COUNT] __attribute__((used));
 uint32_t traceCount __attribute__((used));
 }  // namespace kernel_profiler
 #endif

--- a/tt_metal/hw/firmware/src/tt-2xx/trisc.cc
+++ b/tt_metal/hw/firmware/src/tt-2xx/trisc.cc
@@ -27,10 +27,10 @@
 
 #if defined(PROFILE_KERNEL)
 namespace kernel_profiler {
-uint32_t wIndex __attribute__((used));
-uint32_t stackSize __attribute__((used));
-uint32_t sums[SUM_COUNT] __attribute__((used));
-uint32_t sumIDs[SUM_COUNT] __attribute__((used));
+thread_local uint32_t wIndex __attribute__((used));
+thread_local uint32_t stackSize __attribute__((used));
+thread_local uint32_t sums[SUM_COUNT] __attribute__((used));
+thread_local uint32_t sumIDs[SUM_COUNT] __attribute__((used));
 }  // namespace kernel_profiler
 #endif
 

--- a/tt_metal/programming_examples/profiler/test_full_buffer/test_full_buffer.cpp
+++ b/tt_metal/programming_examples/profiler/test_full_buffer/test_full_buffer.cpp
@@ -3,13 +3,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <cstdint>
-#include <map>
 #include <string>
 #include <vector>
 
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/device.hpp>
 #include <tt-metalium/distributed.hpp>
+#include <tt-metalium/tt_metal_profiler.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program.hpp>
 
 using namespace tt;
 using namespace tt::tt_metal;
@@ -21,44 +23,94 @@ constexpr uint32_t FULL_L1_MARKER_COUNT = 256;
 void RunFillUpAllBuffers(
     const std::shared_ptr<distributed::MeshDevice>& mesh_device, int loop_count, bool fast_dispatch) {
     CoreCoord compute_with_storage_size = mesh_device->compute_with_storage_grid_size();
-    CoreCoord start_core = {0, 0};
-    CoreCoord end_core = {compute_with_storage_size.x - 1, compute_with_storage_size.y - 1};
-    CoreRange all_cores(start_core, end_core);
+    const experimental::NodeRange all_nodes(
+        experimental::NodeCoord{0, 0},
+        experimental::NodeCoord{compute_with_storage_size.x - 1, compute_with_storage_size.y - 1});
 
     // Mesh workload + device range span the mesh; program encapsulates kernels
     distributed::MeshWorkload workload;
     distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(mesh_device->shape());
-    tt_metal::Program program = tt_metal::CreateProgram();
 
     constexpr int loop_size = 200;
-    std::map<std::string, std::string> kernel_defines = {
+    const experimental::KernelSpec::CompilerOptions::Defines defines = {
         {"LOOP_COUNT", std::to_string(loop_count)}, {"LOOP_SIZE", std::to_string(loop_size)}};
 
-    tt_metal::CreateKernel(
-        program,
-        "tt_metal/programming_examples/profiler/test_full_buffer/kernels/full_buffer.cpp",
-        all_cores,
-        tt_metal::DataMovementConfig{
-            .processor = tt_metal::DataMovementProcessor::RISCV_0,
-            .noc = tt_metal::NOC::RISCV_0_default,
-            .defines = kernel_defines});
-    tt_metal::CreateKernel(
-        program,
-        "tt_metal/programming_examples/profiler/test_full_buffer/kernels/full_buffer.cpp",
-        all_cores,
-        tt_metal::DataMovementConfig{
-            .processor = tt_metal::DataMovementProcessor::RISCV_1,
-            .noc = tt_metal::NOC::RISCV_1_default,
-            .defines = kernel_defines});
-    std::vector<uint32_t> trisc_kernel_args = {};
-    tt_metal::CreateKernel(
-        program,
-        "tt_metal/programming_examples/profiler/test_full_buffer/kernels/full_buffer_compute.cpp",
-        all_cores,
-        tt_metal::ComputeConfig{.compile_args = trisc_kernel_args, .defines = kernel_defines});
+    const std::string dm_src = "tt_metal/programming_examples/profiler/test_full_buffer/kernels/full_buffer.cpp";
+    const std::string compute_src =
+        "tt_metal/programming_examples/profiler/test_full_buffer/kernels/full_buffer_compute.cpp";
+
+    std::vector<experimental::KernelSpec> kernel_specs;
+    std::vector<experimental::KernelSpecName> wu_kernels;
+    if (mesh_device->arch() == tt::ARCH::QUASAR) {
+        const experimental::KernelSpecName DM_KERNEL{"full_buffer_dm"};
+        const experimental::KernelSpecName COMPUTE_KERNEL{"full_buffer_compute"};
+        kernel_specs = {
+            experimental::KernelSpec{
+                .unique_id = DM_KERNEL,
+                .source = dm_src,
+                .num_threads = 6,
+                .compiler_options = {.defines = defines},
+                .hw_config = experimental::DataMovementHardwareConfig{experimental::DataMovementGen2Config{}},
+            },
+            experimental::KernelSpec{
+                .unique_id = COMPUTE_KERNEL,
+                .source = compute_src,
+                .num_threads = 4,
+                .compiler_options = {.defines = defines},
+                .hw_config = experimental::ComputeGen2Config{},
+            },
+        };
+        wu_kernels = {DM_KERNEL, COMPUTE_KERNEL};
+    } else {
+        const experimental::KernelSpecName BRISC_KERNEL{"full_buffer_brisc"};
+        const experimental::KernelSpecName NCRISC_KERNEL{"full_buffer_ncrisc"};
+        const experimental::KernelSpecName COMPUTE_KERNEL{"full_buffer_compute"};
+        kernel_specs = {
+            experimental::KernelSpec{
+                .unique_id = BRISC_KERNEL,
+                .source = dm_src,
+                .num_threads = 1,
+                .compiler_options = {.defines = defines},
+                .hw_config = experimental::DataMovementHardwareConfig{experimental::DataMovementGen1Config{
+                    .processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default}},
+            },
+            experimental::KernelSpec{
+                .unique_id = NCRISC_KERNEL,
+                .source = dm_src,
+                .num_threads = 1,
+                .compiler_options = {.defines = defines},
+                .hw_config = experimental::DataMovementHardwareConfig{experimental::DataMovementGen1Config{
+                    .processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default}},
+            },
+            experimental::KernelSpec{
+                .unique_id = COMPUTE_KERNEL,
+                .source = compute_src,
+                .num_threads = 1,
+                .compiler_options = {.defines = defines},
+                .hw_config = experimental::ComputeGen1Config{},
+            },
+        };
+        wu_kernels = {BRISC_KERNEL, NCRISC_KERNEL, COMPUTE_KERNEL};
+    }
+
+    experimental::WorkUnitSpec wu{
+        .name = "full_buffer",
+        .kernels = wu_kernels,
+        .target_nodes = all_nodes,
+    };
+    experimental::ProgramSpec spec{
+        .name = "full_buffer",
+        .kernels = kernel_specs,
+        .work_units = {wu},
+    };
+
+    Program program = experimental::MakeProgramFromSpec(*mesh_device, spec);
+    experimental::ProgramRunArgs params;  // kernels take no runtime args
+    experimental::SetProgramRunArgs(program, params);
 
     workload.add_program(device_range, std::move(program));
-    if (fast_dispatch) {
+    // One enqueue is enough to fill the L1 profiler buffer on Quasar
+    if (fast_dispatch && mesh_device->arch() != tt::ARCH::QUASAR) {
         for (int i = 0; i < DRAM_MARKER_COUNT / FULL_L1_MARKER_COUNT; i++) {
             // Enqueue the same mesh workload multiple times to generate profiler traffic
             distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), workload, false);

--- a/tt_metal/tools/profiler/kernel_profiler.hpp
+++ b/tt_metal/tools/profiler/kernel_profiler.hpp
@@ -45,12 +45,19 @@
     (!defined(DISPATCH_KERNEL) || (defined(DISPATCH_KERNEL) && (PROFILE_KERNEL & PROFILER_OPT_DO_DISPATCH_CORES)))
 namespace kernel_profiler {
 
+#if defined(ARCH_QUASAR)
+extern thread_local uint32_t wIndex;
+extern thread_local uint32_t stackSize;
+extern thread_local uint32_t sums[SUM_COUNT];
+extern thread_local uint32_t sumIDs[SUM_COUNT];
+#else
 extern uint32_t wIndex;
 extern uint32_t stackSize;
-extern uint32_t traceCount;
-
 extern uint32_t sums[SUM_COUNT];
 extern uint32_t sumIDs[SUM_COUNT];
+#endif
+// Quasar: traceCount is a per-core trace-replay counter managed by the DM0, NOT thread_local.
+extern uint32_t traceCount;
 
 constexpr uint32_t PROFILER_FULL_HOST_VECTOR_SIZE_PER_RISC = PROFILER_FULL_HOST_BUFFER_SIZE_PER_RISC / sizeof(uint32_t);
 constexpr uint32_t NOC_ALIGNMENT_FACTOR = 4;
@@ -699,7 +706,15 @@ template <uint32_t timer_id, DoingDispatch dispatch = DoingDispatch::NOT_DISPATC
 struct profileScope {
     bool start_marked = false;
     inline __attribute__((always_inline)) profileScope() {
+#if defined(ARCH_QUASAR)
+        // Quasar is L1-only for now, once the L1 buffer fills, markers are dropped.
+        // The ~profileScope() writes the ZONE_END unconditionally, so the constructor reserves room
+        // for both the zone's start and end markers. Request (2 * PROFILER_L1_MARKER_UINT32_SIZE - 1)
+        // "additional" words.
+        if (bufferHasRoom<dispatch>(2 * PROFILER_L1_MARKER_UINT32_SIZE - 1)) {
+#else
         if (bufferHasRoom<dispatch>()) {
+#endif
             stackSize += PROFILER_L1_MARKER_UINT32_SIZE;
             start_marked = true;
             mark_time_at_index_inlined(wIndex, timer_id);
@@ -1037,7 +1052,7 @@ __attribute__((noinline)) void trace_only_init() {
         kernel_profiler::set_host_counter(counter);    \
     }
 
-#if defined(COMPILE_FOR_BRISC) || defined(COMPILE_FOR_ERISC) || defined(COMPILE_FOR_AERISC)
+#if defined(COMPILE_FOR_BRISC) || defined(COMPILE_FOR_ERISC) || defined(COMPILE_FOR_AERISC) || defined(COMPILE_FOR_DM)
 #define DeviceProfilerInit()                          \
     if constexpr (kernel_profiler::TRACE_ON_TENSIX) { \
         kernel_profiler::init_profiler();             \


### PR DESCRIPTION
### PR Category
Feature

### Summary
Phase 2 of #48927 
Quasar profiler can record markers for 125 zones per processor, then the profiler buffer in L1 is full and zones beyond that are dropped. 
Updated the test_full_buffer programming example and the expected numbers on quasar

Testing

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-profiler.yaml/badge.svg?branch=shengxiangji/profiler-fullbuffer-48927)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-profiler.yaml?query=branch:shengxiangji/profiler-fullbuffer-48927)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml/badge.svg?branch=shengxiangji/profiler-fullbuffer-48927)](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml?query=branch:shengxiangji/profiler-fullbuffer-48927)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=shengxiangji/profiler-fullbuffer-48927)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:shengxiangji/profiler-fullbuffer-48927)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=shengxiangji/profiler-fullbuffer-48927)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:shengxiangji/profiler-fullbuffer-48927)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=shengxiangji/profiler-fullbuffer-48927)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:shengxiangji/profiler-fullbuffer-48927)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=shengxiangji/profiler-fullbuffer-48927)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:shengxiangji/profiler-fullbuffer-48927)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=shengxiangji/profiler-fullbuffer-48927)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:shengxiangji/profiler-fullbuffer-48927)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=shengxiangji/profiler-fullbuffer-48927)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:shengxiangji/profiler-fullbuffer-48927)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=shengxiangji/profiler-fullbuffer-48927)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:shengxiangji/profiler-fullbuffer-48927)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=shengxiangji/profiler-fullbuffer-48927)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:shengxiangji/profiler-fullbuffer-48927)