### PR TITLE
Register MiniMax-M3 Tier 1 tests and model targets

### DIFF
--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -369,7 +369,7 @@ models:
     wh_galaxy_perf: 150
     bh_galaxy: 470
     # blaze_models_prefill_tests.yaml sum of bh_sc1 job timeouts (tightened from 840)
-    bh_sc1: 392
+    bh_sc1: 437
     bh_sc1_high_power: 108
     wh_n150: 500
     wh_n150_civ2: 300

--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -337,7 +337,7 @@ models:
     wh_galaxy_perf: 45
     bh_p150: 20
     bh_quietbox_2: 260
-    bh_galaxy: 70
+    bh_galaxy: 75
     bh_sc1: 25  # Flux multihost tests (timeout 20 + headroom)
   unit_tier2:
     wh_llmbox: 114
@@ -369,7 +369,7 @@ models:
     wh_galaxy_perf: 150
     bh_galaxy: 470
     # blaze_models_prefill_tests.yaml sum of bh_sc1 job timeouts (tightened from 840)
-    bh_sc1: 377
+    bh_sc1: 392
     bh_sc1_high_power: 108
     wh_n150: 500
     wh_n150_civ2: 300

--- a/.github/workflows/blaze-models-prefill-tests.yaml
+++ b/.github/workflows/blaze-models-prefill-tests.yaml
@@ -12,7 +12,7 @@ on:
           Empty or "all" runs every stage. Valid stages: moe_gate, mla, mla_chunked,
           kv_cache_table, prefill_block, kimi_mla, kimi_moe,
           kimi_prefill_block, kimi_chunked, kimi_chunked_padded, kimi_dflash, glm_chunked, dsa_mla, dsa_mla_glm, glm_moe, glm_prefill_block, glm_chunked_accuracy, prefill_block_determinism,
-          prefill_transformer_determinism, prefill_runner.
+          prefill_transformer_determinism, prefill_runner, minimax_prefill_kv_pcc.
           The "module" group also runs every stage; the "sdpa_perf" group runs the
           ring joint SDPA perf checks.
         required: false

--- a/.github/workflows/models-t1-unit-tests.yaml
+++ b/.github/workflows/models-t1-unit-tests.yaml
@@ -17,6 +17,7 @@ on:
           - qwen3-32b-galaxy
           - qwen3.6-27b
           - gpt-oss-120b
+          - minimax-m3
           - whisper
           - gemma-4-12b
           - gemma-4-26b-a4b

--- a/models/demos/minimax_m3/tests/galaxy_prefill_kv_pcc.py
+++ b/models/demos/minimax_m3/tests/galaxy_prefill_kv_pcc.py
@@ -14,6 +14,7 @@ Env:
   PREFILL_CHUNK_SIZE  chunk size in tokens (chunked mode)                                  [default 5120]
   PREFILL_TPS_ITERS   prefill repetitions for the throughput measurement (less noise)      [default 1]
   PREFILL_SKIP_PCC    "1" -> perf only: skip the per-layer golden KV PCC (no kv_cache/ needed) [default 0]
