### PR TITLE
ttnn: fix nanobind leaked-instance warning from module-level MemoryConfig constants

### DIFF
--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -612,7 +612,7 @@ import atexit as _atexit
 
 
 def _ttnn_cleanup():
-    """Release Python-side references to C++ operation wrappers before interpreter shutdown.
+    """Release Python-side references to C++ nanobind objects before interpreter shutdown.
 
     nanobind's leak checker fires before module dicts are fully cleared on some
     Python versions. Explicitly clearing REGISTERED_OPERATIONS ensures the
@@ -625,6 +625,37 @@ def _ttnn_cleanup():
     except Exception as e:
         # Best-effort cleanup: ignore errors during interpreter shutdown but log for diagnosis.
         logger.debug("Failed to clear ttnn REGISTERED_OPERATIONS during atexit cleanup: {}", e)
+
+    # Release the module-level nanobind *instance* constants bound into the `_ttnn.types`
+    # extension module (DRAM_MEMORY_CONFIG / L1_MEMORY_CONFIG). These are owned MemoryConfig
+    # instances created via `mod.attr(...) = nb::cast(...)` in ttnn-nanobind/types.cpp.
+    #
+    # CPython does not clear the __dict__ of PEP 489 multi-phase extension modules during
+    # finalization before the C-level Py_AtExit handlers run, and nanobind registers its
+    # leak checker via Py_AtExit. So these constants stay in `_ttnn.types.__dict__` and are
+    # reported as "leaked instances". Critically, nanobind only escalates to dumping *all*
+    # still-registered types and functions when at least one instance leaks (see nanobind
+    # src/nb_internals.cpp, where type/function reporting is gated on inst_leaks > 0), so
+    # these few constants are what turn a clean shutdown into the multi-hundred-line
+    # "leaked N types / leaked N functions" report.
+    #
+    # The Python-side re-exports (ttnn.DRAM_MEMORY_CONFIG, ttnn.types.*) are ordinary module
+    # globals that _PyImport_Cleanup clears before the Py_AtExit checker runs, so only the
+    # extension-module references need to be dropped here.
+    try:
+        from ttnn import _ttnn
+
+        _types_module = getattr(_ttnn, "types", None)
+        if _types_module is not None:
+            for _const_name in ("DRAM_MEMORY_CONFIG", "L1_MEMORY_CONFIG"):
+                try:
+                    delattr(_types_module, _const_name)
+                except Exception:
+                    # Attribute may be absent or read-only depending on build; ignore.
+                    pass
+    except Exception as e:
+        # Best-effort cleanup: ignore errors during interpreter shutdown but log for diagnosis.
+        logger.debug("Failed to release ttnn module-constant instances during atexit cleanup: {}", e)
 
 
 _atexit.register(_ttnn_cleanup)


### PR DESCRIPTION
## Summary

Fixes the `nanobind: leaked N instances! / leaked N types! / leaked N functions!` warning that nanobind prints at Python interpreter shutdown for ttnn processes.

Observed in CI (SDXL op sanity test), shutdown of a `tracy`-wrapped pytest:

```
nanobind: leaked 3 instances!
 - leaked instance 0x... of type "ttnn._ttnn.tensor.MemoryConfig"
 - leaked instance 0x... of type "ttnn._ttnn.tensor.CoreRangeSet"
 - leaked instance 0x... of type "ttnn._ttnn.tensor.MemoryConfig"
nanobind: leaked 20 types!
 - leaked type "ttnn._ttnn.operations.matmul.MatmulMultiCoreReuseMultiCast1DProgramConfig"
 - leaked type "BufferType" / "UnaryOpType" / "Layout" / "Arch" ...
nanobind: leaked 249 functions!
nanobind: this is likely caused by a reference counting issue in the binding code.
```

