### PR TITLE
feat: chunk device transfers to speed up llk tests

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/fuser/fused_operand.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/fused_operand.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass, field
 from typing import List, Optional, Tuple
 
 import torch
+from helpers.device_io import read_from_device, write_to_device
 from helpers.llk_params import DataFormat, PartialFace, format_dict, format_tile_sizes
 from helpers.stimuli_generator import (
     StimuliSpec,
@@ -20,7 +21,6 @@ from helpers.tile_constants import (
 from helpers.tile_shape import TileShape, construct_tile_shape
 from helpers.tilize_untilize import tilize_block, untilize_block
 from helpers.unpack import unpack_res_tiles
-from ttexalens.tt_exalens_lib import read_from_device, write_to_device
 
 
 @dataclass

--- a/tt_metal/tt-llk/tests/python_tests/fuser/fuser_config.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/fuser_config.py
@@ -10,12 +10,12 @@ from typing import List
 import pandas as pd
 import pytest
 from helpers.chip_architecture import ChipArchitecture
+from helpers.device_io import read_words_from_device
 from helpers.llk_params import DestAccumulation, PerfRunType
 from helpers.logger import logger
 from helpers.perf import PerfReport
 from helpers.profiler import Profiler, ProfilerData
 from helpers.test_config import BuildMode, ProfilerBuild, StimuliMode, TestConfig
-from ttexalens.tt_exalens_lib import read_words_from_device
 
 from .fused_operand import OperandRegistry
 from .fused_operation import FusedOperation

--- a/tt_metal/tt-llk/tests/python_tests/helpers/counters.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/counters.py
@@ -6,9 +6,9 @@ from typing import Dict, List
 
 import pandas as pd
 from loguru import logger
-from ttexalens.tt_exalens_lib import read_words_from_device, write_words_to_device
 
 from .chip_architecture import ChipArchitecture, get_chip_architecture
+from .device_io import read_words_from_device, write_words_to_device
 from .test_config import TestConfig
 
 # Constants and Configuration (derived from TestConfig).

--- a/tt_metal/tt-llk/tests/python_tests/helpers/device.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/device.py
@@ -20,11 +20,10 @@ from ttexalens.tt_exalens_lib import (
     check_context,
     convert_coordinate,
     parse_elf,
-    read_from_device,
     read_word_from_device,
-    write_words_to_device,
 )
 
+from .device_io import read_from_device, write_words_to_device
 from .llk_params import BriscCmd
 from .logger import logger
 

--- a/tt_metal/tt-llk/tests/python_tests/helpers/device_io.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/device_io.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tt_metal/tt-llk/tests/python_tests/helpers/device_io.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/device_io.py
@@ -1,0 +1,171 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Drop-in replacements for the ttexalens transfer helpers that split large
+requests into small ones.
+
+ttexalens only takes its DMA path when ``can_use_dma`` is true, which excludes
+Blackhole, the simulator, and non-MMIO devices. Without DMA the request goes to
+UMD's register access, which has a hard cliff: anything up to ~2112 bytes is
+moved in bulk, anything larger degrades to one 4-byte word at a time. Measured
+on Blackhole, a 128 KB result buffer takes 94 ms to read as a single request but
+3.4 ms split into 2 KB requests; the same write goes from 47 ms to 1.5 ms.
+
+Splitting is skipped where DMA is available, since there a large transfer is a
+single descriptor and chunking would only multiply the setup cost.
+
+These wrappers mirror the signatures of the ttexalens functions they replace, so
+call sites only need to change their import.
+"""
+
+import struct
+from functools import lru_cache
+
+from ttexalens.tt_exalens_lib import convert_coordinate
+from ttexalens.tt_exalens_lib import read_from_device as _read_from_device
+from ttexalens.tt_exalens_lib import read_words_from_device as _read_words_from_device
+from ttexalens.tt_exalens_lib import write_to_device as _write_to_device
+from ttexalens.tt_exalens_lib import write_words_to_device as _write_words_to_device
+
+# Comfortably below the measured ~2112 byte cliff, and a natural alignment.
+MAX_TRANSFER_BYTES = 2048
+
+
+@lru_cache(maxsize=None)
+def _splitting_helps(device_id: int) -> bool:
+    from ttexalens import check_context
+
+    try:
+        return not check_context().devices[device_id]._umd_device.can_use_dma
+    except Exception:
+        # Rather than guess at a ttexalens internal that moved, keep splitting:
+        # it is a large win without DMA and only a small loss with it.
+        return True
+
+
+def read_from_device(
+    location,
+    addr,
+    device_id=0,
+    num_bytes=4,
+    context=None,
+    noc_id=None,
+    use_4B_mode=None,
+    safe_mode=None,
+):
+    if num_bytes <= MAX_TRANSFER_BYTES or not _splitting_helps(device_id):
+        return _read_from_device(
+            location,
+            addr,
+            device_id,
+            num_bytes,
+            context,
+            noc_id,
+            use_4B_mode,
+            safe_mode,
+        )
+
+    # Resolve once so each chunk skips re-parsing the "x,y" location string.
+    coordinate = convert_coordinate(location, device_id, context)
+    return b"".join(
+        _read_from_device(
+            coordinate,
+            addr + offset,
+            device_id,
+            min(MAX_TRANSFER_BYTES, num_bytes - offset),
+            context,
+            noc_id,
+            use_4B_mode,
+            safe_mode,
+        )
+        for offset in range(0, num_bytes, MAX_TRANSFER_BYTES)
+    )
+
+
+def write_to_device(
+    location,
+    addr,
+    data,
+    device_id=0,
+    context=None,
+    noc_id=None,
+    use_4B_mode=None,
+    safe_mode=None,
+):
+    if isinstance(data, list):
+        data = bytes(data)
+
+    if len(data) <= MAX_TRANSFER_BYTES or not _splitting_helps(device_id):
+        return _write_to_device(
+            location, addr, data, device_id, context, noc_id, use_4B_mode, safe_mode
+        )
+
+    coordinate = convert_coordinate(location, device_id, context)
+    for offset in range(0, len(data), MAX_TRANSFER_BYTES):
+        _write_to_device(
+            coordinate,
+            addr + offset,
+            data[offset : offset + MAX_TRANSFER_BYTES],
+            device_id,
+            context,
+            noc_id,
+            use_4B_mode,
+            safe_mode,
+        )
+
+
+def read_words_from_device(
+    location,
+    addr,
+    device_id=0,
+    word_count=1,
+    context=None,
+    noc_id=None,
+    use_4B_mode=None,
+    safe_mode=None,
+):
+    num_bytes = 4 * word_count
+    if num_bytes <= MAX_TRANSFER_BYTES or not _splitting_helps(device_id):
+        return _read_words_from_device(
+            location,
+            addr,
+            device_id,
+            word_count,
+            context,
+            noc_id,
+            use_4B_mode,
+            safe_mode,
+        )
+
+    raw = read_from_device(
+        location, addr, device_id, num_bytes, context, noc_id, use_4B_mode, safe_mode
+    )
+    return list(struct.unpack(f"<{word_count}I", raw))
+
+
+def write_words_to_device(
+    location,
+    addr,
+    data,
+    device_id=0,
+    context=None,
+    noc_id=None,
+    use_4B_mode=None,
+    safe_mode=None,
+):
+    if isinstance(data, int) or len(data) * 4 <= MAX_TRANSFER_BYTES:
+        return _write_words_to_device(
+            location, addr, data, device_id, context, noc_id, use_4B_mode, safe_mode
+        )
+
+    return write_to_device(
+        location,
+        addr,
+        b"".join(word.to_bytes(4, "little") for word in data),
+        device_id,
+        context,
+        noc_id,
+        use_4B_mode,
+        safe_mode,
+    )

--- a/tt_metal/tt-llk/tests/python_tests/helpers/device_io.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/device_io.py
@@ -36,12 +36,13 @@ MAX_TRANSFER_BYTES = 2048
 def _splitting_helps(device_id: int) -> bool:
     from ttexalens import check_context
 
+    context = check_context()
     try:
-        return not check_context().devices[device_id]._umd_device.can_use_dma
-    except Exception:
-        # Rather than guess at a ttexalens internal that moved, keep splitting:
-        # it is a large win without DMA and only a small loss with it.
+        can_use_dma = context.devices[device_id]._umd_device.can_use_dma
+    except AttributeError:
+        # If the private ttexalens API moves, conservatively keep splitting.
         return True
+    return not can_use_dma
 
 
 def read_from_device(

--- a/tt_metal/tt-llk/tests/python_tests/helpers/device_io.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/device_io.py
@@ -20,7 +20,6 @@ call sites only need to change their import.
 """
 
 import struct
-from functools import lru_cache
 
 from ttexalens.tt_exalens_lib import convert_coordinate
 from ttexalens.tt_exalens_lib import read_from_device as _read_from_device
@@ -32,17 +31,22 @@ from ttexalens.tt_exalens_lib import write_words_to_device as _write_words_to_de
 MAX_TRANSFER_BYTES = 2048
 
 
-@lru_cache(maxsize=None)
-def _splitting_helps(device_id: int) -> bool:
-    from ttexalens import check_context
+def _splitting_helps(coordinate) -> bool:
+    """Whether this coordinate's device lacks the DMA path that makes splitting
+    unnecessary.
 
-    context = check_context()
+    Read off the resolved coordinate rather than the global context, so that a
+    caller passing an explicit ``context`` (or an already-resolved coordinate as
+    ``location``) is answered for the device that will actually perform the
+    transfer. This is a couple of attribute lookups and is only reached for
+    transfers already large enough to be worth splitting, so it is not cached.
+    """
     try:
-        can_use_dma = context.devices[device_id]._umd_device.can_use_dma
+        return not coordinate.device._umd_device.can_use_dma
     except AttributeError:
-        # If the private ttexalens API moves, conservatively keep splitting.
+        # If the private ttexalens API moves, conservatively keep splitting: it
+        # is a large win without DMA and only a small loss with it.
         return True
-    return not can_use_dma
 
 
 def read_from_device(
@@ -55,7 +59,7 @@ def read_from_device(
     use_4B_mode=None,
     safe_mode=None,
 ):
-    if num_bytes <= MAX_TRANSFER_BYTES or not _splitting_helps(device_id):
+    if num_bytes <= MAX_TRANSFER_BYTES:
         return _read_from_device(
             location,
             addr,
@@ -69,6 +73,18 @@ def read_from_device(
 
     # Resolve once so each chunk skips re-parsing the "x,y" location string.
     coordinate = convert_coordinate(location, device_id, context)
+    if not _splitting_helps(coordinate):
+        return _read_from_device(
+            coordinate,
+            addr,
+            device_id,
+            num_bytes,
+            context,
+            noc_id,
+            use_4B_mode,
+            safe_mode,
+        )
+
     return b"".join(
         _read_from_device(
             coordinate,
@@ -97,12 +113,17 @@ def write_to_device(
     if isinstance(data, list):
         data = bytes(data)
 
-    if len(data) <= MAX_TRANSFER_BYTES or not _splitting_helps(device_id):
+    if len(data) <= MAX_TRANSFER_BYTES:
         return _write_to_device(
             location, addr, data, device_id, context, noc_id, use_4B_mode, safe_mode
         )
 
     coordinate = convert_coordinate(location, device_id, context)
+    if not _splitting_helps(coordinate):
+        return _write_to_device(
+            coordinate, addr, data, device_id, context, noc_id, use_4B_mode, safe_mode
+        )
+
     for offset in range(0, len(data), MAX_TRANSFER_BYTES):
         _write_to_device(
             coordinate,
@@ -127,7 +148,7 @@ def read_words_from_device(
     safe_mode=None,
 ):
     num_bytes = 4 * word_count
-    if num_bytes <= MAX_TRANSFER_BYTES or not _splitting_helps(device_id):
+    if num_bytes <= MAX_TRANSFER_BYTES:
         return _read_words_from_device(
             location,
             addr,

--- a/tt_metal/tt-llk/tests/python_tests/helpers/device_print.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/device_print.py
@@ -31,6 +31,7 @@ from pathlib import Path
 from typing import Any
 
 from helpers.chip_architecture import ChipArchitecture, get_chip_architecture
+from helpers.device_io import read_from_device, write_words_to_device
 from helpers.format_config import (
     BLACKHOLE_DATA_FORMAT_ENUM_VALUES,
     QUASAR_DATA_FORMAT_ENUM_VALUES,
@@ -39,7 +40,7 @@ from helpers.format_config import (
 )
 from helpers.logger import logger
 from helpers.utils import TILE_BG_RESULT, format_tile_row
-from ttexalens.tt_exalens_lib import parse_elf, read_from_device, write_words_to_device
+from ttexalens.tt_exalens_lib import parse_elf
 
 # hostdev/device_print_structures.h: DevicePrintStringInfo is four uint32_t
 # on 32-bit ELFs, and four uint64_t on 64-bit ELFs (Rocket cores on Quasar).

--- a/tt_metal/tt-llk/tests/python_tests/helpers/profiler.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/profiler.py
@@ -8,8 +8,8 @@ from enum import Enum
 from typing import ClassVar
 
 import pandas as pd
-from ttexalens.tt_exalens_lib import read_words_from_device
 
+from .device_io import read_words_from_device
 from .llk_params import PerfRunType
 from .test_config import TestConfig
 

--- a/tt_metal/tt-llk/tests/python_tests/helpers/stimuli_config.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/stimuli_config.py
@@ -10,11 +10,8 @@ from pathlib import Path
 from typing import ClassVar
 
 import torch
-from ttexalens.tt_exalens_lib import (
-    read_from_device,
-    write_to_device,
-)
 
+from .device_io import read_from_device, write_to_device
 from .format_config import DataFormat
 from .golden_generators import GeneratorProxy, ProxyMode
 from .llk_params import format_tile_sizes

--- a/tt_metal/tt-llk/tests/python_tests/helpers/stream.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/stream.py
@@ -5,9 +5,10 @@
 import time
 from typing import Optional
 
-from ttexalens.tt_exalens_lib import (
+from ttexalens.tt_exalens_lib import read_word_from_device
+
+from .device_io import (
     read_from_device,
-    read_word_from_device,
     write_to_device,
     write_words_to_device,
 )

--- a/tt_metal/tt-llk/tests/python_tests/helpers/test_config.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/test_config.py
@@ -22,10 +22,7 @@ from ttexalens.tt_exalens_lib import (
     TTException,
     load_elf,
     parse_elf,
-    read_from_device,
     read_word_from_device,
-    write_to_device,
-    write_words_to_device,
 )
 
 from . import device as device_module
@@ -46,6 +43,7 @@ from .device import (
     set_tensix_soft_reset,
     wait_brisc_boot_ready,
 )
+from .device_io import read_from_device, write_to_device, write_words_to_device
 from .device_print import aux_size_for
 from .format_config import (
     BLACKHOLE_DATA_FORMAT_ENUM_VALUES,
@@ -1559,14 +1557,24 @@ class TestConfig:
             else timeout
         )
 
+        # Poll every mailbox in a single NoC transaction. They occupy one
+        # contiguous block (Unpacker, +4, +8, plus +12 on Quasar), so reading the
+        # whole span costs one round trip per iteration instead of one per TRISC.
+        # Taking min/max rather than assuming adjacency keeps this correct even
+        # if the layout gains a gap; it would just read a slightly wider span.
+        base = min(mailbox.value for mailbox in mailboxes)
+        span = max(mailbox.value for mailbox in mailboxes) + 4 - base
+        word_index = {mailbox: (mailbox.value - base) // 4 for mailbox in mailboxes}
+
         completed = set()
         end_time = time.time() + timeout
         while time.time() < end_time:
+            words = np.frombuffer(
+                read_from_device(TestConfig.TENSIX_LOCATION, base, num_bytes=span),
+                dtype=np.uint32,
+            )
             for mailbox in mailboxes - completed:
-                if (
-                    read_word_from_device(TestConfig.TENSIX_LOCATION, mailbox.value)
-                    == KERNEL_COMPLETE
-                ):
+                if words[word_index[mailbox]] == KERNEL_COMPLETE:
                     completed.add(mailbox)
 
             if poll_callback is not None:

--- a/tt_metal/tt-llk/tests/python_tests/test_fast_tilize_full.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_fast_tilize_full.py
@@ -302,7 +302,7 @@ def test_fast_tilize_overflow_guard(formats, dest_acc, dimensions):
     #   word[0] = 0x4680 (marker), word[1..4] = corrupted count per guard tile.
     import struct
 
-    from ttexalens.tt_exalens_lib import read_from_device
+    from helpers.device_io import read_from_device
 
     stim = configuration.variant_stimuli
     last_g_addr = (

--- a/tt_metal/tt-llk/tests/python_tests/test_fast_tilize_tiny_tiles.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_fast_tilize_tiny_tiles.py
@@ -4,6 +4,7 @@
 import pytest
 import torch
 from conftest import skip_for_blackhole
+from helpers.device_io import read_from_device
 from helpers.format_config import DataFormat
 from helpers.llk_params import DestAccumulation, format_dict, format_tile_sizes
 from helpers.param_config import input_output_formats, parametrize
@@ -19,7 +20,6 @@ from helpers.test_variant_parameters import (
 from helpers.tile_constants import calculate_tile_size_bytes, get_tile_params
 from helpers.tilize_untilize import tilize_block
 from helpers.utils import passed_test
-from ttexalens.tt_exalens_lib import read_from_device
 
 TILE_DIMENSIONS = [16, 32]
 

--- a/tt_metal/tt-llk/tests/python_tests/test_fast_untilize.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_fast_untilize.py
@@ -29,6 +29,7 @@ from fast_untilize_common import (
     fast_untilize_formats,
 )
 from helpers.chip_architecture import ChipArchitecture, get_chip_architecture
+from helpers.device_io import read_from_device
 from helpers.format_config import DataFormat, InputOutputFormat
 from helpers.golden_generators import UntilizeGolden, get_golden_generator
 from helpers.llk_params import DestAccumulation, DestSync, PerfRunType, format_dict
@@ -45,7 +46,6 @@ from helpers.test_variant_parameters import (
     generate_input_dim,
 )
 from helpers.utils import passed_test
-from ttexalens.tt_exalens_lib import read_from_device
 
 
 def generate_tile_face_row_ids(tile_count, dtype=torch.bfloat16):

--- a/tt_metal/tt-llk/tests/python_tests/test_profiler_stress.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_profiler_stress.py
@@ -6,12 +6,12 @@ from dataclasses import dataclass
 
 import pytest
 from conftest import skip_for_coverage
+from helpers.device_io import read_words_from_device
 from helpers.param_config import parametrize
 from helpers.perf import PerfConfig
 from helpers.profiler import EntryType, Profiler
 from helpers.test_config import BuildMode, TestConfig
 from helpers.test_variant_parameters import TemplateParameter
-from ttexalens.tt_exalens_lib import read_words_from_device
 
 
 @dataclass

--- a/tt_metal/tt-llk/tests/python_tests/test_sdpa_reinits.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_sdpa_reinits.py
@@ -5,6 +5,7 @@
 import pytest
 import torch
 from conftest import skip_for_coverage, skip_for_wormhole
+from helpers.device_io import read_from_device, write_to_device
 from helpers.format_config import DataFormat
 from helpers.golden_generators import (
     BroadcastGolden,
@@ -35,7 +36,6 @@ from helpers.test_variant_parameters import (
 from helpers.tilize_untilize import tilize_block, untilize_block
 from helpers.unpack import unpack_res_tiles
 from helpers.utils import passed_test
-from ttexalens.tt_exalens_lib import read_from_device, write_to_device
 
 
 @skip_for_coverage


### PR DESCRIPTION
### PR Category
Performance

### Summary
On Blackhole, ttexalens never takes its DMA path since `UmdDevice.can_use_dma` returns `False` for the arch, so every L1 read and write goes through UMD register access.
That path has a hard size cliff: a request up to ~2112 bytes is moved in bulk, and anything larger falls back to one 4-byte word at a time.
Measured on a Blackhole card:
| request size | read      | write     |
| ------------ | --------- | --------- |
| ≤ 2112 B     | ~38 MB/s  | ~87 MB/s  |
| > 2112 B     | 1.4 MB/s  | 2.8 MB/s  |

Every test pays this, because stimuli writes and result readback are each issued as one large transfer. A 128 KB result buffer costs 94 ms to read and 47 ms to write, against 3.4 ms and 1.5 ms for the same bytes moved in 2 KB requests.

New `helpers/device_io.py` provides drop-in replacements for `read_from_device`, `write_to_device`, `read_words_from_device` and `write_words_to_device`. Requests larger than 2048 bytes are split into 2 KB pieces, keeping every request on the fast side of the cliff. The location is resolved to an `OnChipCoordinate` once per call
rather than once per chunk. Splitting is skipped where `can_use_dma` is true, so Wormhole still issues a single DMA descriptor instead of sixty-four. Every device transfer call site under `python_tests/` now imports from there.

Thirteen of the fifteen touched files are a one-line import redirect.


### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=filip/chunk-device-transfers)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:filip/chunk-device-transfers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=filip/chunk-device-transfers)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:filip/chunk-device-transfers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=filip/chunk-device-transfers)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:filip/chunk-device-transfers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=filip/chunk-device-transfers)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:filip/chunk-device-transfers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=filip/chunk-device-transfers)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:filip/chunk-device-transfers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=filip/chunk-device-transfers)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:filip/chunk-device-transfers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=filip/chunk-device-transfers)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:filip/chunk-device-transfers)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=filip/chunk-device-transfers)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:filip/chunk-device-transfers)