### PR TITLE
int32 min/max performance regression fix

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/reduction/test_min_max.py
+++ b/tests/ttnn/nightly/unit_tests/operations/reduction/test_min_max.py
@@ -90,3 +90,122 @@ def test_min_max_for_dim_hw(device, shape_dim, kind, layout):
     else:
         # test for equivalance
         assert_equal(torch_output, tt_output)
+
+
+# W-reduce (dim=-1) on HEIGHT_SHARDED L1 tensors takes a fast path only when the input and output share
+# a shard grid, shard height and orientation, and the shards tile the tensor exactly; any other geometry
+# must fall back to the generic path. The output memory config contributes only its grid and
+# orientation -- the shard shape is re-derived.
+
+SHARDED_W_SHAPE = (1, 1, 256, 4096)
+ROW_MAJOR = ttnn.ShardOrientation.ROW_MAJOR
+COL_MAJOR = ttnn.ShardOrientation.COL_MAJOR
+
+
+def _height_sharded(shard_h, shard_w, num_cores, grid_x=1, orientation=ROW_MAJOR):
+    # create_sharded_memory_config swaps (h, w) for COL_MAJOR, so pre-swap to keep geometry fixed.
+    shape = (shard_h, shard_w) if orientation == ROW_MAJOR else (shard_w, shard_h)
+    return ttnn.create_sharded_memory_config(
+        shape=shape,
+        core_grid=ttnn.CoreGrid(x=grid_x, y=num_cores // grid_x),
+        strategy=ttnn.ShardStrategy.HEIGHT,
+        orientation=orientation,
+        use_height_and_width_as_shard_shape=True,
+    )
+
+
+def _reduce_w_int32_sharded(device, op, input_config, output_config, shape=SHARDED_W_SHAPE):
+    torch.manual_seed(0)
+    torch_input = torch.randint(-50_000, 50_000, shape, dtype=torch.int32)
+    torch_output = (torch.amax if op == "max" else torch.amin)(torch_input, dim=-1, keepdim=True)
+
+    tt_input = ttnn.from_torch(
+        torch_input,
+        dtype=ttnn.int32,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=input_config,
+    )
+    reduce_op = ttnn.max if op == "max" else ttnn.min
+    tt_output = reduce_op(tt_input, dim=-1, keepdim=True, memory_config=output_config)
+
+    assert_equal(torch_output, ttnn.to_torch(tt_output))
+    return tt_output
+
+
+@pytest.mark.parametrize("op", ["max", "min"])
+def test_reduce_w_height_sharded(device, op):
+    """Matched shard grid and shard height, so the height-sharded fast path is used."""
+    tt_output = _reduce_w_int32_sharded(device, op, _height_sharded(32, 4096, 8), _height_sharded(32, 32, 8))
+
+    output_mem_config = tt_output.memory_config()
+    assert output_mem_config.memory_layout == ttnn.TensorMemoryLayout.HEIGHT_SHARDED
+    assert output_mem_config.shard_spec.num_cores() == 8
+
+
+@pytest.mark.parametrize("op", ["max", "min"])
+def test_reduce_w_height_sharded_grid_mismatch(device, op):
+    """Grids differ (8 vs 4) while shard heights match, so the fast path is rejected."""
+    tt_output = _reduce_w_int32_sharded(device, op, _height_sharded(64, 4096, 8), _height_sharded(64, 32, 4))
+    assert tt_output.memory_config().shard_spec.num_cores() == 4
+
+
+def test_reduce_w_height_sharded_shard_height_mismatch(device):
+    """Shard heights differ (64 vs re-derived 32) while grids match; without the guard this hangs."""
+    _reduce_w_int32_sharded(device, "max", _height_sharded(64, 4096, 8), _height_sharded(32, 32, 8))
+
+
+@pytest.mark.parametrize("num_cores", [3, 5, 7], ids=["3cores", "5cores", "7cores"])
+def test_reduce_w_height_sharded_uneven_split(device, num_cores):
+    """Shard heights match but 256 rows don't divide across these grids, so the fast path is rejected."""
+    # W=1024 rather than SHARDED_W_SHAPE's 4096 keeps the taller int32 shard inside L1.
+    height, width = SHARDED_W_SHAPE[2], 1024
+    shard_h = ((height + num_cores - 1) // num_cores + 31) // 32 * 32
+    _reduce_w_int32_sharded(
+        device,
+        "max",
+        _height_sharded(shard_h, width, num_cores),
+        _height_sharded(shard_h, 32, num_cores),
+        shape=(1, 1, height, width),
+    )
+
+
+def test_reduce_w_height_sharded_float_min(device):
+    """bfloat16 min lowers to -MAX(-x) (reduce_w_neg), a different kernel on the same fast path."""
+    torch.manual_seed(0)
+    torch_input = torch.randn(SHARDED_W_SHAPE, dtype=torch.bfloat16)
+    torch_output = torch.amin(torch_input, dim=-1, keepdim=True)
+
+    tt_input = ttnn.from_torch(
+        torch_input,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=_height_sharded(32, 4096, 8),
+    )
+    tt_output = ttnn.min(tt_input, dim=-1, keepdim=True, memory_config=_height_sharded(32, 32, 8))
+
+    assert_equal(torch_output, ttnn.to_torch(tt_output))
+
+
+@pytest.mark.parametrize("orientation", [ROW_MAJOR, COL_MAJOR], ids=["row_major", "col_major"])
+@pytest.mark.parametrize("op", ["max", "min"])
+def test_reduce_w_height_sharded_orientation_matched(device, op, orientation):
+    """Matched orientations take the fast path; the 2x4 grid is what makes the two orders differ."""
+    _reduce_w_int32_sharded(
+        device,
+        op,
+        _height_sharded(32, 4096, 8, grid_x=2, orientation=orientation),
+        _height_sharded(32, 32, 8, grid_x=2, orientation=orientation),
+    )
+
+
+@pytest.mark.parametrize("op", ["max", "min"])
+def test_reduce_w_height_sharded_orientation_mismatch(device, op):
+    """Orientations differ on a 2x4 grid, so each core would reduce into another core's output shard."""
+    _reduce_w_int32_sharded(
+        device,
+        op,
+        _height_sharded(32, 4096, 8, grid_x=2, orientation=ROW_MAJOR),
+        _height_sharded(32, 32, 8, grid_x=2, orientation=COL_MAJOR),
+    )

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/reader_unary_reduce_input_rows_partitioned_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/reader_unary_reduce_input_rows_partitioned_sharded.cpp
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/endpoints.h"
+#include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_dataflow.hpp"
+
+// Height-sharded W-reduce reader (mirror of the width-sharded H reader
+// reader_unary_transpose_wh_interleaved_input_cols_partitioned_sharded.cpp, but for ReduceOpDim::W).
+//
+// For a HEIGHT_SHARDED input the whole per-core shard is already resident in this core's L1 as
+// cb_id_in1 (aliased to the input tensor).  The shard is stored row-major as
+// (shard_Ht tile-rows) x (Wt tile-cols), which is exactly the (row, col) order the unified W-reduce
+// compute kernel (REDUCE_ROW, WaitAndPopPerTile) consumes tiles in.  So the reader simply streams the
+// resident tiles sequentially into cb_id_in0 via a local (loopback) NoC read - no cross-core traffic
+// and no reordering - instead of gathering every tile through the generic interleaved TensorAccessor.
+void kernel_main() {
+    uint32_t num_tiles = get_arg_val<uint32_t>(0);
+
+    constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(0);
+    constexpr uint32_t cb_id_in1 = get_compile_time_arg_val(1);
+
+#ifdef REDUCE_SCALER
+    constexpr uint32_t cb_id_in2 = get_compile_time_arg_val(2);
+    constexpr uint32_t scaler_bits = get_compile_time_arg_val(3);
+    float scaler_f = __builtin_bit_cast(float, scaler_bits);
+    dataflow_kernel_lib::prepare_reduce_scaler<cb_id_in2, REDUCE_OP, REDUCE_DIM>(scaler_f);
+#endif
+
+    constexpr uint32_t onetile = 1;
+    uint32_t tile_bytes = get_tile_size(cb_id_in0);
+
+    Noc noc;
+    CircularBuffer cb_in0(cb_id_in0);
+    CircularBuffer cb_in1(cb_id_in1);
+
+    cb_in1.reserve_back(num_tiles);
+    uint32_t base_l1_addr = cb_in1.get_write_ptr();
+
+    UnicastEndpoint src;
+    uint32_t src_noc_x = my_x[noc_index];
+    uint32_t src_noc_y = my_y[noc_index];
+
+    for (uint32_t t = 0; t < num_tiles; ++t) {
+        cb_in0.reserve_back(onetile);
+        noc.async_read(
+            src,
+            cb_in0,
+            tile_bytes,
+            {.noc_x = src_noc_x, .noc_y = src_noc_y, .addr = base_l1_addr + t * tile_bytes},
+            {.offset_bytes = 0});
+        noc.async_read_barrier();
+        cb_in0.push_back(onetile);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_w_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_w_program_factory.cpp
@@ -31,9 +31,22 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreWProgramFa
     uint32_t W = shape[3], H = shape[2], NC = shape[1] * shape[0];
     const uint32_t tile_height = a.tensor_spec().tile().get_height();
     const uint32_t tile_width = a.tensor_spec().tile().get_width();
+    const uint32_t tile_hw = a.tensor_spec().tile().get_tile_hw();
 
     uint32_t Wt = tt::div_up(W, tile_width);
     uint32_t Ht = tt::div_up(H, tile_height);
+
+    // Height-sharded fast path: each core reduces its own L1-resident shard locally instead of
+    // gathering tiles over the NoC. Needs matching shard grid, height and orientation, plus shards
+    // that tile the tensor exactly; anything else falls through to the generic path.
+    const uint32_t shard_Ht = a.shard_spec().has_value() ? a.shard_spec()->shape[0] / tile_height : 0;
+    const bool use_height_sharding =
+        !rm_path && a.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED &&
+        output.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED && a.shard_spec().has_value() &&
+        output.shard_spec().has_value() && a.shard_spec()->grid == output.shard_spec()->grid &&
+        a.shard_spec()->shape[0] == output.shard_spec()->shape[0] &&
+        a.shard_spec()->orientation == output.shard_spec()->orientation &&
+        shard_Ht * a.shard_spec()->grid.num_cores() == NC * Ht;
 
     if (rm_path) {
         validate_rm_preconditions(
@@ -91,6 +104,17 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreWProgramFa
     }
     TT_FATAL(num_cores > 0, "Reduce W requires at least one worker core");
 
+    // Height-sharded: pin the worker set to the shard grid and give each core exactly the rows
+    // (tile-rows) in its own shard. Each row reduces over the full Wt columns -> one output tile.
+    if (use_height_sharding) {
+        all_cores = a.shard_spec().value().grid;
+        num_cores = all_cores.num_cores();
+        core_group_1 = all_cores;
+        core_group_2 = CoreRangeSet();
+        num_rows_per_core_group_1 = shard_Ht;
+        num_rows_per_core_group_2 = 0;
+    }
+
     ProgramDescriptor desc;
 
     if (rm_path) {
@@ -134,6 +158,7 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreWProgramFa
     }
 
     uint32_t src0_cb_index = 0;
+    uint32_t src1_cb_index = tt::CBIndex::c_1;
     uint32_t num_input_tiles = 2;
     if (rm_path) {
         num_input_tiles = std::max(num_input_tiles, plan.wt_tiles_per_chunk);
@@ -148,6 +173,21 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreWProgramFa
         }}},
     });
 
+    // Height-sharded: alias the resident input shard as c_1 so the reader can stream it locally.
+    if (use_height_sharding) {
+        uint32_t num_shard_tiles = a.shard_spec().value().numel() / tile_hw;
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = num_shard_tiles * src0_single_tile_size,
+            .core_ranges = all_cores,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(src1_cb_index),
+                .data_format = src0_cb_data_format,
+                .page_size = src0_single_tile_size,
+            }}},
+            .tensor = &a,
+        });
+    }
+
     desc.cbs.push_back(CBDescriptor{
         .total_size = scaler_single_tile_size,
         .core_ranges = all_cores,
@@ -159,7 +199,9 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreWProgramFa
     });
 
     uint32_t output_cb_index = tt::CBIndex::c_3;
