### PR TITLE
[Quasar] Fix 32-bit MOV destination bank switching

### DIFF
--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_unary_datacopy_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_unary_datacopy_api.h
@@ -51,8 +51,7 @@ inline void llk_math_eltwise_unary_datacopy_init(const std::uint32_t operand) {
     } else {
         static_assert(type == DataCopyType::B2D);
         const ckernel::TensorShape tensor_shape = get_operand_tensor_shape(operand);
-        _llk_math_eltwise_unary_broadcast_init_<src_b_bcast_type, false /*unpack_to_dest*/, EN_32BIT_DEST>(
-            tensor_shape);
+        _llk_math_eltwise_unary_broadcast_init_<src_b_bcast_type, false /*unpack_to_dest*/>(tensor_shape);
     }
 }
 
@@ -82,7 +81,7 @@ inline void llk_math_eltwise_unary_datacopy(const std::uint32_t dst_index, const
     if constexpr (src_b_bcast_type != BroadcastType::NONE && !unpack_to_dest) {
         static_assert(type == DataCopyType::B2D, "Unary broadcast math path requires DataCopyType::B2D");
         const ckernel::TensorShape tensor_shape = get_operand_tensor_shape(operand);
-        _llk_math_eltwise_unary_broadcast_<src_b_bcast_type, false, EN_32BIT_DEST>(dst_index, tensor_shape);
+        _llk_math_eltwise_unary_broadcast_(dst_index);
     } else {
         // 32-bit unpack-to-dest: math is a sync-only forwarder (unpacker wrrites DEST), no MOP to run.
         if constexpr (!unpack_to_dest) {

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_A_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_A_api.h
@@ -79,9 +79,7 @@ inline void llk_unpack_A_init(
             }
         } else {
             constexpr std::uint32_t unp_sel = unpack_to_dest ? p_unpacr::UNP_A : p_unpacr::UNP_B;
-            constexpr bool is_fp32_dest_acc_en = unpack_to_dest ? false : DST_ACCUM_MODE;
-            _llk_unpack_unary_broadcast_operands_init_<unp_sel, BType, unpack_to_dest, is_fp32_dest_acc_en>(
-                operand_id, 1);
+            _llk_unpack_unary_broadcast_operands_init_<unp_sel, BType, unpack_to_dest>(operand_id, 1);
         }
     }
 }

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_unary_broadcast_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_unary_broadcast_quasar.py
@@ -3,7 +3,6 @@
 
 import pytest
 import torch
