### PR TITLE
[upsample] Add missing read barrier before crediting the bilinear reader's CB

### DIFF
--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/kernels/dataflow/reader_bilinear_multi_core_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/kernels/dataflow/reader_bilinear_multi_core_sharded.cpp
@@ -405,6 +405,8 @@ void kernel_main() {
                 weight_bottom_right_bf16);
             scalar_dfb.push_back(1);
 
+            // Ensure the 4 neighbor reads have landed before crediting the CB to compute.
+            noc.async_read_barrier();
             tilize_reduce_dfb.push_back(4);
             block_offset += current_block_size_bytes;
         }


### PR DESCRIPTION
### Summary
Adds the missing `noc_async_read_barrier()` in the bilinear-upsample sharded reader, before it credits the `tilize_reduce` CB to the compute kernel.

`reader_bilinear_multi_core_sharded.cpp` issues 4 async neighbor reads into the CB and then calls `push_back(4)` with no read barrier in between. `noc.async_read` is an asynchronous NIU DMA — the RISC issues the descriptor and continues, and completion is only observable via the read-flushed counter that `async_read_barrier` waits on — so the CB credit can be posted before the reads have landed in L1. This one line restores the ordering and matches every sibling reader (`reader_upsample_nearest_float.cpp`, `reader_upsample_unary_stick_layout_interleaved_start_id.cpp`, and the `pool`/`conv` readers), which all do `reserve → async_read → async_read_barrier → push_back`.

### Why this code is unlikely to fail today
The 4 reads are **local L1→L1** (`self_ep` + `local_addr`), which the NIU completes near-instantly, so in practice the data lands before the compute unpacker (the earliest possible consumer) touches the CB. This was verified not to fail despite an exhaustive attempt to force it on Blackhole p100a:

- Natural run: `test_bilinear_multi_core` passes 25/25 across 7 sweeps (175 executions).
- A CB-tile poison sentinel (proven to fire — 5/5 fail when the real reads are skipped) is never observed with the reads present.
- Real different-address NoC congestion of up to ~262k extra reads/pixel — measured to add only ~1s over 15 iterations, confirming local reads are ~instant — does not open the window.
- Large-channel configs (up to 8192 channels / 32 blocks), congestion, and poison combined: clean.
- Back-to-back loop and trace capture/replay bursts: clean.
- The per-read size is hard-capped at `MAX_TILES_PER_REDUCTION` = 8 tiles (512 B) by the program factory, so an "unusually large read" config isn't even reachable.

Because the race cannot be forced on current hardware, there is **no failing regression test** to add — a test would pass with or without this change.

### Why add the synchronization anyway
The ordering the programming model requires is currently *absent*; it only holds by the incidental timing of local reads, not by contract. This is a correctness-by-construction / **template-safety** fix: this reader is a natural copy source, and as soon as derived code adds more async reads between the gather and the `push_back` — especially **high-latency DRAM reads**, whose responses can lag well behind the credit — the missing barrier stops being latent and the credit races ahead of unfinished reads, so compute consumes stale L1. Adding the barrier makes the reader correct regardless of what reads precede the credit.

### Testing
`test_bilinear_multi_core` passes 25/25 with the fix (regression-safe; no throughput-relevant change — the barrier waits on reads that already complete before this point today).

Closes #50980. Part of #50973.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amahmud/upsample-bilinear-read-barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amahmud/upsample-bilinear-read-barrier)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amahmud/upsample-bilinear-read-barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amahmud/upsample-bilinear-read-barrier)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=amahmud/upsample-bilinear-read-barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:amahmud/upsample-bilinear-read-barrier)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amahmud/upsample-bilinear-read-barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amahmud/upsample-bilinear-read-barrier)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amahmud/upsample-bilinear-read-barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amahmud/upsample-bilinear-read-barrier)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amahmud/upsample-bilinear-read-barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amahmud/upsample-bilinear-read-barrier)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amahmud/upsample-bilinear-read-barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amahmud/upsample-bilinear-read-barrier)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amahmud/upsample-bilinear-read-barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amahmud/upsample-bilinear-read-barrier)