### PR TITLE
[Bug fix] MINFRA-1297 ttop-create-environment: refactor environment actions onto shared await

### DIFF
--- a/.github/actions/ttop-create-environment/action.yaml
+++ b/.github/actions/ttop-create-environment/action.yaml
@@ -26,10 +26,6 @@ inputs:
     description: 'Whether to mount volume shared with the runner (multihost-with-nfs runner required)'
     required: false
     default: 'false'
-  timeout:
-    description: 'Timeout duration'
-    required: false
-    default: '5m'
   namespace:
     description: 'Target namespace for the environment'
     required: false
@@ -42,6 +38,14 @@ inputs:
     description: 'Path to dump configs'
     required: false
     default: '/etc/ttop'
+  timeoutSeconds:
+    description: 'Max seconds to keep retrying before failing.'
+    required: false
+    default: '300'
+  retries:
+    description: 'Number of retries minting the OIDC in one attempt before giving up'
+    required: false
+    default: '3'
 
 runs:
   using: 'composite'
@@ -107,13 +111,20 @@ runs:
         echo "${{ env.ENVIRONMENT_MANIFEST }}" | kubectl --token ${{ steps.token.outputs.idToken }} -n${{ inputs.namespace }} apply -f -
 
     - name: Wait for environment
-      shell: bash
-      run: |
-        echo "Waiting for environment to be ready..."
-        kubectl --token ${{ steps.token.outputs.idToken }} -n${{ inputs.namespace }} wait --for=condition=Ready helmrelease/${{ inputs.environmentName }} --timeout=${{ inputs.timeout }}
+      uses: ./.github/actions/ttop-await-resource
+      with:
+        namespace: ${{ inputs.namespace }}
+        resource: helmrelease/${{ inputs.environmentName }}
+        mode: poll
+        jsonpath: '{.status.conditions[?(@.type=="Ready")].status}'
+        expected: 'True'
+        timeoutSeconds: ${{ inputs.timeoutSeconds }}
+        retries: ${{ inputs.retries }}
 
     - name: Connect to the environment
       shell: bash
       run: |
         echo "Connecting to environment..."
