### PR TITLE
[move] Drain handshake atomics before the overlap-move receiver returns

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/move/device/kernels/dataflow/move_interleaved_with_overlap.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/move/device/kernels/dataflow/move_interleaved_with_overlap.cpp
@@ -94,4 +94,8 @@ void kernel_main() {
         cb_read_offset += tile_bytes;
     }
     dfb.pop_front(num_tiles);
+
+    // Drain the sem.up()/set_multicast handshake atomics before returning, so no non-posted atomic
+    // is in flight at kernel exit (per-write async_write_barrier already drained the dst writes).
+    noc.async_atomic_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/move/device/kernels/dataflow/move_stick_layout_interleaved_with_overlap.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/move/device/kernels/dataflow/move_stick_layout_interleaved_with_overlap.cpp
@@ -93,4 +93,8 @@ void kernel_main() {
         l1_read_addr += aligned_page_size;
     }
     dfb.pop_front(num_pages);
+
+    // Drain the sem.up()/set_multicast handshake atomics before returning, so no non-posted atomic
+    // is in flight at kernel exit (per-write async_write_barrier already drained the dst writes).
+    noc.async_atomic_barrier();
 }


### PR DESCRIPTION
### Summary
Adds `noc.async_atomic_barrier()` before `kernel_main` returns in the two mainline overlap-move receiver kernels, so no non-posted atomic is in flight at kernel exit.

The multi-core overlap move (L1 src/dst overlap, `dst > src`) splits work across a controller + non-controller cores. Non-controllers issue `sem.up()` (a non-posted remote atomic) then `sem.wait(control_value)`; the controller `set_multicast`s the go signal. The dst-write loop drains its writes per-iteration (`async_write_barrier`), but nothing drains the handshake atomics before return. The **quasar** overlap-move siblings already drain this (`noc.async_full_barrier()`); the mainline kernels did not.

### Why this code is unlikely to fail today
The trailing `sem.wait(control_value)` — the controller aggregates every non-controller before multicasting back, a long wait — incidentally drains the atomic's ACK before exit. Verified on Blackhole p100a with a large L1→L1 overlapping `ttnn.move` (`[1,3,320,384]`, both L1 — the config that actually runs the multi-core non-controller path, confirmed via an infinite-loop control that hung the device): under `TT_METAL_WATCHER=1`, **0 atomics-flushed asserts** shipped, and **0 asserts + PCC pass** with the fix.

### Why add the synchronization anyway
Correctness-by-construction + consistency. The Metal-2.0 kernel-exit epilogue asserts `ncrisc_noc_nonposted_atomics_flushed`; the receiver is safe today only because the long wait incidentally drains its single atomic, not by contract. If an atomic were added after the wait — or the kernel copied — the epilogue would assert (Watcher on) or the leftover ACK would race the next kernel's counter re-sync and wedge dispatch (Watcher off). This brings the mainline overlap-move kernels in line with the quasar siblings, which already drain. The generic epilogue-asserts-on-undrained-atomic / barrier-fixes-it behavior is demonstrated in the sibling matmul PR #50997.

No failing regression test is added: the shipped code does not fail (the trailing wait drains today), so a test would pass with or without the change.

Closes #51003. Part of #50973.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amahmud/move-overlap-atomic-barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amahmud/move-overlap-atomic-barrier)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amahmud/move-overlap-atomic-barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amahmud/move-overlap-atomic-barrier)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=amahmud/move-overlap-atomic-barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:amahmud/move-overlap-atomic-barrier)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amahmud/move-overlap-atomic-barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amahmud/move-overlap-atomic-barrier)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amahmud/move-overlap-atomic-barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amahmud/move-overlap-atomic-barrier)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amahmud/move-overlap-atomic-barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amahmud/move-overlap-atomic-barrier)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amahmud/move-overlap-atomic-barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amahmud/move-overlap-atomic-barrier)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amahmud/move-overlap-atomic-barrier)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amahmud/move-overlap-atomic-barrier)