### PR TITLE
Roll back Blackhole SFPI comparison kernel rewrites

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_comp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_comp.h
@@ -6,7 +6,6 @@
 #pragma once
 
 #include <type_traits>
-#include <cstdint>
 
 #include "ckernel_addrmod.h"
 #include "sfpi.h"
@@ -23,110 +22,139 @@ template <SfpuType Op>
 inline constexpr bool is_fp32_weak_ordered_compare_v = Op == SfpuType::le || Op == SfpuType::ge;
 
 template <SfpuType Op>
-inline constexpr bool is_fp32_compare_v =
-    is_fp32_equal_compare_v<Op> || is_fp32_strict_ordered_compare_v<Op> || is_fp32_weak_ordered_compare_v<Op>;
+inline constexpr bool is_fp32_compare_v = is_fp32_equal_compare_v<Op> || is_fp32_strict_ordered_compare_v<Op> || is_fp32_weak_ordered_compare_v<Op>;
 
 template <SfpuType>
 inline constexpr bool unsupported_fp32_compare_v = false;
 
-// fp32 total-order comparison helpers. Semantics preserved from the original raw-TTI
-// implementation: |a|+|b| folds ±0/subnormals together (sum == 0) and detects NaN
-// (as<vInt>(sum) > +inf bits). dst_reg[] uses sfpi row units (32/tile) vs the raw 64.
-//
-// NOTE: the fp32 comparison paths have no reliable tt-llk python coverage — the float
-// comparison suite (test_sfpu_binary_float) disables Lt/Gt/Le/Ge/Eq/Ne because the
-// generated stimuli produce near-ties. Validate at the ttnn level.
-constexpr int FP32_INF_BITS = 0x7F800000;
-constexpr std::uint32_t dst_tile_size_sfpi_comp = 32;
-
 template <int ITERATIONS, SfpuType RELATIONAL_OP>
-inline void calculate_binary_comp_fp32_equal(
-    const std::uint32_t dst_index_in0, const std::uint32_t dst_index_in1, const std::uint32_t dst_index_out) {
+inline void calculate_binary_comp_fp32_equal(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
     static_assert(is_fp32_equal_compare_v<RELATIONAL_OP>, "Supported operation types: eq, ne");
 
-    constexpr float default_result = RELATIONAL_OP == SfpuType::eq ? 0.0f : 1.0f;
-    constexpr float equal_result = RELATIONAL_OP == SfpuType::eq ? 1.0f : 0.0f;
+    constexpr uint a = p_sfpu::LREG0;
+    constexpr uint b = p_sfpu::LREG1;
+    constexpr uint abs_a = p_sfpu::LREG2;
+    constexpr uint abs_b = p_sfpu::LREG3;
+    constexpr uint sum = p_sfpu::LREG4;
+    constexpr uint inf = p_sfpu::LREG5;
+    constexpr uint default_result = RELATIONAL_OP == SfpuType::eq ? p_sfpu::LCONST_0 : p_sfpu::LCONST_1;
+    constexpr uint equal_result = RELATIONAL_OP == SfpuType::eq ? p_sfpu::LCONST_1 : p_sfpu::LCONST_0;
+    constexpr uint dst_tile_size = 64;
+
+    TTI_SFPLOADI(inf, sfpi::SFPLOADI_MOD0_FLOATB, 0x7f80);
 
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
-        sfpi::vFloat a = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi_comp];
-        sfpi::vFloat b = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi_comp];
-        sfpi::vFloat sum = sfpi::abs(a) + sfpi::abs(b);
-        sfpi::vInt sum_bits = sfpi::as<sfpi::vInt>(sum);
-        sfpi::vFloat result = default_result;
+        TT_SFPLOAD(a, InstrModLoadStore::DEFAULT, ADDR_MOD_7, dst_index_in0 * dst_tile_size);
+        TT_SFPLOAD(b, InstrModLoadStore::DEFAULT, ADDR_MOD_7, dst_index_in1 * dst_tile_size);
+        TT_SFPSTORE(default_result, InstrModLoadStore::DEFAULT, ADDR_MOD_7, dst_index_out * dst_tile_size);
 
-        // total-order a == b (a <= b && b <= a)
-        v_if(a <= b && b <= a) { result = equal_result; }
-        v_endif;
-        // |a|+|b| == 0 treats all ±0/subnormals as equal
-        v_if(sum == 0.0f) { result = equal_result; }
-        v_endif;
-        // NaN (|a|+|b| > inf) is never equal
-        v_if(sum_bits > FP32_INF_BITS) { result = default_result; }
-        v_endif;
+        TTI_SFPSETSGN(0, b, abs_b, 1); // SFPSETSGN_MOD1_ARG_IMM
+        TTI_SFPSETSGN(0, a, abs_a, 1); // SFPSETSGN_MOD1_ARG_IMM
+        TTI_SFPMAD(p_sfpu::LCONST_1, abs_a, abs_b, sum, 0);
 
