### PR TITLE
[skip ci] Add optional model_family field to models e2e/unit/sweep test registries

### DIFF
--- a/tests/pipeline_reorg/models_e2e_tests.yaml
+++ b/tests/pipeline_reorg/models_e2e_tests.yaml
@@ -4,6 +4,7 @@
 #   name: The display name for the job in GitHub Actions.
 #   cmd: The exact command to run (env vars must be inlined).
 #   model: Model identifier for filtering (workflow_dispatch model selection).
+#   model_family: (optional) Human-facing model family for grouping/reporting (e.g. Llama, Qwen, Gemma). Omit when a test spans multiple families.
 #   skus: A mapping of SKU names to their configuration:
 #     timeout: Job timeout in minutes.
 #     tier: Model tier (1, 2, or 3) used to filter which pipeline runs this test.
@@ -26,6 +27,7 @@
     pytest --timeout 600 models/tt_transformers/demo/simple_text_demo.py -k "performance-ci-eval-32" --use_prefetcher True --repeat_batches 1
     pytest --timeout 420 models/tt_transformers/demo/simple_text_demo.py -k "performance-ci-token-matching" --use_hf_rope
   model: llama3.1-8b
+  model_family: Llama
   skus:
     wh_n150:
       timeout: 11
@@ -60,6 +62,7 @@
     export TT_CACHE_PATH=/mnt/MLPerf/huggingface/meta-llama/Llama-3.1-8B-Instruct
     pytest --timeout 600 models/tt_transformers/demo/simple_text_demo.py -k "performance and ci-32" --data_parallel 2 --max_seq_len 131072
   model: llama3.1-8b-dp
+  model_family: Llama
   skus:
     bh_p300:
       timeout: 25
@@ -73,6 +76,7 @@
     export HF_MODEL=meta-llama/Llama-3.1-8B-Instruct TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/meta-llama/Llama-3.1-8B-Instruct
     pytest models/tt_transformers/demo/simple_text_demo.py -k "performance-ci-b1-DP-4 or performance-ci-b1-DP-8" --timeout 1000
   model: llama3.1-8b-dp
+  model_family: Llama
   skus:
     wh_llmbox_perf:
       timeout: 20
@@ -92,6 +96,7 @@
     export HF_MODEL=meta-llama/Llama-3.1-8B-Instruct TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/meta-llama/Llama-3.1-8B-Instruct
     pytest models/tt_transformers/demo/simple_text_demo.py -k "performance-ci-b1-DP" --timeout 1000
   model: llama3.1-8b-dp-galaxy
+  model_family: Llama
   skus:
     wh_galaxy_perf:
       timeout: 20
@@ -104,6 +109,7 @@
     export HF_MODEL=meta-llama/Llama-3.2-1B-Instruct HF_HUB_OFFLINE=1 TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/tttv2/meta-llama/Llama-3.2-1B-Instruct MESH_DEVICE=N150
     pytest --timeout 600 models/common/tests/demos/llama32_1b/demo.py -k "token-accuracy and performance"
   model: llama3.2-1b
+  model_family: Llama
   skus:
     wh_n150:
       timeout: 5
@@ -118,6 +124,7 @@
     # TT_CACHE_PATH (cold-cache weight conversion) before the demo runs; warm re-runs are faster.
     pytest --timeout 720 models/common/tests/demos/llama32_3b/demo.py -k "token-accuracy and performance"
   model: llama3.2-3b
+  model_family: Llama
   skus:
     wh_n150:
       timeout: 12
@@ -130,6 +137,7 @@
     export HF_MODEL=meta-llama/Llama-3.2-11B-Vision-Instruct TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/meta-llama/Llama-3.2-11B-Vision-Instruct MESH_DEVICE=T3K
     pytest --timeout 900 models/tt_transformers/demo/simple_vision_demo.py -k "not batch1-notrace"
   model: llama3.2-11b-vision
+  model_family: Llama
   skus:
     wh_llmbox_perf:
       timeout: 15
@@ -142,6 +150,7 @@
     export HF_MODEL=meta-llama/Llama-3.2-90B-Vision-Instruct TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/meta-llama/Llama-3.2-90B-Vision-Instruct MESH_DEVICE=T3K
     pytest --timeout 1500 models/tt_transformers/demo/simple_vision_demo.py -k "batch1-trace"
   model: llama3.2-90b-vision
+  model_family: Llama
   skus:
     wh_llmbox_perf:
       timeout: 25
@@ -158,6 +167,7 @@
     pytest --timeout 4200 models/tt_transformers/demo/simple_text_demo.py -k "performance-ci-token-matching"
     pytest --timeout 1800 models/tt_transformers/demo/simple_text_demo.py -k "performance-ci-eval-32"
   model: llama3.3-70b
+  model_family: Llama
   skus:
     bh_quietbox_2:
       timeout: 30
@@ -173,6 +183,7 @@
     pytest --timeout 1000 models/demos/llama3_70b_galaxy/demo/text_demo.py -k "ci-token-matching"
     pytest --timeout 1000 models/demos/llama3_70b_galaxy/demo/text_demo.py -k "repeat2"
   model: llama3.3-70b-galaxy
+  model_family: Llama
   skus:
     wh_galaxy_perf:
       timeout: 30
