### PR TITLE
Fix auto-approve UMD job failing on bracketed bot usernames (curl URL globbing) [skip ci]

### DIFF
--- a/.github/workflows/auto-approve.yaml
+++ b/.github/workflows/auto-approve.yaml
@@ -189,7 +189,10 @@ jobs:
         run: |
           # Check if the PR author is a member of tenstorrent/umd-admins.
           # Uses the PAT (which has org:read scope) to query team membership.
-          HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+          # -g (--globoff) is required: bot logins like github-actions[bot] contain
+          # [ ] which curl would otherwise parse as glob/range syntax and reject
+          # the URL as malformed (exit 3) before any request is made.
+          HTTP_CODE=$(curl -s -g -o /dev/null -w "%{http_code}" \
             -H "Authorization: Bearer $GH_TOKEN" \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \


### PR DESCRIPTION
### Problem

The `auto-approve-umd` job in `.github/workflows/auto-approve.yaml` puts a red X on unrelated PRs whenever the PR author's login contains square brackets — i.e. any bot: `github-actions[bot]`, `dependabot[bot]`.

Observed live on #51111, an unrelated repo-assist auto-fix PR authored by `github-actions[bot]`:
https://github.com/tenstorrent/tt-metal/actions/runs/30313161404/job/90203890600

### Root cause

Unlike the other three jobs, `auto-approve-umd` cannot hardcode an author in `if:` — `umd-admins` is a *team*, not one person. So its first step ("Check umd-admins team membership") runs for **every** non-draft PR and interpolates the PR author's login into a curl URL path:

```bash
"https://api.github.com/orgs/tenstorrent/teams/umd-admins/members/${PR_AUTHOR}"
```

`curl` treats `[` and `]` in a URL as its own glob/range syntax unless `-g`/`--globoff` is given. With `PR_AUTHOR=github-actions[bot]`, curl parses `[bot]` as an invalid range, and exits **3 (URL malformed)** without ever making a request. The non-zero exit fails the step, the job, and the check.

Reproduced locally:

```
$ PR_AUTHOR='github-actions[bot]'
$ curl -s -o /dev/null -w "%{http_code}" ".../members/${PR_AUTHOR}"; echo "exit=$?"
exit=3          # no request made

$ curl -s -g -o /dev/null -w "%{http_code}" ".../members/${PR_AUTHOR}"; echo "exit=$?"
401 exit=0      # request made (401 = unauthenticated locally; 404 in CI = not a member)
```

### Fix

Add `-g` to that one curl invocation so brackets are treated literally. The request then completes and returns `404` for non-members, which the step already handles — it sets `is_member=false` and the job skips cleanly, as intended.

### Why only the UMD job

The `auto-approve-sfpi`, `auto-approve-ttsim` and `auto-approve-tracy` jobs gate on a hardcoded `github.event.pull_request.user.login == '...'` in their `if:`, so they never reach a curl call with an untrusted username. Their curl URLs interpolate only the numeric `$PR_NUMBER`; `$PR_AUTHOR` appears solely inside JSON `-d` bodies, which are not subject to URL globbing. No change needed there.

### Scope

One-line change plus an explanatory comment. No behavioral change for legitimate `umd-admins` members (their logins contain no brackets, and `-g` only disables curl-side glob parsing).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=fix/auto-approve-umd-bracket-username)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:fix/auto-approve-umd-bracket-username)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=fix/auto-approve-umd-bracket-username)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:fix/auto-approve-umd-bracket-username)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=fix/auto-approve-umd-bracket-username)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:fix/auto-approve-umd-bracket-username)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fix/auto-approve-umd-bracket-username)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fix/auto-approve-umd-bracket-username)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=fix/auto-approve-umd-bracket-username)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:fix/auto-approve-umd-bracket-username)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=fix/auto-approve-umd-bracket-username)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:fix/auto-approve-umd-bracket-username)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=fix/auto-approve-umd-bracket-username)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:fix/auto-approve-umd-bracket-username)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=fix/auto-approve-umd-bracket-username)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:fix/auto-approve-umd-bracket-username)