### PR TITLE
[LLK][Quasar] Add "memory" clobber to vector_load/vector_store asm

### DIFF
--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/ckernel_vector.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/ckernel_vector.h
@@ -190,7 +190,7 @@ template <vreg vec_reg_no, typename T, vdatasz data_size = type_to_datasz(T)>
 inline void vector_load(T const *addr)
 {
     std::uint32_t constexpr e_val = vdatasz_asm_nums[data_size];
-    asm volatile("vle%c[e_val].v v%c[vec_reg_no], (%[addr]) \n" : : [e_val] "i"(e_val), [vec_reg_no] "i"(vec_reg_no), [addr] "r"(addr));
+    asm volatile("vle%c[e_val].v v%c[vec_reg_no], (%[addr]) \n" : : [e_val] "i"(e_val), [vec_reg_no] "i"(vec_reg_no), [addr] "r"(addr) : "memory");
 }
 
 // For backwards compatibility
@@ -198,14 +198,14 @@ template <vdatasz data_size, vreg vec_reg_no, typename T>
 inline void vector_load(T const *addr)
 {
     std::uint32_t constexpr e_val = vdatasz_asm_nums[data_size];
-    asm volatile("vle%c[e_val].v v%c[vec_reg_no], (%[addr]) \n" : : [e_val] "i"(e_val), [vec_reg_no] "i"(vec_reg_no), [addr] "r"(addr));
+    asm volatile("vle%c[e_val].v v%c[vec_reg_no], (%[addr]) \n" : : [e_val] "i"(e_val), [vec_reg_no] "i"(vec_reg_no), [addr] "r"(addr) : "memory");
 }
 
 template <vreg vec_reg_no, typename T, vdatasz data_size = type_to_datasz(T)>
 inline void vector_store(T *addr)
 {
     std::uint32_t constexpr e_val = vdatasz_asm_nums[data_size];
-    asm volatile("vse%c[e_val].v v%c[vec_reg_no], (%[addr]) \n" : : [e_val] "i"(e_val), [vec_reg_no] "i"(vec_reg_no), [addr] "r"(addr));
+    asm volatile("vse%c[e_val].v v%c[vec_reg_no], (%[addr]) \n" : : [e_val] "i"(e_val), [vec_reg_no] "i"(vec_reg_no), [addr] "r"(addr) : "memory");
 }
 
 // For backwards compatibility
@@ -213,7 +213,7 @@ template <vdatasz data_size, vreg vec_reg_no, typename T>
 inline void vector_store(T *addr)
 {
     std::uint32_t constexpr e_val = vdatasz_asm_nums[data_size];
-    asm volatile("vse%c[e_val].v v%c[vec_reg_no], (%[addr]) \n" : : [e_val] "i"(e_val), [vec_reg_no] "i"(vec_reg_no), [addr] "r"(addr));
+    asm volatile("vse%c[e_val].v v%c[vec_reg_no], (%[addr]) \n" : : [e_val] "i"(e_val), [vec_reg_no] "i"(vec_reg_no), [addr] "r"(addr) : "memory");
 }
 
 template <vreg dest_vec_reg_no, vreg src_vec_reg_no, int shift_amt>


### PR DESCRIPTION
## What
`vector_load` (`vle`) and `vector_store` (`vse`) in `tt_llk_quasar/common/inc/ckernel_vector.h` pass the buffer only as an `"r"` register-value input — no memory operand, no `"memory"` clobber. `asm volatile` keeps the op from being deleted/reordered vs other volatile asm, but does **not** model the read (`vle`) / write (`vse`) of `*addr` or order surrounding **non-volatile** scalar accesses to that buffer, so the compiler may reorder or dead-store-eliminate them across the vector op → silent corruption once used.

## Fix
Add a `"memory"` clobber to all four `vle`/`vse` overloads (matches the `ckernel_risc_atomics.h` idiom). A typed `"m"` operand can't express RVV's dynamic `vsetvl`-controlled length, so the conservative full `"memory"` clobber is the right form. Only `vle`/`vse` touch memory; register-only ops keep no clobber.

## Verification
Compiler-correctness fix, arch-independent; CI builds the Quasar target. Currently dormant (these two are not yet called) → zero regression risk; hardens the API before RVV codegen is enabled.

Closes #51045. Finding #12 of #50974.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amahmud/quasar-vle-vse-memory-clobber)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amahmud/quasar-vle-vse-memory-clobber)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amahmud/quasar-vle-vse-memory-clobber)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amahmud/quasar-vle-vse-memory-clobber)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=amahmud/quasar-vle-vse-memory-clobber)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:amahmud/quasar-vle-vse-memory-clobber)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amahmud/quasar-vle-vse-memory-clobber)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amahmud/quasar-vle-vse-memory-clobber)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amahmud/quasar-vle-vse-memory-clobber)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amahmud/quasar-vle-vse-memory-clobber)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amahmud/quasar-vle-vse-memory-clobber)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amahmud/quasar-vle-vse-memory-clobber)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amahmud/quasar-vle-vse-memory-clobber)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amahmud/quasar-vle-vse-memory-clobber)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amahmud/quasar-vle-vse-memory-clobber)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amahmud/quasar-vle-vse-memory-clobber)