@@ -202,6 +213,7 @@
     pytest --timeout 4200 models/tt_transformers/demo/simple_text_demo.py -k "performance-ci-token-matching"
     pytest --timeout 1800 models/tt_transformers/demo/simple_text_demo.py -k "performance-ci-eval-32"
   model: qwen3-32b
+  model_family: Qwen
   skus:
     wh_llmbox_perf:
       timeout: 15
@@ -217,6 +229,7 @@
     export HF_MODEL=Qwen/Qwen3-32B TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/Qwen/Qwen3-32B
     pytest --timeout 1000 models/demos/llama3_70b_galaxy/demo/text_qwen_demo.py -k "ci-token-matching"
   model: qwen3-32b-galaxy
+  model_family: Qwen
   skus:
     wh_galaxy_perf:
       timeout: 30
@@ -230,6 +243,7 @@
     pytest --timeout 1500 models/tt_transformers/demo/simple_text_demo.py -k "performance-ci-token-matching"
     pytest --timeout 1800 models/tt_transformers/demo/simple_text_demo.py -k "performance-ci-eval-32"
   model: qwen2.5-32b
+  model_family: Qwen
   skus:
     wh_llmbox_perf:
       timeout: 20
@@ -246,6 +260,7 @@
     pytest --timeout 1500 models/tt_transformers/demo/simple_text_demo.py -k "performance-ci-token-matching"
     pytest --timeout 1800 models/tt_transformers/demo/simple_text_demo.py -k "performance-ci-eval-32"
   model: qwen2.5-coder-32b
+  model_family: Qwen
   skus:
     wh_llmbox_perf:
       timeout: 18
@@ -258,6 +273,7 @@
     export HF_MODEL=Qwen/Qwen2.5-7B-Instruct TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/Qwen/Qwen2.5-7B-Instruct
     pytest --timeout 420 models/tt_transformers/demo/simple_text_demo.py -k "performance-ci-token-matching"
   model: qwen2.5-7b
+  model_family: Qwen
   skus:
     wh_n300:
       timeout: 5
@@ -284,6 +300,7 @@
     export HF_MODEL=Qwen/Qwen2.5-VL-72B-Instruct TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/Qwen/Qwen2.5-VL-72B-Instruct MESH_DEVICE=T3K
     pytest --timeout 900 models/demos/qwen25_vl/demo/demo.py
   model: qwen2.5-vl-72b
+  model_family: Qwen
   skus:
     wh_llmbox_perf:
       timeout: 20
@@ -300,6 +317,7 @@
     export HF_MODEL=Qwen/Qwen2.5-VL-32B-Instruct TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/Qwen/Qwen2.5-VL-32B-Instruct MESH_DEVICE=T3K
     pytest --timeout 600 models/demos/qwen25_vl/demo/demo.py
   model: qwen2.5-vl-32b
+  model_family: Qwen
   skus:
     wh_llmbox_perf:
       timeout: 15
@@ -316,6 +334,7 @@
     export HF_MODEL=Qwen/Qwen3-VL-32B-Instruct TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/Qwen/Qwen3-VL-32B-Instruct MESH_DEVICE=T3K PYTEST_ADDOPTS="--tb=short"
     pytest models/demos/qwen3_vl/demo/demo.py --timeout 600
   model: qwen3-vl-32b
+  model_family: Qwen
   skus:
     wh_llmbox_perf:
       timeout: 10
@@ -330,6 +349,7 @@
     export HF_MODEL=Qwen/QwQ-32B TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/Qwen/QwQ-32B
     pytest --timeout 600 models/tt_transformers/demo/simple_text_demo.py -k "performance-ci-eval-32"
   model: qwq-32b
+  model_family: Qwen
   skus:
     wh_llmbox_perf:
       timeout: 15
@@ -344,6 +364,7 @@
     pytest --timeout 1200 models/demos/blackhole/qwen36/demo/text_demo.py -k "determinism_128"
     pytest --timeout 1800 models/demos/blackhole/qwen36/demo/vision_demo.py -k "traced_single_image"
   model: qwen3.6-27b
+  model_family: Qwen
   skus:
     bh_quietbox_2:
       timeout: 45
@@ -359,6 +380,7 @@
     pytest --timeout 1000 models/demos/multimodal/gemma3/demo/text_demo.py -k "performance and ci-1"
     pytest --timeout 1000 models/demos/multimodal/gemma3/demo/vision_demo.py -k "performance and batch1-multi-image-trace"
   model: gemma-3-4b
+  model_family: Gemma
   skus:
     wh_n150:
       timeout: 15
@@ -372,6 +394,7 @@
     pytest --timeout 1000 models/demos/multimodal/gemma3/demo/text_demo.py -k "performance and ci-1"
     pytest --timeout 1000 models/demos/multimodal/gemma3/demo/vision_demo.py -k "performance and batch1-multi-image-trace"
   model: gemma-3-27b
+  model_family: Gemma
   skus:
     wh_llmbox_perf:
       timeout: 15
@@ -399,6 +422,7 @@
       models/demos/gemma4/tests/unit/test_packed_verify.py \
       models/demos/gemma4/tests/unit/test_model.py::test_full_model
   model: gemma-4-e2b
+  model_family: Gemma
   skus:
     wh_n150:
       timeout: 5
