### PR TITLE
[ttnn] Add validate_program_args config (skip Metal 2.0 host-side arg validation off-CI)

### DIFF
--- a/.github/workflows/galaxy-sanity-impl.yaml
+++ b/.github/workflows/galaxy-sanity-impl.yaml
@@ -64,6 +64,7 @@ jobs:
         LD_LIBRARY_PATH: /work/build/lib
         LOGURU_LEVEL: INFO
         GTEST_OUTPUT: xml:/work/generated/test_reports/
+        TTNN_CONFIG_OVERRIDES: '{"validate_program_run_args": true}'
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G

--- a/.github/workflows/galaxy-sanity-impl.yaml
+++ b/.github/workflows/galaxy-sanity-impl.yaml
@@ -64,7 +64,7 @@ jobs:
         LD_LIBRARY_PATH: /work/build/lib
         LOGURU_LEVEL: INFO
         GTEST_OUTPUT: xml:/work/generated/test_reports/
-        TTNN_CONFIG_OVERRIDES: '{"validate_program_run_args": true}'
+        TTNN_CONFIG_OVERRIDES: '{"validate_program_args": true}'
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G

--- a/.github/workflows/ops-sanity-impl.yaml
+++ b/.github/workflows/ops-sanity-impl.yaml
@@ -88,6 +88,7 @@ jobs:
         ARCH_NAME: ${{ (contains(matrix.test-group.sku, 'bh_') || contains(matrix.test-group.sku, 'blackhole')) && 'blackhole' || 'wormhole_b0' }}
         LOGURU_LEVEL: INFO
         PYTHONPATH: /work
+        TTNN_CONFIG_OVERRIDES: '{"validate_program_run_args": true}'
       volumes:
         - ${{ github.workspace }}/docker-job:/work
         - /dev/hugepages-1G:/dev/hugepages-1G

--- a/.github/workflows/ops-sanity-impl.yaml
+++ b/.github/workflows/ops-sanity-impl.yaml
@@ -88,7 +88,7 @@ jobs:
         ARCH_NAME: ${{ (contains(matrix.test-group.sku, 'bh_') || contains(matrix.test-group.sku, 'blackhole')) && 'blackhole' || 'wormhole_b0' }}
         LOGURU_LEVEL: INFO
         PYTHONPATH: /work
-        TTNN_CONFIG_OVERRIDES: '{"validate_program_run_args": true}'
+        TTNN_CONFIG_OVERRIDES: '{"validate_program_args": true}'
       volumes:
         - ${{ github.workspace }}/docker-job:/work
         - /dev/hugepages-1G:/dev/hugepages-1G

--- a/.github/workflows/runtime-sanity-tests-impl.yaml
+++ b/.github/workflows/runtime-sanity-tests-impl.yaml
@@ -120,6 +120,7 @@ jobs:
         LOGURU_LEVEL: INFO
         GTEST_OUTPUT: xml:/work/generated/test_reports/
         LSAN_OPTIONS: suppressions=/usr/share/tt-metalium/lsan.supp
+        TTNN_CONFIG_OVERRIDES: '{"validate_program_run_args": true}'
       volumes:
         - ${{ github.workspace }}/docker-job:/work
         - /dev/hugepages-1G:/dev/hugepages-1G

--- a/.github/workflows/runtime-sanity-tests-impl.yaml
+++ b/.github/workflows/runtime-sanity-tests-impl.yaml
@@ -120,7 +120,7 @@ jobs:
         LOGURU_LEVEL: INFO
         GTEST_OUTPUT: xml:/work/generated/test_reports/
         LSAN_OPTIONS: suppressions=/usr/share/tt-metalium/lsan.supp
-        TTNN_CONFIG_OVERRIDES: '{"validate_program_run_args": true}'
+        TTNN_CONFIG_OVERRIDES: '{"validate_program_args": true}'
       volumes:
         - ${{ github.workspace }}/docker-job:/work
         - /dev/hugepages-1G:/dev/hugepages-1G

--- a/.github/workflows/t3000-sanity-tests-impl.yaml
+++ b/.github/workflows/t3000-sanity-tests-impl.yaml
@@ -95,6 +95,7 @@ jobs:
         ARCH_NAME: wormhole_b0
         LOGURU_LEVEL: INFO
         GTEST_OUTPUT: xml:/work/generated/test_reports/
+        TTNN_CONFIG_OVERRIDES: '{"validate_program_run_args": true}'
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G

--- a/.github/workflows/t3000-sanity-tests-impl.yaml
+++ b/.github/workflows/t3000-sanity-tests-impl.yaml
@@ -95,7 +95,7 @@ jobs:
         ARCH_NAME: wormhole_b0
         LOGURU_LEVEL: INFO
         GTEST_OUTPUT: xml:/work/generated/test_reports/
-        TTNN_CONFIG_OVERRIDES: '{"validate_program_run_args": true}'
+        TTNN_CONFIG_OVERRIDES: '{"validate_program_args": true}'
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G

