### PR TITLE
[Perf] Softmax: Fixed block_size (4/8) in attention-optimized interleaved softmax to maximize dest usage 

### DIFF
--- a/tests/ttnn/unit_tests/operations/fused/test_softmax.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_softmax.py
@@ -718,6 +718,137 @@ def test_softmax_large_kernel_block_size(device, Wt):
     )
 
 
+def _run_softmax_non_divisible_width(device, Wt, fp32_acc_en, numeric_stable):
+    torch.manual_seed(0)
+
+    W = Wt * 32
+    shape = (1, 1, 64, W)
+    torch_input = torch.randn(shape, dtype=torch.bfloat16)
+    torch_output = F.softmax(torch_input, dim=-1, dtype=torch.bfloat16)
+
+    compute_config = ttnn.WormholeComputeKernelConfig(
+        math_fidelity=ttnn.MathFidelity.HiFi4,
+        fp32_dest_acc_en=fp32_acc_en,
+    )
+
+    ttnn_input = ttnn.from_torch(torch_input, layout=ttnn.TILE_LAYOUT, device=device)
+    ttnn_output = ttnn.softmax(ttnn_input, dim=-1, compute_kernel_config=compute_config, numeric_stable=numeric_stable)
+    ttnn_output = ttnn.to_torch(ttnn_output)
+
+    assert_numeric_metrics(
+        torch_output,
+        ttnn_output,
+        pcc_threshold=0.999,
+        rtol=0.09,
+        atol=0.01,
+        frobenius_threshold=0.05,
+    )
+
+
+@pytest.mark.parametrize(
+    "Wt",
+    [
+        5,
+        7,
+        11,
+        13,
+        47,
+    ],
+)
+@pytest.mark.parametrize("fp32_acc_en", [True, False])
+@pytest.mark.parametrize("numeric_stable", [True, False])
+def test_softmax_non_divisible_width(device, Wt, fp32_acc_en, numeric_stable):
+    _run_softmax_non_divisible_width(device, Wt, fp32_acc_en, numeric_stable)
+
+
+@pytest.mark.parametrize(
+    "Wt",
+    [
+        # Wide enough for the large-kernel path; Wt % 80 (capped CB length) is not a
+        # multiple of block_size either.
+        637,
+        703,
+        1001,
+    ],
+)
+def test_softmax_large_non_divisible_width(device, Wt):
+    _run_softmax_non_divisible_width(device, Wt, fp32_acc_en=True, numeric_stable=True)
+
+
+@pytest.mark.parametrize(
+    "batch, causal, Wt",
+    [
+        # broadcast mask: batch * Ht = 128 tile rows, so every core gets more than one row
+        (64, False, 5),
+        (64, False, 7),
+        (64, False, 13),
+        (64, False, 47),
+        # causal mask: re-read for every row rather than once per batch, square Wt*32 mask
+        (16, True, 5),
+        (16, True, 7),
+        (16, True, 13),
+        # wide enough to select the streaming large kernel, which pads c_4 per pass
+        (1, False, 637),
+        (1, False, 1001),
+    ],
+)
+@pytest.mark.parametrize("fp32_acc_en", [True, False])
+@pytest.mark.parametrize("numeric_stable", [True, False])
+def test_scale_mask_softmax_non_divisible_width(device, batch, causal, Wt, fp32_acc_en, numeric_stable):
+    """Issue #39050: the fused scale/mask path streams the attention mask (c_4) in blocks of the
+    fixed block_size. Its CB is sized round_up(Wt, block_size), so a row of Wt tiles leaves the fifo
+    mid-cycle and a missing realignment shows up as a wrapped mask read on a later row."""
+    torch.manual_seed(0)
+
+    W = Wt * 32
+    scale = 0.75
+    mask_shape = (batch, 1, W, W) if causal else (batch, 1, 32, W)
+
+    torch_input = torch.randn((batch, 1, W if causal else 64, W), dtype=torch.bfloat16)
+    attention_mask = torch.zeros(mask_shape, dtype=torch.bfloat16)
+    attention_mask[torch.rand_like(attention_mask, dtype=torch.float32) < 0.2] = float("-inf")
+
+    # a broadcast mask only contributes its first row to every input row
+    golden_mask = attention_mask if causal else attention_mask[:, :, :1, :]
+    torch_output = F.softmax(torch_input * scale + golden_mask, dim=-1, dtype=torch.bfloat16)
+
+    compute_config = ttnn.WormholeComputeKernelConfig(
+        math_fidelity=ttnn.MathFidelity.HiFi4,
+        fp32_dest_acc_en=fp32_acc_en,
+    )
+
+    ttnn_input = ttnn.from_torch(torch_input, layout=ttnn.TILE_LAYOUT, device=device, preserve_nan_values=True)
+    ttnn_mask = ttnn.from_torch(attention_mask, layout=ttnn.TILE_LAYOUT, device=device, preserve_nan_values=True)
+    if causal:
+        # scale_mask_softmax rejects a square mask; the causal path is reachable in place only
+        ttnn_output = ttnn.scale_mask_softmax_in_place(
+            ttnn_input,
+            scale,
+            ttnn_mask,
+            is_causal_mask=True,
+            compute_kernel_config=compute_config,
+            numeric_stable=numeric_stable,
+        )
+    else:
+        ttnn_output = ttnn.scale_mask_softmax(
+            ttnn_input,
+            scale,
+            ttnn_mask,
+            compute_kernel_config=compute_config,
+            numeric_stable=numeric_stable,
+        )
+    ttnn_output = ttnn.to_torch(ttnn_output)
+
+    assert_numeric_metrics(
+        torch_output,
+        ttnn_output,
+        pcc_threshold=0.999,
+        rtol=0.09,
+        atol=0.01,
+        frobenius_threshold=0.05,
+    )
+
+
 def test_softmax_4096x4096_fp32(device):
     torch.manual_seed(0)
     torch_input_tensor = torch.rand((1, 1, 4096, 4096), dtype=torch.float32)

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/attention/compute/softmax.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/attention/compute/softmax.cpp
@@ -101,11 +101,15 @@ void kernel_main() {
     constexpr std::uint32_t in0_t = get_arg(args::in0_t);          // in0 DFB tile capacity
     const std::uint32_t out0_t = ndst * 2;                         // matches factory out0_t = block_size * 2
     const std::uint32_t exps_t = ((Wt + ndst - 1) / ndst) * ndst;  // dfb_exps/dfb_x capacity, rounded to ndst
+    // Every CB capacity is a multiple of ndst, so when ndst divides Wt the blocks tile each fifo
+    // exactly: a row already ends on the base and no pad is needed. Zero guards keep the modulo safe.
+    const bool pad_to_fifo_base = Wt > 0 && ndst > 0 && (Wt % ndst) != 0;
     // Tiles needed after Wt to finish each CB's cycle, named for the capacity they align.
-    const std::uint32_t in0_pad = (in0_t > 0 && Wt > 0) ? ((in0_t - (Wt % in0_t)) % in0_t) : 0;
-    const std::uint32_t out0_pad = (out0_t > 0 && Wt > 0) ? ((out0_t - (Wt % out0_t)) % out0_t) : 0;
-    const std::uint32_t exps_pad = (exps_t > Wt) ? (exps_t - Wt) : 0;
+    const std::uint32_t in0_pad = pad_to_fifo_base ? ((in0_t - (Wt % in0_t)) % in0_t) : 0;
+    const std::uint32_t out0_pad = pad_to_fifo_base ? ((out0_t - (Wt % out0_t)) % out0_t) : 0;
+    const std::uint32_t exps_pad = pad_to_fifo_base ? (exps_t - Wt) : 0;
     const std::uint32_t attn_pad = exps_pad;  // in4_t is also round_up(Wt, ndst); reader pushes the pad
+    const std::uint32_t scale_mask_pad = pad_to_fifo_base ? (exps_pad + ndst) : 0;  // im3_t = exps_t + ndst
 
     constexpr std::uint32_t onetile = 1;
     // reserve one tile for zeros on dfb_in2
@@ -380,7 +384,7 @@ void kernel_main() {
         drain_dfb_pad(dfb_in0, in0_pad);
         cycle_dfb_pad(dfb_exps, exps_pad);
 #if FUSED_SCALE_MASK
-        cycle_dfb_pad(dfb_scale_mask, exps_pad + ndst);  // im3_t = exps_t + ndst
+        cycle_dfb_pad(dfb_scale_mask, scale_mask_pad);
 #ifdef NUMERIC_STABLE
         // Without NUMERIC_STABLE, dfb_x aliases dfb_exps; cycling it again would drift it per row.
         cycle_dfb_pad(dfb_x, exps_pad);

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/attention/compute/softmax.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/attention/compute/softmax.cpp
@@ -42,25 +42,51 @@ void calc_numeric_stable(std::uint32_t Wt, std::uint32_t ndst) {
     dfb_max_obj.wait_front(1);
     sub_bcast_cols_init(dfb_in, dfb_max);
     for (std::uint32_t wt = 0; wt < Wt; wt += ndst) {
+        const std::uint32_t rem = (wt + ndst > Wt) ? (Wt - wt) : ndst;  // clamped final block
         tile_regs_acquire();
-        for (std::uint32_t wt8 = 0; wt8 < ndst; wt8++) {
+        for (std::uint32_t wt8 = 0; wt8 < rem; wt8++) {
             sub_tiles_bcast_cols(dfb_in, dfb_max, wt + wt8, 0, wt8);
         }
-        dfb_out_obj.reserve_back(ndst);
-        for (std::uint32_t wt8 = 0; wt8 < ndst; wt8++) {
+        dfb_out_obj.reserve_back(rem);
+        for (std::uint32_t wt8 = 0; wt8 < rem; wt8++) {
             exp_tile<EXP_APPROX>(wt8);  // exp on DST[0]
         }
         tile_regs_commit();
         tile_regs_wait();
-        for (std::uint32_t wt8 = 0; wt8 < ndst; wt8++) {
+        for (std::uint32_t wt8 = 0; wt8 < rem; wt8++) {
             pack_tile(wt8, dfb_out);  // reuse the exps buffer again, this time in a circular manner
         }
         tile_regs_release();
-        dfb_out_obj.push_back(ndst);
+        dfb_out_obj.push_back(rem);
     }
     dfb_in_obj.pop_front(Wt);
     dfb_max_obj.pop_front(1);
     dfb_out_obj.wait_front(Wt);
+}
+
+// CB consumers cannot wrap mid-fifo: pops in one cycle must land exactly on fifo_limit.
+// After a partial row (Wt not a multiple of the CB capacity), rd/wr sit at that offset.
+// Push/pop `pad` tiles to complete the cycle and return pointers to the CB base.
+// Kept identical to the copy in softmax_large_tensor.cpp.
+ALWI void cycle_dfb_pad(std::uint32_t dfb_id, std::uint32_t pad) {
+    if (pad == 0) {
+        return;
+    }
+    DataflowBuffer dfb(dfb_id);
+    dfb.reserve_back(pad);
+    dfb.push_back(pad);
+    dfb.wait_front(pad);
+    dfb.pop_front(pad);
+}
+
+// Same, for CBs whose padding tiles the reader already pushed: only consume them.
+ALWI void drain_dfb_pad(std::uint32_t dfb_id, std::uint32_t pad) {
+    if (pad == 0) {
+        return;
+    }
+    DataflowBuffer dfb(dfb_id);
+    dfb.wait_front(pad);
+    dfb.pop_front(pad);
 }
 
 void kernel_main() {
@@ -72,6 +98,14 @@ void kernel_main() {
     // The pad-mask data (W > W_unpadded) is host-known; it is carried as the MASK_PADDED_DATA compile-time
     // define (not a runtime arg), which lets the c_5 pad-mask DFB and the c_10 intermediate be bound only
     // on the paths that use them.
+    constexpr std::uint32_t in0_t = get_arg(args::in0_t);          // in0 DFB tile capacity
+    const std::uint32_t out0_t = ndst * 2;                         // matches factory out0_t = block_size * 2
+    const std::uint32_t exps_t = ((Wt + ndst - 1) / ndst) * ndst;  // dfb_exps/dfb_x capacity, rounded to ndst
+    // Tiles needed after Wt to finish each CB's cycle, named for the capacity they align.
+    const std::uint32_t in0_pad = (in0_t > 0 && Wt > 0) ? ((in0_t - (Wt % in0_t)) % in0_t) : 0;
+    const std::uint32_t out0_pad = (out0_t > 0 && Wt > 0) ? ((out0_t - (Wt % out0_t)) % out0_t) : 0;
+    const std::uint32_t exps_pad = (exps_t > Wt) ? (exps_t - Wt) : 0;
+    const std::uint32_t attn_pad = exps_pad;  // in4_t is also round_up(Wt, ndst); reader pushes the pad
 
     constexpr std::uint32_t onetile = 1;
     // reserve one tile for zeros on dfb_in2
@@ -135,21 +169,22 @@ void kernel_main() {
         pack_reconfig_data_format(dfb_scale_mask);
         mul_bcast_scalar_init(dfb_in0, dfb_fused_scale);
         for (std::uint32_t wt = 0; wt < Wt; wt += ndst) {
+            const std::uint32_t rem = (wt + ndst > Wt) ? (Wt - wt) : ndst;  // clamped final block
             // apply fused scale [*= 1/sqrt(...)]
             tile_regs_acquire();
-            dfb_in0_obj.wait_front(ndst);
-            dfb_scale_mask_obj.reserve_back(ndst);
-            for (std::uint32_t wt8 = 0; wt8 < ndst; wt8++) {
+            dfb_in0_obj.wait_front(rem);
+            dfb_scale_mask_obj.reserve_back(rem);
+            for (std::uint32_t wt8 = 0; wt8 < rem; wt8++) {
                 mul_tiles_bcast_scalar(dfb_in0, dfb_fused_scale, wt8, 0, wt8);  // mul bcast-HW -> DST[wt8]
             }
             tile_regs_commit();
             tile_regs_wait();
-            for (std::uint32_t wt8 = 0; wt8 < ndst; wt8++) {
+            for (std::uint32_t wt8 = 0; wt8 < rem; wt8++) {
                 pack_tile(wt8, dfb_scale_mask);  // reuse exps buffer
             }
             tile_regs_release();
-            dfb_scale_mask_obj.push_back(ndst);
-            dfb_in0_obj.pop_front(ndst);
+            dfb_scale_mask_obj.push_back(rem);
+            dfb_in0_obj.pop_front(rem);
         }
         reconfig_data_format(dfb_scale_mask, dfb_fused_attn);
 
@@ -163,36 +198,37 @@ void kernel_main() {
         add_bcast_rows_init(dfb_scale_mask, dfb_fused_attn);
 #endif
         for (std::uint32_t wt = 0; wt < Wt; wt += ndst) {
+            const std::uint32_t rem = (wt + ndst > Wt) ? (Wt - wt) : ndst;  // clamped final block
             tile_regs_acquire();
-            dfb_scale_mask_obj.wait_front(ndst);
+            dfb_scale_mask_obj.wait_front(rem);
 #ifdef CAUSAL_MASK
-            dfb_fused_attn_obj.wait_front(wt + ndst);  // cumulative wait for up to Wt tiles
-            for (std::uint32_t wt8 = 0; wt8 < ndst; wt8++) {
+            dfb_fused_attn_obj.wait_front(wt + rem);  // cumulative wait for up to Wt tiles
+            for (std::uint32_t wt8 = 0; wt8 < rem; wt8++) {
                 add_tiles(dfb_scale_mask, dfb_fused_attn, wt8, wt + wt8, wt8);  // tile *= 1/(sum(exp(x)))
             }
 #else
             if (wait_mask) {
-                dfb_fused_attn_obj.wait_front(wt + ndst);  // cumulative wait for up to Wt tiles, only at first ht
+                dfb_fused_attn_obj.wait_front(wt + rem);  // cumulative wait for up to Wt tiles, only at first ht
             }
 
-            for (std::uint32_t wt8 = 0; wt8 < ndst; wt8++) {
+            for (std::uint32_t wt8 = 0; wt8 < rem; wt8++) {
                 add_tiles_bcast_rows(dfb_scale_mask, dfb_fused_attn, wt8, wt + wt8, wt8);  // tile *= 1/(sum(exp(x)))
             }
 #endif
-            dfb_scale_mask_obj.pop_front(ndst);
-            dfb_x_obj.reserve_back(ndst);
+            dfb_scale_mask_obj.pop_front(rem);
+            dfb_x_obj.reserve_back(rem);
 #ifndef NUMERIC_STABLE
-            for (std::uint32_t wt8 = 0; wt8 < ndst; wt8++) {
+            for (std::uint32_t wt8 = 0; wt8 < rem; wt8++) {
                 exp_tile<EXP_APPROX>(wt8);  // exp on DST[0]
             }
 #endif
             tile_regs_commit();
             tile_regs_wait();
-            for (std::uint32_t wt8 = 0; wt8 < ndst; wt8++) {
+            for (std::uint32_t wt8 = 0; wt8 < rem; wt8++) {
                 pack_tile(wt8, dfb_x);  // reuse the exps buffer again, this time in a circular manner
             }
             tile_regs_release();
-            dfb_x_obj.push_back(ndst);
+            dfb_x_obj.push_back(rem);
         }
 
 // add numeric_stable
@@ -203,6 +239,7 @@ void kernel_main() {
 
 #ifdef CAUSAL_MASK
         dfb_fused_attn_obj.pop_front(Wt);
+        drain_dfb_pad(dfb_fused_attn, attn_pad);
 #else
         if (wait_mask) {
             wait_mask = false;
@@ -210,6 +247,7 @@ void kernel_main() {
         ht++;
         if (ht == Ht) {
             dfb_fused_attn_obj.pop_front(Wt);
+            drain_dfb_pad(dfb_fused_attn, attn_pad);
             ht = 0;
             wait_mask = true;
         }
@@ -226,10 +264,11 @@ void kernel_main() {
 #ifdef MASK_PADDED_DATA
         {
             for (std::uint32_t wt = 0; wt < Wt; wt += ndst) {
+                const std::uint32_t rem = (wt + ndst > Wt) ? (Wt - wt) : ndst;  // clamped final block
                 tile_regs_acquire();
-                dfb_in0_obj.wait_front(ndst);
-                for (std::uint32_t wt8 = 0; wt8 < ndst; ++wt8) {
-                    if (wt == (Wt - ndst) && (wt8 == ndst - 1)) {
+                dfb_in0_obj.wait_front(rem);
+                for (std::uint32_t wt8 = 0; wt8 < rem; ++wt8) {
+                    if (wt + wt8 == Wt - 1) {  // last tile of the row gets the -inf padding mask
                         reconfig_data_format(dfb_in0, dfb_mask_padded);
                         add_bcast_rows_init(dfb_in0, dfb_mask_padded);
                         dfb_mask_padded_obj.wait_front(1);
@@ -238,21 +277,21 @@ void kernel_main() {
                         copy_tile(dfb_in0, wt8, wt8);  // copy from c_in[0] to DST[0]
                     }
                 }
-                dfb_in0_obj.pop_front(ndst);
+                dfb_in0_obj.pop_front(rem);
 
-                dfb_x_obj.reserve_back(ndst);
+                dfb_x_obj.reserve_back(rem);
 #ifndef NUMERIC_STABLE
-                for (std::uint32_t wt8 = 0; wt8 < ndst; ++wt8) {
+                for (std::uint32_t wt8 = 0; wt8 < rem; ++wt8) {
                     exp_tile<EXP_APPROX>(wt8);  // exp on DST[0]
                 }
 #endif
                 tile_regs_commit();
                 tile_regs_wait();
-                for (std::uint32_t wt8 = 0; wt8 < ndst; ++wt8) {
+                for (std::uint32_t wt8 = 0; wt8 < rem; ++wt8) {
                     pack_tile(wt8, dfb_x);  // DST[0]->dfb_id[wt]
                 }
                 tile_regs_release();
-                dfb_x_obj.push_back(ndst);
+                dfb_x_obj.push_back(rem);
             }
 
 // add numeric_stable
@@ -269,24 +308,25 @@ void kernel_main() {
             calc_numeric_stable<dfb_in0, dfb_max_scaler, dfb_max, dfb_exps>(Wt, ndst);
 #else
             for (std::uint32_t wt = 0; wt < Wt; wt += ndst) {
+                const std::uint32_t rem = (wt + ndst > Wt) ? (Wt - wt) : ndst;  // clamped final block
                 tile_regs_acquire();
-                dfb_in0_obj.wait_front(ndst);
-                for (std::uint32_t wt8 = 0; wt8 < ndst; ++wt8) {
+                dfb_in0_obj.wait_front(rem);
+                for (std::uint32_t wt8 = 0; wt8 < rem; ++wt8) {
                     copy_tile(dfb_in0, wt8, wt8);  // copy from c_in[0] to DST[0]
                 }
-                dfb_in0_obj.pop_front(ndst);
+                dfb_in0_obj.pop_front(rem);
 
-                dfb_exps_obj.reserve_back(ndst);
-                for (std::uint32_t wt8 = 0; wt8 < ndst; ++wt8) {
+                dfb_exps_obj.reserve_back(rem);
+                for (std::uint32_t wt8 = 0; wt8 < rem; ++wt8) {
                     exp_tile<EXP_APPROX>(wt8);  // exp on DST[0]
                 }
                 tile_regs_commit();
                 tile_regs_wait();
-                for (std::uint32_t wt8 = 0; wt8 < ndst; ++wt8) {
+                for (std::uint32_t wt8 = 0; wt8 < rem; ++wt8) {
                     pack_tile(wt8, dfb_exps);  // DST[0]->dfb_id[wt]
                 }
                 tile_regs_release();
-                dfb_exps_obj.push_back(ndst);
+                dfb_exps_obj.push_back(rem);
             }
 #endif
         }
@@ -317,23 +357,42 @@ void kernel_main() {
         // by now we already did a cumulative wait for Wt tiles in dfb_exps
         mul_bcast_cols_init(dfb_exps, dfb_recipsumexps);
         for (std::uint32_t wt = 0; wt < Wt; wt += ndst) {
+            const std::uint32_t rem = (wt + ndst > Wt) ? (Wt - wt) : ndst;  // clamped final block
             tile_regs_acquire();
-            dfb_out0_obj.reserve_back(ndst);
-            for (std::uint32_t wt8 = 0; wt8 < ndst; wt8++) {
+            dfb_out0_obj.reserve_back(rem);
+            for (std::uint32_t wt8 = 0; wt8 < rem; wt8++) {
                 // wt+wt8 since we pop Wt after the entire loop
                 mul_tiles_bcast<BroadcastType::COL>(
                     dfb_exps, dfb_recipsumexps, wt + wt8, 0, wt8);  // tile *= 1/(sum(exp(x)))
             }
             tile_regs_commit();
             tile_regs_wait();
-            for (std::uint32_t wt8 = 0; wt8 < ndst; wt8++) {
+            for (std::uint32_t wt8 = 0; wt8 < rem; wt8++) {
                 pack_tile(wt8, dfb_out0);
             }
             tile_regs_release();
-            dfb_out0_obj.push_back(ndst);
+            dfb_out0_obj.push_back(rem);
         }
         dfb_recipsumexps_obj.pop_front(1);
         dfb_exps_obj.pop_front(Wt);
+
+        // Realign CBs before the next row when Wt does not fill them exactly.
+        drain_dfb_pad(dfb_in0, in0_pad);
+        cycle_dfb_pad(dfb_exps, exps_pad);
+#if FUSED_SCALE_MASK
+        cycle_dfb_pad(dfb_scale_mask, exps_pad + ndst);  // im3_t = exps_t + ndst
+#ifdef NUMERIC_STABLE
+        // Without NUMERIC_STABLE, dfb_x aliases dfb_exps; cycling it again would drift it per row.
+        cycle_dfb_pad(dfb_x, exps_pad);
+#endif
+#elif defined(NUMERIC_STABLE) && defined(MASK_PADDED_DATA)
+        // dfb_x is a distinct buffer only here; without NUMERIC_STABLE it aliases dfb_exps (already cycled).
+        cycle_dfb_pad(dfb_x, exps_pad);
+#endif
+        if (out0_pad > 0) {
+            dfb_out0_obj.reserve_back(out0_pad);
+            dfb_out0_obj.push_back(out0_pad);  // writer drains, does not write to DRAM
+        }
     }  // NCHt loop
     // The scaler tiles are each waited once and reused across the whole NCHt loop; pop them at
     // the end so the CBs are left balanced.

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/attention/compute/softmax_large_tensor.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/attention/compute/softmax_large_tensor.cpp
@@ -65,6 +65,31 @@ template <PoolType reduce_type, std::uint32_t dfb_in_id, std::uint32_t dfb_scale
 void reduce_cb(bool use_prev_reduce, std::uint32_t dfb_length_t);
 void apply_recip(std::uint32_t dfb_in, std::uint32_t dfb_recip, std::uint32_t dfb_out, std::uint32_t dfb_length_t, std::uint32_t blk);
 
+// CB consumers cannot wrap mid-fifo: pops in one cycle must land exactly on fifo_limit.
+// After a partial last pass (Wt % dfb_length_t != 0), rd/wr sit at that offset. Push/pop
+// `pad` tiles to complete the cycle and return pointers to the CB base before the next stage.
+// Kept identical to the copy in softmax.cpp.
+ALWI void cycle_dfb_pad(std::uint32_t dfb_id, std::uint32_t pad) {
+    if (pad == 0) {
+        return;
+    }
+    DataflowBuffer dfb(dfb_id);
+    dfb.reserve_back(pad);
+    dfb.push_back(pad);
+    dfb.wait_front(pad);
+    dfb.pop_front(pad);
+}
+
+// Same, for CBs whose padding tiles the reader already pushed: only consume them.
+ALWI void drain_dfb_pad(std::uint32_t dfb_id, std::uint32_t pad) {
+    if (pad == 0) {
+        return;
+    }
+    DataflowBuffer dfb(dfb_id);
+    dfb.wait_front(pad);
+    dfb.pop_front(pad);
+}
+
 // for scale+mask+softmax:
 // bcast HW (mul by 1 tile)  example: (  [2,1,1024,64] * [1,1,32,32]  )
 // bcast add H               example: ( [2,1,1024,64] + [2,1,32,64] ) (bcast W -> H)
@@ -75,32 +100,27 @@ void apply_fused_scale_mask(
     std::uint32_t dfb_in, std::uint32_t dfb_fused_scale_mask, std::uint32_t dfb_out, std::uint32_t dfb_length_t, std::uint32_t blk) {
     // Requirements:
     //   dfb_length_t of dfb_in and dfb_out are the same.
-    //   blk is a divisor of dfb_length_t
+    //   A partial final block (dfb_length_t not a multiple of blk) is handled by clamping rem below.
     DataflowBuffer dfb_in_obj(dfb_in);
     DataflowBuffer dfb_out_obj(dfb_out);
     reconfig_data_format(dfb_in, dfb_fused_scale_mask);
     pack_reconfig_data_format(dfb_out);
     mul_bcast_scalar_init(dfb_in, dfb_fused_scale_mask);
     for (std::uint32_t cur_blk = 0; cur_blk < dfb_length_t; cur_blk += blk) {
-        if(dfb_length_t -cur_blk < blk){
-            blk = dfb_length_t- cur_blk;
-        }
+        const std::uint32_t rem = (cur_blk + blk > dfb_length_t) ? (dfb_length_t - cur_blk) : blk;
         tile_regs_acquire();
-        dfb_in_obj.wait_front(blk);
-        dfb_out_obj.reserve_back(blk);
-        if (dfb_length_t - cur_blk < blk) {
-            blk = dfb_length_t - cur_blk;
-        }
-        for (std::uint32_t cur_dst = 0; cur_dst < blk; cur_dst++) {
+        dfb_in_obj.wait_front(rem);
+        dfb_out_obj.reserve_back(rem);
+        for (std::uint32_t cur_dst = 0; cur_dst < rem; cur_dst++) {
             mul_tiles_bcast_scalar(dfb_in, dfb_fused_scale_mask, cur_dst, 0, cur_dst);
         }
         tile_regs_wait();
         tile_regs_commit();
-        for (std::uint32_t cur_dst = 0; cur_dst < blk; cur_dst++) {
+        for (std::uint32_t cur_dst = 0; cur_dst < rem; cur_dst++) {
             pack_tile(cur_dst, dfb_out);
         }
-        dfb_out_obj.push_back(blk);
-        dfb_in_obj.pop_front(blk);
+        dfb_out_obj.push_back(rem);
+        dfb_in_obj.pop_front(rem);
         tile_regs_release();
     }
 }
@@ -119,41 +139,37 @@ void apply_fused_attn_mask(
     add_bcast_rows_init(dfb_in, dfb_fused_attn_mask);
 #endif
     for (std::uint32_t cur_blk = 0; cur_blk < dfb_length_t; cur_blk += blk) {
+        const std::uint32_t rem = (cur_blk + blk > dfb_length_t) ? (dfb_length_t - cur_blk) : blk;
         tile_regs_acquire();
-        if(dfb_length_t -cur_blk < blk){
-            blk = dfb_length_t- cur_blk;
-        }
         tile_regs_wait();
-        dfb_in_obj.wait_front(blk);
-        dfb_fused_attn_mask_obj.wait_front(blk);  // cumulative wait for up to wt tiles
-        dfb_out_obj.reserve_back(blk);
-        if (dfb_length_t - cur_blk < blk) {
-            blk = dfb_length_t - cur_blk;
-        }
+        dfb_in_obj.wait_front(rem);
+        dfb_fused_attn_mask_obj.wait_front(rem);  // cumulative wait for up to wt tiles
+        dfb_out_obj.reserve_back(rem);
 #ifdef CAUSAL_MASK
-        for (std::uint32_t cur_dst = 0; cur_dst < blk; cur_dst++) {
+        for (std::uint32_t cur_dst = 0; cur_dst < rem; cur_dst++) {
             add_tiles(dfb_in, dfb_fused_attn_mask, cur_dst, cur_dst, cur_dst);  // tile *= 1/(sum(exp(x)))
         }
 #else
-        for (std::uint32_t cur_dst = 0; cur_dst < blk; cur_dst++) {
+        for (std::uint32_t cur_dst = 0; cur_dst < rem; cur_dst++) {
             add_tiles_bcast_rows(dfb_in, dfb_fused_attn_mask, cur_dst, cur_dst, cur_dst);
         }
 #endif
-        if (do_mask && cur_blk == dfb_length_t - blk) {
+        if (do_mask && cur_blk + rem == dfb_length_t) {
             // add mask to the last register to pad with -inf
             reconfig_data_format_srca(dfb_mask_padded);
-            binary_dest_reuse_tiles_init<EltwiseBinaryType::ELWADD, EltwiseBinaryReuseDestType::DEST_TO_SRCB>(dfb_mask_padded);
+            binary_dest_reuse_tiles_init<EltwiseBinaryType::ELWADD, EltwiseBinaryReuseDestType::DEST_TO_SRCB>(
+                dfb_mask_padded);
             dfb_mask_padded_obj.wait_front(1);
             binary_dest_reuse_tiles<EltwiseBinaryType::ELWADD, EltwiseBinaryReuseDestType::DEST_TO_SRCB>(
-                dfb_mask_padded, 0 /*in_tile_index*/, blk - 1);
+                dfb_mask_padded, 0 /*in_tile_index*/, rem - 1);
         }
         tile_regs_commit();
-        for (std::uint32_t cur_dst = 0; cur_dst < blk; cur_dst++) {
+        for (std::uint32_t cur_dst = 0; cur_dst < rem; cur_dst++) {
             pack_tile(cur_dst, dfb_out);
         }
-        dfb_out_obj.push_back(blk);
-        dfb_in_obj.pop_front(blk);
-        dfb_fused_attn_mask_obj.pop_front(blk);
+        dfb_out_obj.push_back(rem);
+        dfb_in_obj.pop_front(rem);
+        dfb_fused_attn_mask_obj.pop_front(rem);
         tile_regs_release();
     }
 }
@@ -168,14 +184,12 @@ void pad_input(std::uint32_t dfb_in, std::uint32_t dfb_out, std::uint32_t dfb_le
     pack_reconfig_data_format(dfb_out);
     copy_tile_init(dfb_in);  // need to copy from CB to DST to be able to run sfpu math
     for (std::uint32_t cur_blk = 0; cur_blk < dfb_length_t; cur_blk += blk) {
+        const std::uint32_t rem = (cur_blk + blk > dfb_length_t) ? (dfb_length_t - cur_blk) : blk;
         tile_regs_acquire();
-        dfb_in_obj.wait_front(blk);
-        dfb_out_obj.reserve_back(blk);
-        if (dfb_length_t - cur_blk < blk) {
-            blk = dfb_length_t - cur_blk;
-        }
-        for (std::uint32_t cur_dst = 0; cur_dst < blk; cur_dst++) {
-            if (cur_dst == blk - 1 && cur_blk == dfb_length_t - blk) {
+        dfb_in_obj.wait_front(rem);
+        dfb_out_obj.reserve_back(rem);
+        for (std::uint32_t cur_dst = 0; cur_dst < rem; cur_dst++) {
+            if (cur_dst == rem - 1 && cur_blk + rem == dfb_length_t) {
                 add_init(dfb_in, dfb_mask_padded);
                 dfb_mask_padded_obj.wait_front(1);
                 add_tiles(dfb_in, dfb_mask_padded, cur_dst, 0, cur_dst);
@@ -185,11 +199,11 @@ void pad_input(std::uint32_t dfb_in, std::uint32_t dfb_out, std::uint32_t dfb_le
         }
         tile_regs_wait();
         tile_regs_commit();
-        for (std::uint32_t cur_dst = 0; cur_dst < blk; cur_dst++) {
+        for (std::uint32_t cur_dst = 0; cur_dst < rem; cur_dst++) {
             pack_tile(cur_dst, dfb_out);
         }
-        dfb_out_obj.push_back(blk);
-        dfb_in_obj.pop_front(blk);
+        dfb_out_obj.push_back(rem);
+        dfb_in_obj.pop_front(rem);
         tile_regs_release();
     }
 }
@@ -197,10 +211,9 @@ void pad_input(std::uint32_t dfb_in, std::uint32_t dfb_out, std::uint32_t dfb_le
 void exp_cb(std::uint32_t dfb_in, std::uint32_t dfb_out, std::uint32_t dfb_max, const std::uint32_t dfb_length_t, std::uint32_t blk) {
     // requirements:
     //   dfb_length_t of dfb_in and dfb_out are the same.
-    //   blk is a divisor of dfb_length_t
     //   Calculates e^dfb_in for dfb_length_t num of tiles
     //      Also if numeric stable calcs e^(dfb_in- BCASTCOL(dfb_max))
-    ASSERT(dfb_length_t % blk == 0);
+    //   A partial final block (dfb_length_t not a multiple of blk) is handled by clamping rem below.
 
     DataflowBuffer dfb_in_obj(dfb_in);
     DataflowBuffer dfb_out_obj(dfb_out);
@@ -213,33 +226,30 @@ void exp_cb(std::uint32_t dfb_in, std::uint32_t dfb_out, std::uint32_t dfb_max, 
     copy_tile_init(dfb_in);  // need to copy from CB to DST to be able to run sfpu math
 #endif
     exp_tile_init<EXP_APPROX>();
-    std::uint32_t loop = 0;
     for (std::uint32_t cur_blk = 0; cur_blk < dfb_length_t; cur_blk += blk) {
-        if (dfb_length_t - cur_blk < blk) {
-            blk = dfb_length_t - cur_blk;
-        }
-        dfb_in_obj.wait_front(blk);
-        dfb_out_obj.reserve_back(blk);
+        const std::uint32_t rem = (cur_blk + blk > dfb_length_t) ? (dfb_length_t - cur_blk) : blk;
+        dfb_in_obj.wait_front(rem);
+        dfb_out_obj.reserve_back(rem);
         tile_regs_acquire();
 #ifdef NUMERIC_STABLE
-        for (std::uint32_t cur_dst = 0; cur_dst < blk; cur_dst++) {
+        for (std::uint32_t cur_dst = 0; cur_dst < rem; cur_dst++) {
             sub_tiles_bcast_cols(dfb_in, dfb_max, cur_dst, 0, cur_dst);
         }
 #else
-        for (std::uint32_t cur_dst = 0; cur_dst < blk; cur_dst++) {
+        for (std::uint32_t cur_dst = 0; cur_dst < rem; cur_dst++) {
             copy_tile(dfb_in, cur_dst, cur_dst);
         }
 #endif
-        dfb_in_obj.pop_front(blk);
-        for (std::uint32_t cur_dst = 0; cur_dst < blk; cur_dst++) {
+        dfb_in_obj.pop_front(rem);
+        for (std::uint32_t cur_dst = 0; cur_dst < rem; cur_dst++) {
             exp_tile<EXP_APPROX>(cur_dst);  // exp on DST[0]
         }
         tile_regs_wait();
         tile_regs_commit();
-        for (std::uint32_t cur_dst = 0; cur_dst < blk; cur_dst++) {
+        for (std::uint32_t cur_dst = 0; cur_dst < rem; cur_dst++) {
             pack_tile(cur_dst, dfb_out);
         }
-        dfb_out_obj.push_back(blk);
+        dfb_out_obj.push_back(rem);
         tile_regs_release();
     }
 }
@@ -295,22 +305,20 @@ void apply_recip(std::uint32_t dfb_in, std::uint32_t dfb_recip, std::uint32_t df
     dfb_recip_obj.wait_front(1);
     mul_bcast_cols_init(dfb_in, dfb_recip);
     for (std::uint32_t cur_blk = 0; cur_blk < dfb_length_t; cur_blk += blk) {
-        dfb_in_obj.wait_front(blk);
+        const std::uint32_t rem = (cur_blk + blk > dfb_length_t) ? (dfb_length_t - cur_blk) : blk;
+        dfb_in_obj.wait_front(rem);
         tile_regs_acquire();
         tile_regs_wait();
-        if (dfb_length_t - cur_blk < blk) {
-            blk = dfb_length_t - cur_blk;
-        }
-        for (std::uint32_t cur_dst = 0; cur_dst < blk; cur_dst++) {
+        for (std::uint32_t cur_dst = 0; cur_dst < rem; cur_dst++) {
             mul_tiles_bcast_cols(dfb_in, dfb_recip, cur_dst, 0, cur_dst);
         }
         tile_regs_commit();
-        dfb_out_obj.reserve_back(blk);
-        for (std::uint32_t cur_dst = 0; cur_dst < blk; cur_dst++) {
+        dfb_out_obj.reserve_back(rem);
+        for (std::uint32_t cur_dst = 0; cur_dst < rem; cur_dst++) {
             pack_tile(cur_dst, dfb_out);
         }
-        dfb_in_obj.pop_front(blk);
-        dfb_out_obj.push_back(blk);
+        dfb_in_obj.pop_front(rem);
+        dfb_out_obj.push_back(rem);
         tile_regs_release();
     }
 }
@@ -371,6 +379,11 @@ void kernel_main() {
     const std::uint32_t dfb_max_final = dfb_exps;
 #endif
     const std::uint32_t dfb_sum_final = (num_dfb_passes & 1) ? (std::uint32_t)dfb_sumexps : (std::uint32_t)dfb_prev_reduce;
+    // Tiles needed after Wt to finish each CB's cycle, named for the capacity they align.
+    // The streamed CBs all share dfb_length_t; the reader pushes dfb_in0/dfb_fused_attn's pad.
+    const std::uint32_t stream_pad = (dfb_length_t - (Wt % dfb_length_t)) % dfb_length_t;
+    // out0 is sized 2*blk; pad so multi-row cores realign (writer drains the same count).
+    const std::uint32_t out0_pad = ((blk * 2) - (Wt % (blk * 2))) % (blk * 2);
 
     // First loop is to parse and find the sum
     std::uint32_t dst0 = 0;
@@ -411,6 +424,17 @@ void kernel_main() {
             length_left_t -= cur_dfb_length_t;
             cur_dfb_length_t = std::min(cur_dfb_length_t, length_left_t);
         }
+        // Finish the CB cycle so the next stage starts at fifo base (see realign helpers).
+        drain_dfb_pad(dfb_in0, stream_pad);
+#if FUSED_SCALE_MASK
+        drain_dfb_pad(dfb_fused_attn, stream_pad);
+        cycle_dfb_pad(dfb_scale_mask, stream_pad);
+        cycle_dfb_pad(dfb_x, stream_pad);
+#else
+        if (mask_padded_data) {
+            cycle_dfb_pad(dfb_x, stream_pad);
+        }
+#endif
         use_prev_reduce = false;
         length_left_t = Wt;
         cur_dfb_length_t = dfb_length_t;
@@ -450,6 +474,17 @@ void kernel_main() {
             length_left_t -= cur_dfb_length_t;
             cur_dfb_length_t = std::min(cur_dfb_length_t, length_left_t);
         }
+        drain_dfb_pad(dfb_in0, stream_pad);
+        cycle_dfb_pad(dfb_exps, stream_pad);
+#if FUSED_SCALE_MASK
+        drain_dfb_pad(dfb_fused_attn, stream_pad);
+        cycle_dfb_pad(dfb_scale_mask, stream_pad);
+        cycle_dfb_pad(dfb_x, stream_pad);
+#else
+        if (mask_padded_data) {
+            cycle_dfb_pad(dfb_x, stream_pad);
+        }
+#endif
         /*
          * --------------------------------------------------------
          * --------------------------------------------------------
@@ -506,6 +541,22 @@ void kernel_main() {
             apply_recip(dfb_exps, dfb_recip, dfb_out0, cur_dfb_length_t, blk);
             length_left_t -= cur_dfb_length_t;
             cur_dfb_length_t = std::min(cur_dfb_length_t, length_left_t);
+        }
+        drain_dfb_pad(dfb_in0, stream_pad);
+        cycle_dfb_pad(dfb_exps, stream_pad);
+#if FUSED_SCALE_MASK
+        drain_dfb_pad(dfb_fused_attn, stream_pad);
+        cycle_dfb_pad(dfb_scale_mask, stream_pad);
+        cycle_dfb_pad(dfb_x, stream_pad);
+#else
+        if (mask_padded_data) {
+            cycle_dfb_pad(dfb_x, stream_pad);
+        }
+#endif
+        if (out0_pad > 0) {
+            DataflowBuffer dfb_out0_obj(dfb_out0);
+            dfb_out0_obj.reserve_back(out0_pad);
+            dfb_out0_obj.push_back(out0_pad);
         }
         dfb_recip_obj.pop_front(1);
 #ifdef NUMERIC_STABLE

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/attention/compute/softmax_large_tensor.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/attention/compute/softmax_large_tensor.cpp
@@ -383,7 +383,8 @@ void kernel_main() {
     // The streamed CBs all share dfb_length_t; the reader pushes dfb_in0/dfb_fused_attn's pad.
     const std::uint32_t stream_pad = (dfb_length_t - (Wt % dfb_length_t)) % dfb_length_t;
     // out0 is sized 2*blk; pad so multi-row cores realign (writer drains the same count).
-    const std::uint32_t out0_pad = ((blk * 2) - (Wt % (blk * 2))) % (blk * 2);
+    // Uniform blk blocks tile 2*blk exactly, so a Wt that blk divides needs no realignment.
+    const std::uint32_t out0_pad = (blk > 0 && (Wt % blk) != 0) ? (((blk * 2) - (Wt % (blk * 2))) % (blk * 2)) : 0;
 
     // First loop is to parse and find the sum
     std::uint32_t dst0 = 0;

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/attention/dataflow/reader_unary_interleaved_sm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/attention/dataflow/reader_unary_interleaved_sm.cpp
@@ -18,9 +18,11 @@ void kernel_main() {
     const std::uint32_t Wt = get_arg(args::Wt);
     // in0's DFB capacity; pad finishes the fifo cycle between rows.
     constexpr std::uint32_t in0_t = get_arg(args::in0_t);
-    const std::uint32_t in0_pad = (in0_t > 0 && Wt > 0) ? ((in0_t - (Wt % in0_t)) % in0_t) : 0;
+    // Uniform blocks tile every CB capacity, so a row that blk divides already ends on the base.
+    const bool pad_to_fifo_base = Wt > 0 && blk > 0 && (Wt % blk) != 0;
+    const std::uint32_t in0_pad = pad_to_fifo_base ? ((in0_t - (Wt % in0_t)) % in0_t) : 0;
     // fused_attn is sized in4_t = round_up(Wt, blk) but only Wt tiles are read per row/batch; same deal.
-    const std::uint32_t attn_pad = (blk > 0) ? ((blk - (Wt % blk)) % blk) : 0;
+    const std::uint32_t attn_pad = pad_to_fifo_base ? ((blk - (Wt % blk)) % blk) : 0;
 
     constexpr std::uint32_t dfb_id_in0 = dfb::in0;
 

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/attention/dataflow/reader_unary_interleaved_sm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/attention/dataflow/reader_unary_interleaved_sm.cpp
@@ -16,6 +16,11 @@ void kernel_main() {
     const std::uint32_t num_blks = get_arg(args::num_rows);
     const std::uint32_t tile_offset = get_arg(args::tile_offset);
     const std::uint32_t Wt = get_arg(args::Wt);
+    // in0's DFB capacity; pad finishes the fifo cycle between rows.
+    constexpr std::uint32_t in0_t = get_arg(args::in0_t);
+    const std::uint32_t in0_pad = (in0_t > 0 && Wt > 0) ? ((in0_t - (Wt % in0_t)) % in0_t) : 0;
+    // fused_attn is sized in4_t = round_up(Wt, blk) but only Wt tiles are read per row/batch; same deal.
+    const std::uint32_t attn_pad = (blk > 0) ? ((blk - (Wt % blk)) % blk) : 0;
 
     constexpr std::uint32_t dfb_id_in0 = dfb::in0;
 
@@ -74,7 +79,7 @@ void kernel_main() {
     std::uint32_t curr_tile = tile_offset;
     for (std::uint32_t i = 0; i < num_blks; ++i) {
         for (std::uint32_t j = 0; j < Wt; j += blk) {
-            std::uint32_t rem = blk;  // (i + blk > num_tiles) ? num_tiles - i : blk;
+            std::uint32_t rem = (j + blk > Wt) ? (Wt - j) : blk;  // clamped final block
             dfb_id_in0_obj.reserve_back(rem);
             std::uint32_t write_offset = 0;
             for (std::uint32_t r = 0; r < rem; ++r) {
@@ -86,6 +91,10 @@ void kernel_main() {
             noc.async_read_barrier();
             dfb_id_in0_obj.push_back(rem);
         }
+        if (in0_pad > 0) {
+            dfb_id_in0_obj.reserve_back(in0_pad);
+            dfb_id_in0_obj.push_back(in0_pad);
+        }
 
 #if FUSED_SCALE_MASK
 // Recall that the total attention tensor size in tiles is NC,1,Wt
@@ -93,9 +102,10 @@ void kernel_main() {
 // of slice of tensor that was assigned to our core, then we skip to next batch
 #if CAUSAL_MASK
         for (std::uint32_t j = 0; j < Wt; j += blk) {
-            dfb_id_attn_obj.reserve_back(blk);
+            std::uint32_t rem = (j + blk > Wt) ? (Wt - j) : blk;  // clamped final block
+            dfb_id_attn_obj.reserve_back(rem);
             std::uint32_t mask_write_offset = 0;
-            for (std::uint32_t wb = 0; wb < blk; ++wb) {
+            for (std::uint32_t wb = 0; wb < rem; ++wb) {
                 noc.async_read(
                     addr_mask,
                     dfb_id_attn_obj,
@@ -106,7 +116,11 @@ void kernel_main() {
                 ++mask_id;
             }
             noc.async_read_barrier();
-            dfb_id_attn_obj.push_back(blk);
+            dfb_id_attn_obj.push_back(rem);
+        }
+        if (attn_pad > 0) {
+            dfb_id_attn_obj.reserve_back(attn_pad);
+            dfb_id_attn_obj.push_back(attn_pad);
         }
         ++ht;
         ++mask_ht;
@@ -122,9 +136,10 @@ void kernel_main() {
         if (read_mask) {
             for (std::uint32_t j = 0; j < Wt; j += blk) {
                 // This is only executed every blk wts
-                dfb_id_attn_obj.reserve_back(blk);
+                std::uint32_t rem = (j + blk > Wt) ? (Wt - j) : blk;  // clamped final block
+                dfb_id_attn_obj.reserve_back(rem);
                 std::uint32_t mask_write_offset = 0;
-                for (std::uint32_t wb = 0; wb < blk; ++wb) {
+                for (std::uint32_t wb = 0; wb < rem; ++wb) {
                     noc.async_read(
                         addr_mask,
                         dfb_id_attn_obj,
@@ -135,7 +150,11 @@ void kernel_main() {
                     ++mask_id;
                 }
                 noc.async_read_barrier();
-                dfb_id_attn_obj.push_back(blk);
+                dfb_id_attn_obj.push_back(rem);
+            }
+            if (attn_pad > 0) {
+                dfb_id_attn_obj.reserve_back(attn_pad);
+                dfb_id_attn_obj.push_back(attn_pad);
             }
             read_mask = false;
         }

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/attention/dataflow/reader_unary_interleaved_sm_large_tensor.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/attention/dataflow/reader_unary_interleaved_sm_large_tensor.cpp
@@ -15,6 +15,8 @@ void kernel_main() {
     const std::uint32_t NCht = get_arg(args::num_rows);
     const std::uint32_t tile_offset = get_arg(args::tile_offset);
     const std::uint32_t Wt = get_arg(args::Wt);
+    // Capacity shared by the streamed CBs; a partial last pass is padded up to it.
+    constexpr std::uint32_t dfb_length_t = get_arg(args::dfb_length);
 
     constexpr std::uint32_t dfb_id_in0 = dfb::in0;
 
@@ -90,13 +92,14 @@ void kernel_main() {
             mask_index = mask_id_offset;
 #endif
             for (std::uint32_t wt = 0; wt < Wt; wt += blk) {
-                dfb_id_in0_obj.reserve_back(blk);
+                std::uint32_t rem = (wt + blk > Wt) ? (Wt - wt) : blk;  // clamped final block
+                dfb_id_in0_obj.reserve_back(rem);
                 std::uint32_t write_offset = 0;
 #if FUSED_SCALE_MASK
-                dfb_id_attn_obj.reserve_back(blk);
+                dfb_id_attn_obj.reserve_back(rem);
                 std::uint32_t mask_write_offset = 0;
 #endif
-                for (std::uint32_t regs = 0; regs < blk; regs++) {
+                for (std::uint32_t regs = 0; regs < rem; regs++) {
                     noc.async_read(
                         src_a,
                         dfb_id_in0_obj,
@@ -117,10 +120,21 @@ void kernel_main() {
 #endif
                 }
                 noc.async_read_barrier();
-                dfb_id_in0_obj.push_back(blk);
+                dfb_id_in0_obj.push_back(rem);
 #if FUSED_SCALE_MASK
-                dfb_id_attn_obj.push_back(blk);
+                dfb_id_attn_obj.push_back(rem);
 
+#endif
+            }
+            // Complete the CB cycle after a partial last Wt pass so compute can realign to fifo base.
+            // Pad tiles are discarded by compute; contents are unused.
+            const std::uint32_t dfb_align_pad = (dfb_length_t - (Wt % dfb_length_t)) % dfb_length_t;
+            if (dfb_align_pad > 0) {
+                dfb_id_in0_obj.reserve_back(dfb_align_pad);
+                dfb_id_in0_obj.push_back(dfb_align_pad);
+#if FUSED_SCALE_MASK
+                dfb_id_attn_obj.reserve_back(dfb_align_pad);
+                dfb_id_attn_obj.push_back(dfb_align_pad);
 #endif
             }
         }

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/attention/dataflow/writer_unary_interleaved_start_id_blocked_sm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/attention/dataflow/writer_unary_interleaved_start_id_blocked_sm.cpp
@@ -16,6 +16,9 @@ void kernel_main() {
     const std::uint32_t num_tiles = get_arg(args::num_tiles);
     const std::uint32_t tile_offset = get_arg(args::tile_offset);
     const std::uint32_t blk = get_arg(args::blk);
+    // Wt is required so rem matches compute/reader (per-row), not flat num_tiles.
+    // When Wt % blk != 0 but (num_rows*Wt) % blk == 0, a flat rem clamp deadlocks.
+    const std::uint32_t Wt = get_arg(args::Wt);
 
     constexpr std::uint32_t num_datum_padded = get_arg(args::num_datum_padded);
     constexpr std::uint32_t tile_hw = get_arg(args::tile_hw);
@@ -51,16 +54,29 @@ void kernel_main() {
     const auto s = TensorAccessor(tensor::dst);
 
     std::uint32_t tile_id = tile_offset;
-    for (std::uint32_t i = 0; i < num_tiles; i += blk) {
-        dfb_id_out0_obj.wait_front(blk);
+    // Idle cores are given num_tiles=0 / Wt=0; avoid 0/0 and skip the write loop.
+    if (num_tiles > 0 && Wt > 0) {
+        const std::uint32_t out0_pad = ((blk * 2) - (Wt % (blk * 2))) % (blk * 2);
+        const std::uint32_t num_rows = num_tiles / Wt;
+        for (std::uint32_t row = 0; row < num_rows; ++row) {
+            for (std::uint32_t wt = 0; wt < Wt; wt += blk) {
+                const std::uint32_t rem = (wt + blk > Wt) ? (Wt - wt) : blk;  // clamped final block of each row
+                dfb_id_out0_obj.wait_front(rem);
 
-        std::uint32_t read_offset = 0;
-        for (std::uint32_t j = 0; j < blk; j++) {
-            noc.async_write(dfb_id_out0_obj, s, tile_bytes, {.offset_bytes = read_offset}, {.page_id = tile_id});
-            tile_id++;
-            read_offset += tile_bytes;
+                std::uint32_t read_offset = 0;
+                for (std::uint32_t j = 0; j < rem; j++) {
+                    noc.async_write(
+                        dfb_id_out0_obj, s, tile_bytes, {.offset_bytes = read_offset}, {.page_id = tile_id});
+                    tile_id++;
+                    read_offset += tile_bytes;
+                }
+                noc.async_write_barrier();
+                dfb_id_out0_obj.pop_front(rem);
+            }
+            if (out0_pad > 0) {
+                dfb_id_out0_obj.wait_front(out0_pad);
+                dfb_id_out0_obj.pop_front(out0_pad);
+            }
         }
-        noc.async_write_barrier();
-        dfb_id_out0_obj.pop_front(blk);
     }
 }

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/attention/dataflow/writer_unary_interleaved_start_id_blocked_sm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/attention/dataflow/writer_unary_interleaved_start_id_blocked_sm.cpp
@@ -54,9 +54,10 @@ void kernel_main() {
     const auto s = TensorAccessor(tensor::dst);
 
     std::uint32_t tile_id = tile_offset;
-    // Idle cores are given num_tiles=0 / Wt=0; avoid 0/0 and skip the write loop.
+    // num_rows below divides by Wt; guard against a zero-work core rather than trapping on 0/0.
     if (num_tiles > 0 && Wt > 0) {
-        const std::uint32_t out0_pad = ((blk * 2) - (Wt % (blk * 2))) % (blk * 2);
+        // Uniform blocks tile the CB capacity, so a row that blk divides needs no realignment.
+        const std::uint32_t out0_pad = (Wt % blk == 0) ? 0 : (((blk * 2) - (Wt % (blk * 2))) % (blk * 2));
         const std::uint32_t num_rows = num_tiles / Wt;
         for (std::uint32_t row = 0; row < num_rows; ++row) {
             for (std::uint32_t wt = 0; wt < Wt; wt += blk) {

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_program_factory_attention_optimized.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_program_factory_attention_optimized.cpp
@@ -89,8 +89,9 @@ SoftmaxDeviceOperation::SoftmaxProgramFactoryAttentionOptimized::create_program_
         im_cb_data_format == tt::DataFormat::Float32 ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b;
     const std::uint32_t sum_scaler_tile_size = tt::tile_size(sum_scaler_cb_data_format);
 
-    std::uint32_t block_size =
-        fp32_dest_acc_en ? tt::tt_metal::find_max_divisor(Wt, 4) : tt::tt_metal::find_max_divisor(Wt, 8);
+    // Fixed block size that maximizes dest register usage: 4 with fp32 accumulation, 8 otherwise.
+    // Widths not divisible by block_size are handled by the kernels via a clamped final block.
+    std::uint32_t block_size = fp32_dest_acc_en ? 4 : 8;
 
     // calc_numeric_stable() in softmax.cpp uses indexed access over Wt tiles of its input CB and a
     // WaitUpfrontNoPop reduce, so whichever CB it consumes must be sized to Wt:
@@ -115,9 +116,8 @@ SoftmaxDeviceOperation::SoftmaxProgramFactoryAttentionOptimized::create_program_
     std::uint32_t im2_t = 1;
     std::uint32_t im4_t = tt::div_up(Wt, block_size) * block_size;
 
-    // cb_exps - keeps exps in tt::CBIndex in L1 to avoid recomputing
+    // cb_exps - keeps exps in tt::CBIndex in L1 to avoid recomputing (rounded up to a multiple of block_size)
     std::uint32_t im0_t = block_size * tt::div_up(Wt, block_size);
-    TT_FATAL(im0_t == Wt, "im0_t: {} == Wt: {}, (Non user error)", im0_t, Wt);
 
     // used for buffering scale-mask
     // can't easily reuse im0_t because cumulative wait for Wt needs to have Wt tiles contiguous free
@@ -148,13 +148,17 @@ SoftmaxDeviceOperation::SoftmaxProgramFactoryAttentionOptimized::create_program_
         im4_t = large_kernel_cb_size;
         im0_t = large_kernel_cb_size;
         im3_t = large_kernel_cb_size;
+        // c_4 is streamed a pass at a time too, and both large kernels align its pad to cb_length_t.
+        in4_t = large_kernel_cb_size;
     }
     if (!use_large_kernel) {
         TT_FATAL(
-            im3_t == Wt + block_size, "im3_t {} == Width in tiles {} + num_dest_regs to use {}", im3_t, Wt, block_size);
+            im3_t >= Wt + block_size,
+            "im3_t {} must be >= Width in tiles {} + num_dest_regs to use {}",
+            im3_t,
+            Wt,
+            block_size);
     }
-    TT_FATAL(Wt % block_size == 0, "Wt: {} must be divisible by one of the numbers in the range from 8 to 1.", Wt);
-    TT_FATAL((block_size != -1), "Wt: {} must be divisible by one of the numbers in the range from 8 to 1.", Wt);
     TT_FATAL(
         im0_t % block_size == 0,
         "Size of cb: {} must be divisible by the size of block used by the reader and compute kernel.",
@@ -341,6 +345,13 @@ SoftmaxDeviceOperation::SoftmaxProgramFactoryAttentionOptimized::create_program_
         }
     }
     KernelSpec::CompileTimeArgs reader_cta;
+    if (use_large_kernel) {
+        // The large reader pads in0/fused_attn so each streamed pass ends on the fifo base.
+        reader_cta.insert({"dfb_length", dfb_length});
+    } else {
+        // The small reader pads in0 up to this capacity so its fifo ends each tile row on the base.
+        reader_cta.insert({"in0_t", in0_t});
+    }
     if (has_mask && attributes.is_causal_mask) {
         const std::uint32_t num_tiles_causal_mask = tensor_args.mask.value().padded_shape()[-1] *
                                                     tensor_args.mask.value().padded_shape()[-2] / tile_width /
@@ -373,7 +384,7 @@ SoftmaxDeviceOperation::SoftmaxProgramFactoryAttentionOptimized::create_program_
                  .endpoint_type = DFBEndpointType::PRODUCER}},
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = DST, .accessor_name = "dst"}},
         .compile_time_args = {{"num_datum_padded", num_datum_padded}, {"tile_hw", tile_height * tile_width}},
-        .runtime_arg_schema = {.runtime_arg_names = {"num_tiles", "tile_offset", "blk", "mask_padded_data"}},
+        .runtime_arg_schema = {.runtime_arg_names = {"num_tiles", "tile_offset", "blk", "mask_padded_data", "Wt"}},
         .hw_config = ttnn::create_writer_datamovement_config(arch),
     };
 
@@ -470,12 +481,19 @@ SoftmaxDeviceOperation::SoftmaxProgramFactoryAttentionOptimized::create_program_
         }
     }
 
+    KernelSpec::CompileTimeArgs compute_cta;
+    if (!use_large_kernel) {
+        // The small compute drains the pad the reader pushed to in0, so both agree on the capacity.
+        compute_cta.insert({"in0_t", in0_t});
+    }
+
     KernelSpec compute{
         .unique_id = COMPUTE,
         .source = std::string(SOFTMAX_KERNEL_PATH_ATTENTION) +
                   (use_large_kernel ? "/compute/softmax_large_tensor.cpp" : "/compute/softmax.cpp"),
         .compiler_options = {.defines = compute_defines, .opt_level = tt::tt_metal::KernelBuildOptLevel::O3},
         .dfb_bindings = compute_bindings,
+        .compile_time_args = compute_cta,
         .runtime_arg_schema = {.runtime_arg_names = compute_rta_names},
         .hw_config = compute_hw,
     };
@@ -548,7 +566,8 @@ SoftmaxDeviceOperation::SoftmaxProgramFactoryAttentionOptimized::create_program_
             {{"num_tiles", num_tile_rows_per_core * Wt},
              {"tile_offset", tile_offset},
              {"blk", block_size},
-             {"mask_padded_data", static_cast<std::uint32_t>(mask_padded_data)}});
+             {"mask_padded_data", static_cast<std::uint32_t>(mask_padded_data)},
+             {"Wt", Wt}});
 
         if (use_large_kernel) {
             AddRuntimeArgsForNode(

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_program_factory_attention_optimized.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_program_factory_attention_optimized.cpp
@@ -93,6 +93,15 @@ SoftmaxDeviceOperation::SoftmaxProgramFactoryAttentionOptimized::create_program_
     // Widths not divisible by block_size are handled by the kernels via a clamped final block.
     std::uint32_t block_size = fp32_dest_acc_en ? 4 : 8;
 
+    // Prefer an exact divisor of Wt when it costs no extra register batches: uniform blocks keep every
+    // CB capacity a multiple of the block, so no fifo needs realignment between tile rows.
+    if (Wt % block_size != 0) {
+        const std::uint32_t divisor = static_cast<std::uint32_t>(tt::tt_metal::find_max_divisor(Wt, block_size));
+        if (tt::div_up(Wt, block_size) == Wt / divisor) {
+            block_size = divisor;
+        }
+    }
+
     // calc_numeric_stable() in softmax.cpp uses indexed access over Wt tiles of its input CB and a
     // WaitUpfrontNoPop reduce, so whichever CB it consumes must be sized to Wt:
     //   - no mask, no padding: it consumes cb_in0 directly.


### PR DESCRIPTION
### PR Category

Bug fix / Performance — attention-optimized interleaved softmax: use a fixed dest-register block size instead of a divisor-derived one, issue #39050.

### Summary

`softmax_program_factory_attention_optimized.cpp` derived its blocking from `find_max_divisor(Wt, 8)` (or `4` when `fp32_dest_acc_en`). That helper skips `5` and `7`, so any width without a divisor in `{8,6,4,3,2}` collapses to `block_size == 1`: one tile per `tile_regs_acquire`, one NoC read per tile, one CB push per tile. Widths like `Wt = 5, 7, 11, 13, 47` therefore ran at a fraction of the achievable dest utilization. Three `TT_FATAL`s (`im0_t == Wt`, `im3_t == Wt + block_size`, `Wt % block_size == 0`) also hard-locked CB sizing to exactly-divisible widths.

This PR blocks at **4 with fp32 accumulation, 8 otherwise**, stepping down to an exact divisor of `Wt` only when that costs no extra register batches (e.g. `Wt = 6` → `6`, still one batch), and makes every producer/consumer in the pipeline tolerate a clamped final block. Two things were required to make that safe:

1. **Clamped final block** — every blocked loop in the reader, compute, and writer kernels computes `rem = min(blk, Wt - wt)` and reserves/pushes/pops exactly `rem` tiles, instead of assuming `blk` divides the loop bound. The large kernel already had ad-hoc (and duplicated, partly mid-loop) `blk` mutation for this; that is replaced by a single `const uint32_t rem` per iteration, so `blk` is no longer clobbered across iterations.
2. **CB fifo realignment** — CB consumers cannot wrap mid-fifo: the pops within one cycle must land exactly on `fifo_limit`. Once `Wt` is not a multiple of a CB's tile capacity, a row (or a streamed pass) ends with rd/wr at an interior offset and the next row drifts further. With `dfb_x` aliasing `dfb_exps` and the attention mask CB `c_4` sized `round_up(Wt, blk)`, that drift shows up as a wrapped mask read or a hang, and only on cores that own ≥ 2 tile rows. Fixed by completing the cycle at each row/pass boundary with two small helpers — `cycle_dfb_pad` (push + pop dummy tiles for compute-produced CBs) and `drain_dfb_pad` (consume only, for CBs whose pad the reader already pushed). Every pad is gated on `Wt % blk != 0`, since with uniform blocks each capacity is a multiple of `blk` and a row already ends on the fifo base.

### Changes Made

**`softmax_program_factory_attention_optimized.cpp`**

- `block_size = fp32_dest_acc_en ? 4 : 8`, narrowed to `find_max_divisor(Wt, block_size)` only when `div_up(Wt, block_size) == Wt / divisor` (same register-batch count, uniform blocks, no realignment).
- Dropped `TT_FATAL(im0_t == Wt)`, `TT_FATAL(Wt % block_size == 0)`, and the `block_size != -1` check; relaxed `im3_t == Wt + block_size` to `im3_t >= Wt + block_size`, since `im0_t`/`im3_t`/`im4_t` are now `round_up(Wt, block_size)`.
- Large-kernel path also caps `in4_t` at `large_kernel_cb_size`, because `c_4` is streamed a pass at a time and both large kernels align its pad to `dfb_length`.
- New args so the kernels derive their own pads: `in0_t` compile-time arg to the small reader and to compute, `dfb_length` to the large reader, and a `Wt` runtime arg for the writer (per-row geometry, see below).

**Compute — `attention/compute/softmax.cpp`**

- `rem`-clamped final block in the fused-scale, fused-attn, `mask_padded_data`, plain-exp, `calc_numeric_stable`, and final recip-multiply loops. The padding-mask tile is now selected by `wt + wt8 == Wt - 1` rather than `wt == Wt - ndst && wt8 == ndst - 1`, which is wrong for a short last block.
- Per-row realignment at the end of the `NCHt` loop: `drain_dfb_pad(dfb_in0)`, `cycle_dfb_pad(dfb_exps)`, `cycle_dfb_pad(dfb_scale_mask, exps_pad + ndst)` (its capacity is `exps_t + ndst`), and `dfb_x` only under `NUMERIC_STABLE` — without it `dfb_x` aliases `dfb_exps` and cycling twice would drift it per row. `dfb_out0` gets its pad pushed for the writer to drain, and `dfb_fused_attn`'s pad is drained where the mask is popped (per row under `CAUSAL_MASK`, per batch otherwise).

**Compute — `attention/compute/softmax_large_tensor.cpp`**

- Same `rem` clamp in `apply_fused_scale_mask`, `apply_fused_attn_mask`, `pad_input`, `exp_cb`, `apply_recip`; removed `ASSERT(cb_length_t % blk == 0)` and the duplicated in-loop `blk` reassignments.
- `stream_pad = (dfb_length - Wt % dfb_length) % dfb_length` applied after each of the three streaming stages (max pass, sum pass, recip pass), plus `out0_pad` sized to the `2*blk` out CB and gated on `Wt % blk != 0`.

**Dataflow — readers**

- `reader_unary_interleaved_sm.cpp`: `rem` clamp on the input and both mask read loops (causal per-row, broadcast per-batch); pushes `in0_pad` / `attn_pad` so the compute side can drain rather than generate them.
- `reader_unary_interleaved_sm_large_tensor.cpp`: `rem` clamp per pass, and pushes the align pad for `dfb_in0` (+ `c_4` under `FUSED_SCALE_MASK`) after a partial final pass.

**Dataflow — `writer_unary_interleaved_start_id_blocked_sm.cpp`**

- Rewritten as an outer row loop × inner blocked loop, so `rem` matches the compute/reader per-row blocking. A flat `rem` clamp over `num_tiles` deadlocks whenever `Wt % blk != 0` but `(num_rows * Wt) % blk == 0`. Drains `out0_pad` per row, and skips the loop entirely for idle cores (`num_tiles == 0`, avoiding a `0/0`).

**Tests — `tests/ttnn/unit_tests/operations/fused/test_softmax.py`**

- `test_softmax_non_divisible_width` — `Wt ∈ {5, 7, 11, 13, 47}` (small kernel), crossed with `fp32_acc_en` × `numeric_stable`.
- `test_softmax_large_non_divisible_width` — `Wt ∈ {637, 703, 1001}` (large kernel, chosen so `Wt % 80`, the capped CB length, is also not a multiple of `block_size`), at `fp32_acc_en=True` / `numeric_stable=True`.
- `test_scale_mask_softmax_non_divisible_width` — the fused scale/mask path, where `c_4` is the CB most sensitive to fifo drift, crossed with `fp32_acc_en` × `numeric_stable`. Uses `batch=64` so every core owns > 1 tile row (the drift is invisible with one row per core), a causal variant via `scale_mask_softmax_in_place` (`scale_mask_softmax` rejects a square mask), and large-kernel widths `637`/`1001` — which is where both large-kernel modes and both 4/8-register blockings get exercised.

Both assert PCC ≥ 0.999 with `rtol=0.09 / atol=0.01` and a Frobenius-norm bound.
<!DOCTYPE html>
|      | case         | shape           |        detail |   Wt |   bs |    main |    head |         Δ% |
| ---- | ------------ | --------------- | ------------: | ---: | ---: | ------: | ------: | ---------: |
| 0    | lg_softmax   | (1,128,128000)  |               | 4000 |  8→8 | 2782.54 | 2777.33 |      −0.19 |
| 1    | lg_softmax   | (1,32,128000)   |               | 4000 |  8→8 | 2762.86 | 2762.73 |      −0.00 |
| 2    | lg_softmax   | (1,2048,32000)  |               | 1000 |  8→8 | 2505.43 | 2510.98 |      +0.22 |
| 3    | lg_softmax   | (1,512,32000)   |               | 1000 |  8→8 |  806.78 |  807.00 |      +0.03 |
| 4    | lg_softmax   | (1,32,32000)    |               | 1000 |  8→8 |  695.28 |  695.17 |      −0.02 |
| 5    | lg_softmax   | (1,24,42)       |               |    2 |  2→2 |   15.37 |   15.38 |      +0.06 |
| 6    | softmax      | (1,32,64)       |        dim=−1 |    2 |  2→2 |    5.39 |    5.41 |      +0.21 |
| 7    | softmax      | (16,64,64)      |        dim=−1 |    2 |  2→2 |    6.41 |    6.47 |      +0.86 |
| 8    | softmax      | (1,24,42)       |        dim=−1 |    2 |  2→2 |   15.36 |   15.36 |      −0.04 |
| 9    | softmax      | (1,32,64)       |        dim=−2 |    2 |  n/a |   22.15 |   22.17 |      +0.07 |
| 10   | softmax      | (1,32,64)       |         dim=0 |    2 |  n/a |    6.42 |    6.43 |      +0.05 |
| 11   | softmax_3D   | (8,1500,1500)   |               |   47 |  1→8 |  489.09 |  436.12 | **−10.83** |
| 12   | pad_tile     | (8,2,2)         |               |    1 |  1→1 |   16.45 |   16.45 |      −0.01 |
| 13   | pad_tile_lg  | (8,100,1200)    |               |   38 |  2→8 |   47.85 |   48.20 |      +0.73 |
| 14   | softmax_5d   | (1,1,1,32,32)   |        dim=−1 |    1 |  1→1 |   22.64 |   22.65 |      +0.02 |
| 15   | softmax_5d   | (1,2,4,64,64)   |        dim=−1 |    2 |  2→2 |   24.87 |   24.86 |      −0.05 |
| 16   | dtypes       | (1,1,64,128)    |          bf16 |    4 |  4→4 |    6.81 |    6.84 |      +0.42 |
| 17   | dtypes       | (1,1,64,128)    |         bf8_b |    4 |  4→4 |    6.42 |    6.45 |      +0.48 |
| 18   | dtypes       | (1,1,64,128)    |          fp32 |    4 |  4→4 |    8.90 |    8.96 |      +0.67 |
| 19   | lg_kern_bs   | (1,1,32,6176)   |      fp32_acc |  193 |  1→4 |  521.09 |  409.36 | **−21.44** |
| 20   | lg_kern_bs   | (1,1,32,6208)   |      fp32_acc |  194 |  2→4 |  452.89 |  411.12 |  **−9.22** |
| 21   | lg_kern_bs   | (1,1,32,6240)   |      fp32_acc |  195 |  3→4 |  427.20 |  413.27 |      −3.26 |
| 22   | lg_kern_bs   | (1,1,32,6272)   |      fp32_acc |  196 |  4→4 |  415.26 |  415.13 |      −0.03 |
| 23   | non_div_w    | (1,1,64,160)    |            TT |    5 |  1→4 |   17.88 |   15.91 | **−10.98** |
| 24   | non_div_w    | (1,1,64,160)    |            TF |    5 |  1→4 |   15.05 |   14.45 |      −3.98 |
| 25   | non_div_w    | (1,1,64,160)    |            FT |    5 |  1→8 |   13.37 |   10.72 | **−19.88** |
| 26   | non_div_w    | (1,1,64,160)    |            FF |    5 |  1→8 |   10.55 |    9.81 |      −6.97 |
| 27   | non_div_w    | (1,1,64,224)    |            TT |    7 |  1→4 |   23.15 |   19.86 | **−14.19** |
| 28   | non_div_w    | (1,1,64,224)    |            TF |    7 |  1→4 |   19.18 |   18.03 |      −6.00 |
| 29   | non_div_w    | (1,1,64,224)    |            FT |    7 |  1→8 |   16.91 |   13.07 | **−22.74** |
| 30   | non_div_w    | (1,1,64,224)    |            FF |    7 |  1→8 |   13.00 |   11.96 |      −8.00 |
| 31   | non_div_w    | (1,1,64,352)    |            TT |   11 |  1→4 |   33.90 |   28.31 | **−16.49** |
| 32   | non_div_w    | (1,1,64,352)    |            TF |   11 |  1→4 |   27.62 |   25.29 |      −8.41 |
| 33   | non_div_w    | (1,1,64,352)    |            FT |   11 |  1→8 |   24.33 |   18.12 | **−25.52** |
| 34   | non_div_w    | (1,1,64,352)    |            FF |   11 |  1→8 |   18.18 |   15.90 |     −12.54 |
| 35   | non_div_w    | (1,1,64,416)    |            TT |   13 |  1→4 |   39.23 |   32.73 | **−16.56** |
| 36   | non_div_w    | (1,1,64,416)    |            TF |   13 |  1→4 |   31.77 |   28.91 |      −8.98 |
| 37   | non_div_w    | (1,1,64,416)    |            FT |   13 |  1→8 |   28.07 |   20.26 | **−27.84** |
| 38   | non_div_w    | (1,1,64,416)    |            FF |   13 |  1→8 |   20.66 |   17.72 |     −14.23 |
| 39   | non_div_w    | (1,1,64,1504)   |            TT |   47 |  1→4 |  130.41 |  103.82 | **−20.39** |
| 40   | non_div_w    | (1,1,64,1504)   |            TF |   47 |  1→4 |  103.66 |   90.66 |     −12.54 |
| 41   | non_div_w    | (1,1,64,1504)   |            FT |   47 |  1→8 |   91.10 |   59.18 | **−35.03** |
| 42   | non_div_w    | (1,1,64,1504)   |            FF |   47 |  1→8 |   64.61 |   49.24 | **−23.79** |
| 43   | non_div_w    | (1,1,64,22496)  |            TT |  703 |  1→4 | 2872.54 | 2485.63 | **−13.47** |
| 44   | non_div_w    | (1,1,64,22496)  |            TF |  703 |  1→4 | 2534.23 | 2337.82 |      −7.75 |
| 45   | non_div_w    | (1,1,64,22496)  |            FT |  703 |  1→8 | 1759.89 | 1269.86 | **−27.84** |
| 46   | non_div_w    | (1,1,64,22496)  |            FF |  703 |  1→8 | 1425.26 | 1167.61 | **−18.08** |
| 47   | non_div_w    | (1,1,64,32032)  |            TT | 1001 |  1→4 | 4088.11 | 3537.08 | **−13.48** |
| 48   | non_div_w    | (1,1,64,32032)  |            TF | 1001 |  1→4 | 3606.81 | 3325.87 |      −7.79 |
| 49   | non_div_w    | (1,1,64,32032)  |            FT | 1001 |  1→8 | 2503.85 | 1805.29 | **−27.90** |
| 50   | non_div_w    | (1,1,64,32032)  |            FF | 1001 |  1→8 | 2026.91 | 1659.93 | **−18.11** |
| 51   | lg_kern_mask | (1,100,6800)    |      fp32_acc |  213 |  3→4 |  796.23 |  781.32 |      −1.87 |
| 52   | sm_4096      | (1,1,4096,4096) |               |  128 |  8→8 |  820.39 |  822.27 |      +0.23 |
| 53   | sm_accuracy  | (1,1,16384,256) |            TT |    8 |  4→4 |  154.61 |  154.69 |      +0.06 |
| 54   | sm_accuracy  | (1,1,16384,256) |            TF |    8 |  4→4 |  142.25 |  142.28 |      +0.02 |
| 55   | prog_cache   | (8,1,128,1024)  |        skip T |   32 |  8→8 |   58.15 |   58.26 |      +0.18 |
| 56   | prog_cache   | (8,1,128,1024)  |        skip F |   32 |  8→8 |   69.28 |   69.44 |      +0.23 |
| 57   | sbert_shard  | (8,12,192,192)  |   bf8 L1+mask |    6 |  6→6 |   66.33 |   66.66 |      +0.51 |
| 58   | sbert_shard  | (8,12,384,384)  |   bf8 L1+mask |   12 |  6→6 |  186.02 |  186.54 |      +0.28 |
| 59   | sbert_shard  | (8,12,512,512)  |   bf8 L1+mask |   16 |  8→8 |  307.16 |  308.21 |      +0.34 |
| 60   | sbert_dram   | (8,12,192,192)  | bf8 DRAM+mask |    6 |  6→6 |   67.24 |   67.64 |      +0.59 |
| 61   | sbert_dram   | (8,12,384,384)  | bf8 DRAM+mask |   12 |  6→6 |  192.71 |  192.97 |      +0.14 |
| 62   | sbert_dram   | (8,12,512,512)  | bf8 DRAM+mask |   16 |  8→8 |  313.55 |  314.15 |      +0.19 |


### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ign/39050_softmax_attn_fixed_block_size)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ign/39050_softmax_attn_fixed_block_size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ign/39050_softmax_attn_fixed_block_size)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ign/39050_softmax_attn_fixed_block_size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ign/39050_softmax_attn_fixed_block_size)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ign/39050_softmax_attn_fixed_block_size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ign/39050_softmax_attn_fixed_block_size)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ign/39050_softmax_attn_fixed_block_size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ign/39050_softmax_attn_fixed_block_size)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ign/39050_softmax_attn_fixed_block_size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ign/39050_softmax_attn_fixed_block_size)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ign/39050_softmax_attn_fixed_block_size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ign/39050_softmax_attn_fixed_block_size)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ign/39050_softmax_attn_fixed_block_size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ign/39050_softmax_attn_fixed_block_size)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ign/39050_softmax_attn_fixed_block_size)