### PR TITLE
Store welford cb_combined tile through volatile pointer

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/quasar/reduction/generic/device/kernels/dataflow/writer_welford_hw.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/reduction/generic/device/kernels/dataflow/writer_welford_hw.cpp
@@ -125,7 +125,7 @@ void kernel_main() {
         // L1 contents there are harmless.
         cb_combined_obj.reserve_back(1);
         if constexpr (combined_is_bf16) {
-            auto* combined_ptr = reinterpret_cast<uint16_t*>(cb_combined_obj.get_write_ptr());
+            auto* combined_ptr = reinterpret_cast<volatile uint16_t*>(cb_combined_obj.get_write_ptr());
             for (uint32_t i = 0; i < FACE_W; ++i) {
                 combined_ptr[i] = 0;
             }
@@ -133,7 +133,7 @@ void kernel_main() {
             // hardware so the output is bit-identical to a packer-produced bf16.
             combined_ptr[0] = fp32_to_bf16(final_var);
         } else {
-            auto* combined_ptr = reinterpret_cast<float*>(cb_combined_obj.get_write_ptr());
+            auto* combined_ptr = reinterpret_cast<volatile float*>(cb_combined_obj.get_write_ptr());
             for (uint32_t i = 0; i < FACE_W; ++i) {
                 combined_ptr[i] = 0.0f;
             }


### PR DESCRIPTION
## What
`writer_welford_hw.cpp` wrote the combined scalar into `cb_combined` through a **non-volatile** pointer (lines 128/136), then issued `cb_combined_obj.push_back(1)`. The read side of the same file already uses the volatile idiom (`volatile float*`, lines 89-90).

Because the payload stores are non-volatile and nothing in this TU reads the tile (the consumer is the compute kernel on the same Tensix), the compiler is permitted to reorder them past the `push_back` credit or dead-store-eliminate them — the consumer could see the credit before the data.

## Fix
Qualify the write pointer `volatile` in both branches (`volatile uint16_t*` / `volatile float*`), matching the read-side idiom.

## Scope
Compiler-ordering half only. On Quasar the same path also needs a HW cache flush (`flush_l2_cache_range`) so the DM write-back caches are visible to the TRISC unpacker — that is #50974 findings #3/#27 (owner-gated). `volatile` is necessary-not-sufficient on Quasar; the two are complementary.

## Verification
Correctness-by-construction: the C++ memory model permits reordering/elimination of the non-volatile stores relative to the volatile credit; `volatile` removes that permission. Strictly more-constrained (always valid); makes the write side consistent with the read side. No forceable repro (by design of the fix); behavioral validation on Quasar pairs with the #3/#27 cache-flush work and needs the Quasar env.

Closes #51028. Finding #28 of #50974.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amahmud/welford-combined-volatile-store)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amahmud/welford-combined-volatile-store)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amahmud/welford-combined-volatile-store)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amahmud/welford-combined-volatile-store)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=amahmud/welford-combined-volatile-store)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:amahmud/welford-combined-volatile-store)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amahmud/welford-combined-volatile-store)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amahmud/welford-combined-volatile-store)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amahmud/welford-combined-volatile-store)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amahmud/welford-combined-volatile-store)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amahmud/welford-combined-volatile-store)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amahmud/welford-combined-volatile-store)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amahmud/welford-combined-volatile-store)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amahmud/welford-combined-volatile-store)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amahmud/welford-combined-volatile-store)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amahmud/welford-combined-volatile-store)