### PR TITLE
Migrate off deprecated pack_tile_block / copy_block_matmul_partials

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/11_remote_cb_sync_matmul_single_core/kernels/bmm_large_block_zm_fused_bias_activation_copy.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/11_remote_cb_sync_matmul_single_core/kernels/bmm_large_block_zm_fused_bias_activation_copy.cpp
@@ -73,7 +73,7 @@ void kernel_main() {
         cb_reserve_back(out_cb_id, out_block_num_tiles);
         tile_regs_wait();
         uint32_t start_dst_index = 0;
-        pack_tile_block(start_dst_index, out_cb_id, out_block_num_tiles);
+        pack_block(start_dst_index, out_cb_id, out_block_num_tiles);
         tile_regs_release();
         cb_push_back(out_cb_id, out_block_num_tiles);
     }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/1_compute_mm/kernels/bmm_large_block_zm_fused_bias_activation_copy.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/1_compute_mm/kernels/bmm_large_block_zm_fused_bias_activation_copy.cpp
@@ -31,7 +31,7 @@ FORCE_INLINE void reload_from_cb_to_dst(
 
     uint32_t start_dst_index = 0;
     uint32_t start_tile_index = 0;
-    copy_block_matmul_partials(mm_partials_cb_id, start_tile_index, start_dst_index, out_subblock_num_tiles);
+    copy_block(mm_partials_cb_id, start_tile_index, start_dst_index, out_subblock_num_tiles);
 
     cb_pop_front(mm_partials_cb_id, out_subblock_num_tiles);
     // Reconfigure srcA back
@@ -225,7 +225,7 @@ void kernel_main() {
 #endif
 
                         uint32_t start_dst_index = 0;
-                        pack_tile_block(start_dst_index, mm_out_cb_id, out_subblock_num_tiles);
+                        pack_block(start_dst_index, mm_out_cb_id, out_subblock_num_tiles);
 
                         tile_regs_release();
                         cb_push_back(mm_out_cb_id, out_subblock_num_tiles);
@@ -250,7 +250,7 @@ void kernel_main() {
 #endif
 
                         uint32_t start_dst_index = 0;
-                        pack_tile_block(start_dst_index, mm_partials_cb_id, out_subblock_num_tiles);
+                        pack_block(start_dst_index, mm_partials_cb_id, out_subblock_num_tiles);
 
                         tile_regs_release();
                         cb_push_back(mm_partials_cb_id, out_subblock_num_tiles);

--- a/tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_block_matmul_partials.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_block_matmul_partials.cpp
@@ -26,10 +26,10 @@ void kernel_main() {
         tile_regs_wait();
 
         for (uint32_t i = 0; i < num_single_transfer; ++i) {
-            copy_block_matmul_partials(dfb::in, i, i, 1);
+            copy_block(dfb::in, i, i, 1);
         }
 
-        pack_tile_block(0, dfb::out, num_single_transfer);
+        pack_block(0, dfb::out, num_single_transfer);
 
         tile_regs_commit();
         tile_regs_release();

--- a/tests/tt_metal/tt_metal/test_kernels/compute/reconfig.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/reconfig.cpp
@@ -52,7 +52,7 @@ void kernel_main() {
             copy_tile(cb_in2, 0, 0);
         }
 #elif (BLOCK_COPY == 0)
-        copy_block_matmul_partials(cb_in2, 0, 0, ublock_size_tiles);
+        copy_block(cb_in2, 0, 0, ublock_size_tiles);
 #endif
         cbin2.pop_front(ublock_size_tiles);
 
@@ -96,7 +96,7 @@ void kernel_main() {
         pack_reconfig_l1_acc(true);
 #endif
         // Configured already for CB_16, Bfp16_b
-        pack_tile_block(0, cb_out0, ublock_size_tiles);
+        pack_block(0, cb_out0, ublock_size_tiles);
         // Reconfig for CB_17, Bfp8_b, then pack to CB_17
 #if (EXPLICIT_RECONFIG == 1)
         // Indices for old_output, new_output
@@ -108,7 +108,7 @@ void kernel_main() {
         // Not testing for L1 accumulation
         pack_reconfig_l1_acc(false);
 
-        pack_tile_block(0, cb_out1, ublock_size_tiles);
+        pack_block(0, cb_out1, ublock_size_tiles);
         tile_regs_release();
 
         cbin0.pop_front(ublock_size_tiles);

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_bmm_tilize.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_bmm_tilize.cpp
@@ -423,7 +423,7 @@ void kernel_main() {
 
                             uint32_t start_dst_index = 0;
                             uint32_t start_tile_index = 0;
-                            copy_block_matmul_partials(
+                            copy_block(
                                 matmul_partials_cb, start_tile_index, start_dst_index, out_subblock_num_tiles);
 
                             dfb_matmul_partials.pop_front(out_subblock_num_tiles);
@@ -489,7 +489,7 @@ void kernel_main() {
                         }
 
                         uint32_t start_dst_index = 0;
-                        pack_tile_block(start_dst_index, curr_matmul_out_cb, out_subblock_num_tiles);
+                        pack_block(start_dst_index, curr_matmul_out_cb, out_subblock_num_tiles);
 
                         tile_regs_release();
                         curr_out_dfb.push_back(out_subblock_num_tiles);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/kernels/compute/bmm_large_block_zm_fused_bias_activation_gathered.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/llama_all_gather_matmul_async/device/kernels/compute/bmm_large_block_zm_fused_bias_activation_gathered.cpp
@@ -32,7 +32,7 @@ FORCE_INLINE void reload_from_cb_to_dst(
 
     uint32_t start_dst_index = 0;
     uint32_t start_tile_index = 0;
-    copy_block_matmul_partials(mm_partials_cb_id, start_tile_index, start_dst_index, out_subblock_num_tiles);
+    copy_block(mm_partials_cb_id, start_tile_index, start_dst_index, out_subblock_num_tiles);
 
     cb_mm_partials.pop_front(out_subblock_num_tiles);
     // Reconfigure srcA back
@@ -355,7 +355,7 @@ void kernel_main() {
                         if constexpr (untilize_out) {
                             pack_untilize_dest<out_subblock_num_tiles>(mm_out_cb_id);
                         } else {
-                            pack_tile_block(start_dst_index, mm_out_cb_id, out_subblock_num_tiles);
+                            pack_block(start_dst_index, mm_out_cb_id, out_subblock_num_tiles);
                         }
 
                         tile_regs_release();
@@ -379,7 +379,7 @@ void kernel_main() {
 #endif
 
                         uint32_t start_dst_index = 0;
-                        pack_tile_block(start_dst_index, mm_partials_cb_id, out_subblock_num_tiles);
+                        pack_block(start_dst_index, mm_partials_cb_id, out_subblock_num_tiles);
 
                         tile_regs_release();
                         cb_mm_partials.push_back(out_subblock_num_tiles);

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek/mla/matmul_wo/device/kernels/compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek/mla/matmul_wo/device/kernels/compute.cpp
@@ -101,7 +101,7 @@ void kernel_main() {
         tile_regs_wait();
 
         cb_c2w_out.reserve_back(num_n_tiles_per_iter);
-        pack_tile_block(0, cb_c2w_out_id, num_n_tiles_per_iter);
+        pack_block(0, cb_c2w_out_id, num_n_tiles_per_iter);
         cb_c2w_out.push_back(num_n_tiles_per_iter);
         tile_regs_release();
     }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/compute/fused_swiglu.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/compute/fused_swiglu.cpp
@@ -200,7 +200,7 @@ FORCE_INLINE void matmul_phase(
                 tile_regs_commit();
                 partials_cb.reserve_back(out_subblock_num_tiles);
                 tile_regs_wait();
-                pack_tile_block(0, partials_cb_id, out_subblock_num_tiles);
+                pack_block(0, partials_cb_id, out_subblock_num_tiles);
                 tile_regs_release();
                 partials_cb.push_back(out_subblock_num_tiles);
 

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/kernels/conv_bmm_tilize.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/kernels/conv_bmm_tilize.cpp
@@ -434,7 +434,7 @@ void kernel_main() {
 
                             uint32_t start_dst_index = 0;
                             uint32_t start_tile_index = 0;
-                            copy_block_matmul_partials(
+                            copy_block(
                                 matmul_partials_cb, start_tile_index, start_dst_index, out_subblock_num_tiles);
 
                             cb_matmul_partials.pop_front(out_subblock_num_tiles);
@@ -505,7 +505,7 @@ void kernel_main() {
                         }
 
                         uint32_t start_dst_index = 0;
-                        pack_tile_block(start_dst_index, curr_matmul_out_cb, out_subblock_num_tiles);
+                        pack_block(start_dst_index, curr_matmul_out_cb, out_subblock_num_tiles);
 
                         tile_regs_release();
                         curr_out_cb.push_back(out_subblock_num_tiles);

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/kernels/conv_bmm_tilize_metal2.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/kernels/conv_bmm_tilize_metal2.cpp
@@ -553,7 +553,7 @@ void kernel_main() {
 
                             uint32_t start_dst_index = 0;
                             uint32_t start_tile_index = 0;
-                            copy_block_matmul_partials(
+                            copy_block(
                                 matmul_partials_cb, start_tile_index, start_dst_index, out_subblock_num_tiles);
 
                             cb_matmul_partials.pop_front(out_subblock_num_tiles);
@@ -609,7 +609,7 @@ void kernel_main() {
                             }
 
                             uint32_t start_dst_index = 0;
-                            pack_tile_block(start_dst_index, curr_matmul_out_cb, out_subblock_num_tiles);
+                            pack_block(start_dst_index, curr_matmul_out_cb, out_subblock_num_tiles);
 
                             tile_regs_release();
                             curr_out_cb.push_back(out_subblock_num_tiles);

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp
@@ -103,7 +103,7 @@ FORCE_INLINE void reload_from_cb_to_dst(
 
     uint32_t start_dst_index = 0;
     uint32_t start_tile_index = 0;
-    copy_block_matmul_partials(mm_partials_cb_id, start_tile_index, start_dst_index, out_subblock_num_tiles);
+    copy_block(mm_partials_cb_id, start_tile_index, start_dst_index, out_subblock_num_tiles);
 
     mm_partials_cb.pop_front(out_subblock_num_tiles);
     // Reconfigure srcA back
@@ -384,7 +384,7 @@ void kernel_main() {
 #endif
 #endif
                                 uint32_t start_dst_index = 0;
-                                pack_tile_block(start_dst_index, mm_out_cb_id, out_subblock_num_tiles);
+                                pack_block(start_dst_index, mm_out_cb_id, out_subblock_num_tiles);
 
                                 tile_regs_release();
                                 mm_out_cb.push_back(out_subblock_num_tiles);
@@ -407,7 +407,7 @@ void kernel_main() {
 #endif
 
                                 uint32_t start_dst_index = 0;
-                                pack_tile_block(start_dst_index, mm_partials_cb_id, out_subblock_num_tiles);
+                                pack_block(start_dst_index, mm_partials_cb_id, out_subblock_num_tiles);
 
                                 tile_regs_release();
                                 mm_partials_cb.push_back(out_subblock_num_tiles);

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation_gathered.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation_gathered.cpp
@@ -33,7 +33,7 @@ FORCE_INLINE void reload_from_cb_to_dst(
 
     uint32_t start_dst_index = 0;
     uint32_t start_tile_index = 0;
-    copy_block_matmul_partials(mm_partials_cb_id, start_tile_index, start_dst_index, out_subblock_num_tiles);
+    copy_block(mm_partials_cb_id, start_tile_index, start_dst_index, out_subblock_num_tiles);
 
     mm_partials_cb.pop_front(out_subblock_num_tiles);
     // Reconfigure srcA back
@@ -414,7 +414,7 @@ void kernel_main() {
                         if constexpr (untilize_out) {
                             pack_untilize_dest<out_subblock_num_tiles>(mm_out_cb_id);
                         } else {
-                            pack_tile_block(start_dst_index, mm_out_cb_id, out_subblock_num_tiles);
+                            pack_block(start_dst_index, mm_out_cb_id, out_subblock_num_tiles);
                         }
 
                         tile_regs_release();
@@ -438,7 +438,7 @@ void kernel_main() {
 #endif
 
                         uint32_t start_dst_index = 0;
-                        pack_tile_block(start_dst_index, mm_partials_cb_id, out_subblock_num_tiles);
+                        pack_block(start_dst_index, mm_partials_cb_id, out_subblock_num_tiles);
 
                         tile_regs_release();
                         mm_partials_cb.push_back(out_subblock_num_tiles);

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation_metal2.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation_metal2.cpp
@@ -123,7 +123,7 @@ FORCE_INLINE void reload_from_cb_to_dst(
 
     uint32_t start_dst_index = 0;
     uint32_t start_tile_index = 0;
-    copy_block_matmul_partials(mm_partials_cb_id, start_tile_index, start_dst_index, out_subblock_num_tiles);
+    copy_block(mm_partials_cb_id, start_tile_index, start_dst_index, out_subblock_num_tiles);
 
     mm_partials_cb.pop_front(out_subblock_num_tiles);
     // Reconfigure srcA back
@@ -430,7 +430,7 @@ void kernel_main() {
 #endif
 #endif
                                 uint32_t start_dst_index = 0;
-                                pack_tile_block(start_dst_index, mm_out_cb_id, out_subblock_num_tiles);
+                                pack_block(start_dst_index, mm_out_cb_id, out_subblock_num_tiles);
 
                                 tile_regs_release();
                                 mm_out_cb.push_back(out_subblock_num_tiles);
@@ -453,7 +453,7 @@ void kernel_main() {
 #endif
 
                                 uint32_t start_dst_index = 0;
-                                pack_tile_block(start_dst_index, mm_partials_cb_id, out_subblock_num_tiles);
+                                pack_block(start_dst_index, mm_partials_cb_id, out_subblock_num_tiles);
 
                                 tile_regs_release();
                                 mm_partials_cb.push_back(out_subblock_num_tiles);

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/reduction/generic/device/kernels/compute/welford_reduce_hw.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/reduction/generic/device/kernels/compute/welford_reduce_hw.cpp
@@ -155,7 +155,7 @@ void kernel_main() {
                 cb_partial_obj.reserve_back(2);
                 tile_regs_wait();
                 pack_reconfig_data_format(cb_partial);
-                pack_tile_block(mean_dst, cb_partial, 2);
+                pack_block(mean_dst, cb_partial, 2);
                 tile_regs_release();
                 cb_partial_obj.push_back(2);
             }

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp
@@ -117,7 +117,7 @@ FORCE_INLINE void reload_from_cb_to_dst(
 
     uint32_t start_dst_index = 0;
     uint32_t start_tile_index = 0;
-    copy_block_matmul_partials(mm_partials_reload_dfb_id, start_tile_index, start_dst_index, out_subblock_num_tiles);
+    copy_block(mm_partials_reload_dfb_id, start_tile_index, start_dst_index, out_subblock_num_tiles);
 
     mm_partials_dfb.pop_front(out_subblock_num_tiles);
     // Reconfigure srcA back
@@ -407,7 +407,7 @@ void kernel_main() {
 #endif
 #endif
                                 uint32_t start_dst_index = 0;
-                                pack_tile_block(start_dst_index, mm_out_dfb_id, out_subblock_num_tiles);
+                                pack_block(start_dst_index, mm_out_dfb_id, out_subblock_num_tiles);
 
                                 tile_regs_release();
                                 mm_out_dfb.push_back(out_subblock_num_tiles);
@@ -430,7 +430,7 @@ void kernel_main() {
 #endif
 
                                 uint32_t start_dst_index = 0;
-                                pack_tile_block(start_dst_index, mm_partials_dfb_id, out_subblock_num_tiles);
+                                pack_block(start_dst_index, mm_partials_dfb_id, out_subblock_num_tiles);
 
                                 tile_regs_release();
                                 mm_partials_dfb.push_back(out_subblock_num_tiles);

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation_gathered.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation_gathered.cpp
@@ -33,7 +33,7 @@ FORCE_INLINE void reload_from_cb_to_dst(
 
     uint32_t start_dst_index = 0;
     uint32_t start_tile_index = 0;
-    copy_block_matmul_partials(mm_partials_dfb_id, start_tile_index, start_dst_index, out_subblock_num_tiles);
+    copy_block(mm_partials_dfb_id, start_tile_index, start_dst_index, out_subblock_num_tiles);
 
     mm_partials_dfb.pop_front(out_subblock_num_tiles);
     // Reconfigure srcA back
@@ -439,7 +439,7 @@ void kernel_main() {
                         if constexpr (untilize_out) {
                             pack_untilize_dest<out_subblock_num_tiles>(mm_out_dfb_id);
                         } else {
-                            pack_tile_block(start_dst_index, mm_out_dfb_id, out_subblock_num_tiles);
+                            pack_block(start_dst_index, mm_out_dfb_id, out_subblock_num_tiles);
                         }
 
                         tile_regs_release();
@@ -463,7 +463,7 @@ void kernel_main() {
 #endif
 
                         uint32_t start_dst_index = 0;
-                        pack_tile_block(start_dst_index, mm_partials_dfb_id, out_subblock_num_tiles);
+                        pack_block(start_dst_index, mm_partials_dfb_id, out_subblock_num_tiles);
 
                         tile_regs_release();
                         mm_partials_dfb.push_back(out_subblock_num_tiles);

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/welford_groupnorm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/welford_groupnorm.cpp
@@ -375,7 +375,7 @@ void kernel_main() {
 
         tile_regs_commit();
         tile_regs_wait();
-        pack_tile_block(mean_dst, dfb_ex_partial_id, 2);
+        pack_block(mean_dst, dfb_ex_partial_id, 2);
         tile_regs_release();
         dfb_ex_partial.push_back(2);
         // End Statistics Aggregation

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/welford_groupnorm_sharded_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/welford_groupnorm_sharded_v2.cpp
@@ -278,7 +278,7 @@ void kernel_main() {
 
         tile_regs_commit();
         tile_regs_wait();
-        pack_tile_block(mean_dst, dfb_ex_partial_id, 2);
+        pack_block(mean_dst, dfb_ex_partial_id, 2);
         tile_regs_release();
         dfb_ex_partial.push_back(2);
 

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/welford_reduce_hw.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/welford_reduce_hw.cpp
@@ -154,7 +154,7 @@ void kernel_main() {
                 dfb_partial_obj.reserve_back(2);
                 tile_regs_wait();
                 pack_reconfig_data_format(dfb_partial);
-                pack_tile_block(mean_dst, dfb_partial, 2);
+                pack_block(mean_dst, dfb_partial, 2);
                 tile_regs_release();
                 dfb_partial_obj.push_back(2);
             }


### PR DESCRIPTION
## What

Renames all in-repo call sites of the two deprecated block variants to their current names:

- `pack_tile_block(...)` -> `pack_block(...)`
- `copy_block_matmul_partials(...)` -> `copy_block(...)`

## Why

These two emit deprecation warnings on every build that compiles the kernels using them (matmul, conv, groupnorm, reduction, and the Quasar variants), which spams the CI logs. Migrating the callers clears the spam.

## Safety

Pure rename. Both deprecated functions are thin shims that forward to the new name with the same arguments, so the change is behavior neutral (39 insertions, 39 deletions, one for one). The host test helper names in `test_copy_block_matmul_partials.cpp` are intentionally left as is (they are test names, not calls).

The deprecated shims in `pack.h` and `tile_move_copy.h` stay in place for external callers until their grace period ends; this PR only removes the in-repo usages.

## CI sweep

Pure rename (`pack_tile_block` -> `pack_block`, `copy_block_matmul_partials` -> `copy_block`), so it is behavior neutral. Every red below is main baseline, runner infra, or a stale base artifact -- none come from the rename. Each justification links the main run (which does not have this change) used as evidence.

| Pipeline | Result | Why (evidence from main) |
|---|---|---|
| [Sanity](https://github.com/tenstorrent/tt-metal/actions/runs/30075933754) | pass | - |
| [Blackhole Sanity](https://github.com/tenstorrent/tt-metal/actions/runs/30075935714) | fail: `sdpa group` (sparse-SDPA regression) | main baseline -- also fails on main: [run 30080864988](https://github.com/tenstorrent/tt-metal/actions/runs/30080864988) |
| [Device Perf (single-card)](https://github.com/tenstorrent/tt-metal/actions/runs/30075937793) | pass | - |
| [Blackhole e2e](https://github.com/tenstorrent/tt-metal/actions/runs/30075939632) | fail: `ccl` / `DeepSeek` | main baseline -- also fails on main: [run 30080197320](https://github.com/tenstorrent/tt-metal/actions/runs/30080197320) |
| [LLK perf](https://github.com/tenstorrent/tt-metal/actions/runs/30075942332) | fail: `CLAMP_NEGATIVE` compile (untouched file) + flaky hangs | stale base (branch is 9 commits behind main); `CLAMP_NEGATIVE` is defined on current main where LLK perf passes: [run 30065741262](https://github.com/tenstorrent/tt-metal/actions/runs/30065741262). Rebase clears it. |
| [LLK PR Review (effort: max)](https://github.com/tenstorrent/tt-metal/actions/runs/30075943856) | fail: Tailscale runner infra (0 findings) | runner infra, not a test; advisory only, not a merge gate. Re-run [30085589453](https://github.com/tenstorrent/tt-metal/actions/runs/30085589453) also infra-failed. |
| [All Models Tier 1 and 2](https://github.com/tenstorrent/tt-metal/actions/runs/30075945473) | running (queued) | will update when it lands |
| [Nightly L2](https://github.com/tenstorrent/tt-metal/actions/runs/30075947394) | fail: tt-train / ccl / sdxl spread | main baseline -- also fails on main: [run 30073306888](https://github.com/tenstorrent/tt-metal/actions/runs/30073306888) |
| [PR Gate (auto)](https://github.com/tenstorrent/tt-metal/actions/runs/30075110133) | pass | - |

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nkc/remove-deprecated-block-variants)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nkc/remove-deprecated-block-variants)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nkc/remove-deprecated-block-variants)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nkc/remove-deprecated-block-variants)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=nkc/remove-deprecated-block-variants)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:nkc/remove-deprecated-block-variants)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nkc/remove-deprecated-block-variants)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nkc/remove-deprecated-block-variants)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nkc/remove-deprecated-block-variants)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nkc/remove-deprecated-block-variants)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nkc/remove-deprecated-block-variants)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nkc/remove-deprecated-block-variants)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nkc/remove-deprecated-block-variants)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nkc/remove-deprecated-block-variants)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nkc/remove-deprecated-block-variants)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nkc/remove-deprecated-block-variants)
