### PR TITLE
[Bug Fix] Revert pad/unpad checks introduced in #50285

### DIFF
--- a/tests/tt_metal/tt_metal/api/tensor/test_host_tensor_spec_preservation.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_host_tensor_spec_preservation.cpp
@@ -135,8 +135,8 @@ TEST(HostTensorSpecPreservation, ToLayoutPhysicalMismatchThrows) {
     auto alignment = Alignment({32, 24});
     auto tile = Tile({16, 16});
 
-    auto source_spec = TensorSpec(
-        shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR, tile), memory_config, alignment));
+    auto source_spec =
+        TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config, alignment));
     auto source = HostTensor::from_vector<float>(data, source_spec);
 
     EXPECT_ANY_THROW(std::ignore = to_tile_layout(source, tile));

--- a/tests/tt_metal/tt_metal/api/tensor/test_host_tensor_spec_preservation.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_host_tensor_spec_preservation.cpp
@@ -164,10 +164,10 @@ TEST(HostTensorSpecPreservation, ToTileLayoutBfpTileMismatchThrows) {
     EXPECT_ANY_THROW(std::ignore = to_tile_layout(source, Tile({16, 16})));
 }
 
-TEST(HostTensorSpecPreservation, PadUnpadInterleavedPreservesMemoryAndGeometry) {
+TEST(HostTensorSpecPreservation, DISABLED_PadUnpadDropsMemoryConfigToDefault) {
     const Shape logical{2, 3};
     auto data = CMAKE_UNIQUE_NAMESPACE::make_ramp<float>(logical.volume());
-    // pad/unpad reject sharded hosts, so per_core cannot be set true here; exact_spec_match still covers the flag.
+    // Pre-#50285 host pad/unpad always emit MemoryConfig{} (interleaved DRAM).
     auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
     auto source_spec =
         TensorSpec(logical, TensorLayout(DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config));
@@ -179,20 +179,18 @@ TEST(HostTensorSpecPreservation, PadUnpadInterleavedPreservesMemoryAndGeometry) 
     auto expected_pad_spec = TensorSpec(
         logical,
         TensorLayout::fromPaddedShape(
-            DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config, logical, padded));
+            DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), MemoryConfig{}, logical, padded));
     EXPECT_TRUE(CMAKE_UNIQUE_NAMESPACE::exact_spec_match(padded_tensor.tensor_spec(), expected_pad_spec));
-    EXPECT_EQ(padded_tensor.memory_config().buffer_type(), BufferType::DRAM);
+    EXPECT_EQ(padded_tensor.memory_config(), MemoryConfig{});
     EXPECT_EQ(padded_tensor.padded_shape(), padded);
     EXPECT_EQ(padded_tensor.logical_shape(), logical);
     CMAKE_UNIQUE_NAMESPACE::expect_packed_sizes(padded_tensor);
 
     auto unpadded = unpad(padded_tensor, Shape{0, 0}, Shape{2, 3});
-    auto expected_unpad_spec = TensorSpec(
-        logical,
-        TensorLayout::fromPaddedShape(
-            DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config, logical, logical));
+    auto expected_unpad_spec =
+        TensorSpec(logical, TensorLayout(DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), MemoryConfig{}));
     EXPECT_TRUE(CMAKE_UNIQUE_NAMESPACE::exact_spec_match(unpadded.tensor_spec(), expected_unpad_spec));
-    EXPECT_EQ(unpadded.memory_config().buffer_type(), BufferType::DRAM);
+    EXPECT_EQ(unpadded.memory_config(), MemoryConfig{});
     EXPECT_EQ(unpadded.logical_shape(), logical);
     EXPECT_EQ(unpadded.padded_shape(), logical);
     CMAKE_UNIQUE_NAMESPACE::expect_packed_sizes(unpadded);
@@ -204,7 +202,7 @@ TEST(HostTensorSpecPreservation, PadUnpadInterleavedPreservesMemoryAndGeometry) 
     }
 }
 
