### PR TITLE
[deepseek_v3_d_p] Fix stale MLA KV-cache callers after #50207 wrapper migration

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_cache.py
+++ b/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_cache.py
@@ -35,7 +35,7 @@ from models.demos.deepseek_v3_d_p.tt.mla.indexer import (
 )
 from models.demos.deepseek_v3_d_p.tt.mla.rope import RotarySetup
 from models.demos.deepseek_v3_d_p.utils.fast_cache_checker import init_checker, report_and_clear
-from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import init_kvpe_cache
+from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import MlaKvCacheFormat, init_kvpe_cache, init_mla_kv_cache
 from models.demos.deepseek_v3_d_p.utils.test_utils import WH_WORKER_L1_SIZE
 from tests.ttnn.utils_for_testing import comp_pcc
 
@@ -137,15 +137,14 @@ def _forward(mla, mesh_device, rope_tensors, kvpe_cache, index_kv_cache, hidden)
 def _new_kvpe(config, mesh_device, mesh_shape):
     # Sparse attention (sparse_sdpa) reads the KVPE cache natively: it must be uncompressed bf16 and
     # ROW_MAJOR (the sparse forward asserts this), not the init_kvpe_cache bf8/TILE default.
-    return init_kvpe_cache(
-        kvpe_cache_head_dim=config.kv_lora_rank + config.qk_rope_head_dim,
+    return init_mla_kv_cache(
+        cache_format=MlaKvCacheFormat.BF16_RM,
+        hf_config=config,
         mesh_device=mesh_device,
         seq_len=SEQ_LEN,
         mesh_shape=mesh_shape,
         sp_axis=SP_AXIS,
         num_kvpe_cache_layers=1,
-        dtype=ttnn.bfloat16,
-        layout=ttnn.ROW_MAJOR_LAYOUT,
     )
 
 

--- a/models/demos/deepseek_v3_d_p/tests/test_kv_cache_table.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_kv_cache_table.py
@@ -126,8 +126,9 @@ def test_kv_cache_table(
     kvpe_cache_head_dim = config.qk_rope_head_dim + config.kv_lora_rank  # 576
 
     num_kvpe_cache_layers = 1
-    tt_kvpe_cache = init_kvpe_cache(
-        kvpe_cache_head_dim=kvpe_cache_head_dim,
+    tt_kvpe_cache = init_mla_kv_cache(
+        cache_format=MlaKvCacheFormat.BFP8_TILE,
+        hf_config=config,
         mesh_device=mesh_device,
         seq_len=seq_len,
         mesh_shape=mesh_shape,
@@ -150,7 +151,7 @@ def test_kv_cache_table(
         mesh_shape=mesh_shape,
         seq_len=seq_len,
         sp_axis=sp_axis,
-        tt_kvpe_cache=tt_kvpe_cache,
+        tt_kvpe_cache=tt_kvpe_cache.storage,
         chunk_size_bytes=CHUNK_SIZE_BYTES,
     )
 
@@ -171,7 +172,7 @@ def test_kv_cache_table(
     )
 
     tt_kvpe_cache_torch = ttnn.to_torch(
-        tt_kvpe_cache,
+        tt_kvpe_cache.storage,
         mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(2, 1), mesh_shape=mesh_device.shape),
     ).to(torch.bfloat16)
 
@@ -262,8 +263,9 @@ def test_kimi_kv_cache_table(
     kvpe_cache_head_dim = config.qk_rope_head_dim + config.kv_lora_rank  # 576
 
     num_kvpe_cache_layers = 1
-    tt_kvpe_cache = init_kvpe_cache(
-        kvpe_cache_head_dim=kvpe_cache_head_dim,
+    tt_kvpe_cache = init_mla_kv_cache(
+        cache_format=MlaKvCacheFormat.BFP8_TILE,
+        hf_config=config,
         mesh_device=mesh_device,
         seq_len=seq_len,
         mesh_shape=mesh_shape,
@@ -286,7 +288,7 @@ def test_kimi_kv_cache_table(
         mesh_shape=mesh_shape,
         seq_len=seq_len,
         sp_axis=sp_axis,
-        tt_kvpe_cache=tt_kvpe_cache,
+        tt_kvpe_cache=tt_kvpe_cache.storage,
         chunk_size_bytes=CHUNK_SIZE_BYTES,
     )
 
@@ -307,7 +309,7 @@ def test_kimi_kv_cache_table(
     )
 
     tt_kvpe_cache_torch = ttnn.to_torch(
-        tt_kvpe_cache,
+        tt_kvpe_cache.storage,
         mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(2, 1), mesh_shape=mesh_device.shape),
     ).to(torch.bfloat16)
 
@@ -616,7 +618,7 @@ def test_glm_kv_cache_table(
         mesh_shape=mesh_shape,
         seq_len=seq_len,
         sp_axis=sp_axis,
-        tt_kvpe_cache=tt_kvpe_cache,
+        tt_kvpe_cache=tt_kvpe_cache.storage,
         chunk_size_bytes=KVPE_CHUNK_SIZE_BYTES,
         num_users=1,
         config_id=KVPE_CONFIG_ID,

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_block_chunked.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_block_chunked.py
@@ -505,7 +505,7 @@ def run_chunked_block_multiuser(
     block.forward(
         tt_h,
         indexed_rope,
-        tt_kvpe_cache.storage,
+        tt_kvpe_cache,
         cache_layer_idx=0,
         actual_start=0,
         actual_end=CHUNK,
@@ -1057,16 +1057,15 @@ def run_chunked_block_glm_indexer(
 
     rope_setup = RotarySetup(config, mesh_device, sp_axis=sp_axis, is_balanced=False)
     indexed_rope = rope_setup.get_rope_tensors_indexed(cache_seq_len_global=SEQ_CACHE, chunk_size_global=CHUNK)
-    tt_kvpe_cache = init_kvpe_cache(
-        kvpe_cache_head_dim=kvpe_dim,
+    tt_kvpe_cache = init_mla_kv_cache(
+        cache_format=MlaKvCacheFormat.BF16_RM,
+        hf_config=config,
         mesh_device=mesh_device,
         seq_len=SEQ_CACHE,
         mesh_shape=mesh_shape,
         sp_axis=sp_axis,
         num_kvpe_cache_layers=1,
         num_users=1,
-        dtype=ttnn.bfloat16,
-        layout=ttnn.ROW_MAJOR_LAYOUT,
     )
     tt_index_kv_cache = init_kvpe_cache(
         kvpe_cache_head_dim=idx_dim,
@@ -1125,7 +1124,7 @@ def run_chunked_block_glm_indexer(
     dev_idx = unrotate_cache_layer(
         gather_cache_tp0(tt_index_kv_cache, mesh_device)[full_indexer_rank(config, layer_idx)], p, total_len
     )
-    dev_kvpe = unrotate_cache_layer(gather_cache_tp0(tt_kvpe_cache, mesh_device)[0], p, total_len)
+    dev_kvpe = unrotate_cache_layer(gather_cache_tp0(tt_kvpe_cache.storage, mesh_device)[0], p, total_len)
     _, out_pcc = comp_pcc(ref_out, out_accum)
     idx_rope_pcc, idx_nope = cache_half_pccs(g_idx, dev_idx, idx_rope, pe_interleave=False)
     kv_nope, kv_pe = cache_half_pccs(g_post, dev_kvpe, kv_lora, pe_interleave=True)

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer.py
@@ -511,7 +511,7 @@ def run_model(
             torch.manual_seed(0)
             first_token_id, _, tt_intermediates = transformer(
                 tt_tokens,
-                tt_kvpe_cache.storage,
+                tt_kvpe_cache,
                 actual_isl=number_of_non_padded_tokens,
                 return_intermediates=True,
                 read_profiler=False,

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py
@@ -677,8 +677,8 @@ def run_chunked_transformer(
             config.kv_lora_rank,
             mesh_device,
             sp_axis,
-            kvpe_dtype_layout.get("dtype", ttnn.bfloat8_b),
-            kvpe_dtype_layout.get("layout", ttnn.TILE_LAYOUT),
+            cache_format.storage_dtype,
+            cache_format.storage_layout,
         )
         if tt_index_kv_cache is not None:
             _preload_indexer_k_prefix_from_trace(
@@ -1269,9 +1269,9 @@ def run_chunked_transformer_no_pcc(
     # (sparse_sdpa reads it natively; mla.forward asserts) — NOT the init_kvpe_cache bfloat8_b/TILE
     # default that dense ring_mla wants. Match the cache format to the path (dense variants keep the
     # default). Same distinction as run_chunked_transformer.
-    kvpe_dtype_layout = dict(dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT) if resolve_has_indexer(config) else {}
+    cache_format = MlaKvCacheFormat.BF16_RM if resolve_has_indexer(config) else MlaKvCacheFormat.BFP8_TILE
     tt_kvpe_cache = init_mla_kv_cache(
-        cache_format=MlaKvCacheFormat.BFP8_TILE,
+        cache_format=cache_format,
         hf_config=config,
         mesh_device=mesh_device,
         seq_len=SEQ_CACHE_NOPCC,
@@ -1279,7 +1279,6 @@ def run_chunked_transformer_no_pcc(
         sp_axis=sp_axis,
         num_kvpe_cache_layers=num_layers,
         num_users=1,
-        **kvpe_dtype_layout,
     )
 
     # Sparse (DSA) layers read a block-cyclic indexer key cache that is caller-owned and passed into
@@ -1316,8 +1315,8 @@ def run_chunked_transformer_no_pcc(
             config.kv_lora_rank,
             mesh_device,
             sp_axis,
-            kvpe_dtype_layout.get("dtype", ttnn.bfloat8_b),
-            kvpe_dtype_layout.get("layout", ttnn.TILE_LAYOUT),
+            cache_format.storage_dtype,
+            cache_format.storage_layout,
         )
         if tt_index_kv_cache is not None:
             _preload_indexer_k_prefix_from_trace(

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py
@@ -181,7 +181,7 @@ def _record_kv_cache_pcc(
     [:total_len] against the golden kv_post_transform trace ([nope | pe], the pe half re-based to the
     device Meta interleave via cache_half_pccs). Per-layer cache — slot == layer."""
     logger.info("Device KV cache vs golden kv_post_transform:")
-    cache_full = gather_cache_tp0(tt_kvpe_cache, mesh_device)  # [num_layers, seq_len_cache, kvpe]
+    cache_full = gather_cache_tp0(tt_kvpe_cache.storage, mesh_device)  # [num_layers, seq_len_cache, kvpe]
     p = blockcyclic_positions(sp, CHUNK, seq_len_cache)
     cache_min_pcc = {}
     for i in range(num_layers):


### PR DESCRIPTION
### What

#50207 changed `init_mla_kv_cache` to return an `MlaKvCache` wrapper (`.storage` / `.geometry` / `.format`) instead of a raw tensor. Wrapper-consuming APIs (block / transformer / mla `forward`, `run_mla_inference`, `kv_cache_to_host`) need the wrapper; bare `ttnn` ops and the chunk-address-table builders (which read `.shape` / `.buffer_address()`) need the raw `.storage` tensor. Every stale caller crashes with an `AttributeError` from the mismatch. This branch fixes all of them across the `deepseek_v3_d_p` tests.

**Note:** most of these tests are not in CI, so the misses were found by a full inspection sweep of every `init_mla_kv_cache` / `init_kvpe_cache` caller, not by red jobs.

### Commits

**1 — forward/preload/init callers (`6eede6ddd80`):**
- `test_prefill_transformer.py`: determinism forward passed `.storage`; `mla.forward` reads `.geometry`. Pass the wrapper.
- `test_prefill_transformer_chunked.py` `run_chunked_transformer`: trace-preload referenced removed `kvpe_dtype_layout` (NameError). Derive dtype/layout from `cache_format`.
- `test_prefill_transformer_chunked.py` `run_chunked_transformer_no_pcc`: passed `**kvpe_dtype_layout` into `init_mla_kv_cache` (TypeError) and hardcoded `BFP8_TILE` for GLM's indexer path. Use `BF16_RM if has_indexer else BFP8_TILE`.

**2 — end-of-run KV-cache PCC gather (`c606e5a8902`):**
- `_record_kv_cache_pcc` passed the wrapper straight into `gather_cache_tp0` → `ttnn.to_torch` → `AttributeError: 'MlaKvCache' object has no attribute 'dtype'`. Only surfaced after all 78 layers passed (~450s in). Unwrap to `.storage`.

**3 — full-sweep remainder (`37c2ff4321d`):**
- `test_prefill_block_chunked.py`: `run_chunked_block_multiuser` passed `.storage` to `block.forward` (→ wrapper); `run_chunked_block_glm_indexer` allocated KVPE via `init_kvpe_cache` (raw) and passed it to `block.forward` (→ `init_mla_kv_cache(BF16_RM)` + wrapper + `.storage` at the gather).
- `test_sparse_mla_cache.py` `_new_kvpe`: raw `init_kvpe_cache` fed to `mla.forward` → `init_mla_kv_cache(BF16_RM)`.
- `test_kv_cache_table.py`: DS + Kimi tests fed a raw cache to `run_mla_inference` (reads `.format`) → `init_mla_kv_cache(BFP8_TILE)` + `.storage` at the create-table/to_torch reads; GLM test passed the wrapper to `populate_kv_chunk_address_table_kimi` (needs raw) → `.storage`.

### Verification

All caller/consumer pairings verified against the `forward` / builder signatures; `BF16_RM` and `BFP8_TILE` confirmed to reproduce the exact storage dtype/layout/width the old `init_kvpe_cache` calls used. Commits 1–2 exercised by the Galaxy-Blaze Chunked GLM Accuracy pipeline; the commit-3 files are Blackhole-gated tests not in CI (inspection only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
