### PR TITLE
[Cleanup] Reuse pre-allocated tensor as output in accumulation op

### DIFF
--- a/tests/ttnn/unit_tests/operations/reduce/test_cumsum.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_cumsum.py
@@ -88,6 +88,7 @@ def test_cumsum(size, dim, dtypes, device):
     [
         ([], 0),
         ([1], 0),
+        ([64], 0),
         ([2, 3], 0),
         ([2, 3], -1),
         ([1, 1024, 32], 0),
@@ -133,6 +134,49 @@ def test_cumsum_with_preallocated_output(size, dim, dtypes, device):
     assert preallocated_output_tensor == output_tensor
 
     assert_cumsum_quality(expected_output, torch_output)
+
+    assert device.num_program_cache_entries() >= 1
+
+
+# Exercises the general path (input_rank - dim < 4) with a preallocated output whose dtype
+# differs from the input dtype (input FLOAT32, out BFLOAT16). This covers the typecast-on-write
+# into the caller's buffer, which the matching-dtype cases above do not reach.
+@pytest.mark.parametrize(
+    "size, dim",
+    [
+        ([2, 3], 0),
+        ([2, 3], -1),
+        ([33, 35, 37], -1),
+        ([1, 1024, 32], 0),
+    ],
+)
+def test_cumsum_preallocated_output_dtype_mismatch(size, dim, device):
+    torch.manual_seed(29112024)
+
+    torch_input_tensor = torch.randint(-2, 3, size, dtype=torch.float32)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, device=device, dtype=ttnn.float32, layout=ttnn.Layout.TILE)
+    input_tensor = ttnn.fill_implicit_tile_padding(input_tensor, TEST_PADDING_VALUE)
+
+    # out dtype (bfloat16) deliberately differs from input dtype (float32)
+    preallocated_output_tensor = ttnn.zeros_like(input_tensor, dtype=ttnn.bfloat16, layout=ttnn.Layout.TILE)
+
+    output_tensor = ttnn.cumsum(input_tensor, dim=dim, dtype=ttnn.bfloat16, out=preallocated_output_tensor)
+
+    assert output_tensor.dtype == ttnn.bfloat16
+    assert preallocated_output_tensor.dtype == ttnn.bfloat16
+
+    assert output_tensor.shape == (size)
+    assert preallocated_output_tensor.shape == (size)
+
+    # the returned handle must alias/equal the caller's preallocated buffer
+    assert preallocated_output_tensor == output_tensor
+
+    expected_output = torch.cumsum(torch_input_tensor, dim=dim, dtype=torch.float32)
+
+    # the CALLER's buffer must hold the result (not just the returned handle)
+    prealloc_torch = ttnn.to_torch(preallocated_output_tensor, dtype=torch.float32)
+    assert_cumsum_quality(expected_output, prealloc_torch)
 
     assert device.num_program_cache_entries() >= 1
 

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/accumulation_common.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/accumulation_common.cpp
@@ -81,6 +81,15 @@ void validate_output_tensor(const Tensor& input_tensor, const Tensor& output_ten
         "Shape mismatch: input tensor shape {} does not match output tensor shape {}.",
         input_tensor.logical_shape(),
         output_tensor.logical_shape());
