### PR TITLE
#51177: Add an experimental Quasar port of Llama 3.2 1B

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -584,6 +584,7 @@ models/experimental/tt_transformers_v2 @gwangTT @yieldthought @uaydonat @tenstor
 models/experimental/tt_symbiote @alnah005 @mbahnasTT @yieldthought @uaydonat @tenstorrent/codeowner-bypass
 models/experimental/retinanet @dvartaniansTT @tenstorrent/cse-developer-ttnn @tenstorrent/codeowner-bypass
 models/experimental/efficientdetd0 @dvartaniansTT @tenstorrent/cse-developer-ttnn @tenstorrent/codeowner-bypass
+models/experimental/llama32_1b_quasar @tenstorrent/metalium-developers-mmfusedreduce @tenstorrent/codeowner-bypass
 models/**/requirements*.txt @tenstorrent/metalium-developers-infra @tenstorrent/codeowner-bypass
 models/vllm_test_utils/ @viktorpusTT @tchedaTT @uaydonat @tenstorrent/codeowner-bypass
 models/experimental/pi0 @sdawle-TT @dvartaniansTT @tenstorrent/cse-developer-ttnn @tenstorrent/codeowner-bypass

--- a/models/experimental/llama32_1b_quasar/auto_compose.py
+++ b/models/experimental/llama32_1b_quasar/auto_compose.py
@@ -1,0 +1,161 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Automatic composition of multi-device sharded tensors using TensorTopology.
+
+This module provides utilities to infer the correct MeshToTensor composer from a
+sharded ttnn.Tensor's topology metadata and use it to compose shards on host.
+"""
+
+from typing import Optional
+
+import torch
+from loguru import logger
+
+import ttnn
+
+# ======================================================================================
+# Public API
+# ======================================================================================
+
+
+def to_torch_auto_compose(tensor: ttnn.Tensor, device: Optional[ttnn.MeshDevice] = None) -> torch.Tensor:
+    """
+    Convert a (possibly multi-device) TTNN tensor to torch, automatically
+    composing shards based on the tensor's topology.
+
+    Args:
+        tensor: The distributed tensor to convert
+        device: Optional MeshDevice to use when the tensor lives on host
+
+    Returns:
+        PyTorch tensor with shards composed
+    """
+    composer = _infer_mesh_composer_from_topology(tensor, device=device)
+    try:
+        return ttnn.to_torch(tensor, mesh_composer=composer)
+    except Exception as e:
+        logger.error(f"Failed to convert tensor to torch with mesh_composer: {e}")
+        raise
+
+
+def extract_tensor_topology_info(
+    tensor: ttnn.Tensor,
+) -> tuple[list[object], list[int]]:
+    """
+    Extract placements and distribution shape from a tensor's topology.
+
+    Returns:
+        (placements, dist_shape)
+    """
+    topology = tensor.tensor_topology()
+    placements = topology.placements()
+    dist_shape = list(topology.distribution_shape())
+    return placements, dist_shape
+
+
+def get_device_from_tensor(tensor: ttnn.Tensor) -> Optional[ttnn.MeshDevice]:
+    """Get device from tensor or fallback to provided mesh_device."""
+    device = tensor.device()
+    # tensor.device() returns None if the tensor is on the host (ttnn/core/tensor/tensor.cpp --> Tensor::device())
+    if device is None:
+        logger.debug("tensor.device() returns None, tensor is on the host")
+    else:
+        logger.debug(f"tensor.device() returns {device}")
+
+    return device
+
+
+# ======================================================================================
+# Private Implementation
+# ======================================================================================
+
+
+def _infer_mesh_composer_from_topology(
+    tensor: ttnn.Tensor, *, device: Optional[ttnn.MeshDevice] = None
+) -> Optional[ttnn.CppMeshToTensor]:
+    """
+    Return a MeshToTensor composer inferred from the tensor's TensorTopology,
+    or None if no composition is needed (fully replicated, single-device).
+
+    Note: For ND meshes with replicated dimensions, the composer will concatenate
+    all replicas, resulting in duplicated data. Callers may want to slice the
+    result if only one copy is desired.
+
+    Args:
+        tensor: The distributed tensor to infer composer for
+
+    Returns:
+        MeshToTensor composer or None if no composition needed
+    """
+    placements, dist_shape = extract_tensor_topology_info(tensor)
+
+    # No distribution or trivial 1-device case
+    if len(dist_shape) == 0 or (len(dist_shape) == 1 and dist_shape[0] == 1):
+        return None
+
+    tensor_device = get_device_from_tensor(tensor)
+    mesh_device = tensor_device or device
+    if mesh_device is None:
+        # As a last resort, try default device for backward-compatibility
+        mesh_device = ttnn.GetDefaultDevice()
+        if mesh_device is None:
+            raise RuntimeError(
+                "Tensor is on host and no mesh_device provided. "
+                "Pass device=... to to_torch_auto_compose or set a default via ttnn.SetDefaultDevice(...)."
+            )
+
+    # Must match length (should be guaranteed by C++ TT_FATAL in ttnn/core/distributed/distributed_tensor.cpp)
+    assert len(dist_shape) == len(placements)
+
+    if len(dist_shape) == 1 and mesh_device.shape.dims() == 1:
+        return _compose_1d_sharded(mesh_device, placements, dist_shape)
+    else:
+        # N >= 2 dimensions
+        return _compose_nd_sharded(mesh_device, placements, dist_shape)
+
+
+def _compose_1d_sharded(
+    device: ttnn.MeshDevice,
+    placements: list[object],
+    dist_shape: list[int],
+) -> Optional[ttnn.CppMeshToTensor]:
+    """Handle 1D case - returns None if fully replicated."""
+    p = placements[0]
+    if isinstance(p, ttnn.PlacementShard):
+        # Use ND composer with shape override to match the tensor's distribution
+        composer_cfg = ttnn.MeshComposerConfig(dims=[p.dim], mesh_shape_override=ttnn.MeshShape(dist_shape))
+        return ttnn.create_mesh_composer(device, composer_cfg)
+    # Fully replicated - no composition needed
+    return None
+
+
+def _compose_nd_sharded(
+    device: ttnn.MeshDevice,
+    placements: list[object],
+    dist_shape: list[int],
+) -> ttnn.CppMeshToTensor:
+    """
+    Handle ND (N>=2) case.
+
+    For replicated mesh dims, we use dim 0 as convention (the composed result
+    will include all replicas concatenated, which is typically not desired but
+    is how the C++ API works).
+    """
+    dims = []
+    shape_override = []
+    for i, p in enumerate(placements):
+        if isinstance(p, ttnn.PlacementShard):
+            dims.append(p.dim)
+            shape_override.append(dist_shape[i])
+        else:
+            assert isinstance(p, ttnn.PlacementReplicate)
+            # [INFO] steal from TensorDistribution2x4Test test case in test_distributed_tensor.cpp
+            # Replicated: use dim 0 as convention
+            dims.append(0)
+            # Replicated: use shape 1 to skip concatenation
+            shape_override.append(1)
+
+    composer_cfg = ttnn.MeshComposerConfig(dims=dims, mesh_shape_override=ttnn.MeshShape(shape_override))
+    return ttnn.create_mesh_composer(device, composer_cfg)

--- a/models/experimental/llama32_1b_quasar/lightweightmodule.py
+++ b/models/experimental/llama32_1b_quasar/lightweightmodule.py
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+
+class LightweightModule:
+    """Torch modules add a surprising amount of host overhead for attribute
+    access and method calls. This class is a lightweight alternative that
+    just wraps a forward function for now."""
+
+    def __call__(self, *args, **kwargs):
+        return self.forward(*args, **kwargs)

--- a/models/experimental/llama32_1b_quasar/models/executor.py
+++ b/models/experimental/llama32_1b_quasar/models/executor.py
@@ -1,0 +1,3190 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+LLM Executor Engines — thick engines that own prefill/decode implementation.
+
+EagerLLMExecutor  — direct execution (no tracing)
+TracedLLMExecutor — traced execution (capture/replay)
+
+These are reusable engines. Model-specific executors (e.g., EagerLlamaExecutor)
+are thin wrappers that pass the model to these engines.
+
+Design principle: Thick engine, thin model executor.
+- Engine owns the implementation (prefill/decode forward, KV cache, trace capture/replay)
+- Model executor owns the model (passes transformer to engine)
+- Model-specific details come from model.model_args or model attributes
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+import time
+from collections import defaultdict
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import torch
+from loguru import logger
+
+import ttnn
+from models.experimental.llama32_1b_quasar.models.module_input_validation import (
+    suspend_module_input_validation,
+    validate_module_input_configs,
+)
+from models.experimental.llama32_1b_quasar.sampling.sampling_params import SamplingParams
+from models.experimental.llama32_1b_quasar.tests.demos.cleanup_utils import cleanup_ttnn_value
+from models.tt_transformers.tt.common import (
+    Mode,
+    copy_host_to_device,
+    get_block_size,
+    get_max_prefill_chunk_size,
+    get_padded_prefill_len,
+    num_blocks_in_seq,
+)
+
+if TYPE_CHECKING:
+    # Type-only import (annotations are lazy under ``from __future__ import annotations``),
+    # so the optional perf-benchmark profiler adds no runtime import cost / no infra dep.
+    from models.perf.benchmarking_utils import BenchmarkProfiler
+
+# =============================================================================
+# Page Table Helpers
+# =============================================================================
+
+
+def make_contiguous_page_table(
+    batch_size: int,
+    max_seq_len: int,
+    block_size: int,
+) -> torch.Tensor:
+    """Create a simple contiguous page table for demos/tests.
+
+    Returns page_table [batch_size, num_blocks] where each user gets contiguous
+    blocks: user 0 -> [0,1,2,...], user 1 -> [N,N+1,...], etc.
+
+    This is the simplest allocation strategy. For advanced use cases:
+    - Shared prefix: multiple users can point to the same physical blocks
+    - Pooled allocation: vLLM-style dynamic block allocation from a shared pool
+
+    Args:
+        batch_size: Number of users/sequences.
+        max_seq_len: Maximum sequence length per user.
+        block_size: KV cache block size (tokens per block).
+
+    Returns:
+        Page table tensor [batch_size, num_blocks], dtype int32.
+    """
+    num_blocks_per_user = (max_seq_len + block_size - 1) // block_size
+    page_table = torch.zeros(batch_size, num_blocks_per_user, dtype=torch.int32)
+    for user_id in range(batch_size):
+        start_block = user_id * num_blocks_per_user
+        page_table[user_id] = torch.arange(start_block, start_block + num_blocks_per_user, dtype=torch.int32)
+    return page_table
+
+
+# =============================================================================
+# Batched prefill (partial B=8) — predicate + slot packing + per-bucket grouping
+# =============================================================================
+# TTTv2 normally prefills 32 users in a sequential per-user loop (32 forward passes). When a group of
+# users shares the same padded prefill length and has no prefix cache, those passes can be fused into
+# batched passes over a folded [1, 1, padded_batch*S, dim] tensor — a single-pass-per-group device
+# workload that utilises the core grid far better than the 32 small S=128 passes. This closes the
+# batch-32 TTFT gap vs TTTv1. Predicate ported from TTTv1 generator.py use_batched_prefill (L631-691),
+# capped at `max_prefill_batch_size` (default 8) for partial batching — most of the win, far less DRAM
+# risk than full B=32.
+#
+# Composition with the Phase-1 per-bucket TTFT fix: the Phase-1 fix restored per-bucket prefill (each
+# user prefills at its OWN get_padded_prefill_len bucket, with a SHARED persistent cos/sin so ≥2
+# bucket traces coexist correctly). Batched prefill therefore fires PER UNIFORM-LENGTH BUCKET GROUP —
+# _group_slots_by_prefill_bucket splits empty_slots by bucket, and the predicate is applied per group.
+# A mixed batch {128,1024} thus batches the 128-bucket users together and the 1024-bucket users
+# together (≥2 coexisting BATCHED traces), rather than declining the whole batch. The batched trace
+# body sources cos/sin from the SAME shared persistent tensor (never a fresh per-capture slice) so the
+# mixed-bucket aliasing the Phase-1 fix cured cannot return under batching.
+
+# Mirror of TTTv1 generator.py constants.
+SUPPORTED_PREFILL_BATCH_SIZES = (1, 2, 4, 8, 16, 32)
+MAX_BATCHED_PREFILL_SEQ_LEN = 128 * 1024
+
+# A/B escape hatch: set TTT_BATCHED_EXTRACT_HOST_GATHER=1 to force the legacy host-gather last-token
+# extraction (reads the whole folded [1,1,B*S,dim] hidden to host, gathers on host, re-uploads).
+# Default (unset) uses the on-device selection-matmul gather, which keeps the hidden on device and
+# reads back only the [1,1,32,vocab] logits — closing the batch-32 prefill-TTFT gap vs TTTv1. Kept
+# only for before/after measurement; the on-device path is bit-identical (see _gather_last_tokens_*).
+_BATCHED_EXTRACT_HOST_GATHER = bool(os.environ.get("TTT_BATCHED_EXTRACT_HOST_GATHER"))
+
+
+def select_batched_prefill_padded_batch(model_args, batch_size, prefill_seq_lens, num_cached_per_user):
+    """Return the per-group batch size for batched prefill, or ``None`` to use the sequential loop.
+
+    Conditions (TTTv1 parity, design §4):
+      - ``batch_size > 1`` and ``model_args`` present,
+      - per-model opt-in (``supports_batched_prefill``) and not disabled (``disable_batched_prefill``),
+      - all users share one padded prefill length (uniform ``prefill_seq_lens``),
+      - no prefix caching (all ``num_cached_per_user == 0``; the batched path feeds full tokens),
+      - ``data_parallel == 1``,
+      - ``seq <= max_prefill_chunk_size`` (chunked prompts stay sequential — batching buys no
+        single-pass win and re-introduces the DRAM pressure chunking relieves, tt-metal #45234),
+      - ``padded_batch * seq < MAX_BATCHED_PREFILL_SEQ_LEN`` (DRAM / all-gather guard).
+
+    ``padded_batch`` is the smallest supported batch size >= ``min(batch_size, max_prefill_batch_size)``;
+    32 users with the default cap of 8 therefore run as 4 batched passes of 8. This predicate is applied
+    per uniform-length bucket group (see _group_slots_by_prefill_bucket), not to the whole batch.
+    """
+    if model_args is None or batch_size <= 1:
+        return None
+    # Opt-in: only models whose prefill_forward threads `batch_size` (and that set this flag) may use
+    # the batched path. Unmodified models fall through to the sequential loop — never crash.
+    if not getattr(model_args, "supports_batched_prefill", False):
+        return None
+    if getattr(model_args, "disable_batched_prefill", False):
+        return None
+    if len(set(prefill_seq_lens)) != 1:
+        return None
+    if any(n != 0 for n in num_cached_per_user):
+        return None
+    if getattr(model_args, "data_parallel", 1) != 1:
+        return None
+    seq = int(prefill_seq_lens[0])
+    max_chunk = getattr(model_args, "max_prefill_chunk_size", seq)
+    if max_chunk is not None and seq > max_chunk:
+        return None
+    cap = getattr(model_args, "max_prefill_batch_size", 8) or 8
+    group = min(batch_size, cap)
+    padded_batch = next((b for b in SUPPORTED_PREFILL_BATCH_SIZES if b >= group), group)
+    if padded_batch > batch_size:
+        # Never clamp to a non-power-of-2 count. The folded QKV matmul reshapes [1,1,padded_batch*seq,·]
+        # into MAX_QKV_MM_SEQ_LEN(2048)-length chunks (attention_1d.py); a fold longer than 2048 that is
+        # not a multiple of 2048 raises. Clamping padded_batch straight to batch_size produced exactly
+        # that for group sizes in (16,32) — e.g. a 30-user rotation folded to 3840 and crashed. Snap to
+        # the largest SUPPORTED (power-of-2) bucket <= batch_size instead: the fold is then always
+        # reshape-safe (power-of-2 * 128), and the sub-group loop prefills the trailing remainder as a
+        # partial (eager) sub-group — the same partial path the default cap=8 already exercises. So 32
+        # users fold in one pass while a 30-user group folds as 16 + 14. (TTTv1 instead pads UP to the
+        # bucket and fills padding slots; this keeps TTTv2's no-pad-waste design and stays safe.)
+        padded_batch = max((b for b in SUPPORTED_PREFILL_BATCH_SIZES if b <= batch_size), default=1)
+    if padded_batch <= 1:
+        return None
+    if padded_batch * seq >= MAX_BATCHED_PREFILL_SEQ_LEN:
+        return None
+    return padded_batch
+
+
+def _group_slots_by_prefill_bucket(empty_slots, prompt_lens, num_cached_per_user):
+    """Group ``empty_slots`` (positions in the batch) by their padded prefill bucket.
+
+    Returns an ordered dict ``{prefill_seq_len: [positions]}`` where each position ``i`` indexes
+    ``empty_slots``/``prompt_lens``/``num_cached_per_user`` (NOT the physical slot). Positions whose
+    ``prompt_lens[i] - num_cached_per_user[i] <= 0`` (nothing to prefill) are dropped — the caller
+    handles those in the sequential skip path. Buckets are returned in first-seen order so the
+    dispatch is deterministic across repeats (matches the sequential loop's slot order).
+    """
+    groups: dict[int, list[int]] = {}
+    for i in range(len(empty_slots)):
+        new_tokens = int(prompt_lens[i]) - num_cached_per_user[i]
+        if new_tokens <= 0:
+            continue
+        bucket = get_padded_prefill_len(new_tokens)
+        groups.setdefault(bucket, []).append(i)
+    return groups
+
+
+def _plan_batched_prefill(model_args, empty_slots, prompt_lens, num_cached_per_user):
+    """Decide which positions batch (per bucket) and which stay sequential.
+
+    Returns ``(batched_groups, sequential_positions)`` where:
+      - ``batched_groups`` is a list of ``(prefill_seq_len, padded_batch, positions)`` — one entry per
+        uniform-length bucket group that satisfies the predicate; ``positions`` index ``empty_slots``.
+      - ``sequential_positions`` is the set of positions NOT covered by any batched group (buckets that
+        declined batching, e.g. a lone user or a bucket the predicate rejected).
+
+    When ``batched_groups`` is empty every position is sequential and the caller's original per-user
+    loop runs unchanged — the ``DISABLE_BATCHED_PREFILL`` / non-opted-in / batch<=1 path is therefore
+    byte-identical to the pre-feature code.
+    """
+    groups = _group_slots_by_prefill_bucket(empty_slots, prompt_lens, num_cached_per_user)
+    batched_groups = []
+    sequential_positions: set[int] = set()
+    for bucket, positions in groups.items():
+        group_seq_lens = [bucket] * len(positions)
+        group_cached = [num_cached_per_user[i] for i in positions]
+        padded_batch = select_batched_prefill_padded_batch(model_args, len(positions), group_seq_lens, group_cached)
+        if padded_batch is not None:
+            batched_groups.append((bucket, padded_batch, positions))
+        else:
+            sequential_positions.update(positions)
+    return batched_groups, sequential_positions
+
+
+def _build_batched_prefill_group(tokens, prompt_lens, page_table, positions, padded_batch, prefill_seq_len, block_size):
+    """Pack one group of users into folded batched-prefill inputs.
+
+    ``positions`` are the (up to ``padded_batch``) positional row indices into
+    ``tokens``/``prompt_lens``/``page_table`` for the real users in this group — the same integers the
+    plan uses to index ``empty_slots``, since those tensors are laid out in empty-slot order. Returns
+    ``(folded_tokens [1, padded_batch*prefill_seq_len], group_page_table [padded_batch, num_blocks],
+    group_idxs, last_token_idxs)``. ``group_idxs`` are those row indices (used to index
+    ``tokens``/``prompt_lens``/the output); the page table is built with one LOCAL row per real user
+    (row i = that user's physical blocks), so the attention KV-fill loop and the captured trace use
+    local batch_idx 0..padded_batch-1 — identical across every group, which lets a single trace replay
+    for all groups.
+    """
+    num_blocks = num_blocks_in_seq(prefill_seq_len, block_size)
+    folded = torch.zeros(1, padded_batch * prefill_seq_len, dtype=tokens.dtype)
+    group_pt = torch.zeros(padded_batch, num_blocks, dtype=torch.int32)
+    group_idxs = list(positions[:padded_batch])
+    last_token_idxs = []
+    for local_i, idx in enumerate(group_idxs):
+        sl = int(prompt_lens[idx])
+        folded[0, local_i * prefill_seq_len : local_i * prefill_seq_len + sl] = tokens[idx, :sl]
+        group_pt[local_i] = page_table[idx, :num_blocks]
+        last_token_idxs.append(sl - 1)
+    return folded, group_pt, group_idxs, last_token_idxs
+
+
+def _build_decode_topk_param_tensors(mesh_device, sampling_params, batch_size, allow_force_argmax=True):
+    """Build replicated (k, p, temp) device tensors for ``Sampling1D``'s top-k path.
+
+    Reuses ``format_sampling_params`` (so temperature inversion, top-p clamping and the
+    ``temp==0 -> k=1`` rewrite match TTTv1 / PERF.md exactly), then mirrors TTSampling's
+    1D layout: ROW_MAJOR, uint32 k / bfloat16 p / bfloat16 temp, replicated across the mesh.
+
+    Returns ``None`` **only when force-argmax is allowed** and the formatted params reduce to
+    greedy (all k==1, p==0, temp==1) — the caller then uses the cheaper full-vocab argmax path.
+    When ``allow_force_argmax`` is False the model has no argmax path, so greedy params must
+    still build real tensors and route through the top-k op (k=1 top-k == argmax-via-topk),
+    exactly as TTTv1 does for the ``temp=0`` PERF.md recipe — never returning ``None``.
+
+    Note: ``format_sampling_params`` rewrites every ``temp==0`` row to ``(temp=1, k=1, p=0)``
+    (generator.py:512-517) — top_p is zeroed too — so the PERF.md ``temp=0, top_k=32, top_p=0.08``
+    recipe reduces to the greedy representation, not ``k=1/p=0.08/temp=1``.
+    """
+    from models.experimental.llama32_1b_quasar.sampling import format_sampling_params
+
+    # format_sampling_params asserts the batch is a multiple of 32; round up for the call (the
+    # greedy params are uniform/broadcast) then slice back to batch_size. This lets the argmax
+    # reduction below return None for batch_size < 32 (argmax works at any batch) instead of
+    # tripping that assert before we ever reach the check.
+    fmt_len = ((batch_size + 31) // 32) * 32
+    fmt = format_sampling_params(sampling_params, fmt_len)
+    k = list(fmt.top_k)[:batch_size]
+    p = list(fmt.top_p)[:batch_size]
+    temp = list(fmt.temperature)[:batch_size]
+
+    if allow_force_argmax and all(kk == 1 for kk in k) and all(pp == 0 for pp in p) and all(tt == 1 for tt in temp):
+        return None
+
+    mapper = ttnn.ReplicateTensorToMesh(mesh_device)
+    k_tt = ttnn.from_torch(
+        torch.tensor(k, dtype=torch.int32),
+        device=mesh_device,
+        dtype=ttnn.uint32,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        mesh_mapper=mapper,
+    )
+    p_tt = ttnn.from_torch(
+        torch.tensor(p, dtype=torch.float32),
+        device=mesh_device,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        mesh_mapper=mapper,
+    )
+    temp_tt = ttnn.from_torch(
+        torch.tensor(temp, dtype=torch.float32),
+        device=mesh_device,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        mesh_mapper=mapper,
+    )
+    return k_tt, p_tt, temp_tt
+
+
+# =============================================================================
+# Protocol: LLMModel
+# =============================================================================
+# The engine expects a model with these attributes/methods. This is a duck-typed
+# protocol, not a formal interface (no ABC). Any model that provides these can
+# be used with the engine.
+#
+# Required attributes:
+#   - vocab_size: int
+#   - n_layers: int
+#   - num_devices: int
+#   - rope_setup: has .get_rot_idxs(), .get_rot_mats(), .cos_matrix, .sin_matrix, .load_device_weights()
+#   - sampling: Sampling1D | None
+#   - mesh_device: ttnn.MeshDevice
+#
+# Required methods:
+#   - embed_prefill(tokens_tt) -> ttnn.Tensor
+#   - embed_decode(tokens_tt) -> ttnn.Tensor
+#   - prefill_forward(x_embed, rot_mats, user_id, page_table, chunk_page_table, chunk_start_idx, get_last_token) -> ttnn.Tensor
+#   - post_process_prefill_output(hidden_states, last_token_idx) -> ttnn.Tensor
+#   - decode_forward(x_embed, current_pos, rot_mats, page_table) -> ttnn.Tensor
+#   - gather_and_untilize_logits(logits) -> ttnn.Tensor
+#   - increment_positions(current_pos, rot_mat_idxs) -> None
+#   - set_kv_cache(kv_cache) -> None
+
+
+# =============================================================================
+# Output Spec — captures device-level tensor spec from compile
+# =============================================================================
+
+
+@dataclass
+class TensorSpec:
+    """Captured tensor specification from compile warmup run.
+
+    These specs describe what the executor produces. Useful for:
+    - Multi-CQ output buffer pre-allocation
+    - Exit-boundary validation
+    - Downstream consumer contracts
+    """
+
+    shape: tuple[int, ...]
+    dtype: ttnn.DataType
+    layout: ttnn.Layout
+    memory_config: ttnn.MemoryConfig | None = None
+
+    @classmethod
+    def from_tensor(cls, tensor: ttnn.Tensor) -> TensorSpec:
+        """Capture spec from an actual device tensor."""
+        return cls(
+            shape=tuple(tensor.shape),
+            dtype=tensor.dtype,
+            layout=tensor.layout,
+            memory_config=tensor.memory_config() if tensor.is_allocated() else None,
+        )
+
+
+# =============================================================================
+# EagerLLMExecutor — thick engine for direct execution
+# =============================================================================
+
+
+class EagerLLMExecutor:
+    """Eager executor engine — owns prefill/decode implementation.
+
+    Common LLM operations live here. Model-specific details come from
+    the model object (model.model_args).
+
+    This is a thick engine: it owns the full implementation of prefill/decode,
+    including input prep, output processing, chunked prefill, and KV cache allocation.
+
+    Attributes:
+        model: Transformer model with prefill_forward(), decode_forward(), model_args.
+        mesh_device: TT mesh device for execution.
+        mode: Current execution mode (PREFILL or DECODE).
+        prefill_output_spec: Captured output spec from compile_prefill().
+        decode_output_spec: Captured output spec from compile_decode().
+    """
+
+    def __init__(self, model, mesh_device: ttnn.MeshDevice, iter_named_modules=None) -> None:
+        """Initialize eager executor engine.
+
+        Args:
+            model: Transformer model with prefill_forward(), decode_forward(), model_args, etc.
+            mesh_device: TT mesh device for execution.
+        """
+        self.model = model
+        self.mesh_device = mesh_device
+        self._iter_named_modules = iter_named_modules
+        self.mode = None
+        self._kv_cache: list | None = None
+
+        # todo)) this could be a composed optional for debug!
+        # Output specs captured during compile (for multi-CQ pre-allocation)
+        self.prefill_output_spec: TensorSpec | None = None
+        self.decode_output_spec: TensorSpec | None = None
+
+    @property
+    def model_args(self):
+        """Model args come from the model object."""
+        return getattr(self.model, "model_args", None)
+
+    # =========================================================================
+    # KV Cache
+    # =========================================================================
+
+    def allocate_kv_cache(
+        self,
+        kv_cache_shape: tuple[int, ...],  # [num_blocks, num_heads, block_size, head_dim]
+        dtype: torch.dtype,
+        num_layers: int,
+    ) -> list[list[ttnn.Tensor]]:
+        """Allocate paged KV cache on device. Returns list[list[ttnn.Tensor]]."""
+        cache_kv = torch.zeros(kv_cache_shape, dtype=dtype)
+        kv_cache = []
+        cache_path = self.model_args.model_cache_path if self.model_args else None
+
+        for layer_num in range(num_layers):
+            kv_cache_dtype = ttnn.bfloat8_b
+            ma = self.model_args
+            if ma is not None:
+                explicit = getattr(ma, "kv_cache_dtype", None)
+                if explicit is not None:
+                    kv_cache_dtype = explicit
+                elif getattr(ma, "optimizations", None) is not None:
+                    from models.tt_transformers.tt.model_config import TensorGroup
+
+                    configured = ma.optimizations.get_tensor_dtype(decoder_id=layer_num, tensor=TensorGroup.KV_CACHE)
+                    if configured is not None:
+                        kv_cache_dtype = configured
+
+            # todo)) this could be lazy weight?
+            # todo)) use ttnn.zeros() directly instead of as_tensor?
+            kv_tt_i = [
+                ttnn.as_tensor(
+                    cache_kv,
+                    device=self.mesh_device,
+                    mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
+                    layout=ttnn.TILE_LAYOUT,
+                    memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                    dtype=kv_cache_dtype,
+                    cache_file_name=(
+                        cache_path / f"empty_{kv}cache_paged_attention{kv_cache_shape}" if cache_path else None
+                    ),
+                )
+                for kv in ["k", "v"]
+            ]
+            kv_cache.append(kv_tt_i)
+
+        self._kv_cache = kv_cache
+        self.model.set_kv_cache(kv_cache)
+        return kv_cache
+
+    # =========================================================================
+    # On-device sampling routing (argmax vs top-k op path)
+    # =========================================================================
+
+    def _sampling_decode_forward(self, logits, sampling_params, tt_out_tok=None):
+        """Run ``model.sampling`` on device, choosing the path that matches PERF.md.
+
+        Routing depends on the model's ``allow_force_argmax``:
+          * ``allow_force_argmax=True``  — greedy params reducing to (k==1, p==0, temp==1) take
+            the force-argmax full-vocab all-gather path (``decode_forward`` with no k/p/temp).
+          * ``allow_force_argmax=False`` (the 1B/7B recipe) — there is no argmax path, so *every*
+            recipe, greedy included, builds k/p/temp tensors and takes the **top-k op path**:
+            per-device ``ttnn.topk`` → barrier-free all-gather of the ``[*,32]`` tuples →
+            ``ttnn.sampling``. This mirrors TTTv1, whose ``temp=0`` PERF.md recipe always runs
+            ``ttnn.topk`` (``format_sampling_params`` rewrites ``temp=0`` to the greedy k=1/p=0/temp=1
+            representation, so k=1 top-k == argmax-via-topk).
+
+        The k/p/temp tensors are built once and cached so the *same* persistent device
+        tensors are referenced during trace warmup, capture and replay (greedy decode
+        keeps them constant, so no per-step update is needed).
+        """
+        kpt = self._get_decode_sampling_kpt(sampling_params)
+        if kpt is None:
+            return self.model.sampling.decode_forward(logits, tt_out_tok=tt_out_tok)
+        k_tt, p_tt, temp_tt = kpt
+        return self.model.sampling.decode_forward(logits, k=k_tt, p=p_tt, temp=temp_tt, tt_out_tok=tt_out_tok)
+
+    def _get_decode_sampling_kpt(self, sampling_params):
+        """Lazily build + cache (k, p, temp) device tensors, or None for force-argmax."""
+        if getattr(self, "_decode_sampling_kpt_built", False):
+            return self._decode_sampling_kpt
+        self._decode_sampling_kpt = _build_decode_topk_param_tensors(
+            self.mesh_device,
+            sampling_params,
+            self.model.sampling.config.max_batch_size,
+            allow_force_argmax=self.model.sampling.config.allow_force_argmax,
+        )
+        self._decode_sampling_kpt_built = True
+        return self._decode_sampling_kpt
+
+    def _assert_kv_cache_identity(self, kv_cache):
+        """Verify kv_cache passed to forward is the same object bound at allocation."""
+        if kv_cache is not None and self._kv_cache is not None:
+            assert kv_cache is self._kv_cache, (
+                "kv_cache passed to forward differs from the allocated cache. "
+                "Call allocate_kv_cache() again after reallocating."
+            )
+
+    # =========================================================================
+    # Input Preparation
+    # =========================================================================
+
+    def _prepare_prefill_device_inputs(
+        self, tokens, page_table, start_pos=0, chunk_page_table=None, last_token_idx=None
+    ):
+        """Prepare eager prefill device inputs. Returns (tokens_embd, cos, sin, page_table_tt, chunk_page_table_tt).
+
+        Args:
+            tokens: Input tokens [1, seq_len].
+            page_table: Page table for paged attention [1, num_blocks]. Required.
+            start_pos: Starting position for prefix caching.
+            chunk_page_table: Chunk page table for chunked prefill (optional, derived from page_table).
+            last_token_idx: Index of last token for output extraction.
+        """
+        assert tokens.dim() == 2, "tokens must be 2D"
+        tokens_reshaped = tokens.reshape(1, 1, 1, -1)
+        S = tokens_reshaped.shape[-1]
+        tokens_tt = ttnn.from_torch(
+            tokens_reshaped,
+            device=self.mesh_device,
+            dtype=ttnn.uint32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
+        )
+
+        tokens_embd = self.model.embed_prefill(tokens_tt)
+
+        # todo)) this rope code could be refactored?
+        rope = self.model.rope_setup
+        rope.load_device_weights()
+        mat_len = rope.cos_matrix.shape[2]
+        seq_len = last_token_idx + 1 if last_token_idx is not None else S
+        assert mat_len >= seq_len, f"Sequence length {seq_len} exceeds max seq len {mat_len}"
+
+        required_end = start_pos + S
+        pad_len = max(0, required_end - mat_len)
+
+        prefill_start = start_pos
+        slice_end = min(mat_len, required_end)
+
+        cos_slice = rope.cos_matrix[:, :, prefill_start:slice_end, :]
+        sin_slice = rope.sin_matrix[:, :, prefill_start:slice_end, :]
+
+        if pad_len > 0:
+            padding = [(0, 0)] * 4
+            padding[2] = (0, pad_len)
+            cos_slice = ttnn.pad(cos_slice, padding=padding, value=0.0)
+            sin_slice = ttnn.pad(sin_slice, padding=padding, value=0.0)
+
+        tt_page_table = ttnn.from_torch(
+            page_table,
+            device=self.mesh_device,
+            dtype=ttnn.int32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
+        )
+
+        # NOTE: this is a dynamic feature because it depends on seq_len
+        tt_chunk_page_table = None
+        if chunk_page_table is not None:
+            tt_chunk_page_table = ttnn.from_torch(
+                chunk_page_table,
+                device=self.mesh_device,
+                dtype=ttnn.int32,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+                mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
+            )
+
+        return (
+            tokens_embd,
+            cos_slice,
+            sin_slice,
+            tt_page_table,
+            tt_chunk_page_table,
+        )
+
+    def prepare_decode_inputs_host(self, tokens, current_pos, page_table):
+        """Prepare decode inputs as host tensors. Returns (tokens, current_pos, rope_idxs, page_table).
+
+        Args:
+            tokens: Input tokens [batch_size].
+            current_pos: Current position per user [batch_size].
+            page_table: Page table for paged attention [batch_size, max_blocks]. Required.
+        """
+        B = tokens.shape[0]
+        max_batch = self.model_args.max_batch_size if self.model_args else B
+        assert B == max_batch, f"Batch size {B} must equal max_batch_size {max_batch}"
+
+        tokens_padded = torch.nn.functional.pad(tokens.view(-1), (0, 32 - len(tokens)), "constant", 0)
+        tokens_tt = ttnn.from_torch(
+            tokens_padded,
+            device=None,
+            dtype=ttnn.uint32,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
+        )
+        tokens_tt = ttnn.unsqueeze_to_4D(tokens_tt)
+
+        rot_current_pos = torch.maximum(current_pos, torch.tensor(0, dtype=torch.int64))
+        rope_idxs = self.model.rope_setup.get_rot_idxs(rot_current_pos, on_host=True)
+
+        cluster_shape = self.model_args.cluster_shape if self.model_args else [1, 1]
+        current_pos_tt = ttnn.from_torch(
+            current_pos,
+            device=None,
+            dtype=ttnn.int32,
+            mesh_mapper=ttnn.ShardTensor2dMesh(
+                self.mesh_device,
+                dims=(None, None),
+                mesh_shape=cluster_shape,
+            ),
+        )
+
+        tt_page_table = ttnn.from_torch(
+            page_table,
+            device=None,
+            dtype=ttnn.int32,
+            mesh_mapper=ttnn.ShardTensor2dMesh(
+                self.mesh_device,
+                dims=(None, None),
+                mesh_shape=cluster_shape,
+            ),
+        )
+
+        return tokens_tt, current_pos_tt, rope_idxs, tt_page_table
+
+    # todo)) inline this function
+    def prepare_decode_inputs_device(self, tokens, current_pos, page_table):
+        """Prepare decode inputs on device. Returns device tensors."""
+        host_inputs = self.prepare_decode_inputs_host(tokens, current_pos, page_table)
+        return copy_host_to_device(host_inputs, mesh_device=self.mesh_device)
+
+    # =========================================================================
+    # Compile
+    # =========================================================================
+
+    def compile_prefill(
+        self,
+        *,
+        tokens: torch.Tensor,  # [batch_size, seq_len], int64
+        page_table: torch.Tensor,  # [batch_size, max_blocks], int32
+        kv_cache: list[list[ttnn.Tensor]] | None = None,
+        prompt_lens: torch.Tensor | None = None,  # [batch_size], int64
+        empty_slots: list[int] | None = None,
+        start_pos: torch.Tensor | None = None,  # [batch_size], int64
+        sampling_params: SamplingParams | None = None,  # accepted for parity; eager path never traces
+    ) -> torch.Tensor:  # [batch_size, 1, vocab_size], float32
+        """Compile prefill for specific inputs. Returns logits from warmup run.
+
+        Also captures output spec for multi-CQ pre-allocation.
+
+        Args:
+            tokens: Input token IDs, shape [batch_size, seq_len].
+            page_table: Page table for paged attention, shape [batch_size, max_blocks]. Required.
+            kv_cache: Per-layer KV cache from allocate_kv_cache().
+            prompt_lens: Actual prompt length per user, shape [batch_size].
+            empty_slots: List of user IDs to prefill.
+            start_pos: Starting position for prefix caching, shape [batch_size].
+
+        Returns:
+            Logits tensor, shape [batch_size, 1, vocab_size].
+        """
+        # Boundary assertions
+        assert tokens.dim() == 2, f"tokens must be [batch_size, seq_len], got {tokens.dim()}D"
+        assert page_table.dim() == 2, f"page_table must be [batch_size, max_blocks], got {page_table.dim()}D"
+        if prompt_lens is not None:
+            assert prompt_lens.dim() == 1, f"prompt_lens must be [batch_size], got {prompt_lens.dim()}D"
+        if start_pos is not None:
+            assert start_pos.dim() == 1, f"start_pos must be [batch_size], got {start_pos.dim()}D"
+
+        logits = self.prefill_forward(
+            tokens,
+            page_table=page_table,
+            kv_cache=kv_cache,
+            prompt_lens=prompt_lens,
+            empty_slots=empty_slots,
+            start_pos=start_pos,
+        )
+        ttnn.synchronize_device(self.mesh_device)
+
+        # Capture output spec (logits is host tensor here, so just record shape/dtype)
+        # todo)) use TensorSpec.from_tensor() directly? logits is torch.tensor though so may need new function/method
+        self.prefill_output_spec = TensorSpec(
+            shape=tuple(logits.shape),
+            dtype=ttnn.bfloat16,  # Model output dtype
+            layout=ttnn.TILE_LAYOUT,
+            memory_config=None,  # Host tensor
+        )
+
+        return logits
+
+    def compile_decode(
+        self,
+        *,
+        tokens: torch.Tensor,  # [batch_size], int64
+        start_pos: torch.Tensor,  # [batch_size], int64
+        page_table: torch.Tensor,  # [batch_size, max_blocks], int32
+        kv_cache: list[list[ttnn.Tensor]] | None = None,
+        sampling_params: SamplingParams | None = None,
+    ) -> None:
+        """Compile decode for specific inputs. One warmup run, discard output.
+
+        Also captures output spec for multi-CQ pre-allocation.
+
+        Args:
+            tokens: Input token IDs, shape [batch_size].
+            start_pos: Current position per user, shape [batch_size].
+            page_table: Page table for paged attention, shape [batch_size, max_blocks]. Required.
+            kv_cache: Per-layer KV cache from allocate_kv_cache().
+            sampling_params: Sampling parameters for on-device sampling.
+        """
+        # Boundary assertions
+        assert tokens.dim() == 1, f"tokens must be [batch_size], got {tokens.dim()}D"
+        assert start_pos.dim() == 1, f"start_pos must be [batch_size], got {start_pos.dim()}D"
+        assert page_table.dim() == 2, f"page_table must be [batch_size, max_blocks], got {page_table.dim()}D"
+
+        output = self.decode_forward(
+            tokens,
+            start_pos,
+            page_table=page_table,
+            kv_cache=kv_cache,
+            read_from_device=False,
+            sampling_params=sampling_params,
+        )
+        ttnn.synchronize_device(self.mesh_device)
+
+        # Capture output spec from device tensor
+        logits_or_tokens, _ = output
+        if isinstance(logits_or_tokens, ttnn.Tensor) and logits_or_tokens.is_allocated():
+            self.decode_output_spec = TensorSpec.from_tensor(logits_or_tokens)
+
+    def compile(
+        self,
+        *,
+        prefill_tokens: torch.Tensor,  # [batch_size, seq_len], int64
+        prefill_page_table: torch.Tensor,  # [batch_size, max_blocks], int32
+        kv_cache: list[list[ttnn.Tensor]] | None = None,
+        prompt_lens: torch.Tensor | None = None,  # [batch_size], int64
+        empty_slots: list[int] | None = None,
+        start_pos: torch.Tensor | None = None,  # [batch_size], int64
+        sampling_params: SamplingParams | None = None,
+        validate_configs: bool = False,
+    ) -> None:
+        """One-shot prefill + decode warmup compile.
+
+        Convenience wrapper that compiles both prefill and decode for the given
+        inputs (one warmup run each, output specs captured along the way). This is
+        the per-instance counterpart to ``compile_prefill()`` / ``compile_decode()``
+        and delegates to the same internal helper used by ``run_teacher_forcing()``.
+
+        Args:
+            prefill_tokens: Prefill token IDs, shape [batch_size, seq_len].
+            prefill_page_table: Page table for paged attention, shape
+                [batch_size, max_blocks]. Required.
+            kv_cache: Per-layer KV cache from allocate_kv_cache().
+            prompt_lens: Actual prompt length per user, shape [batch_size].
+            empty_slots: List of user IDs to prefill.
+            start_pos: Starting position for prefix caching, shape [batch_size].
+            sampling_params: Sampling parameters for on-device decode sampling.
+            validate_configs: When True, instrument the warmup passes to check that
+                each module's actual input memory config matches its declared config
+                (see ``_validate_module_configs``). Defaults to False.
+        """
+        _compile_prefill_and_decode(
+            self,
+            prefill_tokens=prefill_tokens,
+            prefill_page_table=prefill_page_table,
+            kv_cache=kv_cache,
+            prompt_lens=prompt_lens,
+            empty_slots=empty_slots,
+            start_pos=start_pos,
+            sampling_params=sampling_params,
+            validate_configs=validate_configs,
+        )
+
+    def _validate_module_configs(self, *, mode: str):
+        """Context manager that validates module input configs for one forward pass.
+
+        Instruments the model's modules during a single ``mode`` ("prefill" or
+        "decode") forward pass and checks that each module's actual input memory
+        config matches the config it declares. Returns a no-op context when this
+        executor has no ``iter_named_modules`` hook.
+
+        Usage::
+
+            with executor._validate_module_configs(mode="prefill"):
+                executor.compile_prefill(...)
+        """
+        return _get_validation_context(self, mode=mode)
+
+    # =========================================================================
+    # Prefill Forward
+    # =========================================================================
+
+    def prefill_forward(
+        self,
+        tokens: torch.Tensor,  # [batch_size, seq_len], int64
+        page_table: torch.Tensor,  # [batch_size, max_blocks], int32
+        kv_cache: list[list[ttnn.Tensor]] | None = None,
+        prompt_lens: torch.Tensor | None = None,  # [batch_size], int64
+        empty_slots: list[int] | None = None,
+        sampling_params: SamplingParams | None = None,
+        start_pos: torch.Tensor | None = None,  # [batch_size], int64
+    ) -> torch.Tensor:  # [batch_size, 1, vocab_size], float32
+        """Per-user prefill loop with chunked prefill + prefix caching.
+
+        Args:
+            tokens: Input token IDs, shape [batch_size, seq_len].
+            page_table: Page table for paged attention, shape [batch_size, max_blocks]. Required.
+            kv_cache: Per-layer KV cache from allocate_kv_cache().
+            prompt_lens: Actual prompt length per user, shape [batch_size].
+            empty_slots: List of user IDs to prefill.
+            sampling_params: Sampling parameters (not used in prefill).
+            start_pos: Starting position for prefix caching, shape [batch_size].
+
+        Returns:
+            Logits tensor, shape [batch_size, 1, vocab_size].
+        """
+        # Boundary assertions
+        assert tokens.dim() == 2, f"tokens must be [batch_size, seq_len], got {tokens.dim()}D"
+        assert page_table.dim() == 2, f"page_table must be [batch_size, max_blocks], got {page_table.dim()}D"
+        if prompt_lens is not None:
+            assert prompt_lens.dim() == 1, f"prompt_lens must be [batch_size], got {prompt_lens.dim()}D"
+        if start_pos is not None:
+            assert start_pos.dim() == 1, f"start_pos must be [batch_size], got {start_pos.dim()}D"
+        self.mode = Mode.PREFILL
+        self._assert_kv_cache_identity(kv_cache)
+
+        batch_size, batch_seq_len = tokens.shape
+        vocab_size = self.model.vocab_size
+        cluster_shape = self.model_args.cluster_shape if self.model_args else [1, 1]
+
+        # todo)) output_tensor is just overwritten later? why allocate it here then?
+        output_tensor = torch.zeros(batch_size, 1, vocab_size)
+        prompt_lens = prompt_lens if prompt_lens is not None else torch.tensor([batch_seq_len] * batch_size)
+        if empty_slots is None:
+            empty_slots = list(range(batch_size))
+
+        prefill_results = []
+
+        # Batched prefill fast path: fuse equal-length users into batched passes, PER uniform-length
+        # bucket group (see _plan_batched_prefill / select_batched_prefill_padded_batch). Positions the
+        # plan leaves sequential (or all positions when batching is off / declined) fall through to the
+        # per-user loop below, which is byte-identical to the pre-feature path.
+        num_cached_per_user = [int(start_pos[i]) if start_pos is not None else 0 for i in range(len(empty_slots))]
+        batched_groups, sequential_positions = _plan_batched_prefill(
+            self.model_args, empty_slots, prompt_lens, num_cached_per_user
+        )
+        seq_filter = None
+        if batched_groups:
+            seq_filter = sequential_positions
+            for prefill_seq_len_g, padded_batch_g, positions_g in batched_groups:
+                logger.info(
+                    f"Batched prefill: {len(positions_g)} users in groups of {padded_batch_g} "
+                    f"(seq={prefill_seq_len_g})"
+                )
+                prefill_results.extend(
+                    self._prefill_forward_batched_group(
+                        tokens, page_table, prompt_lens, positions_g, padded_batch_g, prefill_seq_len_g
+                    )
+                )
+
+        for idx, user_id in enumerate(empty_slots):
+            if seq_filter is not None and idx not in seq_filter:
+                continue  # handled by the batched path above
+            seq_len = int(prompt_lens[idx])
+            num_cached_tokens = int(start_pos[idx]) if start_pos is not None else 0
+            new_tokens = seq_len - num_cached_tokens
+            if new_tokens <= 0:
+                logger.info(
+                    f"Skipping prefill for user_id={user_id}: seq_len={seq_len}, num_cached_tokens={num_cached_tokens}"
+                )
+                continue
+            last_token_idx = seq_len - 1
+            prefill_seq_len = get_padded_prefill_len(new_tokens)
+
+            logger.info(f"Prefilling User {user_id + 1} up to {seq_len} tokens")
+
+            prefill_ids = torch.cat(
+                [
+                    tokens[idx : idx + 1, num_cached_tokens:seq_len],
+                    torch.zeros(1, prefill_seq_len - new_tokens).long(),
+                ],
+                dim=-1,
+            )
+
+            page_table_user = _get_prefill_user_page_table(
+                page_table[idx : idx + 1],
+                kv_cache,
+                seq_len,
+            )
+
+            logits = self._prefill_single_user(
+                prefill_ids,
+                page_table=page_table_user,
+                user_id=0,  # Always 0 with paged attention (page table handles user mapping)
+                last_token_idx=last_token_idx,
+                num_cached_tokens=num_cached_tokens,
+            )
+
+            logits = ttnn.untilize(logits, use_multicore=True)
+            prefill_results.append(
+                {
+                    "idx": idx,
+                    "last_token_idx": last_token_idx,
+                    "logits": logits.cpu(blocking=False),
+                }
+            )
+
+        # One device barrier drains every pending ``logits.cpu(blocking=False)`` transfer dispatched
+        # above; ``_process_output_prefill`` then runs on the already-resident HOST tensors (no device
+        # work). One barrier suffices (an idle ``synchronize_device`` is cheap), so the old per-user
+        # barrier was redundant — kept hoisted as a cleanup. Batched extraction returns ONE shared host
+        # logits tensor for a whole group (each user is a distinct row); concat its shards once per
+        # unique tensor and slice each user's row instead of re-concatenating per user (32 host concats
+        # -> 1 on batch-32). Cache keyed by tensor identity, so the sequential path is unchanged.
+        if prefill_results:
+            ttnn.synchronize_device(self.mesh_device)
+        _concat_cache: dict = {}
+        for res in prefill_results:
+            key = id(res["logits"])
+            full = _concat_cache.get(key)
+            if full is None:
+                assert res["logits"].storage_type() == ttnn.StorageType.HOST, "Expected host tensor"
+                full = _concat_host_output(res["logits"], cluster_shape)
+                _concat_cache[key] = full
+            last_relative = res["last_token_idx"] - (int(start_pos[res["idx"]]) if start_pos is not None else 0)
+            output_tensor[res["idx"]] = full[0, 0, last_relative % 32, :vocab_size]
+
+        return output_tensor
+
+    def _prefill_single_user(self, tokens, page_table, user_id, last_token_idx, num_cached_tokens=0):
+        """Prefill a single user with chunked prefill support.
+
+        Args:
+            tokens: Input tokens [1, seq_len].
+            page_table: Page table for this user [1, num_blocks]. Required.
+            user_id: User ID (always 0 with paged attention).
+            last_token_idx: Index of last token for output extraction.
+            num_cached_tokens: Number of tokens already in KV cache (prefix caching).
+        """
+        seq_len = tokens.shape[-1]
+        max_chunk = self.model_args.max_prefill_chunk_size if self.model_args else seq_len
+        use_chunked = seq_len > max_chunk
+        use_prefix_caching = num_cached_tokens > 0
+
+        # todo)) refactor this to be more readable?
+        if use_chunked or use_prefix_caching:
+            assert self._kv_cache is not None, "KV cache must be allocated for chunked prefill or prefix caching"
+            chunk_size = get_max_prefill_chunk_size(seq_len, max_chunk) if use_chunked else seq_len
+
+            last_token_in_seq = last_token_idx - num_cached_tokens
+            block_size = get_block_size(self._kv_cache)
+            last_token_in_chunk = last_token_in_seq % chunk_size
+            last_chunk_start = (last_token_in_seq // chunk_size) * chunk_size
+
+            page_table_user = page_table[user_id : user_id + 1, :]
+            num_pad_blocks = num_blocks_in_seq(seq_len + num_cached_tokens, block_size) - page_table_user.shape[1]
+            page_table_padded = torch.cat([page_table_user, torch.zeros(1, num_pad_blocks, dtype=torch.int32)], dim=-1)
+
+            for chunk_start in range(num_cached_tokens, num_cached_tokens + seq_len, chunk_size):
+                chunk_end = chunk_start + chunk_size
+                chunk_start_rel = chunk_start - num_cached_tokens
+                chunk_end_rel = chunk_end - num_cached_tokens
+
+                chunk_tokens = tokens[:, chunk_start_rel:chunk_end_rel]
+                chunk_page_table = page_table_padded[:, chunk_start // block_size : chunk_end // block_size]
+
+                prefill_input, cos, sin, page_table_tt, chunk_page_table_tt = self._prepare_prefill_device_inputs(
+                    chunk_tokens,
+                    start_pos=chunk_start,
+                    page_table=page_table_padded,
+                    chunk_page_table=chunk_page_table,
+                    last_token_idx=last_token_idx,
+                )
+
+                get_last_token = (last_token_in_chunk // 32) * 32
+                logits = self.model.prefill_forward(
+                    prefill_input,
+                    [cos, sin],
+                    user_id=0,
+                    page_table=page_table_tt,
+                    chunk_page_table=chunk_page_table_tt,
+                    chunk_start_idx=chunk_start,
+                    get_last_token=get_last_token,
+                )
+
+                if chunk_start_rel == last_chunk_start:
+                    return logits
+                else:
+                    del logits
+        else:
+            prefill_input, cos, sin, page_table_tt, _ = self._prepare_prefill_device_inputs(
+                tokens,
+                page_table=page_table,
+                last_token_idx=last_token_idx,
+            )
+
+            get_last_token = (last_token_idx // 32) * 32
+            return self.model.prefill_forward(
+                prefill_input,
+                [cos, sin],
+                user_id=user_id,
+                page_table=page_table_tt,
+                get_last_token=get_last_token,
+            )
+
+    # =========================================================================
+    # Batched Prefill (partial B=padded_batch)
+    # =========================================================================
+
+    def _prepare_batched_prefill_device_inputs(self, folded_tokens, group_page_table, prefill_seq_len):
+        """Prepare device inputs for one batched-prefill group (eager / trace-warmup compile).
+
+        Returns ``(tokens_embd, cos, sin, page_table_tt)``:
+          - ``folded_tokens`` [1, padded_batch*S] is embedded to a folded [1, 1, padded_batch*S, dim],
+          - ``cos``/``sin`` are the per-user rope slices for positions 0..S-1 (all users start at 0,
+            so the same slices broadcast over the batch axis inside attention),
+          - ``group_page_table`` [padded_batch, num_blocks] maps each local row to its physical blocks.
+
+        This eager path is used for direct eager execution and for the traced JIT warmup; the persistent
+        TRACE inputs come from ``TracedLLMExecutor._prepare_batched_prefill_trace_inputs_host`` which
+        instead sources cos/sin from the shared persistent tensor.
+        """
+        tokens_reshaped = folded_tokens.reshape(1, 1, 1, -1)
+        tokens_tt = ttnn.from_torch(
+            tokens_reshaped,
+            device=self.mesh_device,
+            dtype=ttnn.uint32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
+        )
+        tokens_embd = self.model.embed_prefill(tokens_tt)
+
+        rope = self.model.rope_setup
+        rope.load_device_weights()
+        cos_slice = rope.cos_matrix[:, :, 0:prefill_seq_len, :]
+        sin_slice = rope.sin_matrix[:, :, 0:prefill_seq_len, :]
+
+        page_table_tt = ttnn.from_torch(
+            group_page_table,
+            device=self.mesh_device,
+            dtype=ttnn.int32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
+        )
+        return tokens_embd, cos_slice, sin_slice, page_table_tt
+
+    def _extract_batched_prefill_logits(self, hidden, padded_batch, prefill_seq_len, group_idxs, last_token_idxs):
+        """Extract each user's last-token logits from a folded batched-prefill hidden state.
+
+        ``hidden`` is the folded [1, 1, padded_batch*S, dim]. Two paths (gated by model_args
+        ``batched_prefill_batched_extract``, default True):
+
+        * **batched** (default): gather every user's last-token hidden row into one [1,1,32,dim]
+          tensor and run norm + lm_head ONCE for the whole group (TTTv1
+          ``extract_last_tokens_batched_prefill`` + ``_apply_norm_and_lm_head``). At padded_batch=32 this
+          is a single lm_head over 32 rows == TTTv1's layout; the per-slot path instead runs 32 lm_heads
+          (each wasting 31 padding rows of the tile) — the residual TTTv2→TTTv1 TTFT gap. Per-row math is
+          identical (RMSNorm is per-row, lm_head rows are independent), so logits match the per-slot path.
+        * **per-slot** (fallback): one ``post_process_prefill_output`` (norm+lm_head) per user — bit-
+          identical to the sequential path, but 32× the lm_head work.
+
+        Returns a list of per-user result dicts.
+        """
+        batched_extract = getattr(self.model_args, "batched_prefill_batched_extract", True)
+        if batched_extract:
+            return self._extract_batched_prefill_logits_gathered(
+                hidden, padded_batch, prefill_seq_len, group_idxs, last_token_idxs
+            )
+
+        dim = hidden.shape[-1]
+        hidden = ttnn.reshape(hidden, [padded_batch, 1, prefill_seq_len, dim])
+        results = []
+        for local_i, idx in enumerate(group_idxs):
+            slot_hidden = hidden[local_i : local_i + 1, :, :, :]
+            logits = self.model.post_process_prefill_output(slot_hidden, last_token_idxs[local_i])
+            logits = ttnn.untilize(logits, use_multicore=True)
+            results.append(
+                {"idx": idx, "last_token_idx": last_token_idxs[local_i], "logits": logits.cpu(blocking=False)}
+            )
+        return results
+
+    def _extract_batched_prefill_logits_gathered(
+        self, hidden, padded_batch, prefill_seq_len, group_idxs, last_token_idxs
+    ):
+        """Batched last-token extraction: one norm + lm_head over all users in the group.
+
+        Gathers each user's last-token hidden row (folded layout: user ``i`` occupies rows
+        ``[i*S : i*S+S]``) into a single [1,1,32,dim] tensor — column-sharded across the mesh the same
+        way the prefill residual is (dim=-1), so the model's distributed norm all-gathers correctly —
+        then runs ``post_process_prefill_output`` once (slice [0:32] is a no-op on the 32-row tile).
+
+        The gather is done ON DEVICE by default (``_gather_last_tokens_on_device``): a one-hot selection
+        matmul keeps the folded hidden on device and reads back only the small [1,1,32,vocab] logits,
+        instead of copying the whole [1,1,B*S,dim] hidden to host (~25 MB at B=32,S=128) to gather 32
+        rows. This is the batched analogue of ``fast_prefill_last_token`` and closes the residual
+        TTTv2-vs-TTTv1 batch-32 prefill-TTFT gap. Set ``TTT_BATCHED_EXTRACT_HOST_GATHER=1`` to force the
+        legacy host gather (mirrors TTTv1 ``extract_last_tokens_batched_prefill``) for A/B measurement;
+        both paths are bit-identical (deterministic gather of the same rows).
+        """
+        TILE = 32
+        if _BATCHED_EXTRACT_HOST_GATHER:
+            gathered = self._gather_last_tokens_host(hidden, padded_batch, prefill_seq_len, group_idxs, last_token_idxs)
+        else:
+            gathered = self._gather_last_tokens_on_device(
+                hidden, padded_batch, prefill_seq_len, group_idxs, last_token_idxs
+            )
+        # last_token_idx = TILE-1 → post_process slices [0:TILE] (whole tile) then runs norm+lm_head once.
+        logits = self.model.post_process_prefill_output(gathered, TILE - 1)
+        logits = ttnn.untilize(logits, use_multicore=True)
+        logits_host = logits.cpu(blocking=False)
+        # Each user's logits sit at row local_i of the shared [.,.,32,vocab] output.
+        return [
+            {"idx": idx, "last_token_idx": local_i, "logits": logits_host} for local_i, idx in enumerate(group_idxs)
+        ]
+
+    def _gather_last_tokens_on_device(self, hidden, padded_batch, prefill_seq_len, group_idxs, last_token_idxs):
+        """Gather each user's last-token row from the folded hidden ON DEVICE (no host round-trip).
+
+        ``hidden`` is folded ``[1, 1, padded_batch*S, dim]``, column-sharded on ``dim`` (dim=-1). User
+        ``local_i``'s last token sits at fold row ``local_i*S + last_token_idxs[local_i]``. A one-hot
+        selection matmul ``sel[1,1,32,B*S] @ hidden[1,1,B*S,dim] -> [1,1,32,dim]`` performs the gather:
+        each device computes ``sel @ (its dim-shard of hidden)``, producing the dim-shard of the 32
+        gathered rows — no collective, output stays column-sharded (dim=-1) TILE_LAYOUT, exactly what
+        the distributed norm expects. ``sel`` has a single 1.0 per output row, so with HiFi4 + fp32
+        accumulation the result is bit-identical to reading ``hidden[row]`` (``1.0*x + 0*... = x``; the
+        bf16 value round-trips through fp32 unchanged). Only ``sel`` (tiny) is uploaded and only the
+        final logits are read back — the ~B*S*dim host read (25 MB at B=32,S=128) is eliminated.
+        Generalizes TTTv1's on-device slice (``all_same`` only) to arbitrary per-user last-token rows.
+        """
+        TILE = 32
+        fold_len = padded_batch * prefill_seq_len
+        sel = torch.zeros(1, 1, TILE, fold_len, dtype=torch.bfloat16)
+        for local_i, _ in enumerate(group_idxs):
+            sel[0, 0, local_i, local_i * prefill_seq_len + last_token_idxs[local_i]] = 1.0
+        sel_tt = ttnn.from_torch(
+            sel,
+            device=self.mesh_device,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
+        )
+        gathered = ttnn.matmul(
+            sel_tt,
+            hidden,
+            dtype=ttnn.bfloat16,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            compute_kernel_config=ttnn.init_device_compute_kernel_config(
+                self.mesh_device.arch(),
+                math_fidelity=ttnn.MathFidelity.HiFi4,
+                math_approx_mode=False,
+                fp32_dest_acc_en=True,
+                packer_l1_acc=False,
+            ),
+        )
+        ttnn.deallocate(sel_tt)
+        return gathered
+
+    def _gather_last_tokens_host(self, hidden, padded_batch, prefill_seq_len, group_idxs, last_token_idxs):
+        """Legacy host gather (A/B baseline; TTTv1 ``extract_last_tokens_batched_prefill`` parity).
+
+        Reads the whole folded ``[1,1,B*S,dim]`` hidden to host, gathers each user's last-token row, and
+        re-uploads a ``[1,1,32,dim]`` column-sharded tile. Deterministic; bit-identical to the on-device
+        path. Only used when ``TTT_BATCHED_EXTRACT_HOST_GATHER=1``.
+        """
+        ttnn.synchronize_device(self.mesh_device)
+        shards = [ttnn.to_torch(t) for t in ttnn.get_device_tensors(hidden)]
+        host_full = torch.cat(shards, dim=-1) if len(shards) > 1 else shards[0]  # [1,1,B*S,full_dim]
+        full_dim = host_full.shape[-1]
+        host_full = host_full.reshape(padded_batch, prefill_seq_len, full_dim)
+        TILE = 32
+        combined = torch.zeros(1, 1, TILE, full_dim, dtype=host_full.dtype)
+        for local_i, _ in enumerate(group_idxs):
+            combined[0, 0, local_i, :] = host_full[local_i, last_token_idxs[local_i], :]
+        return ttnn.from_torch(
+            combined,
+            device=self.mesh_device,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            mesh_mapper=ttnn.ShardTensorToMesh(self.mesh_device, dim=-1),
+        )
+
+    def _prefill_forward_batched_group(self, tokens, page_table, prompt_lens, positions, padded_batch, prefill_seq_len):
+        """Eager batched prefill for ONE uniform-length bucket group: process ``positions`` (row
+        indices into ``tokens``/``prompt_lens``/``page_table``) in sub-groups of ``padded_batch``, one
+        forward per sub-group, then extract each user's last-token logits. Returns a list of per-user
+        result dicts."""
+        block_size = get_block_size(self._kv_cache) if self._kv_cache is not None else 32
+        prefill_results = []
+        for g0 in range(0, len(positions), padded_batch):
+            sub_positions = positions[g0 : g0 + padded_batch]
+            folded, group_pt, group_idxs, last_token_idxs = _build_batched_prefill_group(
+                tokens, prompt_lens, page_table, sub_positions, padded_batch, prefill_seq_len, block_size
+            )
+            tokens_embd, cos, sin, pt_tt = self._prepare_batched_prefill_device_inputs(
+                folded, group_pt, prefill_seq_len
+            )
+            hidden = self.model.prefill_forward(
+                tokens_embd,
+                [cos, sin],
+                user_id=list(range(len(group_idxs))),
+                page_table=pt_tt,
+                get_last_token=-1,
+                batch_size=padded_batch,
+            )
+            prefill_results.extend(
+                self._extract_batched_prefill_logits(hidden, padded_batch, prefill_seq_len, group_idxs, last_token_idxs)
+            )
+        return prefill_results
+
+    # =========================================================================
+    # Decode Forward
+    # =========================================================================
+
+    def decode_forward(
+        self,
+        tokens: torch.Tensor,  # [batch_size], int64
+        start_pos: torch.Tensor,  # [batch_size], int64
+        page_table: torch.Tensor,  # [batch_size, max_blocks], int32
+        kv_cache: list[list[ttnn.Tensor]] | None = None,
+        read_from_device: bool = True,
+        sampling_params: SamplingParams | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        """Single decode step.
+
+        Args:
+            tokens: Input token IDs, shape [batch_size].
+            start_pos: Current position per user, shape [batch_size].
+            page_table: Page table for paged attention, shape [batch_size, max_blocks]. Required.
+            kv_cache: Per-layer KV cache (for identity assertion).
+            read_from_device: Whether to return host tensors.
+            sampling_params: Sampling parameters for on-device sampling.
+
+        Returns:
+            (logits_or_tokens, log_probs) tuple.
+            If sampling_params is None: logits [batch_size, 1, vocab_size], None
+            If sampling_params provided: tokens [batch_size], None
+        """
+        # Boundary assertions
+        assert tokens.dim() == 1, f"tokens must be [batch_size], got {tokens.dim()}D"
+        assert start_pos.dim() == 1, f"start_pos must be [batch_size], got {start_pos.dim()}D"
+        assert page_table.dim() == 2, f"page_table must be [batch_size, max_blocks], got {page_table.dim()}D"
+        self.mode = Mode.DECODE
+        self._assert_kv_cache_identity(kv_cache)
+        B = tokens.shape[0]
+        vocab_size = self.model.vocab_size
+        num_devices = self.model.num_devices
+        cluster_shape = self.model_args.cluster_shape if self.model_args else [1, 1]
+
+        sampling_on_device = sampling_params is not None
+
+        if (
+            sampling_on_device
+            and self.model.sampling is not None
+            and hasattr(self.model.sampling, "apply_decode_state")
+        ):
+            # TTTv1 SamplingGenerator pushes per-request k/p/temp into persistent device buffers
+            # via apply_decode_state + seed_manager. The TTTv2 Sampling1D module holds no mutable
+            # state (k/p/temp are per-call args; greedy/argmax needs none), so skip when absent.
+            from models.experimental.llama32_1b_quasar.sampling import broadcast_sampling_params, format_sampling_params
+
+            per_request_params = format_sampling_params(broadcast_sampling_params(sampling_params, 0, slot_len=B), B)
+            self.model.sampling.apply_decode_state(
+                [per_request_params],
+                reset_batch=False,
+            )
+            self.model.sampling.seed_manager.get_new_values()
+
+        tt_tokens, tt_current_pos, tt_rot_mat_idxs, tt_page_table = self.prepare_decode_inputs_device(
+            tokens, start_pos, page_table
+        )
+
+        # todo)) why is this here? it would be clearer to get_rot_mats right before its used?
+        rot_mats = self.model.rope_setup.get_rot_mats(tt_rot_mat_idxs)
+        x_embed = self.model.embed_decode(tt_tokens)
+
+        logits = self.model.decode_forward(
+            x_embed,
+            tt_current_pos,
+            rot_mats,
+            page_table=tt_page_table,
+        )
+
+        if sampling_on_device and self.model.sampling is not None:
+            # increment_positions omitted: positions are re-supplied from host each decode step
+            # (see TracedLLMExecutor._capture_decode_trace for the trace-capture rationale).
+            # tt_out_tok=None: let sampling allocate its own correctly-shaped output token tensor.
+            # Reusing the [1,1,1,32] input-token buffer as the argmax output ([1,1,32]) is a shape
+            # mismatch that forces a realloc — fatal during trace capture.
+            tt_toks, tt_log_probs = self._sampling_decode_forward(logits, sampling_params, tt_out_tok=None)
+            if read_from_device:
+                ttnn.synchronize_device(self.mesh_device)
+                toks = _process_output_decode_tokens(tt_toks.cpu(), B, cluster_shape)
+                return toks, None
+            return (tt_toks, tt_log_probs)
+
+        logits = self.model.gather_and_untilize_logits(logits)
+
+        if read_from_device:
+            logits_host = logits.cpu()
+            ttnn.synchronize_device(self.mesh_device)
+            return _process_output_decode(logits_host, B, vocab_size, num_devices, cluster_shape), None
+
+        return (logits, None)
+
+    # =========================================================================
+    # Cleanup
+    # =========================================================================
+
+    def cleanup(self) -> None:
+        """No-op for eager executor."""
+
+
+# =============================================================================
+# TracedLLMExecutor — thick engine with trace capture/replay
+# =============================================================================
+
+
+class TracedLLMExecutor:
+    """Traced executor engine — adds trace capture/replay to eager execution.
+
+    Same public API as EagerLLMExecutor. Compile methods capture traces,
+    forward methods replay or fall back to eager.
+
+    Attributes:
+        model: Transformer model with prefill_forward(), decode_forward(), model_args.
+        mesh_device: TT mesh device for execution.
+        mode: Current execution mode (PREFILL or DECODE).
+        prefill_output_spec: Captured output spec from compile_prefill().
+        decode_output_spec: Captured output spec from compile_decode().
+    """
+
+    def __init__(
+        self,
+        model,
+        mesh_device: ttnn.MeshDevice,
+        iter_named_modules=None,
+        ondevice_decode_loop: bool = False,
+        fast_prefill_last_token: bool = False,
+    ) -> None:
+        """Initialize traced executor engine.
+
+        Args:
+            model: Transformer model with prefill_forward(), decode_forward(), model_args, etc.
+            mesh_device: TT mesh device for execution.
+            iter_named_modules: Optional callable yielding the model's named modules for config
+                validation (model-specific; defaults to the generic walk in the eager engine).
+            fast_prefill_last_token: Opt-in, default OFF. In the single-user (batch_size==1) sequential
+                prefill path only the last-token ROW of the [1,1,32,vocab] logits tile is ever consumed
+                (the assembly picks ``full[0,0,last%32,:]``). When True, that one row is sliced on device
+                BEFORE the host readback, so the PCIe transfer + host ``torch.cat`` of the 8 device shards
+                move [1,1,1,vocab] instead of the full 32-row tile (~32x less host concat + readback — the
+                dominant non-forward term in the T3K batch-1 prefill TTFT gap vs TTTv1, which reads back
+                only tokens). Correctness-identical (same row, sliced on device instead of host). Purely
+                internal to prefill_forward (callers only ever see the row-reduced output_tensor), so it
+                generalizes to every model's single-user prefill; kept opt-in to bound the change to the
+                wired path. Inert for batched prefill (batch_size>1 shares a multi-row logits tile).
+            ondevice_decode_loop: Opt-in, default OFF. When True, the captured decode trace advances
+                position/rope on device (in-place ``ttnn.plus_one``) and feeds the sampled token back
+                into the persistent token buffer (``ttnn.sampling(output_tensor=...)``), so steady-state
+                steps replay with NO per-step host input staging — mirroring TTTv1's on-device sampling
+                trace (generator ``refresh_trace_inputs=False`` + ``_increment_decode_positions_device``).
+                Valid ONLY for free-running greedy/top-k generation, NOT teacher forcing (which injects
+                host tokens every step), so accuracy/teacher-forcing runs must leave this OFF. Also inert
+                on the force-argmax path (``_decode_loop_active`` gates it to the top-k op path).
+        """
+        self.model = model
+        self.mesh_device = mesh_device
+        self._eager = EagerLLMExecutor(model, mesh_device, iter_named_modules=iter_named_modules)
+        self._cleaned_up = False
+        self.ondevice_decode_loop = ondevice_decode_loop
+        self.fast_prefill_last_token = fast_prefill_last_token
+
+        # todo)) we cannot save many traces in memory! Gotta limit the number of traces! --> lru_cache?
+        #        but the warmup_model_prefill() traces must be kept around forever!
+        # Prefill traces: keyed by padded seq_len
+        self.trace_id_prefill: dict[int, int | None] = defaultdict(lambda: None)
+        self.trace_inputs_prefill: dict[int, tuple | None] = defaultdict(lambda: None)
+        self.trace_output_prefill: dict[int, ttnn.Tensor | None] = defaultdict(lambda: None)
+
+        # Batched prefill traces: keyed by (prefill_seq_len, padded_batch). One trace serves every
+        # group of `padded_batch` users at that bucket — the captured KV-fill batch_idx values are
+        # LOCAL (0..pb-1), identical across groups; only the tokens + page table differ and are copied
+        # in on replay. Multiple (bucket, pb) traces coexist (mixed-length eval-32 -> {128,1024}); like
+        # the single-user traces they share ONE persistent cos/sin (see _shared_prefill_cos_sin) so no
+        # fresh per-capture cos/sin buffer lands in a coexisting trace's live range.
+        self.trace_id_prefill_batched: dict[tuple, int | None] = defaultdict(lambda: None)
+        self.trace_inputs_prefill_batched: dict[tuple, tuple | None] = defaultdict(lambda: None)
+        self.trace_output_prefill_batched: dict[tuple, ttnn.Tensor | None] = defaultdict(lambda: None)
+
+        # Shared, persistent full-range prefill cos/sin trace inputs (keyed by max_seq_len).
+        # Materialised ONCE and reused by every per-bucket prefill trace so that no fresh per-capture
+        # cos/sin slice buffer can land inside another coexisting bucket's live residual/activation
+        # buffer and corrupt it (the ci-eval-32 mixed-bucket bug). See _shared_prefill_cos_sin.
+        self._prefill_cos_sin_shared: dict[int, tuple] = {}
+
+        # Decode traces: keyed by sampling_on_device (bool)
+        self.trace_ids_decode: dict[bool, int | None] = defaultdict(lambda: None)
+        self.trace_inputs_decode: dict[bool, tuple | None] = defaultdict(lambda: None)
+        self.trace_output_decode: dict[bool, tuple | None] = defaultdict(lambda: None)
+
+        # Per sampling-mode flag: the next decode step must re-seed the persistent buffers from host
+        # (correct first token + start position). Set after every prefill and at init; cleared once
+        # the device has been seeded, after which steady-state steps carry state on device.
+        self._decode_needs_reseed: dict[bool, bool] = defaultdict(lambda: True)
+        # Keyed per sampling-mode (True=on-device sampling, False=host), matching the per-key
+        # decode trace + device page_table buffer in trace_inputs_decode. A single shared tensor
+        # would let one mode's page-table update mask a needed copy on the other mode's trace
+        # (whose device buffer is separate), leaving it stale.
+        self._prev_decode_page_table: dict[bool, torch.Tensor | None] = defaultdict(lambda: None)
+
+        self.mode = None
+        self.already_warmed_up_prefill = False
+
+        # Output specs captured during compile (for multi-CQ pre-allocation)
+        self.prefill_output_spec: TensorSpec | None = None
+        self.decode_output_spec: TensorSpec | None = None
+
+    @property
+    def model_args(self):
+        """Model args come from the model object."""
+        return getattr(self.model, "model_args", None)
+
+    # =========================================================================
+    # Delegate KV cache to eager engine
+    # =========================================================================
+
+    def allocate_kv_cache(self, kv_cache_shape, dtype, num_layers) -> list:
+        """Allocate paged KV cache on device. Delegates to eager engine."""
+        return self._eager.allocate_kv_cache(kv_cache_shape, dtype, num_layers)
+
+    @property
+    def _kv_cache(self):
+        return self._eager._kv_cache
+
+    # =========================================================================
+    # Warmup
+    # =========================================================================
+
+    def warmup_model_prefill(
+        self,
+        seq_lens: list[int],
+        make_tokens,  # Callable[[int], torch.Tensor] — seq_len -> tokens [1, seq_len]
+        make_page_table,  # Callable[[int], torch.Tensor] — seq_len -> page_table [1, num_blocks]
+    ) -> None:
+        """Compile prefill for multiple sequence lengths. Caller provides input factories.
+
+        Args:
+            seq_lens: List of sequence lengths to compile.
+            make_tokens: Factory function: seq_len -> tokens tensor [1, seq_len].
+            make_page_table: Factory function: seq_len -> page_table tensor [1, num_blocks].
+        """
+        for seq_len in seq_lens:
+            tokens = make_tokens(seq_len)
+            page_table = make_page_table(seq_len)
+            self.compile_prefill(tokens=tokens, page_table=page_table)
+
+    # =========================================================================
+    # Trace Key Computation
+    # =========================================================================
+
+    def _get_prefill_trace_key(self, tokens: torch.Tensor) -> int:
+        """Prefill trace key = padded seq_len."""
+        return get_padded_prefill_len(tokens.shape[-1])
+
+    def _get_decode_trace_key(self, sampling_params) -> bool:
+        """Decode trace key = whether sampling is on device."""
+        return sampling_params is not None
+
+    def _decode_loop_active(self, sampling_params) -> bool:
+        """Whether the on-device decode loop applies for this decode call.
+
+        Requires: the opt-in flag, on-device sampling, AND the top-k op path (``ttnn.sampling``),
+        whose output is uint32 ``[1,1,1,32]`` on Wormhole/Blackhole — an exact match for the
+        persistent token buffer, so it can be fed back in place via ``output_tensor=`` with no
+        realloc. The force-argmax path (``ttnn.argmax`` → uint32 ``[1,1,32]``, rank-3) does NOT
+        match the rank-4 token buffer, so the loop stays off there and falls back to host resupply.
+        """
+        if not self.ondevice_decode_loop or sampling_params is None or self.model.sampling is None:
+            return False
+        # kpt is None only for the force-argmax path; non-None => top-k op path.
+        return self._eager._get_decode_sampling_kpt(sampling_params) is not None
+
+    def _prepare_prefill_trace_inputs_host(
+        self, tokens, page_table, start_pos=0, chunk_page_table=None, last_token_idx=None
+    ):
+        """Prepare traced prefill host inputs for copy_host_to_device replay.
+
+        Args:
+            tokens: Input tokens [1, seq_len].
+            page_table: Page table for paged attention [1, num_blocks]. Required.
+            start_pos: Starting position for prefix caching.
+            chunk_page_table: Chunk page table for chunked prefill (optional).
+            last_token_idx: Index of last token for output extraction.
+        """
+        assert tokens.dim() == 2, "tokens must be 2D"
+        tokens_reshaped = tokens.reshape(1, 1, 1, -1)
+        S = tokens_reshaped.shape[-1]
+        tokens_tt = ttnn.from_torch(
+            tokens_reshaped,
+            device=None,
+            dtype=ttnn.uint32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
+        )
+
+        rope = self.model.rope_setup
+        rope.load_device_weights()
+        mat_len = rope.cos_matrix.shape[2]
+        seq_len = last_token_idx + 1 if last_token_idx is not None else S
+        assert mat_len >= seq_len, f"Sequence length {seq_len} exceeds max seq len {mat_len}"
+
+        required_end = start_pos + S
+        pad_len = max(0, required_end - mat_len)
+        max_seq_len = self.model_args.max_seq_len if self.model_args else mat_len
+
+        if pad_len > 0:
+            # Prefix-caching / out-of-range path: per-call padded slice (rare; not the batched-prefill
+            # trace path). Kept as a fresh tensor since the shape is call-specific.
+            cos_slice = rope.cos_matrix[:, :, 0:max_seq_len, :]
+            sin_slice = rope.sin_matrix[:, :, 0:max_seq_len, :]
+            padding = [(0, 0)] * 4
+            padding[2] = (0, pad_len)
+            cos_slice = ttnn.pad(cos_slice, padding=padding, value=0.0)
+            sin_slice = ttnn.pad(sin_slice, padding=padding, value=0.0)
+        else:
+            # Standard batched-prefill trace path: the cos/sin slice is the CONSTANT [0:max_seq_len]
+            # range for EVERY bucket (same shape, same content, read-only, and never re-copied on
+            # replay). Materialise it ONCE and share the SAME persistent device tensor across all
+            # per-bucket prefill traces. This removes the fresh per-capture cos/sin buffer that
+            # otherwise gets bottom-up-allocated into another coexisting bucket's live residual buffer
+            # and corrupts it (device-verified: mixed-bucket ci-eval-32 corruption tracked exactly this
+            # overlap). Mirrors TTTv1, which feeds prefill rot_mats from the persistent cos/sin matrix
+            # rather than re-materialising a slice per bucket.
+            cos_slice, sin_slice = self._shared_prefill_cos_sin(rope, max_seq_len)
+
+        tt_page_table = ttnn.from_torch(
+            page_table,
+            device=None,
+            dtype=ttnn.int32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
+        )
+
+        tt_chunk_page_table = None
+        if chunk_page_table is not None:
+            tt_chunk_page_table = ttnn.from_torch(
+                chunk_page_table,
+                device=None,
+                dtype=ttnn.int32,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+                mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
+            )
+
+        return tokens_tt, cos_slice, sin_slice, tt_page_table, tt_chunk_page_table
+
+    def _shared_prefill_cos_sin(self, rope, max_seq_len: int) -> tuple[ttnn.Tensor, ttnn.Tensor]:
+        """Return the persistent, shared full-range ``[0:max_seq_len]`` prefill cos/sin tensors.
+
+        Materialised once per ``max_seq_len`` and reused by every per-bucket prefill trace. The
+        slice is content- and shape-identical for every bucket (the executor always slices the
+        constant ``[0:max_seq_len]`` range, independent of the padded bucket length), cos/sin are
+        read-only inside the trace body (``rotary_embedding_llama`` takes them by const ref), and
+        they are never re-copied on replay. Sharing one device buffer therefore changes nothing
+        functionally while eliminating the fresh per-capture slice buffer that could be allocated
+        into another coexisting bucket trace's live residual buffer and corrupt it.
+        """
+        cached = self._prefill_cos_sin_shared.get(max_seq_len)
+        if cached is not None:
+            return cached
+        cos_slice = rope.cos_matrix[:, :, 0:max_seq_len, :]
+        sin_slice = rope.sin_matrix[:, :, 0:max_seq_len, :]
+        self._prefill_cos_sin_shared[max_seq_len] = (cos_slice, sin_slice)
+        return cos_slice, sin_slice
+
+    # =========================================================================
+    # Compile (delegates to eager, captures output specs)
+    # =========================================================================
+
+    def compile_prefill(
+        self,
+        *,
+        tokens: torch.Tensor,  # [batch_size, seq_len], int64
+        page_table: torch.Tensor,  # [batch_size, max_blocks], int32
+        kv_cache: list[list[ttnn.Tensor]] | None = None,
+        prompt_lens: torch.Tensor | None = None,  # [batch_size], int64
+        empty_slots: list[int] | None = None,
+        start_pos: torch.Tensor | None = None,  # [batch_size], int64
+        sampling_params: SamplingParams | None = None,
+    ) -> torch.Tensor | None:  # [batch_size, 1, vocab_size] or None if already compiled
+        """Compile prefill for specific inputs. Returns logits from warmup run.
+
+        Returns None if trace for this seq_len already exists (no work needed).
+        Also captures output spec for multi-CQ pre-allocation.
+
+        Args:
+            tokens: Input token IDs, shape [batch_size, seq_len].
+            page_table: Page table for paged attention, shape [batch_size, max_blocks]. Required.
+            kv_cache: Per-layer KV cache from allocate_kv_cache().
+            prompt_lens: Actual prompt length per user, shape [batch_size].
+            empty_slots: List of user IDs to prefill.
+            start_pos: Starting position for prefix caching, shape [batch_size].
+        """
+        # Boundary assertions
+        assert tokens.dim() == 2, f"tokens must be [batch_size, seq_len], got {tokens.dim()}D"
+        assert page_table.dim() == 2, f"page_table must be [batch_size, max_blocks], got {page_table.dim()}D"
+
+        # Skip if already compiled for this seq_len
+        trace_key = self._get_prefill_trace_key(tokens)
+        if self.trace_id_prefill[trace_key] is not None:
+            return None
+
+        # Allocate persistent on-device sampling buffers BEFORE the prefill trace is captured
+        # (self.prefill_forward below). If they are first materialised during decode-trace capture
+        # (while this prefill trace is live), tt-metal places them unsafely and a decode-trace buffer
+        # clobbers the k tensor on replay -> corrupt k -> sampling-writer hang. See
+        # _prealloc_sampling_buffers.
+        self._prealloc_sampling_buffers(sampling_params)
+
+        logits = self.prefill_forward(
+            tokens,
+            page_table=page_table,
+            kv_cache=kv_cache,
+            prompt_lens=prompt_lens,
+            empty_slots=empty_slots,
+            start_pos=start_pos,
+        )
+        ttnn.synchronize_device(self.mesh_device)
+
+        # Capture output spec
+        self.prefill_output_spec = TensorSpec(
+            shape=tuple(logits.shape),
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            memory_config=None,
+        )
+
+        return logits
+
+    def compile_decode(
+        self,
+        *,
+        tokens: torch.Tensor,  # [batch_size], int64
+        start_pos: torch.Tensor,  # [batch_size], int64
+        page_table: torch.Tensor,  # [batch_size, max_blocks], int32
+        kv_cache: list[list[ttnn.Tensor]] | None = None,
+        sampling_params: SamplingParams | None = None,
+    ) -> None:
+        """Compile decode for specific inputs. One warmup run, discard output.
+
+        Skips if trace for this sampling mode already exists.
+        Also captures output spec for multi-CQ pre-allocation.
+
+        Args:
+            tokens: Input token IDs, shape [batch_size].
+            start_pos: Current position per user, shape [batch_size].
+            page_table: Page table for paged attention, shape [batch_size, max_blocks]. Required.
+            kv_cache: Per-layer KV cache from allocate_kv_cache().
+            sampling_params: Sampling parameters for on-device sampling.
+        """
+        # Boundary assertions
+        assert tokens.dim() == 1, f"tokens must be [batch_size], got {tokens.dim()}D"
+        assert start_pos.dim() == 1, f"start_pos must be [batch_size], got {start_pos.dim()}D"
+        assert page_table.dim() == 2, f"page_table must be [batch_size, max_blocks], got {page_table.dim()}D"
+
+        # Skip if already compiled for this sampling mode
+        trace_key = self._get_decode_trace_key(sampling_params)
+        if self.trace_ids_decode[trace_key] is not None:
+            return
+
+        output = self.decode_forward(
+            tokens,
+            start_pos,
+            page_table=page_table,
+            kv_cache=kv_cache,
+            read_from_device=False,
+            sampling_params=sampling_params,
+        )
+        ttnn.synchronize_device(self.mesh_device)
+
+        # Capture output spec from device tensor
+        logits_or_tokens, _ = output
+        if isinstance(logits_or_tokens, ttnn.Tensor) and logits_or_tokens.is_allocated():
+            self.decode_output_spec = TensorSpec.from_tensor(logits_or_tokens)
+
+    # =========================================================================
+    # Prefill (traced)
+    # =========================================================================
+
+    def prefill_forward(
+        self,
+        tokens: torch.Tensor,  # [batch_size, seq_len], int64
+        page_table: torch.Tensor,  # [batch_size, max_blocks], int32
+        kv_cache: list[list[ttnn.Tensor]] | None = None,
+        prompt_lens: torch.Tensor | None = None,  # [batch_size], int64
+        empty_slots: list[int] | None = None,
+        # todo)) remove unnecessary sampling_params?
+        sampling_params: SamplingParams | None = None,
+        start_pos: torch.Tensor | None = None,  # [batch_size], int64
+    ) -> torch.Tensor:  # [batch_size, 1, vocab_size], float32
+        """Traced prefill: lazy capture on first call per seq_len, replay after.
+
+        Args:
+            tokens: Input token IDs, shape [batch_size, seq_len].
+            page_table: Page table for paged attention, shape [batch_size, max_blocks]. Required.
+            kv_cache: Per-layer KV cache from allocate_kv_cache().
+            prompt_lens: Actual prompt length per user, shape [batch_size].
+            empty_slots: List of user IDs to prefill.
+            sampling_params: Sampling parameters (not used in prefill).
+            start_pos: Starting position for prefix caching, shape [batch_size].
+
+        Returns:
+            Logits tensor, shape [batch_size, 1, vocab_size].
+        """
+        # Boundary assertions
+        assert tokens.dim() == 2, f"tokens must be [batch_size, seq_len], got {tokens.dim()}D"
+        assert page_table.dim() == 2, f"page_table must be [batch_size, max_blocks], got {page_table.dim()}D"
+        if prompt_lens is not None:
+            assert prompt_lens.dim() == 1, f"prompt_lens must be [batch_size], got {prompt_lens.dim()}D"
+        if start_pos is not None:
+            assert start_pos.dim() == 1, f"start_pos must be [batch_size], got {start_pos.dim()}D"
+
+        self.mode = Mode.PREFILL
+        self._eager._assert_kv_cache_identity(kv_cache)
+        # A prefill breaks decode continuity: the next decode step must re-seed the persistent
+        # on-device buffers from host (correct first token + start position) before the device
+        # can carry state on its own. Mark all sampling modes stale, and drop the cached page
+        # tables so the first post-prefill step always re-copies (device buffers are reused).
+        self._decode_needs_reseed = defaultdict(lambda: True)
+        self._prev_decode_page_table = defaultdict(lambda: None)
+
+        batch_size, batch_seq_len = tokens.shape
+        vocab_size = self.model.vocab_size
+        cluster_shape = self.model_args.cluster_shape if self.model_args else [1, 1]
+        output_tensor = torch.zeros(batch_size, 1, vocab_size)
+        prompt_lens = prompt_lens if prompt_lens is not None else torch.tensor([batch_seq_len] * batch_size)
+        # todo)) empty_slots is only used when integrating with vLLM? If true, we should move this integration into generator.py
+        if empty_slots is None:
+            empty_slots = list(range(batch_size))
+
+        prefill_results = []
+
+        # Batched prefill fast path (traced): fuse equal-length users into batched passes, PER uniform-
+        # length bucket group (see _plan_batched_prefill). Positions the plan leaves sequential (or all
+        # positions when batching is off / declined) fall through to the per-user loop below.
+        #
+        # Per-user (sequential) prefill: each user is traced at its OWN get_padded_prefill_len bucket
+        # (TTTv1-parity per-bucket TTFT). Multiple bucket traces (e.g. {128, 1024}) — single-user AND
+        # batched — coexist correctly because every prefill trace's cos/sin input is the SAME shared
+        # persistent tensor (_shared_prefill_cos_sin), never a fresh per-capture slice (a fresh slice
+        # would be bottom-up-allocated into another coexisting trace's live residual buffer and corrupt
+        # it — the ci-eval-32 mixed-bucket bug). No single-bucket collapse is needed.
+        num_cached_per_user = [int(start_pos[i]) if start_pos is not None else 0 for i in range(len(empty_slots))]
+        batched_groups, sequential_positions = _plan_batched_prefill(
+            self.model_args, empty_slots, prompt_lens, num_cached_per_user
+        )
+        seq_filter = None
+        if batched_groups:
+            seq_filter = sequential_positions
+            for prefill_seq_len_g, padded_batch_g, positions_g in batched_groups:
+                logger.info(
+                    f"Batched prefill (traced): {len(positions_g)} users in groups of {padded_batch_g} "
+                    f"(seq={prefill_seq_len_g})"
+                )
+                prefill_results.extend(
+                    self._prefill_forward_batched_group_traced(
+                        tokens, page_table, prompt_lens, positions_g, padded_batch_g, prefill_seq_len_g
+                    )
+                )
+
+        for idx, user_id in enumerate(empty_slots):
+            if seq_filter is not None and idx not in seq_filter:
+                continue  # handled by the batched path above
+            seq_len = int(prompt_lens[idx])
+            # todo)) prefix caching could be refactored into composable feature? --> shouldn't vLLM handle this not use? --> this could be a composable feature!
+            num_cached_tokens = int(start_pos[idx]) if start_pos is not None else 0
+            new_tokens = seq_len - num_cached_tokens
+            if new_tokens <= 0:
+                logger.info(
+                    f"Skipping prefill for user_id={user_id}: seq_len={seq_len}, num_cached_tokens={num_cached_tokens}"
+                )
+                continue
+            last_token_idx = seq_len - 1
+            prefill_seq_len = get_padded_prefill_len(new_tokens)
+
+            prefill_ids = torch.cat(
+                [
+                    tokens[idx : idx + 1, num_cached_tokens:seq_len],
+                    torch.zeros(1, prefill_seq_len - new_tokens).long(),
+                ],
+                dim=-1,
+            )
+
+            can_trace = self.model_args and self.model_args.can_enable_trace(prefill_seq_len, num_cached_tokens)
+
+            if can_trace:
+                page_table_user = _get_prefill_trace_user_page_table(
+                    page_table[idx : idx + 1],
+                    kv_cache,
+                    prefill_seq_len,
+                )
+            else:
+                page_table_user = _get_prefill_user_page_table(
+                    page_table[idx : idx + 1],
+                    kv_cache,
+                    seq_len,
+                )
+
+            # todo)) there should be warning message about prefill that cannot be traced!
+            if can_trace:
+                # todo)) what does it take to make the whole thing traceable?
+                logits = self._easy_trace_prefill(
+                    prefill_ids,
+                    page_table=page_table_user,
+                    user_id=0,
+                    last_token_idx=last_token_idx,
+                    prefill_seq_len=prefill_seq_len,
+                )
+                logits = self.model.post_process_prefill_output(logits, last_token_idx)
+            else:
+                logits = self._eager._prefill_single_user(
+                    prefill_ids,
+                    page_table=page_table_user,
+                    user_id=0,  # Always 0 with paged attention
+                    last_token_idx=last_token_idx,
+                    num_cached_tokens=num_cached_tokens,
+                )
+
+            logits = ttnn.untilize(logits, use_multicore=True)
+            # Single-user last-token slice ON DEVICE before readback (see fast_prefill_last_token):
+            # only row (last_token_idx - num_cached)%32 of this [1,1,32,vocab] tile is consumed by the
+            # assembly, so slicing it here shrinks the host readback + concat from the full tile to one
+            # row. row_override tells the assembly the row already sits at index 0.
+            row_override = None
+            if self.fast_prefill_last_token and batch_size == 1:
+                _row = (last_token_idx - num_cached_tokens) % 32
+                logits = ttnn.slice(logits, (0, 0, _row, 0), (1, 1, _row + 1, logits.shape[-1]))
+                row_override = 0
+            prefill_results.append(
+                {
+                    "idx": idx,
+                    "last_token_idx": last_token_idx,
+                    "logits": logits.cpu(blocking=False),
+                    "row_override": row_override,
+                }
+            )
+
+        # One device barrier drains every pending ``logits.cpu(blocking=False)`` transfer dispatched
+        # above (batched extraction + sequential loop); ``_process_output_prefill`` then runs on the
+        # already-resident HOST tensors (it asserts HOST storage; no device work). One barrier suffices
+        # (an idle ``synchronize_device`` is cheap), so the old per-user barrier was redundant — kept
+        # hoisted purely as a cleanup. Batched extraction returns ONE shared host logits tensor for a
+        # whole group (each user is a distinct row); concat its shards once per unique tensor and slice
+        # each user's row instead of re-concatenating per user in ``_process_output_prefill`` (32 host
+        # concats -> 1 on batch-32). On batch-32 this host work was ~52ms (fold-invariant), the largest
+        # non-forward term in the TTTv2->TTTv1 batch-32 TTFT gap. Cache is keyed by tensor identity, so
+        # the sequential path (a unique tensor per user) is unchanged (one concat each).
+        if prefill_results:
+            ttnn.synchronize_device(self.mesh_device)
+        _concat_cache: dict = {}
+        for res in prefill_results:
+            key = id(res["logits"])
+            full = _concat_cache.get(key)
+            if full is None:
+                assert res["logits"].storage_type() == ttnn.StorageType.HOST, "Expected host tensor"
+                full = _concat_host_output(res["logits"], cluster_shape)
+                _concat_cache[key] = full
+            last_relative = res["last_token_idx"] - (int(start_pos[res["idx"]]) if start_pos is not None else 0)
+            row = res.get("row_override")
+            output_tensor[res["idx"]] = full[0, 0, last_relative % 32 if row is None else row, :vocab_size]
+
+        return output_tensor
+
+    def _easy_trace_prefill(self, tokens, page_table, user_id, last_token_idx, prefill_seq_len):
+        """Lazy trace capture for prefill. Captures on first call per seq_len."""
+        if self.trace_id_prefill[prefill_seq_len] is None:
+            return self._capture_and_run_prefill_trace(
+                tokens,
+                page_table,
+                user_id,
+                last_token_idx,
+                prefill_seq_len,
+            )
+
+        host_inputs = self._prepare_prefill_trace_inputs_host(
+            tokens,
+            page_table=page_table,
+            last_token_idx=last_token_idx,
+        )
+        trace_inputs = self.trace_inputs_prefill[prefill_seq_len]
+        copy_host_to_device(
+            host_tensors=(host_inputs[0], host_inputs[3], host_inputs[4]),
+            device_tensors=(trace_inputs[0], trace_inputs[3], trace_inputs[4]),
+        )
+
+        ttnn.execute_trace(self.mesh_device, self.trace_id_prefill[prefill_seq_len], cq_id=0, blocking=False)
+        return self.trace_output_prefill[prefill_seq_len]
+
+    def _run_prefill_trace_body(self, device_inputs, user_id):
+        tokens_embd = self.model.embed_prefill(device_inputs[0])
+        rot_mats = [device_inputs[1], device_inputs[2]]
+        tt_page_table = device_inputs[3]
+        tt_chunk_page_table = device_inputs[4]
+
+        return self.model.prefill_forward(
+            tokens_embd,
+            rot_mats,
+            user_id=user_id,
+            page_table=tt_page_table,
+            chunk_page_table=tt_chunk_page_table,
+            get_last_token=-1,
+        )
+
+    def _capture_and_run_prefill_trace(self, tokens, page_table, user_id, last_token_idx, prefill_seq_len):
+        """Compile + capture trace for a specific prefill seq_len."""
+        # todo)) should just assert the expected trace is already there (look up by prefill_seq_len)
+        self._eager._prefill_single_user(
+            tokens,
+            page_table=page_table,
+            user_id=user_id,
+            last_token_idx=last_token_idx,
+        )
+        ttnn.synchronize_device(self.mesh_device)
+        logger.info(f"Compiled prefill for seq_len={prefill_seq_len}")
+
+        host_inputs = self._prepare_prefill_trace_inputs_host(
+            tokens,
+            page_table=page_table,
+            last_token_idx=last_token_idx,
+        )
+        device_inputs = list(copy_host_to_device(host_inputs, mesh_device=self.mesh_device))
+        # host_inputs[1],[2] are already the SHARED persistent cos/sin device tensors (from
+        # _shared_prefill_cos_sin). copy_host_to_device is a no-op for already-on-device tensors, but
+        # pin the shared object identity explicitly so every bucket's captured trace inputs reference
+        # the SAME cos/sin buffer (never a fresh per-capture copy) — this is what prevents a second
+        # bucket's cos/sin from being allocated into another bucket trace's live residual and
+        # corrupting it. cos/sin are read-only in the trace and not re-copied on replay.
+        device_inputs[1] = host_inputs[1]
+        device_inputs[2] = host_inputs[2]
+        device_inputs = tuple(device_inputs)
+
+        with suspend_module_input_validation():
+            trace_warmup_output = self._run_prefill_trace_body(device_inputs, user_id)
+        ttnn.synchronize_device(self.mesh_device)
+        cleanup_ttnn_value(trace_warmup_output)
+        ttnn.synchronize_device(self.mesh_device)
+        logger.info(f"Compiled trace-compatible prefill for seq_len={prefill_seq_len}")
+
+        trace_id = ttnn.begin_trace_capture(self.mesh_device, cq_id=0)
+        with suspend_module_input_validation():
+            logits = self._run_prefill_trace_body(device_inputs, user_id)
+
+        ttnn.end_trace_capture(self.mesh_device, trace_id, cq_id=0)
+        ttnn.synchronize_device(self.mesh_device)
+
+        self.trace_id_prefill[prefill_seq_len] = trace_id
+        self.trace_inputs_prefill[prefill_seq_len] = device_inputs
+        self.trace_output_prefill[prefill_seq_len] = logits
+
+        logger.info(f"Captured prefill trace for seq_len={prefill_seq_len}")
+        return logits
+
+    # =========================================================================
+    # Batched Prefill (traced, partial B=padded_batch)
+    # =========================================================================
+
+    def _prepare_batched_prefill_trace_inputs_host(self, folded_tokens, group_page_table):
+        """Host-side inputs for a batched-prefill trace.
+
+        Tokens and page table are host tensors (copied in per group on replay); cos/sin are the SHARED
+        persistent full-range ``[0:max_seq_len]`` rope tensors (``_shared_prefill_cos_sin``), the SAME
+        object every single-user AND batched trace uses. The rotary op accepts cos whose seq dim is
+        longer than q's and broadcasts cos's batch dim (==1) over the unfolded [B,nh,S,hd] q
+        (device-verified: rotary_embedding_llama prefill validate has no seq-dim check and requires
+        cos.shape[0]==1). Reusing one buffer means NO fresh per-capture cos/sin slice can be
+        bottom-up-allocated into a coexisting trace's live range — the Phase-1 mixed-bucket fix holds
+        under batching. cos/sin are read-only in the trace body and never re-copied on replay.
+        """
+        tokens_reshaped = folded_tokens.reshape(1, 1, 1, -1)
+        tokens_tt = ttnn.from_torch(
+            tokens_reshaped,
+            device=None,
+            dtype=ttnn.uint32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
+        )
+        rope = self.model.rope_setup
+        rope.load_device_weights()
+        max_seq_len = self.model_args.max_seq_len if self.model_args else rope.cos_matrix.shape[2]
+        cos_slice, sin_slice = self._shared_prefill_cos_sin(rope, max_seq_len)
+        page_table_tt = ttnn.from_torch(
+            group_page_table,
+            device=None,
+            dtype=ttnn.int32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
+        )
+        return tokens_tt, cos_slice, sin_slice, page_table_tt
+
+    def _run_batched_prefill_trace_body(self, device_inputs, padded_batch, num_real):
+        tokens_embd = self.model.embed_prefill(device_inputs[0])
+        rot_mats = [device_inputs[1], device_inputs[2]]
+        tt_page_table = device_inputs[3]
+        return self.model.prefill_forward(
+            tokens_embd,
+            rot_mats,
+            user_id=list(range(num_real)),
+            page_table=tt_page_table,
+            get_last_token=-1,
+            batch_size=padded_batch,
+        )
+
+    def _easy_trace_batched_prefill(self, folded, group_pt, padded_batch, prefill_seq_len, num_real):
+        """Lazy capture/replay of the batched-prefill trace keyed by (prefill_seq_len, padded_batch)."""
+        key = (prefill_seq_len, padded_batch)
+        if self.trace_id_prefill_batched[key] is None:
+            return self._capture_and_run_batched_prefill_trace(
+                folded, group_pt, padded_batch, prefill_seq_len, num_real
+            )
+
+        host_inputs = self._prepare_batched_prefill_trace_inputs_host(folded, group_pt)
+        trace_inputs = self.trace_inputs_prefill_batched[key]
+        # Only tokens (idx 0) and page table (idx 3) vary per group; cos/sin (idx 1,2) are the shared
+        # persistent tensors, baked at capture and never re-copied.
+        copy_host_to_device(
+            host_tensors=(host_inputs[0], host_inputs[3]),
+            device_tensors=(trace_inputs[0], trace_inputs[3]),
+        )
+        ttnn.execute_trace(self.mesh_device, self.trace_id_prefill_batched[key], cq_id=0, blocking=False)
+        return self.trace_output_prefill_batched[key]
+
+    def _capture_and_run_batched_prefill_trace(self, folded, group_pt, padded_batch, prefill_seq_len, num_real):
+        """Compile + capture a batched-prefill trace for (prefill_seq_len, padded_batch)."""
+        key = (prefill_seq_len, padded_batch)
+        # Eager warmup (JIT-compile the batched ops outside trace capture). Throwaway cos/sin here.
+        tokens_embd, cos, sin, pt_tt = self._eager._prepare_batched_prefill_device_inputs(
+            folded, group_pt, prefill_seq_len
+        )
+        with suspend_module_input_validation():
+            self.model.prefill_forward(
+                tokens_embd,
+                [cos, sin],
+                user_id=list(range(num_real)),
+                page_table=pt_tt,
+                get_last_token=-1,
+                batch_size=padded_batch,
+            )
+        ttnn.synchronize_device(self.mesh_device)
+        logger.info(f"Compiled batched prefill for seq_len={prefill_seq_len}, padded_batch={padded_batch}")
+
+        host_inputs = self._prepare_batched_prefill_trace_inputs_host(folded, group_pt)
+        device_inputs = list(copy_host_to_device(host_inputs, mesh_device=self.mesh_device))
+        # host_inputs[1],[2] are the SHARED persistent cos/sin device tensors (from _shared_prefill_cos_sin);
+        # copy_host_to_device is a no-op for already-on-device tensors, but pin the shared object identity
+        # so every batched trace references the SAME cos/sin buffer (never a fresh per-capture copy). This
+        # is what keeps the Phase-1 mixed-bucket aliasing fix intact across coexisting batched traces.
+        device_inputs[1] = host_inputs[1]
+        device_inputs[2] = host_inputs[2]
+        device_inputs = tuple(device_inputs)
+
+        with suspend_module_input_validation():
+            trace_warmup_output = self._run_batched_prefill_trace_body(device_inputs, padded_batch, num_real)
+        ttnn.synchronize_device(self.mesh_device)
+        cleanup_ttnn_value(trace_warmup_output)
+        ttnn.synchronize_device(self.mesh_device)
+
+        trace_id = ttnn.begin_trace_capture(self.mesh_device, cq_id=0)
+        with suspend_module_input_validation():
+            hidden = self._run_batched_prefill_trace_body(device_inputs, padded_batch, num_real)
+        ttnn.end_trace_capture(self.mesh_device, trace_id, cq_id=0)
+        ttnn.synchronize_device(self.mesh_device)
+
+        self.trace_id_prefill_batched[key] = trace_id
+        self.trace_inputs_prefill_batched[key] = device_inputs
+        self.trace_output_prefill_batched[key] = hidden
+
+        logger.info(f"Captured batched prefill trace for seq_len={prefill_seq_len}, padded_batch={padded_batch}")
+        return hidden
+
+    def _prefill_forward_batched_group_traced(
+        self, tokens, page_table, prompt_lens, positions, padded_batch, prefill_seq_len
+    ):
+        """Traced batched prefill for ONE uniform-length bucket group: one batched (traced when
+        allowed) pass per sub-group of padded_batch users, then last-token extraction. Only full
+        sub-groups are traced; a partial trailing sub-group runs eager (it would bake a different
+        KV-fill loop length into the trace). Returns a list of per-user result dicts."""
+        block_size = get_block_size(self._kv_cache) if self._kv_cache is not None else 32
+        can_trace = bool(self.model_args and self.model_args.can_enable_trace(prefill_seq_len, 0))
+        prefill_results = []
+
+        for g0 in range(0, len(positions), padded_batch):
+            sub_positions = positions[g0 : g0 + padded_batch]
+            folded, group_pt, group_idxs, last_token_idxs = _build_batched_prefill_group(
+                tokens, prompt_lens, page_table, sub_positions, padded_batch, prefill_seq_len, block_size
+            )
+            if can_trace and len(group_idxs) == padded_batch:
+                hidden = self._easy_trace_batched_prefill(
+                    folded, group_pt, padded_batch, prefill_seq_len, num_real=len(group_idxs)
+                )
+            else:
+                tokens_embd, cos, sin, pt_tt = self._eager._prepare_batched_prefill_device_inputs(
+                    folded, group_pt, prefill_seq_len
+                )
+                hidden = self.model.prefill_forward(
+                    tokens_embd,
+                    [cos, sin],
+                    user_id=list(range(len(group_idxs))),
+                    page_table=pt_tt,
+                    get_last_token=-1,
+                    batch_size=padded_batch,
+                )
+            prefill_results.extend(
+                self._eager._extract_batched_prefill_logits(
+                    hidden, padded_batch, prefill_seq_len, group_idxs, last_token_idxs
+                )
+            )
+        return prefill_results
+
+    # =========================================================================
+    # Decode (traced)
+    # =========================================================================
+
+    def decode_forward(
+        self,
+        tokens: torch.Tensor,  # [batch_size], int64
+        start_pos: torch.Tensor,  # [batch_size], int64
+        page_table: torch.Tensor,  # [batch_size, max_blocks], int32
+        kv_cache: list[list[ttnn.Tensor]] | None = None,
+        read_from_device: bool = True,
+        sampling_params: SamplingParams | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        """Traced decode: lazy capture on first call, replay after.
+
+        Args:
+            tokens: Input token IDs, shape [batch_size].
+            start_pos: Current position per user, shape [batch_size].
+            page_table: Page table for paged attention, shape [batch_size, max_blocks]. Required.
+            kv_cache: Per-layer KV cache (for identity assertion).
+            read_from_device: Whether to return host tensors.
+            sampling_params: Sampling parameters for on-device sampling.
+
+        Returns:
+            (logits_or_tokens, log_probs) tuple.
+            If sampling_params is None: logits [batch_size, 1, vocab_size], None
+            If sampling_params provided: tokens [batch_size], None
+        """
+        # Boundary assertions
+        assert tokens.dim() == 1, f"tokens must be [batch_size], got {tokens.dim()}D"
+        assert start_pos.dim() == 1, f"start_pos must be [batch_size], got {start_pos.dim()}D"
+        assert page_table.dim() == 2, f"page_table must be [batch_size, max_blocks], got {page_table.dim()}D"
+
+        self.mode = Mode.DECODE
+        self._eager._assert_kv_cache_identity(kv_cache)
+        sampling_on_device = sampling_params is not None
+        B = tokens.shape[0]
+        vocab_size = self.model.vocab_size
+        num_devices = self.model.num_devices
+        cluster_shape = self.model_args.cluster_shape if self.model_args else [1, 1]
+
+        if (
+            sampling_on_device
+            and self.model.sampling is not None
+            and hasattr(self.model.sampling, "apply_decode_state")
+        ):
+            # TTTv1-only: push per-request k/p/temp into persistent device buffers before replay.
+            # TTTv2 Sampling1D has no such state (greedy/argmax needs none) — skip when absent.
+            from models.experimental.llama32_1b_quasar.sampling import broadcast_sampling_params, format_sampling_params
+
+            per_request_params = format_sampling_params(broadcast_sampling_params(sampling_params, 0, slot_len=B), B)
+            self.model.sampling.apply_decode_state(
+                [per_request_params],
+                reset_batch=False,
+            )
+            self.model.sampling.seed_manager.get_new_values()
+
+        if not self.trace_ids_decode[sampling_on_device]:
+            self._capture_decode_trace(tokens, start_pos, page_table, kv_cache, sampling_on_device, sampling_params)
+
+        loop_active = self._decode_loop_active(sampling_params)
+        if loop_active and not self._decode_needs_reseed[sampling_on_device]:
+            # Steady-state on-device loop: the captured trace advanced current_pos/rot_mat_idxs
+            # (in-place plus_one) and wrote the sampled token back into the persistent token buffer
+            # on the previous replay, so tokens/positions need NO host staging. Refresh only the
+            # page table, and only when it actually changed (block boundaries crossed).
+            prev_page_table = self._prev_decode_page_table[sampling_on_device]
+            if prev_page_table is None or not torch.equal(prev_page_table, page_table):
+                host_inputs = self._eager.prepare_decode_inputs_host(tokens, start_pos, page_table)
+                device_inputs = self.trace_inputs_decode[sampling_on_device]
+                ttnn.copy_host_to_device_tensor(host_inputs[3], device_inputs[3])  # page_table only
+                self._prev_decode_page_table[sampling_on_device] = page_table.clone()
+        else:
+            # Reseed (first step after prefill, or loop disabled): full host refresh of all inputs.
+            host_inputs = self._eager.prepare_decode_inputs_host(tokens, start_pos, page_table)
+            copy_host_to_device(
+                host_tensors=host_inputs,
+                device_tensors=self.trace_inputs_decode[sampling_on_device],
+            )
+            self._prev_decode_page_table[sampling_on_device] = page_table.clone()
+            if loop_active:
+                self._decode_needs_reseed[sampling_on_device] = False
+
+        ttnn.execute_trace(
+            self.mesh_device,
+            self.trace_ids_decode[sampling_on_device],
+            cq_id=0,
+            blocking=False,
+        )
+        tt_output = self.trace_output_decode[sampling_on_device]
+
+        if read_from_device:
+            if sampling_on_device:
+                tt_toks, tt_log_probs = tt_output
+                toks_host = tt_toks.cpu()
+                return _process_output_decode_tokens(toks_host, B, cluster_shape), None
+            else:
+                logits, _ = tt_output
+                logits_host = logits.cpu()
+                return _process_output_decode(logits_host, B, vocab_size, num_devices, cluster_shape), None
+
+        return tt_output
+
+    def _prealloc_sampling_buffers(self, sampling_params) -> None:
+        """Materialise the *persistent* on-device sampling buffers before ANY trace is captured.
+
+        The k/p/temp param tensors and Sampling1D's device buffers were previously created lazily
+        inside ``_capture_decode_trace`` — i.e. AFTER the prefill trace is already live. tt-metal
+        flags this ("Allocating device buffers is unsafe due to the existence of an active trace",
+        allocator.cpp) and the buffers can land where a decode-trace buffer overlaps them; on replay
+        the trace clobbers the ``k`` tensor, the sampling writer reads a corrupt (huge) k and walks
+        its top-p loop out of L1 -> hard device hang (seen on perf batch-32 + perf_decode_tuning
+        "LoFi" on N300; LoFi shifts the decode-trace layout so the overlap lands on ``k``).
+        Allocating them here, with no trace active, gives them stable addresses that the prefill and
+        decode traces reserve around. Idempotent: the later capture-time calls reuse these caches.
+        """
+        if sampling_params is None or self.model.sampling is None:
+            return
+        # k/p/temp param tensors (cached on the eager engine; returns None for force-argmax models).
+        self._eager._get_decode_sampling_kpt(sampling_params)
+        # Sampling1D persistent device buffers (local indices / offsets / seeds / user ids).
+        if hasattr(self.model.sampling, "load_device_buffers"):
+            self.model.sampling.load_device_buffers()
+        logger.info("Pre-allocated on-device sampling buffers before trace capture")
+
+    def _capture_decode_trace(self, tokens, start_pos, page_table, kv_cache, sampling_on_device, sampling_params=None):
+        """Compile + capture decode trace."""
+        self._eager.decode_forward(
+            tokens,
+            start_pos,
+            page_table=page_table,
+            kv_cache=kv_cache,
+            read_from_device=False,
+            sampling_params=None,
+        )
+        ttnn.synchronize_device(self.mesh_device)
+        logger.info("Compiled decode")
+
+        host_inputs = self._eager.prepare_decode_inputs_host(tokens, start_pos, page_table)
+        device_inputs = copy_host_to_device(host_inputs, mesh_device=self.mesh_device)
+
+        # On-device decode loop: when active, the sampled token is fed back in place into the
+        # persistent token buffer (device_inputs[0]) and position/rope are advanced on device.
+        loop_active = self._decode_loop_active(sampling_params)
+
+        # On-device sampling: materialise sampling buffers AND JIT-compile the sampling program
+        # BEFORE trace capture. Both buffer materialisation (Sampling1D LazyBuffers + the
+        # LogProbsCalculator's ttnn.as_tensor scratch) and a first-run program compile issue device
+        # writes, which are illegal inside begin/end_trace_capture
+        # ("TT_FATAL: Writes are not supported during trace capture"). The eager warmup above runs
+        # the non-sampling path (sampling_params=None), so the argmax/all-gather sampling op is not
+        # yet compiled — warm it up here against real device logits.
+        if (
+            sampling_on_device
+            and self.model.sampling is not None
+            and hasattr(self.model.sampling, "load_device_buffers")
+        ):
+            self.model.sampling.load_device_buffers()
+            ttnn.synchronize_device(self.mesh_device)
+            with suspend_module_input_validation():
+                wu_tokens, wu_current_pos, wu_rot_mat_idxs, wu_page_table = device_inputs
+                wu_rot_mats = self.model.rope_setup.get_rot_mats(wu_rot_mat_idxs)
+                wu_embed = self.model.embed_decode(wu_tokens)
+                wu_logits = self.model.decode_forward(wu_embed, wu_current_pos, wu_rot_mats, page_table=wu_page_table)
+                # Warm up with the SAME output_tensor the captured body uses, so the
+                # ttnn.sampling(output_tensor=...) program variant is compiled before capture
+                # (avoids a "compile during trace capture" fatal).
+                wu_feedback = wu_tokens if loop_active else None
+                wu_toks, _ = self._eager._sampling_decode_forward(wu_logits, sampling_params, tt_out_tok=wu_feedback)
+            ttnn.synchronize_device(self.mesh_device)
+            # Only free wu_toks if it is a fresh allocation; when loop_active it aliases the
+            # persistent token buffer (device_inputs[0]) and MUST NOT be deallocated.
+            if wu_feedback is None:
+                cleanup_ttnn_value(wu_toks)
+            ttnn.synchronize_device(self.mesh_device)
+            if loop_active:
+                # Warm up BOTH ttnn.plus_one program variants (skip_negative_entries True/False are
+                # distinct compile-time programs) so they are in the program cache before capture —
+                # otherwise the in-trace plus_one triggers "Cannot load new binaries during trace
+                # capture". These increment wu_current_pos/wu_rot_mat_idxs once; harmless, since the
+                # first decode step re-seeds the persistent buffers from host.
+                ttnn.plus_one(wu_current_pos, skip_negative_entries=True)
+                ttnn.plus_one(wu_rot_mat_idxs)
+                ttnn.synchronize_device(self.mesh_device)
+            logger.info("Compiled on-device sampling")
+
+        trace_id = ttnn.begin_trace_capture(self.mesh_device, cq_id=0)
+
+        with suspend_module_input_validation():
+            tt_tokens, tt_current_pos, tt_rot_mat_idxs, tt_page_table = device_inputs
+            rot_mats = self.model.rope_setup.get_rot_mats(tt_rot_mat_idxs)
+            x_embed = self.model.embed_decode(tt_tokens)
+
+            logits = self.model.decode_forward(
+                x_embed,
+                tt_current_pos,
+                rot_mats,
+                page_table=tt_page_table,
+            )
+
+            if sampling_on_device and self.model.sampling is not None:
+                if loop_active:
+                    # On-device loop: feed the sampled token back into the persistent token buffer
+                    # (device_inputs[0]) in place. On the top-k path ttnn.sampling emits uint32
+                    # [1,1,1,32] on Wormhole/Blackhole — an exact match for the token buffer, so
+                    # output_tensor= writes in place with no realloc (safe during capture). Then
+                    # advance position + rope index on device (in-place plus_one), so the NEXT
+                    # execute_trace sees the new token at the new position with zero host staging.
+                    # These writes are AFTER every read of the buffers in this body, so there is no
+                    # intra-trace hazard. plus_one is a pure device op (in-place, traceable); the
+                    # earlier "host-assisted writes illegal during capture" note was mistaken.
+                    tt_toks, tt_log_probs = self._eager._sampling_decode_forward(
+                        logits, sampling_params, tt_out_tok=tt_tokens
+                    )
+                    ttnn.plus_one(tt_current_pos, skip_negative_entries=True)
+                    ttnn.plus_one(tt_rot_mat_idxs)
+                else:
+                    # tt_out_tok=None: sampling allocates its own output; decode_forward re-supplies
+                    # current_pos/rot_mat_idxs from host every step, so no in-trace increment.
+                    tt_toks, tt_log_probs = self._eager._sampling_decode_forward(
+                        logits, sampling_params, tt_out_tok=None
+                    )
+                output = (tt_toks, tt_log_probs)
+            else:
+                logits = self.model.gather_and_untilize_logits(logits)
+                output = (logits, None)
+
+        ttnn.end_trace_capture(self.mesh_device, trace_id, cq_id=0)
+        ttnn.synchronize_device(self.mesh_device)
+
+        self.trace_ids_decode[sampling_on_device] = trace_id
+        self.trace_inputs_decode[sampling_on_device] = device_inputs
+        self.trace_output_decode[sampling_on_device] = output
+
+        logger.info("Captured decode trace")
+
+    # =========================================================================
+    # Cleanup
+    # =========================================================================
+
+    def cleanup(self) -> None:
+        """Release all captured traces and their pinned device tensors."""
+        if self._cleaned_up:
+            return
+
+        # Shared prefill cos/sin tensors are referenced by EVERY per-bucket trace-input tuple
+        # (indices 1,2). Deallocate them exactly once below (not per trace) to avoid a double-free.
+        shared_cos_sin_ids = {
+            id(t) for pair in self._prefill_cos_sin_shared.values() for t in pair if isinstance(t, ttnn.Tensor)
+        }
+        for key, trace_id in list(self.trace_id_prefill.items()):
+            if trace_id is not None:
+                ttnn.release_trace(self.mesh_device, trace_id)
+            inputs = self.trace_inputs_prefill[key]
+            if inputs is not None:
+                for t in inputs:
+                    if isinstance(t, ttnn.Tensor) and id(t) in shared_cos_sin_ids:
+                        continue  # shared cos/sin: freed once, after this loop
+                    cleanup_ttnn_value(t)
+            cleanup_ttnn_value(self.trace_output_prefill[key])
+            self.trace_id_prefill[key] = None
+            self.trace_inputs_prefill[key] = None
+            self.trace_output_prefill[key] = None
+        # Batched prefill traces: same shared-cos/sin id-skip (indices 1,2 are the shared tensors).
+        for key, trace_id in list(self.trace_id_prefill_batched.items()):
+            if trace_id is not None:
+                ttnn.release_trace(self.mesh_device, trace_id)
+            inputs = self.trace_inputs_prefill_batched[key]
+            if inputs is not None:
+                for t in inputs:
+                    if isinstance(t, ttnn.Tensor) and id(t) in shared_cos_sin_ids:
+                        continue  # shared cos/sin: freed once, below
+                    cleanup_ttnn_value(t)
+            cleanup_ttnn_value(self.trace_output_prefill_batched[key])
+            self.trace_id_prefill_batched[key] = None
+            self.trace_inputs_prefill_batched[key] = None
+            self.trace_output_prefill_batched[key] = None
+        # Free the shared cos/sin once.
+        for pair in self._prefill_cos_sin_shared.values():
+            cleanup_ttnn_value(pair)
+        self._prefill_cos_sin_shared.clear()
+        for key, trace_id in list(self.trace_ids_decode.items()):
+            if trace_id is not None:
+                ttnn.release_trace(self.mesh_device, trace_id)
+            cleanup_ttnn_value(self.trace_inputs_decode[key])
+            cleanup_ttnn_value(self.trace_output_decode[key])
+            self.trace_ids_decode[key] = None
+            self.trace_inputs_decode[key] = None
+            self.trace_output_decode[key] = None
+
+        self._eager._kv_cache = None
+        self._cleaned_up = True
+
+
+def _get_validation_context(executor, *, mode: str):
+    """Return the config-validation context for an executor or thin wrapper."""
+    engine = getattr(executor, "_engine", executor)
+    if isinstance(engine, TracedLLMExecutor):
+        engine = engine._eager
+    if isinstance(engine, EagerLLMExecutor):
+        return validate_module_input_configs(
+            model=engine.model,
+            iter_named_modules=engine._iter_named_modules,
+            mode=mode,
+        )
+    return contextlib.nullcontext()
+
+
+def _is_traced_executor(executor) -> bool:
+    """Identify executors that expose trace-facing APIs."""
+    return hasattr(executor, "trace_id_prefill") and hasattr(executor, "trace_ids_decode")
+
+
+def _compile_prefill_and_decode(
+    executor: EagerLLMExecutor | TracedLLMExecutor,
+    *,
+    prefill_tokens: torch.Tensor,
+    prefill_page_table: torch.Tensor,  # Required
+    kv_cache: list[list[ttnn.Tensor]] | None = None,
+    prompt_lens: torch.Tensor | None = None,
+    empty_slots: list[int] | None = None,
+    start_pos: torch.Tensor | None = None,
+    sampling_params: SamplingParams | None = None,
+    validate_configs: bool = False,
+) -> None:
+    """Internal convenience helper for one-shot prefill+decode warmup."""
+    assert prefill_tokens.dim() == 2, f"prefill_tokens must be [batch_size, seq_len], got {prefill_tokens.dim()}D"
+    assert (
+        prefill_page_table.dim() == 2
+    ), f"prefill_page_table must be [batch_size, max_blocks], got {prefill_page_table.dim()}D"
+
+    # Capture the DECODE trace BEFORE the prefill trace. The batched-prefill trace's folded buffers are
+    # ~padded_batch× the single-user footprint; when the prefill trace is captured FIRST and the decode
+    # trace is captured immediately after (while the prefill trace is live), the decode capture lands in
+    # a layout that overlaps the large batched-prefill trace and clobbers its replay — every batched user
+    # then decodes garbage from the very first token (single-user prefill survives only by its far smaller
+    # footprint). Capturing decode first — so its buffers are reserved before the large prefill trace is
+    # built, and nothing is captured after prefill to overlap it — removes the overlap. Correctness is
+    # unaffected by the swap: the decode trace is warmed with placeholder tokens, but decode
+    # tokens/positions are refreshed from host (or fed back on device) on every replay, so warmup values
+    # never reach the output; only the capture ORDER changes. (This also removes the reason the sampling
+    # buffers had to be pre-materialised while the prefill trace was live — decode now captures with no
+    # prefill trace active — while _prealloc_sampling_buffers in compile_prefill still guards the prefill
+    # capture.)
+    prefill_context = (
+        _get_validation_context(executor, mode="prefill") if validate_configs else contextlib.nullcontext()
+    )
+    decode_context = _get_validation_context(executor, mode="decode") if validate_configs else contextlib.nullcontext()
+    batch_size = prefill_tokens.shape[0]
+
+    decode_start_pos = torch.full(
+        (batch_size,),
+        prefill_tokens.shape[-1],
+        dtype=torch.long,
+        device=prefill_tokens.device,
+    )
+    with decode_context:
+        executor.compile_decode(
+            tokens=torch.zeros(batch_size, dtype=torch.long, device=prefill_tokens.device),
+            start_pos=decode_start_pos,
+            page_table=prefill_page_table,
+            kv_cache=kv_cache,
+            sampling_params=sampling_params,
+        )
+
+    with prefill_context:
+        executor.compile_prefill(
+            tokens=prefill_tokens,
+            page_table=prefill_page_table,
+            kv_cache=kv_cache,
+            prompt_lens=prompt_lens,
+            empty_slots=empty_slots,
+            start_pos=start_pos,
+            sampling_params=sampling_params,
+        )
+
+
+# =============================================================================
+# Loop Policy Functions
+# =============================================================================
+
+
+@dataclass
+class TeacherForceResult:
+    """Result from a teacher-forcing evaluation run."""
+
+    predicted_tokens: list[int]
+    predicted_tokens_per_user: list[list[int]]
+    reference_top5: torch.Tensor  # shape [num_tokens, 5]
+    # Timing — populated by run_teacher_forcing so the token-accuracy leg can emit the SAME
+    # benchmark measurement set as TTTv1's ci-token-matching leg (prefill_t/s, decode_t/s,
+    # decode_t/s/u, TTFT). The decode loop feeds ground-truth tokens (teacher forcing), but the
+    # device ops — and therefore the measured durations — are identical to a free-running decode,
+    # so these are real perf numbers for the accuracy path. Defaults keep the dataclass
+    # backward-compatible for any caller that ignores timing. Mirrors PerfBenchmarkResult.
+    prefill_time_s: float = 0.0
+    compile_decode_time_s: float = 0.0
+    decode_times_s: list[float] = field(default_factory=list)
+    batch_size: int = 1
+    prefill_len: int = 0
+
+    def top1_accuracy(self) -> float:
+        matches = sum(1 for i, p in enumerate(self.predicted_tokens) if self.reference_top5[i, 0].item() == p)
+        return matches / len(self.predicted_tokens)
+
+    def top5_accuracy(self) -> float:
+        matches = sum(1 for i, p in enumerate(self.predicted_tokens) if p in self.reference_top5[i, :])
+        return matches / len(self.predicted_tokens)
+
+    @property
+    def ttft_ms(self) -> float:
+        """Average time-to-first-token per user (ms)."""
+        return self.prefill_time_s / self.batch_size * 1000 if self.batch_size else 0.0
+
+    @property
+    def prefill_time_to_token_s(self) -> float:
+        """Average time-to-first-token per user (seconds) — TTTv1 ``prefill_time_to_token``."""
+        return self.prefill_time_s / self.batch_size if self.batch_size else 0.0
+
+    @property
+    def prefill_tok_s(self) -> float:
+        """Prefill throughput (tokens/s) over all users."""
+        return (self.batch_size * self.prefill_len) / self.prefill_time_s if self.prefill_time_s > 0 else 0.0
+
+    @property
+    def decode_tok_s_u(self) -> float:
+        """Steady-state decode tokens/s/user (compile/warmup step excluded)."""
+        return len(self.decode_times_s) / sum(self.decode_times_s) if self.decode_times_s else 0.0
+
+    @property
+    def decode_tok_s(self) -> float:
+        """Steady-state decode throughput (tokens/s) over all users."""
+        return self.decode_tok_s_u * self.batch_size
+
+
+def run_teacher_forcing(
+    executor: EagerLLMExecutor | TracedLLMExecutor,
+    *,
+    prompt_tokens: torch.Tensor,
+    reference_tokens: torch.Tensor,
+    top5_tokens: torch.Tensor,
+    kv_cache: list,
+    page_table: torch.Tensor,  # Required
+    max_batch_size: int = 1,
+    profiler: BenchmarkProfiler | None = None,
+) -> TeacherForceResult:
+    """Run teacher-forcing accuracy measurement.
+
+    Teacher forcing feeds ground truth tokens at each step and measures
+    prediction accuracy. This is the canonical accuracy measurement for LLMs.
+
+    The prefill and per-step decode regions are timed (compile is excluded — it runs in a
+    separate warmup pass, and the first timed decode step is treated as post-compile warmup like
+    ``run_perf_benchmark``), so the returned ``TeacherForceResult`` also carries prefill/decode
+    throughput. This lets the token-accuracy leg emit the same benchmark measurements as TTTv1's
+    ci-token-matching leg. When ``profiler`` is supplied, the timed regions are also bracketed
+    with ``inference_prefill`` / ``inference_decode`` steps for CI benchmark-data emission.
+
+    Args:
+        executor: Any executor with prefill_forward() and decode_forward() methods.
+        prompt_tokens: Prompt token IDs, shape [batch_size, prompt_len].
+        reference_tokens: Full reference sequence (prompt + target), shape [total_len].
+        top5_tokens: Top-5 reference tokens per position, shape [num_target_tokens, 5].
+        kv_cache: Per-layer KV cache from allocate_kv_cache().
+        page_table: Page table for paged attention. Required.
+        max_batch_size: Maximum batch size. Must match prompt_tokens.shape[0].
+        profiler: Optional ``BenchmarkProfiler``; when supplied, brackets the timed prefill /
+            decode regions ("inference_prefill" / "inference_decode"). Default ``None`` ⇒
+            byte-inert for callers that don't emit benchmark data.
+
+    Returns:
+        TeacherForceResult with predicted tokens, accuracy metrics, and prefill/decode timings.
+    """
+    batch_size = prompt_tokens.shape[0]
+    assert (
+        batch_size == max_batch_size
+    ), f"Teacher forcing expects active batch to match max_batch_size, got {batch_size} vs {max_batch_size}"
+    prompt_len = prompt_tokens.shape[-1]
+    total_len = len(reference_tokens)
+    num_target = total_len - prompt_len
+
+    # Compile prefill + decode with config validation
+    _compile_prefill_and_decode(
+        executor,
+        prefill_tokens=prompt_tokens,
+        prefill_page_table=page_table,
+        kv_cache=kv_cache,
+        prompt_lens=torch.tensor([prompt_len] * batch_size),
+        empty_slots=list(range(batch_size)),
+        validate_configs=True,
+    )
+
+    logger.info(f"Teacher forcing: prefilling {prompt_len} tokens with batch={batch_size}")
+    prefill_kwargs = dict(
+        page_table=page_table,
+        kv_cache=kv_cache,
+        prompt_lens=torch.tensor([prompt_len] * batch_size),
+        empty_slots=list(range(batch_size)),
+    )
+    # Inference prefill: timed run with ops already compiled (this is TTFT). Mirror
+    # run_perf_benchmark: synchronize inside the timed region for an accurate prefill duration.
+    if profiler is not None:
+        profiler.start("inference_prefill")
+    t0 = time.perf_counter()
+    prefill_output = executor.prefill_forward(prompt_tokens, **prefill_kwargs)
+    if hasattr(executor, "mesh_device"):
+        ttnn.synchronize_device(executor.mesh_device)
+    prefill_time_s = time.perf_counter() - t0
+    if profiler is not None:
+        profiler.end("inference_prefill")
+
+    first_tokens = torch.argmax(prefill_output, dim=-1).view(-1).tolist()
+    predicted_tokens_per_user = [[int(tok)] for tok in first_tokens]
+
+    logger.info(f"Teacher forcing: decoding {num_target - 1} tokens")
+    decode_times_s: list[float] = []
+    compile_decode_time_s = 0.0
+    if profiler is not None:
+        profiler.start("inference_decode")
+    for step in range(1, num_target):
+        gt_token = reference_tokens[prompt_len + step - 1]
+        decode_token = torch.full((batch_size,), gt_token, dtype=torch.long)
+
+        current_pos = torch.full((batch_size,), prompt_len + step - 1, dtype=torch.long)
+
+        decode_kwargs = dict(
+            page_table=page_table,
+            kv_cache=kv_cache,
+            read_from_device=True,
+        )
+        t0 = time.perf_counter()
+        logits, _ = executor.decode_forward(decode_token, current_pos, **decode_kwargs)
+        elapsed = time.perf_counter() - t0
+        # First timed decode step is post-compile warmup (excluded from the steady-state average),
+        # mirroring run_perf_benchmark / TTTv1's iteration-0 handling.
+        if step == 1:
+            compile_decode_time_s = elapsed
+        else:
+            decode_times_s.append(elapsed)
+
+        next_tokens = torch.argmax(logits[:, -1, :], dim=-1).view(-1).tolist()
+        for user_id, tok in enumerate(next_tokens):
+            predicted_tokens_per_user[user_id].append(int(tok))
+    if profiler is not None:
+        profiler.end("inference_decode")
+
+    return TeacherForceResult(
+        predicted_tokens=predicted_tokens_per_user[0],
+        predicted_tokens_per_user=predicted_tokens_per_user,
+        reference_top5=top5_tokens[:num_target],
+        prefill_time_s=prefill_time_s,
+        compile_decode_time_s=compile_decode_time_s,
+        decode_times_s=decode_times_s,
+        batch_size=batch_size,
+        prefill_len=prompt_len,
+    )
+
+
+@dataclass
+class PerfBenchmarkResult:
+    """Result from a performance benchmark run."""
+
+    prefill_time_s: float
+    compile_decode_time_s: float
+    decode_times_s: list[float]
+    batch_size: int
+    num_decode_tokens: int
+    generated_token_ids: list[list[int]]
+
+    @property
+    def ttft_ms(self) -> float:
+        """Average time-to-first-token per user (ms)."""
+        return self.prefill_time_s / self.batch_size * 1000
+
+    @property
+    def tok_s_u(self) -> float:
+        """Tokens per second per user (steady-state decode)."""
+        if not self.decode_times_s:
+            return 0.0
+        return len(self.decode_times_s) / sum(self.decode_times_s)
+
+    @property
+    def tok_s(self) -> float:
+        """Total throughput."""
+        return self.tok_s_u * self.batch_size
+
+    @property
+    def decode_latency_mean_ms(self) -> float:
+        if not self.decode_times_s:
+            return 0.0
+        return (sum(self.decode_times_s) / len(self.decode_times_s)) * 1000
+
+    def meets_target(self, expected: dict, tolerance: float = 0.05) -> dict[str, bool]:
+        """Check against expected metrics. Returns {metric: passed}."""
+        return {
+            "tok_s_u": self.tok_s_u >= expected["tok_s_u"] * (1 - tolerance),
+            "ttft_ms": self.ttft_ms <= expected["ttft_ms"] * (1 + tolerance),
+        }
+
+
+def run_perf_benchmark(
+    executor: EagerLLMExecutor | TracedLLMExecutor,
+    *,
+    tokens: torch.Tensor,
+    kv_cache: list,
+    page_table: torch.Tensor,  # Required
+    num_decode_tokens: int = 128,
+    max_batch_size: int = 1,
+    prompt_lens: torch.Tensor | None = None,
+    start_pos: list[int] | None = None,
+    sampling_params=None,
+    pipeline_readback: bool = True,
+    profiler: BenchmarkProfiler | None = None,
+) -> PerfBenchmarkResult:
+    """Run timed prefill + decode loop for performance measurement.
+
+    Matches TTTv1 methodology: compile prefill is excluded from TTFT.
+    Iteration 0 of decode is the compile iteration (timed separately).
+
+    Args:
+        executor: Any executor with prefill_forward() and decode_forward() methods.
+        tokens: Input token IDs, shape [batch_size, seq_len].
+        kv_cache: Per-layer KV cache from allocate_kv_cache().
+        page_table: Page table for paged attention. Required.
+        num_decode_tokens: Number of decode tokens to generate.
+        max_batch_size: Maximum batch size.
+        prompt_lens: Actual prompt length per user, shape [batch_size].
+        start_pos: Starting position for prefix caching.
+        sampling_params: Explicit sampling params (None = host argmax).
+        pipeline_readback: Overlap each step's token readback with the next step's
+            trace (host one step behind the device). Only engages when the executor's
+            on-device decode loop is active on the top-k path; ignored otherwise. Set
+            False to A/B against the blocking readback.
+        profiler: Optional ``BenchmarkProfiler``. When supplied, the timed inference-prefill
+            and inference-decode regions are bracketed with ``start``/``end`` steps
+            ("inference_prefill" / "inference_decode") so callers can emit CI benchmark
+            data. Default ``None`` ⇒ byte-inert for every other caller.
+
+    Returns:
+        PerfBenchmarkResult with raw timings + derived metrics.
+    """
+    assert _is_traced_executor(executor), "run_perf_benchmark() expects a traced executor during this transition"
+
+    batch_size = tokens.shape[0]
+    prompt_len = tokens.shape[1]
+    max_batch_size = max(max_batch_size, batch_size)
+    # todo)) prompt_lens should be always passed in!
+    prompt_lens = prompt_lens if prompt_lens is not None else torch.tensor([prompt_len] * batch_size)
+
+    prefill_kwargs = dict(
+        page_table=page_table,
+        kv_cache=kv_cache,
+        prompt_lens=prompt_lens,
+        empty_slots=list(range(batch_size)),
+        start_pos=start_pos,
+    )
+
+    compile_batch_size = max_batch_size
+    compile_tokens = torch.zeros(compile_batch_size, prompt_len, dtype=tokens.dtype)
+    compile_tokens[:batch_size] = tokens
+    compile_prompt_lens = torch.zeros(compile_batch_size, dtype=prompt_lens.dtype)
+    compile_prompt_lens[:batch_size] = prompt_lens
+
+    # Compile prefill + decode: warmup run with config validation (excluded from TTFT)
+    _compile_prefill_and_decode(
+        executor,
+        prefill_tokens=compile_tokens,
+        prefill_page_table=page_table,
+        kv_cache=kv_cache,
+        prompt_lens=compile_prompt_lens,
+        empty_slots=list(range(batch_size)),
+        start_pos=start_pos,
+        sampling_params=sampling_params,
+        validate_configs=True,
+    )
+
+    # Inference prefill: timed run with ops already compiled (this is TTFT)
+    if profiler is not None:
+        profiler.start("inference_prefill")
+    t0 = time.perf_counter()
+    prefill_output = executor.prefill_forward(tokens, **prefill_kwargs, sampling_params=sampling_params)
+    if hasattr(executor, "mesh_device"):
+        ttnn.synchronize_device(executor.mesh_device)
+    prefill_time = time.perf_counter() - t0
+    if profiler is not None:
+        profiler.end("inference_prefill")
+
+    if isinstance(prefill_output, tuple):
+        first_token = prefill_output[0]
+    else:
+        first_token = torch.argmax(prefill_output, dim=-1)
+    first_token = first_token.view(-1)[:batch_size].detach().cpu()
+    generated_token_ids = [[int(tok)] for tok in first_token.tolist()]
+
+    current_tokens = torch.zeros(max_batch_size, dtype=torch.long)
+    current_tokens[:batch_size] = first_token
+
+    current_pos = torch.full((max_batch_size,), -1, dtype=torch.long)
+    current_pos[:batch_size] = prompt_lens[:batch_size]
+
+    compile_time = None
+    decode_times = []
+
+    # Pipelined non-blocking readback (on-device decode loop, top-k path only).
+    # The captured trace feeds the sampled token back on device (ttnn.sampling
+    # output_tensor=) and advances position/rope on device (ttnn.plus_one), so step
+    # N+1's replay does NOT depend on step N's token reaching the host. We therefore
+    # issue each step's token readback non-blocking, launch the next step's trace,
+    # and resolve step N's token one iteration later — the host stays exactly one
+    # step behind the device. This mirrors the deferred-readback idiom in
+    # models/demos/llama3_70b_galaxy/demo/demo_decode.py (``.cpu(blocking=False)`` +
+    # ``record_event`` ... ``event_synchronize``) and the vLLM async-read path; note
+    # the single-box text demo instead reads back blocking. Overlapping the readback +
+    # host bookkeeping with device compute removes the per-step host round-trip that
+    # otherwise serializes with the very short batch-1 device step. The token stream is
+    # unchanged: the device produces the same tokens; we only read them back deferred,
+    # then drain the last one so generated_token_ids is byte-identical to the blocking
+    # loop. Pass pipeline_readback=False to A/B back to the blocking readback.
+    # Every other path (host resupply, force-argmax, host sampling) is unaffected —
+    # only _decode_loop_active (executor.ondevice_decode_loop + top-k) qualifies.
+    _engine = getattr(executor, "_engine", executor)
+    _pipeline_readback = (
+        isinstance(_engine, TracedLLMExecutor) and _engine._decode_loop_active(sampling_params) and pipeline_readback
+    )
+
+    if profiler is not None:
+        profiler.start("inference_decode")
+    if _pipeline_readback:
+        cluster_shape = _engine.model_args.cluster_shape if getattr(_engine, "model_args", None) else [1, 1]
+        mesh_device = executor.mesh_device
+
+        def _consume(host_tok):
+            toks = _process_output_decode_tokens(host_tok, batch_size, cluster_shape)
+            for user_id, tok in enumerate(toks.view(-1)[:batch_size].tolist()):
+                generated_token_ids[user_id].append(int(tok))
+
+        prev_event = None
+        prev_host_tok = None
+        for i in range(num_decode_tokens):
+            t0 = time.perf_counter()
+            # read_from_device=False: get the persistent device token buffer without
+            # a blocking readback. current_tokens is intentionally not refreshed — the
+            # device owns the token via in-trace feedback after the first (reseed)
+            # step; the steady-state path ignores it (and a page-table refresh copies
+            # only the page table, never the token buffer).
+            tt_output = executor.decode_forward(
+                current_tokens,
+                current_pos,
+                page_table=page_table,
+                kv_cache=kv_cache,
+                read_from_device=False,
+                sampling_params=sampling_params,
+            )
+            tt_toks = tt_output[0]
+            host_tok = tt_toks.cpu(blocking=False)  # issue read; do not wait
+            read_event = ttnn.record_event(mesh_device, 0)  # retires when this read lands
+            if prev_event is not None:
+                # Wait for the PREVIOUS step's read, which retired in the background
+                # while this step's trace ran — this is the loop's device-paced beat.
+                ttnn.event_synchronize(prev_event)
+            elapsed = time.perf_counter() - t0
+
+            if prev_host_tok is not None:
+                _consume(prev_host_tok)
+            prev_event, prev_host_tok = read_event, host_tok
+            current_pos[:batch_size] += 1
+
+            if i == 0:
+                compile_time = elapsed
+            else:
+                decode_times.append(elapsed)
+
+        # Drain the final in-flight token so the generated stream matches exactly.
+        if prev_host_tok is not None:
+            ttnn.event_synchronize(prev_event)
+            _consume(prev_host_tok)
+    else:
+        for i in range(num_decode_tokens):
+            t0 = time.perf_counter()
+            logits, _ = executor.decode_forward(
+                current_tokens,
+                current_pos,
+                page_table=page_table,
+                kv_cache=kv_cache,
+                read_from_device=True,
+                sampling_params=sampling_params,
+            )
+            elapsed = time.perf_counter() - t0
+
+            if i == 0:
+                compile_time = elapsed
+            else:
+                decode_times.append(elapsed)
+
+            if isinstance(logits, torch.Tensor) and logits.dim() >= 2:
+                next_tok = torch.argmax(logits[:, -1, :], dim=-1)
+            else:
+                next_tok = logits
+            next_tok = next_tok.view(-1)[:batch_size].detach().cpu()
+            for user_id, tok in enumerate(next_tok.tolist()):
+                generated_token_ids[user_id].append(int(tok))
+            current_tokens[:batch_size] = next_tok
+            current_pos[:batch_size] += 1
+
+    if profiler is not None:
+        profiler.end("inference_decode")
+
+    return PerfBenchmarkResult(
+        prefill_time_s=prefill_time,
+        compile_decode_time_s=compile_time or 0.0,
+        decode_times_s=decode_times,
+        batch_size=batch_size,
+        num_decode_tokens=num_decode_tokens,
+        generated_token_ids=generated_token_ids,
+    )
+
+
+# =============================================================================
+# ci-eval-32: 32-user cross-batch determinism (self-consistency) helpers
+# =============================================================================
+#
+# TTTv2 equivalent of the TTTv1 ``ci-eval-32`` case: run the batch-32 prefill+decode
+# loop ``repeat_batches`` times, rotating the prompt->slot assignment by one each
+# repeat, and assert that undoing the rotation lines up per-user outputs. There is no
+# external golden — the target is the model's own output under prompt rotation.
+#
+# These helpers operate on the per-user token-id streams already returned by
+# ``run_perf_benchmark`` (``PerfBenchmarkResult.generated_token_ids``) — no new device
+# plumbing. Comparing token-id lists (not decoded text) is stricter than TTTv1's
+# decoded-string compare and avoids tokenizer-decode ambiguity.
+#
+# Prompt parity with TTTv1: the demos feed ``eval_repeat_prompts_batch32.json`` — the same
+# numeric sequence-continuation prompts TTTv1's ci-eval-32 case uses (simple_text_demo.py).
+# Caveat: the self-consistency assert requires bit-exact reproduction of a prompt's greedy
+# output across batch slots. With the CI default (host argmax) decoding is slot-invariant and
+# deterministic, so the case passes and is gated in CI with no xfail. The residual risk is
+# on-device sampling on DEGENERATE repetitive output (a small model looping on one token): such
+# output sits on argmax near-ties whose resolution can shift with batch position (batched-matmul
+# / all-gather FP non-associativity) and would not be slot-invariant. This has NOT been observed
+# for TTTv2-1B — the case is green on N300 under both host and on_device_topk (batched prefill on
+# and off). If a future model's prompts degenerate under on-device sampling, prefer the host-argmax
+# default for this case (or add per-model prompts) rather than treating it as a harness bug.
+
+
+def load_eval_repeat_prompts_batch32() -> list[str]:
+    """The 32 numeric sequence-continuation prompts TTTv1's ci-eval-32 uses (parity)."""
+    path = Path("models/tt_transformers/demo/sample_prompts/eval_repeat_prompts_batch32.json")
+    with open(path) as f:
+        data = json.load(f)
+    return [entry["prompt"] for entry in data]
+
+
+def rotate_prompts(all_prompts: list[str], repeat: int) -> list[str]:
+    """Rotate the prompt->slot assignment by ``repeat``: slot j holds prompt (j+repeat)%N."""
+    n = len(all_prompts)
+    return [all_prompts[(j + repeat) % n] for j in range(n)]
+
+
+def truncate_at_stop(ids: list[int], stop_ids: set[int]) -> list[int]:
+    """Prefix of ``ids`` up to (excluding) the first id in ``stop_ids``."""
+    out: list[int] = []
+    for t in ids:
+        if t in stop_ids:
+            break
+        out.append(t)
+    return out
+
+
+def hf_stop_ids(tokenizer, hf_model_id: str | None = None) -> set[int]:
+    """Best-effort stop-token id set for an HF ``AutoTokenizer``.
+
+    Raw HF tokenizers have no ``.stop_tokens`` (that only exists on the TTTv1 wrapped
+    tokenizer). Build the set from ``eos_token_id`` (int|list|None), and — when an
+    ``hf_model_id`` is supplied — also fold in the model's ``generation_config`` eos ids,
+    since chat models (e.g. Llama-3 Instruct) often carry extra eot ids there rather than
+    on ``eos_token_id``. Missing/empty -> empty set (truncation simply runs full length).
+    """
+    stop: set[int] = set()
+
+    def _add(value) -> None:
+        if value is None:
+            return
+        if isinstance(value, bool):  # guard: bool is an int subclass
+            return
+        if isinstance(value, int):
+            stop.add(int(value))
+        elif isinstance(value, (list, tuple, set)):
+            for e in value:
+                _add(e)
+
+    _add(getattr(tokenizer, "eos_token_id", None))
+    # tt_transformers ModelArgs.tokenizer augments the HF tokenizer with ``stop_tokens``
+    # (eos + any extra eot ids); raw HF AutoTokenizers don't have it (getattr -> None).
+    _add(getattr(tokenizer, "stop_tokens", None))
+    if hf_model_id is not None:
+        try:
+            from transformers import GenerationConfig
+
+            gen_cfg = GenerationConfig.from_pretrained(hf_model_id)
+            _add(getattr(gen_cfg, "eos_token_id", None))
+        except Exception as e:  # generation_config absent / unreadable — eos_token_id is enough
+            logger.debug(f"ci-eval-32: could not read generation_config eos ids for {hf_model_id}: {e}")
+    return stop
+
+
+def assert_cross_batch_consistency(per_repeat_outputs: list[list[list[int]]]) -> None:
+    """Assert prompt-position invariance across repeats.
+
+    ``per_repeat_outputs[b][u]`` = truncated token-id list for slot ``u`` of repeat ``b``.
+    With slot j of repeat b holding prompt (j+b)%N (see ``rotate_prompts``), the same prompt
+    sits at slot (offset+1)%N of repeat b and slot offset of repeat b+1 — so those two
+    outputs must be identical if no per-user state leaks.
+    """
+    num_batches = len(per_repeat_outputs)
+    assert num_batches >= 2, "cross-batch consistency needs >=2 repeats"
+    n = len(per_repeat_outputs[0])
+    failed, total = 0, 0
+    first_failure = None
+    for b in range(num_batches - 1):
+        cur, nxt = per_repeat_outputs[b], per_repeat_outputs[b + 1]
+        for offset in range(n):
+            total += 1
+            if cur[(offset + 1) % n] != nxt[offset]:
+                failed += 1
+                if first_failure is None:
+                    first_failure = (b, offset)
+    assert failed == 0, (
+        f"ci-eval-32: {failed}/{total} cross-batch consistency checks failed "
+        f"(first at repeat {first_failure[0]}->{first_failure[0] + 1}, offset {first_failure[1]})"
+    )
+
+
+def run_eval_repeat_batch32(
+    *,
+    make_executor,
+    allocate_kv_cache,
+    page_table: torch.Tensor,
+    prompts: list[str],
+    tokenizer,
+    tokenize_fn,
+    num_decode_tokens: int,
+    max_batch_size: int,
+    sampling_params=None,
+    repeat_batches: int = 3,
+    hf_model_id: str | None = None,
+) -> None:
+    """Drive the ci-eval-32 determinism case, building a fresh traced executor per repeat.
+
+    Each repeat builds its own traced executor (``make_executor()``) and its own zeroed KV
+    cache (``allocate_kv_cache(executor)``), so the rotated batches are fully independent —
+    no shared device or host state can leak across repeats. The executor is cleaned up after
+    each repeat. (The model is bit-deterministic across repeats either way; fresh-per-repeat
+    is simply the cleanest independence guarantee for a determinism test, and the trace
+    recapture cost is negligible at batch-32.)
+
+    Args:
+        make_executor: Zero-arg callable returning a fresh traced executor
+            (``run_perf_benchmark`` requires traced). Called once per repeat.
+        allocate_kv_cache: Callable(executor) -> fresh zeroed kv_cache bound on that executor.
+        page_table: Fixed contiguous page table (shared across repeats).
+        prompts: The N (=max_batch_size) prompts to rotate (TTTv1 ci-eval-32 numeric prompts;
+            see the module note above re: degenerate-output sensitivity on small models).
+        tokenizer: HF tokenizer (for stop / special ids).
+        tokenize_fn: Callable(list[str]) -> (tokens, prompt_lens).
+        num_decode_tokens: Decode steps per repeat.
+        max_batch_size: Padded batch (== len(prompts) for this fixed-32 case).
+        sampling_params: None -> host argmax (deterministic, mesh-agnostic default).
+        repeat_batches: Number of rotated repeats (TTTv1 uses 3).
+        hf_model_id: Optional, to enrich stop ids from generation_config.
+    """
+    assert (
+        len(prompts) == max_batch_size
+    ), f"ci-eval-32 expects len(prompts)==max_batch_size; got {len(prompts)} vs {max_batch_size}"
+    stop_ids = hf_stop_ids(tokenizer, hf_model_id)
+    special_ids = set(getattr(tokenizer, "all_special_ids", []) or [])
+    # Garbage guard targets only special tokens that are NOT recognized stops: a legitimate
+    # stop is removed by truncation, so anything special left in the body is degenerate output.
+    garbage_ids = special_ids - stop_ids
+    logger.info(
+        f"ci-eval-32: repeat_batches={repeat_batches}, N={len(prompts)}, "
+        f"stop_ids={sorted(stop_ids)}, |special_ids|={len(special_ids)}, sampling_params={sampling_params}"
+    )
+
+    per_repeat: list[list[list[int]]] = []
+    for i in range(repeat_batches):
+        traced_executor = make_executor()
+        try:
+            kv_cache = allocate_kv_cache(traced_executor)
+            rotated = rotate_prompts(prompts, i)
+            tokens, prompt_lens = tokenize_fn(rotated)
+            result = run_perf_benchmark(
+                traced_executor,
+                tokens=tokens,
+                kv_cache=kv_cache,
+                page_table=page_table,
+                num_decode_tokens=num_decode_tokens,
+                max_batch_size=max_batch_size,
+                prompt_lens=prompt_lens,
+                sampling_params=sampling_params,
+            )
+        finally:
+            traced_executor.cleanup()
+        truncated = [truncate_at_stop(ids, stop_ids) for ids in result.generated_token_ids]
+        for u, ids in enumerate(truncated):
+            bad = set(ids) & garbage_ids
+            assert not bad, f"ci-eval-32: user {u} produced special token(s) {sorted(bad)} mid-stream"
+        per_repeat.append(truncated)
+        logger.info(f"ci-eval-32 repeat {i}: truncated lengths = {[len(t) for t in truncated]}")
+
+    assert_cross_batch_consistency(per_repeat)
+    logger.info(f"ci-eval-32: all {(repeat_batches - 1) * len(prompts)} cross-batch consistency checks passed")
+
+
+# =============================================================================
+# Shared helpers
+# =============================================================================
+
+
+def _concat_host_output(tt_out, cluster_shape, is_galaxy=False):
+    """Concatenate multi-device output into a single host tensor."""
+    torch_out_tensors = [ttnn.to_torch(x) for x in ttnn.get_device_tensors(tt_out)]
+    row_dim, col_dim = (1, -1)
+
+    rows, cols = cluster_shape
+    mesh_shape = [torch_out_tensors[i : i + cols] for i in range(0, len(torch_out_tensors), cols)]
+    row_concatenated = [torch.cat(row, dim=col_dim) for row in mesh_shape]
+    return torch.cat(row_concatenated, dim=row_dim)
+
+
+def _process_output_prefill(tt_out, last_token_idx, vocab_size, cluster_shape):
+    """Device→host for prefill. Returns logits for the last token."""
+    assert tt_out.storage_type() == ttnn.StorageType.HOST, "Expected host tensor"
+    return _concat_host_output(tt_out, cluster_shape)[0, 0, last_token_idx, :vocab_size]
+
+
+def _process_output_decode(tt_out, B, vocab_size, num_devices, cluster_shape):
+    """Device→host for decode. Returns logits [B, 1, vocab_size]."""
+    if num_devices > 1:
+        # Decode logits are vocab-sharded across devices; stitch shards back before argmax.
+        tt_out = _concat_host_output(tt_out, cluster_shape).float()
+    else:
+        tt_out = ttnn.to_torch(tt_out).float()
+    return tt_out[:, :, :B, :vocab_size].contiguous().view(B, 1, -1)
+
+
+def _process_output_decode_tokens(tt_out, B, cluster_shape):
+    """Device→host for decode when sampling on device. Returns token ids [B]."""
+    padded_batch_size = 32
+    tt_out = ttnn.reshape(tt_out, ttnn.Shape([1, 1, padded_batch_size, 1]))
+    return _concat_host_output(tt_out, cluster_shape)[0, 0, :B, 0]
+
+
+def _get_prefill_user_page_table(page_table, kv_cache, prefill_len):
+    """Slice and pad page table for a single prefill user."""
+    block_size = get_block_size(kv_cache)
+    num_blocks = num_blocks_in_seq(prefill_len, block_size)
+    return page_table[:, :num_blocks]
+
+
+def _get_prefill_trace_user_page_table(page_table, kv_cache, prefill_seq_len):
+    """Slice page table for traced prefill's padded sequence length."""
+    block_size = get_block_size(kv_cache)
+    num_blocks = num_blocks_in_seq(prefill_seq_len, block_size)
+    return page_table[:, :num_blocks]

--- a/models/experimental/llama32_1b_quasar/models/generator.py
+++ b/models/experimental/llama32_1b_quasar/models/generator.py
@@ -1,0 +1,98 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Llama3Generator — thin vLLM adapter wrapping an executor.
+
+Zero trace state, zero warmup state, zero execution logic.
+Just signature adaptation for TTModelRunner.
+"""
+
+import ttnn
+from models.common.models.llama3_8b.model import EagerLlamaExecutor, Llama3Transformer1D, TracedLlamaExecutor
+
+
+class Llama3Generator:
+    """vLLM-compatible adapter. Wraps any executor (typically traced).
+
+    Usage:
+        generator = Llama3Generator.initialize_vllm_model(hf_config, mesh_device, ...)
+        kv_cache = generator.allocate_kv_cache(shape, dtype, num_layers)
+        logits = generator.prefill_forward(tokens, page_table=..., kv_cache=kv_cache, ...)
+        output = generator.decode_forward(tokens, start_pos, page_table=..., kv_cache=kv_cache, ...)
+    """
+
+    model_capabilities = {"supports_prefix_caching": True}
+
+    def __init__(self, executor: EagerLlamaExecutor | TracedLlamaExecutor, model_args=None):
+        self.executor = executor
+        self.model = executor.model
+        self.model_args = model_args
+        self.mesh_device = executor.mesh_device
+
+    @classmethod
+    def initialize_vllm_model(
+        cls,
+        hf_config,
+        mesh_device,
+        max_batch_size,
+        max_seq_len,
+        n_layers=None,
+        optimizations="performance",
+    ):
+        """Build Llama3Transformer1D from HF config and wrap in traced executor.
+
+        This is the entry point called by vLLM's TTModelRunner.
+        """
+        from models.tt_transformers.tt.model_config import DecodersPrecision, ModelArgs
+
+        hf_model_name = hf_config._name_or_path
+        instruct = "Instruct" in hf_model_name
+
+        model_args = ModelArgs(
+            mesh_device,
+            instruct=instruct,
+            max_batch_size=max_batch_size,
+            optimizations=(
+                DecodersPrecision.from_string(optimizations)
+                if optimizations is not None
+                else DecodersPrecision.performance
+            ),
+            max_seq_len=max_seq_len,
+        )
+
+        if n_layers is not None:
+            model_args.n_layers = n_layers
+
+        state_dict = model_args.load_state_dict()
+        dtype = ttnn.bfloat8_b
+
+        model = Llama3Transformer1D.from_model_args(
+            mesh_device=mesh_device,
+            args=model_args,
+            state_dict=state_dict,
+            weight_cache_path=model_args.weight_cache_path(dtype),
+            dtype=dtype,
+        )
+
+        executor = TracedLlamaExecutor(model, mesh_device, model_args=model_args)
+        return cls(executor, model_args=model_args)
+
+    def prefill_forward(self, *args, **kwargs):
+        return self.executor.prefill_forward(*args, **kwargs)
+
+    def decode_forward(self, *args, **kwargs):
+        return self.executor.decode_forward(*args, **kwargs)
+
+    def allocate_kv_cache(self, *args, **kwargs):
+        return self.executor.allocate_kv_cache(*args, **kwargs)
+
+    def warmup_model_prefill(self, *args, **kwargs):
+        if hasattr(self.executor, "warmup_model_prefill"):
+            return self.executor.warmup_model_prefill(*args, **kwargs)
+
+    @property
+    def cache_path(self):
+        if self.model_args:
+            return self.model_args.model_cache_path
+        return None

--- a/models/experimental/llama32_1b_quasar/models/llama32_1b/__init__.py
+++ b/models/experimental/llama32_1b_quasar/models/llama32_1b/__init__.py
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+from models.experimental.llama32_1b_quasar.models.llama32_1b.model import (
+    LLAMA32_1B_ACCURACY,
+    LLAMA32_1B_PERFORMANCE,
+    EagerLlama32_1BExecutor,
+    Llama32_1BConfig,
+    Llama32_1BExecutorRuntimeConfig,
+    Llama32_1BPrecisionConfig,
+    Llama32_1BTransformer1D,
+    TracedLlama32_1BExecutor,
+)
+
+__all__ = [
+    "LLAMA32_1B_ACCURACY",
+    "LLAMA32_1B_PERFORMANCE",
+    "EagerLlama32_1BExecutor",
+    "Llama32_1BConfig",
+    "Llama32_1BExecutorRuntimeConfig",
+    "Llama32_1BPrecisionConfig",
+    "Llama32_1BTransformer1D",
+    "TracedLlama32_1BExecutor",
+]

--- a/models/experimental/llama32_1b_quasar/models/llama32_1b/demo.py
+++ b/models/experimental/llama32_1b_quasar/models/llama32_1b/demo.py
@@ -251,6 +251,8 @@ def test_llama32_1b_executor_prefill_smoke(mesh_device, hf_model_id, seq_len: in
 
     ttnn.SetDefaultDevice(mesh_device)
     try:
+        # Model build already skips above; execution errors and the shape assertions
+        # below must surface as real failures (not skips) so a prefill regression fails CI.
         ex = EagerLlama32_1BExecutor(model, mesh_device)
         kv = ex.allocate_kv_cache(kv_shape, torch.bfloat16, ma.n_layers)
         page_table = make_contiguous_page_table(1, ma.max_seq_len, 32)
@@ -261,8 +263,6 @@ def test_llama32_1b_executor_prefill_smoke(mesh_device, hf_model_id, seq_len: in
         assert (
             logits.shape[-1] == model.vocab_size
         ), f"expected last dim == vocab_size={model.vocab_size}, got {logits.shape}"
-    except Exception as e:
-        pytest.skip(f"Executor prefill not runnable: {e}")
     finally:
         ttnn.SetDefaultDevice(None)
         cleanup_model_case(model, mesh_device)

--- a/models/experimental/llama32_1b_quasar/models/llama32_1b/demo.py
+++ b/models/experimental/llama32_1b_quasar/models/llama32_1b/demo.py
@@ -1,0 +1,314 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Smoke tests for ``Llama32_1B`` (meta-llama/Llama-3.2-1B-Instruct, TTTv2).
+
+Milestones covered:
+  M1 — model builds + raw prefill/decode forward runs end-to-end
+  M2 — ``EagerLlama32_1BExecutor`` + paged KV: prefill → host logits
+  M3 — ``TracedLlama32_1BExecutor`` vs ``EagerLlama32_1BExecutor`` logits parity
+
+Supported meshes: N150 (1×1), N300 (1×2) and T3K (1×8).
+
+Run::
+
+    # M1 prefill smoke — N300
+    MESH_DEVICE=N300 HF_MODEL=meta-llama/Llama-3.2-1B-Instruct \\
+      ./python_env/bin/pytest models/experimental/llama32_1b_quasar/models/llama32_1b/demo.py -v -k prefill_smoke
+
+    # M2 executor smoke — N150
+    MESH_DEVICE=N150 HF_MODEL=meta-llama/Llama-3.2-1B-Instruct \\
+      ./python_env/bin/pytest models/experimental/llama32_1b_quasar/models/llama32_1b/demo.py -v -k executor_prefill_smoke
+
+    # M3 eager/traced parity — N300
+    MESH_DEVICE=N300 HF_MODEL=meta-llama/Llama-3.2-1B-Instruct \\
+      ./python_env/bin/pytest models/experimental/llama32_1b_quasar/models/llama32_1b/demo.py -v -k eager_traced_parity
+
+Notes:
+  * ``from_pretrained`` loads HF weights directly (TTTv2-native, no TTTv1 bridge).
+    Set ``LLAMA32_1B_DEMO_NUM_LAYERS=1`` for fast single-layer smoke runs.
+    On first run the LazyWeight cache is cold (~3-5 min); subsequent runs are fast.
+  * ``MESH_DEVICE`` must satisfy: n_heads (32) and n_kv_heads (8) divisible
+    by device count. N150 (1), N300 (2) and T3K (8) all satisfy this.
+  * fabric_config is set to FABRIC_1D on multi-device meshes (required by
+    TTTv2 CCL ops).
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+import torch
+
+import ttnn
+from models.experimental.llama32_1b_quasar.models.executor import make_contiguous_page_table
+from models.experimental.llama32_1b_quasar.models.llama32_1b.model import (
+    LLAMA32_1B_ACCURACY,
+    EagerLlama32_1BExecutor,
+    Llama32_1BTransformer1D,
+    TracedLlama32_1BExecutor,
+)
+from models.experimental.llama32_1b_quasar.tests.demos.cleanup_utils import cleanup_model_case
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Fixtures / pytestmark
+# ─────────────────────────────────────────────────────────────────────────────
+
+_MESH_SHAPE = {"N150": (1, 1), "N300": (1, 2), "T3K": (1, 8), "TG": (8, 4)}.get(
+    os.environ.get("MESH_DEVICE"), len(ttnn.get_device_ids())
+)
+
+
+@pytest.fixture
+def device_params(request, galaxy_type):
+    """Translate ``fabric_config: True`` → real FabricConfig for multi-device meshes."""
+    params = getattr(request, "param", {}).copy()
+    is_single = (_MESH_SHAPE == (1, 1)) if isinstance(_MESH_SHAPE, tuple) else (_MESH_SHAPE == 1)
+    if "fabric_config" in params:
+        if is_single:
+            params["fabric_config"] = None
+        elif params["fabric_config"] is True:
+            params["fabric_config"] = (
+                ttnn.FabricConfig.FABRIC_1D_RING if galaxy_type == "6U" else ttnn.FabricConfig.FABRIC_1D
+            )
+    return params
+
+
+pytestmark = [
+    pytest.mark.parametrize("mesh_device", [_MESH_SHAPE], indirect=True),
+    pytest.mark.parametrize("device_params", [{"fabric_config": True}], indirect=True),
+]
+
+
+@pytest.fixture(scope="module")
+def hf_model_id():
+    return os.environ.get("HF_MODEL", "meta-llama/Llama-3.2-1B-Instruct")
+
+
+_slow = pytest.mark.slow
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Helpers
+# ─────────────────────────────────────────────────────────────────────────────
+
+_LLAMA32_1B_N_HEADS = 32
+_LLAMA32_1B_N_KV_HEADS = 8
+
+
+def _skip_unless_heads_divide_mesh(mesh_device: ttnn.MeshDevice) -> None:
+    n_dev = mesh_device.get_num_devices()
+    if n_dev <= 1:
+        return
+    if _LLAMA32_1B_N_HEADS % n_dev == 0 and _LLAMA32_1B_N_KV_HEADS % n_dev == 0:
+        return
+    pytest.skip(
+        f"Incompatible mesh for Llama-3.2-1B-Instruct: {n_dev} devices; "
+        f"need n_heads ({_LLAMA32_1B_N_HEADS}) and n_kv_heads ({_LLAMA32_1B_N_KV_HEADS}) "
+        f"each divisible by {n_dev}. Use MESH_DEVICE=N150 (1), N300 (2) or T3K (8)."
+    )
+
+
+def _create_model(
+    mesh_device,
+    *,
+    executor_mode: bool = True,
+    optimizations: str = "accuracy",
+    max_batch_size: int = 32,
+    max_seq_len: int = 1024,
+):
+    """Build Llama32_1BTransformer1D via TTTv2-native from_pretrained.
+
+    Returns the model. When executor_mode=True, model.model_args is set to
+    a Llama32_1BExecutorRuntimeConfig.
+    """
+    from models.experimental.llama32_1b_quasar.models.llama32_1b.model import LLAMA32_1B_PERFORMANCE
+
+    hf_model = os.environ.get("HF_MODEL", "meta-llama/Llama-3.2-1B-Instruct")
+    num_layers = int(os.environ.get("LLAMA32_1B_DEMO_NUM_LAYERS", 0)) or None
+    cache_dir = os.environ.get("TT_CACHE_PATH", None)
+
+    precision = LLAMA32_1B_ACCURACY if optimizations == "accuracy" else LLAMA32_1B_PERFORMANCE
+
+    return Llama32_1BTransformer1D.from_pretrained(
+        mesh_device,
+        hf_model_id=hf_model,
+        max_batch_size=max_batch_size,
+        max_seq_len=max_seq_len,
+        num_layers=num_layers,
+        cache_dir=cache_dir,
+        precision=precision,
+        block_size=32,
+        executor_mode=executor_mode,
+    )
+
+
+def _kv_shape_from_model(model, mesh_device):
+    ma = model.model_args
+    block_size = 32
+    max_num_blocks = (ma.max_seq_len // block_size) * ma.max_batch_size
+    return (
+        max_num_blocks,
+        ma.n_kv_heads // mesh_device.get_num_devices(),
+        block_size,
+        ma.head_dim,
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# M1: prefill smoke + decode smoke
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@_slow
+@pytest.mark.parametrize("seq_len", [128])
+def test_llama32_1b_prefill_smoke(mesh_device, hf_model_id, seq_len: int, tmp_path_factory):
+    """M1 — model builds and EagerLlama32_1BExecutor prefill returns correct-shape logits."""
+    _skip_unless_heads_divide_mesh(mesh_device)
+    model = None
+    try:
+        model = _create_model(mesh_device, executor_mode=True, optimizations="accuracy")
+    except Exception as e:
+        pytest.skip(f"Could not build model (weights / memory): {e}")
+
+    kv_shape = _kv_shape_from_model(model, mesh_device)
+    ma = model.model_args
+
+    ttnn.SetDefaultDevice(mesh_device)
+    try:
+        ex = EagerLlama32_1BExecutor(model, mesh_device)
+        kv = ex.allocate_kv_cache(kv_shape, torch.bfloat16, ma.n_layers)
+        page_table = make_contiguous_page_table(1, ma.max_seq_len, 32)
+        toks = torch.zeros(1, seq_len, dtype=torch.long)
+        toks[0, :4] = torch.tensor([1, 2, 3, 4], dtype=torch.long)
+        logits = ex.prefill_forward(toks, page_table=page_table, kv_cache=kv)
+        assert logits.shape[0] == 1, f"expected batch dim 1, got {logits.shape}"
+        assert logits.shape[-1] == model.vocab_size, f"expected vocab_size={model.vocab_size}, got {logits.shape}"
+    finally:
+        ttnn.SetDefaultDevice(None)
+        cleanup_model_case(model, mesh_device)
+
+
+@_slow
+def test_llama32_1b_decode_smoke(mesh_device, hf_model_id, tmp_path_factory):
+    """M1 — prefill 128 tokens then one decode step; verifies decode KV-cache update."""
+    _skip_unless_heads_divide_mesh(mesh_device)
+    seq_len = 128
+    model = None
+    try:
+        model = _create_model(
+            mesh_device, executor_mode=True, optimizations="accuracy", max_batch_size=1, max_seq_len=512
+        )
+    except Exception as e:
+        pytest.skip(f"Could not build model (weights / memory): {e}")
+
+    kv_shape = _kv_shape_from_model(model, mesh_device)
+    ma = model.model_args
+
+    ttnn.SetDefaultDevice(mesh_device)
+    try:
+        ex = EagerLlama32_1BExecutor(model, mesh_device)
+        kv = ex.allocate_kv_cache(kv_shape, torch.bfloat16, ma.n_layers)
+        page_table = make_contiguous_page_table(1, ma.max_seq_len, 32)
+        toks = torch.zeros(1, seq_len, dtype=torch.long)
+        toks[0, :4] = torch.tensor([1, 2, 3, 4], dtype=torch.long)
+        prefill_logits = ex.prefill_forward(toks, page_table=page_table, kv_cache=kv)
+        assert prefill_logits is not None, "prefill returned None"
+        next_tok = int(torch.argmax(torch.tensor(prefill_logits[0, 0]).float()).item())
+        decode_toks = torch.tensor([next_tok], dtype=torch.long)
+        start_pos = torch.tensor([seq_len], dtype=torch.long)
+        decode_logits, _ = ex.decode_forward(
+            decode_toks, start_pos, page_table=page_table, kv_cache=kv, read_from_device=True
+        )
+        assert decode_logits is not None, "decode returned None"
+        assert (
+            decode_logits.shape[-1] == model.vocab_size
+        ), f"expected vocab_size={model.vocab_size}, got {decode_logits.shape}"
+    finally:
+        ttnn.SetDefaultDevice(None)
+        cleanup_model_case(model, mesh_device)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# M2: executor prefill smoke — full paged KV contract
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@_slow
+@pytest.mark.parametrize("seq_len", [128])
+def test_llama32_1b_executor_prefill_smoke(mesh_device, hf_model_id, seq_len: int, tmp_path_factory):
+    """M2 — EagerLlama32_1BExecutor + paged KV: prefill returns host logits."""
+    _skip_unless_heads_divide_mesh(mesh_device)
+    model = None
+    try:
+        model = _create_model(mesh_device, executor_mode=True, optimizations="accuracy")
+    except Exception as e:
+        pytest.skip(f"Could not build model (weights / memory): {e}")
+
+    kv_shape = _kv_shape_from_model(model, mesh_device)
+    ma = model.model_args
+
+    ttnn.SetDefaultDevice(mesh_device)
+    try:
+        ex = EagerLlama32_1BExecutor(model, mesh_device)
+        kv = ex.allocate_kv_cache(kv_shape, torch.bfloat16, ma.n_layers)
+        page_table = make_contiguous_page_table(1, ma.max_seq_len, 32)
+        toks = torch.zeros(1, seq_len, dtype=torch.long)
+        toks[0, :4] = torch.tensor([1, 2, 3, 4], dtype=torch.long)
+        logits = ex.prefill_forward(toks, page_table=page_table, kv_cache=kv)
+        assert logits.shape[0] == 1, f"expected batch dim 1, got {logits.shape}"
+        assert (
+            logits.shape[-1] == model.vocab_size
+        ), f"expected last dim == vocab_size={model.vocab_size}, got {logits.shape}"
+    except Exception as e:
+        pytest.skip(f"Executor prefill not runnable: {e}")
+    finally:
+        ttnn.SetDefaultDevice(None)
+        cleanup_model_case(model, mesh_device)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# M3: eager vs traced parity
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@_slow
+def test_llama32_1b_eager_traced_parity(mesh_device, hf_model_id, tmp_path_factory):
+    """M3 — EagerLlama32_1BExecutor vs TracedLlama32_1BExecutor: prefill logits within tolerance.
+
+    Prefill trace capture is gated off under LazyWeight + distributed norms
+    (``can_enable_trace`` returns False). The traced executor falls back to eager
+    for prefill while keeping decode traced.
+    """
+    _skip_unless_heads_divide_mesh(mesh_device)
+    seq_len = 128
+    m_e = m_t = None
+    try:
+        m_e = _create_model(mesh_device, executor_mode=True, optimizations="accuracy")
+        m_t = _create_model(mesh_device, executor_mode=True, optimizations="accuracy")
+    except Exception as e:
+        pytest.skip(f"Could not build models (weights / memory): {e}")
+
+    kv_shape_e = _kv_shape_from_model(m_e, mesh_device)
+    kv_shape_t = _kv_shape_from_model(m_t, mesh_device)
+    ma_e = m_e.model_args
+    ma_t = m_t.model_args
+
+    ttnn.SetDefaultDevice(mesh_device)
+    try:
+        eager_ex = EagerLlama32_1BExecutor(m_e, mesh_device)
+        traced_ex = TracedLlama32_1BExecutor(m_t, mesh_device)
+        kv_e = eager_ex.allocate_kv_cache(kv_shape_e, torch.bfloat16, ma_e.n_layers)
+        kv_t = traced_ex.allocate_kv_cache(kv_shape_t, torch.bfloat16, ma_t.n_layers)
+        page_table = make_contiguous_page_table(1, ma_e.max_seq_len, 32)
+        toks = torch.zeros(1, seq_len, dtype=torch.long)
+        toks[0, :4] = torch.tensor([1, 2, 3, 4], dtype=torch.long)
+        le = eager_ex.prefill_forward(toks, page_table=page_table, kv_cache=kv_e)
+        lt = traced_ex.prefill_forward(toks, page_table=page_table, kv_cache=kv_t)
+        diff = (le.float() - lt.float()).abs().max().item()
+        assert diff < 0.25, f"eager/traced prefill logits max abs diff too large: {diff:.4f}"
+    finally:
+        ttnn.SetDefaultDevice(None)
+        cleanup_model_case(m_e, mesh_device)
+        cleanup_model_case(m_t, mesh_device)

--- a/models/experimental/llama32_1b_quasar/models/llama32_1b/generator.py
+++ b/models/experimental/llama32_1b_quasar/models/llama32_1b/generator.py
@@ -1,0 +1,96 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+vLLM-shaped adapter and greedy helpers for Llama-3.2-1B-Instruct TTTv2.
+
+Uses ``AutoConfig`` / ``Llama32_1BTransformer1D.from_pretrained`` and
+:class:`Llama32_1BGeneratorConfig` only — no v1 ``ModelArgs``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import ttnn
+from models.experimental.llama32_1b_quasar.models.executor import make_contiguous_page_table
+from models.experimental.llama32_1b_quasar.models.llama32_1b.model import (
+    LLAMA32_1B_ACCURACY,
+    EagerLlama32_1BExecutor,
+    Llama32_1BPrecisionConfig,
+    Llama32_1BTransformer1D,
+    TracedLlama32_1BExecutor,
+)
+
+
+@dataclass
+class Llama32_1BGeneratorConfig:
+    """Port-local serving / executor knobs (HF-free beyond ``hf_model_id``)."""
+
+    hf_model_id: str = "meta-llama/Llama-3.2-1B-Instruct"
+    hf_revision: str | None = None
+    max_batch_size: int = 32
+    max_seq_len: int = 4096
+    num_layers: int | None = None
+    cache_dir: Path | str | None = None
+    precision: Llama32_1BPrecisionConfig = LLAMA32_1B_ACCURACY
+    traced: bool = False
+
+
+class Llama32_1BGenerator:
+    """Thin vLLM adapter: ``allocate_kv_cache``, ``prefill_forward``, ``decode_forward``."""
+
+    model_capabilities = {"supports_prefix_caching": True}
+
+    def __init__(
+        self,
+        executor: EagerLlama32_1BExecutor | TracedLlama32_1BExecutor,
+        *,
+        gen_cfg: Llama32_1BGeneratorConfig,
+    ):
+        self.executor = executor
+        self.model = executor.model
+        self.gen_cfg = gen_cfg
+        self.mesh_device = executor.mesh_device
+
+    @classmethod
+    def from_pretrained(
+        cls,
+        mesh_device: ttnn.MeshDevice,
+        gen_cfg: Llama32_1BGeneratorConfig | None = None,
+    ) -> Llama32_1BGenerator:
+        gen_cfg = gen_cfg or Llama32_1BGeneratorConfig()
+        model = Llama32_1BTransformer1D.from_pretrained(
+            mesh_device,
+            gen_cfg.hf_model_id,
+            max_batch_size=gen_cfg.max_batch_size,
+            max_seq_len=gen_cfg.max_seq_len,
+            num_layers=gen_cfg.num_layers,
+            cache_dir=gen_cfg.cache_dir,
+            precision=gen_cfg.precision,
+            executor_mode=True,
+        )
+        ex: EagerLlama32_1BExecutor | TracedLlama32_1BExecutor
+        if gen_cfg.traced:
+            ex = TracedLlama32_1BExecutor(model, mesh_device)
+        else:
+            ex = EagerLlama32_1BExecutor(model, mesh_device)
+        return cls(ex, gen_cfg=gen_cfg)
+
+    def allocate_kv_cache(self, kv_cache_shape, dtype, num_layers):
+        return self.executor.allocate_kv_cache(kv_cache_shape, dtype, num_layers)
+
+    def prefill_forward(self, *args, **kwargs):
+        return self.executor.prefill_forward(*args, **kwargs)
+
+    def decode_forward(self, *args, **kwargs):
+        return self.executor.decode_forward(*args, **kwargs)
+
+    def warmup_model_prefill(self, *args, **kwargs):
+        if hasattr(self.executor, "warmup_model_prefill"):
+            return self.executor.warmup_model_prefill(*args, **kwargs)
+
+    @staticmethod
+    def default_page_table(batch_size: int, max_seq_len: int, block_size: int = 32) -> "torch.Tensor":  # noqa: F821
+        return make_contiguous_page_table(batch_size, max_seq_len, block_size)

--- a/models/experimental/llama32_1b_quasar/models/llama32_1b/model.py
+++ b/models/experimental/llama32_1b_quasar/models/llama32_1b/model.py
@@ -1,0 +1,1319 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+TTTv2 Llama 3.2-1B-Instruct — native stack (no ``models/tt_transformers`` imports).
+
+Architecture: standard Llama 1D transformer, same topology family as Llama 3.2-3B / 3.1-8B.
+  hidden=2048, layers=16, n_heads=32, n_kv_heads=8, head_dim=64,
+  intermediate=8192, vocab=128256, rope_theta=500000, RoPE llama3-scaled,
+  tie_word_embeddings=True (HF ties ``lm_head.weight`` to ``embed_tokens.weight``;
+  the loader reads ``hf.lm_head.weight`` which transformers populates from the tie).
+
+Mesh compatibility: N150 (1×1), N300 (1×2), T3K (1×8) — 32 heads / 8 KV heads
+divide all three.
+
+TTTv1 source for precision recipes:
+  ``models/tt_transformers/tt/model_config.py :: DecodersPrecision``
+  (Llama-3 group: ``accuracy()`` lines 130-159, ``performance()`` lines 208-218)
+"""
+
+from __future__ import annotations
+
+import math
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, List
+
+import torch
+from loguru import logger
+from transformers import AutoConfig, AutoModelForCausalLM
+
+import ttnn
+from models.experimental.llama32_1b_quasar.lightweightmodule import LightweightModule
+from models.experimental.llama32_1b_quasar.models.executor import EagerLLMExecutor, TracedLLMExecutor
+from models.experimental.llama32_1b_quasar.models.llama32_1b import weight_utils
+from models.experimental.llama32_1b_quasar.modules.attention.attention_1d import (
+    Attention1D,
+    Attention1DConfig,
+    _dram_matmul_config,
+    _dram_shard_core_grid,
+)
+from models.experimental.llama32_1b_quasar.modules.embedding.embedding_1d import Embedding1D, Embedding1DConfig
+from models.experimental.llama32_1b_quasar.modules.lazy_weight import LazyWeight
+from models.experimental.llama32_1b_quasar.modules.lm_head.lm_head_1d import LMHead1D, LMHead1DConfig, _nearest_32
+from models.experimental.llama32_1b_quasar.modules.mlp.mlp_1d import MLP1D, MLP1DConfig, _dram_shard_core_grid_k_n
+from models.experimental.llama32_1b_quasar.modules.rmsnorm.rmsnorm_1d import (
+    RMSNorm1D,
+    RMSNorm1DConfig,
+    _create_sharded_norm_program_config,
+)
+from models.experimental.llama32_1b_quasar.modules.rope.rope_1d import Rope1DConfig, RotarySetup1D, prepare_rot_idxs
+from models.experimental.llama32_1b_quasar.modules.sampling.sampling_1d import Sampling1D
+from models.experimental.llama32_1b_quasar.modules.tt_ccl import default_topology, get_tt_ccl
+from models.experimental.llama32_1b_quasar.tensor_utils import TILE_SIZE, get_padded_hidden_dim
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+
+def _lazy(
+    tensor: torch.Tensor,
+    *,
+    dtype: ttnn.DataType,
+    cache: tuple[Path, str] | None,
+) -> LazyWeight:
+    return LazyWeight(source=tensor, dtype=dtype, cache_dir_weight_name=cache)
+
+
+# =============================================================================
+# TransformerBlock1D — single decoder layer
+# =============================================================================
+
+
+@dataclass
+class TransformerBlock1DConfig:
+    attention_norm_config: RMSNorm1DConfig
+    attention_config: Attention1DConfig
+    ff_norm_config: RMSNorm1DConfig
+    mlp_config: MLP1DConfig
+
+    decode_residual_memcfg: ttnn.MemoryConfig | None = None
+    prefill_residual_memcfg: ttnn.MemoryConfig | None = None
+    activation_dtype: ttnn.DataType | None = None
+
+
+class TransformerBlock1D(LightweightModule):
+    def __init__(
+        self,
+        attention_norm: RMSNorm1D,
+        attention: Attention1D,
+        ff_norm: RMSNorm1D,
+        feed_forward: MLP1D,
+        decode_residual_memcfg: ttnn.MemoryConfig | None = None,
+        prefill_residual_memcfg: ttnn.MemoryConfig | None = None,
+        activation_dtype: ttnn.DataType | None = None,
+    ):
+        super().__init__()
+        self.attention_norm = attention_norm
+        self.attention = attention
+        self.ff_norm = ff_norm
+        self.feed_forward = feed_forward
+        self.decode_residual_memcfg = decode_residual_memcfg
+        self.prefill_residual_memcfg = prefill_residual_memcfg or ttnn.DRAM_MEMORY_CONFIG
+        self.activation_dtype = activation_dtype
+
+    @classmethod
+    def from_config(cls, config: TransformerBlock1DConfig) -> TransformerBlock1D:
+        return cls(
+            attention_norm=RMSNorm1D.from_config(config.attention_norm_config),
+            attention=Attention1D.from_config(config.attention_config),
+            ff_norm=RMSNorm1D.from_config(config.ff_norm_config),
+            feed_forward=MLP1D.from_config(config.mlp_config),
+            decode_residual_memcfg=config.decode_residual_memcfg,
+            prefill_residual_memcfg=config.prefill_residual_memcfg,
+            activation_dtype=config.activation_dtype,
+        )
+
+    def decode_forward(self, x: ttnn.Tensor, current_pos, rot_mats, page_table) -> ttnn.Tensor:
+        residual = x
+
+        x = _all_gather_rmsnorm_tensor(
+            self.attention_norm, x, memory_config=self.attention_norm.config.decode_memory_config
+        )
+        attn_in = self.attention_norm.decode_forward(x)
+        attn_out = self.attention.decode_forward(attn_in, current_pos, rot_mats, page_table=page_table)
+        attn_out = ttnn.to_memory_config(attn_out, self.decode_residual_memcfg)
+
+        hidden_states = ttnn.add(residual, attn_out, memory_config=self.decode_residual_memcfg)
+        residual = hidden_states
+
+        hidden_states = _all_gather_rmsnorm_tensor(
+            self.ff_norm, hidden_states, memory_config=self.ff_norm.config.decode_memory_config
+        )
+        hidden_states = self.ff_norm.decode_forward(hidden_states)
+        ttnn.deallocate(attn_out)
+        hidden_states = self.feed_forward.decode_forward(hidden_states)
+
+        out = ttnn.add(
+            residual,
+            hidden_states,
+            memory_config=self.decode_residual_memcfg,
+            dtype=self.activation_dtype or ttnn.bfloat16,
+        )
+        return out
+
+    def prefill_forward(
+        self, x: ttnn.Tensor, rot_mats, user_id, page_table, chunk_page_table, chunk_start_idx, batch_size: int = 1
+    ) -> ttnn.Tensor:
+        # For batched prefill (batch_size > 1) x is the folded [1,1,B*S,dim] hidden state; norm,
+        # residual add and MLP are row-independent so they treat B*S as one long sequence unchanged.
+        # Only attention unfolds the batch axis internally (see Attention1D.prefill_forward).
+        residual = x
+
+        attn_in = self.attention_norm.prefill_forward(x)
+        attn_in = _all_gather_rmsnorm_tensor(self.attention_norm, attn_in)
+        attn_out = self.attention.prefill_forward(
+            attn_in,
+            rot_mats,
+            user_id=user_id,
+            page_table=page_table,
+            chunk_page_table=chunk_page_table,
+            chunk_start_idx=chunk_start_idx,
+            batch_size=batch_size,
+        )
+        attn_out = ttnn.to_memory_config(attn_out, self.prefill_residual_memcfg)
+
+        hidden_states = ttnn.add(residual, attn_out, memory_config=self.prefill_residual_memcfg)
+        residual = hidden_states
+        x.deallocate(True)
+
+        hidden_states = self.ff_norm.prefill_forward(hidden_states)
+        hidden_states = _all_gather_rmsnorm_tensor(self.ff_norm, hidden_states)
+        ttnn.deallocate(attn_out)
+        hidden_states = self.feed_forward.prefill_forward(hidden_states)
+
+        out = ttnn.add(
+            residual,
+            hidden_states,
+            memory_config=self.prefill_residual_memcfg,
+            dtype=self.activation_dtype or ttnn.bfloat16,
+        )
+        return out
+
+    def forward(
+        self,
+        x,
+        current_pos=None,
+        rot_mats=None,
+        user_id=0,
+        mode="decode",
+        page_table=None,
+        chunk_page_table=None,
+        chunk_start_idx=None,
+        batch_size: int = 1,
+    ):
+        if mode == "prefill":
+            return self.prefill_forward(
+                x, rot_mats, user_id, page_table, chunk_page_table, chunk_start_idx, batch_size=batch_size
+            )
+        return self.decode_forward(x, current_pos, rot_mats, page_table)
+
+
+# =============================================================================
+# RMSNorm gather helper
+# =============================================================================
+
+
+def _all_gather_rmsnorm_tensor(
+    norm: RMSNorm1D, x: ttnn.Tensor, *, memory_config: ttnn.MemoryConfig | None = None
+) -> ttnn.Tensor:
+    cfg = norm.config
+    if cfg.mesh_device.get_num_devices() == 1 or x.shape[-1] == cfg.weight.source.numel():
+        return x
+
+    if memory_config is None:
+        memory_config = x.memory_config()
+
+    tt_ccl = cfg.tt_ccl or get_tt_ccl(cfg.mesh_device)
+    # CCL pipelining matched to the proven mistral_7b / qwen25_7b N300 recipe
+    # (num_links=1, chunks_per_sync=24, num_workers_per_link=4) for parity with the
+    # reference ports. Measured neutral vs the prior (num_links=2, chunks_per_sync=10,
+    # num_workers_per_link=2) config on N300 batch-1 decode (perf-tuning.md §Axis-3: the
+    # per-layer gather is invisible in the decode-step budget on N150/N300; it only bites
+    # at T3K+ scale), but kept to avoid oversubscribing N300's single inter-chip link.
+    return ttnn.experimental.all_gather_async(
+        x,
+        persistent_output_buffer=None,
+        dim=3,
+        multi_device_global_semaphore=tt_ccl.get_and_cycle_ag_semaphore_handles(),
+        num_links=1,
+        topology=default_topology(cfg.mesh_device),
+        memory_config=memory_config,
+        barrier_semaphore=tt_ccl.get_and_cycle_barrier_semaphore_handle(),
+        chunks_per_sync=24,
+        num_workers_per_link=4,
+        num_buffers_per_channel=2,
+    )
+
+
+# =============================================================================
+# PrecisionConfig — TTTv1-matched recipes for Llama 3.2 1B Instruct
+# =============================================================================
+
+_LOFI_COMPUTE_KERNEL_CFG = ttnn.WormholeComputeKernelConfig(
+    math_fidelity=ttnn.MathFidelity.LoFi,
+    math_approx_mode=False,
+    fp32_dest_acc_en=False,
+    packer_l1_acc=True,
+)
+
+
+@dataclass(frozen=True)
+class Llama32_1BPrecisionConfig:
+    """Per-layer precision + math-fidelity recipe for Llama 3.2 1B Instruct.
+
+    Two module-level recipes: :data:`LLAMA32_1B_ACCURACY` and :data:`LLAMA32_1B_PERFORMANCE`.
+    Pass one to :meth:`Llama32_1BTransformer1D.from_pretrained` via ``precision=``.
+
+    Attention compute-kernel configs are absent: TTTv1 uses HIFI2 QKV/O decode,
+    HIFI4 SDPA prefill, HIFI2 SDPA decode — matching ``Attention1D``'s TTTv2 defaults.
+    """
+
+    wqkv_dtype: ttnn.DataType = ttnn.bfloat8_b
+    wo_dtype: ttnn.DataType = ttnn.bfloat8_b
+    kv_cache_dtype: ttnn.DataType = ttnn.bfloat8_b
+
+    mlp_w1_w3_dtype: ttnn.DataType = ttnn.bfloat8_b
+    mlp_w2_dtype: ttnn.DataType = ttnn.bfloat8_b
+    # None → MLP1D default HIFI2_FP16 (matches TTTv1 LI_FF1_FF3 / LI_FF2 accuracy)
+    mlp_ff1_3_compute_kernel_cfg: ttnn.WormholeComputeKernelConfig | None = None
+    mlp_ff2_compute_kernel_cfg: ttnn.WormholeComputeKernelConfig | None = None
+
+    lm_head_dtype: ttnn.DataType = ttnn.bfloat8_b
+
+
+# TTTv1 DecodersPrecision.accuracy("Llama-3.2-1B-Instruct") (model_config.py Llama-3 group):
+#   wqkv=BFP8, wo=BFP8, kv_cache=BFP8, mlp_w1_w3=BFP8, mlp_w2=BFP8,
+#   LI_FF1_FF3=HIFI2_FP16, LI_FF2=HIFI2_FP16, SDPA_prefill=HIFI4 (Attention1D default)
+LLAMA32_1B_ACCURACY = Llama32_1BPrecisionConfig()
+
+# TTTv1 DecodersPrecision.performance("Llama-3.2-1B-Instruct"):
+#   FF1_FF3 → BFP4, LI_FF1_FF3 → LOFI; all other fields same as accuracy.
+LLAMA32_1B_PERFORMANCE = Llama32_1BPrecisionConfig(
+    mlp_w1_w3_dtype=ttnn.bfloat4_b,
+    mlp_ff1_3_compute_kernel_cfg=_LOFI_COMPUTE_KERNEL_CFG,
+)
+
+
+# =============================================================================
+# Runtime configs
+# =============================================================================
+
+
+@dataclass
+class Llama32_1BExecutorRuntimeConfig:
+    """Engine-facing runtime knobs. Exposed as ``model.model_args`` for ``EagerLLMExecutor``."""
+
+    n_layers: int
+    n_kv_heads: int
+    head_dim: int
+    max_batch_size: int
+    max_seq_len: int
+    cluster_shape: list[int]
+    max_prefill_chunk_size: int = 2048
+    model_cache_path: Path | None = None
+    kv_cache_dtype: ttnn.DataType = ttnn.bfloat8_b
+    optimizations: Any = None
+    # Batched prefill (parity caveat #12): fuse equal-length users into batched passes to close the
+    # batch-32 TTFT gap. ``supports_batched_prefill`` is the per-model opt-in (the shared engine only
+    # batches models whose prefill_forward threads ``batch_size``). ``max_prefill_batch_size`` caps the
+    # per-group batch; ``disable_batched_prefill`` is the escape hatch back to the sequential loop.
+    #
+    # Set to 32 (== max_batch_size) so a 32-user batch folds in a SINGLE traced pass, matching TTTv1's
+    # full-batch fold. On T3K this ~halves the number of folded passes vs the old cap of 8 (4 passes ->
+    # 1) and, together with the shared-engine batch-32 prefill fixes (single-concat last-token assembly
+    # + power-of-2 fold clamp in executor.py), closes the T3K batch-32-ci prefill TTFT gap vs TTTv1
+    # (7.4ms -> 4.0ms per user, vs TTTv1 3.67ms; #49118). The clamp guarantees any partially-filled
+    # group still folds to a reshape-safe power-of-2, so raising the cap is safe (eval-32's mixed-bucket
+    # rotations verified). 1B weights are tiny, so the single-pass fold fits DRAM on every SKU.
+    supports_batched_prefill: bool = True
+    max_prefill_batch_size: int = 32
+    disable_batched_prefill: bool = False
+    # When True (default), batched prefill runs norm+lm_head ONCE per group over the gathered last-token
+    # rows (TTTv1 parity); False falls back to the bit-identical per-slot path (one lm_head per user).
+    batched_prefill_batched_extract: bool = True
+
+    def can_enable_trace(self, prefill_seq_len: int, num_cached_tokens: int = 0) -> bool:
+        # Mirror TTTv1's prefill-trace gate (model_config.get_trace_prefill_supported_seq_lens):
+        # only trace the seq lens TTTv1 lists — bigger seq lens already have small op2op gaps, so
+        # tracing buys nothing. 1B uses the family default: N150 -> [128], N300/T3K -> [128, 1024].
+        # (The PERF.md batch-1 workload is 512 -> eager on BOTH stacks; batch-32 is 128 -> traced on
+        # both.) Decode trace remains enabled at the engine layer regardless.
+        num_devices = int(self.cluster_shape[0]) * int(self.cluster_shape[1])
+        allowed = {1: (128,), 2: (128, 1024), 8: (128, 1024)}.get(num_devices, (128,))
+        return (
+            prefill_seq_len in allowed
+            and prefill_seq_len <= self.max_prefill_chunk_size
+            and prefill_seq_len <= self.max_seq_len
+        )
+
+
+@dataclass
+class Llama32_1BPagedAttentionConfig:
+    """Paged KV layout for ``Attention1D`` (duck-typed; matches Attention1D's expected interface)."""
+
+    block_size: int
+    max_num_blocks: int
+
+
+@dataclass
+class Llama32_1BConfig:
+    """Resolved hyper-parameters for a loaded HF Llama-3.2-1B-Instruct checkpoint."""
+
+    hf_model_id: str
+    dim: int
+    n_heads: int
+    n_kv_heads: int
+    head_dim: int
+    hidden_dim: int
+    vocab_size: int
+    rms_norm_eps: float
+    rope_theta: float
+    num_hidden_layers: int
+    max_batch_size: int
+    max_seq_len: int
+    rope_table_len: int
+
+
+# =============================================================================
+# Wormhole tuning
+# =============================================================================
+
+
+@dataclass
+class _Llama32_1BWHTuning:
+    mlp_prefill_len_cutoff: int | None = None
+    mlp_decode_spill_w1_to_dram: bool = False
+    # Use ttnn.experimental.minimal_matmul for QKV + W2 prefill matmuls above seq_len > 128 (TTTv1
+    # parity, PLAN_01). A/B escape hatch: set DISABLE_MINIMAL_MATMUL=1 to force ttnn.linear. ~Parity on
+    # tiny 1B (matmuls small vs fixed overhead) but kept on for consistency + long-prompt prefill.
+    prefill_minimal_matmul: bool = True
+
+
+def _resolve_llama32_1b_wh_tuning(*, num_dev: int, max_batch_size: int) -> _Llama32_1BWHTuning:
+    """Pick WH tuning knobs.
+
+    TTTv1 (model_config.py): prefill_len_cutoff defaults to 1024 on Wormhole and is only
+    reduced to 512 for an explicit model/device allowlist (Llama-3.1-8B, Llama-3.2-11B,
+    Mistral-7B, gemma-3-*, Phi-4 on N150; Qwen2.5-7B/VL-7B/Phi-4 on N300; Mixtral on T3K).
+    Llama-3.2-1B is in none of them, so it stays at 1024 on N150/N300/T3K — unlike the
+    llama32_3b port, which uses 512 on N150 as a 3B-specific choice.
+    """
+    t = _Llama32_1BWHTuning()
+    t.mlp_prefill_len_cutoff = 1024
+    t.mlp_decode_spill_w1_to_dram = False
+    t.prefill_minimal_matmul = not os.environ.get("DISABLE_MINIMAL_MATMUL")
+    logger.info(
+        f"MLP tuning for Llama-3.2-1B on {num_dev} device(s): "
+        f"prefill_len_cutoff={t.mlp_prefill_len_cutoff}, "
+        f"decode_spill_w1_to_dram={t.mlp_decode_spill_w1_to_dram}"
+    )
+    return t
+
+
+# =============================================================================
+# Layer + head builders
+# =============================================================================
+
+
+def _post_attn_norm_decode_configs(
+    mlp: MLP1D,
+    *,
+    dim: int,
+    hidden_dim: int,
+    num_devices: int,
+    max_batch_size: int,
+) -> tuple[Any, ttnn.MemoryConfig]:
+    """Resolve post-attention RMSNorm decode sharding to match MLP1D W1/W3 input."""
+    padded_hidden = get_padded_hidden_dim(hidden_dim, num_devices, TILE_SIZE)
+    grid = _dram_shard_core_grid_k_n(dim, padded_hidden // num_devices)
+    tile_padded_batch_rows = TILE_SIZE * math.ceil(max_batch_size / TILE_SIZE)
+    program_config = _create_sharded_norm_program_config(dim, grid, tile_padded_batch_rows, TILE_SIZE)
+    return program_config, mlp.config.decode_input_memcfg
+
+
+def _build_decoder_layer(
+    *,
+    idx: int,
+    hf_layer: Any,
+    mcfg: Llama32_1BConfig,
+    mesh_device: ttnn.MeshDevice,
+    tt_ccl: Any,
+    topology: Any,
+    num_dev: int,
+    torch_dtype: torch.dtype,
+    precision: Llama32_1BPrecisionConfig,
+    executor_mode: bool,
+    paged_block_size: int | None,
+    paged_max_blocks: int | None,
+    cache_path: Path | None,
+    wh: _Llama32_1BWHTuning,
+    decode_residual_memcfg: ttnn.MemoryConfig,
+) -> TransformerBlock1D:
+    prefix = f"layer{idx}"
+
+    wqkv, wo = weight_utils.attention_wqkv_wo_from_hf_layer(hf_layer.self_attn, num_dev)
+    lazy_wqkv = _lazy(
+        wqkv, dtype=precision.wqkv_dtype, cache=(cache_path / "attn", f"{prefix}_wqkv") if cache_path else None
+    )
+    lazy_wo = _lazy(wo, dtype=precision.wo_dtype, cache=(cache_path / "attn", f"{prefix}_wo") if cache_path else None)
+
+    paged_cfg = None
+    if executor_mode and paged_block_size is not None and paged_max_blocks is not None:
+        paged_cfg = Llama32_1BPagedAttentionConfig(block_size=paged_block_size, max_num_blocks=paged_max_blocks)
+
+    attn = Attention1D.from_config(
+        Attention1DConfig(
+            wqkv=lazy_wqkv,
+            wo=lazy_wo,
+            mesh_device=mesh_device,
+            tt_ccl=tt_ccl,
+            topology=topology,
+            n_heads=mcfg.n_heads,
+            n_kv_heads=mcfg.n_kv_heads,
+            head_dim=mcfg.head_dim,
+            max_batch_size=mcfg.max_batch_size,
+            max_seq_len=mcfg.max_seq_len,
+            use_vllm_paged_kv_cache=executor_mode,
+            paged_attention_config=paged_cfg,
+            kv_cache=None,
+            kv_cache_dtype=precision.kv_cache_dtype,
+            # TTTv1 parity: Llama-3 family decode SDPA runs HIFI2 with exp_approx_mode=True
+            # (model_config.py `_default_settings` → SDPA_DECODE=HIFI2, used in BOTH accuracy
+            # and performance). Attention1D's generic default builds this prog config with
+            # exp_approx_mode=False, leaving decode SDPA slower than TTTv1. Flip it to match.
+            decode_sdpa_prg_config=ttnn.SDPAProgramConfig(
+                compute_with_storage_grid_size=(8, 8),
+                exp_approx_mode=True,
+                q_chunk_size=0,
+                k_chunk_size=0,
+            ),
+            prefill_qkv_minimal_matmul=wh.prefill_minimal_matmul,
+        )
+    )
+
+    w1, w2, w3 = weight_utils.mlp_weights_from_hf_layer(hf_layer.mlp)
+    mlp = MLP1D.from_config(
+        MLP1DConfig(
+            w1=_lazy(
+                w1,
+                dtype=precision.mlp_w1_w3_dtype,
+                cache=(cache_path / "mlp", f"{prefix}_w1") if cache_path else None,
+            ),
+            w2=_lazy(
+                w2,
+                dtype=precision.mlp_w2_dtype,
+                cache=(cache_path / "mlp", f"{prefix}_w2") if cache_path else None,
+            ),
+            w3=_lazy(
+                w3,
+                dtype=precision.mlp_w1_w3_dtype,
+                cache=(cache_path / "mlp", f"{prefix}_w3") if cache_path else None,
+            ),
+            mesh_device=mesh_device,
+            tt_ccl=tt_ccl,
+            topology=topology,
+            max_batch_size=mcfg.max_batch_size,
+            prefill_len_cutoff=wh.mlp_prefill_len_cutoff,
+            decode_spill_w1_to_dram_before_w3=wh.mlp_decode_spill_w1_to_dram,
+            w1_w3_dtype=precision.mlp_w1_w3_dtype,
+            w2_dtype=precision.mlp_w2_dtype,
+            ff1_3_compute_kernel_cfg=precision.mlp_ff1_3_compute_kernel_cfg,
+            decode_ff1_3_compute_kernel_cfg=precision.mlp_ff1_3_compute_kernel_cfg,
+            ff2_compute_kernel_cfg=precision.mlp_ff2_compute_kernel_cfg,
+            decode_ff2_compute_kernel_cfg=precision.mlp_ff2_compute_kernel_cfg,
+            prefill_w2_minimal_matmul=wh.prefill_minimal_matmul,
+        )
+    )
+
+    post_attn_decode_program_config, post_attn_decode_memory_config = _post_attn_norm_decode_configs(
+        mlp,
+        dim=mcfg.dim,
+        hidden_dim=mcfg.hidden_dim,
+        num_devices=num_dev,
+        max_batch_size=mcfg.max_batch_size,
+    )
+
+    def _build_norm(hf_norm: Any, name: str, **extra: Any) -> RMSNorm1D:
+        lw = _lazy(
+            weight_utils.rms_weight_torch(hf_norm).to(torch_dtype),
+            dtype=ttnn.bfloat16,
+            cache=(cache_path / "norm", f"{prefix}_{name}") if cache_path else None,
+        )
+        return RMSNorm1D.from_config(
+            RMSNorm1DConfig(
+                weight=lw,
+                mesh_device=mesh_device,
+                eps=mcfg.rms_norm_eps,
+                max_batch_size=mcfg.max_batch_size,
+                tt_ccl=tt_ccl,
+                **extra,
+            )
+        )
+
+    attn_norm = _build_norm(hf_layer.input_layernorm, "pre_attn")
+    ff_norm = _build_norm(
+        hf_layer.post_attention_layernorm,
+        "post_attn",
+        decode_program_config=post_attn_decode_program_config,
+        decode_memory_config=post_attn_decode_memory_config,
+    )
+
+    return TransformerBlock1D(
+        attention_norm=attn_norm,
+        attention=attn,
+        ff_norm=ff_norm,
+        feed_forward=mlp,
+        decode_residual_memcfg=decode_residual_memcfg,
+        prefill_residual_memcfg=ttnn.DRAM_MEMORY_CONFIG,
+        activation_dtype=None,
+    )
+
+
+def _build_lm_head(
+    *,
+    mesh_device: ttnn.MeshDevice,
+    hf_lm_head: torch.nn.Module,
+    mcfg: Llama32_1BConfig,
+    lm_head_dtype: ttnn.DataType,
+    cache_path: Path | None,
+) -> LMHead1D:
+    lm_w = hf_lm_head.weight.detach().to(torch.bfloat16).clone()
+    lm_splits, lm_split_sizes, lm_weights_memcfgs = weight_utils.build_lm_head_lazy_weights(
+        mesh_device,
+        lm_w,
+        dim=mcfg.dim,
+        vocab_size=mcfg.vocab_size,
+        dtype=lm_head_dtype,
+        cache_dir=cache_path / "lm_head" if cache_path else None,
+    )
+    lm_head_core_grid = _dram_shard_core_grid(mcfg.dim)
+    tile = ttnn.TILE_SIZE
+    tile_padded_batch_rows = tile * math.ceil(mcfg.max_batch_size / tile)
+    lm_prog_configs = [
+        _dram_matmul_config(tile_padded_batch_rows, mcfg.dim, ss, lm_head_core_grid.num_cores) for ss in lm_split_sizes
+    ]
+    lm_input_memcfg = ttnn.create_sharded_memory_config(
+        (tile_padded_batch_rows, _nearest_32(mcfg.dim // lm_head_core_grid.num_cores)),
+        lm_head_core_grid,
+        ttnn.ShardStrategy.WIDTH,
+        ttnn.ShardOrientation.ROW_MAJOR,
+        use_height_and_width_as_shard_shape=True,
+    )
+    return LMHead1D.from_config(
+        LMHead1DConfig(
+            output_weights=lm_splits,
+            mesh_device=mesh_device,
+            dim=mcfg.dim,
+            max_batch_size=mcfg.max_batch_size,
+            lm_head_dtype=lm_head_dtype,
+            program_configs=lm_prog_configs,
+            compute_kernel_config=None,
+            input_memcfg=lm_input_memcfg,
+            weights_memcfgs=lm_weights_memcfgs,
+        )
+    )
+
+
+# =============================================================================
+# Llama32_1BTransformer1D
+# =============================================================================
+
+
+class Llama32_1BTransformer1D(LightweightModule):
+    """TTTv2 Llama 3.2-1B-Instruct transformer.
+
+    Construct via :meth:`from_pretrained`. Sub-modules (``embedding``, ``rope_setup``,
+    ``layers``, ``norm``, ``lm_head``) are pre-built from HF weights with ``LazyWeight``.
+
+    Bind KV cache with :meth:`set_kv_cache` before first executor forward.
+    ``model_args`` is set to a :class:`Llama32_1BExecutorRuntimeConfig` when
+    ``executor_mode=True``.
+    """
+
+    decode_residual_memcfg = ttnn.DRAM_MEMORY_CONFIG
+
+    def __init__(
+        self,
+        cfg: Llama32_1BConfig,
+        embedding: Embedding1D,
+        rope_setup: RotarySetup1D,
+        layers: List[TransformerBlock1D],
+        norm: RMSNorm1D,
+        lm_head: LMHead1D,
+        mesh_device: ttnn.MeshDevice,
+    ):
+        super().__init__()
+        self.cfg = cfg
+        self.embedding = embedding
+        self.rope_setup = rope_setup
+        self.layers = layers
+        self.norm = norm
+        self.lm_head = lm_head
+        self.mesh_device = mesh_device
+        self.model_args: Llama32_1BExecutorRuntimeConfig | None = None
+
+        self.vocab_size = cfg.vocab_size
+        self.n_layers = cfg.num_hidden_layers
+        self.num_devices = mesh_device.get_num_devices()
+        self.tt_ccl = get_tt_ccl(mesh_device) if self.num_devices > 1 else None
+        self.activation_dtypes = [None] * cfg.num_hidden_layers
+
+        # EXPERIMENTAL (N150/N300 on-device-sampling evidence; see the on-device sampling handoff notes):
+        # the prior `num_devices >= 8` gate assumed sub-8-device sampling could not be trace-captured.
+        # test_sampling1d_trace_capture disproves that — argmax + top-k both capture/replay on 1x1 and
+        # 1x2 — so the gate is relaxed here to all 1D meshes. The model owns its sampler; callers pick
+        # behavior per request via sampling_params. Buffers are lazy (nothing materializes until the
+        # first on-device sampled decode), so this is harmless when sampling_params is None.
+        self.supports_on_device_sampling = self.num_devices >= 1
+        self.sampling = (
+            Sampling1D(
+                vocab_size=self.vocab_size,
+                mesh_device=mesh_device,
+                tt_ccl=self.tt_ccl,
+                max_batch_size=_nearest_32(cfg.max_batch_size),
+                # Clone TTTv1's decision: default_sampling_force_argmax.allow_force_argmax=False for
+                # all non-Galaxy meshes (only Llama-3.1-8B on TG flips it True). The 1B perf recipe
+                # (temp=0, top_p=0.08, top_k=32) routes through the cheap top-k op path — per-device
+                # ttnn.topk -> all-gather of the [*,32] tuples -> ttnn.sampling — never the full-vocab
+                # argmax all-gather. See models/tt_transformers/tt/model_config.py:1007.
+                allow_force_argmax=False,
+                pad_to_power_of_2=True,
+            )
+            if self.supports_on_device_sampling
+            else None
+        )
+
+    @classmethod
+    def from_pretrained(
+        cls,
+        mesh_device: ttnn.MeshDevice,
+        hf_model_id: str = "meta-llama/Llama-3.2-1B-Instruct",
+        *,
+        max_batch_size: int = 32,
+        max_seq_len: int = 4096,
+        num_layers: int | None = None,
+        cache_dir: Path | str | None = None,
+        precision: Llama32_1BPrecisionConfig = LLAMA32_1B_ACCURACY,
+        block_size: int = 32,
+        executor_mode: bool = False,
+    ) -> Llama32_1BTransformer1D:
+        """Load HF weights and build TTNN modules (weights materialize on first forward).
+
+        Args:
+            mesh_device: Open mesh device (N150 ``(1,1)``, N300 ``(1,2)``).
+            hf_model_id: Hugging Face hub id or local path.
+            max_batch_size: Decode batch / KV allocation.
+            max_seq_len: KV cache sequence budget per layer.
+            num_layers: If set, truncate stack for smoke tests (``LLAMA32_1B_DEMO_NUM_LAYERS``).
+            cache_dir: Directory for ``LazyWeight`` tensor caches.
+            precision: Per-layer precision recipe. Defaults to :data:`LLAMA32_1B_ACCURACY`.
+            block_size: Paged attention block size.
+            executor_mode: If True, use external paged KV (``set_kv_cache`` + shared executor).
+        """
+        ttnn.SetDefaultDevice(mesh_device)
+        cache_path = Path(cache_dir) if cache_dir else None
+        num_dev = mesh_device.get_num_devices()
+        tt_ccl = get_tt_ccl(mesh_device) if num_dev > 1 else None
+        topology = default_topology(mesh_device)
+
+        hf_cfg = AutoConfig.from_pretrained(hf_model_id)
+        n_heads_hf = hf_cfg.num_attention_heads
+        n_kv_hf = hf_cfg.num_key_value_heads
+        if num_dev > 1 and (n_heads_hf % num_dev != 0 or n_kv_hf % num_dev != 0):
+            raise ValueError(
+                f"Checkpoint requires n_heads ({n_heads_hf}) and n_kv_heads ({n_kv_hf}) "
+                f"each divisible by device count ({num_dev})."
+            )
+
+        torch_dtype = torch.bfloat16
+        logger.info(f"Loading HF weights: {hf_model_id}")
+        hf = AutoModelForCausalLM.from_pretrained(hf_model_id, torch_dtype=torch_dtype)
+        hf.eval()
+        base = hf.model
+
+        n_layers = num_layers if num_layers is not None else hf_cfg.num_hidden_layers
+        dim = hf_cfg.hidden_size
+        n_heads = hf_cfg.num_attention_heads
+        n_kv = hf_cfg.num_key_value_heads
+        head_dim = dim // n_heads
+        inter = hf_cfg.intermediate_size
+        vocab = hf_cfg.vocab_size
+        rope_len = max(max_seq_len * 2, 8192)
+        rope_len = (rope_len + 127) // 128 * 128
+
+        blocks_per_user = (max_seq_len + block_size - 1) // block_size
+        max_num_blocks = blocks_per_user * max_batch_size
+
+        mcfg = Llama32_1BConfig(
+            hf_model_id=hf_model_id,
+            dim=dim,
+            n_heads=n_heads,
+            n_kv_heads=n_kv,
+            head_dim=head_dim,
+            hidden_dim=inter,
+            vocab_size=vocab,
+            rms_norm_eps=hf_cfg.rms_norm_eps,
+            rope_theta=getattr(hf_cfg, "rope_theta", 500_000.0),
+            num_hidden_layers=n_layers,
+            max_batch_size=max_batch_size,
+            max_seq_len=max_seq_len,
+            rope_table_len=rope_len,
+        )
+
+        emb_src = weight_utils.embed_tokens_torch(base.embed_tokens)
+        embedding = Embedding1D.from_config(
+            Embedding1DConfig(
+                weights=_lazy(
+                    emb_src,
+                    dtype=ttnn.bfloat16,
+                    cache=(cache_path / "embedding", "tok_embeddings") if cache_path else None,
+                ),
+                mesh_device=mesh_device,
+                embed_scale=1.0,
+            )
+        )
+
+        cos_t, sin_t = weight_utils.build_rope_cos_sin_torch(base.rotary_emb, rope_len, head_dim, torch_dtype)
+        cos_lw = _lazy(cos_t, dtype=ttnn.bfloat16, cache=(cache_path / "rope", "cos") if cache_path else None)
+        sin_lw = _lazy(sin_t, dtype=ttnn.bfloat16, cache=(cache_path / "rope", "sin") if cache_path else None)
+        rope_setup = RotarySetup1D.from_config(
+            Rope1DConfig(
+                cos_matrix=cos_lw,
+                sin_matrix=sin_lw,
+                max_batch_size=max_batch_size,
+                head_dim=head_dim,
+                device=mesh_device,
+                use_qk_fused=False,
+            )
+        )
+
+        wh = _resolve_llama32_1b_wh_tuning(num_dev=num_dev, max_batch_size=max_batch_size)
+
+        layers: list[TransformerBlock1D] = [
+            _build_decoder_layer(
+                idx=idx,
+                hf_layer=base.layers[idx],
+                mcfg=mcfg,
+                mesh_device=mesh_device,
+                tt_ccl=tt_ccl,
+                topology=topology,
+                num_dev=num_dev,
+                torch_dtype=torch_dtype,
+                precision=precision,
+                executor_mode=executor_mode,
+                paged_block_size=block_size,
+                paged_max_blocks=max_num_blocks,
+                cache_path=cache_path,
+                wh=wh,
+                decode_residual_memcfg=ttnn.DRAM_MEMORY_CONFIG,
+            )
+            for idx in range(n_layers)
+        ]
+
+        norm_lw = _lazy(
+            weight_utils.rms_weight_torch(base.norm).to(torch_dtype),
+            dtype=ttnn.bfloat16,
+            cache=(cache_path / "norm", "final") if cache_path else None,
+        )
+        final_norm = RMSNorm1D.from_config(
+            RMSNorm1DConfig(
+                weight=norm_lw,
+                mesh_device=mesh_device,
+                eps=hf_cfg.rms_norm_eps,
+                max_batch_size=max_batch_size,
+                tt_ccl=tt_ccl,
+            )
+        )
+
+        lm = _build_lm_head(
+            mesh_device=mesh_device,
+            hf_lm_head=hf.lm_head,
+            mcfg=mcfg,
+            lm_head_dtype=precision.lm_head_dtype,
+            cache_path=cache_path,
+        )
+
+        del hf
+
+        model = cls(mcfg, embedding, rope_setup, layers, final_norm, lm, mesh_device)
+        if executor_mode:
+            model.model_args = Llama32_1BExecutorRuntimeConfig(
+                n_layers=n_layers,
+                n_kv_heads=n_kv,
+                head_dim=head_dim,
+                max_batch_size=max_batch_size,
+                max_seq_len=max_seq_len,
+                cluster_shape=list(mesh_device.shape),
+                model_cache_path=cache_path,
+                kv_cache_dtype=precision.kv_cache_dtype,
+            )
+        return model
+
+    # =========================================================================
+    # KV cache binding
+    # =========================================================================
+
+    def set_kv_cache(self, kv_cache: list) -> None:
+        assert len(kv_cache) == len(
+            self.layers
+        ), f"kv_cache has {len(kv_cache)} entries but model has {len(self.layers)} layers"
+        for i, layer in enumerate(self.layers):
+            layer.attention.config.kv_cache = tuple(kv_cache[i])
+
+    # =========================================================================
+    # Forward methods — take pre-embedded tensors
+    # =========================================================================
+
+    def decode_forward(
+        self,
+        x_embed: ttnn.Tensor,
+        current_pos: ttnn.Tensor,
+        rot_mats: tuple[ttnn.Tensor, ttnn.Tensor],
+        page_table: ttnn.Tensor | None = None,
+    ) -> ttnn.Tensor:
+        x = x_embed
+        for i, layer in enumerate(self.layers):
+            x = ttnn.to_memory_config(x, self.decode_residual_memcfg, self.activation_dtypes[i])
+            x = layer.decode_forward(x, current_pos, rot_mats, page_table)
+
+        x = _all_gather_rmsnorm_tensor(self.norm, x, memory_config=self.norm.config.decode_memory_config)
+        x = self.norm.decode_forward(x)
+        x = self.lm_head.forward(x)
+        return x
+
+    def prefill_forward(
+        self,
+        x_embed: ttnn.Tensor,
+        rot_mats: tuple[ttnn.Tensor, ttnn.Tensor],
+        user_id: int = 0,
+        page_table: ttnn.Tensor | None = None,
+        chunk_page_table: ttnn.Tensor | None = None,
+        chunk_start_idx: int | None = None,
+        get_last_token: int = -1,
+        batch_size: int = 1,
+    ) -> ttnn.Tensor:
+        # batch_size > 1: x_embed is the folded [1,1,B*S,dim] tensor (B users). The batched path always
+        # returns the full hidden state (get_last_token == -1); the executor does per-slot last-token
+        # extraction + norm/lm_head so those stages stay bit-identical to the single-user path.
+        x = x_embed
+        for i, layer in enumerate(self.layers):
+            activation_dtype = self.activation_dtypes[i]
+            if activation_dtype is not None and x.dtype != activation_dtype:
+                old = x
+                x = ttnn.typecast(x, activation_dtype)
+                ttnn.deallocate(old)
+            x = layer.prefill_forward(x, rot_mats, user_id, page_table, chunk_page_table, chunk_start_idx, batch_size)
+
+        if get_last_token == -1:
+            return x
+
+        get_last_token_floor = (get_last_token // 32) * 32
+        old = x
+        x = ttnn.slice(x, (0, 0, get_last_token_floor, 0), (1, 1, get_last_token_floor + 32, x.shape[-1]))
+        ttnn.deallocate(old)
+
+        x = self.norm.prefill_forward(x)
+        x = _all_gather_rmsnorm_tensor(self.norm, x)
+        lm_head_memcfg = self.lm_head.config.input_memcfg
+        if lm_head_memcfg is not None and lm_head_memcfg.is_sharded():
+            x = ttnn.interleaved_to_sharded(x, lm_head_memcfg)
+        x = self.lm_head.forward(x)
+        return ttnn.to_memory_config(x, ttnn.DRAM_MEMORY_CONFIG)
+
+    def post_process_prefill_output(self, hidden_states: ttnn.Tensor, last_token_idx: int) -> ttnn.Tensor:
+        get_last_token_floor = (last_token_idx // 32) * 32
+        x = ttnn.slice(
+            hidden_states,
+            (0, 0, get_last_token_floor, 0),
+            (1, 1, get_last_token_floor + 32, hidden_states.shape[-1]),
+        )
+        x = self.norm.prefill_forward(x)
+        x = _all_gather_rmsnorm_tensor(self.norm, x)
+        lm_head_memcfg = self.lm_head.config.input_memcfg
+        if lm_head_memcfg is not None and lm_head_memcfg.is_sharded():
+            x = ttnn.interleaved_to_sharded(x, lm_head_memcfg)
+        x = self.lm_head.forward(x)
+        return ttnn.to_memory_config(x, ttnn.DRAM_MEMORY_CONFIG)
+
+    def forward(
+        self,
+        x: ttnn.Tensor,
+        current_pos=None,
+        rot_mats_global=None,
+        rot_mats_local=None,
+        user_id: int = 0,
+        mode: str = "decode",
+        page_table=None,
+        chunk_page_table=None,
+        chunk_start_idx=None,
+        get_last_token: int = -1,
+        batch_size: int = 1,
+    ) -> ttnn.Tensor:
+        rot_mats = rot_mats_global
+        if mode == "prefill":
+            return self.prefill_forward(
+                x,
+                rot_mats,
+                user_id=user_id,
+                page_table=page_table,
+                chunk_page_table=chunk_page_table,
+                chunk_start_idx=chunk_start_idx,
+                get_last_token=get_last_token,
+                batch_size=batch_size,
+            )
+        return self.decode_forward(x, current_pos, rot_mats, page_table=page_table)
+
+    # =========================================================================
+    # Embedding + output processing helpers (executor contract)
+    # =========================================================================
+
+    def embed_decode(self, tokens: ttnn.Tensor) -> ttnn.Tensor:
+        x = self.embedding.forward(tokens)
+        x = ttnn.unsqueeze_to_4D(x)
+        return ttnn.to_memory_config(x, self.decode_residual_memcfg)
+
+    def embed_prefill(self, tokens: ttnn.Tensor) -> ttnn.Tensor:
+        x = self.embedding.forward(tokens)
+        return ttnn.unsqueeze_to_4D(x)
+
+    def gather_and_untilize_logits(self, logits: ttnn.Tensor) -> ttnn.Tensor:
+        if self.num_devices > 1 and self.tt_ccl is not None:
+            logits = ttnn.experimental.all_gather_async(
+                logits,
+                persistent_output_buffer=None,
+                dim=3,
+                multi_device_global_semaphore=self.tt_ccl.get_and_cycle_ag_semaphore_handles(),
+                num_links=1,
+                memory_config=logits.memory_config(),
+                topology=default_topology(self.mesh_device),
+                barrier_semaphore=self.tt_ccl.get_and_cycle_barrier_semaphore_handle(),
+                chunks_per_sync=10,
+                num_workers_per_link=2,
+                num_buffers_per_channel=2,
+            )
+        return ttnn.untilize(logits, use_multicore=True, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+
+    def increment_positions(self, current_pos: ttnn.Tensor, rot_mat_idxs: ttnn.Tensor) -> None:
+        ttnn.plus_one(current_pos, skip_negative_entries=True)
+        ttnn.plus_one(rot_mat_idxs)
+
+    # =========================================================================
+    # Smoke-test helpers (no executor, no page_table)
+    # =========================================================================
+
+    def prefill_from_token_ids(self, token_ids_tt: ttnn.Tensor, *, start_pos: int = 0, user_id: int = 0) -> ttnn.Tensor:
+        x = self.embed_prefill(token_ids_tt)
+        seq_len = x.shape[2]
+        assert seq_len % 128 == 0, "prefill seq_len must be divisible by 128"
+        rot = self.rope_setup.prefill_forward(start_pos, seq_len)
+        h = x
+        for layer in self.layers:
+            h = layer.prefill_forward(
+                h, rot, user_id=user_id, page_table=None, chunk_page_table=None, chunk_start_idx=None
+            )
+        h = self.norm.prefill_forward(h)
+        return _all_gather_rmsnorm_tensor(self.norm, h)
+
+    def decode_from_token_ids(self, token_ids_tt: ttnn.Tensor, *, current_pos: int) -> ttnn.Tensor:
+        x = self.embedding.forward(token_ids_tt)
+        x = ttnn.unsqueeze_to_4D(x)
+        pos = torch.tensor([current_pos], dtype=torch.long)
+        rot_idxs = prepare_rot_idxs(self.rope_setup.config, pos, on_host=False)
+        rot = self.rope_setup.decode_forward(rot_idxs)
+        cur = ttnn.from_torch(
+            pos,
+            device=self.mesh_device,
+            dtype=ttnn.int32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            mesh_mapper=ttnn.replicate_tensor_to_mesh_mapper(self.mesh_device),
+        )
+        h = x
+        for layer in self.layers:
+            h = layer.decode_forward(h, cur, rot, page_table=None)
+        h = _all_gather_rmsnorm_tensor(self.norm, h, memory_config=self.norm.config.decode_memory_config)
+        return self.norm.decode_forward(h)
+
+
+# =============================================================================
+# Executor validation traversal
+# =============================================================================
+
+
+def _iter_llama_executor_named_modules(model):
+    """Yield named submodules that declare executor input contracts."""
+    if not hasattr(model, "layers"):
+        return
+
+    for i, layer in enumerate(model.layers):
+        for suffix, submodule in [
+            ("attn_norm", getattr(layer, "attention_norm", None)),
+            ("attention", getattr(layer, "attention", None)),
+            ("ff_norm", getattr(layer, "ff_norm", None)),
+            ("mlp", getattr(layer, "feed_forward", None)),
+        ]:
+            if submodule is not None:
+                yield f"layer[{i}].{suffix}", submodule
+
+    if hasattr(model, "norm"):
+        yield "final_norm", model.norm
+    if hasattr(model, "lm_head"):
+        yield "lm_head", model.lm_head
+
+
+# =============================================================================
+# EagerLlama32_1BExecutor — thin wrapper
+# =============================================================================
+
+
+class EagerLlama32_1BExecutor:
+    """Thin wrapper: passes Llama32_1B model to EagerLLMExecutor."""
+
+    def __init__(self, model: Llama32_1BTransformer1D, mesh_device: ttnn.MeshDevice, model_args=None):
+        if model_args is not None:
+            model.model_args = model_args
+        self._engine = EagerLLMExecutor(model, mesh_device, iter_named_modules=_iter_llama_executor_named_modules)
+
+    @property
+    def model(self):
+        return self._engine.model
+
+    @property
+    def mesh_device(self):
+        return self._engine.mesh_device
+
+    @property
+    def model_args(self):
+        return self._engine.model_args
+
+    @property
+    def mode(self):
+        return self._engine.mode
+
+    @mode.setter
+    def mode(self, value):
+        self._engine.mode = value
+
+    def allocate_kv_cache(self, kv_cache_shape, dtype, num_layers):
+        return self._engine.allocate_kv_cache(kv_cache_shape, dtype, num_layers)
+
+    def _assert_kv_cache_identity(self, kv_cache):
+        return self._engine._assert_kv_cache_identity(kv_cache)
+
+    def prepare_decode_inputs_host(self, tokens, current_pos, page_table):
+        return self._engine.prepare_decode_inputs_host(tokens, current_pos, page_table)
+
+    def prepare_decode_inputs_device(self, tokens, current_pos, page_table):
+        return self._engine.prepare_decode_inputs_device(tokens, current_pos, page_table)
+
+    def compile_prefill(
+        self,
+        *,
+        tokens,
+        page_table,
+        kv_cache=None,
+        prompt_lens=None,
+        empty_slots=None,
+        start_pos=None,
+        sampling_params=None,
+    ):
+        return self._engine.compile_prefill(
+            tokens=tokens,
+            page_table=page_table,
+            kv_cache=kv_cache,
+            prompt_lens=prompt_lens,
+            empty_slots=empty_slots,
+            start_pos=start_pos,
+            sampling_params=sampling_params,
+        )
+
+    def compile_decode(self, *, tokens, start_pos, page_table, kv_cache=None, sampling_params=None):
+        return self._engine.compile_decode(
+            tokens=tokens,
+            start_pos=start_pos,
+            page_table=page_table,
+            kv_cache=kv_cache,
+            sampling_params=sampling_params,
+        )
+
+    def prefill_forward(
+        self,
+        tokens,
+        page_table,
+        kv_cache=None,
+        prompt_lens=None,
+        empty_slots=None,
+        sampling_params=None,
+        start_pos=None,
+    ):
+        return self._engine.prefill_forward(
+            tokens,
+            page_table=page_table,
+            kv_cache=kv_cache,
+            prompt_lens=prompt_lens,
+            empty_slots=empty_slots,
+            sampling_params=sampling_params,
+            start_pos=start_pos,
+        )
+
+    def _prefill_single_user(self, tokens, page_table, user_id, last_token_idx, num_cached_tokens=0):
+        return self._engine._prefill_single_user(tokens, page_table, user_id, last_token_idx, num_cached_tokens)
+
+    def decode_forward(self, tokens, start_pos, page_table, kv_cache=None, read_from_device=True, sampling_params=None):
+        return self._engine.decode_forward(
+            tokens,
+            start_pos,
+            page_table=page_table,
+            kv_cache=kv_cache,
+            read_from_device=read_from_device,
+            sampling_params=sampling_params,
+        )
+
+    def cleanup(self):
+        return self._engine.cleanup()
+
+
+# =============================================================================
+# TracedLlama32_1BExecutor — thin wrapper
+# =============================================================================
+
+
+class TracedLlama32_1BExecutor:
+    """Thin wrapper: passes Llama32_1B model to TracedLLMExecutor."""
+
+    def __init__(
+        self,
+        model: Llama32_1BTransformer1D,
+        mesh_device: ttnn.MeshDevice,
+        model_args=None,
+        ondevice_decode_loop: bool = False,
+        fast_prefill_last_token: bool = False,
+    ):
+        if model_args is not None:
+            model.model_args = model_args
+        self._engine = TracedLLMExecutor(
+            model,
+            mesh_device,
+            iter_named_modules=_iter_llama_executor_named_modules,
+            ondevice_decode_loop=ondevice_decode_loop,
+            fast_prefill_last_token=fast_prefill_last_token,
+        )
+
+    @property
+    def model(self):
+        return self._engine.model
+
+    @property
+    def mesh_device(self):
+        return self._engine.mesh_device
+
+    @property
+    def model_args(self):
+        return self._engine.model_args
+
+    @property
+    def mode(self):
+        return self._engine.mode
+
+    @mode.setter
+    def mode(self, value):
+        self._engine.mode = value
+
+    @property
+    def trace_id_prefill(self):
+        return self._engine.trace_id_prefill
+
+    @property
+    def trace_ids_decode(self):
+        return self._engine.trace_ids_decode
+
+    @property
+    def already_warmed_up_prefill(self):
+        return self._engine.already_warmed_up_prefill
+
+    def allocate_kv_cache(self, kv_cache_shape, dtype, num_layers):
+        return self._engine.allocate_kv_cache(kv_cache_shape, dtype, num_layers)
+
+    def warmup_model_prefill(self, seq_lens, make_tokens, make_page_table):
+        return self._engine.warmup_model_prefill(seq_lens, make_tokens, make_page_table)
+
+    def compile_prefill(
+        self,
+        *,
+        tokens,
+        page_table,
+        kv_cache=None,
+        prompt_lens=None,
+        empty_slots=None,
+        start_pos=None,
+        sampling_params=None,
+    ):
+        return self._engine.compile_prefill(
+            tokens=tokens,
+            page_table=page_table,
+            kv_cache=kv_cache,
+            prompt_lens=prompt_lens,
+            empty_slots=empty_slots,
+            start_pos=start_pos,
+            sampling_params=sampling_params,
+        )
+
+    def compile_decode(self, *, tokens, start_pos, page_table, kv_cache=None, sampling_params=None):
+        return self._engine.compile_decode(
+            tokens=tokens,
+            start_pos=start_pos,
+            page_table=page_table,
+            kv_cache=kv_cache,
+            sampling_params=sampling_params,
+        )
+
+    def prefill_forward(
+        self,
+        tokens,
+        page_table,
+        kv_cache=None,
+        prompt_lens=None,
+        empty_slots=None,
+        sampling_params=None,
+        start_pos=None,
+    ):
+        return self._engine.prefill_forward(
+            tokens,
+            page_table=page_table,
+            kv_cache=kv_cache,
+            prompt_lens=prompt_lens,
+            empty_slots=empty_slots,
+            sampling_params=sampling_params,
+            start_pos=start_pos,
+        )
+
+    def decode_forward(self, tokens, start_pos, page_table, kv_cache=None, read_from_device=True, sampling_params=None):
+        return self._engine.decode_forward(
+            tokens,
+            start_pos,
+            page_table=page_table,
+            kv_cache=kv_cache,
+            read_from_device=read_from_device,
+            sampling_params=sampling_params,
+        )
+
+    def cleanup(self):
+        return self._engine.cleanup()
+
+
+# =============================================================================
+# Public exports
+# =============================================================================
+
+__all__ = [
+    # Precision recipes
+    "Llama32_1BPrecisionConfig",
+    "LLAMA32_1B_ACCURACY",
+    "LLAMA32_1B_PERFORMANCE",
+    # Runtime config
+    "Llama32_1BExecutorRuntimeConfig",
+    "Llama32_1BConfig",
+    # Model
+    "Llama32_1BTransformer1D",
+    # Executors
+    "EagerLlama32_1BExecutor",
+    "TracedLlama32_1BExecutor",
+    # Building blocks
+    "TransformerBlock1D",
+    "TransformerBlock1DConfig",
+    "_all_gather_rmsnorm_tensor",
+    "_iter_llama_executor_named_modules",
+]

--- a/models/experimental/llama32_1b_quasar/models/llama32_1b/weight_utils.py
+++ b/models/experimental/llama32_1b_quasar/models/llama32_1b/weight_utils.py
@@ -1,0 +1,178 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Host-side HF weight layout helpers for Llama-3.2-1B-Instruct (TTTv2 port).
+
+Q/K linear weights use HuggingFace head layout; TTNN RoPE expects Meta layout.
+This duplicates the small permute helpers from ``load_checkpoints.reverse_permute``
+without importing ``models/tt_transformers``.
+
+Llama 3.2 1B has no QKV bias and no Q/K norm.
+"""
+
+from __future__ import annotations
+
+import math
+from pathlib import Path
+from typing import Any
+
+import torch
+
+import ttnn
+from models.experimental.llama32_1b_quasar.modules.lazy_weight import LazyWeight
+
+
+def reverse_permute(tensor: torch.Tensor, n_heads: int, dim1: int, dim2: int) -> torch.Tensor:
+    """HF Q/K weight rows → Meta layout (RoPE-compatible)."""
+    return tensor.view(n_heads, 2, dim1 // n_heads // 2, dim2).transpose(1, 2).reshape(dim1, dim2)
+
+
+def permute_hf_rope_to_meta_tables(cos: torch.Tensor, sin: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """Convert HF cos/sin tables to Meta-style tables for ``RotarySetup1D``."""
+    if len(cos.shape) == 3:
+        cos = cos.squeeze(0)
+        sin = sin.squeeze(0)
+    cos = cos[:, : cos.shape[1] // 2]
+    cos = torch.stack((cos, cos), dim=-1).flatten(-2)
+    sin = sin[:, : sin.shape[1] // 2]
+    sin = torch.stack((sin, sin), dim=-1).flatten(-2)
+    cos = cos.unsqueeze(0).unsqueeze(0)
+    sin = sin.unsqueeze(0).unsqueeze(0)
+    return cos, sin
+
+
+def build_rope_cos_sin_torch(
+    rotary_emb: Any, table_len: int, head_dim: int, dtype: torch.dtype
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Build ``[1, 1, table_len, head_dim]`` cos/sin tensors (Meta layout) from HF rotary module."""
+    x = torch.zeros(1, 1, table_len, head_dim, dtype=dtype)
+    position_ids = torch.arange(table_len, dtype=torch.long).unsqueeze(0)
+    with torch.no_grad():
+        cos_hf, sin_hf = rotary_emb(x, position_ids)
+    cos_m, sin_m = permute_hf_rope_to_meta_tables(cos_hf.float(), sin_hf.float())
+    return cos_m.to(dtype), sin_m.to(dtype)
+
+
+def attention_wqkv_wo_from_hf_layer(
+    self_attn: Any,
+    num_devices: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Pack QKV and WO from an HF Llama attention block for ``Attention1D`` sharding."""
+    wq_raw = self_attn.q_proj.weight
+    wk_raw = self_attn.k_proj.weight
+    wv_raw = self_attn.v_proj.weight
+    wo_raw = self_attn.o_proj.weight
+
+    dim = wq_raw.shape[1]
+    cfg = self_attn.config
+    n_heads = cfg.num_attention_heads
+    n_kv_heads = cfg.num_key_value_heads
+    head_dim = cfg.hidden_size // n_heads
+    n_heads_times_head_dim = n_heads * head_dim
+    n_kv_heads_times_head_dim = n_kv_heads * head_dim
+
+    wq_meta = reverse_permute(wq_raw, n_heads, n_heads_times_head_dim, dim)
+    wk_meta = reverse_permute(wk_raw, n_kv_heads, n_kv_heads_times_head_dim, dim)
+    wv_meta = wv_raw
+    wo_meta = wo_raw
+
+    wq = wq_meta.T
+    wk = wk_meta.T
+    wv = wv_meta.T
+    wo = wo_meta.T
+
+    qkv_list = []
+    for i in range(num_devices):
+        wq_chunk = torch.chunk(wq, num_devices, dim=1)[i]
+        wk_chunk = torch.chunk(wk, num_devices, dim=1)[i]
+        wv_chunk = torch.chunk(wv, num_devices, dim=1)[i]
+        qkv = torch.cat([wq_chunk, wk_chunk, wv_chunk], dim=-1)
+        qkv_list.append(qkv)
+    wqkv = torch.cat(qkv_list, dim=-1).unsqueeze(0).unsqueeze(0).clone()
+    wo = wo.unsqueeze(0).unsqueeze(0).clone()
+    return wqkv, wo
+
+
+def mlp_weights_from_hf_layer(mlp: Any) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Return (w1, w2, w3) TTNN layouts: gate^T, down^T, up^T for ``MLP1D``."""
+    w1 = mlp.gate_proj.weight.T.contiguous().clone()
+    w3 = mlp.up_proj.weight.T.contiguous().clone()
+    w2 = mlp.down_proj.weight.T.contiguous().clone()
+    return w1, w2, w3
+
+
+def rms_weight_torch(layernorm: Any) -> torch.Tensor:
+    return layernorm.weight.detach().float().clone()
+
+
+def embed_tokens_torch(embed: Any) -> torch.Tensor:
+    w = embed.weight.detach().float().clone()
+    return w.unsqueeze(0).unsqueeze(0)
+
+
+def build_lm_head_lazy_weights(
+    mesh_device: ttnn.MeshDevice,
+    lm_head_weight: torch.Tensor,
+    *,
+    dim: int,
+    vocab_size: int,
+    max_columns_per_device: int = 8192,
+    dtype: ttnn.DataType = ttnn.bfloat8_b,
+    cache_dir: Path | None = None,
+) -> tuple[list[LazyWeight], list[int], list[ttnn.MemoryConfig]]:
+    """Column-split LM head for ``LMHead1D`` (DRAM-sharded matmul chunks per device).
+
+    ``lm_head_weight`` shape: ``[vocab_size, dim]`` (HF). Returns
+    ``(lazy_weights, split_sizes, weights_memcfgs)`` for ``LMHead1DConfig``.
+    """
+    num_devices = mesh_device.get_num_devices()
+    torch_w = lm_head_weight.T.contiguous().to(torch.bfloat16)
+    padded_vocab_size = math.ceil(vocab_size / 32) * 32
+    if vocab_size < padded_vocab_size:
+        pad = padded_vocab_size - vocab_size
+        torch_w = torch.cat([torch_w, torch.zeros(torch_w.shape[0], pad, dtype=torch_w.dtype)], dim=-1)
+
+    size_per_device = padded_vocab_size // num_devices
+    num_splits = math.ceil(size_per_device / max_columns_per_device)
+    split_sizes = [min(size_per_device, max_columns_per_device)] * (num_splits - 1)
+    split_sizes.append(size_per_device - sum(split_sizes))
+
+    dram_size = mesh_device.dram_grid_size()
+    dram_grid = ttnn.CoreRangeSet(
+        {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(dram_size.x - 1, dram_size.y - 1))}
+    )
+    tile = ttnn.TILE_SIZE
+
+    def dram_sharded_memcfg(k: int, n: int) -> ttnn.MemoryConfig:
+        padded_n = math.ceil(n / (tile * dram_size.x)) * (tile * dram_size.x)
+        shard_spec = ttnn.ShardSpec(dram_grid, (k, padded_n // dram_size.x), ttnn.ShardOrientation.ROW_MAJOR)
+        return ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.DRAM, shard_spec)
+
+    output_weights: list[LazyWeight] = []
+    weights_memcfgs: list[ttnn.MemoryConfig] = []
+    for i, split_size in enumerate(split_sizes):
+        device_splits = []
+        for device_idx in range(num_devices):
+            start = device_idx * size_per_device + sum(split_sizes[:i])
+            end = start + split_size
+            device_splits.append(torch_w[:, start:end])
+        combined = torch.cat(device_splits, dim=-1)
+        mem_cfg = dram_sharded_memcfg(dim, math.ceil(combined.shape[-1] / num_devices))
+        weights_memcfgs.append(mem_cfg)
+        name = f"lm_head_split_{i}_{combined.shape[-1]}"
+        output_weights.append(
+            LazyWeight(
+                source=combined,
+                dtype=dtype,
+                device=mesh_device,
+                mesh_mapper_config=ttnn.MeshMapperConfig(
+                    placements=[ttnn.PlacementShard(-1)],
+                    mesh_shape_override=ttnn.MeshShape([mesh_device.get_num_devices()]),
+                ),
+                layout=ttnn.TILE_LAYOUT,
+                memory_config=mem_cfg,
+                cache_dir_weight_name=(cache_dir, name) if cache_dir else None,
+            )
+        )
+    return output_weights, split_sizes, weights_memcfgs

--- a/models/experimental/llama32_1b_quasar/models/module_input_validation.py
+++ b/models/experimental/llama32_1b_quasar/models/module_input_validation.py
@@ -1,0 +1,110 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Runtime validation helpers for declared module input configs."""
+
+from __future__ import annotations
+
+import contextlib
+import contextvars
+import functools
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+
+from loguru import logger
+
+import ttnn
+
+NamedModuleIterator = Callable[[object], Iterable[tuple[str, object]]]
+_validation_suspend_depth = contextvars.ContextVar("module_input_validation_suspend_depth", default=0)
+
+
+@dataclass
+class ConfigMismatch:
+    """Record of a module config mismatch detected during validation."""
+
+    module_name: str
+    expected_memcfg: ttnn.MemoryConfig
+    actual_memcfg: ttnn.MemoryConfig
+    # todo)) check for more details like dtype --> example: somebody messed up and run compile with float32 but actual is bfloat16 --> meaning unexpected compilation time included in the actual run
+
+
+@contextlib.contextmanager
+def suspend_module_input_validation():
+    """Temporarily bypass validation checks while keeping wrapped methods installed."""
+    token = _validation_suspend_depth.set(_validation_suspend_depth.get() + 1)
+    try:
+        yield
+    finally:
+        _validation_suspend_depth.reset(token)
+
+
+@contextlib.contextmanager
+def validate_module_input_configs(
+    *,
+    model: object,
+    iter_named_modules: NamedModuleIterator | None,
+    mode: str,
+):
+    """Instrument one forward pass to check actual vs declared input memcfgs."""
+    if iter_named_modules is None:
+        # Generator-based context managers must yield once even for a no-op branch.
+        yield
+        return
+    if mode not in {"prefill", "decode"}:
+        raise ValueError(f"Unsupported validation mode: {mode}")
+
+    mismatches: list[ConfigMismatch] = []
+    originals: dict[str, tuple[object, str, Callable]] = {}
+
+    for name, module in iter_named_modules(model):
+        if not hasattr(module, "config"):
+            continue
+
+        expected_attr = f"{mode}_input_memcfg"
+        expected = getattr(module.config, expected_attr, None)
+        if expected is None:
+            continue
+
+        method_name = f"{mode}_forward"
+        if not hasattr(module, method_name):
+            raise AttributeError(f"Module {name} has {expected_attr} but no {method_name} method")
+
+        original_method = getattr(module, method_name)
+        originals[name] = (module, method_name, original_method)
+
+        def make_wrapper(orig, mod_name, exp_memcfg):
+            @functools.wraps(orig)
+            def wrapper(x, *args, **kwargs):
+                # TODO: replace monkey-patched method interception with explicit module-level validation hooks.
+                if _validation_suspend_depth.get() <= 0 and isinstance(x, ttnn.Tensor) and x.is_allocated():
+                    actual = x.memory_config()
+                    logger.info(
+                        f"[validate_module_configs] Validating module configs in {mode} mode: "
+                        f"{mod_name} expected {exp_memcfg}, actual {actual}"
+                    )
+                    if actual != exp_memcfg:
+                        mismatches.append(
+                            ConfigMismatch(
+                                module_name=mod_name,
+                                expected_memcfg=exp_memcfg,
+                                actual_memcfg=actual,
+                            )
+                        )
+                return orig(x, *args, **kwargs)
+
+            return wrapper
+
+        setattr(module, method_name, make_wrapper(original_method, name, expected))
+
+    try:
+        yield
+    finally:
+        for name, (module, method_name, original) in originals.items():
+            setattr(module, method_name, original)
+
+        for mismatch in mismatches:
+            logger.warning(
+                f"Config mismatch at {mismatch.module_name}: "
+                f"declared {mismatch.expected_memcfg}, actual {mismatch.actual_memcfg}"
+            )

--- a/models/experimental/llama32_1b_quasar/modules/attention/attention_1d.py
+++ b/models/experimental/llama32_1b_quasar/modules/attention/attention_1d.py
@@ -1,0 +1,2270 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+TTTv2-style Attention module for 1D-topology devices: N150 (1x1), N300 (1x2), T3K (1x8).
+
+Single unified Attention1D class with separate forward methods:
+  - decode_forward(): For decode mode (single token per user)
+  - prefill_forward(): For prefill mode (multiple tokens)
+  - forward(x, mode, **kwargs): Dispatcher that calls the appropriate method
+
+Execution paths:
+  Decode:  QKV matmul → all_reduce → create_qkv_heads → rotary → KV cache update → SDPA → concat_heads → WO matmul → all_reduce
+  Prefill: [reshape] → QKV matmul → all_reduce → create_qkv_heads → rotary → KV cache fill → SDPA → concat_heads → [reshape] → all_gather → WO matmul → reduce_scatter
+
+Key design decisions:
+  - No static branching on topology in forward() - TG excluded at module level
+  - Paged vs non-paged KV cache selected at runtime based on page_table presence
+  - Fused all-gather matmul used for Ring topology (T3K 1x8) when dimensions allow
+
+Weight format requirements:
+  Q and K weights MUST be in Meta format, not HuggingFace format. HuggingFace stores
+  Q/K weights with a different head layout that is incompatible with TTNN's RoPE
+  implementation. Use `reverse_permute` from `models.tt_transformers.tt.load_checkpoints`
+  to convert HF weights to Meta format before passing to Attention1D:
+
+    from models.tt_transformers.tt.load_checkpoints import reverse_permute
+    wq_meta = reverse_permute(wq_hf, n_heads, n_heads * head_dim, dim)
+    wk_meta = reverse_permute(wk_hf, n_kv_heads, n_kv_heads * head_dim, dim)
+
+  The `from_model_args` factory handles this automatically via `convert_hf_to_meta`.
+  When using `from_config` with weights extracted directly from HuggingFace models,
+  you must apply this transformation manually.
+"""
+
+import math
+from dataclasses import dataclass, field, replace
+from functools import lru_cache
+from pathlib import Path
+from typing import Callable, Optional
+
+import ttnn
+from models.experimental.llama32_1b_quasar.lightweightmodule import LightweightModule
+from models.experimental.llama32_1b_quasar.modules.lazy_weight import LazyWeight, resolve_lazy_weight
+from models.experimental.llama32_1b_quasar.modules.rmsnorm.rmsnorm_1d import RMSNorm1D, RMSNorm1DConfig
+from models.experimental.llama32_1b_quasar.modules.tt_ccl import (
+    CCL_CHUNKS_PER_SYNC,
+    CCL_NUM_BUFFERS_PER_CHANNEL,
+    CCL_NUM_WORKERS_PER_LINK,
+    TT_CCL,
+    default_topology,
+    get_tt_ccl,
+)
+from models.experimental.llama32_1b_quasar.tensor_utils import (
+    TILE_SIZE,
+    get_rot_transformation_mat,
+    zeros_like_kv_cache,
+    zeros_like_paged_cache,
+)
+from models.experimental.llama32_1b_quasar.utility_functions import is_blackhole, nearest_32
+
+# =============================================================================
+# Constants
+# =============================================================================
+
+MAX_QKV_MM_SEQ_LEN = 2048  # Maximum sequence length for single QKV matmul
+
+# Maximum sequence length for WO matmul operation on Wormhole/Blackhole.
+# Sequences longer than this are reshaped to [1, seq_len // MAX_MM_SEQ_LEN, MAX_MM_SEQ_LEN, dim]
+# to fit on device and parallelize computation. After matmul, reshaped back.
+# Source: TTTv1 model_config.py "MAX_MM_SEQ_LEN": 1024
+MAX_MM_SEQ_LEN = 1024
+
+# =============================================================================
+# Attention1DConfig dataclass
+# =============================================================================
+
+
+@dataclass
+class Attention1DConfig:
+    """
+    Central configuration for Attention1D - the single source of truth for all settings.
+
+    Simple usage (all defaults):
+        config = Attention1DConfig(wqkv, wo)
+
+    Override any field:
+        config = Attention1DConfig(wqkv, wo, n_heads=32, head_dim=128)
+
+    Full customization:
+        config = Attention1DConfig(
+            wqkv, wo,
+            mesh_device=custom_device,
+            decode_xqkv_prg_config=my_program_config,
+            ...
+        )
+    """
+
+    # Required: weights (LazyWeight)
+    # IMPORTANT: Q and K weights must be in Meta format (not HuggingFace format).
+    # HF weights require `reverse_permute` transformation for RoPE compatibility.
+    # See module docstring for details.
+    wqkv: LazyWeight  # Combined QKV projection weight (Q/K in Meta format)
+    wo: LazyWeight  # Output projection weight
+
+    # Optional: Q/K normalization configs (e.g., for Qwen models)
+    # Composed sub-module pattern: RMSNorm1DConfig instead of raw weights
+    q_norm_config: RMSNorm1DConfig | None = None
+    k_norm_config: RMSNorm1DConfig | None = None
+
+    # Optional: QKV bias (e.g., for Qwen models)
+    wqkv_bias: LazyWeight | None = None
+
+    # Device and collectives
+    mesh_device: ttnn.MeshDevice | None = None
+    tt_ccl: TT_CCL | None = None
+    topology: Optional[ttnn.Topology] = None  # None = auto-detect
+    num_reduce_scatter_links: int | None = None
+    num_all_gather_links: int | None = None
+
+    # Optional CCL dtype for the prefill output reduce-scatter. When the fused all-gather+WO path is
+    # not selected, attention runs a separate reduce-scatter on the bf16 WO output; reducing it in a
+    # smaller dtype (e.g. bfloat8_b) halves the cross-device payload — matching TTTv1's bfloat8_b
+    # ccl_dtype (model_config.py) and the MLP w2 reduce. None keeps the WO output dtype (no cast,
+    # default — byte-identical to leaving the reduce untouched).
+    prefill_reduce_ccl_dtype: ttnn.DataType | None = None
+
+    # Model dimensions (derived from weights if None)
+    dim: int | None = None
+    n_heads: int | None = None
+    n_kv_heads: int | None = None
+    head_dim: int | None = None
+    qkv_size: int | None = None  # head_dim * (2 * n_kv_heads + n_heads)
+
+    # Batch and sequence config
+    max_batch_size: int = 32
+    max_seq_len: int = 128 * 1024
+
+    # Attention config
+    scale: float | None = None  # Default: head_dim ** -0.5
+    sliding_window: int | None = None  # For sliding window attention
+    use_qk_fused: bool = False  # Fused Q/K rotary embedding
+
+    # KV cache config
+    #
+    # The KV cache is a static configuration, allocated once and reused for all forward calls.
+    # This reflects how inference engines like vLLM manage KV caches:
+    # - Cache shape is determined by static model config (num_kv_heads, head_dim, block_size)
+    # - The cache is allocated once during model initialization (allocate_vllm_kv_cache)
+    # - The same cache tensors are passed to every forward call
+    #
+    # kv_cache options:
+    # - None: Set externally before forward (e.g., via from_model_args or direct assignment)
+    # - tuple[LazyWeight, LazyWeight]: (keys, values) backed by cache files, resolved lazily
+    # - tuple[ttnn.Tensor, ttnn.Tensor]: Pre-allocated (keys, values) tensors (e.g., from vLLM)
+    # When enabled, KV cache allocation and capacity are owned by the caller.
+    use_vllm_paged_kv_cache: bool = False
+    kv_cache: "tuple[LazyWeight, LazyWeight] | tuple[ttnn.Tensor, ttnn.Tensor] | None" = None
+    paged_attention_config: "PagedAttentionConfig | None" = None  # type: ignore
+    kv_cache_dtype: ttnn.DataType = ttnn.bfloat8_b
+    # Threshold for sharding KV cache during prefill to handle update_cache memory limitations.
+    min_kv_prefill_shard_seqlen: int | None = None
+
+    # Weight dtypes (None = auto-resolved based on device arch / model config)
+    wqkv_dtype: ttnn.DataType | None = None  # QKV projection weight dtype
+    wo_dtype: ttnn.DataType | None = None  # Output projection weight dtype
+    activation_dtype: ttnn.DataType | None = None  # Intermediate activation dtype (post-RoPE, etc.)
+
+    # Weight memory configs (None = DRAM interleaved by default)
+    wqkv_memcfg: ttnn.MemoryConfig | None = None  # QKV weight placement
+    wo_memcfg: ttnn.MemoryConfig | None = None  # Output weight placement
+
+    # Decode program configs (None = auto-derived in _resolve_attention1d_config)
+    decode_input_memcfg: ttnn.MemoryConfig | None = None  # DRAM-sharded input for decode
+    decode_xqkv_prg_config: "ttnn.MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig | None" = None  # QKV matmul
+    decode_sdpa_prg_config: ttnn.SDPAProgramConfig | None = None  # Scaled dot-product attention
+    decode_attn_output_prg_config: "ttnn.MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig | None" = (
+        None  # WO matmul
+    )
+    decode_residual_memcfg: ttnn.MemoryConfig | None = None  # Residual add output placement
+    decode_create_qkv_head_memcfg: ttnn.MemoryConfig | None = None  # QKV head split output
+    decode_scores_memcfg: Callable[[int], ttnn.MemoryConfig] | None = None  # SDPA scores; f(batch_size)
+
+    # Prefill program configs (Callable factories: seq_len → config)
+    prefill_input_memcfg: ttnn.MemoryConfig | None = None  # DRAM interleaved input for prefill
+    prefill_xqkv_prg_config: Callable[
+        [int], ttnn.MatmulMultiCoreReuseMultiCastProgramConfig
+    ] | None = None  # f(seq_len)
+    prefill_sdpa_prg_config: Callable[[int, int | None], ttnn.SDPAProgramConfig] | None = None  # f(seq_len, chunk_size)
+    prefill_wo_prg_config: Callable[[int], ttnn.MatmulMultiCoreReuseMultiCastProgramConfig] | None = None  # f(seq_len)
+    prefill_kv_memcfg: Callable[[int], ttnn.MemoryConfig] | None = None  # f(seq_len) for KV cache write
+
+    # Optional: use ttnn.experimental.minimal_matmul (instead of ttnn.linear) for the QKV prefill
+    # matmul above seq_len > 128 — matches TTTv1's long-prefill path (attention.py L907-913), which is
+    # ~2x faster on the large folded-batch QKV matmul. Default OFF so untouched models / decode stay
+    # byte-identical; the caller opts in. The factory yields a ttnn.MinimalMatmulConfig keyed on the
+    # folded seq_len (sibling to prefill_xqkv_prg_config, NOT a replacement — both coexist).
+    prefill_qkv_minimal_matmul: bool = False
+    prefill_xqkv_minimal_matmul_config: Callable[[int], "ttnn.MinimalMatmulConfig"] | None = None  # f(seq_len)
+
+    # Fused all-gather matmul (Ring topology only, decode path)
+    use_fused_all_gather_matmul: bool | None = None  # None = auto-detect based on topology + dim
+    decode_all_gather_matmul_prg_config: "ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig | None" = (
+        None  # Fused AG+WO
+    )
+    decode_all_gather_matmul_memcfg: ttnn.MemoryConfig | None = None  # Output placement for fused AG+WO
+
+    # Separate all-gather (non-Ring topology or non-fused decode path)
+    decode_gather_users_memcfg: ttnn.MemoryConfig | None = None  # Output placement for standalone all_gather
+
+    # Compute kernel configs (None = auto-derived; fp32 dest acc, math fidelity, etc.)
+    li_qkv_decode_compute_kernel_cfg: ttnn.WormholeComputeKernelConfig | None = None  # Decode QKV matmul kernel
+    sdpa_decode_compute_kernel_cfg: ttnn.WormholeComputeKernelConfig | None = None  # Decode SDPA kernel
+    li_o_decode_compute_kernel_cfg: ttnn.WormholeComputeKernelConfig | None = None  # Decode WO matmul kernel
+    li_qkv_prefill_compute_kernel_cfg: ttnn.WormholeComputeKernelConfig | None = None  # Prefill QKV matmul kernel
+    sdpa_prefill_compute_kernel_cfg: ttnn.WormholeComputeKernelConfig | None = None  # Prefill SDPA kernel
+    li_o_prefill_compute_kernel_cfg: ttnn.WormholeComputeKernelConfig | None = None  # Prefill WO matmul kernel
+
+    # Transformation matrices for rotary embedding (static, computed once).
+    # These are NOT LazyWeights because they are:
+    # - Small fixed-size tensors (32x32), not large model weights
+    # - Computed programmatically (get_rot_transformation_mat), not loaded from checkpoints
+    transformation_mat_decode: ttnn.Tensor | None = None
+    transformation_mat_prefill: ttnn.Tensor | None = None
+
+    # Internal: pre-computed bias LazyWeights (materialized in __init__)
+    _wqkv_bias_decode: list[LazyWeight] | None = field(default=None, repr=False)
+    _wqkv_bias_prefill: LazyWeight | None = field(default=None, repr=False)
+
+    def use_minimal_qkv_matmul(self, seq_len: int) -> bool:
+        """Whether the QKV prefill matmul should use ttnn.experimental.minimal_matmul.
+
+        Mirrors TTTv1 ``use_minimal_qkv_prefill_matmul`` (model_config.py:1659) — minimal_matmul
+        only above ``seq_len > 128`` (the folded-batch / long-prompt regime), and only when the
+        per-model opt-in is set. ``seq_len`` is the folded ``B*S`` length.
+        """
+        return bool(self.prefill_qkv_minimal_matmul) and seq_len > 128
+
+    def is_resolved(self) -> bool:
+        """Check if all required fields are resolved."""
+        required = [
+            "wqkv",
+            "wo",
+            "mesh_device",
+            "dim",
+            "n_heads",
+            "n_kv_heads",
+            "head_dim",
+            "qkv_size",
+            "scale",
+            "decode_xqkv_prg_config",  # Required for all 1D (DRAM-sharded matmul)
+            "decode_attn_output_prg_config",  # Required for all 1D (DRAM-sharded matmul)
+            "decode_sdpa_prg_config",
+            "decode_residual_memcfg",
+            "prefill_xqkv_prg_config",
+            "prefill_sdpa_prg_config",
+            "prefill_wo_prg_config",
+            "li_qkv_decode_compute_kernel_cfg",
+            "sdpa_decode_compute_kernel_cfg",
+            "li_o_decode_compute_kernel_cfg",
+        ]
+
+        # Multi-device needs CCL and topology
+        if self.mesh_device and self.mesh_device.get_num_devices() > 1:
+            required.extend(["tt_ccl", "topology"])
+
+        return all(getattr(self, f) is not None for f in required)
+
+
+# =============================================================================
+# Attention1D Class
+# =============================================================================
+
+
+class Attention1D(LightweightModule):
+    """
+    Attention for 1D mesh topologies (N150, N300, T3K).
+
+    Simple API (90% of users) - requires weights, model dimensions, and memory bounds:
+        attn = Attention1D(wqkv, wo, n_heads=32, n_kv_heads=8, head_dim=128,
+                           max_batch_size=1, max_seq_len=2048)
+
+    Power API (10% of users) - full customization via config:
+        config = Attention1DConfig(wqkv, wo, n_heads=32, n_kv_heads=8, head_dim=128,
+                                   sliding_window=4096, q_norm_config=..., ...)
+        attn = Attention1D.from_config(config)
+
+    Execution paths:
+      Decode:  QKV matmul → all_reduce → create_qkv_heads → rotary → KV cache → SDPA → concat_heads → WO matmul → all_reduce
+      Prefill: [reshape] → QKV matmul → all_reduce → create_qkv_heads → rotary → KV cache → SDPA → concat_heads → WO matmul
+
+    KV Cache Management:
+        The KV cache is a static configuration stored in Attention1DConfig.kv_cache,
+        allocated once and reused for all forward calls. This design reflects how
+        inference engines like vLLM manage KV caches: the cache shape is determined
+        by static model config and the same tensors are reused for all forward calls.
+
+        Options:
+        - from_model_args(): Automatically allocates KV cache (TTTv1 compatibility)
+        - from_config() with kv_cache: Pre-allocated (keys, values) tensors (vLLM integration)
+        - from_config() with kv_cache as LazyWeight tuple: Cache backed by files
+    """
+
+    def __init__(
+        self,
+        wqkv: LazyWeight,
+        wo: LazyWeight,
+        n_heads: int,
+        n_kv_heads: int,
+        head_dim: int,
+        max_batch_size: int,
+        max_seq_len: int,
+    ):
+        """
+        Simple API for 90% of users - requires weights, model dimensions, and memory bounds.
+
+        Args:
+            wqkv: Combined QKV projection weight, sharded on dim=-1
+            wo: Output projection weight, sharded on dim=-2
+            n_heads: Number of attention heads (from model config)
+            n_kv_heads: Number of key/value heads for GQA (from model config)
+            head_dim: Dimension per head (from model config)
+            max_batch_size: Maximum batch size for KV cache allocation
+            max_seq_len: Maximum sequence length for KV cache allocation
+
+        Other settings (mesh_device, topology, program configs, etc.) are derived
+        automatically. Use from_config() for full customization.
+
+        Example:
+            attn = Attention1D(wqkv, wo, n_heads=32, n_kv_heads=8, head_dim=128,
+                               max_batch_size=1, max_seq_len=2048)
+        """
+        super().__init__()
+        self.config = _resolve_attention1d_config(
+            Attention1DConfig(
+                wqkv=wqkv,
+                wo=wo,
+                n_heads=n_heads,
+                n_kv_heads=n_kv_heads,
+                head_dim=head_dim,
+                max_batch_size=max_batch_size,
+                max_seq_len=max_seq_len,
+            )
+        )
+        self._device_weights_loaded = False
+        self._bind_forward_methods()
+
+    @classmethod
+    def from_config(cls, config: Attention1DConfig):
+        """
+        Power API for 10% of users - any level of customization via config.
+
+        Override any subset of fields in Attention1DConfig:
+            config = Attention1DConfig(wqkv, wo, n_heads=32, head_dim=128)
+            attn = Attention1D.from_config(config)
+        """
+        instance = object.__new__(cls)
+        super(Attention1D, instance).__init__()
+        instance.config = _resolve_attention1d_config(config)
+        instance._device_weights_loaded = False
+        instance._bind_forward_methods()
+        return instance
+
+    def prefill_forward(
+        self,
+        x: ttnn.Tensor | LazyWeight,
+        rot_mats: tuple[ttnn.Tensor, ttnn.Tensor],
+        user_id: int | list[int] = 0,
+        page_table: ttnn.Tensor | None = None,
+        chunk_page_table: ttnn.Tensor | None = None,
+        chunk_start_idx: int | None = None,
+        batch_size: int = 1,
+    ) -> ttnn.Tensor:
+        """
+        Prefill forward - multiple tokens.
+
+        Args:
+            x: Input tensor, shape (1, 1, seq_len, dim), TILE_LAYOUT. For batched prefill
+                (``batch_size > 1``) the leading dims hold ``batch_size`` users' tokens folded
+                into the sequence axis: shape ``(1, 1, batch_size * S, dim)``.
+                Memory config: DRAM interleaved (default ``prefill_input_memcfg``).
+                If ``LazyWeight``, it is automatically placed with the correct memory config.
+            rot_mats: Tuple of (cos, sin) rotation matrices for rotary embedding,
+                each shape (1, 1, head_dim, head_dim), TILE_LAYOUT, DRAM interleaved.
+            user_id: User ID for KV cache fill (selects which user's cache to write). For batched
+                prefill this is the *list* of valid slot indices, one per user in the batch.
+            page_table: Page table for paged attention (optional). For batched prefill this is the
+                full ``[batch_size, num_blocks]`` table; each user's row is selected by ``batch_idx``.
+            chunk_page_table: Page table for chunked prefill (optional).
+            chunk_start_idx: Start index for chunked prefill (optional). Batched prefill always uses
+                the non-chunked path (the executor predicate keeps chunked prompts sequential).
+            batch_size: Number of users batched into one forward pass. ``1`` = the single-user path
+                (unchanged). ``> 1`` unfolds ``[1,1,B*S,*] -> [B,1,S,*]`` only for the
+                create_qkv_heads → rotary → KV-fill → SDPA → concat_heads window, mirroring TTTv1.
+
+        Returns:
+            Output tensor (1, 1, seq_len, dim), DRAM interleaved. For batched prefill the output is
+            the folded ``(1, 1, batch_size * S, dim)`` hidden state.
+
+        Note:
+            seq_len must be divisible by 128 and > 0.
+        """
+        self.load_device_weights()
+        x = _load_input_device_tensor(x, self.config, mode="prefill")
+        cfg = self.config
+
+        seq_len = x.shape[-2]  # folded length (batch_size * S) when batched
+        assert seq_len % 128 == 0 and seq_len > 0, "seq_len must be divisible by 128"
+        assert seq_len % batch_size == 0, f"folded seq_len {seq_len} must be divisible by batch_size {batch_size}"
+        # Per-user sequence length (== seq_len when batch_size == 1).
+        per_user_seq_len = seq_len // batch_size
+        if batch_size > 1:
+            assert chunk_start_idx is None, "batched prefill does not support chunked SDPA"
+
+        num_devices = cfg.mesh_device.get_num_devices()
+        n_local_heads = cfg.n_heads // num_devices
+        n_local_kv_heads = cfg.n_kv_heads // num_devices
+
+        # --- STAGE 1: Reshape for long sequences ---
+        # The QKV matmul runs on the folded [1,1,seq_len,dim] tensor (seq_len = B*S), exactly like a
+        # single long sequence — so the batch axis is folded into the sequence here (TTTv1 parity).
+        if seq_len > MAX_QKV_MM_SEQ_LEN:
+            if seq_len % MAX_QKV_MM_SEQ_LEN != 0:
+                raise ValueError(f"seq_len {seq_len} must be divisible by {MAX_QKV_MM_SEQ_LEN}")
+            x = ttnn.reshape(x, [1, seq_len // MAX_QKV_MM_SEQ_LEN, MAX_QKV_MM_SEQ_LEN, -1])
+
+        # --- STAGE 2: QKV Matmul ---
+        # Above seq_len > 128 the folded-batch QKV matmul is large; minimal_matmul is ~2x faster than
+        # ttnn.linear there (TTTv1 parity). Opt-in via prefill_qkv_minimal_matmul; output shape is
+        # identical to the ttnn.linear path so everything downstream is unchanged.
+        if cfg.use_minimal_qkv_matmul(seq_len):
+            xqkv_fused = ttnn.experimental.minimal_matmul(
+                x,
+                self.wqkv,
+                compute_kernel_config=cfg.li_qkv_prefill_compute_kernel_cfg,
+                config=cfg.prefill_xqkv_minimal_matmul_config(seq_len),
+            )
+        else:
+            xqkv_fused = ttnn.linear(
+                x,
+                self.wqkv,
+                dtype=cfg.activation_dtype or ttnn.bfloat16,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                compute_kernel_config=cfg.li_qkv_prefill_compute_kernel_cfg,
+                program_config=cfg.prefill_xqkv_prg_config(seq_len),
+            )
+
+        # Add bias if present
+        if self.wqkv_bias_prefill is not None:
+            xqkv_fused = xqkv_fused + self.wqkv_bias_prefill
+
+        # --- STAGE 3: No all-reduce for 1D topologies ---
+        # For 1D meshes (1xN), QKV weights are sharded only on axis 1 (columns).
+        # After matmul, each device has complete rows - no partial sums to reduce.
+        # TTTv1's tt_all_reduce with cluster_axis=1 is a no-op for 1D meshes.
+
+        # Reshape back
+        if seq_len > MAX_QKV_MM_SEQ_LEN:
+            xqkv_fused = ttnn.reshape(xqkv_fused, [1, 1, seq_len, -1])
+
+        # Batched prefill: unfold the folded sequence axis into a real batch axis so each user's
+        # tokens become an independent row for head-splitting / rotary / SDPA (TTTv1 attention.py
+        # L945-946). Single-user (batch_size == 1) is a no-op.
+        if batch_size > 1:
+            xqkv_fused = ttnn.reshape(xqkv_fused, [batch_size, 1, per_user_seq_len, -1])
+
+        ttnn.deallocate(x)
+
+        # --- STAGE 4: Create QKV Heads ---
+        q_heads_pre_rot, k_heads_pre_rot, v_heads = ttnn.experimental.nlp_create_qkv_heads(
+            xqkv_fused,
+            num_heads=n_local_heads,
+            num_kv_heads=n_local_kv_heads,
+            transpose_k_heads=False,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+        ttnn.deallocate(xqkv_fused)
+
+        # --- STAGE 5: Q/K Normalization (optional) ---
+        if self.q_norm is not None:
+            q_heads_pre_rot = self.q_norm.prefill_forward(q_heads_pre_rot)
+        if self.k_norm is not None:
+            k_heads_pre_rot = self.k_norm.prefill_forward(k_heads_pre_rot)
+
+        # --- STAGE 6: Rotary Embedding ---
+        # Explicit dtype check is required - ttnn.typecast is NOT a no-op when source == target types.
+        # Without this check, typecast would allocate a new tensor and run an identity copy kernel.
+        if q_heads_pre_rot.dtype != ttnn.bfloat16:
+            q_heads_pre_rot = ttnn.typecast(q_heads_pre_rot, dtype=ttnn.bfloat16)
+
+        q_heads = ttnn.experimental.rotary_embedding_llama(
+            q_heads_pre_rot, rot_mats[0], rot_mats[1], cfg.transformation_mat_prefill, is_decode_mode=False
+        )
+        ttnn.deallocate(q_heads_pre_rot)
+
+        if k_heads_pre_rot.dtype != ttnn.bfloat16:
+            k_heads_pre_rot = ttnn.typecast(k_heads_pre_rot, dtype=ttnn.bfloat16)
+
+        k_heads = ttnn.experimental.rotary_embedding_llama(
+            k_heads_pre_rot, rot_mats[0], rot_mats[1], cfg.transformation_mat_prefill, is_decode_mode=False
+        )
+        ttnn.deallocate(k_heads_pre_rot)
+
+        # --- STAGE 7: Typecast to cache dtype ---
+        keys, values = self.kv_cache
+
+        k_heads_cache_dtype = ttnn.typecast(k_heads, dtype=keys.dtype)
+        ttnn.deallocate(k_heads)
+
+        v_heads_cache_dtype = ttnn.typecast(v_heads, dtype=values.dtype)
+        ttnn.deallocate(v_heads)
+
+        # --- STAGE 8: Shard KV for long sequences ---
+        # The shard memcfg is derived for the folded seq_len and assumes a [1,*,S,*] layout, so it
+        # only applies to single-user prefill. Batched prefill is always paged (page_table set), so
+        # this branch is naturally skipped; the extra batch_size==1 guard makes that explicit.
+        if seq_len >= cfg.min_kv_prefill_shard_seqlen and page_table is None and batch_size == 1:
+            k_fill = ttnn.interleaved_to_sharded(k_heads_cache_dtype, cfg.prefill_kv_memcfg(seq_len))
+            v_fill = ttnn.interleaved_to_sharded(v_heads_cache_dtype, cfg.prefill_kv_memcfg(seq_len))
+        else:
+            k_fill = k_heads_cache_dtype
+            v_fill = v_heads_cache_dtype
+
+        # --- STAGE 9: KV Cache Fill ---
+        # Method bound at construction based on paged_attention_config (see _bind_forward_methods).
+        # Batched prefill fills one user per call in a loop: paged_fill_cache reads batch_idx_ptr[0]
+        # for all rows, so a per-row batch_idx in a single call is unsupported (TTTv1 attention.py
+        # L1013-1040). Device-verified correct (kernel probe E: per-slot readback pcc=1.0).
+        if batch_size > 1:
+            self._kv_fill_prefill_batched(keys, values, k_fill, v_fill, user_id, page_table, chunk_page_table)
+        else:
+            self._kv_fill_prefill(keys, values, k_fill, v_fill, user_id, page_table, chunk_page_table)
+
+        # Deallocate sharded k_fill/v_fill only in non-paged mode (paged mode uses sliced views)
+        is_paged = cfg.paged_attention_config is not None
+        if seq_len >= cfg.min_kv_prefill_shard_seqlen and not is_paged and batch_size == 1:
+            ttnn.deallocate(k_fill)
+            ttnn.deallocate(v_fill)
+
+        # --- STAGE 10: SDPA ---
+        q_heads_sdpa = ttnn.typecast(q_heads, dtype=cfg.activation_dtype or ttnn.bfloat8_b)
+        ttnn.deallocate(q_heads)
+
+        # Chunked vs non-chunked is a RUNTIME decision (based on seq_len vs max_prefill_chunk_size),
+        # so this branching is valid under TTTv2 principles. Valid combinations:
+        # - Paged + Chunked: production vLLM serving (long prompts)
+        # - Paged + Non-chunked: short prompts in vLLM
+        # - Non-paged + Non-chunked: simple testing (uses else branch with contiguous KV)
+        # Invalid combinations (rejected at config time in _resolve_attention1d_config):
+        # - Non-paged + Chunked: chunked_sdpa requires page_table
+        # - sliding_window + Chunked: chunked_sdpa does not implement window masking
+        if chunk_start_idx is not None:
+            attn_output = ttnn.transformer.chunked_scaled_dot_product_attention(
+                input_tensor_q=q_heads_sdpa,
+                input_tensor_k=keys,
+                input_tensor_v=values,
+                page_table_tensor=page_table,
+                chunk_start_idx=chunk_start_idx,
+                compute_kernel_config=cfg.sdpa_prefill_compute_kernel_cfg,
+                program_config=cfg.prefill_sdpa_prg_config(seq_len, chunk_start_idx),
+            )
+        else:
+            # Batched: q/k/v are [B, n_heads, per_user_seq_len, head_dim]; is_causal masks each row to
+            # its own sequence (device-verified: kernel probe C, pcc 0.9998, row0 independent). The
+            # program config keys on the per-user seq len, not the folded length.
+            attn_output = ttnn.transformer.scaled_dot_product_attention(
+                q_heads_sdpa,
+                k_heads_cache_dtype,
+                v_heads_cache_dtype,
+                is_causal=True,
+                sliding_window_size=cfg.sliding_window,
+                scale=cfg.scale,
+                compute_kernel_config=cfg.sdpa_prefill_compute_kernel_cfg,
+                program_config=cfg.prefill_sdpa_prg_config(per_user_seq_len, None),
+            )
+
+        ttnn.deallocate(q_heads_sdpa)
+        ttnn.deallocate(k_heads_cache_dtype)
+        ttnn.deallocate(v_heads_cache_dtype)
+
+        # --- STAGE 11: Reshape and Concat Heads ---
+        # Single-user: [1, n_heads, S, hd]. Batched: keep [B, n_heads, S, hd] — reshaping to
+        # [1, n_heads, B*S, hd] before concat would scramble data across the head axis (TTTv1
+        # attention.py L1112-1119). nlp_concat_heads handles the real batch axis natively.
+        if batch_size == 1:
+            attn_output = ttnn.reshape(attn_output, [1, n_local_heads, -1, cfg.head_dim])
+
+        attn_output_concat = ttnn.experimental.nlp_concat_heads(attn_output, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        ttnn.deallocate(attn_output)
+
+        # Batched: nlp_concat_heads emits [B, 1, S, n_heads*hd]; refold the batch axis back into the
+        # sequence ([1, 1, B*S, n_heads*hd]) so the WO matmul runs as one long-sequence matmul. This
+        # MUST happen after concat_heads to preserve layout (TTTv1 attention.py L1130-1134).
+        if batch_size > 1:
+            attn_output_concat = ttnn.reshape(attn_output_concat, [1, 1, seq_len, -1])
+
+        # --- STAGE 12: Reshape for long sequences (to fit WO matmul on device) ---
+        if seq_len > MAX_MM_SEQ_LEN:
+            attn_output_concat = ttnn.reshape(attn_output_concat, [1, seq_len // MAX_MM_SEQ_LEN, MAX_MM_SEQ_LEN, -1])
+
+        # --- STAGE 13: All-Gather for Ring topology ---
+        # Method bound at construction based on use_fused_all_gather_matmul (see _bind_forward_methods)
+        attn_output_concat = self._all_gather_before_wo_prefill(attn_output_concat)
+
+        # --- STAGE 14: WO Matmul ---
+        output = ttnn.linear(
+            attn_output_concat,
+            self.wo,
+            compute_kernel_config=cfg.li_o_prefill_compute_kernel_cfg,
+            dtype=cfg.activation_dtype or ttnn.bfloat8_b,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            program_config=cfg.prefill_wo_prg_config(seq_len),
+        )
+
+        # --- STAGE 15: Reshape back (undo long sequence reshape) ---
+        if seq_len > MAX_MM_SEQ_LEN:
+            output = ttnn.reshape(output, [1, 1, seq_len, -1])
+
+        ttnn.deallocate(attn_output_concat)
+
+        # --- STAGE 16: All-Reduce output ---
+        # Method bound at construction based on use_fused_all_gather_matmul (see _bind_forward_methods)
+        output = self._reduce_after_wo_prefill(output)
+
+        return output
+
+    def decode_forward(
+        self,
+        x: ttnn.Tensor | LazyWeight,
+        current_pos: ttnn.Tensor,
+        rot_mats: tuple[ttnn.Tensor, ttnn.Tensor],
+        page_table: ttnn.Tensor | None = None,
+    ) -> ttnn.Tensor:
+        """
+        Decode forward - single token per user.
+
+        Args:
+            x: Input tensor, shape (seq_len, 1, batch, dim), TILE_LAYOUT.
+                Memory config: DRAM WIDTH_SHARDED (default ``decode_input_memcfg``).
+                If ``LazyWeight``, it is automatically placed with the correct memory config.
+            current_pos: Current position tensor, shape (batch_size,) on host.
+            rot_mats: Tuple of (cos, sin) rotation matrices for rotary embedding,
+                each shape (1, batch, head_dim, head_dim), TILE_LAYOUT, L1 interleaved.
+            page_table: Page table for paged attention (optional).
+
+        Returns:
+            Output tensor (seq_len, 1, batch, dim), DRAM WIDTH_SHARDED
+            (``decode_residual_memcfg``).
+        """
+        self.load_device_weights()
+        x = _load_input_device_tensor(x, self.config, mode="decode")
+        cfg = self.config
+
+        num_devices = cfg.mesh_device.get_num_devices()
+        n_local_heads = cfg.n_heads // num_devices
+        n_local_kv_heads = cfg.n_kv_heads // num_devices
+
+        # --- STAGE 1: QKV Matmul ---
+        # All 1D topologies use DRAM-sharded matmul with L1_WIDTH_SHARDED output (matches TTTv1)
+        xqkv_fused_sharded = ttnn.linear(
+            x,
+            self.wqkv,
+            memory_config=ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG,
+            program_config=cfg.decode_xqkv_prg_config,
+            compute_kernel_config=cfg.li_qkv_decode_compute_kernel_cfg,
+            dtype=cfg.activation_dtype or ttnn.bfloat16,
+        )
+
+        # Add bias if present
+        if self.wqkv_bias_decode:
+            num_tiles = int(math.ceil(xqkv_fused_sharded.shape[-2] / TILE_SIZE))
+            xqkv_fused_sharded = xqkv_fused_sharded + self.wqkv_bias_decode[num_tiles - 1]
+
+        ttnn.deallocate(x)
+
+        # --- STAGE 2: Convert QKV from sharded to interleaved (matches TTTv1) ---
+        xqkv_fused = self._all_reduce_qkv_decode(xqkv_fused_sharded)
+        ttnn.deallocate(xqkv_fused_sharded)
+
+        # Reshape for create_qkv_heads
+        fqkv_shape = xqkv_fused.shape
+        xqkv_fused = ttnn.reshape(xqkv_fused, (1, 1, cfg.max_batch_size, fqkv_shape[3]), (1, 1, 32, fqkv_shape[3]))
+
+        # --- STAGE 3: Create QKV Heads ---
+        q_heads_pre_rot, k_heads_pre_rot, v_heads = ttnn.experimental.nlp_create_qkv_heads_decode(
+            xqkv_fused,
+            num_heads=n_local_heads,
+            num_kv_heads=n_local_kv_heads,
+            overlap_qk_coregrid=self._decode_overlap_qk_coregrid,
+            memory_config=cfg.decode_create_qkv_head_memcfg,
+        )
+        ttnn.deallocate(xqkv_fused)
+
+        # --- STAGE 4: Q/K Normalization (optional) ---
+        # Workaround: RMSNorm doesn't support HEIGHT_SHARDED inputs (TTTv1 norm_reshard pattern)
+        if self.q_norm is not None:
+            q_mem_cfg = q_heads_pre_rot.memory_config()
+            q_heads_pre_rot = ttnn.to_memory_config(q_heads_pre_rot, ttnn.L1_MEMORY_CONFIG, dtype=q_heads_pre_rot.dtype)
+            q_heads_pre_rot = self.q_norm.decode_forward(q_heads_pre_rot)
+            q_heads_pre_rot = ttnn.to_memory_config(q_heads_pre_rot, q_mem_cfg, dtype=q_heads_pre_rot.dtype)
+        if self.k_norm is not None:
+            k_mem_cfg = k_heads_pre_rot.memory_config()
+            k_heads_pre_rot = ttnn.to_memory_config(k_heads_pre_rot, ttnn.L1_MEMORY_CONFIG, dtype=k_heads_pre_rot.dtype)
+            k_heads_pre_rot = self.k_norm.decode_forward(k_heads_pre_rot)
+            k_heads_pre_rot = ttnn.to_memory_config(k_heads_pre_rot, k_mem_cfg, dtype=k_heads_pre_rot.dtype)
+
+        # --- STAGE 5: Rotary Embedding ---
+        # Method bound at construction based on use_qk_fused (see _bind_forward_methods)
+        q_heads, k_heads = self._rotary_embed_decode(q_heads_pre_rot, k_heads_pre_rot, rot_mats)
+        ttnn.deallocate(q_heads_pre_rot)
+        ttnn.deallocate(k_heads_pre_rot)
+
+        # --- STAGE 6: KV Cache Update ---
+        # Method bound at construction based on use_qk_fused (see _bind_forward_methods)
+        keys, values = self.kv_cache
+        self._kv_update_decode(keys, values, k_heads, v_heads, current_pos, page_table)
+        ttnn.deallocate(k_heads)
+        ttnn.deallocate(v_heads)
+
+        # --- STAGE 7: SDPA ---
+        # Method bound at construction based on paged_attention_config (see _bind_forward_methods)
+        attn_output = self._sdpa_decode(q_heads, keys, values, current_pos, page_table)
+
+        ttnn.deallocate(q_heads)
+
+        # --- STAGE 8: Reshape for concat heads ---
+        attn_output_sharded = ttnn.to_memory_config(
+            attn_output, memory_config=cfg.decode_scores_memcfg(cfg.max_batch_size)
+        )
+
+        # --- STAGE 9: Concat Heads ---
+        attn_output_cat = ttnn.experimental.nlp_concat_heads_decode(attn_output_sharded, num_heads=n_local_heads)
+        ttnn.deallocate(attn_output_sharded)
+        ttnn.deallocate(attn_output)
+
+        # --- STAGE 10: All-Gather + WO Matmul ---
+        # Method bound at construction based on use_fused_all_gather_matmul (see _bind_forward_methods)
+        dense_out = self._all_gather_wo_decode(attn_output_cat)
+
+        ttnn.deallocate(attn_output_cat)
+
+        # --- STAGE 11: Finalize output ---
+        # Method bound at construction based on use_fused_all_gather_matmul (see _bind_forward_methods)
+        # Fused path: returns dense_out as-is
+        # Non-fused path: reduce-scatter + final memory config
+        return self._finalize_decode_output(dense_out)
+
+    def forward(
+        self,
+        x: ttnn.Tensor | LazyWeight,
+        current_pos: ttnn.Tensor | None,
+        rot_mats: tuple[ttnn.Tensor, ttnn.Tensor],
+        user_id: int | list[int] = 0,
+        mode: str = "decode",
+        page_table: ttnn.Tensor | None = None,
+        chunk_page_table: ttnn.Tensor | None = None,
+        chunk_start_idx: int | None = None,
+        batch_size: int = 1,
+    ) -> ttnn.Tensor:
+        """Dispatch to the appropriate forward method based on mode."""
+        if mode == "prefill":
+            return self.prefill_forward(
+                x,
+                rot_mats,
+                user_id=user_id,
+                page_table=page_table,
+                chunk_page_table=chunk_page_table,
+                chunk_start_idx=chunk_start_idx,
+                batch_size=batch_size,
+            )
+        else:
+            return self.decode_forward(
+                x,
+                current_pos,
+                rot_mats,
+                page_table=page_table,
+            )
+
+    def _bind_forward_methods(self):
+        """
+        Bind forward method variants based on static config.
+
+        This eliminates runtime if-statements in the hot path by pre-binding:
+        - _sdpa_decode: paged or non-paged SDPA for decode
+        - _kv_fill_prefill: paged or non-paged KV cache fill for prefill
+        - _all_gather_before_wo_prefill: fused all-gather or no-op
+        - _reduce_after_wo_prefill: reduce-scatter or no-op
+        - _all_gather_wo_decode: fused or separate all-gather + WO matmul
+        - _finalize_decode_output: fused (direct return) or non-fused (reduce + memcfg)
+        - _rotary_embed_decode: fused QK or separate rotary embedding
+        - _kv_update_decode: fused or separate KV cache update
+
+        Note: page_table is still passed as a forward argument for vLLM compatibility
+        (vLLM dynamically manages page tables), but the method binding is static.
+        """
+        cfg = self.config
+        is_paged = cfg.paged_attention_config is not None
+
+        # Bind paged vs non-paged methods
+        if is_paged:
+            self._sdpa_decode = self._sdpa_decode_paged
+            self._kv_fill_prefill = self._kv_fill_prefill_paged
+        else:
+            self._sdpa_decode = self._sdpa_decode_non_paged
+            self._kv_fill_prefill = self._kv_fill_prefill_non_paged
+
+        # Bind fused all-gather methods (based on use_fused_all_gather_matmul + topology)
+        use_fused = cfg.use_fused_all_gather_matmul and cfg.topology == ttnn.Topology.Ring
+        if use_fused:
+            self._all_gather_before_wo_prefill = self._all_gather_before_wo_prefill_fused
+            self._reduce_after_wo_prefill = self._reduce_after_wo_prefill_fused
+            self._all_gather_wo_decode = self._fused_all_gather_wo_decode
+            self._finalize_decode_output = self._finalize_decode_output_fused
+        else:
+            self._all_gather_before_wo_prefill = self._all_gather_before_wo_prefill_noop
+            self._reduce_after_wo_prefill = self._reduce_after_wo_prefill_non_fused
+            self._all_gather_wo_decode = self._separate_all_gather_wo_decode
+            self._finalize_decode_output = self._finalize_decode_output_non_fused
+
+        # Bind fused QK methods (rotary embedding and KV cache update)
+        self._decode_overlap_qk_coregrid = not cfg.use_qk_fused
+        if cfg.use_qk_fused:
+            self._rotary_embed_decode = self._rotary_embed_decode_fused
+            self._kv_update_decode = self._kv_update_decode_fused
+        else:
+            self._rotary_embed_decode = self._rotary_embed_decode_nonfused
+            self._kv_update_decode = self._kv_update_decode_nonfused
+
+    # =========================================================================
+    # Bound SDPA Decode Methods (paged vs non-paged)
+    # =========================================================================
+
+    def _sdpa_decode_paged(self, q_heads, keys, values, current_pos, page_table) -> ttnn.Tensor:
+        """Paged SDPA decode - uses page_table for KV cache lookup."""
+        cfg = self.config
+        return ttnn.transformer.paged_scaled_dot_product_attention_decode(
+            q_heads,
+            keys,
+            values,
+            page_table_tensor=page_table,
+            cur_pos_tensor=current_pos,
+            scale=cfg.scale,
+            sliding_window_size=cfg.sliding_window,
+            program_config=cfg.decode_sdpa_prg_config,
+            compute_kernel_config=cfg.sdpa_decode_compute_kernel_cfg,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+
+    def _sdpa_decode_non_paged(self, q_heads, keys, values, current_pos, page_table) -> ttnn.Tensor:
+        """Non-paged SDPA decode - contiguous KV cache (page_table ignored)."""
+        cfg = self.config
+        return ttnn.transformer.scaled_dot_product_attention_decode(
+            q_heads,
+            keys,
+            values,
+            cur_pos_tensor=current_pos,
+            scale=cfg.scale,
+            sliding_window_size=cfg.sliding_window,
+            program_config=cfg.decode_sdpa_prg_config,
+            compute_kernel_config=cfg.sdpa_decode_compute_kernel_cfg,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+
+    # =========================================================================
+    # Bound KV Fill Prefill Methods (paged vs non-paged)
+    # =========================================================================
+
+    def _kv_fill_prefill_paged(self, keys, values, k_fill, v_fill, user_id, page_table, chunk_page_table) -> None:
+        """Paged KV cache fill for prefill - uses page_table for block allocation."""
+        block_size = keys.shape[2]
+        fill_page_table = chunk_page_table if chunk_page_table is not None else page_table
+        page_len = fill_page_table.shape[1] * block_size
+
+        k_fill_sliced = k_fill[:, :, :page_len, :] if page_len < k_fill.shape[2] else k_fill
+        v_fill_sliced = v_fill[:, :, :page_len, :] if page_len < v_fill.shape[2] else v_fill
+
+        ttnn.experimental.paged_fill_cache(keys, k_fill_sliced, fill_page_table, batch_idx=user_id)
+        ttnn.experimental.paged_fill_cache(values, v_fill_sliced, fill_page_table, batch_idx=user_id)
+
+    def _kv_fill_prefill_non_paged(self, keys, values, k_fill, v_fill, user_id, page_table, chunk_page_table) -> None:
+        """Non-paged KV cache fill for prefill - contiguous cache (page_table ignored)."""
+        cfg = self.config
+        ttnn.fill_cache(keys, k_fill, user_id % cfg.max_batch_size)
+        ttnn.fill_cache(values, v_fill, user_id % cfg.max_batch_size)
+
+    def _kv_fill_prefill_batched(self, keys, values, k_fill, v_fill, user_id, page_table, chunk_page_table) -> None:
+        """Batched prefill KV fill — one fill call per user (loop), mirroring TTTv1 attention.py
+        L1013-1040.
+
+        ``k_fill`` / ``v_fill`` are ``[batch_size, n_kv_heads, per_user_seq_len, head_dim]`` and
+        ``user_id`` is the list of *local* valid row indices (padded slots are excluded). ``batch_idx``
+        is a scalar per call because ``paged_fill_cache`` reads ``batch_idx_ptr[0]`` for all rows — a
+        per-row batch_idx in one call is unsupported. The executor builds ``page_table`` with one row
+        per local user, so local row ``i`` selects that user's physical blocks. Device-verified
+        correct (kernel probe E: per-slot readback pcc 1.0).
+        """
+        cfg = self.config
+        is_paged = cfg.paged_attention_config is not None
+        valid_slots = user_id if isinstance(user_id, (list, tuple)) else list(range(k_fill.shape[0]))
+
+        if is_paged:
+            block_size = keys.shape[2]
+            fill_page_table = chunk_page_table if chunk_page_table is not None else page_table
+            page_len = fill_page_table.shape[1] * block_size
+            seq_len_per_user = k_fill.shape[2]
+            for slot_idx in valid_slots:
+                k_user = k_fill[slot_idx : slot_idx + 1, :, :, :]
+                v_user = v_fill[slot_idx : slot_idx + 1, :, :, :]
+                k_user = k_user[:, :, :page_len, :] if page_len < seq_len_per_user else k_user
+                v_user = v_user[:, :, :page_len, :] if page_len < seq_len_per_user else v_user
+                ttnn.experimental.paged_fill_cache(keys, k_user, fill_page_table, batch_idx=slot_idx)
+                ttnn.experimental.paged_fill_cache(values, v_user, fill_page_table, batch_idx=slot_idx)
+        else:
+            for slot_idx in valid_slots:
+                ttnn.fill_cache(keys, k_fill[slot_idx : slot_idx + 1, :, :, :], slot_idx % cfg.max_batch_size)
+                ttnn.fill_cache(values, v_fill[slot_idx : slot_idx + 1, :, :, :], slot_idx % cfg.max_batch_size)
+
+    # =========================================================================
+    # Bound All-Gather/Reduce Methods for Prefill (fused vs non-fused)
+    # =========================================================================
+
+    def _all_gather_before_wo_prefill_fused(self, attn_output_concat: ttnn.Tensor) -> ttnn.Tensor:
+        """Fused path: all-gather before WO matmul (Ring topology)."""
+        cfg = self.config
+        return ttnn.experimental.all_gather_async(
+            attn_output_concat,
+            persistent_output_buffer=None,
+            dim=3,
+            multi_device_global_semaphore=cfg.tt_ccl.get_and_cycle_ag_semaphore_handles(),
+            num_links=1,
+            topology=cfg.topology,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            barrier_semaphore=cfg.tt_ccl.get_and_cycle_barrier_semaphore_handle(),
+            chunks_per_sync=CCL_CHUNKS_PER_SYNC,
+            num_workers_per_link=CCL_NUM_WORKERS_PER_LINK,
+            num_buffers_per_channel=CCL_NUM_BUFFERS_PER_CHANNEL,
+        )
+
+    def _all_gather_before_wo_prefill_noop(self, attn_output_concat: ttnn.Tensor) -> ttnn.Tensor:
+        """Non-fused path: no all-gather before WO matmul."""
+        return attn_output_concat
+
+    def _reduce_after_wo_prefill_fused(self, output: ttnn.Tensor) -> ttnn.Tensor:
+        """Fused path: no reduce after WO matmul (already complete from all-gather)."""
+        return output
+
+    def _reduce_after_wo_prefill_non_fused(self, output: ttnn.Tensor) -> ttnn.Tensor:
+        """Non-fused path: reduce-scatter after WO matmul."""
+        return self._all_reduce_output_prefill(output)
+
+    # =========================================================================
+    # Bound Finalize Methods for Decode (fused vs non-fused)
+    # =========================================================================
+
+    def _finalize_decode_output_fused(self, dense_out: ttnn.Tensor) -> ttnn.Tensor:
+        """Fused path: output is already complete, return as-is."""
+        return dense_out
+
+    def _finalize_decode_output_non_fused(self, dense_out: ttnn.Tensor) -> ttnn.Tensor:
+        """Non-fused path: reduce-scatter and apply final memory config."""
+        cfg = self.config
+
+        dense_out_reduced = self._all_reduce_output_decode(dense_out)
+
+        # Only deallocate if a new tensor was created (multi-device case).
+        # For single device, _all_reduce_output_decode returns input unchanged.
+        if cfg.mesh_device.get_num_devices() > 1:
+            ttnn.deallocate(dense_out)
+
+        return ttnn.to_memory_config(dense_out_reduced, cfg.decode_residual_memcfg)
+
+    # =========================================================================
+    # Bound Rotary Embedding Methods for Decode (fused QK vs separate)
+    # =========================================================================
+
+    def _rotary_embed_decode_fused(
+        self, q_heads_pre_rot: ttnn.Tensor, k_heads_pre_rot: ttnn.Tensor, rot_mats: tuple[ttnn.Tensor, ttnn.Tensor]
+    ) -> tuple[ttnn.Tensor, ttnn.Tensor]:
+        """Fused QK rotary embedding - single kernel for both Q and K.
+
+        The fused kernel requires Q and K on non-overlapping core grids.
+        After create_qkv_heads_decode with interleaved input, Q is already on the
+        correct cores (first batch cores), so only K needs resharding to a
+        non-overlapping grid — saving 1 dispatch vs the original 2-reshard approach.
+        """
+        cfg = self.config
+        k_heads_pre_rot = self._reshard_k_for_fused(k_heads_pre_rot, q_heads_pre_rot.shape[1])
+        return ttnn.experimental.rotary_embedding_llama_fused_qk(
+            q_heads_pre_rot, k_heads_pre_rot, rot_mats[0], rot_mats[1], cfg.transformation_mat_decode
+        )
+
+    def _rotary_embed_decode_nonfused(
+        self, q_heads_pre_rot: ttnn.Tensor, k_heads_pre_rot: ttnn.Tensor, rot_mats: tuple[ttnn.Tensor, ttnn.Tensor]
+    ) -> tuple[ttnn.Tensor, ttnn.Tensor]:
+        """Separate rotary embedding - independent kernels for Q and K."""
+        cfg = self.config
+        q_heads = ttnn.experimental.rotary_embedding_llama(
+            q_heads_pre_rot, rot_mats[0], rot_mats[1], cfg.transformation_mat_decode, is_decode_mode=True
+        )
+        k_heads = ttnn.experimental.rotary_embedding_llama(
+            k_heads_pre_rot, rot_mats[0], rot_mats[1], cfg.transformation_mat_decode, is_decode_mode=True
+        )
+        return q_heads, k_heads
+
+    # =========================================================================
+    # Bound KV Cache Update Methods for Decode (fused vs separate)
+    # =========================================================================
+
+    def _kv_update_decode_fused(
+        self,
+        keys: ttnn.Tensor,
+        values: ttnn.Tensor,
+        k_heads: ttnn.Tensor,
+        v_heads: ttnn.Tensor,
+        current_pos: ttnn.Tensor,
+        page_table: ttnn.Tensor | None,
+    ) -> None:
+        """Fused KV cache update - single kernel for both K and V."""
+        ttnn.experimental.paged_fused_update_cache(
+            keys, k_heads, values, v_heads, update_idxs_tensor=current_pos, page_table=page_table
+        )
+
+    def _kv_update_decode_nonfused(
+        self,
+        keys: ttnn.Tensor,
+        values: ttnn.Tensor,
+        k_heads: ttnn.Tensor,
+        v_heads: ttnn.Tensor,
+        current_pos: ttnn.Tensor,
+        page_table: ttnn.Tensor | None,
+    ) -> None:
+        """Separate KV cache update - independent kernels for K and V."""
+        ttnn.experimental.paged_update_cache(keys, k_heads, update_idxs_tensor=current_pos, page_table=page_table)
+        ttnn.experimental.paged_update_cache(values, v_heads, update_idxs_tensor=current_pos, page_table=page_table)
+
+    def load_device_weights(self):
+        """Materialize LazyWeights onto device. Called automatically on first forward; idempotent."""
+        if self._device_weights_loaded:
+            return
+
+        assert self.config.is_resolved(), "config must be resolved before loading device weights!"
+
+        cfg = self.config
+        self.wqkv = cfg.wqkv.get_device_weight()
+        self.wo = cfg.wo.get_device_weight()
+
+        # Initialize Q/K norm RMSNorm1D instances if configs present
+        if cfg.q_norm_config is not None:
+            self.q_norm = RMSNorm1D.from_config(cfg.q_norm_config)
+            self.q_norm.load_device_weights()
+        else:
+            self.q_norm = None
+
+        if cfg.k_norm_config is not None:
+            self.k_norm = RMSNorm1D.from_config(cfg.k_norm_config)
+            self.k_norm.load_device_weights()
+        else:
+            self.k_norm = None
+
+        # Materialize bias LazyWeights
+        if cfg._wqkv_bias_decode is not None:
+            self.wqkv_bias_decode = [bias.get_device_weight() for bias in cfg._wqkv_bias_decode]
+        else:
+            self.wqkv_bias_decode = None
+        if cfg._wqkv_bias_prefill is not None:
+            self.wqkv_bias_prefill = cfg._wqkv_bias_prefill.get_device_weight()
+        else:
+            self.wqkv_bias_prefill = None
+
+        if cfg.kv_cache is not None:
+            keys, values = cfg.kv_cache
+            if isinstance(keys, LazyWeight):
+                keys = keys.get_device_weight()
+            if isinstance(values, LazyWeight):
+                values = values.get_device_weight()
+            self.kv_cache = (keys, values)
+        else:
+            assert not hasattr(self, "kv_cache") or self.kv_cache is None, (
+                "kv_cache was set directly on Attention1D instead of via config.kv_cache. "
+                "Use model.set_kv_cache() to bind kv_cache through the config."
+            )
+            self.kv_cache = None
+
+        self._device_weights_loaded = True
+
+    # =========================================================================
+    # Internal CCL methods
+    # =========================================================================
+
+    def _all_reduce_qkv_decode(self, xqkv: ttnn.Tensor) -> ttnn.Tensor:
+        """
+        All-reduce QKV for decode mode.
+
+        For 1D topologies, tt_all_reduce with cluster_axis=1 returns input as-is (no reduction).
+        We just need to convert from sharded to interleaved (matches TTTv1 non-TG path).
+        """
+        # All 1D topologies: convert L1_WIDTH_SHARDED to L1 interleaved (matches TTTv1)
+        # bfloat16 is required by nlp_create_qkv_heads_decode
+        return ttnn.sharded_to_interleaved(xqkv, ttnn.L1_MEMORY_CONFIG, ttnn.bfloat16)
+
+    def _all_reduce_output_decode(self, output: ttnn.Tensor) -> ttnn.Tensor:
+        """
+        Final all-reduce for decode output.
+
+        For 1D topologies (1xN), this is reduce_scatter only.
+        """
+        cfg = self.config
+
+        # Single device: no all-reduce needed
+        if cfg.mesh_device.get_num_devices() == 1:
+            return output
+
+        # For 1D topologies: reduce_scatter across devices on axis 1
+        # Convert sharded to interleaved first if needed
+        if output.is_sharded():
+            output_interleaved = ttnn.sharded_to_interleaved(output, ttnn.L1_MEMORY_CONFIG)
+            output.deallocate(True)
+        else:
+            output_interleaved = output
+
+        reduced = ttnn.experimental.reduce_scatter_minimal_async(
+            output_interleaved,
+            persistent_output_buffers=None,
+            dim=3,
+            multi_device_global_semaphore=cfg.tt_ccl.get_and_cycle_rs_semaphore_handles(),
+            barrier_semaphore=cfg.tt_ccl.get_and_cycle_barrier_semaphore_handle(),
+            num_links=cfg.num_reduce_scatter_links,
+            memory_config=cfg.decode_residual_memcfg,
+            intermediate_memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            topology=cfg.topology,
+            chunks_per_sync=CCL_CHUNKS_PER_SYNC,
+            num_workers_per_link=CCL_NUM_WORKERS_PER_LINK,
+            num_buffers_per_channel=CCL_NUM_BUFFERS_PER_CHANNEL,
+        )
+        output_interleaved.deallocate(True)
+
+        return reduced
+
+    def _all_reduce_output_prefill(self, output: ttnn.Tensor) -> ttnn.Tensor:
+        """
+        Final all-reduce for prefill output.
+
+        For 1D topologies (1xN), this is reduce_scatter only.
+        """
+        cfg = self.config
+
+        # Single device: no all-reduce needed
+        if cfg.mesh_device.get_num_devices() == 1:
+            return output
+
+        # For 1D topologies: reduce_scatter across devices
+        # Prefill uses interleaved memory, ensure we're in DRAM.
+        output = ttnn.to_memory_config(output, ttnn.DRAM_MEMORY_CONFIG)
+
+        # When the fused all-gather+WO path is off, the WO output (bf16) is reduce-scattered here.
+        # Optionally cast it to a smaller CCL dtype first to halve the cross-device payload (matches
+        # TTTv1's bfloat8_b ccl_dtype). None (default) leaves the dtype unchanged. to_memory_config
+        # does not cast an already-DRAM tensor, so an explicit typecast is required.
+        if cfg.prefill_reduce_ccl_dtype is not None and output.dtype != cfg.prefill_reduce_ccl_dtype:
+            output_cast = ttnn.typecast(output, cfg.prefill_reduce_ccl_dtype)
+            ttnn.deallocate(output)
+            output = output_cast
+
+        reduced = ttnn.experimental.reduce_scatter_minimal_async(
+            output,
+            persistent_output_buffers=None,
+            dim=3,
+            multi_device_global_semaphore=cfg.tt_ccl.get_and_cycle_rs_semaphore_handles(),
+            barrier_semaphore=cfg.tt_ccl.get_and_cycle_barrier_semaphore_handle(),
+            num_links=cfg.num_reduce_scatter_links,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            intermediate_memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            topology=cfg.topology,
+            chunks_per_sync=CCL_CHUNKS_PER_SYNC,
+            num_workers_per_link=CCL_NUM_WORKERS_PER_LINK,
+            num_buffers_per_channel=CCL_NUM_BUFFERS_PER_CHANNEL,
+        )
+        output.deallocate(True)
+
+        return reduced
+
+    def _fused_all_gather_wo_decode(self, attn_output_cat: ttnn.Tensor) -> ttnn.Tensor:
+        """Fused all-gather matmul for Ring topology."""
+        cfg = self.config
+
+        attn_output_cat = ttnn.to_memory_config(attn_output_cat, cfg.decode_all_gather_matmul_memcfg)
+
+        _, dense_out = ttnn.experimental.all_gather_matmul_async(
+            attn_output_cat,
+            self.wo,
+            persistent_output_buffer=None,
+            dim=3,
+            multi_device_global_semaphore=cfg.tt_ccl.get_and_cycle_ag_semaphore_handles(),
+            all_gather_core_grid_offset=(0, 4),
+            barrier_semaphore=cfg.tt_ccl.get_and_cycle_barrier_semaphore_handle(),
+            num_links=1,
+            memory_config_ag=cfg.decode_all_gather_matmul_memcfg,
+            memory_config_mm=cfg.decode_residual_memcfg,
+            program_config=cfg.decode_all_gather_matmul_prg_config,
+            compute_kernel_config=cfg.li_o_decode_compute_kernel_cfg,
+            chunks_per_sync=CCL_CHUNKS_PER_SYNC,
+            num_workers_per_link=CCL_NUM_WORKERS_PER_LINK,
+            num_buffers_per_channel=CCL_NUM_BUFFERS_PER_CHANNEL,
+        )
+
+        return ttnn.to_memory_config(dense_out, cfg.decode_residual_memcfg)
+
+    def _separate_all_gather_wo_decode(self, attn_output_cat: ttnn.Tensor) -> ttnn.Tensor:
+        """
+        Separate all-gather then WO matmul (non-Ring or when fused not available).
+
+        For 1D topologies with cluster_axis=1, all-gather is a no-op since there's only
+        1 device on axis 0. The attention heads are already local to each device.
+        """
+        cfg = self.config
+
+        # For 1D topologies (1xN mesh), all-gather with cluster_axis=1 is a no-op
+        # because axis 0 has only 1 device. Skip the CCL call entirely.
+        # This matches TTTv1 behavior where tt_all_gather returns input unchanged.
+
+        # WO matmul
+        dense_out = ttnn.linear(
+            attn_output_cat,
+            self.wo,
+            program_config=cfg.decode_attn_output_prg_config,
+            memory_config=ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG,
+            compute_kernel_config=cfg.li_o_decode_compute_kernel_cfg,
+        )
+
+        return dense_out
+
+    def _reshard_k_for_fused(self, k_tensor: ttnn.Tensor, q_batch: int) -> ttnn.Tensor:
+        """Move K tensor to non-overlapping core grid for fused QK rotary embedding.
+
+        After create_qkv_heads_decode with interleaved input, Q and K share the
+        same core grid.  The fused rotary kernel requires non-overlapping grids.
+        Q's grid (first ``q_batch`` cores) is already correct, so we only move K
+        to the next ``q_batch`` cores — one dispatch instead of two.
+        """
+        n_kv_heads = k_tensor.shape[2]
+        row_size = 8
+        k_start_core = ttnn.CoreCoord(q_batch % row_size, q_batch // row_size)
+        k_core_grid = ttnn.CoreRangeSet({_num_to_corerange(q_batch, start_core=k_start_core)})
+        k_mem_config = ttnn.create_sharded_memory_config(
+            shape=(nearest_32(n_kv_heads), self.config.head_dim),
+            core_grid=k_core_grid,
+            strategy=ttnn.ShardStrategy.HEIGHT,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+        return ttnn.to_memory_config(k_tensor, k_mem_config)
+
+    # =========================================================================
+    # Factory method for backward compatibility
+    # =========================================================================
+
+    @classmethod
+    def from_model_args(
+        cls,
+        mesh_device,
+        tt_ccl,
+        args,
+        state_dict,
+        weight_cache_path,
+        layer_num: int,
+        transformation_mats: dict[str, ttnn.Tensor],
+        paged_attention_config=None,
+        use_paged_kv_cache: bool = False,
+    ):
+        """Factory method for backward compatibility with ModelArgs."""
+        import torch
+
+        from models.tt_transformers.tt.model_config import OpGroup, TensorGroup
+
+        if args.is_galaxy:
+            raise ValueError("Attention1D cannot be used for Galaxy devices. Use Attention2D instead.")
+
+        configuration = args
+        model_config = configuration.get_model_config()
+        decoders_opt = model_config.get("DECODERS_OPTIMIZATIONS")
+
+        layer_name = configuration.get_state_dict_prefix("Attention", layer_num)
+
+        wq_str = f"{layer_name}.wq"
+        wk_str = f"{layer_name}.wk"
+        wv_str = f"{layer_name}.wv"
+        wo_str = f"{layer_name}.wo"
+        q_norm_str = f"{layer_name}.q_norm"
+        k_norm_str = f"{layer_name}.k_norm"
+
+        # Get dtypes
+        wqkv_dtype = decoders_opt.get_tensor_dtype(decoder_id=layer_num, tensor=TensorGroup.WQKV)
+        wo_dtype = decoders_opt.get_tensor_dtype(decoder_id=layer_num, tensor=TensorGroup.WO)
+        kv_cache_dtype = decoders_opt.get_tensor_dtype(decoder_id=layer_num, tensor=TensorGroup.KV_CACHE)
+        activation_dtype = decoders_opt.get_tensor_dtype(decoder_id=layer_num, tensor=TensorGroup.ACTIVATION)
+
+        # Get compute kernel configs
+        li_qkv_decode_cfg = decoders_opt.get_math_fidelity(
+            decoder_id=layer_num, op=OpGroup.LI_QKV_DECODE, configuration=configuration
+        )
+        sdpa_decode_cfg = decoders_opt.get_math_fidelity(
+            decoder_id=layer_num, op=OpGroup.SDPA_DECODE, configuration=configuration
+        )
+        li_o_decode_cfg = decoders_opt.get_math_fidelity(
+            decoder_id=layer_num, op=OpGroup.LI_O_DECODE, configuration=configuration
+        )
+        li_qkv_prefill_cfg = decoders_opt.get_math_fidelity(
+            decoder_id=layer_num, op=OpGroup.LI_QKV_PREFILL, configuration=configuration
+        )
+        sdpa_prefill_cfg = decoders_opt.get_math_fidelity(
+            decoder_id=layer_num, op=OpGroup.SDPA_PREFILL, configuration=configuration
+        )
+        li_o_prefill_cfg = decoders_opt.get_math_fidelity(
+            decoder_id=layer_num, op=OpGroup.LI_O_PREFILL, configuration=configuration
+        )
+
+        # Build combined QKV weight
+        num_devices = mesh_device.get_num_devices()
+        qkv_list = []
+        for i in range(num_devices):
+            wq_selected = torch.chunk(state_dict[f"{wq_str}.weight"], num_devices, dim=0)[i]
+            wk_selected = torch.chunk(state_dict[f"{wk_str}.weight"], num_devices, dim=0)[i]
+            wv_selected = torch.chunk(state_dict[f"{wv_str}.weight"], num_devices, dim=0)[i]
+
+            wq = torch.transpose(wq_selected, -2, -1)
+            wk = torch.transpose(wk_selected, -2, -1)
+            wv = torch.transpose(wv_selected, -2, -1)
+
+            qkv = torch.cat([wq, wk, wv], dim=-1)
+            qkv_list.append(qkv)
+
+        qkv_cat = torch.cat(qkv_list, dim=-1).unsqueeze(0).unsqueeze(0)
+
+        # Create LazyWeights
+        wqkv_mem_config = configuration.create_dram_sharded_mem_config(
+            configuration.dim, configuration.qkv_size // num_devices
+        )
+
+        wqkv = LazyWeight(
+            source=qkv_cat,
+            dtype=wqkv_dtype,
+            device=mesh_device,
+            layout=ttnn.TILE_LAYOUT,
+            memory_config=wqkv_mem_config,
+            mesh_mapper_config=ttnn.MeshMapperConfig(
+                placements=[ttnn.PlacementShard(-1)],
+                mesh_shape_override=ttnn.MeshShape([num_devices]),
+            ),
+            cache_dir_weight_name=(Path(weight_cache_path) / layer_name, "wqkv_sharded") if weight_cache_path else None,
+        )
+
+        pt_wo = state_dict[f"{wo_str}.weight"].transpose(-1, -2).unsqueeze(0).unsqueeze(0)
+        wo_mem_config = configuration.create_dram_sharded_mem_config(
+            (configuration.n_heads * configuration.head_dim) // num_devices, configuration.dim
+        )
+
+        use_fused_all_gather_matmul = model_config.get("USE_FUSED_ALL_GATHER_MATMUL", False)
+
+        wo = LazyWeight(
+            source=pt_wo,
+            dtype=wo_dtype,
+            device=mesh_device,
+            layout=ttnn.TILE_LAYOUT,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG if use_fused_all_gather_matmul else wo_mem_config,
+            mesh_mapper_config=ttnn.MeshMapperConfig(
+                # For fused: shard on dim -1 (width) - matches TTTv1 dims=(2, 3)
+                # For non-fused: shard on dim -2 (height) - matches TTTv1 dims=(3, 2)
+                placements=[ttnn.PlacementShard(-1 if use_fused_all_gather_matmul else -2)],
+                mesh_shape_override=ttnn.MeshShape([num_devices]),
+            ),
+            cache_dir_weight_name=(
+                (
+                    Path(weight_cache_path) / layer_name,
+                    "wo_width_sharded" if use_fused_all_gather_matmul else "wo",
+                )
+                if weight_cache_path
+                else None
+            ),
+        )
+
+        # Q/K norm configs (optional) - using RMSNorm1DConfig composition pattern
+        q_norm_config = None
+        k_norm_config = None
+
+        # Get compute kernel config for Q/K normalization
+        # Q/K norm uses interleaved path (not sharded like regular decode RMSNorm)
+        qk_norm_compute_kernel = ttnn.WormholeComputeKernelConfig(
+            math_fidelity=ttnn.MathFidelity.HiFi2,
+            math_approx_mode=False,
+            fp32_dest_acc_en=True,
+            packer_l1_acc=False,
+        )
+
+        if f"{q_norm_str}.weight" in state_dict:
+            q_norm_torch = state_dict[f"{q_norm_str}.weight"]
+            # Note: add_unit_offset is handled by RMSNorm1DConfig resolution
+            q_norm_torch = q_norm_torch.reshape(1, 1, -1, TILE_SIZE)
+
+            q_norm_lazy = LazyWeight(
+                source=q_norm_torch,
+                dtype=ttnn.bfloat16,
+                device=mesh_device,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                cache_dir_weight_name=(Path(weight_cache_path) / layer_name, "q_norm") if weight_cache_path else None,
+            )
+
+            q_norm_config = RMSNorm1DConfig(
+                weight=q_norm_lazy,
+                mesh_device=mesh_device,
+                eps=configuration.norm_eps,
+                add_unit_offset=configuration.rms_norm_add_unit_offset,
+                decode_in_sharded=False,  # Q/K heads are interleaved after create_qkv_heads
+                decode_out_sharded=False,
+                prefill_distributed=False,  # Q/K norm doesn't need distributed prefill
+                compute_kernel_config=qk_norm_compute_kernel,
+            )
+
+        if f"{k_norm_str}.weight" in state_dict:
+            k_norm_torch = state_dict[f"{k_norm_str}.weight"]
+            # Note: add_unit_offset is handled by RMSNorm1DConfig resolution
+            k_norm_torch = k_norm_torch.reshape(1, 1, -1, TILE_SIZE)
+
+            k_norm_lazy = LazyWeight(
+                source=k_norm_torch,
+                dtype=ttnn.bfloat16,
+                device=mesh_device,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                cache_dir_weight_name=(Path(weight_cache_path) / layer_name, "k_norm") if weight_cache_path else None,
+            )
+
+            k_norm_config = RMSNorm1DConfig(
+                weight=k_norm_lazy,
+                mesh_device=mesh_device,
+                eps=configuration.norm_eps,
+                add_unit_offset=configuration.rms_norm_add_unit_offset,
+                decode_in_sharded=False,  # Q/K heads are interleaved after create_qkv_heads
+                decode_out_sharded=False,
+                prefill_distributed=False,  # Q/K norm doesn't need distributed prefill
+                compute_kernel_config=qk_norm_compute_kernel,
+            )
+
+        # Handle QKV bias
+        wqkv_bias = None
+        if f"{wq_str}.bias" in state_dict:
+            qkv_bias = torch.concat(
+                [
+                    torch.concat(
+                        [
+                            torch.chunk(state_dict[f"{wq_str}.bias"], num_devices)[i],
+                            torch.chunk(state_dict[f"{wk_str}.bias"], num_devices)[i],
+                            torch.chunk(state_dict[f"{wv_str}.bias"], num_devices)[i],
+                        ],
+                        dim=-1,
+                    )
+                    for i in range(num_devices)
+                ],
+                dim=-1,
+            )
+            wqkv_bias = LazyWeight(source=qkv_bias)
+
+        # Determine scale
+        if configuration.query_pre_attn_scalar is not None:
+            scale = configuration.query_pre_attn_scalar**-0.5
+        else:
+            scale = configuration.head_dim**-0.5
+
+        # Build config
+        # Note: kv_cache is created by default in _resolve_attention1d_config if not provided
+        # and use_paged_kv_cache=False. For paged cache (vLLM), set use_paged_kv_cache=True.
+        config = Attention1DConfig(
+            wqkv=wqkv,
+            wo=wo,
+            q_norm_config=q_norm_config,
+            k_norm_config=k_norm_config,
+            wqkv_bias=wqkv_bias,
+            mesh_device=mesh_device,
+            tt_ccl=tt_ccl,
+            topology=configuration.ccl_topology(),
+            dim=configuration.dim,
+            n_heads=configuration.n_heads,
+            n_kv_heads=configuration.n_kv_heads,
+            head_dim=configuration.head_dim,
+            qkv_size=configuration.qkv_size,
+            max_batch_size=configuration.max_batch_size,
+            max_seq_len=configuration.max_seq_len,
+            scale=scale,
+            sliding_window=configuration.sliding_window if hasattr(configuration, "sliding_window") else None,
+            use_qk_fused=getattr(configuration, "use_qk_fused", False),
+            use_vllm_paged_kv_cache=use_paged_kv_cache,
+            paged_attention_config=paged_attention_config,
+            kv_cache_dtype=kv_cache_dtype,
+            min_kv_prefill_shard_seqlen=configuration.min_kv_prefill_shard_seqlen,
+            wqkv_dtype=wqkv_dtype,
+            wo_dtype=wo_dtype,
+            activation_dtype=activation_dtype,
+            decode_xqkv_prg_config=model_config.get("XQKV_DECODE_PROGCFG"),
+            decode_sdpa_prg_config=model_config.get("SDPA_DECODE_PROGCFG"),
+            decode_attn_output_prg_config=model_config.get("ATTN_OUTPUT_PROGCFG"),
+            decode_residual_memcfg=model_config.get("DECODE_RESIDUAL_MEMCFG"),
+            decode_create_qkv_head_memcfg=model_config.get("CREATE_QKV_DECODE_SHARD"),
+            decode_scores_memcfg=model_config.get("SCORES_BATCHED_MM_OUTPUT_MEMCFG"),
+            prefill_xqkv_prg_config=model_config.get("XQKV_PREFILL_PROGCFG"),
+            prefill_sdpa_prg_config=model_config.get("SDPA_PROGCFG"),
+            prefill_wo_prg_config=model_config.get("WO_PREFILL_PROGCFG"),
+            prefill_kv_memcfg=model_config.get("KV_PREFILL_MEM_CFG"),
+            use_fused_all_gather_matmul=use_fused_all_gather_matmul,
+            decode_all_gather_matmul_prg_config=model_config.get("ATTN_ALL_GATHER_MATMUL_PROGCFG"),
+            decode_all_gather_matmul_memcfg=model_config.get("ATTN_ALL_GATHER_MATMUL_OUTPUT_MEMCFG"),
+            li_qkv_decode_compute_kernel_cfg=li_qkv_decode_cfg,
+            sdpa_decode_compute_kernel_cfg=sdpa_decode_cfg,
+            li_o_decode_compute_kernel_cfg=li_o_decode_cfg,
+            li_qkv_prefill_compute_kernel_cfg=li_qkv_prefill_cfg,
+            sdpa_prefill_compute_kernel_cfg=sdpa_prefill_cfg,
+            li_o_prefill_compute_kernel_cfg=li_o_prefill_cfg,
+            # Use provided transformation matrices if available; otherwise auto-created in resolve
+            transformation_mat_decode=transformation_mats.get("decode") if transformation_mats else None,
+            transformation_mat_prefill=transformation_mats.get("prefill") if transformation_mats else None,
+        )
+
+        return cls.from_config(config)
+
+
+# =============================================================================
+# Config resolution
+# =============================================================================
+
+
+def _resolve_attention1d_config(config: Attention1DConfig) -> Attention1DConfig:
+    """Materialize the config with sensible defaults."""
+    to_set = {}
+
+    # --- Phase 1: Model dimensions (fail-fast validation, no device needed) ---
+    # n_heads, n_kv_heads, head_dim MUST be provided - they cannot be reliably inferred
+    # from weight shapes alone (different models have different configurations).
+
+    n_heads = config.n_heads
+    n_kv_heads = config.n_kv_heads
+    head_dim = config.head_dim
+
+    if n_heads is None:
+        raise ValueError(
+            "n_heads must be provided. It cannot be reliably inferred from weights. "
+            "Get this value from your model's config.json (num_attention_heads)."
+        )
+    if n_kv_heads is None:
+        raise ValueError(
+            "n_kv_heads must be provided. It cannot be reliably inferred from weights. "
+            "Get this value from your model's config.json (num_key_value_heads)."
+        )
+    if head_dim is None:
+        raise ValueError(
+            "head_dim must be provided. It cannot be reliably inferred from weights. "
+            "Typically: head_dim = hidden_size // num_attention_heads."
+        )
+
+    # Reject sliding_window + paged attention (chunked prefill doesn't support window masking)
+    if config.sliding_window is not None and config.paged_attention_config is not None:
+        raise ValueError(
+            "Chunked prefill with sliding_window attention is not supported. "
+            "chunked_scaled_dot_product_attention does not implement sliding window masking. "
+            "Set sliding_window=None or disable paged attention / chunked prefill."
+        )
+
+    # --- Phase 2: Device and foundational fields ---
+
+    # Derive mesh_device
+    mesh_device = config.mesh_device
+    if mesh_device is None:
+        mesh_device = config.wqkv.device
+    if mesh_device is None:
+        mesh_device = ttnn.GetDefaultDevice()
+    if config.mesh_device is None:
+        to_set["mesh_device"] = mesh_device
+
+    assert mesh_device is not None, "mesh_device must be available!"
+
+    num_devices = mesh_device.get_num_devices()
+
+    if num_devices > 1:
+        if n_heads % num_devices != 0:
+            raise ValueError(
+                f"n_heads ({n_heads}) must be divisible by mesh device count ({num_devices}) "
+                "for Attention1D tensor-parallel sharding."
+            )
+        if n_kv_heads % num_devices != 0:
+            raise ValueError(
+                f"n_kv_heads ({n_kv_heads}) must be divisible by mesh device count ({num_devices}) "
+                "for Attention1D tensor-parallel sharding."
+            )
+
+    # Derive tt_ccl
+    if config.tt_ccl is None and num_devices > 1:
+        to_set["tt_ccl"] = get_tt_ccl(mesh_device)
+
+    # Auto-detect topology
+    if config.topology is None:
+        to_set["topology"] = default_topology(mesh_device)
+
+    topology = to_set.get("topology", config.topology)
+
+    # Auto-detect num_links (same approach as TTTv1 ccl.py tt_all_reduce)
+    tt_ccl = to_set.get("tt_ccl", config.tt_ccl)
+    if config.num_reduce_scatter_links is None and num_devices > 1:
+        to_set["num_reduce_scatter_links"] = tt_ccl.get_num_links()
+    if config.num_all_gather_links is None and num_devices > 1:
+        to_set["num_all_gather_links"] = tt_ccl.get_num_links()
+
+    # --- Phase 3: Derived dimensions ---
+
+    # dim CAN be reliably inferred from weight shapes
+    dim = config.dim
+    if dim is None:
+        # wqkv shape is (1, 1, dim, qkv_size_per_device * num_devices) or (dim, qkv_size)
+        wqkv_shape = config.wqkv.source.shape
+        dim = wqkv_shape[-2] if len(wqkv_shape) == 4 else wqkv_shape[0]
+        to_set["dim"] = dim
+
+    # qkv_size is derived from the required dimensions
+    qkv_size = config.qkv_size
+    if qkv_size is None:
+        qkv_size = head_dim * (2 * n_kv_heads + n_heads)
+        to_set["qkv_size"] = qkv_size
+
+    if config.scale is None:
+        to_set["scale"] = head_dim**-0.5
+
+    if config.min_kv_prefill_shard_seqlen is None:
+        to_set["min_kv_prefill_shard_seqlen"] = (TILE_SIZE * 8 * 8) // (n_kv_heads // num_devices)
+
+    # --- Phase 4: Dtypes ---
+
+    if config.wqkv_dtype is None:
+        to_set["wqkv_dtype"] = ttnn.bfloat8_b
+    if config.wo_dtype is None:
+        to_set["wo_dtype"] = ttnn.bfloat8_b
+    if config.activation_dtype is None:
+        to_set["activation_dtype"] = ttnn.bfloat16
+
+    # --- Phase 5: Compute kernel configs ---
+
+    compute_kernel_hifi2_fp16 = ttnn.WormholeComputeKernelConfig(
+        math_fidelity=ttnn.MathFidelity.HiFi2,
+        math_approx_mode=False,
+        fp32_dest_acc_en=False,
+        packer_l1_acc=True,
+    )
+    compute_kernel_hifi4 = ttnn.WormholeComputeKernelConfig(
+        math_fidelity=ttnn.MathFidelity.HiFi4,
+        math_approx_mode=False,
+        fp32_dest_acc_en=True,
+        packer_l1_acc=True,
+    )
+
+    if config.li_qkv_decode_compute_kernel_cfg is None:
+        to_set["li_qkv_decode_compute_kernel_cfg"] = compute_kernel_hifi2_fp16
+    if config.sdpa_decode_compute_kernel_cfg is None:
+        to_set["sdpa_decode_compute_kernel_cfg"] = compute_kernel_hifi2_fp16
+    if config.li_o_decode_compute_kernel_cfg is None:
+        to_set["li_o_decode_compute_kernel_cfg"] = compute_kernel_hifi2_fp16
+    if config.li_qkv_prefill_compute_kernel_cfg is None:
+        to_set["li_qkv_prefill_compute_kernel_cfg"] = compute_kernel_hifi2_fp16
+    if config.sdpa_prefill_compute_kernel_cfg is None:
+        to_set["sdpa_prefill_compute_kernel_cfg"] = compute_kernel_hifi4
+    if config.li_o_prefill_compute_kernel_cfg is None:
+        to_set["li_o_prefill_compute_kernel_cfg"] = compute_kernel_hifi2_fp16
+
+    # --- Phase 6: Program configs ---
+
+    tile_size = TILE_SIZE
+    tile_padded_batch_rows = tile_size * math.ceil(config.max_batch_size / tile_size)
+    n_local_heads = n_heads // num_devices
+
+    # Decode configs - use DRAM-sharded matmul for all 1D topologies (matches TTTv1)
+    if config.decode_xqkv_prg_config is None:
+        attn_input_grid = _dram_shard_core_grid(dim)
+        to_set["decode_xqkv_prg_config"] = _dram_matmul_config(
+            m=tile_padded_batch_rows,
+            k=dim,
+            n=qkv_size // num_devices,
+            num_cores=attn_input_grid.num_cores,
+        )
+
+    if config.decode_sdpa_prg_config is None:
+        to_set["decode_sdpa_prg_config"] = ttnn.SDPAProgramConfig(
+            compute_with_storage_grid_size=(8, 8),
+            exp_approx_mode=False,
+            q_chunk_size=0,
+            k_chunk_size=0,
+        )
+
+    if config.decode_attn_output_prg_config is None:
+        # Use DRAM-sharded matmul for all 1D topologies (matches TTTv1)
+        to_set["decode_attn_output_prg_config"] = _dram_matmul_config(
+            m=tile_padded_batch_rows,
+            k=(n_heads * head_dim) // num_devices,
+            n=dim,
+            num_cores=n_local_heads,
+        )
+
+    if config.decode_residual_memcfg is None:
+        residual_grid = _dram_shard_core_grid(dim // num_devices)
+        to_set["decode_residual_memcfg"] = ttnn.create_sharded_memory_config(
+            (tile_padded_batch_rows, dim // residual_grid.num_cores // num_devices),
+            residual_grid,
+            ttnn.ShardStrategy.WIDTH,
+            ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+
+    if config.decode_create_qkv_head_memcfg is None:
+        to_set["decode_create_qkv_head_memcfg"] = (
+            ttnn.create_sharded_memory_config(
+                shape=(TILE_SIZE, head_dim),
+                core_grid=ttnn.CoreGrid(y=4, x=8),
+                strategy=ttnn.ShardStrategy.HEIGHT,
+                orientation=ttnn.ShardOrientation.ROW_MAJOR,
+                use_height_and_width_as_shard_shape=True,
+            )
+            if is_blackhole()
+            else ttnn.L1_HEIGHT_SHARDED_MEMORY_CONFIG
+        )
+
+    if config.decode_scores_memcfg is None:
+
+        def scores_memcfg(batch_size):
+            return ttnn.create_sharded_memory_config(
+                shape=(math.ceil(n_local_heads / 32) * 32, head_dim),
+                core_grid=ttnn.CoreRangeSet({_num_to_corerange(batch_size)}),
+                strategy=ttnn.ShardStrategy.HEIGHT,
+                orientation=ttnn.ShardOrientation.ROW_MAJOR,
+                use_height_and_width_as_shard_shape=True,
+            )
+
+        to_set["decode_scores_memcfg"] = scores_memcfg
+
+    # Prefill configs
+    # DRAM shard grid width: on Wormhole always 8 (despite 12 physical DRAM cores);
+    # on Blackhole use actual DRAM grid width (7 for P100, 8 for P150).
+    # Matching per_core_N to this width avoids silent PCC issues on P100.
+    dram_shard_grid_width = 8 if not is_blackhole() else mesh_device.dram_grid_size().x
+
+    if config.prefill_xqkv_prg_config is None:
+
+        @lru_cache
+        def xqkv_prefill_prg_config(seq_len: int):
+            return ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+                compute_with_storage_grid_size=(8, 10) if is_blackhole() else (8, 8),
+                in0_block_w=1,
+                out_subblock_h=1,
+                out_subblock_w=1,
+                per_core_M=max(1, 8 if seq_len >= MAX_QKV_MM_SEQ_LEN else math.ceil(seq_len / tile_size / 8)),
+                per_core_N=math.ceil(qkv_size / num_devices / 32 / dram_shard_grid_width),
+                transpose_mcast=False,
+                fused_activation=None,
+                fuse_batch=seq_len <= MAX_QKV_MM_SEQ_LEN,
+            )
+
+        to_set["prefill_xqkv_prg_config"] = xqkv_prefill_prg_config
+
+    # minimal_matmul config for QKV (only materialized when the opt-in is set). Block sizes and grid
+    # mirror TTTv1 (model_config.py:1626-1632): a full 8x8 (8x10 on BH) compute grid, 8/8/8 blocks.
+    if config.prefill_qkv_minimal_matmul and config.prefill_xqkv_minimal_matmul_config is None:
+        minimal_qkv_grid = ttnn.CoreCoord(8, 10) if is_blackhole() else ttnn.CoreCoord(8, 8)
+
+        @lru_cache
+        def xqkv_minimal_matmul_config(seq_len: int):
+            return ttnn.MinimalMatmulConfig(
+                M_block_size=8,
+                K_block_size=8,
+                N_block_size=8,
+                compute_with_storage_grid_size=minimal_qkv_grid,
+            )
+
+        to_set["prefill_xqkv_minimal_matmul_config"] = xqkv_minimal_matmul_config
+
+    if config.prefill_sdpa_prg_config is None:
+
+        @lru_cache
+        def sdpa_prg_config(seq_len: int, chunk_start_idx: int | None):
+            q_chunk = 256 if seq_len >= 2048 else 64
+            k_chunk = 256 if seq_len >= 2048 else 64
+
+            if chunk_start_idx is not None and chunk_start_idx != 0:
+                q_chunk = min(q_chunk, chunk_start_idx & -chunk_start_idx)
+                k_chunk = min(k_chunk, chunk_start_idx & -chunk_start_idx)
+
+            return ttnn.SDPAProgramConfig(
+                compute_with_storage_grid_size=(8, 8),
+                exp_approx_mode=False,
+                q_chunk_size=q_chunk,
+                k_chunk_size=k_chunk,
+            )
+
+        to_set["prefill_sdpa_prg_config"] = sdpa_prg_config
+
+    if config.prefill_wo_prg_config is None:
+        use_fused = to_set.get("use_fused_all_gather_matmul", config.use_fused_all_gather_matmul)
+        if use_fused is None:
+            use_fused = (
+                num_devices == 8
+                and (dim // tile_size // num_devices) % num_devices == 0
+                and num_devices > 1
+                and topology == ttnn.Topology.Ring
+            )
+            to_set["use_fused_all_gather_matmul"] = use_fused
+
+        k_dim = (n_heads * head_dim) // num_devices
+        n_dim = MAX_MM_SEQ_LEN if use_fused and MAX_MM_SEQ_LEN % (dim // num_devices) == 0 else dim
+        prefill_rows = 8
+
+        @lru_cache
+        def wo_prefill_prg_config(seq_len: int):
+            num_rows = min(seq_len, MAX_MM_SEQ_LEN)
+            grid_size = _find_prefill_grid(prefill_rows, k_dim // tile_size)
+            return _matmul_config(
+                m=num_rows,
+                k=k_dim,
+                n=n_dim,
+                grid_size=grid_size,
+                in0_block_w=1,
+                fuse_batch=seq_len <= MAX_MM_SEQ_LEN,
+                per_core_n=math.ceil(n_dim / (tile_size * dram_shard_grid_width)) if not use_fused else None,
+            )
+
+        to_set["prefill_wo_prg_config"] = wo_prefill_prg_config
+
+    if config.prefill_kv_memcfg is None:
+        n_local_kv_heads = n_kv_heads // num_devices
+
+        @lru_cache
+        def kv_prefill_memcfg(seq_len: int):
+            # Shard the combined (n_kv_heads * seq_len) dimension across 64 cores
+            # This ensures tile-aligned shard shapes (multiples of 32)
+            num_cores = 8 * 8  # 64 cores
+            shard_height = (n_local_kv_heads * seq_len) // num_cores
+            return ttnn.create_sharded_memory_config(
+                shape=(shard_height, head_dim),
+                core_grid=ttnn.CoreGrid(y=8, x=8),
+                strategy=ttnn.ShardStrategy.HEIGHT,
+                orientation=ttnn.ShardOrientation.ROW_MAJOR,
+                use_height_and_width_as_shard_shape=True,
+            )
+
+        to_set["prefill_kv_memcfg"] = kv_prefill_memcfg
+
+    # Fused all-gather matmul configs
+    if config.use_fused_all_gather_matmul is None:
+        use_fused = (
+            num_devices == 8
+            and (dim // tile_size // num_devices) % num_devices == 0
+            and num_devices > 1
+            and topology == ttnn.Topology.Ring
+        )
+        to_set["use_fused_all_gather_matmul"] = use_fused
+
+    use_fused = to_set.get("use_fused_all_gather_matmul", config.use_fused_all_gather_matmul)
+
+    if use_fused and config.decode_all_gather_matmul_prg_config is None:
+        do_core_grid_size = (8, 1)
+        do_per_core_N = dim // num_devices // tile_size // (do_core_grid_size[0] * do_core_grid_size[1])
+
+        to_set["decode_all_gather_matmul_prg_config"] = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+            compute_with_storage_grid_size=do_core_grid_size,
+            in0_block_w=dim // tile_size // (do_core_grid_size[0] * do_core_grid_size[1]),
+            out_subblock_h=1,
+            out_subblock_w=_get_out_subblock_w(do_per_core_N, out_subblock_h=1),
+            per_core_M=tile_padded_batch_rows // tile_size,
+            per_core_N=do_per_core_N,
+            fuse_batch=True,
+            fused_activation=None,
+            mcast_in0=True,
+        )
+
+    if use_fused and config.decode_all_gather_matmul_memcfg is None:
+        to_set["decode_all_gather_matmul_memcfg"] = ttnn.create_sharded_memory_config(
+            (tile_padded_batch_rows, dim // 8),
+            ttnn.CoreGrid(x=8, y=1),
+            ttnn.ShardStrategy.WIDTH,
+            ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+
+    # Separate all-gather memory config (non-Ring or non-fused path)
+    # Matches TTTv1 GATHER_USERS_MEMCFG: shape=(tile_size * mesh_cols, dim // 8 // users_core_grid.num_cores)
+    if not use_fused and config.decode_gather_users_memcfg is None and num_devices > 1:
+        mesh_cols = list(mesh_device.shape)[1]
+        users_core_grid = _dram_shard_core_grid(dim // 8)
+        to_set["decode_gather_users_memcfg"] = ttnn.create_sharded_memory_config(
+            (tile_size * mesh_cols, dim // 8 // users_core_grid.num_cores),
+            users_core_grid,
+            ttnn.ShardStrategy.WIDTH,
+            ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+
+    # --- Phase 7: Input/output memory configs ---
+
+    if config.decode_input_memcfg is None:
+        # All 1D topologies use WIDTH_SHARDED for DRAM-sharded matmul (matches TTTv1)
+        attn_input_grid = _dram_shard_core_grid(dim)
+        to_set["decode_input_memcfg"] = ttnn.create_sharded_memory_config(
+            (tile_padded_batch_rows, dim // attn_input_grid.num_cores),
+            attn_input_grid,
+            ttnn.ShardStrategy.WIDTH,
+            ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+
+    if config.prefill_input_memcfg is None:
+        to_set["prefill_input_memcfg"] = ttnn.DRAM_MEMORY_CONFIG
+
+    # --- Phase 8: Resolve LazyWeights ---
+
+    wqkv_dtype = to_set.get("wqkv_dtype", config.wqkv_dtype)
+    wo_dtype = to_set.get("wo_dtype", config.wo_dtype)
+
+    wqkv_mem_config = config.wqkv_memcfg
+    if wqkv_mem_config is None:
+        # Use DRAM-sharded config for all 1D topologies (matches TTTv1 behavior)
+        # Note: For multi-device, the per-device portion uses qkv_size/num_devices
+        dram_grid_size = mesh_device.dram_grid_size()
+        dram_grid = ttnn.CoreRangeSet(
+            {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(dram_grid_size.x - 1, dram_grid_size.y - 1))}
+        )
+        # For multi-device, each device has qkv_size/num_devices columns
+        per_device_qkv_size = qkv_size // num_devices
+        wqkv_mem_config = _create_dram_sharded_mem_config(
+            k=dim, n=per_device_qkv_size, dram_grid=dram_grid, dram_cores=dram_grid_size.x
+        )
+
+    to_set["wqkv"] = resolve_lazy_weight(
+        config.wqkv,
+        device=mesh_device,
+        memory_config=wqkv_mem_config,
+        mesh_mapper_config=ttnn.MeshMapperConfig(
+            placements=[ttnn.PlacementShard(-1)],
+            mesh_shape_override=ttnn.MeshShape([num_devices]),
+        ),
+        layout=ttnn.TILE_LAYOUT,
+        dtype=wqkv_dtype,
+    )
+
+    wo_mem_config = config.wo_memcfg
+    if wo_mem_config is None:
+        # Fused all-gather matmul needs INTERLEAVED (TTTv1: dims=(2,3) for fused)
+        # Non-fused uses DRAM-sharded for all 1D topologies (TTTv1 behavior)
+        if use_fused:
+            wo_mem_config = ttnn.DRAM_MEMORY_CONFIG
+        else:
+            dram_grid_size = mesh_device.dram_grid_size()
+            dram_grid = ttnn.CoreRangeSet(
+                {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(dram_grid_size.x - 1, dram_grid_size.y - 1))}
+            )
+            # For multi-device, each device has (n_heads * head_dim) / num_devices input dim
+            per_device_hidden = (n_heads * head_dim) // num_devices
+            wo_mem_config = _create_dram_sharded_mem_config(
+                k=per_device_hidden, n=dim, dram_grid=dram_grid, dram_cores=dram_grid_size.x
+            )
+
+    to_set["wo"] = resolve_lazy_weight(
+        config.wo,
+        device=mesh_device,
+        memory_config=wo_mem_config,
+        mesh_mapper_config=ttnn.MeshMapperConfig(
+            # For fused: shard on dim -1 (width) - matches TTTv1 dims=(2, 3)
+            # For non-fused: shard on dim -2 (height) - matches TTTv1 dims=(3, 2)
+            placements=[ttnn.PlacementShard(-1 if use_fused else -2)],
+            mesh_shape_override=ttnn.MeshShape([num_devices]),
+        ),
+        layout=ttnn.TILE_LAYOUT,
+        dtype=wo_dtype,
+    )
+
+    # Resolve Q/K norm configs if present
+    # RMSNorm1DConfig needs mesh_device propagated from attention config
+    if config.q_norm_config is not None:
+        q_norm_cfg = config.q_norm_config
+        if q_norm_cfg.mesh_device is None:
+            q_norm_cfg = replace(q_norm_cfg, mesh_device=mesh_device)
+        to_set["q_norm_config"] = q_norm_cfg
+
+    if config.k_norm_config is not None:
+        k_norm_cfg = config.k_norm_config
+        if k_norm_cfg.mesh_device is None:
+            k_norm_cfg = replace(k_norm_cfg, mesh_device=mesh_device)
+        to_set["k_norm_config"] = k_norm_cfg
+
+    # --- Phase 9: Handle QKV bias ---
+
+    if config.wqkv_bias is not None:
+        # Extract source tensor from LazyWeight for custom transformation
+        qkv_bias = config.wqkv_bias.source
+
+        # Mesh mapper config for sharding bias on last dimension
+        # For 1D mesh: [Replicate on dim 0, Shard on dim -1]
+        bias_mesh_mapper_config = (
+            ttnn.MeshMapperConfig(
+                placements=[ttnn.PlacementReplicate(), ttnn.PlacementShard(-1)],
+                mesh_shape_override=ttnn.MeshShape(1, num_devices),
+            )
+            if num_devices > 1
+            else None  # Single device: replicate (no sharding)
+        )
+
+        # Prefill bias: transform to 4D shape (1, 1, 1, qkv_size)
+        # Use replace() to create new LazyWeight with transformed source, then resolve_lazy_weight
+        prefill_bias_lazy = resolve_lazy_weight(
+            replace(config.wqkv_bias, source=qkv_bias.unsqueeze(0).unsqueeze(0).unsqueeze(0)),
+            device=mesh_device,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper_config=bias_mesh_mapper_config,
+        )
+        to_set["_wqkv_bias_prefill"] = prefill_bias_lazy
+
+        # Decode bias - one per batch size multiple
+        # Match TTTv1 pattern: 2D tensor (batch_size, qkv_size)
+        wqkv_bias_decode = []
+        for batch_size in range(tile_size, tile_padded_batch_rows + tile_size, tile_size):
+            decode_bias_lazy = resolve_lazy_weight(
+                replace(config.wqkv_bias, source=qkv_bias.unsqueeze(0).expand(batch_size, -1)),
+                device=mesh_device,
+                dtype=ttnn.bfloat16,
+                layout=ttnn.TILE_LAYOUT,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                mesh_mapper_config=bias_mesh_mapper_config,
+            )
+            wqkv_bias_decode.append(decode_bias_lazy)
+        to_set["_wqkv_bias_decode"] = wqkv_bias_decode
+
+    # --- Phase 10: Create transformation matrices for rotary embedding ---
+
+    if config.transformation_mat_decode is None:
+        use_qk_fused = config.use_qk_fused
+        max_batch_size = config.max_batch_size
+        doubled_batch_size = max_batch_size * 2 if use_qk_fused else max_batch_size
+
+        # Get core grid for batch distribution
+        core_grid = ttnn.CoreCoord(8, 8) if is_blackhole() else mesh_device.compute_with_storage_grid_size()
+        batch_grid = ttnn.num_cores_to_corerangeset(doubled_batch_size, core_grid, row_wise=True)
+
+        # Create transformation matrix repeated across batch cores
+        trans_mat = get_rot_transformation_mat().repeat(1, 1, doubled_batch_size, 1)
+        trans_mat_mem_config = ttnn.create_sharded_memory_config(
+            shape=(TILE_SIZE, TILE_SIZE),
+            core_grid=batch_grid,
+            strategy=ttnn.ShardStrategy.HEIGHT,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+        transformation_mat_decode = ttnn.from_torch(
+            trans_mat,
+            device=mesh_device,
+            layout=ttnn.TILE_LAYOUT,
+            dtype=ttnn.bfloat16,
+            memory_config=trans_mat_mem_config,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+        )
+        to_set["transformation_mat_decode"] = transformation_mat_decode
+
+    if config.transformation_mat_prefill is None:
+        # Prefill uses simpler DRAM config (replicated across devices)
+        prefill_trans_mat = get_rot_transformation_mat()
+        transformation_mat_prefill = ttnn.from_torch(
+            prefill_trans_mat,
+            device=mesh_device,
+            layout=ttnn.TILE_LAYOUT,
+            dtype=ttnn.bfloat16,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+        )
+        to_set["transformation_mat_prefill"] = transformation_mat_prefill
+
+    # --- Phase 11: Resolve KV cache ---
+    # KV cache is a static configuration, allocated once and reused for all forward calls.
+    # If use_paged_kv_cache=True, the cache is managed externally (e.g., by vLLM) and not created here.
+    # Attention1D does not validate KV-cache DRAM/token capacity; callers own sizing.
+    # Allocation will fail at device memory allocation time if the cache does not fit.
+    if not config.use_vllm_paged_kv_cache:
+        n_local_kv_heads = n_kv_heads // num_devices
+        kv_cache_dtype = config.kv_cache_dtype
+        kv_cache_defaults = dict(
+            device=mesh_device,
+            dtype=kv_cache_dtype,
+            layout=ttnn.TILE_LAYOUT,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper_config=ttnn.MeshMapperConfig(
+                placements=[ttnn.PlacementReplicate()],
+                mesh_shape_override=ttnn.MeshShape([num_devices]),
+            ),
+        )
+
+        if config.kv_cache is None:
+            # Create default kv_cache LazyWeights
+            if config.paged_attention_config:
+                cache_k = zeros_like_paged_cache(config.paged_attention_config, n_local_kv_heads, head_dim)
+                cache_v = zeros_like_paged_cache(config.paged_attention_config, n_local_kv_heads, head_dim)
+            else:
+                cache_k = zeros_like_kv_cache(config.max_batch_size, n_local_kv_heads, config.max_seq_len, head_dim)
+                cache_v = zeros_like_kv_cache(config.max_batch_size, n_local_kv_heads, config.max_seq_len, head_dim)
+            kv_cache = (LazyWeight(source=cache_k), LazyWeight(source=cache_v))
+        else:
+            kv_cache = config.kv_cache
+
+        # Resolve defaults for LazyWeights; pass through pre-allocated tensors as-is
+        resolved = []
+        for i, entry in enumerate(kv_cache):
+            if isinstance(entry, LazyWeight):
+                resolved.append(resolve_lazy_weight(entry, **kv_cache_defaults))
+            elif isinstance(entry, ttnn.Tensor):
+                resolved.append(entry)
+            else:
+                raise TypeError(f"kv_cache[{i}] must be LazyWeight or ttnn.Tensor, got {type(entry).__name__}")
+        to_set["kv_cache"] = tuple(resolved)
+
+    return replace(config, **to_set)
+
+
+# =============================================================================
+# Helper functions
+# =============================================================================
+
+
+def _find_largest_divisor(n: int, max_divisor: int = 8) -> int:
+    """Find largest divisor of n up to max_divisor."""
+    for i in range(max_divisor, 0, -1):
+        if n % i == 0:
+            return i
+    return 1
+
+
+def _find_grid(n_tiles: int, max_rows: int = 8, max_cols: int = 8) -> tuple[int, int]:
+    """Find grid dimensions (rows, cols) that evenly divide n_tiles."""
+    max_cores = max_rows * max_cols
+    target = 32
+    possible_cores = [k for k in range(1, max_cores + 1) if n_tiles % k == 0]
+    possible_cores.sort(key=lambda x: abs(x - target))
+
+    for cores in possible_cores:
+        for rows in range(1, max_rows + 1):
+            if cores % rows == 0:
+                cols = cores // rows
+                if cols <= max_cols:
+                    return rows, cols
+
+    raise AssertionError(f"Cannot find grid for {n_tiles} tiles within {max_rows}x{max_cols}")
+
+
+def _find_prefill_grid(row_tiles: int, col_tiles: int, max_rows: int = 8, max_cols: int = 8) -> tuple[int, int]:
+    """Find grid where row_tiles divides rows and col_tiles divides cols."""
+    cols = next((i for i in range(max_cols, 0, -1) if col_tiles % i == 0), None)
+    rows = next((i for i in range(max_rows, 0, -1) if row_tiles % i == 0), None)
+    assert cols is not None and rows is not None
+    return rows, cols
+
+
+def _get_out_subblock_w(per_core_n: int, out_subblock_h: int = 1) -> int:
+    """Get output subblock width that divides per_core_n and satisfies constraints."""
+    out_subblock_w = 4
+    while out_subblock_w > 1:
+        if out_subblock_w * out_subblock_h <= 4 and per_core_n % out_subblock_w == 0:
+            break
+        out_subblock_w -= 1
+    return out_subblock_w
+
+
+def _dram_shard_core_grid(k: int, tile_size: int = TILE_SIZE) -> ttnn.CoreGrid:
+    """Get core grid for DRAM sharding based on K dimension."""
+    rows, cols = _find_grid(k // tile_size)
+    return ttnn.CoreGrid(x=cols, y=rows)
+
+
+def _dram_matmul_config(
+    m: int, k: int, n: int, num_cores: int, tile_size: int = TILE_SIZE
+) -> ttnn.MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig:
+    """Create DRAM-sharded matmul program config."""
+    return ttnn.MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig(
+        in0_block_w=_find_largest_divisor(k // (tile_size * num_cores)),
+        per_core_M=math.ceil(m / tile_size),
+        per_core_N=math.ceil(n / (tile_size * num_cores)),
+        fused_activation=None,
+    )
+
+
+def _matmul_config(
+    m: int,
+    k: int,
+    n: int,
+    grid_size: tuple[int, int],
+    tile_size: int = TILE_SIZE,
+    in0_block_w: int = None,
+    fuse_batch: bool = False,
+    fused_activation=None,
+    per_core_m: int = None,
+    per_core_n: int = None,
+) -> ttnn.MatmulMultiCoreReuseMultiCastProgramConfig:
+    """Create multicast matmul program config."""
+    if per_core_m is None:
+        per_core_m = math.ceil(m / (tile_size * grid_size[1]))
+    if per_core_n is None:
+        per_core_n = math.ceil(n / (tile_size * grid_size[0]))
+
+    out_subblock_h = 1
+    out_subblock_w = _get_out_subblock_w(per_core_n, out_subblock_h)
+
+    if in0_block_w is None:
+        in0_block_w = _find_largest_divisor(k // (tile_size * grid_size[1]))
+
+    return ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+        compute_with_storage_grid_size=grid_size,
+        in0_block_w=in0_block_w,
+        out_subblock_h=out_subblock_h,
+        out_subblock_w=out_subblock_w,
+        per_core_M=per_core_m,
+        per_core_N=per_core_n,
+        transpose_mcast=False,
+        fused_activation=fused_activation,
+        fuse_batch=fuse_batch,
+    )
+
+
+def _create_dram_sharded_mem_config(
+    k: int, n: int, dram_grid: ttnn.CoreRangeSet, tile_size: int = TILE_SIZE, dram_cores: int = 12
+) -> ttnn.MemoryConfig:
+    """Create DRAM-sharded memory config for weight tensors."""
+    padded_size = math.ceil(n / (tile_size * dram_cores)) * (tile_size * dram_cores)
+    shard_spec = ttnn.ShardSpec(dram_grid, (k, padded_size // dram_cores), ttnn.ShardOrientation.ROW_MAJOR)
+    return ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.DRAM, shard_spec)
+
+
+def _num_to_corerange(num_cores: int, start_core: ttnn.CoreCoord = None) -> ttnn.CoreRange:
+    """Convert number of cores to CoreRange."""
+    if start_core is None:
+        start_core = ttnn.CoreCoord(0, 0)
+
+    if num_cores == 1:
+        return ttnn.CoreRange(start_core, start_core)
+
+    # Arrange cores in rows of 8
+    row_size = 8
+    start_x, start_y = start_core.x, start_core.y
+
+    # Calculate end coordinates
+    total_cores_with_start = start_x + num_cores
+    end_y = start_y + (total_cores_with_start - 1) // row_size
+    end_x = (total_cores_with_start - 1) % row_size
+
+    return ttnn.CoreRange(start_core, ttnn.CoreCoord(end_x, end_y))
+
+
+def _load_input_device_tensor(x: ttnn.Tensor | LazyWeight, config: Attention1DConfig, mode: str) -> ttnn.Tensor:
+    """Resolve input tensor to ttnn.Tensor if LazyWeight, otherwise return as-is."""
+    assert mode in ("decode", "prefill"), f"mode must be 'decode' or 'prefill', got {mode}"
+
+    if isinstance(x, LazyWeight):
+        mem_cfg = config.decode_input_memcfg if mode == "decode" else config.prefill_input_memcfg
+        resolved_x = resolve_lazy_weight(
+            x,
+            device=config.mesh_device,
+            memory_config=mem_cfg,
+            mesh_mapper_config=None,  # replicated
+            layout=ttnn.TILE_LAYOUT,
+        )
+        return resolved_x.get_device_weight()
+
+    assert isinstance(x, ttnn.Tensor), f"x must be ttnn.Tensor or LazyWeight, got {type(x)}"
+    return x

--- a/models/experimental/llama32_1b_quasar/modules/embedding/embedding_1d.py
+++ b/models/experimental/llama32_1b_quasar/modules/embedding/embedding_1d.py
@@ -1,0 +1,284 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+TTTv2-style Embedding module for 1D-topology devices: N150 (1x1), N300 (1x2), T3K (1x8).
+
+Single unified Embedding1D class:
+  - forward(x): Token embedding lookup, optionally scaled by embed_scale.
+
+Execution path:
+  embedding(x, weights) → [multiply(embed_scale) if embed_scale != 1.0]
+
+This module replaces both TTTv1 Embedding and ScaledEmbedding classes.
+"""
+
+from dataclasses import dataclass, replace
+from pathlib import Path
+
+import ttnn
+from models.experimental.llama32_1b_quasar.lightweightmodule import LightweightModule
+from models.experimental.llama32_1b_quasar.modules.lazy_weight import LazyWeight, resolve_lazy_weight
+
+# =============================================================================
+# Top-level config dataclass
+# =============================================================================
+
+
+@dataclass
+class Embedding1DConfig:
+    """
+    Central configuration for Embedding1D - the single source of truth for all settings.
+
+    Simple usage (all defaults):
+        config = Embedding1DConfig(weights=lazy_weights)
+
+    With scale:
+        config = Embedding1DConfig(weights=lazy_weights, embed_scale=3072**0.5)
+
+    Full customization:
+        config = Embedding1DConfig(
+            weights=lazy_weights,
+            mesh_device=custom_device,
+            weights_memcfg=custom_memcfg,
+        )
+    """
+
+    # Required: embedding weight table (vocab_size, dim), sharded on dim=-1
+    weights: LazyWeight
+
+    # Optional: device (derived from weights if None)
+    mesh_device: ttnn.MeshDevice | None = None
+
+    # Optional: scaling factor applied after lookup (1.0 = no scaling)
+    embed_scale: float = 1.0
+
+    # Optional: power-user overrides (None = compute defaults)
+    weights_dtype: ttnn.DataType | None = None
+    weights_memcfg: ttnn.MemoryConfig | None = None
+    output_memcfg: ttnn.MemoryConfig | None = None
+
+    def is_resolved(self) -> bool:
+        """Check if all fields are resolved."""
+        return all(getattr(self, f) is not None for f in self.__dataclass_fields__)
+
+
+# =============================================================================
+# Embedding1D - Unified Embedding for 1D-topology devices
+# =============================================================================
+
+
+class Embedding1D(LightweightModule):
+    """
+    Embedding for non-TG devices supporting token lookup with optional scaling.
+
+    Replaces both TTTv1 Embedding and ScaledEmbedding.
+
+    Simple API (90% of users):
+        emb = Embedding1D(weights)
+
+    With scaling:
+        emb = Embedding1D(weights, embed_scale=3072**0.5)
+
+    Power API (10% of users):
+        config = Embedding1DConfig(weights=lazy_w, weights_memcfg=custom_cfg)
+        emb = Embedding1D.from_config(config)
+
+    Execution path:
+      embedding(x, weights) → [multiply(embed_scale) if embed_scale != 1.0]
+    """
+
+    def __init__(self, weights: LazyWeight, embed_scale: float = 1.0):
+        """
+        Simple API - derives all config from weights.
+
+        Args:
+            weights: Embedding weight table (vocab_size, dim), sharded on last dim.
+            embed_scale: Scale factor applied after lookup (default 1.0 = no scaling).
+        """
+        super().__init__()
+        self.config = _resolve_embedding1d_config(Embedding1DConfig(weights=weights, embed_scale=embed_scale))
+        self._device_weights_loaded = False
+
+    @classmethod
+    def from_config(cls, config: Embedding1DConfig):
+        """
+        Power API - any level of customization via config.
+
+        Override any subset of fields in Embedding1DConfig:
+            config = Embedding1DConfig(weights=w, embed_scale=2.0)
+            emb = Embedding1D.from_config(config)
+        """
+        instance = object.__new__(cls)
+        super(Embedding1D, instance).__init__()
+        instance.config = _resolve_embedding1d_config(config)
+        instance._device_weights_loaded = False
+        return instance
+
+    def load_device_weights(self):
+        if self._device_weights_loaded:
+            return
+
+        assert self.config.is_resolved(), "config must be resolved before loading device weights!"
+        self.weights = self.config.weights.get_device_weight()
+        self._device_weights_loaded = True
+
+    def forward(self, x: ttnn.Tensor | LazyWeight) -> ttnn.Tensor:
+        """
+        Token embedding lookup.
+
+        Args:
+            x: Token IDs tensor (uint32), shape [1, 1, 1, seq_len].
+
+        Returns:
+            Embedded tokens, shape [1, 1, seq_len, dim].
+        """
+        self.load_device_weights()
+        x = _load_input_device_tensor(x, self.config)
+
+        out = ttnn.embedding(
+            x,
+            self.weights,
+            layout=ttnn.TILE_LAYOUT,
+            memory_config=self.config.output_memcfg,
+        )
+
+        if self.config.embed_scale != 1.0:
+            out = ttnn.multiply(out, self.config.embed_scale, memory_config=self.config.output_memcfg)
+
+        return out
+
+    # [INFO] this is the entry point for TTTv1 model_config.py and will retire with TTTv1
+    @classmethod
+    def from_model_args(
+        cls,
+        mesh_device,
+        args,
+        weight_cache_path,
+        state_dict,
+        dtype,
+        embed_scale: float = 1.0,
+    ):
+        """Factory method for backward compatibility with ModelArgs.
+
+        Args:
+            mesh_device: The mesh device to use.
+            args: Model arguments (ModelArgs instance).
+            weight_cache_path: Path for weight caching.
+            state_dict: The state dictionary containing weights.
+            dtype: Data type for weights.
+            embed_scale: Scale factor applied after lookup (default 1.0).
+        """
+        if args.is_galaxy:
+            raise ValueError("Embedding1D cannot be used for Galaxy devices.")
+
+        base_name = args.get_state_dict_prefix("", None) + "tok_embeddings.weight"
+        torch_weight = state_dict[base_name].unsqueeze(0).unsqueeze(0)
+
+        cache_dir = None if args.dummy_weights else Path(weight_cache_path) / "embedding"
+
+        num_devices = mesh_device.get_num_devices()
+
+        weights = LazyWeight(
+            source=torch_weight,
+            dtype=dtype,
+            device=mesh_device,
+            mesh_mapper_config=ttnn.MeshMapperConfig(
+                placements=[ttnn.PlacementShard(-1)],
+                mesh_shape_override=ttnn.MeshShape([num_devices]),
+            ),
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            cache_dir_weight_name=(cache_dir, "tok_embeddings") if cache_dir else None,
+        )
+
+        config = Embedding1DConfig(
+            weights=weights,
+            mesh_device=mesh_device,
+            embed_scale=embed_scale,
+            weights_dtype=dtype,
+            weights_memcfg=ttnn.DRAM_MEMORY_CONFIG,
+            output_memcfg=ttnn.DRAM_MEMORY_CONFIG,
+        )
+        return cls.from_config(config)
+
+
+# =============================================================================
+# Config resolution
+# =============================================================================
+
+
+def _resolve_embedding1d_config(config: Embedding1DConfig) -> Embedding1DConfig:
+    """Materialize the config to known good defaults using replace pattern."""
+
+    to_set = {}
+
+    # --- Phase 1: Foundational fields ---
+
+    # Derive mesh_device from weights
+    mesh_device = config.mesh_device
+    if mesh_device is None:
+        mesh_device = config.weights.device
+    if mesh_device is None:
+        mesh_device = ttnn.GetDefaultDevice()
+    if config.mesh_device is None:
+        to_set["mesh_device"] = mesh_device
+
+    assert mesh_device is not None, "mesh_device must be available at this point!"
+
+    # --- Phase 2: Default configs ---
+
+    if config.weights_dtype is None:
+        to_set["weights_dtype"] = ttnn.bfloat16
+
+    if config.weights_memcfg is None:
+        to_set["weights_memcfg"] = ttnn.DRAM_MEMORY_CONFIG
+
+    if config.output_memcfg is None:
+        to_set["output_memcfg"] = ttnn.DRAM_MEMORY_CONFIG
+
+    # --- Phase 3: Resolve LazyWeight ---
+
+    num_devices = mesh_device.get_num_devices()
+    weights_memcfg = (
+        config.weights_memcfg
+        if config.weights_memcfg is not None
+        else to_set.get("weights_memcfg", ttnn.DRAM_MEMORY_CONFIG)
+    )
+    weights_dtype = (
+        config.weights_dtype if config.weights_dtype is not None else to_set.get("weights_dtype", ttnn.bfloat16)
+    )
+
+    to_set["weights"] = resolve_lazy_weight(
+        config.weights,
+        device=mesh_device,
+        memory_config=weights_memcfg,
+        mesh_mapper_config=ttnn.MeshMapperConfig(
+            placements=[ttnn.PlacementShard(-1)],
+            mesh_shape_override=ttnn.MeshShape([num_devices]),
+        ),
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        dtype=weights_dtype,
+    )
+
+    resolved_config = replace(config, **to_set)
+    assert resolved_config.is_resolved(), "Config must be resolved!"
+    assert resolved_config.weights.is_resolved(), "Weights must be resolved!"
+
+    return resolved_config
+
+
+def _load_input_device_tensor(x: ttnn.Tensor | LazyWeight, config: Embedding1DConfig) -> ttnn.Tensor:
+    """Resolve the input tensor to ttnn tensor if x is a LazyWeight, otherwise return as-is."""
+    if isinstance(x, LazyWeight):
+        resolved_x = resolve_lazy_weight(
+            x,
+            device=config.mesh_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper_config=None,  # replicated
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+        )
+        return resolved_x.get_device_weight()
+
+    assert isinstance(x, ttnn.Tensor), "x must be a ttnn tensor at this point!"
+    return x

--- a/models/experimental/llama32_1b_quasar/modules/lazy_buffer.py
+++ b/models/experimental/llama32_1b_quasar/modules/lazy_buffer.py
@@ -1,0 +1,157 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+LazyBuffer: Lazy device buffer allocation for mutable state tensors.
+
+This module has NO torch dependency - it accepts any tensor-like object that
+ttnn.from_torch() can handle (duck typing with string type hints).
+
+Design principles:
+- Mirrors LazyWeight's allocation contract (source + from_torch() parameters)
+- Designed for buffers that are mutated in-place after allocation, NOT immutable model weights
+- No disk caching: mutable buffers would corrupt state across instances
+- No fingerprinting: without caching, there is no cache to invalidate
+- Explicit parameters over hidden closures (IDE-friendly)
+- Duck typing for source tensors (no torch import)
+
+See also: LazyWeight in models/common/modules/lazy_weight.py
+"""
+
+from dataclasses import dataclass, field, replace
+from typing import Optional
+
+import ttnn
+
+
+@dataclass
+class LazyBuffer:
+    """
+    Lazy-allocated device buffer for mutable state tensors.
+
+    Mirrors LazyWeight's allocation contract (source + from_torch() parameters) but is
+    designed for buffers that are mutated in-place after allocation, NOT immutable model weights.
+
+    Key differences from LazyWeight:
+    - No disk caching: The device data is overwritten in-place via output_tensor= during
+      decode (e.g., penalty masks, token counts). Caching a mutable buffer would cause
+      state corruption if loaded by another instance.
+    - No fingerprinting: Without caching, there is no cache to invalidate.
+    - _value caching is safe: The ttnn.Tensor *handle* returned by get_device_buffer()
+      never changes — only the on-device data changes via output_tensor= writes.
+      So "allocate once, return same handle" is correct for mutable buffers.
+
+    The only thing that makes these different from weights is post-allocation mutability
+    and no disk caching. If a buffer becomes read-only in a future refactor, it can be
+    promoted to a LazyWeight with caching enabled.
+
+    See also: LazyWeight in models/common/modules/lazy_weight.py
+
+    Example usage:
+        # Fully specified at construction
+        buf = LazyBuffer(
+            source=torch.zeros(32, 128256, dtype=torch.int32),
+            device=mesh_device,
+            dtype=ttnn.int32,
+            layout=ttnn.TILE_LAYOUT,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+        tt_tensor = buf.get_device_buffer()  # allocates on first call
+
+        # Refresh device data without reallocation
+        buf.update(torch.ones(32, 128256, dtype=torch.int32))
+
+        # Partial construction — resolve later
+        buf = LazyBuffer(source=torch.zeros(32, 1))
+        buf = resolve_lazy_buffer(buf, device=mesh_device, dtype=ttnn.int32)
+    """
+
+    # Source: initial host tensor values (e.g., torch.zeros, torch.ones).
+    # Duck-typed — string annotation avoids torch import at module level.
+    source: "torch.Tensor"
+
+    # from_torch() parameters — same fields as LazyWeight (minus cache_dir_weight_name, pad_value).
+    # Unlike LazyWeight, mesh_mapper stores a pre-built mapper (e.g., ShardTensor2dMesh)
+    # rather than a MeshMapperConfig, because LazyBuffer has no caching/fingerprinting.
+    dtype: Optional[ttnn.DataType] = ttnn.int32
+    layout: Optional[ttnn.Layout] = ttnn.TILE_LAYOUT
+    device: Optional[ttnn.MeshDevice] = None
+    mesh_mapper: object = None  # Pre-built mapper (ShardTensor2dMesh, etc.) or None for replicate
+    memory_config: Optional[ttnn.MemoryConfig] = None
+
+    # Cached device tensor handle (allocated once, device data mutated in-place)
+    _value: Optional[ttnn.Tensor] = field(default=None, repr=False)
+
+    def _get_mesh_mapper(self):
+        """Get mesh mapper for from_torch(). Shared by get_device_buffer() and update()."""
+        if self.mesh_mapper is not None:
+            return self.mesh_mapper
+        return ttnn.replicate_tensor_to_mesh_mapper(self.device)
+
+    def _from_torch_args(self, *, device):
+        """
+        Build the full from_torch() kwargs. Used by both get_device_buffer() and update()
+        to ensure the same dtype/layout/mesh_mapper/memory_config are used consistently.
+        Only ``device`` differs: real device for allocation, None for host-side update.
+        """
+        return dict(
+            dtype=self.dtype,
+            layout=self.layout,
+            device=device,
+            mesh_mapper=self._get_mesh_mapper(),
+            memory_config=self.memory_config,
+        )
+
+    def get_device_buffer(self) -> ttnn.Tensor:
+        """Allocate on first call, return cached handle thereafter."""
+        if self._value is not None:
+            return self._value
+
+        if self.device is None:
+            raise ValueError("device must be set before materializing buffer")
+        if self.layout is None:
+            raise ValueError("layout must be set before materializing buffer")
+
+        self._value = ttnn.from_torch(
+            self.source,
+            **self._from_torch_args(device=self.device),
+        )
+        return self._value
+
+    def update(self, new_source: "torch.Tensor") -> None:
+        """
+        Overwrite the device buffer contents with a new source tensor, without reallocating.
+
+        If the buffer has not yet been materialized (get_device_buffer not called), this
+        simply replaces self.source for future materialization.
+
+        If the buffer IS already materialized, this performs an in-place device update
+        using the SAME from_torch() args as the original allocation (dtype, layout,
+        mesh_mapper, memory_config) but with device=None to create a host tensor::
+
+            host_tt = ttnn.from_torch(new_source, **same_args, device=None)
+            ttnn.copy_host_to_device_tensor(host_tt, self._value)
+
+        The ttnn.Tensor handle (self._value) is preserved — no DRAM reallocation.
+
+        This encapsulates the pattern seen in:
+        - TTPenalties._copy_host_to_device (tt_penalties.py:157-159)
+        - SeedManager.get_new_values (generator.py:382-383)
+        """
+        self.source = new_source
+        if self._value is not None:
+            host_tt = ttnn.from_torch(
+                new_source,
+                **self._from_torch_args(device=None),
+            )
+            ttnn.copy_host_to_device_tensor(host_tt, self._value)
+
+    def is_resolved(self) -> bool:
+        """Check if all required fields for materialization are set."""
+        return self.device is not None and self.dtype is not None and self.layout is not None
+
+
+def resolve_lazy_buffer(buf: LazyBuffer, **kwargs) -> LazyBuffer:
+    """Resolve None fields of ``buf`` with the given kwargs; do not override non-None fields."""
+    to_set = {k: v for k, v in kwargs.items() if getattr(buf, k, None) is None}
+    return replace(buf, **to_set)

--- a/models/experimental/llama32_1b_quasar/modules/lazy_weight.py
+++ b/models/experimental/llama32_1b_quasar/modules/lazy_weight.py
@@ -1,0 +1,354 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+LazyWeight: Lazy weight loading with explicit TTNN conversion parameters.
+
+This module has NO torch dependency - it accepts any tensor-like object that
+ttnn.from_torch() can handle (duck typing with string type hints).
+
+Design principles:
+- Explicit parameters over hidden closures (IDE-friendly)
+- Duck typing for source tensors (no torch import)
+- Deterministic cache fingerprinting from configuration
+- Lazy conversion: defer ttnn.from_torch until first access
+- Cache-first: skip torch entirely if TTNN cache exists
+"""
+
+import hashlib
+import pathlib
+from dataclasses import dataclass, field, replace
+from pathlib import Path
+from typing import Optional
+
+from loguru import logger
+
+import ttnn
+from models.experimental.llama32_1b_quasar.tensor_utils import (
+    get_padded_hidden_dim,
+    pad_to_shape,
+    parse_shard_dims_from_mesh_mapper_config,
+)
+
+
+# todo)) maybe useful to support a mechanism that can be used to disable the cache for every LazyWeight instance
+# todo)) needs unit tests to provide coverage
+@dataclass
+class LazyWeight:
+    """
+    Lazy weight loading with explicit TTNN conversion parameters.
+
+    The source can be:
+    - A tensor directly (duck-typed, typically torch.Tensor)
+
+    All fields except source are optional at construction time and can be
+    provided later. get_weight() will check
+
+    Example usage:
+        # Fully specified at construction
+        weight = LazyWeight(
+            source=torch_tensor,
+            device=mesh_device,
+            dtype=ttnn.bfloat16,
+        )
+        ttnn_tensor = weight.get_weight()
+
+        # Minimal construction, provide defaults at materialize time
+        weight = LazyWeight(source=torch_tensor)
+        ttnn_tensor = weight.get_weight(device=mesh_device, dtype=ttnn.bfloat16)
+
+        # Partial specification - override defaults selectively
+        weight = LazyWeight(source=torch_tensor, dtype=ttnn.bfloat4_b)
+        ttnn_tensor = weight.get_weight(device=mesh_device, dtype=ttnn.bfloat16)  # uses bfloat4_b
+
+        # Using convenience class methods
+        weight = LazyWeight.sharded_1d(source=tensor, device=mesh_device, dtype=ttnn.bfloat16, dim=3)
+        weight = LazyWeight.replicated(source=tensor, device=mesh_device, dtype=ttnn.bfloat16)
+
+    """
+
+    # Source: duck-typed tensor
+    # String annotation documents intent without importing torch
+    # todo)) use something like LazyStateDict for the source
+    source: "torch.Tensor"
+
+    # All other fields are optional at construction time.
+    cache_dir_weight_name: Optional[tuple[Path, str]] = None  # do not cache if None
+    pad_value: Optional[float] = 0.0
+    dtype: Optional[ttnn.DataType] = ttnn.bfloat16
+    # Lazy fields that can be materialize at get_weight time;
+    # Still named as public fields to allow users to override at construction time (be proactive if you want).
+    device: Optional[ttnn.MeshDevice] = None
+    mesh_mapper_config: Optional[ttnn.MeshMapperConfig] = None
+    memory_config: Optional[ttnn.MemoryConfig] = None
+    layout: Optional[ttnn.Layout] = None
+
+    # Private fields
+    _value: Optional[ttnn.Tensor] = field(default=None, repr=False)
+
+    def __post_init__(self):
+        assert self.source.shape is not None and len(self.source.shape) > 0, "source must have a shape"
+
+    def get_device_weight(self) -> ttnn.Tensor:
+        """
+        Get the TTNN tensor, converting from source if needed.
+
+        On first call:
+        1. Check cache → load if exists
+        2. Otherwise: resolve source → convert → cache
+
+        Subsequent calls return the cached tensor (defaults ignored after first call).
+        """
+        # todo)) is there a better way to enforce immutability of all fields after construction? and self._value after first call?
+        if self._value is not None:
+            return self._value
+
+        cache_dir, weight_name = None, None
+        if self.cache_dir_weight_name is not None:
+            cache_dir, weight_name = self.cache_dir_weight_name
+
+        # Validate required fields
+        if self.device is None:
+            raise ValueError("device must be provided (either on LazyWeight or in defaults)")
+        if self.layout is None:
+            raise ValueError("layout must be provided (either on LazyWeight or in defaults)")
+        if self.memory_config is None:
+            raise ValueError("memory_config must be provided (either on LazyWeight or in defaults)")
+
+        # Try loading from cache first (skip torch entirely if possible)
+        cache_file_name = self._get_cache_fill_path(
+            cache_dir=cache_dir,
+            weight_name=weight_name,
+        )
+        if cache_file_name and cache_file_name.exists():
+            logger.info(f"\033[32m[cache hit]\033[0m Loading tensor from cache: {cache_file_name}")
+            self._value = ttnn.load_tensor(str(cache_file_name), device=self.device)
+            return self._value
+
+        # Resolve source
+        tensor = self.source
+
+        # Get mesh mapper (created from config)
+        if self.mesh_mapper_config is not None:
+            mesh_mapper = ttnn.create_mesh_mapper(self.device, self.mesh_mapper_config)
+            # Auto-pad tensor for tile alignment (only needed for TILE_LAYOUT sharding)
+            if self.layout == ttnn.TILE_LAYOUT:
+                tensor = _auto_pad_for_sharded_tiles(tensor, self.padded_shape, pad_value=self.pad_value)
+        else:
+            # None config means replicate
+            mesh_mapper = ttnn.replicate_tensor_to_mesh_mapper(self.device)
+        is_replicated = self.mesh_mapper_config is None
+
+        # Convert to TTNN and cache
+        self._value = _from_torch_and_dump(
+            tensor=tensor,
+            device=self.device,
+            dtype=self.dtype,
+            layout=self.layout,
+            memory_config=self.memory_config,
+            mesh_mapper=mesh_mapper,
+            is_replicated=is_replicated,
+            pad_value=self.pad_value,
+            cache_file_name=cache_file_name,
+        )
+
+        return self._value
+
+    # todo)) refactor into a base class for Lazy and Transparent Pattern (LaTr)
+    def is_resolved(self) -> bool:
+        """Check if all required fields for weight materialization are set.
+
+        Excludes: _value (private), cache_dir_weight_name (optional caching)
+        """
+        required_fields = ("source", "pad_value", "dtype", "device", "mesh_mapper_config", "memory_config", "layout")
+        return all(getattr(self, field) is not None for field in required_fields)
+
+    def _get_cache_fill_path(
+        self,
+        cache_dir: Optional[Path],
+        weight_name: Optional[str],
+    ) -> Optional[Path]:
+        """Generate the cache file path based on configuration fingerprint."""
+        if cache_dir is None or weight_name is None:
+            return None
+        fingerprint = self._get_fingerprint()
+        return cache_dir / f"{weight_name}_{fingerprint}.tensorbin"
+
+    def _get_fingerprint(
+        self,
+    ) -> str:
+        """
+        Generate a unique fingerprint from the conversion configuration.
+
+        This ensures cache invalidation when config changes.
+        """
+        parts = []
+
+        # source
+        # todo)) add better fingerprinting for the source tensor to enable cache invalidation when the source tensor changes; for now, use shape.
+        #        maybe a sampled hash (on, say, first N bytes) would be a good solution --> needs testing! --> test_rope_1d.py is a good test case with differring rope_theta values
+        parts.append(f"srcshape_{'_'.join(str(dim) for dim in self.source.shape)}")
+
+        # dtype
+        parts.append(f"dtype_{self.dtype.name}")
+
+        # layout
+        parts.append(f"layout_{self.layout.name}")
+
+        # memory_config (use hash if non-default)
+        if self.memory_config is not None and self.memory_config != ttnn.DRAM_MEMORY_CONFIG:
+            parts.append(f"memcfg_{hash(self.memory_config)}")
+
+        # mesh_mapper_config fingerprint
+        parts.append(self._get_mesh_mapper_fingerprint())
+
+        # device fingerprint
+        device_id = self.device.id() if hasattr(self.device, "id") else "single"
+        parts.append(f"device_{device_id}")
+
+        # pad_value (only if non-default)
+        if self.pad_value != 0.0:
+            parts.append(f"pad_{self.pad_value}")
+
+        return "_".join(parts)
+
+    def _get_mesh_mapper_fingerprint(self) -> str:
+        """
+        Generate a fingerprint for the mesh_mapper_config.
+
+        Uses the config's __repr__ for deterministic hashing since
+        MeshMapperConfig exposes a proper string representation via pybind.
+        """
+        if self.mesh_mapper_config is None:
+            return "replicated"
+
+        # Use repr of config for deterministic fingerprint
+        config_repr = repr(self.mesh_mapper_config)
+        # Hash to keep fingerprint short but unique
+        config_hash = hashlib.md5(config_repr.encode()).hexdigest()[:12]
+        return f"mapper_{config_hash}"
+
+    @property
+    def padded_shape(self) -> tuple[int, ...]:
+        """
+        Returns the shape after padding for tile alignment.
+        Requires device and mesh_mapper_config to be set.
+
+        Note: source.shape remains the canonical unpadded shape.
+
+        Tile-alignment padding is only applied for TILE_LAYOUT. ROW_MAJOR_LAYOUT
+        does not require tile-aligned shard sizes.
+        """
+        assert self.is_resolved(), "LazyWeight must be resolved to compute padded_shape"
+
+        if self.device is None:
+            raise ValueError("device must be set to compute padded_shape")
+
+        shape = list(self.source.shape)
+        if self.mesh_mapper_config is None:
+            return tuple(shape)  # replicated, no padding
+
+        num_devices = self.device.get_num_devices()
+        if num_devices == 1:
+            return tuple(shape)
+
+        # ROW_MAJOR_LAYOUT doesn't require tile-aligned shard sizes
+        if self.layout == ttnn.ROW_MAJOR_LAYOUT:
+            return tuple(shape)
+
+        shard_dims = parse_shard_dims_from_mesh_mapper_config(self.mesh_mapper_config)
+        for shard_dim in shard_dims:
+            if shard_dim < 0:
+                shard_dim = len(shape) + shard_dim
+            shape[shard_dim] = get_padded_hidden_dim(shape[shard_dim], num_devices)
+
+        return tuple(shape)
+
+
+def _auto_pad_for_sharded_tiles(
+    tensor: "torch.Tensor",
+    padded_shape: tuple[int, ...],
+    pad_value: float = 0.0,
+) -> "torch.Tensor":
+    """
+    Auto-pad tensor for tile-aligned sharding (TILE_LAYOUT only).
+
+    ttnn.from_torch requires physical shard shapes to be tile-aligned when using
+    TILE_LAYOUT. This function pads the global tensor to the pre-computed padded_shape.
+
+    Args:
+        tensor: Source torch tensor
+        padded_shape: Target shape after padding (from LazyWeight.padded_shape)
+        pad_value: Value to use for padding (default 0.0)
+
+    Returns:
+        Padded tensor if padding was needed, otherwise original tensor
+    """
+    if tensor.shape != padded_shape:
+        logger.debug(f"Auto-padding from {tuple(tensor.shape)} to {padded_shape} for tile alignment")
+        return pad_to_shape(tensor, padded_shape, pad_value=pad_value)
+    return tensor
+
+
+def _from_torch_and_dump(
+    tensor: "torch.Tensor",
+    device: Optional[ttnn.MeshDevice],
+    dtype: Optional[ttnn.DataType],
+    layout: Optional[ttnn.Layout],
+    memory_config: Optional[ttnn.MemoryConfig],
+    mesh_mapper: Optional[ttnn.CppTensorToMesh],
+    is_replicated: bool,
+    pad_value: float,
+    cache_file_name: Optional[str],
+):
+    """
+    Convert a torch tensor to TTNN format and optionally cache it.
+
+    Args:
+        tensor: Source torch tensor
+        device: Target MeshDevice
+        dtype: Target data type
+        layout: Target layout
+        memory_config: Target memory config
+        mesh_mapper: The mesh mapper to use for distribution
+        is_replicated: If True, cache the unsharded tensor for portability
+        cache_file_name: Path to cache file, or None to skip caching
+    """
+    local_mesh_mapper = None if is_replicated else mesh_mapper
+    if cache_file_name is None:
+        return ttnn.from_torch(
+            tensor,
+            dtype=dtype,
+            layout=layout,
+            mesh_mapper=local_mesh_mapper,
+            memory_config=memory_config,
+            device=device,
+            pad_value=pad_value,
+        )
+
+    tensor = ttnn.from_torch(
+        tensor,
+        dtype=dtype,
+        layout=layout,
+        mesh_mapper=local_mesh_mapper,
+        memory_config=memory_config,
+        # For fully replicated tensors, cache unsharded tensor so it can be loaded on any device.
+        device=None,
+        pad_value=pad_value,
+    )
+    assert tensor.storage_type() == ttnn.StorageType.HOST, "tensor should be on host"
+
+    assert cache_file_name is not None, "cache_file_name must be provided for caching"
+    logger.debug(f"\033[33m[cache miss]\033[0m Generating cache for {cache_file_name}")
+    pathlib.Path(cache_file_name).parent.mkdir(parents=True, exist_ok=True)
+    ttnn._ttnn.tensor.dump_tensor_flatbuffer(str(cache_file_name), tensor)
+
+    if device is not None:
+        tensor = tensor.to(device, memory_config)
+    return tensor
+
+
+def resolve_lazy_weight(weight: LazyWeight, **kwargs) -> LazyWeight:
+    """Resolve the None fields of `weight` with the given kwargs; do not override non-None fields"""
+    to_set = {k: v for k, v in kwargs.items() if getattr(weight, k, None) is None}
+    return replace(weight, **to_set)

--- a/models/experimental/llama32_1b_quasar/modules/lm_head/lm_head_1d.py
+++ b/models/experimental/llama32_1b_quasar/modules/lm_head/lm_head_1d.py
@@ -1,0 +1,408 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+TTTv2-style LM Head module for 1D-topology devices: N150 (1x1), N300 (1x2), T3K (1x8).
+
+Computes logits over the vocabulary by splitting the output projection into
+weight chunks that fit in L1, running linear ops per chunk, and concatenating.
+
+Each device holds the correct logits for its vocab shard (column-parallel linear,
+no partial sums). The caller handles all_gather for multi-device argmax.
+
+Execution path:
+  for each (weight, pc): linear(x, weight) → sharded_to_interleaved → append
+  → concat
+"""
+
+import math
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import List
+
+import ttnn
+from models.experimental.llama32_1b_quasar.lightweightmodule import LightweightModule
+from models.experimental.llama32_1b_quasar.modules.lazy_weight import LazyWeight, resolve_lazy_weight
+from models.experimental.llama32_1b_quasar.tensor_utils import TILE_SIZE
+
+# =============================================================================
+# Config dataclass
+# =============================================================================
+
+
+@dataclass
+class LMHead1DConfig:
+    """
+    Configuration for LMHead1D.
+
+    Simple usage (pre-split weights):
+        config = LMHead1DConfig(output_weights=[w1, w2, w3])
+
+    The program_configs and other fields are auto-computed from weights if None.
+    """
+
+    # Required: output projection weights (already split for L1 fit)
+    output_weights: List[LazyWeight]
+
+    # Optional: device
+    mesh_device: ttnn.MeshDevice | None = None
+
+    # Optional: derived from weights if None
+    dim: int | None = None
+
+    # Optional: batch/tile config
+    max_batch_size: int = 32
+
+    # Optional: power-user overrides
+    program_configs: List | None = None
+    compute_kernel_config: ttnn.WormholeComputeKernelConfig | None = None
+    lm_head_dtype: ttnn.DataType = ttnn.bfloat8_b
+    output_memcfg: ttnn.MemoryConfig | None = None
+
+    # Input memory config (None = DRAM interleaved for simple API, width-sharded for from_model_args)
+    input_memcfg: ttnn.MemoryConfig | None = None
+
+    # Weight memory configs (None = auto-compute)
+    weights_memcfgs: List[ttnn.MemoryConfig] | None = None
+
+    def is_resolved(self) -> bool:
+        return all(getattr(self, f) is not None for f in self.__dataclass_fields__)
+
+
+# =============================================================================
+# LMHead1D
+# =============================================================================
+
+
+class LMHead1D(LightweightModule):
+    """
+    LM Head for non-TG (1D) devices.
+
+    Splits vocabulary projection into L1-sized chunks, runs linear per chunk,
+    and concatenates. Each device holds correct logits for its vocab shard;
+    caller handles all_gather for multi-device argmax.
+
+    Simple API:
+        lm_head = LMHead1D(output_weights=[w1, w2])
+
+    Power API:
+        config = LMHead1DConfig(output_weights=[w1, w2], lm_head_dtype=ttnn.bfloat16)
+        lm_head = LMHead1D.from_config(config)
+
+    Execution path:
+      for each (w, pc): linear(x, w) → sharded_to_interleaved → concat
+    """
+
+    def __init__(self, output_weights: List[LazyWeight]):
+        super().__init__()
+        self.config = _resolve_lm_head_1d_config(LMHead1DConfig(output_weights=output_weights))
+        self._device_weights_loaded = False
+
+    @classmethod
+    def from_config(cls, config: LMHead1DConfig):
+        instance = object.__new__(cls)
+        super(LMHead1D, instance).__init__()
+        instance.config = _resolve_lm_head_1d_config(config)
+        instance._device_weights_loaded = False
+        return instance
+
+    def load_device_weights(self):
+        if self._device_weights_loaded:
+            return
+        self.output_weights = [w.get_device_weight() for w in self.config.output_weights]
+        self._device_weights_loaded = True
+
+    def forward(self, x: ttnn.Tensor | LazyWeight) -> ttnn.Tensor:
+        """
+        Compute logits over vocabulary.
+
+        Args:
+            x: Input hidden states, shape [1, 1, batch_rows, dim].
+
+        Returns:
+            Logits tensor, shape [1, 1, batch_rows, padded_vocab / num_devices] per device.
+        """
+        self.load_device_weights()
+        x = _load_input_device_tensor(x, self.config)
+        cfg = self.config
+
+        outputs = []
+        for weight, pc in zip(self.output_weights, cfg.program_configs):
+            if pc is not None:
+                # DRAM-sharded path (from_model_args): width-sharded output → interleaved
+                output = ttnn.linear(
+                    x,
+                    weight,
+                    compute_kernel_config=cfg.compute_kernel_config,
+                    program_config=pc,
+                    memory_config=ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG,
+                    dtype=cfg.lm_head_dtype,
+                )
+                outputs.append(ttnn.sharded_to_interleaved(output, memory_config=cfg.output_memcfg))
+            else:
+                # Auto path (simple API): interleaved output directly
+                output = ttnn.linear(
+                    x,
+                    weight,
+                    compute_kernel_config=cfg.compute_kernel_config,
+                    memory_config=cfg.output_memcfg,
+                    dtype=cfg.lm_head_dtype,
+                )
+                outputs.append(output)
+
+        # Concatenate splits
+        output = ttnn.concat(outputs, dim=-1, memory_config=cfg.output_memcfg)
+
+        return output
+
+    # [INFO] this is the entry point for TTTv1 model_config.py and will retire with TTTv1
+    @classmethod
+    def from_model_args(
+        cls,
+        mesh_device,
+        args,
+        state_dict,
+        state_dict_prefix,
+        weight_cache_path,
+        max_columns_per_device,
+        dtype=None,
+        model_config=None,
+        tt_ccl=None,
+    ):
+        """Factory method for backward compatibility with ModelArgs.
+
+        Note: tt_ccl is accepted for signature compatibility with TTTv1 LMHead
+        but is not used -- 1D LMHead does not need CCL (column-parallel, no partial sums).
+        """
+        if args.is_galaxy:
+            raise ValueError("LMHead1D cannot be used for Galaxy devices.")
+
+        import torch
+
+        vocab_size = args.vocab_size
+        num_devices = mesh_device.get_num_devices()
+        dim = args.dim
+        padded_vocab_size = math.ceil(vocab_size / 32) * 32
+        size_per_device = padded_vocab_size // num_devices
+        num_splits = math.ceil(size_per_device / max_columns_per_device)
+        split_sizes = [min(size_per_device, max_columns_per_device)] * (num_splits - 1)
+        split_sizes.append(size_per_device - sum(split_sizes))
+
+        # Build output weights
+        torch_output_weights = state_dict[f"{state_dict_prefix}output.weight"].permute(1, 0)
+        if vocab_size < padded_vocab_size:
+            padding_size = padded_vocab_size - vocab_size
+            torch_output_weights = torch.cat(
+                [
+                    torch_output_weights,
+                    torch.zeros(torch_output_weights.shape[0], padding_size, dtype=torch_output_weights.dtype),
+                ],
+                dim=-1,
+            )
+
+        # DRAM grid for weight memory configs
+        dram_size = mesh_device.dram_grid_size()
+        dram_grid = ttnn.CoreRangeSet(
+            {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(dram_size.x - 1, dram_size.y - 1))}
+        )
+
+        cache_dir = None if args.dummy_weights else Path(weight_cache_path) / "lm_head"
+
+        output_weights = []
+        weights_memcfgs = []
+        for i, split_size in enumerate(split_sizes):
+            device_splits = []
+            for device_idx in range(num_devices):
+                start = device_idx * size_per_device + sum(split_sizes[:i])
+                end = start + split_size
+                device_splits.append(torch_output_weights[:, start:end])
+            combined_split = torch.cat(device_splits, dim=-1)
+
+            mem_cfg = _create_dram_sharded_mem_config(
+                k=dim,
+                n=math.ceil(combined_split.shape[-1] / num_devices),
+                dram_grid=dram_grid,
+                tile_size=TILE_SIZE,
+                dram_cores=dram_size.x,
+            )
+            weights_memcfgs.append(mem_cfg)
+
+            w_dtype = dtype if dtype is not None else ttnn.bfloat8_b
+            output_weights.append(
+                LazyWeight(
+                    source=combined_split,
+                    dtype=w_dtype,
+                    device=mesh_device,
+                    mesh_mapper_config=ttnn.MeshMapperConfig(
+                        placements=[ttnn.PlacementShard(-1)],
+                        mesh_shape_override=ttnn.MeshShape([num_devices]),
+                    ),
+                    layout=ttnn.TILE_LAYOUT,
+                    memory_config=mem_cfg,
+                    cache_dir_weight_name=(cache_dir, f"output_split_{i}_{combined_split.shape[-1]}")
+                    if cache_dir
+                    else None,
+                )
+            )
+
+        # Program configs - use the args.lm_head_core_grid which TTTv1 carefully computes
+        tile_padded_batch_rows = TILE_SIZE * math.ceil(args.max_batch_size / TILE_SIZE)
+        lm_head_core_grid = args.lm_head_core_grid
+        program_configs = [
+            args.dram_matmul_config(
+                tile_padded_batch_rows,
+                dim,
+                ss,
+                lm_head_core_grid.num_cores,
+            )
+            for ss in split_sizes
+        ]
+
+        # Get input memory config: width-sharded across lm_head_core_grid
+        # (DRAM-sharded matmul requires width-sharded input in L1)
+        input_memcfg = ttnn.create_sharded_memory_config(
+            (
+                tile_padded_batch_rows,
+                _nearest_32(dim // lm_head_core_grid.num_cores),
+            ),
+            lm_head_core_grid,
+            ttnn.ShardStrategy.WIDTH,
+            ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+
+        config = LMHead1DConfig(
+            output_weights=output_weights,
+            mesh_device=mesh_device,
+            dim=dim,
+            max_batch_size=args.max_batch_size,
+            program_configs=program_configs,
+            compute_kernel_config=_compute_kernel_config_hifi2(),
+            lm_head_dtype=getattr(args, "lm_head_dtype", ttnn.bfloat8_b),
+            output_memcfg=ttnn.L1_MEMORY_CONFIG,
+            input_memcfg=input_memcfg,
+            weights_memcfgs=weights_memcfgs,
+        )
+        return cls.from_config(config)
+
+
+# =============================================================================
+# Config resolution
+# =============================================================================
+
+
+def _resolve_lm_head_1d_config(config: LMHead1DConfig) -> LMHead1DConfig:
+    """Resolve defaults for LMHead1DConfig."""
+    to_set = {}
+
+    # Mesh device
+    mesh_device = config.mesh_device
+    if mesh_device is None:
+        mesh_device = config.output_weights[0].device
+    if mesh_device is None:
+        mesh_device = ttnn.GetDefaultDevice()
+    if config.mesh_device is None:
+        to_set["mesh_device"] = mesh_device
+
+    assert mesh_device is not None
+
+    # Dim
+    dim = config.dim
+    if dim is None:
+        dim = config.output_weights[0].source.shape[-2]
+        to_set["dim"] = dim
+
+    # Compute kernel config
+    if config.compute_kernel_config is None:
+        to_set["compute_kernel_config"] = _compute_kernel_config_hifi2()
+
+    # Output memcfg
+    if config.output_memcfg is None:
+        to_set["output_memcfg"] = ttnn.L1_MEMORY_CONFIG
+
+    # Input memcfg
+    if config.input_memcfg is None:
+        to_set["input_memcfg"] = ttnn.DRAM_MEMORY_CONFIG
+
+    # Program configs
+    num_devices = mesh_device.get_num_devices()
+
+    if config.program_configs is None:
+        # Use None program configs for auto-resolve (let ttnn.linear auto-select).
+        # DRAM-sharded program configs require matching DRAM-sharded weight memory configs,
+        # which are only set up correctly via from_model_args.
+        pcs = [None for _ in config.output_weights]
+        to_set["program_configs"] = pcs
+
+    # Weight memory configs + resolve LazyWeights
+    if config.weights_memcfgs is None:
+        # Use regular DRAM for auto-resolve (DRAM sharded requires DRAM-core-aligned padding
+        # which is handled by from_model_args when it explicitly provides weights_memcfgs)
+        memcfgs = [ttnn.DRAM_MEMORY_CONFIG for _ in config.output_weights]
+        to_set["weights_memcfgs"] = memcfgs
+
+    weights_memcfgs = (
+        config.weights_memcfgs if config.weights_memcfgs is not None else to_set.get("weights_memcfgs", [])
+    )
+
+    resolved_weights = []
+    for i, w in enumerate(config.output_weights):
+        mem_cfg = weights_memcfgs[i] if i < len(weights_memcfgs) else ttnn.DRAM_MEMORY_CONFIG
+        resolved_weights.append(
+            resolve_lazy_weight(
+                w,
+                device=mesh_device,
+                memory_config=mem_cfg,
+                mesh_mapper_config=ttnn.MeshMapperConfig(
+                    placements=[ttnn.PlacementShard(-1)],
+                    mesh_shape_override=ttnn.MeshShape([num_devices]),
+                ),
+                layout=ttnn.TILE_LAYOUT,
+                dtype=config.lm_head_dtype,
+            )
+        )
+    to_set["output_weights"] = resolved_weights
+
+    resolved = replace(config, **to_set)
+    return resolved
+
+
+def _load_input_device_tensor(x: ttnn.Tensor | LazyWeight, config: LMHead1DConfig) -> ttnn.Tensor:
+    """Resolve input tensor using config's input_memcfg."""
+    if isinstance(x, LazyWeight):
+        resolved_x = resolve_lazy_weight(
+            x,
+            device=config.mesh_device,
+            memory_config=config.input_memcfg,
+            mesh_mapper_config=None,
+            layout=ttnn.TILE_LAYOUT,
+        )
+        return resolved_x.get_device_weight()
+    assert isinstance(x, ttnn.Tensor)
+    return x
+
+
+# =============================================================================
+# Config helper functions (adapted from TTTv1 model_config.py)
+# =============================================================================
+
+
+def _nearest_32(x: int) -> int:
+    return math.ceil(x / 32) * 32
+
+
+def _compute_kernel_config_hifi2() -> ttnn.WormholeComputeKernelConfig:
+    return ttnn.WormholeComputeKernelConfig(
+        math_fidelity=ttnn.MathFidelity.HiFi2,
+        math_approx_mode=False,
+        fp32_dest_acc_en=False,
+        packer_l1_acc=True,
+    )
+
+
+def _create_dram_sharded_mem_config(
+    k: int, n: int, dram_grid: ttnn.CoreRangeSet, tile_size: int = TILE_SIZE, dram_cores: int = 12
+) -> ttnn.MemoryConfig:
+    padded_size = math.ceil(n / (tile_size * dram_cores)) * (tile_size * dram_cores)
+    shard_spec = ttnn.ShardSpec(dram_grid, (k, padded_size // dram_cores), ttnn.ShardOrientation.ROW_MAJOR)
+    return ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.DRAM, shard_spec)

--- a/models/experimental/llama32_1b_quasar/modules/mlp/mlp_1d.py
+++ b/models/experimental/llama32_1b_quasar/modules/mlp/mlp_1d.py
@@ -1,0 +1,1093 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+TTTv2-style MLP module for 1D-topology devices: N150 (1x1), N300 (1x2), T3K (1x8).
+
+Single unified MLP1D class with separate forward methods:
+  - decode_forward(): For decode mode
+  - prefill_forward(): For prefill mode
+  - forward(x, mode): Dispatcher that calls the appropriate method
+
+Execution paths:
+  Decode:  linear(w1) → linear(w3) → mul+silu → reshard → linear(w2) → all_reduce(sharded) → reshard
+  Prefill: [reshape] → linear(w1) → linear(w3) → mul+silu → linear(w2) → all_reduce → reshape
+
+"""
+
+import math
+from dataclasses import dataclass, replace
+from functools import lru_cache
+from pathlib import Path
+from typing import Callable, Optional
+
+import ttnn
+from models.experimental.llama32_1b_quasar.lightweightmodule import LightweightModule
+from models.experimental.llama32_1b_quasar.modules.lazy_weight import LazyWeight, resolve_lazy_weight
+from models.experimental.llama32_1b_quasar.modules.tt_ccl import (
+    CCL_CHUNKS_PER_SYNC,
+    CCL_NUM_BUFFERS_PER_CHANNEL,
+    CCL_NUM_WORKERS_PER_LINK,
+    TT_CCL,
+    default_topology,
+    get_tt_ccl,
+)
+from models.experimental.llama32_1b_quasar.tensor_utils import TILE_SIZE, get_padded_hidden_dim, pad_dim_to_size
+from models.experimental.llama32_1b_quasar.utility_functions import is_blackhole
+from models.tt_transformers.tt.common import Mode
+
+# =============================================================================
+# Top-level config dataclass
+# =============================================================================
+
+
+@dataclass
+class MLP1DConfig:
+    """
+    Central configuration for MLP1D - the single source of truth for all settings.
+
+    Simple usage (all defaults):
+        config = MLP1DConfig(w1, w2, w3)
+
+    Override any field:
+        config = MLP1DConfig(w1, w2, w3, max_batch_size=64, topology=ttnn.Topology.Ring)
+
+    Full customization:
+        config = MLP1DConfig(
+            w1, w2, w3,
+            mesh_device=custom_device,
+            decode_w1_w3_prg_config=my_program_config,
+            ...
+        )
+    """
+
+    # Required: weights (LazyWeight)
+    w1: LazyWeight
+    w2: LazyWeight
+    w3: LazyWeight
+
+    # Optional: device and collectives
+    mesh_device: ttnn.MeshDevice | None = None
+    tt_ccl: TT_CCL | None = None
+    topology: Optional[ttnn.Topology] = None  # None = auto-detect
+    num_reduce_scatter_links: int = 1
+
+    # Optional: derived from weights if None
+    dim: int | None = None
+    hidden_dim: int | None = None
+
+    # Optional: sensible defaults
+    max_batch_size: int = 32
+    mlp_activation_type: ttnn.UnaryOpType = ttnn.UnaryOpType.SILU
+
+    # Optional: power-user overrides (None = compute defaults)
+    w1_w3_memcfg: ttnn.MemoryConfig | None = None
+    w2_memcfg: ttnn.MemoryConfig | None = None
+
+    decode_input_memcfg: ttnn.MemoryConfig | None = None
+    decode_w1_w3_prg_config: ttnn.MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig | None = None
+    decode_w2_prg_config: ttnn.MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig | None = None
+    decode_mlp2_input_memcfg: ttnn.MemoryConfig | None = None
+    decode_residual_memcfg: ttnn.MemoryConfig | None = None
+
+    prefill_input_memcfg: ttnn.MemoryConfig | None = None
+    prefill_w1_w3_prg_config: Callable[[int], ttnn.MatmulMultiCoreReuseMultiCastProgramConfig] | None = None
+    prefill_w2_prg_config: Callable[[int], ttnn.MatmulMultiCoreReuseMultiCastProgramConfig] | None = None
+
+    # Optional: use ttnn.experimental.minimal_matmul (instead of ttnn.linear) for the W2 down-proj
+    # prefill matmul above seq_len > 128 — matches TTTv1 (mlp.py L275-281), ~2.5x faster on the large
+    # folded-batch down-proj. Default OFF so untouched models / decode stay byte-identical; the caller
+    # opts in. FF1/FF3 stay on ttnn.linear (TTTv1 does too). The factory yields a ttnn.MinimalMatmulConfig
+    # keyed on the folded seq_len (sibling to prefill_w2_prg_config).
+    prefill_w2_minimal_matmul: bool = False
+    prefill_w2_minimal_matmul_config: Callable[[int], "ttnn.MinimalMatmulConfig"] | None = None
+
+    w1_w3_dtype: ttnn.DataType | None = None
+    w2_dtype: ttnn.DataType | None = None
+    activation_dtype: ttnn.DataType | None = None
+    ff1_3_compute_kernel_cfg: ttnn.WormholeComputeKernelConfig | None = None
+    ff2_compute_kernel_cfg: ttnn.WormholeComputeKernelConfig | None = None
+    # Optional decode-only overrides (DRAM-sharded decode matmuls). When None, match ff1_3 / ff2.
+    decode_ff1_3_compute_kernel_cfg: ttnn.WormholeComputeKernelConfig | None = None
+    decode_ff2_compute_kernel_cfg: ttnn.WormholeComputeKernelConfig | None = None
+    # If True, move W1 decode output to DRAM before W3 linear so W3 CB validation does not overlap W1 L1.
+    decode_spill_w1_to_dram_before_w3: bool = False
+
+    linear_dtype: ttnn.DataType | None = None
+    mul_dtype: ttnn.DataType | None = None
+    prefill_len_cutoff: int | None = None
+
+    def use_minimal_w2_matmul(self, seq_len: int) -> bool:
+        """Whether the W2 down-proj prefill matmul should use minimal_matmul.
+
+        Mirrors TTTv1 (mlp.py:275) — minimal_matmul only above ``seq_len > 128`` and only when the
+        per-model opt-in is set. ``seq_len`` is the folded ``B*S`` length.
+        """
+        return bool(self.prefill_w2_minimal_matmul) and seq_len > 128
+
+    def is_resolved(self) -> bool:
+        """Check if all fields except optional ones are resolved."""
+        # activation_dtype is optional override for linear_dtype and mul_dtype.
+        # prefill_w2_minimal_matmul_config is only materialized when the minimal-matmul opt-in is set.
+        optional = {"activation_dtype", "prefill_w2_minimal_matmul_config"}
+        # topology: None for single_device (CCL not needed)
+        if self.mesh_device and self.mesh_device.get_num_devices() == 1:
+            optional.add("topology")
+
+        return all(getattr(self, f) is not None for f in self.__dataclass_fields__ if f not in optional)
+
+
+# =============================================================================
+# MLP1D - Unified MLP for 1D-topology devices (Linear or Ring) with decode and prefill modes
+# =============================================================================
+
+
+class MLP1D(LightweightModule):
+    """
+    MLP for non-TG devices supporting both decode and prefill modes.
+
+    Simple API (90% of users):
+        mlp = MLP1D(w1, w2, w3)
+
+    Power API (10% of users) - any level of customization via config:
+        config = MLP1DConfig(w1, w2, w3, max_batch_size=64, topology=ttnn.Topology.Ring)
+        mlp = MLP1D.from_config(config)
+
+    Execution paths:
+      Decode:  linear(w1) → linear(w3) → mul+silu → reshard → linear(w2) → all_reduce(sharded) → reshard
+      Prefill: [reshape] → linear(w1) → linear(w3) → mul+silu → linear(w2) → all_reduce → reshape
+    """
+
+    def __init__(self, w1: LazyWeight, w2: LazyWeight, w3: LazyWeight):
+        """
+        Simple API for 90% of users - derives all config from weights.
+
+        Args:
+            w1: Gate projection weight (dim, hidden_dim), sharded on dim=-1
+            w2: Down projection weight (hidden_dim, dim), sharded on dim=-2
+            w3: Up projection weight (dim, hidden_dim), sharded on dim=-1
+
+        The mesh_device is derived from w1.device(). tt_ccl is created/cached automatically.
+        All other settings use sensible defaults.
+        """
+        super().__init__()
+        self.config = _resolve_mlp1d_config(MLP1DConfig(w1=w1, w2=w2, w3=w3))
+        self._device_weights_loaded = False
+
+    @classmethod
+    def from_config(cls, config: MLP1DConfig):
+        """
+        Power API for 10% of users - any level of customization via config.
+
+        Override any subset of fields in MLP1DConfig:
+            config = MLP1DConfig(w1, w2, w3, max_batch_size=64)
+            mlp = MLP1D.from_config(config)
+
+        Full customization:
+            config = MLP1DConfig(
+                w1, w2, w3,
+                mesh_device=custom_device,
+                decode_w1_w3_prg_config=my_program_config,
+                ...
+            )
+            mlp = MLP1D.from_config(config)
+        """
+        # bypass the __init__ method of the base class for power users who want to customize the config
+        instance = object.__new__(cls)
+        super(MLP1D, instance).__init__()  # Call LightweightModule.__init__()
+        instance.config = _resolve_mlp1d_config(config)  # make a resolved copy of `config`
+        instance._device_weights_loaded = False
+        return instance
+
+    def load_device_weights(self):
+        """Materialize LazyWeights onto device. Called automatically on first forward; idempotent."""
+        if self._device_weights_loaded:
+            return
+
+        assert self.config.is_resolved(), "config must be resolved before loading device weights!"
+
+        self.w1 = self.config.w1.get_device_weight()
+        self.w2 = self.config.w2.get_device_weight()
+        self.w3 = self.config.w3.get_device_weight()
+
+        self._device_weights_loaded = True
+
+    def decode_forward(self, x: ttnn.Tensor | LazyWeight) -> ttnn.Tensor:
+        """
+        Decode forward - NO if-else, fully flattened.
+
+        Execution path:
+          linear(w1) → linear(w3) → mul+silu → reshard → linear(w2) → all_reduce(sharded) → reshard
+        """
+        self.load_device_weights()
+        x = _load_input_device_tensor(x, self.config, mode="decode")
+        cfg = self.config
+
+        # --- STAGE 1: W1/W3 Linear (L1 sharded) ---
+        w1_out = ttnn.linear(
+            x,
+            self.w1,
+            dtype=cfg.linear_dtype,
+            core_grid=None,
+            compute_kernel_config=cfg.decode_ff1_3_compute_kernel_cfg,
+            program_config=cfg.decode_w1_w3_prg_config,
+            memory_config=ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG,
+        )
+        if cfg.decode_spill_w1_to_dram_before_w3:
+            w1_dram = ttnn.to_memory_config(w1_out, ttnn.DRAM_MEMORY_CONFIG)
+            ttnn.deallocate(w1_out)
+            w1_out = w1_dram
+
+        w3_out = ttnn.linear(
+            x,
+            self.w3,
+            dtype=cfg.linear_dtype,
+            core_grid=None,
+            compute_kernel_config=cfg.decode_ff1_3_compute_kernel_cfg,
+            program_config=cfg.decode_w1_w3_prg_config,
+            memory_config=ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG,
+        )
+        ttnn.deallocate(x)
+
+        # --- STAGE 2: No CCL for non-TG ---
+
+        # --- STAGE 3: Activation + Multiply ---
+        mul_out_memcfg = ttnn.DRAM_MEMORY_CONFIG if cfg.decode_spill_w1_to_dram_before_w3 else w1_out.memory_config()
+        w2_in = ttnn.mul(
+            w1_out,
+            w3_out,
+            input_tensor_a_activations=[cfg.mlp_activation_type],
+            dtype=cfg.mul_dtype,
+            memory_config=mul_out_memcfg,
+        )
+
+        # --- STAGE 3.5: Reshard for w2 ---
+        w2_in = ttnn.to_memory_config(w2_in, cfg.decode_mlp2_input_memcfg)
+
+        ttnn.deallocate(w3_out)
+        ttnn.deallocate(w1_out)
+
+        # --- STAGE 4: No all_gather for non-TG ---
+
+        # --- STAGE 5: W2 Linear ---
+        w2_out = ttnn.linear(
+            w2_in,
+            self.w2,
+            compute_kernel_config=cfg.decode_ff2_compute_kernel_cfg,
+            dtype=cfg.linear_dtype,
+            program_config=cfg.decode_w2_prg_config,
+            memory_config=ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG,
+            core_grid=None,
+        )
+        ttnn.deallocate(w2_in)
+
+        # --- STAGE 6: Final All-Reduce (decode: sharded=True, no runtime branching) ---
+        w2_out_reduced = self._all_reduce_decode(w2_out)
+
+        # --- STAGE 7: Reshape + Final memory config ---
+        original_shape = w2_out_reduced.shape
+        w2_out_reduced = ttnn.reshape(
+            w2_out_reduced, (1, 1, original_shape[-4] * original_shape[-3] * original_shape[-2], original_shape[-1])
+        )
+        w2_out_reduced = ttnn.to_memory_config(w2_out_reduced, cfg.decode_residual_memcfg)
+
+        return w2_out_reduced
+
+    def prefill_forward(self, x: ttnn.Tensor | LazyWeight) -> ttnn.Tensor:
+        """
+        Prefill forward - minimal runtime logic for seq_len-dependent configs.
+
+        Execution path:
+          [reshape if seq_len >= cutoff] → linear(w1) → linear(w3) → mul+silu → linear(w2) → all_reduce → reshape
+        """
+        self.load_device_weights()
+        x = _load_input_device_tensor(x, self.config, mode="prefill")
+
+        cfg = self.config
+        seq_len = x.shape[-2]
+
+        # Seq_len-dependent: reshape for long sequences
+        if seq_len >= cfg.prefill_len_cutoff:
+            assert (
+                seq_len % cfg.prefill_len_cutoff == 0
+            ), f"seq_len ({seq_len}) must be divisible by prefill_len_cutoff ({cfg.prefill_len_cutoff})"
+            x = ttnn.reshape(x, [1, seq_len // cfg.prefill_len_cutoff, cfg.prefill_len_cutoff, -1])
+
+        # Seq_len-dependent: get program configs by calling methods on config
+        pc_w1_w3 = cfg.prefill_w1_w3_prg_config(seq_len)
+        pc_w2 = cfg.prefill_w2_prg_config(seq_len)
+
+        # --- STAGE 1: W1/W3 Linear (DRAM) ---
+        w1_out = ttnn.linear(
+            x,
+            self.w1,
+            dtype=cfg.linear_dtype,
+            core_grid=None,
+            compute_kernel_config=cfg.ff1_3_compute_kernel_cfg,
+            program_config=pc_w1_w3,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+        w3_out = ttnn.linear(
+            x,
+            self.w3,
+            dtype=cfg.linear_dtype,
+            core_grid=None,
+            compute_kernel_config=cfg.ff1_3_compute_kernel_cfg,
+            program_config=pc_w1_w3,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+        ttnn.deallocate(x)
+
+        # --- STAGE 2: No CCL for non-TG ---
+
+        # --- STAGE 3: Activation + Multiply ---
+        w2_in = ttnn.mul(
+            w1_out,
+            w3_out,
+            input_tensor_a_activations=[cfg.mlp_activation_type],
+            dtype=cfg.mul_dtype,
+            memory_config=w1_out.memory_config(),
+        )
+
+        # --- STAGE 3.5: No reshard for prefill ---
+
+        ttnn.deallocate(w3_out)
+        ttnn.deallocate(w1_out)
+
+        # --- STAGE 4: No all_gather for non-TG ---
+
+        # --- STAGE 5: W2 Linear ---
+        # Above seq_len > 128 the folded-batch down-proj is large; minimal_matmul is ~2.5x faster than
+        # ttnn.linear there (TTTv1 parity). Opt-in via prefill_w2_minimal_matmul; output shape is
+        # identical to the ttnn.linear path. FF1/FF3 stay on ttnn.linear (matches TTTv1).
+        if cfg.use_minimal_w2_matmul(seq_len):
+            w2_out = ttnn.experimental.minimal_matmul(
+                w2_in,
+                self.w2,
+                compute_kernel_config=cfg.ff2_compute_kernel_cfg,
+                config=cfg.prefill_w2_minimal_matmul_config(seq_len),
+            )
+        else:
+            w2_out = ttnn.linear(
+                w2_in,
+                self.w2,
+                compute_kernel_config=cfg.ff2_compute_kernel_cfg,
+                dtype=cfg.linear_dtype,
+                program_config=pc_w2,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                core_grid=None,
+            )
+        ttnn.deallocate(w2_in)
+
+        # --- STAGE 6: Final All-Reduce (prefill: sharded=False) ---
+        w2_out_reduced = self._all_reduce_prefill(w2_out)
+
+        # --- STAGE 7: Reshape (no final memory config change for prefill) ---
+        original_shape = w2_out_reduced.shape
+        w2_out_reduced = ttnn.reshape(
+            w2_out_reduced, (1, 1, original_shape[-4] * original_shape[-3] * original_shape[-2], original_shape[-1])
+        )
+
+        return w2_out_reduced
+
+    def forward(self, x: ttnn.Tensor | LazyWeight, mode: str | Mode) -> ttnn.Tensor:
+        """Dispatch to the appropriate forward method based on mode."""
+        if isinstance(mode, Mode):
+            mode = mode.value
+        if mode == "decode":
+            return self.decode_forward(x)
+        else:
+            return self.prefill_forward(x)
+
+    def _all_reduce_decode(self, w2_out: ttnn.Tensor) -> ttnn.Tensor:
+        """All-reduce for decode mode (sharded input)."""
+        cfg = self.config
+        if cfg.mesh_device.get_num_devices() == 1:
+            return w2_out
+
+        original_shape = w2_out.shape
+        if original_shape[0] != 1 or original_shape[1] != 1:
+            w2_out = ttnn.reshape(
+                w2_out, (1, 1, original_shape[-4] * original_shape[-3] * original_shape[-2], original_shape[-1])
+            )
+
+        reduced = ttnn.experimental.reduce_scatter_minimal_async(
+            w2_out,
+            persistent_output_buffers=None,
+            dim=3,
+            multi_device_global_semaphore=cfg.tt_ccl.get_and_cycle_rs_semaphore_handles(),
+            barrier_semaphore=cfg.tt_ccl.get_and_cycle_barrier_semaphore_handle(),
+            num_links=cfg.num_reduce_scatter_links,
+            memory_config=w2_out.memory_config(),
+            intermediate_memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            topology=cfg.topology,
+            chunks_per_sync=CCL_CHUNKS_PER_SYNC,
+            num_workers_per_link=CCL_NUM_WORKERS_PER_LINK,
+            num_buffers_per_channel=CCL_NUM_BUFFERS_PER_CHANNEL,
+        )
+        w2_out.deallocate(True)
+        return reduced
+
+    def _all_reduce_prefill(self, w2_out: ttnn.Tensor) -> ttnn.Tensor:
+        """All-reduce for prefill mode (interleaved input)."""
+        cfg = self.config
+        if cfg.mesh_device.get_num_devices() == 1:
+            return w2_out
+
+        original_shape = w2_out.shape
+        if original_shape[0] != 1 or original_shape[1] != 1:
+            w2_out = ttnn.reshape(
+                w2_out, (1, 1, original_shape[-4] * original_shape[-3] * original_shape[-2], original_shape[-1])
+            )
+
+        if w2_out.is_sharded():
+            w2_out_sharded = w2_out
+            w2_out = ttnn.sharded_to_interleaved(w2_out_sharded, ttnn.L1_MEMORY_CONFIG)
+            w2_out_sharded.deallocate(True)
+
+        reduced = ttnn.experimental.reduce_scatter_minimal_async(
+            w2_out,
+            persistent_output_buffers=None,
+            dim=3,
+            multi_device_global_semaphore=cfg.tt_ccl.get_and_cycle_rs_semaphore_handles(),
+            barrier_semaphore=cfg.tt_ccl.get_and_cycle_barrier_semaphore_handle(),
+            num_links=cfg.num_reduce_scatter_links,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            intermediate_memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            topology=cfg.topology,
+            chunks_per_sync=CCL_CHUNKS_PER_SYNC,
+            num_workers_per_link=CCL_NUM_WORKERS_PER_LINK,
+            num_buffers_per_channel=CCL_NUM_BUFFERS_PER_CHANNEL,
+        )
+        w2_out.deallocate(True)
+        return reduced
+
+    # [INFO] this is the entry point for TTTv1 model_config.py and will retire with TTTv1
+    @classmethod
+    def from_model_args(
+        cls,
+        mesh_device,
+        tt_ccl,
+        args,
+        state_dict,
+        weight_cache_path,
+        layer_num: int,
+        dtype=None,
+        model_config=None,
+        state_dict_prefix: Optional[str] = None,
+        prefetcher=None,
+    ):
+        """Factory method for backward compatibility with ModelArgs.
+
+        Args:
+            mesh_device: The mesh device to use.
+            tt_ccl: The TT CCL instance.
+            args: Model arguments (ModelArgs instance).
+            state_dict: The state dictionary containing weights.
+            weight_cache_path: Path for weight caching.
+            layer_num: The layer number.
+            dtype: Optional data type for weights (for signature compatibility with TTTv1 MLP).
+            model_config: Optional model config dict. If None, calls args.get_model_config().
+            state_dict_prefix: Optional prefix for state dict keys.
+
+        Note:
+            The `dtype` parameter is accepted for signature compatibility with TTTv1 MLP
+            but is not used directly - dtype is determined by the DecodersPrecision config.
+        """
+        if args.is_galaxy:
+            raise ValueError("MLP1D cannot be used for Galaxy devices.")
+
+        import torch
+
+        from models.tt_transformers.tt.model_config import OpGroup, TensorGroup
+
+        # Get model_config for overrides - use passed model_config if provided
+        if model_config is None:
+            model_config = args.get_model_config()
+        decoders_opt = model_config.get("DECODERS_OPTIMIZATIONS")
+        effective_layer_num = max(layer_num, 0)
+
+        # Extract settings from args/model_config
+        ccl_topology = args.ccl_topology()
+
+        if state_dict_prefix is None:
+            state_dict_prefix = args.get_state_dict_prefix("MLP", layer_num)
+
+        # Get dtypes from optimizer config
+        ff1_3_dtype = decoders_opt.get_tensor_dtype(decoder_id=effective_layer_num, tensor=TensorGroup.FF1_FF3)
+        ff2_dtype = decoders_opt.get_tensor_dtype(decoder_id=effective_layer_num, tensor=TensorGroup.FF2)
+        activation_dtype = decoders_opt.get_tensor_dtype(decoder_id=effective_layer_num, tensor=TensorGroup.ACTIVATION)
+
+        # Get compute kernel configs
+        ff1_3_compute_kernel_cfg = decoders_opt.get_math_fidelity(
+            decoder_id=effective_layer_num, op=OpGroup.LI_FF1_FF3, configuration=args
+        )
+        ff2_compute_kernel_cfg = decoders_opt.get_math_fidelity(
+            decoder_id=effective_layer_num, op=OpGroup.LI_FF2, configuration=args
+        )
+
+        # Get decode program configs from model_config
+        decode_w1_w3_prg_config = args.get_mlp_ff1_3_prg_config(Mode.DECODE, None, None)
+        decode_w2_prg_config = args.get_mlp_ff2_prg_config(Mode.DECODE, None, None)
+        decode_mlp2_input_memcfg = args.get_mlp_binary_mult_mem_config(Mode.DECODE)
+        decode_residual_memcfg = args.get_mlp_output_mem_config(Mode.DECODE, None)
+
+        # Compute memory configs for weights
+        num_devices = mesh_device.get_num_devices()
+        tile_size = TILE_SIZE
+        dram_size = mesh_device.dram_grid_size()
+        dram_grid = ttnn.CoreRangeSet(
+            {
+                ttnn.CoreRange(
+                    ttnn.CoreCoord(0, 0),
+                    ttnn.CoreCoord(dram_size.x - 1, dram_size.y - 1),
+                )
+            }
+        )
+
+        w1_w3_mem_config = _create_dram_sharded_mem_config(
+            k=args.dim,
+            n=args.hidden_dim // num_devices,
+            dram_grid=dram_grid,
+            tile_size=tile_size,
+            dram_cores=dram_size.x,
+        )
+        w2_mem_config = _create_dram_sharded_mem_config(
+            k=args.hidden_dim // num_devices,
+            n=args.dim,
+            dram_grid=dram_grid,
+            tile_size=tile_size,
+            dram_cores=dram_size.x,
+        )
+
+        cache_dir = None if args.dummy_weights else Path(weight_cache_path) / state_dict_prefix
+
+        # Create LazyWeights
+        def make_weight_source(name: str, shard_dim: int):
+            tensor = torch.transpose(state_dict[f"{state_dict_prefix}.{name}.weight"], -2, -1)
+            return pad_dim_to_size(tensor, dim=shard_dim, size=args.hidden_dim)
+
+        w1 = LazyWeight(
+            source=make_weight_source("w1", -1),
+            dtype=ff1_3_dtype,
+            device=mesh_device,
+            mesh_mapper_config=ttnn.MeshMapperConfig(
+                placements=[ttnn.PlacementShard(-1)],
+                mesh_shape_override=ttnn.MeshShape([mesh_device.get_num_devices()]),
+            ),
+            layout=ttnn.TILE_LAYOUT,
+            memory_config=w1_w3_mem_config,
+            cache_dir_weight_name=(cache_dir, "w1_sharded") if cache_dir else None,
+        )
+        w2 = LazyWeight(
+            source=make_weight_source("w2", -2),
+            dtype=ff2_dtype,
+            device=mesh_device,
+            mesh_mapper_config=ttnn.MeshMapperConfig(
+                placements=[ttnn.PlacementShard(-2)],
+                mesh_shape_override=ttnn.MeshShape([mesh_device.get_num_devices()]),
+            ),
+            layout=ttnn.TILE_LAYOUT,
+            memory_config=w2_mem_config,
+            cache_dir_weight_name=(cache_dir, "w2_sharded") if cache_dir else None,
+        )
+        w3 = LazyWeight(
+            source=make_weight_source("w3", -1),
+            dtype=ff1_3_dtype,
+            device=mesh_device,
+            mesh_mapper_config=ttnn.MeshMapperConfig(
+                placements=[ttnn.PlacementShard(-1)],
+                mesh_shape_override=ttnn.MeshShape([mesh_device.get_num_devices()]),
+            ),
+            layout=ttnn.TILE_LAYOUT,
+            memory_config=w1_w3_mem_config,
+            cache_dir_weight_name=(cache_dir, "w3_sharded") if cache_dir else None,
+        )
+
+        # Create config with all the overrides and use from_config
+        config = MLP1DConfig(
+            w1=w1,
+            w2=w2,
+            w3=w3,
+            mesh_device=mesh_device,
+            tt_ccl=tt_ccl,
+            dim=args.dim,
+            hidden_dim=args.hidden_dim,
+            max_batch_size=args.max_batch_size,
+            mlp_activation_type=getattr(args, "mlp_activation_type", ttnn.UnaryOpType.SILU),
+            topology=ccl_topology,
+            decode_w1_w3_prg_config=decode_w1_w3_prg_config,
+            decode_w2_prg_config=decode_w2_prg_config,
+            decode_mlp2_input_memcfg=decode_mlp2_input_memcfg,
+            decode_residual_memcfg=decode_residual_memcfg,
+            w1_w3_dtype=ff1_3_dtype,
+            w2_dtype=ff2_dtype,
+            activation_dtype=activation_dtype,
+            ff1_3_compute_kernel_cfg=ff1_3_compute_kernel_cfg,
+            ff2_compute_kernel_cfg=ff2_compute_kernel_cfg,
+            decode_ff1_3_compute_kernel_cfg=ff1_3_compute_kernel_cfg,
+            decode_ff2_compute_kernel_cfg=ff2_compute_kernel_cfg,
+            decode_spill_w1_to_dram_before_w3=False,
+            # Use prefill_len_cutoff from args to match original MLP behavior
+            prefill_len_cutoff=args.prefill_len_cutoff,
+        )
+        return cls.from_config(config)
+
+
+# =============================================================================
+# Config helper functions (adapted from TTTv1 model_config.py)
+# =============================================================================
+
+
+def _find_largest_divisor(n: int, max_divisor: int = 8) -> int:
+    """Find largest divisor of n up to max_divisor."""
+    for i in range(max_divisor, 0, -1):
+        if n % i == 0:
+            return i
+    return 1
+
+
+def _find_grid(n_tiles: int, max_rows: int = 8, max_cols: int = 8) -> tuple[int, int]:
+    """Find grid dimensions (rows, cols) that evenly divide n_tiles."""
+    max_cores = max_rows * max_cols
+    target = max_cores // 2  # prefer half the grid for balanced utilization
+    possible_cores = [k for k in range(1, max_cores + 1) if n_tiles % k == 0]
+    possible_cores.sort(key=lambda x: abs(x - target))
+
+    for cores in possible_cores:
+        for rows in range(1, max_rows + 1):
+            if cores % rows == 0:
+                cols = cores // rows
+                if cols <= max_cols:
+                    return rows, cols
+
+    raise AssertionError(f"Cannot find grid for {n_tiles} tiles within {max_rows}x{max_cols}")
+
+
+def _find_grid_k_n(k_tiles: int, n_tiles: int, max_rows: int = 8, max_cols: int = 8) -> tuple[int, int]:
+    """Find grid that evenly divides both K and N tile counts."""
+    max_cores = max_rows * max_cols
+    possible_cores = [c for c in range(1, max_cores + 1) if k_tiles % c == 0 and n_tiles % c == 0]
+    possible_cores.sort(reverse=True)
+
+    for cores in possible_cores:
+        for rows in range(1, max_rows + 1):
+            if cores % rows == 0:
+                cols = cores // rows
+                if cols <= max_cols:
+                    return rows, cols
+
+    raise AssertionError(f"Cannot find grid for K={k_tiles}, N={n_tiles} tiles")
+
+
+def _find_prefill_grid(row_tiles: int, col_tiles: int, max_rows: int = 8, max_cols: int = 8) -> tuple[int, int]:
+    """Find grid where row_tiles divides rows and col_tiles divides cols."""
+    cols = next((i for i in range(max_cols, 0, -1) if col_tiles % i == 0), None)
+    rows = next((i for i in range(max_rows, 0, -1) if row_tiles % i == 0), None)
+    assert cols is not None and rows is not None
+    return rows, cols
+
+
+def _get_out_subblock_w(per_core_n: int, out_subblock_h: int = 1) -> int:
+    """Get output subblock width that divides per_core_n and satisfies constraints."""
+    # [ALIGNED] Exactly matching models/tt_transformers/tt/common.py:get_out_subblock_w
+    out_subblock_w = 4  # TODO: Check with LLK team if this is the true bound, might be 8 now
+    while out_subblock_w > 1:
+        if out_subblock_w * out_subblock_h <= 4 and per_core_n % out_subblock_w == 0:
+            break
+        out_subblock_w -= 1
+    return out_subblock_w
+
+
+def _dram_shard_core_grid(k: int, tile_size: int = TILE_SIZE) -> ttnn.CoreGrid:
+    """Get core grid for DRAM sharding based on K dimension."""
+    rows, cols = _find_grid(k // tile_size)
+    return ttnn.CoreGrid(x=cols, y=rows)
+
+
+def _dram_shard_core_grid_k_n(k: int, n: int, tile_size: int = TILE_SIZE) -> ttnn.CoreGrid:
+    """Get core grid for DRAM sharding based on K and N dimensions."""
+    rows, cols = _find_grid_k_n(k // tile_size, n // tile_size)
+    return ttnn.CoreGrid(x=cols, y=rows)
+
+
+def _dram_matmul_config(
+    m: int, k: int, n: int, num_cores: int, tile_size: int = TILE_SIZE, fused_activation=None
+) -> ttnn.MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig:
+    """Create DRAM-sharded matmul program config."""
+    return ttnn.MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig(
+        in0_block_w=_find_largest_divisor(k // (tile_size * num_cores)),
+        per_core_M=math.ceil(m / tile_size),
+        per_core_N=math.ceil(n / (tile_size * num_cores)),
+        fused_activation=fused_activation,
+    )
+
+
+def _matmul_config(
+    m: int,
+    k: int,
+    n: int,
+    grid_size: tuple[int, int],
+    tile_size: int = TILE_SIZE,
+    in0_block_w: int = None,
+    fuse_batch: bool = False,
+    fused_activation=None,
+    per_core_m: int = None,
+    per_core_n: int = None,
+) -> ttnn.MatmulMultiCoreReuseMultiCastProgramConfig:
+    """Create multicast matmul program config."""
+    if per_core_m is None:
+        per_core_m = math.ceil(m / (tile_size * grid_size[1]))
+    if per_core_n is None:
+        per_core_n = math.ceil(n / (tile_size * grid_size[0]))
+
+    out_subblock_h = 1
+    out_subblock_w = _get_out_subblock_w(per_core_n, out_subblock_h)
+
+    if in0_block_w is None:
+        in0_block_w = _find_largest_divisor(k // (tile_size * grid_size[1]))
+
+    return ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+        compute_with_storage_grid_size=grid_size,
+        in0_block_w=in0_block_w,
+        out_subblock_h=out_subblock_h,
+        out_subblock_w=out_subblock_w,
+        per_core_M=per_core_m,
+        per_core_N=per_core_n,
+        transpose_mcast=False,
+        fused_activation=fused_activation,
+        fuse_batch=fuse_batch,
+    )
+
+
+def _compute_kernel_config_hifi2_fp16() -> ttnn.WormholeComputeKernelConfig:
+    """Default compute kernel config for MLP (HiFi2 with FP16 accumulation)."""
+    return ttnn.WormholeComputeKernelConfig(
+        math_fidelity=ttnn.MathFidelity.HiFi2,
+        math_approx_mode=False,
+        fp32_dest_acc_en=False,
+        packer_l1_acc=True,
+    )
+
+
+def _create_dram_sharded_mem_config(
+    k: int, n: int, dram_grid: ttnn.CoreRangeSet, tile_size: int = TILE_SIZE, dram_cores: int = 12
+) -> ttnn.MemoryConfig:
+    """Create DRAM-sharded memory config for weight tensors."""
+    padded_size = math.ceil(n / (tile_size * dram_cores)) * (tile_size * dram_cores)
+    shard_spec = ttnn.ShardSpec(dram_grid, (k, padded_size // dram_cores), ttnn.ShardOrientation.ROW_MAJOR)
+    return ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.DRAM, shard_spec)
+
+
+def _resolve_mlp1d_config(config: MLP1DConfig) -> MLP1DConfig:
+    """Materialize the config to known good defaults using replace pattern."""
+
+    to_set = {}
+
+    # --- Phase 1: Foundational fields (order matters due to dependencies) ---
+
+    # Derive dimensions from weights
+    # w1 is expected in TTNN layout: (dim, hidden_dim) - caller must transpose if needed
+    dim = config.dim
+    if config.dim is None:
+        dim = config.w1.source.shape[-2]
+        to_set["dim"] = dim
+
+    hidden_dim = config.hidden_dim
+    if config.hidden_dim is None:
+        hidden_dim = config.w1.source.shape[-1]
+        to_set["hidden_dim"] = hidden_dim
+
+    # Derive mesh_device from weights, fall back to default
+    mesh_device = config.mesh_device
+    if mesh_device is None:
+        mesh_device = config.w1.device
+    if mesh_device is None:
+        mesh_device = ttnn.GetDefaultDevice()
+    if config.mesh_device is None:
+        to_set["mesh_device"] = mesh_device
+
+    assert mesh_device is not None, "mesh_device must be available at this point!"
+    if config.w1.device is not None:
+        assert mesh_device == config.w1.device, "mesh_device must match the device of w1!"
+    if config.w2.device is not None:
+        assert mesh_device == config.w2.device, "mesh_device must match the device of w2!"
+    if config.w3.device is not None:
+        assert mesh_device == config.w3.device, "mesh_device must match the device of w3!"
+
+    # Derive tt_ccl
+    tt_ccl = config.tt_ccl
+    if config.tt_ccl is None:
+        tt_ccl = get_tt_ccl(mesh_device)
+        to_set["tt_ccl"] = tt_ccl
+
+    assert tt_ccl is not None, "tt_ccl must be available at this point!"
+    assert tt_ccl.mesh_device == mesh_device, "tt_ccl must match the device of mesh_device!"
+
+    # Auto-detect topology
+    topology = config.topology
+    if config.topology is None:
+        topology = default_topology(mesh_device)
+        to_set["topology"] = topology
+
+    # --- Phase 2: Derived fields ---
+
+    num_devices = mesh_device.get_num_devices()
+    tile_size = TILE_SIZE
+    tile_padded_batch_rows = tile_size * math.ceil(config.max_batch_size / tile_size)
+
+    # Compute padded hidden_dim for memory configs (must match auto-padding in LazyWeight)
+    padded_hidden_dim = get_padded_hidden_dim(hidden_dim, num_devices, tile_size)
+
+    # Always computed (not user-overridable None fields)
+    w1_w3_dtype = config.w1_w3_dtype
+    if config.w1_w3_dtype is None:
+        w1_w3_dtype = ttnn.bfloat8_b
+        to_set["w1_w3_dtype"] = w1_w3_dtype
+    w2_dtype = config.w2_dtype
+    if config.w2_dtype is None:
+        w2_dtype = ttnn.bfloat8_b
+        to_set["w2_dtype"] = w2_dtype
+
+    if config.linear_dtype is None:
+        to_set["linear_dtype"] = config.activation_dtype or ttnn.bfloat16
+    if config.mul_dtype is None:
+        to_set["mul_dtype"] = config.activation_dtype or ttnn.bfloat8_b
+    prefill_len_cutoff = config.prefill_len_cutoff
+    if config.prefill_len_cutoff is None:
+        to_set["prefill_len_cutoff"] = 512 if is_blackhole() else 1024
+        prefill_len_cutoff = to_set["prefill_len_cutoff"]
+
+    # Compute kernel configs
+    if config.ff1_3_compute_kernel_cfg is None:
+        to_set["ff1_3_compute_kernel_cfg"] = _compute_kernel_config_hifi2_fp16()
+    if config.ff2_compute_kernel_cfg is None:
+        to_set["ff2_compute_kernel_cfg"] = _compute_kernel_config_hifi2_fp16()
+
+    ff13_resolved = config.ff1_3_compute_kernel_cfg or to_set.get("ff1_3_compute_kernel_cfg")
+    ff2_resolved = config.ff2_compute_kernel_cfg or to_set.get("ff2_compute_kernel_cfg")
+    if config.decode_ff1_3_compute_kernel_cfg is None:
+        to_set["decode_ff1_3_compute_kernel_cfg"] = ff13_resolved
+    if config.decode_ff2_compute_kernel_cfg is None:
+        to_set["decode_ff2_compute_kernel_cfg"] = ff2_resolved
+
+    # --- Phase 3: Decode program configs ---
+    # Note: Use padded_hidden_dim to match auto-padding in LazyWeight
+
+    mlp_core_grid = _dram_shard_core_grid_k_n(dim, padded_hidden_dim // num_devices)
+
+    if config.decode_input_memcfg is None:
+        to_set["decode_input_memcfg"] = ttnn.create_sharded_memory_config(
+            (tile_padded_batch_rows, dim // mlp_core_grid.num_cores),  # Shard shape: 1 shard per core
+            mlp_core_grid,
+            ttnn.ShardStrategy.WIDTH,
+            ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+
+    if config.decode_w1_w3_prg_config is None:
+        to_set["decode_w1_w3_prg_config"] = _dram_matmul_config(
+            m=tile_padded_batch_rows,
+            k=dim,
+            n=padded_hidden_dim // num_devices,
+            num_cores=mlp_core_grid.num_cores,
+        )
+
+    mlp2_core_grid = _dram_shard_core_grid_k_n(padded_hidden_dim // num_devices, dim)
+
+    if config.decode_w2_prg_config is None:
+        to_set["decode_w2_prg_config"] = _dram_matmul_config(
+            m=tile_padded_batch_rows,
+            k=padded_hidden_dim // num_devices,
+            n=dim,
+            num_cores=mlp2_core_grid.num_cores,
+        )
+
+    if config.decode_mlp2_input_memcfg is None:
+        to_set["decode_mlp2_input_memcfg"] = ttnn.create_sharded_memory_config(
+            (tile_padded_batch_rows, padded_hidden_dim // num_devices // mlp2_core_grid.num_cores),
+            mlp2_core_grid,
+            ttnn.ShardStrategy.WIDTH,
+            ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+
+    if config.decode_residual_memcfg is None:
+        residual_grid = _dram_shard_core_grid(dim // num_devices)
+        to_set["decode_residual_memcfg"] = ttnn.create_sharded_memory_config(
+            (tile_padded_batch_rows, dim // residual_grid.num_cores // num_devices),
+            residual_grid,
+            ttnn.ShardStrategy.WIDTH,
+            ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+
+    # --- Phase 4: Prefill program configs ---
+
+    # DRAM shard grid width: on Wormhole always 8 (despite 12 physical DRAM cores);
+    # on Blackhole use actual DRAM grid width (7 for P100, 8 for P150).
+    # Matching per_core_N to this width avoids silent PCC issues on P100.
+    dram_shard_grid_width = 8 if not is_blackhole() else mesh_device.dram_grid_size().x
+
+    if config.prefill_input_memcfg is None:
+        to_set["prefill_input_memcfg"] = ttnn.DRAM_MEMORY_CONFIG
+
+    if config.prefill_w1_w3_prg_config is None:
+        prefill_rows = 8
+        prefill_mlp_grid_size = _find_prefill_grid(prefill_rows, dim // tile_size)
+        n_w1_w3 = padded_hidden_dim // num_devices
+
+        @lru_cache
+        def w1_w3_prg_config(seq_len: int):
+            return _matmul_config(
+                m=min(seq_len, prefill_len_cutoff),
+                k=dim,
+                n=n_w1_w3,
+                grid_size=prefill_mlp_grid_size,
+                per_core_n=math.ceil(n_w1_w3 / (tile_size * dram_shard_grid_width)),
+            )
+
+        to_set["prefill_w1_w3_prg_config"] = lambda seq_len: w1_w3_prg_config(seq_len)
+
+    if config.prefill_w2_prg_config is None:
+        n_w2 = dim
+        prefill_rows = 8
+        grid_size = _find_prefill_grid(prefill_rows, padded_hidden_dim // tile_size)
+
+        @lru_cache
+        def w2_prg_config(seq_len: int):
+            return _matmul_config(
+                m=min(seq_len, prefill_len_cutoff),
+                k=padded_hidden_dim,
+                n=n_w2,
+                grid_size=grid_size,
+                per_core_n=math.ceil(n_w2 / (tile_size * dram_shard_grid_width)),
+            )
+
+        to_set["prefill_w2_prg_config"] = lambda seq_len: w2_prg_config(seq_len)
+
+    # minimal_matmul config for W2 (only materialized when the opt-in is set). Block sizes mirror TTTv1
+    # (mlp.py via model_config.py:1329-1334: 8/8/8 blocks); the compute grid is the W2 prefill grid
+    # (find_prefill_grid over padded_hidden_dim), equivalent to TTTv1's mlp2_grid(seq_len).
+    if config.prefill_w2_minimal_matmul and config.prefill_w2_minimal_matmul_config is None:
+        minimal_w2_grid = _find_prefill_grid(8, padded_hidden_dim // tile_size)
+
+        @lru_cache
+        def w2_minimal_matmul_config(seq_len: int):
+            return ttnn.MinimalMatmulConfig(
+                M_block_size=8,
+                K_block_size=8,
+                N_block_size=8,
+                compute_with_storage_grid_size=ttnn.CoreCoord(minimal_w2_grid[0], minimal_w2_grid[1]),
+            )
+
+        to_set["prefill_w2_minimal_matmul_config"] = lambda seq_len: w2_minimal_matmul_config(seq_len)
+
+    # --- Phase 5: Weight memory configs ---
+
+    dram_grid_size = mesh_device.dram_grid_size()
+    dram_grid = ttnn.CoreRangeSet(
+        {
+            ttnn.CoreRange(
+                ttnn.CoreCoord(0, 0),
+                ttnn.CoreCoord(dram_grid_size.x - 1, dram_grid_size.y - 1),
+            )
+        }
+    )
+
+    w1_w3_memcfg = config.w1_w3_memcfg
+    if w1_w3_memcfg is None:
+        w1_w3_memcfg = _create_dram_sharded_mem_config(
+            k=dim,
+            n=padded_hidden_dim // num_devices,
+            dram_grid=dram_grid,
+            tile_size=tile_size,
+            dram_cores=dram_grid_size.x,
+        )
+        to_set["w1_w3_memcfg"] = w1_w3_memcfg
+
+    w2_memcfg = config.w2_memcfg
+    if w2_memcfg is None:
+        w2_memcfg = _create_dram_sharded_mem_config(
+            k=padded_hidden_dim // num_devices,
+            n=dim,
+            dram_grid=dram_grid,
+            tile_size=tile_size,
+            dram_cores=dram_grid_size.x,
+        )
+        to_set["w2_memcfg"] = w2_memcfg
+
+    # --- Phase 6: Resolve LazyWeights ---
+
+    w1_w3_mesh_mapper_config = ttnn.MeshMapperConfig(
+        placements=[ttnn.PlacementShard(-1)],
+        mesh_shape_override=ttnn.MeshShape([num_devices]),
+    )
+    to_set["w1"] = resolve_lazy_weight(
+        config.w1,
+        device=mesh_device,
+        memory_config=w1_w3_memcfg,
+        mesh_mapper_config=w1_w3_mesh_mapper_config,
+        layout=ttnn.TILE_LAYOUT,
+        dtype=w1_w3_dtype,
+    )
+
+    to_set["w2"] = resolve_lazy_weight(
+        config.w2,
+        device=mesh_device,
+        memory_config=w2_memcfg,
+        mesh_mapper_config=ttnn.MeshMapperConfig(
+            placements=[ttnn.PlacementShard(-2)],
+            mesh_shape_override=ttnn.MeshShape([num_devices]),
+        ),
+        layout=ttnn.TILE_LAYOUT,
+        dtype=w2_dtype,
+    )
+
+    to_set["w3"] = resolve_lazy_weight(
+        config.w3,
+        device=mesh_device,
+        memory_config=w1_w3_memcfg,
+        mesh_mapper_config=w1_w3_mesh_mapper_config,
+        layout=ttnn.TILE_LAYOUT,
+        dtype=w1_w3_dtype,
+    )
+
+    # --- Final: Create new config with all resolved fields ---
+    # todo)) using the current if <field> is None else to_set[<field>] does not seem to be worth the saving in space. Maybe cleaner to build all the fields in to_set and then replace the config with them with:
+    #     to_override_set = {k: v for k, v in kwargs.items() if getattr(config, k, None) is None}
+    #     return replace(config, **to_override_set)
+    resolved_config = replace(config, **to_set)
+
+    assert all(
+        [resolved_config.w1.is_resolved(), resolved_config.w2.is_resolved(), resolved_config.w3.is_resolved()]
+    ), "All weights must be resolved!"
+    assert resolved_config.is_resolved(), "Config must be resolved!"
+    # check that the padded shapes match the config
+    assert resolved_config.w1.padded_shape == (dim, padded_hidden_dim), "w1 padded_shape does not match the config!"
+    assert resolved_config.w2.padded_shape == (padded_hidden_dim, dim), "w2 padded_shape does not match the config!"
+    assert resolved_config.w3.padded_shape == (dim, padded_hidden_dim), "w3 padded_shape does not match the config!"
+
+    return resolved_config
+
+
+def _load_input_device_tensor(x: ttnn.Tensor | LazyWeight, config: MLP1DConfig, mode: str) -> ttnn.Tensor:
+    """Resolve the input tensor to ttnn tensor if x is a LazyWeight, otherwise sanity check x and then return as is"""
+    assert mode in ["decode", "prefill"], "mode must be one of decode or prefill!"
+    mem_cfg = config.decode_input_memcfg if mode == "decode" else config.prefill_input_memcfg
+    if isinstance(x, LazyWeight):
+        # resolve in place
+        resolved_x = resolve_lazy_weight(
+            x,
+            device=config.mesh_device,
+            memory_config=mem_cfg,
+            mesh_mapper_config=None,  # replicated
+            layout=ttnn.TILE_LAYOUT,
+        )
+        return resolved_x.get_device_weight()
+
+    assert isinstance(x, ttnn.Tensor), "x must be a ttnn tensor at this point!"
+    if x.memory_config() != mem_cfg:
+        raise ValueError("Input tensor memory config does not match the config!")
+
+    return x

--- a/models/experimental/llama32_1b_quasar/modules/rmsnorm/rmsnorm_1d.py
+++ b/models/experimental/llama32_1b_quasar/modules/rmsnorm/rmsnorm_1d.py
@@ -1,0 +1,676 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+RMSNorm1D: RMSNorm for 1D mesh topologies (single-chip, n150, n300, T3K row/column).
+
+Execution paths:
+  - Path 1: _decode_local - Local decode (sharded or interleaved) - always for 1D decode
+  - Path 2: _prefill_local - Local prefill (interleaved) - single-device or prefill_distributed=False
+  - Path 3: _prefill_1d_distributed - 1D distributed prefill - multi-device, Ring topology
+
+Key design:
+  - decode_forward always uses local sharded path (no 1D distributed decode)
+  - prefill_forward switches between local and distributed based on prefill_distributed config
+  - Config provides program_config/memory_config for sharded, None for interleaved
+  - from_model_args() sets prefill_distributed=True when dim >= 4096 for backward compatibility
+"""
+
+import math
+from dataclasses import dataclass, replace
+from typing import Optional
+
+import ttnn
+from models.experimental.llama32_1b_quasar.lightweightmodule import LightweightModule
+from models.experimental.llama32_1b_quasar.modules.lazy_weight import LazyWeight, resolve_lazy_weight
+from models.experimental.llama32_1b_quasar.modules.tt_ccl import get_tt_ccl
+from models.experimental.llama32_1b_quasar.tensor_utils import TILE_SIZE
+
+# =============================================================================
+# Constants
+# =============================================================================
+
+SHARD_HEIGHT = TILE_SIZE  # Current ttnn.rms_norm requires shard height = single tile
+
+
+# =============================================================================
+# RMSNorm1DConfig
+# =============================================================================
+
+
+@dataclass
+class RMSNorm1DConfig:
+    """
+    Configuration for RMSNorm1D - only fields relevant to 1D mesh topologies.
+
+    Paths:
+      - Path 1: Local decode (sharded) - set decode_program_config & decode_memory_config
+      - Path 2: Local prefill (interleaved) - no extra config needed
+      - Path 3: 1D distributed prefill - requires tt_ccl for Ring all-gather
+
+    Simple usage:
+        config = RMSNorm1DConfig(weight)
+
+    Override any field:
+        config = RMSNorm1DConfig(weight, eps=1e-6, prefill_distributed=True)
+    """
+
+    # Required: weight
+    weight: LazyWeight
+
+    # Device and collectives
+    mesh_device: ttnn.MeshDevice | None = None
+    tt_ccl: "TT_CCL | None" = None  # type: ignore
+
+    # Normalization settings
+    eps: float = 1e-5
+    add_unit_offset: bool = False
+
+    # Distributed control (None = auto-detect: True for multi-device, False for single-device)
+    prefill_distributed: bool | None = None
+
+    # Batch size for decode
+    max_batch_size: int = 32
+
+    # Local decode configs (Path 1)
+    decode_in_sharded: bool = True  # If True, use sharded decode; if False, use interleaved
+    decode_out_sharded: bool = True  # If True, output stays sharded (only valid if in_sharded=True)
+    decode_program_config: ttnn.LayerNormShardedMultiCoreProgramConfig | None = None
+    decode_memory_config: ttnn.MemoryConfig | None = None
+
+    # Input memory configs (optional, for prepare_input_tensor)
+    decode_input_memcfg: ttnn.MemoryConfig | None = None
+    prefill_input_memcfg: ttnn.MemoryConfig | None = None
+
+    # Compute kernel config (shared across paths)
+    compute_kernel_config: ttnn.WormholeComputeKernelConfig | None = None
+
+    # Internal: distributed weight LazyWeight (sharded across devices for Path 3)
+    # Note: Uses LazyWeight with explicit mesh_mapper_config to shard weights correctly.
+    # The get_device_weight() call respects the mesh_mapper_config for proper distribution.
+    _weight_distributed: LazyWeight | None = None
+
+    def is_resolved(self) -> bool:
+        """Check if all required fields are resolved."""
+        required = ["weight", "mesh_device", "compute_kernel_config"]
+
+        # Multi-device distributed prefill needs CCL and distributed weight
+        num_devices = self.mesh_device.get_num_devices() if self.mesh_device else 1
+        if num_devices > 1 and self.prefill_distributed:
+            required.extend(["tt_ccl", "_weight_distributed"])
+
+        # Decode always needs sharded config
+        required.extend(["decode_program_config", "decode_memory_config"])
+
+        return all(getattr(self, f) is not None for f in required)
+
+
+# =============================================================================
+# RMSNorm1D
+# =============================================================================
+
+
+class RMSNorm1D(LightweightModule):
+    """
+    RMSNorm for 1D mesh topologies.
+
+    Execution paths (bound at construction):
+      - decode_forward -> _decode_local (Path 1) - always local sharded
+      - prefill_forward -> _prefill_local (Path 2) or _prefill_1d_distributed (Path 3)
+
+    Simple API:
+        norm = RMSNorm1D(weight)
+
+    Power API:
+        config = RMSNorm1DConfig(weight, max_batch_size=64)
+        norm = RMSNorm1D.from_config(config)
+    """
+
+    def __init__(self, weight: LazyWeight):
+        """
+        Simple API - derives all config from weight.
+
+        Args:
+            weight: RMSNorm weight tensor of shape (dim,) or (1, 1, dim // SHARD_HEIGHT, SHARD_HEIGHT)
+
+        Note: Use from_config() to customize eps, add_unit_offset, or other settings.
+        """
+        super().__init__()
+        self.config = _resolve_1d_config(RMSNorm1DConfig(weight=weight))
+        self._device_weights_loaded = False
+        self._bind_forward_methods()
+
+    @classmethod
+    def from_config(cls, config: RMSNorm1DConfig):
+        """Power API - any level of customization via config."""
+        instance = object.__new__(cls)
+        super(RMSNorm1D, instance).__init__()
+        instance.config = _resolve_1d_config(config)
+        instance._device_weights_loaded = False
+        instance._bind_forward_methods()
+        return instance
+
+    def _bind_forward_methods(self):
+        """Bind decode_forward and prefill_forward based on config."""
+        cfg = self.config
+
+        # Decode: sharded or interleaved based on config
+        if cfg.decode_in_sharded:
+            self.decode_forward = self._decode_local_sharded
+        else:
+            self.decode_forward = self._decode_local_interleaved
+
+        # Prefill: local or 1D distributed based on dim
+        if cfg.prefill_distributed:
+            self.prefill_forward = self._prefill_1d_distributed
+        else:
+            self.prefill_forward = self._prefill_local
+
+    def load_device_weights(self):
+        """Load weights to device lazily."""
+        if self._device_weights_loaded:
+            return
+
+        assert self.config.is_resolved(), "config must be resolved before loading device weights!"
+
+        cfg = self.config
+
+        # Always load replicated weight (decode always needs it)
+        self.weight = cfg.weight.get_device_weight()
+
+        # Load sharded weight if distributed prefill is enabled
+        if cfg.prefill_distributed and cfg._weight_distributed is not None:
+            self.weight_distributed = cfg._weight_distributed.get_device_weight()
+
+        self._device_weights_loaded = True
+
+    # =========================================================================
+    # Path 1a: Local decode - sharded
+    # =========================================================================
+
+    def _decode_local_sharded(self, x: ttnn.Tensor | LazyWeight) -> ttnn.Tensor:
+        """
+        Sharded decode - standard LLM decode path.
+
+        Execution: to_sharded -> rms_norm(sharded) with program_config and memory_config.
+        Output: sharded if decode_out_sharded=True, interleaved otherwise
+        """
+        self.load_device_weights()
+        x = _load_input_device_tensor(x, self.config, mode="decode")
+        cfg = self.config
+
+        assert cfg.decode_in_sharded, "decode_in_sharded must be True for sharded decode"
+
+        x = ttnn.to_memory_config(x, memory_config=cfg.decode_memory_config)
+
+        x = ttnn.rms_norm(
+            x,
+            epsilon=cfg.eps,
+            weight=self.weight,
+            program_config=cfg.decode_program_config,
+            memory_config=cfg.decode_memory_config,
+            compute_kernel_config=cfg.compute_kernel_config,
+        )
+
+        if not cfg.decode_out_sharded:
+            x = ttnn.sharded_to_interleaved(x)
+
+        return x
+
+    # =========================================================================
+    # Path 1b: Local decode - interleaved
+    # =========================================================================
+
+    def _decode_local_interleaved(self, x: ttnn.Tensor | LazyWeight) -> ttnn.Tensor:
+        """
+        Interleaved decode - for vision encoder decode.
+
+        Execution: rms_norm with program_config=None, memory_config=None
+        Output: always interleaved (decode_out_sharded must be False)
+        """
+        self.load_device_weights()
+        x = _load_input_device_tensor(x, self.config, mode="decode")
+        cfg = self.config
+
+        assert not cfg.decode_in_sharded, "decode_in_sharded must be False for interleaved decode"
+        assert not cfg.decode_out_sharded, "decode_out_sharded must be False when decode_in_sharded=False"
+
+        return ttnn.rms_norm(
+            x,
+            epsilon=cfg.eps,
+            weight=self.weight,
+            program_config=None,
+            memory_config=None,
+            compute_kernel_config=cfg.compute_kernel_config,
+        )
+
+    # =========================================================================
+    # Path 2: Local prefill (interleaved)
+    # =========================================================================
+
+    def _prefill_local(self, x: ttnn.Tensor | LazyWeight) -> ttnn.Tensor:
+        """
+        Local prefill - interleaved RMSNorm when prefill_distributed=False.
+
+        Execution: rms_norm(interleaved) without program_config
+        """
+        self.load_device_weights()
+        x = _load_input_device_tensor(x, self.config, mode="prefill")
+        cfg = self.config
+
+        return ttnn.rms_norm(
+            x,
+            epsilon=cfg.eps,
+            weight=self.weight,
+            program_config=None,
+            memory_config=None,
+            compute_kernel_config=cfg.compute_kernel_config,
+        )
+
+    # =========================================================================
+    # Path 3: 1D distributed prefill (Ring topology, no cluster_axis)
+    # =========================================================================
+
+    def _prefill_1d_distributed(self, x: ttnn.Tensor | LazyWeight) -> ttnn.Tensor:
+        """
+        1D distributed prefill - when prefill_distributed=True.
+
+        Uses Ring topology, no cluster_axis.
+
+        Execution:
+          rms_norm_pre_all_gather -> all_gather(stats) -> rms_norm_post_all_gather
+        """
+        self.load_device_weights()
+        x = _load_input_device_tensor(x, self.config, mode="prefill")
+        cfg = self.config
+
+        # Run distributed rmsnorm part 1
+        tt_stats = ttnn.rms_norm_pre_all_gather(x, compute_kernel_config=cfg.compute_kernel_config, dtype=ttnn.bfloat16)
+
+        # AllGather stats (Ring topology, no cluster_axis)
+        tt_stats = ttnn.experimental.all_gather_async(
+            tt_stats,
+            persistent_output_buffer=None,
+            dim=3,
+            multi_device_global_semaphore=cfg.tt_ccl.get_and_cycle_ag_semaphore_handles(),
+            num_links=1,
+            topology=ttnn.Topology.Ring,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            barrier_semaphore=cfg.tt_ccl.get_and_cycle_barrier_semaphore_handle(),
+            chunks_per_sync=10,
+            num_workers_per_link=2,
+            num_buffers_per_channel=2,
+        )
+
+        # Run distributed rmsnorm part 2 (uses sharded weight)
+        tt_out = ttnn.rms_norm_post_all_gather(
+            x,
+            tt_stats,
+            epsilon=cfg.eps,
+            weight=self.weight_distributed,
+            compute_kernel_config=cfg.compute_kernel_config,
+        )
+        tt_stats.deallocate(True)
+
+        return tt_out
+
+    # =========================================================================
+    # Forward dispatcher
+    # =========================================================================
+
+    def forward(self, x: "ttnn.Tensor | LazyWeight", mode: str) -> ttnn.Tensor:
+        """
+        Dispatch to the appropriate forward method based on mode.
+
+        Args:
+            x: Input tensor (ttnn.Tensor or LazyWeight wrapping torch tensor)
+            mode: "decode" or "prefill"
+
+        Note: Sharding behavior for decode is controlled via config:
+            - decode_in_sharded: True for sharded (LLM), False for interleaved (vision)
+            - decode_out_sharded: True to keep output sharded, False to convert to interleaved
+        """
+        if mode == "decode":
+            return self.decode_forward(x)
+        else:
+            return self.prefill_forward(x)
+
+    # [INFO] this is the entry point for TTTv1 model_config.py and will retire with TTTv1
+    @classmethod
+    def from_model_args(
+        cls,
+        mesh_device,
+        tt_ccl,
+        args,
+        state_dict,
+        weight_cache_path,
+        layer_num: int,
+        weight_key: str,
+        state_dict_prefix: Optional[str] = None,
+        sharded_program_config=None,
+        sharded_output_config=None,
+    ):
+        """Factory method for backward compatibility with ModelArgs."""
+
+        if args.is_galaxy:
+            raise ValueError("RMSNorm1D cannot be used for Galaxy devices. Use RMSNorm2D instead.")
+
+        # Build weight name from state_dict_prefix and weight_key
+        if state_dict_prefix:
+            weight_name = f"{state_dict_prefix}{weight_key}.weight"
+        else:
+            if layer_num is None:
+                weight_name = f"{weight_key}.weight"
+            else:
+                weight_name = f"layers.{layer_num}.{weight_key}.weight"
+
+        # Transform weight to expected shape: (1, 1, dim // SHARD_HEIGHT, SHARD_HEIGHT)
+        dim = args.dim
+        torch_weight = (
+            state_dict[weight_name].unsqueeze(0).view(1, 1, dim).reshape([1, 1, dim // SHARD_HEIGHT, SHARD_HEIGHT])
+        )
+
+        # Add offset before creating LazyWeight
+        if args.rms_norm_add_unit_offset:
+            torch_weight = torch_weight + 1.0
+
+        # Create LazyWeight
+        lazy_weight = LazyWeight(
+            source=torch_weight,
+            dtype=ttnn.bfloat16,
+            device=mesh_device,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            cache_dir_weight_name=(weight_cache_path, weight_name) if weight_cache_path else None,
+            mesh_mapper_config=(
+                ttnn.MeshMapperConfig(
+                    placements=[ttnn.PlacementReplicate()],
+                    mesh_shape_override=ttnn.MeshShape([mesh_device.get_num_devices()]),
+                )
+                if mesh_device.get_num_devices() > 1
+                else None
+            ),
+        )
+
+        # Get compute kernel config (e.g., fp32_dest_acc_en for Qwen models)
+        fp32_dest_acc_en = True
+        if hasattr(args, "base_model_name") and args.base_model_name in ("Qwen2.5-7B", "Qwen2.5-VL-7B"):
+            fp32_dest_acc_en = False
+
+        compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+            math_fidelity=ttnn.MathFidelity.HiFi2,
+            math_approx_mode=False,
+            fp32_dest_acc_en=fp32_dest_acc_en,
+            packer_l1_acc=False,
+        )
+
+        # Determine prefill_distributed based on dim and num_devices.
+        # Keep dim=4096 on the distributed path so multichip prefill norms match
+        # fractured activations produced by TTTv2 integration.
+        num_devices = mesh_device.get_num_devices()
+        prefill_distributed = num_devices > 1 and dim >= 4096
+
+        # Build config
+        config = RMSNorm1DConfig(
+            weight=lazy_weight,
+            eps=args.norm_eps,
+            add_unit_offset=False,  # Already applied above
+            mesh_device=mesh_device,
+            tt_ccl=tt_ccl,
+            max_batch_size=args.max_batch_size,
+            prefill_distributed=prefill_distributed,
+            decode_program_config=sharded_program_config,
+            decode_memory_config=sharded_output_config,
+            compute_kernel_config=compute_kernel_config,
+        )
+
+        return cls.from_config(config)
+
+
+# =============================================================================
+# Config resolution
+# =============================================================================
+
+
+def _resolve_1d_config(config: RMSNorm1DConfig) -> RMSNorm1DConfig:
+    """Resolve config defaults for RMSNorm1D."""
+
+    to_set = {}
+
+    # --- Phase 1: Foundational fields ---
+
+    # Derive dim from weight (works for any shape: [dim], [1, dim], [1, 1, dim//32, 32], etc.)
+    dim = config.weight.source.numel()
+
+    # Derive mesh_device from weight
+    mesh_device = config.mesh_device
+    if mesh_device is None:
+        mesh_device = config.weight.device
+    if mesh_device is None:
+        mesh_device = ttnn.GetDefaultDevice()
+    if config.mesh_device is None:
+        to_set["mesh_device"] = mesh_device
+
+    assert mesh_device is not None, "mesh_device must be available!"
+
+    num_devices = mesh_device.get_num_devices()
+
+    # --- Phase 2: Auto-detect distributed prefill ---
+    # Weight shape is (1, 1, dim // SHARD_HEIGHT, SHARD_HEIGHT), shard on dim 2
+    # Need at least num_devices tiles to shard across devices
+    num_weight_tiles = dim // SHARD_HEIGHT
+    can_shard_weights = num_weight_tiles >= num_devices
+
+    if config.prefill_distributed is None:
+        if num_devices == 1:
+            to_set["prefill_distributed"] = False
+        elif not can_shard_weights:
+            # Can't shard weight tiles across num_devices, use local prefill
+            to_set["prefill_distributed"] = False
+        else:
+            to_set["prefill_distributed"] = True
+
+    prefill_distributed = to_set.get("prefill_distributed", config.prefill_distributed)
+
+    # Derive tt_ccl (only needed for distributed prefill)
+    if config.tt_ccl is None and num_devices > 1 and prefill_distributed:
+        to_set["tt_ccl"] = get_tt_ccl(mesh_device)
+
+    # --- Phase 3: Compute kernel config ---
+
+    if config.compute_kernel_config is None:
+        to_set["compute_kernel_config"] = ttnn.WormholeComputeKernelConfig(
+            math_fidelity=ttnn.MathFidelity.HiFi2,
+            math_approx_mode=False,
+            fp32_dest_acc_en=True,
+            packer_l1_acc=True,
+        )
+
+    # --- Phase 4: Local decode configs (Path 1) ---
+
+    tile_size = TILE_SIZE
+    tile_padded_batch_rows = tile_size * math.ceil(config.max_batch_size / tile_size)
+
+    if config.decode_program_config is None:
+        norm_core_grid = _compute_norm_core_grid(dim)
+        to_set["decode_program_config"] = _create_sharded_norm_program_config(
+            dim, norm_core_grid, tile_padded_batch_rows, tile_size
+        )
+
+    if config.decode_memory_config is None:
+        norm_core_grid = _compute_norm_core_grid(dim)
+        to_set["decode_memory_config"] = ttnn.create_sharded_memory_config(
+            (tile_padded_batch_rows, dim // norm_core_grid.num_cores),
+            norm_core_grid,
+            ttnn.ShardStrategy.WIDTH,
+            ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+
+    # --- Phase 5: Resolve LazyWeight (replicated for decode and local prefill) ---
+
+    if num_devices == 1:
+        mesh_mapper_config_replicated = None
+        mesh_mapper_config_sharded = None
+    else:
+        # For 1D mesh topology, use 2D placement: [Replicate, Replicate]
+        # This replicates the weight to all devices
+        mesh_mapper_config_replicated = ttnn.MeshMapperConfig(
+            placements=[ttnn.PlacementReplicate(), ttnn.PlacementReplicate()],
+            mesh_shape_override=ttnn.MeshShape(1, num_devices),
+        )
+        # For distributed prefill, shard on tensor dim 2 (hidden tiles)
+        # Weight shape is (1, 1, dim // 32, 32), so dim 2 is the tiles dimension
+        mesh_mapper_config_sharded = ttnn.MeshMapperConfig(
+            placements=[ttnn.PlacementReplicate(), ttnn.PlacementShard(2)],
+            mesh_shape_override=ttnn.MeshShape(1, num_devices),
+        )
+
+    # Reshape weight to expected shape (1, 1, dim // SHARD_HEIGHT, SHARD_HEIGHT)
+    assert dim % SHARD_HEIGHT == 0, "dim must be divisible by SHARD_HEIGHT"
+    expected_shape = (1, 1, dim // SHARD_HEIGHT, SHARD_HEIGHT)
+    if config.weight.source.shape != expected_shape:
+        transformed_source = config.weight.source.reshape(*expected_shape)
+    else:
+        transformed_source = config.weight.source
+
+    # Apply unit offset if requested (e.g., for Gemma models)
+    if config.add_unit_offset:
+        transformed_source = transformed_source + 1.0
+
+    # Create a new LazyWeight with the transformed source
+    transformed_weight = replace(config.weight, source=transformed_source)
+
+    resolved_weight = resolve_lazy_weight(
+        transformed_weight,
+        dtype=ttnn.bfloat16,
+        device=mesh_device,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        mesh_mapper_config=mesh_mapper_config_replicated,
+    )
+    to_set["weight"] = resolved_weight
+
+    # --- Phase 7: Create distributed weight LazyWeight (for Path 3) ---
+    #
+    # Note: We create a LazyWeight with explicit mesh_mapper_config (ShardTensor2dMesh)
+    # to shard weights across devices. The get_device_weight() call at line 182 respects
+    # this config for proper distributed RMSNorm alignment.
+
+    if prefill_distributed and num_devices > 1:
+        # Create LazyWeight with sharded mesh_mapper_config
+        # The mesh_mapper_config with ShardTensor2dMesh ensures proper weight distribution
+        weight_distributed = replace(
+            transformed_weight,
+            dtype=ttnn.bfloat16,  # RMSNorm weights are always bfloat16
+            device=mesh_device,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper_config=mesh_mapper_config_sharded,
+        )
+        to_set["_weight_distributed"] = weight_distributed
+
+    return replace(config, **to_set)
+
+
+# =============================================================================
+# Helper functions
+# =============================================================================
+
+
+def _compute_norm_core_grid(dim: int, tile_size: int = TILE_SIZE) -> ttnn.CoreGrid:
+    """Compute core grid for RMSNorm that evenly divides dim."""
+    n_tiles = dim // tile_size
+    rows, cols = _find_grid(n_tiles)
+    return ttnn.CoreGrid(x=cols, y=rows)
+
+
+def _find_grid(n_tiles: int, max_rows: int = 8, max_cols: int = 8) -> tuple[int, int]:
+    """Find grid dimensions (rows, cols) that evenly divide n_tiles."""
+    max_cores = max_rows * max_cols
+    target = 32  # based on TTTv1 tuned configs
+    possible_cores = [k for k in range(1, max_cores + 1) if n_tiles % k == 0]
+    possible_cores.sort(key=lambda x: abs(x - target))
+
+    for cores in possible_cores:
+        for rows in range(1, max_rows + 1):
+            if cores % rows == 0:
+                cols = cores // rows
+                if cols <= max_cols:
+                    return rows, cols
+
+    raise AssertionError(f"Cannot find grid for {n_tiles} tiles within {max_rows}x{max_cols}")
+
+
+def _create_sharded_norm_program_config(
+    dim: int, grid: ttnn.CoreGrid, tile_padded_batch_rows: int, tile_size: int = TILE_SIZE
+) -> ttnn.LayerNormShardedMultiCoreProgramConfig:
+    """Create LayerNormShardedMultiCoreProgramConfig for RMSNorm."""
+    block_w = dim // grid.num_cores // tile_size
+    subblock_w = 4
+    while subblock_w > 0:
+        if block_w % subblock_w == 0:
+            break
+        subblock_w -= 1
+
+    return ttnn.LayerNormShardedMultiCoreProgramConfig(
+        compute_with_storage_grid_size=[grid.x, grid.y],
+        subblock_w=subblock_w,
+        block_h=tile_padded_batch_rows // tile_size,
+        block_w=block_w,
+        inplace=False,
+    )
+
+
+# =============================================================================
+# Input Tensor Utilities
+# =============================================================================
+
+
+def _load_input_device_tensor(x: ttnn.Tensor | LazyWeight, config: RMSNorm1DConfig, mode: str) -> ttnn.Tensor:
+    """
+    Resolve the input tensor to ttnn tensor if x is a LazyWeight, otherwise return as is.
+
+    For distributed prefill, uses sharded mesh_mapper_config to shard input across devices.
+    For decode/non-distributed prefill, replicates input (mesh_mapper_config=None).
+
+    Args:
+        x: Input tensor (ttnn.Tensor or LazyWeight wrapping torch tensor)
+        config: Resolved RMSNorm1DConfig
+        mode: "decode" or "prefill"
+
+    Returns:
+        ttnn.Tensor ready for the actual forward computation
+    """
+    assert mode in ("decode", "prefill"), f"mode must be 'decode' or 'prefill', got {mode}"
+
+    if isinstance(x, LazyWeight):
+        # Determine memory config based on mode (default to DRAM if not specified)
+        if mode == "decode":
+            mem_cfg = config.decode_input_memcfg or ttnn.DRAM_MEMORY_CONFIG
+        else:
+            mem_cfg = config.prefill_input_memcfg or ttnn.DRAM_MEMORY_CONFIG
+
+        # For distributed prefill, shard input on last dim; otherwise replicate
+        is_distributed = mode == "prefill" and config.prefill_distributed
+        if is_distributed:
+            num_devices = config.mesh_device.get_num_devices()
+            mesh_mapper_config = ttnn.MeshMapperConfig(
+                placements=[ttnn.PlacementReplicate(), ttnn.PlacementShard(-1)],
+                mesh_shape_override=ttnn.MeshShape(1, num_devices),
+            )
+        else:
+            mesh_mapper_config = None
+
+        resolved_x = resolve_lazy_weight(
+            x,
+            device=config.mesh_device,
+            memory_config=mem_cfg,
+            mesh_mapper_config=mesh_mapper_config,
+            layout=ttnn.TILE_LAYOUT,
+        )
+        return resolved_x.get_device_weight()
+
+    # Already a ttnn.Tensor - return as is
+    assert isinstance(x, ttnn.Tensor), f"x must be ttnn.Tensor or LazyWeight, got {type(x)}"
+    return x

--- a/models/experimental/llama32_1b_quasar/modules/rope/rope_1d.py
+++ b/models/experimental/llama32_1b_quasar/modules/rope/rope_1d.py
@@ -164,8 +164,8 @@ class RotarySetup1D(LightweightModule):
         self.load_device_weights()
         cfg = self.config
 
-        # Send to device if needed
-        if rot_idxs.device != cfg.device:
+        # Send to device if needed (tensor.device() is a method; returns None for host tensors)
+        if rot_idxs.device() != cfg.device:
             rot_idxs = ttnn.to_device(rot_idxs, cfg.device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
 
         # Embedding lookup: [1, batch] → [1, batch, head_dim]

--- a/models/experimental/llama32_1b_quasar/modules/rope/rope_1d.py
+++ b/models/experimental/llama32_1b_quasar/modules/rope/rope_1d.py
@@ -1,0 +1,511 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+TTTv2-style Rotary Position Embedding (RoPE) setup for 1D-topology devices.
+
+RotarySetup1D takes pre-computed cos/sin rotation matrices (as LazyWeight) and
+provides efficient position-based lookup at runtime.
+
+Core API:
+  - decode_forward(rot_idxs): Look up cos/sin rotation matrices from ttnn.Tensor indices
+  - prefill_forward(start_pos, seq_len): Slice cos/sin matrices for prefill
+  - get_both_trans_mats(): Decode + prefill transformation matrices (read-only)
+
+Backward-compatible API (will retire with TTTv1):
+  - get_rot_idxs(position_idxs): Convert torch position indices to ttnn tensor
+  - get_rot_mats(position_idxs): Combined get_rot_idxs + decode_forward
+
+Helper:
+  - prepare_rot_idxs(config, position_idxs, on_host): Standalone torch→ttnn index conversion
+
+Note: torch is used at construction time for building transformation matrices.
+      The decode_forward() and prefill_forward() methods use only ttnn ops.
+"""
+
+from dataclasses import dataclass, replace
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+import ttnn
+from models.experimental.llama32_1b_quasar.lightweightmodule import LightweightModule
+from models.experimental.llama32_1b_quasar.modules.lazy_weight import LazyWeight, resolve_lazy_weight
+from models.experimental.llama32_1b_quasar.tensor_utils import TILE_SIZE, get_rot_transformation_mat
+from models.experimental.llama32_1b_quasar.utility_functions import nearest_32
+
+# =============================================================================
+# Config dataclass
+# =============================================================================
+
+
+@dataclass
+class Rope1DConfig:
+    """
+    Configuration for RotarySetup1D.
+
+    Simple usage:
+        rope = RotarySetup1D(cos_lw, sin_lw, max_batch_size=32)
+
+    Power API:
+        config = Rope1DConfig(cos_lw, sin_lw, max_batch_size=32,
+                              device=mesh_device, use_qk_fused=True)
+        rope = RotarySetup1D.from_config(config)
+    """
+
+    # Required: cos/sin embedding lookup tables as LazyWeight
+    # source shape: [1, 1, max_seq_len, head_dim]
+    cos_matrix: LazyWeight
+    sin_matrix: LazyWeight
+
+    # Required scalars
+    max_batch_size: int
+
+    # Optional (derived from weights if None)
+    head_dim: int | None = None  # derived from cos_matrix.source.shape[-1]
+    device: Any | None = None  # derived from cos_matrix.device
+    use_qk_fused: bool = False
+    datatype: ttnn.DataType = ttnn.bfloat16
+
+    # Derived (resolved by _resolve_rope_config, None = auto)
+    batch_size_per_device_group: int | None = None
+    core_grid: Any | None = None
+    batch_grid: Any | None = None
+    decode_trans_mat_mem_config: Optional[ttnn.MemoryConfig] = None
+    cos_sin_shard_mem_config: Optional[ttnn.MemoryConfig] = None
+
+    # Internal: transformation matrix LazyWeights (built by _resolve_rope_config)
+    _decode_trans_mat: Optional[LazyWeight] = None
+    _prefill_trans_mat: Optional[LazyWeight] = None
+
+
+# =============================================================================
+# RotarySetup1D
+# =============================================================================
+
+
+class RotarySetup1D(LightweightModule):
+    """
+    Rotary position embedding setup for non-TG (1D) devices.
+
+    Takes pre-computed cos/sin lookup tables as LazyWeight and provides
+    efficient position-based rotation matrix lookup at runtime.
+
+    Simple API:
+        rope = RotarySetup1D(cos_lw, sin_lw, max_batch_size=32)
+        rot_idxs = prepare_rot_idxs(rope.config, position_idxs)
+        [cos, sin] = rope.decode_forward(rot_idxs)
+        [cos, sin] = rope.prefill_forward(start_pos=0, seq_len=128)
+
+    Power API:
+        config = Rope1DConfig(cos_lw, sin_lw, max_batch_size=32, use_qk_fused=True)
+        rope = RotarySetup1D.from_config(config)
+
+    Backward-compatible API:
+        rope.get_rot_mats(position_idxs)  # accepts torch.Tensor or ttnn.Tensor
+        rope.get_rot_idxs(position_idxs, on_host=True)
+    """
+
+    def __init__(
+        self,
+        cos_matrix: LazyWeight,
+        sin_matrix: LazyWeight,
+        max_batch_size: int,
+    ) -> None:
+        """
+        Simple API — takes cos/sin as LazyWeight, derives all other config.
+
+        Args:
+            cos_matrix: LazyWeight with source shape [1, 1, max_seq_len, head_dim].
+            sin_matrix: LazyWeight with source shape [1, 1, max_seq_len, head_dim].
+            max_batch_size: Maximum batch size for decode mode.
+        """
+        super().__init__()
+        config = Rope1DConfig(
+            cos_matrix=cos_matrix,
+            sin_matrix=sin_matrix,
+            max_batch_size=max_batch_size,
+        )
+        self.config = _resolve_rope_config(config)
+        self._device_weights_loaded = False
+
+    @classmethod
+    def from_config(cls, config: Rope1DConfig):
+        """Power API — construct from config dataclass with full customization."""
+        instance = object.__new__(cls)
+        super(RotarySetup1D, instance).__init__()
+        instance.config = _resolve_rope_config(config)
+        instance._device_weights_loaded = False
+        return instance
+
+    def load_device_weights(self):
+        """Load cos/sin and transformation matrices to device. Called lazily on first use."""
+        if self._device_weights_loaded:
+            return
+
+        cfg = self.config
+
+        self.cos_matrix = cfg.cos_matrix.get_device_weight()
+        self.sin_matrix = cfg.sin_matrix.get_device_weight()
+        self.transformation_mat = cfg._decode_trans_mat.get_device_weight()
+        self.transformation_mat_prefill = cfg._prefill_trans_mat.get_device_weight()
+
+        self._device_weights_loaded = True
+
+    # ---- Core API ----
+
+    def decode_forward(self, rot_idxs: ttnn.Tensor) -> List[ttnn.Tensor]:
+        """Look up cos/sin rotation matrices for given position indices (decode mode).
+
+        Args:
+            rot_idxs: ttnn.Tensor of shape [1, batch], dtype uint32.
+
+        Returns:
+            [cos, sin] — height-sharded rotation matrices.
+        """
+        self.load_device_weights()
+        cfg = self.config
+
+        # Send to device if needed
+        if rot_idxs.device != cfg.device:
+            rot_idxs = ttnn.to_device(rot_idxs, cfg.device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+
+        # Embedding lookup: [1, batch] → [1, batch, head_dim]
+        cos = ttnn.embedding(rot_idxs, self.cos_matrix, layout=ttnn.TILE_LAYOUT)
+        sin = ttnn.embedding(rot_idxs, self.sin_matrix, layout=ttnn.TILE_LAYOUT)
+
+        # Reshape: [1, batch, head_dim] → [1, 1, batch, head_dim] → [1, batch, 1[32], head_dim]
+        cos = ttnn.unsqueeze_to_4D(cos)
+        sin = ttnn.unsqueeze_to_4D(sin)
+        cos = ttnn.transpose(cos, 1, 2)
+        sin = ttnn.transpose(sin, 1, 2)
+
+        # Trim to actual batch size.
+        # When batch_size_per_device_group is not a multiple of TILE_SIZE (e.g., batch=1),
+        # the embedding produces nearest_32(batch) rows that need trimming.
+        # When tile-aligned (e.g., batch=32), this is a no-op slice.
+        cos = cos[:, : cfg.batch_size_per_device_group, :, :]
+        sin = sin[:, : cfg.batch_size_per_device_group, :, :]
+
+        # Shard to batch cores
+        cos = ttnn.interleaved_to_sharded(cos, cfg.cos_sin_shard_mem_config)
+        sin = ttnn.interleaved_to_sharded(sin, cfg.cos_sin_shard_mem_config)
+
+        return [cos, sin]
+
+    def prefill_forward(self, start_pos: int, seq_len: int, pad_to: int | None = None) -> List[ttnn.Tensor]:
+        """Slice cos/sin matrices for prefill mode.
+
+        This replaces the duplicated cos/sin slicing logic found in every model's
+        prepare_inputs_prefill(). Models no longer need to reach into
+        rope_setup.cos_matrix / sin_matrix directly.
+
+        Args:
+            start_pos: Starting position in the sequence.
+            seq_len: Number of positions to slice (typically the padded input length S).
+            pad_to: If set, zero-pad the sequence dim to this length (for SDPA alignment).
+                    Ignored when pad_to <= seq_len.
+
+        Returns:
+            [cos_slice, sin_slice] — interleaved DRAM tensors,
+            shape [1, 1, seq_len (or pad_to), head_dim].
+        """
+        self.load_device_weights()
+
+        mat_len = self.cos_matrix.shape[2]
+        end_pos = start_pos + seq_len
+        assert mat_len >= end_pos, f"Requested range [{start_pos}:{end_pos}) exceeds cos/sin table length {mat_len}"
+
+        cos_slice = self.cos_matrix[:, :, start_pos:end_pos, :]
+        sin_slice = self.sin_matrix[:, :, start_pos:end_pos, :]
+
+        if pad_to is not None and pad_to > seq_len:
+            pad_len = pad_to - seq_len
+            padding = [(0, 0)] * 4
+            padding[2] = (0, pad_len)
+            cos_slice = ttnn.pad(cos_slice, padding=padding, value=0.0)
+            sin_slice = ttnn.pad(sin_slice, padding=padding, value=0.0)
+
+        return [cos_slice, sin_slice]
+
+    def forward(self, mode: str, **kwargs) -> List[ttnn.Tensor]:
+        """Dispatch to decode_forward or prefill_forward based on mode.
+
+        Args:
+            mode: "decode" or "prefill".
+            **kwargs: Forwarded to the underlying method.
+                decode:  rot_idxs (ttnn.Tensor)
+                prefill: start_pos (int), seq_len (int), pad_to (int | None)
+        """
+        if mode == "decode":
+            return self.decode_forward(**kwargs)
+        elif mode == "prefill":
+            return self.prefill_forward(**kwargs)
+        else:
+            raise ValueError(f"Unknown mode: {mode!r}. Expected 'decode' or 'prefill'.")
+
+    def get_both_trans_mats(self) -> Dict[str, ttnn.Tensor]:
+        """Return both decode and prefill transformation matrices."""
+        self.load_device_weights()
+        return {"decode": self.transformation_mat, "prefill": self.transformation_mat_prefill}
+
+    # ---- Backward-compatible API (will retire with TTTv1) ----
+
+    def get_rot_idxs(self, position_idxs: "torch.Tensor", on_host: bool = False) -> ttnn.Tensor:
+        """Convert torch position indices to ttnn tensor. Delegates to prepare_rot_idxs()."""
+        return prepare_rot_idxs(self.config, position_idxs, on_host=on_host)
+
+    def get_rot_mats(
+        self,
+        position_idxs: "Union[torch.Tensor, ttnn.Tensor]",
+        return_rot_idxs: bool = False,
+    ) -> "Union[List[ttnn.Tensor], Tuple[List[ttnn.Tensor], ttnn.Tensor]]":
+        """Look up cos/sin from torch or ttnn position indices.
+
+        For new code, prefer: rot_idxs = prepare_rot_idxs(...); rope.decode_forward(rot_idxs)
+        """
+        import torch
+
+        if isinstance(position_idxs, torch.Tensor):
+            rot_idxs = self.get_rot_idxs(position_idxs)
+        else:
+            rot_idxs = position_idxs
+
+        cos_sin = self.decode_forward(rot_idxs)
+
+        if return_rot_idxs:
+            return cos_sin, rot_idxs
+        return cos_sin
+
+    # ---- Factory for TTTv1 backward compatibility ----
+
+    @classmethod
+    def from_model_args(cls, device: Any, args, model_name: str = "unknown"):
+        """Factory method for backward compatibility with ModelArgs.
+
+        Args:
+            device: MeshDevice or single device.
+            args: Model arguments (ModelArgs instance).
+            model_name: Model name for logging (default "unknown").
+        """
+        if args.is_galaxy:
+            raise ValueError("RotarySetup1D cannot be used for Galaxy devices.")
+
+        from models.tt_transformers.tt.common import rope_scaling_model_factory
+
+        rope_scaling = None
+        if hasattr(args, "rope_scaling_params") and args.rope_scaling_params is not None:
+            rope_scaling = rope_scaling_model_factory(
+                args.rope_scaling_params, getattr(args, "original_max_context_len", None)
+            )
+
+        # Compute cos/sin torch tensors using TTTv1 reference
+        from models.tt_transformers.tt.rope import compute_gather_cos_sin
+
+        cos_torch, sin_torch = compute_gather_cos_sin(
+            dhead=args.head_dim, end=2 * args.max_seq_len, theta=args.rope_theta, rope_scaling=rope_scaling
+        )
+
+        # Wrap in LazyWeight
+        cos_lw = LazyWeight(source=cos_torch, device=device)
+        sin_lw = LazyWeight(source=sin_torch, device=device)
+
+        config = Rope1DConfig(
+            cos_matrix=cos_lw,
+            sin_matrix=sin_lw,
+            max_batch_size=args.max_batch_size,
+            head_dim=args.head_dim,
+            device=device,
+            use_qk_fused=getattr(args, "use_qk_fused", False),
+            datatype=ttnn.bfloat16,
+        )
+        return cls.from_config(config)
+
+
+# =============================================================================
+# Config resolver
+# =============================================================================
+
+
+def _resolve_rope_config(config: Rope1DConfig) -> Rope1DConfig:
+    """Resolve None fields in Rope1DConfig to sensible defaults.
+
+    Fills in:
+      - head_dim: derived from cos_matrix.source.shape[-1]
+      - device: derived from cos_matrix.device if None
+      - batch_size_per_device_group, core_grid, batch_grid
+      - decode_trans_mat_mem_config, cos_sin_shard_mem_config
+      - cos_matrix/sin_matrix LazyWeight fields: device, memory_config, layout, dtype
+      - _decode_trans_mat, _prefill_trans_mat: internal transformation matrix LazyWeights
+    """
+    to_set = {}
+
+    # --- Phase 1: Foundational fields ---
+
+    head_dim = config.head_dim
+    if head_dim is None:
+        head_dim = config.cos_matrix.source.shape[-1]
+        to_set["head_dim"] = head_dim
+
+    device = config.device
+    if device is None:
+        device = config.cos_matrix.device
+    if device is None:
+        device = ttnn.GetDefaultDevice()
+    if config.device is None:
+        to_set["device"] = device
+
+    assert device is not None, "device must be available at this point!"
+
+    # --- Phase 2: Derived scalars ---
+
+    batch_size_per_device_group = config.batch_size_per_device_group
+    if batch_size_per_device_group is None:
+        batch_size_per_device_group = config.max_batch_size * 2 if config.use_qk_fused else config.max_batch_size
+        to_set["batch_size_per_device_group"] = batch_size_per_device_group
+
+    core_grid = config.core_grid
+    if core_grid is None:
+        core_grid = device.compute_with_storage_grid_size()
+        to_set["core_grid"] = core_grid
+
+    batch_grid = config.batch_grid
+    if batch_grid is None:
+        batch_grid = ttnn.num_cores_to_corerangeset(batch_size_per_device_group, core_grid, row_wise=True)
+        to_set["batch_grid"] = batch_grid
+
+    # --- Phase 3: Memory configs ---
+
+    if config.decode_trans_mat_mem_config is None:
+        to_set["decode_trans_mat_mem_config"] = ttnn.create_sharded_memory_config(
+            shape=(TILE_SIZE, TILE_SIZE),
+            core_grid=batch_grid,
+            strategy=ttnn.ShardStrategy.HEIGHT,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+
+    if config.cos_sin_shard_mem_config is None:
+        to_set["cos_sin_shard_mem_config"] = ttnn.create_sharded_memory_config(
+            shape=(TILE_SIZE, head_dim),
+            core_grid=batch_grid,
+            strategy=ttnn.ShardStrategy.HEIGHT,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+
+    # --- Phase 4: Resolve LazyWeights ---
+
+    to_set["cos_matrix"] = resolve_lazy_weight(
+        config.cos_matrix,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        mesh_mapper_config=None,  # replicated
+        layout=ttnn.TILE_LAYOUT,
+        dtype=config.datatype,
+    )
+    to_set["sin_matrix"] = resolve_lazy_weight(
+        config.sin_matrix,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        mesh_mapper_config=None,  # replicated
+        layout=ttnn.TILE_LAYOUT,
+        dtype=config.datatype,
+    )
+
+    # --- Phase 5: Transformation matrix LazyWeights ---
+
+    decode_trans_mat_mem_config = to_set.get("decode_trans_mat_mem_config", config.decode_trans_mat_mem_config)
+
+    assert config._decode_trans_mat is None, "_decode_trans_mat is internal and should not be set by the user"
+    decode_trans_mat_source = get_rot_transformation_mat(dhead=TILE_SIZE).repeat(
+        1,
+        1,
+        batch_size_per_device_group,
+        1,
+    )
+    to_set["_decode_trans_mat"] = LazyWeight(
+        source=decode_trans_mat_source,
+        device=device,
+        memory_config=decode_trans_mat_mem_config,
+        mesh_mapper_config=None,  # replicated
+        layout=ttnn.TILE_LAYOUT,
+        dtype=config.datatype,
+    )
+
+    assert config._prefill_trans_mat is None, "_prefill_trans_mat is internal and should not be set by the user"
+    prefill_trans_mat_source = get_rot_transformation_mat(dhead=TILE_SIZE)
+    to_set["_prefill_trans_mat"] = LazyWeight(
+        source=prefill_trans_mat_source,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        mesh_mapper_config=None,  # replicated
+        layout=ttnn.TILE_LAYOUT,
+        dtype=config.datatype,
+    )
+
+    return replace(config, **to_set)
+
+
+# =============================================================================
+# Standalone helper function
+# =============================================================================
+
+
+def prepare_rot_idxs(
+    config: Rope1DConfig,
+    position_idxs: "torch.Tensor",
+    on_host: bool = False,
+) -> ttnn.Tensor:
+    """Convert torch position indices to a TTNN rotation index tensor.
+
+    This is the standalone equivalent of RotarySetup1D.get_rot_idxs().
+    Useful for pre-allocating host tensors for trace mode.
+
+    Args:
+        config: Resolved Rope1DConfig (device must be set).
+        position_idxs: 1D torch tensor of position indices, shape [batch].
+        on_host: If True, return tensor on host (for later copy_host_to_device_tensor).
+
+    Returns:
+        ttnn tensor of shape [1, nearest_32(batch)], dtype uint32.
+    """
+    import torch
+
+    assert isinstance(position_idxs, torch.Tensor), "Position ids must be a torch tensor"
+    assert len(position_idxs.shape) == 1, "position idxs must be a [batch] tensor"
+    assert config.device is not None, "config.device must be set (use a resolved config)"
+    assert config.batch_size_per_device_group is not None, "config must be resolved (_resolve_rope_config)"
+
+    if config.use_qk_fused:
+        position_idxs = position_idxs.repeat(2)
+        assert (
+            position_idxs.shape[0] == config.batch_size_per_device_group
+        ), "Position idxs must match batch_size_per_device_group"
+
+    batch = position_idxs.shape[0]
+    position_idxs = position_idxs.reshape(1, batch)
+    assert torch.min(position_idxs) >= 0, "Position idxs must be non-negative"
+
+    # Pad to nearest tile boundary
+    pad_size = nearest_32(batch) - batch
+    position_idxs = torch.nn.functional.pad(position_idxs, (0, pad_size), "constant", 0)
+
+    device = config.device
+
+    if on_host:
+        rot_idxs = ttnn.as_tensor(
+            position_idxs,
+            dtype=ttnn.uint32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            mesh_mapper=ttnn.replicate_tensor_to_mesh_mapper(device),
+        )
+    else:
+        rot_idxs = ttnn.as_tensor(
+            position_idxs,
+            dtype=ttnn.uint32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            device=device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=ttnn.replicate_tensor_to_mesh_mapper(device),
+        )
+
+    return rot_idxs

--- a/models/experimental/llama32_1b_quasar/modules/sampling/penalties_1d.py
+++ b/models/experimental/llama32_1b_quasar/modules/sampling/penalties_1d.py
@@ -1,0 +1,578 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Penalties1D: Presence/frequency/repetition penalty transforms for 1D mesh topologies.
+
+TTTv2 module — declarative config, lazy buffer allocation, no mutable module state.
+Penalty state (PenaltyParams, PenaltyAccumulator) is caller-constructed and passed
+as arguments to forward methods.
+
+See also: models/common/sampling/tt_penalties.py (TTTv1 source)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from typing import Any, Optional
+
+import ttnn
+from models.experimental.llama32_1b_quasar.lightweightmodule import LightweightModule
+from models.experimental.llama32_1b_quasar.modules.lazy_buffer import LazyBuffer, resolve_lazy_buffer
+
+# ---------------------------------------------------------------------------
+# Caller-constructed penalty state dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class PenaltyParams:
+    """Per-request penalty constants. Set before the decode loop, read-only during it.
+
+    Caller allocates tensors directly (via LazyBuffer, ttnn.from_torch, or any other means)
+    and constructs this dataclass. The module does NOT provide a convenience creation method.
+    """
+
+    prompt_mask: ttnn.Tensor  # [max_batch_size, vocab_per_device], int32, sharded
+    presence_penalties: ttnn.Tensor  # [max_batch_size, 1], bfloat16
+    frequency_penalties: ttnn.Tensor  # [max_batch_size, 1], bfloat16
+    repetition_penalties: ttnn.Tensor  # [max_batch_size, 1], bfloat16
+    inverse_repetition_penalties: ttnn.Tensor  # [max_batch_size, 1], bfloat16 (precomputed 1/rep)
+
+
+@dataclass
+class PenaltyAccumulator:
+    """Per-step accumulator state. Mutated by update_output_tokens() after each sampled token.
+
+    Caller allocates tensors directly and constructs this dataclass.
+    """
+
+    output_mask: ttnn.Tensor  # [max_batch_size, vocab_per_device], int32, sharded
+    output_counts: ttnn.Tensor  # [max_batch_size, vocab_per_device], int32, sharded
+    output_counts_gathered: ttnn.Tensor  # [max_batch_size, vocab_size], int32, replicated
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Penalties1DConfig:
+    """Declarative config for Penalties1D.
+
+    Buffer fields use the triple-type pattern: ``LazyBuffer | ttnn.Tensor | None``.
+
+    - ``None`` → auto-filled by ``_resolve_penalties1d_config()`` with topology-aware defaults.
+    - ``LazyBuffer`` → declarative spec, materialized lazily in ``load_device_buffers()``.
+    - ``ttnn.Tensor`` → pre-allocated device tensor, used directly (power user bypass).
+    """
+
+    vocab_size: int  # Required. Caller pre-pads to be divisible by num_devices.
+    mesh_device: Optional[ttnn.MeshDevice] = None  # None → GetDefaultDevice()
+    max_batch_size: int = 32
+    sub_core_grids: Any = None  # From args.sub_core_grids; passed to ttnn ops via op_kwargs
+
+    # --- Persistent buffer specs (LazyBuffer | ttnn.Tensor | None) ---
+    # Sharded vocab buffers: [max_batch_size, vocab_size], int32, TILE, sharded across devices
+    prompt_mask: LazyBuffer | ttnn.Tensor | None = None
+    output_mask: LazyBuffer | ttnn.Tensor | None = None
+    output_counts: LazyBuffer | ttnn.Tensor | None = None
+    # Replicated vocab buffers: [max_batch_size, vocab_size], int32, replicated
+    output_counts_gathered: LazyBuffer | ttnn.Tensor | None = None
+    zeros: LazyBuffer | ttnn.Tensor | None = None
+    # Utility buffers
+    decode_src: LazyBuffer | ttnn.Tensor | None = None  # [max_batch_size, 1], int32, ROW_MAJOR, ones
+    # BF16 penalty param buffers: [max_batch_size, 1], bfloat16, TILE, replicated
+    presence_penalties: LazyBuffer | ttnn.Tensor | None = None
+    frequency_penalties: LazyBuffer | ttnn.Tensor | None = None
+    repetition_penalties: LazyBuffer | ttnn.Tensor | None = None
+    inverse_repetition_penalties: LazyBuffer | ttnn.Tensor | None = None
+
+    @staticmethod
+    def _buf_resolved(buf) -> bool:
+        if buf is None:
+            return False
+        if isinstance(buf, ttnn.Tensor):
+            return True
+        return buf.is_resolved()
+
+    def is_resolved(self) -> bool:
+        return self.mesh_device is not None and all(
+            self._buf_resolved(getattr(self, f))
+            for f in (
+                "prompt_mask",
+                "output_mask",
+                "output_counts",
+                "output_counts_gathered",
+                "zeros",
+                "decode_src",
+                "presence_penalties",
+                "frequency_penalties",
+                "repetition_penalties",
+                "inverse_repetition_penalties",
+            )
+        )
+
+
+# ---------------------------------------------------------------------------
+# Module
+# ---------------------------------------------------------------------------
+
+
+class Penalties1D(LightweightModule):
+    """Presence/frequency/repetition penalty transforms for 1D mesh topologies.
+
+    Pure compute pipeline — all penalty state (PenaltyParams, PenaltyAccumulator) is
+    caller-constructed and passed as arguments to forward methods.
+    """
+
+    def __init__(self, vocab_size: int, mesh_device: ttnn.MeshDevice | None = None, **kwargs):
+        """Happy path — minimal required args, config auto-resolved."""
+        super().__init__()
+        self.config = _resolve_penalties1d_config(
+            Penalties1DConfig(vocab_size=vocab_size, mesh_device=mesh_device, **kwargs)
+        )
+        self._device_buffers_loaded = False
+
+    @classmethod
+    def from_config(cls, config: Penalties1DConfig) -> Penalties1D:
+        """Power path — fully custom config."""
+        instance = object.__new__(cls)
+        super(Penalties1D, instance).__init__()
+        instance.config = _resolve_penalties1d_config(config)
+        instance._device_buffers_loaded = False
+        return instance
+
+    @classmethod
+    def from_model_args(cls, mesh_device, args) -> Penalties1D:
+        """Backward compat factory for TTTv1 model args."""
+        cluster_shape = mesh_device.shape
+        if min(cluster_shape) > 1:
+            raise ValueError(
+                f"Penalties1D only supports 1D mesh topologies, got shape {cluster_shape}. "
+                "Use TTPenalties for Galaxy (2D) topologies."
+            )
+        padded_vocab_size = getattr(args, "padded_vocab_size", None)
+        vocab_size = padded_vocab_size if padded_vocab_size is not None else args.vocab_size
+        sub_core_grids = getattr(args, "sub_core_grids", None)
+        return cls(vocab_size=vocab_size, mesh_device=mesh_device, sub_core_grids=sub_core_grids)
+
+    # -- Device buffers (idempotent) ------------------------------------------
+
+    def load_device_buffers(self):
+        """Materialize module-owned buffers. Called on first forward; idempotent."""
+        if self._device_buffers_loaded:
+            return
+
+        assert self.config.is_resolved(), "config must be resolved before loading device buffers!"
+        cfg = self.config
+
+        # Module-owned buffers
+        self._decode_src = _materialize(cfg.decode_src)
+        self._zeros = _materialize(cfg.zeros)
+
+        # Derived topology fields
+        self._cluster_shape = cfg.mesh_device.shape
+        self._num_devices = max(self._cluster_shape[-1], self._cluster_shape[-2])
+        self._op_kwargs = {"sub_core_grids": cfg.sub_core_grids} if cfg.sub_core_grids else {}
+        self._replicate_mapper = ttnn.ShardTensor2dMesh(
+            cfg.mesh_device, dims=(None, None), mesh_shape=self._cluster_shape
+        )
+        self._use_low_perf_tilize = cfg.sub_core_grids is not None
+
+        # Slice tensors for scatter → slice (port from tt_penalties.py:117-139)
+        self._slice_start, self._slice_end = self._build_slice_tensors()
+
+        self._device_buffers_loaded = True
+
+    # -- Lifecycle methods (per-request setup) ---------------------------------
+
+    def init_prompt_penalties(
+        self,
+        params: PenaltyParams,
+        accum: PenaltyAccumulator,
+        prompt_tokens: "torch.Tensor",
+    ) -> None:
+        """Record prompt token positions into params.prompt_mask via scatter_add.
+
+        Called once per request before the decode loop.
+        Port of TTPenalties.reset_prompt_tokens (tt_penalties.py:194-212).
+        """
+        # todo)) can we get rid of the torch import here? --> will rethink the boundaries of the module when active development is done on the TTTv1 side
+        import torch
+
+        self.load_device_buffers()
+
+        prompt_tokens_2d = prompt_tokens.reshape(-1, prompt_tokens.shape[-1])
+        prompt_tokens_2d = self._pad_batch_to_max(prompt_tokens_2d, pad_value=-1)
+
+        src_host = (prompt_tokens_2d != -1).to(torch.int32)
+        idx_host = torch.where(prompt_tokens_2d == -1, torch.zeros_like(prompt_tokens_2d), prompt_tokens_2d)
+
+        prompt_tokens_tt = ttnn.from_torch(
+            idx_host,
+            device=self.config.mesh_device,
+            dtype=ttnn.int32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            mesh_mapper=self._replicate_mapper,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+        src_tt = ttnn.from_torch(
+            src_host,
+            device=self.config.mesh_device,
+            dtype=ttnn.int32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            mesh_mapper=self._replicate_mapper,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+        self._token_bin_counts_and_mask(new_tokens=prompt_tokens_tt, src=src_tt, mask=params.prompt_mask)
+
+    # -- Forward methods ------------------------------------------------------
+
+    def decode_forward(
+        self,
+        logits: ttnn.Tensor,
+        params: PenaltyParams,
+        accum: PenaltyAccumulator,
+    ) -> ttnn.Tensor:
+        """Apply presence/frequency/repetition penalties to logits.
+
+        Port of apply_penalties() at tt_penalties.py:32-75.
+        """
+        self.load_device_buffers()
+        op = self._op_kwargs
+
+        original_shape = logits.shape
+        logits = ttnn.reshape(logits, (-1, original_shape[-1]))
+
+        # Presence: logits -= typecast(output_mask, bf16) * presence
+        presence_term = ttnn.multiply(
+            ttnn.typecast(accum.output_mask, ttnn.bfloat16, **op), params.presence_penalties, **op
+        )
+        presence_term_bf16 = ttnn.typecast(presence_term, ttnn.bfloat16, **op)
+        presence_term.deallocate()
+        logits = ttnn.subtract(logits, presence_term_bf16, output_tensor=logits, **op)
+        presence_term_bf16.deallocate()
+
+        # Frequency: logits -= typecast(output_counts, bf16) * frequency
+        output_counts_bf16 = ttnn.typecast(accum.output_counts, ttnn.bfloat16, **op)
+        freq_term = ttnn.multiply(output_counts_bf16, params.frequency_penalties, **op)
+        output_counts_bf16.deallocate()
+        freq_term_bf16 = ttnn.typecast(freq_term, ttnn.bfloat16, **op)
+        freq_term.deallocate()
+        logits = ttnn.subtract(logits, freq_term_bf16, output_tensor=logits, **op)
+        freq_term_bf16.deallocate()
+
+        # Repetition: sign-dependent scaling
+        combined_mask_int32 = ttnn.add(params.prompt_mask, accum.output_mask, **op)
+        combined_mask = ttnn.typecast(combined_mask_int32, ttnn.bfloat16, **op)
+        combined_mask_int32.deallocate()
+        penalties = ttnn.where(combined_mask, params.repetition_penalties, 1.0, **op)
+        inverse_penalties = ttnn.where(combined_mask, params.inverse_repetition_penalties, 1.0, **op)
+        combined_mask.deallocate()
+
+        logits_bf16 = ttnn.typecast(logits, ttnn.bfloat16, **op)
+        logits_gt1 = ttnn.gt(logits_bf16, 0, **op)
+        logits_bf16.deallocate()
+        scaling = ttnn.where(logits_gt1, inverse_penalties, penalties, **op)
+        logits_gt1.deallocate()
+        penalties.deallocate()
+        inverse_penalties.deallocate()
+        logits = ttnn.multiply(logits, scaling, output_tensor=logits, **op)
+        scaling.deallocate()
+
+        return ttnn.reshape(logits, original_shape)
+
+    def forward(self, logits, params=None, accum=None, **kwargs) -> ttnn.Tensor:
+        """Dispatcher. If params/accum are None, returns logits unchanged."""
+        if params is None or accum is None:
+            return logits
+        if "prompt_tokens" in kwargs:
+            self.init_prompt_penalties(params, accum, kwargs["prompt_tokens"])
+            return logits
+        return self.decode_forward(logits, params, accum)
+
+    # -- Accumulator operations (called AFTER sampling) -----------------------
+
+    def update_output_tokens(self, accum: PenaltyAccumulator, new_tokens: ttnn.Tensor) -> None:
+        """Update accum with newly sampled tokens.
+
+        Port of TTPenalties.update_output_tokens (tt_penalties.py:247-264).
+        Called after each decode step, between decode_forward and the next step.
+        """
+        self.load_device_buffers()
+
+        if (new_tokens.shape[-1] == self.config.max_batch_size and new_tokens.shape[-2] == 1) or (
+            new_tokens.shape[-2] == self.config.max_batch_size and new_tokens.shape[-1] == 1
+        ):
+            # Standard decode: [..., 1, B] or row-sharded: [..., B, 1] → [B, 1]
+            new_tokens = ttnn.reshape(new_tokens, [self.config.max_batch_size, 1], **self._op_kwargs)
+            src = self._decode_src
+        else:
+            # todo)) can we get rid of the torch import here? --> will rethink the boundaries of the module when active development is done on the TTTv1 side
+            import torch
+
+            src = ttnn.from_torch(
+                torch.ones(self.config.max_batch_size, new_tokens.shape[-1], dtype=torch.int32),
+                device=self.config.mesh_device,
+                dtype=ttnn.int32,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+                mesh_mapper=self._replicate_mapper,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            )
+        self._token_bin_counts_and_mask(
+            new_tokens=new_tokens,
+            counts=accum.output_counts_gathered,
+            src=src,
+            counts_sliced=accum.output_counts,
+            mask=accum.output_mask,
+        )
+
+    def reset_output_tokens(self, accum: PenaltyAccumulator, tokens: "torch.Tensor | None" = None) -> None:
+        """Zero out accumulator buffers. Optionally re-initialize from provided tokens.
+
+        Port of TTPenalties.reset_output_tokens (tt_penalties.py:214-245).
+        """
+        self.load_device_buffers()
+        op = self._op_kwargs
+
+        accum.output_mask = ttnn.mul(accum.output_mask, 0, output_tensor=accum.output_mask, **op)
+        accum.output_counts = ttnn.mul(accum.output_counts, 0, output_tensor=accum.output_counts, **op)
+        accum.output_counts_gathered = ttnn.mul(
+            accum.output_counts_gathered, 0, output_tensor=accum.output_counts_gathered, **op
+        )
+
+        if tokens is not None:
+            # todo)) can we get rid of the torch import here? --> will rethink the boundaries of the module when active development is done on the TTTv1 side
+            import torch
+
+            tokens_2d = tokens.reshape(-1, tokens.shape[-1])
+            tokens_2d = self._pad_batch_to_max(tokens_2d, pad_value=-1)
+            src_host = (tokens_2d != -1).to(torch.int32)
+            idx_host = torch.where(tokens_2d == -1, torch.zeros_like(tokens_2d), tokens_2d)
+
+            tokens_tt = ttnn.from_torch(
+                idx_host,
+                device=self.config.mesh_device,
+                dtype=ttnn.uint32,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+                mesh_mapper=self._replicate_mapper,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            )
+            src_tt = ttnn.from_torch(
+                src_host,
+                device=self.config.mesh_device,
+                dtype=ttnn.int32,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+                mesh_mapper=self._replicate_mapper,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            )
+            self._token_bin_counts_and_mask(
+                new_tokens=tokens_tt,
+                counts=accum.output_counts_gathered,
+                src=src_tt,
+                counts_sliced=accum.output_counts,
+                mask=accum.output_mask,
+            )
+
+    # -- Private helpers ------------------------------------------------------
+
+    def _build_slice_tensors(self):
+        """Derive slice_start/slice_end from vocab_size and num_devices.
+
+        Port of tt_penalties.py:117-139.
+        """
+        # todo)) can we get rid of the torch import here? --> will rethink the boundaries of the module when active development is done on the TTTv1 side
+        import torch
+
+        cfg = self.config
+        vocab_per_dev = cfg.vocab_size // self._num_devices
+        d = torch.arange(self._num_devices, dtype=torch.int32)
+
+        if self._cluster_shape[-1] == self._num_devices:
+            shard_dims_slice = (None, 0)
+        else:
+            shard_dims_slice = (0, None)
+
+        start_1d = torch.empty(2 * self._num_devices, dtype=torch.int32)
+        start_1d[0::2] = 0
+        start_1d[1::2] = d * vocab_per_dev
+
+        end_1d = torch.empty(2 * self._num_devices, dtype=torch.int32)
+        end_1d[0::2] = cfg.max_batch_size
+        end_1d[1::2] = (d + 1) * vocab_per_dev
+
+        slice_start = ttnn.from_torch(
+            start_1d,
+            device=cfg.mesh_device,
+            mesh_mapper=ttnn.ShardTensor2dMesh(cfg.mesh_device, dims=shard_dims_slice, mesh_shape=self._cluster_shape),
+        )
+        slice_end = ttnn.from_torch(
+            end_1d,
+            device=cfg.mesh_device,
+            mesh_mapper=ttnn.ShardTensor2dMesh(cfg.mesh_device, dims=shard_dims_slice, mesh_shape=self._cluster_shape),
+        )
+        return slice_start, slice_end
+
+    def _pad_batch_to_max(self, tokens_2d: "torch.Tensor", pad_value: int) -> "torch.Tensor":
+        """Pad/truncate first dim to max_batch_size."""
+        # todo)) can we get rid of the torch import here? --> will rethink the boundaries of the module when active development is done on the TTTv1 side
+        import torch
+
+        if tokens_2d.dim() != 2:
+            raise ValueError(f"Expected 2D tensor [B, S], got {tokens_2d.shape}")
+        B, S = tokens_2d.shape
+        if B < self.config.max_batch_size:
+            pad = torch.full((self.config.max_batch_size - B, S), pad_value, dtype=tokens_2d.dtype)
+            return torch.cat([tokens_2d, pad], dim=0)
+        if B > self.config.max_batch_size:
+            return tokens_2d[: self.config.max_batch_size]
+        return tokens_2d
+
+    def _token_bin_counts_and_mask(self, new_tokens, src, counts=None, mask=None, counts_sliced=None):
+        """Scatter tokens into histogram, slice per-device, compute mask.
+
+        Port of TTPenalties.token_bin_counts_and_mask (tt_penalties.py:266-289).
+        """
+        op = self._op_kwargs
+        counts_new = ttnn.scatter_add(self._zeros, 1, new_tokens, src, **op)
+
+        new_tokens.deallocate()
+        counts_new = ttnn.tilize(counts_new, **op, use_low_perf=self._use_low_perf_tilize)
+        if counts is not None:
+            counts = ttnn.add(counts, counts_new, output_tensor=counts, **op)
+        else:
+            counts = counts_new
+        counts_sliced = ttnn.slice(
+            counts,
+            self._slice_start,
+            self._slice_end,
+            output_tensor=counts_sliced,
+            slice_dim=1,
+            num_devices=self._num_devices,
+            **op,
+        )
+
+        mask = ttnn.gt(counts_sliced, 0, output_tensor=mask, **op)
+        return counts, mask
+
+
+# ---------------------------------------------------------------------------
+# Config resolution
+# ---------------------------------------------------------------------------
+
+
+def _resolve_penalties1d_config(config: Penalties1DConfig) -> Penalties1DConfig:
+    """Fill None fields in config with topology-aware defaults.
+
+    Power users who set fields explicitly will NOT have them overwritten.
+    Mirrors the ``_resolve_mlp1d_config()`` pattern.
+    """
+    import torch  # lazy import — only needed for source tensor construction
+
+    to_set: dict = {}
+
+    # Phase 1: Device
+    mesh_device = config.mesh_device or ttnn.GetDefaultDevice()
+    to_set["mesh_device"] = mesh_device
+
+    # Phase 2: Topology → shard_dims (port from tt_penalties.py:97-103)
+    cluster_shape = mesh_device.shape
+    num_devices = max(cluster_shape[-1], cluster_shape[-2])
+    if cluster_shape[-1] == num_devices:
+        shard_dims = (None, 1)
+    else:
+        shard_dims = (1, None)
+
+    B = config.max_batch_size
+    V = config.vocab_size
+
+    # Build mesh mappers
+    shard_mapper = ttnn.ShardTensor2dMesh(mesh_device, dims=shard_dims, mesh_shape=cluster_shape)
+    replicate_mapper = None  # None → replicate_tensor_to_mesh_mapper in LazyBuffer
+
+    def _resolve_buf(field_val, defaults, source_factory):
+        """Resolve a single buffer field: None → LazyBuffer, LazyBuffer → fill, ttnn.Tensor → passthrough."""
+        if field_val is None:
+            return LazyBuffer(source=source_factory(), **defaults)
+        if isinstance(field_val, ttnn.Tensor):
+            return field_val
+        return resolve_lazy_buffer(field_val, **defaults)
+
+    # Phase 3: Sharded vocab buffers — [B, V], int32, TILE, sharded
+    sharded_vocab_defaults = dict(
+        dtype=ttnn.int32,
+        layout=ttnn.TILE_LAYOUT,
+        device=mesh_device,
+        mesh_mapper=shard_mapper,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    zeros_BV = lambda: torch.zeros(B, V, dtype=torch.int32)
+    to_set["prompt_mask"] = _resolve_buf(config.prompt_mask, sharded_vocab_defaults, zeros_BV)
+    to_set["output_mask"] = _resolve_buf(config.output_mask, sharded_vocab_defaults, zeros_BV)
+    to_set["output_counts"] = _resolve_buf(config.output_counts, sharded_vocab_defaults, zeros_BV)
+
+    # Phase 4: Replicated vocab buffers — [B, V], int32, replicated
+    replicated_vocab_defaults = dict(
+        dtype=ttnn.int32,
+        layout=ttnn.TILE_LAYOUT,
+        device=mesh_device,
+        mesh_mapper=replicate_mapper,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    to_set["output_counts_gathered"] = _resolve_buf(config.output_counts_gathered, replicated_vocab_defaults, zeros_BV)
+
+    replicated_vocab_rm_defaults = dict(
+        dtype=ttnn.int32,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=mesh_device,
+        mesh_mapper=replicate_mapper,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    to_set["zeros"] = _resolve_buf(config.zeros, replicated_vocab_rm_defaults, zeros_BV)
+
+    # Phase 5: Utility buffers
+    decode_src_defaults = dict(
+        dtype=ttnn.int32,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=mesh_device,
+        mesh_mapper=replicate_mapper,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    to_set["decode_src"] = _resolve_buf(
+        config.decode_src, decode_src_defaults, lambda: torch.ones(B, 1, dtype=torch.int32)
+    )
+
+    # Phase 6: BF16 penalty param buffers — [B, 1], bfloat16, TILE, replicated
+    bf16_param_defaults = dict(
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=mesh_device,
+        mesh_mapper=replicate_mapper,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    zeros_B1 = lambda: torch.zeros(B, 1, dtype=torch.float32)
+    for field_name in (
+        "presence_penalties",
+        "frequency_penalties",
+        "repetition_penalties",
+        "inverse_repetition_penalties",
+    ):
+        to_set[field_name] = _resolve_buf(getattr(config, field_name), bf16_param_defaults, zeros_B1)
+
+    resolved = replace(config, **to_set)
+    assert resolved.is_resolved(), "Config not fully resolved after _resolve_penalties1d_config"
+    return resolved
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _materialize(buf):
+    """Materialize a buffer field: ttnn.Tensor passthrough, LazyBuffer → get_device_buffer()."""
+    if isinstance(buf, ttnn.Tensor):
+        return buf
+    return buf.get_device_buffer()

--- a/models/experimental/llama32_1b_quasar/modules/sampling/sampling_1d.py
+++ b/models/experimental/llama32_1b_quasar/modules/sampling/sampling_1d.py
@@ -1,0 +1,856 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Sampling1D: Top-k/top-p/temperature sampling for 1D mesh topologies.
+
+TTTv2 module — declarative config, lazy buffer allocation, k/p/temp as per-call args.
+No mutable sampling state stored on the module.
+
+See also: models/common/sampling/tt_sampling.py (TTTv1 source)
+"""
+
+from __future__ import annotations
+
+import inspect
+import sys
+from dataclasses import dataclass, replace
+from typing import Any, Optional
+
+from loguru import logger
+
+import ttnn
+from models.experimental.llama32_1b_quasar.lightweightmodule import LightweightModule
+from models.experimental.llama32_1b_quasar.modules.lazy_buffer import LazyBuffer, resolve_lazy_buffer
+from models.experimental.llama32_1b_quasar.modules.tt_ccl import default_topology, get_tt_ccl
+from models.experimental.llama32_1b_quasar.sampling.vocab_padding import (
+    build_invalid_vocab_mask,
+    build_tail_invalid_vocab_mask,
+    get_vocab_shard_dims,
+)
+
+# ---------------------------------------------------------------------------
+# Power-of-2 helpers (local copies; keep this TTTv2 module self-contained)
+# ---------------------------------------------------------------------------
+
+
+def _is_power_of_2(n: int) -> bool:
+    return n > 0 and (n & (n - 1)) == 0
+
+
+def _upper_power_of_2(n: int) -> int:
+    if n <= 1:
+        return 1
+    return 1 << (n - 1).bit_length()
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Sampling1DConfig:
+    """Declarative config for Sampling1D.
+
+    Buffer fields use the triple-type pattern: ``LazyBuffer | ttnn.Tensor | None``.
+    k/p/temp are NOT stored here — they are per-call forward args.
+    """
+
+    vocab_size: int  # Required. Padded logits width; caller pre-pads to be divisible by num_devices.
+    valid_vocab_size: Optional[int] = None  # Real token vocabulary size. Defaults to vocab_size.
+    mesh_device: Optional[ttnn.MeshDevice] = None  # None → GetDefaultDevice()
+    tt_ccl: Any = None  # None → get_tt_ccl(mesh_device) if multi-device
+    max_batch_size: int = 32
+    max_top_k: int = 32
+    sub_core_grids: Any = None
+    sub_core_grid_topk: Any = None
+    start_core: Optional[ttnn.CoreCoord] = None  # None → CoreCoord(0,0)
+    num_gather_links: int = 1
+    sampling_memory_config: Optional[ttnn.MemoryConfig] = None  # None → DRAM_MEMORY_CONFIG
+    allow_force_argmax: bool = False
+    num_argmax_gather_links: Optional[int] = None  # None → same as num_gather_links
+    ag_topology: Optional[ttnn.Topology] = None  # None → Topology.Linear
+    # Pad each per-device logit shard up to the next power of 2 before ttnn.topk. Big device-perf
+    # win for non-power-of-2 vocab on the multi-device path (TTTv1's pad_logits_to_power_of_2).
+    # Strict TTTv1 parity: only the multi-device path is padded — the 1×1 multi_step split path
+    # is left unpadded.
+    pad_to_power_of_2: bool = False
+
+    # --- Persistent buffer specs (LazyBuffer | ttnn.Tensor | None) ---
+    # Static index buffers (computed from vocab_size + num_devices, never mutated)
+    index_offsets: LazyBuffer | ttnn.Tensor | None = None  # [1,1,32,max_top_k*num_devices], int32, TILE
+    local_indices: LazyBuffer | ttnn.Tensor | None = (
+        None  # [1,1,32,W], uint16, TILE (W=vocab for 1x1, per_dev_vocab otherwise)
+    )
+    invalid_vocab_mask: LazyBuffer | ttnn.Tensor | None = None  # Full fallback mask, sharded like logits
+    invalid_vocab_tail_mask: LazyBuffer | ttnn.Tensor | None = None  # Compact [1,1,32,tail] local mask
+    invalid_vocab_tail_width: int = 0
+    # Seed/ID buffers (seeds mutable via LazyBuffer.update(), user_ids static)
+    seeds: LazyBuffer | ttnn.Tensor | None = None  # [32], uint32, ROW_MAJOR
+    user_ids: LazyBuffer | ttnn.Tensor | None = None  # [32], uint32, ROW_MAJOR
+
+    @staticmethod
+    def _buf_resolved(buf) -> bool:
+        if buf is None:
+            return False
+        if isinstance(buf, ttnn.Tensor):
+            return True
+        return buf.is_resolved()
+
+    def is_resolved(self) -> bool:
+        if self.mesh_device is None:
+            return False
+        if self.mesh_device.get_num_devices() > 1 and self.tt_ccl is None:
+            return False
+        required_buffers = ["index_offsets", "local_indices", "seeds", "user_ids"]
+        if not all(self._buf_resolved(getattr(self, f)) for f in required_buffers):
+            return False
+        if self.valid_vocab_size is not None and self.valid_vocab_size < self.vocab_size:
+            return self._buf_resolved(self.invalid_vocab_mask) or self._buf_resolved(self.invalid_vocab_tail_mask)
+        return True
+
+
+# ---------------------------------------------------------------------------
+# Module
+# ---------------------------------------------------------------------------
+
+
+class Sampling1D(LightweightModule):
+    """Top-k/top-p/temperature sampling for 1D mesh topologies.
+
+    k/p/temp are per-call forward args — NOT stored on the module. This eliminates
+    mutable sampling state.
+    """
+
+    def __init__(self, vocab_size: int, mesh_device: ttnn.MeshDevice | None = None, **kwargs):
+        """Happy path — minimal required args."""
+        super().__init__()
+        self.config = _resolve_sampling1d_config(
+            Sampling1DConfig(vocab_size=vocab_size, mesh_device=mesh_device, **kwargs)
+        )
+        self._device_buffers_loaded = False
+        self._bind_strategy()
+
+    @classmethod
+    def from_config(cls, config: Sampling1DConfig) -> Sampling1D:
+        """Power path — fully custom config."""
+        instance = object.__new__(cls)
+        super(Sampling1D, instance).__init__()
+        instance.config = _resolve_sampling1d_config(config)
+        instance._device_buffers_loaded = False
+        instance._bind_strategy()
+        return instance
+
+    # -- Strategy binding (TTTv2: no if-else in forward) ----------------------
+
+    def _bind_strategy(self):
+        """Bind self._topk to the correct strategy based on mesh topology."""
+        cluster_shape = self.config.mesh_device.shape
+        self._multi_step_reduction = list(cluster_shape) == [1, 1]
+        if self._multi_step_reduction:
+            self._topk = self._topk_single_device
+        else:
+            self._topk = self._topk_multi_device
+
+        # Argmax strategy: single vs multi-device
+        num_devices = self.config.mesh_device.get_num_devices()
+        if num_devices > 1:
+            self._pre_argmax_gather = self._argmax_all_gather
+        else:
+            self._pre_argmax_gather = self._argmax_noop
+
+        # Memory config strategy for top-k post-processing
+        cfg = self.config
+        if cfg.sampling_memory_config is not None and cfg.sampling_memory_config != ttnn.DRAM_MEMORY_CONFIG:
+            self._prepare_topk_memory = self._topk_memory_sharded_roundtrip
+        else:
+            self._prepare_topk_memory = self._topk_memory_noop
+
+        # CCL introspection (port from TTSampling.__init__ lines 77-91)
+        self._line_all_gather = getattr(self.config.tt_ccl, "line_all_gather", None) if self.config.tt_ccl else None
+        self._line_all_gather_supports_buffer_key = False
+        self._line_all_gather_supports_dtype = False
+        if callable(self._line_all_gather):
+            try:
+                sig = inspect.signature(self._line_all_gather)
+                params = sig.parameters
+                self._line_all_gather_supports_buffer_key = "buffer_key" in params or any(
+                    p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values()
+                )
+                self._line_all_gather_supports_dtype = "dtype" in params or any(
+                    p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values()
+                )
+            except (TypeError, ValueError):
+                logger.warning("Unable to inspect line_all_gather signature")
+
+    # -- Device buffers (idempotent) ------------------------------------------
+
+    def load_device_buffers(self):
+        """Materialize all LazyBuffer fields from resolved config."""
+        if self._device_buffers_loaded:
+            return
+
+        assert self.config.is_resolved(), "config must be resolved before loading device buffers!"
+        cfg = self.config
+
+        self._index_offsets = _materialize(cfg.index_offsets)
+        self._local_indices = _materialize(cfg.local_indices)
+        self._invalid_vocab_mask = _materialize(cfg.invalid_vocab_mask) if cfg.invalid_vocab_mask is not None else None
+        self._invalid_vocab_tail_mask = (
+            _materialize(cfg.invalid_vocab_tail_mask) if cfg.invalid_vocab_tail_mask is not None else None
+        )
+        self._invalid_vocab_tail_width = cfg.invalid_vocab_tail_width
+        self._seeds = _materialize(cfg.seeds)
+        self._user_ids = _materialize(cfg.user_ids)
+        from models.experimental.llama32_1b_quasar.utils import LogProbsCalculator  # lazy: transitively imports torch
+
+        self._log_probs_calculator = LogProbsCalculator(cfg.mesh_device, cfg.sub_core_grids, cfg.tt_ccl)
+
+        # Pre-compute static sub_core_grids for ttnn.sampling()
+        self._sampling_sub_core_grids = (
+            ttnn.num_cores_to_corerangeset_in_subcoregrids(
+                cfg.start_core, cfg.max_batch_size, cfg.sub_core_grids, row_wise=True
+            )
+            if cfg.sub_core_grids is not None
+            else None
+        )
+
+        self._device_buffers_loaded = True
+
+    # -- Forward methods ------------------------------------------------------
+
+    def decode_forward(
+        self,
+        logits: ttnn.Tensor,
+        *,
+        k: ttnn.Tensor | None = None,
+        p: ttnn.Tensor | None = None,
+        temp: ttnn.Tensor | None = None,
+        seeds: ttnn.Tensor | None = None,
+        tt_out_tok: ttnn.Tensor | None = None,
+        enable_log_probs: bool | list[bool] = False,
+    ):
+        """Sample tokens from logits.
+
+        Args:
+            logits: Input logits tensor (sharded across devices)
+            k, p, temp: Per-call sampling parameters. All None + allow_force_argmax → argmax path.
+                All provided → top-k sampling path.
+            seeds: Optional per-call seed override. If None, uses config seeds buffer.
+            tt_out_tok: Optional output tensor to write results to.
+            enable_log_probs: Per-call logprobs toggle (bool, or per-user list of bool — if any
+                user is enabled the whole batch computes logprobs). Refreshed every call, so no
+                mutable logprobs state is stored on the module. Only the top-k path emits logprobs
+                (sampled-token logprob); the argmax path never does (see ``_sample_argmax``). The
+                calculator additionally requires a multi-device shard (T3K 1×8) — it returns ``None``
+                on 1×1/1×2 even when enabled.
+
+        Returns:
+            (token_ids, log_probs_or_none)
+        """
+        self.load_device_buffers()
+        cfg = self.config
+
+        # Per-call logprobs mode — refreshed each forward from the arg, never persisted on the
+        # module (TTTv2 principle: no mutable sampling state). Mirrors main's reset_params path.
+        self._log_probs_calculator.set_log_probs_mode(enable_log_probs)
+
+        # Route: argmax or top-k
+        if k is None and p is None and temp is None:
+            if cfg.allow_force_argmax:
+                return self._sample_argmax(logits, tt_out_tok)
+            else:
+                raise ValueError("k/p/temp are all None but allow_force_argmax is False")
+        if k is None or p is None or temp is None:
+            raise ValueError("k, p, temp must all be provided, or all be None (for argmax)")
+
+        return self._sample_topk(logits, k, p, temp, seeds, tt_out_tok)
+
+    def forward(self, logits, **kwargs):
+        """Dispatcher."""
+        return self.decode_forward(logits, **kwargs)
+
+    # -- Argmax path (port from tt_sampling.py:310-341) -----------------------
+
+    def _sample_argmax(self, logits, tt_out_tok):
+        slice_valid_vocab = self._can_slice_valid_vocab_for_argmax()
+        if not slice_valid_vocab:
+            logits = self._mask_invalid_vocab_logits(logits)
+        logits = self._pre_argmax_gather(logits)
+        if slice_valid_vocab:
+            logits = self._slice_valid_vocab_for_argmax(logits)
+        x_untilized = ttnn.untilize(logits, use_multicore=True)
+        tt_out_tok = ttnn.argmax(
+            x_untilized,
+            dim=-1,
+            output_tensor=tt_out_tok,
+            keepdim=False,
+        )
+        # Argmax path never emits logprobs (main's contract: force-argmax is disabled whenever
+        # logprobs are requested). Return None unconditionally — do not call the calculator.
+        return tt_out_tok, None
+
+    def _get_argmax_all_gather_config(self, cluster_axis):
+        """Clamp the tuned all-gather config to what the actual submesh supports.
+
+        Port of main's ``_get_force_argmax_all_gather_config`` (#44246): bound num_links to the
+        links available on the submesh, and force Linear topology below 8 devices (Ring routing
+        like D0→D12 only wraps cleanly on T3K-class 8-device groups).
+        """
+        cfg = self.config
+        num_links = cfg.num_argmax_gather_links
+        if hasattr(cfg.tt_ccl, "get_num_links"):
+            num_links = min(num_links, cfg.tt_ccl.get_num_links(cluster_axis))
+        topology = cfg.ag_topology
+        if cfg.mesh_device.get_num_devices() < 8:
+            topology = ttnn.Topology.Linear
+        return max(1, num_links), topology
+
+    def _argmax_all_gather(self, logits):
+        """Multi-device: all-gather logits before argmax.
+
+        On ring-capable meshes (e.g. T3K 1×8) use Ring topology with no barrier semaphore to match the
+        model's logits gather and avoid trace-capture issues seen with some barrier-based configurations.
+        For other meshes, fall back to the clamped Linear+barrier path.
+        """
+        cfg = self.config
+        if default_topology(cfg.mesh_device) == ttnn.Topology.Ring:
+            return ttnn.experimental.all_gather_async(
+                logits,
+                persistent_output_buffer=None,
+                dim=3,
+                multi_device_global_semaphore=cfg.tt_ccl.get_and_cycle_ag_semaphore_handles(),
+                num_links=1,
+                memory_config=logits.memory_config(),
+                topology=ttnn.Topology.Ring,
+                chunks_per_sync=24,
+                num_workers_per_link=4,
+                num_buffers_per_channel=2,
+            )
+        cluster_axis = 1
+        num_links, topology = self._get_argmax_all_gather_config(cluster_axis)
+        return ttnn.experimental.all_gather_async(
+            logits,
+            persistent_output_buffer=None,
+            dim=3,
+            multi_device_global_semaphore=cfg.tt_ccl.get_and_cycle_ag_semaphore_handles(cluster_axis),
+            num_links=num_links,
+            memory_config=logits.memory_config(),
+            cluster_axis=cluster_axis,
+            topology=topology,
+            barrier_semaphore=cfg.tt_ccl.get_and_cycle_barrier_semaphore_handle(cluster_axis),
+            chunks_per_sync=10,
+            num_workers_per_link=1,
+            num_buffers_per_channel=2,
+        )
+
+    @staticmethod
+    def _argmax_noop(logits):
+        """Single-device: no gather needed."""
+        return logits
+
+    # -- Top-k memory strategies (bound at init, no if-else in forward) -------
+
+    def _topk_memory_sharded_roundtrip(self, topk_values, topk_indices_int32):
+        """Non-DRAM sampling_memory_config: round-trip through sharded memory."""
+        cfg = self.config
+        topk_values_sharded = ttnn.to_memory_config(
+            topk_values, memory_config=cfg.sampling_memory_config, dtype=ttnn.bfloat16
+        )
+        topk_values = ttnn.to_memory_config(topk_values_sharded, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        ttnn.deallocate(topk_values_sharded)
+        topk_indices_int32 = ttnn.to_memory_config(topk_indices_int32, cfg.sampling_memory_config)
+        return topk_values, topk_indices_int32
+
+    @staticmethod
+    def _topk_memory_noop(topk_values, topk_indices_int32):
+        """DRAM memory config: no extra round-trip needed."""
+        return topk_values, topk_indices_int32
+
+    # -- Top-k sampling (port from tt_sampling.py:343-481) --------------------
+
+    def _sample_topk(self, logits, k, p, temp, seeds, tt_out_tok):
+        cfg = self.config
+
+        x_bf16 = ttnn.typecast(logits, dtype=ttnn.bfloat16, sub_core_grids=cfg.sub_core_grids)
+        x_bf16 = self._mask_invalid_vocab_logits(x_bf16)
+
+        # Strategy-dispatched top-k
+        topk_values, topk_indices = self._topk(x_bf16)
+
+        # Convert indices to int32
+        topk_indices_int32 = ttnn.typecast(topk_indices, dtype=ttnn.int32, sub_core_grids=cfg.sub_core_grids)
+
+        topk_values, topk_indices_int32 = self._prepare_topk_memory(topk_values, topk_indices_int32)
+
+        # Add device offsets for global vocabulary indices
+        topk_global_indices = ttnn.add(
+            self._index_offsets,
+            topk_indices_int32,
+            dtype=ttnn.int32,
+            memory_config=cfg.sampling_memory_config,
+            sub_core_grids=cfg.sub_core_grids,
+        )
+        ttnn.deallocate(topk_indices_int32)
+
+        # Use distinct names so we can free the interleaved intermediate after untilize
+        topk_global_indices_interleaved = ttnn.to_memory_config(topk_global_indices, ttnn.DRAM_MEMORY_CONFIG)
+        topk_global_indices = ttnn.untilize(
+            topk_global_indices_interleaved, use_multicore=True, sub_core_grids=cfg.sub_core_grids
+        )
+        ttnn.deallocate(topk_global_indices_interleaved)
+
+        # Seed the RNG
+        seeds_tensor = seeds if seeds is not None else self._seeds
+        ttnn.manual_seed(
+            seeds=seeds_tensor,
+            user_ids=self._user_ids,
+            sub_core_grids=cfg.sub_core_grids,
+        )
+
+        # Sample
+        tt_out_tok = ttnn.sampling(
+            topk_values,
+            topk_global_indices,
+            k=k,
+            p=p,
+            temp=temp,
+            sub_core_grids=self._sampling_sub_core_grids,
+            output_tensor=tt_out_tok,
+        )
+
+        ttnn.deallocate(topk_values)
+        ttnn.deallocate(topk_global_indices)
+
+        # Logprobs (old path: single sampled-token logprob). Gated on enable_log_probs so the
+        # disabled case incurs zero extra ops. The calculator itself returns None unless the mesh
+        # is multi-device with num_devices ∈ {8, 32} (T3K 1×8).
+        if self._log_probs_calculator.enable_log_probs:
+            log_probs = self._log_probs_calculator.calculate_log_probs(logits, tt_out_tok)
+        else:
+            log_probs = None
+        return tt_out_tok, log_probs
+
+    def _mask_invalid_vocab_logits(self, logits):
+        if self._invalid_vocab_tail_mask is not None:
+            return self._mask_invalid_vocab_tail_logits(logits)
+        if self._invalid_vocab_mask is None:
+            return logits
+        return ttnn.add(
+            logits,
+            self._invalid_vocab_mask,
+            memory_config=logits.memory_config(),
+            sub_core_grids=self.config.sub_core_grids,
+        )
+
+    def _mask_invalid_vocab_tail_logits(self, logits):
+        cfg = self.config
+        tail_width = self._invalid_vocab_tail_width
+        local_width = logits.shape[-1]
+        valid_width = local_width - tail_width
+        if tail_width <= 0 or valid_width < 0:
+            return self._mask_invalid_vocab_logits_fallback(logits)
+        if valid_width == 0:
+            return ttnn.add(
+                logits,
+                self._invalid_vocab_tail_mask,
+                memory_config=logits.memory_config(),
+                sub_core_grids=cfg.sub_core_grids,
+            )
+
+        valid_logits = ttnn.slice(
+            logits,
+            [0, 0, 0, 0],
+            [logits.shape[0], logits.shape[1], logits.shape[2], valid_width],
+            memory_config=logits.memory_config(),
+            sub_core_grids=cfg.sub_core_grids,
+        )
+        tail_logits = ttnn.slice(
+            logits,
+            [0, 0, 0, valid_width],
+            [logits.shape[0], logits.shape[1], logits.shape[2], local_width],
+            memory_config=logits.memory_config(),
+            sub_core_grids=cfg.sub_core_grids,
+        )
+        masked_tail_logits = ttnn.add(
+            tail_logits,
+            self._invalid_vocab_tail_mask,
+            memory_config=logits.memory_config(),
+            sub_core_grids=cfg.sub_core_grids,
+        )
+        masked_logits = ttnn.concat(
+            [valid_logits, masked_tail_logits],
+            dim=3,
+            memory_config=logits.memory_config(),
+            sub_core_grids=cfg.sub_core_grids,
+        )
+        ttnn.deallocate(valid_logits)
+        ttnn.deallocate(tail_logits)
+        ttnn.deallocate(masked_tail_logits)
+        return masked_logits
+
+    def _mask_invalid_vocab_logits_fallback(self, logits):
+        if self._invalid_vocab_mask is None:
+            return logits
+        return ttnn.add(
+            logits,
+            self._invalid_vocab_mask,
+            memory_config=logits.memory_config(),
+            sub_core_grids=self.config.sub_core_grids,
+        )
+
+    def _can_slice_valid_vocab_for_argmax(self):
+        cfg = self.config
+        return cfg.valid_vocab_size < cfg.vocab_size and cfg.valid_vocab_size % ttnn.TILE_SIZE == 0
+
+    def _slice_valid_vocab_for_argmax(self, logits):
+        cfg = self.config
+        if not self._can_slice_valid_vocab_for_argmax() or logits.shape[-1] != cfg.vocab_size:
+            return logits
+        return ttnn.slice(
+            logits,
+            [0, 0, 0, 0],
+            [logits.shape[0], logits.shape[1], logits.shape[2], cfg.valid_vocab_size],
+            memory_config=logits.memory_config(),
+            sub_core_grids=cfg.sub_core_grids,
+        )
+
+    # -- Top-k strategies (bound at init, no if-else in forward) --------------
+
+    def _topk_single_device(self, x_bf16):
+        """Split vocab in half → two topk → concat. Port of tt_sampling.py:346-371."""
+        cfg = self.config
+        x_list = ttnn.split(x_bf16, x_bf16.shape[-1] // 2, dim=3)
+        indices_list = ttnn.split(self._local_indices, self._local_indices.shape[-1] // 2, dim=3)
+
+        values_parts = []
+        indices_parts = []
+        for i in range(len(x_list)):
+            vals, idxs = ttnn.topk(
+                x_list[i],
+                k=cfg.max_top_k,
+                dim=-1,
+                sub_core_grids=cfg.sub_core_grid_topk,
+                indices_tensor=indices_list[i],
+            )
+            values_parts.append(vals)
+            indices_parts.append(idxs)
+            x_list[i].deallocate()
+            indices_list[i].deallocate()
+
+        gathered_values = ttnn.concat(values_parts, dim=3)
+        gathered_indices = ttnn.concat(indices_parts, dim=3)
+
+        for v, i in zip(values_parts, indices_parts):
+            ttnn.deallocate(v)
+            ttnn.deallocate(i)
+
+        return gathered_values, gathered_indices
+
+    def _topk_multi_device(self, x_bf16):
+        """Local topk → all_gather across devices. Port of tt_sampling.py:372-421."""
+        cfg = self.config
+        cluster_shape = cfg.mesh_device.shape
+
+        # Pad the per-device shard up to the next power of 2 so ttnn.topk hits its fast path.
+        # Padded entries get -inf so they are never selected; the pre-padded _local_indices buffer
+        # is widened to match (see _resolve_sampling1d_config). Mirrors tt_sampling.py:451-458.
+        if cfg.pad_to_power_of_2 and not _is_power_of_2(x_bf16.shape[-1]):
+            padded_width = _upper_power_of_2(x_bf16.shape[-1])
+            x_bf16 = ttnn.pad(
+                x_bf16,
+                [(0, 0), (0, 0), (0, 0), (0, padded_width - x_bf16.shape[-1])],
+                value=-sys.float_info.max,
+                sub_core_grids=cfg.sub_core_grids,
+            )
+
+        topk_values, topk_indices = ttnn.topk(
+            x_bf16,
+            k=cfg.max_top_k,
+            dim=-1,
+            sub_core_grids=cfg.sub_core_grid_topk,
+            indices_tensor=self._local_indices,
+        )
+
+        # For 1D meshes use cluster_axis=None
+        sampling_cluster_axis = None if 1 in cluster_shape else 0
+
+        # Gather values
+        gathered_values = self._perform_all_gather(
+            topk_values,
+            dim=3,
+            cluster_axis=sampling_cluster_axis,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            num_links=cfg.num_gather_links,
+            buffer_key="SAMPLING_VALUES",
+        )
+        ttnn.deallocate(topk_values)
+
+        # Gather indices
+        gathered_indices = self._perform_all_gather(
+            topk_indices,
+            dim=3,
+            cluster_axis=sampling_cluster_axis,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            num_links=cfg.num_gather_links,
+            buffer_key="SAMPLING_INDICES",
+            dtype=ttnn.uint16,
+        )
+        ttnn.deallocate(topk_indices)
+
+        return gathered_values, gathered_indices
+
+    # -- CCL helper -----------------------------------------------------------
+
+    def _perform_all_gather(self, tensor, dim, cluster_axis, memory_config, num_links, buffer_key=None, dtype=None):
+        """Flexible all-gather: prefer line_all_gather if available, else ttnn.all_gather.
+
+        Port of TTSampling._perform_all_gather (tt_sampling.py:231-259).
+        """
+        if callable(self._line_all_gather):
+            kwargs = {
+                "dim": dim,
+                "cluster_axis": cluster_axis,
+                "memory_config": memory_config,
+                "num_links": num_links,
+            }
+            if self._line_all_gather_supports_buffer_key and buffer_key is not None:
+                kwargs["buffer_key"] = buffer_key
+            if self._line_all_gather_supports_dtype and dtype is not None:
+                kwargs["dtype"] = dtype
+            return self._line_all_gather(tensor, **kwargs)
+
+        return ttnn.all_gather(
+            tensor,
+            dim=dim,
+            num_links=num_links,
+            memory_config=memory_config,
+            cluster_axis=cluster_axis,
+            topology=ttnn.Topology.Linear,
+        )
+
+    # -- (Backward compat) Model args factory ----------------------------------
+
+    @classmethod
+    def from_model_args(cls, mesh_device, tt_ccl, args, model_config=None) -> Sampling1D:
+        """Backward compat factory for TTTv1 model args."""
+        cluster_shape = mesh_device.shape
+        if min(cluster_shape) > 1:
+            raise ValueError(
+                f"Sampling1D only supports 1D mesh topologies, got shape {cluster_shape}. "
+                "Use TTSampling for Galaxy (2D) topologies."
+            )
+        padded_vocab_size = getattr(args, "padded_vocab_size", None)
+        vocab_size = padded_vocab_size if padded_vocab_size is not None else args.vocab_size
+        valid_vocab_size = getattr(args, "vocab_size", vocab_size)
+
+        # Extract config from model_config dict
+        mc = model_config or getattr(args, "model_config", {})
+        num_gather_links = 1
+        if "GALAXY_NUM_LINKS" in mc:
+            max_links = mc["GALAXY_NUM_LINKS"]
+            max_top_k = getattr(args, "max_top_k", 32)
+            num_gather_links = min(max_top_k // 32, max_links) if max_top_k // 32 <= max_links else max_links
+
+        sampling_memory_config = mc.get("DECODE_SAMPLING_INPUT_MEMCFG", ttnn.DRAM_MEMORY_CONFIG)
+
+        allow_force_argmax = False
+        num_argmax_gather_links = num_gather_links
+        ag_topology = ttnn.Topology.Linear
+        if "SAMPLING_AG_CONFIG" in mc:
+            ag_cfg = mc["SAMPLING_AG_CONFIG"]
+            allow_force_argmax = ag_cfg.get("allow_force_argmax", False)
+            num_argmax_gather_links = ag_cfg.get("num_links", num_gather_links)
+            ag_topology = ag_cfg.get("topology", ttnn.Topology.Linear)
+
+        config = Sampling1DConfig(
+            vocab_size=vocab_size,
+            valid_vocab_size=valid_vocab_size,
+            mesh_device=mesh_device,
+            tt_ccl=tt_ccl,
+            max_batch_size=getattr(args, "max_batch_size", 32),
+            max_top_k=getattr(args, "max_top_k", 32),
+            sub_core_grids=getattr(args, "sub_core_grids", None),
+            sub_core_grid_topk=getattr(args, "sub_core_grid_topk", None),
+            start_core=getattr(args, "start_core", ttnn.CoreCoord(0, 0)),
+            num_gather_links=num_gather_links,
+            sampling_memory_config=sampling_memory_config,
+            allow_force_argmax=allow_force_argmax,
+            num_argmax_gather_links=num_argmax_gather_links,
+            ag_topology=ag_topology,
+            pad_to_power_of_2=getattr(args, "pad_logits_to_power_of_2", False),
+        )
+        return cls.from_config(config)
+
+
+# ---------------------------------------------------------------------------
+# Config resolution
+# ---------------------------------------------------------------------------
+
+
+def _resolve_sampling1d_config(config: Sampling1DConfig) -> Sampling1DConfig:
+    """Fill None fields with topology-aware defaults."""
+    import torch
+
+    to_set: dict = {}
+
+    # Phase 1: Device and CCL
+    mesh_device = config.mesh_device or ttnn.GetDefaultDevice()
+    to_set["mesh_device"] = mesh_device
+
+    cluster_shape = mesh_device.shape
+    num_devices = mesh_device.get_num_devices()
+    multi_step_reduction = list(cluster_shape) == [1, 1]
+
+    if num_devices > 1 and config.tt_ccl is None:
+        to_set["tt_ccl"] = get_tt_ccl(mesh_device)
+
+    # Phase 2: Scalar config defaults
+    valid_vocab_size = config.valid_vocab_size if config.valid_vocab_size is not None else config.vocab_size
+    if valid_vocab_size > config.vocab_size:
+        raise ValueError(f"valid_vocab_size ({valid_vocab_size}) must be <= vocab_size ({config.vocab_size})")
+    to_set["valid_vocab_size"] = valid_vocab_size
+    if config.start_core is None:
+        to_set["start_core"] = ttnn.CoreCoord(0, 0)
+    if config.sampling_memory_config is None:
+        to_set["sampling_memory_config"] = ttnn.DRAM_MEMORY_CONFIG
+    if config.num_argmax_gather_links is None:
+        to_set["num_argmax_gather_links"] = config.num_gather_links
+    if config.ag_topology is None:
+        to_set["ag_topology"] = ttnn.Topology.Linear
+
+    # Phase 3: Buffer specs
+    B = config.max_batch_size
+    K = config.max_top_k
+    V = config.vocab_size
+    replicate_mapper = ttnn.ShardTensor2dMesh(mesh_device, dims=(None, None), mesh_shape=cluster_shape)
+
+    # num_devices_in_mesh for index computation
+    if multi_step_reduction:
+        num_devices_in_mesh = 2
+    else:
+        num_devices_in_mesh = max(cluster_shape[0], cluster_shape[1])
+    per_device_vocab = V // num_devices_in_mesh
+
+    def _resolve_buf(field_val, defaults, source_factory):
+        if field_val is None:
+            return LazyBuffer(source=source_factory(), **defaults)
+        if isinstance(field_val, ttnn.Tensor):
+            return field_val
+        return resolve_lazy_buffer(field_val, **defaults)
+
+    # index_offsets: [1, 1, B, K * num_devices_in_mesh]
+    def _make_index_offsets():
+        offsets = torch.ones(1, 1, B, K * num_devices_in_mesh, dtype=torch.int64)
+        for device_id in range(num_devices_in_mesh):
+            offsets[:, :, :, device_id * K : (device_id + 1) * K] = device_id * per_device_vocab
+        return offsets
+
+    idx_defaults = dict(
+        dtype=ttnn.int32,
+        layout=ttnn.TILE_LAYOUT,
+        device=mesh_device,
+        mesh_mapper=replicate_mapper,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    to_set["index_offsets"] = _resolve_buf(config.index_offsets, idx_defaults, _make_index_offsets)
+
+    # local_indices: [1, 1, B, local_indices_width]
+    # For multi-device: width = per_device_vocab (each device's shard)
+    # For single-device split (multi_step_reduction): width = V (full vocab), so that
+    #   after ttnn.split(..., V//2, dim=3) each half has width V//2 = per_device_vocab,
+    #   matching the logits half width. Each half contains a 0-based range [0..V//2-1].
+    #   Bug fix: TTTv1 used per_device_vocab here too, causing a 2x width mismatch
+    #   between indices_tensor and logits in ttnn.topk on single-device.
+    local_indices_width = V if multi_step_reduction else per_device_vocab
+
+    def _make_local_indices():
+        if multi_step_reduction:
+            half = local_indices_width // 2
+            r = torch.arange(half, dtype=torch.int32)
+            row = torch.cat([r, r])
+        else:
+            row = torch.arange(local_indices_width, dtype=torch.int32)
+        out = row.unsqueeze(0).unsqueeze(0).expand(1, 1, B, -1).contiguous()
+        # Pad the indices buffer to match the power-of-2-padded topk input width (multi-device
+        # path only — strict TTTv1 parity, so the 1×1 split path is never padded). Fill with -1
+        # (invalid index) so the padded slots are never used. Mirrors tt_sampling.py:277-284.
+        if config.pad_to_power_of_2 and not multi_step_reduction and not _is_power_of_2(local_indices_width):
+            padded_width = _upper_power_of_2(local_indices_width)
+            out = torch.nn.functional.pad(out, (0, padded_width - local_indices_width), mode="constant", value=-1)
+        return out
+
+    local_idx_defaults = dict(
+        dtype=ttnn.uint16,
+        layout=ttnn.TILE_LAYOUT,
+        device=mesh_device,
+        mesh_mapper=replicate_mapper,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    to_set["local_indices"] = _resolve_buf(config.local_indices, local_idx_defaults, _make_local_indices)
+
+    vocab_shard_dims = get_vocab_shard_dims(cluster_shape)
+    invalid_vocab_defaults = dict(
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=mesh_device,
+        mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=vocab_shard_dims, mesh_shape=cluster_shape),
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    invalid_vocab_tail_mask = build_tail_invalid_vocab_mask(
+        valid_vocab_size,
+        V,
+        B,
+        cluster_shape,
+        tile_size=ttnn.TILE_SIZE,
+    )
+    if config.invalid_vocab_mask is None and (
+        invalid_vocab_tail_mask is not None or config.invalid_vocab_tail_mask is not None
+    ):
+        to_set["invalid_vocab_tail_width"] = (
+            invalid_vocab_tail_mask.tail_width
+            if invalid_vocab_tail_mask is not None
+            else config.invalid_vocab_tail_width
+        )
+        to_set["invalid_vocab_tail_mask"] = _resolve_buf(
+            config.invalid_vocab_tail_mask,
+            invalid_vocab_defaults,
+            lambda: invalid_vocab_tail_mask.mask,
+        )
+    else:
+        invalid_vocab_mask = build_invalid_vocab_mask(valid_vocab_size, V, B)
+        if invalid_vocab_mask is not None or config.invalid_vocab_mask is not None:
+            to_set["invalid_vocab_mask"] = _resolve_buf(
+                config.invalid_vocab_mask,
+                invalid_vocab_defaults,
+                lambda: invalid_vocab_mask,
+            )
+
+    # seeds and user_ids: [B], uint32, ROW_MAJOR
+    seed_defaults = dict(
+        dtype=ttnn.uint32,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=mesh_device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    to_set["seeds"] = _resolve_buf(
+        config.seeds, seed_defaults, lambda: torch.arange(B, dtype=torch.int64).to(torch.int32)
+    )
+    to_set["user_ids"] = _resolve_buf(
+        config.user_ids, seed_defaults, lambda: torch.arange(B, dtype=torch.int64).to(torch.int32)
+    )
+
+    resolved = replace(config, **to_set)
+    assert resolved.is_resolved(), "Config not fully resolved after _resolve_sampling1d_config"
+    return resolved
+
+
+# -- Helper functions -------------------------------------------------------
+
+
+def _materialize(buf):
+    """Materialize a buffer field: ttnn.Tensor passthrough, LazyBuffer → get_device_buffer()."""
+    if isinstance(buf, ttnn.Tensor):
+        return buf
+    return buf.get_device_buffer()

--- a/models/experimental/llama32_1b_quasar/modules/tt_ccl.py
+++ b/models/experimental/llama32_1b_quasar/modules/tt_ccl.py
@@ -1,0 +1,219 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional
+
+import ttnn
+
+# =============================================================================
+# CCL tuning defaults - shared across all TTTv2 modules
+# =============================================================================
+
+# Default number of chunks per synchronization barrier in CCL operations.
+# Higher values reduce sync overhead but increase latency per chunk.
+CCL_CHUNKS_PER_SYNC = 10
+
+# Default number of worker threads per Ethernet link for CCL operations.
+CCL_NUM_WORKERS_PER_LINK = 2
+
+# Default number of double-buffered channels per CCL link.
+CCL_NUM_BUFFERS_PER_CHANNEL = 2
+
+# =============================================================================
+# TT_CCL cache - one instance per mesh_device (semaphores are hardware resources)
+# =============================================================================
+
+
+_tt_ccl_cache: dict[int, "TT_CCL"] = {}
+
+
+def get_tt_ccl(mesh_device: ttnn.MeshDevice) -> "TT_CCL":
+    """Get or create TT_CCL for mesh_device (cached per device id)."""
+    mesh_id = mesh_device.id()
+    if mesh_id not in _tt_ccl_cache:
+        _tt_ccl_cache[mesh_id] = TT_CCL(mesh_device)
+    return _tt_ccl_cache[mesh_id]
+
+
+def clear_tt_ccl_cache():
+    """Clear cache (for testing)."""
+    _tt_ccl_cache.clear()
+
+
+def _get_local_num_devices(mesh_device: Optional[ttnn.MeshDevice]) -> int:
+    """Return the number of devices visible to the current host process."""
+    if mesh_device is None:
+        raise ValueError("mesh_device is required to determine CCL link counts")
+
+    try:
+        local_device_ids = mesh_device.get_device_ids()
+    except Exception as exc:
+        raise ValueError("CCL link detection requires at least one host-local device") from exc
+    if not local_device_ids:
+        raise ValueError("CCL link detection requires at least one host-local device")
+
+    return len(local_device_ids)
+
+
+# =============================================================================
+# TT_CCL class
+# =============================================================================
+
+
+class TT_CCL:
+    def __init__(
+        self,
+        mesh_device,
+    ):
+        self.mesh_device = mesh_device
+        self.sub_device_crs = ttnn.CoreRangeSet(
+            {
+                ttnn.CoreRange(
+                    ttnn.CoreCoord(0, 0),
+                    ttnn.CoreCoord(
+                        self.mesh_device.compute_with_storage_grid_size().x - 1,
+                        self.mesh_device.compute_with_storage_grid_size().y - 1,
+                    ),
+                )
+            }
+        )
+
+        self.barrier_semaphore_idx = [0, 0, 0]
+        self.barrier_semaphore_handles = [[], [], []]
+
+        self.ag_semaphores_idx = [0, 0, 0]
+        self.ag_semaphore_handles = [[], [], []]
+
+        self.rs_semaphores_idx = [0, 0, 0]
+        self.rs_semaphore_handles = [[], [], []]
+
+        # cluster-axis-0, cluster-axis-1, no-cluster-axis
+        for i in range(3):
+            # double buffered semaphores
+            for _ in range(2):
+                self.barrier_semaphore_handles[i].append(
+                    ttnn.create_global_semaphore(self.mesh_device, self.sub_device_crs, 0)
+                )
+
+                self.ag_semaphore_handles[i].append(
+                    [ttnn.create_global_semaphore(self.mesh_device, self.sub_device_crs, 0) for _ in range(2)]
+                )
+
+                self.rs_semaphore_handles[i].append(
+                    [ttnn.create_global_semaphore(self.mesh_device, self.sub_device_crs, 0) for _ in range(3)]
+                )
+
+    def get_and_cycle_barrier_semaphore_handle(self, cluster_axis=None):
+        semaphore_index = 2 if cluster_axis is None else cluster_axis
+        current_idx = self.barrier_semaphore_idx[semaphore_index]
+        self.barrier_semaphore_idx[semaphore_index] = (current_idx + 1) % 2
+        return self.barrier_semaphore_handles[semaphore_index][current_idx]
+
+    def get_and_cycle_ag_semaphore_handles(self, cluster_axis=None):
+        semaphore_index = 2 if cluster_axis is None else cluster_axis
+        current_idx = self.ag_semaphores_idx[semaphore_index]
+        self.ag_semaphores_idx[semaphore_index] = (current_idx + 1) % 2
+        return self.ag_semaphore_handles[semaphore_index][current_idx]
+
+    def get_and_cycle_rs_semaphore_handles(self, cluster_axis=None):
+        semaphore_index = 2 if cluster_axis is None else cluster_axis
+        current_idx = self.rs_semaphores_idx[semaphore_index]
+        self.rs_semaphores_idx[semaphore_index] = (current_idx + 1) % 2
+        return self.rs_semaphore_handles[semaphore_index][current_idx]
+
+    def get_num_links(self, cluster_axis=None):
+        """Get the number of available Ethernet links for CCL operations on this mesh device."""
+        return get_num_links(self.mesh_device, cluster_axis)
+
+
+# =============================================================================
+# Topology auto-detection
+# =============================================================================
+
+
+# todo)) work with the CCL team to find opportunity to simplify this --> e.g., build into TTNN APIs?
+def default_topology(mesh_device: ttnn.MeshDevice) -> Optional[ttnn.Topology]:
+    """Auto-detect CCL topology based on cluster type and device count."""
+    num_devices = mesh_device.get_num_devices()
+    if num_devices == 8 and ttnn.cluster.get_cluster_type() in [
+        ttnn.cluster.ClusterType.T3K,
+        ttnn.cluster.ClusterType.GALAXY,
+    ]:
+        # NOTE: we always want to do ring if it is available
+        return ttnn.Topology.Ring
+    elif num_devices > 1:
+        # NOTE: this should be a fallback when the ring is not available
+        return ttnn.Topology.Linear
+    return None
+
+
+# =============================================================================
+# Device name / link count helpers (copied from TTTv1 ccl.py + model_config.py
+# to avoid importing from tt_transformers)
+# =============================================================================
+
+
+def _determine_device_name(mesh_device: ttnn.MeshDevice) -> str:
+    """Determine device name for CCL based on the host-local device count."""
+    num_devices = _get_local_num_devices(mesh_device)
+    arch_name = ttnn.get_arch_name()
+    dram_grid_size = mesh_device.dram_grid_size()
+
+    if "blackhole" in arch_name:
+        dict_device_names = {
+            1: "P100" if dram_grid_size and dram_grid_size.x == 7 else "P150",
+            2: "P300",
+            4: "P150x4",
+            8: "P150x8",
+            32: "BHGLX",
+        }
+    elif "wormhole_b0" in arch_name:
+        dict_device_names = {
+            1: "N150",
+            2: "N300",
+            4: "N150x4",
+            8: "T3K",
+            32: "TG",
+        }
+    else:
+        raise ValueError(f"Unsupported architecture: {arch_name}")
+
+    if num_devices in dict_device_names:
+        return dict_device_names[num_devices]
+    raise ValueError(f"Unsupported number of local devices: {num_devices} for {arch_name}")
+
+
+def get_num_links(mesh_device: ttnn.MeshDevice, cluster_axis: int | None = None) -> int:
+    """
+    Get the number of available Ethernet links for CCL operations.
+
+    Args:
+        mesh_device: The mesh device to query.
+        cluster_axis: Optional cluster axis to query links for.
+            - 0: vertical axis (North-South).
+            - 1: horizontal axis (East-West).
+            - None: minimum across all axes.
+
+    Returns:
+        int: The number of available links.
+    """
+    device_name = _determine_device_name(mesh_device)
+    link_dict = {
+        "P100": (0, 0),
+        "P150": (0, 0),
+        "N150": (0, 0),
+        "N300": (1, 1),
+        "T3K": (1, 1),
+        "P150x4": (2, 2),
+        "P150x8": (2, 2),
+        "P300": (2, 2),
+        "BHGLX": (2, 2),
+        "TG": (4, 4),
+        "N150x4": (1, 1),
+    }
+    device_links = link_dict[device_name]
+    if cluster_axis is None:
+        return min(device_links)
+    if cluster_axis in (0, 1):
+        return device_links[cluster_axis]
+    raise ValueError(f"Unsupported cluster_axis: {cluster_axis}")

--- a/models/experimental/llama32_1b_quasar/sampling/README.md
+++ b/models/experimental/llama32_1b_quasar/sampling/README.md
@@ -16,7 +16,7 @@ penalties with optional trace capture.
 
 ## Quick Start
 ```python
-from models.common.sampling import SamplingGenerator, format_sampling_params
+from models.experimental.llama32_1b_quasar.sampling import SamplingGenerator, format_sampling_params
 
 sampling = SamplingGenerator(args=args, mesh_device=mesh_device, tt_ccl=tt_ccl)
 

--- a/models/experimental/llama32_1b_quasar/sampling/README.md
+++ b/models/experimental/llama32_1b_quasar/sampling/README.md
@@ -1,0 +1,115 @@
+# Sampling Module Overview
+
+The `models.common.sampling` package bundles everything needed to run on-device
+sampling (top-k / top-p / temperature/ seed) plus presence/frequency/repetition
+penalties with optional trace capture.
+
+## Key Components
+- `SamplingGenerator`: high-level class that owns both `TTSampling` and
+  `TTPenalties`, exposes helper methods to reset sampling parameters, penalties,
+  prompt/output state, and to run sampling with or without trace capture.
+- `format_sampling_params`: utility that pads/clamps sampling parameters to the
+  hardware-friendly layout expected by `TTSampling`.
+- `LogProbsCalculator`: computes per-token log-probabilities across a sharded
+  vocabulary using numerically stable log-softmax (global max / sum-exp
+  reduction across devices).
+
+## Quick Start
+```python
+from models.common.sampling import SamplingGenerator, format_sampling_params
+
+sampling = SamplingGenerator(args=args, mesh_device=mesh_device, tt_ccl=tt_ccl)
+
+params = format_sampling_params(user_params, max_batch_size=32)
+sampling.reset_sampling_params(params)
+
+sampling.reset_seed(seed)
+
+sampling.reset_prompt_tokens(prompt_tokens)   # torch tensor shaped [B, S]
+sampling.reset_output_state(output_tokens)
+
+tt_tokens = sampling.sample(
+    tt_logits,
+    tt_out_tok=tt_out_buffer,
+)
+```
+
+`SamplingGenerator.sample()` accepts `enable_trace=True` to record/replay
+sampling traces.
+
+## File Map
+
+| File | Purpose |
+|---|---|
+| `generator.py` | `SamplingGenerator` orchestrator; `SamplingParams`; `format_sampling_params`; `broadcast_sampling_params`; `chunk_sampling_params`; `SeedManager` |
+| `tt_sampling.py` | `TTSampling` — on-device top-k/top-p/temp with multi-device all-gather |
+| `tt_penalties.py` | `TTPenalties` — presence / frequency / repetition penalties |
+| `tt_log_probs.py` | `LogProbsCalculator` — log-softmax across sharded vocabulary |
+| `_utils.py` | Shared helpers: `clamp`, `is_default_value`, `filter_none`, `split_list` |
+
+## Required `args` Attributes
+
+```python
+vocab_size: int           # actual vocabulary size (unpadded)
+cluster_shape: tuple      # (rows, cols) of the device mesh, e.g. (4, 8)
+```
+
+Optional (with defaults):
+
+```python
+padded_vocab_size: int    # tile-aligned total vocab; defaults to vocab_size
+max_batch_size: int       # per sampling row; default 32
+max_top_k: int            # default 32
+sampling_dp: int          # >1 for multi-row DP; default 1
+sub_core_grids            # CoreRangeSet or None
+model_config: dict        # keys: GALAXY_NUM_LINKS, DECODE_SAMPLING_INPUT_MEMCFG, SAMPLING_AG_CONFIG
+```
+
+## `data_parallel` vs `sampling_dp`
+
+These are different concepts and should not be mixed:
+
+- **`data_parallel`** lives above this package. It means multiple TT model
+  instances / submeshes process different requests in parallel.
+- **`sampling_dp`** lives inside this package. It means one TT model instance
+  has multiple independent sampling groups, usually one per mesh row.
+
+For `sampling_dp > 1`:
+- logits are still computed per sampling group
+- but sampling params, seeds, and penalty state are flattened to
+  `max_batch_size * sampling_dp`
+- those flattened host tensors are then row-sharded onto the device
+
+Decode already follows this contract by using `chunk_sampling_params(...)`
+plus `apply_decode_state(...)`.
+
+## Param Distribution API
+
+**`SamplingParams`**: Canonical dataclass for sampling parameters (temp, top_k, top_p, penalties, seed, log_probs). Import from `models.common.sampling`. vLLM has its own duck-type-compatible `TTSamplingParams`.
+
+**`broadcast_sampling_params(params, idx, slot_len=32)`**: Expand a single user's params to fill `slot_len` slots. Used during prefill.
+
+**`chunk_sampling_params(params, sampling_dp)`**: Split a SamplingParams into `sampling_dp` pieces. List fields split evenly; scalars replicated. Works with duck-typed objects (vLLM).
+
+**`SamplingGenerator.apply_prefill_state(...)`**: Reset params, seeds, prompt tokens, and output state for a prefill request.
+
+**`SamplingGenerator.apply_decode_state(chunks, ...)`**: Format/merge params and apply for one model instance. Handles both simple (1 chunk) and row-sharded (multiple chunks) cases. Does NOT advance seeds — callers manage `seed_manager.get_new_values()` separately.
+
+## Pitfalls
+
+**`padded_vocab_size` vs `vocab_size`**: TTSampling device offsets for global token IDs must use the padded vocab size to match how the LM head shards logits across devices. Using unpadded `vocab_size` for offsets shifts token IDs from devices 1+ and produces garbled output.
+
+**Padded vocab logits**: If the LM head pads output weights beyond the real tokenizer vocabulary, the sampler must mask those padded token IDs before force-argmax or local top-k. Zero-padded LM-head weights are useful for legal sharded matmul shapes, but they are not a sampling mask.
+
+**`sampling_dp`**: When >1, k/p/temp tensors must have length `max_batch_size * sampling_dp` and are row-sharded via `ShardTensor2dMesh(dims=(0, None))`. Use `chunk_sampling_params` + `apply_decode_state` to distribute params across mesh rows.
+
+**Batched prefill + on-device sampling**: This path is only valid when the
+runtime prefill compute layout matches the sampling-group layout. If a model
+uses `sampling_dp > 1` but does not expose a row-sharded batched-prefill input
+contract, batched prefill must fall back to sequential prefill for correctness.
+
+**Trace invalidation**: Changing `force_argmax_sampling` state invalidates captured traces. Force-argmax is triggered when callers pass k=1, p=1.0, temp=1.0 (note: p=1.0 means "no top-p filtering", distinct from the internal initialization default of p=0). `SamplingGenerator.reset_sampling_params` handles this.
+
+## Future Work
+
+- Consolidate DeepSeek's minimal `SamplingParams` (in `models/demos/deepseek_v3/tt/generator.py`) to use the common one

--- a/models/experimental/llama32_1b_quasar/sampling/__init__.py
+++ b/models/experimental/llama32_1b_quasar/sampling/__init__.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from .tt_sampling import TTSampling
+from .tt_penalties import TTPenalties, apply_penalties
+from .tt_log_probs import LogProbsCalculator, LogProbsResult
+from .generator import (
+    SamplingGenerator,
+    SamplingParams,
+    SAMPLING_PARAM_FIELDS,
+    format_sampling_params,
+    broadcast_sampling_params,
+    chunk_sampling_params,
+    SeedManager,
+)
+from ._utils import split_list
+
+__all__ = [
+    "TTSampling",
+    "TTPenalties",
+    "apply_penalties",
+    "LogProbsCalculator",
+    "LogProbsResult",
+    "SamplingGenerator",
+    "SamplingParams",
+    "SAMPLING_PARAM_FIELDS",
+    "format_sampling_params",
+    "broadcast_sampling_params",
+    "chunk_sampling_params",
+    "SeedManager",
+    "split_list",
+]

--- a/models/experimental/llama32_1b_quasar/sampling/_utils.py
+++ b/models/experimental/llama32_1b_quasar/sampling/_utils.py
@@ -1,0 +1,91 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+from loguru import logger
+
+
+def clamp(value, min_value, max_value):
+    if value < min_value:
+        return min_value
+    elif value > max_value:
+        return max_value
+    return value
+
+
+def is_default_value(values, default):
+    """Check if values match a default, handling None, scalar, and iterable inputs."""
+    if values is None:
+        return True
+    if isinstance(values, (int, float)):
+        return values == default
+    return all(value == default for value in values)
+
+
+def filter_none(kwargs: dict) -> dict:
+    return {k: v for k, v in kwargs.items() if v is not None}
+
+
+def split_list(lst, n):
+    """Split list into n equal parts."""
+    chunk_size = len(lst) // n
+    return [list(lst[i * chunk_size : (i + 1) * chunk_size]) for i in range(n)]
+
+
+def compact_debug_list(values, max_items=12):
+    if values is None:
+        return None
+    if hasattr(values, "reshape") and hasattr(values, "tolist"):
+        values = values.reshape(-1).tolist()
+    elif isinstance(values, tuple):
+        values = list(values)
+    elif not isinstance(values, list):
+        values = list(values) if isinstance(values, range) else [values]
+    if len(values) <= max_items:
+        return values
+    half = max(1, max_items // 2)
+    return {"len": len(values), "head": values[:half], "tail": values[-half:]}
+
+
+def is_llama33_70b_model(args) -> bool:
+    if isinstance(args, list):
+        args = args[0] if args else None
+    if args is None:
+        return False
+
+    fields_to_check = (
+        "model_name",
+        "base_model_name",
+        "model_base_path",
+        "model_cache_path",
+        "tokenizer_path",
+        "CKPT_DIR",
+        "LLAMA_DIR",
+        "hf_model",
+        "HF_MODEL",
+    )
+    for field in fields_to_check:
+        value = getattr(args, field, None)
+        if value is None:
+            continue
+        normalized = str(value).lower().replace("_", "-")
+        if "llama" in normalized and "3.3-70b" in normalized:
+            return True
+    return False
+
+
+def log_sampling_debug(enabled, message, **kwargs):
+    if not enabled:
+        return
+    compact = {key: value for key, value in kwargs.items() if value is not None}
+    logger.info(f"SamplingDBG {message}: {compact}")
+
+
+def is_power_of_2(n):
+    return n > 0 and (n & (n - 1)) == 0
+
+
+def upper_power_of_2(n: int) -> int:
+    if n <= 1:
+        return 1
+    return 1 << (n - 1).bit_length()

--- a/models/experimental/llama32_1b_quasar/sampling/generator.py
+++ b/models/experimental/llama32_1b_quasar/sampling/generator.py
@@ -1,0 +1,932 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import copy
+import random
+import secrets
+from dataclasses import dataclass, fields, replace
+from typing import List, Optional
+
+import torch
+from loguru import logger
+
+import ttnn
+
+from ._utils import clamp
+from ._utils import compact_debug_list as _compact_debug_list
+from ._utils import is_default_value, is_llama33_70b_model
+from ._utils import log_sampling_debug as _log_sampling_debug
+from ._utils import split_list
+from .tt_penalties import TTPenalties
+from .tt_sampling import TTSampling
+
+MAX_UINT32 = 2**32 - 1
+# MAX_UINT32 is reserved as the device skip sentinel; keep real seeds in a bounded positive range.
+DEVICE_SEED_MAX = 1_000_000
+_UINT64_MASK = (1 << 64) - 1
+
+
+def _hash_request_seed_to_device_seed(seed: int, counter: int) -> int:
+    """Derive a stable per-token device seed from a request seed.
+
+    The device sampling op accepts bounded positive seeds, while vLLM
+    request seeds can be any integer and must be reproducible regardless
+    of batch slot. Hashing (request seed, token counter) gives each token
+    a deterministic but well-mixed device seed without relying on mutable
+    per-slot RNG state. The constants below are the SplitMix64 finalizer.
+    """
+    value = (int(seed) & _UINT64_MASK) ^ ((int(counter) + 0x9E3779B97F4A7C15) & _UINT64_MASK)
+    value = ((value ^ (value >> 30)) * 0xBF58476D1CE4E5B9) & _UINT64_MASK
+    value = ((value ^ (value >> 27)) * 0x94D049BB133111EB) & _UINT64_MASK
+    value = (value ^ (value >> 31)) & _UINT64_MASK
+    return (value % DEVICE_SEED_MAX) + 1
+
+
+@dataclass(frozen=True)
+class SamplingParams:
+    """
+    Sampling parameters for on-device greedy decoding / sampling.
+
+    Used by Generator decode/prefill functions. vLLM has its own duck-type-compatible
+    TTSamplingParams (in vllm/worker/tt_model_runner.py) that works with the same
+    format_sampling_params / chunk_sampling_params functions.
+    """
+
+    temperature: float | list[float]
+    top_k: int | list[int]
+    top_p: float | list[float]
+    presence_penalty: float | list[float] = 0.0
+    frequency_penalty: float | list[float] = 0.0
+    repetition_penalty: float | list[float] = 1.0
+    seed: int | list[int] | None = None
+    enable_log_probs: bool | list[bool] = False
+    num_logprobs: int | list[int] = 0
+
+
+SAMPLING_PARAM_FIELDS = tuple(f.name for f in fields(SamplingParams))
+
+
+@dataclass(frozen=True)
+class _TraceKey:
+    penalties_on: bool
+    log_probs_on: bool
+    force_argmax: bool
+
+
+class SamplingGenerator:
+    """
+    High-level sampling helper that owns both `TTSampling` and `TTPenalties`
+    modules and optionally manages TTNN trace capture/execution for sampling.
+
+    Typical usage:
+        generator = SamplingGenerator(args=args, mesh_device=mesh_device, tt_ccl=tt_ccl)
+        generator.reset_sampling_params(k=..., p=..., temp=...)
+        tokens = generator.sample(logits, enable_trace=True)
+    """
+
+    _DEFAULT_PENALTIES = {
+        "presence": 0.0,
+        "frequency": 0.0,
+        "repetition": 1.0,
+    }
+
+    def __init__(
+        self,
+        *,
+        args,
+        mesh_device,
+        tt_ccl,
+        cq_id: int = 0,
+    ):
+        self.mesh_device = mesh_device
+        self.cq_id = cq_id
+        self.args = args
+        self._sampling_debug_enabled = is_llama33_70b_model(args)
+        self.sub_core_grids = getattr(args, "sub_core_grids", None)
+        self.tt_sampling = TTSampling(mesh_device=mesh_device, tt_ccl=tt_ccl, args=args)
+        self.tt_penalties = TTPenalties(mesh_device=mesh_device, args=args)
+
+        self._penalties_active = False
+
+        self._trace_states: dict[_TraceKey, dict] = {}
+        seed_batch_size = self.tt_sampling.max_batch_size * self.tt_sampling._sampling_dp
+        self.seed_manager = SeedManager(
+            self.tt_sampling,
+            max_batch_size=seed_batch_size,
+        )
+
+    def _new_trace_state(self):
+        return {"id": None, "input": None, "output": None, "kwargs": {}}
+
+    def _trace_slot(self, penalties_on: bool, log_probs_on: bool, force_argmax: bool):
+        key = _TraceKey(penalties_on=penalties_on, log_probs_on=log_probs_on, force_argmax=force_argmax)
+        slot = self._trace_states.get(key)
+        if slot is None:
+            slot = self._new_trace_state()
+            self._trace_states[key] = slot
+        return key, slot
+
+    def reset_trace(self):
+        """
+        Drop any cached trace metadata for both penalties/no-penalties and log-probs/no-log-probs paths.
+        """
+        for key, slot in self._trace_states.items():
+            if slot["id"] is None:
+                continue
+            logger.debug(
+                f"Resetting sampling trace (penalties={key.penalties_on}, log_probs={key.log_probs_on}, force_argmax={key.force_argmax}, trace_id={slot['id']})"
+            )
+            try:
+                ttnn.release_trace(self.mesh_device, slot["id"])
+            except Exception as e:
+                logger.warning(f"Failed to release trace {slot['id']} : {e}")
+                continue
+        self._trace_states.clear()
+
+    def reset_prompt_tokens(self, prompt_tokens):
+        if not self._penalties_active:
+            return
+        self.tt_penalties.reset_prompt_tokens(prompt_tokens)
+
+    def reset_output_state(self, tokens=None):
+        if not self._penalties_active:
+            return
+        self.tt_penalties.reset_output_tokens(tokens)
+
+    # ---------------------------------------------------------------------
+    # Prefill / decode state helpers
+    # ---------------------------------------------------------------------
+    def apply_prefill_state(
+        self,
+        *,
+        sampling_params,
+        prompt_tokens: torch.Tensor | None,
+        empty_slots: list[int],
+        replicate_seeds: bool = True,
+    ):
+        """Prepare sampling state for a prefill request.
+
+        Resets params, seeds, prompt tokens, and output state in the correct order.
+        """
+        self.reset_sampling_params(sampling_params, empty_slots=empty_slots)
+        seed = getattr(sampling_params, "seed", None)
+        # assert on condition that seed is not None
+        assert seed is not None, "sampling_params must be formatted (seed should be a list, not None)"
+        self.seed_manager.reset_seed(seed, empty_slots)
+        self.seed_manager.get_new_values(empty_slots, replicate_seeds=replicate_seeds)
+        if prompt_tokens is not None:
+            self.reset_prompt_tokens(prompt_tokens)
+        self.reset_output_state()
+
+    def apply_decode_state(
+        self,
+        sampling_params_chunks: list,
+        *,
+        reset_batch: bool = False,
+        prompt_tokens: torch.Tensor | None = None,
+        output_tokens: torch.Tensor | None = None,
+    ):
+        """Format, merge (if row-sharded), and apply sampling params for one model instance.
+
+        Args:
+            sampling_params_chunks: List of SamplingParams assigned to this instance.
+                Length-1 for simple cases; >1 for row-sharded (sampling_dp > data_parallel).
+            reset_batch: Also reset prompt tokens and output state (first decode step).
+            prompt_tokens: Prompt tokens for penalty tracking.
+            output_tokens: Output tokens for penalty tracking.
+
+        Does NOT call ``seed_manager.get_new_values()`` — callers manage seed
+        advancement separately since generators call it at different points.
+        """
+        chunks_per_model = len(sampling_params_chunks)
+
+        max_batch_size = self.tt_sampling.max_batch_size
+
+        if chunks_per_model == 1:
+            formatted_params = format_sampling_params(sampling_params_chunks[0], max_batch_size)
+            self.reset_sampling_params(formatted_params)
+        else:
+            # Row-sharded case: format each chunk to max_batch_size, concatenate.
+            # After (0, None) sharding each row gets its own chunk of max_batch_size entries.
+            # Both TTSampling and TTPenalties use the same concatenated params.
+            formatted_chunks = [format_sampling_params(chunk, max_batch_size) for chunk in sampling_params_chunks]
+            concat_fields = {}
+            for field in SAMPLING_PARAM_FIELDS:
+                lists = [getattr(fc, field) for fc in formatted_chunks]
+                if all(v is None for v in lists):
+                    concat_fields[field] = None
+                else:
+                    concat_fields[field] = sum((v if isinstance(v, list) else [v] for v in lists), [])
+            formatted_params = SamplingParams(**concat_fields)
+            self.reset_sampling_params(formatted_params)
+
+        if reset_batch:
+            self.reset_prompt_tokens(prompt_tokens)
+            self.reset_output_state(output_tokens)
+
+    # ---------------------------------------------------------------------
+    # Sampling helpers
+    # ---------------------------------------------------------------------
+    def reset_sampling_params(self, sampling_params, empty_slots: list[int] | None = None):
+        old_force_argmax_sampling = self.tt_sampling.force_argmax_sampling
+        num_logprobs = getattr(sampling_params, "num_logprobs", None)
+        self.tt_sampling.reset_params(
+            k=sampling_params.top_k,
+            p=sampling_params.top_p,
+            temp=sampling_params.temperature,
+            enable_log_probs=sampling_params.enable_log_probs,
+            num_logprobs=num_logprobs,
+            empty_slots=empty_slots,
+        )
+        if self.tt_sampling.force_argmax_sampling != old_force_argmax_sampling:
+            self.reset_trace()
+
+        old_penalties_active = self._penalties_active
+        self._penalties_active = not (
+            is_default_value(sampling_params.presence_penalty, self._DEFAULT_PENALTIES["presence"])
+            and is_default_value(sampling_params.frequency_penalty, self._DEFAULT_PENALTIES["frequency"])
+            and is_default_value(sampling_params.repetition_penalty, self._DEFAULT_PENALTIES["repetition"])
+        )
+        if (
+            not self.tt_sampling.force_argmax_sampling
+            or self._penalties_active
+            or self._penalties_active != old_penalties_active
+        ):
+            self.tt_penalties.reset_params(
+                sampling_params.presence_penalty, sampling_params.frequency_penalty, sampling_params.repetition_penalty
+            )
+        self._log_probs_active = self.tt_sampling.log_probs_calculator.enable_log_probs
+        _log_sampling_debug(
+            self._sampling_debug_enabled,
+            "SamplingGenerator reset params",
+            empty_slots=_compact_debug_list(empty_slots),
+            force_argmax=self.tt_sampling.force_argmax_sampling,
+            force_argmax_changed=self.tt_sampling.force_argmax_sampling != old_force_argmax_sampling,
+            penalties_active=self._penalties_active,
+            log_probs_active=self._log_probs_active,
+            temperature=_compact_debug_list(sampling_params.temperature),
+            top_k=_compact_debug_list(sampling_params.top_k),
+            top_p=_compact_debug_list(sampling_params.top_p),
+            presence_penalty=_compact_debug_list(sampling_params.presence_penalty),
+            frequency_penalty=_compact_debug_list(sampling_params.frequency_penalty),
+            repetition_penalty=_compact_debug_list(sampling_params.repetition_penalty),
+            seed=_compact_debug_list(getattr(sampling_params, "seed", None)),
+        )
+
+    def _validate_trace_inputs(self, slot, logits: ttnn.Tensor, tt_out_tok: Optional[ttnn.Tensor]):
+        if slot["input"] is None or slot["output"] is None:
+            raise RuntimeError("Trace metadata missing. Call capture_trace first.")
+
+        if logits is not slot["input"]:
+            raise ValueError(
+                "The provided logits tensor does not match the tensor used during trace capture. "
+                "Call `reset_trace()` before tracing with new tensors."
+            )
+        if isinstance(slot["output"], tuple):
+            if tt_out_tok is not None and tt_out_tok is not slot["output"][0]:
+                raise ValueError(
+                    "The provided output tensor does not match the tensor used during trace capture. "
+                    "Call `reset_trace()` before tracing with new tensors."
+                )
+        else:
+            if tt_out_tok is not None and tt_out_tok is not slot["output"]:
+                raise ValueError(
+                    "The provided output tensor does not match the tensor used during trace capture. "
+                    "Call `reset_trace()` before tracing with new tensors."
+                )
+
+    def _run_sampling(
+        self,
+        logits,
+        *,
+        penalties_on: bool,
+        tt_out_tok: Optional[ttnn.Tensor],
+    ):
+        if penalties_on:
+            logits = self.tt_penalties.apply(logits)
+        tt_tokens, tt_log_probs = self.tt_sampling(logits, tt_out_tok=tt_out_tok)
+        return tt_tokens, tt_log_probs
+
+    def capture_trace(
+        self,
+        logits: ttnn.Tensor,
+        *,
+        tt_out_tok: Optional[ttnn.Tensor] = None,
+        skip_precompile: bool = False,
+    ) -> ttnn.Tensor:
+        """
+        Capture a trace of the sampling pipeline for the given configuration.
+        """
+        penalties_on = self._penalties_active
+        log_probs_on = getattr(self, "_log_probs_active", False)
+        force_argmax = self.tt_sampling.force_argmax_sampling
+
+        key, slot = self._trace_slot(penalties_on, log_probs_on, force_argmax)
+
+        if not skip_precompile:
+            logger.debug(
+                f"Pre-compiling sampling path before trace capture (penalties={penalties_on},log_probs_on={log_probs_on},force_argmax={force_argmax})"
+            )
+            self._run_sampling(
+                logits,
+                penalties_on=penalties_on,
+                tt_out_tok=tt_out_tok,
+            )
+
+        trace_id = ttnn.begin_trace_capture(self.mesh_device, cq_id=self.cq_id)
+        sampled = self._run_sampling(
+            logits,
+            penalties_on=penalties_on,
+            tt_out_tok=tt_out_tok,
+        )
+        ttnn.end_trace_capture(self.mesh_device, trace_id, cq_id=self.cq_id)
+        ttnn.synchronize_device(self.mesh_device)
+
+        if tt_out_tok is not None:
+            if isinstance(sampled, tuple):
+                output = (tt_out_tok, sampled[-1])
+            else:
+                output = (tt_out_tok, sampled)
+        else:
+            output = sampled
+
+        slot["id"] = trace_id
+        slot["input"] = logits
+        slot["output"] = output
+        slot["kwargs"] = {"tt_out_tok": tt_out_tok}
+
+        return slot["output"]
+
+    def _execute_trace(self, key: _TraceKey) -> ttnn.Tensor:
+        slot = self._trace_states.get(key)
+        if slot is None:
+            raise RuntimeError("Trace has not been captured yet.")
+        if slot["id"] is None or slot["output"] is None:
+            raise RuntimeError("Trace has not been captured yet.")
+
+        ttnn.execute_trace(self.mesh_device, slot["id"], cq_id=self.cq_id, blocking=False)
+        return slot["output"]
+
+    def sample(
+        self,
+        logits: ttnn.Tensor,
+        *,
+        enable_trace: bool = True,
+        tt_out_tok: Optional[ttnn.Tensor] = None,
+        skip_precompile: bool = False,
+    ) -> ttnn.Tensor:
+        """
+        Convenience wrapper that either runs the sampling module directly or
+        replays a captured trace.
+        """
+
+        penalties_on = self._penalties_active
+        log_probs_on = getattr(self, "_log_probs_active", False)
+        force_argmax = self.tt_sampling.force_argmax_sampling
+        # Explicit request seeds update a persistent seed tensor every token;
+        # run them directly so trace replay cannot observe stale seed state.
+        use_internal_trace = enable_trace and not self.seed_manager.has_active_request_seed()
+        _log_sampling_debug(
+            self._sampling_debug_enabled,
+            "SamplingGenerator sample",
+            enable_trace=enable_trace,
+            use_internal_trace=use_internal_trace,
+            penalties_on=penalties_on,
+            log_probs_on=log_probs_on,
+            force_argmax=force_argmax,
+            logits_shape=list(logits.shape),
+            tt_out_tok_shape=list(tt_out_tok.shape) if tt_out_tok is not None else None,
+        )
+
+        if not use_internal_trace:
+            tt_out = self._run_sampling(
+                logits,
+                penalties_on=penalties_on,
+                tt_out_tok=tt_out_tok,
+            )
+        else:
+            key, slot = self._trace_slot(penalties_on, log_probs_on, force_argmax)
+            if slot["id"] is None:
+                return self.capture_trace(
+                    logits,
+                    tt_out_tok=tt_out_tok,
+                    skip_precompile=skip_precompile,
+                )
+
+            self._validate_trace_inputs(slot, logits, tt_out_tok)
+            tt_out = self._execute_trace(key)
+
+        if penalties_on and tt_out is not None:
+            if isinstance(tt_out, tuple):
+                self.tt_penalties.update_output_tokens(tt_out[0])
+            else:
+                self.tt_penalties.update_output_tokens(tt_out)
+        return tt_out
+
+
+def format_sampling_params(sampling_params, max_batch_size):
+    """
+    Format sampling parameters for on-device use.
+
+    Converts scalar fields to lists, pads all lists to ``max_batch_size``,
+    inverts temperature, clamps top-p/top-k, and normalises penalties.
+
+    Returns a **new** SamplingParams — the input is never mutated.
+    """
+    if not isinstance(sampling_params.temperature, List):
+        update_dict = {field.name: [getattr(sampling_params, field.name)] for field in fields(sampling_params)}
+        sampling_params = replace(sampling_params, **update_dict)
+
+    target_len = max_batch_size
+    assert target_len % 32 == 0, f"Sampling batch size must be a multiple of 32, got {target_len}"
+
+    # Defaults used when padding short lists to target_len
+    defaults = {
+        "temperature": 0.0,
+        "top_p": 1.0,
+        "top_k": 1,
+        "presence_penalty": 0.0,
+        "frequency_penalty": 0.0,
+        "repetition_penalty": 1.0,
+        "seed": None,
+        "num_logprobs": 0,
+        "enable_log_probs": False,
+    }
+
+    def _pad(lst, name):
+        """Return a new list padded to target_len with the default for *name*."""
+        if len(lst) >= target_len:
+            return list(lst)
+        return list(lst) + [defaults[name]] * (target_len - len(lst))
+
+    # Pad core sampling fields (scalar→list already done above)
+    temperature = _pad(sampling_params.temperature, "temperature")
+    top_p = _pad(sampling_params.top_p, "top_p")
+    top_k = _pad(sampling_params.top_k, "top_k")
+
+    # enable_log_probs / num_logprobs: scalar → broadcast to all users.
+    # Multi-element list → pad with default (False/0) for inactive slots.
+    # Single-element list (from scalar→list conversion) → broadcast to all.
+    def _broadcast_pad(lst, name):
+        if not isinstance(lst, list):
+            return [lst] * target_len
+        if len(lst) == 1:
+            return lst * target_len
+        return _pad(lst, name)
+
+    enable_log_probs = _broadcast_pad(sampling_params.enable_log_probs, "enable_log_probs")
+    if getattr(sampling_params, "num_logprobs", None) is not None:
+        num_logprobs = _broadcast_pad(sampling_params.num_logprobs, "num_logprobs")
+    else:
+        num_logprobs = None
+
+    # Normalise and pad penalty / seed fields (may still be None/scalar)
+    def _normalise_and_pad(name):
+        value = getattr(sampling_params, name, None)
+        if value is None:
+            lst = [defaults[name]]
+        elif isinstance(value, List):
+            lst = list(value)
+        else:
+            lst = [value]
+        return _pad(lst, name)
+
+    presence_penalty = _normalise_and_pad("presence_penalty")
+    frequency_penalty = _normalise_and_pad("frequency_penalty")
+    repetition_penalty = _normalise_and_pad("repetition_penalty")
+    seed = _normalise_and_pad("seed")
+
+    # Clamp / transform values in the new lists (no mutation of the input)
+    TOP_P_MIN = 0.0
+    TOP_P_MAX = 1.0
+
+    for i in range(len(temperature)):
+        top_p[i] = clamp(top_p[i], TOP_P_MIN, TOP_P_MAX)
+
+        if temperature[i] == 0:
+            temperature[i] = 1.0
+            top_k[i] = 1
+            # Device sampling treats p=0 as a first-token cutoff; with k=1
+            # this is the compact argmax representation for greedy rows.
+            top_p[i] = 0.0
+        else:
+            temperature[i] = 1 / temperature[i]
+
+        # top_k contract: TT sampling supports up to 32 today.
+        # k < 1 means "no restriction" → max (32); k > 32 → capped to 32.
+        if top_k[i] < 1:
+            top_k[i] = 32
+        if top_k[i] > 32:
+            top_k[i] = 32
+
+        if repetition_penalty[i] == 0:
+            repetition_penalty[i] = defaults["repetition_penalty"]
+
+    kwargs = dict(
+        temperature=temperature,
+        top_p=top_p,
+        top_k=top_k,
+        presence_penalty=presence_penalty,
+        frequency_penalty=frequency_penalty,
+        repetition_penalty=repetition_penalty,
+        seed=seed,
+    )
+    # Only include logprobs fields if the input dataclass has them
+    # (vLLM's TTSamplingParams may not have these fields)
+    input_fields = {f.name for f in fields(sampling_params)}
+    if "num_logprobs" in input_fields:
+        kwargs["num_logprobs"] = num_logprobs
+    if "enable_log_probs" in input_fields:
+        kwargs["enable_log_probs"] = enable_log_probs
+
+    return replace(sampling_params, **kwargs)
+
+
+def broadcast_sampling_params(
+    formatted_sampling_params,
+    idx: int,
+    slot_len: int = 32,
+):
+    """
+    Create a new SamplingParams where each list field is broadcast to a full list of length
+    ``slot_len``, taking the value from ``idx``. Does not mutate the input.
+    """
+    kwargs = {}
+    for f in fields(formatted_sampling_params):
+        value = getattr(formatted_sampling_params, f.name)
+        value_is_list = isinstance(value, List)
+        if value_is_list:
+            chosen = value[idx] if idx < len(value) else value[0]
+        else:
+            chosen = value
+        if value_is_list:
+            # Preserve list fields as lists even when the selected value is None.
+            kwargs[f.name] = [chosen] * slot_len
+        elif chosen is None:
+            kwargs[f.name] = None
+        else:
+            kwargs[f.name] = [chosen] * slot_len
+    return SamplingParams(**kwargs)
+
+
+def chunk_sampling_params(sampling_params, sampling_dp: int) -> list:
+    """
+    Chunk a SamplingParams (or duck-type-compatible object) into ``sampling_dp`` pieces.
+
+    List fields are split evenly (length must be divisible by ``sampling_dp``).
+    Scalar fields are replicated to all chunks.  Falls back to dataclass defaults
+    for missing attributes so that vLLM's TTSamplingParams works transparently.
+
+    Returns a list of SamplingParams.
+    """
+    if sampling_dp == 1:
+        return [sampling_params]
+
+    chunked_fields = {}
+    for field_name in SAMPLING_PARAM_FIELDS:
+        try:
+            val = getattr(sampling_params, field_name)
+        except AttributeError:
+            if hasattr(SamplingParams, field_name):
+                val = getattr(SamplingParams, field_name)
+            else:
+                raise
+        if isinstance(val, list):
+            assert (
+                len(val) % sampling_dp == 0
+            ), f"Sampling param '{field_name}' length {len(val)} not divisible by sampling_dp {sampling_dp}"
+            chunked_fields[field_name] = split_list(val, sampling_dp)
+        else:
+            chunked_fields[field_name] = [val] * sampling_dp
+
+    return [
+        SamplingParams(**{field: chunked_fields[field][i] for field in SAMPLING_PARAM_FIELDS})
+        for i in range(sampling_dp)
+    ]
+
+
+class SeedManager:
+    """Manages per-user RNG seeds for on-device sampling.
+
+    Tracks which users have explicit seeds set (``_seed_active``) and avoids
+    unnecessary host-to-device copies during decode when no seeds are active.
+    """
+
+    def __init__(self, tt_sampling, max_batch_size=32):
+        self.max_batch_size = max_batch_size
+        self.seeds = [None for _ in range(max_batch_size)]
+        self.seed_counters = [0 for _ in range(max_batch_size)]
+        # Pre-allocate RNG objects; actual request seeds are set via reset_seed().
+        self.rngs = [random.Random(secrets.randbits(64)) for _ in range(max_batch_size)]
+        self.tt_sampling = tt_sampling
+        self._sampling_debug_enabled = getattr(tt_sampling, "_sampling_debug_enabled", False)
+        # True when at least one user slot has a non-None request seed.
+        self._seed_active = False
+        # Set to True by reset_seed() so the next get_new_values() pushes
+        # fresh values to the device. When _seed_active is True this pushes
+        # per-user seeds; when False it pushes varied per-user
+        # values to diversify the device RNG state. Cleared after the push.
+        self._reseted = False
+        # When True, the next get_new_values() must push MAX_UINT32 (SKIP) so
+        # the device transitions from rand_tile_init to rand_tile advance.
+        self._needs_skip = False
+        # True only for the most recent get_new_values() call when at least
+        # one active slot used an explicit request seed.
+        self._active_request_seed = False
+        # Mesh mapper for sharding seeds across rows when sampling_dp > 1.
+        if tt_sampling._sampling_dp > 1:
+            self._seed_mapper = ttnn.ShardTensor2dMesh(
+                tt_sampling.mesh_device, dims=tt_sampling._param_dims, mesh_shape=tt_sampling.cluster_shape
+            )
+        else:
+            self._seed_mapper = None
+
+    def _next_unseeded_rng_seed(self) -> int:
+        return secrets.randbits(64)
+
+    def _next_unseeded_device_seed(self) -> int:
+        return secrets.randbelow(DEVICE_SEED_MAX) + 1
+
+    def _next_device_seed_from_rng(self, rng: random.Random) -> int:
+        return rng.randint(1, DEVICE_SEED_MAX)
+
+    def _next_device_seed_for_slot(self, slot: int) -> int:
+        request_seed = self.seeds[slot]
+        if request_seed is None:
+            return self._next_device_seed_from_rng(self.rngs[slot])
+        device_seed = _hash_request_seed_to_device_seed(int(request_seed), self.seed_counters[slot])
+        self.seed_counters[slot] += 1
+        return device_seed
+
+    def _seed_from_slot_params(self, seeds, slot: int):
+        if seeds is None:
+            return None
+        if isinstance(seeds, torch.Tensor):
+            flat = seeds.reshape(-1)
+            if slot < 0 or slot >= flat.numel():
+                return None
+            seed = flat[slot]
+        elif isinstance(seeds, list):
+            if slot < 0 or slot >= len(seeds):
+                return None
+            seed = seeds[slot]
+        else:
+            seed = seeds
+
+        if seed is None:
+            return None
+        if isinstance(seed, torch.Tensor):
+            if seed.numel() == 0:
+                return None
+            seed = seed.reshape(-1)[0].item()
+        return int(seed)
+
+    def reset_seed_from_slots(self, seeds, user_ids):
+        """Reset decode seed state from slot-indexed sampling params."""
+        if user_ids is None:
+            user_ids = range(self.max_batch_size)
+        for user in user_ids:
+            slot = int(user)
+            seed = self._seed_from_slot_params(seeds, slot)
+            self.seeds[slot] = seed
+            self.seed_counters[slot] = 0
+            if seed is None:
+                self.rngs[slot].seed(self._next_unseeded_rng_seed())
+            else:
+                self.rngs[slot].seed(int(seed))
+        self._seed_active = any(s is not None for s in self.seeds)
+        self._reseted = True
+
+    def reset_seed_from_slots_if_needed(self, seeds, user_ids) -> bool:
+        """Reset only active slots whose slot-indexed seed changed."""
+        if user_ids is None:
+            user_ids = range(self.max_batch_size)
+        reset_slots = []
+        for user in user_ids:
+            slot = int(user)
+            if self._seed_from_slot_params(seeds, slot) != self.seeds[slot]:
+                reset_slots.append(slot)
+        if not reset_slots:
+            return False
+        self.reset_seed_from_slots(seeds, reset_slots)
+        return True
+
+    def align_seed_counters_to_positions(self, seeds, user_ids, positions, offset: int = 1):
+        """Make explicit-seed decode independent of persistent slot lifetime.
+
+        vLLM can temporarily remove running requests from the persistent batch
+        while admitting another prefill batch, then re-add them in different
+        slots. For explicit request seeds, deriving the per-token device seed
+        from the absolute decode position keeps the stream reproducible even
+        when the Python-side slot counter was reset or moved.
+        """
+        if positions is None:
+            return
+        if user_ids is None:
+            user_ids = range(self.max_batch_size)
+
+        if isinstance(positions, torch.Tensor):
+            flat_positions = positions.reshape(-1)
+
+            def _position(slot):
+                if slot < 0 or slot >= flat_positions.numel():
+                    return None
+                pos = flat_positions[slot]
+                return int(pos.item())
+
+        elif isinstance(positions, list):
+
+            def _position(slot):
+                if slot < 0 or slot >= len(positions):
+                    return None
+                return int(positions[slot])
+
+        else:
+
+            def _position(_slot):
+                return int(positions)
+
+        for user in user_ids:
+            slot = int(user)
+            seed = self._seed_from_slot_params(seeds, slot)
+            if seed is None:
+                continue
+            position = _position(slot)
+            if position is None or position < 0:
+                continue
+            self.seed_counters[slot] = max(0, position + offset)
+
+    def has_active_request_seed(self) -> bool:
+        return self._active_request_seed
+
+    def _debug_state(self, slots=None):
+        if slots is None:
+            slots = range(self.max_batch_size)
+        state = []
+        for slot in slots:
+            slot = int(slot)
+            if slot < 0 or slot >= self.max_batch_size:
+                continue
+            seed = self.seeds[slot]
+            if seed is not None:
+                state.append((slot, seed))
+        return _compact_debug_list(state)
+
+    def apply_slot_remap(self, remap):
+        """Reindex RNG state after batch condense.
+
+        ``remap`` is a 1-D int tensor of length ``max_batch_size`` where
+        ``remap[i] = j`` means slot *i* now holds the request that was
+        previously at slot *j*. Identity entries (``remap[i] == i``) are
+        no-ops. Only non-identity entries trigger a move.
+        """
+        if not self._seed_active:
+            return
+        moves = [(int(remap[i]), i) for i in range(len(remap)) if int(remap[i]) != i]
+        if not moves:
+            _log_sampling_debug(
+                self._sampling_debug_enabled, "SeedManager slot remap identity", seed_active=self._seed_active
+            )
+            return
+        # Snapshot the state we're about to overwrite.
+        _log_sampling_debug(
+            self._sampling_debug_enabled,
+            "SeedManager slot remap",
+            moves=_compact_debug_list(moves),
+            state_before=self._debug_state(),
+        )
+        old_seeds = list(self.seeds)
+        old_counters = list(self.seed_counters)
+        old_rngs = list(self.rngs)
+        moved_sources = {old_slot for old_slot, _ in moves}
+        moved_destinations = {new_slot for _, new_slot in moves}
+        for old_slot, new_slot in moves:
+            self.seeds[new_slot] = old_seeds[old_slot]
+            self.seed_counters[new_slot] = old_counters[old_slot]
+            # copy.copy preserves internal RNG state but creates an
+            # independent object so the old slot reference does not alias
+            # the new one.
+            self.rngs[new_slot] = copy.copy(old_rngs[old_slot])
+        for old_slot in moved_sources - moved_destinations:
+            self.seeds[old_slot] = None
+            self.seed_counters[old_slot] = 0
+        self._seed_active = any(s is not None for s in self.seeds)
+        _log_sampling_debug(
+            self._sampling_debug_enabled,
+            "SeedManager slot remap done",
+            seed_active=self._seed_active,
+            state_after=self._debug_state(),
+        )
+
+    def reset_seed(self, seeds, user_ids):
+        """Update RNG state for the given user slots after a prefill.
+
+        Args:
+            seeds: Seed values in request order. Accepts a list, tensor, scalar,
+                or None (treated as all unseeded).
+            user_ids: Batch slot indices being prefilled.
+        """
+        user_ids = [int(user) for user in user_ids]
+        _log_sampling_debug(
+            self._sampling_debug_enabled,
+            "SeedManager reset prefill",
+            user_ids=_compact_debug_list(user_ids),
+            requested_seeds=_compact_debug_list(seeds),
+            state_before=self._debug_state(user_ids),
+        )
+        for i, user in enumerate(user_ids):
+            slot = int(user)
+            seed = self._seed_from_slot_params(seeds, i)
+            self.seeds[slot] = seed
+            self.seed_counters[slot] = 0
+            if seed is None:
+                self.rngs[slot].seed(self._next_unseeded_rng_seed())
+            else:
+                self.rngs[slot].seed(int(seed))
+        self._seed_active = any(s is not None for s in self.seeds)
+        self._reseted = True
+        _log_sampling_debug(
+            self._sampling_debug_enabled,
+            "SeedManager reset prefill done",
+            seed_active=self._seed_active,
+            state_after=self._debug_state(user_ids),
+        )
+
+    def get_new_values(self, empty_slots=None, replicate_seeds=False):
+        """Generate and push new seed values to the device.
+
+        **Seeded path** (``_seed_active=True``):
+        Advances each active slot seed state and copies the new values to
+        the device every step. Explicit request seeds produce slot-independent
+        device seeds derived from the request seed and the slot counter. Some
+        decode callers align that counter to the absolute token position so
+        vLLM batch-layout changes cannot reset a request's random stream.
+
+        **Unseeded path** (``_seed_active=False``):
+        Uses a three-state machine to ensure each user gets a unique device
+        RNG state without redundant host-to-device copies during decode:
+
+          State 1 - **init** (``_reseted=True``):
+            Push varied per-user values from system entropy.
+
+          State 2 - **transition** (``_needs_skip=True``):
+            Push MAX_UINT32 (SKIP) so the device stops reinitializing and
+            starts advancing via rand_tile().
+
+          State 3 - **steady** (both flags clear):
+            Early-return with no device copy.
+        """
+        if empty_slots is None:
+            empty_slots = list(range(self.max_batch_size))
+        else:
+            empty_slots = [int(slot) for slot in empty_slots]
+        empty_slot_set = set(empty_slots)
+        self._active_request_seed = any(self.seeds[i] is not None for i in empty_slot_set)
+
+        if not self._seed_active:
+            self._active_request_seed = False
+            if self._reseted:
+                new_seeds = [self._next_unseeded_device_seed() for _ in range(self.max_batch_size)]
+                self._needs_skip = True
+            elif self._needs_skip:
+                new_seeds = [MAX_UINT32] * self.max_batch_size
+                self._needs_skip = False
+            else:
+                # State 3 (steady): device already has SKIP, rand_tile
+                # advances on its own, so no host-to-device copy is needed.
+                _log_sampling_debug(
+                    self._sampling_debug_enabled,
+                    "SeedManager seed update skipped",
+                    active_slots=_compact_debug_list(empty_slots),
+                    seed_active=self._seed_active,
+                    reseted=self._reseted,
+                    needs_skip=self._needs_skip,
+                )
+                return
+        else:
+            new_seeds = [
+                self._next_device_seed_for_slot(i) if i in empty_slot_set else MAX_UINT32
+                for i in range(self.max_batch_size)
+            ]
+            if replicate_seeds:
+                assert len(empty_slots) == 1, "Cannot replicate seeds if empty_slots is not length 1"
+                new_seeds = self.max_batch_size * [new_seeds[empty_slots[0]]]
+
+        _log_sampling_debug(
+            self._sampling_debug_enabled,
+            "SeedManager seed update",
+            active_slots=_compact_debug_list(empty_slots),
+            replicate_seeds=replicate_seeds,
+            seed_active=self._seed_active,
+            reseted=self._reseted,
+            needs_skip=self._needs_skip,
+            new_device_seeds=_compact_debug_list(new_seeds),
+            state_after_counter_advance=self._debug_state(empty_slots),
+        )
+
+        new_seed_tt = ttnn.from_torch(
+            torch.tensor(new_seeds), dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT, mesh_mapper=self._seed_mapper
+        )
+        ttnn.copy_host_to_device_tensor(new_seed_tt, self.tt_sampling.seeds_tt_tensor)
+        self._reseted = False

--- a/models/experimental/llama32_1b_quasar/sampling/sampling_params.py
+++ b/models/experimental/llama32_1b_quasar/sampling/sampling_params.py
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class SamplingParams:
+    """
+    Used in Generator decode forward functions for greedy decoding / sampling on device.
+    The same data class exists in vLLM at vllm/v1/worker/tt_model_runner.py.
+    """
+
+    temperature: float | list[float]
+    top_k: int | list[int]
+    top_p: float | list[float]
+    presence_penalty: float | list[float] = 0.0
+    frequency_penalty: float | list[float] = 0.0
+    repetition_penalty: float | list[float] = 1.0
+    seed: int | list[int] | None = None
+    enable_log_probs: bool | list[bool] = False
+    num_logprobs: int | list[int] = 0

--- a/models/experimental/llama32_1b_quasar/sampling/tt_log_probs.py
+++ b/models/experimental/llama32_1b_quasar/sampling/tt_log_probs.py
@@ -1,0 +1,711 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import inspect
+from dataclasses import dataclass
+from typing import Optional
+
+import torch
+from loguru import logger
+
+import ttnn
+from models.experimental.llama32_1b_quasar.sampling._utils import filter_none
+
+# Maximum number of top logprobs that can be requested (OpenAI API limit)
+MAX_TOP_LOGPROBS = 20
+# Number of top logprobs computed on device (gathered top-k from all devices)
+DEVICE_TOP_K = 32
+
+
+@dataclass
+class LogProbsResult:
+    """Result of log-probs calculation for a batch.
+
+    Contains logprobs and global indices for the gathered top-k tokens across all
+    devices.  The sampled token is always part of the gathered top-k (it was selected
+    from them by ttnn.sampling), so its logprob can be looked up by matching its
+    index in ``topk_indices``.
+
+    Attributes:
+        topk_logprobs: Optional ttnn.Tensor of shape (1, 1, batch_size, DEVICE_TOP_K)
+            containing logprobs for the gathered top-k tokens.
+        topk_indices: Optional ttnn.Tensor of shape (1, 1, batch_size, DEVICE_TOP_K)
+            containing global vocabulary indices for the gathered top-k tokens.
+        topk_logprobs_host: Optional ttnn.Tensor on host of shape (1, 1, batch_size, DEVICE_TOP_K)
+            containing logprobs for the gathered top-k tokens after moving to host.
+        topk_indices_host: Optional ttnn.Tensor on host of shape (1, 1, batch_size, DEVICE_TOP_K)
+            containing global vocabulary indices for the gathered top-k tokens after moving to host.
+    """
+
+    topk_logprobs: Optional[ttnn.Tensor]
+    topk_indices: Optional[ttnn.Tensor]
+    topk_logprobs_host: Optional[ttnn.Tensor]
+    topk_indices_host: Optional[ttnn.Tensor]
+
+    def cpu(self, blocking: bool = True) -> "LogProbsResult":
+        """Transfer device tensors to host CPU.
+
+        Args:
+            blocking: If True, wait for the host tensor to be ready before returning.
+
+        Returns:
+            A new LogProbsResult so that each iteration gets its own host
+            tensor references (avoids race with trace-captured singletons).
+        """
+        return LogProbsResult(
+            topk_logprobs=None,
+            topk_indices=None,
+            topk_logprobs_host=self.topk_logprobs.cpu(blocking=blocking),
+            topk_indices_host=self.topk_indices.cpu(blocking=blocking),
+        )
+
+    def extract_user(self, user_batch_idx: int) -> "LogProbsResult":
+        """Extract a single user's top-K logprobs from a batched host result.
+
+        Args:
+            user_batch_idx: Index of the user within the batch dimension.
+
+        Returns:
+            A new LogProbsResult with host tensors sliced to shape (1, DEVICE_TOP_K).
+        """
+        lp_torch = ttnn.to_torch(ttnn.get_device_tensors(self.topk_logprobs_host)[0])
+        idx_torch = ttnn.to_torch(ttnn.get_device_tensors(self.topk_indices_host)[0])
+        return LogProbsResult(
+            topk_logprobs=None,
+            topk_indices=None,
+            topk_logprobs_host=lp_torch[0, 0, user_batch_idx, :].unsqueeze(0),
+            topk_indices_host=idx_torch[0, 0, user_batch_idx, :].unsqueeze(0),
+        )
+
+    def to_torch_pair(self):
+        """Convert host tensors to a (logprobs, indices) pair of torch tensors.
+
+        Returns:
+            Tuple of (logprobs_tensor, indices_tensor), each of shape (DEVICE_TOP_K,).
+        """
+        lp = self.topk_logprobs_host
+        idx = self.topk_indices_host
+        if isinstance(lp, torch.Tensor):
+            return lp.reshape(-1)[:DEVICE_TOP_K].float(), idx.reshape(-1)[:DEVICE_TOP_K].int()
+        return ttnn.to_torch(lp).reshape(-1)[:DEVICE_TOP_K].float(), ttnn.to_torch(idx).reshape(-1)[:DEVICE_TOP_K].int()
+
+
+def reformat_logprobs(output_log_probs, batch_size):
+    """Convert a list of per-user logprobs into the format expected by vLLM.
+
+    Args:
+        output_log_probs: List of LogProbsResult, torch.Tensor, float, int, or None per user.
+        batch_size: Total batch size.
+
+    Returns:
+        For new path (LogProbsResult): tuple of (topk_lp[B, DEVICE_TOP_K], topk_idx[B, DEVICE_TOP_K])
+        For old path: flat tensor of shape [B]
+    """
+    has_logprobs_result = any(isinstance(lp, LogProbsResult) for lp in output_log_probs)
+    if has_logprobs_result:
+        all_lp = torch.zeros(batch_size, DEVICE_TOP_K, dtype=torch.float32)
+        all_idx = torch.zeros(batch_size, DEVICE_TOP_K, dtype=torch.int32)
+        for i, lp in enumerate(output_log_probs):
+            if isinstance(lp, LogProbsResult) and lp.topk_logprobs_host is not None:
+                all_lp[i], all_idx[i] = lp.to_torch_pair()
+        return (all_lp, all_idx)
+    else:
+        flat_lp = torch.ones(batch_size, dtype=torch.float32)
+        for i, lp in enumerate(output_log_probs):
+            if lp is not None and isinstance(lp, (torch.Tensor, float, int)):
+                flat_lp[i] = float(lp)
+        return flat_lp
+
+
+class LogProbsCalculator:
+    """
+    Class to calculate log-probs for a given logits tensor and indices tensor.
+
+    Supports two modes:
+    - Old mode (backward compat): calculate_log_probs() returns single sampled-token logprob
+    - New mode (gpt-oss-120b): calculate_topk_log_probs() returns top-32 logprobs + indices
+
+    Args:
+        mesh_device: MeshDevice to use for all-gather operations
+        sub_core_grids: Sub-core grid configuration for operations (optional)
+        tt_ccl: CCL object for distributed operations (optional)
+        batch_size: Maximum batch size for log-probs calculation (default: 32)
+        use_topk_logprobs: If True, allocate tensors for new top-K path instead of old path
+    """
+
+    def __init__(
+        self,
+        mesh_device: ttnn.MeshDevice,
+        sub_core_grids: ttnn.CoreRangeSet = None,
+        tt_ccl=None,
+        batch_size: int = 32,
+        use_topk_logprobs: bool = False,
+    ):
+        self.global_max = None
+        self.global_exp_sum = None
+        self.mesh_device = mesh_device
+        self.enable_log_probs = False  # default to False
+        # Per-user boolean array tracking which users have logprobs enabled
+        self.logprobs_enabled = [False] * batch_size
+        # Per-user integer array tracking how many top logprobs each user requested (0-20)
+        self.num_logprobs = [0] * batch_size
+        # Flag: True when at least one user needs top-k logprobs (num_logprobs > 0)
+        self.topk_logprobs_needed = False
+        self.cluster_shape = list(mesh_device.shape)
+        self.sub_core_grids = sub_core_grids
+        self.tt_ccl = tt_ccl
+        self.batch_size = batch_size
+        self._use_topk_logprobs = use_topk_logprobs
+        self.common_args = filter_none(
+            {
+                "sub_core_grids": sub_core_grids,
+            }
+        )
+
+        # CCL introspection (same pattern as TTSampling)
+        self._line_all_gather = getattr(self.tt_ccl, "line_all_gather", None)
+        self._line_all_gather_supports_buffer_key = False
+        if callable(self._line_all_gather):
+            try:
+                sig = inspect.signature(self._line_all_gather)
+                params = sig.parameters
+                self._line_all_gather_supports_buffer_key = "buffer_key" in params or any(
+                    p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values()
+                )
+            except (TypeError, ValueError):
+                logger.warning("Unable to inspect line_all_gather signature; assuming no buffer_key support.")
+
+        num_devices = self.mesh_device.get_num_devices()
+
+        # Determine the TP dimension: logits are sharded across the mesh axis that
+        # holds multiple devices. Handles 2D (e.g. 8×4), 1×N (T3K), and N×1 meshes.
+        if num_devices > 1:
+            if self.cluster_shape[0] > 1 and self.cluster_shape[1] > 1:
+                tp_axis = 0 if self.cluster_shape[0] >= self.cluster_shape[1] else 1
+            elif self.cluster_shape[0] > 1:
+                tp_axis = 0
+            else:
+                # num_devices > 1 implies at least one dim > 1; here dim0 == 1 → 1×N (T3K)
+                tp_axis = 1
+            num_devices_for_sharding = self.cluster_shape[tp_axis]
+            self._all_gather_cluster_axis = tp_axis
+        else:
+            num_devices_for_sharding = num_devices
+            self._all_gather_cluster_axis = None
+
+        self.num_devices_for_sharding = num_devices_for_sharding
+
+        # Initialize tensors based on mode
+        # Old path tensors (backward compat for non-gpt-oss models)
+        self.mask = None
+        self.output_tensor = None
+        # New path tensors (gpt-oss-120b top-K logprobs)
+        self.topk_logprobs_output = None
+        self.topk_indices_output = None
+
+        if use_topk_logprobs:
+            # New path: allocate top-K output tensors
+            self.topk_logprobs_output = ttnn.as_tensor(
+                torch.zeros(1, 1, batch_size, DEVICE_TOP_K),
+                dtype=ttnn.bfloat16,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                device=self.mesh_device,
+                layout=ttnn.TILE_LAYOUT,
+                mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
+            )
+            self.topk_indices_output = ttnn.as_tensor(
+                torch.zeros(1, 1, batch_size, DEVICE_TOP_K, dtype=torch.int32),
+                dtype=ttnn.uint32,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                device=self.mesh_device,
+                layout=ttnn.TILE_LAYOUT,
+                mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
+            )
+        else:
+            # Old path: allocate mask and output tensors
+            mask_tensor = (
+                torch.arange(num_devices_for_sharding).unsqueeze(1).expand(num_devices_for_sharding, batch_size)
+            )
+
+            if self._all_gather_cluster_axis is not None:
+                dims = (0, None) if self._all_gather_cluster_axis == 0 else (None, 0)
+                mesh_mapper = ttnn.ShardTensor2dMesh(self.mesh_device, dims=dims, mesh_shape=self.cluster_shape)
+            else:
+                mesh_mapper = ttnn.ReplicateTensorToMesh(self.mesh_device)
+
+            self.mask = ttnn.as_tensor(
+                mask_tensor,
+                dtype=ttnn.bfloat16,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                device=self.mesh_device,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+                preprocess=lambda x: x.to(torch.bfloat16),
+                mesh_mapper=mesh_mapper,
+            )
+            self.output_tensor = ttnn.as_tensor(
+                torch.ones(1, 1, 1, batch_size),
+                dtype=ttnn.bfloat16,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                device=self.mesh_device,
+                layout=ttnn.TILE_LAYOUT,
+                mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
+            )
+
+    def _perform_all_gather(self, tensor: ttnn.Tensor, dim: int, num_links: int, buffer_key: str = None):
+        if callable(self._line_all_gather):
+            kwargs = {
+                "dim": dim,
+                "num_links": num_links,
+                "memory_config": tensor.memory_config(),
+                "cluster_axis": self._all_gather_cluster_axis,
+            }
+            if self._line_all_gather_supports_buffer_key and buffer_key is not None:
+                kwargs["buffer_key"] = buffer_key
+            return self._line_all_gather(tensor, **kwargs)
+
+        return ttnn.all_gather(
+            tensor,
+            dim=dim,
+            num_links=num_links,
+            memory_config=tensor.memory_config(),
+            cluster_axis=self._all_gather_cluster_axis,
+            topology=ttnn.Topology.Linear,
+        )
+
+    def set_log_probs_mode(
+        self,
+        enable_log_probs: bool | list[bool] = False,
+        num_logprobs: int | list[int] | None = None,
+        empty_slots: list[int] | None = None,
+    ):
+        """Set logprobs mode for the current batch.
+
+        Args:
+            enable_log_probs: Boolean or per-user boolean list. If any user has logprobs
+                enabled, the entire batch runs logprobs computation.
+            num_logprobs: Integer or per-user integer list (0-20). Specifies how many
+                top logprobs to return per user. 0 means sampled token logprob only.
+                Values > 0 trigger top-k logprobs computation on device.
+            empty_slots: Optional list of batch indices at which to apply the new
+                logprobs settings. When provided, only those positions are updated
+                and the rest of the batch retains its previous values.
+        """
+        if empty_slots is not None:
+            # Partial update: only modify the specified batch positions
+            if isinstance(enable_log_probs, list):
+                for i, slot in enumerate(empty_slots):
+                    self.logprobs_enabled[slot] = enable_log_probs[i]
+            else:
+                for slot in empty_slots:
+                    self.logprobs_enabled[slot] = enable_log_probs
+
+            if num_logprobs is not None:
+                if isinstance(num_logprobs, list):
+                    for i, slot in enumerate(empty_slots):
+                        self.num_logprobs[slot] = num_logprobs[i]
+                else:
+                    for slot in empty_slots:
+                        self.num_logprobs[slot] = num_logprobs
+        else:
+            # Full batch update
+            if isinstance(enable_log_probs, list):
+                self.logprobs_enabled = list(enable_log_probs)
+            else:
+                self.logprobs_enabled = [enable_log_probs] * self.batch_size
+
+            if num_logprobs is not None:
+                if isinstance(num_logprobs, list):
+                    self.num_logprobs = list(num_logprobs)
+                else:
+                    self.num_logprobs = [num_logprobs] * self.batch_size
+            else:
+                self.num_logprobs = [0] * self.batch_size
+
+        # Recompute derived flags from the full arrays
+        self.enable_log_probs = any(self.logprobs_enabled)
+        # Top-K computation is needed whenever logprobs are enabled (even with
+        # num_logprobs=0) because the sampled token's logprob is extracted from
+        # the top-K results in the new path.
+        self.topk_logprobs_needed = self.enable_log_probs
+
+    def _compute_global_stats(
+        self,
+        logits_tensor: ttnn.Tensor,
+    ):
+        """
+        To calculate log-probs, we need to calculate the global max and global sum(exp(logits - global_max)) for each chip.
+        This is done by all-gathering the max and sum(exp(logits - global_max)) for each chip and then taking the max and sum of the gathered tensors.
+        log-prob formula: log-prob(x) = logits(x) - global_max - log(sum(exp(logits - global_max)))
+
+        Args:
+            logits_tensor (ttnn.Tensor): Logits as model output (1, 1, batch_size, vocab_size_per_device)
+        """
+        # Calculate local max
+        local_max_tensor = ttnn.max(logits_tensor, dim=-1, keepdim=True, **self.common_args)
+
+        gathered_max_tensors = self._perform_all_gather(
+            local_max_tensor,
+            dim=1,
+            num_links=1,
+            buffer_key="LOGPROBS_MAX_REDUCTION",
+        )
+        # Convert to ROW_MAJOR_LAYOUT due to memory clobbering which affects all ttnn.reshape ops with TILE_LAYOUT
+        gathered_max_tensors = ttnn.to_layout(gathered_max_tensors, ttnn.ROW_MAJOR_LAYOUT, **self.common_args)
+        ttnn.deallocate(local_max_tensor)
+        D = self.num_devices_for_sharding
+        B = gathered_max_tensors.shape[2]
+        gathered_max_tensors = ttnn.reshape(gathered_max_tensors, (1, 1, D, B), **self.common_args)
+        gathered_max_tensors = ttnn.to_layout(gathered_max_tensors, ttnn.TILE_LAYOUT, **self.common_args)
+
+        self.global_max = ttnn.max(gathered_max_tensors, dim=2, keepdim=True, **self.common_args)
+
+        global_max_to_subtract = ttnn.to_layout(self.global_max, ttnn.ROW_MAJOR_LAYOUT, **self.common_args)
+        global_max_to_subtract = ttnn.reshape(global_max_to_subtract, (1, 1, B, 1), **self.common_args)
+        global_max_to_subtract = ttnn.to_layout(global_max_to_subtract, ttnn.TILE_LAYOUT, **self.common_args)
+
+        # Calculate stable local sum-exp using subtract of global-max from each local logit
+        subtracted_tensor = ttnn.subtract(logits_tensor, global_max_to_subtract, **self.common_args)
+        exp_tensor = ttnn.exp(subtracted_tensor, **self.common_args)
+        ttnn.deallocate(global_max_to_subtract)
+        ttnn.deallocate(subtracted_tensor)
+        sum_exp_tensor = ttnn.sum(exp_tensor, dim=-1, keepdim=True, **self.common_args)
+        ttnn.deallocate(exp_tensor)
+
+        gathered_sum_exp_tensors = self._perform_all_gather(
+            sum_exp_tensor,
+            dim=1,
+            num_links=1,
+            buffer_key="LOGPROBS_SUM_EXP_REDUCTION",
+        )
+        gathered_sum_exp_tensors = ttnn.to_layout(gathered_sum_exp_tensors, ttnn.ROW_MAJOR_LAYOUT, **self.common_args)
+        ttnn.deallocate(sum_exp_tensor)
+        B_sum = gathered_sum_exp_tensors.shape[2]
+        gathered_sum_exp_tensors = ttnn.reshape(gathered_sum_exp_tensors, (1, 1, D, B_sum), **self.common_args)
+        gathered_sum_exp_tensors = ttnn.to_layout(gathered_sum_exp_tensors, ttnn.TILE_LAYOUT, **self.common_args)
+
+        self.global_exp_sum = ttnn.sum(gathered_sum_exp_tensors, dim=2, keepdim=True, **self.common_args)
+        ttnn.deallocate(gathered_sum_exp_tensors)
+
+    def _is_supported(self):
+        """Check if logprobs computation is supported on this device configuration."""
+        num_devices = self.mesh_device.get_num_devices()
+        if num_devices not in (8, 32):
+            return False
+        if self.num_devices_for_sharding < 2:
+            return False
+        return True
+
+    # -----------------------------------------------------------------------
+    # Old path (backward compat for non-gpt-oss models)
+    # -----------------------------------------------------------------------
+
+    def _prepare_relevant_logits(self, logits_tensor: ttnn.Tensor, global_idx_tensor: ttnn.Tensor):
+        """
+        Prepare global idx tensor with correct values on all devices.
+        """
+        size_per_device = logits_tensor.shape[-1]
+
+        # convert global_idx_tensor to ttnn.TILE_LAYOUT
+        global_idx_tilized_tensor = ttnn.to_layout(global_idx_tensor, ttnn.TILE_LAYOUT, **self.common_args)
+
+        # TODO: Raise an issue on this since for UINT_32 ttnn.div produces incorrect output (all zeros)
+        global_idx_tilized_tensor = ttnn.typecast(global_idx_tilized_tensor, ttnn.float32, **self.common_args)
+
+        # Get chip_id for each user based on global_idx values in global_idx_tensor
+        chip_ids_tensor = ttnn.div(
+            global_idx_tilized_tensor,
+            size_per_device,
+            rounding_mode="floor",
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            **self.common_args,
+        )
+
+        # Get local index for each user based on global_idx values in global_idx_tensor
+        remainder_tensor = ttnn.remainder(
+            global_idx_tilized_tensor,
+            size_per_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            **self.common_args,
+        )
+
+        # Convert remainder_tensor to int32
+        remainder_tensor = ttnn.typecast(remainder_tensor, ttnn.uint32, **self.common_args)
+        # convert to ROW_MAJOR_LAYOUT due to memory clobbering which affects all ttnn.reshape ops with TILE_LAYOUT
+        remainder_tensor = ttnn.to_layout(remainder_tensor, ttnn.ROW_MAJOR_LAYOUT, **self.common_args)
+        batch_vol = remainder_tensor.shape[2] * remainder_tensor.shape[3]
+        remainder_tensor = ttnn.reshape(remainder_tensor, (1, 1, batch_vol, 1), **self.common_args)
+        remainder_tensor = ttnn.to_layout(remainder_tensor, ttnn.TILE_LAYOUT, **self.common_args)
+
+        # Get logits for each user on each chip based on local index
+        selected_logits_tensor = ttnn.gather(logits_tensor, dim=3, index=remainder_tensor, **self.common_args)
+
+        # convert to ROW_MAJOR_LAYOUT due to memory clobbering which affects all ttnn.reshape ops with TILE_LAYOUT
+        selected_logits_tensor = ttnn.to_layout(selected_logits_tensor, ttnn.ROW_MAJOR_LAYOUT, **self.common_args)
+        batch_vol_s = selected_logits_tensor.shape[2] * selected_logits_tensor.shape[3]
+        selected_logits_tensor = ttnn.reshape(selected_logits_tensor, (1, 1, 1, batch_vol_s), **self.common_args)
+        selected_logits_tensor = ttnn.to_layout(selected_logits_tensor, ttnn.TILE_LAYOUT, **self.common_args)
+        # Compare mask to chip_ids tensor and select correct positions for each user on all chips inplace
+        ttnn.eq_(chip_ids_tensor, self.mask, **self.common_args)
+
+        # Multiply selected_logits_tensor with chip_ids_tensor to get expected logits for each user
+        selected_logits_tensor = ttnn.multiply(selected_logits_tensor, chip_ids_tensor, **self.common_args)
+
+        # All gather logits across all devices
+        selected_logits_tensor = self._perform_all_gather(
+            selected_logits_tensor,
+            dim=1,
+            num_links=1,
+            buffer_key="LOGPROBS_LOGITS",
+        )
+
+        selected_logits_tensor = ttnn.to_layout(selected_logits_tensor, ttnn.ROW_MAJOR_LAYOUT, **self.common_args)
+        D_s = self.num_devices_for_sharding
+        B_g = selected_logits_tensor.shape[3]
+        selected_logits_tensor = ttnn.reshape(selected_logits_tensor, (1, 1, D_s, B_g), **self.common_args)
+        selected_logits_tensor = ttnn.to_layout(selected_logits_tensor, ttnn.TILE_LAYOUT, **self.common_args)
+
+        # Apply sum over device dimension to get logits for each user on all chips
+        selected_logits_tensor = ttnn.sum(selected_logits_tensor, dim=2, keepdim=True, **self.common_args)
+
+        return selected_logits_tensor
+
+    def _calculate_log_probs(self, sampled_logits_tensor: ttnn.Tensor):
+        """
+        Calculate log-probs for a given logits tensor with formula:
+        log-prob(x) = logits(x) - global_max - log(global_exp_sum)
+        """
+        out = ttnn.subtract(sampled_logits_tensor, self.global_max, **self.common_args)
+        log_global_exp_sum = ttnn.log(self.global_exp_sum, **self.common_args)
+        # Subtract and put result to self.output_tensor
+        ttnn.subtract(out, log_global_exp_sum, output_tensor=self.output_tensor, **self.common_args)
+
+    def calculate_log_probs(
+        self,
+        logits_tensor: ttnn.Tensor,
+        indices_tensor: ttnn.Tensor,
+    ):
+        """
+        Calculate log-probs for a given logits tensor and indices tensor.
+        Returns None if log-probs are not requested, not supported, or the device count is not 8 or 32.
+        (Old path — backward compat for non-gpt-oss models)
+        """
+        if not self.enable_log_probs:
+            return None
+
+        if not self._is_supported():
+            return None
+
+        # Calculating log-probs requires bfloat16 precision for near-stable sum-exp calculation
+        if logits_tensor.dtype == ttnn.bfloat8_b:
+            logits_tensor = ttnn.typecast(logits_tensor, ttnn.bfloat16, **self.common_args)
+
+        # Compute global max and global sum(exp(logits - global_max)) for each chip
+        self._compute_global_stats(logits_tensor)
+
+        # Prepare relevant logits for each user on each chip
+        relevant_logits = self._prepare_relevant_logits(logits_tensor, indices_tensor)
+
+        # Calculate log-probs for each user on each chip and stores in self.output_tensor
+        self._calculate_log_probs(relevant_logits)
+
+        return self.output_tensor
+
+    # -----------------------------------------------------------------------
+    # New path (gpt-oss-120b top-K logprobs)
+    # -----------------------------------------------------------------------
+
+    def _calculate_topk_log_probs_from_values(self, topk_values: ttnn.Tensor):
+        """Compute logprobs for gathered top-k values using pre-computed global stats.
+
+        Applies the log-softmax formula: logprob = logit - global_max - log(global_exp_sum)
+        to each of the gathered top-k values.
+
+        Args:
+            topk_values: Gathered top-k values tensor of shape (1, 1, batch_size, num_topk).
+        """
+        B = topk_values.shape[2]
+
+        # Reshape global_max from (1,1,1,B) to (1,1,B,1) for broadcasting with (1,1,B,K)
+        global_max_bcast = ttnn.to_layout(self.global_max, ttnn.ROW_MAJOR_LAYOUT, **self.common_args)
+        global_max_bcast = ttnn.reshape(global_max_bcast, (1, 1, B, 1), **self.common_args)
+        global_max_bcast = ttnn.to_layout(global_max_bcast, ttnn.TILE_LAYOUT, **self.common_args)
+
+        # Compute log(global_exp_sum) and reshape for broadcasting
+        log_global_exp_sum = ttnn.log(self.global_exp_sum, **self.common_args)
+        log_global_exp_sum_bcast = ttnn.to_layout(log_global_exp_sum, ttnn.ROW_MAJOR_LAYOUT, **self.common_args)
+        log_global_exp_sum_bcast = ttnn.reshape(log_global_exp_sum_bcast, (1, 1, B, 1), **self.common_args)
+        log_global_exp_sum_bcast = ttnn.to_layout(log_global_exp_sum_bcast, ttnn.TILE_LAYOUT, **self.common_args)
+        ttnn.deallocate(log_global_exp_sum)
+
+        # Apply log-softmax formula: logprob = logit - global_max - log(global_exp_sum)
+        ttnn.subtract(topk_values, global_max_bcast, output_tensor=self.topk_logprobs_output, **self.common_args)
+        ttnn.subtract(
+            self.topk_logprobs_output,
+            log_global_exp_sum_bcast,
+            output_tensor=self.topk_logprobs_output,
+            **self.common_args,
+        )
+        ttnn.deallocate(global_max_bcast)
+        ttnn.deallocate(log_global_exp_sum_bcast)
+
+        return self.topk_logprobs_output
+
+    def calculate_topk_log_probs(
+        self,
+        logits_tensor: ttnn.Tensor,
+        topk_values: ttnn.Tensor,
+        topk_global_indices: ttnn.Tensor,
+        sub_core_grid_topk: ttnn.CoreRangeSet = None,
+    ) -> LogProbsResult | None:
+        """Calculate logprobs for the gathered top-k tokens in a single pass.
+
+        Args:
+            logits_tensor: Full logits tensor, sharded across devices.
+            topk_values: Gathered top-k values from all devices. Shape: (1,1,B,256).
+            topk_global_indices: Global vocabulary indices for the gathered top-k. Shape: (1,1,B,256).
+            sub_core_grid_topk: Sub-core grid for topk operation.
+
+        Returns:
+            LogProbsResult with top-32 logprobs and indices, or None if disabled/unsupported.
+        """
+        if not self.enable_log_probs:
+            return None
+
+        if not self._is_supported():
+            return None
+
+        # Ensure bfloat16 precision for numerical stability
+        if logits_tensor.dtype == ttnn.bfloat8_b:
+            logits_tensor = ttnn.typecast(logits_tensor, ttnn.bfloat16, **self.common_args)
+
+        # Compute global stats — large intermediates allocated and freed here
+        self._compute_global_stats(logits_tensor)
+
+        # Narrow 256 -> 32 topk values and indices
+        topk_local_values, topk_local_indices = ttnn.topk(
+            topk_values,
+            k=DEVICE_TOP_K,
+            dim=-1,
+            sub_core_grids=sub_core_grid_topk,
+        )
+
+        # ttnn.gather requires uint32 indices in TILE_LAYOUT
+        topk_local_indices = ttnn.typecast(topk_local_indices, ttnn.uint32, **self.common_args)
+        topk_local_indices = ttnn.to_layout(topk_local_indices, ttnn.ROW_MAJOR_LAYOUT, **self.common_args)
+        topk_local_indices = ttnn.to_layout(topk_local_indices, ttnn.TILE_LAYOUT, **self.common_args)
+        ttnn.gather(
+            topk_global_indices, dim=-1, index=topk_local_indices, out=self.topk_indices_output, **self.common_args
+        )
+        ttnn.deallocate(topk_local_indices)
+
+        # Ensure topk_values is bfloat16 for consistent computation
+        if topk_local_values.dtype != ttnn.bfloat16:
+            topk_local_values = ttnn.typecast(topk_local_values, ttnn.bfloat16, **self.common_args)
+
+        # Single-pass logprob computation for all gathered top-k tokens
+        self._calculate_topk_log_probs_from_values(topk_local_values)
+        ttnn.deallocate(topk_local_values)
+
+        return LogProbsResult(
+            topk_logprobs=self.topk_logprobs_output,
+            topk_indices=self.topk_indices_output,
+            topk_logprobs_host=None,
+            topk_indices_host=None,
+        )
+
+    # -----------------------------------------------------------------------
+    # Host transfer helpers
+    # -----------------------------------------------------------------------
+
+    def _build_mesh_composer(self):
+        """Build the appropriate mesh composer for transferring tensors from device to host."""
+        if self.cluster_shape[0] > 1 and self.cluster_shape[1] > 1:
+            return ttnn.ConcatMesh2dToTensor(
+                self.mesh_device,
+                dims=(0, 1),
+                mesh_shape=self.cluster_shape,
+            )
+        else:
+            return ttnn.ConcatMeshToTensor(self.mesh_device, dim=0)
+
+    def transfer_logprobs_to_host(
+        self,
+        log_probs_result: LogProbsResult | None,
+        sampled_token_ids: torch.Tensor,
+        num_logprobs_per_user: list[int] | None = None,
+    ) -> list[dict | None]:
+        """Move logprobs from device to host and build per-user response objects.
+
+        tt-metal path only (standalone demos/tests). vLLM does NOT call this.
+
+        Args:
+            log_probs_result: LogProbsResult from calculate_topk_log_probs.
+            sampled_token_ids: Host tensor of sampled token IDs, shape (batch_size,).
+            num_logprobs_per_user: Per-user count of top logprobs to return (0-20).
+                If None, uses self.num_logprobs.
+
+        Returns:
+            List of length batch_size. Each element is None for users with
+            logprobs disabled, otherwise a dict with returned_token and top_logprobs.
+        """
+        if log_probs_result is None:
+            return [None] * self.batch_size
+
+        if num_logprobs_per_user is None:
+            num_logprobs_per_user = self.num_logprobs
+
+        mesh_composer = self._build_mesh_composer()
+
+        topk_logprobs_host = ttnn.to_torch(
+            log_probs_result.topk_logprobs_host
+            if log_probs_result.topk_logprobs_host is not None
+            else log_probs_result.topk_logprobs,
+            mesh_composer=mesh_composer,
+        )
+        topk_indices_host = ttnn.to_torch(
+            log_probs_result.topk_indices_host
+            if log_probs_result.topk_indices_host is not None
+            else log_probs_result.topk_indices,
+            mesh_composer=mesh_composer,
+        )
+        # Remove replicas
+        topk_logprobs_host = topk_logprobs_host[0, 0, ...].float()
+        topk_indices_host = topk_indices_host[0, 0, ...].to(torch.int32)
+
+        results: list[dict | None] = []
+        for user_idx in range(self.batch_size):
+            if not self.logprobs_enabled[user_idx]:
+                results.append(None)
+                continue
+
+            sampled_id = int(sampled_token_ids[user_idx].item())
+            user_logprobs = topk_logprobs_host[user_idx]
+            user_indices = topk_indices_host[user_idx]
+
+            # Extract sampled token logprob by matching its ID in the top-k
+            match_mask = user_indices == sampled_id
+            if match_mask.any():
+                sampled_logprob = float(user_logprobs[match_mask][0].item())
+            else:
+                logger.warning(f"Sampled token {sampled_id} not found in top-k for user {user_idx}")
+                sampled_logprob = float("nan")
+
+            n = num_logprobs_per_user[user_idx] if user_idx < len(num_logprobs_per_user) else 0
+
+            results.append(
+                {
+                    "returned_token": {
+                        "token_idx": sampled_id,
+                        "logprob": sampled_logprob,
+                    },
+                    "top_logprobs": {
+                        "token_indices": user_indices[:n].tolist(),
+                        "logprobs": user_logprobs[:n].tolist(),
+                        "num_logprobs": n,
+                        "logprobs_formatted": False,
+                    },
+                }
+            )
+
+        return results

--- a/models/experimental/llama32_1b_quasar/sampling/tt_penalties.py
+++ b/models/experimental/llama32_1b_quasar/sampling/tt_penalties.py
@@ -1,0 +1,390 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+"""
+On-device penalties module with persistent buffers, mirroring TTSampling.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, List, Optional
+
+import torch
+
+import ttnn
+from models.experimental.llama32_1b_quasar.lightweightmodule import LightweightModule
+from models.experimental.llama32_1b_quasar.sampling._utils import compact_debug_list as _compact_debug_list
+from models.experimental.llama32_1b_quasar.sampling._utils import is_llama33_70b_model
+from models.experimental.llama32_1b_quasar.sampling._utils import log_sampling_debug as _log_sampling_debug
+
+
+@dataclass
+class PenaltyContext:
+    prompt_mask: ttnn.Tensor
+    output_mask: ttnn.Tensor
+    output_counts: ttnn.Tensor
+    output_counts_gathered: ttnn.Tensor
+    presence_penalties: ttnn.Tensor
+    frequency_penalties: ttnn.Tensor
+    repetition_penalties: ttnn.Tensor
+    inverse_repetition_penalties: ttnn.Tensor
+    sub_core_grids: Any | None = None
+
+
+def _tokens_debug_summary(tokens: torch.Tensor) -> dict[str, Any]:
+    valid = tokens >= 0
+    row_lengths = valid.sum(dim=1).tolist()
+    flat_valid = tokens[valid]
+    if flat_valid.numel() == 0:
+        unique_count = 0
+        duplicate_count = 0
+        head = []
+    else:
+        unique_count = int(torch.unique(flat_valid).numel())
+        duplicate_count = int(flat_valid.numel() - unique_count)
+        head = flat_valid[:16].tolist()
+    return {
+        "shape": list(tokens.shape),
+        "dtype": str(tokens.dtype),
+        "valid_tokens": int(valid.sum().item()),
+        "unique_tokens": unique_count,
+        "duplicate_tokens": duplicate_count,
+        "row_lengths": _compact_debug_list(row_lengths),
+        "head_tokens": head,
+    }
+
+
+def apply_penalties(logits: ttnn.Tensor, context: Optional[PenaltyContext]) -> ttnn.Tensor:
+    if context is None:
+        return logits
+
+    op_kwargs = {"sub_core_grids": context.sub_core_grids} if context.sub_core_grids else {}
+    # presence
+    presence_term = ttnn.multiply(
+        ttnn.typecast(context.output_mask, ttnn.bfloat16, **op_kwargs), context.presence_penalties, **op_kwargs
+    )
+    presence_term_bf16 = ttnn.typecast(presence_term, ttnn.bfloat16, **op_kwargs)
+    logits = ttnn.subtract(logits, presence_term_bf16, output_tensor=logits, **op_kwargs)
+    presence_term_bf16.deallocate()
+
+    # frequency
+    output_counts_bf16 = ttnn.typecast(context.output_counts, ttnn.bfloat16, **op_kwargs)
+
+    freq_term = ttnn.multiply(output_counts_bf16, context.frequency_penalties, **op_kwargs)
+
+    freq_term_bf16 = ttnn.typecast(freq_term, ttnn.bfloat16, **op_kwargs)
+    logits = ttnn.subtract(logits, freq_term_bf16, output_tensor=logits, **op_kwargs)
+    freq_term_bf16.deallocate()
+
+    # repetition
+
+    # If token appears in prompt or output, apply, otherwise use 1.0 for no-op.
+
+    combined_mask_int32 = ttnn.add(context.prompt_mask, context.output_mask, **op_kwargs)
+    combined_mask = ttnn.typecast(combined_mask_int32, ttnn.bfloat16, **op_kwargs)
+    combined_mask_int32.deallocate()
+    penalties = ttnn.where(combined_mask, context.repetition_penalties, 1.0, **op_kwargs)
+    inverse_penalties = ttnn.where(combined_mask, context.inverse_repetition_penalties, 1.0, **op_kwargs)
+    combined_mask.deallocate()
+
+    # If logits are >0, divide by penalty, otherwise multiply by penalty.
+    logits_bf16 = ttnn.typecast(logits, ttnn.bfloat16, **op_kwargs)
+    logits_gt1 = ttnn.gt(logits_bf16, 0, **op_kwargs)
+    scaling = ttnn.where(logits_gt1, inverse_penalties, penalties, **op_kwargs)
+    logits_gt1.deallocate()
+    penalties.deallocate()
+    inverse_penalties.deallocate()
+    logits = ttnn.multiply(logits, scaling, output_tensor=logits, **op_kwargs)
+    scaling.deallocate()
+
+    return logits
+
+
+class TTPenalties(LightweightModule):
+    """
+    Penalty module with persistent device tensors, similar to TTSampling.
+    """
+
+    def __init__(self, mesh_device, args):
+        super().__init__()
+        self.mesh_device = mesh_device
+        self._sampling_debug_enabled = is_llama33_70b_model(args)
+        self.cluster_shape = mesh_device.shape
+        # Floor at 32 so that ROW_MAJOR [batch, vocab] buffers passed to
+        # ttnn.tilize always have physical_volume divisible by TILE_HW
+        # (32*32 = 1024).  32 * V is 1024-aligned for any 32-aligned V.
+        self.max_batch_size = max(getattr(args, "max_batch_size", 32), 32)
+
+        padded_vocab_size = getattr(args, "padded_vocab_size", None)
+        self.vocab_size = padded_vocab_size if padded_vocab_size is not None else args.vocab_size
+
+        self.sub_core_grids = getattr(args, "sub_core_grids", None)
+        self._op_kwargs = {"sub_core_grids": self.sub_core_grids} if self.sub_core_grids else {}
+
+        # sampling_dp > 1 when multiple mesh rows each sample independently
+        # (e.g. GPT-OSS on [4,8] Galaxy: 4 rows × 32 users = 128 total)
+        self._sampling_dp = getattr(args, "sampling_dp", 1)
+
+        # When rows are used for data parallelism (sampling_dp > 1), vocab
+        # must be sharded along columns; otherwise pick the larger dimension.
+        if self._sampling_dp > 1:
+            num_devices = mesh_device.shape[-1]
+        else:
+            num_devices = max(mesh_device.shape[-1], mesh_device.shape[-2])
+        self.num_devices = num_devices
+        # Total batch across all rows. Host tensors use this size; after
+        # (0, ...) sharding each row gets max_batch_size entries.
+        self._total_batch = self.max_batch_size * self._sampling_dp
+
+        # shard vocab size over larger cluster dim
+        if mesh_device.shape[-1] == self.num_devices:
+            shard_dims = (None, 1)
+            shard_dims_slice = (None, 0)
+        else:
+            shard_dims = (1, None)
+            shard_dims_slice = (0, None)
+
+        # For row-sharded mode (sampling_dp > 1), also shard the batch dimension
+        # across mesh rows so each row gets its own per-user penalty state.
+        if self._sampling_dp > 1:
+            assert (
+                mesh_device.shape[-1] == self.num_devices
+            ), "Row-sharded penalties require vocab sharding along mesh columns"
+            shard_dims = (0, 1)  # batch across rows, vocab across cols
+            shard_dims_gathered = (0, None)  # batch across rows, vocab replicated
+            shard_dims_bf16 = (0, None)  # per-row penalty params
+            per_row_batch = self.max_batch_size  # NOT divided: each row gets max_batch_size
+        else:
+            shard_dims_gathered = (None, None)
+            shard_dims_bf16 = None
+            per_row_batch = self.max_batch_size
+
+        self.per_row_batch_size = per_row_batch
+        self._shard_dims_gathered = shard_dims_gathered
+
+        self.prompt_mask = self._alloc_int_buffer(shard_dims=shard_dims)
+        self.output_mask = self._alloc_int_buffer(shard_dims=shard_dims)
+        self.output_counts_gathered = self._alloc_int_buffer(shard_dims=shard_dims_gathered)
+        self.output_counts = self._alloc_int_buffer(shard_dims=shard_dims)
+        self._shard_dims_mask = shard_dims
+        self.decode_src = self._alloc_int_buffer(
+            host=torch.ones(self._total_batch, 1), shard_dims=shard_dims_gathered, layout=ttnn.ROW_MAJOR_LAYOUT
+        )
+        self.zeros = self._alloc_int_buffer(shard_dims=shard_dims_gathered, layout=ttnn.ROW_MAJOR_LAYOUT)
+        self.presence_penalties = self._alloc_bf16_buffer(shard_dims=shard_dims_bf16)
+        self.frequency_penalties = self._alloc_bf16_buffer(shard_dims=shard_dims_bf16)
+        self.repetition_penalties = self._alloc_bf16_buffer(shard_dims=shard_dims_bf16)
+        self.inverse_repetition_penalties = self._alloc_bf16_buffer(shard_dims=shard_dims_bf16)
+
+        vocab_per_dev = self.vocab_size // self.num_devices
+        d = torch.arange(self.num_devices, dtype=torch.int32)
+
+        # [0, 0, 0, vocab_per_dev, 0, 2*vocab_per_dev, ...]
+        start_1d = torch.empty(2 * self.num_devices, dtype=torch.int32)
+        start_1d[0::2] = 0
+        start_1d[1::2] = d * vocab_per_dev
+
+        # [batch, vocab_per_dev, batch, 2*vocab_per_dev, ...]
+        end_1d = torch.empty(2 * self.num_devices, dtype=torch.int32)
+        end_1d[0::2] = per_row_batch  # per-row batch size, exclusive
+        end_1d[1::2] = (d + 1) * vocab_per_dev  # exclusive
+
+        self.slice_start = ttnn.from_torch(
+            start_1d,
+            device=self.mesh_device,
+            mesh_mapper=ttnn.ShardTensor2dMesh(self.mesh_device, dims=shard_dims_slice, mesh_shape=self.cluster_shape),
+        )
+        self.slice_end = ttnn.from_torch(
+            end_1d,
+            device=self.mesh_device,
+            mesh_mapper=ttnn.ShardTensor2dMesh(self.mesh_device, dims=shard_dims_slice, mesh_shape=self.cluster_shape),
+        )
+
+    def _alloc_int_buffer(self, shard_dims, host=None, layout=ttnn.TILE_LAYOUT):
+        if host is None:
+            host = torch.zeros((self._total_batch, self.vocab_size), dtype=torch.int32)
+        return ttnn.from_torch(
+            host,
+            dtype=ttnn.int32,
+            layout=layout,
+            device=self.mesh_device,
+            mesh_mapper=ttnn.ShardTensor2dMesh(self.mesh_device, dims=shard_dims, mesh_shape=self.cluster_shape),
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+
+    def _alloc_bf16_buffer(self, shard_dims=None):
+        host = torch.zeros((self._total_batch, 1), dtype=torch.float32)
+        if shard_dims is not None:
+            return ttnn.from_torch(
+                host,
+                dtype=ttnn.bfloat16,
+                layout=ttnn.TILE_LAYOUT,
+                device=self.mesh_device,
+                mesh_mapper=ttnn.ShardTensor2dMesh(self.mesh_device, dims=shard_dims, mesh_shape=self.cluster_shape),
+            )
+        return ttnn.from_torch(host, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=self.mesh_device)
+
+    def _copy_host_to_device(self, dst: ttnn.Tensor, src: torch.Tensor):
+        if self._sampling_dp > 1:
+            # For row-sharded buffers, create a properly sharded host tensor
+            # so copy_host_to_device_tensor writes per-row shards correctly.
+            mapper = ttnn.ShardTensor2dMesh(self.mesh_device, dims=(0, None), mesh_shape=self.cluster_shape)
+            src_tt = ttnn.from_torch(src, dtype=dst.dtype, layout=ttnn.TILE_LAYOUT, device=None, mesh_mapper=mapper)
+        else:
+            src_tt = ttnn.from_torch(src, dtype=dst.dtype, layout=ttnn.TILE_LAYOUT, device=None)
+        ttnn.copy_host_to_device_tensor(src_tt, dst)
+
+    def _copy_int_host_to_device(self, dst: ttnn.Tensor, src: torch.Tensor, shard_dims):
+        mapper = ttnn.ShardTensor2dMesh(self.mesh_device, dims=shard_dims, mesh_shape=self.cluster_shape)
+        src_tt = ttnn.from_torch(src, dtype=dst.dtype, layout=ttnn.TILE_LAYOUT, device=None, mesh_mapper=mapper)
+        ttnn.copy_host_to_device_tensor(src_tt, dst)
+
+    def _token_counts_host(self, tokens_2d: torch.Tensor) -> torch.Tensor:
+        valid = (tokens_2d >= 0) & (tokens_2d < self.vocab_size)
+        token_ids = torch.where(valid, tokens_2d, torch.zeros_like(tokens_2d)).to(torch.int64)
+        counts = torch.zeros((self._total_batch, self.vocab_size), dtype=torch.int32)
+        counts.scatter_add_(1, token_ids, valid.to(torch.int32))
+        return counts
+
+    def reset_params(self, presence: List[float], frequency: List[float], repetition: List[float]):
+        presence_tensor = self._pad_params(presence)
+        frequency_tensor = self._pad_params(frequency)
+        repetition_tensor = self._pad_params(repetition)
+        inverse_repetition_tensor = 1 / repetition_tensor
+
+        self._copy_host_to_device(self.presence_penalties, presence_tensor)
+        self._copy_host_to_device(self.frequency_penalties, frequency_tensor)
+        self._copy_host_to_device(self.repetition_penalties, repetition_tensor)
+        self._copy_host_to_device(self.inverse_repetition_penalties, inverse_repetition_tensor)
+
+    def _pad_params(self, values: List[float]) -> torch.Tensor:
+        tensor = torch.tensor(values, dtype=torch.float32)
+        if tensor.numel() < self._total_batch:
+            pad_value = tensor[-1] if tensor.numel() > 0 else torch.tensor(0.0)
+            pad = pad_value.repeat(self._total_batch - tensor.numel())
+            tensor = torch.cat([tensor, pad])
+        elif tensor.numel() > self._total_batch:
+            tensor = tensor[: self._total_batch]
+        return tensor.view(self._total_batch, 1)
+
+    def _pad_batch_to_max(self, tokens_2d: torch.Tensor, pad_value: int) -> torch.Tensor:
+        """Pad/truncate first dim to _total_batch."""
+        if tokens_2d.dim() != 2:
+            raise ValueError(f"Expected 2D tensor [B, S], got {tokens_2d.shape}")
+        B, S = tokens_2d.shape
+        if B < self._total_batch:
+            pad = torch.full((self._total_batch - B, S), pad_value, dtype=tokens_2d.dtype)
+            return torch.cat([tokens_2d, pad], dim=0)
+        if B > self._total_batch:
+            return tokens_2d[: self._total_batch]
+        return tokens_2d
+
+    def reset_prompt_tokens(self, prompt_tokens: torch.Tensor):
+        prompt_tokens_2d = prompt_tokens.reshape(-1, prompt_tokens.shape[-1])
+        prompt_tokens_2d = self._pad_batch_to_max(prompt_tokens_2d, pad_value=-1)
+        _log_sampling_debug(
+            self._sampling_debug_enabled,
+            "TTPenalties reset prompt tokens",
+            tokens=_tokens_debug_summary(prompt_tokens_2d),
+        )
+
+        # Build reset masks on host to avoid device scatter_add races on
+        # duplicate prompt token ids (common in penalty tests/prompts).
+        prompt_counts = self._token_counts_host(prompt_tokens_2d)
+        prompt_mask = (prompt_counts > 0).to(torch.int32)
+        self._copy_int_host_to_device(self.prompt_mask, prompt_mask, self._shard_dims_mask)
+
+    def reset_output_tokens(self, tokens=None):
+        # ALWAYS reset output buffers to zero first (this is the core accuracy fix from issue #35731)
+        # This ensures penalty statistics are cleared between prefill and decode phases
+        self.output_mask = ttnn.mul(self.output_mask, 0, output_tensor=self.output_mask, **self._op_kwargs)
+        self.output_counts = ttnn.mul(self.output_counts, 0, output_tensor=self.output_counts, **self._op_kwargs)
+        self.output_counts_gathered = ttnn.mul(
+            self.output_counts_gathered, 0, output_tensor=self.output_counts_gathered, **self._op_kwargs
+        )
+
+        # THEN optionally repopulate if tokens are provided
+        if tokens is not None:
+            tokens_2d = tokens.reshape(-1, tokens.shape[-1])
+            tokens_2d = self._pad_batch_to_max(tokens_2d, pad_value=-1)
+            _log_sampling_debug(
+                self._sampling_debug_enabled,
+                "TTPenalties reset output tokens",
+                tokens=_tokens_debug_summary(tokens_2d),
+            )
+            output_counts = self._token_counts_host(tokens_2d)
+            output_mask = (output_counts > 0).to(torch.int32)
+            self._copy_int_host_to_device(self.output_counts_gathered, output_counts, self._shard_dims_gathered)
+            self._copy_int_host_to_device(self.output_counts, output_counts, self._shard_dims_mask)
+            self._copy_int_host_to_device(self.output_mask, output_mask, self._shard_dims_mask)
+        else:
+            _log_sampling_debug(self._sampling_debug_enabled, "TTPenalties reset output tokens", tokens=None)
+
+    def update_output_tokens(self, new_tokens):
+        # Reshape decode token to [batch, 1] for scatter_add.
+        # Non-row-sharded: token shape is [1,1,1,batch] → shape[-1]==batch, shape[-2]==1
+        # Row-sharded:     token shape is [1,1,batch,1] → shape[-2]==batch, shape[-1]==1
+        batch = self.per_row_batch_size
+        if (new_tokens.shape[-1] == batch and new_tokens.shape[-2] == 1) or (
+            new_tokens.shape[-2] == batch and new_tokens.shape[-1] == 1
+        ):
+            new_tokens = ttnn.reshape(new_tokens, [batch, 1], **self._op_kwargs)
+            src = self.decode_src
+        else:
+            src = self._alloc_int_buffer(
+                host=torch.ones(self._total_batch, new_tokens.shape[-1]),
+                shard_dims=self._shard_dims_gathered,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+            )
+        self.token_bin_counts_and_mask(
+            new_tokens=new_tokens,
+            counts=self.output_counts_gathered,
+            src=src,
+            counts_sliced=self.output_counts,
+            mask=self.output_mask,
+        )
+
+    def token_bin_counts_and_mask(self, new_tokens, src, counts=None, mask=None, counts_sliced=None):
+        counts_new = ttnn.scatter_add(self.zeros, 1, new_tokens, src, **self._op_kwargs)
+
+        new_tokens.deallocate()
+        # need to use use_low_perf because llama galaxy runs out of L1 otherwise
+        counts_new = ttnn.tilize(
+            counts_new, **self._op_kwargs, use_low_perf=True if self.sub_core_grids is not None else False
+        )
+        if counts:
+            counts = ttnn.add(counts, counts_new, output_tensor=counts, **self._op_kwargs)
+        else:
+            counts = counts_new
+        counts_sliced = ttnn.slice(
+            counts,
+            self.slice_start,
+            self.slice_end,
+            output_tensor=counts_sliced,
+            slice_dim=1,
+            num_devices=self.num_devices,
+            **self._op_kwargs,
+        )
+
+        mask = ttnn.gt(counts_sliced, 0, output_tensor=mask, **self._op_kwargs)
+        return counts, mask
+
+    def apply(self, tt_logits: ttnn.Tensor) -> ttnn.Tensor:
+        if tt_logits is None:
+            return tt_logits
+        context = PenaltyContext(
+            prompt_mask=self.prompt_mask,
+            output_mask=self.output_mask,
+            output_counts=self.output_counts,
+            output_counts_gathered=self.output_counts_gathered,
+            presence_penalties=self.presence_penalties,
+            frequency_penalties=self.frequency_penalties,
+            repetition_penalties=self.repetition_penalties,
+            inverse_repetition_penalties=self.inverse_repetition_penalties,
+            sub_core_grids=self.sub_core_grids,
+        )
+        original_shape = tt_logits.shape
+        reshaped = ttnn.reshape(tt_logits, (-1, original_shape[-1]))
+        apply_penalties(reshaped, context)
+        return ttnn.reshape(reshaped, original_shape)

--- a/models/experimental/llama32_1b_quasar/sampling/tt_penalties.py
+++ b/models/experimental/llama32_1b_quasar/sampling/tt_penalties.py
@@ -61,19 +61,20 @@ def apply_penalties(logits: ttnn.Tensor, context: Optional[PenaltyContext]) -> t
 
     op_kwargs = {"sub_core_grids": context.sub_core_grids} if context.sub_core_grids else {}
     # presence
-    presence_term = ttnn.multiply(
-        ttnn.typecast(context.output_mask, ttnn.bfloat16, **op_kwargs), context.presence_penalties, **op_kwargs
-    )
+    output_mask_bf16 = ttnn.typecast(context.output_mask, ttnn.bfloat16, **op_kwargs)
+    presence_term = ttnn.multiply(output_mask_bf16, context.presence_penalties, **op_kwargs)
+    output_mask_bf16.deallocate()
     presence_term_bf16 = ttnn.typecast(presence_term, ttnn.bfloat16, **op_kwargs)
+    presence_term.deallocate()
     logits = ttnn.subtract(logits, presence_term_bf16, output_tensor=logits, **op_kwargs)
     presence_term_bf16.deallocate()
 
     # frequency
     output_counts_bf16 = ttnn.typecast(context.output_counts, ttnn.bfloat16, **op_kwargs)
-
     freq_term = ttnn.multiply(output_counts_bf16, context.frequency_penalties, **op_kwargs)
-
+    output_counts_bf16.deallocate()
     freq_term_bf16 = ttnn.typecast(freq_term, ttnn.bfloat16, **op_kwargs)
+    freq_term.deallocate()
     logits = ttnn.subtract(logits, freq_term_bf16, output_tensor=logits, **op_kwargs)
     freq_term_bf16.deallocate()
 
@@ -91,6 +92,7 @@ def apply_penalties(logits: ttnn.Tensor, context: Optional[PenaltyContext]) -> t
     # If logits are >0, divide by penalty, otherwise multiply by penalty.
     logits_bf16 = ttnn.typecast(logits, ttnn.bfloat16, **op_kwargs)
     logits_gt1 = ttnn.gt(logits_bf16, 0, **op_kwargs)
+    logits_bf16.deallocate()
     scaling = ttnn.where(logits_gt1, inverse_penalties, penalties, **op_kwargs)
     logits_gt1.deallocate()
     penalties.deallocate()

--- a/models/experimental/llama32_1b_quasar/sampling/tt_sampling.py
+++ b/models/experimental/llama32_1b_quasar/sampling/tt_sampling.py
@@ -1,0 +1,797 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import inspect
+import sys
+
+import torch
+from loguru import logger
+
+import ttnn
+from models.experimental.llama32_1b_quasar.lightweightmodule import LightweightModule
+from models.experimental.llama32_1b_quasar.sampling._utils import compact_debug_list as _compact_debug_list
+from models.experimental.llama32_1b_quasar.sampling._utils import is_default_value, is_llama33_70b_model, is_power_of_2
+from models.experimental.llama32_1b_quasar.sampling._utils import log_sampling_debug as _log_sampling_debug
+from models.experimental.llama32_1b_quasar.sampling._utils import upper_power_of_2
+from models.experimental.llama32_1b_quasar.sampling.tt_log_probs import LogProbsCalculator
+from models.experimental.llama32_1b_quasar.sampling.vocab_padding import (
+    build_invalid_vocab_mask,
+    build_tail_invalid_vocab_mask,
+    get_vocab_shard_dims,
+)
+
+
+class TTSampling(LightweightModule):
+    """
+    On-device sampling module supporting top-k, top-p, and temperature-based sampling.
+
+    This class implements high-performance on-device sampling that can work across different
+    model implementations by accepting configuration parameters rather than assuming specific
+    args structures.
+
+    Multi-device sampling works by partitioning the vocabulary across devices. Each device
+    computes top-k locally on its vocabulary partition, then all-gather operations combine
+    the results across devices to perform global top-k selection before final sampling.
+
+    Args:
+        mesh_device: The device or MeshDevice for computations
+        tt_ccl: CCL object for distributed operations (supports both line_all_gather and tt_all_gather)
+        vocab_size: Vocabulary size of the model
+        padded_vocab_size: Padded vocabulary size (must be divisible by num devices)
+        max_batch_size: Maximum batch size supported
+        max_top_k: Maximum number of top-k tokens to consider
+        cluster_shape: Shape of the device cluster (rows, cols)
+        sampling_all_gather_axis: Axis to all-gather over in 2D meshes (0=rows, 1=cols, default: 0)
+        sub_core_grids: Sub-core grid configuration for operations
+        sub_core_grid_topk: Sub-core grid configuration specifically for top-k operations
+        start_core: Starting core coordinate for sampling operations
+        num_gather_links: Number of links to use for all-gather operations (optional)
+        sampling_memory_config: Memory configuration for sampling tensors (optional)
+        k, p, temp: Initial sampling parameters (tensors of size max_batch_size)
+
+    Note:
+        Uses persistent buffers when CCL supports line_all_gather (llama3_70b_galaxy),
+        otherwise uses standard all_gather where the CCL API handles memory allocation (tt-transformers).
+    """
+
+    def _is_force_argmax_sampling(self, k, p, temp):
+        """Detect whether all users request deterministic greedy decoding.
+
+        When every user in the batch has k=1 (top-1), p=0.0 or p=1.0 (no top-p filter),
+        and temp=1.0 (no temperature scaling), we can skip the full top-k / top-p /
+        temperature / RNG pipeline and use a single all-gather + argmax instead.
+        This is significantly faster because argmax needs only one all-gather of the
+        full logits tensor vs. three gathers (values, indices, sampled tokens) in the
+        normal path.
+
+        Note: callers may represent greedy rows with p=1.0, while the
+        device argmax-style representation uses p=0.0.
+        The model config must also set allow_force_argmax=True for this to activate.
+
+        Changing this state between decode steps invalidates captured traces, so
+        SamplingGenerator maintains separate trace slots keyed by force_argmax.
+        """
+        return (
+            self._allow_force_argmax_sampling
+            and is_default_value(k, 1)
+            and (is_default_value(p, 1.0) or is_default_value(p, 0.0))
+            and is_default_value(temp, 1.0)
+        )
+
+    def _select_topk_indices_dtype(self, per_device_vocab_size: int, multi_step_reduction: bool):
+        # if vocab is larger than uint16 max, return uint32 for indices
+        if per_device_vocab_size > torch.iinfo(torch.uint16).max:
+            return ttnn.uint32
+
+        # if vocab size is missaligned with tile size and multi-step reduction is used, we need uint32 because of slice op compatibility
+        if multi_step_reduction and (per_device_vocab_size // 2) % ttnn.TILE_SIZE != 0:
+            return ttnn.uint32
+
+        return ttnn.uint16
+
+    @property
+    def force_argmax_sampling(self) -> bool:
+        return self._force_argmax_sampling
+
+    def __init__(
+        self,
+        mesh_device,
+        tt_ccl,
+        args,
+        k=None,
+        p=None,
+        temp=None,
+    ):
+        super().__init__()
+        self.mesh_device = mesh_device
+        self._sampling_debug_enabled = is_llama33_70b_model(args)
+        # Multi-step reduction is supported only on single device
+        self.multi_step_reduction = list(mesh_device.shape) == [1, 1]
+        self.tt_ccl = tt_ccl
+        self._line_all_gather = getattr(self.tt_ccl, "line_all_gather", None)
+        self._line_all_gather_supports_buffer_key = False
+        self._line_all_gather_supports_dtype = False
+        self.pad_to_power_of_2 = getattr(args, "pad_logits_to_power_of_2", False)
+        if callable(self._line_all_gather):
+            try:
+                line_all_gather_sig = inspect.signature(self._line_all_gather)
+                line_all_gather_params = line_all_gather_sig.parameters
+                self._line_all_gather_supports_buffer_key = "buffer_key" in line_all_gather_params or any(
+                    param.kind == inspect.Parameter.VAR_KEYWORD for param in line_all_gather_params.values()
+                )
+                self._line_all_gather_supports_dtype = "dtype" in line_all_gather_params or any(
+                    param.kind == inspect.Parameter.VAR_KEYWORD for param in line_all_gather_params.values()
+                )
+            except (TypeError, ValueError):
+                logger.warning("Unable to inspect line_all_gather signature; assuming no buffer_key or dtype support.")
+
+        padded_vocab_size = getattr(args, "padded_vocab_size", None)
+        self.padded_vocab_size = padded_vocab_size if padded_vocab_size is not None else args.vocab_size
+        self.vocab_size = args.vocab_size
+        # Round up to the next tile boundary (32) — device tensors must be tile-aligned.
+        raw_batch = getattr(args, "max_batch_size", 32)
+        self.max_batch_size = max(32, ((raw_batch + 31) // 32) * 32)
+        self.max_top_k = getattr(args, "max_top_k", 32)
+        self.cluster_shape = args.cluster_shape
+
+        self.sampling_all_gather_axis = getattr(args, "sampling_all_gather_axis", 0)
+        self.sub_core_grids = getattr(args, "sub_core_grids", None)
+        self.sub_core_grid_topk = getattr(args, "sub_core_grid_topk", None)
+        self.start_core = getattr(args, "start_core", ttnn.CoreCoord(0, 0))
+        self._sampling_sub_core_grids = (
+            ttnn.num_cores_to_corerangeset_in_subcoregrids(
+                self.start_core, self.max_batch_size, self.sub_core_grids, row_wise=True
+            )
+            if self.sub_core_grids is not None
+            else None
+        )
+
+        # sampling_dp > 1 when multiple mesh groups each sample users independently
+        # (e.g. GPT-OSS on [4,8]: 4 rows × 32 users; Llama Galaxy on [8,4]: 4 cols × 8 users)
+        self._sampling_dp = getattr(args, "sampling_dp", 1)
+        # Shard params along the non-all-gather axis; replicate along the all-gather axis
+        if self._sampling_dp > 1:
+            if self.sampling_all_gather_axis == 0:
+                self._param_dims = (None, 0)  # shard along cols
+            else:
+                self._param_dims = (0, None)  # shard along rows
+        else:
+            self._param_dims = (None, None)
+
+        if hasattr(args, "model_config") and "GALAXY_NUM_LINKS" in args.model_config:
+            # Calculate num_gather_links based on model config
+            max_num_gather_links = args.model_config["GALAXY_NUM_LINKS"]
+            self.num_gather_links = (
+                args.max_top_k // 32 if args.max_top_k // 32 <= max_num_gather_links else max_num_gather_links
+            )
+        else:
+            self.num_gather_links = 1
+        if hasattr(args, "model_config") and "DECODE_SAMPLING_INPUT_MEMCFG" in args.model_config:
+            self.sampling_memory_config = args.model_config["DECODE_SAMPLING_INPUT_MEMCFG"]
+        else:
+            self.sampling_memory_config = ttnn.DRAM_MEMORY_CONFIG
+
+        # Force argmax sampling
+        if hasattr(args, "model_config") and "SAMPLING_AG_CONFIG" in args.model_config:
+            # The model config may describe the fastest full-size Galaxy path, but
+            # the actual CCL shape is resolved from the runtime mesh below.
+            sampling_ag_config = args.model_config["SAMPLING_AG_CONFIG"]
+            self._allow_force_argmax_sampling = sampling_ag_config["allow_force_argmax"]
+            self.num_argmax_gather_links = sampling_ag_config["num_links"]
+            self.argmax_chunks_per_sync = sampling_ag_config.get("chunks_per_sync", 10)
+            self.argmax_num_workers_per_link = 1
+            self.ag_topology = sampling_ag_config["topology"]
+        else:
+            self._allow_force_argmax_sampling = False
+            self.num_argmax_gather_links = self.num_gather_links
+            self.argmax_chunks_per_sync = 10
+            self.argmax_num_workers_per_link = 1
+            self.ag_topology = ttnn.Topology.Linear
+
+        # Set defaults for sampling parameters if not provided
+        # Default: k=1 (top-1), p=0 (effectively argmax), temp=1 (no temperature scaling)
+        # When p=0, the sampling operation will select the token with highest probability (argmax)
+        total_param_size = self.max_batch_size * self._sampling_dp
+        if k is None:
+            k = torch.ones(total_param_size)
+        if p is None:
+            p = torch.zeros(total_param_size)
+        if temp is None:
+            temp = torch.ones(total_param_size)
+
+        self._force_argmax_sampling = self._is_force_argmax_sampling(k, p, temp)
+
+        # Create sampling parameter tensors on device
+        # When _sampling_dp > 1, dims=(0, None) shards the [128] tensor across 4 rows → [32] per row
+        self.k_tensor = ttnn.from_torch(
+            k,
+            device=self.mesh_device,
+            dtype=ttnn.uint32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            mesh_mapper=ttnn.ShardTensor2dMesh(self.mesh_device, dims=self._param_dims, mesh_shape=self.cluster_shape),
+        )
+        self.p_tensor = ttnn.from_torch(
+            p,
+            device=self.mesh_device,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            mesh_mapper=ttnn.ShardTensor2dMesh(self.mesh_device, dims=self._param_dims, mesh_shape=self.cluster_shape),
+        )
+        self.temp_tensor = ttnn.from_torch(
+            temp,
+            device=self.mesh_device,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            mesh_mapper=ttnn.ShardTensor2dMesh(self.mesh_device, dims=self._param_dims, mesh_shape=self.cluster_shape),
+        )
+
+        # Create device offset indices for global indexing
+        self._create_indices_tensors()
+        self._create_invalid_vocab_mask()
+        # Log-probs tensor to store the log-probs for the batch
+        self.tt_log_probs = None
+        self.log_probs_calculator = LogProbsCalculator(
+            self.mesh_device,
+            self.sub_core_grids,
+            self.tt_ccl,
+            batch_size=self.max_batch_size,
+            use_topk_logprobs=getattr(args, "use_topk_logprobs", False),
+        )
+
+        # Seeds tensor: one RNG slot per user across all rows.
+        # When sampling_dp > 1, shard across rows so each row gets its own slice.
+        # user_ids tensor: core routing only (32 per row, replicated).
+        self.seeds_tt_tensor = ttnn.from_torch(
+            torch.arange(total_param_size).to(torch.uint32),
+            device=self.mesh_device,
+            dtype=ttnn.uint32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            mesh_mapper=ttnn.ShardTensor2dMesh(self.mesh_device, dims=self._param_dims, mesh_shape=self.cluster_shape)
+            if self._sampling_dp > 1
+            else None,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+        self.user_ids_tt_tensor = ttnn.as_tensor(
+            torch.arange(self.max_batch_size).to(torch.uint32),
+            dtype=ttnn.uint32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            device=self.mesh_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+
+    def _get_num_sampling_shards(self):
+        if self.multi_step_reduction:
+            return 2
+        if 1 in self.cluster_shape:
+            return max(self.cluster_shape[0], self.cluster_shape[1])
+
+        if self.sampling_all_gather_axis not in (0, 1):
+            raise ValueError(
+                f"sampling_all_gather_axis must be 0 or 1 for 2D meshes, got {self.sampling_all_gather_axis}"
+            )
+        return self.cluster_shape[self.sampling_all_gather_axis]
+
+    def _create_indices_tensors(self):
+        """Create the indices tensors needed for distributed top-k operations."""
+        num_devices_in_mesh = self._get_num_sampling_shards()
+        indices_device_offsets = torch.ones(
+            1, 1, self.max_batch_size, self.max_top_k * num_devices_in_mesh, dtype=torch.int64
+        )
+        # padded_per_device: tile-aligned width matching actual logit tensors (for indices tensor)
+        padded_per_device = self.padded_vocab_size // num_devices_in_mesh
+
+        for device_id in range(num_devices_in_mesh):
+            indices_device_offsets[:, :, :, device_id * self.max_top_k : (device_id + 1) * self.max_top_k] = (
+                device_id * padded_per_device
+            )
+        self.tt_indices_device_offsets = ttnn.from_torch(
+            indices_device_offsets,
+            device=self.mesh_device,
+            dtype=ttnn.int32,
+            layout=ttnn.TILE_LAYOUT,
+            mesh_mapper=ttnn.ShardTensor2dMesh(self.mesh_device, dims=(None, None), mesh_shape=self.cluster_shape),
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+
+        # Create local indices tensor for top-k operations (must match logit width)
+        indices_tensor_torch = torch.zeros(1, 1, self.max_batch_size, padded_per_device, dtype=torch.int32)
+        for i in range(padded_per_device):
+            indices_tensor_torch[:, :, :, i] = i
+
+        # pad to power of 2 if needed
+        if self.pad_to_power_of_2 and not is_power_of_2(indices_tensor_torch.shape[-1]):
+            padded_value = upper_power_of_2(indices_tensor_torch.shape[-1])
+            indices_tensor_torch = torch.nn.functional.pad(
+                indices_tensor_torch,
+                (0, padded_value - indices_tensor_torch.shape[-1]),  # pad only last dim
+                mode="constant",
+                value=-1,  # invalid index to ensure that the padding values are not used
+            )
+
+        indices_dtype = self._select_topk_indices_dtype(padded_per_device, self.multi_step_reduction)
+        self.tt_indices_tensor = ttnn.from_torch(
+            indices_tensor_torch,
+            dtype=indices_dtype,
+            layout=ttnn.Layout.TILE,
+            device=self.mesh_device,
+            mesh_mapper=ttnn.ShardTensor2dMesh(self.mesh_device, dims=(None, None), mesh_shape=self.cluster_shape),
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+
+    def _create_invalid_vocab_mask(self):
+        self.tt_invalid_vocab_mask = None
+        self.tt_invalid_vocab_tail_mask = None
+        self._invalid_vocab_tail_width = 0
+
+        vocab_shard_dims = get_vocab_shard_dims(self.cluster_shape, self.sampling_all_gather_axis)
+        tail_mask = build_tail_invalid_vocab_mask(
+            self.vocab_size,
+            self.padded_vocab_size,
+            self.max_batch_size,
+            self.cluster_shape,
+            self.sampling_all_gather_axis,
+            tile_size=ttnn.TILE_SIZE,
+        )
+        if tail_mask is not None:
+            self._invalid_vocab_tail_width = tail_mask.tail_width
+            self.tt_invalid_vocab_tail_mask = ttnn.from_torch(
+                tail_mask.mask,
+                dtype=ttnn.bfloat16,
+                layout=ttnn.TILE_LAYOUT,
+                device=self.mesh_device,
+                mesh_mapper=ttnn.ShardTensor2dMesh(
+                    self.mesh_device,
+                    dims=vocab_shard_dims,
+                    mesh_shape=self.cluster_shape,
+                ),
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            )
+            return
+
+        invalid_vocab_mask = build_invalid_vocab_mask(
+            self.vocab_size,
+            self.padded_vocab_size,
+            self.max_batch_size,
+        )
+        if invalid_vocab_mask is None:
+            return
+
+        self.tt_invalid_vocab_mask = ttnn.from_torch(
+            invalid_vocab_mask,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=self.mesh_device,
+            mesh_mapper=ttnn.ShardTensor2dMesh(
+                self.mesh_device,
+                dims=vocab_shard_dims,
+                mesh_shape=self.cluster_shape,
+            ),
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+
+    def _mask_invalid_vocab_logits(self, logits):
+        if self.tt_invalid_vocab_tail_mask is not None:
+            return self._mask_invalid_vocab_tail_logits(logits)
+        if self.tt_invalid_vocab_mask is None:
+            return logits
+        return ttnn.add(
+            logits,
+            self.tt_invalid_vocab_mask,
+            memory_config=logits.memory_config(),
+            sub_core_grids=self.sub_core_grids,
+        )
+
+    def _mask_invalid_vocab_tail_logits(self, logits):
+        tail_width = self._invalid_vocab_tail_width
+        local_width = logits.shape[-1]
+        valid_width = local_width - tail_width
+        if tail_width <= 0 or valid_width < 0:
+            return self._mask_invalid_vocab_logits_fallback(logits)
+        if valid_width == 0:
+            return ttnn.add(
+                logits,
+                self.tt_invalid_vocab_tail_mask,
+                memory_config=logits.memory_config(),
+                sub_core_grids=self.sub_core_grids,
+            )
+
+        valid_logits = ttnn.slice(
+            logits,
+            [0, 0, 0, 0],
+            [logits.shape[0], logits.shape[1], logits.shape[2], valid_width],
+            memory_config=logits.memory_config(),
+            sub_core_grids=self.sub_core_grids,
+        )
+        tail_logits = ttnn.slice(
+            logits,
+            [0, 0, 0, valid_width],
+            [logits.shape[0], logits.shape[1], logits.shape[2], local_width],
+            memory_config=logits.memory_config(),
+            sub_core_grids=self.sub_core_grids,
+        )
+        masked_tail_logits = ttnn.add(
+            tail_logits,
+            self.tt_invalid_vocab_tail_mask,
+            memory_config=logits.memory_config(),
+            sub_core_grids=self.sub_core_grids,
+        )
+        masked_logits = ttnn.concat(
+            [valid_logits, masked_tail_logits],
+            dim=3,
+            memory_config=logits.memory_config(),
+            sub_core_grids=self.sub_core_grids,
+        )
+        ttnn.deallocate(valid_logits)
+        ttnn.deallocate(tail_logits)
+        ttnn.deallocate(masked_tail_logits)
+        return masked_logits
+
+    def _mask_invalid_vocab_logits_fallback(self, logits):
+        if self.tt_invalid_vocab_mask is None:
+            return logits
+        return ttnn.add(
+            logits,
+            self.tt_invalid_vocab_mask,
+            memory_config=logits.memory_config(),
+            sub_core_grids=self.sub_core_grids,
+        )
+
+    def _can_slice_valid_vocab_for_argmax(self):
+        return self.vocab_size < self.padded_vocab_size and self.vocab_size % ttnn.TILE_SIZE == 0
+
+    def _slice_valid_vocab_for_argmax(self, logits):
+        if not self._can_slice_valid_vocab_for_argmax() or logits.shape[-1] != self.padded_vocab_size:
+            return logits
+        return ttnn.slice(
+            logits,
+            [0, 0, 0, 0],
+            [logits.shape[0], logits.shape[1], logits.shape[2], self.vocab_size],
+            memory_config=logits.memory_config(),
+            sub_core_grids=self.sub_core_grids,
+        )
+
+    def _perform_all_gather(self, tensor, dim, cluster_axis, memory_config, num_links, buffer_key=None, dtype=None):
+        """
+        Flexible all-gather that works across different CCL implementations.
+
+        - If `tt_ccl` exposes `line_all_gather`, prefer it (enables persistent buffer usage on some stacks).
+        - Otherwise fall back to `ttnn.all_gather`.
+        """
+        if callable(self._line_all_gather):
+            # Some implementations accept `buffer_key` (for persistent buffers), others may not.
+            line_all_gather_kwargs = {
+                "dim": dim,
+                "cluster_axis": cluster_axis,
+                "memory_config": memory_config,
+                "num_links": num_links,
+            }
+            if self._line_all_gather_supports_buffer_key and buffer_key is not None:
+                line_all_gather_kwargs["buffer_key"] = buffer_key
+            if self._line_all_gather_supports_dtype and dtype is not None:
+                line_all_gather_kwargs["dtype"] = dtype
+            return self._line_all_gather(tensor, **line_all_gather_kwargs)
+
+        return ttnn.all_gather(
+            tensor,
+            dim=dim,
+            num_links=num_links,
+            memory_config=memory_config,
+            cluster_axis=cluster_axis,
+            topology=ttnn.Topology.Linear,
+        )
+
+    def _get_sampling_cluster_axis(self):
+        if self.mesh_device.get_num_devices() <= 1:
+            return None
+        # 1D submeshes should use the default CCL axis; forcing axis 1 can make
+        # smaller Galaxy DP groups request routes outside the submesh.
+        if 1 in self.cluster_shape:
+            return None
+        return self.sampling_all_gather_axis
+
+    def _get_force_argmax_all_gather_config(self, cluster_axis):
+        num_links = self.num_argmax_gather_links
+        if hasattr(self.tt_ccl, "get_num_links"):
+            # Clamp the tuned config to the links available on the actual submesh.
+            num_links = min(num_links, self.tt_ccl.get_num_links(cluster_axis))
+
+        topology = self.ag_topology
+        # Ring is available for T3K-like 8-device groups; smaller DP groups need
+        # linear routing to avoid wraparound routes such as D0 -> D12.
+        if self.mesh_device.get_num_devices() < 8:
+            topology = ttnn.Topology.Linear
+
+        return max(1, num_links), topology
+
+    def reset_params(
+        self,
+        k,
+        p,
+        temp,
+        enable_log_probs: bool | list[bool] = None,
+        num_logprobs: int | list[int] = None,
+        empty_slots: list[int] | None = None,
+    ):
+        """Update sampling parameters (k, p, temperature, logprobs) dynamically."""
+        self._force_argmax_sampling = self._is_force_argmax_sampling(k, p, temp)
+        _log_sampling_debug(
+            self._sampling_debug_enabled,
+            "TTSampling reset params",
+            force_argmax=self._force_argmax_sampling,
+            empty_slots=_compact_debug_list(empty_slots),
+            top_k=_compact_debug_list(k),
+            top_p=_compact_debug_list(p),
+            temperature=_compact_debug_list(temp),
+            enable_log_probs=_compact_debug_list(enable_log_probs),
+            num_logprobs=_compact_debug_list(num_logprobs),
+            sampling_dp=self._sampling_dp,
+        )
+        if not self._force_argmax_sampling:
+            # When _sampling_dp > 1, create multi-device host tensors so
+            # copy_host_to_device_tensor writes per-row shards correctly.
+            if self._sampling_dp > 1:
+                mapper = ttnn.ShardTensor2dMesh(self.mesh_device, dims=self._param_dims, mesh_shape=self.cluster_shape)
+            else:
+                mapper = None
+
+            self.k_tensor_new = ttnn.from_torch(
+                torch.tensor(k),
+                device=None,
+                dtype=ttnn.uint32,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+                mesh_mapper=mapper,
+            )
+            self.p_tensor_new = ttnn.from_torch(
+                torch.tensor(p),
+                device=None,
+                dtype=ttnn.bfloat16,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+                mesh_mapper=mapper,
+            )
+            self.temp_tensor_new = ttnn.from_torch(
+                torch.tensor(temp),
+                device=None,
+                dtype=ttnn.bfloat16,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+                mesh_mapper=mapper,
+            )
+
+            ttnn.copy_host_to_device_tensor(self.k_tensor_new, self.k_tensor)
+            ttnn.copy_host_to_device_tensor(self.p_tensor_new, self.p_tensor)
+            ttnn.copy_host_to_device_tensor(self.temp_tensor_new, self.temp_tensor)
+
+        self.log_probs_calculator.set_log_probs_mode(
+            enable_log_probs, num_logprobs=num_logprobs, empty_slots=empty_slots
+        )
+
+    def forward(
+        self,
+        x: ttnn.Tensor,
+        tt_out_tok: ttnn.Tensor = None,
+    ):
+        """
+        Perform on-device sampling on logits tensor.
+        The logits are sharded over the devices in the cluster.
+        We perform local top-k on each device, then all-gather the top-k values and indices across all devices.
+        We then convert the gathered values and indices to the appropriate format, add the device offsets to get the global vocabulary indices,
+        and perform the actual sampling with top-k, top-p, and temperature.
+
+        Args:
+            x: Input logits tensor
+            tt_out_tok: Optional output tensor to write results to
+
+        Returns:
+            Sampled token indices tensor
+        """
+        _log_sampling_debug(
+            self._sampling_debug_enabled,
+            "TTSampling forward",
+            force_argmax=self._force_argmax_sampling,
+            logits_shape=list(x.shape),
+            tt_out_tok_shape=list(tt_out_tok.shape) if tt_out_tok is not None else None,
+            max_top_k=self.max_top_k,
+            multi_step_reduction=self.multi_step_reduction,
+            sampling_dp=self._sampling_dp,
+        )
+        if self._force_argmax_sampling:
+            logger.info("Forcing argmax sampling")
+            slice_valid_vocab = self._can_slice_valid_vocab_for_argmax()
+            if not slice_valid_vocab:
+                x = self._mask_invalid_vocab_logits(x)
+            # Gather the output across all devices and untilize the tensor (for argmax)
+            num_devices = self.mesh_device.get_num_devices()
+            if num_devices > 1:
+                cluster_axis = self._get_sampling_cluster_axis()
+                num_links, topology = self._get_force_argmax_all_gather_config(cluster_axis)
+                logger.debug(
+                    f"Force argmax sampling all-gather: cluster_axis={cluster_axis}, "
+                    f"num_links={num_links}, topology={topology}"
+                )
+                x = ttnn.experimental.all_gather_async(
+                    x,
+                    persistent_output_buffer=None,
+                    dim=3,
+                    multi_device_global_semaphore=self.tt_ccl.get_and_cycle_ag_semaphore_handles(cluster_axis),
+                    num_links=num_links,
+                    memory_config=x.memory_config(),
+                    cluster_axis=cluster_axis,
+                    topology=topology,
+                    barrier_semaphore=self.tt_ccl.get_and_cycle_barrier_semaphore_handle(cluster_axis),
+                    chunks_per_sync=self.argmax_chunks_per_sync,
+                    num_workers_per_link=self.argmax_num_workers_per_link,
+                    num_buffers_per_channel=2,
+                )
+            if slice_valid_vocab:
+                x = self._slice_valid_vocab_for_argmax(x)
+            x_untilized = ttnn.untilize(x, use_multicore=True)
+            tt_out_tok = ttnn.argmax(
+                x_untilized,
+                dim=-1,
+                output_tensor=tt_out_tok,
+                keepdim=False,
+            )
+            # Argmax path: logprobs not supported (force-argmax is disabled
+            # when logprobs are enabled via format_sampling_params guard).
+            self.tt_log_probs = None
+            return tt_out_tok, self.tt_log_probs
+
+        # Convert to bfloat16 for top-k operations (typecast is no-op if already bfloat16)
+        x_bf16 = ttnn.typecast(x, dtype=ttnn.bfloat16, sub_core_grids=self.sub_core_grids)
+        x_bf16 = self._mask_invalid_vocab_logits(x_bf16)
+
+        if self.multi_step_reduction:
+            x_bf16_list = ttnn.split(x_bf16, x_bf16.shape[-1] // 2, dim=3)
+            indices_tensor_list = ttnn.split(self.tt_indices_tensor, self.tt_indices_tensor.shape[-1] // 2, dim=3)
+            topk_values_list = []
+            topk_indices_list = []
+
+            for i in range(len(x_bf16_list)):
+                topk_values, topk_indices = ttnn.topk(
+                    x_bf16_list[i],
+                    k=self.max_top_k,
+                    dim=-1,
+                    sub_core_grids=self.sub_core_grid_topk,
+                    indices_tensor=indices_tensor_list[i],
+                )
+                topk_values_list.append(topk_values)
+                topk_indices_list.append(topk_indices)
+                x_bf16_list[i].deallocate()
+                indices_tensor_list[i].deallocate()
+
+            topk_values_gathered_bf16_interleaved = ttnn.concat(topk_values_list, dim=3)
+            topk_indices_gathered = ttnn.concat(topk_indices_list, dim=3)
+
+            for i in range(len(topk_indices_list)):
+                ttnn.deallocate(topk_values_list[i])
+                ttnn.deallocate(topk_indices_list[i])
+
+        else:
+            # apply padding to the input tensor if needed
+            # if number is not power of 2, pad to upper power of 2
+            # pad only last dimension with float::min value to upper_power_of_2
+            # This is necessary to use full optimization in the topk operation.
+            if self.pad_to_power_of_2 and not is_power_of_2(x_bf16.shape[-1]):
+                padded_value = upper_power_of_2(x_bf16.shape[-1])
+                x_bf16 = ttnn.pad(
+                    x_bf16,
+                    [(0, 0), (0, 0), (0, 0), (0, padded_value - x_bf16.shape[-1])],
+                    value=-sys.float_info.max,
+                    sub_core_grids=self.sub_core_grids,
+                )
+            # Perform local top-k on each device
+            topk_values, topk_indices = ttnn.topk(
+                x_bf16,
+                k=self.max_top_k,
+                dim=-1,
+                sub_core_grids=self.sub_core_grid_topk,
+                indices_tensor=self.tt_indices_tensor,
+            )
+
+            # For 1D meshes use `cluster_axis=None`. For 2D meshes, use the configured gather axis.
+            sampling_cluster_axis = self._get_sampling_cluster_axis()
+
+            # Gather top-k values across all devices
+            topk_values_gathered = self._perform_all_gather(
+                topk_values,
+                dim=3,
+                cluster_axis=sampling_cluster_axis,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                num_links=self.num_gather_links,
+                buffer_key="SAMPLING_VALUES",
+            )
+
+            ttnn.deallocate(topk_values)
+
+            # Convert gathered values to appropriate format
+            if self.sampling_memory_config != ttnn.DRAM_MEMORY_CONFIG:
+                topk_values_gathered_bf16 = ttnn.to_memory_config(
+                    topk_values_gathered,
+                    memory_config=self.sampling_memory_config,
+                    dtype=ttnn.bfloat16,
+                )
+                topk_values_gathered_bf16_interleaved = ttnn.to_memory_config(
+                    topk_values_gathered_bf16, memory_config=ttnn.DRAM_MEMORY_CONFIG
+                )
+                ttnn.deallocate(topk_values_gathered_bf16)
+            else:
+                topk_values_gathered_bf16_interleaved = topk_values_gathered
+
+            # Gather top-k indices across all devices
+            topk_indices_gathered = self._perform_all_gather(
+                topk_indices,
+                dim=3,
+                cluster_axis=sampling_cluster_axis,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                num_links=self.num_gather_links,
+                buffer_key="SAMPLING_INDICES",
+                dtype=ttnn.uint16,
+            )
+            ttnn.deallocate(topk_indices)
+
+        # Convert indices to appropriate data types
+
+        topk_indices_gathered_int32 = ttnn.typecast(
+            topk_indices_gathered, dtype=ttnn.int32, sub_core_grids=self.sub_core_grids
+        )
+
+        if self.sampling_memory_config != ttnn.DRAM_MEMORY_CONFIG:
+            topk_indices_gathered_int32_sharded = ttnn.to_memory_config(
+                topk_indices_gathered_int32, self.sampling_memory_config
+            )
+            ttnn.deallocate(topk_indices_gathered_int32)
+        else:
+            topk_indices_gathered_int32_sharded = topk_indices_gathered_int32
+
+        # Add device offsets to get global vocabulary indices
+        topk_global_indices = ttnn.add(
+            self.tt_indices_device_offsets,
+            topk_indices_gathered_int32_sharded,
+            dtype=ttnn.uint32,
+            memory_config=self.sampling_memory_config,
+        )
+
+        ttnn.deallocate(topk_indices_gathered_int32_sharded)
+
+        topk_global_indices_interleaved = ttnn.to_memory_config(topk_global_indices, ttnn.DRAM_MEMORY_CONFIG)
+
+        # Untilize indices for sampling operation
+        topk_global_indices_interleaved_untilised = ttnn.untilize(
+            topk_global_indices_interleaved, use_multicore=True, sub_core_grids=self.sub_core_grids
+        )
+        ttnn.manual_seed(
+            seeds=self.seeds_tt_tensor,
+            user_ids=self.user_ids_tt_tensor,
+            sub_core_grids=self._sampling_sub_core_grids,
+        )
+        # Perform the actual sampling with top-k, top-p, and temperature
+        tt_out_tok = ttnn.sampling(
+            topk_values_gathered_bf16_interleaved,
+            topk_global_indices_interleaved_untilised,
+            k=self.k_tensor,
+            p=self.p_tensor,
+            temp=self.temp_tensor,
+            sub_core_grids=self._sampling_sub_core_grids,
+            output_tensor=tt_out_tok,
+        )
+
+        # Compute logprobs if enabled
+        if self.log_probs_calculator.enable_log_probs and self.log_probs_calculator._use_topk_logprobs:
+            # New path: top-K logprobs for gpt-oss-120b
+            self.tt_log_probs = self.log_probs_calculator.calculate_topk_log_probs(
+                logits_tensor=x,
+                topk_values=topk_values_gathered_bf16_interleaved,
+                topk_global_indices=topk_global_indices_interleaved,
+                sub_core_grid_topk=self.sub_core_grid_topk,
+            )
+        elif self.log_probs_calculator.enable_log_probs:
+            # Old path: single sampled-token logprob
+            self.tt_log_probs = self.log_probs_calculator.calculate_log_probs(x, tt_out_tok)
+        else:
+            self.tt_log_probs = None
+
+        ttnn.deallocate(topk_values_gathered_bf16_interleaved)
+        ttnn.deallocate(topk_global_indices_interleaved)
+        ttnn.deallocate(topk_global_indices_interleaved_untilised)
+
+        return tt_out_tok, self.tt_log_probs

--- a/models/experimental/llama32_1b_quasar/sampling/vocab_padding.py
+++ b/models/experimental/llama32_1b_quasar/sampling/vocab_padding.py
@@ -1,0 +1,153 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+from dataclasses import dataclass
+
+import torch
+
+
+@dataclass(frozen=True)
+class InvalidVocabTailMask:
+    """A compact additive mask for the tile-aligned invalid tail of the final vocab shard."""
+
+    mask: torch.Tensor
+    tail_width: int
+    shard_width: int
+    num_vocab_shards: int
+
+
+def build_invalid_vocab_mask(
+    vocab_size: int,
+    padded_vocab_size: int,
+    max_batch_size: int,
+    *,
+    dtype: torch.dtype = torch.bfloat16,
+) -> torch.Tensor | None:
+    """Build an additive logits mask for LM-head vocabulary padding.
+
+    LM heads may pad output weights so the sharded matmul has legal tile/device
+    dimensions. Those padded columns produce logits, but they are not real token
+    IDs and must be masked before argmax or top-k sampling.
+    """
+    if vocab_size < 0:
+        raise ValueError(f"vocab_size must be non-negative, got {vocab_size}")
+    if padded_vocab_size < vocab_size:
+        raise ValueError(f"padded_vocab_size ({padded_vocab_size}) must be >= vocab_size ({vocab_size})")
+    if max_batch_size <= 0:
+        raise ValueError(f"max_batch_size must be positive, got {max_batch_size}")
+    if vocab_size == padded_vocab_size:
+        return None
+
+    if not torch.empty((), dtype=dtype).is_floating_point():
+        raise TypeError(f"dtype must be a floating point torch dtype, got {dtype}")
+
+    mask = torch.zeros(1, 1, max_batch_size, padded_vocab_size, dtype=dtype)
+    mask[..., vocab_size:] = torch.finfo(dtype).min
+    return mask
+
+
+def _validate_cluster_shape(cluster_shape: tuple[int, int] | list[int]) -> tuple[int, int]:
+    cluster_shape = tuple(cluster_shape)
+    if len(cluster_shape) != 2:
+        raise ValueError(f"cluster_shape must have two dimensions, got {cluster_shape}")
+
+    rows, cols = int(cluster_shape[0]), int(cluster_shape[1])
+    if rows <= 0 or cols <= 0:
+        raise ValueError(f"cluster_shape dimensions must be positive, got {cluster_shape}")
+    return rows, cols
+
+
+def get_vocab_num_shards(
+    cluster_shape: tuple[int, int] | list[int],
+    sampling_all_gather_axis: int = 0,
+) -> int:
+    """Return how many mesh partitions own contiguous slices of the vocab dimension."""
+    rows, cols = _validate_cluster_shape(cluster_shape)
+
+    if rows == 1 and cols == 1:
+        return 1
+    if rows == 1:
+        return cols
+    if cols == 1:
+        return rows
+    if sampling_all_gather_axis == 0:
+        return rows
+    if sampling_all_gather_axis == 1:
+        return cols
+    raise ValueError(f"sampling_all_gather_axis must be 0 or 1, got {sampling_all_gather_axis}")
+
+
+def build_tail_invalid_vocab_mask(
+    vocab_size: int,
+    padded_vocab_size: int,
+    max_batch_size: int,
+    cluster_shape: tuple[int, int] | list[int],
+    sampling_all_gather_axis: int = 0,
+    *,
+    dtype: torch.dtype = torch.bfloat16,
+    tile_size: int = 32,
+) -> InvalidVocabTailMask | None:
+    """Build a compact mask for padding that lives only at the final shard tail.
+
+    The sampling logits are sharded into equal local vocab widths. For model
+    shapes like Qwen3-32B on T3K, all invalid IDs are a small tile-aligned suffix
+    of the last local shard. In that case callers can mask only the local tail
+    slice instead of adding a full-vocab all-zero mask on every device.
+
+    Returns ``None`` when the invalid range is not a tile-aligned final-shard
+    suffix; callers should use ``build_invalid_vocab_mask`` as the correctness
+    fallback.
+    """
+    if vocab_size < 0:
+        raise ValueError(f"vocab_size must be non-negative, got {vocab_size}")
+    if padded_vocab_size < vocab_size:
+        raise ValueError(f"padded_vocab_size ({padded_vocab_size}) must be >= vocab_size ({vocab_size})")
+    if max_batch_size <= 0:
+        raise ValueError(f"max_batch_size must be positive, got {max_batch_size}")
+    if tile_size <= 0:
+        raise ValueError(f"tile_size must be positive, got {tile_size}")
+    if vocab_size == padded_vocab_size:
+        return None
+    if not torch.empty((), dtype=dtype).is_floating_point():
+        raise TypeError(f"dtype must be a floating point torch dtype, got {dtype}")
+
+    num_vocab_shards = get_vocab_num_shards(cluster_shape, sampling_all_gather_axis)
+    if padded_vocab_size % num_vocab_shards != 0:
+        return None
+
+    shard_width = padded_vocab_size // num_vocab_shards
+    tail_width = padded_vocab_size - vocab_size
+    if tail_width > shard_width:
+        return None
+    if tail_width % tile_size != 0 or (shard_width - tail_width) % tile_size != 0:
+        return None
+
+    mask = torch.zeros(1, 1, max_batch_size, tail_width * num_vocab_shards, dtype=dtype)
+    final_tail_start = tail_width * (num_vocab_shards - 1)
+    mask[..., final_tail_start:] = torch.finfo(dtype).min
+    return InvalidVocabTailMask(
+        mask=mask,
+        tail_width=tail_width,
+        shard_width=shard_width,
+        num_vocab_shards=num_vocab_shards,
+    )
+
+
+def get_vocab_shard_dims(
+    cluster_shape: tuple[int, int] | list[int],
+    sampling_all_gather_axis: int = 0,
+) -> tuple[int | None, int | None]:
+    """Return the 2D mesh mapper dims for sharding vocab over the sampling TP axis."""
+    rows, cols = _validate_cluster_shape(cluster_shape)
+
+    if rows == 1 and cols == 1:
+        return (None, None)
+    if rows == 1:
+        return (None, 3)
+    if cols == 1:
+        return (3, None)
+    if sampling_all_gather_axis == 0:
+        return (3, None)
+    if sampling_all_gather_axis == 1:
+        return (None, 3)
+    raise ValueError(f"sampling_all_gather_axis must be 0 or 1, got {sampling_all_gather_axis}")

--- a/models/experimental/llama32_1b_quasar/tensor_utils.py
+++ b/models/experimental/llama32_1b_quasar/tensor_utils.py
@@ -1,0 +1,196 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Tensor utility functions for TTTv2 modules.
+"""
+
+import json
+import re
+
+import torch
+
+import ttnn
+
+# Standard tile size - hardware constant
+TILE_SIZE = ttnn.TILE_SIZE  # 32
+
+
+def align_shape_to_tile(shape, tile_size: int = TILE_SIZE):
+    """Round up the last two dimensions of *shape* to multiples of *tile_size*.
+
+    This is the recommended replacement for the deprecated ``ttnn.pad_to_tile_shape``.
+
+    Args:
+        shape: An iterable of dimension sizes (list, tuple, or ttnn.Shape).
+        tile_size: Tile dimension to align to (default 32).
+
+    Returns:
+        List[int]: A new shape with the last two dims tile-aligned.
+    """
+    import math
+
+    result = list(shape)
+    if len(result) >= 1:
+        result[-1] = math.ceil(result[-1] / tile_size) * tile_size
+    if len(result) >= 2:
+        result[-2] = math.ceil(result[-2] / tile_size) * tile_size
+    return result
+
+
+def get_rot_transformation_mat(dhead: int = TILE_SIZE) -> torch.Tensor:
+    """
+    Create rotation transformation matrix for RoPE.
+
+    Constructs a permutation matrix that pairs adjacent dimensions with
+    signs (+1, -1) for the RoPE rotation:
+        [0, 1] → +1 at (0,1), -1 at (1,0)
+        [2, 3] → +1 at (2,3), -1 at (3,2)
+        ...
+
+    Used by ttnn.experimental.rotary_embedding_llama.
+
+    Args:
+        dhead: Matrix dimension. Must equal TILE_SIZE. Use TILE_SIZE for decode.
+
+    Returns:
+        torch.Tensor of shape [1, 1, dhead, dhead].
+    """
+    rot_emb_matrix = torch.zeros(1, 1, dhead, dhead)
+    rot_emb_matrix[..., torch.arange(0, dhead, 2), torch.arange(1, dhead, 2)] = 1
+    rot_emb_matrix[..., torch.arange(1, dhead, 2), torch.arange(0, dhead, 2)] = -1
+    return rot_emb_matrix
+
+
+def zeros_like_kv_cache(batch_size: int, n_kv_heads: int, max_seq_len: int, head_dim: int) -> torch.Tensor:
+    """Create zeros tensor for standard KV cache."""
+    return torch.zeros((batch_size, n_kv_heads, max_seq_len, head_dim))
+
+
+def zeros_like_paged_cache(paged_config, n_kv_heads: int, head_dim: int) -> torch.Tensor:
+    """Create zeros tensor for paged KV cache."""
+    return torch.zeros((paged_config.max_num_blocks, n_kv_heads, paged_config.block_size, head_dim))
+
+
+# todo)) add a on-device pad_dim_to_size function?
+def pad_dim_to_size(x: "torch.Tensor", dim: int, size: int) -> "torch.Tensor":
+    """Pads the specified dimension of the input tensor with zeros."""
+    if dim < 0:
+        dim = x.dim() + dim
+    current_size = x.size(dim)
+    pad_size = size - current_size
+
+    if pad_size < 0:
+        raise ValueError(f"Target size {size} is smaller than current size {current_size} on dim {dim}")
+
+    if pad_size == 0:
+        return x
+
+    pad = [0] * (2 * x.dim())
+    pad_index = 2 * (x.dim() - dim - 1)
+    pad[pad_index + 1] = pad_size
+
+    return torch.nn.functional.pad(x, pad, mode="constant", value=0)
+
+
+def pad_to_shape(x: "torch.Tensor", target_shape: tuple[int, ...], pad_value: float = 0.0) -> "torch.Tensor":
+    """Pad tensor to target_shape in a single F.pad call (more efficient than per-dim padding)."""
+    if x.shape == target_shape:
+        return x
+
+    # F.pad expects: (left_last, right_last, left_second_last, right_second_last, ...)
+    pad = []
+    for orig, target in zip(reversed(x.shape), reversed(target_shape)):
+        if target < orig:
+            raise ValueError(f"Target size {target} is smaller than current size {orig}")
+        pad.extend([0, target - orig])
+
+    return torch.nn.functional.pad(x, pad, mode="constant", value=pad_value)
+
+
+def get_padded_hidden_dim(hidden_dim: int, num_devices: int, tile_size: int = 32) -> int:
+    """
+    Compute padded hidden_dim to satisfy ttnn.from_torch's tile alignment constraint.
+
+    ttnn.from_torch requires physical shard shapes to be tile-aligned. When sharding
+    a tensor across devices, each shard_dim = hidden_dim / num_devices must be
+    divisible by tile_size.
+
+    We pad the global tensor first, then shard evenly so only the last shard has padding.
+    """
+    shard_dim = hidden_dim // num_devices
+    padded_shard = ((shard_dim + tile_size - 1) // tile_size) * tile_size
+    return padded_shard * num_devices
+
+
+def parse_shard_dims_from_mesh_mapper_config(mesh_mapper_config: ttnn.MeshMapperConfig) -> list[int]:
+    """
+    Parse shard dimensions from MeshMapperConfig's repr.
+
+    MeshMapperConfig doesn't expose .placements directly, but repr shows them:
+        'MeshMapperConfig(placements: [PlacementShard(-1)], mesh_shape_override=MeshShape([8]))'
+
+    This parses out the shard dimensions (e.g., [-1]) from PlacementShard entries.
+    Returns empty list if no PlacementShard found (e.g., replicated).
+
+    Note: This is a workaround until TTNN exposes .placements directly.
+    """
+    config_repr = repr(mesh_mapper_config)
+    matches = re.findall(r"PlacementShard\((-?\d+)\)", config_repr)
+    return [int(d) for d in matches]
+
+
+def memory_config_to_dict(memory_config: ttnn.MemoryConfig):
+    # Convert to plain types for deterministic serialization.
+    return {
+        "memory_layout": str(memory_config.memory_layout),
+        "buffer_type": str(memory_config.buffer_type),
+        "shard_spec": str(memory_config.shard_spec),
+        "is_sharded": bool(memory_config.is_sharded()),
+        "interleaved": bool(memory_config.interleaved),
+        "hash": int(memory_config.__hash__()),
+    }
+
+
+def compute_kernel_config_to_str(compute_kernel_config: ttnn.WormholeComputeKernelConfig):
+    # Backward compat shim; prefer compute_kernel_config_to_dict + serialize_config.
+    cfg = compute_kernel_config_to_dict(compute_kernel_config)
+    return serialize_config(cfg)
+
+
+def compute_kernel_config_to_dict(compute_kernel_config: ttnn.WormholeComputeKernelConfig):
+    return {
+        "math_fidelity": str(compute_kernel_config.math_fidelity),
+        "math_approx_mode": str(compute_kernel_config.math_approx_mode),
+        "fp32_dest_acc_en": bool(compute_kernel_config.fp32_dest_acc_en),
+        "packer_l1_acc": bool(compute_kernel_config.packer_l1_acc),
+        "dst_full_sync_en": bool(compute_kernel_config.dst_full_sync_en),
+        "throttle_level": str(compute_kernel_config.throttle_level),
+    }
+
+
+def program_config_to_str(program_config: ttnn.MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig):
+    # Backward compat shim; prefer program_config_to_dict + serialize_config.
+    cfg = program_config_to_dict(program_config)
+    return serialize_config(cfg)
+
+
+def program_config_to_dict(program_config):
+    if hasattr(program_config, "to_json"):
+        d = json.loads(program_config.to_json())
+        d["type"] = type(program_config).__name__
+        return d
+    else:
+        return {"type": type(program_config).__name__, "repr": repr(program_config)}
+
+
+def serialize_config(cfg_dict: dict, fmt: str = "json") -> str:
+    if fmt == "json":
+        return json.dumps(cfg_dict, sort_keys=True)
+    if fmt == "yaml":
+        try:
+            import yaml
+        except ImportError as exc:  # pragma: no cover - optional dependency
+            raise RuntimeError("PyYAML is required for yaml serialization") from exc
+        return yaml.safe_dump(cfg_dict, sort_keys=True)
+    raise ValueError(f"Unsupported format: {fmt}")

--- a/models/experimental/llama32_1b_quasar/tests/conftest.py
+++ b/models/experimental/llama32_1b_quasar/tests/conftest.py
@@ -1,0 +1,265 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+
+import contextlib
+import fcntl
+import os
+import time
+
+import pytest
+
+import ttnn
+
+# ==============================================================================
+# Device Lock - Coordinates exclusive access to TT devices across processes
+# ==============================================================================
+
+_TT_DEVICE_LOCK_PATH = os.environ.get("TT_DEVICE_LOCK_PATH", "/tmp/tt_device.lock")
+_TT_DEVICE_LOCK_TIMEOUT = float(os.environ.get("TT_DEVICE_LOCK_TIMEOUT", "60"))  # 1 min default
+
+
+class DeviceLockTimeout(Exception):
+    """Raised when acquiring the device lock times out."""
+
+
+# todo)) the UMD already provides a lock mechanism -- use it instead of this?
+@contextlib.contextmanager
+def tt_device_lock(lock_path: str = _TT_DEVICE_LOCK_PATH, timeout: float = _TT_DEVICE_LOCK_TIMEOUT):
+    """
+    Context manager for exclusive access to TT devices.
+
+    Uses flock for cross-process coordination. Blocks until lock is acquired
+    or timeout is reached.
+
+    Usage:
+        with tt_device_lock():
+            mesh = ttnn.open_mesh_device(...)
+            # ... do work ...
+            ttnn.close_mesh_device(mesh)
+
+    Debug stuck locks with: lsof /tmp/tt_device.lock
+
+    Environment variables:
+        TT_DEVICE_LOCK_PATH: Override lock file path (default: /tmp/tt_device.lock)
+        TT_DEVICE_LOCK_TIMEOUT: Override timeout in seconds (default: 300)
+    """
+    lock_dir = os.path.dirname(lock_path)
+    if lock_dir and not os.path.exists(lock_dir):
+        os.makedirs(lock_dir, exist_ok=True)
+
+    lock_file = open(lock_path, "a+")  # open the file in append mode to avoid truncation race condition among processes
+    start_time = time.monotonic()
+    lock_acquired = False
+
+    try:
+        # Poll for lock with timeout
+        logged_waiting = False
+        while True:
+            try:
+                fcntl.flock(lock_file, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                lock_acquired = True
+                break
+            except BlockingIOError:
+                pass  # Lock held by another process
+
+            if not logged_waiting:
+                print(f"[tt_device_lock] Waiting for device lock (held by another process)...")
+                print(f"[tt_device_lock] Debug with: lsof {lock_path}")
+                logged_waiting = True
+
+            if time.monotonic() - start_time >= timeout:
+                lock_file.close()
+                raise DeviceLockTimeout(
+                    f"Timed out after {timeout}s waiting for device lock. " f"Check: lsof {lock_path}"
+                )
+
+            time.sleep(1)  # sleep for 1 second to avoid busy-waiting
+
+        if logged_waiting:
+            print(f"[tt_device_lock] Lock acquired after {time.monotonic() - start_time:.1f}s")
+
+        # Write PID for debugging
+        lock_file.truncate(0)  # clear the file
+        lock_file.write(f"{os.getpid()}\n")
+        lock_file.flush()
+
+        yield
+
+    finally:
+        if lock_acquired:
+            fcntl.flock(lock_file, fcntl.LOCK_UN)
+        lock_file.close()
+
+
+def pytest_collection_modifyitems(config, items):
+    """Deselect tests where ttnn_mesh_device fixture doesn't match mesh_shape param.
+
+    This enables tests to use cross-product parametrization (all meshes × all cases)
+    while only running the valid combinations, without noisy skip messages.
+    """
+    selected = []
+    deselected = []
+
+    for item in items:
+        if not hasattr(item, "callspec"):
+            selected.append(item)
+            continue
+
+        params = item.callspec.params
+        fixture_mesh = params.get("ttnn_mesh_device")
+        required_mesh = params.get("mesh_shape")
+
+        # Keep test if no mesh_shape param or if meshes match
+        if required_mesh is None or fixture_mesh == required_mesh:
+            selected.append(item)
+        else:
+            deselected.append(item)
+
+    items[:] = selected
+    if deselected:
+        config.hook.pytest_deselected(items=deselected)
+
+
+@pytest.fixture(scope="module")
+def ttnn_mesh_device(request):
+    """Create and yield a mesh device for a given mesh shape, cleanup on teardown."""
+    if not hasattr(request, "param"):
+        pytest.skip(f"{__file__}: mesh_device fixture called without parametrization")
+
+    if ttnn.device.is_blackhole():
+        pytest.skip(f"{__file__}: Blackhole device is not supported for this test yet")
+
+    # request.param is either a Sequence of ints or a dict with fabric_config and etc.
+    params = getattr(request, "param", tuple())
+    if isinstance(params, tuple):
+        mesh_shape = params
+        updated_params = dict()
+    else:
+        try:
+            updated_params = params.copy()
+            mesh_shape = updated_params.pop("mesh_shape")
+        except Exception as e:
+            pytest.skip(f"{__file__}: mesh_shape is required: {e}")
+
+    # Pre-check: if no devices at all, skip without invoking C++ open.
+    # Some environments can throw here (e.g. transient driver/UMD issues); treat as "device unavailable".
+    try:
+        num_pcie = ttnn.get_num_pcie_devices()
+    except Exception as e:
+        pytest.skip(f"{__file__}: Unable to query TT devices on this system: {e}")
+
+    if isinstance(num_pcie, int) and num_pcie == 0:
+        pytest.skip(f"{__file__}: No TT devices detected on this system")
+
+    # Pre-check: skip shapes that cannot fit into the SystemMesh to avoid native exceptions
+    sys_desc = ttnn._ttnn.multi_device.SystemMeshDescriptor()  # type: ignore[attr-defined]
+    sys_shape = tuple(sys_desc.shape())
+    req_shape = tuple(mesh_shape)
+    allowed = _allowed_req_shapes_for_system(sys_shape)
+    if req_shape not in allowed:
+        pytest.skip(
+            f"{__file__}: Requested mesh {req_shape} unsupported on system {sys_shape}. "
+            f"Allowed for this system: {allowed}"
+        )
+
+    parent_shape = _pick_parent_shape_for_submesh(sys_shape, req_shape)
+
+    # config fabric config
+    fabric_config = updated_params.pop("fabric_config", None)
+    if parent_shape == (1, 1):
+        # Single device does not need fabric config.
+        pass
+    else:
+        # Provide default fabric config for the mesh we actually open (full system mesh).
+        num_devices = parent_shape[0] * parent_shape[1]
+        if fabric_config is None:
+            if num_devices >= 8:
+                fabric_config = ttnn.FabricConfig.FABRIC_1D_RING
+            else:
+                fabric_config = ttnn.FabricConfig.FABRIC_1D
+        # set all other input arguments to default values by top-level conftest.py
+        ttnn.set_fabric_config(
+            fabric_config, ttnn.FabricReliabilityMode.STRICT_INIT, None, ttnn.FabricTensixConfig.DISABLED
+        )
+
+    # config dispatch core to default values by conftest.py
+    updated_params["dispatch_core_config"] = ttnn.DispatchCoreConfig(type=None, axis=None, fabric_tensix_config=None)
+
+    # If a test requests a submesh of a larger system mesh (e.g. request 2x4 on a 8x4 system),
+    # fabric cannot be initialized on only the subset of devices. In that case, open the full
+    # system mesh first, then return the "first" submesh. We intentionally rely on the default
+    # offset behavior here (i.e. no explicit offset selection).
+    parent_device = None
+    submesh_device = None
+
+    # Acquire exclusive lock to prevent concurrent device access across processes
+    with tt_device_lock():
+        try:
+            if req_shape != parent_shape:
+                parent_device = ttnn.open_mesh_device(mesh_shape=ttnn.MeshShape(parent_shape), **updated_params)
+                submesh_device = parent_device.create_submesh(ttnn.MeshShape(req_shape))
+                yield submesh_device
+            else:
+                parent_device = ttnn.open_mesh_device(mesh_shape=ttnn.MeshShape(parent_shape), **updated_params)
+                yield parent_device
+        except Exception as e:
+            pytest.skip(f"{__file__}: Mesh device unavailable or unsupported for this configuration: {e}")
+        finally:
+            if submesh_device is not None:
+                ttnn.close_mesh_device(submesh_device)
+            if parent_device is not None:
+                ttnn.close_mesh_device(parent_device)
+            if fabric_config:
+                ttnn.set_fabric_config(ttnn.FabricConfig.DISABLED)
+            del parent_device
+
+
+def _allowed_req_shapes_for_system(sys_shape: tuple[int, int]) -> set[tuple[int, int]]:
+    # todo)) Different cluster has potentially different physical interconnects (in terms of number of links, topology, etc.).
+    #        Thus, a tuple of ints may not be enough to fingerprint the parent/system mesh device. We need to use a more sophisticated fingerprinting mechanism so we can base the allowed list of (sub)mesh shapes on the parent/system mesh device.
+    # [INFO] The most robust way to identify the underlying system is to use ttnn.cluster.get_cluster_type(), which returns a ClusterType enum that precisely identifies your hardware configuration. cluster.cpp:16-37
+
+    _CANDIDATE_REQ_SHAPES = {
+        (1, 1): ((1, 1),),
+        (1, 2): ((1, 2), (1, 1)),
+        (2, 4): ((2, 4), (1, 8), (1, 4), (1, 2), (1, 1)),
+        (8, 4): ((8, 4), (4, 8), (1, 8), (1, 4), (1, 2), (1, 1)),
+        # [INFO] add more system shapes here
+    }
+
+    allowed: set[tuple[int, int]] = set()
+
+    if sys_shape in _CANDIDATE_REQ_SHAPES:
+        for mesh_shape in _CANDIDATE_REQ_SHAPES[sys_shape]:
+            allowed.add(mesh_shape)
+
+    return allowed
+
+
+def _pick_parent_shape_for_submesh(system_shape: tuple[int, int], requested_shape: tuple[int, int]) -> tuple[int, int]:
+    # For multi-device workloads we always open the full system mesh (fabric cannot be launched on a subset),
+    # but we may choose the *orientation* of the full mesh such that the requested submesh fits with the
+    # default offset (i.e. "first submesh").
+    if requested_shape == (1, 1):
+        return (1, 1)
+
+    # If the request uses all devices, treat it as a "full-mesh view" shape and open the parent mesh in that view.
+    # This enables shapes like (1,32) on a system whose SystemMeshDescriptor reports (8,4).
+    system_num_devices = system_shape[0] * system_shape[1]
+    requested_num_devices = requested_shape[0] * requested_shape[1]
+    if requested_num_devices == system_num_devices:
+        return requested_shape
+
+    if requested_shape[0] <= system_shape[0] and requested_shape[1] <= system_shape[1]:
+        return system_shape
+
+    rotated = (system_shape[1], system_shape[0])
+    if requested_shape[0] <= rotated[0] and requested_shape[1] <= rotated[1]:
+        return rotated
+
+    # No orientation can fit this request without an explicit offset / mapping.
+    pytest.skip(
+        f"{__file__}: Requested submesh {requested_shape} does not fit within system mesh {system_shape} "
+        f"(or its rotated view {rotated}) with default offset."
+    )

--- a/models/experimental/llama32_1b_quasar/tests/conftest.py
+++ b/models/experimental/llama32_1b_quasar/tests/conftest.py
@@ -5,6 +5,7 @@
 import contextlib
 import fcntl
 import os
+import tempfile
 import time
 
 import pytest
@@ -15,7 +16,26 @@ import ttnn
 # Device Lock - Coordinates exclusive access to TT devices across processes
 # ==============================================================================
 
-_TT_DEVICE_LOCK_PATH = os.environ.get("TT_DEVICE_LOCK_PATH", "/tmp/tt_device.lock")
+
+def _sanitize_lock_path(raw: str) -> str:
+    """Confine the (env-derived, untrusted) lock path to the system temp directory.
+
+    ``TT_DEVICE_LOCK_PATH`` is operator-controlled input, so it is treated as
+    untrusted: only its basename is kept and anchored under the trusted temp dir,
+    preventing path traversal or writes outside the intended location. All
+    processes on a host still resolve to the same lock file, so cross-process
+    coordination is preserved.
+    """
+    base = os.path.realpath(tempfile.gettempdir())
+    name = os.path.basename(raw) or "tt_device.lock"
+    resolved = os.path.realpath(os.path.join(base, name))
+    # Defense in depth: never allow the resolved path to escape the trusted base.
+    if os.path.commonpath([base, resolved]) != base:
+        resolved = os.path.join(base, "tt_device.lock")
+    return resolved
+
+
+_TT_DEVICE_LOCK_PATH = _sanitize_lock_path(os.environ.get("TT_DEVICE_LOCK_PATH", "/tmp/tt_device.lock"))
 _TT_DEVICE_LOCK_TIMEOUT = float(os.environ.get("TT_DEVICE_LOCK_TIMEOUT", "60"))  # 1 min default
 
 
@@ -41,9 +61,13 @@ def tt_device_lock(lock_path: str = _TT_DEVICE_LOCK_PATH, timeout: float = _TT_D
     Debug stuck locks with: lsof /tmp/tt_device.lock
 
     Environment variables:
-        TT_DEVICE_LOCK_PATH: Override lock file path (default: /tmp/tt_device.lock)
+        TT_DEVICE_LOCK_PATH: Override lock file NAME (its basename is anchored under
+            the system temp dir; directory/traversal components are stripped)
         TT_DEVICE_LOCK_TIMEOUT: Override timeout in seconds (default: 300)
     """
+    # Re-sanitize at the sink: guarantee the path reaching the filesystem is
+    # confined to the trusted temp dir, regardless of what the caller passed.
+    lock_path = _sanitize_lock_path(lock_path)
     lock_dir = os.path.dirname(lock_path)
     if lock_dir and not os.path.exists(lock_dir):
         os.makedirs(lock_dir, exist_ok=True)
@@ -196,15 +220,19 @@ def ttnn_mesh_device(request):
     # Acquire exclusive lock to prevent concurrent device access across processes
     with tt_device_lock():
         try:
-            if req_shape != parent_shape:
+            # Device *setup* only inside this inner try/except: a failure here means the
+            # device is unavailable or the configuration is unsupported, which is a
+            # legitimate skip. The yield is deliberately kept OUTSIDE the skip-converting
+            # except so that exceptions raised by the test body propagate as real
+            # failures instead of being masked as skips.
+            try:
                 parent_device = ttnn.open_mesh_device(mesh_shape=ttnn.MeshShape(parent_shape), **updated_params)
-                submesh_device = parent_device.create_submesh(ttnn.MeshShape(req_shape))
-                yield submesh_device
-            else:
-                parent_device = ttnn.open_mesh_device(mesh_shape=ttnn.MeshShape(parent_shape), **updated_params)
-                yield parent_device
-        except Exception as e:
-            pytest.skip(f"{__file__}: Mesh device unavailable or unsupported for this configuration: {e}")
+                if req_shape != parent_shape:
+                    submesh_device = parent_device.create_submesh(ttnn.MeshShape(req_shape))
+            except Exception as e:
+                pytest.skip(f"{__file__}: Mesh device unavailable or unsupported for this configuration: {e}")
+
+            yield submesh_device if submesh_device is not None else parent_device
         finally:
             if submesh_device is not None:
                 ttnn.close_mesh_device(submesh_device)

--- a/models/experimental/llama32_1b_quasar/tests/demos/cleanup_utils.py
+++ b/models/experimental/llama32_1b_quasar/tests/demos/cleanup_utils.py
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+import gc
+
+import ttnn
+from models.experimental.llama32_1b_quasar.modules.lazy_weight import LazyWeight
+
+
+def cleanup_ttnn_value(value):
+    if value is None:
+        return
+
+    if isinstance(value, ttnn.Tensor):
+        ttnn.deallocate(value)
+        return
+
+    if isinstance(value, dict):
+        for nested_value in value.values():
+            cleanup_ttnn_value(nested_value)
+        return
+
+    if isinstance(value, (list, tuple, set)):
+        for nested_value in value:
+            cleanup_ttnn_value(nested_value)
+
+
+def cleanup_object_graph(obj, seen=None):
+    if obj is None:
+        return
+    if seen is None:
+        seen = set()
+
+    obj_id = id(obj)
+    if obj_id in seen:
+        return
+    seen.add(obj_id)
+
+    if isinstance(obj, ttnn.Tensor):
+        cleanup_ttnn_value(obj)
+        return
+
+    if isinstance(obj, LazyWeight):
+        if obj._value is not None:
+            cleanup_ttnn_value(obj._value)
+            obj._value = None
+        return
+
+    if isinstance(obj, dict):
+        for value in obj.values():
+            cleanup_object_graph(value, seen)
+        return
+
+    if isinstance(obj, (list, tuple, set)):
+        for value in obj:
+            cleanup_object_graph(value, seen)
+        return
+
+    state = getattr(obj, "__dict__", None)
+    if state is None:
+        return
+
+    for name, value in list(state.items()):
+        cleanup_object_graph(value, seen)
+        if isinstance(value, ttnn.Tensor):
+            setattr(obj, name, None)
+
+    if hasattr(obj, "_device_weights_loaded"):
+        obj._device_weights_loaded = False
+
+
+def cleanup_model_case(model, mesh_device):
+    ttnn.synchronize_device(mesh_device)
+    if model is not None:
+        cleanup_object_graph(model)
+    ttnn.synchronize_device(mesh_device)
+    gc.collect()

--- a/models/experimental/llama32_1b_quasar/tests/demos/llama32_1b/__init__.py
+++ b/models/experimental/llama32_1b_quasar/tests/demos/llama32_1b/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0

--- a/models/experimental/llama32_1b_quasar/tests/demos/llama32_1b/demo.py
+++ b/models/experimental/llama32_1b_quasar/tests/demos/llama32_1b/demo.py
@@ -1,0 +1,1147 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+TTTv2 Llama-3.2-1B-Instruct demo — accuracy and performance measurement.
+
+Uses ``EagerLlama32_1BExecutor`` / ``TracedLlama32_1BExecutor`` directly (no vLLM adapter).
+
+**Mesh note:** Llama-3.2-1B-Instruct has 32 attention heads and 8 KV heads, so N150 (1),
+N300 (2) and T3K (8) are all supported (32 and 8 each divide 1/2/8). PERF.md publishes
+this model for N150, N300 and T3K, so all three are exercised.
+
+**Workload:** performance tests prefill each prompt at its natural length (TTTv1
+``preprocess_inputs_prefill`` semantics; these sample prompts are ~90-125 tokens -> 128
+prefill bucket) + 200 decode iterations. Accuracy / teacher-forcing scores the model
+against the committed ``.refpt`` continuation tokens.
+
+Usage::
+
+    # Token accuracy test
+    MESH_DEVICE=N300 HF_MODEL=meta-llama/Llama-3.2-1B-Instruct \\
+      pytest models/experimental/llama32_1b_quasar/tests/demos/llama32_1b/demo.py -k "token-accuracy" -v
+
+    # Batch-1 latency test
+    MESH_DEVICE=N300 HF_MODEL=meta-llama/Llama-3.2-1B-Instruct \\
+      pytest models/experimental/llama32_1b_quasar/tests/demos/llama32_1b/demo.py -k "batch-1" -v
+
+    # Batch-32 throughput test
+    MESH_DEVICE=N300 HF_MODEL=meta-llama/Llama-3.2-1B-Instruct \\
+      pytest models/experimental/llama32_1b_quasar/tests/demos/llama32_1b/demo.py -k "batch-32" -v
+
+LazyWeight tensor cache: ``TT_CACHE_PATH/<device_name>`` when set, otherwise
+``model_cache/<HF_MODEL>/<device_name>`` under the current working directory.
+
+Reference artifact (``.refpt``): the accuracy test gates against the committed book
+reference at ``models/tt_transformers/tests/reference_outputs/<basename(HF_MODEL)>.refpt``
+(ground-truth real-text targets, PERF.md-comparable). The loader supports both the
+legacy half-split format and a metadata-rich format carrying ``prompt_len``.
+"""
+
+import json
+import math
+import os
+from pathlib import Path
+
+import pytest
+import torch
+from loguru import logger
+from transformers import AutoConfig, AutoTokenizer
+
+import ttnn
+from models.experimental.llama32_1b_quasar.models.executor import (
+    load_eval_repeat_prompts_batch32,
+    run_eval_repeat_batch32,
+    run_perf_benchmark,
+    run_teacher_forcing,
+)
+from models.experimental.llama32_1b_quasar.models.llama32_1b.model import (
+    LLAMA32_1B_ACCURACY,
+    LLAMA32_1B_PERFORMANCE,
+    EagerLlama32_1BExecutor,
+    Llama32_1BTransformer1D,
+    TracedLlama32_1BExecutor,
+)
+from models.experimental.llama32_1b_quasar.sampling.sampling_params import SamplingParams
+from models.experimental.llama32_1b_quasar.tests.demos.cleanup_utils import cleanup_model_case
+from models.demos.utils.llm_demo_utils import create_benchmark_data
+from models.demos.utils.model_targets import resolve_accuracy_targets
+from models.perf.benchmarking_utils import BenchmarkProfiler
+from models.tt_transformers.tt.common import encode_prompt_hf
+
+
+def _demo_num_layers() -> int | None:
+    """Optional layer-count override for reduced-model runs (e.g. Quasar 2-node emulator).
+
+    Set ``LLAMA32_1B_DEMO_NUM_LAYERS=1`` (or 2) to truncate the 16-layer stack; unset/0 => full model.
+    Mirrors the smoke demo in ``models/experimental/llama32_1b_quasar/models/llama32_1b/demo.py``.
+    """
+    return int(os.environ.get("LLAMA32_1B_DEMO_NUM_LAYERS", 0)) or None
+
+
+# =============================================================================
+# Expected metrics — perf gates set from an exhaustive TTTv1-vs-TTTv2 performance sweep
+# (3 runs per cell, all SKUs × both profiles × both sampling modes), cross-checked against
+# fresh same-machine re-runs. No PERF.md throughput value is used.
+#
+# Rule: each ``tok_s_u`` target is the BETTER of TTTv1 vs TTTv2 for that sampling mode. TTTv1
+# has only an on-device sampling path, so:
+#     on_device_topk : max(TTTv1_on_device, TTTv2_on_device_topk)
+#     host           : TTTv2_host                      (TTTv1 has no host-sampling path)
+# Decode throughput is prefill-independent, so batched prefill (default-ON for 1B on this base)
+# does NOT change ``tok_s_u`` — the swept values apply directly. ``ttft_ms`` targets are
+# conservative upper bounds: the swept TTTv2 prefill predates batched prefill, which only LOWERS
+# TTFT, so the current base clears them with margin while gross prefill regressions are still caught.
+#
+# T3K batch-1 GAP CLOSED (issue #49282 -> fix #49284, on main): the ~16%-under-TTTv1 TTTv2 decode
+# gap once seen at this cell (~128 vs ~153 t/s/u) was closed by the shared on-device decode loop.
+# The gate stays at the TTTv1 value (better-of rule); TTTv2 now measures ~152/150 t/s/u (perf/acc,
+# T3K on_device_topk), TTTv1 parity within the 5% PERF_TOLERANCE. Enabled on the perf path via
+# TracedLlama32_1BExecutor(ondevice_decode_loop=...). Every cell is now at parity-or-better.
+# =============================================================================
+
+# top1/top5 are teacher-forcing accuracy floors (sampling-independent). Perf metrics for batch-1
+# live in EXPECTED_METRICS_BATCH1 (sampling-mode-aware); this dict only gates token-accuracy.
+EXPECTED_METRICS = {
+    "performance": {
+        "N150": {"top1": 79, "top5": 97},
+        "N300": {"top1": 79, "top5": 97},
+        "T3K": {"top1": 80, "top5": 97},
+    },
+    "accuracy": {
+        "N150": {"top1": 87, "top5": 99},
+        "N300": {"top1": 87, "top5": 98},
+        "T3K": {"top1": 88, "top5": 99},
+    },
+}
+
+# batch-1 throughput, sampling-mode-aware (see rule above). host = TTTv2-host; on_device_topk =
+# max(TTTv1, TTTv2-on-device). ttft_ms is sampler-INDEPENDENT (prefill precedes sampling), so the host
+# and on_device_topk b1 TTFT bounds are equal per SKU; it is set generously (30-32ms) because
+# single-user prefill TTFT is a ~20ms measurement that swings run-to-run (fresh 2026-07-09: N300 b1
+# prefill measured 17.7ms on-device but 24.9-26.2ms host on separate runs — pure variance).
+EXPECTED_METRICS_BATCH1 = {
+    "host": {
+        "performance": {
+            "N150": {"tok_s_u": 81.0, "ttft_ms": 30},
+            "N300": {"tok_s_u": 67.7, "ttft_ms": 32},
+            # host on T3K is a degenerate, non-shipped path (on-device is ~12x faster); its decode
+            # tok/s/u is dominated by the 8-chip host round-trip and is noisy run-to-run (~9.5-15.8),
+            # so it is gated only with a coarse floor, not a tight best-of target.
+            "T3K": {"tok_s_u": 9.0, "ttft_ms": 30},
+        },
+        "accuracy": {
+            "N150": {"tok_s_u": 77.6, "ttft_ms": 30},
+            "N300": {"tok_s_u": 65.2, "ttft_ms": 32},
+            "T3K": {"tok_s_u": 9.0, "ttft_ms": 30},  # degenerate host-on-T3K path (see performance note)
+        },
+    },
+    "on_device_topk": {
+        "performance": {
+            "N150": {"tok_s_u": 12.2, "ttft_ms": 30},
+            "N300": {"tok_s_u": 37.9, "ttft_ms": 32},
+            "T3K": {"tok_s_u": 153.5, "ttft_ms": 30},  # gate = TTTv1 (better-of); TTTv2 at parity via #49284 (~152)
+        },
+        "accuracy": {
+            "N150": {"tok_s_u": 12.1, "ttft_ms": 30},
+            "N300": {"tok_s_u": 37.5, "ttft_ms": 32},
+            "T3K": {"tok_s_u": 153.2, "ttft_ms": 30},  # gate = TTTv1 (better-of); TTTv2 at parity via #49284 (~150)
+        },
+    },
+}
+
+# Short-context batch-32 throughput (seq1024 / 200 decode), sampling-mode-aware. Not profile-split:
+# perf and accuracy batch-32 are within tolerance, so the (slightly higher) performance target is
+# used as the bound for both. Same rule as above.
+EXPECTED_METRICS_BATCH32 = {
+    "host": {
+        "N150": {"tok_s_u": 71.2, "ttft_ms": 26},
+        "N300": {"tok_s_u": 63.0, "ttft_ms": 22},
+        "T3K": {"tok_s_u": 16.8, "ttft_ms": 16},
+    },
+    "on_device_topk": {
+        "N150": {"tok_s_u": 12.0, "ttft_ms": 26},
+        "N300": {"tok_s_u": 35.4, "ttft_ms": 22},
+        "T3K": {"tok_s_u": 126.8, "ttft_ms": 16},
+    },
+}
+
+# CI-faithful batch-32 targets (the ``batch-32-ci`` leg), measured at max_seq_len=2048 with a
+# 1024-token decode budget (TTTv1 ci-32 workload). This is a SEPARATE workload from the lighter
+# batch-32 leg above (seq1024 / 200 decode steps): the seq2048 KV cache means the decode read
+# window grows to position ~1150, so steady-state per-token decode is legitimately a bit slower
+# than the short-context batch-32 numbers. Setting the gate to the short-context constant would
+# be wrong (a config artifact, not a regression).
+#
+# The gate is keyed by SAMPLING_MODE because host argmax and on-device sampling are ~1.7x apart on
+# 1B (on-device pays the slow upstream ``ttnn.topk``); a single constant cannot gate both paths.
+# Each per-path target is the FRESHLY-MEASURED value on this base and sits at/above same-box TTTv1
+# ci-32 for the comparable path -- so this is a correct per-path target, never a weakening.
+#
+# Re-measured 2026-07-07 on N300 (this base: batched prefill now default-ON for 1B), cross-checked
+# against TTTv1 ci-32 on the IDENTICAL seq2048/decode1024 workload on the same N300:
+#   TTTv2 batch-32-ci host           : 58.8 tok/s/u, TTFT  7.6ms  (host argmax, shipped default)
+#   TTTv2 batch-32-ci on_device_topk : 34.3 tok/s/u, TTFT  7.5ms  (batched-ON) / 16.4ms (batched-OFF)
+#   TTTv1 ci-32 (on-device topk)     : 35.98 tok/s/u (perf) / 35.71 (acc), TTFT ~6.2ms
+# Parity: host (58.8) is far above TTTv1's on-device path. on_device_topk (34.3) is at TTTv1 parity
+# WITHIN the +/-PERF_TOLERANCE band (34.3 vs 35.98 is a 4.7% delta < 5%); the small delta is
+# TTTv2 run_perf_benchmark's per-iteration host read-back + synchronize_device inside the timed
+# region (TTTv1's traced generator overlaps read-back), NOT a model/kernel regression -- both pay
+# the same ttnn.topk. tok_s_u is stable to 0.1 across two on-device runs, so this is not noise.
+#
+# ttft_ms tracks the shipped batched-ON prefill (the CI default; ttft is sampler-independent so host
+# and on_device_topk share one bound per SKU). The batch-32 prefill was rewritten to reach TTTv1
+# parity (#49118): the last-token assembly now concatenates each group's shared logits tensor ONCE
+# instead of once per user (32 host concats -> 1 on batch-32 -- the largest non-forward TTFT term),
+# the fold snaps to a reshape-safe power-of-2, and 1B folds all 32 users in a SINGLE traced pass
+# (max_prefill_batch_size=32) like TTTv1's full-batch fold. Same-box T3K batch-32-ci prefill went
+# 7.4ms -> 3.8ms (TTTv1 ci-32 = 3.67ms same-box, i.e. parity); N300 7.5 -> 5.8ms; N150 -> 6.5ms.
+# Gates tightened to match (was a stale 17ms sized for the pre-fix sequential path); the
+# +/-PERF_TOLERANCE band absorbs run-to-run variance. The DISABLE_BATCHED_PREFILL=1 A/B path
+# (sequential, ~16ms) is a diagnostic knob, not a CI leg, so it is intentionally not gated here.
+#
+# Per-SKU CI-workload targets. N150/T3K were freshly measured 2026-07-09 at the seq2048/decode1024
+# ci workload; previously they fell back to EXPECTED_METRICS_BATCH32 (short-context), whose HOST bound
+# (71.2 on N150) the longer ci workload legitimately cannot reach (N150 host ci-32 measures ~62 --
+# exactly the config-artifact this dict exists to avoid). Each value is the measured TTTv2 tok/s/u for
+# that SKU/path (best-of vs TTTv1 ci-32 where TTTv1 runs); the +/-PERF_TOLERANCE band absorbs variance.
+# T3K on_device_topk ci-32 measures ~146.7 (>> TTTv1 ci-32 125.5) -- gated at a conservative 140 floor.
+# host on T3K ci-32 ERRORs (MMIO per-op timeout on the 8-chip host round-trip) so it has no entry --
+# not a shipped path (on-device is the T3K sampler). N150 fresh: host 62.9/61.8, on-dev 11.8/11.7.
+EXPECTED_METRICS_BATCH32_CI = {
+    "host": {
+        "N150": {"tok_s_u": 61.0, "ttft_ms": 9},
+        "N300": {"tok_s_u": 58.8, "ttft_ms": 8},
+    },
+    "on_device_topk": {
+        "N150": {"tok_s_u": 11.6, "ttft_ms": 9},  # prefill 6.5ms (batched-ON, #49118)
+        "N300": {"tok_s_u": 34.3, "ttft_ms": 8},  # prefill 5.8ms (batched-ON, #49118)
+        "T3K": {"tok_s_u": 140.0, "ttft_ms": 5},  # prefill 3.8ms == TTTv1 ci-32 parity (#49118)
+    },
+}
+
+# Perf workload: natural-length prefill (these sample prompts are ~90-125 tokens -> 128 bucket,
+# matching TTTv1), 200 decode steps. Accuracy uses the 511-token teacher-forcing refpt.
+_PERF_NUM_DECODE_TOKENS = 200
+
+# Tolerance band for the PERFORMANCE gates (tok/s/u, ttft_ms) ONLY. Kept intentionally tight (5%):
+# these gates are not the CI perf-validation path (perf is verified separately), so a loose band
+# would defeat the purpose of this test's local perf-regression check. NOTE: accuracy does NOT use
+# this — TTTv1 gates accuracy at an ABSOLUTE centralized-target − 0.5 pp (no ratio tolerance);
+# see _run_token_accuracy.
+PERF_TOLERANCE = 0.05
+
+
+def _sampling_bucket() -> str:
+    """Map SAMPLING_MODE to a perf-gate bucket. Non-topk on-device modes (e.g. force-argmax)
+    fall into ``on_device_topk`` so they stay gated, never silently un-gated."""
+    return "host" if os.environ.get("SAMPLING_MODE", "host").lower() == "host" else "on_device_topk"
+
+
+_MESH_DEVICE_TO_SHAPE: dict[str, tuple[int, int]] = {
+    "N150": (1, 1),
+    "N300": (1, 2),
+    "T3K": (1, 8),
+}
+
+
+def _ttnn_mesh_device_param_from_env() -> dict:
+    env = os.environ.get("MESH_DEVICE", "").strip()
+    if not env:
+        pytest.skip(
+            "MESH_DEVICE must be set (e.g. N150, N300 or T3K). See module docstring.",
+            allow_module_level=True,
+        )
+    shape = _MESH_DEVICE_TO_SHAPE.get(env)
+    if shape is None:
+        pytest.skip(
+            f"Unsupported MESH_DEVICE={env!r} for Llama-3.2-1B; use N150, N300 or T3K.",
+            allow_module_level=True,
+        )
+    param = {
+        "mesh_shape": shape,
+        "trace_region_size": 50_000_000,
+        "num_command_queues": 1,
+    }
+    # TTTv2 multi-device executor dispatch (and the on-device sampling all-gather) stalls without
+    # an explicit 1D fabric; the root conftest does not auto-enable it. Mirror the sibling
+    # models/common/models/llama32_1b/demo.py wiring: FABRIC_1D on any >1-device mesh.
+    if shape != (1, 1):
+        param["fabric_config"] = ttnn.FabricConfig.FABRIC_1D
+    return param
+
+
+pytestmark = [
+    pytest.mark.parametrize(
+        "ttnn_mesh_device",
+        [_ttnn_mesh_device_param_from_env()],
+        indirect=True,
+        ids=[os.environ.get("MESH_DEVICE", "mesh").strip() or "mesh"],
+    ),
+]
+
+
+@pytest.fixture(scope="module")
+def mesh_device(ttnn_mesh_device):
+    return ttnn_mesh_device
+
+
+def _skip_unless_heads_divide_mesh(mesh_device: ttnn.MeshDevice, hf_model_id: str) -> None:
+    n_dev = mesh_device.get_num_devices()
+    if n_dev <= 1:
+        return
+    cfg = AutoConfig.from_pretrained(hf_model_id)
+    n_h, n_kv = cfg.num_attention_heads, cfg.num_key_value_heads
+    if n_h % n_dev == 0 and n_kv % n_dev == 0:
+        return
+    pytest.skip(
+        f"Incompatible mesh for {hf_model_id}: {n_dev} devices, "
+        f"num_attention_heads={n_h}, num_key_value_heads={n_kv}."
+    )
+
+
+def get_device_name(mesh_device: ttnn.MeshDevice) -> str:
+    n = mesh_device.get_num_devices()
+    if n == 1:
+        return "N150"
+    if n == 2:
+        return "N300"
+    if n == 8:
+        return "T3K"
+    return f"{n}dev"
+
+
+def lazy_weight_cache_dir_for_demo(mesh_device: ttnn.MeshDevice, hf_model_id: str) -> Path:
+    device_name = get_device_name(mesh_device)
+    hf = hf_model_id.strip("/")
+    tt_cache = os.getenv("TT_CACHE_PATH")
+    if tt_cache:
+        root = Path(tt_cache) / device_name
+    else:
+        root = Path("model_cache") / hf / device_name
+    root.mkdir(parents=True, exist_ok=True)
+    logger.info(f"Llama-3.2-1B demo LazyWeight cache directory: {root.resolve()}")
+    return root
+
+
+def load_reference_data(hf_model_id: str):
+    """Load reference tensors and optional metadata from ``.refpt``.
+
+    Supports both the metadata-rich format (``prompt_len`` + ``metadata`` keys) and
+    the legacy half-split book format.
+    """
+    name = hf_model_id.strip("/").split("/")[-1]
+    ref_path = Path("models/tt_transformers/tests/reference_outputs") / f"{name}.refpt"
+    if not ref_path.exists():
+        pytest.skip(f"Reference file not found: {ref_path}")
+
+    ref_data = torch.load(ref_path, map_location="cpu", weights_only=False)
+    reference_tokens = ref_data["reference_tokens"]
+    top5_tokens = ref_data["top5_tokens"]
+    prompt_len = ref_data.get("prompt_len")
+    metadata = ref_data.get("metadata")
+    return reference_tokens, top5_tokens, prompt_len, metadata
+
+
+def load_input_prompts(batch_size: int) -> list[str]:
+    prompts_path = Path("models/tt_transformers/demo/sample_prompts/input_data_questions_prefill_128.json")
+    if not prompts_path.exists():
+        return ["What is the meaning of life?"] * batch_size
+    with open(prompts_path) as f:
+        data = json.load(f)
+    prompts = (
+        [entry["prompt"] for entry in data] if isinstance(data, list) else data.get("prompts", [data.get("prompt", "")])
+    )
+    while len(prompts) < batch_size:
+        prompts = prompts * 2
+    return prompts[:batch_size]
+
+
+def tokenize_prompts(
+    prompts: list[str],
+    tokenizer,
+    *,
+    max_prefill_len: int | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Tokenize prompts to their natural length — TTTv1 ``preprocess_inputs_prefill`` semantics.
+
+    Each prompt is encoded with the chat template at its real length. The returned ``[batch,
+    max_len]`` token tensor is right-padded to the batch-max for rectangularity, while the
+    returned per-user lengths are the *real* token counts — the executor reads only
+    ``tokens[user, :prompt_len]`` and then buckets each user to ``get_padded_prefill_len``
+    (128 / 1024 / next-pow2). This matches TTTv1 exactly: no fixed pad-to-N prefill budget.
+
+    ``max_prefill_len`` is an optional clip *cap* (like TTTv1's ``max_prefill_len``): prompts
+    longer than it are left-clipped to their most recent tokens. It is never a pad-up target.
+    """
+    pad_id = tokenizer.pad_token_id if tokenizer.pad_token_id is not None else tokenizer.eos_token_id
+    encoded: list[list[int]] = []
+    for p in prompts:
+        ids = list(encode_prompt_hf(tokenizer, p))
+        if max_prefill_len is not None and len(ids) > max_prefill_len:
+            ids = ids[-max_prefill_len:]
+        encoded.append(ids)
+    lens = [len(ids) for ids in encoded]
+    max_len = max(lens)
+    padded = [ids + [pad_id] * (max_len - len(ids)) for ids in encoded]
+    t = torch.tensor(padded, dtype=torch.long)
+    return t, torch.tensor(lens, dtype=torch.long)
+
+
+def select_teacher_forcing_top5_slice(
+    top5_tokens: torch.Tensor,
+    reference_tokens: torch.Tensor,
+    prompt_len: int,
+    *,
+    metadata_aligned: bool,
+) -> torch.Tensor:
+    """Align ``top5_tokens`` with teacher-forcing targets across refpt conventions."""
+    num_target = len(reference_tokens) - prompt_len
+    target_tokens = reference_tokens[prompt_len : prompt_len + num_target]
+    if num_target <= 0:
+        raise ValueError("prompt_len must be smaller than reference length")
+
+    if metadata_aligned and top5_tokens.shape[0] == num_target:
+        logger.info(
+            f"Teacher-forcing top5: metadata direct path (top5_len={top5_tokens.shape[0]}, target_len={num_target})"
+        )
+        return top5_tokens
+
+    candidates = []
+    starts = (0, prompt_len - 1, prompt_len) if metadata_aligned else (prompt_len - 1, prompt_len)
+    for start in starts:
+        end = start + num_target
+        if start < 0 or end > top5_tokens.shape[0]:
+            continue
+        aligned = top5_tokens[start:end]
+        probe = min(16, num_target)
+        score = sum(int(aligned[i, 0].item() == target_tokens[i].item()) for i in range(probe))
+        candidates.append((score, start, aligned))
+
+    if not candidates:
+        raise ValueError(
+            f"Cannot align top5: prompt_len={prompt_len}, num_target={num_target}, top5_len={top5_tokens.shape[0]}"
+        )
+
+    best_score, best_start, best = max(candidates, key=lambda x: x[0])
+    logger.info(f"Teacher-forcing top5 alignment: start={best_start}, score={best_score}/{min(16, num_target)}")
+    return best
+
+
+def log_generated_text(prompts, generated_token_ids, tokenizer):
+    logger.info("Finished decoding, printing the final outputs...\n")
+    for user, output_ids in enumerate(generated_token_ids):
+        prompt_text = prompts[user] if user < len(prompts) else ""
+        generated_text = tokenizer.decode(output_ids, skip_special_tokens=True).strip()
+        short_prompt = (
+            prompt_text[:100] + "\n<long prompt not printed in full>\n" + prompt_text[-100:]
+            if len(prompt_text) > 200
+            else prompt_text
+        )
+        logger.info(f"\n==USER {user} - PROMPT\n{short_prompt}\n==USER {user} - OUTPUT\n{generated_text}\n")
+
+
+def create_model(
+    mesh_device: ttnn.MeshDevice,
+    optimizations: str,
+    cache_dir: Path,
+    *,
+    max_batch_size: int = 32,
+    max_seq_len: int = 4096,
+) -> Llama32_1BTransformer1D:
+    """Build ``Llama32_1BTransformer1D`` in executor (paged KV) mode.
+
+    Picks one of the two module-level precision recipes (``LLAMA32_1B_ACCURACY`` /
+    ``LLAMA32_1B_PERFORMANCE``) — both defined in ``llama32_1b/model.py`` and grounded
+    in TTTv1's ``DecodersPrecision`` for Llama-3.2-1B-Instruct.
+    """
+    hf_model = os.environ.get("HF_MODEL", "meta-llama/Llama-3.2-1B-Instruct")
+    _skip_unless_heads_divide_mesh(mesh_device, hf_model)
+
+    precision = LLAMA32_1B_PERFORMANCE if optimizations == "performance" else LLAMA32_1B_ACCURACY
+
+    try:
+        model = Llama32_1BTransformer1D.from_pretrained(
+            mesh_device,
+            hf_model,
+            max_batch_size=max_batch_size,
+            max_seq_len=max_seq_len,
+            num_layers=_demo_num_layers(),
+            cache_dir=cache_dir,
+            precision=precision,
+            executor_mode=True,
+        )
+    except Exception as e:
+        pytest.skip(f"Could not build Llama-3.2-1B model (weights / memory / mesh): {e}")
+
+    return model
+
+
+# =============================================================================
+# ci-b1-DP: single-user data-parallel scaling smoke (TTTv1 ci-b1-DP-* parity)
+# =============================================================================
+#
+# One user per DP group, model replicated across ``data_parallel`` disjoint submeshes,
+# instruct prompts, paged attention, trace on. The ONLY correctness check is the
+# special-token garbage guard plus "runs to completion without hang/exception". This is a
+# mesh / KV-cache / page-table scaling smoke test, NOT an accuracy or perf gate.
+#
+# Per-case size table (TTTv1 simple_text_demo.py parity, with the DP-2 N300 addition):
+#   ci-b1-DP-2  : max_seq_len=1024, max_generated_tokens=200, stop_at_eos=True
+#                 (fast smoke; the only DP case runnable on N300 — 2 single-device groups)
+#   ci-b1-DP-4  : max_seq_len=4096, max_generated_tokens=2048, stop_at_eos=False
+#   ci-b1-DP-8  : max_seq_len=4096, max_generated_tokens=2048, stop_at_eos=False
+#   ci-b1-DP-16 : max_seq_len=1024, max_generated_tokens=200,  stop_at_eos=True
+#   ci-b1-DP-32 : max_seq_len=1024, max_generated_tokens=200,  stop_at_eos=True
+#
+# Hardware feasibility: each DP group is one device (batch_size=1 per group), so
+# ``data_parallel == n_devices``. On N300 (2 chips) only DP-2 fits; DP-4/8/16/32 cleanly
+# ``pytest.skip`` via ``_dp_or_skip``. ``stop_at_eos`` is effectively a no-op in TTTv2's
+# fixed-budget ``run_perf_benchmark`` loop (it always runs ``num_decode_tokens`` steps); the
+# special-token guard truncates at the first stop token before scanning, so this is fine.
+_DP_SIZE_TABLE: dict[int, dict] = {
+    2: {"max_seq_len": 1024, "max_generated_tokens": 200, "stop_at_eos": True},
+    4: {"max_seq_len": 4096, "max_generated_tokens": 2048, "stop_at_eos": False},
+    8: {"max_seq_len": 4096, "max_generated_tokens": 2048, "stop_at_eos": False},
+    16: {"max_seq_len": 1024, "max_generated_tokens": 200, "stop_at_eos": True},
+    32: {"max_seq_len": 1024, "max_generated_tokens": 200, "stop_at_eos": True},
+}
+
+
+def create_dp_submeshes(mesh_device: ttnn.MeshDevice, data_parallel: int) -> list:
+    """Partition the open parent mesh into ``data_parallel`` disjoint row-submeshes.
+
+    Mirrors TTTv1 ``generator.create_submeshes`` minus the Galaxy reshape-to-(4,8) branch
+    (no Galaxy reachable here). For the single-user DP cases on our hardware
+    ``n // data_parallel == 1``, so each submesh is a ``(1,1)`` mesh. Fabric stays owned by
+    the parent — do NOT set fabric per-submesh.
+    """
+    if data_parallel == 1:
+        return [mesh_device]
+    n = mesh_device.get_num_devices()
+    assert n % data_parallel == 0, f"{n} devices not divisible by data_parallel={data_parallel}"
+    return mesh_device.create_submeshes(ttnn.MeshShape(1, n // data_parallel))
+
+
+def _dp_or_skip(mesh_device: ttnn.MeshDevice, data_parallel: int) -> None:
+    """Skip unless the mesh has exactly ``data_parallel`` single-device DP groups."""
+    n = mesh_device.get_num_devices()
+    if n % data_parallel != 0 or (n // data_parallel) != 1:
+        pytest.skip(f"DP-{data_parallel} needs {data_parallel} single-device groups; have {n} devices")
+
+
+def assert_no_special_tokens(
+    generated_token_ids, tokenizer, *, case_name: str = "", is_ci_env: bool | None = None
+) -> None:
+    """Garbage guard: no special token mid-stream. Mirrors TTTv1 ``simple_text_demo.py``.
+
+    TTTv2's ``result.generated_token_ids[user]`` already starts at the first generated token
+    (prefill argmax), so unlike TTTv1 we do not slice off the prompt — these are output-only. Each
+    user's output is truncated at the first stop token (EoS / eot) before scanning, then checked for
+    any ``tokenizer.all_special_ids`` member. Following TTTv1, a survivor logs a warning always but
+    hard-fails only under CI (``CI == "true"``), so local runs finish while CI stays strict.
+    """
+    if is_ci_env is None:
+        is_ci_env = os.environ.get("CI") == "true"
+    special = set(tokenizer.all_special_ids)
+    stop = set()
+    if tokenizer.eos_token_id is not None:
+        stop.add(tokenizer.eos_token_id)
+    eot = tokenizer.convert_tokens_to_ids("<|eot_id|>")
+    if isinstance(eot, int) and eot >= 0:
+        stop.add(eot)
+    offenders = 0
+    for out in generated_token_ids:
+        seq = list(out)
+        for i, t in enumerate(seq):
+            if t in stop:
+                seq = seq[:i]
+                break
+        if any(t in special for t in seq):
+            offenders += 1
+    if offenders:
+        logger.warning(f"[{case_name}] model produced special tokens ({offenders}/{len(generated_token_ids)} users)")
+        if is_ci_env:
+            assert False, f"model produced special tokens ({offenders} users)"
+
+
+def _run_dp_smoke(
+    mesh_device: ttnn.MeshDevice,
+    optimizations: str,
+    cache_dir: Path,
+    data_parallel: int,
+    max_seq_len: int,
+    max_gen_tokens: int,
+    stop_at_eos: bool,
+) -> None:
+    """Single-user data-parallel scaling smoke across ``data_parallel`` submeshes.
+
+    Builds one model + one traced executor + one KV cache + one page table per submesh
+    (one user each), runs ``run_perf_benchmark`` per submesh sequentially, collects the
+    per-submesh output, and asserts no special tokens. Every executor and model is cleaned
+    up in ``finally`` even on mid-loop failure.
+    """
+    _dp_or_skip(mesh_device, data_parallel)
+
+    hf_model = os.environ.get("HF_MODEL", "meta-llama/Llama-3.2-1B-Instruct")
+    _skip_unless_heads_divide_mesh(mesh_device, hf_model)
+    tokenizer = AutoTokenizer.from_pretrained(hf_model)
+    precision = LLAMA32_1B_PERFORMANCE if optimizations == "performance" else LLAMA32_1B_ACCURACY
+
+    submeshes = create_dp_submeshes(mesh_device, data_parallel)
+
+    # One prompt per DP group (load_input_prompts pads/truncates to the requested count).
+    prompts = load_input_prompts(data_parallel)
+
+    sampling_mode = os.environ.get("SAMPLING_MODE", "host").lower()
+    _on_device_params = {
+        "on_device": SamplingParams(temperature=0.0, top_k=1, top_p=0.0),
+        "on_device_topk": SamplingParams(temperature=0.0, top_k=32, top_p=0.08),
+    }
+
+    models: list = []
+    executors: list = []
+    all_generated: list = []
+    try:
+        for i, sm in enumerate(submeshes):
+            try:
+                model = Llama32_1BTransformer1D.from_pretrained(
+                    sm,
+                    hf_model,
+                    max_batch_size=1,
+                    max_seq_len=max_seq_len,
+                    num_layers=_demo_num_layers(),
+                    cache_dir=cache_dir,
+                    precision=precision,
+                    executor_mode=True,
+                )
+            except Exception as e:
+                pytest.skip(f"Could not build Llama-3.2-1B model (weights / memory / mesh): {e}")
+            models.append((model, sm))
+
+            traced_executor = TracedLlama32_1BExecutor(model, sm)
+            executors.append(traced_executor)
+
+            ma = model.model_args
+            assert ma is not None
+
+            block_size = 32
+            n_dev_sm = sm.get_num_devices()
+            max_num_blocks_per_user = ma.max_seq_len // block_size
+            max_num_blocks = max_num_blocks_per_user * ma.max_batch_size  # max_batch_size == 1
+
+            kv_cache_shape = (max_num_blocks, ma.n_kv_heads // n_dev_sm, block_size, ma.head_dim)
+            kv_cache = traced_executor.allocate_kv_cache(kv_cache_shape, torch.bfloat16, ma.n_layers)
+            page_table = torch.arange(max_num_blocks, dtype=torch.int32).reshape(
+                ma.max_batch_size, max_num_blocks_per_user
+            )
+
+            input_tokens, prompt_lens = tokenize_prompts(prompts[i : i + 1], tokenizer)
+
+            sampling_params = (
+                _on_device_params[sampling_mode]
+                if sampling_mode in _on_device_params and getattr(model, "supports_on_device_sampling", False)
+                else None
+            )
+            logger.info(
+                f"[ci-b1-DP-{data_parallel}] submesh {i} SAMPLING_MODE={sampling_mode} "
+                f"-> sampling_params={sampling_params}, stop_at_eos={stop_at_eos}"
+            )
+
+            result = run_perf_benchmark(
+                traced_executor,
+                tokens=input_tokens,
+                kv_cache=kv_cache,
+                page_table=page_table,
+                num_decode_tokens=max_gen_tokens,
+                max_batch_size=1,
+                prompt_lens=prompt_lens,
+                sampling_params=sampling_params,
+            )
+            all_generated.append(result.generated_token_ids[0])
+            log_generated_text(prompts[i : i + 1], result.generated_token_ids, tokenizer)
+
+        assert_no_special_tokens(all_generated, tokenizer, case_name=f"ci-b1-DP-{data_parallel}")
+    finally:
+        for ex in executors:
+            ex.cleanup()
+        for model, sm in models:
+            cleanup_model_case(model, sm)
+        # When data_parallel > 1 we carved child submeshes off the fixture-owned parent
+        # mesh. Those submeshes share the parent's command queue, so the parent cannot be
+        # closed (by the module-scoped ttnn_mesh_device fixture) while they remain in use.
+        # Drain the parent + submesh CQs and reset their in-use state before teardown.
+        if data_parallel > 1:
+            mesh_device.quiesce_devices()
+
+
+# =============================================================================
+# Tests
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "test_config",
+    [
+        pytest.param("token-accuracy", id="token-accuracy"),
+        pytest.param("batch-1", id="batch-1"),
+        pytest.param("batch-32", id="batch-32"),
+        pytest.param("batch-32-ci", id="batch-32-ci"),
+        pytest.param("eval-32", id="eval-32"),
+        pytest.param("ci-b1-DP-2", id="ci-b1-DP-2"),
+        pytest.param("ci-b1-DP-4", id="ci-b1-DP-4"),
+        pytest.param("ci-b1-DP-8", id="ci-b1-DP-8"),
+        pytest.param("ci-b1-DP-16", id="ci-b1-DP-16"),
+        pytest.param("ci-b1-DP-32", id="ci-b1-DP-32"),
+    ],
+)
+@pytest.mark.parametrize("optimizations", ["performance", "accuracy"])
+def test_llama32_1b(test_config, mesh_device, optimizations):
+    """Main test entry for TTTv2 Llama-3.2-1B-Instruct."""
+    device_name = get_device_name(mesh_device)
+    expected = EXPECTED_METRICS.get(optimizations, {}).get(device_name, {})
+    model = None
+    hf_model = os.environ.get("HF_MODEL", "meta-llama/Llama-3.2-1B-Instruct")
+    cache_dir = lazy_weight_cache_dir_for_demo(mesh_device, hf_model)
+
+    try:
+        # ci-b1-DP-*: single-user data-parallel smoke. Builds N models itself (one per
+        # submesh), so it does NOT go through the shared create_model path below.
+        if test_config.startswith("ci-b1-DP"):
+            data_parallel = int(test_config.rsplit("-", 1)[1])
+            sizes = _DP_SIZE_TABLE[data_parallel]
+            _run_dp_smoke(
+                mesh_device,
+                optimizations,
+                cache_dir,
+                data_parallel=data_parallel,
+                max_seq_len=sizes["max_seq_len"],
+                max_gen_tokens=sizes["max_generated_tokens"],
+                stop_at_eos=sizes["stop_at_eos"],
+            )
+            return
+
+        # Token-accuracy feeds a single reference sequence — max_batch_size=1 avoids
+        # DRAM pressure from a full 32-user KV cache allocation.
+        # batch-32 uses max_seq_len=1024 (matching the llama32_3b demo); 1B weights are
+        # tiny so DRAM is not a constraint, and 1024 comfortably covers the 128-bucket
+        # prefill + 200 decode workload.
+        # batch-32 and eval-32 both run 32 users with max_seq_len=1024 (matching the
+        # llama32_3b demo); 1B weights are tiny so DRAM is not a constraint.
+        if test_config in ("batch-32", "eval-32"):
+            max_bs, max_seq_len = 32, 1024
+            expected = EXPECTED_METRICS_BATCH32.get(_sampling_bucket(), {}).get(device_name, {})
+        elif test_config == "batch-32-ci":
+            # CI-faithful batch-32 leg (TTTv1 ci-32 parity): larger seq len + 1024 decode
+            # budget. 1B weights are tiny so seq2048 fits at batch-32 on every SKU.
+            max_bs, max_seq_len = 32, 2048
+            # Own perf gate measured at the seq2048/decode1024 workload (NOT the lighter batch-32
+            # constant, which would be a config-artifact miss). The gate is keyed by SAMPLING_MODE
+            # because host argmax and on-device sampling are ~1.7x apart on 1B (on-device pays the
+            # slow ttnn.topk). Each per-path N300 target is freshly measured on this base and sits
+            # at/above same-box TTTv1 ci-32 for the comparable path (see EXPECTED_METRICS_BATCH32_CI).
+            # Non-topk on-device modes (force-argmax) fall back to the on_device_topk bucket so they
+            # stay gated, never silently un-gated; N150/T3K fall back to the short-context constant.
+            _bucket = _sampling_bucket()
+            expected = EXPECTED_METRICS_BATCH32_CI.get(_bucket, {}).get(
+                device_name, EXPECTED_METRICS_BATCH32.get(_bucket, {}).get(device_name, {})
+            )
+        else:
+            max_bs, max_seq_len = 1, 4096
+        model = create_model(mesh_device, optimizations, cache_dir, max_batch_size=max_bs, max_seq_len=max_seq_len)
+
+        if test_config == "token-accuracy":
+            _run_token_accuracy(model, mesh_device, expected)
+        elif test_config == "batch-1":
+            perf_expected = (
+                EXPECTED_METRICS_BATCH1.get(_sampling_bucket(), {}).get(optimizations, {}).get(device_name, {})
+            )
+            _run_perf_benchmark(model, mesh_device, perf_expected, batch_size=1, case_name=f"{optimizations}/batch-1")
+        elif test_config == "batch-32":
+            # Natural-length prefill: these sample prompts bucket to 128 (PERF.md Short-Context
+            # Batch-32 row), matching TTTv1's traced-prefill seq len without a forced pad.
+            _run_perf_benchmark(model, mesh_device, expected, batch_size=32, case_name=f"{optimizations}/batch-32")
+        elif test_config == "batch-32-ci":
+            # CI-faithful leg: seq2048 + 1024 decode tokens (clamped in _run_perf_benchmark).
+            # Gated by EXPECTED_METRICS_BATCH32_CI (measured at this workload, TTTv1-parity).
+            _run_perf_benchmark(
+                model,
+                mesh_device,
+                expected,
+                batch_size=32,
+                case_name=f"{optimizations}/batch-32-ci",
+                num_decode_tokens=1024,
+            )
+        elif test_config == "eval-32":
+            # 32-user cross-batch determinism (self-consistency under prompt rotation).
+            _run_eval_repeat_batch32(model, mesh_device)
+    finally:
+        cleanup_model_case(model, mesh_device)
+
+
+def _run_token_accuracy(model: Llama32_1BTransformer1D, mesh_device, expected):
+    """Teacher-forcing token accuracy vs ``.refpt``."""
+    hf_model = os.environ.get("HF_MODEL", "meta-llama/Llama-3.2-1B-Instruct")
+    reference_tokens, top5_tokens, prompt_len, metadata = load_reference_data(hf_model)
+
+    if reference_tokens.dim() > 1:
+        reference_tokens = reference_tokens.squeeze()
+
+    has_prompt_len_metadata = prompt_len is not None
+    if has_prompt_len_metadata:
+        prompt_len = int(prompt_len)
+        logger.info(f"Using metadata prompt_len={prompt_len}")
+    else:
+        prompt_len = len(reference_tokens) // 2
+        logger.info(f"Reference missing prompt_len metadata; using legacy half-split={prompt_len}.")
+
+    if metadata:
+        logger.info(
+            f"Reference metadata: hf_model_id={metadata.get('hf_model_id')}, "
+            f"revision={metadata.get('revision')}, created_at={metadata.get('created_at')}"
+        )
+
+    prompt_tokens = reference_tokens[:prompt_len].unsqueeze(0)
+
+    executor = EagerLlama32_1BExecutor(model, mesh_device)
+    ma = model.model_args
+    assert ma is not None
+
+    max_batch_size = ma.max_batch_size
+    prompt_tokens = prompt_tokens.repeat(max_batch_size, 1)
+    block_size = 32
+    max_seq_len = ma.max_seq_len
+    max_num_blocks_per_user = max_seq_len // block_size
+    max_num_blocks = max_num_blocks_per_user * max_batch_size
+
+    kv_cache_shape = (max_num_blocks, ma.n_kv_heads // mesh_device.get_num_devices(), block_size, ma.head_dim)
+    kv_cache = executor.allocate_kv_cache(kv_cache_shape, torch.bfloat16, ma.n_layers)
+    page_table = torch.arange(max_num_blocks, dtype=torch.int32).reshape(max_batch_size, max_num_blocks_per_user)
+
+    target_top5 = select_teacher_forcing_top5_slice(
+        top5_tokens,
+        reference_tokens,
+        prompt_len,
+        metadata_aligned=has_prompt_len_metadata,
+    )
+    is_ci_env = os.environ.get("CI") == "true"
+    profiler = BenchmarkProfiler()
+    profiler.start("run")
+    # run_teacher_forcing times the prefill + per-step (teacher-forced) decode loop and, given the
+    # profiler, brackets the "inference_prefill" / "inference_decode" steps itself — so the returned
+    # result carries prefill/decode throughput alongside accuracy for CI benchmark-data emission.
+    result = run_teacher_forcing(
+        executor,
+        prompt_tokens=prompt_tokens,
+        reference_tokens=reference_tokens,
+        top5_tokens=target_top5,
+        kv_cache=kv_cache,
+        page_table=page_table,
+        max_batch_size=max_batch_size,
+        profiler=profiler,
+    )
+    profiler.end("run")
+
+    top1 = result.top1_accuracy() * 100
+    top5 = result.top5_accuracy() * 100
+    logger.info(
+        f"Token accuracy — top1: {top1:.1f}%, top5: {top5:.1f}% | "
+        f"TTFT: {result.ttft_ms:.1f}ms, decode: {result.decode_tok_s_u:.1f} tok/s/u"
+    )
+
+    # CI-dashboard telemetry: emit a ``demo_accuracy`` partial mirroring TTTv1 simple_text_demo.py
+    # — the FULL perf measurement set (prefill_t/s, prefill_time_to_token, decode_t/s, decode_t/s/u)
+    # PLUS top1/top5, all from this timed teacher-forcing run. create_benchmark_data /
+    # save_partial_run_json are no-ops unless CI == "true" (they guard on it internally); the
+    # is_ci_env guard here keeps the import/attr access off the local path too. Saved BEFORE the
+    # accuracy asserts so telemetry is captured even when the gate later fails.
+    if is_ci_env:
+        num_target = len(reference_tokens) - prompt_len
+        measurements = {
+            "prefill_t/s": result.prefill_tok_s,
+            "prefill_time_to_token": result.prefill_time_to_token_s,  # seconds (TTTv1 units)
+            "decode_t/s": result.decode_tok_s,
+            "decode_t/s/u": result.decode_tok_s_u,
+        }
+        benchmark_data = create_benchmark_data(
+            profiler, measurements, {"inference_prefill": 0, "inference_decode": 1}, targets={}
+        )
+        benchmark_data.add_measurement(profiler, 0, "inference_decode", "top1_token_accuracy", top1, target=None)
+        benchmark_data.add_measurement(profiler, 0, "inference_decode", "top5_token_accuracy", top5, target=None)
+        benchmark_data.save_partial_run_json(
+            profiler,
+            run_type="demo_accuracy",
+            ml_model_name=hf_model,
+            ml_model_type="llm",
+            device_name=get_device_name(mesh_device),
+            num_layers=ma.n_layers,
+            batch_size=1,
+            input_sequence_length=prompt_len,
+            output_sequence_length=num_target,
+        )
+
+    # Accuracy gate — threshold SOURCE is flag-controlled. The flag is
+    # currently ``is_ci_env``:
+    #   use_centralized_targets = True  → mirror TTTv1: pull centralized targets via
+    #       resolve_accuracy_targets and subtract an ABSOLUTE 0.5 pp (get_accuracy_thresholds,
+    #       simple_text_demo.py). Missing entry is a hard error (never silently un-gate in CI).
+    #   use_centralized_targets = False → use the demo's local EXPECTED_METRICS values DIRECTLY
+    #       (no ratio tolerance — TTTv1 applies none to accuracy).
+    # Measured accuracy is rounded up with math.ceil before the compare, matching TTTv1 exactly
+    # (simple_text_demo.py:1657-1658, ``math.ceil(acc[...] * 100)``).
+    use_centralized_targets = is_ci_env
+    device_name = get_device_name(mesh_device)
+    if use_centralized_targets:
+        central = resolve_accuracy_targets(hf_model, device_name, batch_size=1, seq_len=512)
+        if not central or "top1" not in central or "top5" not in central:
+            raise ValueError(
+                f"No centralized accuracy target for {hf_model} on {device_name} "
+                "(batch_size=1, seq_len=512); add an entry to models/model_targets.yaml."
+            )
+        min_top1 = float(central["top1"]) - 0.5
+        min_top5 = float(central["top5"]) - 0.5
+    else:
+        min_top1 = float(expected.get("top1", 0))
+        min_top5 = float(expected.get("top5", 0))
+
+    # math.ceil matches TTTv1's integer-rounded accuracy check (simple_text_demo.py:1657-1658).
+    meas_top1 = math.ceil(top1)
+    meas_top5 = math.ceil(top5)
+    assert meas_top1 >= min_top1, f"Top-1 accuracy {top1:.1f}% (ceil {meas_top1}) below threshold {min_top1:.1f}%"
+    assert meas_top5 >= min_top5, f"Top-5 accuracy {top5:.1f}% (ceil {meas_top5}) below threshold {min_top5:.1f}%"
+
+
+def _run_perf_benchmark(
+    model: Llama32_1BTransformer1D,
+    mesh_device,
+    expected,
+    batch_size: int,
+    case_name: str,
+    max_prefill_len: int | None = None,
+    num_decode_tokens: int | None = None,
+):
+    """Timed prefill + decode (``TracedLlama32_1BExecutor``).
+
+    Prefill uses each prompt's natural token length (TTTv1 ``preprocess_inputs_prefill``
+    semantics — the executor buckets to ``get_padded_prefill_len``); decode runs for
+    ``num_decode_tokens`` steps (default ``_PERF_NUM_DECODE_TOKENS``).
+    ``max_prefill_len`` is an optional clip cap for over-long prompts, never a pad-up target.
+
+    The decode budget is clamped to what the paged KV cache can hold:
+    ``effective = min(requested, max_seq_len - prompt_bucket - margin)`` so the high-water
+    decode position never overruns the page table (the ``batch-32-ci`` leg requests 1024).
+    """
+    hf_model = os.environ.get("HF_MODEL", "meta-llama/Llama-3.2-1B-Instruct")
+    tokenizer = AutoTokenizer.from_pretrained(hf_model)
+
+    # On-device sampling toggle for N150/N300 evidence-gathering (see sampling handoff docs):
+    #   host            -> sampling_params=None (host-argmax, the default shipped path)
+    #   on_device       -> greedy temp=0,k=1,p=0 => trace-captured FORCE-ARGMAX full-vocab path
+    #   on_device_topk  -> temp=0,k=32,p=0.08    => trace-captured TOP-K op path (gathers only
+    #                      the [*,32] tuples; PERF.md-parity recipe, faster than force-argmax)
+    sampling_mode = os.environ.get("SAMPLING_MODE", "host").lower()
+    _on_device_params = {
+        "on_device": SamplingParams(temperature=0.0, top_k=1, top_p=0.0),
+        "on_device_topk": SamplingParams(temperature=0.0, top_k=32, top_p=0.08),
+    }
+    sampling_params = (
+        _on_device_params[sampling_mode]
+        if sampling_mode in _on_device_params and getattr(model, "supports_on_device_sampling", False)
+        else None
+    )
+    logger.info(f"[{case_name}] SAMPLING_MODE={sampling_mode} -> sampling_params={sampling_params}")
+
+    # Batched-prefill A/B knob (parity caveat #12): set DISABLE_BATCHED_PREFILL=1 to force the
+    # sequential per-user prefill loop (the pre-feature baseline) for before/after TTFT comparison.
+    # Companion knob (PLAN_01): DISABLE_MINIMAL_MATMUL=1 forces QKV/W2 prefill back to ttnn.linear
+    # (read at model build time, so it must be in the env before from_pretrained — it already is here).
+    if os.environ.get("DISABLE_BATCHED_PREFILL") and model.model_args is not None:
+        model.model_args.disable_batched_prefill = True
+
+    # Free-running perf run: enable the executor's on-device decode loop on the on-device sampling
+    # path (inert on host/force-argmax; gated to the top-k path by _decode_loop_active). This is the
+    # #49282 T3K batch-1 decode-gap fix — it must be active on the perf path for the T3K b1 gate.
+    # fast_prefill_last_token: slice the single consumed last-token row on device before readback so the
+    # batch-1 host concat/readback moves one row instead of the full [1,1,32,vocab] tile — closes most of
+    # the residual T3K batch-1 PREFILL TTFT gap vs TTTv1 (which reads back only tokens). Inert for batch>1.
+    traced_executor = TracedLlama32_1BExecutor(
+        model, mesh_device, ondevice_decode_loop=sampling_params is not None, fast_prefill_last_token=True
+    )
+    try:
+        ma = model.model_args
+        assert ma is not None
+
+        block_size = 32
+        max_seq_len = ma.max_seq_len
+        max_batch_size = ma.max_batch_size
+        max_num_blocks_per_user = max_seq_len // block_size
+        max_num_blocks = max_num_blocks_per_user * max_batch_size
+
+        kv_cache_shape = (max_num_blocks, ma.n_kv_heads // mesh_device.get_num_devices(), block_size, ma.head_dim)
+        kv_cache = traced_executor.allocate_kv_cache(kv_cache_shape, torch.bfloat16, ma.n_layers)
+        page_table = torch.arange(max_num_blocks, dtype=torch.int32).reshape(max_batch_size, max_num_blocks_per_user)
+
+        # Decode-token budget, clamped to the KV-cache headroom. Prompts bucket to ~128 and
+        # we keep a 16-token margin, so the high-water decode position stays inside max_seq_len.
+        _PROMPT_BUCKET = 128
+        _DECODE_MARGIN = 16
+        requested_decode = _PERF_NUM_DECODE_TOKENS if num_decode_tokens is None else num_decode_tokens
+        effective_decode = min(requested_decode, max_seq_len - _PROMPT_BUCKET - _DECODE_MARGIN)
+        logger.info(
+            f"[{case_name}] num_decode_tokens: requested={requested_decode}, "
+            f"effective={effective_decode} (max_seq_len={max_seq_len})"
+        )
+
+        prompts = load_input_prompts(batch_size)
+        # Natural-length tokenization (matches TTTv1): the executor buckets each user's real
+        # length to get_padded_prefill_len. These sample prompts are ~90-125 tokens -> 128 bucket.
+        input_tokens, prompt_lens = tokenize_prompts(prompts, tokenizer, max_prefill_len=max_prefill_len)
+
+        # BenchmarkProfiler brackets the timed prefill/decode regions inside run_perf_benchmark
+        # (default-None ⇒ byte-inert for every other caller) so we can emit CI perf telemetry.
+        is_ci_env = os.environ.get("CI") == "true"
+        profiler = BenchmarkProfiler()
+        profiler.start("run")
+        result = run_perf_benchmark(
+            traced_executor,
+            tokens=input_tokens,
+            kv_cache=kv_cache,
+            page_table=page_table,
+            num_decode_tokens=effective_decode,
+            max_batch_size=max_batch_size,
+            prompt_lens=prompt_lens,
+            sampling_params=sampling_params,
+            profiler=profiler,
+        )
+        profiler.end("run")
+
+        logger.info(
+            f"Performance [{case_name}] — TTFT: {result.ttft_ms:.1f}ms, "
+            f"tok/s/u: {result.tok_s_u:.1f}, "
+            f"tok/s: {result.tok_s:.1f}, "
+            f"decode latency: {result.decode_latency_mean_ms:.2f}ms"
+        )
+        log_generated_text(prompts, result.generated_token_ids, tokenizer)
+
+        # CI-dashboard telemetry: emit a ``demo_perf`` partial mirroring TTTv1 simple_text_demo.py.
+        # Saved BEFORE the special-token guard and perf gate so telemetry is captured even when a
+        # downstream assert fails. No-op unless CI == "true" (BenchmarkData guards on it).
+        if is_ci_env:
+            prefill_seq_len = int(prompt_lens.max())
+            prefill_time_s = result.prefill_time_s
+            measurements = {
+                "prefill_t/s": (result.batch_size * prefill_seq_len) / prefill_time_s if prefill_time_s > 0 else 0.0,
+                "prefill_time_to_token": prefill_time_s / result.batch_size,  # seconds (TTTv1 units)
+                "decode_t/s": result.tok_s,
+                "decode_t/s/u": result.tok_s_u,
+            }
+            benchmark_data = create_benchmark_data(
+                profiler, measurements, {"inference_prefill": 0, "inference_decode": 1}, targets={}
+            )
+            benchmark_data.save_partial_run_json(
+                profiler,
+                run_type="demo_perf",
+                ml_model_name=hf_model,
+                ml_model_type="llm",
+                device_name=get_device_name(mesh_device),
+                num_layers=ma.n_layers,
+                batch_size=result.batch_size,
+                input_sequence_length=prefill_seq_len,
+                output_sequence_length=effective_decode,
+            )
+
+        assert_no_special_tokens(result.generated_token_ids, tokenizer, case_name=case_name)
+
+        if expected:
+            failures = []
+            if "tok_s_u" in expected:
+                tgt = expected["tok_s_u"] * (1 - PERF_TOLERANCE)
+                if result.tok_s_u < tgt:
+                    failures.append(f"tok/s/u {result.tok_s_u:.1f} < target {expected['tok_s_u']}")
+            if "ttft_ms" in expected:
+                tgt = expected["ttft_ms"] * (1 + PERF_TOLERANCE)
+                if result.ttft_ms > tgt:
+                    failures.append(f"ttft_ms {result.ttft_ms:.1f} > target {expected['ttft_ms']}")
+            assert not failures, f"{case_name}: " + "; ".join(failures)
+    finally:
+        traced_executor.cleanup()
+
+
+# ci-eval-32 determinism case: 3 rotated repeats of the batch-32 workload.
+_EVAL_REPEAT_BATCHES = 3
+_EVAL_NUM_DECODE_TOKENS = _PERF_NUM_DECODE_TOKENS
+
+
+def _run_eval_repeat_batch32(model: Llama32_1BTransformer1D, mesh_device):
+    """32-user cross-batch determinism (self-consistency under prompt rotation).
+
+    Runs the batch-32 prefill+decode loop ``_EVAL_REPEAT_BATCHES`` times, rotating the
+    prompt->slot assignment by one each repeat (fresh traced executor + KV cache per repeat),
+    then asserts that undoing the rotation lines up per-user outputs. No external golden.
+    Honors the same ``SAMPLING_MODE`` knob as ``_run_perf_benchmark`` (default host argmax —
+    deterministic and mesh-agnostic, the recommended default for the determinism assert).
+    """
+    hf_model = os.environ.get("HF_MODEL", "meta-llama/Llama-3.2-1B-Instruct")
+    tokenizer = AutoTokenizer.from_pretrained(hf_model)
+
+    ma = model.model_args
+    assert ma is not None
+
+    # Batched-prefill A/B knob (parity caveat #12): DISABLE_BATCHED_PREFILL=1 forces the pure
+    # per-bucket sequential prefill (the Phase-1 path) so eval-32 can be validated both ON and OFF.
+    if os.environ.get("DISABLE_BATCHED_PREFILL"):
+        ma.disable_batched_prefill = True
+
+    block_size = 32
+    max_seq_len = ma.max_seq_len
+    max_batch_size = ma.max_batch_size
+    max_num_blocks_per_user = max_seq_len // block_size
+    max_num_blocks = max_num_blocks_per_user * max_batch_size
+
+    kv_cache_shape = (max_num_blocks, ma.n_kv_heads // mesh_device.get_num_devices(), block_size, ma.head_dim)
+    page_table = torch.arange(max_num_blocks, dtype=torch.int32).reshape(max_batch_size, max_num_blocks_per_user)
+
+    # Fresh traced executor + zeroed KV cache per repeat (driver owns the lifecycle), so the
+    # rotated batches are fully independent — see run_eval_repeat_batch32 for why reuse corrupts
+    # the 3rd repeat on hardware.
+    def make_executor():
+        return TracedLlama32_1BExecutor(model, mesh_device)
+
+    def allocate_kv_cache(executor):
+        return executor.allocate_kv_cache(kv_cache_shape, torch.bfloat16, ma.n_layers)
+
+    # TTTv1 ci-eval-32 numeric prompts (parity). NOTE: on small models these can in principle
+    # degenerate into repetitive loops whose argmax ties flip by batch slot under on-device sampling
+    # (see run_eval_repeat_batch32). Not observed for llama32_1b: this case is green on N300 under
+    # both host and on_device_topk, so it is gated in CI with no xfail; the host-argmax default is
+    # slot-invariant and deterministic.
+    prompts = load_eval_repeat_prompts_batch32()
+
+    def tokenize_fn(ps):
+        return tokenize_prompts(ps, tokenizer)
+
+    sampling_mode = os.environ.get("SAMPLING_MODE", "host").lower()
+    _on_device_params = {
+        "on_device": SamplingParams(temperature=0.0, top_k=1, top_p=0.0),
+        "on_device_topk": SamplingParams(temperature=0.0, top_k=32, top_p=0.08),
+    }
+    sampling_params = (
+        _on_device_params[sampling_mode]
+        if sampling_mode in _on_device_params and getattr(model, "supports_on_device_sampling", False)
+        else None
+    )
+    logger.info(f"[eval-32] SAMPLING_MODE={sampling_mode} -> sampling_params={sampling_params}")
+
+    run_eval_repeat_batch32(
+        make_executor=make_executor,
+        allocate_kv_cache=allocate_kv_cache,
+        page_table=page_table,
+        prompts=prompts,
+        tokenizer=tokenizer,
+        tokenize_fn=tokenize_fn,
+        num_decode_tokens=_EVAL_NUM_DECODE_TOKENS,
+        max_batch_size=max_batch_size,
+        sampling_params=sampling_params,
+        repeat_batches=_EVAL_REPEAT_BATCHES,
+        hf_model_id=hf_model,
+    )

--- a/models/experimental/llama32_1b_quasar/tests/modules/attention/test_attention_1d.py
+++ b/models/experimental/llama32_1b_quasar/tests/modules/attention/test_attention_1d.py
@@ -1,0 +1,2453 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Tests for the Attention1D module (1D mesh topology: N150, N300, T3K).
+
+This test suite verifies:
+1. Unit tests for config dataclasses (no device needed)
+2. Attention1D class matches HuggingFace/Meta reference model
+3. Attention1D correctly rejects TG/Galaxy devices
+4. Sliding window attention works correctly (seq_len > window_size)
+
+Test coverage notes:
+- Paged attention: Tested via (page_block_size, chunk_size) parameter combinations.
+- Chunked prefill: Tested via paged-chunked variant. Requires paged=True and mode="prefill".
+- Variants: non-paged, paged, paged-chunked (3 combinations per test case).
+"""
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+from loguru import logger
+from transformers import AutoConfig, AutoModelForCausalLM
+
+from models.experimental.llama32_1b_quasar.utility_functions import hf_cache_layer_kv, hf_cache_num_layers
+
+# transformers 5.x moved no_init_weights to transformers.initialization; fall back
+# to the old location for transformers < 5.x.
+try:
+    from transformers.initialization import no_init_weights
+except ImportError:
+    from transformers.modeling_utils import no_init_weights
+
+import ttnn
+from models.experimental.llama32_1b_quasar.auto_compose import to_torch_auto_compose
+from models.experimental.llama32_1b_quasar.modules.attention.attention_1d import (
+    Attention1D,
+    Attention1DConfig,
+    _resolve_attention1d_config,
+)
+from models.experimental.llama32_1b_quasar.modules.lazy_weight import LazyWeight
+from models.experimental.llama32_1b_quasar.modules.rmsnorm.rmsnorm_1d import RMSNorm1DConfig
+from models.experimental.llama32_1b_quasar.modules.tt_ccl import TT_CCL
+from models.experimental.llama32_1b_quasar.tensor_utils import (
+    get_rot_transformation_mat,
+    zeros_like_kv_cache,
+    zeros_like_paged_cache,
+)
+from models.experimental.llama32_1b_quasar.tests.utils import stable_model_seed
+from models.experimental.llama32_1b_quasar.utility_functions import comp_allclose, comp_pcc, nearest_32
+
+# =============================================================================
+# RoPE Helper Functions (replaces TTTv1 rope imports)
+# =============================================================================
+
+
+def _permute_to_meta_format(cos: torch.Tensor, sin: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """
+    Convert HuggingFace RoPE format to Meta format for TTNN compatibility.
+
+    HF stores cos/sin with shape [batch, seq_len, head_dim] where head_dim is interleaved.
+    Meta format expects [1, 1, seq_len, head_dim] with doubled values.
+    """
+    # Handle different HF output shapes
+    if len(cos.shape) == 3:
+        cos = cos.squeeze(0)  # [seq_len, head_dim]
+        sin = sin.squeeze(0)
+
+    # Undo the HF permute: take first half and duplicate
+    cos = cos[:, : cos.shape[1] // 2]
+    cos = torch.stack((cos, cos), dim=-1).flatten(-2)
+
+    sin = sin[:, : sin.shape[1] // 2]
+    sin = torch.stack((sin, sin), dim=-1).flatten(-2)
+
+    # Add batch dimensions: [1, 1, seq_len, head_dim]
+    cos = cos.unsqueeze(0).unsqueeze(0)
+    sin = sin.unsqueeze(0).unsqueeze(0)
+
+    return cos, sin
+
+
+def get_cos_sin_from_hf(
+    rotary_emb,
+    seq_len: int,
+    head_dim: int,
+    dtype: torch.dtype = torch.bfloat16,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """
+    Extract cos/sin rotation matrices from HuggingFace rotary_emb module.
+
+    Args:
+        rotary_emb: HuggingFace rotary embedding module (e.g., LlamaRotaryEmbedding)
+        seq_len: Maximum sequence length
+        head_dim: Head dimension
+        dtype: Output dtype
+
+    Returns:
+        (cos, sin) tensors in Meta format with shape [1, 1, seq_len, head_dim]
+    """
+    # Create dummy input for HF's rotary_emb forward
+    x = torch.zeros(1, 1, seq_len, head_dim, dtype=dtype)
+    position_ids = torch.arange(seq_len).unsqueeze(0)
+
+    # HF rotary_emb.forward() returns (cos, sin)
+    with torch.no_grad():
+        cos_hf, sin_hf = rotary_emb(x, position_ids)
+
+    # Convert to Meta format
+    cos_meta, sin_meta = _permute_to_meta_format(cos_hf.float(), sin_hf.float())
+
+    return cos_meta.to(dtype), sin_meta.to(dtype)
+
+
+def get_rot_mats_from_hf(
+    rotary_emb,
+    seq_len: int,
+    head_dim: int,
+    device: ttnn.MeshDevice,
+    dtype: ttnn.DataType = ttnn.bfloat16,
+) -> list[ttnn.Tensor]:
+    """
+    Create TTNN rotation matrices from HuggingFace rotary_emb.
+
+    Replaces `get_rot_mats` from models.tt_transformers.tt.rope.
+    """
+    cos_meta, sin_meta = get_cos_sin_from_hf(rotary_emb, seq_len * 2, head_dim)
+
+    cos_tt = ttnn.from_torch(
+        cos_meta,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        dtype=dtype,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(device),
+    )
+    sin_tt = ttnn.from_torch(
+        sin_meta,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        dtype=dtype,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(device),
+    )
+
+    return [cos_tt, sin_tt]
+
+
+class RotarySetupHelper:
+    """
+    Simplified RotarySetup for testing - extracts rotation matrices from HuggingFace's
+    rotary_emb instead of computing from scratch. Replaces TTTv1's RotarySetup class.
+    """
+
+    def __init__(
+        self,
+        device: ttnn.MeshDevice,
+        batch_size: int,
+        head_dim: int,
+        max_seq_len: int,
+        rotary_emb,  # HuggingFace rotary embedding module
+        use_qk_fused: bool = False,
+        datatype: ttnn.DataType = ttnn.bfloat16,
+    ):
+        self.device = device
+        self.head_dim = head_dim
+        self.use_qk_fused = use_qk_fused
+        self.batch_size = batch_size
+        self.doubled_batch_size = batch_size * 2 if use_qk_fused else batch_size
+
+        is_mesh = isinstance(device, ttnn.MeshDevice)
+        num_devices = device.get_num_devices() if is_mesh else 1
+
+        if num_devices == 32:
+            self.batch_size_per_device_group = max(self.doubled_batch_size // device.shape[1], 1)
+        else:
+            self.batch_size_per_device_group = self.doubled_batch_size
+
+        self.core_grid = device.compute_with_storage_grid_size()
+        self.batch_grid = ttnn.num_cores_to_corerangeset(self.doubled_batch_size, self.core_grid, row_wise=True)
+
+        # Get cos/sin from HuggingFace rotary_emb
+        self.cos_matrix, self.sin_matrix = get_rot_mats_from_hf(rotary_emb, max_seq_len, head_dim, device, datatype)
+
+        # Create transformation matrices
+        trans_mat = get_rot_transformation_mat().repeat(1, 1, self.doubled_batch_size, 1)
+        trans_mat_mem_config = ttnn.create_sharded_memory_config(
+            shape=(ttnn.TILE_SIZE, ttnn.TILE_SIZE),
+            core_grid=self.batch_grid,
+            strategy=ttnn.ShardStrategy.HEIGHT,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+        self.transformation_mat = ttnn.from_torch(
+            trans_mat,
+            device=device,
+            layout=ttnn.TILE_LAYOUT,
+            dtype=datatype,
+            memory_config=trans_mat_mem_config,
+            mesh_mapper=(
+                ttnn.ShardTensor2dMesh(
+                    device,
+                    dims=(None, 2) if (num_devices == 32 and batch_size > 1) else (None, None),
+                    mesh_shape=list(device.shape),
+                )
+                if is_mesh
+                else None
+            ),
+        )
+
+        # Prefill transformation matrix
+        prefill_trans_mat = get_rot_transformation_mat()
+        if head_dim != ttnn.TILE_SIZE:
+            prefill_trans_mat = torch.zeros(1, 1, head_dim, head_dim)
+            base_mat = get_rot_transformation_mat()
+            prefill_trans_mat[:, :, : ttnn.TILE_SIZE, : ttnn.TILE_SIZE] = base_mat
+
+        self.transformation_mat_prefill = ttnn.from_torch(
+            prefill_trans_mat,
+            device=device,
+            layout=ttnn.TILE_LAYOUT,
+            dtype=datatype,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(device) if is_mesh else None,
+        )
+
+    def get_both_trans_mats(self) -> dict[str, ttnn.Tensor]:
+        """Return transformation matrices for decode and prefill."""
+        return {"decode": self.transformation_mat, "prefill": self.transformation_mat_prefill}
+
+    def get_rot_idxs(self, position_idxs: torch.Tensor, on_host: bool = False) -> ttnn.Tensor:
+        """Convert position indices to TTNN tensor."""
+
+        if self.use_qk_fused:
+            position_idxs = position_idxs.repeat(2)
+
+        batch = position_idxs.shape[0]
+        position_idxs = position_idxs.reshape(1, batch)
+
+        # Pad to tile boundary
+        pad_size = nearest_32(batch) - batch
+        position_idxs = torch.nn.functional.pad(position_idxs, (0, pad_size), "constant", 0)
+
+        rot_idxs = ttnn.as_tensor(
+            position_idxs,
+            dtype=ttnn.uint32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            device=None if on_host else self.device,
+            memory_config=None if on_host else ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(self.device),
+        )
+        return rot_idxs
+
+    def get_rot_mats(self, position_idxs: torch.Tensor) -> list[ttnn.Tensor]:
+        """Get rotation matrices for given position indices."""
+        rot_idxs = self.get_rot_idxs(position_idxs)
+
+        if rot_idxs.device != self.device:
+            rot_idxs = ttnn.to_device(rot_idxs, self.device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+
+        cos = ttnn.embedding(rot_idxs, self.cos_matrix, layout=ttnn.TILE_LAYOUT)
+        sin = ttnn.embedding(rot_idxs, self.sin_matrix, layout=ttnn.TILE_LAYOUT)
+
+        cos = ttnn.unsqueeze_to_4D(cos)
+        sin = ttnn.unsqueeze_to_4D(sin)
+
+        cos = ttnn.transpose(cos, 1, 2)
+        sin = ttnn.transpose(sin, 1, 2)
+
+        if self.batch_size_per_device_group % ttnn.TILE_SIZE != 0:
+            cos = cos[:, : self.batch_size_per_device_group, :, :]
+            sin = sin[:, : self.batch_size_per_device_group, :, :]
+
+        mem_config = ttnn.create_sharded_memory_config(
+            shape=(ttnn.TILE_SIZE, self.head_dim),
+            core_grid=self.batch_grid,
+            strategy=ttnn.ShardStrategy.HEIGHT,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+
+        cos = ttnn.interleaved_to_sharded(cos, mem_config)
+        sin = ttnn.interleaved_to_sharded(sin, mem_config)
+
+        return [cos, sin]
+
+
+# =============================================================================
+# HfAttentionWrapper (replaces TTTv1 model_config import)
+# =============================================================================
+
+
+class HfAttentionWrapper:
+    """
+    Wrapper for HuggingFace attention modules with KV cache support.
+    Provides a consistent interface for running HF attention as reference.
+    """
+
+    def __init__(self, attention, head_dim: int, rotary_emb):
+        from transformers import DynamicCache
+
+        self.attention = attention
+        self.past_key_value = DynamicCache()
+        self.head_dim = head_dim
+        self.rotary_emb = rotary_emb
+
+    def forward(self, x: torch.Tensor, start_pos: int, mask=None):
+        """Run attention forward pass using rotary_emb directly."""
+        position_ids = torch.tensor([list(range(start_pos, start_pos + x.shape[1]))] * x.shape[0])
+
+        if mask is not None:
+            while len(mask.shape) < 4:
+                mask = mask.unsqueeze(0)
+
+        if self.rotary_emb is not None:
+            position_embeddings = self.rotary_emb(x, position_ids)
+            output, *_ = self.attention(
+                x,
+                position_embeddings=position_embeddings,
+                past_key_value=self.past_key_value,
+                use_cache=True,
+                attention_mask=mask,
+            )
+        else:
+            output, _, self.past_key_value = self.attention(
+                x,
+                past_key_value=self.past_key_value,
+                use_cache=True,
+                position_ids=position_ids,
+                attention_mask=mask,
+            )
+        return output
+
+    def __call__(self, *args, **kwargs):
+        return self.forward(*args, **kwargs)
+
+    def reset_cache(self):
+        """Reset KV cache for new sequence."""
+        from transformers import DynamicCache
+
+        self.past_key_value = DynamicCache()
+
+    @property
+    def cache_k(self) -> torch.Tensor:
+        """Get key cache in shape [batch, seq_len, n_kv_heads, head_dim]."""
+        if hf_cache_num_layers(self.past_key_value) == 0:
+            return torch.zeros(0)
+        # DynamicCache stores as [batch, n_heads, seq_len, head_dim]
+        # Transpose to [batch, seq_len, n_heads, head_dim]
+        return hf_cache_layer_kv(self.past_key_value, 0)[0].transpose(1, 2)
+
+    @property
+    def cache_v(self) -> torch.Tensor:
+        """Get value cache in shape [batch, seq_len, n_kv_heads, head_dim]."""
+        if hf_cache_num_layers(self.past_key_value) == 0:
+            return torch.zeros(0)
+        # DynamicCache stores as [batch, n_heads, seq_len, head_dim]
+        # Transpose to [batch, seq_len, n_heads, head_dim]
+        return hf_cache_layer_kv(self.past_key_value, 0)[1].transpose(1, 2)
+
+
+# =============================================================================
+# PagedAttentionConfig (replaces TTTv1 common import)
+# =============================================================================
+
+
+@dataclass
+class PagedAttentionConfig:
+    """Configuration for paged attention."""
+
+    block_size: int = 64
+    max_num_blocks: int = 2048
+
+
+# =============================================================================
+# Weight extraction helpers
+# =============================================================================
+
+
+def _reverse_permute(tensor, n_heads, dim1, dim2):
+    """Convert HuggingFace Q/K weights to Meta format for RoPE compatibility.
+
+    HuggingFace stores Q/K weights in a format optimized for their attention implementation,
+    while Meta format is required for TTNN's RoPE implementation.
+    """
+    return tensor.view(n_heads, 2, dim1 // n_heads // 2, dim2).transpose(1, 2).reshape(dim1, dim2)
+
+
+def _reverse_permute_1d(tensor):
+    """Convert the last dim from separate real/imaginary (r1,r2,i1,i2,...) to interleaved (r1,i1,r2,i2,...)"""
+    shape = tensor.shape
+    dim = shape[-1]
+    assert dim % 2 == 0, "Last dimension must be even"
+    reals = tensor[..., : dim // 2]
+    imags = tensor[..., dim // 2 :]
+    interleaved = torch.stack((reals, imags), dim=-1).flatten(start_dim=len(shape) - 1)
+    return interleaved
+
+
+def get_attention_weights_from_ref_model(
+    reference_attn, num_devices: int = 1
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None, torch.Tensor | None, torch.Tensor | None]:
+    """
+    Extract attention weights from a reference attention module in TTNN layout.
+
+    Applies reverse_permute to Q and K weights to convert from HuggingFace format
+    to Meta format, which is required for TTNN's RoPE implementation.
+
+    Returns:
+        (wqkv, wo, q_norm, k_norm, wqkv_bias) tensors in TTNN layout
+    """
+    # Phi-3 / Phi-4 ship a FUSED qkv_proj (single Linear) instead of separate q/k/v projections.
+    # Split it into Q/K/V rows here so the rest of the pipeline is architecture-agnostic.
+    fused_qkv = hasattr(reference_attn, "qkv_proj") and not hasattr(reference_attn, "q_proj")
+    if fused_qkv:
+        cfg = reference_attn.config
+        _n_heads = cfg.num_attention_heads
+        _n_kv = getattr(cfg, "num_key_value_heads", _n_heads)
+        _hd = (
+            getattr(reference_attn, "head_dim", None) or getattr(cfg, "head_dim", None) or (cfg.hidden_size // _n_heads)
+        )
+        _q = _n_heads * _hd
+        _kv = _n_kv * _hd
+        qkv_w = reference_attn.qkv_proj.weight  # (n_heads*hd + 2*n_kv*hd, dim), order Q|K|V
+        wq_raw = qkv_w[:_q]  # (n_heads * head_dim, dim)
+        wk_raw = qkv_w[_q : _q + _kv]  # (n_kv_heads * head_dim, dim)
+        wv_raw = qkv_w[_q + _kv : _q + 2 * _kv]  # (n_kv_heads * head_dim, dim)
+        wo_raw = reference_attn.o_proj.weight  # (dim, n_heads * head_dim)
+    else:
+        # Get raw weights from HF module
+        wq_raw = reference_attn.q_proj.weight  # (n_heads * head_dim, dim)
+        wk_raw = reference_attn.k_proj.weight  # (n_kv_heads * head_dim, dim)
+        wv_raw = reference_attn.v_proj.weight  # (n_kv_heads * head_dim, dim)
+        wo_raw = reference_attn.o_proj.weight  # (dim, n_heads * head_dim)
+
+    # Compute head_dim from weight shapes
+    dim = wq_raw.shape[1]
+    n_heads_times_head_dim = wq_raw.shape[0]
+    n_kv_heads_times_head_dim = wk_raw.shape[0]
+
+    # For head_dim calculation, we need n_heads. Use the ratio of Q/K sizes.
+    # Q: (n_heads * head_dim, dim), K: (n_kv_heads * head_dim, dim)
+    # If n_heads == n_kv_heads (no GQA), just use q shape
+    # Otherwise, we need to infer from config or assume head_dim from common values
+    if hasattr(reference_attn, "head_dim"):
+        head_dim = reference_attn.head_dim
+    elif hasattr(reference_attn, "config") and hasattr(reference_attn.config, "head_dim"):
+        head_dim = reference_attn.config.head_dim
+    else:
+        # Common head_dim values for LLaMA models
+        head_dim = 128 if n_heads_times_head_dim >= 4096 else 64
+
+    n_heads = n_heads_times_head_dim // head_dim
+    n_kv_heads = n_kv_heads_times_head_dim // head_dim
+
+    # Apply reverse_permute to convert HF format to Meta format for RoPE compatibility
+    # This transformation is critical for Q and K weights
+    wq_meta = _reverse_permute(wq_raw, n_heads, n_heads_times_head_dim, dim)
+    wk_meta = _reverse_permute(wk_raw, n_kv_heads, n_kv_heads_times_head_dim, dim)
+    # V and O don't need permutation
+    wv_meta = wv_raw
+    wo_meta = wo_raw
+
+    # Transpose to TTNN layout: (dim, out_features)
+    wq = wq_meta.T  # (dim, n_heads * head_dim)
+    wk = wk_meta.T  # (dim, n_kv_heads * head_dim)
+    wv = wv_meta.T  # (dim, n_kv_heads * head_dim)
+    wo = wo_meta.T  # (n_heads * head_dim, dim)
+
+    # Build combined QKV weight
+    # Shape: (1, 1, dim, qkv_size_per_device * num_devices)
+    qkv_list = []
+    for i in range(num_devices):
+        wq_chunk = torch.chunk(wq, num_devices, dim=1)[i]
+        wk_chunk = torch.chunk(wk, num_devices, dim=1)[i]
+        wv_chunk = torch.chunk(wv, num_devices, dim=1)[i]
+        qkv = torch.cat([wq_chunk, wk_chunk, wv_chunk], dim=-1)
+        qkv_list.append(qkv)
+
+    wqkv = torch.cat(qkv_list, dim=-1).unsqueeze(0).unsqueeze(0)
+
+    # WO weight: (1, 1, n_heads * head_dim, dim)
+    wo = wo.unsqueeze(0).unsqueeze(0)
+
+    # Q/K norm weights (optional, e.g., for Qwen models)
+    # These also need reverse_permute_1d transformation
+    q_norm = None
+    k_norm = None
+    if hasattr(reference_attn, "q_norm") and reference_attn.q_norm is not None:
+        q_norm = _reverse_permute_1d(reference_attn.q_norm.weight)
+    if hasattr(reference_attn, "k_norm") and reference_attn.k_norm is not None:
+        k_norm = _reverse_permute_1d(reference_attn.k_norm.weight)
+
+    # QKV bias (optional, e.g., for Qwen2/Qwen2.5 models)
+    # Bias also needs the same chunking/concat pattern as weights
+    wqkv_bias = None
+    if not fused_qkv and hasattr(reference_attn.q_proj, "bias") and reference_attn.q_proj.bias is not None:
+        bq_raw = reference_attn.q_proj.bias  # (n_heads * head_dim,)
+        bk_raw = reference_attn.k_proj.bias  # (n_kv_heads * head_dim,)
+        bv_raw = reference_attn.v_proj.bias  # (n_kv_heads * head_dim,)
+
+        # Apply reverse_permute to Q and K biases (same as weights)
+        bq_meta = _reverse_permute_1d(bq_raw.view(n_heads, head_dim)).view(-1)
+        bk_meta = _reverse_permute_1d(bk_raw.view(n_kv_heads, head_dim)).view(-1)
+        bv_meta = bv_raw  # V doesn't need permutation
+
+        # Build combined QKV bias with chunking for multi-device
+        qkv_bias_list = []
+        for i in range(num_devices):
+            bq_chunk = torch.chunk(bq_meta, num_devices, dim=0)[i]
+            bk_chunk = torch.chunk(bk_meta, num_devices, dim=0)[i]
+            bv_chunk = torch.chunk(bv_meta, num_devices, dim=0)[i]
+            qkv_bias = torch.cat([bq_chunk, bk_chunk, bv_chunk], dim=-1)
+            qkv_bias_list.append(qkv_bias)
+
+        wqkv_bias = torch.cat(qkv_bias_list, dim=-1)
+
+    return wqkv, wo, q_norm, k_norm, wqkv_bias
+
+
+# ============================================================================
+# Weight Caching - Avoid expensive torch.randn_like() per test
+# ============================================================================
+
+_CACHED_ATTN_WEIGHTS: dict[str, dict[str, torch.Tensor]] = {}
+
+
+def _init_weight_scaled_normal(param: torch.Tensor, name: str) -> torch.Tensor:
+    """Initialize a weight tensor using scaled normal distribution.
+
+    Uses a scaling factor based on typical pretrained LLM weight statistics
+    (std ~0.02) rather than pure randn (std=1.0) which can cause
+    extreme activations and numerical issues in softmax.
+
+    For 2D weights (linear layers): Uses normal with std = 0.02
+    For 1D weights (biases, norms): Uses appropriate initialization
+
+    NOTE: Uses torch.randn() instead of torch.randn_like() to ensure
+    the global RNG state (set via torch.manual_seed) is respected.
+    torch.randn_like() may not use the global RNG consistently.
+    """
+    if param.dim() >= 2:
+        # Linear layer weights: scaled normal initialization
+        # std=0.02 matches typical pretrained transformer weights
+        return torch.randn(param.shape, dtype=param.dtype, device=param.device) * 0.02
+    elif "norm" in name.lower() or "weight" in name.lower():
+        # Norm weights (e.g., q_norm.weight, k_norm.weight): use ones
+        return torch.ones_like(param)
+    else:
+        # Biases: use small random values
+        return torch.randn(param.shape, dtype=param.dtype, device=param.device) * 0.01
+
+
+def _get_or_init_attn_weights(model_name: str, reference_attn) -> None:
+    """Initialize attention weights once per model, cache and reuse across tests.
+
+    Uses scaled normal initialization (std=0.02) for better numerical conditioning
+    compared to pure random noise (std=1.0). This helps maintain reasonable
+    activation magnitudes through the attention computation.
+
+    NOTE: Uses a deterministic seed per model to ensure reproducible weights
+    regardless of test execution order or Python process hash randomization.
+    This prevents flaky tests where PCC varies based on which tests ran first.
+    """
+    if model_name not in _CACHED_ATTN_WEIGHTS:
+        logger.info(f"\033[33m[cache miss]\033[0m Initializing weights for {model_name}")
+        _CACHED_ATTN_WEIGHTS[model_name] = {}
+        # Use deterministic seed based on model name to ensure reproducible weights
+        # regardless of test execution order
+        seed = stable_model_seed(model_name)
+        rng_state = torch.get_rng_state()
+        torch.manual_seed(seed)
+        with torch.no_grad():
+            for name, param in reference_attn.named_parameters():
+                _CACHED_ATTN_WEIGHTS[model_name][name] = _init_weight_scaled_normal(param, name)
+        torch.set_rng_state(rng_state)  # Restore original RNG state
+    else:
+        logger.info(f"\033[32m[cache hit]\033[0m Reusing cached weights for {model_name}")
+
+    # Load cached weights into model
+    with torch.no_grad():
+        for name, param in reference_attn.named_parameters():
+            param.copy_(_CACHED_ATTN_WEIGHTS[model_name][name])
+
+
+# ============================================================================
+# Unit Tests - No device required
+# ============================================================================
+
+
+def test_attention_1d_config_creation():
+    """Test that Attention1DConfig dataclass can be created with explicit values."""
+    mock_mesh_device = MagicMock()
+    mock_tt_ccl = MagicMock()
+    mock_wqkv = MagicMock()
+    mock_wo = MagicMock()
+
+    # Create config with explicit values
+    config = Attention1DConfig(
+        wqkv=mock_wqkv,
+        wo=mock_wo,
+        mesh_device=mock_mesh_device,
+        tt_ccl=mock_tt_ccl,
+        dim=4096,
+        n_heads=32,
+        n_kv_heads=8,
+        head_dim=128,
+        max_batch_size=64,
+        topology=ttnn.Topology.Ring,
+    )
+
+    # Verify explicit values are preserved
+    assert config.wqkv is mock_wqkv
+    assert config.wo is mock_wo
+    assert config.mesh_device is mock_mesh_device
+    assert config.tt_ccl is mock_tt_ccl
+    assert config.dim == 4096
+    assert config.n_heads == 32
+    assert config.n_kv_heads == 8
+    assert config.head_dim == 128
+    assert config.max_batch_size == 64
+    assert config.topology == ttnn.Topology.Ring
+
+
+def test_attention_1d_config_defaults():
+    """Test that Attention1DConfig has sensible defaults."""
+    # Minimal creation - only required fields
+    config = Attention1DConfig(wqkv=MagicMock(), wo=MagicMock())
+
+    # Check defaults
+    assert config.max_batch_size == 32
+    assert config.max_seq_len == 128 * 1024
+    assert config.use_vllm_paged_kv_cache is False
+    assert config.kv_cache_dtype == ttnn.bfloat8_b
+    assert config.use_qk_fused is False
+    assert config.num_reduce_scatter_links is None
+    assert config.num_all_gather_links is None
+
+    # Optional fields default to None
+    assert config.mesh_device is None
+    assert config.tt_ccl is None
+    assert config.dim is None
+    assert config.n_heads is None
+    assert config.n_kv_heads is None
+    assert config.q_norm_config is None
+    assert config.k_norm_config is None
+
+
+def test_attention_1d_config_power_user_overrides():
+    """Test that Attention1DConfig accepts power-user overrides for program configs."""
+    mock_prg_config = MagicMock()
+    mock_mem_config = MagicMock()
+    mock_compute_kernel = MagicMock()
+
+    config = Attention1DConfig(
+        wqkv=MagicMock(),
+        wo=MagicMock(),
+        decode_xqkv_prg_config=mock_prg_config,
+        decode_sdpa_prg_config=mock_prg_config,
+        decode_attn_output_prg_config=mock_prg_config,
+        decode_residual_memcfg=mock_mem_config,
+        li_qkv_decode_compute_kernel_cfg=mock_compute_kernel,
+        activation_dtype=ttnn.bfloat16,
+        scale=0.08838834764831843,  # 1/sqrt(128)
+    )
+
+    # User-provided overrides should be preserved
+    assert config.decode_xqkv_prg_config is mock_prg_config
+    assert config.decode_sdpa_prg_config is mock_prg_config
+    assert config.decode_attn_output_prg_config is mock_prg_config
+    assert config.decode_residual_memcfg is mock_mem_config
+    assert config.li_qkv_decode_compute_kernel_cfg is mock_compute_kernel
+    assert config.activation_dtype == ttnn.bfloat16
+    assert config.scale == pytest.approx(0.08838834764831843)
+
+
+def test_attention_1d_happy_path_signature():
+    """Test that Attention1D.__init__ accepts the happy path signature (weights + dimensions).
+
+    Note: This is a unit test that verifies the API signature without a device.
+    Full integration testing of Attention1D creation happens in device tests.
+    """
+    import inspect
+
+    # Verify the __init__ signature has the expected parameters
+    sig = inspect.signature(Attention1D.__init__)
+    params = list(sig.parameters.keys())
+
+    # Expected: self, wqkv, wo, n_heads, n_kv_heads, head_dim
+    assert "wqkv" in params, "wqkv should be a parameter"
+    assert "wo" in params, "wo should be a parameter"
+    assert "n_heads" in params, "n_heads should be a required parameter"
+    assert "n_kv_heads" in params, "n_kv_heads should be a required parameter"
+    assert "head_dim" in params, "head_dim should be a required parameter"
+
+    # Verify n_heads, n_kv_heads, head_dim have no defaults (are required)
+    for param_name in ["n_heads", "n_kv_heads", "head_dim"]:
+        param = sig.parameters[param_name]
+        assert param.default is inspect.Parameter.empty, f"{param_name} should be required (no default)"
+
+
+def test_attention_1d_resolve_requires_n_heads(expect_error):
+    """Test that _resolve_attention1d_config raises ValueError when n_heads is missing."""
+    mock_source = MagicMock()
+    mock_source.shape = (4096, 1536)
+
+    mock_wqkv = MagicMock(spec=LazyWeight)
+    mock_wqkv.source = mock_source
+    mock_wqkv.device = None
+
+    config = Attention1DConfig(
+        wqkv=mock_wqkv,
+        wo=MagicMock(spec=LazyWeight),
+        n_heads=None,  # Missing!
+        n_kv_heads=8,
+        head_dim=128,
+    )
+
+    with expect_error(ValueError, "n_heads must be provided"):
+        _resolve_attention1d_config(config)
+
+
+def test_attention_1d_resolve_requires_n_kv_heads(expect_error):
+    """Test that _resolve_attention1d_config raises ValueError when n_kv_heads is missing."""
+    mock_source = MagicMock()
+    mock_source.shape = (4096, 1536)
+
+    mock_wqkv = MagicMock(spec=LazyWeight)
+    mock_wqkv.source = mock_source
+    mock_wqkv.device = None
+
+    config = Attention1DConfig(
+        wqkv=mock_wqkv,
+        wo=MagicMock(spec=LazyWeight),
+        n_heads=32,
+        n_kv_heads=None,  # Missing!
+        head_dim=128,
+    )
+
+    with expect_error(ValueError, "n_kv_heads must be provided"):
+        _resolve_attention1d_config(config)
+
+
+def test_attention_1d_resolve_requires_head_dim(expect_error):
+    """Test that _resolve_attention1d_config raises ValueError when head_dim is missing."""
+    mock_source = MagicMock()
+    mock_source.shape = (4096, 1536)
+
+    mock_wqkv = MagicMock(spec=LazyWeight)
+    mock_wqkv.source = mock_source
+    mock_wqkv.device = None
+
+    config = Attention1DConfig(
+        wqkv=mock_wqkv,
+        wo=MagicMock(spec=LazyWeight),
+        n_heads=32,
+        n_kv_heads=8,
+        head_dim=None,  # Missing!
+    )
+
+    with expect_error(ValueError, "head_dim must be provided"):
+        _resolve_attention1d_config(config)
+
+
+def test_attention_1d_resolve_kv_cache_tensor_passthrough():
+    """Test that _resolve_attention1d_config passes through raw ttnn.Tensor KV cache entries."""
+    mock_source = MagicMock()
+    mock_source.shape = (4096, 1536)
+
+    mock_wqkv = MagicMock(spec=LazyWeight)
+    mock_wqkv.source = mock_source
+    mock_wqkv.device = None
+
+    # Simulate pre-allocated ttnn.Tensor KV cache (e.g., from vLLM).
+    # Use plain MagicMock (NOT spec=LazyWeight) so isinstance(_, LazyWeight) is False.
+    mock_cache_k = MagicMock()
+    mock_cache_v = MagicMock()
+
+    config = Attention1DConfig(
+        wqkv=mock_wqkv,
+        wo=MagicMock(spec=LazyWeight),
+        n_heads=32,
+        n_kv_heads=8,
+        head_dim=128,
+        max_batch_size=1,
+        max_seq_len=128,
+        kv_cache=(mock_cache_k, mock_cache_v),
+    )
+
+    # Should not crash — previously would fail with dataclasses.replace on non-dataclass
+    try:
+        resolved = _resolve_attention1d_config(config)
+    except (ValueError, AssertionError) as e:
+        # Only device-related errors are acceptable, not kv_cache errors
+        assert "kv_cache" not in str(e).lower(), f"Unexpected kv_cache error: {e}"
+        return
+
+    # If resolution succeeded fully, verify the tensors were passed through as-is
+    assert resolved.kv_cache[0] is mock_cache_k
+    assert resolved.kv_cache[1] is mock_cache_v
+
+
+def test_attention_1d_resolve_rejects_sliding_window_with_paged(expect_error):
+    """Test that _resolve_attention1d_config rejects sliding_window + paged_attention_config."""
+    mock_source = MagicMock()
+    mock_source.shape = (4096, 1536)
+
+    mock_wqkv = MagicMock(spec=LazyWeight)
+    mock_wqkv.source = mock_source
+    mock_wqkv.device = None
+
+    config = Attention1DConfig(
+        wqkv=mock_wqkv,
+        wo=MagicMock(spec=LazyWeight),
+        n_heads=32,
+        n_kv_heads=8,
+        head_dim=128,
+        max_batch_size=1,
+        max_seq_len=128,
+        sliding_window=4096,
+        paged_attention_config=PagedAttentionConfig(block_size=64, max_num_blocks=2048),
+    )
+
+    with expect_error(ValueError, "sliding_window"):
+        _resolve_attention1d_config(config)
+
+
+# ============================================================================
+# Model name constants
+# ============================================================================
+
+LLAMA_8B = "meta-llama/Llama-3.1-8B-Instruct"
+LLAMA_70B = "meta-llama/Llama-3.3-70B-Instruct"
+LLAMA_1B = "meta-llama/Llama-3.2-1B-Instruct"
+LLAMA_3B = "meta-llama/Llama-3.2-3B-Instruct"
+LLAMA_11B = "meta-llama/Llama-3.2-11B-Vision-Instruct"
+LLAMA_90B = "meta-llama/Llama-3.2-90B-Vision-Instruct"
+MISTRAL_7B = "mistralai/Mistral-7B-Instruct-v0.3"
+MIXTRAL_8X7B = "mistralai/Mixtral-8x7B-v0.1"
+QWEN2_7B = "Qwen/Qwen2-7B-Instruct"
+QWEN25_7B = "Qwen/Qwen2.5-7B-Instruct"
+QWEN25_72B = "Qwen/Qwen2.5-72B-Instruct"
+QWEN25_CODER_32B = "Qwen/Qwen2.5-Coder-32B-Instruct"
+DEEPSEEK_R1_14B = "deepseek-ai/DeepSeek-R1-Distill-Qwen-14B"
+QWEN3_32B = "Qwen/Qwen3-32B"
+PHI4 = "microsoft/phi-4"  # Phi3 architecture: fused qkv_proj, no bias, no q/k norm, GQA 40/10
+
+_slow = pytest.mark.slow
+
+
+# ============================================================================
+# Test cases from attn_1d_performance.csv - hardcoded as pytest parameters
+# ============================================================================
+
+
+def _list_test_cases() -> list[pytest.param]:
+    """
+    Hardcoded test cases from attn_1d_performance.csv.
+
+    Parameters: mesh_shape, seq_len, batch_size, mode, x_dtype, wqkv_dtype, hf_model_name, pcc
+
+    batch_size semantics:
+    - Prefill: batch_size=1 (single user prefill), input shape (1, 1, seq_len, dim)
+    - Decode: batch_size=32 (continuous batching), input shape (1, 1, batch_size, dim)
+    """
+    # fmt: off
+    return [
+        # === Fast tests (minimal coverage set) ===
+        # Single device (1x1)
+        pytest.param((1, 1), 128, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_1B, 0.99, id="1x1-prefill-128-1B"),
+        pytest.param((1, 1), 32, 32, "decode", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_1B, 0.99, id="1x1-decode-32-1B"),
+        pytest.param((1, 1), 8192, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_1B, 0.99, id="1x1-prefill-8192-1B"),
+        # Dual device (1x2)
+        pytest.param((1, 2), 128, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_8B, 0.99, id="1x2-prefill-128-8B"),
+        pytest.param((1, 2), 32, 32, "decode", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_8B, 0.99, id="1x2-decode-32-8B"),
+        pytest.param((1, 2), 32, 32, "decode", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_11B, 0.99, id="1x2-decode-32-11B"),
+        pytest.param((1, 2), 32, 32, "decode", ttnn.bfloat16, ttnn.bfloat16, QWEN25_7B, 0.95, id="1x2-decode-32-Qwen2.5-7B", marks=pytest.mark.skip(reason="Disabled: see #45980")),
+        # Multi-device (1x8)
+        pytest.param((1, 8), 128, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_8B, 0.99, id="1x8-prefill-128-8B"),
+        pytest.param((1, 8), 32, 32, "decode", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_8B, 0.99, id="1x8-decode-32-8B"),
+
+        # === Slow tests (full coverage from models sweep) ===
+        # --- Llama-3.2-1B on N150 (1x1) ---
+        pytest.param((1, 1), 1024, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_1B, 0.99, id="1x1-prefill-1024-1B", marks=_slow),
+        pytest.param((1, 1), 2048, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_1B, 0.99, id="1x1-prefill-2048-1B", marks=_slow),
+        pytest.param((1, 1), 4096, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_1B, 0.99, id="1x1-prefill-4096-1B", marks=_slow),
+        pytest.param((1, 1), 16384, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_1B, 0.99, id="1x1-prefill-16384-1B", marks=_slow),
+        pytest.param((1, 1), 32768, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_1B, 0.99, id="1x1-prefill-32768-1B", marks=_slow),
+
+        # --- Llama-3.2-3B on N150 (1x1) ---
+        pytest.param((1, 1), 128, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_3B, 0.99, id="1x1-prefill-128-3B", marks=_slow),
+        pytest.param((1, 1), 1024, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_3B, 0.99, id="1x1-prefill-1024-3B", marks=_slow),
+        pytest.param((1, 1), 2048, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_3B, 0.99, id="1x1-prefill-2048-3B", marks=_slow),
+        pytest.param((1, 1), 4096, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_3B, 0.99, id="1x1-prefill-4096-3B", marks=_slow),
+        pytest.param((1, 1), 8192, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_3B, 0.99, id="1x1-prefill-8192-3B", marks=_slow),
+        pytest.param((1, 1), 32, 32, "decode", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_3B, 0.99, id="1x1-decode-32-3B", marks=_slow),
+
+        # --- Llama-3.1-8B on N150 (1x1) ---
+        pytest.param((1, 1), 128, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_8B, 0.99, id="1x1-prefill-128-8B", marks=_slow),
+        pytest.param((1, 1), 1024, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_8B, 0.99, id="1x1-prefill-1024-8B", marks=_slow),
+        pytest.param((1, 1), 2048, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_8B, 0.99, id="1x1-prefill-2048-8B", marks=_slow),
+        pytest.param((1, 1), 4096, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_8B, 0.99, id="1x1-prefill-4096-8B", marks=_slow),
+        pytest.param((1, 1), 32, 32, "decode", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_8B, 0.99, id="1x1-decode-32-8B", marks=_slow),
+
+        # --- Mistral-7B on N150 (1x1) ---
+        pytest.param((1, 1), 128, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, MISTRAL_7B, 0.99, id="1x1-prefill-128-Mistral-7B", marks=_slow),
+        pytest.param((1, 1), 1024, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, MISTRAL_7B, 0.99, id="1x1-prefill-1024-Mistral-7B", marks=_slow),
+        pytest.param((1, 1), 2048, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, MISTRAL_7B, 0.99, id="1x1-prefill-2048-Mistral-7B", marks=_slow),
+        pytest.param((1, 1), 4096, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, MISTRAL_7B, 0.99, id="1x1-prefill-4096-Mistral-7B", marks=_slow),
+        pytest.param((1, 1), 32, 32, "decode", ttnn.bfloat16, ttnn.bfloat8_b, MISTRAL_7B, 0.99, id="1x1-decode-32-Mistral-7B", marks=_slow),
+
+        # --- Llama-3.2-1B on N300 (1x2) ---
+        pytest.param((1, 2), 128, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_1B, 0.99, id="1x2-prefill-128-1B", marks=_slow),
+        pytest.param((1, 2), 1024, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_1B, 0.99, id="1x2-prefill-1024-1B", marks=_slow),
+        pytest.param((1, 2), 2048, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_1B, 0.99, id="1x2-prefill-2048-1B", marks=_slow),
+        pytest.param((1, 2), 4096, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_1B, 0.99, id="1x2-prefill-4096-1B", marks=_slow),
+        pytest.param((1, 2), 8192, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_1B, 0.99, id="1x2-prefill-8192-1B", marks=_slow),
+        pytest.param((1, 2), 16384, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_1B, 0.99, id="1x2-prefill-16384-1B", marks=_slow),
+        pytest.param((1, 2), 32768, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_1B, 0.99, id="1x2-prefill-32768-1B", marks=_slow),
+        pytest.param((1, 2), 32, 32, "decode", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_1B, 0.99, id="1x2-decode-32-1B", marks=_slow),
+
+        # --- Llama-3.2-3B on N300 (1x2) ---
+        pytest.param((1, 2), 128, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_3B, 0.99, id="1x2-prefill-128-3B", marks=_slow),
+        pytest.param((1, 2), 1024, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_3B, 0.99, id="1x2-prefill-1024-3B", marks=_slow),
+        pytest.param((1, 2), 2048, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_3B, 0.99, id="1x2-prefill-2048-3B", marks=_slow),
+        pytest.param((1, 2), 4096, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_3B, 0.99, id="1x2-prefill-4096-3B", marks=_slow),
+        pytest.param((1, 2), 8192, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_3B, 0.99, id="1x2-prefill-8192-3B", marks=_slow),
+        pytest.param((1, 2), 16384, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_3B, 0.99, id="1x2-prefill-16384-3B", marks=_slow),
+        pytest.param((1, 2), 32768, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_3B, 0.99, id="1x2-prefill-32768-3B", marks=_slow),
+        pytest.param((1, 2), 32, 32, "decode", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_3B, 0.99, id="1x2-decode-32-3B", marks=_slow),
+
+        # --- Llama-3.1-8B on N300 (1x2) ---
+        pytest.param((1, 2), 128, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_8B, 0.99, id="1x2-prefill-128-8B", marks=_slow),
+        pytest.param((1, 2), 1024, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_8B, 0.99, id="1x2-prefill-1024-8B", marks=_slow),
+        pytest.param((1, 2), 2048, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_8B, 0.99, id="1x2-prefill-2048-8B", marks=_slow),
+        pytest.param((1, 2), 4096, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_8B, 0.99, id="1x2-prefill-4096-8B", marks=_slow),
+        pytest.param((1, 2), 8192, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_8B, 0.99, id="1x2-prefill-8192-8B", marks=_slow),
+        pytest.param((1, 2), 16384, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_8B, 0.99, id="1x2-prefill-16384-8B", marks=_slow),
+        pytest.param((1, 2), 32768, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_8B, 0.99, id="1x2-prefill-32768-8B", marks=_slow),
+        pytest.param((1, 2), 32, 32, "decode", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_8B, 0.99, id="1x2-decode-32-8B", marks=_slow),
+
+        # --- Llama-3.2-11B on N300 (1x2) ---
+        pytest.param((1, 2), 128, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_11B, 0.99, id="1x2-prefill-128-11B", marks=_slow),
+        # NOTE: 11B 1024+ prefill has lower PCC (0.9845) due to vision model complexity
+        pytest.param((1, 2), 1024, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_11B, 0.98, id="1x2-prefill-1024-11B", marks=_slow),
+        pytest.param((1, 2), 2048, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_11B, 0.98, id="1x2-prefill-2048-11B", marks=_slow),
+        pytest.param((1, 2), 4096, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_11B, 0.98, id="1x2-prefill-4096-11B", marks=_slow),
+        pytest.param((1, 2), 8192, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_11B, 0.98, id="1x2-prefill-8192-11B", marks=_slow),
+        pytest.param((1, 2), 16384, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_11B, 0.98, id="1x2-prefill-16384-11B", marks=_slow),
+        pytest.param((1, 2), 32768, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_11B, 0.98, id="1x2-prefill-32768-11B", marks=_slow),
+
+        # --- Mistral-7B on N300 (1x2) ---
+        pytest.param((1, 2), 128, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, MISTRAL_7B, 0.99, id="1x2-prefill-128-Mistral-7B", marks=_slow),
+        pytest.param((1, 2), 1024, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, MISTRAL_7B, 0.99, id="1x2-prefill-1024-Mistral-7B", marks=_slow),
+        pytest.param((1, 2), 2048, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, MISTRAL_7B, 0.99, id="1x2-prefill-2048-Mistral-7B", marks=_slow),
+        pytest.param((1, 2), 4096, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, MISTRAL_7B, 0.99, id="1x2-prefill-4096-Mistral-7B", marks=_slow),
+        pytest.param((1, 2), 32, 32, "decode", ttnn.bfloat16, ttnn.bfloat8_b, MISTRAL_7B, 0.99, id="1x2-decode-32-Mistral-7B", marks=_slow),
+
+        # --- Phi-4 on N300 (1x2) --- fused qkv_proj split, GQA 40/10, head_dim 128, no bias/qk-norm.
+        # decode-32 is validated on N300 for both standard and paged SDPA-decode (the earlier
+        # num_output_cores limit for Phi-4's 10 KV heads no longer trips); batch-1 decode is
+        # additionally covered end-to-end by the M5 token-accuracy demo (97-99% top-1).
+        pytest.param((1, 2), 128, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, PHI4, 0.99, id="1x2-prefill-128-Phi-4", marks=_slow),
+        pytest.param((1, 2), 32, 32, "decode", ttnn.bfloat16, ttnn.bfloat8_b, PHI4, 0.99, id="1x2-decode-32-Phi-4", marks=_slow),
+
+        # --- Qwen2-7B on N300 (1x2) ---
+        # NOTE: Qwen2-7B has Q/K biases causing numerical precision issues
+        pytest.param((1, 2), 128, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, QWEN2_7B, 0.98, id="1x2-prefill-128-Qwen2-7B", marks=_slow),
+        pytest.param((1, 2), 1024, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, QWEN2_7B, 0.97, id="1x2-prefill-1024-Qwen2-7B", marks=_slow),
+        pytest.param((1, 2), 2048, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, QWEN2_7B, 0.97, id="1x2-prefill-2048-Qwen2-7B", marks=_slow),
+        pytest.param((1, 2), 4096, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, QWEN2_7B, 0.97, id="1x2-prefill-4096-Qwen2-7B", marks=_slow),
+        pytest.param((1, 2), 32, 32, "decode", ttnn.bfloat16, ttnn.bfloat8_b, QWEN2_7B, 0.99, id="1x2-decode-32-Qwen2-7B", marks=_slow),
+
+        # --- Qwen2.5-7B on N300 (1x2) ---
+        # NOTE: Qwen2.5-7B has large Q/K biases causing numerical precision issues
+        pytest.param((1, 2), 128, 1, "prefill", ttnn.bfloat16, ttnn.bfloat16, QWEN25_7B, 0.98, id="1x2-prefill-128-Qwen2.5-7B", marks=_slow),
+        pytest.param((1, 2), 1024, 1, "prefill", ttnn.bfloat16, ttnn.bfloat16, QWEN25_7B, 0.97, id="1x2-prefill-1024-Qwen2.5-7B", marks=_slow),
+        pytest.param((1, 2), 2048, 1, "prefill", ttnn.bfloat16, ttnn.bfloat16, QWEN25_7B, 0.97, id="1x2-prefill-2048-Qwen2.5-7B", marks=_slow),
+        pytest.param((1, 2), 4096, 1, "prefill", ttnn.bfloat16, ttnn.bfloat16, QWEN25_7B, 0.97, id="1x2-prefill-4096-Qwen2.5-7B", marks=_slow),
+        pytest.param((1, 2), 8192, 1, "prefill", ttnn.bfloat16, ttnn.bfloat16, QWEN25_7B, 0.97, id="1x2-prefill-8192-Qwen2.5-7B", marks=_slow),
+        pytest.param((1, 2), 16384, 1, "prefill", ttnn.bfloat16, ttnn.bfloat16, QWEN25_7B, 0.97, id="1x2-prefill-16384-Qwen2.5-7B", marks=_slow),
+        pytest.param((1, 2), 32768, 1, "prefill", ttnn.bfloat16, ttnn.bfloat16, QWEN25_7B, 0.97, id="1x2-prefill-32768-Qwen2.5-7B", marks=_slow),
+        # NOTE: Qwen2.5-7B has lower PCC for prefill+decode due to Q/K biases + RoPE interaction.
+        # TTTv1's test_attention.py also shows ~0.984 min PCC. With 128-token prefill, accumulated
+        # numerical error in SDPA over the larger KV cache causes further degradation.
+        # See models/common/tests/modules/attention/low_pcc_notes.md for detailed analysis
+
+        # --- DeepSeek-R1-14B on N300 (1x2) ---
+        pytest.param((1, 2), 128, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, DEEPSEEK_R1_14B, 0.99, id="1x2-prefill-128-DeepSeek-R1-14B", marks=_slow),
+        pytest.param((1, 2), 1024, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, DEEPSEEK_R1_14B, 0.99, id="1x2-prefill-1024-DeepSeek-R1-14B", marks=_slow),
+        pytest.param((1, 2), 2048, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, DEEPSEEK_R1_14B, 0.99, id="1x2-prefill-2048-DeepSeek-R1-14B", marks=_slow),
+        pytest.param((1, 2), 4096, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, DEEPSEEK_R1_14B, 0.99, id="1x2-prefill-4096-DeepSeek-R1-14B", marks=_slow),
+        pytest.param((1, 2), 8192, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, DEEPSEEK_R1_14B, 0.99, id="1x2-prefill-8192-DeepSeek-R1-14B", marks=_slow),
+        pytest.param((1, 2), 32, 32, "decode", ttnn.bfloat16, ttnn.bfloat8_b, DEEPSEEK_R1_14B, 0.99, id="1x2-decode-32-DeepSeek-R1-14B", marks=_slow),
+
+        # --- Llama-3.2-1B on T3K (1x8) ---
+        pytest.param((1, 8), 128, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_1B, 0.99, id="1x8-prefill-128-1B", marks=_slow),
+        pytest.param((1, 8), 1024, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_1B, 0.99, id="1x8-prefill-1024-1B", marks=_slow),
+        pytest.param((1, 8), 2048, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_1B, 0.99, id="1x8-prefill-2048-1B", marks=_slow),
+        pytest.param((1, 8), 4096, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_1B, 0.99, id="1x8-prefill-4096-1B", marks=_slow),
+        pytest.param((1, 8), 8192, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_1B, 0.99, id="1x8-prefill-8192-1B", marks=_slow),
+        pytest.param((1, 8), 16384, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_1B, 0.99, id="1x8-prefill-16384-1B", marks=_slow),
+        pytest.param((1, 8), 32768, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_1B, 0.99, id="1x8-prefill-32768-1B", marks=_slow),
+        pytest.param((1, 8), 32, 32, "decode", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_1B, 0.99, id="1x8-decode-32-1B", marks=_slow),
+
+        # --- Llama-3.2-3B on T3K (1x8) ---
+        pytest.param((1, 8), 128, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_3B, 0.99, id="1x8-prefill-128-3B", marks=_slow),
+        pytest.param((1, 8), 1024, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_3B, 0.99, id="1x8-prefill-1024-3B", marks=_slow),
+        pytest.param((1, 8), 2048, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_3B, 0.99, id="1x8-prefill-2048-3B", marks=_slow),
+        pytest.param((1, 8), 4096, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_3B, 0.99, id="1x8-prefill-4096-3B", marks=_slow),
+        pytest.param((1, 8), 8192, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_3B, 0.99, id="1x8-prefill-8192-3B", marks=_slow),
+        pytest.param((1, 8), 16384, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_3B, 0.99, id="1x8-prefill-16384-3B", marks=_slow),
+        pytest.param((1, 8), 32768, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_3B, 0.99, id="1x8-prefill-32768-3B", marks=_slow),
+        pytest.param((1, 8), 32, 32, "decode", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_3B, 0.99, id="1x8-decode-32-3B", marks=_slow),
+
+        # --- Llama-3.1-8B on T3K (1x8) ---
+        pytest.param((1, 8), 256, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_8B, 0.99, id="1x8-prefill-256-8B", marks=_slow),
+        pytest.param((1, 8), 1024, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_8B, 0.99, id="1x8-prefill-1024-8B", marks=_slow),
+        pytest.param((1, 8), 2048, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_8B, 0.99, id="1x8-prefill-2048-8B", marks=_slow),
+        pytest.param((1, 8), 4096, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_8B, 0.99, id="1x8-prefill-4096-8B", marks=_slow),
+        pytest.param((1, 8), 8192, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_8B, 0.99, id="1x8-prefill-8192-8B", marks=_slow),
+        pytest.param((1, 8), 16384, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_8B, 0.99, id="1x8-prefill-16384-8B", marks=_slow),
+        pytest.param((1, 8), 32768, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_8B, 0.99, id="1x8-prefill-32768-8B", marks=_slow),
+        pytest.param((1, 8), 32, 32, "decode", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_8B, 0.99, id="1x8-decode-32-8B", marks=_slow),
+
+        # --- Llama-3.2-11B on T3K (1x8) ---
+        pytest.param((1, 8), 128, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_11B, 0.99, id="1x8-prefill-128-11B", marks=_slow),
+        # NOTE: 11B 1024+ prefill has lower PCC (0.9844) due to vision model complexity
+        pytest.param((1, 8), 1024, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_11B, 0.98, id="1x8-prefill-1024-11B", marks=_slow),
+        pytest.param((1, 8), 2048, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_11B, 0.98, id="1x8-prefill-2048-11B", marks=_slow),
+        pytest.param((1, 8), 4096, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_11B, 0.98, id="1x8-prefill-4096-11B", marks=_slow),
+        pytest.param((1, 8), 8192, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_11B, 0.98, id="1x8-prefill-8192-11B", marks=_slow),
+        pytest.param((1, 8), 16384, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_11B, 0.98, id="1x8-prefill-16384-11B", marks=_slow),
+        pytest.param((1, 8), 32768, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_11B, 0.98, id="1x8-prefill-32768-11B", marks=_slow),
+        pytest.param((1, 8), 32, 32, "decode", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_11B, 0.99, id="1x8-decode-32-11B", marks=_slow),
+
+        # --- Llama-3.3-70B on T3K (1x8) ---
+        # NOTE: 70B has slightly lower PCC (0.997) due to model size and multi-device communication
+        pytest.param((1, 8), 128, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_70B, 0.99, id="1x8-prefill-128-70B", marks=_slow),
+        pytest.param((1, 8), 1024, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_70B, 0.99, id="1x8-prefill-1024-70B", marks=_slow),
+        pytest.param((1, 8), 2048, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_70B, 0.99, id="1x8-prefill-2048-70B", marks=_slow),
+        pytest.param((1, 8), 4096, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_70B, 0.99, id="1x8-prefill-4096-70B", marks=_slow),
+        pytest.param((1, 8), 32, 32, "decode", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_70B, 0.97, id="1x8-decode-32-70B", marks=_slow),
+
+        # --- Llama-3.2-90B on T3K (1x8) ---
+        # NOTE: 90B has slightly lower PCC (0.995-0.996) due to model size
+        pytest.param((1, 8), 128, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_90B, 0.99, id="1x8-prefill-128-90B", marks=_slow),
+        pytest.param((1, 8), 32, 32, "decode", ttnn.bfloat16, ttnn.bfloat8_b, LLAMA_90B, 0.99, id="1x8-decode-32-90B", marks=_slow),
+
+        # --- Mistral-7B on T3K (1x8) ---
+        pytest.param((1, 8), 128, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, MISTRAL_7B, 0.99, id="1x8-prefill-128-Mistral-7B", marks=_slow),
+        pytest.param((1, 8), 1024, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, MISTRAL_7B, 0.99, id="1x8-prefill-1024-Mistral-7B", marks=_slow),
+        pytest.param((1, 8), 2048, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, MISTRAL_7B, 0.99, id="1x8-prefill-2048-Mistral-7B", marks=_slow),
+        pytest.param((1, 8), 4096, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, MISTRAL_7B, 0.99, id="1x8-prefill-4096-Mistral-7B", marks=_slow),
+        pytest.param((1, 8), 32, 32, "decode", ttnn.bfloat16, ttnn.bfloat8_b, MISTRAL_7B, 0.99, id="1x8-decode-32-Mistral-7B", marks=_slow),
+
+        # --- Mixtral-8x7B on T3K (1x8) ---
+        pytest.param((1, 8), 128, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, MIXTRAL_8X7B, 0.99, id="1x8-prefill-128-Mixtral-8x7B", marks=_slow),
+        pytest.param((1, 8), 1024, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, MIXTRAL_8X7B, 0.99, id="1x8-prefill-1024-Mixtral-8x7B", marks=_slow),
+        pytest.param((1, 8), 2048, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, MIXTRAL_8X7B, 0.99, id="1x8-prefill-2048-Mixtral-8x7B", marks=_slow),
+        pytest.param((1, 8), 4096, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, MIXTRAL_8X7B, 0.99, id="1x8-prefill-4096-Mixtral-8x7B", marks=_slow),
+        pytest.param((1, 8), 32, 32, "decode", ttnn.bfloat16, ttnn.bfloat8_b, MIXTRAL_8X7B, 0.99, id="1x8-decode-32-Mixtral-8x7B", marks=_slow),
+
+        # --- Qwen2.5-72B on T3K (1x8) ---
+        pytest.param((1, 8), 128, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, QWEN25_72B, 0.99, id="1x8-prefill-128-Qwen2.5-72B", marks=_slow),
+        pytest.param((1, 8), 1024, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, QWEN25_72B, 0.99, id="1x8-prefill-1024-Qwen2.5-72B", marks=_slow),
+        pytest.param((1, 8), 2048, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, QWEN25_72B, 0.99, id="1x8-prefill-2048-Qwen2.5-72B", marks=_slow),
+        pytest.param((1, 8), 4096, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, QWEN25_72B, 0.99, id="1x8-prefill-4096-Qwen2.5-72B", marks=_slow),
+        pytest.param((1, 8), 8192, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, QWEN25_72B, 0.99, id="1x8-prefill-8192-Qwen2.5-72B", marks=_slow),
+        pytest.param((1, 8), 16384, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, QWEN25_72B, 0.99, id="1x8-prefill-16384-Qwen2.5-72B", marks=_slow),
+        pytest.param((1, 8), 32, 32, "decode", ttnn.bfloat16, ttnn.bfloat8_b, QWEN25_72B, 0.99, id="1x8-decode-32-Qwen2.5-72B", marks=_slow),
+
+        # --- Qwen2.5-Coder-32B on T3K (1x8) ---
+        pytest.param((1, 8), 128, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, QWEN25_CODER_32B, 0.99, id="1x8-prefill-128-Qwen2.5-Coder-32B", marks=_slow),
+        pytest.param((1, 8), 1024, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, QWEN25_CODER_32B, 0.99, id="1x8-prefill-1024-Qwen2.5-Coder-32B", marks=_slow),
+        pytest.param((1, 8), 2048, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, QWEN25_CODER_32B, 0.99, id="1x8-prefill-2048-Qwen2.5-Coder-32B", marks=_slow),
+        pytest.param((1, 8), 4096, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, QWEN25_CODER_32B, 0.99, id="1x8-prefill-4096-Qwen2.5-Coder-32B", marks=_slow),
+        pytest.param((1, 8), 32, 32, "decode", ttnn.bfloat16, ttnn.bfloat8_b, QWEN25_CODER_32B, 0.99, id="1x8-decode-32-Qwen2.5-Coder-32B", marks=_slow),
+        # BF16 weights
+        pytest.param((1, 8), 128, 1, "prefill", ttnn.bfloat16, ttnn.bfloat16, QWEN25_CODER_32B, 0.99, id="1x8-prefill-128-Qwen2.5-Coder-32B-bf16", marks=_slow),
+        pytest.param((1, 8), 1024, 1, "prefill", ttnn.bfloat16, ttnn.bfloat16, QWEN25_CODER_32B, 0.99, id="1x8-prefill-1024-Qwen2.5-Coder-32B-bf16", marks=_slow),
+        pytest.param((1, 8), 32, 32, "decode", ttnn.bfloat16, ttnn.bfloat16, QWEN25_CODER_32B, 0.99, id="1x8-decode-32-Qwen2.5-Coder-32B-bf16", marks=_slow),
+
+        # --- Qwen3-32B on T3K (1x8) ---
+        pytest.param((1, 8), 128, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, QWEN3_32B, 0.99, id="1x8-prefill-128-Qwen3-32B", marks=_slow),
+        pytest.param((1, 8), 1024, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, QWEN3_32B, 0.99, id="1x8-prefill-1024-Qwen3-32B", marks=_slow),
+        pytest.param((1, 8), 2048, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, QWEN3_32B, 0.99, id="1x8-prefill-2048-Qwen3-32B", marks=_slow),
+        pytest.param((1, 8), 4096, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, QWEN3_32B, 0.99, id="1x8-prefill-4096-Qwen3-32B", marks=_slow),
+        pytest.param((1, 8), 8192, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, QWEN3_32B, 0.99, id="1x8-prefill-8192-Qwen3-32B", marks=_slow),
+        pytest.param((1, 8), 16384, 1, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, QWEN3_32B, 0.99, id="1x8-prefill-16384-Qwen3-32B", marks=_slow),
+        pytest.param((1, 8), 32, 32, "decode", ttnn.bfloat16, ttnn.bfloat8_b, QWEN3_32B, 0.99, id="1x8-decode-32-Qwen3-32B", marks=_slow),
+        # BF16 weights
+        pytest.param((1, 8), 128, 1, "prefill", ttnn.bfloat16, ttnn.bfloat16, QWEN3_32B, 0.99, id="1x8-prefill-128-Qwen3-32B-bf16", marks=_slow),
+        pytest.param((1, 8), 1024, 1, "prefill", ttnn.bfloat16, ttnn.bfloat16, QWEN3_32B, 0.99, id="1x8-prefill-1024-Qwen3-32B-bf16", marks=_slow),
+        pytest.param((1, 8), 32, 32, "decode", ttnn.bfloat16, ttnn.bfloat16, QWEN3_32B, 0.99, id="1x8-decode-32-Qwen3-32B-bf16", marks=_slow),
+    ]
+    # fmt: on
+
+
+# ============================================================================
+# Integration Tests - Require device
+# ============================================================================
+
+
+@torch.no_grad()
+@pytest.mark.parametrize(
+    "ttnn_mesh_device",
+    [(1, 1), (1, 2), (1, 8)],
+    ids=["1x1", "1x2", "1x8"],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "mesh_shape,seq_len,batch_size,mode,act_dtype,wqkv_dtype,hf_model_name,pcc",
+    _list_test_cases(),
+)
+@pytest.mark.parametrize(
+    "page_block_size,chunk_size",
+    [
+        (None, None),  # standard (non-paged, non-chunked)
+        (64, None),  # paged only (non-chunked)
+        (64, 4096),  # paged + chunked
+    ],
+    ids=["standard", "paged", "paged-chunked"],
+)
+@pytest.mark.parametrize("num_decode_iterations", [10])
+def test_attention_1d_vs_reference(
+    ttnn_mesh_device: ttnn.MeshDevice,
+    mesh_shape,
+    seq_len,
+    batch_size,
+    mode,
+    act_dtype,
+    wqkv_dtype,
+    hf_model_name,
+    pcc,
+    page_block_size,
+    chunk_size,
+    num_decode_iterations,
+):
+    """
+    Test Attention1D constructed via from_config (direct API) executes successfully.
+
+    This test uses the TTTv2 pattern:
+    1. Load HF config directly via AutoConfig.from_pretrained
+    2. Extract weights from HF reference model
+    3. Create LazyWeight objects
+    4. Build Attention1DConfig with explicit parameters
+    5. Create Attention1D via from_config (NOT from_model_args)
+    6. Run forward pass and verify execution
+
+    Note: Full numerical comparison against HF reference is done in
+    test_attention_1d_vs_reference_from_model_args which uses existing infrastructure
+    that handles HF API differences.
+    """
+    # Skip if mesh_shape doesn't match device
+    device_shape = (ttnn_mesh_device.shape[0], ttnn_mesh_device.shape[1])
+    if device_shape != mesh_shape:
+        pytest.skip(f"Test requires {mesh_shape} mesh, got {device_shape}")
+
+    # Chunked prefill only applies to prefill mode
+    chunked_prefill = chunk_size is not None
+    if chunked_prefill and mode != "prefill":
+        pytest.skip("Chunked prefill only applies to prefill mode")
+
+    # Chunked prefill requires seq_len > chunk_size
+    # TTTv1 uses chunk_size = N * 1024 where N ranges from 4-128 depending on model/device
+    # Default of 4096 matches TTTv1's minimum (4 * 1024)
+    if chunked_prefill and seq_len <= chunk_size:
+        pytest.skip(f"Chunked prefill requires seq_len > chunk_size ({chunk_size})")
+
+    # batch_size is now a test parameter:
+    # - Prefill: typically batch_size=1, input shape (1, 1, seq_len, dim)
+    # - Decode: typically batch_size=32 (continuous batching), input shape (1, 1, batch, dim)
+    #   current_pos has shape (batch_size,) - one position per user
+    # Note: For decode tests, seq_len parameter is unused (kept for parameterization compatibility)
+
+    # max_seq_len: minimum allocation for KV cache
+    # - Prefill: exactly seq_len tokens written to cache
+    # - Decode: num_decode_iterations tokens (starts from position 0, no prefill)
+    # Round up to alignment (SDPA kernel requires multiples of 32, paged attention requires page_block_size)
+    if mode == "prefill":
+        max_seq_len = seq_len
+    else:
+        max_seq_len = num_decode_iterations
+    # Round up: use page_block_size if paged, otherwise 32 (SDPA tile alignment)
+    alignment = page_block_size if page_block_size is not None else 32
+    max_seq_len = ((max_seq_len + alignment - 1) // alignment) * alignment
+    num_devices = ttnn_mesh_device.get_num_devices()
+
+    # Seed for reproducibility
+    seed = 1234
+    torch.manual_seed(seed)
+
+    # Load HF config directly (no ModelArgs)
+    hf_config = AutoConfig.from_pretrained(hf_model_name)
+
+    # Handle multimodal models (Mllama, LLaVA, etc.) which nest text config under .text_config
+    is_multimodal = hasattr(hf_config, "text_config") and hf_config.text_config is not None
+    cfg = hf_config.text_config if is_multimodal else hf_config
+    cfg.num_hidden_layers = 1  # Only need 1 layer for testing
+
+    dim = cfg.hidden_size
+    n_heads = cfg.num_attention_heads
+    n_kv_heads = getattr(cfg, "num_key_value_heads", n_heads)
+    # Use explicit head_dim if available (e.g., Qwen3 models), else calculate from dim/n_heads
+    # Note: some configs have head_dim=None explicitly, so we use `or` to fallback
+    head_dim = getattr(cfg, "head_dim", None) or (dim // n_heads)
+    sliding_window = getattr(cfg, "sliding_window", None)
+
+    # Load HF model structure without weights, then initialize with random weights
+    # This avoids slow network downloads and ensures reproducible deterministic testing
+    if is_multimodal:
+        # For multimodal models, import and use the specific model class
+        from transformers import MllamaForConditionalGeneration
+
+        with no_init_weights():
+            # MllamaForConditionalGeneration uses _from_config (internal method) instead of from_config
+            hf_model = MllamaForConditionalGeneration._from_config(hf_config, torch_dtype=torch.bfloat16)
+        # Mllama has layers directly at language_model.layers (not language_model.model.layers).
+        # transformers 5.x nests the text model under hf_model.model.language_model.
+        text_model = hf_model.language_model if hasattr(hf_model, "language_model") else hf_model.model.language_model
+        first_layer = text_model.layers[0]
+        rotary_emb = getattr(text_model, "rotary_emb", None)
+    else:
+        with no_init_weights():
+            hf_model = AutoModelForCausalLM.from_config(hf_config, torch_dtype=torch.bfloat16)
+        first_layer = hf_model.model.layers[0]
+        rotary_emb = getattr(hf_model.model, "rotary_emb", None)
+
+    # Get reference attention from first layer
+    reference_attn = first_layer.self_attn
+
+    # Initialize attention weights deterministically (cached for speed across test cases)
+    _get_or_init_attn_weights(hf_model_name, reference_attn)
+
+    # Wrap in HfAttentionWrapper for consistent KV cache and RoPE handling (local class)
+    reference_wrapper = HfAttentionWrapper(reference_attn, head_dim, rotary_emb)
+
+    # Extract attention weights in TTNN layout
+    wqkv_torch, wo_torch, q_norm_torch, k_norm_torch, wqkv_bias_torch = get_attention_weights_from_ref_model(
+        reference_attn, num_devices
+    )
+
+    # Create LazyWeights with caching enabled
+    # Cache keys include model name + seed to avoid mismatched cached weights across runs
+    ttnn.SetDefaultDevice(ttnn_mesh_device)
+    cache_dir = Path(os.getenv("TT_CACHE_PATH", "model_cache/attention_1d"))
+    model_seed = stable_model_seed(hf_model_name)
+    model_cache_prefix = f"{hf_model_name.replace('/', '_').replace('-', '_')}_seed{model_seed:08x}"
+
+    # QKV weight: shard on dim=-1
+    lazy_wqkv = LazyWeight(
+        source=wqkv_torch,
+        dtype=wqkv_dtype,
+        cache_dir_weight_name=(cache_dir, f"{model_cache_prefix}_layer0_wqkv"),
+    )
+
+    # WO weight: shard on dim=-2
+    lazy_wo = LazyWeight(
+        source=wo_torch,
+        dtype=wqkv_dtype,
+        cache_dir_weight_name=(cache_dir, f"{model_cache_prefix}_layer0_wo"),
+    )
+
+    # Q/K norm configs (optional) - using RMSNorm1DConfig composition pattern
+    q_norm_config = None
+    k_norm_config = None
+    if q_norm_torch is not None:
+        lazy_q_norm = LazyWeight(
+            source=q_norm_torch.unsqueeze(0).unsqueeze(0).unsqueeze(0),
+            dtype=ttnn.bfloat16,
+            cache_dir_weight_name=(cache_dir, f"{model_cache_prefix}_layer0_q_norm"),
+        )
+        q_norm_config = RMSNorm1DConfig(
+            weight=lazy_q_norm,
+            mesh_device=ttnn_mesh_device,
+            eps=1e-5,
+            decode_in_sharded=False,  # Q/K heads are interleaved
+            decode_out_sharded=False,
+            prefill_distributed=False,
+        )
+    if k_norm_torch is not None:
+        lazy_k_norm = LazyWeight(
+            source=k_norm_torch.unsqueeze(0).unsqueeze(0).unsqueeze(0),
+            dtype=ttnn.bfloat16,
+            cache_dir_weight_name=(cache_dir, f"{model_cache_prefix}_layer0_k_norm"),
+        )
+        k_norm_config = RMSNorm1DConfig(
+            weight=lazy_k_norm,
+            mesh_device=ttnn_mesh_device,
+            eps=1e-5,
+            decode_in_sharded=False,  # Q/K heads are interleaved
+            decode_out_sharded=False,
+            prefill_distributed=False,
+        )
+
+    # Create TT_CCL for multi-device
+    tt_ccl = TT_CCL(ttnn_mesh_device) if num_devices > 1 else None
+
+    # Determine topology
+    if num_devices == 1:
+        topology = None
+    elif num_devices == 2:
+        topology = ttnn.Topology.Linear
+    else:
+        topology = ttnn.Topology.Ring
+
+    # Setup paged attention config and page table if enabled
+    paged_attention_config = None
+    page_table_tt = None
+    page_table = None
+    reverse_permutation = None
+
+    if page_block_size is not None:
+        # Paged attention parameters (use local PagedAttentionConfig)
+        # Each user needs ceil(max_seq_len / block_size) blocks
+        blocks_per_user = (max_seq_len + page_block_size - 1) // page_block_size
+        max_num_blocks = max(128, blocks_per_user * batch_size)
+
+        paged_attention_config = PagedAttentionConfig(
+            block_size=page_block_size,
+            max_num_blocks=max_num_blocks,
+        )
+
+        # Create page table: random permutation simulates block allocation
+        permutation = torch.randperm(max_num_blocks)
+        reverse_permutation = torch.argsort(permutation)
+        page_table = reverse_permutation.reshape(batch_size, max_num_blocks // batch_size)
+        page_table_tt = ttnn.from_torch(
+            page_table,
+            device=ttnn_mesh_device,
+            dtype=ttnn.int32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            mesh_mapper=ttnn.ShardTensor2dMesh(ttnn_mesh_device, dims=(None, None), mesh_shape=mesh_shape),
+        )
+
+    # Determine if we need the power user path (from_config) or can use the simple API
+    # Power user path is needed for models with special features that aren't in the simple API
+    has_special_features = (
+        q_norm_config is not None
+        or k_norm_config is not None
+        or wqkv_bias_torch is not None
+        or sliding_window is not None
+        or paged_attention_config is not None
+    )
+
+    if has_special_features:
+        # Power user path: use from_config() for models with special features
+        config = Attention1DConfig(
+            wqkv=lazy_wqkv,
+            wo=lazy_wo,
+            n_heads=n_heads,
+            n_kv_heads=n_kv_heads,
+            head_dim=head_dim,
+            max_batch_size=batch_size,
+            max_seq_len=max_seq_len,
+            q_norm_config=q_norm_config,
+            k_norm_config=k_norm_config,
+            wqkv_bias=LazyWeight(source=wqkv_bias_torch) if wqkv_bias_torch is not None else None,
+            sliding_window=sliding_window,
+            paged_attention_config=paged_attention_config,
+        )
+        tt_model = Attention1D.from_config(config)
+    else:
+        # Happy path: simple API for basic Llama-style models
+        tt_model = Attention1D(
+            wqkv=lazy_wqkv,
+            wo=lazy_wo,
+            n_heads=n_heads,
+            n_kv_heads=n_kv_heads,
+            head_dim=head_dim,
+            max_batch_size=batch_size,
+            max_seq_len=max_seq_len,
+        )
+
+    # Verify config is properly resolved (works for both happy path and from_config)
+    assert tt_model.config.is_resolved(), "Config should be resolved after Attention1D creation"
+    assert tt_model.config.dim == dim
+    assert tt_model.config.n_heads == n_heads
+    assert tt_model.config.n_kv_heads == n_kv_heads
+    assert tt_model.config.head_dim == head_dim
+
+    if mode == "prefill":
+        _run_prefill_test(
+            tt_model=tt_model,
+            reference_wrapper=reference_wrapper,
+            ttnn_mesh_device=ttnn_mesh_device,
+            mesh_shape=mesh_shape,
+            batch_size=batch_size,
+            seq_len=seq_len,
+            dim=dim,
+            n_heads=n_heads,
+            n_kv_heads=n_kv_heads,
+            head_dim=head_dim,
+            act_dtype=act_dtype,
+            page_block_size=page_block_size,
+            chunked_prefill=chunked_prefill,
+            chunk_size=chunk_size,
+            paged_attention_config=paged_attention_config,
+            page_table=page_table,
+            page_table_tt=page_table_tt,
+            pcc=pcc,
+        )
+    else:
+        _run_decode_test(
+            tt_model=tt_model,
+            reference_wrapper=reference_wrapper,
+            ttnn_mesh_device=ttnn_mesh_device,
+            mesh_shape=mesh_shape,
+            batch_size=batch_size,
+            dim=dim,
+            n_heads=n_heads,
+            n_kv_heads=n_kv_heads,
+            head_dim=head_dim,
+            max_seq_len=max_seq_len,
+            act_dtype=act_dtype,
+            page_block_size=page_block_size,
+            page_table_tt=page_table_tt,
+            num_decode_iterations=num_decode_iterations,
+            pcc=pcc,
+        )
+
+
+def _run_prefill_test(
+    tt_model,
+    reference_wrapper,
+    ttnn_mesh_device,
+    mesh_shape,
+    batch_size,
+    seq_len,
+    dim,
+    n_heads,
+    n_kv_heads,
+    head_dim,
+    act_dtype,
+    page_block_size,
+    chunked_prefill,
+    chunk_size,
+    paged_attention_config,
+    page_table,
+    page_table_tt,
+    pcc,
+):
+    """Run prefill test and compare against HuggingFace reference."""
+    pt_attention_input = torch.randn(batch_size, seq_len, dim, dtype=torch.bfloat16)
+
+    # Prepare TT input for prefill
+    tt_input = ttnn.from_torch(
+        pt_attention_input.unsqueeze(0),  # [1, batch, seq_len, dim]
+        device=ttnn_mesh_device,
+        dtype=act_dtype,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        mesh_mapper=ttnn.ShardTensor2dMesh(ttnn_mesh_device, dims=(None, None), mesh_shape=mesh_shape),
+    )
+
+    # Get rot_mats for prefill (cos/sin matrices) - extract from HF rotary_emb
+    if chunked_prefill:
+        # Chunked prefill: process sequence in chunks
+        # Compute full rotation matrices once (covering all positions 0 to seq_len)
+        full_cos, full_sin = get_cos_sin_from_hf(
+            reference_wrapper.rotary_emb,
+            seq_len=seq_len,
+            head_dim=head_dim,
+        )
+
+        num_chunks = seq_len // chunk_size
+        tt_outputs_chunked = []
+
+        for chunk_idx in range(num_chunks):
+            chunk_start = chunk_idx * chunk_size
+            chunk_end = chunk_start + chunk_size
+
+            # Extract chunk input
+            pt_chunk = pt_attention_input[:, chunk_start:chunk_end, :]
+
+            # Prepare TT input for this chunk
+            tt_chunk = ttnn.from_torch(
+                pt_chunk.unsqueeze(0),
+                device=ttnn_mesh_device,
+                dtype=act_dtype,
+                layout=ttnn.TILE_LAYOUT,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                mesh_mapper=ttnn.ShardTensor2dMesh(ttnn_mesh_device, dims=(None, None), mesh_shape=mesh_shape),
+            )
+
+            # Chunk page table: subset of pages for this chunk
+            block_size = paged_attention_config.block_size
+            chunk_page_table_pt = page_table[:, chunk_start // block_size : chunk_end // block_size]
+            chunk_page_table_tt = ttnn.from_torch(
+                chunk_page_table_pt,
+                device=ttnn_mesh_device,
+                dtype=ttnn.int32,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+                mesh_mapper=ttnn.ShardTensor2dMesh(ttnn_mesh_device, dims=(None, None), mesh_shape=mesh_shape),
+            )
+
+            # Slice rotation matrices for this chunk's positions
+            chunk_cos = full_cos[:, :, chunk_start:chunk_end, :]
+            chunk_sin = full_sin[:, :, chunk_start:chunk_end, :]
+
+            chunk_cos_tt = ttnn.from_torch(
+                chunk_cos,
+                device=ttnn_mesh_device,
+                layout=ttnn.TILE_LAYOUT,
+                dtype=act_dtype,
+                mesh_mapper=ttnn.ReplicateTensorToMesh(ttnn_mesh_device),
+            )
+            chunk_sin_tt = ttnn.from_torch(
+                chunk_sin,
+                device=ttnn_mesh_device,
+                layout=ttnn.TILE_LAYOUT,
+                dtype=act_dtype,
+                mesh_mapper=ttnn.ReplicateTensorToMesh(ttnn_mesh_device),
+            )
+            chunk_rot_mats = [chunk_cos_tt, chunk_sin_tt]
+
+            # Run chunked prefill
+            tt_chunk_out = tt_model.forward(
+                tt_chunk,
+                None,
+                chunk_rot_mats,
+                mode="prefill",
+                page_table=page_table_tt,
+                chunk_page_table=chunk_page_table_tt,
+                chunk_start_idx=chunk_start,
+            )
+
+            # Collect output
+            tt_chunk_out_torch = to_torch_auto_compose(tt_chunk_out)
+            tt_chunk_output = tt_chunk_out_torch[:, 0:1, :chunk_size, :dim].view(batch_size, chunk_size, dim)
+            tt_outputs_chunked.append(tt_chunk_output)
+
+        # Concatenate all chunk outputs
+        tt_output_torch = torch.cat(tt_outputs_chunked, dim=1)
+    else:
+        # Standard prefill: single forward pass - use HF rotary_emb
+        rot_mats = get_rot_mats_from_hf(
+            reference_wrapper.rotary_emb,
+            seq_len=seq_len,
+            head_dim=head_dim,
+            device=ttnn_mesh_device,
+        )
+
+        # Run TT model - verify forward pass executes without error
+        tt_out = tt_model.forward(
+            tt_input,
+            None,  # current_pos not used in prefill
+            rot_mats,
+            mode="prefill",
+            page_table=page_table_tt,
+        )
+
+        # Convert output to torch and verify shape
+        tt_out = to_torch_auto_compose(tt_out)
+        tt_output_torch = tt_out[:, 0:1, :seq_len, :dim].view(batch_size, seq_len, dim)
+    ttnn.SetDefaultDevice(None)
+
+    # Verify output shape and content
+    assert tt_output_torch.shape == (
+        batch_size,
+        seq_len,
+        dim,
+    ), f"Expected shape {(batch_size, seq_len, dim)}, got {tt_output_torch.shape}"
+    assert not torch.isnan(tt_output_torch).any(), "Output contains NaN values"
+    assert not torch.isinf(tt_output_torch).any(), "Output contains Inf values"
+
+    # Run reference HuggingFace attention using HfAttentionWrapper
+    # Note: freqs_cis_i is None because HfAttentionWrapper uses rotary_emb directly
+    with torch.no_grad():
+        reference_output = reference_wrapper(pt_attention_input, start_pos=0, mask=None)
+
+    # Compare TT output with reference using PCC
+    passing, pcc_message = comp_pcc(reference_output, tt_output_torch.to(reference_output.dtype), pcc)
+    logger.info(f"  PCC comparison: {pcc_message}")
+    logger.info(comp_allclose(reference_output, tt_output_torch.to(reference_output.dtype)))
+    assert passing, f"Prefill PCC failed: {pcc_message} (expected >= {pcc})"
+
+    # Note: KV cache comparison is skipped because:
+    # - HF's DynamicCache stores K/V after applying HF-format RoPE
+    # - TT's Attention1D stores K/V after applying Meta-format RoPE
+    # These are different rotary embedding formats, so cached values won't match.
+    # The output comparison above is the meaningful correctness check.
+    logger.info("  KV cache validation: SKIPPED (HF/TT use different RoPE formats in cache)")
+
+    paged_str = f"paged(block_size={page_block_size})" if page_block_size is not None else "non-paged"
+    chunked_str = "chunked" if chunked_prefill else "non-chunked"
+    logger.info(
+        f"test_attention_1d_vs_reference (from_config): PASSED for mode=prefill, seq_len={seq_len}, {paged_str}, {chunked_str}"
+    )
+    logger.info(f"  Config: dim={dim}, n_heads={n_heads}, n_kv_heads={n_kv_heads}, head_dim={head_dim}")
+    logger.info(f"  Output shape: {tt_output_torch.shape}, dtype: {tt_output_torch.dtype}")
+
+
+def _run_decode_test(
+    tt_model,
+    reference_wrapper,
+    ttnn_mesh_device,
+    mesh_shape,
+    batch_size,
+    dim,
+    n_heads,
+    n_kv_heads,
+    head_dim,
+    max_seq_len,
+    act_dtype,
+    page_block_size,
+    page_table_tt,
+    num_decode_iterations,
+    pcc,
+):
+    """
+    Run decode-only test starting from position 0 (TTTv1 style).
+
+    This is a pure unit test for decode_forward:
+    - No prefill step - KV cache builds incrementally during decode
+    - Runs num_decode_iterations decode steps at positions 0, 1, 2, ...
+    - Compares each iteration against HuggingFace reference
+
+    For batch_size > 1 (continuous batching):
+    - All users decode with identical inputs at the same position
+    - Verifies batching mechanism doesn't introduce numerical errors
+
+    Note: prefill→decode transition is tested separately in test_attention_1d_prefill_decode_transition.
+    """
+    # Create decode-specific RotarySetupHelper using HF rotary_emb (reused across iterations)
+    decode_rope_setup = RotarySetupHelper(
+        ttnn_mesh_device,
+        batch_size,
+        head_dim,
+        max_seq_len,
+        reference_wrapper.rotary_emb,
+        use_qk_fused=False,
+    )
+
+    # Decode iterations starting from position 0
+    # KV cache builds incrementally: position 0, 1, 2, ... (TTTv1 style)
+    all_iterations_passing = True
+    min_pcc_across_iterations = 1.0
+
+    for decode_iter in range(num_decode_iterations):
+        current_pos_value = decode_iter  # Start from 0, not after prefill
+
+        # Create identical input for all users (for comparison against single HF reference)
+        # TTNN decode expects shape (1, 1, batch_size, dim) - seq_len=1, batch in 3rd dim
+        pt_decode_single = torch.randn(1, 1, dim, dtype=torch.bfloat16)
+        pt_decode_batched = pt_decode_single.unsqueeze(2).expand(1, 1, batch_size, dim).contiguous()
+
+        tt_decode_input = ttnn.from_torch(
+            pt_decode_batched,
+            device=ttnn_mesh_device,
+            dtype=act_dtype,
+            layout=ttnn.TILE_LAYOUT,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=ttnn.ShardTensor2dMesh(ttnn_mesh_device, dims=(None, None), mesh_shape=mesh_shape),
+        )
+
+        # Convert to decode input memory config
+        tt_decode_input = ttnn.to_memory_config(tt_decode_input, tt_model.config.decode_input_memcfg)
+
+        # Position for decode: all users at the same position
+        position_idxs = torch.full((batch_size,), current_pos_value, dtype=torch.long)
+        decode_rot_mats = decode_rope_setup.get_rot_mats(position_idxs)
+
+        current_pos = ttnn.from_torch(
+            position_idxs,
+            device=ttnn_mesh_device,
+            dtype=ttnn.int32,
+            mesh_mapper=ttnn.replicate_tensor_to_mesh_mapper(ttnn_mesh_device),
+        )
+
+        # Run TT decode (batched)
+        tt_out = tt_model.forward(
+            tt_decode_input,
+            current_pos,
+            decode_rot_mats,
+            mode="decode",
+            page_table=page_table_tt,
+        )
+
+        # Convert output to torch
+        tt_out = to_torch_auto_compose(tt_out)
+
+        # Extract TT output: shape (1, 1, batch_size, dim) -> (batch_size, 1, dim)
+        tt_output_torch = tt_out[:, 0:1, :batch_size, :dim].view(batch_size, 1, dim)
+
+        # Run HuggingFace decode using wrapper (single user reference)
+        with torch.no_grad():
+            reference_output = reference_wrapper(pt_decode_single, start_pos=current_pos_value, mask=None)
+
+        # Verify output content
+        assert tt_output_torch.numel() > 0, f"Output is empty at iteration {decode_iter}"
+        assert not torch.isnan(tt_output_torch).any(), f"Output contains NaN at iteration {decode_iter}"
+        assert not torch.isinf(tt_output_torch).any(), f"Output contains Inf at iteration {decode_iter}"
+
+        # Compare EACH user's TT output with the single HF reference
+        for user_idx in range(batch_size):
+            user_output = tt_output_torch[user_idx : user_idx + 1]
+            passing, pcc_value = comp_pcc(reference_output, user_output.to(reference_output.dtype), pcc)
+            if isinstance(pcc_value, (int, float)):
+                min_pcc_across_iterations = min(min_pcc_across_iterations, float(pcc_value))
+            if not passing:
+                logger.warning(f"  Iteration {decode_iter}, User {user_idx} PCC failed: {pcc_value}")
+                all_iterations_passing = False
+
+    ttnn.SetDefaultDevice(None)
+
+    logger.info(
+        f"  Decode iterations: {num_decode_iterations}, min_pcc={min_pcc_across_iterations:.6f} across all iterations"
+    )
+    assert all_iterations_passing, f"Decode PCC failed (min_pcc={min_pcc_across_iterations:.6f}, expected >= {pcc})"
+
+    paged_str = f"paged(block_size={page_block_size})" if page_block_size is not None else "non-paged"
+    logger.info(
+        f"test_attention_1d_vs_reference (from_config): PASSED for mode=decode, "
+        f"batch_size={batch_size}, {paged_str}, iterations={num_decode_iterations}"
+    )
+    logger.info(f"  Config: dim={dim}, n_heads={n_heads}, n_kv_heads={n_kv_heads}, head_dim={head_dim}")
+
+
+# =============================================================================
+# Integration Test: Prefill → Decode Transition
+# =============================================================================
+
+
+@torch.no_grad()
+@pytest.mark.parametrize(
+    "ttnn_mesh_device",
+    [
+        (1, 1),  # single device
+        (1, 2),  # 1D mesh, 2 devices
+        (1, 8),  # 1D mesh, 8 devices
+    ],
+    ids=["1x1", "1x2", "1x8"],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "page_block_size",
+    [None, 64],  # Test both non-paged and paged attention
+    ids=["non-paged", "paged"],
+)
+def test_attention_1d_prefill_decode_transition(ttnn_mesh_device: ttnn.MeshDevice, page_block_size):
+    """
+    Integration test for prefill→decode transition.
+
+    This test verifies that KV cache state is correctly maintained across the
+    prefill→decode boundary. Unlike the unit tests which test prefill and decode
+    in isolation, this test verifies the handoff between modes.
+
+    **Integration Point: KV Cache**
+    The KV cache is explicitly created and passed to the model config, making
+    the integration point crystal clear:
+    - Prefill writes keys/values to positions 0..prefill_seq_len-1
+    - Decode reads from those positions and writes to prefill_seq_len+
+
+    Test flow:
+    1. Create explicit KV cache tensors (the integration point)
+    2. Run prefill → populates KV cache positions 0..N-1
+    3. Run decode at positions N, N+1, ... → reads from cache, writes new positions
+    4. Compare outputs against HuggingFace reference
+    """
+    # Minimal test parameters - we're testing transition, not model variations
+    hf_model_name = "meta-llama/Llama-3.2-1B-Instruct"
+    prefill_seq_len = 128  # Must be divisible by 128
+    num_decode_after_prefill = 5
+    batch_size = 32  # Realistic continuous batching scenario
+    pcc = 0.98
+
+    seed = 42
+    torch.manual_seed(seed)
+
+    # Load HF config
+    hf_config = AutoConfig.from_pretrained(hf_model_name)
+    cfg = hf_config.text_config if hasattr(hf_config, "text_config") else hf_config
+    cfg.num_hidden_layers = 1
+
+    dim = cfg.hidden_size
+    n_heads = cfg.num_attention_heads
+    n_kv_heads = getattr(cfg, "num_key_value_heads", n_heads)
+    head_dim = getattr(cfg, "head_dim", None) or (dim // n_heads)
+
+    # Calculate max_seq_len with proper alignment
+    max_seq_len = prefill_seq_len + num_decode_after_prefill
+    alignment = page_block_size if page_block_size is not None else 32
+    max_seq_len = ((max_seq_len + alignment - 1) // alignment) * alignment
+
+    mesh_shape = ttnn_mesh_device.shape
+    num_devices = ttnn_mesh_device.get_num_devices()
+    n_local_kv_heads = n_kv_heads // num_devices
+
+    # Load HF model
+    with no_init_weights():
+        hf_model = AutoModelForCausalLM.from_config(hf_config, torch_dtype=torch.bfloat16)
+    first_layer = hf_model.model.layers[0]
+    rotary_emb = getattr(hf_model.model, "rotary_emb", None)
+
+    reference_attn = first_layer.self_attn
+    _get_or_init_attn_weights(hf_model_name, reference_attn)
+    reference_wrapper = HfAttentionWrapper(reference_attn, head_dim, rotary_emb)
+
+    # Extract weights
+    wqkv_torch, wo_torch, q_norm_torch, k_norm_torch, wqkv_bias_torch = get_attention_weights_from_ref_model(
+        reference_attn, num_devices
+    )
+
+    act_dtype = ttnn.bfloat16
+    wqkv_dtype = ttnn.bfloat8_b
+    lazy_wqkv = LazyWeight(source=wqkv_torch, dtype=wqkv_dtype, cache_dir_weight_name=None)
+    lazy_wo = LazyWeight(source=wo_torch, dtype=wqkv_dtype, cache_dir_weight_name=None)
+
+    # Setup paged attention if enabled
+    paged_attention_config = None
+    page_table_tt = None
+    if page_block_size is not None:
+        # Each user needs ceil(max_seq_len / block_size) blocks
+        blocks_per_user = (max_seq_len + page_block_size - 1) // page_block_size
+        max_num_blocks = max(128, blocks_per_user * batch_size)
+        paged_attention_config = PagedAttentionConfig(block_size=page_block_size, max_num_blocks=max_num_blocks)
+
+        permutation = torch.randperm(max_num_blocks)
+        reverse_permutation = torch.argsort(permutation)
+        page_table = reverse_permutation.reshape(batch_size, max_num_blocks // batch_size)
+        page_table_tt = ttnn.from_torch(
+            page_table,
+            device=ttnn_mesh_device,
+            dtype=ttnn.int32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            mesh_mapper=ttnn.ShardTensor2dMesh(ttnn_mesh_device, dims=(None, None), mesh_shape=mesh_shape),
+        )
+
+    # =========================================================================
+    # INTEGRATION POINT: Explicitly create KV cache tensors
+    # =========================================================================
+    # The KV cache is the shared state between prefill and decode.
+    # By creating it explicitly here, we make the integration point visible:
+    # - Prefill will WRITE to this cache (positions 0..prefill_seq_len-1)
+    # - Decode will READ from this cache and WRITE new positions
+    # =========================================================================
+    if paged_attention_config is not None:
+        cache_k = zeros_like_paged_cache(paged_attention_config, n_local_kv_heads, head_dim)
+        cache_v = zeros_like_paged_cache(paged_attention_config, n_local_kv_heads, head_dim)
+    else:
+        cache_k = zeros_like_kv_cache(batch_size, n_local_kv_heads, max_seq_len, head_dim)
+        cache_v = zeros_like_kv_cache(batch_size, n_local_kv_heads, max_seq_len, head_dim)
+
+    # Wrap as LazyWeight for config
+    kv_cache = (LazyWeight(source=cache_k), LazyWeight(source=cache_v))
+
+    # Build config with explicit KV cache
+    topology = ttnn.Topology.Ring if num_devices > 1 else None
+    tt_ccl = TT_CCL(ttnn_mesh_device) if num_devices > 1 else None
+
+    config = Attention1DConfig(
+        wqkv=lazy_wqkv,
+        wo=lazy_wo,
+        mesh_device=ttnn_mesh_device,
+        tt_ccl=tt_ccl,
+        topology=topology,
+        dim=dim,
+        n_heads=n_heads,
+        n_kv_heads=n_kv_heads,
+        head_dim=head_dim,
+        max_batch_size=batch_size,
+        max_seq_len=max_seq_len,
+        scale=head_dim**-0.5,
+        use_vllm_paged_kv_cache=False,
+        paged_attention_config=paged_attention_config,
+        kv_cache=kv_cache,  # <-- EXPLICIT KV CACHE: the integration point
+        wqkv_dtype=wqkv_dtype,
+        wo_dtype=wqkv_dtype,
+        activation_dtype=act_dtype,
+    )
+
+    tt_model = Attention1D.from_config(config)
+
+    # =========================================================================
+    # Step 1: PREFILL - populates KV cache positions 0..prefill_seq_len-1
+    # =========================================================================
+    # Run prefill per-user (continuous batching style) to avoid compute grid limits.
+    # Each user gets the same input for easy comparison.
+    # =========================================================================
+    pt_prefill_input_single = torch.randn(1, prefill_seq_len, dim, dtype=torch.bfloat16)
+    prefill_rot_mats = get_rot_mats_from_hf(rotary_emb, prefill_seq_len, head_dim, ttnn_mesh_device)
+
+    # Collect outputs for all users
+    tt_prefill_outputs = []
+    for user_id in range(batch_size):
+        tt_prefill_input = ttnn.from_torch(
+            pt_prefill_input_single.unsqueeze(0),  # (1, 1, prefill_seq_len, dim)
+            device=ttnn_mesh_device,
+            dtype=act_dtype,
+            layout=ttnn.TILE_LAYOUT,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=ttnn.ShardTensor2dMesh(ttnn_mesh_device, dims=(None, None), mesh_shape=mesh_shape),
+        )
+        tt_prefill_out = tt_model.forward(
+            tt_prefill_input, None, prefill_rot_mats, user_id=user_id, mode="prefill", page_table=page_table_tt
+        )
+        tt_prefill_out = to_torch_auto_compose(tt_prefill_out)
+        tt_prefill_outputs.append(tt_prefill_out[:, 0:1, :prefill_seq_len, :dim].view(1, prefill_seq_len, dim))
+
+    # Stack outputs: (batch_size, prefill_seq_len, dim)
+    tt_prefill_output = torch.cat(tt_prefill_outputs, dim=0)
+
+    # HF reference prefill (single user, same input)
+    with torch.no_grad():
+        ref_prefill_output = reference_wrapper(pt_prefill_input_single, start_pos=0, mask=None)
+
+    # Compare first user's output (all users have same input, should match)
+    passing, pcc_msg = comp_pcc(ref_prefill_output, tt_prefill_output[0:1].to(ref_prefill_output.dtype), pcc)
+    logger.info(f"  Prefill PCC: {pcc_msg}")
+    assert passing, f"Prefill failed: {pcc_msg}"
+
+    # =========================================================================
+    # Step 2: DECODE - uses prefill output as input (realistic autoregressive flow)
+    # =========================================================================
+    # In real autoregressive generation:
+    # - First decode input = last position of prefill output
+    # - Subsequent decode inputs = previous decode output
+    # This tests both KV cache integration AND data flow between modes.
+    # =========================================================================
+    decode_rope_setup = RotarySetupHelper(
+        ttnn_mesh_device, batch_size, head_dim, max_seq_len, rotary_emb, use_qk_fused=False
+    )
+
+    # First decode input: last position of prefill output (shape: batch, 1, dim)
+    pt_decode_input = tt_prefill_output[:, -1:, :].clone()  # (batch_size, 1, dim)
+    ref_decode_input = ref_prefill_output[:, -1:, :].clone()  # For HF reference
+
+    for decode_iter in range(num_decode_after_prefill):
+        current_pos_value = prefill_seq_len + decode_iter
+
+        # Prepare TT input: (batch, 1, dim) -> (1, 1, batch, dim) for TTNN decode format
+        pt_decode_batched = pt_decode_input.transpose(0, 1).unsqueeze(0)  # (1, 1, batch_size, dim)
+
+        tt_decode_input = ttnn.from_torch(
+            pt_decode_batched,
+            device=ttnn_mesh_device,
+            dtype=act_dtype,
+            layout=ttnn.TILE_LAYOUT,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=ttnn.ShardTensor2dMesh(ttnn_mesh_device, dims=(None, None), mesh_shape=mesh_shape),
+        )
+        tt_decode_input = ttnn.to_memory_config(tt_decode_input, tt_model.config.decode_input_memcfg)
+
+        position_idxs = torch.full((batch_size,), current_pos_value, dtype=torch.long)
+        decode_rot_mats = decode_rope_setup.get_rot_mats(position_idxs)
+
+        current_pos = ttnn.from_torch(
+            position_idxs,
+            device=ttnn_mesh_device,
+            dtype=ttnn.int32,
+            mesh_mapper=ttnn.replicate_tensor_to_mesh_mapper(ttnn_mesh_device),
+        )
+
+        tt_decode_out = tt_model.forward(
+            tt_decode_input, current_pos, decode_rot_mats, mode="decode", page_table=page_table_tt
+        )
+        tt_decode_out = to_torch_auto_compose(tt_decode_out)
+        tt_decode_output = tt_decode_out[:, 0:1, :batch_size, :dim].view(batch_size, 1, dim)
+
+        # HF reference decode (using same input flow)
+        with torch.no_grad():
+            ref_decode_output = reference_wrapper(ref_decode_input, start_pos=current_pos_value, mask=None)
+
+        # Compare first user's output (all users have identical input, should produce identical output)
+        passing, pcc_msg = comp_pcc(ref_decode_output, tt_decode_output[0:1].to(ref_decode_output.dtype), pcc)
+        logger.info(f"  Decode[pos={current_pos_value}] PCC: {pcc_msg}")
+        assert passing, f"Decode at position {current_pos_value} failed: {pcc_msg}"
+
+        # Next decode input = this decode output (autoregressive flow)
+        pt_decode_input = tt_decode_output.clone()
+        ref_decode_input = ref_decode_output.clone()
+
+    ttnn.SetDefaultDevice(None)
+
+    paged_str = f"paged(block_size={page_block_size})" if page_block_size is not None else "non-paged"
+    logger.info(
+        f"test_attention_1d_prefill_decode_transition: PASSED ({paged_str}, "
+        f"prefill={prefill_seq_len}, decode={num_decode_after_prefill})"
+    )
+
+
+@torch.no_grad()
+@pytest.mark.parametrize(
+    "ttnn_mesh_device",
+    [
+        (1, 1),  # single device
+        (1, 2),  # 1D mesh, 2 devices
+        (1, 8),  # 1D mesh, 8 devices
+    ],
+    ids=["1x1", "1x2", "1x8"],
+    indirect=True,
+)
+@pytest.mark.parametrize("seq_len", (512, 32))
+def test_attention_1d_vs_reference_from_model_args(ttnn_mesh_device: ttnn.MeshDevice, seq_len):
+    """
+    Test that Attention1D class created via from_model_args matches reference model.
+
+    This test validates backward compatibility with the ModelArgs factory method
+    and performs numerical PCC comparison against the reference attention.
+    """
+    from models.tt_transformers.tests.test_utils import get_ref_model_dype
+    from models.tt_transformers.tt.ccl import TT_CCL
+    from models.tt_transformers.tt.common import precompute_freqs
+    from models.tt_transformers.tt.model_config import Mode, ModelArgs
+    from models.tt_transformers.tt.rope import RotarySetup, get_rot_mats
+
+    # Use HF_MODEL env var if set, otherwise use appropriate default based on device count
+    # Multi-device requires larger models (dim >= 4096) for proper sharding
+    num_devices = ttnn_mesh_device.get_num_devices()
+    env_model = os.environ.get("HF_MODEL")
+
+    if not env_model:
+        # Set default model based on device configuration
+        if num_devices == 1:
+            # Small model works for single device
+            default_model = "meta-llama/Llama-3.2-1B"
+        else:
+            # Multi-device needs larger model with dim >= 4096
+            default_model = "meta-llama/Llama-3.1-8B-Instruct"
+        os.environ["HF_MODEL"] = default_model
+        logger.info(f"HF_MODEL not set, using default: {default_model}")
+
+    dtype = ttnn.bfloat8_b
+    pcc = 0.98
+    batch_size = 1
+    mode = "decode" if seq_len <= 32 else "prefill"
+
+    model_args = ModelArgs(ttnn_mesh_device, max_batch_size=batch_size, max_seq_len=2048, cache_hf=True)
+    model_args.n_layers = 1
+
+    if model_args.is_galaxy:
+        pytest.skip("Attention1D test only runs on non-TG devices")
+
+    # Verify model dimensions are sufficient for multi-device
+    if num_devices > 1 and model_args.dim < 4096:
+        pytest.skip(f"Model dim={model_args.dim} too small for {num_devices} devices - use 8B+ models")
+
+    state_dict = model_args.load_state_dict()
+
+    # Load reference attention model
+    first_layer_prefix = model_args.get_state_dict_prefix("Attention", 0) + "."
+    partial_state_dict = {
+        k[len(first_layer_prefix) :]: v for k, v in state_dict.items() if k.startswith(first_layer_prefix)
+    }
+    reference_model = model_args.reference_attention()
+    reference_model.load_state_dict(partial_state_dict)
+
+    # Setup RoPE transformation matrices
+    rope_setup = RotarySetup(
+        ttnn_mesh_device,
+        batch_size,
+        model_args.head_dim,
+        model_args.max_seq_len,
+        model_args.rope_theta,
+        model_args.rope_scaling,
+        model_args.use_qk_fused,
+    )
+    transformation_mats = rope_setup.get_both_trans_mats()
+
+    # Precompute freqs_cis for reference model
+    cos, sin = precompute_freqs(
+        model_args.head_dim,
+        model_args.max_seq_len * 2,
+        model_args.rope_theta,
+        model_args.rope_scaling.factor if model_args.rope_scaling else None,
+        model_args.rope_scaling.original_max_position_embeddings if model_args.rope_scaling else None,
+        model_args.rope_scaling.rope_type.value if model_args.rope_scaling else "llama3",
+    )
+    freqs_cis = torch.complex(cos, sin)
+
+    # Cache path
+    def topology_aware_cache_path(dtype):
+        if model_args.instruct:
+            return model_args.model_cache_path / {
+                ttnn.bfloat16: f"tensor_cache_instruct_bf16_{ttnn_mesh_device.shape}",
+                ttnn.bfloat8_b: f"tensor_cache_instruct_bfp8_{ttnn_mesh_device.shape}",
+            }.get(dtype, f"tensor_cache_instruct_{ttnn_mesh_device.shape}")
+        return model_args.model_cache_path / {
+            ttnn.bfloat16: f"tensor_cache_bf16_{ttnn_mesh_device.shape}",
+            ttnn.bfloat8_b: f"tensor_cache_bfp8_{ttnn_mesh_device.shape}",
+        }.get(dtype, f"tensor_cache_{ttnn_mesh_device.shape}")
+
+    weight_cache_path = topology_aware_cache_path(dtype)
+
+    # Create TT_CCL for multi-device
+    tt_ccl = TT_CCL(ttnn_mesh_device) if num_devices > 1 else None
+
+    # Create Attention1D via from_model_args
+    tt_model = Attention1D.from_model_args(
+        mesh_device=ttnn_mesh_device,
+        tt_ccl=tt_ccl,
+        args=model_args,
+        state_dict=state_dict,
+        weight_cache_path=weight_cache_path,
+        layer_num=0,
+        transformation_mats=transformation_mats,
+        use_paged_kv_cache=False,
+    )
+
+    # Verify the model was created successfully
+    assert tt_model is not None
+    assert tt_model.config.is_resolved()
+    assert tt_model.config.dim == model_args.dim
+    assert tt_model.config.n_heads == model_args.n_heads
+    assert tt_model.config.n_kv_heads == model_args.n_kv_heads
+
+    logger.info(f"test_attention_1d_vs_reference_from_model_args: Testing mode={mode}, seq_len={seq_len}")
+
+    if mode == "prefill":
+        # Prefill mode test
+        pt_attention_input = torch.randn(
+            batch_size, seq_len, model_args.dim, dtype=get_ref_model_dype(reference_model, model_args.model_name)
+        )
+
+        # Prepare TT input
+        tt_input = ttnn.from_torch(
+            pt_attention_input.unsqueeze(0),  # [1, batch, seq_len, dim]
+            device=ttnn_mesh_device,
+            dtype=dtype,
+            layout=ttnn.TILE_LAYOUT,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=ttnn.ShardTensor2dMesh(
+                ttnn_mesh_device, dims=(None, None), mesh_shape=model_args.cluster_shape
+            ),
+        )
+
+        # Get rot_mats for prefill
+        rot_mats = get_rot_mats(
+            head_dim=model_args.head_dim,
+            device=ttnn_mesh_device,
+            seq_len=seq_len,
+            theta=model_args.rope_theta,
+            rope_scaling=model_args.rope_scaling,
+        )
+
+        # Run TT model
+        tt_out = tt_model.forward(
+            tt_input,
+            None,  # current_pos not used in prefill
+            rot_mats,
+            mode="prefill",
+        )
+
+        # Convert TT output to torch
+        tt_out = to_torch_auto_compose(tt_out)
+        tt_output_torch = tt_out[:, 0:1, :seq_len, : model_args.dim].view(batch_size, seq_len, model_args.dim)
+
+        # Run reference model
+        freqs_cis_slice = freqs_cis[:seq_len]
+        reference_output = reference_model(pt_attention_input, start_pos=0, freqs_cis_i=freqs_cis_slice, mask=None)
+
+        # Compare with PCC
+        passing, pcc_message = comp_pcc(reference_output, tt_output_torch.to(reference_output.dtype), pcc)
+        logger.info(f"  PCC comparison: {pcc_message}")
+        logger.info(comp_allclose(reference_output, tt_output_torch.to(reference_output.dtype)))
+        assert passing, f"Prefill PCC failed: {pcc_message} (expected >= {pcc})"
+
+        logger.info(f"test_attention_1d_vs_reference_from_model_args: PASSED for mode={mode}, seq_len={seq_len}")
+
+    else:
+        # Decode mode test - requires prefill first to populate KV cache
+        prefill_seq_len = 128
+        pt_prefill_input = torch.randn(
+            batch_size,
+            prefill_seq_len,
+            model_args.dim,
+            dtype=get_ref_model_dype(reference_model, model_args.model_name),
+        )
+
+        # Prefill TT model
+        tt_prefill_input = ttnn.from_torch(
+            pt_prefill_input.unsqueeze(0),
+            device=ttnn_mesh_device,
+            dtype=dtype,
+            layout=ttnn.TILE_LAYOUT,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=ttnn.ShardTensor2dMesh(
+                ttnn_mesh_device, dims=(None, None), mesh_shape=model_args.cluster_shape
+            ),
+        )
+
+        prefill_rot_mats = get_rot_mats(
+            head_dim=model_args.head_dim,
+            device=ttnn_mesh_device,
+            seq_len=prefill_seq_len,
+            theta=model_args.rope_theta,
+            rope_scaling=model_args.rope_scaling,
+        )
+
+        _ = tt_model.forward(
+            tt_prefill_input,
+            None,
+            prefill_rot_mats,
+            user_id=0,
+            mode="prefill",
+        )
+
+        # Prefill reference model (to populate its KV cache state)
+        freqs_cis_prefill = freqs_cis[:prefill_seq_len]
+        _ = reference_model(pt_prefill_input, start_pos=0, freqs_cis_i=freqs_cis_prefill, mask=None)
+
+        # Decode pass
+        current_pos = torch.tensor([prefill_seq_len])
+        current_pos_tensor = ttnn.from_torch(
+            current_pos,
+            device=ttnn_mesh_device,
+            dtype=ttnn.int32,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(ttnn_mesh_device),
+        )
+
+        pt_decode_input = torch.randn(
+            batch_size, 1, model_args.dim, dtype=get_ref_model_dype(reference_model, model_args.model_name)
+        )
+
+        # Prepare decode input for TT
+        attention_input = model_args.prepare_residual_tensor_decode(
+            pt_decode_input.clone(),
+            model_args.get_attn_input_mem_config(Mode.DECODE),
+            force_replicated=True,
+        )
+
+        decode_rot_mats = rope_setup.get_rot_mats(current_pos)
+
+        # Run TT decode
+        tt_out = tt_model.forward(
+            attention_input,
+            current_pos_tensor,
+            decode_rot_mats,
+            mode="decode",
+        )
+
+        # Convert TT output
+        tt_out = to_torch_auto_compose(tt_out)
+        tt_output_torch = tt_out[:, 0:1, :batch_size, : model_args.dim].view(batch_size, 1, model_args.dim)
+
+        # Run reference decode
+        freqs_cis_i = freqs_cis[prefill_seq_len, :].unsqueeze(0)
+        reference_output = reference_model(
+            pt_decode_input, start_pos=prefill_seq_len, freqs_cis_i=freqs_cis_i, mask=None
+        )
+
+        # Compare with PCC
+        passing, pcc_message = comp_pcc(reference_output, tt_output_torch.to(reference_output.dtype), pcc)
+        logger.info(f"  PCC comparison: {pcc_message}")
+        logger.info(comp_allclose(reference_output, tt_output_torch.to(reference_output.dtype)))
+        assert passing, f"Decode PCC failed: {pcc_message} (expected >= {pcc})"
+
+        logger.info(f"test_attention_1d_vs_reference_from_model_args: PASSED for mode={mode}, seq_len={seq_len}")
+
+
+def test_attention_1d_rejects_galaxy(expect_error):
+    """Test that Attention1D.from_model_args rejects Galaxy/TG devices."""
+    # Mock args with is_galaxy = True
+    mock_args = MagicMock()
+    mock_args.is_galaxy = True
+
+    with expect_error(ValueError, "cannot be used for Galaxy"):
+        Attention1D.from_model_args(
+            mesh_device=MagicMock(),
+            tt_ccl=MagicMock(),
+            args=mock_args,
+            state_dict={},
+            weight_cache_path=None,
+            layer_num=0,
+            transformation_mats={},
+        )
+
+
+@torch.no_grad()
+@pytest.mark.parametrize(
+    "ttnn_mesh_device",
+    [(1, 1)],
+    ids=["1x1"],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "sliding_window,seq_len,pcc",
+    [
+        pytest.param(64, 128, 0.99, id="sw64-seq128"),
+        pytest.param(64, 256, 0.99, id="sw64-seq256"),
+        pytest.param(128, 256, 0.99, id="sw128-seq256"),
+    ],
+)
+def test_attention_1d_sliding_window(
+    ttnn_mesh_device: ttnn.MeshDevice,
+    sliding_window: int,
+    seq_len: int,
+    pcc: float,
+):
+    """
+    Test Attention1D with sliding window attention.
+
+    This test explicitly verifies that sliding window masking works correctly by:
+    1. Using seq_len > sliding_window to ensure the window is actually applied
+    2. Creating a reference implementation with sliding window causal mask
+    3. Comparing TT output against the masked reference
+
+    The sliding window limits attention to the last `sliding_window` tokens,
+    which affects which KV entries are attended to during SDPA.
+    """
+    # Use Llama-3.2-1B as base model (fast to load, no sliding window by default)
+    hf_model_name = LLAMA_1B
+
+    mesh_shape = tuple(ttnn_mesh_device.shape)
+    num_devices = ttnn_mesh_device.get_num_devices()
+    batch_size = 1
+    max_seq_len = max(512, seq_len * 2)
+
+    torch.manual_seed(42)
+
+    # Load HuggingFace model
+    hf_config = AutoConfig.from_pretrained(hf_model_name)
+    hf_model = AutoModelForCausalLM.from_pretrained(hf_model_name, torch_dtype=torch.bfloat16)
+    reference_attn = hf_model.model.layers[0].self_attn
+    rotary_emb = getattr(hf_model.model, "rotary_emb", None)
+
+    dim = hf_config.hidden_size
+    n_heads = hf_config.num_attention_heads
+    n_kv_heads = hf_config.num_key_value_heads
+    head_dim = dim // n_heads
+
+    # Get weights from reference model
+    wqkv_torch, wo_torch, _, _, _ = get_attention_weights_from_ref_model(reference_attn, num_devices)
+
+    # Create TT model with sliding window
+    ttnn.SetDefaultDevice(ttnn_mesh_device)
+    lazy_wqkv = LazyWeight(source=wqkv_torch, dtype=ttnn.bfloat8_b, cache_dir_weight_name=None)
+    lazy_wo = LazyWeight(source=wo_torch, dtype=ttnn.bfloat8_b, cache_dir_weight_name=None)
+
+    # Note: kv_cache is auto-created by config resolution
+    config = Attention1DConfig(
+        wqkv=lazy_wqkv,
+        wo=lazy_wo,
+        mesh_device=ttnn_mesh_device,
+        dim=dim,
+        n_heads=n_heads,
+        n_kv_heads=n_kv_heads,
+        head_dim=head_dim,
+        max_batch_size=batch_size,
+        max_seq_len=max_seq_len,
+        scale=head_dim**-0.5,
+        sliding_window=sliding_window,  # Enable sliding window
+        use_vllm_paged_kv_cache=False,
+        activation_dtype=ttnn.bfloat16,
+    )
+
+    tt_model = Attention1D.from_config(config)
+
+    rot_mats = get_rot_mats_from_hf(
+        rotary_emb,
+        seq_len=seq_len,
+        head_dim=head_dim,
+        device=ttnn_mesh_device,
+    )
+
+    # Prepare input
+    pt_input = torch.randn(batch_size, seq_len, dim, dtype=torch.bfloat16)
+
+    tt_input = ttnn.from_torch(
+        pt_input.unsqueeze(0),  # [1, batch, seq_len, dim]
+        device=ttnn_mesh_device,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        mesh_mapper=ttnn.ShardTensor2dMesh(ttnn_mesh_device, dims=(None, None), mesh_shape=mesh_shape),
+    )
+
+    # Run TT model with sliding window
+    tt_out = tt_model.forward(
+        tt_input,
+        None,  # current_pos not used in prefill
+        rot_mats,
+        mode="prefill",
+    )
+
+    tt_out_torch = to_torch_auto_compose(tt_out)
+    tt_output = tt_out_torch[:, 0:1, :seq_len, :dim].view(batch_size, seq_len, dim)
+
+    # Create reference with sliding window causal mask
+    # Sliding window mask: position i can only attend to positions max(0, i - sliding_window + 1) to i
+    def create_sliding_window_mask(seq_len: int, sliding_window: int) -> torch.Tensor:
+        """Create a sliding window causal attention mask for HuggingFace attention."""
+        # HF expects mask shape: (batch, 1, seq_len, seq_len) where 0 = attend, -inf = mask
+        mask = torch.zeros(seq_len, seq_len, dtype=torch.bfloat16)
+
+        for i in range(seq_len):
+            # Position i can attend to [max(0, i - sliding_window + 1), i]
+            for j in range(seq_len):
+                if j > i:
+                    # Causal: can't attend to future
+                    mask[i, j] = torch.finfo(torch.bfloat16).min
+                elif j < i - sliding_window + 1:
+                    # Sliding window: can't attend beyond window
+                    mask[i, j] = torch.finfo(torch.bfloat16).min
+
+        return mask.unsqueeze(0).unsqueeze(0)  # (1, 1, seq_len, seq_len)
+
+    sliding_mask = create_sliding_window_mask(seq_len, sliding_window)
+
+    # Setup reference attention using local HfAttentionWrapper
+    reference_wrapper = HfAttentionWrapper(reference_attn, head_dim, rotary_emb)
+
+    # Run reference WITH sliding window mask
+    ref_output_sw = reference_wrapper(pt_input, start_pos=0, mask=sliding_mask)
+
+    # Also run reference WITHOUT sliding window (full attention) for comparison
+    # Need a fresh wrapper since it caches KV
+    reference_wrapper_full = HfAttentionWrapper(reference_attn, head_dim, rotary_emb)
+    ref_output_full = reference_wrapper_full(pt_input, start_pos=0, mask=None)
+
+    ttnn.SetDefaultDevice(None)
+
+    # Basic sanity checks
+    assert not torch.isnan(tt_output).any(), "TT output contains NaN"
+    assert not torch.isinf(tt_output).any(), "TT output contains Inf"
+    assert tt_output.shape == (batch_size, seq_len, dim), f"Shape mismatch: {tt_output.shape}"
+
+    logger.info(f"Sliding window test: sw={sliding_window}, seq_len={seq_len}")
+
+    # Compare TT output (with sliding window) against HF reference (with sliding window mask)
+    passing_sw, pcc_sw = comp_pcc(ref_output_sw, tt_output.to(ref_output_sw.dtype), pcc)
+    logger.info(f"  PCC TT vs HF (both with sliding window): {pcc_sw}")
+    assert passing_sw, f"Sliding window PCC failed: {pcc_sw} (expected >= {pcc})"
+
+    # Verify sliding window actually has an effect by comparing to full attention
+    if seq_len > sliding_window:
+        # The sliding window reference should differ from full attention
+        ref_diff = (ref_output_sw - ref_output_full).abs().mean()
+        logger.info(f"  HF sliding window vs full attention diff: {ref_diff:.6f}")
+        assert ref_diff > 1e-4, "HF sliding window mask had no effect on reference"
+
+        # TT output should also differ from full attention
+        tt_diff = (tt_output - ref_output_full).abs().mean()
+        logger.info(f"  TT sliding window vs HF full attention diff: {tt_diff:.6f}")
+        assert tt_diff > 1e-4, "TT sliding window had no effect"
+
+        # The TT-vs-reference-sliding-window PCC should be higher than TT-vs-full-attention
+        _, pcc_full = comp_pcc(ref_output_full, tt_output.to(ref_output_full.dtype), 0.0)
+        logger.info(f"  PCC TT (sliding) vs HF (full): {pcc_full}")
+
+        # Compare PCC values
+        pcc_sw_val = float(pcc_sw)
+        pcc_full_val = float(pcc_full)
+        assert pcc_sw_val > pcc_full_val, (
+            f"TT sliding window should match HF sliding window better than HF full attention. "
+            f"PCC(TT,HF_sw)={pcc_sw_val:.4f} should be > PCC(TT,HF_full)={pcc_full_val:.4f}"
+        )
+
+    logger.info(f"test_attention_1d_sliding_window: PASSED (sw={sliding_window}, seq_len={seq_len})")

--- a/models/experimental/llama32_1b_quasar/tests/modules/attention/test_attention_1d.py
+++ b/models/experimental/llama32_1b_quasar/tests/modules/attention/test_attention_1d.py
@@ -257,7 +257,8 @@ class RotarySetupHelper:
         """Get rotation matrices for given position indices."""
         rot_idxs = self.get_rot_idxs(position_idxs)
 
-        if rot_idxs.device != self.device:
+        # tensor.device() is a method; returns None for host tensors
+        if rot_idxs.device() != self.device:
             rot_idxs = ttnn.to_device(rot_idxs, self.device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
 
         cos = ttnn.embedding(rot_idxs, self.cos_matrix, layout=ttnn.TILE_LAYOUT)

--- a/models/experimental/llama32_1b_quasar/tests/modules/embedding/test_embedding_1d.py
+++ b/models/experimental/llama32_1b_quasar/tests/modules/embedding/test_embedding_1d.py
@@ -1,0 +1,510 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Tests for the Embedding1D module (1D mesh topology: N150, N300, T3K).
+
+This test suite verifies:
+1. Unit tests for config dataclasses (no device needed)
+2. Embedding1D class matches torch.nn.Embedding reference
+3. Embedding1D correctly rejects TG/Galaxy devices
+4. from_model_args backward compatibility
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+from models.experimental.llama32_1b_quasar.auto_compose import to_torch_auto_compose
+from models.experimental.llama32_1b_quasar.modules.embedding.embedding_1d import Embedding1D, Embedding1DConfig
+from models.experimental.llama32_1b_quasar.modules.lazy_weight import LazyWeight
+from models.experimental.llama32_1b_quasar.utility_functions import comp_allclose, comp_pcc
+
+# ============================================================================
+# HF model name constants
+# ============================================================================
+
+LLAMA_1B = "meta-llama/Llama-3.2-1B-Instruct"
+LLAMA_3B = "meta-llama/Llama-3.2-3B-Instruct"
+LLAMA_8B = "meta-llama/Llama-3.1-8B-Instruct"
+LLAMA_11B = "meta-llama/Llama-3.2-11B-Vision-Instruct"
+LLAMA_70B = "meta-llama/Llama-3.3-70B-Instruct"
+MISTRAL_7B = "mistralai/Mistral-7B-Instruct-v0.3"
+QWEN2_7B = "Qwen/Qwen2-7B-Instruct"
+QWEN25_7B = "Qwen/Qwen2.5-7B-Instruct"
+QWEN25_72B = "Qwen/Qwen2.5-72B-Instruct"
+QWEN25_CODER_32B = "Qwen/Qwen2.5-Coder-32B-Instruct"
+DEEPSEEK_R1_14B = "deepseek-ai/DeepSeek-R1-Distill-Qwen-14B"
+QWEN3_32B = "Qwen/Qwen3-32B"
+MIXTRAL_8X7B = "mistralai/Mixtral-8x7B-v0.1"
+
+
+# ============================================================================
+# Unit Tests - No device required
+# ============================================================================
+
+
+def test_embedding_1d_config_creation():
+    """Test that Embedding1DConfig dataclass can be created with explicit values."""
+    from unittest.mock import MagicMock
+
+    mock_w = MagicMock()
+    mock_device = MagicMock()
+
+    config = Embedding1DConfig(
+        weights=mock_w,
+        mesh_device=mock_device,
+        embed_scale=2.0,
+        weights_dtype=ttnn.bfloat16,
+    )
+
+    assert config.weights is mock_w
+    assert config.mesh_device is mock_device
+    assert config.embed_scale == 2.0
+    assert config.weights_dtype == ttnn.bfloat16
+
+
+def test_embedding_1d_config_defaults():
+    """Test that Embedding1DConfig has sensible defaults."""
+    from unittest.mock import MagicMock
+
+    config = Embedding1DConfig(weights=MagicMock())
+
+    assert config.embed_scale == 1.0
+    assert config.mesh_device is None
+    assert config.weights_dtype is None
+    assert config.weights_memcfg is None
+    assert config.output_memcfg is None
+
+
+def test_embedding_1d_config_embed_scale_override():
+    """Test that embed_scale can be overridden for ScaledEmbedding use case."""
+    from unittest.mock import MagicMock
+
+    config = Embedding1DConfig(weights=MagicMock(), embed_scale=55.4256)
+    assert config.embed_scale == 55.4256
+
+
+# ============================================================================
+# Weight caching
+# ============================================================================
+
+_CACHED_EMB_WEIGHTS: dict[str, torch.Tensor] = {}
+
+
+def _get_or_init_embedding_weight(model_name: str, vocab_size: int, dim: int) -> torch.Tensor:
+    """Initialize embedding weight once per model, cache and reuse across tests."""
+    key = f"{model_name}_{vocab_size}_{dim}"
+    if key not in _CACHED_EMB_WEIGHTS:
+        logger.info(f"\033[33m[cache miss]\033[0m Initializing embedding weight for {key}")
+        _CACHED_EMB_WEIGHTS[key] = torch.randn(vocab_size, dim, dtype=torch.bfloat16)
+    else:
+        logger.info(f"\033[32m[cache hit]\033[0m Reusing cached embedding weight for {key}")
+    return _CACHED_EMB_WEIGHTS[key]
+
+
+# ============================================================================
+# Integration Tests - Require device
+# ============================================================================
+
+_slow = pytest.mark.slow
+
+
+# Each case: (mesh_shape, vocab_size, dim, seq_len, embed_scale, hf_model_name, pcc)
+# Vocab/dim derived from model, seq_len varies per collected case.
+def _list_test_cases() -> list[pytest.param]:
+    # fmt: off
+    return [
+        # === Fast tests (minimal coverage set) ===
+        # Single device (1x1) - Llama 1B (vocab=128256, dim=2048)
+        pytest.param((1, 1), 128256, 2048, 32, 1.0, LLAMA_1B, 0.999, id="1x1-32-1B"),
+        pytest.param((1, 1), 128256, 2048, 128, 1.0, LLAMA_1B, 0.999, id="1x1-128-1B"),
+        # N300 (1x2) - Llama 8B (vocab=128256, dim=4096)
+        pytest.param((1, 2), 128256, 4096, 128, 1.0, LLAMA_8B, 0.999, id="1x2-128-8B"),
+        pytest.param((1, 2), 128256, 4096, 32, 1.0, LLAMA_8B, 0.999, id="1x2-32-8B"),
+        # T3K (1x8) - Llama 70B (vocab=128256, dim=8192)
+        pytest.param((1, 8), 128256, 8192, 128, 1.0, LLAMA_70B, 0.999, id="1x8-128-70B"),
+        pytest.param((1, 8), 128256, 8192, 32, 1.0, LLAMA_70B, 0.999, id="1x8-32-70B"),
+        # Non-Llama models
+        pytest.param((1, 1), 32768, 4096, 32, 1.0, MISTRAL_7B, 0.999, id="1x1-32-Mistral-7B"),
+        pytest.param((1, 2), 152064, 3584, 128, 1.0, QWEN2_7B, 0.999, id="1x2-128-Qwen2-7B"),
+        pytest.param((1, 8), 32000, 4096, 128, 1.0, MIXTRAL_8X7B, 0.999, id="1x8-128-Mixtral-8x7B"),
+
+        # === Slow tests (full coverage) ===
+        # (1,1) Llama-3.2-1B
+        pytest.param((1, 1), 128256, 2048, 1024, 1.0, LLAMA_1B, 0.999, id="1x1-1024-1B", marks=_slow),
+        pytest.param((1, 1), 128256, 2048, 2048, 1.0, LLAMA_1B, 0.999, id="1x1-2048-1B", marks=_slow),
+        pytest.param((1, 1), 128256, 2048, 4096, 1.0, LLAMA_1B, 0.999, id="1x1-4096-1B", marks=_slow),
+        pytest.param((1, 1), 128256, 2048, 8192, 1.0, LLAMA_1B, 0.999, id="1x1-8192-1B", marks=_slow),
+        # (1,1) Llama-3.2-3B
+        pytest.param((1, 1), 128256, 3072, 32, 1.0, LLAMA_3B, 0.999, id="1x1-32-3B", marks=_slow),
+        pytest.param((1, 1), 128256, 3072, 128, 1.0, LLAMA_3B, 0.999, id="1x1-128-3B", marks=_slow),
+        pytest.param((1, 1), 128256, 3072, 1024, 1.0, LLAMA_3B, 0.999, id="1x1-1024-3B", marks=_slow),
+        pytest.param((1, 1), 128256, 3072, 2048, 1.0, LLAMA_3B, 0.999, id="1x1-2048-3B", marks=_slow),
+        pytest.param((1, 1), 128256, 3072, 4096, 1.0, LLAMA_3B, 0.999, id="1x1-4096-3B", marks=_slow),
+        pytest.param((1, 1), 128256, 3072, 8192, 1.0, LLAMA_3B, 0.999, id="1x1-8192-3B", marks=_slow),
+        # (1,1) Llama-3.1-8B
+        pytest.param((1, 1), 128256, 4096, 32, 1.0, LLAMA_8B, 0.999, id="1x1-32-8B", marks=_slow),
+        pytest.param((1, 1), 128256, 4096, 128, 1.0, LLAMA_8B, 0.999, id="1x1-128-8B", marks=_slow),
+        pytest.param((1, 1), 128256, 4096, 1024, 1.0, LLAMA_8B, 0.999, id="1x1-1024-8B", marks=_slow),
+        pytest.param((1, 1), 128256, 4096, 2048, 1.0, LLAMA_8B, 0.999, id="1x1-2048-8B", marks=_slow),
+        pytest.param((1, 1), 128256, 4096, 4096, 1.0, LLAMA_8B, 0.999, id="1x1-4096-8B", marks=_slow),
+        # (1,1) Mistral-7B
+        pytest.param((1, 1), 32768, 4096, 128, 1.0, MISTRAL_7B, 0.999, id="1x1-128-Mistral-7B", marks=_slow),
+        pytest.param((1, 1), 32768, 4096, 1024, 1.0, MISTRAL_7B, 0.999, id="1x1-1024-Mistral-7B", marks=_slow),
+        pytest.param((1, 1), 32768, 4096, 2048, 1.0, MISTRAL_7B, 0.999, id="1x1-2048-Mistral-7B", marks=_slow),
+        pytest.param((1, 1), 32768, 4096, 4096, 1.0, MISTRAL_7B, 0.999, id="1x1-4096-Mistral-7B", marks=_slow),
+        # (1,2) Llama-3.2-1B
+        pytest.param((1, 2), 128256, 2048, 32, 1.0, LLAMA_1B, 0.999, id="1x2-32-1B", marks=_slow),
+        pytest.param((1, 2), 128256, 2048, 128, 1.0, LLAMA_1B, 0.999, id="1x2-128-1B", marks=_slow),
+        pytest.param((1, 2), 128256, 2048, 1024, 1.0, LLAMA_1B, 0.999, id="1x2-1024-1B", marks=_slow),
+        pytest.param((1, 2), 128256, 2048, 2048, 1.0, LLAMA_1B, 0.999, id="1x2-2048-1B", marks=_slow),
+        pytest.param((1, 2), 128256, 2048, 4096, 1.0, LLAMA_1B, 0.999, id="1x2-4096-1B", marks=_slow),
+        pytest.param((1, 2), 128256, 2048, 8192, 1.0, LLAMA_1B, 0.999, id="1x2-8192-1B", marks=_slow),
+        # (1,2) Llama-3.2-3B
+        pytest.param((1, 2), 128256, 3072, 32, 1.0, LLAMA_3B, 0.999, id="1x2-32-3B", marks=_slow),
+        pytest.param((1, 2), 128256, 3072, 128, 1.0, LLAMA_3B, 0.999, id="1x2-128-3B", marks=_slow),
+        pytest.param((1, 2), 128256, 3072, 1024, 1.0, LLAMA_3B, 0.999, id="1x2-1024-3B", marks=_slow),
+        pytest.param((1, 2), 128256, 3072, 2048, 1.0, LLAMA_3B, 0.999, id="1x2-2048-3B", marks=_slow),
+        pytest.param((1, 2), 128256, 3072, 4096, 1.0, LLAMA_3B, 0.999, id="1x2-4096-3B", marks=_slow),
+        pytest.param((1, 2), 128256, 3072, 8192, 1.0, LLAMA_3B, 0.999, id="1x2-8192-3B", marks=_slow),
+        # (1,2) Llama-3.1-8B
+        pytest.param((1, 2), 128256, 4096, 1024, 1.0, LLAMA_8B, 0.999, id="1x2-1024-8B", marks=_slow),
+        pytest.param((1, 2), 128256, 4096, 2048, 1.0, LLAMA_8B, 0.999, id="1x2-2048-8B", marks=_slow),
+        pytest.param((1, 2), 128256, 4096, 4096, 1.0, LLAMA_8B, 0.999, id="1x2-4096-8B", marks=_slow),
+        pytest.param((1, 2), 128256, 4096, 8192, 1.0, LLAMA_8B, 0.999, id="1x2-8192-8B", marks=_slow),
+        # (1,2) Llama-3.2-11B
+        pytest.param((1, 2), 128256, 4096, 32, 1.0, LLAMA_11B, 0.999, id="1x2-32-11B", marks=_slow),
+        pytest.param((1, 2), 128256, 4096, 128, 1.0, LLAMA_11B, 0.999, id="1x2-128-11B", marks=_slow),
+        pytest.param((1, 2), 128256, 4096, 1024, 1.0, LLAMA_11B, 0.999, id="1x2-1024-11B", marks=_slow),
+        pytest.param((1, 2), 128256, 4096, 2048, 1.0, LLAMA_11B, 0.999, id="1x2-2048-11B", marks=_slow),
+        pytest.param((1, 2), 128256, 4096, 4096, 1.0, LLAMA_11B, 0.999, id="1x2-4096-11B", marks=_slow),
+        pytest.param((1, 2), 128256, 4096, 8192, 1.0, LLAMA_11B, 0.999, id="1x2-8192-11B", marks=_slow),
+        # (1,2) Mistral-7B
+        pytest.param((1, 2), 32768, 4096, 32, 1.0, MISTRAL_7B, 0.999, id="1x2-32-Mistral-7B", marks=_slow),
+        pytest.param((1, 2), 32768, 4096, 128, 1.0, MISTRAL_7B, 0.999, id="1x2-128-Mistral-7B", marks=_slow),
+        pytest.param((1, 2), 32768, 4096, 1024, 1.0, MISTRAL_7B, 0.999, id="1x2-1024-Mistral-7B", marks=_slow),
+        pytest.param((1, 2), 32768, 4096, 2048, 1.0, MISTRAL_7B, 0.999, id="1x2-2048-Mistral-7B", marks=_slow),
+        pytest.param((1, 2), 32768, 4096, 4096, 1.0, MISTRAL_7B, 0.999, id="1x2-4096-Mistral-7B", marks=_slow),
+        # (1,2) Qwen2-7B
+        pytest.param((1, 2), 152064, 3584, 32, 1.0, QWEN2_7B, 0.999, id="1x2-32-Qwen2-7B", marks=_slow),
+        pytest.param((1, 2), 152064, 3584, 1024, 1.0, QWEN2_7B, 0.999, id="1x2-1024-Qwen2-7B", marks=_slow),
+        pytest.param((1, 2), 152064, 3584, 2048, 1.0, QWEN2_7B, 0.999, id="1x2-2048-Qwen2-7B", marks=_slow),
+        pytest.param((1, 2), 152064, 3584, 4096, 1.0, QWEN2_7B, 0.999, id="1x2-4096-Qwen2-7B", marks=_slow),
+        # (1,2) Qwen2.5-7B
+        pytest.param((1, 2), 152064, 3584, 32, 1.0, QWEN25_7B, 0.999, id="1x2-32-Qwen2.5-7B", marks=_slow),
+        pytest.param((1, 2), 152064, 3584, 128, 1.0, QWEN25_7B, 0.999, id="1x2-128-Qwen2.5-7B", marks=_slow),
+        pytest.param((1, 2), 152064, 3584, 1024, 1.0, QWEN25_7B, 0.999, id="1x2-1024-Qwen2.5-7B", marks=_slow),
+        pytest.param((1, 2), 152064, 3584, 2048, 1.0, QWEN25_7B, 0.999, id="1x2-2048-Qwen2.5-7B", marks=_slow),
+        pytest.param((1, 2), 152064, 3584, 4096, 1.0, QWEN25_7B, 0.999, id="1x2-4096-Qwen2.5-7B", marks=_slow),
+        pytest.param((1, 2), 152064, 3584, 8192, 1.0, QWEN25_7B, 0.999, id="1x2-8192-Qwen2.5-7B", marks=_slow),
+        # (1,2) DeepSeek-R1-Distill-Qwen-14B
+        pytest.param((1, 2), 152064, 5120, 32, 1.0, DEEPSEEK_R1_14B, 0.999, id="1x2-32-DeepSeek-R1-14B", marks=_slow),
+        pytest.param((1, 2), 152064, 5120, 128, 1.0, DEEPSEEK_R1_14B, 0.999, id="1x2-128-DeepSeek-R1-14B", marks=_slow),
+        pytest.param((1, 2), 152064, 5120, 1024, 1.0, DEEPSEEK_R1_14B, 0.999, id="1x2-1024-DeepSeek-R1-14B", marks=_slow),
+        pytest.param((1, 2), 152064, 5120, 2048, 1.0, DEEPSEEK_R1_14B, 0.999, id="1x2-2048-DeepSeek-R1-14B", marks=_slow),
+        pytest.param((1, 2), 152064, 5120, 4096, 1.0, DEEPSEEK_R1_14B, 0.999, id="1x2-4096-DeepSeek-R1-14B", marks=_slow),
+        pytest.param((1, 2), 152064, 5120, 8192, 1.0, DEEPSEEK_R1_14B, 0.999, id="1x2-8192-DeepSeek-R1-14B", marks=_slow),
+        # (1,8) Llama-3.2-1B
+        pytest.param((1, 8), 128256, 2048, 32, 1.0, LLAMA_1B, 0.999, id="1x8-32-1B", marks=_slow),
+        pytest.param((1, 8), 128256, 2048, 128, 1.0, LLAMA_1B, 0.999, id="1x8-128-1B", marks=_slow),
+        pytest.param((1, 8), 128256, 2048, 1024, 1.0, LLAMA_1B, 0.999, id="1x8-1024-1B", marks=_slow),
+        pytest.param((1, 8), 128256, 2048, 2048, 1.0, LLAMA_1B, 0.999, id="1x8-2048-1B", marks=_slow),
+        pytest.param((1, 8), 128256, 2048, 4096, 1.0, LLAMA_1B, 0.999, id="1x8-4096-1B", marks=_slow),
+        pytest.param((1, 8), 128256, 2048, 8192, 1.0, LLAMA_1B, 0.999, id="1x8-8192-1B", marks=_slow),
+        # (1,8) Llama-3.2-3B
+        pytest.param((1, 8), 128256, 3072, 32, 1.0, LLAMA_3B, 0.999, id="1x8-32-3B", marks=_slow),
+        pytest.param((1, 8), 128256, 3072, 128, 1.0, LLAMA_3B, 0.999, id="1x8-128-3B", marks=_slow),
+        pytest.param((1, 8), 128256, 3072, 1024, 1.0, LLAMA_3B, 0.999, id="1x8-1024-3B", marks=_slow),
+        pytest.param((1, 8), 128256, 3072, 2048, 1.0, LLAMA_3B, 0.999, id="1x8-2048-3B", marks=_slow),
+        pytest.param((1, 8), 128256, 3072, 4096, 1.0, LLAMA_3B, 0.999, id="1x8-4096-3B", marks=_slow),
+        pytest.param((1, 8), 128256, 3072, 8192, 1.0, LLAMA_3B, 0.999, id="1x8-8192-3B", marks=_slow),
+        # (1,8) Llama-3.1-8B
+        pytest.param((1, 8), 128256, 4096, 32, 1.0, LLAMA_8B, 0.999, id="1x8-32-8B", marks=_slow),
+        pytest.param((1, 8), 128256, 4096, 128, 1.0, LLAMA_8B, 0.999, id="1x8-128-8B", marks=_slow),
+        pytest.param((1, 8), 128256, 4096, 1024, 1.0, LLAMA_8B, 0.999, id="1x8-1024-8B", marks=_slow),
+        pytest.param((1, 8), 128256, 4096, 2048, 1.0, LLAMA_8B, 0.999, id="1x8-2048-8B", marks=_slow),
+        pytest.param((1, 8), 128256, 4096, 4096, 1.0, LLAMA_8B, 0.999, id="1x8-4096-8B", marks=_slow),
+        pytest.param((1, 8), 128256, 4096, 8192, 1.0, LLAMA_8B, 0.999, id="1x8-8192-8B", marks=_slow),
+        # (1,8) Llama-3.2-11B
+        pytest.param((1, 8), 128256, 4096, 32, 1.0, LLAMA_11B, 0.999, id="1x8-32-11B", marks=_slow),
+        pytest.param((1, 8), 128256, 4096, 128, 1.0, LLAMA_11B, 0.999, id="1x8-128-11B", marks=_slow),
+        pytest.param((1, 8), 128256, 4096, 1024, 1.0, LLAMA_11B, 0.999, id="1x8-1024-11B", marks=_slow),
+        pytest.param((1, 8), 128256, 4096, 2048, 1.0, LLAMA_11B, 0.999, id="1x8-2048-11B", marks=_slow),
+        pytest.param((1, 8), 128256, 4096, 4096, 1.0, LLAMA_11B, 0.999, id="1x8-4096-11B", marks=_slow),
+        pytest.param((1, 8), 128256, 4096, 8192, 1.0, LLAMA_11B, 0.999, id="1x8-8192-11B", marks=_slow),
+        # (1,8) Llama-3.3-70B
+        pytest.param((1, 8), 128256, 8192, 1024, 1.0, LLAMA_70B, 0.999, id="1x8-1024-70B", marks=_slow),
+        pytest.param((1, 8), 128256, 8192, 2048, 1.0, LLAMA_70B, 0.999, id="1x8-2048-70B", marks=_slow),
+        pytest.param((1, 8), 128256, 8192, 4096, 1.0, LLAMA_70B, 0.999, id="1x8-4096-70B", marks=_slow),
+        # (1,8) Mistral-7B
+        pytest.param((1, 8), 32768, 4096, 32, 1.0, MISTRAL_7B, 0.999, id="1x8-32-Mistral-7B", marks=_slow),
+        pytest.param((1, 8), 32768, 4096, 128, 1.0, MISTRAL_7B, 0.999, id="1x8-128-Mistral-7B", marks=_slow),
+        pytest.param((1, 8), 32768, 4096, 1024, 1.0, MISTRAL_7B, 0.999, id="1x8-1024-Mistral-7B", marks=_slow),
+        pytest.param((1, 8), 32768, 4096, 2048, 1.0, MISTRAL_7B, 0.999, id="1x8-2048-Mistral-7B", marks=_slow),
+        pytest.param((1, 8), 32768, 4096, 4096, 1.0, MISTRAL_7B, 0.999, id="1x8-4096-Mistral-7B", marks=_slow),
+        # (1,8) Qwen2.5-72B
+        pytest.param((1, 8), 152064, 8192, 32, 1.0, QWEN25_72B, 0.999, id="1x8-32-Qwen2.5-72B", marks=_slow),
+        pytest.param((1, 8), 152064, 8192, 128, 1.0, QWEN25_72B, 0.999, id="1x8-128-Qwen2.5-72B", marks=_slow),
+        pytest.param((1, 8), 152064, 8192, 1024, 1.0, QWEN25_72B, 0.999, id="1x8-1024-Qwen2.5-72B", marks=_slow),
+        pytest.param((1, 8), 152064, 8192, 2048, 1.0, QWEN25_72B, 0.999, id="1x8-2048-Qwen2.5-72B", marks=_slow),
+        pytest.param((1, 8), 152064, 8192, 4096, 1.0, QWEN25_72B, 0.999, id="1x8-4096-Qwen2.5-72B", marks=_slow),
+        pytest.param((1, 8), 152064, 8192, 8192, 1.0, QWEN25_72B, 0.999, id="1x8-8192-Qwen2.5-72B", marks=_slow),
+        # (1,8) Qwen2.5-Coder-32B
+        pytest.param((1, 8), 152064, 5120, 32, 1.0, QWEN25_CODER_32B, 0.999, id="1x8-32-Qwen2.5-Coder-32B", marks=_slow),
+        pytest.param((1, 8), 152064, 5120, 128, 1.0, QWEN25_CODER_32B, 0.999, id="1x8-128-Qwen2.5-Coder-32B", marks=_slow),
+        pytest.param((1, 8), 152064, 5120, 1024, 1.0, QWEN25_CODER_32B, 0.999, id="1x8-1024-Qwen2.5-Coder-32B", marks=_slow),
+        pytest.param((1, 8), 152064, 5120, 2048, 1.0, QWEN25_CODER_32B, 0.999, id="1x8-2048-Qwen2.5-Coder-32B", marks=_slow),
+        pytest.param((1, 8), 152064, 5120, 4096, 1.0, QWEN25_CODER_32B, 0.999, id="1x8-4096-Qwen2.5-Coder-32B", marks=_slow),
+        # (1,8) Qwen3-32B
+        pytest.param((1, 8), 151936, 5120, 32, 1.0, QWEN3_32B, 0.999, id="1x8-32-Qwen3-32B", marks=_slow),
+        pytest.param((1, 8), 151936, 5120, 128, 1.0, QWEN3_32B, 0.999, id="1x8-128-Qwen3-32B", marks=_slow),
+        pytest.param((1, 8), 151936, 5120, 1024, 1.0, QWEN3_32B, 0.999, id="1x8-1024-Qwen3-32B", marks=_slow),
+        pytest.param((1, 8), 151936, 5120, 2048, 1.0, QWEN3_32B, 0.999, id="1x8-2048-Qwen3-32B", marks=_slow),
+        pytest.param((1, 8), 151936, 5120, 4096, 1.0, QWEN3_32B, 0.999, id="1x8-4096-Qwen3-32B", marks=_slow),
+    ]
+    # fmt: on
+
+
+@pytest.mark.parametrize(
+    "ttnn_mesh_device",
+    [(1, 1), (1, 2), (1, 8)],
+    ids=["1x1", "1x2", "1x8"],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "mesh_shape,vocab_size,dim,seq_len,embed_scale,hf_model_name,pcc",
+    _list_test_cases(),
+)
+def test_embedding_1d_vs_reference(
+    ttnn_mesh_device: ttnn.MeshDevice,
+    mesh_shape,
+    vocab_size,
+    dim,
+    seq_len,
+    embed_scale,
+    hf_model_name,
+    pcc,
+):
+    """
+    Test Embedding1D constructed via direct APIs matches torch.nn.Embedding reference.
+    """
+    seed = 42
+    torch.manual_seed(seed)
+
+    # Get or create deterministic random embedding weight
+    weight_torch = _get_or_init_embedding_weight(hf_model_name, vocab_size, dim)
+
+    # Reference: torch.nn.Embedding
+    ref_embedding = torch.nn.Embedding(vocab_size, dim)
+    with torch.no_grad():
+        ref_embedding.weight.copy_(weight_torch)
+
+    # Input: random token IDs
+    input_ids = torch.randint(0, vocab_size, (1, seq_len), dtype=torch.int64)
+
+    # Reference output
+    with torch.no_grad():
+        ref_output = ref_embedding(input_ids)  # [1, seq_len, dim]
+        if embed_scale != 1.0:
+            ref_output = ref_output * embed_scale
+
+    # Build Embedding1D TT model
+    # Weight shape for TTNN: [1, 1, vocab_size, dim] to match TTTv1 convention
+    weight_4d = weight_torch.unsqueeze(0).unsqueeze(0)  # [1, 1, vocab_size, dim]
+
+    ttnn.SetDefaultDevice(ttnn_mesh_device)
+    cache_dir = Path(os.getenv("TT_CACHE_PATH", "model_cache/embedding"))
+    lazy_weights = LazyWeight(
+        source=weight_4d,
+        dtype=ttnn.bfloat16,
+        cache_dir_weight_name=(cache_dir, "weights"),
+    )
+
+    tt_model = Embedding1D(weights=lazy_weights, embed_scale=embed_scale)
+
+    # Input: reshape to [1, 1, 1, seq_len] uint32 for TTNN, wrap in LazyWeight
+    input_ids_4d = input_ids.reshape(1, 1, 1, seq_len).to(torch.int32)
+    lazy_input = LazyWeight(
+        source=input_ids_4d,
+        dtype=ttnn.uint32,
+    )
+
+    tt_output = tt_model.forward(lazy_input)
+    tt_output_torch = to_torch_auto_compose(tt_output)
+    ttnn.SetDefaultDevice(None)
+
+    # Reshape for comparison: tt output is [1, 1, seq_len, dim/num_devices] per shard
+    # auto_compose concatenates shards -> [1, 1, seq_len, dim]
+    # ref output is [1, seq_len, dim]
+    tt_output_torch = tt_output_torch.squeeze(0)  # remove leading batch dim if present
+
+    # Handle shape differences: ref is [1, seq_len, dim], tt might be [1, seq_len, padded_dim]
+    if tt_output_torch.shape[-1] > ref_output.shape[-1]:
+        tt_output_torch = tt_output_torch[..., : ref_output.shape[-1]]
+
+    # Ensure shapes match
+    if tt_output_torch.dim() == 3 and ref_output.dim() == 2:
+        ref_output = ref_output.unsqueeze(0)
+    elif tt_output_torch.dim() == 2 and ref_output.dim() == 3:
+        tt_output_torch = tt_output_torch.unsqueeze(0)
+
+    passing, pcc_message = comp_pcc(ref_output, tt_output_torch, pcc)
+    logger.info(comp_allclose(ref_output, tt_output_torch))
+    logger.info(f"Embedding1D PCC vs reference: {pcc_message}")
+
+    assert passing, f"Embedding1D output does not meet PCC requirement {pcc}: {pcc_message}."
+    logger.info(f"Embedding1D vs reference: PASSED for seq_len={seq_len}, vocab={vocab_size}, dim={dim}")
+
+
+# ============================================================================
+# from_model_args backward compatibility test
+# ============================================================================
+
+
+@pytest.mark.parametrize(
+    "ttnn_mesh_device",
+    [
+        (1, 1),
+        (1, 2),
+        (1, 8),
+    ],
+    ids=["1x1", "1x2", "1x8"],
+    indirect=True,
+)
+@pytest.mark.parametrize("seq_len", [32, 128])
+def test_embedding_1d_vs_reference_from_model_args(ttnn_mesh_device: ttnn.MeshDevice, seq_len):
+    """
+    Test that Embedding1D.from_model_args matches torch.nn.Embedding reference.
+
+    Uses HF_MODEL env var or defaults to Llama-3.1-8B-Instruct.
+    """
+    from models.tt_transformers.tt.model_config import ModelArgs
+
+    dtype = ttnn.bfloat16
+
+    model_args = ModelArgs(ttnn_mesh_device, max_batch_size=1, max_seq_len=128, cache_hf=True)
+    model_args.n_layers = 1
+
+    if model_args.is_galaxy:
+        pytest.skip("Embedding1D test only runs on non-TG devices")
+
+    state_dict = model_args.load_state_dict()
+
+    # Get reference embedding weight from state dict
+    base_name = model_args.get_state_dict_prefix("", None) + "tok_embeddings.weight"
+    ref_weight = state_dict[base_name]
+    vocab_size, dim = ref_weight.shape
+
+    # Reference model
+    ref_embedding = torch.nn.Embedding(vocab_size, dim)
+    with torch.no_grad():
+        ref_embedding.weight.copy_(ref_weight.to(torch.bfloat16))
+
+    # Build TT model via from_model_args
+    def topology_aware_cache_path():
+        return model_args.model_cache_path / f"tensor_cache_bf16_{ttnn_mesh_device.shape}"
+
+    tt_model = Embedding1D.from_model_args(
+        mesh_device=ttnn_mesh_device,
+        args=model_args,
+        weight_cache_path=topology_aware_cache_path(),
+        state_dict=state_dict,
+        dtype=dtype,
+    )
+
+    # Input tokens
+    torch.manual_seed(42)
+    input_ids = torch.randint(0, vocab_size, (1, seq_len), dtype=torch.int64)
+
+    # Reference output
+    with torch.no_grad():
+        ref_output = ref_embedding(input_ids)  # [1, seq_len, dim]
+
+    # TT input: [1, 1, 1, seq_len] uint32
+    tt_input = ttnn.from_torch(
+        input_ids.reshape(1, 1, 1, seq_len).to(torch.int32),
+        device=ttnn_mesh_device,
+        dtype=ttnn.uint32,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        mesh_mapper=ttnn.replicate_tensor_to_mesh_mapper(ttnn_mesh_device),
+    )
+
+    tt_output = tt_model.forward(tt_input)
+    tt_output_torch = to_torch_auto_compose(tt_output)
+
+    # Shape: tt is [1, 1, seq_len, dim/N] per shard, composed to [1, 1, seq_len, dim]
+    # Trim padding if needed
+    if tt_output_torch.shape[-1] > dim:
+        tt_output_torch = tt_output_torch[..., :dim]
+
+    # Flatten to [1, seq_len, dim] for comparison
+    tt_output_torch = tt_output_torch.view(1, seq_len, dim)
+
+    pcc_required = 0.999
+    passing, pcc_message = comp_pcc(ref_output, tt_output_torch, pcc_required)
+    logger.info(comp_allclose(ref_output, tt_output_torch))
+    logger.info(f"Embedding1D (from_model_args) PCC vs reference: {pcc_message}")
+
+    assert passing, f"Embedding1D output does not meet PCC requirement {pcc_required}: {pcc_message}."
+    logger.info(f"Embedding1D (from_model_args) vs reference: PASSED for seq_len={seq_len}")
+
+
+# ============================================================================
+# ttnn.Tensor input path test (forward accepts ttnn.Tensor | LazyWeight)
+# ============================================================================
+
+
+@pytest.mark.parametrize(
+    "ttnn_mesh_device",
+    [(1, 1)],
+    ids=["1x1"],
+    indirect=True,
+)
+def test_embedding_1d_forward_with_ttnn_tensor_input(ttnn_mesh_device: ttnn.MeshDevice):
+    """
+    Test that Embedding1D.forward() works when x is a pre-built ttnn.Tensor (not LazyWeight).
+
+    This covers the ttnn.Tensor branch of the forward(x: ttnn.Tensor | LazyWeight) signature.
+    """
+    torch.manual_seed(42)
+    vocab_size, dim, seq_len = 1024, 128, 32
+
+    weight_torch = torch.randn(1, 1, vocab_size, dim, dtype=torch.bfloat16)
+    input_ids = torch.randint(0, vocab_size, (1, seq_len), dtype=torch.int64)
+
+    # Reference
+    ref_embedding = torch.nn.Embedding(vocab_size, dim)
+    with torch.no_grad():
+        ref_embedding.weight.copy_(weight_torch.squeeze(0).squeeze(0))
+    ref_output = ref_embedding(input_ids)  # [1, seq_len, dim]
+
+    # Build TT model
+    ttnn.SetDefaultDevice(ttnn_mesh_device)
+    lazy_weights = LazyWeight(source=weight_torch, dtype=ttnn.bfloat16)
+    tt_model = Embedding1D(weights=lazy_weights)
+
+    # Pass a pre-built ttnn.Tensor as input (not LazyWeight)
+    tt_input = ttnn.from_torch(
+        input_ids.reshape(1, 1, 1, seq_len).to(torch.int32),
+        device=ttnn_mesh_device,
+        dtype=ttnn.uint32,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        mesh_mapper=ttnn.replicate_tensor_to_mesh_mapper(ttnn_mesh_device),
+    )
+
+    tt_output = tt_model.forward(tt_input)
+    tt_output_torch = to_torch_auto_compose(tt_output)
+    ttnn.SetDefaultDevice(None)
+
+    tt_output_torch = tt_output_torch.view(1, seq_len, dim)
+
+    pcc_required = 0.999
+    passing, pcc_message = comp_pcc(ref_output, tt_output_torch, pcc_required)
+    logger.info(f"Embedding1D (ttnn.Tensor input) PCC vs reference: {pcc_message}")
+
+    assert passing, f"Embedding1D ttnn.Tensor input PCC failed: {pcc_message}."

--- a/models/experimental/llama32_1b_quasar/tests/modules/lm_head/test_lm_head_1d.py
+++ b/models/experimental/llama32_1b_quasar/tests/modules/lm_head/test_lm_head_1d.py
@@ -1,0 +1,411 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Tests for the LMHead1D module (1D mesh topology: N150, N300, T3K).
+
+This test suite verifies:
+1. Unit tests for config dataclass (no device needed)
+2. LMHead1D matches torch.nn.Linear reference for logit computation
+3. from_model_args backward compatibility
+"""
+
+import math
+import os
+from pathlib import Path
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+from models.experimental.llama32_1b_quasar.auto_compose import to_torch_auto_compose
+from models.experimental.llama32_1b_quasar.modules.lazy_weight import LazyWeight
+from models.experimental.llama32_1b_quasar.modules.lm_head.lm_head_1d import LMHead1D, LMHead1DConfig
+from models.experimental.llama32_1b_quasar.tensor_utils import TILE_SIZE
+from models.experimental.llama32_1b_quasar.utility_functions import comp_allclose, comp_pcc
+
+# ============================================================================
+# Unit Tests - No device required
+# ============================================================================
+
+
+def test_lm_head_1d_config_creation():
+    """Test LMHead1DConfig dataclass creation."""
+    from unittest.mock import MagicMock
+
+    config = LMHead1DConfig(
+        output_weights=[MagicMock()],
+        mesh_device=MagicMock(),
+        dim=4096,
+    )
+    assert config.dim == 4096
+    assert config.lm_head_dtype == ttnn.bfloat8_b
+    assert config.max_batch_size == 32
+
+
+def test_lm_head_1d_config_defaults():
+    """Test LMHead1DConfig default values."""
+    from unittest.mock import MagicMock
+
+    config = LMHead1DConfig(output_weights=[MagicMock()])
+    assert config.mesh_device is None
+    assert config.program_configs is None
+    assert config.compute_kernel_config is None
+    assert config.lm_head_dtype == ttnn.bfloat8_b
+    assert config.output_memcfg is None
+    assert config.input_memcfg is None
+    assert config.weights_memcfgs is None
+
+
+def test_lm_head_1d_config_is_resolved_all_fields():
+    """Test is_resolved() when all fields are set."""
+    from unittest.mock import MagicMock
+
+    mock_device = MagicMock()
+    mock_device.get_num_devices.return_value = 1
+
+    config = LMHead1DConfig(
+        output_weights=[MagicMock()],
+        mesh_device=mock_device,
+        dim=4096,
+        program_configs=[None],
+        compute_kernel_config=MagicMock(),
+        output_memcfg=MagicMock(),
+        input_memcfg=MagicMock(),
+        weights_memcfgs=[MagicMock()],
+    )
+    assert config.is_resolved()
+
+
+def test_compute_kernel_config_hifi2():
+    """Test _compute_kernel_config_hifi2 returns valid config."""
+    from models.experimental.llama32_1b_quasar.modules.lm_head.lm_head_1d import _compute_kernel_config_hifi2
+
+    cfg = _compute_kernel_config_hifi2()
+    assert cfg.math_fidelity == ttnn.MathFidelity.HiFi2
+    assert cfg.packer_l1_acc is True
+    assert cfg.fp32_dest_acc_en is False
+
+
+def test_create_dram_sharded_mem_config():
+    """Test _create_dram_sharded_mem_config produces valid MemoryConfig."""
+    from models.experimental.llama32_1b_quasar.modules.lm_head.lm_head_1d import _create_dram_sharded_mem_config
+
+    dram_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(11, 0))})
+    mc = _create_dram_sharded_mem_config(k=4096, n=16032, dram_grid=dram_grid, dram_cores=12)
+    assert mc.is_sharded()
+    assert mc.memory_layout == ttnn.TensorMemoryLayout.WIDTH_SHARDED
+    assert mc.buffer_type == ttnn.BufferType.DRAM
+
+
+def test_from_model_args_rejects_galaxy(expect_error):
+    """Test from_model_args raises for Galaxy devices."""
+    from unittest.mock import MagicMock
+
+    mock_args = MagicMock()
+    mock_args.is_galaxy = True
+
+    with expect_error(ValueError, "Galaxy"):
+        LMHead1D.from_model_args(
+            mesh_device=MagicMock(),
+            args=mock_args,
+            state_dict={},
+            state_dict_prefix="",
+            weight_cache_path="",
+            max_columns_per_device=32000,
+        )
+
+
+# ============================================================================
+# Weight helpers
+# ============================================================================
+
+_CACHED_LM_WEIGHTS: dict[str, torch.Tensor] = {}
+
+
+def _get_or_init_lm_weight(key: str, dim: int, vocab_size: int) -> torch.Tensor:
+    if key not in _CACHED_LM_WEIGHTS:
+        logger.info(f"\033[33m[cache miss]\033[0m Initializing LM head weight for {key}")
+        _CACHED_LM_WEIGHTS[key] = torch.randn(vocab_size, dim, dtype=torch.bfloat16)
+    else:
+        logger.info(f"\033[32m[cache hit]\033[0m Reusing cached LM head weight for {key}")
+    return _CACHED_LM_WEIGHTS[key]
+
+
+def _prepare_lm_head_weights(
+    weight: torch.Tensor, vocab_size: int, dim: int, num_devices: int, max_columns_per_device: int
+) -> list[torch.Tensor]:
+    """Split LM head weight into chunks matching TTTv1 logic (non-TG path)."""
+    padded_vocab_size = math.ceil(vocab_size / 32) * 32
+    size_per_device = padded_vocab_size // num_devices
+    num_splits = math.ceil(size_per_device / max_columns_per_device)
+    split_sizes = [min(size_per_device, max_columns_per_device)] * (num_splits - 1)
+    split_sizes.append(size_per_device - sum(split_sizes))
+
+    # Transpose to (dim, vocab) and pad
+    torch_w = weight.T  # (dim, vocab_size)
+    if vocab_size < padded_vocab_size:
+        torch_w = torch.cat([torch_w, torch.zeros(dim, padded_vocab_size - vocab_size, dtype=torch_w.dtype)], dim=-1)
+
+    splits = []
+    for i, split_size in enumerate(split_sizes):
+        device_splits = []
+        for dev in range(num_devices):
+            start = dev * size_per_device + sum(split_sizes[:i])
+            end = start + split_size
+            device_splits.append(torch_w[:, start:end])
+        splits.append(torch.cat(device_splits, dim=-1))
+
+    return splits
+
+
+# ============================================================================
+# Model names from HF to cover in tests
+# ============================================================================
+
+LLAMA_1B = "meta-llama/Llama-3.2-1B-Instruct"
+LLAMA_3B = "meta-llama/Llama-3.2-3B-Instruct"
+LLAMA_8B = "meta-llama/Llama-3.1-8B-Instruct"
+LLAMA_11B = "meta-llama/Llama-3.2-11B-Vision-Instruct"
+LLAMA_70B = "meta-llama/Llama-3.3-70B-Instruct"
+MISTRAL_7B = "mistralai/Mistral-7B-Instruct-v0.3"
+QWEN2_7B = "Qwen/Qwen2-7B-Instruct"
+QWEN25_7B = "Qwen/Qwen2.5-7B-Instruct"
+QWEN25_72B = "Qwen/Qwen2.5-72B-Instruct"
+QWEN25_CODER_32B = "Qwen/Qwen2.5-Coder-32B-Instruct"
+QWEN3_32B = "Qwen/Qwen3-32B"
+DEEPSEEK_R1_14B = "deepseek-ai/DeepSeek-R1-Distill-Qwen-14B"
+
+
+_slow = pytest.mark.slow
+
+
+def _list_test_cases() -> list[pytest.param]:
+    # max_columns_per_device derived from TTTv1: 668 * lm_head_core_grid.num_cores
+    # For simplicity, use the actual split counts from CSV
+    # fmt: off
+    return [
+        # === Fast tests ===
+        # 1x1 Llama-3.1-8B: 3 splits (dim=4096, padded_vocab=128256)
+        pytest.param((1, 1), 4096, 128256, 42752, LLAMA_8B, 0.999, id="1x1-8B"),
+        # 1x2 Llama-3.1-8B: 2 splits
+        pytest.param((1, 2), 4096, 128256, 42752, LLAMA_8B, 0.999, id="1x2-8B"),
+        # 1x8 Llama-3.1-8B: 1 split
+        pytest.param((1, 8), 4096, 128256, 16032, LLAMA_8B, 0.999, id="1x8-8B"),
+        # 1x8 Llama-3.3-70B: 1 split (dim=8192)
+        pytest.param((1, 8), 8192, 128256, 16032, LLAMA_70B, 0.999, id="1x8-70B"),
+
+        # === Slow tests ===
+        # 1x1 Llama-3.2-1B: 3 splits (dim=2048)
+        pytest.param((1, 1), 2048, 128256, 42752, LLAMA_1B, 0.999, id="1x1-1B", marks=_slow),
+        # 1x1 Llama-3.2-3B: 4 splits (dim=3072)
+        pytest.param((1, 1), 3072, 128256, 32064, LLAMA_3B, 0.999, id="1x1-3B", marks=_slow),
+        # 1x1 Mistral-7B: 1 split (dim=4096, vocab=32768)
+        pytest.param((1, 1), 4096, 32768, 32768, MISTRAL_7B, 0.999, id="1x1-Mistral-7B", marks=_slow),
+        # 1x2 Llama-3.2-1B: 2 splits
+        pytest.param((1, 2), 2048, 128256, 42752, LLAMA_1B, 0.999, id="1x2-1B", marks=_slow),
+        # 1x2 Llama-3.2-3B: 2 splits
+        pytest.param((1, 2), 3072, 128256, 32064, LLAMA_3B, 0.999, id="1x2-3B", marks=_slow),
+        # 1x2 Llama-3.2-11B: 2 splits
+        pytest.param((1, 2), 4096, 128256, 42752, LLAMA_11B, 0.999, id="1x2-11B", marks=_slow),
+        # 1x2 Mistral-7B: 1 split
+        pytest.param((1, 2), 4096, 32768, 16384, MISTRAL_7B, 0.999, id="1x2-Mistral-7B", marks=_slow),
+        # 1x2 Qwen2-7B: 3 splits (dim=3584, vocab=152064)
+        pytest.param((1, 2), 3584, 152064, 37408, QWEN2_7B, 0.999, id="1x2-Qwen2-7B", marks=_slow),
+        # 1x2 DeepSeek-R1-14B: 3 splits (dim=5120, vocab=152064)
+        pytest.param((1, 2), 5120, 152064, 26720, DEEPSEEK_R1_14B, 0.999, id="1x2-DeepSeek-R1-14B", marks=_slow),
+        # 1x2 Qwen2.5-7B: 3 splits
+        pytest.param((1, 2), 3584, 152064, 37408, QWEN25_7B, 0.999, id="1x2-Qwen2.5-7B", marks=_slow),
+        # 1x8 Llama-3.2-1B: 1 split
+        pytest.param((1, 8), 2048, 128256, 16032, LLAMA_1B, 0.999, id="1x8-1B", marks=_slow),
+        # 1x8 Llama-3.2-3B: 1 split
+        pytest.param((1, 8), 3072, 128256, 16032, LLAMA_3B, 0.999, id="1x8-3B", marks=_slow),
+        # 1x8 Llama-3.2-11B: 1 split
+        pytest.param((1, 8), 4096, 128256, 16032, LLAMA_11B, 0.999, id="1x8-11B", marks=_slow),
+        # 1x8 Qwen2.5-72B: 1 split (dim=8192, vocab=152064)
+        pytest.param((1, 8), 8192, 152064, 19008, QWEN25_72B, 0.999, id="1x8-Qwen2.5-72B", marks=_slow),
+        # 1x8 Qwen2.5-Coder-32B: 1 split (dim=5120)
+        pytest.param((1, 8), 5120, 152064, 19008, QWEN25_CODER_32B, 0.999, id="1x8-Qwen2.5-Coder-32B", marks=_slow),
+        # 1x8 Qwen3-32B: 1 split (dim=5120, vocab=151936)
+        pytest.param((1, 8), 5120, 151936, 18992, QWEN3_32B, 0.999, id="1x8-Qwen3-32B", marks=_slow),
+        # 1x8 Mistral-7B: 1 split
+        pytest.param((1, 8), 4096, 32768, 4096, MISTRAL_7B, 0.999, id="1x8-Mistral-7B", marks=_slow),
+    ]
+    # fmt: on
+
+
+@pytest.mark.parametrize(
+    "ttnn_mesh_device",
+    [(1, 1), (1, 2), (1, 8)],
+    ids=["1x1", "1x2", "1x8"],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "mesh_shape,dim,vocab_size,max_col_per_dev,hf_model_name,pcc",
+    _list_test_cases(),
+)
+def test_lm_head_1d_vs_reference(
+    ttnn_mesh_device: ttnn.MeshDevice,
+    mesh_shape,
+    dim,
+    vocab_size,
+    max_col_per_dev,
+    hf_model_name,
+    pcc,
+):
+    """
+    Test LMHead1D output shape and basic numerical correctness.
+
+    Uses random weights split per TTTv1 logic, verifies output is non-zero
+    and has correct shape.
+    """
+    seed = 42
+    torch.manual_seed(seed)
+    batch_rows = 32  # tile_padded_batch_rows for batch_size=1
+    num_devices = ttnn_mesh_device.get_num_devices()
+
+    # Get reference weight
+    key = f"{hf_model_name}_{vocab_size}_{dim}"
+    full_weight = _get_or_init_lm_weight(key, dim, vocab_size)
+
+    # Reference: torch.nn.Linear (no bias), in bfloat16
+    ref_linear = torch.nn.Linear(dim, vocab_size, bias=False, dtype=torch.bfloat16)
+    with torch.no_grad():
+        ref_linear.weight.copy_(full_weight)
+
+    # Reference output
+    torch_input = torch.randn(1, 1, batch_rows, dim, dtype=torch.bfloat16)
+    with torch.no_grad():
+        ref_output = ref_linear(torch_input)  # [1, 1, 32, vocab_size]
+
+    # Split weights for TT model
+    weight_splits = _prepare_lm_head_weights(full_weight, vocab_size, dim, num_devices, max_col_per_dev)
+
+    # Create LazyWeights (cache-backed for faster repeated runs)
+    ttnn.SetDefaultDevice(ttnn_mesh_device)
+    cache_dir = Path(os.getenv("TT_CACHE_PATH", "model_cache/lm_head_1d"))
+    lazy_weights = []
+    for i, split in enumerate(weight_splits):
+        lazy_weights.append(
+            LazyWeight(source=split, dtype=ttnn.bfloat8_b, cache_dir_weight_name=(cache_dir, f"w_split_{i}"))
+        )
+
+    tt_model = LMHead1D(output_weights=lazy_weights)
+
+    # Run TT model
+    tt_input = LazyWeight(source=torch_input, dtype=ttnn.bfloat16)
+    tt_output = tt_model.forward(tt_input)
+    tt_output_torch = to_torch_auto_compose(tt_output)
+    ttnn.SetDefaultDevice(None)
+
+    # Shape checks
+    assert tt_output_torch.shape[-2] == batch_rows, f"Expected batch_rows={batch_rows}, got {tt_output_torch.shape[-2]}"
+    assert tt_output_torch.shape[-1] >= vocab_size, (
+        f"Expected vocab cols>={vocab_size}, got {tt_output_torch.shape[-1]}. " f"num_devices={num_devices}"
+    )
+
+    # PCC against torch reference (trim to actual vocab_size, ignore padding zeros)
+    ref_trimmed = ref_output[..., :vocab_size]
+    tt_trimmed = tt_output_torch[..., :vocab_size]
+
+    passing, pcc_message = comp_pcc(ref_trimmed, tt_trimmed, pcc)
+    logger.info(comp_allclose(ref_trimmed, tt_trimmed))
+    logger.info(f"LMHead1D vs reference: {pcc_message}")
+    assert passing, f"LMHead1D output does not meet PCC {pcc}: {pcc_message}."
+    logger.info(f"LMHead1D: PASSED for {hf_model_name} (mesh={mesh_shape}, devices={num_devices})")
+
+
+# ============================================================================
+# from_model_args backward compatibility test
+# ============================================================================
+
+
+@pytest.mark.parametrize(
+    "ttnn_mesh_device",
+    [(1, 1), (1, 2), (1, 8)],
+    ids=["1x1", "1x2", "1x8"],
+    indirect=True,
+)
+def test_lm_head_1d_vs_reference_from_model_args(ttnn_mesh_device: ttnn.MeshDevice):
+    """
+    Test LMHead1D.from_model_args produces valid output.
+    """
+    from models.tt_transformers.tt.model_config import ModelArgs
+
+    model_args = ModelArgs(ttnn_mesh_device, max_batch_size=1, max_seq_len=128, cache_hf=True)
+    model_args.n_layers = 1
+
+    if model_args.is_galaxy:
+        pytest.skip("LMHead1D test only runs on non-TG devices")
+
+    state_dict = model_args.load_state_dict()
+    state_dict_prefix = model_args.get_state_dict_prefix("", None)
+
+    def topology_aware_cache_path():
+        return model_args.model_cache_path / f"tensor_cache_bfp8_{ttnn_mesh_device.shape}"
+
+    max_columns = getattr(model_args, "max_columns_per_device_lm_head", 128256 // 4)
+
+    tt_model = LMHead1D.from_model_args(
+        mesh_device=ttnn_mesh_device,
+        args=model_args,
+        state_dict=state_dict,
+        state_dict_prefix=state_dict_prefix,
+        weight_cache_path=topology_aware_cache_path(),
+        max_columns_per_device=max_columns,
+        dtype=ttnn.bfloat8_b,
+    )
+
+    # Create input in the correct memory config for LM head (width-sharded matching lm_head_core_grid)
+    batch_rows = TILE_SIZE * math.ceil(model_args.max_batch_size / TILE_SIZE)
+    torch_input = torch.randn(1, 1, batch_rows, model_args.dim, dtype=torch.bfloat16)
+
+    def _nearest_32(x):
+        return math.ceil(x / 32) * 32
+
+    input_memcfg = ttnn.create_sharded_memory_config(
+        (
+            batch_rows,
+            _nearest_32(model_args.dim // model_args.lm_head_core_grid.num_cores),
+        ),
+        model_args.lm_head_core_grid,
+        ttnn.ShardStrategy.WIDTH,
+        ttnn.ShardOrientation.ROW_MAJOR,
+        use_height_and_width_as_shard_shape=True,
+    )
+    tt_input = ttnn.from_torch(
+        torch_input,
+        device=ttnn_mesh_device,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=input_memcfg,
+        mesh_mapper=ttnn.ShardTensor2dMesh(ttnn_mesh_device, dims=(None, None), mesh_shape=model_args.cluster_shape),
+    )
+
+    tt_output = tt_model.forward(tt_input)
+    tt_output_torch = to_torch_auto_compose(tt_output)
+
+    # Shape checks
+    num_devices = ttnn_mesh_device.get_num_devices()
+    assert tt_output_torch.shape[-2] == batch_rows, f"Expected batch_rows={batch_rows}, got {tt_output_torch.shape[-2]}"
+    assert tt_output_torch.shape[-1] >= model_args.vocab_size, (
+        f"Expected vocab cols>={model_args.vocab_size}, got {tt_output_torch.shape[-1]}. " f"num_devices={num_devices}"
+    )
+
+    # PCC against torch reference
+    ref_weight = state_dict[f"{state_dict_prefix}output.weight"]
+    ref_linear = torch.nn.Linear(model_args.dim, model_args.vocab_size, bias=False, dtype=torch.bfloat16)
+    with torch.no_grad():
+        ref_linear.weight.copy_(ref_weight.to(torch.bfloat16))
+        ref_output = ref_linear(torch_input)
+
+    ref_trimmed = ref_output[..., : model_args.vocab_size]
+    tt_trimmed = tt_output_torch[..., : model_args.vocab_size]
+
+    pcc_required = 0.999
+    passing, pcc_message = comp_pcc(ref_trimmed, tt_trimmed, pcc_required)
+    logger.info(comp_allclose(ref_trimmed, tt_trimmed))
+    logger.info(f"LMHead1D (from_model_args) vs reference: {pcc_message}")
+    assert passing, f"LMHead1D from_model_args PCC {pcc_required} not met: {pcc_message}."
+    logger.info(f"LMHead1D.from_model_args: PASSED for {model_args.model_name}")

--- a/models/experimental/llama32_1b_quasar/tests/modules/mlp/test_mlp_1d.py
+++ b/models/experimental/llama32_1b_quasar/tests/modules/mlp/test_mlp_1d.py
@@ -1,0 +1,815 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Tests for the MLP1D module (1D mesh topology: N150, N300, T3K).
+
+This test suite verifies:
+1. Unit tests for config dataclasses (no device needed)
+2. MLP1D class matches HuggingFace/Meta reference model
+3. MLP1D correctly rejects TG/Galaxy devices
+"""
+
+import math
+import os
+from functools import lru_cache
+from pathlib import Path
+
+import pytest
+import torch
+from loguru import logger
+from transformers import AutoConfig, AutoModelForCausalLM
+
+# transformers 5.x moved no_init_weights to transformers.initialization; fall back
+# to the old location for transformers < 5.x.
+try:
+    from transformers.initialization import no_init_weights
+except ImportError:
+    from transformers.modeling_utils import no_init_weights
+
+import ttnn
+from models.experimental.llama32_1b_quasar.auto_compose import to_torch_auto_compose
+from models.experimental.llama32_1b_quasar.modules.lazy_weight import LazyWeight
+from models.experimental.llama32_1b_quasar.modules.mlp.mlp_1d import MLP1D, MLP1DConfig, _matmul_config
+from models.experimental.llama32_1b_quasar.tensor_utils import TILE_SIZE
+from models.experimental.llama32_1b_quasar.utility_functions import comp_allclose, comp_pcc
+from models.tt_transformers.tt.common import Mode
+
+
+def get_mlp_weights_from_ref_model(reference_mlp) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """
+    Extract w1, w2, w3 weights from a reference MLP module in TTNN layout (transposed).
+
+    Handles both standard LLaMA-style MLPs (gate_proj, up_proj, down_proj) and
+    fused gate_up_proj models (Phi-3/Phi-4).
+
+    Returns:
+        (w1, w2, w3) tensors in TTNN layout: (in_features, out_features)
+    """
+    if hasattr(reference_mlp, "gate_proj"):
+        w1_torch = reference_mlp.gate_proj.weight.T  # (dim, hidden_dim)
+        w3_torch = reference_mlp.up_proj.weight.T  # (dim, hidden_dim)
+    elif hasattr(reference_mlp, "gate_up_proj"):
+        # Handle models like Phi-3/Phi-4 that use fused gate_up_proj
+        gate_up_weight = reference_mlp.gate_up_proj.weight
+        hidden_dim = gate_up_weight.shape[0] // 2
+        w1_torch = gate_up_weight[:hidden_dim, :].T  # (dim, hidden_dim)
+        w3_torch = gate_up_weight[hidden_dim:, :].T  # (dim, hidden_dim)
+    else:
+        raise AttributeError(f"Reference MLP {type(reference_mlp)} has no gate_proj or gate_up_proj")
+
+    w2_torch = reference_mlp.down_proj.weight.T  # (hidden_dim, dim)
+    return w1_torch, w2_torch, w3_torch
+
+
+def _get_prefill_len_cutoff(hf_model_name: str, mesh_shape: tuple[int, int]) -> int | None:
+    """
+    Get model/device-specific prefill_len_cutoff override.
+
+    Root cause:
+        The matmul program config computes per_core_M = ceil(m / (tile_size * grid_height)),
+        where m = min(seq_len, prefill_len_cutoff). Larger per_core_M requires more L1 memory
+        for circular buffers. Combined with in0_block_w=8 and BFP8 weights, certain model/device
+        combinations overflow L1.
+
+    Symptom:
+        RuntimeError: TT_FATAL ... "Statically allocated circular buffers ... grow to ...
+        beyond max L1 size"
+
+    Fix:
+        Reduce prefill_len_cutoff from 1024 to 512 for affected models. This halves m,
+        reducing per_core_M (e.g., from 4 to 2), which fits in L1.
+
+    Matches tt_transformers/tt/model_config.py:577-584 logic:
+    - Llama-3.1-8B, Llama-3.2-11B, Mistral-7B, gemma-3-4b on N150 (1x1) → 512
+    - Qwen2.5-7B on N300 (1x2) → 512
+    - Mixtral-8x7B on T3K (1x8) → 512
+    - Others → None (use default)
+    """
+    # Extract base model name from HF model name
+    base_name = hf_model_name.split("/")[-1].rsplit("-Instruct", 1)[0]
+
+    # Map mesh_shape to device type
+    if mesh_shape == (1, 1):
+        device = "N150"
+    elif mesh_shape == (1, 2):
+        device = "N300"
+    elif mesh_shape == (1, 8):
+        device = "T3K"
+    else:
+        device = None
+
+    # Apply model_config.py logic
+    if base_name in ["Llama-3.1-8B", "Llama-3.2-11B", "Mistral-7B", "gemma-3-4b"] and device == "N150":
+        return 512
+    elif base_name in ["Qwen2.5-7B"] and device == "N300":
+        return 512
+    elif base_name in ["Mixtral-8x7B"] and device == "T3K":
+        return 512
+
+    return None  # Use default
+
+
+# ============================================================================
+# Weight Caching - Avoid expensive torch.randn_like() per test
+# ============================================================================
+
+_CACHED_MLP_WEIGHTS: dict[str, dict[str, torch.Tensor]] = {}
+
+
+def _get_or_init_mlp_weights(model_name: str, reference_mlp) -> None:
+    """Initialize MLP weights once per model, cache and reuse across tests.
+
+    torch.randn_like() is very slow for large models (18s for 70B).
+    This caches the random weights and reuses them across tests.
+    """
+    if model_name not in _CACHED_MLP_WEIGHTS:
+        logger.info(f"\033[33m[cache miss]\033[0m Initializing weights for {model_name}")
+        _CACHED_MLP_WEIGHTS[model_name] = {}
+        with torch.no_grad():
+            for name, param in reference_mlp.named_parameters():
+                _CACHED_MLP_WEIGHTS[model_name][name] = torch.randn_like(param)
+    else:
+        logger.info(f"\033[32m[cache hit]\033[0m Reusing cached weights for {model_name}")
+
+    # Load cached weights into model
+    with torch.no_grad():
+        for name, param in reference_mlp.named_parameters():
+            param.copy_(_CACHED_MLP_WEIGHTS[model_name][name])
+
+
+# ============================================================================
+# Unit Tests - No device required
+# ============================================================================
+# Note: These tests only test the MLP1DConfig dataclass creation.
+# The _resolve_mlp1d_config function is tested via integration tests
+# (test_mlp_1d_vs_reference) since it requires real LazyWeight instances.
+
+
+def test_mlp_1d_config_creation():
+    """Test that MLP1DConfig dataclass can be created with explicit values."""
+    from unittest.mock import MagicMock
+
+    from models.experimental.llama32_1b_quasar.modules.mlp.mlp_1d import MLP1DConfig
+
+    mock_mesh_device = MagicMock()
+    mock_tt_ccl = MagicMock()
+    mock_w1 = MagicMock()
+    mock_w2 = MagicMock()
+    mock_w3 = MagicMock()
+
+    # Create config with explicit values
+    config = MLP1DConfig(
+        w1=mock_w1,
+        w2=mock_w2,
+        w3=mock_w3,
+        mesh_device=mock_mesh_device,
+        tt_ccl=mock_tt_ccl,
+        dim=4096,
+        hidden_dim=14336,
+        max_batch_size=64,
+        topology=ttnn.Topology.Ring,
+    )
+
+    # Verify explicit values are preserved
+    assert config.w1 is mock_w1
+    assert config.w2 is mock_w2
+    assert config.w3 is mock_w3
+    assert config.mesh_device is mock_mesh_device
+    assert config.tt_ccl is mock_tt_ccl
+    assert config.dim == 4096
+    assert config.hidden_dim == 14336
+    assert config.max_batch_size == 64
+    assert config.topology == ttnn.Topology.Ring
+
+
+def test_mlp_1d_config_defaults():
+    """Test that MLP1DConfig has sensible defaults."""
+    from unittest.mock import MagicMock
+
+    from models.experimental.llama32_1b_quasar.modules.mlp.mlp_1d import MLP1DConfig
+
+    # Minimal creation - only required fields
+    config = MLP1DConfig(w1=MagicMock(), w2=MagicMock(), w3=MagicMock())
+
+    # Check defaults
+    assert config.max_batch_size == 32
+    assert config.mlp_activation_type == ttnn.UnaryOpType.SILU
+
+    # Optional fields default to None
+    assert config.mesh_device is None
+    assert config.tt_ccl is None
+    assert config.dim is None
+    assert config.hidden_dim is None
+
+
+def test_mlp_1d_config_power_user_overrides():
+    """Test that MLP1DConfig accepts power-user overrides for program configs."""
+    from unittest.mock import MagicMock
+
+    from models.experimental.llama32_1b_quasar.modules.mlp.mlp_1d import MLP1DConfig
+
+    mock_prg_config = MagicMock()
+    mock_mem_config = MagicMock()
+
+    config = MLP1DConfig(
+        w1=MagicMock(),
+        w2=MagicMock(),
+        w3=MagicMock(),
+        decode_w1_w3_prg_config=mock_prg_config,
+        decode_w2_prg_config=mock_prg_config,
+        decode_mlp2_input_memcfg=mock_mem_config,
+        decode_residual_memcfg=mock_mem_config,
+        activation_dtype=ttnn.bfloat16,
+    )
+
+    # User-provided overrides should be preserved
+    assert config.decode_w1_w3_prg_config is mock_prg_config
+    assert config.decode_w2_prg_config is mock_prg_config
+    assert config.decode_mlp2_input_memcfg is mock_mem_config
+    assert config.decode_residual_memcfg is mock_mem_config
+    assert config.activation_dtype == ttnn.bfloat16
+
+
+# Pulled from deduped perf sweep of existing model tests in CI
+LLAMA_8B = "meta-llama/Llama-3.1-8B-Instruct"
+LLAMA_70B = "meta-llama/Llama-3.3-70B-Instruct"
+LLAMA_1B = "meta-llama/Llama-3.2-1B-Instruct"
+LLAMA_3B = "meta-llama/Llama-3.2-3B-Instruct"
+LLAMA_11B = "meta-llama/Llama-3.2-11B-Vision-Instruct"
+LLAMA_90B = "meta-llama/Llama-3.2-90B-Vision-Instruct"
+MISTRAL_7B = "mistralai/Mistral-7B-Instruct-v0.3"
+QWEN2_7B = "Qwen/Qwen2-7B-Instruct"
+QWEN25_7B = "Qwen/Qwen2.5-7B-Instruct"
+QWEN25_72B = "Qwen/Qwen2.5-72B-Instruct"
+QWEN25_CODER_32B = "Qwen/Qwen2.5-Coder-32B-Instruct"
+DEEPSEEK_R1_14B = "deepseek-ai/DeepSeek-R1-Distill-Qwen-14B"
+PHI_4 = "microsoft/phi-4"
+QWEN3_32B = "Qwen/Qwen3-32B"
+
+_slow = pytest.mark.slow
+
+
+# [INFO] Galaxy DP run multiple copies of the following on 1x1, 1x2, and 1x8 meshes.
+def _list_glx_test_cases() -> list[pytest.param]:
+    # fmt: off
+    return [
+        # === Fast tests (minimal coverage set) ===
+        # Single device
+        pytest.param((1, 1), 1, 128, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, LLAMA_8B, 0.98, id="1x1-prefill-128-mixed-8B"),
+        pytest.param((1, 1), 1, 32, "decode", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, LLAMA_8B, 0.99, id="1x1-decode-32-uniform-8B"),
+        # Multi-device (1x8)
+        pytest.param((1, 8), 1, 128, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, LLAMA_8B, 0.98, id="1x8-prefill-128-mixed-8B"),
+        pytest.param((1, 8), 1, 1024, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, LLAMA_8B, 0.98, id="1x8-prefill-1024-mixed-8B"),
+        pytest.param((1, 8), 1, 32, "decode", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, LLAMA_8B, 0.98, id="1x8-decode-32-mixed-8B"),
+        # 70B (larger dims)
+        pytest.param((1, 8), 1, 1024, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, LLAMA_70B, 0.98, id="1x8-prefill-1024-mixed-70B"),
+        # === Slow tests (full coverage from models sweep) ===
+        # (1,1) mesh - from DP-32 (8B)
+        pytest.param((1, 1), 1, 128, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, LLAMA_8B, 0.99, id="1x1-prefill-128-uniform-8B", marks=_slow),
+        pytest.param((1, 1), 1, 256, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, LLAMA_8B, 0.98, id="1x1-prefill-256-mixed-8B", marks=_slow),
+        pytest.param((1, 1), 1, 512, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, LLAMA_8B, 0.98, id="1x1-prefill-512-mixed-8B", marks=_slow),
+        pytest.param((1, 1), 1, 1024, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, LLAMA_8B, 0.98, id="1x1-prefill-1024-mixed-8B", marks=_slow),
+        pytest.param((1, 1), 1, 32, "decode", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, LLAMA_8B, 0.98, id="1x1-decode-32-mixed-8B", marks=_slow),
+        # (1,2) mesh - from DP-16 (8B)
+        pytest.param((1, 2), 1, 128, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, LLAMA_8B, 0.98, id="1x2-prefill-128-mixed-8B", marks=_slow),
+        pytest.param((1, 2), 1, 128, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, LLAMA_8B, 0.99, id="1x2-prefill-128-uniform-8B", marks=_slow),
+        pytest.param((1, 2), 1, 256, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, LLAMA_8B, 0.98, id="1x2-prefill-256-mixed-8B", marks=_slow),
+        pytest.param((1, 2), 1, 512, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, LLAMA_8B, 0.98, id="1x2-prefill-512-mixed-8B", marks=_slow),
+        pytest.param((1, 2), 1, 1024, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, LLAMA_8B, 0.98, id="1x2-prefill-1024-mixed-8B", marks=_slow),
+        pytest.param((1, 2), 1, 32, "decode", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, LLAMA_8B, 0.98, id="1x2-decode-32-mixed-8B", marks=_slow),
+        pytest.param((1, 2), 1, 32, "decode", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, LLAMA_8B, 0.99, id="1x2-decode-32-uniform-8B", marks=_slow),
+        # (1,8) mesh - from DP-4 (8B)
+        pytest.param((1, 8), 1, 128, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, LLAMA_8B, 0.99, id="1x8-prefill-128-uniform-8B", marks=_slow),
+        pytest.param((1, 8), 1, 256, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, LLAMA_8B, 0.98, id="1x8-prefill-256-mixed-8B", marks=_slow),
+        pytest.param((1, 8), 1, 512, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, LLAMA_8B, 0.98, id="1x8-prefill-512-mixed-8B", marks=_slow),
+        pytest.param((1, 8), 1, 32, "decode", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, LLAMA_8B, 0.99, id="1x8-decode-32-uniform-8B", marks=_slow),
+        # (1,8) mesh - from DP-4_70B (70B, mixed dtype only)
+        pytest.param((1, 8), 1, 128, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, LLAMA_70B, 0.98, id="1x8-prefill-128-mixed-70B", marks=_slow),
+        pytest.param((1, 8), 1, 256, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, LLAMA_70B, 0.98, id="1x8-prefill-256-mixed-70B", marks=_slow),
+        pytest.param((1, 8), 1, 512, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, LLAMA_70B, 0.98, id="1x8-prefill-512-mixed-70B", marks=_slow),
+        pytest.param((1, 8), 1, 2048, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, LLAMA_70B, 0.98, id="1x8-prefill-2048-mixed-70B", marks=_slow),
+        pytest.param((1, 8), 1, 4096, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, LLAMA_70B, 0.98, id="1x8-prefill-4096-mixed-70B", marks=_slow),
+        pytest.param((1, 8), 1, 32, "decode", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, LLAMA_70B, 0.98, id="1x8-decode-32-mixed-70B", marks=_slow),
+    ]
+    # fmt: on
+
+
+# [INFO] Non-Galaxy test cases from N150/N300/T3K/BH runs.
+def _list_non_glx_test_cases() -> list[pytest.param]:
+    # fmt: off
+    return [
+        # === Fast tests (minimal coverage set) ===
+        # Single device (1x1) - small model
+        pytest.param((1, 1), 1, 128, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, LLAMA_1B, 0.98, id="1x1-prefill-128-mixed-1B"),
+        pytest.param((1, 1), 1, 32, "decode", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, LLAMA_1B, 0.99, id="1x1-decode-32-uniform-1B"),
+        # Multi-device (1x2) - vision model 11B
+        pytest.param((1, 2), 1, 128, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, LLAMA_11B, 0.99, id="1x2-prefill-128-uniform-11B"),
+        pytest.param((1, 2), 1, 32, "decode", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, LLAMA_11B, 0.99, id="1x2-decode-32-uniform-11B"),
+        # Multi-device (1x8) - vision model 90B
+        pytest.param((1, 8), 1, 128, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, LLAMA_90B, 0.98, id="1x8-prefill-128-mixed-90B"),
+        pytest.param((1, 8), 1, 32, "decode", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, LLAMA_90B, 0.98, id="1x8-decode-32-mixed-90B"),
+        # Non-Llama model families
+        pytest.param((1, 2), 1, 128, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, PHI_4, 0.99, id="1x2-prefill-128-uniform-phi-4"),
+        pytest.param((1, 8), 1, 128, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, QWEN3_32B, 0.98, id="1x8-prefill-128-mixed-Qwen3-32B"),
+        pytest.param((1, 2), 1, 128, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, QWEN25_7B, 0.99, id="1x2-prefill-128-uniform-Qwen2.5-7B"),
+        pytest.param((1, 2), 1, 128, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, DEEPSEEK_R1_14B, 0.98, id="1x2-prefill-128-mixed-DeepSeek-R1-14B"),
+        # === Slow tests (full coverage) ===
+        # (1,1) LLAMA_1B - remaining cases not in fast set
+        pytest.param((1, 1), 1, 256, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, LLAMA_1B, 0.98, id="1x1-prefill-256-mixed-1B", marks=_slow),
+        pytest.param((1, 1), 1, 512, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, LLAMA_1B, 0.98, id="1x1-prefill-512-mixed-1B", marks=_slow),
+        pytest.param((1, 1), 1, 32, "decode", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, LLAMA_1B, 0.98, id="1x1-decode-32-mixed-1B", marks=_slow),
+        pytest.param((1, 1), 1, 1024, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, LLAMA_1B, 0.98, id="1x1-prefill-1024-mixed-1B", marks=_slow),
+        pytest.param((1, 1), 1, 128, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, LLAMA_1B, 0.99, id="1x1-prefill-128-uniform-1B", marks=_slow),
+        pytest.param((1, 1), 1, 256, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, LLAMA_1B, 0.99, id="1x1-prefill-256-uniform-1B", marks=_slow),
+        pytest.param((1, 1), 1, 512, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, LLAMA_1B, 0.99, id="1x1-prefill-512-uniform-1B", marks=_slow),
+        pytest.param((1, 1), 1, 128, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, LLAMA_3B, 0.98, id="1x1-prefill-128-mixed-3B", marks=_slow),
+        pytest.param((1, 1), 1, 256, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, LLAMA_3B, 0.98, id="1x1-prefill-256-mixed-3B", marks=_slow),
+        pytest.param((1, 1), 1, 512, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, LLAMA_3B, 0.98, id="1x1-prefill-512-mixed-3B", marks=_slow),
+        pytest.param((1, 1), 1, 32, "decode", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, LLAMA_3B, 0.98, id="1x1-decode-32-mixed-3B", marks=_slow),
+        pytest.param((1, 1), 1, 1024, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, LLAMA_3B, 0.98, id="1x1-prefill-1024-mixed-3B", marks=_slow),
+        pytest.param((1, 1), 1, 128, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, LLAMA_3B, 0.99, id="1x1-prefill-128-uniform-3B", marks=_slow),
+        pytest.param((1, 1), 1, 256, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, LLAMA_3B, 0.99, id="1x1-prefill-256-uniform-3B", marks=_slow),
+        pytest.param((1, 1), 1, 512, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, LLAMA_3B, 0.99, id="1x1-prefill-512-uniform-3B", marks=_slow),
+        pytest.param((1, 1), 1, 32, "decode", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, LLAMA_3B, 0.99, id="1x1-decode-32-uniform-3B", marks=_slow),
+        pytest.param((1, 1), 1, 128, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, LLAMA_8B, 0.98, id="1x1-prefill-128-mixed-8B", marks=_slow),
+        pytest.param((1, 1), 1, 128, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, LLAMA_8B, 0.99, id="1x1-prefill-128-uniform-8B", marks=_slow),
+        pytest.param((1, 1), 1, 256, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, LLAMA_8B, 0.98, id="1x1-prefill-256-mixed-8B", marks=_slow),
+        pytest.param((1, 1), 1, 256, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, LLAMA_8B, 0.99, id="1x1-prefill-256-uniform-8B", marks=_slow),
+        pytest.param((1, 1), 1, 512, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, LLAMA_8B, 0.98, id="1x1-prefill-512-mixed-8B", marks=_slow),
+        pytest.param((1, 1), 1, 512, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, LLAMA_8B, 0.99, id="1x1-prefill-512-uniform-8B", marks=_slow),
+        pytest.param((1, 1), 1, 1024, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, LLAMA_8B, 0.98, id="1x1-prefill-1024-mixed-8B", marks=_slow),
+        pytest.param((1, 1), 1, 1024, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, LLAMA_8B, 0.99, id="1x1-prefill-1024-uniform-8B", marks=_slow),
+        pytest.param((1, 1), 1, 32, "decode", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, LLAMA_8B, 0.98, id="1x1-decode-32-mixed-8B", marks=_slow),
+        pytest.param((1, 1), 1, 32, "decode", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, LLAMA_8B, 0.99, id="1x1-decode-32-uniform-8B", marks=_slow),
+        pytest.param((1, 2), 1, 128, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, LLAMA_1B, 0.98, id="1x2-prefill-128-mixed-1B", marks=_slow),
+        pytest.param((1, 2), 1, 256, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, LLAMA_1B, 0.98, id="1x2-prefill-256-mixed-1B", marks=_slow),
+        pytest.param((1, 2), 1, 512, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, LLAMA_1B, 0.98, id="1x2-prefill-512-mixed-1B", marks=_slow),
+        pytest.param((1, 2), 1, 1024, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, LLAMA_1B, 0.98, id="1x2-prefill-1024-mixed-1B", marks=_slow),
+        pytest.param((1, 2), 1, 32, "decode", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, LLAMA_1B, 0.98, id="1x2-decode-32-mixed-1B", marks=_slow),
+        pytest.param((1, 2), 1, 128, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, LLAMA_1B, 0.99, id="1x2-prefill-128-uniform-1B", marks=_slow),
+        pytest.param((1, 2), 1, 256, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, LLAMA_1B, 0.99, id="1x2-prefill-256-uniform-1B", marks=_slow),
+        pytest.param((1, 2), 1, 512, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, LLAMA_1B, 0.99, id="1x2-prefill-512-uniform-1B", marks=_slow),
+        pytest.param((1, 2), 1, 1024, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, LLAMA_1B, 0.99, id="1x2-prefill-1024-uniform-1B", marks=_slow),
+        pytest.param((1, 2), 1, 32, "decode", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, LLAMA_1B, 0.99, id="1x2-decode-32-uniform-1B", marks=_slow),
+        pytest.param((1, 2), 1, 128, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, LLAMA_3B, 0.98, id="1x2-prefill-128-mixed-3B", marks=_slow),
+        pytest.param((1, 2), 1, 256, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, LLAMA_3B, 0.98, id="1x2-prefill-256-mixed-3B", marks=_slow),
+        pytest.param((1, 2), 1, 512, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, LLAMA_3B, 0.98, id="1x2-prefill-512-mixed-3B", marks=_slow),
+        pytest.param((1, 2), 1, 1024, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, LLAMA_3B, 0.98, id="1x2-prefill-1024-mixed-3B", marks=_slow),
+        pytest.param((1, 2), 1, 32, "decode", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, LLAMA_3B, 0.98, id="1x2-decode-32-mixed-3B", marks=_slow),
+        pytest.param((1, 2), 1, 128, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, LLAMA_3B, 0.99, id="1x2-prefill-128-uniform-3B", marks=_slow),
+        pytest.param((1, 2), 1, 256, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, LLAMA_3B, 0.99, id="1x2-prefill-256-uniform-3B", marks=_slow),
+        pytest.param((1, 2), 1, 512, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, LLAMA_3B, 0.99, id="1x2-prefill-512-uniform-3B", marks=_slow),
+        pytest.param((1, 2), 1, 1024, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, LLAMA_3B, 0.99, id="1x2-prefill-1024-uniform-3B", marks=_slow),
+        pytest.param((1, 2), 1, 32, "decode", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, LLAMA_3B, 0.99, id="1x2-decode-32-uniform-3B", marks=_slow),
+        pytest.param((1, 2), 1, 128, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, LLAMA_8B, 0.98, id="1x2-prefill-128-mixed-8B", marks=_slow),
+        pytest.param((1, 2), 1, 128, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, LLAMA_8B, 0.99, id="1x2-prefill-128-uniform-8B", marks=_slow),
+        pytest.param((1, 2), 1, 256, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, LLAMA_8B, 0.98, id="1x2-prefill-256-mixed-8B", marks=_slow),
+        pytest.param((1, 2), 1, 256, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, LLAMA_8B, 0.99, id="1x2-prefill-256-uniform-8B", marks=_slow),
+        pytest.param((1, 2), 1, 512, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, LLAMA_8B, 0.98, id="1x2-prefill-512-mixed-8B", marks=_slow),
+        pytest.param((1, 2), 1, 512, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, LLAMA_8B, 0.99, id="1x2-prefill-512-uniform-8B", marks=_slow),
+        pytest.param((1, 2), 1, 1024, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, LLAMA_8B, 0.98, id="1x2-prefill-1024-mixed-8B", marks=_slow),
+        pytest.param((1, 2), 1, 1024, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, LLAMA_8B, 0.99, id="1x2-prefill-1024-uniform-8B", marks=_slow),
+        pytest.param((1, 2), 1, 2048, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, LLAMA_8B, 0.98, id="1x2-prefill-2048-mixed-8B", marks=_slow),
+        pytest.param((1, 2), 1, 2048, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, LLAMA_8B, 0.99, id="1x2-prefill-2048-uniform-8B", marks=_slow),
+        pytest.param((1, 2), 1, 4096, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, LLAMA_8B, 0.98, id="1x2-prefill-4096-mixed-8B", marks=_slow),
+        pytest.param((1, 2), 1, 4096, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, LLAMA_8B, 0.99, id="1x2-prefill-4096-uniform-8B", marks=_slow),
+        pytest.param((1, 2), 1, 8192, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, LLAMA_8B, 0.98, id="1x2-prefill-8192-mixed-8B", marks=_slow),
+        pytest.param((1, 2), 1, 8192, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, LLAMA_8B, 0.99, id="1x2-prefill-8192-uniform-8B", marks=_slow),
+        pytest.param((1, 2), 1, 32, "decode", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, LLAMA_8B, 0.98, id="1x2-decode-32-mixed-8B", marks=_slow),
+        pytest.param((1, 2), 1, 32, "decode", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, LLAMA_8B, 0.99, id="1x2-decode-32-uniform-8B", marks=_slow),
+        pytest.param((1, 2), 1, 128, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, LLAMA_11B, 0.98, id="1x2-prefill-128-mixed-11B", marks=_slow),
+        pytest.param((1, 2), 1, 256, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, LLAMA_11B, 0.98, id="1x2-prefill-256-mixed-11B", marks=_slow),
+        pytest.param((1, 2), 1, 512, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, LLAMA_11B, 0.98, id="1x2-prefill-512-mixed-11B", marks=_slow),
+        pytest.param((1, 2), 1, 1024, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, LLAMA_11B, 0.98, id="1x2-prefill-1024-mixed-11B", marks=_slow),
+        pytest.param((1, 2), 1, 32, "decode", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, LLAMA_11B, 0.98, id="1x2-decode-32-mixed-11B", marks=_slow),
+        pytest.param((1, 2), 1, 256, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, LLAMA_11B, 0.99, id="1x2-prefill-256-uniform-11B", marks=_slow),
+        pytest.param((1, 2), 1, 512, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, LLAMA_11B, 0.99, id="1x2-prefill-512-uniform-11B", marks=_slow),
+        pytest.param((1, 2), 1, 1024, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, LLAMA_11B, 0.99, id="1x2-prefill-1024-uniform-11B", marks=_slow),
+        pytest.param((1, 1), 1, 128, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, MISTRAL_7B, 0.98, id="1x1-prefill-128-mixed-Mistral-7B-Instruct-v0.3", marks=_slow),
+        pytest.param((1, 1), 1, 256, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, MISTRAL_7B, 0.98, id="1x1-prefill-256-mixed-Mistral-7B-Instruct-v0.3", marks=_slow),
+        pytest.param((1, 1), 1, 512, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, MISTRAL_7B, 0.98, id="1x1-prefill-512-mixed-Mistral-7B-Instruct-v0.3", marks=_slow),
+        pytest.param((1, 1), 1, 32, "decode", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, MISTRAL_7B, 0.98, id="1x1-decode-32-mixed-Mistral-7B-Instruct-v0.3", marks=_slow),
+        pytest.param((1, 1), 1, 1024, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, MISTRAL_7B, 0.98, id="1x1-prefill-1024-mixed-Mistral-7B-Instruct-v0.3", marks=_slow),
+        pytest.param((1, 1), 1, 128, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, MISTRAL_7B, 0.99, id="1x1-prefill-128-uniform-Mistral-7B-Instruct-v0.3", marks=_slow),
+        pytest.param((1, 1), 1, 256, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, MISTRAL_7B, 0.99, id="1x1-prefill-256-uniform-Mistral-7B-Instruct-v0.3", marks=_slow),
+        pytest.param((1, 1), 1, 512, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, MISTRAL_7B, 0.99, id="1x1-prefill-512-uniform-Mistral-7B-Instruct-v0.3", marks=_slow),
+        pytest.param((1, 1), 1, 32, "decode", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, MISTRAL_7B, 0.99, id="1x1-decode-32-uniform-Mistral-7B-Instruct-v0.3", marks=_slow),
+        pytest.param((1, 2), 1, 128, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, MISTRAL_7B, 0.98, id="1x2-prefill-128-mixed-Mistral-7B-Instruct-v0.3", marks=_slow),
+        pytest.param((1, 2), 1, 256, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, MISTRAL_7B, 0.98, id="1x2-prefill-256-mixed-Mistral-7B-Instruct-v0.3", marks=_slow),
+        pytest.param((1, 2), 1, 512, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, MISTRAL_7B, 0.98, id="1x2-prefill-512-mixed-Mistral-7B-Instruct-v0.3", marks=_slow),
+        pytest.param((1, 2), 1, 1024, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, MISTRAL_7B, 0.98, id="1x2-prefill-1024-mixed-Mistral-7B-Instruct-v0.3", marks=_slow),
+        pytest.param((1, 2), 1, 32, "decode", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, MISTRAL_7B, 0.98, id="1x2-decode-32-mixed-Mistral-7B-Instruct-v0.3", marks=_slow),
+        pytest.param((1, 2), 1, 128, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, MISTRAL_7B, 0.99, id="1x2-prefill-128-uniform-Mistral-7B-Instruct-v0.3", marks=_slow),
+        pytest.param((1, 2), 1, 256, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, MISTRAL_7B, 0.99, id="1x2-prefill-256-uniform-Mistral-7B-Instruct-v0.3", marks=_slow),
+        pytest.param((1, 2), 1, 512, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, MISTRAL_7B, 0.99, id="1x2-prefill-512-uniform-Mistral-7B-Instruct-v0.3", marks=_slow),
+        pytest.param((1, 2), 1, 1024, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, MISTRAL_7B, 0.99, id="1x2-prefill-1024-uniform-Mistral-7B-Instruct-v0.3", marks=_slow),
+        pytest.param((1, 2), 1, 32, "decode", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, MISTRAL_7B, 0.99, id="1x2-decode-32-uniform-Mistral-7B-Instruct-v0.3", marks=_slow),
+        pytest.param((1, 2), 1, 128, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, QWEN2_7B, 0.98, id="1x2-prefill-128-mixed-Qwen2-7B-Instruct", marks=_slow),
+        pytest.param((1, 2), 1, 256, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, QWEN2_7B, 0.98, id="1x2-prefill-256-mixed-Qwen2-7B-Instruct", marks=_slow),
+        pytest.param((1, 2), 1, 512, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, QWEN2_7B, 0.98, id="1x2-prefill-512-mixed-Qwen2-7B-Instruct", marks=_slow),
+        pytest.param((1, 2), 1, 1024, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, QWEN2_7B, 0.98, id="1x2-prefill-1024-mixed-Qwen2-7B-Instruct", marks=_slow),
+        pytest.param((1, 2), 1, 32, "decode", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, QWEN2_7B, 0.98, id="1x2-decode-32-mixed-Qwen2-7B-Instruct", marks=_slow),
+        pytest.param((1, 2), 1, 256, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, PHI_4, 0.99, id="1x2-prefill-256-uniform-phi-4", marks=_slow),
+        pytest.param((1, 2), 1, 512, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, PHI_4, 0.99, id="1x2-prefill-512-uniform-phi-4", marks=_slow),
+        pytest.param((1, 2), 1, 1024, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, PHI_4, 0.99, id="1x2-prefill-1024-uniform-phi-4", marks=_slow),
+        pytest.param((1, 2), 1, 32, "decode", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, PHI_4, 0.99, id="1x2-decode-32-uniform-phi-4", marks=_slow),
+        pytest.param((1, 8), 1, 128, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, LLAMA_1B, 0.98, id="1x8-prefill-128-mixed-1B", marks=_slow),
+        pytest.param((1, 8), 1, 256, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, LLAMA_1B, 0.98, id="1x8-prefill-256-mixed-1B", marks=_slow),
+        pytest.param((1, 8), 1, 512, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, LLAMA_1B, 0.98, id="1x8-prefill-512-mixed-1B", marks=_slow),
+        pytest.param((1, 8), 1, 1024, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, LLAMA_1B, 0.98, id="1x8-prefill-1024-mixed-1B", marks=_slow),
+        pytest.param((1, 8), 1, 32, "decode", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, LLAMA_1B, 0.98, id="1x8-decode-32-mixed-1B", marks=_slow),
+        pytest.param((1, 8), 1, 128, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, LLAMA_1B, 0.99, id="1x8-prefill-128-uniform-1B", marks=_slow),
+        pytest.param((1, 8), 1, 256, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, LLAMA_1B, 0.99, id="1x8-prefill-256-uniform-1B", marks=_slow),
+        pytest.param((1, 8), 1, 512, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, LLAMA_1B, 0.99, id="1x8-prefill-512-uniform-1B", marks=_slow),
+        pytest.param((1, 8), 1, 1024, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, LLAMA_1B, 0.99, id="1x8-prefill-1024-uniform-1B", marks=_slow),
+        pytest.param((1, 8), 1, 32, "decode", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, LLAMA_1B, 0.99, id="1x8-decode-32-uniform-1B", marks=_slow),
+        pytest.param((1, 8), 1, 128, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, LLAMA_3B, 0.98, id="1x8-prefill-128-mixed-3B", marks=_slow),
+        pytest.param((1, 8), 1, 256, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, LLAMA_3B, 0.98, id="1x8-prefill-256-mixed-3B", marks=_slow),
+        pytest.param((1, 8), 1, 512, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, LLAMA_3B, 0.98, id="1x8-prefill-512-mixed-3B", marks=_slow),
+        pytest.param((1, 8), 1, 1024, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, LLAMA_3B, 0.98, id="1x8-prefill-1024-mixed-3B", marks=_slow),
+        pytest.param((1, 8), 1, 32, "decode", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, LLAMA_3B, 0.98, id="1x8-decode-32-mixed-3B", marks=_slow),
+        pytest.param((1, 8), 1, 128, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, LLAMA_3B, 0.99, id="1x8-prefill-128-uniform-3B", marks=_slow),
+        pytest.param((1, 8), 1, 256, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, LLAMA_3B, 0.99, id="1x8-prefill-256-uniform-3B", marks=_slow),
+        pytest.param((1, 8), 1, 512, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, LLAMA_3B, 0.99, id="1x8-prefill-512-uniform-3B", marks=_slow),
+        pytest.param((1, 8), 1, 1024, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, LLAMA_3B, 0.99, id="1x8-prefill-1024-uniform-3B", marks=_slow),
+        pytest.param((1, 8), 1, 32, "decode", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, LLAMA_3B, 0.99, id="1x8-decode-32-uniform-3B", marks=_slow),
+        pytest.param((1, 8), 1, 128, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, LLAMA_8B, 0.98, id="1x8-prefill-128-mixed-8B", marks=_slow),
+        pytest.param((1, 8), 1, 128, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, LLAMA_8B, 0.99, id="1x8-prefill-128-uniform-8B", marks=_slow),
+        pytest.param((1, 8), 1, 256, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, LLAMA_8B, 0.98, id="1x8-prefill-256-mixed-8B", marks=_slow),
+        pytest.param((1, 8), 1, 256, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, LLAMA_8B, 0.99, id="1x8-prefill-256-uniform-8B", marks=_slow),
+        pytest.param((1, 8), 1, 512, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, LLAMA_8B, 0.98, id="1x8-prefill-512-mixed-8B", marks=_slow),
+        pytest.param((1, 8), 1, 512, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, LLAMA_8B, 0.99, id="1x8-prefill-512-uniform-8B", marks=_slow),
+        pytest.param((1, 8), 1, 1024, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, LLAMA_8B, 0.98, id="1x8-prefill-1024-mixed-8B", marks=_slow),
+        pytest.param((1, 8), 1, 1024, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, LLAMA_8B, 0.99, id="1x8-prefill-1024-uniform-8B", marks=_slow),
+        pytest.param((1, 8), 1, 2048, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, LLAMA_8B, 0.98, id="1x8-prefill-2048-mixed-8B", marks=_slow),
+        pytest.param((1, 8), 1, 2048, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, LLAMA_8B, 0.99, id="1x8-prefill-2048-uniform-8B", marks=_slow),
+        pytest.param((1, 8), 1, 4096, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, LLAMA_8B, 0.98, id="1x8-prefill-4096-mixed-8B", marks=_slow),
+        pytest.param((1, 8), 1, 4096, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, LLAMA_8B, 0.99, id="1x8-prefill-4096-uniform-8B", marks=_slow),
+        pytest.param((1, 8), 1, 8192, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, LLAMA_8B, 0.98, id="1x8-prefill-8192-mixed-8B", marks=_slow),
+        pytest.param((1, 8), 1, 8192, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, LLAMA_8B, 0.99, id="1x8-prefill-8192-uniform-8B", marks=_slow),
+        pytest.param((1, 8), 1, 32, "decode", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, LLAMA_8B, 0.98, id="1x8-decode-32-mixed-8B", marks=_slow),
+        pytest.param((1, 8), 1, 32, "decode", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, LLAMA_8B, 0.99, id="1x8-decode-32-uniform-8B", marks=_slow),
+        pytest.param((1, 8), 1, 128, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, LLAMA_11B, 0.98, id="1x8-prefill-128-mixed-11B", marks=_slow),
+        pytest.param((1, 8), 1, 256, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, LLAMA_11B, 0.98, id="1x8-prefill-256-mixed-11B", marks=_slow),
+        pytest.param((1, 8), 1, 512, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, LLAMA_11B, 0.98, id="1x8-prefill-512-mixed-11B", marks=_slow),
+        pytest.param((1, 8), 1, 1024, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, LLAMA_11B, 0.98, id="1x8-prefill-1024-mixed-11B", marks=_slow),
+        pytest.param((1, 8), 1, 32, "decode", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, LLAMA_11B, 0.98, id="1x8-decode-32-mixed-11B", marks=_slow),
+        pytest.param((1, 8), 1, 128, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, LLAMA_11B, 0.99, id="1x8-prefill-128-uniform-11B", marks=_slow),
+        pytest.param((1, 8), 1, 256, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, LLAMA_11B, 0.99, id="1x8-prefill-256-uniform-11B", marks=_slow),
+        pytest.param((1, 8), 1, 512, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, LLAMA_11B, 0.99, id="1x8-prefill-512-uniform-11B", marks=_slow),
+        pytest.param((1, 8), 1, 1024, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, LLAMA_11B, 0.99, id="1x8-prefill-1024-uniform-11B", marks=_slow),
+        pytest.param((1, 8), 1, 32, "decode", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, LLAMA_11B, 0.99, id="1x8-decode-32-uniform-11B", marks=_slow),
+        pytest.param((1, 8), 1, 256, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, QWEN3_32B, 0.98, id="1x8-prefill-256-mixed-Qwen3-32B", marks=_slow),
+        pytest.param((1, 8), 1, 512, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, QWEN3_32B, 0.98, id="1x8-prefill-512-mixed-Qwen3-32B", marks=_slow),
+        pytest.param((1, 8), 1, 1024, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, QWEN3_32B, 0.98, id="1x8-prefill-1024-mixed-Qwen3-32B", marks=_slow),
+        pytest.param((1, 8), 1, 32, "decode", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, QWEN3_32B, 0.98, id="1x8-decode-32-mixed-Qwen3-32B", marks=_slow),
+        pytest.param((1, 8), 1, 128, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, QWEN3_32B, 0.99, id="1x8-prefill-128-uniform-Qwen3-32B", marks=_slow),
+        pytest.param((1, 8), 1, 256, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, QWEN3_32B, 0.99, id="1x8-prefill-256-uniform-Qwen3-32B", marks=_slow),
+        pytest.param((1, 8), 1, 512, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, QWEN3_32B, 0.99, id="1x8-prefill-512-uniform-Qwen3-32B", marks=_slow),
+        pytest.param((1, 8), 1, 1024, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, QWEN3_32B, 0.99, id="1x8-prefill-1024-uniform-Qwen3-32B", marks=_slow),
+        pytest.param((1, 8), 1, 32, "decode", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, QWEN3_32B, 0.99, id="1x8-decode-32-uniform-Qwen3-32B", marks=_slow),
+        pytest.param((1, 8), 1, 128, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, MISTRAL_7B, 0.98, id="1x8-prefill-128-mixed-Mistral-7B-Instruct-v0.3", marks=_slow),
+        pytest.param((1, 8), 1, 256, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, MISTRAL_7B, 0.98, id="1x8-prefill-256-mixed-Mistral-7B-Instruct-v0.3", marks=_slow),
+        pytest.param((1, 8), 1, 512, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, MISTRAL_7B, 0.98, id="1x8-prefill-512-mixed-Mistral-7B-Instruct-v0.3", marks=_slow),
+        pytest.param((1, 8), 1, 1024, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, MISTRAL_7B, 0.98, id="1x8-prefill-1024-mixed-Mistral-7B-Instruct-v0.3", marks=_slow),
+        pytest.param((1, 8), 1, 32, "decode", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, MISTRAL_7B, 0.98, id="1x8-decode-32-mixed-Mistral-7B-Instruct-v0.3", marks=_slow),
+        pytest.param((1, 8), 1, 128, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, MISTRAL_7B, 0.99, id="1x8-prefill-128-uniform-Mistral-7B-Instruct-v0.3", marks=_slow),
+        pytest.param((1, 8), 1, 256, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, MISTRAL_7B, 0.99, id="1x8-prefill-256-uniform-Mistral-7B-Instruct-v0.3", marks=_slow),
+        pytest.param((1, 8), 1, 512, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, MISTRAL_7B, 0.99, id="1x8-prefill-512-uniform-Mistral-7B-Instruct-v0.3", marks=_slow),
+        pytest.param((1, 8), 1, 1024, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, MISTRAL_7B, 0.99, id="1x8-prefill-1024-uniform-Mistral-7B-Instruct-v0.3", marks=_slow),
+        pytest.param((1, 8), 1, 32, "decode", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, MISTRAL_7B, 0.99, id="1x8-decode-32-uniform-Mistral-7B-Instruct-v0.3", marks=_slow),
+        # --- New test cases from mlp_1d_performance.csv ---
+        # Qwen2.5-7B on N300 (1x2) - uniform BF8
+        pytest.param((1, 2), 1, 256, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, QWEN25_7B, 0.99, id="1x2-prefill-256-uniform-Qwen2.5-7B", marks=_slow),
+        pytest.param((1, 2), 1, 512, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, QWEN25_7B, 0.99, id="1x2-prefill-512-uniform-Qwen2.5-7B", marks=_slow),
+        pytest.param((1, 2), 1, 1024, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, QWEN25_7B, 0.99, id="1x2-prefill-1024-uniform-Qwen2.5-7B", marks=_slow),
+        pytest.param((1, 2), 1, 32, "decode", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, QWEN25_7B, 0.99, id="1x2-decode-32-uniform-Qwen2.5-7B", marks=_slow),
+        # Qwen2.5-72B on T3K (1x8) - mixed BF4/BF8
+        pytest.param((1, 8), 1, 128, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, QWEN25_72B, 0.98, id="1x8-prefill-128-mixed-Qwen2.5-72B", marks=_slow),
+        pytest.param((1, 8), 1, 256, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, QWEN25_72B, 0.98, id="1x8-prefill-256-mixed-Qwen2.5-72B", marks=_slow),
+        pytest.param((1, 8), 1, 512, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, QWEN25_72B, 0.98, id="1x8-prefill-512-mixed-Qwen2.5-72B", marks=_slow),
+        pytest.param((1, 8), 1, 1024, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, QWEN25_72B, 0.98, id="1x8-prefill-1024-mixed-Qwen2.5-72B", marks=_slow),
+        pytest.param((1, 8), 1, 32, "decode", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, QWEN25_72B, 0.98, id="1x8-decode-32-mixed-Qwen2.5-72B", marks=_slow),
+        # DeepSeek-R1-Distill-Qwen-14B on N300 (1x2) - mixed BF4/BF8
+        pytest.param((1, 2), 1, 256, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, DEEPSEEK_R1_14B, 0.98, id="1x2-prefill-256-mixed-DeepSeek-R1-14B", marks=_slow),
+        pytest.param((1, 2), 1, 512, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, DEEPSEEK_R1_14B, 0.98, id="1x2-prefill-512-mixed-DeepSeek-R1-14B", marks=_slow),
+        pytest.param((1, 2), 1, 1024, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, DEEPSEEK_R1_14B, 0.98, id="1x2-prefill-1024-mixed-DeepSeek-R1-14B", marks=_slow),
+        pytest.param((1, 2), 1, 32, "decode", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, DEEPSEEK_R1_14B, 0.98, id="1x2-decode-32-mixed-DeepSeek-R1-14B", marks=_slow),
+        # Qwen2.5-Coder-32B on T3K (1x8) - mixed BF4/BF8
+        pytest.param((1, 8), 1, 128, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, QWEN25_CODER_32B, 0.98, id="1x8-prefill-128-mixed-Qwen2.5-Coder-32B", marks=_slow),
+        pytest.param((1, 8), 1, 256, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, QWEN25_CODER_32B, 0.98, id="1x8-prefill-256-mixed-Qwen2.5-Coder-32B", marks=_slow),
+        pytest.param((1, 8), 1, 512, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, QWEN25_CODER_32B, 0.98, id="1x8-prefill-512-mixed-Qwen2.5-Coder-32B", marks=_slow),
+        pytest.param((1, 8), 1, 1024, "prefill", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, QWEN25_CODER_32B, 0.98, id="1x8-prefill-1024-mixed-Qwen2.5-Coder-32B", marks=_slow),
+        pytest.param((1, 8), 1, 32, "decode", ttnn.bfloat16, ttnn.bfloat4_b, ttnn.bfloat8_b, ttnn.bfloat4_b, QWEN25_CODER_32B, 0.98, id="1x8-decode-32-mixed-Qwen2.5-Coder-32B", marks=_slow),
+        # Qwen2.5-Coder-32B on T3K (1x8) - uniform BF8
+        pytest.param((1, 8), 1, 128, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, QWEN25_CODER_32B, 0.99, id="1x8-prefill-128-uniform-Qwen2.5-Coder-32B", marks=_slow),
+        pytest.param((1, 8), 1, 256, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, QWEN25_CODER_32B, 0.99, id="1x8-prefill-256-uniform-Qwen2.5-Coder-32B", marks=_slow),
+        pytest.param((1, 8), 1, 512, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, QWEN25_CODER_32B, 0.99, id="1x8-prefill-512-uniform-Qwen2.5-Coder-32B", marks=_slow),
+        pytest.param((1, 8), 1, 1024, "prefill", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, QWEN25_CODER_32B, 0.99, id="1x8-prefill-1024-uniform-Qwen2.5-Coder-32B", marks=_slow),
+        pytest.param((1, 8), 1, 32, "decode", ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat8_b, ttnn.bfloat8_b, QWEN25_CODER_32B, 0.99, id="1x8-decode-32-uniform-Qwen2.5-Coder-32B", marks=_slow),
+    ]
+
+
+# [INFO] generate random tensor for every test case is too expensive; cache weights and reuse them across test cases
+# [INFO] separate out ttnn_mesh_device parameter allows for sharing the same mesh device across test cases
+@pytest.mark.parametrize(
+    "ttnn_mesh_device",
+    [(1, 1), (1, 2), (1, 8)],
+    ids=["1x1", "1x2", "1x8"],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "mesh_shape,batch_size,seq_len,mode,act_dtype,w1_dtype,w2_dtype,w3_dtype,hf_model_name,pcc",
+    _list_non_glx_test_cases() + _list_glx_test_cases(),
+)
+def test_mlp_1d_vs_reference(
+    ttnn_mesh_device: ttnn.MeshDevice,
+    mesh_shape,
+    batch_size,
+    seq_len,
+    mode,
+    act_dtype,
+    w1_dtype,
+    w2_dtype,
+    w3_dtype,
+    hf_model_name,
+    pcc,
+):
+    """
+    Test MLP1D constructed via direct APIs (MLP1DConfig) matches HF reference MLP.
+
+    Configs pulled from perf sweep CSVs (b{batch_size}-DP-{dp}_{model}).
+    """
+
+    # get reference model; generate and load deterministic, random weights into the reference model
+    seed = 1234
+    torch.manual_seed(seed)
+
+    # HF model (default small) for reference; skip global init to only seed MLP.
+    config = AutoConfig.from_pretrained(hf_model_name)
+    config.num_hidden_layers = 1
+
+    with no_init_weights():
+        hf_model = AutoModelForCausalLM.from_config(config, torch_dtype=torch.bfloat16)
+    first_layer = hf_model.model.layers[0]
+    reference_mlp = first_layer.mlp
+
+    # Initialize only the MLP submodule deterministically (cached for speed).
+    _get_or_init_mlp_weights(hf_model_name, reference_mlp)
+
+    # Build MLP1D TT model and load the same weights as the reference model
+    w1_torch, w2_torch, w3_torch = get_mlp_weights_from_ref_model(reference_mlp)
+    dim = w1_torch.shape[0]
+    torch_input = torch.randn(batch_size, 1, seq_len, dim, dtype=torch.bfloat16)
+
+    # Create LazyWeights
+    ttnn.SetDefaultDevice(ttnn_mesh_device)
+    cache_dir = Path(os.getenv("TT_CACHE_PATH", "model_cache/mlp_1d"))
+    lazy_w1 = LazyWeight(source=w1_torch, dtype=w1_dtype, cache_dir_weight_name=(cache_dir, "w1"))
+    lazy_w2 = LazyWeight(source=w2_torch, dtype=w2_dtype, cache_dir_weight_name=(cache_dir, "w2"))
+    lazy_w3 = LazyWeight(source=w3_torch, dtype=w3_dtype, cache_dir_weight_name=(cache_dir, "w3"))
+
+    # Get model/device-specific prefill_len_cutoff
+    prefill_len_cutoff = _get_prefill_len_cutoff(hf_model_name, mesh_shape)
+
+    # Construct the MLP1D model
+    if prefill_len_cutoff is None:
+        # Use default prefill_len_cutoff, take the happy path of MLP1D
+        tt_model = MLP1D(w1=lazy_w1, w2=lazy_w2, w3=lazy_w3)
+    else:
+        # Use custom config with prefill_len_cutoff override
+        mlp_config = MLP1DConfig(w1=lazy_w1, w2=lazy_w2, w3=lazy_w3, prefill_len_cutoff=prefill_len_cutoff)
+        tt_model = MLP1D.from_config(mlp_config)
+
+    # Run TT model with the same input -- torch_input -- converted to ttnn tensor lazily on the fly
+    # [INFO] we use LazyWeight on input for the benefit of faster testing (cached input); in production, the input is already a ttnn tensor.
+    tt_input = LazyWeight(
+        source=torch_input,
+        dtype=act_dtype,
+        # cache_dir_weight_name=(cache_dir, "input"), # todo)) needs better fingerprinting for input tensor to enable
+    )
+    tt_output = tt_model.forward(tt_input, mode)
+    tt_output_torch = to_torch_auto_compose(tt_output)
+    ttnn.SetDefaultDevice(None)
+
+    # Now both models are ready to go
+    # Run reference model
+    with torch.no_grad():
+        reference_output = reference_mlp(torch_input)
+
+    passing, pcc_message = comp_pcc(reference_output, tt_output_torch, pcc)
+
+    logger.info(comp_allclose(reference_output, tt_output_torch))
+    logger.info(f"MLP1D (direct API) vs HF reference: {pcc_message}")
+
+    assert passing, f"MLP1D output does not meet PCC requirement {pcc}: {pcc_message}."
+    logger.info(f"MLP1D (direct API) vs HF reference: PASSED for mode={mode}, seq_len={seq_len}")
+
+
+@pytest.mark.parametrize(
+    "ttnn_mesh_device",
+    [(1, 8)],
+    ids=["1x8"],
+    indirect=True,
+)
+def test_mlp_1d_config_prefill_override(ttnn_mesh_device: ttnn.MeshDevice):
+    """
+    Show how to override prefill_w2_prg_config with the MLP1DConfig API.
+
+    Use MLP1D.from_config() for any customization beyond the simple 3-weight API.
+    """
+    from models.experimental.llama32_1b_quasar.modules.mlp.mlp_1d import _find_prefill_grid
+
+    # Use Llama 8B config
+    hf_model_name = "meta-llama/Llama-3.1-8B-Instruct"
+    hf_config = AutoConfig.from_pretrained(hf_model_name)
+    seq_len = 128
+    batch_size = 1
+
+    # Load HF model for reference weights
+    hf_config.num_hidden_layers = 1
+    with no_init_weights():
+        hf_model = AutoModelForCausalLM.from_config(hf_config, torch_dtype=torch.bfloat16)
+    reference_mlp = hf_model.model.layers[0].mlp
+
+    # Generate random weights directly for this test
+    # todo)) using _get_or_init_mlp_weights instead here would interfere with the test_mlp_1d_vs_reference test; this problem could be solved by provenance-based fingerprinting the torch.tensor inputs
+    with torch.no_grad():
+        for param in reference_mlp.parameters():
+            param.copy_(torch.randn_like(param))
+
+    # Prepare weights
+    w1_torch, w2_torch, w3_torch = get_mlp_weights_from_ref_model(reference_mlp)
+
+    # Create LazyWeights (no disk cache)
+    ttnn.SetDefaultDevice(ttnn_mesh_device)
+    lazy_w1 = LazyWeight(source=w1_torch, dtype=ttnn.bfloat4_b)
+    lazy_w2 = LazyWeight(source=w2_torch, dtype=ttnn.bfloat8_b)
+    lazy_w3 = LazyWeight(source=w3_torch, dtype=ttnn.bfloat4_b)
+
+    # Step 1: Create MLP1D with default config
+    tt_model = MLP1D.from_config(MLP1DConfig(w1=lazy_w1, w2=lazy_w2, w3=lazy_w3))
+
+    # Step 2: Define custom prefill w2 config using resolved values from tt_model.config
+    cfg = tt_model.config
+    dim = cfg.dim
+    hidden_dim = cfg.hidden_dim
+    tile_size = TILE_SIZE
+    prefill_len_cutoff = cfg.prefill_len_cutoff
+
+    @lru_cache
+    def custom_prefill_w2_prg_config(seq_len: int):
+        n_w2 = dim
+        dram_shard_grid_width = 8
+        prefill_rows = 8
+        grid_size = _find_prefill_grid(prefill_rows, hidden_dim // tile_size)
+        return _matmul_config(
+            m=min(seq_len, prefill_len_cutoff),
+            k=hidden_dim,
+            n=n_w2,
+            grid_size=grid_size,
+            per_core_n=math.ceil(n_w2 / (tile_size * dram_shard_grid_width)),
+        )
+
+    # Step 3: Override the prefill config on the existing model
+    tt_model.config.prefill_w2_prg_config = custom_prefill_w2_prg_config
+
+    # Verify the override was applied
+    assert tt_model.config.prefill_w2_prg_config is custom_prefill_w2_prg_config
+
+    # Run prefill forward
+    torch_input = torch.randn(batch_size, 1, seq_len, dim, dtype=torch.bfloat16)
+    tt_input = LazyWeight(source=torch_input, dtype=ttnn.bfloat8_b)
+    tt_output = tt_model.forward(tt_input, mode="prefill")
+    tt_output_torch = to_torch_auto_compose(tt_output)
+    ttnn.SetDefaultDevice(None)
+
+    # Verify output shape matches input shape (MLP is dim -> dim)
+    assert tt_output_torch.shape == torch_input.shape, f"Expected {torch_input.shape}, got {tt_output_torch.shape}"
+
+    # Verify numerical correctness against reference
+    with torch.no_grad():
+        reference_output = reference_mlp(torch_input)
+    passing, pcc_message = comp_pcc(reference_output, tt_output_torch, 0.98)
+    assert passing, f"MLP1D with custom prefill config failed PCC: {pcc_message}"
+    logger.info(f"test_mlp_1d_config_prefill_override: PASSED - {pcc_message}")
+
+
+# ============================================================================
+# Integration Tests - Require device
+# ============================================================================
+
+
+# [INFO] this test will retire once models/tt_transformers/tt/model_config.py retires
+@pytest.mark.parametrize(
+    "ttnn_mesh_device",
+    [
+        (1, 1),  # single device
+        (1, 2),  # 1D mesh, 2 devices
+        (1, 4),  # 1D mesh, 4 devices
+        (1, 8),  # 1D mesh, 8 devices
+    ],
+    ids=["1x1", "1x2", "1x4", "1x8"],
+    indirect=True,
+)
+@pytest.mark.parametrize("seq_len", (512, 32))
+def test_mlp_1d_vs_reference_from_model_args(ttnn_mesh_device: ttnn.MeshDevice, seq_len):
+    """
+    Test that MLP1D class matches the HuggingFace/Meta reference model.
+    """
+    from models.experimental.llama32_1b_quasar.modules.mlp.mlp_1d import MLP1D
+    from models.tt_transformers.tests.test_utils import get_ref_model_dype
+    from models.tt_transformers.tt.ccl import TT_CCL
+    from models.tt_transformers.tt.model_config import ModelArgs
+
+    dtype = ttnn.bfloat8_b
+    batch_size = 1
+    mode = "decode" if seq_len <= 32 else "prefill"
+
+    model_args = ModelArgs(ttnn_mesh_device, max_batch_size=batch_size, max_seq_len=128, cache_hf=True)
+    model_args.n_layers = 1
+
+    if model_args.is_galaxy:
+        pytest.skip("MLP1D test only runs on non-TG devices")
+
+    state_dict = model_args.load_state_dict()
+    model_config = model_args.get_model_config()
+
+    # Load reference model
+    first_layer_prefix = model_args.get_state_dict_prefix("MLP", 0)
+    partial_state_dict = {
+        k[len(first_layer_prefix) + 1 :]: v for k, v in state_dict.items() if k.startswith(first_layer_prefix)
+    }
+
+    reference_model = model_args.reference_mlp()
+    reference_model.load_state_dict(partial_state_dict)
+
+    # Create MLP1D
+    def topology_aware_cache_path(dtype):
+        if model_args.instruct:
+            return (
+                model_args.model_cache_path
+                / {
+                    ttnn.bfloat16: f"tensor_cache_instruct_bf16_{ttnn_mesh_device.shape}",
+                    ttnn.bfloat8_b: f"tensor_cache_instruct_bfp8_{ttnn_mesh_device.shape}",
+                }[dtype]
+            )
+        else:
+            return (
+                model_args.model_cache_path
+                / {
+                    ttnn.bfloat16: f"tensor_cache_bf16_{ttnn_mesh_device.shape}",
+                    ttnn.bfloat8_b: f"tensor_cache_bfp8_{ttnn_mesh_device.shape}",
+                }[dtype]
+            )
+
+    tt_ccl = TT_CCL(ttnn_mesh_device)
+    tt_model = MLP1D.from_model_args(
+        mesh_device=ttnn_mesh_device,
+        tt_ccl=tt_ccl,
+        args=model_args,
+        state_dict=state_dict,
+        weight_cache_path=topology_aware_cache_path(dtype),
+        layer_num=0,
+        dtype=dtype,
+        model_config=model_config,
+    )
+
+    # Create input
+    torch_input = torch.randn(
+        1, 1, seq_len, model_args.dim, dtype=get_ref_model_dype(reference_model, model_args.model_name)
+    )
+
+    # Run reference
+    reference_output = reference_model(torch_input)
+
+    # Run TT model
+    input_mem_config = model_args.get_mlp_input_mem_config(Mode(mode), None)
+
+    tt_input = ttnn.from_torch(
+        torch_input,
+        device=ttnn_mesh_device,
+        mesh_mapper=ttnn.ShardTensor2dMesh(ttnn_mesh_device, dims=(None, None), mesh_shape=model_args.cluster_shape),
+        dtype=ttnn.bfloat8_b,
+        memory_config=input_mem_config,
+        layout=ttnn.TILE_LAYOUT,
+    )
+
+    tt_output = tt_model.forward(tt_input, mode)
+
+    tt_output_torch = ttnn.to_torch(
+        tt_output,
+        mesh_composer=ttnn.ConcatMesh2dToTensor(ttnn_mesh_device, dims=(1, 3), mesh_shape=model_args.cluster_shape),
+    )
+    tt_output_torch = tt_output_torch[:, :1, :, :]
+
+    # Compare
+    pcc_required = 0.99
+    passing, pcc_message = comp_pcc(reference_output, tt_output_torch, pcc_required)
+
+    logger.info(comp_allclose(reference_output, tt_output_torch))
+    logger.info(f"MLP1D vs reference: {pcc_message}")
+
+    assert passing, f"MLP1D output does not meet PCC requirement {pcc_required}: {pcc_message}."
+    logger.info(f"MLP1D vs reference: PASSED for mode={mode}, seq_len={seq_len}")

--- a/models/experimental/llama32_1b_quasar/tests/modules/rmsnorm/test_rmsnorm_1d.py
+++ b/models/experimental/llama32_1b_quasar/tests/modules/rmsnorm/test_rmsnorm_1d.py
@@ -1,0 +1,782 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Tests for the RMSNorm1D module (1D mesh topology: N150, N300, T3K).
+
+This test suite verifies:
+1. Unit tests for config dataclasses (no device needed)
+2. RMSNorm1D class matches PyTorch/HuggingFace reference model
+3. RMSNorm1D correctly rejects TG/Galaxy devices
+"""
+
+import os
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+from loguru import logger
+from transformers import AutoConfig, AutoModelForCausalLM
+
+# transformers 5.x moved no_init_weights to transformers.initialization; fall back
+# to the old location for transformers < 5.x.
+try:
+    from transformers.initialization import no_init_weights
+except ImportError:
+    from transformers.modeling_utils import no_init_weights
+
+import ttnn
+from models.experimental.llama32_1b_quasar.auto_compose import to_torch_auto_compose
+from models.experimental.llama32_1b_quasar.modules.lazy_weight import LazyWeight
+from models.experimental.llama32_1b_quasar.modules.rmsnorm.rmsnorm_1d import (
+    RMSNorm1D,
+    RMSNorm1DConfig,
+    _compute_norm_core_grid,
+    _create_sharded_norm_program_config,
+)
+from models.experimental.llama32_1b_quasar.utility_functions import comp_allclose, comp_pcc
+
+# ============================================================================
+# Weight Caching - Avoid expensive weight loading per test
+# ============================================================================
+
+_CACHED_NORM_WEIGHTS: dict[str, torch.Tensor] = {}
+
+
+def _get_or_init_norm_weights(model_name: str, reference_norm) -> None:
+    """Initialize RMSNorm weights once per model, cache and reuse across tests."""
+    if model_name not in _CACHED_NORM_WEIGHTS:
+        logger.info(f"\033[33m[cache miss]\033[0m Initializing weights for {model_name}")
+        with torch.no_grad():
+            _CACHED_NORM_WEIGHTS[model_name] = torch.randn_like(reference_norm.weight)
+    else:
+        logger.info(f"\033[32m[cache hit]\033[0m Reusing cached weights for {model_name}")
+
+    # Load cached weights into model
+    with torch.no_grad():
+        reference_norm.weight.copy_(_CACHED_NORM_WEIGHTS[model_name])
+
+
+def _get_or_create_synthetic_weight(dim: int, seed: int = 1234) -> torch.Tensor:
+    """Get or create synthetic RMSNorm weight, cached by dimension."""
+    cache_key = f"synthetic_dim{dim}"
+    if cache_key not in _CACHED_NORM_WEIGHTS:
+        logger.info(f"\033[33m[cache miss]\033[0m Creating synthetic weight for dim={dim}")
+        torch.manual_seed(seed)
+        _CACHED_NORM_WEIGHTS[cache_key] = torch.randn(dim, dtype=torch.bfloat16)
+    return _CACHED_NORM_WEIGHTS[cache_key]
+
+
+# ============================================================================
+# Unit Tests - No device required
+# ============================================================================
+
+
+def test_rmsnorm_1d_config_creation():
+    """Test that RMSNorm1DConfig dataclass can be created with explicit values."""
+    mock_mesh_device = MagicMock()
+    mock_tt_ccl = MagicMock()
+    mock_weight = MagicMock()
+
+    config = RMSNorm1DConfig(
+        weight=mock_weight,
+        eps=1e-6,
+        add_unit_offset=True,
+        mesh_device=mock_mesh_device,
+        tt_ccl=mock_tt_ccl,
+        max_batch_size=64,
+    )
+
+    assert config.weight == mock_weight
+    assert config.eps == 1e-6
+    assert config.add_unit_offset is True
+    assert config.mesh_device == mock_mesh_device
+    assert config.tt_ccl == mock_tt_ccl
+    assert config.max_batch_size == 64
+
+
+def test_rmsnorm_1d_config_defaults():
+    """Test that RMSNorm1DConfig has sensible defaults."""
+    config = RMSNorm1DConfig(weight=MagicMock())
+
+    # Check defaults
+    assert config.eps == 1e-5
+    assert config.add_unit_offset is False
+    assert config.max_batch_size == 32
+    assert config.decode_in_sharded is True
+    assert config.decode_out_sharded is True
+
+    # Optional fields default to None
+    assert config.mesh_device is None
+    assert config.tt_ccl is None
+    assert config.prefill_distributed is None
+    assert config.decode_program_config is None
+
+
+def test_rmsnorm_1d_config_power_user_overrides():
+    """Test that RMSNorm1DConfig accepts power-user overrides for program configs."""
+    mock_prg_config = MagicMock()
+    mock_mem_config = MagicMock()
+
+    config = RMSNorm1DConfig(
+        weight=MagicMock(),
+        decode_program_config=mock_prg_config,
+        decode_memory_config=mock_mem_config,
+        decode_in_sharded=False,
+    )
+
+    assert config.decode_program_config == mock_prg_config
+    assert config.decode_memory_config == mock_mem_config
+    assert config.decode_in_sharded is False
+
+
+def test_compute_norm_core_grid():
+    """Test _compute_norm_core_grid helper function."""
+    # dim=4096 -> 128 tiles -> should find a grid that divides 128
+    grid = _compute_norm_core_grid(4096)
+    assert grid.num_cores > 0
+    assert 128 % grid.num_cores == 0
+
+    # dim=8192 -> 256 tiles -> should find a grid that divides 256
+    grid = _compute_norm_core_grid(8192)
+    assert grid.num_cores > 0
+    assert 256 % grid.num_cores == 0
+
+
+def test_create_sharded_norm_program_config():
+    """Test _create_sharded_norm_program_config helper function."""
+    dim = 4096
+    grid = ttnn.CoreGrid(x=8, y=4)  # 32 cores
+    tile_padded_batch_rows = 32
+
+    config = _create_sharded_norm_program_config(dim, grid, tile_padded_batch_rows)
+
+    # Just verify the config is created successfully
+    assert isinstance(config, ttnn.LayerNormShardedMultiCoreProgramConfig)
+
+
+# ============================================================================
+# Integration Tests - Device required
+# ============================================================================
+
+
+# HuggingFace model paths
+LLAMA_1B = "meta-llama/Llama-3.2-1B-Instruct"
+LLAMA_3B = "meta-llama/Llama-3.2-3B-Instruct"
+LLAMA_8B = "meta-llama/Llama-3.1-8B-Instruct"
+LLAMA_11B = "meta-llama/Llama-3.2-11B-Vision-Instruct"
+LLAMA_70B = "meta-llama/Llama-3.3-70B-Instruct"
+LLAMA_90B = "meta-llama/Llama-3.2-90B-Vision-Instruct"
+MISTRAL_7B = "mistralai/Mistral-7B-Instruct-v0.3"
+MIXTRAL_MOE = "mistralai/Mixtral-8x7B-Instruct-v0.1"
+QWEN2_7B = "Qwen/Qwen2-7B-Instruct"
+QWEN25_7B = "Qwen/Qwen2.5-7B-Instruct"
+QWEN25_72B = "Qwen/Qwen2.5-72B-Instruct"
+QWEN25_CODER_32B = "Qwen/Qwen2.5-Coder-32B-Instruct"
+QWEN3_32B = "Qwen/Qwen3-32B"
+DEEPSEEK_R1_14B = "deepseek-ai/DeepSeek-R1-Distill-Qwen-14B"
+
+_slow = pytest.mark.slow
+
+
+def _list_rmsnorm_1d_test_cases() -> list[pytest.param]:
+    """
+    Test cases from rmsnorm_1d_testcases.csv.
+
+    These cover various models across 1D topologies (1x1, 1x2, 1x8).
+    Includes both decode and prefill modes with various seq_len values.
+
+    Parameters:
+    - mesh_shape: (cluster_shape_x, cluster_shape_y) tuple
+    - input_shape: (x0, x1, x2, x3) - x1 > 1 for vision encoder norms
+    - mode: "decode" or "prefill"
+    - dim: hidden dimension
+    - eps: epsilon for numerical stability
+    - in_sharded: whether input is sharded
+    - out_sharded: whether output is sharded
+    - is_distributed: whether distributed path is used
+    - model_name: HuggingFace model path
+    - pcc: minimum PCC threshold
+    """
+    # fmt: off
+    return [
+        # === Fast tests (minimal coverage set) ===
+        # Single device (1x1) - local paths
+        pytest.param((1, 1), (1, 1, 128, 2048), "prefill", 2048, 1e-5, False, False, False, LLAMA_1B, 0.999, id="1x1-prefill-128-1B"),
+        pytest.param((1, 1), (1, 1, 32, 2048), "decode", 2048, 1e-5, True, True, False, LLAMA_1B, 0.999, id="1x1-decode-32-1B"),
+        pytest.param((1, 1), (1, 1, 128, 4096), "prefill", 4096, 1e-5, False, False, False, LLAMA_8B, 0.999, id="1x1-prefill-128-8B"),
+        pytest.param((1, 1), (1, 1, 32, 4096), "decode", 4096, 1e-5, True, True, False, LLAMA_8B, 0.999, id="1x1-decode-32-8B"),
+        # Multi-device (1x2) - local paths
+        pytest.param((1, 2), (1, 1, 128, 4096), "prefill", 4096, 1e-5, False, False, False, LLAMA_8B, 0.999, id="1x2-prefill-128-8B"),
+        pytest.param((1, 2), (1, 1, 32, 4096), "decode", 4096, 1e-5, True, True, False, LLAMA_8B, 0.999, id="1x2-decode-32-8B"),
+        # Multi-device (1x8) - includes distributed path
+        pytest.param((1, 8), (1, 1, 128, 4096), "prefill", 4096, 1e-5, False, False, False, LLAMA_8B, 0.999, id="1x8-prefill-128-8B"),
+        pytest.param((1, 8), (1, 1, 32, 8192), "decode", 8192, 1e-5, True, True, False, LLAMA_70B, 0.999, id="1x8-decode-32-70B"),
+        pytest.param((1, 8), (1, 1, 128, 8192), "prefill", 8192, 1e-5, False, False, True, LLAMA_70B, 0.999, id="1x8-prefill-128-70B-dist"),
+        # Non-Llama models
+        pytest.param((1, 2), (1, 1, 128, 3584), "prefill", 3584, 1e-6, False, False, False, QWEN25_7B, 0.999, id="1x2-prefill-128-Qwen2.5-7B"),
+        pytest.param((1, 8), (1, 1, 128, 5120), "prefill", 5120, 1e-6, False, False, True, QWEN3_32B, 0.999, id="1x8-prefill-128-Qwen3-32B-dist"),
+        # Vision encoder norms (x_shape_1 > 1, dim=128)
+        pytest.param((1, 1), (1, 4, 6528, 128), "decode", 128, 1e-5, False, False, False, LLAMA_11B, 0.999, id="1x1-decode-6528x4-11B-vision"),
+        pytest.param((1, 1), (1, 16, 128, 128), "prefill", 128, 1e-5, False, False, False, LLAMA_11B, 0.999, id="1x1-prefill-128x16-11B-vision"),
+        # === Slow tests (full coverage from CSV) ===
+        # Mesh 1x1
+        pytest.param((1, 1), (1, 1, 128, 2048), "prefill", 2048, 1e-05, False, False, False, LLAMA_1B, 0.999, id="1x1-prefill-128-1B", marks=_slow),
+        pytest.param((1, 1), (1, 1, 32, 2048), "prefill", 2048, 1e-05, False, False, False, LLAMA_1B, 0.999, id="1x1-prefill-32-1B", marks=_slow),
+        pytest.param((1, 1), (1, 1, 1024, 2048), "prefill", 2048, 1e-05, False, False, False, LLAMA_1B, 0.999, id="1x1-prefill-1024-1B", marks=_slow),
+        pytest.param((1, 1), (1, 1, 2048, 2048), "prefill", 2048, 1e-05, False, False, False, LLAMA_1B, 0.999, id="1x1-prefill-2048-1B", marks=_slow),
+        pytest.param((1, 1), (1, 1, 4096, 2048), "prefill", 2048, 1e-05, False, False, False, LLAMA_1B, 0.999, id="1x1-prefill-4096-1B", marks=_slow),
+        pytest.param((1, 1), (1, 1, 8192, 2048), "prefill", 2048, 1e-05, False, False, False, LLAMA_1B, 0.999, id="1x1-prefill-8192-1B", marks=_slow),
+        pytest.param((1, 1), (1, 1, 32, 2048), "decode", 2048, 1e-05, True, True, False, LLAMA_1B, 0.999, id="1x1-decode-32-1B", marks=_slow),
+        pytest.param((1, 1), (1, 1, 16384, 2048), "prefill", 2048, 1e-05, False, False, False, LLAMA_1B, 0.999, id="1x1-prefill-16384-1B", marks=_slow),
+        pytest.param((1, 1), (1, 1, 32768, 2048), "prefill", 2048, 1e-05, False, False, False, LLAMA_1B, 0.999, id="1x1-prefill-32768-1B", marks=_slow),
+        pytest.param((1, 1), (1, 1, 128, 3072), "prefill", 3072, 1e-05, False, False, False, LLAMA_3B, 0.999, id="1x1-prefill-128-3B", marks=_slow),
+        pytest.param((1, 1), (1, 1, 32, 3072), "prefill", 3072, 1e-05, False, False, False, LLAMA_3B, 0.999, id="1x1-prefill-32-3B", marks=_slow),
+        pytest.param((1, 1), (1, 1, 1024, 3072), "prefill", 3072, 1e-05, False, False, False, LLAMA_3B, 0.999, id="1x1-prefill-1024-3B", marks=_slow),
+        pytest.param((1, 1), (1, 1, 2048, 3072), "prefill", 3072, 1e-05, False, False, False, LLAMA_3B, 0.999, id="1x1-prefill-2048-3B", marks=_slow),
+        pytest.param((1, 1), (1, 1, 4096, 3072), "prefill", 3072, 1e-05, False, False, False, LLAMA_3B, 0.999, id="1x1-prefill-4096-3B", marks=_slow),
+        pytest.param((1, 1), (1, 1, 8192, 3072), "prefill", 3072, 1e-05, False, False, False, LLAMA_3B, 0.999, id="1x1-prefill-8192-3B", marks=_slow),
+        pytest.param((1, 1), (1, 1, 32, 3072), "decode", 3072, 1e-05, True, True, False, LLAMA_3B, 0.999, id="1x1-decode-32-3B", marks=_slow),
+        pytest.param((1, 1), (1, 1, 128, 4096), "prefill", 4096, 1e-05, False, False, False, LLAMA_8B, 0.999, id="1x1-prefill-128-8B", marks=_slow),
+        pytest.param((1, 1), (1, 1, 32, 4096), "prefill", 4096, 1e-05, False, False, False, LLAMA_8B, 0.999, id="1x1-prefill-32-8B", marks=_slow),
+        pytest.param((1, 1), (1, 1, 1024, 4096), "prefill", 4096, 1e-05, False, False, False, LLAMA_8B, 0.999, id="1x1-prefill-1024-8B", marks=_slow),
+        pytest.param((1, 1), (1, 1, 2048, 4096), "prefill", 4096, 1e-05, False, False, False, LLAMA_8B, 0.999, id="1x1-prefill-2048-8B", marks=_slow),
+        pytest.param((1, 1), (1, 1, 4096, 4096), "prefill", 4096, 1e-05, False, False, False, LLAMA_8B, 0.999, id="1x1-prefill-4096-8B", marks=_slow),
+        pytest.param((1, 1), (1, 1, 32, 4096), "decode", 4096, 1e-05, True, True, False, LLAMA_8B, 0.999, id="1x1-decode-32-8B", marks=_slow),
+        pytest.param((1, 1), (1, 1, 128, 4096), "prefill", 4096, 1e-05, False, False, False, MISTRAL_7B, 0.999, id="1x1-prefill-128-7B", marks=_slow),
+        pytest.param((1, 1), (1, 1, 32, 4096), "prefill", 4096, 1e-05, False, False, False, MISTRAL_7B, 0.999, id="1x1-prefill-32-7B", marks=_slow),
+        pytest.param((1, 1), (1, 1, 1024, 4096), "prefill", 4096, 1e-05, False, False, False, MISTRAL_7B, 0.999, id="1x1-prefill-1024-7B", marks=_slow),
+        pytest.param((1, 1), (1, 1, 2048, 4096), "prefill", 4096, 1e-05, False, False, False, MISTRAL_7B, 0.999, id="1x1-prefill-2048-7B", marks=_slow),
+        pytest.param((1, 1), (1, 1, 4096, 4096), "prefill", 4096, 1e-05, False, False, False, MISTRAL_7B, 0.999, id="1x1-prefill-4096-7B", marks=_slow),
+        pytest.param((1, 1), (1, 1, 32, 4096), "decode", 4096, 1e-05, True, True, False, MISTRAL_7B, 0.999, id="1x1-decode-32-7B", marks=_slow),
+        # Mesh 1x2
+        pytest.param((1, 2), (1, 1, 128, 4096), "prefill", 4096, 1e-05, False, False, False, LLAMA_11B, 0.999, id="1x2-prefill-128-1B", marks=_slow),
+        pytest.param((1, 2), (1, 4, 6528, 128), "decode", 128, 1e-05, False, False, False, LLAMA_11B, 0.999, id="1x2-decode-6528x4-1B-vision", marks=_slow),
+        pytest.param((1, 2), (1, 16, 128, 128), "prefill", 128, 1e-05, False, False, False, LLAMA_11B, 0.999, id="1x2-prefill-128x16-1B-vision", marks=_slow),
+        pytest.param((1, 2), (1, 1, 32, 4096), "prefill", 4096, 1e-05, False, False, False, LLAMA_11B, 0.999, id="1x2-prefill-32-1B", marks=_slow),
+        pytest.param((1, 2), (1, 1, 32, 4096), "decode", 4096, 1e-05, True, True, False, LLAMA_11B, 0.999, id="1x2-decode-32-1B", marks=_slow),
+        pytest.param((1, 2), (1, 16, 16, 128), "decode", 128, 1e-05, False, False, False, LLAMA_11B, 0.999, id="1x2-decode-16x16-1B-vision", marks=_slow),
+        pytest.param((1, 2), (1, 4, 16, 128), "decode", 128, 1e-05, False, False, False, LLAMA_11B, 0.999, id="1x2-decode-16x4-1B-vision", marks=_slow),
+        pytest.param((1, 2), (1, 1, 128, 2048), "prefill", 2048, 1e-05, False, False, False, LLAMA_1B, 0.999, id="1x2-prefill-128-1B", marks=_slow),
+        pytest.param((1, 2), (1, 1, 32, 2048), "prefill", 2048, 1e-05, False, False, False, LLAMA_1B, 0.999, id="1x2-prefill-32-1B", marks=_slow),
+        pytest.param((1, 2), (1, 1, 1024, 2048), "prefill", 2048, 1e-05, False, False, False, LLAMA_1B, 0.999, id="1x2-prefill-1024-1B", marks=_slow),
+        pytest.param((1, 2), (1, 1, 2048, 2048), "prefill", 2048, 1e-05, False, False, False, LLAMA_1B, 0.999, id="1x2-prefill-2048-1B", marks=_slow),
+        pytest.param((1, 2), (1, 1, 4096, 2048), "prefill", 2048, 1e-05, False, False, False, LLAMA_1B, 0.999, id="1x2-prefill-4096-1B", marks=_slow),
+        pytest.param((1, 2), (1, 1, 8192, 2048), "prefill", 2048, 1e-05, False, False, False, LLAMA_1B, 0.999, id="1x2-prefill-8192-1B", marks=_slow),
+        pytest.param((1, 2), (1, 1, 32, 2048), "decode", 2048, 1e-05, True, True, False, LLAMA_1B, 0.999, id="1x2-decode-32-1B", marks=_slow),
+        pytest.param((1, 2), (1, 1, 16384, 2048), "prefill", 2048, 1e-05, False, False, False, LLAMA_1B, 0.999, id="1x2-prefill-16384-1B", marks=_slow),
+        pytest.param((1, 2), (1, 1, 32768, 2048), "prefill", 2048, 1e-05, False, False, False, LLAMA_1B, 0.999, id="1x2-prefill-32768-1B", marks=_slow),
+        pytest.param((1, 2), (1, 1, 128, 3072), "prefill", 3072, 1e-05, False, False, False, LLAMA_3B, 0.999, id="1x2-prefill-128-3B", marks=_slow),
+        pytest.param((1, 2), (1, 1, 32, 3072), "prefill", 3072, 1e-05, False, False, False, LLAMA_3B, 0.999, id="1x2-prefill-32-3B", marks=_slow),
+        pytest.param((1, 2), (1, 1, 1024, 3072), "prefill", 3072, 1e-05, False, False, False, LLAMA_3B, 0.999, id="1x2-prefill-1024-3B", marks=_slow),
+        pytest.param((1, 2), (1, 1, 2048, 3072), "prefill", 3072, 1e-05, False, False, False, LLAMA_3B, 0.999, id="1x2-prefill-2048-3B", marks=_slow),
+        pytest.param((1, 2), (1, 1, 4096, 3072), "prefill", 3072, 1e-05, False, False, False, LLAMA_3B, 0.999, id="1x2-prefill-4096-3B", marks=_slow),
+        pytest.param((1, 2), (1, 1, 8192, 3072), "prefill", 3072, 1e-05, False, False, False, LLAMA_3B, 0.999, id="1x2-prefill-8192-3B", marks=_slow),
+        pytest.param((1, 2), (1, 1, 32, 3072), "decode", 3072, 1e-05, True, True, False, LLAMA_3B, 0.999, id="1x2-decode-32-3B", marks=_slow),
+        pytest.param((1, 2), (1, 1, 16384, 3072), "prefill", 3072, 1e-05, False, False, False, LLAMA_3B, 0.999, id="1x2-prefill-16384-3B", marks=_slow),
+        pytest.param((1, 2), (1, 1, 32768, 3072), "prefill", 3072, 1e-05, False, False, False, LLAMA_3B, 0.999, id="1x2-prefill-32768-3B", marks=_slow),
+        pytest.param((1, 2), (1, 1, 128, 4096), "prefill", 4096, 1e-05, False, False, False, LLAMA_8B, 0.999, id="1x2-prefill-128-8B", marks=_slow),
+        pytest.param((1, 2), (1, 1, 32, 4096), "prefill", 4096, 1e-05, False, False, False, LLAMA_8B, 0.999, id="1x2-prefill-32-8B", marks=_slow),
+        pytest.param((1, 2), (1, 1, 1024, 4096), "prefill", 4096, 1e-05, False, False, False, LLAMA_8B, 0.999, id="1x2-prefill-1024-8B", marks=_slow),
+        pytest.param((1, 2), (1, 1, 2048, 4096), "prefill", 4096, 1e-05, False, False, False, LLAMA_8B, 0.999, id="1x2-prefill-2048-8B", marks=_slow),
+        pytest.param((1, 2), (1, 1, 4096, 4096), "prefill", 4096, 1e-05, False, False, False, LLAMA_8B, 0.999, id="1x2-prefill-4096-8B", marks=_slow),
+        pytest.param((1, 2), (1, 1, 8192, 4096), "prefill", 4096, 1e-05, False, False, False, LLAMA_8B, 0.999, id="1x2-prefill-8192-8B", marks=_slow),
+        pytest.param((1, 2), (1, 1, 32, 4096), "decode", 4096, 1e-05, True, True, False, LLAMA_8B, 0.999, id="1x2-decode-32-8B", marks=_slow),
+        pytest.param((1, 2), (1, 1, 16384, 4096), "prefill", 4096, 1e-05, False, False, False, LLAMA_8B, 0.999, id="1x2-prefill-16384-8B", marks=_slow),
+        pytest.param((1, 2), (1, 1, 32768, 4096), "prefill", 4096, 1e-05, False, False, False, LLAMA_8B, 0.999, id="1x2-prefill-32768-8B", marks=_slow),
+        pytest.param((1, 2), (1, 1, 1024, 4096), "prefill", 4096, 1e-05, False, False, False, LLAMA_11B, 0.999, id="1x2-prefill-1024-1B", marks=_slow),
+        pytest.param((1, 2), (1, 1, 2048, 4096), "prefill", 4096, 1e-05, False, False, False, LLAMA_11B, 0.999, id="1x2-prefill-2048-1B", marks=_slow),
+        pytest.param((1, 2), (1, 1, 4096, 4096), "prefill", 4096, 1e-05, False, False, False, LLAMA_11B, 0.999, id="1x2-prefill-4096-1B", marks=_slow),
+        pytest.param((1, 2), (1, 1, 8192, 4096), "prefill", 4096, 1e-05, False, False, False, LLAMA_11B, 0.999, id="1x2-prefill-8192-1B", marks=_slow),
+        pytest.param((1, 2), (1, 1, 16384, 4096), "prefill", 4096, 1e-05, False, False, False, LLAMA_11B, 0.999, id="1x2-prefill-16384-1B", marks=_slow),
+        pytest.param((1, 2), (1, 1, 32768, 4096), "prefill", 4096, 1e-05, False, False, False, LLAMA_11B, 0.999, id="1x2-prefill-32768-1B", marks=_slow),
+        pytest.param((1, 2), (1, 1, 128, 4096), "prefill", 4096, 1e-05, False, False, False, MISTRAL_7B, 0.999, id="1x2-prefill-128-7B", marks=_slow),
+        pytest.param((1, 2), (1, 1, 32, 4096), "prefill", 4096, 1e-05, False, False, False, MISTRAL_7B, 0.999, id="1x2-prefill-32-7B", marks=_slow),
+        pytest.param((1, 2), (1, 1, 1024, 4096), "prefill", 4096, 1e-05, False, False, False, MISTRAL_7B, 0.999, id="1x2-prefill-1024-7B", marks=_slow),
+        pytest.param((1, 2), (1, 1, 2048, 4096), "prefill", 4096, 1e-05, False, False, False, MISTRAL_7B, 0.999, id="1x2-prefill-2048-7B", marks=_slow),
+        pytest.param((1, 2), (1, 1, 4096, 4096), "prefill", 4096, 1e-05, False, False, False, MISTRAL_7B, 0.999, id="1x2-prefill-4096-7B", marks=_slow),
+        pytest.param((1, 2), (1, 1, 32, 4096), "decode", 4096, 1e-05, True, True, False, MISTRAL_7B, 0.999, id="1x2-decode-32-7B", marks=_slow),
+        pytest.param((1, 2), (1, 1, 128, 3584), "prefill", 3584, 1e-06, False, False, False, QWEN2_7B, 0.999, id="1x2-prefill-128-7B", marks=_slow),
+        pytest.param((1, 2), (1, 1, 32, 3584), "prefill", 3584, 1e-06, False, False, False, QWEN2_7B, 0.999, id="1x2-prefill-32-7B", marks=_slow),
+        pytest.param((1, 2), (1, 1, 1024, 3584), "prefill", 3584, 1e-06, False, False, False, QWEN2_7B, 0.999, id="1x2-prefill-1024-7B", marks=_slow),
+        pytest.param((1, 2), (1, 1, 2048, 3584), "prefill", 3584, 1e-06, False, False, False, QWEN2_7B, 0.999, id="1x2-prefill-2048-7B", marks=_slow),
+        pytest.param((1, 2), (1, 1, 4096, 3584), "prefill", 3584, 1e-06, False, False, False, QWEN2_7B, 0.999, id="1x2-prefill-4096-7B", marks=_slow),
+        pytest.param((1, 2), (1, 1, 32, 3584), "decode", 3584, 1e-06, True, True, False, QWEN2_7B, 0.999, id="1x2-decode-32-7B", marks=_slow),
+        pytest.param((1, 2), (1, 1, 128, 2560), "prefill", 5120, 1e-05, False, False, True, DEEPSEEK_R1_14B, 0.999, id="1x2-prefill-128-DeepSeek-dist", marks=_slow),
+        pytest.param((1, 2), (1, 1, 32, 2560), "prefill", 5120, 1e-05, False, False, True, DEEPSEEK_R1_14B, 0.999, id="1x2-prefill-32-DeepSeek-dist", marks=_slow),
+        pytest.param((1, 2), (1, 1, 1024, 2560), "prefill", 5120, 1e-05, False, False, True, DEEPSEEK_R1_14B, 0.999, id="1x2-prefill-1024-DeepSeek-dist", marks=_slow),
+        pytest.param((1, 2), (1, 1, 2048, 2560), "prefill", 5120, 1e-05, False, False, True, DEEPSEEK_R1_14B, 0.999, id="1x2-prefill-2048-DeepSeek-dist", marks=_slow),
+        pytest.param((1, 2), (1, 1, 4096, 2560), "prefill", 5120, 1e-05, False, False, True, DEEPSEEK_R1_14B, 0.999, id="1x2-prefill-4096-DeepSeek-dist", marks=_slow),
+        pytest.param((1, 2), (1, 1, 8192, 2560), "prefill", 5120, 1e-05, False, False, True, DEEPSEEK_R1_14B, 0.999, id="1x2-prefill-8192-DeepSeek-dist", marks=_slow),
+        pytest.param((1, 2), (1, 1, 32, 5120), "decode", 5120, 1e-05, True, True, False, DEEPSEEK_R1_14B, 0.999, id="1x2-decode-32-DeepSeek", marks=_slow),
+        pytest.param((1, 2), (1, 1, 128, 3584), "prefill", 3584, 1e-06, False, False, False, QWEN25_7B, 0.999, id="1x2-prefill-128-7B", marks=_slow),
+        pytest.param((1, 2), (1, 1, 32, 3584), "prefill", 3584, 1e-06, False, False, False, QWEN25_7B, 0.999, id="1x2-prefill-32-7B", marks=_slow),
+        pytest.param((1, 2), (1, 1, 1024, 3584), "prefill", 3584, 1e-06, False, False, False, QWEN25_7B, 0.999, id="1x2-prefill-1024-7B", marks=_slow),
+        pytest.param((1, 2), (1, 1, 2048, 3584), "prefill", 3584, 1e-06, False, False, False, QWEN25_7B, 0.999, id="1x2-prefill-2048-7B", marks=_slow),
+        pytest.param((1, 2), (1, 1, 4096, 3584), "prefill", 3584, 1e-06, False, False, False, QWEN25_7B, 0.999, id="1x2-prefill-4096-7B", marks=_slow),
+        pytest.param((1, 2), (1, 1, 8192, 3584), "prefill", 3584, 1e-06, False, False, False, QWEN25_7B, 0.999, id="1x2-prefill-8192-7B", marks=_slow),
+        pytest.param((1, 2), (1, 1, 32, 3584), "decode", 3584, 1e-06, True, True, False, QWEN25_7B, 0.999, id="1x2-decode-32-7B", marks=_slow),
+        pytest.param((1, 2), (1, 1, 16384, 3584), "prefill", 3584, 1e-06, False, False, False, QWEN25_7B, 0.999, id="1x2-prefill-16384-7B", marks=_slow),
+        pytest.param((1, 2), (1, 1, 32768, 3584), "prefill", 3584, 1e-06, False, False, False, QWEN25_7B, 0.999, id="1x2-prefill-32768-7B", marks=_slow),
+        # Mesh 1x8
+        pytest.param((1, 8), (1, 1, 128, 4096), "prefill", 4096, 1e-05, False, False, False, LLAMA_11B, 0.999, id="1x8-prefill-128-1B", marks=_slow),
+        pytest.param((1, 8), (1, 1, 6528, 128), "decode", 128, 1e-05, False, False, False, LLAMA_11B, 0.999, id="1x8-decode-6528-1B", marks=_slow),
+        pytest.param((1, 8), (1, 4, 128, 128), "prefill", 128, 1e-05, False, False, False, LLAMA_11B, 0.999, id="1x8-prefill-128x4-1B-vision", marks=_slow),
+        pytest.param((1, 8), (1, 1, 32, 4096), "prefill", 4096, 1e-05, False, False, False, LLAMA_11B, 0.999, id="1x8-prefill-32-1B", marks=_slow),
+        pytest.param((1, 8), (1, 1, 32, 4096), "decode", 4096, 1e-05, True, True, False, LLAMA_11B, 0.999, id="1x8-decode-32-1B", marks=_slow),
+        pytest.param((1, 8), (1, 1, 4, 128), "decode", 128, 1e-05, False, False, False, LLAMA_11B, 0.999, id="1x8-decode-4-1B", marks=_slow),
+        pytest.param((1, 8), (1, 32, 4, 128), "decode", 128, 1e-05, False, False, False, LLAMA_11B, 0.999, id="1x8-decode-4x32-1B-vision", marks=_slow),
+        pytest.param((1, 8), (1, 4, 4, 128), "decode", 128, 1e-05, False, False, False, LLAMA_11B, 0.999, id="1x8-decode-4x4-1B-vision", marks=_slow),
+        pytest.param((1, 8), (1, 1, 128, 1024), "prefill", 8192, 1e-05, False, False, True, LLAMA_90B, 0.999, id="1x8-prefill-128-90B-dist", marks=_slow),
+        pytest.param((1, 8), (1, 1, 6528, 128), "decode", 128, 1e-05, False, False, False, LLAMA_90B, 0.999, id="1x8-decode-6528-90B", marks=_slow),
+        pytest.param((1, 8), (1, 8, 128, 128), "prefill", 128, 1e-05, False, False, False, LLAMA_90B, 0.999, id="1x8-prefill-128x8-90B-vision", marks=_slow),
+        pytest.param((1, 8), (1, 1, 32, 1024), "prefill", 8192, 1e-05, False, False, True, LLAMA_90B, 0.999, id="1x8-prefill-32-90B-dist", marks=_slow),
+        pytest.param((1, 8), (1, 1, 32, 8192), "decode", 8192, 1e-05, True, True, False, LLAMA_90B, 0.999, id="1x8-decode-32-90B", marks=_slow),
+        pytest.param((1, 8), (1, 1, 8, 128), "decode", 128, 1e-05, False, False, False, LLAMA_90B, 0.999, id="1x8-decode-8-90B", marks=_slow),
+        pytest.param((1, 8), (1, 1, 128, 2048), "prefill", 2048, 1e-05, False, False, False, LLAMA_1B, 0.999, id="1x8-prefill-128-1B", marks=_slow),
+        pytest.param((1, 8), (1, 1, 32, 2048), "prefill", 2048, 1e-05, False, False, False, LLAMA_1B, 0.999, id="1x8-prefill-32-1B", marks=_slow),
+        pytest.param((1, 8), (1, 1, 1024, 2048), "prefill", 2048, 1e-05, False, False, False, LLAMA_1B, 0.999, id="1x8-prefill-1024-1B", marks=_slow),
+        pytest.param((1, 8), (1, 1, 2048, 2048), "prefill", 2048, 1e-05, False, False, False, LLAMA_1B, 0.999, id="1x8-prefill-2048-1B", marks=_slow),
+        pytest.param((1, 8), (1, 1, 4096, 2048), "prefill", 2048, 1e-05, False, False, False, LLAMA_1B, 0.999, id="1x8-prefill-4096-1B", marks=_slow),
+        pytest.param((1, 8), (1, 1, 8192, 2048), "prefill", 2048, 1e-05, False, False, False, LLAMA_1B, 0.999, id="1x8-prefill-8192-1B", marks=_slow),
+        pytest.param((1, 8), (1, 1, 32, 2048), "decode", 2048, 1e-05, True, True, False, LLAMA_1B, 0.999, id="1x8-decode-32-1B", marks=_slow),
+        pytest.param((1, 8), (1, 1, 16384, 2048), "prefill", 2048, 1e-05, False, False, False, LLAMA_1B, 0.999, id="1x8-prefill-16384-1B", marks=_slow),
+        pytest.param((1, 8), (1, 1, 32768, 2048), "prefill", 2048, 1e-05, False, False, False, LLAMA_1B, 0.999, id="1x8-prefill-32768-1B", marks=_slow),
+        pytest.param((1, 8), (1, 1, 128, 3072), "prefill", 3072, 1e-05, False, False, False, LLAMA_3B, 0.999, id="1x8-prefill-128-3B", marks=_slow),
+        pytest.param((1, 8), (1, 1, 32, 3072), "prefill", 3072, 1e-05, False, False, False, LLAMA_3B, 0.999, id="1x8-prefill-32-3B", marks=_slow),
+        pytest.param((1, 8), (1, 1, 1024, 3072), "prefill", 3072, 1e-05, False, False, False, LLAMA_3B, 0.999, id="1x8-prefill-1024-3B", marks=_slow),
+        pytest.param((1, 8), (1, 1, 2048, 3072), "prefill", 3072, 1e-05, False, False, False, LLAMA_3B, 0.999, id="1x8-prefill-2048-3B", marks=_slow),
+        pytest.param((1, 8), (1, 1, 4096, 3072), "prefill", 3072, 1e-05, False, False, False, LLAMA_3B, 0.999, id="1x8-prefill-4096-3B", marks=_slow),
+        pytest.param((1, 8), (1, 1, 8192, 3072), "prefill", 3072, 1e-05, False, False, False, LLAMA_3B, 0.999, id="1x8-prefill-8192-3B", marks=_slow),
+        pytest.param((1, 8), (1, 1, 32, 3072), "decode", 3072, 1e-05, True, True, False, LLAMA_3B, 0.999, id="1x8-decode-32-3B", marks=_slow),
+        pytest.param((1, 8), (1, 1, 16384, 3072), "prefill", 3072, 1e-05, False, False, False, LLAMA_3B, 0.999, id="1x8-prefill-16384-3B", marks=_slow),
+        pytest.param((1, 8), (1, 1, 32768, 3072), "prefill", 3072, 1e-05, False, False, False, LLAMA_3B, 0.999, id="1x8-prefill-32768-3B", marks=_slow),
+        pytest.param((1, 8), (1, 1, 128, 4096), "prefill", 4096, 1e-05, False, False, False, LLAMA_8B, 0.999, id="1x8-prefill-128-8B", marks=_slow),
+        pytest.param((1, 8), (1, 1, 32, 4096), "prefill", 4096, 1e-05, False, False, False, LLAMA_8B, 0.999, id="1x8-prefill-32-8B", marks=_slow),
+        pytest.param((1, 8), (1, 1, 1024, 4096), "prefill", 4096, 1e-05, False, False, False, LLAMA_8B, 0.999, id="1x8-prefill-1024-8B", marks=_slow),
+        pytest.param((1, 8), (1, 1, 2048, 4096), "prefill", 4096, 1e-05, False, False, False, LLAMA_8B, 0.999, id="1x8-prefill-2048-8B", marks=_slow),
+        pytest.param((1, 8), (1, 1, 4096, 4096), "prefill", 4096, 1e-05, False, False, False, LLAMA_8B, 0.999, id="1x8-prefill-4096-8B", marks=_slow),
+        pytest.param((1, 8), (1, 1, 8192, 4096), "prefill", 4096, 1e-05, False, False, False, LLAMA_8B, 0.999, id="1x8-prefill-8192-8B", marks=_slow),
+        pytest.param((1, 8), (1, 1, 32, 4096), "decode", 4096, 1e-05, True, True, False, LLAMA_8B, 0.999, id="1x8-decode-32-8B", marks=_slow),
+        pytest.param((1, 8), (1, 1, 16384, 4096), "prefill", 4096, 1e-05, False, False, False, LLAMA_8B, 0.999, id="1x8-prefill-16384-8B", marks=_slow),
+        pytest.param((1, 8), (1, 1, 32768, 4096), "prefill", 4096, 1e-05, False, False, False, LLAMA_8B, 0.999, id="1x8-prefill-32768-8B", marks=_slow),
+        pytest.param((1, 8), (1, 1, 1024, 4096), "prefill", 4096, 1e-05, False, False, False, LLAMA_11B, 0.999, id="1x8-prefill-1024-1B", marks=_slow),
+        pytest.param((1, 8), (1, 1, 2048, 4096), "prefill", 4096, 1e-05, False, False, False, LLAMA_11B, 0.999, id="1x8-prefill-2048-1B", marks=_slow),
+        pytest.param((1, 8), (1, 1, 4096, 4096), "prefill", 4096, 1e-05, False, False, False, LLAMA_11B, 0.999, id="1x8-prefill-4096-1B", marks=_slow),
+        pytest.param((1, 8), (1, 1, 8192, 4096), "prefill", 4096, 1e-05, False, False, False, LLAMA_11B, 0.999, id="1x8-prefill-8192-1B", marks=_slow),
+        pytest.param((1, 8), (1, 1, 16384, 4096), "prefill", 4096, 1e-05, False, False, False, LLAMA_11B, 0.999, id="1x8-prefill-16384-1B", marks=_slow),
+        pytest.param((1, 8), (1, 1, 32768, 4096), "prefill", 4096, 1e-05, False, False, False, LLAMA_11B, 0.999, id="1x8-prefill-32768-1B", marks=_slow),
+        pytest.param((1, 8), (1, 1, 128, 1024), "prefill", 8192, 1e-05, False, False, True, LLAMA_70B, 0.999, id="1x8-prefill-128-70B-dist", marks=_slow),
+        pytest.param((1, 8), (1, 1, 32, 1024), "prefill", 8192, 1e-05, False, False, True, LLAMA_70B, 0.999, id="1x8-prefill-32-70B-dist", marks=_slow),
+        pytest.param((1, 8), (1, 1, 1024, 1024), "prefill", 8192, 1e-05, False, False, True, LLAMA_70B, 0.999, id="1x8-prefill-1024-70B-dist", marks=_slow),
+        pytest.param((1, 8), (1, 1, 2048, 1024), "prefill", 8192, 1e-05, False, False, True, LLAMA_70B, 0.999, id="1x8-prefill-2048-70B-dist", marks=_slow),
+        pytest.param((1, 8), (1, 1, 4096, 1024), "prefill", 8192, 1e-05, False, False, True, LLAMA_70B, 0.999, id="1x8-prefill-4096-70B-dist", marks=_slow),
+        pytest.param((1, 8), (1, 1, 32, 8192), "decode", 8192, 1e-05, True, True, False, LLAMA_70B, 0.999, id="1x8-decode-32-70B", marks=_slow),
+        pytest.param((1, 8), (1, 1, 128, 1024), "prefill", 8192, 1e-06, False, False, True, QWEN25_72B, 0.999, id="1x8-prefill-128-Qwen2.5-dist", marks=_slow),
+        pytest.param((1, 8), (1, 1, 32, 1024), "prefill", 8192, 1e-06, False, False, True, QWEN25_72B, 0.999, id="1x8-prefill-32-Qwen2.5-dist", marks=_slow),
+        pytest.param((1, 8), (1, 1, 1024, 1024), "prefill", 8192, 1e-06, False, False, True, QWEN25_72B, 0.999, id="1x8-prefill-1024-Qwen2.5-dist", marks=_slow),
+        pytest.param((1, 8), (1, 1, 2048, 1024), "prefill", 8192, 1e-06, False, False, True, QWEN25_72B, 0.999, id="1x8-prefill-2048-Qwen2.5-dist", marks=_slow),
+        pytest.param((1, 8), (1, 1, 4096, 1024), "prefill", 8192, 1e-06, False, False, True, QWEN25_72B, 0.999, id="1x8-prefill-4096-Qwen2.5-dist", marks=_slow),
+        pytest.param((1, 8), (1, 1, 8192, 1024), "prefill", 8192, 1e-06, False, False, True, QWEN25_72B, 0.999, id="1x8-prefill-8192-Qwen2.5-dist", marks=_slow),
+        pytest.param((1, 8), (1, 1, 32, 8192), "decode", 8192, 1e-06, True, True, False, QWEN25_72B, 0.999, id="1x8-decode-32-Qwen2.5", marks=_slow),
+        pytest.param((1, 8), (1, 1, 16384, 1024), "prefill", 8192, 1e-06, False, False, True, QWEN25_72B, 0.999, id="1x8-prefill-16384-Qwen2.5-dist", marks=_slow),
+        pytest.param((1, 8), (1, 1, 128, 640), "prefill", 5120, 1e-06, False, False, True, QWEN25_CODER_32B, 0.999, id="1x8-prefill-128-32B-dist", marks=_slow),
+        pytest.param((1, 8), (1, 1, 32, 640), "prefill", 5120, 1e-06, False, False, True, QWEN25_CODER_32B, 0.999, id="1x8-prefill-32-32B-dist", marks=_slow),
+        pytest.param((1, 8), (1, 1, 1024, 640), "prefill", 5120, 1e-06, False, False, True, QWEN25_CODER_32B, 0.999, id="1x8-prefill-1024-32B-dist", marks=_slow),
+        pytest.param((1, 8), (1, 1, 2048, 640), "prefill", 5120, 1e-06, False, False, True, QWEN25_CODER_32B, 0.999, id="1x8-prefill-2048-32B-dist", marks=_slow),
+        pytest.param((1, 8), (1, 1, 4096, 640), "prefill", 5120, 1e-06, False, False, True, QWEN25_CODER_32B, 0.999, id="1x8-prefill-4096-32B-dist", marks=_slow),
+        pytest.param((1, 8), (1, 1, 32, 5120), "decode", 5120, 1e-06, True, True, False, QWEN25_CODER_32B, 0.999, id="1x8-decode-32-32B", marks=_slow),
+        pytest.param((1, 8), (1, 1, 128, 640), "prefill", 5120, 1e-06, False, False, True, QWEN3_32B, 0.999, id="1x8-prefill-128-32B-dist", marks=_slow),
+        pytest.param((1, 8), (1, 8, 128, 128), "prefill", 128, 1e-06, False, False, False, QWEN3_32B, 0.999, id="1x8-prefill-128x8-32B-vision", marks=_slow),
+        pytest.param((1, 8), (1, 1, 128, 128), "prefill", 128, 1e-06, False, False, False, QWEN3_32B, 0.999, id="1x8-prefill-128-32B", marks=_slow),
+        pytest.param((1, 8), (1, 1, 32, 640), "prefill", 5120, 1e-06, False, False, True, QWEN3_32B, 0.999, id="1x8-prefill-32-32B-dist", marks=_slow),
+        pytest.param((1, 8), (1, 1, 1024, 640), "prefill", 5120, 1e-06, False, False, True, QWEN3_32B, 0.999, id="1x8-prefill-1024-32B-dist", marks=_slow),
+        pytest.param((1, 8), (1, 8, 1024, 128), "prefill", 128, 1e-06, False, False, False, QWEN3_32B, 0.999, id="1x8-prefill-1024x8-32B-vision", marks=_slow),
+        pytest.param((1, 8), (1, 1, 1024, 128), "prefill", 128, 1e-06, False, False, False, QWEN3_32B, 0.999, id="1x8-prefill-1024-32B", marks=_slow),
+        pytest.param((1, 8), (1, 1, 2048, 640), "prefill", 5120, 1e-06, False, False, True, QWEN3_32B, 0.999, id="1x8-prefill-2048-32B-dist", marks=_slow),
+        pytest.param((1, 8), (1, 8, 2048, 128), "prefill", 128, 1e-06, False, False, False, QWEN3_32B, 0.999, id="1x8-prefill-2048x8-32B-vision", marks=_slow),
+        pytest.param((1, 8), (1, 1, 2048, 128), "prefill", 128, 1e-06, False, False, False, QWEN3_32B, 0.999, id="1x8-prefill-2048-32B", marks=_slow),
+        pytest.param((1, 8), (1, 1, 4096, 640), "prefill", 5120, 1e-06, False, False, True, QWEN3_32B, 0.999, id="1x8-prefill-4096-32B-dist", marks=_slow),
+        pytest.param((1, 8), (1, 8, 4096, 128), "prefill", 128, 1e-06, False, False, False, QWEN3_32B, 0.999, id="1x8-prefill-4096x8-32B-vision", marks=_slow),
+        pytest.param((1, 8), (1, 1, 4096, 128), "prefill", 128, 1e-06, False, False, False, QWEN3_32B, 0.999, id="1x8-prefill-4096-32B", marks=_slow),
+        pytest.param((1, 8), (1, 1, 32, 5120), "decode", 5120, 1e-06, True, True, False, QWEN3_32B, 0.999, id="1x8-decode-32-32B", marks=_slow),
+        pytest.param((1, 8), (1, 1, 8, 128), "decode", 128, 1e-06, False, False, False, QWEN3_32B, 0.999, id="1x8-decode-8-32B", marks=_slow),
+        pytest.param((1, 8), (1, 1, 1, 128), "decode", 128, 1e-06, False, False, False, QWEN3_32B, 0.999, id="1x8-decode-1-32B", marks=_slow),
+        pytest.param((1, 8), (1, 1, 16384, 640), "prefill", 5120, 1e-06, False, False, True, QWEN3_32B, 0.999, id="1x8-prefill-16384-32B-dist", marks=_slow),
+        pytest.param((1, 8), (1, 8, 16384, 128), "prefill", 128, 1e-06, False, False, False, QWEN3_32B, 0.999, id="1x8-prefill-16384x8-32B-vision", marks=_slow),
+        pytest.param((1, 8), (1, 1, 16384, 128), "prefill", 128, 1e-06, False, False, False, QWEN3_32B, 0.999, id="1x8-prefill-16384-32B", marks=_slow),
+        pytest.param((1, 8), (1, 1, 128, 4096), "prefill", 4096, 1e-05, False, False, False, MISTRAL_7B, 0.999, id="1x8-prefill-128-7B", marks=_slow),
+        pytest.param((1, 8), (1, 1, 32, 4096), "prefill", 4096, 1e-05, False, False, False, MISTRAL_7B, 0.999, id="1x8-prefill-32-7B", marks=_slow),
+        pytest.param((1, 8), (1, 1, 1024, 4096), "prefill", 4096, 1e-05, False, False, False, MISTRAL_7B, 0.999, id="1x8-prefill-1024-7B", marks=_slow),
+        pytest.param((1, 8), (1, 1, 2048, 4096), "prefill", 4096, 1e-05, False, False, False, MISTRAL_7B, 0.999, id="1x8-prefill-2048-7B", marks=_slow),
+        pytest.param((1, 8), (1, 1, 4096, 4096), "prefill", 4096, 1e-05, False, False, False, MISTRAL_7B, 0.999, id="1x8-prefill-4096-7B", marks=_slow),
+        pytest.param((1, 8), (1, 1, 32, 4096), "decode", 4096, 1e-05, True, True, False, MISTRAL_7B, 0.999, id="1x8-decode-32-7B", marks=_slow),
+        pytest.param((1, 8), (1, 1, 128, 4096), "prefill", 4096, 1e-05, False, False, False, MIXTRAL_MOE, 0.999, id="1x8-prefill-128-7B", marks=_slow),
+        pytest.param((1, 8), (1, 1, 32, 4096), "prefill", 4096, 1e-05, False, False, False, MIXTRAL_MOE, 0.999, id="1x8-prefill-32-7B", marks=_slow),
+        pytest.param((1, 8), (1, 1, 1024, 4096), "prefill", 4096, 1e-05, False, False, False, MIXTRAL_MOE, 0.999, id="1x8-prefill-1024-7B", marks=_slow),
+        pytest.param((1, 8), (1, 1, 2048, 4096), "prefill", 4096, 1e-05, False, False, False, MIXTRAL_MOE, 0.999, id="1x8-prefill-2048-7B", marks=_slow),
+        pytest.param((1, 8), (1, 1, 4096, 4096), "prefill", 4096, 1e-05, False, False, False, MIXTRAL_MOE, 0.999, id="1x8-prefill-4096-7B", marks=_slow),
+        pytest.param((1, 8), (1, 1, 32, 4096), "decode", 4096, 1e-05, True, True, False, MIXTRAL_MOE, 0.999, id="1x8-decode-32-7B", marks=_slow),
+    ]
+    # fmt: on
+
+
+def _list_rmsnorm_2d_unique_test_cases() -> list[pytest.param]:
+    """
+    Unique test cases from rmsnorm_2d_testcases.csv (not duplicated in rmsnorm_1d_testcases.csv).
+
+    These are the 1x4 cluster shape cases for Llama-3.1-8B that only exist in the 2D file.
+    Note: Despite being in the "2D" file, these are still 1D topologies (cluster_shape_x=1).
+    """
+    # fmt: off
+    return [
+        # === Fast tests (1x4 minimal coverage) ===
+        pytest.param((1, 4), (1, 1, 128, 4096), "prefill", 4096, 1e-5, False, False, False, LLAMA_8B, 0.999, id="1x4-prefill-128-8B"),
+        pytest.param((1, 4), (1, 1, 32, 4096), "decode", 4096, 1e-5, True, True, False, LLAMA_8B, 0.999, id="1x4-decode-32-8B"),
+        # === Slow tests (full 1x4 coverage) ===
+        pytest.param((1, 4), (1, 1, 32, 4096), "prefill", 4096, 1e-5, False, False, False, LLAMA_8B, 0.999, id="1x4-prefill-32-8B", marks=_slow),
+        pytest.param((1, 4), (1, 1, 1024, 4096), "prefill", 4096, 1e-5, False, False, False, LLAMA_8B, 0.999, id="1x4-prefill-1024-8B", marks=_slow),
+        pytest.param((1, 4), (1, 1, 2048, 4096), "prefill", 4096, 1e-5, False, False, False, LLAMA_8B, 0.999, id="1x4-prefill-2048-8B", marks=_slow),
+        pytest.param((1, 4), (1, 1, 4096, 4096), "prefill", 4096, 1e-5, False, False, False, LLAMA_8B, 0.999, id="1x4-prefill-4096-8B", marks=_slow),
+    ]
+    # fmt: on
+
+
+def _list_rmsnorm_1d_test_cases_from_distnorm() -> list[pytest.param]:
+    """
+    Test cases derived from rmsnorm_*d_testcases_by_dist_norm.csv (de-duplicated).
+
+    These are cases collected from distribute_norm.py runs, representing
+    actual production usage patterns. Many overlap with existing tests but
+    include some unique mesh/dim combinations.
+
+    Generated by: models/common/tests/modules/rmsnorm/dedup_dist_rmsnorm.py
+    """
+    # fmt: off
+    return [
+        # === Fast tests (minimal coverage from dist_norm runs) ===
+        # DeepSeek 1x2 distributed prefill
+        pytest.param((1, 2), (1, 1, 128, 2560), "prefill", 5120, 1e-05, False, False, True, DEEPSEEK_R1_14B, 0.999, id="1x2-prefill-128-DeepSeek-14B-dist"),
+        # Qwen 1x2 non-distributed (eps=1e-06)
+        pytest.param((1, 2), (1, 1, 128, 3584), "prefill", 3584, 1e-06, False, False, False, QWEN25_7B, 0.999, id="1x2-prefill-128-Qwen25-7B"),
+        # Qwen 1x8 distributed prefill
+        pytest.param((1, 8), (1, 1, 128, 1024), "prefill", 8192, 1e-06, False, False, True, QWEN25_72B, 0.999, id="1x8-prefill-128-Qwen25-72B-dist"),
+        # Llama 1x8 decode
+        pytest.param((1, 8), (1, 1, 32, 4096), "decode", 4096, 1e-05, True, True, False, LLAMA_8B, 0.999, id="1x8-decode-32-8B-dn"),
+
+        # === Slow tests (full coverage) ===
+        # DEEPSEEK_R1_14B
+        pytest.param((1, 2), (1, 1, 32, 5120), "decode", 5120, 1e-05, True, True, False, DEEPSEEK_R1_14B, 0.999, id="1x2-decode-32-DeepSeek-14B", marks=_slow),
+
+        # LLAMA_11B
+        pytest.param((1, 2), (1, 1, 32, 4096), "decode", 4096, 1e-05, True, True, False, LLAMA_11B, 0.999, id="1x2-decode-32-11B", marks=_slow),
+        pytest.param((1, 2), (1, 1, 128, 4096), "prefill", 4096, 1e-05, False, False, False, LLAMA_11B, 0.999, id="1x2-prefill-128-11B", marks=_slow),
+        pytest.param((1, 8), (1, 1, 32, 4096), "decode", 4096, 1e-05, True, True, False, LLAMA_11B, 0.999, id="1x8-decode-32-11B", marks=_slow),
+        pytest.param((1, 8), (1, 1, 128, 4096), "prefill", 4096, 1e-05, False, False, False, LLAMA_11B, 0.999, id="1x8-prefill-128-11B", marks=_slow),
+
+        # LLAMA_1B
+        pytest.param((1, 1), (1, 1, 32, 2048), "decode", 2048, 1e-05, True, True, False, LLAMA_1B, 0.999, id="1x1-decode-32-1B-dn", marks=_slow),
+        pytest.param((1, 1), (1, 1, 128, 2048), "prefill", 2048, 1e-05, False, False, False, LLAMA_1B, 0.999, id="1x1-prefill-128-1B-dn", marks=_slow),
+        pytest.param((1, 2), (1, 1, 32, 2048), "decode", 2048, 1e-05, True, True, False, LLAMA_1B, 0.999, id="1x2-decode-32-1B", marks=_slow),
+        pytest.param((1, 2), (1, 1, 128, 2048), "prefill", 2048, 1e-05, False, False, False, LLAMA_1B, 0.999, id="1x2-prefill-128-1B", marks=_slow),
+        pytest.param((1, 8), (1, 1, 32, 2048), "decode", 2048, 1e-05, True, True, False, LLAMA_1B, 0.999, id="1x8-decode-32-1B", marks=_slow),
+        pytest.param((1, 8), (1, 1, 128, 2048), "prefill", 2048, 1e-05, False, False, False, LLAMA_1B, 0.999, id="1x8-prefill-128-1B", marks=_slow),
+
+        # LLAMA_3B
+        pytest.param((1, 1), (1, 1, 32, 3072), "decode", 3072, 1e-05, True, True, False, LLAMA_3B, 0.999, id="1x1-decode-32-3B-dn", marks=_slow),
+        pytest.param((1, 1), (1, 1, 128, 3072), "prefill", 3072, 1e-05, False, False, False, LLAMA_3B, 0.999, id="1x1-prefill-128-3B-dn", marks=_slow),
+        pytest.param((1, 2), (1, 1, 32, 3072), "decode", 3072, 1e-05, True, True, False, LLAMA_3B, 0.999, id="1x2-decode-32-3B", marks=_slow),
+        pytest.param((1, 2), (1, 1, 128, 3072), "prefill", 3072, 1e-05, False, False, False, LLAMA_3B, 0.999, id="1x2-prefill-128-3B", marks=_slow),
+        pytest.param((1, 8), (1, 1, 32, 3072), "decode", 3072, 1e-05, True, True, False, LLAMA_3B, 0.999, id="1x8-decode-32-3B", marks=_slow),
+        pytest.param((1, 8), (1, 1, 128, 3072), "prefill", 3072, 1e-05, False, False, False, LLAMA_3B, 0.999, id="1x8-prefill-128-3B", marks=_slow),
+
+        # LLAMA_70B
+        pytest.param((1, 8), (1, 1, 32, 8192), "decode", 8192, 1e-05, True, True, False, LLAMA_70B, 0.999, id="1x8-decode-32-70B-dn", marks=_slow),
+        pytest.param((1, 8), (1, 1, 128, 1024), "prefill", 8192, 1e-05, False, False, True, LLAMA_70B, 0.999, id="1x8-prefill-128-70B-dist-dn", marks=_slow),
+
+        # LLAMA_8B
+        pytest.param((1, 1), (1, 1, 32, 4096), "decode", 4096, 1e-05, True, True, False, LLAMA_8B, 0.999, id="1x1-decode-32-8B-dn", marks=_slow),
+        pytest.param((1, 1), (1, 1, 128, 4096), "prefill", 4096, 1e-05, False, False, False, LLAMA_8B, 0.999, id="1x1-prefill-128-8B-dn", marks=_slow),
+        pytest.param((1, 2), (1, 1, 32, 4096), "decode", 4096, 1e-05, True, True, False, LLAMA_8B, 0.999, id="1x2-decode-32-8B-dn", marks=_slow),
+        pytest.param((1, 2), (1, 1, 128, 4096), "prefill", 4096, 1e-05, False, False, False, LLAMA_8B, 0.999, id="1x2-prefill-128-8B-dn", marks=_slow),
+        pytest.param((1, 8), (1, 1, 128, 4096), "prefill", 4096, 1e-05, False, False, False, LLAMA_8B, 0.999, id="1x8-prefill-128-8B-dn", marks=_slow),
+
+        # MISTRAL_7B
+        pytest.param((1, 1), (1, 1, 32, 4096), "decode", 4096, 1e-05, True, True, False, MISTRAL_7B, 0.999, id="1x1-decode-32-7B-dn", marks=_slow),
+        pytest.param((1, 1), (1, 1, 128, 4096), "prefill", 4096, 1e-05, False, False, False, MISTRAL_7B, 0.999, id="1x1-prefill-128-7B-dn", marks=_slow),
+        pytest.param((1, 2), (1, 1, 32, 4096), "decode", 4096, 1e-05, True, True, False, MISTRAL_7B, 0.999, id="1x2-decode-32-7B-dn", marks=_slow),
+        pytest.param((1, 2), (1, 1, 128, 4096), "prefill", 4096, 1e-05, False, False, False, MISTRAL_7B, 0.999, id="1x2-prefill-128-7B-dn", marks=_slow),
+        pytest.param((1, 8), (1, 1, 32, 4096), "decode", 4096, 1e-05, True, True, False, MISTRAL_7B, 0.999, id="1x8-decode-32-7B-dn", marks=_slow),
+        pytest.param((1, 8), (1, 1, 128, 4096), "prefill", 4096, 1e-05, False, False, False, MISTRAL_7B, 0.999, id="1x8-prefill-128-7B-dn", marks=_slow),
+
+        # MIXTRAL_MOE
+        pytest.param((1, 8), (1, 1, 32, 4096), "decode", 4096, 1e-05, True, True, False, MIXTRAL_MOE, 0.999, id="1x8-decode-32-MOE", marks=_slow),
+        pytest.param((1, 8), (1, 1, 128, 4096), "prefill", 4096, 1e-05, False, False, False, MIXTRAL_MOE, 0.999, id="1x8-prefill-128-MOE", marks=_slow),
+
+        # QWEN25_72B
+        pytest.param((1, 8), (1, 1, 32, 8192), "decode", 8192, 1e-06, True, True, False, QWEN25_72B, 0.999, id="1x8-decode-32-Qwen25-72B", marks=_slow),
+
+        # QWEN25_7B
+        pytest.param((1, 2), (1, 1, 32, 3584), "decode", 3584, 1e-06, True, True, False, QWEN25_7B, 0.999, id="1x2-decode-32-Qwen25-7B", marks=_slow),
+
+        # QWEN25_CODER_32B
+        pytest.param((1, 8), (1, 1, 32, 5120), "decode", 5120, 1e-06, True, True, False, QWEN25_CODER_32B, 0.999, id="1x8-decode-32-Qwen25-Coder-32B", marks=_slow),
+        pytest.param((1, 8), (1, 1, 128, 640), "prefill", 5120, 1e-06, False, False, True, QWEN25_CODER_32B, 0.999, id="1x8-prefill-128-Qwen25-Coder-32B-dist", marks=_slow),
+
+        # QWEN2_7B
+        pytest.param((1, 2), (1, 1, 32, 3584), "decode", 3584, 1e-06, True, True, False, QWEN2_7B, 0.999, id="1x2-decode-32-Qwen2-7B", marks=_slow),
+        pytest.param((1, 2), (1, 1, 128, 3584), "prefill", 3584, 1e-06, False, False, False, QWEN2_7B, 0.999, id="1x2-prefill-128-Qwen2-7B", marks=_slow),
+
+        # QWEN3_32B
+        pytest.param((1, 8), (1, 1, 32, 5120), "decode", 5120, 1e-06, True, True, False, QWEN3_32B, 0.999, id="1x8-decode-32-Qwen3-32B", marks=_slow),
+        pytest.param((1, 8), (1, 1, 128, 640), "prefill", 5120, 1e-06, False, False, True, QWEN3_32B, 0.999, id="1x8-prefill-128-Qwen3-32B-dist", marks=_slow),
+    ]
+    # fmt: on
+
+
+# ============================================================================
+# CSV-based Parametrized Test
+# ============================================================================
+
+
+@pytest.mark.parametrize(
+    "ttnn_mesh_device",
+    [(1, 1), (1, 2), (1, 4), (1, 8)],
+    ids=["1x1", "1x2", "1x4", "1x8"],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "mesh_shape,input_shard_shape,mode,dim,eps,in_sharded,out_sharded,is_distributed,model_name,pcc",
+    _list_rmsnorm_1d_test_cases() + _list_rmsnorm_2d_unique_test_cases() + _list_rmsnorm_1d_test_cases_from_distnorm(),
+)
+def test_rmsnorm_1d_vs_reference(
+    ttnn_mesh_device: ttnn.MeshDevice,
+    mesh_shape: tuple[int, int],
+    input_shard_shape: tuple[int, int, int, int],
+    mode: str,
+    dim: int,
+    eps: float,
+    in_sharded: bool,
+    out_sharded: bool,
+    is_distributed: bool,
+    model_name: str,
+    pcc: float,
+):
+    """
+    Test RMSNorm1D matches PyTorch reference for test cases from CSV files.
+
+    Test cases are derived from:
+    - rmsnorm_1d_testcases.csv (all cases)
+    - rmsnorm_2d_testcases.csv (unique 1x4 cases only, duplicates excluded)
+    """
+    # Skip if mesh_shape doesn't match the current device
+    if ttnn_mesh_device.shape != ttnn.MeshShape(*mesh_shape):
+        pytest.skip(f"Test requires {mesh_shape} mesh, got {ttnn_mesh_device.shape}")
+
+    seed = 1234
+    torch.manual_seed(seed)
+
+    # Create synthetic weights for RMSNorm reference.
+    # This approach is used for all cases because:
+    # 1. The test validates RMSNorm1D implementation correctness, not HF weight loading
+    # 2. Production code loads weights from state_dict, not HF AutoModel
+    # 3. The math is identical regardless of weight values
+    # 4. Avoids HF model loading overhead and config complexity (e.g., MllamaConfig)
+    # Weights are cached by dim to avoid regeneration across tests.
+    norm_weight = _get_or_create_synthetic_weight(dim, seed)
+    reference_norm = torch.nn.RMSNorm(dim, eps=eps).to(torch.bfloat16)
+    reference_norm.weight.data.copy_(norm_weight)
+
+    # Create input tensor with full hidden dimension
+    # input_shard_shape = (x0, x1, x2, x3) where:
+    # - x0, x1 = batch dimensions (x1 > 1 for vision encoder norms)
+    # - x2 = sequence length
+    # - x3 = per-device hidden dim (equals dim for non-distributed, dim/num_devices for distributed)
+    # We always create full input shape using dim, then let prepare_input_tensor handle sharding
+    torch_input = torch.randn(*input_shard_shape[:-1], dim, dtype=torch.bfloat16)
+
+    # Create LazyWeights
+    ttnn.SetDefaultDevice(ttnn_mesh_device)
+    cache_dir = Path(os.getenv("TT_CACHE_PATH", "model_cache/rmsnorm_1d"))
+
+    lazy_weight = LazyWeight(
+        source=norm_weight,  # Raw [dim] shape - module reshapes internally
+        dtype=ttnn.bfloat16,
+        cache_dir_weight_name=(cache_dir, f"norm_weight_{model_name}_dim{dim}"),
+    )
+
+    # Construct RMSNorm1D
+    # Happy path: standard cases with default eps and sharded decode
+    # Power path: vision encoder (interleaved decode) or non-default eps
+    is_default_eps = eps == 1e-5
+    is_default_sharding = in_sharded and out_sharded
+
+    # 1x4 mesh special case: Ring topology all_gather is not supported on 1x4 on WH LB/QB because
+    # fabric cannot route between non-adjacent devices (e.g., D0 -> D3). We must
+    # explicitly set prefill_distributed from test params to override auto-detection,
+    # which would otherwise enable distributed prefill based on num_devices and dim.
+    needs_explicit_distributed = mesh_shape == (1, 4)
+
+    if is_default_eps and is_default_sharding and not needs_explicit_distributed:
+        tt_model = RMSNorm1D(weight=lazy_weight)
+    else:
+        config = RMSNorm1DConfig(
+            weight=lazy_weight,
+            eps=eps,
+            decode_in_sharded=in_sharded,
+            decode_out_sharded=out_sharded,
+            prefill_distributed=is_distributed if needs_explicit_distributed else None,
+        )
+        tt_model = RMSNorm1D.from_config(config)
+
+    # Verify config matches expected sharding behavior from CSV
+    cfg = tt_model.config
+    if mode == "prefill":
+        # Prefill uses interleaved memory (not sharded)
+        assert not in_sharded, f"Prefill should have in_sharded=False, got {in_sharded}"
+        assert not out_sharded, f"Prefill should have out_sharded=False, got {out_sharded}"
+    else:  # decode
+        # Decode never uses distributed path
+        assert not is_distributed, f"Decode should have is_distributed=False, got {is_distributed}"
+        # Verify decode sharding config matches CSV
+        assert cfg.decode_in_sharded == in_sharded, f"Expected decode_in_sharded={in_sharded}"
+        assert cfg.decode_out_sharded == out_sharded, f"Expected decode_out_sharded={out_sharded}"
+        # in_sharded/out_sharded should match (decode either shards both or neither externally)
+        assert (
+            in_sharded == out_sharded
+        ), f"Decode in_sharded and out_sharded should match, got in={in_sharded}, out={out_sharded}"
+
+    # Run TT model - wrap input in LazyWeight, forward() handles conversion
+    tt_input = LazyWeight(source=torch_input, dtype=ttnn.bfloat16)
+    tt_output = tt_model.forward(tt_input, mode=mode)
+    tt_output_torch = to_torch_auto_compose(tt_output)
+    ttnn.SetDefaultDevice(None)
+
+    # Run reference model
+    # RMSNorm operates on last dimension, so reshape to 2D, apply, reshape back
+    # For distributed cases, torch_input already has full dim (not sharded)
+    original_shape = torch_input.shape
+    torch_input_2d = torch_input.reshape(-1, original_shape[-1])  # (batch*heads*seq, dim)
+    with torch.no_grad():
+        reference_output_2d = reference_norm(torch_input_2d)
+    reference_output = reference_output_2d.reshape(original_shape)
+
+    # For distributed cases with sharded output, we may need to adjust comparison
+    # The TT output is auto-composed (gathered) so should match full reference
+
+    # Compare
+    passing, pcc_message = comp_pcc(reference_output, tt_output_torch, pcc)
+
+    logger.info(comp_allclose(reference_output, tt_output_torch))
+    logger.info(f"RMSNorm1D vs HF reference: {pcc_message}")
+
+    assert passing, f"RMSNorm1D output does not meet PCC requirement {pcc}: {pcc_message}."
+    logger.info(
+        f"RMSNorm1D vs HF reference: PASSED for model={model_name}, mode={mode}, shard_shape={input_shard_shape}"
+    )
+
+
+# Get HF model name from environment variable or use default
+HF_MODEL_NAME = os.environ.get("HF_MODEL", "meta-llama/Llama-3.1-8B-Instruct")
+
+
+@pytest.mark.parametrize(
+    "ttnn_mesh_device",
+    [(1, 8)],
+    ids=["1x8"],
+    indirect=True,
+)
+@pytest.mark.parametrize("seq_len", [1, 128])
+def test_rmsnorm_1d_vs_reference_from_model_args(ttnn_mesh_device: ttnn.MeshDevice, seq_len: int):
+    """
+    Test RMSNorm1D.from_model_args() factory method.
+    """
+    from models.tt_transformers.tt.ccl import TT_CCL
+    from models.tt_transformers.tt.model_config import ModelArgs
+
+    seed = 1234
+    torch.manual_seed(seed)
+    batch_size = 1
+    mode = "decode" if seq_len <= 32 else "prefill"
+
+    # Create ModelArgs
+    model_args = ModelArgs(ttnn_mesh_device, max_batch_size=batch_size, max_seq_len=512, cache_hf=True)
+    model_args.n_layers = 1
+
+    # Load HF model for reference
+    hf_model_name = HF_MODEL_NAME
+    config = AutoConfig.from_pretrained(hf_model_name)
+    config.num_hidden_layers = 1
+
+    with no_init_weights():
+        hf_model = AutoModelForCausalLM.from_config(config, torch_dtype=torch.bfloat16)
+
+    first_layer = hf_model.model.layers[0]
+    reference_norm = first_layer.input_layernorm
+    _get_or_init_norm_weights(hf_model_name, reference_norm)
+
+    # Get state_dict
+    state_dict = hf_model.state_dict()
+
+    # Create TT_CCL
+    tt_ccl = TT_CCL(ttnn_mesh_device)
+
+    # Get model config for sharded configs
+    model_config = model_args.get_model_config()
+    sharded_program_config = model_config.get("SHARDED_NORM_ATTN_PRGM_CFG")
+    sharded_output_config = model_config.get("SHARDED_ATTN_INPUT_MEMCFG")
+
+    # Build RMSNorm1D via from_model_args
+    cache_dir = Path(os.getenv("TT_CACHE_PATH", "model_cache/rmsnorm_1d_from_args"))
+    tt_model = RMSNorm1D.from_model_args(
+        mesh_device=ttnn_mesh_device,
+        tt_ccl=tt_ccl,
+        args=model_args,
+        state_dict=state_dict,
+        weight_cache_path=cache_dir,
+        layer_num=0,
+        weight_key="input_layernorm",
+        state_dict_prefix="model.layers.0.",
+        sharded_program_config=sharded_program_config,
+        sharded_output_config=sharded_output_config,
+    )
+
+    # Run TT model
+    dim = config.hidden_size
+    torch_input = torch.randn(batch_size, 1, seq_len, dim, dtype=torch.bfloat16)
+    tt_input = LazyWeight(source=torch_input, dtype=ttnn.bfloat16)
+    ttnn.SetDefaultDevice(ttnn_mesh_device)
+    tt_output = tt_model.forward(tt_input, mode=mode)
+    tt_output_torch = to_torch_auto_compose(tt_output)
+    ttnn.SetDefaultDevice(None)
+
+    # Run reference
+    torch_input_squeezed = torch_input.squeeze(1)
+    with torch.no_grad():
+        reference_output = reference_norm(torch_input_squeezed)
+    reference_output = reference_output.unsqueeze(1)
+
+    # Compare
+    pcc = 0.999
+    passing, pcc_message = comp_pcc(reference_output, tt_output_torch, pcc)
+
+    logger.info(f"RMSNorm1D (from_model_args) vs HF reference: {pcc_message}")
+    assert passing, f"RMSNorm1D output does not meet PCC requirement {pcc}: {pcc_message}."
+
+
+def test_rmsnorm_1d_rejects_galaxy(expect_error):
+    """Test that RMSNorm1D.from_model_args raises error for Galaxy devices."""
+    mock_args = MagicMock()
+    mock_args.is_galaxy = True
+
+    with expect_error(ValueError, "cannot be used for Galaxy devices"):
+        RMSNorm1D.from_model_args(
+            mesh_device=MagicMock(),
+            tt_ccl=MagicMock(),
+            args=mock_args,
+            state_dict={},
+            weight_cache_path=None,
+            layer_num=0,
+            weight_key="input_layernorm",
+        )

--- a/models/experimental/llama32_1b_quasar/tests/modules/rope/test_rope_1d.py
+++ b/models/experimental/llama32_1b_quasar/tests/modules/rope/test_rope_1d.py
@@ -1,0 +1,845 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Tests for the RotarySetup1D module (1D mesh topology: N150, N300, T3K).
+
+This test suite verifies:
+1. Unit tests for config dataclass and transformation matrix utility
+2. RotarySetup1D init + API methods (get_both_trans_mats, forward)
+3. Numerical correctness vs pure-torch HF reference
+4. from_model_args backward compatibility (vs TTTv1)
+"""
+
+import math
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional, Tuple
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+from models.experimental.llama32_1b_quasar.auto_compose import to_torch_auto_compose
+from models.experimental.llama32_1b_quasar.modules.lazy_weight import LazyWeight
+from models.experimental.llama32_1b_quasar.modules.rope.rope_1d import Rope1DConfig, RotarySetup1D, prepare_rot_idxs
+from models.experimental.llama32_1b_quasar.tensor_utils import get_rot_transformation_mat
+from models.experimental.llama32_1b_quasar.utility_functions import comp_pcc
+
+# ============================================================================
+# Pure-torch RoPE reference (no TTTv1 dependency)
+# ============================================================================
+
+_slow = pytest.mark.slow
+
+
+@dataclass
+class Llama3Scaling:
+    """Llama-3.x frequency scaling parameters."""
+
+    factor: float = 8.0
+    original_max_position_embeddings: int = 8192
+    low_freq_factor: float = 1.0
+    high_freq_factor: float = 4.0
+
+
+def _apply_llama3_scaling(freqs: torch.Tensor, s: Llama3Scaling) -> torch.Tensor:
+    """Apply Llama-3.x frequency scaling (pure torch, mirrors HF implementation)."""
+    low_freq_wavelen = s.original_max_position_embeddings / s.low_freq_factor
+    high_freq_wavelen = s.original_max_position_embeddings / s.high_freq_factor
+    new_freqs = []
+    for freq in freqs:
+        wavelen = 2 * math.pi / freq
+        if wavelen < high_freq_wavelen:
+            new_freqs.append(freq)
+        elif wavelen > low_freq_wavelen:
+            new_freqs.append(freq / s.factor)
+        else:
+            smooth = (s.original_max_position_embeddings / wavelen - s.low_freq_factor) / (
+                s.high_freq_factor - s.low_freq_factor
+            )
+            new_freqs.append((1 - smooth) * freq / s.factor + smooth * freq)
+    return torch.tensor(new_freqs, dtype=freqs.dtype, device=freqs.device)
+
+
+def _rope_cos_sin(
+    head_dim: int,
+    max_seq_len: int,
+    theta: float,
+    scaling: Optional[Llama3Scaling] = None,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Compute RoPE cos/sin tables in Meta interleaved format (pure torch).
+
+    This is the HF reference implementation for RoPE, independent of TTTv1.
+
+    Returns:
+        cos, sin: [1, 1, max_seq_len, head_dim] in Meta interleaved format
+            where adjacent pairs repeat: [c0, c0, c1, c1, ...]
+    """
+    inv_freq = 1.0 / (theta ** (torch.arange(0, head_dim, 2).float() / head_dim))
+
+    if scaling is not None:
+        # Scaled: apply frequency adjustment, then gather
+        inv_freq = _apply_llama3_scaling(inv_freq, scaling)
+        t = torch.arange(max_seq_len * 2.0)
+        freqs = torch.outer(t, inv_freq).float()
+        cos = freqs.cos()
+        sin = freqs.sin()
+        # Gather sequential positions and interleave
+        positions = torch.arange(max_seq_len)
+        pos_expanded = positions.unsqueeze(1).expand(-1, cos.shape[-1])
+        cos = cos.gather(0, pos_expanded)
+        sin = sin.gather(0, pos_expanded)
+    else:
+        # Unscaled: standard RoPE
+        t = torch.arange(max_seq_len, dtype=inv_freq.dtype)
+        freqs = torch.outer(t, inv_freq)
+        cos = freqs.cos()
+        sin = freqs.sin()
+
+    # Convert to Meta interleaved format: [c0, c0, c1, c1, ...]
+    cos = torch.stack([cos, cos], dim=-1).flatten(-2).unsqueeze(0).unsqueeze(0)
+    sin = torch.stack([sin, sin], dim=-1).flatten(-2).unsqueeze(0).unsqueeze(0)
+    return cos, sin
+
+
+# ============================================================================
+# Unit Tests - No device required
+# ============================================================================
+
+
+def test_rope_1d_config_creation():
+    """Test that Rope1DConfig can be created with required fields."""
+    cos_source = torch.randn(1, 1, 8192, 128)
+    sin_source = torch.randn(1, 1, 8192, 128)
+    cos_lw = LazyWeight(source=cos_source)
+    sin_lw = LazyWeight(source=sin_source)
+
+    config = Rope1DConfig(
+        cos_matrix=cos_lw,
+        sin_matrix=sin_lw,
+        max_batch_size=32,
+    )
+    assert config.max_batch_size == 32
+    assert config.head_dim is None  # derived later
+    assert config.use_qk_fused is False
+    assert config.datatype == ttnn.bfloat16
+
+
+def test_rope_1d_config_with_options():
+    """Test config with all optional fields set."""
+    from unittest.mock import MagicMock
+
+    cos_source = torch.randn(1, 1, 8192, 64)
+    sin_source = torch.randn(1, 1, 8192, 64)
+    cos_lw = LazyWeight(source=cos_source)
+    sin_lw = LazyWeight(source=sin_source)
+
+    config = Rope1DConfig(
+        cos_matrix=cos_lw,
+        sin_matrix=sin_lw,
+        max_batch_size=1,
+        head_dim=64,
+        device=MagicMock(),
+        use_qk_fused=True,
+        datatype=ttnn.bfloat8_b,
+    )
+    assert config.head_dim == 64
+    assert config.use_qk_fused is True
+    assert config.datatype == ttnn.bfloat8_b
+
+
+def test_rope_1d_from_model_args_rejects_galaxy(expect_error):
+    """Test that from_model_args raises for Galaxy devices."""
+    from unittest.mock import MagicMock
+
+    args = MagicMock()
+    args.is_galaxy = True
+
+    with expect_error(ValueError, "Galaxy"):
+        RotarySetup1D.from_model_args(device=MagicMock(), args=args)
+
+
+def test_compute_cos_sin_no_scaling():
+    """Test cos/sin computation without scaling (Mistral/Qwen-style)."""
+    cos, sin = _rope_cos_sin(head_dim=128, max_seq_len=8192, theta=1000000.0)
+    assert cos.shape == (1, 1, 8192, 128)
+    assert sin.shape == (1, 1, 8192, 128)
+    # cos/sin values should be in [-1, 1]
+    assert cos.abs().max() <= 1.0 + 1e-6
+    assert sin.abs().max() <= 1.0 + 1e-6
+
+
+def test_compute_cos_sin_llama3_scaling():
+    """Test cos/sin computation with Llama-3.x scaling."""
+    cos, sin = _rope_cos_sin(head_dim=128, max_seq_len=8192, theta=500000.0, scaling=Llama3Scaling())
+    assert cos.shape == (1, 1, 8192, 128)
+    assert sin.shape == (1, 1, 8192, 128)
+
+
+def test_compute_cos_sin_head_dim_64():
+    """Test cos/sin computation with head_dim=64 (Llama-3.2-1B)."""
+    cos, sin = _rope_cos_sin(head_dim=64, max_seq_len=8192, theta=500000.0, scaling=Llama3Scaling())
+    assert cos.shape == (1, 1, 8192, 64)
+    assert sin.shape == (1, 1, 8192, 64)
+
+
+# ============================================================================
+# Integration Tests - Require device
+# ============================================================================
+
+
+# Collected from rope_1d_init_test_cases.csv (deduplicated)
+# Format: (device_shape, batch_size, head_dim, max_seq_len, rope_theta, rope_scaling_str, use_qk_fused)
+def _list_init_test_cases() -> list[pytest.param]:
+    # fmt: off
+    return [
+        # === Fast tests (one per unique model family) ===
+        # Llama-3.2-1B: head_dim=64, llama3 scaling, theta=500000
+        pytest.param((1, 1), 1, 64, 8192, 500000.0, "llama3", True, id="1x1-b1-hd64-llama3-fused"),
+        # Llama-3.1-8B: head_dim=128, llama3 scaling, theta=500000
+        pytest.param((1, 2), 1, 128, 8192, 500000.0, "llama3", True, id="1x2-b1-hd128-llama3-fused"),
+        # Mistral-7B: head_dim=128, no scaling, theta=1000000
+        pytest.param((1, 1), 1, 128, 8192, 1000000.0, "none", True, id="1x1-b1-hd128-none-fused"),
+        # Llama-3.2-11B: use_qk_fused=False
+        pytest.param((1, 2), 1, 128, 8192, 500000.0, "llama3", False, id="1x2-b1-hd128-llama3-nofused"),
+        # T3K Llama-3.3-70B
+        pytest.param((1, 8), 1, 128, 8192, 500000.0, "llama3", True, id="1x8-b1-hd128-llama3-fused"),
+        # T3K Qwen2.5-72B: no scaling, theta=1000000
+        pytest.param((1, 8), 1, 128, 8192, 1000000.0, "none", True, id="1x8-b1-hd128-none-fused"),
+        # Phi-4 (head_dim=128, no scaling, theta=250000) uses the exact same decode code path as the
+        # Mistral (1x1) and Qwen2.5-72B (1x8) "none"/hd128 rows above; theta is the only differing
+        # value and it does not change the code path, so no dedicated row is added here. Phi-4's RoPE
+        # is exercised end-to-end (real rope, not this reference harness) by the attention-1d module
+        # test (models/common/tests/modules/attention/test_attention_1d.py, the "*-Phi-4" cases).
+
+        # === Slow tests (remaining from CSV) ===
+        # (1,1) batch=32
+        pytest.param((1, 1), 32, 64, 2048, 500000.0, "llama3", True, id="1x1-b32-hd64-llama3-fused", marks=_slow),
+        pytest.param((1, 1), 32, 128, 2048, 500000.0, "llama3", True, id="1x1-b32-hd128-llama3-fused-8B", marks=_slow),
+        pytest.param((1, 1), 32, 128, 2048, 1000000.0, "none", True, id="1x1-b32-hd128-none-fused-Mistral", marks=_slow),
+        # (1,1) hd=128, llama3, batch=1 (Llama-3.2-3B, 3.1-8B on N150)
+        pytest.param((1, 1), 1, 128, 8192, 500000.0, "llama3", True, id="1x1-b1-hd128-llama3-fused-8B", marks=_slow),
+        pytest.param((1, 1), 1, 128, 1024, 500000.0, "llama3", True, id="1x1-b1-hd128-llama3-fused-seqlen1024", marks=_slow),
+        pytest.param((1, 1), 32, 128, 1024, 500000.0, "llama3", True, id="1x1-b32-hd128-llama3-fused-seqlen1024", marks=_slow),
+        pytest.param((1, 1), 1, 128, 32768, 500000.0, "llama3", True, id="1x1-b1-hd128-llama3-fused-seqlen32k", marks=_slow),
+        # (1,1) hd=128, none (Mistral), additional seq_len
+        pytest.param((1, 1), 1, 128, 1024, 1000000.0, "none", True, id="1x1-b1-hd128-none-fused-seqlen1024", marks=_slow),
+        pytest.param((1, 1), 32, 128, 1024, 1000000.0, "none", True, id="1x1-b32-hd128-none-fused-seqlen1024", marks=_slow),
+        pytest.param((1, 1), 1, 128, 32768, 1000000.0, "none", True, id="1x1-b1-hd128-none-fused-seqlen32k", marks=_slow),
+        # (1,1) hd=64 additional seq_len
+        pytest.param((1, 1), 1, 64, 1024, 500000.0, "llama3", True, id="1x1-b1-hd64-llama3-seqlen1024", marks=_slow),
+        pytest.param((1, 1), 32, 64, 1024, 500000.0, "llama3", True, id="1x1-b32-hd64-llama3-seqlen1024", marks=_slow),
+        pytest.param((1, 1), 1, 64, 32768, 500000.0, "llama3", True, id="1x1-b1-hd64-llama3-seqlen32k", marks=_slow),
+        # (1,2) variants
+        pytest.param((1, 2), 32, 64, 2048, 500000.0, "llama3", True, id="1x2-b32-hd64-llama3-fused", marks=_slow),
+        pytest.param((1, 2), 32, 128, 2048, 500000.0, "llama3", True, id="1x2-b32-hd128-llama3-fused", marks=_slow),
+        pytest.param((1, 2), 32, 128, 2048, 1000000.0, "none", True, id="1x2-b32-hd128-none-fused-Mistral", marks=_slow),
+        pytest.param((1, 2), 32, 128, 2048, 500000.0, "llama3", False, id="1x2-b32-hd128-llama3-nofused-11B", marks=_slow),
+        pytest.param((1, 2), 1, 128, 1024, 500000.0, "llama3", True, id="1x2-b1-hd128-llama3-fused-seqlen1024", marks=_slow),
+        pytest.param((1, 2), 32, 128, 1024, 500000.0, "llama3", True, id="1x2-b32-hd128-llama3-fused-seqlen1024", marks=_slow),
+        pytest.param((1, 2), 1, 128, 32768, 500000.0, "llama3", True, id="1x2-b1-hd128-llama3-fused-seqlen32k", marks=_slow),
+        pytest.param((1, 2), 1, 128, 8192, 1000000.0, "none", True, id="1x2-b1-hd128-none-fused-Qwen2", marks=_slow),
+        pytest.param((1, 2), 1, 64, 8192, 500000.0, "llama3", True, id="1x2-b1-hd64-llama3-fused", marks=_slow),
+        pytest.param((1, 2), 1, 64, 1024, 500000.0, "llama3", True, id="1x2-b1-hd64-llama3-fused-seqlen1024", marks=_slow),
+        pytest.param((1, 2), 32, 64, 1024, 500000.0, "llama3", True, id="1x2-b32-hd64-llama3-fused-seqlen1024", marks=_slow),
+        pytest.param((1, 2), 1, 64, 32768, 500000.0, "llama3", True, id="1x2-b1-hd64-llama3-fused-seqlen32k", marks=_slow),
+        pytest.param((1, 2), 1, 128, 1024, 500000.0, "llama3", False, id="1x2-b1-hd128-llama3-nofused-11B-seqlen1024", marks=_slow),
+        pytest.param((1, 2), 32, 128, 1024, 500000.0, "llama3", False, id="1x2-b32-hd128-llama3-nofused-11B-seqlen1024", marks=_slow),
+        pytest.param((1, 2), 1, 128, 32768, 500000.0, "llama3", False, id="1x2-b1-hd128-llama3-nofused-11B-seqlen32k", marks=_slow),
+        pytest.param((1, 2), 1, 128, 1024, 1000000.0, "none", True, id="1x2-b1-hd128-none-fused-seqlen1024", marks=_slow),
+        pytest.param((1, 2), 32, 128, 1024, 1000000.0, "none", True, id="1x2-b32-hd128-none-fused-seqlen1024", marks=_slow),
+        pytest.param((1, 2), 1, 128, 32768, 1000000.0, "none", True, id="1x2-b1-hd128-none-fused-seqlen32k", marks=_slow),
+        # (1,2) batch=4, 16 from Llama-3.2-11B (nofused)
+        pytest.param((1, 2), 16, 128, 512, 500000.0, "llama3", False, id="1x2-b16-hd128-llama3-nofused-11B", marks=_slow),
+        pytest.param((1, 2), 4, 128, 512, 500000.0, "llama3", False, id="1x2-b4-hd128-llama3-nofused-11B", marks=_slow),
+        # (1,8) variants — hd=64
+        pytest.param((1, 8), 1, 64, 8192, 500000.0, "llama3", True, id="1x8-b1-hd64-llama3-fused", marks=_slow),
+        pytest.param((1, 8), 32, 64, 2048, 500000.0, "llama3", True, id="1x8-b32-hd64-llama3-fused", marks=_slow),
+        pytest.param((1, 8), 1, 64, 1024, 500000.0, "llama3", True, id="1x8-b1-hd64-llama3-fused-seqlen1024", marks=_slow),
+        pytest.param((1, 8), 32, 64, 1024, 500000.0, "llama3", True, id="1x8-b32-hd64-llama3-fused-seqlen1024", marks=_slow),
+        pytest.param((1, 8), 1, 64, 32768, 500000.0, "llama3", True, id="1x8-b1-hd64-llama3-fused-seqlen32k", marks=_slow),
+        # (1,8) variants — hd=128, llama3, fused
+        pytest.param((1, 8), 32, 128, 2048, 500000.0, "llama3", True, id="1x8-b32-hd128-llama3-fused-8B", marks=_slow),
+        pytest.param((1, 8), 1, 128, 1024, 500000.0, "llama3", True, id="1x8-b1-hd128-llama3-fused-seqlen1024", marks=_slow),
+        pytest.param((1, 8), 32, 128, 1024, 500000.0, "llama3", True, id="1x8-b32-hd128-llama3-fused-seqlen1024", marks=_slow),
+        pytest.param((1, 8), 1, 128, 32768, 500000.0, "llama3", True, id="1x8-b1-hd128-llama3-fused-seqlen32k", marks=_slow),
+        # (1,8) variants — hd=128, llama3, nofused (11B)
+        pytest.param((1, 8), 1, 128, 8192, 500000.0, "llama3", False, id="1x8-b1-hd128-llama3-nofused-11B", marks=_slow),
+        pytest.param((1, 8), 32, 128, 2048, 500000.0, "llama3", False, id="1x8-b32-hd128-llama3-nofused-11B", marks=_slow),
+        pytest.param((1, 8), 1, 128, 1024, 500000.0, "llama3", False, id="1x8-b1-hd128-llama3-nofused-11B-seqlen1024", marks=_slow),
+        pytest.param((1, 8), 32, 128, 1024, 500000.0, "llama3", False, id="1x8-b32-hd128-llama3-nofused-11B-seqlen1024", marks=_slow),
+        pytest.param((1, 8), 1, 128, 32768, 500000.0, "llama3", False, id="1x8-b1-hd128-llama3-nofused-11B-seqlen32k", marks=_slow),
+        # (1,8) variants — hd=128, none (Qwen/Mistral/Mixtral)
+        pytest.param((1, 8), 32, 128, 2048, 1000000.0, "none", True, id="1x8-b32-hd128-none-fused-Qwen72B", marks=_slow),
+        pytest.param((1, 8), 1, 128, 1024, 1000000.0, "none", True, id="1x8-b1-hd128-none-fused-seqlen1024", marks=_slow),
+        pytest.param((1, 8), 32, 128, 1024, 1000000.0, "none", True, id="1x8-b32-hd128-none-fused-seqlen1024", marks=_slow),
+        pytest.param((1, 8), 1, 128, 32768, 1000000.0, "none", True, id="1x8-b1-hd128-none-fused-seqlen32k", marks=_slow),
+        # (1,8) batch=4 from Llama-3.2-11B (nofused)
+        pytest.param((1, 8), 4, 128, 512, 500000.0, "llama3", False, id="1x8-b4-hd128-llama3-nofused-11B", marks=_slow),
+        pytest.param((1, 8), 32, 128, 512, 500000.0, "llama3", False, id="1x8-b32-hd128-llama3-nofused-11B-seqlen512", marks=_slow),
+        # Llama-3.2-90B (from api CSV)
+        pytest.param((1, 8), 1, 128, 512, 500000.0, "llama3", False, id="1x8-b1-hd128-llama3-nofused-90B", marks=_slow),
+    ]
+    # fmt: on
+
+
+@pytest.mark.parametrize(
+    "ttnn_mesh_device",
+    [(1, 1), (1, 2), (1, 8)],
+    ids=["1x1", "1x2", "1x8"],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "mesh_shape,batch_size,head_dim,max_seq_len,rope_theta,rope_scaling_str,use_qk_fused",
+    _list_init_test_cases(),
+)
+def test_rope_1d_decode_forward_vs_reference(
+    ttnn_mesh_device: ttnn.MeshDevice,
+    mesh_shape,
+    batch_size,
+    head_dim,
+    max_seq_len,
+    rope_theta,
+    rope_scaling_str,
+    use_qk_fused,
+):
+    """
+    Test RotarySetup1D initialization and all API methods.
+
+    Verifies:
+    1. Construction succeeds with given parameters
+    2. get_both_trans_mats() returns valid tensors with correct PCC
+    3. get_rot_idxs() produces correct shape
+    4. get_rot_mats() produces cos/sin with correct shapes and PCC vs reference
+    5. decode_forward() with ttnn.Tensor input matches torch-input path
+    """
+    scaling = Llama3Scaling() if rope_scaling_str == "llama3" else None
+
+    cos_torch, sin_torch = _rope_cos_sin(head_dim=head_dim, max_seq_len=max_seq_len, theta=rope_theta, scaling=scaling)
+    scaling_tag = "llama3" if scaling else "none"
+    tag = f"theta{rope_theta}_{scaling_tag}"
+    cache_dir = Path(os.getenv("TT_CACHE_PATH", "model_cache/rope_1d"))
+    cos_lw = LazyWeight(source=cos_torch, device=ttnn_mesh_device, cache_dir_weight_name=(cache_dir, f"cos_{tag}"))
+    sin_lw = LazyWeight(source=sin_torch, device=ttnn_mesh_device, cache_dir_weight_name=(cache_dir, f"sin_{tag}"))
+
+    # Use __init__ (happy path) when defaults suffice, from_config (power path) otherwise.
+    # This exercises both constructors across the test matrix.
+    if not use_qk_fused:
+        rope = RotarySetup1D(cos_lw, sin_lw, max_batch_size=batch_size)
+    else:
+        config = Rope1DConfig(
+            cos_matrix=cos_lw,
+            sin_matrix=sin_lw,
+            max_batch_size=batch_size,
+            head_dim=head_dim,
+            device=ttnn_mesh_device,
+            use_qk_fused=use_qk_fused,
+        )
+        rope = RotarySetup1D.from_config(config)
+
+    # --- get_both_trans_mats ---
+    trans_mats = rope.get_both_trans_mats()
+    assert "decode" in trans_mats
+    assert "prefill" in trans_mats
+
+    # Prefill trans mat PCC: the rotary_embedding_llama op requires a single
+    # TILE_SIZE x TILE_SIZE tile (TT_FATAL on any other shape), so the module
+    # builds the prefill trans-mat at TILE_SIZE, not head_dim. See rope_1d.py.
+    prefill_ref = get_rot_transformation_mat(dhead=ttnn.TILE_SIZE)  # [1, 1, 32, 32]
+    prefill_tt = to_torch_auto_compose(trans_mats["prefill"])
+    prefill_tt_trimmed = prefill_tt[:1, :1, : prefill_ref.shape[2], : prefill_ref.shape[3]]
+    pcc_prefill, msg_prefill = comp_pcc(prefill_ref.to(torch.bfloat16), prefill_tt_trimmed.to(torch.bfloat16), 0.9999)
+    assert pcc_prefill, f"prefill trans_mat PCC failed: {msg_prefill}"
+
+    # Decode trans mat PCC
+    effective_batch = batch_size * 2 if use_qk_fused else batch_size
+    decode_ref = get_rot_transformation_mat(dhead=ttnn.TILE_SIZE).repeat(1, 1, effective_batch, 1)
+    decode_tt = to_torch_auto_compose(trans_mats["decode"])
+    decode_tt_trimmed = decode_tt[:1, :1, : decode_ref.shape[2], : decode_ref.shape[3]]
+    pcc_decode, msg_decode = comp_pcc(decode_ref.to(torch.bfloat16), decode_tt_trimmed.to(torch.bfloat16), 0.9999)
+    assert pcc_decode, f"decode trans_mat PCC failed: {msg_decode}"
+
+    # --- PCC check: cos/sin vs torch reference ---
+    # Use non-zero positions to avoid sin(0)=0 (PCC undefined for all-zero tensors)
+    pcc_position_idxs = torch.arange(42, 42 + batch_size)
+
+    # TTTv2 API: prepare_rot_idxs → forward
+    rot_idxs = prepare_rot_idxs(rope.config, pcc_position_idxs, on_host=True)
+    pcc_rot_mats = rope.decode_forward(rot_idxs)
+    assert len(pcc_rot_mats) == 2
+
+    cos_torch_ref, sin_torch_ref = _rope_cos_sin(
+        head_dim=head_dim, max_seq_len=max_seq_len, theta=rope_theta, scaling=scaling
+    )
+
+    cos_tt = to_torch_auto_compose(pcc_rot_mats[0])
+    sin_tt = to_torch_auto_compose(pcc_rot_mats[1])
+
+    # Build expected cos/sin from torch reference for chosen positions
+    if use_qk_fused:
+        ref_positions = list(range(42, 42 + batch_size)) * 2
+    else:
+        ref_positions = list(range(42, 42 + batch_size))
+    expected_cos = cos_torch_ref[:, :, ref_positions, :]  # [1, 1, effective_batch, head_dim]
+    expected_sin = sin_torch_ref[:, :, ref_positions, :]
+
+    # Reshape TT output: [1, batch, TILE_SIZE, head_dim] → [1, 1, batch*TILE_SIZE, head_dim]
+    cos_tt_flat = cos_tt.reshape(1, 1, -1, head_dim)
+    sin_tt_flat = sin_tt.reshape(1, 1, -1, head_dim)
+
+    # Compare first effective_batch rows (rest is padding from tile alignment)
+    cos_tt_trimmed = cos_tt_flat[:, :, :effective_batch, :]
+    sin_tt_trimmed = sin_tt_flat[:, :, :effective_batch, :]
+
+    pcc_cos, msg_cos = comp_pcc(expected_cos.to(torch.bfloat16), cos_tt_trimmed.to(torch.bfloat16), 0.999)
+    pcc_sin, msg_sin = comp_pcc(expected_sin.to(torch.bfloat16), sin_tt_trimmed.to(torch.bfloat16), 0.999)
+
+    logger.info(f"cos PCC: {msg_cos}")
+    logger.info(f"sin PCC: {msg_sin}")
+
+    assert pcc_cos, f"cos PCC failed: {msg_cos}"
+    assert pcc_sin, f"sin PCC failed: {msg_sin}"
+
+    logger.info(
+        f"RotarySetup1D: PASSED for mesh={mesh_shape}, batch={batch_size}, "
+        f"head_dim={head_dim}, max_seq_len={max_seq_len}, rope_theta={rope_theta}, "
+        f"scaling={rope_scaling_str}, fused={use_qk_fused}"
+    )
+
+
+# ============================================================================
+# Standalone helper test: prepare_rot_idxs
+# ============================================================================
+
+
+@pytest.mark.parametrize(
+    "ttnn_mesh_device",
+    [(1, 1), (1, 2)],
+    ids=["1x1", "1x2"],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "batch_size,use_qk_fused",
+    [
+        pytest.param(1, False, id="b1-nofused"),
+        pytest.param(1, True, id="b1-fused"),
+        pytest.param(32, True, id="b32-fused"),
+    ],
+)
+def test_prepare_rot_idxs(
+    ttnn_mesh_device: ttnn.MeshDevice,
+    batch_size,
+    use_qk_fused,
+):
+    """Test prepare_rot_idxs standalone helper produces correct ttnn tensor."""
+    cos_torch, sin_torch = _rope_cos_sin(head_dim=128, max_seq_len=8192, theta=500000.0, scaling=Llama3Scaling())
+    tag = "theta500000.0_llama3"
+    cache_dir = Path(os.getenv("TT_CACHE_PATH", "model_cache/rope_1d"))
+    cos_lw = LazyWeight(source=cos_torch, device=ttnn_mesh_device, cache_dir_weight_name=(cache_dir, f"cos_{tag}"))
+    sin_lw = LazyWeight(source=sin_torch, device=ttnn_mesh_device, cache_dir_weight_name=(cache_dir, f"sin_{tag}"))
+    config = Rope1DConfig(
+        cos_matrix=cos_lw,
+        sin_matrix=sin_lw,
+        max_batch_size=batch_size,
+        head_dim=128,
+        device=ttnn_mesh_device,
+        use_qk_fused=use_qk_fused,
+    )
+    rope = RotarySetup1D.from_config(config)
+
+    position_idxs = torch.arange(batch_size)
+
+    # Test on-device path
+    rot_idxs = prepare_rot_idxs(rope.config, position_idxs, on_host=False)
+    assert isinstance(rot_idxs, ttnn.Tensor)
+
+    # Test on-host path
+    rot_idxs_host = prepare_rot_idxs(rope.config, position_idxs, on_host=True)
+    assert isinstance(rot_idxs_host, ttnn.Tensor)
+
+    # Both paths should produce usable tensors for decode_forward()
+    cos_sin_device = rope.decode_forward(rot_idxs)
+    assert len(cos_sin_device) == 2
+
+    cos_sin_host = rope.get_rot_mats(rot_idxs_host)
+    assert len(cos_sin_host) == 2
+
+    # PCC: both paths should produce identical results
+    cos_d = to_torch_auto_compose(cos_sin_device[0])
+    cos_h = to_torch_auto_compose(cos_sin_host[0])
+    pcc_ok, msg = comp_pcc(cos_d, cos_h, 0.9999)
+    assert pcc_ok, f"on-device vs on-host cos mismatch: {msg}"
+
+
+# ============================================================================
+# forward() dispatcher tests
+# ============================================================================
+
+
+@pytest.mark.parametrize(
+    "ttnn_mesh_device",
+    [(1, 1)],
+    ids=["1x1"],
+    indirect=True,
+)
+def test_forward_dispatch_decode(ttnn_mesh_device: ttnn.MeshDevice):
+    """Test that forward(mode='decode', ...) delegates to decode_forward."""
+    cos_torch, sin_torch = _rope_cos_sin(head_dim=128, max_seq_len=8192, theta=500000.0, scaling=Llama3Scaling())
+    cos_lw = LazyWeight(source=cos_torch, device=ttnn_mesh_device)
+    sin_lw = LazyWeight(source=sin_torch, device=ttnn_mesh_device)
+
+    rope = RotarySetup1D(cos_lw, sin_lw, max_batch_size=1)
+
+    position_idxs = torch.tensor([42])
+    rot_idxs = prepare_rot_idxs(rope.config, position_idxs)
+
+    via_forward = rope.forward(mode="decode", rot_idxs=rot_idxs)
+    via_direct = rope.decode_forward(rot_idxs)
+
+    cos_fwd = to_torch_auto_compose(via_forward[0])
+    cos_dir = to_torch_auto_compose(via_direct[0])
+    pcc_ok, msg = comp_pcc(cos_fwd, cos_dir, 0.9999)
+    assert pcc_ok, f"forward(decode) vs decode_forward mismatch: {msg}"
+
+
+@pytest.mark.parametrize(
+    "ttnn_mesh_device",
+    [(1, 1)],
+    ids=["1x1"],
+    indirect=True,
+)
+def test_forward_dispatch_prefill(ttnn_mesh_device: ttnn.MeshDevice):
+    """Test that forward(mode='prefill', ...) delegates to prefill_forward."""
+    cos_torch, sin_torch = _rope_cos_sin(head_dim=128, max_seq_len=8192, theta=500000.0, scaling=Llama3Scaling())
+    cos_lw = LazyWeight(source=cos_torch, device=ttnn_mesh_device)
+    sin_lw = LazyWeight(source=sin_torch, device=ttnn_mesh_device)
+
+    rope = RotarySetup1D(cos_lw, sin_lw, max_batch_size=1)
+
+    via_forward = rope.forward(mode="prefill", start_pos=0, seq_len=128)
+    via_direct = rope.prefill_forward(start_pos=0, seq_len=128)
+
+    cos_fwd = to_torch_auto_compose(via_forward[0])
+    cos_dir = to_torch_auto_compose(via_direct[0])
+    pcc_ok, msg = comp_pcc(cos_fwd, cos_dir, 0.9999)
+    assert pcc_ok, f"forward(prefill) vs prefill_forward mismatch: {msg}"
+
+
+# ============================================================================
+# prefill_forward tests
+# ============================================================================
+
+
+def _list_prefill_test_cases() -> list[pytest.param]:
+    # fmt: off
+    return [
+        # === Fast tests (one per model family + edge cases) ===
+        # Llama-3.2-1B: hd64, llama3
+        pytest.param(64, 8192, 500000.0, "llama3", 0, 128, None, id="hd64-llama3-seq8k-start0-S128"),
+        # Llama-3.2-3B / 3.1-8B: hd128, llama3
+        pytest.param(128, 8192, 500000.0, "llama3", 0, 128, None, id="hd128-llama3-seq8k-start0-S128"),
+        # Mistral / Qwen: hd128, no scaling
+        pytest.param(128, 8192, 1000000.0, "none", 0, 128, None, id="hd128-none-seq8k-start0-S128"),
+        # Chunked prefill (llama3): nonzero start_pos
+        pytest.param(128, 32768, 500000.0, "llama3", 4096, 4096, None, id="hd128-llama3-seq32k-start4k-S4k"),
+        # Chunked prefill (none): nonzero start_pos
+        pytest.param(128, 32768, 1000000.0, "none", 4096, 4096, None, id="hd128-none-seq32k-start4k-S4k"),
+        # SDPA padding (not collected — manual edge case)
+        pytest.param(128, 8192, 500000.0, "llama3", 0, 100, 128, id="hd128-llama3-seq8k-start0-S100-pad128"),
+
+        # === Slow tests (remaining from CSV) ===
+
+        # --- hd=64, llama3, theta=500k ---
+        pytest.param(64, 1024, 500000.0, "llama3", 0, 128, None, id="hd64-llama3-seq1k-start0-S128", marks=_slow),
+        pytest.param(64, 1024, 500000.0, "llama3", 0, 1024, None, id="hd64-llama3-seq1k-start0-S1024", marks=_slow),
+        pytest.param(64, 2048, 500000.0, "llama3", 0, 128, None, id="hd64-llama3-seq2k-start0-S128", marks=_slow),
+        pytest.param(64, 2048, 500000.0, "llama3", 0, 1024, None, id="hd64-llama3-seq2k-start0-S1024", marks=_slow),
+        pytest.param(64, 2048, 500000.0, "llama3", 0, 2048, None, id="hd64-llama3-seq2k-start0-S2048", marks=_slow),
+        pytest.param(64, 8192, 500000.0, "llama3", 0, 1024, None, id="hd64-llama3-seq8k-start0-S1024", marks=_slow),
+        pytest.param(64, 8192, 500000.0, "llama3", 0, 2048, None, id="hd64-llama3-seq8k-start0-S2048", marks=_slow),
+        pytest.param(64, 8192, 500000.0, "llama3", 0, 4096, None, id="hd64-llama3-seq8k-start0-S4096", marks=_slow),
+        pytest.param(64, 8192, 500000.0, "llama3", 0, 8192, None, id="hd64-llama3-seq8k-start0-S8192", marks=_slow),
+        pytest.param(64, 32768, 500000.0, "llama3", 0, 128, None, id="hd64-llama3-seq32k-start0-S128", marks=_slow),
+        pytest.param(64, 32768, 500000.0, "llama3", 0, 1024, None, id="hd64-llama3-seq32k-start0-S1024", marks=_slow),
+        pytest.param(64, 32768, 500000.0, "llama3", 0, 2048, None, id="hd64-llama3-seq32k-start0-S2048", marks=_slow),
+        pytest.param(64, 32768, 500000.0, "llama3", 0, 4096, None, id="hd64-llama3-seq32k-start0-S4096", marks=_slow),
+        pytest.param(64, 32768, 500000.0, "llama3", 0, 8192, None, id="hd64-llama3-seq32k-start0-S8192", marks=_slow),
+        pytest.param(64, 32768, 500000.0, "llama3", 0, 16384, None, id="hd64-llama3-seq32k-start0-S16384", marks=_slow),
+        pytest.param(64, 32768, 500000.0, "llama3", 0, 32768, None, id="hd64-llama3-seq32k-start0-S32768", marks=_slow),
+
+        # --- hd=128, llama3, theta=500k ---
+        pytest.param(128, 1024, 500000.0, "llama3", 0, 128, None, id="hd128-llama3-seq1k-start0-S128", marks=_slow),
+        pytest.param(128, 1024, 500000.0, "llama3", 0, 1024, None, id="hd128-llama3-seq1k-start0-S1024", marks=_slow),
+        pytest.param(128, 2048, 500000.0, "llama3", 0, 128, None, id="hd128-llama3-seq2k-start0-S128", marks=_slow),
+        pytest.param(128, 2048, 500000.0, "llama3", 0, 1024, None, id="hd128-llama3-seq2k-start0-S1024", marks=_slow),
+        pytest.param(128, 2048, 500000.0, "llama3", 0, 2048, None, id="hd128-llama3-seq2k-start0-S2048", marks=_slow),
+        pytest.param(128, 8192, 500000.0, "llama3", 0, 1024, None, id="hd128-llama3-seq8k-start0-S1024", marks=_slow),
+        pytest.param(128, 8192, 500000.0, "llama3", 0, 2048, None, id="hd128-llama3-seq8k-start0-S2048", marks=_slow),
+        pytest.param(128, 8192, 500000.0, "llama3", 0, 4096, None, id="hd128-llama3-seq8k-start0-S4096", marks=_slow),
+        pytest.param(128, 8192, 500000.0, "llama3", 0, 8192, None, id="hd128-llama3-seq8k-start0-S8192", marks=_slow),
+        pytest.param(128, 32768, 500000.0, "llama3", 0, 128, None, id="hd128-llama3-seq32k-start0-S128", marks=_slow),
+        pytest.param(128, 32768, 500000.0, "llama3", 0, 1024, None, id="hd128-llama3-seq32k-start0-S1024", marks=_slow),
+        pytest.param(128, 32768, 500000.0, "llama3", 0, 2048, None, id="hd128-llama3-seq32k-start0-S2048", marks=_slow),
+        pytest.param(128, 32768, 500000.0, "llama3", 0, 4096, None, id="hd128-llama3-seq32k-start0-S4096", marks=_slow),
+        pytest.param(128, 32768, 500000.0, "llama3", 0, 8192, None, id="hd128-llama3-seq32k-start0-S8192", marks=_slow),
+        pytest.param(128, 32768, 500000.0, "llama3", 0, 16384, None, id="hd128-llama3-seq32k-start0-S16384", marks=_slow),
+        pytest.param(128, 32768, 500000.0, "llama3", 0, 32768, None, id="hd128-llama3-seq32k-start0-S32768", marks=_slow),
+        # Chunked prefill (Llama-3.1-8B, 3.3-70B)
+        pytest.param(128, 32768, 500000.0, "llama3", 8192, 4096, None, id="hd128-llama3-seq32k-start8k-S4k", marks=_slow),
+        pytest.param(128, 32768, 500000.0, "llama3", 8192, 8192, None, id="hd128-llama3-seq32k-start8k-S8k", marks=_slow),
+        pytest.param(128, 32768, 500000.0, "llama3", 12288, 4096, None, id="hd128-llama3-seq32k-start12k-S4k", marks=_slow),
+
+        # --- hd=128, none, theta=1000k (Mistral / Qwen) ---
+        pytest.param(128, 1024, 1000000.0, "none", 0, 128, None, id="hd128-none-seq1k-start0-S128", marks=_slow),
+        pytest.param(128, 1024, 1000000.0, "none", 0, 1024, None, id="hd128-none-seq1k-start0-S1024", marks=_slow),
+        pytest.param(128, 2048, 1000000.0, "none", 0, 128, None, id="hd128-none-seq2k-start0-S128", marks=_slow),
+        pytest.param(128, 2048, 1000000.0, "none", 0, 1024, None, id="hd128-none-seq2k-start0-S1024", marks=_slow),
+        pytest.param(128, 2048, 1000000.0, "none", 0, 2048, None, id="hd128-none-seq2k-start0-S2048", marks=_slow),
+        pytest.param(128, 8192, 1000000.0, "none", 0, 1024, None, id="hd128-none-seq8k-start0-S1024", marks=_slow),
+        pytest.param(128, 8192, 1000000.0, "none", 0, 2048, None, id="hd128-none-seq8k-start0-S2048", marks=_slow),
+        pytest.param(128, 8192, 1000000.0, "none", 0, 4096, None, id="hd128-none-seq8k-start0-S4096", marks=_slow),
+        pytest.param(128, 8192, 1000000.0, "none", 0, 8192, None, id="hd128-none-seq8k-start0-S8192", marks=_slow),
+        pytest.param(128, 32768, 1000000.0, "none", 0, 128, None, id="hd128-none-seq32k-start0-S128", marks=_slow),
+        pytest.param(128, 32768, 1000000.0, "none", 0, 1024, None, id="hd128-none-seq32k-start0-S1024", marks=_slow),
+        pytest.param(128, 32768, 1000000.0, "none", 0, 2048, None, id="hd128-none-seq32k-start0-S2048", marks=_slow),
+        pytest.param(128, 32768, 1000000.0, "none", 0, 4096, None, id="hd128-none-seq32k-start0-S4096", marks=_slow),
+        pytest.param(128, 32768, 1000000.0, "none", 0, 8192, None, id="hd128-none-seq32k-start0-S8192", marks=_slow),
+        pytest.param(128, 32768, 1000000.0, "none", 0, 16384, None, id="hd128-none-seq32k-start0-S16384", marks=_slow),
+        pytest.param(128, 32768, 1000000.0, "none", 0, 32768, None, id="hd128-none-seq32k-start0-S32768", marks=_slow),
+        # Chunked prefill (Mistral-7B, Qwen2.5-Coder-32B)
+        pytest.param(128, 32768, 1000000.0, "none", 8192, 4096, None, id="hd128-none-seq32k-start8k-S4k", marks=_slow),
+        pytest.param(128, 32768, 1000000.0, "none", 12288, 4096, None, id="hd128-none-seq32k-start12k-S4k", marks=_slow),
+        pytest.param(128, 32768, 1000000.0, "none", 16384, 4096, None, id="hd128-none-seq32k-start16k-S4k", marks=_slow),
+
+        # --- SDPA padding edge cases (manual — not collected, but exercises pad_to path) ---
+        pytest.param(128, 8192, 500000.0, "llama3", 32, 64, 128, id="hd128-llama3-pad-start32-S64-pad128", marks=_slow),
+        pytest.param(128, 8192, 500000.0, "llama3", 0, 128, 128, id="hd128-llama3-pad-noop-S128-pad128", marks=_slow),
+    ]
+    # fmt: on
+
+
+@pytest.mark.parametrize(
+    "ttnn_mesh_device",
+    [(1, 1), (1, 2), (1, 8)],
+    ids=["1x1", "1x2", "1x8"],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "head_dim,max_seq_len,rope_theta,rope_scaling_str,start_pos,prefill_seq_len,pad_to",
+    _list_prefill_test_cases(),
+)
+def test_rope_1d_prefill_forward_vs_reference(
+    ttnn_mesh_device: ttnn.MeshDevice,
+    head_dim,
+    max_seq_len,
+    rope_theta,
+    rope_scaling_str,
+    start_pos,
+    prefill_seq_len,
+    pad_to,
+):
+    """
+    Test RotarySetup1D.prefill_forward() returns correct cos/sin slices
+    by comparing against the torch reference tables.
+    """
+    scaling = Llama3Scaling() if rope_scaling_str == "llama3" else None
+
+    cos_torch, sin_torch = _rope_cos_sin(head_dim=head_dim, max_seq_len=max_seq_len, theta=rope_theta, scaling=scaling)
+    scaling_tag = "llama3" if scaling else "none"
+    tag = f"theta{rope_theta}_{scaling_tag}"
+    cache_dir = Path(os.getenv("TT_CACHE_PATH", "model_cache/rope_1d"))
+    cos_lw = LazyWeight(source=cos_torch, device=ttnn_mesh_device, cache_dir_weight_name=(cache_dir, f"cos_{tag}"))
+    sin_lw = LazyWeight(source=sin_torch, device=ttnn_mesh_device, cache_dir_weight_name=(cache_dir, f"sin_{tag}"))
+
+    rope = RotarySetup1D(cos_lw, sin_lw, max_batch_size=1)
+
+    # Call prefill_forward
+    cos_sin = rope.prefill_forward(start_pos=start_pos, seq_len=prefill_seq_len, pad_to=pad_to)
+    assert len(cos_sin) == 2
+
+    cos_tt = to_torch_auto_compose(cos_sin[0])
+    sin_tt = to_torch_auto_compose(cos_sin[1])
+
+    # Expected output shape
+    expected_seq_dim = pad_to if (pad_to is not None and pad_to > prefill_seq_len) else prefill_seq_len
+    assert cos_tt.shape[2] >= expected_seq_dim, f"cos seq dim {cos_tt.shape[2]} < expected {expected_seq_dim}"
+    assert sin_tt.shape[2] >= expected_seq_dim, f"sin seq dim {sin_tt.shape[2]} < expected {expected_seq_dim}"
+
+    # PCC: compare the non-padded region against torch reference
+    end_pos = start_pos + prefill_seq_len
+    expected_cos = cos_torch[:, :, start_pos:end_pos, :]
+    expected_sin = sin_torch[:, :, start_pos:end_pos, :]
+
+    # Trim TT output to the non-padded region for comparison
+    cos_tt_trimmed = cos_tt[:1, :1, :prefill_seq_len, :head_dim]
+    sin_tt_trimmed = sin_tt[:1, :1, :prefill_seq_len, :head_dim]
+
+    pcc_cos, msg_cos = comp_pcc(expected_cos.to(torch.bfloat16), cos_tt_trimmed.to(torch.bfloat16), 0.999)
+    pcc_sin, msg_sin = comp_pcc(expected_sin.to(torch.bfloat16), sin_tt_trimmed.to(torch.bfloat16), 0.999)
+
+    logger.info(f"prefill_forward cos PCC: {msg_cos}")
+    logger.info(f"prefill_forward sin PCC: {msg_sin}")
+
+    assert pcc_cos, f"prefill cos PCC failed: {msg_cos}"
+    assert pcc_sin, f"prefill sin PCC failed: {msg_sin}"
+
+    # If padded, verify the padded region is zeros
+    if pad_to is not None and pad_to > prefill_seq_len:
+        cos_pad_region = (
+            cos_tt_trimmed[:1, :1, prefill_seq_len:pad_to, :head_dim] if cos_tt.shape[2] >= pad_to else None
+        )
+        if cos_pad_region is not None:
+            # Padded region is from the full output
+            cos_full_pad = cos_tt[:1, :1, prefill_seq_len:pad_to, :head_dim]
+            sin_full_pad = sin_tt[:1, :1, prefill_seq_len:pad_to, :head_dim]
+            assert torch.allclose(cos_full_pad, torch.zeros_like(cos_full_pad), atol=1e-3), "cos pad region not zero"
+            assert torch.allclose(sin_full_pad, torch.zeros_like(sin_full_pad), atol=1e-3), "sin pad region not zero"
+
+    logger.info(
+        f"prefill_forward: PASSED for head_dim={head_dim}, start_pos={start_pos}, "
+        f"seq_len={prefill_seq_len}, pad_to={pad_to}"
+    )
+
+
+@pytest.mark.parametrize(
+    "ttnn_mesh_device",
+    [(1, 1)],
+    ids=["1x1"],
+    indirect=True,
+)
+def test_prefill_forward_bounds_check(ttnn_mesh_device: ttnn.MeshDevice, expect_error):
+    """Test that prefill_forward raises when the requested range exceeds the table."""
+    cos_torch, sin_torch = _rope_cos_sin(head_dim=128, max_seq_len=256, theta=500000.0)
+    cos_lw = LazyWeight(source=cos_torch, device=ttnn_mesh_device)
+    sin_lw = LazyWeight(source=sin_torch, device=ttnn_mesh_device)
+
+    rope = RotarySetup1D(cos_lw, sin_lw, max_batch_size=1)
+
+    # Should work: exactly at the boundary
+    cos_sin = rope.prefill_forward(start_pos=0, seq_len=256)
+    assert len(cos_sin) == 2
+
+    # Should fail: exceeds table
+    with expect_error(AssertionError, "exceeds cos/sin table length"):
+        rope.prefill_forward(start_pos=0, seq_len=257)
+
+    with expect_error(AssertionError, "exceeds cos/sin table length"):
+        rope.prefill_forward(start_pos=200, seq_len=128)
+
+
+# ============================================================================
+# from_model_args backward compatibility test
+# ============================================================================
+
+
+@pytest.mark.parametrize(
+    "ttnn_mesh_device",
+    [(1, 1), (1, 2), (1, 8)],
+    ids=["1x1", "1x2", "1x8"],
+    indirect=True,
+)
+def test_rope_1d_vs_reference_from_model_args(ttnn_mesh_device: ttnn.MeshDevice):
+    """
+    Test that RotarySetup1D.from_model_args produces numerically identical
+    rotation matrices compared to TTTv1 RotarySetup built with the same args.
+    """
+    from models.tt_transformers.tt.model_config import ModelArgs
+    from models.tt_transformers.tt.rope import RotarySetup as TTTv1RotarySetup
+
+    model_args = ModelArgs(ttnn_mesh_device, max_batch_size=1, max_seq_len=128, cache_hf=True)
+    model_args.n_layers = 1
+
+    if model_args.is_galaxy:
+        pytest.skip("RotarySetup1D test only runs on non-TG devices")
+
+    # Build TTTv2 via from_model_args
+    rope_v2 = RotarySetup1D.from_model_args(
+        device=ttnn_mesh_device,
+        args=model_args,
+        model_name=model_args.model_name,
+    )
+
+    # Build TTTv1 reference with same params
+    from models.tt_transformers.tt.common import rope_scaling_model_factory
+
+    rope_scaling = None
+    if hasattr(model_args, "rope_scaling_params") and model_args.rope_scaling_params is not None:
+        rope_scaling = rope_scaling_model_factory(
+            model_args.rope_scaling_params, getattr(model_args, "original_max_context_len", None)
+        )
+
+    rope_v1 = TTTv1RotarySetup(
+        device=ttnn_mesh_device,
+        batch_size=model_args.max_batch_size,
+        head_dim=model_args.head_dim,
+        max_seq_len=model_args.max_seq_len,
+        rope_theta=model_args.rope_theta,
+        rope_scaling=rope_scaling,
+        use_qk_fused=getattr(model_args, "use_qk_fused", False),
+        datatype=ttnn.bfloat16,
+    )
+
+    # --- Backward-compat wrappers: get_rot_idxs, get_rot_mats, return_rot_idxs ---
+    position_idxs = torch.arange(42, 42 + model_args.max_batch_size)
+
+    # get_rot_idxs
+    rot_idxs = rope_v2.get_rot_idxs(position_idxs, on_host=True)
+
+    # get_rot_mats (torch input)
+    v2_cos_sin = rope_v2.get_rot_mats(position_idxs)
+    v1_cos_sin = rope_v1.get_rot_mats(position_idxs)
+
+    # get_rot_mats with return_rot_idxs
+    v2_mats_and_idxs = rope_v2.get_rot_mats(position_idxs, return_rot_idxs=True)
+    assert len(v2_mats_and_idxs) == 2
+    v2_rot_mats_2, v2_rot_idxs_2 = v2_mats_and_idxs
+    assert len(v2_rot_mats_2) == 2
+
+    # get_rot_mats via ttnn rot_idxs (production calling pattern)
+    v2_cos_sin_via_ttnn = rope_v2.get_rot_mats(rot_idxs)
+
+    # PCC: v2 vs v1
+    v2_cos_torch = to_torch_auto_compose(v2_cos_sin[0])
+    v1_cos_torch = to_torch_auto_compose(v1_cos_sin[0])
+    v2_sin_torch = to_torch_auto_compose(v2_cos_sin[1])
+    v1_sin_torch = to_torch_auto_compose(v1_cos_sin[1])
+
+    pcc_cos, msg_cos = comp_pcc(v1_cos_torch, v2_cos_torch, 0.9999)
+    pcc_sin, msg_sin = comp_pcc(v1_sin_torch, v2_sin_torch, 0.9999)
+
+    logger.info(f"from_model_args cos PCC: {msg_cos}")
+    logger.info(f"from_model_args sin PCC: {msg_sin}")
+
+    assert pcc_cos, f"from_model_args cos mismatch: {msg_cos}"
+    assert pcc_sin, f"from_model_args sin mismatch: {msg_sin}"
+
+    # PCC: torch-input vs ttnn-input paths should match
+    cos_via_ttnn = to_torch_auto_compose(v2_cos_sin_via_ttnn[0])
+    pcc_path, msg_path = comp_pcc(v2_cos_torch, cos_via_ttnn, 0.9999)
+    assert pcc_path, f"torch vs ttnn input path mismatch: {msg_path}"
+
+    # PCC check: decode transformation matrix
+    v2_trans = rope_v2.get_both_trans_mats()
+    v1_trans = rope_v1.get_both_trans_mats()
+
+    v2_decode = to_torch_auto_compose(v2_trans["decode"])
+    v1_decode = to_torch_auto_compose(v1_trans["decode"])
+    pcc_decode, msg_decode = comp_pcc(v1_decode, v2_decode, 0.9999)
+    logger.info(f"from_model_args trans_mat[decode] PCC: {msg_decode}")
+    assert pcc_decode, f"from_model_args trans_mat[decode] mismatch: {msg_decode}"
+
+    # PCC check: prefill transformation matrix (overlapping region)
+    v2_prefill = to_torch_auto_compose(v2_trans["prefill"])
+    v1_prefill = to_torch_auto_compose(v1_trans["prefill"])
+    min_h = min(v1_prefill.shape[-2], v2_prefill.shape[-2])
+    min_w = min(v1_prefill.shape[-1], v2_prefill.shape[-1])
+    v1_prefill_trimmed = v1_prefill[:1, :1, :min_h, :min_w]
+    v2_prefill_trimmed = v2_prefill[:1, :1, :min_h, :min_w]
+    pcc_prefill, msg_prefill = comp_pcc(v1_prefill_trimmed, v2_prefill_trimmed, 0.9999)
+    logger.info(f"from_model_args trans_mat[prefill] PCC (overlapping): {msg_prefill}")
+    assert pcc_prefill, f"from_model_args trans_mat[prefill] mismatch: {msg_prefill}"
+
+    logger.info(f"RotarySetup1D.from_model_args vs TTTv1: PASSED for {model_args.model_name}")

--- a/models/experimental/llama32_1b_quasar/tests/modules/sampling/test_penalties_1d.py
+++ b/models/experimental/llama32_1b_quasar/tests/modules/sampling/test_penalties_1d.py
@@ -1,0 +1,1049 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for Penalties1D module."""
+
+import pytest
+import torch
+
+import ttnn
+from models.experimental.llama32_1b_quasar.modules.sampling.penalties_1d import (
+    Penalties1D,
+    Penalties1DConfig,
+    PenaltyAccumulator,
+    PenaltyParams,
+    _materialize,
+    _resolve_penalties1d_config,
+)
+from models.experimental.llama32_1b_quasar.utility_functions import comp_pcc
+
+# ---------------------------------------------------------------------------
+# Model name constants (match test_mlp_1d.py naming convention)
+# ---------------------------------------------------------------------------
+LLAMA_1B = "meta-llama/Llama-3.2-1B-Instruct"
+LLAMA_3B = "meta-llama/Llama-3.2-3B-Instruct"
+LLAMA_8B = "meta-llama/Llama-3.1-8B-Instruct"
+LLAMA_11B = "meta-llama/Llama-3.2-11B-Vision-Instruct"
+LLAMA_70B = "meta-llama/Llama-3.3-70B-Instruct"
+MISTRAL_7B = "mistralai/Mistral-7B-Instruct-v0.3"
+MIXTRAL_8X7B = "mistralai/Mixtral-8x7B-v0.1"
+QWEN25_72B = "Qwen/Qwen2.5-72B-Instruct"
+QWEN3_32B = "Qwen/Qwen3-32B"
+
+_slow = pytest.mark.slow
+
+
+def _list_collected_penalty_cases() -> list[pytest.param]:
+    """
+    Collected from TTTv1 demo runs (Phase B of test_case_collection.md).
+
+    Each entry is:
+        (mesh_shape, vocab_size, batch_size, seq_len,
+         presence, frequency, repetition, pcc, hf_model_name)
+
+    Source CSVs: sampling_generator_config_collected.csv,
+                 sampling_generator_params_collected.csv,
+                 penalties_prompt_tokens_collected.csv
+    Deduplicated by (topology, vocab, batch, seq_len, penalties_active).
+    """
+    # fmt: off
+    return [
+        # --- (1,1) Mistral7B v32768 ---
+        pytest.param((1, 1), 32768, 32, 128, 0.0, 0.0, 1.0, 0.999, MISTRAL_7B, id="1x1-Mistral7B-v32768-b32-s128-no-pen"),
+        pytest.param((1, 1), 32768, 32, 128, 1.2, 1.2, 1.5, 0.95, MISTRAL_7B, id="1x1-Mistral7B-v32768-b32-s128-pen", marks=_slow),
+        pytest.param((1, 1), 32768, 32, 1024, 0.0, 0.0, 1.0, 0.999, MISTRAL_7B, id="1x1-Mistral7B-v32768-b32-s1024-no-pen", marks=_slow),
+        pytest.param((1, 1), 32768, 32, 1024, 1.2, 1.2, 1.5, 0.95, MISTRAL_7B, id="1x1-Mistral7B-v32768-b32-s1024-pen", marks=_slow),
+        pytest.param((1, 1), 32768, 32, 2048, 0.0, 0.0, 1.0, 0.999, MISTRAL_7B, id="1x1-Mistral7B-v32768-b32-s2048-no-pen", marks=_slow),
+        pytest.param((1, 1), 32768, 32, 2048, 1.2, 1.2, 1.5, 0.95, MISTRAL_7B, id="1x1-Mistral7B-v32768-b32-s2048-pen", marks=_slow),
+        pytest.param((1, 1), 32768, 32, 4096, 0.0, 0.0, 1.0, 0.999, MISTRAL_7B, id="1x1-Mistral7B-v32768-b32-s4096-no-pen", marks=_slow),
+        pytest.param((1, 1), 32768, 32, 4096, 1.2, 1.2, 1.5, 0.95, MISTRAL_7B, id="1x1-Mistral7B-v32768-b32-s4096-pen", marks=_slow),
+        # --- (1,1) Llama8B v128256 ---
+        pytest.param((1, 1), 128256, 1, 125, 0.0, 0.0, 1.0, 0.999, LLAMA_8B, id="1x1-Llama8B-v128256-b1-s125-no-pen"),
+        # --- (1,1) Llama1B v128256 ---
+        pytest.param((1, 1), 128256, 1, 71, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x1-Llama1B-v128256-b1-s71-no-pen", marks=_slow),
+        pytest.param((1, 1), 128256, 1, 80, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x1-Llama1B-v128256-b1-s80-no-pen", marks=_slow),
+        pytest.param((1, 1), 128256, 1, 115, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x1-Llama1B-v128256-b1-s115-no-pen", marks=_slow),
+        pytest.param((1, 1), 128256, 1, 337, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x1-Llama1B-v128256-b1-s337-no-pen", marks=_slow),
+        pytest.param((1, 1), 128256, 1, 512, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x1-Llama1B-v128256-b1-s512-no-pen", marks=_slow),
+        pytest.param((1, 1), 128256, 1, 785, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x1-Llama1B-v128256-b1-s785-no-pen", marks=_slow),
+        pytest.param((1, 1), 128256, 1, 16229, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x1-Llama1B-v128256-b1-s16229-no-pen", marks=_slow),
+        pytest.param((1, 1), 128256, 32, 52, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x1-Llama1B-v128256-b32-s52-no-pen", marks=_slow),
+        pytest.param((1, 1), 128256, 32, 56, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x1-Llama1B-v128256-b32-s56-no-pen", marks=_slow),
+        pytest.param((1, 1), 128256, 32, 57, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x1-Llama1B-v128256-b32-s57-no-pen", marks=_slow),
+        pytest.param((1, 1), 128256, 32, 59, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x1-Llama1B-v128256-b32-s59-no-pen", marks=_slow),
+        pytest.param((1, 1), 128256, 32, 60, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x1-Llama1B-v128256-b32-s60-no-pen", marks=_slow),
+        pytest.param((1, 1), 128256, 32, 61, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x1-Llama1B-v128256-b32-s61-no-pen", marks=_slow),
+        pytest.param((1, 1), 128256, 32, 63, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x1-Llama1B-v128256-b32-s63-no-pen", marks=_slow),
+        pytest.param((1, 1), 128256, 32, 65, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x1-Llama1B-v128256-b32-s65-no-pen", marks=_slow),
+        pytest.param((1, 1), 128256, 32, 66, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x1-Llama1B-v128256-b32-s66-no-pen", marks=_slow),
+        pytest.param((1, 1), 128256, 32, 67, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x1-Llama1B-v128256-b32-s67-no-pen", marks=_slow),
+        pytest.param((1, 1), 128256, 32, 70, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x1-Llama1B-v128256-b32-s70-no-pen", marks=_slow),
+        pytest.param((1, 1), 128256, 32, 71, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x1-Llama1B-v128256-b32-s71-no-pen", marks=_slow),
+        pytest.param((1, 1), 128256, 32, 72, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x1-Llama1B-v128256-b32-s72-no-pen", marks=_slow),
+        pytest.param((1, 1), 128256, 32, 75, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x1-Llama1B-v128256-b32-s75-no-pen", marks=_slow),
+        pytest.param((1, 1), 128256, 32, 77, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x1-Llama1B-v128256-b32-s77-no-pen", marks=_slow),
+        pytest.param((1, 1), 128256, 32, 80, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x1-Llama1B-v128256-b32-s80-no-pen", marks=_slow),
+        pytest.param((1, 1), 128256, 32, 81, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x1-Llama1B-v128256-b32-s81-no-pen", marks=_slow),
+        pytest.param((1, 1), 128256, 32, 84, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x1-Llama1B-v128256-b32-s84-no-pen", marks=_slow),
+        pytest.param((1, 1), 128256, 32, 86, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x1-Llama1B-v128256-b32-s86-no-pen", marks=_slow),
+        pytest.param((1, 1), 128256, 32, 87, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x1-Llama1B-v128256-b32-s87-no-pen", marks=_slow),
+        pytest.param((1, 1), 128256, 32, 91, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x1-Llama1B-v128256-b32-s91-no-pen", marks=_slow),
+        pytest.param((1, 1), 128256, 32, 93, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x1-Llama1B-v128256-b32-s93-no-pen", marks=_slow),
+        pytest.param((1, 1), 128256, 32, 94, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x1-Llama1B-v128256-b32-s94-no-pen", marks=_slow),
+        pytest.param((1, 1), 128256, 32, 96, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x1-Llama1B-v128256-b32-s96-no-pen", marks=_slow),
+        pytest.param((1, 1), 128256, 32, 98, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x1-Llama1B-v128256-b32-s98-no-pen", marks=_slow),
+        pytest.param((1, 1), 128256, 32, 99, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x1-Llama1B-v128256-b32-s99-no-pen", marks=_slow),
+        pytest.param((1, 1), 128256, 32, 101, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x1-Llama1B-v128256-b32-s101-no-pen", marks=_slow),
+        pytest.param((1, 1), 128256, 32, 102, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x1-Llama1B-v128256-b32-s102-no-pen", marks=_slow),
+        pytest.param((1, 1), 128256, 32, 103, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x1-Llama1B-v128256-b32-s103-no-pen", marks=_slow),
+        pytest.param((1, 1), 128256, 32, 104, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x1-Llama1B-v128256-b32-s104-no-pen", marks=_slow),
+        pytest.param((1, 1), 128256, 32, 105, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x1-Llama1B-v128256-b32-s105-no-pen", marks=_slow),
+        pytest.param((1, 1), 128256, 32, 106, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x1-Llama1B-v128256-b32-s106-no-pen", marks=_slow),
+        pytest.param((1, 1), 128256, 32, 109, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x1-Llama1B-v128256-b32-s109-no-pen", marks=_slow),
+        pytest.param((1, 1), 128256, 32, 113, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x1-Llama1B-v128256-b32-s113-no-pen", marks=_slow),
+        pytest.param((1, 1), 128256, 32, 114, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x1-Llama1B-v128256-b32-s114-no-pen", marks=_slow),
+        pytest.param((1, 1), 128256, 32, 115, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x1-Llama1B-v128256-b32-s115-no-pen", marks=_slow),
+        pytest.param((1, 1), 128256, 32, 116, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x1-Llama1B-v128256-b32-s116-no-pen", marks=_slow),
+        pytest.param((1, 1), 128256, 32, 117, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x1-Llama1B-v128256-b32-s117-no-pen", marks=_slow),
+        pytest.param((1, 1), 128256, 32, 119, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x1-Llama1B-v128256-b32-s119-no-pen", marks=_slow),
+        pytest.param((1, 1), 128256, 32, 124, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x1-Llama1B-v128256-b32-s124-no-pen", marks=_slow),
+        pytest.param((1, 1), 128256, 32, 125, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x1-Llama1B-v128256-b32-s125-no-pen", marks=_slow),
+        pytest.param((1, 1), 128256, 32, 128, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x1-Llama1B-v128256-b32-s128-no-pen", marks=_slow),
+        pytest.param((1, 1), 128256, 32, 128, 1.2, 1.2, 1.5, 0.95, LLAMA_1B, id="1x1-Llama1B-v128256-b32-s128-pen", marks=_slow),
+        pytest.param((1, 1), 128256, 32, 337, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x1-Llama1B-v128256-b32-s337-no-pen", marks=_slow),
+        pytest.param((1, 1), 128256, 32, 512, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x1-Llama1B-v128256-b32-s512-no-pen", marks=_slow),
+        pytest.param((1, 1), 128256, 32, 712, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x1-Llama1B-v128256-b32-s712-no-pen", marks=_slow),
+        pytest.param((1, 1), 128256, 32, 785, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x1-Llama1B-v128256-b32-s785-no-pen", marks=_slow),
+        pytest.param((1, 1), 128256, 32, 1024, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x1-Llama1B-v128256-b32-s1024-no-pen", marks=_slow),
+        pytest.param((1, 1), 128256, 32, 1024, 1.2, 1.2, 1.5, 0.95, LLAMA_1B, id="1x1-Llama1B-v128256-b32-s1024-pen", marks=_slow),
+        pytest.param((1, 1), 128256, 32, 2048, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x1-Llama1B-v128256-b32-s2048-no-pen", marks=_slow),
+        pytest.param((1, 1), 128256, 32, 2048, 1.2, 1.2, 1.5, 0.95, LLAMA_1B, id="1x1-Llama1B-v128256-b32-s2048-pen", marks=_slow),
+        pytest.param((1, 1), 128256, 32, 4096, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x1-Llama1B-v128256-b32-s4096-no-pen", marks=_slow),
+        pytest.param((1, 1), 128256, 32, 4096, 1.2, 1.2, 1.5, 0.95, LLAMA_1B, id="1x1-Llama1B-v128256-b32-s4096-pen", marks=_slow),
+        pytest.param((1, 1), 128256, 32, 8192, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x1-Llama1B-v128256-b32-s8192-no-pen", marks=_slow),
+        pytest.param((1, 1), 128256, 32, 8192, 1.2, 1.2, 1.5, 0.95, LLAMA_1B, id="1x1-Llama1B-v128256-b32-s8192-pen", marks=_slow),
+        pytest.param((1, 1), 128256, 32, 16229, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x1-Llama1B-v128256-b32-s16229-no-pen", marks=_slow),
+        pytest.param((1, 1), 128256, 32, 16384, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x1-Llama1B-v128256-b32-s16384-no-pen", marks=_slow),
+        pytest.param((1, 1), 128256, 32, 16384, 1.2, 1.2, 1.5, 0.95, LLAMA_1B, id="1x1-Llama1B-v128256-b32-s16384-pen", marks=_slow),
+        pytest.param((1, 1), 128256, 32, 32768, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x1-Llama1B-v128256-b32-s32768-no-pen", marks=_slow),
+        pytest.param((1, 1), 128256, 32, 32768, 1.2, 1.2, 1.5, 0.95, LLAMA_1B, id="1x1-Llama1B-v128256-b32-s32768-pen", marks=_slow),
+        # --- (1,2) Mistral7B v32768 ---
+        pytest.param((1, 2), 32768, 32, 128, 0.0, 0.0, 1.0, 0.999, MISTRAL_7B, id="1x2-Mistral7B-v32768-b32-s128-no-pen"),
+        pytest.param((1, 2), 32768, 32, 128, 1.2, 1.2, 1.5, 0.95, MISTRAL_7B, id="1x2-Mistral7B-v32768-b32-s128-pen", marks=_slow),
+        pytest.param((1, 2), 32768, 32, 1024, 0.0, 0.0, 1.0, 0.999, MISTRAL_7B, id="1x2-Mistral7B-v32768-b32-s1024-no-pen", marks=_slow),
+        pytest.param((1, 2), 32768, 32, 1024, 1.2, 1.2, 1.5, 0.95, MISTRAL_7B, id="1x2-Mistral7B-v32768-b32-s1024-pen", marks=_slow),
+        pytest.param((1, 2), 32768, 32, 2048, 0.0, 0.0, 1.0, 0.999, MISTRAL_7B, id="1x2-Mistral7B-v32768-b32-s2048-no-pen", marks=_slow),
+        pytest.param((1, 2), 32768, 32, 2048, 1.2, 1.2, 1.5, 0.95, MISTRAL_7B, id="1x2-Mistral7B-v32768-b32-s2048-pen", marks=_slow),
+        pytest.param((1, 2), 32768, 32, 4096, 0.0, 0.0, 1.0, 0.999, MISTRAL_7B, id="1x2-Mistral7B-v32768-b32-s4096-no-pen", marks=_slow),
+        pytest.param((1, 2), 32768, 32, 4096, 1.2, 1.2, 1.5, 0.95, MISTRAL_7B, id="1x2-Mistral7B-v32768-b32-s4096-pen", marks=_slow),
+        # --- (1,2) Llama1B v128256 ---
+        pytest.param((1, 2), 128256, 1, 71, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x2-Llama1B-v128256-b1-s71-no-pen"),
+        pytest.param((1, 2), 128256, 1, 80, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x2-Llama1B-v128256-b1-s80-no-pen", marks=_slow),
+        pytest.param((1, 2), 128256, 1, 115, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x2-Llama1B-v128256-b1-s115-no-pen", marks=_slow),
+        pytest.param((1, 2), 128256, 1, 337, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x2-Llama1B-v128256-b1-s337-no-pen", marks=_slow),
+        pytest.param((1, 2), 128256, 1, 512, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x2-Llama1B-v128256-b1-s512-no-pen", marks=_slow),
+        pytest.param((1, 2), 128256, 1, 785, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x2-Llama1B-v128256-b1-s785-no-pen", marks=_slow),
+        pytest.param((1, 2), 128256, 1, 16229, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x2-Llama1B-v128256-b1-s16229-no-pen", marks=_slow),
+        pytest.param((1, 2), 128256, 32, 52, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x2-Llama1B-v128256-b32-s52-no-pen", marks=_slow),
+        pytest.param((1, 2), 128256, 32, 56, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x2-Llama1B-v128256-b32-s56-no-pen", marks=_slow),
+        pytest.param((1, 2), 128256, 32, 57, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x2-Llama1B-v128256-b32-s57-no-pen", marks=_slow),
+        pytest.param((1, 2), 128256, 32, 59, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x2-Llama1B-v128256-b32-s59-no-pen", marks=_slow),
+        pytest.param((1, 2), 128256, 32, 60, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x2-Llama1B-v128256-b32-s60-no-pen", marks=_slow),
+        pytest.param((1, 2), 128256, 32, 61, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x2-Llama1B-v128256-b32-s61-no-pen", marks=_slow),
+        pytest.param((1, 2), 128256, 32, 63, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x2-Llama1B-v128256-b32-s63-no-pen", marks=_slow),
+        pytest.param((1, 2), 128256, 32, 65, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x2-Llama1B-v128256-b32-s65-no-pen", marks=_slow),
+        pytest.param((1, 2), 128256, 32, 66, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x2-Llama1B-v128256-b32-s66-no-pen", marks=_slow),
+        pytest.param((1, 2), 128256, 32, 67, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x2-Llama1B-v128256-b32-s67-no-pen", marks=_slow),
+        pytest.param((1, 2), 128256, 32, 70, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x2-Llama1B-v128256-b32-s70-no-pen", marks=_slow),
+        pytest.param((1, 2), 128256, 32, 71, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x2-Llama1B-v128256-b32-s71-no-pen", marks=_slow),
+        pytest.param((1, 2), 128256, 32, 72, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x2-Llama1B-v128256-b32-s72-no-pen", marks=_slow),
+        pytest.param((1, 2), 128256, 32, 75, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x2-Llama1B-v128256-b32-s75-no-pen", marks=_slow),
+        pytest.param((1, 2), 128256, 32, 77, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x2-Llama1B-v128256-b32-s77-no-pen", marks=_slow),
+        pytest.param((1, 2), 128256, 32, 80, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x2-Llama1B-v128256-b32-s80-no-pen", marks=_slow),
+        pytest.param((1, 2), 128256, 32, 81, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x2-Llama1B-v128256-b32-s81-no-pen", marks=_slow),
+        pytest.param((1, 2), 128256, 32, 84, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x2-Llama1B-v128256-b32-s84-no-pen", marks=_slow),
+        pytest.param((1, 2), 128256, 32, 86, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x2-Llama1B-v128256-b32-s86-no-pen", marks=_slow),
+        pytest.param((1, 2), 128256, 32, 87, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x2-Llama1B-v128256-b32-s87-no-pen", marks=_slow),
+        pytest.param((1, 2), 128256, 32, 91, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x2-Llama1B-v128256-b32-s91-no-pen", marks=_slow),
+        pytest.param((1, 2), 128256, 32, 93, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x2-Llama1B-v128256-b32-s93-no-pen", marks=_slow),
+        pytest.param((1, 2), 128256, 32, 94, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x2-Llama1B-v128256-b32-s94-no-pen", marks=_slow),
+        pytest.param((1, 2), 128256, 32, 96, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x2-Llama1B-v128256-b32-s96-no-pen", marks=_slow),
+        pytest.param((1, 2), 128256, 32, 98, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x2-Llama1B-v128256-b32-s98-no-pen", marks=_slow),
+        pytest.param((1, 2), 128256, 32, 99, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x2-Llama1B-v128256-b32-s99-no-pen", marks=_slow),
+        pytest.param((1, 2), 128256, 32, 101, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x2-Llama1B-v128256-b32-s101-no-pen", marks=_slow),
+        pytest.param((1, 2), 128256, 32, 102, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x2-Llama1B-v128256-b32-s102-no-pen", marks=_slow),
+        pytest.param((1, 2), 128256, 32, 103, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x2-Llama1B-v128256-b32-s103-no-pen", marks=_slow),
+        pytest.param((1, 2), 128256, 32, 104, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x2-Llama1B-v128256-b32-s104-no-pen", marks=_slow),
+        pytest.param((1, 2), 128256, 32, 105, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x2-Llama1B-v128256-b32-s105-no-pen", marks=_slow),
+        pytest.param((1, 2), 128256, 32, 106, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x2-Llama1B-v128256-b32-s106-no-pen", marks=_slow),
+        pytest.param((1, 2), 128256, 32, 109, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x2-Llama1B-v128256-b32-s109-no-pen", marks=_slow),
+        pytest.param((1, 2), 128256, 32, 113, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x2-Llama1B-v128256-b32-s113-no-pen", marks=_slow),
+        pytest.param((1, 2), 128256, 32, 114, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x2-Llama1B-v128256-b32-s114-no-pen", marks=_slow),
+        pytest.param((1, 2), 128256, 32, 115, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x2-Llama1B-v128256-b32-s115-no-pen", marks=_slow),
+        pytest.param((1, 2), 128256, 32, 116, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x2-Llama1B-v128256-b32-s116-no-pen", marks=_slow),
+        pytest.param((1, 2), 128256, 32, 117, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x2-Llama1B-v128256-b32-s117-no-pen", marks=_slow),
+        pytest.param((1, 2), 128256, 32, 119, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x2-Llama1B-v128256-b32-s119-no-pen", marks=_slow),
+        pytest.param((1, 2), 128256, 32, 124, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x2-Llama1B-v128256-b32-s124-no-pen", marks=_slow),
+        pytest.param((1, 2), 128256, 32, 125, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x2-Llama1B-v128256-b32-s125-no-pen", marks=_slow),
+        pytest.param((1, 2), 128256, 32, 128, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x2-Llama1B-v128256-b32-s128-no-pen", marks=_slow),
+        pytest.param((1, 2), 128256, 32, 128, 1.2, 1.2, 1.5, 0.95, LLAMA_1B, id="1x2-Llama1B-v128256-b32-s128-pen", marks=_slow),
+        pytest.param((1, 2), 128256, 32, 337, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x2-Llama1B-v128256-b32-s337-no-pen", marks=_slow),
+        pytest.param((1, 2), 128256, 32, 512, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x2-Llama1B-v128256-b32-s512-no-pen", marks=_slow),
+        pytest.param((1, 2), 128256, 32, 712, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x2-Llama1B-v128256-b32-s712-no-pen", marks=_slow),
+        pytest.param((1, 2), 128256, 32, 785, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x2-Llama1B-v128256-b32-s785-no-pen", marks=_slow),
+        pytest.param((1, 2), 128256, 32, 1024, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x2-Llama1B-v128256-b32-s1024-no-pen", marks=_slow),
+        pytest.param((1, 2), 128256, 32, 1024, 1.2, 1.2, 1.5, 0.95, LLAMA_1B, id="1x2-Llama1B-v128256-b32-s1024-pen", marks=_slow),
+        pytest.param((1, 2), 128256, 32, 2048, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x2-Llama1B-v128256-b32-s2048-no-pen", marks=_slow),
+        pytest.param((1, 2), 128256, 32, 2048, 1.2, 1.2, 1.5, 0.95, LLAMA_1B, id="1x2-Llama1B-v128256-b32-s2048-pen", marks=_slow),
+        pytest.param((1, 2), 128256, 32, 4096, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x2-Llama1B-v128256-b32-s4096-no-pen", marks=_slow),
+        pytest.param((1, 2), 128256, 32, 4096, 1.2, 1.2, 1.5, 0.95, LLAMA_1B, id="1x2-Llama1B-v128256-b32-s4096-pen", marks=_slow),
+        pytest.param((1, 2), 128256, 32, 8192, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x2-Llama1B-v128256-b32-s8192-no-pen", marks=_slow),
+        pytest.param((1, 2), 128256, 32, 8192, 1.2, 1.2, 1.5, 0.95, LLAMA_1B, id="1x2-Llama1B-v128256-b32-s8192-pen", marks=_slow),
+        pytest.param((1, 2), 128256, 32, 16229, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x2-Llama1B-v128256-b32-s16229-no-pen", marks=_slow),
+        pytest.param((1, 2), 128256, 32, 16384, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x2-Llama1B-v128256-b32-s16384-no-pen", marks=_slow),
+        pytest.param((1, 2), 128256, 32, 16384, 1.2, 1.2, 1.5, 0.95, LLAMA_1B, id="1x2-Llama1B-v128256-b32-s16384-pen", marks=_slow),
+        pytest.param((1, 2), 128256, 32, 32768, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x2-Llama1B-v128256-b32-s32768-no-pen", marks=_slow),
+        pytest.param((1, 2), 128256, 32, 32768, 1.2, 1.2, 1.5, 0.95, LLAMA_1B, id="1x2-Llama1B-v128256-b32-s32768-pen", marks=_slow),
+        # --- (1,8) Mixtral8x7B v32000 ---
+        pytest.param((1, 8), 32000, 1, 87, 0.0, 0.0, 1.0, 0.999, MIXTRAL_8X7B, id="1x8-Mixtral8x7B-v32000-b1-s87-no-pen"),
+        pytest.param((1, 8), 32000, 1, 393, 0.0, 0.0, 1.0, 0.999, MIXTRAL_8X7B, id="1x8-Mixtral8x7B-v32000-b1-s393-no-pen", marks=_slow),
+        pytest.param((1, 8), 32000, 32, 57, 0.0, 0.0, 1.0, 0.999, MIXTRAL_8X7B, id="1x8-Mixtral8x7B-v32000-b32-s57-no-pen", marks=_slow),
+        pytest.param((1, 8), 32000, 32, 61, 0.0, 0.0, 1.0, 0.999, MIXTRAL_8X7B, id="1x8-Mixtral8x7B-v32000-b32-s61-no-pen", marks=_slow),
+        pytest.param((1, 8), 32000, 32, 64, 0.0, 0.0, 1.0, 0.999, MIXTRAL_8X7B, id="1x8-Mixtral8x7B-v32000-b32-s64-no-pen", marks=_slow),
+        pytest.param((1, 8), 32000, 32, 66, 0.0, 0.0, 1.0, 0.999, MIXTRAL_8X7B, id="1x8-Mixtral8x7B-v32000-b32-s66-no-pen", marks=_slow),
+        pytest.param((1, 8), 32000, 32, 67, 0.0, 0.0, 1.0, 0.999, MIXTRAL_8X7B, id="1x8-Mixtral8x7B-v32000-b32-s67-no-pen", marks=_slow),
+        pytest.param((1, 8), 32000, 32, 69, 0.0, 0.0, 1.0, 0.999, MIXTRAL_8X7B, id="1x8-Mixtral8x7B-v32000-b32-s69-no-pen", marks=_slow),
+        pytest.param((1, 8), 32000, 32, 70, 0.0, 0.0, 1.0, 0.999, MIXTRAL_8X7B, id="1x8-Mixtral8x7B-v32000-b32-s70-no-pen", marks=_slow),
+        pytest.param((1, 8), 32000, 32, 72, 0.0, 0.0, 1.0, 0.999, MIXTRAL_8X7B, id="1x8-Mixtral8x7B-v32000-b32-s72-no-pen", marks=_slow),
+        pytest.param((1, 8), 32000, 32, 73, 0.0, 0.0, 1.0, 0.999, MIXTRAL_8X7B, id="1x8-Mixtral8x7B-v32000-b32-s73-no-pen", marks=_slow),
+        pytest.param((1, 8), 32000, 32, 74, 0.0, 0.0, 1.0, 0.999, MIXTRAL_8X7B, id="1x8-Mixtral8x7B-v32000-b32-s74-no-pen", marks=_slow),
+        pytest.param((1, 8), 32000, 32, 76, 0.0, 0.0, 1.0, 0.999, MIXTRAL_8X7B, id="1x8-Mixtral8x7B-v32000-b32-s76-no-pen", marks=_slow),
+        pytest.param((1, 8), 32000, 32, 79, 0.0, 0.0, 1.0, 0.999, MIXTRAL_8X7B, id="1x8-Mixtral8x7B-v32000-b32-s79-no-pen", marks=_slow),
+        pytest.param((1, 8), 32000, 32, 82, 0.0, 0.0, 1.0, 0.999, MIXTRAL_8X7B, id="1x8-Mixtral8x7B-v32000-b32-s82-no-pen", marks=_slow),
+        pytest.param((1, 8), 32000, 32, 83, 0.0, 0.0, 1.0, 0.999, MIXTRAL_8X7B, id="1x8-Mixtral8x7B-v32000-b32-s83-no-pen", marks=_slow),
+        pytest.param((1, 8), 32000, 32, 87, 0.0, 0.0, 1.0, 0.999, MIXTRAL_8X7B, id="1x8-Mixtral8x7B-v32000-b32-s87-no-pen", marks=_slow),
+        pytest.param((1, 8), 32000, 32, 89, 0.0, 0.0, 1.0, 0.999, MIXTRAL_8X7B, id="1x8-Mixtral8x7B-v32000-b32-s89-no-pen", marks=_slow),
+        pytest.param((1, 8), 32000, 32, 101, 0.0, 0.0, 1.0, 0.999, MIXTRAL_8X7B, id="1x8-Mixtral8x7B-v32000-b32-s101-no-pen", marks=_slow),
+        pytest.param((1, 8), 32000, 32, 128, 0.0, 0.0, 1.0, 0.999, MIXTRAL_8X7B, id="1x8-Mixtral8x7B-v32000-b32-s128-no-pen", marks=_slow),
+        pytest.param((1, 8), 32000, 32, 128, 1.2, 1.2, 1.5, 0.95, MIXTRAL_8X7B, id="1x8-Mixtral8x7B-v32000-b32-s128-pen", marks=_slow),
+        pytest.param((1, 8), 32000, 32, 393, 0.0, 0.0, 1.0, 0.999, MIXTRAL_8X7B, id="1x8-Mixtral8x7B-v32000-b32-s393-no-pen", marks=_slow),
+        pytest.param((1, 8), 32000, 32, 820, 0.0, 0.0, 1.0, 0.999, MIXTRAL_8X7B, id="1x8-Mixtral8x7B-v32000-b32-s820-no-pen", marks=_slow),
+        pytest.param((1, 8), 32000, 32, 1024, 0.0, 0.0, 1.0, 0.999, MIXTRAL_8X7B, id="1x8-Mixtral8x7B-v32000-b32-s1024-no-pen", marks=_slow),
+        pytest.param((1, 8), 32000, 32, 1024, 1.2, 1.2, 1.5, 0.95, MIXTRAL_8X7B, id="1x8-Mixtral8x7B-v32000-b32-s1024-pen", marks=_slow),
+        pytest.param((1, 8), 32000, 32, 2048, 0.0, 0.0, 1.0, 0.999, MIXTRAL_8X7B, id="1x8-Mixtral8x7B-v32000-b32-s2048-no-pen", marks=_slow),
+        pytest.param((1, 8), 32000, 32, 2048, 1.2, 1.2, 1.5, 0.95, MIXTRAL_8X7B, id="1x8-Mixtral8x7B-v32000-b32-s2048-pen", marks=_slow),
+        pytest.param((1, 8), 32000, 32, 4096, 0.0, 0.0, 1.0, 0.999, MIXTRAL_8X7B, id="1x8-Mixtral8x7B-v32000-b32-s4096-no-pen", marks=_slow),
+        pytest.param((1, 8), 32000, 32, 4096, 1.2, 1.2, 1.5, 0.95, MIXTRAL_8X7B, id="1x8-Mixtral8x7B-v32000-b32-s4096-pen", marks=_slow),
+        # --- (1,8) Mistral7B v32768 ---
+        pytest.param((1, 8), 32768, 32, 128, 0.0, 0.0, 1.0, 0.999, MISTRAL_7B, id="1x8-Mistral7B-v32768-b32-s128-no-pen"),
+        pytest.param((1, 8), 32768, 32, 128, 1.2, 1.2, 1.5, 0.95, MISTRAL_7B, id="1x8-Mistral7B-v32768-b32-s128-pen", marks=_slow),
+        pytest.param((1, 8), 32768, 32, 1024, 0.0, 0.0, 1.0, 0.999, MISTRAL_7B, id="1x8-Mistral7B-v32768-b32-s1024-no-pen", marks=_slow),
+        pytest.param((1, 8), 32768, 32, 1024, 1.2, 1.2, 1.5, 0.95, MISTRAL_7B, id="1x8-Mistral7B-v32768-b32-s1024-pen", marks=_slow),
+        pytest.param((1, 8), 32768, 32, 2048, 0.0, 0.0, 1.0, 0.999, MISTRAL_7B, id="1x8-Mistral7B-v32768-b32-s2048-no-pen", marks=_slow),
+        pytest.param((1, 8), 32768, 32, 2048, 1.2, 1.2, 1.5, 0.95, MISTRAL_7B, id="1x8-Mistral7B-v32768-b32-s2048-pen", marks=_slow),
+        pytest.param((1, 8), 32768, 32, 4096, 0.0, 0.0, 1.0, 0.999, MISTRAL_7B, id="1x8-Mistral7B-v32768-b32-s4096-no-pen", marks=_slow),
+        pytest.param((1, 8), 32768, 32, 4096, 1.2, 1.2, 1.5, 0.95, MISTRAL_7B, id="1x8-Mistral7B-v32768-b32-s4096-pen", marks=_slow),
+        # --- (1,8) Llama1B v128256 ---
+        pytest.param((1, 8), 128256, 1, 71, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x8-Llama1B-v128256-b1-s71-no-pen"),
+        pytest.param((1, 8), 128256, 1, 80, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x8-Llama1B-v128256-b1-s80-no-pen", marks=_slow),
+        pytest.param((1, 8), 128256, 1, 115, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x8-Llama1B-v128256-b1-s115-no-pen", marks=_slow),
+        pytest.param((1, 8), 128256, 1, 337, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x8-Llama1B-v128256-b1-s337-no-pen", marks=_slow),
+        pytest.param((1, 8), 128256, 1, 512, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x8-Llama1B-v128256-b1-s512-no-pen", marks=_slow),
+        pytest.param((1, 8), 128256, 1, 785, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x8-Llama1B-v128256-b1-s785-no-pen", marks=_slow),
+        pytest.param((1, 8), 128256, 1, 16229, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x8-Llama1B-v128256-b1-s16229-no-pen", marks=_slow),
+        pytest.param((1, 8), 128256, 32, 52, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x8-Llama1B-v128256-b32-s52-no-pen", marks=_slow),
+        pytest.param((1, 8), 128256, 32, 56, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x8-Llama1B-v128256-b32-s56-no-pen", marks=_slow),
+        pytest.param((1, 8), 128256, 32, 57, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x8-Llama1B-v128256-b32-s57-no-pen", marks=_slow),
+        pytest.param((1, 8), 128256, 32, 59, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x8-Llama1B-v128256-b32-s59-no-pen", marks=_slow),
+        pytest.param((1, 8), 128256, 32, 60, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x8-Llama1B-v128256-b32-s60-no-pen", marks=_slow),
+        pytest.param((1, 8), 128256, 32, 61, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x8-Llama1B-v128256-b32-s61-no-pen", marks=_slow),
+        pytest.param((1, 8), 128256, 32, 63, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x8-Llama1B-v128256-b32-s63-no-pen", marks=_slow),
+        pytest.param((1, 8), 128256, 32, 65, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x8-Llama1B-v128256-b32-s65-no-pen", marks=_slow),
+        pytest.param((1, 8), 128256, 32, 66, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x8-Llama1B-v128256-b32-s66-no-pen", marks=_slow),
+        pytest.param((1, 8), 128256, 32, 67, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x8-Llama1B-v128256-b32-s67-no-pen", marks=_slow),
+        pytest.param((1, 8), 128256, 32, 70, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x8-Llama1B-v128256-b32-s70-no-pen", marks=_slow),
+        pytest.param((1, 8), 128256, 32, 71, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x8-Llama1B-v128256-b32-s71-no-pen", marks=_slow),
+        pytest.param((1, 8), 128256, 32, 72, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x8-Llama1B-v128256-b32-s72-no-pen", marks=_slow),
+        pytest.param((1, 8), 128256, 32, 75, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x8-Llama1B-v128256-b32-s75-no-pen", marks=_slow),
+        pytest.param((1, 8), 128256, 32, 77, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x8-Llama1B-v128256-b32-s77-no-pen", marks=_slow),
+        pytest.param((1, 8), 128256, 32, 80, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x8-Llama1B-v128256-b32-s80-no-pen", marks=_slow),
+        pytest.param((1, 8), 128256, 32, 81, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x8-Llama1B-v128256-b32-s81-no-pen", marks=_slow),
+        pytest.param((1, 8), 128256, 32, 84, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x8-Llama1B-v128256-b32-s84-no-pen", marks=_slow),
+        pytest.param((1, 8), 128256, 32, 86, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x8-Llama1B-v128256-b32-s86-no-pen", marks=_slow),
+        pytest.param((1, 8), 128256, 32, 87, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x8-Llama1B-v128256-b32-s87-no-pen", marks=_slow),
+        pytest.param((1, 8), 128256, 32, 91, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x8-Llama1B-v128256-b32-s91-no-pen", marks=_slow),
+        pytest.param((1, 8), 128256, 32, 93, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x8-Llama1B-v128256-b32-s93-no-pen", marks=_slow),
+        pytest.param((1, 8), 128256, 32, 94, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x8-Llama1B-v128256-b32-s94-no-pen", marks=_slow),
+        pytest.param((1, 8), 128256, 32, 96, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x8-Llama1B-v128256-b32-s96-no-pen", marks=_slow),
+        pytest.param((1, 8), 128256, 32, 98, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x8-Llama1B-v128256-b32-s98-no-pen", marks=_slow),
+        pytest.param((1, 8), 128256, 32, 99, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x8-Llama1B-v128256-b32-s99-no-pen", marks=_slow),
+        pytest.param((1, 8), 128256, 32, 101, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x8-Llama1B-v128256-b32-s101-no-pen", marks=_slow),
+        pytest.param((1, 8), 128256, 32, 102, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x8-Llama1B-v128256-b32-s102-no-pen", marks=_slow),
+        pytest.param((1, 8), 128256, 32, 103, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x8-Llama1B-v128256-b32-s103-no-pen", marks=_slow),
+        pytest.param((1, 8), 128256, 32, 104, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x8-Llama1B-v128256-b32-s104-no-pen", marks=_slow),
+        pytest.param((1, 8), 128256, 32, 105, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x8-Llama1B-v128256-b32-s105-no-pen", marks=_slow),
+        pytest.param((1, 8), 128256, 32, 106, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x8-Llama1B-v128256-b32-s106-no-pen", marks=_slow),
+        pytest.param((1, 8), 128256, 32, 109, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x8-Llama1B-v128256-b32-s109-no-pen", marks=_slow),
+        pytest.param((1, 8), 128256, 32, 113, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x8-Llama1B-v128256-b32-s113-no-pen", marks=_slow),
+        pytest.param((1, 8), 128256, 32, 114, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x8-Llama1B-v128256-b32-s114-no-pen", marks=_slow),
+        pytest.param((1, 8), 128256, 32, 115, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x8-Llama1B-v128256-b32-s115-no-pen", marks=_slow),
+        pytest.param((1, 8), 128256, 32, 116, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x8-Llama1B-v128256-b32-s116-no-pen", marks=_slow),
+        pytest.param((1, 8), 128256, 32, 117, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x8-Llama1B-v128256-b32-s117-no-pen", marks=_slow),
+        pytest.param((1, 8), 128256, 32, 119, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x8-Llama1B-v128256-b32-s119-no-pen", marks=_slow),
+        pytest.param((1, 8), 128256, 32, 124, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x8-Llama1B-v128256-b32-s124-no-pen", marks=_slow),
+        pytest.param((1, 8), 128256, 32, 125, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x8-Llama1B-v128256-b32-s125-no-pen", marks=_slow),
+        pytest.param((1, 8), 128256, 32, 128, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x8-Llama1B-v128256-b32-s128-no-pen", marks=_slow),
+        pytest.param((1, 8), 128256, 32, 128, 1.2, 1.2, 1.5, 0.95, LLAMA_1B, id="1x8-Llama1B-v128256-b32-s128-pen", marks=_slow),
+        pytest.param((1, 8), 128256, 32, 337, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x8-Llama1B-v128256-b32-s337-no-pen", marks=_slow),
+        pytest.param((1, 8), 128256, 32, 512, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x8-Llama1B-v128256-b32-s512-no-pen", marks=_slow),
+        pytest.param((1, 8), 128256, 32, 712, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x8-Llama1B-v128256-b32-s712-no-pen", marks=_slow),
+        pytest.param((1, 8), 128256, 32, 785, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x8-Llama1B-v128256-b32-s785-no-pen", marks=_slow),
+        pytest.param((1, 8), 128256, 32, 1024, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x8-Llama1B-v128256-b32-s1024-no-pen", marks=_slow),
+        pytest.param((1, 8), 128256, 32, 1024, 1.2, 1.2, 1.5, 0.95, LLAMA_1B, id="1x8-Llama1B-v128256-b32-s1024-pen", marks=_slow),
+        pytest.param((1, 8), 128256, 32, 2048, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x8-Llama1B-v128256-b32-s2048-no-pen", marks=_slow),
+        pytest.param((1, 8), 128256, 32, 2048, 1.2, 1.2, 1.5, 0.95, LLAMA_1B, id="1x8-Llama1B-v128256-b32-s2048-pen", marks=_slow),
+        pytest.param((1, 8), 128256, 32, 4096, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x8-Llama1B-v128256-b32-s4096-no-pen", marks=_slow),
+        pytest.param((1, 8), 128256, 32, 4096, 1.2, 1.2, 1.5, 0.95, LLAMA_1B, id="1x8-Llama1B-v128256-b32-s4096-pen", marks=_slow),
+        pytest.param((1, 8), 128256, 32, 8192, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x8-Llama1B-v128256-b32-s8192-no-pen", marks=_slow),
+        pytest.param((1, 8), 128256, 32, 8192, 1.2, 1.2, 1.5, 0.95, LLAMA_1B, id="1x8-Llama1B-v128256-b32-s8192-pen", marks=_slow),
+        pytest.param((1, 8), 128256, 32, 16229, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x8-Llama1B-v128256-b32-s16229-no-pen", marks=_slow),
+        pytest.param((1, 8), 128256, 32, 16384, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x8-Llama1B-v128256-b32-s16384-no-pen", marks=_slow),
+        pytest.param((1, 8), 128256, 32, 16384, 1.2, 1.2, 1.5, 0.95, LLAMA_1B, id="1x8-Llama1B-v128256-b32-s16384-pen", marks=_slow),
+        pytest.param((1, 8), 128256, 32, 32768, 0.0, 0.0, 1.0, 0.999, LLAMA_1B, id="1x8-Llama1B-v128256-b32-s32768-no-pen", marks=_slow),
+        pytest.param((1, 8), 128256, 32, 32768, 1.2, 1.2, 1.5, 0.95, LLAMA_1B, id="1x8-Llama1B-v128256-b32-s32768-pen", marks=_slow),
+        # --- (1,8) Qwen3-32B v151936 ---
+        pytest.param((1, 8), 151936, 32, 128, 1.2, 1.2, 1.5, 0.95, QWEN3_32B, id="1x8-Qwen3-32B-v151936-b32-s128-pen"),
+        # --- (1,8) Qwen2.5-72B v152064 ---
+        pytest.param((1, 8), 152064, 1, 65, 0.0, 0.0, 1.0, 0.999, QWEN25_72B, id="1x8-Qwen2.5-72B-v152064-b1-s65-no-pen"),
+        pytest.param((1, 8), 152064, 1, 80, 0.0, 0.0, 1.0, 0.999, QWEN25_72B, id="1x8-Qwen2.5-72B-v152064-b1-s80-no-pen", marks=_slow),
+        pytest.param((1, 8), 152064, 1, 109, 0.0, 0.0, 1.0, 0.999, QWEN25_72B, id="1x8-Qwen2.5-72B-v152064-b1-s109-no-pen", marks=_slow),
+        pytest.param((1, 8), 152064, 1, 421, 0.0, 0.0, 1.0, 0.999, QWEN25_72B, id="1x8-Qwen2.5-72B-v152064-b1-s421-no-pen", marks=_slow),
+        pytest.param((1, 8), 152064, 1, 512, 0.0, 0.0, 1.0, 0.999, QWEN25_72B, id="1x8-Qwen2.5-72B-v152064-b1-s512-no-pen", marks=_slow),
+        pytest.param((1, 8), 152064, 1, 780, 0.0, 0.0, 1.0, 0.999, QWEN25_72B, id="1x8-Qwen2.5-72B-v152064-b1-s780-no-pen", marks=_slow),
+        pytest.param((1, 8), 152064, 32, 48, 0.0, 0.0, 1.0, 0.999, QWEN25_72B, id="1x8-Qwen2.5-72B-v152064-b32-s48-no-pen", marks=_slow),
+        pytest.param((1, 8), 152064, 32, 50, 0.0, 0.0, 1.0, 0.999, QWEN25_72B, id="1x8-Qwen2.5-72B-v152064-b32-s50-no-pen", marks=_slow),
+        pytest.param((1, 8), 152064, 32, 51, 0.0, 0.0, 1.0, 0.999, QWEN25_72B, id="1x8-Qwen2.5-72B-v152064-b32-s51-no-pen", marks=_slow),
+        pytest.param((1, 8), 152064, 32, 54, 0.0, 0.0, 1.0, 0.999, QWEN25_72B, id="1x8-Qwen2.5-72B-v152064-b32-s54-no-pen", marks=_slow),
+        pytest.param((1, 8), 152064, 32, 55, 0.0, 0.0, 1.0, 0.999, QWEN25_72B, id="1x8-Qwen2.5-72B-v152064-b32-s55-no-pen", marks=_slow),
+        pytest.param((1, 8), 152064, 32, 56, 0.0, 0.0, 1.0, 0.999, QWEN25_72B, id="1x8-Qwen2.5-72B-v152064-b32-s56-no-pen", marks=_slow),
+        pytest.param((1, 8), 152064, 32, 57, 0.0, 0.0, 1.0, 0.999, QWEN25_72B, id="1x8-Qwen2.5-72B-v152064-b32-s57-no-pen", marks=_slow),
+        pytest.param((1, 8), 152064, 32, 59, 0.0, 0.0, 1.0, 0.999, QWEN25_72B, id="1x8-Qwen2.5-72B-v152064-b32-s59-no-pen", marks=_slow),
+        pytest.param((1, 8), 152064, 32, 60, 0.0, 0.0, 1.0, 0.999, QWEN25_72B, id="1x8-Qwen2.5-72B-v152064-b32-s60-no-pen", marks=_slow),
+        pytest.param((1, 8), 152064, 32, 61, 0.0, 0.0, 1.0, 0.999, QWEN25_72B, id="1x8-Qwen2.5-72B-v152064-b32-s61-no-pen", marks=_slow),
+        pytest.param((1, 8), 152064, 32, 64, 0.0, 0.0, 1.0, 0.999, QWEN25_72B, id="1x8-Qwen2.5-72B-v152064-b32-s64-no-pen", marks=_slow),
+        pytest.param((1, 8), 152064, 32, 65, 0.0, 0.0, 1.0, 0.999, QWEN25_72B, id="1x8-Qwen2.5-72B-v152064-b32-s65-no-pen", marks=_slow),
+        pytest.param((1, 8), 152064, 32, 68, 0.0, 0.0, 1.0, 0.999, QWEN25_72B, id="1x8-Qwen2.5-72B-v152064-b32-s68-no-pen", marks=_slow),
+        pytest.param((1, 8), 152064, 32, 69, 0.0, 0.0, 1.0, 0.999, QWEN25_72B, id="1x8-Qwen2.5-72B-v152064-b32-s69-no-pen", marks=_slow),
+        pytest.param((1, 8), 152064, 32, 71, 0.0, 0.0, 1.0, 0.999, QWEN25_72B, id="1x8-Qwen2.5-72B-v152064-b32-s71-no-pen", marks=_slow),
+        pytest.param((1, 8), 152064, 32, 74, 0.0, 0.0, 1.0, 0.999, QWEN25_72B, id="1x8-Qwen2.5-72B-v152064-b32-s74-no-pen", marks=_slow),
+        pytest.param((1, 8), 152064, 32, 75, 0.0, 0.0, 1.0, 0.999, QWEN25_72B, id="1x8-Qwen2.5-72B-v152064-b32-s75-no-pen", marks=_slow),
+        pytest.param((1, 8), 152064, 32, 76, 0.0, 0.0, 1.0, 0.999, QWEN25_72B, id="1x8-Qwen2.5-72B-v152064-b32-s76-no-pen", marks=_slow),
+        pytest.param((1, 8), 152064, 32, 80, 0.0, 0.0, 1.0, 0.999, QWEN25_72B, id="1x8-Qwen2.5-72B-v152064-b32-s80-no-pen", marks=_slow),
+        pytest.param((1, 8), 152064, 32, 81, 0.0, 0.0, 1.0, 0.999, QWEN25_72B, id="1x8-Qwen2.5-72B-v152064-b32-s81-no-pen", marks=_slow),
+        pytest.param((1, 8), 152064, 32, 85, 0.0, 0.0, 1.0, 0.999, QWEN25_72B, id="1x8-Qwen2.5-72B-v152064-b32-s85-no-pen", marks=_slow),
+        pytest.param((1, 8), 152064, 32, 87, 0.0, 0.0, 1.0, 0.999, QWEN25_72B, id="1x8-Qwen2.5-72B-v152064-b32-s87-no-pen", marks=_slow),
+        pytest.param((1, 8), 152064, 32, 88, 0.0, 0.0, 1.0, 0.999, QWEN25_72B, id="1x8-Qwen2.5-72B-v152064-b32-s88-no-pen", marks=_slow),
+        pytest.param((1, 8), 152064, 32, 90, 0.0, 0.0, 1.0, 0.999, QWEN25_72B, id="1x8-Qwen2.5-72B-v152064-b32-s90-no-pen", marks=_slow),
+        pytest.param((1, 8), 152064, 32, 92, 0.0, 0.0, 1.0, 0.999, QWEN25_72B, id="1x8-Qwen2.5-72B-v152064-b32-s92-no-pen", marks=_slow),
+        pytest.param((1, 8), 152064, 32, 93, 0.0, 0.0, 1.0, 0.999, QWEN25_72B, id="1x8-Qwen2.5-72B-v152064-b32-s93-no-pen", marks=_slow),
+        pytest.param((1, 8), 152064, 32, 95, 0.0, 0.0, 1.0, 0.999, QWEN25_72B, id="1x8-Qwen2.5-72B-v152064-b32-s95-no-pen", marks=_slow),
+        pytest.param((1, 8), 152064, 32, 96, 0.0, 0.0, 1.0, 0.999, QWEN25_72B, id="1x8-Qwen2.5-72B-v152064-b32-s96-no-pen", marks=_slow),
+        pytest.param((1, 8), 152064, 32, 97, 0.0, 0.0, 1.0, 0.999, QWEN25_72B, id="1x8-Qwen2.5-72B-v152064-b32-s97-no-pen", marks=_slow),
+        pytest.param((1, 8), 152064, 32, 98, 0.0, 0.0, 1.0, 0.999, QWEN25_72B, id="1x8-Qwen2.5-72B-v152064-b32-s98-no-pen", marks=_slow),
+        pytest.param((1, 8), 152064, 32, 99, 0.0, 0.0, 1.0, 0.999, QWEN25_72B, id="1x8-Qwen2.5-72B-v152064-b32-s99-no-pen", marks=_slow),
+        pytest.param((1, 8), 152064, 32, 100, 0.0, 0.0, 1.0, 0.999, QWEN25_72B, id="1x8-Qwen2.5-72B-v152064-b32-s100-no-pen", marks=_slow),
+        pytest.param((1, 8), 152064, 32, 101, 0.0, 0.0, 1.0, 0.999, QWEN25_72B, id="1x8-Qwen2.5-72B-v152064-b32-s101-no-pen", marks=_slow),
+        pytest.param((1, 8), 152064, 32, 102, 0.0, 0.0, 1.0, 0.999, QWEN25_72B, id="1x8-Qwen2.5-72B-v152064-b32-s102-no-pen", marks=_slow),
+        pytest.param((1, 8), 152064, 32, 103, 0.0, 0.0, 1.0, 0.999, QWEN25_72B, id="1x8-Qwen2.5-72B-v152064-b32-s103-no-pen", marks=_slow),
+        pytest.param((1, 8), 152064, 32, 107, 0.0, 0.0, 1.0, 0.999, QWEN25_72B, id="1x8-Qwen2.5-72B-v152064-b32-s107-no-pen", marks=_slow),
+        pytest.param((1, 8), 152064, 32, 108, 0.0, 0.0, 1.0, 0.999, QWEN25_72B, id="1x8-Qwen2.5-72B-v152064-b32-s108-no-pen", marks=_slow),
+        pytest.param((1, 8), 152064, 32, 109, 0.0, 0.0, 1.0, 0.999, QWEN25_72B, id="1x8-Qwen2.5-72B-v152064-b32-s109-no-pen", marks=_slow),
+        pytest.param((1, 8), 152064, 32, 110, 0.0, 0.0, 1.0, 0.999, QWEN25_72B, id="1x8-Qwen2.5-72B-v152064-b32-s110-no-pen", marks=_slow),
+        pytest.param((1, 8), 152064, 32, 111, 0.0, 0.0, 1.0, 0.999, QWEN25_72B, id="1x8-Qwen2.5-72B-v152064-b32-s111-no-pen", marks=_slow),
+        pytest.param((1, 8), 152064, 32, 113, 0.0, 0.0, 1.0, 0.999, QWEN25_72B, id="1x8-Qwen2.5-72B-v152064-b32-s113-no-pen", marks=_slow),
+        pytest.param((1, 8), 152064, 32, 118, 0.0, 0.0, 1.0, 0.999, QWEN25_72B, id="1x8-Qwen2.5-72B-v152064-b32-s118-no-pen", marks=_slow),
+        pytest.param((1, 8), 152064, 32, 119, 0.0, 0.0, 1.0, 0.999, QWEN25_72B, id="1x8-Qwen2.5-72B-v152064-b32-s119-no-pen", marks=_slow),
+        pytest.param((1, 8), 152064, 32, 128, 0.0, 0.0, 1.0, 0.999, QWEN25_72B, id="1x8-Qwen2.5-72B-v152064-b32-s128-no-pen", marks=_slow),
+        pytest.param((1, 8), 152064, 32, 128, 1.2, 1.2, 1.5, 0.95, QWEN25_72B, id="1x8-Qwen2.5-72B-v152064-b32-s128-pen", marks=_slow),
+        pytest.param((1, 8), 152064, 32, 421, 0.0, 0.0, 1.0, 0.999, QWEN25_72B, id="1x8-Qwen2.5-72B-v152064-b32-s421-no-pen", marks=_slow),
+        pytest.param((1, 8), 152064, 32, 512, 0.0, 0.0, 1.0, 0.999, QWEN25_72B, id="1x8-Qwen2.5-72B-v152064-b32-s512-no-pen", marks=_slow),
+        pytest.param((1, 8), 152064, 32, 707, 0.0, 0.0, 1.0, 0.999, QWEN25_72B, id="1x8-Qwen2.5-72B-v152064-b32-s707-no-pen", marks=_slow),
+        pytest.param((1, 8), 152064, 32, 780, 0.0, 0.0, 1.0, 0.999, QWEN25_72B, id="1x8-Qwen2.5-72B-v152064-b32-s780-no-pen", marks=_slow),
+        pytest.param((1, 8), 152064, 32, 1024, 0.0, 0.0, 1.0, 0.999, QWEN25_72B, id="1x8-Qwen2.5-72B-v152064-b32-s1024-no-pen", marks=_slow),
+        pytest.param((1, 8), 152064, 32, 1024, 1.2, 1.2, 1.5, 0.95, QWEN25_72B, id="1x8-Qwen2.5-72B-v152064-b32-s1024-pen", marks=_slow),
+        pytest.param((1, 8), 152064, 32, 2048, 0.0, 0.0, 1.0, 0.999, QWEN25_72B, id="1x8-Qwen2.5-72B-v152064-b32-s2048-no-pen", marks=_slow),
+        pytest.param((1, 8), 152064, 32, 2048, 1.2, 1.2, 1.5, 0.95, QWEN25_72B, id="1x8-Qwen2.5-72B-v152064-b32-s2048-pen", marks=_slow),
+        pytest.param((1, 8), 152064, 32, 4096, 0.0, 0.0, 1.0, 0.999, QWEN25_72B, id="1x8-Qwen2.5-72B-v152064-b32-s4096-no-pen", marks=_slow),
+        pytest.param((1, 8), 152064, 32, 4096, 1.2, 1.2, 1.5, 0.95, QWEN25_72B, id="1x8-Qwen2.5-72B-v152064-b32-s4096-pen", marks=_slow),
+        pytest.param((1, 8), 152064, 32, 8192, 0.0, 0.0, 1.0, 0.999, QWEN25_72B, id="1x8-Qwen2.5-72B-v152064-b32-s8192-no-pen", marks=_slow),
+        pytest.param((1, 8), 152064, 32, 8192, 1.2, 1.2, 1.5, 0.95, QWEN25_72B, id="1x8-Qwen2.5-72B-v152064-b32-s8192-pen", marks=_slow),
+        pytest.param((1, 8), 152064, 32, 16255, 0.0, 0.0, 1.0, 0.999, QWEN25_72B, id="1x8-Qwen2.5-72B-v152064-b32-s16255-no-pen", marks=_slow),
+        pytest.param((1, 8), 152064, 32, 16384, 0.0, 0.0, 1.0, 0.999, QWEN25_72B, id="1x8-Qwen2.5-72B-v152064-b32-s16384-no-pen", marks=_slow),
+        pytest.param((1, 8), 152064, 32, 16384, 1.2, 1.2, 1.5, 0.95, QWEN25_72B, id="1x8-Qwen2.5-72B-v152064-b32-s16384-pen", marks=_slow),
+
+    ]
+    # fmt: on
+
+
+# ==============================================================================
+# Reference implementation (pure torch)
+# ==============================================================================
+
+
+def reference_apply_penalties(logits, prompt_mask, output_mask, output_counts, presence, frequency, repetition):
+    """Pure-torch reference for penalty math, following the OpenAI API spec.
+
+    Algorithm source: vLLM's ``apply_penalties`` in ``vllm/model_executor/layers/utils.py``
+    (https://github.com/vllm-project/vllm/blob/main/vllm/model_executor/layers/utils.py).
+
+    - Presence: subtract flat penalty for each token that appeared in output
+    - Frequency: subtract penalty proportional to token occurrence count
+    - Repetition: sign-dependent scaling for tokens in prompt OR output
+      (positive logits divided by penalty, negative logits multiplied by penalty)
+    """
+    logits = logits.clone().float()
+    output_mask_f = output_mask.float()
+    output_counts_f = output_counts.float()
+
+    # Presence: logits -= output_mask * presence  (vLLM: presence_penalties * output_mask)
+    logits -= output_mask_f * presence
+
+    # Frequency: logits -= output_counts * frequency  (vLLM: frequency_penalties * output_bin_counts)
+    logits -= output_counts_f * frequency
+
+    # Repetition: sign-dependent scaling  (vLLM: apply_repetition_penalties on combined prompt+output mask)
+    combined = ((prompt_mask + output_mask) > 0).float()
+    inv_rep = 1.0 / repetition
+    # If logit > 0: multiply by 1/rep (shrink toward 0). If logit <= 0: multiply by rep (push away from 0).
+    scale = torch.where(
+        logits > 0,
+        torch.where(combined.bool(), inv_rep, torch.ones_like(logits)),
+        torch.where(combined.bool(), repetition, torch.ones_like(logits)),
+    )
+    logits *= scale
+    return logits
+
+
+# ==============================================================================
+# Unit tests: Config and dataclasses (no device)
+# ==============================================================================
+
+
+class TestConfigUnit:
+    def test_config_defaults(self):
+        cfg = Penalties1DConfig(vocab_size=1024)
+        assert cfg.max_batch_size == 32
+        assert cfg.mesh_device is None
+        assert cfg.sub_core_grids is None
+        assert cfg.prompt_mask is None
+
+    def test_config_not_resolved_without_mesh_device(self):
+        cfg = Penalties1DConfig(vocab_size=1024)
+        assert not cfg.is_resolved()
+
+    def test_penalty_params_fields(self):
+        fields = PenaltyParams.__dataclass_fields__
+        assert set(fields.keys()) == {
+            "prompt_mask",
+            "presence_penalties",
+            "frequency_penalties",
+            "repetition_penalties",
+            "inverse_repetition_penalties",
+        }
+
+    def test_penalty_accumulator_fields(self):
+        fields = PenaltyAccumulator.__dataclass_fields__
+        assert set(fields.keys()) == {"output_mask", "output_counts", "output_counts_gathered"}
+
+
+# ==============================================================================
+# Device tests: Config resolution and Penalties1D
+# ==============================================================================
+
+
+@pytest.mark.parametrize("ttnn_mesh_device", [(1, 1), (1, 2), (1, 8)], ids=["1x1", "1x2", "1x8"], indirect=True)
+class TestPenalties1DDevice:
+    @pytest.mark.parametrize("vocab_size", [1024])
+    def test_resolve_config(self, ttnn_mesh_device, vocab_size):
+        cfg = Penalties1DConfig(vocab_size=vocab_size, mesh_device=ttnn_mesh_device)
+        resolved = _resolve_penalties1d_config(cfg)
+        assert resolved.is_resolved()
+        assert resolved.mesh_device is ttnn_mesh_device
+
+    @pytest.mark.parametrize("vocab_size", [1024])
+    def test_load_device_buffers(self, ttnn_mesh_device, vocab_size):
+        pen = Penalties1D(vocab_size=vocab_size, mesh_device=ttnn_mesh_device)
+        pen.load_device_buffers()
+        assert pen._device_buffers_loaded
+        assert isinstance(pen._decode_src, ttnn.Tensor)
+        assert isinstance(pen._zeros, ttnn.Tensor)
+
+    @pytest.mark.parametrize("vocab_size", [1024])
+    def test_decode_forward_none_passthrough(self, ttnn_mesh_device, vocab_size):
+        """forward() with None params/accum returns logits unchanged."""
+        pen = Penalties1D(vocab_size=vocab_size, mesh_device=ttnn_mesh_device)
+        logits_host = torch.randn(32, vocab_size, dtype=torch.bfloat16)
+        logits_tt = ttnn.from_torch(logits_host, device=ttnn_mesh_device, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)
+
+        result = pen.forward(logits_tt, params=None, accum=None)
+        assert result is logits_tt
+
+    @pytest.mark.parametrize("vocab_size", [1024])
+    def test_from_model_args(self, ttnn_mesh_device, vocab_size):
+        """from_model_args backward compat factory."""
+
+        class MockArgs:
+            padded_vocab_size = vocab_size
+            sub_core_grids = None
+
+        pen = Penalties1D.from_model_args(ttnn_mesh_device, MockArgs())
+        assert pen.config.vocab_size == vocab_size
+        assert pen.config.mesh_device is ttnn_mesh_device
+
+    def test_rejects_galaxy(self, ttnn_mesh_device, expect_error):
+        """from_model_args should reject 2D (Galaxy) topologies."""
+
+        class FakeMesh:
+            shape = (2, 4)
+
+        class MockArgs:
+            padded_vocab_size = 1024
+            sub_core_grids = None
+
+        with expect_error(ValueError, "1D mesh topologies"):
+            Penalties1D.from_model_args(FakeMesh(), MockArgs())
+
+
+# ==============================================================================
+# VS Reference tests — full penalty pipeline compared against pure-torch golden
+# ==============================================================================
+
+
+def _make_penalty_tensors_on_device(
+    ttnn_mesh_device,
+    B,
+    *,
+    prompt_mask_host,
+    output_mask_host,
+    output_counts_host,
+    presence_val,
+    frequency_val,
+    repetition_val,
+):
+    """Helper: build PenaltyParams + PenaltyAccumulator on device from host tensors."""
+    params = PenaltyParams(
+        prompt_mask=ttnn.from_torch(
+            prompt_mask_host,
+            device=ttnn_mesh_device,
+            dtype=ttnn.int32,
+            layout=ttnn.TILE_LAYOUT,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        ),
+        presence_penalties=ttnn.from_torch(
+            torch.full((B, 1), presence_val),
+            device=ttnn_mesh_device,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+        ),
+        frequency_penalties=ttnn.from_torch(
+            torch.full((B, 1), frequency_val),
+            device=ttnn_mesh_device,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+        ),
+        repetition_penalties=ttnn.from_torch(
+            torch.full((B, 1), repetition_val),
+            device=ttnn_mesh_device,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+        ),
+        inverse_repetition_penalties=ttnn.from_torch(
+            torch.full((B, 1), 1.0 / repetition_val),
+            device=ttnn_mesh_device,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+        ),
+    )
+    accum = PenaltyAccumulator(
+        output_mask=ttnn.from_torch(
+            output_mask_host,
+            device=ttnn_mesh_device,
+            dtype=ttnn.int32,
+            layout=ttnn.TILE_LAYOUT,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        ),
+        output_counts=ttnn.from_torch(
+            output_counts_host,
+            device=ttnn_mesh_device,
+            dtype=ttnn.int32,
+            layout=ttnn.TILE_LAYOUT,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        ),
+        output_counts_gathered=ttnn.from_torch(
+            output_counts_host,
+            device=ttnn_mesh_device,
+            dtype=ttnn.int32,
+            layout=ttnn.TILE_LAYOUT,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        ),
+    )
+    return params, accum
+
+
+def _readback_logits(result_tt, ttnn_mesh_device, B, vocab_size):
+    """Helper: read logits back from device to host torch tensor."""
+    result_host = ttnn.to_torch(
+        result_tt,
+        mesh_composer=ttnn.ConcatMesh2dToTensor(
+            ttnn_mesh_device, dims=(0, 1), mesh_shape=tuple(ttnn_mesh_device.shape)
+        ),
+    )
+    return result_host[:B, :vocab_size].float()
+
+
+@pytest.mark.parametrize("ttnn_mesh_device", [(1, 1), (1, 2), (1, 8)], ids=["1x1", "1x2", "1x8"], indirect=True)
+@pytest.mark.parametrize(
+    "mesh_shape,vocab_size,batch_size,seq_len,presence,frequency,repetition,pcc,hf_model_name",
+    _list_collected_penalty_cases(),
+)
+def test_penalties1d_vs_reference(
+    ttnn_mesh_device,
+    mesh_shape,
+    vocab_size,
+    batch_size,
+    seq_len,
+    presence,
+    frequency,
+    repetition,
+    pcc,
+    hf_model_name,
+):
+    """
+    Test Penalties1D.decode_forward matches the pure-torch reference_apply_penalties.
+
+    Parametrized across penalty combinations to verify each penalty type independently
+    and in combination. PCC thresholds account for bfloat16 precision.
+    """
+    torch.manual_seed(42)
+    B = 32
+
+    pen = Penalties1D(vocab_size=vocab_size, mesh_device=ttnn_mesh_device)
+
+    # Build host tensors with realistic patterns
+    logits_host = torch.randn(B, vocab_size, dtype=torch.bfloat16)
+
+    # prompt_mask: first 50 tokens were in the prompt
+    prompt_mask_host = torch.zeros(B, vocab_size, dtype=torch.int32)
+    prompt_mask_host[:, :50] = 1
+
+    # output_mask: tokens 40-60 appeared in output (overlaps with prompt)
+    output_mask_host = torch.zeros(B, vocab_size, dtype=torch.int32)
+    output_mask_host[:, 40:60] = 1
+
+    # output_counts: tokens 40-60 appeared 1-3 times
+    output_counts_host = torch.zeros(B, vocab_size, dtype=torch.int32)
+    output_counts_host[:, 40:50] = 2
+    output_counts_host[:, 50:60] = 1
+
+    # --- Reference (pure torch) ---
+    expected = reference_apply_penalties(
+        logits_host,
+        prompt_mask_host,
+        output_mask_host,
+        output_counts_host,
+        presence,
+        frequency,
+        repetition,
+    )
+
+    # --- TT device ---
+    logits_tt = ttnn.from_torch(
+        logits_host,
+        device=ttnn_mesh_device,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+    )
+    params, accum = _make_penalty_tensors_on_device(
+        ttnn_mesh_device,
+        B,
+        prompt_mask_host=prompt_mask_host,
+        output_mask_host=output_mask_host,
+        output_counts_host=output_counts_host,
+        presence_val=presence,
+        frequency_val=frequency,
+        repetition_val=repetition,
+    )
+
+    result_tt = pen.decode_forward(logits_tt, params, accum)
+    result_host = _readback_logits(result_tt, ttnn_mesh_device, B, vocab_size)
+
+    passing, pcc_msg = comp_pcc(expected, result_host, pcc=pcc)
+    assert passing, f"Penalties1D vs reference failed: {pcc_msg} (threshold={pcc})"
+
+
+@pytest.mark.parametrize("ttnn_mesh_device", [(1, 1), (1, 2), (1, 8)], ids=["1x1", "1x2", "1x8"], indirect=True)
+def test_penalties1d_changes_argmax(ttnn_mesh_device):
+    """
+    Heavy repetition penalty should change which token has the highest logit.
+
+    Setup: token 0 has the highest logit AND appears in prompt+output.
+    With repetition=5.0, the penalty should push token 0's logit down far enough
+    that a different token becomes the argmax.
+    """
+    torch.manual_seed(123)
+    B = 32
+    vocab_size = 1024
+
+    pen = Penalties1D(vocab_size=vocab_size, mesh_device=ttnn_mesh_device)
+
+    # Token 0 is the clear winner in raw logits
+    logits_host = torch.randn(B, vocab_size, dtype=torch.bfloat16)
+    logits_host[:, 0] = 10.0  # make token 0 dominant
+
+    # Token 0 appears in prompt and output
+    prompt_mask_host = torch.zeros(B, vocab_size, dtype=torch.int32)
+    prompt_mask_host[:, 0] = 1
+    output_mask_host = torch.zeros(B, vocab_size, dtype=torch.int32)
+    output_mask_host[:, 0] = 1
+    output_counts_host = torch.zeros(B, vocab_size, dtype=torch.int32)
+    output_counts_host[:, 0] = 3
+
+    # Original argmax should be token 0
+    assert logits_host[0].argmax().item() == 0
+
+    logits_tt = ttnn.from_torch(
+        logits_host,
+        device=ttnn_mesh_device,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+    )
+    params, accum = _make_penalty_tensors_on_device(
+        ttnn_mesh_device,
+        B,
+        prompt_mask_host=prompt_mask_host,
+        output_mask_host=output_mask_host,
+        output_counts_host=output_counts_host,
+        presence_val=2.0,
+        frequency_val=2.0,
+        repetition_val=5.0,
+    )
+
+    result_tt = pen.decode_forward(logits_tt, params, accum)
+    result_host = _readback_logits(result_tt, ttnn_mesh_device, B, vocab_size)
+
+    # After heavy penalties, token 0 should no longer be argmax
+    new_argmax = result_host[0].argmax().item()
+    assert new_argmax != 0, f"Expected penalty to change argmax from 0, but it's still {new_argmax}"
+
+
+# ==============================================================================
+# Helper: build topology-correct PenaltyParams + PenaltyAccumulator from config
+# ==============================================================================
+
+
+def _make_proper_params_accum(pen: Penalties1D):
+    """Build PenaltyParams + PenaltyAccumulator from the module's resolved config.
+
+    Uses the config's LazyBuffer mesh_mappers to guarantee the correct dtype/layout/
+    sharding for whatever device topology is active. This is required for methods like
+    init_prompt_penalties and update_output_tokens that call _token_bin_counts_and_mask,
+    which expects properly sharded output tensors.
+    """
+    params = PenaltyParams(
+        prompt_mask=_materialize(pen.config.prompt_mask),
+        presence_penalties=_materialize(pen.config.presence_penalties),
+        frequency_penalties=_materialize(pen.config.frequency_penalties),
+        repetition_penalties=_materialize(pen.config.repetition_penalties),
+        inverse_repetition_penalties=_materialize(pen.config.inverse_repetition_penalties),
+    )
+    accum = PenaltyAccumulator(
+        output_mask=_materialize(pen.config.output_mask),
+        output_counts=_materialize(pen.config.output_counts),
+        output_counts_gathered=_materialize(pen.config.output_counts_gathered),
+    )
+    return params, accum
+
+
+# ==============================================================================
+# Additional unit tests (no device)
+# ==============================================================================
+
+
+class TestConfigUnitMore:
+    def test_buf_resolved_with_lazy_buffer(self):
+        """_buf_resolved calls buf.is_resolved() for a LazyBuffer (line 97)."""
+        from models.experimental.llama32_1b_quasar.modules.lazy_buffer import LazyBuffer
+
+        lb = LazyBuffer(source=torch.zeros(1), device=None)
+        assert not Penalties1DConfig._buf_resolved(lb)  # is_resolved() → False (device=None)
+
+    def test_buf_resolved_returns_false_for_none(self):
+        """_buf_resolved returns False for None (baseline, complements line 95/97 tests)."""
+        assert not Penalties1DConfig._buf_resolved(None)
+
+
+# ==============================================================================
+# Additional device tests: coverage for previously untested methods
+# ==============================================================================
+
+
+@pytest.mark.parametrize("ttnn_mesh_device", [(1, 1), (1, 2), (1, 8)], ids=["1x1", "1x2", "1x8"], indirect=True)
+class TestPenalties1DDeviceExtra:
+    """Coverage for methods not exercised by the reference tests."""
+
+    # ------------------------------------------------------------------
+    # _buf_resolved ttnn.Tensor path (line 95)
+    # ------------------------------------------------------------------
+
+    def test_buf_resolved_with_tt_tensor(self, ttnn_mesh_device):
+        """_buf_resolved returns True for a real ttnn.Tensor (line 95)."""
+        tt = ttnn.from_torch(
+            torch.zeros(1, 1, dtype=torch.int32),
+            device=ttnn_mesh_device,
+            dtype=ttnn.int32,
+            layout=ttnn.TILE_LAYOUT,
+        )
+        assert Penalties1DConfig._buf_resolved(tt)
+
+    # ------------------------------------------------------------------
+    # from_config (lines 141-145)
+    # ------------------------------------------------------------------
+
+    @pytest.mark.parametrize("vocab_size", [1024])
+    def test_from_config(self, ttnn_mesh_device, vocab_size):
+        """from_config power-path classmethod (lines 141-145)."""
+        cfg = Penalties1DConfig(vocab_size=vocab_size, mesh_device=ttnn_mesh_device)
+        pen = Penalties1D.from_config(cfg)
+        assert pen.config.vocab_size == vocab_size
+        assert pen.config.mesh_device is ttnn_mesh_device
+        assert not pen._device_buffers_loaded
+
+    # ------------------------------------------------------------------
+    # load_device_buffers idempotent guard (line 166)
+    # ------------------------------------------------------------------
+
+    @pytest.mark.parametrize("vocab_size", [1024])
+    def test_load_device_buffers_idempotent(self, ttnn_mesh_device, vocab_size):
+        """Second call to load_device_buffers returns early without re-allocating (line 166)."""
+        pen = Penalties1D(vocab_size=vocab_size, mesh_device=ttnn_mesh_device)
+        pen.load_device_buffers()
+        decode_src_first = pen._decode_src
+        pen.load_device_buffers()  # hits early-return at line 166
+        assert pen._decode_src is decode_src_first
+
+    # ------------------------------------------------------------------
+    # init_prompt_penalties + _token_bin_counts_and_mask counts=None path
+    # ------------------------------------------------------------------
+
+    @pytest.mark.parametrize("vocab_size", [1024])
+    def test_init_prompt_penalties(self, ttnn_mesh_device, vocab_size):
+        """init_prompt_penalties scatters prompt tokens into prompt_mask."""
+        B = 32
+        pen = Penalties1D(vocab_size=vocab_size, mesh_device=ttnn_mesh_device)
+        pen.load_device_buffers()
+        params, accum = _make_proper_params_accum(pen)
+
+        prompt_tokens = torch.randint(0, vocab_size, (B, 10))
+        pen.init_prompt_penalties(params, accum, prompt_tokens)
+
+    # ------------------------------------------------------------------
+    # forward() prompt init dispatch
+    # ------------------------------------------------------------------
+
+    @pytest.mark.parametrize("vocab_size", [1024])
+    def test_forward_dispatches_to_init_prompt(self, ttnn_mesh_device, vocab_size):
+        """forward() with prompt_tokens kwarg routes to init_prompt_penalties."""
+        B = 32
+        pen = Penalties1D(vocab_size=vocab_size, mesh_device=ttnn_mesh_device)
+        pen.load_device_buffers()
+        params, accum = _make_proper_params_accum(pen)
+
+        logits_tt = ttnn.from_torch(
+            torch.randn(B, vocab_size, dtype=torch.bfloat16),
+            device=ttnn_mesh_device,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+        )
+        prompt_tokens = torch.randint(0, vocab_size, (B, 5))
+        result = pen.forward(logits_tt, params=params, accum=accum, prompt_tokens=prompt_tokens)
+        assert result is logits_tt
+
+    @pytest.mark.parametrize("vocab_size", [1024])
+    def test_forward_dispatches_to_decode(self, ttnn_mesh_device, vocab_size):
+        """forward() without prompt_tokens routes to decode_forward (line 280).
+
+        Uses unsharded (replicated) tensors — same topology as test_penalties1d_vs_reference —
+        so the broadcast between logits [B, V] and penalty masks [B, V] is valid on all mesh
+        shapes. The goal here is line 280 coverage, not correctness (covered elsewhere).
+        """
+        B = 32
+        pen = Penalties1D(vocab_size=vocab_size, mesh_device=ttnn_mesh_device)
+
+        zeros_BV = torch.zeros(B, vocab_size, dtype=torch.int32)
+        params, accum = _make_penalty_tensors_on_device(
+            ttnn_mesh_device,
+            B,
+            prompt_mask_host=zeros_BV,
+            output_mask_host=zeros_BV,
+            output_counts_host=zeros_BV,
+            presence_val=0.0,
+            frequency_val=0.0,
+            repetition_val=1.0,
+        )
+        logits_tt = ttnn.from_torch(
+            torch.randn(B, vocab_size, dtype=torch.bfloat16),
+            device=ttnn_mesh_device,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+        )
+        result = pen.forward(logits_tt, params=params, accum=accum)
+        assert result is not None
+
+    # ------------------------------------------------------------------
+    # update_output_tokens: standard decode path (lines 290-294)
+    # and _token_bin_counts_and_mask counts-not-None path (line 419)
+    # ------------------------------------------------------------------
+
+    @pytest.mark.parametrize("vocab_size", [1024])
+    def test_update_output_tokens_standard(self, ttnn_mesh_device, vocab_size):
+        """update_output_tokens with standard decode-shape [1,1,1,B] (lines 290-294)."""
+        B = 32
+        pen = Penalties1D(vocab_size=vocab_size, mesh_device=ttnn_mesh_device)
+        pen.load_device_buffers()
+        _, accum = _make_proper_params_accum(pen)
+
+        # Standard sampling output: shape[-1]=B=32, shape[-2]=1 → if-branch
+        tokens_tt = ttnn.from_torch(
+            torch.randint(0, vocab_size, (1, 1, 1, B), dtype=torch.int32),
+            device=ttnn_mesh_device,
+            dtype=ttnn.int32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+        )
+        pen.update_output_tokens(accum, tokens_tt)
+
+    # ------------------------------------------------------------------
+    # update_output_tokens: multi-token else branch (lines 296-303)
+    # ------------------------------------------------------------------
+
+    @pytest.mark.parametrize("vocab_size", [1024])
+    def test_update_output_tokens_multi_token(self, ttnn_mesh_device, vocab_size):
+        """update_output_tokens with multi-token [B,S] shape triggers else-branch (lines 296-303)."""
+        B = 32
+        pen = Penalties1D(vocab_size=vocab_size, mesh_device=ttnn_mesh_device)
+        pen.load_device_buffers()
+        _, accum = _make_proper_params_accum(pen)
+
+        # shape[-1]=4 != B=32 → else-branch; src = ones(B, 4) created inline
+        tokens_tt = ttnn.from_torch(
+            torch.randint(0, vocab_size, (B, 4), dtype=torch.int32),
+            device=ttnn_mesh_device,
+            dtype=ttnn.int32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+        )
+        pen.update_output_tokens(accum, tokens_tt)
+
+    # ------------------------------------------------------------------
+    # reset_output_tokens: tokens=None (lines 317-324) and with tokens (lines 326-346)
+    # ------------------------------------------------------------------
+
+    @pytest.mark.parametrize("vocab_size", [1024])
+    def test_reset_output_tokens_no_tokens(self, ttnn_mesh_device, vocab_size):
+        """reset_output_tokens(tokens=None) zeros the accum buffers (lines 317-324)."""
+        pen = Penalties1D(vocab_size=vocab_size, mesh_device=ttnn_mesh_device)
+        pen.load_device_buffers()
+        _, accum = _make_proper_params_accum(pen)
+        pen.reset_output_tokens(accum, tokens=None)
+
+    @pytest.mark.parametrize("vocab_size", [1024])
+    def test_reset_output_tokens_with_tokens(self, ttnn_mesh_device, vocab_size):
+        """reset_output_tokens(tokens=...) zeros then re-initializes from tokens (lines 326-346)."""
+        B = 32
+        pen = Penalties1D(vocab_size=vocab_size, mesh_device=ttnn_mesh_device)
+        pen.load_device_buffers()
+        _, accum = _make_proper_params_accum(pen)
+        tokens = torch.randint(0, vocab_size, (B, 5))
+        pen.reset_output_tokens(accum, tokens=tokens)
+
+    # ------------------------------------------------------------------
+    # _pad_batch_to_max: pad (lines 399-401), truncate (402-403), ValueError (396-397)
+    # ------------------------------------------------------------------
+
+    def test_pad_batch_to_max_pads_small_batch(self, ttnn_mesh_device):
+        """_pad_batch_to_max pads when B < max_batch_size (lines 399-401)."""
+        pen = Penalties1D(vocab_size=1024, mesh_device=ttnn_mesh_device)
+        pen.load_device_buffers()
+        small = torch.randint(0, 100, (4, 10))
+        padded = pen._pad_batch_to_max(small, pad_value=-1)
+        assert padded.shape[0] == pen.config.max_batch_size
+        assert (padded[4:] == -1).all()
+
+    def test_pad_batch_to_max_truncates_large_batch(self, ttnn_mesh_device):
+        """_pad_batch_to_max truncates when B > max_batch_size (lines 402-403)."""
+        pen = Penalties1D(vocab_size=1024, mesh_device=ttnn_mesh_device)
+        pen.load_device_buffers()
+        large = torch.randint(0, 100, (64, 10))
+        truncated = pen._pad_batch_to_max(large, pad_value=-1)
+        assert truncated.shape[0] == pen.config.max_batch_size
+
+    def test_pad_batch_to_max_raises_on_non_2d(self, ttnn_mesh_device, expect_error):
+        """_pad_batch_to_max raises ValueError for non-2D input (lines 396-397)."""
+        pen = Penalties1D(vocab_size=1024, mesh_device=ttnn_mesh_device)
+        pen.load_device_buffers()
+        with expect_error(ValueError, "Expected 2D"):
+            pen._pad_batch_to_max(torch.zeros(10), pad_value=-1)
+
+    # ------------------------------------------------------------------
+    # _resolve_buf: ttnn.Tensor passthrough (lines 474-475)
+    # and LazyBuffer resolve (line 476)
+    # ------------------------------------------------------------------
+
+    @pytest.mark.parametrize("vocab_size", [1024])
+    def test_resolve_buf_tensor_passthrough(self, ttnn_mesh_device, vocab_size):
+        """Pre-existing ttnn.Tensor passes through _resolve_buf unchanged (lines 474-475)."""
+        B = 32
+        pre_tensor = ttnn.from_torch(
+            torch.zeros(B, vocab_size, dtype=torch.int32),
+            device=ttnn_mesh_device,
+            dtype=ttnn.int32,
+            layout=ttnn.TILE_LAYOUT,
+        )
+        cfg = Penalties1DConfig(vocab_size=vocab_size, mesh_device=ttnn_mesh_device, prompt_mask=pre_tensor)
+        resolved = _resolve_penalties1d_config(cfg)
+        assert resolved.prompt_mask is pre_tensor
+
+    @pytest.mark.parametrize("vocab_size", [1024])
+    def test_resolve_buf_lazy_buffer_passthrough(self, ttnn_mesh_device, vocab_size):
+        """Pre-existing LazyBuffer with device=None gets device filled in (line 476)."""
+        from models.experimental.llama32_1b_quasar.modules.lazy_buffer import LazyBuffer
+
+        B = 32
+        partial_lb = LazyBuffer(
+            source=torch.zeros(B, vocab_size, dtype=torch.int32),
+            dtype=ttnn.int32,
+            layout=ttnn.TILE_LAYOUT,
+            device=None,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+        cfg = Penalties1DConfig(vocab_size=vocab_size, mesh_device=ttnn_mesh_device, prompt_mask=partial_lb)
+        resolved = _resolve_penalties1d_config(cfg)
+        assert isinstance(resolved.prompt_mask, LazyBuffer)
+        assert resolved.prompt_mask.device is ttnn_mesh_device
+
+    # ------------------------------------------------------------------
+    # _materialize: ttnn.Tensor passthrough (line 552)
+    # ------------------------------------------------------------------
+
+    @pytest.mark.parametrize("vocab_size", [1024])
+    def test_materialize_tensor_passthrough(self, ttnn_mesh_device, vocab_size):
+        """Pre-existing ttnn.Tensor as decode_src passes through _materialize (line 552)."""
+        B = 32
+        pre_src = ttnn.from_torch(
+            torch.ones(B, 1, dtype=torch.int32),
+            device=ttnn_mesh_device,
+            dtype=ttnn.int32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+        )
+        cfg = Penalties1DConfig(vocab_size=vocab_size, mesh_device=ttnn_mesh_device, decode_src=pre_src)
+        pen = Penalties1D.from_config(cfg)
+        pen.load_device_buffers()
+        assert pen._decode_src is pre_src

--- a/models/experimental/llama32_1b_quasar/tests/modules/sampling/test_sampling_1d.py
+++ b/models/experimental/llama32_1b_quasar/tests/modules/sampling/test_sampling_1d.py
@@ -1,0 +1,1650 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for Sampling1D module."""
+
+import pytest
+import torch
+
+import ttnn
+from models.experimental.llama32_1b_quasar.auto_compose import to_torch_auto_compose
+from models.experimental.llama32_1b_quasar.modules.sampling.sampling_1d import (
+    Sampling1D,
+    Sampling1DConfig,
+    _resolve_sampling1d_config,
+)
+
+# ---------------------------------------------------------------------------
+# Model name constants (match test_mlp_1d.py naming convention)
+# ---------------------------------------------------------------------------
+LLAMA_1B = "meta-llama/Llama-3.2-1B-Instruct"
+LLAMA_3B = "meta-llama/Llama-3.2-3B-Instruct"
+LLAMA_8B = "meta-llama/Llama-3.1-8B-Instruct"
+LLAMA_11B = "meta-llama/Llama-3.2-11B-Vision-Instruct"
+LLAMA_70B = "meta-llama/Llama-3.3-70B-Instruct"
+MISTRAL_7B = "mistralai/Mistral-7B-Instruct-v0.3"
+MIXTRAL_8X7B = "mistralai/Mixtral-8x7B-v0.1"
+QWEN25_72B = "Qwen/Qwen2.5-72B-Instruct"
+QWEN3_32B = "Qwen/Qwen3-32B"
+
+_slow = pytest.mark.slow
+
+
+def _sub_core_grids_for_32_users():
+    return ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 3))})
+
+
+def _list_collected_sampling_cases() -> list[pytest.param]:
+    """
+    Collected from TTTv1 demo runs (Phase B of test_case_collection.md).
+
+    Each entry is:
+        (mesh_shape, vocab_size, k, p, temp, force_argmax, hf_model_name)
+
+    Source CSVs: sampling_generator_config_collected.csv,
+                 sampling_generator_params_collected.csv
+    Deduplicated by (topology, vocab, k, p, temp, force_argmax).
+    """
+    # fmt: off
+    return [
+        # --- (1,1) Mistral7B v32768 ---
+        pytest.param((1, 1), 32768, 1, 1.0, 1.0, False, MISTRAL_7B, id="1x1-Mistral7B-v32768-k1-p1.0-t1.0"),
+        pytest.param((1, 1), 32768, 10, 0.9, 1.0, False, MISTRAL_7B, id="1x1-Mistral7B-v32768-k10-p0.9-t1.0", marks=_slow),
+        # --- (1,1) Llama8B v128256 ---
+        pytest.param((1, 1), 128256, 1, 1.0, 1.0, True, LLAMA_8B, id="1x1-Llama8B-v128256-k1-p1.0-t1.0-argmax"),
+        # --- (1,1) Llama1B v128256 ---
+        pytest.param((1, 1), 128256, 1, 0.08, 1.0, False, LLAMA_1B, id="1x1-Llama1B-v128256-k1-p0.08-t1.0", marks=_slow),
+        pytest.param((1, 1), 128256, 1, 1.0, 1.0, False, LLAMA_1B, id="1x1-Llama1B-v128256-k1-p1.0-t1.0", marks=_slow),
+        pytest.param((1, 1), 128256, 10, 0.9, 1.0, False, LLAMA_1B, id="1x1-Llama1B-v128256-k10-p0.9-t1.0", marks=_slow),
+        # --- (1,2) Mistral7B v32768 ---
+        pytest.param((1, 2), 32768, 1, 1.0, 1.0, False, MISTRAL_7B, id="1x2-Mistral7B-v32768-k1-p1.0-t1.0"),
+        pytest.param((1, 2), 32768, 10, 0.9, 1.0, False, MISTRAL_7B, id="1x2-Mistral7B-v32768-k10-p0.9-t1.0", marks=_slow),
+        # --- (1,2) Llama8B v128256 ---
+        pytest.param((1, 2), 128256, 1, 1.0, 1.0, True, LLAMA_8B, id="1x2-Llama8B-v128256-k1-p1.0-t1.0-argmax"),
+        # --- (1,2) Llama1B v128256 ---
+        pytest.param((1, 2), 128256, 1, 0.08, 1.0, False, LLAMA_1B, id="1x2-Llama1B-v128256-k1-p0.08-t1.0", marks=_slow),
+        pytest.param((1, 2), 128256, 1, 1.0, 1.0, False, LLAMA_1B, id="1x2-Llama1B-v128256-k1-p1.0-t1.0", marks=_slow),
+        pytest.param((1, 2), 128256, 10, 0.9, 1.0, False, LLAMA_1B, id="1x2-Llama1B-v128256-k10-p0.9-t1.0", marks=_slow),
+        # --- (1,8) Mixtral8x7B v32000 ---
+        pytest.param((1, 8), 32000, 1, 0.08, 1.0, False, MIXTRAL_8X7B, id="1x8-Mixtral8x7B-v32000-k1-p0.08-t1.0"),
+        pytest.param((1, 8), 32000, 1, 1.0, 1.0, False, MIXTRAL_8X7B, id="1x8-Mixtral8x7B-v32000-k1-p1.0-t1.0", marks=_slow),
+        pytest.param((1, 8), 32000, 10, 0.9, 1.0, False, MIXTRAL_8X7B, id="1x8-Mixtral8x7B-v32000-k10-p0.9-t1.0", marks=_slow),
+        # --- (1,8) Mistral7B v32768 ---
+        pytest.param((1, 8), 32768, 1, 1.0, 1.0, False, MISTRAL_7B, id="1x8-Mistral7B-v32768-k1-p1.0-t1.0"),
+        pytest.param((1, 8), 32768, 10, 0.9, 1.0, False, MISTRAL_7B, id="1x8-Mistral7B-v32768-k10-p0.9-t1.0", marks=_slow),
+        # --- (1,8) Llama8B v128256 ---
+        pytest.param((1, 8), 128256, 1, 1.0, 1.0, True, LLAMA_8B, id="1x8-Llama8B-v128256-k1-p1.0-t1.0-argmax"),
+        # --- (1,8) Llama1B v128256 ---
+        pytest.param((1, 8), 128256, 1, 0.08, 1.0, False, LLAMA_1B, id="1x8-Llama1B-v128256-k1-p0.08-t1.0", marks=_slow),
+        pytest.param((1, 8), 128256, 1, 1.0, 1.0, False, LLAMA_1B, id="1x8-Llama1B-v128256-k1-p1.0-t1.0", marks=_slow),
+        pytest.param((1, 8), 128256, 10, 0.9, 1.0, False, LLAMA_1B, id="1x8-Llama1B-v128256-k10-p0.9-t1.0", marks=_slow),
+        # --- (1,8) Qwen3-32B v151936 ---
+        pytest.param((1, 8), 151936, 10, 0.9, 1.0, False, QWEN3_32B, id="1x8-Qwen3-32B-v151936-k10-p0.9-t1.0"),
+        # --- (1,8) Qwen2.5-72B v152064 ---
+        pytest.param((1, 8), 152064, 1, 0.08, 1.0, False, QWEN25_72B, id="1x8-Qwen2.5-72B-v152064-k1-p0.08-t1.0"),
+        pytest.param((1, 8), 152064, 1, 1.0, 1.0, False, QWEN25_72B, id="1x8-Qwen2.5-72B-v152064-k1-p1.0-t1.0", marks=_slow),
+        pytest.param((1, 8), 152064, 10, 0.9, 1.0, False, QWEN25_72B, id="1x8-Qwen2.5-72B-v152064-k10-p0.9-t1.0", marks=_slow),
+
+    ]
+    # fmt: on
+
+
+# ==============================================================================
+# Unit tests: Config (no device)
+# ==============================================================================
+
+
+class TestConfigUnit:
+    def test_config_defaults(self):
+        cfg = Sampling1DConfig(vocab_size=1024)
+        assert cfg.max_batch_size == 32
+        assert cfg.max_top_k == 32
+        assert cfg.allow_force_argmax is False
+        assert cfg.num_gather_links == 1
+        assert cfg.mesh_device is None
+        assert cfg.index_offsets is None
+        assert cfg.seeds is None
+
+    def test_config_custom(self):
+        cfg = Sampling1DConfig(vocab_size=128256, max_top_k=64, allow_force_argmax=True)
+        assert cfg.vocab_size == 128256
+        assert cfg.max_top_k == 64
+        assert cfg.allow_force_argmax is True
+
+    def test_config_not_resolved_without_device(self):
+        cfg = Sampling1DConfig(vocab_size=1024)
+        assert not cfg.is_resolved()
+
+    def test_config_not_resolved_multi_device_no_ccl(self):
+        """is_resolved() returns False when multi-device mesh but tt_ccl is None (line 65)."""
+        from unittest.mock import MagicMock
+
+        mock_device = MagicMock()
+        mock_device.get_num_devices.return_value = 2
+        cfg = Sampling1DConfig(vocab_size=1024, mesh_device=mock_device, tt_ccl=None)
+        assert not cfg.is_resolved()
+
+
+# ==============================================================================
+# Device tests
+# ==============================================================================
+
+
+@pytest.mark.parametrize("ttnn_mesh_device", [(1, 1), (1, 2), (1, 8)], ids=["1x1", "1x2", "1x8"], indirect=True)
+class TestSampling1DDevice:
+    @pytest.mark.parametrize("vocab_size", [1024])
+    def test_resolve_config(self, ttnn_mesh_device, vocab_size):
+        cfg = Sampling1DConfig(vocab_size=vocab_size, mesh_device=ttnn_mesh_device)
+        resolved = _resolve_sampling1d_config(cfg)
+        assert resolved.is_resolved()
+        assert resolved.start_core is not None
+        assert resolved.sampling_memory_config is not None
+        assert resolved.index_offsets is not None
+        assert resolved.seeds is not None
+
+    @pytest.mark.parametrize("vocab_size", [1024])
+    def test_load_device_buffers(self, ttnn_mesh_device, vocab_size):
+        sampler = Sampling1D(vocab_size=vocab_size, mesh_device=ttnn_mesh_device)
+        sampler.load_device_buffers()
+        assert sampler._device_buffers_loaded
+        assert isinstance(sampler._index_offsets, ttnn.Tensor)
+        assert isinstance(sampler._local_indices, ttnn.Tensor)
+        assert isinstance(sampler._seeds, ttnn.Tensor)
+        assert isinstance(sampler._user_ids, ttnn.Tensor)
+
+    @pytest.mark.parametrize("vocab_size", [1024])
+    def test_force_argmax(self, ttnn_mesh_device, vocab_size):
+        """allow_force_argmax=True, k/p/temp=None → matches torch.argmax."""
+        sampler = Sampling1D(vocab_size=vocab_size, mesh_device=ttnn_mesh_device, allow_force_argmax=True)
+        sampler.load_device_buffers()
+        B = sampler.config.max_batch_size
+
+        torch.manual_seed(42)
+        logits_host = torch.randn(1, 1, B, vocab_size, dtype=torch.bfloat16)
+
+        logits_tt = _make_logits_tt(logits_host, ttnn_mesh_device)
+
+        tokens_tt, log_probs = sampler.decode_forward(logits_tt)
+        tokens_host = to_torch_auto_compose(tokens_tt)
+
+        expected_argmax = logits_host.float().argmax(dim=-1)
+        # .long(): ttnn.argmax → uint32, torch.argmax → int64; normalize before compare
+        tokens_flat = tokens_host.flatten()[:B].long()
+        expected_flat = expected_argmax.flatten()[:B].long()
+
+        assert torch.equal(
+            tokens_flat, expected_flat
+        ), f"Argmax mismatch: got {tokens_flat[:5]} vs expected {expected_flat[:5]}"
+
+    @pytest.mark.parametrize("vocab_size", [1024])
+    def test_error_on_partial_params(self, ttnn_mesh_device, vocab_size, expect_error):
+        """k provided but not p/temp → ValueError."""
+        sampler = Sampling1D(vocab_size=vocab_size, mesh_device=ttnn_mesh_device)
+        logits_host = torch.randn(1, 1, 32, vocab_size, dtype=torch.bfloat16)
+        logits_tt = _make_logits_tt(logits_host, ttnn_mesh_device)
+        k_tt = ttnn.from_torch(torch.ones(32), device=ttnn_mesh_device, dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT)
+
+        with expect_error(ValueError, "k, p, temp must all be provided"):
+            sampler.decode_forward(logits_tt, k=k_tt)
+
+    @pytest.mark.parametrize("vocab_size", [1024])
+    def test_from_model_args(self, ttnn_mesh_device, vocab_size):
+        """from_model_args backward compat factory."""
+
+        class MockArgs:
+            padded_vocab_size = vocab_size
+            sub_core_grids = None
+            sub_core_grid_topk = None
+            start_core = ttnn.CoreCoord(0, 0)
+            max_top_k = 32
+
+        sampler = Sampling1D.from_model_args(ttnn_mesh_device, None, MockArgs())
+        assert sampler.config.vocab_size == vocab_size
+        assert sampler.config.mesh_device is ttnn_mesh_device
+
+    # ------------------------------------------------------------------
+    # CCL introspection (_bind_strategy lines 116-126)
+    # ------------------------------------------------------------------
+
+    def test_bind_strategy_ccl_introspection_with_kwargs(self, ttnn_mesh_device):
+        """_bind_strategy correctly detects buffer_key/dtype support on line_all_gather."""
+        from dataclasses import replace
+
+        sampler = Sampling1D(vocab_size=1024, mesh_device=ttnn_mesh_device)
+
+        class MockCCL:
+            def line_all_gather(self, tensor, dim, cluster_axis, memory_config, num_links, buffer_key=None, dtype=None):
+                return tensor
+
+        sampler.config = replace(sampler.config, tt_ccl=MockCCL())
+        sampler._bind_strategy()
+
+        assert sampler._line_all_gather_supports_buffer_key
+        assert sampler._line_all_gather_supports_dtype
+
+    def test_bind_strategy_ccl_introspection_no_kwargs(self, ttnn_mesh_device):
+        """_bind_strategy detects when line_all_gather does NOT support buffer_key/dtype."""
+        from dataclasses import replace
+
+        sampler = Sampling1D(vocab_size=1024, mesh_device=ttnn_mesh_device)
+
+        class MockCCL:
+            def line_all_gather(self, tensor, dim, cluster_axis, memory_config, num_links):
+                return tensor
+
+        sampler.config = replace(sampler.config, tt_ccl=MockCCL())
+        sampler._bind_strategy()
+
+        assert not sampler._line_all_gather_supports_buffer_key
+        assert not sampler._line_all_gather_supports_dtype
+
+    def test_bind_strategy_ccl_introspection_exception(self, ttnn_mesh_device):
+        """_bind_strategy handles TypeError from inspect.signature gracefully (lines 125-126)."""
+        from dataclasses import replace
+        from unittest.mock import patch
+
+        sampler = Sampling1D(vocab_size=1024, mesh_device=ttnn_mesh_device)
+
+        class MockCCL:
+            def line_all_gather(self, *args, **kwargs):
+                return args[0]
+
+        sampler.config = replace(sampler.config, tt_ccl=MockCCL())
+
+        with patch(
+            "models.experimental.llama32_1b_quasar.modules.sampling.sampling_1d.inspect.signature",
+            side_effect=TypeError("Cannot inspect"),
+        ):
+            sampler._bind_strategy()
+
+        assert not sampler._line_all_gather_supports_buffer_key
+        assert not sampler._line_all_gather_supports_dtype
+
+    # ------------------------------------------------------------------
+    # Error paths (lines 178, 186)
+    # ------------------------------------------------------------------
+
+    @pytest.mark.parametrize("vocab_size", [1024])
+    def test_error_all_none_no_force_argmax(self, ttnn_mesh_device, vocab_size, expect_error):
+        """decode_forward with all-None k/p/temp when allow_force_argmax=False → ValueError (line 178)."""
+        sampler = Sampling1D(vocab_size=vocab_size, mesh_device=ttnn_mesh_device)
+        logits_host = torch.randn(1, 1, 32, vocab_size, dtype=torch.bfloat16)
+        logits_tt = _make_logits_tt(logits_host, ttnn_mesh_device)
+
+        with expect_error(ValueError, "allow_force_argmax is False"):
+            sampler.decode_forward(logits_tt)
+
+    @pytest.mark.parametrize("vocab_size", [1024])
+    def test_forward_dispatches_to_decode_forward(self, ttnn_mesh_device, vocab_size):
+        """forward() delegates to decode_forward() (line 186)."""
+        sampler = Sampling1D(vocab_size=vocab_size, mesh_device=ttnn_mesh_device, allow_force_argmax=True)
+        logits_host = torch.randn(1, 1, 32, vocab_size, dtype=torch.bfloat16)
+        logits_tt = _make_logits_tt(logits_host, ttnn_mesh_device)
+
+        result = sampler.forward(logits_tt)
+        assert result is not None
+        assert len(result) == 2  # (token_ids, log_probs)
+
+    # ------------------------------------------------------------------
+    # _perform_all_gather with line_all_gather (lines 367-377)
+    # ------------------------------------------------------------------
+
+    @pytest.mark.parametrize("vocab_size", [1024])
+    def test_perform_all_gather_with_mock_ccl(self, ttnn_mesh_device, vocab_size):
+        """_perform_all_gather passes buffer_key/dtype kwargs when line_all_gather supports them."""
+        B, K = 32, 32
+        sampler = Sampling1D(vocab_size=vocab_size, mesh_device=ttnn_mesh_device)
+        sampler.load_device_buffers()
+
+        captured_kwargs = {}
+
+        def mock_line_ag(tensor, **kwargs):
+            captured_kwargs.update(kwargs)
+            return tensor
+
+        sampler._line_all_gather = mock_line_ag
+        sampler._line_all_gather_supports_buffer_key = True
+        sampler._line_all_gather_supports_dtype = True
+
+        test_tensor = ttnn.from_torch(
+            torch.zeros(1, 1, B, K, dtype=torch.bfloat16),
+            device=ttnn_mesh_device,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+
+        result = sampler._perform_all_gather(
+            test_tensor,
+            dim=3,
+            cluster_axis=None,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            num_links=1,
+            buffer_key="TEST_KEY",
+            dtype=ttnn.bfloat16,
+        )
+
+        assert result is test_tensor
+        assert captured_kwargs.get("buffer_key") == "TEST_KEY"
+        assert captured_kwargs.get("dtype") == ttnn.bfloat16
+
+    # ------------------------------------------------------------------
+    # from_model_args model_config branches (lines 406-408, 416-419)
+    # ------------------------------------------------------------------
+
+    def test_from_model_args_with_galaxy_num_links(self, ttnn_mesh_device):
+        """from_model_args reads num_gather_links from GALAXY_NUM_LINKS in model_config (lines 406-408)."""
+
+        class MockArgs:
+            padded_vocab_size = 1024
+            sub_core_grids = None
+            sub_core_grid_topk = None
+            start_core = ttnn.CoreCoord(0, 0)
+            max_top_k = 32
+
+        model_config = {"GALAXY_NUM_LINKS": 4}
+        sampler = Sampling1D.from_model_args(ttnn_mesh_device, None, MockArgs(), model_config=model_config)
+        # max_top_k=32 → 32//32=1, max_links=4 → min(1, 4) = 1
+        assert sampler.config.num_gather_links == 1
+
+    def test_from_model_args_with_sampling_ag_config(self, ttnn_mesh_device):
+        """from_model_args reads allow_force_argmax/num_links/topology from SAMPLING_AG_CONFIG (lines 416-419)."""
+
+        class MockArgs:
+            padded_vocab_size = 1024
+            sub_core_grids = None
+            sub_core_grid_topk = None
+            start_core = ttnn.CoreCoord(0, 0)
+            max_top_k = 32
+
+        model_config = {
+            "SAMPLING_AG_CONFIG": {
+                "allow_force_argmax": True,
+                "num_links": 3,
+                "topology": ttnn.Topology.Linear,
+            }
+        }
+        sampler = Sampling1D.from_model_args(ttnn_mesh_device, None, MockArgs(), model_config=model_config)
+        assert sampler.config.allow_force_argmax is True
+        assert sampler.config.num_argmax_gather_links == 3
+        assert sampler.config.ag_topology == ttnn.Topology.Linear
+
+    # ------------------------------------------------------------------
+    # Buffer passthrough: _resolve_buf ttnn.Tensor path (lines 493-494)
+    # and _materialize ttnn.Tensor path (line 554)
+    # ------------------------------------------------------------------
+
+    @pytest.mark.parametrize("vocab_size", [1024])
+    def test_resolve_buf_tensor_passthrough_and_materialize(self, ttnn_mesh_device, vocab_size):
+        """Pre-existing ttnn.Tensor passes through _resolve_buf (493-494) and _materialize (554)."""
+        cluster_shape = tuple(ttnn_mesh_device.shape)
+        num_devices_in_mesh = 2 if list(cluster_shape) == [1, 1] else max(cluster_shape)
+        B, K = 32, 32
+
+        replicate_mapper = ttnn.ShardTensor2dMesh(ttnn_mesh_device, dims=(None, None), mesh_shape=cluster_shape)
+        offsets_host = torch.zeros(1, 1, B, K * num_devices_in_mesh, dtype=torch.int64)
+        pre_tensor = ttnn.from_torch(
+            offsets_host,
+            device=ttnn_mesh_device,
+            dtype=ttnn.int32,
+            layout=ttnn.TILE_LAYOUT,
+            mesh_mapper=replicate_mapper,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+
+        cfg = Sampling1DConfig(vocab_size=vocab_size, mesh_device=ttnn_mesh_device, index_offsets=pre_tensor)
+        resolved = _resolve_sampling1d_config(cfg)
+        assert resolved.index_offsets is pre_tensor  # ttnn.Tensor passthrough in _resolve_buf
+
+        sampler = Sampling1D.from_config(cfg)
+        sampler.load_device_buffers()
+        assert sampler._index_offsets is pre_tensor  # ttnn.Tensor passthrough in _materialize
+
+    # ------------------------------------------------------------------
+    # Buffer passthrough: _resolve_buf LazyBuffer path (line 495)
+    # ------------------------------------------------------------------
+
+    @pytest.mark.parametrize("vocab_size", [1024])
+    def test_resolve_buf_lazy_buffer_passthrough(self, ttnn_mesh_device, vocab_size):
+        """Pre-existing LazyBuffer with device=None → resolve_lazy_buffer fills in device (line 495)."""
+        from models.experimental.llama32_1b_quasar.modules.lazy_buffer import LazyBuffer
+
+        cluster_shape = tuple(ttnn_mesh_device.shape)
+        num_devices_in_mesh = 2 if list(cluster_shape) == [1, 1] else max(cluster_shape)
+        B, K = 32, 32
+
+        replicate_mapper = ttnn.ShardTensor2dMesh(ttnn_mesh_device, dims=(None, None), mesh_shape=cluster_shape)
+        partial_lb = LazyBuffer(
+            source=torch.zeros(1, 1, B, K * num_devices_in_mesh, dtype=torch.int32),
+            dtype=ttnn.int32,
+            layout=ttnn.TILE_LAYOUT,
+            device=None,  # device not set — resolve_lazy_buffer fills it in
+            mesh_mapper=replicate_mapper,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+
+        cfg = Sampling1DConfig(vocab_size=vocab_size, mesh_device=ttnn_mesh_device, index_offsets=partial_lb)
+        resolved = _resolve_sampling1d_config(cfg)
+        assert isinstance(resolved.index_offsets, LazyBuffer)
+        assert resolved.index_offsets.device is ttnn_mesh_device  # filled in by resolve_lazy_buffer
+
+    def test_rejects_galaxy(self, ttnn_mesh_device, expect_error):
+        """from_model_args should reject 2D (Galaxy) topologies."""
+
+        class FakeMesh:
+            shape = (2, 4)
+
+            def get_num_devices(self):
+                return 8
+
+        class MockArgs:
+            padded_vocab_size = 1024
+            sub_core_grids = None
+            sub_core_grid_topk = None
+            start_core = ttnn.CoreCoord(0, 0)
+            max_top_k = 32
+
+        with expect_error(ValueError, "1D mesh topologies"):
+            Sampling1D.from_model_args(FakeMesh(), None, MockArgs())
+
+
+# ==============================================================================
+# Shared helper: tie-break-aware mismatch assertion
+# ==============================================================================
+
+
+def _assert_no_true_mismatches(
+    device_tokens: "torch.Tensor",
+    ref_tokens: "torch.Tensor",
+    logits_2d: "torch.Tensor",
+    *,
+    test_label: str,
+    quant_tolerance: float = 0.0,
+):
+    """Classify index mismatches as tie-breaks vs true mismatches. Assert zero true mismatches.
+
+    In low-precision formats (bfloat16, bfloat8_b), multiple elements can share the same
+    representable value. When ttnn.topk picks a different index among tied elements, that's
+    a TIE-BREAK (acceptable). Only a TRUE-MISMATCH (device picked a genuinely lower value)
+    indicates a kernel bug.
+
+    Args:
+        device_tokens: [B] int tensor of device-chosen indices.
+        ref_tokens:    [B] int tensor of reference indices.
+        logits_2d:     [B, V] tensor for value lookups (same precision as device input).
+        test_label:    Printed header, e.g. "top-k=1 vs argmax (V=32768, mesh=(1,1))".
+        quant_tolerance: Max acceptable value delta for quantization-boundary effects
+            (0.0 for bfloat16, ~0.032 for bfloat8_b block-float).
+    """
+    B = len(device_tokens)
+    num_mismatches = (device_tokens != ref_tokens).sum().item()
+
+    true_mismatches = 0
+    tie_breaks = 0
+    true_mismatch_details = []
+
+    for b in range(B):
+        dev_idx = int(device_tokens[b].item())
+        ref_idx = int(ref_tokens[b].item())
+        if dev_idx == ref_idx:
+            continue
+        dev_val = logits_2d[b, dev_idx].float().item()
+        ref_val = logits_2d[b, ref_idx].float().item()
+        delta = ref_val - dev_val
+
+        if delta > quant_tolerance:
+            true_mismatches += 1
+            true_mismatch_details.append(
+                f"  batch {b}: device idx={dev_idx} (val={dev_val:.6f}) "
+                f"< ref idx={ref_idx} (val={ref_val:.6f}), delta={delta:.6f}"
+            )
+        else:
+            tie_breaks += 1
+
+    # Report
+    print(f"\n--- {test_label} ---")
+    print(f"  index mismatches: {num_mismatches}/{B}  (tie-breaks: {tie_breaks}, true: {true_mismatches})")
+
+    if num_mismatches > 0:
+        for b in range(B):
+            dev_idx = int(device_tokens[b].item())
+            ref_idx = int(ref_tokens[b].item())
+            if dev_idx == ref_idx:
+                continue
+            dev_val = logits_2d[b, dev_idx].float().item()
+            ref_val = logits_2d[b, ref_idx].float().item()
+            delta = ref_val - dev_val
+            if delta > quant_tolerance:
+                label = "TRUE-MISMATCH"
+            elif delta > 0:
+                label = "QUANT-BOUNDARY"
+            else:
+                label = "TIE-BREAK"
+            print(
+                f"  batch {b} [{label}]: device idx={dev_idx} (val={dev_val:.6f}), "
+                f"ref idx={ref_idx} (val={ref_val:.6f}), delta={delta:.6f}"
+            )
+
+    # Assert
+    assert true_mismatches == 0, (
+        f"{test_label}: {true_mismatches}/{B} TRUE mismatches "
+        f"(device picked a lower value, not a tie-break)\n"
+        f"  ({num_mismatches} total index disagreements, {tie_breaks} are tie-breaks)\n"
+        + "\n".join(true_mismatch_details)
+    )
+
+    return num_mismatches, tie_breaks, true_mismatches
+
+
+# ==============================================================================
+# VS Reference tests — sampling correctness against torch golden
+# ==============================================================================
+
+
+def _make_logits_tt(logits_host, ttnn_mesh_device, *, shard_vocab=False):
+    """Create logits on device. shard_vocab=True shards the last dim across devices (for top-k path)."""
+    cluster_shape = tuple(ttnn_mesh_device.shape)
+    if not shard_vocab or max(cluster_shape) == 1:
+        shard_dims = (None, None)
+    elif cluster_shape[-1] >= cluster_shape[-2]:
+        shard_dims = (None, -1)
+    else:
+        shard_dims = (-1, None)
+    return ttnn.from_torch(
+        logits_host,
+        device=ttnn_mesh_device,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        mesh_mapper=ttnn.ShardTensor2dMesh(ttnn_mesh_device, dims=shard_dims, mesh_shape=cluster_shape),
+    )
+
+
+def _make_sampling_params(ttnn_mesh_device, B, *, k_val=1, p_val=0.0, temp_val=1.0, cluster_shape=(1, 1)):
+    """Helper: create k/p/temp device tensors for Sampling1D.decode_forward()."""
+    k = ttnn.from_torch(
+        torch.full((B,), k_val, dtype=torch.int32),
+        device=ttnn_mesh_device,
+        dtype=ttnn.uint32,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        mesh_mapper=ttnn.ShardTensor2dMesh(ttnn_mesh_device, dims=(None, None), mesh_shape=cluster_shape),
+    )
+    p = ttnn.from_torch(
+        torch.full((B,), p_val),
+        device=ttnn_mesh_device,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        mesh_mapper=ttnn.ShardTensor2dMesh(ttnn_mesh_device, dims=(None, None), mesh_shape=cluster_shape),
+    )
+    temp = ttnn.from_torch(
+        torch.full((B,), temp_val),
+        device=ttnn_mesh_device,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        mesh_mapper=ttnn.ShardTensor2dMesh(ttnn_mesh_device, dims=(None, None), mesh_shape=cluster_shape),
+    )
+    return k, p, temp
+
+
+@pytest.mark.parametrize("ttnn_mesh_device", [(1, 1), (1, 2), (1, 8)], ids=["1x1", "1x2", "1x8"], indirect=True)
+@pytest.mark.parametrize(
+    "mesh_shape,vocab_size,k_val,p_val,temp_val,force_argmax,hf_model_name",
+    _list_collected_sampling_cases(),
+)
+def test_sampling1d_topk1_vs_argmax(
+    ttnn_mesh_device, mesh_shape, vocab_size, k_val, p_val, temp_val, force_argmax, hf_model_name
+):
+    """
+    Top-k=1, p=0.0, temp=1.0 should produce the same result as torch.argmax.
+
+    This is the primary correctness test: with k=1 the sampling degenerates to argmax,
+    giving us an exact reference to compare against.
+    """
+    torch.manual_seed(42)
+    B = 32
+
+    sampler = Sampling1D(vocab_size=vocab_size, mesh_device=ttnn_mesh_device)
+
+    logits_host = torch.randn(1, 1, B, vocab_size, dtype=torch.bfloat16)
+
+    logits_tt = _make_logits_tt(logits_host, ttnn_mesh_device, shard_vocab=True)
+
+    cluster_shape = tuple(ttnn_mesh_device.shape)
+    k, p, temp = _make_sampling_params(
+        ttnn_mesh_device, B, k_val=1, p_val=0.0, temp_val=1.0, cluster_shape=cluster_shape
+    )
+
+    tokens_tt, _ = sampler.decode_forward(logits_tt, k=k, p=p, temp=temp)
+    tokens_host = to_torch_auto_compose(tokens_tt).flatten()[:B]
+
+    # Naive fp32 reference — shows how many index disagreements arise from bfloat16 precision.
+    # These are NOT correctness failures; they demonstrate why the bf16-sharded reference below
+    # is necessary. All fp32 mismatches should be tie-breaks (same bf16 value, different index).
+    fp32_expected = logits_host.float().argmax(dim=-1).flatten()[:B]
+    fp32_mismatches = (tokens_host.long() != fp32_expected.long()).sum().item()
+    mesh_label = tuple(ttnn_mesh_device.shape)
+    print(f"\n  fp32 argmax mismatches: {fp32_mismatches}/{B} (V={vocab_size}, mesh={mesh_label})")
+
+    # Bfloat16-aware sharded reference: shard the vocab the same way the device does,
+    # find top-1 per shard, then pick the global winner. This accounts for bfloat16 precision
+    # loss at shard boundaries that torch.argmax on float32 doesn't see.
+    num_devices = max(ttnn_mesh_device.shape)
+    if num_devices == 1:
+        num_shards = 2  # single device splits vocab in half internally
+    else:
+        num_shards = num_devices
+    logits_bf16 = logits_host.squeeze().bfloat16()  # [B, V] in bfloat16
+    shard_size = vocab_size // num_shards
+    # For each batch element, find the global argmax by comparing shard-local argmaxes
+    bf16_expected = torch.zeros(B, dtype=torch.long)
+    for b in range(B):
+        best_val = float("-inf")
+        best_idx = 0
+        for s in range(num_shards):
+            shard = logits_bf16[b, s * shard_size : (s + 1) * shard_size]
+            local_idx = shard.float().argmax().item()
+            local_val = shard[local_idx].float().item()
+            if local_val > best_val:
+                best_val = local_val
+                best_idx = s * shard_size + local_idx
+        bf16_expected[b] = best_idx
+
+    _assert_no_true_mismatches(
+        tokens_host.long(),
+        bf16_expected,
+        logits_bf16,
+        test_label=f"top-k=1 vs bf16-sharded argmax (V={vocab_size}, mesh={mesh_label})",
+    )
+
+
+@pytest.mark.parametrize("ttnn_mesh_device", [(1, 1), (1, 2), (1, 8)], ids=["1x1", "1x2", "1x8"], indirect=True)
+def test_sampling1d_argmax_vs_reference(ttnn_mesh_device):
+    """
+    Force-argmax path (k/p/temp=None, allow_force_argmax=True) vs torch.argmax.
+
+    Tests the all-gather-free argmax path on single device.
+    """
+    torch.manual_seed(99)
+    B = 32
+    vocab_size = 1024
+
+    sampler = Sampling1D(
+        vocab_size=vocab_size,
+        mesh_device=ttnn_mesh_device,
+        allow_force_argmax=True,
+    )
+
+    logits_host = torch.randn(1, 1, B, vocab_size, dtype=torch.bfloat16)
+    logits_tt = _make_logits_tt(logits_host, ttnn_mesh_device)
+
+    tokens_tt, _ = sampler.decode_forward(logits_tt)
+    # .long(): ttnn.argmax → uint32, torch.argmax → int64; normalize before compare
+    tokens_host = to_torch_auto_compose(tokens_tt).flatten()[:B].long()
+    expected = logits_host.float().argmax(dim=-1).flatten()[:B].long()
+
+    assert torch.equal(
+        tokens_host, expected
+    ), f"argmax path mismatch:\n  got:      {tokens_host[:8]}\n  expected: {expected[:8]}"
+
+
+@pytest.mark.parametrize("ttnn_mesh_device", [(1, 8)], ids=["1x8"], indirect=True)
+def test_sampling1d_qwen3_32b_uses_compact_tail_mask(ttnn_mesh_device):
+    sampler = Sampling1D(vocab_size=152064, valid_vocab_size=151936, mesh_device=ttnn_mesh_device)
+    sampler.load_device_buffers()
+
+    assert sampler._invalid_vocab_mask is None
+    assert isinstance(sampler._invalid_vocab_tail_mask, ttnn.Tensor)
+    assert sampler._invalid_vocab_tail_width == 128
+
+
+@pytest.mark.parametrize("ttnn_mesh_device", [(1, 8)], ids=["1x8"], indirect=True)
+def test_sampling1d_topk_masks_qwen3_32b_padded_tail(ttnn_mesh_device):
+    B = 32
+    valid_vocab_size = 151936
+    padded_vocab_size = 152064
+    sampler = Sampling1D(vocab_size=padded_vocab_size, valid_vocab_size=valid_vocab_size, mesh_device=ttnn_mesh_device)
+
+    logits_host = torch.full((1, 1, B, padded_vocab_size), -1.0, dtype=torch.bfloat16)
+    logits_host[..., valid_vocab_size:] = 0.0
+    logits_tt = _make_logits_tt(logits_host, ttnn_mesh_device, shard_vocab=True)
+
+    cluster_shape = tuple(ttnn_mesh_device.shape)
+    k, p, temp = _make_sampling_params(
+        ttnn_mesh_device, B, k_val=1, p_val=0.0, temp_val=1.0, cluster_shape=cluster_shape
+    )
+    tokens_tt, _ = sampler.decode_forward(logits_tt, k=k, p=p, temp=temp)
+    tokens_host = to_torch_auto_compose(tokens_tt).flatten()[:B].long()
+
+    assert torch.all(tokens_host < valid_vocab_size)
+
+
+@pytest.mark.parametrize("ttnn_mesh_device", [(1, 8)], ids=["1x8"], indirect=True)
+def test_sampling1d_padded_tail_with_sub_core_grids_runs(ttnn_mesh_device):
+    B = 32
+    valid_vocab_size = 151936
+    padded_vocab_size = 152064
+    sub_core_grids = _sub_core_grids_for_32_users()
+    sampler = Sampling1D(
+        vocab_size=padded_vocab_size,
+        valid_vocab_size=valid_vocab_size,
+        mesh_device=ttnn_mesh_device,
+        sub_core_grids=sub_core_grids,
+        sub_core_grid_topk=sub_core_grids,
+        start_core=ttnn.CoreCoord(0, 0),
+    )
+    sampler.load_device_buffers()
+
+    logits_host = torch.full((1, 1, B, padded_vocab_size), -1.0, dtype=torch.bfloat16)
+    logits_host[..., valid_vocab_size:] = 0.0
+    logits_tt = _make_logits_tt(logits_host, ttnn_mesh_device, shard_vocab=True)
+
+    cluster_shape = tuple(ttnn_mesh_device.shape)
+    k, p, temp = _make_sampling_params(
+        ttnn_mesh_device, B, k_val=1, p_val=0.0, temp_val=1.0, cluster_shape=cluster_shape
+    )
+
+    worker_sub_device_id = ttnn.SubDeviceId(0)
+    worker_sub_device = ttnn.SubDevice([sub_core_grids])
+    sub_device_manager = ttnn_mesh_device.create_sub_device_manager([worker_sub_device], 0)
+    stall_group_set = False
+    manager_loaded = False
+    try:
+        ttnn_mesh_device.load_sub_device_manager(sub_device_manager)
+        manager_loaded = True
+        ttnn_mesh_device.set_sub_device_stall_group([worker_sub_device_id])
+        stall_group_set = True
+
+        tokens_tt, _ = sampler.decode_forward(logits_tt, k=k, p=p, temp=temp)
+        tokens_host = to_torch_auto_compose(tokens_tt).flatten()[:B].long()
+
+        assert torch.all(tokens_host < valid_vocab_size)
+    finally:
+        if stall_group_set:
+            ttnn_mesh_device.reset_sub_device_stall_group()
+        if manager_loaded:
+            ttnn_mesh_device.clear_loaded_sub_device_manager()
+        ttnn_mesh_device.remove_sub_device_manager(sub_device_manager)
+
+
+@pytest.mark.parametrize("ttnn_mesh_device", [(1, 8)], ids=["1x8"], indirect=True)
+def test_sampling1d_argmax_slices_qwen3_32b_padded_tail(ttnn_mesh_device):
+    B = 32
+    valid_vocab_size = 151936
+    padded_vocab_size = 152064
+    sampler = Sampling1D(
+        vocab_size=padded_vocab_size,
+        valid_vocab_size=valid_vocab_size,
+        mesh_device=ttnn_mesh_device,
+        allow_force_argmax=True,
+    )
+
+    logits_host = torch.full((1, 1, B, padded_vocab_size), -1.0, dtype=torch.bfloat16)
+    logits_host[..., valid_vocab_size:] = 0.0
+    logits_tt = _make_logits_tt(logits_host, ttnn_mesh_device, shard_vocab=True)
+
+    tokens_tt, _ = sampler.decode_forward(logits_tt)
+    tokens_host = to_torch_auto_compose(tokens_tt).flatten()[:B].long()
+
+    assert torch.all(tokens_host < valid_vocab_size)
+
+
+@pytest.mark.parametrize("ttnn_mesh_device", [(1, 1), (1, 2), (1, 8)], ids=["1x1", "1x2", "1x8"], indirect=True)
+def test_sampling1d_topk32_in_range(ttnn_mesh_device):
+    """
+    Top-k=32, p=1.0 → sampled token must be within the top-32 set for every batch element.
+
+    This is a statistical correctness test: we don't know which token will be sampled
+    (it's stochastic), but it MUST be one of the top-32 tokens by logit value.
+    """
+    torch.manual_seed(77)
+    B = 32
+    vocab_size = 1024
+
+    sampler = Sampling1D(vocab_size=vocab_size, mesh_device=ttnn_mesh_device)
+
+    logits_host = torch.randn(1, 1, B, vocab_size, dtype=torch.bfloat16)
+    logits_tt = _make_logits_tt(logits_host, ttnn_mesh_device, shard_vocab=True)
+
+    cluster_shape = tuple(ttnn_mesh_device.shape)
+    k, p, temp = _make_sampling_params(
+        ttnn_mesh_device, B, k_val=32, p_val=1.0, temp_val=1.0, cluster_shape=cluster_shape
+    )
+
+    tokens_tt, _ = sampler.decode_forward(logits_tt, k=k, p=p, temp=temp)
+    tokens_host = to_torch_auto_compose(tokens_tt).flatten()[:B]
+
+    # Compute the top-32 token set per batch element
+    _, top32_indices = logits_host.float().squeeze().topk(32, dim=-1)  # [B, 32]
+
+    for b in range(B):
+        sampled_token = tokens_host[b].item()
+        top32_set = set(top32_indices[b].tolist())
+        assert sampled_token in top32_set, f"Batch {b}: sampled token {sampled_token} not in top-32 set"
+
+
+def _hf_valid_token_set(logits_row: "torch.Tensor", k: int, p: float, temp: float) -> set:
+    """Compute the set of tokens eligible under top-k / top-p / temperature filtering.
+
+    Mirrors the pipeline inside ttnn.sampling:
+      1. Temperature: divide logits by temp  (skipped if temp == 1.0)
+      2. Top-k:       zero out all but top-k tokens
+      3. Top-p:       zero out tokens outside the cumulative-probability nucleus
+
+    Uses HuggingFace's LogitsWarper classes so this reference is auditable against
+    the transformers library rather than a hand-rolled implementation.
+
+    Returns the set of token ids that have finite logit after filtering — any
+    sampled token MUST come from this set.
+    """
+    from transformers.generation.logits_process import TemperatureLogitsWarper, TopKLogitsWarper, TopPLogitsWarper
+
+    # Warpers expect input_ids (unused here, pass None) and a [1, V] float32 scores tensor.
+    scores = logits_row.float().unsqueeze(0)  # [1, V]
+    if temp != 1.0:
+        scores = TemperatureLogitsWarper(temperature=temp)(None, scores)
+    if k > 0:
+        scores = TopKLogitsWarper(top_k=k)(None, scores)
+    if 0.0 < p < 1.0:
+        scores = TopPLogitsWarper(top_p=p)(None, scores)
+    # Tokens with -inf logit are filtered out; all others are valid candidates.
+    return set(scores[0].isfinite().nonzero(as_tuple=False).squeeze(-1).tolist())
+
+
+@pytest.mark.parametrize("ttnn_mesh_device", [(1, 1), (1, 2), (1, 8)], ids=["1x1", "1x2", "1x8"], indirect=True)
+@pytest.mark.parametrize(
+    "k, p, temp, max_boundary_violations",
+    [
+        # p=0.0 or p=1.0 → no nucleus boundary; token MUST be in top-k, zero tolerance.
+        pytest.param(1, 0.0, 1.0, 0, id="k1-p0-t1"),  # degenerates to argmax
+        pytest.param(8, 1.0, 1.0, 0, id="k8-p1-t1"),  # pure top-k, no nucleus cut
+        # p ∈ (0, 1) → nucleus boundary may differ between bf16 (device) and f32 (HF ref).
+        # ttnn.sampling computes softmax+cumsum in bf16; at the p-threshold, a token can
+        # fall inside or outside depending on precision. max_boundary_violations is the
+        # empirically-calibrated headroom for these boundary disagreements. A regression
+        # (violations >> max) indicates a correctness issue beyond precision noise.
+        pytest.param(32, 0.5, 1.0, 3, id="k32-p0.5-t1"),  # tight nucleus, neutral temp
+        pytest.param(32, 0.9, 2.0, 2, id="k32-p0.9-t2"),  # loose nucleus, flat dist
+        pytest.param(32, 0.9, 0.5, 6, id="k32-p0.9-t0.5"),  # loose nucleus, peaked dist
+    ],
+)
+def test_sampling1d_token_in_valid_set(ttnn_mesh_device, k, p, temp, max_boundary_violations):
+    """Sampled token must lie within the HF-derived valid candidate set (up to bf16 boundary).
+
+    For each (k, p, temp), the HuggingFace pipeline
+        TemperatureLogitsWarper → TopKLogitsWarper → TopPLogitsWarper
+    defines which tokens are eligible. Any sampled token MUST come from this set.
+
+    Precision note: ttnn.sampling runs its softmax/cumsum in bfloat16, while the HF
+    reference uses float32. Tokens near the nucleus cutoff may fall on different sides
+    of the cumulative-probability threshold. max_boundary_violations allows for this;
+    it is zero when p ∈ {0.0, 1.0} (no nucleus threshold exists) and small-but-nonzero
+    otherwise. Violations significantly above max indicate a real correctness regression.
+    """
+    torch.manual_seed(42)
+    B = 32
+    vocab_size = 1024
+
+    sampler = Sampling1D(vocab_size=vocab_size, mesh_device=ttnn_mesh_device)
+
+    logits_host = torch.randn(1, 1, B, vocab_size, dtype=torch.bfloat16)
+    logits_tt = _make_logits_tt(logits_host, ttnn_mesh_device, shard_vocab=True)
+
+    cluster_shape = tuple(ttnn_mesh_device.shape)
+    k_tt, p_tt, temp_tt = _make_sampling_params(
+        ttnn_mesh_device, B, k_val=k, p_val=p, temp_val=temp, cluster_shape=cluster_shape
+    )
+
+    tokens_tt, _ = sampler.decode_forward(logits_tt, k=k_tt, p=p_tt, temp=temp_tt)
+    tokens_host = to_torch_auto_compose(tokens_tt).flatten()[:B]
+
+    # Build per-batch-element valid sets from bf16 logits (same precision as device input)
+    logits_2d = logits_host.squeeze().bfloat16()  # [B, V]
+    violations = []
+    for b in range(B):
+        valid = _hf_valid_token_set(logits_2d[b], k=k, p=p, temp=temp)
+        token = tokens_host[b].item()
+        if token not in valid:
+            violations.append((b, token, len(valid)))
+
+    assert len(violations) <= max_boundary_violations, (
+        f"k={k} p={p} temp={temp}: {len(violations)}/{B} tokens outside valid set "
+        f"(max allowed={max_boundary_violations} for bf16 boundary):\n"
+        + "\n".join(f"  batch {b}: token {tok} not in {n}-token valid set" for b, tok, n in violations[:5])
+    )
+
+
+@pytest.mark.parametrize("ttnn_mesh_device", [(1, 1), (1, 2), (1, 8)], ids=["1x1", "1x2", "1x8"], indirect=True)
+def test_sampling1d_deterministic_with_same_seed(ttnn_mesh_device):
+    """
+    Two decode_forward calls with the same seed tensor should produce the same tokens.
+    """
+    torch.manual_seed(42)
+    B = 32
+    vocab_size = 1024
+
+    sampler = Sampling1D(vocab_size=vocab_size, mesh_device=ttnn_mesh_device)
+
+    logits_host = torch.randn(1, 1, B, vocab_size, dtype=torch.bfloat16)
+    cluster_shape = tuple(ttnn_mesh_device.shape)
+    k, p, temp = _make_sampling_params(
+        ttnn_mesh_device, B, k_val=32, p_val=0.9, temp_val=0.8, cluster_shape=cluster_shape
+    )
+
+    # Use explicit seed tensor
+    seed_tensor = ttnn.from_torch(
+        torch.arange(B, dtype=torch.int64).to(torch.int32),
+        device=ttnn_mesh_device,
+        dtype=ttnn.uint32,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    # First call
+    logits_tt1 = _make_logits_tt(logits_host, ttnn_mesh_device, shard_vocab=True)
+    tokens1, _ = sampler.decode_forward(logits_tt1, k=k, p=p, temp=temp, seeds=seed_tensor)
+    tokens1_host = to_torch_auto_compose(tokens1).flatten()[:B]
+
+    # Second call with same seed
+    logits_tt2 = _make_logits_tt(logits_host, ttnn_mesh_device, shard_vocab=True)
+    tokens2, _ = sampler.decode_forward(logits_tt2, k=k, p=p, temp=temp, seeds=seed_tensor)
+    tokens2_host = to_torch_auto_compose(tokens2).flatten()[:B]
+
+    assert torch.equal(
+        tokens1_host, tokens2_host
+    ), f"Same seed produced different tokens:\n  call1: {tokens1_host[:8]}\n  call2: {tokens2_host[:8]}"
+
+
+# ==============================================================================
+# Isolation tests — ttnn.topk + ttnn.all_gather without Sampling1D
+# ==============================================================================
+
+
+@pytest.mark.parametrize("ttnn_mesh_device", [(1, 2), (1, 8)], ids=["1x2", "1x8"], indirect=True)
+@pytest.mark.parametrize(
+    "vocab_size",
+    [
+        pytest.param(1024, id="v1024"),
+        pytest.param(32000, id="v32000"),
+    ],
+)
+def test_topk_allgather_isolation(ttnn_mesh_device, vocab_size):
+    """
+    Minimal reproducer: ttnn.topk + ttnn.all_gather on multi-device, bypassing Sampling1D.
+
+    Runs the raw op pipeline that Sampling1D._topk_multi_device performs:
+      1. Shard logits across devices along the vocab dim
+      2. ttnn.topk per device (local top-K)
+      3. ttnn.all_gather values and indices across devices
+      4. Add index offsets for global vocab indices
+      5. Pick global top-1 from gathered results
+
+    Compare against a bfloat16-sharded torch reference. This isolates whether
+    mismatches come from topk+all_gather or from downstream ops (sampling, typecast, etc.).
+    """
+    torch.manual_seed(42)
+    B = 32
+    K = 32  # max_top_k, matches Sampling1D default
+
+    cluster_shape = tuple(ttnn_mesh_device.shape)
+    num_devices = max(cluster_shape)
+    per_device_vocab = vocab_size // num_devices
+
+    # -- 1. Shard logits across devices (same as _make_logits_tt with shard_vocab=True) --
+    logits_host = torch.randn(1, 1, B, vocab_size, dtype=torch.bfloat16)
+
+    shard_dims = (None, -1) if cluster_shape[-1] >= cluster_shape[-2] else (-1, None)
+    logits_tt = ttnn.from_torch(
+        logits_host,
+        device=ttnn_mesh_device,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        mesh_mapper=ttnn.ShardTensor2dMesh(ttnn_mesh_device, dims=shard_dims, mesh_shape=cluster_shape),
+    )
+
+    # -- 2. Build local_indices buffer replicated on all devices --
+    replicate_mapper = ttnn.ShardTensor2dMesh(ttnn_mesh_device, dims=(None, None), mesh_shape=cluster_shape)
+    local_indices_host = torch.zeros(1, 1, B, per_device_vocab, dtype=torch.int32)
+    for i in range(per_device_vocab):
+        local_indices_host[:, :, :, i] = i
+
+    local_indices_tt = ttnn.from_torch(
+        local_indices_host,
+        device=ttnn_mesh_device,
+        dtype=ttnn.uint16,
+        layout=ttnn.TILE_LAYOUT,
+        mesh_mapper=replicate_mapper,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    # -- 3. ttnn.topk per device --
+    topk_values, topk_indices = ttnn.topk(
+        logits_tt,
+        k=K,
+        dim=-1,
+        indices_tensor=local_indices_tt,
+    )
+
+    # -- 4. all_gather values and indices along the vocab dim --
+    sampling_cluster_axis = None if 1 in cluster_shape else 0
+
+    gathered_values = ttnn.all_gather(
+        topk_values,
+        dim=3,
+        num_links=1,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        cluster_axis=sampling_cluster_axis,
+        topology=ttnn.Topology.Linear,
+    )
+    ttnn.deallocate(topk_values)
+
+    gathered_indices = ttnn.all_gather(
+        topk_indices,
+        dim=3,
+        num_links=1,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        cluster_axis=sampling_cluster_axis,
+        topology=ttnn.Topology.Linear,
+    )
+    ttnn.deallocate(topk_indices)
+
+    # -- 5. Add per-device offsets to convert local → global vocab indices --
+    offsets_host = torch.zeros(1, 1, B, K * num_devices, dtype=torch.int64)
+    for d in range(num_devices):
+        offsets_host[:, :, :, d * K : (d + 1) * K] = d * per_device_vocab
+
+    index_offsets_tt = ttnn.from_torch(
+        offsets_host,
+        device=ttnn_mesh_device,
+        dtype=ttnn.int32,
+        layout=ttnn.TILE_LAYOUT,
+        mesh_mapper=replicate_mapper,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    gathered_indices_int32 = ttnn.typecast(gathered_indices, dtype=ttnn.int32)
+    global_indices = ttnn.add(index_offsets_tt, gathered_indices_int32, dtype=ttnn.int32)
+
+    # -- 6. Read back to host --
+    values_host = to_torch_auto_compose(gathered_values).squeeze()[:B]  # [B, K*num_devices]
+    indices_host = to_torch_auto_compose(global_indices).squeeze()[:B]  # [B, K*num_devices]
+
+    # -- 7. Pick global top-1: find max value position then look up its global index --
+    top1_pos = values_host.float().argmax(dim=-1)
+    device_top1 = torch.tensor([indices_host[b, top1_pos[b]].item() for b in range(B)], dtype=torch.long)
+
+    # -- 8. Bfloat16-sharded torch reference (same method as test_sampling1d_topk1_vs_argmax) --
+    logits_bf16 = logits_host.squeeze().bfloat16()  # [B, V]
+    bf16_expected = torch.zeros(B, dtype=torch.long)
+    for b in range(B):
+        best_val = float("-inf")
+        best_idx = 0
+        for s in range(num_devices):
+            shard = logits_bf16[b, s * per_device_vocab : (s + 1) * per_device_vocab]
+            local_idx = shard.float().argmax().item()
+            local_val = shard[local_idx].float().item()
+            if local_val > best_val:
+                best_val = local_val
+                best_idx = s * per_device_vocab + local_idx
+        bf16_expected[b] = best_idx
+
+    # -- 9. Report and assert (tie-break-aware) --
+    _assert_no_true_mismatches(
+        device_top1,
+        bf16_expected,
+        logits_bf16,
+        test_label=f"topk+all_gather isolation (V={vocab_size}, mesh={cluster_shape})",
+    )
+
+
+@pytest.mark.parametrize("ttnn_mesh_device", [(1, 2), (1, 8)], ids=["1x2", "1x8"], indirect=True)
+@pytest.mark.parametrize(
+    "vocab_size",
+    [
+        pytest.param(1024, id="v1024"),
+        pytest.param(32000, id="v32000"),
+    ],
+)
+def test_ttnn_sampling_isolation(ttnn_mesh_device, vocab_size):
+    """
+    Hypothesis 2: does ttnn.sampling introduce mismatches at k=1, p=0.0, temp=1.0?
+
+    Builds correct gathered_values + global_indices via the topk+all_gather pipeline
+    (confirmed 0 mismatches in test_topk_allgather_isolation), then runs the remaining
+    steps from Sampling1D._sample_topk verbatim:
+      - ttnn.typecast (uint16 → int32)
+      - ttnn.add (index offsets)
+      - ttnn.untilize (TILE → ROW_MAJOR, required by ttnn.sampling)
+      - ttnn.manual_seed + ttnn.sampling(k=1, p=0.0, temp=1.0)
+
+    Compares against the bfloat16-sharded torch argmax reference.
+    Any mismatches here can be attributed to ttnn.sampling itself.
+
+    Observed results (seed=42, B=32):
+      v1024-1x2:  1/32 mismatches  ← ttnn.sampling
+      v1024-1x8:  1/32 mismatches  ← same batch as 1x2, topology-independent
+      v32000-1x2: 4/32 mismatches  ← ttnn.sampling
+      v32000-1x8: 7/32 mismatches  ← 4 shared with 1x2 + 3 additional
+
+    The growing mismatch count with more devices (1x2→1x8) is not caused by
+    all_gather (test_topk_allgather_isolation confirms 0/32 there). The extra
+    mismatches at 1x8 come from ttnn.sampling seeing a wider candidate buffer
+    (K*8=256 entries vs K*2=64), causing its internal softmax reduction to
+    diverge from argmax on more batches.
+    """
+    torch.manual_seed(42)
+    B = 32
+    K = 32  # max_top_k
+
+    cluster_shape = tuple(ttnn_mesh_device.shape)
+    num_devices = max(cluster_shape)
+    per_device_vocab = vocab_size // num_devices
+    replicate_mapper = ttnn.ShardTensor2dMesh(ttnn_mesh_device, dims=(None, None), mesh_shape=cluster_shape)
+
+    # ---- Step A: topk + all_gather (confirmed correct, 0 mismatches) --------
+
+    logits_host = torch.randn(1, 1, B, vocab_size, dtype=torch.bfloat16)
+
+    shard_dims = (None, -1) if cluster_shape[-1] >= cluster_shape[-2] else (-1, None)
+    logits_tt = ttnn.from_torch(
+        logits_host,
+        device=ttnn_mesh_device,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        mesh_mapper=ttnn.ShardTensor2dMesh(ttnn_mesh_device, dims=shard_dims, mesh_shape=cluster_shape),
+    )
+
+    local_indices_host = torch.zeros(1, 1, B, per_device_vocab, dtype=torch.int32)
+    for i in range(per_device_vocab):
+        local_indices_host[:, :, :, i] = i
+    local_indices_tt = ttnn.from_torch(
+        local_indices_host,
+        device=ttnn_mesh_device,
+        dtype=ttnn.uint16,
+        layout=ttnn.TILE_LAYOUT,
+        mesh_mapper=replicate_mapper,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    topk_values, topk_indices = ttnn.topk(logits_tt, k=K, dim=-1, indices_tensor=local_indices_tt)
+
+    sampling_cluster_axis = None if 1 in cluster_shape else 0
+    gathered_values = ttnn.all_gather(
+        topk_values,
+        dim=3,
+        num_links=1,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        cluster_axis=sampling_cluster_axis,
+        topology=ttnn.Topology.Linear,
+    )
+    ttnn.deallocate(topk_values)
+    gathered_indices = ttnn.all_gather(
+        topk_indices,
+        dim=3,
+        num_links=1,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        cluster_axis=sampling_cluster_axis,
+        topology=ttnn.Topology.Linear,
+    )
+    ttnn.deallocate(topk_indices)
+
+    # ---- Step B: index offset addition (same as _sample_topk lines 233-253) -
+
+    gathered_indices_int32 = ttnn.typecast(gathered_indices, dtype=ttnn.int32)
+
+    offsets_host = torch.zeros(1, 1, B, K * num_devices, dtype=torch.int64)
+    for d in range(num_devices):
+        offsets_host[:, :, :, d * K : (d + 1) * K] = d * per_device_vocab
+    index_offsets_tt = ttnn.from_torch(
+        offsets_host,
+        device=ttnn_mesh_device,
+        dtype=ttnn.int32,
+        layout=ttnn.TILE_LAYOUT,
+        mesh_mapper=replicate_mapper,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    global_indices_tiled = ttnn.add(
+        index_offsets_tt, gathered_indices_int32, dtype=ttnn.int32, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+    ttnn.deallocate(gathered_indices_int32)
+
+    global_indices_rm = ttnn.untilize(global_indices_tiled, use_multicore=True)
+    ttnn.deallocate(global_indices_tiled)
+
+    # ---- Step C: seed + ttnn.sampling(k=1, p=0.0, temp=1.0) -----------------
+
+    seeds_host = torch.arange(B, dtype=torch.int32)
+    seeds_tt = ttnn.from_torch(
+        seeds_host,
+        device=ttnn_mesh_device,
+        dtype=ttnn.uint32,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        mesh_mapper=replicate_mapper,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    user_ids_tt = ttnn.from_torch(
+        seeds_host,
+        device=ttnn_mesh_device,
+        dtype=ttnn.uint32,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        mesh_mapper=replicate_mapper,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    ttnn.manual_seed(seeds=seeds_tt, user_ids=user_ids_tt)
+
+    k_tt = ttnn.from_torch(
+        torch.ones(B, dtype=torch.int32),
+        device=ttnn_mesh_device,
+        dtype=ttnn.uint32,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        mesh_mapper=replicate_mapper,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    p_tt = ttnn.from_torch(
+        torch.zeros(B, dtype=torch.float32),
+        device=ttnn_mesh_device,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        mesh_mapper=replicate_mapper,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    temp_tt = ttnn.from_torch(
+        torch.ones(B, dtype=torch.float32),
+        device=ttnn_mesh_device,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        mesh_mapper=replicate_mapper,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    sampled_tokens = ttnn.sampling(gathered_values, global_indices_rm, k=k_tt, p=p_tt, temp=temp_tt)
+
+    ttnn.deallocate(gathered_values)
+    ttnn.deallocate(global_indices_rm)
+
+    # ---- Step D: compare against bfloat16-sharded torch reference -----------
+
+    tokens_host = to_torch_auto_compose(sampled_tokens).flatten()[:B]
+
+    # Bfloat16-sharded reference (same as other tests in this file)
+    logits_bf16 = logits_host.squeeze().bfloat16()
+    bf16_expected = torch.zeros(B, dtype=torch.long)
+    for b in range(B):
+        best_val, best_idx = float("-inf"), 0
+        for s in range(num_devices):
+            shard = logits_bf16[b, s * per_device_vocab : (s + 1) * per_device_vocab]
+            local_idx = shard.float().argmax().item()
+            local_val = shard[local_idx].float().item()
+            if local_val > best_val:
+                best_val, best_idx = local_val, s * per_device_vocab + local_idx
+        bf16_expected[b] = best_idx
+
+    _assert_no_true_mismatches(
+        tokens_host.long(),
+        bf16_expected,
+        logits_bf16,
+        test_label=f"ttnn.sampling isolation (V={vocab_size}, mesh={cluster_shape})",
+    )
+
+
+# ==============================================================================
+# Minimal reproducer: ttnn.topk correctness at various input widths
+# ==============================================================================
+
+
+@pytest.mark.parametrize("ttnn_mesh_device", [(1, 1)], ids=["1x1"], indirect=True)
+@pytest.mark.parametrize(
+    "input_width",
+    [
+        pytest.param(512, id="w512"),
+        pytest.param(1024, id="w1024"),
+        pytest.param(2048, id="w2048"),
+        pytest.param(4096, id="w4096"),
+        pytest.param(8192, id="w8192"),
+        pytest.param(16384, id="w16384"),
+        pytest.param(32768, id="w32768"),
+    ],
+)
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        pytest.param(ttnn.bfloat16, id="bf16"),
+        pytest.param(ttnn.bfloat8_b, id="bf8b"),
+    ],
+)
+def test_ttnn_topk_correctness(ttnn_mesh_device, input_width, dtype):
+    """
+    Minimal reproducer for ttnn.topk index disagreements at various input widths and dtypes.
+
+    Isolates ttnn.topk on a SINGLE device with NO Sampling1D, NO all_gather,
+    NO ttnn.sampling — just the raw topk op. We compare:
+      1. Top-1 (argmax): device top-1 index vs torch.topk top-1
+      2. Top-K set: whether the device's top-32 index SET matches torch's top-32 set
+      3. Top-K values: whether the returned values match the expected values
+
+    Note: ttnn.topk only supports BFLOAT16 and BFLOAT8_B inputs (enforced by the kernel
+    at topk_device_operation.cpp:146). Float32 is not a valid input dtype.
+
+    Observed results (seed=42, B=32, K=32, single device 1x1):
+
+    bfloat16 (~128 distinct values in the typical randn range):
+        Width   Top-1 mismatches   Top-K set mismatches   Top-1 value mismatches
+        -----   ----------------   --------------------   ----------------------
+          512          0/32                3/32                    0/32
+         1024          1/32                3/32                    0/32
+         2048          1/32               14/32                    0/32
+         4096          3/32                7/32                    0/32
+         8192          6/32               12/32                    0/32
+        16384          8/32               13/32                    0/32
+        32768         17/32               14/32                    0/32
+
+        All top-1 mismatches are TIE-BREAKS (delta=0.0000). Zero true mismatches.
+
+    bfloat8_b (even fewer distinct values → more ties expected):
+        Serves as a confirmation of the tie-breaking hypothesis: with coarser
+        quantization, ties are more frequent, so index disagreements should
+        increase compared to bfloat16 at the same width.
+
+    Key findings:
+      - NOT a comparison bug. Every top-1 mismatch has delta=0.0000: the device picks a
+        different index that has the SAME value as the reference's top-1.
+      - Values are always correct (0/32 value mismatches at every width). ttnn.topk finds
+        the right maximum value; it just returns a different index among tied elements.
+      - Root cause: low-precision tie-breaking non-determinism. With few distinct
+        representable values, ties become very common as width grows, explaining
+        why mismatches scale with width.
+      - Implication: the "10/32 mismatches" in Sampling1D with vocab=32768 are NOT a
+        ttnn.topk kernel bug — they are precision tie-breaks. Any element with the max
+        value is a valid argmax. Tests should only assert on true mismatches (device
+        picked a genuinely lower value), not on tie-breaks.
+    """
+    # Both supported dtypes use bfloat16 as the host torch dtype; bfloat8_b is a
+    # device-side block-float format that ttnn converts from bfloat16 on the host.
+    torch_dtype = torch.bfloat16
+    dtype_tag = "bf16" if dtype == ttnn.bfloat16 else "bf8b"
+
+    torch.manual_seed(42)
+    B = 32
+    K = 32
+
+    # -- 1. Create input tensor [1, 1, B, W] in the target dtype --
+    input_host = torch.randn(1, 1, B, input_width, dtype=torch_dtype)
+
+    input_tt = ttnn.from_torch(
+        input_host,
+        device=ttnn_mesh_device,
+        dtype=dtype,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    # -- 2. Create local_indices [1, 1, B, W] with 0-based range --
+    #    This matches the production code: indices_tensor[..., i] = i
+    local_indices_host = torch.zeros(1, 1, B, input_width, dtype=torch.int32)
+    for i in range(input_width):
+        local_indices_host[:, :, :, i] = i
+
+    local_indices_tt = ttnn.from_torch(
+        local_indices_host,
+        device=ttnn_mesh_device,
+        dtype=ttnn.uint16,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    # -- 3. Run ttnn.topk --
+    topk_values_tt, topk_indices_tt = ttnn.topk(input_tt, k=K, dim=-1, indices_tensor=local_indices_tt)
+
+    # -- 4. Read back to host --
+    values_host = to_torch_auto_compose(topk_values_tt).squeeze()[:B]  # [B, K]
+    indices_host = to_torch_auto_compose(topk_indices_tt).squeeze()[:B]  # [B, K]
+
+    ttnn.deallocate(topk_values_tt)
+    ttnn.deallocate(topk_indices_tt)
+    ttnn.deallocate(input_tt)
+    ttnn.deallocate(local_indices_tt)
+
+    # -- 5. Torch reference on the SAME input (compare in native precision) --
+    input_2d = input_host.squeeze()  # [B, W]
+    ref_values, ref_indices = torch.topk(input_2d.float(), k=K, dim=-1)
+    ref_values = ref_values.to(torch_dtype)  # compare in the same dtype
+
+    # -- 6a. Check top-1 (argmax) correctness --
+    device_top1 = indices_host[:, 0].long()  # first column = top-1 index
+    ref_top1 = ref_indices[:, 0].long()
+    top1_mismatches = (device_top1 != ref_top1).sum().item()
+
+    # -- 6b. Check top-K set correctness (order doesn't matter) --
+    set_mismatches = 0
+    missing_details = []
+    for b in range(B):
+        device_set = set(indices_host[b].long().tolist())
+        ref_set = set(ref_indices[b].tolist())
+        missing_from_device = ref_set - device_set
+        if missing_from_device:
+            set_mismatches += 1
+            if len(missing_details) < 5:
+                extra_in_device = device_set - ref_set
+                missing_details.append(
+                    f"  batch {b}: missing {len(missing_from_device)} ref indices, "
+                    f"has {len(extra_in_device)} wrong indices\n"
+                    f"    missing (first 5): {sorted(missing_from_device)[:5]}\n"
+                    f"    extra   (first 5): {sorted(extra_in_device)[:5]}"
+                )
+
+    # -- 6c. Check top-1 value correctness (did it at least get the max value right?) --
+    device_top1_vals = values_host[:, 0].float()
+    ref_top1_vals = ref_values[:, 0].float()
+    val_mismatches = (device_top1_vals != ref_top1_vals).sum().item()
+
+    # -- 6d. Tie-break-aware assertion on top-1 indices --
+    #    bfloat8_b uses block-float quantization (shared exponent per block of 32 elements).
+    #    Elements within a block can lose up to 2 ULPs (~0.03125 at typical magnitudes)
+    #    relative to the bfloat16 host view.
+    quant_tolerance = 0.032 if dtype == ttnn.bfloat8_b else 0.0
+
+    # Print additional top-K diagnostics before the shared assertion prints its report
+    print(f"\n  top-1 index mismatches: {top1_mismatches}/{B}")
+    print(f"  top-K set mismatches:   {set_mismatches}/{B}")
+    print(f"  top-1 value mismatches: {val_mismatches}/{B}")
+
+    _assert_no_true_mismatches(
+        device_top1,
+        ref_top1,
+        input_2d,
+        test_label=f"ttnn.topk isolation (width={input_width}, dtype={dtype_tag}, B={B}, K={K})",
+        quant_tolerance=quant_tolerance,
+    )
+
+
+# ==============================================================================
+# Logprobs plumbing (enable_log_probs per-call arg)
+# ==============================================================================
+
+
+@pytest.mark.parametrize("ttnn_mesh_device", [(1, 1), (1, 2), (1, 8)], ids=["1x1", "1x2", "1x8"], indirect=True)
+def test_sampling1d_logprobs_disabled_returns_none(ttnn_mesh_device):
+    """Default (enable_log_probs=False) → log_probs is None on every mesh, both paths."""
+    torch.manual_seed(42)
+    B = 32
+    vocab_size = 1024
+
+    sampler = Sampling1D(vocab_size=vocab_size, mesh_device=ttnn_mesh_device, allow_force_argmax=True)
+    logits_host = torch.randn(1, 1, B, vocab_size, dtype=torch.bfloat16)
+    cluster_shape = tuple(ttnn_mesh_device.shape)
+
+    # Top-k path
+    logits_tt = _make_logits_tt(logits_host, ttnn_mesh_device, shard_vocab=True)
+    k, p, temp = _make_sampling_params(
+        ttnn_mesh_device, B, k_val=1, p_val=0.0, temp_val=1.0, cluster_shape=cluster_shape
+    )
+    _, log_probs = sampler.decode_forward(logits_tt, k=k, p=p, temp=temp)
+    assert log_probs is None, "top-k path must return None when enable_log_probs=False"
+
+    # Argmax path
+    logits_tt2 = _make_logits_tt(logits_host, ttnn_mesh_device)
+    _, log_probs_argmax = sampler.decode_forward(logits_tt2)
+    assert log_probs_argmax is None, "argmax path must return None when enable_log_probs=False"
+
+
+@pytest.mark.parametrize("ttnn_mesh_device", [(1, 1), (1, 2), (1, 8)], ids=["1x1", "1x2", "1x8"], indirect=True)
+def test_sampling1d_argmax_never_emits_logprobs(ttnn_mesh_device):
+    """Argmax contract (P0): argmax path returns None even when enable_log_probs=True."""
+    torch.manual_seed(42)
+    B = 32
+    vocab_size = 1024
+
+    sampler = Sampling1D(vocab_size=vocab_size, mesh_device=ttnn_mesh_device, allow_force_argmax=True)
+    logits_host = torch.randn(1, 1, B, vocab_size, dtype=torch.bfloat16)
+    logits_tt = _make_logits_tt(logits_host, ttnn_mesh_device)
+
+    _, log_probs = sampler.decode_forward(logits_tt, enable_log_probs=True)
+    assert log_probs is None, "argmax path must never compute logprobs (force-argmax ⇒ no logprobs)"
+
+
+@pytest.mark.parametrize("ttnn_mesh_device", [(1, 1), (1, 2), (1, 8)], ids=["1x1", "1x2", "1x8"], indirect=True)
+def test_sampling1d_logprobs_topk(ttnn_mesh_device):
+    """enable_log_probs=True on the top-k path.
+
+    The old single-token logprob path only computes on multi-device shards with
+    num_devices ∈ {8, 32} (T3K 1×8). On 1×1/1×2 the calculator returns None even when enabled.
+    On 1×8, with k=1/p=0/temp=1 the sampled token is the argmax, so its logprob must match
+    torch.log_softmax(logits)[argmax].
+    """
+    from models.experimental.llama32_1b_quasar.utility_functions import comp_pcc
+
+    torch.manual_seed(42)
+    B = 32
+    vocab_size = 32768  # divisible by 8
+
+    sampler = Sampling1D(vocab_size=vocab_size, mesh_device=ttnn_mesh_device)
+    logits_host = torch.randn(1, 1, B, vocab_size, dtype=torch.bfloat16)
+    logits_tt = _make_logits_tt(logits_host, ttnn_mesh_device, shard_vocab=True)
+
+    cluster_shape = tuple(ttnn_mesh_device.shape)
+    k, p, temp = _make_sampling_params(
+        ttnn_mesh_device, B, k_val=1, p_val=0.0, temp_val=1.0, cluster_shape=cluster_shape
+    )
+
+    tokens_tt, log_probs = sampler.decode_forward(logits_tt, k=k, p=p, temp=temp, enable_log_probs=True)
+
+    num_devices = max(cluster_shape)
+    if num_devices not in (8, 32):
+        assert log_probs is None, f"logprobs unsupported on {num_devices} devices → expected None"
+        return
+
+    assert log_probs is not None, "logprobs must be computed on a 1×8 mesh when enabled"
+
+    # output_tensor shape (1,1,1,B), replicated across devices — match test_sampling.py read path
+    mesh_composer = ttnn.ConcatMeshToTensor(ttnn_mesh_device, dim=3)
+    lp_host = ttnn.to_torch(log_probs, mesh_composer=mesh_composer)[:, :, 0, :B].reshape(-1).float()
+    tokens_host = to_torch_auto_compose(tokens_tt).flatten()[:B].long()
+
+    # Reference: log_softmax over the full vocab (fp32), indexed at the sampled token.
+    ref_log_softmax = torch.log_softmax(logits_host.float().squeeze(), dim=-1)  # [B, V]
+    ref_lp = ref_log_softmax[torch.arange(B), tokens_host]
+
+    passing, pcc_msg = comp_pcc(ref_lp, lp_host, pcc=0.99)
+    print(f"\n  logprobs PCC (V={vocab_size}, mesh={cluster_shape}): {pcc_msg}")
+    assert passing, f"logprobs PCC below threshold: {pcc_msg}"
+
+
+# ==============================================================================
+# Trace capture — on-device sampling under begin/end_trace_capture (N150/N300)
+# ==============================================================================
+#
+# The tests above prove the sampler is correct *eagerly* on every mesh. They do NOT exercise the
+# thing that actually gates on-device sampling in a model: whether the sampling op graph can be
+# captured inside ttnn.begin_trace_capture / ttnn.end_trace_capture. TracedLLMExecutor runs
+# model.sampling.decode_forward *inside* trace capture (executor.py:_capture_decode_trace).
+#
+# The TTTv2 perf-recovery handoff gated models' supports_on_device_sampling on num_devices >= 8,
+# assuming the sub-8-device Linear+barrier all-gather could not be trace-captured. The cases below
+# DISPROVE that at the op level: argmax and top-k both capture AND replay correctly on 1x1 (N150,
+# no CCL) and 1x2 (N300, Linear+barrier all-gather). See the handoff doc's "wrong assumption" note.
+#
+# Note the dict-form ttnn_mesh_device param: it carries trace_region_size so the device is opened
+# with a trace region (the fixture does not set one by default).
+
+_TRACE_REGION_SIZE = 32 << 20
+
+
+@pytest.mark.parametrize(
+    "ttnn_mesh_device",
+    [
+        {"mesh_shape": (1, 1), "trace_region_size": _TRACE_REGION_SIZE},
+        {"mesh_shape": (1, 2), "trace_region_size": _TRACE_REGION_SIZE},
+    ],
+    ids=["1x1", "1x2"],
+    indirect=True,
+)
+@pytest.mark.parametrize("mode", ["argmax", "topk"])
+def test_sampling1d_trace_capture(ttnn_mesh_device, mode):
+    """Sampling1D.decode_forward must trace-capture and replay correctly on N150/N300.
+
+    Mirrors TracedLLMExecutor._capture_decode_trace: warmup-compile + load_device_buffers OUTSIDE
+    capture (those issue device writes that are illegal mid-capture), then run decode_forward
+    inside begin/end_trace_capture and replay, asserting replayed tokens == eager tokens.
+
+    All four (mesh x mode) combos pass — including the 1x2 Linear+barrier all-gather the
+    ``num_devices >= 8`` model gate assumes is not capturable.
+    """
+    mesh_device = ttnn_mesh_device
+    num_devices = mesh_device.get_num_devices()
+    cluster_shape = tuple(mesh_device.shape)
+
+    torch.manual_seed(0)
+    B = 32
+    vocab_size = 128256  # Llama-class vocab; per-device shard on 1x2 (64128) >> max_top_k=32
+    logits_host = torch.randn(1, 1, B, vocab_size, dtype=torch.bfloat16)
+
+    sampler = Sampling1D(
+        vocab_size=vocab_size,
+        mesh_device=mesh_device,
+        max_batch_size=B,
+        allow_force_argmax=True,
+        pad_to_power_of_2=(mode == "topk" and num_devices > 1),
+    )
+
+    # k/p/temp built ONCE, OUTSIDE capture, and the same persistent tensors are referenced inside
+    # it — exactly as TracedLLMExecutor caches them (executor.py:_get_decode_sampling_kpt).
+    # Building them inside capture would itself be an illegal in-capture host->device write.
+    kpt = (
+        _make_sampling_params(mesh_device, B, k_val=1, p_val=0.0, temp_val=1.0, cluster_shape=cluster_shape)
+        if mode == "topk"
+        else None
+    )
+
+    def _forward(logits_tt):
+        if mode == "argmax":
+            return sampler.decode_forward(logits_tt)
+        k, p, temp = kpt
+        return sampler.decode_forward(logits_tt, k=k, p=p, temp=temp)
+
+    # Persistent input buffer, reused across warmup / capture / replay (as the executor does).
+    logits_tt = _make_logits_tt(logits_host, mesh_device, shard_vocab=True)
+
+    # --- Warmup: load buffers + JIT-compile the sampling program OUTSIDE capture ---
+    sampler.load_device_buffers()
+    eager_tok, _ = _forward(logits_tt)
+    ttnn.synchronize_device(mesh_device)
+    eager_host = to_torch_auto_compose(eager_tok).flatten()[:B].long()
+
+    # --- Capture (close+release in finally so a failed capture can't wedge the next case) ---
+    trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+    captured_tok = None
+    try:
+        captured_tok, _ = _forward(logits_tt)
+    finally:
+        ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
+        ttnn.synchronize_device(mesh_device)
+
+    # --- Replay (same logits -> same tokens) ---
+    ttnn.execute_trace(mesh_device, trace_id, cq_id=0, blocking=True)
+    replay_host = to_torch_auto_compose(captured_tok).flatten()[:B].long()
+    ttnn.release_trace(mesh_device, trace_id)
+
+    assert torch.equal(replay_host, eager_host), (
+        f"[{mode} mesh={cluster_shape}] traced tokens diverged from eager:\n"
+        f"  eager:  {eager_host[:8]}\n  replay: {replay_host[:8]}"
+    )

--- a/models/experimental/llama32_1b_quasar/tests/utils.py
+++ b/models/experimental/llama32_1b_quasar/tests/utils.py
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared helpers for models/common tests."""
+
+from __future__ import annotations
+
+import zlib
+
+
+def stable_model_seed(model_name: str) -> int:
+    """Stable 32-bit seed derived from model name.
+
+    Python's built-in hash is randomized per process, which breaks reproducibility
+    across runs and can mismatch on-disk cached weights. Use CRC32 instead.
+
+    NOTE: Avoid a single hardcoded global seed (e.g., 1234) for all models; a
+    per-model stable seed keeps caches distinct and reduces correlated RNG paths.
+    """
+    return zlib.crc32(model_name.encode("utf-8")) & 0xFFFFFFFF

--- a/models/experimental/llama32_1b_quasar/utility_functions.py
+++ b/models/experimental/llama32_1b_quasar/utility_functions.py
@@ -88,10 +88,9 @@ def torch_random_with_zeros(shape, low, high, dtype, zero_fraction=0.1):
     # Shuffle the tensor
     shuffled = combined[torch.randperm(combined.size(0))]
 
-    # Reshape to the desired shape
+    # Reshape to the desired shape (Tensor.to is not in-place — return the converted tensor)
     result_tensor = shuffled.view(shape)
-    result_tensor.to(dtype)
-    return result_tensor
+    return result_tensor.to(dtype)
 
 
 ### Profiling ###

--- a/models/experimental/llama32_1b_quasar/utility_functions.py
+++ b/models/experimental/llama32_1b_quasar/utility_functions.py
@@ -1,0 +1,1245 @@
+# SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import math
+import os
+import struct
+import time
+from typing import Union
+
+import numpy as np
+import pytest
+import torch
+from loguru import logger
+from ttnn.device import Arch
+from typing_extensions import deprecated
+
+import ttnn
+
+
+def get_mesh_device():
+    """Fixture to provide mesh device configuration."""
+    mesh_device = os.environ.get("MESH_DEVICE", "N150")
+    mesh_config = {
+        "N150": (1, 1),
+        "N300": (2, 1),
+        "T3K": (8, 1),
+        "TG": (8, 4),
+    }.get(mesh_device, (ttnn.get_num_devices(), 1))
+    return mesh_config
+
+
+### Math operations ###
+def _nearest_32(x):
+    return math.ceil(x / 32) * 32
+
+
+def nearest_32(
+    x,
+):  # needs refctoring; to match alias called in some scripts (e.g. test_padding_test in unit tests)
+    return _nearest_32(x)
+
+
+def _nearest_y(x, y):
+    return math.ceil(x / y) * y
+
+
+def nearest_y(x, y):
+    return _nearest_y(x, y)
+
+
+def divup(a, b):
+    return (a + b - 1) // b
+
+
+def roundup(a, b):
+    result = divup(a, b) * b
+    return result
+
+
+def roundup32(a):
+    return roundup(a, 32)
+
+
+def float_to_bits(x):
+    s = struct.pack(">f", x)
+    return struct.unpack(">l", s)[0]
+
+
+def torch_random(shape, low, high, dtype):
+    if dtype in [torch.int64, torch.int32, torch.int16, torch.int8]:
+        return torch.randint(low, high, shape, dtype=dtype)
+    return torch.zeros(shape, dtype=dtype).uniform_(low, high)
+
+
+def torch_random_with_zeros(shape, low, high, dtype, zero_fraction=0.1):
+    total_elements = torch.prod(torch.tensor(shape)).item()
+    num_zeros = int(total_elements * zero_fraction)
+    num_random = total_elements - num_zeros
+
+    # Generate random values between low and high
+    random_values = torch.empty(num_random).uniform_(low, high)
+    zeros = torch.zeros(num_zeros)
+
+    # Combine zeros and random values
+    combined = torch.cat([zeros, random_values])
+
+    # Shuffle the tensor
+    shuffled = combined[torch.randperm(combined.size(0))]
+
+    # Reshape to the desired shape
+    result_tensor = shuffled.view(shape)
+    result_tensor.to(dtype)
+    return result_tensor
+
+
+### Profiling ###
+class Profiler:
+    def __init__(self):
+        self.start_times = dict()
+        self.times = dict()
+        self.disabled = False
+
+    def clear(self):
+        self.start_times = dict()
+        self.times = dict()
+        self.disabled = False
+
+    def enable(self):
+        self.disabled = False
+
+    def disable(self):
+        self.disabled = True
+
+    def start(self, key, force_enable=False):
+        if self.disabled and not force_enable:
+            return
+
+        self.start_times[key] = time.time()
+
+    def end(self, key, PERF_CNT=1, force_enable=False):
+        if self.disabled and not force_enable:
+            return
+
+        if key not in self.start_times:
+            return
+
+        diff = time.time() - self.start_times[key]
+
+        if key not in self.times:
+            self.times[key] = []
+
+        self.times[key].append(diff / PERF_CNT)
+
+    def get(self, key):
+        if key not in self.times:
+            return 0
+
+        return sum(self.times[key]) / len(self.times[key])
+
+    def print(self, units="s"):
+        for key in self.times:
+            average = self.get(key)
+            if units == "s":
+                pass
+            elif units == "ms":
+                average *= 1000
+            elif units == "us":
+                average *= 1000000
+            elif units == "ns":
+                average *= 1000000000
+            else:
+                raise ValueError(f"Invalid units: {units}")
+            print(f"{key}: {average:.3f}{units}")
+
+
+profiler = Profiler()
+
+
+### Turn flags on/off ###
+def enable_memory_reports():
+    """
+    Enables generating reports of memory allocation statistics in .reports/tt_metal dir
+    """
+    return ttnn.device.EnableMemoryReports()
+
+
+def disable_memory_reports():
+    """
+    Disables generating reports of memory allocation statistics
+    """
+    return ttnn.device.DisableMemoryReports()
+
+
+### Tensor conversion ###
+def torch2tt_tensor(
+    py_tensor: torch.Tensor,
+    tt_device,
+    tt_layout=ttnn.TILE_LAYOUT,
+    tt_memory_config=ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED),
+    tt_dtype=ttnn.bfloat16,
+):
+    size = list(py_tensor.size())
+
+    while len(size) < 4:
+        size.insert(0, 1)
+
+    tt_tensor = ttnn.Tensor(py_tensor.reshape(size), tt_dtype)
+    tt_tensor = tt_tensor.to(tt_layout)
+
+    if tt_device is not None:
+        tt_tensor = tt_tensor.to(tt_device, tt_memory_config)
+    else:
+        tt_tensor = tt_tensor.cpu()
+
+    return tt_tensor
+
+
+def tt_tensors_to_torch_tensors(
+    tt_tensors_device: ttnn.Tensor, mesh_device: Union[ttnn.MeshDevice, ttnn.Device], concat_dim: int = 0
+):
+    # Convert tensors to interleaved
+    if tt_tensors_device.is_sharded():
+        tt_tensors_device = ttnn.sharded_to_interleaved(tt_tensors_device)
+
+    # Convert tensors to RM layout
+    if tt_tensors_device.layout == ttnn.TILE_LAYOUT:
+        # Convert to bfloat16 to ensure untilize works
+        if tt_tensors_device.dtype != ttnn.bfloat16:
+            tt_tensors_device = ttnn.clone(
+                tt_tensors_device, dtype=ttnn.bfloat16, memory_config=ttnn.DRAM_MEMORY_CONFIG
+            )
+        # Untilize using singlecore since multicore version runs out of l1 memory (Issue #9022)
+        tt_tensors_device = ttnn.untilize(tt_tensors_device, use_multicore=False)
+
+    return torch.cat([t.to_torch() for t in ttnn.get_device_tensors(tt_tensors_device.cpu())], dim=concat_dim)
+
+
+def tt2torch_tensor(tt_tensor):
+    tt_output = tt_tensor.cpu()
+    if tt_output.get_layout() != ttnn.ROW_MAJOR_LAYOUT:
+        tt_output = tt_output.to(ttnn.ROW_MAJOR_LAYOUT)
+    return tt_output.to_torch()
+
+
+def tt_to_torch_tensor(tt_tensor):
+    tt_output = tt_tensor.cpu().to(ttnn.ROW_MAJOR_LAYOUT)
+    return tt_output.to_torch()
+
+
+def torch_to_tt_tensor_rm(py_tensor, device, shape=None, put_on_device=True):
+    if shape is None:
+        shape = list(py_tensor.size())
+        while len(shape) < 4:
+            shape.insert(0, 1)
+
+    tt_tensor = ttnn.Tensor(py_tensor.reshape(shape), ttnn.bfloat16)
+    if put_on_device:
+        tt_tensor = tt_tensor.to(device)
+    return tt_tensor
+
+
+def torch_to_tt_tensor(py_tensor, device):
+    shape = list(py_tensor.size())
+    while len(shape) < 4:
+        shape.insert(0, 1)
+
+    tt_tensor = (
+        ttnn.Tensor(py_tensor.reshape(shape), ttnn.bfloat16)
+        .to(
+            ttnn.TILE_LAYOUT
+        )  # change memory layout of TT Tensor to TILE (as operation that will use it expects TILE layout)
+        .to(device)  # move TT Tensor from host to TT accelerator device (device is of type ttnn.device.Device)
+    )
+
+    return tt_tensor
+
+
+def unpad_from_zero(x, desired_shape):
+    if x.padded_shape[-1] == desired_shape[-1] and x.padded_shape[-2] == desired_shape[-2]:
+        x = tt2torch_tensor(x)
+    else:
+        x = x.cpu()
+        if x.get_layout() != ttnn.ROW_MAJOR_LAYOUT:
+            x = x.to(ttnn.ROW_MAJOR_LAYOUT)
+        x = x.unpad(
+            (0, 0, 0, 0),
+            (
+                desired_shape[0],
+                desired_shape[1],
+                desired_shape[2],
+                desired_shape[3],
+            ),
+        )
+
+        x = x.to_torch()
+    return x
+
+
+def pad_activation(x):
+    """
+    This function pads an activation with 0s as a pre-preprocessing step to tilization.
+
+    In the 2d case, it pads a vector to the right with 0s, and in the 2+d case,
+    it pads the bottom and right corners of the last two dimensions.
+
+    :param x: Input PyTorch Tensor
+    :type x: class:`torch.Tensor`
+
+    WARNING: This function should eventually be retired in favour of padding on device
+    """
+    nearest_32 = _nearest_32
+
+    assert isinstance(x, torch.Tensor), "Input to this function must be an instance of torch.Tensor"
+    assert len(x.shape) >= 1 and len(x.shape) <= 4, "Only tensors with dimension 1-4 supported"
+    if len(x.shape) == 1:  # (num_features,)
+        padded_tensor = torch.zeros(1, 1, 32, nearest_32(x.shape[0]))
+        padded_tensor[:, 0, 0, : x.shape[0]] = x
+    elif len(x.shape) == 2:  # (batch, num features)
+        padded_tensor = torch.zeros(x.shape[0], 1, 32, nearest_32(x.shape[1]))
+        padded_tensor[:, 0, 0, : x.shape[1]] = x
+    elif len(x.shape) == 3:  # (batch, num features y, num features x)
+        padded_tensor = torch.zeros(x.shape[0], 1, nearest_32(x.shape[-2]), nearest_32(x.shape[-1]))
+        padded_tensor[..., 0, : x.shape[-2], : x.shape[-1]] = x
+    else:  # (batch, num channels, num features y, num features x)
+        padded_tensor = torch.zeros(*x.shape[:-2], nearest_32(x.shape[-2]), nearest_32(x.shape[-1]))
+        padded_tensor[..., : x.shape[-2], : x.shape[-1]] = x
+    return padded_tensor
+
+
+def pad_weight(x):
+    """
+    This function pads a weight/bias with 0s as a pre-preprocessing step to tilization.
+
+    tt_tensor = ttnn.Tensor(
+        py_tensor.reshape(shape), ttnn.bfloat16
+    In the 2d case, it pads a vector to the right with 0s, and in the 2+d case,
+    it pads the bottom and right corners of the last two dimensions.
+
+    :param x: Input PyTorch Tensor
+    :type x: class:`torch.Tensor`
+
+    WARNING: This function should eventually be retired in favour of padding on device
+    """
+    nearest_32 = _nearest_32
+
+    assert isinstance(x, torch.Tensor), "Input to this function must be an instance of torch.Tensor"
+    assert len(x.shape) >= 1 and len(x.shape) <= 4, "Only tensors with dimension 1-4 supported"
+
+    if len(x.shape) == 1:  # (num_features,)
+        padded_tensor = torch.zeros(1, 1, 32, nearest_32(x.shape[0]))
+        padded_tensor[:, 0, 0, : x.shape[0]] = x
+    elif len(x.shape) == 2:  # (r_features, c_features)
+        padded_tensor = torch.zeros(1, 1, nearest_32(x.shape[0]), nearest_32(x.shape[1]))
+        padded_tensor[:, 0, : x.shape[0], : x.shape[1]] = x
+    else:
+        padded_tensor = torch.zeros(*x.shape[:-2], nearest_32(x.shape[-2]), nearest_32(x.shape[-1]))
+        padded_tensor[..., : x.shape[-2], : x.shape[-1]] = x
+
+    return padded_tensor
+
+
+def convert_weights_2d_matrix(weights, w_shape):
+    """
+    :param weights: Input PyTorch Tensor
+    :type weights: class:`torch.Tensor`
+    """
+    ret_shape = [1, 1, w_shape[0], w_shape[1] * w_shape[2] * w_shape[3]]
+    if isinstance(weights, torch.Tensor):
+        ret = torch.zeros(np.prod(ret_shape))
+    else:
+        ret = np.zeros(np.prod(ret_shape))
+    idx = 0
+    for k in range(w_shape[0]):
+        for r in range(w_shape[2]):
+            for s in range(w_shape[3]):
+                for c in range(w_shape[1]):
+                    ret[idx] = weights[k][c][r][s]
+                    idx += 1
+    assert idx == np.prod(ret_shape)
+    return ret.reshape(ret_shape).transpose(2, 3)
+
+
+def convert_act_2d_matrix(activation, kernel_y, kernel_x, stride_y, stride_x, pad_y, pad_x):
+    """
+    :param activation: Input PyTorch Tensor
+    :type activation: class:`torch.Tensor`
+    """
+    N = activation.shape[0]
+    C = activation.shape[1]
+    H = activation.shape[2]
+    W = activation.shape[3]
+
+    OH = (int)((H - kernel_y + 2 * pad_y) // stride_y) + 1
+    OW = ((W - kernel_x + 2 * pad_x) // stride_x) + 1
+    nrows = OH * OW
+    ncols = C * kernel_x * kernel_y
+    ret_shape = [1, N, nrows, ncols]
+    if isinstance(activation, torch.Tensor):
+        ret = torch.zeros(np.prod(ret_shape))
+    else:
+        ret = np.zeros(np.prod(ret_shape))
+    idx = 0
+    for n in range(N):
+        for h in range(-1 * pad_y, H + pad_y - kernel_y + 1, stride_y):
+            for w in range(-1 * pad_x, W + pad_x - kernel_x + 1, stride_x):
+                for r in range(kernel_y):
+                    for s in range(kernel_x):
+                        for c in range(C):
+                            h_offs = h + r
+                            w_offs = w + s
+                            pad = h_offs < 0 or h_offs >= H or w_offs < 0 or w_offs >= W
+                            ret[idx] = 0 if pad else activation[n][c][h_offs][w_offs]
+                            idx += 1
+    assert idx == np.prod(ret_shape)
+    return ret.reshape(ret_shape)
+
+
+### Tilizing / Untilizing ###
+@deprecated("PyTorch data is handled automatically in tensor infra. This function does nothing now:")
+def tilize(x):
+    return x
+
+
+@deprecated("PyTorch data is handled automatically in tensor infra. This function does nothing now:")
+def tilize_to_list(x):
+    """
+    Returns a flattened list of the tensor
+    """
+    return tilize(x).reshape(-1).tolist()
+
+
+@deprecated("PyTorch data is handled automatically in tensor infra. This function does nothing now:")
+def untilize(x):
+    return x
+
+
+### Measuring accuracy and other metrics ###
+def is_close(a, b, rtol=1e-2, atol=1e-2, max_mag=2.0, max_mag_fraction=0.02):
+    """
+    A variant of np.isclose with logging.
+    """
+    absdiff = (a - b).abs()
+    reldiff1 = (a.abs() / b.abs()) - 1.0
+    reldiff2 = (a.abs() + 1.0) / (b.abs() + 1.0) - 1.0  # in case b.abs() is 0
+    reldiff_or = torch.logical_or(reldiff1.abs() < rtol, reldiff2.abs() < rtol)
+    max_mag_ok = absdiff < max_mag * max_mag_fraction
+
+    or_abs_rel = torch.logical_or(absdiff < atol, reldiff_or)
+    or_abs_rel = torch.logical_or(or_abs_rel, max_mag_ok)
+    debug_index = or_abs_rel.to(torch.int32).argmin().item()
+
+    if not or_abs_rel.reshape(-1)[debug_index]:
+        logger.info(f"isclose mismatch at index={debug_index}")
+        logger.info(a.reshape(-1)[debug_index])
+        logger.info(b.reshape(-1)[debug_index])
+        logger.info(f"reldiff1={reldiff1.reshape(-1)[debug_index]}")
+        logger.info(f"reldiff2={reldiff2.reshape(-1)[debug_index]}")
+        logger.info(f"absdiff={absdiff.reshape(-1)[debug_index]}")
+
+        HT = a.shape[-2] // 32
+        WT = a.shape[-1] // 32
+        hwt = debug_index // 1024
+        wt = hwt % WT
+        ht = hwt // WT
+        h = (debug_index % 1024) // 32
+        w = (debug_index % 1024) % 32
+
+        logger.info(f"****    at {debug_index} --- HTWT={ht} {wt} HW={h} {w}")
+
+    return torch.all(or_abs_rel)
+
+
+def _comp_nonfinite(golden, calculated):
+    """
+    Returns True if tensors contain the same non-finite values (nan, inf, -inf) at the same positions. Also returns True if all elements are finite.
+    Returns False if non-finite values differ between both tensors.
+    """
+
+    # torch.equal(['nan'], ['nan']] => False
+    # For this reason, we check for nan and inf separately
+    if torch.not_equal(torch.isnan(golden), torch.isnan(calculated)).any():
+        return False
+
+    golden_inf_mask = torch.isinf(golden)
+    calculated_inf_mask = torch.isinf(calculated)
+
+    if torch.not_equal(golden_inf_mask, calculated_inf_mask).any():
+        return False
+
+    golden_inf = golden[golden_inf_mask]
+    calculated_inf = calculated[calculated_inf_mask]
+    return torch.equal(golden_inf, calculated_inf)
+
+
+def comp_allclose(golden, calculated, rtol=1e-05, atol=1e-08):
+    if golden.dtype != calculated.dtype:
+        calculated = calculated.type(golden.dtype)
+
+    atol_delta = torch.max(torch.abs(golden - calculated)).item()
+    rtol_delta = torch.max(torch.abs(golden - calculated) / torch.abs(calculated)).item()
+    return (
+        torch.allclose(golden, calculated, rtol, atol, True),
+        f"Max ATOL Delta: {atol_delta}, Max RTOL Delta: {rtol_delta}",
+    )
+
+
+def comp_pcc(golden, calculated, pcc=0.99, rtol=1e-05, atol=1e-04):
+    golden = torch.Tensor(golden)
+    calculated = torch.Tensor(calculated)
+
+    if golden.dtype != calculated.dtype:
+        calculated = calculated.type(golden.dtype)
+
+    if torch.all(torch.isnan(golden)) and torch.all(torch.isnan(calculated)):
+        logger.warning("Both tensors are 'nan'")
+        return True, 1.0
+
+    if torch.all(torch.isnan(golden)) or torch.all(torch.isnan(calculated)):
+        logger.error("One tensor is all nan, the other is not.")
+        return False, 0.0
+
+    # Test if either is completely zero — but a zero tensor is also a constant tensor,
+    # so fall back to allclose instead of a hard 0.0: zero-vs-small-constant may be
+    # within the caller's tolerances.
+    if torch.any(golden.bool()) != torch.any(calculated.bool()):
+        logger.warning("One tensor is all zero. PCC undefined; falling back to allclose.")
+        result = torch.allclose(golden, calculated, rtol=rtol, atol=atol)
+        return result, float(result)
+
+    golden = torch.squeeze(golden).flatten()
+    calculated = torch.squeeze(calculated).flatten()
+
+    # For now, mask all infs and nans (to zero) so that we check the rest... TODO
+    # Skip this for integer types which don't have NaN/Inf values.
+    if golden.dtype.is_floating_point:
+        # FP8 doesn't support isfinite/nan_to_num and bfloat16 products lose precision,
+        # so correlate these in float32.
+        if golden.dtype in (torch.float8_e4m3fn, torch.float8_e5m2, torch.bfloat16):
+            golden = golden.to(torch.float32)
+            calculated = calculated.to(torch.float32)
+
+        # Zero out NaN/Inf, preserving the historical PCC values. nan_to_num allocates a
+        # full-size copy of each tensor, so only do it when invalid values are actually
+        # present; on the common all-finite path the tensors stay as views and no copy is
+        # made (this short-circuit is what keeps peak memory near 1x of one input).
+        if not bool((torch.isfinite(golden) & torch.isfinite(calculated)).all()):
+            golden = torch.nan_to_num(golden, nan=0.0, posinf=0.0, neginf=0.0)
+            calculated = torch.nan_to_num(calculated, nan=0.0, posinf=0.0, neginf=0.0)
+
+    if torch.equal(golden, calculated):
+        return True, 1.0
+
+    # Integer tensors must be correlated in floating point (centering/products would
+    # otherwise truncate/overflow). float32 keeps the working set small.
+    if not golden.dtype.is_floating_point:
+        golden = golden.to(torch.float32)
+        calculated = calculated.to(torch.float32)
+
+    # Pearson r with float64 *accumulation* (dtype= on the reductions) over the float32
+    # data: no float64 copy of either tensor is materialized, so peak memory stays near
+    # 1x of one input on large tensors while matching a full-float64 correlation to
+    # |Δ|<1e-9 across the high-PCC (>=0.999) range.
+    n = golden.numel()
+    g_centered = golden - (golden.sum(dtype=torch.float64) / n).to(golden.dtype)
+    c_centered = calculated - (calculated.sum(dtype=torch.float64) / n).to(calculated.dtype)
+    cov = (g_centered * c_centered).sum(dtype=torch.float64)
+    g_sq_sum = g_centered.pow(2).sum(dtype=torch.float64)
+    c_sq_sum = c_centered.pow(2).sum(dtype=torch.float64)
+    denom = torch.sqrt(g_sq_sum * c_sq_sum)
+    # pow/sum stay in float32 before the reduction; large-magnitude tensors (e.g. ldexp)
+    # can overflow to inf here even though float64 accumulation would be finite.
+    if not math.isfinite(denom.item()) or not math.isfinite(cov.item()):
+        g_centered64 = g_centered.to(torch.float64)
+        c_centered64 = c_centered.to(torch.float64)
+        cov = (g_centered64 * c_centered64).sum()
+        denom = torch.sqrt(g_centered64.pow(2).sum() * c_centered64.pow(2).sum())
+    cal_pcc = (cov / denom).item()
+
+    # Zero variance -> denom == 0 -> cal_pcc is nan: PCC is undefined for constant tensors.
+    # Fall back to allclose rather than returning a misleading 1.0.
+    if math.isnan(cal_pcc):
+        logger.warning("PCC is NaN (zero variance / constant tensor). Falling back to allclose check.")
+        result = torch.allclose(golden, calculated, rtol=rtol, atol=atol)
+        return result, float(result)
+
+    return cal_pcc >= pcc, cal_pcc
+
+
+def ulp(x: Union[ttnn.Tensor, torch.Tensor]) -> Union[ttnn.Tensor, torch.Tensor]:
+    "Return Unit of Least Precision for each element of a given tensor"
+
+    received_ttnn_input = False
+    if isinstance(x, ttnn.Tensor):
+        x = ttnn.to_torch(x)
+        received_ttnn_input = True
+
+    # Notes:
+    # - This should be identical to the definition of ULP by Goldberg
+    #   "What every computer scientist should know about floating-point arithmetic"
+    #   https://docs.oracle.com/cd/E19957-01/806-3568/ncg_goldberg.html
+    # - We use torch.abs(x) to ensure symmetry ULP(-x) == ULP(x)
+    # - For x powers of 2, x + ULP(x) is not closest number but second closest (previous number is 2x closer)
+    #   However, this avoids rounding-to-nearest-tie-to-even issues on addition (i.e. x + ULP(x) != x)
+    abs_x = torch.abs(x)
+    next = torch.nextafter(
+        abs_x, torch.tensor(math.inf, dtype=x.dtype)
+    )  # 1 ULP ~ Difference between two consecutive floating point numbers
+    ulp_value = next - abs_x
+
+    # Special case: if abs_x == torch.finfo(x.dtype).max, then next == math.inf, which leads to ULP(x) == inf rather than finite number
+    # We fix this problem by manually calculating ULP at max value, and masking tensor when input == max
+    dtype_max = torch.finfo(x.dtype).max
+    max_epsilon = dtype_max - torch.nextafter(
+        torch.tensor(dtype_max, dtype=x.dtype), torch.tensor(-math.inf, dtype=x.dtype)
+    )
+    ulp_value = torch.where(abs_x == dtype_max, max_epsilon, ulp_value)
+
+    if received_ttnn_input:  # Ensures that type(input) == type(output)
+        ulp_value = ttnn.from_torch(ulp_value)
+
+    return ulp_value
+
+
+def comp_ulp(golden, calculated, ulp_threshold, allow_nonfinite=False):
+    """
+    Compute absolute error between two tensors in Units of Least Precision (ULP)
+    """
+
+    # If both tensors are empty, then we can return True
+    if torch.numel(golden) == 0 and torch.numel(calculated) == 0:
+        return True, "Both tensors are empty"
+
+    if not allow_nonfinite and not torch.all(torch.isfinite(calculated)):
+        return False, "Calculated tensor contains non-finite values"
+
+    if not _comp_nonfinite(golden, calculated):
+        return False, "Tensors are not finite at the same positions"
+    # nonfinite elements can interfere with ULP error calculation
+    # To avoid this, replace nan, +inf, -inf with 0
+    # (we have already checked that both tensors have the same nonfinite elements)
+    mask_finite = ~torch.isfinite(golden)
+    golden = golden.clone()
+    calculated = calculated.clone()
+    golden[mask_finite] = 0
+    calculated[mask_finite] = 0
+
+    # ULP is measured according to the golden tensor
+    # In most cases, data type of golden tensor should be the same as calculated tensor.
+    # However, in some cases, we may want to measure < 1 ULP differences, which requires golden tensor
+    # to have higher precision than calculated tensor.
+    # If we passed golden tensor to ulp() as is, we would get ULP of higher precision.
+    # e.g. ulp of float32 rather bfloat16 calculation, which would give us a wrong value.
+    ulp_value = ulp(golden.type(calculated.dtype))
+
+    if golden.dtype != calculated.dtype:  # Note: assumes that golden has higher precision than calculated tensor
+        calculated = calculated.type(golden.dtype)
+        ulp_value = ulp_value.type(golden.dtype)  # Convert ULP to higher precision (for sub-1 ULP measurements)
+
+    ulp_tensor = torch.abs(calculated - golden) / ulp_value
+    ulp_delta = torch.max(ulp_tensor)
+    within_threshold = ulp_delta <= ulp_threshold
+    message = f"Max ULP Delta: {ulp_delta}"
+    if not within_threshold:
+        ulp_index = torch.argmax(ulp_tensor)
+        ulp_index_tuple = tuple(int(idx) for idx in torch.unravel_index(ulp_index, golden.shape))
+        message += (
+            f" @ {list(ulp_index_tuple)} = "
+            f"|calculated {calculated[ulp_index_tuple]} - golden {golden[ulp_index_tuple]}| "
+            f"/ ULP(golden) {ulp_value[ulp_index_tuple]}"
+        )
+    return (within_threshold, message)
+
+
+def calculate_detailed_ulp_stats(expected, actual):
+    """
+    Calculate detailed ULP statistics for analysis.
+
+    Returns:
+        dict: Dictionary with ULP statistics including max, mean, std, and percentiles
+    """
+    if isinstance(actual, ttnn.Tensor):
+        actual = ttnn.to_torch(actual)
+    if isinstance(expected, ttnn.Tensor):
+        expected = ttnn.to_torch(expected)
+
+    # Convert to bfloat16 if not already
+    expected = expected.to(torch.bfloat16)
+    actual = actual.to(torch.bfloat16)
+
+    # Handle special cases
+    if torch.allclose(expected, actual, rtol=0, atol=0, equal_nan=True):
+        return {
+            "max_ulp": 0.0,
+            "mean_ulp": 0.0,
+            "median_ulp": 0.0,
+            "std_ulp": 0.0,
+            "p95_ulp": 0.0,
+            "p99_ulp": 0.0,
+            "perfect_matches": 1.0,
+        }
+
+    # Convert bfloat16 to uint16 representation for bit manipulation
+    expected_bits = expected.view(torch.int16).to(torch.int32)
+    actual_bits = actual.view(torch.int16).to(torch.int32)
+
+    # Handle sign differences
+    expected_sign = expected_bits < 0
+    actual_sign = actual_bits < 0
+    same_sign = expected_sign == actual_sign
+
+    # Calculate ULP differences
+    expected_abs_bits = torch.where(expected_sign, -expected_bits, expected_bits)
+    actual_abs_bits = torch.where(actual_sign, -actual_bits, actual_bits)
+
+    ulp_diff = torch.where(same_sign, torch.abs(expected_bits - actual_bits), expected_abs_bits + actual_abs_bits)
+
+    # Handle non-finite values
+    expected_finite = torch.isfinite(expected)
+    actual_finite = torch.isfinite(actual)
+    both_finite = expected_finite & actual_finite
+
+    ulp_diff = torch.where(both_finite, ulp_diff, torch.tensor(float("inf")))
+
+    # Handle same non-finite values
+    both_nan = torch.isnan(expected) & torch.isnan(actual)
+    both_posinf = torch.isposinf(expected) & torch.isposinf(actual)
+    both_neginf = torch.isneginf(expected) & torch.isneginf(actual)
+    same_nonfinite = both_nan | both_posinf | both_neginf
+
+    ulp_diff = torch.where(same_nonfinite, torch.tensor(0.0), ulp_diff)
+
+    # Calculate statistics only on finite ULP differences
+    finite_ulp = ulp_diff[torch.isfinite(ulp_diff)]
+
+    if len(finite_ulp) == 0:
+        return {
+            "max_ulp": float("inf"),
+            "mean_ulp": float("inf"),
+            "median_ulp": float("inf"),
+            "std_ulp": float("inf"),
+            "p95_ulp": float("inf"),
+            "p99_ulp": float("inf"),
+            "perfect_matches": 0.0,
+        }
+
+    finite_ulp_float = finite_ulp.float()
+    perfect_matches = (finite_ulp == 0).float().mean().item()
+
+    return {
+        "max_ulp": torch.max(finite_ulp).item(),
+        "mean_ulp": torch.mean(finite_ulp_float).item(),
+        "median_ulp": torch.median(finite_ulp_float).item(),
+        "std_ulp": torch.std(finite_ulp_float).item(),
+        "p95_ulp": torch.quantile(finite_ulp_float, 0.95).item(),
+        "p99_ulp": torch.quantile(finite_ulp_float, 0.99).item(),
+        "perfect_matches": perfect_matches,
+    }
+
+
+def comp_allclose_and_pcc(golden, calculated, rtol=1e-05, atol=1e-08, pcc=0.99):
+    # 0-volume tensors are special because they don't have elements, so we can't compute PCC, etc.
+    # If one of the tensors is a 0-volume tensor, simply call torch.equal to check if they are equal
+    # (i.e. that both are 0-volume tensors and they have equal shapes).
+    if golden.numel() == 0 or calculated.numel() == 0:
+        return torch.equal(golden, calculated), f"{golden} != {calculated}"
+
+    if golden.dtype != calculated.dtype:
+        calculated = calculated.type(golden.dtype)
+
+    passing = True
+    output = ""
+    passing_allclose, output_allclose = comp_allclose(golden, calculated, rtol, atol)
+    passing &= passing_allclose
+    output += output_allclose
+    if torch.numel(golden) != 1:
+        passing_pcc, output_pcc = comp_pcc(golden, calculated, pcc, rtol=rtol, atol=atol)
+        passing &= passing_pcc
+        output += f", pcc={output_pcc}"
+
+    return passing, output
+
+
+def comp_equal(golden, calculated):
+    if golden.dtype != calculated.dtype:
+        calculated = calculated.type(golden.dtype)
+
+    # If either tensor is zero-volume, broadcasting can still yield an empty delta and
+    # crash torch.max(); defer entirely to torch.equal (False on shape mismatch).
+    if golden.numel() == 0 or calculated.numel() == 0:
+        return torch.equal(golden, calculated), f"{golden} != {calculated}"
+
+    atol_delta = torch.max(torch.abs(golden - calculated)).item()
+    rtol_delta = torch.max(torch.abs(golden - calculated) / torch.abs(calculated)).item()
+    return (
+        torch.equal(golden, calculated),
+        f"Max ATOL Delta: {atol_delta}, Max RTOL Delta: {rtol_delta}",
+    )
+
+
+def get_oom_of_float(float_lst):
+    """
+    Given a list of floats, returns a list of the order or magnitudes
+    of the floats. Useful when you want to make sure that even if your
+    tt outputs don't match pytorch all that well, they are at least
+    on the same order of magnitude
+    """
+    ooms = []
+    for el in float_lst:
+        str_el = str(el)
+        if "e" in str_el:
+            oom = int(str_el.split("e")[1])
+        elif str_el[:2] == "0.":
+            str_el = str_el.split(".")[1]
+
+            oom = -1
+            for e in str_el:
+                if e != "0":
+                    break
+                oom -= 1
+        else:
+            oom = len(str_el.split(".")[0])
+
+        ooms.append(oom)
+
+    return ooms
+
+
+def print_diff_argmax(a, b, annotation=""):
+    """
+    Prints out the value of both tensors at a point where the absolute difference is the largest.
+    """
+    absdiff = (a - b).abs()
+    argmax = absdiff.argmax().item()
+    diff = absdiff.reshape(-1)[argmax]
+    rela = a.abs() / (torch.max(a.abs(), b.abs()))
+    relb = b.abs() / (torch.max(a.abs(), b.abs()))
+    HT = a.shape[-2] // 32
+    WT = a.shape[-1] // 32
+    hwt = argmax // 1024
+    wt = hwt % WT
+    ht = hwt // WT
+    h = (argmax % 1024) // 32
+    w = (argmax % 1024) % 32
+    print(
+        "Abs diff=",
+        diff,
+        " at ",
+        argmax,
+        " --- ",
+        annotation,
+        "HTWT=",
+        ht,
+        wt,
+        "HW=",
+        h,
+        w,
+    )
+    print("  (a=", a.reshape(-1)[argmax].item(), ")")
+    print("  (b=", b.reshape(-1)[argmax].item(), ")")
+    print("  Rel a=", rela.reshape(-1)[argmax], " at ", argmax)
+    print("  Rel b=", relb.reshape(-1)[argmax], " at ", argmax)
+    return diff.item()
+
+
+def print_diff_tt_pyt(a, b, annotation=""):
+    # first convert a pytorch tensor argument b to tt
+    padded_b = pad_weight(b)
+    pyt_a = tt2torch(a)  # untilizes also
+    return print_diff_argmax(pyt_a, padded_b, annotation)
+
+
+def ttP(x, count=4, offset=0, stride=1):
+    if type(x) == torch.Tensor:
+        t1 = x.reshape(-1)
+    else:
+        tt_out = x.cpu()
+        torch_out = untilize(tt_out.to_torch())
+        t1 = torch_out.reshape(-1)
+    print("Tensor vals: (", end="")
+    for j in range(offset, offset + count * stride, stride):
+        print(t1[j].item(), " ", end="")
+    print(")")
+
+
+### Conv related helpers ###
+def read_conv_act_into_mm_act_block(
+    conv_act,
+    act_address_map_index,
+    address_map,
+    address_map_this_block_size,
+    act_block_h,
+    act_block_w,
+):
+    mm_act_block_shape = [1, 1, act_block_h * 32, act_block_w * 32]
+    mm_act_block_size = act_block_h * act_block_w * 1024
+    mm_act_block = torch.zeros(mm_act_block_size, dtype=torch.bfloat16).float()
+    for i in range(0, address_map_this_block_size, 4):
+        src_address = address_map[act_address_map_index]
+        dst_address = address_map[act_address_map_index + 1]
+        read_size = address_map[act_address_map_index + 2]
+        pad = address_map[act_address_map_index + 3]
+        for s in range(read_size):
+            assert dst_address + s < mm_act_block_size
+            if pad:
+                mm_act_block[dst_address + s] = 0
+            else:
+                assert src_address + s < len(conv_act)
+                mm_act_block[dst_address + s] = conv_act[src_address + s]
+        act_address_map_index += 4
+    return (mm_act_block.reshape(mm_act_block_shape), act_address_map_index)
+
+
+def read_conv_weight_into_mm_weight_block(
+    conv_weight,
+    weight_address_map_index,
+    weight_address_map,
+    weight_address_map_this_block_size,
+    weight_block_h,
+    weight_block_w,
+):
+    mm_weight_block_shape = [1, 1, weight_block_h * 32, weight_block_w * 32]
+    mm_weight_block_size = weight_block_h * weight_block_w * 1024
+    mm_weight_block = torch.zeros(mm_weight_block_size, dtype=torch.bfloat16).float()
+    for i in range(0, weight_address_map_this_block_size, 4):
+        src_address = weight_address_map[weight_address_map_index]
+        dst_address = weight_address_map[weight_address_map_index + 1]
+        read_size = weight_address_map[weight_address_map_index + 2]
+        pad = weight_address_map[weight_address_map_index + 3]
+        for s in range(read_size):
+            assert dst_address + s < mm_weight_block_size
+            if pad:
+                mm_weight_block[dst_address + s] = 0
+            else:
+                assert src_address + s < len(conv_weight)
+                mm_weight_block[dst_address + s] = conv_weight[src_address + s]
+        weight_address_map_index += 4
+    return (mm_weight_block.reshape(mm_weight_block_shape), weight_address_map_index)
+
+
+def blocked_mm_with_conv_act(
+    conv_act,
+    mm_weight,
+    act_address_map,
+    weight_address_map,
+    num_blocks_act_h,
+    num_blocks_act_w,
+    num_blocks_weight_w,
+    act_block_h,
+    act_block_w,
+    weight_block_w,
+):
+    # act refers to conv activation tensor
+    # weight refers to conv weight tensor
+    mm_output_shape = [
+        1,
+        1,
+        num_blocks_act_h * act_block_h * 32,
+        num_blocks_weight_w * weight_block_w * 32,
+    ]
+    ret = torch.zeros(mm_output_shape, dtype=torch.bfloat16).float()
+    mm_output_block_shape = [1, 1, act_block_h * 32, weight_block_w * 32]
+    act_address_map_index = 0
+    weight_address_map_index = 0
+    weight_block_h = act_block_w
+    num_groups = act_address_map[act_address_map_index]
+    assert num_groups == num_blocks_act_h * num_blocks_act_w * num_blocks_weight_w
+    weight_num_groups = act_address_map[weight_address_map_index]
+    assert weight_num_groups == num_groups
+    act_address_map_index += 1
+    weight_address_map_index += 1
+    for block_act_h in range(num_blocks_act_h):
+        # Reset weight (weight) to the starting tile in this column
+        for block_weight_w in range(num_blocks_weight_w):
+            output_block = torch.zeros(mm_output_block_shape, dtype=torch.bfloat16).float()
+            for block_act_w in range(num_blocks_act_w):
+                address_map_this_block_size = act_address_map[act_address_map_index]
+                act_address_map_index += 1
+                weight_address_map_this_block_size = weight_address_map[weight_address_map_index]
+                weight_address_map_index += 1
+                (mm_act_block, act_address_map_index) = read_conv_act_into_mm_act_block(
+                    conv_act,
+                    act_address_map_index,
+                    act_address_map,
+                    address_map_this_block_size,
+                    act_block_h,
+                    act_block_w,
+                )
+                (
+                    mm_weight_block,
+                    weight_address_map_index,
+                ) = read_conv_weight_into_mm_weight_block(
+                    mm_weight,
+                    weight_address_map_index,
+                    weight_address_map,
+                    weight_address_map_this_block_size,
+                    weight_block_h,
+                    weight_block_w,
+                )
+                # Untilize weight block (this CPU reference does matmul on untilized blocks)
+                mm_weight_block = untilize(mm_weight_block)
+                for out_h_block in range(act_block_h * 32):
+                    for out_w_block in range(weight_block_w * 32):
+                        output_block[0][0][out_h_block][out_w_block] += torch.dot(
+                            mm_act_block[0, 0, out_h_block, :].reshape(-1),
+                            mm_weight_block[0, 0, :, out_w_block].reshape(-1),
+                        )
+            start_oh = block_act_h * act_block_h * 32
+            start_ow = block_weight_w * weight_block_w * 32
+            end_oh = start_oh + (act_block_h * 32)
+            end_ow = start_ow + (weight_block_w * 32)
+            ret[0, 0, start_oh:end_oh, start_ow:end_ow] = output_block
+
+    return ret
+
+
+def is_conv_supported_on_device(conv_params):
+    K, C, R, S, U, V, P_H, P_W, dilation, groups = [conv_params[i] for i in range(10)]
+
+    if K % 32 != 0 or dilation != 1 or groups != 1:
+        logger.warning("DOES NOT HAVE SUPPORT FOR Conv with following parameters -")
+        logger.warning(
+            "K="
+            + str(K)
+            + " C="
+            + str(C)
+            + " R="
+            + str(R)
+            + " S="
+            + str(S)
+            + " U="
+            + str(U)
+            + " V="
+            + str(V)
+            + " PH="
+            + str(P_H)
+            + " PW="
+            + str(P_W)
+            + " dilation="
+            + str(dilation)
+            + " groups="
+            + str(groups)
+        )
+        return False
+
+    return True
+
+
+def is_x2_harvested(device):
+    grid = device.compute_with_storage_grid_size()
+    return device.arch() == Arch.WORMHOLE_B0 and (grid.x, grid.y) == (8, 7)
+
+
+def is_single_chip():
+    return ttnn.GetNumAvailableDevices() == 1
+
+
+def is_quasar():
+    ARCH_NAME = ttnn.get_arch_name()
+    return "quasar" in ARCH_NAME
+
+
+def is_blackhole():
+    ARCH_NAME = ttnn.get_arch_name()
+    return "blackhole" in ARCH_NAME
+
+
+def is_wormhole_b0():
+    ARCH_NAME = ttnn.get_arch_name()
+    return "wormhole_b0" in ARCH_NAME
+
+
+def is_watcher_enabled():
+    watcher = os.environ.get("TT_METAL_WATCHER")
+    lightweight_asserts = os.environ.get("TT_METAL_LIGHTWEIGHT_KERNEL_ASSERTS")
+    return (watcher is not None and watcher != "") or lightweight_asserts == "1"
+
+
+def is_llk_assert_enabled():
+    llk_assert = os.environ.get("TT_METAL_LLK_ASSERTS")
+    return llk_assert == "1"
+
+
+def is_n300():
+    return os.environ.get("MESH_DEVICE", "N150") == "N300"
+
+
+def is_slow_dispatch():
+    return os.environ.get("TT_METAL_SLOW_DISPATCH_MODE") == "1"
+
+
+def ti_skip(condition, reason="Invalid test parameters"):
+    return pytest.mark.skipif(condition, reason="Skipping unsupported case: " + reason)
+
+
+def skip_for_blackhole(reason_str="not a blackhole test"):
+    return ti_skip(is_blackhole(), reason=reason_str)
+
+
+def skip_for_wormhole_b0(reason_str="not a wormhole test"):
+    return ti_skip(is_wormhole_b0(), reason=reason_str)
+
+
+def skip_with_watcher(reason_str="Test is not passing with watcher enabled"):
+    return ti_skip(is_watcher_enabled(), reason=reason_str)
+
+
+def skip_with_llk_assert(reason_str="Test is not passing with LLK asserts enabled"):
+    return ti_skip(is_llk_assert_enabled(), reason=reason_str)
+
+
+def run_for_blackhole(reason_str="only runs for Blackhole"):
+    return ti_skip(not is_blackhole(), reason=reason_str)
+
+
+def run_for_wormhole_b0(reason_str="only runs for Wormhole B0"):
+    return ti_skip(not is_wormhole_b0(), reason=reason_str)
+
+
+def run_for_wormhole_b0_or_blackhole(reason_str="only runs for Wormhole B0 or Blackhole"):
+    return ti_skip(not (is_wormhole_b0() or is_blackhole()), reason=reason_str)
+
+
+def run_for_n_dev(n, reason_str="Test is not meant for this number of devices"):
+    return ti_skip(ttnn.get_num_devices() != n, reason=reason_str)
+
+
+def skip_for_n_dev(n, reason_str="Test is not meant for this number of devices"):
+    return ti_skip(ttnn.get_num_devices() == n, reason=reason_str)
+
+
+def skip_for_n_or_less_dev(n, reason_str="Test is not meant for this number of devices"):
+    return ti_skip(ttnn.get_num_devices() <= n, reason=reason_str)
+
+
+def skip_for_slow_dispatch(reason_str="not working for slow dispatch"):
+    return ti_skip(is_slow_dispatch(), reason=reason_str)
+
+
+def ttl_complex_2_torch_complex(tt_tensor):
+    torch_tensor = tt2torch_tensor(tt_tensor)
+
+    # extract real and imag parts of the complex tensor
+    real = torch_tensor[:, :, :, : torch_tensor.shape[-1] // 2].to(torch.bfloat16).to(torch.float)
+    imag = torch_tensor[:, :, :, torch_tensor.shape[-1] // 2 :].to(torch.bfloat16).to(torch.float)
+
+    # create torch complex tensor
+    result = torch.complex(real, imag)
+    return result
+
+
+def pad_and_fold_conv_filters_for_unity_stride(filter_pyt_nchw_tensor, stride_h, stride_w, align_c=4):
+    assert stride_h == stride_w
+    assert filter_pyt_nchw_tensor.shape[2] == filter_pyt_nchw_tensor.shape[3]
+    assert isinstance(align_c, int) and align_c > 0
+    # Fold activation for unity stride
+    # Pad channel size to align_c. This keeps L1 read addresses aligned; extra channels become
+    # zero-valued weights that contribute nothing to the convolution. align_c=4 is the WH/BH default
+    # (16B alignment for bf16 gives C a multiple of 4 with a tiled conv reader). Quasar's row-major
+    # fold needs align_c=8 (bf16 row-major shard width must be a multiple of 8) so the first conv
+    # folds to groups*8 input channels and consumes the aligned output without per-group padding strip.
+    C = _nearest_y(filter_pyt_nchw_tensor.shape[1], align_c)
+    # Pad filter to nearest stride
+    Padded_filter_height = _nearest_y(filter_pyt_nchw_tensor.shape[2], stride_h)
+    Padded_filter_width = _nearest_y(filter_pyt_nchw_tensor.shape[3], stride_w)
+    filter_pyt_padded = torch.nn.functional.pad(
+        filter_pyt_nchw_tensor,
+        (
+            0,
+            Padded_filter_width - filter_pyt_nchw_tensor.shape[3],
+            0,
+            Padded_filter_height - filter_pyt_nchw_tensor.shape[2],
+            0,
+            C - filter_pyt_nchw_tensor.shape[1],
+        ),
+    )
+    # Fold filter for unity stride.
+    filter_pyt_padded_folded = torch.zeros(
+        [
+            filter_pyt_padded.shape[0],
+            C * stride_h * stride_w,
+            (int)(filter_pyt_padded.shape[2] / stride_h),
+            (int)(filter_pyt_padded.shape[3] / stride_w),
+        ]
+    )
+    for h in range(0, filter_pyt_padded.shape[2], stride_h):
+        for w in range(0, filter_pyt_padded.shape[3], stride_w):
+            folded_h = (int)(h / stride_h)
+            folded_w = (int)(w / stride_w)
+            for i in range(4):
+                start_c = i * C
+                filter_pyt_padded_folded[:, start_c : start_c + C, folded_h, folded_w] = filter_pyt_padded[
+                    :, :, h + (int)(i / stride_w), w + (int)(i % stride_w)
+                ]
+    return filter_pyt_padded_folded
+
+
+# produces a tensor where each element in a page is the page number
+# this tensor is easy to debug and visualize
+def get_debug_tensor(num_pages_width, num_pages_height, dtype, page_width=32, page_height=32):
+    torch_tensor = None
+    for row_idx in range(0, int(num_pages_height)):
+        tile_row = None
+        for col_idx in range(0, int(num_pages_width)):
+            tile_idx = col_idx + num_pages_width * row_idx
+            tile = torch.full((1, 1, page_width, page_height), tile_idx + 1, dtype=dtype)
+            if tile_row == None:
+                tile_row = tile
+            else:
+                tile_row = torch.cat((tile_row, tile), 3)
+        if torch_tensor == None:
+            torch_tensor = tile_row
+        else:
+            torch_tensor = torch.cat((torch_tensor, tile_row), 2)
+
+    return torch_tensor
+
+
+# ── transformers 5.x Cache API compatibility ────────────────────────────────
+# transformers 5.x removed the legacy Cache API: DynamicCache no longer exposes
+# from_legacy_cache / to_legacy_cache / key_cache / value_cache (per-layer KV now
+# lives at cache.layers[i].keys/.values). These helpers work on both 4.x and 5.x.
+def hf_cache_layer_kv(cache, layer_idx):
+    """Return (key, value) tensors for a layer of a transformers Cache.
+
+    Handles the legacy tuple-of-tuples past_key_values, transformers <5 Cache
+    (key_cache/value_cache), and transformers >=5 Cache (layers[i].keys/.values).
+    """
+    if isinstance(cache, (tuple, list)):  # legacy tuple-of-tuples past_key_values
+        return cache[layer_idx][0], cache[layer_idx][1]
+    if hasattr(cache, "key_cache"):  # transformers < 5.x Cache
+        return cache.key_cache[layer_idx], cache.value_cache[layer_idx]
+    layer = cache.layers[layer_idx]  # transformers >= 5.x Cache
+    return layer.keys, layer.values
+
+
+def hf_cache_to_legacy(cache):
+    """Export a transformers Cache to the legacy tuple-of-(key, value) format."""
+    if hasattr(cache, "to_legacy_cache"):  # transformers < 5.x
+        return cache.to_legacy_cache()
+    return tuple((layer.keys, layer.values) for layer in cache.layers)  # transformers >= 5.x
+
+
+def hf_dynamic_cache_from_legacy(layer_kvs):
+    """Build a transformers DynamicCache from per-layer (key, value) tuples."""
+    from transformers import DynamicCache
+
+    layer_kvs = tuple(layer_kvs)
+    if hasattr(DynamicCache, "from_legacy_cache"):  # transformers < 5.x
+        return DynamicCache.from_legacy_cache(layer_kvs)
+    return DynamicCache(layer_kvs)  # transformers >= 5.x
+
+
+def hf_cache_num_layers(cache):
+    """Number of populated layers in a transformers Cache (version-tolerant)."""
+    return len(cache.key_cache) if hasattr(cache, "key_cache") else len(cache.layers)
+
+
+def hf_empty_encoder_decoder_cache():
+    """Create an empty transformers EncoderDecoderCache (version-tolerant)."""
+    from transformers import DynamicCache, EncoderDecoderCache
+
+    if hasattr(EncoderDecoderCache, "from_legacy_cache"):  # transformers < 5.x
+        return EncoderDecoderCache.from_legacy_cache(None)
+    return EncoderDecoderCache(DynamicCache(), DynamicCache())  # transformers >= 5.x

--- a/models/experimental/llama32_1b_quasar/utils.py
+++ b/models/experimental/llama32_1b_quasar/utils.py
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import torch.nn.functional as F
+from torch import Tensor
+
+# Backward compatibility: filter_none moved to models.experimental.llama32_1b_quasar.sampling._utils
+from models.experimental.llama32_1b_quasar.sampling._utils import filter_none  # noqa: F401
+
+# Backward compatibility: LogProbsCalculator moved to models.experimental.llama32_1b_quasar.sampling.tt_log_probs
+from models.experimental.llama32_1b_quasar.sampling.tt_log_probs import LogProbsCalculator  # noqa: F401
+
+
+def top_k_top_p_filtering(
+    logits: Tensor,
+    top_k: int = 0,
+    top_p: float = 1.0,
+    filter_value: float = -float("Inf"),
+    min_tokens_to_keep: int = 1,
+) -> Tensor:
+    """Filter a distribution of logits using top-k and/or nucleus (top-p) filtering
+    Args:
+        logits: logits distribution shape (batch size, vocabulary size)
+        if top_k > 0: keep only top k tokens with highest probability (top-k filtering).
+        if top_p < 1.0: keep the top tokens with cumulative probability >= top_p (nucleus filtering).
+            Nucleus filtering is described in Holtzman et al. (http://arxiv.org/abs/1904.09751)
+        Make sure we keep at least min_tokens_to_keep per batch example in the output
+    From: https://gist.github.com/thomwolf/1a5a29f6962089e871b94cbd09daf317
+    """
+    if top_k > 0:
+        top_k = min(max(top_k, min_tokens_to_keep), logits.size(-1))  # Safety check
+        # Remove all tokens with a probability less than the last token of the top-k
+        indices_to_remove = logits < torch.topk(logits, top_k)[0][..., -1, None]
+        logits[indices_to_remove] = filter_value
+
+    if top_p < 1.0:
+        sorted_logits, sorted_indices = torch.sort(logits, descending=True)
+        cumulative_probs = torch.cumsum(F.softmax(sorted_logits, dim=-1), dim=-1)
+
+        # Remove tokens with cumulative probability above the threshold (token with 0 are kept)
+        sorted_indices_to_remove = cumulative_probs > top_p
+        if min_tokens_to_keep > 1:
+            # Keep at least min_tokens_to_keep (set to min_tokens_to_keep-1 because we add the first one below)
+            sorted_indices_to_remove[..., :min_tokens_to_keep] = 0
+        # Shift the indices to the right to keep also the first token above the threshold
+        sorted_indices_to_remove[..., 1:] = sorted_indices_to_remove[..., :-1].clone()
+        sorted_indices_to_remove[..., 0] = 0
+
+        # scatter sorted tensors to original indexing
+        indices_to_remove = sorted_indices_to_remove.scatter(1, sorted_indices, sorted_indices_to_remove)
+        logits[indices_to_remove] = filter_value
+    return logits


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

Feature

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->
- Closes #51177 
- Updates codeowners
- Copies over lama32_1b at models/common/models/llama32_1b and all of its dependencies, from various locations, e.g.
models/common/models/executor.py
models/common/models/generator.py
models/common/modules
models/common/sampling
models/common/tests/demos/llama32_1b

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

This is a mostly self-contained copy (nothing calls it although CI jobs will be added later, although it does depend on some files outside of the copy), with some refactoring to address AI comments, to use pytest.raises, and to use the files copied over for imports instead of the originals.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=bbradel-51177_llamaq)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:bbradel-51177_llamaq)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=bbradel-51177_llamaq)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:bbradel-51177_llamaq)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=bbradel-51177_llamaq)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:bbradel-51177_llamaq)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bbradel-51177_llamaq)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bbradel-51177_llamaq)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=bbradel-51177_llamaq)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:bbradel-51177_llamaq)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bbradel-51177_llamaq)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bbradel-51177_llamaq)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bbradel-51177_llamaq)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bbradel-51177_llamaq)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bbradel-51177_llamaq)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bbradel-51177_llamaq)