+  PREFILL_STANDALONE_CHUNKED_PCC  min K/V/index_k PCC gate (fail below this)                 [default 0.88]
   PREFILL_NUM_LAYERS  build/run only the first N decoder layers (faster partial-model runs; also auto-sets
                       M3_LOAD_NLAYERS so only those layers' weight shards are read)          [default: all]
   EXPERT_DTYPE        MoE routed-expert weight dtype: "bf4" or "bf8" (cache holds both)      [default bf4]
@@ -89,11 +90,16 @@ def plan(n_tokens, chunk_size, chunked):
 def check_kv_pcc(runtime, kv_cache, golden_dir, n_tokens, num_layers, hf_config):
     """Per-layer K / V / index_k PCC: device cache (gather_layer) vs the golden trace. The device
     stores K / index_k Meta-RoPE swizzled over the rotary slice; the golden is HF half-split, so
-    permute the golden's rotary slice (identity tail) before comparing. V is raw (no swizzle)."""
+    permute the golden's rotary slice (identity tail) before comparing. V is raw (no swizzle).
+
+    Fails if overall min PCC is below PREFILL_STANDALONE_CHUNKED_PCC (default 0.88), matching
+    models/demos/minimax_m3/tt/runners/prefill_kv_validation.py.
+    """
     from safetensors import safe_open
 
     from models.common.utility_functions import comp_pcc
 
+    threshold = float(os.environ.get("PREFILL_STANDALONE_CHUNKED_PCC", "0.88"))
     head_dim = hf_config.head_dim
     rotary_dim = getattr(hf_config, "rotary_dim", head_dim)
     half = rotary_dim // 2
@@ -124,10 +130,13 @@ def check_kv_pcc(runtime, kv_cache, golden_dir, n_tokens, num_layers, hf_config)
             line += f" index_k={pcc_ik:.5f}"
         logger.info(line)
 
+    min_pcc = min(mins.values())
     logger.info(
         f"[kv-pcc] min PCC across {num_layers} layers: "
-        f"K={mins['k']:.5f} V={mins['v']:.5f} index_k={mins['index_k']:.5f}"
+        f"K={mins['k']:.5f} V={mins['v']:.5f} index_k={mins['index_k']:.5f} "
+        f"(overall {min_pcc:.5f}, threshold {threshold})"
     )
+    assert min_pcc >= threshold, f"KV-cache PCC {min_pcc:.5f} < threshold {threshold}"
     return mins
 
 

--- a/models/demos/minimax_m3/tests/unit/test_msa_layer_vs_ref.py
+++ b/models/demos/minimax_m3/tests/unit/test_msa_layer_vs_ref.py
@@ -16,7 +16,6 @@ PCC drops. Single card (TP=1); SP=8×TP=4 sharding of this same path is validate
 """
 
 import os
-import sys
 from types import SimpleNamespace
 
 import pytest
@@ -39,11 +38,9 @@ from models.demos.minimax_m3.tt.ccl import CCLManager
 from models.demos.minimax_m3.tt.model import create_rope_setup
 from models.demos.minimax_m3.utils.general_utils import get_default_num_links
 from models.demos.minimax_m3.utils.weight_conversion import convert_hf_qkv_to_meta_format_partial
+from tests.ttnn.unit_tests.operations.sdpa.sparse_sdpa_msa_test_utils import sparse_attention_ref_msa_sampled_tokens
 
 from ..test_factory import parametrize_mesh_with_fabric
-
-sys.path.insert(0, os.path.join("tests/ttnn/unit_tests/operations/sdpa"))
-from sparse_sdpa_msa_test_utils import sparse_attention_ref_msa_sampled_tokens  # noqa: E402
 
 HIDDEN, NQ, NKV, NIDX, HEAD_DIM, IDX_DIM, ROTARY_DIM, THETA, EPS = 6144, 64, 4, 4, 128, 128, 64, 5_000_000.0, 1e-6
 BLOCK, TOPK = 128, 16

--- a/models/demos/minimax_m3/tests/unit/test_msa_prefill_vs_ref.py
+++ b/models/demos/minimax_m3/tests/unit/test_msa_prefill_vs_ref.py
@@ -19,10 +19,9 @@ Pipeline (merged ops):
   host: top-16 blocks -> block-ids [1,1,S,16] int32
   sparse_sdpa_msa(q[1,16,S,128] RM, k/v[1,1,T,128] TILE, block-ids uint32 RM, block_size=128) -> [1,16,S,128]
   vs sparse_attention_ref_msa (the op's own block-level golden), same block-ids.
-"""
 
-import os
-import sys
+Single-card only (mesh 1x1) — shapes match one Galaxy chip's shard; SP mesh coverage is in test_msa_sp_*.
+"""
 
 import pytest
 import torch
@@ -30,21 +29,18 @@ from loguru import logger
 
 import ttnn
 from models.common.utility_functions import comp_pcc
+from tests.ttnn.unit_tests.operations.sdpa.sparse_sdpa_msa_test_utils import sparse_attention_ref_msa
 
-# Locate the shared sparse-SDPA test util relative to the repo root (5 levels up from this
-# file), so the import works regardless of pytest's invocation cwd.
-_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), *([".."] * 5)))
-sys.path.insert(0, os.path.join(_REPO_ROOT, "tests/ttnn/unit_tests/operations/sdpa"))
-from sparse_sdpa_msa_test_utils import sparse_attention_ref_msa  # noqa: E402
+from ..test_factory import parametrize_mesh_with_fabric
 
 # Per-device TP=4 slice of M3: 64 q / 4 kv -> 16 q / 1 kv; 1 index-q head + 1 shared index-k; num_groups=1.
 H_DEV, NKV_DEV, NIDX_DEV, NGROUPS = 16, 1, 1, 1
 HEAD_DIM, BLOCK, TOPK_BLK = 128, 128, 16
 
 
