### PR TITLE
[Bug fix] Fix DFB tile-counter staging overflow in dataflow_buffer_init

### DIFF
--- a/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_config.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_config.h
@@ -27,6 +27,10 @@ constexpr uint8_t TC_TENSIX_POOL_START = NUM_TENSIX_TILE_COUNTERS_FOR_DM;  // = 
 constexpr uint8_t NUM_REMAPPER_PAIRINGS = 64;
 constexpr uint8_t NUM_TXN_IDS = 4;
 constexpr uint8_t MAX_NUM_TILE_COUNTERS_TO_RR = 6;
+// Max tile counter ids that can be collected for one side (producer or consumer) of a DFB during
+// init, summed across that side's riscs. Bounded by TxnDFBDescriptor::tile_counters, the ISR
+// descriptor the collected ids are copied into, so the two must never diverge.
+constexpr uint8_t MAX_TILE_COUNTERS_PER_SIDE = 18;
 
 constexpr uint16_t TENSIX_RISC_OFFSET = 8; // First 8 represent DMs
 

--- a/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_init.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_init.h
@@ -216,10 +216,19 @@ FORCE_INLINE void setup_local_dfb_interfaces(uint32_t tt_l1_ptr* dfb_config_base
             volatile dfb_initializer_per_risc_t* per_risc_base =
                 reinterpret_cast<volatile dfb_initializer_per_risc_t*>(base_ptr + sizeof(dfb_initializer_t));
 
+            // Sized to the ISR descriptor these ids are copied into (see MAX_TILE_COUNTERS_PER_SIDE).
+            // The two sides are adjacent stack locals, so an unbounded fill of one silently
+            // overwrites the other's ids; the collection loops below must stay in bounds.
             uint8_t num_producer_tcs = 0;
-            uint8_t producer_tcs[16] = {};
+            uint8_t producer_tcs[dfb::MAX_TILE_COUNTERS_PER_SIDE] = {};
             uint8_t num_consumer_tcs = 0;
-            uint8_t consumer_tcs[16] = {};
+            uint8_t consumer_tcs[dfb::MAX_TILE_COUNTERS_PER_SIDE] = {};
+            // Only collect a side's ids when that side actually programs a TxnDFBDescriptor below.
+            // A side with no transaction ids (e.g. a Tensix-only consumer, which never gets one)
+            // would otherwise gather ids that are never read - wasted work that can also exceed the
+            // staging capacity, e.g. 6 producers x 4 ALL Tensix consumers needs 24 ids.
+            const bool collect_producer_tcs = init_ptr->producer_txn_descriptor.num_txn_ids > 0;
+            const bool collect_consumer_tcs = init_ptr->consumer_txn_descriptor.num_txn_ids > 0;
             for (uint8_t i = 0; i < num_riscs; i++) {
                 volatile dfb_initializer_per_risc_t* per_risc_ptr = per_risc_base + i;
 
@@ -255,11 +264,19 @@ FORCE_INLINE void setup_local_dfb_interfaces(uint32_t tt_l1_ptr* dfb_config_base
                         g_remapper_configurator.write_all_configs();
                     }
 
-                    for (uint8_t i = 0; i < per_risc_ptr->num_tcs_and_init.num_tcs_to_rr; i++) {
+                    for (uint8_t i = 0; collect_producer_tcs && i < per_risc_ptr->num_tcs_and_init.num_tcs_to_rr; i++) {
+                        ASSERT(num_producer_tcs < dfb::MAX_TILE_COUNTERS_PER_SIDE);
+                        if (num_producer_tcs >= dfb::MAX_TILE_COUNTERS_PER_SIDE) {
+                            break;
+                        }
                         producer_tcs[num_producer_tcs++] = per_risc_ptr->packed_tile_counter[i];
                     }
                 } else {
-                    for (uint8_t i = 0; i < per_risc_ptr->num_tcs_and_init.num_tcs_to_rr; i++) {
+                    for (uint8_t i = 0; collect_consumer_tcs && i < per_risc_ptr->num_tcs_and_init.num_tcs_to_rr; i++) {
+                        ASSERT(num_consumer_tcs < dfb::MAX_TILE_COUNTERS_PER_SIDE);
+                        if (num_consumer_tcs >= dfb::MAX_TILE_COUNTERS_PER_SIDE) {
+                            break;
+                        }
                         consumer_tcs[num_consumer_tcs++] = per_risc_ptr->packed_tile_counter[i];
                     }
                 }

--- a/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_interface.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_interface.h
@@ -140,7 +140,7 @@ inline LocalDFBInterface& get_local_dfb_interface(uint32_t logical_dfb_id) {
 // It is used by the ISR to understand which tile counters need to update which credits (post/ack)
 struct TxnDFBDescriptor {
     uint8_t num_counters;
-    dfb::PackedTileCounter tile_counters[18];
+    dfb::PackedTileCounter tile_counters[dfb::MAX_TILE_COUNTERS_PER_SIDE];
     union {
         uint8_t tiles_to_post;
         uint8_t tiles_to_ack;

--- a/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
+++ b/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
@@ -511,6 +511,10 @@ std::vector<uint8_t> DataflowBufferImpl::serialize_for_core(const CoreCoord& cor
         }
     }
 
+    // Mirrors the device's per-side tile-counter staging, which sums num_tcs_to_rr across that
+    // side's riscs in risc_mask order before copying the ids into a TxnDFBDescriptor.
+    uint32_t total_producer_tcs = 0;
+    uint32_t total_consumer_tcs = 0;
     // Write one dfb_initializer_per_risc_t per risc, in risc_mask order
     for (int bit = 0; bit < 16; bit++) {
         if (!(this->risc_mask & (1 << bit))) {
@@ -529,6 +533,7 @@ std::vector<uint8_t> DataflowBufferImpl::serialize_for_core(const CoreCoord& cor
         dfb_initializer_per_risc_t per_risc = {};
 
         per_risc.num_tcs_and_init.num_tcs_to_rr = rc->config.num_tcs_to_rr;
+        (rc->is_producer ? total_producer_tcs : total_consumer_tcs) += rc->config.num_tcs_to_rr;
         per_risc.num_tcs_and_init.tc_init_done = 0;  // set by device when this producer finishes TC init
         per_risc.num_tcs_and_init.broadcast_tc = rc->config.broadcast_tc;
         log_debug(tt::LogMetal, "Num tcs to rr: {}", rc->config.num_tcs_to_rr);
@@ -562,6 +567,28 @@ std::vector<uint8_t> DataflowBufferImpl::serialize_for_core(const CoreCoord& cor
         const auto* cfg_bytes = reinterpret_cast<const uint8_t*>(&per_risc);
         data.insert(data.end(), cfg_bytes, cfg_bytes + sizeof(per_risc));
     }
+
+    // A side only programs a TxnDFBDescriptor when it has transaction ids (implicit sync, and not
+    // Tensix-only). Such a side must fit the descriptor, otherwise the device would have to drop
+    // counter ids and the ISR would never credit them. Sides with no descriptor collect ids that
+    // are never read, so they are exempt.
+    TT_FATAL(
+        producer_txn_descriptor.num_txn_ids == 0 || total_producer_tcs <= ::dfb::MAX_TILE_COUNTERS_PER_SIDE,
+        "DFB {}: producer side needs {} tile counters ({} producers) but a transaction descriptor holds at "
+        "most {}.",
+        this->id,
+        total_producer_tcs,
+        this->config.num_producers,
+        static_cast<uint32_t>(::dfb::MAX_TILE_COUNTERS_PER_SIDE));
+    TT_FATAL(
+        consumer_txn_descriptor.num_txn_ids == 0 || total_consumer_tcs <= ::dfb::MAX_TILE_COUNTERS_PER_SIDE,
+        "DFB {}: consumer side needs {} tile counters ({} consumers x {} producers) but a transaction "
+        "descriptor holds at most {}.",
+        this->id,
+        total_consumer_tcs,
+        this->config.num_consumers,
+        this->config.num_producers,
+        static_cast<uint32_t>(::dfb::MAX_TILE_COUNTERS_PER_SIDE));
 
     log_debug(tt::LogMetal, "Serialized DFB {} for core ({},{}) size: {}", this->id, core.x, core.y, data.size());
 


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

`DMTensixTest1xDFB6Sx4A_2_0/ImplicitSyncTrue` fails on Quasar due to a stack buffer overflow in DFB init. For an ALL consumer, `calculate_num_tile_counters` returns `num_producers` per consumer risc, so 6 producers × 4 Tensix consumers stages 24 tile-counter ids into `uint8_t consumer_tcs[16]` with no bounds check. The 8 overflow bytes land on the adjacent local `producer_tcs[16]`, destroying all six producer TC ids, the producer's `TxnDFBDescriptor` then holds garbage counters, the ISR credits the wrong ones, and the producer waits forever on its own TC.

Only implicit sync is affected, because the loop that *reads* `producer_tcs` is gated on `producer_txn_descriptor.num_txn_ids`, which is 0 with implicit sync off, the same overflow is inert there. Across the ALL-pattern sweep, staged ids = `num_consumers * num_producers`, and 6Sx4A (24) is the only case exceeding 16 (4Sx4A sits exactly at 16).

A Tensix-only consumer never gets a transaction descriptor, so its 24 ids were collected and then never read. The fix gates both collection loops on that side actually having a descriptor, removing the overflow at its source. They also now have bounds guards plus a host `TT_FATAL` as backstops.

### Notes for reviewers
- Verified passing on both the 1x3 and 2x3 Quasar emulators with the watcher on.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ymoussa/fix_dfb_consumer_tcs_overflow)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ymoussa/fix_dfb_consumer_tcs_overflow)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ymoussa/fix_dfb_consumer_tcs_overflow)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ymoussa/fix_dfb_consumer_tcs_overflow)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ymoussa/fix_dfb_consumer_tcs_overflow)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ymoussa/fix_dfb_consumer_tcs_overflow)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ymoussa/fix_dfb_consumer_tcs_overflow)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ymoussa/fix_dfb_consumer_tcs_overflow)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ymoussa/fix_dfb_consumer_tcs_overflow)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ymoussa/fix_dfb_consumer_tcs_overflow)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ymoussa/fix_dfb_consumer_tcs_overflow)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ymoussa/fix_dfb_consumer_tcs_overflow)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ymoussa/fix_dfb_consumer_tcs_overflow)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ymoussa/fix_dfb_consumer_tcs_overflow)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ymoussa/fix_dfb_consumer_tcs_overflow)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ymoussa/fix_dfb_consumer_tcs_overflow)