### PR TITLE
#48928: ternary migrate get_dynamic_runtime_args to override_runtime_arguments

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_ternary.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_ternary.py
@@ -385,7 +385,7 @@ def test_ternary_scalar_distinguishes_cache_entries(device):
     addcmul(a, b, c, value) packs `value` (scalar_input_a) into the compute-kernel runtime args.
     The scalar is intentionally EXCLUDED from to_hash()/compute_program_hash (so calls differing
     only in the scalar cache-hit instead of recompiling) but must be re-applied to the cached
-    program on every dispatch via TernaryDeviceOperation::get_dynamic_runtime_args(). Pins both
+    program on every dispatch via TernaryDeviceOperation::override_runtime_arguments(). Pins both
     halves of the contract:
       * a different scalar must NOT grow the cache  -> guards against re-adding the scalar to the
         hash (the recompile-per-scalar hack).
@@ -442,7 +442,7 @@ def test_ternary_addcmul_cache_hit_refreshes_operand_addresses(device):
     second same-shaped call whose operand lived in a DIFFERENT buffer ran against the first call's
     stale addresses and returned silent garbage (PCC ~0). Here the operands are distinct
     ttnn.chunk() slices of a single parent tensor, so they are the same shape but different buffers.
-    TernaryDeviceOperation::get_dynamic_runtime_args() must refresh reader slots 0/1/2 and writer
+    TernaryDeviceOperation::override_runtime_arguments() must refresh reader slots 0/1/2 and writer
     slot 0 on every dispatch.
     """
     device.enable_program_cache()
@@ -487,5 +487,62 @@ def test_ternary_addcmul_cache_hit_refreshes_operand_addresses(device):
 
     assert_with_pcc(reference(0), ttnn.to_torch(out0).float(), 0.99)
     assert_with_pcc(reference(2), ttnn.to_torch(out1).float(), 0.99)
+
+    device.disable_and_clear_program_cache()
+
+
+def test_ternary_addcmul_cache_hit_inplace_readdresses(device):
+    """Regression guard for the ternary IN-PLACE cache-hit path (the exact #48928 failure mode).
+
+    This is the migration from the deprecated get_dynamic_runtime_args() cache-hit hook to
+    TernaryDeviceOperation::override_runtime_arguments(), which re-derives the whole program from
+    TernaryProgramFactory::create_descriptor() on every cache hit -- so all tensor-backed
+    reader/writer buffer addresses are re-applied, INCLUDING the aliased output==input_a case.
+
+    An in-place addcmul (output_tensor aliases input_a) is dispatched twice at the SAME shape, so the
+    second call is a program-cache HIT that reuses the first program WITHOUT rebuild. Each dispatch
+    allocates fresh operands that are kept alive, so the cached program sees DIFFERENT buffer
+    addresses on the hit -- including the aliased output/input_a address. The legacy resolve_bindings
+    bailed on this ambiguous aliasing and left the addresses frozen at first miss, so the hit ran
+    against stale buffers and returned silent garbage (PCC ~0). Asserts (a) numerically-correct output
+    on the hit for the new operands and (b) the program-cache entry count does NOT grow.
+    """
+    device.enable_program_cache()
+    device.clear_program_cache()
+
+    shape = (1, 1, 256, 256)
+    value = 2.0
+    keep_alive = []  # hold refs so each dispatch's tensors get fresh (different) addresses
+
+    def inplace_addcmul(seed):
+        torch.manual_seed(seed)
+        a = torch.rand(shape, dtype=torch.bfloat16)
+        b = torch.rand(shape, dtype=torch.bfloat16)
+        c = torch.rand(shape, dtype=torch.bfloat16)
+        tt_a = ttnn.from_torch(a, device=device, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)
+        tt_b = ttnn.from_torch(b, device=device, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)
+        tt_c = ttnn.from_torch(c, device=device, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)
+        # In-place: output_tensor aliases input_a. addcmul(a, b, c, value) = a + value * b * c.
+        tt_out = ttnn.addcmul(tt_a, tt_b, tt_c, value=value, output_tensor=tt_a)
+        # Prove it is ACTUALLY in-place; otherwise the aliasing path is never exercised and a future
+        # change that allocated a fresh output would still pass PCC + single-cache-entry.
+        assert tt_out.buffer_address() == tt_a.buffer_address()
+        keep_alive.extend([tt_a, tt_b, tt_c, tt_out])
+        golden = a.float() + value * b.float() * c.float()
+        return golden, ttnn.to_torch(tt_out).float()
+
+    # First call compiles the in-place addcmul program.
+    ref1, out1 = inplace_addcmul(0)
+    entries_after_first = device.num_program_cache_entries()
+    assert_with_pcc(ref1, out1, 0.99)
+
+    # Cache HIT at the same shape with fresh, differently-addressed operands (incl. the aliased
+    # output/input_a): the program must be reused (no new entry) yet still produce correct values.
+    ref2, out2 = inplace_addcmul(1)
+    assert device.num_program_cache_entries() == entries_after_first, (
+        "in-place addcmul at the same shape must reuse the cached program (no new cache entry) -- a "
+        "new entry means the program was rebuilt, masking whether addresses are re-applied on the hit"
+    )
+    assert_with_pcc(ref2, out2, 0.99)
 
     device.disable_and_clear_program_cache()

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_device_operation.hpp
@@ -60,8 +60,11 @@ struct TernaryDeviceOperation {
     static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
     static bool skip_launch(const operation_attributes_t&, const tensor_args_t&, const tensor_return_value_t&);
 
-    // scalar_input_a/b are excluded from the hash; re-applied each dispatch. Mirrors the factory.
-    static std::vector<tt::tt_metal::DynamicRuntimeArg> get_dynamic_runtime_args(
+    // scalar_input_a/b are excluded from the hash; re-applied on every cache hit via
+    // override_runtime_arguments() by re-running TernaryProgramFactory::create_descriptor
+    // (single source of truth). See the .cpp.
+    static void override_runtime_arguments(
+        tt::tt_metal::Program& program,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
         tensor_return_value_t& output,

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_program_factory.cpp
@@ -1394,41 +1394,18 @@ tt::tt_metal::ProgramDescriptor TernaryDeviceOperation::TernaryProgramFactory::c
     return desc;
 }
 
-std::vector<tt::tt_metal::DynamicRuntimeArg> TernaryDeviceOperation::get_dynamic_runtime_args(
+void TernaryDeviceOperation::override_runtime_arguments(
+    tt::tt_metal::Program& program,
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& output,
     const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
-    // scalar_input_a / scalar_input_b are EXCLUDED from compute_program_hash (so calls differing
-    // only in a scalar cache-hit instead of recompiling).  On a cache hit the descriptor is never
-    // rebuilt, so the scalar baked at first miss would otherwise stay frozen.  Re-apply it here.
-    //
-    // MUST mirror create_descriptor()/populate_runtime_arguments() exactly:
-    //   - kernels are pushed reader(0), writer(1), compute(2)  -> scalar lives in kernel 2.
-    //   - compute per-core runtime args are {num_tiles_per_core, freq, counter, scalar_arg}
-    //     -> scalar is arg_idx 3.
-    //   - the scalar is written only to WORK cores (core_group_1/core_group_2); noop cores get
-    //     all-zero compute args and do no work, so they are left untouched.
-    // The packed value and the (cores, work-group) partition both come from the same helpers used
-    // by populate_runtime_arguments(), so this stays a by-construction exact mirror.
-    constexpr uint32_t kComputeKernelIdx = 2;
-    constexpr uint32_t kScalarArgIdx = 3;
-
-    const uint32_t scalar_arg = CMAKE_UNIQUE_NAMESPACE::pack_compute_scalar_arg(operation_attributes, output.dtype());
-
-    auto partition = CMAKE_UNIQUE_NAMESPACE::compute_core_partition(operation_attributes, tensor_args, output);
-
-    std::vector<tt::tt_metal::DynamicRuntimeArg> dynamic_args;
-    dynamic_args.reserve(partition.cores.size());
-    for (uint32_t i = 0; i < partition.num_cores_total; ++i) {
-        const auto& core = partition.cores[i];
-        const bool is_work_core = partition.core_group_1.contains(core) || partition.core_group_2.contains(core);
-        if (!is_work_core) {
-            continue;  // noop core: compute arg[3] stays 0, mirrors create_descriptor()
-        }
-        dynamic_args.push_back({kComputeKernelIdx, core, kScalarArgIdx, scalar_arg});
-    }
-    return dynamic_args;
+    // Re-derive the descriptor from the single source of truth (TernaryProgramFactory::create_descriptor)
+    // and re-apply its per-core runtime args (incl. hash-excluded scalar_input_a/b) + tensor-backed
+    // CB/buffer addresses to the cached program. No program rebuild; supersedes get_dynamic and
+    // resolve_bindings and is correct under in-place aliasing (#48928).
+    auto desc = TernaryProgramFactory::create_descriptor(operation_attributes, tensor_args, output);
+    tt::tt_metal::apply_descriptor_runtime_args(program, desc);
 }
 
 }  // namespace ttnn::operations::ternary


### PR DESCRIPTION
## What

Migrates `ternary` off the legacy `get_dynamic_runtime_args` cache-hit hook onto the descriptor-era `override_runtime_arguments` hook (same mechanism as #50346 / #50339 / #49828).

`override_runtime_arguments` re-derives the full descriptor from `TernaryProgramFactory::create_descriptor` (single source of truth) and re-applies all per-core runtime args (incl. hash-excluded `scalar_input_a`/`scalar_input_b`) plus tensor-backed CB/buffer addresses via `apply_descriptor_runtime_args`. No program rebuild; supersedes `get_dynamic_runtime_args` and `resolve_bindings`, correct under in-place aliasing (#48928).

## Why

Part of the #48928 campaign to eliminate `get_dynamic_runtime_args` from all descriptor ops. The adapter `static_assert`s that an op must not declare both hooks.

Relates to #48928.

## Notes for reviewers

Draft — pending CI. Single `TernaryProgramFactory` (ProgramDescriptor); `create_descriptor` re-run cost is per-tile arg packing, not an expensive per-core stick-walk.

Made with [Cursor](https://cursor.com)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/48928_to_ora_ternary)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/48928_to_ora_ternary)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/48928_to_ora_ternary)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/48928_to_ora_ternary)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/48928_to_ora_ternary)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/48928_to_ora_ternary)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=AlexeyZaytsev-epam/48928_to_ora_ternary)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:AlexeyZaytsev-epam/48928_to_ora_ternary)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/48928_to_ora_ternary)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:AlexeyZaytsev-epam/48928_to_ora_ternary)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=AlexeyZaytsev-epam/48928_to_ora_ternary)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:AlexeyZaytsev-epam/48928_to_ora_ternary)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=AlexeyZaytsev-epam/48928_to_ora_ternary)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:AlexeyZaytsev-epam/48928_to_ora_ternary)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=AlexeyZaytsev-epam/48928_to_ora_ternary)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:AlexeyZaytsev-epam/48928_to_ora_ternary)