### PR TITLE
[Codegen] Rename SKIP_TESTER → LOCK_TESTS; writer retries compile

### DIFF
--- a/tt_metal/tt-llk/codegen/CLAUDE.md
+++ b/tt_metal/tt-llk/codegen/CLAUDE.md
@@ -142,7 +142,7 @@ python codegen/scripts/state.py --worktree-dir "{worktree_dir}" set RUN_ID     "
 python codegen/scripts/state.py --worktree-dir "{worktree_dir}" set START_TIME "{start_time}"
 ```
 Optional per-run override flags — set the same way (`state.py --worktree-dir … set <FLAG> true`) only when the request asks for them:
-- `SKIP_TESTER` — the writer validates against the existing tests; tester/refiner are skipped.
+- `LOCK_TESTS` — the tester runs test-locked: it treats the existing test as the immutable source of truth, authors or modifies no test, and only runs it and debugs the kernel; the writer→tester→refiner loop is otherwise unchanged.
 - `HIDE_EXISTING_KERNEL` — the orchestrator's Step 2b git-removes-and-commits the target op's existing files on the worktree branch, so it regenerates blind. Never `rm` the files in the prompt; set this flag and let the orchestrator do it.
 
 Then invoke the orchestrator, telling it only `WORKTREE_DIR={worktree_dir}` —

--- a/tt_metal/tt-llk/codegen/agents/quasar/llk-analysis-refiner.md
+++ b/tt_metal/tt-llk/codegen/agents/quasar/llk-analysis-refiner.md
@@ -27,7 +27,8 @@ KERNEL_TYPE="$($ST --log-dir "$LOG_DIR" get KERNEL_TYPE)"
 TARGET_ARCH="$($ST --log-dir "$LOG_DIR" get TARGET_ARCH)"
 KERNEL_PATH="$($ST --log-dir "$LOG_DIR" get GENERATED_KERNEL)"   # the failed kernel
 SKIP_WRITER="$($ST --log-dir "$LOG_DIR" get SKIP_WRITER)"
-for v in LOG_DIR KERNEL_NAME KERNEL_TYPE TARGET_ARCH KERNEL_PATH SKIP_WRITER; do echo "$v=${!v:-<empty>}"; done
+LOCK_TESTS="$($ST --log-dir "$LOG_DIR" get LOCK_TESTS)"
+for v in LOG_DIR KERNEL_NAME KERNEL_TYPE TARGET_ARCH KERNEL_PATH SKIP_WRITER LOCK_TESTS; do echo "$v=${!v:-<empty>}"; done
 ```
 
 Run all file I/O from `$WORKTREE_DIR/tt_metal/tt-llk`. Throughout, `{KERNEL_NAME}` denotes the resolved value. Derived paths:
@@ -110,6 +111,8 @@ Pick the **one primary** category — the one whose fix cascades the most downst
 | **MISSING_INSTRUCTION_ON_TARGET** | Kernel uses an instruction the assembler rejected / simulated to a NOP; `assembly.yaml` has no entry | Drop it; redesign the semantic step (may need an algorithm change — Taylor instead of LUT, integer emulation, …) |
 | **HARNESS_INCOMPATIBILITY** | Every variant times out / all-zeros with near-identical signatures; the sibling smoke passes; the test source calls foreign-arch `_llk_*` / sync / `wait_*` symbols or reaches them via a `*_compat*` shim | The kernel plan was likely fine — the test source was never converted to target-native. Direct the tester to author a native test source before further kernel edits. Do NOT rewrite §6b |
 | **UNDIAGNOSABLE** | No coherent pattern — different signatures, different categories | Escalate. Do not refine on noise |
+
+When `LOCK_TESTS=true` (from Inputs), the test is locked — do not recommend authoring or editing any test, golden, or input-prep; treat `HARNESS_INCOMPATIBILITY` as terminal and `ESCALATE`.
 
 If you cannot confidently pick ONE category after reading the logs twice, classify `UNDIAGNOSABLE` and escalate.
 