+@parametrize_mesh_with_fabric(mesh_shapes=[(1, 1)])
 @pytest.mark.parametrize("S,T", [(640, 5120)], ids=["chunk640_ctx5120"])  # 5120 chunk/SP=8; 40 blocks
-def test_msa_prefill(device, S, T):
-    torch.manual_seed(0)
+def test_msa_prefill(mesh_device, device_params, S, T, reset_seeds):
     chunk_start = T - S  # the chunk is the tail of the ~5k context; query s sees keys [0 : chunk_start+s]
 
     q = torch.randn(1, H_DEV, S, HEAD_DIM, dtype=torch.bfloat16) * 0.1
@@ -53,11 +49,15 @@ def test_msa_prefill(device, S, T):
     iq = torch.randn(1, NIDX_DEV, S, HEAD_DIM, dtype=torch.bfloat16) * 0.1
     ik = torch.randn(1, 1, T, HEAD_DIM, dtype=torch.bfloat16) * 0.1  # ONE shared index-k head (op: k_shape[1]==1)
 
+    mapper = ttnn.ReplicateTensorToMesh(mesh_device)
+
     def dev_tile(t, dt=ttnn.bfloat16):
-        return ttnn.from_torch(t.to(torch.bfloat16), dtype=dt, layout=ttnn.TILE_LAYOUT, device=device)
+        return ttnn.from_torch(
+            t.to(torch.bfloat16), dtype=dt, layout=ttnn.TILE_LAYOUT, device=mesh_device, mesh_mapper=mapper
+        )
 
     def dev_rm(t, dt):
-        return ttnn.from_torch(t, dtype=dt, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
+        return ttnn.from_torch(t, dtype=dt, layout=ttnn.ROW_MAJOR_LAYOUT, device=mesh_device, mesh_mapper=mapper)
 
     # --- indexer block scores (device); op already force-locals the current block (no sink, per upstream) ---
     block_scores = ttnn.experimental.indexer_score_msa(
@@ -69,7 +69,7 @@ def test_msa_prefill(device, S, T):
         block_size=BLOCK,
         program_config=ttnn.IndexerScoreProgramConfig(q_chunk_size=64, k_chunk_size=1024, head_group_size=0),
     )
-    bs = ttnn.to_torch(block_scores).float()  # [1, NGROUPS, S, nblk]
+    bs = ttnn.to_torch(ttnn.get_device_tensors(block_scores)[0]).float()  # [1, NGROUPS, S, nblk]
     block_ids = bs.topk(TOPK_BLK, dim=-1).indices.to(torch.int32)  # [1, NGROUPS, S, 16]
 
     # --- device op (mirror run_op_msa_native) + the op's golden, SAME block-ids ---
@@ -81,7 +81,7 @@ def test_msa_prefill(device, S, T):
         scale=HEAD_DIM**-0.5,
         block_size=BLOCK,
     )
-    out_t = ttnn.to_torch(out)[:, :H_DEV].float()
+    out_t = ttnn.to_torch(ttnn.get_device_tensors(out)[0])[:, :H_DEV].float()
     ref = sparse_attention_ref_msa(q.float(), k.float(), v.float(), block_ids, HEAD_DIM**-0.5)
 
     passing, pcc = comp_pcc(ref, out_t, 0.99)