--- a/.github/workflows/ttnn-sanity-tests-impl.yaml
+++ b/.github/workflows/ttnn-sanity-tests-impl.yaml
@@ -182,6 +182,7 @@ jobs:
         LOGURU_LEVEL: INFO
         PYTHONPATH: /work
         TT_LOGGER_LEVEL: warn
+        TTNN_CONFIG_OVERRIDES: '{"validate_program_run_args": true}'
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
@@ -241,7 +242,7 @@ jobs:
       - name: Set ttnn fast runtime if exists in config
         if: ${{ matrix.test-group.fast_runtime_mode_off }}
         run: |
-          echo "TTNN_CONFIG_OVERRIDES={\"enable_fast_runtime_mode\": false}" >> $GITHUB_ENV
+          echo "TTNN_CONFIG_OVERRIDES={\"enable_fast_runtime_mode\": false, \"validate_program_run_args\": true}" >> $GITHUB_ENV
 
       - name: Set up coverage profiling
         if: ${{ inputs.collect-coverage }}

--- a/.github/workflows/ttnn-sanity-tests-impl.yaml
+++ b/.github/workflows/ttnn-sanity-tests-impl.yaml
@@ -182,7 +182,7 @@ jobs:
         LOGURU_LEVEL: INFO
         PYTHONPATH: /work
         TT_LOGGER_LEVEL: warn
-        TTNN_CONFIG_OVERRIDES: '{"validate_program_run_args": true}'
+        TTNN_CONFIG_OVERRIDES: '{"validate_program_args": true}'
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
@@ -242,7 +242,7 @@ jobs:
       - name: Set ttnn fast runtime if exists in config
         if: ${{ matrix.test-group.fast_runtime_mode_off }}
         run: |
-          echo "TTNN_CONFIG_OVERRIDES={\"enable_fast_runtime_mode\": false, \"validate_program_run_args\": true}" >> $GITHUB_ENV
+          echo "TTNN_CONFIG_OVERRIDES={\"enable_fast_runtime_mode\": false, \"validate_program_args\": true}" >> $GITHUB_ENV
 
       - name: Set up coverage profiling
         if: ${{ inputs.collect-coverage }}

--- a/ttnn/api/ttnn/config.hpp
+++ b/ttnn/api/ttnn/config.hpp
@@ -26,6 +26,8 @@ struct Config {
         std::filesystem::path tmp_dir = "/tmp/ttnn";
         bool enable_model_cache = false;
         bool enable_fast_runtime_mode = true;
+        // Validate Metal 2.0 ProgramRunArgs on Set/UpdateProgramRunArgs. Off by default; CI turns it on.
+        bool validate_program_run_args = false;
         bool throw_exception_on_fallback = false;
         bool enable_logging = false;
         bool enable_graph_report = false;

--- a/ttnn/api/ttnn/config.hpp
+++ b/ttnn/api/ttnn/config.hpp
@@ -26,8 +26,9 @@ struct Config {
         std::filesystem::path tmp_dir = "/tmp/ttnn";
         bool enable_model_cache = false;
         bool enable_fast_runtime_mode = true;
-        // Validate Metal 2.0 ProgramRunArgs on Set/UpdateProgramRunArgs. Off by default; CI turns it on.
-        bool validate_program_run_args = false;
+        // Validate the Metal 2.0 host-side program args: the ProgramSpec on MakeProgramFromSpec and the
+        // ProgramRunArgs on Set/UpdateProgramRunArgs. Off by default; CI turns it on.
+        bool validate_program_args = false;
         bool throw_exception_on_fallback = false;
         bool enable_logging = false;
         bool enable_graph_report = false;

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -28,6 +28,7 @@
 #include <tuple>
 #include "ttnn/distributed/types.hpp"
 #include "ttnn/mesh_device_operation_utils.hpp"
+#include "ttnn/config.hpp"
 #include "ttnn/metal_v2_artifacts.hpp"
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
 #include "ttnn/operation_concepts.hpp"
@@ -905,11 +906,12 @@ public:
             auto op_owned_tensors =
                 std::make_shared<std::vector<tt::tt_metal::MeshTensor>>(std::move(artifacts.op_owned_tensors));
 
+            const bool skip_validation = !ttnn::CONFIG.get<"validate_program_run_args">();
             tt::tt_metal::distributed::MeshWorkload mesh_workload;
             std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
             for (const auto& range : tensor_coords.ranges()) {
                 auto program = tt::tt_metal::experimental::MakeProgramFromSpec(*mesh_device, artifacts.spec);
-                tt::tt_metal::experimental::SetProgramRunArgs(program, artifacts.run_params);
+                tt::tt_metal::experimental::SetProgramRunArgs(program, artifacts.run_params, skip_validation);
                 shared_variables.emplace(
                     range, shared_variables_t{.bindings = bindings, .op_owned_tensors = op_owned_tensors});
                 mesh_workload.add_program(range, std::move(program));
@@ -962,13 +964,14 @@ public:
             const operation_attributes_t& attrs,
             const tensor_args_t& tensor_args,
             tensor_return_value_t& tensor_return_value) {
+            const bool skip_validation = !ttnn::CONFIG.get<"validate_program_run_args">();
             for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
                 auto run_args = CustomSpecFactory::override_runtime_arguments(
                     attrs,
                     tensor_args,
                     tensor_return_value,
                     std::optional<ttnn::MeshCoordinate>(coordinate_range.start_coord()));
-                tt::tt_metal::experimental::UpdateProgramRunArgs(program, run_args);
+                tt::tt_metal::experimental::UpdateProgramRunArgs(program, run_args, skip_validation);
             }
         }
     };

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -906,11 +906,12 @@ public:
             auto op_owned_tensors =
                 std::make_shared<std::vector<tt::tt_metal::MeshTensor>>(std::move(artifacts.op_owned_tensors));
 
