### PR TITLE
Blaze prefill (route perf jobs to high-power galaxy pool)

### DIFF
--- a/.github/scripts/utils/extract_allocation_from_sku.py
+++ b/.github/scripts/utils/extract_allocation_from_sku.py
@@ -97,11 +97,13 @@ def main():
     if "match_labels" in allocation:
         lines.append("matchLabels:")
         for key, value in allocation["match_labels"].items():
-            # Quote keys that contain special characters like dots
+            # Quote keys that contain special characters like dots, and always
+            # quote the value: matchLabels values must stay strings, so bare
+            # tokens like true/1 must not be coerced to a YAML bool/int downstream.
             if "." in key or "/" in key:
-                lines.append(f'  "{key}": {value}')
+                lines.append(f'  "{key}": "{value}"')
             else:
-                lines.append(f"  {key}: {value}")
+                lines.append(f'  {key}: "{value}"')
 
     if "topologyKeys" in allocation:
         lines.append("topologyKeys:")

--- a/.github/sku_config.yaml
+++ b/.github/sku_config.yaml
@@ -188,6 +188,17 @@ skus:
       type: Count
       count: 1
 
+  # Like bh_sc1, but restricts the single-galaxy allocation to nodes labelled
+  # exabox.tenstorrent.com/power=14kw.
+  bh_sc1_high_power:
+    runs_on:
+      - exabox-multihost-with-nfs
+    allocation:
+      type: Count
+      count: 1
+      match_labels:
+        exabox.tenstorrent.com/power: "14kw"
+
   bh_sc4:
     runs_on:
       - exabox-multihost-with-nfs

--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -368,11 +368,8 @@ models:
     wh_galaxy: 345
     wh_galaxy_perf: 150
     bh_galaxy: 470
-    # blaze_models_prefill_tests.yaml sum of bh_sc1 job timeouts (was 485 before the
-    # kimi_chunked/glm_chunked/ring_joint_sdpa_perf jobs moved to the bh_sc1_high_power pool)
+    # blaze_models_prefill_tests.yaml sum of bh_sc1 job timeouts (tightened from 840)
     bh_sc1: 377
-    # Sum of the bh_sc1_high_power job timeouts: kimi_chunked (40) + glm_chunked (45)
-    # + ring_joint_sdpa_perf (23). Same single-galaxy hardware, high_power-labelled pool.
     bh_sc1_high_power: 108
     wh_n150: 500
     wh_n150_civ2: 300

--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -368,8 +368,12 @@ models:
     wh_galaxy: 345
     wh_galaxy_perf: 150
     bh_galaxy: 470
-    # blaze_models_prefill_tests.yaml sum of bh_sc1 job timeouts (tightened from 840)
-    bh_sc1: 485
+    # blaze_models_prefill_tests.yaml sum of bh_sc1 job timeouts (was 485 before the
+    # kimi_chunked/glm_chunked/ring_joint_sdpa_perf jobs moved to the bh_sc1_high_power pool)
+    bh_sc1: 377
+    # Sum of the bh_sc1_high_power job timeouts: kimi_chunked (40) + glm_chunked (45)
+    # + ring_joint_sdpa_perf (23). Same single-galaxy hardware, high_power-labelled pool.
+    bh_sc1_high_power: 108
     wh_n150: 500
     wh_n150_civ2: 300
     wh_n300: 600

--- a/.github/workflows/blaze-models-prefill-tests-impl.yaml
+++ b/.github/workflows/blaze-models-prefill-tests-impl.yaml
@@ -171,7 +171,10 @@ jobs:
           pip3 install PyYAML
           {
             echo "allocation_spec<<EOF"
-            python3 .github/scripts/utils/extract_allocation_from_sku.py "bh_${{ inputs.sp-config }}"
+            # Derive the allocation from this leg's own SKU (matrix.test-group.sku) rather than
+            # the pipeline-wide sp-config, so individual tests can opt into a different allocation
+            # pool (e.g. bh_sc1_high_power) without changing the pool for the rest of the run.
+            python3 .github/scripts/utils/extract_allocation_from_sku.py "${{ matrix.test-group.sku }}"
             echo "EOF"
           } >> $GITHUB_OUTPUT
 

--- a/.github/workflows/blaze-models-prefill-tests.yaml
+++ b/.github/workflows/blaze-models-prefill-tests.yaml
@@ -102,7 +102,7 @@ jobs:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-      enabled-skus: bh_sc1
+      enabled-skus: bh_sc1,bh_sc1_high_power
       sp-config: sc1
       test-type: ${{ needs.validate-test-type.outputs.test-type }}
       # Keep the perf checks in a focused job so the long functional run remains unchanged.