-        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi_comp] = result;
-        sfpi::dst_reg++;
+        TTI_SFPLE(0, b, a, 1); // SFPLE_MOD1_SET_CC
+        // if total-order a == b
+        TTI_SFPLE(0, a, b, 1); // SFPLE_MOD1_SET_CC
+        // if abs(a) + abs(b) <= inf; rejects NaN
+        TTI_SFPIADD(0, inf, sum, sfpi::SFPIADD_MOD1_ARG_2SCOMP_LREG_DST | sfpi::SFPIADD_MOD1_CC_GTE0);
+        TT_SFPSTORE(equal_result, InstrModLoadStore::DEFAULT, ADDR_MOD_7, dst_index_out * dst_tile_size);
+
+        TTI_SFPENCC(0, 0, 0, 0);
+
+        // if abs(a) + abs(b) == 0; this allows us to treat all ±subnormals as equal
+        TTI_SFPSETCC(0, sum, 0, sfpi::SFPSETCC_MOD1_LREG_EQ0);
+        TT_SFPSTORE(equal_result, InstrModLoadStore::DEFAULT, ADDR_MOD_6, dst_index_out * dst_tile_size);
+
+        TTI_SFPENCC(0, 0, 0, 0);
     }
 }
 
 template <int ITERATIONS, SfpuType RELATIONAL_OP>
 inline void calculate_binary_comp_fp32_strict_ordered(
-    const std::uint32_t dst_index_in0, const std::uint32_t dst_index_in1, const std::uint32_t dst_index_out) {
+    const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
     static_assert(is_fp32_strict_ordered_compare_v<RELATIONAL_OP>, "Supported operation types: lt, gt");
 
-    // gt(a,b) == lt(b,a): swap operands and compute the shared strict-less-than body.
+    constexpr uint a = p_sfpu::LREG0;
+    constexpr uint b = p_sfpu::LREG1;
+    constexpr uint abs_a = p_sfpu::LREG2;
+    constexpr uint abs_b = p_sfpu::LREG3;
+    constexpr uint sum = p_sfpu::LREG4;
+    constexpr uint inf = p_sfpu::LREG5;
+    constexpr uint dst_tile_size = 64;
+
     constexpr bool swap_operands = RELATIONAL_OP == SfpuType::gt;
-    const std::uint32_t dst_index_a = swap_operands ? dst_index_in1 : dst_index_in0;
-    const std::uint32_t dst_index_b = swap_operands ? dst_index_in0 : dst_index_in1;
+    const uint dst_index_a = swap_operands ? dst_index_in1 : dst_index_in0;
+    const uint dst_index_b = swap_operands ? dst_index_in0 : dst_index_in1;
+
+    TTI_SFPLOADI(inf, sfpi::SFPLOADI_MOD0_FLOATB, 0x7f80);
 
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
-        sfpi::vFloat a = sfpi::dst_reg[dst_index_a * dst_tile_size_sfpi_comp];
-        sfpi::vFloat b = sfpi::dst_reg[dst_index_b * dst_tile_size_sfpi_comp];
-        sfpi::vFloat sum = sfpi::abs(a) + sfpi::abs(b);
-        sfpi::vInt sum_bits = sfpi::as<sfpi::vInt>(sum);
-        sfpi::vFloat result = 0.0f;
+        TT_SFPLOAD(a, InstrModLoadStore::DEFAULT, ADDR_MOD_7, dst_index_a * dst_tile_size);
+        TT_SFPLOAD(b, InstrModLoadStore::DEFAULT, ADDR_MOD_7, dst_index_b * dst_tile_size);
+        TT_SFPSTORE(p_sfpu::LCONST_0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, dst_index_out * dst_tile_size);
 
-        // a < b, excluding both-±0/subnormal (sum == 0)
-        v_if(a < b && sum != 0.0f) { result = 1.0f; }
-        v_endif;
-        // NaN (|a|+|b| > inf) is never strictly ordered
-        v_if(sum_bits > FP32_INF_BITS) { result = 0.0f; }
-        v_endif;
+        TTI_SFPSETSGN(0, a, abs_a, 1); // SFPSETSGN_MOD1_ARG_IMM
+        TTI_SFPSETSGN(0, b, abs_b, 1); // SFPSETSGN_MOD1_ARG_IMM
 
-        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi_comp] = result;
-        sfpi::dst_reg++;
+        TTI_SFPMAD(p_sfpu::LCONST_1, abs_a, abs_b, sum, 0);
+        // if total-order a < b
+        TTI_SFPGT(0, a, b, 1); // SFPGT_MOD1_SET_CC
+
+        // if abs(a) + abs(b) != 0; rejects if both are ±subnormal
+        TTI_SFPSETCC(0, sum, 0, sfpi::SFPSETCC_MOD1_LREG_NE0);
+        // if abs(a) + abs(b) <= inf; rejects NaN
+        TTI_SFPIADD(0, inf, sum, sfpi::SFPIADD_MOD1_ARG_2SCOMP_LREG_DST | sfpi::SFPIADD_MOD1_CC_GTE0);
+        TT_SFPSTORE(p_sfpu::LCONST_1, InstrModLoadStore::DEFAULT, ADDR_MOD_6, dst_index_out * dst_tile_size);
+
+        TTI_SFPENCC(0, 0, 0, 0);
     }
 }
 
 template <int ITERATIONS, SfpuType RELATIONAL_OP>
 inline void calculate_binary_comp_fp32_weak_ordered(
-    const std::uint32_t dst_index_in0, const std::uint32_t dst_index_in1, const std::uint32_t dst_index_out) {
+    const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
     static_assert(is_fp32_weak_ordered_compare_v<RELATIONAL_OP>, "Supported operation types: le, ge");
 
-    // ge(a,b) == le(b,a): swap operands and compute the shared less-than-or-equal body.
+    constexpr uint a = p_sfpu::LREG0;
+    constexpr uint b = p_sfpu::LREG1;
+    constexpr uint abs_a = p_sfpu::LREG2;
+    constexpr uint abs_b = p_sfpu::LREG3;
+    constexpr uint sum = p_sfpu::LREG4;
+    constexpr uint inf = p_sfpu::LREG5;
+    constexpr uint dst_tile_size = 64;
+
     constexpr bool swap_operands = RELATIONAL_OP == SfpuType::ge;
-    const std::uint32_t dst_index_a = swap_operands ? dst_index_in1 : dst_index_in0;
-    const std::uint32_t dst_index_b = swap_operands ? dst_index_in0 : dst_index_in1;
+    const uint dst_index_a = swap_operands ? dst_index_in1 : dst_index_in0;
+    const uint dst_index_b = swap_operands ? dst_index_in0 : dst_index_in1;
+
+    TTI_SFPLOADI(inf, sfpi::SFPLOADI_MOD0_FLOATB, 0x7f80);
 
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
-        sfpi::vFloat a = sfpi::dst_reg[dst_index_a * dst_tile_size_sfpi_comp];
-        sfpi::vFloat b = sfpi::dst_reg[dst_index_b * dst_tile_size_sfpi_comp];
-        sfpi::vFloat sum = sfpi::abs(a) + sfpi::abs(b);
-        sfpi::vInt sum_bits = sfpi::as<sfpi::vInt>(sum);
-        sfpi::vFloat result = 1.0f;
+        TT_SFPLOAD(a, InstrModLoadStore::DEFAULT, ADDR_MOD_7, dst_index_a * dst_tile_size);
+        TT_SFPLOAD(b, InstrModLoadStore::DEFAULT, ADDR_MOD_7, dst_index_b * dst_tile_size);
+        TT_SFPSTORE(p_sfpu::LCONST_1, InstrModLoadStore::DEFAULT, ADDR_MOD_7, dst_index_out * dst_tile_size);
 
-        // a > b (excluding both-±0/subnormal) -> 0
-        v_if(a > b && sum != 0.0f) { result = 0.0f; }
-        v_endif;
-        // NaN (|a|+|b| > inf) -> 0
-        v_if(sum_bits > FP32_INF_BITS) { result = 0.0f; }
-        v_endif;
+        TTI_SFPSETSGN(0, a, abs_a, 1); // SFPSETSGN_MOD1_ARG_IMM
+        TTI_SFPSETSGN(0, b, abs_b, 1); // SFPSETSGN_MOD1_ARG_IMM
 
-        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi_comp] = result;
-        sfpi::dst_reg++;
+        TTI_SFPMAD(p_sfpu::LCONST_1, abs_a, abs_b, sum, 0);
+        // if total-order a > b
+        TTI_SFPGT(0, b, a, 1); // SFPGT_MOD1_SET_CC
+
+        // if abs(a) + abs(b) != 0; rejects if both are ±subnormal
+        TTI_SFPSETCC(0, sum, 0, sfpi::SFPSETCC_MOD1_LREG_NE0);
+        TT_SFPSTORE(p_sfpu::LCONST_0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, dst_index_out * dst_tile_size);
+
+        TTI_SFPENCC(0, 0, 0, 0);
+
+        // if abs(a) + abs(b) > inf; a or b is NaN
+        TTI_SFPIADD(0, inf, sum, sfpi::SFPIADD_MOD1_ARG_2SCOMP_LREG_DST | sfpi::SFPIADD_MOD1_CC_LT0);
+        TT_SFPSTORE(p_sfpu::LCONST_0, InstrModLoadStore::DEFAULT, ADDR_MOD_6, dst_index_out * dst_tile_size);
+
+        TTI_SFPENCC(0, 0, 0, 0);
     }
 }
 
