### PR TITLE
#50684: Shrink CoreRangeSet in generate_transpose_shard_spec to populated shards

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_gather.py
+++ b/tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_gather.py
@@ -349,6 +349,31 @@ def test_gather_tile_interleaved_to_sharded_no_spec(memory_layout, dtype, device
     )
 
 
+def test_gather_specless_sharded_output_grid_shrinks_height(device):
+    """Specless HEIGHT_SHARDED out via generate_transpose_shard_spec: tensor_h=128, shard_h=32 → 4 populated cores."""
+    compute_grid = device.compute_with_storage_grid_size()
+    if compute_grid.x * compute_grid.y <= 4:
+        pytest.skip("Device grid too small to observe shrink (need > 4 cores)")
+    out_mc = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1)
+    torch.manual_seed(12345)
+    x = torch.randn((1, 1, 128, 128), dtype=torch.bfloat16)
+    idx = torch.randint(0, 128, (1, 1, 128, 64), dtype=torch.int64)
+    ttnn_in = ttnn.from_torch(
+        x, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, device=device, memory_config=L1_INTERLEAVED
+    )
+    ttnn_idx = ttnn.from_torch(
+        idx, layout=ttnn.TILE_LAYOUT, dtype=ttnn.uint32, device=device, memory_config=L1_INTERLEAVED
+    )
+    result = ttnn.gather(ttnn_in, -1, index=ttnn_idx, memory_config=out_mc)
+    grid = result.memory_config().shard_spec.grid
+    assert grid.num_cores() == 4, f"Expected 4 populated cores, got {grid.num_cores()}"
+    expected = ttnn.num_cores_to_corerangeset(4, compute_grid, True)
+    assert grid == expected, f"Expected row-wise CoreRangeSet {expected}, got {grid}"
+    ref = torch.gather(x, -1, idx)
+    got = ttnn.to_torch(result.cpu().to(ttnn.ROW_MAJOR_LAYOUT))
+    assert_equal(ref, got)
+
+
 # ────────────────────────────────────────────────────────────────────────────────
 # Group C: RM — interleaved single-core + multi-core + sharded in/out, bf16 + f32.
 # ────────────────────────────────────────────────────────────────────────────────

--- a/tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_permute.py
+++ b/tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_permute.py
@@ -924,3 +924,92 @@ def test_permute_dram_sharded_fallback(device):
     ref = x.permute(0, 1, 3, 2)
     got = ttnn.to_torch(result.cpu().to(ttnn.ROW_MAJOR_LAYOUT))
     assert_with_ulp(ref, got, ulp_threshold=0)
+
+
+# Specless sharded output must shrink CoreRangeSet to populated shard count.
+
+
+def _permute_and_assert_shrink(device, shape, dims, out_layout, expected_grid_factory, n_expected):
+    compute_grid = device.compute_with_storage_grid_size()
+    if compute_grid.x * compute_grid.y < n_expected:
+        pytest.skip(f"Device grid too small for shrink test (need >= {n_expected} cores)")
+    torch.manual_seed(12345)
+    x = torch.rand(shape, dtype=torch.bfloat16)
+    ttnn_in = ttnn.from_torch(
+        x, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, device=device, memory_config=L1_INTERLEAVED
+    )
+    out_mc = ttnn.MemoryConfig(out_layout, ttnn.BufferType.L1)
+    result = ttnn.permute(ttnn_in, dims, memory_config=out_mc)
+    grid = result.memory_config().shard_spec.grid
+    assert grid.num_cores() == n_expected, f"Expected {n_expected} populated cores, got {grid.num_cores()}"
+    expected = expected_grid_factory(compute_grid)
+    assert grid == expected, f"Expected grid {expected}, got {grid}"
+    ref = x.permute(dims)
+    got = ttnn.to_torch(result.cpu().to(ttnn.ROW_MAJOR_LAYOUT))
+    assert_with_ulp(ref, got, ulp_threshold=0)
+
+
+def test_permute_specless_sharded_output_grid_shrinks_height(device):
+    """HEIGHT_SHARDED no-spec output: expect ceil(tensor_h / shard_h) populated cores.
+    permute (2,2,32,64) (0,1,3,2) → out=(2,2,64,32); tensor_h=256, shard_h=32 → 8 populated cores."""
+    _permute_and_assert_shrink(
+        device,
+        shape=(2, 2, 32, 64),
+        dims=(0, 1, 3, 2),
+        out_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        expected_grid_factory=lambda grid: ttnn.num_cores_to_corerangeset(8, grid, True),
+        n_expected=8,
+    )
+
+
+def test_permute_specless_sharded_output_grid_shrinks_width(device):
+    """WIDTH_SHARDED no-spec output: expect ceil(tensor_w / shard_w) populated cores.
+    permute (2,2,64,32) (0,1,3,2) → out=(2,2,32,64); tensor_w=64, shard_w=32 → 2 populated cores."""
+    _permute_and_assert_shrink(
+        device,
+        shape=(2, 2, 64, 32),
+        dims=(0, 1, 3, 2),
+        out_layout=ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        expected_grid_factory=lambda grid: ttnn.num_cores_to_corerangeset(2, grid, True),
+        n_expected=2,
+    )
+
+
+def test_permute_specless_sharded_output_grid_shrinks_block(device):
+    """BLOCK_SHARDED no-spec output: expect rectangular 2x2 populated grid.
+    permute (1,1,64,64) (0,1,3,2) → out=(1,1,64,64); shard=32x32 → 2x2 rectangle = 4 cores."""
+    compute_grid = device.compute_with_storage_grid_size()
+    if compute_grid.x < 2 or compute_grid.y < 2:
+        pytest.skip("Device grid too small for 2x2 BLOCK shrink test")
+    _permute_and_assert_shrink(
+        device,
+        shape=(1, 1, 64, 64),
+        dims=(0, 1, 3, 2),
+        out_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+        expected_grid_factory=lambda _grid: ttnn.CoreRangeSet(
+            {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 1))}
+        ),
+        n_expected=4,
+    )
+
+
+def test_permute_specless_sharded_output_grid_shrinks_block_col_major(device):
+    """BLOCK+COL_MAJOR (input-inherited) shrink: shard=(32,32), n_h=2/n_w=3 → COL_MAJOR rect 2x3=6 cores."""
+    shape = (1, 1, 96, 64)
+    compute_grid = device.compute_with_storage_grid_size()
+    if compute_grid.x < 2 or compute_grid.y < 3:
+        pytest.skip("Device grid too small for COL_MAJOR 2x3 BLOCK shrink test")
+    in_mc = _block_shard_config(shape, device, orientation=ttnn.ShardOrientation.COL_MAJOR)
+    out_mc = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.BLOCK_SHARDED, ttnn.BufferType.L1)
+    torch.manual_seed(12345)
+    x = torch.rand(shape, dtype=torch.bfloat16)
+    ttnn_in = ttnn.from_torch(x, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, device=device, memory_config=in_mc)
+    result = ttnn.permute(ttnn_in, (0, 1, 3, 2), memory_config=out_mc)
+    ss = result.memory_config().shard_spec
+    assert ss.orientation == ttnn.ShardOrientation.COL_MAJOR, f"Expected COL_MAJOR, got {ss.orientation}"
+    assert ss.grid.num_cores() == 6, f"Expected 2x3=6 populated cores, got {ss.grid.num_cores()}"
+    expected = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 2))})
+    assert ss.grid == expected, f"Expected COL_MAJOR rect (0,0)->(1,2), got {ss.grid}"
+    ref = x.permute(0, 1, 3, 2)
+    got = ttnn.to_torch(result.cpu().to(ttnn.ROW_MAJOR_LAYOUT))
+    assert_with_ulp(ref, got, ulp_threshold=0)

