### PR TITLE
[ttnn] rand: migrate to Metal 2.0 spec path (CustomProgramSpecFactoryConcept) + perf

### DIFF
--- a/ttnn/cpp/ttnn/operations/rand/device/kernels/compute_rand_spec.cpp
+++ b/ttnn/cpp/ttnn/operations/rand/device/kernels/compute_rand_spec.cpp
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Metal 2.0 (ProgramSpec) compute kernel for rand: producer of the intermediate DFB.
+// Port of operations/uniform/device/kernels/compute_uniform.cpp to named accessors.
+// seed/from/to are DYNAMIC runtime args (re-applied every dispatch via override_runtime_arguments);
+// tile_offset/units_per_core are enqueue-invariant runtime args.
+#include "api/compute/compute_kernel_api.h"
+#include "api/compute/eltwise_unary/eltwise_unary.h"
+#include "api/compute/eltwise_unary/rand.h"
+#include "api/dataflow/dataflow_buffer.h"
+#include "experimental/kernel_args.h"
+
+void kernel_main() {
+    const uint32_t seed = get_arg(args::seed);
+    union {
+        float f;
+        uint32_t u;
+    } f2u_from, f2u_to, f2u_scale;
+    f2u_from.u = get_arg(args::from);
+    f2u_to.u = get_arg(args::to);
+    f2u_scale.f = f2u_to.f - f2u_from.f;
+    const uint32_t start_id = get_arg(args::tile_offset);
+    const uint32_t num_tiles = get_arg(args::units_per_core);
+    const uint32_t end_id = start_id + num_tiles;
+
+    DataflowBuffer cb_intermed(dfb::intermed);
+
+    init_sfpu(dfb::intermed, dfb::intermed);
+
+    rand_tile_init(seed);
+    for (uint32_t i = start_id; i < end_id; ++i) {
+        cb_intermed.reserve_back(1);
+
+        tile_regs_acquire();
+        rand_tile(0, f2u_from.u, f2u_scale.u);
+        tile_regs_commit();
+
+        tile_regs_wait();
+        pack_tile(0, dfb::intermed, 0);
+        tile_regs_release();
+
+        cb_intermed.push_back(1);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/rand/device/kernels/writer_rand_spec.cpp
+++ b/ttnn/cpp/ttnn/operations/rand/device/kernels/writer_rand_spec.cpp
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Metal 2.0 (ProgramSpec) writer kernel for rand: consumer of the intermediate DFB, writes the
+// generated tiles to the interleaved output. Port of
+// operations/uniform/device/kernels/writer_uniform.cpp to named accessors:
+//   - dst buffer address RTA -> TensorAccessor(tensor::output)
+//   - CircularBuffer(cb_id)  -> DataflowBuffer(dfb::name)
+//   - positional RTAs        -> get_arg(args::name)
+// tile_offset/units_per_core are enqueue-invariant runtime args (unchanged across dispatches).
+#include <tt-metalium/constants.hpp>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/dataflow_buffer.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
+
+using namespace tt;
+
+void kernel_main() {
+    const uint32_t start_id = get_arg(args::tile_offset);
+    const uint32_t num_tiles = get_arg(args::units_per_core);
+    const uint32_t end_id = start_id + num_tiles;
+
+    const auto output_addrg = TensorAccessor(tensor::output);
+
+    DataflowBuffer cb_intermed(dfb::intermed);
+
+    Noc noc;
+
+#ifdef OUTPUT_DTYPE_BFLOAT16
+    // bfloat16 output: convert each Float32 intermediate tile into the dst staging DFB (a
+    // writer self-loop DFB), then NOC-write the packed bf16 page to the output.
+    DataflowBuffer cb_dst(dfb::dst);
+    const uint32_t page_bytes = cb_dst.get_entry_size();
+    cb_dst.reserve_back(1);
+    uint32_t dst_cb_write_ptr = cb_dst.get_write_ptr();
+
+    for (uint32_t i = start_id; i < end_id; ++i) {
+        cb_intermed.wait_front(1);
+        uint32_t intermed_cb_read_ptr = cb_intermed.get_read_ptr();
+        auto intermed_cb_addr = reinterpret_cast<float*>(intermed_cb_read_ptr);
+
+        auto dst_cb_addr = reinterpret_cast<uint8_t*>(dst_cb_write_ptr);
+        for (uint32_t k = 0; k < constants::TILE_WIDTH; k++) {
+            for (uint32_t j = 0; j < constants::TILE_HEIGHT; j++) {
+                float rand_float = *intermed_cb_addr;
+                uint16_t* uint16_ptr = reinterpret_cast<uint16_t*>(&rand_float) + 1;
+                *(uint16_t*)dst_cb_addr = *uint16_ptr;
+                dst_cb_addr += 2;
+                intermed_cb_addr += 1;
+            }
+        }
+        cb_intermed.pop_front(1);
+
+        noc.async_write(CoreLocalMem<uint32_t>(dst_cb_write_ptr), output_addrg, page_bytes, {}, {.page_id = i});
+        noc.async_write_barrier();
+    }
+    // dst_cb is a conversion-staging region (consumed only by direct NOC writes); commit the
+    // reservation so the self-loop DFB is left balanced.
+    cb_dst.push_back(1);
+#else
+    // float32 output: NOC-write the Float32 intermediate tile directly.
+    const uint32_t page_bytes = cb_intermed.get_entry_size();
+    for (uint32_t i = start_id; i < end_id; ++i) {
+        cb_intermed.wait_front(1);
+        uint32_t intermed_cb_read_ptr = cb_intermed.get_read_ptr();
+        noc.async_write(CoreLocalMem<uint32_t>(intermed_cb_read_ptr), output_addrg, page_bytes, {}, {.page_id = i});
+        noc.async_write_barrier();
+        cb_intermed.pop_front(1);
+    }
+#endif
+}

--- a/ttnn/cpp/ttnn/operations/rand/device/rand_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/rand/device/rand_device_operation.hpp
@@ -11,8 +11,8 @@
 
 #include "ttnn/device_operation.hpp"
 #include "ttnn/distributed/types.hpp"
-#include <tt-metalium/program_descriptors.hpp>
-#include <tt-metalium/experimental/program_descriptor_patching.hpp>
+#include "ttnn/metal_v2_artifacts.hpp"
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
 
 namespace ttnn::operations::rand {
 
@@ -42,15 +42,19 @@ struct RandDeviceOperation {
     using spec_return_value_t = tt::tt_metal::TensorSpec;
     using tensor_return_value_t = Tensor;
 
+    // Metal 2.0 spec factory (CustomProgramSpecFactoryConcept): create_program_artifacts returns a
+    // ProgramSpec + ProgramRunArgs; override_runtime_arguments re-applies the DYNAMIC seed/from/to
+    // runtime args (omitted from the cache key) on every cache hit via UpdateProgramRunArgs, so calls
+    // differing only in seed/from/to reuse the cached program instead of recompiling. The seed/from/to
+    // values built in create_program_artifacts must mirror those in override_runtime_arguments — the
+    // test_rand_different_seed_values regression test enforces this.
     struct RandProgramFactory {
-        static tt::tt_metal::ProgramDescriptor create_descriptor(
+        static ttnn::device_operation::ProgramArtifacts create_program_artifacts(
             const operation_attributes_t& operation_attributes,
             const tensor_args_t& tensor_args,
-            tensor_return_value_t& output,
-            const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate = std::nullopt);
+            tensor_return_value_t& output);
 
-        static void override_runtime_arguments(
-            tt::tt_metal::Program& program,
+        static tt::tt_metal::experimental::ProgramRunArgs override_runtime_arguments(
             const operation_attributes_t& operation_attributes,
             const tensor_args_t& tensor_args,
             tensor_return_value_t& output,

--- a/ttnn/cpp/ttnn/operations/rand/device/rand_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/rand/device/rand_program_factory.cpp
@@ -8,15 +8,19 @@
 
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/work_split.hpp>
-#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
 #include "ttnn/tensor/types.hpp"
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+#include "ttnn/operations/core/data_movement_kernel/datamovement_kernel_config.hpp"
 #include "rand_device_operation.hpp"
-#include <tt-metalium/tensor_accessor_args.hpp>
 
 namespace ttnn::operations::rand {
 
 using namespace tt;
 using namespace tt::tt_metal;
+using namespace tt::tt_metal::experimental;
 
 namespace {
 
@@ -25,10 +29,17 @@ std::uniform_int_distribution distribution(1, std::numeric_limits<int32_t>::max(
 
 auto get_random_seed() -> uint32_t { return distribution(rng); }
 
-constexpr const char* WRITER_KERNEL_PATH = "ttnn/cpp/ttnn/operations/uniform/device/kernels/writer_uniform.cpp";
-constexpr const char* COMPUTE_KERNEL_PATH = "ttnn/cpp/ttnn/operations/uniform/device/kernels/compute_uniform.cpp";
+constexpr const char* WRITER_KERNEL_PATH = "ttnn/cpp/ttnn/operations/rand/device/kernels/writer_rand_spec.cpp";
+constexpr const char* COMPUTE_KERNEL_PATH = "ttnn/cpp/ttnn/operations/rand/device/kernels/compute_rand_spec.cpp";
 
-// Work split + per-device seed offset, shared by create_descriptor (cache miss) and
+// Spec resource names (prefixed to stay distinct under unity builds).
+const KernelSpecName RAND_COMPUTE{"rand_compute"};
+const KernelSpecName RAND_WRITER{"rand_writer"};
+const DFBSpecName RAND_INTERMED{"rand_intermed"};
+const DFBSpecName RAND_DST{"rand_dst"};
+const TensorParamName RAND_OUTPUT{"rand_output"};
+
+// Work split + per-device seed offset, shared by create_program_artifacts (cache miss) and
 // override_runtime_arguments (cache hit) so both derive the identical core list and seed offset.
 struct RandWorkSplit {
     uint32_t num_cores = 0;
@@ -84,9 +95,8 @@ uint32_t rand_seed_for_core(
     return attrs.seed != 0 ? attrs.seed + i + device_seed_offset : get_random_seed();
 }
 
-// Per-core work assignment. Single-sourced so the cache-miss build (create_descriptor) and the
-// cache-hit patch (override_runtime_arguments) can never drift on core-group selection or tile_offset
-// accumulation — each derives its runtime args from the same layout.
+// Per-core work assignment (core, units_per_core, tile_offset). Single-sourced so the cache-miss
+// build and the cache-hit override can never drift on core-group selection or tile_offset.
 struct RandCoreWork {
     CoreCoord core;
     uint32_t units_per_core;
@@ -113,144 +123,153 @@ std::vector<RandCoreWork> rand_core_layout(const RandWorkSplit& ws) {
 
 }  // namespace
 
-ProgramDescriptor RandDeviceOperation::RandProgramFactory::create_descriptor(
+ttnn::device_operation::ProgramArtifacts RandDeviceOperation::RandProgramFactory::create_program_artifacts(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& /*tensor_args*/,
-    tensor_return_value_t& output,
-    const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate) {
-    const auto ws = compute_rand_work_split(operation_attributes, output, mesh_dispatch_coordinate);
-    const auto& all_cores = ws.all_cores;
-    const auto num_cores_total = ws.cores.size();
+    tensor_return_value_t& output) {
+    // create_program_artifacts is called once and the resulting spec is stamped across the mesh, so the
+    // (per-device) seed offset is baked at the zero coordinate here; override_runtime_arguments re-applies
+    // the correct per-coordinate seeds on every cache hit.
+    const auto ws = compute_rand_work_split(operation_attributes, output, std::nullopt);
 
-    DataType output_dtype = output.dtype();
-    auto out_data_format = datatype_to_dataformat_converter(output_dtype);
+    const DataType output_dtype = output.dtype();
+    const auto out_data_format = datatype_to_dataformat_converter(output_dtype);
     const uint32_t dtype_tile_size = tile_size(out_data_format);
     const uint32_t intermed_tile_size = tile_size(tt::DataFormat::Float32);
-
-    constexpr uint32_t in_out_num_tiles = 1;
-    constexpr uint32_t intermed_num_tiles = 2;
-
-    constexpr uint32_t intermed_cb_id = CBIndex::c_24;
-    constexpr uint32_t dst_cb_id = CBIndex::c_0;
-
-    ProgramDescriptor desc;
-
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = intermed_num_tiles * intermed_tile_size,
-        .core_ranges = all_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = intermed_cb_id,
-            .data_format = tt::DataFormat::Float32,
-            .page_size = intermed_tile_size,
-        }}},
-    });
-
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = in_out_num_tiles * dtype_tile_size,
-        .core_ranges = all_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = dst_cb_id,
-            .data_format = out_data_format,
-            .page_size = dtype_tile_size,
-        }}},
-    });
-
-    KernelDescriptor::CompileTimeArgs writer_ct_args;
-    writer_ct_args.reserve(8);
-    writer_ct_args.push_back(intermed_cb_id);
-    writer_ct_args.push_back(dst_cb_id);
-    TensorAccessorArgs(*output.buffer()).append_to(writer_ct_args);
-
-    KernelDescriptor writer_desc;
-    writer_desc.kernel_source = WRITER_KERNEL_PATH;
-    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    writer_desc.core_ranges = all_cores;
-    writer_desc.compile_time_args = std::move(writer_ct_args);
-    writer_desc.config = WriterConfigDescriptor{};
+    const bool is_bfloat16 = output_dtype == DataType::BFLOAT16;
     switch (output_dtype) {
-        case DataType::BFLOAT16: writer_desc.defines.emplace_back("OUTPUT_DTYPE_BFLOAT16", "1"); break;
-        case DataType::FLOAT32: writer_desc.defines.emplace_back("OUTPUT_DTYPE_FLOAT32", "1"); break;
+        case DataType::BFLOAT16:
+        case DataType::FLOAT32: break;
         default:
             // The writer kernel only implements float32 and bfloat16 output paths.
-            // Fail fast here so we never instantiate a program that can hang at runtime.
             TT_THROW("RandDeviceOperation: unsupported output dtype for writer kernel");
     }
-    writer_desc.runtime_args.reserve(num_cores_total);
-
-    KernelDescriptor compute_desc;
-    compute_desc.kernel_source = COMPUTE_KERNEL_PATH;
-    compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    compute_desc.core_ranges = all_cores;
-    compute_desc.compile_time_args = {intermed_cb_id};
-    compute_desc.config = ComputeConfigDescriptor{
-        .math_fidelity = tt::tt_metal::MathFidelity::HiFi4,
-        .fp32_dest_acc_en = true,  // if fp32_dest_acc_en set to false a precision error may occur which makes
-                                   // generated number out of range [from, to)
-        .dst_full_sync_en = false,
-        .math_approx_mode = true,
-    };
-    compute_desc.runtime_args.reserve(num_cores_total);
 
     const float eps = 1e-6f;
     const uint32_t from_bits = std::bit_cast<uint32_t>(operation_attributes.from);
     const uint32_t to_bits = std::bit_cast<uint32_t>(operation_attributes.to - eps);
+
+    // ---- ProgramSpec ----
+    ProgramSpec spec;
+    spec.name = "rand";
+
+    spec.tensor_parameters = {TensorParameter{.unique_id = RAND_OUTPUT, .spec = output.tensor_spec()}};
+
+    // Intermediate DFB: compute PRODUCES Float32 tiles, writer CONSUMES them (double-buffered).
+    spec.dataflow_buffers.push_back(DataflowBufferSpec{
+        .unique_id = RAND_INTERMED,
+        .entry_size = intermed_tile_size,
+        .num_entries = 2,
+        .data_format_metadata = tt::DataFormat::Float32,
+    });
+    // bfloat16 output uses a writer-local staging DFB (self-loop) for the fp32->bf16 conversion.
+    if (is_bfloat16) {
+        spec.dataflow_buffers.push_back(DataflowBufferSpec{
+            .unique_id = RAND_DST,
+            .entry_size = dtype_tile_size,
+            .num_entries = 1,
+            .data_format_metadata = out_data_format,
+        });
+    }
+
+    // Compute kernel: producer of the intermediate DFB.
+    KernelSpec compute{
+        .unique_id = RAND_COMPUTE,
+        .source = COMPUTE_KERNEL_PATH,
+        .dfb_bindings = {ProducerOf(RAND_INTERMED, "intermed")},
+        .runtime_arg_schema = {.runtime_arg_names = {"seed", "from", "to", "tile_offset", "units_per_core"}},
+        .hw_config = ttnn::to_compute_hardware_config(
+            output.device()->arch(),
+            ttnn::ComputeKernelConfig{
+                .math_fidelity = MathFidelity::HiFi4,
+                // if fp32_dest_acc_en is false a precision error may make numbers out of range [from, to)
+                .math_approx_mode = true,
+                .fp32_dest_acc_en = true,
+                .dst_full_sync_en = false,
+            }),
+    };
+    // tile_offset/units_per_core are static per core; only seed/from/to change per dispatch.
+    compute.advanced_options.enqueue_invariant_runtime_args = {"tile_offset", "units_per_core"};
+
+    // Writer kernel: consumer of the intermediate DFB; writes to the interleaved output.
+    KernelSpec writer{
+        .unique_id = RAND_WRITER,
+        .source = WRITER_KERNEL_PATH,
+        .dfb_bindings = {ConsumerOf(RAND_INTERMED, "intermed")},
+        .tensor_bindings = {TensorBinding{.tensor_parameter_name = RAND_OUTPUT, .accessor_name = "output"}},
+        .runtime_arg_schema = {.runtime_arg_names = {"tile_offset", "units_per_core"}},
+        .hw_config = ttnn::create_writer_datamovement_config(output.device()->arch()),
+    };
+    writer.advanced_options.enqueue_invariant_runtime_args = {"tile_offset", "units_per_core"};
+    if (is_bfloat16) {
+        writer.compiler_options.defines.emplace("OUTPUT_DTYPE_BFLOAT16", "1");
+        // Writer-local self-loop staging DFB (one PRODUCER + one CONSUMER on the same kernel).
+        writer.dfb_bindings.push_back(ProducerOf(RAND_DST, "dst"));
+        writer.dfb_bindings.push_back(ConsumerOf(RAND_DST, "dst"));
+    }
+
+    spec.kernels.push_back(compute);
+    spec.kernels.push_back(writer);
+
+    Group<KernelSpecName> wu_kernels = {RAND_COMPUTE, RAND_WRITER};
+    spec.work_units = {WorkUnitSpec{.name = "main", .kernels = wu_kernels, .target_nodes = ws.all_cores}};
+
+    // ---- ProgramRunArgs ----
+    ProgramRunArgs run_args;
+    KernelRunArgs compute_run{.kernel = RAND_COMPUTE};
+    KernelRunArgs writer_run{.kernel = RAND_WRITER};
 
     const auto layout = rand_core_layout(ws);
     for (int i = 0; i < static_cast<int>(layout.size()); ++i) {
         const auto& [core, units_per_core, tile_offset] = layout[i];
         const uint32_t seed = rand_seed_for_core(operation_attributes, i, ws.device_seed_offset);
 
-        // seed/from/to are DYNAMIC (omitted from the cache key / attribute_names): baked here for the
-        // cache-miss build, and re-applied on every cache hit via override_runtime_arguments().
-        compute_desc.runtime_args.emplace_back(
-            core, KernelDescriptor::CoreRuntimeArgs{seed, from_bits, to_bits, tile_offset, units_per_core});
-
-        // Register the output address as a Buffer* binding so rand takes the fast cache-hit path
-        // (real program caching) with the address correctly re-patched each dispatch.
-        writer_desc.emplace_runtime_args(core, {output.buffer(), tile_offset, units_per_core});
+        AddRuntimeArgsForNode(
+            compute_run.runtime_arg_values,
+            core,
+            {{"seed", seed},
+             {"from", from_bits},
+             {"to", to_bits},
+             {"tile_offset", tile_offset},
+             {"units_per_core", units_per_core}});
+        AddRuntimeArgsForNode(
+            writer_run.runtime_arg_values, core, {{"tile_offset", tile_offset}, {"units_per_core", units_per_core}});
     }
 
-    desc.kernels.push_back(std::move(writer_desc));
-    desc.kernels.push_back(std::move(compute_desc));
+    run_args.kernel_run_args.push_back(compute_run);
+    run_args.kernel_run_args.push_back(writer_run);
+    run_args.tensor_args.emplace(RAND_OUTPUT, TensorArgument{output.mesh_tensor()});
 
-    return desc;
+    return ttnn::device_operation::ProgramArtifacts{.spec = std::move(spec), .run_params = std::move(run_args)};
 }
 
-void RandDeviceOperation::RandProgramFactory::override_runtime_arguments(
-    tt::tt_metal::Program& program,
+tt::tt_metal::experimental::ProgramRunArgs RandDeviceOperation::RandProgramFactory::override_runtime_arguments(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& /*tensor_args*/,
     tensor_return_value_t& output,
     const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate) {
-    // Re-derive every per-dispatch arg on each cache hit from the same builder create_descriptor uses:
-    // compute's seed/from/to and the writer's output address. override replaces resolve_bindings, so
-    // the address is ours to re-apply too. Push order in create_descriptor: writer 0, compute 1.
-    constexpr uint32_t writer_kernel_idx = 0;
-    constexpr uint32_t compute_kernel_idx = 1;
-
+    // seed/from/to are DYNAMIC (omitted from the cache key) and re-applied every dispatch; the static
+    // tile_offset/units_per_core args are enqueue-invariant and retained from the cache-miss
+    // SetProgramRunArgs. The output tensor arg is re-supplied so its (freshly allocated) address is
+    // re-patched (UpdateProgramRunArgs applies both).
     const auto ws = compute_rand_work_split(operation_attributes, output, mesh_dispatch_coordinate);
+
     const float eps = 1e-6f;
     const uint32_t from_bits = std::bit_cast<uint32_t>(operation_attributes.from);
     const uint32_t to_bits = std::bit_cast<uint32_t>(operation_attributes.to - eps);
-    const uint32_t out_addr = output.buffer()->address();
 
+    ProgramRunArgs run_args;
+    KernelRunArgs compute_run{.kernel = RAND_COMPUTE};
     const auto layout = rand_core_layout(ws);
     for (int i = 0; i < static_cast<int>(layout.size()); ++i) {
-        const auto& [core, units_per_core, tile_offset] = layout[i];
+        const auto& core = layout[i].core;
         const uint32_t seed = rand_seed_for_core(operation_attributes, i, ws.device_seed_offset);
-
-        auto& compute_args = tt::tt_metal::GetRuntimeArgs(program, compute_kernel_idx, core);
-        compute_args[0] = seed;
-        compute_args[1] = from_bits;
-        compute_args[2] = to_bits;
-        compute_args[3] = tile_offset;
-        compute_args[4] = units_per_core;
-
-        auto& writer_args = tt::tt_metal::GetRuntimeArgs(program, writer_kernel_idx, core);
-        writer_args[0] = out_addr;
-        writer_args[1] = tile_offset;
-        writer_args[2] = units_per_core;
+        AddRuntimeArgsForNode(
+            compute_run.runtime_arg_values, core, {{"seed", seed}, {"from", from_bits}, {"to", to_bits}});
     }
+    run_args.kernel_run_args.push_back(compute_run);
+    run_args.tensor_args.emplace(RAND_OUTPUT, TensorArgument{output.mesh_tensor()});
+    return run_args;
 }
 
 }  // namespace ttnn::operations::rand


### PR DESCRIPTION
> **Stacked on #50942** (base = `dgomez/metal2-custom-program-spec-factory`). Diff is rand-only. Exploratory — for validating the infra + comparing spec-override vs descriptor-override host cost; not intended to merge as-is.

### What

Migrates `rand` from the ProgramDescriptor path (current `main`, PR #50488: `create_descriptor` + descriptor-style `override_runtime_arguments` patched via `GetRuntimeArgs`) to the **Metal 2.0 spec path** on the new `CustomProgramSpecFactoryConcept`:

- `create_program_artifacts` returns a `ProgramSpec` + `ProgramRunArgs`.
- `override_runtime_arguments` returns a `ProgramRunArgs` applied via `UpdateProgramRunArgs` on every cache hit — `seed`/`from`/`to` are re-applied; `tile_offset`/`units_per_core` are declared enqueue-invariant and retained; the output tensor is re-supplied so its (freshly allocated) address re-patches.
- New named-accessor kernels under `rand/device/kernels/` (`compute_rand_spec.cpp`, `writer_rand_spec.cpp`) ported from the shared `uniform` positional kernels: `CircularBuffer`→`DataflowBuffer(dfb::)`, buffer-address RTA→`TensorAccessor(tensor::)`, positional args→`get_arg(args::)`. The intermediate CB is a plain compute→writer DFB; the bf16 fp32→bf16 staging CB is a writer self-loop DFB (one PRODUCER + one CONSUMER on the same kernel).

### Correctness

`tests/ttnn/nightly/unit_tests/operations/rand/test_rand.py`: **44 passed, 10 skipped** (multi-device), 7 xfailed, 11 xpassed — same as the descriptor baseline. Includes `test_rand_different_seed_values` (proves the cache-hit override re-applies dynamic scalars) and `test_rand_different_from_to_values`, across fp32/bf16, tile + row-major, all memory configs.

### Perf — spec-override vs descriptor-override (cache-hit host dispatch, median µs/op)

Same op, same base, only the override mechanism differs. Measured on a single Wormhole device: warmup (cache miss) then 300 same-shape `ttnn.rand` calls (cache hits), one device sync at the end; median of 5 trials.

| shape | descriptor-override (baseline) | spec-override (this PR) | Δ |
|---|---|---|---|
| 512² | 41.5 | 69.3 | **+28 µs (~1.7×)** |
| 1024² | 82.1 | 82.6 | ~0 |
| 2048² | 271.6 | 271.6 | ~0 |
| 4096² | 1023.8 | 1024.1 | ~0 |

The spec-override path costs **~28 µs/op more on the host-bound small shape**, and is at parity once the op is device-execution-bound (larger shapes hide the host cost). This is consistent with the base spec adapter's known-unoptimized per-cache-hit path: it builds a fresh heap `ProgramRunArgs` table and runs full `UpdateProgramRunArgs` validation each dispatch, vs the descriptor path's direct in-place `GetRuntimeArgs` writes. A data point for the descriptors-vs-specs decision, not a recommendation to merge.

### Build / measurement note

Built and measured in an isolated worktree off the infra branch (rebased onto current `main`); the main checkout was untouched. This branch is stacked on the infra PR — merge/CI should target the infra branch first.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/rand-spec-migration)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/rand-spec-migration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/rand-spec-migration)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/rand-spec-migration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=dgomez/rand-spec-migration)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:dgomez/rand-spec-migration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/rand-spec-migration)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/rand-spec-migration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/rand-spec-migration)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/rand-spec-migration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/rand-spec-migration)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/rand-spec-migration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/rand-spec-migration)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/rand-spec-migration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/rand-spec-migration)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/rand-spec-migration)