### PR TITLE
Revert "deepseek_prefill: skip fabric2d mesh-4x2 MoE tests (all-gathe…

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_ttnn_dispatch_combine.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_ttnn_dispatch_combine.py
@@ -423,7 +423,6 @@ def dispatch_combine_shape_params():
 )
 def test_ttnn_dispatch_combine(
     mesh_device,
-    device_params,
     seq_len_per_chip,
     emb_dim,
     num_routed_experts,
@@ -436,11 +435,6 @@ def test_ttnn_dispatch_combine(
     is_ci_env,
     is_ci_v2_env,
 ):
-    if device_params.get("fabric_config") == ttnn.FabricConfig.FABRIC_2D and tuple(mesh_device.shape) == (4, 2):
-        pytest.skip(
-            "fabric2d mesh-4x2 all-gather hang. Revert this skip when "
-            "https://github.com/tenstorrent/tt-metal/issues/50559 is closed."
-        )
     run_dispatch_combine(
         mesh_device,
         seq_len_per_chip,

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_moe_routing_setup.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_moe_routing_setup.py
@@ -114,7 +114,6 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
 @pytest.mark.parametrize("padded_percent", [0, 50], ids=lambda p: f"pad{p}")
 def test_prep_dispatch_combine(
     mesh_device,
-    device_params,
     seq_len_per_chip,
     emb_dim,
     num_routed_experts,
@@ -150,11 +149,6 @@ def test_prep_dispatch_combine(
             dispatch_group_size dimension). Equals global_expert_offsets minus the
             per-source-device local offset.
     """
-    if device_params.get("fabric_config") == ttnn.FabricConfig.FABRIC_2D and tuple(mesh_device.shape) == (4, 2):
-        pytest.skip(
-            "fabric2d mesh-4x2 all-gather hang. Revert this skip when "
-            "https://github.com/tenstorrent/tt-metal/issues/50559 is closed."
-        )
     torch.manual_seed(42)
     num_devices = mesh_device.get_num_devices()
 

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py
@@ -713,11 +713,6 @@ def test_ds_moe(
     request,
     padded_percent,
 ):
-    if device_params.get("fabric_config") == ttnn.FabricConfig.FABRIC_2D and tuple(mesh_device.shape) == (4, 2):
-        pytest.skip(
-            "fabric2d mesh-4x2 all-gather hang. Revert this skip when "
-            "https://github.com/tenstorrent/tt-metal/issues/50559 is closed."
-        )
     run_model(
         variant,
         config_only,

--- a/models/demos/deepseek_v3_d_p/tests/perf/test_prefill_block_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_prefill_block_perf.py
@@ -142,7 +142,7 @@ _SUBTORUS_4X4_HOSTGATE_SKIP = pytest.mark.skip(
         ),
         (
             f"pytest {_TEST_PATH} -k 'fabric2d-mesh-2x4 and layer3 and gate_device and no_ref and isl_6k4'",
-            58_182_777,  # Re-centered 2026-07-30 for two stacked speedups now in the tree -- BOTH
+            56_147_080,  # Re-centered 2026-07-30 for two stacked speedups now in the tree -- BOTH
             # the in-place direct-write change (measured 64.30 ms alone) AND #47536
             # (update_padded_kv_cache RM/fp8; measured 64.80 ms alone). The combined 2x4-2link number
             # can't be measured on the galaxy, so the target is the midpoint of the plausible combined


### PR DESCRIPTION
Reverts this PR since issue was fixed - https://github.com/tenstorrent/tt-metal/issues/50559.

https://github.com/tenstorrent/tt-metal/actions/runs/30365478325

One CI job is red but the tests that were reverted are passing.

Also update perf target for PERF test.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nostojic/restore_skipped_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nostojic/restore_skipped_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nostojic/restore_skipped_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nostojic/restore_skipped_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=nostojic/restore_skipped_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:nostojic/restore_skipped_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nostojic/restore_skipped_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nostojic/restore_skipped_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nostojic/restore_skipped_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nostojic/restore_skipped_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nostojic/restore_skipped_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nostojic/restore_skipped_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nostojic/restore_skipped_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nostojic/restore_skipped_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nostojic/restore_skipped_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nostojic/restore_skipped_tests)