### PR TITLE
[LLK] Shard llk_smoke_blackhole into two pytest groups

### DIFF
--- a/tests/pipeline_reorg/llk_pr_gate_tests.yaml
+++ b/tests/pipeline_reorg/llk_pr_gate_tests.yaml
@@ -22,7 +22,8 @@
       timeout: 15
   owner_id: U07J3K6KS1K # LLK team
 
-- name: llk_smoke_blackhole
+- name: llk_smoke_blackhole group 1/2
+  split_group: 1
   team: llk
   coverage: false
   cmd: |
@@ -30,8 +31,26 @@
     cd tests/python_tests
     pytest -q --override-ini=log_cli=false -n auto -x \
       --dist=worksteal -m "$PYTEST_MARKERS" \
+      --splits 2 --group 1 \
       --timeout=60 \
-      --junitxml=pytest-report-blackhole.xml .
+      --junitxml=pytest-report-blackhole-1.xml .
+  skus:
+    bh_p150b_civ2_viommu:
+      timeout: 15
+  owner_id: U07J3K6KS1K # LLK team
+
+- name: llk_smoke_blackhole group 2/2
+  split_group: 2
+  team: llk
+  coverage: false
+  cmd: |
+    set -euo pipefail
+    cd tests/python_tests
+    pytest -q --override-ini=log_cli=false -n auto -x \
+      --dist=worksteal -m "$PYTEST_MARKERS" \
+      --splits 2 --group 2 \
+      --timeout=60 \
+      --junitxml=pytest-report-blackhole-2.xml .
   skus:
     bh_p150b_civ2_viommu:
       timeout: 15


### PR DESCRIPTION
## Summary
- Split the single `llk_smoke_blackhole` entry in `tests/pipeline_reorg/llk_pr_gate_tests.yaml` into two shards (`group 1/2`, `group 2/2`) driven by `pytest --splits 2 --group K`, so the merge-gate wall time fits inside the 15-minute per-test budget the pipeline was hitting.
- Uses the same `split_group` + pytest-split convention already in `llk_e2e_tests.yaml`; junit reports are named `pytest-report-blackhole-<K>.xml` to line up with the `pytest-report-*-${{ matrix.test-group.split_group }}.xml` globs in `.github/workflows/llk-smoke-impl.yaml`.
- Wormhole entry untouched (not blowing the budget).

Verified locally with the workflow's own checks against the updated yaml:
- `verify_time_budget.py … pr_gate --max-per-test-timeout 15`: bh totals 30 min (2 × 15), inside the 40-min `pr_gate` budget; per-shard timeout at the 15-min ceiling.
- `prepare_test_matrix.py … --event merge_group`: matrix expands to 3 rows (WH + BH×2), both BH shards routed to `bh_p150b_civ2_viommu_prio` runners with `split_group` populated.

## Test plan
- [ ] Merge-queue run: confirm both `llk_smoke_blackhole group 1/2` and `group 2/2` jobs are scheduled onto `bh_p150b_civ2_viommu_prio` runners and finish under 15 min each.
- [ ] Verify per-shard junit artifacts `junit-report-blackhole-1` / `-2` upload and the `Publish Test Results` step picks up `pytest-report-blackhole-1.xml` / `-2.xml`.
- [ ] Sanity-check that wormhole leg still runs unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=fvranic/shard-llk-smoke-blackhole)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:fvranic/shard-llk-smoke-blackhole)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=fvranic/shard-llk-smoke-blackhole)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:fvranic/shard-llk-smoke-blackhole)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=fvranic/shard-llk-smoke-blackhole)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:fvranic/shard-llk-smoke-blackhole)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fvranic/shard-llk-smoke-blackhole)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fvranic/shard-llk-smoke-blackhole)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=fvranic/shard-llk-smoke-blackhole)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:fvranic/shard-llk-smoke-blackhole)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=fvranic/shard-llk-smoke-blackhole)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:fvranic/shard-llk-smoke-blackhole)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=fvranic/shard-llk-smoke-blackhole)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:fvranic/shard-llk-smoke-blackhole)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=fvranic/shard-llk-smoke-blackhole)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:fvranic/shard-llk-smoke-blackhole)