### PR TITLE
#48928: update_cache migrate get_dynamic_runtime_args to override_runtime_arguments

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_update_cache.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_update_cache.py
@@ -184,17 +184,17 @@ def test_update_cache_decode_program_cache_hits(in_sharded, input_dtype, device)
 
     UpdateKVCacheOperation::compute_program_hash excludes update_idx (cache_idx)
     and batch_offset, so repeated update_cache calls that differ ONLY in those
-    values hit the program cache. get_dynamic_runtime_args must re-apply the
-    per-dispatch write/read offsets (cache_start_id / tile_update_offset /
-    batch_read_offset) on every hit; if any froze at the first cache-miss value
-    the update would land at (or read from) the wrong position and the
-    per-iteration comp_equal below would fail. We also assert the program cache
-    grew by exactly ONE entry, i.e. every call after the first was a genuine hit
-    (not a recompile that would silently mask a freeze).
+    values hit the program cache. UpdateKVCacheOperation::override_runtime_arguments
+    must re-apply the per-dispatch write/read offsets (cache_start_id /
+    tile_update_offset / batch_read_offset) on every hit; if any froze at the
+    first cache-miss value the update would land at (or read from) the wrong
+    position and the per-iteration comp_equal below would fail. We also assert the
+    program cache grew by exactly ONE entry, i.e. every call after the first was a
+    genuine hit (not a recompile that would silently mask a freeze).
 
     This exercises the branch the reviewer flagged: the pre-existing
     test_update_cache_decode calls update_cache only once per (freshly built)