-TEST(HostTensorSpecPreservation, PadShardedLegacyThrows) {
+TEST(HostTensorSpecPreservation, DISABLED_PadShardedLegacyDropsSharding) {
     const Shape shape{32, 32};
     auto data = CMAKE_UNIQUE_NAMESPACE::make_ramp<float>(shape.volume());
     auto memory_config = MemoryConfig{
@@ -214,10 +212,14 @@ TEST(HostTensorSpecPreservation, PadShardedLegacyThrows) {
     auto source_spec = TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config));
     auto source = HostTensor::from_vector<float>(data, source_spec);
 
-    EXPECT_ANY_THROW(std::ignore = pad(source, Shape{64, 32}, Shape{0, 0}, 0.0f));
+    auto padded = pad(source, Shape{64, 32}, Shape{0, 0}, 0.0f);
+    EXPECT_FALSE(padded.memory_config().is_sharded());
+    EXPECT_EQ(padded.memory_config(), MemoryConfig{});
+    EXPECT_EQ(padded.padded_shape(), Shape({64, 32}));
+    CMAKE_UNIQUE_NAMESPACE::expect_packed_sizes(padded);
 }
 
-TEST(HostTensorSpecPreservation, UnpadShardedLegacyThrows) {
+TEST(HostTensorSpecPreservation, DISABLED_UnpadShardedLegacyDropsSharding) {
     const Shape shape{32, 32};
     auto data = CMAKE_UNIQUE_NAMESPACE::make_ramp<float>(shape.volume());
     auto memory_config = MemoryConfig{
@@ -227,10 +229,14 @@ TEST(HostTensorSpecPreservation, UnpadShardedLegacyThrows) {
     auto source_spec = TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config));
     auto source = HostTensor::from_vector<float>(data, source_spec);
 
-    EXPECT_ANY_THROW(std::ignore = unpad(source, Shape{0, 0}, Shape{16, 32}));
+    auto unpadded = unpad(source, Shape{0, 0}, Shape{16, 32});
+    EXPECT_FALSE(unpadded.memory_config().is_sharded());
+    EXPECT_EQ(unpadded.memory_config(), MemoryConfig{});
+    EXPECT_EQ(unpadded.logical_shape(), Shape({16, 32}));
+    CMAKE_UNIQUE_NAMESPACE::expect_packed_sizes(unpadded);
 }
 
-TEST(HostTensorSpecPreservation, PadShardedConvertibleNdThrows) {
+TEST(HostTensorSpecPreservation, DISABLED_PadShardedConvertibleNdDropsSharding) {
     const Shape shape{32, 32};
     auto data = CMAKE_UNIQUE_NAMESPACE::make_ramp<float>(shape.volume());
     // Convertible ND: 2D height-sharded via NdShardSpec (auto-fills legacy shard_spec).
@@ -241,10 +247,14 @@ TEST(HostTensorSpecPreservation, PadShardedConvertibleNdThrows) {
     ASSERT_TRUE(source_spec.memory_config().shard_spec().has_value());
     auto source = HostTensor::from_vector<float>(data, source_spec);
 
-    EXPECT_ANY_THROW(std::ignore = pad(source, Shape{64, 32}, Shape{0, 0}, 0.0f));
+    auto padded = pad(source, Shape{64, 32}, Shape{0, 0}, 0.0f);
+    EXPECT_FALSE(padded.memory_config().is_sharded());
+    EXPECT_EQ(padded.memory_config(), MemoryConfig{});
+    EXPECT_EQ(padded.padded_shape(), Shape({64, 32}));
+    CMAKE_UNIQUE_NAMESPACE::expect_packed_sizes(padded);
 }
 
-TEST(HostTensorSpecPreservation, UnpadShardedConvertibleNdThrows) {
+TEST(HostTensorSpecPreservation, DISABLED_UnpadShardedConvertibleNdDropsSharding) {
     const Shape shape{32, 32};
     auto data = CMAKE_UNIQUE_NAMESPACE::make_ramp<float>(shape.volume());
     NdShardSpec nd_shard_spec{Shape{32, 32}, CoreRangeSet({CoreRange({0, 0}, {0, 0})}), ShardOrientation::ROW_MAJOR};
@@ -252,7 +262,11 @@ TEST(HostTensorSpecPreservation, UnpadShardedConvertibleNdThrows) {
     auto source_spec = TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config));
     auto source = HostTensor::from_vector<float>(data, source_spec);
 
-    EXPECT_ANY_THROW(std::ignore = unpad(source, Shape{0, 0}, Shape{16, 32}));
+    auto unpadded = unpad(source, Shape{0, 0}, Shape{16, 32});
+    EXPECT_FALSE(unpadded.memory_config().is_sharded());
+    EXPECT_EQ(unpadded.memory_config(), MemoryConfig{});
+    EXPECT_EQ(unpadded.logical_shape(), Shape({16, 32}));
+    CMAKE_UNIQUE_NAMESPACE::expect_packed_sizes(unpadded);
 }
 
 }  // namespace

--- a/tests/tt_metal/tt_metal/api/tensor/test_host_tensor_to_dtype.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_host_tensor_to_dtype.cpp
@@ -122,41 +122,6 @@ TEST(HostTensorToDtype, NonBfpPreservesMetadata) {
     EXPECT_EQ(result.tensor_spec().tile(), tile);
 }
 
-TEST(HostTensorToDtype, RowMajorToBfpChangesLayoutToTileAndPreservesTile) {
-    const Shape shape{32, 32};
-    auto data = CMAKE_UNIQUE_NAMESPACE::make_ramp<float>(shape.volume());
-    auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
-    auto alignment = tt::tt_metal::Alignment({32, 32});
-    auto tile = Tile({16, 16});
-
-    // Create a ROW_MAJOR tensor, but specify a tile in the page config (embedded tile)
-    auto source_spec = TensorSpec(
-        shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR, tile), memory_config, alignment));
-    auto source = HostTensor::from_vector<float>(data, source_spec);
-
-    auto result = to_dtype(source, DataType::BFLOAT8_B);
-
-    auto expected_spec =
-        TensorSpec(shape, TensorLayout(DataType::BFLOAT8_B, PageConfig(Layout::TILE, tile), memory_config, alignment));
-
-    EXPECT_TRUE(CMAKE_UNIQUE_NAMESPACE::exact_spec_match(result.tensor_spec(), expected_spec));
-    EXPECT_EQ(result.layout(), Layout::TILE);
-    EXPECT_EQ(result.tensor_spec().tile(), tile);
-
-    // Value check on the aligned supported path
-    // We can unpack the BFP8_B data to float and check if it matches the original data
-    auto result_packed_data = host_buffer::get_as<uint32_t>(result);
-    auto unpacked_data =
-        unpack_bfp8_tiles_into_float_vec(result_packed_data, /*row_major_output=*/false, /*is_exp_a=*/false, tile);
-    auto rm_data =
-        tensor_impl::to_row_major_layout(expected_spec.physical_shape(), tile, ttsl::make_const_span(unpacked_data));
-
-    EXPECT_EQ(rm_data.size(), data.size());
-    for (size_t i = 0; i < data.size(); ++i) {
-        EXPECT_NEAR(rm_data[i], data[i], 1.0f);
-    }
-}
-
 TEST(HostTensorToDtype, TileBfp8ToFloat32ValueCheck) {
     const Shape shape{32, 32};
     const auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
@@ -391,16 +356,15 @@ TEST(HostTensorToDtype, RowMajorToBfpPhysicalMismatchThrows) {
     const Shape shape{32, 24};
     auto data = CMAKE_UNIQUE_NAMESPACE::make_ramp<float>(shape.volume());
     auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
-    // Alignment that is NOT a multiple of 16 (tile size)
+    // Alignment that is NOT a multiple of the default tile width
     auto alignment = tt::tt_metal::Alignment({32, 24});
-    auto tile = Tile({16, 16});
 
-    auto source_spec = TensorSpec(
-        shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR, tile), memory_config, alignment));
+    auto source_spec =
+        TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config, alignment));
     auto source = HostTensor::from_vector<float>(data, source_spec);
 
