### PR TITLE
#48928: uniform migrate get_dynamic_runtime_args to override_runtime_arguments

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/rand/test_uniform.py
+++ b/tests/ttnn/nightly/unit_tests/operations/rand/test_uniform.py
@@ -176,6 +176,46 @@ def test_uniform_seed_distinguishes_cache_entries(device):
     device.disable_and_clear_program_cache()
 
 
+def test_uniform_range_reapplied_on_cache_hit(device):
+    """Guards that from/to (like seed) are re-applied to the cached program on a cache HIT.
+
+    from/to/seed are excluded from compute_program_hash, so calls differing only in those values
+    cache-hit instead of recompiling. override_runtime_arguments() must re-derive and re-apply the
+    per-core f2u_from/f2u_to compute-kernel runtime args on every hit (via create_descriptor).
+    seed-only tests above hold from/to fixed, so they would not catch a frozen range arg. Pins:
+      * changing only from/to must NOT grow the cache -> guards against re-adding them to the hash.
+      * changing from/to must move the output into the new range -> guards against a frozen range
+        arg on the in-place cache-hit fast path.
+    """
+    device.enable_program_cache()
+    device.clear_program_cache()
+
+    shape = (256, 256)
+    npu = ttnn.from_torch(
+        torch.zeros(shape, dtype=torch.float32), device=device, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT
+    )
+
+    ttnn.uniform(npu, 0.0, 1.0, 1234)
+    out_lo = ttnn.to_torch(npu).float().clone()
+    entries_first = device.num_program_cache_entries()
+
+    # from/to are hash-excluded -> this is a cache HIT even though the range differs.
+    ttnn.uniform(npu, 100.0, 200.0, 1234)
+    out_hi = ttnn.to_torch(npu).float().clone()
+    entries_second = device.num_program_cache_entries()
+
+    assert entries_first > 0
+    assert (
+        entries_second == entries_first
+    ), "changing only from/to must NOT add a cache entry -- they are dynamic, not hashed"
+    assert out_lo.min() >= 0.0 and out_lo.max() < 1.0, "initial from/to range not respected"
+    assert (
+        out_hi.min() >= 100.0 and out_hi.max() < 200.0
+    ), "from/to not re-applied on the cache-hit fast path (frozen range runtime arg)"
+
+    device.disable_and_clear_program_cache()
+
+
 @pytest.mark.parametrize(
     "shape",
     [[512, 512], [5, 2, 4, 70, 40]],

--- a/ttnn/cpp/ttnn/operations/uniform/device/uniform_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/uniform/device/uniform_device_operation.hpp
@@ -48,9 +48,10 @@ struct UniformDeviceOperation {
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 
     // seed/from/to are excluded from the program hash (so calls differing only in those values
-    // cache-hit instead of recompiling); they are DYNAMIC and re-applied to the cached program on
-    // every dispatch. Must mirror the compute-kernel runtime args built in create_descriptor().
-    static std::vector<tt::tt_metal::DynamicRuntimeArg> get_dynamic_runtime_args(
+    // cache-hit instead of recompiling); they are re-applied to the cached program on every hit via
+    // override_runtime_arguments() by re-running create_descriptor() (single source of truth). See the .cpp.
+    static void override_runtime_arguments(
+        tt::tt_metal::Program& program,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
         tensor_return_value_t& output,

--- a/ttnn/cpp/ttnn/operations/uniform/device/uniform_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/uniform/device/uniform_program_factory.cpp
@@ -179,29 +179,18 @@ ProgramDescriptor UniformDeviceOperation::create_descriptor(
     return desc;
 }
 
-std::vector<tt::tt_metal::DynamicRuntimeArg> UniformDeviceOperation::get_dynamic_runtime_args(
+void UniformDeviceOperation::override_runtime_arguments(
+    tt::tt_metal::Program& program,
     const operation_attributes_t& operation_attributes,
-    const tensor_args_t& /*tensor_args*/,
+    const tensor_args_t& tensor_args,
     tensor_return_value_t& output,
     const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
-    // compute is kernel 1; its runtime args are {seed, f2u_from, f2u_to, tile_offset, units_per_core}.
-    // seed/from/to are excluded from the hash and re-applied here; the rest are static.
-    constexpr uint32_t kComputeKernelIdx = 1;
-    auto cores = uniform_work_split(output).cores;
-
-    const float eps = 1e-6f;
-    const uint32_t f2u_from = std::bit_cast<uint32_t>(operation_attributes.from);
-    const uint32_t f2u_to = std::bit_cast<uint32_t>(operation_attributes.to - eps);
-
-    std::vector<tt::tt_metal::DynamicRuntimeArg> dynamic_args;
-    dynamic_args.reserve(cores.size() * 3);
-    for (int i = 0; i < static_cast<int>(cores.size()); ++i) {
-        const uint32_t seed = operation_attributes.seed != 0 ? operation_attributes.seed + i : get_random_seed();
-        dynamic_args.push_back({kComputeKernelIdx, cores[i], 0, seed});
-        dynamic_args.push_back({kComputeKernelIdx, cores[i], 1, f2u_from});
-        dynamic_args.push_back({kComputeKernelIdx, cores[i], 2, f2u_to});
-    }
-    return dynamic_args;
+    // Re-derive the descriptor from the single source of truth (create_descriptor) and re-apply its
+    // per-core runtime args (incl. hash-excluded seed/from/to) + tensor-backed CB/buffer addresses to
+    // the cached program. No program rebuild; supersedes get_dynamic/resolve_bindings and is correct
+    // under in-place aliasing (#48928).
+    auto desc = create_descriptor(operation_attributes, tensor_args, output);
+    tt::tt_metal::apply_descriptor_runtime_args(program, desc);
 }
 
 }  // namespace ttnn::operations::uniform

--- a/ttnn/cpp/ttnn/operations/uniform/device/uniform_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/uniform/device/uniform_program_factory.cpp
@@ -187,8 +187,7 @@ void UniformDeviceOperation::override_runtime_arguments(
     const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
     // Re-derive the descriptor from the single source of truth (create_descriptor) and re-apply its
     // per-core runtime args (incl. hash-excluded seed/from/to) + tensor-backed CB/buffer addresses to
-    // the cached program. No program rebuild; supersedes get_dynamic/resolve_bindings and is correct
-    // under in-place aliasing (#48928).
+    // the cached program. No program rebuild;
     auto desc = create_descriptor(operation_attributes, tensor_args, output);
     tt::tt_metal::apply_descriptor_runtime_args(program, desc);
 }


### PR DESCRIPTION
## What

Migrates `uniform` off the legacy `get_dynamic_runtime_args` cache-hit hook onto the descriptor-era `override_runtime_arguments` hook (same mechanism as #50346 / #50339 / #49828).

`override_runtime_arguments` re-derives the full descriptor from `create_descriptor` (single source of truth) and re-applies all per-core runtime args (incl. hash-excluded `seed`/`from`/`to`) plus tensor-backed CB/buffer addresses via `apply_descriptor_runtime_args`. No program rebuild; supersedes `get_dynamic_runtime_args` and `resolve_bindings`, correct under in-place aliasing (#48928).

## Why

Striving to eliminate `get_dynamic_runtime_args` from all descriptor ops. The adapter `static_assert`s that an op must not declare both hooks.

## Notes for reviewers

Draft — pending CI. `create_descriptor` re-run is cheap for `uniform` (no expensive per-core stick-walk), so no cache-hit dispatch regression is expected.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/48928_to_ora_uniform)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/48928_to_ora_uniform)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/48928_to_ora_uniform)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/48928_to_ora_uniform)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/48928_to_ora_uniform)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/48928_to_ora_uniform)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=AlexeyZaytsev-epam/48928_to_ora_uniform)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:AlexeyZaytsev-epam/48928_to_ora_uniform)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/48928_to_ora_uniform)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:AlexeyZaytsev-epam/48928_to_ora_uniform)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=AlexeyZaytsev-epam/48928_to_ora_uniform)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:AlexeyZaytsev-epam/48928_to_ora_uniform)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=AlexeyZaytsev-epam/48928_to_ora_uniform)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:AlexeyZaytsev-epam/48928_to_ora_uniform)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=AlexeyZaytsev-epam/48928_to_ora_uniform)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:AlexeyZaytsev-epam/48928_to_ora_uniform)