### PR TITLE
Cleanup: Remove UBB motherboard check from physical system discovery

### DIFF
--- a/tt_metal/fabric/physical_system_discovery.cpp
+++ b/tt_metal/fabric/physical_system_discovery.cpp
@@ -138,10 +138,6 @@ std::pair<TrayID, ASICLocation> get_asic_position(
     std::unordered_map<uint32_t, ASICLocation>& pcie_id_to_asic_location) {
     if (cluster_desc.get_board_type(chip_id) == BoardType::UBB_WORMHOLE ||
         cluster_desc.get_board_type(chip_id) == BoardType::UBB_BLACKHOLE) {
-        constexpr std::string_view ubb_mobo_name = "S7T-MB";
-
-        TT_FATAL(
-            using_mock_cluster_desc || get_mobo_name() == ubb_mobo_name, "UBB systems must use S7T-MB motherboard.");
         auto ubb_id = tt::tt_fabric::get_ubb_id(cluster_desc, chip_id);
         auto pcie_id = cluster_desc.get_chips_with_mmio().at(chip_id);
         pcie_devices_per_tray[ubb_id.tray_id].insert(pcie_id);


### PR DESCRIPTION
### PR Category
Context:
Alexandre Ibrini  [9:17 AM]
Hi team --  I’m looking for guidance on a Galaxy system running inside an OpenStack VM. The error we’re hitting is:
2026-05-23 11:45:05.616 | critical |     Always | TT_FATAL: UBB systems must use S7T-MB motherboard.
(assert.hpp:104)

From the debugging so far, it looks like tt-metal’s physical system discovery reads /sys/class/dmi/id/board_name, and this is the source reference: https://github.com/tenstorrent/tt-metal/blob/main/tt_metal/fabric/physical_system_discovery.cpp#L144. In the OpenStack VM, that SMBIOS type 2 information is not exposed.

Please also note that OpenStack Nova does not appear to support passthrough of SMBIOS type 2 information here, and manual XML injection gets reverted by Nova. Based on that, this may need a tt-metal / fabric-side change so VM environments can be identified when SMBIOS type 2 is unavailable, with SMBIOS type 1 potentially usable to confirm system type as Galaxy if needed.

Could someone from the fabric side advise whether this is the right direction, and who would be the best person to work with on a fix?[physical_system_discovery.cpp](https://github.com/tenstorrent/tt-metal/blob/main/tt_metal/fabric/physical_system_discovery.cpp)            using_mock_cluster_desc || get_mobo_name() == ubb_mobo_name, "UBB systems must use S7T-MB motherboard.");
[tenstorrent/tt-metal](https://github.com/tenstorrent/tt-metal) | Added by [GitHub](https://tenstorrent.enterprise.slack.com/services/B08PF3B3RSB)

### Summary
Removes the `TT_FATAL` assertion in `get_asic_position()` (tt_metal/fabric/physical_system_discovery.cpp) that required UBB systems (UBB_WORMHOLE / UBB_BLACKHOLE) to report the "S7T-MB" motherboard via `get_mobo_name()` before discovery could proceed. This hardcoded motherboard check no longer reflects valid deployment configurations and shouldn't gate physical system discovery.

### Notes for reviewers
- Scoped to just the assertion + its now-unused local (`ubb_mobo_name`); the rest of the UBB branch (tray/ASIC location resolution) is untouched.
- `using_mock_cluster_desc` remains used later in the function, so no dangling unused-parameter warning.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ridvan/remove-mobo-check-physical-discovery)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ridvan/remove-mobo-check-physical-discovery)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ridvan/remove-mobo-check-physical-discovery)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ridvan/remove-mobo-check-physical-discovery)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ridvan/remove-mobo-check-physical-discovery)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ridvan/remove-mobo-check-physical-discovery)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ridvan/remove-mobo-check-physical-discovery)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ridvan/remove-mobo-check-physical-discovery)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ridvan/remove-mobo-check-physical-discovery)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ridvan/remove-mobo-check-physical-discovery)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ridvan/remove-mobo-check-physical-discovery)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ridvan/remove-mobo-check-physical-discovery)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ridvan/remove-mobo-check-physical-discovery)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ridvan/remove-mobo-check-physical-discovery)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ridvan/remove-mobo-check-physical-discovery)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ridvan/remove-mobo-check-physical-discovery)