### PR TITLE
[Bugfix] Reject DRAM tensor binding tokens in LocalTensorAccessor

### DIFF
--- a/tt_metal/hw/inc/api/tensor/local_tensor_accessor.h
+++ b/tt_metal/hw/inc/api/tensor/local_tensor_accessor.h
@@ -54,6 +54,12 @@ public:
         // The region's L1 base address is stored in the CRTA at the token-supplied offset.
         // Delegates to the legacy constructor, which takes a raw L1 base address.
         LocalTensorAccessor(get_common_arg_val<uint32_t>(ADDR_CRTA_OFFSET / sizeof(uint32_t))) {
+        // LocalTensorAccessor is legal only for tensors stored in L1 (SRAM) node-local memory.
+        // Hard error if TensorBindingToken represents a DRAM tensor.
+        static_assert(
+            !tensor_accessor::TensorBindingToken<CTA_OFFSET, ADDR_CRTA_OFFSET>::args_t::is_dram,
+            "LocalTensorAccessor requires an L1-resident tensor, but this binding token is for a DRAM "
+            "tensor. A DRAM tensor has no node-local L1 region; use TensorAccessor instead.");
         // ADDR_CRTA_OFFSET is a byte offset; dividing recovers the word index
         static_assert(
             ADDR_CRTA_OFFSET % sizeof(uint32_t) == 0, "TensorBindingToken: ADDR_CRTA_OFFSET must be 4-byte aligned");


### PR DESCRIPTION
### PR Category
Bugfix (legality only)

### Summary
A LocalTensorAccessor reads a tensor's node-local L1 region directly, so constructing one from a DRAM tensor's binding token is meaningless — there is no local L1 region. It previously compiled silently and would read garbage from a bogus (DRAM) base address at runtime. 

Add a compile-time static_assert on the token's is_dram flag so the mistake is a clear build error instead.

### Notes for reviewers
Vetted locally on a kernel compile. Doesn't seem worth a unit test for a static assert.
I scanned the codebase for (mis)users; there were none that will get affected by the new check.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=akertesz/local-tensor-guards)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:akertesz/local-tensor-guards)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=akertesz/local-tensor-guards)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:akertesz/local-tensor-guards)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=akertesz/local-tensor-guards)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:akertesz/local-tensor-guards)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=akertesz/local-tensor-guards)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:akertesz/local-tensor-guards)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=akertesz/local-tensor-guards)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:akertesz/local-tensor-guards)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=akertesz/local-tensor-guards)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:akertesz/local-tensor-guards)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=akertesz/local-tensor-guards)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:akertesz/local-tensor-guards)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=akertesz/local-tensor-guards)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:akertesz/local-tensor-guards)