### PR TITLE
Fix Blackhole hang on RM reshape to [N,1]

### DIFF
--- a/tests/ttnn/unit_tests/base_functionality/test_reshape.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_reshape.py
@@ -4,7 +4,6 @@
 
 import math
 import pytest
-
 import torch
 
 import ttnn
@@ -934,3 +933,108 @@ def test_reshape_rm_interleaved_wide_multi_page(device, input_shape, output_shap
     )
     y = ttnn.reshape(x, output_shape)
     assert_equal(t.reshape(*output_shape), ttnn.to_torch(y))
+
+
+@pytest.mark.parametrize(
+    "rows,cols",
+    [
+        # dest_page_size = 1 * sizeof(bf16) = 2B — non-clean RM reshape path (issue #50191).
+        (64, 65),
+        (32, 17),
+    ],
+)
+def test_reshape_rm_unit_last_dim_dram(device, rows, cols):
+    """ROW_MAJOR reshape to [N, 1] on interleaved DRAM must not hang and must be correct.
+
+    Regression for https://github.com/tenstorrent/tt-metal/issues/50191: previously the
+    dual-kernel non-clean path issued millions of barriered 2-byte DRAM writes and could
+    hard-deadlock Blackhole (SYS-1419). Shape is smaller than the issue repro but still
+    hits dest_page_size_bytes=2; loop a few times to catch intermittent hangs.
+    """
+    torch.manual_seed(0)
+    torch_input = torch.randn((rows, cols), dtype=torch.bfloat16)
+    n = rows * cols
+    torch_expected = torch_input.reshape(n, 1)
+
+    for _ in range(8):
+        tt_input = ttnn.from_torch(
+            torch_input,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            device=device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+        tt_out = ttnn.reshape(tt_input, (n, 1))
+        ttnn.synchronize_device(device)
+        actual = ttnn.to_torch(tt_out)
+        assert_equal(torch_expected, actual)
+        ttnn.deallocate(tt_out)
+        ttnn.deallocate(tt_input)
+
+
+@pytest.mark.parametrize(
+    "input_shape,output_shape",
+    [
+        # One accumulate + one drain case on the non-clean path (#50191).
+        ((96, 3), (32, 9)),  # src=6B, dest=18B — accumulate
+        ((32, 9), (96, 3)),  # src=18B, dest=6B — drain
+    ],
+    ids=["accumulate_6_to_18", "drain_18_to_6"],
+)
+def test_reshape_rm_nonclean_misaligned_last_dim(device, input_shape, output_shape):
+    """Non-clean RM DRAM reshape with odd last dims must stay bit-exact (#50191)."""
+    torch.manual_seed(2)
+    torch_input = torch.randn(input_shape, dtype=torch.bfloat16)
+    tt_input = ttnn.from_torch(
+        torch_input,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    tt_out = ttnn.reshape(tt_input, output_shape)
+    ttnn.synchronize_device(device)
+    assert_equal(torch_input.reshape(output_shape), ttnn.to_torch(tt_out))
+
+
+@pytest.mark.parametrize(
+    "input_shape,output_shape",
+    [
+        ((48, 65), (24, 130)),  # dest_page=260B — multi-slot staging
+        # Issue #50191 width: 8 fixed slots would exceed L1; factory must shrink.
+        ((200002, 1), (2, 100001)),
+    ],
+    ids=["dest_page_260B", "dest_page_200002B_issue_width"],
+)
+def test_reshape_rm_nonclean_large_odd_dest_page_l1_cb(device, input_shape, output_shape):
+    """Non-clean RM reshape with large odd dest pages must fit dest CB and be correct."""
+    torch.manual_seed(3)
+    torch_input = torch.randn(input_shape, dtype=torch.bfloat16)
+    tt_input = ttnn.from_torch(
+        torch_input,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    tt_out = ttnn.reshape(tt_input, output_shape)
+    ttnn.synchronize_device(device)
+    assert_equal(torch_input.reshape(output_shape), ttnn.to_torch(tt_out))
+
+
+def test_quasar_reshape_rm_unit_last_dim(device):
+    """Quasar RM factory/kernel: misaligned [N, 1] reshape must stay bit-exact (#50191)."""
+    rows, cols = 32, 17
+    torch.manual_seed(4)
+    torch_input = torch.randn((rows, cols), dtype=torch.bfloat16)
+    n = rows * cols
+    tt_input = ttnn.from_torch(
+        torch_input,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    tt_out = ttnn.experimental.quasar.reshape(tt_input, (n, 1))
+    ttnn.synchronize_device(device)
+    assert_equal(torch_input.reshape(n, 1), ttnn.to_torch(tt_out))

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/device/rm_reshape_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/device/rm_reshape_interleaved.cpp
@@ -5,32 +5,46 @@
 /*
 Function reads from RM and writes to RM
 
-Assumptions:
-
-Compile arguments
-0. src0_is_dram: 1 if source is dram else 0
-1. read_size_is_pow2: 1 if read size is power of 2 else 0
-2. log_base_2_of_page_size: log base 2 of page size
-3. write_size_is_pow2: 1 if write size is power of 2 else 0
-4. log_base_2_of_page_size: log base 2 of page size
-5. needs_read_allignment: 1 if read needs alignment else 0
-//Needed if BRAM and page size is not multiple of 64 bytes
+Compile-time arguments
+0. src_aligned_to_64
+1. src_aligned_to_16
+2. cb_id_in0
+3. cb_id_in1
+4. source_page_size_bytes
+5. dest_page_size_bytes
+6. num_dest_write_slots
+7. dest_slot_size_bytes
+8. dest_write_size_bytes
+9+. TensorAccessorArgs for src, then dst
 
 Runtime arguments
-0. src_addr: source address
-1. dst_addr: destination address
-2. source_read_size_bytes: source read size in bytes
-3. read_start_page: read start page
-4. read_end_page: read end page
-5. write_start_page: write start page
-6. write_start_offset: write start offset
-7. nop: 1 if this core should be skipped
+0. src_addr
+1. dst_addr
+2. source_read_size_bytes
+3. read_start_page
+4. read_end_page
+5. write_start_page
+6. write_start_offset
+7. nop
 */
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
 #include "api/debug/dprint.h"  // required in all kernels using DPRINT
 #include "ttnn/operations/data_movement/common/kernels/common.hpp"
+
+FORCE_INLINE void acquire_dest_slot(Noc noc, uint32_t& slots_in_flight, const uint32_t num_dest_write_slots) {
+    if (slots_in_flight >= num_dest_write_slots) {
+        noc.async_write_barrier();
+        slots_in_flight = 0;
+    }
+}
+
+FORCE_INLINE void advance_dest_slot(
+    uint32_t& dest_slot, uint32_t& slots_in_flight, const uint32_t num_dest_write_slots) {
+    slots_in_flight++;
+    dest_slot = (dest_slot + 1) % num_dest_write_slots;
+}
 
 void kernel_main() {
     // We are guaranteed to be in 2D going to 2D
@@ -52,7 +66,10 @@ void kernel_main() {
     constexpr uint32_t cb_id_in1 = get_compile_time_arg_val(3);
     constexpr uint32_t source_page_size_bytes = get_compile_time_arg_val(4);
     constexpr uint32_t dest_page_size_bytes = get_compile_time_arg_val(5);
-    constexpr auto src_args = TensorAccessorArgs<6>();
+    constexpr uint32_t num_dest_write_slots = get_compile_time_arg_val(6);
+    constexpr uint32_t dest_slot_size_bytes = get_compile_time_arg_val(7);
+    constexpr uint32_t dest_write_size_bytes = get_compile_time_arg_val(8);
+    constexpr auto src_args = TensorAccessorArgs<9>();
     constexpr auto dst_args = TensorAccessorArgs<src_args.next_compile_time_args_offset()>();
 
     // Since we need to operate on a grid of cores but sometimes pages don't split properly, if nop then don't use this
@@ -69,10 +86,7 @@ void kernel_main() {
     uint32_t write_page = write_start_page;
     uint32_t readable = 0;
     uint32_t end_to_write = 0;
-    uint32_t transaction = 0;
     uint32_t writable = dest_page_size_bytes - write_start_offset;
-    // cb_id_in0 is a CB source_read_size_bytes page size, 1 page
-    // cb_id_in1 is a CB dest_page_size_bytes + allignment_to_64 page size, 1 page
     cb_reserve_back(cb_id_in0, 1);
     cb_reserve_back(cb_id_in1, 1);
     const uint32_t source_buffer = get_write_ptr(cb_id_in0);
@@ -85,6 +99,10 @@ void kernel_main() {
     uint64_t begin_write_offset = write_offset;
     constexpr bool can_be_clean = ((source_page_size_bytes % 16) == 0 && (dest_page_size_bytes % 16) == 0);
     uint64_t dst_noc_addr_offset = 0;
+
+    uint32_t dest_slot = 0;
+    uint32_t slots_in_flight = 0;
+
     for (uint32_t i = read_start_page; i < read_end_page; i++) {
         // Drain any prior iteration's writes that read source_buffer before this iteration's read
         // overwrites it: source_buffer is a single fixed CB slot reused every iteration, and the
@@ -115,18 +133,24 @@ void kernel_main() {
 
         // Write to dest
         while (readable > 0) {
-            noc.async_write_barrier();
+            if constexpr (can_be_clean) {
+                noc.async_write_barrier();
+            }
             if (readable < writable) {
                 if constexpr (can_be_clean) {
                     tt::data_movement::common::enhanced_noc_async_write<dest_page_size_bytes, false>(
                         noc, source_buffer + read_offset, dst_noc_addr + dst_noc_addr_offset, readable);
                     dst_noc_addr_offset = dst_noc_addr_offset + readable;
                 } else {
-                    tt::data_movement::common::tt_memmove<false, true, false, dest_page_size_bytes>(
-                        noc, dest_buffer + write_offset, source_buffer + read_offset, readable);
+                    acquire_dest_slot(noc, slots_in_flight, num_dest_write_slots);
+                    const uint32_t slot_base = dest_buffer + dest_slot * dest_slot_size_bytes;
+                    // use_read_datamover=true: sync via read barrier so prior DRAM dest writes stay in flight.
+                    tt::data_movement::common::tt_memmove<false, false, true, dest_page_size_bytes>(
+                        noc, slot_base + write_offset, source_buffer + read_offset, readable);
                     if (i == read_end_page - 1) {
-                        tt::data_movement::common::enhanced_noc_async_write<dest_page_size_bytes, false>(
-                            noc, dest_buffer + begin_write_offset, dst_noc_addr, end_to_write);
+                        const uint32_t bytes_to_flush = end_to_write + readable;
+                        tt::data_movement::common::enhanced_noc_async_write<dest_write_size_bytes, false>(
+                            noc, slot_base + begin_write_offset, dst_noc_addr, bytes_to_flush);
                         noc.async_write_barrier();
                         return;
                     }
@@ -141,10 +165,14 @@ void kernel_main() {
                     tt::data_movement::common::enhanced_noc_async_write<dest_page_size_bytes, false>(
                         noc, source_buffer + read_offset, dst_noc_addr + dst_noc_addr_offset, readable);
                 } else {
-                    tt::data_movement::common::tt_memmove<false, false, false, dest_page_size_bytes>(
-                        noc, dest_buffer + write_offset, source_buffer + read_offset, readable);
-                    tt::data_movement::common::enhanced_noc_async_write<dest_page_size_bytes, false>(
-                        noc, dest_buffer + begin_write_offset, dst_noc_addr, dest_page_size_bytes);
+                    acquire_dest_slot(noc, slots_in_flight, num_dest_write_slots);
+                    const uint32_t slot_base = dest_buffer + dest_slot * dest_slot_size_bytes;
+                    // use_read_datamover=true: sync via read barrier so prior DRAM dest writes stay in flight.
+                    tt::data_movement::common::tt_memmove<false, false, true, dest_page_size_bytes>(
+                        noc, slot_base + write_offset, source_buffer + read_offset, readable);
+                    tt::data_movement::common::enhanced_noc_async_write<dest_write_size_bytes, false>(
+                        noc, slot_base + begin_write_offset, dst_noc_addr, dest_write_size_bytes);
+                    advance_dest_slot(dest_slot, slots_in_flight, num_dest_write_slots);
                 }
                 dst_noc_addr_offset = 0;
 
@@ -166,10 +194,14 @@ void kernel_main() {
                     tt::data_movement::common::enhanced_noc_async_write<dest_page_size_bytes, false>(
                         noc, source_buffer + read_offset, dst_noc_addr + dst_noc_addr_offset, writable);
                 } else {
-                    tt::data_movement::common::tt_memmove<false, false, false, dest_page_size_bytes>(
-                        noc, dest_buffer + write_offset, source_buffer + read_offset, writable);
-                    tt::data_movement::common::enhanced_noc_async_write<dest_page_size_bytes, false>(
-                        noc, dest_buffer + begin_write_offset, dst_noc_addr, dest_page_size_bytes);
+                    acquire_dest_slot(noc, slots_in_flight, num_dest_write_slots);
+                    const uint32_t slot_base = dest_buffer + dest_slot * dest_slot_size_bytes;
+                    // use_read_datamover=true: sync via read barrier so prior DRAM dest writes stay in flight.
+                    tt::data_movement::common::tt_memmove<false, false, true, dest_page_size_bytes>(
+                        noc, slot_base + write_offset, source_buffer + read_offset, writable);
+                    tt::data_movement::common::enhanced_noc_async_write<dest_write_size_bytes, false>(
+                        noc, slot_base + begin_write_offset, dst_noc_addr, dest_write_size_bytes);
+                    advance_dest_slot(dest_slot, slots_in_flight, num_dest_write_slots);
                 }
                 // writable < readable
                 readable = readable - writable;

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/device/rm_reshape_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/device/rm_reshape_interleaved.cpp
@@ -33,6 +33,9 @@ Runtime arguments
 #include "api/debug/dprint.h"  // required in all kernels using DPRINT
 #include "ttnn/operations/data_movement/common/kernels/common.hpp"
 
+// Make the current slot of the L1 staging ring safe to overwrite. Writes issued from the
+// ring are left in flight so several destination pages share one barrier; once every slot
+// has an outstanding write we must drain them all before reusing the oldest one.
 FORCE_INLINE void acquire_dest_slot(Noc noc, uint32_t& slots_in_flight, const uint32_t num_dest_write_slots) {
     if (slots_in_flight >= num_dest_write_slots) {
         noc.async_write_barrier();
@@ -40,6 +43,8 @@ FORCE_INLINE void acquire_dest_slot(Noc noc, uint32_t& slots_in_flight, const ui
     }
 }
 
+// Move to the next slot of the L1 staging ring after its write has been issued, and count
+// that write against the in-flight budget checked by acquire_dest_slot.
 FORCE_INLINE void advance_dest_slot(
     uint32_t& dest_slot, uint32_t& slots_in_flight, const uint32_t num_dest_write_slots) {
     slots_in_flight++;

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_rm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_rm_program_factory.cpp
@@ -112,10 +112,13 @@ ProgramDescriptor ReshapeViewRMProgramFactory::create_descriptor(
 
     const bool pages_noc_aligned = (source_page_size_bytes % noc_page_alignment_bytes == 0) &&
                                    (dest_page_size_bytes % noc_page_alignment_bytes == 0);
+    const bool dest_noc_aligned = (dest_page_size_bytes % noc_page_alignment_bytes == 0);
     const bool pages_divisible =
         (source_page_size_bytes % dest_page_size_bytes == 0 || dest_page_size_bytes % source_page_size_bytes == 0);
-    // Avoid dual-kernel on non-aligned DRAM dests (Blackhole SYS-1419 / #50191).
-    const bool can_use_dual_kernel = pages_divisible && (pages_noc_aligned || !dst_buffer->is_dram());
+    // Avoid dual-kernel when dest writes are too small for DRAM (Blackhole SYS-1419 / #50191).
+    // Only dest alignment matters: source alignment selects the clean-vs-staging read path
+    // but doesn't affect the size of writes hitting DRAM.
+    const bool can_use_dual_kernel = pages_divisible && (dest_noc_aligned || !dst_buffer->is_dram());
 
     const uint32_t num_dest_write_slots =
         choose_num_dest_write_slots(device, pages_noc_aligned, can_use_dual_kernel, cb_size0, dest_slot_size_bytes);

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_rm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_rm_program_factory.cpp
@@ -4,9 +4,13 @@
 
 #include "ttnn/operations/data_movement/reshape_view/device/reshape_row_major_program_factory.hpp"
 
+#include <algorithm>
+
+#include <tt-metalium/hal.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/tt_align.hpp>
 
 #define MASK_64 0xFFFFFFFFFFFFFFC0
 #define MASK_16 0xFFFFFFFFFFFFFFF0
@@ -14,6 +18,46 @@
 namespace ttnn::prim {
 
 using namespace tt::tt_metal;
+
+namespace {
+constexpr uint32_t kSmallDestWriteSlots = 8;
+
+// Kept local (not a shared header): Quasar's factory is an intentional mirror of this
+// file; a cross-op helper would only dedupe ~30 lines and add CMake/packaging coupling.
+// Non-clean dest staging uses a multi-slot L1 ring. Cap slots by per-core L1 budget so
+// wide odd destinations (e.g. bf16 width 100001 from #50191) still fit.
+uint32_t choose_num_dest_write_slots(
+    IDevice* device,
+    bool pages_16b_aligned,
+    bool can_use_dual_kernel,
+    uint32_t cb_size0,
+    uint32_t dest_slot_size_bytes) {
+    if (pages_16b_aligned) {
+        return 1u;
+    }
+
+    // Use full per-core L1 (minus reserved), not live occupancy: slot count is a
+    // compile-time arg / CB size and must stay cache-stable. Occupancy-dependent
+    // sizing would leave a large cached ring after later L1 allocs shrink the ceiling.
+    const uint32_t l1_reserved = device->allocator()->get_base_allocator_addr(HalMemType::L1);
+    const uint32_t l1_size = device->l1_size_per_core();
+    TT_FATAL(l1_size > l1_reserved, "L1 size ({}) must exceed reserved base ({})", l1_size, l1_reserved);
+    const uint32_t l1_available = l1_size - l1_reserved;
+
+    const uint32_t num_kernel_copies = can_use_dual_kernel ? 2u : 1u;
+    const uint32_t source_cb_bytes = cb_size0 * 2u * num_kernel_copies;
+    const uint32_t min_dest_cb_bytes = dest_slot_size_bytes * num_kernel_copies;
+    TT_FATAL(
+        l1_available >= source_cb_bytes + min_dest_cb_bytes,
+        "RM reshape dest staging does not fit in L1: need at least {} B dest + {} B source, have {} B",
+        min_dest_cb_bytes,
+        source_cb_bytes,
+        l1_available);
+
+    const uint32_t max_slots = (l1_available - source_cb_bytes) / (dest_slot_size_bytes * num_kernel_copies);
+    return std::max(1u, std::min(kSmallDestWriteSlots, max_slots));
+}
+}  // namespace
 
 ProgramDescriptor ReshapeViewRMProgramFactory::create_descriptor(
     const ReshapeViewParams& operation_attributes, const ReshapeViewInputs& tensor_args, Tensor& tensor_return_value) {
@@ -56,10 +100,23 @@ ProgramDescriptor ReshapeViewRMProgramFactory::create_descriptor(
         responsibility++;
     }
     const uint32_t cb_size0 = source_read_size_bytes;
-    const uint32_t cb_size1 = ((dest_page_size_bytes - 1) & MASK_64) + 80;
+    const uint32_t dest_slot_size_bytes = ((dest_page_size_bytes - 1) & MASK_64) + 80;
 
-    bool can_use_dual_kernel =
+    const bool pages_16b_aligned = (source_page_size_bytes % 16 == 0) && (dest_page_size_bytes % 16 == 0);
+    const bool pages_divisible =
         (source_page_size_bytes % dest_page_size_bytes == 0 || dest_page_size_bytes % source_page_size_bytes == 0);
+    // Avoid dual-kernel on non-aligned DRAM dests (Blackhole SYS-1419 / #50191).
+    const bool can_use_dual_kernel = pages_divisible && (pages_16b_aligned || !dst_buffer->is_dram());
+
+    const uint32_t num_dest_write_slots =
+        choose_num_dest_write_slots(device, pages_16b_aligned, can_use_dual_kernel, cb_size0, dest_slot_size_bytes);
+    const uint32_t cb_size1 = dest_slot_size_bytes * num_dest_write_slots;
+
+    const uint32_t write_alignment =
+        dst_buffer->is_dram() ? tt::tt_metal::hal::get_dram_alignment() : tt::tt_metal::hal::get_l1_alignment();
+    const uint32_t noc_write_align = std::min(write_alignment, tt::tt_metal::hal::get_l1_alignment());
+    const uint32_t dest_write_size_bytes =
+        pages_16b_aligned ? dest_page_size_bytes : tt::align(dest_page_size_bytes, noc_write_align);
 
     constexpr uint32_t src0_cb_index = 0;
     constexpr uint32_t src1_cb_index = 1;
@@ -93,7 +150,10 @@ ProgramDescriptor ReshapeViewRMProgramFactory::create_descriptor(
         src0_cb_index,
         src1_cb_index,
         source_page_size_bytes,
-        dest_page_size_bytes};
+        dest_page_size_bytes,
+        num_dest_write_slots,
+        dest_slot_size_bytes,
+        dest_write_size_bytes};
     TensorAccessorArgs(*src_buffer).append_to(compile_time_args);
     TensorAccessorArgs(*dst_buffer).append_to(compile_time_args);
 

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_rm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_rm_program_factory.cpp
@@ -20,7 +20,15 @@ namespace ttnn::prim {
 using namespace tt::tt_metal;
 
 namespace {
-constexpr uint32_t kSmallDestWriteSlots = 8;
+// Page-size alignment the kernel needs to write straight from the source CB; must stay in
+// sync with MASK_16/OFFSET_16 and the can_be_clean predicate in rm_reshape_interleaved.cpp.
+constexpr uint32_t noc_page_alignment_bytes = 16;
+
+// Depth of the L1 staging ring used when pages are not NoC-aligned. Eight destination
+// pages share one write barrier, which is enough to keep the tiny-page case (2 B pages for
+// the [N, 1] reshape in #50191) off a per-page barrier without making the ring so deep that
+// wide destinations stop fitting in L1.
+constexpr uint32_t small_dest_write_slots = 8;
 
 // Kept local (not a shared header): Quasar's factory is an intentional mirror of this
 // file; a cross-op helper would only dedupe ~30 lines and add CMake/packaging coupling.
@@ -28,11 +36,11 @@ constexpr uint32_t kSmallDestWriteSlots = 8;
 // wide odd destinations (e.g. bf16 width 100001 from #50191) still fit.
 uint32_t choose_num_dest_write_slots(
     IDevice* device,
-    bool pages_16b_aligned,
+    bool pages_noc_aligned,
     bool can_use_dual_kernel,
     uint32_t cb_size0,
     uint32_t dest_slot_size_bytes) {
-    if (pages_16b_aligned) {
+    if (pages_noc_aligned) {
         return 1u;
     }
 
@@ -55,7 +63,7 @@ uint32_t choose_num_dest_write_slots(
         l1_available);
 
     const uint32_t max_slots = (l1_available - source_cb_bytes) / (dest_slot_size_bytes * num_kernel_copies);
-    return std::max(1u, std::min(kSmallDestWriteSlots, max_slots));
+    return std::max(1u, std::min(small_dest_write_slots, max_slots));
 }
 }  // namespace
 
@@ -102,21 +110,22 @@ ProgramDescriptor ReshapeViewRMProgramFactory::create_descriptor(
     const uint32_t cb_size0 = source_read_size_bytes;
     const uint32_t dest_slot_size_bytes = ((dest_page_size_bytes - 1) & MASK_64) + 80;
 
-    const bool pages_16b_aligned = (source_page_size_bytes % 16 == 0) && (dest_page_size_bytes % 16 == 0);
+    const bool pages_noc_aligned = (source_page_size_bytes % noc_page_alignment_bytes == 0) &&
+                                   (dest_page_size_bytes % noc_page_alignment_bytes == 0);
     const bool pages_divisible =
         (source_page_size_bytes % dest_page_size_bytes == 0 || dest_page_size_bytes % source_page_size_bytes == 0);
     // Avoid dual-kernel on non-aligned DRAM dests (Blackhole SYS-1419 / #50191).
-    const bool can_use_dual_kernel = pages_divisible && (pages_16b_aligned || !dst_buffer->is_dram());
+    const bool can_use_dual_kernel = pages_divisible && (pages_noc_aligned || !dst_buffer->is_dram());
 
     const uint32_t num_dest_write_slots =
-        choose_num_dest_write_slots(device, pages_16b_aligned, can_use_dual_kernel, cb_size0, dest_slot_size_bytes);
+        choose_num_dest_write_slots(device, pages_noc_aligned, can_use_dual_kernel, cb_size0, dest_slot_size_bytes);
     const uint32_t cb_size1 = dest_slot_size_bytes * num_dest_write_slots;
 
     const uint32_t write_alignment =
         dst_buffer->is_dram() ? tt::tt_metal::hal::get_dram_alignment() : tt::tt_metal::hal::get_l1_alignment();
     const uint32_t noc_write_align = std::min(write_alignment, tt::tt_metal::hal::get_l1_alignment());
     const uint32_t dest_write_size_bytes =
-        pages_16b_aligned ? dest_page_size_bytes : tt::align(dest_page_size_bytes, noc_write_align);
+        pages_noc_aligned ? dest_page_size_bytes : tt::align(dest_page_size_bytes, noc_write_align);
 
     constexpr uint32_t src0_cb_index = 0;
     constexpr uint32_t src1_cb_index = 1;

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_rm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_rm_program_factory.cpp
@@ -44,13 +44,16 @@ uint32_t choose_num_dest_write_slots(
         return 1u;
     }
 
-    // Use full per-core L1 (minus reserved), not live occupancy: slot count is a
-    // compile-time arg / CB size and must stay cache-stable. Occupancy-dependent
-    // sizing would leave a large cached ring after later L1 allocs shrink the ceiling.
-    const uint32_t l1_reserved = device->allocator()->get_base_allocator_addr(HalMemType::L1);
-    const uint32_t l1_size = device->l1_size_per_core();
-    TT_FATAL(l1_size > l1_reserved, "L1 size ({}) must exceed reserved base ({})", l1_size, l1_reserved);
-    const uint32_t l1_available = l1_size - l1_reserved;
+    // Budget the staging ring against live L1 occupancy so CBs never collide with
+    // tensors already allocated in L1 (vadv2 regression). CBs grow upward from the
+    // base; L1 tensors are allocated downward from the top. The ceiling is the lowest
+    // occupied L1 address — or the full core size when nothing is live.
+    const uint32_t l1_base = device->allocator()->get_base_allocator_addr(HalMemType::L1);
+    const std::optional<DeviceAddr> lowest_occupied = device->lowest_occupied_compute_l1_address();
+    const uint32_t l1_ceiling =
+        lowest_occupied.has_value() ? static_cast<uint32_t>(lowest_occupied.value()) : device->l1_size_per_core();
+    TT_FATAL(l1_ceiling > l1_base, "L1 ceiling ({}) must exceed base ({})", l1_ceiling, l1_base);
+    const uint32_t l1_available = l1_ceiling - l1_base;
 
     const uint32_t num_kernel_copies = can_use_dual_kernel ? 2u : 1u;
     const uint32_t source_cb_bytes = cb_size0 * 2u * num_kernel_copies;

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/reshape_view/device/device/rm_reshape_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/reshape_view/device/device/rm_reshape_interleaved.cpp
@@ -5,26 +5,27 @@
 /*
 Function reads from RM and writes to RM
 
-Assumptions:
-
-Compile arguments
-0. src0_is_dram: 1 if source is dram else 0
-1. read_size_is_pow2: 1 if read size is power of 2 else 0
-2. log_base_2_of_page_size: log base 2 of page size
-3. write_size_is_pow2: 1 if write size is power of 2 else 0
-4. log_base_2_of_page_size: log base 2 of page size
-5. needs_read_allignment: 1 if read needs alignment else 0
-//Needed if BRAM and page size is not multiple of 64 bytes
+Compile-time arguments
+0. src_aligned_to_64
+1. src_aligned_to_16
+2. cb_id_in0
+3. cb_id_in1
+4. source_page_size_bytes
+5. dest_page_size_bytes
+6. num_dest_write_slots
+7. dest_slot_size_bytes
+8. dest_write_size_bytes
+9+. TensorAccessorArgs for src, then dst
 
 Runtime arguments
-0. src_addr: source address
-1. dst_addr: destination address
-2. source_read_size_bytes: source read size in bytes
-3. read_start_page: read start page
-4. read_end_page: read end page
-5. write_start_page: write start page
-6. write_start_offset: write start offset
-7. nop: 1 if this core should be skipped
+0. src_addr
+1. dst_addr
+2. source_read_size_bytes
+3. read_start_page
+4. read_end_page
+5. write_start_page
+6. write_start_offset
+7. nop
 */
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
@@ -33,6 +34,19 @@ Runtime arguments
 #include "api/dataflow/dataflow_buffer.h"
 #include "api/debug/dprint.h"  // required in all kernels using DPRINT
 #include "ttnn/operations/data_movement/common/kernels/common.hpp"
+
+FORCE_INLINE void acquire_dest_slot(Noc noc, uint32_t& slots_in_flight, const uint32_t num_dest_write_slots) {
+    if (slots_in_flight >= num_dest_write_slots) {
+        noc.async_write_barrier();
+        slots_in_flight = 0;
+    }
+}
+
+FORCE_INLINE void advance_dest_slot(
+    uint32_t& dest_slot, uint32_t& slots_in_flight, const uint32_t num_dest_write_slots) {
+    slots_in_flight++;
+    dest_slot = (dest_slot + 1) % num_dest_write_slots;
+}
 
 void kernel_main() {
     // We are guaranteed to be in 2D going to 2D
@@ -54,7 +68,10 @@ void kernel_main() {
     constexpr uint32_t cb_id_in1 = get_compile_time_arg_val(3);
     constexpr uint32_t source_page_size_bytes = get_compile_time_arg_val(4);
     constexpr uint32_t dest_page_size_bytes = get_compile_time_arg_val(5);
-    constexpr auto src_args = TensorAccessorArgs<6>();
+    constexpr uint32_t num_dest_write_slots = get_compile_time_arg_val(6);
+    constexpr uint32_t dest_slot_size_bytes = get_compile_time_arg_val(7);
+    constexpr uint32_t dest_write_size_bytes = get_compile_time_arg_val(8);
+    constexpr auto src_args = TensorAccessorArgs<9>();
     constexpr auto dst_args = TensorAccessorArgs<src_args.next_compile_time_args_offset()>();
 
     // Since we need to operate on a grid of cores but sometimes pages don't split properly, if nop then don't use this
@@ -73,10 +90,8 @@ void kernel_main() {
     uint32_t write_page = write_start_page;
     uint32_t readable = 0;
     uint32_t end_to_write = 0;
-    uint32_t transaction = 0;
     uint32_t writable = dest_page_size_bytes - write_start_offset;
-    // cb_id_in0 is a CB source_read_size_bytes page size, 1 page
-    // cb_id_in1 is a CB dest_page_size_bytes + allignment_to_64 page size, 1 page
+    // Ring base from DataflowBuffer; slot offsets applied manually below.
     cb_in0.reserve_back(1);
     cb_in1.reserve_back(1);
     const uint32_t source_buffer = cb_in0.get_write_ptr();
@@ -89,6 +104,10 @@ void kernel_main() {
     uint64_t begin_write_offset = write_offset;
     constexpr bool can_be_clean = ((source_page_size_bytes % 16) == 0 && (dest_page_size_bytes % 16) == 0);
     uint64_t dst_noc_addr_offset = 0;
+
+    uint32_t dest_slot = 0;
+    uint32_t slots_in_flight = 0;
+
     for (uint32_t i = read_start_page; i < read_end_page; i++) {
         // Drain any prior iteration's writes that read source_buffer before this iteration's read
         // overwrites it: source_buffer is a single fixed CB slot reused every iteration, and the
@@ -119,18 +138,24 @@ void kernel_main() {
 
         // Write to dest
         while (readable > 0) {
-            noc.async_write_barrier();
+            if constexpr (can_be_clean) {
+                noc.async_write_barrier();
+            }
             if (readable < writable) {
                 if constexpr (can_be_clean) {
                     tt::data_movement::common::enhanced_noc_async_write<dest_page_size_bytes, false>(
                         noc, source_buffer + read_offset, dst_noc_addr + dst_noc_addr_offset, readable);
                     dst_noc_addr_offset = dst_noc_addr_offset + readable;
                 } else {
-                    tt::data_movement::common::tt_memmove<false, true, false, dest_page_size_bytes>(
-                        noc, dest_buffer + write_offset, source_buffer + read_offset, readable);
+                    acquire_dest_slot(noc, slots_in_flight, num_dest_write_slots);
+                    const uint32_t slot_base = dest_buffer + dest_slot * dest_slot_size_bytes;
+                    // use_read_datamover=true: sync via read barrier so prior DRAM dest writes stay in flight.
+                    tt::data_movement::common::tt_memmove<false, false, true, dest_page_size_bytes>(
+                        noc, slot_base + write_offset, source_buffer + read_offset, readable);
                     if (i == read_end_page - 1) {
-                        tt::data_movement::common::enhanced_noc_async_write<dest_page_size_bytes, false>(
-                            noc, dest_buffer + begin_write_offset, dst_noc_addr, end_to_write);
+                        const uint32_t bytes_to_flush = end_to_write + readable;
+                        tt::data_movement::common::enhanced_noc_async_write<dest_write_size_bytes, false>(
+                            noc, slot_base + begin_write_offset, dst_noc_addr, bytes_to_flush);
                         noc.async_write_barrier();
                         return;
                     }
@@ -145,10 +170,14 @@ void kernel_main() {
                     tt::data_movement::common::enhanced_noc_async_write<dest_page_size_bytes, false>(
                         noc, source_buffer + read_offset, dst_noc_addr + dst_noc_addr_offset, readable);
                 } else {
-                    tt::data_movement::common::tt_memmove<false, false, false, dest_page_size_bytes>(
-                        noc, dest_buffer + write_offset, source_buffer + read_offset, readable);
-                    tt::data_movement::common::enhanced_noc_async_write<dest_page_size_bytes, false>(
-                        noc, dest_buffer + begin_write_offset, dst_noc_addr, dest_page_size_bytes);
+                    acquire_dest_slot(noc, slots_in_flight, num_dest_write_slots);
+                    const uint32_t slot_base = dest_buffer + dest_slot * dest_slot_size_bytes;
+                    // use_read_datamover=true: sync via read barrier so prior DRAM dest writes stay in flight.
+                    tt::data_movement::common::tt_memmove<false, false, true, dest_page_size_bytes>(
+                        noc, slot_base + write_offset, source_buffer + read_offset, readable);
+                    tt::data_movement::common::enhanced_noc_async_write<dest_write_size_bytes, false>(
+                        noc, slot_base + begin_write_offset, dst_noc_addr, dest_write_size_bytes);
+                    advance_dest_slot(dest_slot, slots_in_flight, num_dest_write_slots);
                 }
                 dst_noc_addr_offset = 0;
 
@@ -170,10 +199,14 @@ void kernel_main() {
                     tt::data_movement::common::enhanced_noc_async_write<dest_page_size_bytes, false>(
                         noc, source_buffer + read_offset, dst_noc_addr + dst_noc_addr_offset, writable);
                 } else {
-                    tt::data_movement::common::tt_memmove<false, false, false, dest_page_size_bytes>(
-                        noc, dest_buffer + write_offset, source_buffer + read_offset, writable);
-                    tt::data_movement::common::enhanced_noc_async_write<dest_page_size_bytes, false>(
-                        noc, dest_buffer + begin_write_offset, dst_noc_addr, dest_page_size_bytes);
+                    acquire_dest_slot(noc, slots_in_flight, num_dest_write_slots);
+                    const uint32_t slot_base = dest_buffer + dest_slot * dest_slot_size_bytes;
+                    // use_read_datamover=true: sync via read barrier so prior DRAM dest writes stay in flight.
+                    tt::data_movement::common::tt_memmove<false, false, true, dest_page_size_bytes>(
+                        noc, slot_base + write_offset, source_buffer + read_offset, writable);
+                    tt::data_movement::common::enhanced_noc_async_write<dest_write_size_bytes, false>(
+                        noc, slot_base + begin_write_offset, dst_noc_addr, dest_write_size_bytes);
+                    advance_dest_slot(dest_slot, slots_in_flight, num_dest_write_slots);
                 }
                 // writable < readable
                 readable = readable - writable;

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/reshape_view/device/device/rm_reshape_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/reshape_view/device/device/rm_reshape_interleaved.cpp
@@ -35,6 +35,9 @@ Runtime arguments
 #include "api/debug/dprint.h"  // required in all kernels using DPRINT
 #include "ttnn/operations/data_movement/common/kernels/common.hpp"
 
+// Make the current slot of the L1 staging ring safe to overwrite. Writes issued from the
+// ring are left in flight so several destination pages share one barrier; once every slot
+// has an outstanding write we must drain them all before reusing the oldest one.
 FORCE_INLINE void acquire_dest_slot(Noc noc, uint32_t& slots_in_flight, const uint32_t num_dest_write_slots) {
     if (slots_in_flight >= num_dest_write_slots) {
         noc.async_write_barrier();
@@ -42,6 +45,8 @@ FORCE_INLINE void acquire_dest_slot(Noc noc, uint32_t& slots_in_flight, const ui
     }
 }
 
+// Move to the next slot of the L1 staging ring after its write has been issued, and count
+// that write against the in-flight budget checked by acquire_dest_slot.
 FORCE_INLINE void advance_dest_slot(
     uint32_t& dest_slot, uint32_t& slots_in_flight, const uint32_t num_dest_write_slots) {
     slots_in_flight++;

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/reshape_view/device/device/rm_reshape_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/reshape_view/device/device/rm_reshape_interleaved.cpp
@@ -5,26 +5,27 @@
 /*
 Function reads from RM and writes to RM
 
-Assumptions:
-
-Compile arguments
-0. src0_is_dram: 1 if source is dram else 0
-1. read_size_is_pow2: 1 if read size is power of 2 else 0
-2. log_base_2_of_page_size: log base 2 of page size
-3. write_size_is_pow2: 1 if write size is power of 2 else 0
-4. log_base_2_of_page_size: log base 2 of page size
-5. needs_read_allignment: 1 if read needs alignment else 0
-//Needed if BRAM and page size is not multiple of 64 bytes
+Compile-time arguments
+0. src_aligned_to_64
+1. src_aligned_to_16
+2. cb_id_in0
+3. cb_id_in1
+4. source_page_size_bytes
+5. dest_page_size_bytes
+6. num_dest_write_slots
+7. dest_slot_size_bytes
+8. dest_write_size_bytes
+9+. TensorAccessorArgs for src, then dst
 
 Runtime arguments
-0. src_addr: source address
-1. dst_addr: destination address
-2. source_read_size_bytes: source read size in bytes
-3. read_start_page: read start page
-4. read_end_page: read end page
-5. write_start_page: write start page
-6. write_start_offset: write start offset
-7. nop: 1 if this core should be skipped
+0. src_addr
+1. dst_addr
+2. source_read_size_bytes
+3. read_start_page
+4. read_end_page
+5. write_start_page
+6. write_start_offset
+7. nop
 */
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
@@ -32,6 +33,19 @@ Runtime arguments
 #include "api/dataflow/circular_buffer.h"
 #include "api/dataflow/dataflow_buffer.h"
 #include "ttnn/operations/data_movement/common/kernels/common.hpp"
+
+FORCE_INLINE void acquire_dest_slot(Noc noc, uint32_t& slots_in_flight, const uint32_t num_dest_write_slots) {
+    if (slots_in_flight >= num_dest_write_slots) {
+        noc.async_write_barrier();
+        slots_in_flight = 0;
+    }
+}
+
+FORCE_INLINE void advance_dest_slot(
+    uint32_t& dest_slot, uint32_t& slots_in_flight, const uint32_t num_dest_write_slots) {
+    slots_in_flight++;
+    dest_slot = (dest_slot + 1) % num_dest_write_slots;
+}
 
 void kernel_main() {
     // We are guaranteed to be in 2D going to 2D
@@ -53,7 +67,10 @@ void kernel_main() {
     constexpr uint32_t cb_id_in1 = get_compile_time_arg_val(3);
     constexpr uint32_t source_page_size_bytes = get_compile_time_arg_val(4);
     constexpr uint32_t dest_page_size_bytes = get_compile_time_arg_val(5);
-    constexpr auto src_args = TensorAccessorArgs<6>();
+    constexpr uint32_t num_dest_write_slots = get_compile_time_arg_val(6);
+    constexpr uint32_t dest_slot_size_bytes = get_compile_time_arg_val(7);
+    constexpr uint32_t dest_write_size_bytes = get_compile_time_arg_val(8);
+    constexpr auto src_args = TensorAccessorArgs<9>();
     constexpr auto dst_args = TensorAccessorArgs<src_args.next_compile_time_args_offset()>();
 
     // Since we need to operate on a grid of cores but sometimes pages don't split properly, if nop then don't use this
@@ -72,10 +89,8 @@ void kernel_main() {
     uint32_t write_page = write_start_page;
     uint32_t readable = 0;
     uint32_t end_to_write = 0;
-    uint32_t transaction = 0;
     uint32_t writable = dest_page_size_bytes - write_start_offset;
-    // cb_id_in0 is a CB source_read_size_bytes page size, 1 page
-    // cb_id_in1 is a CB dest_page_size_bytes + allignment_to_64 page size, 1 page
+    // Ring base from DataflowBuffer; slot offsets applied manually below.
     cb_in0.reserve_back(1);
     cb_in1.reserve_back(1);
     const uint32_t source_buffer = cb_in0.get_write_ptr();
@@ -88,6 +103,10 @@ void kernel_main() {
     uint64_t begin_write_offset = write_offset;
     constexpr bool can_be_clean = ((source_page_size_bytes % 16) == 0 && (dest_page_size_bytes % 16) == 0);
     uint64_t dst_noc_addr_offset = 0;
+
+    uint32_t dest_slot = 0;
+    uint32_t slots_in_flight = 0;
+
     for (uint32_t i = read_start_page; i < read_end_page; i++) {
         // Drain any prior iteration's writes that read source_buffer before this iteration's read
         // overwrites it: source_buffer is a single fixed CB slot reused every iteration, and the
@@ -118,18 +137,24 @@ void kernel_main() {
 
         // Write to dest
         while (readable > 0) {
-            noc.async_write_barrier();
+            if constexpr (can_be_clean) {
+                noc.async_write_barrier();
+            }
             if (readable < writable) {
                 if constexpr (can_be_clean) {
                     tt::data_movement::common::enhanced_noc_async_write<dest_page_size_bytes, false>(
                         noc, source_buffer + read_offset, dst_noc_addr + dst_noc_addr_offset, readable);
                     dst_noc_addr_offset = dst_noc_addr_offset + readable;
                 } else {
-                    tt::data_movement::common::tt_memmove<false, true, false, dest_page_size_bytes>(
-                        noc, dest_buffer + write_offset, source_buffer + read_offset, readable);
+                    acquire_dest_slot(noc, slots_in_flight, num_dest_write_slots);
+                    const uint32_t slot_base = dest_buffer + dest_slot * dest_slot_size_bytes;
+                    // use_read_datamover=true: sync via read barrier so prior DRAM dest writes stay in flight.
+                    tt::data_movement::common::tt_memmove<false, false, true, dest_page_size_bytes>(
+                        noc, slot_base + write_offset, source_buffer + read_offset, readable);
                     if (i == read_end_page - 1) {
-                        tt::data_movement::common::enhanced_noc_async_write<dest_page_size_bytes, false>(
-                            noc, dest_buffer + begin_write_offset, dst_noc_addr, end_to_write);
+                        const uint32_t bytes_to_flush = end_to_write + readable;
+                        tt::data_movement::common::enhanced_noc_async_write<dest_write_size_bytes, false>(
+                            noc, slot_base + begin_write_offset, dst_noc_addr, bytes_to_flush);
                         noc.async_write_barrier();
                         return;
                     }
@@ -144,10 +169,14 @@ void kernel_main() {
                     tt::data_movement::common::enhanced_noc_async_write<dest_page_size_bytes, false>(
                         noc, source_buffer + read_offset, dst_noc_addr + dst_noc_addr_offset, readable);
                 } else {
-                    tt::data_movement::common::tt_memmove<false, false, false, dest_page_size_bytes>(
-                        noc, dest_buffer + write_offset, source_buffer + read_offset, readable);
-                    tt::data_movement::common::enhanced_noc_async_write<dest_page_size_bytes, false>(
-                        noc, dest_buffer + begin_write_offset, dst_noc_addr, dest_page_size_bytes);
+                    acquire_dest_slot(noc, slots_in_flight, num_dest_write_slots);
+                    const uint32_t slot_base = dest_buffer + dest_slot * dest_slot_size_bytes;
+                    // use_read_datamover=true: sync via read barrier so prior DRAM dest writes stay in flight.
+                    tt::data_movement::common::tt_memmove<false, false, true, dest_page_size_bytes>(
+                        noc, slot_base + write_offset, source_buffer + read_offset, readable);
+                    tt::data_movement::common::enhanced_noc_async_write<dest_write_size_bytes, false>(
+                        noc, slot_base + begin_write_offset, dst_noc_addr, dest_write_size_bytes);
+                    advance_dest_slot(dest_slot, slots_in_flight, num_dest_write_slots);
                 }
                 dst_noc_addr_offset = 0;
 
@@ -169,10 +198,14 @@ void kernel_main() {
                     tt::data_movement::common::enhanced_noc_async_write<dest_page_size_bytes, false>(
                         noc, source_buffer + read_offset, dst_noc_addr + dst_noc_addr_offset, writable);
                 } else {
-                    tt::data_movement::common::tt_memmove<false, false, false, dest_page_size_bytes>(
-                        noc, dest_buffer + write_offset, source_buffer + read_offset, writable);
-                    tt::data_movement::common::enhanced_noc_async_write<dest_page_size_bytes, false>(
-                        noc, dest_buffer + begin_write_offset, dst_noc_addr, dest_page_size_bytes);
+                    acquire_dest_slot(noc, slots_in_flight, num_dest_write_slots);
+                    const uint32_t slot_base = dest_buffer + dest_slot * dest_slot_size_bytes;
+                    // use_read_datamover=true: sync via read barrier so prior DRAM dest writes stay in flight.
+                    tt::data_movement::common::tt_memmove<false, false, true, dest_page_size_bytes>(
+                        noc, slot_base + write_offset, source_buffer + read_offset, writable);
+                    tt::data_movement::common::enhanced_noc_async_write<dest_write_size_bytes, false>(
+                        noc, slot_base + begin_write_offset, dst_noc_addr, dest_write_size_bytes);
+                    advance_dest_slot(dest_slot, slots_in_flight, num_dest_write_slots);
                 }
                 // writable < readable
                 readable = readable - writable;

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/reshape_view/device/device/rm_reshape_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/reshape_view/device/device/rm_reshape_interleaved.cpp
@@ -34,6 +34,9 @@ Runtime arguments
 #include "api/dataflow/dataflow_buffer.h"
 #include "ttnn/operations/data_movement/common/kernels/common.hpp"
 
+// Make the current slot of the L1 staging ring safe to overwrite. Writes issued from the
+// ring are left in flight so several destination pages share one barrier; once every slot
+// has an outstanding write we must drain them all before reusing the oldest one.
 FORCE_INLINE void acquire_dest_slot(Noc noc, uint32_t& slots_in_flight, const uint32_t num_dest_write_slots) {
     if (slots_in_flight >= num_dest_write_slots) {
         noc.async_write_barrier();
@@ -41,6 +44,8 @@ FORCE_INLINE void acquire_dest_slot(Noc noc, uint32_t& slots_in_flight, const ui
     }
 }
 
+// Move to the next slot of the L1 staging ring after its write has been issued, and count
+// that write against the in-flight budget checked by acquire_dest_slot.
 FORCE_INLINE void advance_dest_slot(
     uint32_t& dest_slot, uint32_t& slots_in_flight, const uint32_t num_dest_write_slots) {
     slots_in_flight++;

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/reshape_view/device/reshape_rm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/reshape_view/device/reshape_rm_program_factory.cpp
@@ -112,10 +112,13 @@ ProgramDescriptor ReshapeViewRMProgramFactory::create_descriptor(
 
     const bool pages_noc_aligned = (source_page_size_bytes % noc_page_alignment_bytes == 0) &&
                                    (dest_page_size_bytes % noc_page_alignment_bytes == 0);
+    const bool dest_noc_aligned = (dest_page_size_bytes % noc_page_alignment_bytes == 0);
     const bool pages_divisible =
         (source_page_size_bytes % dest_page_size_bytes == 0 || dest_page_size_bytes % source_page_size_bytes == 0);
-    // Avoid dual-kernel on non-aligned DRAM dests (Blackhole SYS-1419 / #50191).
-    const bool can_use_dual_kernel = pages_divisible && (pages_noc_aligned || !dst_buffer->is_dram());
+    // Avoid dual-kernel when dest writes are too small for DRAM (Blackhole SYS-1419 / #50191).
+    // Only dest alignment matters: source alignment selects the clean-vs-staging read path
+    // but doesn't affect the size of writes hitting DRAM.
+    const bool can_use_dual_kernel = pages_divisible && (dest_noc_aligned || !dst_buffer->is_dram());
 
     const uint32_t num_dest_write_slots =
         choose_num_dest_write_slots(device, pages_noc_aligned, can_use_dual_kernel, cb_size0, dest_slot_size_bytes);

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/reshape_view/device/reshape_rm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/reshape_view/device/reshape_rm_program_factory.cpp
@@ -4,9 +4,13 @@
 
 #include "ttnn/operations/experimental/quasar/reshape_view/device/reshape_row_major_program_factory.hpp"
 
+#include <algorithm>
+
+#include <tt-metalium/hal.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/tt_align.hpp>
 
 #define MASK_64 0xFFFFFFFFFFFFFFC0
 #define MASK_16 0xFFFFFFFFFFFFFFF0
@@ -14,6 +18,46 @@
 namespace ttnn::prim::qsr {
 
 using namespace tt::tt_metal;
+
+namespace {
+constexpr uint32_t kSmallDestWriteSlots = 8;
+
+// Kept local (not a shared header): this factory mirrors data_movement reshape_view;
+// extracting a cross-op helper would only dedupe ~30 lines and add CMake coupling.
+// Non-clean dest staging uses a multi-slot L1 ring. Cap slots by per-core L1 budget so
+// wide odd destinations (e.g. bf16 width 100001 from #50191) still fit.
+uint32_t choose_num_dest_write_slots(
+    IDevice* device,
+    bool pages_16b_aligned,
+    bool can_use_dual_kernel,
+    uint32_t cb_size0,
+    uint32_t dest_slot_size_bytes) {
+    if (pages_16b_aligned) {
+        return 1u;
+    }
+
+    // Use full per-core L1 (minus reserved), not live occupancy: slot count is a
+    // compile-time arg / CB size and must stay cache-stable. Occupancy-dependent
+    // sizing would leave a large cached ring after later L1 allocs shrink the ceiling.
+    const uint32_t l1_reserved = device->allocator()->get_base_allocator_addr(HalMemType::L1);
+    const uint32_t l1_size = device->l1_size_per_core();
+    TT_FATAL(l1_size > l1_reserved, "L1 size ({}) must exceed reserved base ({})", l1_size, l1_reserved);
+    const uint32_t l1_available = l1_size - l1_reserved;
+
+    const uint32_t num_kernel_copies = can_use_dual_kernel ? 2u : 1u;
+    const uint32_t source_cb_bytes = cb_size0 * 2u * num_kernel_copies;
+    const uint32_t min_dest_cb_bytes = dest_slot_size_bytes * num_kernel_copies;
+    TT_FATAL(
+        l1_available >= source_cb_bytes + min_dest_cb_bytes,
+        "RM reshape dest staging does not fit in L1: need at least {} B dest + {} B source, have {} B",
+        min_dest_cb_bytes,
+        source_cb_bytes,
+        l1_available);
+
+    const uint32_t max_slots = (l1_available - source_cb_bytes) / (dest_slot_size_bytes * num_kernel_copies);
+    return std::max(1u, std::min(kSmallDestWriteSlots, max_slots));
+}
+}  // namespace
 
 ProgramDescriptor ReshapeViewRMProgramFactory::create_descriptor(
     const ReshapeViewParams& operation_attributes, const ReshapeViewInputs& tensor_args, Tensor& tensor_return_value) {
@@ -56,10 +100,23 @@ ProgramDescriptor ReshapeViewRMProgramFactory::create_descriptor(
         responsibility++;
     }
     const uint32_t cb_size0 = source_read_size_bytes;
-    const uint32_t cb_size1 = ((dest_page_size_bytes - 1) & MASK_64) + 80;
+    const uint32_t dest_slot_size_bytes = ((dest_page_size_bytes - 1) & MASK_64) + 80;
 
-    bool can_use_dual_kernel =
+    const bool pages_16b_aligned = (source_page_size_bytes % 16 == 0) && (dest_page_size_bytes % 16 == 0);
+    const bool pages_divisible =
         (source_page_size_bytes % dest_page_size_bytes == 0 || dest_page_size_bytes % source_page_size_bytes == 0);
+    // Avoid dual-kernel on non-aligned DRAM dests (Blackhole SYS-1419 / #50191).
+    const bool can_use_dual_kernel = pages_divisible && (pages_16b_aligned || !dst_buffer->is_dram());
+
+    const uint32_t num_dest_write_slots =
+        choose_num_dest_write_slots(device, pages_16b_aligned, can_use_dual_kernel, cb_size0, dest_slot_size_bytes);
+    const uint32_t cb_size1 = dest_slot_size_bytes * num_dest_write_slots;
+
+    const uint32_t write_alignment =
+        dst_buffer->is_dram() ? tt::tt_metal::hal::get_dram_alignment() : tt::tt_metal::hal::get_l1_alignment();
+    const uint32_t noc_write_align = std::min(write_alignment, tt::tt_metal::hal::get_l1_alignment());
+    const uint32_t dest_write_size_bytes =
+        pages_16b_aligned ? dest_page_size_bytes : tt::align(dest_page_size_bytes, noc_write_align);
 
     constexpr uint32_t src0_cb_index = 0;
     constexpr uint32_t src1_cb_index = 1;
@@ -93,7 +150,10 @@ ProgramDescriptor ReshapeViewRMProgramFactory::create_descriptor(
         src0_cb_index,
         src1_cb_index,
         source_page_size_bytes,
-        dest_page_size_bytes};
+        dest_page_size_bytes,
+        num_dest_write_slots,
+        dest_slot_size_bytes,
+        dest_write_size_bytes};
     TensorAccessorArgs(*src_buffer).append_to(compile_time_args);
     TensorAccessorArgs(*dst_buffer).append_to(compile_time_args);
 

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/reshape_view/device/reshape_rm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/reshape_view/device/reshape_rm_program_factory.cpp
@@ -20,7 +20,15 @@ namespace ttnn::prim::qsr {
 using namespace tt::tt_metal;
 
 namespace {
-constexpr uint32_t kSmallDestWriteSlots = 8;
+// Page-size alignment the kernel needs to write straight from the source CB; must stay in
+// sync with MASK_16/OFFSET_16 and the can_be_clean predicate in rm_reshape_interleaved.cpp.
+constexpr uint32_t noc_page_alignment_bytes = 16;
+
+// Depth of the L1 staging ring used when pages are not NoC-aligned. Eight destination
+// pages share one write barrier, which is enough to keep the tiny-page case (2 B pages for
+// the [N, 1] reshape in #50191) off a per-page barrier without making the ring so deep that
+// wide destinations stop fitting in L1.
+constexpr uint32_t small_dest_write_slots = 8;
 
 // Kept local (not a shared header): this factory mirrors data_movement reshape_view;
 // extracting a cross-op helper would only dedupe ~30 lines and add CMake coupling.
@@ -28,11 +36,11 @@ constexpr uint32_t kSmallDestWriteSlots = 8;
 // wide odd destinations (e.g. bf16 width 100001 from #50191) still fit.
 uint32_t choose_num_dest_write_slots(
     IDevice* device,
-    bool pages_16b_aligned,
+    bool pages_noc_aligned,
     bool can_use_dual_kernel,
     uint32_t cb_size0,
     uint32_t dest_slot_size_bytes) {
-    if (pages_16b_aligned) {
+    if (pages_noc_aligned) {
         return 1u;
     }
 
@@ -55,7 +63,7 @@ uint32_t choose_num_dest_write_slots(
         l1_available);
 
     const uint32_t max_slots = (l1_available - source_cb_bytes) / (dest_slot_size_bytes * num_kernel_copies);
-    return std::max(1u, std::min(kSmallDestWriteSlots, max_slots));
+    return std::max(1u, std::min(small_dest_write_slots, max_slots));
 }
 }  // namespace
 
@@ -102,21 +110,22 @@ ProgramDescriptor ReshapeViewRMProgramFactory::create_descriptor(
     const uint32_t cb_size0 = source_read_size_bytes;
     const uint32_t dest_slot_size_bytes = ((dest_page_size_bytes - 1) & MASK_64) + 80;
 
-    const bool pages_16b_aligned = (source_page_size_bytes % 16 == 0) && (dest_page_size_bytes % 16 == 0);
+    const bool pages_noc_aligned = (source_page_size_bytes % noc_page_alignment_bytes == 0) &&
+                                   (dest_page_size_bytes % noc_page_alignment_bytes == 0);
     const bool pages_divisible =
         (source_page_size_bytes % dest_page_size_bytes == 0 || dest_page_size_bytes % source_page_size_bytes == 0);
     // Avoid dual-kernel on non-aligned DRAM dests (Blackhole SYS-1419 / #50191).
-    const bool can_use_dual_kernel = pages_divisible && (pages_16b_aligned || !dst_buffer->is_dram());
+    const bool can_use_dual_kernel = pages_divisible && (pages_noc_aligned || !dst_buffer->is_dram());
 
     const uint32_t num_dest_write_slots =
-        choose_num_dest_write_slots(device, pages_16b_aligned, can_use_dual_kernel, cb_size0, dest_slot_size_bytes);
+        choose_num_dest_write_slots(device, pages_noc_aligned, can_use_dual_kernel, cb_size0, dest_slot_size_bytes);
     const uint32_t cb_size1 = dest_slot_size_bytes * num_dest_write_slots;
 
     const uint32_t write_alignment =
         dst_buffer->is_dram() ? tt::tt_metal::hal::get_dram_alignment() : tt::tt_metal::hal::get_l1_alignment();
     const uint32_t noc_write_align = std::min(write_alignment, tt::tt_metal::hal::get_l1_alignment());
     const uint32_t dest_write_size_bytes =
-        pages_16b_aligned ? dest_page_size_bytes : tt::align(dest_page_size_bytes, noc_write_align);
+        pages_noc_aligned ? dest_page_size_bytes : tt::align(dest_page_size_bytes, noc_write_align);
 
     constexpr uint32_t src0_cb_index = 0;
     constexpr uint32_t src1_cb_index = 1;

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/reshape_view/device/reshape_rm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/reshape_view/device/reshape_rm_program_factory.cpp
@@ -44,13 +44,16 @@ uint32_t choose_num_dest_write_slots(
         return 1u;
     }
 
-    // Use full per-core L1 (minus reserved), not live occupancy: slot count is a
-    // compile-time arg / CB size and must stay cache-stable. Occupancy-dependent
-    // sizing would leave a large cached ring after later L1 allocs shrink the ceiling.
-    const uint32_t l1_reserved = device->allocator()->get_base_allocator_addr(HalMemType::L1);
-    const uint32_t l1_size = device->l1_size_per_core();
-    TT_FATAL(l1_size > l1_reserved, "L1 size ({}) must exceed reserved base ({})", l1_size, l1_reserved);
-    const uint32_t l1_available = l1_size - l1_reserved;
+    // Budget the staging ring against live L1 occupancy so CBs never collide with
+    // tensors already allocated in L1 (vadv2 regression). CBs grow upward from the
+    // base; L1 tensors are allocated downward from the top. The ceiling is the lowest
+    // occupied L1 address — or the full core size when nothing is live.
+    const uint32_t l1_base = device->allocator()->get_base_allocator_addr(HalMemType::L1);
+    const std::optional<DeviceAddr> lowest_occupied = device->lowest_occupied_compute_l1_address();
+    const uint32_t l1_ceiling =
+        lowest_occupied.has_value() ? static_cast<uint32_t>(lowest_occupied.value()) : device->l1_size_per_core();
+    TT_FATAL(l1_ceiling > l1_base, "L1 ceiling ({}) must exceed base ({})", l1_ceiling, l1_base);
+    const uint32_t l1_available = l1_ceiling - l1_base;
 
     const uint32_t num_kernel_copies = can_use_dual_kernel ? 2u : 1u;
     const uint32_t source_cb_bytes = cb_size0 * 2u * num_kernel_copies;


### PR DESCRIPTION
### Summary
* Fixes hard deadlock on Blackhole when reshaping ROW_MAJOR `bfloat16` tensors to unit last-dim shapes like `[N, 1]` on interleaved DRAM (`ttnn.synchronize_device` never returns; only `SIGKILL` / `tt-smi -r` recovers).
* Root cause: `dest_page_size_bytes = 2` takes the non-clean path and dual-issues NOC0+NOC1 with a barrier on every tiny DRAM write, triggering the Blackhole DRAM-arbiter hang (SYS-1419).
* Fix (factory + kernel, data_movement + Quasar):
  1. **Disable dual-kernel** when destination page is not NoC-aligned on DRAM (source alignment does not affect DRAM write safety).
  2. **Pipeline non-clean dest writes** via an L1 staging ring (barrier per batch, not per page); slot count is capped by available L1 (`lowest_occupied_compute_l1_address()`), falling back toward 1 slot for wide odd dests.
  3. **Pad** full-page non-clean writes to NOC write alignment (16B); safe because each interleaved page owns a private aligned slot.
  4. **Stage with read-datamover** `tt_memmove` so local staging does not drain in-flight DRAM dest writes (keeps ring batching effective).
  5. Quasar kernel keeps **DataflowBuffer** reserve/push APIs; slot ring offsets remain manual.


Fixes #50191
Verified the hanging test (Test file : [test_reshape_hang.py](https://github.com/user-attachments/files/30342097/test_reshape_hang.py) , Result : [result.txt](https://github.com/user-attachments/files/30342113/result.txt) ) 

### Pipeline status

- [x] Sanity
- [x] (Runtime) Sanity Test
- [x] BHPC
- [x] Nightly
- [x] All model test
- [x] Single card
- [x] T3K
- [x] Galaxy

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=virdhatchani/reshape_bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:virdhatchani/reshape_bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=virdhatchani/reshape_bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:virdhatchani/reshape_bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=virdhatchani/reshape_bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:virdhatchani/reshape_bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=virdhatchani/reshape_bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:virdhatchani/reshape_bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=virdhatchani/reshape_bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:virdhatchani/reshape_bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=virdhatchani/reshape_bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:virdhatchani/reshape_bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=virdhatchani/reshape_bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:virdhatchani/reshape_bug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=virdhatchani/reshape_bug)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:virdhatchani/reshape_bug)