### PR TITLE
Feat: Query Class For FSD Hierarchy Fields

### DIFF
--- a/tools/scaleout/CMakeLists.txt
+++ b/tools/scaleout/CMakeLists.txt
@@ -49,6 +49,7 @@ target_sources(
             cabling_generator/cabling_generator.hpp
             cabling_generator/regen_descriptors.hpp
             connector/connector.hpp
+            factory_system_descriptor/query.hpp
             factory_system_descriptor/utils.hpp
             node/node_types.hpp
     PRIVATE
@@ -58,6 +59,7 @@ target_sources(
         cabling_generator/cabling_generator.cpp
         cabling_generator/regen_descriptors.cpp
         connector/connector.cpp
+        factory_system_descriptor/query.cpp
         factory_system_descriptor/utils.cpp
         ${GENERATED_PROTO_SRCS}
 )

--- a/tools/scaleout/cabling_generator/cabling_generator.cpp
+++ b/tools/scaleout/cabling_generator/cabling_generator.cpp
@@ -16,6 +16,7 @@
 #include <functional>
 #include <unordered_set>
 #include <fmt/base.h>
+#include <fmt/ranges.h>
 #include <google/protobuf/text_format.h>
 #include <tt-logger/tt-logger.hpp>
 #include <tt_stl/caseless_comparison.hpp>
@@ -2550,6 +2551,9 @@ void CablingGenerator::apply_instance_filter(
     std::set<HostId> kept_host_ids;
     std::vector<bool> include_used(includes.size(), false);
     std::vector<bool> exclude_used(excludes.size(), false);
+    // Full instance paths each filter matched (for logging + multi-parent ambiguity detection).
+    std::vector<std::vector<std::vector<std::string>>> include_matches(includes.size());
+    std::vector<std::vector<std::vector<std::string>>> exclude_matches(excludes.size());
 
     // A suffix-matched filter applies to its instance's whole subtree (carried via
     // included/excluded_by_ancestor). Keep a leaf iff base-selected (or no include) and not excluded.
@@ -2565,12 +2569,14 @@ void CablingGenerator::apply_instance_filter(
             for (size_t i = 0; i < includes.size(); ++i) {
                 if (path_is_suffix(includes[i], prefix)) {
                     include_used[i] = true;
+                    include_matches[i].push_back(prefix);
                     included_here = true;
                 }
             }
             for (size_t i = 0; i < excludes.size(); ++i) {
                 if (path_is_suffix(excludes[i], prefix)) {
                     exclude_used[i] = true;
+                    exclude_matches[i].push_back(prefix);
                     excluded_here = true;
                 }
             }
@@ -2611,6 +2617,44 @@ void CablingGenerator::apply_instance_filter(
     if (kept_host_ids.empty()) {
         throw std::runtime_error("Instance filter selected no nodes");
     }
+
+    // Report what each filter matched. Matching is suffix-based and fully inclusive: a filter selects the
+    // whole subtree of EVERY instance whose path ends with it. When a (possibly colliding) name matches
+    // instances under more than one parent, warn - the selection is broader than a unique name would give.
+    auto report_filter = [](const char* kind,
+                            const std::vector<std::vector<std::string>>& filters,
+                            const std::vector<std::vector<std::vector<std::string>>>& matches) {
+        for (size_t i = 0; i < filters.size(); ++i) {
+            std::vector<std::string> joined_paths;
+            std::set<std::string> parents;
+            for (const auto& path : matches[i]) {
+                joined_paths.push_back(join_instance_path(path));
+                std::vector<std::string> parent(
+                    path.begin(), path.end() - static_cast<std::ptrdiff_t>(filters[i].size()));
+                parents.insert(join_instance_path(parent));
+            }
+            log_info(
+                tt::LogDistributed,
+                "Instance filter {} '{}' matched {} instance(s): {}",
+                kind,
+                join_instance_path(filters[i]),
+                joined_paths.size(),
+                fmt::join(joined_paths, ", "));
+            if (parents.size() > 1) {
+                log_warning(
+                    tt::LogDistributed,
+                    "Instance filter {} '{}' is ambiguous: matched instances under {} different parents; every "
+                    "match's subtree is selected. Use a longer path to disambiguate. Matches: {}",
+                    kind,
+                    join_instance_path(filters[i]),
+                    parents.size(),
+                    fmt::join(joined_paths, ", "));
+            }
+        }
+    };
+    report_filter("include", includes, include_matches);
+    report_filter("exclude", excludes, exclude_matches);
+    log_info(tt::LogDistributed, "Instance filter selected {} node(s)", kept_host_ids.size());
 
     // Prune structure: keep nodes whose host_id survived, and subgraphs with any surviving node.
     auto prune = [&](auto& self, ResolvedGraphInstance& graph) -> bool {

--- a/tools/scaleout/cabling_generator/cabling_generator.cpp
+++ b/tools/scaleout/cabling_generator/cabling_generator.cpp
@@ -2551,7 +2551,7 @@ void CablingGenerator::apply_instance_filter(
     std::set<HostId> kept_host_ids;
     std::vector<bool> include_used(includes.size(), false);
     std::vector<bool> exclude_used(excludes.size(), false);
-    // Full instance paths each filter matched (for logging + multi-parent ambiguity detection).
+    // Full instance paths each filter matched (for logging + nested-lineage ambiguity detection).
     std::vector<std::vector<std::vector<std::string>>> include_matches(includes.size());
     std::vector<std::vector<std::vector<std::string>>> exclude_matches(excludes.size());
 
@@ -2618,20 +2618,16 @@ void CablingGenerator::apply_instance_filter(
         throw std::runtime_error("Instance filter selected no nodes");
     }
 
-    // Report what each filter matched. Matching is suffix-based and fully inclusive: a filter selects the
-    // whole subtree of EVERY instance whose path ends with it. When a (possibly colliding) name matches
-    // instances under more than one parent, warn - the selection is broader than a unique name would give.
+    // Log each filter's matches, and warn on nested-lineage ambiguity: a name matching both an instance and
+    // a descendant of it (e.g. 'node_0' -> 'sp_0/node_0' and 'sp_0/node_0/node_0'). Fan-out across distinct
+    // parents ('sp_0/node_0' and 'sp_1/node_0') is intended, not ambiguous.
     auto report_filter = [](const char* kind,
                             const std::vector<std::vector<std::string>>& filters,
                             const std::vector<std::vector<std::vector<std::string>>>& matches) {
         for (size_t i = 0; i < filters.size(); ++i) {
             std::vector<std::string> joined_paths;
-            std::set<std::string> parents;
             for (const auto& path : matches[i]) {
                 joined_paths.push_back(join_instance_path(path));
-                std::vector<std::string> parent(
-                    path.begin(), path.end() - static_cast<std::ptrdiff_t>(filters[i].size()));
-                parents.insert(join_instance_path(parent));
             }
             log_info(
                 tt::LogDistributed,
@@ -2640,14 +2636,27 @@ void CablingGenerator::apply_instance_filter(
                 join_instance_path(filters[i]),
                 joined_paths.size(),
                 fmt::join(joined_paths, ", "));
-            if (parents.size() > 1) {
+            // Ambiguous iff one match is a strict path prefix of another (same lineage, name recurs).
+            bool nested = false;
+            for (size_t a = 0; a < matches[i].size() && !nested; ++a) {
+                for (size_t b = 0; b < matches[i].size(); ++b) {
+                    const auto& ancestor = matches[i][a];
+                    const auto& descendant = matches[i][b];
+                    if (a != b && ancestor.size() < descendant.size() &&
+                        std::equal(ancestor.begin(), ancestor.end(), descendant.begin())) {
+                        nested = true;
+                        break;
+                    }
+                }
+            }
+            if (nested) {
                 log_warning(
                     tt::LogDistributed,
-                    "Instance filter {} '{}' is ambiguous: matched instances under {} different parents; every "
-                    "match's subtree is selected. Use a longer path to disambiguate. Matches: {}",
+                    "Instance filter {} '{}' is ambiguous: it matches nested instances on the same path (a match "
+                    "and a descendant of it), so a subtree is selected at more than one depth. Use a longer path "
+                    "to disambiguate. Matches: {}",
                     kind,
                     join_instance_path(filters[i]),
-                    parents.size(),
                     fmt::join(joined_paths, ", "));
             }
         }

--- a/tools/scaleout/factory_system_descriptor/query.cpp
+++ b/tools/scaleout/factory_system_descriptor/query.cpp
@@ -5,6 +5,7 @@
 #include "query.hpp"
 
 #include <algorithm>
+#include <set>
 #include <stdexcept>
 
 #include <fmt/format.h>
@@ -23,9 +24,17 @@ FsdQuery::FsdQuery(const fsd::proto::FactorySystemDescriptor& fsd) : fsd_(fsd) {
                 fmt::format("Duplicate hostname '{}' in factory system descriptor", hosts[i].hostname()));
         }
     }
+
+    // Cache the distinct hierarchy tiers (deepest-first) across all eth connections.
+    std::set<uint32_t, std::greater<>> tiers;
+    for (const auto& connection : fsd_.eth_connections().connection()) {
+        tiers.insert(lcp_length(connection.endpoint_a().host_id(), connection.endpoint_b().host_id()));
+    }
+    hierarchy_tiers_.assign(tiers.begin(), tiers.end());
+    max_hierarchy_depth_ = hierarchy_tiers_.empty() ? 0 : hierarchy_tiers_.front();
 }
 
-std::vector<std::string> FsdQuery::longest_common_prefix(uint32_t host_id_a, uint32_t host_id_b) const {
+uint32_t FsdQuery::lcp_length(uint32_t host_id_a, uint32_t host_id_b) const {
     const auto num_hosts = static_cast<uint32_t>(fsd_.hosts().size());
     if (host_id_a >= num_hosts || host_id_b >= num_hosts) {
         throw std::out_of_range(
@@ -34,9 +43,20 @@ std::vector<std::string> FsdQuery::longest_common_prefix(uint32_t host_id_a, uin
     const auto& path_a = fsd_.hosts()[host_id_a].instance_path();
     const auto& path_b = fsd_.hosts()[host_id_b].instance_path();
 
-    std::vector<std::string> prefix;
     const int limit = std::min(path_a.size(), path_b.size());
-    for (int i = 0; i < limit && path_a[i] == path_b[i]; ++i) {
+    int n = 0;
+    while (n < limit && path_a[n] == path_b[n]) {
+        ++n;
+    }
+    return static_cast<uint32_t>(n);
+}
+
+std::vector<std::string> FsdQuery::longest_common_prefix(uint32_t host_id_a, uint32_t host_id_b) const {
+    const uint32_t n = lcp_length(host_id_a, host_id_b);
+    const auto& path_a = fsd_.hosts()[host_id_a].instance_path();
+    std::vector<std::string> prefix;
+    prefix.reserve(n);
+    for (uint32_t i = 0; i < n; ++i) {
         prefix.push_back(path_a[i]);
     }
     return prefix;
@@ -45,6 +65,14 @@ std::vector<std::string> FsdQuery::longest_common_prefix(uint32_t host_id_a, uin
 std::vector<std::string> FsdQuery::longest_common_prefix(
     const std::string& hostname_a, const std::string& hostname_b) const {
     return longest_common_prefix(host_id_for(hostname_a), host_id_for(hostname_b));
+}
+
+uint32_t FsdQuery::hierarchy_depth(uint32_t host_id_a, uint32_t host_id_b) const {
+    return lcp_length(host_id_a, host_id_b);
+}
+
+uint32_t FsdQuery::hierarchy_depth(const std::string& hostname_a, const std::string& hostname_b) const {
+    return lcp_length(host_id_for(hostname_a), host_id_for(hostname_b));
 }
 
 uint32_t FsdQuery::host_id_for(const std::string& hostname) const {

--- a/tools/scaleout/factory_system_descriptor/query.cpp
+++ b/tools/scaleout/factory_system_descriptor/query.cpp
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "query.hpp"
+
+#include <algorithm>
+#include <stdexcept>
+
+#include <fmt/format.h>
+
+#include "protobuf/factory_system_descriptor.pb.h"
+
+namespace tt::scaleout_tools {
+
+FsdQuery::FsdQuery(const fsd::proto::FactorySystemDescriptor& fsd) : fsd_(fsd) {
+    const auto& hosts = fsd_.hosts();
+    hostname_to_host_id_.reserve(hosts.size());
+    for (int i = 0; i < hosts.size(); ++i) {
+        auto [it, inserted] = hostname_to_host_id_.emplace(hosts[i].hostname(), static_cast<uint32_t>(i));
+        if (!inserted) {
+            throw std::runtime_error(
+                fmt::format("Duplicate hostname '{}' in factory system descriptor", hosts[i].hostname()));
+        }
+    }
+}
+
+std::vector<std::string> FsdQuery::longest_common_prefix(uint32_t host_id_a, uint32_t host_id_b) const {
+    const auto num_hosts = static_cast<uint32_t>(fsd_.hosts().size());
+    if (host_id_a >= num_hosts || host_id_b >= num_hosts) {
+        throw std::out_of_range(
+            fmt::format("host_id out of range (a={}, b={}, num_hosts={})", host_id_a, host_id_b, num_hosts));
+    }
+    const auto& path_a = fsd_.hosts()[host_id_a].instance_path();
+    const auto& path_b = fsd_.hosts()[host_id_b].instance_path();
+
+    std::vector<std::string> prefix;
+    const int limit = std::min(path_a.size(), path_b.size());
+    for (int i = 0; i < limit && path_a[i] == path_b[i]; ++i) {
+        prefix.push_back(path_a[i]);
+    }
+    return prefix;
+}
+
+std::vector<std::string> FsdQuery::longest_common_prefix(
+    const std::string& hostname_a, const std::string& hostname_b) const {
+    return longest_common_prefix(host_id_for(hostname_a), host_id_for(hostname_b));
+}
+
+uint32_t FsdQuery::host_id_for(const std::string& hostname) const {
+    auto it = hostname_to_host_id_.find(hostname);
+    if (it == hostname_to_host_id_.end()) {
+        throw std::runtime_error(fmt::format("Hostname '{}' not found in factory system descriptor", hostname));
+    }
+    return it->second;
+}
+
+}  // namespace tt::scaleout_tools

--- a/tools/scaleout/factory_system_descriptor/query.cpp
+++ b/tools/scaleout/factory_system_descriptor/query.cpp
@@ -5,6 +5,7 @@
 #include "query.hpp"
 
 #include <algorithm>
+#include <functional>
 #include <set>
 #include <stdexcept>
 

--- a/tools/scaleout/factory_system_descriptor/query.cpp
+++ b/tools/scaleout/factory_system_descriptor/query.cpp
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <functional>
+#include <map>
 #include <set>
 #include <stdexcept>
 
@@ -87,6 +88,23 @@ uint32_t FsdQuery::hierarchy_depth(uint32_t host_id_a, uint32_t host_id_b) const
 
 uint32_t FsdQuery::hierarchy_depth(const std::string& hostname_a, const std::string& hostname_b) const {
     return lcp_length(host_id_for(hostname_a), host_id_for(hostname_b));
+}
+
+std::vector<std::vector<uint32_t>> FsdQuery::hierarchy_partition(uint32_t depth) const {
+    // Group host_ids by their first `depth` instance_path segments (fewer if the path is shorter).
+    std::map<std::vector<std::string>, std::vector<uint32_t>> groups;
+    const auto num_hosts = static_cast<uint32_t>(fsd_.hosts().size());
+    for (uint32_t id = 0; id < num_hosts; ++id) {
+        const auto& path = fsd_.hosts()[id].instance_path();
+        const int take = std::min(static_cast<int>(depth), path.size());
+        groups[std::vector<std::string>(path.begin(), path.begin() + take)].push_back(id);
+    }
+    std::vector<std::vector<uint32_t>> partition;
+    partition.reserve(groups.size());
+    for (auto& [prefix, ids] : groups) {
+        partition.push_back(std::move(ids));
+    }
+    return partition;
 }
 
 uint32_t FsdQuery::host_id_for(const std::string& hostname) const {

--- a/tools/scaleout/factory_system_descriptor/query.cpp
+++ b/tools/scaleout/factory_system_descriptor/query.cpp
@@ -34,6 +34,19 @@ FsdQuery::FsdQuery(const fsd::proto::FactorySystemDescriptor& fsd) : fsd_(fsd) {
     max_hierarchy_depth_ = hierarchy_tiers_.empty() ? 0 : hierarchy_tiers_.front();
 }
 
+std::vector<std::string> FsdQuery::get_instance_path(uint32_t host_id) const {
+    const auto num_hosts = static_cast<uint32_t>(fsd_.hosts().size());
+    if (host_id >= num_hosts) {
+        throw std::out_of_range(fmt::format("host_id out of range (id={}, num_hosts={})", host_id, num_hosts));
+    }
+    const auto& path = fsd_.hosts()[host_id].instance_path();
+    return std::vector<std::string>(path.begin(), path.end());
+}
+
+std::vector<std::string> FsdQuery::get_instance_path(const std::string& hostname) const {
+    return get_instance_path(host_id_for(hostname));
+}
+
 uint32_t FsdQuery::lcp_length(uint32_t host_id_a, uint32_t host_id_b) const {
     const auto num_hosts = static_cast<uint32_t>(fsd_.hosts().size());
     if (host_id_a >= num_hosts || host_id_b >= num_hosts) {

--- a/tools/scaleout/factory_system_descriptor/query.hpp
+++ b/tools/scaleout/factory_system_descriptor/query.hpp
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace tt::scaleout_tools::fsd::proto {
+class FactorySystemDescriptor;
+}
+
+namespace tt::scaleout_tools {
+
+// Read-only query interface over a FactorySystemDescriptor.
+// Builds a hostname -> host_id index once; the referenced proto must outlive this object.
+class FsdQuery {
+public:
+    explicit FsdQuery(const fsd::proto::FactorySystemDescriptor& fsd);
+
+    // Longest common prefix of the two hosts' instance_path segments.
+    // host_id indexes hosts positionally (the i-th host has host_id i), matching connection endpoints.
+    std::vector<std::string> longest_common_prefix(uint32_t host_id_a, uint32_t host_id_b) const;
+    std::vector<std::string> longest_common_prefix(const std::string& hostname_a, const std::string& hostname_b) const;
+
+private:
+    uint32_t host_id_for(const std::string& hostname) const;
+
+    const fsd::proto::FactorySystemDescriptor& fsd_;
+    std::unordered_map<std::string, uint32_t> hostname_to_host_id_;
+};
+
+}  // namespace tt::scaleout_tools

--- a/tools/scaleout/factory_system_descriptor/query.hpp
+++ b/tools/scaleout/factory_system_descriptor/query.hpp
@@ -26,11 +26,27 @@ public:
     std::vector<std::string> longest_common_prefix(uint32_t host_id_a, uint32_t host_id_b) const;
     std::vector<std::string> longest_common_prefix(const std::string& hostname_a, const std::string& hostname_b) const;
 
+    // Hierarchy tier of a link = length of the two hosts' instance_path common prefix.
+    // Larger depth = closer in the hierarchy (same node); smaller = farther (crosses the top).
+    uint32_t hierarchy_depth(uint32_t host_id_a, uint32_t host_id_b) const;
+    uint32_t hierarchy_depth(const std::string& hostname_a, const std::string& hostname_b) const;
+
+    // Deepest (most-connected / closest) tier across all eth_connections. Cached; O(1).
+    uint32_t max_hierarchy_depth() const { return max_hierarchy_depth_; }
+
+    // Distinct tiers present across all eth_connections, sorted deepest-first (the phasing order).
+    // front() == max_hierarchy_depth() when non-empty.
+    const std::vector<uint32_t>& hierarchy_tiers_deepest_first() const { return hierarchy_tiers_; }
+
 private:
     uint32_t host_id_for(const std::string& hostname) const;
+    // Common prefix length of two hosts' instance_paths (shared by longest_common_prefix / hierarchy_depth).
+    uint32_t lcp_length(uint32_t host_id_a, uint32_t host_id_b) const;
 
     const fsd::proto::FactorySystemDescriptor& fsd_;
     std::unordered_map<std::string, uint32_t> hostname_to_host_id_;
+    std::vector<uint32_t> hierarchy_tiers_;  // distinct LCP depths over eth_connections, deepest-first
+    uint32_t max_hierarchy_depth_ = 0;
 };
 
 }  // namespace tt::scaleout_tools

--- a/tools/scaleout/factory_system_descriptor/query.hpp
+++ b/tools/scaleout/factory_system_descriptor/query.hpp
@@ -20,6 +20,7 @@ namespace tt::scaleout_tools {
 class FsdQuery {
 public:
     explicit FsdQuery(const fsd::proto::FactorySystemDescriptor& fsd);
+    FsdQuery(fsd::proto::FactorySystemDescriptor&&) = delete;
 
     // Full instance_path segments of a host (root -> host).
     std::vector<std::string> get_instance_path(uint32_t host_id) const;

--- a/tools/scaleout/factory_system_descriptor/query.hpp
+++ b/tools/scaleout/factory_system_descriptor/query.hpp
@@ -43,6 +43,12 @@ public:
     // front() == max_hierarchy_depth() when non-empty.
     const std::vector<uint32_t>& hierarchy_tiers_deepest_first() const { return hierarchy_tiers_; }
 
+    // Partition hosts into subgroups by their depth-`depth` instance_path prefix: each returned group is
+    // the host_ids sharing the same first `depth` segments (one hierarchy node at that level). Hosts with
+    // fewer than `depth` segments group by their full path. Groups are ordered deterministically by prefix,
+    // host_ids ascending within a group. This is the subgroup set for per-hierarchy-node phased discovery.
+    std::vector<std::vector<uint32_t>> hierarchy_partition(uint32_t depth) const;
+
 private:
     uint32_t host_id_for(const std::string& hostname) const;
     // Common prefix length of two hosts' instance_paths (shared by longest_common_prefix / hierarchy_depth).

--- a/tools/scaleout/factory_system_descriptor/query.hpp
+++ b/tools/scaleout/factory_system_descriptor/query.hpp
@@ -21,6 +21,10 @@ class FsdQuery {
 public:
     explicit FsdQuery(const fsd::proto::FactorySystemDescriptor& fsd);
 
+    // Full instance_path segments of a host (root -> host).
+    std::vector<std::string> get_instance_path(uint32_t host_id) const;
+    std::vector<std::string> get_instance_path(const std::string& hostname) const;
+
     // Longest common prefix of the two hosts' instance_path segments.
     // host_id indexes hosts positionally (the i-th host has host_id i), matching connection endpoints.
     std::vector<std::string> longest_common_prefix(uint32_t host_id_a, uint32_t host_id_b) const;

--- a/tools/tests/scaleout/test_factory_system_descriptor.cpp
+++ b/tools/tests/scaleout/test_factory_system_descriptor.cpp
@@ -460,6 +460,13 @@ fsd::proto::FactorySystemDescriptor make_fsd_with_paths(
     return fsd;
 }
 
+// Add an eth connection between two hosts (only host_id matters for hierarchy queries).
+void add_connection(fsd::proto::FactorySystemDescriptor& fsd, uint32_t host_id_a, uint32_t host_id_b) {
+    auto* connection = fsd.mutable_eth_connections()->add_connection();
+    connection->mutable_endpoint_a()->set_host_id(host_id_a);
+    connection->mutable_endpoint_b()->set_host_id(host_id_b);
+}
+
 }  // namespace
 
 TEST(FsdQuery, LongestCommonPrefixByHostId) {
@@ -516,6 +523,45 @@ TEST(FsdQuery, ThrowsOnUnknownHostIdOrHostname) {
 TEST(FsdQuery, ThrowsOnDuplicateHostname) {
     auto fsd = make_fsd_with_paths({{"dup", {"sp_0"}}, {"dup", {"sp_1"}}});
     EXPECT_THROW(FsdQuery{fsd}, std::runtime_error);
+}
+
+TEST(FsdQuery, HierarchyDepthIsCommonPrefixLength) {
+    auto fsd = make_fsd_with_paths({
+        {"node0", {"root", "sp_0", "node_0"}},
+        {"node1", {"root", "sp_0", "node_1"}},
+        {"node2", {"root", "sp_1"}},
+    });
+    FsdQuery query(fsd);
+
+    EXPECT_EQ(query.hierarchy_depth(0u, 1u), 2u);  // share root, sp_0
+    EXPECT_EQ(query.hierarchy_depth(0u, 2u), 1u);  // share root only
+    EXPECT_EQ(query.hierarchy_depth("node0", "node1"), 2u);
+    EXPECT_EQ(query.hierarchy_depth(0u, 0u), 3u);  // full path with itself
+}
+
+TEST(FsdQuery, MaxDepthAndTiersFromConnections) {
+    auto fsd = make_fsd_with_paths({
+        {"node0", {"root", "sp_0", "node_0"}},
+        {"node1", {"root", "sp_0", "node_1"}},
+        {"node2", {"root", "sp_1", "node_0"}},
+    });
+    add_connection(fsd, 0, 1);  // depth 2 (root, sp_0)
+    add_connection(fsd, 0, 2);  // depth 1 (root)
+    add_connection(fsd, 1, 2);  // depth 1 (root)
+    FsdQuery query(fsd);
+
+    EXPECT_EQ(query.max_hierarchy_depth(), 2u);
+    // Distinct tiers, deepest-first; front() is the max depth.
+    EXPECT_EQ(query.hierarchy_tiers_deepest_first(), (std::vector<uint32_t>{2u, 1u}));
+    EXPECT_EQ(query.hierarchy_tiers_deepest_first().front(), query.max_hierarchy_depth());
+}
+
+TEST(FsdQuery, NoConnectionsMeansZeroMaxDepth) {
+    auto fsd = make_fsd_with_paths({{"node0", {"root", "sp_0"}}});
+    FsdQuery query(fsd);
+
+    EXPECT_EQ(query.max_hierarchy_depth(), 0u);
+    EXPECT_TRUE(query.hierarchy_tiers_deepest_first().empty());
 }
 
 }  // namespace tt::scaleout_tools

--- a/tools/tests/scaleout/test_factory_system_descriptor.cpp
+++ b/tools/tests/scaleout/test_factory_system_descriptor.cpp
@@ -11,12 +11,14 @@
 #include <yaml-cpp/yaml.h>
 
 #include <cabling_generator/cabling_generator.hpp>
+#include <factory_system_descriptor/query.hpp>
 #include <factory_system_descriptor/utils.hpp>
 #include <node/node_types.hpp>
 
 // Include generated protobuf headers
 #include "protobuf/deployment.pb.h"
 #include "protobuf/cluster_config.pb.h"
+#include "protobuf/factory_system_descriptor.pb.h"
 
 namespace tt::scaleout_tools {
 
@@ -440,6 +442,80 @@ TEST(CablingGenerator, PruneDeadChannelsIgnoresUnknownChannel) {
 
     EXPECT_TRUE(gen.prune_dead_channels({bogus}).empty());  // no cable matched
     EXPECT_EQ(gen.get_chip_connections().size(), before);   // FSD unchanged
+}
+
+namespace {
+
+// Build an FSD with the given (hostname, instance_path) hosts, indexed by host_id in order.
+fsd::proto::FactorySystemDescriptor make_fsd_with_paths(
+    const std::vector<std::pair<std::string, std::vector<std::string>>>& hosts) {
+    fsd::proto::FactorySystemDescriptor fsd;
+    for (const auto& [hostname, path] : hosts) {
+        auto* host = fsd.add_hosts();
+        host->set_hostname(hostname);
+        for (const auto& segment : path) {
+            host->add_instance_path(segment);
+        }
+    }
+    return fsd;
+}
+
+}  // namespace
+
+TEST(FsdQuery, LongestCommonPrefixByHostId) {
+    auto fsd = make_fsd_with_paths({
+        {"node0", {"sp_0", "node_0", "h_0"}},
+        {"node1", {"sp_0", "node_0", "h_1"}},
+        {"node2", {"sp_0", "node_1", "h_0"}},
+        {"node3", {"sp_1", "node_0", "h_0"}},
+    });
+    FsdQuery query(fsd);
+
+    EXPECT_EQ(query.longest_common_prefix(0u, 1u), (std::vector<std::string>{"sp_0", "node_0"}));
+    EXPECT_EQ(query.longest_common_prefix(0u, 2u), (std::vector<std::string>{"sp_0"}));
+    EXPECT_EQ(query.longest_common_prefix(0u, 3u), (std::vector<std::string>{}));
+    // Same host is a prefix of itself.
+    EXPECT_EQ(query.longest_common_prefix(2u, 2u), (std::vector<std::string>{"sp_0", "node_1", "h_0"}));
+    // Order does not matter.
+    EXPECT_EQ(query.longest_common_prefix(1u, 0u), query.longest_common_prefix(0u, 1u));
+}
+
+TEST(FsdQuery, LongestCommonPrefixByHostname) {
+    auto fsd = make_fsd_with_paths({
+        {"node0", {"sp_0", "node_0"}},
+        {"node1", {"sp_0", "node_1"}},
+    });
+    FsdQuery query(fsd);
+
+    EXPECT_EQ(query.longest_common_prefix("node0", "node1"), (std::vector<std::string>{"sp_0"}));
+    EXPECT_EQ(query.longest_common_prefix("node0", "node0"), (std::vector<std::string>{"sp_0", "node_0"}));
+}
+
+TEST(FsdQuery, HandlesEmptyAndUnequalLengthPaths) {
+    auto fsd = make_fsd_with_paths({
+        {"node0", {}},
+        {"node1", {"sp_0"}},
+        {"node2", {"sp_0", "node_0", "h_0"}},
+    });
+    FsdQuery query(fsd);
+
+    // Empty path shares nothing with anyone.
+    EXPECT_EQ(query.longest_common_prefix(0u, 1u), (std::vector<std::string>{}));
+    // Shorter path is a full prefix of the longer one.
+    EXPECT_EQ(query.longest_common_prefix(1u, 2u), (std::vector<std::string>{"sp_0"}));
+}
+
+TEST(FsdQuery, ThrowsOnUnknownHostIdOrHostname) {
+    auto fsd = make_fsd_with_paths({{"node0", {"sp_0"}}});
+    FsdQuery query(fsd);
+
+    EXPECT_THROW(query.longest_common_prefix(0u, 5u), std::out_of_range);
+    EXPECT_THROW(query.longest_common_prefix("node0", "missing"), std::runtime_error);
+}
+
+TEST(FsdQuery, ThrowsOnDuplicateHostname) {
+    auto fsd = make_fsd_with_paths({{"dup", {"sp_0"}}, {"dup", {"sp_1"}}});
+    EXPECT_THROW(FsdQuery{fsd}, std::runtime_error);
 }
 
 }  // namespace tt::scaleout_tools

--- a/tools/tests/scaleout/test_factory_system_descriptor.cpp
+++ b/tools/tests/scaleout/test_factory_system_descriptor.cpp
@@ -525,6 +525,66 @@ TEST(FsdQuery, ThrowsOnDuplicateHostname) {
     EXPECT_THROW(FsdQuery{fsd}, std::runtime_error);
 }
 
+TEST(FsdQuery, HierarchyPartition) {
+    auto fsd = make_fsd_with_paths({
+        {"h0", {"root", "sp_0", "node_0"}},
+        {"h1", {"root", "sp_0", "node_1"}},
+        {"h2", {"root", "sp_1", "node_0"}},
+        {"h3", {"root", "sp_1", "node_1"}},
+    });
+    FsdQuery query(fsd);
+
+    // depth 2 -> partition by (root, sp_x): two subgroups.
+    auto p2 = query.hierarchy_partition(2u);
+    ASSERT_EQ(p2.size(), 2u);
+    EXPECT_EQ(p2[0], (std::vector<uint32_t>{0u, 1u}));  // sp_0
+    EXPECT_EQ(p2[1], (std::vector<uint32_t>{2u, 3u}));  // sp_1
+
+    // depth 3 -> each host is its own subgroup.
+    EXPECT_EQ(query.hierarchy_partition(3u).size(), 4u);
+
+    // depth 1 -> all share "root" -> a single subgroup with every host.
+    auto p1 = query.hierarchy_partition(1u);
+    ASSERT_EQ(p1.size(), 1u);
+    EXPECT_EQ(p1[0], (std::vector<uint32_t>{0u, 1u, 2u, 3u}));
+}
+
+TEST(FsdQuery, HierarchyPartitionHandlesShortPaths) {
+    auto fsd = make_fsd_with_paths({
+        {"h0", {"root", "sp_0"}},
+        {"h1", {"root", "sp_0", "node_1"}},
+        {"h2", {"root"}},
+    });
+    FsdQuery query(fsd);
+
+    // depth 3: h0 (len 2) and h2 (len 1) group by their full path; h1 by its full 3 segments.
+    auto p = query.hierarchy_partition(3u);
+    EXPECT_EQ(p.size(), 3u);
+}
+
+// A graph_instance may reference multiple leaf node_descriptors, so several hosts can sit under the same
+// hierarchy node, sharing the instance_path prefix and differing only in the final (leaf) segment. They
+// must land in the same subgroup at the node-level depth (no one-node-per-leaf-level assumption).
+TEST(FsdQuery, HierarchyPartitionGroupsMultipleLeavesUnderOneNode) {
+    auto fsd = make_fsd_with_paths({
+        {"h0", {"sp_0", "node_0", "node_0"}},  // two leaf nodes under sp_0/node_0
+        {"h1", {"sp_0", "node_0", "node_1"}},
+        {"h2", {"sp_0", "node_1", "node_0"}},
+    });
+    FsdQuery query(fsd);
+
+    // depth 2 = the node level: h0 and h1 (both under sp_0/node_0) share a subgroup; h2 is separate.
+    auto p2 = query.hierarchy_partition(2u);
+    ASSERT_EQ(p2.size(), 2u);
+    EXPECT_EQ(p2[0], (std::vector<uint32_t>{0u, 1u}));  // sp_0/node_0 leaves grouped together
+    EXPECT_EQ(p2[1], (std::vector<uint32_t>{2u}));      // sp_0/node_1
+
+    // An intra-node link (h0<->h1) has LCP depth 2, i.e. the same depth at which they co-locate.
+    add_connection(fsd, 0, 1);
+    FsdQuery query_with_conn(fsd);
+    EXPECT_EQ(query_with_conn.hierarchy_depth(0u, 1u), 2u);
+}
+
 TEST(FsdQuery, GetInstancePath) {
     auto fsd = make_fsd_with_paths({
         {"node0", {"root", "sp_0", "node_0"}},

--- a/tools/tests/scaleout/test_factory_system_descriptor.cpp
+++ b/tools/tests/scaleout/test_factory_system_descriptor.cpp
@@ -525,6 +525,20 @@ TEST(FsdQuery, ThrowsOnDuplicateHostname) {
     EXPECT_THROW(FsdQuery{fsd}, std::runtime_error);
 }
 
+TEST(FsdQuery, GetInstancePath) {
+    auto fsd = make_fsd_with_paths({
+        {"node0", {"root", "sp_0", "node_0"}},
+        {"node1", {}},
+    });
+    FsdQuery query(fsd);
+
+    EXPECT_EQ(query.get_instance_path(0u), (std::vector<std::string>{"root", "sp_0", "node_0"}));
+    EXPECT_EQ(query.get_instance_path("node0"), (std::vector<std::string>{"root", "sp_0", "node_0"}));
+    EXPECT_TRUE(query.get_instance_path(1u).empty());
+    EXPECT_THROW(query.get_instance_path(5u), std::out_of_range);
+    EXPECT_THROW(query.get_instance_path("missing"), std::runtime_error);
+}
+
 TEST(FsdQuery, HierarchyDepthIsCommonPrefixLength) {
     auto fsd = make_fsd_with_paths({
         {"node0", {"root", "sp_0", "node_0"}},

--- a/tools/tests/scaleout/test_instance_filter.cpp
+++ b/tools/tests/scaleout/test_instance_filter.cpp
@@ -143,6 +143,23 @@ TEST(InstanceFilterTest, RelativeIncludeSelectsNameUnderEveryParent) {
     EXPECT_EQ(cross_host_pairs(gen).size(), 1u);
 }
 
+TEST(InstanceFilterTest, RelativeNameSpansMultipleParentsMatchesAll) {
+    // "node1" occurs under every superpod, so a relative include matches ALL of them - the selection is
+    // inclusive, not one prioritized match. This is the ambiguous/colliding-name case (matches span
+    // multiple distinct parents) that drives the match-logging + ambiguity warning; behavior is unchanged.
+    auto gen = make_gen();
+    gen.apply_instance_filter({{"node1"}}, {});
+    auto paths = instance_paths(gen);
+    ASSERT_EQ(paths.size(), 4u);
+    EXPECT_THAT(paths, Each(ElementsAre("n300_lb_cluster", _, "node1")));  // every selected host is a node1 leaf
+    // ...sitting under 4 DISTINCT parents (superpod0..3) - i.e. the multi-parent (ambiguous) match.
+    std::set<std::string> parents;
+    for (const auto& p : paths) {
+        parents.insert(p[1]);
+    }
+    EXPECT_EQ(parents.size(), 4u);
+}
+
 TEST(InstanceFilterTest, RootLevelNameDoesNotMatchDeeperInstances) {
     // "superpod1" is a suffix only of the top-level instance, never of a deeper node path.
     auto gen = make_gen();

--- a/tools/tests/scaleout/test_instance_filter.cpp
+++ b/tools/tests/scaleout/test_instance_filter.cpp
@@ -144,15 +144,13 @@ TEST(InstanceFilterTest, RelativeIncludeSelectsNameUnderEveryParent) {
 }
 
 TEST(InstanceFilterTest, RelativeNameSpansMultipleParentsMatchesAll) {
-    // "node1" occurs under every superpod, so a relative include matches ALL of them - the selection is
-    // inclusive, not one prioritized match. This is the ambiguous/colliding-name case (matches span
-    // multiple distinct parents) that drives the match-logging + ambiguity warning; behavior is unchanged.
+    // "node1" occurs under every superpod, so a relative include matches ALL of them under 4 distinct
+    // parents. This is intended fan-out, not the nested-lineage ambiguity case.
     auto gen = make_gen();
     gen.apply_instance_filter({{"node1"}}, {});
     auto paths = instance_paths(gen);
     ASSERT_EQ(paths.size(), 4u);
-    EXPECT_THAT(paths, Each(ElementsAre("n300_lb_cluster", _, "node1")));  // every selected host is a node1 leaf
-    // ...sitting under 4 DISTINCT parents (superpod0..3) - i.e. the multi-parent (ambiguous) match.
+    EXPECT_THAT(paths, Each(ElementsAre("n300_lb_cluster", _, "node1")));
     std::set<std::string> parents;
     for (const auto& p : paths) {
         parents.insert(p[1]);


### PR DESCRIPTION
### PR Category
Feature

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->
Closes #50788 


### Notes for reviewers
Continues instance_path work of #50787 to make instance paths queryable. Use Longest Common Path to quantify relation between 2 hosts, and thus be used in  determining hierarchy level of a connection between 2 hosts.

Also some filtering fixes/adjustments to warn on edge/rare cases

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=agupta/fsd-query-instance-path)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:agupta/fsd-query-instance-path)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=agupta/fsd-query-instance-path)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:agupta/fsd-query-instance-path)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=agupta/fsd-query-instance-path)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:agupta/fsd-query-instance-path)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=agupta/fsd-query-instance-path)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:agupta/fsd-query-instance-path)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=agupta/fsd-query-instance-path)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:agupta/fsd-query-instance-path)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=agupta/fsd-query-instance-path)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:agupta/fsd-query-instance-path)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=agupta/fsd-query-instance-path)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:agupta/fsd-query-instance-path)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=agupta/fsd-query-instance-path)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:agupta/fsd-query-instance-path)