### PR TITLE
DS Prefill :: Improve fabric links usage for dispatch operation

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/perf/test_dispatch_combine_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_dispatch_combine_perf.py
@@ -49,14 +49,14 @@ _GLM52_CHUNK_PICKS = [
 # Key is (topo, nlinks, layer, col). Baselines are single tracy runs on LB 8x1
 # (run-to-run spread measured at ~0.5%, well inside the margins below).
 _DISPATCH_DS_CHUNK_EXPECTED_NS: dict[tuple[str, int, int, int], int] = {
-    ("linear", 2, 19, 2): 1_532_188,
-    ("linear", 2, 29, 0): 2_013_572,
-    ("linear", 2, 4, 2): 868_328,
-    ("linear", 2, 56, 3): 1_195_248,
-    ("ring", 2, 19, 2): 969_226,
-    ("ring", 2, 29, 0): 1_074_814,
-    ("ring", 2, 4, 2): 561_040,
-    ("ring", 2, 56, 3): 753_133,
+    ("linear", 2, 19, 2): 1_436_892,
+    ("linear", 2, 29, 0): 1_611_611,
+    ("linear", 2, 4, 2): 828_157,
+    ("linear", 2, 56, 3): 1_121_669,
+    ("ring", 2, 19, 2): 872_934,
+    ("ring", 2, 29, 0): 837_074,
+    ("ring", 2, 4, 2): 552_136,
+    ("ring", 2, 56, 3): 634_804,
 }
 _COMBINE_DS_CHUNK_EXPECTED_NS: dict[tuple[str, int, int, int], int] = {
     ("linear", 2, 19, 2): 1_716_614,
@@ -69,14 +69,14 @@ _COMBINE_DS_CHUNK_EXPECTED_NS: dict[tuple[str, int, int, int], int] = {
     ("ring", 2, 56, 3): 905_037,
 }
 _DISPATCH_KIMI_CHUNK_EXPECTED_NS: dict[tuple[str, int, int, int], int] = {
-    ("linear", 2, 45, 2): 1_525_048,
-    ("linear", 2, 48, 0): 2_051_422,
-    ("linear", 2, 30, 3): 984_699,
-    ("linear", 2, 32, 1): 813_274,
-    ("ring", 2, 45, 2): 1_011_584,
-    ("ring", 2, 48, 0): 995_205,
-    ("ring", 2, 30, 3): 594_741,
-    ("ring", 2, 32, 1): 623_676,
+    ("linear", 2, 45, 2): 1_236_188,
+    ("linear", 2, 48, 0): 1_459_057,
+    ("linear", 2, 30, 3): 788_904,
+    ("linear", 2, 32, 1): 797_993,
+    ("ring", 2, 45, 2): 878_836,
+    ("ring", 2, 48, 0): 806_776,
+    ("ring", 2, 30, 3): 553_826,
+    ("ring", 2, 32, 1): 555_157,
 }
 _COMBINE_KIMI_CHUNK_EXPECTED_NS: dict[tuple[str, int, int, int], int] = {
     ("linear", 2, 45, 2): 1_558_296,
@@ -90,14 +90,14 @@ _COMBINE_KIMI_CHUNK_EXPECTED_NS: dict[tuple[str, int, int, int], int] = {
 }
 
 _DISPATCH_GLM52_CHUNK_EXPECTED_NS: dict[tuple[str, int, int, int], int] = {
-    ("linear", 2, 3, 0): 3_219_833,
-    ("linear", 2, 8, 0): 1_399_270,
-    ("linear", 2, 14, 2): 838_546,
-    ("linear", 2, 10, 0): 809_860,
-    ("ring", 2, 3, 0): 2_006_807,
-    ("ring", 2, 8, 0): 977_686,
-    ("ring", 2, 14, 2): 543_524,
-    ("ring", 2, 10, 0): 512_407,
+    ("linear", 2, 3, 0): 1_859_463,
+    ("linear", 2, 8, 0): 1_331_674,
+    ("linear", 2, 14, 2): 766_664,
+    ("linear", 2, 10, 0): 819_157,
+    ("ring", 2, 3, 0): 1_247_679,
+    ("ring", 2, 8, 0): 815_378,
+    ("ring", 2, 14, 2): 493_043,
+    ("ring", 2, 10, 0): 473_592,
 }
 _COMBINE_GLM52_CHUNK_EXPECTED_NS: dict[tuple[str, int, int, int], int] = {
     ("linear", 2, 3, 0): 2_071_561,

--- a/models/demos/deepseek_v3_d_p/tests/perf/test_prefill_block_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_prefill_block_perf.py
@@ -104,7 +104,7 @@ _SUBTORUS_4X4_HOSTGATE_SKIP = pytest.mark.skip(
         ),
         (
             f"pytest {_TEST_PATH} -k 'mesh-2x4-2link and layer3 and gate_device and no_ref and isl_6k4'",
-            36_777_010,  # Re-centered 2026-07-27 for two stacked speedups now in the tree -- BOTH
+            35_655_993,  # Re-centered 2026-07-27 for two stacked speedups now in the tree -- BOTH
             # the in-place direct-write change (drop the separate output buffer + per-layer fill;
             # measured 50.61 ms alone) AND #47536 (update_padded_kv_cache RM/fp8; measured 51.29 ms
             # alone). The combined 2x4-2link number can't be measured on the galaxy, so the target is

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/reader_worker_dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/reader_worker_dispatch.cpp
@@ -92,7 +92,6 @@ void kernel_main() {
     constexpr uint32_t max_dispatch_buffer_token_size = get_compile_time_arg_val(19);
     constexpr uint32_t sender_core_idx = get_compile_time_arg_val(20);
     constexpr uint32_t num_sender_cores = get_compile_time_arg_val(21);
-    constexpr uint32_t core_mask = num_sender_cores - 1;
     // Batches are assigned round-robin (batch i -> core i % total_workers); all cores
     // grow offsets[] left-to-right from the single shared owner copy under the baton.
 
@@ -249,9 +248,12 @@ void kernel_main() {
     }
 #endif
 
-    // Variable that tracks the number of fabric sends. Used to determine which fabric
-    // link will be used to send the token to the destination device.
+    // Running counts of the two send classes, used to spread work round-robin across sender
+    // cores: fabric_sends_seen picks the fabric link for cross-device tokens, dram_writes_seen
+    // picks the writer core for local (DRAM) tokens. Balanced independently so each class is
+    // uniform on its own.
     uint32_t fabric_sends_seen = 0;
+    uint32_t dram_writes_seen = 0;
     for (uint32_t batch_idx = core_id; batch_idx < effective_total_batches; batch_idx += total_workers) {
         uint32_t batch_start = batch_idx * read_batch_size;
         uint32_t batch_end =
@@ -368,22 +370,12 @@ void kernel_main() {
                 uint32_t expert_chip = device_begin_idx + (uint32_t)expert_chip_og * device_stride;
                 bool expert_lives_on_this_chip = (expert_chip == linearized_mesh_coord);
 
-                // expert_lives_on_this_chip - does the expert we have to write to live on this chip, if so
-                // we write to DRAM.
-                // this_core_writes_token_to_expert - this worker core from this sender group should write,
-                // if so, then this core writes to DRAM, else, the other worker core from the other sender group writes
-                // to DRAM.
-                bool this_core_writes_token_to_expert = (((uint32_t)routed_expert & core_mask) == sender_core_idx);
-                if (expert_lives_on_this_chip && !this_core_writes_token_to_expert) {
-                    continue;
-                }
-
                 // Destination page in the expert's dispatch buffer, from offsets[e] (one per token:
-                // offset++). Both sender groups process the same entries in the same order, so their
+                // offset++). Every sender core processes the same entries in the same order, so their
                 // offsets[e] stay identical with no runtime sync — every core computes the SAME page
-                // for a given token. The send-split below then picks the one sender that forwards it,
-                // so the token is sent exactly once (no double-send). (Within a group, its workers
-                // share one offsets[] copy via the baton.)
+                // for a given token. The send-split below then picks the one sender that handles it,
+                // so the token is written/sent exactly once (no double-send). (Within a group, its
+                // workers share one offsets[] copy via the baton.)
                 // If the dispatch buffer for this expert is full, still bump the counter
                 // (so capacity accounting stays consistent) but drop the token — no entry.
                 uint32_t& offset = offsets[routed_expert];
@@ -393,10 +385,16 @@ void kernel_main() {
                 }
                 uint32_t page_idx = offset++;
 
-                // Calculate the target fabric link for the token that needs to be sent via fabric.
-                if (!expert_lives_on_this_chip) {
-                    // Decision whether the token will be forwarded via this link is in round-robin
-                    // fashion, in order for fabric links to be better balanced.
+                // Pick which sender core handles this token, round-robin so the work is spread evenly
+                // across sender cores. Balanced separately per class — local experts -> DRAM writes,
+                // remote experts -> fabric sends. Every sender core advances the same counter in
+                // lockstep, so exactly one core is selected per token (no double-send, no drop).
+                if (expert_lives_on_this_chip) {
+                    uint32_t target_writer_core = dram_writes_seen++ % num_sender_cores;
+                    if (target_writer_core != sender_core_idx) {
+                        continue;
+                    }
+                } else {
                     uint32_t target_fabric_link = fabric_sends_seen++ % num_sender_cores;
                     if (target_fabric_link != sender_core_idx) {
                         continue;

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/reader_worker_dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/reader_worker_dispatch.cpp
@@ -249,10 +249,8 @@ void kernel_main() {
     }
 #endif
 
-    // ===== Per-batch loop — this core handles batches core_id, core_id+total_workers, ... =====
-    // Running count of cross-device (fabric) plan entries seen; used to round-robin each remote send
-    // across the sender cores / links. Persists across batches. Every core counts the same entries in
-    // the same order, so they agree on which core emits which send.
+    // Variable that tracks the number of fabric sends. Used to determine which fabric
+    // link will be used to send the token to the destination device.
     uint32_t fabric_sends_seen = 0;
     for (uint32_t batch_idx = core_id; batch_idx < effective_total_batches; batch_idx += total_workers) {
         uint32_t batch_start = batch_idx * read_batch_size;

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/reader_worker_dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/reader_worker_dispatch.cpp
@@ -359,20 +359,29 @@ void kernel_main() {
             // dispatch core (after the ownership / mapping / capacity filters below).
             for (uint32_t k = 0; k < num_experts_per_tok; k++) {
                 int32_t routed_expert = indices_t[k];
-                // Skip experts not owned by this dispatch core (low bits of the expert id
-                // select the dispatch core), and experts the table maps nowhere (-1).
-                if (((uint32_t)routed_expert & core_mask) != dispatch_core_idx) {
-                    continue;
-                }
+                // Experts the table maps nowhere (-1) are dropped by every dispatch core.
                 int32_t expert_chip_og = expert_dispatch_table[routed_expert];
                 if (expert_chip_og == -1) {
                     continue;
                 }
+                uint32_t expert_chip = device_begin_idx + (uint32_t)expert_chip_og * device_stride;
+                bool is_local = (expert_chip == linearized_mesh_coord);
+
+                // Work split between the dispatch cores (= sender cores / fabric links):
+                //  - LOCAL tokens keep the expert-parity split: this core owns experts whose low bits
+                //    == dispatch_core_idx, and only the owner touches offsets[e] / emits them.
+                //  - REMOTE (fabric) tokens: EVERY dispatch core walks all of them and advances
+                //    offsets[e] identically, so page_idx stays globally consistent with no cross-core
+                //    sync (deterministic replica). But each core EMITS only its slice — chosen per
+                //    entry by (token_idx, k) — so the fabric sends split evenly across the links.
+                bool owned_local = (((uint32_t)routed_expert & core_mask) == dispatch_core_idx);
+                if (is_local && !owned_local) {
+                    continue;  // another dispatch core owns this local expert (parity split, unchanged)
+                }
 
                 // Allocate this token's destination DRAM page from the expert's counter.
-                // Single shared counter; all cores grow it left-to-right from offsets[e].
-                // If the dispatch buffer for this expert is full, still bump the counter
-                // (so capacity accounting stays consistent) but drop the token — no entry.
+                // If the dispatch buffer for this expert is full, still bump the counter (so capacity
+                // accounting stays consistent across cores) but drop the token — no entry.
                 uint32_t& offset = offsets[routed_expert];
                 if (offset >= max_dispatch_buffer_token_size) {
                     offset++;
@@ -380,8 +389,14 @@ void kernel_main() {
                 }
                 uint32_t page_idx = offset++;
 
-                uint32_t expert_chip = device_begin_idx + (uint32_t)expert_chip_og * device_stride;
-                bool is_local = (expert_chip == linearized_mesh_coord);
+                // Remote tokens: emit only this core's slice. offset was already advanced above (full
+                // walk on every core) so the page assignment is identical no matter who sends it.
+                if (!is_local) {
+                    uint32_t send_slot = token_idx * num_experts_per_tok + k;
+                    if ((send_slot % num_dispatch_cores) != dispatch_core_idx) {
+                        continue;
+                    }
+                }
 
                 volatile tt_l1_ptr PlanEntry* entry = &entries[entry_count];
                 entry->flags = is_local ? PLAN_FLAG_LOCAL : 0;

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/reader_worker_dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/reader_worker_dispatch.cpp
@@ -90,9 +90,9 @@ void kernel_main() {
     constexpr uint32_t num_experts_per_tok = get_compile_time_arg_val(17);
     constexpr uint32_t n_routed_experts = get_compile_time_arg_val(18);
     constexpr uint32_t max_dispatch_buffer_token_size = get_compile_time_arg_val(19);
-    constexpr uint32_t dispatch_core_idx = get_compile_time_arg_val(20);
-    constexpr uint32_t num_dispatch_cores = get_compile_time_arg_val(21);
-    constexpr uint32_t core_mask = num_dispatch_cores - 1;
+    constexpr uint32_t sender_core_idx = get_compile_time_arg_val(20);
+    constexpr uint32_t num_sender_cores = get_compile_time_arg_val(21);
+    constexpr uint32_t core_mask = num_sender_cores - 1;
     // Batches are assigned round-robin (batch i -> core i % total_workers); all cores
     // grow offsets[] left-to-right from the single shared owner copy under the baton.
 
@@ -215,7 +215,7 @@ void kernel_main() {
     uint32_t turn_expected = 1;  // per-core baton counter; +1 for each batch this core handles
     DPRINT_DISPATCH(
         "[R s={} c={}] startup done; owner={} total_batches={} total_workers={}\n",
-        (uint32_t)dispatch_core_idx,
+        (uint32_t)sender_core_idx,
         (uint32_t)core_id,
         (uint32_t)IS_OWNER,
         (uint32_t)total_batches,
@@ -250,6 +250,10 @@ void kernel_main() {
 #endif
 
     // ===== Per-batch loop — this core handles batches core_id, core_id+total_workers, ... =====
+    // Running count of cross-device (fabric) plan entries seen; used to round-robin each remote send
+    // across the sender cores / links. Persists across batches. Every core counts the same entries in
+    // the same order, so they agree on which core emits which send.
+    uint32_t fabric_sends_seen = 0;
     for (uint32_t batch_idx = core_id; batch_idx < effective_total_batches; batch_idx += total_workers) {
         uint32_t batch_start = batch_idx * read_batch_size;
         uint32_t batch_end =
@@ -320,7 +324,7 @@ void kernel_main() {
         // 4. Build per-batch route plan into c_14.
         DPRINT_DISPATCH(
             "[R s={} c={}] b={} reserving plan slot (blocks on writer drain)\n",
-            (uint32_t)dispatch_core_idx,
+            (uint32_t)sender_core_idx,
             (uint32_t)core_id,
             batch_idx);
         cb_reserve_back(cb_plan_id, 1);
@@ -332,13 +336,13 @@ void kernel_main() {
 
         DPRINT_DISPATCH(
             "[R s={} c={}] b={} WAIT baton (turn_sem>={}, have={})\n",
-            (uint32_t)dispatch_core_idx,
+            (uint32_t)sender_core_idx,
             (uint32_t)core_id,
             batch_idx,
             turn_expected,
             (uint32_t)(*turn_sem_ptr));
         noc_semaphore_wait_min(turn_sem_ptr, turn_expected);
-        DPRINT_DISPATCH("[R s={} c={}] b={} GOT baton\n", (uint32_t)dispatch_core_idx, (uint32_t)core_id, batch_idx);
+        DPRINT_DISPATCH("[R s={} c={}] b={} GOT baton\n", (uint32_t)sender_core_idx, (uint32_t)core_id, batch_idx);
         turn_expected++;
         if constexpr (!IS_OWNER) {
             noc.async_read(
@@ -359,29 +363,30 @@ void kernel_main() {
             // dispatch core (after the ownership / mapping / capacity filters below).
             for (uint32_t k = 0; k < num_experts_per_tok; k++) {
                 int32_t routed_expert = indices_t[k];
-                // Experts the table maps nowhere (-1) are dropped by every dispatch core.
+
                 int32_t expert_chip_og = expert_dispatch_table[routed_expert];
                 if (expert_chip_og == -1) {
                     continue;
                 }
                 uint32_t expert_chip = device_begin_idx + (uint32_t)expert_chip_og * device_stride;
-                bool is_local = (expert_chip == linearized_mesh_coord);
+                bool expert_lives_on_this_chip = (expert_chip == linearized_mesh_coord);
 
-                // Work split between the dispatch cores (= sender cores / fabric links):
-                //  - LOCAL tokens keep the expert-parity split: this core owns experts whose low bits
-                //    == dispatch_core_idx, and only the owner touches offsets[e] / emits them.
-                //  - REMOTE (fabric) tokens: EVERY dispatch core walks all of them and advances
-                //    offsets[e] identically, so page_idx stays globally consistent with no cross-core
-                //    sync (deterministic replica). But each core EMITS only its slice — chosen per
-                //    entry by (token_idx, k) — so the fabric sends split evenly across the links.
-                bool owned_local = (((uint32_t)routed_expert & core_mask) == dispatch_core_idx);
-                if (is_local && !owned_local) {
-                    continue;  // another dispatch core owns this local expert (parity split, unchanged)
+                // expert_lives_on_this_chip - does the expert we have to write to live on this chip, if so
+                // we write to DRAM.
+                // this_core_writes_token_to_expert - this worker core from this sender group should write,
+                // if so, then this core writes to DRAM, else, the other worker core from the other sender group writes
+                // to DRAM.
+                bool this_core_writes_token_to_expert = (((uint32_t)routed_expert & core_mask) == sender_core_idx);
+                if (expert_lives_on_this_chip && !this_core_writes_token_to_expert) {
+                    continue;
                 }
 
-                // Allocate this token's destination DRAM page from the expert's counter.
-                // If the dispatch buffer for this expert is full, still bump the counter (so capacity
-                // accounting stays consistent across cores) but drop the token — no entry.
+                // Allocate this token's destination DRAM page from the expert's counter. offsets[e]
+                // grows left-to-right: shared within a group via the baton, and replicated identically
+                // across groups (every core walks all remote experts), so a token lands on the same
+                // page no matter which core sends it.
+                // If the dispatch buffer for this expert is full, still bump the counter
+                // (so capacity accounting stays consistent across cores) but drop the token — no entry.
                 uint32_t& offset = offsets[routed_expert];
                 if (offset >= max_dispatch_buffer_token_size) {
                     offset++;
@@ -391,15 +396,17 @@ void kernel_main() {
 
                 // Remote tokens: emit only this core's slice. offset was already advanced above (full
                 // walk on every core) so the page assignment is identical no matter who sends it.
-                if (!is_local) {
-                    uint32_t send_slot = token_idx * num_experts_per_tok + k;
-                    if ((send_slot % num_dispatch_cores) != dispatch_core_idx) {
+                if (!expert_lives_on_this_chip) {
+                    // Round-robin each fabric send across the links: 0,1,…,L-1,0,… — an exact even
+                    // split, since every core advances the same counter over the same remote entries.
+                    uint32_t target_fabric_link = fabric_sends_seen++ % num_sender_cores;
+                    if (target_fabric_link != sender_core_idx) {
                         continue;
                     }
                 }
 
                 volatile tt_l1_ptr PlanEntry* entry = &entries[entry_count];
-                entry->flags = is_local ? PLAN_FLAG_LOCAL : 0;
+                entry->flags = expert_lives_on_this_chip ? PLAN_FLAG_LOCAL : 0;
                 entry->token_t = t;
                 entry->routed_expert = (uint32_t)routed_expert;
                 entry->page_idx = page_idx;
@@ -411,7 +418,7 @@ void kernel_main() {
                 // writer recomputes the EDM direction and (mesh,chip) header from it.
                 entry->dst_chip = expert_chip;
 
-                if (!is_local) {
+                if (!expert_lives_on_this_chip) {
                     if constexpr (is_1d_topology<topology>()) {
                         entry->route = get_route<topology, mesh_rows, mesh_cols>(linearized_mesh_coord, expert_chip);
                         entry->distance =
@@ -442,14 +449,14 @@ void kernel_main() {
             noc_semaphore_inc(next_turn_sem_noc_addr, 1);
             DPRINT_DISPATCH(
                 "[R s={} c={}] b={} RELEASE baton -> signaled next (entries={})\n",
-                (uint32_t)dispatch_core_idx,
+                (uint32_t)sender_core_idx,
                 (uint32_t)core_id,
                 batch_idx,
                 entry_count);
         } else {
             DPRINT_DISPATCH(
                 "[R s={} c={}] b={} RELEASE baton -> LAST batch, no signal (entries={})\n",
-                (uint32_t)dispatch_core_idx,
+                (uint32_t)sender_core_idx,
                 (uint32_t)core_id,
                 batch_idx,
                 entry_count);
@@ -461,7 +468,7 @@ void kernel_main() {
 
     // Teardown: all batches done — push the two end-of-stream sentinels this core's
     // consumers wait on.
-    DPRINT_DISPATCH("[R s={} c={}] loop DONE -> pushing sentinels\n", (uint32_t)dispatch_core_idx, (uint32_t)core_id);
+    DPRINT_DISPATCH("[R s={} c={}] loop DONE -> pushing sentinels\n", (uint32_t)sender_core_idx, (uint32_t)core_id);
 #ifndef ROW_MAJOR_INPUT
     // (1) Sentinel value to compute so it breaks out of its untilize loop. Row-major has no compute
     //     kernel, so this signal is skipped entirely.

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/reader_worker_dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/reader_worker_dispatch.cpp
@@ -363,7 +363,6 @@ void kernel_main() {
             // dispatch core (after the ownership / mapping / capacity filters below).
             for (uint32_t k = 0; k < num_experts_per_tok; k++) {
                 int32_t routed_expert = indices_t[k];
-
                 int32_t expert_chip_og = expert_dispatch_table[routed_expert];
                 if (expert_chip_og == -1) {
                     continue;
@@ -381,12 +380,14 @@ void kernel_main() {
                     continue;
                 }
 
-                // Allocate this token's destination DRAM page from the expert's counter. offsets[e]
-                // grows left-to-right: shared within a group via the baton, and replicated identically
-                // across groups (every core walks all remote experts), so a token lands on the same
-                // page no matter which core sends it.
+                // Destination page in the expert's dispatch buffer, from offsets[e] (one per token:
+                // offset++). Both sender groups process the same entries in the same order, so their
+                // offsets[e] stay identical with no runtime sync — every core computes the SAME page
+                // for a given token. The send-split below then picks the one sender that forwards it,
+                // so the token is sent exactly once (no double-send). (Within a group, its workers
+                // share one offsets[] copy via the baton.)
                 // If the dispatch buffer for this expert is full, still bump the counter
-                // (so capacity accounting stays consistent across cores) but drop the token — no entry.
+                // (so capacity accounting stays consistent) but drop the token — no entry.
                 uint32_t& offset = offsets[routed_expert];
                 if (offset >= max_dispatch_buffer_token_size) {
                     offset++;
@@ -394,11 +395,10 @@ void kernel_main() {
                 }
                 uint32_t page_idx = offset++;
 
-                // Remote tokens: emit only this core's slice. offset was already advanced above (full
-                // walk on every core) so the page assignment is identical no matter who sends it.
+                // Calculate the target fabric link for the token that needs to be sent via fabric.
                 if (!expert_lives_on_this_chip) {
-                    // Round-robin each fabric send across the links: 0,1,…,L-1,0,… — an exact even
-                    // split, since every core advances the same counter over the same remote entries.
+                    // Decision whether the token will be forwarded via this link is in round-robin
+                    // fashion, in order for fabric links to be better balanced.
                     uint32_t target_fabric_link = fabric_sends_seen++ % num_sender_cores;
                     if (target_fabric_link != sender_core_idx) {
                         continue;


### PR DESCRIPTION
## Summary

Dispatch sends each token to the device that hosts its routed expert over one of the chip's two **fabric links**. This PR changes how that link is chosen so both links are used evenly — which speeds the op.skewed.

---

## What changed

> **Before — link chosen by expert id.**
> The link was derived from the expert id: each sender group owned a fixed set of experts (the low bits of the id), so every token routed to those experts left over that group's link. A token's link was fixed by *which expert it hit*.

> **Now — link chosen round-robin.**
> Each cross-device send is handed to the next link in turn (`link0 → link1 → link0 → …`), independent of the expert.

---

## Speedup on `test_dispatch_combine_perf`

DispatchDeviceOperation device-kernel time. Routing captured from a real 5k-chunked prefill run for both DeepSeek-V3 and Kimi-K2.6 - these numbers, layers, and columns all come from that. main = base, branch = this PR.

<details>
<summary><h3>🟦 GLX firmware (200 Gb/s ETH) — dsv3, kimik26 and glm52</h3></summary>

**DeepSeek-V3**

| Config | main (ns) | branch (ns) | Improvement |
|---|--:|--:|--:|
| Linear l19, col2 | 2,157,141 | 1,968,341 | −8.8% |
| Linear l29, col0 | 2,760,607 | 2,117,101 | −23.3% |
| Linear l4, col2 | 1,139,236 | 1,091,836 | −4.2% |
| Linear l56, col3 | 1,729,994 | 1,499,879 | −13.3% |
| Ring l19, col2 | 1,260,976 | 1,013,153 | −19.7% |
| Ring l29, col0 | 1,338,769 | 1,025,773 | −23.4% |
| Ring l4, col2 | 578,793 | 581,264 | +0.4% |
| Ring l56, col3 | 836,373 | 733,665 | −12.3% |
| **Average** | | | **−13.1%** |

**Kimi-K2.6**

| Config | main (ns) | branch (ns) | Improvement |
|---|--:|--:|--:|
| Linear l45, col2 | 2,086,303 | 1,644,646 | −21.2% |
| Linear l48, col0 | 2,928,396 | 1,961,149 | −33.0% |
| Linear l30, col3 | 1,394,802 | 1,022,961 | −26.7% |
| Linear l32, col1 | 1,148,426 | 1,073,730 | −6.5% |
| Ring l45, col2 | 1,463,779 | 1,073,839 | −26.6% |
| Ring l48, col0 | 1,389,241 | 912,226 | −34.3% |
| Ring l30, col3 | 718,244 | 579,706 | −19.3% |
| Ring l32, col1 | 664,865 | 592,847 | −10.8% |
| **Average** | | | **−22.3%** |

**GLM-5.2**

| Config | main (ns) | branch (ns) | Improvement |
|---|--:|--:|--:|
| Linear l3, col0 | 4,346,871 | 2,452,901 | −43.6% |
| Linear l8, col0 | 1,904,221 | 1,763,907 | −7.4% |
| Linear l14, col2 | 1,121,052 | 996,179 | −11.1% |
| Linear l10, col0 | 1,058,893 | 1,072,323 | +1.3% |
| Ring l3, col0 | 2,510,554 | 1,453,847 | −42.1% |
| Ring l8, col0 | 1,241,545 | 1,034,697 | −16.7% |
| Ring l14, col2 | 621,806 | 524,507 | −15.6% |
| Ring l10, col0 | 578,028 | 571,189 | −1.2% |
| **Average** | | | **−17.0%** |

</details>

<details>
<summary><h3>🟩 LB firmware (400 Gb/s ETH) — dsv3, kimik26 and glm52</h3></summary>

**DeepSeek-V3**

| Config | main (ns) | branch (ns) | Improvement |
|---|--:|--:|--:|
| Linear l19, col2 | 1,537,040 | 1,493,919 | −2.8% |
| Linear l29, col0 | 1,922,337 | 1,549,952 | −19.4% |
| Linear l42, col3 | 1,565,324 | 1,236,901 | −21.0% |
| Linear l24, col1 | 1,309,013 | 1,259,583 | −3.8% |
| Ring l19, col2 | 1,038,929 | 850,397 | −18.1% |
| Ring l29, col0 | 1,075,967 | 836,906 | −22.2% |
| Ring l42, col3 | 880,931 | 812,908 | −7.7% |
| Ring l24, col1 | 822,824 | 752,964 | −8.5% |
| **Average** | | | **−12.9%** |

**Kimi-K2.6**

| Config | main (ns) | branch (ns) | Improvement |
|---|--:|--:|--:|
| Linear l45, col2 | 1,442,864 | 1,201,752 | −16.7% |
| Linear l48, col0 | 1,957,441 | 1,427,822 | −27.1% |
| Linear l44, col1 | 1,490,306 | 1,202,053 | −19.3% |
| Linear l50, col1 | 1,461,867 | 1,308,940 | −10.5% |
| Ring l45, col2 | 1,007,091 | 864,817 | −14.1% |
| Ring l48, col0 | 1,012,609 | 793,813 | −21.6% |
| Ring l44, col1 | 1,371,579 | 1,027,117 | −25.1% |
| Ring l50, col1 | 1,046,244 | 858,198 | −18.0% |
| **Average** | | | **−19.0%** |

**GLM-5.2**

| Config | main (ns) | branch (ns) | Improvement |
|---|--:|--:|--:|
| Linear l3, col0 | 3,219,833 | 1,850,313 | −42.5% |
| Linear l8, col0 | 1,399,270 | 1,342,051 | −4.1% |
| Linear l14, col2 | 838,546 | 761,860 | −9.1% |
| Linear l10, col0 | 809,860 | 826,114 | +2.0% |
| Ring l3, col0 | 2,006,807 | 1,244,513 | −38.0% |
| Ring l8, col0 | 977,686 | 819,050 | −16.2% |
| Ring l14, col2 | 543,524 | 485,326 | −10.7% |
| Ring l10, col0 | 512,407 | 472,710 | −7.7% |
| **Average** | | | **−15.8%** |

</details>

---

## E2E difference

## KimiK2.6

```text
Kimi K2.6 - L61, 11 chunks x 5120 (code_debug 55k), median of 9 iters   [negative = dispatch opt faster]
+-----------------+-------------+-----------------------+--------------------+------------+
| chunk           | main        | dispatch optimization | delta (opt - main) | delta %    |
+-----------------+-------------+-----------------------+--------------------+------------+
| chunk 0         |   1.177s    |   1.170s              |   -0.007s          |   -0.59%   |
| chunk 1         |   1.247s    |   1.243s              |   -0.004s          |   -0.32%   |
| chunk 2         |   1.255s    |   1.261s              |   +0.006s          |   +0.48%   |
| chunk 3         |   1.247s    |   1.241s              |   -0.006s          |   -0.48%   |
| chunk 4         |   1.273s    |   1.236s              |   -0.037s          |   -2.91%   |
| chunk 5         |   1.259s    |   1.242s              |   -0.017s          |   -1.35%   |
| chunk 6         |   1.240s    |   1.248s              |   +0.008s          |   +0.65%   |
| chunk 7         |   1.251s    |   1.246s              |   -0.005s          |   -0.40%   |
| chunk 8         |   1.264s    |   1.254s              |   -0.010s          |   -0.79%   |
| chunk 9         |   1.253s    |   1.248s              |   -0.005s          |   -0.40%   |
| chunk 10        |   1.241s    |   1.241s              |   +0.000s          |   +0.00%   |
| TOTAL 56320 tok |   13.707s   |   13.630s             |   -0.077s          |   -0.56%   |
+-----------------+-------------+-----------------------+--------------------+------------+
```

## GLM-5.2

```text
GLM-5.2 - L78, 11 chunks x 5120 (code_debug 55k), median of 9 iters   [negative = dispatch opt faster]
+-----------------+-------------+-----------------------+--------------------+------------+
| chunk           | main        | dispatch optimization | delta (opt - main) | delta %    |
+-----------------+-------------+-----------------------+--------------------+------------+
| chunk 0         |   2.140s    |   2.083s              |   -0.057s          |   -2.66%   |
| chunk 1         |   2.218s    |   2.181s              |   -0.037s          |   -1.67%   |
| chunk 2         |   2.208s    |   2.182s              |   -0.026s          |   -1.18%   |
| chunk 3         |   2.228s    |   2.172s              |   -0.056s          |   -2.51%   |
| chunk 4         |   2.221s    |   2.185s              |   -0.036s          |   -1.62%   |
| chunk 5         |   2.220s    |   2.185s              |   -0.035s          |   -1.58%   |
| chunk 6         |   2.215s    |   2.180s              |   -0.035s          |   -1.58%   |
| chunk 7         |   2.212s    |   2.171s              |   -0.041s          |   -1.85%   |
| chunk 8         |   2.232s    |   2.186s              |   -0.046s          |   -2.06%   |
| chunk 9         |   2.221s    |   2.174s              |   -0.047s          |   -2.12%   |
| chunk 10        |   2.225s    |   2.189s              |   -0.036s          |   -1.62%   |
| TOTAL 56320 tok |   24.340s   |   23.888s             |   -0.452s          |   -1.86%   |
+-----------------+-------------+-----------------------+--------------------+------------+
```

---

## Why it's better

Previously, we could have a situation where more tokens had to be sent to experts that should be sent via one fabric link. While one fabric link could get a lot more work then the second one, it caused the imbalance of load and the dispatch operation lasting longer since we were fabric bound.

---

## How it works

Dispatch builds a plan of cross-device sends, then assigns them to links in turn. Take a worst-case plan where every token routes to the same experts — all owned by one link under the old scheme:

In other words, tokens should be sent to experts and when we chose which sender will send the token, it would fall to the sender on link1 to send that token.

```
plan  (token -> routed experts)
  token0 -> e0, e2, e4, e6
  token1 -> e0, e2, e4, e6
  token2 -> e0, e2, e4, e6
  token3 -> e0, e2, e4, e6
```

**Before — one link does everything.** `e0, e2, e4, e6` are all owned by `link0`, so every send leaves over `link0`:

```
  link0:  ALL 16 sends   (t0e0 t0e2 t0e4 t0e6  t1e0 ... t3e6)
  link1:  idle
```

*Two sender cores — only one is issuing fabric sends:*
<img width="1600" height="291" alt="image" src="https://github.com/user-attachments/assets/8c8f2461-2e0a-4787-8748-295816a636a0" />

**Now — both links share the load.** Each send in turn goes to the next link, so both carry half the traffic instead of one link doing all of it:

```
  send:  t0e0 t0e2 t0e4 t0e6  t1e0 t1e2 t1e4 t1e6  ...
  link:   L0   L1   L0   L1    L0   L1   L0   L1   ...

  link0:  8 sends
  link1:  8 sends
```

*Both sender cores now issue fabric sends:*
<img width="1600" height="334" alt="image" src="https://github.com/user-attachments/assets/44ca1fdd-4467-4abb-b159-f9434a242b86" />

---

## Measured impact

This is exactly that worst case — a routing where every token hits a single expert, so all sends collapse onto one link before this change:

| Dispatch device time | Before (`main`) | Now (this PR) | Speedup |
|---|--:|--:|--:|
| Worst case — all sends on one link | 76.24 ms | 40.38 ms | **−47%** |

---

## Plan-building overhead (hidden behind fabric)

Building the send plan on the reader core costs slightly more now: in `reader_worker_dispatch.cpp` the reader walks each token's routed experts and, for every cross-device send, picks the target link round-robin (`fabric_sends_seen++ % num_sender_cores`) — a little more per-entry work than the old fixed expert→link mapping. This shows up as a marginally longer `reader_build_plan` zone:

| `reader_build_plan` per instance | main (ns) | branch (ns) |
|---|--:|--:|
| min | 344 | 764 |
| mean | 625 | 865 |
| max | 879 | 935 |

That extra time is effectively free. The reader is the producer in a producer/consumer pipeline: it builds a plan and hands it to the writer core over the plan CB (`cb_push_back`), and the writer is the one that issues the actual fabric sends. Wall-clock is dominated by those fabric sends, and the reader builds the next batch's plan while the writer is still draining the current one — so the longer plan-building is hidden behind fabric latency and does not add to the op's runtime.

---

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=nostojc/dispatch_link_usage_improvement)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:nostojc/dispatch_link_usage_improvement)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blaze-models-prefill-tests.yaml/badge.svg?branch=nostojc/dispatch_link_usage_improvement)](https://github.com/tenstorrent/tt-metal/actions/workflows/blaze-models-prefill-tests.yaml?query=branch:nostojc/dispatch_link_usage_improvement)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml/badge.svg?branch=nostojc/dispatch_link_usage_improvement)](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml?query=branch:nostojc/dispatch_link_usage_improvement)

Relevant tests are passing - all failed tests were known at the time CI was ran

## CI Status

_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nostojc/dispatch_link_usage_improvement)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nostojc/dispatch_link_usage_improvement)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nostojc/dispatch_link_usage_improvement)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nostojc/dispatch_link_usage_improvement)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=nostojc/dispatch_link_usage_improvement)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:nostojc/dispatch_link_usage_improvement)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nostojc/dispatch_link_usage_improvement)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nostojc/dispatch_link_usage_improvement)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nostojc/dispatch_link_usage_improvement)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nostojc/dispatch_link_usage_improvement)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nostojc/dispatch_link_usage_improvement)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nostojc/dispatch_link_usage_improvement)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nostojc/dispatch_link_usage_improvement)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nostojc/dispatch_link_usage_improvement)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nostojc/dispatch_link_usage_improvement)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nostojc/dispatch_link_usage_improvement)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nostojc/dispatch_link_usage_improvement)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nostojc/dispatch_link_usage_improvement)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nostojc/dispatch_link_usage_improvement)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nostojc/dispatch_link_usage_improvement)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=nostojc/dispatch_link_usage_improvement)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:nostojc/dispatch_link_usage_improvement)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nostojc/dispatch_link_usage_improvement)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nostojc/dispatch_link_usage_improvement)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nostojc/dispatch_link_usage_improvement)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nostojc/dispatch_link_usage_improvement)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nostojc/dispatch_link_usage_improvement)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nostojc/dispatch_link_usage_improvement)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nostojc/dispatch_link_usage_improvement)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nostojc/dispatch_link_usage_improvement)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nostojc/dispatch_link_usage_improvement)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nostojc/dispatch_link_usage_improvement)



