### PR TITLE
[Bug fix] sweeps: honour skip_negative_entries in the plus_one golden

### DIFF
--- a/tests/sweep_framework/sweeps/model_traced/plus_one_model_traced.py
+++ b/tests/sweep_framework/sweeps/model_traced/plus_one_model_traced.py
@@ -78,7 +78,29 @@ def run(
             partial(torch_random, low=-100, high=100, dtype=torch.float32), input_a_dtype
         )(shape)
 
-    torch_output_tensor = torch_input_tensor_a + 1
+    # The traced `skip_negative_entries` flag changes the op's semantics: the kernel
+    # increments ONLY entries in [0, INT32_MAX) and leaves negative entries (and
+    # INT32_MAX, which would overflow) unchanged --
+    # see reader_plusone_interleaved.cpp: `if (val < INT32_MAX && val >= 0) val + 1`.
+    # The golden must model that, otherwise every negative entry is off by one.
+    #
+    # On multi-element tensors PCC HIDES the mismatch: an all-negative input is a
+    # uniform +1 offset (perfectly correlated, PCC 1.0) and a mixed-sign input still
+    # scores ~0.99999 against the 0.999 threshold. But on a SINGLE-element tensor PCC
+    # is undefined (zero variance), so comp_pcc falls back to an exact allclose and the
+    # off-by-one surfaces as PCC 0.0. That is the deterministic `(1,)` INT32 failure
+    # seen on every lane (n150/n300/t3k/p100a/p150b/p300a/galaxy) -- with seed 0 the
+    # single element is -56, so the device correctly returns -56 while an unconditional
+    # golden expects -55.
+    if op_kwargs.get("skip_negative_entries", False):
+        _INT32_MAX = 2**31 - 1
+        torch_output_tensor = torch.where(
+            (torch_input_tensor_a >= 0) & (torch_input_tensor_a < _INT32_MAX),
+            torch_input_tensor_a + 1,
+            torch_input_tensor_a,
+        )
+    else:
+        torch_output_tensor = torch_input_tensor_a + 1
 
     is_host = storage_type and "HOST" in str(storage_type)
 


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
The traced `plus_one` configs carry **`skip_negative_entries=True`**, which is forwarded to the op, but the sweep golden was unconditionally `input + 1`. The kernel increments **only** entries in `[0, INT32_MAX)`:

```cpp
// ttnn/cpp/ttnn/operations/experimental/plusone/device/kernels/reader_plusone_interleaved.cpp
if constexpr (skip_negative_entries) {
    if (val < INT32_MAX && val >= 0) { stick[i] = val + 1; }
} else { stick[i] = val + 1; }
```

so every negative entry was compared off by one. **The device is correct** — the flag deliberately preserves negative sentinels (`-1` = inactive user slot in `current_pos`; see `models/tt_transformers/tt/model.py:742`, which passes the flag for `current_pos` but *not* for `rot_mat_idxs`). Only the golden was wrong.

**Why it only surfaced on shape `(1,)`** — PCC masks the error on larger tensors:
- an all-negative input is a uniform `+1` offset → perfectly correlated → **PCC 1.0**
- a mixed-sign input still scores **~0.99999** against the 0.999 threshold
- a **single-element** tensor has zero variance → PCC undefined → `comp_pcc` falls back to an exact `allclose` → the off-by-one surfaces as **PCC 0.0**

With `torch.manual_seed(0)` the single element is `-56`, so the device correctly returned `-56` while the golden expected `-55`.

This is the deterministic `(1,)` INT32 failure seen on **every lane** — n150 `7076fa1a`, n300 `1aa23d50`, t3k `baf5d194`, p100a `b01fae19`, p150b `2a52fa19`, p300a `de1a1a76`, galaxy `0dbb95f2` — all shape `(1,)` INT32 with the flag set. **13 of 39** `plus_one` configs carry the flag: 7 failed outright, 6 were silently mis-scored.

### Notes for reviewers
- Validated on N300 against the **real vectors**: all 6 n150 configs pass, including the previously-failing `7076fa1a` → `(True, '1.0')`.
- The silently-masked configs also tighten to an exact match, e.g. `edc913becb` `(32,)`: `0.9999908709442376` → `1.0`.
- Configs **without** the flag are unchanged (no regression); `uint32` inputs are generated non-negative so they were never affected.
- The `INT32_MAX` bound mirrors the kernel's overflow guard exactly.
- Follow-up (separate PR): the `plus_one` pybind docstring says *"Equivalent pytorch code: `torch.add(input_tensor, 1)`"*, which is wrong when the flag is set — that documentation is what this golden was written against.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=brain/plus-one-golden-skip-negative-entries)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:brain/plus-one-golden-skip-negative-entries)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=brain/plus-one-golden-skip-negative-entries)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:brain/plus-one-golden-skip-negative-entries)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=brain/plus-one-golden-skip-negative-entries)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:brain/plus-one-golden-skip-negative-entries)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=brain/plus-one-golden-skip-negative-entries)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:brain/plus-one-golden-skip-negative-entries)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=brain/plus-one-golden-skip-negative-entries)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:brain/plus-one-golden-skip-negative-entries)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=brain/plus-one-golden-skip-negative-entries)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:brain/plus-one-golden-skip-negative-entries)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=brain/plus-one-golden-skip-negative-entries)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:brain/plus-one-golden-skip-negative-entries)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=brain/plus-one-golden-skip-negative-entries)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:brain/plus-one-golden-skip-negative-entries)