CI job: https://github.com/tenstorrent/tt-metal/actions/runs/30017094673/job/89244573936
(Note: that job's *failure* is an unrelated perf-range assertion; the nanobind warning is a separate shutdown-time diagnostic that fires on essentially every ttnn process.)

## Root cause

The two **deterministic, always-present** leaked instances are the module-level constants `DRAM_MEMORY_CONFIG` and `L1_MEMORY_CONFIG`, bound in `ttnn/cpp/ttnn-nanobind/types.cpp` as **owned** `MemoryConfig` instances:

```cpp
mod.attr("DRAM_MEMORY_CONFIG") = nb::cast(DRAM_MEMORY_CONFIG);
mod.attr("L1_MEMORY_CONFIG")   = nb::cast(L1_MEMORY_CONFIG);
```

`nb::cast(<lvalue>)` copies into a new Python-owned instance that is stored in the `_ttnn.types` extension-module dict. CPython does **not** clear the `__dict__` of PEP 489 multi-phase-init extension modules before the C-level `Py_AtExit` handlers run, and nanobind registers its leak checker via `Py_AtExit` (`src/nb_internals.cpp` → `Py_AtExit(internals_cleanup)`). So these two `MemoryConfig` instances are still registered in nanobind's `inst_c2p` when the checker fires → "leaked instances".

**Why 2 leaked instances produce a 269-line report:** nanobind only reports leaked *types* and *functions* when at least one *instance* leaked. From `src/nb_internals.cpp`:

```cpp
// Only report function/type leaks if actual nanobind instances were leaked
if (!leak)              // leak == (inst_leaks > 0 || keep_alive_leaks > 0)
    print_leak_warnings = false;
```

The 20 "leaked types" and 249 "leaked functions" are just the normal set of still-registered bindings living in the (never-cleared) extension-module dicts — benign on their own. They are only *surfaced* because the module-constant instances tip `inst_leaks` above zero. Drive `inst_leaks` to 0 and the entire block (instances **and** types **and** functions) is suppressed, and nanobind cleanly frees its internals.

## Fix

Extend the existing `_ttnn_cleanup()` atexit handler (added in #41421) to also drop the `_ttnn.types` references to these constants before the `Py_AtExit` checker runs:

```python
from ttnn import _ttnn
_types_module = getattr(_ttnn, "types", None)
if _types_module is not None:
    for _const_name in ("DRAM_MEMORY_CONFIG", "L1_MEMORY_CONFIG"):
        try:
            delattr(_types_module, _const_name)
        except Exception:
            pass
```

Python `atexit` handlers run during finalization **before** `_PyImport_Cleanup` and well before the C-level `Py_AtExit` checker. The Python-side re-exports (`ttnn.DRAM_MEMORY_CONFIG`, `ttnn.types.*`) are ordinary module globals that `_PyImport_Cleanup` clears in between, so only the extension-module references need to be released here. Cleanup is best-effort and guarded, matching the existing handler. One file changed; no functional/binding change.

## Relationship to prior work

- #40158 (issue) — original report of this leak signature.
- #41421 (merged) — heap-allocated operation `wrapper_t` + `take_ownership`, and the `_ttnn_cleanup()` atexit that clears `REGISTERED_OPERATIONS`. Eliminated the bulk (~580 instances). This PR builds directly on that handler.
- #44517 (open) — clears **operation-wrapper** references still reachable via module attrs. That is a *different* reference path (operation wrappers); it does **not** touch the `_ttnn.types` value-type constants addressed here. The two are complementary.

## Verification / limitations

- ✅ `python3 -m py_compile ttnn/ttnn/__init__.py` passes.
- ✅ Logic of the new block validated with a standalone mock (`_ttnn.types` with the two constants → both deleted → `inst_leaks` reaches 0 → nanobind gate suppresses the whole report; robust when the attrs/submodule are absent or read-only).
- ⚠️ **Not run against real Tenstorrent hardware / a real ttnn build in my environment** (no device or built wheel available), so I have not observed the warning disappear at runtime. The root-cause reasoning is from static analysis of the bindings + the pinned nanobind 2.12.0 source.
- ⚠️ **Scope caveat:** this eliminates the deterministic, always-present module-constant instance leaks (reproducible on a bare `import ttnn; exit()`). The single `CoreRangeSet` instance in the linked job is *situational* — the only `CoreRangeSet` defaults in the tree are 3 in experimental `moe_compute`, so this one is most likely an operation default retained via the operation-wrapper module-attr path that #44517 targets. If so, fully zeroing `inst_leaks` in operation-heavy tests may require this PR **and** #44517. This is why this is a **draft** pending hardware confirmation of whether the constants alone bring the count to 0 on the relevant tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nsexton/fix-nanobind-module-constant-leak)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nsexton/fix-nanobind-module-constant-leak)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nsexton/fix-nanobind-module-constant-leak)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nsexton/fix-nanobind-module-constant-leak)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=nsexton/fix-nanobind-module-constant-leak)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:nsexton/fix-nanobind-module-constant-leak)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nsexton/fix-nanobind-module-constant-leak)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nsexton/fix-nanobind-module-constant-leak)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nsexton/fix-nanobind-module-constant-leak)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nsexton/fix-nanobind-module-constant-leak)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nsexton/fix-nanobind-module-constant-leak)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nsexton/fix-nanobind-module-constant-leak)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nsexton/fix-nanobind-module-constant-leak)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nsexton/fix-nanobind-module-constant-leak)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nsexton/fix-nanobind-module-constant-leak)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nsexton/fix-nanobind-module-constant-leak)