### PR TITLE
#51287: Fix heap buffer underflow in memory::pack_from_segments with contentless leading segment

### DIFF
--- a/tests/tt_metal/tt_metal/api/test_tt_memory.cpp
+++ b/tests/tt_metal/tt_metal/api/test_tt_memory.cpp
@@ -72,5 +72,47 @@ TEST(MemorySegmentOrdering, ContiguousCoalescesIntoSingleSpan) {
     EXPECT_EQ(m.data(), expected_data);
 }
 
+// Regression test for a heap buffer underflow in pack_from_segments(). Under DISCRETE loading a
+// span is only started for segments that have file contents, so if the *first* segment in address
+// order has none (a .bss-only PT_LOAD has p_filesz == 0, so zero content words) link_spans_ is
+// still empty when the accumulate step runs, and link_spans_.back() writes 8 bytes before the
+// start of the buffer. Such a segment carries no data, so it must simply contribute no span.
+TEST(MemorySegmentOrdering, DiscreteHandlesEmptyFirstSegmentInAddressOrder) {
+    // segments[0] is text (the loader requires the first segment to be text), placed high in
+    // memory; a .bss-only segment sits lower, so the address sort puts the empty one first.
+    const std::vector<word_t> text_contents = {0x1111'1111, 0x2222'2222};  // addr 0x2000, 2 words
+
+    std::vector<ElfFile::Segment> segments;
+    segments.emplace_back(std::span<const word_t>(text_contents), /*addr=*/0x2000, /*lma=*/0x2000, /*membytes=*/8);
+    // No file contents, but a non-zero memory image -- exactly a .bss-only PT_LOAD.
+    segments.emplace_back(std::span<const word_t>(), /*addr=*/0x1000, /*lma=*/0x1000, /*membytes=*/0x40);
+
+    const memory m = memory::from_segments(segments, memory::Loading::DISCRETE);
+
+    // The contentless segment contributes no span and no data; only text is emitted.
+    const std::vector<std::pair<std::uint64_t, std::uint32_t>> expected = {{0x2000, 2}};
+    EXPECT_EQ(span_order(m), expected);
+    EXPECT_EQ(m.num_spans(), 1u);
+    EXPECT_EQ(m.data(), text_contents);
+    EXPECT_EQ(m.get_text_addr(), 0x2000u);
+    EXPECT_EQ(m.get_text_size(), 8u);
+}
+
+// A contentless segment that does not sort first must also be dropped -- this already worked, and
+// guards that the underflow fix did not change the behaviour of the previously-reachable case.
+TEST(MemorySegmentOrdering, DiscreteDropsEmptyTrailingSegment) {
+    const std::vector<word_t> text_contents = {0x1111'1111, 0x2222'2222};  // addr 0x1000, 2 words
+
+    std::vector<ElfFile::Segment> segments;
+    segments.emplace_back(std::span<const word_t>(text_contents), /*addr=*/0x1000, /*lma=*/0x1000, /*membytes=*/8);
+    segments.emplace_back(std::span<const word_t>(), /*addr=*/0x2000, /*lma=*/0x2000, /*membytes=*/0x40);
+
+    const memory m = memory::from_segments(segments, memory::Loading::DISCRETE);
+
+    const std::vector<std::pair<std::uint64_t, std::uint32_t>> expected = {{0x1000, 2}};
+    EXPECT_EQ(span_order(m), expected);
+    EXPECT_EQ(m.data(), text_contents);
+}
+
 }  // namespace
 }  // namespace ll_api

--- a/tt_metal/llrt/tt_memory.cpp
+++ b/tt_metal/llrt/tt_memory.cpp
@@ -92,7 +92,15 @@ void memory::pack_from_segments(const std::string& path, const std::vector<ElfFi
         if (loading_ == Loading::DISCRETE ? !segment.contents.empty() : link_spans_.empty()) {
             link_spans_.emplace_back(segment.address, 0);
         }
-        link_spans_.back().len += segment.contents.size();
+        // For DISCRETE loads no span is created for a segment with no file contents, so
+        // link_spans_ is still empty if the *first* segment in address order has none -- a
+        // .bss-only PT_LOAD has p_filesz == 0, hence zero `contents` words. There is nothing to
+        // accumulate into in that case (contents.size() is 0 and the insert below is a no-op), and
+        // link_spans_.back() on an empty vector would write 8 bytes before the start of the
+        // buffer. Non-DISCRETE loads always emplace on the first iteration, so they are unaffected.
+        if (!link_spans_.empty()) {
+            link_spans_.back().len += segment.contents.size();
+        }
         data_.insert(data_.end(), segment.contents.begin(), segment.contents.end());
     }
 }


### PR DESCRIPTION
### PR Category
Bug fix

### Summary

Fixes a heap buffer underflow in `ll_api::memory::pack_from_segments` (`tt_metal/llrt/tt_memory.cpp:95` on `main`).

Under `Loading::DISCRETE`, a new `link_spans_` entry is only appended for segments that have file contents, but the very next line accumulates into `link_spans_.back()` unconditionally:

```cpp
if (loading_ == Loading::DISCRETE ? !segment.contents.empty() : link_spans_.empty()) {
    link_spans_.emplace_back(segment.address, 0);
}
link_spans_.back().len += segment.contents.size();   // <-- underflow
```