--- a/tt_metal/tt-llk/codegen/agents/quasar/llk-analyzer.md
+++ b/tt_metal/tt-llk/codegen/agents/quasar/llk-analyzer.md
@@ -56,6 +56,8 @@ fi
 Run all subsequent file I/O from `$WORKTREE_DIR/tt_metal/tt-llk`. Your output goes to
 `codegen/artifacts/{KERNEL_NAME}_analysis.md`.
 
+Never dispatch the Sage Quasar agent. Read the markdown reference files directly for any ADDITIONAL information you need, if you need.
+
 **Throughout this playbook**, `{...}` denotes the value of the variable `...` echoed above
 (e.g. with `KERNEL_NAME=gelu`, `codegen/artifacts/{KERNEL_NAME}_analysis.md` means
 `codegen/artifacts/gelu_analysis.md`).

--- a/tt_metal/tt-llk/codegen/agents/quasar/llk-kernel-writer.md
+++ b/tt_metal/tt-llk/codegen/agents/quasar/llk-kernel-writer.md
@@ -23,7 +23,6 @@ TARGET_ARCH="$($ST      --log-dir "$LOG_DIR" get TARGET_ARCH)"
 GENERATED_KERNEL="$($ST --log-dir "$LOG_DIR" get GENERATED_KERNEL)"
 SFPI_MODE="$($ST        --log-dir "$LOG_DIR" get SFPI_MODE)"
 SKIP_WRITER="$($ST      --log-dir "$LOG_DIR" get SKIP_WRITER)"
-SKIP_TESTER="$($ST      --log-dir "$LOG_DIR" get SKIP_TESTER)"
 ```
 
 The analysis doc is `codegen/artifacts/{KERNEL_NAME}_analysis.md`. It already contains everything you need: function shape (§6a), full pseudocode per function (§6b), risks (§6e), the Available Instructions and Semantic → Instruction Mapping tables, Instruction Encoding Constraints, and Format Applicability. Trust these sections — do NOT re-derive them from sibling kernels or the test harness. Open an existing file only if the analysis cites it as a pattern source and you need a detail it did not quote. Never reconstruct the target op's own prior implementation from git (`git show HEAD/origin/main:<path>`, history, or a deleted file) — if it is not on the branch it does not exist; build purely from the analysis.
@@ -49,9 +48,7 @@ Do this even when the user asked for an "SFPI version." You still produce the re
 
 ### Step 0: Already-copied kernel (`SKIP_WRITER`)
 
-If `SKIP_WRITER` is `true` (resolved in Inputs), the analyzer already placed a verbatim SFPI kernel at `$WORKTREE_DIR/$GENERATED_KERNEL`. Do **NOT** generate or overwrite it.
-- If `SKIP_TESTER` is also `true`, do **not** report yet — go to **Step 4b** and validate the copied kernel against its existing tests, then report from there.
-- Otherwise report success and stop (the tester compiles and runs it):
+If `SKIP_WRITER` is `true` (resolved in Inputs), the analyzer already placed a verbatim SFPI kernel at `$WORKTREE_DIR/$GENERATED_KERNEL`. Do **NOT** generate or overwrite it. Report success and stop (the tester compiles and runs it):
 ```
 Kernel Type: {type}
 Generated: {GENERATED_KERNEL} (verbatim SFPI copy — writer skipped)
