### PR TITLE
Bug fix: bcast ShardedHOptimised latent buffer over-runs

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_bcast.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_bcast.py
@@ -27,6 +27,9 @@ from tt_lib.utils import (
         (512, 1280, 40, (8, 5), ttnn.ShardStrategy.BLOCK),
         (128, 1280, 32, (4, 8), ttnn.ShardStrategy.BLOCK),
         (512, 1280, 64, (8, 8), ttnn.ShardStrategy.BLOCK),
+        # Wt=10 per core (=ceil(1280/32/4)) exercises the partial w-block path (w_blk=8):
+        # regression for the reader over-read/over-produce that deadlocked when batch_b>1.
+        (128, 1280, 4, (8, 5), ttnn.ShardStrategy.WIDTH),
     ),
 )
 @pytest.mark.parametrize(

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_bcast.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_bcast.py
@@ -27,8 +27,9 @@ from tt_lib.utils import (
         (512, 1280, 40, (8, 5), ttnn.ShardStrategy.BLOCK),
         (128, 1280, 32, (4, 8), ttnn.ShardStrategy.BLOCK),
         (512, 1280, 64, (8, 8), ttnn.ShardStrategy.BLOCK),
-        # Wt=10 per core (=ceil(1280/32/4)) exercises the partial w-block path (w_blk=8):
-        # regression for the reader over-read/over-produce that deadlocked when batch_b>1.
+        # Wt=10 per core (=ceil(1280/32/4)): pre-fix w_blk=min(Wt,8)=8 did not divide Wt and
+        # deadlocked / corrupted on batch_b>1. Post-fix factory picks w_blk=5 (largest divisor
+        # <=8), so chunks are full (no partial w-block). in0=in1=2 also covers h partial-block.
         (128, 1280, 4, (8, 5), ttnn.ShardStrategy.WIDTH),
     ),
 )

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_sharded_h_optimised_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_sharded_h_optimised_program_factory.cpp
@@ -90,7 +90,16 @@ tt::tt_metal::ProgramDescriptor BcastShardedHOptimisedProgramFactory::create_des
     const uint32_t output_cb_index = tt::CBIndex::c_16;
 
     const uint32_t h_blk = std::min(Ht, 8u);
