### PR TITLE
[Bug fix] Qwen3-VL: slice page table before multimodal prefill

### DIFF
--- a/models/demos/qwen3_vl/tests/test_generator_vllm.py
+++ b/models/demos/qwen3_vl/tests/test_generator_vllm.py
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+
+from models.demos.qwen3_vl.tt import generator_vllm
+
+
+def test_single_user_prefill_receives_sliced_multi_user_page_table():
+    class FakeTTGenerator:
+        def __init__(self):
+            self.calls = []
+
+        def _get_prefill_user_page_table(self, page_table, kv_cache, prefill_len):
+            self.calls.append((page_table, kv_cache, prefill_len))
+            return page_table[:, :17]
+
+    class FakeVLLMGenerator:
+        def __init__(self):
+            self._ttt_generator = FakeTTGenerator()
+            self.prefill_kwargs = None
+
+        def prefill_forward_single_user_text(self, input_prefill, **kwargs):
+            self.prefill_kwargs = kwargs
+            return input_prefill
+
+    generator = FakeVLLMGenerator()
+    input_prefill = object()
+    page_table = torch.arange(128, dtype=torch.int32).reshape(2, 64)
+    kv_cache = object()
+    rot_mats = object()
+    deepstack_visual_embeds = object()
+
+    result = generator_vllm._prefill_single_user_with_sliced_page_table(
+        generator,
+        input_prefill,
+        page_table,
+        user_id=1,
+        decoding_pos=1043,
+        rot_mats=rot_mats,
+        kv_cache=kv_cache,
+        deepstack_visual_embeds=deepstack_visual_embeds,
+    )
+
+    assert result is input_prefill
+    assert generator._ttt_generator.calls == [(page_table, kv_cache, 1043)]
+    sliced_page_table = generator.prefill_kwargs.pop("page_table")
+    assert torch.equal(sliced_page_table, page_table[:, :17])
+    assert generator.prefill_kwargs == {
+        "user_id": 1,
+        "last_token_idx": 1042,
+        "rot_mats": rot_mats,
+        "kv_cache": kv_cache,
+        "deepstack_visual_embeds": deepstack_visual_embeds,
+    }

--- a/models/demos/qwen3_vl/tests/test_generator_vllm.py
+++ b/models/demos/qwen3_vl/tests/test_generator_vllm.py
@@ -2,8 +2,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import pytest
 import torch
 
+pytest.importorskip("vllm")
 from models.demos.qwen3_vl.tt import generator_vllm
 
 