@@ -134,18 +131,7 @@ CHIP_ARCH={TARGET_ARCH} python scripts/compiler.py {path_to_test_source} \
 ```
 For parameter selection, see **Compiler Parameters** below.
 
-Do NOT iterate on errors yourself — if the compile fails, report `FAILED` and let the orchestrator route it (to the refiner). (Exception: `SKIP_TESTER` mode — see Step 4b.)
-
-### Step 4b: Validate against existing tests (`SKIP_TESTER` only)
-
-If `SKIP_TESTER` is not `true`, skip this step — the compile-check is your last action.
-
-If `SKIP_TESTER` is `true`, do not stop at the compile-check. Validate the kernel against its **existing** test — do NOT author, extend, register, or modify any test:
-1. Locate the existing test: the unified SFPU category test (from the analysis `## SFPU Category`) or the sibling test for math/pack/unpack.
-2. Run it via `run_test.sh` as `llk-tester` does — `compile` then `simulate`, foreground (Bash `timeout: 600000` backstop, `dangerouslyDisableSandbox: true`, one blocking call, no resume loop), `--maxfail 0`, with the category-correct `--k` token (lowercase op for unary, UPPERCASE id for binary, `where` for ternary). First confirm it selects variants (`run_test.sh count ... --k "{K}"` must be > 0). `dangerouslyDisableSandbox: true` is required on every `run_test.sh` call (emulator network + `/tmp` build-cache writes); it is a no-op when already un-sandboxed.
-3. On a runtime failure, diagnose and fix the **kernel** (never the test), then re-run. Cap at **5 simulator runs** (compile-step failures excluded). If `run_test.sh` reports `ENV_ERROR` (exit 3 / `RUN_LLK_TESTS_VERDICT === ENV_ERROR`, e.g. the emulator never became ready), the environment is broken, not the kernel: stop now — do not count it against the 5 runs, do not modify the kernel, do not re-run — and report `ENV_ERROR` (Step 5).
-4. Before reporting, record the counts as `llk-tester` does on pass: `TESTS_TOTAL`, `TESTS_PASSED`, `TESTER_COMPILE_COUNT`, `PHASE_DEBUGS`.
-5. If it passes, report the Step 5 success block. On the 5th runtime failure, report the Step 5 failure block with the last failure signature as the Error summary.
+Iterate here until the kernel compiles clean — however many attempts it takes, there is no cap: fix each compile error and re-run this command, staying faithful to §6b — fix includes, parameter types, and signatures to match the harness; never invent an instruction sequence not in §6b. Report `FAILED` **only** when the kernel cannot compile without deviating from §6b (an analysis error, not a mechanical fix); put the deviation in the Error summary and the orchestrator routes it to the refiner. Never run the kernel on the simulator; the compile is your last action and the tester runs it.
 
 ### Step 5: Report
 
@@ -163,15 +149,8 @@ Kernel Type: {type}
 Generated: {path}
 Final compiled: FAILED
 Error summary: [brief description]
+Compile attempts: {N}
 Ready for: llk-analysis-refiner agent
-```
-
-On environment error (emulator/infra unavailable — kernel not implicated, no retry):
-```
-Kernel Type: {type}
-Generated: {path}
-Final compiled: ENV_ERROR
-Diagnosis: [run_test.sh verdict / why the emulator was unavailable]
 ```
 
 ---

--- a/tt_metal/tt-llk/codegen/agents/quasar/llk-tester.md
+++ b/tt_metal/tt-llk/codegen/agents/quasar/llk-tester.md
@@ -1,13 +1,18 @@
 ---
 name: llk-tester
-description: Validate the kernel produced (or copied) earlier in this run. Author or extend the target functional test, run it, and iteratively diagnose-and-fix the kernel until it passes. Hard-capped at 5 simulator test runs (compile-time failures excluded).
+description: Validate the kernel produced (or copied) earlier in this run. Run the target functional test — pre-existing when LOCK_TESTS=true, otherwise authored from the analysis spec — and iteratively diagnose-and-fix the kernel until it passes; never modify a locked test. Hard-capped at 5 simulator test runs (compile-time failures excluded).
 model: inherit
 tools: Read, Write, Edit, Bash, Glob, Grep, mcp__atlassian__getConfluencePage
 ---
 
 # LLK Tester Agent
 
-You run after the kernel exists (freshly written, or copied verbatim by the analyzer). It already compiles. Your mission is to prove it is **functionally correct** — and when it is not, to fix it. You always author/extend the target test, run it, and fix the kernel until it passes. You own the whole test-and-fix loop.
+You run after the kernel exists (freshly written, or copied verbatim by the analyzer). It already compiles. Your mission is to prove it is **functionally correct**, and to fix the **kernel** when it is not. Take one of two paths by `LOCK_TESTS` (from Inputs):
+
+- **`LOCK_TESTS=true`** — the test already exists in the repo. Run it as-is; when it fails, debug the kernel and **never change the test** (see § Test-Locked Mode).
+- **`LOCK_TESTS=false`** — no test exists yet. Author/extend the target test from the analysis spec (Step 1), then run it and fix the kernel until it passes.
+
+You own the whole test-and-fix loop.
 
 ---
 
@@ -27,8 +32,9 @@ TARGET_ARCH="$($ST      --log-dir "$LOG_DIR" get TARGET_ARCH)"
 GENERATED_KERNEL="$($ST --log-dir "$LOG_DIR" get GENERATED_KERNEL)"
 CYCLE="$($ST            --log-dir "$LOG_DIR" get CYCLE)"
 SKIP_WRITER="$($ST      --log-dir "$LOG_DIR" get SKIP_WRITER)"
+LOCK_TESTS="$($ST      --log-dir "$LOG_DIR" get LOCK_TESTS)"
 
-for v in LOG_DIR KERNEL_NAME KERNEL_TYPE TARGET_ARCH GENERATED_KERNEL CYCLE; do
+for v in LOG_DIR KERNEL_NAME KERNEL_TYPE TARGET_ARCH GENERATED_KERNEL CYCLE LOCK_TESTS; do
     echo "$v=${!v:-<empty>}"
 done
 ```
