### PR TITLE
[fuser] quasar synchronization with semaphores

### DIFF
--- a/tt_metal/tt-llk/tests/helpers/include/boot.h
+++ b/tt_metal/tt-llk/tests/helpers/include/boot.h
@@ -101,6 +101,7 @@ TT_ALWAYS_INLINE void device_setup()
 #if defined(ARCH_QUASAR)
     // Reset all dest dvalid bits for all clients
     TTI_CLEARDVALID(0, 0, 0xf, 0xf, 0, 0);
+    TTI_SEMINIT(1, 0, 0, ckernel::semaphore::t6_sem(ckernel::semaphore::PACK_DONE));
 #endif
 
 // Enable CC stack

--- a/tt_metal/tt-llk/tests/helpers/include/boot.h
+++ b/tt_metal/tt-llk/tests/helpers/include/boot.h
@@ -10,6 +10,9 @@
 #include "cfg_defines.h"
 #include "ckernel.h"
 #include "ckernel_helper.h"
+#if defined(ARCH_QUASAR)
+#include "ckernel_trisc_common.h"
+#endif
 
 // C-runtime related linker symbols
 extern volatile char __ldm_bss_start[], __ldm_bss_end[];
@@ -101,7 +104,7 @@ TT_ALWAYS_INLINE void device_setup()
 #if defined(ARCH_QUASAR)
     // Reset all dest dvalid bits for all clients
     TTI_CLEARDVALID(0, 0, 0xf, 0xf, 0, 0);
-    TTI_SEMINIT(1, 0, 0, ckernel::semaphore::t6_sem(ckernel::semaphore::PACK_DONE));
+    TTI_SEMINIT(1, 0, 0, ckernel::trisc::semaphore::t6_sem(ckernel::trisc::semaphore::PACK_UNPACK));
 #endif
 
 // Enable CC stack

