### PR TITLE
Invalidate L1 cache in MoE-gate cross-RISC sync poll loops

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/deepseek_moe_gate/device/unified_kernels/kernel_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/deepseek_moe_gate/device/unified_kernels/kernel_utils.hpp
@@ -99,8 +99,9 @@ FORCE_INLINE void sync_riscs_enter(volatile uint32_t tt_l1_ptr* sem_addr) {
 #endif
     __atomic_fetch_add(&sem_addr[0], 1, __ATOMIC_RELAXED);
 #elif defined(COMPILE_FOR_NCRISC)
-    while (__atomic_load_n(&sem_addr[0], __ATOMIC_RELAXED) < 3) {
-    }
+    do {
+        invalidate_l1_cache();
+    } while (__atomic_load_n(&sem_addr[0], __ATOMIC_RELAXED) < 3);
     sem_addr[0] = 0;
 #endif
 }
@@ -110,8 +111,9 @@ FORCE_INLINE void sync_riscs_exit(volatile uint32_t tt_l1_ptr* sem_addr) {
 #if defined(COMPILE_FOR_NCRISC)
     __atomic_fetch_add(&sem_addr[1], 3, __ATOMIC_RELAXED);
 #elif defined(COMPILE_FOR_BRISC) || defined(UCK_CHLKC_UNPACK) || defined(UCK_CHLKC_PACK)
-    while (__atomic_load_n(&sem_addr[1], __ATOMIC_RELAXED) == 0) {
-    }
+    do {
+        invalidate_l1_cache();
+    } while (__atomic_load_n(&sem_addr[1], __ATOMIC_RELAXED) == 0);
     __atomic_fetch_sub(&sem_addr[1], 1, __ATOMIC_RELAXED);
 #endif
 }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/generalized_moe_gate/device/unified_kernels/kernel_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/generalized_moe_gate/device/unified_kernels/kernel_utils.hpp
@@ -99,8 +99,9 @@ FORCE_INLINE void sync_riscs_enter(volatile uint32_t tt_l1_ptr* sem_addr) {
 #endif
     __atomic_fetch_add(&sem_addr[0], 1, __ATOMIC_RELAXED);
 #elif defined(COMPILE_FOR_NCRISC)
-    while (__atomic_load_n(&sem_addr[0], __ATOMIC_RELAXED) < 3) {
-    }
+    do {
+        invalidate_l1_cache();
+    } while (__atomic_load_n(&sem_addr[0], __ATOMIC_RELAXED) < 3);
     sem_addr[0] = 0;
 #endif
 }
@@ -110,8 +111,9 @@ FORCE_INLINE void sync_riscs_exit(volatile uint32_t tt_l1_ptr* sem_addr) {
 #if defined(COMPILE_FOR_NCRISC)
     __atomic_fetch_add(&sem_addr[1], 3, __ATOMIC_RELAXED);
 #elif defined(COMPILE_FOR_BRISC) || defined(UCK_CHLKC_UNPACK) || defined(UCK_CHLKC_PACK)
-    while (__atomic_load_n(&sem_addr[1], __ATOMIC_RELAXED) == 0) {
-    }
+    do {
+        invalidate_l1_cache();
+    } while (__atomic_load_n(&sem_addr[1], __ATOMIC_RELAXED) == 0);
     __atomic_fetch_sub(&sem_addr[1], 1, __ATOMIC_RELAXED);
 #endif
 }


### PR DESCRIPTION
## What
`sync_riscs_enter`/`sync_riscs_exit` in `deepseek_moe_gate` and `generalized_moe_gate` (`.../unified_kernels/kernel_utils.hpp`) synchronize BR/TR0/TR2/NC on the same Tensix via two L1 semaphore words. The waiters spun with `__atomic_load_n(..., __ATOMIC_RELAXED)` and **no `invalidate_l1_cache()`**:
```cpp
while (__atomic_load_n(&sem_addr[0], __ATOMIC_RELAXED) < 3) {}   // NC enter-waiter
while (__atomic_load_n(&sem_addr[1], __ATOMIC_RELAXED) == 0) {}  // BR/UNPACK/PACK exit-waiter
```
`__ATOMIC_RELAXED` is only a compiler barrier. On Blackhole's write-through L1 data cache, a word written by another RISC on the same core is invisible to the cached read, so the waiter can spin on a stale value and hang.

## Fix
Wrap both poll loops in `do { invalidate_l1_cache(); } while (...)`, matching the sibling deepseek kernels (`moe_compute`/`moe_gpt` `noc_semaphore_wait_min`) and `Semaphore::down()`. Both byte-identical files fixed together.

## Verification
- `test_generalized_moe_gate_program_cache.py` passes 3/3 on Blackhole (p100a) with the edited kernel JIT-compiled fresh — compiles in all RISC contexts, no regression.
- No-op on Wormhole and with the L1 data cache disabled (self-guarded to a BH `fence`).
- The BH cross-proc stale-read mechanism was HW-validated on a p100a via the probe in #51031. Latent unless the L1 data cache is enabled.

Closes #51038. Findings of #50974.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amahmud/moe-gate-sync-riscs-invalidate)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amahmud/moe-gate-sync-riscs-invalidate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amahmud/moe-gate-sync-riscs-invalidate)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amahmud/moe-gate-sync-riscs-invalidate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=amahmud/moe-gate-sync-riscs-invalidate)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:amahmud/moe-gate-sync-riscs-invalidate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amahmud/moe-gate-sync-riscs-invalidate)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amahmud/moe-gate-sync-riscs-invalidate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amahmud/moe-gate-sync-riscs-invalidate)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amahmud/moe-gate-sync-riscs-invalidate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amahmud/moe-gate-sync-riscs-invalidate)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amahmud/moe-gate-sync-riscs-invalidate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amahmud/moe-gate-sync-riscs-invalidate)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amahmud/moe-gate-sync-riscs-invalidate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amahmud/moe-gate-sync-riscs-invalidate)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amahmud/moe-gate-sync-riscs-invalidate)