--- a/models/model_ci_tiers.md
+++ b/models/model_ci_tiers.md
@@ -45,6 +45,7 @@ The initial release of the 3-tier model CI includes models owned by the models-t
 | Llama3.3-70B | WH Galaxy |
 | Qwen3-32B | WH Galaxy |
 | GPT-OSS 120B | WH Galaxy, BH Galaxy, BH QuietBox 2 |
+| MiniMax-M3 | BH P150, BH Galaxy |
 | Whisper | WH N150, BH P150 |
 | Gemma-4-12B | BH QuietBox 2 |
 | Gemma-4-26B-A4B | BH QuietBox 2 |

--- a/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
+++ b/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
@@ -481,6 +481,7 @@
     export PREFILL_CHUNKED=1
     export PREFILL_CHUNK_SIZE=5120
     export PREFILL_TPS_ITERS=1
+    export PREFILL_STANDALONE_CHUNKED_PCC=0.99
     mpirun --pernode --tag-output bash -lc '
       python3 models/demos/minimax_m3/tests/galaxy_prefill_kv_pcc.py
     '

--- a/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
+++ b/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
@@ -481,7 +481,6 @@
     export PREFILL_CHUNKED=1
     export PREFILL_CHUNK_SIZE=5120
     export PREFILL_TPS_ITERS=1
-    export PREFILL_STANDALONE_CHUNKED_PCC=0.99
     mpirun --pernode --tag-output bash -lc '
       python3 models/demos/minimax_m3/tests/galaxy_prefill_kv_pcc.py
     '

--- a/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
+++ b/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
@@ -473,7 +473,7 @@
   cmd: |
     export LOGURU_LEVEL=INFO
     export HF_MODEL=/mnt/models/MiniMaxAI/MiniMax-M3-ref/
-    export PREFILL_TRACE_DIR=/mnt/models/MiniMaxAI/MiniMax-M3-ref/golden
+    export PREFILL_TRACE_DIR=/mnt/models/MiniMaxAI/MiniMax-M3-ref/golden/longbook_10240
     export TT_MESH_GRAPH_DESC_PATH=$TT_METAL_HOME/tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_mesh_graph_descriptor.textproto
     export EXPERT_DTYPE=bf4
     export PREFILL_CHUNKED=0

--- a/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
+++ b/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
@@ -462,3 +462,31 @@
   owner_id: U09L76N1MAT  # Nenad Babin
   team: models
   sp_config: sc1
+
+# MiniMax-M3 full-model real-weights prefill + per-layer KV PCC (standalone harness, not pytest).
+# Requires staged mounts (same layout as models/demos/minimax_m3/scripts/README_golden_kv.md):
+#   HF_MODEL          -> /mnt/models/MiniMaxAI/MiniMax-M3-ref/
+#   PREFILL_TRACE_DIR -> /mnt/models/minimax-m3-cache/golden/longbook_full
+#   TT_CACHE_PATH     -> optional; defaults under HF_MODEL. Prefill the tilized
+#                       tensor_cache_bfp8_{MeshShape(8,4)} there or CI will cold-build for hours.
+- name: "Blaze - MiniMax-M3 Prefill KV PCC"
+  cmd: |
+    export LOGURU_LEVEL=INFO
+    export HF_MODEL=/mnt/models/MiniMaxAI/MiniMax-M3-ref/
+    export PREFILL_TRACE_DIR=/mnt/models/minimax-m3-cache/golden/longbook_full
+    export TT_MESH_GRAPH_DESC_PATH=$TT_METAL_HOME/tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_mesh_graph_descriptor.textproto
+    export EXPERT_DTYPE=bf4
+    export PREFILL_CHUNKED=0
+    export PREFILL_TPS_ITERS=1
+    mpirun --pernode --tag-output bash -lc '
+      python3 models/demos/minimax_m3/tests/galaxy_prefill_kv_pcc.py
+    '
+  test_type: minimax_prefill_kv_pcc
+  test_group: module
+  skus:
+    bh_sc1:
+      # Warm tilized-cache + one-shot prefill + KV PCC; cold weight-cache build will exceed this.
+      timeout: 60
+  owner_id: U08ECJQ848G # Viacheslav Melnykov
+  team: models
+  sp_config: sc1

