### PR TITLE
[ttnn] mesh_partition: fix height-sharded RM slice cache-hit rebuild

### DIFF
--- a/ttnn/cpp/ttnn/operations/ccl/mesh_partition/device/mesh_partition_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/mesh_partition/device/mesh_partition_program_factory.cpp
@@ -148,17 +148,24 @@ void MeshPartitionDeviceOperation::MeshPartition::override_runtime_arguments(
         auto [slice_attrs, slice_tensor_args] =
             compute_slice_parameters(operation_attributes, tensor_args, mesh_coordinate);
 
-        // Re-build the descriptor for this coord and let the framework copy
-        // its per-core / common runtime args (and patch dynamic CB addresses)
-        // onto the cached Program — same scheme as the legacy
-        // override_runtime_args path, but driven by ProgramDescriptor.  CB
-        // total_size/page_size are not re-applied on cache hit, so any sizing
-        // that varies across calls must be folded into compute_program_hash().
+        // Re-apply this coord's per-dispatch state to the cached Program. CB total_size/page_size are
+        // not re-applied on a hit, so any sizing that varies across calls must be in compute_program_hash().
         std::visit(
             [&](auto&& program_factory) {
                 using Factory = std::decay_t<decltype(program_factory)>;
-                auto descriptor = Factory::create_descriptor(slice_attrs, slice_tensor_args, tensor_return_value);
-                tt::tt_metal::apply_descriptor_runtime_args(program, descriptor);
+                // Height-sharded RM is CB-bound: only the two sharded CB addresses change on a hit (per-core
+                // reader args are cache-keyed), so patch just those in O(1) rather than re-running the
+                // O(num_cores) per-core arg walk. Mirrors the SliceDeviceOperation fix (this op drives the
+                // factory directly). CB order matches create_descriptor: src0 (input), c_16 (output).
+                if constexpr (std::is_same_v<Factory, ttnn::prim::SliceRmShardedProgramFactory>) {
+                    tt::tt_metal::ProgramDescriptor cb_addr_only;
+                    cb_addr_only.cbs.push_back(tt::tt_metal::CBDescriptor{.buffer = slice_tensor_args.input.buffer()});
+                    cb_addr_only.cbs.push_back(tt::tt_metal::CBDescriptor{.buffer = tensor_return_value.buffer()});
+                    tt::tt_metal::apply_descriptor_runtime_args(program, cb_addr_only);
+                } else {
+                    auto descriptor = Factory::create_descriptor(slice_attrs, slice_tensor_args, tensor_return_value);
+                    tt::tt_metal::apply_descriptor_runtime_args(program, descriptor);
+                }
             },
             shared_variables.slice_program_factory);
     }


### PR DESCRIPTION
## What
Follow-up to the slice cache-hit-rebuild fix (#50894), found by sweeping every op with `override_runtime_arguments` for the same anti-pattern.

`MeshPartition::override_runtime_arguments` re-runs the pinned slice factory's `create_descriptor` on **every cache hit, per mesh coordinate**. When that factory is `SliceRmShardedProgramFactory`, that's the exact O(num_cores) per-core arg walk (+ per-core `std::map`) that regressed non-traced resnet via the slice op — and because mesh_partition drives the factory directly, it does **not** inherit the O(1) fix in `SliceDeviceOperation::override_runtime_arguments`.

## Fix
For the height-sharded RM factory, the only per-dispatch state that changes on a cache hit is the two sharded CB base addresses (per-core reader args are pure functions of shapes/slice_start/shard specs, all cache-keyed). Patch just those in O(1) instead of rebuilding the full descriptor. Other factories bake addresses into runtime args and keep re-deriving. Same pattern as #50894.

## Validation
- Correctness: `tests/nightly/t3000/ccl/test_mesh_partition.py` on multi-device hardware. Single-card cannot reach the multi-coord sharded path, so validated in CI.
- Correct-by-parity with #50894: the per-coord program is a `SliceRmShardedProgramFactory` program with the same 2-CB layout (src0, c_16); the cheap patch applies the identical CB-address updates the full rebuild did, minus the cache-invariant per-core rt-arg walk.
- Reference (slice) measured 94us→1445us @56 cores rebuild-on-hit → flat 61us after the equivalent patch.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/fix-mesh-partition-sharded-override)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/fix-mesh-partition-sharded-override)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/fix-mesh-partition-sharded-override)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/fix-mesh-partition-sharded-override)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=dgomez/fix-mesh-partition-sharded-override)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:dgomez/fix-mesh-partition-sharded-override)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/fix-mesh-partition-sharded-override)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/fix-mesh-partition-sharded-override)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/fix-mesh-partition-sharded-override)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/fix-mesh-partition-sharded-override)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/fix-mesh-partition-sharded-override)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/fix-mesh-partition-sharded-override)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/fix-mesh-partition-sharded-override)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/fix-mesh-partition-sharded-override)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/fix-mesh-partition-sharded-override)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/fix-mesh-partition-sharded-override)