@@ -122,7 +122,7 @@ jobs:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-      enabled-skus: bh_sc1
+      enabled-skus: bh_sc1,bh_sc1_high_power
       sp-config: sc1
       # Select the perf entry by its test_group so adding more perf checks needs no workflow edit.
       test-type: sdpa_perf

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py
@@ -52,6 +52,7 @@ from models.demos.deepseek_v3_d_p.tt.tt_prefill_block import get_block_timings, 
 from models.demos.deepseek_v3_d_p.tt.tt_prefill_transformer import TtPrefillTransformer
 from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import MlaKvCacheFormat, init_kvpe_cache, init_mla_kv_cache
 from models.demos.deepseek_v3_d_p.utils.prefill_summary_utils import emit_summary, render_table
+from models.demos.deepseek_v3_d_p.utils.smbus_telemetry import is_high_power
 from models.demos.deepseek_v3_d_p.utils.test_utils import (
     cache_half_pccs,
     gather_cache_tp0,
@@ -1530,6 +1531,10 @@ def run_chunked_transformer_no_pcc(
 )
 @pytest.mark.parametrize("variant", ["kimi_k2_6"], indirect=True, ids=["kimi"])
 @pytest.mark.skipif(not is_blackhole(), reason="Kimi requires Blackhole")
+@pytest.mark.skipif(
+    not is_high_power(),
+    reason="perf job requires a high-power (>=130W TDP) galaxy; guards the exabox.tenstorrent.com/power=14kw label",
+)
 @pytest.mark.timeout(0)
 def test_kimi_prefill_transformer_chunked_no_pcc(
     variant,
@@ -1683,6 +1688,10 @@ def test_ds_prefill_transformer_chunked_no_pcc(
 )
 @pytest.mark.parametrize("variant", ["glm_5_1", "glm_5_2"], indirect=True, ids=["glm51", "glm52"])
 @pytest.mark.skipif(not is_blackhole(), reason="GLM DSA ops (indexer / sparse SDPA) are Blackhole-only")
+@pytest.mark.skipif(
+    not is_high_power(),
+    reason="perf job requires a high-power (>=130W TDP) galaxy; guards the exabox.tenstorrent.com/power=14kw label",
+)
 @pytest.mark.timeout(0)
 def test_glm_prefill_transformer_chunked_no_pcc(
     variant,

--- a/models/demos/deepseek_v3_d_p/utils/smbus_telemetry.py
+++ b/models/demos/deepseek_v3_d_p/utils/smbus_telemetry.py
@@ -35,6 +35,36 @@ def get_board_type():
     return None
 
 
+def get_tdp_limit_max():
+    """Max TDP limit (watts) from smbus_telem, or None.
+
+    Read like get_ddr_speed: smbus_telem values are hex strings, with a
+    SMBUS_TX_-prefixed fallback key. Returns the decoded integer watts.
+    """
+    data = get_smbus_telemetry()
+    if data and data.get("device_info"):
+        smbus_telem = data["device_info"][0].get("smbus_telem", {})
+        tdp = smbus_telem.get("TDP_LIMIT_MAX") or smbus_telem.get("SMBUS_TX_TDP_LIMIT_MAX")
+        if tdp is not None:
+            return tdp if isinstance(tdp, int) else int(str(tdp), 16)
+    return None
+
+
+def is_high_power(min_tdp_watts=130):
+    """True iff the host's max TDP limit (smbus_telem TDP_LIMIT_MAX) is >= min_tdp_watts.
+
+    Guards perf-sensitive CI jobs that must run on high-power galaxy hosts. Like is_p150(),
+    it reads tt-smi only (no compute-device open / CHIP_IN_USE lock), so it is safe to call
+    from a pytest ``skipif`` at collection time. Returns False on any error (tt-smi
+    missing/failed/timeout, or field absent) so callers skip rather than error.
+    """
+    try:
+        tdp = get_tdp_limit_max()
+    except Exception:
+        return False
+    return tdp is not None and tdp >= min_tdp_watts
+
+
 def is_p150():
     """True iff the host's board is a P150 (any revision, e.g. ``p150``/``p150b``).
 

--- a/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
+++ b/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
@@ -34,6 +34,7 @@ from ttnn.operations.ccl import Topology
 
 import ttnn
 from models.common.utility_functions import skip_with_llk_assert, skip_with_watcher
+from models.demos.deepseek_v3_d_p.utils.smbus_telemetry import is_high_power
 
 # ============================================================================
 # CONFIGURATION CONSTANTS
@@ -3541,6 +3542,10 @@ else:
 )
 @skip_with_llk_assert("No need to verify LLK asserts for performance tests.")
 @skip_with_watcher("Watcher perturbs kernel timing; perf checks are not meaningful with it enabled.")
+@pytest.mark.skipif(
+    not is_high_power(),
+    reason="perf job requires a high-power (>=130W TDP) galaxy; guards the exabox.tenstorrent.com/power=14kw label",
+)
 def test_ring_joint_attention_perf_check(
     model_name, q_chunk_size, k_chunk_size, ring_size_expected, expected_util, margin
 ):
@@ -4406,6 +4411,10 @@ else:
 )
 @skip_with_llk_assert("No need to verify LLK asserts for performance tests.")
 @skip_with_watcher("Watcher perturbs kernel timing; perf checks are not meaningful with it enabled.")
+@pytest.mark.skipif(
+    not is_high_power(),
+    reason="perf job requires a high-power (>=130W TDP) galaxy; guards the exabox.tenstorrent.com/power=14kw label",
+)
 def test_ring_mla_chunked_perf_check(model_name, q_chunk_size, k_chunk_size, ring_size_expected, expected_util):
     """Measure ring_mla chunked-prefill math utilization for the kimi 50k+5k galaxy chunk (a 5k Q
     chunk against a 50k K/V prefix), simulated on the 4-device QuietBox, via realtime profiler and assert

--- a/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
+++ b/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
@@ -344,7 +344,7 @@
   test_type: ring_joint_sdpa_perf
   test_group: sdpa_perf
   skus:
-    bh_sc1:
+    bh_sc1_high_power:
       # Both perf checks run in ~5.6 min; 23 leaves headroom for Galaxy variance.
       timeout: 23
   owner_id: U08RL15T4N8
@@ -374,7 +374,7 @@
   test_type: kimi_chunked
   test_group: module
   skus:
-    bh_sc1:
+    bh_sc1_high_power:
       # Job takes under 20 minutes; 40 minute timeout provides buffer for variance and machines with less power.
       timeout: 40
   owner_id: U08RL15T4N8
@@ -395,7 +395,7 @@
   test_type: glm_chunked
   test_group: module
   skus:
-    bh_sc1:
+    bh_sc1_high_power:
       timeout: 45
   owner_id: U07N3CUUN05  # Iva Potkonjak
   team: models


### PR DESCRIPTION
Routes three Blaze prefill perf jobs (Chunked Kimi, Chunked GLM, Ring Joint
SDPA) onto a dedicated high-power galaxy pool, selected by node label, and
guards them with a TDP telemetry check.

## Changes
- New SKU `bh_sc1_high_power`: single galaxy (`Count:1`) restricted to nodes
  labelled `exabox.tenstorrent.com/power=14kw` via `match_labels`.
- Blaze impl derives the allocation from each leg's own SKU
  (`matrix.test-group.sku`) instead of the pipeline-wide `sp-config`, so only
  these jobs use the restricted pool.
- `is_high_power()` in `smbus_telemetry.py` (reads `TDP_LIMIT_MAX`); the three
  tests `skipif(not is_high_power())` so a mislabelled node skips rather than
  running the perf check on wrong hardware.
- `extract_allocation_from_sku.py` quotes `match_labels` values (keep them
  strings); time budget split (`bh_sc1` 377 / `bh_sc1_high_power` 108).

## Prereq
Nodes must carry `exabox.tenstorrent.com/power=14kw`.

## Test
`kimi_chunked` on this branch passed on a 14kw node (run 30280369397).

### Blaze Models Prefill CI
[![Blaze Models Prefill tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blaze-models-prefill-tests.yaml/badge.svg?branch=mbezulj/2607-blaze-prefill-perf-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/blaze-models-prefill-tests.yaml?query=branch:mbezulj/2607-blaze-prefill-perf-ci)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mbezulj/2607-blaze-prefill-perf-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mbezulj/2607-blaze-prefill-perf-ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mbezulj/2607-blaze-prefill-perf-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mbezulj/2607-blaze-prefill-perf-ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mbezulj/2607-blaze-prefill-perf-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mbezulj/2607-blaze-prefill-perf-ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mbezulj/2607-blaze-prefill-perf-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mbezulj/2607-blaze-prefill-perf-ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mbezulj/2607-blaze-prefill-perf-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mbezulj/2607-blaze-prefill-perf-ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mbezulj/2607-blaze-prefill-perf-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mbezulj/2607-blaze-prefill-perf-ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mbezulj/2607-blaze-prefill-perf-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mbezulj/2607-blaze-prefill-perf-ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mbezulj/2607-blaze-prefill-perf-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mbezulj/2607-blaze-prefill-perf-ci)