+    // The accumulation and permute device ops that now write directly into the preallocated output only have
+    // interleaved, tiled kernels; neither validates the layout/memory_layout of the provided output tensor. Assert
+    // the assumption here so a non-tile or sharded preallocated output fails early and clearly, rather than
+    // producing undefined behaviour when the op writes through its buffer.
+    TT_FATAL(
+        output_tensor.layout() == Layout::TILE, "Preallocated output tensor must have TILE layout.");
+    TT_FATAL(
+        output_tensor.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED,
+        "Preallocated output tensor must have INTERLEAVED memory layout.");
 }
 
 Tensor accumulation_invoke(

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/accumulation_common.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/accumulation_common.cpp
@@ -6,6 +6,8 @@
 #include "ttnn/operations/data_movement/clone/clone.hpp"
 #include "ttnn/operations/data_movement/copy/copy.hpp"
 #include "ttnn/operations/copy/typecast/typecast.hpp"
+#include "ttnn/operations/data_movement/permute/device/permute_device_operation.hpp"
+#include "ttnn/operations/experimental/reshape/view.hpp"
 
 namespace ttnn::operations::reduction::accumulation::common {
 
@@ -120,10 +122,105 @@ Tensor accumulation_invoke(
     // Normalize negative dim
     const int32_t cum_axis = (dim < 0) ? (dim + input_rank) : dim;
 
+    // preprocess_input_tensor / postprocess_output_tensor only reshape-to-4D and permute the tensor (changing its
+    // logical shape) when this predicate holds. Otherwise the tensor keeps its original shape end-to-end, so
+    // wip_tensor and optional_out share the same logical shape and the op can write straight into optional_out.
+    const bool shape_is_transformed = (input_rank - cum_axis < FOUR_DIMENSIONS);
+
     Tensor wip_tensor = input_tensor;
     ttsl::SmallVector<int64_t> permutation;
     int32_t accumulation_axis;
     wip_tensor = common::preprocess_input_tensor(wip_tensor, cum_axis, permutation, accumulation_axis, dtype);
+
+    if (optional_out.has_value() && !shape_is_transformed) {
+        // Fast path: the shape is preserved, so hand optional_out to the prim as its output buffer and let the
+        // device op write directly into the caller's preallocated tensor (no extra allocation, no copy).
+        wip_tensor = ttnn::prim::accumulation(
+            wip_tensor,
+            accumulation_axis,
+            dtype,
+            reverse_order,
+            std::move(optional_out),
+            memory_config.has_value() ? memory_config.value() : wip_tensor.memory_config(),
+            op);
+        // No-op here (original_rank - dim >= FOUR_DIMENSIONS), called for uniformity.
+        return common::postprocess_output_tensor(wip_tensor, cum_axis, permutation, input_shape, input_rank);
+    }
+
+    if (optional_out.has_value()) {
+        // General path: preprocessing reshaped/permuted the tensor, so the accumulation op cannot write into
+        // optional_out directly (its shape no longer matches). Rather than add a full-tensor copy on top, the
+        // *unavoidable* permute-back that postprocessing performs is redirected to write its result straight into
+        // optional_out's own buffer -- the caller's preallocated tensor is genuinely reused, with no extra pass.
+        Tensor& preallocated = *optional_out;
+
+        // Produce the accumulation result in optional_out's dtype. ttnn semantics give a preallocated output's
+        // dtype precedence, and it also means the dtype-preserving permute below lands correctly without a
+        // separate typecast (the device op converts on write, exactly like the fast path above).
+        wip_tensor = ttnn::prim::accumulation(
+            wip_tensor,
+            accumulation_axis,
+            preallocated.dtype(),
+            reverse_order,
+            std::nullopt,
+            memory_config.has_value() ? memory_config.value() : wip_tensor.memory_config(),
+            op);
+
+        // Mirror postprocess_output_tensor, but target optional_out's storage. postprocess permutes the tensor
+        // back (always) and, when the input rank was < 4, reshapes off the padded leading dims (a 0-cost relabel
+        // that shares the buffer). We therefore point the permute-back at optional_out (viewed with the
+        // intermediate 4D shape when needed) so it writes through to the caller's buffer.
+        //
+        // The permute's output shape equals wip_tensor's shape with `permutation` applied, which is precisely the
+        // 4D shape preprocess reshaped the input into (`permutation` swaps axis 0 with the cumulation axis, so it
+        // is its own inverse).
+        const ttsl::SmallVector<uint32_t> perm(permutation.begin(), permutation.end());
+        const auto& wip_shape = wip_tensor.logical_shape();
+        ttsl::SmallVector<uint32_t> permuted_dims(perm.size());
+        for (size_t i = 0; i < perm.size(); ++i) {
+            permuted_dims[i] = wip_shape[perm[i]];
+        }
+        const ttnn::Shape intermediate_shape(std::move(permuted_dims));
+
+        // For rank < 4 the intermediate shape only left-pads optional_out with unit dims (preprocess reshaped the
+        // input the same way, and `permutation` is its own inverse), so this is a pure metadata relabel that must
+        // share optional_out's buffer. ttnn::experimental::view guarantees a zero-cost reinterpret (unlike reshape,
+        // which may fall back to a data-moving path). We pass optional_out's own tile-aligned padded shape,
+        // left-padded with unit dims, so the view stays tile-aligned and physically identical to optional_out. For
+        // rank >= 4 preprocess only permutes (no reshape), so wip and optional_out already share this shape and we
+        // permute into optional_out directly. Either way the permute below writes through to the caller's buffer.
+        Tensor permute_target = preallocated;
+        if (input_rank < static_cast<int32_t>(FOUR_DIMENSIONS)) {
+            // Left-pad optional_out's OWN padded shape with unit dims up to 4D. We index by the padded shape's own
+            // rank, not input_rank: a TILE tensor's padded shape is rank max(logical_rank, 2) (tile alignment has
+            // size 2), so a logical rank-1 tensor [W] already has a rank-2 padded shape [32, round_up(W,32)].
+            // Indexing by input_rank would drop the real padded width for rank-1 inputs and mis-size the view.
+            const auto& out_padded = preallocated.padded_shape();
+            const int32_t out_padded_rank = static_cast<int32_t>(out_padded.rank());
+            ttsl::SmallVector<uint32_t> padded_dims(FOUR_DIMENSIONS, 1);
+            const int32_t pad = static_cast<int32_t>(FOUR_DIMENSIONS) - out_padded_rank;
+            for (int32_t i = 0; i < out_padded_rank; ++i) {
+                padded_dims[pad + i] = out_padded[i];
+            }
+            const ttnn::Shape intermediate_padded_shape(std::move(padded_dims));
+            permute_target = ttnn::experimental::view(preallocated, intermediate_shape, intermediate_padded_shape);
+        }
+
+        // prim::permute does not validate that its permuted output shape matches the provided output tensor; the
+        // zero-copy correctness here rests on preprocess_input_tensor producing exactly a unit-dim left-pad plus a
+        // self-inverse axis swap, so permute_target's shape must equal wip permuted by perm. Guard it explicitly so
+        // a future change to that helper fails loudly instead of silently writing into a mismatched buffer.
+        TT_FATAL(
+            permute_target.logical_shape() == intermediate_shape,
+            "Accumulation optional_out reuse: permute target shape {} does not match the expected permuted output "
+            "shape {}. preprocess_input_tensor's shape transform may have changed.",
+            permute_target.logical_shape(),
+            intermediate_shape);
+
+        ttnn::prim::permute(wip_tensor, perm, permute_target.memory_config(), permute_target, /*pad_value=*/0.0f);
+        return preallocated;
+    }
+
     wip_tensor = ttnn::prim::accumulation(
         wip_tensor,
         accumulation_axis,
@@ -132,14 +229,7 @@ Tensor accumulation_invoke(
         std::nullopt,
         memory_config.has_value() ? memory_config.value() : wip_tensor.memory_config(),
         op);
-    wip_tensor = common::postprocess_output_tensor(wip_tensor, cum_axis, permutation, input_shape, input_rank);
-    if (optional_out.has_value()) {
-        // TODO(#37807):
-        // This is a temporary fix, the op needs to be refactored to apply the output directly to optional_out,
-        // or pass in optional_out as a reference.
-        optional_out->tensor_attributes->get_storage() = wip_tensor.tensor_attributes->get_storage();
-    }
-    return wip_tensor;
+    return common::postprocess_output_tensor(wip_tensor, cum_axis, permutation, input_shape, input_rank);
 }
 
 }  // namespace ttnn::operations::reduction::accumulation::common


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
Removes the `tensor::get_storage()` anti-pattern from the accumulation op (cumsum/cumprod). Previously `accumulation_invoke` passed `std::nullopt` to the device op, allocated its own output, and then overwrote `optional_out`'s storage handle — breaking the invariant that a `Tensor`'s storage and `TensorSpec` stay consistent.

The op now genuinely reuses the caller's `optional_out` as the output buffer:

- **Fast path** (preprocessing does not transform the shape — `input_rank - dim >= 4`): `optional_out` is handed straight to `ttnn::prim::accumulation` as its output buffer, so the device op writes directly into the caller's tensor. No extra allocation, no copy.
- **General path** (preprocessing reshaped/permuted the tensor — `input_rank - dim < 4`): the *unavoidable* permute-back that postprocessing already performs is redirected to write straight into `optional_out`'s buffer via `ttnn::prim::permute`'s optional output. When the input rank < 4, `optional_out` is viewed (`ttnn::experimental::view`) with the intermediate 4D shape — a zero-cost, buffer-sharing metadata relabel using `optional_out`'s own tile-aligned padded shape. This adds **no extra device op and no copy** versus the previous code path.

The accumulation **headers, public API surface, and nanobind bindings are unchanged** — only the body of `accumulation_invoke` is modified. The function signature is byte-identical.

Closes #37807

### Notes for reviewers
- **`ttnn::prim::permute` optional-output is used for the first time in the general path.** The mechanism is wired end-to-end (`compute_output_specs` / `create_output_tensors` return the provided tensor; the tiled program factory writes into it), but this is its first non-`nullopt` production caller. A `TT_FATAL` guards the zero-copy invariant (`permute_target.logical_shape() == expected permuted shape`) so any future change to `preprocess_input_tensor`'s shape transform fails loudly instead of silently writing into a mismatched buffer.
- **Rank-1 padded shape:** a TILE rank-1 tensor `[W]` has a **rank-2** padded shape `[32, round_up(W,32)]` (tile alignment forces min rank 2). The general-path view left-pads `optional_out`'s *own* padded shape (by its own rank), not by `input_rank`, so 1-D inputs longer than one tile are handled correctly. A `[64]` dim-0 regression case was added to `test_cumsum.py`'s preallocated parametrization (cumprod already covered `[2000]`).
- **dtype:** the general path passes `optional_out.dtype()` to the prim, matching ttnn's rule that a preallocated output's dtype takes precedence (device op converts on write). Only BFLOAT16/FLOAT32 are supported.
- No local build was run in this environment; correctness rests on code review + CI. The general path with `out=` is already exercised by existing cumsum/cumprod preallocated and backward tests across ranks 1–5.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=riverwu/37807-accumulation-reuse-optional-out)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:riverwu/37807-accumulation-reuse-optional-out)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=riverwu/37807-accumulation-reuse-optional-out)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:riverwu/37807-accumulation-reuse-optional-out)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=riverwu/37807-accumulation-reuse-optional-out)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:riverwu/37807-accumulation-reuse-optional-out)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=riverwu/37807-accumulation-reuse-optional-out)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:riverwu/37807-accumulation-reuse-optional-out)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=riverwu/37807-accumulation-reuse-optional-out)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:riverwu/37807-accumulation-reuse-optional-out)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=riverwu/37807-accumulation-reuse-optional-out)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:riverwu/37807-accumulation-reuse-optional-out)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=riverwu/37807-accumulation-reuse-optional-out)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:riverwu/37807-accumulation-reuse-optional-out)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=riverwu/37807-accumulation-reuse-optional-out)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:riverwu/37807-accumulation-reuse-optional-out)