### PR TITLE
[Fix] Incorrect output in height-sharded 1D matmul with multiple row/col blocks

### DIFF
--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
@@ -4220,7 +4220,9 @@ static ProgramDescriptor create_program_mcast_in1_descriptor(
     if (in0_is_sharded) {
         in0_shard_height_in_tiles = in0_tensor.shard_spec()->shape[0] / in0_tile.get_height();
         in0_shard_width_in_tiles = in0_tensor.shard_spec()->shape[1] / in0_tile.get_width();
-        if (in0_shard_width_in_tiles / in0_block_w > 1) {
+        // Do a real per-block copy (not point cb_in0 at L1) when K needs splitting, or when there's more
+        // than 1 row-block AND col-block: a row-block's data is needed twice, but advancing lands on the wrong one.
+        if (in0_shard_width_in_tiles / in0_block_w > 1 || (in0_num_blocks_y > 1 && in1_num_blocks_x > 1)) {
             extract_shard_sub_blocks = true;
         }
     }


### PR DESCRIPTION
**Summary:**
- Fixes: #26150
- Forces a real per-block copy of `in0` instead of aliasing it directly to L1, for the one specific case where that alias produces wrong data - fixes bad PCC for that config combination.
 
**Problem Description:**
- For `MatmulMultiCoreReuseMultiCast1DProgramConfig` with height-sharded `in0`, certain block-size combinations produce incorrect output (PCC as low as `~0.25` instead of `>0.99`).
- Reproduces both with an explicitly supplied `program_config` using these values, and with no config supplied at all (the auto-selected default also hits this combination).
- Root cause: when `in0_block_w` spans the full K width, `cb_in0` is aliased directly onto the shard's L1 memory instead of being copied per block (an existing optimization to skip a redundant copy). That alias can only advance forward - it can never re-read a block it already passed.
-  core splits its own output into blocks via `out_block_h` and `out_block_w`, and computes them one at a time; a "row-block" below means one out_block_h-sized chunk of a core's own M range, and a "column-block" means one out_block_w-sized chunk of its own N range - not a cross-core shard.
- This is safe whenever a core has only one row-block or only one column-block - each row-block's data is only ever needed once before moving to the next. It breaks when a core has more than one row-block **and** more than one column-block: the second column-block needs the same row-block's data again, but the alias only advances forward, so it hands out the next (wrong) row-block instead.
 
**What's Changed:**
- Extended the `extract_shard_sub_blocks` check in `matmul_multicore_reuse_mcast_1d_program_factory.cpp` (`create_program_mcast_in1_descriptor`). It now also forces the real per-block copy path whenever a core has more than one row-block and more than one column-block - on top of the existing check for K needing splitting.
- The existing K-only condition is untouched, and the shortcut still applies for every case already proven correct (single row-block, or single column-block).
 
**Tests:**
- Verified on hardware - PCC changed from `~0.5` to `~0.99` for the failing config, confirming the fix.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ign/matmul-pcc-26150)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ign/matmul-pcc-26150)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ign/matmul-pcc-26150)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ign/matmul-pcc-26150)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ign/matmul-pcc-26150)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ign/matmul-pcc-26150)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ign/matmul-pcc-26150)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ign/matmul-pcc-26150)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ign/matmul-pcc-26150)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ign/matmul-pcc-26150)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ign/matmul-pcc-26150)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ign/matmul-pcc-26150)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ign/matmul-pcc-26150)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ign/matmul-pcc-26150)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ign/matmul-pcc-26150)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ign/matmul-pcc-26150)