### PR TITLE
fix: add an asymptotic branch to i0 for large |x|

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_i0.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_i0.h
@@ -6,7 +6,9 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
+#include "ckernel_sfpu_exp.h"
 #include "cmath_common.h"
+#include "sfpu/ckernel_sfpu_polyval.h"
 
 using namespace sfpi;
 
@@ -25,15 +27,83 @@ namespace sfpu {
      t4)
 inline void i0_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
 
+// ======================================================================
+// i0(x) — modified Bessel function of the first kind, order 0.
+//
+// The Maclaurin series below is truncated at k=11 (12 terms). Its largest
+// term sits near k ≈ x/2, so the truncation is only safe while x/2 stays
+// well under 11 — in practice to about x = 13. Past that the omitted tail
+// dominates and the result is a silent, finite underestimate: measured
+// 21.0% relative error at x = 20 and 88.6% at x = 30.
+//
+// Fixed by mirroring the two-region structure already used by
+// ckernel_sfpu_i1.h (i0 is even, so no sign handling is needed):
+//   |x| ≤ 7:   the existing Maclaurin polynomial
+//   |x| > 7:   asymptotic i0(x) = exp(|x|)/sqrt(2π|x|) · P(1/|x|)
+//              (Abramowitz & Stegun 9.7.1), degree-5 minimax in 1/|x|
+//              over [1/88.5, 0.1]
+// Inputs are clamped to ±88.5 as in i1, since exp() saturates near ±88.7.
+//
+// Measured relative error against a high-precision reference, dense sweep:
+//   [0, 88.5]    100%  → 3.43e-05
+// The asymptotic branch itself is good to 4.6e-07; the residual is the
+// Maclaurin polynomial just below the handover, so the threshold sets the
+// overall error. Sweeping it: 13 → 3.8e-03, 10 → 2.2e-04, 7 → 3.4e-05,
+// 6 → 4.7e-05. 7 is the minimum. (The issue suggests "~10-13"; that range
+// is inside one BF16 ULP (≈4e-3) but costs two orders of magnitude of
+// accuracy that the asymptotic path is already paying for.)
+// ======================================================================
+
+// Outlined to keep register pressure within SFPI's LRA budget, matching the
+// shape of calculate_i1_asymptotic_. Returns exp(|x|) · 1/sqrt(2π|x|) · P(1/|x|).
+sfpi_inline sfpi::vFloat calculate_i0_asymptotic_(const sfpi::vFloat abs_x) {
+    // exp(|x|) — |x| ∈ [10, 88.5] precludes overflow/underflow, so the
+    // unsafe variants' skipped guards are dead code here.
+#ifdef INP_FLOAT32
+    const sfpi::vFloat exp_abs = _sfpu_exp_fp32_accurate_unsafe_(abs_x);
+#else
+    const sfpi::vFloat exp_abs = _sfpu_exp_21f_bf16_unsafe_<true>(abs_x);
+#endif
+
+    // 1/sqrt(|x|) via Quake-style seed plus two Newton refinements, reused to
+    // derive 1/|x| as rsqrt_y² instead of issuing a separate reciprocal.
+    const sfpi::vInt rsqrt_i = sfpi::as<sfpi::vInt>(sfpi::as<sfpi::vUInt>(abs_x) >> 1);
+    sfpi::vFloat rsqrt_y = sfpi::as<sfpi::vFloat>(sfpi::vInt(0x5f1110a0) - rsqrt_i);
+    sfpi::vFloat c0 = (-rsqrt_y) * (abs_x * rsqrt_y);
+    rsqrt_y = rsqrt_y * (sfpi::vFloat(2.2825186f) + c0 * (sfpi::vFloat(2.2533049f) + c0));
+    c0 = 1.0f + (-rsqrt_y) * (abs_x * rsqrt_y);
+    rsqrt_y = c0 * sfpi::addexp(rsqrt_y, -1) + rsqrt_y;
+
+    const sfpi::vFloat inv_abs_x = rsqrt_y * rsqrt_y;
+
+    // P(y) on y = 1/|x| ∈ [1/88.5, 0.1]. Leading term is 1/sqrt(2π).
+    const sfpi::vFloat correction = PolynomialEvaluator::eval(
+        inv_abs_x,
+        3.9894227266e-01f,
+        4.9868565798e-02f,
+        2.8280049562e-02f,
+        1.8642880395e-02f,
+        1.9414494932e-01f,
+        -5.4021686316e-01f);
+
+    return exp_abs * rsqrt_y * correction;
+}
+
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_i0() {
+    constexpr float I0_MAX_INPUT = 88.5f;
+    constexpr float I0_THRESHOLD = 7.0f;
+
 #pragma GCC unroll 0
 
     for (int d = 0; d < ITERATIONS; d++) {
         vFloat result = 0.0f;
-        vFloat input = dst_reg[0];
+        vFloat input = sfpi::symmetric_clamp(dst_reg[0], I0_MAX_INPUT);
+        const vFloat abs_x = sfpi::abs(input);
         vFloat x = input * input;
 
+        // Polynomial path, computed unconditionally so its intermediates die
+        // at the store and free LRegs for the asymptotic block.
         result = 1.0f + POLYVAL10(
                             1.50E-22f,
                             7.24E-20f,
@@ -47,6 +117,10 @@ inline void calculate_i0() {
                             0.015625f,
                             0.25f,
                             x);
+
+        // Asymptotic overwrite for the out-of-domain lanes.
+        v_if(abs_x > I0_THRESHOLD) { result = calculate_i0_asymptotic_(abs_x); }
+        v_endif;
 
         dst_reg[0] = result;
         dst_reg++;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_i0.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_i0.h
@@ -6,7 +6,9 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
+#include "ckernel_sfpu_exp.h"
 #include "cmath_common.h"
+#include "sfpu/ckernel_sfpu_polyval.h"
 
 using namespace sfpi;
 
@@ -25,15 +27,83 @@ namespace sfpu {
      t4)
 inline void i0_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
 
+// ======================================================================
+// i0(x) — modified Bessel function of the first kind, order 0.
+//
+// The Maclaurin series below is truncated at k=11 (12 terms). Its largest
+// term sits near k ≈ x/2, so the truncation is only safe while x/2 stays
+// well under 11 — in practice to about x = 13. Past that the omitted tail
+// dominates and the result is a silent, finite underestimate: measured
+// 21.0% relative error at x = 20 and 88.6% at x = 30.
+//
+// Fixed by mirroring the two-region structure already used by
+// ckernel_sfpu_i1.h (i0 is even, so no sign handling is needed):
+//   |x| ≤ 7:   the existing Maclaurin polynomial
+//   |x| > 7:   asymptotic i0(x) = exp(|x|)/sqrt(2π|x|) · P(1/|x|)
+//              (Abramowitz & Stegun 9.7.1), degree-5 minimax in 1/|x|
+//              over [1/88.5, 0.1]
+// Inputs are clamped to ±88.5 as in i1, since exp() saturates near ±88.7.
+//
+// Measured relative error against a high-precision reference, dense sweep:
+//   [0, 88.5]    100%  → 3.43e-05
+// The asymptotic branch itself is good to 4.6e-07; the residual is the
+// Maclaurin polynomial just below the handover, so the threshold sets the
+// overall error. Sweeping it: 13 → 3.8e-03, 10 → 2.2e-04, 7 → 3.4e-05,
+// 6 → 4.7e-05. 7 is the minimum. (The issue suggests "~10-13"; that range
+// is inside one BF16 ULP (≈4e-3) but costs two orders of magnitude of
+// accuracy that the asymptotic path is already paying for.)
+// ======================================================================
+
+// Outlined to keep register pressure within SFPI's LRA budget, matching the
+// shape of calculate_i1_asymptotic_. Returns exp(|x|) · 1/sqrt(2π|x|) · P(1/|x|).
+sfpi_inline sfpi::vFloat calculate_i0_asymptotic_(const sfpi::vFloat abs_x) {
+    // exp(|x|) — |x| ∈ [10, 88.5] precludes overflow/underflow, so the
+    // unsafe variants' skipped guards are dead code here.
+#ifdef INP_FLOAT32
+    const sfpi::vFloat exp_abs = _sfpu_exp_fp32_accurate_unsafe_(abs_x);
+#else
+    const sfpi::vFloat exp_abs = _sfpu_exp_21f_bf16_unsafe_<true>(abs_x);
+#endif
+
+    // 1/sqrt(|x|) via Quake-style seed plus two Newton refinements, reused to
+    // derive 1/|x| as rsqrt_y² instead of issuing a separate reciprocal.
+    const sfpi::vInt rsqrt_i = sfpi::as<sfpi::vInt>(sfpi::as<sfpi::vUInt>(abs_x) >> 1);
+    sfpi::vFloat rsqrt_y = sfpi::as<sfpi::vFloat>(sfpi::vInt(0x5f1110a0) - rsqrt_i);
+    sfpi::vFloat c0 = (-rsqrt_y) * (abs_x * rsqrt_y);
+    rsqrt_y = rsqrt_y * (sfpi::vFloat(2.2825186f) + c0 * (sfpi::vFloat(2.2533049f) + c0));
+    c0 = 1.0f + (-rsqrt_y) * (abs_x * rsqrt_y);
+    rsqrt_y = c0 * sfpi::addexp(rsqrt_y, -1) + rsqrt_y;
+
+    const sfpi::vFloat inv_abs_x = rsqrt_y * rsqrt_y;
+
+    // P(y) on y = 1/|x| ∈ [1/88.5, 0.1]. Leading term is 1/sqrt(2π).
+    const sfpi::vFloat correction = PolynomialEvaluator::eval(
+        inv_abs_x,
+        3.9894227266e-01f,
+        4.9868565798e-02f,
+        2.8280049562e-02f,
+        1.8642880395e-02f,
+        1.9414494932e-01f,
+        -5.4021686316e-01f);
+
+    return exp_abs * rsqrt_y * correction;
+}
+
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_i0() {
+    constexpr float I0_MAX_INPUT = 88.5f;
+    constexpr float I0_THRESHOLD = 7.0f;
+
 #pragma GCC unroll 0
 
     for (int d = 0; d < ITERATIONS; d++) {
         vFloat result = 0.0f;
-        vFloat input = dst_reg[0];
+        vFloat input = sfpi::symmetric_clamp(dst_reg[0], I0_MAX_INPUT);
+        const vFloat abs_x = sfpi::abs(input);
         vFloat x = input * input;
 
+        // Polynomial path, computed unconditionally so its intermediates die
+        // at the store and free LRegs for the asymptotic block.
         result = 1.0f + POLYVAL10(
                             1.50E-22f,
                             7.24E-20f,
@@ -47,6 +117,10 @@ inline void calculate_i0() {
                             0.015625f,
                             0.25f,
                             x);
+
+        // Asymptotic overwrite for the out-of-domain lanes.
+        v_if(abs_x > I0_THRESHOLD) { result = calculate_i0_asymptotic_(abs_x); }
+        v_endif;
 
         dst_reg[0] = result;
         dst_reg++;

--- a/tt_metal/tt-llk/tests/python_tests/helpers/sfpu_domains.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/sfpu_domains.py
@@ -324,9 +324,12 @@ _OP_DOMAIN_REGISTRY: Dict[
     MathOperation.I0: OperandSpecs(
         spec_A=StimuliSpec(distribution=DistributionKind.UNIFORM, low=-30.0, high=30.0)
     ),
-    # i1: modified Bessel I1; poly path valid on |x| <= ~3.75 (asymptotic beyond)
+    # i1: modified Bessel I1. Like i0 above, the kernel hands over to an
+    # asymptotic branch (at |x| > 10), so sample past the handover — at +-3.75
+    # the stimulus stops short of i1's own asymptotic path and never executes it.
+    # That is exactly the gap that let #50465 sit unnoticed in i0.
     MathOperation.I1: OperandSpecs(
-        spec_A=StimuliSpec(distribution=DistributionKind.UNIFORM, low=-3.75, high=3.75)
+        spec_A=StimuliSpec(distribution=DistributionKind.UNIFORM, low=-30.0, high=30.0)
     ),
     # erf / erfc: span both tails and the transition through 0
     MathOperation.Erf: OperandSpecs(

--- a/tt_metal/tt-llk/tests/python_tests/helpers/sfpu_domains.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/sfpu_domains.py
@@ -317,9 +317,12 @@ _OP_DOMAIN_REGISTRY: Dict[
     MathOperation.Selu: OperandSpecs(
         spec_A=StimuliSpec(distribution=DistributionKind.UNIFORM, low=-5.0, high=5.0)
     ),
-    # i0: modified Bessel I0; kernel poly approx is only valid on |x| <= 3.75
+    # i0: modified Bessel I0. The Maclaurin polynomial covers |x| <= 7 and an
+    # asymptotic branch takes over above it, so sample past the handover — the
+    # old +-3.75 bound stopped short of the region where the truncated series
+    # silently underestimates (#50465: broke between 16 and 17).
     MathOperation.I0: OperandSpecs(
-        spec_A=StimuliSpec(distribution=DistributionKind.UNIFORM, low=-3.75, high=3.75)
+        spec_A=StimuliSpec(distribution=DistributionKind.UNIFORM, low=-30.0, high=30.0)
     ),
     # i1: modified Bessel I1; poly path valid on |x| <= ~3.75 (asymptotic beyond)
     MathOperation.I1: OperandSpecs(


### PR DESCRIPTION
Closes #50465.

### The bug

`i0`'s Maclaurin series is truncated at k=11. Its largest term sits near `k ≈ x/2`, so the truncation only holds while `x/2` stays well under 11 — about `x = 13`. Past that the omitted tail dominates and the op returns a **silent, finite underestimate**: 21.0 % relative error at `x = 20`, 88.6 % at `x = 30`.

### The fix

Mirrors the two-region structure `ckernel_sfpu_i1.h` already uses (i0 is even, so no sign handling is needed):

```
|x| <= 7    existing Maclaurin polynomial
|x| >  7    asymptotic exp(|x|)/sqrt(2π|x|) · P(1/|x|)
            (Abramowitz & Stegun 9.7.1), degree-5 minimax in 1/|x|
```

Inputs clamp to ±88.5 as in `i1`, since `exp()` saturates near ±88.7.

Dense sweep against a high-precision reference over `[0, 88.5]`: relative error **100 % → 3.43e-05**. The handover threshold sets the residual, so I swept it rather than guessing:

| threshold | max rel err |
|---|---|
| 13 | 3.8e-03 |
| 10 | 2.2e-04 |
| **7** | **3.4e-05** |
| 6 | 4.7e-05 |

7 is the minimum. The issue suggests "~10–13"; that range is inside one BF16 ULP (≈4e-3), but it gives up two orders of magnitude the asymptotic path is already paying for.

### Why it survived

The stimulus domain in `sfpu_domains.py` sampled `±3.75` and never reached the broken region. Widened to `±30`.

### Verification — on ttsim, no hardware

Run through the in-tree LLK suite against `ttsim` v1.9.6 (the hash pinned in `tt_metal/tt-llk/tests/ttsim-version`):

| sampled range | before | after |
|---|---|---|
| `±3.75` (shipped) | passed | passed |
| `±16` | passed | passed |
| `±17` | **FAILED** | **passed** |
| `±20` | **FAILED** | **passed** |
| `±30` | **FAILED** | **passed** |
| `±88` | — | **passed** |

The break starts between **16 and 17**, which the old bound never reached.

**The control that isolates it:** `i1` — which already has the asymptotic path — passes at `±20` and `±30` both before and after, on the same harness at the same magnitudes. The only difference is the domain split this PR adds.

### Caveat

ttsim is a functional simulator, not bit-exact against silicon for every op. The pass/fail transitions are unambiguous and the `i1` control rules out a harness artefact, but I don't have a TT part — **someone with hardware should confirm before merge**.

Blackhole and Wormhole copies are byte-identical before and after, preserving that invariant.
