### PR TITLE
Add blaze-authored Blackhole LLKs to experimental

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_math_deepseek_moe_gate_eltwise_binary_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_math_deepseek_moe_gate_eltwise_binary_api.h
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+#include "llk_math_common_api.h"
+#include "experimental/llk_math_deepseek_moe_gate_eltwise_binary.h"
+
+/*************************************************************************
+ * LLK ELTWISE BINARY
+ *************************************************************************/
+
+// Version with operands
+template <EltwiseBinaryType eltwise_binary_type, DeepseekMoeGateEltwiseBinaryMode mode, MathFidelity math_fidelity>
+inline void llk_math_deepseek_moe_gate_eltwise_binary_init_with_operands(
+    const std::uint32_t operand_A, const std::uint32_t operand_B, const std::uint32_t acc_to_dest = 0) {
+    const std::uint32_t operand_id = get_operand_id(operand_A);  // both operands must have same number of faces
+    const std::uint32_t num_faces = get_operand_num_faces(operand_id);
+
+    _llk_math_deepseek_moe_gate_eltwise_binary_init_<eltwise_binary_type, mode, math_fidelity>(num_faces, acc_to_dest);
+}
+
+template <EltwiseBinaryType eltwise_binary_type, bool is_fp32_dest_acc_en, MathFidelity math_fidelity>
+inline void llk_math_deepseek_moe_gate_eltwise_binary(
+    const std::uint32_t operand_A,
+    const std::uint32_t operand_B,
+    std::uint32_t dst_index,
+    const bool clear_fp32_dst_acc) {
+    const std::uint32_t operand_id = get_operand_id(operand_A);  // both operands must have same number of faces
+    const std::uint32_t num_faces = get_operand_num_faces(operand_id);
+
+    _llk_math_deepseek_moe_gate_eltwise_binary_<eltwise_binary_type, DST_SYNC_MODE, is_fp32_dest_acc_en, math_fidelity>(
+        num_faces, dst_index, clear_fp32_dst_acc);
+}

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_math_hadamard_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_math_hadamard_api.h
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "llk_math_common_api.h"
+#include "experimental/llk_math_hadamard.h"
+
+template <MathFidelity math_fidelity = MathFidelity::HiFi4, bool normalize = true>
+inline void llk_math_hadamard_h128_init() {
+    _llk_math_hadamard_h128_init_<math_fidelity, normalize>();
+}
+
+template <MathFidelity math_fidelity = MathFidelity::HiFi4, bool normalize = true>
+inline void llk_math_hadamard_h128(uint32_t dst_index) {
+    LLK_ASSERT((dst_index < get_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE, DstTileShape::Tile32x32>()), "");
+    _llk_math_hadamard_h128_<math_fidelity, normalize>(dst_index);
+}
+
+inline void llk_math_hadamard_h128_uninit() { _llk_math_hadamard_h128_uninit_(); }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_math_unary_datacopy_softmax_k_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_math_unary_datacopy_softmax_k_api.h
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "experimental/llk_math_eltwise_unary_datacopy_softmax_k.h"
+#include "llk_math_common_api.h"
+
+/*************************************************************************
+ * LLK ELTWISE UNARY DATACOPY — SOFTMAX K
+ *************************************************************************/
+
+inline void llk_math_eltwise_unary_datacopy_softmax_k(uint dst_index) {
+    LLK_ASSERT((dst_index < get_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE, DstTileShape::Tile32x32>()), "");
+    _llk_math_eltwise_unary_datacopy_softmax_k_(dst_index);
+}
+
+inline void llk_math_eltwise_unary_datacopy_softmax_k_init() { _llk_math_eltwise_unary_datacopy_softmax_k_init_(); }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_sfpu/llk_math_generic_moe_gate_topk_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_sfpu/llk_math_generic_moe_gate_topk_api.h
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "llk_math_eltwise_unary_sfpu_init.h"
+#include "llk_math_eltwise_unary_sfpu_params.h"
+#include "sfpu/experimental/ckernel_sfpu_generic_moe_gate_topk.h"
+
+namespace ckernel {
+namespace sfpu {
+
+inline void llk_math_sfpu_generic_moe_gate_topk_init() {
+    llk_math_eltwise_unary_sfpu_init<SfpuType::unused>(_init_generic_moe_gate_topk_);
+}
+
+template <
+    bool normalize,
+    int num_selected_experts,
+    int num_total_experts,
+    bool zero_tail = false,
+    bool full_sort = false,
+    bool generate_indices = true>
+inline void llk_math_sfpu_generic_moe_gate_topk(uint32_t eps, uint32_t scale) {
+    _llk_math_eltwise_unary_sfpu_params_(
+        _generic_moe_gate_topk_<
+            normalize,
+            num_selected_experts,
+            num_total_experts,
+            zero_tail,
+            full_sort,
+            generate_indices>,
+        0,
+        VectorMode::RC_custom,
+        eps,
+        scale);
+}
+
+}  // namespace sfpu
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_sfpu/llk_math_softmax_k_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_sfpu/llk_math_softmax_k_api.h
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "llk_math_eltwise_unary_sfpu_init.h"
+#include "llk_math_eltwise_unary_sfpu_params.h"
+#include "sfpu/experimental/ckernel_sfpu_softmax_k.h"
+
+namespace ckernel {
+namespace sfpu {
+
+inline void llk_math_sfpu_softmax_k_init() { llk_math_eltwise_unary_sfpu_init<SfpuType::unused>(_init_softmax_k_); }
+
+template <int k>
+inline void llk_math_sfpu_softmax_k() {
+    _llk_math_eltwise_unary_sfpu_params_(_softmax_k_<k>, 0, VectorMode::RC_custom);
+}
+
+}  // namespace sfpu
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_unpack_hadamard_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_unpack_hadamard_api.h
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "llk_unpack_common_api.h"
+#include "experimental/llk_unpack_hadamard.h"
+
+// One-shot unpack init for the H128 transform. Configures the unpackers
+// for single-face (16x16) operands and preprograms context 1's srcA base
+// with the H_16 tile's L1 address. Call once during init, after
+// llk_unpack_hw_configure. H_16 must stay resident at this address for
+// the program's lifetime. Operand order: operandA = h16, operandB = input.
+inline void llk_unpack_hadamard_h128_init(
+    const std::uint32_t operandA, const std::uint32_t operandB, const std::uint32_t h16_tile_index) {
+    const std::uint32_t operandA_id = get_operand_id(operandA);  // h16
+    LLK_ASSERT(get_operand_num_faces(operandA_id) == 1, "Hadamard H128 unpack requires single-face h16 operand");
+    LLK_ASSERT(
+        get_operand_num_faces(get_operand_id(operandB)) == 1,
+        "Hadamard H128 unpack requires single-face input operand");
+
+    const std::uint32_t base_address = get_local_cb_interface(operandA_id).fifo_rd_ptr - 1;
+    const std::uint32_t address = base_address + get_local_cb_interface(operandA_id).fifo_page_size * h16_tile_index;
+    _llk_unpack_hadamard_h128_init_(address);
+}
+
+// One tile's worth of Hadamard unpack: phase 1 (h16 -> srcB, input ->
+// srcA bank 0, zeroed + narrowed to 8 rows) and phase 2 (H_16 -> srcA
+// bank 1). Operand order: operandA = h16 (srcB), operandB = input (srcA).
+inline void llk_unpack_hadamard_h128(
+    const std::uint32_t operandA,
+    const std::uint32_t operandB,
+    const std::uint32_t tile_index_a,
+    const std::uint32_t tile_index_b) {
+    const std::uint32_t operandA_id = get_operand_id(operandA);  // h16
+    const std::uint32_t operandB_id = get_operand_id(operandB);  // input
+
+    const std::uint32_t base_address_a = get_local_cb_interface(operandA_id).fifo_rd_ptr - 1;
+    const std::uint32_t base_address_b = get_local_cb_interface(operandB_id).fifo_rd_ptr - 1;
+
+    const std::uint32_t tile_size_a = get_local_cb_interface(operandA_id).fifo_page_size;
+    const std::uint32_t tile_size_b = get_local_cb_interface(operandB_id).fifo_page_size;
+
+    WAYPOINT("UPHW");
+    _llk_unpack_hadamard_h128_(base_address_a, base_address_b, tile_index_a, tile_index_b, tile_size_a, tile_size_b);
+    WAYPOINT("UPHD");
+}

--- a/tt_metal/hw/inc/api/compute/experimental/eltwise_add_scalar.h
+++ b/tt_metal/hw/inc/api/compute/experimental/eltwise_add_scalar.h
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "api/compute/compute_kernel_api.h"
+#include "api/compute/common.h"
+#include "api/compute/eltwise_binary.h"
+
+#ifdef TRISC_MATH
+#include "llk_math_binary_api.h"
+#endif
+#ifdef TRISC_UNPACK
+#include "llk_unpack_AB_api.h"
+#endif
+
+namespace ckernel {
+
+// ============================================================================
+// Binary dest reuse add
+// ============================================================================
+
+/**
+ * Init for binary dest reuse add
+ */
+template <EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::DEST_TO_SRCA>
+ALWI void deepseek_binary_dest_reuse_add_tiles_init(uint32_t icb0, uint32_t call_line = __builtin_LINE()) {
+    state_configure(icb0, call_line);
+    UNPACK((llk_unpack_A_init<BroadcastType::NONE, true, binary_reuse_dest>(false, false, icb0)));
+    MATH(
+        (llk_math_eltwise_binary_init<EltwiseBinaryType::ELWADD, BroadcastType::NONE, MATH_FIDELITY, binary_reuse_dest>(
+            icb0, icb0)));
+}
+
+/**
+ * Binary dest reuse add
+ * dest[idst] = dest[idst] + cb[in_tile_index]
+ */
+template <
+    bool fp32_dest_acc_en = DST_ACCUM_MODE,
+    EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::DEST_TO_SRCA>
+ALWI void deepseek_binary_dest_reuse_add_tiles(uint32_t icb, uint32_t in_tile_index, uint32_t idst) {
+    UNPACK((llk_unpack_A<BroadcastType::NONE, true, binary_reuse_dest>(icb, in_tile_index)));
+    MATH((llk_math_eltwise_binary<
+          EltwiseBinaryType::ELWADD,
+          BroadcastType::NONE,
+          fp32_dest_acc_en,
+          MATH_FIDELITY,
+          binary_reuse_dest>(icb, icb, idst, true)));
+}
+
+}  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/experimental/generic_moe_gate.h
+++ b/tt_metal/hw/inc/api/compute/experimental/generic_moe_gate.h
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "api/compute/compute_kernel_api.h"
+#include "api/compute/common.h"
+// Blackhole-only: the MoE-gate FPU/SFPU LLKs live only in the Blackhole llk_lib.
+#if defined(TRISC_MATH) && defined(ARCH_BLACKHOLE)
+#include "experimental/llk_math_deepseek_moe_gate_eltwise_binary_api.h"  // fpu kernel which puts values into tile 0 of dest and values+bias into tile 2
+#include "experimental/llk_sfpu/llk_math_generic_moe_gate_topk_api.h"
+#endif
+
+namespace ckernel {
+
+#if defined(ARCH_BLACKHOLE)
+
+ALWI void generic_moe_gate_init(uint32_t icb0, uint32_t icb1) {
+    UNPACK((llk_unpack_AB_init<BroadcastType::NONE>(icb0, icb1)));
+
+    // Init copy add (FPU)
+    MATH((llk_math_deepseek_moe_gate_eltwise_binary_init_with_operands<
+          EltwiseBinaryType::ELWADD,
+          DeepseekMoeGateEltwiseBinaryMode::COPY,
+          MATH_FIDELITY>(icb0, icb1, false)));
+    // Init topk (SFPU)
+    MATH((sfpu::llk_math_sfpu_generic_moe_gate_topk_init()));
+}
+
+// generate_indices lets the SFPU fill DST[1] with the position identity [0..N-1] before sorting, which is
+// what standalone GenericMoeGate needs since it uploads no index tensor. Set it false when the caller has
+// pre-loaded DST[1] via copy_tile(input_indices, 0, 1) and wants that mapping to survive the sort -- the
+// bit-15-flagged SRAM slots the hot/cold KimiMoeGate path relies on.
+template <
+    bool normalize = false,
+    int num_selected_experts = 8,
+    int num_total_experts = 256,
+    bool zero_tail = false,
+    bool full_sort = false,
+    bool generate_indices = true>
+ALWI void generic_moe_gate(uint32_t icb0, uint32_t icb1, uint32_t eps, uint32_t scale) {
+    // NOTE: only num_selected_experts == 16 selects the top-16 SFPU path; every other value routes to
+    // top-8, which emits at most eight winners, so 9..15 silently yield 8 rather than the requested
+    // count. Deliberately not static_assert'd here: callers currently advertise a wider contract (blaze's
+    // gptoss_moe_router validates 1..16 and forwards it straight through), so constraining it here alone
+    // would turn a reachable-but-wrong configuration into a build break. Caller validation and this
+    // template have to be tightened together.
+    // Copy add (FPU)
+    UNPACK((llk_unpack_AB(icb0, icb1, 0, 0)));
+    MATH((llk_math_deepseek_moe_gate_eltwise_binary<EltwiseBinaryType::ELWADD, DST_ACCUM_MODE, MATH_FIDELITY>(
+        icb0, icb1, 0, true)));
+
+    // Topk SFPU
+    MATH((sfpu::llk_math_sfpu_generic_moe_gate_topk<
+          normalize,
+          num_selected_experts,
+          num_total_experts,
+          zero_tail,
+          full_sort,
+          generate_indices>(eps, scale)));
+}
+
+#endif
+
+}  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/experimental/hadamard.h
+++ b/tt_metal/hw/inc/api/compute/experimental/hadamard.h
@@ -1,0 +1,130 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Compute-API surface for the H128 (1x128) Hadamard transform.
+//
+// Computes Y = (1/sqrt(128)) * H_128 * x on a single tile (normalize=true,
+// default) or Y = H_128 * x (normalize=false) using the FPU/MM path.
+// See llk_math_hadamard.h for the algorithmic derivation.
+//
+// All operands are 1-face [16, 16] tiles; the inputs are bfloat16 and
+// the result is packed out as bfp8 (bfloat8_b). The math is a custom
+// narrow MOP: one (LoFi) or two (high-fidelity) MVMULs per matmul pass
+// with a MOVD2B bridge, then an SFPU element-wise scale when normalize
+// is true. H_16 is streamed into srcA bank 1 by the unpack thread
+// (overlapping MM1), and the two passes write disjoint dst faces, so
+// there is no MOVB2A copy and no ZEROACC.
+//
+// Tile-format assumptions (caller's responsibility):
+//
+//   h16_cb : single [16, 16] bfloat16 tile. H_16 fills the entire face.
+//            Routed to srcB face (0, 0).
+//
+//   in_cb  : single [16, 16] bfloat16 tile. The 128 real input values
+//            live in rows [0..8), cols [0..16). The unpack path zeroes
+//            rows [8..16) itself (ZEROSRC over the full srcA span, see
+//            llk_unpack_hadamard.h), so callers need not pad them.
+//            Routed to srcA face (0, 0).
+//
+//   out_cb : single [16, 16] bfp8 (bfloat8_b) tile. The 1x128 result
+//            lives in face 0 rows [0..8), cols [0..16). The caller
+//            acquires the dst tile clean (zeroed) and runs one transform
+//            per acquire; MM2 writes face 0, MM1's scratch lands in face 1.
+//
+// Fidelity: MATH_FIDELITY drives the math LLK. LoFi runs one MVMUL per
+// pass; any high fidelity runs two per pass with an asymmetric phase
+// step (MM1 +1, MM2 +2) that skips the zero-valued phases against the
+// ±1 H_16 operand — 4 MVMULs total for full bf16 precision. See
+// llk_math_hadamard.h for the phase derivation.
+
+#pragma once
+
+#include "api/compute/common.h"
+#include "api/compute/reconfig_data_format.h"
+
+// Blackhole-only: the H128 math/unpack LLKs live only in the Blackhole llk_lib.
+#if defined(TRISC_MATH) && defined(ARCH_BLACKHOLE)
+#include "experimental/llk_math_hadamard_api.h"
+#endif
+
+#if defined(TRISC_UNPACK) && defined(ARCH_BLACKHOLE)
+#include "experimental/llk_unpack_hadamard_api.h"
+#endif
+
+namespace ckernel {
+
+#if defined(ARCH_BLACKHOLE)
+
+// clang-format off
+/**
+ * Full initialization for the H128 Hadamard transform. Call once at the
+ * top of a kernel before any hadamard_h128_tile call.
+ *
+ * The `normalize` template flag controls whether a post-MM2 SFPU pass
+ * multiplies dst rows 0..7 by 1/sqrt(128). Default true; set false for
+ * callers that apply their own normalization externally.
+ *
+ * | Argument         | Description                                                            | Type     | Valid Range            | Required              |
+ * |------------------|------------------------------------------------------------------------|----------|------------------------|-----------------------|
+ * | in_cb_id         | The 1x128 input vector tile ([16, 16]; padding auto-zeroed on unpack)  | uint32_t | 0 to 31                | True                  |
+ * | h16_cb_id        | The H_16 weight tile ([16, 16], H_16 fills the single face)            | uint32_t | 0 to 31                | True                  |
+ * | out_cb_id        | The 1x128 output vector tile ([16, 16], result in rows 0..7)           | uint32_t | 0 to 31                | True                  |
+ * | fp32_dest_acc_en | Whether to enable fp32 accumulation in dest                            | bool     | true/false             | False (default off)   |
+ */
+// clang-format on
+template <bool normalize = true, bool fp32_dest_acc_en = DST_ACCUM_MODE>
+ALWI void hadamard_h128_init(const uint32_t in_cb_id, const uint32_t h16_cb_id, const uint32_t out_cb_id) {
+    // Configure both unpackers from h16's [16,16] single-face geometry so the
+    // unpacker config is INDEPENDENT of the input CB's tile shape: srcA reads
+    // the input data with h16's [16,16] config (a 4x[1,32] feed is read as 8
+    // rows of 16), srcB reads h16. Both operands are bf16. in_cb_id is passed
+    // to the init only for its single-face assertion.
+    UNPACK((llk_unpack_hw_configure<fp32_dest_acc_en>(h16_cb_id, h16_cb_id)));
+    UNPACK((llk_unpack_hadamard_h128_init(h16_cb_id, in_cb_id, /*h16_tile_index=*/0)));
+
+    MATH((llk_math_pack_sync_init<fp32_dest_acc_en>()));
+    MATH((llk_math_hw_configure<fp32_dest_acc_en>(h16_cb_id, h16_cb_id)));
+    MATH((llk_math_hadamard_h128_init<MATH_FIDELITY, normalize>()));
+
+    // Fully re-establish the packer HW config + dest layout for out_cb_id.
+    PACK((llk_pack_hw_configure<fp32_dest_acc_en>(out_cb_id)));
+    PACK((llk_pack_dest_init<fp32_dest_acc_en, ckernel::PackMode::Default>()));
+}
+
+// clang-format off
+/**
+ * Perform one H128 Hadamard transform on the current tile. When
+ * normalize=true (default), the result is scaled by 1/sqrt(128) in-place
+ * on the SFPU after the two matmul passes.
+ *
+ * | Argument         | Description                                                  | Type     | Valid Range                                    | Required              |
+ * |------------------|--------------------------------------------------------------|----------|------------------------------------------------|-----------------------|
+ * | in_cb_id         | CB holding the 1x128 input tile (padding auto-zeroed)        | uint32_t | 0 to 31                                        | True                  |
+ * | h16_cb_id        | CB holding the H_16 weight tile (H_16 fills the face)        | uint32_t | 0 to 31                                        | True                  |
+ * | in_tile_index    | Index of the input tile within in_cb_id                      | uint32_t | < CB size                                      | True                  |
+ * | h16_tile_index   | Index of the H_16 tile within h16_cb_id                      | uint32_t | < CB size                                      | True                  |
+ * | dst_index        | DST register index that will receive the result Y            | uint32_t | < acquired DST size                            | True                  |
+ */
+// clang-format on
+template <bool normalize = true>
+ALWI void hadamard_h128_tile(
+    const uint32_t in_cb_id,
+    const uint32_t h16_cb_id,
+    const uint32_t in_tile_index,
+    const uint32_t h16_tile_index,
+    const uint32_t dst_index) {
+    // Single-face Hadamard unpack: phase 1 (context 0) h16 -> srcB,
+    // input -> srcA bank 0 (zeroed + narrowed to 8 rows); phase 2 streams
+    // H_16 into srcA bank 1 (overlaps MM1) so MM2 needs no MOVB2A. See
+    // llk_unpack_hadamard.h.
+    UNPACK((llk_unpack_hadamard_h128(h16_cb_id, in_cb_id, h16_tile_index, in_tile_index)));
+
+    MATH((llk_math_hadamard_h128<MATH_FIDELITY, normalize>(dst_index)));
+}
+
+inline void hadamard_h128_uninit() { MATH((llk_math_hadamard_h128_uninit())); }
+
+#endif
+
+}  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/experimental/pack_rows_to_addr.h
+++ b/tt_metal/hw/inc/api/compute/experimental/pack_rows_to_addr.h
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+// Generic pack_rows_to_addr: pack N row-major rows from DEST to an arbitrary
+// L1 byte address. Reusable across cache-update ops (dsa_indexer_cache_update,
+// kv_cache_update, etc.) for patching rows directly into untilized buffers.
+
+#pragma once
+
+#include "api/compute/common.h"
+
+namespace ckernel {
+
+// Blackhole + Wormhole: the row-pack LLKs (llk_pack_rows.h) exist in both of those llk_libs but not in
+// tt_llk_quasar, so this is an exclusion guard rather than the ARCH_BLACKHOLE inclusion guard the other
+// experimental headers here use.
+#ifndef ARCH_QUASAR
+
+ALWI void pack_rows_to_addr_init(uint32_t num_rows) { PACK((llk_pack_rows_init(num_rows))); }
+
+// NOTE: this raw path bypasses the llk_pack_rows wrapper's dst_index bound check, because it packs to an
+// arbitrary L1 address rather than a CB. Callers are responsible for keeping idst within DEST capacity.
+ALWI void pack_rows_to_addr(uint32_t idst, uint32_t l1_addr) { PACK((_llk_pack_rows_(idst, l1_addr - 1))); }
+
+ALWI void pack_rows_to_addr_uninit() {
+    PACK((llk_pack_rows_uninit()));
+    // pack_rows_to_addr_init (llk_pack_rows_init) overwrote ADDR_MOD_0/1 with
+    // row-pack address mods; llk_pack_rows_uninit only restores the X counter.
+    // Restore the Default tile-pack addrmods so the init/uninit pair is symmetric
+    // and downstream ops that pack via MOP-only pack_block_contiguous_init (which
+    // does not reconfigure addrmods) do not inherit the row-pack mods. This is the
+    // same primitive llk_pack_init<Default> uses to set ADDR_MOD_0/1/2.
+    PACK((_llk_pack_configure_addrmod_<PackMode::Default>()));
+}
+
+#endif
+
+}  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/experimental/sdpa_weighted_reduce.h
+++ b/tt_metal/hw/inc/api/compute/experimental/sdpa_weighted_reduce.h
@@ -1,0 +1,213 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Lightweight "weighted reduction" matmul for the DSA indexer SDPA op.
+//
+// Computes, per chunk:   out[1, 32] = weights[1, 8] x qk[8, 32]
+//   out[p] = sum_{h=0..7} weights[h] * qk[h, p]      (p = 0..31)
+//
+// Realized with two TTI_MVMUL instructions (no matmul MOP / replay reprogram).
+// On Blackhole MVMUL computes  Dst[i,j] += sum_k SrcB[i,k] * SrcA[k,j], so:
+//   - SrcB holds the weights vector in row 0 (cols 0..7 = head weights, 8..15
+//     zero). Rows 1..7 are zero, so only Dst row 0 is populated.
+//   - SrcA holds the qk matrix; face0 = qk[0:8, 0:16], face1 = qk[0:8, 16:32]
+//     sits one 16-row face above face0 in SrcA.
+//   - MVMUL #1 (qk face0)  -> Dst rows 0..7,  cols 0..15  (face0, out[0:16])
+//     then ADDR_MOD_0 advances SrcA +16 rows (-> face1) and Dst +16 rows.
+//   - MVMUL #2 (qk face1)  -> Dst rows 16..23, cols 0..15 (face1, out[16:32]).
+// So DEST logical row 0 == out[0:32] (face0 row0 cols0..15 + face1 row0
+// cols16..31). Only logical row 0 is meaningful.
+//
+// DEST half: this op interleaves with the QK sdpa_custom_mm each chunk and runs
+// on the second SyncHalf of the pair. Math and pack both target the
+// framework-tracked dest half (get_dest_buffer_base() on the math side,
+// SEC0_Offset on the pack side); these stay in sync via the tile_regs
+// acquire/commit/release protocol. The packer ZEROACCs that half on
+// dest-section-done, so the accumulating MVMULs always start from a cleared bank
+// -- no manual clear or src-valid stall needed.
+//
+// The packer then writes DEST logical row 0 (two faces, one row each, single
+// interface, two raw PACR -- no pack MOP) straight into the chunk's logical row of
+// the `partial` tile (tiled layout) -- no row-major round-trip / tilize.
+
+#pragma once
+
+#include "api/compute/common.h"
+#ifdef TRISC_MATH
+#include "llk_math_common_api.h"
+#endif
+#ifdef TRISC_UNPACK
+#include "llk_unpack_AB_api.h"
+#endif
+#ifdef TRISC_PACK
+#include "llk_pack_common.h"
+#endif
+
+namespace ckernel {
+
+// Blackhole-only: the body is written against Blackhole SFPU/packer encodings. The LLK headers included
+// above are arch-generic, so only the API surface needs gating.
+#if defined(ARCH_BLACKHOLE)
+
+// Re-establish the weighted-reduce unpack/math/pack config for one chunk.
+//   weights_cb : [1, 32] tile (row 0 cols 0..7 = head weights)  -> SrcB
+//   qk_cb      : [8, 32] tile (two 8x16 faces)                  -> SrcA
+//   partial_cb : [32, 32] destination tile                      -> pack out
+inline void weighted_reduce_init_short(
+    const std::uint32_t weights_cb, const std::uint32_t qk_cb, const std::uint32_t partial_cb) {
+    // SrcA <- qk (operandA), SrcB <- weights (operandB).
+    reconfig_data_format<SrcOrder::Regular, true>(qk_cb, weights_cb);
+    UNPACK((cfg_reg_rmw_tensix<THCON_SEC0_REG2_Haloize_mode_RMW>(0)));
+    UNPACK(TTI_SETADCXX(p_setadc::UNP_A, FACE_R_DIM * FACE_C_DIM - 1, 0x0));
+}
+
+// Configure the weighted-reduce ADDR_MODs. These are constant across chunks, so
+// call once outside the per-chunk loop (the QK matmul and regular pack init leave
+// ADDR_MOD_6 (math) and ADDR_MOD_3 (pack) untouched).
+//   MATH ADDR_MOD_6 : after MVMUL #1, advance SrcA by one 16-row face (-> qk
+//                     face1) and DEST by 8 rows.
+//   PACK ADDR_MOD_3 : between the two pack PACR, step the DEST read to face1.
+// (MVMUL #2 uses ADDR_MOD_3 from sdpa_custom_mm_init; PACR #2 uses ADDR_MOD_1 from
+// regular pack init.)
+inline void weighted_reduce_addrmod_init() {
+    MATH((addr_mod_t{
+        .srca = {.incr = 16, .clr = 0, .cr = 0},
+        .srcb = {.incr = 0, .clr = 0, .cr = 0},
+        .dest = {.incr = 8, .clr = 0, .cr = 0},
+    }
+              .set(ADDR_MOD_6)));
+    PACK((addr_mod_pack_t{
+        .y_src = {.incr = 0, .clr = 0, .cr = 0},
+        .y_dst = {.incr = 1, .clr = 0, .cr = 0},
+        .z_src = {.incr = 1, .clr = 0},
+        .z_dst = {.incr = 0, .clr = 0},
+    }
+              .set(ADDR_MOD_3)));
+}
+
+#ifdef TRISC_MATH
+inline void weighted_reduce_math_impl() {
+    math::reset_counters(p_setrwc::SET_ABD_F);
+    // Target tile 0 of the framework-tracked dest half (kept in sync with the
+    // packer, which ZEROACCs this half on dest-section-done, so the accumulating
+    // MVMULs start from a cleared bank).
+    TT_SETC16(DEST_TARGET_REG_CFG_MATH_Offset_ADDR32, get_dest_buffer_base());
+    // MVMUL #1: qk face0 -> Dst row 0 (out[0:16]); then advance SrcA+16, Dst+16.
+    TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_6, 0);
+    // MVMUL #2: qk face1 -> Dst row 16 (out[16:32]); clear SrcA/SrcB.
+    // ADDR_MOD_3 is set in sdpa_custom_mm_init
+    TTI_MVMUL(p_setrwc::CLR_AB, 0, ADDR_MOD_3, 0);
+}
+#endif
+
+#ifdef TRISC_UNPACK
+// Raw (no-MOP) replacement for llk_unpack_AB(qk, weights, 0, 0): load tile 0 of
+// qk -> SrcA (both faces) and tile 0 of weights -> SrcB. One SrcB unpack is enough
+// since the MVMULs only read SrcB cols 0..7 (weights face0). Three UNPACR replace
+// the standard AB template MOP, with SetDatValid deferred to the last unpack of
+// each source so both srcs go valid only once fully loaded.
+inline void weighted_reduce_unpack_impl(const std::uint32_t weights_cb, const std::uint32_t qk_cb) {
+    const std::uint32_t qk_id = get_operand_id(qk_cb);            // operandA -> SrcA
+    const std::uint32_t weights_id = get_operand_id(weights_cb);  // operandB -> SrcB
+    const std::uint32_t address_a = get_local_cb_interface(qk_id).fifo_rd_ptr - 1;
+    const std::uint32_t address_b = get_local_cb_interface(weights_id).fifo_rd_ptr - 1;
+
+    volatile std::uint32_t tt_reg_ptr* cfg = get_cfg_pointer();
+
+    TTI_SETADCZW(0b011, 0, 0, 0, 0, 0b1111);  // reset both unpackers' counters
+    // Wait for a free context, program SrcA/SrcB base addresses, release to unpacker.
+    wait_for_next_context(2);
+    _llk_unpack_configure_addresses_(address_a, address_b, cfg);
+    semaphore_post(semaphore::UNPACK_SYNC);
+    TTI_STALLWAIT(p_stall::STALL_UNPACK, p_stall::TRISC_CFG);
+
+    // qk face0 -> SrcA rows 0..15; AddrMode advances the L1 read + SrcA write to
+    // face1, no dvalid yet.
+    TTI_UNPACR(SrcA, 0b00010001, 0, 0, 0, 1, 0, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
+    // weights -> SrcB row 0; sets SrcB dvalid.
+    TTI_UNPACR(SrcB, 0b00000000, 0, 0, 0, 1, 1, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
+    // qk face1 -> SrcA rows 16..31; sets SrcA dvalid.
+    TTI_UNPACR(SrcA, 0b00000000, 0, 0, 0, 1, 1, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
+
+    t6_semaphore_get(semaphore::UNPACK_SYNC);
+    switch_config_context(unp_cfg_context);
+
+    TTI_SETADCZW(0b011, 0, 0, 0, 0, 0b1111);  // reset both unpackers' counters
+}
+#endif
+
+// Unpack qk + weights and run the two MVMULs. Call between tile_regs_acquire and
+// tile_regs_commit.
+inline void weighted_reduce(const std::uint32_t weights_cb, const std::uint32_t qk_cb) {
+    UNPACK((weighted_reduce_unpack_impl(weights_cb, qk_cb)));
+    MATH((weighted_reduce_math_impl()));
+}
+
+#ifdef TRISC_PACK
+// Pack DEST logical row 0 (two faces, one row each) into the chunk's row
+// of the `partial` tile. chunk maps to row (chunk % TILE_R_DIM) of
+// tile (chunk / TILE_R_DIM). Packer L1 addresses are in 16B words
+// (cb_addr_shift == 4): one face row = 16 bf16 = 32 B = 2 words; a 16x16 face = 32 words
+inline void weighted_reduce_pack_impl(const std::uint32_t partial_cb, const std::uint32_t chunk) {
+    constexpr std::uint32_t row_1x32_size_words = 4;  // 1x32 = 4 words
+    const std::uint32_t tile = chunk / TILE_R_DIM;
+    const std::uint32_t row = chunk % TILE_R_DIM;
+    const std::uint8_t out_id = get_output_id(partial_cb);
+    const std::uint32_t addr =
+        get_output_tile_address<true, ckernel::PackMode::Default>(out_id, tile) + row * row_1x32_size_words;
+
+    // ADDR_MOD_3 (pack) is configured once by weighted_reduce_addrmod_init().
+    set_dst_write_addr(0);             // read DEST tile 0 (logical row 0 = result)
+    program_packer_destination(addr);  // L1 write base for face0/face1 of this row
+    // Raw (no-MOP) pack of DEST logical row 0 into the partial tile's row. PACR #1
+    // (ADDR_MOD_3, set above) packs face0 and steps the DEST read to face1; PACR #2
+    // (ADDR_MOD_1 from regular pack init) packs face1 and closes the tile (Last=1).
+    TTI_PACR(
+        p_pacr::CFG_CTXT_0,
+        p_pacr::NO_ROW_PAD_ZERO,
+        p_pacr::DST_ACCESS_NORMAL_MODE,
+        ADDR_MOD_3,
+        p_pacr::ADDR_CNT_CTXT_0,
+        p_pacr::P_ZERO_OUTPUT_DISABLED,
+        p_pacr::SINGLE_INTF_ACTIVE,
+        0,
+        0,
+        0,
+        0,
+        0);
+    TTI_PACR(
+        p_pacr::CFG_CTXT_0,
+        p_pacr::NO_ROW_PAD_ZERO,
+        p_pacr::DST_ACCESS_NORMAL_MODE,
+        ADDR_MOD_1,
+        p_pacr::ADDR_CNT_CTXT_0,
+        p_pacr::P_ZERO_OUTPUT_DISABLED,
+        p_pacr::SINGLE_INTF_ACTIVE,
+        0,
+        0,
+        0,
+        0,
+        1);
+    TTI_SETADCZW(p_setadc::PAC, 0, 0, 0, 0, 0b0101);  // reset z counters
+}
+#endif
+
+// Pack the result. Call between tile_regs_wait and tile_regs_release.
+inline void weighted_reduce_pack(const std::uint32_t partial_cb, const std::uint32_t chunk) {
+    PACK((weighted_reduce_pack_impl(partial_cb, chunk)));
+}
+
+// Restore dataformats, and cfgs to what is needed for sdpa_custom_mm_block
+inline void weighted_reduce_uninit(const std::uint32_t q_in_cb, const std::uint32_t k_in_cb) {
+    // SrcA <- k_in (operandA), SrcB <- q_in (operandB).
+    reconfig_data_format<SrcOrder::Regular, true>(k_in_cb, q_in_cb);
+    UNPACK((cfg_reg_rmw_tensix<THCON_SEC0_REG2_Haloize_mode_RMW>(1)));
+    // UnpA unpacks full tiles
+    constexpr std::uint32_t unpA_x_end = TILE_NUM_FACES * FACE_R_DIM * FACE_C_DIM - 1;
+    UNPACK(TTI_SETADCXX(p_setadc::UNP_A, unpA_x_end, 0x0));
+}
+
+#endif
+
+}  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/experimental/softmax_k.h
+++ b/tt_metal/hw/inc/api/compute/experimental/softmax_k.h
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "api/compute/compute_kernel_api.h"
+#include "api/compute/common.h"
+#include "api/debug/dprint.h"
+// Blackhole-only: the softmax_k datacopy/SFPU LLKs live only in the Blackhole llk_lib.
+#if defined(TRISC_MATH) && defined(ARCH_BLACKHOLE)
+#include "experimental/llk_math_unary_datacopy_softmax_k_api.h"
+#include "experimental/llk_sfpu/llk_math_softmax_k_api.h"
+#endif
+
+#ifdef TRISC_UNPACK
+#include "llk_unpack_A.h"
+#endif
+
+namespace ckernel {
+
+#if defined(ARCH_BLACKHOLE)
+
+ALWI void softmax_k_init(uint32_t icb) {
+    UNPACK((llk_unpack_A_init<BroadcastType::SCALAR, false, EltwiseBinaryReuseDestType::NONE, false>(false, 1, icb)));
+    MATH((llk_math_eltwise_unary_datacopy_softmax_k_init()));
+    MATH((sfpu::llk_math_sfpu_softmax_k_init()));
+}
+
+template <int k = 8>
+ALWI void softmax_k(uint32_t icb) {
+    // NOTE: the implementation handles at most 16 lanes, and the odd-tail mask computes 1u << (k - 1), so k
+    // outside [1, 16] is not supported. Callers validate this today (blaze's softmax_k op asserts the same
+    // range), and it is deliberately not static_assert'd here to keep this a copy of blaze's header.
+    // Unpack row0 to srcB
+    UNPACK((llk_unpack_A<BroadcastType::SCALAR, false, EltwiseBinaryReuseDestType::NONE, false>(icb, 0)));
+
+    // B2D direct copy and scalar broadcast.
+    MATH((llk_math_eltwise_unary_datacopy_softmax_k(0)));
+
+    // Softmax
+    MATH((sfpu::llk_math_sfpu_softmax_k<k>()));
+}
+
+#endif
+
+}  // namespace ckernel

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/experimental/ckernel_sfpu_generic_moe_gate_topk.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/experimental/ckernel_sfpu_generic_moe_gate_topk.h
@@ -1,0 +1,258 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+#include "ckernel.h"
+#include "ckernel_addrmod.h"
+#include "ckernel_instr_params.h"
+#include "ckernel_ops.h"
+#include "ckernel_sfpu_recip.h"
+#include "lltt.h"
+#include "sfpi.h"
+#include "sfpu/ckernel_sfpu_converter.h"
+#include "sfpu/ckernel_sfpu_load_config.h"
+
+namespace ckernel
+{
+namespace sfpu
+{
+
+static constexpr std::uint32_t generic_moe_gate_dst_tile_offset = 64;
+static constexpr std::uint32_t generic_moe_gate_scores_tile     = 0;
+static constexpr std::uint32_t generic_moe_gate_indices_tile    = 1 * generic_moe_gate_dst_tile_offset;
+static constexpr std::uint32_t generic_moe_gate_bias_tile       = 2 * generic_moe_gate_dst_tile_offset;
+static constexpr std::uint32_t generic_moe_gate_interm_tile     = 3 * generic_moe_gate_dst_tile_offset;
+
+// Load a full 16-row face. LREG0-3 hold biased scores; LREG4-7 pack
+// indices into LO16 and original scores into HI16.
+template <std::uint32_t offset>
+inline void _generic_moe_gate_load_16_rows_even_odd_split_()
+{
+    TTI_SFPLOAD(p_sfpu::LREG0, 0, ADDR_MOD_7, generic_moe_gate_bias_tile + 0 + offset);
+    TTI_SFPLOAD(p_sfpu::LREG1, 0, ADDR_MOD_7, generic_moe_gate_bias_tile + 4 + offset);
+    TTI_SFPLOAD(p_sfpu::LREG2, 0, ADDR_MOD_7, generic_moe_gate_bias_tile + 8 + offset);
+    TTI_SFPLOAD(p_sfpu::LREG3, 0, ADDR_MOD_7, generic_moe_gate_bias_tile + 12 + offset);
+
+    TTI_SFPLOAD(p_sfpu::LREG4, InstrModLoadStore::LO16_ONLY, ADDR_MOD_7, generic_moe_gate_indices_tile + 0 + offset);
+    TTI_SFPLOAD(p_sfpu::LREG5, InstrModLoadStore::LO16_ONLY, ADDR_MOD_7, generic_moe_gate_indices_tile + 4 + offset);
+    TTI_SFPLOAD(p_sfpu::LREG6, InstrModLoadStore::LO16_ONLY, ADDR_MOD_7, generic_moe_gate_indices_tile + 8 + offset);
+    TTI_SFPLOAD(p_sfpu::LREG7, InstrModLoadStore::LO16_ONLY, ADDR_MOD_7, generic_moe_gate_indices_tile + 12 + offset);
+    TTI_SFPLOAD(p_sfpu::LREG4, InstrModLoadStore::HI16_ONLY, ADDR_MOD_7, generic_moe_gate_scores_tile + 0 + offset);
+    TTI_SFPLOAD(p_sfpu::LREG5, InstrModLoadStore::HI16_ONLY, ADDR_MOD_7, generic_moe_gate_scores_tile + 4 + offset);
+    TTI_SFPLOAD(p_sfpu::LREG6, InstrModLoadStore::HI16_ONLY, ADDR_MOD_7, generic_moe_gate_scores_tile + 8 + offset);
+    TTI_SFPLOAD(p_sfpu::LREG7, InstrModLoadStore::HI16_ONLY, ADDR_MOD_7, generic_moe_gate_scores_tile + 12 + offset);
+}
+
+template <std::uint32_t offset>
+inline void _generic_moe_gate_store_16_rows_even_odd_split_()
+{
+    TTI_SFPSTORE(p_sfpu::LREG0, 0, ADDR_MOD_7, generic_moe_gate_bias_tile + 0 + offset);
+    TTI_SFPSTORE(p_sfpu::LREG1, 0, ADDR_MOD_7, generic_moe_gate_bias_tile + 4 + offset);
+    TTI_SFPSTORE(p_sfpu::LREG2, 0, ADDR_MOD_7, generic_moe_gate_bias_tile + 8 + offset);
+    TTI_SFPSTORE(p_sfpu::LREG3, 0, ADDR_MOD_7, generic_moe_gate_bias_tile + 12 + offset);
+
+    TTI_SFPSTORE(p_sfpu::LREG4, InstrModLoadStore::LO16_ONLY, ADDR_MOD_7, generic_moe_gate_indices_tile + 0 + offset);
+    TTI_SFPSTORE(p_sfpu::LREG5, InstrModLoadStore::LO16_ONLY, ADDR_MOD_7, generic_moe_gate_indices_tile + 4 + offset);
+    TTI_SFPSTORE(p_sfpu::LREG6, InstrModLoadStore::LO16_ONLY, ADDR_MOD_7, generic_moe_gate_indices_tile + 8 + offset);
+    TTI_SFPSTORE(p_sfpu::LREG7, InstrModLoadStore::LO16_ONLY, ADDR_MOD_7, generic_moe_gate_indices_tile + 12 + offset);
+    TTI_SFPSTORE(p_sfpu::LREG4, InstrModLoadStore::HI16_ONLY, ADDR_MOD_7, generic_moe_gate_scores_tile + 0 + offset);
+    TTI_SFPSTORE(p_sfpu::LREG5, InstrModLoadStore::HI16_ONLY, ADDR_MOD_7, generic_moe_gate_scores_tile + 4 + offset);
+    TTI_SFPSTORE(p_sfpu::LREG6, InstrModLoadStore::HI16_ONLY, ADDR_MOD_7, generic_moe_gate_scores_tile + 8 + offset);
+    TTI_SFPSTORE(p_sfpu::LREG7, InstrModLoadStore::HI16_ONLY, ADDR_MOD_7, generic_moe_gate_scores_tile + 12 + offset);
+}
+
+template <std::uint32_t offset>
+inline void _generic_moe_gate_load_8_rows_even_odd_split_()
+{
+    TTI_SFPLOAD(p_sfpu::LREG0, 0, ADDR_MOD_7, generic_moe_gate_bias_tile + 0 + offset);
+    TTI_SFPLOAD(p_sfpu::LREG1, 0, ADDR_MOD_7, generic_moe_gate_bias_tile + 4 + offset);
+    TTI_SFPLOAD(p_sfpu::LREG2, 0, ADDR_MOD_7, generic_moe_gate_bias_tile + 2 + offset);
+    TTI_SFPLOAD(p_sfpu::LREG3, 0, ADDR_MOD_7, generic_moe_gate_bias_tile + 6 + offset);
+
+    TTI_SFPLOAD(p_sfpu::LREG4, InstrModLoadStore::LO16_ONLY, ADDR_MOD_7, generic_moe_gate_indices_tile + 0 + offset);
+    TTI_SFPLOAD(p_sfpu::LREG5, InstrModLoadStore::LO16_ONLY, ADDR_MOD_7, generic_moe_gate_indices_tile + 4 + offset);
+    TTI_SFPLOAD(p_sfpu::LREG6, InstrModLoadStore::LO16_ONLY, ADDR_MOD_7, generic_moe_gate_indices_tile + 2 + offset);
+    TTI_SFPLOAD(p_sfpu::LREG7, InstrModLoadStore::LO16_ONLY, ADDR_MOD_7, generic_moe_gate_indices_tile + 6 + offset);
+    TTI_SFPLOAD(p_sfpu::LREG4, InstrModLoadStore::HI16_ONLY, ADDR_MOD_7, generic_moe_gate_scores_tile + 0 + offset);
+    TTI_SFPLOAD(p_sfpu::LREG5, InstrModLoadStore::HI16_ONLY, ADDR_MOD_7, generic_moe_gate_scores_tile + 4 + offset);
+    TTI_SFPLOAD(p_sfpu::LREG6, InstrModLoadStore::HI16_ONLY, ADDR_MOD_7, generic_moe_gate_scores_tile + 2 + offset);
+    TTI_SFPLOAD(p_sfpu::LREG7, InstrModLoadStore::HI16_ONLY, ADDR_MOD_7, generic_moe_gate_scores_tile + 6 + offset);
+}
+
+template <std::uint32_t offset>
+inline void _generic_moe_gate_store_8_rows_even_odd_split_()
+{
+    TTI_SFPSTORE(p_sfpu::LREG0, 0, ADDR_MOD_7, generic_moe_gate_bias_tile + 0 + offset);
+    TTI_SFPSTORE(p_sfpu::LREG1, 0, ADDR_MOD_7, generic_moe_gate_bias_tile + 4 + offset);
+
+    TTI_SFPSTORE(p_sfpu::LREG4, InstrModLoadStore::LO16_ONLY, ADDR_MOD_7, generic_moe_gate_indices_tile + 0 + offset);
+    TTI_SFPSTORE(p_sfpu::LREG5, InstrModLoadStore::LO16_ONLY, ADDR_MOD_7, generic_moe_gate_indices_tile + 4 + offset);
+    TTI_SFPSTORE(p_sfpu::LREG4, InstrModLoadStore::HI16_ONLY, ADDR_MOD_7, generic_moe_gate_scores_tile + 0 + offset);
+    TTI_SFPSTORE(p_sfpu::LREG5, InstrModLoadStore::HI16_ONLY, ADDR_MOD_7, generic_moe_gate_scores_tile + 4 + offset);
+}
+
+// Shared P1-P3 network: build a length-16 bitonic sequence in LREG0-3.
+inline void _generic_moe_gate_build_bitonic8_()
+{
+    // P1 - Bitonic 2.
+    TTI_SFPTRANSP(0, 0, 0, 0);
+    TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG1, p_sfpswap::ALL_ROWS_MAX);
+    TTI_SFPSWAP(0, p_sfpu::LREG3, p_sfpu::LREG2, p_sfpswap::ALL_ROWS_MAX);
+
+    // P2 - Bitonic 4.
+    TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG2, p_sfpswap::ROWS_02_MAX);
+    TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG3, p_sfpswap::ROWS_02_MAX);
+    TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG1, p_sfpswap::ROWS_02_MAX);
+    TTI_SFPSWAP(0, p_sfpu::LREG2, p_sfpu::LREG3, p_sfpswap::ROWS_02_MAX);
+
+    // P3 - Bitonic 8.
+    TTI_SFPTRANSP(0, 0, 0, 0);
+    TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG1, p_sfpswap::ALL_ROWS_MAX);
+    TTI_SFPSWAP(0, p_sfpu::LREG3, p_sfpu::LREG2, p_sfpswap::ALL_ROWS_MAX);
+    TTI_SFPTRANSP(0, 0, 0, 0);
+    TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG2, p_sfpswap::ROWS_01_MAX);
+    TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG3, p_sfpswap::ROWS_01_MAX);
+    TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG1, p_sfpswap::ROWS_01_MAX);
+    TTI_SFPSWAP(0, p_sfpu::LREG2, p_sfpu::LREG3, p_sfpswap::ROWS_01_MAX);
+    TTI_SFPTRANSP(0, 0, 0, 0);
+}
+
+inline void _generic_moe_gate_bitonic8_steps_3_to_1_()
+{
+    TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG1, p_sfpswap::ALL_ROWS_MAX);
+    TTI_SFPSWAP(0, p_sfpu::LREG3, p_sfpu::LREG2, p_sfpswap::ALL_ROWS_MAX);
+
+    TTI_SFPTRANSP(0, 0, 0, 0);
+    TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG2, p_sfpswap::ROWS_01_MAX);
+    TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG3, p_sfpswap::ROWS_01_MAX);
+
+    TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG1, p_sfpswap::ROWS_01_MAX);
+    TTI_SFPSWAP(0, p_sfpu::LREG2, p_sfpu::LREG3, p_sfpswap::ROWS_01_MAX);
+    TTI_SFPTRANSP(0, 0, 0, 0);
+}
+
+template <int num_rows, int scores_offset>
+inline void _generic_moe_gate_normalize_(std::uint32_t eps, std::uint32_t scale)
+{
+    TTI_SFPLOAD(p_sfpu::LREG0, 0, ADDR_MOD_7, scores_offset + 0);
+    TTI_SFPLOAD(p_sfpu::LREG1, 0, ADDR_MOD_7, scores_offset + 4);
+    if constexpr (num_rows > 8)
+    {
+        TTI_SFPLOAD(p_sfpu::LREG2, 0, ADDR_MOD_7, scores_offset + 8);
+        TTI_SFPLOAD(p_sfpu::LREG3, 0, ADDR_MOD_7, scores_offset + 12);
+        TTI_SFPADD(p_sfpu::LREG0, p_sfpu::LCONST_1, p_sfpu::LREG1, p_sfpu::LREG0, 0);
+        TTI_SFPADD(p_sfpu::LREG0, p_sfpu::LCONST_1, p_sfpu::LREG2, p_sfpu::LREG0, 0);
+        TTI_SFPADD(p_sfpu::LREG0, p_sfpu::LCONST_1, p_sfpu::LREG3, p_sfpu::LREG0, 0);
+    }
+    else
+    {
+        TTI_SFPADD(p_sfpu::LREG0, p_sfpu::LCONST_1, p_sfpu::LREG1, p_sfpu::LREG0, 0);
+    }
+
+    TTI_SFPTRANSP(0, 0, 0, 0);
+    TTI_SFPADD(p_sfpu::LREG0, p_sfpu::LCONST_1, p_sfpu::LREG1, p_sfpu::LREG0, 0);
+    TTI_SFPADD(p_sfpu::LREG2, p_sfpu::LCONST_1, p_sfpu::LREG3, p_sfpu::LREG2, 0);
+    TTI_SFPADD(p_sfpu::LREG0, p_sfpu::LCONST_1, p_sfpu::LREG2, p_sfpu::LREG0, 0);
+
+    TTI_SFPCONFIG(0, 0xF, 1);
+    sfpi::vFloat l0                 = sfpi::l_reg[sfpi::LRegs::LReg0];
+    sfpi::vFloat eps_value          = Converter::as_float(eps);
+    l0                              = l0 + eps_value;
+    l0                              = sfpu_reciprocal<false>(l0);
+    sfpi::vFloat scale_value        = Converter::as_float(scale);
+    l0                              = l0 * scale_value;
+    sfpi::l_reg[sfpi::LRegs::LReg0] = l0;
+    TTI_SFPNOP;
+
+    TTI_SFPCONFIG(0, p_sfpu::LREG14, 0);
+    TTI_SFPLOAD(p_sfpu::LREG0, 0, ADDR_MOD_7, scores_offset + 0);
+    TTI_SFPLOAD(p_sfpu::LREG1, 0, ADDR_MOD_7, scores_offset + 4);
+    TTI_SFPMUL(p_sfpu::LREG0, p_sfpu::LREG14, p_sfpu::LCONST_0, p_sfpu::LREG0, 0);
+    TTI_SFPMUL(p_sfpu::LREG1, p_sfpu::LREG14, p_sfpu::LCONST_0, p_sfpu::LREG1, 0);
+    TTI_SFPSTORE(p_sfpu::LREG0, 0, ADDR_MOD_7, scores_offset + 0);
+    TTI_SFPSTORE(p_sfpu::LREG1, 0, ADDR_MOD_7, scores_offset + 4);
+    if constexpr (num_rows > 8)
+    {
+        TTI_SFPLOAD(p_sfpu::LREG2, 0, ADDR_MOD_7, scores_offset + 8);
+        TTI_SFPLOAD(p_sfpu::LREG3, 0, ADDR_MOD_7, scores_offset + 12);
+        TTI_SFPMUL(p_sfpu::LREG2, p_sfpu::LREG14, p_sfpu::LCONST_0, p_sfpu::LREG2, 0);
+        TTI_SFPMUL(p_sfpu::LREG3, p_sfpu::LREG14, p_sfpu::LCONST_0, p_sfpu::LREG3, 0);
+        TTI_SFPSTORE(p_sfpu::LREG2, 0, ADDR_MOD_7, scores_offset + 8);
+        TTI_SFPSTORE(p_sfpu::LREG3, 0, ADDR_MOD_7, scores_offset + 12);
+    }
+}
+
+template <int num_total_experts>
+inline void _topk_moe_generate_indices_()
+{
+    static_assert(num_total_experts >= 128 && num_total_experts <= 1024);
+    static_assert(num_total_experts % 128 == 0);
+    constexpr std::uint32_t num_blocks = num_total_experts / 128;
+
+    TTI_SFPMOV(0, p_sfpu::LTILEID, p_sfpu::LREG0, 0);
+
+    TTI_SFPIADD(1, p_sfpu::LREG0, p_sfpu::LREG1, sfpi::SFPIADD_MOD1_ARG_IMM | sfpi::SFPIADD_MOD1_CC_NONE);
+    TTI_SFPIADD(64, p_sfpu::LREG0, p_sfpu::LREG2, sfpi::SFPIADD_MOD1_ARG_IMM | sfpi::SFPIADD_MOD1_CC_NONE);
+    TTI_SFPIADD(65, p_sfpu::LREG0, p_sfpu::LREG3, sfpi::SFPIADD_MOD1_ARG_IMM | sfpi::SFPIADD_MOD1_CC_NONE);
+
+#pragma GCC unroll 8
+    for (std::uint32_t block = 0; block < num_blocks; block++)
+    {
+        const std::uint32_t offset = block * 8;
+        TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::LO16, ADDR_MOD_7, generic_moe_gate_indices_tile + offset + 0);
+        TTI_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::LO16, ADDR_MOD_7, generic_moe_gate_indices_tile + offset + 2);
+        TTI_SFPSTORE(p_sfpu::LREG2, InstrModLoadStore::LO16, ADDR_MOD_7, generic_moe_gate_indices_tile + offset + 4);
+        TTI_SFPSTORE(p_sfpu::LREG3, InstrModLoadStore::LO16, ADDR_MOD_7, generic_moe_gate_indices_tile + offset + 6);
+
+        TTI_SFPIADD(128, p_sfpu::LREG0, p_sfpu::LREG0, sfpi::SFPIADD_MOD1_ARG_IMM | sfpi::SFPIADD_MOD1_CC_NONE);
+        TTI_SFPIADD(128, p_sfpu::LREG1, p_sfpu::LREG1, sfpi::SFPIADD_MOD1_ARG_IMM | sfpi::SFPIADD_MOD1_CC_NONE);
+        TTI_SFPIADD(128, p_sfpu::LREG2, p_sfpu::LREG2, sfpi::SFPIADD_MOD1_ARG_IMM | sfpi::SFPIADD_MOD1_CC_NONE);
+        TTI_SFPIADD(128, p_sfpu::LREG3, p_sfpu::LREG3, sfpi::SFPIADD_MOD1_ARG_IMM | sfpi::SFPIADD_MOD1_CC_NONE);
+    }
+}
+
+} // namespace sfpu
+} // namespace ckernel
+
+#include "sfpu/experimental/ckernel_sfpu_generic_moe_gate_topk_top16.h"
+#include "sfpu/experimental/ckernel_sfpu_generic_moe_gate_topk_top8.h"
+
+namespace ckernel
+{
+namespace sfpu
+{
+
+inline void _init_generic_moe_gate_topk_()
+{
+    sfpu_reciprocal_init<false>();
+}
+
+// generate_indices fills DST[1] with the position identity [0..N-1] before sorting. Set it false when the
+// caller has already loaded DST[1] with its own mapping (e.g. bit-15-flagged SRAM slots) via
+// copy_tile(input_indices, 0, 1): the sort's LREG4-7 LO16 load then reads those values verbatim and the
+// paired sort carries them through to out_indices.
+template <bool normalize, int num_selected_experts, int num_total_experts, bool zero_tail, bool full_sort, bool generate_indices = true>
+inline void _generic_moe_gate_topk_(std::uint32_t eps, std::uint32_t scale)
+{
+    if constexpr (generate_indices)
+    {
+        _topk_moe_generate_indices_<num_total_experts>();
+    }
+    TTI_SFPCONFIG(0x4, 0xF, 1);
+
+    if constexpr (num_selected_experts == 16)
+    {
+        _generic_moe_gate_top16_<normalize, num_total_experts>(eps, scale);
+    }
+    else
+    {
+        _generic_moe_gate_top8_<normalize, num_selected_experts, num_total_experts, zero_tail, full_sort>(eps, scale);
+    }
+}
+
+} // namespace sfpu
+} // namespace ckernel

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/experimental/ckernel_sfpu_generic_moe_gate_topk_top16.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/experimental/ckernel_sfpu_generic_moe_gate_topk_top16.h
@@ -1,0 +1,275 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+// Top-16 implementation details. Include through
+// ckernel_sfpu_generic_moe_gate_topk.h so shared helpers are defined first.
+
+#include <cstdint>
+
+namespace ckernel
+{
+namespace sfpu
+{
+
+template <std::uint32_t offset>
+inline void _generic_moe_gate_top16_bitonic16_directional_()
+{
+    if constexpr (offset == 0)
+    {
+        // Step 4.
+        TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG2, p_sfpswap::ALL_ROWS_MAX);
+        TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG3, p_sfpswap::ALL_ROWS_MAX);
+
+        // Step 3.
+        TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG1, p_sfpswap::ALL_ROWS_MAX);
+        TTI_SFPSWAP(0, p_sfpu::LREG2, p_sfpu::LREG3, p_sfpswap::ALL_ROWS_MAX);
+
+        // Step 2.
+        TTI_SFPTRANSP(0, 0, 0, 0);
+        TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG2, p_sfpswap::ALL_ROWS_MAX);
+        TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG3, p_sfpswap::ALL_ROWS_MAX);
+
+        // Step 1.
+        TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG1, p_sfpswap::ALL_ROWS_MAX);
+        TTI_SFPSWAP(0, p_sfpu::LREG2, p_sfpu::LREG3, p_sfpswap::ALL_ROWS_MAX);
+    }
+    else if constexpr (offset == 2)
+    {
+        // Odd columns sort in the opposite direction.
+        // Step 4.
+        TTI_SFPSWAP(0, p_sfpu::LREG2, p_sfpu::LREG0, p_sfpswap::ALL_ROWS_MAX);
+        TTI_SFPSWAP(0, p_sfpu::LREG3, p_sfpu::LREG1, p_sfpswap::ALL_ROWS_MAX);
+
+        // Step 3.
+        TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG0, p_sfpswap::ALL_ROWS_MAX);
+        TTI_SFPSWAP(0, p_sfpu::LREG3, p_sfpu::LREG2, p_sfpswap::ALL_ROWS_MAX);
+
+        // Step 2.
+        TTI_SFPTRANSP(0, 0, 0, 0);
+        TTI_SFPSWAP(0, p_sfpu::LREG2, p_sfpu::LREG0, p_sfpswap::ALL_ROWS_MAX);
+        TTI_SFPSWAP(0, p_sfpu::LREG3, p_sfpu::LREG1, p_sfpswap::ALL_ROWS_MAX);
+
+        // Step 1.
+        TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG0, p_sfpswap::ALL_ROWS_MAX);
+        TTI_SFPSWAP(0, p_sfpu::LREG3, p_sfpu::LREG2, p_sfpswap::ALL_ROWS_MAX);
+    }
+    TTI_SFPTRANSP(0, 0, 0, 0);
+}
+
+inline void _generic_moe_gate_top16_reverse_sort_order_()
+{
+    TTI_SFPTRANSP(0, 0, 0, 0);
+    TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG3, p_sfpswap::UNCONDITIONALLY);
+    TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG2, p_sfpswap::UNCONDITIONALLY);
+    TTI_SFPTRANSP(0, 0, 0, 0);
+}
+
+template <std::uint32_t offset>
+inline void _generic_moe_gate_top16_store_16_rows_reverse_()
+{
+    TTI_SFPSTORE(p_sfpu::LREG0, 0, ADDR_MOD_7, generic_moe_gate_bias_tile + 12 + offset);
+    TTI_SFPSTORE(p_sfpu::LREG1, 0, ADDR_MOD_7, generic_moe_gate_bias_tile + 8 + offset);
+    TTI_SFPSTORE(p_sfpu::LREG2, 0, ADDR_MOD_7, generic_moe_gate_bias_tile + 4 + offset);
+    TTI_SFPSTORE(p_sfpu::LREG3, 0, ADDR_MOD_7, generic_moe_gate_bias_tile + 0 + offset);
+    TTI_SFPSTORE(p_sfpu::LREG4, InstrModLoadStore::LO16_ONLY, ADDR_MOD_7, generic_moe_gate_indices_tile + 12 + offset);
+    TTI_SFPSTORE(p_sfpu::LREG5, InstrModLoadStore::LO16_ONLY, ADDR_MOD_7, generic_moe_gate_indices_tile + 8 + offset);
+    TTI_SFPSTORE(p_sfpu::LREG6, InstrModLoadStore::LO16_ONLY, ADDR_MOD_7, generic_moe_gate_indices_tile + 4 + offset);
+    TTI_SFPSTORE(p_sfpu::LREG7, InstrModLoadStore::LO16_ONLY, ADDR_MOD_7, generic_moe_gate_indices_tile + 0 + offset);
+    TTI_SFPSTORE(p_sfpu::LREG4, InstrModLoadStore::HI16_ONLY, ADDR_MOD_7, generic_moe_gate_scores_tile + 12 + offset);
+    TTI_SFPSTORE(p_sfpu::LREG5, InstrModLoadStore::HI16_ONLY, ADDR_MOD_7, generic_moe_gate_scores_tile + 8 + offset);
+    TTI_SFPSTORE(p_sfpu::LREG6, InstrModLoadStore::HI16_ONLY, ADDR_MOD_7, generic_moe_gate_scores_tile + 4 + offset);
+    TTI_SFPSTORE(p_sfpu::LREG7, InstrModLoadStore::HI16_ONLY, ADDR_MOD_7, generic_moe_gate_scores_tile + 0 + offset);
+}
+
+inline void _generic_moe_gate_top16_shift_left_once_()
+{
+    // Index tracking must be disabled for SHFT2, so shift value and
+    // score/index LREGs explicitly before restoring tracking.
+    TTI_SFPCONFIG(0, 0xF, 1);
+    TTI_SFPSHFT2(0, p_sfpu::LREG0, p_sfpu::LREG0, sfpi::SFPSHFT2_MOD1_SUBVEC_SHFLROR1);
+    TTI_SFPSHFT2(0, p_sfpu::LREG1, p_sfpu::LREG1, sfpi::SFPSHFT2_MOD1_SUBVEC_SHFLROR1);
+    TTI_SFPSHFT2(0, p_sfpu::LREG2, p_sfpu::LREG2, sfpi::SFPSHFT2_MOD1_SUBVEC_SHFLROR1);
+    TTI_SFPSHFT2(0, p_sfpu::LREG3, p_sfpu::LREG3, sfpi::SFPSHFT2_MOD1_SUBVEC_SHFLROR1);
+
+    TTI_SFPSHFT2(0, p_sfpu::LREG4, p_sfpu::LREG4, sfpi::SFPSHFT2_MOD1_SUBVEC_SHFLROR1);
+    TTI_SFPSHFT2(0, p_sfpu::LREG5, p_sfpu::LREG5, sfpi::SFPSHFT2_MOD1_SUBVEC_SHFLROR1);
+    TTI_SFPSHFT2(0, p_sfpu::LREG6, p_sfpu::LREG6, sfpi::SFPSHFT2_MOD1_SUBVEC_SHFLROR1);
+    TTI_SFPSHFT2(0, p_sfpu::LREG7, p_sfpu::LREG7, sfpi::SFPSHFT2_MOD1_SUBVEC_SHFLROR1);
+    TTI_SFPCONFIG(0x4, 0xF, 1);
+}
+
+template <std::uint32_t offset>
+inline void _generic_moe_gate_top16_reduce_even_odd_columns_to_instance_()
+{
+    _generic_moe_gate_load_8_rows_even_odd_split_<offset>();
+
+    TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG2, p_sfpswap::ALL_ROWS_MAX);
+    TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG3, p_sfpswap::ALL_ROWS_MAX);
+
+    _generic_moe_gate_store_8_rows_even_odd_split_<offset>();
+
+    _generic_moe_gate_load_8_rows_even_odd_split_<offset + 8>();
+
+    // Keep these winners in LREG2/3 (and tracked payloads in LREG6/7),
+    // then reload only the first-half winners into the remaining LREGs.
+    TTI_SFPSWAP(0, p_sfpu::LREG2, p_sfpu::LREG0, p_sfpswap::ALL_ROWS_MAX);
+    TTI_SFPSWAP(0, p_sfpu::LREG3, p_sfpu::LREG1, p_sfpswap::ALL_ROWS_MAX);
+
+    TTI_SFPLOAD(p_sfpu::LREG0, 0, ADDR_MOD_7, generic_moe_gate_bias_tile + 0 + offset);
+    TTI_SFPLOAD(p_sfpu::LREG1, 0, ADDR_MOD_7, generic_moe_gate_bias_tile + 4 + offset);
+    TTI_SFPLOAD(p_sfpu::LREG4, InstrModLoadStore::LO16_ONLY, ADDR_MOD_7, generic_moe_gate_indices_tile + 0 + offset);
+    TTI_SFPLOAD(p_sfpu::LREG5, InstrModLoadStore::LO16_ONLY, ADDR_MOD_7, generic_moe_gate_indices_tile + 4 + offset);
+    TTI_SFPLOAD(p_sfpu::LREG4, InstrModLoadStore::HI16_ONLY, ADDR_MOD_7, generic_moe_gate_scores_tile + 0 + offset);
+    TTI_SFPLOAD(p_sfpu::LREG5, InstrModLoadStore::HI16_ONLY, ADDR_MOD_7, generic_moe_gate_scores_tile + 4 + offset);
+    _generic_moe_gate_bitonic8_steps_3_to_1_();
+}
+
+template <std::uint32_t lane_shifts, bool store_result = true>
+inline void _generic_moe_gate_top16_reduce_lanes_()
+{
+    static_assert(lane_shifts == 1 || lane_shifts == 2 || lane_shifts == 4);
+
+    // Sort the live run descending before shifting it to the next lane.
+    _generic_moe_gate_top16_bitonic16_directional_<0>();
+    _generic_moe_gate_store_16_rows_even_odd_split_<0>();
+
+#pragma GCC unroll 4
+    for (std::uint32_t shift = 0; shift < lane_shifts; ++shift)
+    {
+        _generic_moe_gate_top16_shift_left_once_();
+    }
+    // Horizontal shifts preserve row order; reverse the descending run
+    // into the ascending half required by the bitonic merge.
+    _generic_moe_gate_top16_reverse_sort_order_();
+    _generic_moe_gate_top16_store_16_rows_reverse_<2>();
+
+    _generic_moe_gate_top16_reduce_even_odd_columns_to_instance_<0>();
+    if constexpr (store_result)
+    {
+        _generic_moe_gate_store_16_rows_even_odd_split_<0>();
+    }
+}
+
+template <std::uint32_t load_offset, std::uint32_t store_offset>
+inline void _generic_moe_gate_top16_sort_face_()
+{
+    _generic_moe_gate_load_16_rows_even_odd_split_<load_offset>();
+    _generic_moe_gate_build_bitonic8_();
+    _generic_moe_gate_top16_bitonic16_directional_<0>(); // evens descending
+    _generic_moe_gate_store_16_rows_even_odd_split_<load_offset>();
+
+    _generic_moe_gate_load_16_rows_even_odd_split_<load_offset + 2>();
+    _generic_moe_gate_build_bitonic8_();
+    _generic_moe_gate_top16_bitonic16_directional_<2>(); // odds ascending
+    _generic_moe_gate_store_16_rows_even_odd_split_<load_offset + 2>();
+
+    _generic_moe_gate_top16_reduce_even_odd_columns_to_instance_<load_offset>();
+    _generic_moe_gate_store_16_rows_even_odd_split_<store_offset>();
+}
+
+template <std::uint32_t load_offset, std::uint32_t store_offset>
+inline void _generic_moe_gate_top16_merge_bitonic_face_()
+{
+    _generic_moe_gate_load_16_rows_even_odd_split_<load_offset>();
+    _generic_moe_gate_top16_bitonic16_directional_<0>(); // evens descending
+    _generic_moe_gate_store_16_rows_even_odd_split_<load_offset>();
+
+    _generic_moe_gate_load_16_rows_even_odd_split_<load_offset + 2>();
+    _generic_moe_gate_top16_bitonic16_directional_<2>(); // odds ascending
+    _generic_moe_gate_store_16_rows_even_odd_split_<load_offset + 2>();
+
+    _generic_moe_gate_top16_reduce_even_odd_columns_to_instance_<load_offset>();
+    _generic_moe_gate_store_16_rows_even_odd_split_<store_offset>();
+}
+
+template <std::uint32_t load_offset, std::uint32_t store_offset>
+inline void _generic_moe_gate_top16_sort_half_face_()
+{
+    _generic_moe_gate_load_8_rows_even_odd_split_<load_offset>();
+    _generic_moe_gate_build_bitonic8_();
+    _generic_moe_gate_store_16_rows_even_odd_split_<store_offset>();
+}
+
+template <std::uint32_t face_idx, bool full_face>
+inline void _generic_moe_gate_top16_accumulate_face_()
+{
+    if constexpr (full_face)
+    {
+        _generic_moe_gate_top16_sort_face_<face_idx * 16, 2>();
+    }
+    else
+    {
+        _generic_moe_gate_top16_sort_half_face_<face_idx * 16, 2>();
+    }
+    // Both staged runs already satisfy the bitonic-8 invariant.
+    _generic_moe_gate_top16_merge_bitonic_face_<0, 0>();
+}
+
+template <int num_total_experts>
+inline void _generic_moe_gate_top16_sort_to_instance_()
+{
+    static_assert(num_total_experts >= 128 && num_total_experts <= 1024);
+    static_assert(num_total_experts % 128 == 0);
+
+    if constexpr (num_total_experts == 128)
+    {
+        _generic_moe_gate_top16_sort_half_face_<0, 0>();
+    }
+    else
+    {
+        _generic_moe_gate_top16_sort_face_<0, 0>();
+    }
+    if constexpr (num_total_experts > 256)
+    {
+        _generic_moe_gate_top16_accumulate_face_<1, num_total_experts >= 512>();
+    }
+    if constexpr (num_total_experts > 512)
+    {
+        _generic_moe_gate_top16_accumulate_face_<2, num_total_experts >= 768>();
+    }
+    if constexpr (num_total_experts > 768)
+    {
+        _generic_moe_gate_top16_accumulate_face_<3, num_total_experts >= 1024>();
+    }
+}
+
+inline void _generic_moe_gate_top16_store_outputs_()
+{
+    TTI_SFPSTORE(p_sfpu::LREG4, InstrModLoadStore::LO16_ONLY, ADDR_MOD_7, generic_moe_gate_indices_tile + 0);
+    TTI_SFPSTORE(p_sfpu::LREG5, InstrModLoadStore::LO16_ONLY, ADDR_MOD_7, generic_moe_gate_indices_tile + 4);
+    TTI_SFPSTORE(p_sfpu::LREG6, InstrModLoadStore::LO16_ONLY, ADDR_MOD_7, generic_moe_gate_indices_tile + 8);
+    TTI_SFPSTORE(p_sfpu::LREG7, InstrModLoadStore::LO16_ONLY, ADDR_MOD_7, generic_moe_gate_indices_tile + 12);
+    TTI_SFPSTORE(p_sfpu::LREG4, InstrModLoadStore::HI16_ONLY, ADDR_MOD_7, generic_moe_gate_scores_tile + 0);
+    TTI_SFPSTORE(p_sfpu::LREG5, InstrModLoadStore::HI16_ONLY, ADDR_MOD_7, generic_moe_gate_scores_tile + 4);
+    TTI_SFPSTORE(p_sfpu::LREG6, InstrModLoadStore::HI16_ONLY, ADDR_MOD_7, generic_moe_gate_scores_tile + 8);
+    TTI_SFPSTORE(p_sfpu::LREG7, InstrModLoadStore::HI16_ONLY, ADDR_MOD_7, generic_moe_gate_scores_tile + 12);
+}
+
+inline void _generic_moe_gate_top16_merge_instances_()
+{
+    _generic_moe_gate_top16_reduce_lanes_<1>();
+    _generic_moe_gate_top16_reduce_lanes_<2>();
+    _generic_moe_gate_top16_reduce_lanes_<4, false>();
+
+    // Move the final surviving lane into output column 0.
+    _generic_moe_gate_top16_shift_left_once_();
+    _generic_moe_gate_top16_store_outputs_();
+}
+
+template <bool normalize, int num_total_experts>
+inline void _generic_moe_gate_top16_(std::uint32_t eps, std::uint32_t scale)
+{
+    _generic_moe_gate_top16_sort_to_instance_<num_total_experts>();
+    _generic_moe_gate_top16_merge_instances_();
+
+    if constexpr (normalize)
+    {
+        _generic_moe_gate_normalize_<16, generic_moe_gate_scores_tile>(eps, scale);
+    }
+}
+
+} // namespace sfpu
+} // namespace ckernel

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/experimental/ckernel_sfpu_generic_moe_gate_topk_top8.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/experimental/ckernel_sfpu_generic_moe_gate_topk_top8.h
@@ -1,0 +1,268 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+// Top-8 implementation details. Include through
+// ckernel_sfpu_generic_moe_gate_topk.h so shared helpers are defined first.
+
+#include <cstdint>
+
+namespace ckernel
+{
+namespace sfpu
+{
+
+// At the end of this function, LREG0 and LREG1 contain the top 8 values per column.
+inline void _generic_moe_gate_top8_local_sort_16x8_to_8x8_()
+{
+    _generic_moe_gate_build_bitonic8_();
+
+    // P4 - Partial Bitonic 16 (top8), Step 4.
+    TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG2, p_sfpswap::ALL_ROWS_MAX);
+    TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG3, p_sfpswap::ALL_ROWS_MAX);
+}
+
+inline void _generic_moe_gate_top8_rebuild_and_merge_16x8_to_8x8_()
+{
+    _generic_moe_gate_bitonic8_steps_3_to_1_();
+
+    // Merge top16 rows.
+    TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG2, p_sfpswap::ALL_ROWS_MAX);
+    TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG3, p_sfpswap::ALL_ROWS_MAX);
+}
+
+inline void _generic_moe_gate_top8_merge_instances_()
+{
+    TTI_SFPCONFIG(0, 0xF, 1);
+    TTI_SFPSHFT2(0, p_sfpu::LREG0, p_sfpu::LREG2, sfpi::SFPSHFT2_MOD1_SUBVEC_SHFLROR1);
+    TTI_SFPSHFT2(0, p_sfpu::LREG1, p_sfpu::LREG3, sfpi::SFPSHFT2_MOD1_SUBVEC_SHFLROR1);
+
+    TTI_SFPSHFT2(0, p_sfpu::LREG4, p_sfpu::LREG6, sfpi::SFPSHFT2_MOD1_SUBVEC_SHFLROR1);
+    TTI_SFPSHFT2(0, p_sfpu::LREG5, p_sfpu::LREG7, sfpi::SFPSHFT2_MOD1_SUBVEC_SHFLROR1);
+    TTI_SFPCONFIG(0x4, 0xF, 1);
+    _generic_moe_gate_top8_rebuild_and_merge_16x8_to_8x8_();
+
+    TTI_SFPCONFIG(0, 0xF, 1);
+    TTI_SFPSHFT2(0, p_sfpu::LREG0, p_sfpu::LREG2, sfpi::SFPSHFT2_MOD1_SUBVEC_SHFLROR1);
+    TTI_SFPSHFT2(0, p_sfpu::LREG1, p_sfpu::LREG3, sfpi::SFPSHFT2_MOD1_SUBVEC_SHFLROR1);
+    TTI_SFPSHFT2(0, p_sfpu::LREG2, p_sfpu::LREG2, sfpi::SFPSHFT2_MOD1_SUBVEC_SHFLROR1);
+    TTI_SFPSHFT2(0, p_sfpu::LREG3, p_sfpu::LREG3, sfpi::SFPSHFT2_MOD1_SUBVEC_SHFLROR1);
+
+    TTI_SFPSHFT2(0, p_sfpu::LREG4, p_sfpu::LREG6, sfpi::SFPSHFT2_MOD1_SUBVEC_SHFLROR1);
+    TTI_SFPSHFT2(0, p_sfpu::LREG5, p_sfpu::LREG7, sfpi::SFPSHFT2_MOD1_SUBVEC_SHFLROR1);
+    TTI_SFPSHFT2(0, p_sfpu::LREG6, p_sfpu::LREG6, sfpi::SFPSHFT2_MOD1_SUBVEC_SHFLROR1);
+    TTI_SFPSHFT2(0, p_sfpu::LREG7, p_sfpu::LREG7, sfpi::SFPSHFT2_MOD1_SUBVEC_SHFLROR1);
+    TTI_SFPCONFIG(0x4, 0xF, 1);
+    _generic_moe_gate_top8_rebuild_and_merge_16x8_to_8x8_();
+
+    TTI_SFPCONFIG(0, 0xF, 1);
+    TTI_SFPSHFT2(0, p_sfpu::LREG0, p_sfpu::LREG2, sfpi::SFPSHFT2_MOD1_SUBVEC_SHFLROR1);
+    TTI_SFPSHFT2(0, p_sfpu::LREG1, p_sfpu::LREG3, sfpi::SFPSHFT2_MOD1_SUBVEC_SHFLROR1);
+    TTI_SFPSHFT2(0, p_sfpu::LREG2, p_sfpu::LREG2, sfpi::SFPSHFT2_MOD1_SUBVEC_SHFLROR1);
+    TTI_SFPSHFT2(0, p_sfpu::LREG3, p_sfpu::LREG3, sfpi::SFPSHFT2_MOD1_SUBVEC_SHFLROR1);
+    TTI_SFPSHFT2(0, p_sfpu::LREG2, p_sfpu::LREG2, sfpi::SFPSHFT2_MOD1_SUBVEC_SHFLROR1);
+    TTI_SFPSHFT2(0, p_sfpu::LREG3, p_sfpu::LREG3, sfpi::SFPSHFT2_MOD1_SUBVEC_SHFLROR1);
+    TTI_SFPSHFT2(0, p_sfpu::LREG2, p_sfpu::LREG2, sfpi::SFPSHFT2_MOD1_SUBVEC_SHFLROR1);
+    TTI_SFPSHFT2(0, p_sfpu::LREG3, p_sfpu::LREG3, sfpi::SFPSHFT2_MOD1_SUBVEC_SHFLROR1);
+
+    TTI_SFPSHFT2(0, p_sfpu::LREG4, p_sfpu::LREG6, sfpi::SFPSHFT2_MOD1_SUBVEC_SHFLROR1);
+    TTI_SFPSHFT2(0, p_sfpu::LREG5, p_sfpu::LREG7, sfpi::SFPSHFT2_MOD1_SUBVEC_SHFLROR1);
+    TTI_SFPSHFT2(0, p_sfpu::LREG6, p_sfpu::LREG6, sfpi::SFPSHFT2_MOD1_SUBVEC_SHFLROR1);
+    TTI_SFPSHFT2(0, p_sfpu::LREG7, p_sfpu::LREG7, sfpi::SFPSHFT2_MOD1_SUBVEC_SHFLROR1);
+    TTI_SFPSHFT2(0, p_sfpu::LREG6, p_sfpu::LREG6, sfpi::SFPSHFT2_MOD1_SUBVEC_SHFLROR1);
+    TTI_SFPSHFT2(0, p_sfpu::LREG7, p_sfpu::LREG7, sfpi::SFPSHFT2_MOD1_SUBVEC_SHFLROR1);
+    TTI_SFPSHFT2(0, p_sfpu::LREG6, p_sfpu::LREG6, sfpi::SFPSHFT2_MOD1_SUBVEC_SHFLROR1);
+    TTI_SFPSHFT2(0, p_sfpu::LREG7, p_sfpu::LREG7, sfpi::SFPSHFT2_MOD1_SUBVEC_SHFLROR1);
+    TTI_SFPCONFIG(0x4, 0xF, 1);
+    _generic_moe_gate_top8_rebuild_and_merge_16x8_to_8x8_();
+
+    TTI_SFPCONFIG(0, 0xF, 1);
+    TTI_SFPSHFT2(0, p_sfpu::LREG0, p_sfpu::LREG0, sfpi::SFPSHFT2_MOD1_SUBVEC_SHFLROR1);
+    TTI_SFPSHFT2(0, p_sfpu::LREG1, p_sfpu::LREG1, sfpi::SFPSHFT2_MOD1_SUBVEC_SHFLROR1);
+
+    TTI_SFPSHFT2(0, p_sfpu::LREG4, p_sfpu::LREG4, sfpi::SFPSHFT2_MOD1_SUBVEC_SHFLROR1);
+    TTI_SFPSHFT2(0, p_sfpu::LREG5, p_sfpu::LREG5, sfpi::SFPSHFT2_MOD1_SUBVEC_SHFLROR1);
+    TTI_SFPCONFIG(0x4, 0xF, 1);
+}
+
+template <int num_selected_experts, bool full_sort>
+inline void _generic_moe_gate_top8_sort_rows_()
+{
+    TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG1, p_sfpswap::ALL_ROWS_MAX);
+    if constexpr (num_selected_experts != 4 || full_sort)
+    {
+        TTI_SFPTRANSP(0, 0, 0, 0);
+        TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG2, p_sfpswap::ROWS_01_MAX);
+        TTI_SFPSWAP(0, p_sfpu::LREG1, p_sfpu::LREG3, p_sfpswap::ROWS_01_MAX);
+        if constexpr ((num_selected_experts != 6 && num_selected_experts != 2) || full_sort)
+        {
+            TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG1, p_sfpswap::ROWS_01_MAX);
+            TTI_SFPSWAP(0, p_sfpu::LREG2, p_sfpu::LREG3, p_sfpswap::ROWS_01_MAX);
+        }
+        TTI_SFPTRANSP(0, 0, 0, 0);
+    }
+    else
+    {
+        TTI_NOP;
+    }
+}
+
+template <std::uint32_t offset>
+inline void _generic_moe_gate_top8_load_result_into_upper_lregs_()
+{
+    TTI_SFPLOAD(p_sfpu::LREG2, 0, ADDR_MOD_7, generic_moe_gate_bias_tile + 0 + offset);
+    TTI_SFPLOAD(p_sfpu::LREG3, 0, ADDR_MOD_7, generic_moe_gate_bias_tile + 4 + offset);
+    TTI_SFPLOAD(p_sfpu::LREG6, InstrModLoadStore::LO16_ONLY, ADDR_MOD_7, generic_moe_gate_indices_tile + 0 + offset);
+    TTI_SFPLOAD(p_sfpu::LREG7, InstrModLoadStore::LO16_ONLY, ADDR_MOD_7, generic_moe_gate_indices_tile + 4 + offset);
+    TTI_SFPLOAD(p_sfpu::LREG6, InstrModLoadStore::HI16_ONLY, ADDR_MOD_7, generic_moe_gate_scores_tile + 0 + offset);
+    TTI_SFPLOAD(p_sfpu::LREG7, InstrModLoadStore::HI16_ONLY, ADDR_MOD_7, generic_moe_gate_scores_tile + 4 + offset);
+}
+
+template <std::uint32_t load_offset, std::uint32_t store_offset, bool store_result = true>
+inline void _generic_moe_gate_top8_sort_face_()
+{
+    _generic_moe_gate_load_16_rows_even_odd_split_<load_offset>();
+    _generic_moe_gate_top8_local_sort_16x8_to_8x8_();
+    _generic_moe_gate_store_8_rows_even_odd_split_<load_offset>();
+
+    _generic_moe_gate_load_16_rows_even_odd_split_<load_offset + 2>();
+    _generic_moe_gate_top8_local_sort_16x8_to_8x8_();
+
+    _generic_moe_gate_top8_load_result_into_upper_lregs_<load_offset>();
+    _generic_moe_gate_top8_rebuild_and_merge_16x8_to_8x8_();
+    if constexpr (store_result)
+    {
+        _generic_moe_gate_store_8_rows_even_odd_split_<store_offset>();
+    }
+}
+
+template <std::uint32_t load_offset, std::uint32_t store_offset, bool store_result = true>
+inline void _generic_moe_gate_top8_sort_half_face_()
+{
+    _generic_moe_gate_load_8_rows_even_odd_split_<load_offset>();
+    _generic_moe_gate_top8_local_sort_16x8_to_8x8_();
+    if constexpr (store_result)
+    {
+        _generic_moe_gate_store_8_rows_even_odd_split_<store_offset>();
+    }
+}
+
+template <int num_selected_experts>
+inline void _generic_moe_gate_top8_zero_tail_()
+{
+    if constexpr (num_selected_experts > 4)
+    {
+        TTI_SFPSTORE(p_sfpu::LREG4, InstrModLoadStore::LO16_ONLY, ADDR_MOD_7, generic_moe_gate_interm_tile);
+        TTI_SFPSTORE(p_sfpu::LREG4, InstrModLoadStore::HI16_ONLY, ADDR_MOD_7, generic_moe_gate_interm_tile + 2);
+    }
+    else if (num_selected_experts <= 4)
+    {
+        TTI_SFPLOADI(p_sfpu::LREG5, sfpi::SFPLOADI_MOD0_FLOATB, 0);
+    }
+    if constexpr (num_selected_experts != 4 && num_selected_experts != 8)
+    {
+        TTI_SFPTRANSP(0, 0, 0, 0);
+
+        TTI_SFPLOADI(p_sfpu::LREG7, sfpi::SFPLOADI_MOD0_FLOATB, 0);
+        if constexpr (num_selected_experts != 7 && num_selected_experts != 3)
+        {
+            TTI_SFPLOADI(p_sfpu::LREG6, sfpi::SFPLOADI_MOD0_FLOATB, 0);
+            if constexpr (num_selected_experts != 6 && num_selected_experts != 2)
+            {
+                TTI_SFPLOADI(p_sfpu::LREG5, sfpi::SFPLOADI_MOD0_FLOATB, 0);
+            }
+        }
+
+        TTI_SFPTRANSP(0, 0, 0, 0);
+    }
+    if constexpr (num_selected_experts > 4)
+    {
+        TTI_SFPLOAD(p_sfpu::LREG4, InstrModLoadStore::LO16_ONLY, ADDR_MOD_7, generic_moe_gate_interm_tile);
+        TTI_SFPLOAD(p_sfpu::LREG4, InstrModLoadStore::HI16_ONLY, ADDR_MOD_7, generic_moe_gate_interm_tile + 2);
+    }
+}
+
+template <std::uint32_t face_idx, bool full_face, bool store_result>
+inline void _generic_moe_gate_top8_accumulate_face_()
+{
+    if constexpr (full_face)
+    {
+        _generic_moe_gate_top8_sort_face_<face_idx * 16, 0, false>();
+    }
+    else
+    {
+        _generic_moe_gate_top8_sort_half_face_<face_idx * 16, 0, false>();
+    }
+    _generic_moe_gate_top8_load_result_into_upper_lregs_<0>();
+    _generic_moe_gate_top8_rebuild_and_merge_16x8_to_8x8_();
+    if constexpr (store_result)
+    {
+        _generic_moe_gate_store_8_rows_even_odd_split_<0>();
+    }
+}
+
+template <int num_total_experts>
+inline void _generic_moe_gate_top8_sort_to_instance_()
+{
+    static_assert(num_total_experts >= 128 && num_total_experts <= 1024);
+    static_assert(num_total_experts % 128 == 0);
+
+    if constexpr (num_total_experts == 128)
+    {
+        _generic_moe_gate_top8_sort_half_face_<0, 0, false>();
+    }
+    else
+    {
+        _generic_moe_gate_top8_sort_face_<0, 0, (num_total_experts > 256)>();
+    }
+    if constexpr (num_total_experts > 256)
+    {
+        _generic_moe_gate_top8_accumulate_face_<1, (num_total_experts >= 512), (num_total_experts > 512)>();
+    }
+    if constexpr (num_total_experts > 512)
+    {
+        _generic_moe_gate_top8_accumulate_face_<2, (num_total_experts >= 768), (num_total_experts > 768)>();
+    }
+    if constexpr (num_total_experts > 768)
+    {
+        _generic_moe_gate_top8_accumulate_face_<3, (num_total_experts >= 1024), false>();
+    }
+}
+
+template <bool normalize, int num_selected_experts, int num_total_experts, bool zero_tail, bool full_sort>
+inline void _generic_moe_gate_top8_(std::uint32_t eps, std::uint32_t scale)
+{
+    _generic_moe_gate_top8_sort_to_instance_<num_total_experts>();
+    _generic_moe_gate_top8_merge_instances_();
+
+    if constexpr (num_selected_experts < 8 || full_sort)
+    {
+        _generic_moe_gate_top8_sort_rows_<num_selected_experts, full_sort>();
+    }
+
+    if constexpr (zero_tail || (normalize && num_selected_experts < 8))
+    {
+        _generic_moe_gate_top8_zero_tail_<num_selected_experts>();
+    }
+
+    _generic_moe_gate_store_8_rows_even_odd_split_<0>();
+
+    if constexpr (normalize)
+    {
+        _generic_moe_gate_normalize_<8, generic_moe_gate_scores_tile>(eps, scale);
+    }
+
+    if constexpr (zero_tail)
+    {
+        TTI_SFPLOADI(p_sfpu::LREG0, sfpi::SFPLOADI_MOD0_FLOATB, 0);
+        TTI_SFPSTORE(p_sfpu::LREG0, 0, ADDR_MOD_7, generic_moe_gate_scores_tile + 8);
+        TTI_SFPSTORE(p_sfpu::LREG0, 0, ADDR_MOD_7, generic_moe_gate_scores_tile + 12);
+        TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::LO16_ONLY, ADDR_MOD_7, generic_moe_gate_indices_tile + 8);
+        TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::LO16_ONLY, ADDR_MOD_7, generic_moe_gate_indices_tile + 12);
+    }
+}
+
+} // namespace sfpu
+} // namespace ckernel

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/experimental/ckernel_sfpu_sdpa_exp_unclamped.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/experimental/ckernel_sfpu_sdpa_exp_unclamped.h
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <cstdint>
+
+#include "ckernel_sfpu_exp.h"
+
+namespace ckernel
+{
+namespace sfpu
+{
+
+template <bool is_fp32_dest_acc_en>
+sfpi_inline sfpi::vFloat _sfpu_exp_21f_bf16_lower_clamp_only_(sfpi::vFloat val)
+{
+    constexpr float ONE_LN2 = 1.4426950216293334961f;
+    sfpi::vFloat xlog2      = (val * ONE_LN2 + 127.f);
+
+    // Lower clamp only (xlog2 >= 0). Upper clamp is dead when val <= 0 (see file header).
+    sfpi::vFloat threshold_low = 0.f;
+    sfpi::vec_min_max(threshold_low, xlog2);
+
+    sfpi::vInt z = _float_to_int32_for_exp_21f_(xlog2);
+
+    sfpi::vInt exponential_part = exexp(sfpi::reinterpret<sfpi::vFloat>(z), sfpi::ExponentMode::NoDebias);
+    sfpi::vInt fractional_part  = sfpi::exman(sfpi::reinterpret<sfpi::vFloat>(z));
+
+    sfpi::vFloat frac = sfpi::int32_to_float(fractional_part, sfpi::RoundMode::NearestEven);
+    frac              = PolynomialEvaluator::eval(frac, 1.0017248f, 7.839635491371155e-08f, 4.791750143340323e-15f);
+
+    sfpi::vFloat y = sfpi::setexp(frac, exponential_part);
+
+    if constexpr (!is_fp32_dest_acc_en)
+    {
+        y = sfpi::convert<sfpi::vFloat16b>(y, sfpi::RoundMode::NearestEven);
+    }
+
+    return y;
+}
+
+template <bool SCALE_EN, bool is_fp32_dest_acc_en>
+sfpi_inline sfpi::vFloat _ckernel_sfpu_exp_accurate_upper_unclamped_(sfpi::vFloat val, const std::uint32_t exp_base_scale_factor)
+{
+    static_assert(!is_fp32_dest_acc_en, "upper-unclamped exp variant implemented for bf16 dest only");
+    if constexpr (SCALE_EN)
+    {
+        val = val * sfpi::sFloat16b(exp_base_scale_factor);
+    }
+    return _sfpu_exp_21f_bf16_lower_clamp_only_<is_fp32_dest_acc_en>(val);
+}
+
+} // namespace sfpu
+} // namespace ckernel

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/experimental/ckernel_sfpu_softmax_k.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/experimental/ckernel_sfpu_softmax_k.h
@@ -1,0 +1,154 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+#include "ckernel.h"
+#include "ckernel_addrmod.h"
+#include "ckernel_instr_params.h"
+#include "ckernel_ops.h"
+#include "ckernel_sfpu_exp.h"
+#include "ckernel_sfpu_reduce.h"
+#include "lltt.h"
+#include "sfpi.h"
+#include "sfpu/ckernel_sfpu_binary_bcast.h"
+#include "sfpu/ckernel_sfpu_load_config.h"
+
+namespace ckernel
+{
+namespace sfpu
+{
+
+// sfpu/ckernel_sfpu_binary_bcast.h (included above) used to define these; #49682 moved that header to
+// LTILEID-derived lane masks and dropped them. Values carried over verbatim. SFPCONFIG target index used
+// with an immediate mask to force LReg[11] = 1.0 on specific SFPU instances (= specific "SFPU columns"
+// within each 8-lane group) and 0.0 on the others. Bit N of the mask corresponds to SFPU instance N; the
+// low 8 bits control the 8 SFPU columns.
+constexpr std::uint32_t SFPCONFIG_TARGET_LREG11  = 11;
+constexpr std::uint32_t SFPCONFIG_MOD_SET_LREG11 = 8;
+
+inline void _init_softmax_k_()
+{
+    sfpu::exp_init<false, 0x3F800000, true, DST_ACCUM_MODE>();
+}
+
+// For odd k, the final valid even lane predicates its paired odd tail lane.
+// Clear that extra exponential before it contributes to the row sum.
+template <int k>
+inline void _zero_paired_odd_tail_lane_()
+{
+    if constexpr ((k & 1) && k < 16)
+    {
+        constexpr std::uint32_t all_instances_mask = 0x5555;
+        constexpr std::uint32_t tail_instance_mask = 1u << (k - 1);
+
+        // Mark only the SFPU instance containing odd tail lane k.
+        TTI_SFPLOADI(p_sfpu::LREG0, sfpi::SFPLOADI_MOD0_UPPER, 0x0000);
+        TTI_SFPLOADI(p_sfpu::LREG0, sfpi::SFPLOADI_MOD0_LOWER, 0x0000);
+        TTI_SFPCONFIG(all_instances_mask, SFPCONFIG_TARGET_LREG11, SFPCONFIG_MOD_SET_LREG11);
+        TTI_SFPLOADI(p_sfpu::LREG0, sfpi::SFPLOADI_MOD0_UPPER, 0x3F80);
+        TTI_SFPLOADI(p_sfpu::LREG0, sfpi::SFPLOADI_MOD0_LOWER, 0x0000);
+        TTI_SFPCONFIG(tail_instance_mask, SFPCONFIG_TARGET_LREG11, SFPCONFIG_MOD_SET_LREG11);
+
+        TTI_SFPLOAD(p_sfpu::LREG1, 0, ADDR_MOD_7, 2);
+        TTI_SFPSETCC(0, p_sfpu::LREG11, 0, sfpi::SFPSETCC_MOD1_LREG_NE0);
+        TTI_SFPMOV(0, p_sfpu::LCONST_0, p_sfpu::LREG1, 0);
+        TTI_SFPSTORE(p_sfpu::LREG1, 0, ADDR_MOD_7, 2);
+        TTI_SFPENCC(0, 0, 0, 0);
+
+        // Restore LREG11 to its hardware-default -1.0 value.
+        TTI_SFPLOADI(p_sfpu::LREG0, sfpi::SFPLOADI_MOD0_UPPER, 0xBF80);
+        TTI_SFPLOADI(p_sfpu::LREG0, sfpi::SFPLOADI_MOD0_LOWER, 0x0000);
+        TTI_SFPCONFIG(all_instances_mask, SFPCONFIG_TARGET_LREG11, SFPCONFIG_MOD_SET_LREG11);
+    }
+}
+
+template <int k>
+inline void _softmax_k_()
+{
+    // LREG0 = x - max(x)
+    TTI_SFPLOAD(p_sfpu::LREG0, 0, ADDR_MOD_7, 0);
+    TTI_SFPLOAD(p_sfpu::LREG1, 0, ADDR_MOD_7, 2);
+    TTI_SFPABS(0, p_sfpu::LREG0, p_sfpu::LREG2, 1);
+    TTI_SFPGT(0, p_sfpu::LCONST_0, p_sfpu::LREG2, 1);
+
+    TTI_SFPLOAD(p_sfpu::LREG2, 0, ADDR_MOD_7, 8);
+    TTI_SFPMAD(p_sfpu::LREG2, p_sfpu::LCONST_neg1, p_sfpu::LREG0, p_sfpu::LREG0, 0);
+    TTI_SFPMAD(p_sfpu::LREG2, p_sfpu::LCONST_neg1, p_sfpu::LREG1, p_sfpu::LREG1, 0);
+
+    TTI_SFPSTORE(p_sfpu::LREG0, 0, ADDR_MOD_7, 0);
+    TTI_SFPSTORE(p_sfpu::LREG1, 0, ADDR_MOD_7, 2);
+
+    // //LREG0 = exp(x - max(x))
+    sfpu::calculate_exponential<
+        false,
+        DST_ACCUM_MODE,
+        false, // scaling
+        2,     // iterations
+        true   // clamp negatives
+        >();
+
+    TTI_SFPENCC(0, 0, 0, 0);
+    math::clear_dst_reg_addr();
+    _zero_paired_odd_tail_lane_<k>();
+
+    // LREG0 = sum(exp(x - max(x)))
+    TTI_SFPLOAD(p_sfpu::LREG0, 0, ADDR_MOD_7, 0);
+    TTI_SFPLOAD(p_sfpu::LREG1, 0, ADDR_MOD_7, 2);
+    TTI_SFPADD(p_sfpu::LREG0, p_sfpu::LCONST_1, p_sfpu::LREG1, p_sfpu::LREG0, 0);
+    TTI_SFPLOADI(p_sfpu::LREG4, 0, 0);
+    TTI_SFPNOP;
+    sfpu::horizontal_reduce<false>();
+
+    // Broadcast the column-0 sum across all eight SFPU columns.
+    TTI_SFPMOV(0, p_sfpu::LREG0, p_sfpu::LREG7, 0);
+    _build_lane_mask_col0_();
+    TTI_SFPMOV(0, p_sfpu::LREG7, p_sfpu::LREG0, 0);
+    TTI_SFPMUL(p_sfpu::LREG0, LREG_MASK, p_sfpu::LCONST_0, p_sfpu::LREG0, 0);
+    TTI_SFPNOP;
+
+    TTI_SFPSHFT2(0, p_sfpu::LREG0, p_sfpu::LREG2, SFPSHFT2_MOD1_SUBVEC_SHFLROR1);
+    TTI_SFPNOP;
+    TTI_SFPADD(p_sfpu::LREG0, p_sfpu::LCONST_1, p_sfpu::LREG2, p_sfpu::LREG0, 0);
+    TTI_SFPNOP;
+
+    TTI_SFPSHFT2(0, p_sfpu::LREG0, p_sfpu::LREG2, SFPSHFT2_MOD1_SUBVEC_SHFLROR1);
+    TTI_SFPNOP;
+    TTI_SFPSHFT2(0, p_sfpu::LREG2, p_sfpu::LREG2, SFPSHFT2_MOD1_SUBVEC_SHFLROR1);
+    TTI_SFPNOP;
+    TTI_SFPADD(p_sfpu::LREG0, p_sfpu::LCONST_1, p_sfpu::LREG2, p_sfpu::LREG0, 0);
+    TTI_SFPNOP;
+
+    TTI_SFPSHFT2(0, p_sfpu::LREG0, p_sfpu::LREG2, SFPSHFT2_MOD1_SUBVEC_SHFLROR1);
+    TTI_SFPNOP;
+    TTI_SFPSHFT2(0, p_sfpu::LREG2, p_sfpu::LREG2, SFPSHFT2_MOD1_SUBVEC_SHFLROR1);
+    TTI_SFPNOP;
+    TTI_SFPSHFT2(0, p_sfpu::LREG2, p_sfpu::LREG2, SFPSHFT2_MOD1_SUBVEC_SHFLROR1);
+    TTI_SFPNOP;
+    TTI_SFPSHFT2(0, p_sfpu::LREG2, p_sfpu::LREG2, SFPSHFT2_MOD1_SUBVEC_SHFLROR1);
+    TTI_SFPNOP;
+    TTI_SFPADD(p_sfpu::LREG0, p_sfpu::LCONST_1, p_sfpu::LREG2, p_sfpu::LREG0, 0);
+    TTI_SFPNOP;
+
+    // LREG0 = 1 / sum(exp(x - max(x))).
+    TTI_SFPARECIP(0, p_sfpu::LREG0, p_sfpu::LREG1, sfpi::SFPARECIP_MOD1_RECIP);
+    TTI_SFPMAD(p_sfpu::LREG0, p_sfpu::LREG1, p_sfpu::LCONST_1, p_sfpu::LREG2, 1);
+    TTI_SFPMAD(p_sfpu::LREG2, p_sfpu::LREG2, p_sfpu::LREG2, p_sfpu::LREG3, 0);
+    TTI_SFPMAD(p_sfpu::LREG3, p_sfpu::LREG2, p_sfpu::LREG2, p_sfpu::LREG3, 0);
+    TTI_SFPSWAP(0, p_sfpu::LCONST_1, p_sfpu::LREG3, sfpi::SFPSWAP_MOD1_VEC_MIN_MAX);
+    TTI_SFPMAD(p_sfpu::LREG3, p_sfpu::LREG1, p_sfpu::LREG1, p_sfpu::LREG0, 0);
+
+    // Normalize both column groups and write the completed softmax to row 0.
+    TTI_SFPLOAD(p_sfpu::LREG1, 0, ADDR_MOD_7, 0);
+    TTI_SFPLOAD(p_sfpu::LREG2, 0, ADDR_MOD_7, 2);
+    TTI_SFPMUL(p_sfpu::LREG1, p_sfpu::LREG0, p_sfpu::LCONST_0, p_sfpu::LREG1, 0);
+    TTI_SFPMUL(p_sfpu::LREG2, p_sfpu::LREG0, p_sfpu::LCONST_0, p_sfpu::LREG2, 0);
+    TTI_SFPSTORE(p_sfpu::LREG1, 0, ADDR_MOD_7, 0);
+    TTI_SFPSTORE(p_sfpu::LREG2, 0, ADDR_MOD_7, 2);
+}
+
+} // namespace sfpu
+} // namespace ckernel

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_deepseek_moe_gate_eltwise_binary.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_deepseek_moe_gate_eltwise_binary.h
@@ -1,0 +1,164 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+#include "ckernel_include.h"
+#include "ckernel_ops.h"
+#include "ckernel_template.h"
+#include "cmath_common.h"
+#include "llk_assert.h"
+#include "llk_math_common.h"
+
+using namespace ckernel;
+
+enum class DeepseekMoeGateEltwiseBinaryMode
+{
+    COPY,
+    RELOAD,
+};
+
+// local function declarations
+template <EltwiseBinaryType eltwise_binary_type>
+inline void deepseek_moe_gate_eltwise_binary_configure_addrmod()
+{
+    // Use srcA for data movement
+    if constexpr (
+        (eltwise_binary_type == EltwiseBinaryType::ELWADD) || (eltwise_binary_type == EltwiseBinaryType::ELWSUB) ||
+        (eltwise_binary_type == EltwiseBinaryType::ELWMUL))
+    {
+        addr_mod_t {
+            .srca = {.incr = 8},
+            .srcb = {.incr = 8},
+            .dest = {.incr = 8},
+        }
+            .set(ADDR_MOD_0);
+        addr_mod_t {
+            .srca = {.incr = 0},
+            .srcb = {.incr = 0},
+            .dest = {.incr = 0},
+        }
+            .set(ADDR_MOD_1);
+    }
+}
+
+template <EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE>
+inline void deepseek_moe_gate_eltwise_binary_reuse_dest_as_src()
+{
+    if constexpr (binary_reuse_dest == EltwiseBinaryReuseDestType::DEST_TO_SRCA)
+    {
+        TTI_STALLWAIT(
+            p_stall::STALL_MATH,
+            p_stall::WAIT_SFPU | p_stall::SRCA_VLD); // MOVD2A for a whole face assumes unpacker will set a dummy
+                                                     // data_valid, so we want to wait on that
+        TTI_MOVD2A(0, p_mova2d::MATH_HALO_ROWS + 0, ADDR_MOD_1, p_movd2a::MOV_4_ROWS, 0);
+        TTI_MOVD2A(0, p_mova2d::MATH_HALO_ROWS + 4, ADDR_MOD_1, p_movd2a::MOV_4_ROWS, 4);
+        TTI_MOVD2A(0, p_mova2d::MATH_HALO_ROWS + 8, ADDR_MOD_1, p_movd2a::MOV_4_ROWS, 8);
+        TTI_MOVD2A(0, p_mova2d::MATH_HALO_ROWS + 12, ADDR_MOD_1, p_movd2a::MOV_4_ROWS, 12);
+    }
+    else if constexpr (binary_reuse_dest == EltwiseBinaryReuseDestType::DEST_TO_SRCB)
+    {
+        TTI_STALLWAIT(
+            p_stall::STALL_MATH,
+            p_stall::WAIT_SFPU | p_stall::SRCB_VLD); // MOVD2B for a whole face assumes unpacker will set a dummy
+                                                     // data_valid, so we want to wait on that
+        TTI_MOVD2B(0, p_movd2b::SRC_ZERO_OFFSET + 0, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 0);
+        TTI_MOVD2B(0, p_movd2b::SRC_ZERO_OFFSET + 4, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 4);
+        TTI_MOVD2B(0, p_movd2b::SRC_ZERO_OFFSET + 8, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 8);
+        TTI_MOVD2B(0, p_movd2b::SRC_ZERO_OFFSET + 12, ADDR_MOD_1, p_movd2b::MOV_4_ROWS, 12);
+    }
+}
+
+// NOTE: clear_fp32_dst_acc is accepted but not acted on, and ZERO_ACC_MODE is its unused remnant --
+// unlike _llk_math_eltwise_binary_, this path issues no ZEROACC. Both are marked maybe_unused rather
+// than removed so the signature keeps matching blaze's, which behaves the same way.
+template <EltwiseBinaryType eltwise_binary_type, DstSync Dst, bool is_fp32_dest_acc_en, MathFidelity math_fidelity>
+inline void _llk_math_deepseek_moe_gate_eltwise_binary_(const std::uint32_t num_faces, std::uint32_t dst_index, [[maybe_unused]] const bool clear_fp32_dst_acc)
+{
+    LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
+    constexpr bool high_fidelity                           = is_high_fidelity(math_fidelity);
+    [[maybe_unused]] constexpr std::uint32_t ZERO_ACC_MODE = p_zeroacc::CLR_16;
+    static_assert(!(eltwise_binary_type == EltwiseBinaryType::ELWMUL && high_fidelity), "High fidelity is not supported for ELWMUL");
+
+    math::set_dst_write_addr<DstTileShape::Tile32x32, UnpackDestination::SrcRegs>(dst_index);
+
+    if constexpr (
+        (eltwise_binary_type == EltwiseBinaryType::ELWADD) || (eltwise_binary_type == EltwiseBinaryType::ELWSUB) ||
+        (eltwise_binary_type == EltwiseBinaryType::ELWMUL))
+    {
+        ckernel_template::run();
+    }
+    math::clear_dst_reg_addr();
+}
+
+template <EltwiseBinaryType eltwise_binary_type, DeepseekMoeGateEltwiseBinaryMode mode, MathFidelity math_fidelity>
+inline void deepseek_moe_gate_eltwise_binary_configure_mop(const std::uint32_t acc_to_dest = 0, const std::uint32_t num_faces = 4)
+{
+    LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
+    constexpr bool high_fidelity      = is_high_fidelity(math_fidelity);
+    const std::uint32_t addr_mod      = ADDR_MOD_0;
+    constexpr std::uint32_t innerloop = 16 >> 3; // 8 rows per eltwise op at a time.
+    std::uint32_t outerloop           = num_faces;
+    const auto broadcast_type         = p_elwise::SRCB_NO_BCAST;
+
+    constexpr std::uint32_t dst_tile_offset = 64; // 1 tile x 64 rows per tile
+    constexpr std::uint32_t dst_math_offset = 2 * dst_tile_offset;
+
+    std::uint32_t math_op;
+
+    // TODO: Probably not worth it to use a replay buffer/mop for this
+    // Just hardcode the math ops in _llk_math_deepseek_moe_gate_eltwise_binary_ since we only have 1 face
+    if constexpr (eltwise_binary_type == EltwiseBinaryType::ELWADD)
+    {
+        math_op = TT_OP_ELWADD(0, acc_to_dest, broadcast_type, addr_mod, dst_math_offset);
+    }
+    else if constexpr (eltwise_binary_type == EltwiseBinaryType::ELWSUB)
+    {
+        math_op = TT_OP_ELWSUB(0, acc_to_dest, broadcast_type, addr_mod, dst_math_offset);
+    }
+    else if constexpr (eltwise_binary_type == EltwiseBinaryType::ELWMUL)
+    {
+        static_assert(!high_fidelity, "High fidelity is not supported for ELWMUL");
+        math_op = TT_OP_ELWMUL(0, 0, broadcast_type, addr_mod, dst_math_offset);
+    }
+    if constexpr (mode == DeepseekMoeGateEltwiseBinaryMode::RELOAD)
+    {
+        load_replay_buf(
+            ckernel::math::replay_buf_offset, // replay buffer offset
+            5,
+            [] { deepseek_moe_gate_eltwise_binary_reuse_dest_as_src<EltwiseBinaryReuseDestType::DEST_TO_SRCA>(); });
+        std::uint32_t replay_instr = lltt::replay_insn(math::replay_buf_offset, 5);
+        ckernel_template tmp(outerloop, innerloop, math_op);
+        tmp.set_start_op(replay_instr);
+        tmp.set_end_op(TT_OP_SETRWC(p_setrwc::CLR_AB, p_setrwc::CR_AB, 0, 0, 0, p_setrwc::SET_AB));
+        tmp.program();
+    }
+    else
+    {
+        ckernel_template tmp(outerloop, innerloop, TT_OP_MOVA2D(0, 0, ADDR_MOD_1, p_mova2d::MOV_8_ROWS, 0), math_op);
+        tmp.set_end_op(TT_OP_SETRWC(p_setrwc::CLR_AB, p_setrwc::CR_AB, 0, 0, 0, p_setrwc::SET_AB));
+        tmp.program();
+    }
+}
+
+template <EltwiseBinaryType eltwise_binary_type, DeepseekMoeGateEltwiseBinaryMode mode, MathFidelity math_fidelity>
+inline void _llk_math_deepseek_moe_gate_eltwise_binary_init_(const std::uint32_t num_faces, const std::uint32_t acc_to_dest)
+{
+    LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
+
+    deepseek_moe_gate_eltwise_binary_configure_addrmod<eltwise_binary_type>();
+
+    if constexpr (
+        (eltwise_binary_type == EltwiseBinaryType::ELWADD) || (eltwise_binary_type == EltwiseBinaryType::ELWSUB) ||
+        (eltwise_binary_type == EltwiseBinaryType::ELWMUL))
+    {
+        deepseek_moe_gate_eltwise_binary_configure_mop<eltwise_binary_type, mode, math_fidelity>(acc_to_dest, num_faces);
+    }
+
+    TTI_SETC16(CLR_DVALID_SrcA_Disable_ADDR32, 0);
+
+    math::reset_counters(p_setrwc::SET_ABD_F);
+}

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_eltwise_unary_datacopy_softmax_k.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_eltwise_unary_datacopy_softmax_k.h
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+#include "ckernel_globals.h"
+#include "ckernel_include.h"
+#include "ckernel_ops.h"
+#include "cmath_common.h"
+#include "llk_math_common.h"
+
+using namespace ckernel;
+
+inline void _llk_math_eltwise_unary_datacopy_softmax_k_(const std::uint32_t dst_index)
+{
+    math::set_dst_write_addr<DstTileShape::Tile32x32, UnpackDestination::SrcRegs>(dst_index);
+
+    // Copy row 0 from SrcB, then broadcast its first scalar into DEST row 8.
+    TTI_MOVB2D(p_mov::DEST_NORM, p_movb2d::SRC_ZERO_OFFSET, ADDR_MOD_0, p_movb2d::MOV_1_ROW, 0);
+    TTI_MOVB2D(p_mov::DEST_NORM, p_movb2d::SRC_ZERO_OFFSET, ADDR_MOD_0, p_movb2d::MOV_1_ROW_D0_BRCST, 0);
+    TTI_SETRWC(p_setrwc::CLR_AB, 0, 0, 0, 0, 0);
+
+    math::clear_dst_reg_addr();
+}
+
+inline void _llk_math_eltwise_unary_datacopy_softmax_k_init_()
+{
+    addr_mod_t {
+        .srca = {.incr = 0},
+        .srcb = {.incr = 0},
+        .dest = {.incr = 8},
+    }
+        .set(ADDR_MOD_0);
+
+    TTI_SETC16(CLR_DVALID_SrcA_Disable_ADDR32, 0);
+    math::reset_counters(p_setrwc::SET_ABD_F);
+}

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_hadamard.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_hadamard.h
@@ -1,0 +1,231 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// LLK math primitives for the H128 (1x128) Hadamard transform.
+//
+// Goal: Y = H_128 * x for a 1x128 input vector x. Reshape x as the top
+// 8 rows of a 16x16 zero-padded X_pad; by the H_{2N}-of-half-zero-padded
+// identity, (H_16 X_pad H_16)[0..7] row-major-flattens to H_128 * x.
+//
+// All operands are 1-face [16, 16] bfloat16 tiles; the math path issues
+// MVMUL / MOVD2B directly with our own addrmods.
+//
+// Operand routing (matches Compute API & unpack):
+//   h16   -> srcB face (0, 0) and srcA bank 1 — the entire face is H_16.
+//   input -> srcA bank 0 face (0, 0) — top 8 rows = X_pad, rest zero pad.
+//
+// Per tile, on the math thread (only dst rows 0..7 of each face matter):
+//   1. MM1   : dst.face1[0..7] = (H_16 X_pad)[0..7]; CLR_A flips srcA to
+//              bank 1 (H_16, streamed by the unpack thread during MM1).
+//   2. MOVD2B: copy the MM1 result (dst.face1 -> srcB rows 0..7).
+//   3. MM2   : dst.face0[0..7] = (H_16 X_pad)[0..7] * H_16
+//                              = H_128 x reshape (8, 16).
+//   4. Normalize (normalize=true): SFPU scale dst.face0 by 1/sqrt(128).
+//
+// The MM1/MM2 dst-face split (face 1 then face 0) lets MM2 accumulate
+// into a clean face, removing the ZEROACC that a same-face scheme needs.
+//
+// Fidelity: LoFi runs 1 MVMUL/pass; high fidelity runs 2 (4 total) to
+// capture x at full bf16 precision. See _configure_addrmod_ for the
+// fidelity-phase derivation.
+
+#pragma once
+
+#include <cstdint>
+
+#include "ckernel_include.h"
+#include "ckernel_ops.h"
+#include "ckernel_template.h"
+#include "cmath_common.h"
+#include "llk_assert.h"
+#include "llk_defs.h"
+#include "llk_math_common.h"
+#include "sfpu/ckernel_sfpu_load_config.h"
+
+using namespace ckernel;
+
+// Program the addrmods the custom narrow MOP issues by hand.
+//
+// ADDR_MOD_7 is a true no-op used by every non-fidelity instruction
+// (MOVD2B, the SFPU load/store, the LoFi MVMULs): each carries explicit
+// src/dst row args and runs once, so we never want an implicit advance.
+//
+// The other three slots exist only for high fidelity, where each matmul
+// runs two MVMULs that accumulate partial mantissa products into the same
+// dst. They leave src/dst untouched and only step the FPU fidelity-phase
+// counter, which selects the mantissa halves (cumulative):
+//   phase 0 = srcA_hi·srcB_hi
+//   phase 1 = srcA_lo·srcB_hi   (extends srcA)
+//   phase 2 = srcA_hi·srcB_lo   (extends srcB)
+//   phase 3 = srcA_lo·srcB_lo   (unused)
+// H_16 is a ±1 sign matrix (no low mantissa), so any phase touching its
+// low half is identically zero and is skipped:
+//   ADDR_MOD_0 (+1): MM1 (srcA=x, srcB=H_16) -> phases {0,1}, full x.
+//   ADDR_MOD_1 (+2): MM2 (srcA=H_16, srcB=intermediate) -> {0,2}, full
+//                    intermediate.
+//   ADDR_MOD_2 (reset): zeroes the counter after each pass's 2nd MVMUL,
+//                       before MM2 and the next tile.
+template <MathFidelity math_fidelity = MathFidelity::HiFi4>
+inline void _llk_math_hadamard_h128_configure_addrmod_()
+{
+    addr_mod_t {
+        .srca = {.incr = 0, .clr = 0, .cr = 0},
+        .srcb = {.incr = 0, .clr = 0, .cr = 0},
+        .dest = {.incr = 0, .clr = 0, .cr = 0},
+    }
+        .set(ADDR_MOD_7);
+
+    if constexpr (is_high_fidelity(math_fidelity))
+    {
+        addr_mod_t {
+            .srca     = {.incr = 0, .clr = 0, .cr = 0},
+            .srcb     = {.incr = 0, .clr = 0, .cr = 0},
+            .dest     = {.incr = 0, .clr = 0, .cr = 0},
+            .fidelity = {.incr = 1, .clr = 0},
+        }
+            .set(ADDR_MOD_0);
+
+        addr_mod_t {
+            .srca     = {.incr = 0, .clr = 0, .cr = 0},
+            .srcb     = {.incr = 0, .clr = 0, .cr = 0},
+            .dest     = {.incr = 0, .clr = 0, .cr = 0},
+            .fidelity = {.incr = 2, .clr = 0},
+        }
+            .set(ADDR_MOD_1);
+
+        addr_mod_t {
+            .srca     = {.incr = 0, .clr = 0, .cr = 0},
+            .srcb     = {.incr = 0, .clr = 0, .cr = 0},
+            .dest     = {.incr = 0, .clr = 0, .cr = 0},
+            .fidelity = {.incr = 0, .clr = 1},
+        }
+            .set(ADDR_MOD_2);
+    }
+}
+
+// 1/sqrt(128) as float32 (= sqrt(2)/16 ≈ 0.08838834764831843).
+// Precomputed as constexpr so kH128NormBits folds into the
+// _sfpu_load_config32_ immediates at compile time.
+static constexpr float kH128NormScale        = 0.08838834764831843f;
+static constexpr std::uint32_t kH128NormBits = __builtin_bit_cast(std::uint32_t, kH128NormScale);
+
+template <MathFidelity math_fidelity = MathFidelity::HiFi4, bool normalize = true>
+inline void _llk_math_hadamard_h128_init_()
+{
+    _llk_math_hadamard_h128_configure_addrmod_<math_fidelity>();
+    if constexpr (normalize)
+    {
+        // Reset shared SFPU config registers (LREG12-14), then write
+        // kH128NormScale into LREG12 (vConstFloatPrgm0). The value
+        // persists across all 4 SFPU row groups for the program lifetime.
+        sfpu::_init_sfpu_config_reg();
+        sfpu::_sfpu_load_config32_(p_sfpu::LREG12, (kH128NormBits >> 16) & 0xFFFF, kH128NormBits & 0xFFFF);
+    }
+}
+
+// One H128 transform on the tile at dst_index (see the file header for
+// the algorithm and the unpack/dst-face scheme).
+//
+// Precondition: dst_index's tile is zeroed on acquire and used for one
+// transform per acquire — MM2 relies on a clean face 0, and we never
+// re-zero face 1 between calls.
+template <MathFidelity math_fidelity = MathFidelity::HiFi4, bool normalize = true>
+inline void _llk_math_hadamard_h128_(std::uint32_t dst_index)
+{
+    constexpr bool high_fidelity = is_high_fidelity(math_fidelity);
+
+    // dst row 16 = face 1 (MM1 target), row 0 = face 0 (MM2 target).
+
+    // Position dst and zero the rwc (incl. the fidelity phase — SET_ABD_F
+    // covers F) so the body addresses dst starting at phase 0.
+    math::set_dst_write_addr<DstTileShape::Tile32x32, UnpackDestination::SrcRegs>(dst_index);
+    math::reset_counters(p_setrwc::SET_ABD_F);
+
+    // MM1: dst.face1[0..7] = srcB * srcA = H_16 * X_pad = (H_16 X_pad)[0..7].
+    // HiFi adds phase 1 (see _configure_addrmod_). The final MVMUL carries
+    // CLR_A to release srcA bank 0 so the FPU advances to bank 1 (H_16 from
+    // phase-2 unpack) for MM2. srcB is left valid (FPU keeps ownership).
+    if constexpr (high_fidelity)
+    {
+        TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 16);
+        TTI_MVMUL(p_setrwc::CLR_A, 0, ADDR_MOD_2, 16);
+    }
+    else
+    {
+        TTI_MVMUL(p_setrwc::CLR_A, 0, ADDR_MOD_7, 16);
+    }
+
+    // Drain MM1's dst writeback before MOVD2B reads dst: MVMUL writes dst
+    // on the FPU pipe, MOVD2B reads it on the MOV pipe, which doesn't
+    // auto-track the hazard. Without it MOVD2B races ahead and reads
+    // pre-MM1 dst (PCC failures that vanish when DPRINTs throttle math).
+    TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::MATH);
+
+    // MOVD2B: dst.face1 rows 16..23 (= (H_16 X_pad)[0..7]) -> srcB rows 0..7,
+    // overwriting H_16[0..7] in the FPU-owned srcB bank. srcB rows 8..15
+    // keep H_16; MM2 reads only rows 0..7, so the residue is harmless.
+    TTI_MOVD2B(0, 0, ADDR_MOD_7, p_movd2b::MOV_4_ROWS, 16);
+    TTI_MOVD2B(0, 4, ADDR_MOD_7, p_movd2b::MOV_4_ROWS, 20);
+
+    // Wait for MOVD2B to complete
+    TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::MATH);
+
+    // MM2: dst.face0[0..7] = srcB * srcA = (H_16 X_pad)[0..7] * H_16
+    //                = H_128 x reshape (8, 16). srcA = H_16 (bank 1),
+    // srcB = MM1 result (MOVD2B). HiFi adds phase 2 (see _configure_addrmod_).
+    // face 0 is clean (acquire-zeroed, MM1 wrote face 1) so accumulation
+    // starts from zero. The final MVMUL carries CLR_AB to release srcA/srcB
+    // dvalid for the next tile's UNPACR — without it the dvalid flip-flops
+    // persist across invocations and the next unpack deadlocks.
+    if constexpr (high_fidelity)
+    {
+        TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0);
+        TTI_MVMUL(p_setrwc::CLR_AB, 0, ADDR_MOD_2, 0);
+    }
+    else
+    {
+        TTI_MVMUL(p_setrwc::CLR_AB, 0, ADDR_MOD_7, 0);
+    }
+
+    // Normalize: dst[0..7] *= kH128NormScale (LREG12 = 1/sqrt(128)).
+    if constexpr (normalize)
+    {
+        // FPU->SFPU dst hazard: drain MM2's writeback before SFPU reads dst.
+        TTI_STALLWAIT(p_stall::STALL_SFPU, p_stall::MATH);
+
+        // FP16B mode converts bfloat16 <-> float32 on load/store;
+        // SFPMUL(A, B, LCONST_0, D) computes D = A*B. Issuing all 4 loads
+        // before the muls (then all stores) hides the 4-cycle SFPU
+        // pipeline latency — each group of 4 fills one pipeline depth.
+        constexpr auto kFP16B = InstrModLoadStore::FP16B;
+
+        TTI_SFPLOAD(p_sfpu::LREG0, kFP16B, ADDR_MOD_7, 0); // rows 0..1
+        TTI_SFPLOAD(p_sfpu::LREG1, kFP16B, ADDR_MOD_7, 2); // rows 2..3
+        TTI_SFPLOAD(p_sfpu::LREG2, kFP16B, ADDR_MOD_7, 4); // rows 4..5
+        TTI_SFPLOAD(p_sfpu::LREG3, kFP16B, ADDR_MOD_7, 6); // rows 6..7
+
+        TTI_SFPMUL(p_sfpu::LREG0, p_sfpu::LREG12, p_sfpu::LCONST_0, p_sfpu::LREG0, 0);
+        TTI_SFPMUL(p_sfpu::LREG1, p_sfpu::LREG12, p_sfpu::LCONST_0, p_sfpu::LREG1, 0);
+        TTI_SFPMUL(p_sfpu::LREG2, p_sfpu::LREG12, p_sfpu::LCONST_0, p_sfpu::LREG2, 0);
+        TTI_SFPMUL(p_sfpu::LREG3, p_sfpu::LREG12, p_sfpu::LCONST_0, p_sfpu::LREG3, 0);
+
+        TTI_SFPSTORE(p_sfpu::LREG0, kFP16B, ADDR_MOD_7, 0);
+        TTI_SFPSTORE(p_sfpu::LREG1, kFP16B, ADDR_MOD_7, 2);
+        TTI_SFPSTORE(p_sfpu::LREG2, kFP16B, ADDR_MOD_7, 4);
+        TTI_SFPSTORE(p_sfpu::LREG3, kFP16B, ADDR_MOD_7, 6);
+    }
+}
+
+inline void _llk_math_hadamard_h128_uninit_()
+{
+    // Intentionally empty -- but NOT because the init left no state behind. _llk_math_hadamard_h128_init_
+    // programs ADDR_MOD_0/1/2/7 and, under normalize, resets the shared SFPU config registers and writes
+    // kH128NormScale into LREG12 (vConstFloatPrgm0). Neither is undone here:
+    //   - addrmods: every math LLK reprograms the mods it needs in its own init (see the
+    //     _configure_addrmod_ call at the top of each), so a stale Hadamard mod is overwritten before use.
+    //   - LREG12: persists for the program lifetime by design; a later SFPU op that expects a different
+    //     vConstFloatPrgm0 must set it itself. That is a real cross-op coupling, tracked separately.
+    // Kept as a no-op so the API stays symmetric with the init and matches the blaze original; making it
+    // restore state would emit instructions and change behavior.
+}

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_unpack_hadamard.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_unpack_hadamard.h
@@ -1,0 +1,157 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// LLK unpack primitives for the H128 (1x128) Hadamard transform.
+//
+// Tile geometry (matches op.py / hadamard.h):
+//   h16   ([16, 16], 1 face): H_16 fills face (0, 0). -> srcB face 0.
+//   input ([16, 16], 1 face): 128 input values in top 8 rows of face
+//                              (0, 0), zeros in rows 8..15. -> srcA face 0.
+//
+// Single-face unpack: each phase issues exactly one UNPACR per src
+// register, reading one 16x16 face per operand.
+//
+// Both phases are issued back-to-back on the unpack thread inside
+// _llk_unpack_hadamard_h128_ (MM1 runs concurrently on the math thread):
+//
+//   Phase 1 (context 0, before MM1): one UNPACR per src register —
+//     h16 -> srcB face 0, X_pad -> srcA bank 0 face 0.
+//
+//   Phase 2 (context 1, overlaps MM1): one UNPACR streams H_16 into
+//     srcA's *other* bank. Setting dvalid hands that bank to the FPU, so
+//     after MM1's CLR_A the FPU reads H_16 from srcA bank 1 for MM2.
+//     srcB's dvalid is never cleared during the two passes, so the
+//     FPU keeps H_16 in srcB until the math thread's MOVD2B overwrites
+//     rows 0..7 with the MM1 result.
+//
+// Context scheme (avoids a per-tile CFG write + TRISC_CFG stall for the
+// H_16 stream): the srcA unpacker base lives in two hardware config
+// contexts. Phase 1 runs on context 0 (configuring context 0's srcA/srcB
+// bases per tile) and ends with switch_config_context, so phase 2 runs on
+// context 1. The init preprograms context 1's srcA base once to the H_16
+// tile; since phase 1 only ever touches context 0, every phase-2 UNPACR
+// reads H_16 with no per-tile reconfiguration. Phase 2 ends by resetting
+// the context back to 0 for the next tile.
+//
+// Requirement: H_16 must sit at a fixed L1 address for the program's
+// lifetime (single-slot, persistent tile, h16_tile_index == 0). Phase 1
+// recomputes its srcB address each tile so it tolerates CB rotation, but
+// the preprogrammed context-1 srcA base does not.
+
+#pragma once
+
+#include <cstdint>
+
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "ckernel_ops.h"
+#include "cunpack_common.h"
+#include "llk_unpack_common.h"
+
+using namespace ckernel;
+using namespace ckernel::unpacker;
+
+// One-shot unpack init for the H128 transform. Call once at init, after
+// llk_unpack_hw_configure.
+//
+//   1. Single-face (16x16) config: read exactly one face per operand
+//      (transpose off, no partial face).
+//   2. Preprogram context 1's srcA (SEC0) base with the H_16 tile's fixed
+//      L1 address so phase-2 needs no per-tile CFG write (see "Context
+//      scheme" in the file header). H_16 must stay resident there.
+//   3. Reset to context 0 so the first tile's phase-1 unpack runs there.
+inline void _llk_unpack_hadamard_h128_init_(const std::uint32_t h16_address)
+{
+    LLK_ASSERT(is_valid_L1_address(h16_address), "H_16 L1 address must be in valid L1 memory region");
+
+    // ── Single-face config ────────────────────────────────────────────
+    // Full 16x16-face X span. srcA rests here; the per-tile path narrows it
+    // to 8 rows for the input read and restores it (see _llk_unpack_hadamard_h128_).
+    constexpr std::uint32_t kFaceXEnd = FACE_R_DIM * FACE_C_DIM - 1;
+
+    // Hadamard never transposes faces; force the face-transpose (haloize)
+    // mode off in case a prior datacopy left it on.
+    cfg_reg_rmw_tensix<THCON_SEC0_REG2_Haloize_mode_RMW>(0);
+
+    // Zero the z/w address counters for both unpackers.
+    TTI_SETADCZW(0b011, 0, 0, 0, 0, 0b1111);
+
+    // Full single-face span for srcA (input/h16) and srcB (h16).
+    TT_SETADCXX(p_setadc::UNP_A, kFaceXEnd, 0x0);
+    TT_SETADCXX(p_setadc::UNP_B, kFaceXEnd, 0x0);
+
+    // ── Context-1 H_16 preprogram ─────────────────────────────────────
+    volatile std::uint32_t tt_reg_ptr *cfg         = get_cfg_pointer();
+    cfg[THCON_SEC0_REG3_Base_cntx1_address_ADDR32] = h16_address;
+
+    // Start on context 0 so the first tile's phase-1 unpack runs there.
+    reset_config_context();
+}
+
+// One tile's worth of unpack: phase 1 (h16 -> srcB, input -> srcA bank 0)
+// then phase 2 (H_16 -> srcA bank 1). See the file header for the phase and
+// context scheme. The 1x128 input carries only the 128 real values (no
+// bottom-8 zero pad): phase 1 zeros srcA bank 0 at the full span, narrows to
+// 8 rows for the input UNPACR, then restores the full span (needed for the
+// phase-2 H_16 stream and the next tile's full-span zero-src). Operands:
+//   base_address_a / tile_index_a / tile_size_a -> h16  (srcB)
+//   base_address_b / tile_index_b / tile_size_b -> input (srcA)
+inline void _llk_unpack_hadamard_h128_(
+    const std::uint32_t base_address_a,
+    const std::uint32_t base_address_b,
+    const std::uint32_t tile_index_a,
+    const std::uint32_t tile_index_b,
+    const std::uint32_t tile_size_a,
+    const std::uint32_t tile_size_b)
+{
+    volatile std::uint32_t *cfg = get_cfg_pointer();
+
+    const std::uint32_t address_a = base_address_a + tile_size_a * tile_index_a; // h16
+    const std::uint32_t address_b = base_address_b + tile_size_b * tile_index_b; // input
+
+    constexpr std::uint32_t kFaceXEnd  = FACE_R_DIM * FACE_C_DIM - 1; // full 16x16 face
+    constexpr std::uint32_t kInputXEnd = 8 * FACE_C_DIM - 1;          // 8 rows = 128 datums
+
+    // ── Phase 1 (context 0): h16 -> srcB, input -> srcA bank 0 ──────────
+    wait_for_next_context(2);
+
+    // SEC0 (srcA) <- input, SEC1 (srcB) <- h16.
+    _llk_unpack_configure_addresses_(address_b, address_a, cfg);
+
+    semaphore_post(semaphore::UNPACK_SYNC); // Trisc::SEMPOST for context acquire
+
+    // Stall unpacker until pending CFG writes from Trisc have completed.
+    TTI_STALLWAIT(p_stall::STALL_UNPACK, p_stall::TRISC_CFG);
+
+    // h16 -> srcB (full face, Set Dvalid).
+    TTI_UNPACR(SrcB, 0, 0, 0, 0, 1 /*Set OvrdThreadId*/, 1 /*Set Dvalid*/, p_unpacr::RAREFYB_DISABLE, 0, 0 /*Set ContextIdInc*/, 0, 0, 1);
+
+    // Zero srcA bank 0 at the FULL span (ZEROSRC honors the X span, so this
+    // must precede the narrow) -> rows 8..15 zero for MM1's 16-row reduction.
+    // No Set Dvalid: the input UNPACR below sets it and hands the bank to FPU.
+    TTI_UNPACR_NOP(SrcA, 0, 0, 0 /*no Set Dvalid*/, 0, 0, 0, 0, p_unpacr_nop::UNP_ZEROSRC);
+
+    // Narrow srcA to the top 8 rows (128 datums) for the input read.
+    TTI_SETADCXX(p_setadc::UNP_A, kInputXEnd, 0x0);
+
+    // input -> srcA bank 0 (top 8 rows, Set Dvalid).
+    TTI_UNPACR(SrcA, 0, 0, 0, 0, 1 /*Set OvrdThreadId*/, 1 /*Set Dvalid*/, p_unpacr::RAREFYB_DISABLE, 0, 0 /*Set ContextIdInc*/, 0, 0, 1);
+
+    // Restore full face span: phase 2 streams the entire 16x16 H_16 into
+    // srcA bank 1, and the next tile's zero-src needs the full span.
+    TTI_SETADCXX(p_setadc::UNP_A, kFaceXEnd, 0x0);
+
+    t6_semaphore_get(semaphore::UNPACK_SYNC); // T6::SEMGET for context release
+    switch_config_context(unp_cfg_context);   // -> context 1
+
+    // ── Phase 2 (context 1): stream H_16 into srcA bank 1 (overlaps MM1) ─
+    // SEC0 context-1 srcA base was preprogrammed to H_16 by _init_, so no
+    // per-tile CFG write is needed. Set Dvalid hands srcA bank 1 to the FPU
+    // for MM2.
+    TTI_UNPACR(SrcA, 0, 0, 0, 0, 1 /*Set OvrdThreadId*/, 1 /*Set Dvalid*/, p_unpacr::RAREFYB_DISABLE, 0, 0 /*Set ContextIdInc*/, 0, 0, 1);
+    TTI_STALLWAIT(p_stall::STALL_UNPACK, p_stall::UNPACK);
+
+    // Re-pin phase 1 to context 0 for the next tile (one SETC16, no stall).
+    reset_config_context();
+}


