### PR TITLE
[CI VLLM] Add vllm tt plugin nightly ci

### DIFF
--- a/.github/workflows/aggregate-workflow-data.yaml
+++ b/.github/workflows/aggregate-workflow-data.yaml
@@ -99,6 +99,7 @@ jobs:
               ".github/workflows/tt-metal-l2-nightly.yaml",
               ".github/workflows/ttnn-run-sweeps.yaml",
               ".github/workflows/vllm-nightly-tests.yaml",
+              ".github/workflows/vllm-tt-plugin-nightly-tests.yaml",
               ".github/workflows/metal-run-microbenchmarks.yaml",
               ".github/workflows/sanity-tests-debug.yaml",
               ".github/workflows/merge-gate.yaml",

--- a/.github/workflows/vllm-tt-plugin-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-tt-plugin-nightly-tests-impl.yaml
@@ -1,0 +1,989 @@
+name: "[internal] vLLM TT plugin nightly tests impl"
+
+on:
+  workflow_call:
+    inputs:
+      docker-image:
+        required: true
+        type: string
+      wheel-artifact-name:
+        required: true
+        type: string
+      build-artifact-name:
+        required: true
+        type: string
+      vllm-tt-plugin-ref:
+        description: "vLLM TT plugin branch or sha"
+        required: false
+        default: main
+        type: string
+      model:
+        description: "Model to test (or 'all' for all models)"
+        required: false
+        type: string
+        default: "all"
+      mlperf-read-only:
+        description: "Mount /mnt/MLPerf as read-only (set to false to allow tt_cache write-through during first-use)"
+        required: false
+        type: boolean
+        default: true
+
+jobs:
+  generate-matrix:
+    runs-on: ubuntu-slim
+    outputs:
+      matrix: ${{ steps.generate.outputs.matrix }}
+    steps:
+      - name: Generate test matrix
+        id: generate
+        run: |
+          # Owner mapping:
+          # Pavle Petrovic (U08E1JCDVNX), Salar Hosseini Khorasgani (U08CEGF78ET) - Llama models
+          # Djordje Ivanovic (U053W15B6JF) - Qwen3-32B models
+          # Gongyu Wang (U07RY6B5FLJ) - Qwen 2.5 VL models
+          # Sarva Sanjay (U08H31YMN4Q) - Qwen 3 VL models
+          # Ambrose Ling (U08GELBB1AP) - BH tests
+          # Tomasz Cheda (U091SNDA4TS) - Structured output tests
+          # Radoica Draskic (U08BH66EXAL) - DP tests
+          # Harry Andrews (U08TJ70UFRT), Stuti Raizada (U06F3ER8X9A) - GPT-OSS
+          # Aniruddha Tupe (U08HL8X1ECD) - Qwen3.6 models
+
+          # Note: This matrix must be kept in sync with the original static matrix
+          #
+          # The WH-T3K Gemma4-26B-A4B entry below is temporarily disabled —
+          # DRAM OOM during KV cache allocation (layer 25/30) causes EngineCore
+          # init failure on WH-T3K. Full unquantized KV cache no longer fits.
+          # Re-enable once hybrid KV cache is enabled (which will size the
+          # sliding-window layers' KV cache to the window instead of the full
+          # sequence length, freeing the DRAM needed to fit the full model).
+          # Tracked in https://github.com/tenstorrent/tt-metal/issues/49257
+          #
+          # Disabled entry preserved verbatim for the re-enable:
+          #
+          #   {
+          #     "name": "[WH-T3K] Gemma4-26B-A4B",
+          #     "model": "google/gemma-4-26B-A4B-it",
+          #     "coherence-test": true,
+          #     "server-timeout": 30,
+          #     "benchmark-timeout": 10,
+          #     "runner-label": "config-t3000",
+          #     "arch": "arch-wormhole_b0",
+          #     "mesh-device": "T3K",
+          #     "tt-config": "{\"sample_on_device_mode\": \"decode_only\", \"fabric_config\": \"FABRIC_1D\", \"trace_region_size\": 200000000}",
+          #     "additional-server-args": "--max_num_seqs 1 --async-scheduling",
+          #     "multimodal": false,
+          #     "owner_id": "U08TJ70UFRT"
+          #   },
+          #
+          # KNOWN ERROR — [WH-T3K] Gemma4-31B (kept enabled below to track):
+          # device hang (fast-dispatch timeout) during decode on WH-T3K only;
+          # the same serving config passes on [BH-QB-2] Gemma4-31B. Not a
+          # serving/KV-config issue — a tt-metal dispatch-layer hang.
+          # Tracked in https://github.com/tenstorrent/tt-metal/issues/49494
+          #
+          # Disabled due to Metal timeout in reduce-scatter async tests
+          # https://github.com/tenstorrent/vllm/issues/416
+          # Originally disabled in:
+          #   https://github.com/tenstorrent/tt-metal/pull/39088
+          #   {
+          #     "name": "[WH-T3K] Multi-process reduce scatter test model",
+          #     "model": "models/vllm_test_utils/t3000_multiproc_test",
+          #     "server-timeout": 4,
+          #     "benchmark-timeout": 4,
+          #     "runner-label": "config-t3000",
+          #     "arch": "arch-wormhole_b0",
+          #     "mesh-device": "(2, 4)",
+          #     "tt-config": "{\"rank_binding\": \"tests/tt_metal/distributed/config/2x4_multiprocess_rank_bindings.yaml\", \"mpi_args\": \"--allow-run-as-root --tag-output\", \"config_pkl_dir\": \"vllm\", \"register_test_models\": true}",
+          #     "additional-server-args": "--data_parallel_size 8 --tokenizer meta-llama/Llama-3.1-8B-Instruct --async-scheduling",
+          #     "additional-benchmark-args": "--tokenizer meta-llama/Llama-3.1-8B-Instruct",
+          #     "multimodal": false,
+          #     "co-owner-1-id": "U08CEGF78ET"
+          #   },
+          all_tests='[
+            {
+              "name": "[WH-T3K] Gemma3-27B",
+              "model": "google/gemma-3-27b-it",
+              "server-timeout": 45,
+              "benchmark-timeout": 5,
+              "runner-label": "config-t3000",
+              "arch": "arch-wormhole_b0",
+              "mesh-device": "T3K",
+              "tt-config": "{\"sample_on_device_mode\": \"decode_only\", \"fabric_config\": \"FABRIC_1D\", \"l1_small_size\": 4096}",
+              "additional-server-args": "--async-scheduling",
+              "tt-llama-text-ver": "tt_transformers",
+              "multimodal": true,
+              "co-owner-1-id": "U08E1JCDVNX",
+              "co-owner-2-id": "U08BH66EXAL"
+            },
+            {
+              "name": "[WH-GLX] Gemma3-27B DP=4",
+              "model": "google/gemma-3-27b-it",
+              "server-timeout": 45,
+              "benchmark-timeout": 5,
+              "runner-label": "topology-6u",
+              "arch": "arch-wormhole_b0",
+              "mesh-device": "(4, 8)",
+              "tt-config": "{\"sample_on_device_mode\": \"decode_only\", \"fabric_config\": \"FABRIC_1D_RING\", \"l1_small_size\": 4096}",
+              "additional-server-args": "--data_parallel_size 4 --max_num_seqs 32 --async-scheduling",
+              "tt_mm_throttle_perf": 5,
+              "tt-llama-text-ver": "tt_transformers",
+              "multimodal": true,
+              "co-owner-1-id": "U08E1JCDVNX",
+              "co-owner-2-id": "U08BH66EXAL"
+            },
+            {
+              "name": "[WH-N150] Gemma4-E2B",
+              "model": "google/gemma-4-E2B-it",
+              "server-timeout": 30,
+              "benchmark-timeout": 12,
+              "coherence-test": true,
+              "runner-label": "N150",
+              "arch": "arch-wormhole_b0",
+              "mesh-device": "N150",
+              "additional-server-args": "--max_num_seqs 1 --async-scheduling",
+              "multimodal": false,
+              "owner_id": "U08TJ70UFRT"
+            },
+            {
+              "name": "[BH-QB-2] Gemma4-12B",
+              "model": "google/gemma-4-12B-it",
+              "coherence-test": true,
+              "server-timeout": 20,
+              "benchmark-timeout": 5,
+              "runner-label": "BH-Quietbox-2",
+              "arch": "arch-blackhole",
+              "mesh-device": "P150x4",
+              "tt-config": "{\"sample_on_device_mode\": \"decode_only\", \"fabric_config\": \"FABRIC_1D\", \"trace_region_size\": 400000000}",
+              "additional-server-args": "--max_model_len 131072 --max_num_seqs 1 --async-scheduling",
+              "multimodal": false,
+              "owner_id": "U08TJ70UFRT"
+            },
+            {
+              "name": "[BH-QB-2] Gemma4-26B-A4B",
+              "model": "google/gemma-4-26B-A4B-it",
+              "coherence-test": true,
+              "server-timeout": 30,
+              "benchmark-timeout": 10,
+              "runner-label": "BH-Quietbox-2",
+              "arch": "arch-blackhole",
+              "mesh-device": "P150x4",
+              "tt-config": "{\"sample_on_device_mode\": \"decode_only\", \"fabric_config\": \"FABRIC_1D\", \"trace_region_size\": 300000000}",
+              "additional-server-args": "--max_model_len 131072 --max_num_seqs 1 --async-scheduling",
+              "multimodal": false,
+              "owner_id": "U08TJ70UFRT"
+            },
+            {
+              "name": "[WH-T3K] Gemma4-31B",
+              "model": "google/gemma-4-31B-it",
+              "server-timeout": 45,
+              "benchmark-timeout": 5,
+              "runner-label": "config-t3000",
+              "arch": "arch-wormhole_b0",
+              "mesh-device": "T3K",
+              "tt-config": "{\"sample_on_device_mode\": \"decode_only\", \"fabric_config\": \"FABRIC_1D\"}",
+              "additional-server-args": "--max_model_len 32768 --max_num_seqs 1 --async-scheduling",
+              "multimodal": false,
+              "owner_id": "U08TJ70UFRT"
+            },
+            {
+              "name": "[BH-QB-2] Gemma4-31B",
+              "model": "google/gemma-4-31B-it",
+              "server-timeout": 20,
+              "benchmark-timeout": 5,
+              "runner-label": "BH-Quietbox-2",
+              "arch": "arch-blackhole",
+              "mesh-device": "P150x4",
+              "tt-config": "{\"sample_on_device_mode\": \"decode_only\", \"fabric_config\": \"FABRIC_1D\"}",
+              "additional-server-args": "--max_model_len 32768 --max_num_seqs 1 --async-scheduling",
+              "multimodal": false,
+              "owner_id": "U08TJ70UFRT"
+            },
+            {
+              "name": "[BH-QB-2] Qwen3.6-27B (multimodal B=1)",
+              "model": "Qwen/Qwen3.6-27B",
+              "coherence-test": true,
+              "server-timeout": 30,
+              "benchmark-timeout": 10,
+              "runner-label": "BH-Quietbox-2",
+              "arch": "arch-blackhole",
+              "mesh-device": "P150x4",
+              "tt-config": "{\"fabric_config\": \"FABRIC_1D\", \"trace_region_size\": 268435456, \"l1_small_size\": 24576}",
+              "additional-server-args": "--max_num_seqs 1 --async-scheduling",
+              "default-chat-template-kwargs": "{\"enable_thinking\": false}",
+              "multimodal": true,
+              "owner_id": "U08HL8X1ECD"
+            },
+            {
+              "name": "[BH-QB-2] Qwen3.6-27B (batch=8)",
+              "model": "Qwen/Qwen3.6-27B",
+              "coherence-test": true,
+              "server-timeout": 35,
+              "benchmark-timeout": 10,
+              "runner-label": "BH-Quietbox-2",
+              "arch": "arch-blackhole",
+              "mesh-device": "P150x4",
+              "tt-config": "{\"fabric_config\": \"FABRIC_1D\", \"trace_region_size\": 1073741824, \"l1_small_size\": 24576}",
+              "additional-server-args": "--max_num_seqs 8 --max_model_len 65536 --async-scheduling",
+              "default-chat-template-kwargs": "{\"enable_thinking\": false}",
+              "multimodal": false,
+              "owner_id": "U08HL8X1ECD"
+            },
+            {
+              "name": "[WH-GLX] GPT-OSS-120B (low-latency)",
+              "model": "openai/gpt-oss-120b",
+              "server-timeout": 35,
+              "benchmark-timeout": 30,
+              "runner-label": "topology-6u",
+              "arch": "arch-wormhole_b0",
+              "mesh-device": "(4, 8)",
+              "multimodal": false,
+              "tt-llama-text-ver": "tt_transformers",
+              "tt-config": "{\"sample_on_device_mode\": \"all\"}",
+              "additional-server-args": "--max_num_seqs 1 --async-scheduling",
+              "structured-output": true,
+              "additional-structured-output-args": "--backend openai-chat --endpoint /v1/chat/completions --dataset json",
+              "co-owner-1-id": "U08TJ70UFRT",
+              "co-owner-2-id": "U06F3ER8X9A"
+            },
+            {
+              "name": "[WH-GLX] GPT-OSS-120B (high-throughput)",
+              "model": "openai/gpt-oss-120b",
+              "server-timeout": 35,
+              "benchmark-timeout": 10,
+              "runner-label": "topology-6u",
+              "arch": "arch-wormhole_b0",
+              "mesh-device": "(4, 8)",
+              "multimodal": false,
+              "tt-llama-text-ver": "tt_transformers",
+              "tt-config": "{\"fabric_config\": \"FABRIC_1D_RING\", \"sample_on_device_mode\": \"all\", \"trace_region_size\": 100000000}",
+              "tt_mm_throttle_perf": 2,
+              "additional-server-args": "--data_parallel_size 4 --max_num_seqs 32 --async-scheduling",
+              "structured-output": true,
+              "sampling-tests": true,
+              "sampling-test-timeout": 40,
+              "additional-structured-output-args": "--backend openai-chat --endpoint /v1/chat/completions --dataset json",
+              "co-owner-1-id": "U08TJ70UFRT",
+              "co-owner-2-id": "U06F3ER8X9A"
+            },
+            {
+              "name": "[WH-T3K] Llama-3.1-8B-Instruct with sampling-tests",
+              "model": "meta-llama/Llama-3.1-8B-Instruct",
+              "server-timeout": 15,
+              "benchmark-timeout": 5,
+              "runner-label": "config-t3000",
+              "arch": "arch-wormhole_b0",
+              "mesh-device": "T3K",
+              "tt-llama-text-ver": "tt_transformers",
+              "tt-config": "{\"fabric_config\": \"FABRIC_1D\", \"sample_on_device_mode\": \"all\", \"trace_region_size\": 85000000}",
+              "additional-server-args": "--async-scheduling",
+              "structured-output": true,
+              "sampling-tests": true,
+              "sampling-test-filter": "not test_mixed_params_batch and not TestSeedingAndVariety and not test_repetition_penalty_mixed_batch and not test_presence_penalty_mixed_batch and not test_frequency_penalty_mixed_batch",
+              "multimodal": false,
+              "co-owner-1-id": "U08E1JCDVNX",
+              "co-owner-2-id": "U08CEGF78ET"
+            },
+            {
+              "name": "[WH-T3K] Llama-3.1-8B-Instruct (prefix caching)",
+              "model": "meta-llama/Llama-3.1-8B-Instruct",
+              "server-timeout": 10,
+              "benchmark-timeout": 5,
+              "runner-label": "config-t3000",
+              "arch": "arch-wormhole_b0",
+              "mesh-device": "T3K",
+              "tt-llama-text-ver": "tt_transformers",
+              "tt-config": "{\"fabric_config\": \"FABRIC_1D\"}",
+              "multimodal": false,
+              "additional-benchmark-args": "--random-prefix-len 128",
+              "additional-server-args": "--async-scheduling",
+              "co-owner-1-id": "U08E1JCDVNX",
+              "co-owner-2-id": "U08CEGF78ET"
+            },
+            {
+              "name": "[BH-QB-2] Llama-3.1-8B-Instruct",
+              "model": "meta-llama/Llama-3.1-8B-Instruct",
+              "server-timeout": 10,
+              "benchmark-timeout": 10,
+              "runner-label": "BH-Quietbox-2",
+              "arch": "arch-blackhole",
+              "mesh-device": "P150x4",
+              "tt-config": "{\"trace_region_size\": 76000000}",
+              "tt-llama-text-ver": "tt_transformers",
+              "additional-server-args": "--async-scheduling",
+              "structured-output": true,
+              "multimodal": false,
+              "owner_id": "U08GELBB1AP"
+            },
+            {
+              "name": "[BH-LB] Llama-3.1-8B-Instruct DP=8 with sampling-tests",
+              "model": "meta-llama/Llama-3.1-8B-Instruct",
+              "server-timeout": 35,
+              "benchmark-timeout": 10,
+              "runner-label": "bh-loudbox",
+              "arch": "arch-blackhole",
+              "mesh-device": "P150x8",
+              "tt-llama-text-ver": "tt_transformers",
+              "additional-server-args": "--data_parallel_size 8 --async-scheduling",
+              "structured-output": true,
+              "sampling-tests": true,
+              "multimodal": false,
+              "owner_id": "U08GELBB1AP"
+            },
+            {
+              "name": "[WH-GLX] Llama-3.1-8B-Instruct DP=4",
+              "model": "meta-llama/Llama-3.1-8B-Instruct",
+              "server-timeout": 20,
+              "benchmark-timeout": 5,
+              "runner-label": "topology-6u",
+              "arch": "arch-wormhole_b0",
+              "mesh-device": "TG",
+              "tt-config": "{\"fabric_config\": \"FABRIC_1D_RING\", \"sample_on_device_mode\": \"all\"}",
+              "tt-llama-text-ver": "tt_transformers",
+              "additional-server-args": "--data_parallel_size 4 --async-scheduling",
+              "structured-output": true,
+              "multimodal": false,
+              "co-owner-1-id": "U08E1JCDVNX",
+              "co-owner-2-id": "U08BH66EXAL"
+            },
+            {
+              "name": "[WH-GLX] Llama-3.3-70B-Instruct device with sampling-tests (prefix caching)",
+              "model": "meta-llama/Llama-3.3-70B-Instruct",
+              "server-timeout": 35,
+              "benchmark-timeout": 10,
+              "runner-label": "topology-6u",
+              "arch": "arch-wormhole_b0",
+              "mesh-device": "TG",
+              "tt-llama-text-ver": "llama3_70b_galaxy",
+              "tt-config": "{\"dispatch_core_axis\": \"col\", \"sample_on_device_mode\": \"all\", \"fabric_config\": \"FABRIC_1D_RING\", \"worker_l1_size\": 1344544, \"trace_region_size\": 220000000}",
+              "additional-server-args": "--data_parallel_size 4 --max_num_seqs 8 --async-scheduling",
+              "additional-benchmark-args": "--random-prefix-len 256",
+              "sampling-tests": true,
+              "multimodal": false,
+              "co-owner-1-id": "U08E1JCDVNX",
+              "co-owner-2-id": "U08CEGF78ET"
+            },
+            {
+              "name": "[WH-GLX] Qwen3-32B device with sampling-tests",
+              "model": "Qwen/Qwen3-32B",
+              "server-timeout": 35,
+              "benchmark-timeout": 10,
+              "runner-label": "topology-6u",
+              "arch": "arch-wormhole_b0",
+              "mesh-device": "TG",
+              "tt-qwen3-text-ver": "qwen3_32b_galaxy",
+              "tt-config": "{\"dispatch_core_axis\": \"col\", \"sample_on_device_mode\": \"all\", \"fabric_config\": \"FABRIC_1D_RING\", \"worker_l1_size\": 1344544, \"trace_region_size\": 184915840}",
+              "additional-server-args": "--data_parallel_size 4 --max_num_seqs 8 --async-scheduling",
+              "sampling-tests": true,
+              "multimodal": false,
+              "co-owner-1-id": "U053W15B6JF"
+            },
+            {
+              "name": "[WH-T3K] Qwen2.5-VL-72B-Instruct",
+              "model": "Qwen/Qwen2.5-VL-72B-Instruct",
+              "server-timeout": 12,
+              "benchmark-timeout": 10,
+              "runner-label": "config-t3000",
+              "arch": "arch-wormhole_b0",
+              "mesh-device": "T3K",
+              "tt-llama-text-ver": "tt_transformers",
+              "tt-config": "{\"fabric_config\": \"FABRIC_1D\", \"trace_region_size\": 28467200}",
+              "structured-output": true,
+              "multimodal": true,
+              "additional-server-args": "--max_model_len 2048 --async-scheduling",
+              "co-owner-1-id": "U07RY6B5FLJ"
+            },
+            {
+              "name": "[WH-T3K] Qwen3-VL-32B-Instruct",
+              "model": "Qwen/Qwen3-VL-32B-Instruct",
+              "coherence-test": false,
+              "server-timeout": 10,
+              "benchmark-timeout": 10,
+              "runner-label": "config-t3000",
+              "arch": "arch-wormhole_b0",
+              "mesh-device": "T3K",
+              "tt-llama-text-ver": "tt_transformers",
+              "tt-config": "{\"fabric_config\": \"FABRIC_1D\", \"trace_region_size\": 28467200}",
+              "structured-output": true,
+              "multimodal": true,
+              "additional-server-args": "--max_model_len 131072 --async-scheduling",
+              "additional-structured-output-args": "--backend openai-chat --endpoint /v1/chat/completions",
+              "co-owner-1-id": "U08H31YMN4Q"
+            },
+            {
+              "name": "[WH-GLX] NoOp test model (vLLM overhead)",
+              "model": "models/vllm_test_utils/no_op_test",
+              "server-timeout": 2,
+              "benchmark-timeout": 2,
+              "runner-label": "topology-6u",
+              "arch": "arch-wormhole_b0",
+              "mesh-device": "(1, 1)",
+              "tt-config": "{\"register_test_models\": true, \"input_queue_batching_delay\": 0}",
+              "additional-server-args": "--tokenizer meta-llama/Llama-3.1-8B-Instruct --async-scheduling",
+              "additional-benchmark-args": "--tokenizer meta-llama/Llama-3.1-8B-Instruct --temperature 0.0",
+              "multimodal": false,
+              "owner_id": "U08CEGF78ET"
+            }
+          ]'
+
+          # Filter matrix based on model selection. Substring match (not exact)
+          # so a family-level dropdown entry like "google/gemma-4" picks up
+          # every google/gemma-4-*-it variant in the matrix above, while
+          # explicit hub IDs ("meta-llama/Llama-3.1-8B-Instruct") still
+          # trivially match themselves.
+          if [ "${{ inputs.model }}" = "all" ]; then
+            matrix="$all_tests"
+          else
+            matrix=$(echo "$all_tests" | jq -c "[.[] | select(.model | contains(\"${{ inputs.model }}\"))]")
+          fi
+
+          echo "matrix=$(echo "$matrix" | jq -c .)" >> $GITHUB_OUTPUT
+
+  vllm-tests:
+    needs: generate-matrix
+    strategy:
+      fail-fast: false
+      matrix:
+        test-group: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
+    name: ${{ matrix.test-group.name }}
+    runs-on:
+      - ${{ matrix.test-group.runner-label }}
+      - ${{ matrix.test-group.arch }}
+      - in-service
+      # topology-6u tag is used for WH galaxies. Currently pipeline-perf machines have mlperf access and pipeline-functional machines do not.
+      - ${{ ((matrix.test-group.runner-label == 'BH-Quietbox-2' || matrix.test-group.runner-label == 'topology-6u') && 'pipeline-perf') || 'pipeline-functional' }}
+    # Per-phase log paths kept job-level so they resolve in both the ${{ env }}
+    # expression context (run-with-log log-file inputs) and the container step
+    # shells ($FILE_*). container.env is shell-only, not visible to expressions.
+    env:
+      FILE_SERVER_PID: "./server.pid"
+      FILE_INSTALL_LOG: "./output/vllm_install.log"
+      FILE_SERVER_LOG: "./output/vllm_server.log"
+      FILE_BENCHMARK_LOG: "./output/vllm_benchmark.log"
+      FILE_BENCHMARK_STRUCTURED_OUTPUT_LOG: "./output/vllm_benchmark_structured_output.log"
+      FILE_MULTIMODAL_TEST_LOG: "./output/vllm_multimodal_test.log"
+      FILE_SAMPLING_TESTS_LOG: "./output/vllm_sampling_tests.log"
+    container:
+      image: ${{ inputs.docker-image }}
+      env:
+        TT_METAL_HOME: /work
+        PYTHONPATH: /work:/work/vllm-tt-plugin/src
+        LD_LIBRARY_PATH: /work/build/lib
+        LOGURU_LEVEL: INFO
+        HF_HUB_OFFLINE: 1
+        HF_HUB_CACHE: /mnt/MLPerf/huggingface/hub
+        TT_CACHE_HOME: /mnt/MLPerf/huggingface/tt_cache
+        FILE_SERVER_PID: "./server.pid"
+        FILE_INSTALL_LOG: "./output/vllm_install.log"
+        FILE_SERVER_LOG: "./output/vllm_server.log"
+        FILE_BENCHMARK_LOG: "./output/vllm_benchmark.log"
+        FILE_BENCHMARK_STRUCTURED_OUTPUT_LOG: "./output/vllm_benchmark_structured_output.log"
+        FILE_MULTIMODAL_TEST_LOG: "./output/vllm_multimodal_test.log"
+        FILE_SAMPLING_TESTS_LOG: "./output/vllm_sampling_tests.log"
+        FILE_COHERENCE_TEST_LOG: "./output/vllm_coherence_test.log"
+      volumes:
+        - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
+        - /dev/hugepages-1G:/dev/hugepages-1G
+        # ``mlperf-read-only`` workflow input toggles ro/rw. Default ro for safety;
+        # uncheck the box at dispatch time when a model needs tt_cache first-use
+        # write-through. BH-Quietbox-2 uses a different network mount (/mnt/models, not the shared
+        # /mnt/MLPerf) so the same toggle applies to either physical mount source.
+        - ${{ (matrix.test-group.runner-label == 'BH-Quietbox-2' && format('/mnt/models/huggingface:/mnt/MLPerf/huggingface{0}', inputs.mlperf-read-only && ':ro' || ':rw')) || format('/mnt/MLPerf:/mnt/MLPerf{0}', inputs.mlperf-read-only && ':ro' || ':rw') }}
+      options: "--device /dev/tenstorrent"
+    defaults:
+      run:
+        shell: bash
+        working-directory: /work # https://github.com/actions/runner/issues/878
+    steps:
+      - name: 🧬 Checkout Repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        timeout-minutes: 20
+        with:
+          submodules: recursive
+          path: docker-job
+      - name: ⬇️ Setup Metal
+        uses: ./docker-job/.github/actions/setup-job
+        timeout-minutes: 10
+        with:
+          build-artifact-name: ${{ inputs.build-artifact-name }}
+          wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
+
+      - name: Ensure BH Eth links online
+        if: ${{ contains(matrix.test-group.mesh-device, 'P150') }}
+        uses: tenstorrent/tt-metal/.github/actions/ensure-bh-links-online@main
+        timeout-minutes: 10
+
+      - name: ⬇️ Checkout vLLM TT plugin
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        timeout-minutes: 20
+        with:
+          repository: tenstorrent/vllm-tt-plugin
+          path: docker-job/vllm-tt-plugin
+          ref: ${{ inputs.vllm-tt-plugin-ref }}
+          fetch-depth: 0
+
+      - name: 📂 Create output directory
+        run: |
+          mkdir -p output
+
+      - name: 📀 Install vLLM
+        uses: ./docker-job/.github/actions/run-with-log
+        with:
+          log-file: ${{ env.FILE_INSTALL_LOG }}
+          run: |
+            pushd vllm-tt-plugin
+            source docs/install-vllm-tt.sh
+            popd
+            # Per-model Python deps when the model directory pins versions that
+            # differ from the docker image (Gemma4 needs transformers==5.5.0).
+            case "${{ matrix.test-group.model }}" in
+              google/gemma-4-*) uv pip install -r models/demos/gemma4/requirements.txt ;;
+            esac
+
+      - name: ⬇️ Checkout vLLM benchmark sources
+        run: |
+          VLLM_VERSION="$(python3 -c 'from importlib.metadata import version; print(version("vllm").split("+", 1)[0])')"
+          echo "Checking out vLLM benchmark sources for v${VLLM_VERSION}"
+          git init vllm-source
+          git -C vllm-source remote add origin https://github.com/vllm-project/vllm.git
+          git -C vllm-source fetch --depth 1 origin "refs/tags/v${VLLM_VERSION}"
+          git -C vllm-source checkout --detach FETCH_HEAD
+
+      - name: 🚀 Run server
+        timeout-minutes: 1
+        run: |
+          TT_CONFIG_RAW='${{ matrix.test-group.tt-config }}'
+          if [ -n "$TT_CONFIG_RAW" ]; then
+            ADDITIONAL_CONFIG_RAW="$(jq -nc --argjson tt "$TT_CONFIG_RAW" '{tt: $tt}')"
+            ADDITIONAL_CONFIG=(--additional-config "$ADDITIONAL_CONFIG_RAW")
+          else
+            ADDITIONAL_CONFIG=()
+          fi
+
+          if [ -n "${{ matrix.test-group.additional-server-args }}" ]; then
+            ADDITIONAL_SERVER_ARGS=(${{ matrix.test-group.additional-server-args }})
+          else
+            ADDITIONAL_SERVER_ARGS=()
+          fi
+
+          DEFAULT_CHAT_TEMPLATE_KWARGS_RAW='${{ matrix.test-group.default-chat-template-kwargs }}'
+          if [ -n "$DEFAULT_CHAT_TEMPLATE_KWARGS_RAW" ]; then
+            DEFAULT_CHAT_TEMPLATE_KWARGS=(--default-chat-template-kwargs "$DEFAULT_CHAT_TEMPLATE_KWARGS_RAW")
+          else
+            DEFAULT_CHAT_TEMPLATE_KWARGS=()
+          fi
+
+          export MESH_DEVICE="${{ matrix.test-group.mesh-device }}"
+          if [ -n "${{ matrix.test-group.tt-llama-text-ver }}" ]; then
+            export TT_LLAMA_TEXT_VER="${{ matrix.test-group.tt-llama-text-ver }}"
+          fi
+          if [ -n "${{ matrix.test-group.tt-qwen3-text-ver }}" ]; then
+            export TT_QWEN3_TEXT_VER="${{ matrix.test-group.tt-qwen3-text-ver }}"
+          fi
+
+          # Keep TT cache separate from HF hub
+          export HF_MODEL="${{ matrix.test-group.model }}"
+          MODEL_NAME="${HF_MODEL/\//--}"
+          export TT_CACHE_PATH="$TT_CACHE_HOME/$MODEL_NAME"
+
+          # vLLM environment variables
+          export VLLM_RPC_TIMEOUT=300000
+
+          if [ -n "${{ matrix.test-group.tt_mm_throttle_perf }}" ]; then
+            export TT_MM_THROTTLE_PERF="${{ matrix.test-group.tt_mm_throttle_perf }}"
+          fi
+
+          # Gemma4 trace-region tuning for this benchmark (random-input-len 100,
+          # single-stream max_num_seqs=1):
+          #   * The prefill trace bucket sweep (128..4096) is the dominant trace
+          #     consumer — the 4096 bucket alone is ~0.5 GB on 26B-A4B — yet a
+          #     100-token prompt only ever replays the 128 bucket. Limit it so the
+          #     trace region stays small and startup is fast.
+          #   * Decode warmup captures one resident trace per sampling-param
+          #     permutation; the full penalties×logprobs sweep is unused by the
+          #     default-sampling benchmark. Warm only plain/greedy/None.
+          # Both shrink the required trace_region_size (validated to fit <200 MB
+          # on 26B-A4B P150x4, vs >1 GB unbounded).
+          case "$HF_MODEL" in
+            google/gemma-4-*)
+              export TT_LEAN_DECODE_WARMUP=1
+              export GEMMA4_TRACE_PREFILL_SEQ_LENS=128
+              # 31B: with hybrid KV groups disabled every layer allocates a
+              # full-length KV buffer, and the default all-user pool OOMs DRAM
+              # on QB2/T3K. Cap the pool (the real DRAM lever, distinct from
+              # --max_model_len). See tt-metal #49257 / #49083.
+              if [ "$HF_MODEL" = "google/gemma-4-31B-it" ]; then
+                export GEMMA4_MAX_TOKENS_ALL_USERS=32768
+              fi
+              ;;
+          esac
+
+          # Build the VLLM server arguments array
+          declare -a VLLM_SERVER_ARGS
+          VLLM_SERVER_ARGS+=(--model "$HF_MODEL")
+          VLLM_SERVER_ARGS+=("${ADDITIONAL_SERVER_ARGS[@]}")
+          VLLM_SERVER_ARGS+=("${DEFAULT_CHAT_TEMPLATE_KWARGS[@]}")
+          VLLM_SERVER_ARGS+=("${ADDITIONAL_CONFIG[@]}")
+
+          echo "vLLM server args: ${VLLM_SERVER_ARGS[@]}"
+
+          python3 vllm-tt-plugin/examples/server_example_tt.py "${VLLM_SERVER_ARGS[@]}" > "${FILE_SERVER_LOG}" 2>&1 &
+
+          # Store server's pid for cleanup
+          echo $! > ${FILE_SERVER_PID}
+
+      - name: ⏰ Wait for server to be ready
+        run: |
+          echo "Waiting for server..."
+
+          timeout_seconds=$(( ${{ matrix.test-group.server-timeout }} * 60 ))
+          elapsed=0
+          interval=20
+
+          # Read the launcher PID once. ``read -r`` consumes only the
+          # first line, so a stray trailing line in the PID file can't
+          # turn ``$server_pid`` into a multi-token argument to
+          # ``kill -0``. A missing file or non-numeric content leaves
+          # ``$server_pid`` empty and the liveness check below silently
+          # skips rather than failing closed.
+          server_pid=""
+          if [ -f "${FILE_SERVER_PID}" ]; then
+            read -r server_pid < "${FILE_SERVER_PID}" || server_pid=""
+          fi
+          if ! [[ "$server_pid" =~ ^[0-9]+$ ]]; then
+            server_pid=""
+          fi
+
+          # vLLM writes one of these to the server log within seconds of
+          # an engine-core crash. Polling /health for the full
+          # server-timeout after one has appeared just burns CI minutes —
+          # fail fast so the rest of the matrix can move on. Using a
+          # single ``grep -m1`` with multiple ``-e`` patterns gives one
+          # bounded-by-first-match file scan per poll cycle even as the
+          # log grows.
+          fatal_grep_args=(
+            -F -m1
+            -e "EngineCore failed to start"
+            -e "EngineCore encountered a fatal error"
+            -e "EngineDeadError"
+            -e "Engine core initialization failed"
+            -e "Failed core proc"
+          )
+
+          while [ $elapsed -lt $timeout_seconds ]; do
+            if curl -sf http://localhost:8000/health; then
+              echo "Server is up! 🚀 [$elapsed sec]"
+              exit 0
+            fi
+
+            # Fast-fail when the launcher process has already exited.
+            if [ -n "$server_pid" ] && ! kill -0 "$server_pid" 2>/dev/null; then
+              echo "❌ Server launcher (pid=$server_pid) exited before becoming ready [$elapsed sec]."
+              echo "Check out the server log in a step below."
+              exit 1
+            fi
+
+            # Fast-fail on a fatal marker in the server log. The launcher
+            # may stay alive after engine cores crash (e.g. multiprocess
+            # DP), so the log signal complements the liveness check.
+            if [ -f "${FILE_SERVER_LOG}" ]; then
+              fatal_match=$(grep "${fatal_grep_args[@]}" "${FILE_SERVER_LOG}" 2>/dev/null) || true
+              if [ -n "$fatal_match" ]; then
+                echo "❌ Fatal marker in server log [$elapsed sec]: $fatal_match"
+                echo "Check out the server log in a step below."
+                exit 1
+              fi
+            fi
+
+            sleep $interval
+            elapsed=$((elapsed + interval))
+          done
+
+          echo "❌ Server did not become ready in time (${timeout_seconds}s)."
+          echo "Check out the server log in a step below."
+          exit 1
+
+      - name: 📐 Run benchmark
+        timeout-minutes: ${{ matrix.test-group.benchmark-timeout }}
+        uses: ./docker-job/.github/actions/run-with-log
+        with:
+          log-file: ${{ env.FILE_BENCHMARK_LOG }}
+          run: |
+            if [ -n "${{ matrix.test-group.additional-benchmark-args }}" ]; then
+              ADDITIONAL_BENCHMARK_ARGS=(${{ matrix.test-group.additional-benchmark-args }})
+            else
+              ADDITIONAL_BENCHMARK_ARGS=()
+            fi
+
+            vllm bench serve \
+              --backend vllm \
+              --model ${{ matrix.test-group.model }} \
+              --dataset-name random \
+              --random-input-len 100 \
+              --random-output-len 100 \
+              --num-prompts 32 \
+              --ignore-eos \
+              --percentile-metrics ttft,tpot,itl,e2el \
+              --save-result \
+              --result-filename output/vllm_result.json \
+              "${ADDITIONAL_BENCHMARK_ARGS[@]}"
+      - name: Verify benchmark
+        run: |
+          # `vllm bench serve` exits 0 even when individual requests fail (a crashed
+          # engine surfaces as failed requests, not a non-zero exit). Gate on the saved result and
+          # require EVERY request to complete successfully.
+          RESULT_JSON="output/vllm_result.json"
+          if [ ! -f "$RESULT_JSON" ]; then
+            echo "❌ Benchmark result file not found ($RESULT_JSON) — the benchmark did not complete"
+            echo "Check out the server log in a step below."
+            exit 1
+          fi
+          completed=$(python3 -c "import json; print(json.load(open('$RESULT_JSON'))['completed'])")
+          expected=$(python3 -c "import json; print(json.load(open('$RESULT_JSON'))['num_prompts'])")
+          if [ "$completed" != "$expected" ]; then
+            echo "❌ Only $completed/$expected requests completed successfully (require all)"
+            echo "Check out the server log in a step below."
+            exit 1
+          fi
+          echo "✅ All $expected requests completed successfully"
+
+      - name: 🧠 Run coherence guard (verbatim echo)
+        if: ${{ matrix.test-group.coherence-test }}
+        timeout-minutes: ${{ matrix.test-group.benchmark-timeout }}
+        run: |
+          # Coherence guard: the other CI steps only check structural/throughput
+          # properties (request completion, structured-output schema). A backend
+          # regression that corrupts the forward pass (e.g. a broken on-device
+          # decode trace) still returns deterministic, well-formed-but-garbage
+          # tokens, so those checks pass while the model emits gibberish. Requiring
+          # a verbatim echo of a simple sentence catches that class of bug directly.
+          SENTENCE="The quick brown fox jumps over the lazy dog."
+          curl http://localhost:8000/v1/chat/completions \
+            -H "Content-Type: application/json" \
+            -H "X-User-ID: vllm_test" \
+            -d "{
+              \"model\": \"${{ matrix.test-group.model }}\",
+              \"messages\": [
+                {
+                  \"role\": \"user\",
+                  \"content\": \"Repeat the following sentence exactly, with no extra words, no quotes, and no commentary: $SENTENCE\"
+                }
+              ],
+              \"max_tokens\": 32,
+              \"temperature\": 0.0,
+              \"stream\": false,
+              \"ignore_eos\": false
+          }" \
+          2>&1 | tee ${FILE_COHERENCE_TEST_LOG}
+
+          # A model that cannot reproduce a simple sentence verbatim is not
+          # generating coherent text.
+          if ! grep -qF "$SENTENCE" "${FILE_COHERENCE_TEST_LOG}"; then
+            echo "❌ Coherence guard failed: model did not echo the sentence verbatim (likely gibberish from a corrupted forward pass)."
+            echo "Check out the server log in a step below."
+            exit 1
+          fi
+          echo "✅ Coherence guard passed: verbatim echo found"
+
+      - name: 📐 Run structured output benchmark
+        if: ${{ matrix.test-group.structured-output }}
+        timeout-minutes: ${{ matrix.test-group.benchmark-timeout }}
+        uses: ./docker-job/.github/actions/run-with-log
+        with:
+          log-file: ${{ env.FILE_BENCHMARK_STRUCTURED_OUTPUT_LOG }}
+          run: |
+            if [ -n "${{ matrix.test-group.additional-benchmark-args }}" ]; then
+              ADDITIONAL_BENCHMARK_ARGS=(${{ matrix.test-group.additional-benchmark-args }})
+            else
+              ADDITIONAL_BENCHMARK_ARGS=()
+            fi
+
+            if [ -n "${{ matrix.test-group.additional-structured-output-args }}" ]; then
+              ADDITIONAL_STRUCTURED_OUTPUT_ARGS=(${{ matrix.test-group.additional-structured-output-args }})
+            else
+              ADDITIONAL_STRUCTURED_OUTPUT_ARGS=()
+            fi
+
+            python3 vllm-source/benchmarks/benchmark_serving_structured_output.py \
+              --backend vllm \
+              --model ${{ matrix.test-group.model }} \
+              --num-prompts 32 \
+              --percentile-metrics ttft,tpot,itl,e2el \
+              --dataset json-unique \
+              --output-len 1024 \
+              --save-results \
+              --result-filename output/vllm_result_structured.json \
+              "${ADDITIONAL_BENCHMARK_ARGS[@]}" \
+              "${ADDITIONAL_STRUCTURED_OUTPUT_ARGS[@]}"
+
+            # The model degenerates (repetition/enumeration runaway) on ~1-2% of
+            # structured prompts regardless of vLLM version or sampling temperature,
+            # so an exact-100% gate is a coin flip. Allow up to 2 of 32 to fail:
+            # 30/32 = 93.75%.
+            python3 -c "import json,sys; r=float(json.load(open('output/vllm_result_structured.json'))['correct_rate(%)']); print(f'correct_rate(%)={r}'); sys.exit(0 if r>=93.75 else 1)" \
+              || { echo '❌ Structured output below 93.75% (more than 2/32 failed)'; exit 1; }
+            echo '✅ Structured output passed (correct_rate >= 93.75%)'
+
+      - name: 🖼️ Run multimodal test
+        if: ${{ matrix.test-group.multimodal }}
+        timeout-minutes: ${{ matrix.test-group.benchmark-timeout }}
+        uses: ./docker-job/.github/actions/run-with-log
+        with:
+          log-file: ${{ env.FILE_MULTIMODAL_TEST_LOG }}
+          run: |
+            resp=$(curl -sS http://localhost:8000/v1/chat/completions \
+              -H "Content-Type: application/json" \
+              -H "X-User-ID: vllm_test" \
+              -d '{
+                "model": "${{ matrix.test-group.model }}",
+                "messages": [
+                  {
+                    "role": "user",
+                    "content": [
+                      {
+                        "type": "text",
+                        "text": "Describe this image in 50 words."
+                      },
+                      {
+                        "type": "image_url",
+                        "image_url": {
+                          "url": "https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/cats.jpeg"
+                        }
+                      }
+                    ]
+                  }
+                ],
+                "max_tokens": 512,
+                "temperature": 0.0,
+                "top_p": 0.9,
+                "top_k": 10,
+                "repetition_penalty": 1.0,
+                "stream": false,
+                "ignore_eos": false
+            }')
+            echo "$resp"
+            # cats.jpeg: a correct description mentions a cat, so its absence
+            # means the model or image pipeline misbehaved. Grep the captured
+            # response (not the log) to stay race-free under the wrapper.
+            grep -qi cat <<<"$resp" || { echo '❌ keyword "cat" not found in multimodal response'; exit 1; }
+            echo '✅ Multimodal response describes a cat'
+      - name: 🧪 Run sampling tests
+        if: ${{ matrix.test-group.sampling-tests }}
+        timeout-minutes: ${{ matrix.test-group.sampling-test-timeout || 10 }}
+        uses: ./docker-job/.github/actions/run-with-log
+        with:
+          log-file: ${{ env.FILE_SAMPLING_TESTS_LOG }}
+          run: |
+            FILTER="${{ matrix.test-group.sampling-test-filter }}"
+            if [ -n "$FILTER" ]; then
+              pytest vllm-tt-plugin/tests/tt -v -k "$FILTER" --tt-server-url=http://localhost:8000 --tt-model-name=${{ matrix.test-group.model }}
+            else
+              pytest vllm-tt-plugin/tests/tt -v --tt-server-url=http://localhost:8000 --tt-model-name=${{ matrix.test-group.model }}
+            fi
+
+      - name: 🧹 Cleanup server process
+        if: always()
+        run: |
+          if [ -f "${FILE_SERVER_PID}" ]; then
+            pid=$(cat "${FILE_SERVER_PID}")
+            if kill -0 "$pid" 2>/dev/null; then
+              kill "$pid"
+              echo "✅ Server process with PID $pid terminated."
+              rm -f "${FILE_SERVER_PID}"
+            else
+              echo "❌ Server process already down!"
+              echo "Check out the server log in a step below."
+              exit 1
+            fi
+          else
+            echo "❌ PID file not found. Server may not have started correctly."
+            exit 1
+          fi
+
+      - name: Show server log
+        if: always()
+        continue-on-error: true
+        run: |
+          cat "${FILE_SERVER_LOG}"
+
+      - name: Show report
+        if: always()
+        continue-on-error: true
+        run: |
+          cat output/vllm_result.json
+
+      - name: Show structured output report
+        if: ${{ always() && matrix.test-group.structured-output }}
+        continue-on-error: true
+        run: |
+          cat output/vllm_result_structured.json
+
+      - name: 🤖 AI job summary
+        if: always() && !cancelled()
+        continue-on-error: true
+        uses: tenstorrent/tt-github-actions/.github/actions/ai_summary/job@main
+        with:
+          config: |
+            {
+              "model": "${{ vars.AI_SUMMARY_MODEL }}",
+              "workspace": "$GITHUB_WORKSPACE/docker-job",
+              "input_dirs": ["output"],
+              "output_dir": "ai_summaries"
+            }
+          api-key: ${{ secrets.TT_CHAT_API_KEY }}
+          api-url: ${{ secrets.TT_CHAT_URL }}
+          job-name: ${{ matrix.test-group.name }}
+
+      - name: Set artifact prefix
+        if: ${{ !cancelled() }}
+        id: set-artifact-prefix
+        run: |
+          # Replace spaces with underscores
+          SAFE_NAME=$(echo "${{ matrix.test-group.name }}" | tr ' ' '_')
+          echo "prefix=vllm_output_${SAFE_NAME}_" >> $GITHUB_OUTPUT
+
+      - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
+        timeout-minutes: 10
+        if: ${{ !cancelled() }}
+        with:
+          path: docker-job/output/
+          prefix: ${{ steps.set-artifact-prefix.outputs.prefix }}
+
+      - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
+        if: always()
+
+  ai-run-summary:
+    name: "AI Run Summary"
+    needs: [generate-matrix, vllm-tests]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        timeout-minutes: 20
+      - id: ai-run-summary
+        continue-on-error: true
+        uses: tenstorrent/tt-github-actions/.github/actions/ai_summary/run@main
+        with:
+          config: |
+            {
+              "model": "${{ vars.AI_SUMMARY_MODEL }}",
+              "workspace": "$GITHUB_WORKSPACE",
+              "input_dir": "ai_job_summaries",
+              "output_dir": "ai_run_summaries"
+            }
+          api-key: ${{ secrets.TT_CHAT_API_KEY }}
+          api-url: ${{ secrets.TT_CHAT_URL }}
+          expected-jobs: ${{ needs.generate-matrix.outputs.matrix }}
+          run-result: ${{ needs.vllm-tests.result }}
+      - name: Show report
+        if: always() && steps.ai-run-summary.outputs.report-file != ''
+        continue-on-error: true
+        shell: bash
+        env:
+          REPORT_FILE: ${{ steps.ai-run-summary.outputs.report-file }}
+        run: |
+          if [ -f "$REPORT_FILE" ]; then
+            cat "$REPORT_FILE"
+            cat "$REPORT_FILE" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "::warning::Report file not found: $REPORT_FILE"
+          fi

