### PR TITLE
fix: restore digamma accuracy below the LUT fit floor

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_digamma.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_digamma.h
@@ -68,10 +68,29 @@ template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_digamma() {
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat x = sfpi::dst_reg[0];
+
+        // Small-x recurrence. Below the LUT fit range the rational saturates at
+        // a0/b0 (-337671.9 for the bf16 fit) while digamma(x) -> -inf as x -> 0+,
+        // so the op silently returns a finite constant for an unbounded function.
+        // digamma(x) = digamma(x+1) - 1/x is exact, and one step lands x+1 in
+        // [1, 1.01], comfortably inside the fit range. The reciprocal is already
+        // programmed for the large-x branch below.
+        //
+        // The shift is folded into the LUT argument rather than evaluated in a
+        // second rational body: the evaluator is fully inlined, so a duplicate
+        // call costs LLK instruction space for a branch that only differs in
+        // its input.
+        sfpi::vFloat lut_arg = x;
+        v_if(x < 0.01f) { lut_arg = x + 1.0f; }
+        v_endif;
+
         // Piecewise-rational LUT, fit on [0.01, 102].
         sfpi::vFloat result =
             piecewise_rational_eval<DIGAMMA_NUM_DEGREE, DIGAMMA_DEN_DEGREE, DIGAMMA_NUM_SEGMENTS, DIGAMMA_LUT_SIZE>(
-                DIGAMMA_LUT, x);
+                DIGAMMA_LUT, lut_arg);
+
+        v_if(x < 0.01f) { result = result - sfpu_reciprocal_iter<2>(x); }
+        v_endif;
 
         // Large-x asymptotic (Bernoulli series). Above the LUT fit range the rational
         // extrapolates poorly (issue #45520: "behaves bad for x>1000"); the asymptotic

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_digamma.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_digamma.h
@@ -68,10 +68,29 @@ template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_digamma() {
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat x = sfpi::dst_reg[0];
+
+        // Small-x recurrence. Below the LUT fit range the rational saturates at
+        // a0/b0 (-337671.9 for the bf16 fit) while digamma(x) -> -inf as x -> 0+,
+        // so the op silently returns a finite constant for an unbounded function.
+        // digamma(x) = digamma(x+1) - 1/x is exact, and one step lands x+1 in
+        // [1, 1.01], comfortably inside the fit range. The reciprocal is already
+        // programmed for the large-x branch below.
+        //
+        // The shift is folded into the LUT argument rather than evaluated in a
+        // second rational body: the evaluator is fully inlined, so a duplicate
+        // call costs LLK instruction space for a branch that only differs in
+        // its input.
+        sfpi::vFloat lut_arg = x;
+        v_if(x < 0.01f) { lut_arg = x + 1.0f; }
+        v_endif;
+
         // Piecewise-rational LUT, fit on [0.01, 102].
         sfpi::vFloat result =
             piecewise_rational_eval<DIGAMMA_NUM_DEGREE, DIGAMMA_DEN_DEGREE, DIGAMMA_NUM_SEGMENTS, DIGAMMA_LUT_SIZE>(
-                DIGAMMA_LUT, x);
+                DIGAMMA_LUT, lut_arg);
+
+        v_if(x < 0.01f) { result = result - sfpu_reciprocal_iter<2>(x); }
+        v_endif;
 
         // Large-x asymptotic (Bernoulli series). Above the LUT fit range the rational
         // extrapolates poorly (issue #45520: "behaves bad for x>1000"); the asymptotic

--- a/tt_metal/tt-llk/tests/TTSIM.md
+++ b/tt_metal/tt-llk/tests/TTSIM.md
@@ -105,3 +105,8 @@ the most common format and no SFPU/tilize paths.
   tt-umd. The fix that advances the sim clock on host writes
   (TTSimTTDevice::write_to_device) is required; upgrade to a release
   that contains it.
+- `Simulator binary not found at: <dir>/run.sh` — you reached the **RTL**
+  simulator path, not ttsim. `init_ttexalens(simulation_directory=...)` is for
+  the RTL flow; ttsim is opened with
+  `tt_umd.create_simulation_tt_device("<path>/libttsim_wh.so")`, or by setting
+  `TT_METAL_SIMULATOR` and letting the harness do it.

