### PR TITLE
fix: replace snake_beta range reduction with four-stage Cody-Waite

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_snake_beta.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_snake_beta.h
@@ -14,8 +14,9 @@ namespace ckernel::sfpu {
 
 // SnakeBeta activation: y = x + sin²(α·x) / β.
 // Range-reduces α·x to (-π/2, π/2] then evaluates sin(a) via the calculate_sine() minimax
-// polynomial; sin² is even, so no quadrant sign-fix is needed. Valid for |α·x| < 32767·π
-// (≈1.03e5) before convert<vSMag16> saturates.
+// polynomial; sin² is even, so no quadrant sign-fix is needed. The reduction is a
+// four-stage Cody-Waite in fp32, so there is no saturation cliff; accuracy degrades
+// only as the fp32 spacing of α·x itself approaches a radian (#51116).
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, DataFormat data_format, int ITERATIONS = 8>
 inline void calculate_snake_beta(uint dst_index_x, uint dst_index_alpha, uint dst_index_beta, uint dst_index_out) {
     static_assert(
@@ -24,7 +25,18 @@ inline void calculate_snake_beta(uint dst_index_x, uint dst_index_alpha, uint ds
 
     constexpr uint dst_tile_size_sfpi = 32;
     constexpr float one_over_pi = 0.318309886183791f;
-    constexpr float pi_f = 3.141592653589793f;
+
+    // Cody-Waite split of -π across four fp32 terms, so the reduction stays exact
+    // for large quotients: -π = P0 + P1 + P2 + P3. Same technique calculate_sine()
+    // uses, but with the tail terms as literals rather than vConstFloatPrgm0/1,
+    // which the reciprocal owns here.
+    constexpr float P0 = -0x1.92p+1f;    // representable as bf16
+    constexpr float P1 = -0x1.fbp-11f;   // representable as fp16
+    constexpr float P2 = -0x1.5110b4p-21f;
+    constexpr float P3 = -0x1.7fp-47f;
+    // Shifting by 1.5*2^23 lands the integer in the mantissa, giving round-to-nearest
+    // without a conversion that can saturate.
+    constexpr float rounding_bias = 0x1.8p23f;
 
     // sin(a) minimax coefficients on a ∈ (-π/2, π/2]; mirror calculate_sine().
     constexpr float fp32_C3 = 0x1.5dc908p-19f;
@@ -46,12 +58,22 @@ inline void calculate_snake_beta(uint dst_index_x, uint dst_index_alpha, uint ds
 
         sfpi::vFloat ax = alpha * x;
 
-        // a = (ax/π - round(ax/π)) * π, single-stage reduction; vConstFloatPrgm0/1/2 are
-        // reserved for the reciprocal estimate so convert<vSMag16> is used instead.
-        sfpi::vFloat ax_over_pi = ax * one_over_pi;
-        sfpi::vSMag16 k = sfpi::convert<sfpi::vSMag16>(ax_over_pi, sfpi::RoundMode::Nearest);
-        sfpi::vFloat k_f = sfpi::convert<sfpi::vFloat>(k, sfpi::RoundMode::Nearest);
-        sfpi::vFloat a = (ax_over_pi - k_f) * pi_f;
+        // a = ax - round(ax/π)*π, four-stage Cody-Waite (#51116).
+        //
+        // The previous single-stage form rounded through convert<vSMag16>, whose
+        // sign + 15-bit magnitude saturates at ±32767. Past |ax/π| > 32767 the
+        // subtraction stopped cancelling, so `a` left (-π/2, π/2] and the degree-7
+        // polynomial diverged like a⁷ — finite-but-wrong at |ax| ≈ 1.03e5, then inf.
+        //
+        // Rounding via the mantissa-shift bias keeps the quotient in fp32, which has
+        // no such cliff, and splitting π across four terms keeps the subtraction
+        // accurate once the quotient is large. Branch-free: no v_if on data.
+        sfpi::vFloat j = ax * one_over_pi + rounding_bias;
+        j = j - rounding_bias;
+        sfpi::vFloat a = ax + j * P0;
+        a = a + j * P1;
+        a = a + j * P2;
+        a = a + j * P3;
 
         // sin(a) = a + a·s·poly(s), s = a².  PolynomialEvaluator::eval expands to a Horner chain.
         sfpi::vFloat s = a * a;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_snake_beta.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_snake_beta.h
@@ -14,8 +14,9 @@ namespace ckernel::sfpu {
 
 // SnakeBeta activation: y = x + sin²(α·x) / β.
 // Range-reduces α·x to (-π/2, π/2] then evaluates sin(a) via the calculate_sine() minimax
-// polynomial; sin² is even, so no quadrant sign-fix is needed. Valid for |α·x| < 32767·π
-// (≈1.03e5) before convert<vSMag16> saturates.
+// polynomial; sin² is even, so no quadrant sign-fix is needed. The reduction is a
+// four-stage Cody-Waite in fp32, so there is no saturation cliff; accuracy degrades
+// only as the fp32 spacing of α·x itself approaches a radian (#51116).
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, DataFormat data_format, int ITERATIONS = 8>
 inline void calculate_snake_beta(uint dst_index_x, uint dst_index_alpha, uint dst_index_beta, uint dst_index_out) {
     static_assert(
@@ -24,7 +25,18 @@ inline void calculate_snake_beta(uint dst_index_x, uint dst_index_alpha, uint ds
 
     constexpr uint dst_tile_size_sfpi = 32;
     constexpr float one_over_pi = 0.318309886183791f;
-    constexpr float pi_f = 3.141592653589793f;
+
+    // Cody-Waite split of -π across four fp32 terms, so the reduction stays exact
+    // for large quotients: -π = P0 + P1 + P2 + P3. Same technique calculate_sine()
+    // uses, but with the tail terms as literals rather than vConstFloatPrgm0/1,
+    // which the reciprocal owns here.
+    constexpr float P0 = -0x1.92p+1f;    // representable as bf16
+    constexpr float P1 = -0x1.fbp-11f;   // representable as fp16
+    constexpr float P2 = -0x1.5110b4p-21f;
+    constexpr float P3 = -0x1.7fp-47f;
+    // Shifting by 1.5*2^23 lands the integer in the mantissa, giving round-to-nearest
+    // without a conversion that can saturate.
+    constexpr float rounding_bias = 0x1.8p23f;
 
     // sin(a) minimax coefficients on a ∈ (-π/2, π/2]; mirror calculate_sine().
     constexpr float fp32_C3 = 0x1.5dc908p-19f;
@@ -46,12 +58,22 @@ inline void calculate_snake_beta(uint dst_index_x, uint dst_index_alpha, uint ds
 
         sfpi::vFloat ax = alpha * x;
 
-        // a = (ax/π - round(ax/π)) * π, single-stage reduction; vConstFloatPrgm0/1/2 are
-        // reserved for the reciprocal estimate so convert<vSMag16> is used instead.
-        sfpi::vFloat ax_over_pi = ax * one_over_pi;
-        sfpi::vSMag16 k = sfpi::convert<sfpi::vSMag16>(ax_over_pi, sfpi::RoundMode::Nearest);
-        sfpi::vFloat k_f = sfpi::convert<sfpi::vFloat>(k, sfpi::RoundMode::Nearest);
-        sfpi::vFloat a = (ax_over_pi - k_f) * pi_f;
+        // a = ax - round(ax/π)*π, four-stage Cody-Waite (#51116).
+        //
+        // The previous single-stage form rounded through convert<vSMag16>, whose
+        // sign + 15-bit magnitude saturates at ±32767. Past |ax/π| > 32767 the
+        // subtraction stopped cancelling, so `a` left (-π/2, π/2] and the degree-7
+        // polynomial diverged like a⁷ — finite-but-wrong at |ax| ≈ 1.03e5, then inf.
+        //
+        // Rounding via the mantissa-shift bias keeps the quotient in fp32, which has
+        // no such cliff, and splitting π across four terms keeps the subtraction
+        // accurate once the quotient is large. Branch-free: no v_if on data.
+        sfpi::vFloat j = ax * one_over_pi + rounding_bias;
+        j = j - rounding_bias;
+        sfpi::vFloat a = ax + j * P0;
+        a = a + j * P1;
+        a = a + j * P2;
+        a = a + j * P3;
 
         // sin(a) = a + a·s·poly(s), s = a².  PolynomialEvaluator::eval expands to a Horner chain.
         sfpi::vFloat s = a * a;


### PR DESCRIPTION
Fixes #51116. @mateusznowakTT — measurements below as asked, for both formats and before/after.

## The change

The reduction rounded through `convert<vSMag16>`, whose sign + 15-bit magnitude saturates at ±32767. Past `|ax/π| > 32767` the subtraction stopped cancelling, `a` left `(-π/2, π/2]`, and the degree-7 polynomial diverged like `a⁷`.

Replaced with the mantissa-shift rounding bias plus a four-stage Cody-Waite split of `-π`:

```cpp
sfpi::vFloat j = ax * one_over_pi + rounding_bias;   // 1.5*2^23
j = j - rounding_bias;
sfpi::vFloat a = ax + j * P0;
a = a + j * P1;
a = a + j * P2;
a = a + j * P3;
```

This is what `calculate_sine()` already does. The difference is that `P2`/`P3` are literals rather than `vConstFloatPrgm0/1`, since the reciprocal owns those registers in this kernel — that constraint is what pushed the original toward `vSMag16`.

The four constants sum to `-π` exactly in fp32:

```
P0 + P1 + P2 + P3 = -3.141592653589793
-π                = -3.141592653589793
```

## Branches and instruction count

**No branches on data** — no `v_if`, as requested. Straight-line code either way.

```
before   2 converts (vSMag16 round-trip) + 2 MADs
after    6 MADs
```

Net +2 MADs, −2 converts, no register pressure change (all four constants are immediates).

## Accuracy — fp32

ULP error against `sin²(αx)` computed in double:

| αx | before | after | true | ULP before | ULP after |
|---|---|---|---|---|---|
| 1.0000e+03 | 6.8370e-01 | 6.8373e-01 | 0.6837 | 524 | **1** |
| 1.0284e+05 | 1.3548e-03 | 1.2608e-03 | 0.0013 | 807,181 | **2** |
| 1.0304e+05 | **6.0304e+24** | 7.9218e-01 | 0.7922 | 693,424,944 | **1** |
| 1.0397e+05 | **inf** | 7.1610e-01 | 0.7161 | — | **28** |
| 1.5000e+05 | **inf** | 9.9713e-01 | 0.9971 | — | **1** |
| 1.0000e+06 | **inf** | 1.4371e-01 | 0.1225 | — | 1,591,598 |
| 1.0000e+07 | **inf** | 1.8686e-02 | 0.1769 | — | 27,002,719 |

Note the improvement is not only past the cliff: at `αx = 1e3`, well inside the old valid range, the single-stage reduction was already at **524 ULP** and this brings it to 1.

## Accuracy — bf16

| αx | before | after | true | abs err after |
|---|---|---|---|---|
| 1.0000e+03 | 6.8359e-01 | 6.8359e-01 | 0.6837 | 1.36e-04 |
| 1.0284e+05 | 1.3580e-03 | 1.2589e-03 | 0.0013 | 1.95e-06 |
| 1.0304e+05 | **3.2512e+20** | 7.9297e-01 | 0.7922 | 7.88e-04 |
| 1.5000e+05 | **inf** | 9.9609e-01 | 0.9971 | 1.03e-03 |

All within one bf16 ULP of the true value at that magnitude.

## What this does not fix, stated plainly

The last two fp32 rows are still large. That is not the reduction — it is the input. At `αx = 1e6` the fp32 spacing is 0.0625 rad, and at `1e7` it is 1.0 rad:

```
αx=1e5   fp32 ULP = 7.81e-03 rad
αx=1e6   fp32 ULP = 6.25e-02 rad
αx=1e7   fp32 ULP = 1.00e+00 rad
```

Once neighbouring representable inputs are a radian apart, `sin²` of them differ by up to 0.9 and no implementation can do better — the argument itself no longer carries the phase. What the fix removes is the **saturation cliff**: the output now stays inside `[0, 1]` for every finite input instead of returning `1e24` or `inf`, so the mathematical bound `x ≤ y ≤ x + 1/β` holds throughout.

If you would rather also flag the region where the input has lost phase information, that would be a separate decision (NaN? clamp? leave it?) and I would rather you pick.

## Verification status

Numbers above are from an fp32/bf16 port of the kernel arithmetic, matching how I measured the original report. **Not yet run on ttsim or HW** — happy to do the ttsim sweep next, and to help with the HW check and any perf tuning you want.

Both architectures got the identical file; they were byte-identical before and remain so.
