### PR TITLE
feat: equal-count Welford reduction optimisation (#50612)

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/quasar/reduction/generic/device/kernels/dataflow/writer_welford_hw.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/reduction/generic/device/kernels/dataflow/writer_welford_hw.cpp
@@ -6,17 +6,17 @@
 //
 // Phase 1 (per output): Reads Wt partial (mean, var) tile pairs from
 // cb_partial (written by the compute kernel using
-// welford_finalize_to_row), combines them across W using the parallel
-// Welford merge formula, applies Bessel's correction, and writes the
-// combined scalar into cb_combined for the compute kernel to apply
-// sqrtf (if std) and re-pack in the output format. cb_combined is
-// normally fp32, but for variance output to bf16 the program
-// factory may declare it as bf16 to save SRAM with no precision loss
+// welford_finalize_to_row), combines their equal-sized populations across W
+// using the equal-count Welford formula (no runtime FP divisions), applies
+// Bessel's correction, and writes the combined scalar into cb_combined
+// for the compute kernel to apply sqrtf (if std) and re-pack in the output
+// format. cb_combined is normally fp32, but for variance output to bf16 the
+// program factory may declare it as bf16 to save SRAM with no precision loss
 // since data is packed to bf16 output anyways and there is no math before
 // the final pack. combined_is_bf16 compile-time arg selects the path.
 //
 // Phase 2 (per output): Waits for the compute kernel to pack the
-// output tile into cb_out (in the correct output data format), then
+// output tile into cb_out (in the correct data format), then
 // NOC-writes it to DRAM.
 
 #include <cstdint>
@@ -28,7 +28,6 @@
 #include "api/numeric/bfloat16.h"
 #include "api/tensor/noc_traits.h"
 #include <tt-metalium/constants.hpp>
-#include "ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_combine.h"
 
 void kernel_main() {
     const uint32_t dst_addr = get_arg_val<uint32_t>(0);
@@ -60,6 +59,12 @@ void kernel_main() {
     constexpr uint32_t FACE_ELEMENTS = FACE_W * FACE_W;
     constexpr uint32_t last_tile_cols = (W % tile_width == 0) ? tile_width : W % tile_width;
 
+    // Total number of equal-sized partials per output. Each partial summarizes H
+    // samples, and all have the same count, so we can use the equal-count
+    // Welford formula (precomputed reciprocals, no runtime FP divisions).
+    constexpr uint32_t num_partials = reduce_batch_size * W;
+    constexpr float inv_num_partials = 1.0f / static_cast<float>(num_partials);
+
     const uint32_t partial_tile_size_bytes = get_tile_size(cb_partial);
     const uint32_t out_tile_size_bytes = get_tile_size(cb_out);
 
@@ -77,7 +82,14 @@ void kernel_main() {
 
     for (uint32_t out = 0; out < num_outputs; ++out) {
         // --- Phase 1: W-combine all per-column partials into one scalar ---
-        WelfordStats<float> running = {0.0f, 0.0f, 0};
+        // Equal-count optimization: every partial has the same count H, so we
+        // accumulate centered deltas and compute the result with a precomputed
+        // reciprocal. No runtime FP divisions.
+        float base_mean = 0.0f;
+        float mean_delta_sum = 0.0f;
+        float mean_delta_sq_sum = 0.0f;
+        float var_sum = 0.0f;
+        uint32_t partial_count = 0;
 
         for (uint32_t b = 0; b < reduce_batch_size; ++b) {
             for (uint32_t wt = 0; wt < Wt; ++wt) {
@@ -95,21 +107,40 @@ void kernel_main() {
                     // In tile row format, columns 0-15 are in Face 0 and
                     // columns 16-31 are in Face 1 (offset by FACE_ELEMENTS).
                     uint32_t idx = (c < FACE_W) ? c : (FACE_ELEMENTS + c - FACE_W);
-                    WelfordStats<float> partial;
-                    partial.mean = means_ptr[idx];
-                    partial.variance = vars_ptr[idx];
-                    partial.count = H;
-                    running = combine(running, partial);
+                    const float partial_mean = means_ptr[idx];
+                    const float partial_var = vars_ptr[idx];
+
+                    if (partial_count == 0) {
+                        base_mean = partial_mean;
+                        mean_delta_sum = 0.0f;
+                        mean_delta_sq_sum = 0.0f;
+                        var_sum = partial_var;
+                    } else {
+                        const float delta = partial_mean - base_mean;
+                        mean_delta_sum += delta;
+                        mean_delta_sq_sum += delta * delta;
+                        var_sum += partial_var;
+                    }
+                    ++partial_count;
                 }
 
                 cb_partial_obj.pop_front(2);
             }
         }
 
-        float final_var = running.variance;
+        // Combine using equal-count formula: all partials have the same count H.
+        // Total variance = avg subgroup variance + variance of means.
+        // M2(means) = sum(delta^2) - sum(delta)^2 / N, computed with inv_num_partials.
+        const float mean_delta = mean_delta_sum * inv_num_partials;
+        const float means_m2 = mean_delta_sq_sum - mean_delta_sum * mean_delta;
+        const float combined_mean = base_mean + mean_delta;
+        const float combined_var = (var_sum + means_m2) * inv_num_partials;
+
+        float final_var = combined_var;
         if constexpr (correction) {
-            uint32_t N = running.count;
-            final_var = final_var * static_cast<float>(N) / static_cast<float>(N - 1);
+            constexpr uint32_t N = num_partials * H;
+            constexpr float correction_scale = static_cast<float>(N) / static_cast<float>(N - 1);
+            final_var = final_var * correction_scale;
         }
 
         // Write the combined scalar into a tile in cb_combined.  The compute

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_combine.h
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_combine.h
@@ -50,7 +50,44 @@ inline WelfordStats<float> combine(const WelfordStats<float>& a, const WelfordSt
 }
 
 /**
+ * @brief Combine two sets of Welford stats where both subgroups have equal count.
+ *        Uses precomputed reciprocals to avoid runtime FP divisions.
+ *        Equivalent to combine(a, b) when a.count == b.count, but division-free.
+ * @tparam COUNT_PER_SUBGROUP Number of elements in each subgroup (compile-time known).
+ * @param a First WelfordStats (must have count == COUNT_PER_SUBGROUP).
+ * @param b Second WelfordStats (must have count == COUNT_PER_SUBGROUP).
+ * @return Combined WelfordStats with count == 2 * COUNT_PER_SUBGROUP.
+ */
+template <std::uint32_t COUNT_PER_SUBGROUP>
+inline WelfordStats<float> combine_equal_count(const WelfordStats<float>& a, const WelfordStats<float>& b) {
+    // Both subgroups have COUNT_PER_SUBGROUP elements, so combined count is 2*COUNT_PER_SUBGROUP.
+    // Precompute reciprocals at compile time — no runtime FP divisions.
+    constexpr float inv_combined = 1.0f / static_cast<float>(2 * COUNT_PER_SUBGROUP);
+
+    const float delta = b.mean - a.mean;
+    // mean = a.mean + delta * (b.count / (a.count + b.count)) = a.mean + delta * 0.5f
+    // but we use the precomputed form for consistency:
+    const float b_ratio = static_cast<float>(COUNT_PER_SUBGROUP) * inv_combined;  // = 0.5f
+
+    WelfordStats<float> result;
+    result.count = 2 * COUNT_PER_SUBGROUP;
+    result.mean = a.mean + delta * b_ratio;
+
+    const float m2_a = a.variance * static_cast<float>(COUNT_PER_SUBGROUP);
+    const float m2_b = b.variance * static_cast<float>(COUNT_PER_SUBGROUP);
+    // variance = (m2_a + m2_b + delta^2 * (a.count * b.count / (a.count + b.count))) / (a.count + b.count)
+    // = (m2_a + m2_b + delta^2 * COUNT_PER_SUBGROUP * 0.5f) * inv_combined
+    result.variance =
+        (m2_a + m2_b + delta * delta * (static_cast<float>(COUNT_PER_SUBGROUP) * static_cast<float>(COUNT_PER_SUBGROUP) * inv_combined)) * inv_combined;
+
+    return result;
+}
+
+/**
  * @brief Combine ARRAY_SIZE subgroup stats into overall mean and variance (float version).
+ *        Uses the equal-count optimization: all subgroups have COUNT_PER_VALUE elements,
+ *        so we accumulate centered sums and compute the result with a precomputed
+ *        reciprocal, avoiding all runtime FP divisions.
  * @tparam ARRAY_SIZE Number of subgroups.
  * @tparam COUNT_PER_VALUE Number of elements per subgroup.
  * @tparam STRIDE Stride between elements in input arrays.
@@ -62,18 +99,31 @@ template <std::uint32_t ARRAY_SIZE, std::uint32_t COUNT_PER_VALUE, std::uint32_t
 inline WelfordStats<float> combine_welford_stats(const float* means, const float* vars) {
     static_assert(ARRAY_SIZE > 0, "ARRAY_SIZE must be greater than 0");
 
-    WelfordStats<float> result;
-    result.mean = means[0];
-    result.variance = vars[0];
-    result.count = COUNT_PER_VALUE;
+    // Equal-count optimization: center around first mean, accumulate deltas,
+    // then compute combined stats with a precomputed reciprocal (no runtime divisions).
+    const float base_mean = means[0];
+    float mean_delta_sum = 0.0f;
+    float mean_delta_sq_sum = 0.0f;
+    float var_sum = vars[0];
 
     for (std::uint32_t i = 1; i < ARRAY_SIZE; ++i) {
-        WelfordStats<float> next;
-        next.mean = means[i * STRIDE];
-        next.variance = vars[i * STRIDE];
-        next.count = COUNT_PER_VALUE;
-        result = combine(result, next);
+        const float delta = means[i * STRIDE] - base_mean;
+        mean_delta_sum += delta;
+        mean_delta_sq_sum += delta * delta;
+        var_sum += vars[i * STRIDE];
     }
+
+    // Equal-sized populations: total variance = avg subgroup variance + variance of means.
+    // Centering around the first mean avoids cancellation from absolute magnitude:
+    // M2(means) = sum(delta^2) - sum(delta)^2 / ARRAY_SIZE.
+    constexpr float inv_size = 1.0f / static_cast<float>(ARRAY_SIZE);
+    const float mean_delta = mean_delta_sum * inv_size;
+    const float means_m2 = mean_delta_sq_sum - mean_delta_sum * mean_delta;
+
+    WelfordStats<float> result;
+    result.mean = base_mean + mean_delta;
+    result.variance = (var_sum + means_m2) * inv_size;
+    result.count = ARRAY_SIZE * COUNT_PER_VALUE;
 
     return result;
 }


### PR DESCRIPTION
## Summary

Replace runtime FP divisions with compile-time precomputed reciprocals in the equal-count Welford merge paths, eliminating 3×(K-1) divisions per combine call on data-movement cores (RiscV). The bounty description reports 36-45% measured improvement.

## Changes

### `welford_combine.h`
- **Optimize `combine_welford_stats<float>`**: Replace iterative `combine()` calls with the equal-count accumulation formula (centered deltas, precomputed `inv_size`), matching the bf16 implementation. This eliminates all runtime FP divisions.
- **Add `combine_equal_count<COUNT>` template**: Combines two equal-sized WelfordStats using precomputed reciprocals, no runtime divisions.
- **Keep original `combine()`**: Backward-compatible, still available for unequal-count cases.

### `writer_welford_hw.cpp` (experimental/quasar)
- Replace iterative `combine(running, partial)` loop with equal-count accumulation using centered deltas and `constexpr inv_num_partials`.
- Remove dependency on `welford_combine.h` header (the accumulation is inlined).
- Bessel's correction now uses `constexpr` for the scale factor.

## Mathematical Correctness

The equal-count optimization is already proven in production — the bf16 `combine_welford_stats<uint16_t>` has used this formula since its introduction. The float version now uses the identical algorithm:

```
mean = base_mean + mean_delta  (where mean_delta = mean_delta_sum * inv_size)
variance = (var_sum + means_m2) * inv_size  (where means_m2 = mean_delta_sq_sum - mean_delta_sum * mean_delta)
```

This is algebraically equivalent to the iterative parallel-Welford merge when all subgroups have equal count, but avoids all runtime FP divisions by precomputing `1.0f / ARRAY_SIZE`.

## Test Results

Standalone C++ test validates:
- K=1, K=2, K=4: equal-count and general formulas produce identical results
- Large means: numerical stability matches
- Various subgroup sizes (C=1, 32, 512): all pass
- Ground truth: manual calculation confirms 3.75 variance for 4 groups of 10
- `combine_equal_count<C>` matches `combine()` for equal subgroups

Closes #50612