### PR TITLE
[Quasar] Clean up unpack_reduce_tilizeA_B_init and use hw_startup + init

### DIFF
--- a/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/tilize.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/kernel_apis/compute/tilize.rst
@@ -2,7 +2,7 @@ tilize
 ======
 
 .. doxygenfunction:: tilize_init(uint32_t icb, uint32_t block, uint32_t ocb, uint32_t call_line = __builtin_LINE())
-.. doxygenfunction:: tilizeA_B_reduce_init(uint32_t icb0, uint32_t icb1_scaler, uint32_t block, uint32_t ocb, uint32_t call_line = __builtin_LINE())
+.. doxygenfunction:: tilizeA_B_reduce_init(uint32_t icb0, uint32_t icb1_scaler, uint32_t block, uint32_t call_line = __builtin_LINE())
 .. doxygenfunction:: tilize_init_short_with_dt(uint32_t old_icb, uint32_t new_icb, uint32_t block, uint32_t ocb)
 .. doxygenfunction:: tilize_block(uint32_t icb, uint32_t block, uint32_t ocb, uint32_t input_tile_index = 0, uint32_t output_tile_index = 0)
 .. doxygenfunction:: unpack_tilizeA_B_block(uint32_t icb0, uint32_t icb1, uint32_t block, uint32_t tile_idx_b)

