### PR TITLE
[Bug fix][fused_rms_minimal] Reject non-rectangular shard grids in the validator

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/rms_allgather_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/rms_allgather_device_operation.cpp
@@ -65,6 +65,15 @@ void RMSAllGatherDeviceOperation::validate_on_program_cache_miss(
         a.shard_spec().value().grid,
         semaphore_cores);
 
+    // The stats reduction runs over the shard grid's bounding-box rectangle, so a
+    // non-rectangular grid reads uninitialized L1 from the phantom cells (#50979).
+    const auto& input_shard_grid = a.shard_spec().value().grid;
+    TT_FATAL(
+        input_shard_grid.num_cores() == input_shard_grid.bounding_box().size(),
+        "fused_rms_minimal requires a rectangular shard grid but got {} cores in bounding box {}.",
+        input_shard_grid.num_cores(),
+        input_shard_grid.bounding_box());
+
     uint32_t input_width = a.tensor_spec().tile().get_tile_shape()[1];
     uint32_t input_height = a.tensor_spec().tile().get_tile_shape()[0];
     TT_FATAL(


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

`fused_rms_minimal` (rms_allgather) silently returns wrong results when the input's width-shard grid is non-rectangular (`num_cores != bounding_box`). 
The two-stage stats reduce iterates the bounding-box rectangle, so the phantom cells — inside the bbox but holding no shard data — get read into `E[x^2]`. Their contents are just whatever was last in that L1: `0` on a fresh device (harmless), stale garbage in a running model (corrupts). That L1 dependence is why it's non-deterministic.

A controlled repro gives PCC ~0.70; the arbitrary leftover in a running model pushes decode PCC to ~0 / NaN (tenstorrent/tt-xla#5738). Fresh-vs-stale repro and numbers are in #50979.

#45152 fixed the *hang* on these grids but not the correctness — the reduction still walks the full bounding box.

This rejects non-full-bbox grids in the validator (`num_cores == bounding_box().size()`), the same guard `layernorm`/`groupnorm` already have, so the op fails loud instead of silently corrupting:

```cpp
const auto& input_shard_grid = a.shard_spec().value().grid;
TT_FATAL(
    input_shard_grid.num_cores() == input_shard_grid.bounding_box().size(),
    "fused_rms_minimal requires a rectangular shard grid but got {} cores in bounding box {}.",
    input_shard_grid.num_cores(),
    input_shard_grid.bounding_box());
```

Closes #50979. Relates to tenstorrent/tt-xla#5738.

### Notes for reviewers

- Rejecting is enough to fix the issue for tt-mlir: the optimizer gets feedback that the grid is invalid and retries with a rectangular one. This PR does not add actual support for non-rectangular grids.
- No dedicated test added — the sibling ops (`layernorm`/`groupnorm`) ship this same guard without one; the repro and the fresh-vs-stale-L1 demonstration are in #50979.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mvasiljevic/5738-rms-allgather-nonrect-correctness)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mvasiljevic/5738-rms-allgather-nonrect-correctness)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mvasiljevic/5738-rms-allgather-nonrect-correctness)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mvasiljevic/5738-rms-allgather-nonrect-correctness)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mvasiljevic/5738-rms-allgather-nonrect-correctness)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mvasiljevic/5738-rms-allgather-nonrect-correctness)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mvasiljevic/5738-rms-allgather-nonrect-correctness)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mvasiljevic/5738-rms-allgather-nonrect-correctness)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mvasiljevic/5738-rms-allgather-nonrect-correctness)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mvasiljevic/5738-rms-allgather-nonrect-correctness)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mvasiljevic/5738-rms-allgather-nonrect-correctness)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mvasiljevic/5738-rms-allgather-nonrect-correctness)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mvasiljevic/5738-rms-allgather-nonrect-correctness)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mvasiljevic/5738-rms-allgather-nonrect-correctness)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mvasiljevic/5738-rms-allgather-nonrect-correctness)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mvasiljevic/5738-rms-allgather-nonrect-correctness)