### PR TITLE
Skip 2x4 distributed examples when fewer than 8 devices are available

### DIFF
--- a/tt_metal/programming_examples/distributed/1_distributed_program_dispatch/distributed_program_dispatch.cpp
+++ b/tt_metal/programming_examples/distributed/1_distributed_program_dispatch/distributed_program_dispatch.cpp
@@ -3,14 +3,22 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <tt-metalium/distributed.hpp>
+#include <tt-metalium/host_api.hpp>
 #include <tt-metalium/mesh_workload.hpp>
 #include <tt-metalium/mesh_coord.hpp>
+#include <iostream>
 
 // Stand-alone example demonstrating usage of native multi-device TT-Metalium APIs
 // for issuing a program dispatch across a mesh of devices.
 int main() {
     using namespace tt::tt_metal;
     using namespace tt::tt_metal::distributed;
+
+    constexpr size_t required_devices = 8;
+    if (tt::tt_metal::GetNumAvailableDevices() < required_devices) {
+        std::cout << "distributed_program_dispatch requires " << required_devices << " devices, skipping\n";
+        return 0;
+    }
 
     auto mesh_device = MeshDevice::create(MeshDeviceConfig(MeshShape(2, 4)));
     auto& cq = mesh_device->mesh_command_queue();

--- a/tt_metal/programming_examples/distributed/2_distributed_buffer_rw/distributed_buffer_rw.cpp
+++ b/tt_metal/programming_examples/distributed/2_distributed_buffer_rw/distributed_buffer_rw.cpp
@@ -3,7 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <tt-metalium/distributed.hpp>
+#include <tt-metalium/host_api.hpp>
 #include <tt-metalium/mesh_buffer.hpp>
+#include <iostream>
 
 // Stand-alone example demonstrating usage of native multi-device TT-Metalium APIs
 // for issuing Read and Write commands to a distributed memory buffer spanning
@@ -19,6 +21,12 @@ int main() {
     using namespace tt::tt_metal;
     using namespace tt::tt_metal::distributed;
     using tt::tt_metal::distributed::ShardedBufferConfig;
+
+    constexpr size_t required_devices = 8;
+    if (tt::tt_metal::GetNumAvailableDevices() < required_devices) {
+        std::cout << "distributed_buffer_rw requires " << required_devices << " devices, skipping\n";
+        return 0;
+    }
 
     auto mesh_device = MeshDevice::create(MeshDeviceConfig(MeshShape(2, 4)));
     auto& cq = mesh_device->mesh_command_queue();

--- a/tt_metal/programming_examples/distributed/3_distributed_eltwise_add/distributed_eltwise_add.cpp
+++ b/tt_metal/programming_examples/distributed/3_distributed_eltwise_add/distributed_eltwise_add.cpp
@@ -3,9 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <functional>
+#include <iostream>
 
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/bfloat16.hpp>
+#include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 
 using namespace tt;
@@ -97,6 +99,12 @@ Program CreateEltwiseAddProgram(
 // The example showcases TT-Metalium's ability to abstract away the complexity
 // of distributed memory management and compute.
 int main() {
+    constexpr size_t required_devices = 8;
+    if (tt::tt_metal::GetNumAvailableDevices() < required_devices) {
+        std::cout << "distributed_eltwise_add requires " << required_devices << " devices, skipping\n";
+        return 0;
+    }
+
     auto mesh_device = MeshDevice::create(MeshDeviceConfig(MeshShape(2, 4)));
 
     // Define the global buffer shape and shard shape for distributed buffers

--- a/tt_metal/programming_examples/distributed/4_distributed_trace_and_events/distributed_trace_and_events.cpp
+++ b/tt_metal/programming_examples/distributed/4_distributed_trace_and_events/distributed_trace_and_events.cpp
@@ -4,9 +4,11 @@
 
 #include <tt-metalium/bfloat16.hpp>
 #include <tt-metalium/distributed.hpp>
+#include <tt-metalium/host_api.hpp>
 #include <tt-metalium/mesh_coord.hpp>
 #include <tt-metalium/sub_device.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
+#include <iostream>
 
 using namespace tt;
 using namespace tt::tt_metal;
@@ -126,6 +128,12 @@ int main() {
     constexpr uint32_t ADD_OP_ID = 0;
     constexpr uint32_t MULTIPLY_OP_ID = 1;
     constexpr uint32_t SUBTRACT_OP_ID = 2;
+    constexpr size_t required_devices = 8;
+    if (tt::tt_metal::GetNumAvailableDevices() < required_devices) {
+        std::cout << "distributed_trace_and_events requires " << required_devices << " devices, skipping\n";
+        return 0;
+    }
+
     // Create a 2x4 MeshDevice with 2 MeshCQs, 16MB allocated to the trace region and Ethernet Dispatch enabled
     auto mesh_device = MeshDevice::create(
         MeshDeviceConfig(MeshShape(2, 4)),  // Shape of MeshDevice


### PR DESCRIPTION
### PR Category
Test Only

### Summary
The distributed programming examples unconditionally constructed a `MeshDevice` with shape 2x4, so running the examples from a generic test harness on a single-chip or otherwise smaller system failed during device creation instead of behaving like an example with unmet hardware prerequisites. This change adds a simple `GetNumAvailableDevices()` precondition to the four 2x4 distributed examples and exits successfully with a short skip message when fewer than eight devices are present. Systems with the required device count still execute the same example flow as before, while smaller systems can run the full examples suite without treating topology mismatch as a test failure.

### Notes for reviewers
none

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mcraighead/distributed-examples)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mcraighead/distributed-examples)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mcraighead/distributed-examples)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mcraighead/distributed-examples)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mcraighead/distributed-examples)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mcraighead/distributed-examples)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mcraighead/distributed-examples)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mcraighead/distributed-examples)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mcraighead/distributed-examples)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mcraighead/distributed-examples)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mcraighead/distributed-examples)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mcraighead/distributed-examples)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mcraighead/distributed-examples)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mcraighead/distributed-examples)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mcraighead/distributed-examples)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mcraighead/distributed-examples)