### PR TITLE
[quasar] pack_untilize tiny tiles compute api bringup

### DIFF
--- a/tests/tt_metal/tt_metal/llk/test_golden_impls.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_golden_impls.cpp
@@ -11,6 +11,7 @@
 #include <set>
 
 #include <tt_stl/assert.hpp>
+#include <cstdint>
 #include "test_golden_impls.hpp"
 #include "tests/tt_metal/test_utils/packing.hpp"
 
@@ -18,16 +19,18 @@ using std::vector;
 
 namespace unit_tests::compute {
 
-std::vector<uint32_t> gold_standard_untilize(const std::vector<uint32_t>& src_vec, const GoldenConfig& config) {
-    vector<uint32_t> dst_vec;
+std::vector<std::uint32_t> gold_standard_untilize(
+    const std::vector<std::uint32_t>& src_vec, const GoldenConfig& config) {
+    vector<std::uint32_t> dst_vec;
 
     int num_tile_rows = config.num_tiles_r_dim;
     int num_tile_cols = config.num_tiles_c_dim;
     // Number of uint32 words per face row: face_c_dim elements × datum_bytes / 4 bytes per uint32
     // BF16 (datum_bytes=2): 16*2/4 = 8  FP8 (datum_bytes=1): 16*1/4 = 4
     int num_c_dim = config.face_c_dim * static_cast<int>(config.datum_bytes) / 4;
-    // Standard 16x16 face size in uint32 words
-    int face_size = 16 * 16 * static_cast<int>(config.datum_bytes) / 4;
+    // Face size in uint32 words. A tiny tile is stored compactly: its faces are only face_r_dim
+    // rows tall and sit back to back, rather than occupying full 16x16 slots inside a 32x32 tile.
+    int face_size = (config.tiny_tile ? config.face_r_dim : 16) * 16 * static_cast<int>(config.datum_bytes) / 4;
     int tile_size = face_size * (config.tiny_tile ? config.num_faces : 4);
 
     std::set<int> ind;
@@ -39,7 +42,7 @@ std::vector<uint32_t> gold_standard_untilize(const std::vector<uint32_t>& src_ve
         int physical_start_for_tile_row = tile_start_index * tile_size;
 
         // Iterate over tile columns 32 times (naive, but simple for validation)
-        uint32_t num_iterations = (config.num_faces > 2) ? 2 : 1;
+        std::uint32_t num_iterations = (config.num_faces > 2) ? 2 : 1;
         for (int x = 0; x < num_iterations; x++) {
             for (int i = 0; i < config.face_r_dim; i++) {  // num rows in a face
                 for (int j = 0; j < num_tile_cols; j++) {  // num columns top two faces
@@ -70,8 +73,8 @@ std::vector<uint32_t> gold_standard_untilize(const std::vector<uint32_t>& src_ve
     return dst_vec;
 }
 
-std::vector<uint32_t> gold_standard_tilize(const std::vector<uint32_t>& src_vec, const GoldenConfig& config) {
-    std::vector<uint32_t> dst_vec;
+std::vector<std::uint32_t> gold_standard_tilize(const std::vector<std::uint32_t>& src_vec, const GoldenConfig& config) {
+    std::vector<std::uint32_t> dst_vec;
 
     int num_rows = config.num_tiles_r_dim * config.face_r_dim * (config.num_faces > 2 ? 2 : 1);
     // Number of uint32 words per row: face_c_dim elements × (faces across) × datum_bytes / 4 bytes per uint32
@@ -122,8 +125,8 @@ std::vector<uint32_t> gold_standard_tilize(const std::vector<uint32_t>& src_vec,
 // Templated on the element type: uint16_t holds BF16 bit-patterns,
 // uint32_t holds Float32 bit-patterns or Int32.
 template <typename T>
-std::vector<T> gold_transpose_wh(const std::vector<T>& src_vec, const std::vector<uint32_t>& shape) {
-    vector<uint32_t> shapeT{shape[0], shape[1], shape[3], shape[2]};
+std::vector<T> gold_transpose_wh(const std::vector<T>& src_vec, const std::vector<std::uint32_t>& shape) {
+    vector<std::uint32_t> shapeT{shape[0], shape[1], shape[3], shape[2]};
     TensAddr addr(shape);
     TensAddr addrt(shapeT);
 
@@ -144,21 +147,21 @@ std::vector<T> gold_transpose_wh(const std::vector<T>& src_vec, const std::vecto
     return transposed;
 }
 
-template std::vector<uint16_t> gold_transpose_wh<uint16_t>(
-    const std::vector<uint16_t>& src_vec, const std::vector<uint32_t>& shape);
-template std::vector<uint32_t> gold_transpose_wh<uint32_t>(
-    const std::vector<uint32_t>& src_vec, const std::vector<uint32_t>& shape);
+template std::vector<std::uint16_t> gold_transpose_wh<std::uint16_t>(
+    const std::vector<std::uint16_t>& src_vec, const std::vector<std::uint32_t>& shape);
+template std::vector<std::uint32_t> gold_transpose_wh<std::uint32_t>(
+    const std::vector<std::uint32_t>& src_vec, const std::vector<std::uint32_t>& shape);
 
 // input shape.x is assumed to have the full number of elements in bfloat16
 // src_vec is expected to be untilized
 // result is also untilized
-std::vector<uint16_t> gold_reduce_h(
-    const std::vector<uint16_t>& src_vec,
-    const std::vector<uint32_t>& shape,
+std::vector<std::uint16_t> gold_reduce_h(
+    const std::vector<std::uint16_t>& src_vec,
+    const std::vector<std::uint32_t>& shape,
     float scaler,
-    uint8_t red_type,
+    std::uint8_t red_type,
     bool zeropad) {
-    vector<uint32_t> shape_dst{shape[0], shape[1], 1, shape[3]};
+    vector<std::uint32_t> shape_dst{shape[0], shape[1], 1, shape[3]};
     TT_FATAL(shape[2] > 0, "Error");
     if (zeropad) {
         shape_dst[2] = 32;
@@ -166,7 +169,7 @@ std::vector<uint16_t> gold_reduce_h(
     TensAddr addr(shape);
     TensAddr addr_dst(shape_dst);
 
-    vector<uint16_t> reduced(addr_dst.numel());
+    vector<std::uint16_t> reduced(addr_dst.numel());
     std::fill(reduced.begin(), reduced.end(), 0);
     for (int n = 0; n < shape[0]; n++) {
         for (int c = 0; c < shape[1]; c++) {
@@ -182,7 +185,7 @@ std::vector<uint16_t> gold_reduce_h(
                     }
                 }
                 auto dest_offs = addr_dst.offs(n, c, 0, w);
-                reduced[dest_offs] = std::bit_cast<uint16_t>(bfloat16(sum * scaler));
+                reduced[dest_offs] = std::bit_cast<std::uint16_t>(bfloat16(sum * scaler));
             }
         }
     }
@@ -190,16 +193,20 @@ std::vector<uint16_t> gold_reduce_h(
     return reduced;
 };
 
-std::vector<uint16_t> gold_reduce_w(
-    const vector<uint16_t>& src_vec, const std::vector<uint32_t>& shape, float scaler, uint8_t red_type, bool zeropad) {
-    vector<uint32_t> shape_dst{shape[0], shape[1], shape[2], 1};
+std::vector<std::uint16_t> gold_reduce_w(
+    const vector<std::uint16_t>& src_vec,
+    const std::vector<std::uint32_t>& shape,
+    float scaler,
+    std::uint8_t red_type,
+    bool zeropad) {
+    vector<std::uint32_t> shape_dst{shape[0], shape[1], shape[2], 1};
     if (zeropad) {
         shape_dst[3] = 32;
     }
     TensAddr addr(shape);
     TensAddr addr_dst(shape_dst);
 
-    vector<uint16_t> reduced(addr_dst.numel());
+    vector<std::uint16_t> reduced(addr_dst.numel());
     std::fill(reduced.begin(), reduced.end(), 0);
     for (int n = 0; n < shape[0]; n++) {
         for (int c = 0; c < shape[1]; c++) {
@@ -215,20 +222,20 @@ std::vector<uint16_t> gold_reduce_w(
                     }
                 }
                 auto dest_offs = addr_dst.offs(n, c, h, 0);
-                reduced[dest_offs] = std::bit_cast<uint16_t>(bfloat16(sum * scaler));
+                reduced[dest_offs] = std::bit_cast<std::uint16_t>(bfloat16(sum * scaler));
             }
         }
     }
     return reduced;
 }
 
-std::vector<uint16_t> gold_reduce_hw(
-    const std::vector<uint16_t>& src_vec,
-    const std::vector<uint32_t>& shape,
+std::vector<std::uint16_t> gold_reduce_hw(
+    const std::vector<std::uint16_t>& src_vec,
+    const std::vector<std::uint32_t>& shape,
     float scaler,
-    uint8_t red_type,
+    std::uint8_t red_type,
     bool zeropad) {
-    vector<uint32_t> shape_dst{shape[0], shape[1], 1, 1};
+    vector<std::uint32_t> shape_dst{shape[0], shape[1], 1, 1};
     if (zeropad) {
         shape_dst[2] = 32;
         shape_dst[3] = 32;
@@ -236,7 +243,7 @@ std::vector<uint16_t> gold_reduce_hw(
     TensAddr addr(shape);
     TensAddr addr_dst(shape_dst);
 
-    vector<uint16_t> reduced(addr_dst.numel());
+    vector<std::uint16_t> reduced(addr_dst.numel());
     std::fill(reduced.begin(), reduced.end(), 0);
     for (int n = 0; n < shape[0]; n++) {
         for (int c = 0; c < shape[1]; c++) {
@@ -253,18 +260,20 @@ std::vector<uint16_t> gold_reduce_hw(
                 }
             }
             auto dest_offs = addr_dst.offs(n, c, 0, 0);
-            reduced[dest_offs] = std::bit_cast<uint16_t>(bfloat16(sum * scaler));
+            reduced[dest_offs] = std::bit_cast<std::uint16_t>(bfloat16(sum * scaler));
         }
     }
 
     return reduced;
 }
 
-std::vector<uint32_t> gold_standard_tilize_w_elwadd(
-    const std::vector<uint32_t>& src0_vec, const std::vector<uint32_t>& src1_vec, const GoldenConfig& config) {
+std::vector<std::uint32_t> gold_standard_tilize_w_elwadd(
+    const std::vector<std::uint32_t>& src0_vec,
+    const std::vector<std::uint32_t>& src1_vec,
+    const GoldenConfig& config) {
     std::vector<bfloat16> unpacked_tilize_src0_vec =
-        tt::test_utils::unpack_vector<bfloat16, uint32_t>(gold_standard_tilize(src0_vec, config));
-    std::vector<bfloat16> unpacked_src1_vec = tt::test_utils::unpack_vector<bfloat16, uint32_t>(src1_vec);
+        tt::test_utils::unpack_vector<bfloat16, std::uint32_t>(gold_standard_tilize(src0_vec, config));
+    std::vector<bfloat16> unpacked_src1_vec = tt::test_utils::unpack_vector<bfloat16, std::uint32_t>(src1_vec);
 
     std::vector<bfloat16> result_vec(unpacked_tilize_src0_vec.size());
 
@@ -275,21 +284,23 @@ std::vector<uint32_t> gold_standard_tilize_w_elwadd(
         result_vec.begin(),
         [&](const bfloat16& lhs, const bfloat16& rhs) { return (static_cast<float>(lhs) + static_cast<float>(rhs)); });
 
-    return tt::test_utils::pack_vector<uint32_t, bfloat16>(result_vec);
+    return tt::test_utils::pack_vector<std::uint32_t, bfloat16>(result_vec);
 }
 
-std::vector<uint32_t> gold_standard_tilize_w_reduce_col_max(
-    const std::vector<uint32_t>& src0_vec, const std::vector<uint32_t>& src1_vec, const GoldenConfig& config) {
+std::vector<std::uint32_t> gold_standard_tilize_w_reduce_col_max(
+    const std::vector<std::uint32_t>& src0_vec,
+    const std::vector<std::uint32_t>& src1_vec,
+    const GoldenConfig& config) {
     // Extract scaler from src1_vec (first bfloat16 element)
     float scaler = 1.0f;
     if (!src1_vec.empty()) {
-        std::vector<bfloat16> scaler_unpacked = tt::test_utils::unpack_vector<bfloat16, uint32_t>(src1_vec);
+        std::vector<bfloat16> scaler_unpacked = tt::test_utils::unpack_vector<bfloat16, std::uint32_t>(src1_vec);
         scaler = static_cast<float>(scaler_unpacked[0]);
     }
 
     // Tilize the row-major input
-    std::vector<uint32_t> tilized = gold_standard_tilize(src0_vec, config);
-    std::vector<bfloat16> tilized_unpacked = tt::test_utils::unpack_vector<bfloat16, uint32_t>(tilized);
+    std::vector<std::uint32_t> tilized = gold_standard_tilize(src0_vec, config);
+    std::vector<bfloat16> tilized_unpacked = tt::test_utils::unpack_vector<bfloat16, std::uint32_t>(tilized);
 
     const int num_tile_rows = config.num_tiles_r_dim;
     const int num_tile_cols = config.num_tiles_c_dim;
@@ -334,14 +345,15 @@ std::vector<uint32_t> gold_standard_tilize_w_reduce_col_max(
         }
     }
 
-    return tt::test_utils::pack_vector<uint32_t, bfloat16>(result);
+    return tt::test_utils::pack_vector<std::uint32_t, bfloat16>(result);
 }
 
-std::vector<uint32_t> gold_standard_pack_rows(const std::vector<uint32_t>& src_vec, const PackRowsConfig& config) {
+std::vector<std::uint32_t> gold_standard_pack_rows(
+    const std::vector<std::uint32_t>& src_vec, const PackRowsConfig& config) {
     // Each row = 16 datums = 8 uint32_t (bfloat16 pairs)
     size_t num_uint32_to_extract = config.num_rows * 8;
     size_t actual_count = std::min(num_uint32_to_extract, src_vec.size());
-    vector<uint32_t> dst_vec(actual_count);
+    vector<std::uint32_t> dst_vec(actual_count);
     std::copy_n(src_vec.begin(), actual_count, dst_vec.begin());
     return dst_vec;
 }

--- a/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
@@ -953,17 +953,26 @@ static void run_quasar_tilize_untilize_test(
     bool dst_full_sync_en,
     bool fp32_dest_acc_en,
     tt::DataFormat input_data_format,
-    tt::DataFormat output_data_format) {
+    tt::DataFormat output_data_format,
+    std::uint32_t num_faces = 4,
+    std::uint32_t face_r_dim = 16) {
     bool is_tilize = (mode == QuasarTestMode::TILIZE);
 
     IDevice* dev = mesh_device->get_devices()[0];
     auto& cq = mesh_device->mesh_command_queue();
     const experimental::NodeCoord node{0, 0};
 
+    constexpr std::uint32_t face_c_dim = 16;
+    const bool tiny_tile = (num_faces != 4 || face_r_dim != 16);
+
     bool is_8bit_integer = (input_data_format == tt::DataFormat::Int8 || input_data_format == tt::DataFormat::UInt8);
     std::uint32_t num_tiles = num_tiles_r * num_tiles_c;
     std::uint32_t input_single_tile_size = tt::tile_size(input_data_format);
     std::uint32_t output_single_tile_size = tt::tile_size(output_data_format);
+    if (tiny_tile) {
+        input_single_tile_size = tt::datum_size(input_data_format) * num_faces * face_r_dim * face_c_dim;
+        output_single_tile_size = tt::datum_size(output_data_format) * num_faces * face_r_dim * face_c_dim;
+    }
     std::uint32_t src_dram_buffer_size = input_single_tile_size * num_tiles;
     std::uint32_t dst_dram_buffer_size = output_single_tile_size * num_tiles;
 
@@ -1002,6 +1011,13 @@ static void run_quasar_tilize_untilize_test(
         .num_entries = dfb_num_entries,
         .data_format_metadata = output_data_format,
     };
+    if (tiny_tile) {
+        const auto fg = tt::tt_metal::FaceGeometry{face_r_dim, num_faces};
+        if (!is_tilize) {
+            input_dfb_spec.unpack_face_geometry_metadata = fg;
+        }
+        output_dfb_spec.unpack_face_geometry_metadata = fg;
+    }
 
     experimental::KernelSpec reader_spec{
         .unique_id = READER,
@@ -1165,6 +1181,10 @@ static void run_quasar_tilize_untilize_test(
     ::unit_tests::compute::GoldenConfig golden_config = {
         .num_tiles_r_dim = static_cast<int>(num_tiles_r),
         .num_tiles_c_dim = static_cast<int>(num_tiles_c),
+        .face_r_dim = static_cast<int>(face_r_dim),
+        .face_c_dim = static_cast<int>(face_c_dim),
+        .num_faces = static_cast<int>(num_faces),
+        .tiny_tile = tiny_tile && !is_tilize,
         .datum_bytes = tt::datum_size(input_data_format)};
     auto golden = is_tilize ? ::unit_tests::compute::gold_standard_tilize(src_vec, golden_config)
                             : ::unit_tests::compute::gold_standard_untilize(src_vec, golden_config);
@@ -1248,6 +1268,54 @@ TEST_F(LLKQuasarMeshDeviceSingleCardFixture, QuasarComputePackUntilizeDst) {
                         input_data_format,
                         fp32_dest_acc_en ? tt::DataFormat::Float32 : input_data_format);
                 }
+            }
+        }
+    }
+}
+
+// Pack Untilize tiny tile (1x32, 2x32) via pack_untilize_block (unpack in the loop).
+// {num_faces, face_r_dim}: 1x32 = {2, 1}, 2x32 = {2, 2}.
+TEST_F(LLKQuasarMeshDeviceSingleCardFixture, QuasarComputePackUntilizeTinyTile) {
+    std::vector<vector<std::uint32_t>> test_configs = {{1, 1}, {2, 2}};
+    std::vector<vector<std::uint32_t>> geometries = {{2, 1}, {2, 2}};
+    for (auto& cfg : test_configs) {
+        for (auto& geo : geometries) {
+            for (bool dst_full_sync_en : {true, false}) {
+                run_quasar_tilize_untilize_test(
+                    this->devices_.at(0),
+                    cfg[0],
+                    cfg[1],
+                    QuasarTestMode::UNTILIZE,
+                    dst_full_sync_en,
+                    /*fp32_dest_acc_en=*/false,
+                    tt::DataFormat::Float16_b,
+                    tt::DataFormat::Float16_b,
+                    /*num_faces=*/geo[0],
+                    /*face_r_dim=*/geo[1]);
+            }
+        }
+    }
+}
+
+// Pack Untilize Dst tiny tile (1x32, 2x32): tiles pre-loaded into dest via copy_tile.
+// {num_faces, face_r_dim}: 1x32 = {2, 1}, 2x32 = {2, 2}.
+TEST_F(LLKQuasarMeshDeviceSingleCardFixture, QuasarComputePackUntilizeDstTinyTile) {
+    std::vector<vector<std::uint32_t>> test_configs = {{1, 1}, {2, 2}};
+    std::vector<vector<std::uint32_t>> geometries = {{2, 1}, {2, 2}};
+    for (auto& cfg : test_configs) {
+        for (auto& geo : geometries) {
+            for (bool dst_full_sync_en : {true, false}) {
+                run_quasar_tilize_untilize_test(
+                    this->devices_.at(0),
+                    cfg[0],
+                    cfg[1],
+                    QuasarTestMode::UNTILIZE_DST,
+                    dst_full_sync_en,
+                    /*fp32_dest_acc_en=*/false,
+                    tt::DataFormat::Float16_b,
+                    tt::DataFormat::Float16_b,
+                    /*num_faces=*/geo[0],
+                    /*face_r_dim=*/geo[1]);
             }
         }
     }

--- a/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
@@ -955,14 +955,14 @@ static void run_quasar_tilize_untilize_test(
     tt::DataFormat input_data_format,
     tt::DataFormat output_data_format,
     std::uint32_t num_faces = 4,
-    std::uint32_t face_r_dim = 16) {
+    std::uint32_t face_r_dim = tt::constants::FACE_HEIGHT) {
     bool is_tilize = (mode == QuasarTestMode::TILIZE);
 
     IDevice* dev = mesh_device->get_devices()[0];
     auto& cq = mesh_device->mesh_command_queue();
     const experimental::NodeCoord node{0, 0};
 
-    constexpr std::uint32_t face_c_dim = 16;
+    constexpr std::uint32_t face_c_dim = tt::constants::FACE_WIDTH;
     const bool tiny_tile = (num_faces != 4 || face_r_dim != 16);
 
     bool is_8bit_integer = (input_data_format == tt::DataFormat::Int8 || input_data_format == tt::DataFormat::UInt8);

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_pack_common_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_pack_common_api.h
@@ -42,21 +42,18 @@ inline void llk_pack_hw_configure(const std::uint32_t pack_output) {
             continue;
         }
 
-        // TODO: with multiple TCs are there multiple descriptors?
-        buffer_descriptor_u bd_val = {0};
-        bd_val.f.l1_addr_16B = get_local_dfb_interface(i).tc_slots[0].base_addr;
-        bd_val.f.format = static_cast<std::uint8_t>(l1_data_format);
-        bd_val.f.x_dim = ckernel::trisc::FACE_C_DIM;
-        bd_val.f.y_dim = pack_tile_face_r_dim[i];
-        bd_val.f.z_dim = pack_tile_num_faces[i];
+        const tdma_descriptor_t td = ckernel::trisc::construct_tdma_desc(
+            get_output_tensor_shape(i),
+            get_local_dfb_interface(i).tc_slots[0].base_addr,
+            pack_dst_format[i],
+            i,
+            pack_src_format[i]);
 
-        ckernel::trisc::validate_buffer_desc<ckernel::trisc::L1AccessMode::Continuous>(bd_val);
-        ckernel::trisc::_configure_buf_desc_table_(i, bd_val);
+        ckernel::trisc::_configure_buf_desc_table_(i, td.buf_desc);
     }
 
     tdma_descriptor_t td_val;
     td_val.reg_data_format = static_cast<std::uint8_t>(pack_src_format[output_id]);
-
     _llk_pack_hw_configure_<p_pacr::PACK0, EN_32BIT_DEST>(td_val, ckernel::ReluConfig::none());
 }
 

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_pack_untilize_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_pack_untilize_api.h
@@ -39,7 +39,7 @@ inline void llk_pack_untilize_init(std::uint32_t pack_output) {
 
     LLK_ASSERT(
         tensor_shape.total_num_faces() == ckernel::trisc::NUM_FACES ||
-            (tensor_shape.face_r_dim == 1 || tensor_shape.face_r_dim == 2),
+            (tensor_shape.total_num_faces() == 2 && (tensor_shape.face_r_dim == 1 || tensor_shape.face_r_dim == 2)),
         "only 1x32 and 2x32 tiny tiles supported for pack untilize on Quasar");
 
     if (tensor_shape.total_num_faces() == ckernel::trisc::NUM_FACES) {
@@ -88,7 +88,7 @@ inline void llk_pack_untilize(
 
     LLK_ASSERT(
         tensor_shape.total_num_faces() == ckernel::trisc::NUM_FACES ||
-            (tensor_shape.face_r_dim == 1 || tensor_shape.face_r_dim == 2),
+            (tensor_shape.total_num_faces() == 2 && (tensor_shape.face_r_dim == 1 || tensor_shape.face_r_dim == 2)),
         "only 1x32 and 2x32 tiny tiles supported for pack untilize on Quasar");
 
     const std::uint32_t y_stride = full_ct_dim * tensor_shape.num_faces_r_dim * tensor_shape.face_r_dim;

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_pack_untilize_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_pack_untilize_api.h
@@ -10,6 +10,7 @@
 #include "tensor_shape.h"
 #include "ckernel_template.h"
 #include "cpack_common.h"
+#include "llk_assert.h"
 #include "llk_defs.h"
 #include "llk_io.h"
 #include "llk_outputs.h"
@@ -36,7 +37,14 @@ inline void llk_pack_untilize_init(std::uint32_t pack_output) {
 
     const ckernel::TensorShape tensor_shape = get_output_tensor_shape(output_id);
 
-    if (tensor_shape.face_r_dim < ckernel::pack::PACR_STRIDE_OFFSET_ROWS) {
+    LLK_ASSERT(
+        tensor_shape.total_num_faces() == ckernel::trisc::NUM_FACES ||
+            (tensor_shape.face_r_dim == 1 || tensor_shape.face_r_dim == 2),
+        "only 1x32 and 2x32 tiny tiles supported for pack untilize on Quasar");
+
+    if (tensor_shape.total_num_faces() == ckernel::trisc::NUM_FACES) {
+        _llk_pack_untilize_init_<full_ct_dim, block_ct_dim>(output_id, tensor_shape);
+    } else {
         const tdma_descriptor_t td_val = ckernel::trisc::construct_tdma_desc<ckernel::trisc::L1AccessMode::Strided>(
             tensor_shape,
             get_local_dfb_interface(output_id).tc_slots[0].base_addr,
@@ -44,9 +52,8 @@ inline void llk_pack_untilize_init(std::uint32_t pack_output) {
             output_id,
             pack_src_format[output_id]);
         ckernel::trisc::_configure_buf_desc_table_(td_val.buf_desc_id, td_val.buf_desc);
+        _llk_pack_untilize_strided_init_<full_ct_dim, block_ct_dim>(output_id, tensor_shape);
     }
-
-    _llk_pack_untilize_init_<full_ct_dim, block_ct_dim>(output_id, tensor_shape);
 }
 
 /**
@@ -79,6 +86,11 @@ inline void llk_pack_untilize(
     // merging adjacent face-columns into a single output row. Hence we use num_faces_r_dim instead of num_faces for L1
     // strides
 
+    LLK_ASSERT(
+        tensor_shape.total_num_faces() == ckernel::trisc::NUM_FACES ||
+            (tensor_shape.face_r_dim == 1 || tensor_shape.face_r_dim == 2),
+        "only 1x32 and 2x32 tiny tiles supported for pack untilize on Quasar");
+
     const std::uint32_t y_stride = full_ct_dim * tensor_shape.num_faces_r_dim * tensor_shape.face_r_dim;
     const LocalDFBInterface& local_dfb_interface = get_local_dfb_interface(output_id);
     const std::uint32_t base_l1 = local_dfb_interface.tc_slots[local_dfb_interface.tc_idx].wr_entry_idx *
@@ -87,6 +99,10 @@ inline void llk_pack_untilize(
     for (std::uint32_t block_rt = 0; block_rt < block_rt_dim; block_rt++) {
         const std::uint32_t dest_idx = block_rt * block_ct_dim + tile_dst_rt_offset;
         const std::uint32_t l1_tile_idx = base_l1 + block_rt * y_stride + block_c_index * block_ct_dim;
-        _llk_pack_untilize_(dest_idx, l1_tile_idx);
+        if (tensor_shape.total_num_faces() == ckernel::trisc::NUM_FACES) {
+            _llk_pack_untilize_(dest_idx, l1_tile_idx);
+        } else {
+            _llk_pack_untilize_strided_<full_ct_dim>(output_id, tensor_shape, l1_tile_idx, dest_idx);
+        }
     }
 }

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_common_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_common_api.h
@@ -47,15 +47,17 @@ inline void llk_unpack_hw_configure(const std::uint32_t unpA_operand, const std:
         }
 
         // TODO: with multiple TCs are there multiple descriptors?
-        buffer_descriptor_u bd_val = {0};
-        bd_val.f.l1_addr_16B = get_local_dfb_interface(i).tc_slots[0].base_addr;
-        bd_val.f.format = static_cast<std::uint8_t>(l1_data_format);
-        bd_val.f.x_dim = ckernel::trisc::FACE_C_DIM;
-        bd_val.f.y_dim = unpack_tile_face_r_dim[i];
-        bd_val.f.z_dim = unpack_tile_num_faces[i];
+        // z_dim is derived from the tensor shape rather than the raw face count: the hardware only
+        // accepts z_dim of 1 or 4, so a non-square face grid (e.g. the 1x2 grid of a 1x32 tiny tile)
+        // has to be addressed one face at a time, which is also what the tiny-tile unpack MOP assumes.
+        const tdma_descriptor_t td = ckernel::trisc::construct_tdma_desc(
+            get_operand_tensor_shape(i),
+            get_local_dfb_interface(i).tc_slots[0].base_addr,
+            static_cast<std::uint32_t>(l1_data_format),
+            i,
+            static_cast<std::uint32_t>(unpack_dst_format[i]));
 
-        ckernel::trisc::validate_buffer_desc<ckernel::trisc::L1AccessMode::Continuous>(bd_val);
-        ckernel::trisc::_configure_buf_desc_table_(i, bd_val);
+        ckernel::trisc::_configure_buf_desc_table_(i, td.buf_desc);
     }
 
     tdma_descriptor_t td_val_A, td_val_B;

--- a/tt_metal/tt-llk/tests/sources/quasar/pack_untilize_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/pack_untilize_quasar_test.cpp
@@ -358,7 +358,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
                     }
                     else
                     {
-                        _llk_pack_untilize_strided_<FULL_CT_DIM>(buf_desc_id, tensor_shape, y * FULL_CT_DIM, 0 /*src_tile_idx*/);
+                        _llk_pack_untilize_strided_<FULL_CT_DIM>(buf_desc_id, tensor_shape, y * y_stride_external, 0 /*src_tile_idx*/);
                     }
                 }
             }
@@ -375,7 +375,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
                     }
                     else
                     {
-                        _llk_pack_untilize_strided_<FULL_CT_DIM>(buf_desc_id, tensor_shape, y * FULL_CT_DIM, 0 /*src_tile_idx*/);
+                        _llk_pack_untilize_strided_<FULL_CT_DIM>(buf_desc_id, tensor_shape, y * y_stride_external, 0 /*src_tile_idx*/);
                     }
                     _llk_pack_dest_dvalid_section_done_<dest_sync, is_fp32_dest_acc_en>();
                 }

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_pack_untilize.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_pack_untilize.h
@@ -332,12 +332,11 @@ inline void _llk_pack_untilize_strided_(
     else
     {
         // PACR_STRIDE quirk: need to set BD as 1x1x16 to index rows as tiles
-        // This means that for input tensors with RT_DIM > 1, we need to multiply the l1 tile index calculation buy face_r_dim.
-        TT_SET_DST_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, p_pacr::PACK0, l1_tile_idx * tensor_shape.num_faces_c_dim * tensor_shape.face_r_dim);
+        // This means that for input tensors with RT_DIM > 1, we need to multiply the l1 tile index calculation by face_r_dim.
+        // This scaling is done in external stride calculations, mirroring the 32x32 case.
+        TT_SET_DST_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, p_pacr::PACK0, l1_tile_idx * tensor_shape.num_faces_c_dim);
         TT_SET_SRC_TILE_FACE_ROW_IDX(
-            p_set_inc_sel::TILE_SEL,
-            p_pacr::PACK0,
-            src_tile_idx * ckernel::pack::PACR_STRIDE_OFFSET_ROWS * tensor_shape.total_num_faces() * tensor_shape.face_r_dim);
+            p_set_inc_sel::TILE_SEL, p_pacr::PACK0, src_tile_idx * ckernel::pack::PACR_STRIDE_OFFSET_ROWS * tensor_shape.num_faces_c_dim);
         ckernel::ckernel_template::run_bank0_sw_cntl(instrn_buffer);
     }
 }


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

### Summary
relates to #49309 
- ported BD programming changes to unpack/pack hw configs
- updated pack_untilize llk api to call appropriate init and executor based on tile size
- added metal test for pack_untilize using 1x32, 2x32 tiles (tests single tile, 2x2 tiles format)

misc: modified pack_untilize llk in order to standardize block row stride with full-tile implementation (multiplication by face_r_dim is no longer done within the strided executor)

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jihoonyou/pack-untilize-api-bringup)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jihoonyou/pack-untilize-api-bringup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jihoonyou/pack-untilize-api-bringup)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jihoonyou/pack-untilize-api-bringup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=jihoonyou/pack-untilize-api-bringup)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:jihoonyou/pack-untilize-api-bringup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jihoonyou/pack-untilize-api-bringup)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jihoonyou/pack-untilize-api-bringup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jihoonyou/pack-untilize-api-bringup)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jihoonyou/pack-untilize-api-bringup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jihoonyou/pack-untilize-api-bringup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jihoonyou/pack-untilize-api-bringup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jihoonyou/pack-untilize-api-bringup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jihoonyou/pack-untilize-api-bringup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jihoonyou/pack-untilize-api-bringup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jihoonyou/pack-untilize-api-bringup)