### PR TITLE
[LLK][Feature] Extend L1 address asserts to validate range end, not just base

### DIFF
--- a/tt_metal/tt-llk/common/llk_assert.h
+++ b/tt_metal/tt-llk/common/llk_assert.h
@@ -52,3 +52,31 @@
 
 // Inverse of LLK_ASSERT: Triggers when the condition is true (failure condition)
 #define LLK_PANIC(condition, message) LLK_ASSERT(!(condition), message)
+
+// L1 access-range asserts (debug-only; wrap LLK_ASSERT, so elided in release builds).
+//
+// Validate that BOTH the base and the end of a multi-word / strided L1 access lie inside valid L1,
+// extending the base-only is_valid_L1_address() check. All addresses are LLK-transformed 16B-word
+// addresses (the same space is_valid_L1_address() consumes); the range length is likewise in 16B
+// words, NOT raw bytes. is_valid_L1_address() must be in scope at the call site (include
+// llk_memory_checks.h).
+
+/**
+ * @brief Assert that an L1 access range [base, base + size) lies fully within valid L1.
+ * @param base_address First accessed 16B-word address.
+ * @param size Range length in 16B words (assumed >= 1).
+ * @param message Diagnostic message.
+ * @note Checks both the base and the last word (base + size - 1).
+ */
+#define LLK_ASSERT_L1_RANGE(base_address, size, message) \
+    LLK_ASSERT(is_valid_L1_address(base_address) && is_valid_L1_address((base_address) + (size) - 1), message)
+
+/**
+ * @brief Assert an L1 access whose last accessed word is not simply base + size (strided /
+ *        multi-face); the caller supplies the last accessed word explicitly.
+ * @param base_address First accessed 16B-word address.
+ * @param last_address Last accessed 16B-word address.
+ * @param message Diagnostic message.
+ */
+#define LLK_ASSERT_L1_RANGE_BASE_LAST(base_address, last_address, message) \
+    LLK_ASSERT(is_valid_L1_address(base_address) && is_valid_L1_address(last_address), message)

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_unpack_fast_untilize.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_unpack_fast_untilize.h
@@ -99,8 +99,9 @@ inline void _llk_unpack_fast_untilize_block_(const std::uint32_t address, const 
 
 inline void _llk_unpack_fast_untilize_bfp_block_(const std::uint32_t address, const std::uint32_t tile_stride_16B, const std::uint32_t unit_dim)
 {
-    LLK_ASSERT(is_valid_L1_address(address), "L1 address must be in valid L1 memory region");
-    LLK_ASSERT(is_valid_L1_address(address + tile_stride_16B * (unit_dim - 1)), "L1 address must be in valid L1 memory region");
+    // Faces of the unit_dim tiles are read from address + k * tile_stride_16B for k in [0, unit_dim);
+    // validate the whole strided span, not just the base.
+    LLK_ASSERT_L1_RANGE_BASE_LAST(address, address + tile_stride_16B * (unit_dim - 1), "L1 address range must be in valid L1 memory region");
     LLK_ASSERT(tile_stride_16B > 0, "fast_untilize BFP tile stride must be greater than zero");
     LLK_ASSERT(unit_dim >= 2 && unit_dim <= 4, "fast_untilize BFP unpack supports unit_dim 2, 3, or 4");
 

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/cpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/cpack_common.h
@@ -887,8 +887,6 @@ inline void program_packer_destination(std::uint32_t addr, bool restore = true)
 template <std::uint32_t block_ct_dim, std::uint32_t full_ct_dim, bool diagonal = false, std::uint32_t row_num_datums = TILE_C_DIM>
 inline void program_packer_untilized_destination(const std::uint32_t addr, const std::uint32_t pack_dst_format)
 {
-    LLK_ASSERT(is_valid_L1_address(addr), "L1 address must be in valid L1 memory region");
-
     if constexpr (diagonal)
     {
         // Diagonal untilize drives only packers 0 and 1; the offset2/offset3 + packer-2/3 (SEC1) lines below are
@@ -898,6 +896,9 @@ inline void program_packer_untilized_destination(const std::uint32_t addr, const
         const std::uint32_t offset1     = (1 * block_size) / 16;
         // const uint32_t offset2 = (2*block_size)/16;
         // const uint32_t offset3 = (3*block_size)/16;
+
+        // Packers write to addr + offset0 (base) up through addr + offset1; validate the whole burst.
+        LLK_ASSERT_L1_RANGE_BASE_LAST(addr, addr + offset1, "L1 packer destination range must be in valid L1 memory region");
 
         TT_SETDMAREG(0, LOWER_HALFWORD(addr + offset0), 0, LO_16(p_gpr_pack::OUTPUT_ADDR + 0));
         TT_SETDMAREG(0, UPPER_HALFWORD(addr + offset0), 0, HI_16(p_gpr_pack::OUTPUT_ADDR + 0));
@@ -923,6 +924,9 @@ inline void program_packer_untilized_destination(const std::uint32_t addr, const
         const std::uint32_t offset1     = (1 * row_num_datums * block_size) / 16 / TILE_C_DIM;
         const std::uint32_t offset2     = (2 * row_num_datums * block_size) / 16 / TILE_C_DIM;
         const std::uint32_t offset3     = (3 * row_num_datums * block_size) / 16 / TILE_C_DIM;
+
+        // The four packers write to addr + offset0 (base) up through addr + offset3; validate the whole burst.
+        LLK_ASSERT_L1_RANGE_BASE_LAST(addr, addr + offset3, "L1 packer destination range must be in valid L1 memory region");
 
         TT_SETDMAREG(0, LOWER_HALFWORD(addr + offset0), 0, LO_16(p_gpr_pack::OUTPUT_ADDR + 0));
         TT_SETDMAREG(0, UPPER_HALFWORD(addr + offset0), 0, HI_16(p_gpr_pack::OUTPUT_ADDR + 0));


### PR DESCRIPTION
### PR Category

Feature

### Summary

LLK's existing asserts only checked that the base address of an L1 access was valid, so multi-address or strided accesses could walk past the end of L1 without ever tripping an assert. This adds a range-checking assert helper in llk_assert.h that also validates the last byte of the accessed range, and applies it in the blackhole experimental fast-untilize unpacker and the wormhole_b0 packer common code, where addresses are advanced beyond the base. The check reuses the existing debug-only LLK_ASSERT machinery, so it has no cost in release builds.

Fixes #50897

### Notes for reviewers

This covers only two of the hotspots called out in the issue (blackhole fast untilize and wormhole_b0 cpack_common); other listed sites (tilize/tilizeA_B, unpack_A/AB, general pack, matmul strides) are not yet updated.

Diffstat: 3 files changed, 37 insertions(+), 4 deletions(-).

<sub>Opened by the LLK issue-triage board (AI-assisted, draft) — please review the diff before merging.</sub>

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=llk_code_gen/issue-50897-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:llk_code_gen/issue-50897-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=llk_code_gen/issue-50897-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:llk_code_gen/issue-50897-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=llk_code_gen/issue-50897-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:llk_code_gen/issue-50897-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=llk_code_gen/issue-50897-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:llk_code_gen/issue-50897-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=llk_code_gen/issue-50897-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:llk_code_gen/issue-50897-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=llk_code_gen/issue-50897-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:llk_code_gen/issue-50897-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=llk_code_gen/issue-50897-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:llk_code_gen/issue-50897-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=llk_code_gen/issue-50897-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:llk_code_gen/issue-50897-v1)