@@ -36,6 +42,12 @@ done
 - The kernel under test is at `$WORKTREE_DIR/$GENERATED_KERNEL` (repo-root-relative). Quasar SFPU kernels live under `tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/`; math/pack/unpack live under `tt_llk_quasar/llk_lib/`.
 - The analyzer's spec is `codegen/artifacts/{KERNEL_NAME}_analysis.md`. Read its **SFPU Category**, **Format Applicability** (recommended test formats), and any golden reference from it. The analyzer always writes these sections, including on the verbatim-copy path.
 - Run all file I/O from `$WORKTREE_DIR/tt_metal/tt-llk`. Throughout, `{...}` is the value echoed above (`{arch}` == `TARGET_ARCH`).
+
+---
+
+## Test-Locked Mode (`LOCK_TESTS=true`)
+
+When `LOCK_TESTS` is `true` (from Inputs), the existing test is the immutable source of truth. Skip all test authoring: do **not** run Step 1 §1A.2–§1A.4 or §1B, and do **not** author, extend, register, or modify any test, golden, `SfpuType`/`BinaryOp`/`MathOperation` enum, dispatcher branch, or input-prep. Replace Step 1 with: locate the existing test (SFPU → the unified category test per §1A.1; math/pack/unpack → the per-op file `test_{op}_{arch}.py`), then run the §1D collection smoke to confirm it selects the op's variants. If the test is absent, the `count` is `0`, or the op is unregistered, report `STUCK` (category `TEST_MISSING`) with that as the signature — do not create it. Steps 2–5 are unchanged: run the existing test, diagnose, and fix the **kernel** only. Treat a `HARNESS_INCOMPATIBILITY` as a terminal `STUCK` — do not author a native test source.
 
 ---
 
@@ -455,6 +467,7 @@ State the kernel and test paths literally so downstream steps / humans can inspe
 13. **Use `$WORKTREE_DIR/...` absolute paths.**
 14. **Contradiction check before every hypothesis (§3.0.a).**
 15. **Harness-first on uniform failures (§3.0.b).**
+16. **Test-locked mode (`LOCK_TESTS=true`): the existing test is immutable** — author or modify no test, golden, or input-prep; missing test infrastructure is a terminal `STUCK` (§ Test-Locked Mode).
 
 ---
 

--- a/tt_metal/tt-llk/codegen/agents/quasar/orchestrator.md
+++ b/tt_metal/tt-llk/codegen/agents/quasar/orchestrator.md
@@ -330,22 +330,17 @@ Agent tool:
 - Now WAIT for AGENT completion!
 - THEN writer returns `PASSED` / `FAILED` on its final compile check.
 