### PR DESCRIPTION
### PR Category
Cross-repo clean-up

### Summary
Adds **21 blaze-authored LLKs** under `experimental/`, spread across the four layers exactly as tt-metal does for its own experimental LLKs (compare `mul_reduce_scalar`, `fast_untilize`):

| layer | dir | files |
|---|---|---|
| L1 compute API | `tt_metal/hw/inc/api/compute/experimental/` | 6 |
| L2 llk_api | `tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/` | 4 |
| L2S llk_api SFPU | `.../llk_api/experimental/llk_sfpu/` | 2 |
| L3 llk_lib | `tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/` | 4 |
| L4 SFPU functor | `tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/experimental/` | 5 |

Families: `hadamard`, `generic_moe_gate` (+ `top8`/`top16` variants), `softmax_k`, `sdpa_weighted_reduce`, `sdpa_exp_unclamped`, `eltwise_add_scalar`, `pack_rows_to_addr`, and the `deepseek_moe_gate` eltwise-binary primitive.

19 of the 21 have no counterpart anywhere in tt-metal, neither in the canonical LLK directories nor in `models/demos/deepseek_v3_b1/kernel_includes/`. The two exceptions are the `deepseek_moe_gate` eltwise-binary pair — see "Notes for reviewers".

**Additive only.** No existing file is modified, and no new directory is created - all five destinations already exist here and contain files.