@@ -419,6 +443,7 @@
       models/demos/gemma4/tests/unit/test_packed_verify.py \
       models/demos/gemma4/tests/unit/test_model.py::test_full_model
   model: gemma-4-e4b
+  model_family: Gemma
   skus:
     # wh_n300 disabled due to reduced N300 runner availability — re-enable when capacity returns.
     # wh_n300:
@@ -443,6 +468,7 @@
       models/demos/gemma4/tests/unit/test_packed_verify.py \
       models/demos/gemma4/tests/unit/test_model.py::test_full_model
   model: gemma-4-26b-a4b
+  model_family: Gemma
   skus:
     wh_llmbox_perf:
       timeout: 10
@@ -471,6 +497,7 @@
       models/demos/gemma4/tests/unit/test_packed_verify.py \
       models/demos/gemma4/tests/unit/test_model.py::test_full_model
   model: gemma-4-31b
+  model_family: Gemma
   skus:
     wh_llmbox_perf:
       timeout: 10
@@ -496,6 +523,7 @@
       models/demos/gemma4/tests/unit/test_packed_verify.py \
       models/demos/gemma4/tests/unit/test_model.py::test_full_model
   model: gemma-4-12b
+  model_family: Gemma
   skus:
     bh_quietbox_2:
       timeout: 22
@@ -511,6 +539,7 @@
     pytest --timeout 420 models/tt_transformers/demo/simple_text_demo.py -k "performance-ci-token-matching"
     pytest --timeout 1800 models/tt_transformers/demo/simple_text_demo.py -k "performance-ci-eval-32"
   model: mistral-7b
+  model_family: Mistral
   skus:
     wh_n150:
       timeout: 7
@@ -524,6 +553,7 @@
     pytest --timeout 4200 models/tt_transformers/demo/simple_text_demo.py -k "performance-ci-token-matching"
     pytest --timeout 1800 models/tt_transformers/demo/simple_text_demo.py -k "performance-ci-eval-32"
   model: mixtral-8x7b
+  model_family: Mistral
   skus:
     wh_llmbox_perf:
       timeout: 20
@@ -537,6 +567,7 @@
   cmd: |
     pytest --timeout 420 --disable-warnings -q -s --input-method=cli --cli-input="YOUR PROMPT GOES HERE!" models/demos/wormhole/falcon7b/demo_wormhole.py::test_demo -k "default_mode_1024_stochastic"
   model: falcon-7b
+  model_family: Falcon
   skus:
     wh_n150:
       timeout: 6
@@ -548,6 +579,7 @@
   cmd: |
     pytest --timeout 720 models/demos/t3000/falcon40b/tests/test_demo.py::test_demo[wormhole_b0-mesh_device0-True-device_params0-128]
   model: falcon-40b
+  model_family: Falcon
   skus:
     wh_llmbox_perf:
       timeout: 10
@@ -562,6 +594,7 @@
     export TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/openai--gpt-oss-20b/ HF_MODEL=openai/gpt-oss-20b
     pytest models/demos/gpt_oss/demo/text_demo.py --timeout 600
   model: gpt-oss-20b
+  model_family: GPT-OSS
   skus:
     wh_llmbox_perf:
       timeout: 15
@@ -584,6 +617,7 @@
     [ "${MLPERF_READ_ONLY:-true}" = "false" ] && SKIP_MODEL_LOAD=""
     pytest models/demos/gpt_oss/demo/text_demo.py --timeout 1500 $SKIP_MODEL_LOAD
   model: gpt-oss-120b
+  model_family: GPT-OSS
   skus:
     wh_galaxy_perf:
       timeout: 30
@@ -604,6 +638,7 @@
     export HF_HUB_OFFLINE=0 HF_HOME=/mnt/MLPerf/huggingface HF_HUB_CACHE=/mnt/MLPerf/huggingface/hub HF_DATASETS_CACHE=/tmp/huggingface/datasets
     pytest --timeout=600 models/demos/audio/whisper/demo/demo.py --input-path="models/demos/audio/whisper/demo/dataset/conditional_generation" -k "conditional_generation"
   model: whisper
+  model_family: Whisper
   skus:
     wh_n150:
       timeout: 10
@@ -624,6 +659,7 @@
     export HF_MODEL=microsoft/Phi-3-mini-128k-instruct TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/microsoft/Phi-3-mini-128k-instruct
     pytest --timeout 420 models/tt_transformers/demo/simple_text_demo.py -k "performance-ci-token-matching"
   model: phi-3-mini
+  model_family: Phi
   skus:
     wh_n150:
       timeout: 6
@@ -654,6 +690,7 @@
   cmd: |
     pytest --timeout 420 --disable-warnings -q -s --input-method=json --input-path='models/demos/wormhole/mamba/demo/prompts.json' models/demos/wormhole/mamba/demo/demo.py
   model: mamba-2.8b
+  model_family: Mamba
   skus:
     wh_n150:
       timeout: 5
@@ -669,6 +706,7 @@
   cmd: |
     pytest -sv --timeout 600 models/experimental/functional_unet/tests/test_unet_perf.py -k "test_unet_trace_perf and not test_unet_trace_perf_multi_device"
   model: shallow-unet
