### PR TITLE
#48928: bernoulli migrate get_dynamic_runtime_args to override_runtime_arguments

### DIFF
--- a/ttnn/cpp/ttnn/operations/bernoulli/device/bernoulli_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/bernoulli/device/bernoulli_device_operation.hpp
@@ -48,9 +48,10 @@ struct BernoulliDeviceOperation {
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 
     // seed is excluded from the program hash (so calls differing only in seed cache-hit); it is
-    // DYNAMIC and re-applied to the cached program on every dispatch. Must mirror the compute-kernel
-    // seed runtime arg built in create_descriptor().
-    static std::vector<tt::tt_metal::DynamicRuntimeArg> get_dynamic_runtime_args(
+    // re-applied to the cached program on every hit via override_runtime_arguments() by re-running
+    // create_descriptor() (single source of truth). See the .cpp.
+    static void override_runtime_arguments(
+        tt::tt_metal::Program& program,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
         tensor_return_value_t& output,

--- a/ttnn/cpp/ttnn/operations/bernoulli/device/bernoulli_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/bernoulli/device/bernoulli_program_factory.cpp
@@ -200,23 +200,18 @@ ProgramDescriptor BernoulliDeviceOperation::create_descriptor(
     return desc;
 }
 
-std::vector<tt::tt_metal::DynamicRuntimeArg> BernoulliDeviceOperation::get_dynamic_runtime_args(
+void BernoulliDeviceOperation::override_runtime_arguments(
+    tt::tt_metal::Program& program,
     const operation_attributes_t& operation_attributes,
-    const tensor_args_t& /*tensor_args*/,
+    const tensor_args_t& tensor_args,
     tensor_return_value_t& output,
     const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
-    // compute is kernel 2 (reader 0, writer 1); its args are {seed, tile_offset, units_per_core}.
-    // Only the per-call seed is re-applied.
-    constexpr uint32_t kComputeKernelIdx = 2;
-    auto cores = bernoulli_work_split(output).cores;
-
-    std::vector<tt::tt_metal::DynamicRuntimeArg> dynamic_args;
-    dynamic_args.reserve(cores.size());
-    for (int i = 0; i < static_cast<int>(cores.size()); ++i) {
-        const uint32_t seed = operation_attributes.seed != 0 ? operation_attributes.seed + i : get_random_seed();
-        dynamic_args.push_back({kComputeKernelIdx, cores[i], 0, seed});
-    }
-    return dynamic_args;
+    // Re-derive the descriptor from the single source of truth (create_descriptor) and re-apply its
+    // per-core runtime args (incl. hash-excluded seed) + tensor-backed CB/buffer addresses to the
+    // cached program. No program rebuild; supersedes get_dynamic/resolve_bindings and is correct
+    // under in-place aliasing (#48928).
+    auto desc = create_descriptor(operation_attributes, tensor_args, output);
+    tt::tt_metal::apply_descriptor_runtime_args(program, desc);
 }
 
 }  // namespace ttnn::operations::bernoulli


### PR DESCRIPTION
## What

Migrates `bernoulli` off the legacy `get_dynamic_runtime_args` cache-hit hook onto the descriptor-era `override_runtime_arguments` hook (same mechanism as #50346 / #50339 / #49828).

`override_runtime_arguments` re-derives the full descriptor from `create_descriptor` (single source of truth) and re-applies all per-core runtime args (incl. hash-excluded `seed`) plus tensor-backed CB/buffer addresses via `apply_descriptor_runtime_args`. No program rebuild; supersedes `get_dynamic_runtime_args` and `resolve_bindings`, correct under in-place aliasing (#48928).

## Why

Part of the #48928 campaign to eliminate `get_dynamic_runtime_args` from all descriptor ops. The adapter `static_assert`s that an op must not declare both hooks.

Relates to #48928.

## Notes for reviewers

Draft — pending CI. `create_descriptor` re-run is cheap for `bernoulli` (no expensive per-core stick-walk), so no cache-hit dispatch regression is expected.

Made with [Cursor](https://cursor.com)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/48928_to_ora_bernoulli)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/48928_to_ora_bernoulli)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/48928_to_ora_bernoulli)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/48928_to_ora_bernoulli)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/48928_to_ora_bernoulli)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/48928_to_ora_bernoulli)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=AlexeyZaytsev-epam/48928_to_ora_bernoulli)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:AlexeyZaytsev-epam/48928_to_ora_bernoulli)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/48928_to_ora_bernoulli)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:AlexeyZaytsev-epam/48928_to_ora_bernoulli)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=AlexeyZaytsev-epam/48928_to_ora_bernoulli)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:AlexeyZaytsev-epam/48928_to_ora_bernoulli)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=AlexeyZaytsev-epam/48928_to_ora_bernoulli)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:AlexeyZaytsev-epam/48928_to_ora_bernoulli)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=AlexeyZaytsev-epam/48928_to_ora_bernoulli)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:AlexeyZaytsev-epam/48928_to_ora_bernoulli)