### PR TITLE
[Bug fix] dequantize: widen uint8 input before the tensor-zero-point subtract

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/eltwise/test_quantization.py
+++ b/tests/ttnn/nightly/unit_tests/operations/eltwise/test_quantization.py
@@ -674,3 +674,51 @@ def test_requant_uint8_mixed_dtype_per_tensor_2d(device, in_dtype, in_q_max, out
     result_tr = ttnn.to_torch(dequantized_tt)
     check_pcc(input_tr, result_tr, True)
     check_match_ratio(input_tr, result_tr, ttnn.float32)
+
+
+# uint8 input combined with a tensor zero-point used to abort with
+#   "Input tensor A dtype DataType::UINT8 is not supported for binary operation BinaryOpType::SUB"
+# because the per-tensor composite fallback subtracted the zero-point straight off the uint8
+# input, and SUB has no uint8 operand support. The scalar-zero-point paths feed the DEQUANT LLK
+# (which does take uint8) and the per-channel composite already widened to float32, so only this
+# combination was broken. Widening to int32 first makes it agree bit-for-bit with the same
+# quantized values presented as int32.
+@pytest.mark.parametrize("output_dtype", [ttnn.bfloat16, ttnn.float32])
+@pytest.mark.parametrize("scale_dim", [0, 1])
+@pytest.mark.parametrize("zero_point", [0, 7, 255])
+def test_dequant_uint8_input_with_tensor_zero_point(device, output_dtype, scale_dim, zero_point):
+    torch.manual_seed(0)
+    scale = 0.02
+
+    q_tr = torch.randint(0, 256, (2, 3, 64, 96), dtype=torch.int32)
+    q_uint8 = ttnn.from_torch(q_tr.to(torch.uint8), dtype=ttnn.uint8, layout=ttnn.TILE_LAYOUT, device=device)
+    q_int32 = ttnn.from_torch(q_tr, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
+
+    scale_arg = convert_scalar_to_ttnn_tensor(device, scale, scale_dim, ttnn.float32)
+    zero_point_tt = convert_scalar_to_ttnn_tensor(device, zero_point, 1, ttnn.int32)
+
+    from_uint8 = ttnn.to_torch(ttnn.dequantize(q_uint8, scale_arg, zero_point_tt, dtype=output_dtype))
+    from_int32 = ttnn.to_torch(ttnn.dequantize(q_int32, scale_arg, zero_point_tt, dtype=output_dtype))
+
+    assert torch.equal(from_uint8, from_int32)
+
+
+# requantize with a tensor zero-point falls through to the dequantize composite, so a uint8
+# input hit the same abort one level down.
+@pytest.mark.parametrize("output_dtype", [ttnn.int32, ttnn.uint8])
+def test_requant_uint8_input_with_tensor_zero_point(device, output_dtype):
+    torch.manual_seed(0)
+    in_scale, in_zero_point = 0.02, 7
+    out_scale, out_zero_point = 0.05, 3
+
+    q_tr = torch.randint(0, 256, (2, 3, 64, 96), dtype=torch.int32)
+    q_uint8 = ttnn.from_torch(q_tr.to(torch.uint8), dtype=ttnn.uint8, layout=ttnn.TILE_LAYOUT, device=device)
+    q_int32 = ttnn.from_torch(q_tr, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)
+
+    in_zp_tt = convert_scalar_to_ttnn_tensor(device, in_zero_point, 1, ttnn.int32)
+    out_zp_tt = convert_scalar_to_ttnn_tensor(device, out_zero_point, 1, ttnn.int32)
+
+    from_uint8 = ttnn.to_torch(ttnn.requantize(q_uint8, in_scale, in_zp_tt, out_scale, out_zp_tt, dtype=output_dtype))
+    from_int32 = ttnn.to_torch(ttnn.requantize(q_int32, in_scale, in_zp_tt, out_scale, out_zp_tt, dtype=output_dtype))
+
+    assert torch.equal(from_uint8, from_int32)

--- a/ttnn/cpp/ttnn/operations/eltwise/quantization/quantization.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/quantization/quantization.cpp
@@ -490,6 +490,16 @@ Tensor dequantize(
 
     constexpr ttsl::Span<const operations::unary::EltwiseUnaryWithParam> none{};
 
+    // The tensor-zero-point composite paths below subtract the zero-point straight off the input.
+    // BinaryOpType::SUB does not accept a uint8 operand (dtype_sets::arithmetic_fpu in
+    // binary_op_dtype_policy.hpp lists only bf16/f32/bfp8/bfp4/u32/u16/i32), so widen a uint8
+    // input to int32 first. The per-channel composite already widens to float32 for the same
+    // reason; only the per-tensor paths were missing it. The scalar-zero-point paths feed
+    // binary_ng's DEQUANT directly, which does accept uint8, so they must not pay for this cast.
+    const auto widen_uint8_input = [&]() -> Tensor {
+        return a_dtype == DataType::UINT8 ? ttnn::typecast(input_tensor, DataType::INT32) : input_tensor;
+    };
+
     const bool is_per_channel = axis.has_value();
     if (is_per_channel) {
         const Tensor* scale_p = std::get_if<Tensor>(&scale);
@@ -558,7 +568,7 @@ Tensor dequantize(
                 check_per_tensor_zero_point(zero_point);
                 const Tensor input_shifted = ttnn::typecast(
                     ttnn::subtract(
-                        input_tensor, zero_point, std::nullopt, std::nullopt, std::nullopt, none, none, none),
+                        widen_uint8_input(), zero_point, std::nullopt, std::nullopt, std::nullopt, none, none, none),
                     c_dtype);
                 return ttnn::multiply(
                     input_shifted, scale, c_dtype, memory_config, optional_output_tensor, none, none, none);
@@ -568,7 +578,7 @@ Tensor dequantize(
                 check_per_tensor_zero_point(zero_point);
                 const Tensor input_shifted = ttnn::typecast(
                     ttnn::subtract(
-                        input_tensor, zero_point, std::nullopt, std::nullopt, std::nullopt, none, none, none),
+                        widen_uint8_input(), zero_point, std::nullopt, std::nullopt, std::nullopt, none, none, none),
                     c_dtype);
                 return ttnn::multiply(
                     input_shifted,


### PR DESCRIPTION
### PR Category

Bug fix. Closes #51303.

### Summary

`ttnn.dequantize` aborts with `Input tensor A dtype DataType::UINT8 is not supported for binary operation BinaryOpType::SUB` when the input is uint8 and the zero-point is passed as a tensor. The two per-tensor tensor-zero-point overloads subtract the zero-point straight off the input, and `SUB` accepts only the dtypes in `dtype_sets::arithmetic_fpu`, which does not include uint8.

Every other path already avoids this. The scalar-zero-point paths go to `binary_ng(..., DEQUANT)`, whose dtype set is `{INT32, UINT8}`, and the per-channel composite already widens to float32 before its subtract. This widens a uint8 input to int32 in the per-tensor composite as well, so it takes the same route as the same values presented as int32. The widening is lazy, so the scalar-zero-point fast paths do not pay for an extra typecast pass. `requantize` with a tensor zero-point falls through to this composite and is fixed by the same change.

### Tests

Two tests assert that uint8 input and int32 input produce bit-identical output, across output dtypes, scalar and tensor scales, and zero-points `{0, 7, 255}` for `dequantize` (12 cases) and through `requantize` (2 cases). All 14 abort on `main` and pass here. Full `test_quantization.py` plus `test_quantization2.py` green on Blackhole P300 (8844 passed).

### Future work

A follow-up could route this case through the fused DEQUANT path instead of the float composite, measured locally at 1.22x. It does not subsume this change: the int32 subtract still rejects a uint8 operand, so the widening is needed either way.

