### PR TITLE
#51133: Preserve per-core allocation when tilize/untilize rebuild the output MemoryConfig

### DIFF
--- a/tests/tt_metal/tt_metal/api/tensor/test_tensor_sharding.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_tensor_sharding.cpp
@@ -272,3 +272,70 @@ TEST_F(MemoryConfigEqualityTest, NotEqualOperator_NdShardSpec) {
     EXPECT_TRUE(a != b);
     EXPECT_FALSE(a != a);
 }
+
+// with_shard_spec exists so that ops overriding a caller's shard geometry cannot silently
+// discard the rest of the caller's config. Constructing a fresh MemoryConfig from a handful
+// of fields is what dropped the experimental per-core allocation bit in
+// https://github.com/tenstorrent/tt-metal/issues/51133.
+TEST_F(MemoryConfigEqualityTest, OverridesLayoutAndShardSpec) {
+    MemoryConfig config(TensorMemoryLayout::HEIGHT_SHARDED, BufferType::L1, shard_spec_a_);
+
+    MemoryConfig resharded = config.with_shard_spec(TensorMemoryLayout::WIDTH_SHARDED, shard_spec_b_);
+
+    EXPECT_EQ(resharded.memory_layout(), TensorMemoryLayout::WIDTH_SHARDED);
+    EXPECT_EQ(resharded.shard_spec(), shard_spec_b_);
+}
+
+TEST_F(MemoryConfigEqualityTest, PreservesBufferType) {
+    MemoryConfig config(TensorMemoryLayout::HEIGHT_SHARDED, BufferType::L1, shard_spec_a_);
+
+    MemoryConfig resharded = config.with_shard_spec(TensorMemoryLayout::WIDTH_SHARDED, shard_spec_b_);
+
+    EXPECT_EQ(resharded.buffer_type(), BufferType::L1);
+}
+
+TEST_F(MemoryConfigEqualityTest, PreservesPerCoreAllocation) {
+    MemoryConfig config(TensorMemoryLayout::HEIGHT_SHARDED, BufferType::L1, shard_spec_a_);
+    experimental::per_core_allocation::set_per_core_allocation(config, true);
+
+    MemoryConfig resharded = config.with_shard_spec(TensorMemoryLayout::WIDTH_SHARDED, shard_spec_b_);
+
+    EXPECT_TRUE(experimental::per_core_allocation::is_per_core_allocation(resharded));
+}
+
+TEST_F(MemoryConfigEqualityTest, LeavesPerCoreAllocationUnsetWhenSourceLacksIt) {
+    MemoryConfig config(TensorMemoryLayout::HEIGHT_SHARDED, BufferType::L1, shard_spec_a_);
+
+    MemoryConfig resharded = config.with_shard_spec(TensorMemoryLayout::WIDTH_SHARDED, shard_spec_b_);
+
+    EXPECT_FALSE(experimental::per_core_allocation::is_per_core_allocation(resharded));
+}
+
+TEST_F(MemoryConfigEqualityTest, ClearsStaleNdShardSpecProvenance) {
+    // The nd spec describes the shard being replaced, so it must not survive.
+    // TensorSpec repopulates it from the new legacy spec where an equivalent exists.
+    MemoryConfig config = MemoryConfig::create_with_prepopulated_shard_specs(
+        TensorMemoryLayout::HEIGHT_SHARDED,
+        BufferType::L1,
+        shard_spec_a_,
+        nd_shard_spec_a_,
+        /*created_with_nd_shard_spec=*/true);
+
+    MemoryConfig resharded = config.with_shard_spec(TensorMemoryLayout::WIDTH_SHARDED, shard_spec_b_);
+
+    EXPECT_FALSE(resharded.nd_shard_spec().has_value());
+    EXPECT_FALSE(resharded.created_with_nd_shard_spec());
+}
+
+TEST_F(MemoryConfigEqualityTest, RejectsReshardingPerCoreConfigToInterleaved) {
+    // Surfacing the impossible request beats silently downgrading to a lockstep allocation.
+    MemoryConfig config(TensorMemoryLayout::HEIGHT_SHARDED, BufferType::L1, shard_spec_a_);
+    experimental::per_core_allocation::set_per_core_allocation(config, true);
+
+    EXPECT_THAT(
+        std::function<void()>([&config]() {
+            [[maybe_unused]] auto resharded = config.with_shard_spec(TensorMemoryLayout::INTERLEAVED, std::nullopt);
+        }),
+        ThrowsMessage<std::runtime_error>(
+            ::testing::HasSubstr("cannot re-shard a per_core_allocation config into memory layout")));
+}

