### PR TITLE
[deepseek_v3_d_p] Avoid composite reduce-scatter fallback for indexer wts all-reduce

### DIFF
--- a/models/demos/deepseek_v3_d_p/tt/mla/indexer.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/indexer.py
@@ -327,6 +327,31 @@ class TtIndexer:
             cluster_axis=self.tp_axis,
         )
 
+    def _tp_all_reduce_via_gather(self, t):
+        """All-reduce over TP via gather (dim 1) + local reduce, instead of _tp_rs_ag's reduce-scatter
+        (dim 3) + all-gather. For a narrow dim-3 width (e.g. wts' H_idx=32) that doesn't divide evenly
+        into tile-sized TP shards, _tp_rs_ag's reduce-scatter hits ttnn's composite fallback
+        (use_composite_reduce_scatter) and balloons into ~30 tilize/pad/slice ops. Gathering on dim 1 —
+        the batch/placeholder axis, always size 1 here — has no tile-alignment constraint, so it always
+        takes the fused fast path; fast_reduce_nc then sums the gathered TP axis locally (pure on-device
+        compute, no fabric traffic). Mirrors ttMLA._kv_stem's kv_a_proj_with_mqa all-reduce (mla.py:
+        917-929), measured cheaper even on an 18x-wider tensor than wts."""
+        if self.tp_factor == 1:
+            return t
+        t = ttnn.experimental.all_gather_async(
+            t,
+            dim=1,
+            multi_device_global_semaphore=self.tt_ccl.get_and_cycle_ag_semaphore_handles(cluster_axis=self.tp_axis),
+            barrier_semaphore=self.tt_ccl.get_and_cycle_barrier_semaphore_handle(cluster_axis=self.tp_axis),
+            num_links=self.ccl_num_links,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            topology=self.tp_ccl_topology,
+            cluster_axis=self.tp_axis,
+        )
+        return ttnn.experimental.fast_reduce_nc(
+            t, dims=[1], output=None, compute_kernel_config=self.hifi4_fp32_compute_kernel_config
+        )
+
     def _sp_all_gather(self, t, dim):
         """All-gather across the SP axis (sequence) → full-S replicated on SP. sp=1: no-op."""
         if self.sp_factor == 1:
@@ -564,7 +589,10 @@ class TtIndexer:
             compute_kernel_config=self.default_compute_kernel_config,
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
         )
-        wts = self._tp_rs_ag(wts)  # full all-reduce (RS+AG) over tp -> all H_idx head-weights, replicated
+        # H_idx=32 doesn't divide evenly into tile-sized TP=4 shards (8 < tile width), so _tp_rs_ag's
+        # dim-3 reduce-scatter would hit ttnn's composite fallback (~30 extra tilize/pad/slice ops, see
+        # use_composite_reduce_scatter). Gather-then-local-reduce on dim 1 has no such tile constraint.
+        wts = self._tp_all_reduce_via_gather(wts)  # full all-reduce over tp -> all H_idx head-weights, replicated
         # Indexer softmax scale = index_head_dim**-0.5 (NO mscale), matching the reference IndexerCPU
         # (model.py: softmax_scale = head_dim**-0.5). Distinct from MLA's qk_head_dim*mscale**2 scale —
         # though as a uniform positive multiplier it cannot change the top-k selection regardless.


### PR DESCRIPTION
### What

#50601. The indexer's `wts` TP all-reduce (`indexer.py._tp_rs_ag`) reduce-scatters on a 32-wide dim (`index_n_heads`) that doesn't split evenly across TP=4 (8 < tile width), tripping ttnn's composite `reduce_scatter` fallback (`use_composite_reduce_scatter`) — ~30 extra tilize/pad/slice ops per forward.

This adds `_tp_all_reduce_via_gather`, which instead gathers on the size-1 placeholder dim 1 (no tile-alignment constraint, so it always takes the fused fast path) and reduces the gathered TP axis locally via `fast_reduce_nc` (pure on-device compute, no fabric traffic). It mirrors the `kv_a_proj_with_mqa` all-reduce in `mla.py._kv_stem`.

Wired in for the `wts` call site only. `_tp_rs_ag` (used by the tile-aligned k projection) is unchanged.

### Perf

Measured with a device-only Tracy profiling test (`test_sparse_mla_chunked_tracy_profile`, glm_5_2 on Galaxy SP=8×TP=4, 5120-tok chunk over a 51200-tok cache):

- Completion step: **29 device ops / ~210µs per chip → 2 ops / ~43µs per chip** (~4.9×)

### Correctness

Verified via `test_sparse_mla_chunked` and `test_sparse_mla_indexer_reuse` (glm_5_2).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ipotkonjak/pr_indexer_all_reduce)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ipotkonjak/pr_indexer_all_reduce)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ipotkonjak/pr_indexer_all_reduce)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ipotkonjak/pr_indexer_all_reduce)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ipotkonjak/pr_indexer_all_reduce)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ipotkonjak/pr_indexer_all_reduce)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ipotkonjak/pr_indexer_all_reduce)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ipotkonjak/pr_indexer_all_reduce)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ipotkonjak/pr_indexer_all_reduce)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ipotkonjak/pr_indexer_all_reduce)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ipotkonjak/pr_indexer_all_reduce)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ipotkonjak/pr_indexer_all_reduce)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ipotkonjak/pr_indexer_all_reduce)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ipotkonjak/pr_indexer_all_reduce)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ipotkonjak/pr_indexer_all_reduce)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ipotkonjak/pr_indexer_all_reduce)