--- a/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
+++ b/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
@@ -472,6 +472,8 @@
 - name: "Blaze - MiniMax-M3 Prefill KV PCC"
   cmd: |
     export LOGURU_LEVEL=INFO
+    export TT_METAL_HOME=${TT_METAL_HOME:-$PWD}
+    export PYTHONPATH=${TT_METAL_HOME}${PYTHONPATH:+:$PYTHONPATH}
     export HF_MODEL=/mnt/models/MiniMaxAI/MiniMax-M3-ref/
     export PREFILL_TRACE_DIR=/mnt/models/MiniMaxAI/MiniMax-M3-ref/golden/longbook_10240
     export TT_MESH_GRAPH_DESC_PATH=$TT_METAL_HOME/tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_mesh_graph_descriptor.textproto

--- a/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
+++ b/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
@@ -478,7 +478,8 @@
     export PREFILL_TRACE_DIR=/mnt/models/MiniMaxAI/MiniMax-M3-ref/golden/longbook_56320
     export TT_MESH_GRAPH_DESC_PATH=$TT_METAL_HOME/tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_mesh_graph_descriptor.textproto
     export EXPERT_DTYPE=bf4
-    export PREFILL_CHUNKED=0
+    export PREFILL_CHUNKED=1
+    export PREFILL_CHUNK_SIZE=5120
     export PREFILL_TPS_ITERS=1
     mpirun --pernode --tag-output bash -lc '
       python3 models/demos/minimax_m3/tests/galaxy_prefill_kv_pcc.py
@@ -487,7 +488,7 @@
   test_group: module
   skus:
     bh_sc1:
-      # Warm tilized-cache + one-shot prefill + KV PCC; cold weight-cache build will exceed this.
+      # Warm tilized-cache + chunked prefill (5120) + KV PCC; cold weight-cache build will exceed this.
       timeout: 60
   owner_id: U08ECJQ848G # Viacheslav Melnykov
   team: models

--- a/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
+++ b/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
@@ -475,7 +475,7 @@
     export TT_METAL_HOME=${TT_METAL_HOME:-$PWD}
     export PYTHONPATH=${TT_METAL_HOME}${PYTHONPATH:+:$PYTHONPATH}
     export HF_MODEL=/mnt/models/MiniMaxAI/MiniMax-M3-ref/
-    export PREFILL_TRACE_DIR=/mnt/models/MiniMaxAI/MiniMax-M3-ref/golden/longbook_10240
+    export PREFILL_TRACE_DIR=/mnt/models/MiniMaxAI/MiniMax-M3-ref/golden/longbook_56320
     export TT_MESH_GRAPH_DESC_PATH=$TT_METAL_HOME/tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_mesh_graph_descriptor.textproto
     export EXPERT_DTYPE=bf4
     export PREFILL_CHUNKED=0

--- a/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
+++ b/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
@@ -466,14 +466,14 @@
 # MiniMax-M3 full-model real-weights prefill + per-layer KV PCC (standalone harness, not pytest).
 # Requires staged mounts (same layout as models/demos/minimax_m3/scripts/README_golden_kv.md):
 #   HF_MODEL          -> /mnt/models/MiniMaxAI/MiniMax-M3-ref/
-#   PREFILL_TRACE_DIR -> /mnt/models/minimax-m3-cache/golden/longbook_full
+#   PREFILL_TRACE_DIR -> /mnt/models/MiniMaxAI/MiniMax-M3-ref/golden
 #   TT_CACHE_PATH     -> optional; defaults under HF_MODEL. Prefill the tilized
 #                       tensor_cache_bfp8_{MeshShape(8,4)} there or CI will cold-build for hours.
 - name: "Blaze - MiniMax-M3 Prefill KV PCC"
   cmd: |
     export LOGURU_LEVEL=INFO
     export HF_MODEL=/mnt/models/MiniMaxAI/MiniMax-M3-ref/
