### PR TITLE
#48928: nlp_create_qkv_heads_boltz migrate get_dynamic_runtime_args to override_runtime_arguments

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_nlp_create_qkv_heads_boltz.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_nlp_create_qkv_heads_boltz.py
@@ -90,3 +90,82 @@ def run_nlp_create_qkv_heads_boltz_test(batch, seq_len, head_dim, n_heads, dtype
 @pytest.mark.timeout(120)
 def test_nlp_create_qkv_heads_boltz(batch, seq_len, n_heads, head_dim, dtype, in0_mem_config, request, device):
     run_nlp_create_qkv_heads_boltz_test(batch, seq_len, head_dim, n_heads, dtype, in0_mem_config, device)
+
+
+"""
+#48928 override_runtime_arguments regression: on a program-cache HIT the op must re-derive and
+re-apply the per-dispatch tensor buffer addresses (fused QKV input + q/k/v outputs). The migration
+replaced the deprecated get_dynamic_runtime_args() cache-hit hook with override_runtime_arguments(),
+which re-runs the selected factory's create_descriptor and re-applies its runtime args (the
+Interleaved reader/writer bind the input/output buffers via Buffer* runtime args). If those addresses
+were frozen at the first (cache-miss) dispatch, a same-shape re-run against a freshly-allocated
+(differently-addressed) input tensor would read/write stale addresses and produce wrong outputs.
+"""
+
+
+def _build_boltz_qkv_inputs(batch, seq_len, head_dim, n_heads, dtype, in0_mem_config, device, seed):
+    torch.manual_seed(seed)
+    heads_num = n_heads
+
+    qkvg_shape = [batch, seq_len, seq_len, heads_num * head_dim * 3]
+    qkvg = torch.randn(qkvg_shape)
+
+    ref_q = qkvg[:, :, :, : heads_num * head_dim]
+    ref_k = qkvg[:, :, :, heads_num * head_dim : 2 * heads_num * head_dim]
+    ref_v = qkvg[:, :, :, 2 * heads_num * head_dim :]
+
+    ref_q = torch.reshape(ref_q, [seq_len, seq_len, heads_num, head_dim]).permute(2, 0, 1, 3)
+    ref_k = torch.reshape(ref_k, [seq_len, seq_len, heads_num, head_dim]).permute(2, 0, 1, 3)
+    ref_v = torch.reshape(ref_v, [seq_len, seq_len, heads_num, head_dim]).permute(2, 0, 1, 3)
+
+    qkvg_ttnn = ttnn.Tensor(qkvg, dtype).to(ttnn.TILE_LAYOUT).to(device, in0_mem_config)
+    return qkvg_ttnn, (ref_q, ref_k, ref_v)
+
+
+def _check_boltz_qkv_against_refs(q_ttnn, k_ttnn, v_ttnn, refs, pcc):
+    ref_q, ref_k, ref_v = refs
+    out_pass_q, output_pcc_q = comp_pcc(tt2torch_tensor(q_ttnn), ref_q, pcc)
+    out_pass_k, output_pcc_k = comp_pcc(tt2torch_tensor(k_ttnn), ref_k, pcc)
+    out_pass_v, output_pcc_v = comp_pcc(tt2torch_tensor(v_ttnn), ref_v, pcc)
+    logger.debug(f"Q pcc={output_pcc_q} K pcc={output_pcc_k} V pcc={output_pcc_v}")
+    assert out_pass_q, f"Q tensor quality check failed with PCC: {output_pcc_q}"
+    assert out_pass_k, f"K tensor quality check failed with PCC: {output_pcc_k}"
+    assert out_pass_v, f"V tensor quality check failed with PCC: {output_pcc_v}"
+
+
+@pytest.mark.timeout(120)
+def test_nlp_create_qkv_heads_boltz_cache_hit(device):
+    """Interleaved path: a same-shape cache-HIT dispatch on a freshly-allocated (differently-addressed)
+    fused QKV input tensor must re-apply the input/output buffer addresses (via
+    override_runtime_arguments) and stay numerically correct without growing the program cache."""
+    dtype = ttnn.bfloat16
+    pcc = 0.99
+    in0_mem_config = ttnn.DRAM_MEMORY_CONFIG
+    batch, seq_len, n_heads, head_dim = 1, 768, 4, 32
+
+    def run(seed):
+        qkvg_ttnn, refs = _build_boltz_qkv_inputs(
+            batch, seq_len, head_dim, n_heads, dtype, in0_mem_config, device, seed
+        )
+        q_ttnn, k_ttnn, v_ttnn = ttnn.experimental.nlp_create_qkv_heads_boltz(
+            qkvg_ttnn,
+            num_heads=n_heads,
+            num_kv_heads=n_heads,
+            transpose_k_heads=False,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+        _check_boltz_qkv_against_refs(q_ttnn, k_ttnn, v_ttnn, refs, pcc)
+        return qkvg_ttnn
+
+    # Prime the cache; HOLD the input so the cache-hit run's fresh allocation gets a different address.
+    keep = run(seed=1234)
+    entries_after_prime = device.num_program_cache_entries()
+    assert entries_after_prime > 0, "expected a cached program to hit"
+
+    # Cache HIT: same shape, fresh (differently-addressed) input tensor. Correct outputs prove the
+    # buffer addresses were re-applied on the hit, not frozen at the first (miss) dispatch.
+    hit = run(seed=5678)
+    assert hit.buffer_address() != keep.buffer_address(), "second input must land at a different address"
+    assert (
+        device.num_program_cache_entries() == entries_after_prime
+    ), "identical-shape cache-hit dispatch unexpectedly grew the program cache"

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_boltz/device/nlp_create_qkv_heads_boltz_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_boltz/device/nlp_create_qkv_heads_boltz_device_operation.hpp
@@ -69,14 +69,13 @@ struct NlpCreateHeadsBoltzDeviceOperation {
     // Create the output tensors based on the operation attributes and tensor args
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 
-    // Re-apply the Sharded factory's computed input-buffer addresses on every cache hit.
-    // The Sharded reader/writer bake raw base addresses AND per-core `base + head_offset` start
-    // addresses as uint32 runtime args; a plain Buffer* binding can only express the bare base, so
-    // these address-derived slots are refreshed here instead (the output CBs are patched via their
-    // `.buffer` bindings).  Defined in nlp_create_qkv_heads_boltz_program_factory.cpp so it can reuse
-    // the shared per-core arg builder that create_descriptor() uses. Interleaved returns no dynamic
-    // args.
-    static std::vector<tt::tt_metal::DynamicRuntimeArg> get_dynamic_runtime_args(
+    // Re-apply per-dispatch state on every cache hit via override_runtime_arguments() by re-running
+    // the selected factory's create_descriptor (single source of truth). The Sharded factory bakes
+    // address-derived Q/KV base+start slots that a plain Buffer* binding cannot express; re-deriving
+    // the descriptor re-applies them (Interleaved binds its buffers via emplace_runtime_args and its
+    // rebuild is a no-op re-application). Defined in nlp_create_qkv_heads_boltz_program_factory.cpp.
+    static void override_runtime_arguments(
+        tt::tt_metal::Program&,
         const operation_attributes_t&,
         const tensor_args_t&,
         tensor_return_value_t&,

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_boltz/device/nlp_create_qkv_heads_boltz_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_boltz/device/nlp_create_qkv_heads_boltz_program_factory.cpp
@@ -534,37 +534,25 @@ ProgramDescriptor NlpCreateHeadsBoltzDeviceOperation::Sharded::create_descriptor
     return desc;
 }
 
-std::vector<tt::tt_metal::DynamicRuntimeArg> NlpCreateHeadsBoltzDeviceOperation::get_dynamic_runtime_args(
+void NlpCreateHeadsBoltzDeviceOperation::override_runtime_arguments(
+    tt::tt_metal::Program& program,
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& tensor_args,
     tensor_return_value_t& tensor_return_value,
     const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
-    // Only the Sharded factory smuggles computed addresses; the Interleaved factory binds its
-    // input/output buffers via emplace_runtime_args(Buffer*) and needs no dynamic re-application.
-    const auto factory = select_program_factory(operation_attributes, tensor_args);
-    if (!std::holds_alternative<Sharded>(factory)) {
-        return {};
-    }
-
-    // Re-run the shared per-core builder so the addresses re-applied here are, by construction,
-    // identical to those baked in create_descriptor().  For every active core re-apply the four
-    // address-derived slots on both the reader (kernel 0) and writer (kernel 1).  The active core
-    // set is fixed by the (hashed) output shard specs, so it never grows across hits and every core
-    // that received args on the cache miss also gets them here.
-    auto per_core_args = build_sharded_core_args(operation_attributes, tensor_args, tensor_return_value);
-    std::vector<tt::tt_metal::DynamicRuntimeArg> dynamic_args;
-    dynamic_args.reserve(per_core_args.size() * 8);
-    for (const auto& e : per_core_args) {
-        dynamic_args.push_back({kReaderKernelIdx, e.core, kQBaseAddrIdx, e.reader_args[kQBaseAddrIdx]});
-        dynamic_args.push_back({kReaderKernelIdx, e.core, kQStartAddrIdx, e.reader_args[kQStartAddrIdx]});
-        dynamic_args.push_back({kReaderKernelIdx, e.core, kKVBaseAddrIdx, e.reader_args[kKVBaseAddrIdx]});
-        dynamic_args.push_back({kReaderKernelIdx, e.core, kKVStartAddrIdx, e.reader_args[kKVStartAddrIdx]});
-        dynamic_args.push_back({kWriterKernelIdx, e.core, kQBaseAddrIdx, e.writer_args[kQBaseAddrIdx]});
-        dynamic_args.push_back({kWriterKernelIdx, e.core, kQStartAddrIdx, e.writer_args[kQStartAddrIdx]});
-        dynamic_args.push_back({kWriterKernelIdx, e.core, kKVBaseAddrIdx, e.writer_args[kKVBaseAddrIdx]});
-        dynamic_args.push_back({kWriterKernelIdx, e.core, kKVStartAddrIdx, e.writer_args[kKVStartAddrIdx]});
-    }
-    return dynamic_args;
+    // Re-derive the descriptor from the single source of truth (the selected factory's
+    // create_descriptor) and re-apply its per-core runtime args + tensor-backed CB/buffer addresses
+    // to the cached program. The Sharded factory's address-derived Q/KV base+start slots (which a
+    // plain Buffer* binding cannot express) are re-applied by construction; Interleaved's rebuild
+    // simply re-applies its emplace_runtime_args(Buffer*) bindings. No program rebuild; supersedes
+    // get_dynamic and resolve_bindings (#48928).
+    std::visit(
+        [&](auto&& factory) {
+            using F = std::decay_t<decltype(factory)>;
+            auto desc = F::create_descriptor(operation_attributes, tensor_args, tensor_return_value);
+            tt::tt_metal::apply_descriptor_runtime_args(program, desc);
+        },
+        select_program_factory(operation_attributes, tensor_args));
 }
 
 }  // namespace ttnn::operations::experimental::transformer


### PR DESCRIPTION
## What

Migrates `nlp_create_qkv_heads_boltz` (`NlpCreateHeadsBoltzDeviceOperation`, factories `Interleaved` / `Sharded`) off the legacy `get_dynamic_runtime_args` cache-hit hook onto the descriptor-era `override_runtime_arguments` hook (same mechanism as #50346 / #50339 / #49828).

`override_runtime_arguments` re-selects the program factory and re-derives the full descriptor from its `create_descriptor` (single source of truth), re-applying all per-core runtime args plus tensor-backed CB/buffer addresses via `apply_descriptor_runtime_args`. The `Sharded` factory's address-derived Q/KV base+start slots (which a plain `Buffer*` binding cannot express) are re-applied by construction; `Interleaved` simply re-applies its `emplace_runtime_args(Buffer*)` bindings. No program rebuild; supersedes `get_dynamic_runtime_args` and `resolve_bindings` (#48928).

## Why

Part of the #48928 campaign to eliminate `get_dynamic_runtime_args` from all descriptor ops. The adapter `static_assert`s that an op must not declare both hooks.

Relates to #48928.

## Notes for reviewers

Draft — pending CI.

Made with [Cursor](https://cursor.com)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/48928_to_ora_nlp_create_qkv_heads_boltz)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/48928_to_ora_nlp_create_qkv_heads_boltz)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/48928_to_ora_nlp_create_qkv_heads_boltz)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/48928_to_ora_nlp_create_qkv_heads_boltz)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/48928_to_ora_nlp_create_qkv_heads_boltz)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/48928_to_ora_nlp_create_qkv_heads_boltz)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=AlexeyZaytsev-epam/48928_to_ora_nlp_create_qkv_heads_boltz)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:AlexeyZaytsev-epam/48928_to_ora_nlp_create_qkv_heads_boltz)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/48928_to_ora_nlp_create_qkv_heads_boltz)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:AlexeyZaytsev-epam/48928_to_ora_nlp_create_qkv_heads_boltz)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=AlexeyZaytsev-epam/48928_to_ora_nlp_create_qkv_heads_boltz)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:AlexeyZaytsev-epam/48928_to_ora_nlp_create_qkv_heads_boltz)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=AlexeyZaytsev-epam/48928_to_ora_nlp_create_qkv_heads_boltz)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:AlexeyZaytsev-epam/48928_to_ora_nlp_create_qkv_heads_boltz)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=AlexeyZaytsev-epam/48928_to_ora_nlp_create_qkv_heads_boltz)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:AlexeyZaytsev-epam/48928_to_ora_nlp_create_qkv_heads_boltz)