### PR TITLE
[Feature] DIIM-278 - MPI stress test added to validation and recover

### DIFF
--- a/tools/scaleout/CMakeLists.txt
+++ b/tools/scaleout/CMakeLists.txt
@@ -270,6 +270,18 @@ target_link_libraries(
 )
 
 if(ENABLE_DISTRIBUTED)
+    # MPI stress test: ring-based sendrecv packet validation across all ranks
+    add_executable(run_mpi_stress_test validation/run_mpi_stress_test.cpp)
+
+    set_target_properties(
+        run_mpi_stress_test
+        PROPERTIES
+            RUNTIME_OUTPUT_DIRECTORY
+                ${Metalium_BINARY_DIR}/tools/scaleout
+    )
+
+    target_link_libraries(run_mpi_stress_test PRIVATE OpenMPI::MPI)
+
     # Generate rank bindings tool
     add_executable(generate_rank_bindings src/generate_rank_bindings.cpp)
 

--- a/tools/scaleout/exabox/recover.sh
+++ b/tools/scaleout/exabox/recover.sh
@@ -67,6 +67,7 @@ Optional:
     --skip-validation                       Skip validation, only run tt-smi reset
     --skip-version-check                     Skip the tt-smi/KMD/firmware version checks run on all hosts
                                             before recovery (see minimum versions in utils/host_utils.sh)
+    --skip-mpi-stress-test                  Skip the MPI packet stress test run before recovery
     --no-send-traffic                       Disable --send-traffic in cluster validation
     --check                                 Dry run: verify MPI can reach all hosts via hostname, then exit
     --mpi-if <interface>                    Network interface for MPI TCP transport
@@ -132,6 +133,7 @@ SLEEP_DURATION=5
 SKIP_RESET=false
 SKIP_VALIDATION=false
 SKIP_VERSION_CHECK=false
+SKIP_MPI_STRESS_TEST=false
 SEND_TRAFFIC=true
 CHECK=false
 MPI_IF=""
@@ -241,6 +243,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --skip-version-check)
             SKIP_VERSION_CHECK=true
+            shift
+            ;;
+        --skip-mpi-stress-test)
+            SKIP_MPI_STRESS_TEST=true
             shift
             ;;
         --no-send-traffic)
@@ -459,6 +465,7 @@ echo "Sleep after reset: ${SLEEP_DURATION}s"
 echo "Skip reset: $SKIP_RESET"
 echo "Skip validation: $SKIP_VALIDATION"
 echo "Skip version check: $SKIP_VERSION_CHECK"
+echo "Skip MPI stress test: $SKIP_MPI_STRESS_TEST"
 echo "Output directory: $OUTPUT_DIR"
 echo "Log file: $LOG_FILE"
 echo "Rerun on retrain: $RERUN_ON_RETRAIN"
@@ -479,6 +486,37 @@ if [[ "$SKIP_VERSION_CHECK" == false ]]; then
     fi
 else
     echo "Skipping version check (--skip-version-check)"
+    echo ""
+fi
+
+# Step 0.5: MPI packet stress test — validates MPI transport between all hosts before recovery.
+if [[ "$SKIP_MPI_STRESS_TEST" == false ]]; then
+    echo "Running MPI stress test (1000 iterations, 1048576 bytes/message)..."
+    MPI_STRESS_BIN="./build/tools/scaleout/run_mpi_stress_test"
+    if [[ -n "$DOCKER_IMAGE" ]]; then
+        ./tools/scaleout/exabox/mpi-docker --image "$DOCKER_IMAGE" \
+            --empty-entrypoint \
+            --tag-host \
+            --mpi-interface "$MPI_IF" \
+            "${MPI_EXTRA_ARGS[@]}" \
+            --host "$HOSTS" \
+            --map-by ppr:1:node \
+            --bind-to none \
+            "$MPI_STRESS_BIN" 1000 1048576
+    else
+        timeout --signal=TERM --kill-after=30s 1h mpirun \
+            --host "$HOSTS" \
+            --map-by ppr:1:node \
+            --bind-to none \
+            --mca btl self,vader,tcp \
+            --mca btl_tcp_if_include "$MPI_IF" \
+            "${MPI_EXTRA_ARGS[@]}" \
+            "$MPI_STRESS_BIN" 1000 1048576
+    fi
+    echo "MPI stress test passed."
+    echo ""
+else
+    echo "Skipping MPI stress test (--skip-mpi-stress-test)"
     echo ""
 fi
 

--- a/tools/scaleout/exabox/recover.sh
+++ b/tools/scaleout/exabox/recover.sh
@@ -490,7 +490,10 @@ else
 fi
 
 # Step 0.5: MPI packet stress test — validates MPI transport between all hosts before recovery.
