### PR TITLE
[skip ci] Fix mobile docs layout: prevent content from being crushed into a narrow right strip

### DIFF
--- a/docs/source/common/_static/tt_theme.css
+++ b/docs/source/common/_static/tt_theme.css
@@ -1551,8 +1551,11 @@ body:has(.tt-top-nav) .rst-content dl.py > dd > dl.field-list {
   html, body { overflow-x: hidden; max-width: 100%; }
   .wy-grid-for-nav { overflow-x: hidden; }
 
-  /* Drop the desktop sidebar offset so the page is full-width */
-  .wy-nav-content-wrap {
+  /* Drop the desktop sidebar offset so the page is full-width. Must match the
+     specificity of the desktop `body:has(.tt-top-nav) .wy-nav-content-wrap`
+     rule (both use !important), otherwise the 308px margin wins here and the
+     content is crushed into a narrow strip on the right. */
+  body:has(.tt-top-nav) .wy-nav-content-wrap {
     margin-left: 0 !important;
     padding-right: 0 !important;
     max-width: 100% !important;

--- a/docs/source/common/_static/tt_theme.css
+++ b/docs/source/common/_static/tt_theme.css
@@ -1551,15 +1551,22 @@ body:has(.tt-top-nav) .rst-content dl.py > dd > dl.field-list {
   html, body { overflow-x: hidden; max-width: 100%; }
   .wy-grid-for-nav { overflow-x: hidden; }
 
-  /* Drop the desktop sidebar offset so the page is full-width. Must match the
-     specificity of the desktop `body:has(.tt-top-nav) .wy-nav-content-wrap`
-     rule (both use !important), otherwise the 308px margin wins here and the
-     content is crushed into a narrow strip on the right. */
-  body:has(.tt-top-nav) .wy-nav-content-wrap {
+  /* Drop the desktop sidebar offset so the page is full-width. Keep the
+     unqualified selector so pages that load this stylesheet without the shared
+     top nav (the explicitly-supported mode noted at lines 420–423) still get
+     the overflow / max-width safeguards. */
+  .wy-nav-content-wrap {
     margin-left: 0 !important;
     padding-right: 0 !important;
     max-width: 100% !important;
     overflow-x: hidden;
+  }
+  /* The desktop offset `body:has(.tt-top-nav) .wy-nav-content-wrap` (specificity
+     0,2,1, !important) outranks the unqualified reset above (0,1,0), so on
+     top-nav builds the 308px margin would survive here and crush content into a
+     narrow strip on the right. Re-assert margin-left at matching specificity. */
+  body:has(.tt-top-nav) .wy-nav-content-wrap {
+    margin-left: 0 !important;
   }
   .wy-nav-content {
     max-width: 100% !important;


### PR DESCRIPTION
## Problem

On mobile (viewport ≤ 768px), the TT-Metalium docs pages render with all content squeezed into an ~82px strip on the right edge, leaving a wide empty column on the left where the (now off-screen) sidebar used to sit.

Reported against https://docs.tenstorrent.com/tt-metal/latest/tt-metalium/ — reproduces on Android Chrome and any ≤768px viewport in portrait.

## Root cause

A CSS specificity conflict in `docs/source/common/_static/tt_theme.css`. Two rules set `margin-left` on `.wy-nav-content-wrap`, both with `!important`, so **specificity** decides the winner:

| Rule | Selector | Specificity | Context |
|---|---|---|---|
| Desktop offset | `body:has(.tt-top-nav) .wy-nav-content-wrap` | (0,2,1) | no media query |
| Mobile reset | `.wy-nav-content-wrap` | (0,1,0) | `@media (max-width:768px)` |

Because `(0,2,1)` outranks `(0,1,0)`, the desktop `margin-left: 308px !important` **survives inside the mobile breakpoint**. The 308px margin on a ~390px viewport leaves only ~82px for content.

## Fix

Give the mobile reset the same `body:has(.tt-top-nav)` prefix so it matches the desktop rule's specificity and correctly zeroes the margin on mobile. One-selector change (plus an explanatory comment).

## Verification

Injected the corrected rule live against the deployed page at a 390px viewport:
- `margin-left` on `.wy-nav-content-wrap`: `308px` → `0px`
- content width: `82px` → full `390px`
- sidebar correctly collapses behind the ☰ menu

Before/after screenshots captured during investigation.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=fix/mobile-content-wrap-margin)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:fix/mobile-content-wrap-margin)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=fix/mobile-content-wrap-margin)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:fix/mobile-content-wrap-margin)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=fix/mobile-content-wrap-margin)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:fix/mobile-content-wrap-margin)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fix/mobile-content-wrap-margin)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fix/mobile-content-wrap-margin)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=fix/mobile-content-wrap-margin)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:fix/mobile-content-wrap-margin)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=fix/mobile-content-wrap-margin)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:fix/mobile-content-wrap-margin)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=fix/mobile-content-wrap-margin)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:fix/mobile-content-wrap-margin)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=fix/mobile-content-wrap-margin)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:fix/mobile-content-wrap-margin)