### PR TITLE
fix(docs): load shared tt_theme.css from global _static

### DIFF
--- a/docs/source/common/_templates/layout.html
+++ b/docs/source/common/_templates/layout.html
@@ -3,6 +3,11 @@
 {#── noindex + canonical for versioned (non-latest) pages ────────#}
 {%- block extrahead %}
 {{ super() }}
+{#- Load the shared theme from the global _static (single source of truth,
+    same place the search/nav scripts come from). It carries the search-modal,
+    sidebar and nav styles; the local tt_theme.css only has a subset. -#}
+<link rel="stylesheet" href="https://docs.tenstorrent.com/_static/tt_theme.css">
+
 <script>
 (function() {
     var parts = window.location.pathname.split('/');


### PR DESCRIPTION
Follow-up to #49957/#49959.

## Problem
After the docs redeploy, the **Search / "Ask AI" modal doesn't open** and the **left sidebar / TOC looks wrong** on tt-metal, while it works on the other Tenstorrent docs sites (e.g. tt-lang, ttnn-visualizer).

Root cause: tt-metal loads **only** its local `_static/tt_theme.css` (the version brought in by #49957, ~41 KB), which is an **older subset**. It is missing:
- the `.tt-search-modal` styles (so the modal opens in JS but has no CSS to show it), and
- the newer sidebar/caret styles (12 caret/expand rules in the shared theme vs 4 locally).

The other sites additionally load the **shared** `tt_theme.css` from `https://docs.tenstorrent.com/_static/` (~53 KB), which has all of this. tt-metal never loaded it.

## Fix
Load the shared `tt_theme.css` from the global `_static` in `layout.html` `extrahead` — the same place we already load the global search/nav scripts (`tt-search.js`, `sidebar-scroll.js`, `kapa.js`). It layers on top of the local file, so the modal opens and the sidebar renders correctly, and tt-metal now uses the same single source of truth as the other sites.

One line, template-only, no `conf.py` change.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=fix/docs-load-global-theme-css)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:fix/docs-load-global-theme-css)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=fix/docs-load-global-theme-css)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:fix/docs-load-global-theme-css)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=fix/docs-load-global-theme-css)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:fix/docs-load-global-theme-css)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fix/docs-load-global-theme-css)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fix/docs-load-global-theme-css)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=fix/docs-load-global-theme-css)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:fix/docs-load-global-theme-css)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=fix/docs-load-global-theme-css)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:fix/docs-load-global-theme-css)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=fix/docs-load-global-theme-css)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:fix/docs-load-global-theme-css)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=fix/docs-load-global-theme-css)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:fix/docs-load-global-theme-css)