### PR TITLE
docs: note ttsim's glibc 2.38 requirement

### DIFF
--- a/tt_metal/tt-llk/tests/TTSIM.md
+++ b/tt_metal/tt-llk/tests/TTSIM.md
@@ -10,6 +10,11 @@ of environment variables.
 
 - `libttsim_{wh,bh}.so` downloaded from
   [ttsim releases](https://github.com/tenstorrent/ttsim/releases).
+- A host with **glibc 2.38 or newer**. The `ttsim` binary links against
+  `GLIBC_2.38`, so it fails on older bases with
+  `version 'GLIBC_2.38' not found`. Ubuntu 24.04 (glibc 2.39) works;
+  Ubuntu 22.04 (glibc 2.35) does not. The `.so` itself only needs
+  `GLIBC_2.14`, so this applies to the standalone binary.
 - A SoC descriptor YAML for the target arch, placed next to the `.so`
   and named `soc_descriptor.yaml` (ttsim derives its path from the `.so`
   path).


### PR DESCRIPTION
### Ticket

N/A — documentation gap found while setting ttsim up from scratch.

### Problem description

`TTSIM.md` lists five prerequisites and does not mention glibc, but the `ttsim` binary links against `GLIBC_2.38`. On an older base it fails with:

```
./ttsim: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found (required by ./ttsim)
```

The message names a symbol version rather than the base image, so it is slow to connect to "your container is too old" — I spent a while assuming the download was corrupt.

Verified with `objdump`:

```
$ objdump -T ttsim          | grep -o 'GLIBC_[0-9.]*' | sort -uV | tail -1
GLIBC_2.38
$ objdump -T libttsim_wh.so | grep -o 'GLIBC_[0-9.]*' | sort -uV | tail -1
GLIBC_2.14
```

So it is the standalone binary that constrains the host, not the `.so` — worth stating, since the prerequisites list mentions only the `.so`.

Confirmed against the two obvious bases:

| image | glibc | works |
|---|---|---|
| `ubuntu:24.04` | 2.39 | yes |
| `ubuntu:22.04` | 2.35 | no |

### What's changed

One bullet added to the Prerequisites list. Five lines, docs only.

### Type of change

- [x] Documentation update

### Checklist

- [ ] All post commit CI passes — docs-only change, no code paths touched. Happy to trigger if you'd like it run anyway.
- [ ] Blackhole Post commit CI passes — same.
- [x] Assert validation — no asserts involved.

### Context

I was following `TTSIM.md` to get a hardware-free setup working for [#50465](https://github.com/tenstorrent/tt-metal/issues/50465), and this was the one step where the docs left me guessing. Everything else in that file worked as written — the `.so` and SOC descriptor placement, both env vars, and the pinned `tt-exalens` / `tt-umd` versions all behaved exactly as described, and the simulator does boot a Wormhole device on a plain laptop.

If glibc 2.38 is considered obvious for this toolchain, feel free to close — I'd rather flag it than have the next person assume a corrupt download.