-    uint32_t num_output_tiles = 2;
+    // Height-sharded: alias the resident output shard as c_3 (write results in place). Otherwise a
+    // 2-tile scratch CB feeding the interleaved writer.
+    const uint32_t num_output_tiles = use_height_sharding ? output.shard_spec().value().numel() / tile_hw : 2;
     desc.cbs.push_back(CBDescriptor{
         .total_size = num_output_tiles * dst_single_tile_size,
         .core_ranges = all_cores,
@@ -168,6 +210,7 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreWProgramFa
             .data_format = dst_cb_data_format,
             .page_size = dst_single_tile_size,
         }}},
+        .tensor = use_height_sharding ? &output : nullptr,
     });
 
     // For min/max with non-unity scalar, the GMPOOL hardware path only respects the scaler's
@@ -185,6 +228,9 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreWProgramFa
     if (rm_path) {
         reader_compile_time_args = build_rm_reader_ct_args(
             plan, std::bit_cast<uint32_t>(operation_attributes.scaler), a, ReduceOpDim::W);
+    } else if (use_height_sharding) {
+        reader_compile_time_args = {
+            src0_cb_index, src1_cb_index, CBIndex::c_2, std::bit_cast<uint32_t>(operation_attributes.scaler)};
     } else {
         reader_compile_time_args = {std::bit_cast<uint32_t>(operation_attributes.scaler)};
         TensorAccessorArgs(a).append_to(reader_compile_time_args);
@@ -195,7 +241,9 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreWProgramFa
         writer_compile_time_args = build_rm_writer_ct_args(plan, output, ReduceOpDim::W);
     } else {
         writer_compile_time_args = {static_cast<uint32_t>(output_cb_index)};
-        TensorAccessorArgs(output).append_to(writer_compile_time_args);
+        if (!use_height_sharding) {  // interleaved writer also needs the tensor accessor
+            TensorAccessorArgs(output).append_to(writer_compile_time_args);
+        }
     }
 
     if (use_fpu_negate) {
@@ -241,18 +289,26 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreWProgramFa
     KernelDescriptor reader_desc;
     reader_desc.kernel_source =
         rm_path ? "ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/reader_unary_reduce_rm.cpp"
-                : "ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/"
-                  "reader_unary_reduce_universal_start_id.cpp";
+        : use_height_sharding ? "ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/"
+                                "reader_unary_reduce_input_rows_partitioned_sharded.cpp"
+                              : "ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/"
+                                "reader_unary_reduce_universal_start_id.cpp";
     reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
     reader_desc.core_ranges = all_cores;
     reader_desc.compile_time_args = reader_compile_time_args;
-    reader_desc.defines = {reduce_defines.begin(), reduce_defines.end()};
+    // The sharded reader prepares the scaler tile itself (gated on REDUCE_SCALER).
+    auto reader_defines = reduce_defines;
+    if (use_height_sharding) {
+        reader_defines["REDUCE_SCALER"] = "1";
+    }
+    reader_desc.defines = {reader_defines.begin(), reader_defines.end()};
     reader_desc.config = ReaderConfigDescriptor{};
 
     KernelDescriptor writer_desc;
     writer_desc.kernel_source =
-        rm_path
-            ? "ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/writer_reduce_rm_scalar.cpp"
+        rm_path ? "ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/writer_reduce_rm_scalar.cpp"
+        : use_height_sharding
+            ? "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/writer_unary_sharded.cpp"
             : "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp";
     writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
     writer_desc.core_ranges = all_cores;
@@ -333,6 +389,31 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreWProgramFa
 
     TT_FATAL(Wt != 0, "Width in tiles (Wt) must be non-zero (W={}, tile_width={})", W, tile_width);
     uint32_t out_dim_divider = Wt;
+    if (use_height_sharding) {
+        // Each core streams its resident shard (shard_Ht rows x Wt cols) into c_0 and reduces each
+        // row over Wt -> shard_Ht output tiles written in place to the aliased output shard.
+        // Every core owns an identical local shard, so all cores get the same args.
+        // The generic path's coverage check is past the early return, so restate it here.
+        TT_FATAL(
+            shard_Ht * num_cores == num_rows,
+            "Height-sharded reduce W: {} shard rows across {} cores must cover all {} tile-rows",
+            shard_Ht,
+            num_cores,
+            num_rows);
+        KernelDescriptor::CoreRuntimeArgs reader_rt_args = {shard_Ht * Wt};
+        KernelDescriptor::CoreRuntimeArgs writer_rt_args = {shard_Ht};
+        for (const CoreCoord& core : corerange_to_cores(all_cores)) {
+            reader_desc.runtime_args.emplace_back(core, reader_rt_args);
+            writer_desc.runtime_args.emplace_back(core, writer_rt_args);
+        }
+        desc.kernels.push_back(std::move(reader_desc));
+        desc.kernels.push_back(std::move(writer_desc));
+        desc.kernels.push_back(std::move(compute_desc_g1));
+        if (compute_desc_g2.has_value()) {
+            desc.kernels.push_back(std::move(*compute_desc_g2));
+        }
+        return desc;
+    }
     std::vector<CoreCoord> cores;
     if (rm_path) {
         // Match the row-wise split so core[i] receives the i-th contiguous row chunk.

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_w_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_w_program_factory.cpp
@@ -31,9 +31,18 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreWProgramFa
     uint32_t W = shape[3], H = shape[2], NC = shape[1] * shape[0];
     const uint32_t tile_height = a.tensor_spec().tile().get_height();
     const uint32_t tile_width = a.tensor_spec().tile().get_width();
+    const uint32_t tile_hw = a.tensor_spec().tile().get_tile_hw();
 
     uint32_t Wt = tt::div_up(W, tile_width);
     uint32_t Ht = tt::div_up(H, tile_height);
+
+    // Height-sharded fast path (symmetric to the H factory's width-sharded path): when both input
+    // and output are HEIGHT_SHARDED the whole per-core shard is already resident in L1, so each core
+    // reduces its own rows locally instead of gathering every input tile through the generic
+    // interleaved TensorAccessor (which incurs cross-core NoC traffic and serializes data movement).
+    const bool use_height_sharding = !rm_path &&
+                                     a.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED &&
+                                     output.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED;
 
     if (rm_path) {
         validate_rm_preconditions(
@@ -91,6 +100,19 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreWProgramFa
     }
     TT_FATAL(num_cores > 0, "Reduce W requires at least one worker core");
 
+    // Height-sharded: pin the worker set to the shard grid and give each core exactly the rows
+    // (tile-rows) in its own shard. Each row reduces over the full Wt columns -> one output tile.
+    uint32_t shard_Ht = 0;
+    if (use_height_sharding) {
+        all_cores = a.shard_spec().value().grid;
+        num_cores = all_cores.num_cores();
+        core_group_1 = all_cores;
+        core_group_2 = CoreRangeSet();
+        shard_Ht = a.shard_spec().value().shape[0] / tile_height;
+        num_rows_per_core_group_1 = shard_Ht;
+        num_rows_per_core_group_2 = 0;
+    }
+
     ProgramDescriptor desc;
 
     if (rm_path) {
@@ -134,6 +156,7 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreWProgramFa
     }
 
     uint32_t src0_cb_index = 0;
+    uint32_t src1_cb_index = tt::CBIndex::c_1;
     uint32_t num_input_tiles = 2;
     if (rm_path) {
         num_input_tiles = std::max(num_input_tiles, plan.wt_tiles_per_chunk);
@@ -148,6 +171,21 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreWProgramFa
         }}},
     });
 