-    // This should throw because BFLOAT8_B forces TILE layout, which forces alignment to be multiple of 16
-    // So output physical shape width will be 32 instead of 24
+    // This should throw because BFLOAT8_B forces TILE layout, which forces alignment to be
+    // a multiple of the tile size. So output physical shape width will be 32 instead of 24.
     EXPECT_ANY_THROW(to_dtype(source, DataType::BFLOAT8_B));
 }
 

--- a/tt_metal/impl/tensor/tensor_apis.cpp
+++ b/tt_metal/impl/tensor/tensor_apis.cpp
@@ -970,28 +970,17 @@ HostTensor pad_impl(
         tile = tensor.tensor_spec().tile();
     }
 
-    auto output_spec = TensorSpec(
-        tensor.logical_shape(),
-        TensorLayout::fromPaddedShape(
-            tensor.dtype(),
-            PageConfig(tensor.layout(), tile),
-            tensor.memory_config(),
+    return HostTensor::from_buffer(
+        std::move(transformed_buffer),
+        TensorSpec(
             tensor.logical_shape(),
-            output_padded_shape));
-
-    const size_t expected_shard_size = output_spec.compute_packed_buffer_size_bytes();
-    for (const auto& coord : transformed_buffer.shard_coords()) {
-        auto shard = transformed_buffer.get_shard(coord);
-        if (shard) {
-            TT_FATAL(
-                shard->view_bytes().size() == expected_shard_size,
-                "pad shard size mismatch after conversion: actual {} != expected {}",
-                shard->view_bytes().size(),
-                expected_shard_size);
-        }
-    }
-
-    return HostTensor::from_buffer(std::move(transformed_buffer), output_spec, tensor.tensor_topology());
+            TensorLayout::fromPaddedShape(
+                tensor.dtype(),
+                PageConfig(tensor.layout(), tile),
+                MemoryConfig{},
+                tensor.logical_shape(),
+                output_padded_shape)),
+        tensor.tensor_topology());
 }
 
 template <>
