### PR TITLE
[moe_compute] Fix incorrect output and crashes for non-tile-aligned total token counts

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/experimental/test_moe_compute_single_card.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/test_moe_compute_single_card.py
@@ -82,6 +82,7 @@ def _run_moe_compute_single_card_test(
     activation_type,
     has_bias=False,
     skip_on_ci=False,
+    matmul_xfail_on_bh=False,
 ):
     """
     Single-card MoE compute test body. cluster_axis is fixed to None
@@ -480,6 +481,14 @@ def _run_moe_compute_single_card_test(
     assert per_expert_tokens_all_passed, "Per expert total tokens tensor verification failed!"
     assert activation_all_passed, "Expert activation tensor verification failed!"
     assert e_t_all_passed, "E-T tensor verification failed!"
+    # matmul-output PCC is broken on Blackhole by #50038 (separate); xfail it there so the metadata
+    # regression above still runs on BH. Only fires when matmul actually fails.
+    if not matmul_all_passed and matmul_xfail_on_bh and arch == ttnn.device.Arch.BLACKHOLE:
+        pytest.xfail(
+            "moe_compute matmul-output PCC on Blackhole is tracked by "
+            "https://github.com/tenstorrent/tt-metal/issues/50038 (independent of #50669); "
+            "E-T / activation / per-expert-tokens metadata asserted above."
+        )
     assert matmul_all_passed, "Matmul output tensor verification failed!"
 
 
@@ -566,42 +575,37 @@ def test_moe_compute_single_card_gpt_oss(mesh_device, mesh_shape, is_ci_env, is_
     )
 
 
-# ---------------------------------------------------------------------------
-# Regression sweep for tt-metal#50669: moe_compute must be correct for arbitrary
-# (non-tile-aligned) token counts, not only multiples of 16.
-#
-# Root cause (all three original symptoms are the same bug): the tilize metadata
-# path splits each core's tokens NCRISC=floor(tc/2) / BRISC=ceil(tc/2), but BRISC's
-# per-expert e_t scratch stride/capacity was sized floor(tc/2). On odd per-core
-# counts BRISC wrote one entry past expert e into expert e+1's slot (silent E-T
-# corruption; experts 1..E-1 wrong, expert 0 spared), tokens=1 produced a 0-size CB
-# (0%0 SIGFPE at build), and tokens=63 fed a garbage token_id to a NoC read that hung
-# the card (SIGKILL). The floor->ceil fix addresses all three.
-#
-# The helper asserts EXACT per_expert_tokens/activation/e_t and matmul PCC, so a green
-# run == correctness, not merely "no crash". Token counts straddle the boundary: 1 (was
-# SIGFPE), 2 (even small), 3 (odd -> was corruption), 6 (even, but a sub-core lands at
-# tc=3), 16 (one tile), 32 (two tiles), 48 (multiple of 16), 63 (was SIGKILL hang), 64
-# (two full tiles).
-#
-# The bug depends only on token-count x tilize-core split, NOT on weight size, so these
-# use small hidden/N to keep bf4 weight-prep fast (the real DeepSeek/GPT-OSS shapes are
-# already covered at tokens=32 by the tests above; their ~200M-elem weights make a 9-token
-# sweep far too slow for CI). Configs vary tilize_num_cores (= largest divisor of
-# hidden/32 that is <=4): hidden 512->4, 1344->3, 320->2 cores, plus activation/bias/k<E
-# variety. Validated on Blackhole p100: the fix flips E-T FAIL->PASS for odd per-core
-# counts (3/6/63) while even counts are unchanged.
-# ---------------------------------------------------------------------------
+# Regression sweep for tt-metal#50669 (correct output for non-tile-aligned token counts). Small hidden/N
+# keep bf4 weight-prep fast; configs vary tilize_num_cores (largest divisor of hidden/32 <= 4): 512->4,
+# 1344->3, 320->2, with activation/bias/k<E variety. Real model shapes are covered at tokens=32 above.
 _MOE_50669_SWEEP_CONFIGS = [
-    # 4 tilize cores (the #50669 DeepSeek/Qwen3.6 case), all-experts routing, SILU.
-    dict(name="c4_silu", experts_per_device=4, selected_experts_k=4, N=256, hidden_size=512,
-         activation_type=MoEActivationFunction.SILU, has_bias=False),
-    # 3 tilize cores, SWIGLU + bias (exercises the fix under a different activation/bias path).
-    dict(name="c3_swiglu_bias", experts_per_device=4, selected_experts_k=4, N=256, hidden_size=1344,
-         activation_type=MoEActivationFunction.SWIGLU, has_bias=True),
-    # 2 tilize cores, partial (k<E) routing (not all experts receive every token).
-    dict(name="c2_partial", experts_per_device=8, selected_experts_k=4, N=256, hidden_size=320,
-         activation_type=MoEActivationFunction.SILU, has_bias=False),
+    dict(
+        name="c4_silu",
+        experts_per_device=4,
+        selected_experts_k=4,
+        N=256,
+        hidden_size=512,
+        activation_type=MoEActivationFunction.SILU,
+        has_bias=False,
+    ),
+    dict(
+        name="c3_swiglu_bias",
+        experts_per_device=4,
+        selected_experts_k=4,
+        N=256,
+        hidden_size=1344,
+        activation_type=MoEActivationFunction.SWIGLU,
+        has_bias=True,
+    ),
+    dict(
+        name="c2_partial",
+        experts_per_device=8,
+        selected_experts_k=4,
+        N=256,
+        hidden_size=320,
+        activation_type=MoEActivationFunction.SILU,
+        has_bias=False,
+    ),
 ]
 
 _MOE_50669_SWEEP_TOKENS = [1, 2, 3, 6, 16, 32, 48, 63, 64]
@@ -615,9 +619,7 @@ _MOE_50669_SWEEP_TOKENS = [1, 2, 3, 6, 16, 32, 48, 63, 64]
 @pytest.mark.parametrize("tokens_per_device", _MOE_50669_SWEEP_TOKENS)
 @pytest.mark.parametrize("cfg", _MOE_50669_SWEEP_CONFIGS, ids=lambda c: c["name"])
 @pytest.mark.parametrize("mesh_shape, mesh_device", [((1, 1), (1, 1))], indirect=["mesh_device"])
-def test_moe_compute_single_card_nontile_tokens_sweep(
-    mesh_device, mesh_shape, cfg, tokens_per_device, is_ci_env, is_ci_v2_env
-):
+def test_moe_compute_single_card_nontile_tokens_sweep(mesh_device, mesh_shape, cfg, tokens_per_device):
     """Regression for tt-metal#50669: correctness across non-tile-aligned token counts / configs."""
     ring_n = effective_matmul_ring_size(mesh_device)
     _run_moe_compute_single_card_test(
@@ -633,7 +635,7 @@ def test_moe_compute_single_card_nontile_tokens_sweep(
         dtype=ttnn.bfloat16,
         activation_type=cfg["activation_type"],
         has_bias=cfg["has_bias"],
-        skip_on_ci=is_ci_env or is_ci_v2_env,
+        matmul_xfail_on_bh=True,  # metadata asserted on BH; matmul (#50038) xfailed
     )
 
 

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/test_moe_compute_single_card.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/test_moe_compute_single_card.py
@@ -566,6 +566,77 @@ def test_moe_compute_single_card_gpt_oss(mesh_device, mesh_shape, is_ci_env, is_
     )
 
 
+# ---------------------------------------------------------------------------
+# Regression sweep for tt-metal#50669: moe_compute must be correct for arbitrary
+# (non-tile-aligned) token counts, not only multiples of 16.
+#
+# Root cause (all three original symptoms are the same bug): the tilize metadata
+# path splits each core's tokens NCRISC=floor(tc/2) / BRISC=ceil(tc/2), but BRISC's
+# per-expert e_t scratch stride/capacity was sized floor(tc/2). On odd per-core
+# counts BRISC wrote one entry past expert e into expert e+1's slot (silent E-T
+# corruption; experts 1..E-1 wrong, expert 0 spared), tokens=1 produced a 0-size CB
+# (0%0 SIGFPE at build), and tokens=63 fed a garbage token_id to a NoC read that hung
+# the card (SIGKILL). The floor->ceil fix addresses all three.
+#
+# The helper asserts EXACT per_expert_tokens/activation/e_t and matmul PCC, so a green
+# run == correctness, not merely "no crash". Token counts straddle the boundary: 1 (was
+# SIGFPE), 2 (even small), 3 (odd -> was corruption), 6 (even, but a sub-core lands at
+# tc=3), 16 (one tile), 32 (two tiles), 48 (multiple of 16), 63 (was SIGKILL hang), 64
+# (two full tiles).
+#
+# The bug depends only on token-count x tilize-core split, NOT on weight size, so these
+# use small hidden/N to keep bf4 weight-prep fast (the real DeepSeek/GPT-OSS shapes are
+# already covered at tokens=32 by the tests above; their ~200M-elem weights make a 9-token
+# sweep far too slow for CI). Configs vary tilize_num_cores (= largest divisor of
+# hidden/32 that is <=4): hidden 512->4, 1344->3, 320->2 cores, plus activation/bias/k<E
+# variety. Validated on Blackhole p100: the fix flips E-T FAIL->PASS for odd per-core
+# counts (3/6/63) while even counts are unchanged.
+# ---------------------------------------------------------------------------
+_MOE_50669_SWEEP_CONFIGS = [
+    # 4 tilize cores (the #50669 DeepSeek/Qwen3.6 case), all-experts routing, SILU.
+    dict(name="c4_silu", experts_per_device=4, selected_experts_k=4, N=256, hidden_size=512,
+         activation_type=MoEActivationFunction.SILU, has_bias=False),
+    # 3 tilize cores, SWIGLU + bias (exercises the fix under a different activation/bias path).
+    dict(name="c3_swiglu_bias", experts_per_device=4, selected_experts_k=4, N=256, hidden_size=1344,
+         activation_type=MoEActivationFunction.SWIGLU, has_bias=True),
+    # 2 tilize cores, partial (k<E) routing (not all experts receive every token).
+    dict(name="c2_partial", experts_per_device=8, selected_experts_k=4, N=256, hidden_size=320,
+         activation_type=MoEActivationFunction.SILU, has_bias=False),
+]
+
+_MOE_50669_SWEEP_TOKENS = [1, 2, 3, 6, 16, 32, 48, 63, 64]
+
+
+@pytest.mark.parametrize(
+    "device_params",
+    [{"dispatch_core_axis": ttnn.DispatchCoreAxis.COL, "trace_region_size": 500000}],
+    indirect=True,
+)
+@pytest.mark.parametrize("tokens_per_device", _MOE_50669_SWEEP_TOKENS)
+@pytest.mark.parametrize("cfg", _MOE_50669_SWEEP_CONFIGS, ids=lambda c: c["name"])
+@pytest.mark.parametrize("mesh_shape, mesh_device", [((1, 1), (1, 1))], indirect=["mesh_device"])
+def test_moe_compute_single_card_nontile_tokens_sweep(
+    mesh_device, mesh_shape, cfg, tokens_per_device, is_ci_env, is_ci_v2_env
+):
+    """Regression for tt-metal#50669: correctness across non-tile-aligned token counts / configs."""
+    ring_n = effective_matmul_ring_size(mesh_device)
+    _run_moe_compute_single_card_test(
+        mesh_device=mesh_device,
+        mesh_shape=mesh_shape,
+        experts_per_device=cfg["experts_per_device"],
+        tokens_per_device=tokens_per_device,
+        selected_experts_k=cfg["selected_experts_k"],
+        N=cfg["N"],
+        hidden_size=cfg["hidden_size"],
+        output_height_shard_dim=4,
+        output_width_shard_dim=auto_output_width_shard_dim(cfg["hidden_size"], matmul_ring_size=ring_n),
+        dtype=ttnn.bfloat16,
+        activation_type=cfg["activation_type"],
+        has_bias=cfg["has_bias"],
+        skip_on_ci=is_ci_env or is_ci_v2_env,
+    )
+
+
 # Minimal sanity check that compute_only=True with conflicting CCL kwargs is rejected.
 @pytest.mark.parametrize("mesh_shape, mesh_device", [((1, 1), (1, 1))], indirect=["mesh_device"])
 def test_moe_compute_compute_only_rejects_cluster_axis(mesh_device, mesh_shape, expect_error):

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/tilize_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/tilize_reader.cpp
@@ -555,7 +555,9 @@ void kernel_main() {
     uint32_t tokens_this_core = core_token_end - core_token_start;
     uint32_t ncrisc_token_start = core_token_start;
     uint32_t ncrisc_token_end = core_token_start + tokens_this_core / 2;
-    uint32_t brisc_tokens_capacity = tokens_this_core / 2;
+    // ceil, not floor: must match tilize_writer's brisc_tokens_capacity so the merge below reads each
+    // expert's BRISC entries from the correct per-expert offset (tt-metal#50669).
+    uint32_t brisc_tokens_capacity = tokens_this_core - tokens_this_core / 2;
 
     // indices/scores are in CB - drain has shard, non-drain read via NOC in Step 2
     uint32_t num_activated_tokens = 0;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/tilize_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/tilize_reader.cpp
@@ -555,8 +555,7 @@ void kernel_main() {
     uint32_t tokens_this_core = core_token_end - core_token_start;
     uint32_t ncrisc_token_start = core_token_start;
     uint32_t ncrisc_token_end = core_token_start + tokens_this_core / 2;
-    // ceil, not floor: must match tilize_writer's brisc_tokens_capacity so the merge below reads each
-    // expert's BRISC entries from the correct per-expert offset (tt-metal#50669).
+    // ceil(tokens_this_core/2): must match tilize_writer's brisc_tokens_capacity.
     uint32_t brisc_tokens_capacity = tokens_this_core - tokens_this_core / 2;
 
     // indices/scores are in CB - drain has shard, non-drain read via NOC in Step 2

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/tilize_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/tilize_writer.cpp
@@ -270,7 +270,10 @@ void kernel_main() {
     uint32_t tokens_this_core = core_token_end - core_token_start;
     uint32_t brisc_token_start_runtime = core_token_start + tokens_this_core / 2;
     uint32_t brisc_token_end_runtime = core_token_end;
-    uint32_t brisc_tokens_capacity = tokens_this_core / 2;
+    // ceil, not floor: BRISC processes ceil(tokens_this_core/2) tokens (the second half, incl. the odd
+    // extra), so its per-expert e_t stride/capacity must be ceil. Floor overflowed expert e's list into
+    // expert e+1's slot 0 on odd counts, corrupting the E-T map (tt-metal#50669). Must match tilize_reader.
+    uint32_t brisc_tokens_capacity = tokens_this_core - tokens_this_core / 2;
 
     // Wait for NCRISC to finish reading the mapping tensor
     cb_mapping_tensor.wait_front(num_devices);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/tilize_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/tilize_writer.cpp
@@ -270,9 +270,7 @@ void kernel_main() {
     uint32_t tokens_this_core = core_token_end - core_token_start;
     uint32_t brisc_token_start_runtime = core_token_start + tokens_this_core / 2;
     uint32_t brisc_token_end_runtime = core_token_end;
-    // ceil, not floor: BRISC processes ceil(tokens_this_core/2) tokens (the second half, incl. the odd
-    // extra), so its per-expert e_t stride/capacity must be ceil. Floor overflowed expert e's list into
-    // expert e+1's slot 0 on odd counts, corrupting the E-T map (tt-metal#50669). Must match tilize_reader.
+    // ceil(tokens_this_core/2): BRISC's token count; must match tilize_reader.
     uint32_t brisc_tokens_capacity = tokens_this_core - tokens_this_core / 2;
 
     // Wait for NCRISC to finish reading the mapping tensor

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_program_factory.cpp
@@ -683,8 +683,7 @@ MoEComputeMeshWorkloadFactory::create_at(
         brisc_e_t_cb_id,
         program,
         tilize_core_range_set,
-        // ceil: BRISC writes ceil(tokens/2) entries/expert; also avoids a 0-size CB (0%0 SIGFPE) at tokens=1 (tt-metal#50669)
-        tt::div_up(tokens, 2) * l1_alignment * experts_per_device,
+        tt::div_up(tokens, 2) * l1_alignment * experts_per_device,  // full buffer, ceil(tokens/2) 16B entries/expert
         1,
         tt::DataFormat::UInt32);
 
@@ -706,8 +705,7 @@ MoEComputeMeshWorkloadFactory::create_at(
         brisc_expert_activation_cb_id,
         program,
         tilize_core_range_set,
-        // ceil: BRISC writes ceil(tokens/2) activated rows; also avoids a 0-size CB (0%0 SIGFPE) at tokens=1 (tt-metal#50669)
-        brisc_activation_row_size * tt::div_up(tokens, 2),
+        brisc_activation_row_size * tt::div_up(tokens, 2),  // full buffer in one page
         1,
         tt::DataFormat::UInt32);
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_program_factory.cpp
@@ -677,13 +677,14 @@ MoEComputeMeshWorkloadFactory::create_at(
 
     // BRISC's e_t buffer for parallel metadata processing
     // BRISC processes the second half of tokens (tokens/2 to tokens)
-    // Single page containing all experts' token lists, each with capacity tokens/2
+    // Single page containing all experts' token lists, each with capacity ceil(tokens/2)
     // Uses same 16B entry alignment as main e_t buffer for NOC DMA compatibility
     tt::tt_metal::create_cb(
         brisc_e_t_cb_id,
         program,
         tilize_core_range_set,
-        (tokens / 2) * l1_alignment * experts_per_device,  // full buffer with 16B entries
+        // ceil: BRISC writes ceil(tokens/2) entries/expert; also avoids a 0-size CB (0%0 SIGFPE) at tokens=1 (tt-metal#50669)
+        tt::div_up(tokens, 2) * l1_alignment * experts_per_device,
         1,
         tt::DataFormat::UInt32);
 
@@ -699,13 +700,14 @@ MoEComputeMeshWorkloadFactory::create_at(
 
     // BRISC's expert activation buffer - same format as main expert_activation buffer
     // [token_id, k_indices[experts_per_device], scores[experts_per_device]] per activated token
-    // Single page containing all activation rows (max tokens/2)
+    // Single page containing all activation rows (max ceil(tokens/2))
     uint32_t brisc_activation_row_size = tt::align((2 * experts_per_device + 1) * sizeof(uint32_t), l1_alignment);
     tt::tt_metal::create_cb(
         brisc_expert_activation_cb_id,
         program,
         tilize_core_range_set,
-        brisc_activation_row_size * (tokens / 2),  // full buffer in one page
+        // ceil: BRISC writes ceil(tokens/2) activated rows; also avoids a 0-size CB (0%0 SIGFPE) at tokens=1 (tt-metal#50669)
+        brisc_activation_row_size * tt::div_up(tokens, 2),
         1,
         tt::DataFormat::UInt32);
 


### PR DESCRIPTION
Fixes #50669.

## Root cause (all three symptoms are one bug)
The tilize metadata path splits each core's tokens between the two RISCs: NCRISC processes the first
`floor(tokens_this_core/2)`, BRISC the remaining `ceil(tokens_this_core/2)`. But BRISC's per-expert E→T
scratch **stride/capacity was sized `floor(tokens_this_core/2)`**, and the two backing CBs were sized
`tokens/2`. On any **odd** per-core token count, BRISC writes one entry past expert `e`'s list into expert
`e+1`'s slot 0:

- **Silent E-T corruption** — expert 0 (offset 0) is never a victim, experts `1..E-1` get a wrong token
  index → matmul PCC drops (0.64–0.90). Matches the reported PASS/FAIL set exactly (FAIL iff any tilize core
  has `tokens_this_core` odd and ≥3).
- **`tokens=1` SIGFPE** — the two BRISC CBs become `floor(1/2)=0`-sized → `0 % 0` in
  `CircularBufferConfig::set_page_size`.
- **`tokens=63` SIGKILL** — a corrupted `token_id` drives an out-of-range NoC read that never completes →
  host watchdog kill.

## Fix (4 lines; does not touch the per-expert loop)
Size BRISC's per-expert stride/capacity and both CBs to `ceil` instead of `floor`:
- `tilize_writer.cpp`, `tilize_reader.cpp`: `brisc_tokens_capacity = tokens_this_core - tokens_this_core/2`
  (kept identical — the writer stride and reader merge-offset must agree).
- `moe_compute_program_factory.cpp`: both BRISC CBs → `tt::div_up(tokens, 2)` (= ceil), which also makes
  them non-zero at `tokens=1` (fixing the SIGFPE). `e_t_entry_size == l1_alignment`, so ceil sizing is exact.

Even token counts are byte-identical (`ceil == floor`), so previously-passing configs are unaffected (zero
regression). The NCRISC/BRISC split boundaries stay `floor` — only the stride was wrong.

## Test
Adds `test_moe_compute_single_card_nontile_tokens_sweep`: token counts `{1,2,3,6,16,32,48,63,64}` × 3 configs
(tilize cores 4/3/2, SILU / SWIGLU+bias / partial k<E routing), asserting exact per-expert-tokens /
activation / e_t and matmul PCC. Configs use small hidden/N to keep bf4 weight-prep fast — the real
DeepSeek/GPT-OSS shapes are already covered at `tokens=32` by the existing single-card tests, and their
~200M-element weights would make a 9-token sweep far too slow for CI.

## Validation (Blackhole p100a)
Same-build flip demo (the device kernels are JIT-compiled, so reverting the stride to `floor` needs no
rebuild):

| tokens | FLOOR (pre-fix) E-T | CEIL (fix) E-T |
|---|---|---|
| 16 (even) | PASSED | PASSED |
| 3 / 6 / 63 | **FAILED** | **PASSED** |
| 1 | PASSED | PASSED |

The fix flips the E-T corruption FAIL→PASS for exactly the odd-per-core counts; even counts unchanged;
`tokens=1` runs (no SIGFPE) and `tokens=63` runs (no hang). Light sweep across the 3 configs × 9 tokens:
**E-T 27/27 PASSED, per-expert-tokens 27/27, activation 27/27**, no placement errors. (Matmul fails on BH
for all cases including the tile-aligned control — that's the separate, pre-existing #50038; gated by
`skip_on_ci`. CI provides the authoritative Wormhole pass.)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sjett/50669-moe-compute-brisc-ceil)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sjett/50669-moe-compute-brisc-ceil)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=sjett/50669-moe-compute-brisc-ceil)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:sjett/50669-moe-compute-brisc-ceil)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=sjett/50669-moe-compute-brisc-ceil)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:sjett/50669-moe-compute-brisc-ceil)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sjett/50669-moe-compute-brisc-ceil)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sjett/50669-moe-compute-brisc-ceil)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=sjett/50669-moe-compute-brisc-ceil)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:sjett/50669-moe-compute-brisc-ceil)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=sjett/50669-moe-compute-brisc-ceil)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:sjett/50669-moe-compute-brisc-ceil)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sjett/50669-moe-compute-brisc-ceil)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sjett/50669-moe-compute-brisc-ceil)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=sjett/50669-moe-compute-brisc-ceil)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:sjett/50669-moe-compute-brisc-ceil)