-    export PREFILL_TRACE_DIR=/mnt/models/minimax-m3-cache/golden/longbook_full
+    export PREFILL_TRACE_DIR=/mnt/models/MiniMaxAI/MiniMax-M3-ref/golden
     export TT_MESH_GRAPH_DESC_PATH=$TT_METAL_HOME/tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_mesh_graph_descriptor.textproto
     export EXPERT_DTYPE=bf4
     export PREFILL_CHUNKED=0

--- a/tests/pipeline_reorg/models_unit_tests.yaml
+++ b/tests/pipeline_reorg/models_unit_tests.yaml
@@ -547,7 +547,6 @@
 # Deploy mesh is SP=8 x TP=4 -> (8, 4) on BH Galaxy
 - name: MiniMax-M3 unit tests (1-card)
   cmd: |
-    export HF_MODEL=/mnt/models/MiniMaxAI/MiniMax-M3-ref/
     pytest --timeout 300 models/demos/minimax_m3/tests/unit/ -k "1x1"
   model: minimax-m3
   skus:

--- a/tests/pipeline_reorg/models_unit_tests.yaml
+++ b/tests/pipeline_reorg/models_unit_tests.yaml
@@ -542,12 +542,13 @@
   owner_id: U053W15B6JF # Djordje Ivanovic
   team: models
 
-# MiniMax-M3 unit tests — mostly random-weight module PCC; HF_MODEL enables
-# test_msa_layer_vs_ref real-weights PCC on 1-card.
+# MiniMax-M3 unit tests — random-weight module PCC only (no HF_MODEL / M3_CKPT).
+# test_msa_layer_vs_ref is real-weights and opt-in locally; excluded from CI so Tier-1
+# does not silently skip. Synthetic MSA prefill coverage: test_msa_prefill_vs_ref.
 # Deploy mesh is SP=8 x TP=4 -> (8, 4) on BH Galaxy
 - name: MiniMax-M3 unit tests (1-card)
   cmd: |
-    pytest --timeout 300 models/demos/minimax_m3/tests/unit/ -k "1x1"
+    pytest --timeout 300 models/demos/minimax_m3/tests/unit/ -k "1x1 and not msa_layer"
   model: minimax-m3
   skus:
     bh_p150:

--- a/tests/pipeline_reorg/models_unit_tests.yaml
+++ b/tests/pipeline_reorg/models_unit_tests.yaml
@@ -547,7 +547,7 @@
 # Deploy mesh is SP=8 x TP=4 -> (8, 4) on BH Galaxy
 - name: MiniMax-M3 unit tests (1-card)
   cmd: |
-    # export HF_MODEL=/mnt/models/MiniMaxAI/MiniMax-M3-ref/
+    export HF_MODEL=/mnt/models/MiniMaxAI/MiniMax-M3-ref/
     pytest --timeout 300 models/demos/minimax_m3/tests/unit/ -k "1x1"
   model: minimax-m3
   skus:

--- a/tests/pipeline_reorg/models_unit_tests.yaml
+++ b/tests/pipeline_reorg/models_unit_tests.yaml
@@ -559,6 +559,7 @@
 
 - name: MiniMax-M3 unit tests (BH Galaxy 8x4)
   cmd: |
+    unset TT_METAL_WATCHER  # blocked by #50886 (Watcher data corruption on mesh open)
     export TT_MESH_GRAPH_DESC_PATH=$TT_METAL_HOME/tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_mesh_graph_descriptor.textproto
     # -k 8x4: ring_joint / MSA SP / KV cache / EP MoE / model_sp / attention(+chunked) / dense_mlp@8x4
     pytest --timeout 900 models/demos/minimax_m3/tests/unit/ -k "8x4"

--- a/tests/pipeline_reorg/models_unit_tests.yaml
+++ b/tests/pipeline_reorg/models_unit_tests.yaml
@@ -542,6 +542,34 @@
   owner_id: U053W15B6JF # Djordje Ivanovic
   team: models
 
