### PR TITLE
ci: run GLM prefill tests as GLM-5.2 instead of GLM-5.1

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py
@@ -24,7 +24,7 @@ import ttnn
 from conftest import is_galaxy
 from models.common.utility_functions import is_blackhole, profiler
 from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3Config
-from models.demos.deepseek_v3_d_p.reference.glm_5_1_config import GLM51Config
+from models.demos.deepseek_v3_d_p.reference.glm_5_2_config import GLM52Config
 from models.demos.deepseek_v3_d_p.reference.kimi_k2_6_config import KimiK26Config
 from models.demos.deepseek_v3_d_p.reference.tt.moe.moe import TorchMoe
 from models.demos.deepseek_v3_d_p.tests.reference_runners import run_reference_moe
@@ -614,9 +614,9 @@ def run_model(
         # GLM-5.1 MoE (256 experts / top-8, emb 6144, moe_int 2048). Exercises the >64-expert unfused
         # extract->FFN->insert routed-expert path on GLM dims. Gate is generic here (op-level test);
         # GLM's noaux_tc knife-edge gate is validated at the transformer level. 25k = 3200 per-chip x 8.
-        pytest.param(1600, GLM51Config.EMB_SIZE, GLM51Config.MOE_INTERMEDIATE_SIZE, GLM51Config.NUM_ROUTED_EXPERTS, GLM51Config.NUM_EXPERTS_PER_TOKEN, 5, GateComputeMode.DEVICE_FP32, True,  False, marks=[pytest.mark.skipif(not is_blackhole(), reason="Blackhole only"), pytest.mark.timeout(900)], id="pcc-device-glm-256"),
-        pytest.param(3200, GLM51Config.EMB_SIZE, GLM51Config.MOE_INTERMEDIATE_SIZE, GLM51Config.NUM_ROUTED_EXPERTS, GLM51Config.NUM_EXPERTS_PER_TOKEN, 8, GateComputeMode.DEVICE_FP32, False, True,  marks=pytest.mark.skipif(not is_blackhole(), reason="Blackhole only"), id="perf-device-glm-256"),
-        pytest.param(3200, GLM51Config.EMB_SIZE, GLM51Config.MOE_INTERMEDIATE_SIZE, GLM51Config.NUM_ROUTED_EXPERTS, GLM51Config.NUM_EXPERTS_PER_TOKEN, 5, GateComputeMode.HOST_ALL,    True,  False, marks=[pytest.mark.skipif(not is_blackhole(), reason="Blackhole only"), pytest.mark.skipif(not is_galaxy(), reason="Requires Galaxy")], id="pcc-host-glm-256"),
+        pytest.param(1600, GLM52Config.EMB_SIZE, GLM52Config.MOE_INTERMEDIATE_SIZE, GLM52Config.NUM_ROUTED_EXPERTS, GLM52Config.NUM_EXPERTS_PER_TOKEN, 5, GateComputeMode.DEVICE_FP32, True,  False, marks=[pytest.mark.skipif(not is_blackhole(), reason="Blackhole only"), pytest.mark.timeout(900)], id="pcc-device-glm-256"),
+        pytest.param(3200, GLM52Config.EMB_SIZE, GLM52Config.MOE_INTERMEDIATE_SIZE, GLM52Config.NUM_ROUTED_EXPERTS, GLM52Config.NUM_EXPERTS_PER_TOKEN, 8, GateComputeMode.DEVICE_FP32, False, True,  marks=pytest.mark.skipif(not is_blackhole(), reason="Blackhole only"), id="perf-device-glm-256"),
+        pytest.param(3200, GLM52Config.EMB_SIZE, GLM52Config.MOE_INTERMEDIATE_SIZE, GLM52Config.NUM_ROUTED_EXPERTS, GLM52Config.NUM_EXPERTS_PER_TOKEN, 5, GateComputeMode.HOST_ALL,    True,  False, marks=[pytest.mark.skipif(not is_blackhole(), reason="Blackhole only"), pytest.mark.skipif(not is_galaxy(), reason="Requires Galaxy")], id="pcc-host-glm-256"),
         # fmt: on
     ],
 )

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py
@@ -611,7 +611,7 @@ def run_model(
         pytest.param(3200, DeepSeekV3Config.EMB_SIZE, DeepSeekV3Config.MOE_INTERMEDIATE_SIZE, 256, 8, 5, GateComputeMode.HOST_ALL, True,  False, marks=[pytest.mark.skipif(not is_blackhole(), reason="Blackhole only"), pytest.mark.skipif(not is_galaxy(), reason="Requires Galaxy")], id="pcc-host-256"),
         # Perf: LB 8x1 dispatch/combine proxy. 64 experts + 2 picks/tok match one glx column's per-chip traffic (balanced_load=800).
         pytest.param(3200, DeepSeekV3Config.EMB_SIZE, DeepSeekV3Config.MOE_INTERMEDIATE_SIZE,  64, 2, 8, GateComputeMode.HOST_ALL, False, False, marks=pytest.mark.skipif(not is_blackhole(), reason="Blackhole only"), id="perf-host-64"),
-        # GLM-5.1 MoE (256 experts / top-8, emb 6144, moe_int 2048). Exercises the >64-expert unfused
+        # GLM-5.2 MoE (256 experts / top-8, emb 6144, moe_int 2048). Exercises the >64-expert unfused
         # extract->FFN->insert routed-expert path on GLM dims. Gate is generic here (op-level test);
         # GLM's noaux_tc knife-edge gate is validated at the transformer level. 25k = 3200 per-chip x 8.
         pytest.param(1600, GLM52Config.EMB_SIZE, GLM52Config.MOE_INTERMEDIATE_SIZE, GLM52Config.NUM_ROUTED_EXPERTS, GLM52Config.NUM_EXPERTS_PER_TOKEN, 5, GateComputeMode.DEVICE_FP32, True,  False, marks=[pytest.mark.skipif(not is_blackhole(), reason="Blackhole only"), pytest.mark.timeout(900)], id="pcc-device-glm-256"),

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_block.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_block.py
@@ -32,7 +32,7 @@ from models.demos.deepseek_v3_d_p.reference.glm_5_1_config import GLM51Config
 from models.demos.deepseek_v3_d_p.reference.kimi_k2_6_config import KimiK26Config
 from models.demos.deepseek_v3_d_p.reference.tt.moe.moe import load_moe_weights_from_hf
 from models.demos.deepseek_v3_d_p.tests.sparse_mla.sparse_mla_reference import build_weights
-from models.demos.deepseek_v3_d_p.tt.mla.indexer import num_full_indexer_layers
+from models.demos.deepseek_v3_d_p.tt.mla.indexer import indexer_layer_is_reused, num_full_indexer_layers
 from models.demos.deepseek_v3_d_p.tt.mla.rope import RotarySetup
 from models.demos.deepseek_v3_d_p.tt.mla.utils import (
     create_balanced_chunk_order,
@@ -854,6 +854,17 @@ def test_kimi_prefill_block(
 GLM_BLOCK_OUTPUT_PCC = 0.98
 
 
+def _first_full_moe_layer(config):
+    # First MoE layer (>= first_k_dense_replace) that OWNS a full indexer. A GLM-5.2 "shared" indexer
+    # layer reuses a prior full layer's top-k, which an isolated single block cannot supply; a full
+    # layer computes its own. glm_5_1 has no indexer_types -> every layer is full -> returns
+    # first_k_dense_replace (3). glm_5_2 layers 3-5 are shared -> returns 6.
+    idx = config.first_k_dense_replace
+    while indexer_layer_is_reused(config, idx):
+        idx += 1
+    return idx
+
+
 def _glm_norm_weight(hidden, seed):
     return (torch.randn(hidden, generator=torch.Generator().manual_seed(seed)) * 0.1 + 1.0).to(torch.bfloat16)
 
@@ -948,9 +959,7 @@ def _glm_pretrained_weights(config, model_dir, layer_idx, is_moe):
     indirect=["mesh_device", "device_params"],
 )
 @pytest.mark.parametrize("seq_len", [5120], ids=["seq5120"])
-@pytest.mark.parametrize(
-    "layer_type, layer_idx", [("dense", 0), ("moe", GLM51Config.NUM_DENSE_LAYERS)], ids=["dense", "moe"]
-)
+@pytest.mark.parametrize("layer_type", ["dense", "moe"], ids=["dense", "moe"])
 @pytest.mark.parametrize("variant", ["glm_5_1", "glm_5_2"], indirect=True, ids=["glm51", "glm52"])
 @pytest.mark.skipif(not is_blackhole(), reason="DSA ops (indexer / sparse SDPA) are Blackhole-only")
 @pytest.mark.timeout(0)
@@ -963,7 +972,6 @@ def test_glm_prefill_block(
     topology,
     seq_len,
     layer_type,
-    layer_idx,
     model_path,
     weight_cache_path,
 ):
@@ -971,13 +979,10 @@ def test_glm_prefill_block(
     is_moe = layer_type == "moe"
     config = config_only
     config.max_seq_len = seq_len
-    # GLM-5.2 MoE single-block: skipped. The block feeds a RANDOM input, which drives GLM's
-    # near-degenerate top-8 MoE gate to select different experts on device vs the CPU reference at an
-    # isolated layer (block PCC collapses to ~0.1 though the same layer scores ~0.995 in-context in
-    # test_glm_prefill_transformer). Not an op/weight bug — a random-input artifact of the degenerate
-    # gate. GLM-5.2 MoE is covered by test_glm_prefill_transformer; the device gate by test_ttnn_moe.
-    if is_moe and getattr(config, "indexer_types", None) is not None:
-        pytest.skip("GLM-5.2 single-block MoE unreliable under degenerate gate on random input (see comment)")
+    # MoE runs at the first FULL-indexer MoE layer so the block owns its top-k: a GLM-5.2 "shared"
+    # indexer layer reuses a prior full layer's indices, which an isolated single block cannot supply
+    # (ReuseIndexer.forward raises). glm_5_1 -> first_k_dense_replace (3); glm_5_2 -> 6 (3-5 shared).
+    layer_idx = _first_full_moe_layer(config) if is_moe else 0
     hidden = config.hidden_size
     sp_axis, tp_axis = 0, 1
     mesh_shape = list(mesh_device.shape)
@@ -994,6 +999,17 @@ def test_glm_prefill_block(
         init_checker(effective_cache)  # required before check_cache_complete / pattern_exists
         use_pretrained = TtPrefillBlock.check_cache_complete(effective_cache, layer_idx, not is_moe, experts_per_chip)
     logger.info(f"[glm block {layer_type}] use_pretrained={use_pretrained} (ttnn cache={effective_cache})")
+
+    # Real-weight isolated MoE block: skip. A random block input drives GLM's trained near-degenerate
+    # top-8 gate to pick different experts on device vs the CPU reference (block PCC collapses to ~0.1),
+    # though the same layer scores ~0.995 in-context in test_glm_prefill_transformer. Not an op/weight
+    # bug — a real-weight-gate x random-input artifact. On RANDOM weights the gate is non-degenerate and
+    # the block matches (~0.99), so CI (empty cache -> random) still exercises the MoE path here; the
+    # real-weight MoE gate is covered by test_glm_prefill_transformer and test_ttnn_moe.
+    if is_moe and use_pretrained:
+        pytest.skip(
+            "isolated real-weight MoE block diverges under the degenerate top-8 gate on random input (see comment)"
+        )
 
     if use_pretrained:
         # Device loads real weights from the cache; reference uses matching host weights from the checkpoint.

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_block.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_block.py
@@ -993,23 +993,21 @@ def test_glm_prefill_block(
     sp_factor, tp_factor = mesh_shape[sp_axis], mesh_shape[tp_axis]
     experts_per_chip = GLM51Config.NUM_ROUTED_EXPERTS // (sp_factor * tp_factor)
     effective_cache = (weight_cache_path / f"{sp_factor}x{tp_factor}") if weight_cache_path is not None else None
+    # The isolated MoE block is only meaningful on RANDOM weights, so it never consults the ttnn cache:
+    # a random block input drives GLM's trained near-degenerate top-8 gate to pick different experts on
+    # device vs the CPU reference (block PCC collapses to ~0.1), though the same layer scores ~0.995
+    # in-context in test_glm_prefill_transformer — a real-weight-gate x random-input artifact, not an
+    # op/weight bug. On random weights the gate is non-degenerate and the block matches (~0.99). Forcing
+    # random here keeps the MoE path exercised regardless of what the cache holds; real-weight MoE-gate
+    # coverage lives in test_glm_prefill_transformer and test_ttnn_moe. The dense case still loads real
+    # weights when the cache is complete.
     use_pretrained = False
     if effective_cache is not None:
         effective_cache.mkdir(parents=True, exist_ok=True)
         init_checker(effective_cache)  # required before check_cache_complete / pattern_exists
-        use_pretrained = TtPrefillBlock.check_cache_complete(effective_cache, layer_idx, not is_moe, experts_per_chip)
+        if not is_moe:
+            use_pretrained = TtPrefillBlock.check_cache_complete(effective_cache, layer_idx, True, experts_per_chip)
     logger.info(f"[glm block {layer_type}] use_pretrained={use_pretrained} (ttnn cache={effective_cache})")
-
-    # Real-weight isolated MoE block: skip. A random block input drives GLM's trained near-degenerate
-    # top-8 gate to pick different experts on device vs the CPU reference (block PCC collapses to ~0.1),
-    # though the same layer scores ~0.995 in-context in test_glm_prefill_transformer. Not an op/weight
-    # bug — a real-weight-gate x random-input artifact. On RANDOM weights the gate is non-degenerate and
-    # the block matches (~0.99), so CI (empty cache -> random) still exercises the MoE path here; the
-    # real-weight MoE gate is covered by test_glm_prefill_transformer and test_ttnn_moe.
-    if is_moe and use_pretrained:
-        pytest.skip(
-            "isolated real-weight MoE block diverges under the degenerate top-8 gate on random input (see comment)"
-        )
 
     if use_pretrained:
         # Device loads real weights from the cache; reference uses matching host weights from the checkpoint.

--- a/tests/pipeline_reorg/blackhole_e2e_tests.yaml
+++ b/tests/pipeline_reorg/blackhole_e2e_tests.yaml
@@ -178,14 +178,14 @@
   cmd: |
     exit_code=0
     export DEEPSEEK_V3_HF_MODEL=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528
-    export DEEPSEEK_V32_MLA_REF_CACHE=/tmp/deepseek_v32_mla_ref_cache GLM51_MLA_REF_CACHE=/tmp/glm_5_1_mla_ref_cache
+    export DEEPSEEK_V32_MLA_REF_CACHE=/tmp/deepseek_v32_mla_ref_cache GLM52_MLA_REF_CACHE=/tmp/glm_5_2_mla_ref_cache
     export DS_SPARSE_FABRIC=fabric2d
-    # Sparse MLA (V3.2 + GLM-5.1) vs MLACPU. Random weights + on-the-fly CPU truth -> no staged weights.
-    # GLM-5.1 reshards heads->sequence in _sparse_mla so it now runs at tp=4; 2x4 is its coverage (accuracy
+    # Sparse MLA (V3.2 + GLM-5.2) vs MLACPU. Random weights + on-the-fly CPU truth -> no staged weights.
+    # GLM-5.2 reshards heads->sequence in _sparse_mla so it now runs at tp=4; 2x4 is its coverage (accuracy
     # + the determinism/chunked anchor cases, which pin to the highest-TP mesh). DeepSeek-V3.2 covers the
     # asymmetric 2x4 mesh (its 8x4 coverage is on Galaxy). The sparse suite carries no tier markers, so
     # there is no -m gate.
-    pytest models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla.py -k "glm_5_1 and 2x4 and fabric2d" -vvv --tb=short || exit_code=$?
+    pytest models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla.py -k "glm_5_2 and 2x4 and fabric2d" -vvv --tb=short || exit_code=$?
     pytest models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla.py -k "deepseek_v32 and 2x4 and fabric2d" -vvv --tb=short || exit_code=$?
     exit $exit_code
   skus:

--- a/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
+++ b/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
@@ -180,17 +180,18 @@
   team: models
   sp_config: sc1
 
-- name: "Blaze - DSA MLA (GLM-5.1 + GLM-5.2 indexer reuse)"
+- name: "Blaze - DSA MLA (GLM-5.2)"
   cmd: |
     export MESH_DEVICE=TG
-    export GLM51_MLA_REF_CACHE=/mnt/models/deepseek-prefill-cache/glm_5_1_mla_ref_cache
+    export GLM52_MLA_REF_CACHE=/mnt/models/deepseek-prefill-cache/glm_5_2_mla_ref_cache
     export DS_SPARSE_FABRIC=fabric2d
-    # GLM-5.1 sparse MLA (indexer + sparse SDPA) vs the MLACPU reference, plus the GLM-5.2 indexer-reuse
-    # equivalence case (inject a prior-layer top-k == recompute). Random weights + on-the-fly CPU truth
-    # -> no staged weights. Reuse shares the warm sparse-MLA JIT for this job (same op graph; glm_5_2 == glm_5_1 dims).
+    # GLM-5.2 sparse MLA (indexer + sparse SDPA) vs the MLACPU reference. The glm_5_2 variant sweep at the
+    # 8x4 anchor already includes the indexer-reuse equivalence case (SPARSE_REUSE_CASES is glm_5_2-only),
+    # so no separate -k clause is needed. Random weights + on-the-fly CPU truth -> no staged weights.
+    # (The glm_5_1-only kv_only case is intentionally not run here; GLM-5.1 is fully retired from CI.)
     mpirun --bind-to none --pernode --tag-output bash -lc '
       export OMP_NUM_THREADS=$(nproc)
-      python3 -m pytest models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla.py -k "(glm_5_1 and 8x4 and fabric2d) or indexer_reuse" -vvv --tb=short
+      python3 -m pytest models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla.py -k "glm_5_2 and 8x4 and fabric2d" -vvv --tb=short
     '
   test_type: dsa_mla_glm
   test_group: module
@@ -204,7 +205,7 @@
 - name: "Blaze - GLM MoE"
   cmd: |
     export MESH_DEVICE=TG
-    # GLM-5.1 256-expert MoE (device gate, DEVICE_FP32) vs the CPU MoE reference; random weights.
+    # GLM-5.2 256-expert MoE (device gate, DEVICE_FP32) vs the CPU MoE reference; random weights.
     mpirun --bind-to none --pernode --tag-output bash -lc '
       export OMP_NUM_THREADS=$(nproc)
       python3 -m pytest models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py::test_ds_moe -k "mesh-8x4 and (pcc-device-glm-256 or perf-device-glm-256)" -vvv --tb=short
@@ -218,20 +219,20 @@
   team: models
   sp_config: sc1
 
-- name: "Blaze - GLM-5.1 Prefill Block"
+- name: "Blaze - GLM-5.2 Prefill Block"
   cmd: |
     export MESH_DEVICE=TG
-    export GLM51_HF_MODEL=/mnt/models/deepseek-prefill-cache/GLM-5.1-FP8/
-    export TT_GLM51_PREFILL_TTNN_CACHE=/mnt/models/deepseek-prefill-cache/GLM-5.1-Cache/CI
-    export PREFILL_TRACE_DIR=/mnt/models/deepseek-prefill-cache/golden/structured_traces/glm_51_code_debug_55k_vllm
-    export GLM51_MLA_REF_CACHE=/mnt/models/deepseek-prefill-cache/glm_5_1_mla_ref_cache
-    # Fused GLM-5.1 decoder block (sparse-SDPA MLA + norm/residual + dense/MoE FFN, layers 0 and 3) vs the
-    # composed CPU reference on the fabric2d transport. Real weights via the prebuilt ttnn cache when present
-    # (random fallback otherwise; never rebuilds). -k glm51 so the shared glm_5_2 parametrization is not run
-    # here: its MoE block is skipped under the degenerate gate, and GLM-5.2 is covered by the DSA-MLA/MoE jobs.
+    export GLM52_HF_MODEL=/mnt/models/deepseek-prefill-cache/GLM-5.2-FP8/
+    export TT_GLM52_PREFILL_TTNN_CACHE=/mnt/models/deepseek-prefill-cache/GLM-5.2-Cache/CI
+    # Fused GLM-5.2 decoder block (sparse-SDPA MLA + norm/residual + dense/MoE FFN, layers 0 and 6) vs the
+    # composed CPU reference on the fabric2d transport. The CI ttnn cache dir is empty, so both blocks build
+    # RANDOM weights (never rebuilds): the dense block matches directly, and the MoE block runs at the first
+    # FULL-indexer layer (6; GLM-5.2 layers 3-5 reuse a prior layer's indexer top-k, which an isolated block
+    # cannot supply) where the non-degenerate random gate agrees with the reference. -k glm52 runs both the
+    # dense and MoE parametrizations.
     mpirun --bind-to none --pernode --tag-output bash -lc '
       export OMP_NUM_THREADS=$(nproc)
-      python3 -m pytest models/demos/deepseek_v3_d_p/tests/test_prefill_block.py::test_glm_prefill_block -k "seq5120 and fabric2d-mesh-8x4 and glm51" -vvv --tb=short --timeout=300
+      python3 -m pytest models/demos/deepseek_v3_d_p/tests/test_prefill_block.py::test_glm_prefill_block -k "seq5120 and fabric2d-mesh-8x4 and glm52" -vvv --tb=short --timeout=300
     '
   test_type: glm_prefill_block
   test_group: module

--- a/tests/pipeline_reorg/demo_sp_release_tests.yaml
+++ b/tests/pipeline_reorg/demo_sp_release_tests.yaml
@@ -75,12 +75,12 @@
   owner_id: U0ACLAM77PS # Kosta Grujcic
   team: models
 
-- name: "(bh loudbox) GLM-5.1 Prefill modules"
+- name: "(bh loudbox) GLM-5.2 Prefill modules"
   cmd: |
-    # GLM-5.1 counterparts to the Kimi lines above. GLM's MLA is DSA/sparse (no absorbed-MLA analog), so
+    # GLM-5.2 counterparts to the Kimi lines above. GLM's MLA is DSA/sparse (no absorbed-MLA analog), so
     # it's its own stage with its own MLA ref cache; no EXPECT_NUM_TESTS since _sparse_cases emits a
     # box-dependent seq count.
-    DS_SPARSE_FABRIC=fabric2d GLM51_MLA_REF_CACHE=/tmp/glm_5_1_mla_ref_cache pytest models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla.py -k "glm_5_1 and 2x4 and fabric2d" -vvv --tb=short
+    DS_SPARSE_FABRIC=fabric2d GLM52_MLA_REF_CACHE=/tmp/glm_5_2_mla_ref_cache pytest models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla.py -k "glm_5_2 and 2x4 and fabric2d" -vvv --tb=short
     EXPECT_NUM_TESTS=1 pytest models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py::test_ds_moe -k "linear-8 and pcc-device-glm-256 and not pad50" -vvv --tb=short --timeout=1800
   model: deepseek_prefill
   skus:


### PR DESCRIPTION
## What

Swap every GLM prefill CI job from **GLM-5.1** to **GLM-5.2**, across all three
workflows that ran GLM-5.1. Same tests, same transports — just the 5.2 variant,
envs, and reference caches.

### Jobs moved (5 jobs, 3 workflows)

**`blaze_models_prefill_tests.yaml`** — the GLM-prefill-on-Galaxy (8x4) workflow:
| Job | Test | Change |
|---|---|---|
| DSA MLA | `test_sparse_mla.py` | `-k glm_5_1…` → `-k "glm_5_2 and 8x4 and fabric2d"`; renamed "(GLM-5.2)"; `GLM52_MLA_REF_CACHE`. Now covers the 5.2-only indexer-reuse case; the 5.1-only `kv_only` case is retired. |
| GLM MoE | `test_ttnn_moe.py::test_ds_moe` | reference dims sourced from `GLM52Config` (identical dims → source-of-truth only; `-k` ids unchanged). |
| Prefill Block | `test_prefill_block.py` | `-k …glm51` → `-k …glm52`; renamed "GLM-5.2". Runs dense@L0 + MoE, both random-weight. |

**`blackhole_e2e_tests.yaml`** (loudbox 2x4): `test_sparse_mla.py`, `-k "glm_5_1 and 2x4 and fabric2d"` → `-k "glm_5_2 …"`; `GLM51_MLA_REF_CACHE` → `GLM52_MLA_REF_CACHE`.

**`demo_sp_release_tests.yaml`** (loudbox 2x4): "(bh loudbox) GLM-5.1 Prefill modules" → "GLM-5.2"; `test_sparse_mla.py` `-k` → `glm_5_2`; 5.2 ref-cache env.

### Test-source changes (to make the above run as 5.2)

- **`test_ttnn_moe.py`**: import + config source `GLM51Config` → `GLM52Config`. GLM-5.1/5.2 MoE dims are identical, so this is pure source-of-truth accuracy — zero runtime effect.
- **`test_prefill_block.py`**: the MoE block now runs at the **first full-indexer layer** (glm51 → 3, glm52 → 6) via a new `_first_full_moe_layer(config)` helper, instead of hardcoded layer 3. GLM-5.2 layers 3–5 are "shared" indexer layers that reuse a prior full layer's top-k — an isolated single block can't supply those indices (`ReuseIndexer.forward` raises), so the MoE case must target a full-indexer layer. The real-weight skip is now gated on `use_pretrained` (a random block input drives GLM's trained near-degenerate top-8 gate to diverge from the CPU reference; random weights are non-degenerate and match), keeping the same random-weight behaviour GLM-5.1 had in CI.

## Why

Retire GLM-5.1 from CI in favour of GLM-5.2 — accurate coverage of the shipping model.

## Retired / intentionally not moved

- The GLM-5.1-only `kv_only` sparse-MLA case (its 5.2 counterpart is the indexer-reuse case, which **is** run).
- Two dead envs (`PREFILL_TRACE_DIR`, `GLM51_MLA_REF_CACHE`) removed from the prefill-block job — `test_prefill_block` reads neither (only `test_prefill_transformer_chunked` / `test_mla` do).
- `deepseek_v32` and Kimi jobs unchanged (not GLM-5.1).
- The two test *sources* still support `glm_5_1` as a selectable variant — this PR changes what CI **runs**, not local dev support.

## Reference cache staged

Generated `glm_5_2_mla_ref_cache` → `/mnt/models/deepseek-prefill-cache/glm_5_2_mla_ref_cache` (3 CPU-truth files: `random_seed42_funcidx_seq5120`, `chunked_…_c1024`, `random_seed42_rot10272_funcidx_seq10272`) — the complete 5.2 set for the DSA-MLA job.

## Validation locally - Galaxy (8x4)

All three glx jobs run and pass locally on a TG Blackhole Galaxy (13 selected cases total):

| Job | Result |
|---|---|
| DSA MLA | **7/7 PASS** (incl. 5.2-only `indexer_reuse`) |
| Prefill Block | **2/2 PASS** — dense 0.9997, MoE 0.9946 (random weights, empty CI cache) |
| GLM MoE | **4/4 PASS** (pcc + perf × pad0/pad50; final PCC ~0.988) |


### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nmilicevic/ci-glm51-to-glm52)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nmilicevic/ci-glm51-to-glm52)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nmilicevic/ci-glm51-to-glm52)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nmilicevic/ci-glm51-to-glm52)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=nmilicevic/ci-glm51-to-glm52)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:nmilicevic/ci-glm51-to-glm52)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nmilicevic/ci-glm51-to-glm52)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nmilicevic/ci-glm51-to-glm52)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nmilicevic/ci-glm51-to-glm52)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nmilicevic/ci-glm51-to-glm52)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nmilicevic/ci-glm51-to-glm52)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nmilicevic/ci-glm51-to-glm52)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nmilicevic/ci-glm51-to-glm52)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nmilicevic/ci-glm51-to-glm52)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nmilicevic/ci-glm51-to-glm52)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nmilicevic/ci-glm51-to-glm52)
