### PR TITLE
Publish Blaze prefill performance summaries

### DIFF
--- a/.github/workflows/blaze-models-prefill-tests-impl.yaml
+++ b/.github/workflows/blaze-models-prefill-tests-impl.yaml
@@ -141,6 +141,10 @@ jobs:
       PATH: "/opt/venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
       VIRTUAL_ENV: /opt/venv
       HOME: /home/user
+      # Root the tests' CI summaries (chunked-prefill perf tables under perf/) at a known path so the
+      # publish step below can surface them in the job summary. Rank 0 runs on this head node, so its
+      # files land here.
+      PREFILL_SUMMARIES: /home/user/tt-metal/generated/prefill_summaries
     strategy:
       fail-fast: false
       matrix:
@@ -350,6 +354,22 @@ jobs:
             echo "Running: ${{ matrix.test-group.name }}"
             echo "$CMD"
             eval "$CMD"
+
+      - name: 📊 Publish prefill summaries
+        if: always() && !cancelled()
+        continue-on-error: true
+        run: |
+          shopt -s nullglob
+          files=("$PREFILL_SUMMARIES"/perf/*.md "$PREFILL_SUMMARIES"/pcc/*.md)
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "No prefill summary files under $PREFILL_SUMMARIES"
+            exit 0
+          fi
+          for f in "${files[@]}"; do
+            cat "$f" >> "$GITHUB_STEP_SUMMARY"
+            printf '\n' >> "$GITHUB_STEP_SUMMARY"
+          done
+          echo "Published ${#files[@]} prefill summary file(s) to the job summary"
 
       - name: 🤖 AI job summary
         if: always() && !cancelled()

--- a/.github/workflows/blaze-models-prefill-tests-impl.yaml
+++ b/.github/workflows/blaze-models-prefill-tests-impl.yaml
@@ -141,10 +141,11 @@ jobs:
       PATH: "/opt/venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
       VIRTUAL_ENV: /opt/venv
       HOME: /home/user
-      # Root the tests' CI summaries (chunked-prefill perf tables under perf/) at a known path so the
-      # publish step below can surface them in the job summary. Rank 0 runs on this head node, so its
-      # files land here.
-      PREFILL_SUMMARIES: /home/user/tt-metal/generated/prefill_summaries
+      # Root the tests' CI summaries (chunked-prefill perf tables under perf/) on the /ci NFS volume that
+      # is shared between the mpirun worker pods and this runner (same mount the build artifacts flow
+      # through). /home/user is per-node, so a file written there by a worker rank is invisible to the
+      # runner's publish step; /ci is not. Only rank 0 writes (see emit_summary).
+      PREFILL_SUMMARIES: /ci/prefill_summaries
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/blaze-models-prefill-tests-impl.yaml
+++ b/.github/workflows/blaze-models-prefill-tests-impl.yaml
@@ -141,11 +141,8 @@ jobs:
       PATH: "/opt/venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
       VIRTUAL_ENV: /opt/venv
       HOME: /home/user
-      # Root the tests' CI summaries (chunked-prefill perf tables under perf/) on the /ci NFS volume that
-      # is shared between the mpirun worker pods and this runner (same mount the build artifacts flow
-      # through). /home/user is per-node, so a file written there by a worker rank is invisible to the
-      # runner's publish step; /ci is not. Only rank 0 writes (see emit_summary). The run/attempt/job
-      # subpath isolates each run on the (reused) PVC, so no prior run's files can leak into this one.
+      # /ci is the NFS volume shared with the runner; worker /home/user is per-node, invisible to it.
+      # Rank 0 writes; the run/attempt/job subpath keeps reused-PVC runs from colliding.
       PREFILL_SUMMARIES: /ci/prefill_summaries/${{ github.run_id }}-${{ github.run_attempt }}/${{ inputs.resource-prefix }}-${{ inputs.sp-config }}-${{ strategy.job-index }}
     strategy:
       fail-fast: false

--- a/.github/workflows/blaze-models-prefill-tests-impl.yaml
+++ b/.github/workflows/blaze-models-prefill-tests-impl.yaml
@@ -144,8 +144,9 @@ jobs:
       # Root the tests' CI summaries (chunked-prefill perf tables under perf/) on the /ci NFS volume that
       # is shared between the mpirun worker pods and this runner (same mount the build artifacts flow
       # through). /home/user is per-node, so a file written there by a worker rank is invisible to the
-      # runner's publish step; /ci is not. Only rank 0 writes (see emit_summary).
-      PREFILL_SUMMARIES: /ci/prefill_summaries
+      # runner's publish step; /ci is not. Only rank 0 writes (see emit_summary). The run/attempt/job
+      # subpath isolates each run on the (reused) PVC, so no prior run's files can leak into this one.
+      PREFILL_SUMMARIES: /ci/prefill_summaries/${{ github.run_id }}-${{ github.run_attempt }}/${{ inputs.resource-prefix }}-${{ inputs.sp-config }}-${{ strategy.job-index }}
     strategy:
       fail-fast: false
       matrix:
@@ -220,8 +221,6 @@ jobs:
       - name: Unpack artifacts & install
         run: |
           rm -rf /ci/tt-metal
-          # Start clean: /ci may be a reused PVC, so drop any prior run's summaries before this one writes.
-          if [ -n "$PREFILL_SUMMARIES" ]; then rm -rf "$PREFILL_SUMMARIES"; fi
           cp -r "$GITHUB_WORKSPACE" /ci/tt-metal
           if ! command -v zstd >/dev/null 2>&1; then
             echo "zstd not found in runner context, installing fallback..."
@@ -382,7 +381,7 @@ jobs:
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: prefill-summaries-${{ inputs.resource-prefix }}-${{ inputs.sp-config }}-${{ strategy.job-index }}
-          path: /ci/prefill_summaries/**/*.md
+          path: ${{ env.PREFILL_SUMMARIES }}/**/*.md
           if-no-files-found: ignore
           retention-days: 30
 

--- a/.github/workflows/blaze-models-prefill-tests-impl.yaml
+++ b/.github/workflows/blaze-models-prefill-tests-impl.yaml
@@ -368,7 +368,8 @@ jobs:
             exit 0
           fi
           for f in "${files[@]}"; do
-            cat "$f" >> "$GITHUB_STEP_SUMMARY"
+            # tee so the table shows in this step's log too, not only on the job-summary page.
+            cat "$f" | tee -a "$GITHUB_STEP_SUMMARY"
             printf '\n' >> "$GITHUB_STEP_SUMMARY"
           done
           echo "Published ${#files[@]} prefill summary file(s) to the job summary"

--- a/.github/workflows/blaze-models-prefill-tests-impl.yaml
+++ b/.github/workflows/blaze-models-prefill-tests-impl.yaml
@@ -339,6 +339,11 @@ jobs:
             test -r /mnt/models
           '
 
+      # Start clean so publish/upload only ever see this run's files, even if the runner's /ci PVC is
+      # reused and a prior run was killed before its end-cleanup.
+      - name: 🧹 Reset prefill summaries dir
+        run: '[ -n "$PREFILL_SUMMARIES" ] && rm -rf "$PREFILL_SUMMARIES"'
+
       - name: ${{ matrix.test-group.name }}
         id: run-test
         timeout-minutes: ${{ matrix.test-group.timeout }}
@@ -371,6 +376,22 @@ jobs:
             printf '\n' >> "$GITHUB_STEP_SUMMARY"
           done
           echo "Published ${#files[@]} prefill summary file(s) to the job summary"
+
+      # Keep the raw .md files for cross-run perf-trend analysis. Uploaded before cleanup; unique name per
+      # matrix job so v7 (no auto-merge) doesn't collide when the whole suite runs.
+      - name: ⬆️ Upload prefill summaries
+        if: always() && !cancelled()
+        continue-on-error: true
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: prefill-summaries-${{ inputs.resource-prefix }}-${{ inputs.sp-config }}-${{ strategy.job-index }}
+          path: /ci/prefill_summaries/**/*.md
+          if-no-files-found: ignore
+          retention-days: 30
+
+      - name: 🧹 Clean prefill summaries
+        if: always()
+        run: '[ -n "$PREFILL_SUMMARIES" ] && rm -rf "$PREFILL_SUMMARIES"'
 
       - name: 🤖 AI job summary
         if: always() && !cancelled()

--- a/.github/workflows/blaze-models-prefill-tests-impl.yaml
+++ b/.github/workflows/blaze-models-prefill-tests-impl.yaml
@@ -220,6 +220,8 @@ jobs:
       - name: Unpack artifacts & install
         run: |
           rm -rf /ci/tt-metal
+          # Start clean: /ci may be a reused PVC, so drop any prior run's summaries before this one writes.
+          if [ -n "$PREFILL_SUMMARIES" ]; then rm -rf "$PREFILL_SUMMARIES"; fi
           cp -r "$GITHUB_WORKSPACE" /ci/tt-metal
           if ! command -v zstd >/dev/null 2>&1; then
             echo "zstd not found in runner context, installing fallback..."
@@ -339,11 +341,6 @@ jobs:
             test -r /mnt/models
           '
 
-      # Start clean so publish/upload only ever see this run's files, even if the runner's /ci PVC is
-      # reused and a prior run was killed before its end-cleanup.
-      - name: 🧹 Reset prefill summaries dir
-        run: '[ -n "$PREFILL_SUMMARIES" ] && rm -rf "$PREFILL_SUMMARIES"'
-
       - name: ${{ matrix.test-group.name }}
         id: run-test
         timeout-minutes: ${{ matrix.test-group.timeout }}
@@ -391,7 +388,7 @@ jobs:
 
       - name: 🧹 Clean prefill summaries
         if: always()
-        run: '[ -n "$PREFILL_SUMMARIES" ] && rm -rf "$PREFILL_SUMMARIES"'
+        run: if [ -n "$PREFILL_SUMMARIES" ]; then rm -rf "$PREFILL_SUMMARIES"; fi
 
       - name: 🤖 AI job summary
         if: always() && !cancelled()

--- a/.github/workflows/blaze-models-prefill-tests.yaml
+++ b/.github/workflows/blaze-models-prefill-tests.yaml
@@ -42,14 +42,6 @@ on:
         type: boolean
         default: false
         description: "Enable Link Time Optimization (LTO)"
-      use-artifacts-from-run:
-        required: false
-        type: string
-        default: ""
-        description: >-
-          Reuse the build+wheel from this workflow run ID instead of rebuilding.
-          Only safe when the C++/wheel are unchanged vs that run (e.g. iterating
-          on Python tests or the workflow). Empty = build fresh.
   schedule:
     - cron: "0 5 * * *" # Run at 5:00 AM UTC every day
 
@@ -96,7 +88,6 @@ jobs:
       build-wheel: true
       platform: ${{ inputs.platform || 'Ubuntu 22.04' }}
       enable-lto: ${{ inputs.enable-lto || false }}
-      use-artifacts-from-run: ${{ inputs.use-artifacts-from-run || '' }}
 
   Galaxy-Blaze-models-prefill:
     needs: [validate-test-type, check-harbor, build-artifact]

--- a/.github/workflows/blaze-models-prefill-tests.yaml
+++ b/.github/workflows/blaze-models-prefill-tests.yaml
@@ -42,6 +42,14 @@ on:
         type: boolean
         default: false
         description: "Enable Link Time Optimization (LTO)"
+      use-artifacts-from-run:
+        required: false
+        type: string
+        default: ""
+        description: >-
+          Reuse the build+wheel from this workflow run ID instead of rebuilding.
+          Only safe when the C++/wheel are unchanged vs that run (e.g. iterating
+          on Python tests or the workflow). Empty = build fresh.
   schedule:
     - cron: "0 5 * * *" # Run at 5:00 AM UTC every day
 
@@ -88,6 +96,7 @@ jobs:
       build-wheel: true
       platform: ${{ inputs.platform || 'Ubuntu 22.04' }}
       enable-lto: ${{ inputs.enable-lto || false }}
+      use-artifacts-from-run: ${{ inputs.use-artifacts-from-run || '' }}
 
   Galaxy-Blaze-models-prefill:
     needs: [validate-test-type, check-harbor, build-artifact]

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_summary_utils.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_summary_utils.py
@@ -1,0 +1,79 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Hardware-independent unit tests for the prefill CI summary utility (rank gating, file emission,
+table rendering). No device / ttnn dependency, so these run in a plain CPU job."""
+
+import pytest
+
+from models.demos.deepseek_v3_d_p.utils import prefill_summary_utils as psu
+
+_RANK_VARS = ("OMPI_COMM_WORLD_RANK", "PMIX_RANK", "PMI_RANK")
+
+
+@pytest.fixture(autouse=True)
+def _clean_rank_env(monkeypatch):
+    """Start each test with no MPI rank vars so is_primary_rank is deterministic."""
+    for var in _RANK_VARS:
+        monkeypatch.delenv(var, raising=False)
+
+
+def test_render_table_layout():
+    lines = psu.render_table(["chunk", "median"], [["chunk 0", "1.239s"], ["chunk 10", "1.4s"]])
+    # border, header, border, 2 rows, border
+    assert len(lines) == 6
+    assert lines[0] == lines[2] == lines[-1]  # identical separators
+    assert set(lines[0]) == {"+", "-"}
+    # columns widen to the longest cell ("chunk 10") and every rendered row shares one width
+    assert lines[1] == "| chunk    | median |"
+    assert lines[3] == "| chunk 0  | 1.239s |"
+    assert len({len(line) for line in lines}) == 1
+
+
+@pytest.mark.parametrize(
+    "env, expected",
+    [
+        ({}, True),  # non-MPI run
+        ({"OMPI_COMM_WORLD_RANK": "0"}, True),
+        ({"OMPI_COMM_WORLD_RANK": "1"}, False),
+        ({"PMIX_RANK": "3"}, False),
+        ({"PMI_RANK": "0"}, True),
+    ],
+)
+def test_is_primary_rank(monkeypatch, env, expected):
+    for k, v in env.items():
+        monkeypatch.setenv(k, v)
+    assert psu.is_primary_rank() is expected
+
+
+def test_emit_summary_primary_writes_and_prints(monkeypatch, tmp_path, capsys):
+    monkeypatch.setenv("PREFILL_SUMMARIES", str(tmp_path))
+    lines = psu.render_table(["chunk", "median"], [["chunk 0", "1.239s"]])
+    path = psu.emit_summary("perf", "run_a", "Chunk timing", lines)
+
+    # summary_dir resolves symlinks (e.g. macOS /var -> /private/var), so compare against the resolved path.
+    assert path == tmp_path.resolve() / "perf" / "run_a.md"
+    content = path.read_text()
+    assert content.startswith("### Chunk timing\n\n```text\n")
+    assert content.rstrip().endswith("```")
+    assert "\n".join(lines) in content
+    # also emitted to stdout (loguru is stderr-bound here)
+    assert "Chunk timing" in capsys.readouterr().out
+
+
+def test_emit_summary_non_primary_is_noop(monkeypatch, tmp_path, capsys):
+    monkeypatch.setenv("PREFILL_SUMMARIES", str(tmp_path))
+    monkeypatch.setenv("OMPI_COMM_WORLD_RANK", "1")
+    result = psu.emit_summary("perf", "run_a", "Chunk timing", ["x"])
+
+    assert result is None
+    assert not (tmp_path / "perf").exists()
+    assert capsys.readouterr().out == ""
+
+
+def test_summary_dir_uses_env(monkeypatch, tmp_path):
+    monkeypatch.setenv("PREFILL_SUMMARIES", str(tmp_path))
+    d = psu.summary_dir("pcc")
+    assert d == tmp_path.resolve() / "pcc"
+    assert d.is_dir()

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py
@@ -1406,15 +1406,16 @@ def run_chunked_transformer_no_pcc(
         f"Chunked prefill no-PCC run done (num_layers={num_layers}, n_chunks={n_chunks}, " f"num_iters={num_iters})"
     )
     perf_failures, perf_table_lines = print_duration_table(iteration_chunk_times)
+    timing_lines = [f"  {key}: {profiler.get(key) * 1000:.2f} ms" for key in profiler.times]
     if perf_table_lines:
         emit_summary(
             "perf",
             f"{variant.name}_L{num_layers}_c{n_chunks}_i{num_iters}_p{preload_isl}",
             f"Chunk timing — {variant.name} (L{num_layers}, {n_chunks} chunks, {num_iters} iters, preload {preload_isl})",
-            perf_table_lines,
+            perf_table_lines + ["", "phase timings:"] + timing_lines,
         )
-    for key in profiler.times:
-        logger.info(f"  {key}: {profiler.get(key) * 1000:.2f} ms")
+    for line in timing_lines:
+        logger.info(line)
 
     # Rough per-layer MLA-vs-FFN split (TT_PREFILL_BLOCK_TIMING=1): host wall-clock, sync-bracketed, so
     # absolutes inflate (syncs serialize) — read the RATIO and per-layer shape, not the totals. Mean +/- std

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py
@@ -51,6 +51,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.tt_moe_gate_prefill import GateComputeM
 from models.demos.deepseek_v3_d_p.tt.tt_prefill_block import get_block_timings, reset_block_timings
 from models.demos.deepseek_v3_d_p.tt.tt_prefill_transformer import TtPrefillTransformer
 from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import MlaKvCacheFormat, init_kvpe_cache, init_mla_kv_cache
+from models.demos.deepseek_v3_d_p.utils.prefill_summary_utils import emit_summary, render_table
 from models.demos.deepseek_v3_d_p.utils.test_utils import (
     cache_half_pccs,
     gather_cache_tp0,
@@ -1117,7 +1118,7 @@ def run_chunked_transformer_no_pcc(
         samples = iteration_chunk_times[1:]
         if not samples:
             logger.warning("No post-warmup iterations available for chunk timing stats (need num_iters >= 2)")
-            return []
+            return [], []
 
         gated = baseline_chunk_times_s is not None
         if gated and len(baseline_chunk_times_s) != n_chunks:
@@ -1154,25 +1155,9 @@ def run_chunked_transformer_no_pcc(
                     )
             rows.append(row)
 
-        widths = [len(header) for header in headers]
-        for row in rows:
-            for idx, cell in enumerate(row):
-                widths[idx] = max(widths[idx], len(cell))
-
-        def render_row(values: list[str]) -> str:
-            return "| " + " | ".join(value.ljust(widths[idx]) for idx, value in enumerate(values)) + " |"
-
-        separator = "+-" + "-+-".join("-" * width for width in widths) + "-+"
-
         margin_note = f", baseline gate +/- {margin * 100:.1f}%" if gated else ", record-only (no baseline)"
         logger.info(f"chunk timing stats computed over {len(samples)} iterations (iter 0 omitted){margin_note}")
-        logger.info("\n" + separator)
-        logger.info(render_row(headers))
-        logger.info(separator)
-        for row in rows:
-            logger.info(render_row(row))
-        logger.info(separator)
-        return failures
+        return failures, render_table(headers, rows)
 
     profiler.clear()
     profiler.start("total_test_time")
@@ -1420,7 +1405,14 @@ def run_chunked_transformer_no_pcc(
     logger.success(
         f"Chunked prefill no-PCC run done (num_layers={num_layers}, n_chunks={n_chunks}, " f"num_iters={num_iters})"
     )
-    perf_failures = print_duration_table(iteration_chunk_times)
+    perf_failures, perf_table_lines = print_duration_table(iteration_chunk_times)
+    if perf_table_lines:
+        emit_summary(
+            "perf",
+            f"{variant.name}_L{num_layers}_c{n_chunks}_i{num_iters}_p{preload_isl}",
+            f"Chunk timing — {variant.name} (L{num_layers}, {n_chunks} chunks, {num_iters} iters, preload {preload_isl})",
+            perf_table_lines,
+        )
     for key in profiler.times:
         logger.info(f"  {key}: {profiler.get(key) * 1000:.2f} ms")
 

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py
@@ -1110,10 +1110,11 @@ def run_chunked_transformer_no_pcc(
     def format_duration(seconds: float) -> str:
         return f"{seconds:7.3f}s"
 
-    def print_duration_table(iteration_chunk_times: list[list[float]]) -> list[str]:
+    def print_duration_table(iteration_chunk_times: list[list[float]]) -> tuple[list[str], list[str]]:
         """Log the per-chunk median/stddev table (and, when a baseline is set, the tolerance band +
-        PASS/FAIL). Returns the list of human-readable failure messages (empty if all chunks pass or if
-        there is no baseline) so the caller can assert after the table has been printed."""
+        PASS/FAIL). Returns (failures, table_lines): failures are the human-readable out-of-band messages
+        (empty if all chunks pass or there is no baseline) so the caller can assert after the table is
+        printed; table_lines is the rendered table for the caller to emit as a summary."""
         # Iteration 0 includes compile/JIT effects; exclude it from perf stats.
         samples = iteration_chunk_times[1:]
         if not samples:

--- a/models/demos/deepseek_v3_d_p/tt/prefill_transformer_test_env_vars.md
+++ b/models/demos/deepseek_v3_d_p/tt/prefill_transformer_test_env_vars.md
@@ -162,8 +162,10 @@ Where InfiniteBench prompt subsets are cached (only relevant when `input_source`
 ### `MESH_DEVICE`
 If `TG`/`GALAXY`, the code treats the device as a Galaxy (`is_tg` in `perf_utils.py`).
 
-### `PCC_SUMMARY_DIR`
-Where PCC summary files/plots are written. Default `/tmp/pcc_summaries_<user>`.
+### `PREFILL_SUMMARIES`
+Root dir for CI summary files, one per-kind subdir: `PREFILL_SUMMARIES/pcc` (per-run PCC markdown/plots),
+`PREFILL_SUMMARIES/perf` (chunk-timing tables). One file per parameterized run; a CI step globs a subdir
+and concatenates into `$GITHUB_STEP_SUMMARY`. Default `/tmp/prefill_summaries_<user>`.
 
 ### `<NAME>_OUTPUT_DIR`
 Per-stage dump dir for `save_intermediate_output` — e.g. `NORM_OUTPUT_DIR`,

--- a/models/demos/deepseek_v3_d_p/tt/prefill_transformer_test_env_vars.md
+++ b/models/demos/deepseek_v3_d_p/tt/prefill_transformer_test_env_vars.md
@@ -163,9 +163,10 @@ Where InfiniteBench prompt subsets are cached (only relevant when `input_source`
 If `TG`/`GALAXY`, the code treats the device as a Galaxy (`is_tg` in `perf_utils.py`).
 
 ### `PREFILL_SUMMARIES`
-Root dir for CI summary files, one per-kind subdir: `PREFILL_SUMMARIES/pcc` (per-run PCC markdown/plots),
+Root dir for CI summary files, one per-kind subdir: `PREFILL_SUMMARIES/pcc` (per-run PCC markdown),
 `PREFILL_SUMMARIES/perf` (chunk-timing tables). One file per parameterized run; a CI step globs a subdir
-and concatenates into `$GITHUB_STEP_SUMMARY`. Default `/tmp/prefill_summaries_<user>`.
+and concatenates into `$GITHUB_STEP_SUMMARY`. Default `/tmp/prefill_summaries_<user>`. (PCC PNG plots are
+separate and still go to the trace dir, not here.)
 
 ### `<NAME>_OUTPUT_DIR`
 Per-stage dump dir for `save_intermediate_output` — e.g. `NORM_OUTPUT_DIR`,

--- a/models/demos/deepseek_v3_d_p/utils/pcc_plot_utils.py
+++ b/models/demos/deepseek_v3_d_p/utils/pcc_plot_utils.py
@@ -11,10 +11,11 @@ Provides:
 - Summary file writer for CI integration
 """
 
-import os
 from pathlib import Path
 
 from loguru import logger
+
+from models.demos.deepseek_v3_d_p.utils.prefill_summary_utils import summary_dir
 
 
 def _build_run_name(result: dict) -> str:
@@ -347,20 +348,15 @@ def write_pcc_summary(result: dict, threshold: float = 0.99, output_dir: str = N
     Args:
         result: Dict with 'pcc' tuple and metadata.
         threshold: PCC threshold for pass/fail.
-        output_dir: Directory for summary files.
-                    Defaults to PCC_SUMMARY_DIR env var or /tmp/pcc_summaries.
+        output_dir: Directory for summary files. Defaults to PREFILL_SUMMARIES/pcc.
 
     Returns:
         Path to the written file.
     """
     if output_dir is None:
-        # Per-user default dir: a shared hardcoded /tmp/pcc_summaries is owned by
-        # whoever created it first and raises PermissionError for everyone else.
-        import getpass
-
-        output_dir = os.getenv("PCC_SUMMARY_DIR", f"/tmp/pcc_summaries_{getpass.getuser()}")
-
-    out = Path(output_dir).resolve()
+        out = summary_dir("pcc")  # unified summaries root: PREFILL_SUMMARIES/pcc
+    else:
+        out = Path(output_dir).resolve()
     out.mkdir(parents=True, exist_ok=True)
 
     run_name = _build_run_name(result)

--- a/models/demos/deepseek_v3_d_p/utils/pcc_plot_utils.py
+++ b/models/demos/deepseek_v3_d_p/utils/pcc_plot_utils.py
@@ -15,7 +15,7 @@ from pathlib import Path
 
 from loguru import logger
 
-from models.demos.deepseek_v3_d_p.utils.prefill_summary_utils import summary_dir
+from models.demos.deepseek_v3_d_p.utils.prefill_summary_utils import is_primary_rank, summary_dir
 
 
 def _build_run_name(result: dict) -> str:
@@ -336,7 +336,7 @@ def _y_range(values: list, threshold: float) -> str:
     return f"{max(0, min_val):.2f} --> 1.00"
 
 
-def write_pcc_summary(result: dict, threshold: float = 0.99, output_dir: str = None) -> Path:
+def write_pcc_summary(result: dict, threshold: float = 0.99, output_dir: str = None) -> Path | None:
     """
     Write PCC summary markdown (with Mermaid charts) to a per-run file.
 
@@ -351,8 +351,12 @@ def write_pcc_summary(result: dict, threshold: float = 0.99, output_dir: str = N
         output_dir: Directory for summary files. Defaults to PREFILL_SUMMARIES/pcc.
 
     Returns:
-        Path to the written file.
+        Path to the written file, or None on a non-primary MPI rank (which writes nothing).
     """
+    # The default dir is the shared /ci volume in CI, and this test runs under `mpirun --pernode`;
+    # only rank 0 writes so ranks don't race-truncate the same file (matches emit_summary).
+    if not is_primary_rank():
+        return None
     if output_dir is None:
         out = summary_dir("pcc")  # unified summaries root: PREFILL_SUMMARIES/pcc
     else:

--- a/models/demos/deepseek_v3_d_p/utils/prefill_summary_utils.py
+++ b/models/demos/deepseek_v3_d_p/utils/prefill_summary_utils.py
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Shared CI summary plumbing for DeepSeek/GLM/Kimi prefill tests.
+
+Every prefill summary (per-layer PCC, chunk-timing perf, ...) lands under one root, PREFILL_SUMMARIES,
+in a per-kind subdir (PREFILL_SUMMARIES/pcc, PREFILL_SUMMARIES/perf), one file per parameterized run so a
+sweep never clobbers itself. A CI publish step globs a subdir and concatenates the files into
+$GITHUB_STEP_SUMMARY.
+"""
+
+import getpass
+import os
+from pathlib import Path
+
+from loguru import logger
+
+
+def summaries_root() -> Path:
+    """Root for all prefill CI summaries. A shared fixed dir is owned by whoever creates it first and
+    raises PermissionError for everyone else, so the default is per-user."""
+    return Path(os.getenv("PREFILL_SUMMARIES", f"/tmp/prefill_summaries_{getpass.getuser()}"))
+
+
+def summary_dir(kind: str) -> Path:
+    """PREFILL_SUMMARIES/<kind>, created if absent."""
+    d = (summaries_root() / kind).resolve()
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def render_table(headers: list[str], rows: list[list[str]]) -> list[str]:
+    """Fixed-width ASCII grid table (borders + header + rows) as a list of lines. `headers` and each row
+    are already-formatted cell strings; columns widen to the longest cell and are left-justified."""
+    widths = [len(h) for h in headers]
+    for row in rows:
+        for idx, cell in enumerate(row):
+            widths[idx] = max(widths[idx], len(cell))
+    sep = "+-" + "-+-".join("-" * w for w in widths) + "-+"
+
+    def render_row(values: list[str]) -> str:
+        return "| " + " | ".join(v.ljust(widths[idx]) for idx, v in enumerate(values)) + " |"
+
+    return [sep, render_row(headers), sep, *[render_row(r) for r in rows], sep]
+
+
+def emit_summary(kind: str, run_name: str, title: str, table_lines: list[str]) -> Path:
+    """Log the table to output AND persist it as PREFILL_SUMMARIES/<kind>/<run_name>.md. Emitting to
+    output is deliberate: the table must stay visible in the step log, not only in the file. The file
+    fences the table so it renders monospaced when a CI step concatenates these into
+    $GITHUB_STEP_SUMMARY."""
+    body = "\n".join(table_lines)
+    logger.info(f"{title}\n{body}")
+    path = summary_dir(kind) / f"{run_name}.md"
+    path.write_text(f"### {title}\n\n```text\n{body}\n```\n")
+    logger.info(f"{kind} summary written to {path}")
+    return path

--- a/models/demos/deepseek_v3_d_p/utils/prefill_summary_utils.py
+++ b/models/demos/deepseek_v3_d_p/utils/prefill_summary_utils.py
@@ -46,14 +46,26 @@ def render_table(headers: list[str], rows: list[list[str]]) -> list[str]:
     return [sep, render_row(headers), sep, *[render_row(r) for r in rows], sep]
 
 
-def emit_summary(kind: str, run_name: str, title: str, table_lines: list[str]) -> Path:
-    """Log the table to output AND persist it as PREFILL_SUMMARIES/<kind>/<run_name>.md. Emitting to
-    output is deliberate: the table must stay visible in the step log, not only in the file. The file
-    fences the table so it renders monospaced when a CI step concatenates these into
-    $GITHUB_STEP_SUMMARY."""
-    body = "\n".join(table_lines)
-    logger.info(f"{title}\n{body}")
+def _is_primary_rank() -> bool:
+    """True on MPI rank 0 (or a non-MPI run). Under `mpirun --pernode` every node runs the whole test,
+    so without this every rank would race-write the same file on the shared volume."""
+    for var in ("OMPI_COMM_WORLD_RANK", "PMIX_RANK", "PMI_RANK"):
+        rank = os.environ.get(var)
+        if rank is not None:
+            return rank == "0"
+    return True
+
+
+def emit_summary(kind: str, run_name: str, title: str, lines: list[str]) -> Path | None:
+    """On rank 0 only: print the block to stdout AND persist it as PREFILL_SUMMARIES/<kind>/<run_name>.md.
+    stdout (not loguru, which is stderr-bound here) so the block lands in the captured `-s` output. The
+    file fences the block so it renders monospaced when a CI step concatenates these into
+    $GITHUB_STEP_SUMMARY. Returns None on non-primary ranks (nothing written)."""
+    if not _is_primary_rank():
+        return None
+    body = "\n".join(lines)
+    print(f"{title}\n{body}", flush=True)
     path = summary_dir(kind) / f"{run_name}.md"
     path.write_text(f"### {title}\n\n```text\n{body}\n```\n")
-    logger.info(f"{kind} summary written to {path}")
+    logger.info(f"{kind} summary -> {path}")
     return path

--- a/models/demos/deepseek_v3_d_p/utils/prefill_summary_utils.py
+++ b/models/demos/deepseek_v3_d_p/utils/prefill_summary_utils.py
@@ -46,7 +46,7 @@ def render_table(headers: list[str], rows: list[list[str]]) -> list[str]:
     return [sep, render_row(headers), sep, *[render_row(r) for r in rows], sep]
 
 
-def _is_primary_rank() -> bool:
+def is_primary_rank() -> bool:
     """True on MPI rank 0 (or a non-MPI run). Under `mpirun --pernode` every node runs the whole test,
     so without this every rank would race-write the same file on the shared volume."""
     for var in ("OMPI_COMM_WORLD_RANK", "PMIX_RANK", "PMI_RANK"):
@@ -61,7 +61,7 @@ def emit_summary(kind: str, run_name: str, title: str, lines: list[str]) -> Path
     stdout (not loguru, which is stderr-bound here) so the block lands in the captured `-s` output. The
     file fences the block so it renders monospaced when a CI step concatenates these into
     $GITHUB_STEP_SUMMARY. Returns None on non-primary ranks (nothing written)."""
-    if not _is_primary_rank():
+    if not is_primary_rank():
         return None
     body = "\n".join(lines)
     print(f"{title}\n{body}", flush=True)


### PR DESCRIPTION
- expose perf summary in blaze prefill tests.
- move the .md files from the device to the runner and print them in github summary.
- publish summaries artifacts, for later cross-run analysis.

example for both pcc graph and perf table:
https://github.com/tenstorrent/tt-metal/actions/runs/30152708217

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ppetrovic/prefill-perf-summary)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ppetrovic/prefill-perf-summary)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ppetrovic/prefill-perf-summary)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ppetrovic/prefill-perf-summary)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ppetrovic/prefill-perf-summary)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ppetrovic/prefill-perf-summary)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ppetrovic/prefill-perf-summary)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ppetrovic/prefill-perf-summary)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ppetrovic/prefill-perf-summary)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ppetrovic/prefill-perf-summary)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ppetrovic/prefill-perf-summary)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ppetrovic/prefill-perf-summary)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ppetrovic/prefill-perf-summary)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ppetrovic/prefill-perf-summary)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ppetrovic/prefill-perf-summary)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ppetrovic/prefill-perf-summary)