### PR TITLE
[Bug fix][emule] Fix multi-op fabric-routing staleness + MCAST barrier direction

### DIFF
--- a/tt_metal/impl/emulation/emulated_program_runner.cpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.cpp
@@ -2150,6 +2150,13 @@ static std::mutex g_conn_route_mu;
 // the sender, so a per-core key would miss). Deduped by direction; append order makes index 0=fwd, 1=bwd.
 // See tt-emule docs/fabric-ccl-emulation.md.
 static std::unordered_map<uint32_t, std::vector<ConnRoute>> g_conn_route;
+// Persistent UNDIRECTED ring adjacency (chip -> ring-neighbor chips), accumulated across ALL ops and never
+// reset: the physical ethernet ring is static, but each op's senders open only the connection(s) they use,
+// so any single op's g_conn_route is an incomplete, per-chip one-sided view. The ring walk needs the full
+// undirected topology to traverse the turning Hamiltonian cycle without dead-ending at a chip that opened
+// only one direction this op. Direction (which way a send goes) still comes from per-op g_conn_route; only
+// the ring *connectivity* comes from here. See tt-emule docs/fabric-ccl-emulation.md.
+static std::unordered_map<uint32_t, std::set<uint32_t>> g_ring_adj;
 // Per-op reset flag: cleared at each new op's first connection-record so a later op's different line
 // orientation can't corrupt the src-keyed, direction-deduped table. See tt-emule docs/fabric-ccl-emulation.md.
 static std::atomic<bool> g_conn_route_dirty{true};
