### PR TITLE
fabric: make trimmed speedy credits packet-size aware

### DIFF
--- a/tests/tt_metal/tt_fabric/fabric_router/test_channel_trimming_capture.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_channel_trimming_capture.cpp
@@ -1572,6 +1572,105 @@ TEST_F(Fabric1DChannelTrimmingCaptureAndOverrideFixture, UnicastTrafficWithCaptu
 // bitfield merge logic using synthetic data.
 // ============================================================================
 
+TEST(ChannelTrimmingFastPath, DerivesPacketSizeOnlyFromUsedVC0Senders) {
+    ChannelTrimmingOverrides entry{};
+    entry.sender_channel_used_bitfield_by_vc = 0x1;
+    entry.sender_channel_max_packet_size_seen_bytes_by_vc[0] = 13920;
+    entry.sender_channel_max_packet_size_seen_bytes_by_vc[1] = 15000;
+
+    auto info = try_derive_vc0_trim_fast_path_info(entry, 4, ChannelTrimmingGlobalOverrides{});
+
+    ASSERT_TRUE(info.has_value());
+    EXPECT_TRUE(info->worker_only_nonforwarding);
+    ASSERT_TRUE(info->local_sender_max_packet_size_bytes.has_value());
+    EXPECT_EQ(*info->local_sender_max_packet_size_bytes, 13920);
+    EXPECT_FALSE(info->peer_sender_max_packet_size_bytes.has_value());
+}
+
+TEST(ChannelTrimmingFastPath, BoundsPacketSizeScanToCaptureStorage) {
+    ChannelTrimmingOverrides entry{};
+    entry.sender_channel_used_bitfield_by_vc = std::numeric_limits<uint16_t>::max();
+    entry.sender_channel_max_packet_size_seen_bytes_by_vc.back() = 13920;
+
+    auto info = try_derive_vc0_trim_fast_path_info(
+        entry, std::numeric_limits<std::size_t>::max(), ChannelTrimmingGlobalOverrides{});
+
+    ASSERT_TRUE(info.has_value());
+    ASSERT_TRUE(info->local_sender_max_packet_size_bytes.has_value());
+    EXPECT_EQ(*info->local_sender_max_packet_size_bytes, 13920);
+}
+
+TEST(ChannelTrimmingFastPath, LeavesPacketSizeUnknownWhenVC0HasNoSenderTraffic) {
+    ChannelTrimmingOverrides entry{};
+    entry.receiver_channel_data_forwarded_bitfield_by_vc = 0x1;
+
+    auto info = try_derive_vc0_trim_fast_path_info(entry, 4, ChannelTrimmingGlobalOverrides{});
+
+    ASSERT_TRUE(info.has_value());
+    EXPECT_TRUE(info->terminal_only_nonforwarding);
+    EXPECT_FALSE(info->local_sender_max_packet_size_bytes.has_value());
+}
+
+TEST(ChannelTrimmingFastPath, PacketSizeDoesNotBypassVC0GlobalOverride) {
+    ChannelTrimmingOverrides entry{};
+    entry.sender_channel_used_bitfield_by_vc = 0x1;
+    entry.sender_channel_max_packet_size_seen_bytes_by_vc[0] = 13920;
+    ChannelTrimmingGlobalOverrides global_overrides{};
+    global_overrides.per_vc[0].force_enable_all_sender_channels = true;
+
+    EXPECT_FALSE(try_derive_vc0_trim_fast_path_info(entry, 4, global_overrides).has_value());
+}
+
+TEST(ChannelTrimmingFastPath, CreditAmortizationPreservesReferenceByteBudget) {
+    constexpr uint32_t reference_packet_size_bytes = 4448;
+
+    EXPECT_EQ(limit_credit_amortization_frequency_by_packet_size(4, reference_packet_size_bytes, std::nullopt), 1);
+    EXPECT_EQ(limit_credit_amortization_frequency_by_packet_size(4, reference_packet_size_bytes, 4448), 4);
+    EXPECT_EQ(limit_credit_amortization_frequency_by_packet_size(4, reference_packet_size_bytes, 5000), 3);
+    EXPECT_EQ(limit_credit_amortization_frequency_by_packet_size(4, reference_packet_size_bytes, 13920), 1);
+    EXPECT_EQ(limit_credit_amortization_frequency_by_packet_size(2, reference_packet_size_bytes, 7616), 1);
+    EXPECT_EQ(limit_credit_amortization_frequency_by_packet_size(0, reference_packet_size_bytes, std::nullopt), 0);
+    EXPECT_EQ(limit_credit_amortization_frequency_by_packet_size(4, 0, std::nullopt), 4);
+    EXPECT_EQ(limit_credit_amortization_frequency_by_packet_size(4, reference_packet_size_bytes, 0), 1);
+}
+
+TEST(ChannelTrimmingFastPath, PropagatesPeerPacketSizeIndependentlyOfTerminalSpeedyRx) {
+    Vc0TrimFastPathInfo local_info{};
+    Vc0TrimFastPathInfo peer_info{};
+    peer_info.local_sender_max_packet_size_bytes = 13920;
+
+    apply_vc0_trim_fast_path_peer_info(local_info, peer_info, false);
+
+    EXPECT_EQ(local_info.peer_sender_max_packet_size_bytes, 13920);
+    EXPECT_FALSE(local_info.enable_terminal_speedy_rx);
+}
+
+TEST(ChannelTrimmingFastPath, EnablesTerminalSpeedyRxOnlyForMatching2DPeer) {
+    Vc0TrimFastPathInfo local_info{};
+    local_info.terminal_only_nonforwarding = true;
+    Vc0TrimFastPathInfo peer_info{};
+    peer_info.worker_only_nonforwarding = true;
+
+    apply_vc0_trim_fast_path_peer_info(local_info, peer_info, false);
+    EXPECT_FALSE(local_info.enable_terminal_speedy_rx);
+
+    apply_vc0_trim_fast_path_peer_info(local_info, peer_info, true);
+    EXPECT_TRUE(local_info.enable_terminal_speedy_rx);
+}
+
+TEST(ChannelTrimmingFastPath, UsesSharedSpeedyEligibilityPredicate) {
+    Vc0TrimFastPathInfo info{};
+    EXPECT_TRUE(vc0_speedy_path_enabled(1, false, info));
+    EXPECT_FALSE(vc0_speedy_path_enabled(1, true, info));
+
+    info.worker_only_nonforwarding = true;
+    EXPECT_TRUE(vc0_speedy_path_enabled(4, true, info));
+
+    info.worker_only_nonforwarding = false;
+    info.enable_terminal_speedy_rx = true;
+    EXPECT_TRUE(vc0_speedy_path_enabled(4, true, info));
+}
+
 // Test: Parse a global override YAML with force_enable_all for VC1
 TEST(ChannelTrimmingGlobalOverride, ParseForceEnableAllVC1) {
     // Write a temporary YAML file

--- a/tt_metal/api/tt-metalium/experimental/fabric/control_plane.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/control_plane.hpp
@@ -18,6 +18,7 @@
 
 #include <map>
 #include <memory>
+#include <optional>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -156,6 +157,8 @@ public:
     FabricNodeId get_fabric_node_id_from_physical_chip_id(ChipId physical_chip_id) const;
     // Return physical chip id from fabric node id
     ChipId get_physical_chip_id_from_fabric_node_id(const FabricNodeId& fabric_node_id) const;
+    // Non-fatal variant for optional remote-node metadata.
+    std::optional<ChipId> try_get_physical_chip_id_from_fabric_node_id(const FabricNodeId& fabric_node_id) const;
     // Return fabric node id from ASIC id
     FabricNodeId get_fabric_node_id_from_asic_id(uint64_t asic_id) const;
     // Return user physical mesh ids
@@ -237,6 +240,10 @@ public:
 
     // Peer fabric node (and its Ethernet channel) connected to `fabric_node_id` on `chan_id` via one physical hop
     // (intra-mesh or inter-mesh).
+    std::optional<std::pair<FabricNodeId, chan_id_t>> try_get_connected_mesh_chip_chan_ids(
+        FabricNodeId fabric_node_id, chan_id_t chan_id) const;
+
+    // Fatal variant for callers that require a complete physical-link mapping.
     std::pair<FabricNodeId, chan_id_t> get_connected_mesh_chip_chan_ids(
         FabricNodeId fabric_node_id, chan_id_t chan_id) const;
 

--- a/tt_metal/fabric/channel_trimming_import.cpp
+++ b/tt_metal/fabric/channel_trimming_import.cpp
@@ -59,8 +59,11 @@ std::optional<Vc0TrimFastPathInfo> try_derive_vc0_trim_fast_path_info_impl(
 
     Vc0TrimFastPathInfo info{};
 
-    const std::size_t vc0_width = std::min<std::size_t>(actual_sender_channels_vc0, 8u * sizeof(uint16_t));
-    const uint16_t vc0_mask = vc0_width == 0 ? 0 : static_cast<uint16_t>((1u << vc0_width) - 1u);
+    const std::size_t vc0_mask_width =
+        std::min<std::size_t>(actual_sender_channels_vc0, std::numeric_limits<uint16_t>::digits);
+    const std::size_t packet_size_scan_width =
+        std::min(vc0_mask_width, entry.sender_channel_max_packet_size_seen_bytes_by_vc.size());
+    const uint16_t vc0_mask = vc0_mask_width == 0 ? 0 : static_cast<uint16_t>((1u << vc0_mask_width) - 1u);
     const uint16_t vc0_sender_mask = entry.sender_channel_used_bitfield_by_vc & vc0_mask;
     const bool vc0_sender_idle = vc0_sender_mask == 0;
     const bool vc0_worker_only = vc0_sender_mask == 0x1u;
@@ -73,6 +76,17 @@ std::optional<Vc0TrimFastPathInfo> try_derive_vc0_trim_fast_path_info_impl(
     info.terminal_only_nonforwarding =
         vc0_sender_idle && vc0_receiver_observed_traffic && !vc0_has_downstream_router_forwarding;
     info.terminal_or_source_only = (vc0_sender_idle || vc0_worker_only) && vc0_has_no_downstream_forwarding;
+
+    uint16_t max_packet_size_bytes = 0;
+    for (std::size_t channel = 0; channel < packet_size_scan_width; ++channel) {
+        if ((vc0_sender_mask & (1u << channel)) != 0) {
+            max_packet_size_bytes =
+                std::max(max_packet_size_bytes, entry.sender_channel_max_packet_size_seen_bytes_by_vc[channel]);
+        }
+    }
+    if (max_packet_size_bytes != 0) {
+        info.local_sender_max_packet_size_bytes = max_packet_size_bytes;
+    }
 
     return info;
 }
@@ -149,6 +163,58 @@ std::optional<Vc0TrimFastPathInfo> try_derive_vc0_trim_fast_path_info(
     std::size_t actual_sender_channels_vc0,
     const ChannelTrimmingGlobalOverrides& global_overrides) {
     return try_derive_vc0_trim_fast_path_info_impl(entry, actual_sender_channels_vc0, global_overrides);
+}
+
+bool vc0_speedy_path_enabled(
+    std::size_t actual_sender_channels_vc0, bool deadlock_avoidance_enabled, const Vc0TrimFastPathInfo& info) {
+    return (actual_sender_channels_vc0 == 1 && !deadlock_avoidance_enabled) || info.worker_only_nonforwarding ||
+           info.enable_terminal_speedy_rx;
+}
+
+void apply_vc0_trim_fast_path_peer_info(
+    Vc0TrimFastPathInfo& local_info, const Vc0TrimFastPathInfo& peer_info, bool allow_terminal_speedy_rx) {
+    local_info.peer_sender_max_packet_size_bytes = peer_info.local_sender_max_packet_size_bytes;
+    local_info.enable_terminal_speedy_rx =
+        allow_terminal_speedy_rx && local_info.terminal_only_nonforwarding && peer_info.worker_only_nonforwarding;
+}
+
+uint32_t limit_credit_amortization_frequency_by_packet_size(
+    uint32_t default_frequency,
+    uint32_t reference_packet_size_bytes,
+    std::optional<uint16_t> max_packet_size_bytes,
+    bool log_missing_packet_size_metadata) {
+    if (default_frequency == 0 || reference_packet_size_bytes == 0) {
+        return default_frequency;
+    }
+    if (!max_packet_size_bytes.has_value() || *max_packet_size_bytes == 0) {
+        if (log_missing_packet_size_metadata && default_frequency != 1) {
+            log_debug(
+                tt::LogFabric,
+                "Channel trimming: limiting credit amortization frequency from {} to 1 because packet-size metadata "
+                "is unavailable",
+                default_frequency);
+        }
+        return 1;
+    }
+    if (*max_packet_size_bytes <= reference_packet_size_bytes) {
+        return default_frequency;
+    }
+
+    const uint64_t reference_batch_size_bytes = static_cast<uint64_t>(default_frequency) * reference_packet_size_bytes;
+    const uint32_t packet_limited_frequency =
+        static_cast<uint32_t>(reference_batch_size_bytes / *max_packet_size_bytes);
+    const uint32_t limited_frequency = std::max<uint32_t>(std::min(default_frequency, packet_limited_frequency), 1);
+    if (limited_frequency != default_frequency) {
+        log_debug(
+            tt::LogFabric,
+            "Channel trimming: limiting credit amortization frequency from {} to {} for observed packet size {} bytes "
+            "against reference packet size {} bytes",
+            default_frequency,
+            limited_frequency,
+            *max_packet_size_bytes,
+            reference_packet_size_bytes);
+    }
+    return limited_frequency;
 }
 
 ChannelTrimmingOverrideMap load_channel_trimming_overrides(const std::string& yaml_path) {

--- a/tt_metal/fabric/channel_trimming_import.hpp
+++ b/tt_metal/fabric/channel_trimming_import.hpp
@@ -28,6 +28,8 @@ struct Vc0TrimFastPathInfo {
     bool worker_only_nonforwarding = false;
     bool terminal_only_nonforwarding = false;
     bool enable_terminal_speedy_rx = false;
+    std::optional<uint16_t> local_sender_max_packet_size_bytes;
+    std::optional<uint16_t> peer_sender_max_packet_size_bytes;
 };
 
 // Key: pack(chip_id, eth_channel_id) → overrides
@@ -93,6 +95,25 @@ std::optional<Vc0TrimFastPathInfo> try_derive_vc0_trim_fast_path_info(
     const ChannelTrimmingOverrides& entry,
     std::size_t actual_sender_channels_vc0,
     const ChannelTrimmingGlobalOverrides& global_overrides);
+
+// Whether VC0 can use the speedy path after trimming has been resolved.
+bool vc0_speedy_path_enabled(
+    std::size_t actual_sender_channels_vc0, bool deadlock_avoidance_enabled, const Vc0TrimFastPathInfo& info);
+
+// Propagate sender packet-size metadata across a physical link. Terminal speedy RX
+// remains a 2D-only optimization and additionally requires a matching worker-only peer.
+void apply_vc0_trim_fast_path_peer_info(
+    Vc0TrimFastPathInfo& local_info, const Vc0TrimFastPathInfo& peer_info, bool allow_terminal_speedy_rx);
+
+// Keep the existing packet-count amortization for normal-sized packets, but cap
+// the number of packets batched so that a batch does not exceed the same byte
+// budget when a trimmed speedy path carries larger packets. Missing packet-size
+// metadata (including an observed size of zero) uses the conservative single-packet cadence.
+uint32_t limit_credit_amortization_frequency_by_packet_size(
+    uint32_t default_frequency,
+    uint32_t reference_packet_size_bytes,
+    std::optional<uint16_t> max_packet_size_bytes,
+    bool log_missing_packet_size_metadata = true);
 
 // Apply global overrides to a per-router trimming entry using replacement semantics.
 // Sender and receiver overrides are applied independently per VC.

--- a/tt_metal/fabric/compute_mesh_router_builder.cpp
+++ b/tt_metal/fabric/compute_mesh_router_builder.cpp
@@ -17,6 +17,7 @@
 #include "tt_metal/third_party/umd/device/api/umd/device/types/core_coordinates.hpp"
 #include "llrt/metal_soc_descriptor.hpp"
 #include "tt_metal.hpp"
+#include <tt-logger/tt-logger.hpp>
 #include <tt_stl/assert.hpp>
 #include <tt_stl/fmt.hpp>
 
@@ -357,39 +358,90 @@ std::unique_ptr<ComputeMeshRouterBuilder> ComputeMeshRouterBuilder::build(
                   builder_context.get_channel_trimming_global_overrides())
             : std::nullopt;
 
-    // If this router trims down to a terminal-only VC0 shape, inspect the exact
-    // peer router on this physical link and only enable speedy RX when that peer
-    // independently trims down to the matching worker-only source shape.
+    // Inspect the exact peer router on this physical link whenever this local
+    // router can use a speedy VC0 path. Its captured sender packet size controls
+    // this router's receiver-credit cadence. The terminal speedy-RX decision is
+    // separately constrained to the existing non-UDM Fabric2D configuration.
     auto maybe_finalize_vc0_fast_path_pair = [&]() {
-        if (!fabric_context.is_2D_routing_enabled() || fabric_tensix_extension_udm_mode || location.is_dispatch_link ||
-            local_node.mesh_id != location.remote_node.mesh_id || !local_vc0_fast_path_info.has_value() ||
-            !(local_vc0_fast_path_info->worker_only_nonforwarding ||
-              local_vc0_fast_path_info->terminal_only_nonforwarding)) {
+        if (!local_vc0_fast_path_info.has_value()) {
             return;
         }
 
-        const auto [connected_peer_node, connected_peer_chan] =
-            control_plane.get_connected_mesh_chip_chan_ids(local_node, location.eth_chan);
+        // A terminal may become speedy only after its exact peer is resolved;
+        // all other conditions use the same predicate as the ERISC builder.
+        const bool local_can_use_speedy_vc0 = vc0_speedy_path_enabled(
+                                                  actual_sender_channels_per_vc[0],
+                                                  fabric_context.need_deadlock_avoidance_support(eth_direction),
+                                                  *local_vc0_fast_path_info) ||
+                                              local_vc0_fast_path_info->terminal_only_nonforwarding;
+        if (!local_can_use_speedy_vc0) {
+            return;
+        }
+
+        const auto connected_peer = control_plane.try_get_connected_mesh_chip_chan_ids(local_node, location.eth_chan);
+        if (!connected_peer.has_value()) {
+            log_debug(
+                tt::LogFabric,
+                "Channel trimming: unable to resolve peer for chip {} channel {}; using conservative receiver credit "
+                "amortization",
+                device->id(),
+                location.eth_chan);
+            return;
+        }
+        const auto [connected_peer_node, connected_peer_chan] = *connected_peer;
         if (connected_peer_node != location.remote_node) {
+            log_debug(
+                tt::LogFabric,
+                "Channel trimming: resolved peer {} for chip {} channel {} does not match router peer {}; using "
+                "conservative receiver credit amortization",
+                connected_peer_node,
+                device->id(),
+                location.eth_chan,
+                location.remote_node);
             return;
         }
 
         auto peer_direction = control_plane.get_forwarding_direction(connected_peer_node, local_node);
         if (!peer_direction.has_value()) {
+            log_debug(
+                tt::LogFabric,
+                "Channel trimming: unable to determine the peer forwarding direction from {} to {}; using conservative "
+                "receiver credit amortization",
+                connected_peer_node,
+                local_node);
             return;
         }
 
+        // Logical-to-physical mapping membership guarantees that routing-channel metadata was seeded for this node.
+        const auto peer_physical_chip_id =
+            control_plane.try_get_physical_chip_id_from_fabric_node_id(connected_peer_node);
+        if (!peer_physical_chip_id.has_value()) {
+            log_debug(
+                tt::LogFabric,
+                "Channel trimming: peer {} is not mapped to a local physical chip; using conservative receiver "
+                "credit amortization",
+                connected_peer_node);
+            return;
+        }
         const auto peer_channel_counts = compute_router_channel_counts(
             fabric_context, control_plane, connected_peer_node, *peer_direction, location.is_dispatch_link);
-        const auto peer_physical_chip_id = control_plane.get_physical_chip_id_from_fabric_node_id(connected_peer_node);
         auto peer_vc0_fast_path_info = resolve_vc0_trim_fast_path_info(
-            builder_context, peer_physical_chip_id, connected_peer_chan, peer_channel_counts);
+            builder_context, *peer_physical_chip_id, connected_peer_chan, peer_channel_counts);
         if (!peer_vc0_fast_path_info.has_value()) {
+            log_debug(
+                tt::LogFabric,
+                "Channel trimming: no peer capture entry for chip {} channel {}; using conservative receiver credit "
+                "amortization",
+                *peer_physical_chip_id,
+                connected_peer_chan);
             return;
         }
 
-        local_vc0_fast_path_info->enable_terminal_speedy_rx =
-            local_vc0_fast_path_info->terminal_only_nonforwarding && peer_vc0_fast_path_info->worker_only_nonforwarding;
+        apply_vc0_trim_fast_path_peer_info(
+            *local_vc0_fast_path_info,
+            *peer_vc0_fast_path_info,
+            fabric_context.is_2D_routing_enabled() && local_node.mesh_id == location.remote_node.mesh_id &&
+                !fabric_tensix_extension_udm_mode && !location.is_dispatch_link);
     };
     maybe_finalize_vc0_fast_path_pair();
 

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -1264,24 +1264,36 @@ FabricNodeId ControlPlane::get_fabric_node_id_from_physical_chip_id(ChipId physi
 }
 
 ChipId ControlPlane::get_physical_chip_id_from_fabric_node_id(const FabricNodeId& fabric_node_id) const {
-    auto it = logical_mesh_chip_id_to_physical_chip_id_mapping_.find(fabric_node_id);
+    auto physical_chip_id = try_get_physical_chip_id_from_fabric_node_id(fabric_node_id);
     TT_FATAL(
-        it != logical_mesh_chip_id_to_physical_chip_id_mapping_.end(),
+        physical_chip_id.has_value(),
         "FabricNodeId {} not found in logical-to-physical chip mapping. Check for a fabric mesh/topology "
         "mismatch or a node outside the configured fabric cluster.",
         fabric_node_id);
+    return *physical_chip_id;
+}
+
+std::optional<ChipId> ControlPlane::try_get_physical_chip_id_from_fabric_node_id(
+    const FabricNodeId& fabric_node_id) const {
+    auto it = logical_mesh_chip_id_to_physical_chip_id_mapping_.find(fabric_node_id);
+    if (it == logical_mesh_chip_id_to_physical_chip_id_mapping_.end()) {
+        return std::nullopt;
+    }
     return it->second;
 }
 
-std::pair<FabricNodeId, chan_id_t> ControlPlane::get_connected_mesh_chip_chan_ids(
+std::optional<std::pair<FabricNodeId, chan_id_t>> ControlPlane::try_get_connected_mesh_chip_chan_ids(
     FabricNodeId fabric_node_id, chan_id_t chan_id) const {
     // TODO: simplify this and use Global Physical Desc in ControlPlane soon
     const auto& intra_mesh_connectivity = this->mesh_graph_->get_intra_mesh_connectivity();
     const auto& inter_mesh_connectivity = this->mesh_graph_->get_inter_mesh_connectivity();
     RoutingDirection port_direction = RoutingDirection::NONE;
     routing_plane_id_t routing_plane_id = 0;
-    for (const auto& [direction, eth_chans] :
-         this->router_port_directions_to_physical_eth_chan_map_.at(fabric_node_id)) {
+    const auto source_channels_it = this->router_port_directions_to_physical_eth_chan_map_.find(fabric_node_id);
+    if (source_channels_it == this->router_port_directions_to_physical_eth_chan_map_.end()) {
+        return std::nullopt;
+    }
+    for (const auto& [direction, eth_chans] : source_channels_it->second) {
         for (const auto& eth_chan : eth_chans) {
             if (eth_chan == chan_id) {
                 port_direction = direction;
@@ -1306,11 +1318,17 @@ std::pair<FabricNodeId, chan_id_t> ControlPlane::get_connected_mesh_chip_chan_id
                     .at(fabric_node_id.chip_id)
                     .port_direction;
             // Find the eth chan on connected dst_fabric_chip_id based on routing_plane_id
-            const auto& dst_fabric_node = FabricNodeId(fabric_node_id.mesh_id, dst_fabric_chip_id);
-            const auto& dst_fabric_chip_eth_chans =
-                this->router_port_directions_to_physical_eth_chan_map_.at(dst_fabric_node);
-            for (const auto& [direction, eth_chans] : dst_fabric_chip_eth_chans) {
-                if (direction == reverse_port_direction) {
+            const auto dst_fabric_node = FabricNodeId(fabric_node_id.mesh_id, dst_fabric_chip_id);
+            const auto dst_channels_it = this->router_port_directions_to_physical_eth_chan_map_.find(dst_fabric_node);
+            if (dst_channels_it == this->router_port_directions_to_physical_eth_chan_map_.end()) {
+                continue;
+            }
+            for (const auto& [direction, eth_chans] : dst_channels_it->second) {
+                if (direction == reverse_port_direction && !eth_chans.empty()) {
+                    if (routing_plane_id >= eth_chans.size()) {
+                        // A routing-plane mismatch cannot identify the exact physical peer channel.
+                        return std::nullopt;
+                    }
                     return std::make_pair(dst_fabric_node, eth_chans[routing_plane_id]);
                 }
             }
@@ -1343,11 +1361,13 @@ std::pair<FabricNodeId, chan_id_t> ControlPlane::get_connected_mesh_chip_chan_id
                     .at(fabric_node_id.mesh_id)
                     .port_direction;
             // Find the eth chan on connected dst_fabric_mesh_id based on routing_plane_id
-            const auto& dst_fabric_node = FabricNodeId(dst_fabric_mesh_id, dst_connected_fabric_chip_id);
-            const auto& dst_fabric_chip_eth_chans =
-                this->router_port_directions_to_physical_eth_chan_map_.at(dst_fabric_node);
-            for (const auto& [direction, eth_chans] : dst_fabric_chip_eth_chans) {
-                if (direction == reverse_port_direction) {
+            const auto dst_fabric_node = FabricNodeId(dst_fabric_mesh_id, dst_connected_fabric_chip_id);
+            const auto dst_channels_it = this->router_port_directions_to_physical_eth_chan_map_.find(dst_fabric_node);
+            if (dst_channels_it == this->router_port_directions_to_physical_eth_chan_map_.end()) {
+                continue;
+            }
+            for (const auto& [direction, eth_chans] : dst_channels_it->second) {
+                if (direction == reverse_port_direction && !eth_chans.empty()) {
                     if (routing_plane_id >= eth_chans.size()) {
                         // Only TG non-standard intermesh connections hits this
                         return std::make_pair(dst_fabric_node, eth_chans[0]);
@@ -1357,8 +1377,15 @@ std::pair<FabricNodeId, chan_id_t> ControlPlane::get_connected_mesh_chip_chan_id
             }
         }
     }
-    TT_FATAL(false, "Could not find connected mesh chip chan ids for {} on chan {}", fabric_node_id, chan_id);
-    return std::make_pair(FabricNodeId(MeshId{0}, 0), 0);
+    return std::nullopt;
+}
+
+std::pair<FabricNodeId, chan_id_t> ControlPlane::get_connected_mesh_chip_chan_ids(
+    FabricNodeId fabric_node_id, chan_id_t chan_id) const {
+    auto peer = try_get_connected_mesh_chip_chan_ids(fabric_node_id, chan_id);
+    TT_FATAL(
+        peer.has_value(), "Could not find connected mesh chip chan ids for {} on chan {}", fabric_node_id, chan_id);
+    return *peer;
 }
 
 std::vector<chan_id_t> ControlPlane::get_valid_eth_chans_on_routing_plane(

--- a/tt_metal/fabric/erisc_datamover_builder.cpp
+++ b/tt_metal/fabric/erisc_datamover_builder.cpp
@@ -1068,11 +1068,6 @@ FabricEriscDatamoverBuilder::CompileTimeArgs FabricEriscDatamoverBuilder::get_co
     // peer that makes the speedy receiver path safe on this link.
     const bool vc0_is_terminal_or_source_only_after_trim =
         vc0_trim_fast_path_info_.has_value() && vc0_trim_fast_path_info_->terminal_or_source_only;
-    const bool vc0_is_worker_only_nonforwarding_after_trim =
-        vc0_trim_fast_path_info_.has_value() && vc0_trim_fast_path_info_->worker_only_nonforwarding;
-    const bool vc0_enable_terminal_speedy_rx_after_trim =
-        vc0_trim_fast_path_info_.has_value() && vc0_trim_fast_path_info_->enable_terminal_speedy_rx;
-
     const bool base_enable_deadlock_avoidance = fabric_context.need_deadlock_avoidance_support(this->direction_);
     const bool final_enable_deadlock_avoidance =
         base_enable_deadlock_avoidance && !vc0_is_terminal_or_source_only_after_trim;
@@ -1082,9 +1077,10 @@ FabricEriscDatamoverBuilder::CompileTimeArgs FabricEriscDatamoverBuilder::get_co
     // shape, and optionally enable a terminal-only speedy receiver when the
     // host has already proven that the exact peer on this link is the
     // matching worker-only source router.
-    const bool enable_speedy_vc0 = (actual_sender_channels_vc0 == 1 && !base_enable_deadlock_avoidance) ||
-                                   vc0_is_worker_only_nonforwarding_after_trim ||
-                                   vc0_enable_terminal_speedy_rx_after_trim;
+    const bool enable_speedy_vc0 = vc0_speedy_path_enabled(
+        actual_sender_channels_vc0,
+        base_enable_deadlock_avoidance,
+        vc0_trim_fast_path_info_.value_or(Vc0TrimFastPathInfo{}));
 
     // ===== Build named compile-time args (all non-pool/channel-mapping args) =====
     std::unordered_map<std::string, uint32_t> named_args;
@@ -1377,6 +1373,24 @@ FabricEriscDatamoverBuilder::CompileTimeArgs FabricEriscDatamoverBuilder::get_co
             uint32_t sender_slots = static_cast<uint32_t>(static_alloc->get_sender_channel_number_of_slots(0));
             receiver_amort_freq = std::max<uint32_t>(std::min<uint32_t>(4u, receiver_slots / 2), 1);
             sender_amort_freq = std::max<uint32_t>(std::min<uint32_t>(2u, sender_slots / 2), 1);
+
+            if (vc0_trim_fast_path_info_.has_value()) {
+                // Intentionally use the default payload here, rather than the configured
+                // maximum packet size. The original packet-count cadence was tuned for
+                // this byte budget; using an override-aware maximum would make the cap a no-op.
+                const uint32_t reference_packet_size_bytes =
+                    static_cast<uint32_t>(FabricEriscDatamoverBuilder::default_packet_payload_size_bytes) +
+                    static_cast<uint32_t>(fabric_context.get_fabric_packet_header_size_bytes());
+                sender_amort_freq = limit_credit_amortization_frequency_by_packet_size(
+                    sender_amort_freq,
+                    reference_packet_size_bytes,
+                    vc0_trim_fast_path_info_->local_sender_max_packet_size_bytes,
+                    !vc0_trim_fast_path_info_->terminal_only_nonforwarding);
+                receiver_amort_freq = limit_credit_amortization_frequency_by_packet_size(
+                    receiver_amort_freq,
+                    reference_packet_size_bytes,
+                    vc0_trim_fast_path_info_->peer_sender_max_packet_size_bytes);
+            }
         }
     }
     named_args["SENDER_CREDIT_AMORTIZATION_FREQUENCY"] = sender_amort_freq;

--- a/tt_metal/fabric/fabric_context.cpp
+++ b/tt_metal/fabric/fabric_context.cpp
@@ -296,7 +296,7 @@ bool FabricContext::has_z_router_on_device(
     // Check if this fabric node has Z router ethernet channels
     // Query control plane for active channels and check if any have Z direction
 
-    // Try to get active channels - if node doesn't exist, the map lookup will return empty
+    // Every configured fabric node has channel metadata; an absent entry is a topology error.
     auto active_channels = control_plane.get_active_fabric_eth_channels(fabric_node_id);
 
     // If no channels, node doesn't have Z router (or isn't configured yet)


### PR DESCRIPTION
## Summary
- make trimmed speedy VC0 credit amortization packet-size aware
- preserve the default packet-byte credit budget for 14 KiB Galaxy high-bandwidth all-gather traffic
- resolve peer capture metadata conservatively and retain same-mesh terminal speedy-RX constraints

## Validation
- `cmake --build build --target fabric_unit_tests -j 2`
- `build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="ChannelTrimmingFastPath.*"` (8 passed)
- `git clang-format --diff origin/main`

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/channel-trimming-packet-size-aware)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/channel-trimming-packet-size-aware)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/channel-trimming-packet-size-aware)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/channel-trimming-packet-size-aware)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=pjosipovic/channel-trimming-packet-size-aware)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:pjosipovic/channel-trimming-packet-size-aware)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/channel-trimming-packet-size-aware)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/channel-trimming-packet-size-aware)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/channel-trimming-packet-size-aware)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/channel-trimming-packet-size-aware)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/channel-trimming-packet-size-aware)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/channel-trimming-packet-size-aware)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/channel-trimming-packet-size-aware)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/channel-trimming-packet-size-aware)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/channel-trimming-packet-size-aware)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/channel-trimming-packet-size-aware)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tm-fabric-tests.yaml/badge.svg?branch=pjosipovic/channel-trimming-packet-size-aware)](https://github.com/tenstorrent/tt-metal/actions/workflows/tm-fabric-tests.yaml?query=branch:pjosipovic/channel-trimming-packet-size-aware)