+  model_family: UNet
   skus:
     bh_p150:
       timeout: 5
@@ -683,6 +721,7 @@
     export NO_PROMPT=1
     pytest --timeout 10000 models/tt_dit/tests/models/flux1/test_performance_flux1.py -k flux_schnell
   model: flux.1-schnell
+  model_family: Flux
   skus:
     bh_quietbox_2:
       timeout: 20
@@ -696,6 +735,7 @@
     export NO_PROMPT=1
     pytest --timeout 10000 models/tt_dit/tests/models/flux1/test_performance_flux1.py -k flux_dev
   model: flux.1-dev
+  model_family: Flux
   skus:
     bh_quietbox_2:
       timeout: 20
@@ -710,6 +750,7 @@
     export HF_HUB_OFFLINE=0
     pytest models/demos/stable_diffusion_xl_base/demo/demo.py -k "device_vae and device_encoders and with_trace and no_cfg_parallel"
   model: sdxl
+  model_family: Stable Diffusion
   skus:
     wh_n150:
       timeout: 40
@@ -726,6 +767,7 @@
     export HF_HUB_OFFLINE=0
     pytest models/demos/stable_diffusion_xl_base/demo/demo.py -k "device_vae and device_encoders and with_trace and use_cfg_parallel" --timeout=600
   model: sdxl
+  model_family: Stable Diffusion
   skus:
     wh_n300:
       timeout: 30
@@ -738,6 +780,7 @@
     export HF_HUB_OFFLINE=0
     pytest models/demos/stable_diffusion_xl_base/demo/demo_lora.py -k "device_vae and device_encoders and with_trace and no_cfg_parallel"
   model: sdxl
+  model_family: Stable Diffusion
   skus:
     wh_n150:
       timeout: 30
@@ -750,6 +793,7 @@
     export HF_HUB_OFFLINE=0
     pytest models/demos/stable_diffusion_xl_base/demo/demo_base_and_refiner.py -k "device_vae and device_encoders and with_trace and no_cfg_parallel"
   model: sdxl
+  model_family: Stable Diffusion
   skus:
     wh_n150:
       timeout: 40
@@ -768,6 +812,7 @@
     pytest models/demos/stable_diffusion_xl_base/demo/demo_inpainting.py -k "device_vae and device_encoders and with_trace and no_cfg_parallel" || exit_code=$?
     exit $exit_code
   model: sdxl
+  model_family: Stable Diffusion
   skus:
     wh_n150:
       timeout: 40
@@ -782,6 +827,7 @@
 - name: panoptic-deeplab e2e tests
   cmd: TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE="10,9" pytest models/experimental/panoptic_deeplab/demo/demo.py::test_panoptic_deeplab_demo_pipeline --timeout=1020
   model: panoptic-deeplab
+  model_family: Panoptic-DeepLab
   skus:
     bh_p150b_civ2:
       timeout: 18

--- a/tests/pipeline_reorg/models_sweep_tests.yaml
+++ b/tests/pipeline_reorg/models_sweep_tests.yaml
@@ -4,6 +4,7 @@
 #   name: The display name for the job in GitHub Actions.
 #   cmd: The exact command to run (env vars must be inlined).
 #   model: Model identifier for filtering (workflow_dispatch model selection).
+#   model_family: (optional) Human-facing model family for grouping/reporting (e.g. Llama, Qwen, Gemma). Omit when a test spans multiple families.
 #   skus: A mapping of SKU names to their configuration:
 #     timeout: Job timeout in minutes.
 #     tier: Model tier (1, 2, or 3) used to filter which pipeline runs this test.
@@ -21,6 +22,7 @@
     export HF_MODEL=meta-llama/Llama-3.1-8B-Instruct TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/meta-llama/Llama-3.1-8B-Instruct
     pytest --timeout 840 models/tt_transformers/demo/simple_text_demo.py -k "performance-seqlen-sweep" --num_layers 10
   model: llama3.1-8b
+  model_family: Llama
   skus:
     wh_n150:
       timeout: 15
@@ -36,6 +38,7 @@
     export TT_CACHE_HOME=/mnt/MLPerf/huggingface/tt_cache LLAMA_DIR=/mnt/MLPerf/tt_dnn-models/llama/Llama3.3-70B-Instruct/ MESH_DEVICE=TG
     pytest --timeout 1140 models/demos/llama3_70b_galaxy/demo/prefix_caching_benchmark.py
   model: llama3.3-70b
+  model_family: Llama
   skus:
     wh_galaxy:
       timeout: 20
@@ -48,6 +51,7 @@
     export HF_MODEL=meta-llama/Llama-3.3-70B-Instruct TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/meta-llama/Llama-3.3-70B-Instruct
     pytest --timeout 1440 models/tt_transformers/demo/simple_text_demo.py -k "performance-seqlen-sweep"
   model: llama3.3-70b
+  model_family: Llama
   skus:
     wh_llmbox_perf:
       timeout: 25
@@ -61,6 +65,7 @@
     export HF_MODEL=Qwen/Qwen3-32B TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/Qwen/Qwen3-32B
     pytest --timeout 840 models/tt_transformers/demo/simple_text_demo.py -k "performance-seqlen-sweep"
   model: qwen3-32b