@@ -2174,6 +2181,9 @@ extern "C" void __emule_fabric_record_conn(uint32_t src, uint32_t wx, uint32_t w
     // Record the connection-owner core's (the mux core, on the MUX path) direction, keyed by its LOGICAL
     // coords — before the per-direction dedup below, which is for the src-keyed g_conn_route only.
     g_mux_dir[__emule_worker_key(src, wx, wy)] = dir;
+    // Accumulate the undirected ring edge (persistent; unaffected by the per-op reset above).
+    g_ring_adj[src].insert(neighbor);
+    g_ring_adj[neighbor].insert(src);
     auto& v = g_conn_route[src];
     for (const auto& c : v) {
         if (c.dir == dir) {
@@ -2205,16 +2215,18 @@ static std::vector<uint32_t> __emule_fabric_walk_ring(uint32_t src, uint32_t sta
         return walk;  // start direction not recorded — caller falls back
     }
     walk.push_back(static_cast<uint32_t>(first));
+    // Traverse the persistent UNDIRECTED ring adjacency: g_conn_route only fixes the FIRST hop's direction;
+    // connectivity comes from g_ring_adj so a chip that opened one connection this op doesn't dead-end.
     uint32_t prev = src, cur = static_cast<uint32_t>(first);
     for (int hop = 0; hop < 64; ++hop) {  // 64 = chip-count backstop
-        auto cit = g_conn_route.find(cur);
-        if (cit == g_conn_route.end()) {
+        auto ait = g_ring_adj.find(cur);
+        if (ait == g_ring_adj.end()) {
             break;
         }
         int next = -1;
-        for (const auto& c : cit->second) {
-            if (c.neighbor != prev) {  // the ring edge that continues forward (not the one back to prev)
-                next = static_cast<int>(c.neighbor);
+        for (uint32_t nb : ait->second) {
+            if (nb != prev) {  // the ring edge that continues forward (not the one back to prev)
+                next = static_cast<int>(nb);
                 break;
             }
         }
@@ -2318,8 +2330,19 @@ static std::vector<uint32_t> __emule_fabric_resolve_targets(const uint8_t* h, ui
         // mux signal above is absent. See tt-emule docs/fabric-ccl-emulation.md.
         if (dir < 0 && r.kind == emule_route_kind::MCAST_1D) {
             const uint32_t range = r.b ? r.b : 1;
+            // Match on the direction whose reachable length equals the multicast range, measured along the
+            // ACTUAL ring/line (g_ring_adj via walk_ring) — the compass walk dead-ends on the snaking
+            // Hamiltonian cycle, so it under-measures every direction and the match silently falls through to
+            // conns[0], sending a wide barrier the short way (delivering to too few chips → the barrier's
+            // wait never completes → deadlock). walk_ring reflects the true reach, so a range-R barrier picks
+            // the direction that actually reaches R chips, disambiguating the two directions of a bidirectional
+            // reduce_scatter. See tt-emule docs/fabric-ccl-emulation.md.
             for (const auto& cr : conns) {
-                if (__emule_fabric_walk(src_chip, static_cast<tt::tt_fabric::RoutingDirection>(cr.dir)).size() == range) {
+                size_t reach = __emule_fabric_walk_ring(src_chip, cr.dir).size();
+                if (reach == 0) {
+                    reach = __emule_fabric_walk(src_chip, static_cast<tt::tt_fabric::RoutingDirection>(cr.dir)).size();
+                }
+                if (reach == range) {
                     dir = static_cast<int>(cr.dir);
                     break;
                 }
@@ -3134,7 +3157,9 @@ static void launch_cores(
             id.logical_x = lx;
             id.logical_y = ly;
             id.proc_id = ki.processor_id;
-            id.kernel_src = nullptr;
+            // Point at the KernelInfo's owned source-path string (lives for the program run) so the
+            // deadlock dump names each parked fiber's kernel. EMULE-LOCAL DIAG (Bug B investigation).
+            id.kernel_src = ki.kernel_name.empty() ? nullptr : ki.kernel_name.c_str();
 
             // The fiber entry is the kernel body. __emule_self is set by the scheduler
             // on swap-in; the no-op start-barrier of the OS-thread model is gone (a

--- a/tt_metal/impl/emulation/emulated_program_runner.cpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.cpp
@@ -3062,23 +3062,26 @@ static std::vector<tt::tt_metal::emule::OobStateOwner> g_mesh_oob_keep;
 struct ResolvedProgram {
     std::map<CoreCoord, std::vector<KernelInfo>> core_kernels;
     uint32_t emule_sem_base = 0;
-    // Fabric connection routing captured at first resolve. __emule_fabric_record_conn populates the global
-    // g_conn_route/g_mux_dir during host program construction — but ttnn's program cache SKIPS construction
-    // on a cache hit, so an intervening different op leaves the globals holding ITS routes. Routing is a
-    // property of the program (like the compiled kernels), so snapshot it here and restore it into the
-    // globals at every dispatch, so a cache-hit reinstates its own directions. g_ring_adj (the static
-    // physical ring) is accumulated globally and not snapshotted; g_worker_dir is a run-time cache, not a
-    // program property, so it is cleared (not snapshotted/restored) and re-derived per op. See tt-emule
-    // docs/fabric-ccl-emulation.md.
-    // NOTE (known limitation): an LRU-forced re-resolve of a ttnn program-cache hit re-runs the snapshot
-    // below with construction skipped, so it would capture whatever routes the globals then hold. Bounded
-    // today by kMaxResolvedPrograms >> live CCL programs; tracked for a per-program construction guard.
-    std::unordered_map<uint32_t, std::vector<ConnRoute>> conn_route;
-    std::unordered_map<uint64_t, uint32_t> mux_dir;
 };
 static std::unordered_map<ProgramId, ResolvedProgram> g_resolved_programs;
 static std::deque<ProgramId> g_resolved_lru;
 static constexpr size_t kMaxResolvedPrograms = 256;
+
+// Per-program fabric routing, keyed by ProgramId. __emule_fabric_record_conn populates the globals
+// g_conn_route/g_mux_dir during host program construction, but ttnn's program cache SKIPS construction on a
+// cache hit, so an intervening op leaves the globals holding ITS routes. Routing is a property of the
+// program (like the compiled kernels), so it is captured ONCE (on the program's first resolve, right after
+// its construction recorded it) and restored into the globals at every dispatch, so a cache-hit reinstates
+// its own directions. This map is intentionally NOT LRU-bounded (unlike g_resolved_programs): the routing
+// data is tiny, and it must outlive kernel-cache eviction so an evicted-then-redispatched program restores
+// its own routes rather than re-capturing a foreign op's. g_ring_adj (static physical ring) is accumulated
+// globally and not captured; g_worker_dir is a run-time cache, cleared and re-derived per op. See tt-emule
+// docs/fabric-ccl-emulation.md.
+struct ProgramRoutes {
+    std::unordered_map<uint32_t, std::vector<ConnRoute>> conn_route;
+    std::unordered_map<uint64_t, uint32_t> mux_dir;
+};
+static std::unordered_map<ProgramId, ProgramRoutes> g_program_routes;
 
 static void launch_cores(
     std::vector<CoreSetup>& core_setups,
@@ -3366,14 +3369,15 @@ static ResolvedProgram& prepare_program(IDevice* device, Program& program) {
         pid,
         resolved.core_kernels.size());
 
-    // Snapshot this program's fabric routing (recorded into the globals by __emule_fabric_record_conn during
-    // this program's host construction, just before this first resolve) so a later program-cache HIT — which
-    // skips construction — can restore its own directions instead of inheriting an intervening op's. See the
-    // ResolvedProgram fields and the restore in execute_program_emulated.
+    // Capture this program's fabric routing ONCE, keyed by pid: on its first resolve the globals still hold
+    // what __emule_fabric_record_conn recorded during this program's host construction (just before this
+    // resolve). On an LRU-forced re-resolve of a ttnn cache-hit (construction skipped, globals hold a foreign
+    // op's routes) the entry already exists, so we keep the ORIGINAL. Restored in execute_program_emulated.
     {
         std::lock_guard<std::mutex> lk(g_conn_route_mu);
-        resolved.conn_route = g_conn_route;
-        resolved.mux_dir = g_mux_dir;
+        if (g_program_routes.find(pid) == g_program_routes.end()) {
+            g_program_routes[pid] = ProgramRoutes{g_conn_route, g_mux_dir};
+        }
     }
 
     // LRU-bound the cache (safety net; entries are otherwise valid for the program's life).
@@ -3433,14 +3437,18 @@ void execute_program_emulated(IDevice* device, Program& program) {
     // Restore this program's fabric routing into the globals before the run resolves any 1D send direction.
     // On a fresh resolve this equals what record_conn just recorded (no-op); on a program-cache HIT (which
     // skipped construction + record_conn) it reinstates this program's directions over whatever an
-    // intervening op left behind. g_ring_adj (static physical ring) is intentionally left accumulated;
-    // g_worker_dir is a run-time cache, cleared here so it is re-derived for this op. See
-    // ResolvedProgram / tt-emule docs/fabric-ccl-emulation.md.
+    // intervening op left behind. Keyed by pid in g_program_routes (never LRU-evicted), so it is correct even
+    // after the resolved-program cache evicts and re-resolves this program. g_ring_adj (static physical ring)
+    // is intentionally left accumulated; g_worker_dir is a run-time cache, cleared here so it is re-derived
+    // for this op. See ProgramRoutes / tt-emule docs/fabric-ccl-emulation.md.
     {
+        const ProgramId pid = program.impl().get_id();
         std::lock_guard<std::mutex> lk(g_conn_route_mu);
-        g_conn_route = resolved.conn_route;
+        if (auto rit = g_program_routes.find(pid); rit != g_program_routes.end()) {
+            g_conn_route = rit->second.conn_route;
+            g_mux_dir = rit->second.mux_dir;
+        }
         g_worker_dir.clear();
-        g_mux_dir = resolved.mux_dir;
     }
 
     const bool defer = g_emule_mesh_defer;  // mesh register phase (the run is deferred)

--- a/tt_metal/impl/emulation/emulated_program_runner.cpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.cpp
@@ -2193,10 +2193,14 @@ extern "C" void __emule_fabric_record_conn(uint32_t src, uint32_t wx, uint32_t w
     v.push_back(ConnRoute{dir, neighbor});
 }
 
-// Ordered ring members at distance 1,2,... from `src` starting in `start_dir`, by chaining the per-chip
-// recorded ring neighbors (g_conn_route) — at each hop taking the neighbor that is NOT where we came from,
-// so it follows the turning Hamiltonian cycle the compass walk can't. Returns empty if the chain is
-// incomplete (caller falls back to the compass walk). See tt-emule docs/fabric-ccl-emulation.md.
+// Ordered ring members at distance 1,2,... from `src` starting in `start_dir`. The first hop's direction
+// comes from `g_conn_route[src]`; subsequent hops follow the persistent undirected ring adjacency
+// (g_ring_adj), at each chip taking the unvisited neighbor that is NOT where we came from — so it follows
+// the turning Hamiltonian cycle the compass walk can't. Stops at a dead end or when the cycle closes back
+// at `src`. Returns empty only if `src`/`start_dir` was never recorded. A chip with more than one such
+// continuation means g_ring_adj has accumulated cross-axis edges from another op's collective, which the
+// undirected union cannot disambiguate — that is TT_FATAL (multi-axis topology not modeled), not a silent
+// misroute. See tt-emule docs/fabric-ccl-emulation.md.
 static std::vector<uint32_t> __emule_fabric_walk_ring(uint32_t src, uint32_t start_dir) {
     std::vector<uint32_t> walk;
     std::lock_guard<std::mutex> lk(g_conn_route_mu);
@@ -2217,23 +2221,36 @@ static std::vector<uint32_t> __emule_fabric_walk_ring(uint32_t src, uint32_t sta
     walk.push_back(static_cast<uint32_t>(first));
     // Traverse the persistent UNDIRECTED ring adjacency: g_conn_route only fixes the FIRST hop's direction;
     // connectivity comes from g_ring_adj so a chip that opened one connection this op doesn't dead-end.
+    std::set<uint32_t> visited{src, static_cast<uint32_t>(first)};
     uint32_t prev = src, cur = static_cast<uint32_t>(first);
     for (int hop = 0; hop < 64; ++hop) {  // 64 = chip-count backstop
         auto ait = g_ring_adj.find(cur);
         if (ait == g_ring_adj.end()) {
             break;
         }
+        // The continuation is the neighbor that is neither where we came from nor already on the walk.
+        // A valid 1D ring gives exactly one; more than one means g_ring_adj has accumulated cross-axis
+        // edges from another op's collective, which the undirected union cannot disambiguate.
         int next = -1;
+        int n_cont = 0;
         for (uint32_t nb : ait->second) {
-            if (nb != prev) {  // the ring edge that continues forward (not the one back to prev)
-                next = static_cast<int>(nb);
-                break;
+            if (nb != prev && visited.find(nb) == visited.end()) {
+                if (++n_cont == 1) {
+                    next = static_cast<int>(nb);
+                }
             }
         }
+        TT_FATAL(
+            n_cont <= 1,
+            "walk_ring: ambiguous ring continuation at chip {} (degree {} in g_ring_adj); multi-axis fabric "
+            "topology not modeled",
+            cur,
+            ait->second.size());
         if (next < 0 || static_cast<uint32_t>(next) == src) {
             break;  // dead end, or the cycle closed back at the source
         }
         walk.push_back(static_cast<uint32_t>(next));
+        visited.insert(static_cast<uint32_t>(next));
         prev = cur;
         cur = static_cast<uint32_t>(next);
     }
@@ -2332,20 +2349,24 @@ static std::vector<uint32_t> __emule_fabric_resolve_targets(const uint8_t* h, ui
             const uint32_t range = r.b ? r.b : 1;
             // Match on the direction whose reachable length equals the multicast range, measured along the
             // actual ring/line (g_ring_adj via walk_ring, which follows the snaking Hamiltonian cycle the
-            // compass walk dead-ends on). A range-R barrier picks the direction that reaches R chips,
-            // disambiguating the two directions of a bidirectional reduce_scatter. See tt-emule
-            // docs/fabric-ccl-emulation.md.
+            // compass walk dead-ends on). On an OPEN line the two directions reach different lengths, so a
+            // range-R barrier picks the direction that reaches R chips, disambiguating the two directions of
+            // a bidirectional reduce_scatter. On a CLOSED ring both directions reach N-1, so a full-ring
+            // range matches both — that tie is ambiguous, so fall through to the recorded direction index
+            // rather than guessing conns[0]. See tt-emule docs/fabric-ccl-emulation.md.
+            int matched = -1;
+            int n_match = 0;
             for (const auto& cr : conns) {
-                size_t reach = __emule_fabric_walk_ring(src_chip, cr.dir).size();
-                if (reach == 0) {
-                    reach = __emule_fabric_walk(src_chip, static_cast<tt::tt_fabric::RoutingDirection>(cr.dir)).size();
-                }
-                if (reach == range) {
-                    dir = static_cast<int>(cr.dir);
-                    break;
+                if (__emule_fabric_walk_ring(src_chip, cr.dir).size() == range) {
+                    if (++n_match == 1) {
+                        matched = static_cast<int>(cr.dir);
+                    }
                 }
             }
-            if (dir < 0 && !conns.empty()) {
+            if (n_match == 1) {
+                dir = matched;  // unique range-match — the disambiguated direction
+            } else if (!conns.empty()) {
+                // no match, or an ambiguous closed-ring tie — use the actually-recorded send index
                 dir = static_cast<int>(conns[r.dir_index < conns.size() ? r.dir_index : 0].dir);
             }
             if (dir >= 0) {
@@ -3045,11 +3066,14 @@ struct ResolvedProgram {
     // g_conn_route/g_mux_dir during host program construction — but ttnn's program cache SKIPS construction
     // on a cache hit, so an intervening different op leaves the globals holding ITS routes. Routing is a
     // property of the program (like the compiled kernels), so snapshot it here and restore it into the
-    // globals at every dispatch, so a cache-hit reinstates its own directions. See tt-emule
-    // docs/fabric-ccl-emulation.md. (g_ring_adj is the static physical ring, accumulated globally and not
-    // snapshotted; g_worker_dir is a run-time cache captured empty here so restore resets it per op.)
+    // globals at every dispatch, so a cache-hit reinstates its own directions. g_ring_adj (the static
+    // physical ring) is accumulated globally and not snapshotted; g_worker_dir is a run-time cache, not a
+    // program property, so it is cleared (not snapshotted/restored) and re-derived per op. See tt-emule
+    // docs/fabric-ccl-emulation.md.
+    // NOTE (known limitation): an LRU-forced re-resolve of a ttnn program-cache hit re-runs the snapshot
+    // below with construction skipped, so it would capture whatever routes the globals then hold. Bounded
+    // today by kMaxResolvedPrograms >> live CCL programs; tracked for a per-program construction guard.
     std::unordered_map<uint32_t, std::vector<ConnRoute>> conn_route;
-    std::unordered_map<uint64_t, uint32_t> worker_dir;
     std::unordered_map<uint64_t, uint32_t> mux_dir;
 };
 static std::unordered_map<ProgramId, ResolvedProgram> g_resolved_programs;
@@ -3349,7 +3373,6 @@ static ResolvedProgram& prepare_program(IDevice* device, Program& program) {
     {
         std::lock_guard<std::mutex> lk(g_conn_route_mu);
         resolved.conn_route = g_conn_route;
-        resolved.worker_dir = g_worker_dir;
         resolved.mux_dir = g_mux_dir;
     }
 
@@ -3410,12 +3433,13 @@ void execute_program_emulated(IDevice* device, Program& program) {
     // Restore this program's fabric routing into the globals before the run resolves any 1D send direction.
     // On a fresh resolve this equals what record_conn just recorded (no-op); on a program-cache HIT (which
     // skipped construction + record_conn) it reinstates this program's directions over whatever an
-    // intervening op left behind. g_ring_adj (static physical ring) is intentionally left accumulated. See
+    // intervening op left behind. g_ring_adj (static physical ring) is intentionally left accumulated;
+    // g_worker_dir is a run-time cache, cleared here so it is re-derived for this op. See
     // ResolvedProgram / tt-emule docs/fabric-ccl-emulation.md.
     {
         std::lock_guard<std::mutex> lk(g_conn_route_mu);
         g_conn_route = resolved.conn_route;
-        g_worker_dir = resolved.worker_dir;
+        g_worker_dir.clear();
         g_mux_dir = resolved.mux_dir;
     }
 

--- a/tt_metal/impl/emulation/emulated_program_runner.cpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.cpp
@@ -2193,14 +2193,11 @@ extern "C" void __emule_fabric_record_conn(uint32_t src, uint32_t wx, uint32_t w
     v.push_back(ConnRoute{dir, neighbor});
 }
 
-// Ordered ring members at distance 1,2,... from `src` starting in `start_dir`. The first hop's direction
-// comes from `g_conn_route[src]`; subsequent hops follow the persistent undirected ring adjacency
-// (g_ring_adj), at each chip taking the unvisited neighbor that is NOT where we came from — so it follows
-// the turning Hamiltonian cycle the compass walk can't. Stops at a dead end or when the cycle closes back
-// at `src`. Returns empty only if `src`/`start_dir` was never recorded. A chip with more than one such
-// continuation means g_ring_adj has accumulated cross-axis edges from another op's collective, which the
-// undirected union cannot disambiguate — that is TT_FATAL (multi-axis topology not modeled), not a silent
-// misroute. See tt-emule docs/fabric-ccl-emulation.md.
+// Ordered ring members at distance 1,2,... from `src` in `start_dir`: first hop from g_conn_route[src], then
+// follow the persistent undirected adjacency g_ring_adj (unvisited non-prev neighbor), tracing the turning
+// Hamiltonian cycle the compass walk can't. Stops at a dead end / cycle close; empty if src/start_dir was
+// never recorded. TT_FATALs if a chip has >1 continuation (cross-axis edges from another op's collective,
+// not disambiguable from the undirected union) rather than misroute. See docs/fabric-ccl-emulation.md.
 static std::vector<uint32_t> __emule_fabric_walk_ring(uint32_t src, uint32_t start_dir) {
     std::vector<uint32_t> walk;
     std::lock_guard<std::mutex> lk(g_conn_route_mu);
@@ -2228,9 +2225,7 @@ static std::vector<uint32_t> __emule_fabric_walk_ring(uint32_t src, uint32_t sta
         if (ait == g_ring_adj.end()) {
             break;
         }
-        // The continuation is the neighbor that is neither where we came from nor already on the walk.
-        // A valid 1D ring gives exactly one; more than one means g_ring_adj has accumulated cross-axis
-        // edges from another op's collective, which the undirected union cannot disambiguate.
+        // Continuation = the unvisited neighbor other than `prev` (exactly one on a valid 1D ring; see header).
         int next = -1;
         int n_cont = 0;
         for (uint32_t nb : ait->second) {
@@ -2347,13 +2342,10 @@ static std::vector<uint32_t> __emule_fabric_resolve_targets(const uint8_t* h, ui
         // mux signal above is absent. See tt-emule docs/fabric-ccl-emulation.md.
         if (dir < 0 && r.kind == emule_route_kind::MCAST_1D) {
             const uint32_t range = r.b ? r.b : 1;
-            // Match on the direction whose reachable length equals the multicast range, measured along the
-            // actual ring/line (g_ring_adj via walk_ring, which follows the snaking Hamiltonian cycle the
-            // compass walk dead-ends on). On an OPEN line the two directions reach different lengths, so a
-            // range-R barrier picks the direction that reaches R chips, disambiguating the two directions of
-            // a bidirectional reduce_scatter. On a CLOSED ring both directions reach N-1, so a full-ring
-            // range matches both — that tie is ambiguous, so fall through to the recorded direction index
-            // rather than guessing conns[0]. See tt-emule docs/fabric-ccl-emulation.md.
+            // Pick the direction whose walk_ring reach equals the multicast range (measured along the actual
+            // ring, which walk_ring follows and the compass walk can't). Disambiguates the two directions of a
+            // bidirectional reduce_scatter on an open line; on a closed ring both reach N-1, so a tie falls
+            // through to the recorded direction index rather than guessing conns[0]. See docs/fabric-ccl-emulation.md.
             int matched = -1;
             int n_match = 0;
             for (const auto& cr : conns) {
@@ -3067,16 +3059,13 @@ static std::unordered_map<ProgramId, ResolvedProgram> g_resolved_programs;
 static std::deque<ProgramId> g_resolved_lru;
 static constexpr size_t kMaxResolvedPrograms = 256;
 
-// Per-program fabric routing, keyed by ProgramId. __emule_fabric_record_conn populates the globals
-// g_conn_route/g_mux_dir during host program construction, but ttnn's program cache SKIPS construction on a
-// cache hit, so an intervening op leaves the globals holding ITS routes. Routing is a property of the
-// program (like the compiled kernels), so it is captured ONCE (on the program's first resolve, right after
-// its construction recorded it) and restored into the globals at every dispatch, so a cache-hit reinstates
-// its own directions. This map is intentionally NOT LRU-bounded (unlike g_resolved_programs): the routing
-// data is tiny, and it must outlive kernel-cache eviction so an evicted-then-redispatched program restores
-// its own routes rather than re-capturing a foreign op's. g_ring_adj (static physical ring) is accumulated
-// globally and not captured; g_worker_dir is a run-time cache, cleared and re-derived per op. See tt-emule
-// docs/fabric-ccl-emulation.md.
+// Per-program fabric routing, keyed by ProgramId. record_conn populates the globals g_conn_route/g_mux_dir
+// during host program construction, but ttnn's program cache SKIPS construction on a cache hit, so an
+// intervening op leaves the globals holding ITS routes. Routing is a property of the program (like the
+// compiled kernels), so capture it once (first resolve) and restore it into the globals at each dispatch.
+// Deliberately NOT LRU-bounded (unlike g_resolved_programs): tiny, and must outlive kernel-cache eviction so
+// a re-resolved program keeps its own routes. g_ring_adj (physical ring) stays global; g_worker_dir is a
+// run-time cache, re-derived per op. See docs/fabric-ccl-emulation.md.
 struct ProgramRoutes {
     std::unordered_map<uint32_t, std::vector<ConnRoute>> conn_route;
     std::unordered_map<uint64_t, uint32_t> mux_dir;
@@ -3369,10 +3358,8 @@ static ResolvedProgram& prepare_program(IDevice* device, Program& program) {
         pid,
         resolved.core_kernels.size());
 
-    // Capture this program's fabric routing ONCE, keyed by pid: on its first resolve the globals still hold
-    // what __emule_fabric_record_conn recorded during this program's host construction (just before this
-    // resolve). On an LRU-forced re-resolve of a ttnn cache-hit (construction skipped, globals hold a foreign
-    // op's routes) the entry already exists, so we keep the ORIGINAL. Restored in execute_program_emulated.
+    // Capture once, keyed by pid: on first resolve the globals still hold what record_conn recorded for this
+    // program. A later re-resolve (cache-hit, construction skipped) finds the entry present and keeps it.
     {
         std::lock_guard<std::mutex> lk(g_conn_route_mu);
         if (g_program_routes.find(pid) == g_program_routes.end()) {
@@ -3434,13 +3421,9 @@ void execute_program_emulated(IDevice* device, Program& program) {
 
     ResolvedProgram& resolved = prepare_program(device, program);  // compile-once (memoized)
 
-    // Restore this program's fabric routing into the globals before the run resolves any 1D send direction.
-    // On a fresh resolve this equals what record_conn just recorded (no-op); on a program-cache HIT (which
-    // skipped construction + record_conn) it reinstates this program's directions over whatever an
-    // intervening op left behind. Keyed by pid in g_program_routes (never LRU-evicted), so it is correct even
-    // after the resolved-program cache evicts and re-resolves this program. g_ring_adj (static physical ring)
-    // is intentionally left accumulated; g_worker_dir is a run-time cache, cleared here so it is re-derived
-    // for this op. See ProgramRoutes / tt-emule docs/fabric-ccl-emulation.md.
+    // Restore this program's routing into the globals before any 1D send resolves, so a program-cache hit
+    // reinstates its own directions over an intervening op's. Keyed by pid (never evicted); g_worker_dir is a
+    // run-time cache, cleared here to re-derive per op. See ProgramRoutes / docs/fabric-ccl-emulation.md.
     {
         const ProgramId pid = program.impl().get_id();
         std::lock_guard<std::mutex> lk(g_conn_route_mu);

--- a/tt_metal/impl/emulation/emulated_program_runner.cpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.cpp
@@ -2331,12 +2331,10 @@ static std::vector<uint32_t> __emule_fabric_resolve_targets(const uint8_t* h, ui
         if (dir < 0 && r.kind == emule_route_kind::MCAST_1D) {
             const uint32_t range = r.b ? r.b : 1;
             // Match on the direction whose reachable length equals the multicast range, measured along the
-            // ACTUAL ring/line (g_ring_adj via walk_ring) — the compass walk dead-ends on the snaking
-            // Hamiltonian cycle, so it under-measures every direction and the match silently falls through to
-            // conns[0], sending a wide barrier the short way (delivering to too few chips → the barrier's
-            // wait never completes → deadlock). walk_ring reflects the true reach, so a range-R barrier picks
-            // the direction that actually reaches R chips, disambiguating the two directions of a bidirectional
-            // reduce_scatter. See tt-emule docs/fabric-ccl-emulation.md.
+            // actual ring/line (g_ring_adj via walk_ring, which follows the snaking Hamiltonian cycle the
+            // compass walk dead-ends on). A range-R barrier picks the direction that reaches R chips,
+            // disambiguating the two directions of a bidirectional reduce_scatter. See tt-emule
+            // docs/fabric-ccl-emulation.md.
             for (const auto& cr : conns) {
                 size_t reach = __emule_fabric_walk_ring(src_chip, cr.dir).size();
                 if (reach == 0) {
@@ -3043,6 +3041,16 @@ static std::vector<tt::tt_metal::emule::OobStateOwner> g_mesh_oob_keep;
 struct ResolvedProgram {
     std::map<CoreCoord, std::vector<KernelInfo>> core_kernels;
     uint32_t emule_sem_base = 0;
+    // Fabric connection routing captured at first resolve. __emule_fabric_record_conn populates the global
+    // g_conn_route/g_mux_dir during host program construction — but ttnn's program cache SKIPS construction
+    // on a cache hit, so an intervening different op leaves the globals holding ITS routes. Routing is a
+    // property of the program (like the compiled kernels), so snapshot it here and restore it into the
+    // globals at every dispatch, so a cache-hit reinstates its own directions. See tt-emule
+    // docs/fabric-ccl-emulation.md. (g_ring_adj is the static physical ring, accumulated globally and not
+    // snapshotted; g_worker_dir is a run-time cache captured empty here so restore resets it per op.)
+    std::unordered_map<uint32_t, std::vector<ConnRoute>> conn_route;
+    std::unordered_map<uint64_t, uint32_t> worker_dir;
+    std::unordered_map<uint64_t, uint32_t> mux_dir;
 };
 static std::unordered_map<ProgramId, ResolvedProgram> g_resolved_programs;
 static std::deque<ProgramId> g_resolved_lru;
@@ -3158,7 +3166,7 @@ static void launch_cores(
             id.logical_y = ly;
             id.proc_id = ki.processor_id;
             // Point at the KernelInfo's owned source-path string (lives for the program run) so the
-            // deadlock dump names each parked fiber's kernel. EMULE-LOCAL DIAG (Bug B investigation).
+            // quiescent-deadlock dump names each parked fiber's kernel.
             id.kernel_src = ki.kernel_name.empty() ? nullptr : ki.kernel_name.c_str();
 
             // The fiber entry is the kernel body. __emule_self is set by the scheduler
@@ -3334,6 +3342,17 @@ static ResolvedProgram& prepare_program(IDevice* device, Program& program) {
         pid,
         resolved.core_kernels.size());
 
+    // Snapshot this program's fabric routing (recorded into the globals by __emule_fabric_record_conn during
+    // this program's host construction, just before this first resolve) so a later program-cache HIT — which
+    // skips construction — can restore its own directions instead of inheriting an intervening op's. See the
+    // ResolvedProgram fields and the restore in execute_program_emulated.
+    {
+        std::lock_guard<std::mutex> lk(g_conn_route_mu);
+        resolved.conn_route = g_conn_route;
+        resolved.worker_dir = g_worker_dir;
+        resolved.mux_dir = g_mux_dir;
+    }
+
     // LRU-bound the cache (safety net; entries are otherwise valid for the program's life).
     if (g_resolved_programs.size() >= kMaxResolvedPrograms && !g_resolved_lru.empty()) {
         g_resolved_programs.erase(g_resolved_lru.front());
@@ -3387,6 +3406,18 @@ void execute_program_emulated(IDevice* device, Program& program) {
     g_conn_route_dirty.store(true, std::memory_order_relaxed);
 
     ResolvedProgram& resolved = prepare_program(device, program);  // compile-once (memoized)
+
+    // Restore this program's fabric routing into the globals before the run resolves any 1D send direction.
+    // On a fresh resolve this equals what record_conn just recorded (no-op); on a program-cache HIT (which
+    // skipped construction + record_conn) it reinstates this program's directions over whatever an
+    // intervening op left behind. g_ring_adj (static physical ring) is intentionally left accumulated. See
+    // ResolvedProgram / tt-emule docs/fabric-ccl-emulation.md.
+    {
+        std::lock_guard<std::mutex> lk(g_conn_route_mu);
+        g_conn_route = resolved.conn_route;
+        g_worker_dir = resolved.worker_dir;
+        g_mux_dir = resolved.mux_dir;
+    }
 
     const bool defer = g_emule_mesh_defer;  // mesh register phase (the run is deferred)
     dispatch_to_device(device, program, resolved, defer);


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Emulator-only fix in `tt_metal/impl/emulation/emulated_program_runner.cpp` (compiled only under `-DTT_METAL_USE_EMULE`; no effect on non-emule builds). It lets multi-layer / multi-op collective (CCL) workloads run under tt-emule without deadlock or misroute on a multi-chip mesh, e.g. a gpt-oss decoder stack on an 8-chip loudbox.

**What's Changed**
- MCAST barrier direction on the snaking ring: `__emule_fabric_resolve_targets` matches a 1D multicast's direction along the actual recorded ring adjacency (`g_ring_adj` via `walk_ring`, which follows the T3000 snaking Hamiltonian cycle) instead of the compass walk that dead-ends on it, so a range-R barrier reaches exactly R chips.
- Program-cache routing staleness: connection directions recorded during host program construction are snapshotted into the memoized `ResolvedProgram` and restored at each dispatch, so a ttnn program-cache hit (which skips construction) reinstates its own routes instead of inheriting an intervening op's.
- Review hardening (folds in the earlier draft's review feedback): `walk_ring` now tracks visited chips and `TT_FATAL`s on an ambiguous (degree>2) ring continuation, surfacing an unmodeled multi-axis topology rather than silently misrouting; dead compass fallbacks removed; a closed-ring direction tie falls through to the recorded index instead of guessing; `g_worker_dir` (a run-time cache) is cleared and re-derived per op rather than snapshotted.

**Tests**
Validated via the gpt-oss emule unit tests, run under tt-emule with a mock cluster descriptor (t3k for WH, blackhole_8xP150 for BH) and dummy weights:
- Prefill [`test_model`](https://github.com/tenstorrent/tt-metal/blob/64fe77a0e5ba/models/demos/gpt_oss/tests/unit/test_modules.py#L1209) / [`prefill_b1_s128`](https://github.com/tenstorrent/tt-metal/blob/64fe77a0e5ba/models/demos/gpt_oss/tests/unit/test_modules.py#L1200) on the 1x8 mesh: `test_model[wormhole_b0-1_layer-prefill_b1_s128-1x8]` -> PASS, PCC 0.984.
- Decode [`test_decoder`](https://github.com/tenstorrent/tt-metal/blob/64fe77a0e5ba/models/demos/gpt_oss/tests/unit/test_modules.py#L688) / [`decode_low_latency`](https://github.com/tenstorrent/tt-metal/blob/64fe77a0e5ba/models/demos/gpt_oss/tests/unit/test_modules.py#L663) on the 1x8 mesh: `test_decoder[wormhole_b0-unpaged-layer_0-decode_low_latency-1x8]` -> PASS, decoder-layer PCC 0.934 (MoE experts 0.931, ~= documented silicon 0.927; threshold 0.92 in `models/demos/gpt_oss/unit_test_thresholds.json`).

PCCs are bit-identical before and after the review-hardening commit (no regression). Companion tt-emule-blaze PR: tenstorrent/tt-emule-blaze#165.

### Notes for reviewers
- The entire diff is emule-only and guarded by `-DTT_METAL_USE_EMULE`; non-emule builds are unaffected.
- Focus: `walk_ring` / `__emule_fabric_resolve_targets` (1D fabric direction + target enumeration) and the `ResolvedProgram` fabric-routing snapshot/restore. `walk_ring` `TT_FATAL`s on an ambiguous (degree>2) ring continuation to surface an unmodeled multi-axis topology rather than silently misroute.
- Multichip / loudbox validation runs via the companion tt-emule-blaze regression gate (p150 + loudbox) at the pin-bump step.
- Addresses all review comments from the earlier draft PR #51352.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=brapanan/emule-gptoss-multichip-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:brapanan/emule-gptoss-multichip-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=brapanan/emule-gptoss-multichip-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:brapanan/emule-gptoss-multichip-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=brapanan/emule-gptoss-multichip-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:brapanan/emule-gptoss-multichip-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=brapanan/emule-gptoss-multichip-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:brapanan/emule-gptoss-multichip-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=brapanan/emule-gptoss-multichip-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:brapanan/emule-gptoss-multichip-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=brapanan/emule-gptoss-multichip-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:brapanan/emule-gptoss-multichip-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=brapanan/emule-gptoss-multichip-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:brapanan/emule-gptoss-multichip-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=brapanan/emule-gptoss-multichip-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:brapanan/emule-gptoss-multichip-main)