-        kubectl --token ${{ steps.token.outputs.idToken }} -n ${{ inputs.namespace }} get configmap ${{ inputs.environmentName }}-connection -o jsonpath='{.data.podNodeMapping}' 2>/dev/null | .github/scripts/environment-ssh-setup.sh
+        IDTOKEN=$(curl -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" $ACTIONS_ID_TOKEN_REQUEST_URL -H "Accept: application/json; api-version=2.0" -H "Content-Type: application/json" -d "{}" | jq -r '.value')
+        echo "::add-mask::${IDTOKEN}"
+        kubectl --token "$IDTOKEN" -n ${{ inputs.namespace }} get configmap ${{ inputs.environmentName }}-connection -o jsonpath='{.data.podNodeMapping}' 2>/dev/null | .github/scripts/environment-ssh-setup.sh

--- a/.github/actions/ttop-delete-environment/action.yaml
+++ b/.github/actions/ttop-delete-environment/action.yaml
@@ -9,19 +9,23 @@ inputs:
     description: 'Target namespace for the environment'
     required: false
     default: 'ttop-ci'
+  timeoutSeconds:
+    description: 'Max seconds to keep retrying the delete before failing.'
+    required: false
+    default: '300'
+  retries:
+    description: 'Number of retries minting the OIDC in one attempt before giving up'
+    required: false
+    default: '3'
 
 runs:
   using: 'composite'
   steps:
-    - name: Get github ID token
-      shell: bash
-      id: token
-      run: |
-        IDTOKEN=$(curl -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" $ACTIONS_ID_TOKEN_REQUEST_URL -H "Accept: application/json; api-version=2.0" -H "Content-Type: application/json" -d "{}" | jq -r '.value')
-        echo "::add-mask::${IDTOKEN}"
-        echo "idToken=${IDTOKEN}" >> $GITHUB_OUTPUT
-
     - name: Delete Environment
-      shell: bash
-      run: |
-        kubectl --token ${{ steps.token.outputs.idToken }} -n ${{ inputs.namespace }} delete helmrelease/${{ inputs.environmentName }} --ignore-not-found
+      uses: ./.github/actions/ttop-await-resource
+      with:
+        namespace: ${{ inputs.namespace }}
+        resource: helmrelease/${{ inputs.environmentName }}
+        mode: delete
+        timeoutSeconds: ${{ inputs.timeoutSeconds }}
+        retries: ${{ inputs.retries }}


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
The environment-creation CI step intermittently failed. After `Waiting for environment to be ready...`, the log filled with:

    Failed to watch err="Unauthorized" reflector="k8s.io/client-go/tools/watch/informerwatcher.go:162" type="*unstructured.Unstructured"

until the job hit its timeout and failed. Relates to MINFRA-1297.

Root cause is the same class of bug fixed for allocations in #50729: `kubectl wait --for=condition=Ready` opens a single long-lived watch authenticated with one short-lived (~10–15 min) OIDC token. On a slow run the token expires mid-watch, client-go retries the same dead watch with the expired token, never observes the Ready flip, and spins on `Unauthorized` until timeout. It's intermittent because it only triggers when the environment takes longer than the token lifetime to become ready (normally ~1 min).

Changes (both environment actions now build on the shared `ttop-await-resource` action from #50729):
- **`ttop-create-environment` – Wait:** replaced `kubectl wait` with `ttop-await-resource` in `poll` mode — discrete `kubectl get` polls that re-mint the token on `Unauthorized`, so a mid-wait expiry is absorbed instead of fatal. Readiness expressed as `jsonpath: {.status.conditions[?(@.type=="Ready")].status}` == `True` (the explicit form of `--for=condition=Ready`).
- **`ttop-create-environment` – Connect:** mints a fresh token immediately before its one-shot `kubectl get configmap`, instead of reusing the token minted before the (potentially long) wait.
- **`ttop-delete-environment`:** refactored to a thin caller of `ttop-await-resource` in `delete` mode (retry + hardened token minting), replacing the single-shot `kubectl delete`.
- Added `timeoutSeconds` (default `300`; replaces the old `5m` `timeout`, equivalent) and `retries` inputs, matching the allocation actions.

### Testing
- **Local functional harness** (stubbed `kubectl`/`curl` driving the extracted action logic):
  - create-environment Wait (`poll` mode): 6/6 — ready-immediately, reconciling-then-ready (waits), auth-reissue-then-ready, token-mint blip recovery (exit-6), never-ready timeout, and missing-jsonpath/expected guard.
  - delete-environment (`delete` mode): 4/4 — happy delete, auth-reissue, mint-blip recovery, timeout.
- **Ready-condition jsonpath verified against a real API server** (kind cluster + a HelmRelease CRD): `{.status.conditions[?(@.type=="Ready")].status}` extracts `True`/`False`/empty correctly and selects the `Ready` condition out of a multi-condition array.
- **Real CI** (Blaze Models Prefill on this branch): `Create test environment` and `Delete test environment` both pass against a live cluster/Flux; the environment is fully usable (ttnn imports, `/mnt/models` access, cluster validation all green) and cleanup runs on the failure path (no dangling). 

### Notes for reviewers
- Focus on the two changed files: `ttop-create-environment/action.yaml` (Wait + Connect) and `ttop-delete-environment/action.yaml` (thin delete caller).
- The Ready-condition jsonpath is the one piece reconstructed from `kubectl wait --for=condition=Ready` (no original jsonpath to copy) — see Testing for how it was verified.
- Out of scope / follow-up: the one-shot mints (create-environment apply, connect, `get-allocation-data`) still mint once without retry. They fail fast and visibly, unlike the silent timeout this fixes.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=yiyi/fix-environment)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:yiyi/fix-environment)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=yiyi/fix-environment)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:yiyi/fix-environment)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=yiyi/fix-environment)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:yiyi/fix-environment)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=yiyi/fix-environment)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:yiyi/fix-environment)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=yiyi/fix-environment)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:yiyi/fix-environment)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=yiyi/fix-environment)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:yiyi/fix-environment)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=yiyi/fix-environment)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:yiyi/fix-environment)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=yiyi/fix-environment)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:yiyi/fix-environment)