@@ -1067,35 +1056,15 @@ HostTensor unpad_impl(
     auto transformed_buffer = tensor.buffer().transform(
         [&](const HostBuffer& buffer) { return HostBuffer(unpad(buffer)); },
         DistributedHostBuffer::ProcessShardExecutionPolicy::PARALLEL);
-
-    // Exact authorship: padded == logical == cropped buffer. Do not re-apply source alignment.
-    const auto output_tensor_shape = tt::tt_metal::Shape(output_shape);
-    auto tile = tt::tt_metal::Tile();
-    if (tensor.layout() == Layout::TILE) {
-        tile = tensor.tensor_spec().tile();
-    }
-    auto output_spec = TensorSpec(
-        output_tensor_shape,
-        TensorLayout::fromPaddedShape(
-            tensor.dtype(),
-            PageConfig(tensor.layout(), tile),
-            tensor.memory_config(),
-            output_tensor_shape,
-            output_tensor_shape));
-
-    const size_t expected_shard_size = output_spec.compute_packed_buffer_size_bytes();
-    for (const auto& coord : transformed_buffer.shard_coords()) {
-        auto shard = transformed_buffer.get_shard(coord);
-        if (shard) {
-            TT_FATAL(
-                shard->view_bytes().size() == expected_shard_size,
-                "unpad shard size mismatch after conversion: actual {} != expected {}",
-                shard->view_bytes().size(),
-                expected_shard_size);
-        }
-    }
-
-    return HostTensor::from_buffer(std::move(transformed_buffer), output_spec, tensor.tensor_topology());
+    return HostTensor::from_buffer(
+        std::move(transformed_buffer),
+        TensorSpec(
+            tt::tt_metal::Shape(output_shape),
+            tt::tt_metal::TensorLayout(
+                tensor.dtype(),
+                tt::tt_metal::PageConfig(tensor.layout(), tensor.tensor_spec().tile()),
+                tt::tt_metal::MemoryConfig{})),
+        tensor.tensor_topology());
 }
 
 template <>
@@ -1129,11 +1098,6 @@ HostTensor pad(
     const tt::tt_metal::Shape& input_tensor_start,
     float pad_value) {
     TT_FATAL(tensor.layout() == Layout::ROW_MAJOR, "Tensor layout must be ROW_MAJOR for padding");
-    TT_FATAL(
-        !tensor.memory_config().is_sharded(),
-        "pad: sharded host tensors are not supported (legacy and ND). "
-        "legacyShapeToAlignment short-circuits on shard_spec and ignores output_padded_shape for convertible ND; "
-        "rederiving shard geometry under pad is out of scope.");
     return tensor_impl::dispatch(tensor.dtype(), [&]<typename T>() {
         return CMAKE_UNIQUE_NAMESPACE::pad_impl<T>(tensor, output_padded_shape, input_tensor_start, pad_value);
     });
@@ -1170,11 +1134,6 @@ HostTensor unpad(
     const tt::tt_metal::Shape& output_tensor_start,
     const tt::tt_metal::Shape& output_tensor_end) {
     TT_FATAL(tensor.layout() == Layout::ROW_MAJOR, "Tensor layout must be ROW_MAJOR for unpadding");
-    TT_FATAL(
-        !tensor.memory_config().is_sharded(),
-        "unpad: sharded host tensors are not supported (legacy and ND). "
-        "legacyShapeToAlignment short-circuits on shard_spec and ignores cropped geometry for convertible ND; "
-        "rederiving shard geometry under unpad is out of scope.");
     return tensor_impl::dispatch(tensor.dtype(), [&]<typename T>() {
         return CMAKE_UNIQUE_NAMESPACE::unpad_impl<T>(tensor, output_tensor_start, output_tensor_end);
     });


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

Bug Fix

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

#50285 broke sanity pipeline and vgg model because it introduced more strict checks for host tensor pad/unpad operation.
This PR reverts those checks, fixes #50832 , #50830 .

Also fixes #50882 where host side ops are failing due to stricter Row major tensor tile check, I don't know why I didn't caught this locally??

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

Verification run done locally, sanity run started: https://github.com/tenstorrent/tt-metal/actions/runs/30034634289

Fails on matmul should be result of flakyness: https://github.com/tenstorrent/tt-metal/issues/44354

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=riverwu/pad-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:riverwu/pad-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=riverwu/pad-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:riverwu/pad-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=riverwu/pad-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:riverwu/pad-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=riverwu/pad-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:riverwu/pad-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=riverwu/pad-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:riverwu/pad-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=riverwu/pad-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:riverwu/pad-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=riverwu/pad-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:riverwu/pad-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=riverwu/pad-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:riverwu/pad-fix)