--- a/tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_slice.py
+++ b/tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_slice.py
@@ -983,3 +983,106 @@ def test_slice_dtype_coverage(shape, layout, in_mc_fn, dtype, device):
         device,
         ulp_when_exact=(dtype != ttnn.bfloat8_b),
     )
+
+
+# Specless sharded output must shrink CoreRangeSet to populated shard count.
+
+
+def _slice_and_assert_shrink(device, shape, begins, ends, out_layout, expected_grid_factory, n_expected):
+    """Run slice with a specless sharded output_mem_config; assert result.grid matches expected
+    and result is bit-exact against torch reference."""
+    compute_grid = device.compute_with_storage_grid_size()
+    if compute_grid.x * compute_grid.y < n_expected:
+        pytest.skip(f"Device grid too small for shrink test (need >= {n_expected} cores)")
+    torch.manual_seed(12345)
+    x = torch.rand(shape, dtype=torch.bfloat16)
+    ttnn_in = ttnn.from_torch(
+        x, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, device=device, memory_config=L1_INTERLEAVED
+    )
+    out_mc = ttnn.MemoryConfig(out_layout, ttnn.BufferType.L1)
+    result = ttnn.slice(ttnn_in, begins, ends, (1, 1, 1, 1), memory_config=out_mc)
+    grid = result.memory_config().shard_spec.grid
+    assert grid.num_cores() == n_expected, f"Expected {n_expected} populated cores, got {grid.num_cores()}"
+    expected = expected_grid_factory(compute_grid)
+    assert grid == expected, f"Expected grid {expected}, got {grid}"
+    slices = tuple(slice(b, e, 1) for b, e in zip(begins, ends))
+    ref = x[slices]
+    got = ttnn.to_torch(result.cpu().to(ttnn.ROW_MAJOR_LAYOUT))
+    assert_with_ulp(ref, got, ulp_threshold=0)
+
+
+def test_slice_specless_sharded_output_grid_shrinks_height(device):
+    """HEIGHT_SHARDED no-spec output: expect ceil(tensor_h / shard_h) populated cores.
+    slice (1,1,128,128) → (1,1,64,128); tensor_h=64, shard_h=32 → 2 populated cores."""
+    _slice_and_assert_shrink(
+        device,
+        shape=(1, 1, 128, 128),
+        begins=(0, 0, 0, 0),
+        ends=(1, 1, 64, 128),
+        out_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        expected_grid_factory=lambda grid: ttnn.num_cores_to_corerangeset(2, grid, True),
+        n_expected=2,
+    )
+
+
+def test_slice_specless_sharded_output_grid_shrinks_width(device):
+    """WIDTH_SHARDED no-spec output: expect ceil(tensor_w / shard_w) populated cores.
+    slice (1,1,128,128) → (1,1,128,64); tensor_w=64, shard_w=32 → 2 populated cores."""
+    _slice_and_assert_shrink(
+        device,
+        shape=(1, 1, 128, 128),
+        begins=(0, 0, 0, 0),
+        ends=(1, 1, 128, 64),
+        out_layout=ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        expected_grid_factory=lambda grid: ttnn.num_cores_to_corerangeset(2, grid, True),
+        n_expected=2,
+    )
+
+
+def test_slice_specless_sharded_output_grid_shrinks_block(device):
+    """BLOCK_SHARDED no-spec output: expect rectangular 2x2 populated grid.
+    slice (1,1,128,128) → (1,1,64,64); shard=32x32 → 2x2 rectangle = 4 cores."""
+    compute_grid = device.compute_with_storage_grid_size()
+    if compute_grid.x < 2 or compute_grid.y < 2:
+        pytest.skip("Device grid too small for 2x2 BLOCK shrink test")
+    _slice_and_assert_shrink(
+        device,
+        shape=(1, 1, 128, 128),
+        begins=(0, 0, 0, 0),
+        ends=(1, 1, 64, 64),
+        out_layout=ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+        expected_grid_factory=lambda _grid: ttnn.CoreRangeSet(
+            {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 1))}
+        ),
+        n_expected=4,
+    )
+
+
+def test_slice_specless_sharded_output_grid_shrinks_block_col_major(device):
+    """BLOCK+COL_MAJOR shrink: adjust rejects (sub-tile), falls to gen; shard=(32,32), phys 2x3=6 cores COL_MAJOR."""
+    shape = (1, 1, 128, 128)
+    compute_grid = device.compute_with_storage_grid_size()
+    if compute_grid.x < 2 or compute_grid.y < 3:
+        pytest.skip("Device grid too small for COL_MAJOR 2x3 BLOCK shrink test")
+    in_mc = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+        ttnn.BufferType.L1,
+        ttnn.ShardSpec(
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 1))}),
+            (64, 64),
+            ttnn.ShardOrientation.COL_MAJOR,
+        ),
+    )
+    out_mc = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.BLOCK_SHARDED, ttnn.BufferType.L1)
+    torch.manual_seed(12345)
+    x = torch.rand(shape, dtype=torch.bfloat16)
+    ttnn_in = ttnn.from_torch(x, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, device=device, memory_config=in_mc)
+    result = ttnn.slice(ttnn_in, (0, 0, 0, 0), (1, 1, 64, 96), (1, 1, 1, 1), memory_config=out_mc)
+    ss = result.memory_config().shard_spec
+    assert ss.orientation == ttnn.ShardOrientation.COL_MAJOR, f"Expected COL_MAJOR, got {ss.orientation}"
+    assert ss.grid.num_cores() == 6, f"Expected 2x3=6 populated cores, got {ss.grid.num_cores()}"
+    expected = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 2))})
+    assert ss.grid == expected, f"Expected COL_MAJOR rect (0,0)->(1,2), got {ss.grid}"
+    ref = x[0:1, 0:1, 0:64, 0:96]
+    got = ttnn.to_torch(result.cpu().to(ttnn.ROW_MAJOR_LAYOUT))
+    assert_with_ulp(ref, got, ulp_threshold=0)

