### PR TITLE
[Quasar] Unary broadcast unpack to dest support

### DIFF
--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_unary_datacopy_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_unary_datacopy_api.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include "llk_math_common_api.h"
 #include "llk_math_eltwise_unary_datacopy.h"
 #include "llk_math_unary_broadcast.h"
@@ -50,9 +51,17 @@ inline void llk_math_eltwise_unary_datacopy_init(const std::uint32_t operand) {
         }
     } else {
         static_assert(type == DataCopyType::B2D);
+        static_assert(
+            !(EN_32BIT_DEST && !unpack_to_dest),
+            "32BIT_DEST is not supported for broadcast when unpack_to_dest is false");
+
         const ckernel::TensorShape tensor_shape = get_operand_tensor_shape(operand);
-        _llk_math_eltwise_unary_broadcast_init_<src_b_bcast_type, false /*unpack_to_dest*/, EN_32BIT_DEST>(
-            tensor_shape);
+        LLK_ASSERT(
+            tensor_shape.face_r_dim == MAX_FACE_R_DIM && tensor_shape.num_faces_r_dim == MAX_NUM_FACES_R_DIM &&
+                tensor_shape.num_faces_c_dim == MAX_NUM_FACES_C_DIM,
+            "Unary broadcast currently only supports 32x32 tiles (face_r_dim=16, 2x2 faces)");
+
+        _llk_math_eltwise_unary_broadcast_init_<src_b_bcast_type, false /*unpack_to_dest*/>(tensor_shape);
     }
 }
 
@@ -82,7 +91,7 @@ inline void llk_math_eltwise_unary_datacopy(const std::uint32_t dst_index, const
     if constexpr (src_b_bcast_type != BroadcastType::NONE && !unpack_to_dest) {
         static_assert(type == DataCopyType::B2D, "Unary broadcast math path requires DataCopyType::B2D");
         const ckernel::TensorShape tensor_shape = get_operand_tensor_shape(operand);
-        _llk_math_eltwise_unary_broadcast_<src_b_bcast_type, false, EN_32BIT_DEST>(dst_index, tensor_shape);
+        _llk_math_eltwise_unary_broadcast_(dst_index);
     } else {
         // 32-bit unpack-to-dest: math is a sync-only forwarder (unpacker wrrites DEST), no MOP to run.
         if constexpr (!unpack_to_dest) {

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_A_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_A_api.h
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+#include <cstdint>
 #include "llk_unpack_common_api.h"
 #include "llk_unpack_unary_broadcast_operands.h"
 #include "llk_unpack_unary_operand.h"
@@ -26,7 +27,8 @@
  * @tparam BType: Broadcast type; BroadcastType::NONE selects the plain unary path
  * @tparam acc_to_dest: Unused on Quasar in dest-reuse path; kept for API parity
  * @tparam binary_reuse_dest: Dest reuse mode; when not NONE, selects the dest-reuse sub-path
- * @tparam unpack_to_dest: When true, the (non-broadcast) primitive routes the operand through UNP_DEST regardless of format
+ * @tparam unpack_to_dest: When true, the (non-broadcast) primitive routes the operand through UNP_DEST regardless of
+ * format
  * @param transpose_of_faces: Non-zero enables transpose of 16x16 faces (unary/broadcast NONE path only)
  * @param within_face_16x16_transpose: Unused on Quasar; kept for API parity with Blackhole / other arches
  * @param operand: The input operand logical dataflow buffer / CB id
@@ -78,10 +80,15 @@ inline void llk_unpack_A_init(
                     operand_id, tensor_shape, 1);
             }
         } else {
+            static_assert(
+                !(DST_ACCUM_MODE && !unpack_to_dest),
+                "32BIT_DEST is not supported for broadcast when unpack_to_dest is false");
+            LLK_ASSERT(
+                tensor_shape.face_r_dim == MAX_FACE_R_DIM && tensor_shape.num_faces_r_dim == MAX_NUM_FACES_R_DIM &&
+                    tensor_shape.num_faces_c_dim == MAX_NUM_FACES_C_DIM,
+                "Unary broadcast currently only supports 32x32 tiles (face_r_dim=16, 2x2 faces)");
             constexpr std::uint32_t unp_sel = unpack_to_dest ? p_unpacr::UNP_A : p_unpacr::UNP_B;
-            constexpr bool is_fp32_dest_acc_en = unpack_to_dest ? false : DST_ACCUM_MODE;
-            _llk_unpack_unary_broadcast_operands_init_<unp_sel, BType, unpack_to_dest, is_fp32_dest_acc_en>(
-                operand_id, 1);
+            _llk_unpack_unary_broadcast_operands_init_<unp_sel, BType, unpack_to_dest>(operand_id, 1);
         }
     }
 }
