### PR TITLE
[Cleanup] Remove enqueue-invariance from the Metal 2.0 host API

### DIFF
--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_run_args.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_run_args.cpp
@@ -2384,6 +2384,85 @@ TEST_F(ProgramRunArgsTestQuasar, UpdateProgramRunArgs_OmittingKernelRetainsArgs)
         << "an omitted kernel's args are retained";
 }
 
+// --- Omitted vararg sections (per-node + common) and untouched nodes are retained ---
+
+// Regression for the arbitrary-partial-update vararg axis: a partial update that touches only one
+// named arg on one node must leave every OMITTED vararg section — per-node on both nodes, and the
+// common section — plus the untouched node's values intact. Guards against (a) a re-introduced
+// vararg completeness check (would FATAL on the omission) and (b) a patch that clobbers a retained
+// section or writes the wrong node.
+TEST_F(ProgramRunArgsTestQuasar, UpdateProgramRunArgs_RetainsOmittedVarargsAcrossNodes) {
+    NodeCoord node0{0, 0};
+    NodeCoord node1{1, 0};
+    NodeRangeSet all_nodes(std::set<NodeRange>{NodeRange{node0, node0}, NodeRange{node1, node1}});
+
+    ProgramSpec spec;
+    spec.name = "vararg_retain_program";
+
+    // producer: one named RTA ("addr") + 2 per-node varargs + 2 common varargs, spanning both nodes.
+    auto producer = MakeMinimalGen2DMKernel("producer");
+    producer.runtime_arg_schema.runtime_arg_names = {"addr"};
+    producer.advanced_options = KernelAdvancedOptions{.num_runtime_varargs = 2, .num_common_runtime_varargs = 2};
+    auto consumer = MakeMinimalGen2DMKernel("consumer");
+
+    auto dfb = MakeMinimalDFB("dfb");
+    producer.dfb_bindings.push_back(ProducerOf(DFBSpecName{"dfb"}, "out"));
+    consumer.dfb_bindings.push_back(ConsumerOf(DFBSpecName{"dfb"}, "in"));
+
+    spec.kernels = {producer, consumer};
+    spec.dataflow_buffers = {dfb};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", all_nodes, {"producer", "consumer"})};
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
+
+    // Full set: named RTA + per-node varargs on both nodes + common varargs.
+    KernelRunArgs::RuntimeArgValues named;
+    AddRuntimeArgsForNode(named, node0, {{"addr", 100}});
+    AddRuntimeArgsForNode(named, node1, {{"addr", 200}});
+    ProgramRunArgs full;
+    full.kernel_run_args.push_back(ProgramRunArgs::KernelRunArgs{
+        .kernel = KernelSpecName{"producer"},
+        .runtime_arg_values = named,
+        .advanced_options =
+            AdvancedKernelRunArgs{
+                .runtime_varargs = {{node0, {10, 11}}, {node1, {20, 21}}},
+                .common_runtime_varargs = {30, 31},
+            },
+    });
+    full.kernel_run_args.push_back(ProgramRunArgs::KernelRunArgs{
+        .kernel = KernelSpecName{"consumer"},
+        .advanced_options = AdvancedKernelRunArgs{.runtime_varargs = {{node0, {}}, {node1, {}}}},
+    });
+    SetProgramRunArgs(program, full);
+
+    // Partial update: change ONLY the named RTA on node0. Every vararg section (both nodes' per-node,
+    // and the common section) and node1's named RTA are omitted -> all must be retained.
+    KernelRunArgs::RuntimeArgValues upd_named;
+    AddRuntimeArgsForNode(upd_named, node0, {{"addr", 999}});
+    ProgramRunArgs upd;
+    upd.kernel_run_args.push_back(ProgramRunArgs::KernelRunArgs{
+        .kernel = KernelSpecName{"producer"},
+        .runtime_arg_values = upd_named,
+    });
+    EXPECT_NO_THROW(UpdateProgramRunArgs(program, upd));
+
+    auto prod = program.impl().get_kernel_by_spec_name("producer");
+    // Per-node RTA buffer layout: [named "addr" @ slot 0][vararg0 @ 1][vararg1 @ 2].
+    const auto& rta0 = prod->runtime_args_data(node0);
+    const auto& rta1 = prod->runtime_args_data(node1);
+    ASSERT_GE(rta0.size(), 3u);
+    ASSERT_GE(rta1.size(), 3u);
+    EXPECT_EQ(rta0.data()[0], 999u) << "supplied named RTA on node0 updated";
+    EXPECT_EQ(rta0.data()[1], 10u) << "node0 vararg 0 retained (omitted)";
+    EXPECT_EQ(rta0.data()[2], 11u) << "node0 vararg 1 retained (omitted)";
+    EXPECT_EQ(rta1.data()[0], 200u) << "untouched node1 named RTA retained";
+    EXPECT_EQ(rta1.data()[1], 20u) << "untouched node1 vararg 0 retained";
+    EXPECT_EQ(rta1.data()[2], 21u) << "untouched node1 vararg 1 retained";
+    // CRTA buffer here is just the common varargs (no named CRTAs, tensor bindings, or scratchpad).
+    const auto* crta = prod->common_runtime_args_data().data();
+    EXPECT_EQ(crta[0], 30u) << "common vararg 0 retained (omitted)";
+    EXPECT_EQ(crta[1], 31u) << "common vararg 1 retained (omitted)";
+}
+
 // --- DFB size overrides on the fast path (mock fixture: inspects config, no enqueue) ---
 
 // UpdateProgramRunArgs applies a DFB size override, mirroring the SetProgramRunArgs path.

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_run_args.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_run_args.cpp
@@ -1311,7 +1311,7 @@ TEST_F(ProgramRunArgsTestQuasar, UpdateProgramRunArgs_ResizingBorrowedDFBWithout
     setup.tensor_args = {{TensorParamName{"borrowed_tensor"}, TensorArgument{tensor}}};
     SetProgramRunArgs(program, setup);
 
-    // Partial update resizes the borrowed DFB but omits its (would-be enqueue-invariant) backing tensor.
+    // Partial update resizes the borrowed DFB but omits its backing tensor.
     ProgramRunArgs upd;
     upd.dfb_run_overrides.push_back({.dfb = DFBSpecName{"dfb"}, .num_entries = 4});
     EXPECT_THAT(
@@ -2261,36 +2261,15 @@ TEST_F(ProgramRunArgsTestGen1, MatchPaddedShapeOnly_DynamicWinsWhenBothSet) {
 }
 
 // ============================================================================
-// SECTION: Enqueue-loop invariance + UpdateProgramRunArgs + MergeProgramRunArgs
+// SECTION: UpdateProgramRunArgs (arbitrary partial update) + MergeProgramRunArgs
 // ============================================================================
 
-// --- Spec-time legality: an invariant name must reference a declared named arg ---
+// --- The core contract: omitted args are retained, supplied args are updated ---
 
-TEST_F(ProgramRunArgsTestQuasar, InvariantRuntimeArgNameMustBeDeclaredFails) {
+TEST_F(ProgramRunArgsTestQuasar, UpdateProgramRunArgs_RetainsOmittedCRTA) {
     NodeCoord node{0, 0};
-    ProgramSpec spec = MakeSpecWithNamedArgs(node, /*named_rtas=*/{"real_rta"}, /*named_crtas=*/{});
-    spec.kernels[0].advanced_options.enqueue_invariant_runtime_args = {"not_declared"};
-    EXPECT_THAT(
-        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
-        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("is not a declared named")));
-}
-
-TEST_F(ProgramRunArgsTestQuasar, InvariantCommonRuntimeArgNameMustBeDeclaredFails) {
-    NodeCoord node{0, 0};
-    ProgramSpec spec = MakeSpecWithNamedArgs(node, /*named_rtas=*/{}, /*named_crtas=*/{"real_crta"});
-    spec.kernels[0].advanced_options.enqueue_invariant_common_runtime_args = {"not_declared"};
-    EXPECT_THAT(
-        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
-        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("is not a declared named")));
-}
-
-// --- The core contract: invariant args are retained, regular args are updated ---
-
-TEST_F(ProgramRunArgsTestQuasar, UpdateProgramRunArgs_RetainsInvariantCRTA) {
-    NodeCoord node{0, 0};
-    // Declaration order: keep @ slot 0 (invariant), change @ slot 1 (regular).
+    // Declaration order: keep @ slot 0 (omitted from the update), change @ slot 1 (supplied).
     ProgramSpec spec = MakeSpecWithNamedArgs(node, {}, {"keep", "change"});
-    spec.kernels[0].advanced_options.enqueue_invariant_common_runtime_args = {"keep"};
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
 
     ProgramRunArgs params;
@@ -2301,7 +2280,7 @@ TEST_F(ProgramRunArgsTestQuasar, UpdateProgramRunArgs_RetainsInvariantCRTA) {
     params.kernel_run_args.push_back(MakeKernelRunArgs(KernelSpecName{"compute_kernel"}, node, {}, {}));
     SetProgramRunArgs(program, params);
 
-    // Supply only the regular "change"; omit invariant "keep" and the all-empty compute_kernel.
+    // Supply only "change"; omit "keep" and the all-empty compute_kernel.
     ProgramRunArgs upd;
     upd.kernel_run_args.push_back(ProgramRunArgs::KernelRunArgs{
         .kernel = KernelSpecName{"dm_kernel"},
@@ -2310,14 +2289,13 @@ TEST_F(ProgramRunArgsTestQuasar, UpdateProgramRunArgs_RetainsInvariantCRTA) {
     EXPECT_NO_THROW(UpdateProgramRunArgs(program, upd));
 
     const auto* crta = program.impl().get_kernel_by_spec_name("dm_kernel")->common_runtime_args_data().data();
-    EXPECT_EQ(crta[0], 10u) << "invariant 'keep' must retain its value across a partial update";
-    EXPECT_EQ(crta[1], 99u) << "regular 'change' must be updated";
+    EXPECT_EQ(crta[0], 10u) << "omitted 'keep' must retain its value across a partial update";
+    EXPECT_EQ(crta[1], 99u) << "supplied 'change' must be updated";
 }
 
-TEST_F(ProgramRunArgsTestQuasar, UpdateProgramRunArgs_RetainsInvariantPerNodeRTA) {
+TEST_F(ProgramRunArgsTestQuasar, UpdateProgramRunArgs_RetainsOmittedPerNodeRTA) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeSpecWithNamedArgs(node, {"keep", "change"}, {});
-    spec.kernels[0].advanced_options.enqueue_invariant_runtime_args = {"keep"};
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
 
     ProgramRunArgs params;
@@ -2337,16 +2315,15 @@ TEST_F(ProgramRunArgsTestQuasar, UpdateProgramRunArgs_RetainsInvariantPerNodeRTA
 
     const auto& rta = program.impl().get_kernel_by_spec_name("dm_kernel")->runtime_args(node);
     ASSERT_GE(rta.size(), 2u);
-    EXPECT_EQ(rta[0], 1u) << "invariant 'keep' must retain its value";
-    EXPECT_EQ(rta[1], 99u) << "regular 'change' must be updated";
+    EXPECT_EQ(rta[0], 1u) << "omitted 'keep' must retain its value";
+    EXPECT_EQ(rta[1], 99u) << "supplied 'change' must be updated";
 }
 
-// --- Completeness: a regular (non-invariant) arg may not be omitted ---
+// --- Still enforced: a supplied name must be declared in the schema (no extras) ---
 
-TEST_F(ProgramRunArgsTestQuasar, UpdateProgramRunArgs_MissingRegularCRTAFails) {
+TEST_F(ProgramRunArgsTestQuasar, UpdateProgramRunArgs_UndeclaredCRTANameFails) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeSpecWithNamedArgs(node, {}, {"keep", "change"});
-    spec.kernels[0].advanced_options.enqueue_invariant_common_runtime_args = {"keep"};
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
 
     ProgramRunArgs full;
@@ -2357,15 +2334,15 @@ TEST_F(ProgramRunArgsTestQuasar, UpdateProgramRunArgs_MissingRegularCRTAFails) {
     full.kernel_run_args.push_back(MakeKernelRunArgs(KernelSpecName{"compute_kernel"}, node, {}, {}));
     SetProgramRunArgs(program, full);
 
-    // Supply only the invariant "keep"; omit the regular "change" → error.
+    // Supplying a name that the schema never declared is still an error, even on the partial path.
     ProgramRunArgs upd;
     upd.kernel_run_args.push_back(ProgramRunArgs::KernelRunArgs{
         .kernel = KernelSpecName{"dm_kernel"},
-        .common_runtime_arg_values = {{"keep", 11}},
+        .common_runtime_arg_values = {{"bogus", 11}},
     });
     EXPECT_THAT(
         [&] { UpdateProgramRunArgs(program, upd); },
-        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("is missing named CRTA 'change'")));
+        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("not declared in the schema")));
 }
 
 // --- Precondition: a partial update before any full set fails ---
@@ -2373,7 +2350,6 @@ TEST_F(ProgramRunArgsTestQuasar, UpdateProgramRunArgs_MissingRegularCRTAFails) {
 TEST_F(ProgramRunArgsTestQuasar, UpdateProgramRunArgs_BeforeSetFails) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeSpecWithNamedArgs(node, {}, {"keep", "change"});
-    spec.kernels[0].advanced_options.enqueue_invariant_common_runtime_args = {"keep"};
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
 
     ProgramRunArgs upd;
@@ -2386,11 +2362,11 @@ TEST_F(ProgramRunArgsTestQuasar, UpdateProgramRunArgs_BeforeSetFails) {
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("CRTA buffer not allocated")));
 }
 
-// --- Kernel-omission rule ---
+// --- Kernel omission: an omitted kernel retains all of its args ---
 
-TEST_F(ProgramRunArgsTestQuasar, UpdateProgramRunArgs_OmittingKernelWithRegularArgsFails) {
+TEST_F(ProgramRunArgsTestQuasar, UpdateProgramRunArgs_OmittingKernelRetainsArgs) {
     NodeCoord node{0, 0};
-    ProgramSpec spec = MakeSpecWithNamedArgs(node, {}, {"change"});  // regular CRTA, nothing invariant
+    ProgramSpec spec = MakeSpecWithNamedArgs(node, {}, {"change"});
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
 
     ProgramRunArgs full;
@@ -2401,32 +2377,11 @@ TEST_F(ProgramRunArgsTestQuasar, UpdateProgramRunArgs_OmittingKernelWithRegularA
     full.kernel_run_args.push_back(MakeKernelRunArgs(KernelSpecName{"compute_kernel"}, node, {}, {}));
     SetProgramRunArgs(program, full);
 
-    // Omit dm_kernel entirely though it has a regular CRTA → error.
-    ProgramRunArgs upd;
-    EXPECT_THAT(
-        [&] { UpdateProgramRunArgs(program, upd); },
-        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("was omitted from UpdateProgramRunArgs")));
-}
-
-TEST_F(ProgramRunArgsTestQuasar, UpdateProgramRunArgs_OmittingAllInvariantKernelSucceeds) {
-    NodeCoord node{0, 0};
-    ProgramSpec spec = MakeSpecWithNamedArgs(node, {}, {"keep"});  // single CRTA, invariant
-    spec.kernels[0].advanced_options.enqueue_invariant_common_runtime_args = {"keep"};
-    Program program = MakeProgramFromSpec(*mesh_device_, spec);
-
-    ProgramRunArgs full;
-    full.kernel_run_args.push_back(ProgramRunArgs::KernelRunArgs{
-        .kernel = KernelSpecName{"dm_kernel"},
-        .common_runtime_arg_values = {{"keep", 7}},
-    });
-    full.kernel_run_args.push_back(MakeKernelRunArgs(KernelSpecName{"compute_kernel"}, node, {}, {}));
-    SetProgramRunArgs(program, full);
-
-    // Both kernels may be omitted: dm_kernel's only arg is invariant, compute_kernel is empty.
+    // Omit every kernel: an arbitrary partial update may leave all args untouched.
     ProgramRunArgs upd;
     EXPECT_NO_THROW(UpdateProgramRunArgs(program, upd));
-    EXPECT_EQ(program.impl().get_kernel_by_spec_name("dm_kernel")->common_runtime_args_data().data()[0], 7u)
-        << "invariant CRTA retained even when its kernel is omitted entirely";
+    EXPECT_EQ(program.impl().get_kernel_by_spec_name("dm_kernel")->common_runtime_args_data().data()[0], 20u)
+        << "an omitted kernel's args are retained";
 }
 
 // --- DFB size overrides on the fast path (mock fixture: inspects config, no enqueue) ---
@@ -2481,21 +2436,21 @@ const ProgramRunArgs::KernelRunArgs* FindKernel(const ProgramRunArgs& p, const s
 }
 
 TEST(MergeProgramRunArgs, UnionsDisjointCRTAsForSameKernel) {
-    // The motivating pattern: an invariant-args piece + a volatile-args piece for the SAME kernel
-    // with disjoint named CRTAs merge into one kernel entry holding both.
-    ProgramRunArgs invariant_piece;
-    invariant_piece.kernel_run_args.push_back(ProgramRunArgs::KernelRunArgs{
+    // The motivating pattern: two pieces carrying disjoint named CRTAs for the SAME kernel merge
+    // into one kernel entry holding both.
+    ProgramRunArgs first_piece;
+    first_piece.kernel_run_args.push_back(ProgramRunArgs::KernelRunArgs{
         .kernel = KernelSpecName{"dm_kernel"},
         .common_runtime_arg_values = {{"keep", 10}},
     });
-    ProgramRunArgs volatile_piece;
-    volatile_piece.kernel_run_args.push_back(ProgramRunArgs::KernelRunArgs{
+    ProgramRunArgs second_piece;
+    second_piece.kernel_run_args.push_back(ProgramRunArgs::KernelRunArgs{
         .kernel = KernelSpecName{"dm_kernel"},
         .common_runtime_arg_values = {{"change", 20}},
     });
 
-    std::vector<ProgramRunArgs> rest{volatile_piece};
-    ProgramRunArgs merged = MergeProgramRunArgs(std::move(invariant_piece), rest);
+    std::vector<ProgramRunArgs> rest{second_piece};
+    ProgramRunArgs merged = MergeProgramRunArgs(std::move(first_piece), rest);
 
     const auto* dm = FindKernel(merged, "dm_kernel");
     ASSERT_NE(dm, nullptr);

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
@@ -1095,18 +1095,18 @@ void kernel_main() {
     spec.kernels = {producer, consumer};
     spec.dataflow_buffers = {dfb};
     spec.scratchpads = {ScratchpadSpec{.unique_id = ScratchpadSpecName{"pad"}, .size_per_node = kScratchpadBytes}};
-    // enqueue_invariant so the UPDATE phase may omit it (retaining its bound tensor) — exercises the
-    // "invariant tensor retained across partial update" path. dynamic_tensor_shape widens the binding to
+    // The UPDATE phase omits this tensor (retaining its bound tensor) — exercises the
+    // "omitted tensor retained across partial update" path. dynamic_tensor_shape widens the binding to
     // two CRTA words (base + aligned_page_size) — the multi-word binding this test exists to stress.
     spec.tensor_parameters = {TensorParameter{
         .unique_id = TensorParamName{"io"},
         .spec = tensor_spec,
-        .advanced_options = TensorParameterAdvancedOptions{.enqueue_invariant = true, .dynamic_tensor_shape = true}}};
+        .advanced_options = TensorParameterAdvancedOptions{.dynamic_tensor_shape = true}}};
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit_0", node, {"producer", "consumer"})};
 
     Program program = MakeProgramFromSpec(*mesh_device, spec);
 
-    // Consumer's per-node RTAs (re-supplied on every set/update — they are not enqueue-invariant).
+    // Consumer's per-node RTAs (re-supplied on every set/update in this test).
     auto consumer_args = [&]() {
         return ProgramRunArgs::KernelRunArgs{
             .kernel = KernelSpecName{"consumer"},
@@ -1177,7 +1177,7 @@ void kernel_main() {
         << "partial update: vararg 0 landed at the wrong offset — the vararg base must be "
            "named + tensor-binding(2 words) + scratchpad section words (the A1 sum with a multi-word binding).";
     EXPECT_EQ(u[5], kVararg1Upd) << "partial update: vararg 1 landed at the wrong offset";
-    // Not touched by this update — the invariant tensor's binding (both words) and the scratchpad must survive.
+    // Not touched by this update — the omitted tensor's binding (both words) and the scratchpad must survive.
     EXPECT_EQ(u[2], tensor_base) << "tensor-binding base slot was clobbered by the named/vararg partial update";
     EXPECT_EQ(u[6], kExpectedPageSize) << "tensor-binding page-size slot was clobbered by the partial update";
     EXPECT_EQ(u[3], scratch_base) << "scratchpad slot was clobbered by the named/vararg partial update";

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/advanced_options.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/advanced_options.hpp
@@ -44,21 +44,6 @@ using DFBSpecName = ttsl::StrongType<std::string, struct DFBSpecNameTag>;
 
 struct KernelAdvancedOptions {
     ////////////////////////////////////////////////////////////////////////////////
-    // Enqueue-loop invariant kernel arguments
-    ////////////////////////////////////////////////////////////////////////////////
-
-    // Designate certain runtime arguments and common runtime arguments as enqueue-loop
-    // invariant. This permits the same argument value to be reused across multiple Program
-    // enqueues via UpdateProgramRunArgs, which can improve performance in enqueue loops.
-    // By default, every runtime argument and common runtime argument is expected to be
-    // re-specified (via SetProgramRunArgs) on every enqueue.
-    //
-    // CAUTION: This feature is unsafe if used incorrectly! The onus is on the programmer
-    // to ensure that the designated arguments remain valid across enqueues.
-    Group<std::string> enqueue_invariant_runtime_args;
-    Group<std::string> enqueue_invariant_common_runtime_args;
-
-    ////////////////////////////////////////////////////////////////////////////////
     // Varargs
     ////////////////////////////////////////////////////////////////////////////////
 
@@ -187,22 +172,6 @@ struct SemaphoreAdvancedOptions {
 };
 
 struct TensorParameterAdvancedOptions {
-    ////////////////////////////////////////////////////////////////////////////////
-    // Enqueue-loop invariance
-    ////////////////////////////////////////////////////////////////////////////////
-
-    // Designate this TensorParameter as enqueue-loop invariant.
-    // Permits the same MeshTensor argument to be reused across multiple Program
-    // enqueues via UpdateProgramRunArgs. By default, a TensorParameter is expected to
-    // be re-specified on every enqueue.
-    //
-    // CAUTION:
-    // The user is responsible for managing the MeshTensor argument's lifetime and
-    // ensuring that it remains valid across enqueues. Undefined behavior will result
-    // if the MeshTensor goes out of scope (and its device memory is deallocated),
-    // and you try to re-enqueue the Program with the now-stale MeshTensor argument.
-    bool enqueue_invariant = false;
-
     ////////////////////////////////////////////////////////////////////////////////
     // TensorSpec match relaxation options
     ////////////////////////////////////////////////////////////////////////////////

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/program.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/program.hpp
@@ -73,24 +73,20 @@ distributed::MeshWorkload MakeMeshWorkloadFromSpec(
 // If stateful behavior of parameters is required, use the power user APIs.
 void SetProgramRunArgs(Program& program, const ProgramRunArgs& params, bool skip_validation = false);
 
-// Fast-path partial update: refresh ONLY a subset of arguments for an existing Program.
-// All other arguments exhibit STATEFUL behavior: they retain their values from whatever they
-// were most recently set to.
+// Fast-path partial update: refresh an ARBITRARY subset of arguments for an existing Program.
+// Any argument not supplied exhibits STATEFUL behavior: it retains the value it was most recently
+// set to.
 //
 // PRE-CONDITION: SetProgramRunArgs must have been called previously.
 //
-// CAUTION: It is the caller's responsibility to ensure that the stateful, enqueue-invariant
-// tensor and runtime arguments being retained are still valid in the new execution context.
+// CAUTION: It is the caller's responsibility to ensure that the stateful arguments being retained
+// are still valid in the new execution context. This is especially important for retained tensor
+// arguments: if the previously-bound MeshTensor has gone out of scope (and its device memory has
+// been deallocated), re-enqueuing with the now-stale binding is undefined behavior.
 //
-// COMPLETENESS: Only those tensor and runtime arguments that have been specified in the
-// ProgramSpec as enqueue-loop invariant (via the AdvancedOptions fields) may be omitted
-// when calling UpdateProgramRunArgs. All regular arguments must be specified. This is enforced
-// by runtime validation checks.
-//
-// USE CASE: Program re-enqueue loops where only a subset of ProgramRunArgs need to be mutated
-// per iteration. This saves the host overhead of re-computing, re-specifying and re-validating
-// the full ProgramRunArgs if only a few arguments change per iteration. The onus is on the
-// programmer to ensure that the retained arguments remain valid across iterations.
+// USE CASE: Program re-enqueue loops where only a subset of ProgramRunArgs change per iteration.
+// This saves the host overhead of re-computing, re-specifying and re-validating the full
+// ProgramRunArgs when only a few arguments change per iteration.
 //
 // NOTE: DFB size overrides follow the same stateful rule — a DFB whose size is not overridden here
 //       retains its current size (as last set), rather than reverting to the ProgramSpec default.

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/program_run_args.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/program_run_args.hpp
@@ -59,9 +59,9 @@ struct ProgramRunArgs {
         //  set, for every node the kernel runs on.
         //  Missing arguments or superfluous arguments will trigger validation errors.
         //
-        // When calling UpdateProgramRunArgs:
-        //  Only non-enqueue invariant runtime arguments must be set.
-        //  Updated arguments must be updated for every node the kernel runs on.
+        // When calling UpdateProgramRunArgs (arbitrary partial args update):
+        //  Any subset of Program arguments may be supplied; any omitted ones retain their prior value.
+        //  A supplied runtime argument may target any subset of the kernel's nodes.
         //
         // NOTE: If a kernel runtime argument always has the same value for all nodes,
         // passing a common runtime argument would provide better dispatch efficiency.
@@ -75,9 +75,8 @@ struct ProgramRunArgs {
         //  Every argument in this kernel's RuntimeArgSchema::common_runtime_arg_names
         //  must be set.
         //
-        // When calling UpdateProgramRunArgs:
-        //  Only non-enqueue invariant common runtime arguments must be set.
-        //  (However, CRTAs should seldom-to-never be enqueue invariant!)
+        // When calling UpdateProgramRunArgs (arbitrary partial update):
+        //  Any subset of common runtime arguments may be supplied; omitted ones retain their prior value.
         //
         using CommonRuntimeArgValues = Table<std::string, uint32_t>;
         CommonRuntimeArgValues common_runtime_arg_values;
@@ -87,7 +86,9 @@ struct ProgramRunArgs {
         // positional vararg values.
         AdvancedKernelRunArgs advanced_options;
     };
-    // A KernelRunArgs must be specified for ALL kernels in the ProgramSpec.
+    // For SetProgramRunArgs, a KernelRunArgs must be specified for ALL kernels in the ProgramSpec
+    //  (except for kernels that have no runtime or common runtime arguments).
+    // For UpdateProgramRunArgs, any kernel may be omitted (its arguments retain their prior values).
     Group<KernelRunArgs> kernel_run_args;
 
     ////////////////////////////////////////////////////////////////////////
@@ -98,8 +99,17 @@ struct ProgramRunArgs {
     // (Non-owning reference. Will also permit MeshTensorView when it becomes available.)
     using TensorArgument = std::variant<std::reference_wrapper<const MeshTensor>>;
 
-    // A TensorArgument must be specified for EVERY TensorParameter declared in the ProgramSpec.
-    // The argument's TensorSpec must match the TensorParameter's TensorSpec (shape, layout, data type).
+    // A TensorArgument must be specified:
+    //  For EVERY TensorParameter in the ProgramSpec, when calling SetProgramRunArgs.
+    //  For any SUBSET of TensorParameters, when calling UpdateProgramRunArgs. (For advanced users only.)
+    //
+    // CAUTION: MeshTensor is an RAII object. The user is responsible for ensuring that the MeshTensor
+    //          object remains alive until the last Program execution that uses it has completed on the
+    //          device. Use extreme caution if you use UpdateProgramRunArgs with an incomplete set of
+    //          TensorArguments. A stale binding to a destroyed MeshTensor will produce undefined behavior.
+    //
+    // The argument's TensorSpec MUST match the TensorParameter's TensorSpec (shape, layout, data type).
+    // (Any declared TensorParameter relaxations will modify the matching rules; see advanced_options.hpp.)
     Table<TensorParamName, TensorArgument> tensor_args;
 
     ////////////////////////////////////////////////////////////////////////
@@ -115,8 +125,9 @@ struct ProgramRunArgs {
         std::optional<uint32_t> entry_size = std::nullopt;
         std::optional<uint32_t> num_entries = std::nullopt;
 
-        // Note: borrowed-memory DFBs update their backing L1 SRAM address from
-        // the corresponding tensor_arg.
+        // NOTE: Borrowed-memory DFBs update their backing L1 SRAM address from the corresponding
+        // tensor_arg. If you update a borrowed-memory DFB size from an UpdateProgramRunArgs call
+        // (i.e. partial args update; advanced users only) you must ALSO supply its backing tensor_arg.
     };
     // DFBRunOverrides is optional. Provide entries only when overriding DFB sizes.
     Group<DFBRunOverrides> dfb_run_overrides;

--- a/tt_metal/impl/metal2_host_api/program_run_args.cpp
+++ b/tt_metal/impl/metal2_host_api/program_run_args.cpp
@@ -35,7 +35,8 @@ const AdvancedKernelRunArgs::Varargs& kernel_common_runtime_varargs(const Progra
 }
 
 // Internal validation function - validates a TensorArgument list against the Program's TensorParameters.
-// Shared by SetProgramRunArgs (full path) and UpdateTensorArgs (partial path).
+// Shared by the full path (SetProgramRunArgs, UpdateTensorArgs; require_all=true) and the arbitrary
+// partial-update path (UpdateProgramRunArgs; require_all=false).
 //   - No duplicate tensor_parameter_name entries
 //   - Every entry references a TensorParameter declared in the ProgramSpec
 //   - The supplied MeshTensor's TensorSpec matches the binding's expected TensorSpec, with the
@@ -48,10 +49,9 @@ const AdvancedKernelRunArgs::Varargs& kernel_common_runtime_varargs(const Progra
 //       - dynamic_tensor_shape=true: tensor_layout() must match exactly, and the logical_shape
 //         rank must match. Both logical_shape and padded_shape per-dim values may differ.
 //     See the field doc comments in tensor_parameter.hpp for the full contracts.
-//   - Every declared TensorParameter must be set
-//   - Every declared TensorParameter must be set, UNLESS require_all is false (partial update),
-//     in which case TensorParameters declared enqueue-loop invariant may be omitted (their
-//     previously-bound MeshTensor is retained).
+//   - When require_all is true: every declared TensorParameter must be set.
+//   - When require_all is false (partial update): any TensorParameter may be omitted; its
+//     previously-bound MeshTensor is retained. Supplied entries are still validated as above.
 void ValidateTensorArgs(
     const Program& program,
     const Table<TensorParamName, ProgramRunArgs::TensorArgument>& tensor_args,
@@ -113,16 +113,15 @@ void ValidateTensorArgs(
                 param_name);
         }
     }
-    for (const std::string& declared : program_impl.get_registered_tensor_parameter_names()) {
-        if (!require_all && program_impl.get_tensor_parameter_enqueue_invariant(declared)) {
-            // Partial update: an enqueue-invariant TensorParameter may be omitted; its previously
-            // bound MeshTensor is retained.
-            continue;
+    // Completeness is only enforced on the full path. On the partial-update path any TensorParameter
+    // may be omitted (its previously-bound MeshTensor is retained).
+    if (require_all) {
+        for (const std::string& declared : program_impl.get_registered_tensor_parameter_names()) {
+            TT_FATAL(
+                tensor_parameters_with_params.contains(declared),
+                "TensorParameter '{}' is declared in the Program but has no TensorArgument entry.",
+                declared);
         }
-        TT_FATAL(
-            tensor_parameters_with_params.contains(declared),
-            "TensorParameter '{}' is declared in the Program but has no TensorArgument entry.",
-            declared);
     }
 }
 
@@ -431,9 +430,9 @@ void AttachBorrowedDFBBuffers(
     for (const auto& [dfb_id, tp_name] : borrowed_bindings) {
         auto it = tensor_by_param.find(tp_name);
         if (it == tensor_by_param.end()) {
-            // Partial update (require_all=false): the borrowed TensorParameter is enqueue-invariant
-            // and was omitted; the DFB keeps its previously-attached backing buffer. On the full
-            // path (require_all=true) every borrowed binding must have been supplied.
+            // Partial update (require_all=false): the borrowed TensorParameter was omitted; the DFB
+            // keeps its previously-attached backing buffer. On the full path (require_all=true) every
+            // borrowed binding must have been supplied.
             TT_FATAL(
                 !require_all,
                 "Internal error: DFB id {} borrows from TensorParameter '{}' but no TensorArgument supplied it "
@@ -906,13 +905,18 @@ void MergeKernelRunArgsInto(
     }
 }
 
-// Validation for the partial fast-path UpdateProgramRunArgs.
+// Validation for the partial-update path UpdateProgramRunArgs.
 //
-// Differs from ValidateProgramRunArgs in exactly one dimension: named RTAs/CRTAs and tensor
-// parameters declared enqueue-loop invariant MAY be omitted — the value installed by the prior
-// SetProgramRunArgs is retained. All other ("regular") args must still be fully specified.
-// Varargs are positional and can never be invariant, so they must always be supplied when the
-// schema declares them.
+// UpdateProgramRunArgs applies an ARBITRARY subset of a Program's ProgramRunArgs; any arg not
+// supplied retains the value installed by the most recent SetProgramRunArgs. So, unlike the full
+// ValidateProgramRunArgs, this imposes NO completeness requirement — kernels, named RTAs/CRTAs,
+// varargs, and tensor args may all be freely omitted. Whatever IS supplied is still validated:
+// names must be declared (no extras), target nodes must belong to the kernel, and a supplied
+// vararg section's count must match the schema.
+//
+// The one exception to "tensor args may be omitted": resizing a borrowed-memory DFB requires
+// supplying that DFB's backing TensorParameter in the same update, so the per-bank fit check can
+// re-run against the new size (see the borrowed-DFB guard in the dfb_run_overrides loop below).
 void ValidateUpdateProgramRunArgs(const Program& program, const ProgramRunArgs& params) {
     const detail::ProgramImpl& program_impl = program.impl();
 
@@ -934,10 +938,14 @@ void ValidateUpdateProgramRunArgs(const Program& program, const ProgramRunArgs& 
         const std::shared_ptr<Kernel> kernel = program_impl.get_kernel_by_spec_name(kernel_name.get());
         const std::set<CoreCoord>& kernel_nodes = kernel->logical_cores();
 
-        // --- Vararg RTA counts per node (varargs are never invariant; identical to the full path) ---
-        std::unordered_set<NodeCoord> nodes_with_vararg_params;
+        // --- Vararg RTAs: a node's vararg section may be omitted (retaining its prior value). If
+        //     supplied, its target node must belong to the kernel and its count must match the
+        //     schema for that node. An empty section is treated as omitted (matching both the
+        //     patch step below and the common-vararg handling). ---
         for (const auto& [node_coord, args] : kernel_runtime_varargs(kernel_params)) {
-            nodes_with_vararg_params.insert(node_coord);
+            if (args.empty()) {
+                continue;
+            }
             TT_FATAL(
                 kernel_nodes.contains(node_coord),
                 "Kernel '{}' is setting runtime_varargs for node {}, but the kernel does not run on that node.",
@@ -954,81 +962,41 @@ void ValidateUpdateProgramRunArgs(const Program& program, const ProgramRunArgs& 
                 expected_varargs,
                 args.size());
         }
-        for (const auto& [node_coord, expected_count] : schema->num_runtime_varargs_per_node) {
-            if (expected_count == 0) {
-                continue;
-            }
+
+        // --- Common varargs: may be omitted (empty). If supplied, the count must match the schema. ---
+        const auto& common_varargs = kernel_common_runtime_varargs(kernel_params);
+        if (!common_varargs.empty()) {
             TT_FATAL(
-                nodes_with_vararg_params.contains(node_coord),
-                "Kernel '{}' is missing vararg runtime args for node {} (expected {}). Varargs cannot be "
-                "enqueue-invariant and must be supplied to UpdateProgramRunArgs.",
+                common_varargs.size() == schema->num_common_runtime_varargs,
+                "Kernel '{}' expects {} vararg common runtime args, but {} were provided",
                 kernel_name,
-                node_coord.str(),
-                expected_count);
+                schema->num_common_runtime_varargs,
+                common_varargs.size());
         }
 
-        // --- Common vararg count (never invariant) ---
-        TT_FATAL(
-            kernel_common_runtime_varargs(kernel_params).size() == schema->num_common_runtime_varargs,
-            "Kernel '{}' expects {} vararg common runtime args, but {} were provided",
-            kernel_name,
-            schema->num_common_runtime_varargs,
-            kernel_common_runtime_varargs(kernel_params).size());
-
-        // --- Named RTAs: supplied names must be declared (no extras); every non-invariant name
-        //     must be supplied for every node; invariant names may be omitted. ---
-        const auto& named_rta_names = schema->runtime_arg_names;
-        const std::unordered_set<std::string> named_rta_name_set(named_rta_names.begin(), named_rta_names.end());
-        std::vector<std::string> regular_rta_names;
-        for (const auto& n : named_rta_names) {
-            if (!schema->enqueue_invariant_runtime_arg_names.contains(n)) {
-                regular_rta_names.push_back(n);
-            }
-        }
-        std::unordered_set<NodeCoord> nodes_with_named_params;
+        // --- Named RTAs: any may be omitted. Supplied names must be declared (no extras) and their
+        //     target nodes must belong to the kernel. ---
+        const std::unordered_set<std::string> named_rta_name_set(
+            schema->runtime_arg_names.begin(), schema->runtime_arg_names.end());
         for (const auto& [name, per_node] : kernel_params.runtime_arg_values) {
+            TT_FATAL(
+                named_rta_name_set.contains(name),
+                "Kernel '{}' sets named RTA '{}' which is not declared in the schema.",
+                kernel_name,
+                name);
             for (const auto& [node, _value] : per_node) {
                 (void)_value;
-                nodes_with_named_params.insert(node);
                 TT_FATAL(
                     kernel_nodes.contains(node),
                     "Kernel '{}' is setting runtime_arg_values for node {}, but the kernel does not run on that node.",
                     kernel_name,
                     node.str());
-                TT_FATAL(
-                    named_rta_name_set.contains(name),
-                    "Kernel '{}' node {} sets named RTA '{}' which is not declared in the schema.",
-                    kernel_name,
-                    node.str(),
-                    name);
-            }
-        }
-        if (!regular_rta_names.empty()) {
-            for (const auto& node : kernel_nodes) {
-                TT_FATAL(
-                    nodes_with_named_params.contains(node),
-                    "Kernel '{}' has non-invariant named RTAs but no runtime_arg_values provided for node {}.",
-                    kernel_name,
-                    node.str());
-            }
-        }
-        // Every non-invariant named RTA must be supplied for every node the kernel runs on.
-        for (const auto& rname : regular_rta_names) {
-            auto per_node = kernel_params.runtime_arg_values.get(rname);
-            for (const auto& node : kernel_nodes) {
-                TT_FATAL(
-                    per_node.has_value() && per_node->get(node).has_value(),
-                    "Kernel '{}' node {} is missing named RTA '{}', which is not declared enqueue-invariant and so "
-                    "must be supplied to UpdateProgramRunArgs.",
-                    kernel_name,
-                    node.str(),
-                    rname);
             }
         }
 
-        // --- Named CRTAs: regular ones must be supplied; invariant may be omitted; no extras. ---
-        const auto& named_crta_names = schema->common_runtime_arg_names;
-        const std::unordered_set<std::string> named_crta_name_set(named_crta_names.begin(), named_crta_names.end());
+        // --- Named CRTAs: any may be omitted. Supplied names must be declared (no extras). ---
+        const std::unordered_set<std::string> named_crta_name_set(
+            schema->common_runtime_arg_names.begin(), schema->common_runtime_arg_names.end());
         for (const auto& [name, _value] : kernel_params.common_runtime_arg_values) {
             (void)_value;
             TT_FATAL(
@@ -1037,58 +1005,14 @@ void ValidateUpdateProgramRunArgs(const Program& program, const ProgramRunArgs& 
                 kernel_name,
                 name);
         }
-        for (const auto& name : named_crta_names) {
-            if (schema->enqueue_invariant_common_runtime_arg_names.contains(name)) {
-                continue;
-            }
-            TT_FATAL(
-                kernel_params.common_runtime_arg_values.get(name).has_value(),
-                "Kernel '{}' is missing named CRTA '{}', which is not declared enqueue-invariant and so must be "
-                "supplied to UpdateProgramRunArgs.",
-                kernel_name,
-                name);
-        }
-    }
-
-    // A registered kernel may be omitted from kernel_run_args only if it has nothing regular to
-    // supply: no non-invariant named RTAs, no non-invariant named CRTAs, and no varargs.
-    for (const auto& name : program_impl.get_registered_kernel_names()) {
-        if (kernels_with_params.contains(KernelSpecName{name})) {
-            continue;
-        }
-        const KernelRTASchema* schema = program_impl.get_kernel_rta_schema(name);
-        if (schema == nullptr) {
-            continue;
-        }
-        bool has_regular_rta = false;
-        for (const auto& n : schema->runtime_arg_names) {
-            if (!schema->enqueue_invariant_runtime_arg_names.contains(n)) {
-                has_regular_rta = true;
-                break;
-            }
-        }
-        bool has_regular_crta = false;
-        for (const auto& n : schema->common_runtime_arg_names) {
-            if (!schema->enqueue_invariant_common_runtime_arg_names.contains(n)) {
-                has_regular_crta = true;
-                break;
-            }
-        }
-        const bool has_varargs =
-            !schema->num_runtime_varargs_per_node.empty() || schema->num_common_runtime_varargs > 0;
-        TT_FATAL(
-            !(has_regular_rta || has_regular_crta || has_varargs),
-            "Kernel '{}' has non-invariant runtime args (or varargs) but was omitted from UpdateProgramRunArgs. Only "
-            "kernels whose every runtime arg is enqueue-invariant — and which have no varargs — may be omitted.",
-            name);
     }
 
     // DFB run overrides: same checks as the full path (duplicates; non-zero size overrides), plus a
-    // partial-path-only guard for borrowed-memory DFBs (below). A resized borrowed DFB must have its
-    // backing TensorParameter supplied in this same update, so AttachBorrowedDFBBuffers re-runs the
-    // per-bank fit check against the new size. The full Set path gets this for free (require_all=true);
-    // on the partial path an invariant backing tensor may be omitted, which would otherwise let a grown
-    // DFB overflow its borrowed buffer's per-bank region unchecked at execution.
+    // partial-path-only correctness guard for borrowed-memory DFBs (below). A resized borrowed DFB
+    // must have its backing TensorParameter supplied in this same update, so AttachBorrowedDFBBuffers
+    // re-runs the per-bank fit check against the new size. The full Set path gets this for free
+    // (require_all=true); on this partial path the backing tensor may be omitted, which would
+    // otherwise let a grown DFB overflow its borrowed buffer's per-bank region unchecked at execution.
     std::unordered_map<uint32_t, std::string> borrowed_backing;  // dfb_id -> backing TensorParameter name
     for (const auto& [dfb_id, tp_name] : program_impl.get_dfb_borrowed_bindings()) {
         borrowed_backing.emplace(dfb_id, tp_name);
@@ -1132,7 +1056,8 @@ void ValidateUpdateProgramRunArgs(const Program& program, const ProgramRunArgs& 
         }
     }
 
-    // Tensor args: non-invariant TensorParameters must be supplied; invariant ones may be omitted.
+    // Tensor args: any TensorParameter may be omitted (its prior MeshTensor is retained); supplied
+    // ones are validated against their declared spec.
     ValidateTensorArgs(program, params.tensor_args, /*require_all=*/false);
 }
 
@@ -1149,9 +1074,9 @@ void UpdateProgramRunArgs(Program& program, const ProgramRunArgs& params, bool s
         ValidateUpdateProgramRunArgs(program, params);
     }
 
-    // Patch the supplied args in place. Omitted (enqueue-invariant) named args and tensor params
-    // are left untouched, retaining the value installed by the most recent SetProgramRunArgs.
-    // Positional varargs are never invariant, so a supplied vararg section refreshes wholesale.
+    // Patch the supplied args in place. Omitted named args and tensor params are left untouched,
+    // retaining the value installed by the most recent SetProgramRunArgs. A supplied positional
+    // vararg section refreshes that section wholesale.
     for (const auto& kernel_params : params.kernel_run_args) {
         const auto& kernel_name = kernel_params.kernel;
         std::shared_ptr<Kernel> kernel = program_impl.get_kernel_by_spec_name(kernel_name.get());
@@ -1256,7 +1181,7 @@ void UpdateProgramRunArgs(Program& program, const ProgramRunArgs& params, bool s
     program_impl.apply_dfb_size_overrides(size_overrides);
 
     // ---- Tensor bindings: patch CRTA address slots for SUPPLIED tensors only ----
-    // (Invariant tensors omitted from params keep their previously-patched binding slots.)
+    // (Tensors omitted from params keep their previously-patched binding slots.)
     if (!params.tensor_args.empty()) {
         std::unordered_map<std::string, const MeshTensor*> tensor_by_param;
         tensor_by_param.reserve(params.tensor_args.size());
@@ -1289,14 +1214,14 @@ void UpdateProgramRunArgs(Program& program, const ProgramRunArgs& params, bool s
             for (const auto& handle : binding_handles) {
                 auto t_it = tensor_by_param.find(handle.tensor_parameter_name);
                 if (t_it == tensor_by_param.end()) {
-                    continue;  // invariant tensor omitted → binding slot retained.
+                    continue;  // tensor omitted → binding slot retained.
                 }
                 uint32_t* dst = crta.data() + (handle.addr_crta_offset / sizeof(uint32_t));
                 EmitBindingCrtaValues(handle, *t_it->second, [&dst](uint32_t w) { *dst++ = w; });
             }
         }
 
-        // Re-attach borrowed-memory DFBs for the supplied tensors (skip omitted invariant ones).
+        // Re-attach borrowed-memory DFBs for the supplied tensors (skip omitted ones).
         AttachBorrowedDFBBuffers(program_impl, tensor_by_param, /*require_all=*/false);
     }
 }
@@ -1332,8 +1257,8 @@ ProgramRunArgs MergeProgramRunArgs(ProgramRunArgs base, std::span<const ProgramR
         }
 
         // Kernel run args: union per kernel (a kernel may appear in multiple inputs as long as
-        // the actual args it carries are disjoint — e.g. one input's invariant args, another's
-        // volatile args for the same kernel).
+        // the actual args it carries are disjoint — e.g. one input carries some of the kernel's
+        // args, another input the rest).
         for (const auto& kra : other.kernel_run_args) {
             ProgramRunArgs::KernelRunArgs* dst = nullptr;
             for (auto& existing : base.kernel_run_args) {

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -743,35 +743,6 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
         }
     }
 
-    // Validate enqueue-loop-invariant named-arg declarations: each invariant name must reference a
-    // declared named RTA / CRTA. Invariance requires naming the argument, so positional varargs
-    // cannot be marked invariant.
-    for (const auto& kernel : spec.kernels) {
-        const std::unordered_set<std::string> declared_rtas(
-            kernel.runtime_arg_schema.runtime_arg_names.begin(), kernel.runtime_arg_schema.runtime_arg_names.end());
-        for (const auto& name : kernel.advanced_options.enqueue_invariant_runtime_args) {
-            TT_FATAL(
-                declared_rtas.contains(name),
-                "KernelSpec '{}' marks runtime arg '{}' enqueue-loop invariant, but it is not a declared named runtime "
-                "arg (runtime_arg_schema.runtime_arg_names). Only named runtime args can be marked invariant; "
-                "positional varargs cannot.",
-                kernel.unique_id,
-                name);
-        }
-        const std::unordered_set<std::string> declared_crtas(
-            kernel.runtime_arg_schema.common_runtime_arg_names.begin(),
-            kernel.runtime_arg_schema.common_runtime_arg_names.end());
-        for (const auto& name : kernel.advanced_options.enqueue_invariant_common_runtime_args) {
-            TT_FATAL(
-                declared_crtas.contains(name),
-                "KernelSpec '{}' marks common runtime arg '{}' enqueue-loop invariant, but it is not a declared named "
-                "common runtime arg (runtime_arg_schema.common_runtime_arg_names). Only named common runtime args can "
-                "be marked invariant; positional varargs cannot.",
-                kernel.unique_id,
-                name);
-        }
-    }
-
     // Validate kernel thread counts
     for (const auto& kernel : spec.kernels) {
         TT_FATAL(kernel.num_threads > 0, "KernelSpec '{}' has no threads!", kernel.unique_id);
@@ -2956,9 +2927,8 @@ Program BuildProgramFromSpec(distributed::MeshDevice& mesh_device, const Program
     for (const auto& tensor_parameter : spec.tensor_parameters) {
         const bool dyn_shape = tensor_parameter.advanced_options.dynamic_tensor_shape;
         const bool match_padded_only = tensor_parameter.advanced_options.match_padded_shape_only;
-        const bool enqueue_invariant = tensor_parameter.advanced_options.enqueue_invariant;
         program_impl->register_tensor_parameter(
-            tensor_parameter.unique_id.get(), tensor_parameter.spec, dyn_shape, match_padded_only, enqueue_invariant);
+            tensor_parameter.unique_id.get(), tensor_parameter.spec, dyn_shape, match_padded_only);
     }
 
     // Create DataflowBuffers and build name -> ID map.
@@ -3176,16 +3146,6 @@ Program BuildProgramFromSpec(distributed::MeshDevice& mesh_device, const Program
         }
         for (size_t i = 0; i < runtime_schema.common_runtime_arg_names.size(); ++i) {
             runtime_schema.common_runtime_arg_name_to_slot.emplace(runtime_schema.common_runtime_arg_names[i], i);
-        }
-
-        // Enqueue-loop-invariant named args. Each is a subset of the declared named RTAs/CRTAs and
-        // may be omitted from a partial UpdateProgramRunArgs call (retaining its value). Legality
-        // (each invariant name actually names a declared arg) is checked in ValidateProgramSpec.
-        for (const auto& name : kernel_spec.advanced_options.enqueue_invariant_runtime_args) {
-            runtime_schema.enqueue_invariant_runtime_arg_names.insert(name);
-        }
-        for (const auto& name : kernel_spec.advanced_options.enqueue_invariant_common_runtime_args) {
-            runtime_schema.enqueue_invariant_common_runtime_arg_names.insert(name);
         }
 
         // Varargs schema now lives on KernelAdvancedOptions.

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -720,18 +720,12 @@ void ProgramImpl::reserve_runtime_arg_buffers() {
 }
 
 void ProgramImpl::register_tensor_parameter(
-    const std::string& name,
-    const TensorSpec& spec,
-    bool dynamic_tensor_shape,
-    bool match_padded_shape_only,
-    bool enqueue_invariant) {
+    const std::string& name, const TensorSpec& spec, bool dynamic_tensor_shape, bool match_padded_shape_only) {
     if (!metal2_registry_) {
         metal2_registry_ = Metal2NameRegistry{};
     }
     auto [it, inserted] = metal2_registry_->tensor_parameter_layouts.try_emplace(
-        name,
-        Metal2NameRegistry::RegisteredTensorParameter{
-            spec, dynamic_tensor_shape, match_padded_shape_only, enqueue_invariant});
+        name, Metal2NameRegistry::RegisteredTensorParameter{spec, dynamic_tensor_shape, match_padded_shape_only});
     TT_FATAL(inserted, "Duplicate tensor parameter name: {}", name);
 }
 
@@ -766,17 +760,6 @@ bool ProgramImpl::get_tensor_parameter_match_padded_shape_only(const std::string
         return false;
     }
     return it->second.match_padded_shape_only;
-}
-
-bool ProgramImpl::get_tensor_parameter_enqueue_invariant(const std::string& name) const {
-    if (!metal2_registry_) {
-        return false;
-    }
-    auto it = metal2_registry_->tensor_parameter_layouts.find(name);
-    if (it == metal2_registry_->tensor_parameter_layouts.end()) {
-        return false;
-    }
-    return it->second.enqueue_invariant;
 }
 
 std::vector<std::string> ProgramImpl::get_registered_tensor_parameter_names() const {

--- a/tt_metal/impl/program/program_impl.hpp
+++ b/tt_metal/impl/program/program_impl.hpp
@@ -359,11 +359,7 @@ public:
     void register_dfb_spec_name(const std::string& name, uint32_t dfb_id);
     void register_semaphore_spec_name(const std::string& name, uint32_t sem_id);
     void register_tensor_parameter(
-        const std::string& name,
-        const TensorSpec& spec,
-        bool dynamic_tensor_shape,
-        bool match_padded_shape_only,
-        bool enqueue_invariant);
+        const std::string& name, const TensorSpec& spec, bool dynamic_tensor_shape, bool match_padded_shape_only);
 
     // Metal 2.0: Get handle from name (TT_FATAL if not found)
     KernelHandle get_kernel_handle(const std::string& name) const;
@@ -377,9 +373,6 @@ public:
     // Returns false if the parameter was not registered with match_padded_shape_only=true,
     // or if the name is unknown. (The caller validates known-ness separately.)
     bool get_tensor_parameter_match_padded_shape_only(const std::string& name) const;
-    // Returns false if the parameter was not registered enqueue-invariant, or if the name is
-    // unknown. (The caller validates known-ness separately.)
-    bool get_tensor_parameter_enqueue_invariant(const std::string& name) const;
     std::vector<std::string> get_registered_tensor_parameter_names() const;
 
     // Metal 2.0: register that DFB `dfb_id` borrows its backing L1 memory from the MeshTensor
@@ -413,13 +406,6 @@ public:
         // broadcast count.
         std::unordered_map<CoreCoord, size_t> num_runtime_varargs_per_node;
         size_t num_common_runtime_varargs = 0;
-
-        // Names (each a subset of runtime_arg_names / common_runtime_arg_names) declared
-        // enqueue-loop invariant via KernelAdvancedOptions. These named args may be omitted
-        // from a partial UpdateProgramRunArgs call, in which case the value installed by the
-        // most recent SetProgramRunArgs is retained. (Varargs cannot be marked invariant.)
-        std::unordered_set<std::string> enqueue_invariant_runtime_arg_names;
-        std::unordered_set<std::string> enqueue_invariant_common_runtime_arg_names;
     };
 
     // Metal 2.0: Runtime argument schema registration and lookup
@@ -525,9 +511,6 @@ private:
             TensorSpec spec;
             bool dynamic_tensor_shape = false;
             bool match_padded_shape_only = false;
-            // Declared enqueue-loop invariant: the TensorArgument may be omitted from a partial
-            // UpdateProgramRunArgs call (the previously-bound MeshTensor is retained).
-            bool enqueue_invariant = false;
         };
         std::unordered_map<std::string, RegisteredTensorParameter> tensor_parameter_layouts;
 


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
This PR removes the enqueue-invariance feature from Metal 2.0.

Enqueue-invariance was introduced in #46568. The idea was to explicitly demarcate on the `ProgramSpec` which of the `ProgramRunArgs` _must_ be specified with each enqueue, vs. those that would be set once (i.e. in an outer loop), and held constant over subsequent enqueues (i.e. inner loop enqueue-invariant). This affected legality checks exclusively.

The driving force behind this feature was the TTNN FactoryConcept plan for a seldom used concept (for niche ultra-performance ops) which would be fully safe-by-construction. The TTNN FactoryConcept plans have since shifted, and call for a legacy-style `override_runtime_arguments`. For this factory shape, enqueue-invariance becomes an encumbrance rather than a help.... the `override_runtime_arguments` method itself already documents the non-enqueue-invariant argument subset, and keeping this in sync with `ProgramSpec` enqueue-invariance would be more annoying than helpful.

**Changes:**
 - Delete the `enqueue_invariant` fields from `AdvancedOption`.
 - Update the legality checking code for `UpdateProgramRunArgs` to tolerate arbitrary arg updates.
 - Update the user-facing header comments to document the new behavior.
 - Remove the plumbing that "remembered" the enqueue invariant args info for downstream legality checks.
 - Update unit tests

Nothing ever actually used this feature (outside Metal 2.0 unit tests), so deletion is painless.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=akertesz/remove-enqueue-invariance)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:akertesz/remove-enqueue-invariance)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=akertesz/remove-enqueue-invariance)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:akertesz/remove-enqueue-invariance)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=akertesz/remove-enqueue-invariance)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:akertesz/remove-enqueue-invariance)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=akertesz/remove-enqueue-invariance)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:akertesz/remove-enqueue-invariance)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=akertesz/remove-enqueue-invariance)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:akertesz/remove-enqueue-invariance)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=akertesz/remove-enqueue-invariance)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:akertesz/remove-enqueue-invariance)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=akertesz/remove-enqueue-invariance)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:akertesz/remove-enqueue-invariance)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=akertesz/remove-enqueue-invariance)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:akertesz/remove-enqueue-invariance)