--- a/.github/workflows/vllm-tt-plugin-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-tt-plugin-nightly-tests-impl.yaml
@@ -819,6 +819,7 @@ jobs:
             # structured prompts regardless of vLLM version or sampling temperature,
             # so an exact-100% gate is a coin flip. Allow up to 2 of 32 to fail:
             # 30/32 = 93.75%.
+            # TODO: Remove this once we pass 100% again (maybe https://github.com/tenstorrent/tt-metal/pull/51148)
             python3 -c "import json,sys; r=float(json.load(open('output/vllm_result_structured.json'))['correct_rate(%)']); print(f'correct_rate(%)={r}'); sys.exit(0 if r>=93.75 else 1)" \
               || { echo '❌ Structured output below 93.75% (more than 2/32 failed)'; exit 1; }
             echo '✅ Structured output passed (correct_rate >= 93.75%)'

--- a/.github/workflows/vllm-tt-plugin-nightly-tests.yaml
+++ b/.github/workflows/vllm-tt-plugin-nightly-tests.yaml
@@ -1,0 +1,87 @@
+name: "vLLM TT plugin nightly tests"
+
+on:
+  workflow_dispatch:
+    inputs:
+      vllm-tt-plugin-ref:
+        description: "vLLM TT plugin branch or sha"
+        required: false
+        default: main
+      model:
+        description: "Model to test"
+        required: false
+        type: choice
+        default: "all"
+        options:
+          - all
+          - meta-llama/Llama-3.1-8B-Instruct
+          - meta-llama/Llama-3.3-70B-Instruct
+          - Qwen/Qwen3-32B
+          - Qwen/Qwen3.6-27B
+          - Qwen/Qwen2.5-VL-72B-Instruct
+          - Qwen/Qwen3-VL-32B-Instruct
+          - google/gemma-3-27b-it
+          - google/gemma-4
+          - openai/gpt-oss-120b
+          # - models/vllm_test_utils/t3000_multiproc_test
+          - models/vllm_test_utils/no_op_test
+      platform:
+        required: false
+        type: choice
+        default: "Ubuntu 22.04"
+        options:
+          - "Ubuntu 22.04"
+          - "Ubuntu 24.04"
+        description: "Platform to build and test"
+      build-type:
+        required: false
+        type: choice
+        default: Release
+        options:
+          - Release
+          - Debug
+          - RelWithDebInfo
+          - ASan
+          - TSan
+        description: "Build type configuration"
+      enable-lto:
+        required: false
+        type: boolean
+        default: false
+        description: "Enable Link Time Optimization (LTO)"
+      mlperf-read-only:
+        required: false
+        type: boolean
+        default: true
+        description: "Mount /mnt/MLPerf as read-only (uncheck for read-write access)"
+  schedule:
+    # Offset from the "vLLM nightly tests" 12am UTC run so the two pipelines do
+    # not contend for the same hardware runners.
+    - cron: "0 6 * * *" # This cron schedule runs the workflow every day at 6am UTC
+
+jobs:
+  check-harbor:
+    uses: ./.github/workflows/check-harbor.yaml
+  build-artifact:
+    needs: check-harbor
+    uses: ./.github/workflows/build-artifact.yaml
+    permissions:
+      contents: read
+      packages: write
+    secrets: inherit
+    with:
+      build-type: ${{ inputs.build-type || 'Release' }}
+      platform: ${{ inputs.platform || 'Ubuntu 22.04' }}
+      enable-lto: ${{ inputs.enable-lto || false }}
+      build-wheel: true
+  vllm-tt-plugin-tests:
+    needs: [check-harbor, build-artifact]
+    secrets: inherit
+    uses: ./.github/workflows/vllm-tt-plugin-nightly-tests-impl.yaml
+    with:
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+      vllm-tt-plugin-ref: ${{ inputs.vllm-tt-plugin-ref || 'main' }}
+      model: ${{ inputs.model || 'all' }}
+      mlperf-read-only: ${{ inputs.mlperf-read-only != false }}