@@ -96,7 +103,8 @@ inline void llk_unpack_A_init(
  * @tparam BType: Broadcast type; BroadcastType::NONE selects the plain unary path
  * @tparam acc_to_dest: Unused on Quasar; kept for API parity with Blackhole / other arches
  * @tparam binary_reuse_dest: Dest reuse mode (unary path only)
- * @tparam unpack_to_dest: when true, the (non-broadcast) primitive routes the operand through UNP_DEST regardless of format
+ * @tparam unpack_to_dest: when true, the (non-broadcast) primitive routes the operand through UNP_DEST regardless of
+ * format
  * @param operand: The logical dataflow buffer id
  * @param tile_index: The index in the input CB to read from
  */
@@ -133,7 +141,8 @@ inline void llk_unpack_A(const std::uint32_t operand, const std::uint32_t tile_i
  * @tparam BType: Broadcast type; BroadcastType::NONE selects the plain unary path
  * @tparam acc_to_dest: Unused on Quasar; kept for API parity with Blackhole / other arches
  * @tparam binary_reuse_dest: Dest reuse mode (unary path only)
- * @tparam unpack_to_dest: when true, the (non-broadcast) primitive routes the operand through UNP_DEST regardless of format
+ * @tparam unpack_to_dest: when true, the (non-broadcast) primitive routes the operand through UNP_DEST regardless of
+ * format
  * @param operand: The logical dataflow buffer id
  * @param start_tile_index: The starting tile index within the input buffer
  * @param ntiles: The number of consecutive tiles to unpack
@@ -150,7 +159,7 @@ inline void llk_unpack_A_block(
     const LocalDFBInterface& local_dfb_interface = get_local_dfb_interface(operand_id);
     const std::uint32_t rd_entry_idx = local_dfb_interface.tc_slots[local_dfb_interface.tc_idx].rd_entry_idx;
     const ckernel::TensorShape tensor_shape = get_operand_tensor_shape(operand_id);
-    for (uint32_t tile_index = start_tile_index; tile_index < start_tile_index + ntiles; tile_index++) {
+    for (std::uint32_t tile_index = start_tile_index; tile_index < start_tile_index + ntiles; tile_index++) {
         WAYPOINT("UPAW");
         if constexpr (BType == BroadcastType::NONE) {
             if constexpr (unpack_to_dest) {

--- a/tt_metal/tt-llk/tests/python_tests/helpers/param_config.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/param_config.py
@@ -10,6 +10,7 @@ import pytest
 from helpers.tile_shape import construct_tile_shape
 from typing_extensions import deprecated
 
+from .chip_architecture import ChipArchitecture, get_chip_architecture
 from .data_format_inference import is_format_combination_outlier
 from .format_config import (
     DataFormat,
@@ -653,8 +654,11 @@ def get_num_blocks_and_num_tiles_in_block(
     num_rows_tensor, num_cols_tensor = input_dimensions
     num_rows_tile, num_cols_tile = tile_dimensions
 
-    is_outlier = is_format_combination_outlier(
-        formats.input_format, formats.output_format, dest_acc
+    is_outlier = (
+        is_format_combination_outlier(
+            formats.input_format, formats.output_format, dest_acc
+        )
+        and get_chip_architecture() != ChipArchitecture.QUASAR
     )
 
     capacity_divisor = (

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_unary_broadcast_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_unary_broadcast_quasar.py
@@ -93,7 +93,7 @@ UNARY_BROADCAST_FORMATS = input_output_formats(
         DataFormat.MxInt4,
         DataFormat.MxInt2,
     ],
-    same=True, # input_fmt != output_fmt not tested, ISSUE: #47560
+    same=True,  # input_fmt != output_fmt not tested, ISSUE: #47560
 )
 
 

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_unary_broadcast_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_unary_broadcast_quasar.py
@@ -3,7 +3,6 @@
 
 import pytest
 import torch
-from helpers.constraints import get_valid_dest_accumulation_modes
 from helpers.format_config import DataFormat
 from helpers.golden_generators import (
     BroadcastGolden,
@@ -15,6 +14,7 @@ from helpers.llk_params import (
     DestSync,
     ImpliedMathFormat,
     PerfRunType,
+    UnpackerEngine,
     format_dict,
 )
 from helpers.param_config import (
@@ -26,6 +26,7 @@ from helpers.param_config import (
 )
 from helpers.perf import PerfConfig
 from helpers.stimuli_config import StimuliConfig
+from helpers.stimuli_generator import StimuliSpec, generate_stimuli
 from helpers.test_config import BootMode, TestConfig
 from helpers.test_variant_parameters import (
     BROADCAST_TYPE,
@@ -40,6 +41,7 @@ from helpers.test_variant_parameters import (
     PERF_RUN_TYPE,
     TEST_FACE_DIMS,
     TILE_COUNT,
+    UNPACKER_ENGINE_SEL,
     generate_input_dim,
 )
 from helpers.tile_constants import FACE_C_DIM, get_tile_params
@@ -47,6 +49,24 @@ from helpers.utils import passed_test
 
 INPUT_DIMENSIONS = [[512, 32]]
 TILE_DIMENSIONS = [32, 32]
+
+_FLOAT32_WIDE_RANGE = 10_000.0
+
+
+def _wide_range_spec(fmt: DataFormat):
+    """Return a ``StimuliSpec`` with a wider-than-default range for 32-bit formats.
+
+    The exact bounds are arbitrary but chosen to stress-test with a broader
+    range of values than the generator defaults provide.  Non-32-bit formats
+    return ``None`` so the generator falls back to its own defaults.
+    """
+    if not fmt.is_32_bit():
+        return None
+    if fmt.is_integer():
+        hi = float(torch.iinfo(format_dict[fmt]).max) * 0.9
+    else:
+        hi = _FLOAT32_WIDE_RANGE
+    return StimuliSpec.uniform(low=-hi, high=hi)
 
 
 def unary_broadcast_dest_sync_modes(*, is_perf=False):
@@ -64,26 +84,26 @@ def unary_broadcast_implied_math_formats(formats, *, is_perf=False):
 UNARY_BROADCAST_FORMATS = input_output_formats(
     [
         DataFormat.Float16_b,
-        # DataFormat.Float32, Buggy functionality for Float32 (unpack_to_dest=True) tbd
+        DataFormat.Float32,
         DataFormat.MxFp8R,
         DataFormat.MxFp8P,
         DataFormat.MxFp4,
+        DataFormat.Int32,
         DataFormat.MxInt8,
         DataFormat.MxInt4,
         DataFormat.MxInt2,
     ],
-    same=True,
+    same=True, # input_fmt != output_fmt not tested, ISSUE: #47560
 )
 
 
 def get_valid_dest_acc_unary_broadcast(formats):
     """Valid dest accumulation modes for unary broadcast."""
-    accs = list(get_valid_dest_accumulation_modes(formats))
     if formats.input_format.is_32_bit():
-        accs = [a for a in accs if a == DestAccumulation.Yes]
-    elif formats.output_format == DataFormat.Float32:
-        accs = [a for a in accs if a == DestAccumulation.Yes]
-    return accs if accs else [DestAccumulation.Yes]
+        return [DestAccumulation.Yes]
+    return [
+        DestAccumulation.No
+    ]  # 32bit dest is not supported for the unpack_to_dest=False case, ISSUE: #47560
 
 
 @pytest.mark.quasar
@@ -115,6 +135,10 @@ def test_unary_broadcast_quasar(
     is_perf=False,
     perf_report=None,
 ):
+    unpack_to_dest = (
+        formats.input_format.is_32_bit() and dest_acc == DestAccumulation.Yes
+    )
+
     tile_rows, tile_cols = TILE_DIMENSIONS
     face_r_dim, num_faces_r_dim, num_faces_c_dim = get_tile_params(
         [tile_rows, tile_cols]
@@ -134,8 +158,16 @@ def test_unary_broadcast_quasar(
         BlocksCalculationAlgorithm.Standard,
     )
 
-    torch_format = format_dict[formats.input_format]
-    src_B = torch.randn(num_elements, dtype=torch_format)
+    spec = _wide_range_spec(formats.input_format)
+    src_A, _, src_B, _ = generate_stimuli(
+        stimuli_format_A=formats.input_format,
+        input_dimensions_A=input_dimensions,
+        stimuli_format_B=formats.input_format,
+        input_dimensions_B=input_dimensions,
+        spec_A=spec,
+        spec_B=spec,
+        tile_dimensions=TILE_DIMENSIONS,
+    )
 
     if not is_perf:
         generate_broadcast_golden = get_golden_generator(BroadcastGolden)
@@ -148,20 +180,19 @@ def test_unary_broadcast_quasar(
             face_r_dim=face_r_dim,
         )
 
-    unpack_to_dest = (
-        formats.input_format.is_32_bit() and dest_acc == DestAccumulation.Yes
-    )
-
     src_A = src_B
 
     if is_perf and perf_report is None:
         raise ValueError("perf_report must be provided when is_perf=True")
+
+    unpacker_sel = UnpackerEngine.UnpA if unpack_to_dest else UnpackerEngine.UnpB
 
     test_config_kwargs = {
         "test_name": "sources/quasar/eltwise_unary_broadcast_quasar_test.cpp",
         "formats": formats,
         "templates": [
             IMPLIED_MATH_FORMAT(implied_math_format),
+            UNPACKER_ENGINE_SEL(unpacker_sel),
             BROADCAST_TYPE(broadcast_type),
             DEST_SYNC(dest_sync_mode),
         ],
@@ -200,7 +231,6 @@ def test_unary_broadcast_quasar(
         ),
         "unpack_to_dest": unpack_to_dest,
         "dest_acc": dest_acc,
-        "disable_format_inference": (implied_math_format == ImpliedMathFormat.Yes),
     }
 
     if is_perf:

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_broadcast_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_broadcast_quasar_test.cpp
@@ -13,11 +13,6 @@
 #include "quasar_test_common.h"
 #include "sfpu_stub.h"
 
-// Globals
-std::uint32_t unp_cfg_context          = 0;
-std::uint32_t pack_sync_tile_dst_ptr   = 0;
-std::uint32_t math_sync_tile_dst_index = 0;
-
 #ifdef LLK_TRISC_UNPACK
 
 #include "llk_math_common.h"
@@ -33,8 +28,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #ifndef SPEED_OF_LIGHT
     const std::uint32_t LOOP_FACTOR              = params.LOOP_FACTOR;
     const std::uint32_t TILE_CNT                 = params.TILE_CNT;
-    const std::uint32_t INPUT_NUM_BLOCKS         = params.INPUT_NUM_BLOCKS;
-    const std::uint32_t INPUT_NUM_TILES_IN_BLOCK = params.INPUT_NUM_TILES_IN_BLOCK;
+    const std::uint32_t num_blocks               = params.INPUT_NUM_BLOCKS;
+    const std::uint32_t tiles_in_block       = params.INPUT_NUM_TILES_IN_BLOCK;
     const int num_faces_r_dim_A                  = params.num_faces_r_dim_A;
     const int num_faces_c_dim_A                  = params.num_faces_c_dim_A;
     const Operand& buffer_B                      = params.buffer_B;
@@ -42,7 +37,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
     tdma_descriptor_t td_val_A, td_val_B;
     const std::uint32_t buf_desc_id_a        = 0;
     const std::uint32_t buf_desc_id_b        = 1;
-    const std::uint32_t num_tiles_per_unpack = TILE_CNT;
+    // Unpack to dest must use the num tiles per unpack parameter in order to unpack multiple tiles per Dest bank
+    const std::uint32_t num_tiles_per_unpack = unpack_to_dest ? tiles_in_block : 1;
 
     {
         ZONE_SCOPED("INIT")
@@ -50,7 +46,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         {
             if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1)
             {
-                set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::UNPACK, dest_dvalid_client::PACK});
+                set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::UNPACK, dest_dvalid_client::FPU, dest_dvalid_client::PACK});
             }
             else
             {
@@ -58,7 +54,10 @@ void run_kernel(RUNTIME_PARAMETERS params)
                 // the L1_TO_L1 unpack-to-dest handshake.
                 set_up_zero_dest_dvalid_handshake_for_unpack();
             }
-            _llk_math_upk_to_dest_hw_configure_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en, false /*is_int_fpu_en*/>();
+        }
+        else
+        {
+            set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
         }
 
         const ckernel::TensorShape tensor_shape = TENSOR_SHAPE_FROM_PARAMS(params);
@@ -69,39 +68,18 @@ void run_kernel(RUNTIME_PARAMETERS params)
         _configure_buf_desc_table_(td_val_A.buf_desc_id, td_val_A.buf_desc);
         _configure_buf_desc_table_(td_val_B.buf_desc_id, td_val_B.buf_desc);
 
-        if constexpr (is_fp32_dest_acc_en)
+        if constexpr (is_fp32_dest_acc_en && !unpack_to_dest)
         {
-            if constexpr (unpack_to_dest)
-            {
-                _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(td_val_A, td_val_B);
-            }
-            else
-            {
-                _llk_unpack_configure_unary_<p_unpacr::UNP_B>(td_val_B);
-            }
+            // If Dst fmt is 32b and operation is Mov2D, we need both SrcA/B fmts to be configured since Mov2D will be implemented via ELWADD
+            _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(td_val_A, td_val_B);
         }
         else
         {
-            if constexpr (unpack_to_dest)
-            {
-                _llk_unpack_configure_unary_<p_unpacr::UNP_A>(td_val_A);
-            }
-            else
-            {
-                _llk_unpack_configure_unary_<p_unpacr::UNP_B>(td_val_B);
-            }
+            _llk_unpack_configure_unary_<UNPACKER_ENGINE_SEL>(unpack_to_dest ? td_val_A : td_val_B);
         }
+        _llk_unpack_unary_broadcast_operands_init_<UNPACKER_ENGINE_SEL, BROADCAST_TYPE, unpack_to_dest>(
+                unpack_to_dest ? buf_desc_id_a : buf_desc_id_b, num_tiles_per_unpack);
 
-        if constexpr (unpack_to_dest)
-        {
-            _llk_unpack_unary_broadcast_operands_init_<p_unpacr::UNP_A, BROADCAST_TYPE, unpack_to_dest, is_fp32_dest_acc_en>(
-                buf_desc_id_a, 1 /*num_tiles_per_unpack*/);
-        }
-        else
-        {
-            _llk_unpack_unary_broadcast_operands_init_<p_unpacr::UNP_B, BROADCAST_TYPE, unpack_to_dest, is_fp32_dest_acc_en>(
-                buf_desc_id_b, 1 /*num_tiles_per_unpack*/);
-        }
         PROFILER_SYNC();
     }
     {
@@ -122,16 +100,17 @@ void run_kernel(RUNTIME_PARAMETERS params)
         {
             for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
             {
-                for (std::uint32_t block = 0; block < INPUT_NUM_BLOCKS; block++)
+                for (std::uint32_t block = 0; block < num_blocks; block++)
                 {
-                    for (std::uint32_t tile = 0; tile < INPUT_NUM_TILES_IN_BLOCK; tile++)
-                    {
-                        const std::uint32_t input_tile_idx = (block * INPUT_NUM_TILES_IN_BLOCK) + tile;
-                        _llk_unpack_unary_broadcast_operands_<p_unpacr::UNP_A, unpack_to_dest>(input_tile_idx);
-                    }
+                    const std::uint32_t input_tile_idx = block * tiles_in_block;
+                    _llk_unpack_unary_broadcast_operands_<UNPACKER_ENGINE_SEL, unpack_to_dest>(input_tile_idx);
                     if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1)
                     {
                         _llk_unpack_dest_dvalid_section_done_<dest_sync>();
+                    }
+                    for (std::uint32_t tile = 0; tile < tiles_in_block; tile++)
+                    {
+                        _llk_unpack_set_srcB_dummy_valid_();
                     }
                 }
             }
@@ -140,9 +119,13 @@ void run_kernel(RUNTIME_PARAMETERS params)
         {
             for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
             {
-                for (std::uint32_t i = 0; i < num_tiles_per_unpack; ++i)
+                for (std::uint32_t block = 0; block < num_blocks; block++)
                 {
-                    _llk_unpack_unary_broadcast_operands_<p_unpacr::UNP_B, unpack_to_dest>(i);
+                    for (std::uint32_t tile = 0; tile < tiles_in_block; tile++)
+                    {
+                        const std::uint32_t input_tile_idx = (block * tiles_in_block) + tile;
+                        _llk_unpack_unary_broadcast_operands_<UNPACKER_ENGINE_SEL, unpack_to_dest>(input_tile_idx);
+                    }
                 }
             }
         }
@@ -169,72 +152,87 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #ifndef SPEED_OF_LIGHT
     const std::uint32_t LOOP_FACTOR               = params.LOOP_FACTOR;
     const std::uint32_t num_faces                 = params.num_faces;
-    const std::uint32_t OUTPUT_NUM_TILES_IN_BLOCK = params.OUTPUT_NUM_TILES_IN_BLOCK;
-    const std::uint32_t INPUT_NUM_BLOCKS          = params.INPUT_NUM_BLOCKS;
+    const std::uint32_t tiles_in_block = params.OUTPUT_NUM_TILES_IN_BLOCK;
+    const std::uint32_t num_blocks          = params.INPUT_NUM_BLOCKS;
 #endif
+    const DataFormat math_format     = static_cast<DataFormat>(formats.math);
+    const DataFormat pack_src_format = static_cast<DataFormat>(formats.pack_src);
+    const ckernel::TensorShape tensor_shape = TENSOR_SHAPE_FROM_PARAMS(params);
 
-    if constexpr (!unpack_to_dest)
     {
+        ZONE_SCOPED("INIT")
+        if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1)
         {
-            ZONE_SCOPED("INIT")
-            // Only end-to-end and math-isolate runs use the FPU→PACK dest-dvalid handshake.
-            if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1 || PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
+            if constexpr (unpack_to_dest)
             {
-                set_up_dest_dvalid_per_thread<dest_dvalid_client::FPU>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
-            }
-
-            DataFormat src_format = static_cast<DataFormat>(formats.math);
-            _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en, false /*int32_dest*/>(src_format, src_format);
-
-            const ckernel::TensorShape tensor_shape = TENSOR_SHAPE_FROM_PARAMS(params);
-
-            _llk_math_eltwise_unary_broadcast_init_<BROADCAST_TYPE, unpack_to_dest, is_fp32_dest_acc_en>(tensor_shape);
-            PROFILER_SYNC();
-        }
-        {
-            ZONE_SCOPED("TILE_LOOP")
-            const ckernel::TensorShape tensor_shape = TENSOR_SHAPE_FROM_PARAMS(params);
-
-            const std::uint32_t tiles_in_block = OUTPUT_NUM_TILES_IN_BLOCK;
-            const std::uint32_t num_blocks     = static_cast<std::uint32_t>(INPUT_NUM_BLOCKS);
-
-            if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE)
-            {
-            }
-            else if constexpr (PERF_RUN_TYPE == PerfRunType::UNPACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
-            {
-                const std::uint32_t dvalids_per_tile = (BROADCAST_TYPE == BroadcastType::SCALAR) ? 1u : num_faces;
-                _perf_math_loop_clear_valid<false /*clear_a*/, true /*clear_b*/>(LOOP_FACTOR * num_blocks * tiles_in_block * dvalids_per_tile);
-            }
-            else if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
-            {
-                for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
-                {
-                    for (std::uint32_t block = 0; block < num_blocks; block++)
-                    {
-                        for (std::uint32_t tile = 0; tile < tiles_in_block; tile++)
-                        {
-                            _llk_math_eltwise_unary_broadcast_<BROADCAST_TYPE, unpack_to_dest, is_fp32_dest_acc_en>(tile, tensor_shape);
-                        }
-                    }
-                }
+                set_up_dest_dvalid_per_thread<dest_dvalid_client::FPU>({dest_dvalid_client::UNPACK, dest_dvalid_client::FPU, dest_dvalid_client::PACK});
             }
             else
             {
-                for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
+                set_up_dest_dvalid_per_thread<dest_dvalid_client::FPU>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
+            }
+        }
+        else if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE && unpack_to_dest)
+        {
+            // L1_TO_L1 leaves FPU configured as the middle client in the
+            // UNPACK→FPU→PACK chain. Math isolate has no unpack destination
+            // pulse, so make FPU the producer and restore immediate ownership
+            // of the destination register.
+            set_up_dest_dvalid_per_thread<dest_dvalid_client::FPU>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
+        }
+
+        if (is_fp32_dest_acc_en && pack_src_format == DataFormat::Int32)
+        {
+            _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, false /*fp32_dest*/, true /*int32_dest*/>(math_format, math_format);
+        }
+        else
+        {
+            _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en, false /*int32_dest*/>(math_format, math_format);
+        }
+        _configure_mov_ops_explicit_alu_data_format_state_<is_fp32_dest_acc_en>(math_format, math_format);
+        _llk_math_eltwise_unary_broadcast_init_<BROADCAST_TYPE, unpack_to_dest>(tensor_shape);
+
+        PROFILER_SYNC();
+    }
+    {
+        ZONE_SCOPED("TILE_LOOP")
+
+        if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE)
+        {
+        }
+        else if constexpr (PERF_RUN_TYPE == PerfRunType::UNPACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
+        {
+            const std::uint32_t dvalids_per_tile = (BROADCAST_TYPE == BroadcastType::SCALAR) ? 1u : num_faces;
+            _perf_math_loop_clear_valid<false /*clear_a*/, true /*clear_b*/>(LOOP_FACTOR * num_blocks * tiles_in_block * dvalids_per_tile);
+        }
+        else if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
+        {
+            for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
+            {
+                for (std::uint32_t block = 0; block < num_blocks; block++)
                 {
-                    for (std::uint32_t block = 0; block < num_blocks; block++)
+                    for (std::uint32_t tile = 0; tile < tiles_in_block; tile++)
                     {
-                        for (std::uint32_t tile = 0; tile < tiles_in_block; tile++)
-                        {
-                            _llk_math_eltwise_unary_broadcast_<BROADCAST_TYPE, unpack_to_dest, is_fp32_dest_acc_en>(tile, tensor_shape);
-                        }
-                        _llk_math_set_dvalid_<p_cleardvalid::FPU, dest_sync>();
+                        _llk_math_eltwise_unary_broadcast_(tile);
                     }
                 }
             }
-            PROFILER_SYNC();
         }
+        else
+        {
+            for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
+            {
+                for (std::uint32_t block = 0; block < num_blocks; block++)
+                {
+                    for (std::uint32_t tile = 0; tile < tiles_in_block; tile++)
+                    {
+                        _llk_math_eltwise_unary_broadcast_(tile);
+                    }
+                    _llk_math_set_dvalid_<p_cleardvalid::FPU, dest_sync>();
+                }
+            }
+        }
+        PROFILER_SYNC();
     }
 }
 
@@ -253,12 +251,13 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #endif
 #ifndef SPEED_OF_LIGHT
     const std::uint32_t LOOP_FACTOR               = params.LOOP_FACTOR;
-    const std::uint32_t OUTPUT_NUM_BLOCKS         = params.OUTPUT_NUM_BLOCKS;
-    const std::uint32_t OUTPUT_NUM_TILES_IN_BLOCK = params.OUTPUT_NUM_TILES_IN_BLOCK;
+    const std::uint32_t output_num_blocks         = params.OUTPUT_NUM_BLOCKS;
+    const std::uint32_t output_tiles_in_block = params.OUTPUT_NUM_TILES_IN_BLOCK;
     const Operand& buffer_Res                     = params.buffer_Res;
 #endif
 
-    std::uint32_t const buf_desc_id = 8;
+    constexpr std::uint32_t buf_desc_id    = 8;
+    const std::uint32_t num_tiles_per_pack = 1;
 
     {
         ZONE_SCOPED("INIT")
@@ -273,7 +272,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         {
             if constexpr (unpack_to_dest)
             {
-                set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::UNPACK, dest_dvalid_client::PACK});
+                set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::UNPACK, dest_dvalid_client::FPU, dest_dvalid_client::PACK});
             }
             else
             {
@@ -288,15 +287,12 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
         _configure_buf_desc_table_(tdma_desc.buf_desc_id, tdma_desc.buf_desc);
         _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(tdma_desc, ckernel::ReluConfig::none());
-        _llk_pack_init_(buf_desc_id, tensor_shape, 1 /*num_tiles_per_pack*/);
+        _llk_pack_init_(buf_desc_id, tensor_shape, num_tiles_per_pack);
         PROFILER_SYNC();
     }
     {
         ZONE_SCOPED("TILE_LOOP")
         const ckernel::TensorShape tensor_shape = TENSOR_SHAPE_FROM_PARAMS(params);
-
-        const std::uint32_t output_num_blocks     = static_cast<std::uint32_t>(OUTPUT_NUM_BLOCKS);
-        const std::uint32_t output_tiles_in_block = OUTPUT_NUM_TILES_IN_BLOCK;
 
         if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE || PERF_RUN_TYPE == PerfRunType::UNPACK_ISOLATE)
         {

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_common.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_common.h
@@ -20,9 +20,12 @@ static DataFormatConfigSet data_format_config_set = DataFormatConfigSet::UNCONFI
  * @tparam EN_IMPLIED_MATH_FORMAT: If set to true, will imply math dest format from SrcA reg format
  * @tparam EN_FP32_MATH_FORMAT: Set to true to use math dest in Float32, otherwise default behaviour is Float16/Float16_b depending on input format exponent
  * width
- * @tparam EN_INT32_MATH_FORMAT: Set to true to use math dest in Int32, otherwise default behaviour is Float16/Float16_b depending on input format exponent width
- * @param srcA_format: Input srcA format, used to set ALU configs if not implied math format, values = DataFormat enum, ex: <Float16/Float16_b/Tf32/Int8/Int16/UInt8>
- * @param srcB_format: Input srcB format, used to set ALU configs if not implied math format, values = DataFormat enum, ex: <Float16/Float16_b/Tf32/Int8/Int16/UInt8>
+ * @tparam EN_INT32_MATH_FORMAT: Set to true to use math dest in Int32, otherwise default behaviour is Float16/Float16_b depending on input format exponent
+ * width
+ * @param srcA_format: Input srcA format, used to set ALU configs if not implied math format, values = DataFormat enum, ex:
+ * <Float16/Float16_b/Tf32/Int8/Int16/UInt8>
+ * @param srcB_format: Input srcB format, used to set ALU configs if not implied math format, values = DataFormat enum, ex:
+ * <Float16/Float16_b/Tf32/Int8/Int16/UInt8>
  */
 template <bool EN_IMPLIED_MATH_FORMAT, bool EN_FP32_MATH_FORMAT, bool EN_INT32_MATH_FORMAT>
 inline void _llk_math_srcAB_hw_configure_(DataFormat srcA_format, DataFormat srcB_format)
@@ -80,7 +83,8 @@ inline void _llk_math_srcAB_hw_configure_(DataFormat srcA_format, DataFormat src
  * @tparam EN_IMPLIED_MATH_FORMAT: If set to true, will imply math dest format from SrcA reg format
  * @tparam EN_FP32_MATH_FORMAT: Set to true to use math dest in Float32, otherwise default behaviour is Float16/Float16_b depending on input format exponent
  * width
- * @tparam EN_INT32_MATH_FORMAT: Set to true to use math dest in Int32, otherwise default behaviour is Float16/Float16_b depending on input format exponent width
+ * @tparam EN_INT32_MATH_FORMAT: Set to true to use math dest in Int32, otherwise default behaviour is Float16/Float16_b depending on input format exponent
+ * width
  */
 template <bool EN_IMPLIED_MATH_FORMAT, bool EN_FP32_MATH_FORMAT, bool EN_INT32_MATH_FORMAT>
 inline void _llk_math_upk_to_dest_hw_configure_()
@@ -249,9 +253,9 @@ inline void _configure_default_alu_data_format_state_(DataFormat srcA_format, Da
  * @param srcB_format: Input srcB format, used to set ALU configs
  * values = Dataformat enum, ex: <Float16/Float16_b/Tf32/Float32/Int8/Int16/UInt8/Int32>
  *
- * Special ALU data format config state used for: transpose dest.
+ * Special ALU data format config state used for: transpose dest and unary broadcast with unpack_to_dest=true.
  * Disables implied math format due to MOV op quirks. Sets en_int32_dest_format = false because ALU_ACC_CTRL_INT8_math_enabled
- * does not work with MOVD2A/B. When unpacking Int32 or Fp32 to dest, the ALU_FORMAT_SPEC SrcA/B cfg registers are set to Int32/Fp32.
+ * does not work with MOVD2A/B. When unpacking Int32 or Fp32 to dest, the ALU_FORMAT_SPEC SrcA/B cfg registers are set to Tf32.
  * @note For EN_32BIT_DEST, this forces the dest-format override (ALU_FORMAT_SPEC_REG_Dstacc_override -> Float32) so MOVD2B/MOVB2D
  * read DEST via the current 32b path instead of a stale saved dest format (e.g. Int32 left by a prior compute), which would
  * otherwise select the wrong hi16 datum mux and corrupt face 0. For 16-bit dest no override is applied (DataFormat::Invalid).
@@ -264,11 +268,14 @@ inline void _configure_mov_ops_explicit_alu_data_format_state_(DataFormat srcA_f
         return;
     }
 
+    const DataFormat mov_srcA_format = EN_32BIT_DEST ? DataFormat::Tf32 : srcA_format;
+    const DataFormat mov_srcB_format = EN_32BIT_DEST ? DataFormat::Tf32 : srcB_format;
+
     // For 32-bit dest, force the dest-format override to Float32 so the transpose MOVD2B/MOVB2D read
     // the DEST via the current Float32 32b path instead of a stale saved dest format (e.g. Int32 left
     // by a prior compute), which otherwise selects the wrong hi16 datum mux.
     _configure_alu_formats_<false /* EN_IMPLIED_MATH_FORMAT */, EN_32BIT_DEST>(
-        srcA_format, srcB_format, false /* en_int32_dest_format */, EN_32BIT_DEST ? DataFormat::Float32 : DataFormat::Invalid);
+        mov_srcA_format, mov_srcB_format, false /* en_int32_dest_format */, EN_32BIT_DEST ? DataFormat::Float32 : DataFormat::Invalid);
 
     data_format_config_set = DataFormatConfigSet::MOV_OPS_EXPLICIT_FMT;
 }

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_unary_broadcast.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_unary_broadcast.h
@@ -24,7 +24,7 @@ using namespace ckernel::math;
  * @tparam unpack_to_dest: When true, UNP_A wrote to dest; ADDR_MOD_3 used for dest<->srcB moves
  * @param tensor_shape: Face geometry (face_r_dim, num_faces) for row-broadcast addrmods
  */
-template <BroadcastType BROADCAST_TYPE, bool unpack_to_dest = false>
+template <BroadcastType BROADCAST_TYPE, bool unpack_to_dest>
 inline void _llk_math_eltwise_unary_broadcast_addrmod_(const TensorShape& tensor_shape)
 {
     static_assert(BROADCAST_TYPE != BroadcastType::NONE, "Broadcast type cannot be NONE");
@@ -49,24 +49,39 @@ inline void _llk_math_eltwise_unary_broadcast_addrmod_(const TensorShape& tensor
         if constexpr (BROADCAST_TYPE == BroadcastType::ROW)
         {
             addr_mod_t {
-                .srcb = {.incr = static_cast<std::uint8_t>(tensor_shape.face_r_dim)},
+                .srcb = {.incr = 0},
                 .dest = {.incr = static_cast<std::uint16_t>(tensor_shape.face_r_dim)},
+            }
+                .set(ADDR_MOD_3);
+        }
+        else if constexpr (BROADCAST_TYPE == BroadcastType::COL)
+        {
+            addr_mod_t {
+                .srcb = {.incr = 0},
+                .dest = {.incr = static_cast<std::uint16_t>(tensor_shape.face_r_dim * tensor_shape.num_faces_c_dim)},
             }
                 .set(ADDR_MOD_3);
         }
         else
         {
             addr_mod_t {
-                .srcb = {.incr = static_cast<std::uint8_t>(ELTWISE_MATH_ROWS)},
-                .dest = {.incr = static_cast<std::uint16_t>(ELTWISE_MATH_ROWS)},
+                .srcb = {.incr = 0},
+                .dest = {.incr = row_step},
             }
                 .set(ADDR_MOD_3);
         }
+
+        addr_mod_t {
+            .srca = {.incr = 0},
+            .srcb = {.incr = 0},
+            .dest = {.incr = 0},
+        }
+            .set(ADDR_MOD_4);
     }
 }
 
 /**
- * @brief MOP / replay configuration for MOVB2D unary-broadcast (srcB -> dest).
+ * @brief MOP / replay configuration for unary math broadcast.
  *
  * @tparam BROADCAST_TYPE: Scalar, row, or column broadcast, values = <COL/ROW/SCALAR>
  * @tparam unpack_to_dest: When true, unpack filled dest; MOVB2D reads srcB only, so @ref _llk_math_eltwise_unary_broadcast_ runs MOVD2B (dest->srcB) first,
@@ -74,59 +89,121 @@ inline void _llk_math_eltwise_unary_broadcast_addrmod_(const TensorShape& tensor
  *         ADDR_MOD_3 from addrmod.
  * @param tensor_shape: Tile shape for loop counts and row dimensions
  */
-template <BroadcastType BROADCAST_TYPE, bool unpack_to_dest = false>
+template <BroadcastType BROADCAST_TYPE, bool unpack_to_dest>
 inline void _llk_math_eltwise_unary_broadcast_mop_config_(const TensorShape& tensor_shape)
 {
     static_assert(BROADCAST_TYPE != BroadcastType::NONE, "Broadcast type cannot be NONE");
 
-    if constexpr (BROADCAST_TYPE == BroadcastType::ROW && unpack_to_dest)
+    if constexpr (unpack_to_dest)
     {
-        constexpr std::uint32_t replay_buf_start          = 1;
-        constexpr std::uint32_t replay_movb2d_instr_count = ELTWISE_MATH_ROWS;
-        constexpr std::uint32_t replay_buf_len            = replay_movb2d_instr_count;
-        load_replay_buf<replay_buf_start, replay_buf_len>(
-            []
-            {
-                TTI_MOVB2D(0, 0, ADDR_MOD_0, p_mov_src_to_dest::MOV_8_ROWS, 0, 1);
-                TTI_MOVB2D(0, 0, ADDR_MOD_2, p_mov_src_to_dest::MOV_8_ROWS, 0, 1);
-                TTI_MOVB2D(0, 0, ADDR_MOD_0, p_mov_src_to_dest::MOV_8_ROWS, 0, 1);
-                TTI_MOVB2D(0, 0, ADDR_MOD_1, p_mov_src_to_dest::MOV_8_ROWS, 0, 1);
-                TTI_MOVB2D(0, 0, ADDR_MOD_0, p_mov_src_to_dest::MOV_8_ROWS, 0, 1);
-                TTI_MOVB2D(0, 0, ADDR_MOD_2, p_mov_src_to_dest::MOV_8_ROWS, 0, 1);
-                TTI_MOVB2D(0, 0, ADDR_MOD_0, p_mov_src_to_dest::MOV_8_ROWS, 0, 1);
-                TTI_MOVB2D(0, 0, ADDR_MOD_2, p_mov_src_to_dest::MOV_8_ROWS, 0, 1);
-            });
+        if constexpr (BROADCAST_TYPE == BroadcastType::COL)
+        {
+            constexpr std::uint32_t replay_buf_len = 12;
+            load_replay_buf<0, replay_buf_len>(
+                []
+                {
+                    // Read F0/F2 hi16 from DEST → SrcB[0:15]
+                    TTI_MOVD2B(p_mov::DEST_NORM, 0, ADDR_MOD_4, p_movd2b::MOV_8_ROWS, p_movd2b::TRANSPOSE_OFF, 0);
+                    TTI_MOVD2B(p_mov::DEST_NORM, 8, ADDR_MOD_4, p_movd2b::MOV_8_ROWS, p_movd2b::TRANSPOSE_OFF, 8);
 
-        ckernel_template temp(1, 1, TT_OP_REPLAY(replay_buf_start, replay_buf_len, 0, 0, 0, 0));
-        temp.set_end_op(TT_OP_CLEARDVALID(p_cleardvalid::CLR_SRCB_VLD, 0, 0, 0, 0, 0));
-        temp.program_bank0_sw_cntl(instrn_buffer);
+                    // Read F0/F2 lo16 from DEST → SrcB[16:31]
+                    TTI_MOVD2B(p_mov::DEST_32B_LOW, 16, ADDR_MOD_4, p_movd2b::MOV_8_ROWS, p_movd2b::TRANSPOSE_OFF, 0);
+                    TTI_MOVD2B(p_mov::DEST_32B_LOW, 24, ADDR_MOD_4, p_movd2b::MOV_8_ROWS, p_movd2b::TRANSPOSE_OFF, 8);
+
+                    // Write hi16 to DEST F0,F1/F2,F3 from SrcB[0:31] (column broadcast ON)
+                    TTI_MOVB2D(p_mov::DEST_NORM, 0, ADDR_MOD_4, p_mov_src_to_dest::MOV_8_ROWS, p_movb2d::BCAST_ON, 0);
+                    TTI_MOVB2D(p_mov::DEST_NORM, 8, ADDR_MOD_4, p_mov_src_to_dest::MOV_8_ROWS, p_movb2d::BCAST_ON, 8);
+                    TTI_MOVB2D(p_mov::DEST_NORM, 0, ADDR_MOD_4, p_mov_src_to_dest::MOV_8_ROWS, p_movb2d::BCAST_ON, 16);
+                    TTI_MOVB2D(p_mov::DEST_NORM, 8, ADDR_MOD_4, p_mov_src_to_dest::MOV_8_ROWS, p_movb2d::BCAST_ON, 24);
+
+                    // Write lo16 to DEST F0,F1/F2,F3 from SrcB[0:31] (column broadcast ON)
+                    TTI_MOVB2D(p_mov::DEST_32B_LOW, 16, ADDR_MOD_4, p_mov_src_to_dest::MOV_8_ROWS, p_movb2d::BCAST_ON, 0);
+                    TTI_MOVB2D(p_mov::DEST_32B_LOW, 24, ADDR_MOD_4, p_mov_src_to_dest::MOV_8_ROWS, p_movb2d::BCAST_ON, 8);
+                    TTI_MOVB2D(p_mov::DEST_32B_LOW, 16, ADDR_MOD_4, p_mov_src_to_dest::MOV_8_ROWS, p_movb2d::BCAST_ON, 16);
+                    TTI_MOVB2D(p_mov::DEST_32B_LOW, 24, ADDR_MOD_3, p_mov_src_to_dest::MOV_8_ROWS, p_movb2d::BCAST_ON, 24); // dst += 2* face_r_dim, F0 → F2
+                });
+
+            ckernel_template temp(1 /* mop_outer_loop */, 2 /* mop_inner_loop */, TT_OP_REPLAY(0, replay_buf_len, 0, 0, 0, 0));
+            temp.set_end_op(TT_OP_CLEARDVALID(p_cleardvalid::CLR_SRCB_VLD, 0, 0, 0, 0, 0));
+            temp.program_bank0_sw_cntl(instrn_buffer);
+        }
+        else if constexpr (BROADCAST_TYPE == BroadcastType::ROW)
+        {
+            constexpr std::uint32_t replay_buf_len = 10;
+            load_replay_buf<0, replay_buf_len>(
+                []
+                {
+                    // Read F0/F1 rows[0:7] hi16 and lo16 from DEST → SrcB[0:15]
+                    TTI_MOVD2B(p_mov::DEST_NORM, 0, ADDR_MOD_4, p_movd2b::MOV_8_ROWS, p_movd2b::TRANSPOSE_OFF, 0);
+                    TTI_MOVD2B(p_mov::DEST_32B_LOW, 8, ADDR_MOD_4, p_movd2b::MOV_8_ROWS, p_movd2b::TRANSPOSE_OFF, 0);
+
+                    // Write hi16 to DEST F0,F2/F1,F3 from SrcB[0:7] (row broadcast ON)
+                    TTI_MOVB2D(p_mov::DEST_NORM, 0, ADDR_MOD_4, p_mov_src_to_dest::MOV_8_ROWS, p_movb2d::BCAST_OFF, 0 + 1);
+                    TTI_MOVB2D(p_mov::DEST_NORM, 0, ADDR_MOD_4, p_mov_src_to_dest::MOV_8_ROWS, p_movb2d::BCAST_OFF, 8 + 1);
+                    TTI_MOVB2D(p_mov::DEST_NORM, 0, ADDR_MOD_4, p_mov_src_to_dest::MOV_8_ROWS, p_movb2d::BCAST_OFF, 32 + 1);
+                    TTI_MOVB2D(p_mov::DEST_NORM, 0, ADDR_MOD_4, p_mov_src_to_dest::MOV_8_ROWS, p_movb2d::BCAST_OFF, 40 + 1);
+
+                    // Write lo16 to DEST F0,F2/F1,F3 from SrcB[8:15] (row broadcast ON)
+                    TTI_MOVB2D(p_mov::DEST_32B_LOW, 8, ADDR_MOD_4, p_mov_src_to_dest::MOV_8_ROWS, p_movb2d::BCAST_OFF, 0 + 1);
+                    TTI_MOVB2D(p_mov::DEST_32B_LOW, 8, ADDR_MOD_4, p_mov_src_to_dest::MOV_8_ROWS, p_movb2d::BCAST_OFF, 8 + 1);
+                    TTI_MOVB2D(p_mov::DEST_32B_LOW, 8, ADDR_MOD_4, p_mov_src_to_dest::MOV_8_ROWS, p_movb2d::BCAST_OFF, 32 + 1);
+                    TTI_MOVB2D(p_mov::DEST_32B_LOW, 8, ADDR_MOD_3, p_mov_src_to_dest::MOV_8_ROWS, p_movb2d::BCAST_OFF, 40 + 1); // dst += face_r_dim, F0 → F1
+                });
+
+            ckernel_template temp(1 /* mop_outer_loop */, 2 /* mop_inner_loop */, TT_OP_REPLAY(0, replay_buf_len, 0, 0, 0, 0));
+            temp.set_end_op(TT_OP_CLEARDVALID(p_cleardvalid::CLR_SRCB_VLD, 0, 0, 0, 0, 0));
+            temp.program_bank0_sw_cntl(instrn_buffer);
+        }
+        else // BroadcastType::SCALAR
+        {
+            constexpr std::uint32_t replay_buf_len = 4;
+            load_replay_buf<0, replay_buf_len>(
+                []
+                {
+                    // Read F0 rows[0:7] hi16 and lo16 from DEST → SrcB[0:15]
+                    TTI_MOVD2B(p_mov::DEST_NORM, 0, ADDR_MOD_4, p_movd2b::MOV_8_ROWS, p_movd2b::TRANSPOSE_OFF, 0);
+                    TTI_MOVD2B(p_mov::DEST_32B_LOW, 8, ADDR_MOD_4, p_movd2b::MOV_8_ROWS, p_movd2b::TRANSPOSE_OFF, 0);
+
+                    // Write hi16 and lo16 to DEST[0:63] from SrcB[0:15] (row and column broadcast ON)
+                    TTI_MOVB2D(p_mov::DEST_NORM, 0, ADDR_MOD_4, p_mov_src_to_dest::MOV_8_ROWS, p_movb2d::BCAST_ON, 0 + 1);
+                    TTI_MOVB2D(p_mov::DEST_32B_LOW, 8, ADDR_MOD_3, p_mov_src_to_dest::MOV_8_ROWS, p_movb2d::BCAST_ON, 0 + 1); // dst += 8
+                });
+
+            ckernel_template temp(1 /* mop_outer_loop */, 8 /* mop_inner_loop */, TT_OP_REPLAY(2, 2, 0, 0, 0, 0));
+            temp.set_start_op(TT_OP_REPLAY(0, 2, 0, 0, 0, 0));
+            temp.set_end_op(TT_OP_CLEARDVALID(p_cleardvalid::CLR_SRCB_VLD, 0, 0, 0, 0, 0));
+            temp.program_bank0_sw_cntl(instrn_buffer);
+        }
     }
     else
     {
         const std::uint32_t num_rows =
             (BROADCAST_TYPE == BroadcastType::SCALAR) ? tensor_shape.total_num_faces() * tensor_shape.face_r_dim : tensor_shape.face_r_dim;
-        const std::uint32_t outer    = (BROADCAST_TYPE == BroadcastType::SCALAR) ? 1U : static_cast<std::uint32_t>(tensor_shape.total_num_faces());
-        const std::uint32_t inner    = num_rows >> rows_log2(ELTWISE_MATH_ROWS);
+        const std::uint32_t outer = (BROADCAST_TYPE == BroadcastType::SCALAR) ? 1U : static_cast<std::uint32_t>(tensor_shape.total_num_faces());
+        const std::uint32_t inner = num_rows >> rows_log2(ELTWISE_MATH_ROWS);
 
-        const std::uint32_t dst_lo     = (BROADCAST_TYPE != BroadcastType::COL) ? 1U : 0U;
-        constexpr std::uint32_t bcast0 = (BROADCAST_TYPE == BroadcastType::COL || BROADCAST_TYPE == BroadcastType::SCALAR) ? 1U : 0U;
+        const std::uint32_t bcast_row     = (BROADCAST_TYPE != BroadcastType::COL) ? 1U : 0U;
+        constexpr std::uint32_t bcast_col = (BROADCAST_TYPE != BroadcastType::ROW) ? 1U : 0U;
 
-        const auto movb2d = [bcast0, dst_lo](std::uint8_t am) { return TT_OP_MOVB2D(0, 0, am, p_mov_src_to_dest::MOV_8_ROWS, bcast0, dst_lo); };
+        const auto bcast_instr = [bcast_col, bcast_row](std::uint8_t addr_mod)
+        {
+            return TT_OP_MOVB2D(0, 0, addr_mod, p_mov_src_to_dest::MOV_8_ROWS, bcast_col, bcast_row /* dst_addr */);
+        }; // adding 1 to dst_addr enables row broadcast
 
-        ckernel_template temp(outer, inner, movb2d(ADDR_MOD_0));
+        ckernel_template temp(outer, inner, bcast_instr(ADDR_MOD_0));
         temp.set_end_op(TT_OP_CLEARDVALID(p_cleardvalid::CLR_SRCB_VLD, 0, 0, 0, 0, 0));
         if constexpr (BROADCAST_TYPE == BroadcastType::SCALAR)
         {
-            temp.set_last_outer_loop_instr(movb2d(ADDR_MOD_1));
+            temp.set_last_outer_loop_instr(bcast_instr(ADDR_MOD_1));
         }
         else if constexpr (BROADCAST_TYPE == BroadcastType::COL)
         {
-            temp.set_last_inner_loop_instr(movb2d(ADDR_MOD_1));
+            temp.set_last_inner_loop_instr(bcast_instr(ADDR_MOD_1));
         }
         else
         {
-            temp.set_last_inner_loop_instr(movb2d(ADDR_MOD_0));
-            temp.set_last_outer_loop_instr(movb2d(ADDR_MOD_2));
+            temp.set_last_inner_loop_instr(bcast_instr(ADDR_MOD_0));
+            temp.set_last_outer_loop_instr(bcast_instr(ADDR_MOD_2));
         }
 
         temp.program_bank0_sw_cntl(instrn_buffer);
@@ -134,90 +211,42 @@ inline void _llk_math_eltwise_unary_broadcast_mop_config_(const TensorShape& ten
 }
 
 /**
- * @brief MOP for MOVD2B when unpack wrote to dest (move dest rows back to srcB for MOVB2D).
+ * @brief Init unary-broadcast math: addrmods, mop configuration, reset counters.
  *
  * @tparam BROADCAST_TYPE: Scalar, row, or column broadcast, values = <COL/ROW/SCALAR>
- * @param tensor_shape: Used for row/col loop counts outside ROW special case
- */
-template <BroadcastType BROADCAST_TYPE>
-inline void _llk_math_eltwise_unary_broadcast_d2b_mop_config_(const TensorShape& tensor_shape)
-{
-    if constexpr (BROADCAST_TYPE == BroadcastType::ROW)
-    {
-        const auto f = [](std::uint8_t am, std::uint32_t d32) { return TT_OP_MOVD2B(d32, 0, am, p_movd2b::MOV_1_ROW, 0, 0); };
-
-        constexpr std::uint32_t replay_buf_len = 1;
-        load_replay_buf<0, replay_buf_len>([] { TTI_MOVD2B(0, 0, ADDR_MOD_3, p_movd2b::MOV_1_ROW, 0, 0); });
-
-        ckernel_template temp(1, 1, TT_OP_REPLAY(0, replay_buf_len, 0, 0, 0, 0), f(ADDR_MOD_3, 0));
-        temp.set_last_inner_loop_instr(f(ADDR_MOD_3, 1));
-        temp.program_bank0_sw_cntl(instrn_buffer);
-    }
-    else
-    {
-        // SCALAR: all faces × rows. COL: column broadcast touches two faces in dest (mirrors unpack UNPACR_DEST_FACE 0 and 2), so row count is 2× face_r_dim.
-        const std::uint32_t rows_sel =
-            (BROADCAST_TYPE == BroadcastType::SCALAR) ? tensor_shape.total_num_faces() * tensor_shape.face_r_dim : tensor_shape.face_r_dim * 2;
-        const std::uint32_t inner_d2b = (BROADCAST_TYPE == BroadcastType::SCALAR) ? 1U : rows_sel >> rows_log2(ELTWISE_MATH_ROWS);
-
-        const auto f = [](std::uint8_t am, std::uint32_t d32) { return TT_OP_MOVD2B(d32, 0, am, p_mov_src_to_dest::MOV_8_ROWS, 0, 0); };
-
-        constexpr std::uint32_t replay_buf_len = 1;
-        load_replay_buf<0, replay_buf_len>([] { TTI_MOVD2B(0, 0, ADDR_MOD_3, p_mov_src_to_dest::MOV_8_ROWS, 0, 0); });
-
-        ckernel_template temp(1, inner_d2b * 2, TT_OP_REPLAY(0, replay_buf_len, 0, 0, 0, 0), f(ADDR_MOD_3, 0));
-        temp.set_last_inner_loop_instr(f(ADDR_MOD_3, 1));
-        temp.program_bank0_sw_cntl(instrn_buffer);
-    }
-}
-
-/**
- * @brief Init unary-broadcast math: addrmods, MOP when not unpack_to_dest, reset counters.
- *
- * @tparam BROADCAST_TYPE: Scalar, row, or column broadcast, values = <COL/ROW/SCALAR>
- * @tparam unpack_to_dest: UNP path wrote to dest; MOVB2D MOP deferred to per-tile call
- * @tparam is_fp32_dest_acc_en: Same name/position as unpack init for uniform call sites. Must be false when unpack_to_dest is true (static_assert below)
+ * @tparam unpack_to_dest: UNP path wrote to dest
  * @param tensor_shape: Passed to addrmod / MOP setup
  * @note On the unpack thread, pair with @ref _llk_unpack_unary_broadcast_operands_init_ (T0) with matching BROADCAST_TYPE/unpack_to_dest.
  * @note @ref _llk_math_eltwise_unary_broadcast_ runs the configured op with matching template args.
  */
-template <BroadcastType BROADCAST_TYPE, bool unpack_to_dest = false, bool is_fp32_dest_acc_en = false>
+template <BroadcastType BROADCAST_TYPE, bool unpack_to_dest>
 inline void _llk_math_eltwise_unary_broadcast_init_(const TensorShape& tensor_shape)
 {
-    static_assert(!(unpack_to_dest && is_fp32_dest_acc_en), "Unary broadcast: unpack_to_dest with Float32 dest accumulation is not supported yet");
-    LLK_ASSERT(tensor_shape.total_num_faces() == 4, "Unary broadcast currently only supports 32x32 tiles");
+    LLK_ASSERT(
+        tensor_shape.face_r_dim == MAX_FACE_R_DIM && tensor_shape.num_faces_r_dim == MAX_NUM_FACES_R_DIM && tensor_shape.num_faces_c_dim == MAX_NUM_FACES_C_DIM,
+        "Unary broadcast currently only supports 32x32 tiles (face_r_dim=16, 2x2 faces)");
+
     _llk_math_eltwise_unary_broadcast_addrmod_<BROADCAST_TYPE, unpack_to_dest>(tensor_shape);
-    if constexpr (!unpack_to_dest)
-    {
-        _llk_math_eltwise_unary_broadcast_mop_config_<BROADCAST_TYPE, false>(tensor_shape);
-    }
+    _llk_math_eltwise_unary_broadcast_mop_config_<BROADCAST_TYPE, unpack_to_dest>(tensor_shape);
+
     _reset_counters_<p_setrwc::SET_ABD_F>();
 }
 
 /**
- * @brief Run one tile of unary broadcast math: set dest write addr, optional D2B then MOVB2D when unpack_to_dest.
+ * @brief Run one tile of unary broadcast math: set dest write addr
  *
- * @tparam BROADCAST_TYPE: Scalar, row, or column broadcast, values = <COL/ROW/SCALAR>
- * @tparam unpack_to_dest: When true, runs D2B then MOVB2D replay for unpack-to-dest workaround
- * @tparam is_fp32_dest_acc_en: Same template args as init; combination unpack_to_dest + true is rejected in init
  * @param tile_idx: Destination tile index within current dest bank (SyncHalf)
- * @param tensor_shape: Used when unpack_to_dest (D2B / MOVB2D MOP); otherwise ignored
  * @note Call @ref _llk_math_eltwise_unary_broadcast_init_ with matching template args before this function.
  */
-template <BroadcastType BROADCAST_TYPE, bool unpack_to_dest = false, bool is_fp32_dest_acc_en = false>
-inline void _llk_math_eltwise_unary_broadcast_(const std::uint32_t tile_idx, [[maybe_unused]] const TensorShape& tensor_shape)
+inline void _llk_math_eltwise_unary_broadcast_(const std::uint32_t tile_idx)
 {
     _set_dst_write_addr_<DstTileShape::Tile32x32>(tile_idx);
 
-    if constexpr (unpack_to_dest)
-    {
-        _llk_math_eltwise_unary_broadcast_d2b_mop_config_<BROADCAST_TYPE>(tensor_shape);
-        ckernel::ckernel_template::run_bank0_sw_cntl(instrn_buffer);
-        _reset_counters_<p_setrwc::SET_ABD_F>();
-        _llk_math_eltwise_unary_broadcast_mop_config_<BROADCAST_TYPE, true>(tensor_shape);
-    }
-
+    // Wait condition SRCB_VLD is required as MOVD2B doesn't automatically wait
+    // for SrcB[MatrixUnit.SrcBBank].AllowedClient == SrcClient::MatrixUnit.
     TTI_STALLWAIT(p_stall::STALL_MATH, 0, p_stall::WAIT_SFPU, p_stall::SRCB_VLD); // TEN-4367 - SrcB sync workaround
+
     ckernel::ckernel_template::run_bank0_sw_cntl(instrn_buffer);
+
     _reset_counters_<p_setrwc::SET_ABD_F>();
 }

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_unpack_unary_broadcast_operands.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_unpack_unary_broadcast_operands.h
@@ -20,19 +20,16 @@ using namespace ckernel;
  * @tparam UNP_SEL: Unpacker select; must be UNP_B unless unpack_to_dest (then UNP_A), values = <p_unpacr::UNP_A/UNP_B>
  * @tparam BROADCAST_TYPE: Broadcast type, values = <COL/ROW/SCALAR>
  * @tparam unpack_to_dest: When true, unpack targets math dest (UNP_A); otherwise SrcB (UNP_B), values = <true/false>
- * @tparam is_fp32_dest_acc_en: Float32 dest accumulation enable. Must be false when unpack_to_dest is true
- *         until that path is supported (enforced by static_assert below), values = <true/false>
  * @param buf_desc_id: Buffer descriptor for the UNPACR source.
  * @param num_tiles: Outer MOP loop count (tiles to unpack from L1).
  */
-template <std::uint32_t UNP_SEL, BroadcastType BROADCAST_TYPE, bool unpack_to_dest = false, bool is_fp32_dest_acc_en = false>
+template <std::uint32_t UNP_SEL, BroadcastType BROADCAST_TYPE, bool unpack_to_dest = false>
 inline void _llk_unpack_unary_broadcast_operands_mop_config_(const std::uint32_t buf_desc_id, const std::uint32_t num_tiles)
 {
     static_assert(
         unpack_to_dest || (UNP_SEL == p_unpacr::UNP_B),
         "UNP_SEL must be p_unpacr::UNP_B when unpack_to_dest is false - movA2D broadcast is not working on Quasar");
     static_assert((BROADCAST_TYPE != BroadcastType::NONE), "Broadcast type cannot be NONE for this operation");
-    static_assert(!(unpack_to_dest && is_fp32_dest_acc_en), "Unary broadcast: unpack_to_dest with Float32 dest accumulation is not supported yet");
 
     const std::uint32_t MOP_OUTER_LOOP            = num_tiles;
     constexpr std::uint32_t MOP_INNER_LOOP        = 1;
@@ -45,7 +42,7 @@ inline void _llk_unpack_unary_broadcast_operands_mop_config_(const std::uint32_t
             {
                 if constexpr (unpack_to_dest)
                 {
-                    TT_UNPACR_DEST_ROW(0 /*Dst_Row_Idx*/, 0 /*Src_Row_Idx*/, 0 /*Dst_Face_Idx*/, 0 /*Src_Face_Idx*/, 0, 0, buf_desc_id, 1 /*SetDatValid*/);
+                    TT_UNPACR_DEST_ROW(0 /*Dst_Row_Idx*/, 0 /*Src_Row_Idx*/, 0 /*Dst_Face_Idx*/, 0 /*Src_Face_Idx*/, 0, 0, buf_desc_id, 0 /*SetDatValid*/);
                 }
                 else
                 {
@@ -61,7 +58,7 @@ inline void _llk_unpack_unary_broadcast_operands_mop_config_(const std::uint32_t
                 if constexpr (unpack_to_dest)
                 {
                     TT_UNPACR_DEST_ROW(0 /*Dst_Row_Idx*/, 0 /*Src_Row_Idx*/, 0 /*Dst_Face_Idx*/, 0 /*Src_Face_Idx*/, 0, 0, buf_desc_id, 0 /*SetDatValid*/);
-                    TT_UNPACR_DEST_ROW(0 /*Dst_Row_Idx*/, 0 /*Src_Row_Idx*/, 1 /*Dst_Face_Idx*/, 1 /*Src_Face_Idx*/, 0, 0, buf_desc_id, 1 /*SetDatValid*/);
+                    TT_UNPACR_DEST_ROW(0 /*Dst_Row_Idx*/, 0 /*Src_Row_Idx*/, 1 /*Dst_Face_Idx*/, 1 /*Src_Face_Idx*/, 0, 0, buf_desc_id, 0 /*SetDatValid*/);
                 }
                 else
                 {
@@ -81,7 +78,7 @@ inline void _llk_unpack_unary_broadcast_operands_mop_config_(const std::uint32_t
                 if constexpr (unpack_to_dest)
                 {
                     TT_UNPACR_DEST_FACE(0 /*Dst Face Idx*/, 0 /*Src Face Idx*/, 0, 0, buf_desc_id, 0 /*SetDatValid*/);
-                    TT_UNPACR_DEST_FACE(2 /*Dst Face Idx*/, 2 /*Src Face Idx*/, 0, 0, buf_desc_id, 1 /*SetDatValid*/);
+                    TT_UNPACR_DEST_FACE(2 /*Dst Face Idx*/, 2 /*Src Face Idx*/, 0, 0, buf_desc_id, 0 /*SetDatValid*/);
                 }
                 else
                 {
@@ -105,6 +102,10 @@ inline void _llk_unpack_unary_broadcast_operands_mop_config_(const std::uint32_t
     }
 
     ckernel_template temp(MOP_OUTER_LOOP, MOP_INNER_LOOP, TT_OP_REPLAY(0, replay_buf_len, 0, 0, 0, 0), inc_src_tile_instrn);
+    if constexpr (unpack_to_dest)
+    {
+        temp.set_end_op(TT_OP_INC_DST_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, p_unpacr::UNP_A, 1));
+    }
     temp.program_bank0_sw_cntl(instrn_buffer);
 }
 
@@ -114,18 +115,17 @@ inline void _llk_unpack_unary_broadcast_operands_mop_config_(const std::uint32_t
  * @tparam UNP_SEL: Unpacker resource; must be UNP_B unless unpack_to_dest, values = <p_unpacr::UNP_A/UNP_B>
  * @tparam BROADCAST_TYPE: Broadcast type, values = <COL/ROW/SCALAR>
  * @tparam unpack_to_dest: Route unpack to dest (UNP_A) vs SrcB (UNP_B), values = <true/false>
- * @tparam is_fp32_dest_acc_en: Forwarded to mop_config; must be false when unpack_to_dest is true, values = <true/false>
  * @param buf_desc_id: Buffer descriptor for the UNPACR source.
  * @param num_tiles: Number of tiles in the outer unpack loop.
  * @note On the math thread, pair with @ref _llk_math_eltwise_unary_broadcast_init_ (T1) with matching BROADCAST_TYPE/unpack_to_dest.
  * @note @ref _llk_unpack_unary_broadcast_operands_ is the matching execute call on this thread.
  */
-template <std::uint32_t UNP_SEL, BroadcastType BROADCAST_TYPE, bool unpack_to_dest = false, bool is_fp32_dest_acc_en = false>
+template <std::uint32_t UNP_SEL, BroadcastType BROADCAST_TYPE, bool unpack_to_dest = false>
 inline void _llk_unpack_unary_broadcast_operands_init_(const std::uint32_t buf_desc_id, const std::uint32_t num_tiles)
 {
     cfg_rmw(THCON_UNPACKER0_REG0_TRANSPOSE_RMW, 0);
     cfg_rmw(THCON_UNPACKER1_REG0_TRANSPOSE_RMW, 0);
-    _llk_unpack_unary_broadcast_operands_mop_config_<UNP_SEL, BROADCAST_TYPE, unpack_to_dest, is_fp32_dest_acc_en>(buf_desc_id, num_tiles);
+    _llk_unpack_unary_broadcast_operands_mop_config_<UNP_SEL, BROADCAST_TYPE, unpack_to_dest>(buf_desc_id, num_tiles);
 }
 
 /**


### PR DESCRIPTION
### PR Category
Bug fix

### Issue
https://github.com/tenstorrent/tt-metal/issues/47560

### Summary
The current kernel has several bugs and does not work for unpack_to_dest=False. The bugs are described in https://github.com/tenstorrent/tt-metal/issues/47560.
This PR implements the unary bcast kernel for unpack_to_dest=True and adds tests. The added tests are input_fmt=output_fmt for now. 
Unary broadcast with unpack to dest = true still does not work when Dest banks are switched (DstSync::Half) and unpack_to_dest=true -> opened issue https://github.com/tenstorrent/tt-metal/issues/51329.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amokan/revisit_upk_to_dst_bcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amokan/revisit_upk_to_dst_bcast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amokan/revisit_upk_to_dst_bcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amokan/revisit_upk_to_dst_bcast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=amokan/revisit_upk_to_dst_bcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:amokan/revisit_upk_to_dst_bcast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amokan/revisit_upk_to_dst_bcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amokan/revisit_upk_to_dst_bcast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amokan/revisit_upk_to_dst_bcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amokan/revisit_upk_to_dst_bcast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amokan/revisit_upk_to_dst_bcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amokan/revisit_upk_to_dst_bcast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amokan/revisit_upk_to_dst_bcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amokan/revisit_upk_to_dst_bcast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amokan/revisit_upk_to_dst_bcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amokan/revisit_upk_to_dst_bcast)