### PR TITLE
[bug fix]: split user txn id pool from set of txn ids that dfbs use

### DIFF
--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_configs.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_configs.cpp
@@ -1559,6 +1559,40 @@ CONFIG_TC_TEST_2_0(DMTest1xDFB2Sx4BConfig, DM, DM, 2, 4, STRIDED, ALL, 4, 2)
 // Group 2 M2: B2 (txn-id allocator) + B4 (cached threshold) + B10 (divisibility)
 // =====================================================================================
 
+// Host-only: DFB pool is [DFB_TXN_ID_BASE, HW_TXN_ID_MAX], allocated top-down in ascending blocks.
+TEST(TxnIdAllocatorTest, AllocatesTopDownFromDfbPool) {
+    using tt::tt_metal::experimental::dfb::detail::TxnIdAllocator;
+    TxnIdAllocator alloc;
+
+    auto first = alloc.allocate(2);
+    ASSERT_EQ(first.size(), 2u);
+    EXPECT_EQ(first[0], static_cast<uint8_t>(HW_TXN_ID_MAX - 1));
+    EXPECT_EQ(first[1], HW_TXN_ID_MAX);
+
+    auto second = alloc.allocate(3);
+    ASSERT_EQ(second.size(), 3u);
+    EXPECT_EQ(second[0], static_cast<uint8_t>(HW_TXN_ID_MAX - 4));
+    EXPECT_EQ(second[1], static_cast<uint8_t>(HW_TXN_ID_MAX - 3));
+    EXPECT_EQ(second[2], static_cast<uint8_t>(HW_TXN_ID_MAX - 2));
+
+    // Drain the rest of the pool, then the next allocate must fail.
+    const uint8_t used = 5;
+    const uint8_t leftover = static_cast<uint8_t>(NUM_DFB_POOL_TXN_IDS - used);
+    auto rest = alloc.allocate(leftover);
+    ASSERT_EQ(rest.size(), leftover);
+    EXPECT_EQ(rest.front(), DFB_TXN_ID_BASE);
+    EXPECT_EQ(rest.back(), static_cast<uint8_t>(DFB_TXN_ID_BASE + leftover - 1));
+
+    EXPECT_THAT(
+        [&]() { alloc.allocate(1); },
+        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("TxnIdAllocator exhausted")));
+
+    alloc.reset();
+    auto after_reset = alloc.allocate(1);
+    ASSERT_EQ(after_reset.size(), 1u);
+    EXPECT_EQ(after_reset[0], HW_TXN_ID_MAX);
+}
+
 // B2: For num_entries in {16, 15, 7}, producer_txn_descriptor.num_txn_ids should
 // land on {2, 3, 1} (divisibility-based selection).
 TEST_F(MeshDeviceFixture, B2_TxnIdAllocator_Boundaries_Config_2_0) {
@@ -1594,14 +1628,24 @@ TEST_F(MeshDeviceFixture, B2_TxnIdAllocator_Boundaries_Config_2_0) {
         auto dfbs = program.impl().dataflow_buffers_on_core(CoreCoord(0, 0));
         ASSERT_EQ(dfbs.size(), 1u);
         EXPECT_EQ(dfbs[0]->producer_txn_descriptor.num_txn_ids, c.expected_num_txn_ids);
-        // Txn id 0 is reserved for untagged NoC traffic; DFB assignment starts at 1.
+        // DFB ids come from the runtime pool [DFB_TXN_ID_BASE, HW_TXN_ID_MAX], never 0 or the user pool.
+        auto expect_in_dfb_pool = [](uint8_t txn_id, const char* side, int index) {
+            EXPECT_NE(txn_id, 0) << side << " txn_ids[" << index << "] must not be 0 (NOC_V2_TRID_STATIC)";
+            EXPECT_GE(txn_id, DFB_TXN_ID_BASE)
+                << side << " txn_ids[" << index << "]=" << static_cast<int>(txn_id) << " collides with user pool [0, "
+                << static_cast<int>(USER_TXN_ID_MAX) << "]";
+            EXPECT_LE(txn_id, HW_TXN_ID_MAX)
+                << side << " txn_ids[" << index << "]=" << static_cast<int>(txn_id) << " exceeds HW max";
+        };
         for (uint8_t i = 0; i < dfbs[0]->producer_txn_descriptor.num_txn_ids; ++i) {
-            EXPECT_NE(dfbs[0]->producer_txn_descriptor.txn_ids[i], 0)
-                << "producer txn_ids[" << static_cast<int>(i) << "] must not be 0";
+            expect_in_dfb_pool(dfbs[0]->producer_txn_descriptor.txn_ids[i], "producer", i);
         }
         for (uint8_t i = 0; i < dfbs[0]->consumer_txn_descriptor.num_txn_ids; ++i) {
-            EXPECT_NE(dfbs[0]->consumer_txn_descriptor.txn_ids[i], 0)
-                << "consumer txn_ids[" << static_cast<int>(i) << "] must not be 0";
+            expect_in_dfb_pool(dfbs[0]->consumer_txn_descriptor.txn_ids[i], "consumer", i);
+        }
+        // First DFB on a program draws from the top of the pool.
+        if (c.expected_num_txn_ids > 0) {
+            EXPECT_EQ(dfbs[0]->producer_txn_descriptor.txn_ids[c.expected_num_txn_ids - 1], HW_TXN_ID_MAX);
         }
     }
 }

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_sanitize.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_sanitize.cpp
@@ -64,6 +64,7 @@ enum watcher_features_t {
     SanitizeNOCWriteWithStateBadCoord,
     SanitizeNOCInlineWriteFromState,
     SanitizeNOCInlineWriteWithState,
+    SanitizeNOCInvalidTxnId,
 };
 
 tt::tt_metal::HalMemType get_buffer_mem_type_for_test(watcher_features_t feature) {
@@ -132,6 +133,10 @@ void RunTestOnCore(
     if ((feature == SanitizeNOCMailboxWriteUncachedAlias || feature == SanitizeL1OverflowStraddle) &&
         (!is_quasar || is_eth_core)) {
         GTEST_SKIP() << "Uncached-alias tests only apply to Quasar DM cores";
+    }
+    // Invalid txn-id sanitization is exercised via the Metal 2.0 Noc API on TENSIX only.
+    if (feature == SanitizeNOCInvalidTxnId && is_eth_core) {
+        GTEST_SKIP() << "Invalid txn-id sanitize test is TENSIX-only";
     }
 
     // TENSIX cores use the Metal 2.0 variant; ETH cores stay on the legacy kernel/API.
@@ -289,7 +294,8 @@ void RunTestOnCore(
                       "mcast_dst_end_y",
                       "use_write_with_state",
                       "use_inline_dw_write_from_state",
-                      "use_inline_dw_write_with_state"}},
+                      "use_inline_dw_write_with_state",
+                      "invalid_txn_id"}},
             .hw_config = dm_cfg,
         };
         experimental::WorkUnitSpec wu{
@@ -328,6 +334,10 @@ void RunTestOnCore(
     bool use_write_with_state = false;
     bool use_inline_dw_write_from_state = false;
     bool use_inline_dw_write_with_state = false;
+    // WH/BH: NOC_MAX_TRANSACTION_ID == 0xF. Quasar user pool: USER_TXN_ID_MAX == 15. Same bound.
+    constexpr uint32_t k_max_user_txn_id = 15;
+    constexpr uint32_t k_invalid_txn_id = k_max_user_txn_id + 1;
+    uint32_t invalid_txn_id = 0;
     switch (feature) {
         case SanitizeNOCAddress:
             output_buf_noc_xy.x = 26;
@@ -423,6 +433,7 @@ void RunTestOnCore(
             output_buf_noc_xy.y = 18;
             use_inline_dw_write_with_state = true;
             break;
+        case SanitizeNOCInvalidTxnId: invalid_txn_id = k_invalid_txn_id; break;
         default:
             log_warning(LogTest, "Unrecognized feature to test ({}), skipping...", feature);
             GTEST_SKIP();
@@ -448,7 +459,8 @@ void RunTestOnCore(
         mcast_dst_end_y,
         use_write_with_state,
         use_inline_dw_write_from_state,
-        use_inline_dw_write_with_state};
+        use_inline_dw_write_with_state,
+        invalid_txn_id};
 
     if (is_eth_core) {
         // ETH cores still go through the legacy API.
@@ -478,7 +490,8 @@ void RunTestOnCore(
                  {"mcast_dst_end_y", mcast_dst_end_y},
                  {"use_write_with_state", use_write_with_state},
                  {"use_inline_dw_write_from_state", use_inline_dw_write_from_state},
-                 {"use_inline_dw_write_with_state", use_inline_dw_write_with_state}}),
+                 {"use_inline_dw_write_with_state", use_inline_dw_write_with_state},
+                 {"invalid_txn_id", invalid_txn_id}}),
         }};
         experimental::SetProgramRunArgs(program, params);
     }