@@ -139,15 +167,15 @@ template <
     int ITERATIONS,
     SfpuType RELATIONAL_OP,
     std::enable_if_t<is_fp32_compare_v<RELATIONAL_OP>, int> = 0>
-inline void calculate_binary_comp_fp32(
-    const std::uint32_t dst_index_in0, const std::uint32_t dst_index_in1, const std::uint32_t dst_index_out) {
+inline void calculate_binary_comp_fp32(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
     if constexpr (is_fp32_equal_compare_v<RELATIONAL_OP>) {
         calculate_binary_comp_fp32_equal<ITERATIONS, RELATIONAL_OP>(dst_index_in0, dst_index_in1, dst_index_out);
     } else if constexpr (is_fp32_strict_ordered_compare_v<RELATIONAL_OP>) {
         calculate_binary_comp_fp32_strict_ordered<ITERATIONS, RELATIONAL_OP>(
             dst_index_in0, dst_index_in1, dst_index_out);
     } else if constexpr (is_fp32_weak_ordered_compare_v<RELATIONAL_OP>) {
-        calculate_binary_comp_fp32_weak_ordered<ITERATIONS, RELATIONAL_OP>(dst_index_in0, dst_index_in1, dst_index_out);
+        calculate_binary_comp_fp32_weak_ordered<ITERATIONS, RELATIONAL_OP>(
+            dst_index_in0, dst_index_in1, dst_index_out);
     } else {
         static_assert(unsupported_fp32_compare_v<RELATIONAL_OP>, "Unsupported fp32 comparison operation");
     }
@@ -160,40 +188,37 @@ inline void calculate_binary_comp_fp32(
 // original sign relationship with the subtraction result. The final shift
 // converts the selected top bit to 0 or 1.
 template <bool APPROXIMATION_MODE, int ITERATIONS, SfpuType RELATIONAL_OP>
-inline void calculate_binary_comp_int32(
-    const std::uint32_t dst_index_in0, const std::uint32_t dst_index_in1, const std::uint32_t dst_index_out) {
+inline void calculate_binary_comp_int32(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
     static_assert(
         RELATIONAL_OP == SfpuType::lt || RELATIONAL_OP == SfpuType::gt || RELATIONAL_OP == SfpuType::le ||
             RELATIONAL_OP == SfpuType::ge,
         "Supported operation types: lt, gt, le, ge");
 
-    // INT32 load layout converts Dest sign-magnitude <-> 2's-complement, so the loaded
-    // vInt lanes are true 2's-complement and sfpi's signed comparisons order them correctly.
-    // dst_reg[] indexes in sfpi row units (32/tile), unlike the raw TT_SFPLOAD immediate (64).
-    constexpr std::uint32_t dst_tile_size_sfpi = 32;
+    constexpr bool use_ge = (RELATIONAL_OP == SfpuType::le || RELATIONAL_OP == SfpuType::ge);
+    constexpr bool swap_operands = (RELATIONAL_OP == SfpuType::gt || RELATIONAL_OP == SfpuType::le);
+    constexpr uint a = p_sfpu::LREG0;
+    constexpr uint b = p_sfpu::LREG1;
+    constexpr uint scratch = p_sfpu::LREG2;
+    constexpr uint sign = use_ge ? 1 : 0;
+    constexpr uint tmp = use_ge ? b : a;
+    constexpr uint xor_src = use_ge ? a : b;
+    constexpr uint dst_tile_size = 64;
+
+    const uint dst_index_a = swap_operands ? dst_index_in1 : dst_index_in0;
+    const uint dst_index_b = swap_operands ? dst_index_in0 : dst_index_in1;
 
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
-        sfpi::vInt a = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi].mode<sfpi::DataLayout::I32>();
-        sfpi::vInt b = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi].mode<sfpi::DataLayout::I32>();
-        sfpi::vInt result = 0;
+        TT_SFPLOAD(a, InstrModLoadStore::INT32, ADDR_MOD_7, dst_index_a * dst_tile_size);
+        TT_SFPLOAD(b, InstrModLoadStore::INT32, ADDR_MOD_7, dst_index_b * dst_tile_size);
 
-        if constexpr (RELATIONAL_OP == SfpuType::lt) {
-            v_if(a < b) { result = 1; }
-            v_endif;
-        } else if constexpr (RELATIONAL_OP == SfpuType::gt) {
-            v_if(a > b) { result = 1; }
-            v_endif;
-        } else if constexpr (RELATIONAL_OP == SfpuType::le) {
-            v_if(a <= b) { result = 1; }
-            v_endif;
-        } else if constexpr (RELATIONAL_OP == SfpuType::ge) {
-            v_if(a >= b) { result = 1; }
-            v_endif;
-        }
-
-        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi].mode<sfpi::DataLayout::I32>() = result;
-        sfpi::dst_reg++;
+        TTI_SFPSETSGN(sign, b, scratch, 1); // SFPSETSGN_MOD1_ARG_IMM
+        TTI_SFPIADD(0, a, scratch, sfpi::SFPIADD_MOD1_ARG_2SCOMP_LREG_DST | sfpi::SFPIADD_MOD1_CC_NONE);
+        TTI_SFPXOR(0, xor_src, tmp, 0);
+        TTI_SFPOR(0, scratch, tmp, 0);
+        TTI_SFPXOR(0, b, a, 0);
+        TTI_SFPSHFT((-31) & 0xfff, a, a, 1); // SFPSHFT_MOD1_ARG_IMM
+        TT_SFPSTORE(a, InstrModLoadStore::INT32, ADDR_MOD_6, dst_index_out * dst_tile_size);
     }
 }
 