-from helpers.constraints import get_valid_dest_accumulation_modes
 from helpers.format_config import DataFormat
 from helpers.golden_generators import (
     BroadcastGolden,
@@ -14,6 +13,7 @@ from helpers.llk_params import (
     DestAccumulation,
     DestSync,
     ImpliedMathFormat,
+    UnpackerEngine,
     format_dict,
 )
 from helpers.param_config import (
@@ -21,7 +21,6 @@ from helpers.param_config import (
     get_num_blocks_and_num_tiles_in_block,
     input_output_formats,
     parametrize,
-    runtime,
 )
 from helpers.stimuli_config import StimuliConfig
 from helpers.test_config import BootMode, TestConfig
@@ -36,23 +35,25 @@ from helpers.test_variant_parameters import (
     NUM_TILES_IN_BLOCK,
     TEST_FACE_DIMS,
     TILE_COUNT,
+    UNPACKER_ENGINE_SEL,
     generate_input_dim,
 )
 from helpers.tile_constants import FACE_C_DIM, get_tile_params
 from helpers.utils import passed_test
 
-INPUT_DIMENSIONS = [[512, 32]]
 TILE_DIMENSIONS = [32, 32]
 
 
 def get_valid_dest_acc_unary_broadcast(formats):
     """Valid dest accumulation modes for unary broadcast."""
-    accs = list(get_valid_dest_accumulation_modes(formats))
+    # accs = list(get_valid_dest_accumulation_modes(formats))
     if formats.input_format.is_32_bit():
-        accs = [a for a in accs if a == DestAccumulation.Yes]
-    elif formats.output_format == DataFormat.Float32:
-        accs = [a for a in accs if a == DestAccumulation.Yes]
-    return accs if accs else [DestAccumulation.Yes]
+        return [DestAccumulation.Yes]
+    #     accs = [a for a in accs if a == DestAccumulation.Yes]
+    # elif formats.output_format == DataFormat.Float32:
+    #     accs = [a for a in accs if a == DestAccumulation.Yes]
+    # return accs if accs else [DestAccumulation.Yes]
+    return [DestAccumulation.No]
 
 
 @pytest.mark.quasar
@@ -60,13 +61,13 @@ def get_valid_dest_acc_unary_broadcast(formats):
     formats=input_output_formats(
         [
             DataFormat.Float16_b,
-            # DataFormat.Float32, Buggy functionality for Float32 (unpack_to_dest=True) tbd
-            DataFormat.MxFp8R,
-            DataFormat.MxFp8P,
-            DataFormat.MxFp4,
-            DataFormat.MxInt8,
-            DataFormat.MxInt4,
-            DataFormat.MxInt2,
+            # DataFormat.Float32,  # Buggy functionality for Float32 (unpack_to_dest=True) tbd
+            # DataFormat.MxFp8R,
+            # DataFormat.MxFp8P,
+            # DataFormat.MxFp4,
+            # DataFormat.MxInt8,
+            # DataFormat.MxInt4,
+            # DataFormat.MxInt2,
         ],
         same=True,
     ),
@@ -82,7 +83,6 @@ def get_valid_dest_acc_unary_broadcast(formats):
         else [ImpliedMathFormat.Yes]
     ),
     dest_sync_mode=[DestSync.Half, DestSync.Full],
-    input_dimensions=runtime(INPUT_DIMENSIONS),
 )
 def test_unary_broadcast_quasar(
     formats,
@@ -90,9 +90,13 @@ def test_unary_broadcast_quasar(
     broadcast_type,
     implied_math_format,
     dest_sync_mode,
-    input_dimensions,
     boot_mode=BootMode.DEFAULT,
 ):
+    unpack_to_dest = (
+        formats.input_format.is_32_bit() and dest_acc == DestAccumulation.Yes
+    )
+    input_dimensions = [32, 64] if unpack_to_dest else [512, 32]
+
     tile_rows, tile_cols = TILE_DIMENSIONS
     face_r_dim, num_faces_r_dim, num_faces_c_dim = get_tile_params(
         [tile_rows, tile_cols]
@@ -103,14 +107,9 @@ def test_unary_broadcast_quasar(
     num_elements = rows * cols
     tile_cnt = (rows // tile_rows) * (cols // tile_cols)
 
-    effective_dest_acc = (
-        DestAccumulation.Yes
-        if formats.output_format == DataFormat.Float32
-        else DestAccumulation.No
-    )
     output_num_blocks, output_tiles_in_block = get_num_blocks_and_num_tiles_in_block(
         dest_sync_mode,
-        effective_dest_acc,
+        dest_acc,
         formats,
         input_dimensions,
         TILE_DIMENSIONS,
@@ -130,17 +129,16 @@ def test_unary_broadcast_quasar(
         face_r_dim=face_r_dim,
     )
 
-    unpack_to_dest = (
-        formats.input_format.is_32_bit() and dest_acc == DestAccumulation.Yes
-    )
-
     src_A = src_B
+
+    unpacker_sel = UnpackerEngine.UnpA if unpack_to_dest else UnpackerEngine.UnpB
 
     configuration = TestConfig(
         "sources/quasar/eltwise_unary_broadcast_quasar_test.cpp",
         formats,
         templates=[
             IMPLIED_MATH_FORMAT(implied_math_format),
+            UNPACKER_ENGINE_SEL(unpacker_sel),
             BROADCAST_TYPE(broadcast_type),
             DEST_SYNC(dest_sync_mode),
         ],
@@ -177,9 +175,8 @@ def test_unary_broadcast_quasar(
             use_dense_tile_dimensions=True,
         ),
         unpack_to_dest=unpack_to_dest,
-        dest_acc=DestAccumulation.No,
+        dest_acc=dest_acc,
         boot_mode=boot_mode,
-        disable_format_inference=(implied_math_format == ImpliedMathFormat.Yes),
     )
 
     res_from_L1 = configuration.run().result

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_unary_broadcast_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_unary_broadcast_quasar.py
@@ -50,7 +50,7 @@ def get_valid_dest_acc_unary_broadcast(formats):
         return [DestAccumulation.Yes]
     return [
         DestAccumulation.No
-    ]  # 32bit dest is not supported for the non-unpack to dest case
+    ]  # 32bit dest is not supported for the unpack_to_dest=False case, ISSUE: #47560
 
 
 @pytest.mark.quasar
@@ -62,11 +62,12 @@ def get_valid_dest_acc_unary_broadcast(formats):
             DataFormat.MxFp8R,
             DataFormat.MxFp8P,
             DataFormat.MxFp4,
+            DataFormat.Int32,
             DataFormat.MxInt8,
             DataFormat.MxInt4,
             DataFormat.MxInt2,
         ],
-        same=True,
+        same=True,  # input_fmt != output_fmt not tested, ISSUE: #47560
     ),
     dest_acc=lambda formats: get_valid_dest_acc_unary_broadcast(formats),
     broadcast_type=[
@@ -92,7 +93,10 @@ def test_unary_broadcast_quasar(
     unpack_to_dest = (
         formats.input_format.is_32_bit() and dest_acc == DestAccumulation.Yes
     )
-    input_dimensions = [32, 96] if unpack_to_dest else [512, 32]
+    # Test fails when unpack_to_dest=False, DstSync::Half and Dest bank switching, ISSUE: #51329
+    input_dimensions = (
+        [32, 96] if unpack_to_dest and dest_sync_mode == DestSync.Half else [512, 32]
+    )
 
     tile_rows, tile_cols = TILE_DIMENSIONS
     face_r_dim, num_faces_r_dim, num_faces_c_dim = get_tile_params(
@@ -114,7 +118,17 @@ def test_unary_broadcast_quasar(
     )
 
     torch_format = format_dict[formats.input_format]
-    src_B = torch.randn(num_elements, dtype=torch_format)
+
+    if formats.input_format == DataFormat.Int32:
+        lo, hi = -1_000_000, 1_000_000
+        src_B = torch.randint(lo, hi, (num_elements,), dtype=torch.int32)
+    elif (
+        formats.input_format == DataFormat.Float32
+        and not formats.output_format.is_mx_format()
+    ):
+        src_B = torch.randn(num_elements, dtype=torch.float32) * 10000.0
+    else:
+        src_B = torch.randn(num_elements, dtype=torch_format)
 
     generate_broadcast_golden = get_golden_generator(BroadcastGolden)
     golden_tensor = generate_broadcast_golden(

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_unary_broadcast_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_unary_broadcast_quasar.py
@@ -46,14 +46,11 @@ TILE_DIMENSIONS = [32, 32]
 
 def get_valid_dest_acc_unary_broadcast(formats):
     """Valid dest accumulation modes for unary broadcast."""
-    # accs = list(get_valid_dest_accumulation_modes(formats))
     if formats.input_format.is_32_bit():
         return [DestAccumulation.Yes]
-    #     accs = [a for a in accs if a == DestAccumulation.Yes]
-    # elif formats.output_format == DataFormat.Float32:
-    #     accs = [a for a in accs if a == DestAccumulation.Yes]
-    # return accs if accs else [DestAccumulation.Yes]
-    return [DestAccumulation.No]
+    return [
+        DestAccumulation.No
+    ]  # 32bit dest is not supported for the non-unpack to dest case
 
 
 @pytest.mark.quasar
@@ -61,13 +58,13 @@ def get_valid_dest_acc_unary_broadcast(formats):
     formats=input_output_formats(
         [
             DataFormat.Float16_b,
-            # DataFormat.Float32,  # Buggy functionality for Float32 (unpack_to_dest=True) tbd
-            # DataFormat.MxFp8R,
-            # DataFormat.MxFp8P,
-            # DataFormat.MxFp4,
-            # DataFormat.MxInt8,
-            # DataFormat.MxInt4,
-            # DataFormat.MxInt2,
+            DataFormat.Float32,
+            DataFormat.MxFp8R,
+            DataFormat.MxFp8P,
+            DataFormat.MxFp4,
+            DataFormat.MxInt8,
+            DataFormat.MxInt4,
+            DataFormat.MxInt2,
         ],
         same=True,
     ),
@@ -95,7 +92,7 @@ def test_unary_broadcast_quasar(
     unpack_to_dest = (
         formats.input_format.is_32_bit() and dest_acc == DestAccumulation.Yes
     )
-    input_dimensions = [32, 64] if unpack_to_dest else [512, 32]
+    input_dimensions = [32, 96] if unpack_to_dest else [512, 32]
 
     tile_rows, tile_cols = TILE_DIMENSIONS
     face_r_dim, num_faces_r_dim, num_faces_c_dim = get_tile_params(

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_unary_broadcast_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_unary_broadcast_quasar.py
@@ -93,7 +93,7 @@ def test_unary_broadcast_quasar(
     unpack_to_dest = (
         formats.input_format.is_32_bit() and dest_acc == DestAccumulation.Yes
     )
-    # Test fails when unpack_to_dest=False, DstSync::Half and Dest bank switching, ISSUE: #51329
+    # Test fails when unpack_to_dest=True, DstSync::Half and Dest bank switching, ISSUE: #51329
     input_dimensions = (
         [32, 96] if unpack_to_dest and dest_sync_mode == DestSync.Half else [512, 32]
     )

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_broadcast_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_broadcast_quasar_test.cpp
@@ -11,11 +11,6 @@
 #include "quasar_test_common.h"
 #include "sfpu_stub.h"
 
-// Globals
-std::uint32_t unp_cfg_context          = 0;
-std::uint32_t pack_sync_tile_dst_ptr   = 0;
-std::uint32_t math_sync_tile_dst_index = 0;
-
 #ifdef LLK_TRISC_UNPACK
 
 #include "llk_math_common.h"
@@ -31,13 +26,12 @@ void run_kernel(RUNTIME_PARAMETERS params)
     tdma_descriptor_t td_val_A, td_val_B;
     const std::uint32_t buf_desc_id_a        = 0;
     const std::uint32_t buf_desc_id_b        = 1;
-    const std::uint32_t num_tiles_per_unpack = params.TILE_CNT;
+    const std::uint32_t num_tiles_per_unpack = params.OUTPUT_NUM_TILES_IN_BLOCK;
 
     // Setup data valid scheme
     if (unpack_to_dest)
     {
-        set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::UNPACK, dest_dvalid_client::PACK});
-        _llk_math_upk_to_dest_hw_configure_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en, false /*is_int_fpu_en*/>();
+        set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::UNPACK, dest_dvalid_client::FPU, dest_dvalid_client::PACK});
     }
     else
     {
@@ -52,43 +46,32 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _configure_buf_desc_table_(td_val_A.buf_desc_id, td_val_A.buf_desc);
     _configure_buf_desc_table_(td_val_B.buf_desc_id, td_val_B.buf_desc);
 
-    if (is_fp32_dest_acc_en)
+    if constexpr (is_fp32_dest_acc_en && !unpack_to_dest)
     {
-        if (unpack_to_dest)
-        {
-            _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(td_val_A, td_val_B);
-        }
-        else
-        {
-            _llk_unpack_configure_unary_<p_unpacr::UNP_B>(td_val_B);
-        }
+        // If Dst fmt is 32b and operation is Mov2D, we need both SrcA/B fmts to be configured since Mov2D will be implemented via ELWADD
+        _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(td_val_A, td_val_B);
     }
     else
     {
-        if constexpr (unpack_to_dest)
-        {
-            _llk_unpack_configure_unary_<p_unpacr::UNP_A>(td_val_A);
-        }
-        else
-        {
-            _llk_unpack_configure_unary_<p_unpacr::UNP_B>(td_val_B);
-        }
+        _llk_unpack_configure_unary_<UNPACKER_ENGINE_SEL>(unpack_to_dest ? td_val_A : td_val_B);
     }
 
-    if constexpr (unpack_to_dest)
+    _llk_unpack_unary_broadcast_operands_init_<UNPACKER_ENGINE_SEL, BROADCAST_TYPE, unpack_to_dest, is_fp32_dest_acc_en>(
+        unpack_to_dest ? buf_desc_id_a : buf_desc_id_b, num_tiles_per_unpack);
+
+    const std::uint32_t tiles_in_block = params.OUTPUT_NUM_TILES_IN_BLOCK;
+    const std::uint32_t num_blocks     = static_cast<std::uint32_t>(params.INPUT_NUM_BLOCKS);
+
+    for (std::uint32_t block = 0; block < num_blocks; block++)
     {
-        _llk_unpack_unary_broadcast_operands_init_<p_unpacr::UNP_A, BROADCAST_TYPE, unpack_to_dest, is_fp32_dest_acc_en>(buf_desc_id_a, 1);
-        for (std::uint32_t i = 0; i < num_tiles_per_unpack; ++i)
+        _llk_unpack_unary_broadcast_operands_<UNPACKER_ENGINE_SEL, unpack_to_dest>(block * tiles_in_block);
+        if constexpr (unpack_to_dest)
         {
-            _llk_unpack_unary_broadcast_operands_<p_unpacr::UNP_A, unpack_to_dest>(i);
-        }
-    }
-    else
-    {
-        _llk_unpack_unary_broadcast_operands_init_<p_unpacr::UNP_B, BROADCAST_TYPE, unpack_to_dest, is_fp32_dest_acc_en>(buf_desc_id_b, 1);
-        for (std::uint32_t i = 0; i < num_tiles_per_unpack; ++i)
-        {
-            _llk_unpack_unary_broadcast_operands_<p_unpacr::UNP_B, unpack_to_dest>(i);
+            _llk_unpack_dest_dvalid_section_done_<dest_sync>();
+            for (std::uint32_t i = 0; i < tiles_in_block; ++i)
+            {
+                _llk_unpack_set_srcB_dummy_valid_();
+            }
         }
     }
 }
@@ -109,30 +92,40 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
-    // Unpack-to-dest: operand broadcast is done in UNPACK; MATH keeps ALU/srcB/dest format wiring only
-    // (see unpack_tilize_quasar_test.cpp). Functional MOVB2D / MOP runs only when unpacking to srcB.
-    DataFormat src_format = static_cast<DataFormat>(formats.math);
-    _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en, false /*int32_dest*/>(src_format, src_format);
-
-    if constexpr (!unpack_to_dest)
+    if (unpack_to_dest)
+    {
+        set_up_dest_dvalid_per_thread<dest_dvalid_client::FPU>({dest_dvalid_client::UNPACK, dest_dvalid_client::FPU, dest_dvalid_client::PACK});
+    }
+    else
     {
         set_up_dest_dvalid_per_thread<dest_dvalid_client::FPU>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
+    }
 
-        const auto tensor_shape = tensor_shape_from_params(params);
+    DataFormat math_format     = static_cast<DataFormat>(formats.math);
+    DataFormat pack_src_format = static_cast<DataFormat>(formats.pack_src);
+    if (is_fp32_dest_acc_en && pack_src_format == DataFormat::Int32)
+    {
+        _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, false /*fp32_dest*/, true /*int32_dest*/>(math_format, math_format);
+    }
+    else
+    {
+        _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en, false /*int32_dest*/>(math_format, math_format);
+    }
 
-        _llk_math_eltwise_unary_broadcast_init_<BROADCAST_TYPE, unpack_to_dest, is_fp32_dest_acc_en>(tensor_shape);
+    const auto tensor_shape = tensor_shape_from_params(params);
 
-        const std::uint32_t tiles_in_block = params.OUTPUT_NUM_TILES_IN_BLOCK;
-        const std::uint32_t num_blocks     = static_cast<std::uint32_t>(params.INPUT_NUM_BLOCKS);
+    _llk_math_eltwise_unary_broadcast_init_<BROADCAST_TYPE, unpack_to_dest>(tensor_shape);
 
-        for (std::uint32_t block = 0; block < num_blocks; block++)
+    const std::uint32_t tiles_in_block = params.OUTPUT_NUM_TILES_IN_BLOCK;
+    const std::uint32_t num_blocks     = static_cast<std::uint32_t>(params.INPUT_NUM_BLOCKS);
+
+    for (std::uint32_t block = 0; block < num_blocks; block++)
+    {
+        for (std::uint32_t tile = 0; tile < tiles_in_block; tile++)
         {
-            for (std::uint32_t tile = 0; tile < tiles_in_block; tile++)
-            {
-                _llk_math_eltwise_unary_broadcast_<BROADCAST_TYPE, unpack_to_dest, is_fp32_dest_acc_en>(tile, tensor_shape);
-            }
-            _llk_math_set_dvalid_<p_cleardvalid::FPU, dest_sync>();
+            _llk_math_eltwise_unary_broadcast_(tile);
         }
+        _llk_math_set_dvalid_<p_cleardvalid::FPU, dest_sync>();
     }
 }
 
@@ -150,11 +143,12 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const FormatConfig& formats = params.formats;
 #endif
 
-    std::uint32_t const buf_desc_id = 8;
+    std::uint32_t const buf_desc_id        = 8;
+    const std::uint32_t num_tiles_per_pack = 1;
 
     if (unpack_to_dest)
     {
-        set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::UNPACK, dest_dvalid_client::PACK});
+        set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::UNPACK, dest_dvalid_client::FPU, dest_dvalid_client::PACK});
     }
     else
     {

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_broadcast_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_broadcast_quasar_test.cpp
@@ -57,7 +57,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         _llk_unpack_configure_unary_<UNPACKER_ENGINE_SEL>(unpack_to_dest ? td_val_A : td_val_B);
     }
 