-    program, so the get_dynamic re-application path is never taken.
+    program, so the override_runtime_arguments re-application path is never taken.
     """
     head_dim = 64
     max_seq_len = 4096
@@ -269,7 +269,96 @@ def test_update_cache_decode_program_cache_hits(in_sharded, input_dtype, device)
     assert eq_cache, out_cache
 
     # Exactly one program built: the first call missed, all later calls were
-    # genuine cache hits (so get_dynamic_runtime_args re-applied the offsets).
+    # genuine cache hits (so override_runtime_arguments re-applied the offsets).
+    assert (
+        num_new_cache_entries == 1
+    ), f"Expected a single program-cache entry (genuine hits after first), got {num_new_cache_entries}"
+
+
+@skip_for_blackhole("Mismatching on BH, see #12349")
+@pytest.mark.parametrize("in_sharded", [False, True])
+@pytest.mark.parametrize("input_dtype", [ttnn.bfloat16])
+def test_fill_cache_program_cache_hits(in_sharded, input_dtype, device):
+    """Cache-hit coverage for the FILL path's hash-excluded cache_start_id.
+
+    UpdateKVCacheOperation::compute_program_hash excludes batch_idx and
+    update_idx, so repeated fill_cache calls that differ ONLY in those values
+    hit the program cache. The FillCacheMultiCoreProgramFactory bakes the
+    derived per-core cache_start_id (which encodes batch_idx * seq + update_idx)
+    into a writer runtime arg; UpdateKVCacheOperation::override_runtime_arguments
+    must re-derive and re-apply it on every hit. If it froze at the first
+    cache-miss value every fill after the first would land at the wrong
+    user/seq slot and the per-iteration comp_equal below would fail. We also
+    assert the program cache grew by exactly ONE entry, i.e. every call after
+    the first was a genuine hit (not a recompile that would mask a freeze).
+    """
+    head_dim = 64
+    max_seq_len = 4096
+    num_users = 8
+    num_heads = 2
+    slab_seq_len = 128
+    cache_dtype = input_dtype
+
+    cache_shape = [num_users, num_heads, max_seq_len, head_dim]
+    cache = torch.zeros(cache_shape).bfloat16().float()
+    cachett = ttnn.Tensor(cache, cache_dtype).to(ttnn.TILE_LAYOUT).to(device)
+
+    # Each (batch_idx, update_idx) writes a full slab to a DIFFERENT user and/or
+    # sequence offset while tensor shapes/dtype/sharding stay identical -> all
+    # iterations share a single cached program. All (batch_idx, update_idx) pairs
+    # are distinct and non-overlapping so the whole cache must accumulate every
+    # fill. update_idx + slab_seq_len <= max_seq_len for each.
+    positions = [(0, 0), (1, 128), (3, 256), (7, 0), (2, 384)]
+
+    input_shape = [1, num_heads, slab_seq_len, head_dim]
+    num_new_cache_entries = 0
+    for batch_idx, update_idx in positions:
+        x = torch.randn(input_shape).bfloat16().float()
+        xt = ttnn.Tensor(x, input_dtype).to(ttnn.TILE_LAYOUT)
+        if in_sharded:
+            compute_grid_size = device.compute_with_storage_grid_size()
+            num_cores = min(slab_seq_len // 32 * num_heads, 32)
+            shard_grid = ttnn.num_cores_to_corerangeset(num_cores, compute_grid_size, True)
+            input_shard_spec = ttnn.ShardSpec(
+                shard_grid,
+                [
+                    xt.volume() // xt.padded_shape[-1] // num_cores,
+                    xt.padded_shape[-1],
+                ],
+                ttnn.ShardOrientation.ROW_MAJOR,
+            )
+            input_mem_config = ttnn.MemoryConfig(
+                ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, input_shard_spec
+            )
+            xt = xt.to(device, input_mem_config)
+        else:
+            xt = xt.to(device)
+
+        entries_before = device.num_program_cache_entries()
+        cachett = ttnn.fill_cache(cachett, xt, batch_idx, update_idx=update_idx)
+        num_new_cache_entries += device.num_program_cache_entries() - entries_before
+
+        # Mirror the fill into the torch reference at the SAME user/seq slot.
+        cache[batch_idx : batch_idx + 1, :, update_idx : update_idx + slab_seq_len, :] = x
+
+        # This iteration's slab must land at its own (batch_idx, update_idx). A
+        # frozen cache_start_id would corrupt this slice.
+        tt_got_back = cachett.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
+        eq_slab, out_slab = comp_equal(
+            x, tt_got_back[batch_idx : batch_idx + 1, :, update_idx : update_idx + slab_seq_len, :]
+        )
+        logger.info(f"batch_idx={batch_idx} update_idx={update_idx}: {out_slab}")
+        assert eq_slab, out_slab
+
+    # The full cache must reflect EVERY fill at its own position (catches a
+    # cache_start_id frozen at a prior iteration's value that clobbered elsewhere).
+    tt_got_back = cachett.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
+    eq_cache, out_cache = comp_equal(cache, tt_got_back)
+    logger.info(out_cache)
+    assert eq_cache, out_cache
+
+    # Exactly one program built: the first call missed, all later calls were
+    # genuine cache hits (so override_runtime_arguments re-applied cache_start_id).
     assert (
         num_new_cache_entries == 1
     ), f"Expected a single program-cache entry (genuine hits after first), got {num_new_cache_entries}"

--- a/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_device_operation.cpp
@@ -163,51 +163,24 @@ tt::tt_metal::operation::Hash UpdateKVCacheOperation::compute_program_hash(
         args.op_type, std::vector<Tensor>{tensor_args.cache, tensor_args.input});
 }
 
-std::vector<tt::tt_metal::DynamicRuntimeArg> UpdateKVCacheOperation::get_dynamic_runtime_args(
+void UpdateKVCacheOperation::override_runtime_arguments(
+    tt::tt_metal::Program& program,
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
-    tensor_return_value_t& /*tensor_return_value*/,
+    tensor_return_value_t& tensor_return_value,
     const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
-    // The work-split (hence the core set) depends only on shapes, which ARE in the program hash, so
-    // the active core set is identical on every cache hit — no freeze hazard from growing cores.
-    std::vector<tt::tt_metal::DynamicRuntimeArg> dynamic_args;
-
-    if (operation_attributes.op_type == UpdateCacheOpType::FILL) {
-        // FILL: kernel push order in FillCacheMultiCoreProgramFactory::create_descriptor is
-        // reader(0), writer(1). Only writer arg 2 (cache_start_id) is derived from the
-        // hash-excluded batch_idx/update_idx; the reader args are shape-only.
-        constexpr uint32_t kWriterKernelIdx = 1;
-        constexpr uint32_t kCacheStartIdArgIdx = 2;
-        const auto start_ids = compute_fill_cache_start_ids(operation_attributes, tensor_args);
-        dynamic_args.reserve(start_ids.size());
-        for (const auto& [core, cache_start_id] : start_ids) {
-            dynamic_args.push_back({kWriterKernelIdx, core, kCacheStartIdArgIdx, cache_start_id});
-        }
-        return dynamic_args;
-    }
-
-    // UPDATE: kernel push order in UpdateCacheMultiCoreProgramFactory::create_descriptor is
-    // reader(0), writer(1), compute(2), [optional compute(3)]. The hash-excluded values are:
-    //   reader arg 8  = cache_start_id (per core)
-    //   writer arg 7  = cache_start_id (per core)
-    //   writer arg 10 = tile_update_offset (op-wide)
-    //   writer arg 11 = batch_read_offset (op-wide)
-    constexpr uint32_t kReaderKernelIdx = 0;
-    constexpr uint32_t kWriterKernelIdx = 1;
-    constexpr uint32_t kReaderCacheStartIdArgIdx = 8;
-    constexpr uint32_t kWriterCacheStartIdArgIdx = 7;
-    constexpr uint32_t kWriterTileUpdateOffsetArgIdx = 10;
-    constexpr uint32_t kWriterBatchReadOffsetArgIdx = 11;
-
-    const auto dyn = compute_update_cache_dynamic_args(operation_attributes, tensor_args);
-    dynamic_args.reserve(dyn.cache_start_ids.size() * 4);
-    for (const auto& [core, cache_start_id] : dyn.cache_start_ids) {
-        dynamic_args.push_back({kReaderKernelIdx, core, kReaderCacheStartIdArgIdx, cache_start_id});
-        dynamic_args.push_back({kWriterKernelIdx, core, kWriterCacheStartIdArgIdx, cache_start_id});
-        dynamic_args.push_back({kWriterKernelIdx, core, kWriterTileUpdateOffsetArgIdx, dyn.tile_update_offset});
-        dynamic_args.push_back({kWriterKernelIdx, core, kWriterBatchReadOffsetArgIdx, dyn.batch_read_offset});
-    }
-    return dynamic_args;
+    // Re-derive the descriptor from the single source of truth (the selected factory's
+    // create_descriptor) and re-apply its per-core runtime args (incl. the hash-excluded
+    // cache_start_id / tile_update_offset / batch_read_offset) + tensor-backed CB/buffer addresses to
+    // the cached program. No program rebuild; supersedes get_dynamic and resolve_bindings and is
+    // correct under the in-place (cache == output) aliasing (#48928).
+    std::visit(
+        [&](auto&& factory) {
+            using F = std::decay_t<decltype(factory)>;
+            auto desc = F::create_descriptor(operation_attributes, tensor_args, tensor_return_value);
+            tt::tt_metal::apply_descriptor_runtime_args(program, desc);
+        },
+        select_program_factory(operation_attributes, tensor_args));
 }
 
 Tensor update_cache(

--- a/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/kv_cache/device/update_cache_device_operation.hpp
@@ -37,11 +37,11 @@ struct UpdateKVCacheOperation {
 
     // batch_idx, update_idx and batch_offset are excluded from compute_program_hash (so calls
     // differing only in them cache-hit), yet the factories bake the values they derive
-    // (cache_start_id, tile_update_offset, batch_read_offset) into runtime args. Those must be
-    // re-applied to the cached program on every dispatch or they freeze at the first cache-miss
-    // value — corrupting the write offset. The buffer base addresses are handled separately by the
-    // Buffer* bindings the factories declare via emplace_runtime_args.
-    static std::vector<tt::tt_metal::DynamicRuntimeArg> get_dynamic_runtime_args(
+    // (cache_start_id, tile_update_offset, batch_read_offset) into runtime args. Those are re-applied
+    // to the cached program on every hit via override_runtime_arguments() by re-running the selected
+    // factory's create_descriptor (single source of truth). See the .cpp.
+    static void override_runtime_arguments(
+        tt::tt_metal::Program& program,
         const operation_attributes_t& operation_attributes,
         const tensor_args_t& tensor_args,
         tensor_return_value_t& tensor_return_value,


### PR DESCRIPTION
## What

Migrates `update_cache` (kv_cache; `UpdateKVCacheOperation`, factories `UpdateCacheMultiCoreProgramFactory` / `FillCacheMultiCoreProgramFactory`) off the legacy `get_dynamic_runtime_args` cache-hit hook onto the descriptor-era `override_runtime_arguments` hook (same mechanism as #50346 / #50339 / #49828).

`override_runtime_arguments` re-selects the program factory and re-derives the full descriptor from its `create_descriptor` (single source of truth), re-applying all per-core runtime args (incl. hash-excluded `cache_start_id` / `tile_update_offset` / `batch_read_offset`) plus tensor-backed CB/buffer addresses via `apply_descriptor_runtime_args`. No program rebuild; supersedes `get_dynamic_runtime_args` and `resolve_bindings`, correct under the in-place `cache == output` aliasing (#48928).

## Why

Part of the #48928 campaign to eliminate `get_dynamic_runtime_args` from all descriptor ops. The adapter `static_assert`s that an op must not declare both hooks.

Relates to #48928.

## Notes for reviewers

Draft — pending CI. `create_descriptor` re-derivation is per-core `cache_start_id` arithmetic (cheap), not an expensive stick-walk.

Made with [Cursor](https://cursor.com)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/48928_to_ora_update_cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/48928_to_ora_update_cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/48928_to_ora_update_cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/48928_to_ora_update_cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/48928_to_ora_update_cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/48928_to_ora_update_cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=AlexeyZaytsev-epam/48928_to_ora_update_cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:AlexeyZaytsev-epam/48928_to_ora_update_cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/48928_to_ora_update_cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:AlexeyZaytsev-epam/48928_to_ora_update_cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=AlexeyZaytsev-epam/48928_to_ora_update_cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:AlexeyZaytsev-epam/48928_to_ora_update_cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=AlexeyZaytsev-epam/48928_to_ora_update_cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:AlexeyZaytsev-epam/48928_to_ora_update_cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=AlexeyZaytsev-epam/48928_to_ora_update_cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:AlexeyZaytsev-epam/48928_to_ora_update_cache)