### PR TITLE
Invalidate L1 cache in remote_cb_sender_barrier spin

### DIFF
--- a/tt_metal/hw/inc/api/remote_circular_buffer.h
+++ b/tt_metal/hw/inc/api/remote_circular_buffer.h
@@ -323,8 +323,9 @@ FORCE_INLINE void remote_cb_sender_barrier(uint32_t cb_id) {
     uint32_t num_receivers = remote_cb_num_receivers(remote_cb.num_receivers_and_remote_pages_sent_ptr);
 
     for (uint32_t i = 0; i < num_receivers; ++i) {
-        while (*pages_acked_ptr != *pages_sent_ptr) {
-        }
+        do {
+            invalidate_l1_cache();
+        } while (*pages_acked_ptr != *pages_sent_ptr);
         pages_acked_ptr += REMOTE_CB_LOCAL_PAGES_STRIDE / sizeof(uint32_t);
         pages_sent_ptr += REMOTE_CB_LOCAL_PAGES_STRIDE / sizeof(uint32_t);
     }


### PR DESCRIPTION
## What
`remote_cb_sender_barrier` (`tt_metal/hw/inc/api/remote_circular_buffer.h`) spun on a NoC-updated counter without invalidating the L1 cache:

```cpp
while (*pages_acked_ptr != *pages_sent_ptr) {}
```

`pages_acked_ptr` is written by the remote receiver over NoC. On Blackhole (write-through L1 D-cache) the sender re-reads a stale cached value forever → the barrier hangs. It is the only bare spin in the file; `remote_cb_reserve_back` and the receiver-side waits all use `do { invalidate_l1_cache(); ... } while (...)`.

## Fix
Match the sibling idiom — invalidate at the top of each iteration.

## Verification
`invalidate_l1_cache()` self-guards (BH→`fence`, no-op elsewhere): no-op on Wormhole (read was already coherent), required invalidation added on Blackhole. Grounded in the immediate sibling `remote_cb_reserve_back`. The latent hang needs a Blackhole board to reproduce (deferred to a BH session); the change is correctness-by-construction and regression-safe on WH.

Closes #51030. Finding #15 of #50974.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amahmud/remote-cb-sender-barrier-invalidate)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amahmud/remote-cb-sender-barrier-invalidate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amahmud/remote-cb-sender-barrier-invalidate)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amahmud/remote-cb-sender-barrier-invalidate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=amahmud/remote-cb-sender-barrier-invalidate)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:amahmud/remote-cb-sender-barrier-invalidate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amahmud/remote-cb-sender-barrier-invalidate)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amahmud/remote-cb-sender-barrier-invalidate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amahmud/remote-cb-sender-barrier-invalidate)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amahmud/remote-cb-sender-barrier-invalidate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amahmud/remote-cb-sender-barrier-invalidate)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amahmud/remote-cb-sender-barrier-invalidate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amahmud/remote-cb-sender-barrier-invalidate)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amahmud/remote-cb-sender-barrier-invalidate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amahmud/remote-cb-sender-barrier-invalidate)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amahmud/remote-cb-sender-barrier-invalidate)