-    _llk_unpack_unary_broadcast_operands_init_<UNPACKER_ENGINE_SEL, BROADCAST_TYPE, unpack_to_dest, is_fp32_dest_acc_en>(
+    _llk_unpack_unary_broadcast_operands_init_<UNPACKER_ENGINE_SEL, BROADCAST_TYPE, unpack_to_dest>(
         unpack_to_dest ? buf_desc_id_a : buf_desc_id_b, tiles_in_block /* num tiles per unpack */);
 
     for (std::uint32_t block = 0; block < num_blocks; block++)

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_broadcast_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_broadcast_quasar_test.cpp
@@ -112,6 +112,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     const auto tensor_shape = tensor_shape_from_params(params);
 
+    _configure_mov_ops_explicit_alu_data_format_state_<is_fp32_dest_acc_en>(math_format, math_format);
     _llk_math_eltwise_unary_broadcast_init_<BROADCAST_TYPE, unpack_to_dest>(tensor_shape);
 
     const std::uint32_t tiles_in_block = params.OUTPUT_NUM_TILES_IN_BLOCK;

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_broadcast_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_broadcast_quasar_test.cpp
@@ -24,9 +24,10 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const FormatConfig& formats = params.formats;
 #endif
     tdma_descriptor_t td_val_A, td_val_B;
-    const std::uint32_t buf_desc_id_a        = 0;
-    const std::uint32_t buf_desc_id_b        = 1;
-    const std::uint32_t num_tiles_per_unpack = params.OUTPUT_NUM_TILES_IN_BLOCK;
+    const std::uint32_t buf_desc_id_a  = 0;
+    const std::uint32_t buf_desc_id_b  = 1;
+    const std::uint32_t tiles_in_block = params.OUTPUT_NUM_TILES_IN_BLOCK;
+    const std::uint32_t num_blocks     = static_cast<std::uint32_t>(params.INPUT_NUM_BLOCKS);
 
     // Setup data valid scheme
     if (unpack_to_dest)
@@ -57,10 +58,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     }
 
     _llk_unpack_unary_broadcast_operands_init_<UNPACKER_ENGINE_SEL, BROADCAST_TYPE, unpack_to_dest, is_fp32_dest_acc_en>(
-        unpack_to_dest ? buf_desc_id_a : buf_desc_id_b, num_tiles_per_unpack);
-
-    const std::uint32_t tiles_in_block = params.OUTPUT_NUM_TILES_IN_BLOCK;
-    const std::uint32_t num_blocks     = static_cast<std::uint32_t>(params.INPUT_NUM_BLOCKS);
+        unpack_to_dest ? buf_desc_id_a : buf_desc_id_b, tiles_in_block /* num tiles per unpack */);
 
     for (std::uint32_t block = 0; block < num_blocks; block++)
     {
@@ -162,7 +160,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     _configure_buf_desc_table_(tdma_desc.buf_desc_id, tdma_desc.buf_desc);
     _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(tdma_desc, ckernel::ReluConfig::none());
-    _llk_pack_init_(buf_desc_id, tensor_shape, 1);
+    _llk_pack_init_(buf_desc_id, tensor_shape, num_tiles_per_pack);
 
     const std::uint32_t output_num_blocks     = static_cast<std::uint32_t>(params.OUTPUT_NUM_BLOCKS);
     const std::uint32_t output_tiles_in_block = params.OUTPUT_NUM_TILES_IN_BLOCK;

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_broadcast_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_broadcast_quasar_test.cpp
@@ -30,7 +30,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const std::uint32_t num_blocks     = static_cast<std::uint32_t>(params.INPUT_NUM_BLOCKS);
 
     // Setup data valid scheme
-    if (unpack_to_dest)
+    if constexpr (unpack_to_dest)
     {
         set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::UNPACK, dest_dvalid_client::FPU, dest_dvalid_client::PACK});
     }
@@ -90,7 +90,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
-    if (unpack_to_dest)
+    if constexpr (unpack_to_dest)
     {
         set_up_dest_dvalid_per_thread<dest_dvalid_client::FPU>({dest_dvalid_client::UNPACK, dest_dvalid_client::FPU, dest_dvalid_client::PACK});
     }
@@ -142,10 +142,10 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const FormatConfig& formats = params.formats;
 #endif
 
-    std::uint32_t const buf_desc_id        = 8;
+    constexpr std::uint32_t buf_desc_id    = 8;
     const std::uint32_t num_tiles_per_pack = 1;
 
-    if (unpack_to_dest)
+    if constexpr (unpack_to_dest)
     {
         set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::UNPACK, dest_dvalid_client::FPU, dest_dvalid_client::PACK});
     }

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_common.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_common.h
@@ -20,9 +20,12 @@ static DataFormatConfigSet data_format_config_set = DataFormatConfigSet::UNCONFI
  * @tparam EN_IMPLIED_MATH_FORMAT: If set to true, will imply math dest format from SrcA reg format
  * @tparam EN_FP32_MATH_FORMAT: Set to true to use math dest in Float32, otherwise default behaviour is Float16/Float16_b depending on input format exponent
  * width
- * @tparam EN_INT32_MATH_FORMAT: Set to true to use math dest in Int32, otherwise default behaviour is Float16/Float16_b depending on input format exponent width
- * @param srcA_format: Input srcA format, used to set ALU configs if not implied math format, values = DataFormat enum, ex: <Float16/Float16_b/Tf32/Int8/Int16/UInt8>
- * @param srcB_format: Input srcB format, used to set ALU configs if not implied math format, values = DataFormat enum, ex: <Float16/Float16_b/Tf32/Int8/Int16/UInt8>
+ * @tparam EN_INT32_MATH_FORMAT: Set to true to use math dest in Int32, otherwise default behaviour is Float16/Float16_b depending on input format exponent
+ * width
+ * @param srcA_format: Input srcA format, used to set ALU configs if not implied math format, values = DataFormat enum, ex:
+ * <Float16/Float16_b/Tf32/Int8/Int16/UInt8>
+ * @param srcB_format: Input srcB format, used to set ALU configs if not implied math format, values = DataFormat enum, ex:
+ * <Float16/Float16_b/Tf32/Int8/Int16/UInt8>
  */
 template <bool EN_IMPLIED_MATH_FORMAT, bool EN_FP32_MATH_FORMAT, bool EN_INT32_MATH_FORMAT>
 inline void _llk_math_srcAB_hw_configure_(DataFormat srcA_format, DataFormat srcB_format)
@@ -80,7 +83,8 @@ inline void _llk_math_srcAB_hw_configure_(DataFormat srcA_format, DataFormat src
  * @tparam EN_IMPLIED_MATH_FORMAT: If set to true, will imply math dest format from SrcA reg format
  * @tparam EN_FP32_MATH_FORMAT: Set to true to use math dest in Float32, otherwise default behaviour is Float16/Float16_b depending on input format exponent
  * width
- * @tparam EN_INT32_MATH_FORMAT: Set to true to use math dest in Int32, otherwise default behaviour is Float16/Float16_b depending on input format exponent width
+ * @tparam EN_INT32_MATH_FORMAT: Set to true to use math dest in Int32, otherwise default behaviour is Float16/Float16_b depending on input format exponent
+ * width
  */
 template <bool EN_IMPLIED_MATH_FORMAT, bool EN_FP32_MATH_FORMAT, bool EN_INT32_MATH_FORMAT>
 inline void _llk_math_upk_to_dest_hw_configure_()
@@ -264,11 +268,19 @@ inline void _configure_mov_ops_explicit_alu_data_format_state_(DataFormat srcA_f
         return;
     }
 
-    // For 32-bit dest, force the dest-format override to Float32 so the transpose MOVD2B/MOVB2D read
-    // the DEST via the current Float32 32b path instead of a stale saved dest format (e.g. Int32 left
+    // Quasar selects the 16-bit or 32-bit DEST bank-address bit for MOV
+    // operations from the source ALU format, and only TF32 selects the 32-bit
+    // path. Explicit 32-bit MOV sequences transfer the upper and lower 16-bit
+    // halves separately, so tagging them as TF32 fixes bank switching without
+    // changing the Float32 or Int32 payload.
+    const DataFormat mov_srcA_format = EN_32BIT_DEST ? DataFormat::Tf32 : srcA_format;
+    const DataFormat mov_srcB_format = EN_32BIT_DEST ? DataFormat::Tf32 : srcB_format;
+
+    // For 32-bit dest, also force the dest-format override to Float32 so MOVD2B/MOVB2D read
+    // DEST via the current Float32 32b path instead of a stale saved dest format (e.g. Int32 left
     // by a prior compute), which otherwise selects the wrong hi16 datum mux.
     _configure_alu_formats_<false /* EN_IMPLIED_MATH_FORMAT */, EN_32BIT_DEST>(
-        srcA_format, srcB_format, false /* en_int32_dest_format */, EN_32BIT_DEST ? DataFormat::Float32 : DataFormat::Invalid);
+        mov_srcA_format, mov_srcB_format, false /* en_int32_dest_format */, EN_32BIT_DEST ? DataFormat::Float32 : DataFormat::Invalid);
 
     data_format_config_set = DataFormatConfigSet::MOV_OPS_EXPLICIT_FMT;
 }

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_unary_broadcast.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_unary_broadcast.h
@@ -24,7 +24,7 @@ using namespace ckernel::math;
  * @tparam unpack_to_dest: When true, UNP_A wrote to dest; ADDR_MOD_3 used for dest<->srcB moves
  * @param tensor_shape: Face geometry (face_r_dim, num_faces) for row-broadcast addrmods
  */