-if [[ "$SKIP_MPI_STRESS_TEST" == false ]]; then
+if [[ "$SKIP_VALIDATION" == true ]]; then
+    echo "Skipping MPI stress test (--skip-validation)"
+    echo ""
+elif [[ "$SKIP_MPI_STRESS_TEST" == false ]]; then
     echo "Running MPI stress test (1000 iterations, 1048576 bytes/message)..."
     MPI_STRESS_BIN="./build/tools/scaleout/run_mpi_stress_test"
     if [[ -n "$DOCKER_IMAGE" ]]; then
@@ -502,6 +505,7 @@ if [[ "$SKIP_MPI_STRESS_TEST" == false ]]; then
             --host "$HOSTS" \
             --map-by ppr:1:node \
             --bind-to none \
+            --timeout 3600 \
             "$MPI_STRESS_BIN" 1000 1048576
     else
         timeout --signal=TERM --kill-after=30s 1h mpirun \

--- a/tools/scaleout/exabox/recover.sh
+++ b/tools/scaleout/exabox/recover.sh
@@ -126,7 +126,7 @@ EOF
 HOSTS=""
 CONFIG="4x32"
 DOCKER_IMAGE=""
-DOCKER_IMAGE_DEFAULT="ghcr.io/tenstorrent/tt-metal/upstream-tests-bh-glx:v0.76.0-dev20260721-30-g9dca5ec435f"
+DOCKER_IMAGE_DEFAULT="ghcr.io/tenstorrent/tt-metal/upstream-tests-bh-glx:v0.76.0-dev20260728-7-g04e4029f0e3"
 NUM_ITERATIONS=5
 MAX_ATTEMPTS=1
 SLEEP_DURATION=5

--- a/tools/scaleout/validation/run_mpi_stress_test.cpp
+++ b/tools/scaleout/validation/run_mpi_stress_test.cpp
@@ -91,7 +91,7 @@ int main(int argc, char** argv) {
         }
 
         if ((iteration % 1000) == 0) {
-            MPI_Allreduce(MPI_IN_PLACE, &expected, 1, MPI_UNSIGNED_CHAR, MPI_BXOR, MPI_COMM_WORLD);
+            MPI_Allreduce(MPI_IN_PLACE, &expected, 1, MPI_UINT8_T, MPI_BXOR, MPI_COMM_WORLD);
         }
     }
 

