### PR TITLE
[skip ci] ci: use zstd --long -9 for CPM cache tarball

### DIFF
--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -595,7 +595,7 @@ jobs:
       - name: 📦 Compute CPM cache key
         id: cpm-key
         run: |
-          echo "key=cpm-z22-${{ hashFiles(
+          echo "key=cpm-z9l-${{ hashFiles(
             'third_party/CMakeLists.txt',
             'tt_metal/third_party/umd/third_party/CMakeLists.txt',
             'tt-train/cmake/dependencies.cmake') }}" >> "$GITHUB_OUTPUT"
@@ -673,12 +673,12 @@ jobs:
       - name: 📦 Pack CPM cache
         # Only pack when we can actually save. For fork PRs the restore step is
         # skipped (no secrets), so 'hit' is unset and would otherwise trigger a
-        # pointless ultra-zstd compression that never gets uploaded.
+        # pointless zstd compression that never gets uploaded.
         if: >-
           steps.cpm-cache.outputs.hit != 'true' &&
           (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false)
         run: |
-          [ -d .cpmcache ] && tar -I 'zstd -T0 --ultra -22' -cf .cpmcache.tar.zst .cpmcache || true
+          [ -d .cpmcache ] && tar -I 'zstd -T0 --long -9 -v' -cf .cpmcache.tar.zst .cpmcache || true
 
       - name: 📦 Save CPM source cache (Garage S3)
         # Only upload on a miss, and only where we have S3 creds (same fork guard).

--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -842,7 +842,7 @@ jobs:
           if [[ "${{ inputs.skip-tt-train }}" != "true" ]]; then
             ARTIFACT_PATHS="$ARTIFACT_PATHS build/tt-train data"
           fi
-          tar -I 'zstd --adapt=min=9 -T0' -cvhf /work/ttm_any.tar.zst $ARTIFACT_PATHS
+          tar -I 'zstd -T0 --long -9 -v' -cvhf /work/ttm_any.tar.zst $ARTIFACT_PATHS
 
       - name: Set build artifact name
         id: set_build_artifact_name


### PR DESCRIPTION
## Summary
- Switch the CPM source cache tarball compression from `zstd -T0 --ultra -22` to `zstd -T0 --long -9 -v` in the "Pack CPM cache" step of `build-artifact.yaml`.
- Bump the cache key prefix from `cpm-z22-` to `cpm-z9l-` so caches produced under the new compression settings get a fresh key rather than colliding with existing `-22`-compressed archives.
- Switch the final build artifact tarball ("Tar files" step) from `zstd --adapt=min=9 -T0` to the same `zstd -T0 --long -9 -v`, dropping the adaptive-level behavior (in practice it rarely climbed past 9 anyway) in favor of a fixed level plus long-distance matching.

Both tarballs are now compressed with the same settings: `-T0` (multithreaded), `--long` (long-distance matching), `-9` (fixed level), `-v` (verbose).

## Test plan
- [x] Build Artifact https://github.com/tenstorrent/tt-metal/actions/runs/30299434246/job/90088614829