+  model_family: Qwen
   skus:
     wh_llmbox_perf:
       timeout: 15
@@ -76,6 +81,7 @@
     export HF_MODEL=google/gemma-3-4b-it TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/google/gemma-3-4b-it
     pytest --timeout 540 models/demos/multimodal/gemma3/demo/text_demo.py -k "performance-seqlen-sweep" --max_seq_len 32768
   model: gemma-3-4b
+  model_family: Gemma
   skus:
     wh_n150:
       timeout: 10

--- a/tests/pipeline_reorg/models_unit_tests.yaml
+++ b/tests/pipeline_reorg/models_unit_tests.yaml
@@ -4,6 +4,7 @@
 #   name: The display name for the job in GitHub Actions.
 #   cmd: The exact command to run (env vars must be inlined).
 #   model: Model identifier for filtering (workflow_dispatch model selection).
+#   model_family: (optional) Human-facing model family for grouping/reporting (e.g. Llama, Qwen, Gemma). Omit when a test spans multiple families.
 #   skus: A mapping of SKU names to their configuration:
 #     timeout: Job timeout in minutes.
 #     tier: Model tier (1, 2, or 3) used to filter which pipeline runs this test.
@@ -25,6 +26,7 @@
     # pytest --timeout 500 models/tt_transformers/tests/test_model.py -k full
     # pytest --timeout 500 models/tt_transformers/tests/test_model_prefill.py -k "performance and not accuracy"
   model: llama3.1-8b
+  model_family: Llama
   skus:
     wh_n150:
       timeout: 30
@@ -41,6 +43,7 @@
     pytest --timeout 300 models/tt_transformers/tests/test_decoder.py -k 32-page_params  # batch 32 only
     pytest --timeout 300 models/tt_transformers/tests/test_decoder_prefill.py -k 128-page_params  # 128 seqlen only
   model: llama3.2-1b
+  model_family: Llama
   skus:
     wh_n150:
       timeout: 5
@@ -54,6 +57,7 @@
     pytest --timeout 300 models/tt_transformers/tests/test_decoder.py -k 32-page_params  # batch 32 only
     pytest --timeout 300 models/tt_transformers/tests/test_decoder_prefill.py -k 128-page_params  # 128 seqlen only
   model: llama3.2-3b
+  model_family: Llama
   skus:
     wh_n150:
       timeout: 5
@@ -67,6 +71,7 @@
     pytest --timeout 300 models/tt_transformers/tests/test_decoder.py -k 32-page_params  # batch 32 only
     pytest --timeout 300 models/tt_transformers/tests/test_decoder_prefill.py -k 128-page_params  # 128 seqlen only
   model: llama3.2-11b-vision
+  model_family: Llama
   skus:
     wh_llmbox_perf:
       timeout: 5
@@ -91,6 +96,7 @@
     # pytest --timeout 900 models/tt_transformers/tests/test_model.py -k quick
     # pytest --timeout 900 models/tt_transformers/tests/test_model_prefill.py -k "performance and 1layer"
   model: llama3.2-90b-vision
+  model_family: Llama
   skus:
     wh_llmbox_perf:
       timeout: 15
@@ -109,6 +115,7 @@
     pytest --timeout 900 models/tt_transformers/tests/test_decoder.py
     pytest --timeout 900 models/tt_transformers/tests/test_decoder_prefill.py
   model: llama3.3-70b
+  model_family: Llama
   skus:
     wh_llmbox_perf:
       timeout: 20
@@ -126,6 +133,7 @@
     pytest --timeout 900 models/tt_transformers/tests/test_decoder.py
     pytest --timeout 900 models/tt_transformers/tests/test_decoder_prefill.py
   model: qwen3-32b
+  model_family: Qwen
   skus:
     wh_llmbox_perf:
       timeout: 20
@@ -143,6 +151,7 @@
     pytest --timeout 900 models/tt_transformers/tests/test_decoder.py
     pytest --timeout 900 models/tt_transformers/tests/test_decoder_prefill.py
   model: qwen2.5-32b
+  model_family: Qwen
   skus:
     wh_llmbox_perf:
       timeout: 12
@@ -160,6 +169,7 @@
     pytest --timeout 900 models/tt_transformers/tests/test_decoder.py
     pytest --timeout 900 models/tt_transformers/tests/test_decoder_prefill.py
   model: qwen2.5-coder-32b
+  model_family: Qwen
   skus:
     wh_llmbox_perf:
       timeout: 15
@@ -181,6 +191,7 @@
     pytest --timeout 300 models/demos/blackhole/qwen36/tests/test_model.py
     pytest --timeout 300 models/demos/blackhole/qwen36/tests/test_wrapped_model.py
   model: qwen3.6-27b
+  model_family: Qwen
   skus:
     bh_quietbox_2:
       timeout: 28
@@ -201,6 +212,7 @@
     #pytest --timeout 600 models/tt_transformers/tests/test_model.py -k full
     #pytest --timeout 600 models/tt_transformers/tests/test_model_prefill.py -k "performance and not accuracy"
   model: mistral-7b
+  model_family: Mistral
   skus:
     wh_n150:
       timeout: 20
@@ -212,6 +224,7 @@
   cmd: |
     pytest --timeout 600 models/demos/multimodal/gemma3/tests/test_ci_dispatch.py -k "4b"
   model: gemma-3-4b
