### PR TITLE
[Bug Fix] Revert to_row_major_layout physical-shape check from #50285

### DIFF
--- a/tt_metal/impl/tensor/tensor_apis.cpp
+++ b/tt_metal/impl/tensor/tensor_apis.cpp
@@ -577,23 +577,15 @@ HostTensor to_row_major_layout_impl(const HostTensor& tensor) {
     }
 
     TT_FATAL(tensor.layout() == Layout::TILE, "Converting from {} to Row Major is unsupported.", tensor.layout());
-
-    // Do not pass a non-default tile into ROW_MAJOR PageConfig (deprecation #18536).
-    auto output_spec = TensorSpec(
+    // Construct the new tensor spec first to verify that this is a supported Tensor configuration
+    TensorSpec new_tensor_spec(
         tensor.logical_shape(),
-        TensorLayout(
+        TensorLayout::fromPaddedShape(
             tensor.dtype(),
             PageConfig(Layout::ROW_MAJOR),
-            tensor.memory_config(),
-            tensor.tensor_spec().tensor_layout().get_alignment()));
-
-    TT_FATAL(
-        output_spec.physical_shape() == tensor.tensor_spec().physical_shape(),
-        "to_layout: Converting layout to {} implicitly changed physical shape from {} to {} due to alignment "
-        "constraints. This is currently unsupported. Please pad the tensor explicitly before conversion.",
-        Layout::ROW_MAJOR,
-        tensor.tensor_spec().physical_shape(),
-        output_spec.physical_shape());
+            MemoryConfig{},
+            tensor.logical_shape(),
+            tensor.padded_shape()));
 
     auto tile = tensor.tensor_spec().tile();
     auto physical_shape = tensor.tensor_spec().physical_shape();
@@ -606,9 +598,7 @@ HostTensor to_row_major_layout_impl(const HostTensor& tensor) {
         },
         DistributedHostBuffer::ProcessShardExecutionPolicy::PARALLEL);
 
-    assert_host_shards_match_packed_size(transformed_buffer, output_spec, "to_row_major_layout");
-
-    return HostTensor::from_buffer(std::move(transformed_buffer), output_spec, tensor.tensor_topology());
+    return HostTensor::from_buffer(std::move(transformed_buffer), new_tensor_spec, tensor.tensor_topology());
 }
 
 template <typename T>


### PR DESCRIPTION
### PR Category

Bug Fix

### Summary

#50285 added a strict physical-shape guard to `to_row_major_layout_impl` that hard-errors when a `TILE` → `ROW_MAJOR` conversion implicitly changes the physical shape due to alignment. This broke `test_sharded_tensor.py::test_tensor_conversion_between_torch_and_tt_tile`.

The companion revert #50936 reverted the pad/unpad checks from #50285 but left this `to_layout` guard in place, so the failure persisted after that merge.

Fixes #51047, Fixes #51044.

### Note to reviewers

Verified locally.

Verification run on failed pipeline: https://github.com/tenstorrent/tt-metal/actions/runs/30301945502

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=riverwu/revert-to-row-major-physical-guard)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:riverwu/revert-to-row-major-physical-guard)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=riverwu/revert-to-row-major-physical-guard)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:riverwu/revert-to-row-major-physical-guard)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=riverwu/revert-to-row-major-physical-guard)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:riverwu/revert-to-row-major-physical-guard)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=riverwu/revert-to-row-major-physical-guard)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:riverwu/revert-to-row-major-physical-guard)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=riverwu/revert-to-row-major-physical-guard)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:riverwu/revert-to-row-major-physical-guard)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=riverwu/revert-to-row-major-physical-guard)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:riverwu/revert-to-row-major-physical-guard)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=riverwu/revert-to-row-major-physical-guard)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:riverwu/revert-to-row-major-physical-guard)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=riverwu/revert-to-row-major-physical-guard)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:riverwu/revert-to-row-major-physical-guard)