--- a/tests/ttnn/unit_tests/per_core_allocation/test_per_core_allocation_layout_ops.py
+++ b/tests/ttnn/unit_tests/per_core_allocation/test_per_core_allocation_layout_ops.py
@@ -1,0 +1,294 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Layout-changing ops must preserve experimental per-core L1 allocation.
+
+tilize / tilize_with_val_padding / untilize_with_unpadding rebuild the output
+MemoryConfig when their optimized sharded program factory is selected, substituting the
+shard geometry inherited from the input. That rebuild must carry over the rest of the
+caller's requested config -- in particular the per-core allocation bit, which was
+otherwise silently downgraded to a lockstep allocation.
+
+See https://github.com/tenstorrent/tt-metal/issues/51133.
+
+The `device` fixture comes from this directory's conftest.py, which sets
+TT_METAL_ALLOCATOR_MODE_HYBRID=1 before opening the device. The allocator mode is
+latched process-globally on first use, so this suite has to run in its own pytest
+process -- which is how CI invokes it.
+"""
+
+import pytest
+import torch
+
+import ttnn
+
+
+def _per_core_mem_config(memory_layout, core_range_set, shard_shape):
+    """L1 sharded MemoryConfig with the experimental per-core allocation bit set."""
+    mem_config = ttnn.MemoryConfig(
+        memory_layout,
+        ttnn.BufferType.L1,
+        ttnn.ShardSpec(core_range_set, list(shard_shape), ttnn.ShardOrientation.ROW_MAJOR),
+    )
+    mem_config.experimental_set_per_core_allocation(True)
+    return mem_config
+
+
+def _core_range_set(start, end):
+    return ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(*start), ttnn.CoreCoord(*end))])
+
+
+def _cores_in(core_range_set):
+    cores = []
+    for core_range in core_range_set.ranges():
+        for y in range(core_range.start.y, core_range.end.y + 1):
+            for x in range(core_range.start.x, core_range.end.x + 1):
+                cores.append(ttnn.CoreCoord(x, y))
+    return cores
+
+
+def _assert_uniform_addresses(tensor, core_range_set, label):
+    """Assert a multi-core per-core tensor has the same L1 address on every core.
+
+    Buffer::address() does not properly handle per-core allocated tensors: it returns the
+    first core's address, and the host write, the host read and CB aliasing all use that
+    one value for every core. So a multi-core per-core buffer is only handled correctly
+    when its addresses happen to agree, which is why callers assert it too (see
+    models/demos/deepseek_v3_b1/weights/overlap/packing.py). Checking it here means
+    preserving the per-core bit cannot silently produce a mis-addressed tensor.
+    """
+    cores = _cores_in(core_range_set)
+    addrs = [tensor.experimental_per_core_buffer_address(c) for c in cores]
+    assert len(set(addrs)) == 1, f"{label}: expected uniform per-core addresses, got " + ", ".join(
+        f"({c.x},{c.y})={a:#x}" for c, a in zip(cores, addrs)
+    )
+
+
+def _row_major_per_core_input(device, torch_tensor, memory_layout, core_range_set, shard_shape):
+    """Build a ROW_MAJOR, per-core allocated L1 input tensor on device.
+
+    A sharded memory config always takes the host-construction path in
+    create_tt_tensor_from_host_data, so the per-core bit survives to the device here.
+    """
+    mem_config = _per_core_mem_config(memory_layout, core_range_set, shard_shape)
+    tensor = ttnn.from_torch(
+        torch_tensor,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=device,
+        memory_config=mem_config,
+    )
+    assert tensor.is_per_core_allocated(), "precondition failed: ROW_MAJOR input is not per-core allocated"
+    _assert_uniform_addresses(tensor, core_range_set, "row-major input")
+    return tensor, mem_config
+
+
+@pytest.mark.parametrize(
+    "memory_layout, grid_start, grid_end, tensor_shape, shard_shape",
+    [
+        # WIDTH_SHARDED over 8 cores in a row -- the shape class reported in #51133
+        # (gate_mm: a full-height, one-tile-wide shard).
+        (ttnn.TensorMemoryLayout.WIDTH_SHARDED, (0, 0), (7, 0), (512, 256), (512, 32)),
+        (ttnn.TensorMemoryLayout.HEIGHT_SHARDED, (0, 0), (7, 0), (512, 256), (64, 256)),
+        (ttnn.TensorMemoryLayout.BLOCK_SHARDED, (0, 0), (1, 1), (256, 256), (128, 128)),
+    ],
+    ids=["width_sharded", "height_sharded", "block_sharded"],
+)
+def test_tilize_preserves_per_core_allocation(device, memory_layout, grid_start, grid_end, tensor_shape, shard_shape):
+    """tilize must not downgrade a per-core output request to a lockstep allocation.
+
+    All three parametrizations are eligible for the optimized sharded program factory,
+    which is the path that rebuilds the output MemoryConfig from the input's shard spec.
+    """
+    core_range_set = _core_range_set(grid_start, grid_end)
+    torch_input = torch.randn(*tensor_shape, dtype=torch.bfloat16)
+
+    row_major, mem_config = _row_major_per_core_input(device, torch_input, memory_layout, core_range_set, shard_shape)
+
+    tiled = ttnn.tilize(row_major, memory_config=mem_config, dtype=ttnn.bfloat16)
+
+    assert tiled.is_per_core_allocated(), (
+        "tilize dropped the experimental per-core allocation bit: the output buffer is "
+        "lockstep-allocated even though the requested output memory_config asked for per-core"
+    )
+    _assert_uniform_addresses(tiled, core_range_set, "tilized output")
+    assert torch.equal(ttnn.to_torch(tiled), torch_input), "tilize corrupted the data"
+
+
+def test_to_layout_preserves_per_core_allocation(device):
+    """The same drop site reached through the public ttnn.to_layout entry point."""
+    core_range_set = _core_range_set((0, 0), (7, 0))
+    torch_input = torch.randn(512, 256, dtype=torch.bfloat16)
+
+    row_major, mem_config = _row_major_per_core_input(
+        device, torch_input, ttnn.TensorMemoryLayout.WIDTH_SHARDED, core_range_set, (512, 32)
+    )
+
+    tiled = ttnn.to_layout(row_major, ttnn.TILE_LAYOUT, memory_config=mem_config)
+
+    assert tiled.is_per_core_allocated(), "ttnn.to_layout dropped the per-core allocation bit"
+    _assert_uniform_addresses(tiled, core_range_set, "tilized output")
+    assert torch.equal(ttnn.to_torch(tiled), torch_input)
+
+
+def test_tilize_with_val_padding_preserves_per_core_allocation(device):
+    """tilize_with_val_padding rebuilds the output MemoryConfig the same way tilize does.
+
+    A WIDTH_SHARDED input whose logical height is not tile-aligned (500 -> 512) routes
+    through the optimized sharded factory, which substitutes a reshaped input shard spec.
+    """
+    core_range_set = _core_range_set((0, 0), (7, 0))
+    torch_input = torch.randn(500, 256, dtype=torch.bfloat16)
+
+    row_major, _ = _row_major_per_core_input(
+        device, torch_input, ttnn.TensorMemoryLayout.WIDTH_SHARDED, core_range_set, (500, 32)
+    )
+    output_mem_config = _per_core_mem_config(ttnn.TensorMemoryLayout.WIDTH_SHARDED, core_range_set, (512, 32))
+
+    padded = ttnn.tilize_with_val_padding(row_major, ttnn.Shape([512, 256]), 0.0, memory_config=output_mem_config)
+
+    assert padded.is_per_core_allocated(), "tilize_with_val_padding dropped the per-core allocation bit"
+    _assert_uniform_addresses(padded, core_range_set, "padded output")
+    assert torch.equal(ttnn.to_torch(padded), torch_input)
+
+
+def test_untilize_with_unpadding_preserves_per_core_allocation(device):
+    """untilize_with_unpadding rebuilds the output MemoryConfig for sharded in/out.
+
+    A padded TILE tensor is unpadded back to a shorter logical height, which reshapes
+    the shard spec inherited from the input.
+    """
+    core_range_set = _core_range_set((0, 0), (7, 0))
+    torch_input = torch.randn(512, 256, dtype=torch.bfloat16)
+
+    row_major, mem_config = _row_major_per_core_input(
+        device, torch_input, ttnn.TensorMemoryLayout.WIDTH_SHARDED, core_range_set, (512, 32)
+    )
+    tiled = ttnn.tilize(row_major, memory_config=mem_config, dtype=ttnn.bfloat16)
+
+    unpadded = ttnn.untilize_with_unpadding(tiled, ttnn.Shape([479, 255]), memory_config=mem_config)
+
+    assert unpadded.is_per_core_allocated(), "untilize_with_unpadding dropped the per-core allocation bit"
+    _assert_uniform_addresses(unpadded, core_range_set, "unpadded output")
+    assert torch.equal(ttnn.to_torch(unpadded), torch_input[:480, :256])
+
+
+def test_from_torch_on_device_construction_preserves_per_core_allocation(device):
+    """The reported symptom: from_torch(device=..., memory_config=<per-core L1>).
+
+    With a mesh_mapper and a device-constructible dtype, from_torch builds the tensor
+    on device in ROW_MAJOR and tilizes it there. The per-core bit rides on the caller's
+    memory_config through that whole chain and must survive the on-device tilize.
+
+    ttnn.CreateDevice returns a unit MeshDevice, so the mesh_mapper branch of
+    create_tt_tensor_from_host_data -- the only one that constructs a sharded tensor
+    on device -- is reachable with a single device.
+    """
+    core_range_set = _core_range_set((0, 0), (7, 0))
+    shard_shape = (512, 32)
+    torch_input = torch.randn(shard_shape[0], shard_shape[1] * 8, dtype=torch.bfloat16)
+    mem_config = _per_core_mem_config(ttnn.TensorMemoryLayout.WIDTH_SHARDED, core_range_set, shard_shape)
+
+    on_device = ttnn.from_torch(
+        torch_input,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=mem_config,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(device),
+    )
+
+    assert on_device.is_per_core_allocated(), (
+        "from_torch(device=..., memory_config=<per-core L1>) returned a lockstep-allocated "
+        "tensor; the on-device construction path dropped the per-core request"
+    )
+    _assert_uniform_addresses(on_device, core_range_set, "from_torch output")
+    # Unit mesh + ReplicateTensorToMesh: to_torch returns the single replica.
+    assert torch.equal(ttnn.to_torch(on_device), torch_input)
+
+    # The same request via allocate_tensor_on_device is the route that already worked --
+    # both must agree.
+    host = ttnn.from_torch(
+        torch_input,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=None,
+        memory_config=mem_config,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(device),
+    )
+    allocated = ttnn.allocate_tensor_on_device(host.spec, device)
+    assert allocated.is_per_core_allocated(), "precondition failed: allocate_tensor_on_device is not per-core"
+
+
+_PAD_BYTES = 8192
+
+
+def _pad_core(device, core):
+    """One per-core buffer on a single core, used to skew that core's free list."""
+    c = ttnn.CoreCoord(*core)
+    mem_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        ttnn.BufferType.L1,
+        ttnn.ShardSpec(ttnn.CoreRangeSet([ttnn.CoreRange(c, c)]), [1, _PAD_BYTES], ttnn.ShardOrientation.ROW_MAJOR),
+    )
+    mem_config.experimental_set_per_core_allocation(True)
+    return ttnn.from_torch(
+        torch.zeros(1, _PAD_BYTES, dtype=torch.uint8),
+        dtype=ttnn.uint8,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=device,
+        memory_config=mem_config,
+    )
+
+
+def _skew_free_lists(device, cores):
+    """Core i gets i padding buffers, so every core's free list ends up somewhere different."""
+    return [_pad_core(device, core) for i, core in enumerate(cores) for _ in range(i)]
+
+
+def test_per_core_addresses_diverge_where_lockstep_shares_one(device):
+    """The defining difference between the two allocators.
+
+    Given cores whose free lists sit at different heights, the per-core allocator hands
+    each core its own address, while the lockstep allocator hands out a single address
+    shared by every core.
+
+    Note this documents the *allocator*, not a supported tensor configuration: generic
+    ops cannot handle a multi-core per-core buffer whose addresses diverge. Callers
+    wanting genuinely independent addresses allocate one single-core buffer per core.
+    """
+    cores = [(0, 0), (1, 0), (2, 0), (3, 0)]
+    core_range_set = _core_range_set((0, 0), (3, 0))
+    shard_shape = (512, 32)
+    torch_input = torch.randn(shard_shape[0], shard_shape[1] * len(cores), dtype=torch.bfloat16)
+
+    def build(per_core):
+        mem_config = ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+            ttnn.BufferType.L1,
+            ttnn.ShardSpec(core_range_set, list(shard_shape), ttnn.ShardOrientation.ROW_MAJOR),
+        )
+        if per_core:
+            mem_config.experimental_set_per_core_allocation(True)
+        return ttnn.from_torch(
+            torch_input, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, memory_config=mem_config
+        )
+
+    pads = _skew_free_lists(device, cores)  # noqa: F841 - held alive to keep the skew in place
+    per_core_tensor = build(per_core=True)
+    addrs = [per_core_tensor.experimental_per_core_buffer_address(ttnn.CoreCoord(*c)) for c in cores]
+    assert per_core_tensor.is_per_core_allocated()
+    assert len(set(addrs)) == len(
+        cores
+    ), "per-core allocator should give each core its own address once their free lists differ, got " + ", ".join(
+        f"({c[0]},{c[1]})={a:#x}" for c, a in zip(cores, addrs)
+    )
+    del per_core_tensor
+
+    lockstep_tensor = build(per_core=False)
+    assert not lockstep_tensor.is_per_core_allocated()
+    # buffer_address() only exists for lockstep tensors -- it is the single shared address,
+    # and it fatals for per-core ones precisely because those have no single address.
+    assert isinstance(lockstep_tensor.buffer_address(), int)