--- a/tools/scaleout/validation/run_mpi_stress_test.cpp
+++ b/tools/scaleout/validation/run_mpi_stress_test.cpp
@@ -1,0 +1,110 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <mpi.h>
+
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include <unistd.h>
+
+namespace {
+
+void abort_if(bool condition, const std::string& message, int rank) {
+    if (condition) {
+        std::cerr << "Rank " << rank << ": " << message << "\n";
+        MPI_Abort(MPI_COMM_WORLD, 1);
+    }
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    MPI_Init(&argc, &argv);
+
+    int rank = 0;
+    int size = 0;
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+
+    long iterations = 100000;
+    int message_size = 1024 * 1024;
+
+    if (argc > 1) {
+        iterations = std::strtol(argv[1], nullptr, 10);
+    }
+    if (argc > 2) {
+        message_size = std::atoi(argv[2]);
+    }
+
+    abort_if(size < 2, "At least two ranks are required", rank);
+    abort_if(iterations <= 0, "Invalid iteration count", rank);
+    abort_if(message_size <= 0, "Invalid message size", rank);
+
+    std::vector<uint8_t> sendbuf(static_cast<std::size_t>(message_size));
+    std::vector<uint8_t> recvbuf(static_cast<std::size_t>(message_size));
+
+    std::memset(sendbuf.data(), rank & 0xff, sendbuf.size());
+
+    int next = (rank + 1) % size;
+    int previous = (rank - 1 + size) % size;
+
+    std::string hostname(MPI_MAX_PROCESSOR_NAME, '\0');
+    int hostname_length = 0;
+    MPI_Get_processor_name(hostname.data(), &hostname_length);
+    hostname.resize(static_cast<std::size_t>(hostname_length));
+
+    std::cout << "Rank " << rank << "/" << size << " on " << hostname << ", pid " << getpid() << "\n" << std::flush;
+
+    MPI_Barrier(MPI_COMM_WORLD);
+    double start = MPI_Wtime();
+
+    for (long iteration = 0; iteration < iterations; ++iteration) {
+        MPI_Sendrecv(
+            sendbuf.data(),
+            message_size,
+            MPI_BYTE,
+            next,
+            100,
+            recvbuf.data(),
+            message_size,
+            MPI_BYTE,
+            previous,
+            100,
+            MPI_COMM_WORLD,
+            MPI_STATUS_IGNORE);
+
+        uint8_t expected = static_cast<uint8_t>(previous & 0xff);
+
+        if (recvbuf[0] != expected || recvbuf[static_cast<std::size_t>(message_size) - 1] != expected) {
+            std::cerr << "Rank " << rank << ": corruption at iteration " << iteration
+                      << "; expected=" << static_cast<unsigned>(expected)
+                      << " first=" << static_cast<unsigned>(recvbuf[0])
+                      << " last=" << static_cast<unsigned>(recvbuf[static_cast<std::size_t>(message_size) - 1]) << "\n";
+            MPI_Abort(MPI_COMM_WORLD, 2);
+        }
+
+        if ((iteration % 1000) == 0) {
+            MPI_Allreduce(MPI_IN_PLACE, &expected, 1, MPI_UNSIGNED_CHAR, MPI_BXOR, MPI_COMM_WORLD);
+        }
+    }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+    double elapsed = MPI_Wtime() - start;
+
+    double maximum_elapsed = 0.0;
+    MPI_Reduce(&elapsed, &maximum_elapsed, 1, MPI_DOUBLE, MPI_MAX, 0, MPI_COMM_WORLD);
+
+    if (rank == 0) {
+        std::cout << "PASS: " << iterations << " iterations, " << message_size << " bytes/message, " << maximum_elapsed
+                  << " seconds\n";
+    }
+
+    MPI_Finalize();
+    return 0;
+}

--- a/tools/scaleout/validation/run_mpi_stress_test.cpp
+++ b/tools/scaleout/validation/run_mpi_stress_test.cpp
@@ -81,12 +81,13 @@ int main(int argc, char** argv) {
 
         uint8_t expected = static_cast<uint8_t>(previous & 0xff);
 
-        if (recvbuf[0] != expected || recvbuf[static_cast<std::size_t>(message_size) - 1] != expected) {
-            std::cerr << "Rank " << rank << ": corruption at iteration " << iteration
-                      << "; expected=" << static_cast<unsigned>(expected)
-                      << " first=" << static_cast<unsigned>(recvbuf[0])
-                      << " last=" << static_cast<unsigned>(recvbuf[static_cast<std::size_t>(message_size) - 1]) << "\n";
-            MPI_Abort(MPI_COMM_WORLD, 2);
+        for (std::size_t offset = 0; offset < recvbuf.size(); ++offset) {
+            if (recvbuf[offset] != expected) {
+                std::cerr << "Rank " << rank << ": corruption at iteration " << iteration << "; offset=" << offset
+                          << " expected=" << static_cast<unsigned>(expected)
+                          << " actual=" << static_cast<unsigned>(recvbuf[offset]) << "\n";
+                MPI_Abort(MPI_COMM_WORLD, 2);
+            }
         }
 
         if ((iteration % 1000) == 0) {


### PR DESCRIPTION
### Ticket

[DIIM-278]()

### Summary

- Created MPI packet stress test,
- Added to `tools/scaleout/CMakeLists.txt` under `ENABLE_DISTRIBUTED`, linked against `OpenMPI::MPI`
- Integrated into `recover.sh` as a preflight step (Step 0.5) before the recovery loop
  - Respects both `--skip-validation` and `--skip-mpi-stress-test`
  - Docker path bounded with `--timeout 3600`; local path with `timeout 1h`
  - Output tagged with `[hostname]` for consistent logging
- Full buffer corruption check on every byte (reports first mismatching offset)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mgajewskiTT/DIIM-278-add-pre-flight-host-availability-check-cli-for-multi-host-operations)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mgajewskiTT/DIIM-278-add-pre-flight-host-availability-check-cli-for-multi-host-operations)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mgajewskiTT/DIIM-278-add-pre-flight-host-availability-check-cli-for-multi-host-operations)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mgajewskiTT/DIIM-278-add-pre-flight-host-availability-check-cli-for-multi-host-operations)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mgajewskiTT/DIIM-278-add-pre-flight-host-availability-check-cli-for-multi-host-operations)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mgajewskiTT/DIIM-278-add-pre-flight-host-availability-check-cli-for-multi-host-operations)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mgajewskiTT/DIIM-278-add-pre-flight-host-availability-check-cli-for-multi-host-operations)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mgajewskiTT/DIIM-278-add-pre-flight-host-availability-check-cli-for-multi-host-operations)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mgajewskiTT/DIIM-278-add-pre-flight-host-availability-check-cli-for-multi-host-operations)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mgajewskiTT/DIIM-278-add-pre-flight-host-availability-check-cli-for-multi-host-operations)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mgajewskiTT/DIIM-278-add-pre-flight-host-availability-check-cli-for-multi-host-operations)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mgajewskiTT/DIIM-278-add-pre-flight-host-availability-check-cli-for-multi-host-operations)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mgajewskiTT/DIIM-278-add-pre-flight-host-availability-check-cli-for-multi-host-operations)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mgajewskiTT/DIIM-278-add-pre-flight-host-availability-check-cli-for-multi-host-operations)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mgajewskiTT/DIIM-278-add-pre-flight-host-availability-check-cli-for-multi-host-operations)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mgajewskiTT/DIIM-278-add-pre-flight-host-availability-check-cli-for-multi-host-operations)