### PR TITLE
docs: add the RTL-vs-ttsim entry point to TTSIM troubleshooting

### DIFF
--- a/tt_metal/tt-llk/tests/TTSIM.md
+++ b/tt_metal/tt-llk/tests/TTSIM.md
@@ -105,3 +105,13 @@ the most common format and no SFPU/tilize paths.
   tt-umd. The fix that advances the sim clock on host writes
   (TTSimTTDevice::write_to_device) is required; upgrade to a release
   that contains it.
+- `Simulator binary not found at: <dir>/run.sh` — you passed a **directory** to
+  `init_ttexalens(simulation_directory=...)`, which selects the **RTL** flow and
+  looks for `run.sh` inside it. The argument is overloaded: pass the path to the
+  shared library instead and the same function opens ttsim —
+  `init_ttexalens(simulation_directory="<path>/libttsim_wh.so")`. That is what
+  the harness does itself (`python_tests/conftest.py` forwards
+  `TT_METAL_SIMULATOR` when it ends in `.so`). Setting `TT_METAL_SIMULATOR` and
+  letting the harness initialise is the least error-prone route;
+  `tt_umd.create_simulation_tt_device("<path>/libttsim_wh.so")` also works when
+  driving tt-umd directly.


### PR DESCRIPTION
### Ticket

N/A — documentation gap found while driving ttsim directly.

### Problem description

`init_ttexalens(simulation_directory=...)` looks like the way to open the simulator, but it is the **RTL** simulator path. Pointing it at a ttsim directory fails with:

```
UmdBaseException Simulator binary not found at: /w/run.sh
Location: /project/device/simulation/rtl_sim_communicator.cpp:96
tt::umd::RtlSimulationTTDevice::RtlSimulationTTDevice(...)
```

The message mentions `run.sh` and `RtlSimulationTTDevice`, so it reads as "your ttsim install is incomplete" rather than "wrong entry point". I went looking for a missing file for a while before noticing `RtlSimulation` in the stack.

Verified both paths side by side, same directory, same `.so`:

```
RTL path error: Simulator binary not found at: /w/run.sh
ttsim path OK: TTSimTTDevice
```

`TTSIM.md` already documents `TT_METAL_SIMULATOR`, which is the right answer for the pytest flow. This only bites when opening the device directly — which is a reasonable thing to do when checking a single kernel rather than running a sweep.

### What's changed

One entry appended to the existing Troubleshooting list, in the same shape as the others (symptom → cause → fix). Five lines, docs only.

### Type of change

- [x] Documentation update

### Checklist

- [ ] All post commit CI passes — docs-only, no code paths touched.
- [ ] Blackhole Post commit CI passes — same.
- [x] Assert validation — no asserts involved.

### Context

Follow-up to #51119, from the same exercise: getting a hardware-free ttsim setup working for [#50465](https://github.com/tenstorrent/tt-metal/issues/50465). These were the two places the docs left me guessing; everything else in `TTSIM.md` worked as written.

If direct device access is considered out of scope for this doc — i.e. the intended path really is "always go through pytest" — feel free to close. I'd still suggest the error is worth a line, since the wording points at a missing file rather than a wrong function.
