### PR TITLE
Fix undefined `cb_id` in Quasar-DM reduce-scaler flush (use dfb_id)

### DIFF
--- a/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_dataflow.inl
+++ b/ttnn/cpp/ttnn/kernel_lib/reduce_helpers_dataflow.inl
@@ -196,7 +196,7 @@ FORCE_INLINE void prepare_reduce_scaler(float scaler_f, uint32_t valid_reduce_di
     // On non-Quasar (or non-DM) builds this is a no-op.
 #if defined(ARCH_QUASAR) && defined(COMPILE_FOR_DM)
     {
-        constexpr uint32_t tile_size_bytes = get_tile_size(cb_id);
+        constexpr uint32_t tile_size_bytes = get_tile_size(dfb_id);
         flush_l2_cache_range(write_addr, tile_size_bytes);
     }
 #endif


### PR DESCRIPTION
## What
`prepare_reduce_scaler<uint32_t dfb_id, ...>` in `ttnn/cpp/ttnn/kernel_lib/reduce_helpers_dataflow.inl:199` referenced `cb_id` in its `ARCH_QUASAR && COMPILE_FOR_DM` L1-coherency flush. `cb_id` is undefined in scope — the template parameter is `dfb_id` (used everywhere else, e.g. `get_tile_size(dfb_id)` at line 184). Under Quasar-DM the TU fails to compile; latent because every non-Quasar build preprocesses the block out, leaving the required scaler-tile cache flush effectively absent for Quasar-DM.

## Fix
One token: `get_tile_size(cb_id)` → `get_tile_size(dfb_id)`.

## Verification
Language-level fail-without/pass-with confirmed on a faithful minimal model of the templated scope: `get_tile_size(cb_id)` → `error: use of undeclared identifier 'cb_id'; did you mean 'dfb_id'?`; `get_tile_size(dfb_id)` → clean. Non-Quasar builds unaffected (block is `#if`-gated off), so no functional change on WH/BH.

A real Quasar-DM JIT compile + a regression test that exercises the flush path need the Quasar build/sim environment (not available on the box used here) — tracked as follow-up in the sub-issue.

Closes #51023. Finding #14 of #50974.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amahmud/quasar-reduce-scaler-dfb-id)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amahmud/quasar-reduce-scaler-dfb-id)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amahmud/quasar-reduce-scaler-dfb-id)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amahmud/quasar-reduce-scaler-dfb-id)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=amahmud/quasar-reduce-scaler-dfb-id)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:amahmud/quasar-reduce-scaler-dfb-id)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amahmud/quasar-reduce-scaler-dfb-id)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amahmud/quasar-reduce-scaler-dfb-id)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amahmud/quasar-reduce-scaler-dfb-id)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amahmud/quasar-reduce-scaler-dfb-id)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amahmud/quasar-reduce-scaler-dfb-id)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amahmud/quasar-reduce-scaler-dfb-id)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amahmud/quasar-reduce-scaler-dfb-id)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amahmud/quasar-reduce-scaler-dfb-id)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amahmud/quasar-reduce-scaler-dfb-id)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amahmud/quasar-reduce-scaler-dfb-id)