### PR TITLE
[ttnn] Fix sparse SDPA BF16 alignment assertion

### DIFF
--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sparse_sdpa_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sparse_sdpa_compute.cpp
@@ -180,7 +180,7 @@ void kernel_main() {
                 constexpr uint32_t scale_blocks = sparse_sdpa::scale_block_count(latent_width);
                 constexpr uint32_t scale_bytes = sparse_sdpa::scaled_kv_scale_bytes(latent_width);
                 static_assert(
-                    sparse_sdpa::scaled_kv_rope_offset_is_aligned(latent_width),
+                    !scaled_kv || sparse_sdpa::scaled_kv_rope_offset_is_aligned(latent_width),
                     "scaled KV scale/RoPE boundary must be addressable in 16-byte units");
                 static_assert(
                     packed_row_bytes % (tt::constants::TILE_WIDTH * sizeof(uint16_t)) == 0,


### PR DESCRIPTION
## Summary

Fix sparse SDPA kernel compilation for non-scaled BF16 KV inputs.

## Problem

PR #50207 added a scaled-KV alignment `static_assert` inside a non-template `if constexpr`. The assertion was still evaluated for the discarded BF16 path, so `v_dim=128` failed TRISC compilation because its irrelevant scaled layout would place the RoPE boundary at byte 132.

## Fix

Gate the compile-time alignment check on `scaled_kv`. Scaled-KV layouts remain validated, while BF16 and ordinary FP8 layouts no longer evaluate the scaled-cache constraint.

## Testing

- `test_msa_composed_pcc`: 4 passed
- scaled FP8 positive coverage: passed
- scaled FP8 unaligned-boundary rejection: passed

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=skrstic/fix-sparse-sdpa-scaled-kv-assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:skrstic/fix-sparse-sdpa-scaled-kv-assert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=skrstic/fix-sparse-sdpa-scaled-kv-assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:skrstic/fix-sparse-sdpa-scaled-kv-assert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=skrstic/fix-sparse-sdpa-scaled-kv-assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:skrstic/fix-sparse-sdpa-scaled-kv-assert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=skrstic/fix-sparse-sdpa-scaled-kv-assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:skrstic/fix-sparse-sdpa-scaled-kv-assert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=skrstic/fix-sparse-sdpa-scaled-kv-assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:skrstic/fix-sparse-sdpa-scaled-kv-assert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=skrstic/fix-sparse-sdpa-scaled-kv-assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:skrstic/fix-sparse-sdpa-scaled-kv-assert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=skrstic/fix-sparse-sdpa-scaled-kv-assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:skrstic/fix-sparse-sdpa-scaled-kv-assert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=skrstic/fix-sparse-sdpa-scaled-kv-assert)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:skrstic/fix-sparse-sdpa-scaled-kv-assert)