### PR TITLE
[matmul] Drain mcast-ready atomics before the in0 receiver returns

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_receiver.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_receiver.cpp
@@ -87,4 +87,8 @@ void kernel_main() {
             }
         }
     }
+
+    // Drain the mcast-ready atomics (sender_sem.up) before returning, so no non-posted atomic is
+    // in flight at kernel exit. Matches the dram_sharded / ring_all_gather receivers.
+    noc.async_atomic_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_receiver_metal2.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_receiver_metal2.cpp
@@ -98,4 +98,8 @@ void kernel_main() {
             }
         }
     }
+
+    // Drain the mcast-ready atomics (sender_sem.up) before returning, so no non-posted atomic is
+    // in flight at kernel exit. Matches the dram_sharded / ring_all_gather receivers.
+    noc.async_atomic_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_receiver.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_receiver.cpp
@@ -87,4 +87,8 @@ void kernel_main() {
             }
         }
     }
+
+    // Drain the mcast-ready atomics (sender_sem.up) before returning, so no non-posted atomic is
+    // in flight at kernel exit. Matches the dram_sharded / ring_all_gather receivers.
+    noc.async_atomic_barrier();
 }


### PR DESCRIPTION
### Summary
Adds `noc.async_atomic_barrier()` before `kernel_main` returns in the three in0 mcast receiver kernels (mainline matmul + quasar + quasar metal2), so no non-posted atomic is in flight at kernel exit.

Each block the receiver issues `sender_sem.up()` — a non-posted remote atomic — then `receiver_sem.wait(VALID)`, and returns after the block loop with no atomic barrier. The Metal-2.0 kernel-exit epilogue (`ncrisck.cc`) asserts `ncrisc_noc_nonposted_atomics_flushed`; the newer receivers (dram_sharded, ring_all_gather) drain with `async_atomic_barrier`, these three did not.

### Why this code is unlikely to fail today
The terminal `receiver_sem.wait(VALID)` (a full sender round-trip) incidentally drains the single atomic's ACK before exit. Verified on Blackhole p100a: an interleaved-in0 1D-mcast matmul — the config that actually instantiates the receiver (`in0_sharded=False` + `mcast_in0=True`) — run back-to-back under `TT_METAL_WATCHER=1` shows **0 asserts / 0 hangs**, and matmul PCC is unchanged (0.9998).

### Why add the synchronization anyway
Correctness-by-construction + consistency. The receiver is safe today only by the incidental draining of its single atomic — not by contract. The Metal-2.0 epilogue actively enforces "no non-posted atomic in flight at exit"; if one is (Watcher on) it asserts, and (Watcher off) the leftover ACK races the next kernel's `noc_local_state_init` counter re-sync and can wedge dispatch. This kernel is a copy source, and any atomic added after the wait — or a derived kernel — would trip it. The barrier makes the receiver drain unconditionally and matches the newer sibling receivers.

### Repro / validation (Blackhole p100a, Watcher on)
Injecting undrained atomics into the mainline receiver (injection proven live via an infinite-loop control that correctly hung the device):
- 64 undrained atomics before return, **no** barrier → `DebugAssertNCriscNOCNonpostedAtomicsFlushedTripped`.
- Same **with** the barrier → clean.
- Shipped code (no injection) → clean; interleaved-mcast matmul PCC 0.9998 with the fix.

No failing regression test is added: the shipped code does not fail (the trailing wait drains today), so a test would pass with or without the change.

Note: the two quasar receivers are experimental / not deployed; they are included to keep the three byte-identical receivers in sync.

Closes #50996. Part of #50973.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amahmud/matmul-in0-receiver-atomic-barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amahmud/matmul-in0-receiver-atomic-barrier)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amahmud/matmul-in0-receiver-atomic-barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amahmud/matmul-in0-receiver-atomic-barrier)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=amahmud/matmul-in0-receiver-atomic-barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:amahmud/matmul-in0-receiver-atomic-barrier)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amahmud/matmul-in0-receiver-atomic-barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amahmud/matmul-in0-receiver-atomic-barrier)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amahmud/matmul-in0-receiver-atomic-barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amahmud/matmul-in0-receiver-atomic-barrier)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amahmud/matmul-in0-receiver-atomic-barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amahmud/matmul-in0-receiver-atomic-barrier)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amahmud/matmul-in0-receiver-atomic-barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amahmud/matmul-in0-receiver-atomic-barrier)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amahmud/matmul-in0-receiver-atomic-barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amahmud/matmul-in0-receiver-atomic-barrier)