### PR TITLE
Add prefill runner to Blaze Models Prefill tests and rebalance CI budget time

### DIFF
--- a/.github/workflows/blaze-models-prefill-tests.yaml
+++ b/.github/workflows/blaze-models-prefill-tests.yaml
@@ -12,7 +12,7 @@ on:
           Empty or "all" runs every stage. Valid stages: moe_gate, mla, mla_chunked,
           kv_cache_table, prefill_block, prefill_transformer, kimi_mla, kimi_moe,
           kimi_prefill_block, kimi_chunked, kimi_dflash, glm_chunked, dsa_mla, dsa_mla_glm, glm_moe, glm_prefill_block, glm_chunked_accuracy, prefill_block_determinism,
-          prefill_transformer_determinism.
+          prefill_transformer_determinism, prefill_runner.
           The "module" group also runs every stage; the "sdpa_perf" group runs the
           ring joint SDPA perf checks.
         required: false

--- a/models/demos/common/prefill/tests/test_producer_runner_e2e.py
+++ b/models/demos/common/prefill/tests/test_producer_runner_e2e.py
@@ -39,6 +39,45 @@ _PRODUCER_TIMEOUT_S = int(os.environ.get("PREFILL_CI_PRODUCER_TIMEOUT_S", "900")
 _LOG_TAIL_LINES = int(os.environ.get("PREFILL_CI_LOG_TAIL_LINES", "200"))
 _DESCRIPTOR = f"/dev/shm/tt_h2d_stream_service_{SERVICE_ID}.bin"
 
+# --- launch mode: standard (bare pytest) vs CI (under an MPI launcher) --------------------------
+# This test runs in one of two ways, and ONLY the child-process environment differs between them:
+#
+#   standard  -- `pytest .../test_producer_runner_e2e.py ...` invoked directly (local iteration).
+#                The runner/producer children inherit this process's environment unchanged and come
+#                up as standalone singletons. Historical behaviour; unchanged.
+#
+#   ci        -- launched under mpirun/prterun to match the blaze pipeline convention, e.g.
+#                `mpirun --pernode ... python3 -m pytest ...`. The launcher exports OMPI_*/PMIX_*/
+#                PRTE_* into this (pytest) process. If a child inherited them, the runner's
+#                ttnn.init_distributed_context() (MPI_Init) would join the launcher's PMIx session
+#                instead of standing up its own singleton; because we tear the long-lived runner
+#                down with a signal and never call MPI_Finalize, prterun then reports an "abnormal
+#                termination" and forces mpirun to exit non-zero -- masking an otherwise-green
+#                pytest (the exact failure seen in CI). The CI path strips those launcher vars from
+#                the child environment so the runner/producer detach from prterun and run as clean
+#                singletons, identical to the standard path. This pytest process never calls
+#                MPI_Init, so it exits with pytest's real return code.
+#
+# Auto-detected from the launcher env vars (so the mpirun wrapper works even with no flag) and
+# pinned explicitly by the CI matrix entry via PREFILL_RUNNER_LAUNCH=ci; unset locally (standard).
+_MPI_LAUNCHER_PREFIXES = ("OMPI_", "PMIX_", "PRTE_", "PRRTE_")
+
+
+def _mpi_launcher_keys(env) -> list:
+    """The launcher / PMIx-session variables present in `env` (empty when not under mpirun)."""
+    return [k for k in env if k.startswith(_MPI_LAUNCHER_PREFIXES)]
+
+
+def _launch_mode() -> str:
+    """Return "ci" when launched under an MPI launcher (mpirun/prterun), else "standard".
+    PREFILL_RUNNER_LAUNCH=ci|standard overrides the auto-detection."""
+    forced = os.environ.get("PREFILL_RUNNER_LAUNCH", "").strip().lower()
+    if forced in ("ci", "mpi", "mpirun"):
+        return "ci"
+    if forced in ("standard", "standalone", "local", "bare", "pytest"):
+        return "standard"
+    return "ci" if _mpi_launcher_keys(os.environ) else "standard"
+
 pytestmark = [
     skip_for_slow_dispatch(),
     pytest.mark.skipif(not is_blackhole(), reason="prefill runner + H2DStreamService require a Blackhole galaxy"),
@@ -85,7 +124,11 @@ SCENARIOS = {
 def _transport_env(num_users: int, max_seq_len: int, **extra) -> dict:
     """Inherit the CI/dev env (weights cache, HF, golden trace) and add the shared orchestration knobs
     for this scenario's runner+producer. `extra` layers on the runner (MOCK_MIGRATION) or producer
-    (schedule + CHECK_PCC) knobs."""
+    (schedule + CHECK_PCC) knobs.
+
+    In the CI (mpirun) launch path the launcher's MPI/PMIx session variables are stripped from the
+    returned child environment so the runner/producer run as standalone singletons detached from
+    prterun (see the launch-mode note above). No-op in the standard path."""
     env = dict(os.environ)
     env.update(
         PREFILL_CHUNK_SIZE=str(CHUNK_SIZE),
@@ -97,6 +140,11 @@ def _transport_env(num_users: int, max_seq_len: int, **extra) -> dict:
         PREFILL_MIGRATION_DEVICE_MAP_PATH=DEVMAP_PATH,
     )
     env.update(extra)
+    if _launch_mode() == "ci":
+        # CI path: detach the child from the mpirun/prterun session so it comes up as a standalone
+        # singleton (see the launch-mode note above). Harmless when no launcher vars are present.
+        for key in _mpi_launcher_keys(env):
+            env.pop(key, None)
     return env
 
 
@@ -137,6 +185,15 @@ def _running_runner(tag: str, num_users: int, max_seq_len: int):
     log_path = os.path.join(_REPORT_DIR, f"ci_runner_{tag}.log")
     _cleanup_ipc()  # a stale table/descriptor from a prior scenario would make the readiness poll pass early
     env = _transport_env(num_users, max_seq_len, PREFILL_MOCK_MIGRATION="1")
+    mode = _launch_mode()
+    if mode == "ci":
+        print(
+            f"[producer-runner-e2e] launch mode=ci: detaching runner/producer from mpirun "
+            f"(stripped {len(_mpi_launcher_keys(os.environ))} launcher env vars from child env)",
+            flush=True,
+        )
+    else:
+        print("[producer-runner-e2e] launch mode=standard (bare pytest; children inherit env)", flush=True)
     with open(log_path, "w") as log:
         proc = subprocess.Popen([sys.executable, "-m", _RUNNER_MODULE], env=env, stdout=log, stderr=subprocess.STDOUT)
     try:

--- a/models/demos/common/prefill/tests/test_producer_runner_e2e.py
+++ b/models/demos/common/prefill/tests/test_producer_runner_e2e.py
@@ -78,6 +78,7 @@ def _launch_mode() -> str:
         return "standard"
     return "ci" if _mpi_launcher_keys(os.environ) else "standard"
 
+
 pytestmark = [
     skip_for_slow_dispatch(),
     pytest.mark.skipif(not is_blackhole(), reason="prefill runner + H2DStreamService require a Blackhole galaxy"),

--- a/models/demos/deepseek_v3_d_p/tests/test_kv_cache_table.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_kv_cache_table.py
@@ -53,7 +53,7 @@ from tests.ttnn.utils_for_testing import assert_equal
     indirect=True,
 )
 @pytest.mark.parametrize("use_pretrained", [False, True], ids=["random", "pretrained"])
-@pytest.mark.parametrize("seq_len", [25 * 1024], ids=["seq25k"])
+@pytest.mark.parametrize("seq_len", [5 * 1024, 25 * 1024], ids=["seq5k", "seq25k"])
 @pytest.mark.timeout(0)  # Disable timeout — first run computes and caches CPU reference for large seq lengths
 def test_kv_cache_table(
     use_pretrained,

--- a/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
+++ b/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
@@ -445,7 +445,7 @@
     export PREFILL_MODEL=kimi_k2_6
     export PREFILL_HF_MODEL=/mnt/models/Kimi-K2_6-dequantized
     export PREFILL_TTNN_CACHE=/mnt/models/Kimi-K2_6-Cache/Kimi-K2_6-Cache-prefill
-    export PREFILL_TRACE_DIR=/mnt/models/deepseek-prefill-cache/golden/kimi-26/kimi_longbook_56320
+    export PREFILL_TRACE_DIR=/mnt/models/deepseek-prefill-cache/golden/structured_traces/kimi_debug_55k_vllm
     export PREFILL_NUM_LAYERS=61
     export PREFILL_CI_PRODUCER_TIMEOUT_S=1140
     export PREFILL_CI_RUNNER_READY_TIMEOUT_S=1140

--- a/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
+++ b/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
@@ -456,6 +456,7 @@
     export PREFILL_HF_MODEL=/mnt/models/Kimi-K2_6-dequantized
     export PREFILL_TTNN_CACHE=/mnt/models/Kimi-K2_6-Cache/Kimi-K2_6-Cache-prefill
     export PREFILL_TRACE_DIR=/mnt/models/deepseek-prefill-cache/golden/kimi-26/kimi_longbook_56320
+    export PREFILL_RUNNER_LAUNCH=ci
 
     mpirun --bind-to none --pernode --tag-output bash -lc '
       export OMP_NUM_THREADS=$(nproc)

--- a/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
+++ b/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
@@ -438,3 +438,34 @@
   owner_id: U09L76N1MAT
   team: models
   sp_config: sc1
+
+- name: "Blaze - Kimi Prefill Runner e2e (mock migration)"
+  # Producer<->runner mock-migration e2e on a single Galaxy (bh_sc1 = one galaxy / one host): the
+  # model-agnostic prefill runner opens the 8x4 mesh as a single rank while a device-less producer drives
+  # it as a second process over the H2D socket, gated on per-slot KV-cache PCC. Deepest single-user
+  # scenario -- 11 x 5120 = 56320 tokens = the full Kimi golden trace -- at the test's default depth
+  # (PREFILL_NUM_LAYERS unset -> 2 layers), reading layers 0-1 out of the prebuilt ttnn cache (no build).
+  # Paths mirror the kimi_k2_6 adapter CI defaults (dot-free HF config, prebuilt TTNN cache, and the
+  # kimi_longbook_56320 serving golden trace).
+  # Launched under mpirun to match the blaze convention; on bh_sc1 --pernode resolves to a single rank.
+  # The pytest process itself spawns/tears down the runner + producer subprocesses, so one pytest owns
+  # the orchestration (the runner stands up its own single-rank distributed context).
+  cmd: |
+    export MESH_DEVICE=TG
+    export PREFILL_MODEL=kimi_k2_6
+    export PREFILL_HF_MODEL=/mnt/models/Kimi-K2_6-dequantized
+    export PREFILL_TTNN_CACHE=/mnt/models/Kimi-K2_6-Cache/Kimi-K2_6-Cache-prefill
+    export PREFILL_TRACE_DIR=/mnt/models/deepseek-prefill-cache/golden/kimi-26/kimi_longbook_56320
+
+    mpirun --bind-to none --pernode --tag-output bash -lc '
+      export OMP_NUM_THREADS=$(nproc)
+      python3 -m pytest models/demos/common/prefill/tests/test_producer_runner_e2e.py::test_producer_runner_pcc -k single_user_full_depth -vvv --tb=short --timeout=1500
+    '
+  test_type: prefill_runner
+  test_group: module
+  skus:
+    bh_sc1:
+      timeout: 25
+  owner_id: U09L76N1MAT  # Nenad Babin
+  team: models
+  sp_config: sc1

--- a/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
+++ b/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
@@ -443,8 +443,8 @@
   # Producer<->runner mock-migration e2e on a single Galaxy (bh_sc1 = one galaxy / one host): the
   # model-agnostic prefill runner opens the 8x4 mesh as a single rank while a device-less producer drives
   # it as a second process over the H2D socket, gated on per-slot KV-cache PCC. Deepest single-user
-  # scenario -- 11 x 5120 = 56320 tokens = the full Kimi golden trace -- at the test's default depth
-  # (PREFILL_NUM_LAYERS unset -> 2 layers), reading layers 0-1 out of the prebuilt ttnn cache (no build).
+  # scenario -- 11 x 5120 = 56320 tokens = the full Kimi golden trace -- at FULL model depth
+  # (PREFILL_NUM_LAYERS=61 -> all 61 layers) read from the prebuilt ttnn cache (no build).
   # Paths mirror the kimi_k2_6 adapter CI defaults (dot-free HF config, prebuilt TTNN cache, and the
   # kimi_longbook_56320 serving golden trace).
   # Launched under mpirun to match the blaze convention; on bh_sc1 --pernode resolves to a single rank.
@@ -456,17 +456,27 @@
     export PREFILL_HF_MODEL=/mnt/models/Kimi-K2_6-dequantized
     export PREFILL_TTNN_CACHE=/mnt/models/Kimi-K2_6-Cache/Kimi-K2_6-Cache-prefill
     export PREFILL_TRACE_DIR=/mnt/models/deepseek-prefill-cache/golden/kimi-26/kimi_longbook_56320
+    # Full model depth (all 61 layers) instead of the 2-layer smoke default, to gate the whole
+    # network's KV. Raise both inner sub-timeouts (producer wait ceiling, default 15 min; runner-ready
+    # ceiling, default 20 min) to 29 min so neither trips before the 30-min job/pytest timeout governs
+    # (--timeout below): the runner does the heavy 61-layer load + forward pass and the producer just
+    # waits on its per-layer acks.
+    export PREFILL_NUM_LAYERS=61
+    export PREFILL_CI_PRODUCER_TIMEOUT_S=1740
+    export PREFILL_CI_RUNNER_READY_TIMEOUT_S=1740
+    # CI launch path: detaches the runner/producer children from this mpirun/prterun session so they
+    # run as standalone singletons and the job returns pytest's real exit code.
     export PREFILL_RUNNER_LAUNCH=ci
 
     mpirun --bind-to none --pernode --tag-output bash -lc '
       export OMP_NUM_THREADS=$(nproc)
-      python3 -m pytest models/demos/common/prefill/tests/test_producer_runner_e2e.py::test_producer_runner_pcc -k single_user_full_depth -vvv --tb=short --timeout=1500
+      python3 -m pytest models/demos/common/prefill/tests/test_producer_runner_e2e.py::test_producer_runner_pcc -k single_user_full_depth -vvv --tb=short --timeout=1800
     '
   test_type: prefill_runner
   test_group: module
   skus:
     bh_sc1:
-      timeout: 25
+      timeout: 30
   owner_id: U09L76N1MAT  # Nenad Babin
   team: models
   sp_config: sc1

--- a/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
+++ b/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
@@ -440,33 +440,15 @@
   sp_config: sc1
 
 - name: "Blaze - Kimi Prefill Runner e2e (mock migration)"
-  # Producer<->runner mock-migration e2e on a single Galaxy (bh_sc1 = one galaxy / one host): the
-  # model-agnostic prefill runner opens the 8x4 mesh as a single rank while a device-less producer drives
-  # it as a second process over the H2D socket, gated on per-slot KV-cache PCC. Deepest single-user
-  # scenario -- 11 x 5120 = 56320 tokens = the full Kimi golden trace -- at FULL model depth
-  # (PREFILL_NUM_LAYERS=61 -> all 61 layers) read from the prebuilt ttnn cache (no build).
-  # Paths mirror the kimi_k2_6 adapter CI defaults (dot-free HF config, prebuilt TTNN cache, and the
-  # kimi_longbook_56320 serving golden trace).
-  # Launched under mpirun to match the blaze convention; on bh_sc1 --pernode resolves to a single rank.
-  # The pytest process itself spawns/tears down the runner + producer subprocesses, so one pytest owns
-  # the orchestration (the runner stands up its own single-rank distributed context).
   cmd: |
     export MESH_DEVICE=TG
     export PREFILL_MODEL=kimi_k2_6
     export PREFILL_HF_MODEL=/mnt/models/Kimi-K2_6-dequantized
     export PREFILL_TTNN_CACHE=/mnt/models/Kimi-K2_6-Cache/Kimi-K2_6-Cache-prefill
     export PREFILL_TRACE_DIR=/mnt/models/deepseek-prefill-cache/golden/kimi-26/kimi_longbook_56320
-    # Full model depth (all 61 layers) instead of the 2-layer smoke default, to gate the whole
-    # network's KV. Measured ~14 min end-to-end on bh_sc1 (run 30075995186), so 20 min gives ~6 min
-    # headroom. Raise both inner sub-timeouts (producer wait ceiling, default 15 min; runner-ready
-    # ceiling, default 20 min) to 19 min so neither trips before the 20-min job/pytest timeout governs
-    # (--timeout below): the runner does the heavy 61-layer load + forward pass and the producer just
-    # waits on its per-layer acks.
     export PREFILL_NUM_LAYERS=61
     export PREFILL_CI_PRODUCER_TIMEOUT_S=1140
     export PREFILL_CI_RUNNER_READY_TIMEOUT_S=1140
-    # CI launch path: detaches the runner/producer children from this mpirun/prterun session so they
-    # run as standalone singletons and the job returns pytest's real exit code.
     export PREFILL_RUNNER_LAUNCH=ci
 
     mpirun --bind-to none --pernode --tag-output bash -lc '

--- a/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
+++ b/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
@@ -93,7 +93,7 @@
   test_group: module
   skus:
     bh_sc1:
-      timeout: 7
+      timeout: 3
   owner_id: U08RL15T4N8
   team: models
   sp_config: sc1
@@ -314,13 +314,13 @@
     mpirun --bind-to none --pernode --tag-output bash -lc '
       export OMP_NUM_THREADS=$(nproc)
       uv pip install -r models/demos/deepseek_v3/reference/deepseek/requirements.txt
-      python3 -m pytest models/demos/deepseek_v3_d_p/tests/test_prefill_transformer.py::test_ds_prefill_transformer -k "mesh-8x4 and 5_layers and e256_device_fp32 and longbook_qa_eng and 25600 and iter2 and not iter25 and not iter2000 and smoke and with_determinism and random and balanced and right_pad" -vvv --tb=short --timeout=3120
+      python3 -m pytest models/demos/deepseek_v3_d_p/tests/test_prefill_transformer.py::test_ds_prefill_transformer -k "mesh-8x4 and 5_layers and e256_device_fp32 and longbook_qa_eng and 25600 and iter2 and not iter25 and not iter2000 and smoke and with_determinism and random and balanced and right_pad" -vvv --tb=short --timeout=2940
     '
   test_type: prefill_transformer_determinism
   test_group: module
   skus:
     bh_sc1:
-      timeout: 52
+      timeout: 49
   owner_id: U08RL15T4N8
   team: models
   sp_config: sc1

--- a/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
+++ b/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
@@ -93,7 +93,7 @@
   test_group: module
   skus:
     bh_sc1:
-      timeout: 5
+      timeout: 7
   owner_id: U08RL15T4N8
   team: models
   sp_config: sc1
@@ -314,13 +314,13 @@
     mpirun --bind-to none --pernode --tag-output bash -lc '
       export OMP_NUM_THREADS=$(nproc)
       uv pip install -r models/demos/deepseek_v3/reference/deepseek/requirements.txt
-      python3 -m pytest models/demos/deepseek_v3_d_p/tests/test_prefill_transformer.py::test_ds_prefill_transformer -k "mesh-8x4 and 5_layers and e256_device_fp32 and longbook_qa_eng and 25600 and iter2 and not iter25 and not iter2000 and smoke and with_determinism and random and balanced and right_pad" -vvv --tb=short --timeout=3240
+      python3 -m pytest models/demos/deepseek_v3_d_p/tests/test_prefill_transformer.py::test_ds_prefill_transformer -k "mesh-8x4 and 5_layers and e256_device_fp32 and longbook_qa_eng and 25600 and iter2 and not iter25 and not iter2000 and smoke and with_determinism and random and balanced and right_pad" -vvv --tb=short --timeout=3120
     '
   test_type: prefill_transformer_determinism
   test_group: module
   skus:
     bh_sc1:
-      timeout: 54
+      timeout: 52
   owner_id: U08RL15T4N8
   team: models
   sp_config: sc1

--- a/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
+++ b/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
@@ -86,14 +86,14 @@
     mpirun --bind-to none --pernode --tag-output bash -lc '
       export OMP_NUM_THREADS=$(nproc)
       uv pip install -r models/demos/deepseek_v3/reference/deepseek/requirements.txt
-      python3 -m pytest models/demos/deepseek_v3_d_p/tests/test_kv_cache_table.py::test_kv_cache_table -k "line and pretrained" -vvv --tb=short
+      python3 -m pytest models/demos/deepseek_v3_d_p/tests/test_kv_cache_table.py::test_kv_cache_table -k "line and pretrained and seq5k" -vvv --tb=short
       python3 -m pytest models/demos/deepseek_v3_d_p/tests/test_kv_cache_table.py::test_kimi_kv_cache_mock -k "line" -vvv --tb=short
     '
   test_type: kv_cache_table
   test_group: module
   skus:
     bh_sc1:
-      timeout: 3
+      timeout: 10
   owner_id: U08RL15T4N8
   team: models
   sp_config: sc1

--- a/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
+++ b/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
@@ -77,7 +77,7 @@
 
 - name: "Blaze - KV cache table"
   cmd: |
-    export DEEPSEEK_V3_HF_MODEL=/mnt/models/deepseek-ai/DeepSeek-R1-0528
+    export DEEPSEEK_V3_HF_MODEL=/mnt/models/deepseek-ai/DeepSeek-R1-0528-dequantized
     export DEEPSEEK_V3_CACHE=/mnt/models/DeepSeek-R1-0528-Cache/CI
     export TT_DS_PREFILL_TTNN_CACHE=/mnt/models/DeepSeek-R1-0528-Cache/DeepSeek-R1-0528-Cache-prefill_secure
     export TT_DS_PREFILL_HOST_REF_CACHE=/mnt/models/deepseek-prefill-cache/golden/

--- a/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
+++ b/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
@@ -445,7 +445,7 @@
     export PREFILL_MODEL=kimi_k2_6
     export PREFILL_HF_MODEL=/mnt/models/Kimi-K2_6-dequantized
     export PREFILL_TTNN_CACHE=/mnt/models/Kimi-K2_6-Cache/Kimi-K2_6-Cache-prefill
-    export PREFILL_TRACE_DIR=/mnt/models/deepseek-prefill-cache/golden/structured_traces/kimi_debug_55k_vllm
+    export PREFILL_TRACE_DIR=/mnt/models/kimi-prefill-cache/vllm-kimi-k26-codedebug-56320
     export PREFILL_NUM_LAYERS=61
     export PREFILL_CI_PRODUCER_TIMEOUT_S=1140
     export PREFILL_CI_RUNNER_READY_TIMEOUT_S=1140

--- a/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
+++ b/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
@@ -314,13 +314,13 @@
     mpirun --bind-to none --pernode --tag-output bash -lc '
       export OMP_NUM_THREADS=$(nproc)
       uv pip install -r models/demos/deepseek_v3/reference/deepseek/requirements.txt
-      python3 -m pytest models/demos/deepseek_v3_d_p/tests/test_prefill_transformer.py::test_ds_prefill_transformer -k "mesh-8x4 and 5_layers and e256_device_fp32 and longbook_qa_eng and 25600 and iter2 and not iter25 and not iter2000 and smoke and with_determinism and random and balanced and right_pad" -vvv --tb=short --timeout=3600
+      python3 -m pytest models/demos/deepseek_v3_d_p/tests/test_prefill_transformer.py::test_ds_prefill_transformer -k "mesh-8x4 and 5_layers and e256_device_fp32 and longbook_qa_eng and 25600 and iter2 and not iter25 and not iter2000 and smoke and with_determinism and random and balanced and right_pad" -vvv --tb=short --timeout=3240
     '
   test_type: prefill_transformer_determinism
   test_group: module
   skus:
     bh_sc1:
-      timeout: 60
+      timeout: 54
   owner_id: U08RL15T4N8
   team: models
   sp_config: sc1
@@ -447,19 +447,19 @@
     export PREFILL_TTNN_CACHE=/mnt/models/Kimi-K2_6-Cache/Kimi-K2_6-Cache-prefill
     export PREFILL_TRACE_DIR=/mnt/models/deepseek-prefill-cache/golden/structured_traces/kimi_debug_55k_vllm
     export PREFILL_NUM_LAYERS=61
-    export PREFILL_CI_PRODUCER_TIMEOUT_S=1440
-    export PREFILL_CI_RUNNER_READY_TIMEOUT_S=1440
+    export PREFILL_CI_PRODUCER_TIMEOUT_S=1800
+    export PREFILL_CI_RUNNER_READY_TIMEOUT_S=1800
     export PREFILL_RUNNER_LAUNCH=ci
 
     mpirun --bind-to none --pernode --tag-output bash -lc '
       export OMP_NUM_THREADS=$(nproc)
-      python3 -m pytest models/demos/common/prefill/tests/test_producer_runner_e2e.py::test_producer_runner_pcc -k single_user_full_depth -vvv --tb=short --timeout=1440
+      python3 -m pytest models/demos/common/prefill/tests/test_producer_runner_e2e.py::test_producer_runner_pcc -k single_user_full_depth -vvv --tb=short --timeout=1800
     '
   test_type: prefill_runner
   test_group: module
   skus:
     bh_sc1:
-      timeout: 24
+      timeout: 30
   owner_id: U09L76N1MAT  # Nenad Babin
   team: models
   sp_config: sc1

--- a/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
+++ b/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
@@ -439,13 +439,13 @@
   team: models
   sp_config: sc1
 
-- name: "Blaze - Kimi Prefill Runner e2e (mock migration)"
+- name: "Blaze - Kimi Prefill Runner (code_debug 55k)"
   cmd: |
     export MESH_DEVICE=TG
     export PREFILL_MODEL=kimi_k2_6
     export PREFILL_HF_MODEL=/mnt/models/Kimi-K2_6-dequantized
     export PREFILL_TTNN_CACHE=/mnt/models/Kimi-K2_6-Cache/Kimi-K2_6-Cache-prefill
-    export PREFILL_TRACE_DIR=/mnt/models/kimi-prefill-cache/vllm-kimi-k26-codedebug-56320
+    export PREFILL_TRACE_DIR=/mnt/models/deepseek-prefill-cache/golden/structured_traces/kimi_debug_55k_vllm
     export PREFILL_NUM_LAYERS=61
     export PREFILL_CI_PRODUCER_TIMEOUT_S=1140
     export PREFILL_CI_RUNNER_READY_TIMEOUT_S=1140

--- a/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
+++ b/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
@@ -93,7 +93,7 @@
   test_group: module
   skus:
     bh_sc1:
-      timeout: 10
+      timeout: 7
   owner_id: U08RL15T4N8
   team: models
   sp_config: sc1
@@ -253,7 +253,7 @@
   test_group: module
   skus:
     bh_sc1:
-      timeout: 35
+      timeout: 25
   owner_id: U08RL15T4N8
   team: models
   sp_config: sc1
@@ -274,7 +274,7 @@
   test_group: module
   skus:
     bh_sc1:
-      timeout: 30
+      timeout: 23
   owner_id: U08RL15T4N8
   team: models
   sp_config: sc1
@@ -457,26 +457,27 @@
     export PREFILL_TTNN_CACHE=/mnt/models/Kimi-K2_6-Cache/Kimi-K2_6-Cache-prefill
     export PREFILL_TRACE_DIR=/mnt/models/deepseek-prefill-cache/golden/kimi-26/kimi_longbook_56320
     # Full model depth (all 61 layers) instead of the 2-layer smoke default, to gate the whole
-    # network's KV. Raise both inner sub-timeouts (producer wait ceiling, default 15 min; runner-ready
-    # ceiling, default 20 min) to 29 min so neither trips before the 30-min job/pytest timeout governs
+    # network's KV. Measured ~14 min end-to-end on bh_sc1 (run 30075995186), so 20 min gives ~6 min
+    # headroom. Raise both inner sub-timeouts (producer wait ceiling, default 15 min; runner-ready
+    # ceiling, default 20 min) to 19 min so neither trips before the 20-min job/pytest timeout governs
     # (--timeout below): the runner does the heavy 61-layer load + forward pass and the producer just
     # waits on its per-layer acks.
     export PREFILL_NUM_LAYERS=61
-    export PREFILL_CI_PRODUCER_TIMEOUT_S=1740
-    export PREFILL_CI_RUNNER_READY_TIMEOUT_S=1740
+    export PREFILL_CI_PRODUCER_TIMEOUT_S=1140
+    export PREFILL_CI_RUNNER_READY_TIMEOUT_S=1140
     # CI launch path: detaches the runner/producer children from this mpirun/prterun session so they
     # run as standalone singletons and the job returns pytest's real exit code.
     export PREFILL_RUNNER_LAUNCH=ci
 
     mpirun --bind-to none --pernode --tag-output bash -lc '
       export OMP_NUM_THREADS=$(nproc)
-      python3 -m pytest models/demos/common/prefill/tests/test_producer_runner_e2e.py::test_producer_runner_pcc -k single_user_full_depth -vvv --tb=short --timeout=1800
+      python3 -m pytest models/demos/common/prefill/tests/test_producer_runner_e2e.py::test_producer_runner_pcc -k single_user_full_depth -vvv --tb=short --timeout=1200
     '
   test_type: prefill_runner
   test_group: module
   skus:
     bh_sc1:
-      timeout: 30
+      timeout: 20
   owner_id: U09L76N1MAT  # Nenad Babin
   team: models
   sp_config: sc1

--- a/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
+++ b/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
@@ -93,7 +93,7 @@
   test_group: module
   skus:
     bh_sc1:
-      timeout: 7
+      timeout: 5
   owner_id: U08RL15T4N8
   team: models
   sp_config: sc1
@@ -253,7 +253,7 @@
   test_group: module
   skus:
     bh_sc1:
-      timeout: 25
+      timeout: 24
   owner_id: U08RL15T4N8
   team: models
   sp_config: sc1
@@ -266,15 +266,15 @@
 
     mpirun --bind-to none --pernode --tag-output bash -lc '
       export OMP_NUM_THREADS=$(nproc)
-      python3 -m pytest models/demos/deepseek_v3_d_p/tests/test_prefill_block.py::test_kimi_prefill_block -k "mesh-8x4 and pcc-prompt_5k and iter1 and no_determinism and pretrained" -vvv --tb=short --timeout=1800
-      python3 -m pytest models/demos/deepseek_v3_d_p/tests/test_prefill_block.py::test_kimi_prefill_block -k "mesh-8x4 and pcc-prompt_25k and iter1 and no_determinism and pretrained" -vvv --tb=short --timeout=1800
+      python3 -m pytest models/demos/deepseek_v3_d_p/tests/test_prefill_block.py::test_kimi_prefill_block -k "mesh-8x4 and pcc-prompt_5k and iter1 and no_determinism and pretrained" -vvv --tb=short --timeout=1320
+      python3 -m pytest models/demos/deepseek_v3_d_p/tests/test_prefill_block.py::test_kimi_prefill_block -k "mesh-8x4 and pcc-prompt_25k and iter1 and no_determinism and pretrained" -vvv --tb=short --timeout=1320
     '
 
   test_type: kimi_prefill_block
   test_group: module
   skus:
     bh_sc1:
-      timeout: 23
+      timeout: 22
   owner_id: U08RL15T4N8
   team: models
   sp_config: sc1
@@ -447,19 +447,19 @@
     export PREFILL_TTNN_CACHE=/mnt/models/Kimi-K2_6-Cache/Kimi-K2_6-Cache-prefill
     export PREFILL_TRACE_DIR=/mnt/models/deepseek-prefill-cache/golden/structured_traces/kimi_debug_55k_vllm
     export PREFILL_NUM_LAYERS=61
-    export PREFILL_CI_PRODUCER_TIMEOUT_S=1140
-    export PREFILL_CI_RUNNER_READY_TIMEOUT_S=1140
+    export PREFILL_CI_PRODUCER_TIMEOUT_S=1440
+    export PREFILL_CI_RUNNER_READY_TIMEOUT_S=1440
     export PREFILL_RUNNER_LAUNCH=ci
 
     mpirun --bind-to none --pernode --tag-output bash -lc '
       export OMP_NUM_THREADS=$(nproc)
-      python3 -m pytest models/demos/common/prefill/tests/test_producer_runner_e2e.py::test_producer_runner_pcc -k single_user_full_depth -vvv --tb=short --timeout=1200
+      python3 -m pytest models/demos/common/prefill/tests/test_producer_runner_e2e.py::test_producer_runner_pcc -k single_user_full_depth -vvv --tb=short --timeout=1440
     '
   test_type: prefill_runner
   test_group: module
   skus:
     bh_sc1:
-      timeout: 20
+      timeout: 24
   owner_id: U09L76N1MAT  # Nenad Babin
   team: models
   sp_config: sc1


### PR DESCRIPTION
### Summary
Adds a full-depth Kimi producer↔runner **mock-migration** end-to-end test to the blaze models-prefill CI matrix (single-galaxy `bh_sc1`). The runner loads the 61-layer Kimi model and runs prefill; a device-less producer drives it over the H2D socket, drains every per-layer ack, reads back the KV cache, and gates on per-slot KV-cache PCC. This exercises the producer/runner migration path against the real network in CI for the first time.

The time budget for `models → demo → bh_sc1` is **unchanged vs main (480 min)**: the new 20-min job is funded by trimming three already over-provisioned tests rather than raising the cap.

### What's included

**1. New CI entry — `Blaze - Kimi Prefill Runner e2e (mock migration)`** (`tests/pipeline_reorg/blaze_models_prefill_tests.yaml`)
- Full 61-layer Kimi (`PREFILL_NUM_LAYERS=61`), scenario `single_user_full_depth` (11 chunks × 5120 = 56320 = the full golden trace → 671 layer acks).
- Launched under `mpirun --bind-to none --pernode --tag-output` to match the blaze convention; test-step timeout 20 min (`--timeout=1200`), inner sub-timeouts 19 min.
- KV-cache PCC gate ≥ 0.93.

**2. Two-path launch fix** (`models/demos/common/prefill/tests/test_producer_runner_e2e.py`)
Under `mpirun`, the runner's `ttnn.init_distributed_context()` (MPI_Init) would join the launcher's PMIx session and, because the long-lived runner is torn down with a signal (no `MPI_Finalize`), `prterun` reported an *"abnormal termination"* and forced `mpirun` to exit non-zero — masking an otherwise-green pytest. The test now selects a launch mode:
- `standard` — bare pytest (local iteration); children inherit env unchanged.
- `ci` — strips `OMPI_*` / `PMIX_*` / `PRTE_*` / `PRRTE_*` from the child env so the runner/producer detach from `prterun` and run as clean singletons. pytest itself never calls MPI_Init, so the job returns pytest's real exit code.

Auto-detected from launcher env vars and pinned explicitly by the matrix entry via `PREFILL_RUNNER_LAUNCH=ci`.

**3. Budget-neutral funding** (`tests/pipeline_reorg/blaze_models_prefill_tests.yaml`)
Reclaimed 20 min from three passed tests whose measured step times sit far below their allocation; each retains a generous margin:

| Test | Timeout (before → after) | Measured step | Margin |
|---|:---:|:---:|:---:|
| Kimi MoE | 35 → 25 | ~14.6 min | 1.7× |
| Kimi Prefill Block | 30 → 23 | ~12.2 min | 1.9× |
| KV cache table | 10 → 7 | ~2.2 min | 3.3× |

Net: `−20` from trims `+20` for the new job ⇒ `bh_sc1` budget unchanged at **480** (`.github/time_budget.yaml` has no net diff vs main).

**4. Dispatch registration** (`.github/workflows/blaze-models-prefill-tests.yaml`)
Added `prefill_runner` to the `workflow_dispatch` test-type list.

### Validation
On-galaxy run (`bh_sc1`), job exited **0 (SUCCESS)**:
- KV-cache PCC **min 0.966816 ≥ 0.93** across all 61 layers.
- Producer drained **671/671** layer acks (61 layers × 11 chunks) and read the 32-chip device map.
- End-to-end **~13:43**, comfortably inside the 20-min allocation.
- Confirmed the launch fix: stripping the launcher env vars made `mpirun` return pytest's real exit code (no more "abnormal termination").

### CI
- [ ] [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blaze-models-prefill-tests.yaml/badge.svg?branch=nbabin/runner_in_ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/blaze-models-prefill-tests.yaml?query=branch:nbabin/runner_in_ci)
- [ ] [![(Blackhole) e2e tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=nbabin/nbabin/runner_in_ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:nbabin/runner_in_ci)
- [ ] [![(Release) Model Status for Console Deployment](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml/badge.svg?branch=nbabin/runner_in_ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml?query=branch:nbabin/runner_in_ci)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nbabin/runner_in_ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nbabin/runner_in_ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nbabin/runner_in_ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nbabin/runner_in_ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=nbabin/runner_in_ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:nbabin/runner_in_ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nbabin/runner_in_ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nbabin/runner_in_ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nbabin/runner_in_ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nbabin/runner_in_ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nbabin/runner_in_ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nbabin/runner_in_ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nbabin/runner_in_ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nbabin/runner_in_ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nbabin/runner_in_ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nbabin/runner_in_ci)