### PR TITLE
[tt-train] [Test Only] Disable the Llama 8B TP=4 DDP=8 run on Galaxy Perf Workflow

### DIFF
--- a/.github/workflows/galaxy-perf-tests.yaml
+++ b/.github/workflows/galaxy-perf-tests.yaml
@@ -22,7 +22,7 @@ on:
           - deepseek_v3
           - tinyllama_1_1b_ddp32_shakespeare
           - llama_8b_tp8_ddp4_shakespeare
-          - llama_8b_tp4_ddp8_shakespeare
+          # - llama_8b_tp4_ddp8_shakespeare
 
       build-type:
         required: false

--- a/tests/pipeline_reorg/galaxy_perf_tests.yaml
+++ b/tests/pipeline_reorg/galaxy_perf_tests.yaml
@@ -141,15 +141,16 @@
   arch: blackhole
   save-perf-data: false
 
-- name: Galaxy Llama 8B TP=4 DDP=8 train perf tests
-  cmd: |
-    ./tt-train/scripts/setup_pth.sh
-    python tt-train/scripts/run_models.py --model_config tt-train/scripts/run_models_configs/galaxy.yaml --filter-filenames "llama_8b_tp4_ddp8_shakespeare"
-  model: llama_8b_tp4_ddp8_shakespeare
-  skus:
-    bh_galaxy_perf:
-      timeout: 55
-  owner_id: U07K00A281X # Kevin Wu
-  team: train
-  arch: blackhole
-  save-perf-data: false
+#  Hanging on g13blx01, disable until issue is resolved: https://github.com/tenstorrent/tt-metal/issues/49557
+# - name: Galaxy Llama 8B TP=4 DDP=8 train perf tests
+#   cmd: |
+#     ./tt-train/scripts/setup_pth.sh
+#     python tt-train/scripts/run_models.py --model_config tt-train/scripts/run_models_configs/galaxy.yaml --filter-filenames "llama_8b_tp4_ddp8_shakespeare"
+#   model: llama_8b_tp4_ddp8_shakespeare
+#   skus:
+#     bh_galaxy_perf:
+#       timeout: 55
+#   owner_id: U07K00A281X # Kevin Wu
+#   team: train
+#   arch: blackhole
+#   save-perf-data: false


### PR DESCRIPTION
### PR Category
Test Only

### Summary
The "Llama 8B TP=4 DDP=8 Shakespeare" job has been hanging on `g13blx01` for a while and that is currently the only runner servicing this workflow. While it's being debugged, this PR disables the test from running on nightly so resources won't be wasted. 

The tracking issue is: https://github.com/tenstorrent/tt-metal/issues/49557

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ctr-kevinwu/disable-llama-8b-tp4-ddp8)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ctr-kevinwu/disable-llama-8b-tp4-ddp8)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ctr-kevinwu/disable-llama-8b-tp4-ddp8)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ctr-kevinwu/disable-llama-8b-tp4-ddp8)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ctr-kevinwu/disable-llama-8b-tp4-ddp8)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ctr-kevinwu/disable-llama-8b-tp4-ddp8)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ctr-kevinwu/disable-llama-8b-tp4-ddp8)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ctr-kevinwu/disable-llama-8b-tp4-ddp8)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ctr-kevinwu/disable-llama-8b-tp4-ddp8)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ctr-kevinwu/disable-llama-8b-tp4-ddp8)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ctr-kevinwu/disable-llama-8b-tp4-ddp8)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ctr-kevinwu/disable-llama-8b-tp4-ddp8)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ctr-kevinwu/disable-llama-8b-tp4-ddp8)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ctr-kevinwu/disable-llama-8b-tp4-ddp8)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ctr-kevinwu/disable-llama-8b-tp4-ddp8)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ctr-kevinwu/disable-llama-8b-tp4-ddp8)