@@ -202,16 +227,8 @@ inline void calculate_binary_comp_int32(
 //   ge(a,b) = GE(a,b)           le(a,b) = GE(b,a)
 // UInt32 uses the same subtract/fold structure as Int32. On Blackhole, LO16
 // zero-extends UInt16 values, so sign-magnitude compare matches uint16 order.
-//
-// NOTE (sfpi conversion): still raw TTI. The metal/tt-llk binary-comparison dispatch
-// (sfpu_operations.h) only routes Int32 -> calculate_binary_comp_int32 and everything
-// else -> calculate_binary_comp_fp32, so this uint ordering path (and calculate_binary_eq_int
-// below) are ttnn-only and are neither instantiated nor testable by the tt-llk harness.
-// The uint32 case additionally needs an MSB-fold to emulate unsigned ordering with signed
-// sfpi compares; convert together with ttnn-level validation.
 template <bool APPROXIMATION_MODE, int ITERATIONS, SfpuType RELATIONAL_OP, DataFormat DATA_FORMAT>
-inline void calculate_binary_comp_uint(
-    const std::uint32_t dst_index_in0, const std::uint32_t dst_index_in1, const std::uint32_t dst_index_out) {
+inline void calculate_binary_comp_uint(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
     static_assert(
         DATA_FORMAT == DataFormat::UInt16 || DATA_FORMAT == DataFormat::UInt32,
         "Unsupported data format for calculate_binary_comp_uint(). Supported formats: UInt16, UInt32.");
@@ -224,16 +241,16 @@ inline void calculate_binary_comp_uint(
     constexpr bool swap_operands = (RELATIONAL_OP == SfpuType::gt || RELATIONAL_OP == SfpuType::le);
     constexpr bool needs_msb_handling = (DATA_FORMAT == DataFormat::UInt32);
     constexpr InstrModLoadStore ld_st_mod = needs_msb_handling ? InstrModLoadStore::INT32 : InstrModLoadStore::LO16;
-    constexpr std::uint32_t a = p_sfpu::LREG0;
-    constexpr std::uint32_t b = p_sfpu::LREG1;
-    constexpr std::uint32_t scratch = p_sfpu::LREG2;
-    constexpr std::uint32_t sign = use_ge ? 1 : 0;
-    constexpr std::uint32_t result = use_ge ? a : b;
-    constexpr std::uint32_t xor_src = use_ge ? b : a;
-    constexpr std::uint32_t dst_tile_size = 64;
+    constexpr uint a = p_sfpu::LREG0;
+    constexpr uint b = p_sfpu::LREG1;
+    constexpr uint scratch = p_sfpu::LREG2;
+    constexpr uint sign = use_ge ? 1 : 0;
+    constexpr uint result = use_ge ? a : b;
+    constexpr uint xor_src = use_ge ? b : a;
+    constexpr uint dst_tile_size = 64;
 
-    const std::uint32_t dst_index_a = swap_operands ? dst_index_in1 : dst_index_in0;
-    const std::uint32_t dst_index_b = swap_operands ? dst_index_in0 : dst_index_in1;
+    const uint dst_index_a = swap_operands ? dst_index_in1 : dst_index_in0;
+    const uint dst_index_b = swap_operands ? dst_index_in0 : dst_index_in1;
 
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
@@ -241,20 +258,20 @@ inline void calculate_binary_comp_uint(
         TT_SFPLOAD(b, ld_st_mod, ADDR_MOD_7, dst_index_b * dst_tile_size);
 
         if constexpr (needs_msb_handling) {
-            TTI_SFPSETSGN(sign, b, scratch, 1);  // SFPSETSGN_MOD1_ARG_IMM
+            TTI_SFPSETSGN(sign, b, scratch, 1); // SFPSETSGN_MOD1_ARG_IMM
             TTI_SFPIADD(0, a, scratch, sfpi::SFPIADD_MOD1_ARG_2SCOMP_LREG_DST | sfpi::SFPIADD_MOD1_CC_NONE);
             TTI_SFPXOR(0, xor_src, result, 0);
             TTI_SFPOR(0, scratch, result, 0);
             TTI_SFPXOR(0, xor_src, result, 0);
-            TTI_SFPSHFT((-31) & 0xfff, result, result, 1);  // SFPSHFT_MOD1_ARG_IMM
+            TTI_SFPSHFT((-31) & 0xfff, result, result, 1); // SFPSHFT_MOD1_ARG_IMM
             TT_SFPSTORE(result, ld_st_mod, ADDR_MOD_6, dst_index_out * dst_tile_size);
         } else {
             if constexpr (use_ge) {
-                TTI_SFPLE(0, a, b, 8);  // SFPLE_MOD1_SET_VD: b = (a >= b) ? -1 : 0
+                TTI_SFPLE(0, a, b, 8); // SFPLE_MOD1_SET_VD: b = (a >= b) ? -1 : 0
             } else {
-                TTI_SFPGT(0, a, b, 8);  // SFPGT_MOD1_SET_VD: b = (a < b) ? -1 : 0
+                TTI_SFPGT(0, a, b, 8); // SFPGT_MOD1_SET_VD: b = (a < b) ? -1 : 0
             }
-            TTI_SFPSHFT((-31) & 0xfff, b, b, 1);  // SFPSHFT_MOD1_ARG_IMM
+            TTI_SFPSHFT((-31) & 0xfff, b, b, 1); // SFPSHFT_MOD1_ARG_IMM
             TT_SFPSTORE(b, ld_st_mod, ADDR_MOD_6, dst_index_out * dst_tile_size);
         }
     }
@@ -264,8 +281,7 @@ inline void calculate_binary_comp_uint(
 // XOR a and b; the result is zero if a == b. A conditional store writes
 // the appropriate integer 0 or 1 result.
 template <bool APPROXIMATION_MODE, int ITERATIONS, SfpuType RELATIONAL_OP, DataFormat DATA_FORMAT>
-inline void calculate_binary_eq_int(
-    const std::uint32_t dst_index_in0, const std::uint32_t dst_index_in1, const std::uint32_t dst_index_out) {
+inline void calculate_binary_eq_int(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
     static_assert(
         DATA_FORMAT == DataFormat::Int32 || DATA_FORMAT == DataFormat::UInt16 || DATA_FORMAT == DataFormat::UInt32,
         "Unsupported data format for calculate_binary_eq_int(). Supported formats: Int32, UInt16, UInt32.");
@@ -273,14 +289,14 @@ inline void calculate_binary_eq_int(
 
     constexpr InstrModLoadStore ld_st_mod =
         (DATA_FORMAT == DataFormat::UInt16) ? InstrModLoadStore::LO16 : InstrModLoadStore::INT32;
-    constexpr std::uint32_t a = p_sfpu::LREG0;
-    constexpr std::uint32_t b = p_sfpu::LREG1;
-    constexpr std::uint32_t one = p_sfpu::LREG2;
-    constexpr std::uint32_t dst_tile_size = 64;
+    constexpr uint a = p_sfpu::LREG0;
+    constexpr uint b = p_sfpu::LREG1;
+    constexpr uint one = p_sfpu::LREG2;
+    constexpr uint dst_tile_size = 64;
 
     constexpr bool is_eq = (RELATIONAL_OP == SfpuType::eq);
-    constexpr std::uint32_t default_result = is_eq ? p_sfpu::LCONST_0 : one;
-    constexpr std::uint32_t equal_result = is_eq ? one : p_sfpu::LCONST_0;
+    constexpr uint default_result = is_eq ? p_sfpu::LCONST_0 : one;
+    constexpr uint equal_result = is_eq ? one : p_sfpu::LCONST_0;
 
     TTI_SFPLOADI(one, sfpi::SFPLOADI_MOD0_USHORT, 0x0001);
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_comp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_comp.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include "ckernel.h"
 #include "ckernel_defs.h"
 #include "llk_math_eltwise_unary_sfpu.h"
@@ -47,70 +48,81 @@ inline void not_equal_zero_init() {
 
 template <bool APPROXIMATION_MODE, SfpuType COMP_MODE, int ITERATIONS = 8>
 inline void calculate_comp() {
-    // fp32 total-order comparison-to-zero. |v| is used to fold ±0 together and to
-    // detect NaN: a NaN has |v| whose fp32 bit pattern is strictly greater than +inf
-    // (0x7F800000), so `as<vInt>(|v|) > 0x7F800000` isolates it.
-    constexpr int FP32_INF_BITS = 0x7F800000;
+    constexpr std::uint32_t V = p_sfpu::LREG0;
+    constexpr std::uint32_t ABS_V = p_sfpu::LREG2;
+    constexpr std::uint32_t INF = p_sfpu::LREG5;
+    constexpr std::uint32_t BFLOAT16_INF = 0x7f80;
+
+    if constexpr (
+        COMP_MODE == SfpuType::less_than_zero || COMP_MODE == SfpuType::greater_than_equal_zero ||
+        COMP_MODE == SfpuType::greater_than_zero || COMP_MODE == SfpuType::less_than_equal_zero) {
+        TTI_SFPLOADI(INF, sfpi::SFPLOADI_MOD0_FLOATB, BFLOAT16_INF);
+    }
 
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
-        vFloat v = dst_reg[0];
-        vFloat abs_v = sfpi::abs(v);
-        vInt abs_bits = as<vInt>(abs_v);
-        vFloat result;
+        TTI_SFPLOAD(V, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);
+        TTI_SFPSETSGN(0, V, ABS_V, 1);
 
-        // eqz: 1 where |v| == 0 (handles ±0; NaN has |v| != 0 → 0)
+        // eqz: default 0, set 1 where |v| == 0 (handles ±0; NaN has |v|!=0 → stays 0)
         if constexpr (COMP_MODE == SfpuType::equal_zero) {
-            result = 0.0f;
-            v_if(abs_v == 0.0f) { result = 1.0f; }
-            v_endif;
+            TTI_SFPSTORE(p_sfpu::LCONST_0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);
+            TTI_SFPSETCC(0, ABS_V, 0, sfpi::SFPSETCC_MOD1_LREG_EQ0);
+            TTI_SFPSTORE(p_sfpu::LCONST_1, InstrModLoadStore::DEFAULT, ADDR_MOD_6, 0);
+            TTI_SFPENCC(0, 0, 0, 0);
         }
 
-        // nez: 0 where |v| == 0 (handles ±0; NaN has |v| != 0 → 1)
+        // nez: default 1, set 0 where |v| == 0 (handles ±0; NaN has |v|!=0 → stays 1)
         if constexpr (COMP_MODE == SfpuType::not_equal_zero) {
-            result = 1.0f;
-            v_if(abs_v == 0.0f) { result = 0.0f; }
-            v_endif;
+            TTI_SFPSTORE(p_sfpu::LCONST_1, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);
+            TTI_SFPSETCC(0, ABS_V, 0, sfpi::SFPSETCC_MOD1_LREG_EQ0);
+            TTI_SFPSTORE(p_sfpu::LCONST_0, InstrModLoadStore::DEFAULT, ADDR_MOD_6, 0);
+            TTI_SFPENCC(0, 0, 0, 0);
         }
 
-        // ltz: (v < 0) AND (|v| != 0) → 1, then NaN → 0
+        // ltz: default 0; chain: (v < 0) AND (|v| != 0) AND (|v| <= inf) → 1
         if constexpr (COMP_MODE == SfpuType::less_than_zero) {
-            result = 0.0f;
-            v_if(v < 0.0f && abs_v != 0.0f) { result = 1.0f; }
-            v_endif;
-            v_if(abs_bits > FP32_INF_BITS) { result = 0.0f; }
-            v_endif;
+            TTI_SFPSTORE(p_sfpu::LCONST_0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);
+            TTI_SFPSETCC(0, V, 0, sfpi::SFPSETCC_MOD1_LREG_LT0);
+            TTI_SFPSETCC(0, ABS_V, 0, sfpi::SFPSETCC_MOD1_LREG_NE0);
+            TTI_SFPIADD(0, INF, ABS_V, sfpi::SFPIADD_MOD1_ARG_2SCOMP_LREG_DST | sfpi::SFPIADD_MOD1_CC_GTE0);
+            TTI_SFPSTORE(p_sfpu::LCONST_1, InstrModLoadStore::DEFAULT, ADDR_MOD_6, 0);
+            TTI_SFPENCC(0, 0, 0, 0);
         }
 
-        // gtz: (v >= 0) AND (|v| != 0) → 1, then NaN → 0
+        // gtz: default 0; chain: (v >= 0) AND (|v| != 0) AND (|v| <= inf) → 1
         if constexpr (COMP_MODE == SfpuType::greater_than_zero) {
-            result = 0.0f;
-            v_if(v >= 0.0f && abs_v != 0.0f) { result = 1.0f; }
-            v_endif;
-            v_if(abs_bits > FP32_INF_BITS) { result = 0.0f; }
-            v_endif;
+            TTI_SFPSTORE(p_sfpu::LCONST_0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);
+            TTI_SFPSETCC(0, V, 0, sfpi::SFPSETCC_MOD1_LREG_GTE0);
+            TTI_SFPSETCC(0, ABS_V, 0, sfpi::SFPSETCC_MOD1_LREG_NE0);
+            TTI_SFPIADD(0, INF, ABS_V, sfpi::SFPIADD_MOD1_ARG_2SCOMP_LREG_DST | sfpi::SFPIADD_MOD1_CC_GTE0);
+            TTI_SFPSTORE(p_sfpu::LCONST_1, InstrModLoadStore::DEFAULT, ADDR_MOD_6, 0);
+            TTI_SFPENCC(0, 0, 0, 0);
         }
 
-        // gez: default 1; negatives (excl. -0) → 0; NaN → 0
+        // gez: default 1; chain1: (v<0) AND (|v|!=0) → 0 (negatives excl. -0); chain2: |v|>inf → 0 (NaN)
         if constexpr (COMP_MODE == SfpuType::greater_than_equal_zero) {
-            result = 1.0f;
-            v_if(v < 0.0f && abs_v != 0.0f) { result = 0.0f; }
-            v_endif;
-            v_if(abs_bits > FP32_INF_BITS) { result = 0.0f; }
-            v_endif;
+            TTI_SFPSTORE(p_sfpu::LCONST_1, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);
+            TTI_SFPSETCC(0, V, 0, sfpi::SFPSETCC_MOD1_LREG_LT0);
+            TTI_SFPSETCC(0, ABS_V, 0, sfpi::SFPSETCC_MOD1_LREG_NE0);
+            TTI_SFPSTORE(p_sfpu::LCONST_0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);
+            TTI_SFPENCC(0, 0, 0, 0);
+            TTI_SFPIADD(0, INF, ABS_V, sfpi::SFPIADD_MOD1_ARG_2SCOMP_LREG_DST | sfpi::SFPIADD_MOD1_CC_LT0);
+            TTI_SFPSTORE(p_sfpu::LCONST_0, InstrModLoadStore::DEFAULT, ADDR_MOD_6, 0);
+            TTI_SFPENCC(0, 0, 0, 0);
         }
 
-        // lez: default 1; positives (excl. +0) → 0; NaN → 0
+        // lez: default 1; chain1: (v>=0) AND (|v|!=0) → 0 (positives excl. +0); chain2: |v|>inf → 0 (NaN)
         if constexpr (COMP_MODE == SfpuType::less_than_equal_zero) {
-            result = 1.0f;
-            v_if(v >= 0.0f && abs_v != 0.0f) { result = 0.0f; }
-            v_endif;
-            v_if(abs_bits > FP32_INF_BITS) { result = 0.0f; }
-            v_endif;
+            TTI_SFPSTORE(p_sfpu::LCONST_1, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);
+            TTI_SFPSETCC(0, V, 0, sfpi::SFPSETCC_MOD1_LREG_GTE0);
+            TTI_SFPSETCC(0, ABS_V, 0, sfpi::SFPSETCC_MOD1_LREG_NE0);
+            TTI_SFPSTORE(p_sfpu::LCONST_0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);
+            TTI_SFPENCC(0, 0, 0, 0);
+            TTI_SFPIADD(0, INF, ABS_V, sfpi::SFPIADD_MOD1_ARG_2SCOMP_LREG_DST | sfpi::SFPIADD_MOD1_CC_LT0);
+            TTI_SFPSTORE(p_sfpu::LCONST_0, InstrModLoadStore::DEFAULT, ADDR_MOD_6, 0);
+            TTI_SFPENCC(0, 0, 0, 0);
         }
-
-        dst_reg[0] = result;
-        dst_reg++;
     }
 }
 
@@ -167,26 +179,25 @@ inline void calculate_comp_int() {
     }
 }
 
-// NOTE: the uint16/uint32 comparison-to-zero paths below have no tt-llk python-test
-// coverage (the comp-to-zero suite only exercises Float16_b/Float32). They mirror the
-// original raw-TTI load/store modes (LO16 for uint16, INT32 for uint32) so behaviour is
-// preserved; validate at the ttnn level before relying on them.
 template <bool APPROXIMATION_MODE, SfpuType COMP_MODE, int ITERATIONS = 8>
 inline void calculate_comp_uint16() {
     static_assert((COMP_MODE == SfpuType::equal_zero) or (COMP_MODE == SfpuType::not_equal_zero));
+    // UInt16 values live in the low 16 bits of the dest word; DataLayout::U16 loads/stores them
+    // directly (SFPLOAD/SFPSTORE mod = UINT16), matching the InstrModLoadStore::LO16 path.
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
         vUInt v = dst_reg[0].mode<sfpi::DataLayout::U16>();
-        vUInt result = 0;
         if constexpr (COMP_MODE == SfpuType::equal_zero) {
-            v_if(v == 0) { result = 1; }
+            vUInt r = 0;
+            v_if(v == 0) { r = 1; }
             v_endif;
+            dst_reg[0].mode<sfpi::DataLayout::U16>() = r;
         } else {
-            v_if(v == 0) { result = 0; }
-            v_else { result = 1; }
+            vUInt r = 1;
+            v_if(v == 0) { r = 0; }
             v_endif;
+            dst_reg[0].mode<sfpi::DataLayout::U16>() = r;
         }
-        dst_reg[0].mode<sfpi::DataLayout::U16>() = result;
         dst_reg++;
     }
 }


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Blackhole regressions were seen across eltwise comparison coverage, including `test_binary_scalar.py`, `test_binaryng_fp32.py`, `test_binary_int32.py`, `test_binary_comp_fp32.py`, `test_unary.py`, and `test_unary_ops_ttnn.py`, while the same tests continued to pass on Wormhole. The failures came from the Blackhole comparison portions of the recent complex-SFPU-to-SFPI conversion: `ckernel_sfpu_binary_comp.h` and `ckernel_sfpu_comp.h` replaced deliberately structured raw-TTI comparison sequences with simpler direct SFPI comparisons. That changed important edge-case behavior, most clearly for signed int32 relational compares at full-range boundaries such as `INT32_MAX > -1`, where the old subtract/fold sequence handled ordering correctly but the rewritten path produced the wrong result. This change restores the previous Blackhole comparison implementations in those two files while leaving the unrelated SFPI conversions intact, preserving the established comparison semantics for integer and floating-point comparison paths and fixing the BH-only eltwise regressions.

### Notes for reviewers
This change is a partial revert of commit `2848c65adea1bc1a38bcbf9e7d4483a896eac9e5`.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mcraighead/bh-sanity-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mcraighead/bh-sanity-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mcraighead/bh-sanity-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mcraighead/bh-sanity-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mcraighead/bh-sanity-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mcraighead/bh-sanity-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mcraighead/bh-sanity-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mcraighead/bh-sanity-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mcraighead/bh-sanity-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mcraighead/bh-sanity-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mcraighead/bh-sanity-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mcraighead/bh-sanity-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mcraighead/bh-sanity-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mcraighead/bh-sanity-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mcraighead/bh-sanity-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mcraighead/bh-sanity-fix)