### PR TITLE
ds_prefill - Adaptive per_core_M for routed expert

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/perf/test_moe_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_moe_perf.py
@@ -44,15 +44,13 @@ def test_deepseek_v3_moe_perf_loudbox():
     """
     run_moe_perf_with_approximation(
         command_8x1=_CMD_8X1,
-        # Recalibrated 2026-07-30 on BH LoudBox 8x1 after routed expert optimization with removing prezeroing
-        # Was 17_151_588.
-        expected_ns_8x1=15_506_174,
+        # Recalibrated 2026-07-27 on BH LoudBox 8x1 after routed expert optimization with removing prezeroing
+        # Was 15_506_174.
+        expected_ns_8x1=14_549_108,
         model_name_8x1="deepseek_v3_moe_lb_8x1_dispatch_combine",
         command_2x4=_CMD_2X4,
-        # Recalibrated 2026-07-26 on BH LoudBox 2x4 for the same in-place direct-write
-        # change (no full-buffer device fill per layer): 35.13 ms -> 32.31 ms. UP_SPLIT
-        # was already baked in (39_194_517 -> 35_127_772). Was 35_127_772.
-        expected_ns_2x4=23_956_009,
+        # Recalibrated 2026-07-27 on BH LoudBox 2x4 for. Was 23_956_009.
+        expected_ns_2x4=15_954_784,
         model_name_2x4="deepseek_v3_moe_lb_2x4_gate",
         subdir="deepseek_v3_moe",
         margin=0.03,
@@ -91,7 +89,7 @@ def test_deepseek_v3_moe_perf_galaxy_pad50():
 
     run_model_device_perf_test_with_merge(
         command=_CMD_8X4_pad50,
-        expected_device_perf_ns_per_iteration=15_719_590,  # Recalibrated 2026-07-26 (perf improvement, was 27_159_208).
+        expected_device_perf_ns_per_iteration=14_107_228,  # Recalibrated 2026-07-27 (perf improvement, was 15_719_590).
         subdir="deepseek_v3_moe",
         model_name="deepseek_v3_moe_glx_8x4_pad50",
         num_iterations=1,

--- a/models/demos/deepseek_v3_d_p/tests/perf/test_prefill_block_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_prefill_block_perf.py
@@ -104,7 +104,7 @@ _SUBTORUS_4X4_HOSTGATE_SKIP = pytest.mark.skip(
         ),
         (
             f"pytest {_TEST_PATH} -k 'mesh-2x4-2link and layer3 and gate_device and no_ref and isl_6k4'",
-            44_143_703,  # Re-centered 2026-07-30 for two stacked speedups now in the tree -- BOTH
+            36_777_010,  # Re-centered 2026-07-27 for two stacked speedups now in the tree -- BOTH
             # the in-place direct-write change (drop the separate output buffer + per-layer fill;
             # measured 50.61 ms alone) AND #47536 (update_padded_kv_cache RM/fp8; measured 51.29 ms
             # alone). The combined 2x4-2link number can't be measured on the galaxy, so the target is
@@ -132,7 +132,7 @@ _SUBTORUS_4X4_HOSTGATE_SKIP = pytest.mark.skip(
         ),
         (
             f"pytest {_TEST_PATH} -k 'fabric2d-mesh-8x4 and layer3 and gate_device and no_ref and isl_25k'",
-            76_706_230,  # Recalibrated 2026-07-05 (perf improvement, was 87_100_959).
+            73_816_910,  # Recalibrated 2026-07-27 (perf improvement, was 76_706_230).
             "deepseek_v3_prefill_block",
             "deepseek_v3_prefill_block_8x4_layer3_moe_fabric2d",
             1,
@@ -142,7 +142,7 @@ _SUBTORUS_4X4_HOSTGATE_SKIP = pytest.mark.skip(
         ),
         (
             f"pytest {_TEST_PATH} -k 'fabric2d-mesh-2x4 and layer3 and gate_device and no_ref and isl_6k4'",
-            58_182_777,  # Re-centered 2026-07-30 for two stacked speedups now in the tree -- BOTH
+            50_907_612,  # Re-centered 2026-07-27 for two stacked speedups now in the tree -- BOTH
             # the in-place direct-write change (measured 64.30 ms alone) AND #47536
             # (update_padded_kv_cache RM/fp8; measured 64.80 ms alone). The combined 2x4-2link number
             # can't be measured on the galaxy, so the target is the midpoint of the plausible combined

--- a/models/demos/deepseek_v3_d_p/tests/perf/test_prefill_block_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_prefill_block_perf.py
@@ -142,7 +142,7 @@ _SUBTORUS_4X4_HOSTGATE_SKIP = pytest.mark.skip(
         ),
         (
             f"pytest {_TEST_PATH} -k 'fabric2d-mesh-2x4 and layer3 and gate_device and no_ref and isl_6k4'",
-            50_907_612,  # Re-centered 2026-07-27 for two stacked speedups now in the tree -- BOTH
+            49_115_801,  # Re-centered 2026-07-27 for two stacked speedups now in the tree -- BOTH
             # the in-place direct-write change (measured 64.30 ms alone) AND #47536
             # (update_padded_kv_cache RM/fp8; measured 64.80 ms alone). The combined 2x4-2link number
             # can't be measured on the galaxy, so the target is the midpoint of the plausible combined

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_routed_expert.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_routed_expert.py
@@ -264,7 +264,10 @@ class TtRoutedExpert(LightweightModule):
             experts_per_chip: Number of local experts per chip
             emb_dim: Embedding dimension (default: 7168)
             hidden_dim: Hidden/intermediate dimension (default: 2048)
-            max_tokens: Maximum tokens per expert (default: 1600, used for program config)
+            max_tokens: Maximum tokens per expert (default: 1600, used for program config).
+                          The FFN kernel sizes chunk_M_tiles/per_core_M to each expert's
+                          ACTUAL token count at runtime (read device-side), so no expected-
+                          token hint is needed.
             torch_weights: Optional list of dicts with keys 'gate_proj', 'up_proj', 'down_proj'
                           containing torch tensors. Length must be num_devices * experts_per_chip
                           (total routed experts), with weights ordered by global expert index.

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_single_routed_expert.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_single_routed_expert.py
@@ -8,6 +8,8 @@ Minimal single-device, single-expert test for TtRoutedExpert profiling.
 The simplest scenario: 1 chip, 1 expert, minimal dimensions.
 """
 
+import os
+
 import pytest
 import torch
 from loguru import logger
@@ -34,6 +36,16 @@ SINGLE_CHIP_MESH_PARAMS = [
         id="single-chip",
     ),
 ]
