### PR TITLE
Update matmul multicast test kernels for CircularBuffer AddrSelector API

### DIFF
--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_matmul_tile_layout_in0_receiver_in1_sender.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_matmul_tile_layout_in0_receiver_in1_sender.cpp
@@ -135,8 +135,8 @@ void kernel_main() {
         // Now we have the block in the CB address, we can mcast to dests!
         // num_dests must not include source, since we are NOT really doing a local copy!
         noc.async_write_multicast(
-            use<CircularBuffer::AddrSel::WRITE_PTR>(cb_in1),
-            use<CircularBuffer::AddrSel::WRITE_PTR>(cb_in1),
+            use<CircularBuffer::AddrSelector::WRITE_PTR>(cb_in1),
+            use<CircularBuffer::AddrSelector::WRITE_PTR>(cb_in1),
             in1_block_size_bytes,
             in1_mcast_num_dests,
             {},

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_matmul_tile_layout_in0_sender_in1_receiver.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_matmul_tile_layout_in0_sender_in1_receiver.cpp
@@ -123,8 +123,8 @@ void kernel_main() {
         // Now we have the block in the CB address, we can mcast to dests!
         // num_dests must not include source, since we are NOT really doing a local copy!
         noc.async_write_multicast(
-            use<CircularBuffer::AddrSel::WRITE_PTR>(cb_in0),
-            use<CircularBuffer::AddrSel::WRITE_PTR>(cb_in0),
+            use<CircularBuffer::AddrSelector::WRITE_PTR>(cb_in0),
+            use<CircularBuffer::AddrSelector::WRITE_PTR>(cb_in0),
             in0_block_size_bytes,
             in0_mcast_num_dests,
             {},

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_matmul_tile_layout_in0_sender_in1_sender.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_matmul_tile_layout_in0_sender_in1_sender.cpp
@@ -128,8 +128,8 @@ void kernel_main() {
         // Now we have the block in the CB address, we can mcast to dests!
         // num_dests must not include source, since we are NOT really doing a local copy!
         noc.async_write_multicast(
-            use<CircularBuffer::AddrSel::WRITE_PTR>(cb_in0),
-            use<CircularBuffer::AddrSel::WRITE_PTR>(cb_in0),
+            use<CircularBuffer::AddrSelector::WRITE_PTR>(cb_in0),
+            use<CircularBuffer::AddrSelector::WRITE_PTR>(cb_in0),
             in0_block_size_bytes,
             in0_mcast_num_dests,
             {},
@@ -194,8 +194,8 @@ void kernel_main() {
         // Now we have the block in the CB address, we can mcast to dests!
         // num_dests must not include source, since we are NOT really doing a local copy!
         noc.async_write_multicast(
-            use<CircularBuffer::AddrSel::WRITE_PTR>(cb_in1),
-            use<CircularBuffer::AddrSel::WRITE_PTR>(cb_in1),
+            use<CircularBuffer::AddrSelector::WRITE_PTR>(cb_in1),
+            use<CircularBuffer::AddrSelector::WRITE_PTR>(cb_in1),
             in1_block_size_bytes,
             in1_mcast_num_dests,
             {},


### PR DESCRIPTION
### PR Category
Test Only

### Summary
Three matmul multicast dataflow test kernels still referenced the old `CircularBuffer::AddrSel::WRITE_PTR` name when issuing `noc.async_write_multicast` from a CB write pointer. After the circular-buffer API moved to `CircularBuffer::AddrSelector`, these kernels no longer built when the corresponding integration tests JIT-compiled them, blocking the `TensixMatmulMultiCoreMultiDRAMIn0MCastIn1MCast` coverage. This change updates the stale enum name to `CircularBuffer::AddrSelector::WRITE_PTR` in the affected reader kernels without changing the generated multicast behavior.

### Notes for reviewers
none

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mcraighead/matmul-kernel-cb-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mcraighead/matmul-kernel-cb-api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mcraighead/matmul-kernel-cb-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mcraighead/matmul-kernel-cb-api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mcraighead/matmul-kernel-cb-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mcraighead/matmul-kernel-cb-api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mcraighead/matmul-kernel-cb-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mcraighead/matmul-kernel-cb-api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mcraighead/matmul-kernel-cb-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mcraighead/matmul-kernel-cb-api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mcraighead/matmul-kernel-cb-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mcraighead/matmul-kernel-cb-api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mcraighead/matmul-kernel-cb-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mcraighead/matmul-kernel-cb-api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mcraighead/matmul-kernel-cb-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mcraighead/matmul-kernel-cb-api)