+  model_family: Gemma
   skus:
     wh_n150:
       timeout: 22
@@ -223,6 +236,7 @@
   cmd: |
     pytest --timeout 600 models/demos/multimodal/gemma3/tests/test_ci_dispatch.py -k "27b"
   model: gemma-3-27b
+  model_family: Gemma
   skus:
     wh_llmbox_perf:
       timeout: 22
@@ -235,6 +249,7 @@
   cmd: |
     pytest --timeout 600 models/experimental/janus_pro/tests/test_ci_dispatch.py
   model: janus-pro-7b
+  model_family: Janus
   skus:
     bh_p150:
       timeout: 2
@@ -285,6 +300,7 @@
       -k "not test_bridge_ and not test_full_model_parity and not test_attention_decode_paged_batched and not test_sampling_" \
       models/demos/gemma4/tests/unit/
   model: gemma-4-e2b
+  model_family: Gemma
   skus:
     wh_n150:
       timeout: 10
@@ -310,6 +326,7 @@
       -k "not test_bridge_ and not test_full_model_parity and not test_attention_decode_paged_batched and not test_sampling_" \
       models/demos/gemma4/tests/unit/
   model: gemma-4-e4b
+  model_family: Gemma
   skus:
     # wh_n300 disabled due to reduced N300 runner availability — re-enable when capacity returns.
     # wh_n300:
@@ -339,6 +356,7 @@
       -k "not test_bridge_ and not test_full_model_parity and not test_attention_decode_paged_batched and not test_sampling_" \
       models/demos/gemma4/tests/unit/
   model: gemma-4-26b-a4b
+  model_family: Gemma
   skus:
     wh_llmbox:
       timeout: 30
@@ -372,6 +390,7 @@
       -k "not test_bridge_ and not test_full_model_parity and not test_attention_decode_paged_batched and not test_sampling_" \
       models/demos/gemma4/tests/unit/
   model: gemma-4-31b
+  model_family: Gemma
   skus:
     wh_llmbox:
       timeout: 25
@@ -403,6 +422,7 @@
       -k "not test_bridge_ and not test_full_model_parity and not test_attention_decode_paged_batched and not test_sampling_" \
       models/demos/gemma4/tests/unit/
   model: gemma-4-12b
+  model_family: Gemma
   skus:
     bh_quietbox_2:
       timeout: 15
@@ -414,6 +434,7 @@
   cmd: |
     pytest --timeout 600 models/experimental/functional_unet/tests/test_unet_model.py
   model: shallow-unet
+  model_family: UNet
   skus:
     wh_n150:
       timeout: 5
@@ -438,6 +459,7 @@
     pytest --timeout 120 models/tt_transformers/tests/mixtral/test_mixtral_model.py -k "performance and not accuracy and quick"
     pytest --timeout 120 models/tt_transformers/tests/mixtral/test_mixtral_model_prefill.py -k "paged_attention"
   model: mixtral-8x7b
+  model_family: Mistral
   skus:
     wh_llmbox_perf:
       timeout: 30
@@ -474,6 +496,7 @@
     pytest --timeout 900 models/demos/llama3_70b_galaxy/tests/unit_tests/test_qwen_decoder.py
     pytest --timeout 900 models/demos/llama3_70b_galaxy/tests/unit_tests/test_qwen_decoder_prefill.py
   model: qwen3-32b-galaxy
+  model_family: Qwen
   skus:
     wh_galaxy_perf:
       timeout: 10
@@ -488,6 +511,7 @@
     pytest --timeout 900 models/demos/llama3_70b_galaxy/tests/unit_tests/test_qwen_attention.py
     pytest --timeout 900 models/demos/llama3_70b_galaxy/tests/unit_tests/test_qwen_decoder.py
   model: qwen3-32b-galaxy
+  model_family: Qwen
   skus:
     bh_galaxy:
       timeout: 25
@@ -503,6 +527,7 @@
     export HF_MODEL=models/demos/gpt_oss/configs/gpt-oss-20b
     pytest --timeout 600 models/demos/gpt_oss/tests/unit/
   model: gpt-oss-20b
+  model_family: GPT-OSS
   skus:
     # Wormhole
     wh_llmbox:
@@ -527,6 +552,7 @@
     [ "${MLPERF_READ_ONLY:-true}" = "false" ] && SKIP_MODEL_LOAD=""
     pytest --timeout 1500 models/demos/gpt_oss/tests/unit $SKIP_MODEL_LOAD
   model: gpt-oss-120b
+  model_family: GPT-OSS
   skus:
     # Wormhole
     wh_llmbox:
@@ -558,6 +584,7 @@
     pytest --timeout 600 models/demos/audio/whisper/tests/test_whisper_modules.py
     pytest --timeout 600 models/demos/audio/whisper/tests/test_whisper_streaming_detok.py
   model: whisper
+  model_family: Whisper
   skus:
     wh_n150:
       timeout: 10
@@ -577,6 +604,7 @@
     pytest --timeout 300 models/tt_transformers/tests/test_decoder.py
     pytest --timeout 300 models/tt_transformers/tests/test_decoder_prefill.py
   model: qwq-32b
+  model_family: Qwen
   skus:
     wh_llmbox_perf:
       timeout: 30
