### PR TITLE
[ttnn] Metal 2.0 spec factory: rename MetalV2FactoryConcept + add CustomProgramSpecFactoryConcept

### DIFF
--- a/tests/ttnn/unit_tests/gtests/test_launch_operation.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_launch_operation.cpp
@@ -107,13 +107,13 @@ static_assert(ttnn::device_operation::MeshWorkloadFactoryConcept<NewInfraWorkloa
 static_assert(ttnn::device_operation::ProgramFactoryConcept<NewInfraProgramFactory>);
 
 // ---------------------------------------------------------------------------
-// MetalV2FactoryConcept (Metal 2.0 op-porting stepping stone)
+// ProgramSpecFactoryConcept (Metal 2.0 op-porting stepping stone)
 //
 // No real op uses create_program_artifacts yet, so the adapter's templated
 // method bodies — including the op-owned tensor enumeration and parking added
 // for this concept — are never instantiated by a normal build. The checks below
 // (a) pin the concept's classification (it recognizes a create_program_artifacts
-// factory and is mutually exclusive with the other three factory concepts, per
+// factory and is mutually exclusive with the other factory concepts, per
 // all_factories_valid), and (b) force-instantiate the adapter so its bodies are
 // actually compiled.
 //
@@ -122,34 +122,64 @@ static_assert(ttnn::device_operation::ProgramFactoryConcept<NewInfraProgramFacto
 // real op dispatched through the launch path, i.e. the first op port. Until then
 // this is compile-coverage only.
 // ---------------------------------------------------------------------------
-struct MetalV2Factory {
+struct ProgramSpecFactory {
     static ttnn::device_operation::ProgramArtifacts create_program_artifacts(
         const OperationAttributes& /*attrs*/, const Tensor& /*tensor_args*/, Tensor& /*tensor_return_value*/) {
         return ttnn::device_operation::ProgramArtifacts{};
     }
 };
 
+// Same, but additionally provides override_runtime_arguments -> classified as the
+// custom variant, whose cache-hit path applies the returned ProgramRunArgs via
+// UpdateProgramRunArgs.
+struct CustomProgramSpecFactory {
+    static ttnn::device_operation::ProgramArtifacts create_program_artifacts(
+        const OperationAttributes& /*attrs*/, const Tensor& /*tensor_args*/, Tensor& /*tensor_return_value*/) {
+        return ttnn::device_operation::ProgramArtifacts{};
+    }
+    static tt::tt_metal::experimental::ProgramRunArgs override_runtime_arguments(
+        const OperationAttributes& /*attrs*/,
+        const Tensor& /*tensor_args*/,
+        Tensor& /*tensor_return_value*/,
+        const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/ = std::nullopt) {
+        return {};
+    }
+};
+
 // Minimal device operation supplying just the typedefs the adapter inherits.
-struct MetalV2MinimalOp {
+struct ProgramSpecMinimalOp {
     using operation_attributes_t = OperationAttributes;
     using tensor_args_t = Tensor;
     using spec_return_value_t = tt::tt_metal::TensorSpec;
     using tensor_return_value_t = Tensor;
 };
 
-static_assert(ttnn::device_operation::MetalV2FactoryConcept<MetalV2Factory>);
-static_assert(!ttnn::device_operation::ProgramFactoryConcept<MetalV2Factory>);
-static_assert(!ttnn::device_operation::MeshWorkloadFactoryConcept<MetalV2Factory>);
-static_assert(!ttnn::device_operation::ProgramDescriptorFactoryConcept<MetalV2Factory>);
+static_assert(ttnn::device_operation::ProgramSpecFactoryConcept<ProgramSpecFactory>);
+static_assert(!ttnn::device_operation::CustomProgramSpecFactoryConcept<ProgramSpecFactory>);
+static_assert(!ttnn::device_operation::ProgramFactoryConcept<ProgramSpecFactory>);
+static_assert(!ttnn::device_operation::MeshWorkloadFactoryConcept<ProgramSpecFactory>);
+static_assert(!ttnn::device_operation::ProgramDescriptorFactoryConcept<ProgramSpecFactory>);
+
+// The custom variant is mutually exclusive with the base one.
+static_assert(ttnn::device_operation::CustomProgramSpecFactoryConcept<CustomProgramSpecFactory>);
+static_assert(!ttnn::device_operation::ProgramSpecFactoryConcept<CustomProgramSpecFactory>);
+static_assert(!ttnn::device_operation::ProgramFactoryConcept<CustomProgramSpecFactory>);
+static_assert(!ttnn::device_operation::MeshWorkloadFactoryConcept<CustomProgramSpecFactory>);
+static_assert(!ttnn::device_operation::ProgramDescriptorFactoryConcept<CustomProgramSpecFactory>);
 
 // Compile-coverage: taking the adapter methods' addresses ODR-uses them, forcing
 // the (otherwise un-instantiated) bodies to compile. Never dispatched.
-TEST(LaunchOperationTest, MetalV2AdapterCompiles) {
-    using Adapter = device_operation::MeshDeviceOperationAdapter<MetalV2MinimalOp>::MetalV2MeshWorkloadFactoryAdapter<
-        MetalV2Factory>;
+TEST(LaunchOperationTest, ProgramSpecAdapterCompiles) {
+    using Adapter = device_operation::MeshDeviceOperationAdapter<
+        ProgramSpecMinimalOp>::ProgramSpecMeshWorkloadFactoryAdapter<ProgramSpecFactory>;
     [[maybe_unused]] auto create = &Adapter::create_mesh_workload;
     [[maybe_unused]] auto apply = &Adapter::apply_descriptor;
     [[maybe_unused]] auto resolve = &Adapter::resolve_bindings;
+
+    using CustomAdapter = device_operation::MeshDeviceOperationAdapter<
+        ProgramSpecMinimalOp>::CustomProgramSpecMeshWorkloadFactoryAdapter<CustomProgramSpecFactory>;
+    [[maybe_unused]] auto ccreate = &CustomAdapter::create_mesh_workload;
+    [[maybe_unused]] auto capply = &CustomAdapter::apply_descriptor;
     SUCCEED();
 }
 

--- a/ttnn/api/ttnn/device_operation.hpp
+++ b/ttnn/api/ttnn/device_operation.hpp
@@ -220,8 +220,8 @@ void enqueue_mesh_workload(
 }
 
 // Dispatches `fn` to `program_factory` through either the `MeshWorkloadFactoryConcept` directly, or through the adapted
-// path for `ProgramFactoryConcept` / `ProgramDescriptorFactoryConcept` / `MetalV2FactoryConcept`
-// factories.
+// path for `ProgramFactoryConcept` / `ProgramDescriptorFactoryConcept` / `ProgramSpecFactoryConcept` /
+// `CustomProgramSpecFactoryConcept` factories.
 template <DeviceOperationWithMeshDeviceAdapter mesh_device_operation_t, typename ProgramFactory, typename Fn>
 void dispatch_to_mesh_workload_factory(const ProgramFactory& program_factory, const Fn& fn) {
     std::visit(
@@ -235,9 +235,14 @@ void dispatch_to_mesh_workload_factory(const ProgramFactory& program_factory, co
                 using AdaptedMeshWorkloadFactory = mesh_device_operation_t::template DescriptorMeshWorkloadAdapter<T>;
                 fn.template operator()<AdaptedMeshWorkloadFactory>();
             },
-            [&]<MetalV2FactoryConcept T>(const T&) {
+            [&]<ProgramSpecFactoryConcept T>(const T&) {
                 using AdaptedMeshWorkloadFactory =
-                    mesh_device_operation_t::template MetalV2MeshWorkloadFactoryAdapter<T>;
+                    mesh_device_operation_t::template ProgramSpecMeshWorkloadFactoryAdapter<T>;
+                fn.template operator()<AdaptedMeshWorkloadFactory>();
+            },
+            [&]<CustomProgramSpecFactoryConcept T>(const T&) {
+                using AdaptedMeshWorkloadFactory =
+                    mesh_device_operation_t::template CustomProgramSpecMeshWorkloadFactoryAdapter<T>;
                 fn.template operator()<AdaptedMeshWorkloadFactory>();
             },
             [&]<MeshWorkloadFactoryConcept WorkloadFactory>(const WorkloadFactory&) {

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -879,7 +879,9 @@ public:
                 "ProgramSpec factory adapter requires at least one Tensor in tensor_args or "
                 "tensor_return_value to source the MeshDevice");
             auto* mesh_device = first_tensor.value().device();
-            TT_FATAL(mesh_device != nullptr, "First tensor in tensor_args must be allocated on a MeshDevice");
+            TT_FATAL(
+                mesh_device != nullptr,
+                "The sourced tensor (from tensor_args or tensor_return_value) must be allocated on a MeshDevice");
 
             // The factory produces a single ProgramArtifacts; the adapter stamps it
             // across all coordinate ranges. Bindings derive from the (single) set of

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -29,6 +29,7 @@
 #include "ttnn/distributed/types.hpp"
 #include "ttnn/mesh_device_operation_utils.hpp"
 #include "ttnn/metal_v2_artifacts.hpp"
+#include <tt-metalium/experimental/metal2_host_api/program.hpp>
 #include "ttnn/operation_concepts.hpp"
 #include "ttnn/operation.hpp"
 #include <tt_stl/reflection.hpp>
@@ -756,9 +757,9 @@ public:
     };
 
     // -----------------------------------------------------------------------
-    // MetalV2MeshWorkloadFactoryAdapter
+    // ProgramSpecMeshWorkloadFactoryAdapter
     //
-    // Adapts a MetalV2FactoryConcept factory (Metal 2.0,
+    // Adapts a ProgramSpecFactoryConcept factory (Metal 2.0,
     // single-program / SPMD-flavored) for mesh dispatch. The op author writes
     // ONLY create_program_artifacts, returning a single ProgramArtifacts (one
     // ProgramSpec + ProgramRunArgs + any op-owned tensors). The adapter stamps a
@@ -787,8 +788,8 @@ public:
     //
     // TODO: consider replacing with a general MeshWorkloadSpecFactoryAdapter?
     // -----------------------------------------------------------------------
-    template <MetalV2FactoryConcept MetalV2Factory>
-    struct MetalV2MeshWorkloadFactoryAdapter {
+    template <typename SpecFactory>
+    struct ProgramSpecMeshWorkloadFactoryAdapter {
         using TensorParamName = tt::tt_metal::experimental::TensorParamName;
         using TensorArgument = tt::tt_metal::experimental::ProgramRunArgs::TensorArgument;
 
@@ -866,14 +867,17 @@ public:
             const ttnn::MeshCoordinateRangeSet& tensor_coords,
             const tensor_args_t& tensor_args,
             tensor_return_value_t& tensor_return_value) {
-            // Metal 2.0's MakeProgramFromSpec needs a MeshDevice; pull from the
-            // first device tensor reachable from tensor_args. Op factories
-            // satisfying this concept are tensor-driven, so first_tensor is
-            // always populated for current callers.
+            // Metal 2.0's MakeProgramFromSpec needs a MeshDevice; pull from the first device tensor
+            // reachable from tensor_args, falling back to tensor_return_value for output-only ops
+            // (e.g. rand) whose tensor_args carry no input tensor.
             auto first_tensor = ttsl::reflection::get_first_object_of_type<ttnn::Tensor>(tensor_args);
+            if (!first_tensor.has_value()) {
+                first_tensor = ttsl::reflection::get_first_object_of_type<ttnn::Tensor>(tensor_return_value);
+            }
             TT_FATAL(
                 first_tensor.has_value(),
-                "MetalV2 factory adapter requires at least one Tensor in tensor_args to source the MeshDevice");
+                "ProgramSpec factory adapter requires at least one Tensor in tensor_args or "
+                "tensor_return_value to source the MeshDevice");
             auto* mesh_device = first_tensor.value().device();
             TT_FATAL(mesh_device != nullptr, "First tensor in tensor_args must be allocated on a MeshDevice");
 
@@ -881,7 +885,7 @@ public:
             // across all coordinate ranges. Bindings derive from the (single) set of
             // factory tensor_args and are identical for every stamped program; copy
             // per range into the cached shared state.
-            auto artifacts = MetalV2Factory::create_program_artifacts(attrs, tensor_args, tensor_return_value);
+            auto artifacts = SpecFactory::create_program_artifacts(attrs, tensor_args, tensor_return_value);
 
             // Enumerate io tensors (inputs + outputs), then append the factory's
             // op-owned tensors. resolve_bindings maps each TensorArgument to an
@@ -939,6 +943,30 @@ public:
                     fresh_tensor_args.emplace(b.tensor_parameter_name, TensorArgument{mesh_tensors[b.tensor_idx]});
                 }
                 tt::tt_metal::experimental::UpdateTensorArgs(program, fresh_tensor_args);
+            }
+        }
+    };
+
+    // Like ProgramSpecMeshWorkloadFactoryAdapter (cache-miss build inherited unchanged), but the
+    // cache-hit path calls the factory's override_runtime_arguments and applies the returned
+    // ProgramRunArgs via UpdateProgramRunArgs instead of the base's tensor-only UpdateTensorArgs.
+    template <CustomProgramSpecFactoryConcept CustomSpecFactory>
+    struct CustomProgramSpecMeshWorkloadFactoryAdapter : ProgramSpecMeshWorkloadFactoryAdapter<CustomSpecFactory> {
+        using Base = ProgramSpecMeshWorkloadFactoryAdapter<CustomSpecFactory>;
+        using typename Base::cached_mesh_workload_t;
+
+        static void apply_descriptor(
+            cached_mesh_workload_t& cached_workload,
+            const operation_attributes_t& attrs,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& tensor_return_value) {
+            for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
+                auto run_args = CustomSpecFactory::override_runtime_arguments(
+                    attrs,
+                    tensor_args,
+                    tensor_return_value,
+                    std::optional<ttnn::MeshCoordinate>(coordinate_range.start_coord()));
+                tt::tt_metal::experimental::UpdateProgramRunArgs(program, run_args);
             }
         }
     };

--- a/ttnn/api/ttnn/metal_v2_artifacts.hpp
+++ b/ttnn/api/ttnn/metal_v2_artifacts.hpp
@@ -14,7 +14,8 @@ namespace ttnn::device_operation {
 
 // Build product of a Metal 2.0 op-porting stepping-stone factory: the immutable
 // ProgramSpec, the mutable ProgramRunArgs, and any op-owned tensors the factory
-// allocates for itself. Returned by a ProgramSpecFactoryConcept factory's
+// allocates for itself. Returned by a ProgramSpecFactoryConcept or
+// CustomProgramSpecFactoryConcept factory's
 // create_program_artifacts method; the framework adapter stamps a Program out of
 // this artifact onto each mesh coordinate range of the workload.
 //

--- a/ttnn/api/ttnn/metal_v2_artifacts.hpp
+++ b/ttnn/api/ttnn/metal_v2_artifacts.hpp
@@ -14,7 +14,7 @@ namespace ttnn::device_operation {
 
 // Build product of a Metal 2.0 op-porting stepping-stone factory: the immutable
 // ProgramSpec, the mutable ProgramRunArgs, and any op-owned tensors the factory
-// allocates for itself. Returned by a MetalV2FactoryConcept factory's
+// allocates for itself. Returned by a ProgramSpecFactoryConcept factory's
 // create_program_artifacts method; the framework adapter stamps a Program out of
 // this artifact onto each mesh coordinate range of the workload.
 //

--- a/ttnn/api/ttnn/operation_concepts.hpp
+++ b/ttnn/api/ttnn/operation_concepts.hpp
@@ -14,6 +14,7 @@
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/graph_tracking.hpp>
 #include <tt-metalium/program_cache.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
 
 #include <cstdint>
 
@@ -87,9 +88,44 @@ concept ProgramDescriptorFactoryConcept = (requires { &T::create_descriptor; } |
 // NOTE: This is a stepping-stone concept for incremental migration of operations to
 // Metal 2.0. It is not designed for production use — the cache-hit fast path re-patches
 // op-owned tensors redundantly rather than skipping them.
+//
+namespace detail {
+template <typename F>
+struct static_fn_return {};
+template <typename R, typename... A>
+struct static_fn_return<R (*)(A...)> {
+    using type = R;
+};
+
+// True iff T has a single static override_runtime_arguments returning ProgramRunArgs. Keyed on the
+// return type, not presence, so the legacy void-returning override_runtime_arguments (some matmul
+// factories) doesn't match. The requires-wrap makes any ill-formed step leave it unsatisfied.
 template <typename T>
-concept MetalV2FactoryConcept = requires { &T::create_program_artifacts; } && !ProgramFactoryConcept<T> &&
-                                !MeshWorkloadFactoryConcept<T> && !ProgramDescriptorFactoryConcept<T>;
+concept HasSpecRuntimeArgsOverride = requires {
+    requires std::same_as<
+        typename static_fn_return<decltype(&T::override_runtime_arguments)>::type,
+        tt::tt_metal::experimental::ProgramRunArgs>;
+};
+}  // namespace detail
+
+// Base spec factory: cache hit refreshes only tensor bindings.
+template <typename T>
+concept ProgramSpecFactoryConcept =
+    requires { &T::create_program_artifacts; } && !ProgramFactoryConcept<T> && !MeshWorkloadFactoryConcept<T> &&
+    !ProgramDescriptorFactoryConcept<T> && !detail::HasSpecRuntimeArgsOverride<T>;
+
+// Spec factory that additionally re-applies per-dispatch runtime args on every cache hit: its
+// override_runtime_arguments returns a ProgramRunArgs applied via UpdateProgramRunArgs (the
+// spec-path analog of the ProgramDescriptor path's get_dynamic_runtime_args). Args it omits are
+// retained from the cache-miss SetProgramRunArgs, so they must be enqueue-loop invariant. Full
+// signature (only the return type is concept-enforced):
+//   static ProgramRunArgs override_runtime_arguments(
+//       const operation_attributes_t&, const tensor_args_t&, tensor_return_value_t&,
+//       const std::optional<ttnn::MeshCoordinate>& = std::nullopt);
+template <typename T>
+concept CustomProgramSpecFactoryConcept =
+    requires { &T::create_program_artifacts; } && detail::HasSpecRuntimeArgsOverride<T> && !ProgramFactoryConcept<T> &&
+    !MeshWorkloadFactoryConcept<T> && !ProgramDescriptorFactoryConcept<T>;
 
 // Detect operations that put create_descriptor directly on the operation struct
 // (no program_factory_t wrapper needed for single-descriptor operations).
@@ -128,7 +164,7 @@ concept HasSelectProgramFactory = requires(
 
 // Validate that all variant alternatives in a program_factory_t satisfy exactly one of
 // ProgramFactoryConcept, MeshWorkloadFactoryConcept, ProgramDescriptorFactoryConcept,
-// or MetalV2FactoryConcept.
+// ProgramSpecFactoryConcept, or CustomProgramSpecFactoryConcept.
 namespace detail {
 template <typename Variant, std::size_t... Is>
 consteval bool all_factories_valid(std::index_sequence<Is...>) {
@@ -136,7 +172,8 @@ consteval bool all_factories_valid(std::index_sequence<Is...>) {
         ((ProgramFactoryConcept<std::variant_alternative_t<Is, Variant>> +
           MeshWorkloadFactoryConcept<std::variant_alternative_t<Is, Variant>> +
           ProgramDescriptorFactoryConcept<std::variant_alternative_t<Is, Variant>> +
-          MetalV2FactoryConcept<std::variant_alternative_t<Is, Variant>>) == 1) &&
+          ProgramSpecFactoryConcept<std::variant_alternative_t<Is, Variant>> +
+          CustomProgramSpecFactoryConcept<std::variant_alternative_t<Is, Variant>>) == 1) &&
         ...);
 }
 }  // namespace detail

--- a/ttnn/api/ttnn/operation_concepts.hpp
+++ b/ttnn/api/ttnn/operation_concepts.hpp
@@ -96,6 +96,12 @@ template <typename R, typename... A>
 struct static_fn_return<R (*)(A...)> {
     using type = R;
 };
+// noexcept-qualified static override: its pointer type is a distinct type, so it needs its own
+// specialization or a noexcept override would be silently misclassified (base instead of custom).
+template <typename R, typename... A>
+struct static_fn_return<R (*)(A...) noexcept> {
+    using type = R;
+};
 
 // True iff T has a single static override_runtime_arguments returning ProgramRunArgs. Keyed on the
 // return type, not presence, so the legacy void-returning override_runtime_arguments (some matmul


### PR DESCRIPTION
### What

Extends the Metal 2.0 op-porting factory infrastructure with a dynamic per-dispatch runtime-argument mechanism for the spec path, and renames the existing spec-factory concept to read as a coherent pair.

**1. Rename (mechanical).** `MetalV2FactoryConcept` → `ProgramSpecFactoryConcept`; adapter `MetalV2MeshWorkloadFactoryAdapter` → `ProgramSpecMeshWorkloadFactoryAdapter`. Scope is the infra headers only: the concept definition, the dispatch `std::visit`, `all_factories_valid`, and the gtest. `ProgramArtifacts` / `metal_v2_artifacts.hpp` keep their names (renaming them is broad include churn, out of scope). Note: quasar op-factory files still reference the old name in **comments only** — left untouched to keep this diff scoped to the infra; no code/compile impact.

**2. New `CustomProgramSpecFactoryConcept`.** A spec factory that, on top of `create_program_artifacts`, provides an `override_runtime_arguments` returning a `ProgramRunArgs`. Its adapter `CustomProgramSpecMeshWorkloadFactoryAdapter` inherits the base cache-**miss** build unchanged; on cache **hit** it applies the factory's `override_runtime_arguments` via `experimental::UpdateProgramRunArgs` instead of the base's tensor-only `UpdateTensorArgs`.

This is the spec-path analog of the ProgramDescriptor path's `get_dynamic_runtime_args`: it lets an op re-apply dynamic runtime args (e.g. an RNG seed) on every dispatch without a program rebuild. Args the override omits are retained from the cache-miss `SetProgramRunArgs`, so they must be declared enqueue-loop invariant in the `ProgramSpec` (enforced at runtime by `UpdateProgramRunArgs`).

The concept is discriminated by the override's **return type** (`ProgramRunArgs`), not its mere presence — so factories carrying the legacy void-returning `override_runtime_arguments` (some quasar matmul factories) stay on the base concept. The two spec concepts are mutually exclusive, so each `program_factory_t` variant alternative dispatches to exactly one adapter.

**3. Base-adapter change (behavior-preserving).** The base spec adapter's MeshDevice sourcing now falls back to `tensor_return_value` when `tensor_args` carries no tensor. No effect on existing ProgramSpec ops (their `tensor_args` always has a tensor, so the fallback never fires); it enables output-only ops.

### Testing

- `tests/ttnn/unit_tests/gtests/test_launch_operation.cpp` gains static_asserts pinning the classification + mutual exclusivity of both spec concepts, plus a compile-coverage instantiation of the custom adapter.
- Built green with `./build_metal.sh` at the original branch point. The branch was then rebased onto current `main` (one trivial conflict, in the MeshDevice-sourcing hunk, resolved) and **not** rebuilt locally after the rebase — PR CI is the build of record.

### Note for reviewers

No production consumer in this PR — coverage is the compile-time concept/adapter checks in the gtest, matching how the base concept (then `MetalV2FactoryConcept`) was originally landed (its gtest comment: "No real op uses create_program_artifacts yet… compile-coverage only"). The first consumer — `rand`, ported to the spec path — lives in a separate stacked draft PR so this one stays infra-only.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/metal2-custom-program-spec-factory)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/metal2-custom-program-spec-factory)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/metal2-custom-program-spec-factory)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/metal2-custom-program-spec-factory)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=dgomez/metal2-custom-program-spec-factory)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:dgomez/metal2-custom-program-spec-factory)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/metal2-custom-program-spec-factory)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/metal2-custom-program-spec-factory)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/metal2-custom-program-spec-factory)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/metal2-custom-program-spec-factory)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/metal2-custom-program-spec-factory)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/metal2-custom-program-spec-factory)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/metal2-custom-program-spec-factory)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/metal2-custom-program-spec-factory)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/metal2-custom-program-spec-factory)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/metal2-custom-program-spec-factory)