--- a/tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_split.py
+++ b/tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_split.py
@@ -489,6 +489,26 @@ def test_interleaved_to_sharded_no_spec(device, memory_layout, shape, split_size
     _check(tt_out, ref)
 
 
+def test_specless_sharded_output_grid_shrinks_height(device):
+    """Split via generate_transpose_shard_spec: chunk (2*TILE, 2*TILE); ceil(64/32)=2 populated cores per chunk."""
+    compute_grid = device.compute_with_storage_grid_size()
+    if compute_grid.x * compute_grid.y <= 2:
+        pytest.skip("Device grid too small to observe shrink (need > 2 cores)")
+    shape = [2 * TILE, 4 * TILE]
+    torch.manual_seed(24)
+    t = torch.randn(shape, dtype=torch.bfloat16)
+    ref = torch.split(t, 2 * TILE, dim=-1)
+    tt_in = _from_torch(t, device, mc=L1)
+    out_no_spec = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1)
+    tt_out = ttnn.split(tt_in, 2 * TILE, dim=-1, memory_config=out_no_spec)
+    expected = ttnn.num_cores_to_corerangeset(2, compute_grid, True)
+    for tt_t in tt_out:
+        grid = tt_t.memory_config().shard_spec.grid
+        assert grid.num_cores() == 2, f"Expected 2 populated cores, got {grid.num_cores()}"
+        assert grid == expected, f"Expected row-wise CoreRangeSet {expected}, got {grid}"
+    _check(tt_out, ref)
+
+
 # 9d. Sub-tile rescale → graceful DRAM downgrade (tile-alignment guard on rescaled shard_w=16 < TILE).
 
 

--- a/tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_tranpose.py
+++ b/tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_tranpose.py
@@ -854,3 +854,119 @@ def test_transpose_rm_block_or_width_sharded_to_sharded(shape, dim0, dim1, input
         input_mem_config=input_mem_config,
         output_mem_config=output_mem_config,
     )