--- a/tt_metal/tt-llk/tests/python_tests/helpers/sfpu_domains.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/sfpu_domains.py
@@ -365,9 +365,14 @@ _OP_DOMAIN_REGISTRY: Dict[
     MathOperation.Lgamma: OperandSpecs(
         spec_A=StimuliSpec(distribution=DistributionKind.UNIFORM, low=1.0, high=15.0)
     ),
-    # digamma: LUT fit on [0.01, 102]; keep positive to avoid the poles at x<=0
+    # digamma: LUT fit on [0.01, 102], with a recurrence below the floor and an
+    # asymptotic above the ceiling; keep positive to avoid the poles at x<=0.
+    # `low` deliberately sits under the LUT floor so the (0, 0.01) interval the
+    # public docstring promises ("supported for values greater than 0") is
+    # actually exercised — it was previously untested, which is how the
+    # small-x saturation in #51128 survived.
     MathOperation.Digamma: OperandSpecs(
-        spec_A=StimuliSpec(distribution=DistributionKind.UNIFORM, low=0.1, high=50.0)
+        spec_A=StimuliSpec(distribution=DistributionKind.UNIFORM, low=1e-6, high=50.0)
     ),
     # identity: pass-through; any range is valid
     MathOperation.Identity: OperandSpecs(


### PR DESCRIPTION
Closes #51128.

### The bug

`digamma`'s rational LUT is fit on `[0.01, 102]`. The **upper** bound got an asymptotic branch in #47324; the **lower** bound has no guard. Below it the rational tends to `a0/b0`, so the op saturates at a finite `-337671.9` while `digamma(x) → -∞` as `x → 0⁺`.

The public docstring says *"supported for values greater than 0"*, so the whole `(0, 0.01)` interval is claimed and wrong:

| x | kernel | true | rel err |
|---|---|---|---|
| 1e-04 | -9714.93 | -10000.58 | 2.9 % |
| 1e-06 | -252446.19 | -1.0000e+06 | 74.8 % |
| 1e-20 | -337671.91 | -1.0000e+20 | 100 % |

The fp32 path is worse: at `x = 1e-8` it returns **+7.16e6** for a function that is negative on all of `(0, 1)`.

### The fix

`digamma(x) = digamma(x+1) - 1/x` is exact. One step maps `x < 0.01` into `[1, 1.01]`, comfortably inside the fit range, and the reciprocal is already programmed for the large-x branch. It mirrors the existing `v_if (x > 102.0f)`, and `lgamma` already uses a reflection branch for `in < 0.5f`, so the pattern is established in-tree.

### Why it survived

`sfpu_domains.py` sampled `[0.1, 50.0]` — the sweep never entered the broken interval. Lowered `low` to `1e-6` so the range the docstring promises is actually exercised. **That change alone fails on `main`.**

### Verification — on ttsim, no hardware

Run through the in-tree LLK suite against `ttsim` v1.9.6 (the hash pinned in `tt_metal/tt-llk/tests/ttsim-version`):

| stimulus `low` | before | after |
|---|---|---|
| `0.1` (shipped) | passed | passed |
| `0.01` (fit floor) | passed | passed |
| `0.0001` | passed | passed |
| `0.00005` | **FAILED** | **passed** |
| `0.000001` | **FAILED** | **passed** |

The failing case reported `kernel -251904.00` against `golden -1003520.00` — the saturation, straight from the simulator's tile dump. It also confirms the fp32 port I filed the issue with: I predicted `-252446.19`, the simulator produced `-251904.00`, a 0.215 % gap, i.e. bf16 rounding.

**Large-x is unaffected.** Since this inserts a branch ahead of the asymptotic path, I re-ran with `high=500` (crossing the 102 ceiling) and across the full `1e-6 .. 500` span — both pass.

```
low=1e-6,  high=50.0     1 passed
low=50.0,  high=500.0    1 passed     <- crosses the x>102 branch
low=1e-6,  high=500.0    1 passed
low=0.1,   high=50.0     1 passed     <- shipped domain, unchanged
```

Blackhole and Wormhole copies are byte-identical before and after, preserving that invariant.

### Caveat

ttsim is a functional simulator, not bit-exact against silicon for every op. The pass/fail transitions above are unambiguous, but I do not have a TT part — **someone with hardware should confirm before merge**, particularly the fp32 sign flip at `1e-8`, which I could only measure through a port of the LUT rather than on-device.
