### PR TITLE
[LLK][Quasar] Add reduce block max row support

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/packer/common.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/packer/common.py
@@ -7,6 +7,7 @@ from fuser.wormhole.packer.common import (  # noqa: F401
     configure_pack,
     l1_accumulation_config,
     pack_dest_init,
+    pack_reduce_mask_config,
     packer_dest_section_done,
     packer_sync_with_unpacker,
     packer_wait_for_math,

--- a/tt_metal/tt-llk/tests/python_tests/fuser/fused_fpu.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/fused_fpu.py
@@ -75,6 +75,21 @@ class Fpu:
         """
         return ""
 
+    def pack_tile_condition(
+        self,
+        operation: "FusedOperation",
+        config: "GlobalConfig",
+        compute_unit: "FpuNode",
+        block: "BlockData",
+    ) -> str:
+        """Return a C++ condition selecting destination tiles produced by this FPU.
+
+        Most FPU operations produce every destination tile in a block and return
+        an empty condition. Sparse producers can override this so packers avoid
+        consuming destination tiles that math did not write.
+        """
+        return ""
+
     def uninit(
         self,
         operation: "FusedOperation",

--- a/tt_metal/tt-llk/tests/python_tests/fuser/fused_math.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/fused_math.py
@@ -361,7 +361,8 @@ class ComputePipeline:
     def _pack_reduce_mask_config(self, operation: "FusedOperation") -> str:
         if operation.reduce_dim is not None:
             reduce_dim = operation.reduce_dim.cpp_enum_value
-            return f"_llk_pack_reduce_mask_config_<{reduce_dim}>();\n"
+            tensor_shape = self.pack_nodes[0].output.tile_shape.cpp_value
+            return pack_common.pack_reduce_mask_config(reduce_dim, tensor_shape)
         return ""
 
     def _pack_reduce_mask_clear(self, operation: "FusedOperation") -> str:

--- a/tt_metal/tt-llk/tests/python_tests/fuser/quasar/fpu/common.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/quasar/fpu/common.py
@@ -26,12 +26,12 @@ def configure_math(
 
 
 def math_pack_sync_init(dest_sync: str, dest_acc: str) -> str:
-    return "set_up_dest_dvalid_per_thread<dest_dvalid_client::FPU>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});\n"
+    return f"_llk_math_pack_sync_init_<{dest_sync}>();\n"
 
 
 def math_wait_for_dest(dest_sync: str) -> str:
-    return ""
+    return "_llk_math_wait_for_dest_available_();\n"
 
 
 def math_dest_section_done(dest_sync: str, dest_acc: str) -> str:
-    return f"_llk_math_set_dvalid_<p_cleardvalid::FPU, {dest_sync}>();\n"
+    return f"_llk_math_dest_section_done_<{dest_sync}, {dest_acc}>();\n"

--- a/tt_metal/tt-llk/tests/python_tests/fuser/quasar/fpu/reduce_block_max.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/quasar/fpu/reduce_block_max.py
@@ -1,0 +1,166 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import List, Tuple
+
+import torch
+from fuser.block_data import BlockData
+from fuser.fpu_node import FpuNode
+from fuser.fused_fpu import Fpu
+from fuser.fused_loop import FusedLoop, LoopTileByTile
+from fuser.fused_operation import FusedOperation
+from fuser.fuser_config import GlobalConfig
+from helpers.golden_generators import ReduceBlockMaxRowGolden, get_golden_generator
+from helpers.llk_params import ReduceDimension
+
+
+class ReduceBlockMaxFpu(Fpu):
+    loop: FusedLoop = LoopTileByTile()
+    reduce_dim: ReduceDimension = ReduceDimension.Row
+
+    per_block_init = True
+
+    def init(
+        self,
+        operation: FusedOperation,
+        config: GlobalConfig,
+        compute_unit: FpuNode,
+        block: BlockData,
+    ) -> str:
+        ct_dim = block.block_tiles_x
+        dest_acc = config.dest_acc.cpp_enum_value
+        tensor_shape = compute_unit.src_a.tile_shape.cpp_value
+        return f"_llk_math_reduce_block_max_row_init_<{ct_dim}, {dest_acc}>({tensor_shape});\n"
+
+    def calculate(
+        self,
+        operation: FusedOperation,
+        config: GlobalConfig,
+        compute_unit: FpuNode,
+        block: BlockData,
+    ) -> str:
+        ct_dim = block.block_tiles_x
+        dest_acc = config.dest_acc.cpp_enum_value
+        tensor_shape = compute_unit.src_a.tile_shape.cpp_value
+        tile_x_in_block = f"(({block.tile_id_block}) % {block.block_tiles_x})"
+        tile_y_in_block = f"(({block.tile_id_block}) / {block.block_tiles_x})"
+        dest_expr = f"(({tile_y_in_block}) * {block.block_tiles_x})"
+        return (
+            f"if (({tile_x_in_block}) % {ct_dim} == 0 ) {{\n"
+            f"    _llk_math_reduce_block_max_row_<{ct_dim}, {dest_acc}>({dest_expr}, {tensor_shape});\n"
+            f"}}\n"
+        )
+
+    def pack_tile_condition(
+        self,
+        operation: FusedOperation,
+        config: GlobalConfig,
+        compute_unit: FpuNode,
+        block: BlockData,
+    ) -> str:
+        return f"(({block.tile_id_block}) % {block.block_tiles_x}) == 0"
+
+    def uninit(
+        self,
+        operation: FusedOperation,
+        config: GlobalConfig,
+        compute_unit: FpuNode,
+        block: BlockData,
+    ) -> str:
+        return "_llk_math_reduce_block_max_row_uninit_();\n"
+
+    def golden(
+        self,
+        tensor_a: torch.Tensor,
+        tensor_b: torch.Tensor,
+        tensor_dst: torch.Tensor,
+        operation: FusedOperation,
+        config: GlobalConfig,
+        compute_unit: FpuNode,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        output_format = config.sentinel.golden_math_format
+
+        golden_tensor = torch.zeros_like(tensor_dst)
+        src_a_reduced_tensor = torch.zeros_like(tensor_a)
+        dest_golden_tensor = torch.zeros_like(tensor_dst)
+
+        tile_count_x = (
+            operation.max_output_dimensions[1] // operation.tile_shape.total_col_dim()
+        )
+        tile_count_y = (
+            operation.max_output_dimensions[0] // operation.tile_shape.total_row_dim()
+        )
+        block_tiles_x = operation.block_tiles_x
+        block_tiles_y = operation.block_tiles_y
+
+        full_blocks_x = tile_count_x // block_tiles_x
+        full_blocks_y = tile_count_y // block_tiles_y
+        remaining_tiles_x = tile_count_x % block_tiles_x
+        remaining_tiles_y = tile_count_y % block_tiles_y
+
+        full_x_limit = full_blocks_x * block_tiles_x
+        full_y_limit = full_blocks_y * block_tiles_y
+
+        generate_golden = get_golden_generator(ReduceBlockMaxRowGolden)
+
+        # Rows/cols per tile: 32x32 tiles use 32, 16x32 tiny tiles use 16 rows (one face-row).
+        tile_r = operation.tile_shape.total_row_dim()
+        tile_c = operation.tile_shape.total_col_dim()
+
+        def process_block(block_x, block_y, block_tiles_x_eff, block_tiles_y_eff):
+            src_start_row = block_y * tile_r
+            src_end_row = (block_y + block_tiles_y_eff) * tile_r
+            start_col = block_x * tile_c
+            end_col = (block_x + block_tiles_x_eff) * tile_c
+            dst_start_row = block_y * tile_r
+            dst_end_row = (block_y + block_tiles_y_eff) * tile_r
+            block_dims = [block_tiles_y_eff * tile_r, block_tiles_x_eff * tile_c]
+
+            src_a_reduced_tensor[dst_start_row:dst_end_row, start_col:end_col] = (
+                generate_golden(
+                    tensor_a[src_start_row:src_end_row, start_col:end_col].clone(),
+                    block_tiles_x_eff,
+                    output_format,
+                    block_dims,
+                )
+            )
+
+            dest_golden_tensor[dst_start_row:dst_end_row, start_col:end_col] = (
+                generate_golden(
+                    tensor_dst[src_start_row:src_end_row, start_col:end_col].clone(),
+                    block_tiles_x_eff,
+                    output_format,
+                    block_dims,
+                )
+            )
+
+        if full_blocks_x > 0 and full_blocks_y > 0:
+            for block_x in range(0, full_x_limit, block_tiles_x):
+                for block_y in range(0, full_y_limit, block_tiles_y):
+                    process_block(block_x, block_y, block_tiles_x, block_tiles_y)
+
+        if remaining_tiles_y > 0 and full_blocks_x > 0:
+            for block_x in range(0, full_x_limit, block_tiles_x):
+                process_block(block_x, full_y_limit, block_tiles_x, remaining_tiles_y)
+
+        if remaining_tiles_x > 0 and full_blocks_y > 0:
+            for block_y in range(0, full_y_limit, block_tiles_y):
+                process_block(full_x_limit, block_y, remaining_tiles_x, block_tiles_y)
+
+        if remaining_tiles_x > 0 and remaining_tiles_y > 0:
+            process_block(
+                full_x_limit, full_y_limit, remaining_tiles_x, remaining_tiles_y
+            )
+
+        golden_tensor = golden_tensor.flatten()
+        src_a_reduced_tensor = src_a_reduced_tensor.flatten()
+        dest_golden_tensor = dest_golden_tensor.flatten()
+
+        for i in range(golden_tensor.numel()):
+            golden_tensor[i] = max(src_a_reduced_tensor[i], dest_golden_tensor[i])
+
+        return (tensor_a, tensor_b, golden_tensor)
+
+    def get_headers(self) -> List[str]:
+        return ["experimental/llk_math_reduce_custom.h"]

--- a/tt_metal/tt-llk/tests/python_tests/fuser/quasar/packer/common.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/quasar/packer/common.py
@@ -31,7 +31,7 @@ def hw_configure_pack(
     pack_mode: str = "PackMode::Default",
 ) -> str:
     code = _emit_pack_buf_desc(output, pack_src, pack_dst)
-    code += f"_llk_pack_hw_configure_<p_pacr::PACK0>(td_pack);\n"
+    code += f"_llk_pack_hw_configure_<p_pacr::PACK0, {dest_acc}>(td_pack, ckernel::ReluConfig::none());\n"
     return code
 
 
@@ -43,9 +43,13 @@ def configure_pack(
 ) -> str:
     code = "{\n"
     code += _emit_pack_buf_desc(output, pack_src, pack_dst)
-    code += f"_llk_pack_hw_configure_<p_pacr::PACK0>(td_pack);\n"
+    code += f"_llk_pack_hw_configure_<p_pacr::PACK0, {dest_acc}>(td_pack, ckernel::ReluConfig::none());\n"
     code += "}\n"
     return code
+
+
+def pack_reduce_mask_config(reduce_dim: str, tensor_shape: str) -> str:
+    return f"_llk_pack_reduce_mask_config_<{reduce_dim}>({tensor_shape});\n"
 
 
 def relu_config(relu_config_val: int, dest_acc: str) -> str:
@@ -58,15 +62,15 @@ def l1_accumulation_config(pack_l1_accumulation: L1Accumulation) -> str:
 
 
 def pack_dest_init(dest_sync: str, dest_acc: str) -> str:
-    return "set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});\n"
+    return f"_llk_pack_dest_init_<p_pacr::PACK0, {dest_sync}>();\n"
 
 
 def packer_wait_for_math() -> str:
-    return ""
+    return "_llk_packer_wait_for_math_done_();\n"
 
 
 def packer_dest_section_done(dest_sync: str, dest_acc: str) -> str:
-    return f"_llk_pack_dest_dvalid_section_done_<{dest_sync}, {dest_acc}>();\n"
+    return f"_llk_pack_dest_semaphore_section_done_<p_pacr::PACK0, {dest_sync}, {dest_acc}>();\n"
 
 
 def packer_sync_with_unpacker(stage_id: int, num_stages: int) -> str:

--- a/tt_metal/tt-llk/tests/python_tests/fuser/quasar/packer/packer.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/quasar/packer/packer.py
@@ -6,6 +6,7 @@ from typing import List
 
 import torch
 from fuser.block_data import BlockData
+from fuser.fpu_node import FpuNode
 from fuser.fused_loop import FusedLoop
 from fuser.fused_operation import FusedOperation
 from fuser.fused_packer import Packer as BasePacker
@@ -47,10 +48,7 @@ class Packer(BasePacker):
     ) -> str:
         buf_desc_id = pack_node.output.buf_desc_id
         tensor_shape = pack_node.output.tile_shape.cpp_value
-        en_32bit_dest = config.dest_acc.cpp_enum_value
-        return (
-            f"_llk_pack_init_<{en_32bit_dest}>({buf_desc_id}, " f"{tensor_shape}, 1);\n"
-        )
+        return f"_llk_pack_init_({buf_desc_id}, {tensor_shape}, 1);\n"
 
     def pack(
         self,
@@ -59,4 +57,26 @@ class Packer(BasePacker):
         config: GlobalConfig,
         block: BlockData,
     ) -> str:
-        return f"_llk_pack_({block.tile_id_block}, {block.tile_id_global}, ckernel::DEFAULT_TENSOR_SHAPE);\n"
+        tensor_shape = pack_node.output.tile_shape.cpp_value
+        code = (
+            f"_llk_pack_({block.tile_id_block}, "
+            f"{block.tile_id_global}, "
+            f"{tensor_shape});\n"
+        )
+        final_fpu = next(
+            (
+                node
+                for node in reversed(operation.math.math_nodes)
+                if isinstance(node, FpuNode)
+            ),
+            None,
+        )
+        if final_fpu is None:
+            return code
+
+        condition = final_fpu.fpu.pack_tile_condition(
+            operation, config, final_fpu, block
+        )
+        if condition:
+            return f"if ({condition}) {{\n{code}}}\n"
+        return code

--- a/tt_metal/tt-llk/tests/python_tests/fuser/quasar/parser.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/quasar/parser.py
@@ -5,9 +5,8 @@
 """Quasar fuser config parser.
 
 Supports: eltwise binary (Elwadd/Elwmul/Elwsub), datacopy, matmul, reduce,
-unary SFPU, binary SFPU.
-Unsupported on Quasar: MatmulNoMop, ReduceBlockMax, ReduceBlockMaxRuntime,
-SubBcastColCustom.
+reduce block max, unary SFPU, binary SFPU.
+Unsupported on Quasar: MatmulNoMop, ReduceBlockMaxRuntime, SubBcastColCustom.
 No broadcast, no transpose.
 """
 
@@ -35,11 +34,13 @@ from .fpu.datacopy import DatacopyFpu
 from .fpu.eltwise import EltwiseFpu
 from .fpu.matmul import MatmulFpu
 from .fpu.reduce import ReduceFpu
+from .fpu.reduce_block_max import ReduceBlockMaxFpu
 from .packer.packer import Packer
 from .sfpu.binary import BinarySfpu
 from .sfpu.unary import UnarySfpu
 from .unpacker.matmul import MatmulUnpacker
 from .unpacker.reduce import ReduceUnpacker
+from .unpacker.reduce_block_max import ReduceBlockMaxUnpacker
 from .unpacker.unpack_a import UnpackerA
 from .unpacker.unpack_ab import UnpackerAB
 
@@ -120,6 +121,12 @@ _reduce_params = (
     "Reduce requires both reduce_pool and reduce_dim",
 )
 
+_only_32x32_or_16x32_tile = (
+    lambda s, a, b: (a.tile_shape.total_row_dim(), a.tile_shape.total_col_dim())
+    not in ((32, 32), (16, 32)),
+    "Only (32, 32) or (16, 32) tiles are supported for this operation",
+)
+
 UNPACKER_MAP = {
     "UnpackerA": (
         lambda s: UnpackerA(),
@@ -135,6 +142,10 @@ UNPACKER_MAP = {
     ),
     "ReduceUnpacker": (
         lambda s: ReduceUnpacker(s.reduce_dim, s.reduce_pool),
+        None,
+    ),
+    "ReduceBlockMaxUnpacker": (
+        lambda s: ReduceBlockMaxUnpacker(),
         None,
     ),
 }
@@ -173,6 +184,14 @@ FPU_MAP = {
             _forced_unpacker("ReduceUnpacker"),
         ],
     ),
+    "ReduceBlockMax": (
+        lambda s: ReduceBlockMaxFpu(),
+        [
+            _no_reuse_dest,
+            _forced_unpacker("ReduceBlockMaxUnpacker"),
+            _only_32x32_or_16x32_tile,
+        ],
+    ),
 }
 
 _l1_acc_format = (
@@ -196,6 +215,7 @@ OUTPUT_DIMS = {
     "Datacopy": _src_a_dims,
     "Matmul": _matmul_dims,
     "Reduce": _src_a_dims,
+    "ReduceBlockMax": _src_a_dims,
 }
 
 

--- a/tt_metal/tt-llk/tests/python_tests/fuser/quasar/unpacker/reduce_block_max.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/quasar/unpacker/reduce_block_max.py
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import List, Tuple
+
+import torch
+from fuser.block_data import BlockData
+from fuser.fpu_node import FpuNode
+from fuser.fused_loop import FusedLoop, LoopTileByTile
+from fuser.fused_operation import FusedOperation
+from fuser.fused_unpacker import Unpacker
+from fuser.fuser_config import GlobalConfig
+
+
+class ReduceBlockMaxUnpacker(Unpacker):
+    loop: FusedLoop = LoopTileByTile()
+
+    per_block_init = True
+
+    def init(
+        self,
+        operation: FusedOperation,
+        config: GlobalConfig,
+        compute_unit: FpuNode,
+        block: BlockData,
+    ) -> str:
+        ct_dim = block.block_tiles_x
+        dest_acc = config.dest_acc.cpp_enum_value
+        buf_desc_id_a = compute_unit.src_a.buf_desc_id
+        buf_desc_id_b = compute_unit.src_b.buf_desc_id
+        tensor_shape = compute_unit.src_a.tile_shape.cpp_value
+        return (
+            f"_llk_unpack_reduce_block_max_row_init_"
+            f"<{ct_dim}, {block.tile_count_x}, {block.tile_count_y}, {dest_acc}>"
+            f"({buf_desc_id_a}, {buf_desc_id_b}, {tensor_shape});\n"
+        )
+
+    def unpack(
+        self,
+        operation: FusedOperation,
+        config: GlobalConfig,
+        compute_unit: FpuNode,
+        block: BlockData,
+    ) -> str:
+        ct_dim = block.block_tiles_x
+        tile_x_abs = f"(({block.tile_id_global}) % {block.tile_count_x})"
+        tile_x_in_block = f"({tile_x_abs} - {block.block_x})"
+        dest_acc = config.dest_acc.cpp_enum_value
+        tensor_shape = compute_unit.src_a.tile_shape.cpp_value
+        tiny_condition = f"({block.tile_id_global} == 0)"
+        block_condition = f"(({tile_x_in_block}) % {ct_dim} == 0)"
+        return (
+            f"if ((({tensor_shape}).num_faces_r_dim == 1 && {tiny_condition}) || "
+            f"(({tensor_shape}).num_faces_r_dim != 1 && {block_condition})) {{\n"
+            f"_llk_unpack_reduce_block_max_row_"
+            f"<{ct_dim}, {block.tile_count_x}, {block.tile_count_y}, {dest_acc}>"
+            f"({block.tile_id_global}, {block.tile_id_global}, "
+            f"{compute_unit.src_a.buf_desc_id}, {compute_unit.src_b.buf_desc_id}, "
+            f"{tensor_shape});\n"
+            f"}}\n"
+        )
+
+    def uninit(
+        self,
+        operation: FusedOperation,
+        config: GlobalConfig,
+        compute_unit: FpuNode,
+        block: BlockData,
+    ) -> str:
+        return "_llk_unpack_reduce_block_max_row_uninit_();\n"
+
+    def get_headers(self) -> List[str]:
+        return ["experimental/llk_unpack_reduce_custom.h"]
+
+    def golden(
+        self,
+        tensor_a: torch.Tensor,
+        tensor_b: torch.Tensor,
+        operation: FusedOperation,
+        config: GlobalConfig,
+        compute_unit: FpuNode = None,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        return tensor_a, tensor_b

--- a/tt_metal/tt-llk/tests/python_tests/fuser/quasar/unpacker/reduce_block_max.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/quasar/unpacker/reduce_block_max.py
@@ -48,11 +48,9 @@ class ReduceBlockMaxUnpacker(Unpacker):
         tile_x_in_block = f"({tile_x_abs} - {block.block_x})"
         dest_acc = config.dest_acc.cpp_enum_value
         tensor_shape = compute_unit.src_a.tile_shape.cpp_value
-        tiny_condition = f"({block.tile_id_global} == 0)"
         block_condition = f"(({tile_x_in_block}) % {ct_dim} == 0)"
         return (
-            f"if ((({tensor_shape}).num_faces_r_dim == 1 && {tiny_condition}) || "
-            f"(({tensor_shape}).num_faces_r_dim != 1 && {block_condition})) {{\n"
+            f"if ({block_condition}) {{\n"
             f"_llk_unpack_reduce_block_max_row_"
             f"<{ct_dim}, {block.tile_count_x}, {block.tile_count_y}, {dest_acc}>"
             f"({block.tile_id_global}, {block.tile_id_global}, "

--- a/tt_metal/tt-llk/tests/python_tests/fuser/tests/fpu_reduce_block_max.yaml
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/tests/fpu_reduce_block_max.yaml
@@ -1,6 +1,6 @@
 # Block max reduce. Source B is all ones as the identity scale.
 
-supported_archs: ["wormhole", "blackhole"]
+supported_archs: ["wormhole", "blackhole", "quasar"]
 
 dest_acc: true
 

--- a/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/packer/common.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/packer/common.py
@@ -34,6 +34,10 @@ def configure_pack(
     )
 
 
+def pack_reduce_mask_config(reduce_dim: str, tensor_shape: str) -> str:
+    return f"_llk_pack_reduce_mask_config_<{reduce_dim}>();\n"
+
+
 def relu_config(relu_config_val: int, dest_acc: str) -> str:
     return f"_llk_pack_relu_config_(ReluConfig::from_packed({relu_config_val}));\n"
 

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/experimental/llk_math_reduce_custom.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/experimental/llk_math_reduce_custom.h
@@ -1,0 +1,537 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+#include "ckernel_template.h"
+#include "llk_math_common.h"
+#include "llk_math_reduce.h"
+#include "tensor_shape.h"
+
+using namespace ckernel;
+using namespace ckernel::trisc;
+using namespace ckernel::math;
+
+// Pool slice length: an SrcA completion fence plus GMPOOL for each face in a pair.
+constexpr std::uint32_t REDUCE_MAX_ROW_POOL_LEN = 4;
+// Transpose slice starts right after the pool slice.
+constexpr std::uint32_t REDUCE_MAX_ROW_TRANS_START = REDUCE_MAX_ROW_POOL_LEN;
+
+// Length of the recorded 16-bit transpose slice for this tensor shape. Must match between the
+// recording (mop_config) and the execute-side replay. Per face-row: MOVD2B(transpose) +
+// MOVD2B(copy) + ZEROSRC + ELWADDDI [+ ELWADDDI when face_r_dim > 8]; plus a leading SETRWC
+// (cr_d=0), an inter-face SETRWC (+32) when there are two face-rows, and a final SETRWC.
+inline std::uint32_t _reduce_max_row_trans_len_(const ckernel::TensorShape& tensor_shape)
+{
+    const std::uint32_t writeback_instructions = (tensor_shape.face_r_dim + ELTWISE_MATH_ROWS - 1) / ELTWISE_MATH_ROWS;
+    const std::uint32_t one_row                = 3 + writeback_instructions;
+    return 1 + one_row + (tensor_shape.total_num_faces() == NUM_FACES ? (1 + one_row) : 0) + 1;
+}
+
+template <std::uint32_t even_lreg, std::uint32_t odd_lreg, std::uint32_t rotations>
+inline __attribute__((always_inline)) void _reduce_max_row_sfpu_rotate_pair_()
+{
+#pragma GCC unroll 8
+    for (std::uint32_t i = 0; i < rotations; ++i)
+    {
+        // Mode 3 rotates one LREG across the eight Quasar SFPU columns. Global SFPSHFT2 has
+        // two-cycle throughput, and Quasar v4.0 does not reliably insert the required bubble.
+        TTI_SFPSHFT2(0, even_lreg, even_lreg, 3);
+        TTI_SFPNOP(0, 0, 0);
+        TTI_SFPSHFT2(0, odd_lreg, odd_lreg, 3);
+        TTI_SFPNOP(0, 0, 0);
+    }
+}
+
+/**
+ * @brief Moves one FP32 pool result row into the first column of its destination face.
+ *
+ * A Quasar FP32 SFPLOAD covers four rows and either the eight even or eight odd columns. The pool
+ * result occupies row zero, so the two loads below hold all 16 values across the eight SFPU
+ * columns. Cross-column rotates bring four successive values to column zero; SFPTRANSP then maps
+ * those four LREG row-zero values onto the four physical SFPU rows. Only column zero is meaningful
+ * after each store, which is exactly the datum selected by the pack reduce mask.
+ */
+template <std::uint32_t face_base>
+inline __attribute__((always_inline)) void _reduce_max_row_transpose_fp32_face_sfpu_();
+
+template <std::uint32_t face_base, std::uint32_t output_addr, std::uint32_t first_rotations, std::uint32_t second_rotations>
+inline __attribute__((always_inline)) void _reduce_max_row_transpose_fp32_four_rows_sfpu_()
+{
+    TTI_SFPLOAD(p_sfpu::LREG0, p_sfpu::sfpmem::FP32, ADDR_MOD_7, 0, face_base + 0);
+    TTI_SFPLOAD(p_sfpu::LREG1, p_sfpu::sfpmem::FP32, ADDR_MOD_7, 0, face_base + 2);
+    TTI_SFPMOV(p_sfpu::LREG0, p_sfpu::LREG4, 0);
+    TTI_SFPMOV(p_sfpu::LREG1, p_sfpu::LREG5, 0);
+    _reduce_max_row_sfpu_rotate_pair_<p_sfpu::LREG0, p_sfpu::LREG1, first_rotations>();
+    _reduce_max_row_sfpu_rotate_pair_<p_sfpu::LREG4, p_sfpu::LREG5, second_rotations>();
+    // Quasar can drop the fourth transpose input when the cross-lane shifts target LREG3.
+    // Shift in the independent second grid, then move the completed values into grid zero.
+    TTI_SFPMOV(p_sfpu::LREG4, p_sfpu::LREG2, 0);
+    TTI_SFPMOV(p_sfpu::LREG5, p_sfpu::LREG3, 0);
+    TTI_SFPMOV(p_sfpu::LREG4, p_sfpu::LREG6, 0);
+    TTI_SFPMOV(p_sfpu::LREG5, p_sfpu::LREG7, 0);
+    TTI_SFPNOP(0, 0, 0);
+    TTI_SFPNOP(0, 0, 0);
+    TTI_SFPTRANSP;
+    TTI_SFPNOP(0, 0, 0);
+    TTI_SFPSTORE(p_sfpu::LREG0, p_sfpu::sfpmem::FP32, ADDR_MOD_7, 0, face_base + output_addr);
+}
+
+template <std::uint32_t face_base>
+inline __attribute__((always_inline)) void _reduce_max_row_transpose_fp32_last_four_rows_sfpu_()
+{
+    _reduce_max_row_transpose_fp32_four_rows_sfpu_<face_base, 12, 2, 1>();
+}
+
+template <std::uint32_t face_base>
+inline __attribute__((always_inline)) void _reduce_max_row_transpose_fp32_face_sfpu_()
+{
+    // Four passes map the sixteen source columns into successive groups of four output rows.
+    _reduce_max_row_transpose_fp32_four_rows_sfpu_<face_base, 0, 0, 7>();
+    _reduce_max_row_transpose_fp32_four_rows_sfpu_<face_base, 4, 6, 5>();
+    _reduce_max_row_transpose_fp32_four_rows_sfpu_<face_base, 8, 4, 3>();
+    _reduce_max_row_transpose_fp32_last_four_rows_sfpu_<face_base>();
+}
+
+inline void _reduce_max_row_transpose_fp32_sfpu_(const std::uint32_t dst_index)
+{
+    _llk_math_sfpu_start_(dst_index);
+    _reduce_max_row_transpose_fp32_face_sfpu_<0>();
+    _reduce_max_row_transpose_fp32_face_sfpu_<32>();
+    TTI_STALLWAIT(p_stall::STALL_MATH, 0, 0, p_stall::WAIT_SFPU);
+    _llk_math_sfpu_done_();
+}
+
+template <std::uint32_t face_base>
+inline void _reduce_max_row_transpose_fp32_one_face_sfpu_(const std::uint32_t dst_index)
+{
+    _llk_math_sfpu_start_(dst_index);
+    _reduce_max_row_transpose_fp32_face_sfpu_<face_base>();
+    TTI_STALLWAIT(p_stall::STALL_MATH, 0, 0, p_stall::WAIT_SFPU);
+    _llk_math_sfpu_done_();
+}
+
+/**
+ * @brief Max-combines one face column from the following destination tile into the current tile.
+ */
+template <std::uint32_t face_base>
+inline void _reduce_max_row_combine_fp32_face_tiles_sfpu_(const std::uint32_t dst_index)
+{
+    constexpr std::uint32_t next_tile_offset = MAX_TILE_R_DIM * 2;
+    _llk_math_sfpu_start_(dst_index);
+
+    const auto combine_four_rows = [=](const std::uint32_t row_offset)
+    {
+        TTI_SFPLOAD(p_sfpu::LREG0, p_sfpu::sfpmem::FP32, ADDR_MOD_7, 0, face_base + row_offset);
+        TTI_SFPLOAD(p_sfpu::LREG1, p_sfpu::sfpmem::FP32, ADDR_MOD_7, 0, next_tile_offset + face_base + row_offset);
+        TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG1, p_sfpswap::ALL_ROWS_MAX);
+        TTI_SFPNOP(0, 0, 0);
+        TTI_SFPSTORE(p_sfpu::LREG0, p_sfpu::sfpmem::FP32, ADDR_MOD_7, 0, face_base + row_offset);
+    };
+
+    combine_four_rows(0);
+    combine_four_rows(4);
+    combine_four_rows(8);
+    combine_four_rows(12);
+
+    TTI_STALLWAIT(p_stall::STALL_MATH, 0, 0, p_stall::WAIT_SFPU);
+    _llk_math_sfpu_done_();
+}
+
+/**
+ * @brief Combines two already row-reduced FP32 tiles, keeping the maximum in the first tile.
+ */
+inline void _reduce_max_row_combine_fp32_tiles_sfpu_(const std::uint32_t dst_index)
+{
+    constexpr std::uint32_t next_tile_offset = MAX_TILE_R_DIM * 2;
+    _llk_math_sfpu_start_(dst_index);
+
+    const auto combine_four_rows = [=](const std::uint32_t row_offset)
+    {
+        TTI_SFPLOAD(p_sfpu::LREG0, p_sfpu::sfpmem::FP32, ADDR_MOD_7, 0, row_offset);
+        TTI_SFPLOAD(p_sfpu::LREG1, p_sfpu::sfpmem::FP32, ADDR_MOD_7, 0, next_tile_offset + row_offset);
+        TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG1, p_sfpswap::ALL_ROWS_MAX);
+        TTI_SFPNOP(0, 0, 0);
+        TTI_SFPSTORE(p_sfpu::LREG0, p_sfpu::sfpmem::FP32, ADDR_MOD_7, 0, row_offset);
+    };
+
+    combine_four_rows(0);
+    combine_four_rows(4);
+    combine_four_rows(8);
+    combine_four_rows(12);
+    combine_four_rows(MAX_TILE_R_DIM);
+    combine_four_rows(MAX_TILE_R_DIM + 4);
+    combine_four_rows(MAX_TILE_R_DIM + 8);
+    combine_four_rows(MAX_TILE_R_DIM + 12);
+
+    TTI_STALLWAIT(p_stall::STALL_MATH, 0, 0, p_stall::WAIT_SFPU);
+    _llk_math_sfpu_done_();
+}
+
+/**
+ * @brief Combines four native 16x32 BF16 row reductions into the first destination tile.
+ */
+inline void _reduce_max_row_combine_fp16b_tiles_sfpu_(const std::uint32_t dst_index)
+{
+    _set_dst_write_addr_by_rows_(dst_index);
+    TTI_STALLWAIT(p_stall::STALL_SFPU, 0, 0, p_stall::MATH);
+
+    // Follow the canonical Quasar SFPU walk. Each iteration max-combines the
+    // same two physical rows from all four tile slots, stores once, then advances.
+#pragma GCC unroll 8
+    for (std::uint32_t row_group = 0; row_group < FACE_R_DIM / SFP_ROWS; ++row_group)
+    {
+        TTI_SFPLOAD(p_sfpu::LREG0, p_sfpu::sfpmem::FP16B, ADDR_MOD_7, 0, 0);
+        TTI_SFPLOAD(p_sfpu::LREG1, p_sfpu::sfpmem::FP16B, ADDR_MOD_7, 0, 32);
+        TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG1, p_sfpswap::ALL_ROWS_MAX);
+        TTI_SFPNOP(0, 0, 0);
+        TTI_SFPLOAD(p_sfpu::LREG1, p_sfpu::sfpmem::FP16B, ADDR_MOD_7, 0, 64);
+        TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG1, p_sfpswap::ALL_ROWS_MAX);
+        TTI_SFPNOP(0, 0, 0);
+        TTI_SFPLOAD(p_sfpu::LREG1, p_sfpu::sfpmem::FP16B, ADDR_MOD_7, 0, 96);
+        TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG1, p_sfpswap::ALL_ROWS_MAX);
+        TTI_SFPNOP(0, 0, 0);
+        TTI_SFPSTORE(p_sfpu::LREG0, p_sfpu::sfpmem::FP16B, ADDR_MOD_7, 0, 0);
+        ckernel::math::_incr_counters_<0, 0, SFP_ROWS, 0>();
+    }
+
+    TTI_STALLWAIT(p_stall::STALL_MATH, 0, 0, p_stall::WAIT_SFPU);
+    _llk_math_sfpu_done_();
+}
+
+/**
+ * @brief Native 16x32 BF16 row max without MOP replay.
+ *
+ * The repeated generic row-reduce MOP can stop producing after several fused block sections on
+ * Quasar. This is its two-face instruction sequence with explicit SrcA fences and dvalid release.
+ */
+inline void _llk_math_reduce_row_fp16b_tile_()
+{
+    TTI_STALLWAIT(p_stall::STALL_MATH, 0, 0, p_stall::SRCA_VLD);
+    tti_pool_instr_func<PoolType::MAX, p_gpool::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, 0>();
+
+    TTI_STALLWAIT(p_stall::STALL_MATH, 0, 0, p_stall::SRCA_VLD);
+    tti_pool_instr_func<PoolType::MAX, p_gpool::CLR_SRCA_VLD, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, 0>();
+
+    TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_D, 0, p_setrwc::SET_AB);
+    TTI_MOVD2B(0, p_movd2b::SRC_ROW32_OFFSET, ADDR_MOD_0, p_movd2b::MOV_1_ROW, p_movd2b::TRANSPOSE_ON, 0);
+    TTI_MOVD2B(0, p_movd2b::SRC_ROW32_OFFSET, ADDR_MOD_0, p_movd2b::MOV_1_ROW, 0, 0);
+    TTI_ZEROSRC(0, 0, 0, 0, p_zerosrc::READ_BANK, p_zerosrc::CURR_BANK, p_zerosrc::CLR_A);
+    TTI_ELWADDDI(p_elwise::CLR_NONE, 0, p_movd2b::SRC_ROW32_OFFSET >> 2, 0, ADDR_MOD_1, 0);
+    TTI_ELWADDDI(p_elwise::CLR_NONE, 0, p_movd2b::SRC_ROW32_OFFSET >> 2, 0, ADDR_MOD_1, 0);
+    TTI_SETRWC(p_setrwc::CLR_A, 0, 0, p_setrwc::SET_BD);
+}
+
+/**
+ * @brief Sets up addrmods for block reduce_max_row (pool + transpose writeback).
+ *
+ * ADDR_MOD_0: pool + 16-bit transpose reads, no counter auto-increment.
+ * ADDR_MOD_1: 16-bit transpose writeback, advances SrcB and DEST by 8 rows.
+ * ADDR_MOD_7: SFPU FP32 load/store, no address auto-increment.
+ */
+inline void reduce_max_row_configure_addrmod()
+{
+    addr_mod_t {.srca = {.incr = 0}, .srcb = {.incr = 0}, .dest = {.incr = 0}, .fidelity = {.incr = 0, .clr = 1}}.set(ADDR_MOD_0);
+
+    addr_mod_t {
+        .srca = {.incr = 0},
+        .srcb = {.incr = ELTWISE_MATH_ROWS},
+        .dest = {.incr = ELTWISE_MATH_ROWS},
+    }
+        .set(ADDR_MOD_1);
+
+    _sfpu_configure_addrmod_();
+}
+
+/**
+ * @brief Minimal addrmod re-set after a fused matmul/eltwise clobbered ADDR_MOD_0/1.
+ */
+inline void reduce_max_row_configure_addrmod_reinit_minimal()
+{
+    addr_mod_t {.srca = {.incr = 0}, .srcb = {.incr = 0}, .dest = {.incr = 0}, .fidelity = {.incr = 0, .clr = 1}}.set(ADDR_MOD_0);
+
+    addr_mod_t {
+        .srca = {.incr = 0},
+        .srcb = {.incr = ELTWISE_MATH_ROWS},
+        .dest = {.incr = ELTWISE_MATH_ROWS},
+    }
+        .set(ADDR_MOD_1);
+
+    _sfpu_configure_addrmod_();
+}
+
+/**
+ * @brief Pools one input face into the selected FP32 DEST row and releases SrcA.
+ */
+template <std::uint32_t dst_row>
+inline void _llk_math_reduce_row_fp32_face_()
+{
+    TTI_STALLWAIT(p_stall::STALL_MATH, 0, 0, p_stall::SRCA_VLD);
+    tti_pool_instr_func<PoolType::MAX, p_gpool::CLR_SRCA_VLD, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, dst_row>();
+}
+
+/**
+ * @brief Records the block-reduce replay buffer and programs the MOP.
+ *
+ * The MOP loop only pools; GMPOOL max-accumulates every block tile into fixed DEST rows (row 0 for
+ * F0&F1, row 32 for F2&F3), so the transpose runs once after the whole block. Both destination modes
+ * record the transpose after the two pool instructions.
+ *
+ * @tparam block_ct_dim: number of operand tiles in the block (MOP outer-loop count).
+ * @tparam is_fp32_dest_acc_en: selects the 32-bit dest transpose path in the execute function.
+ * @param tensor_shape: operand tile shape (num faces, face dims).
+ */
+template <std::uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false>
+inline void _llk_math_reduce_block_max_row_mop_config_(const ckernel::TensorShape& tensor_shape)
+{
+    static_assert(block_ct_dim < 128, "block_ct_dim must be less than 128");
+    LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
+    LLK_ASSERT(!(tensor_shape.num_faces_r_dim == 1 && is_fp32_dest_acc_en), "16x32 reduce_block_max_row not supported in FP32 dest mode yet");
+
+    const std::uint32_t replay_buf_len = REDUCE_MAX_ROW_POOL_LEN + (is_fp32_dest_acc_en ? 0 : _reduce_max_row_trans_len_(tensor_shape));
+
+    load_replay_buf(
+        0,
+        replay_buf_len,
+        false,
+        0,
+        0,
+        [tensor_shape]
+        {
+            // ---- POOL SLICE: pool one face-pair into DEST[cr_d], max-accumulating over the block ----
+            // A SrcA-valid fence adds the cycle needed for the final Float32 unpack writes to land
+            // before each GMPOOL reads the face. The first pool releases SrcA valid so the paired
+            // unpack MOP streams the next face; the second is CLR_NONE.
+            TTI_STALLWAIT(p_stall::STALL_MATH, 0, 0, p_stall::SRCA_VLD);
+            tti_pool_instr_func<PoolType::MAX, p_gpool::CLR_SRCA_VLD, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, 0>();
+            TTI_STALLWAIT(p_stall::STALL_MATH, 0, 0, p_stall::SRCA_VLD);
+            tti_pool_instr_func<PoolType::MAX, p_gpool::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, 0>();
+
+            if constexpr (!is_fp32_dest_acc_en)
+            {
+                const std::uint32_t writeback_instructions = (tensor_shape.face_r_dim + ELTWISE_MATH_ROWS - 1) / ELTWISE_MATH_ROWS;
+
+                // ---- TRANSPOSE SLICE: transpose both accumulated face-rows to 16x1 columns, once per block ----
+                // Face-row 0 (DEST rows 0-15):
+                TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_D, 0, p_setrwc::SET_AB); // cr_d = 0
+                TTI_MOVD2B(0, p_movd2b::SRC_ROW32_OFFSET, ADDR_MOD_0, p_movd2b::MOV_1_ROW, p_movd2b::TRANSPOSE_ON,
+                           0); // read DEST, transpose into SrcB
+                TTI_MOVD2B(0, p_movd2b::SRC_ROW32_OFFSET, ADDR_MOD_0, p_movd2b::MOV_1_ROW, 0, 0);
+                TTI_ZEROSRC(0, 0, 0, 0, p_zerosrc::READ_BANK, p_zerosrc::CURR_BANK, p_zerosrc::CLR_A);
+                for (std::uint32_t i = 0; i < writeback_instructions; ++i)
+                {
+                    TTI_ELWADDDI(p_elwise::CLR_NONE, 0x0, p_movd2b::SRC_ROW32_OFFSET >> 2, 0x0, ADDR_MOD_1, 0x0);
+                }
+
+                if (tensor_shape.total_num_faces() == NUM_FACES)
+                {
+                    // Face-row 2 (DEST rows 32-47):
+                    TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_D, MAX_TILE_R_DIM, p_setrwc::SET_D); // cr_d = 32
+                    TTI_MOVD2B(0, p_movd2b::SRC_ROW32_OFFSET, ADDR_MOD_0, p_movd2b::MOV_1_ROW, p_movd2b::TRANSPOSE_ON, 0);
+                    TTI_MOVD2B(0, p_movd2b::SRC_ROW32_OFFSET, ADDR_MOD_0, p_movd2b::MOV_1_ROW, 0, 0);
+                    TTI_ZEROSRC(0, 0, 0, 0, p_zerosrc::READ_BANK, p_zerosrc::CURR_BANK, p_zerosrc::CLR_A);
+                    for (std::uint32_t i = 0; i < writeback_instructions; ++i)
+                    {
+                        TTI_ELWADDDI(p_elwise::CLR_NONE, 0x0, p_movd2b::SRC_ROW32_OFFSET >> 2, 0x0, ADDR_MOD_1, 0x0);
+                    }
+                }
+
+                TTI_SETRWC(p_setrwc::CLR_A, 0, 0, p_setrwc::SET_BD); // final reset
+            }
+        });
+
+    // Pool slice replayed for one face-pair; NOT the transpose (that runs once from execute).
+    const std::uint32_t pool_replay = TT_OP_REPLAY(0, REDUCE_MAX_ROW_POOL_LEN, 0, 0, 0, 0);
+
+    if (tensor_shape.total_num_faces() == NUM_FACES)
+    {
+        // Per tile: pool F0&F1 @cr_d=0 -> inner SETRWC(+32) -> pool F2&F3 @cr_d=32 -> release SrcA + reset.
+        // +32 lives in the inner loop op so it fires on every outer iteration, including the last.
+        ckernel_template temp(block_ct_dim, 1, TT_OP_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_D, MAX_TILE_R_DIM, p_setrwc::SET_D));
+        temp.set_start_op(pool_replay);
+        temp.set_end_ops(pool_replay, TT_OP_SETRWC(p_setrwc::CLR_A, 0, 0, p_setrwc::SET_ABD_F));
+        temp.program_bank0_sw_cntl(instrn_buffer);
+    }
+    else
+    {
+        // Single face-row (16x32 tiny tile): pool F0&F1 only, no F2 jump.
+        ckernel_template temp(block_ct_dim, 1, TT_OP_NOP);
+        temp.set_start_op(pool_replay);
+        temp.set_end_op(TT_OP_SETRWC(p_setrwc::CLR_A, 0, 0, p_setrwc::SET_ABD_F));
+        temp.program_bank0_sw_cntl(instrn_buffer);
+    }
+}
+
+/**
+ * @brief Reprograms only the block-reduce MOP registers, leaving the recorded replay buffer intact.
+ *
+ * Use when a fused eltwise/matmul clobbered the MOP config but the replay buffer at slots
+ * [0, POOL_LEN+TRANS_LEN) still holds the pool + transpose sequence.
+ */
+template <std::uint32_t block_ct_dim>
+inline void _llk_math_reduce_block_max_row_mop_reprogram_only_(const ckernel::TensorShape& tensor_shape)
+{
+    static_assert(block_ct_dim < 128, "block_ct_dim must be less than 128");
+    LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
+
+    const std::uint32_t pool_replay = TT_OP_REPLAY(0, REDUCE_MAX_ROW_POOL_LEN, 0, 0, 0, 0);
+
+    if (tensor_shape.total_num_faces() == NUM_FACES)
+    {
+        ckernel_template temp(block_ct_dim, 1, TT_OP_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_D, MAX_TILE_R_DIM, p_setrwc::SET_D));
+        temp.set_start_op(pool_replay);
+        temp.set_end_ops(pool_replay, TT_OP_SETRWC(p_setrwc::CLR_A, 0, 0, p_setrwc::SET_ABD_F));
+        temp.program_bank0_sw_cntl(instrn_buffer);
+    }
+    else
+    {
+        ckernel_template temp(block_ct_dim, 1, TT_OP_NOP);
+        temp.set_start_op(pool_replay);
+        temp.set_end_op(TT_OP_SETRWC(p_setrwc::CLR_A, 0, 0, p_setrwc::SET_ABD_F));
+        temp.program_bank0_sw_cntl(instrn_buffer);
+    }
+}
+
+/**
+ * @brief Initializes addrmods, dest tile shape, counters and the MOP for block reduce_max_row.
+ *
+ * @tparam block_ct_dim: number of operand tiles in the block.
+ * @tparam is_fp32_dest_acc_en: selects the 32-bit dest transpose path.
+ * @param tensor_shape: operand tile shape.
+ * @note On the unpack thread, pair with @ref _llk_unpack_reduce_block_max_row_init_ (T0).
+ * @note @ref _llk_math_reduce_block_max_row_ runs the configured reduction with matching template args.
+ */
+template <std::uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false>
+inline void _llk_math_reduce_block_max_row_init_(const ckernel::TensorShape& tensor_shape)
+{
+    LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
+
+    reduce_max_row_configure_addrmod();
+    _init_sfpu_config_reg_();
+    if constexpr (is_fp32_dest_acc_en)
+    {
+        LLK_ASSERT(tensor_shape.total_num_faces() == NUM_FACES, "FP32 block row max requires a 32x32 tile");
+        LLK_ASSERT(tensor_shape.face_r_dim == FACE_R_DIM, "FP32 block row max requires full-height faces");
+    }
+    else if (tensor_shape.num_faces_r_dim == 1)
+    {
+        static_assert(block_ct_dim == 4, "16x32 block row max currently supports four tiles per block");
+    }
+    else
+    {
+        _llk_math_reduce_block_max_row_mop_config_<block_ct_dim, false>(tensor_shape);
+    }
+    _set_tile_shape_idx_gpr_(find_max(FACE_R_DIM, tensor_shape.face_r_dim * tensor_shape.total_num_faces()));
+    _reset_counters_<p_setrwc::SET_ABD_F>();
+}
+
+/**
+ * @brief Block reduce_max_row uninit (no state to restore).
+ */
+template <bool is_fp32_dest_acc_en = false>
+inline void _llk_math_reduce_block_max_row_uninit_()
+{
+}
+
+/**
+ * @brief Runs block reduce_max_row: pool the whole block into DEST, then transpose once.
+ *
+ * @tparam block_ct_dim: number of operand tiles in the block.
+ * @tparam is_fp32_dest_acc_en: selects the 32-bit dest transpose path.
+ * @param dst_index: destination tile slot.
+ * @param tensor_shape: operand tile shape.
+ * @note Call @ref _llk_math_reduce_block_max_row_init_ with matching template args before this function.
+ */
+template <std::uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false>
+inline void _llk_math_reduce_block_max_row_(const std::uint32_t dst_index, const ckernel::TensorShape& tensor_shape)
+{
+    LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
+    LLK_ASSERT(!(tensor_shape.num_faces_r_dim == 1 && is_fp32_dest_acc_en), "16x32 reduce_block_max_row not supported in FP32 dest mode yet");
+
+    if constexpr (is_fp32_dest_acc_en)
+    {
+        static_assert(block_ct_dim == 2, "FP32 block row max currently supports two tiles per block");
+
+        // Every face is independently pooled and transposed. The following destination tile is
+        // scratch, so all maxima are lane-wise between identically laid-out FP32 face columns.
+        //
+        // First input tile, F0: initialize the top output face.
+        _set_dst_write_addr_by_rows_(dst_index);
+        _llk_math_reduce_row_fp32_face_<0>();
+        _reduce_max_row_transpose_fp32_one_face_sfpu_<0>(dst_index);
+
+        // First input tile, F1: transpose in scratch and combine into the top output face.
+        _set_dst_write_addr_by_rows_(dst_index + 1);
+        _llk_math_reduce_row_fp32_face_<0>();
+        _reduce_max_row_transpose_fp32_one_face_sfpu_<0>(dst_index + 1);
+        _reduce_max_row_combine_fp32_face_tiles_sfpu_<0>(dst_index);
+
+        // First input tile, F2/F3: initialize then combine the bottom output face.
+        _set_dst_write_addr_by_rows_(dst_index);
+        _llk_math_reduce_row_fp32_face_<MAX_TILE_R_DIM>();
+        _reduce_max_row_transpose_fp32_one_face_sfpu_<MAX_TILE_R_DIM>(dst_index);
+
+        _set_dst_write_addr_by_rows_(dst_index + 1);
+        _llk_math_reduce_row_fp32_face_<MAX_TILE_R_DIM>();
+        _reduce_max_row_transpose_fp32_one_face_sfpu_<MAX_TILE_R_DIM>(dst_index + 1);
+        _reduce_max_row_combine_fp32_face_tiles_sfpu_<MAX_TILE_R_DIM>(dst_index);
+        TTI_SETRWC(p_setrwc::CLR_B, 0, 0, p_setrwc::SET_ABD_F);
+
+        // Second input tile: every face is reduced through scratch and combined into its matching
+        // output face. This completes the 64-column block maximum without a 32-bit Dest round-trip.
+        _set_dst_write_addr_by_rows_(dst_index + 1);
+        _llk_math_reduce_row_fp32_face_<0>();
+        _reduce_max_row_transpose_fp32_one_face_sfpu_<0>(dst_index + 1);
+        _reduce_max_row_combine_fp32_face_tiles_sfpu_<0>(dst_index);
+
+        _set_dst_write_addr_by_rows_(dst_index + 1);
+        _llk_math_reduce_row_fp32_face_<0>();
+        _reduce_max_row_transpose_fp32_one_face_sfpu_<0>(dst_index + 1);
+        _reduce_max_row_combine_fp32_face_tiles_sfpu_<0>(dst_index);
+
+        _set_dst_write_addr_by_rows_(dst_index + 1);
+        _llk_math_reduce_row_fp32_face_<MAX_TILE_R_DIM>();
+        _reduce_max_row_transpose_fp32_one_face_sfpu_<MAX_TILE_R_DIM>(dst_index + 1);
+        _reduce_max_row_combine_fp32_face_tiles_sfpu_<MAX_TILE_R_DIM>(dst_index);
+
+        _set_dst_write_addr_by_rows_(dst_index + 1);
+        _llk_math_reduce_row_fp32_face_<MAX_TILE_R_DIM>();
+        _reduce_max_row_transpose_fp32_one_face_sfpu_<MAX_TILE_R_DIM>(dst_index + 1);
+        _reduce_max_row_combine_fp32_face_tiles_sfpu_<MAX_TILE_R_DIM>(dst_index);
+    }
+    else if (tensor_shape.num_faces_r_dim == 1)
+    {
+        // Preserve each native 16x32 row reduction in its own destination slot, then combine the
+        // four columns in SFPU. This avoids GMPOOL cross-tile destination accumulation.
+        for (std::uint32_t tile = 0; tile < block_ct_dim; ++tile)
+        {
+            _set_dst_write_addr_by_rows_(dst_index + tile);
+            TTI_STALLWAIT(p_stall::STALL_MATH, 0, 0, p_stall::SRCB_VLD);
+            _llk_math_reduce_row_fp16b_tile_();
+            TTI_SETRWC(p_setrwc::CLR_B, 0, 0, p_setrwc::SET_ABD_F);
+        }
+        _reduce_max_row_combine_fp16b_tiles_sfpu_(dst_index);
+    }
+    else
+    {
+        _set_dst_write_addr_by_rows_(dst_index);
+
+        // Pool all block_ct_dim tiles into DEST rows 0 (F0&F1) and 32 (F2&F3).
+        ckernel::ckernel_template::run_bank0_sw_cntl(instrn_buffer);
+
+        // SrcB dvalid handshake required before MOVD2B.
+        TTI_STALLWAIT(p_stall::STALL_MATH, 0, 0, p_stall::SRCB_VLD);
+        TT_REPLAY(REDUCE_MAX_ROW_TRANS_START, _reduce_max_row_trans_len_(tensor_shape), 0, 0, 0, 0);
+    }
+
+    // The tiny path releases SrcB once per logical input tile. Clearing it again
+    // here can erase the next block's scaler dvalid after the unpacker has already
+    // prefetched it, leaving math and unpack permanently out of phase.
+    if (tensor_shape.num_faces_r_dim != 1)
+    {
+        TTI_SETRWC(p_setrwc::CLR_B, 0, 0, p_setrwc::SET_ABD_F);
+    }
+}

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/experimental/llk_math_reduce_custom.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/experimental/llk_math_reduce_custom.h
@@ -15,222 +15,11 @@ using namespace ckernel;
 using namespace ckernel::trisc;
 using namespace ckernel::math;
 
-// Pool slice length: an SrcA completion fence plus GMPOOL for each face in a pair.
-constexpr std::uint32_t REDUCE_MAX_ROW_POOL_LEN = 4;
-// Transpose slice starts right after the pool slice.
-constexpr std::uint32_t REDUCE_MAX_ROW_TRANS_START = REDUCE_MAX_ROW_POOL_LEN;
-
-// Length of the recorded 16-bit transpose slice for this tensor shape. Must match between the
-// recording (mop_config) and the execute-side replay. Per face-row: MOVD2B(transpose) +
-// MOVD2B(copy) + ZEROSRC + ELWADDDI [+ ELWADDDI when face_r_dim > 8]; plus a leading SETRWC
-// (cr_d=0), an inter-face SETRWC (+32) when there are two face-rows, and a final SETRWC.
-inline std::uint32_t _reduce_max_row_trans_len_(const ckernel::TensorShape& tensor_shape)
-{
-    const std::uint32_t writeback_instructions = (tensor_shape.face_r_dim + ELTWISE_MATH_ROWS - 1) / ELTWISE_MATH_ROWS;
-    const std::uint32_t one_row                = 3 + writeback_instructions;
-    return 1 + one_row + (tensor_shape.total_num_faces() == NUM_FACES ? (1 + one_row) : 0) + 1;
-}
-
-template <std::uint32_t even_lreg, std::uint32_t odd_lreg, std::uint32_t rotations>
-inline __attribute__((always_inline)) void _reduce_max_row_sfpu_rotate_pair_()
-{
-#pragma GCC unroll 8
-    for (std::uint32_t i = 0; i < rotations; ++i)
-    {
-        // Mode 3 rotates one LREG across the eight Quasar SFPU columns. Global SFPSHFT2 has
-        // two-cycle throughput, and Quasar v4.0 does not reliably insert the required bubble.
-        TTI_SFPSHFT2(0, even_lreg, even_lreg, 3);
-        TTI_SFPNOP(0, 0, 0);
-        TTI_SFPSHFT2(0, odd_lreg, odd_lreg, 3);
-        TTI_SFPNOP(0, 0, 0);
-    }
-}
-
 /**
- * @brief Moves one FP32 pool result row into the first column of its destination face.
+ * @brief Configure the FPU address modifiers used by block reduce_max_row.
  *
- * A Quasar FP32 SFPLOAD covers four rows and either the eight even or eight odd columns. The pool
- * result occupies row zero, so the two loads below hold all 16 values across the eight SFPU
- * columns. Cross-column rotates bring four successive values to column zero; SFPTRANSP then maps
- * those four LREG row-zero values onto the four physical SFPU rows. Only column zero is meaningful
- * after each store, which is exactly the datum selected by the pack reduce mask.
- */
-template <std::uint32_t face_base>
-inline __attribute__((always_inline)) void _reduce_max_row_transpose_fp32_face_sfpu_();
-
-template <std::uint32_t face_base, std::uint32_t output_addr, std::uint32_t first_rotations, std::uint32_t second_rotations>
-inline __attribute__((always_inline)) void _reduce_max_row_transpose_fp32_four_rows_sfpu_()
-{
-    TTI_SFPLOAD(p_sfpu::LREG0, p_sfpu::sfpmem::FP32, ADDR_MOD_7, 0, face_base + 0);
-    TTI_SFPLOAD(p_sfpu::LREG1, p_sfpu::sfpmem::FP32, ADDR_MOD_7, 0, face_base + 2);
-    TTI_SFPMOV(p_sfpu::LREG0, p_sfpu::LREG4, 0);
-    TTI_SFPMOV(p_sfpu::LREG1, p_sfpu::LREG5, 0);
-    _reduce_max_row_sfpu_rotate_pair_<p_sfpu::LREG0, p_sfpu::LREG1, first_rotations>();
-    _reduce_max_row_sfpu_rotate_pair_<p_sfpu::LREG4, p_sfpu::LREG5, second_rotations>();
-    // Quasar can drop the fourth transpose input when the cross-lane shifts target LREG3.
-    // Shift in the independent second grid, then move the completed values into grid zero.
-    TTI_SFPMOV(p_sfpu::LREG4, p_sfpu::LREG2, 0);
-    TTI_SFPMOV(p_sfpu::LREG5, p_sfpu::LREG3, 0);
-    TTI_SFPMOV(p_sfpu::LREG4, p_sfpu::LREG6, 0);
-    TTI_SFPMOV(p_sfpu::LREG5, p_sfpu::LREG7, 0);
-    TTI_SFPNOP(0, 0, 0);
-    TTI_SFPNOP(0, 0, 0);
-    TTI_SFPTRANSP;
-    TTI_SFPNOP(0, 0, 0);
-    TTI_SFPSTORE(p_sfpu::LREG0, p_sfpu::sfpmem::FP32, ADDR_MOD_7, 0, face_base + output_addr);
-}
-
-template <std::uint32_t face_base>
-inline __attribute__((always_inline)) void _reduce_max_row_transpose_fp32_last_four_rows_sfpu_()
-{
-    _reduce_max_row_transpose_fp32_four_rows_sfpu_<face_base, 12, 2, 1>();
-}
-
-template <std::uint32_t face_base>
-inline __attribute__((always_inline)) void _reduce_max_row_transpose_fp32_face_sfpu_()
-{
-    // Four passes map the sixteen source columns into successive groups of four output rows.
-    _reduce_max_row_transpose_fp32_four_rows_sfpu_<face_base, 0, 0, 7>();
-    _reduce_max_row_transpose_fp32_four_rows_sfpu_<face_base, 4, 6, 5>();
-    _reduce_max_row_transpose_fp32_four_rows_sfpu_<face_base, 8, 4, 3>();
-    _reduce_max_row_transpose_fp32_last_four_rows_sfpu_<face_base>();
-}
-
-inline void _reduce_max_row_transpose_fp32_sfpu_(const std::uint32_t dst_index)
-{
-    _llk_math_sfpu_start_(dst_index);
-    _reduce_max_row_transpose_fp32_face_sfpu_<0>();
-    _reduce_max_row_transpose_fp32_face_sfpu_<32>();
-    TTI_STALLWAIT(p_stall::STALL_MATH, 0, 0, p_stall::WAIT_SFPU);
-    _llk_math_sfpu_done_();
-}
-
-template <std::uint32_t face_base>
-inline void _reduce_max_row_transpose_fp32_one_face_sfpu_(const std::uint32_t dst_index)
-{
-    _llk_math_sfpu_start_(dst_index);
-    _reduce_max_row_transpose_fp32_face_sfpu_<face_base>();
-    TTI_STALLWAIT(p_stall::STALL_MATH, 0, 0, p_stall::WAIT_SFPU);
-    _llk_math_sfpu_done_();
-}
-
-/**
- * @brief Max-combines one face column from the following destination tile into the current tile.
- */
-template <std::uint32_t face_base>
-inline void _reduce_max_row_combine_fp32_face_tiles_sfpu_(const std::uint32_t dst_index)
-{
-    constexpr std::uint32_t next_tile_offset = MAX_TILE_R_DIM * 2;
-    _llk_math_sfpu_start_(dst_index);
-
-    const auto combine_four_rows = [=](const std::uint32_t row_offset)
-    {
-        TTI_SFPLOAD(p_sfpu::LREG0, p_sfpu::sfpmem::FP32, ADDR_MOD_7, 0, face_base + row_offset);
-        TTI_SFPLOAD(p_sfpu::LREG1, p_sfpu::sfpmem::FP32, ADDR_MOD_7, 0, next_tile_offset + face_base + row_offset);
-        TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG1, p_sfpswap::ALL_ROWS_MAX);
-        TTI_SFPNOP(0, 0, 0);
-        TTI_SFPSTORE(p_sfpu::LREG0, p_sfpu::sfpmem::FP32, ADDR_MOD_7, 0, face_base + row_offset);
-    };
-
-    combine_four_rows(0);
-    combine_four_rows(4);
-    combine_four_rows(8);
-    combine_four_rows(12);
-
-    TTI_STALLWAIT(p_stall::STALL_MATH, 0, 0, p_stall::WAIT_SFPU);
-    _llk_math_sfpu_done_();
-}
-
-/**
- * @brief Combines two already row-reduced FP32 tiles, keeping the maximum in the first tile.
- */
-inline void _reduce_max_row_combine_fp32_tiles_sfpu_(const std::uint32_t dst_index)
-{
-    constexpr std::uint32_t next_tile_offset = MAX_TILE_R_DIM * 2;
-    _llk_math_sfpu_start_(dst_index);
-
-    const auto combine_four_rows = [=](const std::uint32_t row_offset)
-    {
-        TTI_SFPLOAD(p_sfpu::LREG0, p_sfpu::sfpmem::FP32, ADDR_MOD_7, 0, row_offset);
-        TTI_SFPLOAD(p_sfpu::LREG1, p_sfpu::sfpmem::FP32, ADDR_MOD_7, 0, next_tile_offset + row_offset);
-        TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG1, p_sfpswap::ALL_ROWS_MAX);
-        TTI_SFPNOP(0, 0, 0);
-        TTI_SFPSTORE(p_sfpu::LREG0, p_sfpu::sfpmem::FP32, ADDR_MOD_7, 0, row_offset);
-    };
-
-    combine_four_rows(0);
-    combine_four_rows(4);
-    combine_four_rows(8);
-    combine_four_rows(12);
-    combine_four_rows(MAX_TILE_R_DIM);
-    combine_four_rows(MAX_TILE_R_DIM + 4);
-    combine_four_rows(MAX_TILE_R_DIM + 8);
-    combine_four_rows(MAX_TILE_R_DIM + 12);
-
-    TTI_STALLWAIT(p_stall::STALL_MATH, 0, 0, p_stall::WAIT_SFPU);
-    _llk_math_sfpu_done_();
-}
-
-/**
- * @brief Combines four native 16x32 BF16 row reductions into the first destination tile.
- */
-inline void _reduce_max_row_combine_fp16b_tiles_sfpu_(const std::uint32_t dst_index)
-{
-    _set_dst_write_addr_by_rows_(dst_index);
-    TTI_STALLWAIT(p_stall::STALL_SFPU, 0, 0, p_stall::MATH);
-
-    // Follow the canonical Quasar SFPU walk. Each iteration max-combines the
-    // same two physical rows from all four tile slots, stores once, then advances.
-#pragma GCC unroll 8
-    for (std::uint32_t row_group = 0; row_group < FACE_R_DIM / SFP_ROWS; ++row_group)
-    {
-        TTI_SFPLOAD(p_sfpu::LREG0, p_sfpu::sfpmem::FP16B, ADDR_MOD_7, 0, 0);
-        TTI_SFPLOAD(p_sfpu::LREG1, p_sfpu::sfpmem::FP16B, ADDR_MOD_7, 0, 32);
-        TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG1, p_sfpswap::ALL_ROWS_MAX);
-        TTI_SFPNOP(0, 0, 0);
-        TTI_SFPLOAD(p_sfpu::LREG1, p_sfpu::sfpmem::FP16B, ADDR_MOD_7, 0, 64);
-        TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG1, p_sfpswap::ALL_ROWS_MAX);
-        TTI_SFPNOP(0, 0, 0);
-        TTI_SFPLOAD(p_sfpu::LREG1, p_sfpu::sfpmem::FP16B, ADDR_MOD_7, 0, 96);
-        TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG1, p_sfpswap::ALL_ROWS_MAX);
-        TTI_SFPNOP(0, 0, 0);
-        TTI_SFPSTORE(p_sfpu::LREG0, p_sfpu::sfpmem::FP16B, ADDR_MOD_7, 0, 0);
-        ckernel::math::_incr_counters_<0, 0, SFP_ROWS, 0>();
-    }
-
-    TTI_STALLWAIT(p_stall::STALL_MATH, 0, 0, p_stall::WAIT_SFPU);
-    _llk_math_sfpu_done_();
-}
-
-/**
- * @brief Native 16x32 BF16 row max without MOP replay.
- *
- * The repeated generic row-reduce MOP can stop producing after several fused block sections on
- * Quasar. This is its two-face instruction sequence with explicit SrcA fences and dvalid release.
- */
-inline void _llk_math_reduce_row_fp16b_tile_()
-{
-    TTI_STALLWAIT(p_stall::STALL_MATH, 0, 0, p_stall::SRCA_VLD);
-    tti_pool_instr_func<PoolType::MAX, p_gpool::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, 0>();
-
-    TTI_STALLWAIT(p_stall::STALL_MATH, 0, 0, p_stall::SRCA_VLD);
-    tti_pool_instr_func<PoolType::MAX, p_gpool::CLR_SRCA_VLD, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, 0>();
-
-    TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_D, 0, p_setrwc::SET_AB);
-    TTI_MOVD2B(0, p_movd2b::SRC_ROW32_OFFSET, ADDR_MOD_0, p_movd2b::MOV_1_ROW, p_movd2b::TRANSPOSE_ON, 0);
-    TTI_MOVD2B(0, p_movd2b::SRC_ROW32_OFFSET, ADDR_MOD_0, p_movd2b::MOV_1_ROW, 0, 0);
-    TTI_ZEROSRC(0, 0, 0, 0, p_zerosrc::READ_BANK, p_zerosrc::CURR_BANK, p_zerosrc::CLR_A);
-    TTI_ELWADDDI(p_elwise::CLR_NONE, 0, p_movd2b::SRC_ROW32_OFFSET >> 2, 0, ADDR_MOD_1, 0);
-    TTI_ELWADDDI(p_elwise::CLR_NONE, 0, p_movd2b::SRC_ROW32_OFFSET >> 2, 0, ADDR_MOD_1, 0);
-    TTI_SETRWC(p_setrwc::CLR_A, 0, 0, p_setrwc::SET_BD);
-}
-
-/**
- * @brief Sets up addrmods for block reduce_max_row (pool + transpose writeback).
- *
- * ADDR_MOD_0: pool + 16-bit transpose reads, no counter auto-increment.
- * ADDR_MOD_1: 16-bit transpose writeback, advances SrcB and DEST by 8 rows.
- * ADDR_MOD_7: SFPU FP32 load/store, no address auto-increment.
+ * ADDR_MOD_0 keeps the GMPOOL and 32-bit move addresses fixed. ADDR_MOD_1
+ * advances SrcB and DEST by eight rows for the native 16-bit transpose.
  */
 inline void reduce_max_row_configure_addrmod()
 {
@@ -242,167 +31,86 @@ inline void reduce_max_row_configure_addrmod()
         .dest = {.incr = ELTWISE_MATH_ROWS},
     }
         .set(ADDR_MOD_1);
-
-    _sfpu_configure_addrmod_();
 }
 
 /**
- * @brief Minimal addrmod re-set after a fused matmul/eltwise clobbered ADDR_MOD_0/1.
+ * @brief Restore address modifiers after another fused operation changes them.
  */
 inline void reduce_max_row_configure_addrmod_reinit_minimal()
 {
-    addr_mod_t {.srca = {.incr = 0}, .srcb = {.incr = 0}, .dest = {.incr = 0}, .fidelity = {.incr = 0, .clr = 1}}.set(ADDR_MOD_0);
-
-    addr_mod_t {
-        .srca = {.incr = 0},
-        .srcb = {.incr = ELTWISE_MATH_ROWS},
-        .dest = {.incr = ELTWISE_MATH_ROWS},
-    }
-        .set(ADDR_MOD_1);
-
-    _sfpu_configure_addrmod_();
+    reduce_max_row_configure_addrmod();
 }
 
 /**
- * @brief Pools one input face into the selected FP32 DEST row and releases SrcA.
+ * @brief Transpose one FP32 GMPOOL result row using FPU move instructions.
+ *
+ * A Quasar Src register cannot hold a complete FP32 datum. Transpose the low
+ * and high 16-bit halves independently, cache the low half in SrcA, then write
+ * both halves back to DEST. The paired transposed/non-transposed MOVD2B
+ * operations also retain the row-form maximum required by the next GMPOOL.
  */
-template <std::uint32_t dst_row>
-inline void _llk_math_reduce_row_fp32_face_()
+inline void _reduce_max_row_transpose_fp32_fpu_()
+{
+    _configure_mov_ops_explicit_alu_data_format_state_<true>(DataFormat::Tf32, DataFormat::Tf32);
+    _reduce_row_transpose_alu_cfg_enter_();
+
+    TTI_STALLWAIT(p_stall::STALL_MATH, 0, 0, p_stall::SRCB_VLD);
+
+    TTI_MOVD2B(p_mov::DEST_32B_LOW, p_movd2b::SRC_ROW16_OFFSET, ADDR_MOD_0, p_movd2b::MOV_1_ROW, p_movd2b::TRANSPOSE_ON, 0);
+    TTI_MOVD2B(p_mov::DEST_32B_LOW, p_movd2b::SRC_ROW16_OFFSET, ADDR_MOD_0, p_movd2b::MOV_1_ROW, 0, 0);
+    TTI_MOVB2A(p_movb2a::SRCA_ZERO_OFFSET + 0, ADDR_MOD_0, p_movb2a::MOV_4_ROWS, p_movb2a::SRCB_ROW16_OFFSET + 0);
+    TTI_MOVB2A(p_movb2a::SRCA_ZERO_OFFSET + 4, ADDR_MOD_0, p_movb2a::MOV_4_ROWS, p_movb2a::SRCB_ROW16_OFFSET + 4);
+    TTI_MOVB2A(p_movb2a::SRCA_ZERO_OFFSET + 8, ADDR_MOD_0, p_movb2a::MOV_4_ROWS, p_movb2a::SRCB_ROW16_OFFSET + 8);
+    TTI_MOVB2A(p_movb2a::SRCA_ZERO_OFFSET + 12, ADDR_MOD_0, p_movb2a::MOV_4_ROWS, p_movb2a::SRCB_ROW16_OFFSET + 12);
+
+    TTI_MOVD2B(p_mov::DEST_NORM, p_movd2b::SRC_ROW16_OFFSET, ADDR_MOD_0, p_movd2b::MOV_1_ROW, p_movd2b::TRANSPOSE_ON, 0);
+    TTI_MOVD2B(p_mov::DEST_NORM, p_movd2b::SRC_ROW16_OFFSET, ADDR_MOD_0, p_movd2b::MOV_1_ROW, 0, 0);
+    TTI_MOVB2D(p_mov::DEST_NORM, p_mov_src_to_dest::SRC_ROW16_OFFSET + 0, ADDR_MOD_0, p_mov_src_to_dest::MOV_4_ROWS, p_movb2d::BCAST_OFF, 0);
+    TTI_MOVB2D(p_mov::DEST_NORM, p_mov_src_to_dest::SRC_ROW16_OFFSET + 4, ADDR_MOD_0, p_mov_src_to_dest::MOV_4_ROWS, p_movb2d::BCAST_OFF, 4);
+    TTI_MOVB2D(p_mov::DEST_NORM, p_mov_src_to_dest::SRC_ROW16_OFFSET + 8, ADDR_MOD_0, p_mov_src_to_dest::MOV_4_ROWS, p_movb2d::BCAST_OFF, 8);
+    TTI_MOVB2D(p_mov::DEST_NORM, p_mov_src_to_dest::SRC_ROW16_OFFSET + 12, ADDR_MOD_0, p_mov_src_to_dest::MOV_4_ROWS, p_movb2d::BCAST_OFF, 12);
+
+    TTI_MOVA2D(p_mov::DEST_32B_LOW, 0, ADDR_MOD_0, p_mov_src_to_dest::MOV_8_ROWS, 0);
+    TTI_MOVA2D(p_mov::DEST_32B_LOW, 8, ADDR_MOD_0, p_mov_src_to_dest::MOV_8_ROWS, 8);
+
+    _reduce_row_transpose_alu_cfg_exit_();
+    _configure_default_alu_data_format_state_<true /* IMPLIED_MATH_FORMAT */, true /* EN_32BIT_DEST */>(DataFormat::Tf32, DataFormat::Tf32);
+}
+
+/**
+ * @brief Reduce one 32x32 FP32 tile into the current DEST tile.
+ *
+ * GMPOOL max-accumulates the top and bottom face pairs into arbitrary DEST
+ * rows 0 and 32. Transposing after each tile preserves both the packed column
+ * and the row-form accumulator needed by the following tile.
+ */
+inline void _llk_math_reduce_row_fp32_tile_()
 {
     TTI_STALLWAIT(p_stall::STALL_MATH, 0, 0, p_stall::SRCA_VLD);
-    tti_pool_instr_func<PoolType::MAX, p_gpool::CLR_SRCA_VLD, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, dst_row>();
+    tti_pool_instr_func<PoolType::MAX, p_gpool::CLR_SRCA_VLD, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, 0>();
+    TTI_STALLWAIT(p_stall::STALL_MATH, 0, 0, p_stall::SRCA_VLD);
+    tti_pool_instr_func<PoolType::MAX, p_gpool::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, 0>();
+    TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_D, 0, p_setrwc::SET_AB);
+    _reduce_max_row_transpose_fp32_fpu_();
+
+    TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_D, MAX_TILE_R_DIM, p_setrwc::SET_D);
+    TTI_SETRWC(p_setrwc::CLR_A, p_setrwc::CR_D, 0, p_setrwc::SET_B);
+
+    TTI_STALLWAIT(p_stall::STALL_MATH, 0, 0, p_stall::SRCA_VLD);
+    tti_pool_instr_func<PoolType::MAX, p_gpool::CLR_SRCA_VLD, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, 0>();
+    TTI_STALLWAIT(p_stall::STALL_MATH, 0, 0, p_stall::SRCA_VLD);
+    tti_pool_instr_func<PoolType::MAX, p_gpool::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, 0>();
+    TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_D, 0, p_setrwc::SET_AB);
+    _reduce_max_row_transpose_fp32_fpu_();
+
+    TTI_SETRWC(p_setrwc::CLR_A, 0, 0, p_setrwc::SET_BD);
 }
 
 /**
- * @brief Records the block-reduce replay buffer and programs the MOP.
+ * @brief Initialize GMPOOL/FPU block reduce_max_row.
  *
- * The MOP loop only pools; GMPOOL max-accumulates every block tile into fixed DEST rows (row 0 for
- * F0&F1, row 32 for F2&F3), so the transpose runs once after the whole block. Both destination modes
- * record the transpose after the two pool instructions.
- *
- * @tparam block_ct_dim: number of operand tiles in the block (MOP outer-loop count).
- * @tparam is_fp32_dest_acc_en: selects the 32-bit dest transpose path in the execute function.
- * @param tensor_shape: operand tile shape (num faces, face dims).
- */
-template <std::uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false>
-inline void _llk_math_reduce_block_max_row_mop_config_(const ckernel::TensorShape& tensor_shape)
-{
-    static_assert(block_ct_dim < 128, "block_ct_dim must be less than 128");
-    LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
-    LLK_ASSERT(!(tensor_shape.num_faces_r_dim == 1 && is_fp32_dest_acc_en), "16x32 reduce_block_max_row not supported in FP32 dest mode yet");
-
-    const std::uint32_t replay_buf_len = REDUCE_MAX_ROW_POOL_LEN + (is_fp32_dest_acc_en ? 0 : _reduce_max_row_trans_len_(tensor_shape));
-
-    load_replay_buf(
-        0,
-        replay_buf_len,
-        false,
-        0,
-        0,
-        [tensor_shape]
-        {
-            // ---- POOL SLICE: pool one face-pair into DEST[cr_d], max-accumulating over the block ----
-            // A SrcA-valid fence adds the cycle needed for the final Float32 unpack writes to land
-            // before each GMPOOL reads the face. The first pool releases SrcA valid so the paired
-            // unpack MOP streams the next face; the second is CLR_NONE.
-            TTI_STALLWAIT(p_stall::STALL_MATH, 0, 0, p_stall::SRCA_VLD);
-            tti_pool_instr_func<PoolType::MAX, p_gpool::CLR_SRCA_VLD, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, 0>();
-            TTI_STALLWAIT(p_stall::STALL_MATH, 0, 0, p_stall::SRCA_VLD);
-            tti_pool_instr_func<PoolType::MAX, p_gpool::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, 0>();
-
-            if constexpr (!is_fp32_dest_acc_en)
-            {
-                const std::uint32_t writeback_instructions = (tensor_shape.face_r_dim + ELTWISE_MATH_ROWS - 1) / ELTWISE_MATH_ROWS;
-
-                // ---- TRANSPOSE SLICE: transpose both accumulated face-rows to 16x1 columns, once per block ----
-                // Face-row 0 (DEST rows 0-15):
-                TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_D, 0, p_setrwc::SET_AB); // cr_d = 0
-                TTI_MOVD2B(0, p_movd2b::SRC_ROW32_OFFSET, ADDR_MOD_0, p_movd2b::MOV_1_ROW, p_movd2b::TRANSPOSE_ON,
-                           0); // read DEST, transpose into SrcB
-                TTI_MOVD2B(0, p_movd2b::SRC_ROW32_OFFSET, ADDR_MOD_0, p_movd2b::MOV_1_ROW, 0, 0);
-                TTI_ZEROSRC(0, 0, 0, 0, p_zerosrc::READ_BANK, p_zerosrc::CURR_BANK, p_zerosrc::CLR_A);
-                for (std::uint32_t i = 0; i < writeback_instructions; ++i)
-                {
-                    TTI_ELWADDDI(p_elwise::CLR_NONE, 0x0, p_movd2b::SRC_ROW32_OFFSET >> 2, 0x0, ADDR_MOD_1, 0x0);
-                }
-
-                if (tensor_shape.total_num_faces() == NUM_FACES)
-                {
-                    // Face-row 2 (DEST rows 32-47):
-                    TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_D, MAX_TILE_R_DIM, p_setrwc::SET_D); // cr_d = 32
-                    TTI_MOVD2B(0, p_movd2b::SRC_ROW32_OFFSET, ADDR_MOD_0, p_movd2b::MOV_1_ROW, p_movd2b::TRANSPOSE_ON, 0);
-                    TTI_MOVD2B(0, p_movd2b::SRC_ROW32_OFFSET, ADDR_MOD_0, p_movd2b::MOV_1_ROW, 0, 0);
-                    TTI_ZEROSRC(0, 0, 0, 0, p_zerosrc::READ_BANK, p_zerosrc::CURR_BANK, p_zerosrc::CLR_A);
-                    for (std::uint32_t i = 0; i < writeback_instructions; ++i)
-                    {
-                        TTI_ELWADDDI(p_elwise::CLR_NONE, 0x0, p_movd2b::SRC_ROW32_OFFSET >> 2, 0x0, ADDR_MOD_1, 0x0);
-                    }
-                }
-
-                TTI_SETRWC(p_setrwc::CLR_A, 0, 0, p_setrwc::SET_BD); // final reset
-            }
-        });
-
-    // Pool slice replayed for one face-pair; NOT the transpose (that runs once from execute).
-    const std::uint32_t pool_replay = TT_OP_REPLAY(0, REDUCE_MAX_ROW_POOL_LEN, 0, 0, 0, 0);
-
-    if (tensor_shape.total_num_faces() == NUM_FACES)
-    {
-        // Per tile: pool F0&F1 @cr_d=0 -> inner SETRWC(+32) -> pool F2&F3 @cr_d=32 -> release SrcA + reset.
-        // +32 lives in the inner loop op so it fires on every outer iteration, including the last.
-        ckernel_template temp(block_ct_dim, 1, TT_OP_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_D, MAX_TILE_R_DIM, p_setrwc::SET_D));
-        temp.set_start_op(pool_replay);
-        temp.set_end_ops(pool_replay, TT_OP_SETRWC(p_setrwc::CLR_A, 0, 0, p_setrwc::SET_ABD_F));
-        temp.program_bank0_sw_cntl(instrn_buffer);
-    }
-    else
-    {
-        // Single face-row (16x32 tiny tile): pool F0&F1 only, no F2 jump.
-        ckernel_template temp(block_ct_dim, 1, TT_OP_NOP);
-        temp.set_start_op(pool_replay);
-        temp.set_end_op(TT_OP_SETRWC(p_setrwc::CLR_A, 0, 0, p_setrwc::SET_ABD_F));
-        temp.program_bank0_sw_cntl(instrn_buffer);
-    }
-}
-
-/**
- * @brief Reprograms only the block-reduce MOP registers, leaving the recorded replay buffer intact.
- *
- * Use when a fused eltwise/matmul clobbered the MOP config but the replay buffer at slots
- * [0, POOL_LEN+TRANS_LEN) still holds the pool + transpose sequence.
- */
-template <std::uint32_t block_ct_dim>
-inline void _llk_math_reduce_block_max_row_mop_reprogram_only_(const ckernel::TensorShape& tensor_shape)
-{
-    static_assert(block_ct_dim < 128, "block_ct_dim must be less than 128");
-    LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
-
-    const std::uint32_t pool_replay = TT_OP_REPLAY(0, REDUCE_MAX_ROW_POOL_LEN, 0, 0, 0, 0);
-
-    if (tensor_shape.total_num_faces() == NUM_FACES)
-    {
-        ckernel_template temp(block_ct_dim, 1, TT_OP_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_D, MAX_TILE_R_DIM, p_setrwc::SET_D));
-        temp.set_start_op(pool_replay);
-        temp.set_end_ops(pool_replay, TT_OP_SETRWC(p_setrwc::CLR_A, 0, 0, p_setrwc::SET_ABD_F));
-        temp.program_bank0_sw_cntl(instrn_buffer);
-    }
-    else
-    {
-        ckernel_template temp(block_ct_dim, 1, TT_OP_NOP);
-        temp.set_start_op(pool_replay);
-        temp.set_end_op(TT_OP_SETRWC(p_setrwc::CLR_A, 0, 0, p_setrwc::SET_ABD_F));
-        temp.program_bank0_sw_cntl(instrn_buffer);
-    }
-}
-
-/**
- * @brief Initializes addrmods, dest tile shape, counters and the MOP for block reduce_max_row.
- *
- * @tparam block_ct_dim: number of operand tiles in the block.
- * @tparam is_fp32_dest_acc_en: selects the 32-bit dest transpose path.
- * @param tensor_shape: operand tile shape.
- * @note On the unpack thread, pair with @ref _llk_unpack_reduce_block_max_row_init_ (T0).
- * @note @ref _llk_math_reduce_block_max_row_ runs the configured reduction with matching template args.
+ * FP32 uses the runtime split-half transpose above. BF16 reuses Quasar's
+ * canonical 16x32 row-reduce MOP.
  */
 template <std::uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false>
 inline void _llk_math_reduce_block_max_row_init_(const ckernel::TensorShape& tensor_shape)
@@ -410,128 +118,56 @@ inline void _llk_math_reduce_block_max_row_init_(const ckernel::TensorShape& ten
     LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
 
     reduce_max_row_configure_addrmod();
-    _init_sfpu_config_reg_();
     if constexpr (is_fp32_dest_acc_en)
     {
+        static_assert(block_ct_dim == 2, "FP32 block row max currently supports two tiles per block");
         LLK_ASSERT(tensor_shape.total_num_faces() == NUM_FACES, "FP32 block row max requires a 32x32 tile");
         LLK_ASSERT(tensor_shape.face_r_dim == FACE_R_DIM, "FP32 block row max requires full-height faces");
     }
-    else if (tensor_shape.num_faces_r_dim == 1)
-    {
-        static_assert(block_ct_dim == 4, "16x32 block row max currently supports four tiles per block");
-    }
     else
     {
-        _llk_math_reduce_block_max_row_mop_config_<block_ct_dim, false>(tensor_shape);
+        static_assert(block_ct_dim == 4, "16x32 block row max currently supports four tiles per block");
+        LLK_ASSERT(tensor_shape.total_num_faces() == 2, "16-bit block row max currently requires 16x32 tiles");
+        _llk_math_reduce_row_mop_config_<PoolType::MAX, ckernel::MathFidelity::LoFi>(tensor_shape);
     }
+
     _set_tile_shape_idx_gpr_(find_max(FACE_R_DIM, tensor_shape.face_r_dim * tensor_shape.total_num_faces()));
     _reset_counters_<p_setrwc::SET_ABD_F>();
 }
 
-/**
- * @brief Block reduce_max_row uninit (no state to restore).
- */
 template <bool is_fp32_dest_acc_en = false>
 inline void _llk_math_reduce_block_max_row_uninit_()
 {
 }
 
 /**
- * @brief Runs block reduce_max_row: pool the whole block into DEST, then transpose once.
+ * @brief Max-reduce all horizontal block tiles into one destination tile.
  *
- * @tparam block_ct_dim: number of operand tiles in the block.
- * @tparam is_fp32_dest_acc_en: selects the 32-bit dest transpose path.
- * @param dst_index: destination tile slot.
- * @param tensor_shape: operand tile shape.
- * @note Call @ref _llk_math_reduce_block_max_row_init_ with matching template args before this function.
+ * Each tile has a distinct SrcB token. Releasing that token before the next
+ * tile is required for reliable SrcB/MOVD2B bank selection.
  */
 template <std::uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false>
 inline void _llk_math_reduce_block_max_row_(const std::uint32_t dst_index, const ckernel::TensorShape& tensor_shape)
 {
     LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
-    LLK_ASSERT(!(tensor_shape.num_faces_r_dim == 1 && is_fp32_dest_acc_en), "16x32 reduce_block_max_row not supported in FP32 dest mode yet");
+    _set_dst_write_addr_by_rows_(dst_index);
 
     if constexpr (is_fp32_dest_acc_en)
     {
-        static_assert(block_ct_dim == 2, "FP32 block row max currently supports two tiles per block");
-
-        // Every face is independently pooled and transposed. The following destination tile is
-        // scratch, so all maxima are lane-wise between identically laid-out FP32 face columns.
-        //
-        // First input tile, F0: initialize the top output face.
-        _set_dst_write_addr_by_rows_(dst_index);
-        _llk_math_reduce_row_fp32_face_<0>();
-        _reduce_max_row_transpose_fp32_one_face_sfpu_<0>(dst_index);
-
-        // First input tile, F1: transpose in scratch and combine into the top output face.
-        _set_dst_write_addr_by_rows_(dst_index + 1);
-        _llk_math_reduce_row_fp32_face_<0>();
-        _reduce_max_row_transpose_fp32_one_face_sfpu_<0>(dst_index + 1);
-        _reduce_max_row_combine_fp32_face_tiles_sfpu_<0>(dst_index);
-
-        // First input tile, F2/F3: initialize then combine the bottom output face.
-        _set_dst_write_addr_by_rows_(dst_index);
-        _llk_math_reduce_row_fp32_face_<MAX_TILE_R_DIM>();
-        _reduce_max_row_transpose_fp32_one_face_sfpu_<MAX_TILE_R_DIM>(dst_index);
-
-        _set_dst_write_addr_by_rows_(dst_index + 1);
-        _llk_math_reduce_row_fp32_face_<MAX_TILE_R_DIM>();
-        _reduce_max_row_transpose_fp32_one_face_sfpu_<MAX_TILE_R_DIM>(dst_index + 1);
-        _reduce_max_row_combine_fp32_face_tiles_sfpu_<MAX_TILE_R_DIM>(dst_index);
-        TTI_SETRWC(p_setrwc::CLR_B, 0, 0, p_setrwc::SET_ABD_F);
-
-        // Second input tile: every face is reduced through scratch and combined into its matching
-        // output face. This completes the 64-column block maximum without a 32-bit Dest round-trip.
-        _set_dst_write_addr_by_rows_(dst_index + 1);
-        _llk_math_reduce_row_fp32_face_<0>();
-        _reduce_max_row_transpose_fp32_one_face_sfpu_<0>(dst_index + 1);
-        _reduce_max_row_combine_fp32_face_tiles_sfpu_<0>(dst_index);
-
-        _set_dst_write_addr_by_rows_(dst_index + 1);
-        _llk_math_reduce_row_fp32_face_<0>();
-        _reduce_max_row_transpose_fp32_one_face_sfpu_<0>(dst_index + 1);
-        _reduce_max_row_combine_fp32_face_tiles_sfpu_<0>(dst_index);
-
-        _set_dst_write_addr_by_rows_(dst_index + 1);
-        _llk_math_reduce_row_fp32_face_<MAX_TILE_R_DIM>();
-        _reduce_max_row_transpose_fp32_one_face_sfpu_<MAX_TILE_R_DIM>(dst_index + 1);
-        _reduce_max_row_combine_fp32_face_tiles_sfpu_<MAX_TILE_R_DIM>(dst_index);
-
-        _set_dst_write_addr_by_rows_(dst_index + 1);
-        _llk_math_reduce_row_fp32_face_<MAX_TILE_R_DIM>();
-        _reduce_max_row_transpose_fp32_one_face_sfpu_<MAX_TILE_R_DIM>(dst_index + 1);
-        _reduce_max_row_combine_fp32_face_tiles_sfpu_<MAX_TILE_R_DIM>(dst_index);
-    }
-    else if (tensor_shape.num_faces_r_dim == 1)
-    {
-        // Preserve each native 16x32 row reduction in its own destination slot, then combine the
-        // four columns in SFPU. This avoids GMPOOL cross-tile destination accumulation.
+#pragma GCC unroll 4
         for (std::uint32_t tile = 0; tile < block_ct_dim; ++tile)
         {
-            _set_dst_write_addr_by_rows_(dst_index + tile);
-            TTI_STALLWAIT(p_stall::STALL_MATH, 0, 0, p_stall::SRCB_VLD);
-            _llk_math_reduce_row_fp16b_tile_();
+            _llk_math_reduce_row_fp32_tile_();
             TTI_SETRWC(p_setrwc::CLR_B, 0, 0, p_setrwc::SET_ABD_F);
         }
-        _reduce_max_row_combine_fp16b_tiles_sfpu_(dst_index);
     }
     else
     {
-        _set_dst_write_addr_by_rows_(dst_index);
-
-        // Pool all block_ct_dim tiles into DEST rows 0 (F0&F1) and 32 (F2&F3).
-        ckernel::ckernel_template::run_bank0_sw_cntl(instrn_buffer);
-
-        // SrcB dvalid handshake required before MOVD2B.
-        TTI_STALLWAIT(p_stall::STALL_MATH, 0, 0, p_stall::SRCB_VLD);
-        TT_REPLAY(REDUCE_MAX_ROW_TRANS_START, _reduce_max_row_trans_len_(tensor_shape), 0, 0, 0, 0);
-    }
-
-    // The tiny path releases SrcB once per logical input tile. Clearing it again
-    // here can erase the next block's scaler dvalid after the unpacker has already
-    // prefetched it, leaving math and unpack permanently out of phase.
-    if (tensor_shape.num_faces_r_dim != 1)
-    {
-        TTI_SETRWC(p_setrwc::CLR_B, 0, 0, p_setrwc::SET_ABD_F);
+#pragma GCC unroll 4
+        for (std::uint32_t tile = 0; tile < block_ct_dim; ++tile)
+        {
+            ckernel::ckernel_template::run_bank0_sw_cntl(instrn_buffer);
+            TTI_SETRWC(p_setrwc::CLR_B, 0, 0, p_setrwc::SET_ABD_F);
+        }
     }
 }

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/experimental/llk_math_reduce_custom.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/experimental/llk_math_reduce_custom.h
@@ -15,6 +15,9 @@ using namespace ckernel;
 using namespace ckernel::trisc;
 using namespace ckernel::math;
 
+// F2/F3 reduce into a separate row-form accumulator at DEST row 32.
+static constexpr std::uint32_t REDUCE_BLOCK_SLOT1_DST = TILE_R_DIM;
+
 /**
  * @brief Configure the FPU address modifiers used by block reduce_max_row.
  *
@@ -80,9 +83,9 @@ inline void _reduce_max_row_transpose_fp32_fpu_()
 /**
  * @brief Reduce one 32x32 FP32 tile into the current DEST tile.
  *
- * GMPOOL max-accumulates the top and bottom face pairs into arbitrary DEST
- * rows 0 and 32. Transposing after each tile preserves both the packed column
- * and the row-form accumulator needed by the following tile.
+ * Quasar's split-half FP32 transpose modifies SrcA and needs a fresh SrcB
+ * token for each tile. Keep this proven per-tile handshake separate from the
+ * 16-bit block-stream schedule below.
  */
 inline void _llk_math_reduce_row_fp32_tile_()
 {
@@ -93,7 +96,7 @@ inline void _llk_math_reduce_row_fp32_tile_()
     TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_D, 0, p_setrwc::SET_AB);
     _reduce_max_row_transpose_fp32_fpu_();
 
-    TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_D, MAX_TILE_R_DIM, p_setrwc::SET_D);
+    TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_D, REDUCE_BLOCK_SLOT1_DST, p_setrwc::SET_D);
     TTI_SETRWC(p_setrwc::CLR_A, p_setrwc::CR_D, 0, p_setrwc::SET_B);
 
     TTI_STALLWAIT(p_stall::STALL_MATH, 0, 0, p_stall::SRCA_VLD);
@@ -107,10 +110,68 @@ inline void _llk_math_reduce_row_fp32_tile_()
 }
 
 /**
+ * @brief Configure the 16-bit pool-only block MOP.
+ *
+ * Quasar streams every transposed face through SrcA rows 0-15, alternating
+ * banks. Each GMPOOL therefore consumes exactly one bank token with
+ * CLR_SRCA_VLD. F0/F1 accumulate at DEST row 0 and F2/F3 at row 32. There is
+ * deliberately no trailing SETRWC(CLR_A): that would release SrcA twice.
+ */
+template <std::uint32_t block_ct_dim>
+inline void _llk_math_reduce_block_max_row_mop_config_(const ckernel::TensorShape& tensor_shape)
+{
+    static_assert(block_ct_dim < 128, "block_ct_dim must be less than 128");
+
+    const bool two_face_rows     = (tensor_shape.num_faces_r_dim > 1);
+    const std::uint32_t pool_len = two_face_rows ? 4u : 2u;
+
+    load_replay_buf(
+        0,
+        pool_len,
+        false,
+        0,
+        0,
+        [two_face_rows]
+        {
+            TTI_GMPOOL(p_gpool::CLR_SRCA_VLD, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS,
+                       0); // F0 -> slot 0
+            TTI_GMPOOL(p_gpool::CLR_SRCA_VLD, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS,
+                       0); // F1 -> slot 0
+            if (two_face_rows)
+            {
+                TTI_GMPOOL(p_gpool::CLR_SRCA_VLD, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS,
+                           REDUCE_BLOCK_SLOT1_DST); // F2 -> slot 1
+                TTI_GMPOOL(p_gpool::CLR_SRCA_VLD, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS,
+                           REDUCE_BLOCK_SLOT1_DST); // F3 -> slot 1
+            }
+        });
+
+    const std::uint32_t pool_replay = TT_OP_REPLAY(0, pool_len, 0, 0, 0, 0);
+    ckernel_template temp(1 /* outer */, block_ct_dim /* inner */, pool_replay);
+    temp.program_bank0_sw_cntl(instrn_buffer);
+}
+
+/**
+ * @brief Transpose one final 16-bit row accumulator into an output column.
+ */
+inline void _reduce_max_row_transpose_fp16b_face_(const bool wide_face)
+{
+    TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_D, 0, p_setrwc::SET_AB);
+    TTI_MOVD2B(0, p_movd2b::SRC_ROW32_OFFSET, ADDR_MOD_0, p_movd2b::MOV_1_ROW, p_movd2b::TRANSPOSE_ON, 0);
+    TTI_MOVD2B(0, p_movd2b::SRC_ROW32_OFFSET, ADDR_MOD_0, p_movd2b::MOV_1_ROW, 0, 0);
+    TTI_MOVB2D(p_mov::DEST_NORM, p_mov_src_to_dest::SRC_ROW32_OFFSET, ADDR_MOD_0, p_mov_src_to_dest::MOV_8_ROWS, p_movb2d::BCAST_OFF, 0);
+    if (wide_face)
+    {
+        TTI_MOVB2D(p_mov::DEST_NORM, p_mov_src_to_dest::SRC_ROW32_OFFSET + 8, ADDR_MOD_0, p_mov_src_to_dest::MOV_8_ROWS, p_movb2d::BCAST_OFF, 8);
+    }
+}
+
+/**
  * @brief Initialize GMPOOL/FPU block reduce_max_row.
  *
- * FP32 uses the runtime split-half transpose above. BF16 reuses Quasar's
- * canonical 16x32 row-reduce MOP.
+ * The 16-bit path keeps GMPOOL results in row form for the complete horizontal
+ * block, matching the working Quasar/Blackhole schedule, then transposes once.
+ * FP32 retains its independent per-tile source handshake.
  */
 template <std::uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false>
 inline void _llk_math_reduce_block_max_row_init_(const ckernel::TensorShape& tensor_shape)
@@ -118,6 +179,7 @@ inline void _llk_math_reduce_block_max_row_init_(const ckernel::TensorShape& ten
     LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
 
     reduce_max_row_configure_addrmod();
+    static_assert(block_ct_dim < 128, "block_ct_dim must be less than 128");
     if constexpr (is_fp32_dest_acc_en)
     {
         static_assert(block_ct_dim == 2, "FP32 block row max currently supports two tiles per block");
@@ -126,9 +188,8 @@ inline void _llk_math_reduce_block_max_row_init_(const ckernel::TensorShape& ten
     }
     else
     {
-        static_assert(block_ct_dim == 4, "16x32 block row max currently supports four tiles per block");
-        LLK_ASSERT(tensor_shape.total_num_faces() == 2, "16-bit block row max currently requires 16x32 tiles");
-        _llk_math_reduce_row_mop_config_<PoolType::MAX, ckernel::MathFidelity::LoFi>(tensor_shape);
+        LLK_ASSERT(tensor_shape.total_num_faces() == 2 || tensor_shape.total_num_faces() == NUM_FACES, "16-bit block row max requires a 16x32 or 32x32 tile");
+        _llk_math_reduce_block_max_row_mop_config_<block_ct_dim>(tensor_shape);
     }
 
     _set_tile_shape_idx_gpr_(find_max(FACE_R_DIM, tensor_shape.face_r_dim * tensor_shape.total_num_faces()));
@@ -143,8 +204,8 @@ inline void _llk_math_reduce_block_max_row_uninit_()
 /**
  * @brief Max-reduce all horizontal block tiles into one destination tile.
  *
- * Each tile has a distinct SrcB token. Releasing that token before the next
- * tile is required for reliable SrcB/MOVD2B bank selection.
+ * The 16-bit path streams SrcA faces through the two banks and holds one SrcB
+ * token for the block. FP32 uses one independently released token per tile.
  */
 template <std::uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false>
 inline void _llk_math_reduce_block_max_row_(const std::uint32_t dst_index, const ckernel::TensorShape& tensor_shape)
@@ -163,11 +224,16 @@ inline void _llk_math_reduce_block_max_row_(const std::uint32_t dst_index, const
     }
     else
     {
-#pragma GCC unroll 4
-        for (std::uint32_t tile = 0; tile < block_ct_dim; ++tile)
+        ckernel::ckernel_template::run_bank0_sw_cntl(instrn_buffer);
+
+        const bool two_face_rows = (tensor_shape.num_faces_r_dim > 1);
+        const bool wide_face     = (tensor_shape.face_r_dim > ELTWISE_MATH_ROWS);
+        _reduce_max_row_transpose_fp16b_face_(wide_face);
+        if (two_face_rows)
         {
-            ckernel::ckernel_template::run_bank0_sw_cntl(instrn_buffer);
-            TTI_SETRWC(p_setrwc::CLR_B, 0, 0, p_setrwc::SET_ABD_F);
+            TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_D, REDUCE_BLOCK_SLOT1_DST, p_setrwc::SET_D);
+            _reduce_max_row_transpose_fp16b_face_(wide_face);
         }
+        TTI_SETRWC(p_setrwc::CLR_B, 0, 0, p_setrwc::SET_ABD_F);
     }
 }

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/experimental/llk_math_reduce_custom.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/experimental/llk_math_reduce_custom.h
@@ -81,32 +81,30 @@ inline void _reduce_max_row_transpose_fp32_fpu_()
 }
 
 /**
- * @brief Reduce one 32x32 FP32 tile into the current DEST tile.
+ * @brief Pool one face row from every FP32 tile in a horizontal block.
  *
- * Quasar's split-half FP32 transpose modifies SrcA and needs a fresh SrcB
- * token for each tile. Keep this proven per-tile handshake separate from the
- * 16-bit block-stream schedule below.
+ * The final pool keeps its SrcA token valid because the FP32 transpose helper
+ * fills that bank with MOVB2A and consumes it with MOVA2D. All preceding pools
+ * release SrcA so unpack can stream through the block.
  */
-inline void _llk_math_reduce_row_fp32_tile_()
+template <std::uint32_t block_ct_dim>
+inline void _llk_math_reduce_row_fp32_block_face_row_()
 {
-    TTI_STALLWAIT(p_stall::STALL_MATH, 0, 0, p_stall::SRCA_VLD);
-    tti_pool_instr_func<PoolType::MAX, p_gpool::CLR_SRCA_VLD, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, 0>();
-    TTI_STALLWAIT(p_stall::STALL_MATH, 0, 0, p_stall::SRCA_VLD);
-    tti_pool_instr_func<PoolType::MAX, p_gpool::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, 0>();
-    TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_D, 0, p_setrwc::SET_AB);
-    _reduce_max_row_transpose_fp32_fpu_();
+    for (std::uint32_t tile = 0; tile < block_ct_dim; ++tile)
+    {
+        TTI_STALLWAIT(p_stall::STALL_MATH, 0, 0, p_stall::SRCA_VLD);
+        tti_pool_instr_func<PoolType::MAX, p_gpool::CLR_SRCA_VLD, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, 0>();
 
-    TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_D, REDUCE_BLOCK_SLOT1_DST, p_setrwc::SET_D);
-    TTI_SETRWC(p_setrwc::CLR_A, p_setrwc::CR_D, 0, p_setrwc::SET_B);
-
-    TTI_STALLWAIT(p_stall::STALL_MATH, 0, 0, p_stall::SRCA_VLD);
-    tti_pool_instr_func<PoolType::MAX, p_gpool::CLR_SRCA_VLD, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, 0>();
-    TTI_STALLWAIT(p_stall::STALL_MATH, 0, 0, p_stall::SRCA_VLD);
-    tti_pool_instr_func<PoolType::MAX, p_gpool::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, 0>();
-    TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_D, 0, p_setrwc::SET_AB);
-    _reduce_max_row_transpose_fp32_fpu_();
-
-    TTI_SETRWC(p_setrwc::CLR_A, 0, 0, p_setrwc::SET_BD);
+        TTI_STALLWAIT(p_stall::STALL_MATH, 0, 0, p_stall::SRCA_VLD);
+        if (tile + 1 == block_ct_dim)
+        {
+            tti_pool_instr_func<PoolType::MAX, p_gpool::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, 0>();
+        }
+        else
+        {
+            tti_pool_instr_func<PoolType::MAX, p_gpool::CLR_SRCA_VLD, p_gpool::DIM_16X16, ADDR_MOD_0, p_gpool::INDEX_DIS, 0>();
+        }
+    }
 }
 
 /**
@@ -171,7 +169,8 @@ inline void _reduce_max_row_transpose_fp16b_face_(const bool wide_face)
  *
  * The 16-bit path keeps GMPOOL results in row form for the complete horizontal
  * block, matching the working Quasar/Blackhole schedule, then transposes once.
- * FP32 retains its independent per-tile source handshake.
+ * FP32 streams one face row across the block at a time and transposes each
+ * accumulated row once.
  */
 template <std::uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false>
 inline void _llk_math_reduce_block_max_row_init_(const ckernel::TensorShape& tensor_shape)
@@ -204,8 +203,8 @@ inline void _llk_math_reduce_block_max_row_uninit_()
 /**
  * @brief Max-reduce all horizontal block tiles into one destination tile.
  *
- * The 16-bit path streams SrcA faces through the two banks and holds one SrcB
- * token for the block. FP32 uses one independently released token per tile.
+ * Both paths stream SrcA through the two banks and hold one SrcB scaler token
+ * for the complete horizontal block.
  */
 template <std::uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false>
 inline void _llk_math_reduce_block_max_row_(const std::uint32_t dst_index, const ckernel::TensorShape& tensor_shape)
@@ -215,12 +214,18 @@ inline void _llk_math_reduce_block_max_row_(const std::uint32_t dst_index, const
 
     if constexpr (is_fp32_dest_acc_en)
     {
-#pragma GCC unroll 4
-        for (std::uint32_t tile = 0; tile < block_ct_dim; ++tile)
-        {
-            _llk_math_reduce_row_fp32_tile_();
-            TTI_SETRWC(p_setrwc::CLR_B, 0, 0, p_setrwc::SET_ABD_F);
-        }
+        _llk_math_reduce_row_fp32_block_face_row_<block_ct_dim>();
+        TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_D, 0, p_setrwc::SET_AB);
+        _reduce_max_row_transpose_fp32_fpu_();
+        TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_D, REDUCE_BLOCK_SLOT1_DST, p_setrwc::SET_D);
+        TTI_SETRWC(p_setrwc::CLR_A, p_setrwc::CR_D, 0, p_setrwc::SET_B);
+
+        _llk_math_reduce_row_fp32_block_face_row_<block_ct_dim>();
+        TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::CR_D, 0, p_setrwc::SET_AB);
+        _reduce_max_row_transpose_fp32_fpu_();
+        TTI_SETRWC(p_setrwc::CLR_A, 0, 0, p_setrwc::SET_BD);
+
+        TTI_SETRWC(p_setrwc::CLR_B, 0, 0, p_setrwc::SET_ABD_F);
     }
     else
     {

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/experimental/llk_unpack_reduce_custom.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/experimental/llk_unpack_reduce_custom.h
@@ -19,7 +19,7 @@ using namespace ckernel;
  *
  * For 16-bit DEST, a single MOP streams the complete operand block into SrcA,
  * one face per source-bank token; the scaler is unpacked once separately.
- * FP32 instead programs one tile per MOP and supplies a scaler token per tile.
+ * FP32 uses a face-row stream in the execute path and does not run this MOP.
  *
  * @tparam block_ct_dim: number of operand tiles streamed by the MOP.
  * @tparam is_fp32_dest_acc_en: reserved for the 32-bit dest path; does not change the unpack stream.
@@ -117,11 +117,7 @@ inline void _llk_unpack_reduce_block_max_row_init_(
             static_assert(tile_count_x * tile_count_y < 1024, "Tiny block row max tile count exceeds the Quasar limit");
         }
     }
-    if constexpr (is_fp32_dest_acc_en)
-    {
-        _llk_unpack_reduce_block_max_row_mop_config_<1, true>(buf_desc_id_0, buf_desc_id_1, tensor_shape);
-    }
-    else
+    if constexpr (!is_fp32_dest_acc_en)
     {
         _llk_unpack_reduce_block_max_row_mop_config_<block_ct_dim, false>(buf_desc_id_0, buf_desc_id_1, tensor_shape);
     }
@@ -144,17 +140,25 @@ inline void _llk_unpack_reduce_block_max_row_(
 {
     if constexpr (is_fp32_dest_acc_en)
     {
-        for (std::uint32_t tile = 0; tile < block_ct_dim; ++tile)
+        // One scaler token remains valid through both block-level face-row
+        // reductions and their FP32 transposes.
+        TT_SET_SRC_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, p_unpacr::UNP_B, start_l1_tile_idx_1);
+        TTI_SET_DST_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, p_unpacr::UNP_B, 0);
+        TTI_UNPACR1_FACE_INC(0, 0, 0, 0, buf_desc_id_1, 1 /* Set Dvalid */);
+
+        // Stream all top face pairs across the block, then all bottom pairs.
+        // Math retains the final pair token while transposing the accumulated
+        // row, so unpack naturally pauses between the two face rows.
+        TTI_SET_DST_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, p_unpacr::UNP_A, 0);
+        for (std::uint32_t face_row = 0; face_row < 2; ++face_row)
         {
-            const std::uint32_t tile_idx_A = start_l1_tile_idx_0 + tile;
-            const std::uint32_t tile_idx_B = start_l1_tile_idx_1 + tile;
-
-            TT_SET_SRC_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, p_unpacr::UNP_A, tile_idx_A);
-            TT_SET_SRC_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, p_unpacr::UNP_B, tile_idx_B);
-            TTI_SET_DST_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, p_unpacr::UNP_A, 0);
-            TTI_SET_DST_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, p_unpacr::UNP_B, 0);
-
-            ckernel::ckernel_template::run_bank0_sw_cntl(instrn_buffer);
+            for (std::uint32_t tile = 0; tile < block_ct_dim; ++tile)
+            {
+                TT_SET_SRC_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, p_unpacr::UNP_A, start_l1_tile_idx_0 + tile);
+                TT_SET_SRC_TILE_FACE_ROW_IDX(p_set_inc_sel::FACE_SEL, p_unpacr::UNP_A, face_row * 2);
+                TTI_UNPACR0_FACE_INC(0, 1, 0, 0, buf_desc_id_0, 1 /* Set Dvalid */);
+                TTI_UNPACR0_FACE_INC(0, 1, 0, 0, buf_desc_id_0, 1 /* Set Dvalid */);
+            }
         }
         return;
     }

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/experimental/llk_unpack_reduce_custom.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/experimental/llk_unpack_reduce_custom.h
@@ -94,22 +94,18 @@ inline void _llk_unpack_reduce_block_max_row_init_(
     cfg_rmw(THCON_UNPACKER0_REG0_TRANSPOSE_RMW, 1); // SrcA transpose ON (reduce-row)
     cfg_rmw(THCON_UNPACKER1_REG0_TRANSPOSE_RMW, 0); // scaler not transposed
 
-    if constexpr (is_fp32_dest_acc_en)
+    if constexpr (!is_fp32_dest_acc_en)
     {
-        _llk_unpack_reduce_block_max_row_mop_config_<1, true>(buf_desc_id_0, buf_desc_id_1, tensor_shape);
-    }
-    else if (tensor_shape.num_faces_r_dim == 1)
-    {
-        // Tiny tensors use a direct execute loop below because repeated Quasar unpack MOP
-        // invocations can lose the Src-valid handoff at block boundaries.
         static_assert(block_ct_dim == 4, "16x32 block row max currently supports four tiles per block");
-        static_assert(tile_count_x % block_ct_dim == 0, "Tiny block row max requires complete horizontal blocks");
-        static_assert(tile_count_x * tile_count_y < 1024, "Tiny block row max tile count exceeds the Quasar limit");
+        if (tensor_shape.num_faces_r_dim == 1)
+        {
+            static_assert(tile_count_x % block_ct_dim == 0, "Tiny block row max requires complete horizontal blocks");
+            static_assert(tile_count_x * tile_count_y < 1024, "Tiny block row max tile count exceeds the Quasar limit");
+        }
     }
-    else
-    {
-        _llk_unpack_reduce_block_max_row_mop_config_<block_ct_dim, false>(buf_desc_id_0, buf_desc_id_1, tensor_shape);
-    }
+    // Match the canonical reduce handshake: each math tile consumes and
+    // releases one SrcB scaler token, so each unpack MOP supplies one token.
+    _llk_unpack_reduce_block_max_row_mop_config_<1, is_fp32_dest_acc_en>(buf_desc_id_0, buf_desc_id_1, tensor_shape);
 }
 
 /**
@@ -123,8 +119,8 @@ template <std::uint32_t block_ct_dim, std::uint32_t tile_count_x, std::uint32_t 
 inline void _llk_unpack_reduce_block_max_row_(
     const std::uint32_t start_l1_tile_idx_0,
     const std::uint32_t start_l1_tile_idx_1,
-    const std::uint32_t buf_desc_id_0,
-    const std::uint32_t buf_desc_id_1,
+    [[maybe_unused]] const std::uint32_t buf_desc_id_0,
+    [[maybe_unused]] const std::uint32_t buf_desc_id_1,
     const ckernel::TensorShape& tensor_shape)
 {
     const auto unpack_tiles = [=](const std::uint32_t tile_offset)
@@ -143,46 +139,9 @@ inline void _llk_unpack_reduce_block_max_row_(
         ckernel::ckernel_template::run_bank0_sw_cntl(instrn_buffer);
     };
 
-    if constexpr (is_fp32_dest_acc_en)
+    for (std::uint32_t tile = 0; tile < block_ct_dim; ++tile)
     {
-        unpack_tiles(0);
-        unpack_tiles(1);
-    }
-    else if (tensor_shape.num_faces_r_dim == 1)
-    {
-        const std::uint32_t l1_idx_B = start_l1_tile_idx_1 * tensor_shape.total_num_faces();
-
-        TT_SET_SRC_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, p_unpacr::UNP_B, l1_idx_B);
-        TTI_SET_DST_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, p_unpacr::UNP_B, 0);
-
-        // The fused kernel traverses horizontal blocks first, then tensor rows. Stream
-        // SrcA in that same order so each math destination section consumes its own block.
-        for (std::uint32_t block_x = 0; block_x < tile_count_x; block_x += block_ct_dim)
-        {
-            for (std::uint32_t block_y = 0; block_y < tile_count_y; ++block_y)
-            {
-                const std::uint32_t block_start_tile = start_l1_tile_idx_0 + block_y * tile_count_x + block_x;
-                TT_SET_SRC_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, p_unpacr::UNP_A, block_start_tile * tensor_shape.total_num_faces());
-                TTI_SET_DST_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, p_unpacr::UNP_A, 0);
-
-                for (std::uint32_t tile = 0; tile < block_ct_dim; ++tile)
-                {
-                    // Native row-reduce releases SrcB after every logical tile, so refresh
-                    // the scaler dvalid each time. The test scaler is constant, hence Src increment 0.
-                    TTI_UNPACR1_TILE_INC(0, 0, buf_desc_id_1, 1);
-
-                    for (std::uint32_t face = 0; face < 2; ++face)
-                    {
-                        TTI_UNPACR_NOP(p_unpacr::UNP_A, 0, p_unpacr::UNP_STALL_UNP_WR, 0, p_unpacr::UNP_CLRSRC_NEGINF, p_unpacr::UNP_CLRSRC_ZERO);
-                        TTI_UNPACR0_TILE_INC(0, 1, buf_desc_id_0, 1);
-                    }
-                }
-            }
-        }
-    }
-    else
-    {
-        unpack_tiles(0);
+        unpack_tiles(tile);
     }
 }
 

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/experimental/llk_unpack_reduce_custom.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/experimental/llk_unpack_reduce_custom.h
@@ -17,10 +17,11 @@ using namespace ckernel;
 /**
  * @brief Builds the block reduce_max_row unpack MOP.
  *
- * Per block tile: unpacks all operand faces into SrcA (transposed for reduce-row) and the scaler face
- * once into SrcB. buf_desc_id_0 feeds UNPACKER0 -> SRCA, buf_desc_id_1 feeds UNPACKER1 -> SRCB.
+ * For 16-bit DEST, a single MOP streams the complete operand block into SrcA,
+ * one face per source-bank token; the scaler is unpacked once separately.
+ * FP32 instead programs one tile per MOP and supplies a scaler token per tile.
  *
- * @tparam block_ct_dim: number of operand tiles in the block (MOP outer-loop count).
+ * @tparam block_ct_dim: number of operand tiles streamed by the MOP.
  * @tparam is_fp32_dest_acc_en: reserved for the 32-bit dest path; does not change the unpack stream.
  * @param buf_desc_id_0/1: buffer descriptor IDs for the operand (SrcA) and scaler (SrcB).
  * @param tensor_shape: operand tile shape (num faces, face dims).
@@ -35,17 +36,23 @@ inline void _llk_unpack_reduce_block_max_row_mop_config_(
     const std::uint32_t MOP_INNER_LOOP = tensor_shape.total_num_faces();
 
     std::uint32_t unpack_srcA_face;
+    std::uint32_t unpack_srcA_face_last;
     std::uint32_t unpack_srcB_face;
-
     if (tensor_shape.total_num_faces() == NUM_FACES)
     {
-        unpack_srcA_face = TT_OP_UNPACR0_FACE_INC(0, 1 /*Src face Idx*/, 0, 0, buf_desc_id_0, 1 /*Set Dvalid*/);
-        unpack_srcB_face = TT_OP_UNPACR1_FACE_INC(0, 0, 0, 0, buf_desc_id_1, 1 /*Set Dvalid*/);
+        // Every face is written to rows 0-15 in alternating SrcA banks. The
+        // final face also advances to the next source tile.
+        unpack_srcA_face      = TT_OP_UNPACR0_FACE_INC(0, 1 /* Src face Idx */, 0, 0, buf_desc_id_0, 1 /* Set Dvalid */);
+        unpack_srcA_face_last = TT_OP_UNPACR0_FACE_INC(0, 1 /* Src face Idx */, 0, 1, buf_desc_id_0, 1 /* Set Dvalid */);
+        unpack_srcB_face      = TT_OP_UNPACR1_FACE_INC(0, 0, 0, 0, buf_desc_id_1, 1 /* Set Dvalid */);
     }
     else
     {
-        unpack_srcA_face = TT_OP_UNPACR0_TILE_INC(0, 1 /*Src tile Idx*/, buf_desc_id_0, 1 /*Set Dvalid*/);
-        unpack_srcB_face = TT_OP_UNPACR1_TILE_INC(0, 0, buf_desc_id_1, 1 /*Set Dvalid*/);
+        // Tiny-tile indices address individual faces, so TILE_INC already
+        // advances the source stream after each face.
+        unpack_srcA_face      = TT_OP_UNPACR0_TILE_INC(0, 1 /* Src tile Idx */, buf_desc_id_0, 1 /* Set Dvalid */);
+        unpack_srcA_face_last = unpack_srcA_face;
+        unpack_srcB_face      = TT_OP_UNPACR1_TILE_INC(0, 0, buf_desc_id_1, 1 /* Set Dvalid */);
     }
 
     // Reduce-row with a full face row needs no SrcA padding; a partial face row (face_r_dim < 16) seeds
@@ -58,13 +65,21 @@ inline void _llk_unpack_reduce_block_max_row_mop_config_(
             TT_OP_UNPACR_NOP(p_unpacr::UNP_A, 0, p_unpacr::UNP_STALL_UNP_WR, 0 /* clear curr bank */, p_unpacr::UNP_CLRSRC_NEGINF, p_unpacr::UNP_CLRSRC_ZERO);
 
         ckernel_template temp(MOP_OUTER_LOOP, MOP_INNER_LOOP, unpack_zero_srcA, unpack_srcA_face);
-        temp.set_start_op(unpack_srcB_face);
+        temp.set_last_inner_loop_instr(unpack_srcA_face_last);
+        if constexpr (is_fp32_dest_acc_en)
+        {
+            temp.set_start_op(unpack_srcB_face);
+        }
         temp.program_bank0_sw_cntl(instrn_buffer);
     }
     else
     {
         ckernel_template temp(MOP_OUTER_LOOP, MOP_INNER_LOOP, unpack_srcA_face);
-        temp.set_start_op(unpack_srcB_face);
+        temp.set_last_inner_loop_instr(unpack_srcA_face_last);
+        if constexpr (is_fp32_dest_acc_en)
+        {
+            temp.set_start_op(unpack_srcB_face);
+        }
         temp.program_bank0_sw_cntl(instrn_buffer);
     }
 }
@@ -96,16 +111,20 @@ inline void _llk_unpack_reduce_block_max_row_init_(
 
     if constexpr (!is_fp32_dest_acc_en)
     {
-        static_assert(block_ct_dim == 4, "16x32 block row max currently supports four tiles per block");
         if (tensor_shape.num_faces_r_dim == 1)
         {
             static_assert(tile_count_x % block_ct_dim == 0, "Tiny block row max requires complete horizontal blocks");
             static_assert(tile_count_x * tile_count_y < 1024, "Tiny block row max tile count exceeds the Quasar limit");
         }
     }
-    // Match the canonical reduce handshake: each math tile consumes and
-    // releases one SrcB scaler token, so each unpack MOP supplies one token.
-    _llk_unpack_reduce_block_max_row_mop_config_<1, is_fp32_dest_acc_en>(buf_desc_id_0, buf_desc_id_1, tensor_shape);
+    if constexpr (is_fp32_dest_acc_en)
+    {
+        _llk_unpack_reduce_block_max_row_mop_config_<1, true>(buf_desc_id_0, buf_desc_id_1, tensor_shape);
+    }
+    else
+    {
+        _llk_unpack_reduce_block_max_row_mop_config_<block_ct_dim, false>(buf_desc_id_0, buf_desc_id_1, tensor_shape);
+    }
 }
 
 /**
@@ -123,26 +142,45 @@ inline void _llk_unpack_reduce_block_max_row_(
     [[maybe_unused]] const std::uint32_t buf_desc_id_1,
     const ckernel::TensorShape& tensor_shape)
 {
-    const auto unpack_tiles = [=](const std::uint32_t tile_offset)
+    if constexpr (is_fp32_dest_acc_en)
     {
-        const std::uint32_t tile_idx_A = start_l1_tile_idx_0 + tile_offset;
-        const std::uint32_t tile_idx_B = start_l1_tile_idx_1 + tile_offset;
-        const std::uint32_t l1_idx_A   = (tensor_shape.total_num_faces() == NUM_FACES) ? tile_idx_A : tile_idx_A * tensor_shape.total_num_faces();
-        const std::uint32_t l1_idx_B   = (tensor_shape.total_num_faces() == NUM_FACES) ? tile_idx_B : tile_idx_B * tensor_shape.total_num_faces();
+        for (std::uint32_t tile = 0; tile < block_ct_dim; ++tile)
+        {
+            const std::uint32_t tile_idx_A = start_l1_tile_idx_0 + tile;
+            const std::uint32_t tile_idx_B = start_l1_tile_idx_1 + tile;
 
-        TT_SET_SRC_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, p_unpacr::UNP_A, l1_idx_A);
-        TT_SET_SRC_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, p_unpacr::UNP_B, l1_idx_B);
+            TT_SET_SRC_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, p_unpacr::UNP_A, tile_idx_A);
+            TT_SET_SRC_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, p_unpacr::UNP_B, tile_idx_B);
+            TTI_SET_DST_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, p_unpacr::UNP_A, 0);
+            TTI_SET_DST_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, p_unpacr::UNP_B, 0);
 
-        TTI_SET_DST_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, p_unpacr::UNP_A, 0);
-        TTI_SET_DST_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, p_unpacr::UNP_B, 0);
-
-        ckernel::ckernel_template::run_bank0_sw_cntl(instrn_buffer);
-    };
-
-    for (std::uint32_t tile = 0; tile < block_ct_dim; ++tile)
-    {
-        unpack_tiles(tile);
+            ckernel::ckernel_template::run_bank0_sw_cntl(instrn_buffer);
+        }
+        return;
     }
+
+    const bool full_tiles        = (tensor_shape.total_num_faces() == NUM_FACES);
+    const std::uint32_t l1_idx_A = full_tiles ? start_l1_tile_idx_0 : start_l1_tile_idx_0 * tensor_shape.total_num_faces();
+    const std::uint32_t l1_idx_B = full_tiles ? start_l1_tile_idx_1 : start_l1_tile_idx_1 * tensor_shape.total_num_faces();
+
+    // SrcB is constant and remains valid through every GMPOOL and the final
+    // MOVD2B transpose. It is released once by the math thread at block end.
+    TT_SET_SRC_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, p_unpacr::UNP_B, l1_idx_B);
+    TTI_SET_DST_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, p_unpacr::UNP_B, 0);
+    if (full_tiles)
+    {
+        TTI_UNPACR1_FACE_INC(0, 0, 0, 0, buf_desc_id_1, 1 /* Set Dvalid */);
+    }
+    else
+    {
+        TTI_UNPACR1_TILE_INC(0, 0, buf_desc_id_1, 1 /* Set Dvalid */);
+    }
+
+    // The MOP walks all faces of all block tiles. Dst_Face_Idx_Inc stays zero,
+    // so SrcA is a two-bank stream at a fixed address rather than a row walk.
+    TT_SET_SRC_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, p_unpacr::UNP_A, l1_idx_A);
+    TTI_SET_DST_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, p_unpacr::UNP_A, 0);
+    ckernel::ckernel_template::run_bank0_sw_cntl(instrn_buffer);
 }
 
 /**

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/experimental/llk_unpack_reduce_custom.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/experimental/llk_unpack_reduce_custom.h
@@ -1,0 +1,195 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+#include "ckernel_template.h"
+#include "ckernel_trisc_common.h"
+#include "llk_defs.h"
+#include "llk_unpack_common.h"
+#include "tensor_shape.h"
+
+using namespace ckernel;
+
+/**
+ * @brief Builds the block reduce_max_row unpack MOP.
+ *
+ * Per block tile: unpacks all operand faces into SrcA (transposed for reduce-row) and the scaler face
+ * once into SrcB. buf_desc_id_0 feeds UNPACKER0 -> SRCA, buf_desc_id_1 feeds UNPACKER1 -> SRCB.
+ *
+ * @tparam block_ct_dim: number of operand tiles in the block (MOP outer-loop count).
+ * @tparam is_fp32_dest_acc_en: reserved for the 32-bit dest path; does not change the unpack stream.
+ * @param buf_desc_id_0/1: buffer descriptor IDs for the operand (SrcA) and scaler (SrcB).
+ * @param tensor_shape: operand tile shape (num faces, face dims).
+ */
+template <std::uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false>
+inline void _llk_unpack_reduce_block_max_row_mop_config_(
+    const std::uint32_t buf_desc_id_0, const std::uint32_t buf_desc_id_1, const ckernel::TensorShape& tensor_shape)
+{
+    static_assert(block_ct_dim < 128, "block_ct_dim must be less than 128");
+
+    const std::uint32_t MOP_OUTER_LOOP = block_ct_dim;
+    const std::uint32_t MOP_INNER_LOOP = tensor_shape.total_num_faces();
+
+    std::uint32_t unpack_srcA_face;
+    std::uint32_t unpack_srcB_face;
+
+    if (tensor_shape.total_num_faces() == NUM_FACES)
+    {
+        unpack_srcA_face = TT_OP_UNPACR0_FACE_INC(0, 1 /*Src face Idx*/, 0, 0, buf_desc_id_0, 1 /*Set Dvalid*/);
+        unpack_srcB_face = TT_OP_UNPACR1_FACE_INC(0, 0, 0, 0, buf_desc_id_1, 1 /*Set Dvalid*/);
+    }
+    else
+    {
+        unpack_srcA_face = TT_OP_UNPACR0_TILE_INC(0, 1 /*Src tile Idx*/, buf_desc_id_0, 1 /*Set Dvalid*/);
+        unpack_srcB_face = TT_OP_UNPACR1_TILE_INC(0, 0, buf_desc_id_1, 1 /*Set Dvalid*/);
+    }
+
+    // Reduce-row with a full face row needs no SrcA padding; a partial face row (face_r_dim < 16) seeds
+    // the missing rows with -Inf so the MAX pool ignores them.
+    const bool needs_srca_clear = (tensor_shape.face_r_dim < FACE_R_DIM);
+
+    if (needs_srca_clear)
+    {
+        const std::uint32_t unpack_zero_srcA =
+            TT_OP_UNPACR_NOP(p_unpacr::UNP_A, 0, p_unpacr::UNP_STALL_UNP_WR, 0 /* clear curr bank */, p_unpacr::UNP_CLRSRC_NEGINF, p_unpacr::UNP_CLRSRC_ZERO);
+
+        ckernel_template temp(MOP_OUTER_LOOP, MOP_INNER_LOOP, unpack_zero_srcA, unpack_srcA_face);
+        temp.set_start_op(unpack_srcB_face);
+        temp.program_bank0_sw_cntl(instrn_buffer);
+    }
+    else
+    {
+        ckernel_template temp(MOP_OUTER_LOOP, MOP_INNER_LOOP, unpack_srcA_face);
+        temp.set_start_op(unpack_srcB_face);
+        temp.program_bank0_sw_cntl(instrn_buffer);
+    }
+}
+
+/**
+ * @brief Initializes the unpacker for block reduce_max_row.
+ *
+ * Enables SrcA transpose (reduce-row) and programs the block unpack MOP.
+ *
+ * @tparam block_ct_dim: number of operand tiles in the block.
+ * @tparam is_fp32_dest_acc_en: enables the 32-bit-dest MOVB2D hi16/lo16 zero-flag config.
+ * @param buf_desc_id_0/1: buffer descriptor IDs for the operand (SrcA) and scaler (SrcB).
+ * @param tensor_shape: operand tile shape.
+ * @note On the math thread, pair with @ref _llk_math_reduce_block_max_row_init_ (T1).
+ * @note @ref _llk_unpack_reduce_block_max_row_ is the matching execute call on this thread.
+ */
+template <std::uint32_t block_ct_dim, std::uint32_t tile_count_x, std::uint32_t tile_count_y, bool is_fp32_dest_acc_en = false>
+inline void _llk_unpack_reduce_block_max_row_init_(
+    const std::uint32_t buf_desc_id_0, const std::uint32_t buf_desc_id_1, const ckernel::TensorShape& tensor_shape)
+{
+    LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
+
+    if constexpr (is_fp32_dest_acc_en)
+    {
+        cfg_rmw(ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW, 1);
+    }
+    cfg_rmw(THCON_UNPACKER0_REG0_TRANSPOSE_RMW, 1); // SrcA transpose ON (reduce-row)
+    cfg_rmw(THCON_UNPACKER1_REG0_TRANSPOSE_RMW, 0); // scaler not transposed
+
+    if constexpr (is_fp32_dest_acc_en)
+    {
+        _llk_unpack_reduce_block_max_row_mop_config_<1, true>(buf_desc_id_0, buf_desc_id_1, tensor_shape);
+    }
+    else if (tensor_shape.num_faces_r_dim == 1)
+    {
+        // Tiny tensors use a direct execute loop below because repeated Quasar unpack MOP
+        // invocations can lose the Src-valid handoff at block boundaries.
+        static_assert(block_ct_dim == 4, "16x32 block row max currently supports four tiles per block");
+        static_assert(tile_count_x % block_ct_dim == 0, "Tiny block row max requires complete horizontal blocks");
+        static_assert(tile_count_x * tile_count_y < 1024, "Tiny block row max tile count exceeds the Quasar limit");
+    }
+    else
+    {
+        _llk_unpack_reduce_block_max_row_mop_config_<block_ct_dim, false>(buf_desc_id_0, buf_desc_id_1, tensor_shape);
+    }
+}
+
+/**
+ * @brief Unpacks one block of operands (SrcA) and the scaler (SrcB) for block reduce_max_row.
+ *
+ * @param start_l1_tile_idx_0/1: start L1 tile indices; index 0 -> UNPACKER0 -> SRCA, index 1 -> UNPACKER1 -> SRCB.
+ * @param tensor_shape: operand tile shape.
+ * @note Call @ref _llk_unpack_reduce_block_max_row_init_ with matching template args before this function.
+ */
+template <std::uint32_t block_ct_dim, std::uint32_t tile_count_x, std::uint32_t tile_count_y, bool is_fp32_dest_acc_en = false>
+inline void _llk_unpack_reduce_block_max_row_(
+    const std::uint32_t start_l1_tile_idx_0,
+    const std::uint32_t start_l1_tile_idx_1,
+    const std::uint32_t buf_desc_id_0,
+    const std::uint32_t buf_desc_id_1,
+    const ckernel::TensorShape& tensor_shape)
+{
+    const auto unpack_tiles = [=](const std::uint32_t tile_offset)
+    {
+        const std::uint32_t tile_idx_A = start_l1_tile_idx_0 + tile_offset;
+        const std::uint32_t tile_idx_B = start_l1_tile_idx_1 + tile_offset;
+        const std::uint32_t l1_idx_A   = (tensor_shape.total_num_faces() == NUM_FACES) ? tile_idx_A : tile_idx_A * tensor_shape.total_num_faces();
+        const std::uint32_t l1_idx_B   = (tensor_shape.total_num_faces() == NUM_FACES) ? tile_idx_B : tile_idx_B * tensor_shape.total_num_faces();
+
+        TT_SET_SRC_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, p_unpacr::UNP_A, l1_idx_A);
+        TT_SET_SRC_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, p_unpacr::UNP_B, l1_idx_B);
+
+        TTI_SET_DST_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, p_unpacr::UNP_A, 0);
+        TTI_SET_DST_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, p_unpacr::UNP_B, 0);
+
+        ckernel::ckernel_template::run_bank0_sw_cntl(instrn_buffer);
+    };
+
+    if constexpr (is_fp32_dest_acc_en)
+    {
+        unpack_tiles(0);
+        unpack_tiles(1);
+    }
+    else if (tensor_shape.num_faces_r_dim == 1)
+    {
+        const std::uint32_t l1_idx_B = start_l1_tile_idx_1 * tensor_shape.total_num_faces();
+
+        TT_SET_SRC_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, p_unpacr::UNP_B, l1_idx_B);
+        TTI_SET_DST_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, p_unpacr::UNP_B, 0);
+
+        // The fused kernel traverses horizontal blocks first, then tensor rows. Stream
+        // SrcA in that same order so each math destination section consumes its own block.
+        for (std::uint32_t block_x = 0; block_x < tile_count_x; block_x += block_ct_dim)
+        {
+            for (std::uint32_t block_y = 0; block_y < tile_count_y; ++block_y)
+            {
+                const std::uint32_t block_start_tile = start_l1_tile_idx_0 + block_y * tile_count_x + block_x;
+                TT_SET_SRC_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, p_unpacr::UNP_A, block_start_tile * tensor_shape.total_num_faces());
+                TTI_SET_DST_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, p_unpacr::UNP_A, 0);
+
+                for (std::uint32_t tile = 0; tile < block_ct_dim; ++tile)
+                {
+                    // Native row-reduce releases SrcB after every logical tile, so refresh
+                    // the scaler dvalid each time. The test scaler is constant, hence Src increment 0.
+                    TTI_UNPACR1_TILE_INC(0, 0, buf_desc_id_1, 1);
+
+                    for (std::uint32_t face = 0; face < 2; ++face)
+                    {
+                        TTI_UNPACR_NOP(p_unpacr::UNP_A, 0, p_unpacr::UNP_STALL_UNP_WR, 0, p_unpacr::UNP_CLRSRC_NEGINF, p_unpacr::UNP_CLRSRC_ZERO);
+                        TTI_UNPACR0_TILE_INC(0, 1, buf_desc_id_0, 1);
+                    }
+                }
+            }
+        }
+    }
+    else
+    {
+        unpack_tiles(0);
+    }
+}
+
+/**
+ * @brief Restores unpacker state after block reduce_max_row (clears the reduce-row transpose config).
+ */
+inline void _llk_unpack_reduce_block_max_row_uninit_()
+{
+    cfg_rmw(THCON_UNPACKER0_REG0_TRANSPOSE_RMW, 0);
+}


### PR DESCRIPTION
## Summary

- add Quasar unpack and math LLKs for `reduce_block_max_row`
- support both 32x32 FP32-dest and 16x32 BF16 tiny-tile paths
- register the operation in the Quasar fuser and gate packing to tiles actually produced by the sparse reduce
- update Quasar fuser pack API calls and use the counting `MATH_PACK` semaphore handshake

## Root cause and fix

- **FP32 path:** GMPOOL produces a 1x16 row, but routing the result through `MOVD2B` and Src loses FP32 precision on Quasar. The new path pools faces independently and performs transpose plus cross-face/tile max entirely in 32-bit Dest using `SFPLOAD`, `SFPTRANSP`, and `SFPSWAP`.
- **16x32 path:** direct unpack needed to follow the fused block traversal, and a generic trailing `CLR_B` cleared SrcB a second time after each block. When unpack had prefetched the next scaler, that clear erased its dvalid and permanently desynchronized unpack and math. The tiny path now clears SrcB exactly once per logical tile.
- **Fuser integration:** Quasar pack signatures had drifted, the previous dvalid synchronization did not provide counting back-pressure, and the packer consumed gap tiles not written by reduce-max. This change updates the API calls, uses the counting semaphore scheme, and adds per-FPU pack gating.

## VCS evidence

Targeted TRISC waves reproduced the two-block deadlock. The final useful sequence showed `i_clear_dvalid` assert `0x04` and then `0x08`; both SrcB current/other-bank ready masks then became `0000`, math issued no further valid instruction, and completion mailboxes remained zero. Removing only the redundant tiny-path `CLR_B` changed the two-block reproducer from a permanent stall to PCC 0.999910.

Internal references: [TEN-4810](https://tenstorrent.atlassian.net/browse/TEN-4810), [MOVD2B](https://tenstorrent.atlassian.net/wiki/spaces/TA/pages/1612939774/MOVD2B), [Neo FPU formats](https://tenstorrent.atlassian.net/wiki/spaces/TA/pages/1124335662/Neo+FPU+Supported+Formats), [Quasar implied-format issues](https://tenstorrent.atlassian.net/wiki/spaces/LLK/pages/2487550308/Quasar+implied+format+issues).

## Validation

Run on the actual Quasar simulator after rebasing onto current `main`:

- [x] `fpu_reduce_block_max` 256x256 FP32: PCC 1.000000
- [x] `fpu_reduce_block_max_tiny` 256x256 BF16: PCC 0.999935
- [x] `fpu_reduce_block_max_runtime`: skipped as expected on Quasar
- [x] `fpu_elwadd`: PCC 1.000000
- [x] `fpu_elwmul`: PCC 1.000000
- [x] pre-commit formatting, lint, whitespace, and codespell hooks

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=llk_code_gen/generated-reduce_max_row-quasar-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:llk_code_gen/generated-reduce_max_row-quasar-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=llk_code_gen/generated-reduce_max_row-quasar-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:llk_code_gen/generated-reduce_max_row-quasar-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=llk_code_gen/generated-reduce_max_row-quasar-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:llk_code_gen/generated-reduce_max_row-quasar-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=llk_code_gen/generated-reduce_max_row-quasar-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:llk_code_gen/generated-reduce_max_row-quasar-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=llk_code_gen/generated-reduce_max_row-quasar-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:llk_code_gen/generated-reduce_max_row-quasar-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=llk_code_gen/generated-reduce_max_row-quasar-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:llk_code_gen/generated-reduce_max_row-quasar-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=llk_code_gen/generated-reduce_max_row-quasar-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:llk_code_gen/generated-reduce_max_row-quasar-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=llk_code_gen/generated-reduce_max_row-quasar-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:llk_code_gen/generated-reduce_max_row-quasar-v1)