+
+
+# Specless sharded output must shrink CoreRangeSet to populated shard count.
+
+
+def _assert_shrink_h_or_w(device, result_mc, n_used):
+    """Common shrink assertion for H/W: exact core count + row-wise CoreRangeSet."""
+    compute_grid = device.compute_with_storage_grid_size()
+    if compute_grid.x * compute_grid.y <= n_used:
+        pytest.skip(f"Device grid too small to observe shrink (need > {n_used} cores)")
+    grid = result_mc.shard_spec.grid
+    assert grid.num_cores() == n_used, f"Expected {n_used} populated cores, got {grid.num_cores()}"
+    expected = ttnn.num_cores_to_corerangeset(n_used, compute_grid, True)
+    assert grid == expected, f"Expected row-wise CoreRangeSet {expected}, got {grid}"
+
+
+def test_transpose_specless_sharded_output_grid_shrinks_height(device):
+    """HEIGHT_SHARDED no-spec output: expect ceil(tensor_h / shard_h) populated cores, not all_cores.
+    shape=(2,2,32,64) WH → out=(2,2,64,32); tensor_h=256, shard_h=32 → 8 populated cores."""
+    shape = (2, 2, 32, 64)
+    out_mc = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1)
+    torch.manual_seed(12345)
+    x = torch.rand(shape, dtype=torch.bfloat16)
+    ttnn_in = ttnn.from_torch(
+        x, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, device=device, memory_config=L1_INTERLEAVED
+    )
+    result = ttnn.transpose(ttnn_in, 2, 3, memory_config=out_mc)
+    _assert_shrink_h_or_w(device, result.memory_config(), n_used=8)
+    ref = x.transpose(2, 3)
+    got = ttnn.to_torch(result.cpu().to(ttnn.ROW_MAJOR_LAYOUT))
+    assert_with_ulp(ref, got, ulp_threshold=0)
+
+
+def test_transpose_specless_sharded_output_grid_shrinks_width(device):
+    """WIDTH_SHARDED no-spec output: expect ceil(tensor_w / shard_w) populated cores.
+    shape=(2,2,64,32) WH → out=(2,2,32,64); tensor_w=64, shard_w=32 → 2 populated cores."""
+    shape = (2, 2, 64, 32)
+    out_mc = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1)
+    torch.manual_seed(12345)
+    x = torch.rand(shape, dtype=torch.bfloat16)
+    ttnn_in = ttnn.from_torch(
+        x, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, device=device, memory_config=L1_INTERLEAVED
+    )
+    result = ttnn.transpose(ttnn_in, 2, 3, memory_config=out_mc)
+    _assert_shrink_h_or_w(device, result.memory_config(), n_used=2)
+    ref = x.transpose(2, 3)
+    got = ttnn.to_torch(result.cpu().to(ttnn.ROW_MAJOR_LAYOUT))
+    assert_with_ulp(ref, got, ulp_threshold=0)
+
+
+def test_transpose_specless_sharded_output_grid_shrinks_block(device):
+    """BLOCK_SHARDED no-spec output: expect rectangular n_rows x n_cols populated grid.
+    shape=(1,1,64,64) WH → out=(1,1,64,64); shard=32x32 → 2x2 rectangle = 4 cores."""
+    shape = (1, 1, 64, 64)
+    out_mc = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.BLOCK_SHARDED, ttnn.BufferType.L1)
+    compute_grid = device.compute_with_storage_grid_size()
+    if compute_grid.x < 2 or compute_grid.y < 2:
+        pytest.skip("Device grid too small for 2x2 BLOCK shrink test")
+    torch.manual_seed(12345)
+    x = torch.rand(shape, dtype=torch.bfloat16)
+    ttnn_in = ttnn.from_torch(
+        x, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, device=device, memory_config=L1_INTERLEAVED
+    )
+    result = ttnn.transpose(ttnn_in, 2, 3, memory_config=out_mc)
+    grid = result.memory_config().shard_spec.grid
+    assert grid.num_cores() == 4, f"Expected 2x2 = 4 populated cores, got {grid.num_cores()}"
+    expected = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 1))})
+    assert grid == expected, f"Expected rectangular BLOCK grid {expected}, got {grid}"
+    ref = x.transpose(2, 3)
+    got = ttnn.to_torch(result.cpu().to(ttnn.ROW_MAJOR_LAYOUT))
+    assert_with_ulp(ref, got, ulp_threshold=0)
+
+
+def test_transpose_specless_sharded_output_grid_shrinks_block_col_major(device):
+    """BLOCK+COL_MAJOR shrink (WH 8x8): orientation-aware divisors → shard=(32,32), n_h=2, n_w=3 → 2x3=6 cores."""
+    shape = (1, 1, 96, 64)
+    compute_grid = device.compute_with_storage_grid_size()
+    if compute_grid.x < 2 or compute_grid.y < 3:
+        pytest.skip("Device grid too small for COL_MAJOR 2x3 BLOCK shrink test")
+    in_mc = _block_shard_config(shape, device, orientation=ttnn.ShardOrientation.COL_MAJOR)
+    out_mc = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.BLOCK_SHARDED, ttnn.BufferType.L1)
+    torch.manual_seed(12345)
+    x = torch.rand(shape, dtype=torch.bfloat16)
+    ttnn_in = ttnn.from_torch(x, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, device=device, memory_config=in_mc)
+    result = ttnn.transpose(ttnn_in, 2, 3, memory_config=out_mc)
+    ss = result.memory_config().shard_spec
+    assert ss.orientation == ttnn.ShardOrientation.COL_MAJOR, f"Expected COL_MAJOR orientation, got {ss.orientation}"
+    assert ss.grid.num_cores() == 6, f"Expected 2x3 = 6 populated cores, got {ss.grid.num_cores()}"
+    expected = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 2))})
+    assert ss.grid == expected, f"Expected COL_MAJOR rect {expected} (phys_x=n_h=2, phys_y=n_w=3), got {ss.grid}"
+    ref = x.transpose(2, 3)
+    got = ttnn.to_torch(result.cpu().to(ttnn.ROW_MAJOR_LAYOUT))
+    assert_with_ulp(ref, got, ulp_threshold=0)
+
+
+def test_transpose_specless_sharded_output_grid_shrinks_block_col_major_non_square(device):
+    """BLOCK+COL_MAJOR non-square (BH p150b 13x10) — orientation-aware divisors → shard=(32,64), 10x7=70 cores."""
+    compute_grid = device.compute_with_storage_grid_size()
+    if compute_grid.x == compute_grid.y or compute_grid.x < 13 or compute_grid.y < 10:
+        pytest.skip(f"needs non-square grid >= 13x10 (have {compute_grid.x}x{compute_grid.y})")
+    shape = (1, 1, 416, 320)
+    in_mc = _block_shard_config(shape, device, orientation=ttnn.ShardOrientation.COL_MAJOR)
+    out_mc = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.BLOCK_SHARDED, ttnn.BufferType.L1)
+    torch.manual_seed(12345)
+    x = torch.rand(shape, dtype=torch.bfloat16)
+    ttnn_in = ttnn.from_torch(x, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, device=device, memory_config=in_mc)
+    result = ttnn.transpose(ttnn_in, 2, 3, memory_config=out_mc)
+    ss = result.memory_config().shard_spec
+    assert ss.orientation == ttnn.ShardOrientation.COL_MAJOR, f"Expected COL_MAJOR, got {ss.orientation}"
+    assert ss.shape[0] == 32 and ss.shape[1] == 64, f"Expected shard=(32,64), got ({ss.shape[0]},{ss.shape[1]})"
+    assert ss.grid.num_cores() == 70, f"Expected 10x7=70 cores, got {ss.grid.num_cores()}"
+    expected = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(9, 6))})
+    assert ss.grid == expected, f"Expected COL_MAJOR rect (0,0)->(9,6), got {ss.grid}"
+    ref = x.transpose(2, 3)
+    got = ttnn.to_torch(result.cpu().to(ttnn.ROW_MAJOR_LAYOUT))
+    assert_with_ulp(ref, got, ulp_threshold=0)

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/quasar/test_quasar_transpose_shrink.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/quasar/test_quasar_transpose_shrink.py
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Smoke coverage for the quasar generate_transpose_shard_spec cross-port; guards drift from the DM twin."""
+
+import pytest
+import torch
+
+import ttnn
+from tests.ttnn.utils_for_testing import assert_with_ulp
+
+
+L1_INTERLEAVED = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1)
+
+
+def test_quasar_transpose_specless_sharded_output_grid_shrinks_height(device):
+    """HEIGHT_SHARDED no-spec output on quasar twin: ceil(tensor_h / shard_h) populated cores.
+    shape=(2,2,32,64) WH → out=(2,2,64,32); tensor_h=256, shard_h=32 → 8 populated cores."""
+    compute_grid = device.compute_with_storage_grid_size()
+    if compute_grid.x * compute_grid.y <= 8:
+        pytest.skip("Device grid too small to observe shrink (need > 8 cores)")
+    shape = (2, 2, 32, 64)
+    out_mc = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1)
+    torch.manual_seed(12345)
+    x = torch.rand(shape, dtype=torch.bfloat16)
+    ttnn_in = ttnn.from_torch(
+        x, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, device=device, memory_config=L1_INTERLEAVED
+    )
+    result = ttnn.experimental.quasar.transpose(ttnn_in, 2, 3, memory_config=out_mc)
+    grid = result.memory_config().shard_spec.grid
+    assert grid.num_cores() == 8, f"Expected 8 populated cores, got {grid.num_cores()}"
+    expected = ttnn.num_cores_to_corerangeset(8, compute_grid, True)
+    assert grid == expected, f"Expected row-wise CoreRangeSet {expected}, got {grid}"
+    ref = x.transpose(2, 3)
+    got = ttnn.to_torch(result.cpu().to(ttnn.ROW_MAJOR_LAYOUT))
+    assert_with_ulp(ref, got, ulp_threshold=0)

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/quasar/test_quasar_transpose_shrink.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/quasar/test_quasar_transpose_shrink.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Smoke coverage for the quasar generate_transpose_shard_spec cross-port; guards drift from the DM twin."""
+"""Guards drift of the quasar generate_transpose_shard_spec twin from the DM helper."""
 
 import pytest
 import torch