@@ -726,6 +739,20 @@ void RunTestOnCore(
                 mcast_end_coord.str(),
                 output_buffer_addr);
         } break;
+        case SanitizeNOCInvalidTxnId: {
+            expected = fmt::format(
+                "Device {} {} core(x={:2},y={:2}) virtual(x={:2},y={:2}): {} used invalid NoC transaction id {} "
+                "(exceeds max {}).",
+                device->id(),
+                core_name,
+                core.x,
+                core.y,
+                virtual_core.x,
+                virtual_core.y,
+                risc_name,
+                k_invalid_txn_id,
+                k_max_user_txn_id);
+        } break;
         default:
             log_warning(LogTest, "Unrecognized feature to test ({}), skipping...", feature);
             GTEST_SKIP();
@@ -901,6 +928,15 @@ TEST_F(MeshWatcherFixture, TensixTestWatcherSanitizeNOCInlineWriteDram) {
         [](MeshWatcherFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
             CoreCoord core{0, 0};
             RunTestOnCore(fixture, mesh_device, core, false, SanitizeNOCInlineWriteDram);
+        },
+        this->devices_[0]);
+}
+
+TEST_F(MeshWatcherFixture, TensixTestWatcherSanitizeNOCInvalidTxnId) {
+    this->RunTestOnDevice(
+        [](MeshWatcherFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
+            CoreCoord core{0, 0};
+            RunTestOnCore(fixture, mesh_device, core, false, SanitizeNOCInvalidTxnId);
         },
         this->devices_[0]);
 }

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dram_copy_to_noc_coord_2_0.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dram_copy_to_noc_coord_2_0.cpp
@@ -8,6 +8,7 @@
 
 #include <cstdint>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
 #include "api/core_local_mem.h"
 #include "api/dataflow/endpoints.h"
 #include "internal/firmware_common.h"
