### PR TITLE
[do not merge] Feature: emulation runtime support for host-facing sockets and multi-chip dispatch

### DIFF
--- a/tt_metal/distributed/d2h_socket.cpp
+++ b/tt_metal/distributed/d2h_socket.cpp
@@ -12,6 +12,9 @@
 #include "impl/context/metal_context.hpp"
 #include "tt_metal/hw/inc/hostdev/socket.h"
 #include "tt_metal/llrt/tt_cluster.hpp"
+#ifdef TT_METAL_USE_EMULE
+#include "tt_metal/impl/emulation/emulated_program_runner.hpp"  // emule::pump_device (host-interleaved socket)
+#endif
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/tt_align.hpp>
 #include <tt-logger/tt-logger.hpp>
@@ -43,12 +46,20 @@ namespace {
 // `_mm_clflush` invalidates one host cache line; 64 B is the line size on typical x86-64.
 constexpr uint32_t k_x86_clflush_line_bytes = 64;
 
+// Drive the device forward one step from a host socket credit-wait loop. Simulator co-steps the umd
+// clock; emule pumps the parked fiber scheduler so a kernel blocked on this host-fed socket resumes.
 void advance_d2h_simulator_socket_device(MeshDevice* mesh_device, const MeshCoordinate& device_coord) {
     if (mesh_device == nullptr) {
         return;
     }
 
     const auto& cluster = MetalContext::instance().get_cluster();
+#ifdef TT_METAL_USE_EMULE
+    if (cluster.get_target_device_type() == tt::TargetDevice::Emule) {
+        tt::tt_metal::emule::pump_device();
+        return;
+    }
+#endif
     if (cluster.get_target_device_type() != tt::TargetDevice::Simulator) {
         return;
     }

--- a/tt_metal/distributed/d2h_socket.cpp
+++ b/tt_metal/distributed/d2h_socket.cpp
@@ -207,10 +207,15 @@ void D2HSocket::init_sender_tlb(const std::shared_ptr<MeshDevice>& mesh_device, 
     if (mesh_device) {
         sender_device_id = mesh_device->get_device(sender_core_.device_coord)->id();
         sender_virtual_core = mesh_device->worker_core_from_logical_core(sender_core_.core_coord);
-        sender_core_tlb_ = cluster.get_driver()
-                               ->get_chip(sender_device_id)
-                               ->get_tlb_manager()
-                               ->get_tlb_window(tt_xy_pair(sender_virtual_core.x, sender_virtual_core.y));
+        // Mock/emulated chips have no real TLB manager (SWEmuleChip::get_tlb_manager() always
+        // returns nullptr) — skip the static-TLB fetch below; the dynamic-TLB pcie_writer_ branch
+        // (cluster.write_core, which SWEmuleChip does support) is used for them instead.
+        if (!cluster.is_mock_or_emulated()) {
+            sender_core_tlb_ = cluster.get_driver()
+                                   ->get_chip(sender_device_id)
+                                   ->get_tlb_manager()
+                                   ->get_tlb_window(tt_xy_pair(sender_virtual_core.x, sender_virtual_core.y));
+        }
     } else {
         sender_device_id = device_id.value();
         sender_virtual_core = cluster.get_virtual_coordinate_from_logical_coordinates(
@@ -218,7 +223,7 @@ void D2HSocket::init_sender_tlb(const std::shared_ptr<MeshDevice>& mesh_device, 
     }
 
     auto arch = MetalContext::instance().hal().get_arch();
-    if (arch == tt::ARCH::BLACKHOLE && mesh_device) {
+    if (arch == tt::ARCH::BLACKHOLE && mesh_device && !cluster.is_mock_or_emulated()) {
         // This process owns a mesh_device and hence has statically initialized TLBs.
         // Entire device address space for Blackhole is statically mapped.
         // Safe to use static TLBs without requiring the driver to do a reconfig.

--- a/tt_metal/distributed/dispatch_context.cpp
+++ b/tt_metal/distributed/dispatch_context.cpp
@@ -51,8 +51,15 @@ void DispatchContext::initialize_fast_dispatch(distributed::MeshDevice* mesh_dev
     }
 
     ContextId context_id = extract_context_id(mesh_device);
-    fast_dispatch_enabled_ = MetalContext::instance(context_id).rtoptions().get_fast_dispatch();
     const auto& cluster = MetalContext::instance(context_id).get_cluster();
+    // Manually toggling Fast Dispatch is a real-hardware throughput optimization (bulk writes via
+    // on-device dispatch firmware); Mock/Emulated devices have no such firmware and already run every
+    // write synchronously regardless of dispatch mode, so this is a no-op for them (mirrors
+    // RiscFirmwareInitializer/FabricFirmwareInitializer's is_mock_or_emulated() skips).
+    if (cluster.is_mock_or_emulated()) {
+        return;
+    }
+    fast_dispatch_enabled_ = MetalContext::instance(context_id).rtoptions().get_fast_dispatch();
     TT_FATAL(
         !fast_dispatch_enabled_,
         "Fast Dispatch can only be manually enabled when running the workload with Slow Dispatch mode.");
@@ -115,10 +122,15 @@ void DispatchContext::terminate_fast_dispatch(distributed::MeshDevice* mesh_devi
         return;
     }
 
+    ContextId context_id = extract_context_id(mesh_device);
+    if (MetalContext::instance(context_id).get_cluster().is_mock_or_emulated()) {
+        // Mirrors the no-op in initialize_fast_dispatch — nothing was actually initialized.
+        return;
+    }
+
     TT_FATAL(fast_dispatch_enabled_, "Can only manually terminate fast dispatch after initializing it.");
     TT_FATAL(num_fd_inits_ == 1, "Fast Dispatch termination requires exactly one active manual Fast Dispatch session.");
 
-    ContextId context_id = extract_context_id(mesh_device);
     const auto& device_manager = MetalContext::instance(context_id).device_manager();
     const auto& active_devices = device_manager->get_all_active_devices();
 

--- a/tt_metal/distributed/h2d_socket.cpp
+++ b/tt_metal/distributed/h2d_socket.cpp
@@ -199,17 +199,22 @@ void H2DSocket::init_receiver_tlb(const std::shared_ptr<MeshDevice>& mesh_device
     if (mesh_device) {
         recv_device_id = mesh_device->get_device(recv_core_.device_coord)->id();
         recv_virtual_core = mesh_device->worker_core_from_logical_core(recv_core_.core_coord);
-        receiver_core_tlb_ = cluster.get_driver()
-                                 ->get_chip(recv_device_id)
-                                 ->get_tlb_manager()
-                                 ->get_tlb_window(tt_xy_pair(recv_virtual_core.x, recv_virtual_core.y));
+        // Mock/emulated chips have no real TLB manager (SWEmuleChip::get_tlb_manager() always
+        // returns nullptr) — skip the static-TLB fetch below; the dynamic-TLB pcie_writer branch
+        // (cluster.write_core, which SWEmuleChip does support) is used for them instead.
+        if (!cluster.is_mock_or_emulated()) {
+            receiver_core_tlb_ = cluster.get_driver()
+                                     ->get_chip(recv_device_id)
+                                     ->get_tlb_manager()
+                                     ->get_tlb_window(tt_xy_pair(recv_virtual_core.x, recv_virtual_core.y));
+        }
     } else {
         recv_device_id = device_id.value();
         recv_virtual_core = cluster.get_virtual_coordinate_from_logical_coordinates(
             recv_device_id, recv_core_.core_coord, CoreType::TENSIX);
     }
     auto arch = MetalContext::instance().hal().get_arch();
-    if (arch == tt::ARCH::BLACKHOLE && mesh_device) {
+    if (arch == tt::ARCH::BLACKHOLE && mesh_device && !cluster.is_mock_or_emulated()) {
         // This process owns a mesh_device and hence has statically initialized TLBs.
         // Entire device address space for Blackhole is statically mapped.
         // Safe to use static TLBs without requiring the driver to do a reconfig.

--- a/tt_metal/distributed/h2d_socket.cpp
+++ b/tt_metal/distributed/h2d_socket.cpp
@@ -12,6 +12,9 @@
 #include "impl/context/metal_context.hpp"
 #include "tt_metal/hw/inc/hostdev/socket.h"
 #include "tt_metal/llrt/tt_cluster.hpp"
+#ifdef TT_METAL_USE_EMULE
+#include "tt_metal/impl/emulation/emulated_program_runner.hpp"  // emule::pump_device (host-interleaved socket)
+#endif
 #include <tt-metalium/tt_align.hpp>
 #include <umd/device/chip_helpers/tlb_manager.hpp>
 #include <tt-logger/tt-logger.hpp>
@@ -24,12 +27,20 @@ namespace tt::tt_metal::distributed {
 
 namespace {
 
+// Drive the device forward one step from a host socket credit-wait loop. Simulator co-steps the umd
+// clock; emule pumps the parked fiber scheduler so a kernel blocked on this host-fed socket resumes.
 void advance_h2d_simulator_socket_device(MeshDevice* mesh_device, const MeshCoordinate& device_coord) {
     if (mesh_device == nullptr) {
         return;
     }
 
     const auto& cluster = MetalContext::instance().get_cluster();
+#ifdef TT_METAL_USE_EMULE
+    if (cluster.get_target_device_type() == tt::TargetDevice::Emule) {
+        tt::tt_metal::emule::pump_device();
+        return;
+    }
+#endif
     if (cluster.get_target_device_type() != tt::TargetDevice::Simulator) {
         return;
     }

--- a/tt_metal/impl/emulation/emulated_program_runner.cpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.cpp
@@ -65,6 +65,7 @@
 #include "impl/context/metal_context.hpp"
 #include "llrt/metal_soc_descriptor.hpp"
 #include "umd/device/chip/sw_emule_chip.hpp"
+#include "umd/device/chip_helpers/simulation_sysmem_manager.hpp"
 #include <tt-metalium/experimental/fabric/control_plane.hpp>  // fabric route table (multi-chip dst resolve)
 #include <tt-metalium/experimental/fabric/fabric_types.hpp>   // FabricNodeId, MeshId, FabricConfig
 #include <tt-metalium/experimental/fabric/fabric.hpp>         // is_2d_fabric_config
@@ -297,12 +298,56 @@ static constexpr uint32_t L1_SLOT_MASK = L1_SLOT_SIZE - 1;  // 0x1FFFFF
 //     that is the true in-bank offset (already includes
 //     `bank_to_dram_offset[bank_index]`). Masking to 2 MB silently aliases
 //     any DRAM access >= 2 MB to an offset within the first 2 MB of the bank.
+// Helper: get SWEmuleChip* from MetalContext cluster for a given device_id. (Relocated up from
+// later in this file — needed here for the PCIe branch below, and by the fabric teleport hooks
+// further down.)
+static tt::umd::SWEmuleChip* get_sw_emulated_chip(tt::ChipId device_id) {
+    auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
+    auto* umd_cluster = cluster.get_driver().get();
+    if (!umd_cluster) {
+        return nullptr;
+    }
+    auto* chip = umd_cluster->get_chip(device_id);
+    return dynamic_cast<tt::umd::SWEmuleChip*>(chip);
+}
+
+// Per-device cache of pcie_base_ (the host-facing/PCIe address threshold), keyed by device_id —
+// avoids a dynamic_cast + cluster lookup on every single NOC-address resolve. Rebuilt lazily; a
+// device close+reopen mints a new SWEmuleChip with a stable arch, so the cached value never goes
+// stale the way the core_map cache (which holds raw Core* into per-chip L1) can.
+static std::mutex g_pcie_base_mutex;
+static std::unordered_map<uint32_t, uint64_t> g_pcie_base_cache;
+
+static uint64_t get_pcie_base_cached(uint32_t device_id) {
+    std::lock_guard<std::mutex> lock(g_pcie_base_mutex);
+    auto it = g_pcie_base_cache.find(device_id);
+    if (it != g_pcie_base_cache.end()) {
+        return it->second;
+    }
+    auto* sw_emu = get_sw_emulated_chip(static_cast<tt::ChipId>(device_id));
+    uint64_t pcie_base =
+        sw_emu ? tt::umd::SysmemManager::get_pcie_base_for_arch(sw_emu->get_soc_descriptor().arch) : UINT64_MAX;
+    g_pcie_base_cache[device_id] = pcie_base;
+    return pcie_base;
+}
+
 extern "C" uint8_t* __emule_resolve_noc_addr(uint64_t noc_addr) {
+    emule_require_self(__func__);
+
+    // Host-facing (PCIe) address: SimulationSysmemManager's device_io_addr space starts at
+    // pcie_base_ and shares the same 64-bit range as a real on-chip NOC address, so this branch
+    // must run FIRST, before any noc_x/noc_y/local_addr decomposition below.
+    uint32_t device_id = __emule_self->chip_id;
+    if (noc_addr >= get_pcie_base_cached(device_id)) {
+        auto* sw_emu = get_sw_emulated_chip(static_cast<tt::ChipId>(device_id));
+        auto* sysmem = sw_emu ? static_cast<tt::umd::SimulationSysmemManager*>(sw_emu->get_sysmem_manager()) : nullptr;
+        return sysmem ? static_cast<uint8_t*>(sysmem->get_mapped_host_ptr(noc_addr, /*size=*/1)) : nullptr;
+    }
+
     uint32_t noc_x = (noc_addr >> NOC_LOCAL_BITS) & NOC_NODE_MASK;
     uint32_t noc_y = (noc_addr >> (NOC_LOCAL_BITS + NOC_NODE_ID_BITS)) & NOC_NODE_MASK;
     uint64_t local_addr = noc_addr & NOC_LOCAL_MASK;  // 36 bits, raw
 
-    emule_require_self(__func__);
     if (__emule_self->core_map) {
         uint64_t key = (uint64_t(noc_x) << 32) | noc_y;
         auto it = __emule_self->core_map->find(key);
@@ -1102,19 +1147,6 @@ static std::function<void()> jit_compile_kernel(
     // 11. Wrap in shared_ptr for lifetime management (dlclose on destruction).
     auto shared_handle = std::shared_ptr<void>(handle, [](void* h) { dlclose(h); });
     return [fn, shared_handle]() { fn(); };
-}
-
-// ---------------------------------------------------------------------------
-// Helper: get SWEmuleChip* from MetalContext cluster for a given device_id.
-// ---------------------------------------------------------------------------
-static tt::umd::SWEmuleChip* get_sw_emulated_chip(ChipId device_id) {
-    auto& cluster = MetalContext::instance().get_cluster();
-    auto* umd_cluster = cluster.get_driver().get();
-    if (!umd_cluster) {
-        return nullptr;
-    }
-    auto* chip = umd_cluster->get_chip(device_id);
-    return dynamic_cast<tt::umd::SWEmuleChip*>(chip);
 }
 
 // ---------------------------------------------------------------------------

--- a/tt_metal/impl/emulation/emulated_program_runner.cpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.cpp
@@ -274,6 +274,9 @@ extern "C" void __emule_fiber_unlock(void) { efib::FiberScheduler::instance().un
 extern "C" void __emule_fiber_park_locked(const void* key) {
     efib::FiberScheduler::instance().park_locked(key);
 }
+extern "C" void __emule_fiber_park_locked_socket(const void* key) {
+    efib::FiberScheduler::instance().park_locked_socket(key);
+}
 extern "C" void __emule_fiber_wake(const void* key) { efib::FiberScheduler::instance().wake(key); }
 extern "C" void __emule_fiber_yield(void) { efib::FiberScheduler::instance().yield(); }
 extern "C" void __emule_fiber_defer_to_quiescence(void) { efib::FiberScheduler::instance().quiescence_park(); }
@@ -3170,6 +3173,12 @@ static bool g_emule_mesh_defer = false;
 static std::vector<std::vector<std::vector<std::unique_ptr<tt_emule::EmuleDFBInterface[]>>>>
     g_mesh_dfb_keep;
 
+// [HOST-INTERLEAVED SOCKET] Set when run_mesh_dispatch's run_persistent() returned HostWait: the mesh
+// run is parked awaiting host socket I/O, with g_mesh_dfb_keep + the scheduler's fibers kept alive.
+// pump_device() drives it forward per host socket call; the pump that completes clears this + the mesh
+// keepalives (the cleanup run_mesh_dispatch deferred). See tt-emule docs/socket-emulation.md §7.
+static bool g_emule_host_wait = false;
+
 // Resolved-program cache — emule's analogue of silicon's is_compiled(): collect + JIT compile + resolve
 // run ONCE per program (keyed by ProgramId); every device dispatches against the shared read-only result.
 // LRU-bounded as a safety net. See tt-emule docs/fiber-engine.md.
@@ -3474,17 +3483,45 @@ void run_mesh_dispatch() {
 #if defined(__x86_64__) && defined(__linux__)
     EmuleSigfpeGuard sigfpe_guard;  // the actual kernel run happens here, across all chips
 #endif
-    // Reset defer + free the kept per-device state even if the run throws.
-    struct Cleanup {
-        ~Cleanup() {
-            g_emule_mesh_defer = false;
-            g_mesh_dfb_keep.clear();
-        }
-    } cleanup;
-    // All devices' fibers were registered (spawned) during the per-device register phase;
-    // run them concurrently on the worker pool in one pass. Each fiber's ctx carries its
-    // device's core_map/bridge_dram, so cross-chip NOC resolution stays correct.
-    tt::tt_metal::emule_fiber::FiberScheduler::instance().run_until_idle();
+    // All devices' fibers were registered (spawned) during the per-device register phase; run them
+    // concurrently on the worker pool in one pass. Each fiber's ctx carries its device's
+    // core_map/bridge_dram, so cross-chip NOC resolution stays correct. run_persistent (vs
+    // run_until_idle) lets a host-interleaved socket program quiesce back to the host mid-run.
+    tt::tt_metal::emule_fiber::RunOutcome oc = tt::tt_metal::emule_fiber::RunOutcome::Completed;
+    try {
+        oc = tt::tt_metal::emule_fiber::FiberScheduler::instance().run_persistent();
+    } catch (...) {
+        // Completed-with-exception (kernel throw / quiescent deadlock): free the kept state, rethrow.
+        g_emule_mesh_defer = false;
+        g_mesh_dfb_keep.clear();
+        throw;
+    }
+    if (oc == tt::tt_metal::emule_fiber::RunOutcome::HostWait) {
+        // A kernel is parked on a host-fed socket wait. Keep g_mesh_dfb_keep + the scheduler's fibers
+        // ALIVE and return to the host; it streams socket tokens and pump_device() drives the run to
+        // completion, which runs the deferred cleanup below (see pump_device()).
+        g_emule_host_wait = true;
+        return;
+    }
+    // Completed synchronously (no host-fed socket wait): the original register-drain cleanup.
+    g_emule_mesh_defer = false;
+    g_mesh_dfb_keep.clear();
+}
+
+void pump_device() {
+    // Drive a parked (run_persistent) mesh run forward one scheduler quantum. No-op unless a run is
+    // parked in HostWait (set by run_mesh_dispatch). The host advanced a socket credit word by a raw
+    // L1 store, so pump() blanket-re-polls the parked fibers to re-check predicates. When every fiber
+    // reaches Done the pump returns Completed — run the mesh cleanup run_mesh_dispatch deferred.
+    if (!g_emule_host_wait) {
+        return;
+    }
+    auto oc = tt::tt_metal::emule_fiber::FiberScheduler::instance().pump();
+    if (oc == tt::tt_metal::emule_fiber::RunOutcome::Completed) {
+        g_emule_host_wait = false;
+        g_emule_mesh_defer = false;
+        g_mesh_dfb_keep.clear();
+    }
 }
 
 }  // namespace tt::tt_metal::emule

--- a/tt_metal/impl/emulation/emulated_program_runner.cpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.cpp
@@ -143,16 +143,16 @@ thread_local uint32_t __emule_l1_host_ranges_count = 0;
 thread_local uint64_t* __emule_l1_resolved_ranges = nullptr;
 thread_local uint32_t* __emule_l1_resolved_ranges_count = nullptr;
 thread_local uint32_t __emule_l1_resolved_ranges_capacity = 0;
-thread_local uint32_t __emule_cb_reserved_pages[32] = {};
-thread_local uint32_t __emule_cb_waited_pages[32] = {};
+thread_local uint32_t __emule_cb_reserved_pages[EMULE_NUM_CBS] = {};
+thread_local uint32_t __emule_cb_waited_pages[EMULE_NUM_CBS] = {};
 // Dirty-CB leak flags: set by reserve/wait, cleared by push/pop; still-set at
 // kernel exit is the leak. Decoupled from the window counters. See SANITIZER_CHECKS.md §11.
-thread_local bool __emule_cb_reserve_dangling[32] = {};
-thread_local bool __emule_cb_wait_dangling[32] = {};
-thread_local const char* __emule_cb_reserve_file[32] = {};
-thread_local uint32_t __emule_cb_reserve_line[32] = {};
-thread_local const char* __emule_cb_wait_file[32] = {};
-thread_local uint32_t __emule_cb_wait_line[32] = {};
+thread_local bool __emule_cb_reserve_dangling[EMULE_NUM_CBS] = {};
+thread_local bool __emule_cb_wait_dangling[EMULE_NUM_CBS] = {};
+thread_local const char* __emule_cb_reserve_file[EMULE_NUM_CBS] = {};
+thread_local uint32_t __emule_cb_reserve_line[EMULE_NUM_CBS] = {};
+thread_local const char* __emule_cb_wait_file[EMULE_NUM_CBS] = {};
+thread_local uint32_t __emule_cb_wait_line[EMULE_NUM_CBS] = {};
 thread_local bool __emule_cb_boundary_strict = false;
 
 // DRAM equivalent of __emule_l1_tensor_ranges; consumed only by __emule_dram_ptr below.

--- a/tt_metal/impl/emulation/emulated_program_runner.cpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.cpp
@@ -344,7 +344,15 @@ extern "C" uint8_t* __emule_resolve_noc_addr(uint64_t noc_addr) {
     if (noc_addr >= get_pcie_base_cached(device_id)) {
         auto* sw_emu = get_sw_emulated_chip(static_cast<tt::ChipId>(device_id));
         auto* sysmem = sw_emu ? static_cast<tt::umd::SimulationSysmemManager*>(sw_emu->get_sysmem_manager()) : nullptr;
-        return sysmem ? static_cast<uint8_t*>(sysmem->get_mapped_host_ptr(noc_addr, /*size=*/1)) : nullptr;
+        // A host-facing address (>= pcie_base) is by construction on an emule chip that has a
+        // SimulationSysmemManager, so a null manager is a contract violation, not a resolvable miss.
+        // (A buffer miss still returns nullptr below — callers like noc_semaphore_set_remote rely on it.)
+        TT_FATAL(
+            sysmem != nullptr,
+            "emule: host-facing NOC address 0x{:x} on chip {} has no SimulationSysmemManager.",
+            noc_addr,
+            device_id);
+        return static_cast<uint8_t*>(sysmem->get_mapped_host_ptr(noc_addr, /*size=*/1));
     }
 
     uint32_t noc_x = (noc_addr >> NOC_LOCAL_BITS) & NOC_NODE_MASK;
@@ -1491,16 +1499,20 @@ static std::map<std::string, std::string> build_kernel_defines(
         }
         for (auto& cb_impl : cb_impls) {
             for (uint8_t idx : cb_impl->local_buffer_indices()) {
-                if (idx < EMULE_NUM_CBS) {
-                    // Calculate tile size from the CB's data format.
-                    const auto& tile = cb_impl->tile(idx);
-                    tile_sizes[idx] = tile.has_value() ? tile->get_tile_size(cb_impl->data_format(idx))
-                                                       : Tile().get_tile_size(cb_impl->data_format(idx));
-                    cb_formats[idx] = static_cast<uint8_t>(cb_impl->data_format(idx));
-                    if (tile.has_value()) {
-                        tile_r_dim[idx] = tile->get_height();
-                        tile_c_dim[idx] = tile->get_width();
-                    }
+                TT_FATAL(
+                    idx < EMULE_NUM_CBS,
+                    "CB index {} exceeds the emulated CB ceiling ({}); the host CircularBufferConfig must cap "
+                    "at the arch's NUM_CIRCULAR_BUFFERS.",
+                    idx,
+                    EMULE_NUM_CBS);
+                // Calculate tile size from the CB's data format.
+                const auto& tile = cb_impl->tile(idx);
+                tile_sizes[idx] = tile.has_value() ? tile->get_tile_size(cb_impl->data_format(idx))
+                                                   : Tile().get_tile_size(cb_impl->data_format(idx));
+                cb_formats[idx] = static_cast<uint8_t>(cb_impl->data_format(idx));
+                if (tile.has_value()) {
+                    tile_r_dim[idx] = tile->get_height();
+                    tile_c_dim[idx] = tile->get_width();
                 }
             }
         }
@@ -2709,7 +2721,13 @@ static void init_core_cb_sync(
     bool configured[EMULE_NUM_CBS] = {};
     auto configure = [&](const std::shared_ptr<CircularBufferImpl>& cb_impl, const CoreCoord& lc) {
         for (uint8_t idx : cb_impl->local_buffer_indices()) {
-            if (idx >= EMULE_NUM_CBS || configured[idx]) {
+            TT_FATAL(
+                idx < EMULE_NUM_CBS,
+                "CB index {} exceeds the emulated CB ceiling ({}); the host CircularBufferConfig must cap "
+                "at the arch's NUM_CIRCULAR_BUFFERS.",
+                idx,
+                EMULE_NUM_CBS);
+            if (configured[idx]) {
                 continue;
             }
             uint32_t cb_addr = cb_impl->address();

--- a/tt_metal/impl/emulation/emulated_program_runner.cpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.cpp
@@ -3531,14 +3531,33 @@ void pump_device() {
     // parked in HostWait (set by run_mesh_dispatch). The host advanced a socket credit word by a raw
     // L1 store, so pump() blanket-re-polls the parked fibers to re-check predicates. When every fiber
     // reaches Done the pump returns Completed — run the mesh cleanup run_mesh_dispatch deferred.
+    //
+    // Serialize: a host program drives H2D and D2H on separate threads, so both credit-wait loops can
+    // call pump_device() concurrently; the single resumable run + g_emule_host_wait are not reentrant.
+    static std::mutex pump_mu;
+    std::lock_guard<std::mutex> pump_lk(pump_mu);
     if (!g_emule_host_wait) {
         return;
     }
-    auto oc = tt::tt_metal::emule_fiber::FiberScheduler::instance().pump();
-    if (oc == tt::tt_metal::emule_fiber::RunOutcome::Completed) {
+#if defined(__x86_64__) && defined(__linux__)
+    // pump() re-enters kernel bodies; run_mesh_dispatch's guard was destroyed at its HostWait return,
+    // so reinstall the SIGFPE->RISC-V divide/overflow handler for the resumed execution.
+    EmuleSigfpeGuard sigfpe_guard;
+#endif
+    try {
+        auto oc = tt::tt_metal::emule_fiber::FiberScheduler::instance().pump();
+        if (oc == tt::tt_metal::emule_fiber::RunOutcome::Completed) {
+            g_emule_host_wait = false;
+            g_emule_mesh_defer = false;
+            g_mesh_dfb_keep.clear();
+        }
+    } catch (...) {
+        // pump() threw (kernel exception / host-wait stall deadlock) — the scheduler registry is torn
+        // down; drop the mesh keepalives + host-wait/defer flags so a later dispatch starts clean.
         g_emule_host_wait = false;
         g_emule_mesh_defer = false;
         g_mesh_dfb_keep.clear();
+        throw;
     }
 }
 

--- a/tt_metal/impl/emulation/emulated_program_runner.cpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.cpp
@@ -352,7 +352,7 @@ extern "C" uint8_t* __emule_resolve_noc_addr(uint64_t noc_addr) {
             "emule: host-facing NOC address 0x{:x} on chip {} has no SimulationSysmemManager.",
             noc_addr,
             device_id);
-        return static_cast<uint8_t*>(sysmem->get_mapped_host_ptr(noc_addr, /*size=*/1));
+        return static_cast<uint8_t*>(sysmem->get_mapped_host_ptr(noc_addr));
     }
 
     uint32_t noc_x = (noc_addr >> NOC_LOCAL_BITS) & NOC_NODE_MASK;

--- a/tt_metal/impl/emulation/emulated_program_runner.hpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.hpp
@@ -24,4 +24,10 @@ void execute_program_emulated(IDevice* device, Program& program);
 void begin_mesh_dispatch();
 void run_mesh_dispatch();
 
+/// Host-interleaved socket dispatch: drive a parked (run_persistent) device forward one scheduler
+/// quantum. Called from the host's H2D/D2H socket credit-wait loops (distributed/{h2d,d2h}_socket.cpp)
+/// so kernels blocked on a host-fed socket wait resume as the host streams tokens after program.run().
+/// No-op unless a run is parked in HostWait. See tt-emule docs/socket-emulation.md §7.
+void pump_device();
+
 }  // namespace tt::tt_metal::emule

--- a/tt_metal/impl/emulation/emule_fiber_scheduler.cpp
+++ b/tt_metal/impl/emulation/emule_fiber_scheduler.cpp
@@ -50,6 +50,8 @@ struct Fiber {
     FiberState state = FiberState::Ready;
     const void* park_key = nullptr;
     Fiber* park_link = nullptr;     // intrusive parked-list
+    bool wait_is_socket = false;    // parked on a host-fed socket credit word (park_locked_socket):
+                                    // marks a quiescence as "waiting for host I/O", not a deadlock
     std::exception_ptr eptr;
     unsigned home = 0;              // pinned worker — a fiber NEVER migrates (the JIT kernel
                                     // caches the thread_local __emule_self address)
@@ -102,6 +104,9 @@ struct FiberSchedulerImpl {
     unsigned active_ = 0;      // fibers not yet Done (under mu_)
     bool deadlock_ = false;
     bool abort_flag_ = false;
+    bool persistent_ = false;  // run_persistent/pump in flight: a host-fed socket wait quiescing is
+                               // a resumable HostWait, not a tier-1 deadlock. See run_persistent().
+    bool host_wait_ = false;   // set by inner_loop when it broke out for host I/O (vs Done/deadlock)
     std::exception_ptr first_eptr_;
 
     std::atomic<uint64_t> progress_{0};      // fiber completions + published pages (tier 2)
@@ -137,6 +142,14 @@ struct FiberSchedulerImpl {
     bool any_ready() const {                 // any runnable fiber in any worker's queue?
         for (const auto& q : ready_) {
             if (!q.empty()) return true;
+        }
+        return false;
+    }
+    bool any_parked_is_socket_wait() const {  // any parked fiber blocked on a host-fed socket wait?
+        for (const auto& kv : parked_) {      // cold path: only called at quiescence
+            for (Fiber* f = kv.second; f; f = f->park_link) {
+                if (f->wait_is_socket) return true;
+            }
         }
         return false;
     }
@@ -219,6 +232,17 @@ void FiberSchedulerImpl::inner_loop(unsigned w) {
                 last_progress_val_ = p;
                 last_progress_resump_ = r;
             } else if (r - last_progress_resump_ > spin_release_window) {
+                // Persistent (host-interleaved) run: churn with zero progress while a host-fed socket
+                // wait is parked means the device is blocked on the host (a peer RISC yield-spins on a
+                // barrier whose other side awaits a socket token). Hand control back so the host can
+                // stream + pump(), rather than force-releasing (which only re-churns). This is the
+                // yield-spin HostWait trigger (vs the quiescence-parked one below). See run_persistent.
+                if (persistent_ && any_parked_is_socket_wait()) {
+                    host_wait_ = true;
+                    abort_flag_ = true;
+                    cv_.notify_all();
+                    break;
+                }
                 for (Fiber* f : quiescence_deferred_) {
                     f->state = FiberState::Ready;
                     ready_[f->home].push_back(f);
@@ -293,6 +317,16 @@ void FiberSchedulerImpl::inner_loop(unsigned w) {
                         --idle_;
                         continue;
                     }
+                    // Re-poll made no new progress: genuinely stuck. Under a persistent run, a
+                    // host-fed socket wait parked here is not a deadlock — it is a resumable
+                    // HostWait: hand control back so the host can feed the socket and pump().
+                    // With no socket wait parked, it is a real deadlock (diagnostics unchanged).
+                    if (persistent_ && any_parked_is_socket_wait()) {
+                        host_wait_ = true;
+                        abort_flag_ = true;
+                        --idle_;
+                        break;
+                    }
                     deadlock_ = true;
                     abort_flag_ = true;
                     --idle_;
@@ -337,17 +371,24 @@ void FiberSchedulerImpl::inner_loop(unsigned w) {
 void FiberScheduler::lock() { p_->mu_.lock(); }
 void FiberScheduler::unlock() { p_->mu_.unlock(); }
 
-void FiberScheduler::park_locked(const void* key) {
+static void park_current(FiberSchedulerImpl* p, const void* key, bool is_socket) {
     // pre: mu_ held by this thread (the .so's __emule_fiber_lock). Register parked and
-    // hand the lock to the worker loop across the switch.
+    // hand the lock to the worker loop across the switch. is_socket tags a host-fed socket
+    // wait so quiescence-with-parked is treated as a resumable HostWait, not a deadlock.
     Fiber* f = t_current;
     f->state = FiberState::Parked;
     f->park_key = key;
-    Fiber*& head = p_->parked_[key];         // inserts nullptr if absent
+    f->wait_is_socket = is_socket;
+    Fiber*& head = p->parked_[key];          // inserts nullptr if absent
     f->park_link = head;
     head = f;
     swapcontext(&f->ctx, &t_sched);          // -> worker loop (mu_ held); resumes mu_-UNLOCKED
 }
+
+void FiberScheduler::park_locked(const void* key) { park_current(p_.get(), key, /*is_socket=*/false); }
+
+// Same as park_locked, but tags the park as a host-fed socket wait (see park_current / inner_loop).
+void FiberScheduler::park_locked_socket(const void* key) { park_current(p_.get(), key, /*is_socket=*/true); }
 
 void FiberScheduler::quiescence_park() {
     // Defer the current fiber to scheduler quiescence: re-queue it at lowest priority,
@@ -513,7 +554,12 @@ void FiberSchedulerImpl::watchdog() {
     }
 }
 
-void FiberScheduler::run_until_idle() {
+// Shared launch+wait: spawn/arm the workers, run one quantum on the pool, and block the dispatch
+// thread until every active worker has finished (done_cv_). initial=true assigns homes from all_
+// (a fresh program); initial=false (pump) reuses the existing homing — the caller has already put
+// the fibers to resume back into ready_. On return the run has reached a boundary: every fiber Done,
+// a deadlock, or (persistent) a host-wait. Teardown/throw is the caller's (teardown_and_throw).
+void FiberScheduler::launch_and_wait(bool initial) {
     // Lazily create the persistent worker pool on the first run (K is process-constant);
     // threads live until ~FiberScheduler. See tt-emule docs/fiber-engine.md.
     if (p_->pool_.empty()) {
@@ -524,36 +570,43 @@ void FiberScheduler::run_until_idle() {
         }
     }
 
-    unsigned W;
+    unsigned W = 0;
     {
         std::lock_guard<std::mutex> g(p_->mu_);
-        p_->active_ = static_cast<unsigned>(p_->all_.size());
-        if (p_->active_ == 0) {
-            return;   // nothing to run; the pool stays parked
+        if (initial) {
+            p_->active_ = static_cast<unsigned>(p_->all_.size());
+            if (p_->active_ == 0) {
+                return;   // nothing to run; the pool stays parked
+            }
         }
         p_->idle_ = 0;
         p_->running_ = 0;
         p_->workers_done_ = 0;
         p_->deadlock_ = false;
         p_->abort_flag_ = false;
+        p_->host_wait_ = false;
         p_->first_eptr_ = nullptr;
-        p_->quiescence_deferred_.clear();
         // Per-run recovery watermarks — reset alongside progress_/resumptions_ (below).
         // A stale last_deadlock_repoll_progress_ from a prior run can collide with this
         // run's quiescence progress and skip the recovery re-poll → spurious deadlock.
         p_->last_progress_val_ = 0;
         p_->last_progress_resump_ = 0;
         p_->last_deadlock_repoll_progress_ = UINT64_MAX;
-        // Activate W = min(K, fiber count) workers; pin each fiber round-robin across [0,W).
-        // Surplus workers (>= W) stay parked on start_cv_, so a tiny program pays no herd.
-        // See tt-emule docs/fiber-engine.md.
-        W = std::min<unsigned>(p_->K_, p_->active_);
-        p_->W_ = W;
-        p_->ready_.assign(W, {});
-        for (size_t i = 0; i < p_->all_.size(); ++i) {
-            Fiber* f = p_->all_[i].get();
-            f->home = static_cast<unsigned>(i % W);
-            p_->ready_[f->home].push_back(f);
+        if (initial) {
+            p_->quiescence_deferred_.clear();
+            // Activate W = min(K, fiber count) workers; pin each fiber round-robin across [0,W).
+            // Surplus workers (>= W) stay parked on start_cv_, so a tiny program pays no herd.
+            // See tt-emule docs/fiber-engine.md.
+            W = std::min<unsigned>(p_->K_, p_->active_);
+            p_->W_ = W;
+            p_->ready_.assign(W, {});
+            for (size_t i = 0; i < p_->all_.size(); ++i) {
+                Fiber* f = p_->all_[i].get();
+                f->home = static_cast<unsigned>(i % W);
+                p_->ready_[f->home].push_back(f);
+            }
+        } else {
+            W = p_->W_;   // pump: reuse homing; ready_ already refilled by pump()'s re-poll
         }
     }
     p_->progress_.store(0);
@@ -583,12 +636,16 @@ void FiberScheduler::run_until_idle() {
     }
     p_->wd_cv_.notify_all();
     wd.join();
+}
 
+// Collect results + clear the registry for the next program / mesh. Rethrows the first fiber
+// exception; throws on a quiescent deadlock. Called only after a run reaches Completed (never on a
+// resumable HostWait — then the fibers must stay alive).
+void FiberScheduler::teardown_and_throw() {
     std::exception_ptr eptr;
     bool deadlock;
     std::string dump;
-    {   // Collect results + clear the registry for the next program / mesh (workers are parked
-        // on start_cv_ now, but take mu_ anyway for clean ordering).
+    {   // workers are parked on start_cv_ now, but take mu_ anyway for clean ordering.
         std::lock_guard<std::mutex> g(p_->mu_);
         eptr = p_->first_eptr_;
         deadlock = p_->deadlock_;
@@ -609,6 +666,53 @@ void FiberScheduler::run_until_idle() {
         throw std::runtime_error("EMULE fiber engine: quiescent deadlock — all workers idle, "
                                  "fibers parked, none runnable.\n" + dump);
     }
+}
+
+void FiberScheduler::run_until_idle() {
+    p_->persistent_ = false;   // non-persistent: a quiescence-with-parked is a tier-1 deadlock
+    launch_and_wait(/*initial=*/true);
+    teardown_and_throw();
+}
+
+RunOutcome FiberScheduler::run_persistent() {
+    p_->persistent_ = true;
+    launch_and_wait(/*initial=*/true);
+    if (p_->host_wait_) {
+        return RunOutcome::HostWait;   // fibers parked awaiting host socket I/O — ALIVE, no teardown
+    }
+    teardown_and_throw();
+    return RunOutcome::Completed;
+}
+
+RunOutcome FiberScheduler::pump() {
+    p_->persistent_ = true;
+    {
+        std::lock_guard<std::mutex> g(p_->mu_);
+        if (p_->all_.empty()) {
+            return RunOutcome::Completed;   // no persistent run in flight — no-op
+        }
+        // The host advanced a credit word with a raw L1 store (no __emule_fiber_wake), so wake
+        // every parked fiber to re-check its predicate. This is the quiescence re-poll, host-driven;
+        // spurious-wake-safe (__emule_fiber_wait re-checks under the lock and re-parks).
+        for (auto& kv : p_->parked_) {
+            for (Fiber* f = kv.second; f;) {
+                Fiber* nx = f->park_link;
+                f->park_link = nullptr;
+                f->park_key = nullptr;
+                f->wait_is_socket = false;
+                f->state = FiberState::Ready;
+                p_->ready_[f->home].push_back(f);
+                f = nx;
+            }
+        }
+        p_->parked_.clear();
+    }
+    launch_and_wait(/*initial=*/false);
+    if (p_->host_wait_) {
+        return RunOutcome::HostWait;
+    }
+    teardown_and_throw();
+    return RunOutcome::Completed;
 }
 
 FiberScheduler::FiberScheduler() : p_(std::make_unique<FiberSchedulerImpl>()) {

--- a/tt_metal/impl/emulation/emule_fiber_scheduler.cpp
+++ b/tt_metal/impl/emulation/emule_fiber_scheduler.cpp
@@ -125,6 +125,13 @@ struct FiberSchedulerImpl {
     uint64_t last_progress_resump_ = 0;
     uint64_t last_deadlock_repoll_progress_ = UINT64_MAX;  // sentinel = never re-polled
 
+    // Host-wait liveness bound (reset per persistent SEQUENCE in run_persistent, NOT per launch).
+    // Counts consecutive pumps that returned HostWait having advanced nothing (progress_ == 0). A
+    // wedged kernel whose socket the host never feeds would otherwise loop host<->pump forever with
+    // no diagnostic; pump() escalates to a tier-1 deadlock after kHostWaitNoProgressLimit such pumps.
+    // See tt-emule docs/socket-emulation.md.
+    uint64_t host_wait_no_progress_pumps_ = 0;
+
     size_t stack_bytes_ = 1u << 20;          // 1 MB default
 
     // Persistent worker pool, created once and reused: threads block on start_cv_
@@ -676,6 +683,7 @@ void FiberScheduler::run_until_idle() {
 
 RunOutcome FiberScheduler::run_persistent() {
     p_->persistent_ = true;
+    p_->host_wait_no_progress_pumps_ = 0;   // start of a fresh host-wait sequence
     launch_and_wait(/*initial=*/true);
     if (p_->host_wait_) {
         return RunOutcome::HostWait;   // fibers parked awaiting host socket I/O — ALIVE, no teardown
@@ -709,6 +717,22 @@ RunOutcome FiberScheduler::pump() {
     }
     launch_and_wait(/*initial=*/false);
     if (p_->host_wait_) {
+        // Liveness bound: a pump that advanced nothing (progress_ == 0) while still parked on a socket
+        // wait is a no-progress cycle. If the host keeps pumping a wedged kernel whose socket never
+        // advances, escalate to the tier-1 deadlock after kHostWaitNoProgressLimit consecutive
+        // no-progress pumps instead of looping host<->pump forever with no diagnostic. Any forward
+        // progress resets the count, so a slow-but-advancing feed is unaffected. Keying on global
+        // progress_ (not the awaited socket) leaves a residual masking window — WA-3, see
+        // tt-emule-blaze/.claude/skills/workarounds.
+        static const uint64_t kHostWaitNoProgressLimit = env_size("TT_EMULE_HOST_WAIT_STALL_LIMIT", 8192);
+        if (p_->progress_.load() == 0) {
+            if (++p_->host_wait_no_progress_pumps_ >= kHostWaitNoProgressLimit) {
+                p_->deadlock_ = true;
+                teardown_and_throw();  // reuses the tier-1 quiescent-deadlock diagnostic (dump_parked)
+            }
+        } else {
+            p_->host_wait_no_progress_pumps_ = 0;
+        }
         return RunOutcome::HostWait;
     }
     teardown_and_throw();

--- a/tt_metal/impl/emulation/emule_fiber_scheduler.cpp
+++ b/tt_metal/impl/emulation/emule_fiber_scheduler.cpp
@@ -495,7 +495,7 @@ std::string FiberSchedulerImpl::dump_parked() {
             if (ctx && ctx->cbs) {
                 auto base = reinterpret_cast<uintptr_t>(ctx->cbs);
                 auto k = reinterpret_cast<uintptr_t>(key);
-                if (k >= base && k < base + sizeof(tt_emule::CBSyncState) * 32) {
+                if (k >= base && k < base + sizeof(tt_emule::CBSyncState) * __EMULE_CTX_MAX_CBS) {
                     std::snprintf(buf, sizeof(buf), "CB %zu",
                                   (k - base) / sizeof(tt_emule::CBSyncState));
                     name = buf;
@@ -585,6 +585,9 @@ void FiberScheduler::launch_and_wait(bool initial) {
             if (p_->active_ == 0) {
                 return;   // nothing to run; the pool stays parked
             }
+            // Clear the captured kernel exception only on a fresh run; a HostWait return bypasses
+            // teardown_and_throw (its sole consumer), so it must survive across pump quanta.
+            p_->first_eptr_ = nullptr;
         }
         p_->idle_ = 0;
         p_->running_ = 0;
@@ -592,7 +595,6 @@ void FiberScheduler::launch_and_wait(bool initial) {
         p_->deadlock_ = false;
         p_->abort_flag_ = false;
         p_->host_wait_ = false;
-        p_->first_eptr_ = nullptr;
         // Per-run recovery watermarks — reset alongside progress_/resumptions_ (below).
         // A stale last_deadlock_repoll_progress_ from a prior run can collide with this
         // run's quiescence progress and skip the recovery re-poll → spurious deadlock.

--- a/tt_metal/impl/emulation/emule_fiber_scheduler.hpp
+++ b/tt_metal/impl/emulation/emule_fiber_scheduler.hpp
@@ -32,6 +32,11 @@ struct FiberIdentity {
     const char* kernel_src = nullptr;  // static string (kernel source path), for diagnostics
 };
 
+// Outcome of a resumable launch. Completed = every fiber ran to Done (registry torn down).
+// HostWait = the run quiesced with a host-facing socket wait parked; the fibers stay ALIVE
+// (no teardown) and the run resumes via pump() as the host feeds the socket. See run_persistent().
+enum class RunOutcome { Completed, HostWait };
+
 class FiberScheduler {
 public:
     static FiberScheduler& instance();
@@ -46,10 +51,21 @@ public:
     // deadlock (tier 1); aborts with a diagnostic dump on livelock/hang (tier 2).
     void run_until_idle();
 
+    // Host-interleaved (persistent) dispatch — for a program whose kernels block on a
+    // host-fed socket. Like run_until_idle(), but if the run quiesces with a host-facing
+    // socket wait parked it returns HostWait WITHOUT tearing down (fibers stay alive);
+    // pump() then resumes them one quantum per host socket call, and Completed tears down.
+    // A quiescent deadlock with NO socket wait parked still throws (diagnostics preserved).
+    // Teardown is automatic: the pump() that observes every fiber Done returns Completed and clears
+    // the registry (driven by the host's final socket barrier / synchronize). No separate join hook.
+    RunOutcome run_persistent();     // initial launch
+    RunOutcome pump();               // resume the SAME parked fibers one quantum (host advanced a credit word)
+
     // ---- Bridge ops (called by the runner's extern-C thunks from a running fiber) ----
     void lock();
     void unlock();
-    void park_locked(const void* key);  // pre: lock held; post: lock released
+    void park_locked(const void* key);         // pre: lock held; post: lock released
+    void park_locked_socket(const void* key);  // as park_locked, tagged as a host-fed socket wait
     void quiescence_park();              // defer to quiescence: re-queue lowest-priority, released at quiescence
     void wake(const void* key);
     void yield();
@@ -61,6 +77,8 @@ public:
 private:
     FiberScheduler();
     ~FiberScheduler();
+    void launch_and_wait(bool initial);  // shared launch+wait tail (run_until_idle/run_persistent/pump)
+    void teardown_and_throw();           // clear the registry; rethrow eptr / throw on deadlock
     std::unique_ptr<FiberSchedulerImpl> p_;
 };
 

--- a/tt_metal/impl/emulation/emule_sanitizers.hpp
+++ b/tt_metal/impl/emulation/emule_sanitizers.hpp
@@ -23,8 +23,11 @@ namespace tt::tt_metal {
 class IDevice;
 }
 
-// Wormhole has 32 CBs; JIT header cb_api.h sizes unpack_tile_size[32].
-static constexpr uint32_t EMULE_NUM_CBS = 32;
+// Max CB count across emule arches: Blackhole has 64 CBs, Wormhole 32. Sized to
+// the max (matches jit_hw cb_api.h's metadata arrays and Core::MAX_CBS); the real
+// per-arch ceiling is enforced upstream by tt-metal's host CircularBufferConfig
+// guard + the per-arch JIT NUM_CIRCULAR_BUFFERS, so WH slots 32..63 go unused.
+static constexpr uint32_t EMULE_NUM_CBS = 64;
 
 // Per-kernel sanitizer thread-local state. The definitions live in
 // emulated_program_runner.cpp (exported via -rdynamic so JIT kernel .so files
@@ -43,14 +46,14 @@ extern thread_local uint32_t __emule_l1_host_ranges_count;
 extern thread_local uint64_t* __emule_l1_resolved_ranges;
 extern thread_local uint32_t* __emule_l1_resolved_ranges_count;
 extern thread_local uint32_t __emule_l1_resolved_ranges_capacity;
-extern thread_local uint32_t __emule_cb_reserved_pages[32];
-extern thread_local uint32_t __emule_cb_waited_pages[32];
-extern thread_local bool __emule_cb_reserve_dangling[32];
-extern thread_local bool __emule_cb_wait_dangling[32];
-extern thread_local const char* __emule_cb_reserve_file[32];
-extern thread_local uint32_t __emule_cb_reserve_line[32];
-extern thread_local const char* __emule_cb_wait_file[32];
-extern thread_local uint32_t __emule_cb_wait_line[32];
+extern thread_local uint32_t __emule_cb_reserved_pages[EMULE_NUM_CBS];
+extern thread_local uint32_t __emule_cb_waited_pages[EMULE_NUM_CBS];
+extern thread_local bool __emule_cb_reserve_dangling[EMULE_NUM_CBS];
+extern thread_local bool __emule_cb_wait_dangling[EMULE_NUM_CBS];
+extern thread_local const char* __emule_cb_reserve_file[EMULE_NUM_CBS];
+extern thread_local uint32_t __emule_cb_reserve_line[EMULE_NUM_CBS];
+extern thread_local const char* __emule_cb_wait_file[EMULE_NUM_CBS];
+extern thread_local uint32_t __emule_cb_wait_line[EMULE_NUM_CBS];
 extern thread_local bool __emule_cb_boundary_strict;
 extern thread_local uint32_t __emule_dram_unreserved_base;
 extern thread_local const uint64_t* __emule_dram_tensor_ranges;


### PR DESCRIPTION
### PR Category
Feature. `[do not merge]` — this is the staging/reference edition (base `emule-blaze-metal-fork`)
that the tt-emule software emulator builds and verifies against; the upstream (main-based)
counterpart is #51108.

### Summary
Emulation-runtime support for host-facing (PCIe) sockets and concurrent multi-chip dispatch. Final
state:
- **Persistent / host-interleaved dispatch.** The fiber scheduler gains a resumable model
  (`RunOutcome{Completed,HostWait}`, `run_persistent()` + `pump()`, with `run_until_idle` refactored
  onto a shared `launch_and_wait`/`teardown_and_throw`): a run that quiesces on a host-fed socket
  wait returns `HostWait` without teardown and resumes one quantum per host socket call.
- **Socket-aware quiescence.** A tagged `park_locked_socket()` + `any_parked_is_socket_wait()` let
  `inner_loop` distinguish "blocked on host I/O" (resumable) from a genuine tier-1 deadlock.
- **Runner driver.** `run_mesh_dispatch()` uses `run_persistent()`; `pump_device()` advances the
  parked run and runs deferred mesh cleanup on completion.
- **Host-facing PCIe NOC resolution.** `__emule_resolve_noc_addr` routes `addr ≥ pcie_base` to a
  `SimulationSysmemManager` (via a per-device `pcie_base` cache) instead of the on-chip core map.
- **Mock/emulated dispatch guards.** H2D/D2H skip the static-TLB fetch (`is_mock_or_emulated`,
  falling back to dynamic-TLB writes); `DispatchContext` fast-dispatch init/terminate are no-ops.
- **CB arrays → 64** (Blackhole ceiling) in `emule_sanitizers.hpp`.

Includes the review hardening: a host-wait no-progress liveness bound in `pump()`
(`TT_EMULE_HOST_WAIT_STALL_LIMIT`), a `TT_FATAL` on out-of-range CB index (was a silent skip), and a
`TT_FATAL` on the unreachable null-`SimulationSysmemManager` case in the resolver. Verified on this
staging edition: p150 `--gate` 452/0, loudbox 15/15. Depends on the umd bump (#3075) it pins.

### Notes for reviewers
- `run_until_idle` → `launch_and_wait(initial)`: the `pump` (`initial=false`) path deliberately
  reuses worker homing and does not re-home fibers; recovery watermarks reset every launch and pump.
- Teardown is implicit — the `pump()` that observes all fibers `Done` returns `Completed` and clears
  the registry (driven by the host's final socket barrier); confirm every host exit reaches it.
- The host-wait bound keys on the scheduler's **global** `progress_`, so a wedge where the awaited
  socket stalls while other work advances is still masked — documented as WA-3 (tt-emule-blaze).
- The umd submodule bump is load-bearing (supplies `SimulationSysmemManager` / `get_pcie_base_for_arch`).
- Companions: upstream #51108; umd #3075; jit_hw tt-emule-blaze #155.