--- a/models/model_ci_tiers.md
+++ b/models/model_ci_tiers.md
@@ -149,4 +149,6 @@ Captures device timing for a single layer of each target model, used to track pe
 | Merge Gate | [`Merge Gate`](../.github/workflows/merge-gate.yaml) |
 | vLLM nightly tests | [`vLLM nightly tests`](../.github/workflows/vllm-nightly-tests.yaml) |
 | vLLM nightly impl | [`[internal] vLLM nightly tests impl`](../.github/workflows/vllm-nightly-tests-impl.yaml) |
+| vLLM TT plugin nightly tests | [`vLLM TT plugin nightly tests`](../.github/workflows/vllm-tt-plugin-nightly-tests.yaml) |
+| vLLM TT plugin nightly impl | [`[internal] vLLM TT plugin nightly tests impl`](../.github/workflows/vllm-tt-plugin-nightly-tests-impl.yaml) |
 | Galaxy stress tests | [`(Galaxy) Stress`](../.github/workflows/galaxy-stress-tests.yaml) |


### PR DESCRIPTION
### Summary

Adds a new nightly workflow that exercises the out-of-tree tenstorrent/vllm-tt-plugin repo instead of the in-monorepo tenstorrent/vllm fork. The existing "vLLM nightly tests" pipeline is left untouched so both can run side by side during the migration.

