### PR TITLE
Revert #49473: restore Blackhole FP8_E4M3 tilize protocol

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_unary_datacopy_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_unary_datacopy_api.h
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include <cstdint>
 #include "llk_math_common_api.h"
 #include "llk_math_eltwise_unary_datacopy.h"
 
@@ -34,7 +33,7 @@ inline void llk_math_eltwise_unary_datacopy_block(
     std::uint32_t start_dst_index, std::uint32_t ntiles, std::uint32_t operand) {
     const std::uint32_t operand_id = get_operand_id(operand);
 
-    for (std::uint32_t dst_index = start_dst_index; dst_index < start_dst_index + ntiles; dst_index++) {
+    for (uint32_t dst_index = start_dst_index; dst_index < start_dst_index + ntiles; dst_index++) {
         LLK_ASSERT((dst_index < get_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE, DstTileShape::Tile32x32>()), "");
 
         _llk_math_eltwise_unary_datacopy_<type, DST_SYNC_MODE, is_fp32_dest_acc_en, src_b_bcast_type, unpack_to_dest>(
@@ -56,8 +55,12 @@ inline void llk_math_eltwise_unary_datacopy_init(const std::uint32_t operand) {
     const std::uint32_t num_faces = get_operand_num_faces(operand_id);
     const std::uint32_t dst_format = get_operand_dst_format(operand_id);
 
+    // For tilize operation, the init function needs to know the src format to determine the is_8bit_format to avoid the
+    // tilize workaround. 8bit datums in input format do not require the tilize workaround on blackhole.
+    const std::uint32_t src_format = get_operand_src_format(operand_id);
+    const bool is_input_8bit_format = IS_8BIT_FORMAT(src_format);
     _llk_math_eltwise_unary_datacopy_init_<type, is_fp32_dest_acc_en, src_b_bcast_type, is_int_fpu_en, pack_mode>(
-        num_faces, dst_format);
+        num_faces, dst_format, is_input_8bit_format);
 }
 
 template <BroadcastType src_b_bcast_type = BroadcastType::NONE, bool unpack_to_dest = false>

--- a/tt_metal/tt-llk/tests/helpers/include/llk_lib_math_wrappers.h
+++ b/tt_metal/tt-llk/tests/helpers/include/llk_lib_math_wrappers.h
@@ -32,7 +32,8 @@ template <
     BroadcastType src_b_bcast_type      = BroadcastType::NONE,
     bool is_int_fpu_en                  = false,
     [[maybe_unused]] PackMode pack_mode = PackMode::Default>
-inline void _llk_math_eltwise_unary_datacopy_init_wrapper_(const std::uint32_t num_faces = 4, const std::uint32_t dst_format = 255)
+inline void _llk_math_eltwise_unary_datacopy_init_wrapper_(
+    const std::uint32_t num_faces = 4, const std::uint32_t dst_format = 255, [[maybe_unused]] const bool skip_bh_tilize_workaround = false)
 {
     static_assert(
         pack_mode == PackMode::Default || pack_mode == PackMode::Untilize || pack_mode == PackMode::Tilize,
@@ -57,6 +58,11 @@ inline void _llk_math_reconfig_remap_wrapper_([[maybe_unused]] const bool remap_
 {
 }
 
+inline bool _llk_math_skip_bh_tilize_workaround_wrapper_([[maybe_unused]] const std::uint32_t unpack_src_format)
+{
+    return false;
+}
+
 template <std::uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false>
 inline void _llk_math_reduce_block_max_row_reinit_wrapper_(const ckernel::TensorShape& tensor_shape)
 {
@@ -71,12 +77,14 @@ template <
     BroadcastType src_b_bcast_type = BroadcastType::NONE,
     bool is_int_fpu_en             = false,
     PackMode pack_mode             = PackMode::Default>
-inline void _llk_math_eltwise_unary_datacopy_init_wrapper_(const std::uint32_t num_faces = 4, const std::uint32_t dst_format = 255)
+inline void _llk_math_eltwise_unary_datacopy_init_wrapper_(
+    const std::uint32_t num_faces = 4, const std::uint32_t dst_format = 255, const bool skip_bh_tilize_workaround = false)
 {
     static_assert(
         pack_mode == PackMode::Default || pack_mode == PackMode::Tilize,
         "Blackhole LLK tests: math datacopy init wrapper supports PackMode::Default or PackMode::Tilize");
-    _llk_math_eltwise_unary_datacopy_init_<type, is_fp32_dest_acc_en, src_b_bcast_type, is_int_fpu_en, pack_mode>(num_faces, dst_format);
+    _llk_math_eltwise_unary_datacopy_init_<type, is_fp32_dest_acc_en, src_b_bcast_type, is_int_fpu_en, pack_mode>(
+        num_faces, dst_format, skip_bh_tilize_workaround);
 }
 
 template <DataCopyType type, DstSync Dst, bool is_fp32_dest_acc_en, BroadcastType src_b_bcast_type = BroadcastType::NONE, bool unpack_to_dest = false>
@@ -95,6 +103,11 @@ inline void _llk_math_transpose_dest_wrapper_(const std::uint32_t dst_index)
 inline void _llk_math_reconfig_remap_wrapper_(const bool remap_enable)
 {
     _llk_math_reconfig_remap_(remap_enable);
+}
+
+inline bool _llk_math_skip_bh_tilize_workaround_wrapper_(const std::uint32_t unpack_src_format)
+{
+    return IS_8BIT_FORMAT(unpack_src_format);
 }
 
 template <[[maybe_unused]] std::uint32_t block_ct_dim, [[maybe_unused]] bool is_fp32_dest_acc_en = false>

--- a/tt_metal/tt-llk/tests/helpers/include/llk_lib_unpack_wrappers.h
+++ b/tt_metal/tt-llk/tests/helpers/include/llk_lib_unpack_wrappers.h
@@ -31,6 +31,12 @@ inline std::uint32_t _llk_unpack_tilize_block_ct_dim_wrapper_(const std::uint32_
     return block_ct_dim;
 }
 
+inline std::uint32_t _llk_unpack_tilize_num_faces_wrapper_(const std::uint32_t num_faces)
+{
+    // Wormhole uses num_faces to select the tilize loop count.
+    return num_faces;
+}
+
 inline std::uint32_t _llk_unpack_tilize_num_dvalids_wrapper_(const std::uint32_t tile_count, const std::uint32_t tile_num_faces)
 {
     // Wormhole tracks dvalids per tile face.
@@ -75,10 +81,15 @@ inline std::uint32_t _llk_unpack_tilize_block_ct_dim_wrapper_([[maybe_unused]] c
     return 0;
 }
 
+inline std::uint32_t _llk_unpack_tilize_num_faces_wrapper_([[maybe_unused]] const std::uint32_t num_faces)
+{
+    // Blackhole tests keep unpack_tilize on the default 4-face path.
+    return 4;
+}
+
 inline std::uint32_t _llk_unpack_tilize_num_dvalids_wrapper_(const std::uint32_t tile_count, [[maybe_unused]] const std::uint32_t tile_num_faces)
 {
-    // Blackhole unpack_tilize emits 1 DVALID per tile: 8-bit via inline path (SetDvalid on
-    // last face of active pair), non-8-bit via the whole-tile BH workaround.
+    // Blackhole tracks one dvalid per tile for unpack_tilize.
     return tile_count;
 }
 

--- a/tt_metal/tt-llk/tests/python_tests/perf_pack_untilize.py
+++ b/tt_metal/tt-llk/tests/python_tests/perf_pack_untilize.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-from helpers.chip_architecture import ChipArchitecture, get_chip_architecture
 from helpers.format_config import DataFormat
 from helpers.llk_params import (
     PerfRunType,
@@ -29,7 +28,6 @@ from helpers.test_variant_parameters import (
             DataFormat.Float32,
             DataFormat.Int32,
             DataFormat.Bfp8_b,
-            DataFormat.Fp8_e4m3,
         ]
     ),
     full_rt_dim=[1, 2, 3, 4, 5, 6, 7, 8],
@@ -41,14 +39,6 @@ def test_perf_pack_untilize(
     full_rt_dim,
     full_ct_dim,
 ):
-    if (
-        formats.input_format == DataFormat.Fp8_e4m3
-        or formats.output_format == DataFormat.Fp8_e4m3
-    ) and get_chip_architecture() != ChipArchitecture.BLACKHOLE:
-        pytest.skip(
-            "Pack Untilize does not support Fp8_e4m3 format on non-BLACKHOLE architectures"
-        )
-
     if formats.output_format == DataFormat.Bfp8_b:
         pytest.skip("Pack Untilize does not support Bfp8_b output")
 

--- a/tt_metal/tt-llk/tests/python_tests/perf_unpack_tilize.py
+++ b/tt_metal/tt-llk/tests/python_tests/perf_unpack_tilize.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-from helpers.chip_architecture import ChipArchitecture, get_chip_architecture
 from helpers.format_config import DataFormat
 from helpers.llk_params import PerfRunType
 from helpers.param_config import input_output_formats, parametrize
@@ -23,7 +22,6 @@ from helpers.test_variant_parameters import (
             DataFormat.Float16,
             DataFormat.Float32,
             DataFormat.Bfp8_b,
-            DataFormat.Fp8_e4m3,
         ]
     ),
     rt_dim=[1, 2, 3, 4, 5, 6, 7, 8],
@@ -35,14 +33,6 @@ def test_perf_unpack_tilize_float(
     rt_dim,
     ct_dim,
 ):
-    if (
-        formats.input_format == DataFormat.Fp8_e4m3
-        or formats.output_format == DataFormat.Fp8_e4m3
-    ) and get_chip_architecture() != ChipArchitecture.BLACKHOLE:
-        pytest.skip(
-            "Unpack Tilize does not support Fp8_e4m3 format on non-BLACKHOLE architectures"
-        )
-
     if formats.input_format == DataFormat.Bfp8_b:
         pytest.skip("Bfp8_b input not supported for unpack_tilize")
 

--- a/tt_metal/tt-llk/tests/python_tests/test_unpack_tilize_sweep.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_unpack_tilize_sweep.py
@@ -147,13 +147,6 @@ def test_unpack_tilize_comprehensive(
             "MOP_OUTER_LOOP=2 and PACK_INTF_SEL values that don't adapt to tiny tiles"
         )
 
-    # BH unpack_tilize does not support num_faces=1 (LLK asserts num_faces in {2, 4}).
-    # WH supports num_faces=1. Tracked in https://github.com/tenstorrent/tt-metal/issues/50707.
-    if arch == ChipArchitecture.BLACKHOLE and num_faces == 1:
-        pytest.skip(
-            "BH unpack_tilize does not support num_faces=1; see https://github.com/tenstorrent/tt-metal/issues/50707"
-        )
-
     is_narrow = narrow_tile == NarrowTile.Yes
     # Narrow tile: 2 vertical 16x16 faces (num_faces=2).
     tile_dimensions = [DEFAULT_TILE_R_DIM, FACE_C_DIM] if is_narrow else None

--- a/tt_metal/tt-llk/tests/python_tests/test_unpack_tilize_uninit_restore.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_unpack_tilize_uninit_restore.py
@@ -26,9 +26,7 @@ and the result diverges from ``TilizeGolden(src_A, num_faces)``.
 that no existing tilize test reaches.
 """
 
-import pytest
 import torch
-from helpers.chip_architecture import ChipArchitecture, get_chip_architecture
 from helpers.format_config import DataFormat
 from helpers.golden_generators import TilizeGolden, get_golden_generator
 from helpers.llk_params import DestAccumulation, format_dict
@@ -60,13 +58,6 @@ def test_unpack_tilize_uninit_restore(
     dest_acc,
     num_faces,
 ):
-    # BH unpack_tilize does not support num_faces=1 (LLK asserts num_faces in {2, 4}).
-    # WH supports num_faces=1. Tracked in https://github.com/tenstorrent/tt-metal/issues/50707.
-    if num_faces == 1 and get_chip_architecture() == ChipArchitecture.BLACKHOLE:
-        pytest.skip(
-            "BH unpack_tilize does not support num_faces=1; see https://github.com/tenstorrent/tt-metal/issues/50707"
-        )
-
     torch_format = format_dict[formats.output_format]
     input_dimensions = [32, 32]
 

--- a/tt_metal/tt-llk/tests/sources/tilize_polluter_matmul_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/tilize_polluter_matmul_test.cpp
@@ -61,7 +61,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     // ---- Run 0: tilize "polluter" (output discarded) ----
     int run                              = 0;
     const std::uint32_t pol_block_ct_dim = _llk_unpack_tilize_block_ct_dim_wrapper_(1);
-    const std::uint32_t pol_tilize_nf    = pol_num_faces;
+    const std::uint32_t pol_tilize_nf    = _llk_unpack_tilize_num_faces_wrapper_(pol_num_faces);
 
     _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
         formats_array[run].unpack_A_src,

--- a/tt_metal/tt-llk/tests/sources/tilize_polluter_tiny_matmul_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/tilize_polluter_tiny_matmul_test.cpp
@@ -56,7 +56,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     // ---- Run 0: regular tilize "polluter" (output discarded to scratch) ----
     int run                              = 0;
     const std::uint32_t pol_block_ct_dim = _llk_unpack_tilize_block_ct_dim_wrapper_(1);
-    const std::uint32_t pol_tilize_nf    = POLLUTER_NUM_FACES;
+    const std::uint32_t pol_tilize_nf    = _llk_unpack_tilize_num_faces_wrapper_(POLLUTER_NUM_FACES);
 
     _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
         formats_array[run].unpack_A_src,

--- a/tt_metal/tt-llk/tests/sources/tilize_transition_reconfig_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/tilize_transition_reconfig_test.cpp
@@ -73,7 +73,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     // ---- Run 0: real tilize "polluter" (output discarded) ----
     const std::uint32_t g0_block_ct  = _llk_unpack_tilize_block_ct_dim_wrapper_(1);
-    const std::uint32_t g0_tilize_nf = g0_num_faces;
+    const std::uint32_t g0_tilize_nf = _llk_unpack_tilize_num_faces_wrapper_(g0_num_faces);
 
     _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
         formats_array[0].unpack_A_src,

--- a/tt_metal/tt-llk/tests/sources/unpack_tilize_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/unpack_tilize_perf.cpp
@@ -95,6 +95,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
 #endif
 
+static constexpr bool TILIZE = true;
+
 #ifdef LLK_TRISC_MATH
 
 #include "llk_lib_math_wrappers.h"
@@ -116,8 +118,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     {
         START_PERF_MEASURE("INIT")
-        _llk_math_hw_configure_<is_fp32_dest_acc_en>(formats.math, formats.math);
-        const bool TILIZE = true;
         // copy srca to dest
         _llk_math_eltwise_unary_datacopy_init_wrapper_<
             DataCopyType::A2D,
@@ -126,6 +126,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
             is_int_fpu_en,
             llk_test_pack_mode_v<false, TILIZE>>(4 /* num_faces */, formats.math);
         _llk_math_pack_sync_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+        _llk_math_hw_configure_<is_fp32_dest_acc_en>(formats.math, formats.math);
         PROFILER_SYNC();
     }
 
@@ -211,29 +212,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     {
         START_PERF_MEASURE("INIT")
-        const bool skip_bh_tilize_workaround = _llk_pack_skip_bh_tilize_workaround_wrapper_(formats.unpack_A_src);
-        const bool TILIZE                    = true;
-        _llk_pack_hw_configure_wrapper_<is_fp32_dest_acc_en, llk_unpack_tilize_sweep_pack_cfg_mode_v<UNTILIZE, false>>(
-            formats.pack_src,
-            formats.pack_dst,
-            16 * 16 * 4 /* tile_size */,
-            FACE_R_DIM,
-            TILE_C_DIM,
-            4 /* num_faces */,
-            false /* partial_face */,
-            false /* narrow_tile */,
-            0 /* relu_config */);
-        _llk_pack_init_with_src_wrapper_<llk_unpack_tilize_sweep_pack_cfg_mode_v<UNTILIZE, TILIZE>, false /* zero_output */>(
-            formats.pack_src,
-            formats.pack_dst,
-            FACE_R_DIM,
-            TILE_C_DIM,
-            4 /* num_faces */,
-            false /* partial_face */,
-            false /* narrow_tile */,
-            1 /* num_tiles */,
-            skip_bh_tilize_workaround);
-        _llk_pack_dest_init_wrapper_<DstSync::SyncHalf, is_fp32_dest_acc_en, llk_test_pack_mode_v<UNTILIZE, false>>();
+
+        _llk_pack_hw_configure_wrapper_<is_fp32_dest_acc_en, llk_unpack_tilize_sweep_pack_cfg_mode_v<UNTILIZE, TILIZE>>(
+            formats.pack_src, formats.pack_dst, 16 * 16 * 4 /* tile_size */);
+        _llk_pack_init_wrapper_<llk_unpack_tilize_sweep_pack_cfg_mode_v<UNTILIZE, TILIZE>, false /* zero_output */>(formats.pack_dst);
+        _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
         PROFILER_SYNC();
     }
     {

--- a/tt_metal/tt-llk/tests/sources/unpack_tilize_sweep_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/unpack_tilize_sweep_test.cpp
@@ -30,7 +30,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         formats.unpack_A_src, formats.unpack_B_src, formats.unpack_A_dst, formats.unpack_B_dst, FACE_R_DIM, FACE_R_DIM, params.num_faces, params.num_faces);
     _llk_unpack_configure_stoch_rnd_<STOCHASTIC_RND>();
 
-    const std::uint32_t num_faces = params.num_faces;
+    const std::uint32_t num_faces = _llk_unpack_tilize_num_faces_wrapper_(params.num_faces);
 
     // Initialize tilize unpacker
     _llk_unpack_tilize_init_wrapper_(formats.unpack_A_src, formats.unpack_A_dst, params.BLOCK_CT_DIM, FACE_R_DIM, params.NARROW_TILE, num_faces);

--- a/tt_metal/tt-llk/tests/sources/unpack_tilize_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/unpack_tilize_test.cpp
@@ -29,7 +29,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const std::uint32_t num_faces = params.num_faces;
     _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
         formats.unpack_A_src, formats.unpack_B_src, formats.unpack_A_dst, formats.unpack_B_dst, FACE_R_DIM, FACE_R_DIM, num_faces, num_faces);
-    _llk_unpack_tilize_init_wrapper_(formats.unpack_A_src, formats.unpack_A_dst, params.BLOCK_CT_DIM, FACE_R_DIM, false /* narrow_tile */, num_faces);
+    _llk_unpack_tilize_init_wrapper_(formats.unpack_A_src, formats.unpack_A_dst, params.BLOCK_CT_DIM, FACE_R_DIM, false /* narrow_tile */);
 
     std::uint32_t read_offset = 0;
 
@@ -71,14 +71,15 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const bool is_int_fpu_en      = false;
 
     _llk_math_hw_configure_<is_fp32_dest_acc_en>(formats.math, formats.math);
-    // copy srca to dest
-    const bool TILIZE = true;
+// copy srca to dest
+    const bool is_8bit_format = _llk_math_skip_bh_tilize_workaround_wrapper_(formats.unpack_A_src);
+    const bool TILIZE         = true;
     _llk_math_eltwise_unary_datacopy_init_wrapper_<
         DataCopyType::A2D,
         is_fp32_dest_acc_en,
         BroadcastType::NONE,
         is_int_fpu_en,
-        llk_test_pack_mode_v<false, TILIZE>>(num_faces, formats.math);
+        llk_test_pack_mode_v<false, TILIZE>>(num_faces, formats.math, is_8bit_format /* skip_bh_tilize_workaround */);
     _llk_math_pack_sync_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
 
     const std::uint32_t tiles_in_block = params.NUM_TILES_IN_BLOCK;
@@ -112,11 +113,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
-    const std::uint32_t num_faces  = params.num_faces;
+    const std::uint32_t num_faces = params.num_faces;
     static constexpr bool UNTILIZE = false;
 
     static constexpr bool TILIZE = true;
-    const bool is_8bit_format    = _llk_pack_skip_bh_tilize_workaround_wrapper_(formats.unpack_A_src);
+    const bool is_8bit_format = _llk_pack_skip_bh_tilize_workaround_wrapper_(formats.unpack_A_src);
     _llk_pack_hw_configure_wrapper_<is_fp32_dest_acc_en, llk_test_pack_mode_v<UNTILIZE, false>>(
         formats.pack_src, formats.pack_dst, 16 * 16 * 4 /* tile_size */, FACE_R_DIM, TILE_C_DIM, num_faces);
     _llk_pack_init_with_src_wrapper_<llk_unpack_tilize_sweep_pack_cfg_mode_v<UNTILIZE, TILIZE>, false /* zero_output */>(

--- a/tt_metal/tt-llk/tests/sources/unpack_tilize_uninit_restore_block_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/unpack_tilize_uninit_restore_block_test.cpp
@@ -73,7 +73,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         num_faces,
         num_faces);
 
-    const std::uint32_t tilize_num_faces = num_faces;
+    const std::uint32_t tilize_num_faces = _llk_unpack_tilize_num_faces_wrapper_(num_faces);
     const std::uint32_t block_ct_dim     = _llk_unpack_tilize_block_ct_dim_wrapper_(params.BLOCK_CT_DIM);
 
     _llk_unpack_tilize_init_wrapper_(

--- a/tt_metal/tt-llk/tests/sources/unpack_tilize_uninit_restore_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/unpack_tilize_uninit_restore_test.cpp
@@ -77,7 +77,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         num_faces,
         num_faces);
 
-    const std::uint32_t tilize_num_faces = num_faces;
+    const std::uint32_t tilize_num_faces = _llk_unpack_tilize_num_faces_wrapper_(num_faces);
     const std::uint32_t block_ct_dim     = _llk_unpack_tilize_block_ct_dim_wrapper_(1);
 
     _llk_unpack_tilize_init_wrapper_(

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_eltwise_unary_datacopy.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_eltwise_unary_datacopy.h
@@ -539,6 +539,7 @@ inline void eltwise_unary_configure_mop(std::uint32_t rows_per_inst, std::uint32
  * @tparam pack_mode: Packing layout, values = <Default/Tilize>
  * @param num_faces: Number of faces in the tile (must be 1, 2, or 4).
  * @param dst_format: Destination data format (DataFormat enum underlying value); 255 means unset.
+ * @param skip_bh_tilize_workaround: Skip the Blackhole tilize workaround (set when unpacking 8-bit datums).
  * @note On the unpack thread, pair with @ref _llk_unpack_A_init_ (copy/transpose), @ref _llk_unpack_tilize_init_ (tilize) or @ref _llk_unpack_untilize_init_
  * (untilize) which feed the tile.
  * @note @ref _llk_math_eltwise_unary_datacopy_ runs the configured op with matching template args.
@@ -549,7 +550,8 @@ template <
     BroadcastType src_b_bcast_type = BroadcastType::NONE,
     bool is_int_fpu_en             = false,
     PackMode pack_mode             = PackMode::Default>
-inline void _llk_math_eltwise_unary_datacopy_init_(const std::uint32_t num_faces = 4, const std::uint32_t dst_format = 255)
+inline void _llk_math_eltwise_unary_datacopy_init_(
+    const std::uint32_t num_faces = 4, const std::uint32_t dst_format = 255, const bool skip_bh_tilize_workaround = false)
 {
     static_assert(
         pack_mode == PackMode::Default || pack_mode == PackMode::Tilize,
@@ -570,10 +572,18 @@ inline void _llk_math_eltwise_unary_datacopy_init_(const std::uint32_t num_faces
 
     if constexpr (type == DataCopyType::A2D && src_b_bcast_type == BroadcastType::NONE)
     {
-        // Tilize: math MOP iterates over all faces of the tile (num_faces * 16 rows).
-        // Non-tilize: single 16-row face pair (MOV_8_ROWS runs twice under the hood).
-        eltwise_unary_configure_mop<type, is_fp32_dest_acc_en, src_b_bcast_type, tilize, is_int_fpu_en>(
-            p_mova2d::MOV_8_ROWS, tilize ? (num_faces * 16) : 16, num_faces, dst_format);
+        const std::uint32_t num_rows = (tilize && !skip_bh_tilize_workaround) ? 64 : 16;
+
+        if (skip_bh_tilize_workaround)
+        {
+            eltwise_unary_configure_mop<type, is_fp32_dest_acc_en, src_b_bcast_type, false /* tilize */, is_int_fpu_en>(
+                p_mova2d::MOV_8_ROWS, 16, num_faces, dst_format);
+        }
+        else
+        {
+            eltwise_unary_configure_mop<type, is_fp32_dest_acc_en, src_b_bcast_type, tilize, is_int_fpu_en>(
+                p_mova2d::MOV_8_ROWS, num_rows, num_faces, dst_format);
+        }
     }
     else if constexpr (type == DataCopyType::B2D)
     {

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_tilize.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_tilize.h
@@ -20,31 +20,48 @@ using namespace ckernel;
 using namespace ckernel::unpacker;
 
 /**
- * @brief Program the unpacker MOP for the non-8-bit tilize path (Blackhole whole-tile workaround).
+ * @brief Program the unpacker MOP for a tilize operation.
  *
- * Selects between unpacking to SrcA (with a SrcB dvalid NOP) or straight to dest. 8-bit formats
- * use the inline 2-context path in @ref _llk_unpack_tilize_ instead (no MOP).
+ * Selects between unpacking to SrcA (with a SrcB dvalid NOP) or straight to dest, and applies the
+ * Blackhole tilize workaround unless skipped (8-bit formats fall back to the Wormhole path).
  *
+ * @param narrow_tile: Whether the tile is narrow (single column of faces).
  * @param unpack_to_dest: Unpack directly into the dest register (32-bit datums).
+ * @param skip_bh_workaround: Skip the Blackhole tilize workaround (e.g. for 8-bit formats).
  */
-inline void _llk_unpack_tilize_mop_config_(const bool unpack_to_dest = false)
+inline void _llk_unpack_tilize_mop_config_(const bool narrow_tile = false, const bool unpack_to_dest = false, const bool skip_bh_workaround = false)
 {
-    // SrcB SET_DVALID + UNP_ZEROSRC: math's ELWADD branch (FP32 dest-accumulate) reads SrcB,
-    // so it must be both dvalid and zeroed. MOVA2D branch ignores it (harmless handshake).
     static constexpr std::uint32_t unpack_srca =
         TT_OP_UNPACR(SrcA, 0b1 /*Z inc*/, 0, 0, 0, 1 /* Set OvrdThreadId*/, 1 /*Set Dvalid*/, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
     static constexpr std::uint32_t unpack_srca_to_dest =
         TT_OP_UNPACR(0, 0b00010001 /*Z inc*/, 0, 0, 0, 1 /* Set OvrdThreadId*/, 0, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
     static constexpr std::uint32_t unpack_srcb_set_dvalid = TT_OP_UNPACR_NOP(SrcB, 0, 0, p_unpacr_nop::SET_DVALID, 0, 0, 0, 0, p_unpacr_nop::UNP_ZEROSRC);
 
-    ckernel_template tmp(1 /*outerloop*/, 1 /*innerloop*/, unpack_to_dest ? unpack_srca_to_dest : unpack_srcb_set_dvalid);
+    const std::uint32_t outerloop = (!skip_bh_workaround || (skip_bh_workaround && narrow_tile)) ? 1 : 2;
+    const std::uint32_t innerloop = 1;
 
-    if (!unpack_to_dest)
+    // ckernel_template is non-assignable, so build and program each variant in its own scope.
+    // skip_bh_workaround (8-bit formats) uses the two-op body (zerosrc + set_dvalid), mirroring Wormhole;
+    // otherwise the single-op BH workaround body is used. Both prepend unpack_srca unless unpacking to dest.
+    if (skip_bh_workaround)
     {
-        tmp.set_start_op(unpack_srca);
+        static constexpr std::uint32_t unpack_srcb_zerosrc = TT_OP_UNPACR_NOP(SrcB, 0, 0, 0, 0, 0, 0, 0, p_unpacr_nop::UNP_ZEROSRC);
+        ckernel_template tmp(outerloop, innerloop, unpack_srcb_zerosrc, unpack_srcb_set_dvalid);
+        if (!unpack_to_dest)
+        {
+            tmp.set_start_op(unpack_srca);
+        }
+        tmp.program();
     }
-
-    tmp.program();
+    else
+    {
+        ckernel_template tmp(outerloop, innerloop, unpack_to_dest ? unpack_srca_to_dest : unpack_srcb_set_dvalid);
+        if (!unpack_to_dest)
+        {
+            tmp.set_start_op(unpack_srca);
+        }
+        tmp.program();
+    }
 }
 
 /**
@@ -52,18 +69,13 @@ inline void _llk_unpack_tilize_mop_config_(const bool unpack_to_dest = false)
  *
  * Disables face transpose, configures the unpacker into tileize mode (throttle, shift amount,
  * per-tile X/Z dims) for the given block column dimension, decides whether 32-bit datums must be
- * unpacked to dest, and:
- *   - 8-bit formats: programs the 1x16 face x_dim per context and (for num_faces==4) the
- *     SCRATCH_SEC0_val preload used by the inline CFGSHIFTMASK. No MOP is programmed —
- *     the UNPACR sequence is issued inline by @ref _llk_unpack_tilize_.
- *   - non-8-bit formats: programs the whole-tile x_dim/z_dim descriptor state and the
- *     MOP template via @ref _llk_unpack_tilize_mop_config_ (Blackhole workaround).
+ * unpacked to dest, and programs the tilize MOP.
  *
  * @param unpack_src_format: Source data format of the operand in L1.
  * @param unpack_dst_format: Destination data format the operand is converted to.
  * @param ct_dim: Number of column tiles in the block, used to size the column dimension.
  * @param face_r_dim: Rows per face, valid values = <2, 4, 8, 16>.
- * @param narrow_tile: Whether the tile is narrow (single column of faces). Not supported on the 8-bit path (asserted false).
+ * @param narrow_tile: Whether the tile is narrow (single column of faces).
  * @param num_faces: Number of faces in the tile, valid values = <2, 4>.
  * @note Call @ref _llk_unpack_tilize_uninit_ to restore the modified tile-descriptor state.
  * @ref _llk_unpack_tilize_ is the matching execute call.
@@ -98,46 +110,27 @@ inline void _llk_unpack_tilize_init_(
     // Set face dim
     TT_SETADCXX(p_setadc::UNP_A, face_r_dim * FACE_C_DIM - 1, 0x0);
 
-    const bool is_8bit_format        = IS_8BIT_FORMAT(unpack_src_format);
-    const std::uint32_t shift_amount = (SCALE_DATUM_SIZE(unpack_src_format, block_c_dim)) >> 4;
-
     // Override default settings to enable tilize mode
     unpack_config_u config   = {0};
     config.f.out_data_format = unpack_dst_format;
     config.f.throttle_mode   = 2;
     config.f.tileize_mode    = 1;
-    config.f.shift_amount    = shift_amount;
+    config.f.shift_amount    = (SCALE_DATUM_SIZE(unpack_src_format, block_c_dim)) >> 4;
 
     TT_SETDMAREG(0, LOWER_HALFWORD(config.val[0]), 0, LO_16(p_gpr_unpack::TMP0));
     TT_SETDMAREG(0, UPPER_HALFWORD(config.val[0]), 0, HI_16(p_gpr_unpack::TMP0));
     TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::THCON);
     TTI_WRCFG(p_gpr_unpack::TMP0, p_cfg::WRCFG_32b, THCON_SEC0_REG2_Out_data_format_ADDR32);
+
+    const bool is_8bit_format = IS_8BIT_FORMAT(unpack_src_format);
+    // 8bit datums do not need the blackhole workaround therefore we fallback to regular tilize operation like for wormhole.
     if (is_8bit_format)
     {
-        LLK_ASSERT(!narrow_tile, "8-bit tilize narrow_tile not supported");
-        LLK_ASSERT(!unpack_to_dest, "8-bit tilize unpack_to_dest not supported");
-
-        // x_dim per context = FACE_C_DIM (1x16 face read). FACE_DIM_1x16 holds
-        // FACE_C_DIM packed in both halfwords, so a 32b WRCFG programs both cntx0 and cntx1.
-        TTI_WRCFG(p_gpr_unpack::FACE_DIM_1x16, p_cfg::WRCFG_32b, THCON_SEC0_REG5_Tile_x_dim_cntx0_ADDR32);
-
-        // SCRATCH_SEC0_val is the increment CFGSHIFTMASK adds to Base_address between
-        // top and bottom face pairs. Only used when num_faces==4 (top pair to bottom pair).
-        // For num_faces==2 (top pair only) no CFGSHIFTMASK fires, so the preload is skipped.
-        //   bot_face_offset = shift_amount * face_r_dim       (in 16B words, jump from top to bottom faces)
-        //   -2 compensates for Z=2 L1 offset (Z * XDim * DatumSize = 2 * 16 * 1 = 32 bytes = 2 16B-words)
-        if (num_faces == 4)
-        {
-            const std::uint32_t base_address_increment = shift_amount * face_r_dim - 2;
-            TT_SETDMAREG(0, LOWER_HALFWORD(base_address_increment), 0, LO_16(p_gpr_unpack::TMP0));
-            TT_SETDMAREG(0, UPPER_HALFWORD(base_address_increment), 0, HI_16(p_gpr_unpack::TMP0));
-            TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::THCON);
-            TTI_WRCFG(p_gpr_unpack::TMP0, p_cfg::WRCFG_32b, SCRATCH_SEC0_val_ADDR32);
-        }
+        TTI_WRCFG(p_gpr_unpack::FACE_DIM_1x16, 0, THCON_SEC0_REG5_Tile_x_dim_cntx0_ADDR32);
     }
     else
     {
-        // Whole-tile unpacking (non-8-bit BH workaround): x_dim covers the entire tile, z_dim=1
+        // below is the configuration for unpack for srca
         const std::uint32_t Tile_x_dim = face_r_dim * num_faces * FACE_C_DIM;
         const std::uint32_t Tile_z_dim = 1;
         cfg_reg_rmw_tensix<THCON_SEC0_REG5_Tile_x_dim_cntx0_ADDR32, 0, 0xffffffff>(Tile_x_dim | (Tile_x_dim << 16));
@@ -148,21 +141,17 @@ inline void _llk_unpack_tilize_init_(
 
         // Set x-end for Unpackers to (face_r_dim * num_faces * FACE_C_DIM - 1)
         TT_SETADCXX(p_setadc::UNP0, Tile_x_dim - 1, 0x0);
-
-        _llk_unpack_tilize_mop_config_(unpack_to_dest);
     }
+
+    _llk_unpack_tilize_mop_config_(narrow_tile, unpack_to_dest, is_8bit_format);
 }
 
 /**
  * @brief Unpack and tilize a tile from L1 into SrcA or the dest register.
  *
- * Computes the L1 base address for the selected column tile and unpacks it into SrcA.
- *   - 8-bit formats: issues an inline 2-context UNPACR sequence (2 UNPACRs for num_faces=2, or
- *     4 UNPACRs + CFGSHIFTMASK for num_faces=4) plus a SrcB SET_DVALID + UNP_ZEROSRC handshake.
- *     Emits 1 DVALID per tile. No MOP; `face_r_dim` is not consumed by the sequence itself
- *     (already programmed via init's SCRATCH_SEC0_val preload) but drives the init-time preload.
- *   - non-8-bit formats: runs the whole-tile MOP programmed at init, and — when unpacking
- *     32-bit datums to dest — manages the dest write address and completion handshake.
+ * Computes per-face L1 addresses for the selected column tile and runs the tilize MOP. For 8-bit
+ * formats it loops over face groups using the Wormhole-style path; otherwise it runs a single pass
+ * and, when unpacking 32-bit datums, manages the dest write address and completion handshake.
  *
  * @param base_address: L1 base address of the source tile buffer.
  * @param tile_index: Column tile index selecting which tile to unpack.
@@ -170,18 +159,18 @@ inline void _llk_unpack_tilize_init_(
  * @param unpack_dst_format: Destination data format the operand is converted to.
  * @param face_r_dim: Rows per face.
  * @param num_faces: Number of faces in the tile, valid values = <2, 4>.
- * @param narrow_tile: Whether the tile is narrow (single column of faces). Not supported on the 8-bit path.
+ * @param narrow_tile: Whether the tile is narrow (single column of faces).
  * @note Call @ref _llk_unpack_tilize_init_ before this function, and
  *       @ref _llk_unpack_tilize_uninit_ after it to restore modified state.
  */
 inline void _llk_unpack_tilize_(
     const std::uint32_t base_address,
     const std::uint32_t tile_index,
-    std::uint32_t unpack_src_format                 = 0,
-    std::uint32_t unpack_dst_format                 = 0,
-    [[maybe_unused]] const std::uint32_t face_r_dim = FACE_R_DIM,
-    const std::uint32_t num_faces                   = 4,
-    const bool narrow_tile                          = false)
+    std::uint32_t unpack_src_format = 0,
+    std::uint32_t unpack_dst_format = 0,
+    const std::uint32_t face_r_dim  = FACE_R_DIM,
+    const std::uint32_t num_faces   = 4,
+    const bool narrow_tile          = false)
 {
     LLK_ASSERT(num_faces == 2 || num_faces == 4, "num_faces must be 2 or 4 for tilize");
 
@@ -197,96 +186,58 @@ inline void _llk_unpack_tilize_(
 
     std::uint32_t top_face_offset_address = SCALE_DATUM_SIZE(unpack_src_format, tile_index) << (narrow_tile ? 0 : 1);
 
-    // 8-bit path: 2-context inline UNPACR sequence. AddrMode=0b00010001 advances BOTH
-    // Ch0.Z (L1 input read) and Ch1.Z (SrcA output write) so face N lands in SrcA rows
-    // 16*N..16*N+15 via the Zstride configured by configure_unpack_AB. This relies on
-    // SRCA_SET_SetOvrdWithAddr = 1 (letting OutAddr drive the SrcA row directly, without
-    // SrcRow being added). Contract: the bit is set to 1 by configure_unpack_AB at unpack
-    // init and is the resting state. It is transiently cleared to 0 only by
-    // set_dst_write_addr with a paired restore in unpack_to_dest_tile_done. Because this
-    // path asserts !unpack_to_dest at init, we can never be inside that transient window
-    // on entry -- the bit is guaranteed to be 1. NOTE: future FP8 unpack_to_dest support
-    // would enter with the bit cleared and must either restore it explicitly or use a
-    // different addressing scheme.
-    // The active context selects between REG3_Base_address (cntx0) and REG3_Base_cntx1
-    // _address for both the base-address cfg write and the CFGSHIFTMASK target.
-    //   num_faces==4: 4 UNPACRs (face 3 with SetDvalid) + CFGSHIFTMASK between top and
-    //                 bottom face pairs (Ch1.Z keeps advancing across the CFGSHIFTMASK
-    //                 since it touches REG3 only).
-    //   num_faces==2: 2 UNPACRs (top pair only, face 1 with SetDvalid). No CFGSHIFTMASK.
+    // 8bit datums do not need the blackhole workaround therefore we fallback to regular tilize operation like for wormhole.
     if (IS_8BIT_FORMAT(unpack_src_format))
     {
-        const std::uint32_t address = base_address + top_face_offset_address;
-        LLK_ASSERT(is_valid_L1_address(address), "L1 base_address must be in valid L1 memory region");
+        // Each iteration unpacks 2 face_r_dimx16 faces (1st 0,1 2nd 2,3 unless tile is <=16x32)
+        // For narrow tile we unpack 1 face in each iteration
+        // Offset address is in 16B words
+        // Datum count = tile_index*face_r_dim (/16 to get word count)
 
-        // Clear Z/W counters on UNP_A for both channels (Ch0 for L1 read, Ch1 for SrcA write)
-        TTI_SETADCZW(0b001, 0, 0, 0, 0, 0b1111);
+        const auto config_vec                 = read_unpack_config();
+        const std::uint32_t shift_amount      = config_vec[0].shift_amount;
+        std::uint32_t bot_face_offset_address = shift_amount * face_r_dim; // bytes for bottom faces
 
-        // Wait for a free context (up to 2 tiles in flight)
-        wait_for_next_context(2);
+        // Program srcA and srcB base addresses
+        std::uint32_t num_loops = narrow_tile ? 2 : num_faces / 2;
 
-        // Write top-face base address to the active context's REG3
-        if (0 == unp_cfg_context)
+        volatile std::uint32_t tt_reg_ptr* cfg = get_cfg_pointer(); // get pointer to registers for current state ID
+
+        for (std::uint32_t n = 0; n < num_loops; n++)
         {
-            cfg[THCON_SEC0_REG3_Base_address_ADDR32] = address;
+            std::uint32_t address = base_address + top_face_offset_address + ((n == 1) ? bot_face_offset_address : 0);
+
+            // Clear z/w start counters
+            TTI_SETADCZW(0b001, 0, 0, 0, 0, 0b1111);
+
+            // Wait for free context
+            wait_for_next_context(2);
+
+            // Validate and configure address
+            _llk_unpack_configure_single_address_(address, cfg);
+
+            // Trisc::SEMPOST for context acquire
+            semaphore_post(semaphore::UNPACK_SYNC);
+
+            // Stall unpacker until pending CFG writes from Trisc have completed
+            TTI_STALLWAIT(p_stall::STALL_UNPACK, p_stall::TRISC_CFG);
+
+            // Run MOP
+            ckernel::ckernel_template::run();
+
+            // T6::SEMGET for context release
+            t6_semaphore_get(semaphore::UNPACK_SYNC);
+
+            // Switch unpacker config context
+            switch_config_context(unp_cfg_context);
         }
-        else
-        {
-            cfg[THCON_SEC0_REG3_Base_cntx1_address_ADDR32] = address;
-        }
-        semaphore_post(semaphore::UNPACK_SYNC);
-
-        // Stall unpacker until pending CFG writes from Trisc have completed
-        TTI_STALLWAIT(p_stall::STALL_UNPACK, p_stall::TRISC_CFG);
-
-        if (num_faces == 4)
-        {
-            // Face 0: Ch0.Z=0, Ch1.Z=0 -> SrcA rows 0..15
-            TTI_UNPACR(SrcA, 0b00010001 /*Ch0.Z+=1, Ch1.Z+=1*/, 0, 0, 0, 1, 0 /*no Dvalid*/, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
-            // Face 1: Ch0.Z=1, Ch1.Z=1 -> SrcA rows 16..31
-            TTI_UNPACR(SrcA, 0b00010001 /*Ch0.Z+=1, Ch1.Z+=1*/, 0, 0, 0, 1, 0 /*no Dvalid*/, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
-
-            // Shift the active context's Base_address by SCRATCH_SEC0_val (= bot_face_offset - 2
-            // in 16B words) so face 2/3 read correctly at Z=2/3 on the L1 side. CFGSHIFTMASK's
-            // target is an instruction immediate, so we pick the variant at compile time per context.
-            if (0 == unp_cfg_context)
-            {
-                TTI_CFGSHIFTMASK(1, 0b011, 32 - 1, 0, 0b11, THCON_SEC0_REG3_Base_address_ADDR32);
-            }
-            else
-            {
-                TTI_CFGSHIFTMASK(1, 0b011, 32 - 1, 0, 0b11, THCON_SEC0_REG3_Base_cntx1_address_ADDR32);
-            }
-            TTI_NOP;
-
-            // Face 2: Ch0.Z=2, Ch1.Z=2 -> SrcA rows 32..47
-            TTI_UNPACR(SrcA, 0b00010001 /*Ch0.Z+=1, Ch1.Z+=1*/, 0, 0, 0, 1, 0 /*no Dvalid*/, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
-            // Face 3: Ch0.Z=3, Ch1.Z=3 -> SrcA rows 48..63. SetDvalid flips the SrcA bank,
-            // handing the full 64-row tile to math.
-            TTI_UNPACR(SrcA, 0b00010001 /*Ch0.Z+=1, Ch1.Z+=1*/, 0, 0, 0, 1, 1 /*Set Dvalid*/, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
-        }
-        else // num_faces == 2: top face pair only, no CFGSHIFTMASK
-        {
-            // Face 0: Ch0.Z=0, Ch1.Z=0 -> SrcA rows 0..15
-            TTI_UNPACR(SrcA, 0b00010001 /*Ch0.Z+=1, Ch1.Z+=1*/, 0, 0, 0, 1, 0 /*no Dvalid*/, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
-            // Face 1: Ch0.Z=1, Ch1.Z=1 -> SrcA rows 16..31. SetDvalid flips the SrcA bank.
-            TTI_UNPACR(SrcA, 0b00010001 /*Ch0.Z+=1, Ch1.Z+=1*/, 0, 0, 0, 1, 1 /*Set Dvalid*/, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
-        }
-
-        // SrcB DVALID + UNP_ZEROSRC. Required so math's ELWADD branch (dest_acc=Yes,
-        // is_int_fpu_en, or dst==UInt8) sees a zero SrcB; for the MOVA2D branch it's
-        // a no-op handshake but kept uniform across formats.
-        TTI_UNPACR_NOP(SrcB, 0, 0, p_unpacr_nop::SET_DVALID, 0, 0, 0, 0, p_unpacr_nop::UNP_ZEROSRC);
-
-        // T6::SEMGET for context release
-        t6_semaphore_get(semaphore::UNPACK_SYNC);
-
-        // Flip to the other context for the next tile
-        switch_config_context(unp_cfg_context);
     }
     else
     {
-        // Non-8-bit path: whole-tile unpack via BH workaround configuration (x_dim covers full tile).
+        // Program srcA and srcB base addresses
+        // FIXME MT: This should be revisited for narrow tiles
+        // std::uint32_t num_loops = narrow_tile ? 2 : num_faces/2;
+
         std::uint32_t address = base_address + top_face_offset_address;
         LLK_ASSERT(is_valid_L1_address(address), "L1 base_address must be in valid L1 memory region");
 


### PR DESCRIPTION
## Summary

Reverts #49473 (`Skrsmanovic/unpack tilize fp8 perf feature`).

#49473 merged to `main` on 2026-07-23 at 16:12 UTC. Its Blackhole `Fp8_e4m3` inline two-context `unpack_tilize` implementation replaced the established face-pair MOP/hand-off protocol. This corrupts gathered K tiles consumed by `ttnn.transformer.sparse_sdpa` with `SparseKVFormat.SCALED_FP8`, yielding PCC 0.0 rather than the required >= 0.999.

This is an LLK-level regression, not a Sparse SDPA semantic issue. Revert the generic LLK change to restore the known-good protocol while the optimized FP8 path is corrected and validated with broader coverage.

## Impact

- GLM-5.1 scaled-FP8 Sparse MLA prefill is broken: both the chunked-PCC and accuracy cases fail downstream of the corrupted K-tile conversion.
- Blackhole L2 nightly SDPA unit tests are affected as well. Their FP8 K/V correctness coverage exercises the same `Fp8_e4m3` tilize path; the scaled-FP8 production case also uses that path.

## Regression evidence

- [Blackhole sanity SDPA failure](https://github.com/tenstorrent/tt-metal/actions/runs/30042305656/job/89387071812): `test_sparse_sdpa_scaled_fp8_kv[multi_chunk]` fails with PCC 0.00000.
- The failure repeats in subsequent scheduled Blackhole sanity runs: [30057190436](https://github.com/tenstorrent/tt-metal/actions/runs/30057190436/job/89376526186) and [30068672592](https://github.com/tenstorrent/tt-metal/actions/runs/30068672592/job/89406936293).

## Validation

```
pytest tests/ttnn/unit_tests/operations/sdpa/test_sparse_sdpa.py -k 'test_sparse_sdpa_scaled_fp8_kv' -q --tb=short
# 7 passed
```

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/revert-49473-unpack-tilize-fp8)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/revert-49473-unpack-tilize-fp8)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/revert-49473-unpack-tilize-fp8)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/revert-49473-unpack-tilize-fp8)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=pjosipovic/revert-49473-unpack-tilize-fp8)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:pjosipovic/revert-49473-unpack-tilize-fp8)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/revert-49473-unpack-tilize-fp8)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/revert-49473-unpack-tilize-fp8)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/revert-49473-unpack-tilize-fp8)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/revert-49473-unpack-tilize-fp8)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/revert-49473-unpack-tilize-fp8)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/revert-49473-unpack-tilize-fp8)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/revert-49473-unpack-tilize-fp8)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/revert-49473-unpack-tilize-fp8)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/revert-49473-unpack-tilize-fp8)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/revert-49473-unpack-tilize-fp8)