--- a/tt_metal/api/tt-metalium/experimental/tensor/spec/memory_config/memory_config.hpp
+++ b/tt_metal/api/tt-metalium/experimental/tensor/spec/memory_config/memory_config.hpp
@@ -59,6 +59,23 @@ public:
     bool is_l1() const;
     bool is_dram() const;
 
+    // Returns a copy of this config re-sharded with `memory_layout` and `shard_spec`.
+    //
+    // Use this instead of re-running a constructor when an op needs to override the shard
+    // geometry of a config it was handed. Constructing a fresh MemoryConfig from a few
+    // fields silently drops every field the caller did not name -- including experimental
+    // state such as per-core allocation, which is private and easy to forget. This copies
+    // *this first, so any field not overridden below (present or future) is carried over.
+    //
+    // The stale `nd_shard_spec_` is cleared: it describes the shard being replaced.
+    // TensorSpec repopulates it from the new legacy spec where an equivalent exists.
+    //
+    // A single-argument `with_shard_spec(shard_spec)` was removed in #45706 because it left
+    // `memory_layout_` describing the *old* sharding while the spec described the new one
+    // (see #42827). Taking both together is what stops them disagreeing.
+    [[nodiscard]] MemoryConfig with_shard_spec(
+        TensorMemoryLayout memory_layout, std::optional<ShardSpec> shard_spec) const;
+
     static constexpr auto attribute_names = std::forward_as_tuple(
         "memory_layout", "buffer_type", "shard_spec", "nd_shard_spec", "created_with_nd_shard_spec");
     auto attribute_values() const {

--- a/tt_metal/impl/tensor/spec/memory_config/memory_config.cpp
+++ b/tt_metal/impl/tensor/spec/memory_config/memory_config.cpp
@@ -3,6 +3,7 @@
 
 #include <cstdint>
 
+#include <tt_stl/assert.hpp>
 #include <tt_stl/reflection.hpp>
 
 #include <tt-metalium/experimental/tensor/tensor_types.hpp>
@@ -40,6 +41,25 @@ MemoryConfig MemoryConfig::create_with_prepopulated_shard_specs(
     bool created_with_nd_shard_spec) {
     return MemoryConfig(
         memory_layout, buffer_type, std::move(shard_spec), std::move(nd_shard_spec), created_with_nd_shard_spec);
+}
+
+MemoryConfig MemoryConfig::with_shard_spec(
+    TensorMemoryLayout memory_layout, std::optional<ShardSpec> shard_spec) const {
+    MemoryConfig result = *this;
+    result.memory_layout_ = memory_layout;
+    result.shard_spec_ = std::move(shard_spec);
+    result.nd_shard_spec_ = std::nullopt;
+    result.created_with_nd_shard_spec_ = false;
+    if (result.per_core_allocation_) {
+        // Re-check the per-core invariants against the new layout rather than silently
+        // dropping the bit -- a caller re-sharding a per-core config into something
+        // per-core cannot express has a bug we want to surface, not paper over.
+        TT_FATAL(
+            result.is_sharded() && result.shard_spec_.has_value(),
+            "with_shard_spec cannot re-shard a per_core_allocation config into memory layout {} without a shard spec",
+            memory_layout);
+    }
+    return result;
 }
 
 bool MemoryConfig::is_sharded() const {

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_device_operation.cpp
@@ -241,11 +241,9 @@ TilizeDeviceOperation::spec_return_value_t TilizeDeviceOperation::compute_output
             tt::LogOp,
             "ttnn::tilize: Using input shard spec for output tensor because the legacy sharded optimized program "
             "factory is being used");
-        auto mem_config = tt::tt_metal::MemoryConfig(
-            input_tensor.memory_config().memory_layout(),
-            operation_attributes.output_mem_config.buffer_type(),
-            input_tensor.memory_config().shard_spec());  // If the input is using the legacy sharded optimized program
-                                                         // factory, the output has the same shard spec as the input.
+        // Output inherits the input's shard spec; the rest of the caller's config is preserved.
+        auto mem_config = operation_attributes.output_mem_config.with_shard_spec(
+            input_tensor.memory_config().memory_layout(), input_tensor.memory_config().shard_spec());
         return {tt::tt_metal::TensorSpec(
             input_tensor.logical_shape(),
             TensorLayout::fromPaddedShape(

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_device_operation.cpp
@@ -179,11 +179,9 @@ tt::tt_metal::TensorSpec TilizeWithValPaddingDeviceOperation::compute_output_spe
         auto shard_spec = input_tensor.shard_spec().value();
         shard_spec.shape[0] =
             operation_attributes.output_padded_shape.volume() / operation_attributes.output_padded_shape[-1];
-        auto mem_config = tt::tt_metal::MemoryConfig(
-            input_tensor.memory_config().memory_layout(),
-            operation_attributes.output_mem_config.buffer_type(),
-            shard_spec);  // If the input is using the legacy sharded optimized program
-                          // factory, the output has the same shard spec as the input.
+        // Output inherits the input's shard spec; the rest of the caller's config is preserved.
+        auto mem_config = operation_attributes.output_mem_config.with_shard_spec(
+            input_tensor.memory_config().memory_layout(), shard_spec);
         return tt::tt_metal::TensorSpec(
             input_shape,
             TensorLayout::fromPaddedShape(

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_device_operation.cpp
@@ -450,10 +450,9 @@ tt::tt_metal::TensorSpec UntilizeWithUnpaddingDeviceOperation::compute_output_sp
             uint32_t num_cores = shard_spec.num_cores();
             shard_spec.shape = {tt::round_up(tt::div_up(fused_height, num_cores), tile_height), shard_spec.shape[1]};
         }
-        auto mem_config = tt::tt_metal::MemoryConfig(
-            operation_attributes.output_mem_config.memory_layout(),
-            operation_attributes.output_mem_config.buffer_type(),
-            shard_spec);
+        // Only the shard shape is derived; the rest of the caller's config is preserved.
+        auto mem_config = operation_attributes.output_mem_config.with_shard_spec(
+            operation_attributes.output_mem_config.memory_layout(), shard_spec);
         return TensorSpec(output_shape, TensorLayout(output_dtype, PageConfig(Layout::ROW_MAJOR), mem_config));
     }
     if (input_tensor_a.memory_config().is_sharded() && operation_attributes.output_mem_config.is_sharded() &&
@@ -517,10 +516,9 @@ tt::tt_metal::TensorSpec UntilizeWithUnpaddingDeviceOperation::compute_output_sp
             shard_shape = {fused_height, shard_spec.shape[1]};
         }
         shard_spec.shape = shard_shape;
-        auto mem_config = tt::tt_metal::MemoryConfig(
-            input_tensor_a.memory_config().memory_layout(),
-            operation_attributes.output_mem_config.buffer_type(),
-            shard_spec);
+        // Output inherits the input's shard spec; the rest of the caller's config is preserved.
+        auto mem_config = operation_attributes.output_mem_config.with_shard_spec(
+            input_tensor_a.memory_config().memory_layout(), shard_spec);
 
         return tt::tt_metal::TensorSpec(
             output_shape, TensorLayout(output_dtype, PageConfig(Layout::ROW_MAJOR), mem_config));

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/tilize_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/tilize_device_operation.cpp
@@ -149,11 +149,9 @@ TilizeDeviceOperation::spec_return_value_t TilizeDeviceOperation::compute_output
             tt::LogOp,
             "ttnn::tilize: Using input shard spec for output tensor because the legacy sharded optimized program "
             "factory is being used");
-        auto mem_config = tt::tt_metal::MemoryConfig(
-            input_tensor.memory_config().memory_layout(),
-            operation_attributes.output_mem_config.buffer_type(),
-            input_tensor.memory_config().shard_spec());  // If the input is using the legacy sharded optimized program
-                                                         // factory, the output has the same shard spec as the input.
+        // Output inherits the input's shard spec; the rest of the caller's config is preserved.
+        auto mem_config = operation_attributes.output_mem_config.with_shard_spec(
+            input_tensor.memory_config().memory_layout(), input_tensor.memory_config().shard_spec());
         return {tt::tt_metal::TensorSpec(
             input_tensor.logical_shape(),
             TensorLayout::fromPaddedShape(

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/tilize_with_val_padding/device/tilize_with_val_padding_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/tilize_with_val_padding/device/tilize_with_val_padding_device_operation.cpp
@@ -185,11 +185,9 @@ tt::tt_metal::TensorSpec TilizeWithValPaddingDeviceOperation::compute_output_spe
         auto shard_spec = input_tensor.shard_spec().value();
         shard_spec.shape[0] =
             operation_attributes.output_padded_shape.volume() / operation_attributes.output_padded_shape[-1];
-        auto mem_config = tt::tt_metal::MemoryConfig(
-            input_tensor.memory_config().memory_layout(),
-            operation_attributes.output_mem_config.buffer_type(),
-            shard_spec);  // If the input is using the legacy sharded optimized program
-                          // factory, the output has the same shard spec as the input.
+        // Output inherits the input's shard spec; the rest of the caller's config is preserved.
+        auto mem_config = operation_attributes.output_mem_config.with_shard_spec(
+            input_tensor.memory_config().memory_layout(), shard_spec);
         return tt::tt_metal::TensorSpec(
             input_shape,
             TensorLayout::fromPaddedShape(

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/untilize_with_unpadding_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/untilize_with_unpadding_device_operation.cpp
@@ -238,10 +238,9 @@ tt::tt_metal::TensorSpec UntilizeWithUnpaddingDeviceOperation::compute_output_sp
             shard_shape = {fused_height, shard_spec.shape[1]};
         }
         shard_spec.shape = shard_shape;
-        auto mem_config = tt::tt_metal::MemoryConfig(
-            input_tensor_a.memory_config().memory_layout(),
-            operation_attributes.output_mem_config.buffer_type(),
-            shard_spec);
+        // Output inherits the input's shard spec; the rest of the caller's config is preserved.
+        auto mem_config = operation_attributes.output_mem_config.with_shard_spec(
+            input_tensor_a.memory_config().memory_layout(), shard_spec);
 
         return tt::tt_metal::TensorSpec(
             output_shape, TensorLayout(output_dtype, PageConfig(Layout::ROW_MAJOR), mem_config));


### PR DESCRIPTION
Fixes #51133.

## Problem

Per-core L1 allocation (`MemoryConfig.experimental_set_per_core_allocation(True)`) which is available when the device is opened with `TT_METAL_ALLOCATOR_MODE_HYBRID=1`, lets each core allocate L1 independently rather than in lockstep with every other core. It is currently used by DeepSeek V3 B1 and downstream Blaze models for weight placement.

With it requested, `ttnn.from_torch(device=..., memory_config=<per-core L1>)` silently returned a tensor that was **not** per-core allocated — no error, no warning. Callers branching on `is_per_core_allocated()` to choose between `buffer_address()` and `experimental_per_core_buffer_address(core)` therefore take the wrong branch. The same `MemoryConfig` works via `allocate_tensor_on_device`, so the request itself is valid.

## Cause

When the optimized sharded factory is selected, `tilize` substitutes the output shard spec with the input's. It did so by building a new `MemoryConfig` from three fields:

```cpp
auto mem_config = tt::tt_metal::MemoryConfig(
    input_tensor.memory_config().memory_layout(),
    operation_attributes.output_mem_config.buffer_type(),
    input_tensor.memory_config().shard_spec());
```

Everything else the caller asked for is discarded, including the per-core allocation bit. Nothing catches it: that bit is private, missing from `attribute_values`, and ignored by `operator==`. `tilize_with_val_padding` and both `untilize_with_unpadding` branches do the same. Same defect class as #46585.

## Fix

Add `MemoryConfig::with_shard_spec(memory_layout, shard_spec)`, which copies `*this` and overrides only those two fields — so no field can be lost by omission, including fields added later:

```cpp
auto mem_config = operation_attributes.output_mem_config.with_shard_spec(
    input_tensor.memory_config().memory_layout(), input_tensor.memory_config().shard_spec());
```

The op now keeps the caller's allocation strategy and buffer type, substituting only shard *geometry*. Applied at all four sites plus three identical copies under `operations/experimental/quasar/`.

With the per-core bit unset this is field-identical to the old constructor, so **non-per-core behaviour is unchanged by construction.**

## Tests

- `test_per_core_allocation_layout_ops.py` (new): `tilize` (width/height/block sharded), `to_layout`, `tilize_with_val_padding`, `untilize_with_unpadding`, and the reported `from_torch` symptom. All fail on `main`, pass here, and check data round-trips exactly.
- `test_tensor_sharding.cpp`: six host gtests for `with_shard_spec` itself — the guard against this recurring.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=esmal/fix-51133-per-core-allocation-tilize)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:esmal/fix-51133-per-core-allocation-tilize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=esmal/fix-51133-per-core-allocation-tilize)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:esmal/fix-51133-per-core-allocation-tilize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=esmal/fix-51133-per-core-allocation-tilize)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:esmal/fix-51133-per-core-allocation-tilize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=esmal/fix-51133-per-core-allocation-tilize)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:esmal/fix-51133-per-core-allocation-tilize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=esmal/fix-51133-per-core-allocation-tilize)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:esmal/fix-51133-per-core-allocation-tilize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=esmal/fix-51133-per-core-allocation-tilize)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:esmal/fix-51133-per-core-allocation-tilize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=esmal/fix-51133-per-core-allocation-tilize)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:esmal/fix-51133-per-core-allocation-tilize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=esmal/fix-51133-per-core-allocation-tilize)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:esmal/fix-51133-per-core-allocation-tilize)
## CI

Dispatched on `1242ecc437d`: [sanity-tests](https://github.com/tenstorrent/tt-metal/actions/runs/30298390969) · [blackhole-sanity-tests](https://github.com/tenstorrent/tt-metal/actions/runs/30298393339) · [runtime-unit-tests](https://github.com/tenstorrent/tt-metal/actions/runs/30298395319) — covering the new ttnn suite, the tilize/untilize data-movement tests, and the new host gtests.