@@ -15,8 +15,7 @@ L1_INTERLEAVED = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.Buf
 
 
 def test_quasar_transpose_specless_sharded_output_grid_shrinks_height(device):
-    """HEIGHT_SHARDED no-spec output on quasar twin: ceil(tensor_h / shard_h) populated cores.
-    shape=(2,2,32,64) WH → out=(2,2,64,32); tensor_h=256, shard_h=32 → 8 populated cores."""
+    """HEIGHT_SHARDED no-spec: baseline that the shrink is wired up at all on the quasar op."""
     compute_grid = device.compute_with_storage_grid_size()
     if compute_grid.x * compute_grid.y <= 8:
         pytest.skip("Device grid too small to observe shrink (need > 8 cores)")
@@ -32,6 +31,37 @@ def test_quasar_transpose_specless_sharded_output_grid_shrinks_height(device):
     assert grid.num_cores() == 8, f"Expected 8 populated cores, got {grid.num_cores()}"
     expected = ttnn.num_cores_to_corerangeset(8, compute_grid, True)
     assert grid == expected, f"Expected row-wise CoreRangeSet {expected}, got {grid}"
+    ref = x.transpose(2, 3)
+    got = ttnn.to_torch(result.cpu().to(ttnn.ROW_MAJOR_LAYOUT))
+    assert_with_ulp(ref, got, ulp_threshold=0)
+
+
+def test_quasar_transpose_specless_sharded_output_grid_shrinks_block_col_major(device):
+    """BLOCK+COL_MAJOR mirror of the DM 6-core case; catches BLOCK divisor/TT_FATAL drift on the port."""
+    compute_grid = device.compute_with_storage_grid_size()
+    if compute_grid.x < 2 or compute_grid.y < 3:
+        pytest.skip("Device grid too small for COL_MAJOR 2x3 BLOCK shrink test")
+    shape = (1, 1, 96, 64)
+    in_mc = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+        ttnn.BufferType.L1,
+        ttnn.ShardSpec(
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 1))}),
+            (64, 32),
+            ttnn.ShardOrientation.COL_MAJOR,
+        ),
+    )
+    out_mc = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.BLOCK_SHARDED, ttnn.BufferType.L1)
+    torch.manual_seed(12345)
+    x = torch.rand(shape, dtype=torch.bfloat16)
+    ttnn_in = ttnn.from_torch(x, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, device=device, memory_config=in_mc)
+    result = ttnn.experimental.quasar.transpose(ttnn_in, 2, 3, memory_config=out_mc)
+    ss = result.memory_config().shard_spec
+    assert ss.orientation == ttnn.ShardOrientation.COL_MAJOR, f"Expected COL_MAJOR, got {ss.orientation}"
+    assert ss.shape[0] == 32 and ss.shape[1] == 32, f"Expected shard=(32,32), got ({ss.shape[0]},{ss.shape[1]})"
+    assert ss.grid.num_cores() == 6, f"Expected 2x3=6 populated cores, got {ss.grid.num_cores()}"
+    expected = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 2))})
+    assert ss.grid == expected, f"Expected COL_MAJOR rect (0,0)->(1,2), got {ss.grid}"
     ref = x.transpose(2, 3)
     got = ttnn.to_torch(result.cpu().to(ttnn.ROW_MAJOR_LAYOUT))
     assert_with_ulp(ref, got, ulp_threshold=0)

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_utils.cpp
@@ -3,9 +3,12 @@
 
 #include "transpose_utils.hpp"
 
