### PR TITLE
[fix] Gemma4 sliding-tail dealloc in chunked prefill.

### DIFF
--- a/models/demos/gemma4/tests/unit/test_attention.py
+++ b/models/demos/gemma4/tests/unit/test_attention.py
@@ -559,3 +559,139 @@ def test_attention_decode_paged_batched(layer_idx, batch, cache_len, mesh_device
         f"Batched decode (layer={layer_idx}, batch={batch}, cache_len={cache_len}, "
         f"tp={tp}, sliding_window={sliding_window}) PCC too low: {pcc_msg}"
     )
+
+
+# ── Cross-call chunked prefill tail lifetime regression ──────────────────
+
+
+@parametrize_mesh_with_fabric(mesh_shapes=[(1, 1)])
+def test_sliding_tail_survives_cross_call_chunking(mesh_device, reset_seeds, request):
+    """Regression test for the sliding-window prefill-tail-lifetime bug.
+
+    vLLM-driven token-chunked prefill makes separate ``__call__`` invocations
+    for each chunk. The first call slices the sliding tail from tt_k/tt_v and
+    stores it on ``self._sliding_prefill_tail``. After the call returns, tt_k
+    and tt_v are deallocated. If the tail is a view (not an independent copy)
+    of tt_k, the second call finds an unallocated tensor and crashes with
+    ``TT_FATAL: Input Tensor is not allocated``.
+
+    This test simulates two separate prefill calls with ``chunk_start_idx``
+    and verifies the second call consumes the persisted tail without error.
+    """
+    from models.demos.gemma4.tt.attention.kv_cache import init_kv_cache
+    from models.tt_transformers.tt.common import PagedAttentionConfig
+
+    hf_text_config = TestFactory.create_hf_text_config()
+    layer_idx = find_layer_idx(hf_text_config, "sliding_attention")
+    config = Gemma4AttentionConfig(TestFactory.create_hf_config(), layer_idx)
+
+    hf_layer = TestFactory.create_hf_reference_layer(hf_text_config, layer_idx)
+    state_dict = {k: v.clone() for k, v in hf_layer.self_attn.state_dict().items() if not k.startswith("v_norm")}
+
+    chunk_size = 1024
+    block_size = 64
+    total_seq = chunk_size * 2  # two chunks
+    max_num_blocks = total_seq // block_size + 2
+    max_seq_len = max_num_blocks * block_size
+    paged_attention_config = PagedAttentionConfig(block_size=block_size, max_num_blocks=max_num_blocks)
+
+    mesh_config = MeshConfig(mesh_device.shape, decode=ModeConfig(tp=1))
+    kv_cache = init_kv_cache(
+        mesh_device=mesh_device,
+        config=config,
+        paged_attention_config=paged_attention_config,
+        cache_dtype=ttnn.bfloat16,
+    )
+
+    tt_attn = Gemma4Attention(
+        mesh_device=mesh_device,
+        config=config,
+        state_dict=state_dict,
+        ccl_manager=None,
+        mesh_config=mesh_config,
+        program_config=None,
+        layer_idx=layer_idx,
+    )
+    tt_attn.kv_cache = kv_cache
+
+    page_table = torch.arange(max_num_blocks, dtype=torch.int32).reshape(1, -1)
+    page_table_tt = ttnn.from_torch(page_table, device=mesh_device, layout=ttnn.ROW_MAJOR_LAYOUT, dtype=ttnn.int32)
+
+    cos_tt, sin_tt = TestFactory.create_tt_rope_cache(mesh_device, hf_text_config, max_seq_len, layer_idx)
+
+    # region Chunk 1 (chunk_start_idx=0)
+    x1 = torch.randn(1, 1, chunk_size, config.hidden_size, dtype=torch.bfloat16)
+    x1_tt = _to_device(x1, mesh_device)
+    chunk1_pt = page_table[:, : chunk_size // block_size]
+    chunk1_pt_tt = ttnn.from_torch(chunk1_pt, device=mesh_device, layout=ttnn.ROW_MAJOR_LAYOUT, dtype=ttnn.int32)
+    out1 = tt_attn(
+        x1_tt,
+        rope_mats=(cos_tt, sin_tt),
+        is_decode=False,
+        page_table=page_table_tt,
+        kv_cache=kv_cache,
+        chunk_start_idx=0,
+        chunk_page_table=chunk1_pt_tt,
+    )
+    # Force deallocation of the output to simulate the model runner dropping it
+    # between scheduling steps (mimics real vLLM inter-step behavior).
+    out1.deallocate(True)
+
+    # The tail must be alive after the first call.
+    tail = getattr(tt_attn, "_sliding_prefill_tail", None)
+    assert tail is not None, "Sliding tail was not persisted after chunk 1"
+    assert all(t.is_allocated() for t in tail), "Sliding tail tensor(s) are not allocated — the clone fix is missing"
+    # endregion
+
+    # region Chunk 2 (chunk_start_idx=chunk_size, consumes persisted tail)
+    x2 = torch.randn(1, 1, chunk_size, config.hidden_size, dtype=torch.bfloat16)
+    x2_tt = _to_device(x2, mesh_device)
+    chunk2_pt = page_table[:, chunk_size // block_size : total_seq // block_size]
+    chunk2_pt_tt = ttnn.from_torch(chunk2_pt, device=mesh_device, layout=ttnn.ROW_MAJOR_LAYOUT, dtype=ttnn.int32)
+    # This call used to crash with "Input Tensor is not allocated" before the
+    # `ttnn.clone` fix in `_prefill_forward_single.
+    out2 = tt_attn(
+        x2_tt,
+        rope_mats=(cos_tt, sin_tt),
+        is_decode=False,
+        page_table=page_table_tt,
+        kv_cache=kv_cache,
+        chunk_start_idx=chunk_size,
+        chunk_page_table=chunk2_pt_tt,
+    )
+    # If we get here, the tail survived the cross-call deallocation.
+    out2_torch = _from_device(out2, mesh_device)
+    assert out2_torch.shape[-2] == chunk_size, f"Expected seq_len={chunk_size} in output, got {out2_torch.shape[-2]}"
+    # endregion
+
+    # region No DRAM pinning during decode
+    # After the last prefill chunk, the tail is still stored (for a potential
+    # next chunk that never comes). The first decode call must release it.
+    tail_before_decode = getattr(tt_attn, "_sliding_prefill_tail", None)
+    assert tail_before_decode is not None, "Tail should still be present after chunk 2 (not yet in decode)"
+
+    # Simulate a decode call: minimal input, just needs to trigger the
+    # `is_decode=True` branch which releases the tail.
+    x_dec = torch.randn(1, 1, 1, config.hidden_size, dtype=torch.bfloat16)
+    x_dec_tt = _to_device(x_dec, mesh_device)
+    position_idx_tt = ttnn.from_torch(
+        torch.tensor([[total_seq]], dtype=torch.int32),
+        device=mesh_device,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        dtype=ttnn.int32,
+    )
+    tt_attn(
+        x_dec_tt,
+        rope_mats=(cos_tt, sin_tt),
+        position_idx=position_idx_tt,
+        is_decode=True,
+        token_index=total_seq,
+        page_table=page_table_tt,
+        kv_cache=kv_cache,
+    )
+
+    tail_after_decode = getattr(tt_attn, "_sliding_prefill_tail", None)
+    assert tail_after_decode is None, (
+        "Tail should be released after the first decode call - " "DRAM must not be pinned during decode"
+    )
+    # endregion

--- a/models/demos/gemma4/tt/attention/__init__.py
+++ b/models/demos/gemma4/tt/attention/__init__.py
@@ -189,6 +189,12 @@ class Gemma4Attention:
             )
 
         if is_decode:
+            # Release any sliding-window prefill tail left over from the
+            # last prefill chunk, since these cloned DRAM buffers are only needed
+            # between continuation chunks, not during decode.
+            if getattr(self, "_sliding_prefill_tail", None) is not None:
+                self._release_sliding_prefill_tail()
+
             return decode_forward(
                 hidden_states=hidden_states,
                 cos_cache=cos_cache,

--- a/models/demos/gemma4/tt/attention/__init__.py
+++ b/models/demos/gemma4/tt/attention/__init__.py
@@ -165,6 +165,13 @@ class Gemma4Attention:
         cache = kv_cache or self.kv_cache
         cos_cache, sin_cache = rope_mats
 
+        # Release any sliding-window prefill tail left over from the last
+        # prefill chunk. These cloned DRAM buffers are only needed between
+        # continuation chunks, not during decode. Placed before both decode
+        # dispatches (packed and ordinary) so neither path retains stale tails.
+        if is_decode and getattr(self, "_sliding_prefill_tail", None) is not None:
+            self._release_sliding_prefill_tail()
+
         if is_decode and packed is not None:
             return packed_decode_forward(
                 hidden_states=hidden_states,
@@ -189,12 +196,6 @@ class Gemma4Attention:
             )
 
         if is_decode:
-            # Release any sliding-window prefill tail left over from the
-            # last prefill chunk, since these cloned DRAM buffers are only needed
-            # between continuation chunks, not during decode.
-            if getattr(self, "_sliding_prefill_tail", None) is not None:
-                self._release_sliding_prefill_tail()
-
             return decode_forward(
                 hidden_states=hidden_states,
                 cos_cache=cos_cache,

--- a/models/demos/gemma4/tt/attention/prefill.py
+++ b/models/demos/gemma4/tt/attention/prefill.py
@@ -296,11 +296,20 @@ def _prefill_forward_single(
                 compute_kernel_config=sdpa_ckc,
             )
         # Save this chunk's last ``hist`` K/V tokens as the next chunk's tail.
+        # The slices must outlive tt_k / tt_v (deallocated below); force an
+        # independent DRAM copy so deallocation of the parent doesn't
+        # invalidate the tail.
         kseq = tt_k.shape[-2]
         nkv = tt_k.shape[1]
         tail_start = max(0, kseq - hist)
-        k_tail_out = ttnn.slice(tt_k, [0, 0, tail_start, 0], [1, nkv, kseq, config.head_dim])
-        v_tail_out = ttnn.slice(tt_v, [0, 0, tail_start, 0], [1, nkv, kseq, config.head_dim])
+        k_tail_out = ttnn.clone(
+            ttnn.slice(tt_k, [0, 0, tail_start, 0], [1, nkv, kseq, config.head_dim]),
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+        v_tail_out = ttnn.clone(
+            ttnn.slice(tt_v, [0, 0, tail_start, 0], [1, nkv, kseq, config.head_dim]),
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
         sliding_tail_out = (k_tail_out, v_tail_out)
     elif need_cross_chunk:
         # Full-attention chunk N>0: attend the full prefix already filled in the


### PR DESCRIPTION
## Summary

Fix an unallocated-tensor crash in `_prefill_forward_single` when vLLM-driven token-chunked prefill splits a prompt across multiple `prefill_forward_text` calls.

The sliding-window KV tail (`k_tail_out`, `v_tail_out`) is sliced from `tt_k` / `tt_v` and persisted on the attention module between calls. `ttnn.slice` may return a view sharing the parent's device buffer. When `tt_k.deallocate(True)` runs at the end of chunk N, the tail's backing memory is freed; chunk N+1 reads an unallocated tensor and hits `TT_FATAL: Input Tensor is not allocated`.

This was never triggered before because the generator's internal chunking loop consumes the tail within the same call (before `tt_k` is deallocated). vLLM scheduler-level chunking makes separate calls, so the tail must survive across call boundaries.

**Fix:** `ttnn.clone(..., memory_config=ttnn.DRAM_MEMORY_CONFIG)` to force an independent DRAM copy that owns its own buffer, and also release prefill tail from the last chunk before decode.

## Related

- vLLM chunked-prefill PR: tenstorrent/vllm#448
- Original issue: tenstorrent/vllm#439
- Metal-side hybrid KV + chunked SDPA: #49614

## Test

`[BH-QB-2] Gemma4-12B (chunked-prefill)` nightly entry:
`--max_num_batched_tokens 1024 --random-input-len 4096` , 4 chunks of 1024
(temporarily lives in [`sanjaradylov/temp_test-gemma4-chunked-prefill`](https://github.com/tenstorrent/tt-metal/tree/sanjaradylov/temp_test-gemma4-chunked-prefill); created only to add a new Gemma4 chunked-prefill job)

**Before**:
[Fails](https://github.com/tenstorrent/tt-metal/actions/runs/30087813945/job/89466055916) with the error mentioned above.

**After**:
[Passes](https://github.com/tenstorrent/tt-metal/actions/runs/30101342098/job/89511284125).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sanjaradylov/fix-gemma4-dealloc-chunked-prefill)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sanjaradylov/fix-gemma4-dealloc-chunked-prefill)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=sanjaradylov/fix-gemma4-dealloc-chunked-prefill)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:sanjaradylov/fix-gemma4-dealloc-chunked-prefill)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=sanjaradylov/fix-gemma4-dealloc-chunked-prefill)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:sanjaradylov/fix-gemma4-dealloc-chunked-prefill)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sanjaradylov/fix-gemma4-dealloc-chunked-prefill)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sanjaradylov/fix-gemma4-dealloc-chunked-prefill)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=sanjaradylov/fix-gemma4-dealloc-chunked-prefill)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:sanjaradylov/fix-gemma4-dealloc-chunked-prefill)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=sanjaradylov/fix-gemma4-dealloc-chunked-prefill)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:sanjaradylov/fix-gemma4-dealloc-chunked-prefill)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sanjaradylov/fix-gemma4-dealloc-chunked-prefill)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sanjaradylov/fix-gemma4-dealloc-chunked-prefill)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=sanjaradylov/fix-gemma4-dealloc-chunked-prefill)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:sanjaradylov/fix-gemma4-dealloc-chunked-prefill)