### PR TITLE
Fix test_clean_init loopback runtime argument ordering

### DIFF
--- a/tests/tt_metal/tt_metal/test_clean_init.cpp
+++ b/tests/tt_metal/tt_metal/test_clean_init.cpp
@@ -112,11 +112,10 @@ int main(int argc, char** /*argv*/) {
                 dram_buffer_size, 100, std::chrono::system_clock::now().time_since_epoch().count());
             distributed::EnqueueWriteMeshBuffer(cq, input_dram_buffer, input_vec, false);
 
-            const std::array<uint32_t, 8> runtime_args = {
+            const std::array<uint32_t, 4> runtime_args = {
                 l1_buffer->address(),
                 input_dram_buffer->address(),
                 output_dram_buffer->address(),
-                l1_buffer->size(),
                 num_tiles};
 
             SetRuntimeArgs(program, dram_copy_kernel_id, core, runtime_args);


### PR DESCRIPTION
### PR Category
Test Only

### Summary
`unit_tests_device` was spending several minutes in `TensixReleaseOwnership.ReleaseOwnershipWithSubprocess` under slow-dispatch simulator runs because the `test_clean_init` subprocess passed `l1_buffer->size()` in the runtime argument slot that `loopback_dram_copy.cpp` interprets as the tile count. That made the loopback kernel copy 102400 pages instead of the intended 50, with a read and write barrier on every iteration. The test now uses the same four-argument contract as the loopback programming example and passes `num_tiles` in arg slot 3, so the kernel executes the intended amount of work while preserving the existing validation path.

### Notes for reviewers
none

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mcraighead/unit-tests-device-slow)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mcraighead/unit-tests-device-slow)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mcraighead/unit-tests-device-slow)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mcraighead/unit-tests-device-slow)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mcraighead/unit-tests-device-slow)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mcraighead/unit-tests-device-slow)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mcraighead/unit-tests-device-slow)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mcraighead/unit-tests-device-slow)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mcraighead/unit-tests-device-slow)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mcraighead/unit-tests-device-slow)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mcraighead/unit-tests-device-slow)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mcraighead/unit-tests-device-slow)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mcraighead/unit-tests-device-slow)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mcraighead/unit-tests-device-slow)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mcraighead/unit-tests-device-slow)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mcraighead/unit-tests-device-slow)