@@ -71,6 +72,7 @@ void kernel_main() {
     bool use_write_with_state = static_cast<bool>(get_arg(args::use_write_with_state));
     bool use_inline_dw_write_from_state = static_cast<bool>(get_arg(args::use_inline_dw_write_from_state));
     bool use_inline_dw_write_with_state = static_cast<bool>(get_arg(args::use_inline_dw_write_with_state));
+    std::uint32_t invalid_txn_id = get_arg(args::invalid_txn_id);
 
     // We will assert later. This kernel will hang.
     // Need to signal completion to dispatcher before hanging so that
@@ -85,6 +87,13 @@ void kernel_main() {
     uint64_t dispatch_addr = calculate_dispatch_addr(go_message_in);
     notify_dispatch_core_done(dispatch_addr, noc_index);
 #endif
+
+    if (invalid_txn_id) {
+        // Trips DEBUG_SANITIZE_NOC_TXN_ID (user trid above the arch max / Quasar user pool).
+        Noc noc;
+        noc.is_read_trid_flushed(invalid_txn_id);
+        return;
+    }
 
     if (l1_overflow_addr) {
         CoreLocalMem<std::uint32_t> l1_overflow_buffer(l1_overflow_addr);

--- a/tt_metal/hw/inc/api/dataflow/noc.h
+++ b/tt_metal/hw/inc/api/dataflow/noc.h
@@ -6,7 +6,6 @@
 
 #include "api/dataflow/dataflow_api.h"
 #include "internal/debug/noc_zero_guard.h"
-
 template <typename DSpecT>
 class TensorAccessor;
 
@@ -65,6 +64,8 @@ constexpr bool has_flag(NocOptions opts, NocOptions flag) noexcept {
  * Fields are only inspected when the corresponding NocOptions flag is set:
  *   - vc  : used when NocOptions::CUSTOM_VC is set
  *   - trid: used when NocOptions::TXN_ID is set
+ *           WH/BH: [0, NOC_MAX_TRANSACTION_ID]
+ *           Quasar: [0, USER_TXN_ID_MAX] (Runtime owns [DFB_TXN_ID_BASE, HW_TXN_ID_MAX])
  */
 struct NocOptVals {
     uint32_t vc   = NOC_UNICAST_WRITE_VC;
@@ -159,6 +160,7 @@ public:
         const dst_args_t<Dst>& dst_args,
         const NocOptVals& noc_opts = {}) const {
         if constexpr (has_flag(opts, NocOptions::TXN_ID)) {
+            DEBUG_SANITIZE_NOC_TXN_ID(noc_id_, noc_opts.trid);
             noc_async_read_set_trid(noc_opts.trid, noc_id_);
             while (noc_available_transactions(noc_id_, noc_opts.trid) < ((NOC_MAX_TRANSACTION_ID_COUNT + 1) / 2)) {
                 // Busy-wait until sufficient transactions are available for the configured transaction ID.
@@ -217,6 +219,7 @@ public:
         ncrisc_noc_read_set_state<noc_mode, max_page_size <= NOC_MAX_BURST_SIZE, has_flag(opts, NocOptions::CUSTOM_VC)>(
             noc_id_, read_cmd_buf, src_noc_addr, size_bytes, noc_opts.vc);
         if constexpr (has_flag(opts, NocOptions::TXN_ID)) {
+            DEBUG_SANITIZE_NOC_TXN_ID(noc_id_, noc_opts.trid);
             noc_async_read_set_trid(noc_opts.trid, noc_id_);
         }
         WAYPOINT("NASD");
@@ -262,6 +265,7 @@ public:
                 max_page_size <= NOC_MAX_BURST_SIZE,
                 "NocOptions::TXN_ID for async_read_with_state requires one-packet mode "
                 "(max_page_size <= NOC_MAX_BURST_SIZE)");
+            DEBUG_SANITIZE_NOC_TXN_ID(noc_id_, noc_opts.trid);
             noc_async_read_one_packet_with_state_with_trid(
                 0,
                 (uint32_t)get_src_ptr<AddressType::NOC>(src, src_args),
@@ -317,6 +321,7 @@ public:
         if constexpr (has_flag(opts, NocOptions::TXN_ID)) {
             // TODO (#31535): Need to add check in ncrisc_noc_fast_write_any_len to ensure outstanding transaction
             // register does not overflow
+            DEBUG_SANITIZE_NOC_TXN_ID(noc_id_, noc_opts.trid);
             WAYPOINT("NAWW");
             auto src_addr = get_src_ptr<AddressType::LOCAL_L1>(src, src_args);
             auto dst_noc_addr = get_dst_ptr<AddressType::NOC>(dst, dst_args);
@@ -587,6 +592,7 @@ public:
      * @param trid Transaction ID to check (must match what was passed to async_read<NocOptions::TXN_ID>)
      */
     bool is_read_trid_flushed(uint32_t trid) const {
+        DEBUG_SANITIZE_NOC_TXN_ID(noc_id_, trid);
         return ncrisc_noc_read_with_transaction_id_flushed(noc_id_, trid);
     }
 
@@ -604,6 +610,7 @@ public:
     template <NocOptions opts = NocOptions::DEFAULT>
     void async_read_barrier(const NocOptVals& noc_opts = {}) const {
         if constexpr (has_flag(opts, NocOptions::TXN_ID)) {
+            DEBUG_SANITIZE_NOC_TXN_ID(noc_id_, noc_opts.trid);
             noc_async_read_barrier_with_trid(noc_opts.trid, noc_id_);
         } else {
             noc_async_read_barrier(noc_id_);
@@ -624,6 +631,7 @@ public:
     template <NocOptions opts = NocOptions::DEFAULT>
     void async_write_barrier(const NocOptVals& noc_opts = {}) const {
         if constexpr (has_flag(opts, NocOptions::TXN_ID)) {
+            DEBUG_SANITIZE_NOC_TXN_ID(noc_id_, noc_opts.trid);
             noc_async_write_barrier_with_trid(noc_opts.trid, noc_id_);
         } else {
             noc_async_write_barrier(noc_id_);
@@ -651,6 +659,7 @@ public:
         } else {  // non-posted
             if constexpr (has_flag(opts, NocOptions::TXN_ID)) {
                 static_assert(noc_mode != DM_DYNAMIC_NOC);  // TODO make an issue for this
+                DEBUG_SANITIZE_NOC_TXN_ID(noc_id_, noc_opts.trid);
                 noc_async_write_flushed_with_trid(noc_opts.trid, noc_id_);
             } else {
                 noc_async_writes_flushed(noc_id_);

--- a/tt_metal/hw/inc/hostdev/dev_msgs.h
+++ b/tt_metal/hw/inc/hostdev/dev_msgs.h
@@ -268,6 +268,7 @@ enum debug_sanitize_noc_return_code_enum {
     DebugSanitizeEthSrcL1AddrOverflow = 15,
     DebugSanitizeEthDestL1AddrOverflow = 16,
     DebugSanitizeCBOutOfBounds = 17,
+    DebugSanitizeNocInvalidTxnId = 18,
 };
 
 struct debug_assert_msg_t {

--- a/tt_metal/hw/inc/internal/debug/sanitize.h
+++ b/tt_metal/hw/inc/internal/debug/sanitize.h
@@ -34,6 +34,10 @@
 #include "internal/circular_buffer_interface.h"
 #endif
 #include "risc_common.h"
+#if defined(ARCH_QUASAR)
+// USER_TXN_ID_MAX: Quasar user vs DFB txn-id pool split.
+#include "internal/tt-2xx/dataflow_buffer/dataflow_buffer_config.h"
+#endif
 
 // A couple defines for specifying read/write and multi/unicast
 #define DEBUG_SANITIZE_NOC_READ true
@@ -836,6 +840,29 @@ void debug_sanitize_eth(uint32_t src_addr, uint32_t dst_addr, uint32_t len) {
 #define DEBUG_SANITIZE_L1_ADDR(addr, l) debug_sanitize_l1_access(addr, l);
 #define DEBUG_SANITIZE_ETH(src_addr, dst_addr, l) debug_sanitize_eth(src_addr, dst_addr, l)
 
+// Validate a user-stamped NoC transaction id.
+// WH/BH: [0, NOC_MAX_TRANSACTION_ID]. Quasar: [0, USER_TXN_ID_MAX] (DFB owns the upper pool).
+// On failure, l1_addr holds the bad trid and len holds the max allowed.
+inline void debug_sanitize_noc_txn_id(uint8_t noc_id, uint32_t trid) {
+#if defined(ARCH_QUASAR)
+    constexpr uint32_t max_trid = USER_TXN_ID_MAX;
+#else
+    constexpr uint32_t max_trid = NOC_MAX_TRANSACTION_ID;
+#endif
+    if (trid > max_trid) {
+        debug_sanitize_post_addr_and_hang(
+            noc_id,
+            0,
+            trid,
+            max_trid,
+            DEBUG_SANITIZE_NOC_UNICAST,
+            DEBUG_SANITIZE_NOC_WRITE,
+            DEBUG_SANITIZE_NOC_TARGET,
+            DebugSanitizeNocInvalidTxnId);
+    }
+}
+#define DEBUG_SANITIZE_NOC_TXN_ID(noc_id, trid) debug_sanitize_noc_txn_id(noc_id, trid)
+
 // Delay for debugging purposes
 inline void debug_insert_delay(uint8_t transaction_type) {
 #if defined(WATCHER_DEBUG_DELAY)
@@ -886,5 +913,6 @@ inline void debug_insert_delay(uint8_t transaction_type) {
 
 #define DEBUG_SANITIZE_L1_ADDR(addr, l)
 #define DEBUG_SANITIZE_ETH(src_addr, dst_addr, l)
+#define DEBUG_SANITIZE_NOC_TXN_ID(noc_id, trid)
 
 #endif  // WATCHER_ENABLED

--- a/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer.inl
+++ b/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer.inl
@@ -431,7 +431,9 @@ inline void DataflowBuffer::write_barrier_impl(const Noc &noc) const {
         return;
     } else {
         for (uint8_t i = 0; i < local_dfb_interface_.num_txn_ids; i++) {
-            noc.async_write_barrier<NocOptions::TXN_ID>({.trid = local_dfb_interface_.txn_ids[i]});
+            // Uses internal API rather than user facing noc.async_write_barrier() since it ASSERTs that the txn_id comes
+            // from the user tnx ID pool and the DFB txn ids are internal only.
+            noc_async_write_barrier_with_trid(local_dfb_interface_.txn_ids[i], noc.get_noc_id());
         }
     }
 }

--- a/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_config.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_config.h
@@ -6,6 +6,17 @@
 
 #include <cstdint>
 
+// Transaction-id space is [0, HW_TXN_ID_MAX]. Id 0 is NOC_V2_TRID_STATIC (untagged).
+// Quasar-only pool split:
+//   user / kernel : [0, USER_TXN_ID_MAX]
+//   DFB / runtime : [DFB_TXN_ID_BASE, HW_TXN_ID_MAX]  (allocated top-down)
+constexpr uint8_t HW_TXN_ID_MAX = 31;
+constexpr uint8_t USER_TXN_ID_MAX = 15;
+constexpr uint8_t DFB_TXN_ID_BASE = USER_TXN_ID_MAX + 1;                       // 16
+constexpr uint8_t NUM_DFB_POOL_TXN_IDS = HW_TXN_ID_MAX - DFB_TXN_ID_BASE + 1;  // 16
+static_assert(USER_TXN_ID_MAX >= 1);
+static_assert(DFB_TXN_ID_BASE > USER_TXN_ID_MAX);
+
 namespace dfb {
 
 enum AccessPattern : uint8_t {
@@ -25,7 +36,9 @@ constexpr uint8_t NUM_TENSIX_TILE_COUNTERS_FOR_DM = 16;
 // Note: The Remapper can be programmed to expose these TCs to DMs.
 constexpr uint8_t TC_TENSIX_POOL_START = NUM_TENSIX_TILE_COUNTERS_FOR_DM;  // = 16
 constexpr uint8_t NUM_REMAPPER_PAIRINGS = 64;
+// Max txn ids assigned to one DFB producer or consumer side
 constexpr uint8_t NUM_TXN_IDS = 4;
+static_assert(NUM_DFB_POOL_TXN_IDS >= NUM_TXN_IDS);
 constexpr uint8_t MAX_NUM_TILE_COUNTERS_TO_RR = 6;
 // Max tile counter ids that can be collected for one side (producer or consumer) of a DFB during
 // init, summed across that side's riscs. Bounded by TxnDFBDescriptor::tile_counters, the ISR

--- a/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
+++ b/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
@@ -143,17 +143,27 @@ uint8_t RemapperIndexAllocator::allocate(const CoreCoord& core_coord) {
 void RemapperIndexAllocator::reset() { next_index_.clear(); }
 
 std::vector<uint8_t> TxnIdAllocator::allocate(uint8_t count) {
-    // IDs are drawn from [1, 31]; id 0 is implicitly reserved (NOC_V2_TRID_STATIC).
+    // DFB pool is [DFB_TXN_ID_BASE, HW_TXN_ID_MAX], allocated top-down so user
+    // kernels can keep constexpr trids in [0, USER_TXN_ID_MAX].
+    const uint8_t remaining =
+        (next_id_ >= DFB_TXN_ID_BASE) ? static_cast<uint8_t>(next_id_ - DFB_TXN_ID_BASE + 1) : static_cast<uint8_t>(0);
     TT_FATAL(
-        next_id_ + count <= 32,
-        "TxnIdAllocator exhausted: requested {} IDs at next_id_={}, but only [1, 31] are available",
+        count <= remaining,
+        "TxnIdAllocator exhausted: requested {} IDs but only {} remain in DFB pool [{}, {}] "
+        "(user kernels own [0, {}]; id 0 is NOC_V2_TRID_STATIC)",
         count,
-        next_id_);
+        remaining,
+        DFB_TXN_ID_BASE,
+        HW_TXN_ID_MAX,
+        USER_TXN_ID_MAX);
+    // Hand out a contiguous ascending block from the top of the remaining pool.
+    const uint8_t first = static_cast<uint8_t>(next_id_ - count + 1);
     std::vector<uint8_t> ids;
     ids.reserve(count);
     for (uint8_t i = 0; i < count; i++) {
-        ids.push_back(next_id_++);
+        ids.push_back(static_cast<uint8_t>(first + i));
     }
+    next_id_ = static_cast<uint8_t>(first - 1);
     return ids;
 }
 

--- a/tt_metal/impl/dataflow_buffer/dataflow_buffer_impl.hpp
+++ b/tt_metal/impl/dataflow_buffer/dataflow_buffer_impl.hpp
@@ -146,16 +146,17 @@ private:
     std::unordered_map<CoreCoord, uint8_t> next_index_;
 };
 
-// Allocates hardware transaction IDs. Valid range: [1, 31].
-// Txn id 0 is reserved for NoC transactions that do not stamp an explicit txn id.
-// DFBs must not assign it.
+// Allocates DFB implicit-sync transaction IDs from the runtime pool
+// [DFB_TXN_ID_BASE, HW_TXN_ID_MAX], top-down.
+// Txn id 0 is reserved (NOC_V2_TRID_STATIC). User kernels may use [0, USER_TXN_ID_MAX].
 class TxnIdAllocator {
 public:
     std::vector<uint8_t> allocate(uint8_t count);
-    void reset() { next_id_ = 1; }
+    void reset() { next_id_ = HW_TXN_ID_MAX; }
 
 private:
-    uint8_t next_id_ = 1;
+    // Next highest ID available to allocate (descending within the DFB pool).
+    uint8_t next_id_ = HW_TXN_ID_MAX;
 };
 
 // Allocates Remapper clientTypes for ALL consumer mode.

--- a/tt_metal/impl/debug/watcher_device_reader.cpp
+++ b/tt_metal/impl/debug/watcher_device_reader.cpp
@@ -788,6 +788,13 @@ void WatcherDeviceReader::Core::DumpNocSanitizeStatus(int noc) const {
             error_msg = get_noc_target_str(reader_.env.get_hal(), reader_.device_id, programmable_core_type_, noc, san);
             error_msg += " (NOC transaction overflows a circular buffer).";
             break;
+        case dev_msgs::DebugSanitizeNocInvalidTxnId:
+            error_msg = fmt::format(
+                "{} used invalid NoC transaction id {} (exceeds max {}).",
+                get_riscv_name(reader_.env.get_hal(), programmable_core_type_, san.which_risc()),
+                san.l1_addr(),
+                san.len());
+            break;
         default:
             error_msg = fmt::format(
                 "Watcher unexpected data corruption, noc debug state on core {}, unknown failure code: {}",


### PR DESCRIPTION
### PR Category
Bug fix 

### Summary
User kernel txn ids and txn ids that DFBs use for implicit sync could clash. To avoid this, split the txn id space in half and allocate DFB txn ids top down. 

@kstevensTT Im not sure if there was another plan for this

ran `test_dataflow_buffer_base.cpp` tests with implicit sync true for testing 

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=abhullar/txn-id-pools)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:abhullar/txn-id-pools)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=abhullar/txn-id-pools)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:abhullar/txn-id-pools)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=abhullar/txn-id-pools)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:abhullar/txn-id-pools)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=abhullar/txn-id-pools)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:abhullar/txn-id-pools)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=abhullar/txn-id-pools)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:abhullar/txn-id-pools)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=abhullar/txn-id-pools)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:abhullar/txn-id-pools)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=abhullar/txn-id-pools)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:abhullar/txn-id-pools)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=abhullar/txn-id-pools)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:abhullar/txn-id-pools)