Segments are iterated in address-sorted order for `DISCRETE` loads (the `std::sort` just above). If the **first segment in address order has no file contents**, nothing has been appended yet, so `.back()` on the empty vector writes `span::len` **8 bytes before the start of the buffer** (`span` is `{uint64_t addr; size_t len}`, so `len` sits at offset +8).

A contentless segment is a real case, not a hypothetical: a `.bss`-only `PT_LOAD` has `p_filesz == 0`, and `tt_elffile.cpp` computes `file_words = (p_filesz + 3) / 4`, i.e. zero content words, while `membytes` stays non-zero. Nothing requires such a segment to be at a high address, so it can sort first.

**This is a memory-safety bug, not a data race.** ASan/TSan report it as a heap-use-after-free because the 8 bytes it stomps happened to belong to a block freed moments earlier on the same worker thread — that adjacency is a red herring.

### History (why now)

The bug is latent and pre-existing; two unrelated PRs changed only its *reachability*:

- #49053 (merged, `4962542`) removed a double-permutation of the segment map. That double-permutation cancelled the sort, which incidentally guaranteed the (always non-empty) text segment was processed first and so always created the first span. Removing it made the sort actually take effect and exposed this path. #49053 is correct and should stay.
- #50876 changed unrelated fabric buffer-slot compile-time args. That shifted an ELF's `PT_LOAD` layout just enough to put a zero-`filesz` segment first for the first time in CI, turning the latent bug into a deterministic TSAN failure: https://github.com/tenstorrent/tt-metal/actions/runs/30300943843/job/90095196136. It was reverted in #51287 purely to unblock; it was never the cause.

The fix belongs here in `tt_memory.cpp`, independent of the fabric change, so #50876 can be re-landed without reintroducing the failure.

**TSAN validation run:** the heavy `build-tsan` / `runtime-smoke-tests` jobs are gated to skip on plain `pull_request` events (by design, per this workflow's own header comment — full validation normally only runs on `main` pushes or in the merge queue). I manually dispatched Merge Gate (`workflow_dispatch`) on this branch to exercise the exact TSAN smoke job that failed originally: https://github.com/tenstorrent/tt-metal/actions/runs/30307851652

### The fix

Guard the accumulate so it is skipped when no span has been started:

```cpp
if (!link_spans_.empty()) {
    link_spans_.back().len += segment.contents.size();
}
```

This is behaviour-preserving for every input that works today:

- Reaching that point with an empty `link_spans_` implies `DISCRETE` **and** `segment.contents.empty()`, so the skipped `len +=` would have added `0`, and the `data_.insert` below is already a no-op for an empty range. No data is dropped.
- Non-`DISCRETE` loads take the `link_spans_.empty()` branch of the condition, so they always append on the first iteration and can never reach the guard with an empty vector. Contiguous coalescing is untouched.
- A contentless segment in any *other* position already contributed no span and no data; this makes the leading position behave the same way.

`text_addr_`/`text_size_` come from `segments[0]` and are unaffected. I checked every consumer of `link_spans_` (`process_spans` x2, `fill_from_mem_template`, `update_spans`, `num_spans`, `operator==`, and the callers in `llrt.cpp`, `kernel.cpp`, `dispatch.cpp`) — all of them iterate the spans and none index `[0]` or otherwise assume at least one span exists, so a smaller (or empty) `link_spans_` is handled gracefully.

### Tests

Added two cases to the existing `tests/tt_metal/tt_metal/api/test_tt_memory.cpp`, which is already registered in `sources.cmake` and needs no build-file changes. They use the existing `memory::from_segments` seam (added precisely so this packing logic can be unit-tested with synthetic segments), so they need no ELF on disk and no device:

- `DiscreteHandlesEmptyFirstSegmentInAddressOrder` — the regression: text at `0x2000`, a `.bss`-only segment (empty contents, `membytes=0x40`) at `0x1000`, so the address sort puts the contentless one first. Crashes on `main`; asserts the resulting span layout, packed data, and text addr/size.
- `DiscreteDropsEmptyTrailingSegment` — the previously-reachable position, guarding that the fix did not change existing behaviour.

### Notes for reviewers

Please sanity-check my claim that dropping a contentless leading segment is the desired semantics rather than, say, emitting a zero-length span at its address. I kept it consistent with what already happens for contentless segments in every other position, but if any downstream consumer wants `.bss` extents represented in `link_spans_`, that would be a larger and separate change.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=fix/tt-memory-pack-from-segments-underflow)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:fix/tt-memory-pack-from-segments-underflow)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=fix/tt-memory-pack-from-segments-underflow)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:fix/tt-memory-pack-from-segments-underflow)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=fix/tt-memory-pack-from-segments-underflow)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:fix/tt-memory-pack-from-segments-underflow)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fix/tt-memory-pack-from-segments-underflow)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fix/tt-memory-pack-from-segments-underflow)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=fix/tt-memory-pack-from-segments-underflow)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:fix/tt-memory-pack-from-segments-underflow)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=fix/tt-memory-pack-from-segments-underflow)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:fix/tt-memory-pack-from-segments-underflow)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=fix/tt-memory-pack-from-segments-underflow)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:fix/tt-memory-pack-from-segments-underflow)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=fix/tt-memory-pack-from-segments-underflow)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:fix/tt-memory-pack-from-segments-underflow)
