### PR TITLE
Performance: deepen the fast dispatch prefetcher's relay_paged scratch to a 3-buffer ring

### DIFF
--- a/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
@@ -788,6 +788,53 @@ TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestMultiplePagesLargerThanMaxPr
     }
 }
 
+// Page sizes that straddle the thresholds process_relay_paged_cmd picks its scratch layout on: a page that fits in
+// one ring buffer streams through the ring, a larger page falls back to the two-buffer split at half the scratch,
+// and above the half the command goes to process_relay_paged_cmd_large. A page landing on the wrong side of either
+// threshold gets a buffer smaller than a page, which reads zero pages per pass and hangs the prefetcher, so cover
+// both boundaries and their neighbors.
+//
+// Mirrors the derivation in cq_prefetch.cpp. Every size is a multiple of the NoC alignment so the buffer's padded
+// page size is the page size the kernel sees, and the aligned-down half is the largest page a buffer read can
+// hand to the fallback loop.
+static std::vector<uint32_t> relay_paged_scratch_threshold_page_sizes() {
+    const uint32_t scratch_db_size = MetalContext::instance().dispatch_mem_map().scratch_db_size();
+    const uint32_t alignment = std::max(
+        MetalContext::instance().hal().get_alignment(HalMemType::DRAM),
+        MetalContext::instance().hal().get_alignment(HalMemType::L1));
+    constexpr uint32_t ring_nbuf = 3;
+    constexpr uint32_t min_ring_buf_size = 32 * 1024;
+    const uint32_t nbuf = (scratch_db_size / ring_nbuf >= min_ring_buf_size) ? ring_nbuf : 2;
+    const uint32_t ring_buf_size = (scratch_db_size / nbuf) / alignment * alignment;
+    const uint32_t half_size = (scratch_db_size / 2) / alignment * alignment;
+
+    std::vector<uint32_t> page_sizes{
+        ring_buf_size - alignment,  // ring, one alignment short of filling a buffer
+        ring_buf_size,              // ring, exactly one page per buffer
+        ring_buf_size + alignment,  // first page too large for the ring: two-buffer fallback
+        half_size,                  // largest page still on the fallback loop
+        half_size + alignment,      // first page handed to process_relay_paged_cmd_large
+    };
+    // The ring collapses to a double buffer on a scratch too small to divide (eth dispatch), where ring_buf_size
+    // and half_size name the same threshold.
+    std::sort(page_sizes.begin(), page_sizes.end());
+    page_sizes.erase(std::unique(page_sizes.begin(), page_sizes.end()), page_sizes.end());
+    return page_sizes;
+}
+
+TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestPagesAtRelayPagedScratchThresholds) {
+    // Pages this large make 8 of them several trips around the deepest ring, so the reads also cover reusing a
+    // buffer whose previous write is still outstanding.
+    constexpr uint32_t num_pages = 8;
+    for (const auto& mesh_device : devices_) {
+        for (const uint32_t page_size : relay_paged_scratch_threshold_page_sizes()) {
+            TestBufferConfig config = {.num_pages = num_pages, .page_size = page_size, .buftype = BufferType::DRAM};
+            local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer(
+                mesh_device, mesh_device->mesh_command_queue(), config);
+        }
+    }
+}
+
 TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestSinglePageLargerThanMaxPrefetchCommandSizeShardedBuffer) {
     const uint32_t page_size = MetalContext::instance().dispatch_mem_map().max_prefetch_command_size() + 2048;
     for (const auto& mesh_device : devices_) {

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -186,6 +186,26 @@ constexpr uint32_t prefetch_q_log_minsize = 4;
 
 const uint32_t scratch_db_top[2] = {scratch_db_base0, scratch_db_base1};
 
+// relay_paged streams through a ring of scratch buffers rather than a plain double buffer. With two buffers the
+// loop has to globally flush every outstanding write to the dispatcher before it can refill the buffer it is
+// about to read into, because that buffer sourced the immediately preceding write; that flush costs ~10% of the
+// prefetcher's time on large transfers. A third buffer makes the write being waited on two iterations old, so
+// the wait is normally already satisfied by the time it is reached. Three measured best on Wormhole; four is
+// slower because the buffers get small enough to coarsen the read/write overlap.
+// The ring shares the L1 region used by the legacy double buffer above; only one scheme is live per command.
+// A page has to fit in a single buffer, so the ring is only usable for pages up to scratch_db_ring_buf_size.
+// Larger pages keep the historical two-buffer split: process_relay_paged_cmd_large is only correct for
+// page_size > scratch_db_half_size (it computes page_size - amt_read, which underflows below that), so the
+// range in between must stay on this loop rather than being pushed down to the large-page path.
+constexpr uint32_t scratch_db_max_nbuf = 3;
+// Align down so the ring works for a scratch size that does not divide evenly by the buffer count; an unaligned
+// buffer stride would misalign every NoC read and write issued from it.
+constexpr uint32_t scratch_db_buf_align = 4096;
+constexpr uint32_t scratch_db_ring_buf_size =
+    (scratch_db_size / scratch_db_max_nbuf) / scratch_db_buf_align * scratch_db_buf_align;
+static_assert(scratch_db_max_nbuf >= 2, "relay_paged needs at least a double buffer");
+static_assert(scratch_db_ring_buf_size > 0, "prefetch scratch is too small for the configured buffer count");
+
 // Currently capping the same as dispatch
 constexpr uint32_t max_read_packed_cmd =
     CQ_PREFETCH_CMD_RELAY_PAGED_PACKED_MAX_SUB_CMDS * sizeof(CQPrefetchRelayPagedPackedSubCmd) / sizeof(uint32_t);
@@ -1075,12 +1095,17 @@ uint32_t process_relay_paged_cmd(uintptr_t cmd_ptr, uint32_t& downstream__data_p
             cmd_ptr, downstream_data_ptr, page_id, base_addr, page_size, pages, length_adjust);
     }
 
+    // Use the deeper ring when a page fits in one of its buffers, otherwise fall back to the two-buffer split.
+    const uint32_t scratch_db_nbuf = (page_size <= scratch_db_ring_buf_size) ? scratch_db_max_nbuf : 2;
+    const uint32_t scratch_db_buf_size =
+        (scratch_db_nbuf == scratch_db_max_nbuf) ? scratch_db_ring_buf_size : scratch_db_half_size;
+
     auto addr_gen = TensorAccessor(tensor_accessor::make_interleaved_dspec<is_dram>(), base_addr, page_size);
 
     // First step - read into DB0
     uint64_t read_wlength = (uint64_t)pages * page_size;
-    uint32_t scratch_read_addr = scratch_db_top[0];
-    uint32_t amt_to_read = (scratch_db_half_size > read_wlength) ? read_wlength : scratch_db_half_size;
+    uint32_t scratch_read_addr = scratch_db_base;
+    uint32_t amt_to_read = (scratch_db_buf_size > read_wlength) ? read_wlength : scratch_db_buf_size;
     uint32_t amt_read = 0;
     while (amt_to_read >= page_size) {
         uint64_t noc_addr = addr_gen.get_noc_addr(page_id);
@@ -1099,25 +1124,35 @@ uint32_t process_relay_paged_cmd(uintptr_t cmd_ptr, uint32_t& downstream__data_p
     std::atomic_signal_fence(std::memory_order_acq_rel);
     noc_async_read_barrier();
 
-    // Second step - read into DB[x], write from DB[x], toggle x, iterate
+    // Second step - read into buf[next], write from buf[cur], advance around the ring, iterate
     // Writes are fast, reads are slow
-    uint32_t db_toggle = 0;
+    uint32_t db_cur = 0;
     uint32_t scratch_write_addr;
+    // Value of the nonposted-writes-issued counter right after the write that last sourced from each buffer.
+    // Waiting on it before refilling that buffer replaces the global flush.
+    uint32_t buf_writes_issued[scratch_db_max_nbuf] = {};
+    uint32_t buf_written_mask = 0;
     read_wlength -= amt_read;
     while (read_wlength != 0) {
         uint32_t read_length = (read_wlength > max_batch_size) ? max_batch_size : static_cast<uint32_t>(read_wlength);
         read_wlength -= read_length;
         while (read_length != 0) {
-            // This ensures that writes from prior iteration are done
-            // TODO(pgk); we can do better on WH w/ tagging
-            noc_async_writes_flushed();
+            uint32_t db_next = db_cur + 1;
+            if (db_next == scratch_db_nbuf) {
+                db_next = 0;
+            }
 
-            db_toggle ^= 1;
-            scratch_read_addr = scratch_db_top[db_toggle];
-            scratch_write_addr = scratch_db_top[db_toggle ^ 1];
+            // Only the write that previously sourced from buf[db_next] has to be out of the way, not every
+            // outstanding write. With more than two buffers that write is several iterations old.
+            if (buf_written_mask & (1u << db_next)) {
+                while (!noc_nonposted_writes_sent_at_count(noc_index, buf_writes_issued[db_next]));
+            }
+
+            scratch_read_addr = scratch_db_base + db_next * scratch_db_buf_size;
+            scratch_write_addr = scratch_db_base + db_cur * scratch_db_buf_size;
 
             uint32_t amt_to_write = amt_read;
-            amt_to_read = (scratch_db_half_size > read_length) ? read_length : scratch_db_half_size;
+            amt_to_read = (scratch_db_buf_size > read_length) ? read_length : scratch_db_buf_size;
             amt_read = 0;
             while (amt_to_read >= page_size) {
                 uint64_t noc_addr = addr_gen.get_noc_addr(page_id);
@@ -1132,11 +1167,15 @@ uint32_t process_relay_paged_cmd(uintptr_t cmd_ptr, uint32_t& downstream__data_p
             uint32_t npages =
                 write_pages_to_dispatcher<0, false>(downstream_data_ptr, scratch_write_addr, amt_to_write);
             DispatchRelayInlineState::cb_writer.release_pages(npages, downstream_data_ptr, /*round_to_page_size*/ true);
+            buf_writes_issued[db_cur] = noc_get_nonposted_writes_issued(noc_index);
+            buf_written_mask |= (1u << db_cur);
 
             read_length -= amt_read;
 
             // TODO(pgk); we can do better on WH w/ tagging
             noc_async_read_barrier();
+
+            db_cur = db_next;
         }
     }
 
@@ -1144,7 +1183,7 @@ uint32_t process_relay_paged_cmd(uintptr_t cmd_ptr, uint32_t& downstream__data_p
     // Note that we may write less than full pages despite reading full pages based on length_adjust
     // Expectation is that the gain from reading less is small to 0, revisit as needed
     ASSERT(length_adjust < page_size);
-    scratch_write_addr = scratch_db_top[db_toggle];
+    scratch_write_addr = scratch_db_base + db_cur * scratch_db_buf_size;
     uint32_t amt_to_write = amt_read - length_adjust;
     uint32_t npages = write_pages_to_dispatcher<1, true>(downstream_data_ptr, scratch_write_addr, amt_to_write);
 

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -201,7 +201,7 @@ const uint32_t scratch_db_top[2] = {scratch_db_base0, scratch_db_base1};
 // The extra buffer only pays for itself while each one still holds a large read chunk. noc_async_read_barrier()
 // below drains every outstanding read each iteration, so a shorter chunk means fewer reads in flight per barrier,
 // and past some point that costs more than the removed flush. Measured on Wormhole with a 64 MB paged read from
-// DRAM: the worker prefetcher (128 KB scratch, 3x43648) gains 5% at 2 KB pages, while the eth prefetcher (19 KB
+// DRAM: the worker prefetcher (128 KB scratch, 3x43680) gains 5% at 2 KB pages, while the eth prefetcher (19 KB
 // scratch, 3x6464) loses 9% and is fastest left as a plain double buffer. So derive the depth from the scratch
 // size rather than fixing it.
 constexpr uint32_t scratch_db_ring_nbuf = 3;

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -1107,6 +1107,17 @@ uint32_t process_relay_paged_cmd(uintptr_t cmd_ptr, uint32_t& downstream__data_p
             cmd_ptr, downstream_data_ptr, page_id, base_addr, page_size, pages, length_adjust);
     }
 
+    // The loop below sizes its reads from a runtime buffer size, which costs the compiler the page_size != 0
+    // fact it gets for free when that size is a constant, and the read loop is the whole cost at small pages.
+    // Handing the fact back is worth 8.6% at 32 B pages and 6.1% at 256 B on the worker prefetcher; it is a
+    // no-op wherever the two candidate buffer sizes are equal and the ternary below folds to a constant.
+    // A zero page_size would spin the read loop forever regardless, so assuming it away costs no safety, but
+    // assert it so watcher builds report a malformed command rather than hanging.
+    ASSERT(page_size != 0);
+    if (page_size == 0) {
+        __builtin_unreachable();
+    }
+
     // Use the deeper ring when a page fits in one of its buffers, otherwise fall back to the two-buffer split.
     // Both the count and the size come from the same test: keying the size off scratch_db_nbuf instead would
     // make the two cases indistinguishable whenever scratch_db_max_nbuf is 2, handing the fallback a buffer

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -191,16 +191,28 @@ const uint32_t scratch_db_top[2] = {scratch_db_base0, scratch_db_base1};
 // about to read into, because that buffer sourced the immediately preceding write; that flush costs ~10% of the
 // prefetcher's time on large transfers. A third buffer makes the write being waited on two iterations old, so
 // the wait is normally already satisfied by the time it is reached. Three measured best on Wormhole; four is
-// slower because the buffers get small enough to coarsen the read/write overlap.
+// slower, for the same reason the depth is capped by the scratch size below.
 // The ring shares the L1 region used by the legacy double buffer above; only one scheme is live per command.
 // A page has to fit in a single buffer, so the ring is only usable for pages up to scratch_db_ring_buf_size.
 // Larger pages keep the historical two-buffer split: process_relay_paged_cmd_large is only correct for
 // page_size > scratch_db_half_size (it computes page_size - amt_read, which underflows below that), so the
 // range in between must stay on this loop rather than being pushed down to the large-page path.
-constexpr uint32_t scratch_db_max_nbuf = 3;
-// Align down so the ring works for a scratch size that does not divide evenly by the buffer count; an unaligned
-// buffer stride would misalign every NoC read and write issued from it.
-constexpr uint32_t scratch_db_buf_align = 4096;
+//
+// The extra buffer only pays for itself while each one still holds a large read chunk. noc_async_read_barrier()
+// below drains every outstanding read each iteration, so a shorter chunk means fewer reads in flight per barrier,
+// and past some point that costs more than the removed flush. Measured on Wormhole with a 64 MB paged read from
+// DRAM: the worker prefetcher (128 KB scratch, 3x43648) gains 5% at 2 KB pages, while the eth prefetcher (19 KB
+// scratch, 3x6464) loses 9% and is fastest left as a plain double buffer. So derive the depth from the scratch
+// size rather than fixing it.
+constexpr uint32_t scratch_db_ring_nbuf = 3;
+constexpr uint32_t scratch_db_min_ring_buf_size = 32 * 1024;
+constexpr uint32_t scratch_db_max_nbuf =
+    (scratch_db_size / scratch_db_ring_nbuf >= scratch_db_min_ring_buf_size) ? scratch_db_ring_nbuf : 2;
+// Align down so the ring works for a scratch size that does not divide evenly by the buffer count. Only the NoC
+// read/write alignment is required here: the buffers feed a byte stream into the dispatcher, and its credit
+// accounting is derived from downstream_data_ptr rather than from the transfer size (see
+// write_pages_to_dispatcher), so a buffer need not be a whole number of dispatcher pages.
+constexpr uint32_t scratch_db_buf_align = DRAM_ALIGNMENT > L1_ALIGNMENT ? DRAM_ALIGNMENT : L1_ALIGNMENT;
 constexpr uint32_t scratch_db_ring_buf_size =
     (scratch_db_size / scratch_db_max_nbuf) / scratch_db_buf_align * scratch_db_buf_align;
 static_assert(scratch_db_max_nbuf >= 2, "relay_paged needs at least a double buffer");
@@ -1096,9 +1108,12 @@ uint32_t process_relay_paged_cmd(uintptr_t cmd_ptr, uint32_t& downstream__data_p
     }
 
     // Use the deeper ring when a page fits in one of its buffers, otherwise fall back to the two-buffer split.
-    const uint32_t scratch_db_nbuf = (page_size <= scratch_db_ring_buf_size) ? scratch_db_max_nbuf : 2;
-    const uint32_t scratch_db_buf_size =
-        (scratch_db_nbuf == scratch_db_max_nbuf) ? scratch_db_ring_buf_size : scratch_db_half_size;
+    // Both the count and the size come from the same test: keying the size off scratch_db_nbuf instead would
+    // make the two cases indistinguishable whenever scratch_db_max_nbuf is 2, handing the fallback a buffer
+    // smaller than a page, which never advances the read loop.
+    const bool page_fits_in_ring_buf = page_size <= scratch_db_ring_buf_size;
+    const uint32_t scratch_db_nbuf = page_fits_in_ring_buf ? scratch_db_max_nbuf : 2;
+    const uint32_t scratch_db_buf_size = page_fits_in_ring_buf ? scratch_db_ring_buf_size : scratch_db_half_size;
 
     auto addr_gen = TensorAccessor(tensor_accessor::make_interleaved_dspec<is_dram>(), base_addr, page_size);
 
@@ -1129,9 +1144,12 @@ uint32_t process_relay_paged_cmd(uintptr_t cmd_ptr, uint32_t& downstream__data_p
     uint32_t db_cur = 0;
     uint32_t scratch_write_addr;
     // Value of the nonposted-writes-issued counter right after the write that last sourced from each buffer.
-    // Waiting on it before refilling that buffer replaces the global flush.
-    uint32_t buf_writes_issued[scratch_db_max_nbuf] = {};
-    uint32_t buf_written_mask = 0;
+    // Waiting on it before refilling that buffer replaces the global flush. At depth two the buffer being
+    // refilled always sourced the immediately preceding write, so there is nothing to be gained over a flush
+    // and the bookkeeping is compiled out.
+    constexpr bool track_writes_per_buf = scratch_db_max_nbuf > 2;
+    [[maybe_unused]] uint32_t buf_writes_issued[scratch_db_max_nbuf] = {};
+    [[maybe_unused]] uint32_t buf_written_mask = 0;
     read_wlength -= amt_read;
     while (read_wlength != 0) {
         uint32_t read_length = (read_wlength > max_batch_size) ? max_batch_size : static_cast<uint32_t>(read_wlength);
@@ -1144,8 +1162,14 @@ uint32_t process_relay_paged_cmd(uintptr_t cmd_ptr, uint32_t& downstream__data_p
 
             // Only the write that previously sourced from buf[db_next] has to be out of the way, not every
             // outstanding write. With more than two buffers that write is several iterations old.
-            if (buf_written_mask & (1u << db_next)) {
-                while (!noc_nonposted_writes_sent_at_count(noc_index, buf_writes_issued[db_next]));
+            if constexpr (track_writes_per_buf) {
+                if (buf_written_mask & (1u << db_next)) {
+                    WAYPOINT("RPBW");
+                    while (!noc_nonposted_writes_sent_at_count(noc_index, buf_writes_issued[db_next]));
+                    WAYPOINT("RPBD");
+                }
+            } else {
+                noc_async_writes_flushed();
             }
 
             scratch_read_addr = scratch_db_base + db_next * scratch_db_buf_size;
@@ -1167,8 +1191,10 @@ uint32_t process_relay_paged_cmd(uintptr_t cmd_ptr, uint32_t& downstream__data_p
             uint32_t npages =
                 write_pages_to_dispatcher<0, false>(downstream_data_ptr, scratch_write_addr, amt_to_write);
             DispatchRelayInlineState::cb_writer.release_pages(npages, downstream_data_ptr, /*round_to_page_size*/ true);
-            buf_writes_issued[db_cur] = noc_get_nonposted_writes_issued(noc_index);
-            buf_written_mask |= (1u << db_cur);
+            if constexpr (track_writes_per_buf) {
+                buf_writes_issued[db_cur] = noc_get_nonposted_writes_issued(noc_index);
+                buf_written_mask |= (1u << db_cur);
+            }
 
             read_length -= amt_read;
 


### PR DESCRIPTION
### PR Category

Performance

### Summary

`process_relay_paged_cmd` streams through a two-buffer scratch double buffer. Because the buffer it is about to read into sourced the immediately preceding write to the dispatcher, every iteration has to call `noc_async_writes_flushed()` first, which waits on *all* outstanding writes.

Instrumenting the prefetcher on a 64 MB interleaved read (8 KB pages) shows where its time actually goes, per transfer:

| stage | cycles | share |
|---|---|---|
| write to dispatcher | 3,254,138 | 76.5% |
| `noc_async_writes_flushed` | 435,451 | **10.2%** |
| source read issue | 365,338 | 8.6% |
| credit wait (`acquire_pages`) | 35,285 | 0.8% |
| source read wait | 18,529 | 0.4% |

The prefetcher is ~100% busy and is neither credit-gated nor source-latency bound, so that flush is the removable cost.

This replaces the global flush with a wait on just the buffer being refilled — snapshot `noc_get_nonposted_writes_issued()` after each write, wait via `noc_nonposted_writes_sent_at_count()`. That is the same pairing `CBReaderWithReleasePolicy::release_block_pages` already uses. Deepening the scratch to three buffers then makes the write being waited on two iterations old, so the wait is normally already satisfied when reached.

The depth is derived from the prefetcher's scratch size rather than fixed at three, because the ring only pays off while each buffer still holds a large read chunk (see "Why the depth is derived" below). The worker prefetcher's 128 KB scratch becomes a 3-buffer ring of 43680 B on Wormhole (43648 B on Blackhole, where the DRAM alignment is 64). The Ethernet prefetcher's 19 KB scratch stays a 2-buffer split of 9728 B, which is byte-identical to today.

Wormhole, 64 MB `EnqueueReadBuffer` from interleaved DRAM, Gi/s:

| worker prefetcher | 32 B | 64 B | 128 B | 256 B | 512 B | 1 KB | 2 KB |
|---|---|---|---|---|---|---|---|
| before | 0.658 | 1.270 | 2.372 | 4.173 | 6.792 | 8.043 | 9.300 |
| after | 0.647 | 1.253 | 2.364 | 4.225 | 7.019 | 8.308 | 9.844 |

+3.3% at 1 KB and +5.9% at 2 KB, tapering to a 1.8% loss at 32 B. That residual is where the amortization ceiling puts it: a 43680 B chunk holds 1365 pages at 45 ns each, so all per-chunk work (flush, barrier, credit release) is worth 1-3% there, and no page-size gate on the ring is warranted. Ethernet dispatch ends up above its pre-change baseline at every page size, by 3.3% at 32 B falling to 0.1% at 2 KB.

An earlier revision of this branch (three buffers unconditionally, aligned to 4096, so 40960 B on the worker) measured 13.17-13.28 -> 16.46-16.80 Gi/s on a 64 MB pinned DRAM read at 8 KB pages with three processes each, and 15.09-15.24 -> 17.09-18.31 Gi/s reading from L1. That setup has not been re-run since the buffers grew to 43680 B.

### Notes for reviewers

**Resource footprint is unchanged, and per-write demand goes down.** The ring is carved out of the existing scratch region — `prefetch_scratch_db_size` is untouched, so no extra L1. Each write to the dispatcher gets *smaller* (42.6 KB vs 64 KB), which moves further inside what the downstream CB can grant at once. That limit is tighter than the `scratch_size < 3 * downstream_cb_block_size` comment in `write_pages_to_dispatcher` suggests: with 4 blocks, one may be filling and the previous may be awaiting flush, so only ~2 blocks are really grantable.

**The large-page threshold is deliberately left alone — please check this bit.** It is tempting to key the `process_relay_paged_cmd_large` dispatch off the new ring buffer size, since the ring loop cannot make progress on a page bigger than one buffer. That is wrong: `process_relay_paged_cmd_large` computes `page_size - amt_read` where `amt_read` can be up to `scratch_db_half_size`, so it underflows for any page below the half size, over-reads past the end of a page, and issues reads with a ~4 G length. I hit exactly that during development and it hung the NoC hard enough to take the host down. Instead, pages larger than a ring buffer fall back to the historical two-buffer split, so the range between the ring buffer size and the half size keeps byte-identical current behavior.

**Why the depth is derived from the scratch size.** Measured at constant buffer size, throughput saturates at three buffers; four is slower because the buffers get small enough to coarsen the read/write overlap. The same effect bounds how small a buffer is worth having: `noc_async_read_barrier()` drains every outstanding read each iteration, so a shorter chunk means fewer reads in flight per barrier, and past some point that costs more than the removed flush. Splitting the Ethernet prefetcher's 19 KB scratch three ways crosses that point — at 3x4096 it lost 14-30%, and at 3x6464 (NoC-aligned, so nothing stranded) it still lost 9%. Hence the 32 KB per-buffer minimum: the worker keeps three buffers, Ethernet stays a plain double buffer. Growing total scratch instead of depth does not help either, since it only makes each buffer bigger, which hurts (512 KB total measured -7%). Size and depth are different variables and only depth is the lever here.

**Small pages needed the `page_size != 0` fact handed back.** Deriving the buffer size from the scratch size made it a runtime choice on the worker (43680 vs 65536 on Wormhole), which cost the compiler the `page_size != 0` fact it got for free while that size was a constant. At small pages the per-page read issue is the whole loop, so the lost fact showed up as a bandwidth regression; `ASSERT` plus `__builtin_unreachable` restores it, worth 8.6% at 32 B pages and 6.1% at 256 B. The hint folds away wherever the two candidate buffer sizes are equal.

**Testing.**

- Wormhole: `unit_tests_dispatch --gtest_filter='*Buffer*'` matches the pre-change baseline exactly (155 run / 116 passed / 0 failed). With `TT_METAL_WATCHER=1`, which compiles in the `release_pages` credit assertion, on worker and on eth dispatch: `UnitMeshCQSingleCard*BufferFixture` 55/55 and `test_prefetcher PrefetcherTests` 27/27, no NoC sanitizer hits.
- Blackhole p150, `TT_METAL_WATCHER=1`, `unit_tests_dispatch --gtest_filter='*Buffer*'`: 156 run / 112 passed / 0 failed, no NoC sanitizer hits. The pass count differs from Wormhole because different cases skip per arch.
- Read data was additionally verified against a device-written ramp over the full 64 MB at 1 KB / 2 KB / 4 KB / 8 KB pages for both DRAM and L1 buffers.
- Reusing a ring buffer whose previous write is still outstanding is covered by the existing interleaved buffer reads. `copy_interleaved_buffer_to_completion_queue` emits one `relay_paged` for the whole transfer, so `Sending131072Pages` (16 MB) and the command-queue-sized cases wrap the ring hundreds of times and validate the data. `test_prefetcher`'s own paged reads top out near 70 KB and never wrap, so that coverage comes from the buffer suite rather than from the prefetcher microbenchmark.
- Added `TestPagesAtRelayPagedScratchThresholds`, which reads buffers whose page size sits one alignment either side of the ring buffer size, at the aligned-down half of the scratch, and one alignment above the half. Those are the two layout switches plus the handoff to `process_relay_paged_cmd_large`, and nothing sat on either side of the first two. The sizes derive from `scratch_db_size()` and the hal alignments — the same inputs the kernel derives its constants from — so the case tracks the thresholds on both worker and eth dispatch rather than hardcoding them, and 8 pages apiece makes the ring cases go around the ring several times. On Blackhole (128 KB scratch, 64 B alignment) that resolves to 43584 and 43648 on the ring, 43712 and 65536 on the fallback split, and 65600 on the large-page path. A mis-selection here hangs rather than corrupts — the read loop reads zero pages per pass — which is the failure mode I hit during development.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jbauman/prefetch-relay-paged-scratch-ring)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jbauman/prefetch-relay-paged-scratch-ring)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jbauman/prefetch-relay-paged-scratch-ring)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jbauman/prefetch-relay-paged-scratch-ring)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=jbauman/prefetch-relay-paged-scratch-ring)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:jbauman/prefetch-relay-paged-scratch-ring)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jbauman/prefetch-relay-paged-scratch-ring)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jbauman/prefetch-relay-paged-scratch-ring)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jbauman/prefetch-relay-paged-scratch-ring)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jbauman/prefetch-relay-paged-scratch-ring)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jbauman/prefetch-relay-paged-scratch-ring)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jbauman/prefetch-relay-paged-scratch-ring)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jbauman/prefetch-relay-paged-scratch-ring)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jbauman/prefetch-relay-paged-scratch-ring)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jbauman/prefetch-relay-paged-scratch-ring)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jbauman/prefetch-relay-paged-scratch-ring)