### Relationship to blaze's copies
Relative to blaze's originals, 19 of the 21 are identical once the following are normalised away: tt-llk clang-format style, the `llk-fix-cstdint` hook (`std::uint*_t` + `<cstdint>`), the `ARCH_BLACKHOLE` / `ARCH_QUASAR` guards, and added comments.

Two carry code changes:

- `sdpa_weighted_reduce.h` — uses the `SrcOrder` overload of `reconfig_data_format`. Required here rather than preferred: blaze's pinned tt-metal only has the deprecated `<to_from_int8, is_tile_dim_reconfig_en>` bool overload, which main removes after 2026-08-20. Both forms expand to the same `detail::reconfig_df_both<true, false>(...)`, since `to_from_int8` is documented as ignored.
- `llk_math_deepseek_moe_gate_eltwise_binary.h` — `[[maybe_unused]]` on `clear_fp32_dst_acc` and `ZERO_ACC_MODE`. No codegen change; needed so the header compiles under the tt-llk harness's `-Werror -Wunused-parameter`.

### Notes for reviewers
Not in this PR:

- **LLK tests / goldens** — tracked separately as tt-blaze#2003
- **The `topk_xl` family (7 headers)** — already upstream here, and partly outside
  `experimental/` (`api/compute/topk_xl.h`, `common/inc/sfpu/ckernel_sfpu_topk_xl.h`).
  Two of the shared copies also diverge semantically from blaze's, so this needs
  per-file reconciliation rather than a copy