+
+
+def _perf_toggle_makes_output_garbage():
+    """True when an RE_SKIP_* perf-investigation toggle is set. Those toggles strip
+    compute/output/read work to isolate DRAM I/O, so the numerical result is garbage
+    and PCC/NaN checks must be skipped on that run."""
+    return any(
+        os.environ.get(var) not in (None, "", "0")
+        for var in ("RE_SKIP_MATMUL", "RE_SKIP_OUTPUT_WRITE", "RE_SKIP_WEIGHT_READ")
+    )
 
 
 def run_single_routed_expert(
@@ -133,10 +145,20 @@ def run_single_routed_expert(
         activation=ttnn.RoutedExpertActivation.Silu,
     )
 
-    # Run TTNN forward
-    logger.debug("Running TTNN forward...")
-    tt_output = tt_expert(tt_input, expert_token_counts_tt, expert_region_offsets_tt)
+    # Run TTNN forward. ROUTED_EXPERT_PERF_ITERS > 1 repeats the op back-to-back
+    # (warm, cached program) so a tracy profiling run captures multiple device
+    # invocations to median over; the first (cold) iteration is dropped in
+    # analysis. The signpost above brackets the whole loop.
+    perf_iters = max(1, int(os.environ.get("ROUTED_EXPERT_PERF_ITERS", "1")))
+    logger.debug(f"Running TTNN forward ({perf_iters} iters)...")
+    for _ in range(perf_iters):
+        tt_output = tt_expert(tt_input, expert_token_counts_tt, expert_region_offsets_tt)
+    ttnn.synchronize_device(mesh_device)
     logger.debug(f"TTNN output shape: {tt_output.shape}")
+
+    if _perf_toggle_makes_output_garbage():
+        logger.warning("RE_SKIP_* set: skipping PCC/NaN checks (perf-only run)")
+        return
 
     # Convert back to torch for comparison. For a 1-device replicated tensor,
     # ConcatMeshToTensor(dim=0) with 1 slice is a no-op that returns the tensor.

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_single_routed_expert.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_single_routed_expert.py
@@ -8,8 +8,6 @@ Minimal single-device, single-expert test for TtRoutedExpert profiling.
 The simplest scenario: 1 chip, 1 expert, minimal dimensions.
 """
 
-import os
-
 import pytest
 import torch
 from loguru import logger
@@ -36,16 +34,6 @@ SINGLE_CHIP_MESH_PARAMS = [
         id="single-chip",
     ),
 ]
-
-
-def _perf_toggle_makes_output_garbage():
-    """True when an RE_SKIP_* perf-investigation toggle is set. Those toggles strip
-    compute/output/read work to isolate DRAM I/O, so the numerical result is garbage
-    and PCC/NaN checks must be skipped on that run."""
-    return any(
-        os.environ.get(var) not in (None, "", "0")
-        for var in ("RE_SKIP_MATMUL", "RE_SKIP_OUTPUT_WRITE", "RE_SKIP_WEIGHT_READ")
-    )
 
 
 def run_single_routed_expert(
@@ -145,20 +133,10 @@ def run_single_routed_expert(
         activation=ttnn.RoutedExpertActivation.Silu,
     )
 
-    # Run TTNN forward. ROUTED_EXPERT_PERF_ITERS > 1 repeats the op back-to-back
-    # (warm, cached program) so a tracy profiling run captures multiple device
-    # invocations to median over; the first (cold) iteration is dropped in
-    # analysis. The signpost above brackets the whole loop.
-    perf_iters = max(1, int(os.environ.get("ROUTED_EXPERT_PERF_ITERS", "1")))
-    logger.debug(f"Running TTNN forward ({perf_iters} iters)...")
-    for _ in range(perf_iters):
-        tt_output = tt_expert(tt_input, expert_token_counts_tt, expert_region_offsets_tt)
-    ttnn.synchronize_device(device)
+    # Run TTNN forward
+    logger.debug("Running TTNN forward...")
+    tt_output = tt_expert(tt_input, expert_token_counts_tt, expert_region_offsets_tt)
     logger.debug(f"TTNN output shape: {tt_output.shape}")
-
-    if _perf_toggle_makes_output_garbage():
-        logger.warning("RE_SKIP_* set: skipping PCC/NaN checks (perf-only run)")
-        return
 
     # Convert back to torch for comparison. For a 1-device replicated tensor,
     # ConcatMeshToTensor(dim=0) with 1 slice is a no-op that returns the tensor.

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_single_routed_expert.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_single_routed_expert.py
@@ -153,7 +153,7 @@ def run_single_routed_expert(
     logger.debug(f"Running TTNN forward ({perf_iters} iters)...")
     for _ in range(perf_iters):
         tt_output = tt_expert(tt_input, expert_token_counts_tt, expert_region_offsets_tt)
-    ttnn.synchronize_device(mesh_device)
+    ttnn.synchronize_device(device)
     logger.debug(f"TTNN output shape: {tt_output.shape}")
 
     if _perf_toggle_makes_output_garbage():

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_single_routed_expert_perf.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_single_routed_expert_perf.py
@@ -15,7 +15,7 @@ localizes to the FFN kernel.
 The ROW_MAJOR x layout (``x_rm``) is measured — the Blackhole fused-tilize
 production fast path (x tilized + bf8-packed inside the op, fresh output).
 
-Baselines in ``_EXPECTED_NS`` were MEASURED LOCALLY on a BH board on 2026-07-20
+Baselines in ``_EXPECTED_NS`` were MEASURED LOCALLY on a BH board on 2026-07-27
 and must be RECALIBRATED on the perf CI runner: device times are DDR-speed
 dependent, so the canonical baselines have to come from the CI runner the check
 actually runs on (mirrors the dated recalibration comments in the sibling
@@ -44,24 +44,24 @@ _WORKER = (
 _LAYOUT_ID = "x_rm"  # Blackhole fused-tilize production fast path (ROW_MAJOR bf16 input)
 
 # Per-(model, active) UnifiedRoutedExpertFfnDeviceOperation device time in ns, measured
-# on a Blackhole P150. Recalibrate on the perf CI runner (device times are HW-dependent).
+# on a Blackhole P150 (2026-07-27). Recalibrate on the perf CI runner (device times are HW-dependent).
 _EXPECTED_NS: dict[tuple[str, int], int] = {
-    ("kimi_k26", 0): 3_968,
-    ("kimi_k26", 128): 477_845,
-    ("kimi_k26", 256): 498_040,
-    ("kimi_k26", 512): 510_028,
-    ("kimi_k26", 1024): 516_735,
-    ("kimi_k26", 2048): 1_065_677,
-    ("kimi_k26", 4096): 1_638_930,
-    ("kimi_k26", 5120): 1_696_890,
-    ("glm_51", 0): 3_947,
-    ("glm_51", 128): 414_370,
-    ("glm_51", 256): 419_515,
-    ("glm_51", 512): 424_731,
-    ("glm_51", 1024): 438_300,
-    ("glm_51", 2048): 910_233,
-    ("glm_51", 4096): 1_389_302,
-    ("glm_51", 5120): 1_435_390,
+    ("kimi_k26", 0): 3_962,
+    ("kimi_k26", 128): 209_611,
+    ("kimi_k26", 256): 221_190,
+    ("kimi_k26", 512): 280_076,
+    ("kimi_k26", 1024): 402_655,
+    ("kimi_k26", 2048): 659_392,
+    ("kimi_k26", 4096): 1_294_679,
+    ("kimi_k26", 5120): 1_681_466,
+    ("glm_51", 0): 3_941,
+    ("glm_51", 128): 186_853,
+    ("glm_51", 256): 194_073,
+    ("glm_51", 512): 244_886,
+    ("glm_51", 1024): 351_959,
+    ("glm_51", 2048): 576_561,
+    ("glm_51", 4096): 1_141_564,
+    ("glm_51", 5120): 1_459_484,
 }
 
 _MARGIN = 0.03

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/adaptive_chunk.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/adaptive_chunk.hpp
@@ -1,0 +1,81 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+// Runtime chunk-size picker, shared by the reader, writer, and compute kernels.
+//
+// The kernel reads this expert's actual token count device-side and picks
+// chunk_M_tiles (hence per_core_M = chunk_M_tiles / GRID_Y and num_chunks)
+// FROM THAT COUNT — the adaptive per_core_M work that used to be sized on the
+// host from an `expected_tokens` argument now happens at runtime, so no caller
+// has to know the token count in advance.
+//
+// CBs are sized on the host to the compile-time MAX shape (per_core_M = 8,
+// chunk_M_tiles = 64; a big-model L1 guard may lower the max, passed in as
+// `max_chunk`). The picker never returns more than `max_chunk`, so the runtime
+// per_core_M always fits the allocated CBs; a smaller pick simply uses fewer of
+// the reserved tiles and shrinks every M-dimension loop.
+//
+// The three kernels MUST derive identical chunk_M_tiles / per_core_M / chunk
+// counts from the same count, or the reader/compute/writer disagree on the row
+// mapping and FFN output lands on the wrong token rows. This is the single
+// source of truth. Pure integer arithmetic (no NoC/CB/reg APIs) so the header
+// is valid in BRISC, NCRISC, and TRISC translation units alike.
+namespace adaptive_chunk {
+
+constexpr uint32_t kGridY = 8;  // M-row cores; a chunk spans per_core_M * kGridY tile-rows
+
+// Chunk layout for `count_tiles` tile-rows, given the CB-sized maximum chunk
+// `max_chunk` (= per_core_M_max * kGridY): a run of FULL chunks of max_chunk,
+// then ONE tail chunk sized down to the remainder. This minimizes the chunk
+// count (each chunk re-reads the full gate/up/down weights, the DRAM bottleneck)
+// AND minimizes phantom M-work (the tail covers only the leftover rows), so
+// per_core_M adapts to the actual token count per chunk with essentially no
+// wasted rows — e.g. 160 tiles -> 64 + 64 + 32 (per_core_M 8,8,4), 3 chunks,
+// zero phantom.
+//
+// CRITICAL: the tail per_core_M is a DIVISOR of per_core_M_max. The gate/up CBs
+// (cb_in0_x, partials, activated) are allocated to per_core_M_max but reserved/
+// pushed at the runtime per_core_M; a per_core_M that does not divide
+// per_core_M_max would make those blocks wrap the CB ring (ring size not a
+// multiple of the block size) and reserve_back would deadlock. Divisors tile
+// evenly, so the ring never wraps mid-block.
+
+// Number of chunks for `count_tiles`: full chunks of max_chunk + one tail chunk.
+inline uint32_t num_chunks(uint32_t count_tiles, uint32_t max_chunk) {
+    if (count_tiles < 1) {
+        return 0;
+    }
+    const uint32_t num_full = count_tiles / max_chunk;
+    const uint32_t tail = count_tiles - num_full * max_chunk;
+    return num_full + ((tail > 0) ? 1u : 0u);
+}
+
+// per_core_M for chunk index `c`: per_core_M_max for the full chunks; for the
+// tail chunk, the smallest DIVISOR of per_core_M_max whose *kGridY covers the
+// tail tiles (so the tail does the least M-work while its block still tiles
+// evenly into the CBs).
+inline uint32_t per_core_M_for_chunk(uint32_t c, uint32_t count_tiles, uint32_t max_chunk) {
+    const uint32_t per_core_M_max = max_chunk / kGridY;
+    const uint32_t num_full = count_tiles / max_chunk;
+    if (c < num_full) {
+        return per_core_M_max;
+    }
+    const uint32_t tail = count_tiles - num_full * max_chunk;  // > 0 for the tail chunk
+    uint32_t need = (tail + kGridY - 1) / kGridY;              // min rows/core to cover the tail
+    if (need < 1) {
+        need = 1;
+    }
+    for (uint32_t d = need; d <= per_core_M_max; ++d) {
+        if ((per_core_M_max % d) == 0) {
+            return d;
+        }
+    }
+    return per_core_M_max;
+}
+
+}  // namespace adaptive_chunk

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/compute/fused_swiglu.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/compute/fused_swiglu.cpp
@@ -174,10 +174,6 @@ FORCE_INLINE void matmul_phase(
                 uint32_t dst_index = 0;
                 uint32_t in0_index = in0_index_subblock_offset;
                 uint32_t in1_index = in1_index_subblock_offset;
-                // RE_SKIP_MATMUL (perf-investigation only): drop the MAC so the kernel
-                // still cycles all CB handshakes / packs but does no matmul compute,
-                // isolating the DRAM-I/O floor. Output is garbage.
-                //
                 // rows [m_subblocks, EFF_M) of cb_in0_down_full are NOT written by the
                 // reader's (bounded) activated mcast, so skip the whole subblock MAC for
                 // them (checked once here, not per K-inner iteration) rather than feed
@@ -186,7 +182,6 @@ FORCE_INLINE void matmul_phase(
                 // and the writer discards them via its row<per_core_M / row<count guards.
                 if (sb_m < m_subblocks) {
                     for (uint32_t inner_dim = 0; inner_dim < k_steps; ++inner_dim) {
-#ifndef RE_SKIP_MATMUL
                         matmul_block(
                             in0_cb_id,
                             in1_cb_id,
@@ -197,7 +192,6 @@ FORCE_INLINE void matmul_phase(
                             out_subblock_w,
                             out_subblock_h,
                             in0_block_w);
-#endif
                         in0_index += 1;
                         in1_index += in1_per_core_w;
                     }
@@ -414,7 +408,6 @@ FORCE_INLINE void matmul_phase_fused_gu(
                     uint32_t in0_index = in0_index_subblock_offset;
                     uint32_t in1_index = in1_index_subblock_offset;
                     for (uint32_t inner_dim = 0; inner_dim < in0_block_w; ++inner_dim) {
-#ifndef RE_SKIP_MATMUL
                         matmul_block(
                             x_cb_id,
                             gate_cb_id,
@@ -425,7 +418,6 @@ FORCE_INLINE void matmul_phase_fused_gu(
                             out_subblock_w,
                             out_subblock_h,
                             in0_block_w);
-#endif
                         in0_index += 1;
                         in1_index += in1_per_core_w;
                     }
@@ -443,7 +435,6 @@ FORCE_INLINE void matmul_phase_fused_gu(
                     uint32_t in0_index = in0_index_subblock_offset;
                     uint32_t in1_index = in1_index_subblock_offset;
                     for (uint32_t inner_dim = 0; inner_dim < in0_block_w; ++inner_dim) {
-#ifndef RE_SKIP_MATMUL
                         matmul_block(
                             x_cb_id,
                             up_cb_id,
@@ -454,7 +445,6 @@ FORCE_INLINE void matmul_phase_fused_gu(
                             out_subblock_w,
                             out_subblock_h,
                             in0_block_w);
-#endif
                         in0_index += 1;
                         in1_index += in1_per_core_w;
                     }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/compute/fused_swiglu.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/compute/fused_swiglu.cpp
@@ -63,6 +63,7 @@
 #include "api/dataflow/circular_buffer.h"
 #include "ttnn/cpp/ttnn/kernel_lib/tilize_helpers.hpp"
 #include "ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_fused_activation.hpp"
+#include "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/adaptive_chunk.hpp"
 
 #ifdef FUSE_BIAS
 // Row-broadcast bias add (gpt-oss). Bias is a (1, N) tensor tiled to one
@@ -107,7 +108,22 @@ FORCE_INLINE void matmul_phase(
     uint32_t in1_cb_id,
     uint32_t partials_cb_id,
     uint32_t final_cb_id,
+    uint32_t m_subblocks,
     uint32_t down_bias_cb_id = 0) {
+    // The DOWN matmul keeps a FULL compile-time-MAX per_core_M ring. Its
+    // PACKER_L1_ACC discipline drains the partials ring every K-block and relies
+    // on push==drain==out_block_num_tiles so the write pointer wraps back to
+    // block 0's slots for cross-K-block accumulation; a runtime-shrunk count
+    // would land block N+1 in the wrong L1 slots and corrupt the accumulation
+    // (a reserve-once / runtime-size variant was proven to do exactly that,
+    // nondeterministic PCC — see the git history). So the adaptive-per_core_M
+    // win is taken in the gate/up + multiply phases (reserve-once, safe to
+    // shrink) while the down matmul packs the full MAX ring and only SKIPS the
+    // MAC for rows >= m_subblocks (= the runtime per_core_M). Those extra rows
+    // pack zeros (cheap; the op is weight-read-bound) and the writer never emits
+    // them (it bounds its drain by the same runtime per_core_M).
+    constexpr uint32_t EFF_M = in0_num_subblocks;
+    constexpr uint32_t EFF_OUT = out_block_num_tiles;
     // Reconfig packer for partials format (previous phase's final_cb format
     // would otherwise leak). pack_reconfig_data_format (the reconfig variant)
     // does NOT reset L1_ACC — we do that explicitly below.
@@ -150,7 +166,7 @@ FORCE_INLINE void matmul_phase(
         const uint32_t k_steps = (block + 1 == num_blocks) ? last_block_w : in0_block_w;
 
         int in0_index_subblock_offset = 0;
-        for (uint32_t sb_m = 0; sb_m < in0_num_subblocks; ++sb_m) {
+        for (uint32_t sb_m = 0; sb_m < EFF_M; ++sb_m) {
             int in1_index_subblock_offset = 0;
             for (uint32_t sb_n = 0; sb_n < in1_num_subblocks; ++sb_n) {
                 tile_regs_acquire();
@@ -158,19 +174,33 @@ FORCE_INLINE void matmul_phase(
                 uint32_t dst_index = 0;
                 uint32_t in0_index = in0_index_subblock_offset;
                 uint32_t in1_index = in1_index_subblock_offset;
-                for (uint32_t inner_dim = 0; inner_dim < k_steps; ++inner_dim) {
-                    matmul_block(
-                        in0_cb_id,
-                        in1_cb_id,
-                        in0_index,
-                        in1_index,
-                        dst_index,
-                        /*transpose=*/0,
-                        out_subblock_w,
-                        out_subblock_h,
-                        in0_block_w);
-                    in0_index += 1;
-                    in1_index += in1_per_core_w;
+                // RE_SKIP_MATMUL (perf-investigation only): drop the MAC so the kernel
+                // still cycles all CB handshakes / packs but does no matmul compute,
+                // isolating the DRAM-I/O floor. Output is garbage.
+                //
+                // rows [m_subblocks, EFF_M) of cb_in0_down_full are NOT written by the
+                // reader's (bounded) activated mcast, so skip the whole subblock MAC for
+                // them (checked once here, not per K-inner iteration) rather than feed
+                // the down matmul stale/uninitialized L1. The partials reserve/pack/drain
+                // below stay FULL for L1_ACC ring alignment; the skipped rows pack zeros
+                // and the writer discards them via its row<per_core_M / row<count guards.
+                if (sb_m < m_subblocks) {
+                    for (uint32_t inner_dim = 0; inner_dim < k_steps; ++inner_dim) {
+#ifndef RE_SKIP_MATMUL
+                        matmul_block(
+                            in0_cb_id,
+                            in1_cb_id,
+                            in0_index,
+                            in1_index,
+                            dst_index,
+                            /*transpose=*/0,
+                            out_subblock_w,
+                            out_subblock_h,
+                            in0_block_w);
+#endif
+                        in0_index += 1;
+                        in1_index += in1_per_core_w;
+                    }
                 }
 
                 tile_regs_commit();
@@ -200,7 +230,7 @@ FORCE_INLINE void matmul_phase(
         // the write pointer back to block 0's slots. The last block's output is
         // left pushed for the second-pass copy below.
         if (block + 1 < num_blocks) {
-            for (uint32_t s = 0; s < out_block_num_tiles; s += out_subblock_num_tiles) {
+            for (uint32_t s = 0; s < EFF_OUT; s += out_subblock_num_tiles) {
                 partials_cb.wait_front(out_subblock_num_tiles);
                 partials_cb.pop_front(out_subblock_num_tiles);
             }
@@ -236,7 +266,7 @@ FORCE_INLINE void matmul_phase(
     copy_tile_to_dst_init_short_with_dt(in1_cb_id, partials_cb_id);
 #endif
 
-    for (uint32_t sb = 0; sb < (out_block_num_tiles / out_subblock_num_tiles); ++sb) {
+    for (uint32_t sb = 0; sb < (EFF_OUT / out_subblock_num_tiles); ++sb) {
         tile_regs_acquire();
         partials_cb.wait_front(out_subblock_num_tiles);
         for (uint32_t i = 0; i < out_subblock_num_tiles; ++i) {
@@ -303,7 +333,18 @@ FORCE_INLINE void matmul_phase_fused_gu(
     uint32_t partials_gu_cb_id,
     uint32_t partials_up_cb_id,
     uint32_t gate_intermed_cb_id,
-    uint32_t up_intermed_cb_id) {
+    uint32_t up_intermed_cb_id,
+    uint32_t m_subblocks) {
+    // Adaptive per_core_M: this core's gate/up work is bounded by the runtime
+    // per_core_M (m_subblocks tile-rows). The x block this core consumes and the
+    // partials/intermed single-block CBs shrink with it; the gate/up WEIGHT
+    // blocks stay full-width (M-independent). The CBs were SIZED on the host to
+    // the compile-time MAX per_core_M, so a smaller runtime count just uses fewer
+    // of the reserved tiles. m_subblocks==0 (this core owns no row this chunk)
+    // reserves/pushes nothing.
+    const uint32_t EFF_M = m_subblocks;
+    const uint32_t x_block_tiles = m_subblocks * in0_block_w;  // runtime x block (per_core_M rows)
+    const uint32_t EFF_OUT = m_subblocks * in1_num_subblocks * out_subblock_num_tiles;
     pack_reconfig_data_format(partials_gu_cb_id);
 #ifdef PACKER_L1_ACC
     PACK((llk_pack_reconfig_l1_acc(0)));
@@ -316,13 +357,16 @@ FORCE_INLINE void matmul_phase_fused_gu(
     CircularBuffer partials_up_cb(partials_up_cb_id);
     CircularBuffer gate_intermed_cb(gate_intermed_cb_id);
 
-    // Reserve both partials CBs once for the full per-core block. pack_tile
+    // Reserve both partials CBs once for the (effective) per-core block. pack_tile
     // with output_tile_index writes to absolute slots; WrPtr doesn't advance
     // until cb_push_back below. Across K-blocks 1..N-1, L1_ACC packs land
     // back in the SAME L1 slots — accumulating physically — which is what
-    // we want. No per-K-block pop+repush needed.
-    partials_gu_cb.reserve_back(out_block_num_tiles);
-    partials_up_cb.reserve_back(out_block_num_tiles);
+    // we want. No per-K-block pop+repush needed. Guarded by EFF_M>0 so an
+    // empty row (m_subblocks==0) never issues a 0-count reserve/push.
+    if (EFF_M > 0) {
+        partials_gu_cb.reserve_back(EFF_OUT);
+        partials_up_cb.reserve_back(EFF_OUT);
+    }
 
     for (uint32_t block = 0; block < num_blocks; ++block) {
         if constexpr (tilize_x) {
@@ -331,16 +375,16 @@ FORCE_INLINE void matmul_phase_fused_gu(
             //  off so the tilize packs OVERWRITE x_cb rather than accumulate; the
             //  shared tilize helper (same one conv_bmm_tilize.cpp uses) then
             //  reconfigures unpack SrcA + pack format, drives the per-strip
-            //  wait/reserve/tilize/push/pop over the in0_block_num_tiles /
-            //  in0_block_w tile-rows, and restores init on exit. The helper left
-            //  SrcA pointing at the bf16 row-major input, so restore it to the
-            //  gate/up weight format before resuming the matmul (SrcB still holds
-            //  x_cb_id — the BH tilize path never touches it); then restore the
-            //  partials packer + L1_ACC state for this block.
+            //  wait/reserve/tilize/push/pop over the runtime x_block_tiles /
+            //  in0_block_w tile-rows (adaptive per_core_M), and restores init on
+            //  exit. The helper left SrcA pointing at the bf16 row-major input, so
+            //  restore it to the gate/up weight format before resuming the matmul
+            //  (SrcB still holds x_cb_id — the BH tilize path never touches it);
+            //  then restore the partials packer + L1_ACC state for this block.
 #ifdef PACKER_L1_ACC
             PACK((llk_pack_reconfig_l1_acc(0)));
 #endif
-            constexpr uint32_t n_strips = in0_block_num_tiles / in0_block_w;
+            const uint32_t n_strips = x_block_tiles / in0_block_w;
             compute_kernel_lib::tilize<
                 in0_block_w,
                 x_rm_cb_id,
@@ -355,13 +399,13 @@ FORCE_INLINE void matmul_phase_fused_gu(
             PACK((llk_pack_reconfig_l1_acc(block == 0 ? 0 : 1)));
 #endif
         }
-        x_cb.wait_front(in0_block_num_tiles);
+        x_cb.wait_front(x_block_tiles);
         gate_cb.wait_front(in1_block_num_tiles);
         up_cb.wait_front(in1_block_num_tiles);
 
         int in0_index_subblock_offset = 0;
         uint32_t partials_slot_idx = 0;
-        for (uint32_t sb_m = 0; sb_m < in0_num_subblocks; ++sb_m) {
+        for (uint32_t sb_m = 0; sb_m < EFF_M; ++sb_m) {
             int in1_index_subblock_offset = 0;
             for (uint32_t sb_n = 0; sb_n < in1_num_subblocks; ++sb_n) {
                 // --- Gate matmul: x * gate -> partials_gu ---
@@ -370,6 +414,7 @@ FORCE_INLINE void matmul_phase_fused_gu(
                     uint32_t in0_index = in0_index_subblock_offset;
                     uint32_t in1_index = in1_index_subblock_offset;
                     for (uint32_t inner_dim = 0; inner_dim < in0_block_w; ++inner_dim) {
+#ifndef RE_SKIP_MATMUL
                         matmul_block(
                             x_cb_id,
                             gate_cb_id,
@@ -380,6 +425,7 @@ FORCE_INLINE void matmul_phase_fused_gu(
                             out_subblock_w,
                             out_subblock_h,
                             in0_block_w);
+#endif
                         in0_index += 1;
                         in1_index += in1_per_core_w;
                     }
@@ -397,6 +443,7 @@ FORCE_INLINE void matmul_phase_fused_gu(
                     uint32_t in0_index = in0_index_subblock_offset;
                     uint32_t in1_index = in1_index_subblock_offset;
                     for (uint32_t inner_dim = 0; inner_dim < in0_block_w; ++inner_dim) {
+#ifndef RE_SKIP_MATMUL
                         matmul_block(
                             x_cb_id,
                             up_cb_id,
@@ -407,6 +454,7 @@ FORCE_INLINE void matmul_phase_fused_gu(
                             out_subblock_w,
                             out_subblock_h,
                             in0_block_w);
+#endif
                         in0_index += 1;
                         in1_index += in1_per_core_w;
                     }
@@ -430,13 +478,15 @@ FORCE_INLINE void matmul_phase_fused_gu(
         }
 #endif
 
-        x_cb.pop_front(in0_block_num_tiles);
+        x_cb.pop_front(x_block_tiles);
         gate_cb.pop_front(in1_block_num_tiles);
         up_cb.pop_front(in1_block_num_tiles);
     }
     // Make the accumulated partials visible to the second-pass copy loops.
-    partials_gu_cb.push_back(out_block_num_tiles);
-    partials_up_cb.push_back(out_block_num_tiles);
+    if (EFF_M > 0) {
+        partials_gu_cb.push_back(EFF_OUT);
+        partials_up_cb.push_back(EFF_OUT);
+    }
 
     // After K-loop: partials_gu holds gate-matmul accumulator,
     // partials_up holds up-matmul accumulator. Copy each to its intermed
@@ -466,7 +516,7 @@ FORCE_INLINE void matmul_phase_fused_gu(
     // SrcA was last configured for the up matmul's in1 (up_cb_id). Switch
     // to partials_gu so copy_tile reads the accumulator.
     copy_tile_to_dst_init_short_with_dt(up_cb_id, partials_gu_cb_id);
-    for (uint32_t sb = 0; sb < (out_block_num_tiles / out_subblock_num_tiles); ++sb) {
+    for (uint32_t sb = 0; sb < (EFF_OUT / out_subblock_num_tiles); ++sb) {
         tile_regs_acquire();
         partials_gu_cb.wait_front(out_subblock_num_tiles);
         for (uint32_t i = 0; i < out_subblock_num_tiles; ++i) {
@@ -523,8 +573,15 @@ FORCE_INLINE void swiglu_oai_activation_phase(
     uint32_t gate_partials_cb_id,
     uint32_t up_partials_cb_id,
     uint32_t activated_cb_id,
+    uint32_t eff_out_tiles,
     uint32_t gate_bias_cb_id = 0,
     uint32_t up_bias_cb_id = 0) {
+    // Adaptive per_core_M: this core produces eff_out_tiles = per_core_M * pcN
+    // activated tiles this chunk (0 if it owns no row -> nothing to do).
+    const uint32_t EFF_OUT = eff_out_tiles;
+    if (EFF_OUT == 0) {
+        return;
+    }
     // Dst budget derived from the host ComputeConfig (via -DFP32_DEST_ACC_EN) so
     // it and the SFPU op's fp32-dest template below stay in sync with the
     // program factory's DST_CAPACITY / fp32_dest_acc_en (no silent drift). The
@@ -538,8 +595,8 @@ FORCE_INLINE void swiglu_oai_activation_phase(
     CircularBuffer up_partials_cb(up_partials_cb_id);
     CircularBuffer activated_cb(activated_cb_id);
 
-    gate_partials_cb.wait_front(out_block_num_tiles);
-    up_partials_cb.wait_front(out_block_num_tiles);
+    gate_partials_cb.wait_front(EFF_OUT);
+    up_partials_cb.wait_front(EFF_OUT);
 
     pack_reconfig_data_format(activated_cb_id);
     // SrcA was last configured for the up matmul's in1 weights (prev_srcA_cb_id,
@@ -568,8 +625,8 @@ FORCE_INLINE void swiglu_oai_activation_phase(
     copy_tile_to_dst_init_short_with_dt(prev_srcA_cb_id, gate_partials_cb_id);
 #endif
 
-    for (uint32_t base = 0; base < out_block_num_tiles; base += kActChunk) {
-        const uint32_t remaining = out_block_num_tiles - base;
+    for (uint32_t base = 0; base < EFF_OUT; base += kActChunk) {
+        const uint32_t remaining = EFF_OUT - base;
         const uint32_t c = remaining < kActChunk ? remaining : kActChunk;
         tile_regs_acquire();
         // gate -> dst[0..c), up -> dst[c..2c) (with gpt-oss bias when FUSE_BIAS)
@@ -597,19 +654,30 @@ FORCE_INLINE void swiglu_oai_activation_phase(
         activated_cb.push_back(c);
         tile_regs_release();
     }
-    gate_partials_cb.pop_front(out_block_num_tiles);
-    up_partials_cb.pop_front(out_block_num_tiles);
+    gate_partials_cb.pop_front(EFF_OUT);
+    up_partials_cb.pop_front(EFF_OUT);
 }
 #endif
 
+// eff_out_tiles = number of valid output tiles this core produces this chunk
+// (= per_core_M * per_core_N_gu, runtime-adaptive). Precomputed by the caller so
+// multiply_phase needs no per_core_M/N template info.
 template <uint32_t out_block_num_tiles, uint32_t out_subblock_num_tiles>
-FORCE_INLINE void multiply_phase(uint32_t gate_cb_id, uint32_t up_cb_id, uint32_t activated_cb_id) {
+FORCE_INLINE void multiply_phase(
+    uint32_t gate_cb_id, uint32_t up_cb_id, uint32_t activated_cb_id, uint32_t eff_out_tiles) {
     CircularBuffer gate_cb(gate_cb_id);
     CircularBuffer up_cb(up_cb_id);
     CircularBuffer activated_cb(activated_cb_id);
 
-    gate_cb.wait_front(out_block_num_tiles);
-    up_cb.wait_front(out_block_num_tiles);
+    const uint32_t EFF_OUT = eff_out_tiles;
+    // Empty row (no valid tiles): gate_intermed / partials_up were not pushed, so
+    // there is nothing to wait on or drain.
+    if (EFF_OUT == 0) {
+        return;
+    }
+
+    gate_cb.wait_front(EFF_OUT);
+    up_cb.wait_front(EFF_OUT);
 
     // Reconfigure packer for activated format and unpacker for both
     // gate_cb (SrcA) and up_cb (SrcB). After phase 2's second pass the
@@ -622,7 +690,7 @@ FORCE_INLINE void multiply_phase(uint32_t gate_cb_id, uint32_t up_cb_id, uint32_
     reconfig_data_format(gate_cb_id, up_cb_id);
     mul_tiles_init(gate_cb_id, up_cb_id);
 
-    constexpr uint32_t num_subblocks = out_block_num_tiles / out_subblock_num_tiles;
+    const uint32_t num_subblocks = EFF_OUT / out_subblock_num_tiles;
     uint32_t base = 0;
     for (uint32_t sb = 0; sb < num_subblocks; ++sb) {
         tile_regs_acquire();
@@ -639,8 +707,8 @@ FORCE_INLINE void multiply_phase(uint32_t gate_cb_id, uint32_t up_cb_id, uint32_
         tile_regs_release();
         base += out_subblock_num_tiles;
     }
-    gate_cb.pop_front(out_block_num_tiles);
-    up_cb.pop_front(out_block_num_tiles);
+    gate_cb.pop_front(EFF_OUT);
+    up_cb.pop_front(EFF_OUT);
 }
 
 }  // namespace
@@ -682,12 +750,17 @@ void kernel_main() {
     constexpr uint32_t d_out_subblock_w = get_compile_time_arg_val(28);
     constexpr uint32_t d_out_subblock_num_tiles = d_out_subblock_h * d_out_subblock_w;
     constexpr uint32_t d_out_block_num_tiles = get_compile_time_arg_val(29);
-    // Multi-chunk: when M_tiles_full > chunk_M_tiles we run all 4 phases
-    // num_chunks times. Reader/writer feed/drain chunk-N+1 while compute is
-    // still on chunk N via the existing CBs.
-    constexpr uint32_t num_chunks = get_compile_time_arg_val(30);
+    // Multi-chunk: the number of chunks is chosen at RUNTIME from the device
+    // token count (see the picker below). num_chunks_max is the compile-time
+    // upper bound (host = ceil(M_tiles_full / min_chunk)) used only to clamp the
+    // runtime chunk count defensively. chunk_M_max is the CB-sized maximum
+    // chunk (per_core_M_max * GRID_Y); the picker never returns more than this.
+    constexpr uint32_t num_chunks_max = get_compile_time_arg_val(30);
     constexpr uint32_t local_expert_id = get_compile_time_arg_val(31);
-    constexpr uint32_t chunk_M_tiles = get_compile_time_arg_val(32);
+    // chunk_M_max is the CB-sized MAXIMUM chunk (per_core_M_max * GRID_Y). The
+    // runtime picker (adaptive_chunk::num_chunks) sizes the actual chunk to the
+    // device token count and never exceeds this.
+    constexpr uint32_t chunk_M_max = get_compile_time_arg_val(32);
     // x_is_row_major: tilize cb_x_rm -> cb_in0_x before the gate/up matmul.
     // 0 => x already TILE in cb_in0_x.
     constexpr uint32_t x_is_row_major = get_compile_time_arg_val(33);
@@ -755,10 +828,18 @@ void kernel_main() {
     }));
     MATH(count_value = ckernel::mailbox_read(ckernel::ThreadId::UnpackThreadId);)
     PACK(count_value = ckernel::mailbox_read(ckernel::ThreadId::UnpackThreadId);)
-    // count is in TOKEN rows; convert to tile rows (ceil) and then to chunks.
+    // count is in TOKEN rows; convert to tile rows (ceil). The picker sizes
+    // chunk_M_tiles (hence per_core_M and the number of chunks) to THIS count,
+    // exactly as the retired host-side picker did — now at runtime, so no
+    // expected-token argument is needed. All three kernels (reader/compute/
+    // writer) run the identical picker on the same count, so they agree on the
+    // row mapping. per_core_M is uniform across cores and chunks; rows past the
+    // count in the tail chunk are zero-filled by the reader and dropped by the
+    // writer (contiguous mapping, same as the old compile-time per_core_M path).
     const uint32_t count_tiles = (count_value + 31) / 32;
-    const uint32_t effective_chunks_runtime = (count_tiles + chunk_M_tiles - 1) / chunk_M_tiles;
-    const uint32_t effective_chunks = effective_chunks_runtime < num_chunks ? effective_chunks_runtime : num_chunks;
+    const uint32_t effective_chunks_runtime = adaptive_chunk::num_chunks(count_tiles, chunk_M_max);
+    const uint32_t effective_chunks =
+        effective_chunks_runtime < num_chunks_max ? effective_chunks_runtime : num_chunks_max;
 
     // SiLU is now applied as a MATH-thread SFPU pass on dst (silu_tile)
     // between copy_tile and pack_tile — not packer-fused via
@@ -777,6 +858,15 @@ void kernel_main() {
     compute_kernel_hw_startup<SrcOrder::Reverse>(cb_in0_x, cb_in1_gate, cb_partials_gu);
 
     for (uint32_t chunk = 0; chunk < effective_chunks; ++chunk) {
+        // Per-chunk per_core_M (per_core_M_max for full chunks, a smaller divisor
+        // for the tail). The gate/up + multiply phases do per_core_M rows of real
+        // work; the down matmul keeps its full compile-time ring and MAC-skips
+        // rows >= per_core_M (see matmul_phase). re_eff_out_gu = per_core_M *
+        // per_core_N_gu (g_in1_num_subblocks * gu_out_subblock_num_tiles ==
+        // per_core_N_gu since gu_out_subblock_h == 1).
+        const uint32_t re_m_valid = adaptive_chunk::per_core_M_for_chunk(chunk, count_tiles, chunk_M_max);
+        const uint32_t re_eff_out_gu = re_m_valid * g_in1_num_subblocks * gu_out_subblock_num_tiles;
+        //
         // matmul_block_init only re-programs addressing, not SrcA/SrcB formats. On
         // chunk >= 1 the unpacker is left on multiply_phase's operands, so reset it
         // to the gate/up inputs here (in1 -> SrcA, in0 -> SrcB).
@@ -811,7 +901,13 @@ void kernel_main() {
             /*x_cb_id=*/cb_in0_x,
             /*x_rm_cb_id=*/cb_x_rm,
             /*tilize_x=*/(x_is_row_major != 0)>(
-            cb_in1_gate, cb_in1_up, cb_partials_gu, cb_partials_up, cb_gate_intermed, cb_up_intermed);
+            cb_in1_gate,
+            cb_in1_up,
+            cb_partials_gu,
+            cb_partials_up,
+            cb_gate_intermed,
+            cb_up_intermed,
+            /*m_subblocks=*/re_m_valid);
 
 #ifdef SWIGLU_OAI
         // Phase 3 (SwiGLU-OAI): fused clamp + alpha-sigmoid + (up+1) directly on
@@ -820,7 +916,7 @@ void kernel_main() {
         // the unpacker's last SrcA operand (up matmul in1), passed so the partials
         // reconfig (weights df -> Float16_b) actually fires.
         swiglu_oai_activation_phase<gu_out_block_num_tiles, g_in1_per_core_w>(
-            cb_in1_up, cb_partials_gu, cb_partials_up, cb_activated, cb_gate_bias, cb_up_bias);
+            cb_in1_up, cb_partials_gu, cb_partials_up, cb_activated, re_eff_out_gu, cb_gate_bias, cb_up_bias);
         (void)cb_gate_intermed;
         (void)cb_up_intermed;
 #else
@@ -830,7 +926,7 @@ void kernel_main() {
         // multiply_phase — both unpacker srcs get reset to the input CB
         // formats.
         multiply_phase<gu_out_block_num_tiles, gu_out_subblock_num_tiles>(
-            cb_gate_intermed, cb_partials_up, cb_activated);
+            cb_gate_intermed, cb_partials_up, cb_activated, re_eff_out_gu);
         (void)cb_up_intermed;
 #endif
 
@@ -861,6 +957,7 @@ void kernel_main() {
             d_out_block_num_tiles,
             /*apply_silu_on_final=*/false,
             /*d_per_core_N=*/d_in1_per_core_w,
-            /*last_block_w=*/d_last_block_w>(cb_in0_down_full, cb_in1_down, cb_partials_d, cb_out, cb_down_bias);
+            /*last_block_w=*/d_last_block_w>(
+            cb_in0_down_full, cb_in1_down, cb_partials_d, cb_out, /*m_subblocks=*/re_m_valid, cb_down_bias);
     }  // end chunk loop
 }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/dataflow/unified_routed_expert_ffn_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/dataflow/unified_routed_expert_ffn_reader.cpp
@@ -604,14 +604,12 @@ void kernel_main() {
                         const uint32_t col = my_nt_gu * per_core_N_gu + n;
                         if (col < N_gate_tiles_full) {
                             const uint32_t tile_idx = row * N_gate_tiles_full + col;
-#ifndef RE_SKIP_WEIGHT_READ
                             noc_read.async_read(
                                 gate_acc,
                                 CoreLocalMem<uint32_t>(l1_w_gate),
                                 gate_tile_bytes,
                                 {.page_id = tile_idx},
                                 {});
-#endif
                         } else {
                             // N-OOB hidden padding column (col >= N_gate_tiles_full ==
                             // down's K_down_tiles). Its garbage gate output feeds the down
@@ -803,10 +801,8 @@ void kernel_main() {
                         const uint32_t col = my_nt_d * per_core_N_d + n;
                         if (row < K_down_tiles && col < N_down_tiles_full) {
                             const uint32_t tile_idx = row * N_down_tiles_full + col;
-#ifndef RE_SKIP_WEIGHT_READ
                             noc_read.async_read(
                                 down_acc, CoreLocalMem<uint32_t>(l1_w), down_tile_bytes, {.page_id = tile_idx}, {});
-#endif
                         } else if (row >= K_down_tiles) {
                             // K-OOB (reduction dim): the matmul may still read these, so keep
                             // them zero — 0 * (stale/Inf weight) would NaN a valid output col.

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/dataflow/unified_routed_expert_ffn_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/dataflow/unified_routed_expert_ffn_reader.cpp
@@ -31,6 +31,7 @@
 #include "api/dataflow/endpoints.h"
 #include "api/core_local_mem.h"
 #include "api/debug/dprint.h"  // TEMP: config dump
+#include "../adaptive_chunk.hpp"
 
 void kernel_main() {
     // -------------------------- runtime args ------------------------------
@@ -99,7 +100,10 @@ void kernel_main() {
     constexpr uint32_t cb_idx_scratch = get_compile_time_arg_val(6);
 
     constexpr uint32_t local_expert_id = get_compile_time_arg_val(7);
-    constexpr uint32_t per_core_M = get_compile_time_arg_val(8);
+    // per_core_M_max: the CB-sized maximum per-core M (= chunk_M_max / GRID_Y).
+    // The RUNTIME per_core_M is picked from the device token count below and is
+    // <= this. CBs are allocated to the max; a smaller runtime pick uses fewer.
+    constexpr uint32_t per_core_M_max = get_compile_time_arg_val(8);
     constexpr uint32_t per_core_N_gu = get_compile_time_arg_val(9);
     constexpr uint32_t per_core_N_d = get_compile_time_arg_val(10);
     constexpr uint32_t K_gate_tiles = get_compile_time_arg_val(11);
@@ -109,8 +113,11 @@ void kernel_main() {
     constexpr uint32_t N_gate_tiles_full = get_compile_time_arg_val(15);
     constexpr uint32_t N_down_tiles_full = get_compile_time_arg_val(16);
     constexpr uint32_t M_tiles_full = get_compile_time_arg_val(17);
-    constexpr uint32_t num_chunks = get_compile_time_arg_val(18);
-    constexpr uint32_t chunk_M_tiles = get_compile_time_arg_val(19);
+    // num_chunks_max: compile-time upper bound on the runtime chunk count (clamp).
+    // chunk_M_max: CB-sized maximum chunk (per_core_M_max * GRID_Y); the runtime
+    // picker never exceeds it.
+    constexpr uint32_t num_chunks_max = get_compile_time_arg_val(18);
+    constexpr uint32_t chunk_M_max = get_compile_time_arg_val(19);
     constexpr uint32_t cb_activated = get_compile_time_arg_val(20);
     constexpr uint32_t GRID_X_NOC = get_compile_time_arg_val(21);  // M-row mcast group size
     constexpr uint32_t K_down_tiles_padded = get_compile_time_arg_val(22);
@@ -136,9 +143,12 @@ void kernel_main() {
     // UP_SPLIT iff the reader multicasts up but does not read it from DRAM.
     constexpr bool up_split = (reader_mcasts_up != 0) && (reader_reads_up == 0);
 
-    constexpr uint32_t g_in0_block_num_tiles = per_core_M * in0_block_w_gu;
     constexpr uint32_t g_in1_block_num_tiles = per_core_N_gu * in0_block_w_gu;
-    constexpr uint32_t d_in0_block_num_tiles = per_core_M * in0_block_w_d;
+    // cb_in0_down_full stays sized to the compile-time MAX per-core M: the down
+    // matmul keeps a full ring and MAC-skips rows >= the runtime per_core_M, so
+    // the reader pushes the full block (filling only per_core_M runtime rows via
+    // the activated mcast; the rest are MAC-skipped downstream).
+    constexpr uint32_t d_in0_block_num_tiles = per_core_M_max * in0_block_w_d;
     constexpr uint32_t d_in1_block_num_tiles = per_core_N_d * in0_block_w_d;
     constexpr uint32_t num_blocks_gu = K_gate_tiles / in0_block_w_gu;
     constexpr uint32_t num_blocks_d = K_down_tiles_padded / in0_block_w_d;
@@ -281,25 +291,16 @@ void kernel_main() {
     // For count=0 the loop is empty (no chunks processed). For count > 0 we
     // process ceil(count_tiles / chunk_M_tiles) chunks; the remaining chunks
     // (if any) are skipped — no DRAM reads, no mcasts, no compute.
-    const uint32_t count_tiles = (count_value + TILE_HEIGHT - 1) / TILE_HEIGHT;
-    const uint32_t effective_chunks_runtime = (count_tiles + chunk_M_tiles - 1) / chunk_M_tiles;
-    // Clamp to compile-time num_chunks just in case (defensive against bad input).
-    const uint32_t effective_chunks = effective_chunks_runtime < num_chunks ? effective_chunks_runtime : num_chunks;
-
-    // TEMP config dump (one core): understand RM vs TILE blocking difference.
-    if (is_in0_sender && my_mt == 0 && my_nt_gu == 0) {
-        DPRINT(
-            "CFG rm="
-            "{}"
-            " ibw_gu={} per_core_M={} chunk_M={} num_chunks={} eff={} K_gate={}\n",
-            (uint32_t)x_is_row_major,
-            in0_block_w_gu,
-            per_core_M,
-            chunk_M_tiles,
-            num_chunks,
-            effective_chunks,
-            K_gate_tiles);
-    }
+    const uint32_t count_tiles = (count_value + 31) / 32;
+    // Runtime chunk layout from the actual token count (identical math in the
+    // compute and writer kernels, so all three agree on the row mapping). Full
+    // chunks span chunk_M_max tile-rows; the tail chunk shrinks per_core_M to the
+    // remainder. per_core_M is thus per-chunk (see the loop) and ADAPTS to the
+    // count with minimal phantom work; the chunk count is the minimum.
+    const uint32_t effective_chunks_runtime = adaptive_chunk::num_chunks(count_tiles, chunk_M_max);
+    // Clamp to the compile-time max just in case (defensive against bad input).
+    const uint32_t effective_chunks =
+        effective_chunks_runtime < num_chunks_max ? effective_chunks_runtime : num_chunks_max;
 
     // x-read row offset. Zero unless read_x_at_offset: then x is a shared buffer
     // and this expert's rows begin at start[global_id]. Fetch the start page and
@@ -397,10 +398,16 @@ void kernel_main() {
 
     // Bound the chunk loop by effective_chunks (= ceil_div(count, chunk_M_tiles))
     // so this expert only does work proportional to its actual token count,
-    // not the max-tokens-padded shape of the input. Eliminates the host-side
-    // count read that previously had to narrow the input tensor.
+    // not the max-tokens-padded shape of the input. chunk_M_tiles / per_core_M
+    // were picked from the count above; the row mapping is contiguous (core gy
+    // owns rows [chunk*chunk_M + gy*per_core_M, + per_core_M)).
     for (uint32_t chunk = 0; chunk < effective_chunks; ++chunk) {
-        const uint32_t this_core_first_row = chunk * chunk_M_tiles + my_mt * per_core_M;
+        // Per-chunk per_core_M: per_core_M_max for full chunks, a smaller divisor
+        // for the tail. Chunk starts are UNIFORM at chunk*chunk_M_max (full chunks
+        // are max_chunk; the tail is last, so its start is num_full*max_chunk too).
+        const uint32_t per_core_M = adaptive_chunk::per_core_M_for_chunk(chunk, count_tiles, chunk_M_max);
+        const uint32_t g_in0_block_num_tiles = per_core_M * in0_block_w_gu;
+        const uint32_t this_core_first_row = chunk * chunk_M_max + my_mt * per_core_M;
 
         // -------- PHASES 1+2 fused — push x ONCE per K-block, then gate then up.
         //
@@ -597,12 +604,14 @@ void kernel_main() {
                         const uint32_t col = my_nt_gu * per_core_N_gu + n;
                         if (col < N_gate_tiles_full) {
                             const uint32_t tile_idx = row * N_gate_tiles_full + col;
+#ifndef RE_SKIP_WEIGHT_READ
                             noc_read.async_read(
                                 gate_acc,
                                 CoreLocalMem<uint32_t>(l1_w_gate),
                                 gate_tile_bytes,
                                 {.page_id = tile_idx},
                                 {});
+#endif
                         } else {
                             // N-OOB hidden padding column (col >= N_gate_tiles_full ==
                             // down's K_down_tiles). Its garbage gate output feeds the down
@@ -794,8 +803,10 @@ void kernel_main() {
                         const uint32_t col = my_nt_d * per_core_N_d + n;
                         if (row < K_down_tiles && col < N_down_tiles_full) {
                             const uint32_t tile_idx = row * N_down_tiles_full + col;
+#ifndef RE_SKIP_WEIGHT_READ
                             noc_read.async_read(
                                 down_acc, CoreLocalMem<uint32_t>(l1_w), down_tile_bytes, {.page_id = tile_idx}, {});
+#endif
                         } else if (row >= K_down_tiles) {
                             // K-OOB (reduction dim): the matmul may still read these, so keep
                             // them zero — 0 * (stale/Inf weight) would NaN a valid output col.
@@ -860,13 +871,20 @@ void kernel_main() {
             // after the in1_down mcast; starts as soon as compute pushes
             // cb_activated AND the ready acks are in (already done in step 1).
             if (is_act_sender) {
-                cb_activated_obj.wait_front(d_in0_block_num_tiles);
+                // cb_activated holds this core's per_core_M (runtime) x in0_block_w_d
+                // activated tiles; read/mcast/pop exactly that many. cb_in0_down_full
+                // is pushed FULL (compile-time max) below so the down matmul's ring
+                // stays aligned — the rows past per_core_M are MAC-skipped there.
+                const uint32_t re_act_tiles = per_core_M * in0_block_w_d;
+                if (re_act_tiles > 0) {
+                    cb_activated_obj.wait_front(re_act_tiles);
+                }
                 act_ready_sem.wait(GRID_X_NOC - 1);
                 act_ready_sem.set(0);
 
                 const uint32_t src_l1 = cb_activated_obj.get_read_ptr();
                 const uint32_t dst_l1 = cb_in0_down_full_obj.get_write_ptr();
-                const uint32_t mcast_bytes = d_in0_block_num_tiles * intermed_tile_bytes;
+                const uint32_t mcast_bytes = re_act_tiles * intermed_tile_bytes;
                 // linked=true keeps the multicast path RESERVED so the
                 // valid-semaphore multicast below travels the SAME path and is
                 // delivered AFTER the data at every receiver. With linked=false
@@ -879,25 +897,29 @@ void kernel_main() {
                 // wait on) — only path-linking orders the sem behind the data.
                 // Mirrors the canonical matmul in0 sender
                 // (reader_bmm_tile_layout_in0_sender_padding.cpp).
-                noc.async_write_multicast<NocOptions::MCAST_INCL_SRC>(
-                    CoreLocalMem<uint32_t>(src_l1),
-                    MulticastEndpoint{},
-                    mcast_bytes,
-                    GRID_X_NOC,
-                    {.offset_bytes = 0},
-                    {.noc_x_start = mrow_first_nx,
-                     .noc_y_start = mrow_first_ny,
-                     .noc_x_end = mrow_last_nx,
-                     .noc_y_end = mrow_last_ny,
-                     .addr = dst_l1},
-                    /*linked=*/true);
+                if (mcast_bytes > 0) {
+                    noc.async_write_multicast<NocOptions::MCAST_INCL_SRC>(
+                        CoreLocalMem<uint32_t>(src_l1),
+                        MulticastEndpoint{},
+                        mcast_bytes,
+                        GRID_X_NOC,
+                        {.offset_bytes = 0},
+                        {.noc_x_start = mrow_first_nx,
+                         .noc_y_start = mrow_first_ny,
+                         .noc_x_end = mrow_last_nx,
+                         .noc_y_end = mrow_last_ny,
+                         .addr = dst_l1},
+                        /*linked=*/true);
+                }
                 noc.async_writes_flushed();
 
                 act_valid_sem.set(ACT_VALID);
                 act_valid_sem.set_multicast<NocOptions::MCAST_INCL_SRC>(
                     noc, mrow_first_nx, mrow_first_ny, mrow_last_nx, mrow_last_ny, GRID_X_NOC);
 
-                cb_activated_obj.pop_front(d_in0_block_num_tiles);
+                if (re_act_tiles > 0) {
+                    cb_activated_obj.pop_front(re_act_tiles);
+                }
             }
 
             // Step 5: receivers wait for both valid sems and push.

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/dataflow/unified_routed_expert_ffn_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/dataflow/unified_routed_expert_ffn_writer.cpp
@@ -215,12 +215,8 @@ void kernel_main() {
                             const uint32_t col = my_nt_gu * per_core_N_gu + n;
                             if (col < N_gate_tiles_full) {
                                 const uint32_t tile_idx = row * N_gate_tiles_full + col;
-#ifndef RE_SKIP_WEIGHT_READ
-                                // RE_SKIP_WEIGHT_READ (perf-investigation only): skip the
-                                // DRAM read, keep pointer advance for the read-bound ceiling.
                                 noc_up.async_read(
                                     up_acc, CoreLocalMem<uint32_t>(l1_w_up), up_tile_bytes, {.page_id = tile_idx}, {});
-#endif
                             } else {
                                 // N-OOB hidden padding column: garbage up output feeds the
                                 // down matmul's K reduction, so keep it zero UNLESS the down
@@ -294,18 +290,12 @@ void kernel_main() {
                             ASSERT(dst_row < dst_M_tiles);
                             if (dst_row < dst_M_tiles) {
                                 const uint32_t tile_idx = dst_row * N_down_tiles_full + col;
-#ifndef RE_SKIP_OUTPUT_WRITE
-                                // RE_SKIP_OUTPUT_WRITE (perf-investigation only): drop the
-                                // output DRAM write while still draining cb_out (below), so
-                                // the down matmul's write-bandwidth cost is isolated. Output
-                                // in DRAM is left stale.
                                 noc.async_write(
                                     cb_out_buf,
                                     out_acc,
                                     out_tile_bytes,
                                     {.offset_bytes = subblock_tile_offset},
                                     {.page_id = tile_idx});
-#endif
                             }
                         }
                         subblock_tile_offset += out_tile_bytes;

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/dataflow/unified_routed_expert_ffn_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/dataflow/unified_routed_expert_ffn_writer.cpp
@@ -42,6 +42,7 @@
 #include "api/dataflow/noc_semaphore.h"
 #include "api/core_local_mem.h"
 #include "api/debug/assert.h"
+#include "../adaptive_chunk.hpp"
 
 constexpr uint32_t TILE_HEIGHT = 32;
 
@@ -64,15 +65,19 @@ void kernel_main() {
     const uint32_t up_done_sem_id = get_arg_val<uint32_t>(8);
 
     constexpr uint32_t cb_out = get_compile_time_arg_val(1);
-    constexpr uint32_t per_core_M = get_compile_time_arg_val(2);
+    // per_core_M_max: CB-sized max per-core M. The runtime per_core_M is picked
+    // from the device count below; the down matmul packs the full max ring (so
+    // cb_out carries per_core_M_max rows) and this writer emits only the first
+    // (runtime) per_core_M of them.
+    constexpr uint32_t per_core_M_max = get_compile_time_arg_val(2);
     constexpr uint32_t per_core_N_gu = get_compile_time_arg_val(3);
     constexpr uint32_t per_core_N_d = get_compile_time_arg_val(4);
     constexpr uint32_t d_out_subblock_h = get_compile_time_arg_val(7);
     constexpr uint32_t d_out_subblock_w = get_compile_time_arg_val(8);
     constexpr uint32_t N_gate_tiles_full = get_compile_time_arg_val(9);
     constexpr uint32_t N_down_tiles_full = get_compile_time_arg_val(10);
-    constexpr uint32_t num_chunks = get_compile_time_arg_val(11);
-    constexpr uint32_t chunk_M_tiles = get_compile_time_arg_val(12);
+    constexpr uint32_t num_chunks_max = get_compile_time_arg_val(11);
+    constexpr uint32_t chunk_M_max = get_compile_time_arg_val(12);
     // device-side count read.
     constexpr uint32_t cb_counts_scratch = get_compile_time_arg_val(13);
     constexpr uint32_t cb_idx_scratch = get_compile_time_arg_val(14);
@@ -103,7 +108,10 @@ void kernel_main() {
     constexpr bool down_k_tail_skip = get_compile_time_arg_val(24) != 0;
 
     constexpr uint32_t d_out_subblock_num_tiles = d_out_subblock_h * d_out_subblock_w;
-    constexpr uint32_t d_in1_num_subblocks_M = per_core_M / d_out_subblock_h;
+    // Full compile-time M-subblock count of cb_out (the down matmul copies the
+    // full max ring). The writer DRAINS all of them but only WRITES the first
+    // (runtime) per_core_M rows (see the drain loop below).
+    constexpr uint32_t d_in1_num_subblocks_M = per_core_M_max / d_out_subblock_h;
     constexpr uint32_t d_in1_num_subblocks_N = per_core_N_d / d_out_subblock_w;
     constexpr uint32_t num_blocks_gu = K_gate_tiles / in0_block_w_gu;
     constexpr uint32_t g_in1_block_num_tiles = per_core_N_gu * in0_block_w_gu;
@@ -145,8 +153,11 @@ void kernel_main() {
     const uint32_t global_expert_id = idx_ptr[local_expert_id];
     const uint32_t count_value = counts_ptr[global_expert_id];
     const uint32_t count_tiles = (count_value + TILE_HEIGHT - 1) / TILE_HEIGHT;
-    const uint32_t effective_chunks_runtime = (count_tiles + chunk_M_tiles - 1) / chunk_M_tiles;
-    const uint32_t effective_chunks = effective_chunks_runtime < num_chunks ? effective_chunks_runtime : num_chunks;
+    // Runtime chunk layout from the actual count (same math as reader/compute so
+    // the row mapping agrees). per_core_M is per-chunk (see the loop).
+    const uint32_t effective_chunks_runtime = adaptive_chunk::num_chunks(count_tiles, chunk_M_max);
+    const uint32_t effective_chunks =
+        effective_chunks_runtime < num_chunks_max ? effective_chunks_runtime : num_chunks_max;
 
     // Destination tile-row offset for direct-write mode. In direct-write
     // mode the output buffer is a SHARED buffer and this expert's slice
@@ -204,8 +215,12 @@ void kernel_main() {
                             const uint32_t col = my_nt_gu * per_core_N_gu + n;
                             if (col < N_gate_tiles_full) {
                                 const uint32_t tile_idx = row * N_gate_tiles_full + col;
+#ifndef RE_SKIP_WEIGHT_READ
+                                // RE_SKIP_WEIGHT_READ (perf-investigation only): skip the
+                                // DRAM read, keep pointer advance for the read-bound ceiling.
                                 noc_up.async_read(
                                     up_acc, CoreLocalMem<uint32_t>(l1_w_up), up_tile_bytes, {.page_id = tile_idx}, {});
+#endif
                             } else {
                                 // N-OOB hidden padding column: garbage up output feeds the
                                 // down matmul's K reduction, so keep it zero UNLESS the down
@@ -229,9 +244,19 @@ void kernel_main() {
         }
 
         // ---- Drain cb_out (down matmul output) to DRAM ----
-        const uint32_t row0 = chunk * chunk_M_tiles + my_mt * per_core_M;
+        // Per-chunk per_core_M (per_core_M_max for full chunks, a smaller divisor
+        // for the tail); chunk starts are uniform at chunk*chunk_M_max. Contiguous
+        // row map: this core owns rows [row0, row0 + per_core_M).
+        const uint32_t per_core_M = adaptive_chunk::per_core_M_for_chunk(chunk, count_tiles, chunk_M_max);
+        const uint32_t row0 = chunk * chunk_M_max + my_mt * per_core_M;
         const uint32_t col0 = my_nt_d * per_core_N_d;
-        for (uint32_t sb_m = 0; sb_m < d_in1_num_subblocks_M; ++sb_m) {
+        // The DOWN matmul packs and pushes the FULL compile-time-MAX ring (its
+        // L1_ACC needs full-ring cycling), so DRAIN all d_in1_num_subblocks_M
+        // rows to keep cb_out balanced — but only WRITE the first per_core_M
+        // (runtime) rows; the rest are MAC-skipped zeros that map onto other
+        // cores' rows and must not be emitted (the sb_m < per_core_M guard below).
+        const uint32_t sb_m_bound = d_in1_num_subblocks_M;
+        for (uint32_t sb_m = 0; sb_m < sb_m_bound; ++sb_m) {
             for (uint32_t sb_n = 0; sb_n < d_in1_num_subblocks_N; ++sb_n) {
                 cb_out_buf.wait_front(d_out_subblock_num_tiles);
                 uint32_t subblock_tile_offset = 0;
@@ -253,7 +278,10 @@ void kernel_main() {
                         //   * row < count_tiles: the last chunk's per_core_M
                         //     rows extend past count_tiles when count_tiles
                         //     is not chunk-aligned.
-                        if (col < N_down_tiles_full && row < M_tiles_full && row < count_tiles) {
+                        //   * sb_m < per_core_M: cb_out carries per_core_M_max
+                        //     rows (full ring); rows past the runtime per_core_M
+                        //     are zeros that belong to other cores — never write.
+                        if (sb_m < per_core_M && col < N_down_tiles_full && row < M_tiles_full && row < count_tiles) {
                             // The destination tile-row must stay inside the
                             // (possibly shared) output buffer. ttnn::insert
                             // asserted the whole-slice fit
@@ -266,12 +294,18 @@ void kernel_main() {
                             ASSERT(dst_row < dst_M_tiles);
                             if (dst_row < dst_M_tiles) {
                                 const uint32_t tile_idx = dst_row * N_down_tiles_full + col;
+#ifndef RE_SKIP_OUTPUT_WRITE
+                                // RE_SKIP_OUTPUT_WRITE (perf-investigation only): drop the
+                                // output DRAM write while still draining cb_out (below), so
+                                // the down matmul's write-bandwidth cost is isolated. Output
+                                // in DRAM is left stale.
                                 noc.async_write(
                                     cb_out_buf,
                                     out_acc,
                                     out_tile_bytes,
                                     {.offset_bytes = subblock_tile_offset},
                                     {.page_id = tile_idx});
+#endif
                             }
                         }
                         subblock_tile_offset += out_tile_bytes;

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_program_factory.cpp
@@ -28,22 +28,6 @@ namespace ttnn::operations::experimental::deepseek_prefill::unified_routed_exper
 namespace {
 constexpr uint32_t TILE = tt::constants::TILE_HEIGHT;
 
-// Perf-investigation toggles (env-var gated, default off). These strip work
-// from the JIT-compiled kernels to isolate DRAM I/O from compute:
-//   RE_SKIP_MATMUL      -> compute kernel skips the matmul MAC inner loops
-//                          (keeps all CB handshakes/packs), leaving the I/O floor.
-//   RE_SKIP_OUTPUT_WRITE -> writer skips the output DRAM write (keeps cb_out
-//                          drain), isolating the down-matmul write-bandwidth cost.
-// Both produce incorrect output and must never be set in production runs.
-//
-// Deliberately not tt::parse_env<bool>: that uses std::stoi and throws on any
-// non-numeric value, whereas these dev toggles accept any truthy string
-// (e.g. RE_SKIP_MATMUL=1 / on / yes) and treat unset or "0" as off.
-bool env_flag_set(const char* name) {
-    const char* v = std::getenv(name);
-    return v != nullptr && v[0] != '\0' && v[0] != '0';
-}
-
 // CB index allocation (kept stable across kernels via named compile-time args).
 constexpr uint32_t CB_IN0_X = tt::CBIndex::c_0;
 constexpr uint32_t CB_IN1_GATE = tt::CBIndex::c_1;
@@ -699,12 +683,6 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
         tt::tt_metal::TensorAccessorArgs(t.down_bias->buffer()).append_to(reader_ct_args);
         reader_defines["FUSE_BIAS"] = "1";
     }
-    // Perf-investigation toggle (see env_flag_set): skip weight DRAM reads to
-    // quantify the read-bound ceiling (reads stripped, mcasts/handshakes kept).
-    const bool skip_weight_read = env_flag_set("RE_SKIP_WEIGHT_READ");
-    if (skip_weight_read) {
-        reader_defines["RE_SKIP_WEIGHT_READ"] = "1";
-    }
     auto reader_kernel_id = tt::tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/dataflow/"
@@ -764,21 +742,12 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
     // up accessor follows start; used only when the writer handles `up`.
     tt::tt_metal::TensorAccessorArgs(up_buffer).append_to(writer_ct_args);
 
-    // Perf-investigation toggles (see env_flag_set): strip the output DRAM write
-    // and/or the `up` weight DRAM read (the latter for the read-bound ceiling).
-    std::map<std::string, std::string> writer_defines{};
-    if (env_flag_set("RE_SKIP_OUTPUT_WRITE")) {
-        writer_defines["RE_SKIP_OUTPUT_WRITE"] = "1";
-    }
-    if (skip_weight_read) {
-        writer_defines["RE_SKIP_WEIGHT_READ"] = "1";
-    }
     auto writer_kernel_id = tt::tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/dataflow/"
         "unified_routed_expert_ffn_writer.cpp",
         core_range_set,
-        tt::tt_metal::WriterDataMovementConfig(writer_ct_args, writer_defines));
+        tt::tt_metal::WriterDataMovementConfig(writer_ct_args));
 
     // Compute kernel compile-time args: positional + named CB ids.
     std::vector<uint32_t> compute_ct_args = {
@@ -874,11 +843,6 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
         // FUSE_BIAS: add gate/up bias (broadcast across rows) before the
         // SwiGLU-OAI activation and down bias after the down matmul (gpt-oss).
         compute_defines["FUSE_BIAS"] = "1";
-    }
-    // Perf-investigation toggle (see env_flag_set): strip the matmul MAC.
-    const bool skip_matmul = env_flag_set("RE_SKIP_MATMUL");
-    if (skip_matmul) {
-        compute_defines["RE_SKIP_MATMUL"] = "1";
     }
 
     auto compute_kernel_id = tt::tt_metal::CreateKernel(

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_program_factory.cpp
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <cstdlib>
 #include <map>
 #include <unordered_map>
 #include <utility>
@@ -26,6 +27,22 @@ namespace ttnn::operations::experimental::deepseek_prefill::unified_routed_exper
 
 namespace {
 constexpr uint32_t TILE = tt::constants::TILE_HEIGHT;
+
+// Perf-investigation toggles (env-var gated, default off). These strip work
+// from the JIT-compiled kernels to isolate DRAM I/O from compute:
+//   RE_SKIP_MATMUL      -> compute kernel skips the matmul MAC inner loops
+//                          (keeps all CB handshakes/packs), leaving the I/O floor.
+//   RE_SKIP_OUTPUT_WRITE -> writer skips the output DRAM write (keeps cb_out
+//                          drain), isolating the down-matmul write-bandwidth cost.
+// Both produce incorrect output and must never be set in production runs.
+//
+// Deliberately not tt::parse_env<bool>: that uses std::stoi and throws on any
+// non-numeric value, whereas these dev toggles accept any truthy string
+// (e.g. RE_SKIP_MATMUL=1 / on / yes) and treat unset or "0" as off.
+bool env_flag_set(const char* name) {
+    const char* v = std::getenv(name);
+    return v != nullptr && v[0] != '\0' && v[0] != '0';
+}
 
 // CB index allocation (kept stable across kernels via named compile-time args).
 constexpr uint32_t CB_IN0_X = tt::CBIndex::c_0;
@@ -102,29 +119,20 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
     // silu and multiply).
     constexpr uint32_t kMaxGridX = 11;
     constexpr uint32_t MAX_GRID_Y = 8;
-    // Short-sequence regime: for small allocated M the 2D layout is stall-bound
-    // (FPU idle), dominated by the gate/up weight DRAM read and by per_core_M.
-    // Both shrink with the grid (pure host config): more N-columns parallelise
-    // the read, and maximising GRID_Y drives per_core_M down to 1-2 for the cost
-    // of a cheap weight multicast. So: GRID_X tuned below, GRID_Y =
-    // min(8, M_tiles_full), single chunk; GRID_Y == 1 drops the multicast.
+    // Full 2D grid, always. The short-sequence special case was removed: real
+    // dispatch buffers are always in the long-sequence range, and the runtime
+    // kernel picker (adaptive_chunk.hpp) already shrinks per_core_M for small
+    // token counts, so no host-side small-M grid tuning is needed.
     //
-    // Branches purely on ALLOCATED M (x.padded_shape); the runtime token count
-    // still bounds the chunk loop device-side. Production keeps M_tiles_full
-    // large, so it stays on the unchanged 2D path.
-    constexpr uint32_t kShortSeqMaxMTiles = 32;  // <= 1024 tokens
+    // chunk_M_tiles here is the CB-sized MAXIMUM chunk (op.chunk_M_tiles, default
+    // 64 => per_core_M_max 8). All three kernels pick the ACTUAL chunk_M /
+    // per_core_M / num_chunks at runtime from the device token count, never
+    // exceeding this max; the CBs below are sized to the max so a smaller pick
+    // simply uses fewer of the reserved tiles.
     uint32_t GRID_X = kMaxGridX;
     uint32_t GRID_Y = MAX_GRID_Y;
     uint32_t chunk_M_tiles = op.chunk_M_tiles;
     uint32_t in0_block_w_gu = 16;
-    const bool short_seq = M_tiles_full <= kShortSeqMaxMTiles;
-    if (short_seq) {
-        // Maximise rows to minimise per_core_M (1 for M <= 8, 2 for M <= 16, ...).
-        GRID_Y = std::min(MAX_GRID_Y, M_tiles_full);
-        GRID_Y = std::max<uint32_t>(GRID_Y, 1);
-        const uint32_t per_core_M_short = (M_tiles_full + GRID_Y - 1) / GRID_Y;
-        chunk_M_tiles = per_core_M_short * GRID_Y;  // single chunk (>= M_tiles_full)
-    }
     const auto grid_size = t.x.device()->compute_with_storage_grid_size();
     TT_FATAL(
         grid_size.x >= kMaxGridX && grid_size.y >= MAX_GRID_Y,
@@ -133,107 +141,28 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
         MAX_GRID_Y,
         grid_size.x,
         grid_size.y);
-    // per_core_M upper bound (requested). `chunk_M_tiles` here is either
-    // op.chunk_M_tiles (general 2D path) or the short_seq single-chunk value;
-    // the adaptive L1-budget guard below may shrink per_core_M / in0_block_w_gu
-    // (and hence chunk_M_tiles) to fit the device's per-core L1.
+    // per_core_M upper bound (the CB-sized max). The adaptive L1-budget guard
+    // below may shrink per_core_M / in0_block_w_gu (and hence chunk_M_tiles) to
+    // fit the device's per-core L1 on large models.
     const uint32_t per_core_M_max = chunk_M_tiles / GRID_Y;
     TT_FATAL(
         per_core_M_max * GRID_Y == chunk_M_tiles && per_core_M_max >= 1,
         "chunk_M_tiles ({}) must be a positive multiple of GRID_Y ({})",
         chunk_M_tiles,
         GRID_Y);
-    // Effective per_core_M. The general path may reduce it below per_core_M_max
-    // to fit L1 (short_seq keeps its picker's value). Also read by the short_seq
-    // GRID_X search below (est_l1_bytes).
+    // Effective (CB-sized) per_core_M. The L1 guard below may reduce it to fit L1.
     uint32_t per_core_M = per_core_M_max;
-    // M_tiles_full is NOT required to divide chunk_M_tiles. The kernel runs
-    // ceil(M_tiles_full / chunk_M_tiles) chunks; the reader zero-fills L1
+    // M_tiles_full is NOT required to divide chunk_M_tiles. The kernels run
+    // ceil(count_tiles / chunk_M_tiles_runtime) chunks; the reader zero-fills L1
     // rows past min(count_tiles, M_tiles_full) in the last chunk; the writer
     // skips OOB writes for output rows >= M_tiles_full. Avoids the host-side
     // pad/slice round-trip in the composite for non-aligned M.
 
-    // Per-core L1 footprint estimator, mirroring the CreateCircularBuffer sizes
-    // below. Bounds the short-seq GRID_X search to the known-good 2D footprint
-    // so we never risk an L1 OOM.
-    const uint32_t x_ts = tt::tile_size(tt::tt_metal::datatype_to_dataformat_converter(t.x.dtype()));
-    // Matmul input CB (cb_in0_x). On the row-major path the compute kernel
-    // tilizes bf16 x into it and packs bf8_b — keeping x bf8 through the matmul
-    // (as the TILE path does) instead of bf16, which halves this CB and frees L1
-    // for a larger per_core_M. cb_x_rm stays bf16 (the mcast/tilize source).
-    const uint32_t in0_x_ts = op.x_is_row_major ? tt::tile_size(tt::DataFormat::Bfp8_b) : x_ts;
-    const uint32_t w_ts = tt::tile_size(tt::tt_metal::datatype_to_dataformat_converter(t.gate_proj.dtype()));
-    const uint32_t p_ts = tt::tile_size(tt::DataFormat::Float16_b);
-    const uint32_t im_ts = tt::tile_size(tt::DataFormat::Bfp8_b);
-    const uint32_t out_ts = tt::tile_size(tt::tt_metal::datatype_to_dataformat_converter(tensor_return_value.dtype()));
     // Bias tile size (FUSE_BIAS): all three bias CBs share the gate-bias dtype
-    // (enforced in validation). Zero when unused so the estimators are unchanged
-    // on the bias-free path.
+    // (enforced in validation). Zero when unused so the L1 footprint estimate
+    // (cb_footprint_bytes below) is unchanged on the bias-free path.
     const uint32_t bias_ts =
         op.fuse_bias ? tt::tile_size(tt::tt_metal::datatype_to_dataformat_converter(t.gate_bias->dtype())) : 0;
-    auto est_l1_bytes = [&](uint32_t gx, uint32_t pcM, uint32_t ibw_gu) -> uint64_t {
-        const uint32_t pcN_gu = (N_gate_tiles_full + gx - 1) / gx;
-        const uint32_t pcN_d = (N_down_tiles_full + gx - 1) / gx;
-        const uint32_t ibw_d = pcN_gu;
-        uint64_t b = 0;
-        b += (op.x_is_row_major ? 1ull : 2ull) * pcM * ibw_gu * in0_x_ts;  // CB_IN0_X (single-buf on RM)
-        if (op.x_is_row_major) {
-            b += 2ull * pcM * ibw_gu * p_ts;  // CB_X_RM bf16 staging (row-major only)
-        }
-        b += 2ull * ibw_gu * pcN_gu * w_ts;  // CB_IN1_GATE
-        b += 2ull * ibw_gu * pcN_gu * w_ts;  // CB_IN1_UP
-        b += 2ull * ibw_d * pcN_d * w_ts;    // CB_IN1_DOWN
-        b += 1ull * pcM * pcN_gu * im_ts;    // CB_GATE_INT
-        b += 1ull * pcM * pcN_gu * im_ts;    // CB_ACTIVATED
-        b += 1ull * pcM * pcN_gu * p_ts;     // CB_PARTIALS_GU
-        b += 1ull * pcM * pcN_gu * p_ts;     // CB_PARTIALS_UP
-        b += 1ull * pcM * pcN_d * p_ts;      // CB_PARTIALS_D
-        b += 2ull * 8 * out_ts;              // CB_OUT (subblock <= 8 tiles, staged x2)
-        b += 2ull * pcM * ibw_d * im_ts;     // CB_IN0_DOWN_FULL
-        b += 8192;                           // counts + idx scratch
-        // Bias CBs (single-buffered, one full per-core N-slice each): gate/up use
-        // pcN_gu tiles, down uses pcN_d. Must be accounted here or a shape near the
-        // L1 limit can pass GRID_X selection and then overflow at program build.
-        b += 1ull * (2 * pcN_gu + pcN_d) * bias_ts;
-        return b;
-    };
-
-    if (short_seq) {
-        // Reference footprint: the largest 2D config (GRID_X=11, per_core_M=8,
-        // in0_block_w_gu=16) is known to fit, so any smaller config fits too.
-        constexpr uint32_t kMax2dPerCoreM = 8;
-        const uint64_t budget = est_l1_bytes(kMaxGridX, kMax2dPerCoreM, 16);
-        // gate/up K-block widths to try (descending = fewest handshakes),
-        // restricted to divisors of K_gate_tiles.
-        const uint32_t ibw_candidates[] = {56, 32, 28, 16, 8, 4, 2, 1};
-        uint32_t best_gx = kMaxGridX;
-        uint32_t best_ibw = 16;
-        bool found = false;
-        // Candidate GRID_X: more N-columns parallelise the dominant weight read,
-        // so prefer gx=8, then 11, then 4. Restricted to values whose
-        // per_core_N_gu has a large (<=8) output-subblock divisor — gx 5/6/7
-        // give per_core_N_gu with only divisor 1, forcing 1-wide pack subblocks
-        // that erase the saving.
-        const uint32_t gx_candidates[] = {8, kMaxGridX, 4};
-        for (uint32_t gx : gx_candidates) {
-            if (found) {
-                break;
-            }
-            for (uint32_t ibw : ibw_candidates) {
-                if (ibw > K_gate_tiles || (K_gate_tiles % ibw) != 0) {
-                    continue;
-                }
-                if (est_l1_bytes(gx, per_core_M, ibw) <= budget) {
-                    best_gx = gx;
-                    best_ibw = ibw;
-                    found = true;
-                    break;  // largest fitting ibw for this gx
-                }
-            }
-        }
-        GRID_X = best_gx;
-        in0_block_w_gu = best_ibw;
-    }
 
     // in0_block_w_gu (the gate/up K-loop block width) must divide K_gate_tiles.
     // The short_seq picker above already restricts itself to divisors, but the
@@ -338,9 +267,9 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
     //      weight re-reads, the dominant DRAM cost;
     //   2. then the largest in0_block_w_gu (divisor of K_gate_tiles) that fits —
     //      wider gate/up K-blocks pipeline DRAM I/O better.
-    // Runs after the short_seq GRID_X/in0_block_w_gu picker, so it also caps
-    // short_seq configs at the real L1 ceiling. This mirrors the CB allocations
-    // in the "circular buffers" section below; keep the two in sync.
+    // The resulting per_core_M is the CB-sized MAX; the runtime picker never
+    // exceeds it. This mirrors the CB allocations in the "circular buffers"
+    // section below; keep the two in sync.
     const auto cb_footprint_bytes = [&](uint32_t M, uint32_t w_gu) -> uint64_t {
         uint64_t total = 0;
         total += static_cast<uint64_t>(M * w_gu * (op.x_is_row_major ? 1 : 2)) *
@@ -379,12 +308,11 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
     const uint64_t l1_budget = static_cast<uint64_t>(l1_device->l1_size_per_core()) - l1_reserved - L1_SCRATCH_MARGIN;
 
     // If the requested config — (per_core_M_max, in0_block_w_gu) from
-    // op.chunk_M_tiles and either the short_seq picker or the default 16 —
-    // overflows the real L1 budget, shrink to fit: reduce per_core_M first (the
-    // kernel just runs more chunks; keeping per_core_M large minimises full
-    // weight re-reads, the dominant DRAM cost), then narrow in0_block_w_gu to
-    // the largest divisor of K_gate_tiles that fits. No-op when the requested
-    // config already fits (all DSV3 / M2.7 dims and every short_seq config).
+    // op.chunk_M_tiles and the default in0_block_w_gu=16 — overflows the real L1
+    // budget, shrink to fit: reduce per_core_M first (fewer weight re-reads, the
+    // dominant DRAM cost), then narrow in0_block_w_gu to the largest divisor of
+    // K_gate_tiles that fits. No-op when the requested config already fits (all
+    // DSV3 / M2.7 dims).
     if (cb_footprint_bytes(per_core_M, in0_block_w_gu) > l1_budget) {
         // Candidate gate/up K-block widths: divisors of K_gate_tiles no wider
         // than the requested in0_block_w_gu, largest first.
@@ -436,7 +364,14 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
         K_gate_tiles,
         in0_block_w_gu);
 
-    const uint32_t num_chunks = (M_tiles_full + chunk_M_tiles - 1) / chunk_M_tiles;
+    // num_chunks is the compile-time UPPER BOUND on the runtime chunk count used
+    // only to clamp the kernels' loop defensively. The runtime picker may choose
+    // a chunk as small as min(16, chunk_M_tiles) (per_core_M 2), so the worst
+    // case is ceil(M_tiles_full / that min). Matches adaptive_chunk.hpp's
+    // kMinChunkMTiles = 16.
+    constexpr uint32_t kMinChunkMTiles = 16;
+    const uint32_t min_chunk = (chunk_M_tiles < kMinChunkMTiles) ? chunk_M_tiles : kMinChunkMTiles;
+    const uint32_t num_chunks = (M_tiles_full + min_chunk - 1) / min_chunk;
 
     // Phase-level numbers.
     const uint32_t gu_in0_num_subblocks = per_core_M / gu_out_subblock_h;
@@ -764,7 +699,12 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
         tt::tt_metal::TensorAccessorArgs(t.down_bias->buffer()).append_to(reader_ct_args);
         reader_defines["FUSE_BIAS"] = "1";
     }
-
+    // Perf-investigation toggle (see env_flag_set): skip weight DRAM reads to
+    // quantify the read-bound ceiling (reads stripped, mcasts/handshakes kept).
+    const bool skip_weight_read = env_flag_set("RE_SKIP_WEIGHT_READ");
+    if (skip_weight_read) {
+        reader_defines["RE_SKIP_WEIGHT_READ"] = "1";
+    }
     auto reader_kernel_id = tt::tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/dataflow/"
@@ -824,12 +764,21 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
     // up accessor follows start; used only when the writer handles `up`.
     tt::tt_metal::TensorAccessorArgs(up_buffer).append_to(writer_ct_args);
 
+    // Perf-investigation toggles (see env_flag_set): strip the output DRAM write
+    // and/or the `up` weight DRAM read (the latter for the read-bound ceiling).
+    std::map<std::string, std::string> writer_defines{};
+    if (env_flag_set("RE_SKIP_OUTPUT_WRITE")) {
+        writer_defines["RE_SKIP_OUTPUT_WRITE"] = "1";
+    }
+    if (skip_weight_read) {
+        writer_defines["RE_SKIP_WEIGHT_READ"] = "1";
+    }
     auto writer_kernel_id = tt::tt_metal::CreateKernel(
         program,
         "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/dataflow/"
         "unified_routed_expert_ffn_writer.cpp",
         core_range_set,
-        tt::tt_metal::WriterDataMovementConfig(writer_ct_args));
+        tt::tt_metal::WriterDataMovementConfig(writer_ct_args, writer_defines));
 
     // Compute kernel compile-time args: positional + named CB ids.
     std::vector<uint32_t> compute_ct_args = {
@@ -925,6 +874,11 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
         // FUSE_BIAS: add gate/up bias (broadcast across rows) before the
         // SwiGLU-OAI activation and down bias after the down matmul (gpt-oss).
         compute_defines["FUSE_BIAS"] = "1";
+    }
+    // Perf-investigation toggle (see env_flag_set): strip the matmul MAC.
+    const bool skip_matmul = env_flag_set("RE_SKIP_MATMUL");
+    if (skip_matmul) {
+        compute_defines["RE_SKIP_MATMUL"] = "1";
     }
 
     auto compute_kernel_id = tt::tt_metal::CreateKernel(

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/unified_routed_expert_ffn.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/unified_routed_expert_ffn.cpp
@@ -32,42 +32,18 @@ ttnn::Tensor unified_routed_expert_ffn(
     // Single-op fused per-expert FFN. One device Program runs gate matmul,
     // up matmul, silu, multiply, down matmul as four phases inside the same
     // kernel. The kernel reads counts[global_expert_idx_table[local_expert_id]]
-    // device-side at entry and bounds its chunk loop to
-    // ceil(count / chunk_M_tiles) — chunks past the actual token count are
-    // skipped entirely (no matmul, no mcast).
+    // device-side at entry and, from that runtime count, PICKS chunk_M_tiles /
+    // per_core_M / num_chunks itself (adaptive_chunk.hpp) — sizing the per-core
+    // work to the actual token count with no expected-token argument. chunks
+    // past the count are skipped entirely (no matmul, no mcast).
     //
-    // chunk_M_tiles: any value in {16, 24, 32, 40, 48, 56, 64} (per_core_M =
-    // chunk_M_tiles / GRID_Y, must be >= 2 and <= 8). M_tiles_full does NOT
-    // need to be a multiple of chunk_M_tiles — the kernel runs
-    // ceil(M_tiles_full / chunk_M_tiles) chunks, reader zero-fills L1 rows
-    // past M_tiles_full in the last chunk, writer skips OOB output writes.
-    //
-    // Picker minimizes the number of chunks first (= ceil(M / chunk)). Each
-    // chunk pays ~25 K-block handshakes (14 gate/up + 11 down) regardless of
-    // per_core_M, so fewer chunks wins more than waste hurts compute. On tie
-    // (same num_chunks), prefers smaller waste = closer to-aligned. For
-    // DS-V3 this picks 64 for nearly all sizes; 5k → 64 (3 chunks, was 40
-    // with 4 chunks); 25k → 64 (13 chunks, was 40 with 20 chunks).
-    constexpr uint32_t kGridY = 8;
-    constexpr uint32_t kMinChunkMTiles = 16;  // per_core_M >= 2
-    constexpr uint32_t kMaxChunkMTiles = 64;  // per_core_M <= 8 (L1 cap)
+    // The host only sets the CB-sized MAXIMUM chunk (kMaxChunkMTiles => per_core_M
+    // 8). The program factory's L1 guard may lower it for large models; the
+    // device picker never exceeds whatever max the CBs were sized to.
+    constexpr uint32_t kMaxChunkMTiles = 64;  // per_core_M_max = 8 (L1 cap)
     // This expert's M in tiles. Defaults to x's allocated M; a caller passing a
     // shared x buffer (wider than one region) supplies the per-expert value.
     const uint32_t M_tiles_full = input_m_tiles.value_or(x.padded_shape()[-2] / 32);
-    uint32_t chunk_M_tiles = kMaxChunkMTiles;
-    uint32_t best_num_chunks = (M_tiles_full + kMinChunkMTiles - 1) / kMinChunkMTiles + 1;
-    uint32_t best_waste = kMaxChunkMTiles + 1;
-    for (uint32_t cand = kMinChunkMTiles; cand <= kMaxChunkMTiles; cand += kGridY) {
-        const uint32_t num_chunks = (M_tiles_full + cand - 1) / cand;
-        const uint32_t rem = M_tiles_full % cand;
-        const uint32_t waste = (rem == 0) ? 0 : (cand - rem);
-        const bool better = (num_chunks < best_num_chunks) || (num_chunks == best_num_chunks && waste < best_waste);
-        if (better) {
-            best_num_chunks = num_chunks;
-            best_waste = waste;
-            chunk_M_tiles = cand;
-        }
-    }
 
     return ttnn::prim::unified_routed_expert_ffn(
         x,
@@ -77,7 +53,7 @@ ttnn::Tensor unified_routed_expert_ffn(
         counts,
         global_expert_idx_table,
         local_expert_id,
-        chunk_M_tiles,
+        kMaxChunkMTiles,
         M_tiles_full,
         read_x_at_offset,
         x_is_row_major,

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/unified_routed_expert_ffn_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/unified_routed_expert_ffn_nanobind.cpp
@@ -91,6 +91,9 @@ void bind_unified_routed_expert_ffn(nb::module_& mod) {
             activation (ttnn.RoutedExpertActivation, optional):
                 Silu (default, DeepSeek) or SwiGluOai (clamped, MiniMax-M3 / gpt-oss).
 
+        The kernel picks chunk_M_tiles / per_core_M / num_chunks at RUNTIME from
+        the device-resident token count, so there is no chunk-sizing argument.
+
         Returns:
             ttnn.Tensor: (M_max, K=emb).
         )doc",
@@ -145,6 +148,10 @@ void bind_unified_routed_expert_ffn(nb::module_& mod) {
             compute_kernel_config (ttnn.DeviceComputeKernelConfig, optional)
             activation (ttnn.RoutedExpertActivation, optional):
                 Silu (default, DeepSeek) or SwiGluOai (clamped, MiniMax-M3 / gpt-oss).
+
+        Each per-expert FFN picks its chunk_M_tiles / per_core_M / num_chunks at
+        RUNTIME from the device-resident token count, so there is no expected-token
+        argument — the work scales to each expert's actual load automatically.
 
         Returns:
             ttnn.Tensor: expert outputs, same shape as dispatched_buffer.


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/50742


### Problem description

The unified routed-expert FFN sized its per-core matmul work - chunk_M_tiles, per_core_M, and num_chunks — on the host, from an expected_tokens_per_expert argument the caller had to pass. That was especially bad when number of active tokens is smaller than 2K tokens (max chunk_M_tiles), because in that case per_core_M was also 8, which is unoptimal.

### What's changed

Chunk / per_core_M sizing moves from the host into the kernels, computed at runtime from the device-read token count. No caller passes an expected-token hint; work scales to each expert's actual load.

- New adaptive_chunk.hpp - shared pure-integer picker used by the reader, compute, and writer so all three derive the same chunk_M_tiles / per_core_M / num_chunks from one count (mismatch → output on wrong token rows).
- Chunk layout - full chunks at per_core_M_max=8, then one tail chunk shrunk to the smallest divisor of per_core_M_max covering the remainder (a non-divisor wraps the gate/up CB ring mid-block and deadlocks reserve_back). The tail per_core_M must divide per_core_M_max=8, so it's one of {1, 2, 4, 8}. e.g. 160 → 64+64+32.
- Compute (fused_swiglu.cpp) - gate/up + multiply reserve CBs once at the runtime per_core_M and shrink their M-loops (real work saved). The down matmul can't shrink: PACKER_L1_ACC accumulates across K-blocks by draining the ring each block with push == drain == out_block_num_tiles, so a smaller ring would corrupt the accumulation. It keeps the full MAX ring and instead skips the MAC for rows ≥ runtime per_core_M (packing zeros, cheap — weight-read-bound); the writer bounds its drain by the same per_core_M, so those rows aren't emitted.
- Host op + program factory - dropped the host chunk picker and expected_tokens_per_expert arg; host only sets the CB-sized MAX chunk.

## Performance

<img width="908" height="1204" alt="image" src="https://github.com/user-attachments/assets/52cd6f67-d7f3-4d7d-9615-f79aa7ea2f62" />


### Tracy for 256 active tokens 5120 allocated
Optimized

<img width="4814" height="648" alt="image" src="https://github.com/user-attachments/assets/df8f5044-aef5-42d1-8e1c-24a59a77362d" />

<img width="3764" height="624" alt="image" src="https://github.com/user-attachments/assets/18c67fcf-248a-4676-89ef-6e0a72fba69e" />

Main

<img width="5004" height="724" alt="image" src="https://github.com/user-attachments/assets/3dbdf503-0c26-47b3-915a-5910bbc1a3a6" />

<img width="4234" height="740" alt="image" src="https://github.com/user-attachments/assets/c67ae18c-05dd-471a-9713-9b0a8a171a41" />

Conclusion:
Both GATE-UP-MATMUL and DOWN-MATMUL are much more faster, due to per_core_M=1 for active tokens 256.
Also IN0-READ was before done only on first row of Tensix cores, now it is done in the same amount on all Tensix rows (all 8 of them) so IN0-READ is split to 8 rows in same amount and is much more faster.

### GALAXY

Main

<img width="3482" height="1380" alt="image" src="https://github.com/user-attachments/assets/1f4ec67a-4209-44d6-b6b8-37d3debc65cb" />


Optimized

<img width="3494" height="1366" alt="image" src="https://github.com/user-attachments/assets/f60841c6-07a0-4cf2-b219-a78fe94326af" />


### DeepSeek CI

- [x] [![(T3K) e2e
tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml/badge.svg?branch=pmilojevic/50742-adaptive-percoreM)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml?query=branch:pmilojevic/50742-adaptive-percoreM)
- [x] [![(BH) e2e
tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=pmilojevic/50742-adaptive-percoreM)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:pmilojevic/50742-adaptive-percoreM)
- [x] [![Demo SP
Release](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml/badge.svg?branch=pmilojevic/50742-adaptive-percoreM)](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml?query=branch:pmilojevic/50742-adaptive-percoreM)
- [x] [![(Galaxy) Blaze Models Prefill tests ](https://github.com/tenstorrent/tt-metal/actions/workflows/blaze-models-prefill-tests.yaml/badge.svg?branch=pmilojevic/50742-adaptive-percoreM)](https://github.com/tenstorrent/tt-metal/actions/workflows/blaze-models-prefill-tests.yaml?query=branch:pmilojevic/50742-adaptive-percoreM)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pmilojevic/50742-adaptive-percoreM)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pmilojevic/50742-adaptive-percoreM)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pmilojevic/50742-adaptive-percoreM)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pmilojevic/50742-adaptive-percoreM)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=pmilojevic/50742-adaptive-percoreM)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:pmilojevic/50742-adaptive-percoreM)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pmilojevic/50742-adaptive-percoreM)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pmilojevic/50742-adaptive-percoreM)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pmilojevic/50742-adaptive-percoreM)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pmilojevic/50742-adaptive-percoreM)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pmilojevic/50742-adaptive-percoreM)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pmilojevic/50742-adaptive-percoreM)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pmilojevic/50742-adaptive-percoreM)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pmilojevic/50742-adaptive-percoreM)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pmilojevic/50742-adaptive-percoreM)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pmilojevic/50742-adaptive-percoreM)