### PR TITLE
[Bugfix] Add legality checks to incoherent Metal 2.0 x legacy API cross-use

### DIFF
--- a/tt_metal/impl/metal2_host_api/program_run_args.cpp
+++ b/tt_metal/impl/metal2_host_api/program_run_args.cpp
@@ -488,6 +488,13 @@ void AttachBorrowedDFBBuffers(
 void SetProgramRunArgs(Program& program, const ProgramRunArgs& params, bool skip_validation) {
     log_debug(tt::LogMetal, "Setting ProgramRunArgs");
 
+    // Metal 2.0 run-args API: only valid on a Program created from a ProgramSpec (the run-args
+    // schema lives on the spec). Legacy Programs configure runtime args via SetRuntimeArgs.
+    TT_FATAL(
+        program.impl().created_from_spec(),
+        "SetProgramRunArgs requires a Metal 2.0 Program. "
+        "For a legacy Program, use SetRuntimeArgs / SetCommonRuntimeArgs.");
+
     // Validate parameters against the schema (can be skipped for trusted inputs, e.g. cached-program
     // re-enqueue inner loops where the args have already been validated once).
     if (!skip_validation) {
@@ -778,6 +785,12 @@ void UpdateTensorArgs(Program& program, const Table<TensorParamName, ProgramRunA
     log_debug(tt::LogMetal, "Updating tensor args (partial fast-path)");
 
     detail::ProgramImpl& program_impl = program.impl();
+    // Metal 2.0 run-args API: only valid on a Program created from a ProgramSpec. (A legacy Program
+    // would also fail the initialized-check below, but this gives the accurate reason.)
+    TT_FATAL(
+        program_impl.created_from_spec(),
+        "UpdateTensorArgs requires a Metal 2.0 Program. "
+        "For a legacy Program, use SetRuntimeArgs / SetCommonRuntimeArgs.");
     TT_FATAL(
         program_impl.program_run_args_initialized(),
         "UpdateTensorArgs called on Program before SetProgramRunArgs. Call SetProgramRunArgs at least once first.");
@@ -1140,6 +1153,12 @@ void UpdateProgramRunArgs(Program& program, const ProgramRunArgs& params, bool s
     log_debug(tt::LogMetal, "Updating ProgramRunArgs (partial fast-path)");
 
     detail::ProgramImpl& program_impl = program.impl();
+    // Metal 2.0 run-args API: only valid on a Program created from a ProgramSpec. (A legacy Program
+    // would also fail the initialized-check below, but this gives the accurate reason.)
+    TT_FATAL(
+        program_impl.created_from_spec(),
+        "UpdateProgramRunArgs requires a Metal 2.0 Program. "
+        "For a legacy Program, use SetRuntimeArgs / SetCommonRuntimeArgs.");
     TT_FATAL(
         program_impl.program_run_args_initialized(),
         "UpdateProgramRunArgs: CRTA buffer not allocated because SetProgramRunArgs has not been called. Call "

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -1221,6 +1221,12 @@ void detail::ProgramImpl::CircularBufferAllocator::mark_address(
 }
 
 CBHandle detail::ProgramImpl::add_circular_buffer_(const std::shared_ptr<CircularBufferImpl>& circular_buffer) {
+    // Metal 2.0 programs use DataflowBuffers, never legacy circular buffers.
+    TT_FATAL(
+        !this->created_from_spec_,
+        "Cannot add a legacy circular buffer to a Metal 2.0 Program; "
+        "Metal 2.0 Programs use DataflowBuffers, and cannot be modified after construction.");
+
     // Globally allocated circular buffer do not invalidate allocation because their addresses are tracked by memory
     // allocator
     if (not circular_buffer->globally_allocated()) {

--- a/tt_metal/impl/program/program_impl.hpp
+++ b/tt_metal/impl/program/program_impl.hpp
@@ -352,6 +352,7 @@ public:
     // Metal 2.0: Mark this Program as created from ProgramSpec
     // This enables legality checks against illegal mixing of Metal 2.0 idioms with legacy Programs.
     void mark_created_from_spec() { created_from_spec_ = true; }
+    bool created_from_spec() const { return created_from_spec_; }
 
     // Metal 2.0: Add name -> handle mappings (temporary indirection)
     void register_kernel_spec_name(const std::string& name, KernelHandle handle);


### PR DESCRIPTION
### PR Category
Bugfix

### Summary
Add legality checks to forbid incoherent mixing of Metal 2.0 and legacy Program APIs:
 - **Reject all legacy `Add...(&program,....)` on a Metal 2.0-generated Program**. Traced through all code paths, and this was largely already handled by the legacy Program "finalize" logic, with one exception: `add_circular_buffer`
 - **Reject Metal 2.0 run-args APIs on a legacy Program**. You can't call `SetProgramRunArgs`, `UpdateProgramRunArgs`, or `UpdateTensorArgs` unless the Program was generated from a Metal 2.0 ProgramSpec.

This PR is a companion to the legacy-side guard (#50483), which forbids `SetRuntimeArgs` (etc) on a Metal 2.0 Program, and #50619. Hopefully all the weird legacy x Metal 2.0 incoherent API calls are now fully legality checked.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=akertesz/metal2-program-guard2)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:akertesz/metal2-program-guard2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=akertesz/metal2-program-guard2)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:akertesz/metal2-program-guard2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=akertesz/metal2-program-guard2)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:akertesz/metal2-program-guard2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=akertesz/metal2-program-guard2)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:akertesz/metal2-program-guard2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=akertesz/metal2-program-guard2)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:akertesz/metal2-program-guard2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=akertesz/metal2-program-guard2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:akertesz/metal2-program-guard2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=akertesz/metal2-program-guard2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:akertesz/metal2-program-guard2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=akertesz/metal2-program-guard2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:akertesz/metal2-program-guard2)