-            const bool skip_validation = !ttnn::CONFIG.get<"validate_program_run_args">();
+            const bool skip_validation = !ttnn::CONFIG.get<"validate_program_args">();
             tt::tt_metal::distributed::MeshWorkload mesh_workload;
             std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
             for (const auto& range : tensor_coords.ranges()) {
-                auto program = tt::tt_metal::experimental::MakeProgramFromSpec(*mesh_device, artifacts.spec);
+                auto program =
+                    tt::tt_metal::experimental::MakeProgramFromSpec(*mesh_device, artifacts.spec, skip_validation);
                 tt::tt_metal::experimental::SetProgramRunArgs(program, artifacts.run_params, skip_validation);
                 shared_variables.emplace(
                     range, shared_variables_t{.bindings = bindings, .op_owned_tensors = op_owned_tensors});
@@ -964,7 +965,7 @@ public:
             const operation_attributes_t& attrs,
             const tensor_args_t& tensor_args,
             tensor_return_value_t& tensor_return_value) {
-            const bool skip_validation = !ttnn::CONFIG.get<"validate_program_run_args">();
+            const bool skip_validation = !ttnn::CONFIG.get<"validate_program_args">();
             for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
                 auto run_args = CustomSpecFactory::override_runtime_arguments(
                     attrs,


### PR DESCRIPTION
### What

Adds a `ttnn.CONFIG` flag **`validate_program_args`** (default `false`) that gates the Metal 2.0 host-side program-arg validation. The spec-factory adapters pass `skip_validation = !validate_program_args` to all three call sites:

- `MakeProgramFromSpec` — cache miss, the Step 1b semantic pass (`ValidateProgramSpec`),
- `SetProgramRunArgs` — cache miss,
- `UpdateProgramRunArgs` — cache hit.

- **Off by default** → prod, models, and perf tests skip the host-side validation overhead.
- **Device-sanity CI turns it on** via `TTNN_CONFIG_OVERRIDES={"validate_program_args": true}` — the same mechanism CI already uses to flip `enable_fast_runtime_mode`. That keeps the validation safety net exactly where regressions are caught, so a bad spec can't silently ship.
- The field is reflection-bound (`reflect::for_each` over `Config::attributes_t`), so it auto-exposes on `ttnn.CONFIG` and via `TTNN_CONFIG_OVERRIDES` / the JSON config with no extra pybind. `Config::validate()` only special-cases named fields, so the new flag falls through with no extra handling.

Note the cache-miss path keeps its structural diagnostics regardless of the flag: `MakeProgramFromSpec` Step 1a (`CollectSpecData`) and the Gen1 multi-binding risc-mask check in Step 2b always run. Only the Step 1b semantic pass is gated.

### CI wiring

The flag is set to `true` in the five device-sanity workflows:

- `.github/workflows/galaxy-sanity-impl.yaml`
- `.github/workflows/ops-sanity-impl.yaml`
- `.github/workflows/runtime-sanity-tests-impl.yaml`
- `.github/workflows/t3000-sanity-tests-impl.yaml`
- `.github/workflows/ttnn-sanity-tests-impl.yaml` (both the job-level env and the `fast_runtime_mode_off` step, which merges both keys into `$GITHUB_ENV` rather than clobbering)

### Perf — validation cost

Host-bound `ttnn.rand` (32×32-tile grid, **cache-hit dispatch**, median of 5 trials × 300 iters), spec-override path:

| validate_program_args | 512² µs/op |
|---|---|
| `true` (CI mode) | 75.8 |
| `false` (default) | 60.7 |

≈ **15 µs/op** saved on the cache-hit path (`UpdateProgramRunArgs`). Larger, device-bound shapes show no delta. This measurement predates the `MakeProgramFromSpec` gating, so the cache-miss saving (`ValidateProgramSpec` + `SetProgramRunArgs`) is on top of these numbers and not quantified here.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/ttnn-validate-program-run-args)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/ttnn-validate-program-run-args)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/ttnn-validate-program-run-args)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/ttnn-validate-program-run-args)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=dgomez/ttnn-validate-program-run-args)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:dgomez/ttnn-validate-program-run-args)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/ttnn-validate-program-run-args)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/ttnn-validate-program-run-args)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/ttnn-validate-program-run-args)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/ttnn-validate-program-run-args)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/ttnn-validate-program-run-args)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/ttnn-validate-program-run-args)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/ttnn-validate-program-run-args)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/ttnn-validate-program-run-args)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/ttnn-validate-program-run-args)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/ttnn-validate-program-run-args)
