### PR TITLE
Invalidate L1 cache in Semaphore::up() local RMW

### DIFF
--- a/tt_metal/hw/inc/api/dataflow/noc_semaphore.h
+++ b/tt_metal/hw/inc/api/dataflow/noc_semaphore.h
@@ -55,6 +55,7 @@ public:
      */
     void up(uint32_t value) {
         auto* sem_addr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(local_l1_addr_);
+        invalidate_l1_cache();
         *sem_addr += value;
     }
 


### PR DESCRIPTION
## What
`Semaphore<>::up(uint32_t)` (`tt_metal/hw/inc/api/dataflow/noc_semaphore.h`) did a local read-modify-write with no cache invalidate:
```cpp
void up(uint32_t value) {
    auto* sem_addr = ...;
    *sem_addr += value;   // reads a possibly-stale cached value on Blackhole
}
```
`down()`/`wait()` in the same class already `invalidate_l1_cache()` before their read, and Quasar routes the semaphore through the uncached alias. `up()` was the lone exception: on Blackhole's write-through L1 D-cache a remote increment (`up(noc,...)`) that already landed in L1 SRAM is invisible to the cached local read, so the RMW clobbers it and the remote update is lost.

## Fix
Add `invalidate_l1_cache()` before the read — parity with `down()`.

## Verification
No-op on Wormhole and with the L1 data cache disabled (`invalidate_l1_cache()` self-guards to a Blackhole `fence`); harmless on Quasar (uncached alias). The Blackhole stale-cached-read mechanism was HW-validated on a p100a via the probe in #51031 (non-invalidated read returns stale; post-invalidate read returns the NoC-written value); this RMW lost-update is a direct corollary. Latent unless the L1 data cache is enabled.

Closes #51036. Finding of #50974.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amahmud/semaphore-up-invalidate)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amahmud/semaphore-up-invalidate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amahmud/semaphore-up-invalidate)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amahmud/semaphore-up-invalidate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=amahmud/semaphore-up-invalidate)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:amahmud/semaphore-up-invalidate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amahmud/semaphore-up-invalidate)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amahmud/semaphore-up-invalidate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amahmud/semaphore-up-invalidate)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amahmud/semaphore-up-invalidate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amahmud/semaphore-up-invalidate)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amahmud/semaphore-up-invalidate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amahmud/semaphore-up-invalidate)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amahmud/semaphore-up-invalidate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amahmud/semaphore-up-invalidate)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amahmud/semaphore-up-invalidate)