-template <BroadcastType BROADCAST_TYPE, bool unpack_to_dest = false>
+template <BroadcastType BROADCAST_TYPE, bool unpack_to_dest>
 inline void _llk_math_eltwise_unary_broadcast_addrmod_(const TensorShape& tensor_shape)
 {
     static_assert(BROADCAST_TYPE != BroadcastType::NONE, "Broadcast type cannot be NONE");
@@ -54,14 +54,29 @@ inline void _llk_math_eltwise_unary_broadcast_addrmod_(const TensorShape& tensor
             }
                 .set(ADDR_MOD_3);
         }
-        else
+        else if constexpr (BROADCAST_TYPE == BroadcastType::COL)
         {
             addr_mod_t {
-                .srcb = {.incr = static_cast<std::uint8_t>(ELTWISE_MATH_ROWS)},
-                .dest = {.incr = static_cast<std::uint16_t>(ELTWISE_MATH_ROWS)},
+                .srcb = {.incr = 0},
+                .dest = {.incr = static_cast<std::uint16_t>(tensor_shape.face_r_dim * 2)},
             }
                 .set(ADDR_MOD_3);
         }
+        else
+        {
+            addr_mod_t {
+                .srcb = {.incr = 0},
+                .dest = {.incr = 8},
+            }
+                .set(ADDR_MOD_3);
+        }
+
+        addr_mod_t {
+            .srca = {.incr = 0},
+            .srcb = {.incr = 0},
+            .dest = {.incr = 0},
+        }
+            .set(ADDR_MOD_4);
     }
 }
 