+    // Height-sharded: alias the resident input shard as c_1 so the reader can stream it locally.
+    if (use_height_sharding) {
+        uint32_t num_shard_tiles = a.shard_spec().value().numel() / tile_hw;
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = num_shard_tiles * src0_single_tile_size,
+            .core_ranges = all_cores,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(src1_cb_index),
+                .data_format = src0_cb_data_format,
+                .page_size = src0_single_tile_size,
+            }}},
+            .tensor = &a,
+        });
+    }
+
     desc.cbs.push_back(CBDescriptor{
         .total_size = scaler_single_tile_size,
         .core_ranges = all_cores,
@@ -159,7 +197,9 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreWProgramFa
     });
 
     uint32_t output_cb_index = tt::CBIndex::c_3;
-    uint32_t num_output_tiles = 2;
+    // Height-sharded: alias the resident output shard as c_3 (write results in place). Otherwise a
+    // 2-tile scratch CB feeding the interleaved writer.
+    const uint32_t num_output_tiles = use_height_sharding ? output.shard_spec().value().numel() / tile_hw : 2;
     desc.cbs.push_back(CBDescriptor{
         .total_size = num_output_tiles * dst_single_tile_size,
         .core_ranges = all_cores,
@@ -168,6 +208,7 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreWProgramFa
             .data_format = dst_cb_data_format,
             .page_size = dst_single_tile_size,
         }}},