-    const uint32_t w_blk = std::min(Wt, 8u);
+    // w_blk must divide Wt. The reader streams b tiles through the small c_1 ring buffer
+    // (num_input_tiles = w_blk) in fixed w_blk chunks, writing each chunk contiguously from
+    // get_write_ptr(). If w_blk does not divide Wt, the per-batch push count (Wt) misaligns
+    // the ring across batches and a chunk's contiguous write wraps past the buffer end,
+    // corrupting b tiles (and over-reading src1 / deadlocking when batch_b > 1). Pick the
+    // largest divisor of Wt that is <= 8; this is unchanged (== min(Wt, 8)) for all Wt <= 8.
+    uint32_t w_blk = std::min(Wt, 8u);
+    while (Wt % w_blk != 0) {
+        w_blk--;
+    }
 
     const uint32_t num_input_tiles = w_blk;
     const uint32_t src1_cb_index = tt::CBIndex::c_1;

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/compute/bcast_h_sharded_optimised.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/compute/bcast_h_sharded_optimised.cpp
@@ -32,15 +32,19 @@ void kernel_main() {
         for (uint32_t wt = 0; wt < Wt; wt++) {
             dfb_b.wait_front(onetile);
             for (uint32_t ht = 0; ht < Ht_per_batch_b; ht += h_blk) {
+                // Clamp the final (partial) block so we never process rows past this batch's
+                // Ht_per_batch_b tiles; otherwise current_index over-runs c_0/c_16 (past
+                // num_tile_per_core on the last batch), corrupting the borrowed shard buffers.
+                const uint32_t block_tiles = (Ht_per_batch_b - ht) < h_blk ? (Ht_per_batch_b - ht) : h_blk;
                 tile_regs_acquire();
-                for (uint32_t htr = 0; htr < h_blk; htr++) {
+                for (uint32_t htr = 0; htr < block_tiles; htr++) {
                     uint32_t current_index = b_offset + (ht + htr) * Wt + wt;
                     BCAST_OP<BroadcastType::ROW>(cb_a_id, cb_b_id, current_index, 0, htr);
                 }
                 tile_regs_commit();
 
                 tile_regs_wait();
-                for (uint32_t htr = 0; htr < h_blk; htr++) {
+                for (uint32_t htr = 0; htr < block_tiles; htr++) {
                     uint32_t current_index = b_offset + (ht + htr) * Wt + wt;
                     pack_tile<true>(htr, cb_out_id, current_index);
                 }


### PR DESCRIPTION
### Issue
Closes #50908.

### Summary

Fixes two **latent buffer over-run bugs** in the `BcastShardedHOptimised` height-broadcast path (`ttnn/cpp/ttnn/operations/data_movement/bcast`). Both pre-exist on `main` and only surface with multi-batch (`batch_b > 1`) or wide-shard (`Wt > 8`) sharded configs — as benign passes, watcher/CB-sanitizer trips, or device hangs.

Closes #50908. Unblocks the Metal 2.0 / Host 2.0 port of this factory tracked in #50790 (the fixes here are behavior-preserving except for the correctness changes below; the port is out of scope).

**Bug 1 — compute kernel h-block over-run (`batch_b > 1`).** In `kernels/compute/bcast_h_sharded_optimised.cpp`, the `ht` loop steps by `h_blk` up to `Ht_per_batch_b`, but the inner `htr` loop runs the full `h_blk` unconditionally (`h_blk = min(Ht, 8)`, independent of `Ht_per_batch_b`). On a partial final block, `current_index` runs past the batch's rows and — on the last batch — past `num_tile_per_core = Wt*Ht`, over-running the `c_0` reads and `c_16` `pack_tile` writes. Passes normally (benign L1 spill) but deadlocks under CB sanitization. Fix: clamp each block to `min(h_blk, Ht_per_batch_b - ht)` for both the `BCAST_OP` and `pack_tile` loops (`c_0`/`c_16` are borrowed full-size buffers, so an absolute-index clamp suffices).

**Bug 2 — reader w-block ring-buffer wrap (`Wt` not a multiple of `w_blk`).** `kernels/dataflow/reader_bcast_h_sharded_optimised.cpp` streams `b` tiles through the small `c_1` ring buffer (`num_input_tiles = w_blk`) in fixed `w_blk` chunks, writing each chunk contiguously from `get_write_ptr()`. With `w_blk = min(Wt, 8)`, when `w_blk` does not divide `Wt` the per-batch push count (`Wt`) misaligns the ring across batches; on `batch_b > 1` a chunk's contiguous write wraps past the buffer end, over-reading `src1` and corrupting `b` tiles. Fix: pick `w_blk` as the largest divisor of `Wt` that is `<= 8` (factory) — a no-op (`== min(Wt, 8)`) for all `Wt <= 8`, so existing configs are byte-for-byte unchanged.

**Regression coverage.** Added a WIDTH-sharded shape `(128, 1280, num_cores=4)` → `Wt = 10` to `misc/test_bcast.py`; its `in0=in1=2` variant exercises `batch_b = 2` together with both partial-block paths, guarding both fixes.

### Notes for reviewers

- The two bugs are on different axes and use technique appropriate to each buffer kind: `h_blk` (borrowed full-size `c_0`/`c_16`, absolute indexing) → kernel clamp; `w_blk` (small streaming `c_1` ring) → factory divisibility so contiguous chunk writes never wrap. A clamp alone does **not** fix Bug 2 (the ring wrap still corrupts `batch>0`); this was confirmed empirically (tile-level: `Wt=10` corrupts batch1 cols 6..9, `Wt=16` is clean).
- The `w_blk` change is deliberately a no-op for every `Wt <= 8`, so no existing config changes program structure.
- Verified on blackhole `p100a` (mechanism is arch-independent); full `tests/tt_eager/python_api_testing/unit_testing/misc/test_bcast.py` (640 cases) passes via `scripts/run_safe_pytest.sh`, and the previously-hanging reproducers pass (Bug 1 also verified clean under `--dev`).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=gchoudhary/50908/fix-bcast-sharded-h-optimised-overrun)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:gchoudhary/50908/fix-bcast-sharded-h-optimised-overrun)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=gchoudhary/50908/fix-bcast-sharded-h-optimised-overrun)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:gchoudhary/50908/fix-bcast-sharded-h-optimised-overrun)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=gchoudhary/50908/fix-bcast-sharded-h-optimised-overrun)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:gchoudhary/50908/fix-bcast-sharded-h-optimised-overrun)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=gchoudhary/50908/fix-bcast-sharded-h-optimised-overrun)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:gchoudhary/50908/fix-bcast-sharded-h-optimised-overrun)