### PR TITLE
Feature: emulation-runtime support for host-facing sockets

### DIFF
--- a/tt_metal/distributed/d2h_socket.cpp
+++ b/tt_metal/distributed/d2h_socket.cpp
@@ -13,6 +13,9 @@
 #include "impl/context/metal_context.hpp"
 #include "tt_metal/hw/inc/hostdev/socket.h"
 #include "tt_metal/llrt/tt_cluster.hpp"
+#ifdef TT_METAL_USE_EMULE
+#include "tt_metal/impl/emulation/emulated_program_runner.hpp"  // emule::pump_device (host-interleaved socket)
+#endif
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/tt_align.hpp>
 #include <tt-logger/tt-logger.hpp>
@@ -44,12 +47,20 @@ namespace {
 // `_mm_clflush` invalidates one host cache line; 64 B is the line size on typical x86-64.
 constexpr uint32_t k_x86_clflush_line_bytes = 64;
 
+// Drive the device forward one step from a host socket credit-wait loop. Simulator co-steps the umd
+// clock; emule pumps the parked fiber scheduler so a kernel blocked on this host-fed socket resumes.
 void advance_d2h_simulator_socket_device(MeshDevice* mesh_device, const MeshCoordinate& device_coord) {
     if (mesh_device == nullptr) {
         return;
     }
 
     const auto& cluster = MetalContext::instance().get_cluster();
+#ifdef TT_METAL_USE_EMULE
+    if (cluster.get_target_device_type() == tt::TargetDevice::Emule) {
+        tt::tt_metal::emule::pump_device();
+        return;
+    }
+#endif
     if (cluster.get_target_device_type() != tt::TargetDevice::Simulator) {
         return;
     }

--- a/tt_metal/distributed/d2h_socket.cpp
+++ b/tt_metal/distributed/d2h_socket.cpp
@@ -225,27 +225,21 @@ void D2HSocket::init_sender_tlb(const std::shared_ptr<MeshDevice>& mesh_device, 
 
     const auto& cluster = MetalContext::instance().get_cluster();
 
-    // MockChip has no TLB manager (get_tlb_manager() == nullptr), so skip TLB window
-    // setup entirely: pcie_writer_ stays unset. Safe under Mock because the runtime I/O
-    // paths that use pcie_writer_ -- read()/write() and notify_sender() -- never execute
-    // for mock devices (mock only exercises socket construction / JIT).
-    //
-    // TODO(emule): this over-skips for Emule. SWEmuleChip also lacks a TLB manager but has
-    // real memory-backed I/O, so it should skip only the TLB-window path and still install
-    // the cluster.write_core() fallback for pcie_writer_. As written, pcie_writer_ is left
-    // null, so enabling D2H socket runtime I/O under emule would null-deref in
-    // notify_sender().
-    if (cluster.is_mock_or_emulated()) {
-        return;
-    }
+    // Mock/emulated chips have no TLB manager (get_tlb_manager() == nullptr), so they skip the
+    // static-TLB fetch below (guarded by !is_mock_or_emulated()) and fall through to the
+    // cluster.write_core() dynamic writer. SWEmuleChip backs that with real memory-backed I/O;
+    // MockChip never invokes pcie_writer_ at runtime (only socket construction / JIT), so the
+    // installed writer is harmless there.
 
     if (mesh_device) {
         sender_device_id = mesh_device->get_device(sender_core_.device_coord)->id();
         sender_virtual_core = mesh_device->worker_core_from_logical_core(sender_core_.core_coord);
-        sender_core_tlb_ = cluster.get_driver()
-                               ->get_chip(sender_device_id)
-                               ->get_tlb_manager()
-                               ->get_tlb_window(tt_xy_pair(sender_virtual_core.x, sender_virtual_core.y));
+        if (!cluster.is_mock_or_emulated()) {
+            sender_core_tlb_ = cluster.get_driver()
+                                   ->get_chip(sender_device_id)
+                                   ->get_tlb_manager()
+                                   ->get_tlb_window(tt_xy_pair(sender_virtual_core.x, sender_virtual_core.y));
+        }
     } else {
         sender_device_id = device_id.value();
         sender_virtual_core = cluster.get_virtual_coordinate_from_logical_coordinates(
@@ -253,7 +247,7 @@ void D2HSocket::init_sender_tlb(const std::shared_ptr<MeshDevice>& mesh_device, 
     }
 
     auto arch = MetalContext::instance().hal().get_arch();
-    if (arch == tt::ARCH::BLACKHOLE && mesh_device) {
+    if (arch == tt::ARCH::BLACKHOLE && mesh_device && !cluster.is_mock_or_emulated()) {
         // This process owns a mesh_device and hence has statically initialized TLBs.
         // Entire device address space for Blackhole is statically mapped.
         // Safe to use static TLBs without requiring the driver to do a reconfig.

--- a/tt_metal/distributed/h2d_socket.cpp
+++ b/tt_metal/distributed/h2d_socket.cpp
@@ -259,19 +259,12 @@ void H2DSocket::init_receiver_tlb(const std::shared_ptr<MeshDevice>& mesh_device
 
     const auto& cluster = MetalContext::instance().get_cluster();
 
-    // MockChip has no TLB manager (get_tlb_manager() == nullptr), so skip TLB window
-    // setup entirely: pcie_writer stays unset. Safe under Mock because the runtime I/O
-    // paths that use pcie_writer -- write() (HOST_PUSH) and notify_receiver() -- never
-    // execute for mock devices (mock only exercises socket construction / JIT).
-    //
-    // TODO(emule): this over-skips for Emule. SWEmuleChip also lacks a TLB manager but has
-    // real memory-backed I/O, so it should skip only the TLB-window path and still install
-    // the cluster.write_core() fallback for pcie_writer. As written, pcie_writer is left
-    // null, so enabling H2D socket runtime I/O under emule would null-deref in
-    // notify_receiver() / write().
-    if (cluster.is_mock_or_emulated()) {
-        return;
-    }
+    // Mock/emulated chips have no TLB manager (get_tlb_manager() == nullptr), so they can't take the
+    // static-TLB path: the target_in_static_tlb guard below excludes them (which also keeps
+    // is_tlb_mapped() from dereferencing the null manager), and they fall through to the
+    // cluster.write_core() dynamic writer. SWEmuleChip backs that with real memory-backed I/O;
+    // MockChip never invokes pcie_writer at runtime (only socket construction / JIT), so the
+    // installed writer is harmless there.
 
     // Receiver core type is recorded explicitly at construction (the DRAM-recv
     // ctor sets Dram, every other path is Tensix). Used only to resolve the
@@ -307,7 +300,8 @@ void H2DSocket::init_receiver_tlb(const std::shared_ptr<MeshDevice>& mesh_device
     // need a per-write driver reconfig.
     const tt_xy_pair tlb_core(recv_virtual_core.x, recv_virtual_core.y);
     const bool target_in_static_tlb =
-        mesh_device && MetalContext::instance().hal().get_arch() == tt::ARCH::BLACKHOLE &&
+        mesh_device && !cluster.is_mock_or_emulated() &&
+        MetalContext::instance().hal().get_arch() == tt::ARCH::BLACKHOLE &&
         cluster.get_driver()
             ->get_chip(recv_device_id)
             ->get_tlb_manager()

--- a/tt_metal/distributed/h2d_socket.cpp
+++ b/tt_metal/distributed/h2d_socket.cpp
@@ -15,6 +15,9 @@
 #include "impl/context/metal_context.hpp"
 #include "tt_metal/hw/inc/hostdev/socket.h"
 #include "tt_metal/llrt/tt_cluster.hpp"
+#ifdef TT_METAL_USE_EMULE
+#include "tt_metal/impl/emulation/emulated_program_runner.hpp"  // emule::pump_device (host-interleaved socket)
+#endif
 #include <tt-metalium/tt_align.hpp>
 #include <umd/device/chip_helpers/tlb_manager.hpp>
 #include <tt-logger/tt-logger.hpp>
@@ -27,12 +30,20 @@ namespace tt::tt_metal::distributed {
 
 namespace {
 
+// Drive the device forward one step from a host socket credit-wait loop. Simulator co-steps the umd
+// clock; emule pumps the parked fiber scheduler so a kernel blocked on this host-fed socket resumes.
 void advance_h2d_simulator_socket_device(MeshDevice* mesh_device, const MeshCoordinate& device_coord) {
     if (mesh_device == nullptr) {
         return;
     }
 
     const auto& cluster = MetalContext::instance().get_cluster();
+#ifdef TT_METAL_USE_EMULE
+    if (cluster.get_target_device_type() == tt::TargetDevice::Emule) {
+        tt::tt_metal::emule::pump_device();
+        return;
+    }
+#endif
     if (cluster.get_target_device_type() != tt::TargetDevice::Simulator) {
         return;
     }

--- a/tt_metal/impl/emulation/emulated_program_runner.cpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.cpp
@@ -243,6 +243,9 @@ extern "C" void __emule_fiber_unlock(void) { efib::FiberScheduler::instance().un
 extern "C" void __emule_fiber_park_locked(const void* key) {
     efib::FiberScheduler::instance().park_locked(key);
 }
+extern "C" void __emule_fiber_park_locked_socket(const void* key) {
+    efib::FiberScheduler::instance().park_locked_socket(key);
+}
 extern "C" void __emule_fiber_wake(const void* key) { efib::FiberScheduler::instance().wake(key); }
 extern "C" void __emule_fiber_yield(void) { efib::FiberScheduler::instance().yield(); }
 extern "C" void __emule_fiber_defer_to_quiescence(void) { efib::FiberScheduler::instance().quiescence_park(); }
@@ -3043,6 +3046,12 @@ static std::vector<std::vector<std::vector<std::unique_ptr<tt_emule::EmuleDFBInt
 // pointers reference, so the captured views stay valid across the vector's own growth.
 static std::vector<tt::tt_metal::emule::OobStateOwner> g_mesh_oob_keep;
 
+// [HOST-INTERLEAVED SOCKET] Set when run_mesh_dispatch's run_persistent() returned HostWait: the mesh
+// run is parked awaiting host socket I/O, with g_mesh_dfb_keep + the scheduler's fibers kept alive.
+// pump_device() drives it forward per host socket call; the pump that completes clears this + the mesh
+// keepalives (the cleanup run_mesh_dispatch deferred). See tt-emule docs/socket-emulation.md §7.
+static bool g_emule_host_wait = false;
+
 // Resolved-program cache — emule's analogue of silicon's is_compiled(): collect + JIT compile + resolve
 // run ONCE per program (keyed by ProgramId); every device dispatches against the shared read-only result.
 // LRU-bounded as a safety net. See tt-emule docs/fiber-engine.md.
@@ -3419,18 +3428,52 @@ void run_mesh_dispatch() {
 #if defined(__x86_64__) && defined(__linux__)
     EmuleSigfpeGuard sigfpe_guard;  // the actual kernel run happens here, across all chips
 #endif
-    // Reset defer + free the kept per-device state even if the run throws.
+    // Reset defer + free the kept per-device state even if the run throws. Disarmed on the
+    // host-wait path, which keeps the state alive across the return to the host.
     struct Cleanup {
+        bool armed = true;
         ~Cleanup() {
+            if (!armed) {
+                return;
+            }
             g_emule_mesh_defer = false;
             g_mesh_dfb_keep.clear();
             g_mesh_oob_keep.clear();
         }
     } cleanup;
-    // All devices' fibers were registered (spawned) during the per-device register phase;
-    // run them concurrently on the worker pool in one pass. Each fiber's ctx carries its
-    // device's core_map/bridge_dram, so cross-chip NOC resolution stays correct.
-    tt::tt_metal::emule_fiber::FiberScheduler::instance().run_until_idle();
+    // All devices' fibers were registered (spawned) during the per-device register phase; run them
+    // concurrently on the worker pool in one pass. Each fiber's ctx carries its device's
+    // core_map/bridge_dram, so cross-chip NOC resolution stays correct. run_persistent (vs
+    // run_until_idle) lets a host-interleaved socket program quiesce back to the host mid-run. On a
+    // throw the RAII Cleanup above frees the kept state during unwind.
+    tt::tt_metal::emule_fiber::RunOutcome oc =
+        tt::tt_metal::emule_fiber::FiberScheduler::instance().run_persistent();
+    if (oc == tt::tt_metal::emule_fiber::RunOutcome::HostWait) {
+        // A kernel is parked on a host-fed socket wait. Keep the kept state + the scheduler's fibers
+        // ALIVE and return to the host; it streams socket tokens and pump_device() drives the run to
+        // completion (which runs the cleanup, see pump_device()).
+        cleanup.armed = false;
+        g_emule_host_wait = true;
+        return;
+    }
+    // Completed synchronously (no host-fed socket wait): the RAII Cleanup frees the kept state.
+}
+
+void pump_device() {
+    // Drive a parked (run_persistent) mesh run forward one scheduler quantum. No-op unless a run is
+    // parked in HostWait (set by run_mesh_dispatch). The host advanced a socket credit word by a raw
+    // L1 store, so pump() blanket-re-polls the parked fibers to re-check predicates. When every fiber
+    // reaches Done the pump returns Completed — run the mesh cleanup run_mesh_dispatch deferred.
+    if (!g_emule_host_wait) {
+        return;
+    }
+    auto oc = tt::tt_metal::emule_fiber::FiberScheduler::instance().pump();
+    if (oc == tt::tt_metal::emule_fiber::RunOutcome::Completed) {
+        g_emule_host_wait = false;
+        g_emule_mesh_defer = false;
+        g_mesh_dfb_keep.clear();
+        g_mesh_oob_keep.clear();
+    }
 }
 
 }  // namespace tt::tt_metal::emule

--- a/tt_metal/impl/emulation/emulated_program_runner.cpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.cpp
@@ -313,7 +313,15 @@ extern "C" uint8_t* __emule_resolve_noc_addr(uint64_t noc_addr) {
     if (noc_addr >= get_pcie_base_cached(device_id)) {
         auto* sw_emu = get_sw_emulated_chip(static_cast<tt::ChipId>(device_id));
         auto* sysmem = sw_emu ? static_cast<tt::umd::SimulationSysmemManager*>(sw_emu->get_sysmem_manager()) : nullptr;
-        return sysmem ? static_cast<uint8_t*>(sysmem->get_mapped_host_ptr(noc_addr, /*size=*/1)) : nullptr;
+        // A host-facing address (>= pcie_base) is by construction on an emule chip that has a
+        // SimulationSysmemManager, so a null manager is a contract violation, not a resolvable miss.
+        // (A buffer miss still returns nullptr below — callers like noc_semaphore_set_remote rely on it.)
+        TT_FATAL(
+            sysmem != nullptr,
+            "emule: host-facing NOC address 0x{:x} on chip {} has no SimulationSysmemManager.",
+            noc_addr,
+            device_id);
+        return static_cast<uint8_t*>(sysmem->get_mapped_host_ptr(noc_addr, /*size=*/1));
     }
 
     uint32_t noc_x = (noc_addr >> NOC_LOCAL_BITS) & NOC_NODE_MASK;
@@ -1414,16 +1422,20 @@ static std::map<std::string, std::string> build_kernel_defines(
         }
         for (auto& cb_impl : cb_impls) {
             for (uint8_t idx : cb_impl->local_buffer_indices()) {
-                if (idx < EMULE_NUM_CBS) {
-                    // Calculate tile size from the CB's data format.
-                    const auto& tile = cb_impl->tile(idx);
-                    tile_sizes[idx] = tile.has_value() ? tile->get_tile_size(cb_impl->data_format(idx))
-                                                       : Tile().get_tile_size(cb_impl->data_format(idx));
-                    cb_formats[idx] = static_cast<uint8_t>(cb_impl->data_format(idx));
-                    if (tile.has_value()) {
-                        tile_r_dim[idx] = tile->get_height();
-                        tile_c_dim[idx] = tile->get_width();
-                    }
+                TT_FATAL(
+                    idx < EMULE_NUM_CBS,
+                    "CB index {} exceeds the emulated CB ceiling ({}); the host CircularBufferConfig must cap "
+                    "at the arch's NUM_CIRCULAR_BUFFERS.",
+                    idx,
+                    EMULE_NUM_CBS);
+                // Calculate tile size from the CB's data format.
+                const auto& tile = cb_impl->tile(idx);
+                tile_sizes[idx] = tile.has_value() ? tile->get_tile_size(cb_impl->data_format(idx))
+                                                   : Tile().get_tile_size(cb_impl->data_format(idx));
+                cb_formats[idx] = static_cast<uint8_t>(cb_impl->data_format(idx));
+                if (tile.has_value()) {
+                    tile_r_dim[idx] = tile->get_height();
+                    tile_c_dim[idx] = tile->get_width();
                 }
             }
         }

--- a/tt_metal/impl/emulation/emulated_program_runner.cpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.cpp
@@ -321,7 +321,7 @@ extern "C" uint8_t* __emule_resolve_noc_addr(uint64_t noc_addr) {
             "emule: host-facing NOC address 0x{:x} on chip {} has no SimulationSysmemManager.",
             noc_addr,
             device_id);
-        return static_cast<uint8_t*>(sysmem->get_mapped_host_ptr(noc_addr, /*size=*/1));
+        return static_cast<uint8_t*>(sysmem->get_mapped_host_ptr(noc_addr));
     }
 
     uint32_t noc_x = (noc_addr >> NOC_LOCAL_BITS) & NOC_NODE_MASK;

--- a/tt_metal/impl/emulation/emulated_program_runner.cpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.cpp
@@ -3476,15 +3476,35 @@ void pump_device() {
     // parked in HostWait (set by run_mesh_dispatch). The host advanced a socket credit word by a raw
     // L1 store, so pump() blanket-re-polls the parked fibers to re-check predicates. When every fiber
     // reaches Done the pump returns Completed — run the mesh cleanup run_mesh_dispatch deferred.
+    //
+    // Serialize: a host program drives H2D and D2H on separate threads, so both credit-wait loops can
+    // call pump_device() concurrently; the single resumable run + g_emule_host_wait are not reentrant.
+    static std::mutex pump_mu;
+    std::lock_guard<std::mutex> pump_lk(pump_mu);
     if (!g_emule_host_wait) {
         return;
     }
-    auto oc = tt::tt_metal::emule_fiber::FiberScheduler::instance().pump();
-    if (oc == tt::tt_metal::emule_fiber::RunOutcome::Completed) {
+#if defined(__x86_64__) && defined(__linux__)
+    // pump() re-enters kernel bodies; run_mesh_dispatch's guard was destroyed at its HostWait return,
+    // so reinstall the SIGFPE->RISC-V divide/overflow handler for the resumed execution.
+    EmuleSigfpeGuard sigfpe_guard;
+#endif
+    try {
+        auto oc = tt::tt_metal::emule_fiber::FiberScheduler::instance().pump();
+        if (oc == tt::tt_metal::emule_fiber::RunOutcome::Completed) {
+            g_emule_host_wait = false;
+            g_emule_mesh_defer = false;
+            g_mesh_dfb_keep.clear();
+            g_mesh_oob_keep.clear();
+        }
+    } catch (...) {
+        // pump() threw (kernel exception / host-wait stall deadlock) — the scheduler registry is torn
+        // down; drop the mesh keepalives + host-wait/defer flags so a later dispatch starts clean.
         g_emule_host_wait = false;
         g_emule_mesh_defer = false;
         g_mesh_dfb_keep.clear();
         g_mesh_oob_keep.clear();
+        throw;
     }
 }
 

--- a/tt_metal/impl/emulation/emulated_program_runner.cpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.cpp
@@ -65,6 +65,7 @@
 #include "impl/context/metal_context.hpp"
 #include "llrt/metal_soc_descriptor.hpp"
 #include "umd/device/chip/sw_emule_chip.hpp"
+#include "umd/device/chip_helpers/simulation_sysmem_manager.hpp"
 #include <tt-metalium/experimental/fabric/control_plane.hpp>  // fabric route table (multi-chip dst resolve)
 #include <tt-metalium/experimental/fabric/fabric_types.hpp>   // FabricNodeId, MeshId, FabricConfig
 #include <tt-metalium/experimental/fabric/fabric.hpp>         // is_2d_fabric_config
@@ -266,12 +267,56 @@ static constexpr uint32_t L1_SLOT_MASK = L1_SLOT_SIZE - 1;  // 0x1FFFFF
 //     that is the true in-bank offset (already includes
 //     `bank_to_dram_offset[bank_index]`). Masking to 2 MB silently aliases
 //     any DRAM access >= 2 MB to an offset within the first 2 MB of the bank.
+// Helper: get SWEmuleChip* from MetalContext cluster for a given device_id. (Relocated up from
+// later in this file — needed here for the PCIe branch below, and by the fabric teleport hooks
+// further down.)
+static tt::umd::SWEmuleChip* get_sw_emulated_chip(tt::ChipId device_id) {
+    auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
+    auto* umd_cluster = cluster.get_driver().get();
+    if (!umd_cluster) {
+        return nullptr;
+    }
+    auto* chip = umd_cluster->get_chip(device_id);
+    return dynamic_cast<tt::umd::SWEmuleChip*>(chip);
+}
+
+// Per-device cache of pcie_base_ (the host-facing/PCIe address threshold), keyed by device_id —
+// avoids a dynamic_cast + cluster lookup on every single NOC-address resolve. Rebuilt lazily; a
+// device close+reopen mints a new SWEmuleChip with a stable arch, so the cached value never goes
+// stale the way the core_map cache (which holds raw Core* into per-chip L1) can.
+static std::mutex g_pcie_base_mutex;
+static std::unordered_map<uint32_t, uint64_t> g_pcie_base_cache;
+
+static uint64_t get_pcie_base_cached(uint32_t device_id) {
+    std::lock_guard<std::mutex> lock(g_pcie_base_mutex);
+    auto it = g_pcie_base_cache.find(device_id);
+    if (it != g_pcie_base_cache.end()) {
+        return it->second;
+    }
+    auto* sw_emu = get_sw_emulated_chip(static_cast<tt::ChipId>(device_id));
+    uint64_t pcie_base =
+        sw_emu ? tt::umd::SysmemManager::get_pcie_base_for_arch(sw_emu->get_soc_descriptor().arch) : UINT64_MAX;
+    g_pcie_base_cache[device_id] = pcie_base;
+    return pcie_base;
+}
+
 extern "C" uint8_t* __emule_resolve_noc_addr(uint64_t noc_addr) {
+    emule_require_self(__func__);
+
+    // Host-facing (PCIe) address: SimulationSysmemManager's device_io_addr space starts at
+    // pcie_base_ and shares the same 64-bit range as a real on-chip NOC address, so this branch
+    // must run FIRST, before any noc_x/noc_y/local_addr decomposition below.
+    uint32_t device_id = __emule_self->chip_id;
+    if (noc_addr >= get_pcie_base_cached(device_id)) {
+        auto* sw_emu = get_sw_emulated_chip(static_cast<tt::ChipId>(device_id));
+        auto* sysmem = sw_emu ? static_cast<tt::umd::SimulationSysmemManager*>(sw_emu->get_sysmem_manager()) : nullptr;
+        return sysmem ? static_cast<uint8_t*>(sysmem->get_mapped_host_ptr(noc_addr, /*size=*/1)) : nullptr;
+    }
+
     uint32_t noc_x = (noc_addr >> NOC_LOCAL_BITS) & NOC_NODE_MASK;
     uint32_t noc_y = (noc_addr >> (NOC_LOCAL_BITS + NOC_NODE_ID_BITS)) & NOC_NODE_MASK;
     uint64_t local_addr = noc_addr & NOC_LOCAL_MASK;  // 36 bits, raw
 
-    emule_require_self(__func__);
     if (__emule_self->core_map) {
         uint64_t key = (uint64_t(noc_x) << 32) | noc_y;
         auto it = __emule_self->core_map->find(key);
@@ -1025,19 +1070,6 @@ static std::function<void()> jit_compile_kernel(
     // 11. Wrap in shared_ptr for lifetime management (dlclose on destruction).
     auto shared_handle = std::shared_ptr<void>(handle, [](void* h) { dlclose(h); });
     return [fn, shared_handle]() { fn(); };
-}
-
-// ---------------------------------------------------------------------------
-// Helper: get SWEmuleChip* from MetalContext cluster for a given device_id.
-// ---------------------------------------------------------------------------
-static tt::umd::SWEmuleChip* get_sw_emulated_chip(ChipId device_id) {
-    auto& cluster = MetalContext::instance().get_cluster();
-    auto* umd_cluster = cluster.get_driver().get();
-    if (!umd_cluster) {
-        return nullptr;
-    }
-    auto* chip = umd_cluster->get_chip(device_id);
-    return dynamic_cast<tt::umd::SWEmuleChip*>(chip);
 }
 
 // ---------------------------------------------------------------------------

--- a/tt_metal/impl/emulation/emulated_program_runner.hpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.hpp
@@ -24,4 +24,10 @@ void execute_program_emulated(IDevice* device, Program& program);
 void begin_mesh_dispatch();
 void run_mesh_dispatch();
 
+/// Host-interleaved socket dispatch: drive a parked (run_persistent) device forward one scheduler
+/// quantum. Called from the host's H2D/D2H socket credit-wait loops (distributed/{h2d,d2h}_socket.cpp)
+/// so kernels blocked on a host-fed socket wait resume as the host streams tokens after program.run().
+/// No-op unless a run is parked in HostWait. See tt-emule docs/socket-emulation.md §7.
+void pump_device();
+
 }  // namespace tt::tt_metal::emule

--- a/tt_metal/impl/emulation/emule_fiber_scheduler.cpp
+++ b/tt_metal/impl/emulation/emule_fiber_scheduler.cpp
@@ -105,6 +105,19 @@ struct FiberSchedulerImpl {
     std::atomic<uint64_t> progress_{0};      // fiber completions + published pages (tier 2)
     std::atomic<uint64_t> resumptions_{0};   // swap-ins (tier 2 livelock signal)
 
+    // Raw-L1-store lost-wakeup recovery watermarks (guarded by mu_; per-run — reset
+    // in run_until_idle alongside progress_/resumptions_). A kernel that advances a
+    // same-core handshake word with a raw L1 store (`*ptr = v`, no noc_semaphore_set)
+    // issues no __emule_fiber_wake, so a peer's noc_semaphore_wait can miss it. This
+    // surfaces two ways: livelock while busy-waiters churn (spin-starvation release),
+    // or true quiescence if every fiber parks at once (one-shot re-poll before the
+    // tier-1 deadlock abort). Both wake all parked fibers to re-check predicates;
+    // spurious-wake-safe (__emule_fiber_wait re-checks under lock), gated so healthy
+    // runs never trigger. See tt-emule docs/fiber-engine.md.
+    uint64_t last_progress_val_ = 0;
+    uint64_t last_progress_resump_ = 0;
+    uint64_t last_deadlock_repoll_progress_ = UINT64_MAX;  // sentinel = never re-polled
+
     size_t stack_bytes_ = 1u << 20;          // 1 MB default
 
     // Persistent worker pool, created once and reused: threads block on start_cv_
@@ -185,8 +198,46 @@ void FiberSchedulerImpl::worker_main(unsigned w) {
 // Per-program scheduling loop. Pre: mu_ held. Post: mu_ held. Runs this program's fibers to
 // completion (active_ == 0) or to an abort (deadlock / kernel exception).
 void FiberSchedulerImpl::inner_loop(unsigned w) {
+    // Force-complete pending in-flight reads + wake all parked fibers once the
+    // scheduler churns this many resumptions with zero progress. Below the tier-2
+    // livelock backstop (TT_EMULE_FIBER_PROGRESS_WINDOW) and above healthy churn.
+    static const uint64_t spin_release_window = env_size("TT_EMULE_SPIN_RELEASE_WINDOW", 4096);
     for (;;) {
         if (abort_flag_) break;
+        // Spin-starvation release: a kernel busy-wait (do{invalidate_l1_cache();}while
+        // (<raw L1 word>)) yields every iteration, so the ready queue never empties and
+        // full quiescence is never reached — quiescence-deferred reads never "complete" and a
+        // raw-store lost wakeup never re-checks. On churn past the window with zero
+        // progress, force-complete the reads AND wake every parked fiber to re-poll its
+        // predicate. Gated so healthy runs (progress advancing) never trigger.
+        if (!quiescence_deferred_.empty() || !parked_.empty()) {
+            uint64_t p = progress_.load(std::memory_order_relaxed);
+            uint64_t r = resumptions_.load(std::memory_order_relaxed);
+            if (p != last_progress_val_) {
+                last_progress_val_ = p;
+                last_progress_resump_ = r;
+            } else if (r - last_progress_resump_ > spin_release_window) {
+                for (Fiber* f : quiescence_deferred_) {
+                    f->state = FiberState::Ready;
+                    ready_[f->home].push_back(f);
+                }
+                quiescence_deferred_.clear();
+                for (auto& kv : parked_) {
+                    Fiber* f = kv.second;
+                    while (f) {
+                        Fiber* nx = f->park_link;
+                        f->park_link = nullptr;
+                        f->park_key = nullptr;
+                        f->state = FiberState::Ready;
+                        ready_[f->home].push_back(f);
+                        f = nx;
+                    }
+                }
+                parked_.clear();
+                cv_.notify_all();
+                last_progress_resump_ = r;  // re-arm; don't re-fire until more churn
+            }
+        }
         if (ready_[w].empty()) {
             if (active_ == 0) break;
             ++idle_;
@@ -211,8 +262,35 @@ void FiberSchedulerImpl::inner_loop(unsigned w) {
                     --idle_;
                     continue;
                 }
-                // Tier-1 quiescent deadlock: nothing to release and fibers still sync-parked.
+                // Fibers still sync-parked at quiescence. Before declaring a tier-1
+                // deadlock, do a one-shot re-poll: wake every parked fiber so it
+                // re-checks its __emule_fiber_wait predicate (recovers a raw-L1-store
+                // lost wakeup when every fiber parked at once). Keyed off a progress
+                // watermark: if progress advanced since the last re-poll (or this is
+                // the first), the wake-all may unblock a waiter whose word a raw store
+                // already set — try it; if a re-poll yields no new progress it is a
+                // genuine deadlock. Spurious-wake-safe: __emule_fiber_wait re-checks
+                // under the lock and re-parks. See tt-emule docs/fiber-engine.md.
                 if (!parked_.empty()) {
+                    uint64_t p = progress_.load(std::memory_order_relaxed);
+                    if (p != last_deadlock_repoll_progress_) {
+                        last_deadlock_repoll_progress_ = p;
+                        for (auto& kv : parked_) {
+                            Fiber* f = kv.second;
+                            while (f) {
+                                Fiber* nx = f->park_link;
+                                f->park_link = nullptr;
+                                f->park_key = nullptr;
+                                f->state = FiberState::Ready;
+                                ready_[f->home].push_back(f);
+                                f = nx;
+                            }
+                        }
+                        parked_.clear();
+                        cv_.notify_all();
+                        --idle_;
+                        continue;
+                    }
                     deadlock_ = true;
                     abort_flag_ = true;
                     --idle_;
@@ -462,6 +540,12 @@ void FiberScheduler::run_until_idle() {
         p_->quiescence_deferred_.clear();
         p_->progress_.store(0);
         p_->resumptions_.store(0);
+        // Per-run recovery watermarks — reset alongside progress_/resumptions_.
+        // A stale last_deadlock_repoll_progress_ from a prior run can collide with this
+        // run's quiescence progress and skip the recovery re-poll → spurious deadlock.
+        p_->last_progress_val_ = 0;
+        p_->last_progress_resump_ = 0;
+        p_->last_deadlock_repoll_progress_ = UINT64_MAX;
         // Activate W = min(K, fiber count) workers; pin each fiber round-robin across [0,W).
         // Surplus workers (>= W) stay parked on start_cv_, so a tiny program pays no herd.
         W = std::min<unsigned>(p_->K_, p_->active_);

--- a/tt_metal/impl/emulation/emule_fiber_scheduler.cpp
+++ b/tt_metal/impl/emulation/emule_fiber_scheduler.cpp
@@ -493,7 +493,7 @@ std::string FiberSchedulerImpl::dump_parked() {
             if (ctx && ctx->cbs) {
                 auto base = reinterpret_cast<uintptr_t>(ctx->cbs);
                 auto k = reinterpret_cast<uintptr_t>(key);
-                if (k >= base && k < base + sizeof(tt_emule::CBSyncState) * 32) {
+                if (k >= base && k < base + sizeof(tt_emule::CBSyncState) * __EMULE_CTX_MAX_CBS) {
                     std::snprintf(buf, sizeof(buf), "CB %zu",
                                   (k - base) / sizeof(tt_emule::CBSyncState));
                     name = buf;
@@ -585,6 +585,9 @@ void FiberScheduler::launch_and_wait(bool initial) {
             if (p_->active_ == 0) {
                 return;   // nothing to run; the pool stays parked
             }
+            // Clear the captured kernel exception only on a fresh run; a HostWait return bypasses
+            // teardown_and_throw (its sole consumer), so it must survive across pump quanta.
+            p_->first_eptr_ = nullptr;
         }
         p_->idle_ = 0;
         p_->running_ = 0;
@@ -592,8 +595,7 @@ void FiberScheduler::launch_and_wait(bool initial) {
         p_->deadlock_ = false;
         p_->abort_flag_ = false;
         p_->host_wait_ = false;
-        p_->first_eptr_ = nullptr;
-        // Per-run recovery watermarks — reset alongside progress_/resumptions_ below.
+        // Per-run recovery watermarks — reset alongside progress_/resumptions_ (below).
         // A stale last_deadlock_repoll_progress_ from a prior run can collide with this
         // run's quiescence progress and skip the recovery re-poll → spurious deadlock.
         p_->last_progress_val_ = 0;

--- a/tt_metal/impl/emulation/emule_fiber_scheduler.cpp
+++ b/tt_metal/impl/emulation/emule_fiber_scheduler.cpp
@@ -48,6 +48,8 @@ struct Fiber {
     FiberState state = FiberState::Ready;
     const void* park_key = nullptr;
     Fiber* park_link = nullptr;     // intrusive parked-list
+    bool wait_is_socket = false;    // parked on a host-fed socket credit word (park_locked_socket):
+                                    // marks a quiescence as "waiting for host I/O", not a deadlock
     std::exception_ptr eptr;
     unsigned home = 0;              // pinned worker — a fiber NEVER migrates (the JIT kernel
                                     // caches the thread_local __emule_self address)
@@ -100,6 +102,9 @@ struct FiberSchedulerImpl {
     unsigned active_ = 0;      // fibers not yet Done (under mu_)
     bool deadlock_ = false;
     bool abort_flag_ = false;
+    bool persistent_ = false;  // run_persistent/pump in flight: a host-fed socket wait quiescing is
+                               // a resumable HostWait, not a tier-1 deadlock. See run_persistent().
+    bool host_wait_ = false;   // set by inner_loop when it broke out for host I/O (vs Done/deadlock)
     std::exception_ptr first_eptr_;
 
     std::atomic<uint64_t> progress_{0};      // fiber completions + published pages (tier 2)
@@ -135,6 +140,14 @@ struct FiberSchedulerImpl {
     bool any_ready() const {                 // any runnable fiber in any worker's queue?
         for (const auto& q : ready_) {
             if (!q.empty()) return true;
+        }
+        return false;
+    }
+    bool any_parked_is_socket_wait() const {  // any parked fiber blocked on a host-fed socket wait?
+        for (const auto& kv : parked_) {      // cold path: only called at quiescence
+            for (Fiber* f = kv.second; f; f = f->park_link) {
+                if (f->wait_is_socket) return true;
+            }
         }
         return false;
     }
@@ -217,6 +230,17 @@ void FiberSchedulerImpl::inner_loop(unsigned w) {
                 last_progress_val_ = p;
                 last_progress_resump_ = r;
             } else if (r - last_progress_resump_ > spin_release_window) {
+                // Persistent (host-interleaved) run: churn with zero progress while a host-fed socket
+                // wait is parked means the device is blocked on the host (a peer RISC yield-spins on a
+                // barrier whose other side awaits a socket token). Hand control back so the host can
+                // stream + pump(), rather than force-releasing (which only re-churns). This is the
+                // yield-spin HostWait trigger (vs the quiescence-parked one below). See run_persistent.
+                if (persistent_ && any_parked_is_socket_wait()) {
+                    host_wait_ = true;
+                    abort_flag_ = true;
+                    cv_.notify_all();
+                    break;
+                }
                 for (Fiber* f : quiescence_deferred_) {
                     f->state = FiberState::Ready;
                     ready_[f->home].push_back(f);
@@ -291,6 +315,16 @@ void FiberSchedulerImpl::inner_loop(unsigned w) {
                         --idle_;
                         continue;
                     }
+                    // Re-poll made no new progress: genuinely stuck. Under a persistent run, a
+                    // host-fed socket wait parked here is not a deadlock — it is a resumable
+                    // HostWait: hand control back so the host can feed the socket and pump().
+                    // With no socket wait parked, it is a real deadlock (diagnostics unchanged).
+                    if (persistent_ && any_parked_is_socket_wait()) {
+                        host_wait_ = true;
+                        abort_flag_ = true;
+                        --idle_;
+                        break;
+                    }
                     deadlock_ = true;
                     abort_flag_ = true;
                     --idle_;
@@ -335,17 +369,24 @@ void FiberSchedulerImpl::inner_loop(unsigned w) {
 void FiberScheduler::lock() { p_->mu_.lock(); }
 void FiberScheduler::unlock() { p_->mu_.unlock(); }
 
-void FiberScheduler::park_locked(const void* key) {
+static void park_current(FiberSchedulerImpl* p, const void* key, bool is_socket) {
     // pre: mu_ held by this thread (the .so's __emule_fiber_lock). Register parked and
-    // hand the lock to the worker loop across the switch.
+    // hand the lock to the worker loop across the switch. is_socket tags a host-fed socket
+    // wait so quiescence-with-parked is treated as a resumable HostWait, not a deadlock.
     Fiber* f = t_current;
     f->state = FiberState::Parked;
     f->park_key = key;
-    Fiber*& head = p_->parked_[key];         // inserts nullptr if absent
+    f->wait_is_socket = is_socket;
+    Fiber*& head = p->parked_[key];          // inserts nullptr if absent
     f->park_link = head;
     head = f;
     swapcontext(&f->ctx, &t_sched);          // -> worker loop (mu_ held); resumes mu_-UNLOCKED
 }
+
+void FiberScheduler::park_locked(const void* key) { park_current(p_.get(), key, /*is_socket=*/false); }
+
+// Same as park_locked, but tags the park as a host-fed socket wait (see park_current / inner_loop).
+void FiberScheduler::park_locked_socket(const void* key) { park_current(p_.get(), key, /*is_socket=*/true); }
 
 void FiberScheduler::quiescence_park() {
     // Defer the current fiber to scheduler quiescence: re-queue it at lowest priority,
@@ -511,7 +552,12 @@ void FiberSchedulerImpl::watchdog() {
     }
 }
 
-void FiberScheduler::run_until_idle() {
+// Shared launch+wait: spawn/arm the workers, run one quantum on the pool, and block the dispatch
+// thread until every active worker has finished (done_cv_). initial=true assigns homes from all_
+// (a fresh program); initial=false (pump) reuses the existing homing — the caller has already put
+// the fibers to resume back into ready_. On return the run has reached a boundary: every fiber Done,
+// a deadlock, or (persistent) a host-wait. Teardown/throw is the caller's (teardown_and_throw).
+void FiberScheduler::launch_and_wait(bool initial) {
     // Lazily create the persistent worker pool on the first run (K is process-constant);
     // threads live until ~FiberScheduler. See tt-emule docs/fiber-engine.md.
     if (p_->pool_.empty()) {
@@ -522,40 +568,50 @@ void FiberScheduler::run_until_idle() {
         }
     }
 
-    unsigned W;
+    unsigned W = 0;
     {   // Publish counters + progress, W_, the ready queues, and ++generation_ in ONE mu_ critical
         // section, so a worker released for a generation never pairs a new W_ with a stale generation_.
         // See tt-emule docs/fiber-engine.md §9.4 (the workers_done_ overshoot / done_cv_ wedge it avoids).
         std::lock_guard<std::mutex> g(p_->mu_);
-        p_->active_ = static_cast<unsigned>(p_->all_.size());
-        if (p_->active_ == 0) {
-            return;   // nothing to run; the pool stays parked
+        if (initial) {
+            p_->active_ = static_cast<unsigned>(p_->all_.size());
+            if (p_->active_ == 0) {
+                return;   // nothing to run; the pool stays parked
+            }
         }
         p_->idle_ = 0;
         p_->running_ = 0;
         p_->workers_done_ = 0;
         p_->deadlock_ = false;
         p_->abort_flag_ = false;
+        p_->host_wait_ = false;
         p_->first_eptr_ = nullptr;
-        p_->quiescence_deferred_.clear();
-        p_->progress_.store(0);
-        p_->resumptions_.store(0);
-        // Per-run recovery watermarks — reset alongside progress_/resumptions_.
+        // Per-run recovery watermarks — reset alongside progress_/resumptions_ below.
         // A stale last_deadlock_repoll_progress_ from a prior run can collide with this
         // run's quiescence progress and skip the recovery re-poll → spurious deadlock.
         p_->last_progress_val_ = 0;
         p_->last_progress_resump_ = 0;
         p_->last_deadlock_repoll_progress_ = UINT64_MAX;
-        // Activate W = min(K, fiber count) workers; pin each fiber round-robin across [0,W).
-        // Surplus workers (>= W) stay parked on start_cv_, so a tiny program pays no herd.
-        W = std::min<unsigned>(p_->K_, p_->active_);
-        p_->W_ = W;
-        p_->ready_.assign(W, {});
-        for (size_t i = 0; i < p_->all_.size(); ++i) {
-            Fiber* f = p_->all_[i].get();
-            f->home = static_cast<unsigned>(i % W);
-            p_->ready_[f->home].push_back(f);
+        if (initial) {
+            p_->quiescence_deferred_.clear();
+            // Activate W = min(K, fiber count) workers; pin each fiber round-robin across [0,W).
+            // Surplus workers (>= W) stay parked on start_cv_, so a tiny program pays no herd.
+            // See tt-emule docs/fiber-engine.md.
+            W = std::min<unsigned>(p_->K_, p_->active_);
+            p_->W_ = W;
+            p_->ready_.assign(W, {});
+            for (size_t i = 0; i < p_->all_.size(); ++i) {
+                Fiber* f = p_->all_[i].get();
+                f->home = static_cast<unsigned>(i % W);
+                p_->ready_[f->home].push_back(f);
+            }
+        } else {
+            W = p_->W_;   // pump: reuse homing; ready_ already refilled by pump()'s re-poll
         }
+        // Reset run counters (a fresh run and each pump re-poll both start from zero, matching the
+        // per-run watermarks above).
+        p_->progress_.store(0);
+        p_->resumptions_.store(0);
         ++p_->generation_;
     }
     if (std::getenv("TT_EMULE_FIBER_LOG_N")) {
@@ -581,12 +637,16 @@ void FiberScheduler::run_until_idle() {
     }
     p_->wd_cv_.notify_all();
     wd.join();
+}
 
+// Collect results + clear the registry for the next program / mesh. Rethrows the first fiber
+// exception; throws on a quiescent deadlock. Called only after a run reaches Completed (never on a
+// resumable HostWait — then the fibers must stay alive).
+void FiberScheduler::teardown_and_throw() {
     std::exception_ptr eptr;
     bool deadlock;
     std::string dump;
-    {   // Collect results + clear the registry for the next program / mesh (workers are parked
-        // on start_cv_ now, but take mu_ anyway for clean ordering).
+    {   // workers are parked on start_cv_ now, but take mu_ anyway for clean ordering.
         std::lock_guard<std::mutex> g(p_->mu_);
         eptr = p_->first_eptr_;
         deadlock = p_->deadlock_;
@@ -607,6 +667,53 @@ void FiberScheduler::run_until_idle() {
         throw std::runtime_error("EMULE fiber engine: quiescent deadlock — all workers idle, "
                                  "fibers parked, none runnable.\n" + dump);
     }
+}
+
+void FiberScheduler::run_until_idle() {
+    p_->persistent_ = false;   // non-persistent: a quiescence-with-parked is a tier-1 deadlock
+    launch_and_wait(/*initial=*/true);
+    teardown_and_throw();
+}
+
+RunOutcome FiberScheduler::run_persistent() {
+    p_->persistent_ = true;
+    launch_and_wait(/*initial=*/true);
+    if (p_->host_wait_) {
+        return RunOutcome::HostWait;   // fibers parked awaiting host socket I/O — ALIVE, no teardown
+    }
+    teardown_and_throw();
+    return RunOutcome::Completed;
+}
+
+RunOutcome FiberScheduler::pump() {
+    p_->persistent_ = true;
+    {
+        std::lock_guard<std::mutex> g(p_->mu_);
+        if (p_->all_.empty()) {
+            return RunOutcome::Completed;   // no persistent run in flight — no-op
+        }
+        // The host advanced a credit word with a raw L1 store (no __emule_fiber_wake), so wake
+        // every parked fiber to re-check its predicate. This is the quiescence re-poll, host-driven;
+        // spurious-wake-safe (__emule_fiber_wait re-checks under the lock and re-parks).
+        for (auto& kv : p_->parked_) {
+            for (Fiber* f = kv.second; f;) {
+                Fiber* nx = f->park_link;
+                f->park_link = nullptr;
+                f->park_key = nullptr;
+                f->wait_is_socket = false;
+                f->state = FiberState::Ready;
+                p_->ready_[f->home].push_back(f);
+                f = nx;
+            }
+        }
+        p_->parked_.clear();
+    }
+    launch_and_wait(/*initial=*/false);
+    if (p_->host_wait_) {
+        return RunOutcome::HostWait;
+    }
+    teardown_and_throw();
+    return RunOutcome::Completed;
 }
 
 FiberScheduler::FiberScheduler() : p_(std::make_unique<FiberSchedulerImpl>()) {

--- a/tt_metal/impl/emulation/emule_fiber_scheduler.cpp
+++ b/tt_metal/impl/emulation/emule_fiber_scheduler.cpp
@@ -123,6 +123,13 @@ struct FiberSchedulerImpl {
     uint64_t last_progress_resump_ = 0;
     uint64_t last_deadlock_repoll_progress_ = UINT64_MAX;  // sentinel = never re-polled
 
+    // Host-wait liveness bound (reset per persistent SEQUENCE in run_persistent, NOT per launch).
+    // Counts consecutive pumps that returned HostWait having advanced nothing (progress_ == 0). A
+    // wedged kernel whose socket the host never feeds would otherwise loop host<->pump forever with
+    // no diagnostic; pump() escalates to a tier-1 deadlock after kHostWaitNoProgressLimit such pumps.
+    // See tt-emule docs/socket-emulation.md.
+    uint64_t host_wait_no_progress_pumps_ = 0;
+
     size_t stack_bytes_ = 1u << 20;          // 1 MB default
 
     // Persistent worker pool, created once and reused: threads block on start_cv_
@@ -677,6 +684,7 @@ void FiberScheduler::run_until_idle() {
 
 RunOutcome FiberScheduler::run_persistent() {
     p_->persistent_ = true;
+    p_->host_wait_no_progress_pumps_ = 0;   // start of a fresh host-wait sequence
     launch_and_wait(/*initial=*/true);
     if (p_->host_wait_) {
         return RunOutcome::HostWait;   // fibers parked awaiting host socket I/O — ALIVE, no teardown
@@ -710,6 +718,22 @@ RunOutcome FiberScheduler::pump() {
     }
     launch_and_wait(/*initial=*/false);
     if (p_->host_wait_) {
+        // Liveness bound: a pump that advanced nothing (progress_ == 0) while still parked on a socket
+        // wait is a no-progress cycle. If the host keeps pumping a wedged kernel whose socket never
+        // advances, escalate to the tier-1 deadlock after kHostWaitNoProgressLimit consecutive
+        // no-progress pumps instead of looping host<->pump forever with no diagnostic. Any forward
+        // progress resets the count, so a slow-but-advancing feed is unaffected. Keying on global
+        // progress_ (not the awaited socket) leaves a residual masking window — WA-3, see
+        // tt-emule-blaze/.claude/skills/workarounds.
+        static const uint64_t kHostWaitNoProgressLimit = env_size("TT_EMULE_HOST_WAIT_STALL_LIMIT", 8192);
+        if (p_->progress_.load() == 0) {
+            if (++p_->host_wait_no_progress_pumps_ >= kHostWaitNoProgressLimit) {
+                p_->deadlock_ = true;
+                teardown_and_throw();  // reuses the tier-1 quiescent-deadlock diagnostic (dump_parked)
+            }
+        } else {
+            p_->host_wait_no_progress_pumps_ = 0;
+        }
         return RunOutcome::HostWait;
     }
     teardown_and_throw();

--- a/tt_metal/impl/emulation/emule_fiber_scheduler.hpp
+++ b/tt_metal/impl/emulation/emule_fiber_scheduler.hpp
@@ -32,6 +32,11 @@ struct FiberIdentity {
     const char* kernel_src = nullptr;  // static string (kernel source path), for diagnostics
 };
 
+// Outcome of a resumable launch. Completed = every fiber ran to Done (registry torn down).
+// HostWait = the run quiesced with a host-facing socket wait parked; the fibers stay ALIVE
+// (no teardown) and the run resumes via pump() as the host feeds the socket. See run_persistent().
+enum class RunOutcome { Completed, HostWait };
+
 class FiberScheduler {
 public:
     static FiberScheduler& instance();
@@ -46,10 +51,21 @@ public:
     // deadlock (tier 1); aborts with a diagnostic dump on livelock/hang (tier 2).
     void run_until_idle();
 
+    // Host-interleaved (persistent) dispatch — for a program whose kernels block on a
+    // host-fed socket. Like run_until_idle(), but if the run quiesces with a host-facing
+    // socket wait parked it returns HostWait WITHOUT tearing down (fibers stay alive);
+    // pump() then resumes them one quantum per host socket call, and Completed tears down.
+    // A quiescent deadlock with NO socket wait parked still throws (diagnostics preserved).
+    // Teardown is automatic: the pump() that observes every fiber Done returns Completed and clears
+    // the registry (driven by the host's final socket barrier / synchronize). No separate join hook.
+    RunOutcome run_persistent();     // initial launch
+    RunOutcome pump();               // resume the SAME parked fibers one quantum (host advanced a credit word)
+
     // ---- Bridge ops (called by the runner's extern-C thunks from a running fiber) ----
     void lock();
     void unlock();
-    void park_locked(const void* key);  // pre: lock held; post: lock released
+    void park_locked(const void* key);         // pre: lock held; post: lock released
+    void park_locked_socket(const void* key);  // as park_locked, tagged as a host-fed socket wait
     void quiescence_park();              // defer to quiescence: re-queue lowest-priority, released at quiescence
     void wake(const void* key);
     void yield();
@@ -61,6 +77,8 @@ public:
 private:
     FiberScheduler();
     ~FiberScheduler();
+    void launch_and_wait(bool initial);  // shared launch+wait tail (run_until_idle/run_persistent/pump)
+    void teardown_and_throw();           // clear the registry; rethrow eptr / throw on deadlock
     std::unique_ptr<FiberSchedulerImpl> p_;
 };
 

--- a/tt_metal/impl/emulation/emule_sanitizers.hpp
+++ b/tt_metal/impl/emulation/emule_sanitizers.hpp
@@ -24,7 +24,7 @@ class IDevice;
 }
 
 // Wormhole has 32 CBs; JIT header cb_api.h sizes unpack_tile_size[32].
-static constexpr uint32_t EMULE_NUM_CBS = 32;
+static constexpr uint32_t EMULE_NUM_CBS = 64;
 
 // The per-launch sanitizer range/counter state used to live in `extern
 // thread_local`s here; it now lives in the per-fiber context


### PR DESCRIPTION
### PR Category
Feature

### Summary
Emulation-runtime support for host-facing (PCIe) sockets and concurrent multi-chip dispatch in the software emulator (`TT_METAL_USE_EMULE`). A host-fed socket (H2D/D2H) requires the device and the host to run in lockstep — the device drains or fills one end of the socket while the host streams the other — so the emulator makes its fiber scheduler resumable and lets the host pump it between socket transfers.

- **Resumable, host-interleaved fiber scheduler.** The scheduler gains a two-outcome run model (`RunOutcome{Completed, HostWait}`). A run that quiesces because every remaining fiber is parked on a host-fed socket credit word returns `HostWait` *without* teardown — the fibers stay alive.`run_until_idle` is refactored onto a shared `launch_and_wait` / `teardown_and_throw`, with `run_persistent()` starting a resumable run.
- **`pump()` — one host-driven quantum.** Each host socket call re-arms the parked fibers (the host advances a credit word with a raw L1 store, which issues no fiber wake), re-homes them onto the ready queues, and runs the scheduler until it quiesces again — returning `HostWait` while still waiting on the host, or `Completed` once every fiber has finished.
- **Socket-aware quiescence.** A fiber blocking on a host-fed socket credit word is parked via `park_locked_socket()` and tagged `wait_is_socket`. At quiescence, `any_parked_is_socket_wait()` lets the scheduling loop distinguish "blocked on host I/O" (a resumable `HostWait`) from a genuine tier-1 deadlock (all fibers parked, none on a socket) — so a legitimate host wait is never misreported as a hang.
- **Runner driver and host-pump hook.** `run_mesh_dispatch()` drives each program with `run_persistent()`; `pump_device()` advances a parked run and runs deferred mesh cleanup on completion. The H2D/D2H socket wait loops call `pump_device()` (under `#ifdef TT_METAL_USE_EMULE`) so a kernel blocked on a host-fed socket resumes as soon as the host feeds it.
- **Host-facing PCIe NOC resolution.** `__emule_resolve_noc_addr` routes any address at or above the device's `pcie_base` (cached per device) to a `SimulationSysmemManager` rather than the on-chip core map, so an emulated kernel reaches host sysmem the same way silicon's NOC does — the substrate the host-fed socket path reads and writes through.
- **Fiber-scheduler recovery internals (first commit).** The persistent-dispatch model builds on the emulator's raw-L1-store lost-wakeup recovery watermarks (`last_progress_val_`, `last_progress_resump_`, `last_deadlock_repoll_progress_`, `spin_release_window`); these land first, on their own, and compile independently of the socket work.
- **Circular-buffer ceiling raised to 64** (Blackhole's maximum), so emulated kernels can address CB ids 32–63.

### Notes for reviewers
- Emule-only — no silicon code path is touched (all changes are under
  `tt_metal/impl/emulation/`, plus the `#ifdef TT_METAL_USE_EMULE` `pump_device()` hook in the H2D/D2H
  socket wait loops)
- Companion UMD PR https://github.com/tenstorrent/tt-umd/pull/3076
- #51107 is the equivalent code change, viewed against the pinned metal version for emule. That is the version that has been tested

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=arminale/emule-sockets-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:arminale/emule-sockets-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=arminale/emule-sockets-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:arminale/emule-sockets-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=arminale/emule-sockets-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:arminale/emule-sockets-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=arminale/emule-sockets-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:arminale/emule-sockets-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=arminale/emule-sockets-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:arminale/emule-sockets-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=arminale/emule-sockets-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:arminale/emule-sockets-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=arminale/emule-sockets-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:arminale/emule-sockets-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=arminale/emule-sockets-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:arminale/emule-sockets-main)