### PR TITLE
Fix indexer_score TP1 performance targets

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/experimental/test_indexer_score.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/test_indexer_score.py
@@ -1302,14 +1302,14 @@ _MATH_UTIL_CASES = [
         "dsv32_tp1",
         lambda device: run_indexer_short(device, 64),
         lambda: indexer_mm_flops(short_valid_tiles(), 64),
-        70.72,
+        67.10,
         "LoFi",
     ),
     (
         "glm5_tp1",
         lambda device: run_indexer_short(device, 32),
         lambda: indexer_mm_flops(short_valid_tiles(), 32),
-        64.98,
+        63.70,
         "LoFi",
     ),
 ]


### PR DESCRIPTION
## What changed

Update the `dsv32_tp1` and `glm5_tp1` math-utilization targets to the values consistently measured on Blackhole.

## Why

PR #50627 switched these cases to BFP8 Q / LoFi but recorded targets that do not reproduce, including on that PR’s own head. This caused false nightly regressions even though the kernels did not regress.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=skrstic/fix-indexer-score-perf-targets)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:skrstic/fix-indexer-score-perf-targets)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=skrstic/fix-indexer-score-perf-targets)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:skrstic/fix-indexer-score-perf-targets)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=skrstic/fix-indexer-score-perf-targets)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:skrstic/fix-indexer-score-perf-targets)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=skrstic/fix-indexer-score-perf-targets)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:skrstic/fix-indexer-score-perf-targets)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=skrstic/fix-indexer-score-perf-targets)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:skrstic/fix-indexer-score-perf-targets)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=skrstic/fix-indexer-score-perf-targets)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:skrstic/fix-indexer-score-perf-targets)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=skrstic/fix-indexer-score-perf-targets)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:skrstic/fix-indexer-score-perf-targets)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=skrstic/fix-indexer-score-perf-targets)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:skrstic/fix-indexer-score-perf-targets)