### PR TITLE
[Cleanup] Device 2.0 Port for eltwise_copy kernel

### DIFF
--- a/ttnn/cpp/ttnn/kernel/compute/eltwise_copy.cpp
+++ b/ttnn/cpp/ttnn/kernel/compute/eltwise_copy.cpp
@@ -7,26 +7,32 @@
 #include "api/compute/common.h"
 #include "api/compute/tile_move_copy.h"
 #include "api/compute/eltwise_unary/eltwise_unary.h"
+#include "api/dataflow/circular_buffer.h"
 
 void kernel_main() {
     uint32_t per_core_tile_cnt = get_compile_time_arg_val(0);
+    constexpr uint32_t onetile = 1;
 
     unary_op_init_common(tt::CBIndex::c_0, tt::CBIndex::c_16);
     copy_tile_init(tt::CBIndex::c_0);
+
+    CircularBuffer cb_in(tt::CBIndex::c_0);
+    CircularBuffer cb_out(tt::CBIndex::c_16);
+
     for (uint32_t b = 0; b < per_core_tile_cnt; ++b) {
         tile_regs_acquire();
 
         // Pop tile after tile, copy to DST and pack
-        cb_wait_front(tt::CBIndex::c_0, 1);
-        cb_reserve_back(tt::CBIndex::c_16, 1);
+        cb_in.wait_front(onetile);
+        cb_out.reserve_back(onetile);
         copy_tile(tt::CBIndex::c_0, 0, 0);
 
         tile_regs_commit();
         tile_regs_wait();
         pack_tile(0, tt::CBIndex::c_16);
 
-        cb_pop_front(tt::CBIndex::c_0, 1);
-        cb_push_back(tt::CBIndex::c_16, 1);
+        cb_in.pop_front(onetile);
+        cb_out.push_back(onetile);
 
         tile_regs_release();
     }


### PR DESCRIPTION
### Summary
eltwise_copy still used the legacy free-function circular-buffer API. It needs to be Device 2.0 compliant to unblock Metal 2.0 ports.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=edwinlee/eltwise_device2.0)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:edwinlee/eltwise_device2.0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=edwinlee/eltwise_device2.0)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:edwinlee/eltwise_device2.0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=edwinlee/eltwise_device2.0)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:edwinlee/eltwise_device2.0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=edwinlee/eltwise_device2.0)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:edwinlee/eltwise_device2.0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=edwinlee/eltwise_device2.0)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:edwinlee/eltwise_device2.0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=edwinlee/eltwise_device2.0)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:edwinlee/eltwise_device2.0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=edwinlee/eltwise_device2.0)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:edwinlee/eltwise_device2.0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=edwinlee/eltwise_device2.0)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:edwinlee/eltwise_device2.0)