Differences from the in-tree pipeline:
 * checks out tenstorrent/vllm-tt-plugin and installs it via the repo's own docs/install-vllm-tt.sh
 * PYTHONPATH points at the plugin's src/ layout (no vllm_dir)
 * benchmark_serving_structured_output.py is not shipped with the plugin, so the upstream vllm-project/vllm tag matching the installed wheel is shallow-cloned into vllm-source/ for it
 * runs at 6am UTC rather than midnight to avoid runner contention

Also folds in fixes validated on viktorpus/vllm-nightly-oot-plugin:
* GPT-OSS low-latency benchmark timeout 15m -> 30m
* Qwen3-VL structured output driven through the chat endpoint
* 93.75% (30/32) structured-output gate instead of an exact-100% one, which the model's occasional repetition runaway makes a coin flip (temporary)

PR https://github.com/tenstorrent/tt-metal/pull/48919 did the same thing but was replacing the old vllm nightly CI, rather than just adding. This allows to have both for some time.

Result: https://github.com/tenstorrent/tt-metal/actions/runs/30285333689

To be decided whether to merge before or after pipeline reorg https://github.com/tenstorrent/tt-metal/pull/50910

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=viktorpus/vllm-tt-plugin-nightly-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:viktorpus/vllm-tt-plugin-nightly-ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=viktorpus/vllm-tt-plugin-nightly-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:viktorpus/vllm-tt-plugin-nightly-ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=viktorpus/vllm-tt-plugin-nightly-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:viktorpus/vllm-tt-plugin-nightly-ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=viktorpus/vllm-tt-plugin-nightly-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:viktorpus/vllm-tt-plugin-nightly-ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=viktorpus/vllm-tt-plugin-nightly-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:viktorpus/vllm-tt-plugin-nightly-ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=viktorpus/vllm-tt-plugin-nightly-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:viktorpus/vllm-tt-plugin-nightly-ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=viktorpus/vllm-tt-plugin-nightly-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:viktorpus/vllm-tt-plugin-nightly-ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=viktorpus/vllm-tt-plugin-nightly-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:viktorpus/vllm-tt-plugin-nightly-ci)