- **`deepseek_compute_kernel_hw_startup.h`** — already on canonical main at the same
  path and diverges from blaze's; tracked in tt-blaze
- **`ckernel_sfpu_sampling.h`** — dropped from this batch. tt-metal already carries a
  copy under `models/demos/deepseek_v3_b1/kernel_includes/` that is exercised by
  `test_sampling.py` and `test_lm_head_sampling.py`, so it needs the demo-fork
  reconciliation first
- **`sum_reduce_scalar.h`** — blaze changed its signature after this branch was cut
  (added `ocb`, switched to `SFPU_UNARY_CALL`); deferred
- **50 further headers with counterparts in the `deepseek_v3_b1` demo tree** — that
  fork also needs retiring, so they require a reconciliation decision first. Blaze's
  version is a compatible superset in every case that differs, so the intended
  resolution is to promote blaze's copy and delete both
- Blaze still consumes its own copies; it is unchanged by this PR and will be
  repointed at these once they reach the branch blaze pins

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pmilenkovic/blaze-llk-experimental-batch1)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pmilenkovic/blaze-llk-experimental-batch1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pmilenkovic/blaze-llk-experimental-batch1)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pmilenkovic/blaze-llk-experimental-batch1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=pmilenkovic/blaze-llk-experimental-batch1)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:pmilenkovic/blaze-llk-experimental-batch1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pmilenkovic/blaze-llk-experimental-batch1)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pmilenkovic/blaze-llk-experimental-batch1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pmilenkovic/blaze-llk-experimental-batch1)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pmilenkovic/blaze-llk-experimental-batch1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pmilenkovic/blaze-llk-experimental-batch1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pmilenkovic/blaze-llk-experimental-batch1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pmilenkovic/blaze-llk-experimental-batch1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pmilenkovic/blaze-llk-experimental-batch1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pmilenkovic/blaze-llk-experimental-batch1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pmilenkovic/blaze-llk-experimental-batch1)