@@ -588,6 +616,7 @@
   cmd: |
     pytest --timeout 300 models/demos/ttnn_falcon7b/tests/test_falcon_decoder.py
   model: falcon-7b
+  model_family: Falcon
   skus:
     wh_n150:
       timeout: 5
@@ -599,6 +628,7 @@
   cmd: |
     pytest --timeout 300 models/demos/t3000/falcon40b/tests/test_falcon_decoder.py
   model: falcon-40b
+  model_family: Falcon
   skus:
     wh_llmbox_perf:
       timeout: 5
@@ -612,6 +642,7 @@
     pytest --timeout 300 models/tt_transformers/tests/test_decoder.py -k 32-page_params  # batch 32 only
     pytest --timeout 300 models/tt_transformers/tests/test_decoder_prefill.py -k 128-page_params  # 128 seqlen only
   model: qwen2.5-7b
+  model_family: Qwen
   skus:
     wh_n300:
       timeout: 5
@@ -625,6 +656,7 @@
     pytest --timeout 300 models/tt_transformers/tests/test_decoder.py -k 32-page_params  # batch 32 only
     pytest --timeout 300 models/tt_transformers/tests/test_decoder_prefill.py -k 128-page_params  # 128 seqlen only
   model: qwen2.5-72b
+  model_family: Qwen
   skus:
     wh_llmbox_perf:
       timeout: 5
@@ -638,6 +670,7 @@
     export HF_MODEL=Qwen/Qwen2.5-VL-72B-Instruct TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/Qwen/Qwen2.5-VL-72B-Instruct MESH_DEVICE=T3K
     pytest --timeout 600 models/demos/qwen25_vl/tests/ --ignore=models/demos/qwen25_vl/tests/test_ci_dispatch.py --ignore=models/demos/qwen25_vl/tests/conftest.py
   model: qwen2.5-vl-72b
+  model_family: Qwen
   skus:
     wh_llmbox_perf:
       timeout: 15
@@ -651,6 +684,7 @@
     export HF_MODEL=Qwen/Qwen2.5-VL-32B-Instruct TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/Qwen/Qwen2.5-VL-32B-Instruct MESH_DEVICE=T3K
     pytest --timeout 300 models/demos/qwen25_vl/tests/test_model.py
   model: qwen2.5-vl-32b
+  model_family: Qwen
   skus:
     wh_llmbox_perf:
       timeout: 5
@@ -664,6 +698,7 @@
     export HF_MODEL=Qwen/Qwen3-VL-32B-Instruct TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/Qwen/Qwen3-VL-32B-Instruct MESH_DEVICE=T3K PYTEST_ADDOPTS="--tb=short"
     pytest models/demos/qwen3_vl/tests/ --ignore=models/demos/qwen3_vl/tests/test_ci_dispatch.py --ignore=models/demos/qwen3_vl/tests/conftest.py
   model: qwen3-vl-32b
+  model_family: Qwen
   skus:
     wh_llmbox:
       timeout: 15
@@ -677,6 +712,7 @@
     pytest --timeout 240 models/tt_transformers/tests/test_decoder.py -k 32-page_params  # batch 32 only
     pytest --timeout 240 models/tt_transformers/tests/test_decoder_prefill.py -k 128-page_params  # 128 seqlen only
   model: phi-3-mini
+  model_family: Phi
   skus:
     wh_n150:
       timeout: 8
@@ -736,6 +772,7 @@
     pytest --timeout 10000 models/tt_dit/tests/models/flux1/test_pipeline_flux1.py -k flux_schnell
     pytest --timeout 10000 models/tt_dit/tests/models/flux1/test_transformer_flux1.py -k flux_schnell
   model: flux.1-schnell
+  model_family: Flux
   skus:
     bh_quietbox_2:
       timeout: 20
@@ -750,6 +787,7 @@
     pytest --timeout 10000 models/tt_dit/tests/models/flux1/test_pipeline_flux1.py -k flux_dev
     pytest --timeout 10000 models/tt_dit/tests/models/flux1/test_transformer_flux1.py -k flux_dev
   model: flux.1-dev
+  model_family: Flux
   skus:
     bh_quietbox_2:
       timeout: 20
@@ -766,6 +804,7 @@
     pytest --timeout 900 models/demos/stable_diffusion_xl_base/lora/tests/pcc || exit_code=$?
     exit $exit_code
   model: sdxl
+  model_family: Stable Diffusion
   skus:
     wh_n150:
       timeout: 40
@@ -784,6 +823,7 @@
     export HF_HUB_OFFLINE=0
     pytest --timeout 600 models/demos/stable_diffusion_xl_base/refiner/tests/pcc --ignore=models/demos/stable_diffusion_xl_base/refiner/tests/pcc/test_unet_loop.py
   model: sdxl
+  model_family: Stable Diffusion
   skus:
     wh_n150:
       timeout: 20
@@ -802,6 +842,7 @@
     export HF_HUB_OFFLINE=0
     pytest --timeout 600 models/demos/stable_diffusion_xl_base/vae/tests/pcc --ignore=models/demos/stable_diffusion_xl_base/vae/tests/pcc/test_welford_state_leak_regression.py
   model: sdxl
