### PR TITLE
[Quasar] Fix failing reduce tests - keep LoFi for Maxpool and pass in tensor_shape to reduce_tile

### DIFF
--- a/tests/tt_metal/tt_metal/test_kernels/compute/reduce_w.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/reduce_w.cpp
@@ -19,10 +19,12 @@ void kernel_main() {
     DataflowBuffer dfb_in_scaler(dfb::in_scaler);
     DataflowBuffer dfb_out(dfb::out);
     compute_kernel_hw_startup(dfb::in_data, dfb::in_scaler, dfb::out);
+#ifndef ARCH_QUASAR
     constexpr bool swap_operands = (REDUCE_DIM == ReduceDim::REDUCE_ROW) && (REDUCE_OP != PoolType::MAX);
     if constexpr (swap_operands) {
         reconfig_data_format(dfb::in_scaler, dfb::in_data);
     }
+#endif
     reduce_init<REDUCE_OP, REDUCE_DIM>(dfb::in_data, dfb::in_scaler, dfb::out);
 
     dfb_in_scaler.wait_front(onetile);

--- a/tt_metal/hw/inc/api/compute/reduce.h
+++ b/tt_metal/hw/inc/api/compute/reduce.h
@@ -228,13 +228,13 @@ ALWI void reduce_block(
 // clang-format on
 template <PoolType reduce_type, ReduceDim reduce_dim>
 ALWI void reduce_tile_math(std::uint32_t idst, std::uint32_t num_faces = 4) {
-#ifndef ARCH_QUASAR
     ASSERT(num_faces > 0 && num_faces <= MAX_NUM_FACES);
     const ckernel::TensorShape tensor_shape = {
         MAX_FACE_R_DIM,
         MAX_FACE_C_DIM,
         (num_faces <= MAX_NUM_FACES_C_DIM) ? static_cast<std::uint8_t>(1) : MAX_NUM_FACES_R_DIM,
         (num_faces <= MAX_NUM_FACES_C_DIM) ? static_cast<std::uint8_t>(num_faces) : MAX_NUM_FACES_C_DIM};
+#ifndef ARCH_QUASAR
     MATH((llk_math_reduce<reduce_type, reduce_dim, DST_ACCUM_MODE, MATH_FIDELITY>(idst, tensor_shape)));
 #else
     MATH((llk_math_reduce<reduce_type, reduce_dim>(idst, tensor_shape)));

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_reduce.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_reduce.h
@@ -248,21 +248,20 @@ template <PoolType POOL_TYPE, ckernel::MathFidelity MATH_FIDELITY_TYPE>
 inline void _llk_math_reduce_row_mop_config_(const TensorShape& tensor_shape)
 {
     constexpr bool RUN_FID_LOOPS = (MATH_FIDELITY_TYPE != ckernel::MathFidelity::LoFi && (POOL_TYPE == PoolType::AVG || POOL_TYPE == PoolType::SUM));
-    constexpr std::uint32_t NUM_FIDELITY_PHASES = MATH_FIDELITY_TYPE == ckernel::MathFidelity::LoFi ? 0 : to_underlying(MATH_FIDELITY_TYPE) - 1;
+    constexpr std::uint32_t NUM_FIDELITY_PHASES = RUN_FID_LOOPS ? (to_underlying(MATH_FIDELITY_TYPE) - 1) : 0;
     constexpr std::uint32_t MOP_OUTER_LOOP      = 1;
     const std::uint32_t MOP_INNER_LOOP          = (tensor_shape.total_num_faces() >= 2 && !(tensor_shape.num_faces_c_dim < tensor_shape.num_faces_r_dim))
                                                       ? (tensor_shape.total_num_faces() >> 1)
                                                       : tensor_shape.total_num_faces();
 
-    constexpr std::uint32_t fidelity_slots = RUN_FID_LOOPS ? NUM_FIDELITY_PHASES : 0;
-    std::uint32_t replay_buf_len           = 7 + fidelity_slots;
+    std::uint32_t replay_buf_len = 7 + NUM_FIDELITY_PHASES;
     if (tensor_shape.total_num_faces() > 1 && tensor_shape.num_faces_c_dim >= tensor_shape.num_faces_r_dim)
     {
         if (tensor_shape.total_num_faces() == NUM_FACES)
         {
             replay_buf_len++;
         }
-        replay_buf_len += fidelity_slots + 1U;
+        replay_buf_len += NUM_FIDELITY_PHASES + 1U;
     }
 
     if (tensor_shape.face_r_dim > ELTWISE_MATH_ROWS)

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_reduce.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_reduce.h
@@ -254,14 +254,15 @@ inline void _llk_math_reduce_row_mop_config_(const TensorShape& tensor_shape)
                                                       ? (tensor_shape.total_num_faces() >> 1)
                                                       : tensor_shape.total_num_faces();
 
-    std::uint32_t replay_buf_len = 7 + NUM_FIDELITY_PHASES;
+    constexpr std::uint32_t fidelity_slots = RUN_FID_LOOPS ? NUM_FIDELITY_PHASES : 0;
+    std::uint32_t replay_buf_len           = 7 + fidelity_slots;
     if (tensor_shape.total_num_faces() > 1 && tensor_shape.num_faces_c_dim >= tensor_shape.num_faces_r_dim)
     {
         if (tensor_shape.total_num_faces() == NUM_FACES)
         {
             replay_buf_len++;
         }
-        replay_buf_len += NUM_FIDELITY_PHASES + 1U;
+        replay_buf_len += fidelity_slots + 1U;
     }
 
     if (tensor_shape.face_r_dim > ELTWISE_MATH_ROWS)


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Fixes compile error which happens because tensor_shape is passed to Quasar reduce_tile compute api without being defined previously.
Fixes failing max pool, HiFi tests. For max pool, math fidelity should be ignored aka LoFi is always used.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amokan/fix_reduce_compile)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amokan/fix_reduce_compile)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amokan/fix_reduce_compile)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amokan/fix_reduce_compile)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=amokan/fix_reduce_compile)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:amokan/fix_reduce_compile)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amokan/fix_reduce_compile)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amokan/fix_reduce_compile)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amokan/fix_reduce_compile)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amokan/fix_reduce_compile)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amokan/fix_reduce_compile)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amokan/fix_reduce_compile)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amokan/fix_reduce_compile)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amokan/fix_reduce_compile)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amokan/fix_reduce_compile)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amokan/fix_reduce_compile)