--- a/models/demos/qwen3_vl/tt/generator_vllm.py
+++ b/models/demos/qwen3_vl/tt/generator_vllm.py
@@ -54,6 +54,29 @@ def allocate_vllm_kv_cache(kv_cache_shape, dtype, num_layers, model: Transformer
     return [l.attention.layer_past for l in model.layers]
 
 
+def _prefill_single_user_with_sliced_page_table(
+    generator,
+    input_prefill,
+    page_table,
+    user_id,
+    decoding_pos,
+    rot_mats,
+    kv_cache,
+    deepstack_visual_embeds,
+):
+    """Run one user prefill without exposing unallocated page-table entries."""
+    user_page_table = generator._ttt_generator._get_prefill_user_page_table(page_table, kv_cache, decoding_pos)
+    return generator.prefill_forward_single_user_text(
+        input_prefill,
+        page_table=user_page_table,
+        user_id=user_id,
+        last_token_idx=decoding_pos - 1,
+        rot_mats=rot_mats,
+        kv_cache=kv_cache,
+        deepstack_visual_embeds=deepstack_visual_embeds,
+    )
+
+
 def get_platform_specific_optimizations(model_name):
     max_seq_len = 131072
 
@@ -309,16 +332,20 @@ class Qwen3VLForConditionalGeneration(QwenVLGenerator, SupportsMultiModal):
             rot_mats = (cos, sin)
             all_rope_deltas.append(rope_deltas)
 
-            # Run text prefill for this single user
-            # Use parent class method which handles page_table slicing internally
-            logits = self.prefill_forward_single_user_text(
+            # The persistent vLLM page table is padded to max_model_len. The
+            # attention prefill path uses its width to decide how much K/V to
+            # write, so expose only blocks allocated for this user's sequence.
+            # Otherwise padded zero block IDs redirect padded K/V writes into
+            # physical block 0 and can corrupt this request's prompt cache.
+            logits = _prefill_single_user_with_sliced_page_table(
+                self,
                 ttnn.unsqueeze(input_prefill, 0),
-                page_table=page_table,
-                user_id=user_id,
-                last_token_idx=decoding_pos - 1,
-                rot_mats=rot_mats,
-                kv_cache=kv_cache,
-                deepstack_visual_embeds=deepstack_visual_embeds,
+                page_table,
+                user_id,
+                decoding_pos,
+                rot_mats,
+                kv_cache,
+                deepstack_visual_embeds,
             )
 
             # Store output


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Qwen3-VL's multimodal prefill processes one user at a time, but it passed vLLM's full persistent page table into the non-chunked single-user prefill path. That table is sized for the request's maximum block capacity, so columns after the allocated prompt blocks are zero-filled padding.

The inherited `prefill_forward_single_user_text` path does not slice the table during normal, non-chunked prefill. It forwards the full table into `prepare_inputs_prefill` and `ttnn_prefill_forward`. The prefill attention path uses the table width to determine how much K/V state to write, so the padded zero entries direct those extra writes to physical KV block 0. This can overwrite valid prompt K/V in block 0 before decode starts.

The old Qwen3-VL comment said the parent method handled page-table slicing, but that is only true for the chunked or prefix-cached branch. The normal prefill branch [passes the supplied table through unchanged](https://github.com/tenstorrent/tt-metal/blob/87a43f86f1620e5f5ec967ae5febba7987f24345/models/tt_transformers/tt/generator.py#L1235-L1251).

This change slices the page table to the blocks required by `decoding_pos` before calling the single-user prefill method. That matches the established pattern in:

- [Qwen2.5-VL](https://github.com/tenstorrent/tt-metal/blob/87a43f86f1620e5f5ec967ae5febba7987f24345/models/demos/qwen25_vl/tt/generator.py#L58-L69)
- [the common model executor](https://github.com/tenstorrent/tt-metal/blob/87a43f86f1620e5f5ec967ae5febba7987f24345/models/common/models/executor.py#L891-L900)
- [the shared TT transformer generator](https://github.com/tenstorrent/tt-metal/blob/87a43f86f1620e5f5ec967ae5febba7987f24345/models/tt_transformers/tt/generator.py#L766-L779)

A focused unit test verifies that Qwen3-VL calls `_get_prefill_user_page_table` with the actual multimodal decoding position and forwards only the returned slice.

### Notes for reviewers
The behavioral change is limited to Qwen3-VL multimodal prefill. Decode page-table handling is unchanged.

Validation:
- `python3 -m py_compile models/demos/qwen3_vl/tt/generator_vllm.py models/demos/qwen3_vl/tests/test_generator_vllm.py`
- `git diff --check origin/main...HEAD`
- Focused pytest was not run locally because the available system Python does not have pytest installed (`No module named pytest`).
- CI: https://github.com/tenstorrent/tt-metal/actions/runs/30254783587

Made with [Cursor](https://cursor.com)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=viktorpus/fix-qwen3-vl-prefill-page-table-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:viktorpus/fix-qwen3-vl-prefill-page-table-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=viktorpus/fix-qwen3-vl-prefill-page-table-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:viktorpus/fix-qwen3-vl-prefill-page-table-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=viktorpus/fix-qwen3-vl-prefill-page-table-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:viktorpus/fix-qwen3-vl-prefill-page-table-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=viktorpus/fix-qwen3-vl-prefill-page-table-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:viktorpus/fix-qwen3-vl-prefill-page-table-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=viktorpus/fix-qwen3-vl-prefill-page-table-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:viktorpus/fix-qwen3-vl-prefill-page-table-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=viktorpus/fix-qwen3-vl-prefill-page-table-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:viktorpus/fix-qwen3-vl-prefill-page-table-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=viktorpus/fix-qwen3-vl-prefill-page-table-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:viktorpus/fix-qwen3-vl-prefill-page-table-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=viktorpus/fix-qwen3-vl-prefill-page-table-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:viktorpus/fix-qwen3-vl-prefill-page-table-main)