### PR TITLE
Split WH mul-reduce-scalar UNPACR_NOP zero-source and set-dvalid

### DIFF
--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_unpack_mul_reduce_scalar.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_unpack_mul_reduce_scalar.h
@@ -27,9 +27,10 @@ inline void _llk_unpack_mul_reduce_scalar_switch_to_reduce_()
 {
     TTI_SETADCZW(0b011, 0, 0, 0, 0, 0b1111);
     semaphore_post(semaphore::UNPACK_SYNC);
-    // WH UNPACR_NOP takes (block_selection, NoOp); UNP_ZEROSRC_SET_DVALID both zeroes the source
-    // and sets DVALID in one op (BH encodes the same via separate Set_Dvalid + Unpack_Pop fields).
-    TTI_UNPACR_NOP(SrcA, p_unpacr_nop::UNP_ZEROSRC_SET_DVALID);
-    TTI_UNPACR_NOP(SrcB, p_unpacr_nop::UNP_ZEROSRC_SET_DVALID);
+    // WH requires ZEROSRC and SET_DVALID to be sequenced as separate UNPACR_NOPs.
+    TTI_UNPACR_NOP(SrcA, p_unpacr_nop::UNP_ZEROSRC);
+    TTI_UNPACR_NOP(SrcA, p_unpacr_nop::UNP_SET_DVALID);
+    TTI_UNPACR_NOP(SrcB, p_unpacr_nop::UNP_ZEROSRC);
+    TTI_UNPACR_NOP(SrcB, p_unpacr_nop::UNP_SET_DVALID);
     t6_semaphore_get(semaphore::UNPACK_SYNC);
 }


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
`MulReduceScalarTests/MulReduceScalarTest.MulReduceScalar/MulReduceScalar_1_Tiles` was emitting a WH `UNPACR_NOP` instruction with `NoOp=0x41` via `UNP_ZEROSRC_SET_DVALID`, which sets a bit outside the `no_op` field described by the WH ISA JSON and was rejected as an invalid opcode. The WH `assembly.yaml` metadata explicitly warns not to use `ZEROSRC + SETDVALID` together for `UNPACR_NOP` and says to issue two `UNPACR_NOP` instructions instead. The WH mul-reduce-scalar unpack transition now follows that documented sequence for both SrcA and SrcB, first zeroing the source and then setting dvalid, which preserves the intended source-bank handoff without depending on the invalid combined encoding.

### Notes for reviewers
none

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mcraighead/wh-unpacr-nop)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mcraighead/wh-unpacr-nop)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mcraighead/wh-unpacr-nop)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mcraighead/wh-unpacr-nop)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mcraighead/wh-unpacr-nop)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mcraighead/wh-unpacr-nop)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mcraighead/wh-unpacr-nop)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mcraighead/wh-unpacr-nop)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mcraighead/wh-unpacr-nop)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mcraighead/wh-unpacr-nop)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mcraighead/wh-unpacr-nop)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mcraighead/wh-unpacr-nop)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mcraighead/wh-unpacr-nop)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mcraighead/wh-unpacr-nop)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mcraighead/wh-unpacr-nop)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mcraighead/wh-unpacr-nop)