+  model_family: Stable Diffusion
   skus:
     wh_n150:
       timeout: 20
@@ -820,6 +861,7 @@
     export HF_HUB_OFFLINE=0
     pytest --timeout 600 models/demos/stable_diffusion_xl_base/tests/pcc --ignore=models/demos/stable_diffusion_xl_base/tests/pcc/test_unet_loop.py --ignore=models/demos/stable_diffusion_xl_base/tests/pcc/test_euler_discrete_scheduler.py
   model: sdxl
+  model_family: Stable Diffusion
   skus:
     wh_n150:
       timeout: 20
@@ -841,6 +883,7 @@
     pytest models/demos/stable_diffusion_xl_base/tests/pcc/test_unet_loop.py --loop-iter-num=50 -v -m "not disable_fast_runtime_mode" --timeout=600 || exit_code=$?
     exit $exit_code
   model: sdxl
+  model_family: Stable Diffusion
   skus:
     wh_n150:
       timeout: 60
@@ -862,6 +905,7 @@
     pytest models/demos/stable_diffusion_xl_base/refiner/tests/pcc/test_unet_loop.py --loop-iter-num=50 -v -m "not disable_fast_runtime_mode" --timeout=600 || exit_code=$?
     exit $exit_code
   model: sdxl
+  model_family: Stable Diffusion
   skus:
     wh_n150:
       timeout: 60
@@ -906,6 +950,7 @@
     mpirun -np 1 --bind-to none --tag-output --wdir "${TT_METAL_HOME}" \
       python3 -m pytest --timeout 10000 models/tt_dit/tests/models/flux1/test_pipeline_flux1.py -k "flux_dev and 2x4sp0tp1"
   model: flux-multihost-tests
+  model_family: Flux
   skus:
     bh_sc1:
       timeout: 20
@@ -921,6 +966,7 @@
     pytest --maxfail 10 --timeout 10000  models/tt_dit/tests/models/wan2_2/test_transformer_wan.py -k "not 720p"
     pytest --maxfail 10 --timeout 10000  models/tt_dit/tests/models/wan2_2/test_pipeline_wan.py
   model: wan-2.2-t2v
+  model_family: Wan
   skus:
     # bh_galaxy:
     #   timeout: 150
@@ -939,6 +985,7 @@
   # NOTE! The -k filtering above is a hack! We ideally should test both is_fsdp0 and is_fsdp1
   # but wh_galaxies error with OOM right now for fsdp0. This workaround lets tests pass on wh_galaxy.
   model: wan-2.2-i2v
+  model_family: Wan
   skus:
     # bh_galaxy:
     #   timeout: 120
@@ -952,6 +999,7 @@
 - name: panoptic-deeplab unit tests
   cmd: TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE="10,9" pytest models/experimental/panoptic_deeplab/tests/pcc/ --timeout=420
   model: panoptic-deeplab
+  model_family: Panoptic-DeepLab
   skus:
     bh_p150b_civ2:
       timeout: 8
@@ -962,6 +1010,7 @@
 - name: bevformer unit tests
   cmd: TT_METAL_CORE_GRID_OVERRIDE_TODEPRECATE="10,9" pytest models/experimental/bevformer/tests/pcc/ --timeout=660
   model: bevformer
+  model_family: BEVFormer
   skus:
     bh_p150b_civ2:
       timeout: 12


### PR DESCRIPTION
## What

Adds a new **optional** `model_family` key to every entry in the tiered model test registries:
- `tests/pipeline_reorg/models_e2e_tests.yaml`
- `tests/pipeline_reorg/models_unit_tests.yaml`
- `tests/pipeline_reorg/models_sweep_tests.yaml`

It gives each test a human-facing **family** name (Llama, Qwen, Gemma, Mistral, GPT-OSS, Falcon, Flux, Wan, Phi, Mamba, Whisper, Janus, Stable Diffusion, UNet, Panoptic-DeepLab, BEVFormer) so downstream tooling can group/report models by family.

## Why

The Models CI dashboard (and other reporting) currently has to guess a model's family by string-matching the model name. Declaring it in the registry makes grouping explicit and authoritative, and keeps it with the test definition.

## Notes

- **Optional & metadata-only** — no change to pipeline behavior or matrix generation. Purely a new field consumed by downstream tooling.
- **Derived from the model name**, reviewed manually. Notable groupings: `mixtral-8x7b` → **Mistral**; `qwq-32b` → **Qwen**; `sdxl` → **Stable Diffusion**; `shallow-unet` → **UNet**.
- **Omitted intentionally** for `dit-common` (the shared TT-DiT common test), which spans multiple families.
- Documented in each file's header comment.
- 98 entries annotated (45 e2e + 48 unit + 5 sweep); 1 skipped (`dit-common`).

Opening as a **draft** for review of the family assignments before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mtairum/model-family-field)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mtairum/model-family-field)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mtairum/model-family-field)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mtairum/model-family-field)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mtairum/model-family-field)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mtairum/model-family-field)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mtairum/model-family-field)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mtairum/model-family-field)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mtairum/model-family-field)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mtairum/model-family-field)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mtairum/model-family-field)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mtairum/model-family-field)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mtairum/model-family-field)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mtairum/model-family-field)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mtairum/model-family-field)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mtairum/model-family-field)