### PR TITLE
Route fabric generated artifacts through TT_METAL_LOGS_PATH

### DIFF
--- a/tests/tt_metal/tt_fabric/common/utils.cpp
+++ b/tests/tt_metal/tt_fabric/common/utils.cpp
@@ -472,7 +472,7 @@ void check_asic_mapping_against_golden(const std::string& test_name, const std::
     int rank = *distributed_context->rank();
 
     std::filesystem::path root_dir = rtoptions.get_root_dir();
-    std::filesystem::path generated_dir = root_dir / "generated" / "fabric";
+    std::filesystem::path generated_dir = std::filesystem::path(rtoptions.get_logs_dir()) / "generated" / "fabric";
     std::filesystem::path golden_dir = root_dir / "tests" / "tt_metal" / "tt_fabric" / "golden_mapping_files";
 
     // Check this rank's generated file
@@ -565,7 +565,7 @@ void check_intermesh_port_assignment_against_golden(const std::string& golden_na
     int rank = *distributed_context->rank();
 
     std::filesystem::path root_dir = rtoptions.get_root_dir();
-    std::filesystem::path fabric_dir = root_dir / "generated" / "fabric";
+    std::filesystem::path fabric_dir = std::filesystem::path(rtoptions.get_logs_dir()) / "generated" / "fabric";
 
     // Each rank writes only its own local mesh's channels. Wait for every rank to finish before rank 0
     // aggregates the per-rank files into the complete, all-mesh assignment (mock runs place all ranks on one

--- a/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
@@ -251,7 +251,7 @@ TEST_F(ControlPlaneFixture, TestT3kControlPlaneInit) {
     int world_size = *distributed_context->size();
     int rank = *distributed_context->rank();
     std::filesystem::path root_dir = rtoptions.get_root_dir();
-    std::filesystem::path generated_dir = root_dir / "generated" / "fabric";
+    std::filesystem::path generated_dir = std::filesystem::path(rtoptions.get_logs_dir()) / "generated" / "fabric";
     std::string generated_filename =
         "asic_to_fabric_node_mapping_rank_" + std::to_string(rank + 1) + "_of_" + std::to_string(world_size) + ".yaml";
     std::filesystem::path generated_file = generated_dir / generated_filename;
@@ -422,7 +422,7 @@ TEST_P(T3kCustomMeshGraphControlPlaneFixture, TestT3kControlPlaneInit) {
     int world_size = *distributed_context->size();
     int rank = *distributed_context->rank();
     std::filesystem::path root_dir = rtoptions.get_root_dir();
-    std::filesystem::path generated_dir = root_dir / "generated" / "fabric";
+    std::filesystem::path generated_dir = std::filesystem::path(rtoptions.get_logs_dir()) / "generated" / "fabric";
     std::string generated_filename =
         "asic_to_fabric_node_mapping_rank_" + std::to_string(rank + 1) + "_of_" + std::to_string(world_size) + ".yaml";
     std::filesystem::path generated_file = generated_dir / generated_filename;

--- a/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
@@ -250,7 +250,6 @@ TEST_F(ControlPlaneFixture, TestT3kControlPlaneInit) {
     const auto& distributed_context = tt::tt_metal::distributed::multihost::DistributedContext::get_current_world();
     int world_size = *distributed_context->size();
     int rank = *distributed_context->rank();
-    std::filesystem::path root_dir = rtoptions.get_root_dir();
     std::filesystem::path generated_dir = std::filesystem::path(rtoptions.get_logs_dir()) / "generated" / "fabric";
     std::string generated_filename =
         "asic_to_fabric_node_mapping_rank_" + std::to_string(rank + 1) + "_of_" + std::to_string(world_size) + ".yaml";
@@ -421,7 +420,6 @@ TEST_P(T3kCustomMeshGraphControlPlaneFixture, TestT3kControlPlaneInit) {
     const auto& distributed_context = tt::tt_metal::distributed::multihost::DistributedContext::get_current_world();
     int world_size = *distributed_context->size();
     int rank = *distributed_context->rank();
-    std::filesystem::path root_dir = rtoptions.get_root_dir();
     std::filesystem::path generated_dir = std::filesystem::path(rtoptions.get_logs_dir()) / "generated" / "fabric";
     std::string generated_filename =
         "asic_to_fabric_node_mapping_rank_" + std::to_string(rank + 1) + "_of_" + std::to_string(world_size) + ".yaml";

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -496,7 +496,7 @@ void ControlPlane::init_control_plane(
 
     // Automatically export physical chip mesh coordinate mapping to generated/fabric directory after topology mapper is
     // created This ensures ttnn-visualizer topology remains functional
-    std::filesystem::path output_file = std::filesystem::path(rtoptions.get_root_dir()) / "generated" / "fabric" /
+    std::filesystem::path output_file = std::filesystem::path(rtoptions.get_logs_dir()) / "generated" / "fabric" /
                                         ("physical_chip_mesh_coordinate_mapping_" + std::to_string(rank + 1) + "_of_" +
                                          std::to_string(world_size) + ".yaml");
     try {
@@ -505,7 +505,7 @@ void ControlPlane::init_control_plane(
         log_warning(tt::LogFabric, "Failed to export physical chip mesh coordinate mapping: {}", e.what());
     }
 
-    std::filesystem::path asic_mapping_file = std::filesystem::path(rtoptions.get_root_dir()) / "generated" / "fabric" /
+    std::filesystem::path asic_mapping_file = std::filesystem::path(rtoptions.get_logs_dir()) / "generated" / "fabric" /
                                               ("asic_to_fabric_node_mapping_rank_" + std::to_string(rank + 1) + "_of_" +
                                                std::to_string(world_size) + ".yaml");
     try {
@@ -524,7 +524,7 @@ void ControlPlane::init_control_plane(
     // Export the resolved inter-mesh port assignment (the port-determination output) to generated/fabric,
     // the same place as the ASIC mapping golden. Used by the inter-mesh golden test.
     {
-        std::filesystem::path intermesh_mapping_file = std::filesystem::path(rtoptions.get_root_dir()) / "generated" /
+        std::filesystem::path intermesh_mapping_file = std::filesystem::path(rtoptions.get_logs_dir()) / "generated" /
                                                        "fabric" /
                                                        ("intermesh_port_assignment_rank_" + std::to_string(rank + 1) +
                                                         "_of_" + std::to_string(world_size) + ".yaml");
@@ -611,7 +611,7 @@ void ControlPlane::init_control_plane_auto_discovery() {
 
     // Automatically export physical chip mesh coordinate mapping to generated/fabric directory after topology mapper is
     // created This ensures ttnn-visualizer topology remains functional
-    std::filesystem::path output_file = std::filesystem::path(rtoptions.get_root_dir()) / "generated" / "fabric" /
+    std::filesystem::path output_file = std::filesystem::path(rtoptions.get_logs_dir()) / "generated" / "fabric" /
                                         ("physical_chip_mesh_coordinate_mapping_" + std::to_string(rank + 1) + "_of_" +
                                          std::to_string(world_size) + ".yaml");
     try {
@@ -620,7 +620,7 @@ void ControlPlane::init_control_plane_auto_discovery() {
         log_warning(tt::LogFabric, "Failed to export physical chip mesh coordinate mapping: {}", e.what());
     }
 
-    std::filesystem::path asic_mapping_file = std::filesystem::path(rtoptions.get_root_dir()) / "generated" / "fabric" /
+    std::filesystem::path asic_mapping_file = std::filesystem::path(rtoptions.get_logs_dir()) / "generated" / "fabric" /
                                               ("asic_to_fabric_node_mapping_rank_" + std::to_string(rank + 1) + "_of_" +
                                                std::to_string(world_size) + ".yaml");
     try {
@@ -639,7 +639,7 @@ void ControlPlane::init_control_plane_auto_discovery() {
     // Export the resolved inter-mesh port assignment (the port-determination output) to generated/fabric,
     // the same place as the ASIC mapping golden. Used by the inter-mesh golden test.
     {
-        std::filesystem::path intermesh_mapping_file = std::filesystem::path(rtoptions.get_root_dir()) / "generated" /
+        std::filesystem::path intermesh_mapping_file = std::filesystem::path(rtoptions.get_logs_dir()) / "generated" /
                                                        "fabric" /
                                                        ("intermesh_port_assignment_rank_" + std::to_string(rank + 1) +
                                                         "_of_" + std::to_string(world_size) + ".yaml");


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Fabric control-plane initialization wrote generated mapping artifacts under `TT_METAL_HOME/generated/fabric`, even when callers set `TT_METAL_LOGS_PATH` to redirect runtime logs and debug output elsewhere. This made fabric inconsistent with other generated-output producers and caused source-tree pollution in test harnesses that intentionally isolate per-process logs. The control-plane writers now place fabric mapping and intermesh assignment files under `rtoptions.get_logs_dir()/generated/fabric`, and the fabric golden-test helpers read and clean up the same location. With `TT_METAL_LOGS_PATH` unset, the default layout is unchanged; when it is set, fabric artifacts now follow the documented logs path along with the rest of the generated runtime output.

### Notes for reviewers
none

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mcraighead/fabric-generated-logs-dir)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mcraighead/fabric-generated-logs-dir)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mcraighead/fabric-generated-logs-dir)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mcraighead/fabric-generated-logs-dir)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mcraighead/fabric-generated-logs-dir)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mcraighead/fabric-generated-logs-dir)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mcraighead/fabric-generated-logs-dir)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mcraighead/fabric-generated-logs-dir)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mcraighead/fabric-generated-logs-dir)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mcraighead/fabric-generated-logs-dir)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mcraighead/fabric-generated-logs-dir)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mcraighead/fabric-generated-logs-dir)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mcraighead/fabric-generated-logs-dir)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mcraighead/fabric-generated-logs-dir)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mcraighead/fabric-generated-logs-dir)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mcraighead/fabric-generated-logs-dir)