-**If `SKIP_TESTER` is true** (read it: `python codegen/scripts/state.py --log-dir "$(python codegen/scripts/state.py --worktree-dir "$WORKTREE_DIR" get LOG_DIR)" get SKIP_TESTER`): the writer already validated against the existing tests. Do **not** spawn the tester (Step 5b) or the refiner (Step 5c).
-- Writer `PASSED` → EXECUTE `execute_step_tester_passed` (it records success from the counts the writer wrote), then go to Step 6.
-- Writer `FAILED` → EXECUTE `execute_step_mark_status failed test_failure`, then jump to Step 8.
-- Writer `ENV_ERROR` (emulator/infra unavailable — kernel not implicated) → EXECUTE `execute_step_tester_env_error "{writer's Diagnosis line}"`, then jump to Step 8. Do **not** invoke the refiner or optimizer.
 
-Otherwise (normal flow):
 
 **If writer reports PASSED**: go to Step 5b.
 
-**If writer reports FAILED** (compile broken): pass the first meaningful line
-from the writer's "Error summary" and the compile count `1` (the writer runs a
-single compile-check). The step records the error, updates the compile counters,
+**If writer reports FAILED** (kernel can't compile without deviating from §6b — an analysis error): pass the first
+meaningful line from the writer's "Error summary" and the writer's reported
+"Compile attempts" count. The step records the error, updates the compile counters,
 writes the failure + phase-end, and refreshes cost:
 ```bash
 source codegen/scripts/quasar/orchestrator_steps.sh
-execute_step_writer_failed "{first meaningful line from the writer's Error summary}" 1
+execute_step_writer_failed "{first meaningful line from the writer's Error summary}" {compile attempts}
 ```
 
 If the step printed `AT_CAP=yes` (cycle 3): EXECUTE the following, then jump to Step 8:
@@ -375,6 +370,11 @@ Agent tool:
     (compile-time failures are excluded from the cap). Each run = compile-producer
     + simulator-consumer. Diagnose and fix between runs. On attempt 5's failure,
     return STUCK — the orchestrator will route to the refiner.
+
+    If LOCK_TESTS=true (read it from state), run in test-locked mode per your
+    playbook: treat the existing test as the immutable source of truth — never
+    author, extend, register, or modify any test, golden, or input-prep; only run
+    the existing test and debug the kernel.
 ```
 
 - WAIT for the Tester finish and return `PASS`, `STUCK`, or `ENV_ERROR`.

--- a/tt_metal/tt-llk/codegen/references/state_contract.md
+++ b/tt_metal/tt-llk/codegen/references/state_contract.md
@@ -2,8 +2,8 @@
 
 `boot` = `--worktree-dir` file · `run` = `--log-dir "$LOG_DIR"` file.
 `★` = agent must write those keys back into `run`.
-`SKIP_TESTER` (boolean, from router; default `false`): when true the writer validates the kernel against its existing tests in a 5-run fix loop and writes the `★` tester counts itself; the orchestrator skips the tester and refiner and routes the writer's PASSED/FAILED straight to optimizer / failed.
-`HIDE_EXISTING_KERNEL` (boolean, from router; default `false`): when true, `execute_step_hide_existing_kernel` (Step 2b) git-removes and commits the target op's existing files on the worktree branch before the analyzer runs, so the pipeline regenerates blind. `execute_step_setup_run` mirrors it from `boot` into `run` exactly like `SKIP_TESTER`.
+`LOCK_TESTS` (boolean, from router; default `false`): when true the tester runs test-locked — it treats the existing test as the immutable source of truth, authors or modifies no test, and only runs it and debugs the kernel; the writer→tester→refiner loop is otherwise unchanged.
+`HIDE_EXISTING_KERNEL` (boolean, from router; default `false`): when true, `execute_step_hide_existing_kernel` (Step 2b) git-removes and commits the target op's existing files on the worktree branch before the analyzer runs, so the pipeline regenerates blind. `execute_step_setup_run` mirrors it from `boot` into `run` exactly like `LOCK_TESTS`.
 
 ## Orchestrator ⇄ agents
 
@@ -11,11 +11,11 @@ Left box into an agent = what it consumes · right box out = what it produces.
 
 ```mermaid
 flowchart LR
-  ROUTER["router (begin_setup → run.json step=setup, pre-worktree)"] --> RB["KERNEL_NAME, TARGET_ARCH, SFPI_MODE, SKIP_TESTER, HIDE_EXISTING_KERNEL,<br/>WORKTREE_BRANCH, LOG_DIR_BASE,<br/>LOG_DIR, RUN_ID, START_TIME (from begin_setup)"] --> ORCH(["orchestrator"])
+  ROUTER["router (begin_setup → run.json step=setup, pre-worktree)"] --> RB["KERNEL_NAME, TARGET_ARCH, SFPI_MODE, LOCK_TESTS, HIDE_EXISTING_KERNEL,<br/>WORKTREE_BRANCH, LOG_DIR_BASE,<br/>LOG_DIR, RUN_ID, START_TIME (from begin_setup)"] --> ORCH(["orchestrator"])
 
   ORCH --> aI["kernel identity"] --> ANA["analyzer"] --> aO["analysis.md,<br/>error line"] --> ORCH
-  ORCH --> wI["analysis, CYCLE,<br/>GENERATED_KERNEL, SKIP_TESTER"] --> WR["writer"] --> wO["PASSED / FAILED, error line, compile count<br/>(SKIP_TESTER: also TESTS_TOTAL, TESTS_PASSED,<br/>TESTER_COMPILE_COUNT, PHASE_DEBUGS)"] --> ORCH
-  ORCH --> tI["compiled kernel,<br/>CYCLE, LOG_DIR"] --> TST["tester ★"] --> tO["PASS / STUCK / ENV_ERROR,<br/>TESTS_TOTAL, TESTS_PASSED, TESTS_GENERATED,<br/>TESTER_COMPILE_COUNT, PHASE_DEBUGS,<br/>FORMATS_TESTED_JSON, FORMATS_EXCLUDED_JSON"] --> ORCH
+  ORCH --> wI["analysis, CYCLE,<br/>GENERATED_KERNEL"] --> WR["writer"] --> wO["PASSED / FAILED, error line, compile count"] --> ORCH
+  ORCH --> tI["compiled kernel,<br/>CYCLE, LOG_DIR, LOCK_TESTS"] --> TST["tester ★"] --> tO["PASS / STUCK / ENV_ERROR,<br/>TESTS_TOTAL, TESTS_PASSED, TESTS_GENERATED,<br/>TESTER_COMPILE_COUNT, PHASE_DEBUGS,<br/>FORMATS_TESTED_JSON, FORMATS_EXCLUDED_JSON"] --> ORCH
   ORCH --> rI["PREV_RESULT,<br/>failure summary, CYCLE"] --> RE["refiner"] --> rO["REFINED / ESCALATE,<br/>reason"] --> ORCH
   ORCH --> oI["passing kernel,<br/>SFPI_MODE"] --> OP["optimizer ★"] --> oO["OPTIMIZED,<br/>OPTIMIZATION_TYPE"] --> ORCH
   ORCH --> fI["kernel"] --> FM["format"] --> ORCH

--- a/tt_metal/tt-llk/codegen/scripts/quasar/orchestrator_steps.sh
+++ b/tt_metal/tt-llk/codegen/scripts/quasar/orchestrator_steps.sh
@@ -206,14 +206,14 @@ execute_step_setup_run() {
     local S="$_ORCH_SCRIPTS" wt
     wt="$(_wt)"
 
-    local START_TIME KERNEL_NAME TARGET_ARCH WORKTREE_BRANCH SFPI_MODE SKIP_TESTER HIDE_EXISTING_KERNEL LOG_DIR_BASE
+    local START_TIME KERNEL_NAME TARGET_ARCH WORKTREE_BRANCH SFPI_MODE LOCK_TESTS HIDE_EXISTING_KERNEL LOG_DIR_BASE
     local RUN_ID LOG_DIR GIT_COMMIT CODEGEN_VERSION PROMPT BATCH_ID MODEL RUN_TYPE
     START_TIME="$(python "$S/state.py" --worktree-dir "$wt" get START_TIME)"; START_TIME="${START_TIME:-$(date -u +%Y-%m-%dT%H:%M:%SZ)}"
     KERNEL_NAME="$(python "$S/state.py" --worktree-dir "$wt" get KERNEL_NAME)"
     TARGET_ARCH="$(python "$S/state.py" --worktree-dir "$wt" get TARGET_ARCH)"
     WORKTREE_BRANCH="$(python "$S/state.py" --worktree-dir "$wt" get WORKTREE_BRANCH)"
     SFPI_MODE="$(python "$S/state.py" --worktree-dir "$wt" get SFPI_MODE)"
-    SKIP_TESTER="$(python "$S/state.py" --worktree-dir "$wt" get SKIP_TESTER)"; SKIP_TESTER="${SKIP_TESTER:-false}"
+    LOCK_TESTS="$(python "$S/state.py" --worktree-dir "$wt" get LOCK_TESTS)"; LOCK_TESTS="${LOCK_TESTS:-false}"
     HIDE_EXISTING_KERNEL="$(python "$S/state.py" --worktree-dir "$wt" get HIDE_EXISTING_KERNEL)"; HIDE_EXISTING_KERNEL="${HIDE_EXISTING_KERNEL:-false}"
     LOG_DIR_BASE="$(python "$S/state.py" --worktree-dir "$wt" get LOG_DIR_BASE)"
     # Reuse begin_setup's identity if the router threaded it into worktree state;
@@ -244,7 +244,7 @@ execute_step_setup_run() {
     ss TARGET_ARCH     "$TARGET_ARCH"
     ss WORKTREE_BRANCH "$WORKTREE_BRANCH"
     ss SFPI_MODE       "$SFPI_MODE" --json
-    ss SKIP_TESTER     "$SKIP_TESTER" --json
+    ss LOCK_TESTS     "$LOCK_TESTS" --json
     ss HIDE_EXISTING_KERNEL "$HIDE_EXISTING_KERNEL" --json
     ss RUN_ID          "$RUN_ID"
     ss START_TIME      "$START_TIME"


### PR DESCRIPTION
### Summary
Two fixes to the Quasar codegen workflow:

1. **`SKIP_TESTER` → `LOCK_TESTS`.** Old flag made the *writer* run the tests and skipped the tester/refiner. New flag keeps the normal writer→tester→refiner loop; the **tester** just runs the existing test as-is (immutable — no editing tests, goldens, or input-prep) and only debugs the kernel.

2. **Writer retries compile errors.** Before, one failed compile → instant `FAILED` → wasted a refinement cycle. Now the writer fixes mechanical compile errors itself (includes, types, signatures) and reports `FAILED` only when the analysis (§6b) is actually wrong. Reports its compile-attempt count too.

Also: analyzer told to read reference `.md` files directly instead of dispatching the Sage Quasar agent.

### Notes for reviewers
- Behavior change: under `LOCK_TESTS=true` the tester now always runs (locked mode); under the old `SKIP_TESTER` it was skipped.
- Removed the writer's `ENV_ERROR` path — that only existed because the writer used to run tests.
- Writer compile loop is uncapped by design; it escalates the moment a fix would need to deviate from §6b.
- No product code touched — 8 files, all under `codegen/`.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jmacanovic/fix-writer-report-fail)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jmacanovic/fix-writer-report-fail)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jmacanovic/fix-writer-report-fail)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jmacanovic/fix-writer-report-fail)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=jmacanovic/fix-writer-report-fail)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:jmacanovic/fix-writer-report-fail)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jmacanovic/fix-writer-report-fail)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jmacanovic/fix-writer-report-fail)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jmacanovic/fix-writer-report-fail)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jmacanovic/fix-writer-report-fail)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jmacanovic/fix-writer-report-fail)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jmacanovic/fix-writer-report-fail)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jmacanovic/fix-writer-report-fail)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jmacanovic/fix-writer-report-fail)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jmacanovic/fix-writer-report-fail)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jmacanovic/fix-writer-report-fail)