### PR TITLE
[ttnn] Spec factory wins over descriptor when both present (pybind-op spec migration)

### DIFF
--- a/tests/ttnn/unit_tests/gtests/test_launch_operation.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_launch_operation.cpp
@@ -167,6 +167,21 @@ static_assert(!ttnn::device_operation::ProgramFactoryConcept<CustomProgramSpecFa
 static_assert(!ttnn::device_operation::MeshWorkloadFactoryConcept<CustomProgramSpecFactory>);
 static_assert(!ttnn::device_operation::ProgramDescriptorFactoryConcept<CustomProgramSpecFactory>);
 
+// A factory with both create_descriptor (kept for a pybind hook) and create_program_artifacts is
+// classified as a spec factory, not a descriptor factory — the spec wins.
+struct DescriptorAndSpecFactory {
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const OperationAttributes& /*attrs*/, const Tensor& /*tensor_args*/, Tensor& /*tensor_return_value*/) {
+        return {};
+    }
+    static ttnn::device_operation::ProgramArtifacts create_program_artifacts(
+        const OperationAttributes& /*attrs*/, const Tensor& /*tensor_args*/, Tensor& /*tensor_return_value*/) {
+        return ttnn::device_operation::ProgramArtifacts{};
+    }
+};
+static_assert(ttnn::device_operation::ProgramSpecFactoryConcept<DescriptorAndSpecFactory>);
+static_assert(!ttnn::device_operation::ProgramDescriptorFactoryConcept<DescriptorAndSpecFactory>);
+
 // Compile-coverage: taking the adapter methods' addresses ODR-uses them, forcing
 // the (otherwise un-instantiated) bodies to compile. Never dispatched.
 TEST(LaunchOperationTest, ProgramSpecAdapterCompiles) {

--- a/tests/ttnn/unit_tests/gtests/test_launch_operation.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_launch_operation.cpp
@@ -182,6 +182,32 @@ struct DescriptorAndSpecFactory {
 static_assert(ttnn::device_operation::ProgramSpecFactoryConcept<DescriptorAndSpecFactory>);
 static_assert(!ttnn::device_operation::ProgramDescriptorFactoryConcept<DescriptorAndSpecFactory>);
 
+// Same, but the spec factory is the CUSTOM variant (ProgramRunArgs-returning override_runtime_arguments):
+// it must classify as CustomProgramSpecFactoryConcept only — descriptor excluded (has
+// create_program_artifacts), base spec excluded (has the override).
+struct DescriptorAndCustomSpecFactory {
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const OperationAttributes& /*attrs*/, const Tensor& /*tensor_args*/, Tensor& /*tensor_return_value*/) {
+        return {};
+    }
+    static ttnn::device_operation::ProgramArtifacts create_program_artifacts(
+        const OperationAttributes& /*attrs*/, const Tensor& /*tensor_args*/, Tensor& /*tensor_return_value*/) {
+        return ttnn::device_operation::ProgramArtifacts{};
+    }
+    static tt::tt_metal::experimental::ProgramRunArgs override_runtime_arguments(
+        const OperationAttributes& /*attrs*/,
+        const Tensor& /*tensor_args*/,
+        Tensor& /*tensor_return_value*/,
+        const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/ = std::nullopt) {
+        return {};
+    }
+};
+static_assert(ttnn::device_operation::CustomProgramSpecFactoryConcept<DescriptorAndCustomSpecFactory>);
+static_assert(!ttnn::device_operation::ProgramSpecFactoryConcept<DescriptorAndCustomSpecFactory>);
+static_assert(!ttnn::device_operation::ProgramDescriptorFactoryConcept<DescriptorAndCustomSpecFactory>);
+static_assert(!ttnn::device_operation::ProgramFactoryConcept<DescriptorAndCustomSpecFactory>);
+static_assert(!ttnn::device_operation::MeshWorkloadFactoryConcept<DescriptorAndCustomSpecFactory>);
+
 // Compile-coverage: taking the adapter methods' addresses ODR-uses them, forcing
 // the (otherwise un-instantiated) bodies to compile. Never dispatched.
 TEST(LaunchOperationTest, ProgramSpecAdapterCompiles) {

--- a/ttnn/api/ttnn/operation_concepts.hpp
+++ b/ttnn/api/ttnn/operation_concepts.hpp
@@ -71,7 +71,11 @@ concept WorkloadDescriptorConcept = requires { &T::create_workload_descriptor; }
 
 template <typename T>
 concept ProgramDescriptorFactoryConcept = (requires { &T::create_descriptor; } || WorkloadDescriptorConcept<T>) &&
-                                          !ProgramFactoryConcept<T> && !MeshWorkloadFactoryConcept<T>;
+                                          !ProgramFactoryConcept<T> && !MeshWorkloadFactoryConcept<T> &&
+                                          // create_program_artifacts present => spec factory wins, so a
+                                          // create_descriptor kept only for a pybind hook won't pin the op
+                                          // to the descriptor path.
+                                          !requires { &T::create_program_artifacts; };
 
 // Metal 2.0 op-porting stepping-stone factory concept: factories that return
 // ProgramArtifacts (a ProgramSpec + ProgramRunArgs + any op-owned tensors) from


### PR DESCRIPTION
> **Stacked on #50942** (base = `dgomez/metal2-custom-program-spec-factory`). Diff is the concept change + its gtest (2 files).

### What

One-line change to `ProgramDescriptorFactoryConcept`: it now excludes any factory that also defines `create_program_artifacts`.

```cpp
concept ProgramDescriptorFactoryConcept =
    (requires { &T::create_descriptor; } || WorkloadDescriptorConcept<T>) &&
    !ProgramFactoryConcept<T> && !MeshWorkloadFactoryConcept<T> &&
    !requires { &T::create_program_artifacts; };   // spec wins when both present
```

So a factory that has **both** `create_descriptor` and `create_program_artifacts` is classified as a spec factory and dispatches through the spec adapter — the spec wins.

### Why

Migration mechanism for ops whose `create_descriptor` exists only to feed a **team-owned pybind introspection hook** (layernorm being the motivating case). Such an op migrates to specs by a **pure add**: write `create_program_artifacts`, leave `create_descriptor` and its pybind untouched. ttnn runs the spec; the descriptor remains as the pybind's artifact, owned and maintained by that team — ttnn does not keep the two in sync. No two-path burden on the ttnn op writer.

### Safety

- No current factory defines both methods in one struct — `reduce`, `binary_ng`, and the quasar `matmul` factories keep descriptor and spec in **separate** variant alternatives. So this is a **no-op reclassification for every existing op**.
- Full `./build_metal.sh` is green, which means every op still satisfies **exactly one** factory concept (`all_factories_valid` static_asserts fire per op at instantiation).
- gtest adds a factory with both methods and asserts it classifies as `ProgramSpecFactoryConcept`, not `ProgramDescriptorFactoryConcept`.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/spec-factory-precedence)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/spec-factory-precedence)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/spec-factory-precedence)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/spec-factory-precedence)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=dgomez/spec-factory-precedence)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:dgomez/spec-factory-precedence)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/spec-factory-precedence)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/spec-factory-precedence)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/spec-factory-precedence)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/spec-factory-precedence)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/spec-factory-precedence)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/spec-factory-precedence)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/spec-factory-precedence)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/spec-factory-precedence)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/spec-factory-precedence)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/spec-factory-precedence)