@@ -74,99 +89,112 @@ inline void _llk_math_eltwise_unary_broadcast_addrmod_(const TensorShape& tensor
  *         ADDR_MOD_3 from addrmod.
  * @param tensor_shape: Tile shape for loop counts and row dimensions
  */
-template <BroadcastType BROADCAST_TYPE, bool unpack_to_dest = false>
+template <BroadcastType BROADCAST_TYPE, bool unpack_to_dest>
 inline void _llk_math_eltwise_unary_broadcast_mop_config_(const TensorShape& tensor_shape)
 {
     static_assert(BROADCAST_TYPE != BroadcastType::NONE, "Broadcast type cannot be NONE");
 
-    if constexpr (BROADCAST_TYPE == BroadcastType::ROW && unpack_to_dest)
+    if constexpr (unpack_to_dest)
     {
-        constexpr std::uint32_t replay_buf_start          = 1;
-        constexpr std::uint32_t replay_movb2d_instr_count = ELTWISE_MATH_ROWS;
-        constexpr std::uint32_t replay_buf_len            = replay_movb2d_instr_count;
-        load_replay_buf<replay_buf_start, replay_buf_len>(
-            []
-            {
-                TTI_MOVB2D(0, 0, ADDR_MOD_0, p_mov_src_to_dest::MOV_8_ROWS, 0, 1);
-                TTI_MOVB2D(0, 0, ADDR_MOD_2, p_mov_src_to_dest::MOV_8_ROWS, 0, 1);
-                TTI_MOVB2D(0, 0, ADDR_MOD_0, p_mov_src_to_dest::MOV_8_ROWS, 0, 1);
-                TTI_MOVB2D(0, 0, ADDR_MOD_1, p_mov_src_to_dest::MOV_8_ROWS, 0, 1);
-                TTI_MOVB2D(0, 0, ADDR_MOD_0, p_mov_src_to_dest::MOV_8_ROWS, 0, 1);
-                TTI_MOVB2D(0, 0, ADDR_MOD_2, p_mov_src_to_dest::MOV_8_ROWS, 0, 1);
-                TTI_MOVB2D(0, 0, ADDR_MOD_0, p_mov_src_to_dest::MOV_8_ROWS, 0, 1);
-                TTI_MOVB2D(0, 0, ADDR_MOD_2, p_mov_src_to_dest::MOV_8_ROWS, 0, 1);
-            });
+        if constexpr (BROADCAST_TYPE == BroadcastType::COL)
+        {
+            constexpr std::uint32_t replay_buf_len = 12;
+            load_replay_buf<0, replay_buf_len>(
+                []
+                {
+                    TTI_MOVD2B(p_mov::DEST_NORM, 0, ADDR_MOD_4, p_movd2b::MOV_8_ROWS, p_movd2b::TRANSPOSE_OFF, 0);
+                    TTI_MOVD2B(p_mov::DEST_NORM, 8, ADDR_MOD_4, p_movd2b::MOV_8_ROWS, p_movd2b::TRANSPOSE_OFF, 8);
 
-        ckernel_template temp(1, 1, TT_OP_REPLAY(replay_buf_start, replay_buf_len, 0, 0, 0, 0));
-        temp.set_end_op(TT_OP_CLEARDVALID(p_cleardvalid::CLR_SRCB_VLD, 0, 0, 0, 0, 0));
-        temp.program_bank0_sw_cntl(instrn_buffer);
+                    TTI_MOVD2B(p_mov::DEST_32B_LOW, 16, ADDR_MOD_4, p_movd2b::MOV_8_ROWS, p_movd2b::TRANSPOSE_OFF, 0);
+                    TTI_MOVD2B(p_mov::DEST_32B_LOW, 24, ADDR_MOD_4, p_movd2b::MOV_8_ROWS, p_movd2b::TRANSPOSE_OFF, 8);
+
+                    TTI_MOVB2D(p_mov::DEST_NORM, 0, ADDR_MOD_4, p_mov_src_to_dest::MOV_8_ROWS, p_movb2d::BCAST_ON, 0);
+                    TTI_MOVB2D(p_mov::DEST_NORM, 8, ADDR_MOD_4, p_mov_src_to_dest::MOV_8_ROWS, p_movb2d::BCAST_ON, 8);
+                    TTI_MOVB2D(p_mov::DEST_NORM, 0, ADDR_MOD_4, p_mov_src_to_dest::MOV_8_ROWS, p_movb2d::BCAST_ON, 16);
+                    TTI_MOVB2D(p_mov::DEST_NORM, 8, ADDR_MOD_4, p_mov_src_to_dest::MOV_8_ROWS, p_movb2d::BCAST_ON, 24);
+
+                    TTI_MOVB2D(p_mov::DEST_32B_LOW, 16, ADDR_MOD_4, p_mov_src_to_dest::MOV_8_ROWS, p_movb2d::BCAST_ON, 0);
+                    TTI_MOVB2D(p_mov::DEST_32B_LOW, 24, ADDR_MOD_4, p_mov_src_to_dest::MOV_8_ROWS, p_movb2d::BCAST_ON, 8);
+                    TTI_MOVB2D(p_mov::DEST_32B_LOW, 16, ADDR_MOD_4, p_mov_src_to_dest::MOV_8_ROWS, p_movb2d::BCAST_ON, 16);
+                    TTI_MOVB2D(p_mov::DEST_32B_LOW, 24, ADDR_MOD_3, p_mov_src_to_dest::MOV_8_ROWS, p_movb2d::BCAST_ON, 24);
+                });
+
+            ckernel_template temp(1 /* mop_outer_loop */, 2 /* mop_inner_loop */, TT_OP_REPLAY(0, replay_buf_len, 0, 0, 0, 0));
+            temp.set_end_op(TT_OP_CLEARDVALID(p_cleardvalid::CLR_SRCB_VLD, 0, 0, 0, 0, 0));
+            temp.program_bank0_sw_cntl(instrn_buffer);
+        }
+        else if (BROADCAST_TYPE == BroadcastType::ROW)
+        {
+            constexpr std::uint32_t replay_buf_len = 10;
+            load_replay_buf<0, replay_buf_len>(
+                []
+                {
+                    TTI_MOVD2B(p_mov::DEST_NORM, 0, ADDR_MOD_4, p_movd2b::MOV_8_ROWS, p_movd2b::TRANSPOSE_OFF, 0);
+                    TTI_MOVD2B(p_mov::DEST_32B_LOW, 8, ADDR_MOD_4, p_movd2b::MOV_8_ROWS, p_movd2b::TRANSPOSE_OFF, 0);
+
+                    TTI_MOVB2D(p_mov::DEST_NORM, 0, ADDR_MOD_4, p_mov_src_to_dest::MOV_8_ROWS, p_movb2d::BCAST_OFF, 0 + 1);
+                    TTI_MOVB2D(p_mov::DEST_NORM, 0, ADDR_MOD_4, p_mov_src_to_dest::MOV_8_ROWS, p_movb2d::BCAST_OFF, 8 + 1);
+                    TTI_MOVB2D(p_mov::DEST_NORM, 0, ADDR_MOD_4, p_mov_src_to_dest::MOV_8_ROWS, p_movb2d::BCAST_OFF, 32 + 1);
+                    TTI_MOVB2D(p_mov::DEST_NORM, 0, ADDR_MOD_4, p_mov_src_to_dest::MOV_8_ROWS, p_movb2d::BCAST_OFF, 40 + 1);
+
+                    TTI_MOVB2D(p_mov::DEST_32B_LOW, 8, ADDR_MOD_4, p_mov_src_to_dest::MOV_8_ROWS, p_movb2d::BCAST_OFF, 0 + 1);
+                    TTI_MOVB2D(p_mov::DEST_32B_LOW, 8, ADDR_MOD_4, p_mov_src_to_dest::MOV_8_ROWS, p_movb2d::BCAST_OFF, 8 + 1);
+                    TTI_MOVB2D(p_mov::DEST_32B_LOW, 8, ADDR_MOD_4, p_mov_src_to_dest::MOV_8_ROWS, p_movb2d::BCAST_OFF, 32 + 1);
+                    TTI_MOVB2D(p_mov::DEST_32B_LOW, 8, ADDR_MOD_3, p_mov_src_to_dest::MOV_8_ROWS, p_movb2d::BCAST_OFF, 40 + 1);
+                });
+
+            ckernel_template temp(1 /* mop_outer_loop */, 2 /* mop_inner_loop */, TT_OP_REPLAY(0, replay_buf_len, 0, 0, 0, 0));
+            temp.set_end_op(TT_OP_CLEARDVALID(p_cleardvalid::CLR_SRCB_VLD, 0, 0, 0, 0, 0));
+            temp.program_bank0_sw_cntl(instrn_buffer);
+        }
+        else // BroadcastType::SCALAR
+        {
+            constexpr std::uint32_t replay_buf_len = 4;
+            load_replay_buf<0, replay_buf_len>(
+                []
+                {
+                    TTI_MOVD2B(p_mov::DEST_NORM, 0, ADDR_MOD_4, p_movd2b::MOV_8_ROWS, p_movd2b::TRANSPOSE_OFF, 0);
+                    TTI_MOVD2B(p_mov::DEST_32B_LOW, 8, ADDR_MOD_4, p_movd2b::MOV_8_ROWS, p_movd2b::TRANSPOSE_OFF, 0);
+
+                    TTI_MOVB2D(p_mov::DEST_NORM, 0, ADDR_MOD_4, p_mov_src_to_dest::MOV_8_ROWS, p_movb2d::BCAST_ON, 0 + 1);
+                    TTI_MOVB2D(p_mov::DEST_32B_LOW, 8, ADDR_MOD_3, p_mov_src_to_dest::MOV_8_ROWS, p_movb2d::BCAST_ON, 0 + 1);
+                });
+
+            ckernel_template temp(1 /* mop_outer_loop */, 8 /* mop_inner_loop */, TT_OP_REPLAY(2, 2, 0, 0, 0, 0));
+            temp.set_start_op(TT_OP_REPLAY(0, 2, 0, 0, 0, 0));
+            temp.set_end_op(TT_OP_CLEARDVALID(p_cleardvalid::CLR_SRCB_VLD, 0, 0, 0, 0, 0));
+            temp.program_bank0_sw_cntl(instrn_buffer);
+        }
     }
     else
     {
         const std::uint32_t num_rows =
             (BROADCAST_TYPE == BroadcastType::SCALAR) ? tensor_shape.total_num_faces() * tensor_shape.face_r_dim : tensor_shape.face_r_dim;
-        const std::uint32_t outer    = (BROADCAST_TYPE == BroadcastType::SCALAR) ? 1U : static_cast<std::uint32_t>(tensor_shape.total_num_faces());
-        const std::uint32_t inner    = num_rows >> rows_log2(ELTWISE_MATH_ROWS);
+        const std::uint32_t outer = (BROADCAST_TYPE == BroadcastType::SCALAR) ? 1U : static_cast<std::uint32_t>(tensor_shape.total_num_faces());
+        const std::uint32_t inner = num_rows >> rows_log2(ELTWISE_MATH_ROWS);
 
-        const std::uint32_t dst_lo     = (BROADCAST_TYPE != BroadcastType::COL) ? 1U : 0U;
-        constexpr std::uint32_t bcast0 = (BROADCAST_TYPE == BroadcastType::COL || BROADCAST_TYPE == BroadcastType::SCALAR) ? 1U : 0U;
+        const std::uint32_t dst_addr      = (BROADCAST_TYPE != BroadcastType::COL) ? 1U : 0U;
+        constexpr std::uint32_t bcast_col = (BROADCAST_TYPE != BroadcastType::ROW) ? 1U : 0U;
 
-        const auto movb2d = [bcast0, dst_lo](std::uint8_t am) { return TT_OP_MOVB2D(0, 0, am, p_mov_src_to_dest::MOV_8_ROWS, bcast0, dst_lo); };
+        const auto bcast_instr = [bcast_col, dst_addr](std::uint8_t addr_mod)
+        { return TT_OP_MOVB2D(0, 0, addr_mod, p_mov_src_to_dest::MOV_8_ROWS, bcast_col, dst_addr); };
 
-        ckernel_template temp(outer, inner, movb2d(ADDR_MOD_0));
+        ckernel_template temp(outer, inner, bcast_instr(ADDR_MOD_0));
         temp.set_end_op(TT_OP_CLEARDVALID(p_cleardvalid::CLR_SRCB_VLD, 0, 0, 0, 0, 0));
         if constexpr (BROADCAST_TYPE == BroadcastType::SCALAR)
         {
-            temp.set_last_outer_loop_instr(movb2d(ADDR_MOD_1));
+            temp.set_last_outer_loop_instr(bcast_instr(ADDR_MOD_1));
         }
         else if constexpr (BROADCAST_TYPE == BroadcastType::COL)
         {
-            temp.set_last_inner_loop_instr(movb2d(ADDR_MOD_1));
+            temp.set_last_inner_loop_instr(bcast_instr(ADDR_MOD_1));
         }
         else
         {
-            temp.set_last_inner_loop_instr(movb2d(ADDR_MOD_0));
-            temp.set_last_outer_loop_instr(movb2d(ADDR_MOD_2));
+            temp.set_last_inner_loop_instr(bcast_instr(ADDR_MOD_0));
+            temp.set_last_outer_loop_instr(bcast_instr(ADDR_MOD_2));
         }
 
-        temp.program_bank0_sw_cntl(instrn_buffer);
-    }
-}
-
-/**
- * @brief MOP for MOVD2B when unpack wrote to dest (move dest rows back to srcB for MOVB2D).
- *
- * @tparam BROADCAST_TYPE: Scalar, row, or column broadcast, values = <COL/ROW/SCALAR>
- * @param tensor_shape: Used for row/col loop counts outside ROW special case
- */
-template <BroadcastType BROADCAST_TYPE>
-inline void _llk_math_eltwise_unary_broadcast_d2b_mop_config_(const TensorShape& tensor_shape)
-{
-    if constexpr (BROADCAST_TYPE == BroadcastType::ROW)
-    {
-        const auto f = [](std::uint8_t am, std::uint32_t d32) { return TT_OP_MOVD2B(d32, 0, am, p_movd2b::MOV_1_ROW, 0, 0); };
-
-        constexpr std::uint32_t replay_buf_len = 1;
-        load_replay_buf<0, replay_buf_len>([] { TTI_MOVD2B(0, 0, ADDR_MOD_3, p_movd2b::MOV_1_ROW, 0, 0); });
-
-        ckernel_template temp(1, 1, TT_OP_REPLAY(0, replay_buf_len, 0, 0, 0, 0), f(ADDR_MOD_3, 0));
-        temp.set_last_inner_loop_instr(f(ADDR_MOD_3, 1));
-        temp.program_bank0_sw_cntl(instrn_buffer);
-    }
-    else
-    {
-        // SCALAR: all faces × rows. COL: column broadcast touches two faces in dest (mirrors unpack UNPACR_DEST_FACE 0 and 2), so row count is 2× face_r_dim.
-        const std::uint32_t rows_sel =
-            (BROADCAST_TYPE == BroadcastType::SCALAR) ? tensor_shape.total_num_faces() * tensor_shape.face_r_dim : tensor_shape.face_r_dim * 2;
-        const std::uint32_t inner_d2b = (BROADCAST_TYPE == BroadcastType::SCALAR) ? 1U : rows_sel >> rows_log2(ELTWISE_MATH_ROWS);
-
-        const auto f = [](std::uint8_t am, std::uint32_t d32) { return TT_OP_MOVD2B(d32, 0, am, p_mov_src_to_dest::MOV_8_ROWS, 0, 0); };
-
-        constexpr std::uint32_t replay_buf_len = 1;
-        load_replay_buf<0, replay_buf_len>([] { TTI_MOVD2B(0, 0, ADDR_MOD_3, p_mov_src_to_dest::MOV_8_ROWS, 0, 0); });
-
-        ckernel_template temp(1, inner_d2b * 2, TT_OP_REPLAY(0, replay_buf_len, 0, 0, 0, 0), f(ADDR_MOD_3, 0));
-        temp.set_last_inner_loop_instr(f(ADDR_MOD_3, 1));
         temp.program_bank0_sw_cntl(instrn_buffer);
     }
 }
@@ -176,48 +204,36 @@ inline void _llk_math_eltwise_unary_broadcast_d2b_mop_config_(const TensorShape&
  *
  * @tparam BROADCAST_TYPE: Scalar, row, or column broadcast, values = <COL/ROW/SCALAR>
  * @tparam unpack_to_dest: UNP path wrote to dest; MOVB2D MOP deferred to per-tile call
- * @tparam is_fp32_dest_acc_en: Same name/position as unpack init for uniform call sites. Must be false when unpack_to_dest is true (static_assert below)
  * @param tensor_shape: Passed to addrmod / MOP setup
  * @note On the unpack thread, pair with @ref _llk_unpack_unary_broadcast_operands_init_ (T0) with matching BROADCAST_TYPE/unpack_to_dest.
  * @note @ref _llk_math_eltwise_unary_broadcast_ runs the configured op with matching template args.
  */
-template <BroadcastType BROADCAST_TYPE, bool unpack_to_dest = false, bool is_fp32_dest_acc_en = false>
+template <BroadcastType BROADCAST_TYPE, bool unpack_to_dest>
 inline void _llk_math_eltwise_unary_broadcast_init_(const TensorShape& tensor_shape)
 {
-    static_assert(!(unpack_to_dest && is_fp32_dest_acc_en), "Unary broadcast: unpack_to_dest with Float32 dest accumulation is not supported yet");
     LLK_ASSERT(tensor_shape.total_num_faces() == 4, "Unary broadcast currently only supports 32x32 tiles");
+
     _llk_math_eltwise_unary_broadcast_addrmod_<BROADCAST_TYPE, unpack_to_dest>(tensor_shape);
-    if constexpr (!unpack_to_dest)
-    {
-        _llk_math_eltwise_unary_broadcast_mop_config_<BROADCAST_TYPE, false>(tensor_shape);
-    }
+    _llk_math_eltwise_unary_broadcast_mop_config_<BROADCAST_TYPE, unpack_to_dest>(tensor_shape);
+
     _reset_counters_<p_setrwc::SET_ABD_F>();
 }
 
 /**
  * @brief Run one tile of unary broadcast math: set dest write addr, optional D2B then MOVB2D when unpack_to_dest.
  *
- * @tparam BROADCAST_TYPE: Scalar, row, or column broadcast, values = <COL/ROW/SCALAR>
- * @tparam unpack_to_dest: When true, runs D2B then MOVB2D replay for unpack-to-dest workaround
- * @tparam is_fp32_dest_acc_en: Same template args as init; combination unpack_to_dest + true is rejected in init
  * @param tile_idx: Destination tile index within current dest bank (SyncHalf)
- * @param tensor_shape: Used when unpack_to_dest (D2B / MOVB2D MOP); otherwise ignored
  * @note Call @ref _llk_math_eltwise_unary_broadcast_init_ with matching template args before this function.
  */
-template <BroadcastType BROADCAST_TYPE, bool unpack_to_dest = false, bool is_fp32_dest_acc_en = false>
-inline void _llk_math_eltwise_unary_broadcast_(const std::uint32_t tile_idx, [[maybe_unused]] const TensorShape& tensor_shape)
+inline void _llk_math_eltwise_unary_broadcast_(const std::uint32_t tile_idx)
 {
     _set_dst_write_addr_<DstTileShape::Tile32x32>(tile_idx);
 
-    if constexpr (unpack_to_dest)
-    {
-        _llk_math_eltwise_unary_broadcast_d2b_mop_config_<BROADCAST_TYPE>(tensor_shape);
-        ckernel::ckernel_template::run_bank0_sw_cntl(instrn_buffer);
-        _reset_counters_<p_setrwc::SET_ABD_F>();
-        _llk_math_eltwise_unary_broadcast_mop_config_<BROADCAST_TYPE, true>(tensor_shape);
-    }
-
+    // Wait condition SRCB_VLD is required as MOVD2B doesn't automatically wait
+    // for SrcB[MatrixUnit.SrcBBank].AllowedClient == SrcClient::MatrixUnit.
     TTI_STALLWAIT(p_stall::STALL_MATH, 0, p_stall::WAIT_SFPU, p_stall::SRCB_VLD); // TEN-4367 - SrcB sync workaround
+
     ckernel::ckernel_template::run_bank0_sw_cntl(instrn_buffer);
+
     _reset_counters_<p_setrwc::SET_ABD_F>();
 }

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_unary_broadcast.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_unary_broadcast.h
@@ -58,7 +58,7 @@ inline void _llk_math_eltwise_unary_broadcast_addrmod_(const TensorShape& tensor
         {
             addr_mod_t {
                 .srcb = {.incr = 0},
-                .dest = {.incr = static_cast<std::uint16_t>(tensor_shape.face_r_dim * 2)},
+                .dest = {.incr = static_cast<std::uint16_t>(tensor_shape.face_r_dim * tensor_shape.num_faces_c_dim)},
             }
                 .set(ADDR_MOD_3);
         }
@@ -81,7 +81,7 @@ inline void _llk_math_eltwise_unary_broadcast_addrmod_(const TensorShape& tensor
 }
 
 /**
- * @brief MOP / replay configuration for MOVB2D unary-broadcast (srcB -> dest).
+ * @brief MOP / replay configuration for unary math broadcast.
  *
  * @tparam BROADCAST_TYPE: Scalar, row, or column broadcast, values = <COL/ROW/SCALAR>
  * @tparam unpack_to_dest: When true, unpack filled dest; MOVB2D reads srcB only, so @ref _llk_math_eltwise_unary_broadcast_ runs MOVD2B (dest->srcB) first,
@@ -102,11 +102,11 @@ inline void _llk_math_eltwise_unary_broadcast_mop_config_(const TensorShape& ten
             load_replay_buf<0, replay_buf_len>(
                 []
                 {
-                    // Read F0/F1 hi16 from DEST → SrcB[0:15]
+                    // Read F0/F2 hi16 from DEST → SrcB[0:15]
                     TTI_MOVD2B(p_mov::DEST_NORM, 0, ADDR_MOD_4, p_movd2b::MOV_8_ROWS, p_movd2b::TRANSPOSE_OFF, 0);
                     TTI_MOVD2B(p_mov::DEST_NORM, 8, ADDR_MOD_4, p_movd2b::MOV_8_ROWS, p_movd2b::TRANSPOSE_OFF, 8);
 
-                    // Read F0/F1 lo16 from DEST → SrcB[16:31]
+                    // Read F0/F2 lo16 from DEST → SrcB[16:31]
                     TTI_MOVD2B(p_mov::DEST_32B_LOW, 16, ADDR_MOD_4, p_movd2b::MOV_8_ROWS, p_movd2b::TRANSPOSE_OFF, 0);
                     TTI_MOVD2B(p_mov::DEST_32B_LOW, 24, ADDR_MOD_4, p_movd2b::MOV_8_ROWS, p_movd2b::TRANSPOSE_OFF, 8);
 
@@ -127,7 +127,7 @@ inline void _llk_math_eltwise_unary_broadcast_mop_config_(const TensorShape& ten
             temp.set_end_op(TT_OP_CLEARDVALID(p_cleardvalid::CLR_SRCB_VLD, 0, 0, 0, 0, 0));
             temp.program_bank0_sw_cntl(instrn_buffer);
         }
-        else if (BROADCAST_TYPE == BroadcastType::ROW)
+        else if constexpr (BROADCAST_TYPE == BroadcastType::ROW)
         {
             constexpr std::uint32_t replay_buf_len = 10;
             load_replay_buf<0, replay_buf_len>(
@@ -164,7 +164,7 @@ inline void _llk_math_eltwise_unary_broadcast_mop_config_(const TensorShape& ten
                     TTI_MOVD2B(p_mov::DEST_NORM, 0, ADDR_MOD_4, p_movd2b::MOV_8_ROWS, p_movd2b::TRANSPOSE_OFF, 0);
                     TTI_MOVD2B(p_mov::DEST_32B_LOW, 8, ADDR_MOD_4, p_movd2b::MOV_8_ROWS, p_movd2b::TRANSPOSE_OFF, 0);
 
-                    // Write hi16 and lo0 to DEST[0:63] from SrcB[0:15] (row and column broadcast ON)
+                    // Write hi16 and lo16 to DEST[0:63] from SrcB[0:15] (row and column broadcast ON)
                     TTI_MOVB2D(p_mov::DEST_NORM, 0, ADDR_MOD_4, p_mov_src_to_dest::MOV_8_ROWS, p_movb2d::BCAST_ON, 0 + 1);
                     TTI_MOVB2D(p_mov::DEST_32B_LOW, 8, ADDR_MOD_3, p_mov_src_to_dest::MOV_8_ROWS, p_movb2d::BCAST_ON, 0 + 1); // dst += 8
                 });
@@ -211,10 +211,10 @@ inline void _llk_math_eltwise_unary_broadcast_mop_config_(const TensorShape& ten
 }
 
 /**
- * @brief Init unary-broadcast math: addrmods, MOP when not unpack_to_dest, reset counters.
+ * @brief Init unary-broadcast math: addrmods, mop configuration, reset counters.
  *
  * @tparam BROADCAST_TYPE: Scalar, row, or column broadcast, values = <COL/ROW/SCALAR>
- * @tparam unpack_to_dest: UNP path wrote to dest; MOVB2D MOP deferred to per-tile call
+ * @tparam unpack_to_dest: UNP path wrote to dest
  * @param tensor_shape: Passed to addrmod / MOP setup
  * @note On the unpack thread, pair with @ref _llk_unpack_unary_broadcast_operands_init_ (T0) with matching BROADCAST_TYPE/unpack_to_dest.
  * @note @ref _llk_math_eltwise_unary_broadcast_ runs the configured op with matching template args.
@@ -231,7 +231,7 @@ inline void _llk_math_eltwise_unary_broadcast_init_(const TensorShape& tensor_sh
 }
 
 /**
- * @brief Run one tile of unary broadcast math: set dest write addr, optional D2B then MOVB2D when unpack_to_dest.
+ * @brief Run one tile of unary broadcast math: set dest write addr
  *
  * @param tile_idx: Destination tile index within current dest bank (SyncHalf)
  * @note Call @ref _llk_math_eltwise_unary_broadcast_init_ with matching template args before this function.

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_unary_broadcast.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_unary_broadcast.h
@@ -49,7 +49,7 @@ inline void _llk_math_eltwise_unary_broadcast_addrmod_(const TensorShape& tensor
         if constexpr (BROADCAST_TYPE == BroadcastType::ROW)
         {
             addr_mod_t {
-                .srcb = {.incr = static_cast<std::uint8_t>(tensor_shape.face_r_dim)},
+                .srcb = {.incr = 0},
                 .dest = {.incr = static_cast<std::uint16_t>(tensor_shape.face_r_dim)},
             }
                 .set(ADDR_MOD_3);
@@ -66,7 +66,7 @@ inline void _llk_math_eltwise_unary_broadcast_addrmod_(const TensorShape& tensor
         {
             addr_mod_t {
                 .srcb = {.incr = 0},
-                .dest = {.incr = 8},
+                .dest = {.incr = row_step},
             }
                 .set(ADDR_MOD_3);
         }
@@ -102,21 +102,25 @@ inline void _llk_math_eltwise_unary_broadcast_mop_config_(const TensorShape& ten
             load_replay_buf<0, replay_buf_len>(
                 []
                 {
+                    // Read F0/F1 hi16 from DEST → SrcB[0:15]
                     TTI_MOVD2B(p_mov::DEST_NORM, 0, ADDR_MOD_4, p_movd2b::MOV_8_ROWS, p_movd2b::TRANSPOSE_OFF, 0);
                     TTI_MOVD2B(p_mov::DEST_NORM, 8, ADDR_MOD_4, p_movd2b::MOV_8_ROWS, p_movd2b::TRANSPOSE_OFF, 8);
 
+                    // Read F0/F1 lo16 from DEST → SrcB[16:31]
                     TTI_MOVD2B(p_mov::DEST_32B_LOW, 16, ADDR_MOD_4, p_movd2b::MOV_8_ROWS, p_movd2b::TRANSPOSE_OFF, 0);
                     TTI_MOVD2B(p_mov::DEST_32B_LOW, 24, ADDR_MOD_4, p_movd2b::MOV_8_ROWS, p_movd2b::TRANSPOSE_OFF, 8);
 
+                    // Write hi16 to DEST F0,F1/F2,F3 from SrcB[0:31] (column broadcast ON)
                     TTI_MOVB2D(p_mov::DEST_NORM, 0, ADDR_MOD_4, p_mov_src_to_dest::MOV_8_ROWS, p_movb2d::BCAST_ON, 0);
                     TTI_MOVB2D(p_mov::DEST_NORM, 8, ADDR_MOD_4, p_mov_src_to_dest::MOV_8_ROWS, p_movb2d::BCAST_ON, 8);
                     TTI_MOVB2D(p_mov::DEST_NORM, 0, ADDR_MOD_4, p_mov_src_to_dest::MOV_8_ROWS, p_movb2d::BCAST_ON, 16);
                     TTI_MOVB2D(p_mov::DEST_NORM, 8, ADDR_MOD_4, p_mov_src_to_dest::MOV_8_ROWS, p_movb2d::BCAST_ON, 24);
 
+                    // Write lo16 to DEST F0,F1/F2,F3 from SrcB[0:31] (column broadcast ON)
                     TTI_MOVB2D(p_mov::DEST_32B_LOW, 16, ADDR_MOD_4, p_mov_src_to_dest::MOV_8_ROWS, p_movb2d::BCAST_ON, 0);
                     TTI_MOVB2D(p_mov::DEST_32B_LOW, 24, ADDR_MOD_4, p_mov_src_to_dest::MOV_8_ROWS, p_movb2d::BCAST_ON, 8);
                     TTI_MOVB2D(p_mov::DEST_32B_LOW, 16, ADDR_MOD_4, p_mov_src_to_dest::MOV_8_ROWS, p_movb2d::BCAST_ON, 16);
-                    TTI_MOVB2D(p_mov::DEST_32B_LOW, 24, ADDR_MOD_3, p_mov_src_to_dest::MOV_8_ROWS, p_movb2d::BCAST_ON, 24);
+                    TTI_MOVB2D(p_mov::DEST_32B_LOW, 24, ADDR_MOD_3, p_mov_src_to_dest::MOV_8_ROWS, p_movb2d::BCAST_ON, 24); // dst += 2* face_r_dim, F0 → F2
                 });
 
             ckernel_template temp(1 /* mop_outer_loop */, 2 /* mop_inner_loop */, TT_OP_REPLAY(0, replay_buf_len, 0, 0, 0, 0));
@@ -129,18 +133,21 @@ inline void _llk_math_eltwise_unary_broadcast_mop_config_(const TensorShape& ten
             load_replay_buf<0, replay_buf_len>(
                 []
                 {
+                    // Read F0/F1 rows[0:7] hi16 and lo16 from DEST → SrcB[0:15]
                     TTI_MOVD2B(p_mov::DEST_NORM, 0, ADDR_MOD_4, p_movd2b::MOV_8_ROWS, p_movd2b::TRANSPOSE_OFF, 0);
                     TTI_MOVD2B(p_mov::DEST_32B_LOW, 8, ADDR_MOD_4, p_movd2b::MOV_8_ROWS, p_movd2b::TRANSPOSE_OFF, 0);
 
+                    // Write hi16 to DEST F0,F2/F1,F3 from SrcB[0:7] (row broadcast ON)
                     TTI_MOVB2D(p_mov::DEST_NORM, 0, ADDR_MOD_4, p_mov_src_to_dest::MOV_8_ROWS, p_movb2d::BCAST_OFF, 0 + 1);
                     TTI_MOVB2D(p_mov::DEST_NORM, 0, ADDR_MOD_4, p_mov_src_to_dest::MOV_8_ROWS, p_movb2d::BCAST_OFF, 8 + 1);
                     TTI_MOVB2D(p_mov::DEST_NORM, 0, ADDR_MOD_4, p_mov_src_to_dest::MOV_8_ROWS, p_movb2d::BCAST_OFF, 32 + 1);
                     TTI_MOVB2D(p_mov::DEST_NORM, 0, ADDR_MOD_4, p_mov_src_to_dest::MOV_8_ROWS, p_movb2d::BCAST_OFF, 40 + 1);
 
+                    // Write lo16 to DEST F0,F2/F1,F3 from SrcB[8:15] (row broadcast ON)
                     TTI_MOVB2D(p_mov::DEST_32B_LOW, 8, ADDR_MOD_4, p_mov_src_to_dest::MOV_8_ROWS, p_movb2d::BCAST_OFF, 0 + 1);
                     TTI_MOVB2D(p_mov::DEST_32B_LOW, 8, ADDR_MOD_4, p_mov_src_to_dest::MOV_8_ROWS, p_movb2d::BCAST_OFF, 8 + 1);
                     TTI_MOVB2D(p_mov::DEST_32B_LOW, 8, ADDR_MOD_4, p_mov_src_to_dest::MOV_8_ROWS, p_movb2d::BCAST_OFF, 32 + 1);
-                    TTI_MOVB2D(p_mov::DEST_32B_LOW, 8, ADDR_MOD_3, p_mov_src_to_dest::MOV_8_ROWS, p_movb2d::BCAST_OFF, 40 + 1);
+                    TTI_MOVB2D(p_mov::DEST_32B_LOW, 8, ADDR_MOD_3, p_mov_src_to_dest::MOV_8_ROWS, p_movb2d::BCAST_OFF, 40 + 1); // dst += face_r_dim, F0 → F1
                 });
 
             ckernel_template temp(1 /* mop_outer_loop */, 2 /* mop_inner_loop */, TT_OP_REPLAY(0, replay_buf_len, 0, 0, 0, 0));
@@ -153,11 +160,13 @@ inline void _llk_math_eltwise_unary_broadcast_mop_config_(const TensorShape& ten
             load_replay_buf<0, replay_buf_len>(
                 []
                 {
+                    // Read F0 rows[0:7] hi16 and lo16 from DEST → SrcB[0:15]
                     TTI_MOVD2B(p_mov::DEST_NORM, 0, ADDR_MOD_4, p_movd2b::MOV_8_ROWS, p_movd2b::TRANSPOSE_OFF, 0);
                     TTI_MOVD2B(p_mov::DEST_32B_LOW, 8, ADDR_MOD_4, p_movd2b::MOV_8_ROWS, p_movd2b::TRANSPOSE_OFF, 0);
 
+                    // Write hi16 and lo0 to DEST[0:63] from SrcB[0:15] (row and column broadcast ON)
                     TTI_MOVB2D(p_mov::DEST_NORM, 0, ADDR_MOD_4, p_mov_src_to_dest::MOV_8_ROWS, p_movb2d::BCAST_ON, 0 + 1);
-                    TTI_MOVB2D(p_mov::DEST_32B_LOW, 8, ADDR_MOD_3, p_mov_src_to_dest::MOV_8_ROWS, p_movb2d::BCAST_ON, 0 + 1);
+                    TTI_MOVB2D(p_mov::DEST_32B_LOW, 8, ADDR_MOD_3, p_mov_src_to_dest::MOV_8_ROWS, p_movb2d::BCAST_ON, 0 + 1); // dst += 8
                 });
 
             ckernel_template temp(1 /* mop_outer_loop */, 8 /* mop_inner_loop */, TT_OP_REPLAY(2, 2, 0, 0, 0, 0));
@@ -173,11 +182,13 @@ inline void _llk_math_eltwise_unary_broadcast_mop_config_(const TensorShape& ten
         const std::uint32_t outer = (BROADCAST_TYPE == BroadcastType::SCALAR) ? 1U : static_cast<std::uint32_t>(tensor_shape.total_num_faces());
         const std::uint32_t inner = num_rows >> rows_log2(ELTWISE_MATH_ROWS);
 
-        const std::uint32_t dst_addr      = (BROADCAST_TYPE != BroadcastType::COL) ? 1U : 0U;
+        const std::uint32_t bcast_row     = (BROADCAST_TYPE != BroadcastType::COL) ? 1U : 0U;
         constexpr std::uint32_t bcast_col = (BROADCAST_TYPE != BroadcastType::ROW) ? 1U : 0U;
 
-        const auto bcast_instr = [bcast_col, dst_addr](std::uint8_t addr_mod)
-        { return TT_OP_MOVB2D(0, 0, addr_mod, p_mov_src_to_dest::MOV_8_ROWS, bcast_col, dst_addr); };
+        const auto bcast_instr = [bcast_col, bcast_row](std::uint8_t addr_mod)
+        {
+            return TT_OP_MOVB2D(0, 0, addr_mod, p_mov_src_to_dest::MOV_8_ROWS, bcast_col, bcast_row /* dst_addr */);
+        }; // adding 1 to dst_addr enables row broadcast
 
         ckernel_template temp(outer, inner, bcast_instr(ADDR_MOD_0));
         temp.set_end_op(TT_OP_CLEARDVALID(p_cleardvalid::CLR_SRCB_VLD, 0, 0, 0, 0, 0));

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_unpack_unary_broadcast_operands.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_unpack_unary_broadcast_operands.h
@@ -32,7 +32,6 @@ inline void _llk_unpack_unary_broadcast_operands_mop_config_(const std::uint32_t
         unpack_to_dest || (UNP_SEL == p_unpacr::UNP_B),
         "UNP_SEL must be p_unpacr::UNP_B when unpack_to_dest is false - movA2D broadcast is not working on Quasar");
     static_assert((BROADCAST_TYPE != BroadcastType::NONE), "Broadcast type cannot be NONE for this operation");
-    static_assert(!(unpack_to_dest && is_fp32_dest_acc_en), "Unary broadcast: unpack_to_dest with Float32 dest accumulation is not supported yet");
 
     const std::uint32_t MOP_OUTER_LOOP            = num_tiles;
     constexpr std::uint32_t MOP_INNER_LOOP        = 1;
@@ -45,7 +44,7 @@ inline void _llk_unpack_unary_broadcast_operands_mop_config_(const std::uint32_t
             {
                 if constexpr (unpack_to_dest)
                 {
-                    TT_UNPACR_DEST_ROW(0 /*Dst_Row_Idx*/, 0 /*Src_Row_Idx*/, 0 /*Dst_Face_Idx*/, 0 /*Src_Face_Idx*/, 0, 0, buf_desc_id, 1 /*SetDatValid*/);
+                    TT_UNPACR_DEST_ROW(0 /*Dst_Row_Idx*/, 0 /*Src_Row_Idx*/, 0 /*Dst_Face_Idx*/, 0 /*Src_Face_Idx*/, 0, 0, buf_desc_id, 0 /*SetDatValid*/);
                 }
                 else
                 {
@@ -61,7 +60,7 @@ inline void _llk_unpack_unary_broadcast_operands_mop_config_(const std::uint32_t
                 if constexpr (unpack_to_dest)
                 {
                     TT_UNPACR_DEST_ROW(0 /*Dst_Row_Idx*/, 0 /*Src_Row_Idx*/, 0 /*Dst_Face_Idx*/, 0 /*Src_Face_Idx*/, 0, 0, buf_desc_id, 0 /*SetDatValid*/);
-                    TT_UNPACR_DEST_ROW(0 /*Dst_Row_Idx*/, 0 /*Src_Row_Idx*/, 1 /*Dst_Face_Idx*/, 1 /*Src_Face_Idx*/, 0, 0, buf_desc_id, 1 /*SetDatValid*/);
+                    TT_UNPACR_DEST_ROW(0 /*Dst_Row_Idx*/, 0 /*Src_Row_Idx*/, 1 /*Dst_Face_Idx*/, 1 /*Src_Face_Idx*/, 0, 0, buf_desc_id, 0 /*SetDatValid*/);
                 }
                 else
                 {
@@ -81,7 +80,7 @@ inline void _llk_unpack_unary_broadcast_operands_mop_config_(const std::uint32_t
                 if constexpr (unpack_to_dest)
                 {
                     TT_UNPACR_DEST_FACE(0 /*Dst Face Idx*/, 0 /*Src Face Idx*/, 0, 0, buf_desc_id, 0 /*SetDatValid*/);
-                    TT_UNPACR_DEST_FACE(2 /*Dst Face Idx*/, 2 /*Src Face Idx*/, 0, 0, buf_desc_id, 1 /*SetDatValid*/);
+                    TT_UNPACR_DEST_FACE(2 /*Dst Face Idx*/, 2 /*Src Face Idx*/, 0, 0, buf_desc_id, 0 /*SetDatValid*/);
                 }
                 else
                 {
@@ -105,6 +104,10 @@ inline void _llk_unpack_unary_broadcast_operands_mop_config_(const std::uint32_t
     }
 
     ckernel_template temp(MOP_OUTER_LOOP, MOP_INNER_LOOP, TT_OP_REPLAY(0, replay_buf_len, 0, 0, 0, 0), inc_src_tile_instrn);
+    if constexpr (unpack_to_dest)
+    {
+        temp.set_end_op(TT_OP_INC_DST_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, p_unpacr::UNP_A, 1));
+    }
     temp.program_bank0_sw_cntl(instrn_buffer);
 }
 

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_unpack_unary_broadcast_operands.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_unpack_unary_broadcast_operands.h
@@ -20,12 +20,10 @@ using namespace ckernel;
  * @tparam UNP_SEL: Unpacker select; must be UNP_B unless unpack_to_dest (then UNP_A), values = <p_unpacr::UNP_A/UNP_B>
  * @tparam BROADCAST_TYPE: Broadcast type, values = <COL/ROW/SCALAR>
  * @tparam unpack_to_dest: When true, unpack targets math dest (UNP_A); otherwise SrcB (UNP_B), values = <true/false>
- * @tparam is_fp32_dest_acc_en: Float32 dest accumulation enable. Must be false when unpack_to_dest is true
- *         until that path is supported (enforced by static_assert below), values = <true/false>
  * @param buf_desc_id: Buffer descriptor for the UNPACR source.
  * @param num_tiles: Outer MOP loop count (tiles to unpack from L1).
  */
-template <std::uint32_t UNP_SEL, BroadcastType BROADCAST_TYPE, bool unpack_to_dest = false, bool is_fp32_dest_acc_en = false>
+template <std::uint32_t UNP_SEL, BroadcastType BROADCAST_TYPE, bool unpack_to_dest = false>
 inline void _llk_unpack_unary_broadcast_operands_mop_config_(const std::uint32_t buf_desc_id, const std::uint32_t num_tiles)
 {
     static_assert(
@@ -117,18 +115,17 @@ inline void _llk_unpack_unary_broadcast_operands_mop_config_(const std::uint32_t
  * @tparam UNP_SEL: Unpacker resource; must be UNP_B unless unpack_to_dest, values = <p_unpacr::UNP_A/UNP_B>
  * @tparam BROADCAST_TYPE: Broadcast type, values = <COL/ROW/SCALAR>
  * @tparam unpack_to_dest: Route unpack to dest (UNP_A) vs SrcB (UNP_B), values = <true/false>
- * @tparam is_fp32_dest_acc_en: Forwarded to mop_config; must be false when unpack_to_dest is true, values = <true/false>
  * @param buf_desc_id: Buffer descriptor for the UNPACR source.
  * @param num_tiles: Number of tiles in the outer unpack loop.
  * @note On the math thread, pair with @ref _llk_math_eltwise_unary_broadcast_init_ (T1) with matching BROADCAST_TYPE/unpack_to_dest.
  * @note @ref _llk_unpack_unary_broadcast_operands_ is the matching execute call on this thread.
  */
-template <std::uint32_t UNP_SEL, BroadcastType BROADCAST_TYPE, bool unpack_to_dest = false, bool is_fp32_dest_acc_en = false>
+template <std::uint32_t UNP_SEL, BroadcastType BROADCAST_TYPE, bool unpack_to_dest = false>
 inline void _llk_unpack_unary_broadcast_operands_init_(const std::uint32_t buf_desc_id, const std::uint32_t num_tiles)
 {
     cfg_rmw(THCON_UNPACKER0_REG0_TRANSPOSE_RMW, 0);
     cfg_rmw(THCON_UNPACKER1_REG0_TRANSPOSE_RMW, 0);
-    _llk_unpack_unary_broadcast_operands_mop_config_<UNP_SEL, BROADCAST_TYPE, unpack_to_dest, is_fp32_dest_acc_en>(buf_desc_id, num_tiles);
+    _llk_unpack_unary_broadcast_operands_mop_config_<UNP_SEL, BROADCAST_TYPE, unpack_to_dest>(buf_desc_id, num_tiles);
 }
 
 /**


### PR DESCRIPTION
## What changed

- Tag explicit 32-bit destination MOV sequences as TF32 when configuring their source ALU formats.
- Preserve the existing 32-bit destination-format override.
- Leave 16-bit destination MOV configuration unchanged.

## Why

The failure only occurs after `DstSync::Half` changes destination banks while using `unpack_to_dest=true`.

A targeted two-section waveform capture showed that the first destination section was produced and consumed correctly. After ownership advanced to the second section, unpack and pack agreed on the active bank, but the math MOV sequence wrote into a different physical destination region. This ruled out output comparison, input generation, and pack clearing as the primary cause.

Comparing the working first section with the failing second section showed that the discrepancy was in how explicit MOV operations selected the destination bank-address bit in 32-bit mode. That selection is derived from the configured MOV source format. Float32 and Int32 tags did not select the 32-bit MOV addressing path, while TF32 did.

The explicit 32-bit MOV sequences already transfer the upper and lower 16-bit halves separately, so using TF32 as the source tag changes the addressing classification without changing the Float32 or Int32 payload.

After the change, a second waveform capture showed the math writes and pack reads using the same destination region across the bank switch.

## Validation

Executed through `tt_metal/tt-llk/.claude/scripts/run_test.sh` on the Quasar simulator:

- Float32 scalar unary broadcast, `unpack_to_dest=true`, `DstSync::Half`
- Int32 scalar unary broadcast, `unpack_to_dest=true`, `DstSync::Half`
- Float16_b scalar unary broadcast neighboring cases

Result: 4 passed.

Fixes #51329

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=vvukomanovic/fix-51329-quasar-dest-bank-mov)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:vvukomanovic/fix-51329-quasar-dest-bank-mov)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=vvukomanovic/fix-51329-quasar-dest-bank-mov)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:vvukomanovic/fix-51329-quasar-dest-bank-mov)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=vvukomanovic/fix-51329-quasar-dest-bank-mov)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:vvukomanovic/fix-51329-quasar-dest-bank-mov)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=vvukomanovic/fix-51329-quasar-dest-bank-mov)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:vvukomanovic/fix-51329-quasar-dest-bank-mov)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=vvukomanovic/fix-51329-quasar-dest-bank-mov)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:vvukomanovic/fix-51329-quasar-dest-bank-mov)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=vvukomanovic/fix-51329-quasar-dest-bank-mov)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vvukomanovic/fix-51329-quasar-dest-bank-mov)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=vvukomanovic/fix-51329-quasar-dest-bank-mov)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vvukomanovic/fix-51329-quasar-dest-bank-mov)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=vvukomanovic/fix-51329-quasar-dest-bank-mov)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vvukomanovic/fix-51329-quasar-dest-bank-mov)