+#include <algorithm>
+
 #include <tt-logger/tt-logger.hpp>
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/work_split.hpp>
 
 namespace ttnn::operations::data_movement::transpose {
 
@@ -129,8 +132,7 @@ std::optional<ShardSpec> adjust_shard_spec_to_shape(
     return ret;
 }
 
-// Build a sharded spec over the full compute grid (used when no input shard_spec is available
-// to scale from, e.g. interleaved input + sharded output request).
+// Size CoreRangeSet to populated shards (avoids L1 waste + misleading .grid.num_cores()).
 ShardSpec generate_transpose_shard_spec(
     const Tensor& input_tensor,
     const ttnn::Shape& padded_out_shape,
@@ -149,6 +151,15 @@ ShardSpec generate_transpose_shard_spec(
     }
     uint64_t tensor_width = padded_out_shape[-1];
 
+    // Resolve orientation first so BLOCK shard_shape below can pick divisors per COL_MAJOR's axis swap.
+    ShardOrientation orientation = ShardOrientation::ROW_MAJOR;
+    if (orientation_hint.has_value()) {
+        orientation = *orientation_hint;
+    } else if (input_tensor.shard_spec().has_value()) {
+        orientation = input_tensor.shard_spec()->orientation;
+    }
+    const bool row_wise = (orientation == ShardOrientation::ROW_MAJOR);
+
     std::array<uint32_t, 2> shard_shape = {0, 0};
     if (memory_layout == TensorMemoryLayout::HEIGHT_SHARDED) {
         auto height_padded = tt::round_up(tensor_height, static_cast<uint64_t>(num_cores) * tt::constants::TILE_HEIGHT);
@@ -160,24 +171,63 @@ ShardSpec generate_transpose_shard_spec(
             tt::round_up(tt::div_up(tensor_width, static_cast<uint64_t>(num_cores)), tt::constants::TILE_WIDTH);
         shard_shape = {static_cast<uint32_t>(tensor_height), static_cast<uint32_t>(shard_width)};
     } else {
+        // BLOCK: divisors track orientation (COL_MAJOR swaps h→grid.x, w→grid.y) so n_h/n_w fit physical axes.
         CoreCoord grid_size = all_cores.bounding_box().grid_size();
-        auto height_padded =
-            tt::round_up(tensor_height, static_cast<uint64_t>(grid_size.y) * tt::constants::TILE_HEIGHT);
+        const uint32_t h_div = row_wise ? grid_size.y : grid_size.x;
+        const uint32_t w_div = row_wise ? grid_size.x : grid_size.y;
+        auto height_padded = tt::round_up(tensor_height, static_cast<uint64_t>(h_div) * tt::constants::TILE_HEIGHT);
         auto shard_height =
-            tt::round_up(tt::div_up(height_padded, static_cast<uint64_t>(grid_size.y)), tt::constants::TILE_HEIGHT);
+            tt::round_up(tt::div_up(height_padded, static_cast<uint64_t>(h_div)), tt::constants::TILE_HEIGHT);
         auto shard_width =
-            tt::round_up(tt::div_up(tensor_width, static_cast<uint64_t>(grid_size.x)), tt::constants::TILE_WIDTH);
+            tt::round_up(tt::div_up(tensor_width, static_cast<uint64_t>(w_div)), tt::constants::TILE_WIDTH);
         shard_shape = {static_cast<uint32_t>(shard_height), static_cast<uint32_t>(shard_width)};
     }
-    log_debug(tt::LogOp, "Transpose: generated shard spec over full compute grid ({} cores)", num_cores);
-    // Prefer explicit hint, then input's orientation, else ROW_MAJOR.
-    ShardOrientation orientation = ShardOrientation::ROW_MAJOR;
-    if (orientation_hint.has_value()) {
-        orientation = *orientation_hint;
-    } else if (input_tensor.shard_spec().has_value()) {
-        orientation = input_tensor.shard_spec()->orientation;
+
+    // Populated-shard count → CoreRangeSet; BLOCK stays rectangular for downstream BLOCK factories.
+    CoreRangeSet used_cores;
+    if (memory_layout == TensorMemoryLayout::HEIGHT_SHARDED) {
+        uint32_t n_used = static_cast<uint32_t>(tt::div_up(tensor_height, static_cast<uint64_t>(shard_shape[0])));
+        n_used = std::min(std::max(n_used, 1u), num_cores);
+        used_cores = (n_used == num_cores)
+                         ? all_cores
+                         : tt::tt_metal::num_cores_to_corerangeset(n_used, compute_grid_size, row_wise);
+    } else if (memory_layout == TensorMemoryLayout::WIDTH_SHARDED) {
+        uint32_t n_used = static_cast<uint32_t>(tt::div_up(tensor_width, static_cast<uint64_t>(shard_shape[1])));
+        n_used = std::min(std::max(n_used, 1u), num_cores);
+        used_cores = (n_used == num_cores)
+                         ? all_cores
+                         : tt::tt_metal::num_cores_to_corerangeset(n_used, compute_grid_size, row_wise);
+    } else {
+        uint32_t n_h = static_cast<uint32_t>(tt::div_up(tensor_height, static_cast<uint64_t>(shard_shape[0])));
+        uint32_t n_w = static_cast<uint32_t>(tt::div_up(tensor_width, static_cast<uint64_t>(shard_shape[1])));
+        const uint32_t n_along_x = row_wise ? n_w : n_h;
+        const uint32_t n_along_y = row_wise ? n_h : n_w;
+        // Guards any regression of the orientation-aware BLOCK divisors.
+        TT_FATAL(
+            n_along_x <= static_cast<uint32_t>(compute_grid_size.x) &&
+                n_along_y <= static_cast<uint32_t>(compute_grid_size.y),
+            "Transpose: BLOCK shard-grid ({}x{} along x/y) exceeds compute grid ({}x{}); shard=({},{}) orientation={}",
+            n_along_x,
+            n_along_y,
+            compute_grid_size.x,
+            compute_grid_size.y,
+            shard_shape[0],
+            shard_shape[1],
+            row_wise ? "ROW_MAJOR" : "COL_MAJOR");
+        const uint32_t phys_x_extent = std::max(n_along_x, 1u);
+        const uint32_t phys_y_extent = std::max(n_along_y, 1u);
+        used_cores = (phys_x_extent == static_cast<uint32_t>(compute_grid_size.x) &&
+                      phys_y_extent == static_cast<uint32_t>(compute_grid_size.y))
+                         ? all_cores
+                         : CoreRangeSet(CoreRange({0, 0}, {phys_x_extent - 1, phys_y_extent - 1}));
     }
-    return ShardSpec(all_cores, shard_shape, orientation);
+    log_debug(
+        tt::LogOp,
+        "Transpose: generated shard spec ({}, {}) over {} populated cores",
+        shard_shape[0],
+        shard_shape[1],
+        used_cores.num_cores());
+    return ShardSpec(used_cores, shard_shape, orientation);
 }
 
 }  // namespace ttnn::operations::data_movement::transpose

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_utils.cpp
@@ -3,9 +3,12 @@
 
 #include "transpose_utils.hpp"
 
+#include <algorithm>
+
 #include <tt-logger/tt-logger.hpp>
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/work_split.hpp>
 
 namespace ttnn::operations::experimental::quasar::transpose_op {
 
@@ -129,10 +132,12 @@ std::optional<ShardSpec> adjust_shard_spec_to_shape(
     return ret;
 }
 
-// Build a sharded spec over the full compute grid (used when no input shard_spec is available
-// to scale from, e.g. interleaved input + sharded output request).
+// Size CoreRangeSet to populated shards (avoids L1 waste + misleading .grid.num_cores()).
 ShardSpec generate_transpose_shard_spec(
-    const Tensor& input_tensor, const ttnn::Shape& padded_out_shape, TensorMemoryLayout memory_layout) {
+    const Tensor& input_tensor,
+    const ttnn::Shape& padded_out_shape,
+    TensorMemoryLayout memory_layout,
+    std::optional<ShardOrientation> orientation_hint) {
     auto* device = input_tensor.device();
     auto compute_grid_size = device->compute_with_storage_grid_size();
     CoreRangeSet all_cores(CoreRange({0, 0}, {compute_grid_size.x - 1, compute_grid_size.y - 1}));
@@ -146,6 +151,15 @@ ShardSpec generate_transpose_shard_spec(
     }
     uint64_t tensor_width = padded_out_shape[-1];
 
+    // Resolve orientation first so BLOCK shard_shape below can pick divisors per COL_MAJOR's axis swap.
+    ShardOrientation orientation = ShardOrientation::ROW_MAJOR;
+    if (orientation_hint.has_value()) {
+        orientation = *orientation_hint;
+    } else if (input_tensor.shard_spec().has_value()) {
+        orientation = input_tensor.shard_spec()->orientation;
+    }
+    const bool row_wise = (orientation == ShardOrientation::ROW_MAJOR);
+
     std::array<uint32_t, 2> shard_shape = {0, 0};
     if (memory_layout == TensorMemoryLayout::HEIGHT_SHARDED) {
         auto height_padded = tt::round_up(tensor_height, static_cast<uint64_t>(num_cores) * tt::constants::TILE_HEIGHT);
@@ -157,17 +171,63 @@ ShardSpec generate_transpose_shard_spec(
             tt::round_up(tt::div_up(tensor_width, static_cast<uint64_t>(num_cores)), tt::constants::TILE_WIDTH);
         shard_shape = {static_cast<uint32_t>(tensor_height), static_cast<uint32_t>(shard_width)};
     } else {
+        // BLOCK: divisors track orientation (COL_MAJOR swaps h→grid.x, w→grid.y) so n_h/n_w fit physical axes.
         CoreCoord grid_size = all_cores.bounding_box().grid_size();
-        auto height_padded =
-            tt::round_up(tensor_height, static_cast<uint64_t>(grid_size.y) * tt::constants::TILE_HEIGHT);
+        const uint32_t h_div = row_wise ? grid_size.y : grid_size.x;
+        const uint32_t w_div = row_wise ? grid_size.x : grid_size.y;
+        auto height_padded = tt::round_up(tensor_height, static_cast<uint64_t>(h_div) * tt::constants::TILE_HEIGHT);
         auto shard_height =
-            tt::round_up(tt::div_up(height_padded, static_cast<uint64_t>(grid_size.y)), tt::constants::TILE_HEIGHT);
+            tt::round_up(tt::div_up(height_padded, static_cast<uint64_t>(h_div)), tt::constants::TILE_HEIGHT);
         auto shard_width =
-            tt::round_up(tt::div_up(tensor_width, static_cast<uint64_t>(grid_size.x)), tt::constants::TILE_WIDTH);
+            tt::round_up(tt::div_up(tensor_width, static_cast<uint64_t>(w_div)), tt::constants::TILE_WIDTH);
         shard_shape = {static_cast<uint32_t>(shard_height), static_cast<uint32_t>(shard_width)};
     }
-    log_debug(tt::LogOp, "Transpose: generated shard spec over full compute grid ({} cores)", num_cores);
-    return ShardSpec(all_cores, shard_shape, ShardOrientation::ROW_MAJOR);
+
+    // Populated-shard count → CoreRangeSet; BLOCK stays rectangular for downstream BLOCK factories.
+    CoreRangeSet used_cores;
+    if (memory_layout == TensorMemoryLayout::HEIGHT_SHARDED) {
+        uint32_t n_used = static_cast<uint32_t>(tt::div_up(tensor_height, static_cast<uint64_t>(shard_shape[0])));
+        n_used = std::min(std::max(n_used, 1u), num_cores);
+        used_cores = (n_used == num_cores)
+                         ? all_cores
+                         : tt::tt_metal::num_cores_to_corerangeset(n_used, compute_grid_size, row_wise);
+    } else if (memory_layout == TensorMemoryLayout::WIDTH_SHARDED) {
+        uint32_t n_used = static_cast<uint32_t>(tt::div_up(tensor_width, static_cast<uint64_t>(shard_shape[1])));
+        n_used = std::min(std::max(n_used, 1u), num_cores);
+        used_cores = (n_used == num_cores)
+                         ? all_cores
+                         : tt::tt_metal::num_cores_to_corerangeset(n_used, compute_grid_size, row_wise);
+    } else {
+        uint32_t n_h = static_cast<uint32_t>(tt::div_up(tensor_height, static_cast<uint64_t>(shard_shape[0])));
+        uint32_t n_w = static_cast<uint32_t>(tt::div_up(tensor_width, static_cast<uint64_t>(shard_shape[1])));
+        const uint32_t n_along_x = row_wise ? n_w : n_h;
+        const uint32_t n_along_y = row_wise ? n_h : n_w;
+        // Guards any regression of the orientation-aware BLOCK divisors.
+        TT_FATAL(
+            n_along_x <= static_cast<uint32_t>(compute_grid_size.x) &&
+                n_along_y <= static_cast<uint32_t>(compute_grid_size.y),
+            "Transpose: BLOCK shard-grid ({}x{} along x/y) exceeds compute grid ({}x{}); shard=({},{}) orientation={}",
+            n_along_x,
+            n_along_y,
+            compute_grid_size.x,
+            compute_grid_size.y,
+            shard_shape[0],
+            shard_shape[1],
+            row_wise ? "ROW_MAJOR" : "COL_MAJOR");
+        const uint32_t phys_x_extent = std::max(n_along_x, 1u);
+        const uint32_t phys_y_extent = std::max(n_along_y, 1u);
+        used_cores = (phys_x_extent == static_cast<uint32_t>(compute_grid_size.x) &&
+                      phys_y_extent == static_cast<uint32_t>(compute_grid_size.y))
+                         ? all_cores
+                         : CoreRangeSet(CoreRange({0, 0}, {phys_x_extent - 1, phys_y_extent - 1}));
+    }
+    log_debug(
+        tt::LogOp,
+        "Transpose: generated shard spec ({}, {}) over {} populated cores",
+        shard_shape[0],
+        shard_shape[1],
+        used_cores.num_cores());
+    return ShardSpec(used_cores, shard_shape, orientation);
 }
 
 }  // namespace ttnn::operations::experimental::quasar::transpose_op

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_utils.hpp
@@ -18,7 +18,11 @@ bool is_native_transpose_sharding(
 std::optional<tt::tt_metal::ShardSpec> adjust_shard_spec_to_shape(
     const tt::tt_metal::ShardSpec& shard_spec, const ttnn::Shape& from_shape, const ttnn::Shape& to_shape);
 
+// Build a sharded spec over the compute grid from the post-transform shape.
 tt::tt_metal::ShardSpec generate_transpose_shard_spec(
-    const Tensor& input_tensor, const ttnn::Shape& padded_out_shape, tt::tt_metal::TensorMemoryLayout memory_layout);
+    const Tensor& input_tensor,
+    const ttnn::Shape& padded_out_shape,
+    tt::tt_metal::TensorMemoryLayout memory_layout,
+    std::optional<tt::tt_metal::ShardOrientation> orientation_hint = std::nullopt);
 
 }  // namespace ttnn::operations::experimental::quasar::transpose_op


### PR DESCRIPTION
### Ticket
Link to Github Issue #50684

### Problem
`ttnn::operations::data_movement::transpose::generate_transpose_shard_spec` — the specless-sharded-output synthesiser — **always allocates the shard spec over the full compute grid (`all_cores`)**, even when the tensor is small enough that only a subset of cores would carry real data. On Wormhole, a tiny specless-sharded output still claims **64 cores**, with the trailing cores holding padded zero-shards.

This wastes L1, produces a misleading `shard_spec.grid.num_cores()` (grid capacity, not populated shards), and forces downstream consumers that iterate over `grid` (custom kernels, buffer allocators) to do more work than necessary.

### What this PR does
- **Shrink `CoreRangeSet` in `generate_transpose_shard_spec`** — HEIGHT/WIDTH sharded outputs now size the `CoreRangeSet` via `num_cores_to_corerangeset(n_used, grid, row_wise)`; BLOCK sharded outputs build a rectangular `CoreRange(0,0)..(nx-1, ny-1)` sized to the actual `(n_h, n_w)` shard counts, mirroring `fold::reshard_if_needed` and `reshape_view`'s BLOCK path.
- **Orientation-aware BLOCK divisors + non-square-grid invariant** — `shard_shape` derivation resolves orientation up-front (hint > input's ShardSpec > `ROW_MAJOR`) and picks `h_div`/`w_div` per the physical axis swap (`ROW_MAJOR`: `h→grid.y, w→grid.x`; `COL_MAJOR`: `h→grid.x, w→grid.y`). A pre-clamp `TT_FATAL` on `n_along_x/y` vs `compute_grid_size.x/y` catches any future BLOCK divisor regression in Release builds; on non-square grids (e.g. 13×10) the pre-fix code silently clamped `n_w` from 13 to 10, dropping 30 populated blocks — this now `TT_FATAL`s instead of producing an under-sized buffer.
- **Preserve BLOCK axis-to-grid mapping under COL_MAJOR** — `row_wise` is derived from the resolved orientation, and BLOCK's rectangular grid maps `(nx, ny)=(n_w, n_h)` for `ROW_MAJOR` / `(n_h, n_w)` for `COL_MAJOR`, so a specless `col_major_block_in → block_out` still lands on the correct `(y, x)` layout the native BLOCK factories expect. Fixes the regression the pre-shrink code masked by claiming the full grid.
- **Cross-port shrink + `orientation_hint` into `experimental/quasar` twin** — the quasar snapshot copied the pre-#48025 signature (no orientation hint) and would silently drop `COL_MAJOR` intent; the twin now matches the DM helper 1:1 (signature, orientation resolution, shrink logic, one-liner comments).
- **Add regression tests for the shrink contract** — 17 new specless-output tests across five callers (`transpose`, `slice`, `permute`, `gather`, `split`) plus the quasar twin, asserting both the end-to-end bf16 result and the exact populated-shard `CoreRangeSet` (`shard_spec.grid.num_cores()` + `bounding_box`), so any future re-declaration of `all_cores` — or drift of the quasar port from DM — is caught at unit-test level. Coverage includes ROW_MAJOR H/W/BLOCK, BLOCK+COL_MAJOR (square 2×3), and a non-square-grid BLOCK+COL_MAJOR regression (gated to grids ≥ 13×10).
- **No behavioural change on native-eligible paths** — `generate_transpose_shard_spec` is only called on the specless-output fallback branch after `is_native_*_sharding` predicates have already ruled out native L1-sharded factories; existing kernels and their grid assumptions are untouched.

### Tests
All on Wormhole B0 (`tt-metal`, Python 3.10, Release):

New shrink regression tests (**16 PASSED, 1 SKIPPED** by hardware gate):
- `test_universal_input_tm_tranpose.py::test_transpose_specless_sharded_output_grid_shrinks_{height,width,block,block_col_major}` — PASSED
- `test_universal_input_tm_tranpose.py::test_transpose_specless_sharded_output_grid_shrinks_block_col_major_non_square` — SKIPPED on WH 8×8 by design (test gates to grids ≥ 13×10).
- `test_universal_input_tm_slice.py::test_slice_specless_sharded_output_grid_shrinks_{height,width,block,block_col_major}` — PASSED
- `test_universal_input_tm_permute.py::test_permute_specless_sharded_output_grid_shrinks_{height,width,block,block_col_major}` — PASSED
- `test_universal_input_tm_gather.py::test_gather_specless_sharded_output_grid_shrinks_height` — PASSED
- `test_universal_input_tm_split.py::test_specless_sharded_output_grid_shrinks_height` — PASSED
- `test_quasar_transpose_shrink.py::test_quasar_transpose_specless_sharded_output_grid_shrinks_{height,block_col_major}` — PASSED (BLOCK+COL_MAJOR guards drift of the quasar port from the DM helper on the load-bearing branch)

Existing specless (`-k nospec`) sweeps across the three suites (27/27 PASSED), including the previously-regressed COL_MAJOR case:
- `test_universal_input_tm_slice.py::test_slice_block_sharded_input_to_sharded_nospec[col_major_block_in_block_out_nospec]` — PASSED
- `test_universal_input_tm_slice.py::test_slice_block_sharded_input_to_sharded_nospec[col_major_block_in_height_out_nospec]` — PASSED
- `test_universal_input_tm_permute.py::test_permute_sharded_input_to_sharded_nospec_wh[{row,col}_major_in-{H,W,B}_out]` (6 params) — PASSED
- `test_universal_input_tm_permute.py::test_permute_native_col_major_sharded_input_to_sharded_nospec_cross_layout[*]` — PASSED
- `test_universal_input_tm_permute.py::test_permute_sharded_input_to_sharded_nospec_nondecomp[{H,B}_out]` — PASSED
- Plus the remaining `nospec` cases across transpose/slice/permute.

### Notes for Reviewers
- **Reference:** issue #50684 (gap analysis + before/after routing) and `synthesize_fold_output_shard_spec` from #50385, which this helper now matches for the H/W path and mirrors for BLOCK.
- **Follow-ups (deliberately out of scope for this PR):** the same over-declaration pattern exists in ~6 other helpers (`generate_repeat_shard_spec`, misc `generate_shard_spec_all_cores`, `interleaved_to_sharded` BLOCK) — separate issues to consolidate them into a shared `synthesize_output_shard_spec` (PR-2 track) are filed, so this PR stays a bounded, reviewable fix.
- **Behaviour change:** tiny tensors that previously reported a full 64-core grid on WH now report a shrunken grid. Callers hard-coding 64-core assumptions on specless-sharded outputs need auditing — none found in-tree via the CI run below.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mouliraj/shard_spec)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mouliraj/shard_spec)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mouliraj/shard_spec)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mouliraj/shard_spec)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mouliraj/shard_spec)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mouliraj/shard_spec)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mouliraj/shard_spec)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mouliraj/shard_spec)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mouliraj/shard_spec)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mouliraj/shard_spec)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mouliraj/shard_spec)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mouliraj/shard_spec)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mouliraj/shard_spec)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mouliraj/shard_spec)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mouliraj/shard_spec)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mouliraj/shard_spec)