--- a/tt_metal/tt-llk/tests/helpers/include/sfpu_operations_quasar.h
+++ b/tt_metal/tt-llk/tests/helpers/include/sfpu_operations_quasar.h
@@ -192,6 +192,8 @@ void call_zero_comp_operation_quasar(std::uint32_t dst_index, DataFormat sfpu_fo
  * @tparam is_fp32_dest_acc_en Whether Dest is in FP32 mode.
  * @tparam APPROX Whether operations with approximate and accurate paths use the approximate path.
  * @tparam ITERATIONS Number of SFPU loop iterations.
+ * @tparam TYPECAST_IN_FORMAT Source format for the typecast op (default Float32).
+ * @tparam TYPECAST_OUT_FORMAT Destination format for the typecast op (default Float16_b).
  * @param dst_index Destination tile index operated on (already offset by DST_INDEX).
  * @param sfpu_format SFPU math format; only the comp family reads it (see
  *        @ref call_zero_comp_operation_quasar), float-only ops ignore it.

--- a/tt_metal/tt-llk/tests/helpers/include/sfpu_operations_quasar.h
+++ b/tt_metal/tt-llk/tests/helpers/include/sfpu_operations_quasar.h
@@ -197,7 +197,14 @@ void call_zero_comp_operation_quasar(std::uint32_t dst_index, DataFormat sfpu_fo
  *        @ref call_zero_comp_operation_quasar), float-only ops ignore it.
  * @note Must be preceded by @ref init_unary_sfpu_operation_quasar for the same op.
  */
-template <SfpuType OPERATION, DstSync DST_SYNC, bool is_fp32_dest_acc_en, bool APPROX = false, int ITERATIONS = SFPU_ITERATIONS>
+template <
+    SfpuType OPERATION,
+    DstSync DST_SYNC,
+    bool is_fp32_dest_acc_en,
+    bool APPROX                    = false,
+    int ITERATIONS                 = SFPU_ITERATIONS,
+    DataFormat TYPECAST_IN_FORMAT  = DataFormat::Float32,
+    DataFormat TYPECAST_OUT_FORMAT = DataFormat::Float16_b>
 void call_unary_sfpu_operation_quasar(std::uint32_t dst_index, DataFormat sfpu_format = DataFormat::Float32)
 {
     if constexpr (OPERATION == SfpuType::abs)
@@ -297,10 +304,6 @@ void call_unary_sfpu_operation_quasar(std::uint32_t dst_index, DataFormat sfpu_f
     }
     else if constexpr (OPERATION == SfpuType::typecast)
     {
-        // Typecast is parameterized by the (input,output) DataFormat pair, which the test
-        // bakes in as the compile-time constants TYPECAST_IN_FORMAT / TYPECAST_OUT_FORMAT (set
-        // by the TYPECAST_FORMATS variant). The functor picks the conversion sequence from the
-        // pair at compile time.
         SFPU_UNARY_CALL(DST_SYNC, is_fp32_dest_acc_en, calculate_typecast, (TYPECAST_IN_FORMAT, TYPECAST_OUT_FORMAT, ITERATIONS), dst_index, VectorMode::RC);
     }
     else

--- a/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/packer/common.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/packer/common.py
@@ -7,6 +7,8 @@ from fuser.wormhole.packer.common import (  # noqa: F401
     configure_pack,
     l1_accumulation_config,
     pack_dest_init,
+    pack_reduce_mask_clear,
+    pack_reduce_mask_config,
     packer_dest_section_done,
     packer_sync_with_unpacker,
     packer_wait_for_math,

--- a/tt_metal/tt-llk/tests/python_tests/fuser/fpu_node.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/fpu_node.py
@@ -92,7 +92,6 @@ class FpuNode:
     ):
         if self.unpacker is None or config.skip_unpack_init:
             return ""
-        config.sentinel.ensure_unpack_buf_desc_ids(self)
         return self.unpacker.init(operation, config, self, block)
 
     def unpack_run(

--- a/tt_metal/tt-llk/tests/python_tests/fuser/fused_generator.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/fused_generator.py
@@ -10,6 +10,7 @@ from typing import Dict
 
 from helpers.chip_architecture import ChipArchitecture
 
+from .fused_operand import OperandRegistry
 from .fuser_config import FuserConfig
 
 FUSED_TESTS_DIR = Path("sources/fused_tests")
@@ -38,6 +39,11 @@ class UnpackKernelGenerator:
             [op.unpack(self.config.global_config) for op in self.config.pipeline]
         )
 
+        buf_desc_init = ""
+        if self.config.global_config.architecture == ChipArchitecture.QUASAR:
+            reg = self.config.operand_registry
+            buf_desc_init = OperandRegistry.emit_operand_init(reg.get_all_inputs())
+
         code = (
             f"\n"
             f"#ifdef LLK_TRISC_UNPACK\n"
@@ -46,6 +52,7 @@ class UnpackKernelGenerator:
             f"\n"
             f"void run_kernel([[maybe_unused]] const volatile struct RuntimeParams& params)\n"
             f"{{\n"
+            f"{buf_desc_init}"
             f"{unpack_calls}"
             f"}}\n"
             f"\n"
@@ -130,6 +137,11 @@ class PackKernelGenerator:
             [op.pack(self.config.global_config) for op in self.config.pipeline]
         )
 
+        buf_desc_init = ""
+        if self.config.global_config.architecture == ChipArchitecture.QUASAR:
+            reg = self.config.operand_registry
+            buf_desc_init = OperandRegistry.emit_operand_init(reg.get_all_outputs())
+
         code = (
             f"\n"
             f"#ifdef LLK_TRISC_PACK\n"
@@ -138,6 +150,7 @@ class PackKernelGenerator:
             f"\n"
             f"void run_kernel([[maybe_unused]] const volatile struct RuntimeParams& params)\n"
             f"{{\n"
+            f"{buf_desc_init}"
             f"{pack_calls}"
             f"}}\n"
             f"\n"
@@ -174,9 +187,20 @@ class FusedKernelGenerator:
             profiler_include += '#include "profiler.h"\n'
             profiler_include += '#include "perf.h"\n'
 
-        operands = self.config.operand_registry.generate_cpp(
-            self.config.global_config.dest_acc.value
+        if self.config.global_config.architecture == ChipArchitecture.QUASAR:
+            operands = ""
+        else:
+            operands = self.config.operand_registry.generate_cpp(
+                self.config.global_config.dest_acc.value
+            )
+
+        operand_include = (
+            ""
+            if self.config.global_config.architecture == ChipArchitecture.QUASAR
+            else '#include "operand.h"\n'
         )
+
+        dvalid_include = ""
 
         combined = (
             f"#define FUSED_TEST\n"
@@ -185,7 +209,8 @@ class FusedKernelGenerator:
             f'#include "ckernel_defs.h"\n'
             f'#include "ckernel_sfpu.h"\n'
             f'#include "tensix_types.h"\n'
-            f'#include "operand.h"\n'
+            f"{operand_include}"
+            f"{dvalid_include}"
             f"{profiler_include}"
             f"\n"
             f"std::uint32_t unp_cfg_context          = 0;\n"
@@ -209,6 +234,7 @@ class FusedKernelGenerator:
         fused_test_cpp_dir.mkdir(parents=True, exist_ok=True)
 
         cpp_path = test_cpp_dir / f"{test_name}"
+        cpp_path.parent.mkdir(parents=True, exist_ok=True)
 
         with open(cpp_path, "w") as f:
             f.write(combined)

--- a/tt_metal/tt-llk/tests/python_tests/fuser/fused_generator.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/fused_generator.py
@@ -200,8 +200,6 @@ class FusedKernelGenerator:
             else '#include "operand.h"\n'
         )
 
-        dvalid_include = ""
-
         combined = (
             f"#define FUSED_TEST\n"
             f'#include "ckernel.h"\n'
@@ -210,7 +208,6 @@ class FusedKernelGenerator:
             f'#include "ckernel_sfpu.h"\n'
             f'#include "tensix_types.h"\n'
             f"{operand_include}"
-            f"{dvalid_include}"
             f"{profiler_include}"
             f"\n"
             f"std::uint32_t unp_cfg_context          = 0;\n"

--- a/tt_metal/tt-llk/tests/python_tests/fuser/fused_generator.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/fused_generator.py
@@ -194,8 +194,8 @@ class FusedKernelGenerator:
                 self.config.global_config.dest_acc.value
             )
 
-        operand_include = (
-            ""
+        quasar_include = (
+            '#include "llk_sync.h"\n'
             if self.config.global_config.architecture == ChipArchitecture.QUASAR
             else '#include "operand.h"\n'
         )
@@ -207,7 +207,7 @@ class FusedKernelGenerator:
             f'#include "ckernel_defs.h"\n'
             f'#include "ckernel_sfpu.h"\n'
             f'#include "tensix_types.h"\n'
-            f"{operand_include}"
+            f"{quasar_include}"
             f"{profiler_include}"
             f"\n"
             f"std::uint32_t unp_cfg_context          = 0;\n"

--- a/tt_metal/tt-llk/tests/python_tests/fuser/fused_loop.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/fused_loop.py
@@ -176,6 +176,7 @@ class LoopTileByTile(FusedLoop):
         code = ""
         if config.perf_run_type == PerfRunType.PACK_ISOLATE:
             return code
+
         code += f"for (std::uint32_t tile_x = 0; tile_x < {block.block_tiles_x}; tile_x++) {{\n"
         code += f"for (std::uint32_t tile_y = 0; tile_y < {block.block_tiles_y}; tile_y++) {{\n"
         block.tile_id_global = f"{block.tile_count_x} * ({block.block_y} + tile_y) + ({block.block_x} + tile_x)"
@@ -203,6 +204,7 @@ class LoopTileByTile(FusedLoop):
         code = ""
         if config.perf_run_type == PerfRunType.PACK_ISOLATE:
             return code
+
         code += f"for (std::uint32_t tile_x = 0; tile_x < {block.block_tiles_x}; tile_x++) {{\n"
         code += f"for (std::uint32_t tile_y = 0; tile_y < {block.block_tiles_y}; tile_y++) {{\n"
         block.tile_id_global = f"{block.tile_count_x} * ({block.block_y} + tile_y) + ({block.block_x} + tile_x)"
@@ -219,7 +221,7 @@ class LoopTileByTile(FusedLoop):
                 operation, config, compute_unit, block
             )
         else:
-            code += f"std::uint32_t tile_id = {tile_id_block};\n"
+            code += f"[[maybe_unused]] std::uint32_t tile_id = {tile_id_block};\n"
             block.tile_id_global = f"{block.tile_count_x} * ({block.block_y} + tile_y) + ({block.block_x} + tile_x)"
             block.tile_id_block = "tile_id"
             code += compute_unit.fpu.calculate(operation, config, compute_unit, block)

--- a/tt_metal/tt-llk/tests/python_tests/fuser/fused_math.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/fused_math.py
@@ -191,7 +191,7 @@ class ComputePipeline:
         operation: "FusedOperation",
         config: "GlobalConfig",
     ) -> str:
-        return unpack_common.sync_with_packer(operation.stage_id)
+        return unpack_common.sync_with_packer(operation.needs_pack_sync)
 
     def unpack_body(self, operation: "FusedOperation", config: "GlobalConfig") -> str:
         unpack_ops = [
@@ -203,7 +203,9 @@ class ComputePipeline:
         hoist_reconfig = hoist or self._all_same_operand_formats(unpack_ops)
 
         init_code = ""
-        init_code += unpack_common.dvalid_init()
+        init_code += unpack_common.dvalid_init(
+            quasar_use_dvalid=config.quasar_use_dvalid
+        )
         init_code += config.sentinel.hw_configure_unpack(config, operation)
         if hoist_reconfig and unpack_ops:
             init_code += unpack_ops[0].unpack_reconfig(operation, config)
@@ -253,7 +255,10 @@ class ComputePipeline:
     ) -> str:
         if config.skip_sync:
             return ""
-        return fpu_common.math_wait_for_dest(operation.dest_sync.cpp_enum_value)
+        return fpu_common.math_wait_for_dest(
+            operation.dest_sync.cpp_enum_value,
+            quasar_use_dvalid=config.quasar_use_dvalid,
+        )
 
     def _math_dest_section_done(
         self, operation: "FusedOperation", config: "GlobalConfig"
@@ -263,14 +268,18 @@ class ComputePipeline:
         return fpu_common.math_dest_section_done(
             operation.dest_sync.cpp_enum_value,
             config.dest_acc.cpp_enum_value,
+            quasar_use_dvalid=config.quasar_use_dvalid,
         )
 
     def _math_pack_sync_init(
         self, operation: "FusedOperation", config: "GlobalConfig"
     ) -> str:
+        if not config.quasar_use_dvalid and operation.stage_id != 1:
+            return ""
         return fpu_common.math_pack_sync_init(
             operation.dest_sync.cpp_enum_value,
             config.dest_acc.cpp_enum_value,
+            quasar_use_dvalid=config.quasar_use_dvalid,
         )
 
     def _math_constants(
@@ -332,7 +341,9 @@ class ComputePipeline:
     def _packer_wait_for_math(self, config: "GlobalConfig") -> str:
         if config.skip_sync:
             return ""
-        return pack_common.packer_wait_for_math()
+        return pack_common.packer_wait_for_math(
+            quasar_use_dvalid=config.quasar_use_dvalid
+        )
 
     def _packer_dest_section_done(
         self, operation: "FusedOperation", config: "GlobalConfig"
@@ -342,14 +353,18 @@ class ComputePipeline:
         return pack_common.packer_dest_section_done(
             operation.dest_sync.cpp_enum_value,
             config.dest_acc.cpp_enum_value,
+            quasar_use_dvalid=config.quasar_use_dvalid,
         )
 
     def _pack_dest_init(
         self, operation: "FusedOperation", config: "GlobalConfig"
     ) -> str:
+        if not config.quasar_use_dvalid and operation.stage_id != 1:
+            return ""
         return pack_common.pack_dest_init(
             operation.dest_sync.cpp_enum_value,
             config.dest_acc.cpp_enum_value,
+            quasar_use_dvalid=config.quasar_use_dvalid,
         )
 
     def _pack_constants(
@@ -361,7 +376,8 @@ class ComputePipeline:
     def _pack_reduce_mask_config(self, operation: "FusedOperation") -> str:
         if operation.reduce_dim is not None:
             reduce_dim = operation.reduce_dim.cpp_enum_value
-            return f"_llk_pack_reduce_mask_config_<{reduce_dim}>();\n"
+            tensor_shape = operation.tile_shape.cpp_value
+            return f"_llk_pack_reduce_mask_config_<{reduce_dim}>({tensor_shape});\n"
         return ""
 
     def _pack_reduce_mask_clear(self, operation: "FusedOperation") -> str:
@@ -374,9 +390,7 @@ class ComputePipeline:
         operation: "FusedOperation",
         config: "GlobalConfig",
     ) -> str:
-        return pack_common.packer_sync_with_unpacker(
-            operation.stage_id, operation.num_stages
-        )
+        return pack_common.packer_sync_with_unpacker(operation.has_pack_consumer)
 
     def _all_same_pack_formats(self) -> bool:
         pack_only = self._get_pack_nodes()
@@ -392,10 +406,10 @@ class ComputePipeline:
         hoist_reconfig = hoist or self._all_same_pack_formats()
 
         init_code = config.sentinel.hw_configure_pack(config, operation, pack_only)
-        init_code += self._pack_dest_init(operation, config)
         init_code += self._pack_reduce_mask_config(operation)
         if hoist_reconfig and pack_only:
             init_code += pack_only[0].reconfig(operation, config)
+        init_code += self._pack_dest_init(operation, config)
         if hoist:
             init_code += pack_only[0].configure(operation, config, None)
         code += self._zone(config, "INIT", init_code)

--- a/tt_metal/tt-llk/tests/python_tests/fuser/fused_math.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/fused_math.py
@@ -373,16 +373,6 @@ class ComputePipeline:
         stage = operation.stage_id
         return f"// Operation {stage}: Packer\n"
 
-    def _pack_reduce_mask_config(self, operation: "FusedOperation") -> str:
-        if operation.reduce_dim is not None:
-            return pack_common.pack_reduce_mask_config(operation)
-        return ""
-
-    def _pack_reduce_mask_clear(self, operation: "FusedOperation") -> str:
-        if operation.reduce_dim is not None:
-            return "_llk_pack_reduce_mask_clear_();\n"
-        return ""
-
     def packer_sync_with_unpacker(
         self,
         operation: "FusedOperation",
@@ -406,7 +396,7 @@ class ComputePipeline:
         init_code = config.sentinel.hw_configure_pack(config, operation, pack_only)
         if hoist_reconfig and pack_only:
             init_code += pack_only[0].reconfig(operation, config)
-        init_code += self._pack_reduce_mask_config(operation)
+        init_code += pack_common.pack_reduce_mask_config(operation)
         init_code += self._pack_dest_init(operation, config)
         if hoist:
             init_code += pack_only[0].configure(operation, config, None)
@@ -444,7 +434,7 @@ class ComputePipeline:
         uninit_code = self.packer_sync_with_unpacker(operation, config)
         if hoist:
             uninit_code += pack_only[0].uninit(operation, config)
-        uninit_code += self._pack_reduce_mask_clear(operation)
+        uninit_code += pack_common.pack_reduce_mask_clear(operation)
         code += self._zone(config, "INIT", uninit_code)
 
         return code

--- a/tt_metal/tt-llk/tests/python_tests/fuser/fused_math.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/fused_math.py
@@ -375,9 +375,7 @@ class ComputePipeline:
 
     def _pack_reduce_mask_config(self, operation: "FusedOperation") -> str:
         if operation.reduce_dim is not None:
-            reduce_dim = operation.reduce_dim.cpp_enum_value
-            tensor_shape = operation.tile_shape.cpp_value
-            return f"_llk_pack_reduce_mask_config_<{reduce_dim}>({tensor_shape});\n"
+            return pack_common.pack_reduce_mask_config(operation)
         return ""
 
     def _pack_reduce_mask_clear(self, operation: "FusedOperation") -> str:
@@ -406,9 +404,9 @@ class ComputePipeline:
         hoist_reconfig = hoist or self._all_same_pack_formats()
 
         init_code = config.sentinel.hw_configure_pack(config, operation, pack_only)
-        init_code += self._pack_reduce_mask_config(operation)
         if hoist_reconfig and pack_only:
             init_code += pack_only[0].reconfig(operation, config)
+        init_code += self._pack_reduce_mask_config(operation)
         init_code += self._pack_dest_init(operation, config)
         if hoist:
             init_code += pack_only[0].configure(operation, config, None)

--- a/tt_metal/tt-llk/tests/python_tests/fuser/fused_operand.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/fused_operand.py
@@ -26,6 +26,7 @@ from helpers.unpack import unpack_res_tiles
 @dataclass
 class Operand:
     _next_buf_desc_id: ClassVar[int] = 0
+    MAX_OPERANDS_NUM: ClassVar[int] = 32
 
     name: str
     dimensions: Tuple[int, int]
@@ -54,9 +55,9 @@ class Operand:
 
     def __post_init__(self):
         self.buf_desc_id = Operand._next_buf_desc_id
-        if self.buf_desc_id >= 32:
+        if self.buf_desc_id >= Operand.MAX_OPERANDS_NUM:
             raise ValueError(
-                f"buf_desc_id {self.buf_desc_id} exceeds maximum of 31 for operand '{self.name}'"
+                f"buf_desc_id {self.buf_desc_id} exceeds maximum of {Operand.MAX_OPERANDS_NUM - 1} for operand '{self.name}'"
             )
         Operand._next_buf_desc_id += 1
         self.tile_count_x = self.dimensions[1] // self.tile_shape.total_col_dim()

--- a/tt_metal/tt-llk/tests/python_tests/fuser/fused_operand.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/fused_operand.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from dataclasses import dataclass, field
-from typing import List, Optional, Tuple
+from typing import ClassVar, List, Optional, Tuple
 
 import torch
 from helpers.device_io import read_from_device, write_to_device
@@ -25,6 +25,8 @@ from helpers.unpack import unpack_res_tiles
 
 @dataclass
 class Operand:
+    _next_buf_desc_id: ClassVar[int] = 0
+
     name: str
     dimensions: Tuple[int, int]
     data_format: DataFormat
@@ -34,6 +36,7 @@ class Operand:
         )
     )
     l1_address: Optional[int] = None
+    is_input: bool = False
     is_output: bool = False
     sfpu: bool = True
     _raw_data: Optional[torch.Tensor] = None
@@ -50,6 +53,12 @@ class Operand:
     buf_desc_id: Optional[int] = None
 
     def __post_init__(self):
+        self.buf_desc_id = Operand._next_buf_desc_id
+        if self.buf_desc_id >= 32:
+            raise ValueError(
+                f"buf_desc_id {self.buf_desc_id} exceeds maximum of 31 for operand '{self.name}'"
+            )
+        Operand._next_buf_desc_id += 1
         self.tile_count_x = self.dimensions[1] // self.tile_shape.total_col_dim()
         self.tile_count_y = self.dimensions[0] // self.tile_shape.total_row_dim()
         self.tile_count = self.tile_count_x * self.tile_count_y
@@ -71,9 +80,6 @@ class Operand:
         self.tile_size = (
             TILE_SIZES.get(self.data_format, 128) * self.tile_shape.total_num_faces()
         ) // 4
-
-    def is_input(self) -> bool:
-        return not self.is_output
 
     def generate_data(self):
         height, width = self.dimensions[0], self.dimensions[1]
@@ -110,13 +116,13 @@ class Operand:
 
     @property
     def raw_data(self) -> Optional[torch.Tensor]:
-        if self._raw_data is None and self.is_input():
+        if self._raw_data is None and not self.is_output:
             self.generate_data()
         return self._raw_data
 
     @property
     def master_golden(self) -> Optional[torch.Tensor]:
-        if self.is_input():
+        if not self.is_output:
             return self.raw_data
         return self._master_golden
 
@@ -180,7 +186,7 @@ class Operand:
                 num_faces=num_faces,
                 tile_dimensions=tile_dims,
             ).flatten()
-            if self.is_input()
+            if not self.is_output
             else torch.zeros(self.dimensions).flatten()
         )
 
@@ -206,6 +212,10 @@ class Operand:
     def cpp_name(self) -> str:
         return f"{self.name}_buffer"
 
+    @property
+    def cpp_desc_name(self) -> str:
+        return f"{self.name}_desc"
+
     def cpp_value(self, dest_acc: bool) -> str:
         buffer_size = calculate_tile_size_bytes(
             data_format=self.data_format,
@@ -219,10 +229,26 @@ class Operand:
         )
         return f"[[maybe_unused]] const Operand {self.cpp_name}({hex(self.l1_address)}, {buffer_size});\n"
 
+    def cpp_tdma_decl_init(self) -> str:
+        return (
+            f"tdma_descriptor_t {self.cpp_desc_name} = "
+            f"ckernel::trisc::construct_tdma_desc("
+            f"{self.tile_shape.cpp_value}, "
+            f"{hex(self.l1_address)} / 16, "
+            f"{self.data_format.cpp_underlying_value}, "
+            f"{self.buf_desc_id}, 0);\n"
+        )
+
+    def emit_buf_desc_table_entry(self) -> str:
+        if self.buf_desc_id is None:
+            return ""
+        return f"ckernel::trisc::_configure_buf_desc_table_({self.buf_desc_id}, {self.cpp_desc_name}.buf_desc);\n"
+
 
 class OperandRegistry:
     def __init__(self):
         self.operands: dict[str, Operand] = {}
+        Operand._next_buf_desc_id = 0
 
     def create(
         self,
@@ -274,7 +300,7 @@ class OperandRegistry:
         return self.operands[name]
 
     def get_all_inputs(self) -> list[Operand]:
-        return [op for op in self.operands.values() if op.is_input()]
+        return [op for op in self.operands.values() if op.is_input]
 
     def get_all_outputs(self) -> list[Operand]:
         return [op for op in self.operands.values() if op.is_output]
@@ -306,13 +332,13 @@ class OperandRegistry:
 
         current_address = start_address
 
-        for operand in self.get_all_inputs():
-            if operand.l1_address is None:
+        for operand in self.operands.values():
+            if not operand.is_output and operand.l1_address is None:
                 operand.l1_address = current_address
                 current_address += operand.calculate_l1_size()
 
-        for operand in self.get_all_outputs():
-            if operand.l1_address is None:
+        for operand in self.operands.values():
+            if operand.is_output and operand.l1_address is None:
                 operand.l1_address = current_address
                 current_address += operand.calculate_l1_size()
                 if current_address > end_address:
@@ -323,11 +349,7 @@ class OperandRegistry:
     def write_inputs_to_l1(self, location: str = "0,0") -> None:
         """Write all input operands to L1 memory."""
 
-        for operand in self.get_all_inputs():
-            for addr, packed_data in operand.pack_for_l1():
-                write_to_device(location, addr, packed_data)
-
-        for operand in self.get_all_outputs():
+        for operand in self.operands.values():
             for addr, packed_data in operand.pack_for_l1():
                 write_to_device(location, addr, packed_data)
 
@@ -390,13 +412,23 @@ class OperandRegistry:
 
             output._raw_data = raw_tensor
 
+    @staticmethod
+    def emit_operand_init(operands: list[Operand]) -> str:
+        code = ""
+        for op in operands:
+            code += op.cpp_tdma_decl_init()
+            code += op.emit_buf_desc_table_entry()
+        return code
+
     def generate_cpp(self, dest_acc: bool):
         code = "// Inputs\n"
-        for operand in self.get_all_inputs():
-            code += operand.cpp_value(dest_acc)
+        for operand in self.operands.values():
+            if not operand.is_output:
+                code += operand.cpp_value(dest_acc)
 
         code += "// Outputs\n"
-        for operand in self.get_all_outputs():
-            code += operand.cpp_value(dest_acc)
+        for operand in self.operands.values():
+            if operand.is_output:
+                code += operand.cpp_value(dest_acc)
 
         return code

--- a/tt_metal/tt-llk/tests/python_tests/fuser/fused_operation.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/fused_operation.py
@@ -27,6 +27,8 @@ class FusedOperation:
     )
     stage_id: int = 0
     num_stages: int = 1
+    needs_pack_sync: bool = False
+    has_pack_consumer: bool = False
     throttle: int = 0
     stochastic_rnd: StochasticRounding = StochasticRounding.No
     tiny_tiles: bool = False

--- a/tt_metal/tt-llk/tests/python_tests/fuser/fused_operation.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/fused_operation.py
@@ -26,7 +26,6 @@ class FusedOperation:
         (DEFAULT_TILE_R_DIM, DEFAULT_TILE_C_DIM)
     )
     stage_id: int = 0
-    num_stages: int = 1
     needs_pack_sync: bool = False
     has_pack_consumer: bool = False
     throttle: int = 0

--- a/tt_metal/tt-llk/tests/python_tests/fuser/fuser_config.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/fuser_config.py
@@ -31,6 +31,7 @@ class GlobalConfig:
     profiler_enabled: bool = False
     perf_run_type: PerfRunType = None
     loop_factor: int = 16
+    quasar_use_dvalid: bool = False
     sentinel: FuserSentinel = field(default_factory=FuserSentinel)
 
     @property
@@ -77,12 +78,6 @@ class FuserConfig(TestConfig):
 
         if self.global_config.architecture is None:
             self.global_config.architecture = self.CHIP_ARCH
-
-        num_stages = len(self.pipeline)
-
-        for i, operation in enumerate(self.pipeline, start=1):
-            operation.stage_id = i
-            operation.num_stages = num_stages
 
     def generate_variant_hash(self):
         NON_COMPILATION_ARGUMENTS = [

--- a/tt_metal/tt-llk/tests/python_tests/fuser/fuser_config_parser.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/fuser_config_parser.py
@@ -122,6 +122,7 @@ class FuserConfigSchema(BaseModel):
 
     dest_acc: DestAccumulation = DestAccumulation.No
     loop_factor: Annotated[int, Field(ge=1)] = 16
+    quasar_use_dvalid: bool = False
     operands: List[OperandDefinition] = Field(..., min_length=1)
     operations: List[OperationSchema] = Field(..., min_length=1)
 
@@ -188,12 +189,29 @@ class FuserConfigSchema(BaseModel):
             for op in self.operations
         ]
 
+        num_stages = len(pipeline)
+        for i, operation in enumerate(pipeline):
+            operation.stage_id = i + 1
+            operation.num_stages = num_stages
+            operation.needs_pack_sync = any(
+                node.src_a.is_output
+                or (node.src_b is not None and node.src_b.is_output)
+                for node in operation.math.math_nodes
+                if hasattr(node, "unpacker") and node.unpacker is not None
+            )
+
+        for i, operation in enumerate(pipeline):
+            operation.has_pack_consumer = any(
+                pipeline[j].needs_pack_sync for j in range(i + 1, num_stages)
+            )
+
         return FuserConfig(
             pipeline=pipeline,
             global_config=GlobalConfig(
                 dest_acc=self.dest_acc,
                 test_name=test_name,
                 loop_factor=self.loop_factor,
+                quasar_use_dvalid=self.quasar_use_dvalid,
             ),
             operand_registry=operands,
         )
@@ -211,6 +229,8 @@ class FuserConfigSchema(BaseModel):
     @classmethod
     def load(cls, test_name: str):
         yaml_path = (FUSER_CONFIG_DIR / f"{test_name}.yaml").resolve()
+        if not yaml_path.exists():
+            yaml_path = (FUSER_CONFIG_DIR / arch.value / f"{test_name}.yaml").resolve()
         if not yaml_path.is_relative_to(FUSER_CONFIG_DIR.resolve()):
             raise ValueError(f"Invalid test name: {test_name}")
         if not yaml_path.exists():

--- a/tt_metal/tt-llk/tests/python_tests/fuser/fuser_config_parser.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/fuser_config_parser.py
@@ -201,8 +201,8 @@ class FuserConfigSchema(BaseModel):
             )
 
         for i, operation in enumerate(pipeline):
-            operation.has_pack_consumer = any(
-                pipeline[j].needs_pack_sync for j in range(i + 1, num_stages)
+            operation.has_pack_consumer = (
+                i + 1 < num_stages and pipeline[i + 1].needs_pack_sync
             )
 
         return FuserConfig(

--- a/tt_metal/tt-llk/tests/python_tests/fuser/fuser_config_parser.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/fuser_config_parser.py
@@ -192,7 +192,6 @@ class FuserConfigSchema(BaseModel):
         num_stages = len(pipeline)
         for i, operation in enumerate(pipeline):
             operation.stage_id = i + 1
-            operation.num_stages = num_stages
             operation.needs_pack_sync = any(
                 node.src_a.is_output
                 or (node.src_b is not None and node.src_b.is_output)

--- a/tt_metal/tt-llk/tests/python_tests/fuser/fuser_sentinel.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/fuser_sentinel.py
@@ -5,7 +5,6 @@
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, List, Optional, Tuple
 
-from helpers.chip_architecture import ChipArchitecture
 from helpers.data_format_inference import (
     infer_math_format,
     infer_pack_in,
@@ -46,32 +45,10 @@ class FuserSentinel:
 
     _pack_src: Optional[DataFormat] = field(default=None, repr=False)
     _pack_dst: Optional[DataFormat] = field(default=None, repr=False)
+    _pack_buf_desc_id: Optional[int] = field(default=None, repr=False)
 
     golden_math_format: Optional[DataFormat] = field(default=None, repr=False)
     golden_pack_src: Optional[DataFormat] = field(default=None, repr=False)
-
-    _next_unpack_buf_desc_id: int = field(default=0, repr=False)
-    _next_pack_buf_desc_id: int = field(default=8, repr=False)
-
-    def _alloc_unpack_buf_desc_id(self) -> int:
-        bid = self._next_unpack_buf_desc_id
-        self._next_unpack_buf_desc_id += 1
-        return bid
-
-    def _alloc_pack_buf_desc_id(self) -> int:
-        bid = self._next_pack_buf_desc_id
-        self._next_pack_buf_desc_id += 1
-        return bid
-
-    def ensure_unpack_buf_desc_ids(self, compute_node: "FpuNode") -> None:
-        if compute_node.src_a is not None and compute_node.src_a.buf_desc_id is None:
-            compute_node.src_a.buf_desc_id = self._alloc_unpack_buf_desc_id()
-        if compute_node.src_b is not None and compute_node.src_b.buf_desc_id is None:
-            compute_node.src_b.buf_desc_id = self._alloc_unpack_buf_desc_id()
-
-    def ensure_pack_buf_desc_id(self, pack_node: "PackNode") -> None:
-        if pack_node.output is not None and pack_node.output.buf_desc_id is None:
-            pack_node.output.buf_desc_id = self._alloc_pack_buf_desc_id()
 
     def reset_unpack_formats(self):
         self._unpack_A_src = None
@@ -89,6 +66,7 @@ class FuserSentinel:
     def reset_pack_formats(self):
         self._pack_src = None
         self._pack_dst = None
+        self._pack_buf_desc_id = None
 
     @staticmethod
     def _find_format_node(
@@ -292,8 +270,6 @@ class FuserSentinel:
             self._unpack_face_r_dim_b = self._unpack_face_r_dim_a
             self._unpack_num_faces_b = self._unpack_num_faces_a
 
-        self.ensure_unpack_buf_desc_ids(compute_node)
-
         return unpack_common.hw_configure_unpack(
             compute_node,
             config.dest_acc.cpp_enum_value,
@@ -349,18 +325,7 @@ class FuserSentinel:
         srca_changed = srca_fmt_changed or srca_tile_changed
         srcb_changed = srcb_fmt_changed or srcb_tile_changed
 
-        if config.architecture == ChipArchitecture.QUASAR:
-            is_unary = unpack_common.is_unary_unpacker(compute_node)
-            needs_buf_desc = compute_node.src_a.buf_desc_id is None
-            if not is_unary:
-                needs_buf_desc = needs_buf_desc or (
-                    compute_node.src_b is not None
-                    and compute_node.src_b.buf_desc_id is None
-                )
-            if not (srca_changed or srcb_changed or needs_buf_desc):
-                return ""
-            self.ensure_unpack_buf_desc_ids(compute_node)
-        elif not (srca_changed or srcb_changed):
+        if not (srca_changed or srcb_changed):
             return ""
 
         code = unpack_common.configure_unpack(
@@ -461,8 +426,6 @@ class FuserSentinel:
         first = pack_nodes[0]
         pack_src, pack_dst = self._resolve_pack_formats(config, operation, first)
 
-        self.ensure_pack_buf_desc_id(first)
-
         code = pack_common.hw_configure_pack(
             first.output,
             config.dest_acc.cpp_enum_value,
@@ -473,6 +436,7 @@ class FuserSentinel:
 
         self._pack_src = pack_src
         self._pack_dst = pack_dst
+        self._pack_buf_desc_id = first.output.buf_desc_id
 
         return code
 
@@ -489,10 +453,11 @@ class FuserSentinel:
         """
         pack_src, pack_dst = self._resolve_pack_formats(config, operation, pack_node)
 
-        if self._pack_src == pack_src and self._pack_dst == pack_dst:
-            return ""
+        buf_desc_changed = self._pack_buf_desc_id != pack_node.output.buf_desc_id
+        format_changed = self._pack_src != pack_src or self._pack_dst != pack_dst
 
-        self.ensure_pack_buf_desc_id(pack_node)
+        if not format_changed and not buf_desc_changed:
+            return ""
 
         code = pack_common.configure_pack(
             pack_node.output,
@@ -503,6 +468,7 @@ class FuserSentinel:
 
         self._pack_src = pack_src
         self._pack_dst = pack_dst
+        self._pack_buf_desc_id = pack_node.output.buf_desc_id
         return code
 
     def configure_golden(

--- a/tt_metal/tt-llk/tests/python_tests/fuser/fuser_sentinel.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/fuser_sentinel.py
@@ -45,7 +45,6 @@ class FuserSentinel:
 
     _pack_src: Optional[DataFormat] = field(default=None, repr=False)
     _pack_dst: Optional[DataFormat] = field(default=None, repr=False)
-    _pack_buf_desc_id: Optional[int] = field(default=None, repr=False)
 
     golden_math_format: Optional[DataFormat] = field(default=None, repr=False)
     golden_pack_src: Optional[DataFormat] = field(default=None, repr=False)
@@ -66,7 +65,6 @@ class FuserSentinel:
     def reset_pack_formats(self):
         self._pack_src = None
         self._pack_dst = None
-        self._pack_buf_desc_id = None
 
     @staticmethod
     def _find_format_node(
@@ -436,7 +434,6 @@ class FuserSentinel:
 
         self._pack_src = pack_src
         self._pack_dst = pack_dst
-        self._pack_buf_desc_id = first.output.buf_desc_id
 
         return code
 
@@ -453,10 +450,7 @@ class FuserSentinel:
         """
         pack_src, pack_dst = self._resolve_pack_formats(config, operation, pack_node)
 
-        buf_desc_changed = self._pack_buf_desc_id != pack_node.output.buf_desc_id
-        format_changed = self._pack_src != pack_src or self._pack_dst != pack_dst
-
-        if not format_changed and not buf_desc_changed:
+        if self._pack_src == pack_src and self._pack_dst == pack_dst:
             return ""
 
         code = pack_common.configure_pack(
@@ -468,7 +462,6 @@ class FuserSentinel:
 
         self._pack_src = pack_src
         self._pack_dst = pack_dst
-        self._pack_buf_desc_id = pack_node.output.buf_desc_id
         return code
 
     def configure_golden(

--- a/tt_metal/tt-llk/tests/python_tests/fuser/pack_node.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/pack_node.py
@@ -66,7 +66,6 @@ class PackNode:
         config: "GlobalConfig",
         block: BlockData,
     ) -> str:
-        config.sentinel.ensure_pack_buf_desc_id(self)
         code = self.packer.init(self, operation, config, block)
         code += self._relu_config(config)
         code += self._l1_accumulation_config(config)

--- a/tt_metal/tt-llk/tests/python_tests/fuser/quasar/fpu/common.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/quasar/fpu/common.py
@@ -25,13 +25,23 @@ def configure_math(
     )
 
 
-def math_pack_sync_init(dest_sync: str, dest_acc: str) -> str:
-    return "set_up_dest_dvalid_per_thread<dest_dvalid_client::FPU>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});\n"
+def math_pack_sync_init(
+    dest_sync: str, dest_acc: str, quasar_use_dvalid: bool = False
+) -> str:
+    if quasar_use_dvalid:
+        return "set_up_dest_dvalid_per_thread<dest_dvalid_client::FPU>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});\n"
+    return f"_llk_math_pack_sync_init_<{dest_sync}>();\n"
 
 
-def math_wait_for_dest(dest_sync: str) -> str:
-    return ""
+def math_wait_for_dest(dest_sync: str, quasar_use_dvalid: bool = False) -> str:
+    if quasar_use_dvalid:
+        return ""
+    return "_llk_math_wait_for_dest_available_();\n"
 
 
-def math_dest_section_done(dest_sync: str, dest_acc: str) -> str:
-    return f"_llk_math_set_dvalid_<p_cleardvalid::FPU, {dest_sync}>();\n"
+def math_dest_section_done(
+    dest_sync: str, dest_acc: str, quasar_use_dvalid: bool = False
+) -> str:
+    if quasar_use_dvalid:
+        return f"_llk_math_set_dvalid_<p_cleardvalid::FPU, {dest_sync}>();\n"
+    return f"_llk_math_dest_section_done_<{dest_sync}, {dest_acc}>();\n"

--- a/tt_metal/tt-llk/tests/python_tests/fuser/quasar/fpu/datacopy.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/quasar/fpu/datacopy.py
@@ -73,11 +73,7 @@ class DatacopyFpu(Fpu):
         compute_unit: FpuNode,
         block: BlockData,
     ) -> str:
-        num_faces = operation.tile_shape.total_num_faces()
-        face_r_dim = operation.tile_shape.face_r_dim
-        num_rows_per_tile = face_r_dim * num_faces
-
-        return f"_llk_math_eltwise_unary_datacopy_({num_rows_per_tile}, {block.tile_id_block});\n"
+        return f"_llk_math_eltwise_unary_datacopy_({block.tile_id_block});\n"
 
     def uninit(
         self,

--- a/tt_metal/tt-llk/tests/python_tests/fuser/quasar/fpu/datacopy.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/quasar/fpu/datacopy.py
@@ -22,7 +22,6 @@ class DatacopyFpu(Fpu):
         return [
             "llk_math_common.h",
             "llk_math_eltwise_unary_datacopy.h",
-            "llk_sync.h",
         ]
 
     def golden(

--- a/tt_metal/tt-llk/tests/python_tests/fuser/quasar/fpu/datacopy.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/quasar/fpu/datacopy.py
@@ -21,6 +21,7 @@ class DatacopyFpu(Fpu):
         return [
             "llk_math_common.h",
             "llk_math_eltwise_unary_datacopy.h",
+            "llk_sync.h",
         ]
 
     def golden(
@@ -53,6 +54,9 @@ class DatacopyFpu(Fpu):
         compute_unit: FpuNode,
         block: BlockData,
     ) -> str:
+        if compute_unit.unpack_to_dest.value:
+            return ""
+
         stage = operation.stage_id
         data_copy_type = compute_unit.data_copy_type.cpp_enum_value
         num_faces = operation.tile_shape.total_num_faces()
@@ -73,6 +77,12 @@ class DatacopyFpu(Fpu):
         compute_unit: FpuNode,
         block: BlockData,
     ) -> str:
+        if compute_unit.unpack_to_dest.value:
+            return (
+                "_llk_sync_wait_<p_stall::STALL_SYNC, p_stall::STALL_ON_ZERO>(semaphore::UNPACK_MATH);\n"
+                "_llk_sync_get_<p_stall::MATH, p_stall::WAIT_SFPU>(semaphore::UNPACK_MATH);\n"
+            )
+
         return f"_llk_math_eltwise_unary_datacopy_({block.tile_id_block});\n"
 
     def uninit(

--- a/tt_metal/tt-llk/tests/python_tests/fuser/quasar/fpu/datacopy.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/quasar/fpu/datacopy.py
@@ -8,14 +8,15 @@ import torch
 from fuser.block_data import BlockData
 from fuser.fpu_node import FpuNode
 from fuser.fused_fpu import Fpu
-from fuser.fused_loop import FusedLoop, LoopTileByTile
+from fuser.fused_loop import FusedLoop, LoopBlockRow
 from fuser.fused_operation import FusedOperation
 from fuser.fuser_config import GlobalConfig
 from helpers.golden_generators import DataCopyGolden, get_golden_generator
 
 
 class DatacopyFpu(Fpu):
-    loop: FusedLoop = LoopTileByTile()
+    loop: FusedLoop = LoopBlockRow()
+    per_block_init = True
 
     def get_headers(self) -> List[str]:
         return [
@@ -67,7 +68,7 @@ class DatacopyFpu(Fpu):
         return (
             f"// Operation {stage}: Datacopy FPU\n"
             f"_llk_math_eltwise_unary_datacopy_init_<{data_copy_type}, {en_32bit_dest}>"
-            f"({num_rows_per_matrix}, 1);\n"
+            f"({num_rows_per_matrix}, {block.block_tiles_x});\n"
         )
 
     def calculate(

--- a/tt_metal/tt-llk/tests/python_tests/fuser/quasar/fpu/eltwise.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/quasar/fpu/eltwise.py
@@ -12,7 +12,12 @@ from fuser.fused_loop import FusedLoop, LoopTileByTile
 from fuser.fused_operation import FusedOperation
 from fuser.fuser_config import GlobalConfig
 from helpers.golden_generators import EltwiseBinaryGolden, get_golden_generator
-from helpers.llk_params import AccToDest, EltwiseBinaryReuseDestType, MathOperation
+from helpers.llk_params import (
+    AccToDest,
+    BroadcastType,
+    EltwiseBinaryReuseDestType,
+    MathOperation,
+)
 
 
 class EltwiseFpu(Fpu):
@@ -29,6 +34,7 @@ class EltwiseFpu(Fpu):
         return [
             "llk_math_common.h",
             "llk_math_eltwise_binary.h",
+            "llk_math_eltwise_binary_broadcast.h",
         ]
 
     def golden(
@@ -80,6 +86,15 @@ class EltwiseFpu(Fpu):
         face_c_dim = operation.tile_shape.face_c_dim
         num_faces_r_dim = compute_unit.src_a.tile_shape.total_row_dim() // face_r_dim
         num_faces_c_dim = compute_unit.src_a.tile_shape.total_col_dim() // face_c_dim
+
+        if compute_unit.broadcast_type != BroadcastType.None_:
+            broadcast_type = compute_unit.broadcast_type.cpp_enum_value
+            return (
+                f"// Operation {stage}: Eltwise {op} broadcast FPU\n"
+                f"_llk_math_eltwise_binary_broadcast_init_<ckernel::EltwiseBinaryType::{op}, {broadcast_type}, {math_fidelity}>"
+                f"(ckernel::TensorShape{{{face_r_dim}, {face_c_dim}, {num_faces_r_dim}, {num_faces_c_dim}}});\n"
+            )
+
         reuse_dest = compute_unit.reuse_dest.cpp_enum_value
         acc_to_dest = compute_unit.acc_to_dest.cpp_enum_value
 
@@ -97,6 +112,10 @@ class EltwiseFpu(Fpu):
         block: BlockData,
     ) -> str:
         op = self.operation.cpp_enum_value
+
+        if compute_unit.broadcast_type != BroadcastType.None_:
+            return f"_llk_math_eltwise_binary_broadcast_({block.tile_id_block});\n"
+
         face_r_dim = operation.tile_shape.face_r_dim
         face_c_dim = operation.tile_shape.face_c_dim
         num_faces_r_dim = compute_unit.src_a.tile_shape.total_row_dim() // face_r_dim

--- a/tt_metal/tt-llk/tests/python_tests/fuser/quasar/fpu/reduce.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/quasar/fpu/reduce.py
@@ -151,7 +151,12 @@ class ReduceFpu(Fpu):
         compute_unit: FpuNode,
         block: BlockData,
     ) -> str:
-        return f"_llk_math_reduce_({block.tile_id_block});\n"
+        pool_type_cpp = self.reduce_pool.cpp_enum_value
+        reduce_dim_cpp = self.reduce_dim.cpp_enum_value
+        return (
+            f"_llk_math_reduce_<{pool_type_cpp}, {reduce_dim_cpp}>"
+            f"({block.tile_id_block}, {compute_unit.src_a.tile_shape.cpp_value});\n"
+        )
 
     def uninit(
         self,

--- a/tt_metal/tt-llk/tests/python_tests/fuser/quasar/packer/common.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/quasar/packer/common.py
@@ -67,7 +67,7 @@ def packer_dest_section_done(
 
 def packer_sync_with_unpacker(has_pack_consumer: bool) -> str:
     if has_pack_consumer:
-        return "t6_semaphore_post<p_stall::PACK>(semaphore::PACK_UNPACK);\n"
+        return "_llk_sync_post_<p_stall::PACK>(semaphore::PACK_UNPACK);\n"
     return ""
 
 

--- a/tt_metal/tt-llk/tests/python_tests/fuser/quasar/packer/common.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/quasar/packer/common.py
@@ -7,22 +7,6 @@ from helpers.format_config import DataFormat
 from helpers.llk_params import L1Accumulation
 
 
-def _emit_pack_buf_desc(
-    output: Operand,
-    pack_src: DataFormat,
-    pack_dst: DataFormat,
-) -> str:
-    return (
-        f"tdma_descriptor_t td_pack = ckernel::trisc::construct_tdma_desc("
-        f"{output.tile_shape.cpp_value}, "
-        f"{output.cpp_name}[0] / 16, "
-        f"{pack_dst.cpp_underlying_value}, "
-        f"{output.buf_desc_id}, "
-        f"{pack_src.cpp_underlying_value});\n"
-        f"_configure_buf_desc_table_(td_pack.buf_desc_id, td_pack.buf_desc);\n"
-    )
-
-
 def hw_configure_pack(
     output: Operand,
     dest_acc: str,
@@ -30,9 +14,11 @@ def hw_configure_pack(
     pack_dst: DataFormat,
     pack_mode: str = "PackMode::Default",
 ) -> str:
-    code = _emit_pack_buf_desc(output, pack_src, pack_dst)
-    code += f"_llk_pack_hw_configure_<p_pacr::PACK0>(td_pack);\n"
-    return code
+    desc = output.cpp_desc_name
+    return (
+        f"{desc}.reg_data_format = static_cast<std::uint8_t>({pack_src.cpp_underlying_value});\n"
+        f"_llk_pack_hw_configure_<p_pacr::PACK0, {dest_acc}>({desc}, ReluConfig::from_packed(0));\n"
+    )
 
 
 def configure_pack(
@@ -41,11 +27,11 @@ def configure_pack(
     pack_src: DataFormat,
     pack_dst: DataFormat,
 ) -> str:
-    code = "{\n"
-    code += _emit_pack_buf_desc(output, pack_src, pack_dst)
-    code += f"_llk_pack_hw_configure_<p_pacr::PACK0>(td_pack);\n"
-    code += "}\n"
-    return code
+    desc = output.cpp_desc_name
+    return (
+        f"{desc}.reg_data_format = static_cast<std::uint8_t>({pack_src.cpp_underlying_value});\n"
+        f"_llk_pack_hw_configure_<p_pacr::PACK0, {dest_acc}>({desc}, ReluConfig::from_packed(0));\n"
+    )
 
 
 def relu_config(relu_config_val: int, dest_acc: str) -> str:
@@ -57,17 +43,39 @@ def l1_accumulation_config(pack_l1_accumulation: L1Accumulation) -> str:
     return f"_llk_pack_set_l1_acc_<p_pacr::PACK0>({l1_acc});\n"
 
 
-def pack_dest_init(dest_sync: str, dest_acc: str) -> str:
-    return "set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});\n"
+def pack_dest_init(
+    dest_sync: str, dest_acc: str, quasar_use_dvalid: bool = False
+) -> str:
+    if quasar_use_dvalid:
+        return "set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});\n"
+    return f"_llk_pack_dest_init_<p_pacr::PACK0, {dest_sync}>();\n"
 
 
-def packer_wait_for_math() -> str:
+def packer_wait_for_math(quasar_use_dvalid: bool = False) -> str:
+    if quasar_use_dvalid:
+        return ""
+    return "_llk_packer_wait_for_math_done_();\n"
+
+
+def packer_dest_section_done(
+    dest_sync: str, dest_acc: str, quasar_use_dvalid: bool = False
+) -> str:
+    if quasar_use_dvalid:
+        return f"_llk_pack_dest_dvalid_section_done_<{dest_sync}, {dest_acc}>();\n"
+    return f"_llk_pack_dest_semaphore_section_done_<p_pacr::PACK0, {dest_sync}, {dest_acc}>();\n"
+
+
+def packer_sync_with_unpacker(has_pack_consumer: bool) -> str:
+    if has_pack_consumer:
+        return "t6_semaphore_post<>(semaphore::PACK_DONE);\n"
     return ""
 
 
-def packer_dest_section_done(dest_sync: str, dest_acc: str) -> str:
-    return f"_llk_pack_dest_dvalid_section_done_<{dest_sync}, {dest_acc}>();\n"
+def pack_reduce_mask_config(operation) -> str:
+    reduce_dim = operation.reduce_dim.cpp_enum_value
+    tensor_shape = operation.tile_shape.cpp_value
+    return f"_llk_pack_reduce_mask_config_<{reduce_dim}>({tensor_shape});\n"
 
 
-def packer_sync_with_unpacker(stage_id: int, num_stages: int) -> str:
-    return ""
+def pack_reduce_mask_clear() -> str:
+    return "_llk_pack_reduce_mask_clear_();\n"

--- a/tt_metal/tt-llk/tests/python_tests/fuser/quasar/packer/common.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/quasar/packer/common.py
@@ -67,15 +67,19 @@ def packer_dest_section_done(
 
 def packer_sync_with_unpacker(has_pack_consumer: bool) -> str:
     if has_pack_consumer:
-        return "t6_semaphore_post<>(semaphore::PACK_DONE);\n"
+        return "t6_semaphore_post<p_stall::PACK>(semaphore::PACK_UNPACK);\n"
     return ""
 
 
 def pack_reduce_mask_config(operation) -> str:
+    if operation.reduce_dim is None:
+        return ""
     reduce_dim = operation.reduce_dim.cpp_enum_value
     tensor_shape = operation.tile_shape.cpp_value
     return f"_llk_pack_reduce_mask_config_<{reduce_dim}>({tensor_shape});\n"
 
 
-def pack_reduce_mask_clear() -> str:
+def pack_reduce_mask_clear(operation) -> str:
+    if operation.reduce_dim is None:
+        return ""
     return "_llk_pack_reduce_mask_clear_();\n"

--- a/tt_metal/tt-llk/tests/python_tests/fuser/quasar/packer/packer.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/quasar/packer/packer.py
@@ -47,10 +47,7 @@ class Packer(BasePacker):
     ) -> str:
         buf_desc_id = pack_node.output.buf_desc_id
         tensor_shape = pack_node.output.tile_shape.cpp_value
-        en_32bit_dest = config.dest_acc.cpp_enum_value
-        return (
-            f"_llk_pack_init_<{en_32bit_dest}>({buf_desc_id}, " f"{tensor_shape}, 1);\n"
-        )
+        return f"_llk_pack_init_({buf_desc_id}, {tensor_shape}, 1);\n"
 
     def pack(
         self,

--- a/tt_metal/tt-llk/tests/python_tests/fuser/quasar/parser.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/quasar/parser.py
@@ -5,10 +5,9 @@
 """Quasar fuser config parser.
 
 Supports: eltwise binary (Elwadd/Elwmul/Elwsub), datacopy, matmul, reduce,
-unary SFPU, binary SFPU.
+unary SFPU, binary SFPU, eltwise broadcast (COL/ROW/SCALAR).
 Unsupported on Quasar: MatmulNoMop, ReduceBlockMax, ReduceBlockMaxRuntime,
 SubBcastColCustom.
-No broadcast, no transpose.
 """
 
 from typing import Annotated, ClassVar, List, Union
@@ -74,12 +73,25 @@ _eltwise_unpacker_default = (
     "Eltwise: unpacker must be UnpackerAB",
 )
 
+_no_broadcast_reuse_dest = (
+    lambda s, a, b: s.broadcast_type != BroadcastType.None_
+    and s.reuse_dest != EltwiseBinaryReuseDestType.NONE,
+    "Quasar broadcast does not support reuse_dest",
+)
+
+_no_broadcast_acc_to_dest = (
+    lambda s, a, b: s.broadcast_type != BroadcastType.None_
+    and s.acc_to_dest == AccToDest.Yes,
+    "Quasar broadcast does not support acc_to_dest",
+)
+
 _eltwise_checks = [
-    _no_broadcast,
     _no_transpose,
     _dest_to_srca_needs_acc,
     _eltwise_unpacker_reuse,
     _eltwise_unpacker_default,
+    _no_broadcast_reuse_dest,
+    _no_broadcast_acc_to_dest,
 ]
 
 _lofi_only = (
@@ -123,11 +135,11 @@ _reduce_params = (
 UNPACKER_MAP = {
     "UnpackerA": (
         lambda s: UnpackerA(),
-        [_no_broadcast, _no_transpose],
+        [_no_transpose],
     ),
     "UnpackerAB": (
         lambda s: UnpackerAB(),
-        [_no_broadcast, _no_transpose],
+        [_no_transpose],
     ),
     "MatmulUnpacker": (
         lambda s: MatmulUnpacker(),
@@ -268,8 +280,6 @@ class OperationSchema(OperationSchemaBase):
     def _arch_validate(self):
         for m in self.math:
             if isinstance(m, FpuMathSchema):
-                if m.broadcast_type != BroadcastType.None_:
-                    raise ValueError("Quasar does not support broadcast in fuser")
                 if (
                     m.unpack_transpose_faces == Transpose.Yes
                     or m.unpack_transpose_within_face == Transpose.Yes

--- a/tt_metal/tt-llk/tests/python_tests/fuser/quasar/parser.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/quasar/parser.py
@@ -57,15 +57,15 @@ _no_transpose_unpack_to_dest = (
     "Quasar does not support transpose with unpack_to_dest",
 )
 
+_no_transpose = (
+    lambda s, a, b: s.unpack_transpose_faces == Transpose.Yes
+    or s.unpack_transpose_within_face == Transpose.Yes,
+    "Quasar does not support transpose for this unpacker",
+)
+
 _no_transpose_mismatch = (
     lambda s, a, b: s.unpack_transpose_faces != s.unpack_transpose_within_face,
     "Quasar requires both transpose_faces and transpose_within_face to have the same value",
-)
-
-_dest_to_srca_needs_acc = (
-    lambda s, a, b: s.reuse_dest == EltwiseBinaryReuseDestType.DEST_TO_SRCA
-    and s.acc_to_dest != AccToDest.Yes,
-    "reuse_dest DEST_TO_SRCA requires acc_to_dest: true",
 )
 
 _eltwise_unpacker_reuse = (
@@ -97,7 +97,6 @@ _no_broadcast_acc_to_dest = (
 _eltwise_checks = [
     _no_transpose_unpack_to_dest,
     _no_transpose_mismatch,
-    _dest_to_srca_needs_acc,
     _eltwise_unpacker_reuse,
     _eltwise_unpacker_default,
     _no_broadcast_reuse_dest,
@@ -144,20 +143,20 @@ _reduce_params = (
 
 UNPACKER_MAP = {
     "UnpackerA": (
-        lambda s: UnpackerA(),
+        lambda s: UnpackerA(reuse_dest=s.reuse_dest),
         [_no_transpose_unpack_to_dest, _no_transpose_mismatch],
     ),
     "UnpackerAB": (
         lambda s: UnpackerAB(),
-        [_no_transpose_unpack_to_dest, _no_transpose_mismatch],
+        [_no_transpose],
     ),
     "MatmulUnpacker": (
         lambda s: MatmulUnpacker(),
-        [_no_transpose_unpack_to_dest, _no_transpose_mismatch],
+        [_no_transpose],
     ),
     "ReduceUnpacker": (
         lambda s: ReduceUnpacker(s.reduce_dim, s.reduce_pool),
-        None,
+        [_no_transpose],
     ),
 }
 
@@ -188,6 +187,7 @@ FPU_MAP = {
         lambda s: MatmulFpu(),
         [
             _no_reuse_dest,
+            _no_broadcast,
             _matmul_dim_check,
             _forced_unpacker("MatmulUnpacker"),
             _matmul_inner_dims,
@@ -197,6 +197,7 @@ FPU_MAP = {
         lambda s: ReduceFpu(s.reduce_dim, s.reduce_pool),
         [
             _no_reuse_dest,
+            _no_broadcast,
             _reduce_params,
             _forced_unpacker("ReduceUnpacker"),
         ],

--- a/tt_metal/tt-llk/tests/python_tests/fuser/quasar/parser.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/quasar/parser.py
@@ -27,6 +27,7 @@ from helpers.llk_params import (
     MathFidelity,
     MathOperation,
     Transpose,
+    UnpackToDest,
 )
 from pydantic import Field
 
@@ -47,10 +48,18 @@ _no_broadcast = (
     "Quasar does not support broadcast in fuser",
 )
 
-_no_transpose = (
-    lambda s, a, b: s.unpack_transpose_faces == Transpose.Yes
-    or s.unpack_transpose_within_face == Transpose.Yes,
-    "Quasar does not support transpose in unpack",
+_no_transpose_unpack_to_dest = (
+    lambda s, a, b: s.unpack_to_dest == UnpackToDest.Yes
+    and (
+        s.unpack_transpose_faces == Transpose.Yes
+        or s.unpack_transpose_within_face == Transpose.Yes
+    ),
+    "Quasar does not support transpose with unpack_to_dest",
+)
+
+_no_transpose_mismatch = (
+    lambda s, a, b: s.unpack_transpose_faces != s.unpack_transpose_within_face,
+    "Quasar requires both transpose_faces and transpose_within_face to have the same value",
 )
 
 _dest_to_srca_needs_acc = (
@@ -86,7 +95,8 @@ _no_broadcast_acc_to_dest = (
 )
 
 _eltwise_checks = [
-    _no_transpose,
+    _no_transpose_unpack_to_dest,
+    _no_transpose_mismatch,
     _dest_to_srca_needs_acc,
     _eltwise_unpacker_reuse,
     _eltwise_unpacker_default,
@@ -135,15 +145,15 @@ _reduce_params = (
 UNPACKER_MAP = {
     "UnpackerA": (
         lambda s: UnpackerA(),
-        [_no_transpose],
+        [_no_transpose_unpack_to_dest, _no_transpose_mismatch],
     ),
     "UnpackerAB": (
         lambda s: UnpackerAB(),
-        [_no_transpose],
+        [_no_transpose_unpack_to_dest, _no_transpose_mismatch],
     ),
     "MatmulUnpacker": (
         lambda s: MatmulUnpacker(),
-        [_no_transpose],
+        [_no_transpose_unpack_to_dest, _no_transpose_mismatch],
     ),
     "ReduceUnpacker": (
         lambda s: ReduceUnpacker(s.reduce_dim, s.reduce_pool),
@@ -166,7 +176,13 @@ FPU_MAP = {
     ),
     "Datacopy": (
         lambda s: DatacopyFpu(),
-        [_no_reuse_dest, _datacopy_unpacker, _no_broadcast, _no_transpose],
+        [
+            _no_reuse_dest,
+            _datacopy_unpacker,
+            _no_broadcast,
+            _no_transpose_unpack_to_dest,
+            _no_transpose_mismatch,
+        ],
     ),
     "Matmul": (
         lambda s: MatmulFpu(),
@@ -278,10 +294,4 @@ class OperationSchema(OperationSchemaBase):
     pack: List[PackEntrySchema] = Field(..., min_length=1)
 
     def _arch_validate(self):
-        for m in self.math:
-            if isinstance(m, FpuMathSchema):
-                if (
-                    m.unpack_transpose_faces == Transpose.Yes
-                    or m.unpack_transpose_within_face == Transpose.Yes
-                ):
-                    raise ValueError("Quasar does not support transpose in unpack")
+        pass

--- a/tt_metal/tt-llk/tests/python_tests/fuser/quasar/sfpu/binary.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/quasar/sfpu/binary.py
@@ -100,15 +100,16 @@ class BinarySfpu(Sfpu):
         op = f"ckernel::BinaryOp::{self.operation.cpp_enum_value}"
         dest_sync = operation.dest_sync.cpp_enum_value
         en_32bit_dest = config.dest_acc.cpp_enum_value
+        quasar_iterations = self.iterations // 4
         src1 = self.dst_index_in0
         src2 = self.dst_index_in1
         dst = self.dst_index_out
+        data_format = config.sentinel._math_format.cpp_enum_value
 
         return (
-            f"    test_utils::call_binary_sfpu_operation_quasar<"
-            f"{op}, {dest_sync}, {en_32bit_dest}, {self.iterations}"
-            f">({src1} /* src0_tile */, {src2} /* src1_tile */, {dst} /* dst_tile */, "
-            f"{config.sentinel.math_format});\n"
+            f"test_utils::call_binary_sfpu_operation_quasar<"
+            f"{op}, {dest_sync}, {en_32bit_dest}, {quasar_iterations}"
+            f">({src1} /* src0_tile */, {src2} /* src1_tile */, {dst} /* dst_tile */, {data_format});\n"
         )
 
     def __str__(self) -> str:

--- a/tt_metal/tt-llk/tests/python_tests/fuser/quasar/sfpu/unary.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/quasar/sfpu/unary.py
@@ -86,9 +86,9 @@ class UnarySfpu(Sfpu):
         en_32bit_dest = config.dest_acc.cpp_enum_value
         approx_mode = self.approx_mode.cpp_enum_value
         return (
-            f"    // Operation {stage}: Unary {self.operation.cpp_enum_value} SFPU\n"
-            f"    _llk_math_eltwise_sfpu_init_();\n"
-            f"    test_utils::init_unary_sfpu_operation_quasar<{op}, {en_32bit_dest}, {approx_mode}>();\n"
+            f"// Operation {stage}: Unary {self.operation.cpp_enum_value} SFPU\n"
+            f"_llk_math_eltwise_sfpu_init_();\n"
+            f"test_utils::init_unary_sfpu_operation_quasar<{op}, {en_32bit_dest}, {approx_mode}>();\n"
         )
 
     def calculate(
@@ -103,9 +103,10 @@ class UnarySfpu(Sfpu):
         en_32bit_dest = config.dest_acc.cpp_enum_value
         sfpu_format = config.sentinel._math_format.cpp_enum_value
         approx_mode = self.approx_mode.cpp_enum_value
+        quasar_iterations = self.iterations // 4
         return (
-            f"    test_utils::call_unary_sfpu_operation_quasar<"
-            f"{op}, {dest_sync}, {en_32bit_dest}, {approx_mode}, {self.iterations}"
+            f"test_utils::call_unary_sfpu_operation_quasar<"
+            f"{op}, {dest_sync}, {en_32bit_dest}, {approx_mode}, {quasar_iterations}"
             f">({self.dest_idx}, {sfpu_format});\n"
         )
 

--- a/tt_metal/tt-llk/tests/python_tests/fuser/quasar/sfpu/unary.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/quasar/sfpu/unary.py
@@ -101,7 +101,6 @@ class UnarySfpu(Sfpu):
         op = f"SfpuType::{self.operation.cpp_enum_value}"
         dest_sync = operation.dest_sync.cpp_enum_value
         en_32bit_dest = config.dest_acc.cpp_enum_value
-        approx_mode = self.approx_mode.cpp_enum_value
         sfpu_format = config.sentinel._math_format.cpp_enum_value
         approx_mode = self.approx_mode.cpp_enum_value
         quasar_iterations = self.iterations // 4

--- a/tt_metal/tt-llk/tests/python_tests/fuser/quasar/sfpu/unary.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/quasar/sfpu/unary.py
@@ -101,6 +101,7 @@ class UnarySfpu(Sfpu):
         op = f"SfpuType::{self.operation.cpp_enum_value}"
         dest_sync = operation.dest_sync.cpp_enum_value
         en_32bit_dest = config.dest_acc.cpp_enum_value
+        approx_mode = self.approx_mode.cpp_enum_value
         sfpu_format = config.sentinel._math_format.cpp_enum_value
         approx_mode = self.approx_mode.cpp_enum_value
         quasar_iterations = self.iterations // 4

--- a/tt_metal/tt-llk/tests/python_tests/fuser/quasar/unpacker/common.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/quasar/unpacker/common.py
@@ -7,12 +7,6 @@ from helpers.format_config import DataFormat
 from helpers.llk_params import EltwiseBinaryReuseDestType
 
 
-def is_datacopy_node(compute_node: FpuNode) -> bool:
-    from fuser.quasar.fpu.datacopy import DatacopyFpu
-
-    return isinstance(compute_node.fpu, DatacopyFpu)
-
-
 def is_unary_unpacker(compute_node: FpuNode) -> bool:
     from fuser.quasar.unpacker.unpack_a import UnpackerA
 
@@ -26,13 +20,15 @@ def _emit_configure(
     unpack_B_dst: DataFormat,
 ) -> str:
     is_unary = is_unary_unpacker(compute_node)
-    is_datacopy_dest_acc = is_datacopy_node(compute_node) and dest_acc == "true"
     has_reuse_dest = compute_node.reuse_dest != EltwiseBinaryReuseDestType.NONE
+    unpack_to_dest = compute_node.unpack_to_dest.value
 
     desc_a = compute_node.src_a.cpp_desc_name
     code = f"{desc_a}.reg_data_format = static_cast<std::uint8_t>({unpack_A_dst.cpp_underlying_value});\n"
+    if unpack_to_dest:
+        code += f"_llk_math_upk_to_dest_hw_configure_<false, {dest_acc}, false>();\n"
 
-    if is_unary and (is_datacopy_dest_acc or has_reuse_dest):
+    if is_unary and ((dest_acc == "true" and not unpack_to_dest) or has_reuse_dest):
         code += f"_llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>({desc_a}, {desc_a});\n"
     elif is_unary:
         code += f"_llk_unpack_configure_unary_<p_unpacr::UNP_A>({desc_a});\n"

--- a/tt_metal/tt-llk/tests/python_tests/fuser/quasar/unpacker/common.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/quasar/unpacker/common.py
@@ -77,7 +77,7 @@ def dvalid_init(quasar_use_dvalid: bool = False) -> str:
 def sync_with_packer(needs_pack_sync: bool) -> str:
     if needs_pack_sync:
         return (
-            "TT_SEMWAIT(p_stall::STALL_SYNC, p_stall::STALL_ON_ZERO, 0, semaphore::t6_sem(semaphore::PACK_DONE));\n"
-            "t6_semaphore_get<>(semaphore::PACK_DONE);\n"
+            "TT_SEMWAIT(p_stall::STALL_SYNC, p_stall::STALL_ON_ZERO, 0, semaphore::t6_sem(semaphore::PACK_UNPACK));\n"
+            "t6_semaphore_get<>(semaphore::PACK_UNPACK);\n"
         )
     return ""

--- a/tt_metal/tt-llk/tests/python_tests/fuser/quasar/unpacker/common.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/quasar/unpacker/common.py
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from fuser.fpu_node import FpuNode
-from fuser.fused_operand import Operand
 from helpers.format_config import DataFormat
+from helpers.llk_params import EltwiseBinaryReuseDestType
 
 
 def is_datacopy_node(compute_node: FpuNode) -> bool:
@@ -19,44 +19,27 @@ def is_unary_unpacker(compute_node: FpuNode) -> bool:
     return isinstance(compute_node.unpacker, UnpackerA)
 
 
-def _emit_buf_desc(
-    var_prefix: str,
-    operand: Operand,
-    src_fmt: DataFormat,
-    dst_fmt: DataFormat,
-) -> str:
-    code = (
-        f"tdma_descriptor_t td_{var_prefix} = ckernel::trisc::construct_tdma_desc("
-        f"{operand.tile_shape.cpp_value}, "
-        f"{operand.cpp_name}[0] / 16, "
-        f"{src_fmt.cpp_underlying_value}, "
-        f"{operand.buf_desc_id}, "
-        f"{dst_fmt.cpp_underlying_value});\n"
-        f"_configure_buf_desc_table_(td_{var_prefix}.buf_desc_id, td_{var_prefix}.buf_desc);\n"
-    )
-    return code
-
-
 def _emit_configure(
     compute_node: FpuNode,
     dest_acc: str,
-    unpack_A_src: DataFormat,
     unpack_A_dst: DataFormat,
-    unpack_B_src: DataFormat,
     unpack_B_dst: DataFormat,
 ) -> str:
     is_unary = is_unary_unpacker(compute_node)
     is_datacopy_dest_acc = is_datacopy_node(compute_node) and dest_acc == "true"
+    has_reuse_dest = compute_node.reuse_dest != EltwiseBinaryReuseDestType.NONE
 
-    code = _emit_buf_desc("val_A", compute_node.src_a, unpack_A_src, unpack_A_dst)
+    desc_a = compute_node.src_a.cpp_desc_name
+    code = f"{desc_a}.reg_data_format = static_cast<std::uint8_t>({unpack_A_dst.cpp_underlying_value});\n"
 
-    if is_unary and is_datacopy_dest_acc:
-        code += "_llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(td_val_A, td_val_A);\n"
+    if is_unary and (is_datacopy_dest_acc or has_reuse_dest):
+        code += f"_llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>({desc_a}, {desc_a});\n"
     elif is_unary:
-        code += "_llk_unpack_configure_unary_<p_unpacr::UNP_A>(td_val_A);\n"
+        code += f"_llk_unpack_configure_unary_<p_unpacr::UNP_A>({desc_a});\n"
     else:
-        code += _emit_buf_desc("val_B", compute_node.src_b, unpack_B_src, unpack_B_dst)
-        code += "_llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(td_val_A, td_val_B);\n"
+        desc_b = compute_node.src_b.cpp_desc_name
+        code += f"{desc_b}.reg_data_format = static_cast<std::uint8_t>({unpack_B_dst.cpp_underlying_value});\n"
+        code += f"_llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>({desc_a}, {desc_b});\n"
 
     return code
 
@@ -69,9 +52,7 @@ def hw_configure_unpack(
     unpack_B_src: DataFormat,
     unpack_B_dst: DataFormat,
 ) -> str:
-    return _emit_configure(
-        compute_node, dest_acc, unpack_A_src, unpack_A_dst, unpack_B_src, unpack_B_dst
-    )
+    return _emit_configure(compute_node, dest_acc, unpack_A_dst, unpack_B_dst)
 
 
 def configure_unpack(
@@ -88,17 +69,19 @@ def configure_unpack(
     srca_tile_changed: bool,
     srcb_tile_changed: bool,
 ) -> str:
-    code = "{\n"
-    code += _emit_configure(
-        compute_node, dest_acc, new_A_src, new_A_dst, new_B_src, new_B_dst
-    )
-    code += "}\n"
-    return code
+    return _emit_configure(compute_node, dest_acc, new_A_dst, new_B_dst)
 
 
-def dvalid_init() -> str:
-    return "set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});\n"
+def dvalid_init(quasar_use_dvalid: bool = False) -> str:
+    if quasar_use_dvalid:
+        return "set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});\n"
+    return ""
 
 
-def sync_with_packer(stage_id: int) -> str:
+def sync_with_packer(needs_pack_sync: bool) -> str:
+    if needs_pack_sync:
+        return (
+            "TT_SEMWAIT(p_stall::STALL_SYNC, p_stall::STALL_ON_ZERO, 0, semaphore::t6_sem(semaphore::PACK_DONE));\n"
+            "t6_semaphore_get<>(semaphore::PACK_DONE);\n"
+        )
     return ""

--- a/tt_metal/tt-llk/tests/python_tests/fuser/quasar/unpacker/common.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/quasar/unpacker/common.py
@@ -77,7 +77,7 @@ def dvalid_init(quasar_use_dvalid: bool = False) -> str:
 def sync_with_packer(needs_pack_sync: bool) -> str:
     if needs_pack_sync:
         return (
-            "TT_SEMWAIT(p_stall::STALL_SYNC, p_stall::STALL_ON_ZERO, 0, semaphore::t6_sem(semaphore::PACK_UNPACK));\n"
-            "t6_semaphore_get<>(semaphore::PACK_UNPACK);\n"
+            "_llk_sync_wait_<p_stall::STALL_SYNC, p_stall::STALL_ON_ZERO>(semaphore::PACK_UNPACK);\n"
+            "_llk_sync_get_<>(semaphore::PACK_UNPACK);\n"
         )
     return ""

--- a/tt_metal/tt-llk/tests/python_tests/fuser/quasar/unpacker/reduce.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/quasar/unpacker/reduce.py
@@ -46,9 +46,10 @@ class ReduceUnpacker(Unpacker):
         buf_desc_id_a = compute_unit.src_a.buf_desc_id
         buf_desc_id_b = compute_unit.src_b.buf_desc_id
         reduce_dim = self.reduce_dim.cpp_enum_value
+        reduce_pool = self.reduce_pool.cpp_enum_value
 
         return (
-            f"_llk_unpack_reduce_init_<{reduce_dim}>"
+            f"_llk_unpack_reduce_init_<{reduce_pool}, {reduce_dim}>"
             f"({buf_desc_id_a}, {buf_desc_id_b}, "
             f"{compute_unit.src_a.tile_shape.cpp_value}, "
             f"1);\n"
@@ -61,7 +62,10 @@ class ReduceUnpacker(Unpacker):
         compute_unit: FpuNode,
         block: BlockData,
     ) -> str:
-        return f"_llk_unpack_reduce_({block.tile_id_global}, {block.tile_id_global});\n"
+        return (
+            f"_llk_unpack_reduce_({block.tile_id_global}, {block.tile_id_global}, "
+            f"{compute_unit.src_a.tile_shape.cpp_value});\n"
+        )
 
     def uninit(
         self,

--- a/tt_metal/tt-llk/tests/python_tests/fuser/quasar/unpacker/unpack_a.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/quasar/unpacker/unpack_a.py
@@ -7,7 +7,7 @@ from typing import List, Tuple
 import torch
 from fuser.block_data import BlockData
 from fuser.fpu_node import FpuNode
-from fuser.fused_loop import FusedLoop, LoopBlockRow
+from fuser.fused_loop import FusedLoop, LoopBlockRow, LoopTileByTile
 from fuser.fused_operation import FusedOperation
 from fuser.fused_unpacker import Unpacker
 from fuser.fuser_config import GlobalConfig
@@ -15,9 +15,24 @@ from helpers.golden_generators import TransposeGolden, get_golden_generator
 from helpers.llk_params import DestSync, EltwiseBinaryReuseDestType, Transpose
 
 
+def _unp_sel(compute_unit: FpuNode) -> str:
+    if compute_unit.unpack_to_dest.value:
+        return "p_unpacr::UNP_DEST"
+    if compute_unit.reuse_dest == EltwiseBinaryReuseDestType.DEST_TO_SRCA:
+        return "p_unpacr::UNP_B"
+    return "p_unpacr::UNP_A"
+
+
 class UnpackerA(Unpacker):
     loop: FusedLoop = LoopBlockRow()
     per_block_init = True
+
+    def __init__(
+        self, reuse_dest: EltwiseBinaryReuseDestType = EltwiseBinaryReuseDestType.NONE
+    ):
+        self.reuse_dest = reuse_dest
+        if reuse_dest != EltwiseBinaryReuseDestType.NONE:
+            self.loop = LoopTileByTile()
 
     def get_headers(self) -> List[str]:
         return [
@@ -77,10 +92,11 @@ class UnpackerA(Unpacker):
         transpose_en = (
             "true" if compute_unit.unpack_transpose_faces == Transpose.Yes else "false"
         )
-        unp_sel = (
-            "p_unpacr::UNP_DEST"
-            if compute_unit.unpack_to_dest.value
-            else "p_unpacr::UNP_A"
+        unp_sel = _unp_sel(compute_unit)
+        num_tiles = (
+            1
+            if compute_unit.reuse_dest != EltwiseBinaryReuseDestType.NONE
+            else block.block_tiles_x
         )
 
         code = ""
@@ -89,7 +105,7 @@ class UnpackerA(Unpacker):
             code += f"_llk_sync_init_(semaphore::UNPACK_MATH, {num_sem}, 0);\n"
         code += (
             f"_llk_unpack_unary_operand_init_<{unp_sel}, {transpose_en}, {en_32bit_dest}, {reuse_dest}, {unpack_to_dest}>"
-            f"({buf_desc_id}, {tensor_shape}, {block.block_tiles_x});\n"
+            f"({buf_desc_id}, {tensor_shape}, {num_tiles});\n"
         )
         return code
 
@@ -100,11 +116,7 @@ class UnpackerA(Unpacker):
         compute_unit: FpuNode,
         block: BlockData,
     ) -> str:
-        unp_sel = (
-            "p_unpacr::UNP_DEST"
-            if compute_unit.unpack_to_dest.value
-            else "p_unpacr::UNP_A"
-        )
+        unp_sel = _unp_sel(compute_unit)
         tensor_shape = compute_unit.src_a.tile_shape.cpp_value
         reuse_dest = compute_unit.reuse_dest.cpp_enum_value
         unpack_to_dest = compute_unit.unpack_to_dest.cpp_enum_value

--- a/tt_metal/tt-llk/tests/python_tests/fuser/quasar/unpacker/unpack_a.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/quasar/unpacker/unpack_a.py
@@ -7,7 +7,7 @@ from typing import List, Tuple
 import torch
 from fuser.block_data import BlockData
 from fuser.fpu_node import FpuNode
-from fuser.fused_loop import FusedLoop, LoopTileByTile
+from fuser.fused_loop import FusedLoop, LoopBlockRow
 from fuser.fused_operation import FusedOperation
 from fuser.fused_unpacker import Unpacker
 from fuser.fuser_config import GlobalConfig
@@ -16,7 +16,8 @@ from helpers.llk_params import DestSync, EltwiseBinaryReuseDestType, Transpose
 
 
 class UnpackerA(Unpacker):
-    loop: FusedLoop = LoopTileByTile()
+    loop: FusedLoop = LoopBlockRow()
+    per_block_init = True
 
     def get_headers(self) -> List[str]:
         return [
@@ -88,7 +89,7 @@ class UnpackerA(Unpacker):
             code += f"_llk_sync_init_(semaphore::UNPACK_MATH, {num_sem}, 0);\n"
         code += (
             f"_llk_unpack_unary_operand_init_<{unp_sel}, {transpose_en}, {en_32bit_dest}, {reuse_dest}, {unpack_to_dest}>"
-            f"({buf_desc_id}, {tensor_shape}, 1);\n"
+            f"({buf_desc_id}, {tensor_shape}, {block.block_tiles_x});\n"
         )
         return code
 

--- a/tt_metal/tt-llk/tests/python_tests/fuser/quasar/unpacker/unpack_a.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/quasar/unpacker/unpack_a.py
@@ -11,7 +11,7 @@ from fuser.fused_loop import FusedLoop, LoopTileByTile
 from fuser.fused_operation import FusedOperation
 from fuser.fused_unpacker import Unpacker
 from fuser.fuser_config import GlobalConfig
-from helpers.llk_params import EltwiseBinaryReuseDestType
+from helpers.llk_params import DestSync, EltwiseBinaryReuseDestType
 
 
 class UnpackerA(Unpacker):
@@ -21,6 +21,7 @@ class UnpackerA(Unpacker):
         return [
             "llk_unpack_common.h",
             "llk_unpack_unary_operand.h",
+            "llk_math_common.h",
         ]
 
     def golden(
@@ -48,11 +49,21 @@ class UnpackerA(Unpacker):
         tensor_shape = compute_unit.src_a.tile_shape.cpp_value
         reuse_dest = compute_unit.reuse_dest.cpp_enum_value
         en_32bit_dest = config.dest_acc.cpp_enum_value
+        unp_sel = (
+            "p_unpacr::UNP_DEST"
+            if compute_unit.unpack_to_dest.value
+            else "p_unpacr::UNP_A"
+        )
 
-        return (
-            f"_llk_unpack_unary_operand_init_<p_unpacr::UNP_A, false, {en_32bit_dest}, {reuse_dest}>"
+        code = ""
+        if compute_unit.unpack_to_dest.value:
+            num_sem = 2 if operation.dest_sync == DestSync.Half else 1
+            code += f"_llk_sync_init_(semaphore::UNPACK_MATH, {num_sem}, 0);\n"
+        code += (
+            f"_llk_unpack_unary_operand_init_<{unp_sel}, false, {en_32bit_dest}, {reuse_dest}>"
             f"({buf_desc_id}, {tensor_shape}, 1);\n"
         )
+        return code
 
     def unpack(
         self,
@@ -61,11 +72,18 @@ class UnpackerA(Unpacker):
         compute_unit: FpuNode,
         block: BlockData,
     ) -> str:
+        unp_sel = (
+            "p_unpacr::UNP_DEST"
+            if compute_unit.unpack_to_dest.value
+            else "p_unpacr::UNP_A"
+        )
         tensor_shape = compute_unit.src_a.tile_shape.cpp_value
         reuse_dest = compute_unit.reuse_dest.cpp_enum_value
+        unpack_to_dest = compute_unit.unpack_to_dest.cpp_enum_value
+        dest_sync = operation.dest_sync.cpp_enum_value
 
         return (
-            f"_llk_unpack_unary_operand_<p_unpacr::UNP_A, {reuse_dest}>"
+            f"_llk_unpack_unary_operand_<{unp_sel}, {reuse_dest}, {unpack_to_dest}, {dest_sync}>"
             f"({block.tile_id_global}, {tensor_shape});\n"
         )
 

--- a/tt_metal/tt-llk/tests/python_tests/fuser/quasar/unpacker/unpack_a.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/quasar/unpacker/unpack_a.py
@@ -11,7 +11,8 @@ from fuser.fused_loop import FusedLoop, LoopTileByTile
 from fuser.fused_operation import FusedOperation
 from fuser.fused_unpacker import Unpacker
 from fuser.fuser_config import GlobalConfig
-from helpers.llk_params import DestSync, EltwiseBinaryReuseDestType
+from helpers.golden_generators import TransposeGolden, get_golden_generator
+from helpers.llk_params import DestSync, EltwiseBinaryReuseDestType, Transpose
 
 
 class UnpackerA(Unpacker):
@@ -32,6 +33,28 @@ class UnpackerA(Unpacker):
         config: GlobalConfig,
         compute_unit: FpuNode,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
+        t_matrix = get_golden_generator(TransposeGolden)
+
+        if compute_unit.unpack_transpose_faces == Transpose.Yes:
+            tensor_a = t_matrix.transpose_faces_multi_tile(
+                tensor_a,
+                compute_unit.src_a.data_format,
+                compute_unit.src_a.tile_count,
+                tilize=True,
+                untilize=True,
+                input_dimensions=compute_unit.src_a.dimensions,
+            )
+
+        if compute_unit.unpack_transpose_within_face == Transpose.Yes:
+            tensor_a = t_matrix.transpose_within_faces_multi_tile(
+                tensor_a,
+                compute_unit.src_a.data_format,
+                compute_unit.src_a.tile_count,
+                tilize=True,
+                untilize=True,
+                input_dimensions=compute_unit.src_a.dimensions,
+            )
+
         if compute_unit.reuse_dest == EltwiseBinaryReuseDestType.DEST_TO_SRCA:
             tensor_b = tensor_a
             tensor_a = None
@@ -49,6 +72,10 @@ class UnpackerA(Unpacker):
         tensor_shape = compute_unit.src_a.tile_shape.cpp_value
         reuse_dest = compute_unit.reuse_dest.cpp_enum_value
         en_32bit_dest = config.dest_acc.cpp_enum_value
+        unpack_to_dest = compute_unit.unpack_to_dest.cpp_enum_value
+        transpose_en = (
+            "true" if compute_unit.unpack_transpose_faces == Transpose.Yes else "false"
+        )
         unp_sel = (
             "p_unpacr::UNP_DEST"
             if compute_unit.unpack_to_dest.value
@@ -60,7 +87,7 @@ class UnpackerA(Unpacker):
             num_sem = 2 if operation.dest_sync == DestSync.Half else 1
             code += f"_llk_sync_init_(semaphore::UNPACK_MATH, {num_sem}, 0);\n"
         code += (
-            f"_llk_unpack_unary_operand_init_<{unp_sel}, false, {en_32bit_dest}, {reuse_dest}>"
+            f"_llk_unpack_unary_operand_init_<{unp_sel}, {transpose_en}, {en_32bit_dest}, {reuse_dest}, {unpack_to_dest}>"
             f"({buf_desc_id}, {tensor_shape}, 1);\n"
         )
         return code

--- a/tt_metal/tt-llk/tests/python_tests/fuser/quasar/unpacker/unpack_ab.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/quasar/unpacker/unpack_ab.py
@@ -11,6 +11,9 @@ from fuser.fused_loop import FusedLoop, LoopTileByTile
 from fuser.fused_operation import FusedOperation
 from fuser.fused_unpacker import Unpacker
 from fuser.fuser_config import GlobalConfig
+from helpers.golden_generators import BroadcastGolden, get_golden_generator
+from helpers.llk_params import BroadcastType
+from helpers.tilize_untilize import tilize_block, untilize_block
 
 
 class UnpackerAB(Unpacker):
@@ -19,6 +22,7 @@ class UnpackerAB(Unpacker):
     def get_headers(self) -> List[str]:
         return [
             "llk_unpack_binary_operands.h",
+            "llk_unpack_binary_broadcast_operands.h",
             "llk_unpack_common.h",
         ]
 
@@ -30,6 +34,36 @@ class UnpackerAB(Unpacker):
         config: GlobalConfig,
         compute_unit: FpuNode,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
+        if compute_unit.broadcast_type != BroadcastType.None_:
+            src_b_tile_dims = (
+                compute_unit.src_b.tile_shape.total_row_dim(),
+                compute_unit.src_b.tile_shape.total_col_dim(),
+            )
+            src_b_num_faces = compute_unit.src_b.tile_shape.total_num_faces()
+            tilized_b = tilize_block(
+                tensor_b,
+                compute_unit.src_b.dimensions,
+                compute_unit.src_b.data_format,
+                num_faces=src_b_num_faces,
+                tile_dimensions=src_b_tile_dims,
+            )
+            broadcast_golden = get_golden_generator(BroadcastGolden)
+            broadcast_result = broadcast_golden(
+                compute_unit.broadcast_type,
+                tilized_b,
+                compute_unit.src_b.data_format,
+                compute_unit.src_a.tile_shape.total_num_faces(),
+                compute_unit.src_b.tile_count,
+                compute_unit.src_a.tile_shape.face_r_dim,
+            )
+            tensor_b = untilize_block(
+                broadcast_result,
+                compute_unit.src_b.data_format,
+                compute_unit.src_b.dimensions,
+                tile_dimensions=src_b_tile_dims,
+                num_faces=src_b_num_faces,
+            )
+
         return tensor_a.flatten(), tensor_b.flatten()
 
     def init(
@@ -41,6 +75,14 @@ class UnpackerAB(Unpacker):
     ) -> str:
         buf_desc_id_a = compute_unit.src_a.buf_desc_id
         buf_desc_id_b = compute_unit.src_b.buf_desc_id
+
+        if compute_unit.broadcast_type != BroadcastType.None_:
+            broadcast_type = compute_unit.broadcast_type.cpp_enum_value
+            return (
+                f"_llk_unpack_binary_broadcast_operands_init_<{broadcast_type}>"
+                f"({buf_desc_id_a}, {buf_desc_id_b}, 1);\n"
+            )
+
         return (
             f"_llk_unpack_binary_operands_init_({buf_desc_id_a}, {buf_desc_id_b}, 1);\n"
         )
@@ -52,6 +94,9 @@ class UnpackerAB(Unpacker):
         compute_unit: FpuNode,
         block: BlockData,
     ) -> str:
+        if compute_unit.broadcast_type != BroadcastType.None_:
+            return f"_llk_unpack_binary_broadcast_operands_({block.tile_id_global}, {block.tile_id_global});\n"
+
         return f"_llk_unpack_binary_operands_({block.tile_id_global}, {block.tile_id_global});\n"
 
     def uninit(

--- a/tt_metal/tt-llk/tests/python_tests/fuser/tests/example.yaml
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/tests/example.yaml
@@ -109,7 +109,6 @@ operations:
         operation: "Neg"
         approximation_mode: false
         iterations: 32
-    dest_sync: "SyncFull"
 
     pack:
       - output: "elwadd_output"

--- a/tt_metal/tt-llk/tests/python_tests/fuser/tests/example.yaml
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/tests/example.yaml
@@ -1,7 +1,7 @@
 # Stress test that chains five fused operations together to exercise as many
 # fuser features as possible: datacopy with fill, tilize with SFPU ops,
 # elwadd with transpose, two matmul stages with SFPU chains, dest accumulation,
-# looping, broadcast scalar, acc_to_dest, SyncFull, and mixed formats.
+# looping, broadcast scalar, acc_to_dest, and mixed formats.
 
 supported_archs: ["wormhole", "blackhole"]
 

--- a/tt_metal/tt-llk/tests/python_tests/fuser/tests/fpu_reduce_block_max_tiny.yaml
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/tests/fpu_reduce_block_max_tiny.yaml
@@ -6,6 +6,8 @@
 # Exercises the num_faces=2 unpack + math (2-face MOP/replay) path for
 # reduce_block_max_row. Source B is all ones as the identity scale.
 
+supported_archs: ["wormhole", "blackhole"]
+
 dest_acc: false
 
 operands:

--- a/tt_metal/tt-llk/tests/python_tests/fuser/tests/quasar/eltwise_broadcast.yaml
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/tests/quasar/eltwise_broadcast.yaml
@@ -1,0 +1,29 @@
+# Single-stage Elwmul with COL broadcast to validate the broadcast path.
+
+dest_acc: true
+
+operands:
+  - name: "input_A"
+    dims: [32, 32]
+    format: "Float16_b"
+    # const_value: 1.0
+  - name: "input_B"
+    dims: [32, 32]
+    format: "Float16_b"
+  - name: "output_A"
+    dims: [32, 32]
+    format: "Float16_b"
+
+operations:
+  - math:
+      - type: "Fpu"
+        src_a: "input_A"
+        src_b: "input_B"
+        operation: "Elwmul"
+        unpacker: "UnpackerAB"
+        broadcast_type: "COL"
+        math_fidelity: "HiFi2"
+    block_size: [32, 32]
+    pack:
+      - output: "output_A"
+        packer: "Packer"

--- a/tt_metal/tt-llk/tests/python_tests/fuser/tests/quasar/reuse_dest.yaml
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/tests/quasar/reuse_dest.yaml
@@ -1,0 +1,39 @@
+# Datacopy followed by Elwmul that reuses dest as src_b.
+
+operands:
+  - name: "input_A"
+    dims: [256, 256]
+    format: "Float16_b"
+  - name: "input_B"
+    dims: [256, 256]
+    format: "Float16_b"
+  - name: "output"
+    dims: [256, 256]
+    format: "Float16_b"
+
+operations:
+  - math:
+      - type: "Fpu"
+        operation: "Datacopy"
+        unpacker: "UnpackerA"
+        math_fidelity: "LoFi"
+        src_a: "input_A"
+        src_b: "input_B"
+      - type: "Fpu"
+        src_a: "input_A"
+        src_b: "input_B"
+        operation: "Elwmul"
+        unpacker: "UnpackerA"
+        reuse_dest: "DEST_TO_SRCB"
+        math_fidelity: "LoFi"
+      - type: "Fpu"
+        src_a: "input_A"
+        src_b: "input_B"
+        operation: "Elwmul"
+        unpacker: "UnpackerA"
+        reuse_dest: "DEST_TO_SRCA"
+        math_fidelity: "LoFi"
+    block_size: [64, 128]
+    pack:
+      - output: "output"
+        packer: "Packer"

--- a/tt_metal/tt-llk/tests/python_tests/fuser/tests/quasar/sdpa_inner_loop.yaml
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/tests/quasar/sdpa_inner_loop.yaml
@@ -1,0 +1,142 @@
+# Simplified SDPA inner loop for Quasar.
+# Mirrors the WH/BH sdpa_inner_loop_step pipeline:
+# QKT matmul, reduce max, sub+exp (datacopy+SFPU), eltwise broadcast multiply,
+# attn_v matmul, reciprocal (datacopy+SFPU), normalize (eltwise broadcast multiply).
+
+operands:
+  # Q: query tile block
+  - name: "Q"
+    dims: [32, 64]
+    format: "Float16_b"
+  # KT: key transposed
+  - name: "KT"
+    dims: [64, 64]
+    format: "Float16_b"
+    const_value: 0.01
+  # V: value matrix
+  - name: "V"
+    dims: [64, 64]
+    format: "Float16_b"
+  # identity_scale: all-ones for reduce
+  - name: "identity_scale"
+    dims: [64, 64]
+    format: "Float16_b"
+    const_value: 1.0
+  # intermediates and outputs
+  - name: "qkt"
+    dims: [32, 64]
+    format: "Float16_b"
+  - name: "row_max"
+    dims: [32, 64]
+    format: "Float16_b"
+  - name: "sub_exp_out"
+    dims: [32, 64]
+    format: "Float16_b"
+  - name: "sub_exp_sum"
+    dims: [32, 64]
+    format: "Float16_b"
+  - name: "attn_v"
+    dims: [32, 64]
+    format: "Float16_b"
+  - name: "sum_recip"
+    dims: [32, 64]
+    format: "Float16_b"
+  - name: "output"
+    dims: [32, 64]
+    format: "Float16_b"
+
+operations:
+  # Step 1: QKT = Q[32,64] x KT[64,64] -> [32,64]
+  - math:
+      - type: "Fpu"
+        src_a: "Q"
+        src_b: "KT"
+        operation: "Matmul"
+        unpacker: "MatmulUnpacker"
+        math_fidelity: "HiFi2"
+    block_size: [32, 64]
+    pack:
+      - output: "qkt"
+        packer: "Packer"
+
+  # Step 2: row_max = reduce_max_row(qkt) with reduce_to_tile
+  - math:
+      - type: "Fpu"
+        src_a: "qkt"
+        src_b: "identity_scale"
+        operation: "Reduce"
+        reduce_dim: "REDUCE_ROW"
+        reduce_pool: "MAX"
+        reduce_to_tile: true
+        unpacker: "ReduceUnpacker"
+        math_fidelity: "LoFi"
+    block_size: [32, 64]
+    pack:
+      - output: "row_max"
+        packer: "Packer"
+
+  # Step 3: sub_exp = exp(datacopy(qkt))
+  # Dual pack: sub_exp_out with ZERO_RELU, sub_exp_sum with L1 accumulation
+  - math:
+      - type: "Fpu"
+        operation: "Datacopy"
+        unpacker: "UnpackerA"
+        math_fidelity: "LoFi"
+        src_a: "qkt"
+        src_b: "identity_scale"
+      - type: "UnarySfpu"
+        operation: "Exp"
+        approximation_mode: true
+        iterations: 32
+    block_size: [32, 64]
+    pack:
+      - output: "sub_exp_out"
+        packer: "Packer"
+        pack_relu: "ZERO_RELU"
+      - output: "sub_exp_sum"
+        packer: "Packer"
+        pack_l1_accumulation: 1
+
+  # Step 4: attn_v = sub_exp_out[32,64] x V[64,64] -> [32,64]
+  - math:
+      - type: "Fpu"
+        src_a: "sub_exp_out"
+        src_b: "V"
+        operation: "Matmul"
+        unpacker: "MatmulUnpacker"
+        math_fidelity: "HiFi2"
+    block_size: [32, 64]
+    pack:
+      - output: "attn_v"
+        packer: "Packer"
+
+  # Step 5: sum_recip = reciprocal(sub_exp_sum)
+  # Datacopy loads sum into DEST, then SFPU reciprocal
+  - math:
+      - type: "Fpu"
+        operation: "Datacopy"
+        unpacker: "UnpackerA"
+        math_fidelity: "LoFi"
+        src_a: "sub_exp_sum"
+        src_b: "identity_scale"
+      - type: "UnarySfpu"
+        operation: "Reciprocal"
+        iterations: 32
+    block_size: [32, 64]
+    pack:
+      - output: "sum_recip"
+        packer: "Packer"
+
+  # Step 6: output = attn_v * bcast_col(sum_recip) — normalize
+  - math:
+      - type: "Fpu"
+        src_a: "attn_v"
+        src_b: "sum_recip"
+        operation: "Elwmul"
+        unpacker: "UnpackerAB"
+        broadcast_type: "COL"
+        math_fidelity: "LoFi"
+    block_size: [32, 64]
+    pack:
+      - output: "output"
+        packer: "Packer"

--- a/tt_metal/tt-llk/tests/python_tests/fuser/tests/quasar/sdpa_inner_loop.yaml
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/tests/quasar/sdpa_inner_loop.yaml
@@ -1,7 +1,7 @@
 # Simplified SDPA inner loop for Quasar.
 # Mirrors the WH/BH sdpa_inner_loop_step pipeline:
-# QKT matmul, reduce max, sub+exp (datacopy+SFPU), eltwise broadcast multiply,
-# attn_v matmul, reciprocal (datacopy+SFPU), normalize (eltwise broadcast multiply).
+# QKT matmul, reduce max, sub+exp (Elwsub+SFPU), attn_v matmul,
+# reciprocal (datacopy+SFPU), normalize (eltwise broadcast multiply).
 
 operands:
   # Q: query tile block
@@ -75,15 +75,16 @@ operations:
       - output: "row_max"
         packer: "Packer"
 
-  # Step 3: sub_exp = exp(datacopy(qkt))
+  # Step 3: sub_exp = exp(qkt - row_max)
   # Dual pack: sub_exp_out with ZERO_RELU, sub_exp_sum with L1 accumulation
   - math:
       - type: "Fpu"
-        operation: "Datacopy"
-        unpacker: "UnpackerA"
-        math_fidelity: "LoFi"
         src_a: "qkt"
-        src_b: "identity_scale"
+        src_b: "row_max"
+        operation: "Elwsub"
+        unpacker: "UnpackerAB"
+        broadcast_type: "COL"
+        math_fidelity: "LoFi"
       - type: "UnarySfpu"
         operation: "Exp"
         approximation_mode: true

--- a/tt_metal/tt-llk/tests/python_tests/fuser/tests/reconfigure.yaml
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/tests/reconfigure.yaml
@@ -1,6 +1,6 @@
 # Three stages that each use different data formats, forcing the unpack, math,
 # and pack pipelines to reconfigure between every stage. Goes from Float16_b
-# through Bfp8_b to Float32.
+# through Float16 to Float32.
 
 dest_acc: true
 

--- a/tt_metal/tt-llk/tests/python_tests/fuser/tests/reconfigure.yaml
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/tests/reconfigure.yaml
@@ -2,8 +2,6 @@
 # and pack pipelines to reconfigure between every stage. Goes from Float16_b
 # through Bfp8_b to Float32.
 
-supported_archs: ["wormhole", "blackhole"]
-
 dest_acc: true
 
 operands:
@@ -25,11 +23,11 @@ operands:
     format: "Float16_b"
   - name: "output_B"
     dims: [32, 32]
-    format: "Bfp8_b"
+    format: "Float16"
 
   - name: "input_E"
     dims: [32, 32]
-    format: "Bfp8_b"
+    format: "Float16"
   - name: "output_C"
     dims: [32, 32]
     format: "Float32"
@@ -44,11 +42,6 @@ operations:
         src_b: "input_B"
       - type: "UnarySfpu"
         operation: "Exp"
-        approximation_mode: false
-        iterations: 32
-        dst_dest_tile_index: 0
-      - type: "UnarySfpu"
-        operation: "Log1p"
         approximation_mode: false
         iterations: 32
         dst_dest_tile_index: 0

--- a/tt_metal/tt-llk/tests/python_tests/fuser/tests/sfpu_binary.yaml
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/tests/sfpu_binary.yaml
@@ -1,0 +1,35 @@
+# Basic datacopy test that reads from source A only.
+
+dest_acc: true
+
+
+operands:
+  - name: "input_A"
+    dims: [256, 256]
+    format: "Float16_b"
+  - name: "input_B"
+    dims: [256, 256]
+    format: "Float16_b"
+  - name: "datacopy_out"
+    dims: [256, 256]
+    format: "Float16_b"
+
+operations:
+  - math:
+      - type: "Fpu"
+        src_a: "input_A"
+        src_b: "input_B"
+        operation: "Datacopy"
+        unpacker: "UnpackerA"
+        math_fidelity: "HiFi2"
+      - type: "BinarySfpu"
+        operation: "SfpuElwadd"
+        approximation_mode: false
+        iterations: 32
+        src1_dest_tile_index: 0
+        src2_dest_tile_index: 1
+        dst_dest_tile_index: 1
+    block_size: [32, 64]
+    pack:
+      - output: "datacopy_out"
+        packer: "Packer"

--- a/tt_metal/tt-llk/tests/python_tests/fuser/tests/sfpu_binary.yaml
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/tests/sfpu_binary.yaml
@@ -1,18 +1,18 @@
-# Basic datacopy test that reads from source A only.
+# Datacopy (unpack_to_dest), then BinarySfpu SfpuElwadd:
+# adds dest tile 0 + dest tile 1 and writes the result to dest tile 2.
 
 dest_acc: true
 
-
 operands:
   - name: "input_A"
-    dims: [256, 256]
-    format: "Float16_b"
+    dims: [32, 128]
+    format: "Float32"
   - name: "input_B"
-    dims: [256, 256]
-    format: "Float16_b"
+    dims: [32, 128]
+    format: "Float32"
   - name: "datacopy_out"
-    dims: [256, 256]
-    format: "Float16_b"
+    dims: [32, 128]
+    format: "Float32"
 
 operations:
   - math:
@@ -22,15 +22,15 @@ operations:
         operation: "Datacopy"
         unpacker: "UnpackerA"
         math_fidelity: "LoFi"
-        # unpack_to_dest: true
+        unpack_to_dest: true
       - type: "BinarySfpu"
         operation: "SfpuElwadd"
         approximation_mode: false
         iterations: 32
         src1_dest_tile_index: 0
         src2_dest_tile_index: 1
-        dst_dest_tile_index: 1
-    block_size: [32, 64]
+        dst_dest_tile_index: 2
     pack:
       - output: "datacopy_out"
         packer: "Packer"
+    block_size: [32, 128]

--- a/tt_metal/tt-llk/tests/python_tests/fuser/tests/sfpu_binary.yaml
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/tests/sfpu_binary.yaml
@@ -21,8 +21,8 @@ operations:
         src_b: "input_B"
         operation: "Datacopy"
         unpacker: "UnpackerA"
-        math_fidelity: "HiFi2"
-        unpack_to_dest: true
+        math_fidelity: "LoFi"
+        # unpack_to_dest: true
       - type: "BinarySfpu"
         operation: "SfpuElwadd"
         approximation_mode: false

--- a/tt_metal/tt-llk/tests/python_tests/fuser/tests/sfpu_binary.yaml
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/tests/sfpu_binary.yaml
@@ -22,6 +22,7 @@ operations:
         operation: "Datacopy"
         unpacker: "UnpackerA"
         math_fidelity: "HiFi2"
+        unpack_to_dest: true
       - type: "BinarySfpu"
         operation: "SfpuElwadd"
         approximation_mode: false

--- a/tt_metal/tt-llk/tests/python_tests/fuser/tests/sfpu_unary.yaml
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/tests/sfpu_unary.yaml
@@ -1,17 +1,16 @@
-# Basic datacopy test that reads from source A only.
+# Datacopy (unpack_to_dest), then UnarySfpu Exp calculates Exp for tile 0.
 
 dest_acc: true
 
-
 operands:
   - name: "input_A"
-    dims: [64, 64]
+    dims: [32, 128]
     format: "Float32"
   - name: "input_B"
-    dims: [64, 64]
+    dims: [32, 128]
     format: "Float32"
   - name: "datacopy_out"
-    dims: [64, 64]
+    dims: [32, 128]
     format: "Float32"
 
 operations:
@@ -22,12 +21,12 @@ operations:
         operation: "Datacopy"
         unpacker: "UnpackerA"
         math_fidelity: "LoFi"
-        # unpack_to_dest: true
+        unpack_to_dest: true
       - type: "UnarySfpu"
         operation: "Exp"
         approximation_mode: false
         iterations: 32
-    block_size: [64, 64]
     pack:
       - output: "datacopy_out"
         packer: "Packer"
+    block_size: [32, 128]

--- a/tt_metal/tt-llk/tests/python_tests/fuser/tests/sfpu_unary.yaml
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/tests/sfpu_unary.yaml
@@ -21,8 +21,8 @@ operations:
         src_b: "input_B"
         operation: "Datacopy"
         unpacker: "UnpackerA"
-        math_fidelity: "HiFi2"
-        unpack_to_dest: true
+        math_fidelity: "LoFi"
+        # unpack_to_dest: true
       - type: "UnarySfpu"
         operation: "Exp"
         approximation_mode: false

--- a/tt_metal/tt-llk/tests/python_tests/fuser/tests/sfpu_unary.yaml
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/tests/sfpu_unary.yaml
@@ -1,0 +1,33 @@
+# Basic datacopy test that reads from source A only.
+
+dest_acc: true
+
+
+operands:
+  - name: "input_A"
+    dims: [256, 256]
+    format: "Float32"
+  - name: "input_B"
+    dims: [256, 256]
+    format: "Float32"
+  - name: "datacopy_out"
+    dims: [256, 256]
+    format: "Float32"
+
+operations:
+  - math:
+      - type: "Fpu"
+        src_a: "input_A"
+        src_b: "input_B"
+        operation: "Datacopy"
+        unpacker: "UnpackerA"
+        math_fidelity: "HiFi2"
+        # unpack_to_dest: true
+      - type: "UnarySfpu"
+        operation: "Exp"
+        approximation_mode: true
+        iterations: 32
+    block_size: [32, 32]
+    pack:
+      - output: "datacopy_out"
+        packer: "Packer"

--- a/tt_metal/tt-llk/tests/python_tests/fuser/tests/sfpu_unary.yaml
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/tests/sfpu_unary.yaml
@@ -5,13 +5,13 @@ dest_acc: true
 
 operands:
   - name: "input_A"
-    dims: [32, 32]
+    dims: [64, 64]
     format: "Float32"
   - name: "input_B"
-    dims: [32, 32]
+    dims: [64, 64]
     format: "Float32"
   - name: "datacopy_out"
-    dims: [32, 32]
+    dims: [64, 64]
     format: "Float32"
 
 operations:
@@ -27,7 +27,7 @@ operations:
         operation: "Exp"
         approximation_mode: false
         iterations: 32
-    block_size: [32, 32]
+    block_size: [64, 64]
     pack:
       - output: "datacopy_out"
         packer: "Packer"

--- a/tt_metal/tt-llk/tests/python_tests/fuser/tests/sfpu_unary.yaml
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/tests/sfpu_unary.yaml
@@ -5,13 +5,13 @@ dest_acc: true
 
 operands:
   - name: "input_A"
-    dims: [256, 256]
+    dims: [32, 32]
     format: "Float32"
   - name: "input_B"
-    dims: [256, 256]
+    dims: [32, 32]
     format: "Float32"
   - name: "datacopy_out"
-    dims: [256, 256]
+    dims: [32, 32]
     format: "Float32"
 
 operations:
@@ -22,10 +22,10 @@ operations:
         operation: "Datacopy"
         unpacker: "UnpackerA"
         math_fidelity: "HiFi2"
-        # unpack_to_dest: true
+        unpack_to_dest: true
       - type: "UnarySfpu"
         operation: "Exp"
-        approximation_mode: true
+        approximation_mode: false
         iterations: 32
     block_size: [32, 32]
     pack:

--- a/tt_metal/tt-llk/tests/python_tests/fuser/tests/unpack_transpose.yaml
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/tests/unpack_transpose.yaml
@@ -1,0 +1,31 @@
+# Unpack transpose test for all architectures.
+# Datacopy with both transpose_faces and transpose_within_face enabled.
+# Verifies that the unpacker correctly transposes data at the tile level.
+
+dest_acc: true
+
+operands:
+  - name: "input_A"
+    dims: [64, 64]
+    format: "Float16_b"
+  - name: "input_B"
+    dims: [64, 64]
+    format: "Float16_b"
+  - name: "datacopy_out"
+    dims: [64, 64]
+    format: "Float16_b"
+
+operations:
+  - math:
+      - type: "Fpu"
+        src_a: "input_A"
+        src_b: "input_B"
+        operation: "Datacopy"
+        unpacker: "UnpackerA"
+        unpack_transpose_faces: true
+        unpack_transpose_within_face: true
+        math_fidelity: "LoFi"
+    block_size: [32, 64]
+    pack:
+      - output: "datacopy_out"
+        packer: "Packer"

--- a/tt_metal/tt-llk/tests/python_tests/fuser/validator.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/validator.py
@@ -228,7 +228,9 @@ class FpuMathSchemaBase(BaseModel):
 
     def to_node(self, operands):
         src_a = operands.get(self.src_a)
+        src_a.is_input = True
         src_b = operands.get(self.src_b)
+        src_b.is_input = True
 
         factory, checks = type(self)._fpu_map[self.operation]
 

--- a/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/fpu/common.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/fpu/common.py
@@ -30,7 +30,7 @@ def configure_math(
     )
 
 
-def math_pack_sync_init(dest_sync: str, dest_acc: str) -> str:
+def math_pack_sync_init(dest_sync: str, dest_acc: str, **kwargs) -> str:
     return f"_llk_math_pack_sync_init_<{dest_sync}, {dest_acc}>();\n"
 
 

--- a/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/fpu/common.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/fpu/common.py
@@ -34,9 +34,9 @@ def math_pack_sync_init(dest_sync: str, dest_acc: str, **kwargs) -> str:
     return f"_llk_math_pack_sync_init_<{dest_sync}, {dest_acc}>();\n"
 
 
-def math_wait_for_dest(dest_sync: str) -> str:
+def math_wait_for_dest(dest_sync: str, **kwargs) -> str:
     return f"_llk_math_wait_for_dest_available_<{dest_sync}>();\n"
 
 
-def math_dest_section_done(dest_sync: str, dest_acc: str) -> str:
+def math_dest_section_done(dest_sync: str, dest_acc: str, **kwargs) -> str:
     return f"_llk_math_dest_section_done_<{dest_sync}, {dest_acc}>();\n"

--- a/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/packer/common.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/packer/common.py
@@ -62,9 +62,13 @@ def packer_sync_with_unpacker(has_pack_consumer: bool) -> str:
 
 
 def pack_reduce_mask_config(operation: "FusedOperation") -> str:
+    if operation.reduce_dim is None:
+        return ""
     reduce_dim = operation.reduce_dim.cpp_enum_value
     return f"_llk_pack_reduce_mask_config_<{reduce_dim}>();\n"
 
 
-def pack_reduce_mask_clear() -> str:
+def pack_reduce_mask_clear(operation) -> str:
+    if operation.reduce_dim is None:
+        return ""
     return "_llk_pack_reduce_mask_clear_();\n"

--- a/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/packer/common.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/packer/common.py
@@ -47,11 +47,11 @@ def pack_dest_init(dest_sync: str, dest_acc: str, **kwargs) -> str:
     return f"_llk_pack_dest_init_<{dest_sync}, {dest_acc}>();\n"
 
 
-def packer_wait_for_math() -> str:
+def packer_wait_for_math(**kwargs) -> str:
     return "_llk_packer_wait_for_math_done_();\n"
 
 
-def packer_dest_section_done(dest_sync: str, dest_acc: str) -> str:
+def packer_dest_section_done(dest_sync: str, dest_acc: str, **kwargs) -> str:
     return f"_llk_pack_dest_section_done_<{dest_sync}, {dest_acc}>();\n"
 
 

--- a/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/packer/common.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/packer/common.py
@@ -43,7 +43,7 @@ def l1_accumulation_config(pack_l1_accumulation: L1Accumulation) -> str:
     return f"_llk_pack_reconfig_l1_acc_({l1_acc});\n"
 
 
-def pack_dest_init(dest_sync: str, dest_acc: str) -> str:
+def pack_dest_init(dest_sync: str, dest_acc: str, **kwargs) -> str:
     return f"_llk_pack_dest_init_<{dest_sync}, {dest_acc}>();\n"
 
 
@@ -55,7 +55,16 @@ def packer_dest_section_done(dest_sync: str, dest_acc: str) -> str:
     return f"_llk_pack_dest_section_done_<{dest_sync}, {dest_acc}>();\n"
 
 
-def packer_sync_with_unpacker(stage_id: int, num_stages: int) -> str:
-    if stage_id < num_stages:
+def packer_sync_with_unpacker(has_pack_consumer: bool) -> str:
+    if has_pack_consumer:
         return "t6_semaphore_post<>(semaphore::PACK_DONE);\n\n"
     return ""
+
+
+def pack_reduce_mask_config(operation: "FusedOperation") -> str:
+    reduce_dim = operation.reduce_dim.cpp_enum_value
+    return f"_llk_pack_reduce_mask_config_<{reduce_dim}>();\n"
+
+
+def pack_reduce_mask_clear() -> str:
+    return "_llk_pack_reduce_mask_clear_();\n"

--- a/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/unpacker/common.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/unpacker/common.py
@@ -122,12 +122,12 @@ def configure_unpack(
     return code
 
 
-def dvalid_init() -> str:
+def dvalid_init(**kwargs) -> str:
     return ""
 
 
-def sync_with_packer(stage_id: int) -> str:
-    if stage_id > 1:
+def sync_with_packer(needs_pack_sync: bool) -> str:
+    if needs_pack_sync:
         return (
             "t6_semaphore_wait_on_zero<p_stall::STALL_SYNC>(semaphore::PACK_DONE);\n"
             "t6_semaphore_get<>(semaphore::PACK_DONE);\n"

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_fused_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_fused_quasar.py
@@ -7,7 +7,8 @@ from conftest import skip_for_blackhole, skip_for_coverage, skip_for_wormhole
 from fuser.fuser_config_parser import FUSER_CONFIG_DIR, FuserConfigSchema
 
 yaml_files = sorted(FUSER_CONFIG_DIR.glob("*.yaml"))
-test_names = [f.stem for f in yaml_files]
+yaml_files += sorted((FUSER_CONFIG_DIR / "quasar").glob("*.yaml"))
+test_names = [str(f.relative_to(FUSER_CONFIG_DIR).with_suffix("")) for f in yaml_files]
 
 
 @skip_for_blackhole

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_sfpu_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_sfpu_quasar_test.cpp
@@ -170,7 +170,14 @@ void run_kernel(RUNTIME_PARAMETERS params)
     // so it is offset by params.DST_INDEX.
     for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
     {
-        test_utils::call_unary_sfpu_operation_quasar<SFPU_UNARY_OPERATION, dest_sync, is_fp32_dest_acc_en, APPROX_MODE>(params.DST_INDEX + i, sfpu_format);
+        test_utils::call_unary_sfpu_operation_quasar<
+            SFPU_UNARY_OPERATION,
+            dest_sync,
+            is_fp32_dest_acc_en,
+            APPROX_MODE,
+            SFPU_ITERATIONS,
+            TYPECAST_IN_FORMAT,
+            TYPECAST_OUT_FORMAT>(params.DST_INDEX + i, sfpu_format);
     }
 
     _llk_math_set_dvalid_<p_cleardvalid::SFPU, dest_sync>();

--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/ckernel_trisc_common.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/ckernel_trisc_common.h
@@ -328,6 +328,7 @@ struct semaphore
     // - UNPACK_MATH = unpack->math
     constexpr static std::uint32_t MATH_PACK   = 1; // math <-> pack sync on dest register
     constexpr static std::uint32_t UNPACK_MATH = 4; // unpack <-> math sync on dest register
+    constexpr static std::uint32_t PACK_DONE   = 5; // pack <-> unpack sync on L1 memory
 
     constexpr static std::uint16_t t6_sem(const std::uint8_t sem_index)
     {

--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/ckernel_trisc_common.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/ckernel_trisc_common.h
@@ -317,7 +317,7 @@ inline void _update_dest_register_offset_()
 // Semaphores mapping and trisc space -> tensix space conversion
 struct semaphore
 {
-    // The math thread is always the middleman, for regular unpack and for unpack_to_dest.
+    // The math thread is the middleman, for regular unpack and for unpack_to_dest.
     // When unpacking to dest, math thread doesn't produce data, it just bridges UNPACK_MATH -> MATH_PACK.
     // Packer only listens on MATH_PACK, so something has to translate the unpack completion into a
     // pack-visible event. Math being the forwarder is also what makes future fused ops cheap:
@@ -326,9 +326,10 @@ struct semaphore
     // Keep pairwise naming with producer_consumer direction:
     // - MATH_PACK = math->pack
     // - UNPACK_MATH = unpack->math
+    // - PACK_UNPACK = pack->unpack
     constexpr static std::uint32_t MATH_PACK   = 1; // math <-> pack sync on dest register
     constexpr static std::uint32_t UNPACK_MATH = 4; // unpack <-> math sync on dest register
-    constexpr static std::uint32_t PACK_DONE   = 5; // pack <-> unpack sync on L1 memory
+    constexpr static std::uint32_t PACK_UNPACK = 7; // pack <-> unpack sync on L1 memory
 
     constexpr static std::uint16_t t6_sem(const std::uint8_t sem_index)
     {


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->
Test Only

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->
#51474

This PR adds support for multiple L1 to L1 iterations on Quasar and introduces better TDMA descriptor management.

What changed
- Extended the fuser pipeline to run multiple L1 to L1 iterations within a single kernel.
- Introduced explicit buffer descriptor initialization on unpack and pack threads. This gives finer control over TDMA descriptor setup and teardown per iteration, reducing descriptor pressure and avoiding stale descriptor reuse between iterations.
- Added support for the same synchronization as Wormhole and Blackhole using semaphores. To toggle between semaphores the dvalid scheme I added `quasar_use_dvalid` parameter to YAML config. Note that dvalid still supports only a single L1 to L1 run.
- Added `PACK_DONE` semaphore for quasar to sync unpack and pack on L1 memory access and optimized the logic for when it should be used. It should only be used when unpack unpacks data that pack from the previous operation packed.
- Added `tests/quasar/` subdirectory with Quasar specific test YAMLs.
- Added 5 new tests:
  - quasar/eltwise_broadcast.yaml
  - quasar/sdpa_inner_loop.yaml
  - sfpu_unary.yaml
  - sfpu_binary.yaml
  - unpack_transpose.yaml

Note: `unpack_to_dest` for quasar is currently supported only when the operand fits into a single dest bank.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=marko/qsr-fuser-semaphores)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:marko/qsr-fuser-semaphores)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=marko/qsr-fuser-semaphores)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:marko/qsr-fuser-semaphores)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=marko/qsr-fuser-semaphores)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:marko/qsr-fuser-semaphores)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=marko/qsr-fuser-semaphores)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:marko/qsr-fuser-semaphores)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=marko/qsr-fuser-semaphores)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:marko/qsr-fuser-semaphores)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=marko/qsr-fuser-semaphores)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:marko/qsr-fuser-semaphores)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=marko/qsr-fuser-semaphores)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:marko/qsr-fuser-semaphores)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=marko/qsr-fuser-semaphores)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:marko/qsr-fuser-semaphores)