+# MiniMax-M3 unit tests — mostly random-weight module PCC; HF_MODEL enables
+# test_msa_layer_vs_ref real-weights PCC on 1-card.
+# Deploy mesh is SP=8 x TP=4 -> (8, 4) on BH Galaxy
+- name: MiniMax-M3 unit tests (1-card)
+  cmd: |
+    # export HF_MODEL=/mnt/models/MiniMaxAI/MiniMax-M3-ref/
+    pytest --timeout 300 models/demos/minimax_m3/tests/unit/ -k "1x1"
+  model: minimax-m3
+  skus:
+    bh_p150:
+      timeout: 5
+      tier: 1
+  owner_id: U08ECJQ848G # Viacheslav Melnykov
+  team: models
+
+- name: MiniMax-M3 unit tests (BH Galaxy 8x4)
+  cmd: |
+    export TT_MESH_GRAPH_DESC_PATH=$TT_METAL_HOME/tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_mesh_graph_descriptor.textproto
+    # -k 8x4: ring_joint / MSA SP / KV cache / EP MoE / model_sp / attention(+chunked) / dense_mlp@8x4
+    pytest --timeout 900 models/demos/minimax_m3/tests/unit/ -k "8x4"
+  model: minimax-m3
+  skus:
+    bh_galaxy:
+      timeout: 40
+      tier: 1
+  owner_id: U08ECJQ848G # Viacheslav Melnykov
+  team: models
+
 # GPT-OSS unit tests: uses HF config only (no weights). parametrize_mesh_with_fabric()
 # picks the largest fitting mesh shape per SKU when CI=true, so one yaml entry
 # covers N150 (1x1), T3K/llmbox (1x8), and Galaxy (4x8) without per-SKU -k filters.

--- a/tests/pipeline_reorg/models_unit_tests.yaml
+++ b/tests/pipeline_reorg/models_unit_tests.yaml
@@ -565,7 +565,7 @@
   model: minimax-m3
   skus:
     bh_galaxy:
-      timeout: 40
+      timeout: 15
       tier: 1
   owner_id: U08ECJQ848G # Viacheslav Melnykov
   team: models


### PR DESCRIPTION
Ads MiniMax-M3 to Tier-1 model CI: 1-card unit tests on BH P150 and 8×4 Galaxy unit tests, plus a Blaze chunked-prefill KV-PCC job on BH SC1 that runs the standalone `galaxy_prefill_kv_pcc` harness against the longbook_56320 golden (chunk size 5120) with a min K/V/index_k PCC gate (default 0.88).
Wires `minimax-m3` into `models-t1-unit-tests` workflow_dispatch; documents MiniMax-M3 in `model_ci_tiers.md`.
Wires `minimax_prefill_kv_pcc` into Blaze prefill stages / workflow_dispatch.
Cleans up MiniMax unit tests (proper package imports for sparse-SDPA utils, mesh-aware MSA prefill test) and raises `time_budget.yaml` Galaxy budgets (`bh_galaxy` 70→75, Blaze `bh_sc1` 485→555) for the new job timeouts.
## Test plan
- [ ] [![models-t1-unit-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/models-t1-unit-tests.yaml/badge.svg?branch=lgalasTT/minmax3_test_cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/models-t1-unit-tests.yaml?query=branch:lgalasTT/minmax3_test_cleanup)
- [ ] [![blaze-models-prefill-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blaze-models-prefill-tests.yaml/badge.svg?branch=lgalasTT/minmax3_test_cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/blaze-models-prefill-tests.yaml?query=branch:lgalasTT/minmax3_test_cleanup)


### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=lgalasTT/minmax3_test_cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:lgalasTT/minmax3_test_cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=lgalasTT/minmax3_test_cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:lgalasTT/minmax3_test_cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=lgalasTT/minmax3_test_cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:lgalasTT/minmax3_test_cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=lgalasTT/minmax3_test_cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:lgalasTT/minmax3_test_cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=lgalasTT/minmax3_test_cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:lgalasTT/minmax3_test_cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=lgalasTT/minmax3_test_cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:lgalasTT/minmax3_test_cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=lgalasTT/minmax3_test_cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:lgalasTT/minmax3_test_cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=lgalasTT/minmax3_test_cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:lgalasTT/minmax3_test_cleanup)