### PR TITLE
[Bug Fix] Qwen3.6: load text weights via explicit HF classes, not AutoModelForCausalLM

### DIFF
--- a/models/demos/blackhole/qwen36/tt/model_config.py
+++ b/models/demos/blackhole/qwen36/tt/model_config.py
@@ -279,7 +279,7 @@ class Qwen36ModelArgs(ModelArgs):
         return Path(root) / suffix
 
     def load_state_dict(self):
-        """Load + remap weights via AutoModelForCausalLM (text-only Qwen3_5ForCausalLM).
+        """Load + remap weights via the text-only HF Qwen3_5ForCausalLM.
         Overrides base meta-key loader."""
         from models.demos.blackhole.qwen36.tt.weight_mapping import (
             is_fp8_checkpoint,
@@ -287,13 +287,32 @@ class Qwen36ModelArgs(ModelArgs):
             remap_qwen36_state_dict,
         )
 
-        # Block FP8 checkpoints: dequant + remap for TP loaders (skip AutoModelForCausalLM).
+        # Block FP8 checkpoints: dequant + remap for TP loaders (skip the HF model).
         if is_fp8_checkpoint(self.CKPT_DIR):
             return load_qwen36_state_dict_fp8(self.CKPT_DIR)
 
-        from transformers import AutoModelForCausalLM
+        # Import the HF classes directly rather than going through AutoModelForCausalLM.
+        # Serving out-of-tree, vllm.transformers_utils.config registers vLLM's OWN
+        # Qwen3_5Config for model_type "qwen3_5" into transformers' AutoConfig
+        # (AutoConfig.register(..., exist_ok=True)), so AutoConfig hands back vLLM's class.
+        # transformers only unwraps a composite config to its text sub-config when
+        # `model_class.config_class == config.sub_configs["text_config"]` — an identity
+        # check that cannot hold across libraries — so the composite config would reach
+        # Qwen3_5ForCausalLM and fail on `config.vocab_size` (which lives one level down,
+        # in text_config). Naming the classes here keeps config and model from the same
+        # library, matching vision/vision_model_config.py::reference_vision_model.
+        #
+        # Qwen3_5TextConfig.from_pretrained picks the `text_config` sub-dict on composite
+        # (3.6 VLM) checkpoints via base_config_key, and reads a text-only (3.5) config.json
+        # as-is, so both checkpoint layouts land on the config Qwen3_5ForCausalLM expects.
+        from transformers.models.qwen3_5 import Qwen3_5ForCausalLM, Qwen3_5TextConfig
 
-        model = AutoModelForCausalLM.from_pretrained(self.CKPT_DIR, dtype="auto", trust_remote_code=True)
+        text_config = Qwen3_5TextConfig.from_pretrained(self.CKPT_DIR)
+        assert text_config.vocab_size == self.vocab_size and text_config.hidden_size == self.dim, (
+            f"HF text config disagrees with model args: vocab_size {text_config.vocab_size} vs "
+            f"{self.vocab_size}, hidden_size {text_config.hidden_size} vs {self.dim}"
+        )
+        model = Qwen3_5ForCausalLM.from_pretrained(self.CKPT_DIR, config=text_config, dtype="auto")
         state_dict = remap_qwen36_state_dict(model.state_dict())
         del model
         return state_dict


### PR DESCRIPTION
### Ticket
n/a — found while running the vLLM nightly from the standalone (out-of-tree) plugin.

### Problem description

`Qwen36ModelArgs.load_state_dict` builds the reference HF model with:

```python
model = AutoModelForCausalLM.from_pretrained(self.CKPT_DIR, dtype="auto", trust_remote_code=True)
```

Under the out-of-tree vLLM plugin this dies during weight loading, before the device is touched:

```
File "/work/models/demos/blackhole/qwen36/tt/model_config.py", line 294, in load_state_dict
  model = AutoModelForCausalLM.from_pretrained(self.CKPT_DIR, dtype="auto", trust_remote_code=True)
...
File ".../transformers/models/qwen3_5/modeling_qwen3_5.py", line 1143, in __init__
  self.embed_tokens = nn.Embedding(config.vocab_size, config.hidden_size, config.pad_token_id)
AttributeError: 'Qwen3_5Config' object has no attribute 'vocab_size'
```

Both BH-QB-2 Qwen3.6-27B jobs (`multimodal B=1` and `batch=8`) fail this way, e.g. [this run](https://github.com/tenstorrent/tt-metal/actions/runs/30285333689/job/90043851412).

### Root cause

`Qwen/Qwen3.6-27B`'s `config.json` is composite (`text_config` / `vision_config`); `vocab_size` only exists inside `text_config`. transformers normally unwraps the composite config when a text-only model class is requested, but only under this check (`transformers/models/auto/auto_factory.py`):

```python
model_class = _get_model_class(config, cls._model_mapping)          # transformers.Qwen3_5ForCausalLM
if model_class.config_class == config.sub_configs.get("text_config", None):
    config = config.get_text_config()
```

Upstream vLLM ships its own `Qwen3_5Config`/`Qwen3_5TextConfig` (`vllm/transformers_utils/configs/qwen3_5.py`) and registers them globally at engine startup (`vllm/transformers_utils/config.py`):

```python
def _register_config_class(model_type, config_class):
    config_class.model_type = model_type
    AutoConfig.register(model_type, config_class, exist_ok=True)
```

So in the engine process `AutoConfig` returns **vLLM's** config class, while the model class still comes from transformers' static name-keyed table. The identity check above then compares `transformers.Qwen3_5TextConfig` against `vllm.Qwen3_5TextConfig` — same name, same fields, different class objects — evaluates `False`, the unwrap is skipped, and the composite config reaches `Qwen3_5ForCausalLM.__init__`.

This is not a vLLM bug: vLLM never instantiates transformers' model classes for this architecture (it imports its own config directly in `vllm/model_executor/models/qwen3_5.py`), so its own pairing is consistent. It only bites us because we build a *transformers* network inside vLLM's process.

Why it is green on `main` and red only on out-of-tree-plugin branches: the in-tree vLLM fork has no `qwen3_5` entry in `_CONFIG_REGISTRY`, so nothing overrides transformers' class. Verified across runs — same docker image (`b6194207c0…`), same checkpoint snapshot (`6a9e13bd…`), same tt-metal loader code, in-tree passes / out-of-tree fails. Not a transformers-version issue: the pre-bump `main` nightly on 5.10.2 passed this job.

### What changed

`load_state_dict` now names the HF classes directly instead of going through `AutoModelForCausalLM`, so config and model always come from the same library:

```python
from transformers.models.qwen3_5 import Qwen3_5ForCausalLM, Qwen3_5TextConfig

text_config = Qwen3_5TextConfig.from_pretrained(self.CKPT_DIR)
model = Qwen3_5ForCausalLM.from_pretrained(self.CKPT_DIR, config=text_config, dtype="auto")
```

- `Qwen3_5TextConfig.from_pretrained` extracts the `text_config` sub-dict on composite (3.6 VLM) checkpoints via `base_config_key`, and reads a text-only (3.5) `config.json` as-is — both checkpoint layouts land on the config `Qwen3_5ForCausalLM` expects.
- An assert cross-checks the HF text config against the `ModelArgs` shapes (which still come from `self.hf_config` via `AutoConfig`), so any future divergence between the two config sources fails loudly at load time instead of producing a mis-shaped model.
- `trust_remote_code=True` is dropped: the checkpoint has no `auto_map`, and a direct class import bypasses that mechanism anyway.
- This is the same pattern `vision/vision_model_config.py::reference_vision_model` already uses — which is why the vision half was never affected.

Untouched: the FP8 branch, `remap_qwen36_state_dict` (input keys are the same `model.*` scheme), and everything device-side. In-tree serving and standalone demos/tests are unaffected — the auto path already resolved to exactly these classes there.

### Checklist
- [ ] vLLM nightly (BH-QB-2 Qwen3.6-27B `multimodal B=1` + `batch=8`) from the out-of-tree plugin — the failing jobs
- [ ] vLLM nightly on the in-tree path — no-change check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=viktorpus/qwen36-loader-hf-config)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:viktorpus/qwen36-loader-hf-config)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=viktorpus/qwen36-loader-hf-config)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:viktorpus/qwen36-loader-hf-config)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=viktorpus/qwen36-loader-hf-config)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:viktorpus/qwen36-loader-hf-config)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=viktorpus/qwen36-loader-hf-config)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:viktorpus/qwen36-loader-hf-config)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=viktorpus/qwen36-loader-hf-config)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:viktorpus/qwen36-loader-hf-config)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=viktorpus/qwen36-loader-hf-config)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:viktorpus/qwen36-loader-hf-config)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=viktorpus/qwen36-loader-hf-config)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:viktorpus/qwen36-loader-hf-config)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=viktorpus/qwen36-loader-hf-config)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:viktorpus/qwen36-loader-hf-config)