+        .tensor = use_height_sharding ? &output : nullptr,
     });
 
     // For min/max with non-unity scalar, the GMPOOL hardware path only respects the scaler's
@@ -185,6 +226,9 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreWProgramFa
     if (rm_path) {
         reader_compile_time_args = build_rm_reader_ct_args(
             plan, std::bit_cast<uint32_t>(operation_attributes.scaler), a, ReduceOpDim::W);
+    } else if (use_height_sharding) {
+        reader_compile_time_args = {
+            src0_cb_index, src1_cb_index, CBIndex::c_2, std::bit_cast<uint32_t>(operation_attributes.scaler)};
     } else {
         reader_compile_time_args = {std::bit_cast<uint32_t>(operation_attributes.scaler)};
         TensorAccessorArgs(a).append_to(reader_compile_time_args);
@@ -195,7 +239,9 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreWProgramFa
         writer_compile_time_args = build_rm_writer_ct_args(plan, output, ReduceOpDim::W);
     } else {
         writer_compile_time_args = {static_cast<uint32_t>(output_cb_index)};
-        TensorAccessorArgs(output).append_to(writer_compile_time_args);
+        if (!use_height_sharding) {  // interleaved writer also needs the tensor accessor
+            TensorAccessorArgs(output).append_to(writer_compile_time_args);
+        }
     }
 
     if (use_fpu_negate) {
@@ -241,18 +287,26 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreWProgramFa
     KernelDescriptor reader_desc;
     reader_desc.kernel_source =
         rm_path ? "ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/reader_unary_reduce_rm.cpp"
-                : "ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/"
-                  "reader_unary_reduce_universal_start_id.cpp";
+        : use_height_sharding ? "ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/"
+                                "reader_unary_reduce_input_rows_partitioned_sharded.cpp"
+                              : "ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/"
+                                "reader_unary_reduce_universal_start_id.cpp";
     reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
     reader_desc.core_ranges = all_cores;
     reader_desc.compile_time_args = reader_compile_time_args;
-    reader_desc.defines = {reduce_defines.begin(), reduce_defines.end()};
+    // The sharded reader prepares the scaler tile itself (gated on REDUCE_SCALER).
+    auto reader_defines = reduce_defines;
+    if (use_height_sharding) {
+        reader_defines["REDUCE_SCALER"] = "1";
+    }
+    reader_desc.defines = {reader_defines.begin(), reader_defines.end()};
     reader_desc.config = ReaderConfigDescriptor{};
 
     KernelDescriptor writer_desc;
     writer_desc.kernel_source =
-        rm_path
-            ? "ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/writer_reduce_rm_scalar.cpp"
+        rm_path ? "ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/writer_reduce_rm_scalar.cpp"
+        : use_height_sharding
+            ? "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/writer_unary_sharded.cpp"
             : "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp";
     writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
     writer_desc.core_ranges = all_cores;
@@ -332,6 +386,24 @@ tt::tt_metal::ProgramDescriptor ReduceDeviceOperation::ReduceMultiCoreWProgramFa
 
     TT_FATAL(Wt != 0, "Width in tiles (Wt) must be non-zero (W={}, tile_width={})", W, tile_width);
     uint32_t out_dim_divider = Wt;
+    if (use_height_sharding) {
+        // Each core streams its resident shard (shard_Ht rows x Wt cols) into c_0 and reduces each
+        // row over Wt -> shard_Ht output tiles written in place to the aliased output shard.
+        // Every core owns an identical local shard, so all cores get the same args.
+        KernelDescriptor::CoreRuntimeArgs reader_rt_args = {shard_Ht * Wt};
+        KernelDescriptor::CoreRuntimeArgs writer_rt_args = {shard_Ht};
+        for (const CoreCoord& core : corerange_to_cores(all_cores)) {
+            reader_desc.runtime_args.emplace_back(core, reader_rt_args);
+            writer_desc.runtime_args.emplace_back(core, writer_rt_args);
+        }
+        desc.kernels.push_back(std::move(reader_desc));
+        desc.kernels.push_back(std::move(writer_desc));
+        desc.kernels.push_back(std::move(compute_desc_g1));
+        if (compute_desc_g2.has_value()) {
+            desc.kernels.push_back(std::move(*compute_desc_g2));
+        }
+        return desc;
+    }
     std::vector<CoreCoord> cores;
     if (rm_path) {
         // Match the row-wise split so core[i] receives the i-th contiguous row chunk.


### PR DESCRIPTION
### PR Category
Performance

### Summary
Closing #44698.

W-reduce (`dim=-1`) on height-sharded L1 tensors previously executed on cores that did not own the input shard, causing most data accesses to go over the NoC and making it significantly slower than the equivalent `dim=-2` reduction.

This change adds a height-sharded fast path so computation runs on the shard-owning cores with local reads and in-place writes. The optimization is enabled only when the input and output are both HEIGHT_SHARDED and their shard grid and shard height match; any other configuration falls through to the pre-existing generic path.

On WH N150 we have following findings (for int32 dtype and L1 sharded; best of 15 iterations after 3 warm-ups))

| Shape          | Dim | Op  | Before fix (ns) | After fix (ns) | Diff (ns) | Diff (%) |
|----------------|:---:|:---:|----------------:|---------------:|----------:|---------:|
| (1,1,4096,256) | -2  | max | 52,157          | 52,187         | +30       | +0.06%   |
| (1,1,4096,256) | -2  | min | 52,265          | 52,241         | −24       | −0.05%   |
| (1,1,256,4096) | -1  | max | 122,045         | 52,308         | −69,737   | −57.1%   |
| (1,1,256,4096) | -1  | min | 119,363         | 52,319         | −67,044   | −56.2%   |

Compared with the pre-#43989 (incorrect) FPU baseline, int32 now shows a similar overhead across both dimensions; the previous dim=-1 overhead was much smaller because it was masked by NoC stalls.

### Notes for reviewers
- Two files: the `use_height_sharding` path in `reduce_op_multi_core_w_program_factory.cpp`, plus
  a new local reader kernel `reader_unary_reduce_input_rows_partitioned_sharded.cpp`. Structurally mirrors the existing width-sharded H path.
- The fast path assumes the output shard layout equals the input's, so it is guarded on both shard
  **grid and shard height** matching. Anything else — including height-sharded tensors with
  differing geometry — falls back to the original path unchanged.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ign/min_max_perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ign/min_max_perf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ign/min_max_perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ign/min_max_perf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ign/min_max_perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ign/min_max_perf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ign/min_max_perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ign/min_max_perf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ign/min_max_perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ign/min_max_perf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ign/min_max_perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ign/min_max_perf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ign/min_max_perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ign/min_max_perf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ign/min_max_perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ign/min_max_perf)