### PR TITLE
[Quasar] Fix fidelity-phase count in direct-indexed eltwise binary

### DIFF
--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_eltwise_binary.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_eltwise_binary.h
@@ -144,7 +144,7 @@ inline void _llk_math_eltwise_di_binary_mop_config_(const ckernel::TensorShape& 
 {
     const std::uint32_t total_num_rows_per_tile = tensor_shape.total_num_faces() * tensor_shape.face_r_dim;
     const std::uint32_t REPLAY_BUF_LEN          = (total_num_rows_per_tile >> rows_log2(ELTWISE_MATH_ROWS));
-    const std::uint32_t MOP_INNER_LOOP          = to_underlying(MATH_FIDELITY_TYPE) + 1;
+    constexpr std::uint32_t MOP_INNER_LOOP      = MATH_FIDELITY_TYPE == ckernel::MathFidelity::LoFi ? 1 : to_underlying(MATH_FIDELITY_TYPE);
     constexpr bool high_fidelity                = MATH_FIDELITY_TYPE != ckernel::MathFidelity::LoFi;
     static_assert(!(high_fidelity && ELTWISE_BINARY_TYPE != EltwiseBinaryType::ELWMUL), "Math fidelity larger than LoFi only works with Eltwise MUL");
     const std::uint32_t EN_DST_ACC = acc_to_dest ? 1u : static_cast<std::uint32_t>(high_fidelity);


### PR DESCRIPTION
### Ticket
Closes #48249 (sub-issue of #48188)

### Problem description
`_llk_math_eltwise_di_binary_mop_config_` (`tt_llk_quasar/llk_lib/llk_math_eltwise_binary.h`) derived the MOP inner-loop count as:

```cpp
const std::uint32_t MOP_INNER_LOOP = to_underlying(MATH_FIDELITY_TYPE) + 1;
```

The MOP main instruction is a `TT_OP_REPLAY` of the whole tile, so the inner loop count *is* the number of FPU fidelity phases accumulated into DEST. But `MathFidelity` is not contiguous — `LoFi = 0, HiFi2 = 2, HiFi3 = 3, HiFi4 = 4` (`llk_defs.h`) — so `+ 1` produces **1 / 3 / 4 / 5** phases where the correct counts are **1 / 2 / 3 / 4**. Every HiFi mode runs one extra fidelity phase and over-accumulates the product. LoFi is correct only by accident (`0 + 1 == 1`).

### What's changed
One line, replacing the expression with the one already used by every other fidelity-phase count in the tree:

```cpp
constexpr std::uint32_t MOP_INNER_LOOP = MATH_FIDELITY_TYPE == ckernel::MathFidelity::LoFi ? 1 : to_underlying(MATH_FIDELITY_TYPE);
```

- the non-DI sibling in the same file (`llk_math_eltwise_binary.h:113`)
- both matmul MOP configs, including the direct-indexed one (`llk_math_matmul.h:216` and `:304`)

`const` → `constexpr` also matches the sibling; `MATH_FIDELITY_TYPE` is a template parameter.

### Blast radius
None to shipped code. The direct-indexing path is Quasar-only and reached solely through `_llk_math_eltwise_binary_init_<..., ENABLE_DIRECT_INDEXING = true>`; nothing in tt-metal, ttnn, or the LLK tests instantiates it (`llk_math_binary_api.h:49` never passes the 4th template argument). Until this PR the template body had never been compiled.

### Validation
1. **Ground truth** — enum values in `llk_defs.h` confirm `+1` cannot be the phase count for a non-contiguous enum.
2. **Tested sibling** — matmul's direct-indexed MOP config uses the identical `ckernel_template temp(1, FIDELITY_PHASES, TT_OP_REPLAY(...))` construct with the corrected formula, and `test_matmul_quasar.py` covers it across `HiFi2/HiFi3/HiFi4` (DI is enabled for the `MxFp4_2x` register formats).
3. **Codegen check** — compiled the (previously never-instantiated) template for all four fidelities with the Quasar SFPI toolchain using the test suite's exact flags (`riscv-tt-elf-g++ -mcpu=tt-qsr32-tensix -O3 -Wall -Werror ...`); clean build. Diffing the emitted assembly before/after shows the MOP inner-loop immediate change exactly as intended:

   | MathFidelity | before | after |
   |---|---|---|
   | LoFi | 1 | 1 (unchanged) |
   | HiFi2 | 3 | **2** |
   | HiFi3 | 4 | **3** |
   | HiFi4 | 5 | **4** |

No regression test is added: there is no Quasar silicon to run one on, Quasar on ttsim is documented as "not validated" (`tests/TTSIM.md`), and the eltwise-binary test harness has no `ENABLE_DIRECT_INDEXING` variant today. Adding that coverage is worth a follow-up — it is the reason this bug went unnoticed.

### Checklist
- [x] Pre-commit hooks pass (clang-format, llk `std::` check, codespell)
- [x] Quasar LLK header compiles for every `MathFidelity` with the DI template instantiated
- [ ] Hardware validation — not possible pre-silicon; the DI path is currently unreachable from tt-metal

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amahmud/fix-quasar-di-eltwise-binary-fidelity)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amahmud/fix-quasar-di-eltwise-binary-fidelity)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amahmud/fix-quasar-di-eltwise-binary-fidelity)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amahmud/fix-quasar-di-eltwise-binary-fidelity)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=amahmud/fix-quasar-di-eltwise-binary-fidelity)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:amahmud/fix-quasar-di-eltwise-binary-fidelity)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amahmud/fix-quasar-di-eltwise-binary-fidelity)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amahmud/fix-quasar-di-eltwise-binary-fidelity)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amahmud/fix-quasar-di-eltwise-binary-fidelity)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amahmud/fix-quasar-di-eltwise-binary-fidelity)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amahmud/fix-quasar-di-eltwise-binary-fidelity)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amahmud/fix-quasar-di-eltwise-binary-fidelity)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amahmud/fix-quasar-di-eltwise-binary-fidelity)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amahmud/fix-quasar-di-eltwise-binary-fidelity)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amahmud/fix-quasar-di-eltwise-binary-fidelity)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amahmud/fix-quasar-di-eltwise-binary-fidelity)