--- a/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
@@ -566,9 +566,7 @@ void run_single_core_unpack_tilizeA_B_program(
 // Uses REDUCE_COL + MAX: tilizes row-major src0 data, reduces each tile independently
 // (column-wise max within each tile), producing output tiles with only row 0 populated.
 void run_single_core_unpack_tilizeA_B_reduce_program(
-    const std::shared_ptr<distributed::MeshDevice>& mesh_device,
-    const TestConfig& test_config,
-    bool use_short_init = false) {
+    const std::shared_ptr<distributed::MeshDevice>& mesh_device, const TestConfig& test_config) {
     auto& cq = mesh_device->mesh_command_queue();
     const experimental::NodeCoord node{0, 0};
 
@@ -672,9 +670,6 @@ void run_single_core_unpack_tilizeA_B_reduce_program(
     };
     if (test_config.fp32_dest_acc_en) {
         compute_defines.emplace("DST_ACCUM_MODE", "1");
-    }
-    if (use_short_init) {
-        compute_defines.emplace("USE_SHORT_INIT", "1");
     }
 
     experimental::ComputeHardwareConfig compute_hw_config;
@@ -1355,28 +1350,26 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarComputeUnpackTilize) {
 // Quasar Unpack TilizeA_B (tilize + reduce col max)
 // Quasar's unpack_tilizeA_B is only compatible with the reduce math kernel.
 TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarComputeUnpackTilizeA_B) {
-    for (bool use_short_init : {false, true}) {
-        for (bool dst_full_sync_en : {true, false}) {
-            for (bool fp32_dest_acc_en : {true, false}) {
-                for (tt::DataFormat input_data_format : {tt::DataFormat::Float16_b}) {
-                    std::uint32_t tile_size = tt::tile_size(input_data_format);
-                    tt::DataFormat output_data_format =
-                        fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b;
-                    std::uint32_t output_tile_size = tt::tile_size(output_data_format);
-                    unit_tests::compute::tilize::TestConfig test_config = {
-                        .dst_full_sync_en = dst_full_sync_en,
-                        .fp32_dest_acc_en = fp32_dest_acc_en,
-                        .input_single_tile_size = tile_size,
-                        .output_single_tile_size = output_tile_size,
-                        .num_tiles_r = 2,
-                        .num_tiles_c = 10,
-                        .tilize_type = unit_tests::compute::tilize::TilizeType::UNPACK_A_B,
-                        .input_fmt = input_data_format,
-                        .output_fmt = output_data_format,
-                        .golden_function = ::unit_tests::compute::gold_standard_tilize_w_reduce_col_max};
-                    unit_tests::compute::tilize::run_single_core_unpack_tilizeA_B_reduce_program(
-                        this->devices_.at(0), test_config, use_short_init);
-                }
+    for (bool dst_full_sync_en : {true, false}) {
+        for (bool fp32_dest_acc_en : {true, false}) {
+            for (tt::DataFormat input_data_format : {tt::DataFormat::Float16_b}) {
+                std::uint32_t tile_size = tt::tile_size(input_data_format);
+                tt::DataFormat output_data_format =
+                    fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b;
+                std::uint32_t output_tile_size = tt::tile_size(output_data_format);
+                unit_tests::compute::tilize::TestConfig test_config = {
+                    .dst_full_sync_en = dst_full_sync_en,
+                    .fp32_dest_acc_en = fp32_dest_acc_en,
+                    .input_single_tile_size = tile_size,
+                    .output_single_tile_size = output_tile_size,
+                    .num_tiles_r = 2,
+                    .num_tiles_c = 10,
+                    .tilize_type = unit_tests::compute::tilize::TilizeType::UNPACK_A_B,
+                    .input_fmt = input_data_format,
+                    .output_fmt = output_data_format,
+                    .golden_function = ::unit_tests::compute::gold_standard_tilize_w_reduce_col_max};
+                unit_tests::compute::tilize::run_single_core_unpack_tilizeA_B_reduce_program(
+                    this->devices_.at(0), test_config);
             }
         }
     }

--- a/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
@@ -566,7 +566,9 @@ void run_single_core_unpack_tilizeA_B_program(
 // Uses REDUCE_COL + MAX: tilizes row-major src0 data, reduces each tile independently
 // (column-wise max within each tile), producing output tiles with only row 0 populated.
 void run_single_core_unpack_tilizeA_B_reduce_program(
-    const std::shared_ptr<distributed::MeshDevice>& mesh_device, const TestConfig& test_config) {
+    const std::shared_ptr<distributed::MeshDevice>& mesh_device,
+    const TestConfig& test_config,
+    bool use_short_init = false) {
     auto& cq = mesh_device->mesh_command_queue();
     const experimental::NodeCoord node{0, 0};
 
@@ -670,6 +672,9 @@ void run_single_core_unpack_tilizeA_B_reduce_program(
     };
     if (test_config.fp32_dest_acc_en) {
         compute_defines.emplace("DST_ACCUM_MODE", "1");
+    }
+    if (use_short_init) {
+        compute_defines.emplace("USE_SHORT_INIT", "1");
     }
 
     experimental::ComputeHardwareConfig compute_hw_config;
@@ -1350,26 +1355,28 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarComputeUnpackTilize) {
 // Quasar Unpack TilizeA_B (tilize + reduce col max)
 // Quasar's unpack_tilizeA_B is only compatible with the reduce math kernel.
 TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarComputeUnpackTilizeA_B) {
-    for (bool dst_full_sync_en : {true, false}) {
-        for (bool fp32_dest_acc_en : {true, false}) {
-            for (tt::DataFormat input_data_format : {tt::DataFormat::Float16_b}) {
-                std::uint32_t tile_size = tt::tile_size(input_data_format);
-                tt::DataFormat output_data_format =
-                    fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b;
-                std::uint32_t output_tile_size = tt::tile_size(output_data_format);
-                unit_tests::compute::tilize::TestConfig test_config = {
-                    .dst_full_sync_en = dst_full_sync_en,
-                    .fp32_dest_acc_en = fp32_dest_acc_en,
-                    .input_single_tile_size = tile_size,
-                    .output_single_tile_size = output_tile_size,
-                    .num_tiles_r = 2,
-                    .num_tiles_c = 10,
-                    .tilize_type = unit_tests::compute::tilize::TilizeType::UNPACK_A_B,
-                    .input_fmt = input_data_format,
-                    .output_fmt = output_data_format,
-                    .golden_function = ::unit_tests::compute::gold_standard_tilize_w_reduce_col_max};
-                unit_tests::compute::tilize::run_single_core_unpack_tilizeA_B_reduce_program(
-                    this->devices_.at(0), test_config);
+    for (bool use_short_init : {false, true}) {
+        for (bool dst_full_sync_en : {true, false}) {
+            for (bool fp32_dest_acc_en : {true, false}) {
+                for (tt::DataFormat input_data_format : {tt::DataFormat::Float16_b}) {
+                    std::uint32_t tile_size = tt::tile_size(input_data_format);
+                    tt::DataFormat output_data_format =
+                        fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b;
+                    std::uint32_t output_tile_size = tt::tile_size(output_data_format);
+                    unit_tests::compute::tilize::TestConfig test_config = {
+                        .dst_full_sync_en = dst_full_sync_en,
+                        .fp32_dest_acc_en = fp32_dest_acc_en,
+                        .input_single_tile_size = tile_size,
+                        .output_single_tile_size = output_tile_size,
+                        .num_tiles_r = 2,
+                        .num_tiles_c = 10,
+                        .tilize_type = unit_tests::compute::tilize::TilizeType::UNPACK_A_B,
+                        .input_fmt = input_data_format,
+                        .output_fmt = output_data_format,
+                        .golden_function = ::unit_tests::compute::gold_standard_tilize_w_reduce_col_max};
+                    unit_tests::compute::tilize::run_single_core_unpack_tilizeA_B_reduce_program(
+                        this->devices_.at(0), test_config, use_short_init);
+                }
             }
         }
     }

--- a/tests/tt_metal/tt_metal/test_kernels/compute/compute_kernel_sentinel.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/compute_kernel_sentinel.cpp
@@ -110,6 +110,6 @@ void kernel_main() {
     copy_tile_to_dst_init_short(cb_in2);
     ASSERT(TEST_RECONFIG_CALLS(RECONFIG_CHANGED_SRCA));
 
-    tilizeA_B_reduce_init<false, true>(cb_in0, cb_in1, 1, cb_out1);
+    tilizeA_B_reduce_init<false, true>(cb_in0, cb_in1, 1);
     ASSERT(TEST_RECONFIG_CALLS(RECONFIG_CHANGED_SRCA));
 }

--- a/tests/tt_metal/tt_metal/test_kernels/compute/unpack_tilizeA_B_reduce.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/unpack_tilizeA_B_reduce.cpp
@@ -19,7 +19,7 @@ void kernel_main() {
 
     compute_kernel_hw_startup(dfb::in_data, dfb::in_scaler, dfb::out);
     tilizeA_B_reduce_init<true /*neginf_srcA*/, false /*zero_srcA_reduce*/>(
-        dfb::in_data, dfb::in_scaler, per_core_block_tile_cnt, dfb::out);
+        dfb::in_data, dfb::in_scaler, per_core_block_tile_cnt);
 
     dfb_in_scaler.wait_front(1);
 

--- a/tests/tt_metal/tt_metal/test_kernels/compute/unpack_tilizeA_B_reduce.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/unpack_tilizeA_B_reduce.cpp
@@ -18,8 +18,13 @@ void kernel_main() {
     DataflowBuffer dfb_out(dfb::out);
 
     compute_kernel_hw_startup(dfb::in_data, dfb::in_scaler, dfb::out);
+#ifdef USE_SHORT_INIT
+    tilizeA_B_reduce_init_short<true /*neginf_srcA*/, false /*zero_srcA_reduce*/>(
+        dfb::in_data, dfb::in_scaler, per_core_block_tile_cnt);
+#else
     tilizeA_B_reduce_init<true /*neginf_srcA*/, false /*zero_srcA_reduce*/>(
         dfb::in_data, dfb::in_scaler, per_core_block_tile_cnt, dfb::out);
+#endif
 
     dfb_in_scaler.wait_front(1);
 

--- a/tests/tt_metal/tt_metal/test_kernels/compute/unpack_tilizeA_B_reduce.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/unpack_tilizeA_B_reduce.cpp
@@ -18,13 +18,8 @@ void kernel_main() {
     DataflowBuffer dfb_out(dfb::out);
 
     compute_kernel_hw_startup(dfb::in_data, dfb::in_scaler, dfb::out);
-#ifdef USE_SHORT_INIT
-    tilizeA_B_reduce_init_short<true /*neginf_srcA*/, false /*zero_srcA_reduce*/>(
-        dfb::in_data, dfb::in_scaler, per_core_block_tile_cnt);
-#else
     tilizeA_B_reduce_init<true /*neginf_srcA*/, false /*zero_srcA_reduce*/>(
         dfb::in_data, dfb::in_scaler, per_core_block_tile_cnt, dfb::out);
-#endif
 
     dfb_in_scaler.wait_front(1);
 

--- a/tt_metal/hw/inc/api/compute/tilize.h
+++ b/tt_metal/hw/inc/api/compute/tilize.h
@@ -70,57 +70,6 @@ ALWI void tilize_init(uint32_t icb, uint32_t block, uint32_t ocb, uint32_t call_
 }
 
 #if (defined(REDUCE_OP) and defined(REDUCE_DIM)) or defined(__DOXYGEN__)
-
-// clang-format off
-/**
- * Initializes the tilize operation with reduction. Should be called once at the beginning of a kernel.
- *
- * Return value: None
- *
- * | Param Type | Name           | Description                              | Type     | Valid Range | Required |
- * |------------|----------------|------------------------------------------|----------|-------------|----------|
- * | Template   | neginf_srcA    | NegInf source A flag                     | bool     | true/false  | False    |
- * | Template   | zero_srcA_reduce| Zero source A for reduce flag           | bool     | true/false  | False    |
- * | Function   | icb0           | Input circular buffer A identifier       | uint32_t | 0 to 31     | True     |
- * | Function   | icb1_scaler    | Input circular buffer for scaler         | uint32_t | 0 to 31     | True     |
- * | Function   | block          | Size of tile block to work on            | uint32_t | > 0         | True     |
- * | Function   | ocb            | Output circular buffer identifier        | uint32_t | 0 to 31     | True     |
- *
- * Unpack face geometry for operand A comes from circular-buffer metadata (JIT unpack_tile_* arrays), e.g.
- * set_unpack_face_geometry / set_tile_dims on the host.
- */
-// clang-format on
-template <bool neginf_srcA = true, bool zero_srcA_reduce = false>
-ALWI void tilizeA_B_reduce_init(
-    uint32_t icb0, uint32_t icb1_scaler, uint32_t block, uint32_t ocb, uint32_t call_line = __builtin_LINE()) {
-    state_configure(icb0, icb1_scaler, ocb, call_line);
-#ifndef ARCH_QUASAR
-    UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE>(icb0, icb1_scaler)));
-    UNPACK((llk_unpack_tilizeA_B_init<neginf_srcA, true /*reload_srcB*/, false /*zero_srcA*/, zero_srcA_reduce>(
-        icb0, icb1_scaler, block)));
-
-    MATH((llk_math_reduce_init<REDUCE_OP, REDUCE_DIM, DST_ACCUM_MODE, MATH_FIDELITY>(icb0, icb1_scaler)));
-    MATH((llk_math_pack_sync_init<DST_ACCUM_MODE>()));
-    MATH((llk_math_hw_configure<DST_ACCUM_MODE>(icb0, icb1_scaler)));
-
-    PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(ocb)));
-    PACK((llk_pack_init(ocb)));
-    PACK((llk_pack_dest_init<DST_ACCUM_MODE, PackMode::Default>(ocb)));
-#else
-    UNPACK((llk_unpack_hw_configure(icb0, icb1_scaler)));
-    UNPACK((llk_unpack_tilizeA_B_init<neginf_srcA, true /*reload_srcB*/, false /*zero_srcA*/, zero_srcA_reduce>(
-        icb0, icb1_scaler, block)));
-
-    MATH((llk_math_reduce_init<REDUCE_OP, REDUCE_DIM, DST_ACCUM_MODE, MATH_FIDELITY>(icb0, icb1_scaler)));
-    MATH((llk_math_pack_sync_init()));
-    MATH((llk_math_hw_configure<DST_ACCUM_MODE>(icb0, icb1_scaler)));
-
-    PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(ocb)));
-    PACK((llk_pack_init(ocb)));
-    PACK((llk_pack_dest_init()));
-#endif
-}
-
 // clang-format off
 /**
  * Short initializes the tilize operation with reduction.
@@ -132,10 +81,15 @@ ALWI void tilizeA_B_reduce_init(
  * | Function   | icb0             | Input circular buffer A identifier   | uint32_t | 0 to 31     | True     |
  * | Function   | icb1_scaler      | Input circular buffer for scaler     | uint32_t | 0 to 31     | True     |
  * | Function   | block            | Size of tile block to work on        | uint32_t | > 0         | True     |
+ *
+ * Unpack face geometry for operand A comes from circular-buffer metadata (JIT unpack_tile_* arrays), e.g.
+ * set_unpack_face_geometry / set_tile_dims on the host.
  */
 // clang-format on
 template <bool neginf_srcA = true, bool zero_srcA_reduce = false>
-ALWI void tilizeA_B_reduce_init_short(uint32_t icb0, uint32_t icb1_scaler, uint32_t block) {
+ALWI void tilizeA_B_reduce_init(
+    uint32_t icb0, uint32_t icb1_scaler, uint32_t block, uint32_t call_line = __builtin_LINE()) {
+    state_configure(icb0, icb1_scaler, call_line);
     UNPACK((llk_unpack_tilizeA_B_init<neginf_srcA, true /*reload_srcB*/, false /*zero_srcA*/, zero_srcA_reduce>(
         icb0, icb1_scaler, block)));
     MATH((llk_math_reduce_init<REDUCE_OP, REDUCE_DIM, DST_ACCUM_MODE, MATH_FIDELITY>(icb0, icb1_scaler)));

--- a/tt_metal/hw/inc/api/compute/tilize.h
+++ b/tt_metal/hw/inc/api/compute/tilize.h
@@ -120,6 +120,26 @@ ALWI void tilizeA_B_reduce_init(
     PACK((llk_pack_dest_init()));
 #endif
 }
+
+// clang-format off
+/**
+ * Short initializes the tilize operation with reduction.
+ *
+ * | Param Type | Name             | Description                          | Type     | Valid Range | Required |
+ * |------------|------------------|--------------------------------------|----------|-------------|----------|
+ * | Template   | neginf_srcA      | NegInf source A flag                 | bool     | true/false  | False    |
+ * | Template   | zero_srcA_reduce | Zero source A for reduce flag        | bool     | true/false  | False    |
+ * | Function   | icb0             | Input circular buffer A identifier   | uint32_t | 0 to 31     | True     |
+ * | Function   | icb1_scaler      | Input circular buffer for scaler     | uint32_t | 0 to 31     | True     |
+ * | Function   | block            | Size of tile block to work on        | uint32_t | > 0         | True     |
+ */
+// clang-format on
+template <bool neginf_srcA = true, bool zero_srcA_reduce = false>
+ALWI void tilizeA_B_reduce_init_short(uint32_t icb0, uint32_t icb1_scaler, uint32_t block) {
+    UNPACK((llk_unpack_tilizeA_B_init<neginf_srcA, true /*reload_srcB*/, false /*zero_srcA*/, zero_srcA_reduce>(
+        icb0, icb1_scaler, block)));
+    MATH((llk_math_reduce_init<REDUCE_OP, REDUCE_DIM, DST_ACCUM_MODE, MATH_FIDELITY>(icb0, icb1_scaler)));
+}
 #endif  // (REDUCE_OP && REDUCE_DIM) || __DOXYGEN__
 
 #ifndef ARCH_QUASAR

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/kernels/conv_bmm_tilize_metal2.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/kernels/conv_bmm_tilize_metal2.cpp
@@ -504,8 +504,7 @@ void kernel_main() {
 #ifdef ARCH_QUASAR
                     // ROOT CAUSE (proven via MMBLK-absent + tile-index>obnt localization): on Quasar the plain
                     // `tilize_init` (tilize.h:63-69) does ONLY unpack+math init and omits ALL pack config --
-                    // unlike the non-Quasar branch (:106-108), BH (:60-62), and the reduce variant
-                    // `tilizeA_B_reduce_init` (:118-120), which all call llk_pack_hw_configure(ocb) +
+                    // unlike the non-Quasar branch (:106-108), BH (:60-62), which all call llk_pack_hw_configure(ocb) +
                     // llk_pack_init(ocb). So the tilize's pack BUFFER DESCRIPTOR is never pointed at
                     // tilized_in0 -- it keeps the stale dfb::out base from compute_kernel_hw_startup, and the
                     // tilize packs tilized_in0's tiles into the OUT L1 region -> PACR0_TILE_INC / ERROR_TRISC1
@@ -526,8 +525,7 @@ void kernel_main() {
                     // of phase with PACK -> Risc IB interrupt (0x19) whose faulting tile/core move with DPRINT
                     // latency (a timing race, not OOB: TZCUR showed wr_entry_idx=0/nent=448). This is the
                     // MATH-side partner of the llk_pack_init/llk_pack_dest_init re-issued just below; runs once
-                    // per tilize group, NO per-block hw_configure. Same Quasar gap the pool hit --
-                    // tilizeA_B_reduce_init_short adds llk_math_pack_sync_init for exactly this reason.
+                    // per tilize group, NO per-block hw_configure.
                     // NB: this seeds the MATH side; a RESIDUAL Quasar DEST-handshake race in the per-tile
                     // tilize_block datacopy<->pack loop (ERROR_TRISC1 0x19, fault tile/core move with DPRINT
                     // latency) survives even with correct init -- it is an LLK-team issue, see

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/kernels/conv_unpack_tilize_probe_metal2.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/kernels/conv_unpack_tilize_probe_metal2.cpp
@@ -17,9 +17,10 @@
 // garbage scalar is fine for a completion probe; it keeps the srcB CB valid without a cross-thread fill.
 //
 // API sequence mirrors ttnn/.../pool_generic/device/kernels/compute/compute_pool_2d.cpp exactly:
-//   tilizeA_B_reduce_init<neginf,zero>(inA, scalar, block, out)            (once, does the hw_configure)
+//   compute_kernel_hw_startup(inA, scalar, out)                             (once, does the hw_configure)
+//   tilizeA_B_reduce_init<neginf,zero>(inA, scalar, block)                  (initializes tilizeA_B, no hw_configure)
 //   pack_untilize_dest_init<CHUNK>(out)                                     (once)
-//   per chunk: tilizeA_B_reduce_init_short<neginf,zero>(inA, scalar, block, out)  (no hw_configure)
+//   per chunk: tilizeA_B_reduce_init<neginf,zero>(inA, scalar, block)  (no hw_configure)
 //              tile_regs_acquire()
 //              unpack_tilizeA_B_block<neginf,reload_srcB=true,zero_srcA=false,zero_reduce=false>(inA, scalar, block, 0)
 //              reduce_tile_math<REDUCE_OP, REDUCE_DIM>(t, num_faces)  for t in 0..block
@@ -88,7 +89,8 @@ void kernel_main() {
     in_scalar_cb.wait_front(1);
 
     // One-time init (does the llk_*_hw_configure): mirror the pool's kernel-start init.
-    tilizeA_B_reduce_init<neginf_srca, zero_srca>(in_cb_id, in_scalar_cb_id, CHUNK, out_cb_id);
+    compute_kernel_hw_startup(in_cb_id, in_scalar_cb_id, out_cb_id);
+    tilizeA_B_reduce_init<neginf_srca, zero_srca>(in_cb_id, in_scalar_cb_id, CHUNK);
     pack_untilize_dest_init<CHUNK>(out_cb_id);
 
     UNPACK(DPRINT(
@@ -99,10 +101,10 @@ void kernel_main() {
         (uint32_t)total_tiles));
 
     for (uint32_t iter = 0; iter < num_chunks; ++iter) {
-        // Re-init unpack+math for this chunk WITHOUT re-running hw_configure (the *_short variant). Re-running
+        // Re-init unpack+math for this chunk WITHOUT re-running hw_configure. Re-running
         // hw_configure per chunk corrupts unpacker state on Quasar (pool comment) — this keeps unpack+math in
         // lockstep, exactly as the pool does per c-block.
-        tilizeA_B_reduce_init_short<neginf_srca, zero_srca>(in_cb_id, in_scalar_cb_id, CHUNK, out_cb_id);
+        tilizeA_B_reduce_init<neginf_srca, zero_srca>(in_cb_id, in_scalar_cb_id, CHUNK);
 
         tile_regs_acquire();
         in_cb.wait_front(CHUNK);

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pool_generic/device/kernels/compute/compute_pool_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pool_generic/device/kernels/compute/compute_pool_2d.cpp
@@ -22,8 +22,8 @@
 //   0 = production path: narrow pack_untilize straight into the real output CB (out_cb), then DPRINT it.
 //   1 = experiment:      full-tile (32x32) pack of the reduced DEST into the scratch CB, then DPRINT it
 //                        (out_cb still gets a balancing push with garbage).
-// The inits (tilizeA_B_reduce_init + pack_untilize_dest_init) and the pack call all follow this switch,
-// so flipping this one value moves the whole pipeline between the two CBs consistently.
+// The pack_untilize_dest_init and the pack call all follow this switch, so flipping this one value moves
+// the whole pack pipeline between the two CBs consistently.
 // NOTE: PACK_TO_SCRATCH==1 requires the reader-side scratch consume (reader_pool_2d.cpp) to be enabled
 // too — compute PRODUCES the scratch CB and the DM reader CONSUMES it; they must be on/off together.
 #define PACK_TO_SCRATCH 1
@@ -41,22 +41,6 @@
 #define FACE_WIDTH 16
 #define TILE_HEIGHT 32
 #define TILE_WIDTH 32
-
-// [#48552] Self-contained copy of the canonical minimal tilize+reduce re-init from the (not-yet-merged)
-// amokan/tilizeA_B_init_short compute-API change. It re-programs ONLY UNPACK (tilizeA_B) and MATH (reduce)
-// for a mid-kernel change of input CB or tiles-to-reduce, deliberately WITHOUT the one-time llk_*_hw_configure
-// that the full tilizeA_B_reduce_init runs at kernel start -- re-running hw_configure per c-block corrupts
-// unpacker state. PACK is re-init'd separately via pack_untilize_dest_init in the loop. This mirrors the LLK
-// team's canonical short init (UNPACK tilizeA_B + MATH reduce only; no pack-sync / pack init / dest-init),
-// which passes test_max_pool2d_strided_reduce.py. Both llk_* signatures match the full tilizeA_B_reduce_init
-// used at kernel start. Remove once amokan/tilizeA_B_init_short lands and this branch picks it up.
-template <bool neginf_srcA = true, bool zero_srcA_reduce = false>
-ALWI void tilizeA_B_reduce_init_short(uint32_t icb0, uint32_t icb1_scaler, uint32_t block, uint32_t ocb) {
-    UNPACK((llk_unpack_tilizeA_B_init<neginf_srcA, true /*reload_srcB*/, false /*zero_srcA*/, zero_srcA_reduce>(
-        icb0, icb1_scaler, block)));
-    MATH((llk_math_reduce_init<REDUCE_OP, REDUCE_DIM, DST_ACCUM_MODE, MATH_FIDELITY>(icb0, icb1_scaler)));
-    (void)ocb;  // PACK re-init handled by pack_untilize_dest_init; ocb kept for call-site compatibility.
-}
 
 void kernel_main() {
 #if DEBUG_PRINT == 1
@@ -190,8 +174,8 @@ void kernel_main() {
 #else
     constexpr uint32_t pack_target_cb_id = tilize_untilize_cb;
 #endif
-    tilizeA_B_reduce_init<neginf_srca_maxpool, zero_srca_avgpool>(
-        in_cb_id_0, in_scalar_cb_id_0, max_tiles_per_iter, pack_target_cb_id);
+    compute_kernel_hw_startup(in_cb_id_0, in_scalar_cb_id_0, tilize_untilize_cb);
+    tilizeA_B_reduce_init<neginf_srca_maxpool, zero_srca_avgpool>(in_cb_id_0, in_scalar_cb_id_0, max_tiles_per_iter);
 
     pack_untilize_dest_init<max_tiles_per_iter>(pack_target_cb_id);
 
@@ -274,12 +258,7 @@ void kernel_main() {
             //   (b) tiles_to_reduce changes across c-blocks (e.g. 4 then 2 for 6 tiles / 192c) -- UNPACK and
             //       MATH must both be re-programmed for the new count (PACK is re-init'd via
             //       pack_untilize_dest_init below).
-            // Use the *_short variant: the full tilizeA_B_reduce_init (called once at kernel start) also runs
-            // llk_*_hw_configure, and re-running hw_configure per c-block corrupts unpacker state (UNPACKER
-            // fault). Re-initing only some engines desynced them (Risc IB interrupt, watcher 0x19, on MATH then
-            // PACK); the short compute API keeps unpack+math in lockstep without the illegal per-block reconfig.
-            tilizeA_B_reduce_init_short<neginf_srca_maxpool, zero_srca_avgpool>(
-                curr_in_cb_id, curr_scalar_cb_id, tiles_to_reduce, pack_target_cb_id);
+            tilizeA_B_reduce_init<neginf_srca_maxpool, zero_srca_avgpool>(curr_in_cb_id, curr_scalar_cb_id, tiles_to_reduce);
             MATH(WATCHER_RING_BUFFER_PUSH(0xC0FFEE11u));
             tile_regs_acquire();
             for (uint32_t chunk = 0; chunk < interm_reduction_chunks; chunk++) {

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d.cpp
@@ -109,8 +109,8 @@ void kernel_main() {
     DataflowBuffer pre_tilize_dfb(pre_tilize_cb_id);
     DataflowBuffer fast_tilize_dfb(fast_tilize_cb_id);
 
-    tilizeA_B_reduce_init<neginf_srca_maxpool, zero_srca_avgpool>(
-        in_cb_id_0, in_scalar_cb_id_0, max_tiles_per_iter, tilize_untilize_cb);
+    compute_kernel_hw_startup(in_cb_id_0, in_scalar_cb_id_0, tilize_untilize_cb);
+    tilizeA_B_reduce_init<neginf_srca_maxpool, zero_srca_avgpool>(in_cb_id_0, in_scalar_cb_id_0, max_tiles_per_iter);
 
     pack_untilize_dest_init<max_tiles_per_iter>(tilize_untilize_cb);
 

--- a/ttnn/cpp/ttnn/operations/pool/upsample/device/kernels/compute/bilinear.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/upsample/device/kernels/compute/bilinear.cpp
@@ -94,8 +94,8 @@ void kernel_main() {
     DataflowBuffer scalar_dfb_2(in_scalar_cb_id2);
     DataflowBuffer out_dfb(out_cb_id);
 
-    tilizeA_B_reduce_init<use_neginf_srcA, zero_srcA_reduce>(
-        tilize_reduce_cb_0, in_scalar_cb_id1, max_tiles_per_iter, out_cb_id);
+    compute_kernel_hw_startup(tilize_reduce_cb_0, in_scalar_cb_id1, out_cb_id);
+    tilizeA_B_reduce_init<use_neginf_srcA, zero_srcA_reduce>(tilize_reduce_cb_0, in_scalar_cb_id1, max_tiles_per_iter);
     pack_untilize_dest_init<max_tiles_per_iter>(out_cb_id); /* face geometry comes from out_cb metadata */
     for (uint32_t i = 0; i < nsticks_per_core_by_nblocks; i++) {
         DataflowBuffer cur_in_dfb = (i % 2 == 0) ? tilize_reduce_dfb0 : tilize_reduce_dfb1;


### PR DESCRIPTION
### PR Category
Feature

### Issue
https://github.com/tenstorrent/tt-metal/issues/49683

### Summary
Quasar needs re-inits when execute function calls change DFB IDs. This is because the buffer descriptor ID is baked into the mop at init.
In Resnet, a different output DFB is used for tilizeA_B execute calls, so for Quasar a tilizeA_B short init is needed.

Instead of introducing a separate short init compute API, this PR swaps all usages of tilizeA_B_reduce_init in our code base with compute_kernel_hw_startup + tilizeA_B_reduce_init.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amokan/tilizeA_B_init_short)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amokan/tilizeA_B_init_short)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amokan/tilizeA_B_init_short)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amokan/tilizeA_B_init_short)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=amokan/tilizeA_B_init_short)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:amokan/tilizeA_B_init_short)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amokan/tilizeA_B_init_short)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amokan/tilizeA_B_init_short)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amokan/tilizeA_B_init_short)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amokan/tilizeA_B_init_short)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amokan/tilizeA_B_init_short)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amokan/tilizeA_B_init_short)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amokan/tilizeA_B_init_short)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amokan/tilizeA_B_init_short)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amokan/tilizeA_B_init_short)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amokan/tilizeA_B_init_short)