### PR TITLE
Fix FP8 sparse SDPA regression: skip int8 re-derive on QK reconfig

### DIFF
--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sparse_sdpa_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sparse_sdpa_compute.cpp
@@ -248,7 +248,9 @@ void kernel_main() {
             // fp8 K tilize leaves srcA in fp8. QK reads K (transposed -> srcA) and Q (srcB), so restore
             // srcA=cb_k_in (bfp8 for fp8 K), srcB=cb_q_in. Reconfigure the tiled descriptor geometry/strides;
             // mm_no_mop_init_short only programs the matmul MOP.
-            reconfig_data_format<SrcOrder::Regular, /*is_tile_dim_reconfig_en=*/true>(cb_k_in, cb_q_in);
+            // skip_int8: do NOT re-derive the int8/unsigned state here -- the fp8 K path relies on the state left
+            // by tilize, and re-deriving it from bfp8 corrupts the QK matmul.
+            reconfig_data_format_skip_int8<SrcOrder::Regular, /*is_tile_dim_reconfig_en=*/true>(cb_k_in, cb_q_in);
             // K tilize also leaves the packer in cb_k_in's format+strides (bfp8 for fp8). Restore bf16 once per
             // chunk for the downstream packs (cb_qk_im/max/sum/out share its geometry); configure_pack_width in
             // the qg loop refreshes only the MOP. No-op for bf16.


### PR DESCRIPTION
## What

One-line fix in `sparse_sdpa_compute.cpp`: the QK reconfig for the fp8 K path now uses `reconfig_data_format_skip_int8<SrcOrder::Regular, true>(...)` instead of the always-derive `reconfig_data_format<SrcOrder::Regular, true>(...)`.

## Why

The reconfig signature change (#49119) migrated this call from the old `reconfig_data_format<false /*to_from_int8*/, true>(...)` to the always-derive form. For the fp8 K path that re-derives the int8/unsigned state from a bfp8 format and corrupts the QK matmul.

Result on main: **`scaled FP8 sparse SDPA PCC 0.0`** in Blackhole sanity, starting exactly at the #49119 merge:

- green on every main run before the merge
- red on every run since (the first red ran on the #49119 merge commit itself; the mixed-format-KV-cache change #50207 is not in it)

`reconfig_data_format_skip_int8` is the drop-in equivalent of the old `to_from_int8=false` behavior that @skotaracTT set in #50614, so this restores the working path with the int8 fix left intact everywhere else.

## Not a fault of #50614

@skotaracTT — your #50614 was correct. The regression is on the migration side: when #49119 moved the `<false>` (skip) call sites onto the new API, this one should have gone to `reconfig_data_format_skip_int8`, not the always-derive form. We should have made every migrated call both non-deprecated **and** behavior-preserving.

## Please review

Could you sanity-check the fix, and also whether these sibling fp8 / sdpa reconfig sites that #49119 migrated to the always-derive form need the same `_skip_int8` treatment? They passed CI, so I did not flip them blindly, but they are in your area:

- `sdpa_decode/.../sdpa_flash_decode.cpp:234`
- `deepseek_prefill/per_token_cast_to_fp8/.../compute_per_token_cast_to_fp8.cpp`
- `deepseek_v3_b1/unified_kernels/sdpa_reduce_worker.hpp`

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nkc/fix-sparse-sdpa-fp8-reconfig-skip-int8)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nkc/fix-sparse-sdpa-fp8-reconfig-skip-int8)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nkc/fix-sparse-sdpa-fp8-reconfig-skip-int8)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nkc/fix-sparse-sdpa-fp8-reconfig-skip-int8)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=nkc/fix-sparse-sdpa-fp8-reconfig-skip-int8)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:nkc/fix-sparse-sdpa-fp8-reconfig-skip-int8)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nkc/fix-sparse-sdpa-fp8-reconfig-skip-int8)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nkc/fix-sparse-sdpa-fp8-reconfig-skip-int8)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nkc/fix-sparse-sdpa-fp8-reconfig-skip-int8)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nkc/fix-sparse-sdpa-fp8-reconfig-skip-int8)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nkc/fix-sparse-sdpa-fp8-reconfig-skip-int8)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nkc/fix-sparse-sdpa-fp8-reconfig-skip-int8)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nkc/fix-sparse-sdpa-fp8-reconfig-skip-int8)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nkc/fix-sparse-sdpa-fp8-reconfig-skip-int8)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nkc/fix-sparse-sdpa-fp8-reconfig-skip-int8)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nkc/fix-sparse-sdpa-fp8-reconfig-skip-int8)