### PR TITLE
GPT-OSS optimization

### DIFF
--- a/models/demos/gpt_oss/conftest.py
+++ b/models/demos/gpt_oss/conftest.py
@@ -10,6 +10,20 @@ import pytest
 
 def pytest_addoption(parser):
     parser.addoption("--skip-model-load", action="store_true", default=False, help="Skip loading the model state dict")
+    # Profiling-only overrides (used by gpt_logs/scripts/tracy.sh). Do not affect default runs.
+    parser.addoption(
+        "--gpt-oss-decode-trace-off",
+        action="store_true",
+        default=False,
+        help="Force enable_decode_trace=False so device profiler (tracy) captures per-op decode timings",
+    )
+    parser.addoption(
+        "--gpt-oss-max-tokens",
+        action="store",
+        type=int,
+        default=0,
+        help="Override max_generated_tokens (0 = use parametrized value). Small values speed up profiling.",
+    )
 
 
 @pytest.fixture(scope="session")

--- a/models/demos/gpt_oss/demo/text_demo.py
+++ b/models/demos/gpt_oss/demo/text_demo.py
@@ -471,6 +471,12 @@ def test_gpt_oss_demo(
     mesh_shape = tuple(mesh_device.shape)
     test_id = request.node.callspec.id if hasattr(request.node, "callspec") else request.node.name
     is_seqlen_sweep = "seqlen-sweep" in test_id
+    # Profiling-only CLI overrides (see models/demos/gpt_oss/conftest.py). Default runs unaffected.
+    if request.config.getoption("--gpt-oss-decode-trace-off"):
+        enable_decode_trace = False
+    _max_tokens_override = request.config.getoption("--gpt-oss-max-tokens")
+    if _max_tokens_override and _max_tokens_override > 0:
+        max_generated_tokens = _max_tokens_override
     # On single-row meshes (T3K, LoudBox), cap max_seq_len at 64k for seqlen-sweep so steps >64k are skipped
     actual_max_seq_len = min(max_seq_len, 64 * 1024) if (is_seqlen_sweep and mesh_shape[0] == 1) else max_seq_len
     if mesh_shape[0] == 1:

--- a/models/demos/gpt_oss/demo/text_demo.py
+++ b/models/demos/gpt_oss/demo/text_demo.py
@@ -901,8 +901,16 @@ def test_gpt_oss_demo(
                     # ttnn.argmax requires bf16/fp32 input.
                     if tl.dtype not in (ttnn.bfloat16, ttnn.float32):
                         tl = ttnn.typecast(tl, ttnn.bfloat16)
-                    tt_am = ttnn.argmax(tl, dim=-1)
-                    out_tok = ttnn.to_torch(tt_am).reshape(-1)[: out_tok.shape[0]].to(torch.int32).view(-1)
+                    # argmax on a TILE-layout [.,.,32,~201K] tensor is ~8ms (reduces all
+                    # 32 padded batch rows in tiled form). Slice to the active batch and
+                    # convert to ROW_MAJOR first: argmax over a row-major 1-row vector is
+                    # ~0.2ms (a ~40x cheaper reduction). Net ~8ms/token saved.
+                    nb = out_tok.shape[0]
+                    V = tl.shape[-1]
+                    tl_rows = ttnn.slice(tl, (0, 0, 0, 0), (1, 1, nb, V))
+                    tl_rm = ttnn.to_layout(tl_rows, ttnn.ROW_MAJOR_LAYOUT)
+                    tt_am = ttnn.argmax(tl_rm, dim=-1)
+                    out_tok = ttnn.to_torch(tt_am).reshape(-1)[:nb].to(torch.int32).view(-1)
                     ttnn.deallocate(tt_am)
                 except Exception:
                     # Robust fallback: full host readback + CPU argmax.

--- a/models/demos/gpt_oss/demo/text_demo.py
+++ b/models/demos/gpt_oss/demo/text_demo.py
@@ -878,16 +878,38 @@ def test_gpt_oss_demo(
                     sampling_params=device_sampling_params,
                 )
             else:
-                # decode_forward returns (logits, log_probs) when sampling_params=None.
-                logits, _ = generator.decode_forward(
+                # Host-side greedy fallback (on-device sampling unavailable when
+                # per-device padded vocab > 64K). Instead of reading the full
+                # [.,.,B,~201K] logits back to host every token (.cpu() + untilize +
+                # CPU argmax ≈ 46 ms/token — the dominant decode cost), keep logits on
+                # device (read_from_device=False), do the argmax on device, and read
+                # back only the token id (~34 ms/token, ~29% faster). Greedy result is
+                # identical to host argmax (validated: ttnn.argmax == torch.argmax).
+                tt_logits = generator.decode_forward(
                     out_tok,
                     current_pos,
                     enable_trace=enable_decode_trace,
                     page_table=page_table,
                     kv_cache=tt_kv_cache,
                     sampling_params=None,
+                    read_from_device=False,
                 )
-                out_tok = torch.argmax(logits, dim=-1).view(-1)
+                tl = tt_logits
+                while isinstance(tl, (list, tuple)):
+                    tl = tl[0]
+                try:
+                    # ttnn.argmax requires bf16/fp32 input.
+                    if tl.dtype not in (ttnn.bfloat16, ttnn.float32):
+                        tl = ttnn.typecast(tl, ttnn.bfloat16)
+                    tt_am = ttnn.argmax(tl, dim=-1)
+                    out_tok = ttnn.to_torch(tt_am).reshape(-1)[: out_tok.shape[0]].to(torch.int32).view(-1)
+                    ttnn.deallocate(tt_am)
+                except Exception:
+                    # Robust fallback: full host readback + CPU argmax.
+                    logits = generator.process_decode_output_host(
+                        generator.read_decode_output(tt_logits), is_tokens=False
+                    )[0]
+                    out_tok = torch.argmax(logits, dim=-1).view(-1)
 
             if iteration == 0:
                 profiler.end(f"compile_decode", iteration=batch_idx)

--- a/models/demos/gpt_oss/kernels/moe_reduce_compute.cpp
+++ b/models/demos/gpt_oss/kernels/moe_reduce_compute.cpp
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// gpt-oss custom fused MoE expert-reduce compute kernel.
+//
+// Computes, per output tile:
+//     dst0 = sum_e  score_col[e] * act_tile[e]        (hardware MAC, col-broadcast)
+//
+// This is the gpt-oss decode expert tail  sum_e w[e] * down[e]  (the bias term
+// bias*sum_e w[e] is added on the host side / by a cheap follow-up op).
+//
+// Adapted from
+//   ttnn/.../deepseek_moe_fast_reduce_nc_fused/device/kernels/..._compute.cpp
+// The reduce math (init_bcast ELWMUL/COL + acc_to_dest MAC) is IDENTICAL and was
+// PCC-validated (TEST A: 0.99995 vs sum_e down[e]). The ONLY difference from the
+// DeepSeek kernel is upstream: our reader packs score tiles with a DIRECT
+// expert->column-0 mapping (expert e == score column e), with no all_to_all
+// dispatch / expert_mapping gather. That removes the a2a byte-layout coupling
+// that made the stock op mis-score on a single 1x1 device.
+
+#include "api/compute/bcast.h"
+#include "api/dataflow/circular_buffer.h"
+
+using namespace ckernel;
+
+constexpr uint32_t num_output_tiles = get_compile_time_arg_val(0);
+constexpr uint32_t reduction_dim_size = get_compile_time_arg_val(1);  // num experts (E)
+constexpr uint32_t input_granularity = get_compile_time_arg_val(2);
+constexpr uint32_t compute_input_cb_id_0 = get_compile_time_arg_val(3);  // activations
+constexpr uint32_t compute_input_cb_id_1 = get_compile_time_arg_val(4);  // score tiles
+constexpr uint32_t compute_output_cb_id = get_compile_time_arg_val(5);
+
+void kernel_main() {
+    CircularBuffer cb_in0(compute_input_cb_id_0);
+    CircularBuffer cb_in1(compute_input_cb_id_1);
+    CircularBuffer cb_out(compute_output_cb_id);
+
+    constexpr uint32_t dst0 = 0;
+    constexpr uint32_t one_tile = 1;
+    constexpr uint32_t num_input_tiles_iter = reduction_dim_size / input_granularity;
+
+    init_bcast<EltwiseBinaryType::ELWMUL, BroadcastType::COL>(
+        compute_input_cb_id_0, compute_input_cb_id_1, compute_output_cb_id);
+
+    // acc_to_dest=1 => each mul_tiles_bcast_cols does dst0 += act * score (MAC)
+    MATH((llk_math_eltwise_binary_init<EltwiseBinaryType::ELWMUL, BroadcastType::COL, MATH_FIDELITY>(
+        compute_input_cb_id_0, compute_input_cb_id_1, 1 /*acc_to_dest*/)));
+
+    reconfig_data_format(compute_input_cb_id_0, compute_input_cb_id_1);
+
+    // Score tiles are pre-loaded once by the reader and stay resident.
+    cb_in1.wait_front(reduction_dim_size);
+    for (uint32_t i = 0; i < num_output_tiles; ++i) {
+        tile_regs_acquire();
+        for (uint32_t j = 0; j < num_input_tiles_iter; ++j) {
+            cb_in0.wait_front(input_granularity);
+            for (uint32_t k = 0; k < input_granularity; ++k) {
+                const uint32_t expert_tile = j * input_granularity + k;
+                mul_tiles_bcast_cols(compute_input_cb_id_0, compute_input_cb_id_1, k, expert_tile, dst0);
+            }
+            cb_in0.pop_front(input_granularity);
+        }
+        tile_regs_commit();
+        cb_out.reserve_back(one_tile);
+        pack_reconfig_data_format(compute_output_cb_id);
+        tile_regs_wait();
+        pack_tile(dst0, compute_output_cb_id);
+        tile_regs_release();
+        cb_out.push_back(one_tile);
+    }
+    cb_in1.pop_front(reduction_dim_size);
+}

--- a/models/demos/gpt_oss/kernels/moe_reduce_reader.cpp
+++ b/models/demos/gpt_oss/kernels/moe_reduce_reader.cpp
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// gpt-oss custom fused MoE expert-reduce reader kernel.
+//
+// Feeds the compute kernel two circular buffers:
+//   cb_scores (cb_in1): E score tiles, loaded ONCE and kept resident. Each tile
+//       is pre-built on the HOST in COL-broadcast format: element [token, col 0]
+//       = routing weight w[token, e]; other columns are ignored by the
+//       BroadcastType::COL MAC. Pre-building on host removes the all_to_all
+//       score-packing machinery of the stock DeepSeek reader.
+//   cb_act (cb_in0): activation (down[e]) tiles, streamed in expert-major order
+//       per output tile. For output tile i (i in 0..num_output_tiles-1) we push
+//       the E expert tiles act[e, i], e=0..E-1, so the compute inner loop can
+//       MAC-accumulate sum_e score[e]*act[e,i].
+//
+// Input activation tensor layout: [E, 1, T=32, H]  -> tiles are expert-major:
+//   tile(e, i) lives at DRAM page  e * num_output_tiles + i   (Tt=1).
+// Score tensor layout: [E, 1, 32, 32] -> E tiles, page e == score tile e.
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/dataflow_buffer.h"
+#include "api/tensor/noc_traits.h"
+
+constexpr uint32_t cb_act_id = get_compile_time_arg_val(0);
+constexpr uint32_t cb_scores_id = get_compile_time_arg_val(1);
+constexpr uint32_t num_experts = get_compile_time_arg_val(2);       // E (reduction dim)
+constexpr uint32_t num_output_tiles = get_compile_time_arg_val(3);  // Ht (Tt=1)
+// TensorAccessor CT args: activation @ 4, scores @ next.
+constexpr uint32_t ct_idx_act = 4;
+constexpr uint32_t ct_idx_scores = TensorAccessorArgs<ct_idx_act>::next_compile_time_args_offset();
+
+void kernel_main() {
+    const uint32_t act_addr = get_arg_val<uint32_t>(0);
+    const uint32_t scores_addr = get_arg_val<uint32_t>(1);
+
+    constexpr auto act_args = TensorAccessorArgs<ct_idx_act>();
+    constexpr auto scores_args = TensorAccessorArgs<ct_idx_scores>();
+    const auto act = TensorAccessor(act_args, act_addr);
+    const auto scores = TensorAccessor(scores_args, scores_addr);
+
+    Noc noc;
+    DataflowBuffer cb_scores(cb_scores_id);
+    DataflowBuffer cb_act(cb_act_id);
+
+    const uint32_t score_page = get_local_cb_interface(cb_scores_id).fifo_page_size;
+    const uint32_t act_page = get_local_cb_interface(cb_act_id).fifo_page_size;
+
+    // Prologue: load all E score tiles once; they stay resident for the whole kernel.
+    cb_scores.reserve_back(num_experts);
+    for (uint32_t e = 0; e < num_experts; ++e) {
+        noc.async_read(scores, cb_scores, score_page, {.page_id = e}, {.offset_bytes = e * score_page});
+    }
+    noc.async_read_barrier();
+    cb_scores.push_back(num_experts);
+
+    // Stream activation: for each output tile i, push the E expert tiles act[e,i].
+    for (uint32_t i = 0; i < num_output_tiles; ++i) {
+        for (uint32_t e = 0; e < num_experts; ++e) {
+            const uint32_t page = e * num_output_tiles + i;
+            cb_act.reserve_back(1);
+            noc.async_read(act, cb_act, act_page, {.page_id = page}, {.offset_bytes = 0});
+            noc.async_read_barrier();
+            cb_act.push_back(1);
+        }
+    }
+}

--- a/models/demos/gpt_oss/kernels/moe_reduce_reader.cpp
+++ b/models/demos/gpt_oss/kernels/moe_reduce_reader.cpp
@@ -60,14 +60,20 @@ void kernel_main() {
     // Stream activation for THIS core's output-tile slice. For each output tile i,
     // push the E expert tiles act[e,i]. Activation tile(e,i) is at DRAM page
     // e*num_output_tiles + i (expert-major, num_output_tiles = full Ht).
+    //
+    // PERF: issue all E async reads for one output tile into a contiguous E-slot CB
+    // window, then a SINGLE barrier, then push all E at once. This overlaps the E
+    // DRAM latencies instead of serializing a barrier per tile (the compute kernel
+    // consumes a full E-batch per output tile anyway via wait_front(input_granularity)
+    // -> here input_granularity==E so it waits once).
     for (uint32_t t = 0; t < n_tiles; ++t) {
         const uint32_t i = start_tile + t;
+        cb_act.reserve_back(num_experts);
         for (uint32_t e = 0; e < num_experts; ++e) {
             const uint32_t page = e * num_output_tiles + i;
-            cb_act.reserve_back(1);
-            noc.async_read(act, cb_act, act_page, {.page_id = page}, {.offset_bytes = 0});
-            noc.async_read_barrier();
-            cb_act.push_back(1);
+            noc.async_read(act, cb_act, act_page, {.page_id = page}, {.offset_bytes = e * act_page});
         }
+        noc.async_read_barrier();
+        cb_act.push_back(num_experts);
     }
 }

--- a/models/demos/gpt_oss/kernels/moe_reduce_reader.cpp
+++ b/models/demos/gpt_oss/kernels/moe_reduce_reader.cpp
@@ -33,6 +33,9 @@ constexpr uint32_t ct_idx_scores = TensorAccessorArgs<ct_idx_act>::next_compile_
 void kernel_main() {
     const uint32_t act_addr = get_arg_val<uint32_t>(0);
     const uint32_t scores_addr = get_arg_val<uint32_t>(1);
+    // Per-core output-tile slice [start_tile, start_tile + n_tiles).
+    const uint32_t start_tile = get_arg_val<uint32_t>(2);
+    const uint32_t n_tiles = get_arg_val<uint32_t>(3);
 
     constexpr auto act_args = TensorAccessorArgs<ct_idx_act>();
     constexpr auto scores_args = TensorAccessorArgs<ct_idx_scores>();
@@ -54,8 +57,11 @@ void kernel_main() {
     noc.async_read_barrier();
     cb_scores.push_back(num_experts);
 
-    // Stream activation: for each output tile i, push the E expert tiles act[e,i].
-    for (uint32_t i = 0; i < num_output_tiles; ++i) {
+    // Stream activation for THIS core's output-tile slice. For each output tile i,
+    // push the E expert tiles act[e,i]. Activation tile(e,i) is at DRAM page
+    // e*num_output_tiles + i (expert-major, num_output_tiles = full Ht).
+    for (uint32_t t = 0; t < n_tiles; ++t) {
+        const uint32_t i = start_tile + t;
         for (uint32_t e = 0; e < num_experts; ++e) {
             const uint32_t page = e * num_output_tiles + i;
             cb_act.reserve_back(1);

--- a/models/demos/gpt_oss/kernels/qkv_headsplit_op.py
+++ b/models/demos/gpt_oss/kernels/qkv_headsplit_op.py
@@ -1,0 +1,92 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Multi-core gpt-oss decode QKV head split producing the STOCK packed layout.
+
+See qkv_headsplit_reader.cpp for the layout and work-decomposition reasoning.
+Work unit = one output tile-row, so max parallelism is
+    ceil(num_q_heads/32) + ceil(num_kv/32) * 2   (= 4 for gpt-oss 64/8/8)
+NOT one-per-head: heads 0..31 share a destination tile.
+
+The ProgramDescriptor is cached keyed on buffer addresses. Rebuilding
+ttnn.RuntimeArgs per call cost 19-97 us and previously masked all device time.
+"""
+import ttnn
+
+_KDIR = "models/demos/gpt_oss/kernels"
+_TILE = 32
+_CACHE = {}
+_PROG = {}
+
+
+def _units(num_q_heads, num_kv_heads):
+    qr = (num_q_heads + _TILE - 1) // _TILE
+    kr = (num_kv_heads + _TILE - 1) // _TILE
+    return qr + 2 * kr
+
+
+def qkv_headsplit(xqkv, q, k, v, num_heads, num_kv_heads, head_dim, ncores=None):
+    head_tiles = head_dim // _TILE
+    elem = 2  # bfloat16
+    subtile_line = 16 * elem
+    n_units = _units(num_heads, num_kv_heads)
+    NC = min(ncores or n_units, n_units)
+
+    key = (id(xqkv.device()), num_heads, num_kv_heads, head_dim, NC)
+    if key not in _CACHE:
+        gx = min(8, NC)
+        gy = (NC + gx - 1) // gx
+        cl = [(x, y) for y in range(gy) for x in range(gx)][:NC]
+        core = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(x, y), ttnn.CoreCoord(x, y)) for (x, y) in cl])
+        cb_q, cb_k, cb_v = 0, 1, 2
+        rct = [cb_q, cb_k, cb_v, num_heads, num_kv_heads, head_tiles, subtile_line, elem]
+        rct += ttnn.TensorAccessorArgs(xqkv).get_compile_time_args()
+        wct = [cb_q, cb_k, cb_v, num_heads, num_kv_heads, head_tiles]
+        for t in (q, k, v):
+            wct += ttnn.TensorAccessorArgs(t).get_compile_time_args()
+        # spread units round-robin over cores
+        per = [[] for _ in range(NC)]
+        for u in range(n_units):
+            per[u % NC].append(u)
+        _CACHE[key] = (core, cl, per, cb_q, cb_k, cb_v, rct, wct, head_tiles)
+
+    core, cl, per, cb_q, cb_k, cb_v, rct, wct, ht = _CACHE[key]
+
+    addrs = (xqkv.buffer_address(), q.buffer_address(), k.buffer_address(), v.buffer_address())
+    pk = (key, addrs)
+    if pk in _PROG:
+        return ttnn.generic_op([xqkv, q, k, v], _PROG[pk])
+
+    tile_bytes = _TILE * _TILE * 2
+
+    def cb(i):
+        fmt = ttnn.CBFormatDescriptor(buffer_index=i, data_format=ttnn.bfloat16, page_size=tile_bytes)
+        return ttnn.CBDescriptor(total_size=2 * ht * tile_bytes, core_ranges=core, format_descriptors=[fmt])
+
+    cbs = [cb(cb_q), cb(cb_k), cb(cb_v)]
+
+    rr = ttnn.RuntimeArgs()
+    wr = ttnn.RuntimeArgs()
+    for ci, (x, y) in enumerate(cl):
+        us = per[ci]
+        st = us[0] if us else 0
+        rr[x][y] = [xqkv.buffer_address(), st, len(us)]
+        wr[x][y] = [q.buffer_address(), k.buffer_address(), v.buffer_address(), st, len(us)]
+
+    reader = ttnn.KernelDescriptor(
+        kernel_source=f"{_KDIR}/qkv_headsplit_reader.cpp",
+        source_type=ttnn.KernelDescriptor.SourceType.FILE_PATH,
+        core_ranges=core,
+        compile_time_args=rct,
+        runtime_args=rr,
+        config=ttnn.ReaderConfigDescriptor(),
+    )
+    writer = ttnn.KernelDescriptor(
+        kernel_source=f"{_KDIR}/qkv_headsplit_writer.cpp",
+        source_type=ttnn.KernelDescriptor.SourceType.FILE_PATH,
+        core_ranges=core,
+        compile_time_args=wct,
+        runtime_args=wr,
+        config=ttnn.WriterConfigDescriptor(),
+    )
+    prog = ttnn.ProgramDescriptor(kernels=[reader, writer], semaphores=[], cbs=cbs)
+    _PROG[pk] = prog
+    return ttnn.generic_op([xqkv, q, k, v], prog)

--- a/models/demos/gpt_oss/kernels/qkv_headsplit_reader.cpp
+++ b/models/demos/gpt_oss/kernels/qkv_headsplit_reader.cpp
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// gpt-oss decode QKV head split, multi-core, producing the SAME packed layout as
+// ttnn.experimental.nlp_create_qkv_heads_decode.
+//
+// WHY: the stock op runs on 1 core of 130 (it shards its output by LOGICAL batch,
+// and decode is batch=1) at 23.28 us/op x 24 layers = 0.558 ms/tok. It is not
+// bandwidth bound: an earlier tile-granular kernel of mine moved 32x the data in
+// 1/3 the time, so the cost is overhead. Spreading the work over several cores
+// should therefore win.
+//
+// LAYOUT (what a first attempt got wrong):
+//   input  xqkv : [1, 1, 32(pad), 5120] TILE; only batch row 0 holds real data
+//   output q    : [1, 1, 64, 64]           = one ROW per head
+//           k,v : [1, 1, 8, 64]
+// Head h is a single head_dim-wide ROW inside a tile, not a whole tile. Placing it
+// needs face-row (sub-tile) addressing, taken from the stock reader: a 32x32 bf16
+// tile is four 16x16 faces, so row r of a tile sits at
+//     r <  16 : r * SUBTILE_LINE_BYTES
+//     r >= 16 : (r-16) * SUBTILE_LINE_BYTES + HALF_TILE_ELEMENTS * ELEMENT_SIZE
+// and each 16-column face segment is one phase, so head_dim 64 = head_tiles
+// tiles x 2 phases.
+//
+// WORK DECOMPOSITION (the second thing to get right): heads 0..31 of q all live in
+// output tile-row 0, so they SHARE tiles. A work unit therefore cannot be one head
+// (two cores would write the same tile through separate CB pages). The work unit
+// is one OUTPUT TILE-ROW per tensor:
+//     q tile-row 0 (heads 0..31), q tile-row 1 (heads 32..63), k tile-row 0, v tile-row 0
+// = 4 work units, each gathering up to 32 head rows into head_tiles tiles.
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+#include "api/core_local_mem.h"
+
+constexpr uint32_t cb_q_id = get_compile_time_arg_val(0);
+constexpr uint32_t cb_k_id = get_compile_time_arg_val(1);
+constexpr uint32_t cb_v_id = get_compile_time_arg_val(2);
+constexpr uint32_t num_q_heads = get_compile_time_arg_val(3);
+constexpr uint32_t num_kv_heads = get_compile_time_arg_val(4);
+constexpr uint32_t head_tiles = get_compile_time_arg_val(5);          // head_dim / 32
+constexpr uint32_t SUBTILE_LINE_BYTES = get_compile_time_arg_val(6);  // 16 elems * elem size
+constexpr uint32_t ELEMENT_SIZE = get_compile_time_arg_val(7);
+constexpr uint32_t ct_in = 8;
+
+constexpr uint32_t TILE_HEIGHT = 32;
+constexpr uint32_t FACE_HEIGHT = 16;
+constexpr uint32_t HALF_TILE_ELEMENTS = 512;                            // 32*32/2
+constexpr uint32_t PHASE_OFFSET_BYTES = 256 * ELEMENT_SIZE;             // one face
+
+void kernel_main() {
+    const uint32_t in_addr = get_arg_val<uint32_t>(0);
+    const uint32_t unit_start = get_arg_val<uint32_t>(1);
+    const uint32_t unit_count = get_arg_val<uint32_t>(2);
+
+    constexpr auto in_args = TensorAccessorArgs<ct_in>();
+    const auto in = TensorAccessor(in_args, in_addr);
+
+    Noc noc;
+
+    // Work-unit table, built at compile time from the head counts.
+    //   unit 0..(q_tile_rows-1) -> q
+    //   next                    -> k
+    //   next                    -> v
+    constexpr uint32_t q_tile_rows = (num_q_heads + TILE_HEIGHT - 1) / TILE_HEIGHT;
+    constexpr uint32_t k_tile_rows = (num_kv_heads + TILE_HEIGHT - 1) / TILE_HEIGHT;
+
+    for (uint32_t u = 0; u < unit_count; ++u) {
+        const uint32_t unit = unit_start + u;
+
+        uint32_t cb_id;
+        uint32_t tile_row;        // which tile-row of the destination
+        uint32_t src_head_base;   // first input head for this unit
+        uint32_t n_rows;          // how many real head rows this unit covers
+
+        if (unit < q_tile_rows) {
+            cb_id = cb_q_id;
+            tile_row = unit;
+            src_head_base = unit * TILE_HEIGHT;
+            const uint32_t left = num_q_heads - src_head_base;
+            n_rows = left < TILE_HEIGHT ? left : TILE_HEIGHT;
+        } else if (unit < q_tile_rows + k_tile_rows) {
+            cb_id = cb_k_id;
+            tile_row = unit - q_tile_rows;
+            src_head_base = num_q_heads + tile_row * TILE_HEIGHT;
+            const uint32_t done = tile_row * TILE_HEIGHT;
+            const uint32_t left = num_kv_heads - done;
+            n_rows = left < TILE_HEIGHT ? left : TILE_HEIGHT;
+        } else {
+            cb_id = cb_v_id;
+            tile_row = unit - q_tile_rows - k_tile_rows;
+            src_head_base = num_q_heads + num_kv_heads + tile_row * TILE_HEIGHT;
+            const uint32_t done = tile_row * TILE_HEIGHT;
+            const uint32_t left = num_kv_heads - done;
+            n_rows = left < TILE_HEIGHT ? left : TILE_HEIGHT;
+        }
+
+        CircularBuffer cb(cb_id);
+        cb.reserve_back(head_tiles);
+        const uint32_t wptr = cb.get_write_ptr();
+
+        for (uint32_t r = 0; r < n_rows; ++r) {
+            const uint32_t head = src_head_base + r;
+            const uint32_t src_tile = head * head_tiles;
+
+            // Destination row r within this tile-row.
+            const uint32_t offset_in_tile =
+                r < FACE_HEIGHT
+                    ? r * SUBTILE_LINE_BYTES
+                    : (r - FACE_HEIGHT) * SUBTILE_LINE_BYTES + HALF_TILE_ELEMENTS * ELEMENT_SIZE;
+
+            for (uint32_t phase = 0; phase < 2; ++phase) {
+                const uint32_t phase_off = phase * PHASE_OFFSET_BYTES;
+                uint32_t waddr = wptr + offset_in_tile + phase_off;
+                for (uint32_t t = 0; t < head_tiles; ++t) {
+                    noc.async_read(
+                        in,
+                        CoreLocalMem<uint32_t>(waddr),
+                        SUBTILE_LINE_BYTES,
+                        {.page_id = src_tile + t, .offset_bytes = phase_off},
+                        {});
+                    // next destination tile, same row: one whole tile onward
+                    waddr += TILE_HEIGHT * TILE_HEIGHT * ELEMENT_SIZE;
+                }
+            }
+        }
+        // One barrier per work unit (batched-barrier), not one per row.
+        noc.async_read_barrier();
+        cb.push_back(head_tiles);
+    }
+}

--- a/models/demos/gpt_oss/kernels/qkv_headsplit_writer.cpp
+++ b/models/demos/gpt_oss/kernels/qkv_headsplit_writer.cpp
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Writer half of the multi-core gpt-oss decode QKV head split. See
+// qkv_headsplit_reader.cpp for layout and work decomposition.
+//
+// The reader has already packed a full destination tile-row (up to 32 head rows,
+// head_tiles tiles wide) into the matching CB. This writer just ships those whole
+// tiles to the right pages of q / k / v, one batched barrier per work unit.
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+
+constexpr uint32_t cb_q_id = get_compile_time_arg_val(0);
+constexpr uint32_t cb_k_id = get_compile_time_arg_val(1);
+constexpr uint32_t cb_v_id = get_compile_time_arg_val(2);
+constexpr uint32_t num_q_heads = get_compile_time_arg_val(3);
+constexpr uint32_t num_kv_heads = get_compile_time_arg_val(4);
+constexpr uint32_t head_tiles = get_compile_time_arg_val(5);
+constexpr uint32_t ct_q = 6;
+constexpr uint32_t ct_k = TensorAccessorArgs<ct_q>::next_compile_time_args_offset();
+constexpr uint32_t ct_v = TensorAccessorArgs<ct_k>::next_compile_time_args_offset();
+
+constexpr uint32_t TILE_HEIGHT = 32;
+
+void kernel_main() {
+    const uint32_t q_addr = get_arg_val<uint32_t>(0);
+    const uint32_t k_addr = get_arg_val<uint32_t>(1);
+    const uint32_t v_addr = get_arg_val<uint32_t>(2);
+    const uint32_t unit_start = get_arg_val<uint32_t>(3);
+    const uint32_t unit_count = get_arg_val<uint32_t>(4);
+
+    constexpr auto q_args = TensorAccessorArgs<ct_q>();
+    constexpr auto k_args = TensorAccessorArgs<ct_k>();
+    constexpr auto v_args = TensorAccessorArgs<ct_v>();
+    const auto qt = TensorAccessor(q_args, q_addr);
+    const auto kt = TensorAccessor(k_args, k_addr);
+    const auto vt = TensorAccessor(v_args, v_addr);
+
+    Noc noc;
+
+    constexpr uint32_t q_tile_rows = (num_q_heads + TILE_HEIGHT - 1) / TILE_HEIGHT;
+    constexpr uint32_t k_tile_rows = (num_kv_heads + TILE_HEIGHT - 1) / TILE_HEIGHT;
+
+    for (uint32_t u = 0; u < unit_count; ++u) {
+        const uint32_t unit = unit_start + u;
+
+        uint32_t cb_id;
+        uint32_t tile_row;
+        uint32_t which;  // 0=q 1=k 2=v
+        if (unit < q_tile_rows) {
+            cb_id = cb_q_id;
+            tile_row = unit;
+            which = 0;
+        } else if (unit < q_tile_rows + k_tile_rows) {
+            cb_id = cb_k_id;
+            tile_row = unit - q_tile_rows;
+            which = 1;
+        } else {
+            cb_id = cb_v_id;
+            tile_row = unit - q_tile_rows - k_tile_rows;
+            which = 2;
+        }
+
+        CircularBuffer cb(cb_id);
+        const uint32_t page_bytes = get_local_cb_interface(cb_id).fifo_page_size;
+
+        cb.wait_front(head_tiles);
+        const uint32_t base_page = tile_row * head_tiles;
+        for (uint32_t t = 0; t < head_tiles; ++t) {
+            const uint32_t off = t * page_bytes;
+            if (which == 0) {
+                noc.async_write(cb, qt, page_bytes, {.offset_bytes = off}, {.page_id = base_page + t});
+            } else if (which == 1) {
+                noc.async_write(cb, kt, page_bytes, {.offset_bytes = off}, {.page_id = base_page + t});
+            } else {
+                noc.async_write(cb, vt, page_bytes, {.offset_bytes = off}, {.page_id = base_page + t});
+            }
+        }
+        noc.async_write_barrier();
+        cb.pop_front(head_tiles);
+    }
+}

--- a/models/demos/gpt_oss/kernels/router_fused_op.py
+++ b/models/demos/gpt_oss/kernels/router_fused_op.py
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Fused MoE router (top-k + softmax + scatter) in one generic_op launch.
+
+Replaces the 16-launch, 58.8 us/layer post-matmul router path with a single
+kernel. See router_fused_reader.cpp for the full rationale and the op list it
+subsumes.
+
+Contract (identical to the path it replaces):
+    in:  router_logits    [1,1,32,E] bf16 TILE   (only row 0 is real)
+    out: routing_weights  [1,1,1,E]  bf16 TILE   dense, 0 outside the top-k
+         expert_ids       [1,1,1,k]  uint32 ROW_MAJOR
+"""
+import ttnn
+
+_KDIR = "models/demos/gpt_oss/kernels"
+_TILE_BYTES = 2 * 1024
+_CACHE = {}
+_PROG = {}
+
+
+def fused_router(logits, weights_out, ids_out, num_experts, top_k):
+    key = (id(logits.device()), num_experts, top_k)
+    if key not in _CACHE:
+        core = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))])
+        cb_in, cb_w, cb_id = 0, 1, 2
+        ct = [cb_in, cb_w, cb_id, num_experts, top_k]
+        ct += ttnn.TensorAccessorArgs(logits).get_compile_time_args()
+        ct += ttnn.TensorAccessorArgs(weights_out).get_compile_time_args()
+        ct += ttnn.TensorAccessorArgs(ids_out).get_compile_time_args()
+        _CACHE[key] = (core, cb_in, cb_w, cb_id, ct)
+
+    core, cb_in, cb_w, cb_id, ct = _CACHE[key]
+
+    addrs = (logits.buffer_address(), weights_out.buffer_address(), ids_out.buffer_address())
+    pk = (key, addrs)
+    if pk in _PROG:
+        return ttnn.generic_op([logits, weights_out, ids_out], _PROG[pk])
+
+    # ids are uint16 TILE, so one full tile page
+    id_bytes = _TILE_BYTES
+
+    def cb(i, page):
+        fmt = ttnn.CBFormatDescriptor(buffer_index=i, data_format=ttnn.bfloat16, page_size=page)
+        return ttnn.CBDescriptor(total_size=page, core_ranges=core, format_descriptors=[fmt])
+
+    cbs = [cb(cb_in, _TILE_BYTES), cb(cb_w, _TILE_BYTES), cb(cb_id, id_bytes)]
+
+    rt = ttnn.RuntimeArgs()
+    rt[0][0] = [logits.buffer_address()]
+
+    rt_w = ttnn.RuntimeArgs()
+    rt_w[0][0] = [weights_out.buffer_address(), ids_out.buffer_address()]
+
+    reader = ttnn.KernelDescriptor(
+        kernel_source=f"{_KDIR}/router_split_reader.cpp",
+        source_type=ttnn.KernelDescriptor.SourceType.FILE_PATH,
+        core_ranges=core,
+        compile_time_args=ct,
+        runtime_args=rt,
+        config=ttnn.ReaderConfigDescriptor(),
+    )
+    writer = ttnn.KernelDescriptor(
+        kernel_source=f"{_KDIR}/router_split_writer.cpp",
+        source_type=ttnn.KernelDescriptor.SourceType.FILE_PATH,
+        core_ranges=core,
+        compile_time_args=ct,
+        runtime_args=rt_w,
+        config=ttnn.WriterConfigDescriptor(),
+    )
+    prog = ttnn.ProgramDescriptor(kernels=[reader, writer], semaphores=[], cbs=cbs)
+    _PROG[pk] = prog
+    return ttnn.generic_op([logits, weights_out, ids_out], prog)

--- a/models/demos/gpt_oss/kernels/router_split_reader.cpp
+++ b/models/demos/gpt_oss/kernels/router_split_reader.cpp
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Fused MoE router, READER half: load the logits tile into cb_in.
+//
+// Split from the writer because a single ReaderConfigDescriptor kernel doing both
+// NoC reads AND writes hung the device. The working megakernel in this repo
+// (swiglu_*) uses separate reader/writer kernels, so this mirrors that.
+//
+// WHY: in gpt-oss decode the post-matmul router path is 16 kernel launches taking
+// 58.8 us per layer = 1.412 ms/tok (9.4% of decode), to do roughly 100 arithmetic
+// operations on a SINGLE [1,32] logits row:
+//     Typecast, FillPad, Pad, FillPad, TopK, Slice, Slice, Softmax, Unary,
+//     Untilize x3, Scatter, Tilize, Untilize, Fill
+// Every one of those is launch-dominated (most run on 1 core and move <1 KB).
+// Five separate attempts to remove individual ops all regressed, because each
+// removal added back an equivalent launch. The only thing that has ever worked on
+// this model is genuine fusion (the SwiGLU megakernel, +1.7 tok/s).
+//
+// This kernel does the whole thing on ONE core with plain scalar C++:
+//   1. read the 32 logits
+//   2. selection-sort the top-k (k=4 of 32 -- trivially cheap serially)
+//   3. softmax over just those k values
+//   4. write a dense [1,E] row with the k weights in their expert slots, 0 elsewhere
+//   5. write the k expert ids as uint32
+//
+// Outputs match the existing contract exactly:
+//   routing_weights [1,1,1,E] bf16 TILE  (dense, zeros outside the top-k)
+//   expert_ids      [1,1,1,k] uint32 ROW_MAJOR
+// so sparse_matmul and the fused SwiGLU consume them unchanged.
+//
+// Single core is correct here, not a limitation: the whole job is ~100 scalar ops
+// on 32 values. Splitting it would cost more in launch than it saves.
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+#include "api/core_local_mem.h"
+
+constexpr uint32_t cb_in_id = get_compile_time_arg_val(0);
+constexpr uint32_t cb_w_id = get_compile_time_arg_val(1);
+constexpr uint32_t cb_id_id = get_compile_time_arg_val(2);
+constexpr uint32_t num_experts = get_compile_time_arg_val(3);
+constexpr uint32_t top_k = get_compile_time_arg_val(4);
+constexpr uint32_t ct_in = 5;
+constexpr uint32_t ct_w = TensorAccessorArgs<ct_in>::next_compile_time_args_offset();
+constexpr uint32_t ct_id = TensorAccessorArgs<ct_w>::next_compile_time_args_offset();
+
+// bf16 helpers: the logits arrive as bfloat16, which is just the high 16 bits of
+// an IEEE float32, so conversion is a shift in both directions.
+inline float bf16_to_f32(uint16_t h) {
+    union {
+        uint32_t u;
+        float f;
+    } v;
+    v.u = ((uint32_t)h) << 16;
+    return v.f;
+}
+
+inline uint16_t f32_to_bf16(float f) {
+    union {
+        float f;
+        uint32_t u;
+    } v;
+    v.f = f;
+    // round-to-nearest-even on the truncated mantissa
+    uint32_t r = v.u + 0x7FFF + ((v.u >> 16) & 1);
+    return (uint16_t)(r >> 16);
+}
+
+// exp(x) via 2^(x*log2e), using the exponent-field trick plus a cubic correction.
+// Accuracy is ~1e-4 relative, far tighter than the bf16 output can represent.
+inline float fast_exp(float x) {
+    if (x < -60.0f) {
+        return 0.0f;
+    }
+    float y = x * 1.44269504088896f;  // log2(e)
+    float fl = (float)(int)(y < 0 ? y - 1.0f : y);
+    float fr = y - fl;
+    // 2^fr on [0,1) -- minimax cubic
+    float p = 1.0f + fr * (0.6931472f + fr * (0.2402265f + fr * 0.0555041f));
+    union {
+        uint32_t u;
+        float f;
+    } v;
+    int e = (int)fl + 127;
+    if (e < 0) {
+        return 0.0f;
+    }
+    if (e > 254) {
+        e = 254;
+    }
+    v.u = ((uint32_t)e) << 23;
+    return p * v.f;
+}
+
+void kernel_main() {
+    const uint32_t in_addr = get_arg_val<uint32_t>(0);
+    constexpr auto in_args = TensorAccessorArgs<ct_in>();
+    const auto in_t = TensorAccessor(in_args, in_addr);
+
+    Noc noc;
+    CircularBuffer cb_in(cb_in_id);
+    const uint32_t in_page = get_local_cb_interface(cb_in_id).fifo_page_size;
+
+    cb_in.reserve_back(1);
+    noc.async_read(in_t, cb_in, in_page, {.page_id = 0}, {.offset_bytes = 0});
+    noc.async_read_barrier();
+    cb_in.push_back(1);
+}

--- a/models/demos/gpt_oss/kernels/router_split_writer.cpp
+++ b/models/demos/gpt_oss/kernels/router_split_writer.cpp
@@ -1,0 +1,201 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Fused MoE router, WRITER half: top-k + softmax + scatter, then ship both outputs.
+//
+// The reader has already placed the logits tile in cb_in. This kernel does all the
+// arithmetic (selection top-k, softmax over k, dense scatter) and writes the two
+// output tensors. Split from the reader because one ReaderConfigDescriptor kernel
+// doing both NoC reads and writes hung the device; swiglu_* splits the same way.
+//
+// WHY: in gpt-oss decode the post-matmul router path is 16 kernel launches taking
+// 58.8 us per layer = 1.412 ms/tok (9.4% of decode), to do roughly 100 arithmetic
+// operations on a SINGLE [1,32] logits row:
+//     Typecast, FillPad, Pad, FillPad, TopK, Slice, Slice, Softmax, Unary,
+//     Untilize x3, Scatter, Tilize, Untilize, Fill
+// Every one of those is launch-dominated (most run on 1 core and move <1 KB).
+// Five separate attempts to remove individual ops all regressed, because each
+// removal added back an equivalent launch. The only thing that has ever worked on
+// this model is genuine fusion (the SwiGLU megakernel, +1.7 tok/s).
+//
+// This kernel does the whole thing on ONE core with plain scalar C++:
+//   1. read the 32 logits
+//   2. selection-sort the top-k (k=4 of 32 -- trivially cheap serially)
+//   3. softmax over just those k values
+//   4. write a dense [1,E] row with the k weights in their expert slots, 0 elsewhere
+//   5. write the k expert ids as uint32
+//
+// Outputs match the existing contract exactly:
+//   routing_weights [1,1,1,E] bf16 TILE  (dense, zeros outside the top-k)
+//   expert_ids      [1,1,1,k] uint32 ROW_MAJOR
+// so sparse_matmul and the fused SwiGLU consume them unchanged.
+//
+// Single core is correct here, not a limitation: the whole job is ~100 scalar ops
+// on 32 values. Splitting it would cost more in launch than it saves.
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+#include "api/core_local_mem.h"
+
+constexpr uint32_t cb_in_id = get_compile_time_arg_val(0);
+constexpr uint32_t cb_w_id = get_compile_time_arg_val(1);
+constexpr uint32_t cb_id_id = get_compile_time_arg_val(2);
+constexpr uint32_t num_experts = get_compile_time_arg_val(3);
+constexpr uint32_t top_k = get_compile_time_arg_val(4);
+constexpr uint32_t ct_in = 5;
+constexpr uint32_t ct_w = TensorAccessorArgs<ct_in>::next_compile_time_args_offset();
+constexpr uint32_t ct_id = TensorAccessorArgs<ct_w>::next_compile_time_args_offset();
+
+// bf16 helpers: the logits arrive as bfloat16, which is just the high 16 bits of
+// an IEEE float32, so conversion is a shift in both directions.
+inline float bf16_to_f32(uint16_t h) {
+    union {
+        uint32_t u;
+        float f;
+    } v;
+    v.u = ((uint32_t)h) << 16;
+    return v.f;
+}
+
+inline uint16_t f32_to_bf16(float f) {
+    union {
+        float f;
+        uint32_t u;
+    } v;
+    v.f = f;
+    // round-to-nearest-even on the truncated mantissa
+    uint32_t r = v.u + 0x7FFF + ((v.u >> 16) & 1);
+    return (uint16_t)(r >> 16);
+}
+
+// exp(x) via 2^(x*log2e), using the exponent-field trick plus a cubic correction.
+// Accuracy is ~1e-4 relative, far tighter than the bf16 output can represent.
+inline float fast_exp(float x) {
+    if (x < -60.0f) {
+        return 0.0f;
+    }
+    float y = x * 1.44269504088896f;  // log2(e)
+    float fl = (float)(int)(y < 0 ? y - 1.0f : y);
+    float fr = y - fl;
+    // 2^fr on [0,1) -- minimax cubic
+    float p = 1.0f + fr * (0.6931472f + fr * (0.2402265f + fr * 0.0555041f));
+    union {
+        uint32_t u;
+        float f;
+    } v;
+    int e = (int)fl + 127;
+    if (e < 0) {
+        return 0.0f;
+    }
+    if (e > 254) {
+        e = 254;
+    }
+    v.u = ((uint32_t)e) << 23;
+    return p * v.f;
+}
+
+void kernel_main() {
+    const uint32_t w_addr = get_arg_val<uint32_t>(0);
+    const uint32_t id_addr = get_arg_val<uint32_t>(1);
+
+    constexpr auto w_args = TensorAccessorArgs<ct_w>();
+    constexpr auto id_args = TensorAccessorArgs<ct_id>();
+    const auto w_t = TensorAccessor(w_args, w_addr);
+    const auto id_t = TensorAccessor(id_args, id_addr);
+
+    Noc noc;
+    CircularBuffer cb_in(cb_in_id), cb_w(cb_w_id), cb_id(cb_id_id);
+    const uint32_t w_page = get_local_cb_interface(cb_w_id).fifo_page_size;
+    const uint32_t id_page = get_local_cb_interface(cb_id_id).fifo_page_size;
+    const uint32_t id_page_elems = id_page / 2;
+
+    cb_in.wait_front(1);
+    volatile tt_l1_ptr uint16_t* logits =
+        (volatile tt_l1_ptr uint16_t*)get_local_cb_interface(cb_in_id).fifo_rd_ptr;
+
+    // ---- top-k by selection ----
+    // In TILE layout, row 0 element j is at (j/16)*256 + (j%16). Only row 0 is real
+    // for decode (batch 1, tile-padded to 32).
+    float best_val[16];
+    uint32_t best_idx[16];
+    bool taken[64];
+    for (uint32_t i = 0; i < num_experts; ++i) {
+        taken[i] = false;
+    }
+    for (uint32_t s = 0; s < top_k; ++s) {
+        float bv = -3.0e38f;
+        uint32_t bi = 0;
+        for (uint32_t j = 0; j < num_experts; ++j) {
+            if (taken[j]) {
+                continue;
+            }
+            const float v = bf16_to_f32(logits[(j >> 4) * 256 + (j & 15)]);
+            if (v > bv) {
+                bv = v;
+                bi = j;
+            }
+        }
+        // Safety clamp. If the input dtype/layout is not what this kernel expects
+        // (e.g. BFLOAT8_B block-float read as bf16), bv/bi can be garbage. An
+        // out-of-range bi would index outside the output CB and corrupt L1, which
+        // wedges the NoC and hangs the device. Clamping keeps a wrong result wrong
+        // but contained, so it fails as bad numbers instead of a hang.
+        if (bi >= num_experts) {
+            bi = 0;
+        }
+        taken[bi] = true;
+        best_val[s] = bv;
+        best_idx[s] = bi;
+    }
+
+    // ---- softmax over the k selected logits ----
+    float mx = best_val[0];
+    for (uint32_t s = 1; s < top_k; ++s) {
+        if (best_val[s] > mx) {
+            mx = best_val[s];
+        }
+    }
+    float sum = 0.0f;
+    for (uint32_t s = 0; s < top_k; ++s) {
+        best_val[s] = fast_exp(best_val[s] - mx);
+        sum += best_val[s];
+    }
+    const float inv = (sum > 0.0f) ? (1.0f / sum) : 0.0f;
+
+    // ---- dense weights row ----
+    cb_w.reserve_back(1);
+    volatile tt_l1_ptr uint16_t* wout =
+        (volatile tt_l1_ptr uint16_t*)get_local_cb_interface(cb_w_id).fifo_wr_ptr;
+    for (uint32_t i = 0; i < w_page / 2; ++i) {
+        wout[i] = 0;
+    }
+    for (uint32_t s = 0; s < top_k; ++s) {
+        const uint32_t j = best_idx[s];
+        wout[(j >> 4) * 256 + (j & 15)] = f32_to_bf16(best_val[s] * inv);
+    }
+    cb_w.push_back(1);
+
+    // ---- expert ids, uint16 TILE (matches the stock op's output) ----
+    cb_id.reserve_back(1);
+    volatile tt_l1_ptr uint16_t* idout =
+        (volatile tt_l1_ptr uint16_t*)get_local_cb_interface(cb_id_id).fifo_wr_ptr;
+    for (uint32_t i = 0; i < id_page_elems; ++i) {
+        idout[i] = 0;
+    }
+    for (uint32_t s = 0; s < top_k; ++s) {
+        idout[(s >> 4) * 256 + (s & 15)] = (uint16_t)best_idx[s];
+    }
+    cb_id.push_back(1);
+
+    // ---- ship both outputs ----
+    cb_w.wait_front(1);
+    noc.async_write(cb_w, w_t, w_page, {.offset_bytes = 0}, {.page_id = 0});
+    cb_id.wait_front(1);
+    noc.async_write(cb_id, id_t, id_page, {.offset_bytes = 0}, {.page_id = 0});
+    noc.async_write_barrier();
+    cb_w.pop_front(1);
+    cb_id.pop_front(1);
+    cb_in.pop_front(1);
+}

--- a/models/demos/gpt_oss/kernels/swiglu_compute.cpp
+++ b/models/demos/gpt_oss/kernels/swiglu_compute.cpp
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// gpt-oss custom fused SwiGLU compute kernel (decode).
+//
+// Computes, per tile, the gpt-oss SwiGLU inner math AFTER the gate/up biases
+// have been folded/added:
+//     out = silu(clamp(gate, max=cap)) * up
+// where `gate` is already alpha-scaled at build time (#66 alpha-fold), so
+// silu(gate) == alpha*gate_raw*sigmoid(alpha*gate_raw), and `up` already
+// includes the (+1) folded into up_proj_bias. Fuses the SwiGLU op chain
+//   clamp(gate) -> silu(gate) -> mul(up, glu)
+// (3 unary/binary launches) into ONE generic_op compute kernel.
+//
+// CBs: cb_gate (in0), cb_up (in1), cb_out (out). Streams n_tiles tiles per core.
+
+#include <cstdint>
+#include "api/compute/eltwise_binary.h"
+#include "api/compute/tile_move_copy.h"
+#include "api/compute/eltwise_unary/eltwise_unary.h"
+#include "api/compute/eltwise_unary/activations.h"
+#include "api/compute/eltwise_unary/clamp.h"
+#include "api/compute/eltwise_unary/binop_with_scalar.h"
+#include "api/compute/eltwise_binary_sfpu.h"
+#include "api/compute/compute_kernel_api.h"
+#include "api/dataflow/circular_buffer.h"
+
+using namespace ckernel;
+
+constexpr uint32_t n_tiles = get_compile_time_arg_val(0);  // tiles this core processes
+constexpr uint32_t cb_gate = get_compile_time_arg_val(1);
+constexpr uint32_t cb_up = get_compile_time_arg_val(2);
+constexpr uint32_t cb_out = get_compile_time_arg_val(3);
+constexpr uint32_t clamp_max_u = get_compile_time_arg_val(4);  // FP32 bits of gate cap (alpha*swiglu_limit)
+constexpr uint32_t up_min_u = get_compile_time_arg_val(5);     // FP32 bits of -swiglu_limit
+constexpr uint32_t up_max_u = get_compile_time_arg_val(6);     // FP32 bits of +swiglu_limit
+constexpr uint32_t one_u = 0x3F800000u;                        // FP32 bits of 1.0f
+
+// clamp_tile takes std::bit_cast<uint32_t>(float) params (matches ttnn). Gate min
+// bound = -1e30f so it only caps the max side. FP32 bits of -1e30 == 0xF149F2CA.
+constexpr uint32_t clamp_min_u = 0xF149F2CAu;
+
+void kernel_main() {
+    CircularBuffer cbg(cb_gate);
+    CircularBuffer cbu(cb_up);
+    CircularBuffer cbo(cb_out);
+
+    unary_op_init_common(cb_gate, cb_out);
+
+    for (uint32_t t = 0; t < n_tiles; ++t) {
+        cbo.reserve_back(1);
+        cbg.wait_front(1);
+        cbu.wait_front(1);
+
+        tile_regs_acquire();
+
+        // Re-init each SFPU op immediately before use (matches ttnn logit_kernel):
+        // clamp and silu both program SFPU state, so silu must re-init after clamp.
+        copy_tile_init(cb_gate);
+        copy_tile(cb_gate, 0, 0);  // dst0 = gate (alpha-scaled)
+        clamp_tile_init();
+        clamp_tile(0, clamp_min_u, clamp_max_u);  // dst0 = clamp(gate, max=cap)
+        silu_tile_init();
+        silu_tile(0);  // dst0 = silu(clamp(gate,max=cap))
+        copy_tile_init(cb_up);
+        copy_tile(cb_up, 0, 1);  // dst1 = up
+        clamp_tile_init();
+        clamp_tile(1, up_min_u, up_max_u);  // dst1 = clamp(up, -limit, +limit)
+        binop_with_scalar_tile_init();
+        add_unary_tile(1, one_u);  // dst1 = up + 1
+        mul_binary_tile_init();
+        mul_binary_tile(0, 1, 0);  // dst0 = silu(gate) * (up+1)
+
+        tile_regs_commit();
+        tile_regs_wait();
+        pack_tile(0, cb_out);
+        tile_regs_release();
+
+        cbg.pop_front(1);
+        cbu.pop_front(1);
+        cbo.push_back(1);
+    }
+}

--- a/models/demos/gpt_oss/kernels/swiglu_compute_bias.cpp
+++ b/models/demos/gpt_oss/kernels/swiglu_compute_bias.cpp
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Fused SwiGLU compute WITH bias-fold: adds per-expert gate/up bias inside the
+// kernel (only for the active experts streamed by the reader), removing the wide
+// [1,E,1,2I] bias-add op. Computes per tile:
+//     out = silu(clamp(gate + gbias, max=cap)) * (clamp(up + ubias, -lim, lim) + 1)
+// gate is alpha-scaled at build (#66); gate bias is alpha-scaled too (weights.py).
+
+#include <cstdint>
+#include "api/compute/eltwise_binary.h"
+#include "api/compute/tile_move_copy.h"
+#include "api/compute/eltwise_unary/eltwise_unary.h"
+#include "api/compute/eltwise_unary/activations.h"
+#include "api/compute/eltwise_unary/clamp.h"
+#include "api/compute/eltwise_unary/binop_with_scalar.h"
+#include "api/compute/eltwise_binary_sfpu.h"
+#include "api/compute/compute_kernel_api.h"
+#include "api/dataflow/circular_buffer.h"
+
+using namespace ckernel;
+
+constexpr uint32_t n_tiles = get_compile_time_arg_val(0);
+constexpr uint32_t cb_gate = get_compile_time_arg_val(1);
+constexpr uint32_t cb_up = get_compile_time_arg_val(2);
+constexpr uint32_t cb_out = get_compile_time_arg_val(3);
+constexpr uint32_t clamp_max_u = get_compile_time_arg_val(4);
+constexpr uint32_t up_min_u = get_compile_time_arg_val(5);
+constexpr uint32_t up_max_u = get_compile_time_arg_val(6);
+constexpr uint32_t cb_gbias = get_compile_time_arg_val(7);
+constexpr uint32_t cb_ubias = get_compile_time_arg_val(8);
+constexpr uint32_t one_u = 0x3F800000u;
+constexpr uint32_t clamp_min_u = 0xF149F2CAu;
+
+void kernel_main() {
+    CircularBuffer cbg(cb_gate);
+    CircularBuffer cbu(cb_up);
+    CircularBuffer cbo(cb_out);
+    CircularBuffer cbgb(cb_gbias);
+    CircularBuffer cbub(cb_ubias);
+
+    unary_op_init_common(cb_gate, cb_out);
+
+    for (uint32_t t = 0; t < n_tiles; ++t) {
+        cbo.reserve_back(1);
+        cbg.wait_front(1);
+        cbu.wait_front(1);
+        cbgb.wait_front(1);
+        cbub.wait_front(1);
+
+        tile_regs_acquire();
+
+        // dst0 = gate + gbias  (FPU binary add of two CBs)
+        add_tiles_init(cb_gate, cb_gbias);
+        add_tiles(cb_gate, cb_gbias, 0, 0, 0);
+        clamp_tile_init();
+        clamp_tile(0, clamp_min_u, clamp_max_u);  // dst0 = clamp(gate+gbias, max=cap)
+        silu_tile_init();
+        silu_tile(0);  // dst0 = silu(...)
+
+        // dst1 = up + ubias
+        add_tiles_init(cb_up, cb_ubias);
+        add_tiles(cb_up, cb_ubias, 0, 0, 1);
+        clamp_tile_init();
+        clamp_tile(1, up_min_u, up_max_u);  // dst1 = clamp(up+ubias, -lim, lim)
+        binop_with_scalar_tile_init();
+        add_unary_tile(1, one_u);  // dst1 = (up+ubias) + 1
+        mul_binary_tile_init();
+        mul_binary_tile(0, 1, 0);  // dst0 = silu(gate) * (up+1)
+
+        tile_regs_commit();
+        tile_regs_wait();
+        pack_tile(0, cb_out);
+        tile_regs_release();
+
+        cbg.pop_front(1);
+        cbu.pop_front(1);
+        cbgb.pop_front(1);
+        cbub.pop_front(1);
+        cbo.push_back(1);
+    }
+}

--- a/models/demos/gpt_oss/kernels/swiglu_final_op.py
+++ b/models/demos/gpt_oss/kernels/swiglu_final_op.py
@@ -1,0 +1,143 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Final fused-SwiGLU driver: transpose-eliminating + expert-skipping + trace-safe.
+
+Reads only the n_active experts (ids from device tensor `idx` [1,1,1,NACT] uint32)
+directly from the raw fused gate/up matmul output `raw` [1,E,1,2I] (bias pre-added),
+computes clamp+silu+clamp+1+mul, and SCATTERS the result to the active expert slots
+of `out` [1,E,1,I]. Replaces the whole reshape->transpose->slice->bias->swiglu chain
+AND skips the 28 inactive experts.
+"""
+import os
+import struct
+
+import ttnn
+
+_KDIR = "models/demos/gpt_oss/kernels"
+_TILE = 32
+_TILE_BYTES = 2 * 1024
+_CACHE = {}
+
+
+def _best_ncores(total, max_cores=64):
+    best = 1
+    for d in range(1, min(total, max_cores) + 1):
+        if total % d == 0:
+            best = d
+    return best
+
+
+def fused_swiglu_final(raw, bias, idx, out, nact, cap, limit, ncores=None):
+    """raw,bias: [1,E,1,2I]; idx: [1,1,1,nact] uint32; out: [1,E,1,I]. Reads gate/up
+    + gate/up bias for active experts, folds bias inside the kernel (no wide add)."""
+    E = raw.shape[-3]
+    twoI = raw.shape[-1]
+    I = twoI // 2
+    Ht = I // _TILE
+    Wt2 = twoI // _TILE
+    total_tiles = nact * Ht
+    key = (id(raw.device()), E, I, nact)
+    if key not in _CACHE:
+        # 45 cores was the in-model optimum for the 4-expert x 90-tile decode SwiGLU
+        # (swept 45/60: both ~57.5-57.8 tok/s, 45 marginally better + fewer cores).
+        NC = ncores or int(os.environ.get("SWIGLU_NCORES", "0")) or 45
+        while total_tiles % NC != 0:
+            NC -= 1
+        per_core = total_tiles // NC
+        gx = min(8, NC)
+        gy = (NC + gx - 1) // gx
+        core_list = [(x, y) for y in range(gy) for x in range(gx)][:NC]
+        core = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(x, y), ttnn.CoreCoord(x, y)) for (x, y) in core_list])
+        cb_gate, cb_up, cb_gb, cb_ub, cb_out, cb_idxr, cb_idxw = 0, 1, 2, 3, 16, 4, 5
+        cap_u = struct.unpack("<I", struct.pack("<f", cap))[0]
+        upmin_u = struct.unpack("<I", struct.pack("<f", -limit))[0]
+        upmax_u = struct.unpack("<I", struct.pack("<f", limit))[0]
+        reader_ct = [cb_gate, cb_up, cb_gb, cb_ub, cb_idxr, Ht, Wt2, nact]
+        reader_ct += ttnn.TensorAccessorArgs(raw).get_compile_time_args()
+        reader_ct += ttnn.TensorAccessorArgs(bias).get_compile_time_args()
+        reader_ct += ttnn.TensorAccessorArgs(idx).get_compile_time_args()
+        writer_ct = [cb_out, cb_idxw, Ht, nact]
+        writer_ct += ttnn.TensorAccessorArgs(out).get_compile_time_args()
+        writer_ct += ttnn.TensorAccessorArgs(idx).get_compile_time_args()
+        compute_ct = [per_core, cb_gate, cb_up, cb_out, cap_u, upmin_u, upmax_u, cb_gb, cb_ub]
+        idx_bytes = ((nact * 4 + _TILE_BYTES - 1) // _TILE_BYTES) * _TILE_BYTES or _TILE_BYTES
+        _CACHE[key] = (
+            core,
+            core_list,
+            per_core,
+            cb_gate,
+            cb_up,
+            cb_gb,
+            cb_ub,
+            cb_out,
+            cb_idxr,
+            cb_idxw,
+            reader_ct,
+            writer_ct,
+            compute_ct,
+            idx_bytes,
+        )
+
+    (
+        core,
+        core_list,
+        per_core,
+        cb_gate,
+        cb_up,
+        cb_gb,
+        cb_ub,
+        cb_out,
+        cb_idxr,
+        cb_idxw,
+        reader_ct,
+        writer_ct,
+        compute_ct,
+        idx_bytes,
+    ) = _CACHE[key]
+
+    def cb(idx_id, n, ps=_TILE_BYTES):
+        fmt = ttnn.CBFormatDescriptor(buffer_index=idx_id, data_format=ttnn.bfloat16, page_size=ps)
+        return ttnn.CBDescriptor(total_size=n * ps, core_ranges=core, format_descriptors=[fmt])
+
+    cbs = [
+        cb(cb_gate, 8),
+        cb(cb_up, 8),
+        cb(cb_gb, 8),
+        cb(cb_ub, 8),
+        cb(cb_out, 4),
+        cb(cb_idxr, 1, idx_bytes),
+        cb(cb_idxw, 1, idx_bytes),
+    ]
+
+    rr = ttnn.RuntimeArgs()
+    wr = ttnn.RuntimeArgs()
+    for c, (x, y) in enumerate(core_list):
+        st = c * per_core
+        rr[x][y] = [raw.buffer_address(), bias.buffer_address(), idx.buffer_address(), st, per_core]
+        wr[x][y] = [out.buffer_address(), idx.buffer_address(), st, per_core]
+
+    reader = ttnn.KernelDescriptor(
+        kernel_source=f"{_KDIR}/swiglu_reader_bias.cpp",
+        source_type=ttnn.KernelDescriptor.SourceType.FILE_PATH,
+        core_ranges=core,
+        compile_time_args=reader_ct,
+        runtime_args=rr,
+        config=ttnn.ReaderConfigDescriptor(),
+    )
+    writer = ttnn.KernelDescriptor(
+        kernel_source=f"{_KDIR}/swiglu_writer_final.cpp",
+        source_type=ttnn.KernelDescriptor.SourceType.FILE_PATH,
+        core_ranges=core,
+        compile_time_args=writer_ct,
+        runtime_args=wr,
+        config=ttnn.WriterConfigDescriptor(),
+    )
+    compute = ttnn.KernelDescriptor(
+        kernel_source=f"{_KDIR}/swiglu_compute_bias.cpp",
+        source_type=ttnn.KernelDescriptor.SourceType.FILE_PATH,
+        core_ranges=core,
+        compile_time_args=compute_ct,
+        runtime_args=[],
+        config=ttnn.ComputeConfigDescriptor(),
+    )
+    prog = ttnn.ProgramDescriptor(kernels=[reader, writer, compute], semaphores=[], cbs=cbs)
+    return ttnn.generic_op([raw, bias, idx, out], prog)

--- a/models/demos/gpt_oss/kernels/swiglu_final_op.py
+++ b/models/demos/gpt_oss/kernels/swiglu_final_op.py
@@ -39,7 +39,13 @@ def fused_swiglu_final(raw, bias, idx, out, nact, cap, limit, ncores=None):
     if key not in _CACHE:
         # 45 cores was the in-model optimum for the 4-expert x 90-tile decode SwiGLU
         # (swept 45/60: both ~57.5-57.8 tok/s, 45 marginally better + fewer cores).
-        NC = ncores or int(os.environ.get("SWIGLU_NCORES", "0")) or 45
+        # 72 cores (8x9). Re-tuned in-model after the expert matmuls moved to 45
+        # cores; the old default of 45 was chosen when gate+up ran on 30. Measured
+        # decode ms/tok: 45 -> 12.807, 60 -> 12.721, 72 -> 12.681.
+        # 72 is the largest core count that BOTH divides the 360-tile workload
+        # (nact=4 x Ht=90) exactly AND fits the 8-wide grid layout on a 10-row
+        # device (8x9). 90 and 120 need 12+ rows and fail to launch.
+        NC = ncores or int(os.environ.get("SWIGLU_NCORES", "0")) or 72
         while total_tiles % NC != 0:
             NC -= 1
         per_core = total_tiles // NC

--- a/models/demos/gpt_oss/kernels/swiglu_reader_bias.cpp
+++ b/models/demos/gpt_oss/kernels/swiglu_reader_bias.cpp
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Final fused-SwiGLU reader WITH bias streaming: reads gate/up from raw AND the
+// matching gate/up bias tiles from the prebuilt bias tensor [1,E,1,2I], for the
+// active experts only. Feeds cb_gate/cb_up/cb_gbias/cb_ubias to the bias-fold
+// compute kernel. Removes the wide [1,E,1,2I] bias-add op.
+//
+// raw & bias share the SAME expert-major page layout: expert e, tile-col j at
+// page e*Wt2 + j. gate half = [0,Ht), up half = [Ht,2Ht).
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/dataflow_buffer.h"
+#include "api/tensor/noc_traits.h"
+
+constexpr uint32_t cb_gate_id = get_compile_time_arg_val(0);
+constexpr uint32_t cb_up_id = get_compile_time_arg_val(1);
+constexpr uint32_t cb_gbias_id = get_compile_time_arg_val(2);
+constexpr uint32_t cb_ubias_id = get_compile_time_arg_val(3);
+constexpr uint32_t cb_idx_id = get_compile_time_arg_val(4);
+constexpr uint32_t Ht = get_compile_time_arg_val(5);
+constexpr uint32_t Wt2 = get_compile_time_arg_val(6);
+constexpr uint32_t nact = get_compile_time_arg_val(7);
+constexpr uint32_t ct_idx_raw = 8;
+constexpr uint32_t ct_idx_bias = TensorAccessorArgs<ct_idx_raw>::next_compile_time_args_offset();
+constexpr uint32_t ct_idx_idx = TensorAccessorArgs<ct_idx_bias>::next_compile_time_args_offset();
+
+void kernel_main() {
+    const uint32_t raw_addr = get_arg_val<uint32_t>(0);
+    const uint32_t bias_addr = get_arg_val<uint32_t>(1);
+    const uint32_t idx_addr = get_arg_val<uint32_t>(2);
+    const uint32_t start_tile = get_arg_val<uint32_t>(3);
+    const uint32_t n_tiles = get_arg_val<uint32_t>(4);
+
+    constexpr auto raw_args = TensorAccessorArgs<ct_idx_raw>();
+    constexpr auto bias_args = TensorAccessorArgs<ct_idx_bias>();
+    constexpr auto idx_args = TensorAccessorArgs<ct_idx_idx>();
+    const auto raw = TensorAccessor(raw_args, raw_addr);
+    const auto bias = TensorAccessor(bias_args, bias_addr);
+    const auto idxt = TensorAccessor(idx_args, idx_addr);
+
+    Noc noc;
+    DataflowBuffer cb_gate(cb_gate_id);
+    DataflowBuffer cb_up(cb_up_id);
+    DataflowBuffer cb_gbias(cb_gbias_id);
+    DataflowBuffer cb_ubias(cb_ubias_id);
+    DataflowBuffer cb_idx(cb_idx_id);
+    const uint32_t gp = get_local_cb_interface(cb_gate_id).fifo_page_size;
+    const uint32_t up_ = get_local_cb_interface(cb_up_id).fifo_page_size;
+    const uint32_t gbp = get_local_cb_interface(cb_gbias_id).fifo_page_size;
+    const uint32_t ubp = get_local_cb_interface(cb_ubias_id).fifo_page_size;
+    const uint32_t idx_page = get_local_cb_interface(cb_idx_id).fifo_page_size;
+
+    cb_idx.reserve_back(1);
+    noc.async_read(idxt, cb_idx, idx_page, {.page_id = 0}, {.offset_bytes = 0});
+    noc.async_read_barrier();
+    cb_idx.push_back(1);
+    volatile tt_l1_ptr uint32_t* exp = (volatile tt_l1_ptr uint32_t*)get_local_cb_interface(cb_idx_id).fifo_rd_ptr;
+
+    for (uint32_t t = 0; t < n_tiles; ++t) {
+        const uint32_t a = start_tile + t;
+        const uint32_t slot = a / Ht;
+        const uint32_t ti = a % Ht;
+        const uint32_t e = exp[slot];
+        const uint32_t gpage = e * Wt2 + ti;
+        const uint32_t upage = e * Wt2 + Ht + ti;
+        cb_gate.reserve_back(1);
+        cb_up.reserve_back(1);
+        cb_gbias.reserve_back(1);
+        cb_ubias.reserve_back(1);
+        noc.async_read(raw, cb_gate, gp, {.page_id = gpage}, {.offset_bytes = 0});
+        noc.async_read(raw, cb_up, up_, {.page_id = upage}, {.offset_bytes = 0});
+        noc.async_read(bias, cb_gbias, gbp, {.page_id = gpage}, {.offset_bytes = 0});
+        noc.async_read(bias, cb_ubias, ubp, {.page_id = upage}, {.offset_bytes = 0});
+        noc.async_read_barrier();
+        cb_gate.push_back(1);
+        cb_up.push_back(1);
+        cb_gbias.push_back(1);
+        cb_ubias.push_back(1);
+    }
+}

--- a/models/demos/gpt_oss/kernels/swiglu_reader_final.cpp
+++ b/models/demos/gpt_oss/kernels/swiglu_reader_final.cpp
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Final fused-SwiGLU reader: transpose-eliminating + expert-skipping + trace-safe.
+//
+// Reads ONLY the n_active experts (ids from a device tensor idx[1,1,1,NACT] uint32,
+// produced from the router top-k each token) directly from the raw fused gate/up
+// sparse_matmul output [1,E,1,2I] (padded [1,E,32,2I]) in native expert-major tile
+// layout. This removes BOTH the reshape/transpose/slice chain AND the 28 inactive
+// experts' work.
+//
+// Raw page math: expert e, tile-col j at page e*Wt2 + j.
+//   gate half = tile-cols [0,Ht);  up half = tile-cols [Ht,2Ht) (Ht=I/32, Wt2=2I/32).
+// Compact active-tile index a in [0, NACT*Ht): slot=a/Ht, ti=a%Ht, e=idx[slot].
+//   gate page = e*Wt2 + ti ;  up page = e*Wt2 + Ht + ti.
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/dataflow_buffer.h"
+#include "api/tensor/noc_traits.h"
+
+constexpr uint32_t cb_gate_id = get_compile_time_arg_val(0);
+constexpr uint32_t cb_up_id = get_compile_time_arg_val(1);
+constexpr uint32_t cb_idx_id = get_compile_time_arg_val(2);
+constexpr uint32_t Ht = get_compile_time_arg_val(3);
+constexpr uint32_t Wt2 = get_compile_time_arg_val(4);
+constexpr uint32_t nact = get_compile_time_arg_val(5);
+constexpr uint32_t ct_idx_raw = 6;
+constexpr uint32_t ct_idx_idx = TensorAccessorArgs<ct_idx_raw>::next_compile_time_args_offset();
+
+void kernel_main() {
+    const uint32_t raw_addr = get_arg_val<uint32_t>(0);
+    const uint32_t idx_addr = get_arg_val<uint32_t>(1);
+    const uint32_t start_tile = get_arg_val<uint32_t>(2);
+    const uint32_t n_tiles = get_arg_val<uint32_t>(3);
+
+    constexpr auto raw_args = TensorAccessorArgs<ct_idx_raw>();
+    constexpr auto idx_args = TensorAccessorArgs<ct_idx_idx>();
+    const auto raw = TensorAccessor(raw_args, raw_addr);
+    const auto idxt = TensorAccessor(idx_args, idx_addr);
+
+    Noc noc;
+    DataflowBuffer cb_gate(cb_gate_id);
+    DataflowBuffer cb_up(cb_up_id);
+    DataflowBuffer cb_idx(cb_idx_id);
+    const uint32_t gate_page = get_local_cb_interface(cb_gate_id).fifo_page_size;
+    const uint32_t up_page = get_local_cb_interface(cb_up_id).fifo_page_size;
+    const uint32_t idx_page = get_local_cb_interface(cb_idx_id).fifo_page_size;
+
+    // Load the active-expert id list (one page: [1,1,1,NACT] uint32) into L1.
+    cb_idx.reserve_back(1);
+    noc.async_read(idxt, cb_idx, idx_page, {.page_id = 0}, {.offset_bytes = 0});
+    noc.async_read_barrier();
+    cb_idx.push_back(1);
+    volatile tt_l1_ptr uint32_t* exp = (volatile tt_l1_ptr uint32_t*)get_local_cb_interface(cb_idx_id).fifo_rd_ptr;
+
+    constexpr uint32_t BATCH = 8;
+    uint32_t t = 0;
+    for (; t + BATCH <= n_tiles; t += BATCH) {
+        cb_gate.reserve_back(BATCH);
+        cb_up.reserve_back(BATCH);
+        for (uint32_t b = 0; b < BATCH; ++b) {
+            const uint32_t a = start_tile + t + b;
+            const uint32_t slot = a / Ht;
+            const uint32_t ti = a % Ht;
+            const uint32_t e = exp[slot];
+            const uint32_t gpage = e * Wt2 + ti;
+            const uint32_t upage = e * Wt2 + Ht + ti;
+            noc.async_read(raw, cb_gate, gate_page, {.page_id = gpage}, {.offset_bytes = b * gate_page});
+            noc.async_read(raw, cb_up, up_page, {.page_id = upage}, {.offset_bytes = b * up_page});
+        }
+        noc.async_read_barrier();
+        cb_gate.push_back(BATCH);
+        cb_up.push_back(BATCH);
+    }
+    for (; t < n_tiles; ++t) {
+        const uint32_t a = start_tile + t;
+        const uint32_t slot = a / Ht;
+        const uint32_t ti = a % Ht;
+        const uint32_t e = exp[slot];
+        const uint32_t gpage = e * Wt2 + ti;
+        const uint32_t upage = e * Wt2 + Ht + ti;
+        cb_gate.reserve_back(1);
+        cb_up.reserve_back(1);
+        noc.async_read(raw, cb_gate, gate_page, {.page_id = gpage}, {.offset_bytes = 0});
+        noc.async_read(raw, cb_up, up_page, {.page_id = upage}, {.offset_bytes = 0});
+        noc.async_read_barrier();
+        cb_gate.push_back(1);
+        cb_up.push_back(1);
+    }
+}

--- a/models/demos/gpt_oss/kernels/swiglu_writer_final.cpp
+++ b/models/demos/gpt_oss/kernels/swiglu_writer_final.cpp
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Scatter writer for the final fused SwiGLU: writes each compact active-slot
+// output tile to its REAL expert slot in the [1,E,1,I] down_input tensor.
+//
+// Compact active-tile index a in [0, NACT*Ht): slot=a/Ht, ti=a%Ht, e=idx[slot].
+//   out page = e*Ht + ti.
+// Inactive expert slots are left untouched (the down sparse_matmul skips them via
+// its sparsity mask, so their contents don't matter).
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/dataflow_buffer.h"
+#include "api/tensor/noc_traits.h"
+
+constexpr uint32_t cb_out_id = get_compile_time_arg_val(0);
+constexpr uint32_t cb_idx_id = get_compile_time_arg_val(1);
+constexpr uint32_t Ht = get_compile_time_arg_val(2);
+constexpr uint32_t nact = get_compile_time_arg_val(3);
+constexpr uint32_t ct_idx_out = 4;
+constexpr uint32_t ct_idx_idx = TensorAccessorArgs<ct_idx_out>::next_compile_time_args_offset();
+
+void kernel_main() {
+    const uint32_t out_addr = get_arg_val<uint32_t>(0);
+    const uint32_t idx_addr = get_arg_val<uint32_t>(1);
+    const uint32_t start_tile = get_arg_val<uint32_t>(2);
+    const uint32_t n_tiles = get_arg_val<uint32_t>(3);
+
+    constexpr auto out_args = TensorAccessorArgs<ct_idx_out>();
+    constexpr auto idx_args = TensorAccessorArgs<ct_idx_idx>();
+    const auto outt = TensorAccessor(out_args, out_addr);
+    const auto idxt = TensorAccessor(idx_args, idx_addr);
+
+    Noc noc;
+    DataflowBuffer cb_out(cb_out_id);
+    DataflowBuffer cb_idx(cb_idx_id);
+    const uint32_t out_page = get_local_cb_interface(cb_out_id).fifo_page_size;
+    const uint32_t idx_page = get_local_cb_interface(cb_idx_id).fifo_page_size;
+
+    // Load active-expert id list into L1 (separate scratch CB from the reader's).
+    cb_idx.reserve_back(1);
+    noc.async_read(idxt, cb_idx, idx_page, {.page_id = 0}, {.offset_bytes = 0});
+    noc.async_read_barrier();
+    cb_idx.push_back(1);
+    volatile tt_l1_ptr uint32_t* exp = (volatile tt_l1_ptr uint32_t*)get_local_cb_interface(cb_idx_id).fifo_rd_ptr;
+
+    for (uint32_t t = 0; t < n_tiles; ++t) {
+        const uint32_t a = start_tile + t;
+        const uint32_t slot = a / Ht;
+        const uint32_t ti = a % Ht;
+        const uint32_t e = exp[slot];
+        const uint32_t page = e * Ht + ti;
+        cb_out.wait_front(1);
+        noc.async_write(cb_out, outt, out_page, {}, {.page_id = page});
+        noc.async_write_barrier();
+        cb_out.pop_front(1);
+    }
+}

--- a/models/demos/gpt_oss/kernels/test_moe_reduce.py
+++ b/models/demos/gpt_oss/kernels/test_moe_reduce.py
@@ -92,16 +92,18 @@ def main():
             return ttnn.CBDescriptor(total_size=npages * tile_bytes, core_ranges=core, format_descriptors=[fmt])
 
         cb_act, cb_sc, cb_out = 0, 1, 16
-        # act CB double-buffered; scores CB holds all E resident; out double-buffered.
-        cbs = [cb(cb_act, 2), cb(cb_sc, E), cb(cb_out, 2)]
+        # act CB holds 2*E (double-buffered E-batch); scores CB all E resident; out double-buffered.
+        cbs = [cb(cb_act, 2 * E), cb(cb_sc, E), cb(cb_out, 2)]
 
         reader_ct = [cb_act, cb_sc, E, Ht]
         reader_ct += ttnn.TensorAccessorArgs(act_t).get_compile_time_args()
         reader_ct += ttnn.TensorAccessorArgs(sc_t).get_compile_time_args()
         writer_ct = [cb_out]
         writer_ct += ttnn.TensorAccessorArgs(out_t).get_compile_time_args()
-        # compute: num_output_tiles(per_core), reduction_dim_size(E), input_granularity, cb0, cb1, cbout
-        compute_ct = [per_core, E, 1, cb_act, cb_sc, cb_out]
+        # compute: num_output_tiles(per_core), reduction_dim_size(E), input_granularity=E, cb0, cb1, cbout
+        # input_granularity=E => compute waits once per output tile for the whole E-batch,
+        # matching the reader's batched E-read + single barrier.
+        compute_ct = [per_core, E, E, cb_act, cb_sc, cb_out]
 
         rr = ttnn.RuntimeArgs()
         wr = ttnn.RuntimeArgs()

--- a/models/demos/gpt_oss/kernels/test_moe_reduce.py
+++ b/models/demos/gpt_oss/kernels/test_moe_reduce.py
@@ -25,6 +25,15 @@ def col0_score_tiles(w):
     return st
 
 
+def _best_ncores(ht, max_cores=64):
+    """Largest divisor of ht that is <= max_cores (uniform per-core tile count)."""
+    best = 1
+    for d in range(1, min(ht, max_cores) + 1):
+        if ht % d == 0:
+            best = d
+    return best
+
+
 def pcc(a, b):
     a = a.flatten().double()
     b = b.flatten().double()
@@ -62,7 +71,20 @@ def main():
             ttnn.Shape([1, 1, T, H]), ttnn.bfloat16, ttnn.TILE_LAYOUT, dev, ttnn.DRAM_MEMORY_CONFIG
         )
 
-        core = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))])
+        # Parallelize the Ht output tiles across a core grid. Pick a core count that
+        # divides Ht evenly so the per-core tile count (a compile-time arg) is uniform.
+        import os
+
+        NCORES = int(os.environ.get("NCORES", "0")) or _best_ncores(Ht, max_cores=64)
+        per_core = Ht // NCORES
+        gx = min(8, NCORES)
+        gy = (NCORES + gx - 1) // gx
+        core_list = [(x, y) for y in range(gy) for x in range(gx)][:NCORES]
+        # Build the CoreRangeSet from EXACTLY the assigned cores (not a bounding
+        # rectangle) so no unassigned core in the rectangle gets the kernel+CBs with
+        # no runtime args (that deadlocks on multi-row grids).
+        core = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(x, y), ttnn.CoreCoord(x, y)) for (x, y) in core_list])
+        print(f"# Ht={Ht} NCORES={NCORES} per_core={per_core} grid={gx}x{gy}")
         tile_bytes = 2 * 1024  # bf16 tile
 
         def cb(idx, npages):
@@ -78,13 +100,15 @@ def main():
         reader_ct += ttnn.TensorAccessorArgs(sc_t).get_compile_time_args()
         writer_ct = [cb_out]
         writer_ct += ttnn.TensorAccessorArgs(out_t).get_compile_time_args()
-        # compute: num_output_tiles, reduction_dim_size(E), input_granularity, cb0, cb1, cbout
-        compute_ct = [Ht, E, 1, cb_act, cb_sc, cb_out]
+        # compute: num_output_tiles(per_core), reduction_dim_size(E), input_granularity, cb0, cb1, cbout
+        compute_ct = [per_core, E, 1, cb_act, cb_sc, cb_out]
 
         rr = ttnn.RuntimeArgs()
         wr = ttnn.RuntimeArgs()
-        rr[0][0] = [act_t.buffer_address(), sc_t.buffer_address()]
-        wr[0][0] = [out_t.buffer_address(), Ht, 0]
+        for c, (x, y) in enumerate(core_list):
+            st = c * per_core
+            rr[x][y] = [act_t.buffer_address(), sc_t.buffer_address(), st, per_core]
+            wr[x][y] = [out_t.buffer_address(), per_core, st]
 
         reader = ttnn.KernelDescriptor(
             kernel_source=f"{KDIR}/moe_reduce_reader.cpp",
@@ -112,7 +136,17 @@ def main():
         )
 
         prog = ttnn.ProgramDescriptor(kernels=[reader, writer, compute], semaphores=[], cbs=cbs)
-        out = ttnn.generic_op([act_t, sc_t, out_t], prog)
+        import time
+
+        out = ttnn.generic_op([act_t, sc_t, out_t], prog)  # compile + first run
+        ttnn.synchronize_device(dev)
+        iters = 20
+        t0 = time.perf_counter()
+        for _ in range(iters):
+            out = ttnn.generic_op([act_t, sc_t, out_t], prog)
+        ttnn.synchronize_device(dev)
+        ms = (time.perf_counter() - t0) / iters * 1e3
+        print(f"RESULT timing: {ms:.4f} ms/call ({NCORES} cores)")
         got = ttnn.to_torch(out).float().reshape(T, H)  # = sum_e w[e]*down[e]
         # add bias term on host: bias * sum_e w[e]
         wsum = w.float().sum(dim=1, keepdim=True)  # [T,1]

--- a/models/demos/gpt_oss/kernels/test_moe_reduce.py
+++ b/models/demos/gpt_oss/kernels/test_moe_reduce.py
@@ -1,0 +1,132 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Standalone PCC test for the custom gpt-oss fused MoE expert-reduce, driven via
+ttnn.generic_op (JiT kernels, no _ttnn.so rebuild).
+
+Computes  out[t,h] = sum_e w[t,e] * down[e,t,h]  on a single core, and checks PCC
+against a torch reference. (The bias term bias*sum_e w[e] is added on host in the
+model-integration step; here we validate the core weighted reduce.)
+"""
+import torch
+
+import ttnn
+
+KDIR = "models/demos/gpt_oss/kernels"
+E = 32  # experts (reduction dim)
+T = 32  # tokens (one tile row)
+H = 2880  # hidden -> Ht = H/32 output tiles
+TILE = 32
+
+
+def col0_score_tiles(w):
+    """Build [E,1,T,32] score tensor: tile e has w[:,e] in column 0, else 0.
+    COL-broadcast MAC reads column 0 of each row."""
+    st = torch.zeros(E, 1, T, TILE, dtype=torch.bfloat16)
+    st[:, 0, :, 0] = w.t()  # [E,T] -> column 0
+    return st
+
+
+def pcc(a, b):
+    a = a.flatten().double()
+    b = b.flatten().double()
+    a = a - a.mean()
+    b = b - b.mean()
+    d = (a.norm() * b.norm()).item()
+    return 1.0 if d == 0 else torch.dot(a, b).item() / d
+
+
+def main():
+    torch.manual_seed(0)
+    dev = ttnn.open_mesh_device(ttnn.MeshShape(1, 1))
+    try:
+        Ht = H // TILE
+        down = torch.randn(E, 1, T, H, dtype=torch.bfloat16) * 0.1
+        bias = torch.randn(H, dtype=torch.bfloat16) * 0.05
+        w = torch.zeros(T, E, dtype=torch.bfloat16)
+        w[:, :4] = torch.rand(T, 4, dtype=torch.bfloat16)
+        # full gpt-oss tail: out = sum_e w[e]*(down[e]+bias)
+        ref = torch.zeros(T, H)
+        for e in range(E):
+            ref += w[:, e : e + 1].float() * (down[e, 0].float() + bias.float())
+
+        act_t = ttnn.from_torch(
+            down, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=dev, memory_config=ttnn.DRAM_MEMORY_CONFIG
+        )
+        sc_t = ttnn.from_torch(
+            col0_score_tiles(w),
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=dev,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+        out_t = ttnn.allocate_tensor_on_device(
+            ttnn.Shape([1, 1, T, H]), ttnn.bfloat16, ttnn.TILE_LAYOUT, dev, ttnn.DRAM_MEMORY_CONFIG
+        )
+
+        core = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))])
+        tile_bytes = 2 * 1024  # bf16 tile
+
+        def cb(idx, npages):
+            fmt = ttnn.CBFormatDescriptor(buffer_index=idx, data_format=ttnn.bfloat16, page_size=tile_bytes)
+            return ttnn.CBDescriptor(total_size=npages * tile_bytes, core_ranges=core, format_descriptors=[fmt])
+
+        cb_act, cb_sc, cb_out = 0, 1, 16
+        # act CB double-buffered; scores CB holds all E resident; out double-buffered.
+        cbs = [cb(cb_act, 2), cb(cb_sc, E), cb(cb_out, 2)]
+
+        reader_ct = [cb_act, cb_sc, E, Ht]
+        reader_ct += ttnn.TensorAccessorArgs(act_t).get_compile_time_args()
+        reader_ct += ttnn.TensorAccessorArgs(sc_t).get_compile_time_args()
+        writer_ct = [cb_out]
+        writer_ct += ttnn.TensorAccessorArgs(out_t).get_compile_time_args()
+        # compute: num_output_tiles, reduction_dim_size(E), input_granularity, cb0, cb1, cbout
+        compute_ct = [Ht, E, 1, cb_act, cb_sc, cb_out]
+
+        rr = ttnn.RuntimeArgs()
+        wr = ttnn.RuntimeArgs()
+        rr[0][0] = [act_t.buffer_address(), sc_t.buffer_address()]
+        wr[0][0] = [out_t.buffer_address(), Ht, 0]
+
+        reader = ttnn.KernelDescriptor(
+            kernel_source=f"{KDIR}/moe_reduce_reader.cpp",
+            source_type=ttnn.KernelDescriptor.SourceType.FILE_PATH,
+            core_ranges=core,
+            compile_time_args=reader_ct,
+            runtime_args=rr,
+            config=ttnn.ReaderConfigDescriptor(),
+        )
+        writer = ttnn.KernelDescriptor(
+            kernel_source="ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp",
+            source_type=ttnn.KernelDescriptor.SourceType.FILE_PATH,
+            core_ranges=core,
+            compile_time_args=writer_ct,
+            runtime_args=wr,
+            config=ttnn.WriterConfigDescriptor(),
+        )
+        compute = ttnn.KernelDescriptor(
+            kernel_source=f"{KDIR}/moe_reduce_compute.cpp",
+            source_type=ttnn.KernelDescriptor.SourceType.FILE_PATH,
+            core_ranges=core,
+            compile_time_args=compute_ct,
+            runtime_args=[],
+            config=ttnn.ComputeConfigDescriptor(),
+        )
+
+        prog = ttnn.ProgramDescriptor(kernels=[reader, writer, compute], semaphores=[], cbs=cbs)
+        out = ttnn.generic_op([act_t, sc_t, out_t], prog)
+        got = ttnn.to_torch(out).float().reshape(T, H)  # = sum_e w[e]*down[e]
+        # add bias term on host: bias * sum_e w[e]
+        wsum = w.float().sum(dim=1, keepdim=True)  # [T,1]
+        got_full = got + bias.float().unsqueeze(0) * wsum
+        p_core = pcc(ref - bias.float().unsqueeze(0) * wsum, got)
+        p_full = pcc(ref, got_full)
+        print(f"RESULT core reduce (sum w*down) PCC = {p_core:.5f}")
+        print(
+            f"RESULT full tail (+bias*sum_w)  PCC = {p_full:.5f}  got.norm={got_full.norm():.2f} ref.norm={ref.norm():.2f}"
+        )
+        print("VERDICT:", "PASS" if p_full >= 0.99 else "FAIL")
+    finally:
+        ttnn.close_mesh_device(dev)
+
+
+if __name__ == "__main__":
+    main()

--- a/models/demos/gpt_oss/tests/sweeps/matmul_sweep.py
+++ b/models/demos/gpt_oss/tests/sweeps/matmul_sweep.py
@@ -1,0 +1,539 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Generalized matmul program-config sweep — a CLI tool.
+
+Give it M, K, N (the GEMM dims, A[M,K] @ B[K,N] = C[M,N]) and it sweeps the
+program configuration, memory configuration, math fidelity and dest/accumulation
+modes for one or more matmul implementations, timing each on device and checking
+PCC against a torch reference. It prints a RESULT line per config, writes a CSV,
+and reports the BEST (fastest PCC-passing) config per implementation.
+
+Implementations (choose with --impl, default: all):
+  minmatmul  ttnn.experimental.minimal_matmul  (MinimalMatmulConfig: M/K/N block + subblock)
+  matmul2d   ttnn.matmul + MatmulMultiCoreReuseMultiCastProgramConfig   (2D mcast)
+  matmul1d   ttnn.matmul + MatmulMultiCoreReuseMultiCast1DProgramConfig (1D mcast)
+
+The sweep OWNS config generation: from M,K,N and the core grid it derives valid
+per-core / block sizes, enumerates the tunable block + subblock params, and skips
+combinations that violate the known hardware constraints (DST-register cap,
+divisibility) up front so the run isn't just a wall of failures.
+
+Examples
+  # BGE-M3 MLP Wi shape (M=12*8192, K=1024, N=4096), all impls, default sweep
+  python models/demos/wormhole/bge_m3/tests/generalize/matmul_sweep.py --M 98304 --K 1024 --N 4096
+
+  # Just minimal_matmul, wider block sweep, save CSV
+  python models/demos/wormhole/bge_m3/tests/generalize/matmul_sweep.py --M 98304 --K 4096 --N 1024 \
+      --impl minmatmul --csv models/demos/wormhole/bge_m3/tests/generalize/out/mlpwo.csv
+
+  # Fixed fidelity/dtype, cap the number of configs tried
+  python models/demos/wormhole/bge_m3/tests/generalize/matmul_sweep.py --M 8192 --K 8192 --N 8192 \
+      --dtypes bfloat8_b --fidelities LoFi --max-configs 40
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import itertools
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import torch
+
+import ttnn
+
+TILE = 32
+
+DTYPES = {
+    "bfloat16": ttnn.bfloat16,
+    "bfloat8_b": ttnn.bfloat8_b,
+    "bfloat4_b": ttnn.bfloat4_b,
+}
+FIDELITIES = {
+    "LoFi": ttnn.MathFidelity.LoFi,
+    "HiFi2": ttnn.MathFidelity.HiFi2,
+    "HiFi4": ttnn.MathFidelity.HiFi4,
+}
+MEMCFGS = {
+    "dram": ttnn.DRAM_MEMORY_CONFIG,
+    "l1": ttnn.L1_MEMORY_CONFIG,
+}
+
+
+# ----------------------------------------------------------------------------
+# Config generation helpers
+# ----------------------------------------------------------------------------
+def divisors(n: int) -> list[int]:
+    return [d for d in range(1, n + 1) if n % d == 0]
+
+
+def subblock_candidates(block_h: int, block_w: int, dst_cap: int) -> list[tuple[int, int]]:
+    """(subblock_h, subblock_w) with h*w <= dst_cap, h | block_h, w | block_w.
+
+    dst_cap is the number of output tiles that fit in the DST register per
+    acquire: 8 for bf16/bf8 dest, 4 when fp32_dest_acc_en=True (fp32 halves it).
+    Larger subblocks amortize the acquire/release + math-init overhead.
+    """
+    out = []
+    for h in divisors(block_h):
+        for w in divisors(block_w):
+            if h * w <= dst_cap and h * w >= 1:
+                out.append((h, w))
+    # Prefer larger subblocks first (usually faster) so early results are good.
+    out.sort(key=lambda hw: -(hw[0] * hw[1]))
+    return out
+
+
+def dst_cap_for(fp32_dest_acc_en: bool) -> int:
+    return 4 if fp32_dest_acc_en else 8
+
+
+@dataclass
+class Trial:
+    impl: str
+    label: str
+    program_config: object
+    out_memcfg_name: str
+    dtype_name: str
+    fidelity_name: str
+    fp32_dest_acc_en: bool
+    packer_l1_acc: bool
+    est_out_cb_bytes: int = 0
+    extra: dict = field(default_factory=dict)
+
+
+def gen_minmatmul(M_t, K_t, N_t, grid, args, dtype_name, fid_name, fp32_dest, packer_l1):
+    """MinimalMatmulConfig: block sizes are in TILES; factory splits M/N across
+    the grid and iterates ceil(per_core / block) blocks. Bigger M/K block cuts
+    iteration overhead but grows the double-buffered CB L1 footprint."""
+    cap = dst_cap_for(fp32_dest)
+    m_blocks = [b for b in args.m_blocks if b <= max(M_t, 1)]
+    k_blocks = [b for b in args.k_blocks if b <= max(K_t, 1)]
+    n_blocks = [b for b in args.n_blocks if b <= max(N_t, 1)]
+    trials = []
+    for mb, kb, nb in itertools.product(m_blocks, k_blocks, n_blocks):
+        for sh, sw in subblock_candidates(mb, nb, cap):
+            cfg = ttnn.MinimalMatmulConfig(
+                M_block_size=mb,
+                K_block_size=kb,
+                N_block_size=nb,
+                subblock_h=sh,
+                subblock_w=sw,
+                compute_with_storage_grid_size=ttnn.CoreCoord(grid[0], grid[1]),
+            )
+            tile_bytes = 2048 if dtype_name == "bfloat16" else (1088 if dtype_name == "bfloat8_b" else 576)
+            est = 2 * (mb * kb + kb * nb + mb * nb) * tile_bytes  # double-buffered CBs
+            trials.append(
+                Trial(
+                    "minmatmul",
+                    f"m{mb}k{kb}n{nb}_sb{sh}x{sw}",
+                    cfg,
+                    "?",
+                    dtype_name,
+                    fid_name,
+                    fp32_dest,
+                    packer_l1,
+                    est_out_cb_bytes=est,
+                    extra={"M_block": mb, "K_block": kb, "N_block": nb, "sbh": sh, "sbw": sw},
+                )
+            )
+    return trials
+
+
+def _percore_and_subblocks(M_t, N_t, grid, cap, transpose_mcast):
+    """per_core_M/N from grid + valid out_subblock candidates."""
+    gx, gy = grid
+    # 2D convention: M parallelised on grid rows (y), N on grid cols (x)
+    cores_m = gx if transpose_mcast else gy
+    cores_n = gy if transpose_mcast else gx
+    per_core_M = max(1, -(-M_t // cores_m))  # ceil
+    per_core_N = max(1, -(-N_t // cores_n))
+    subs = subblock_candidates(per_core_M, per_core_N, cap)
+    return per_core_M, per_core_N, subs
+
+
+def gen_matmul2d(M_t, K_t, N_t, grid, args, dtype_name, fid_name, fp32_dest, packer_l1):
+    cap = dst_cap_for(fp32_dest)
+    trials = []
+    for transpose_mcast in (False, True):
+        per_core_M, per_core_N, subs = _percore_and_subblocks(M_t, N_t, grid, cap, transpose_mcast)
+        for in0_block_w in [w for w in divisors(K_t) if w in args.in0_block_w or not args.in0_block_w]:
+            for sh, sw in subs:
+                if per_core_M % sh or per_core_N % sw:
+                    continue
+                try:
+                    cfg = ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+                        compute_with_storage_grid_size=ttnn.CoreCoord(grid[0], grid[1]),
+                        in0_block_w=in0_block_w,
+                        out_subblock_h=sh,
+                        out_subblock_w=sw,
+                        per_core_M=per_core_M,
+                        per_core_N=per_core_N,
+                        transpose_mcast=transpose_mcast,
+                        fuse_batch=True,
+                    )
+                except Exception:
+                    continue
+                trials.append(
+                    Trial(
+                        "matmul2d",
+                        f"pcM{per_core_M}pcN{per_core_N}_ib{in0_block_w}_sb{sh}x{sw}_t{int(transpose_mcast)}",
+                        cfg,
+                        "?",
+                        dtype_name,
+                        fid_name,
+                        fp32_dest,
+                        packer_l1,
+                        extra={
+                            "per_core_M": per_core_M,
+                            "per_core_N": per_core_N,
+                            "in0_block_w": in0_block_w,
+                            "sbh": sh,
+                            "sbw": sw,
+                            "transpose_mcast": transpose_mcast,
+                        },
+                    )
+                )
+    return trials
+
+
+def gen_matmul1d(M_t, K_t, N_t, grid, args, dtype_name, fid_name, fp32_dest, packer_l1):
+    cap = dst_cap_for(fp32_dest)
+    gx, gy = grid
+    num_cores = gx * gy
+    trials = []
+    for mcast_in0 in (True, False):
+        # 1D lays all cores in a line. mcast_in0=True: split N across cores, M
+        # replicated per core. mcast_in0=False (gather): split M across cores.
+        if mcast_in0:
+            per_core_M = max(1, M_t)
+            per_core_N = max(1, -(-N_t // num_cores))
+        else:
+            per_core_M = max(1, -(-M_t // num_cores))
+            per_core_N = max(1, N_t)
+        subs = subblock_candidates(per_core_M, per_core_N, cap)
+        for in0_block_w in [w for w in divisors(K_t) if w in args.in0_block_w or not args.in0_block_w]:
+            for sh, sw in subs:
+                if per_core_M % sh or per_core_N % sw:
+                    continue
+                try:
+                    cfg = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+                        compute_with_storage_grid_size=ttnn.CoreCoord(grid[0], grid[1]),
+                        in0_block_w=in0_block_w,
+                        out_subblock_h=sh,
+                        out_subblock_w=sw,
+                        per_core_M=per_core_M,
+                        per_core_N=per_core_N,
+                        fuse_batch=True,
+                        mcast_in0=mcast_in0,
+                    )
+                except Exception:
+                    continue
+                trials.append(
+                    Trial(
+                        "matmul1d",
+                        f"pcM{per_core_M}pcN{per_core_N}_ib{in0_block_w}_sb{sh}x{sw}_mc{int(mcast_in0)}",
+                        cfg,
+                        "?",
+                        dtype_name,
+                        fid_name,
+                        fp32_dest,
+                        packer_l1,
+                        extra={
+                            "per_core_M": per_core_M,
+                            "per_core_N": per_core_N,
+                            "in0_block_w": in0_block_w,
+                            "sbh": sh,
+                            "sbw": sw,
+                            "mcast_in0": mcast_in0,
+                        },
+                    )
+                )
+    return trials
+
+
+GENERATORS = {"minmatmul": gen_minmatmul, "matmul2d": gen_matmul2d, "matmul1d": gen_matmul1d}
+
+
+# ----------------------------------------------------------------------------
+# Execution
+# ----------------------------------------------------------------------------
+def pcc(a: torch.Tensor, b: torch.Tensor) -> float:
+    a = a.flatten().to(torch.float64)
+    b = b.flatten().to(torch.float64)
+    a = a - a.mean()
+    b = b - b.mean()
+    denom = (a.norm() * b.norm()).item()
+    return 1.0 if denom == 0 else (torch.dot(a, b).item() / denom)
+
+
+_OOM_MARKERS = (
+    "out of memory",
+    "oom",
+    "clash with l1",
+    "beyond max l1",
+    "circular buffer",
+    "bank_manager",
+    "allocator",
+    "not enough space",
+    "failed to allocate",
+)
+
+
+def _looks_like_oom(exc: BaseException) -> bool:
+    """Classify an exception as an L1/DRAM capacity failure for reporting."""
+    s = str(exc).lower()
+    return any(m in s for m in _OOM_MARKERS)
+
+
+def _device_alive(dev) -> bool:
+    """Cheap probe: round-trip a tiny tensor. Returns False if the device is
+    wedged/unresponsive so the sweep can abort cleanly instead of spinning."""
+    try:
+        x = ttnn.from_torch(
+            torch.zeros(TILE, TILE, dtype=torch.bfloat16),
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=dev,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+        ttnn.synchronize_device(dev)
+        _safe_dealloc(x)
+        return True
+    except Exception:
+        return False
+
+
+def _safe_dealloc(t):
+    """Deallocate a device tensor, swallowing any error (already-freed, bad
+    state, etc.) so cleanup never masks the real failure."""
+    if t is None:
+        return
+    try:
+        ttnn.deallocate(t)
+    except Exception:
+        pass
+
+
+def run_trial(dev, a_t, b_t, ref, trial: Trial, out_memcfg_name, iters):
+    dtype = DTYPES[trial.dtype_name]
+    memcfg = MEMCFGS[out_memcfg_name]
+    a = b = None
+    outs = []  # track every output so we can free them even on mid-loop failure
+    try:
+        a = ttnn.from_torch(
+            a_t, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=dev, memory_config=ttnn.DRAM_MEMORY_CONFIG
+        )
+        b = ttnn.from_torch(
+            b_t, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=dev, memory_config=ttnn.DRAM_MEMORY_CONFIG
+        )
+        ck = ttnn.init_device_compute_kernel_config(
+            dev.arch(),
+            math_fidelity=FIDELITIES[trial.fidelity_name],
+            math_approx_mode=False,
+            fp32_dest_acc_en=trial.fp32_dest_acc_en,
+            packer_l1_acc=trial.packer_l1_acc,
+        )
+
+        def once():
+            if trial.impl == "minmatmul":
+                return ttnn.experimental.minimal_matmul(
+                    input_tensor=a,
+                    weight_tensor=b,
+                    bias_tensor=None,
+                    config=trial.program_config,
+                    memory_config=memcfg,
+                    dtype=dtype,
+                    compute_kernel_config=ck,
+                )
+            return ttnn.matmul(
+                a, b, program_config=trial.program_config, memory_config=memcfg, compute_kernel_config=ck
+            )
+
+        # correctness (warm + compile). A bad program config / L1 OOM / TT_FATAL
+        # throws HERE (at program build, before launch) -> caught by the caller.
+        out = once()
+        outs.append(out)
+        ttnn.synchronize_device(dev)
+        got = ttnn.to_torch(out).to(torch.float32).reshape(ref.shape)
+        p = pcc(ref, got)
+        _safe_dealloc(out)
+        outs.clear()
+
+        # timing (median of iters)
+        samples = []
+        for _ in range(iters):
+            t0 = time.perf_counter()
+            out = once()
+            outs.append(out)
+            ttnn.synchronize_device(dev)
+            samples.append((time.perf_counter() - t0) * 1e3)
+            _safe_dealloc(out)
+            outs.clear()
+        samples.sort()
+        return samples[len(samples) // 2], samples[0], p
+    finally:
+        # Always free inputs + any straggler outputs so a failed trial does not
+        # leak L1/DRAM and cause phantom OOMs on the configs that follow.
+        for o in outs:
+            _safe_dealloc(o)
+        _safe_dealloc(a)
+        _safe_dealloc(b)
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Generalized matmul program-config sweep")
+    ap.add_argument("--M", type=int, required=True, help="rows of A / output (elements)")
+    ap.add_argument("--K", type=int, required=True, help="contraction dim (elements)")
+    ap.add_argument("--N", type=int, required=True, help="cols of B / output (elements)")
+    ap.add_argument(
+        "--impl",
+        nargs="+",
+        default=["minmatmul", "matmul2d", "matmul1d"],
+        choices=list(GENERATORS.keys()),
+        help="which implementations to sweep",
+    )
+    ap.add_argument("--dtypes", nargs="+", default=["bfloat8_b"], choices=list(DTYPES.keys()))
+    ap.add_argument("--fidelities", nargs="+", default=["LoFi", "HiFi2"], choices=list(FIDELITIES.keys()))
+    ap.add_argument("--out-memcfgs", nargs="+", default=["dram", "l1"], choices=list(MEMCFGS.keys()))
+    ap.add_argument(
+        "--fp32-dest", nargs="+", type=int, default=[0], choices=[0, 1], help="fp32_dest_acc_en values to sweep (0/1)"
+    )
+    ap.add_argument("--packer-l1-acc", nargs="+", type=int, default=[1], choices=[0, 1])
+    ap.add_argument("--grid", type=int, nargs=2, default=[8, 8], help="core grid x y")
+    ap.add_argument("--iters", type=int, default=3, help="timing samples per config (median reported)")
+    ap.add_argument("--max-configs", type=int, default=200, help="cap total trials")
+    ap.add_argument("--pcc", type=float, default=0.99, help="PCC threshold to count as passing")
+    ap.add_argument("--m-blocks", type=int, nargs="+", default=[8, 16, 24, 32], help="minmatmul M_block tiles")
+    ap.add_argument("--k-blocks", type=int, nargs="+", default=[4, 8, 16, 32], help="minmatmul K_block tiles")
+    ap.add_argument("--n-blocks", type=int, nargs="+", default=[2, 4, 8], help="minmatmul N_block tiles")
+    ap.add_argument(
+        "--in0-block-w", type=int, nargs="*", default=[], help="fix matmul1d/2d in0_block_w (tiles); empty=all divisors"
+    )
+    ap.add_argument("--csv", type=str, default="", help="write results CSV to this path")
+    ap.add_argument("--seed", type=int, default=0)
+    args = ap.parse_args()
+
+    if args.M % TILE or args.K % TILE or args.N % TILE:
+        raise SystemExit(f"M,K,N must be multiples of {TILE} (tile dim). Got {args.M},{args.K},{args.N}")
+    M_t, K_t, N_t = args.M // TILE, args.K // TILE, args.N // TILE
+    print(
+        f"# GEMM A[{args.M},{args.K}] @ B[{args.K},{args.N}] = C[{args.M},{args.N}]  "
+        f"({M_t}x{K_t}x{N_t} tiles), grid={args.grid}",
+        flush=True,
+    )
+
+    torch.manual_seed(args.seed)
+    a_t = torch.randn(args.M, args.K, dtype=torch.bfloat16)
+    b_t = torch.randn(args.K, args.N, dtype=torch.bfloat16)
+    ref = a_t.to(torch.float32) @ b_t.to(torch.float32)
+
+    # Build the trial list across all axes.
+    trials: list[Trial] = []
+    for impl in args.impl:
+        for dt, fid, fp32, pl1 in itertools.product(args.dtypes, args.fidelities, args.fp32_dest, args.packer_l1_acc):
+            trials += GENERATORS[impl](M_t, K_t, N_t, tuple(args.grid), args, dt, fid, bool(fp32), bool(pl1))
+    # Expand over output memcfgs (cheap axis, keep last so program configs cluster).
+    expanded = []
+    for t in trials:
+        for mc in args.out_memcfgs:
+            t2 = Trial(**{**t.__dict__})
+            t2.out_memcfg_name = mc
+            expanded.append(t2)
+    trials = expanded
+    if len(trials) > args.max_configs:
+        print(f"# generated {len(trials)} trials, capping to --max-configs={args.max_configs}", flush=True)
+        trials = trials[: args.max_configs]
+    else:
+        print(f"# generated {len(trials)} trials", flush=True)
+
+    def _base_row(t, status, note="", **num):
+        return {
+            "impl": t.impl,
+            "label": t.label,
+            "dtype": t.dtype_name,
+            "fidelity": t.fidelity_name,
+            "fp32_dest": int(t.fp32_dest_acc_en),
+            "packer_l1_acc": int(t.packer_l1_acc),
+            "out_memcfg": t.out_memcfg_name,
+            "status": status,
+            "est_out_cb_bytes": t.est_out_cb_bytes,
+            "median_ms": "",
+            "min_ms": "",
+            "pcc": "",
+            "note": note,
+            **num,
+            **t.extra,
+        }
+
+    dev = ttnn.open_mesh_device(ttnn.MeshShape(1, 1))
+    rows = []
+    best = {}
+    n_ok = n_skip = n_fatal = 0
+    try:
+        for i, t in enumerate(trials):
+            full = (
+                f"{t.impl}|{t.label}|{t.dtype_name}|{t.fidelity_name}|"
+                f"fp32d{int(t.fp32_dest_acc_en)}|pl1{int(t.packer_l1_acc)}|out_{t.out_memcfg_name}"
+            )
+            try:
+                med, mn, p = run_trial(dev, a_t, b_t, ref, t, t.out_memcfg_name, args.iters)
+                status = "PASS" if p >= args.pcc else "LOWPCC"
+                print(f"RESULT {full} median_ms={med:.3f} min_ms={mn:.3f} pcc={p:.4f} [{status}]", flush=True)
+                rows.append(_base_row(t, status, median_ms=round(med, 3), min_ms=round(mn, 3), pcc=round(p, 4)))
+                n_ok += 1
+                if status == "PASS" and (t.impl not in best or med < best[t.impl][0]):
+                    best[t.impl] = (med, full)
+            except KeyboardInterrupt:
+                print("\n# interrupted by user - writing partial results", flush=True)
+                break
+            except (RuntimeError, ValueError, MemoryError, RuntimeWarning) as exc:
+                # Expected, recoverable per-config failures: L1/DRAM OOM, bad
+                # program config, TT_FATAL/TT_THROW at program build, PCC-time
+                # reshape mismatch. These throw at COMPILE (before launch), so the
+                # device is not wedged - log and keep sweeping.
+                msg = f"{type(exc).__name__}: {str(exc)[:180]}"
+                kind = "OOM" if _looks_like_oom(exc) else "SKIP"
+                print(f"{kind} {full}: {msg}", flush=True)
+                rows.append(_base_row(t, kind, note=msg))
+                n_skip += 1
+            except BaseException as exc:  # noqa: BLE001 - last-resort guard
+                # Anything unexpected (e.g. a hard device error). Record it,
+                # probe device health, and continue if the device still responds.
+                msg = f"{type(exc).__name__}: {str(exc)[:180]}"
+                print(f"FATAL {full}: {msg}", flush=True)
+                rows.append(_base_row(t, "FATAL", note=msg))
+                n_fatal += 1
+                if not _device_alive(dev):
+                    print("# device no longer responsive - aborting sweep, writing partial results", flush=True)
+                    break
+    finally:
+        try:
+            ttnn.close_mesh_device(dev)
+        except Exception:
+            pass
+    print(f"\n# trials: {n_ok} ran, {n_skip} skipped/oom, {n_fatal} fatal", flush=True)
+
+    print("\n# ==== BEST (fastest PCC-passing) per implementation ====")
+    for impl in args.impl:
+        if impl in best:
+            print(f"BEST {impl}: median_ms={best[impl][0]:.3f}  {best[impl][1]}")
+        else:
+            print(f"BEST {impl}: (no PCC-passing config)")
+
+    if args.csv:
+        p = Path(args.csv)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        cols = sorted({k for r in rows for k in r})
+        with open(p, "w", newline="") as f:
+            w = csv.DictWriter(f, fieldnames=cols)
+            w.writeheader()
+            w.writerows(rows)
+        print(f"# wrote {len(rows)} rows to {p}")
+
+
+if __name__ == "__main__":
+    main()

--- a/models/demos/gpt_oss/tests/sweeps/matmul_sweep.py
+++ b/models/demos/gpt_oss/tests/sweeps/matmul_sweep.py
@@ -37,9 +37,17 @@ from __future__ import annotations
 import argparse
 import csv
 import itertools
+import json
+import os
 import time
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from pathlib import Path
+
+try:
+    from tqdm import tqdm
+except Exception:  # tqdm optional
+    tqdm = None
 
 import torch
 
@@ -414,6 +422,12 @@ def main():
         "--in0-block-w", type=int, nargs="*", default=[], help="fix matmul1d/2d in0_block_w (tiles); empty=all divisors"
     )
     ap.add_argument("--csv", type=str, default="", help="write results CSV to this path")
+    ap.add_argument(
+        "--progress-file",
+        type=str,
+        default="",
+        help="write a live JSON progress file (default: <csv>.progress.json, or ./matmul_sweep.progress.json)",
+    )
     ap.add_argument("--seed", type=int, default=0)
     args = ap.parse_args()
 
@@ -469,10 +483,57 @@ def main():
             **t.extra,
         }
 
+    # Resolve progress-file path: explicit flag > alongside CSV > cwd.
+    if args.progress_file:
+        progress_path = Path(args.progress_file)
+    elif args.csv:
+        progress_path = Path(args.csv).with_suffix(".progress.json")
+    else:
+        progress_path = Path("matmul_sweep.progress.json")
+    progress_path.parent.mkdir(parents=True, exist_ok=True)
+
+    total = len(trials)
+    start_ts = time.perf_counter()
+
+    def write_progress(done, current_label, finished=False):
+        """Atomically write a small JSON snapshot so an external observer can poll
+        sweep progress at any time (elapsed, ETA, per-status counts)."""
+        elapsed = time.perf_counter() - start_ts
+        rate = done / elapsed if elapsed > 0 and done > 0 else 0.0
+        remaining = total - done
+        eta = remaining / rate if rate > 0 else None
+        snap = {
+            "updated": datetime.now(timezone.utc).isoformat(),
+            "pid": os.getpid(),
+            "gemm": f"A[{args.M},{args.K}]@B[{args.K},{args.N}]",
+            "grid": args.grid,
+            "total": total,
+            "done": done,
+            "remaining": remaining,
+            "percent": round(100.0 * done / total, 2) if total else 100.0,
+            "ran": n_ok,
+            "skipped_oom": n_skip,
+            "fatal": n_fatal,
+            "elapsed_s": round(elapsed, 1),
+            "eta_s": round(eta, 1) if eta is not None else None,
+            "avg_s_per_trial": round(1.0 / rate, 3) if rate > 0 else None,
+            "current": current_label,
+            "finished": finished,
+            "csv": str(Path(args.csv)) if args.csv else None,
+        }
+        tmp = progress_path.with_suffix(progress_path.suffix + ".tmp")
+        with open(tmp, "w") as f:
+            json.dump(snap, f, indent=2)
+        os.replace(tmp, progress_path)
+
+    write_progress(0, "(starting)")
+    print(f"# progress file: {progress_path}", flush=True)
+
     dev = ttnn.open_mesh_device(ttnn.MeshShape(1, 1))
     rows = []
     best = {}
     n_ok = n_skip = n_fatal = 0
+    bar = tqdm(total=total, unit="cfg", dynamic_ncols=True) if tqdm is not None else None
     try:
         for i, t in enumerate(trials):
             full = (
@@ -509,8 +570,17 @@ def main():
                 n_fatal += 1
                 if not _device_alive(dev):
                     print("# device no longer responsive - aborting sweep, writing partial results", flush=True)
+                    write_progress(i + 1, full)
                     break
+            # End of iteration (all non-break paths): update live progress.
+            if bar is not None:
+                bar.update(1)
+                bar.set_postfix_str(f"ok={n_ok} skip={n_skip} fatal={n_fatal}", refresh=False)
+            write_progress(i + 1, full)
     finally:
+        if bar is not None:
+            bar.close()
+        write_progress(min(n_ok + n_skip + n_fatal, total), "(done)", finished=True)
         try:
             ttnn.close_mesh_device(dev)
         except Exception:

--- a/models/demos/gpt_oss/tests/sweeps/matmul_sweep.py
+++ b/models/demos/gpt_oss/tests/sweeps/matmul_sweep.py
@@ -526,13 +526,13 @@ def main():
             json.dump(snap, f, indent=2)
         os.replace(tmp, progress_path)
 
+    n_ok = n_skip = n_fatal = 0
     write_progress(0, "(starting)")
     print(f"# progress file: {progress_path}", flush=True)
 
     dev = ttnn.open_mesh_device(ttnn.MeshShape(1, 1))
     rows = []
     best = {}
-    n_ok = n_skip = n_fatal = 0
     bar = tqdm(total=total, unit="cfg", dynamic_ncols=True) if tqdm is not None else None
     try:
         for i, t in enumerate(trials):

--- a/models/demos/gpt_oss/tests/sweeps/moe_sparse_matmul_sweep.py
+++ b/models/demos/gpt_oss/tests/sweeps/moe_sparse_matmul_sweep.py
@@ -1,35 +1,67 @@
 # SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-"""MoE sparse_matmul core-grid sweep for gpt-oss-20b decode.
+"""Generalized MoE sparse_matmul program-config sweep -- a CLI tool.
 
-Reference: models/demos/gpt_oss/tests/sweeps/matmul_sweep.py (same RESULT/BEST/CSV
-structure). This variant targets the *sparse* matmul used by the MoE experts, whose
-dominant tunable is the compute grid (decode_gate_up_cores / decode_down_cores in
-expert_configs.py).
+Sibling of models/demos/gpt_oss/tests/sweeps/matmul_sweep.py (same RESULT/BEST/CSV
+structure + GB/s / BW-percent reporting), but for ttnn.sparse_matmul (the MoE expert
+GEMM) instead of the dense ttnn.matmul. Give it the sparse GEMM dims and it sweeps the
+program configuration (core grid, in0_block_w, out_subblock) x fidelity x dtype,
+timing each on device, checking PCC against a torch reference, and reporting the
+achieved DRAM bandwidth. It prints a RESULT line per config, writes a CSV, and
+reports the BEST (fastest PCC-passing) config.
 
-The decode expert GEMM is, per the real op (GPTOSS_SHAPE_DBG dump):
-    hidden_states [1, 1, M=1, K=2880]   (M padded to a tile = 32 rows on device)
-    weight        [1, E=32, K=2880, N=2880]
-    sparsity      [1, 1, 1, E=32]       (4 of 32 experts active)
-    -> Nt = ceil(N/32) = 90
+The sparse GEMM is a batch of per-expert matmuls gated by a sparsity vector:
+    activation  [1, 1 or E, M=1, K]        (shared over experts, or per-expert)
+    weight      [1, E, K, N]               (one [K,N] slice per expert)
+    sparsity    [1, 1, 1, E]               (`active` of E experts non-zero)
+    -> only `active` experts are actually computed; Nt = ceil(N/32).
+
+Which operand is sparse is selectable:
+    --sparse-input b (default): activation shared [1,1,1,K], weight-sparse (the
+        gpt-oss gate/up projection). Alias: --proj gate_up.
+    --sparse-input a: activation per-expert [1,E,1,K], is_input_a_sparse=True (the
+        gpt-oss down projection). Alias: --proj down.
 
 We sweep (core_x, core_y) grids. For a 1D mcast_in0 sparse matmul the kernel needs
     per_core_N = ceil(Nt / num_cores)   and    ceil(Nt / per_core_N) == num_cores
 (rectangularity). Grids that violate this are skipped up front.
 
-WHY SUBPROCESS-PER-TRIAL:
-    sparse_matmul (mcast_in0) can *deadlock the device* for some configs (e.g. small
-    core counts / large per_core_N, or a wrong nnz). A deadlock is NOT a Python
-    exception -- it hangs the process on a device sync forever and wedges the board,
-    which would otherwise kill the whole sweep. So each grid is run in an isolated
-    worker subprocess with a hard wall-clock timeout. If the worker exceeds it we
-    treat the config as HANG, reset the board (tt-smi -r), and continue to the next
-    grid. One bad config can no longer take down the run.
+AVOIDING DEADLOCKS / HANGS  (applies to ALL MoE models, not just gpt-oss):
+    These are properties of the ttnn.sparse_matmul `mcast_in0` KERNEL (the multicast
+    sender<->receiver semaphore handshake), NOT of any particular model. Any MoE that
+    calls sparse_matmul with these program configs will hit the same deadlocks, so the
+    rules below are general. Empirically observed deadlock modes on Blackhole:
+      1. TINY CORE GRIDS (num_cores below ~12): the in0 multicast handshake wedges
+         when there are too few receiver cores. --min-cores skips these (default 12).
+      2. out_subblock_w > 1 that cannot cleanly subdivide per_core_N into >=2 blocks
+         (e.g. per_core_N=2 with osw=2 -> a single N-block -> the mcast loop hangs).
+         Even when it *can* subdivide, osw>1 is fragile AND never wins for these
+         memory-bound decode GEMMs (out_subblock_w=1 was fastest in every sweep).
+         => DEFAULT is --out-subblock-ws 1. Only raise it deliberately + expect hangs.
+      3. A STATIC nnz that != count_nonzero(sparsity): the receivers loop a fixed
+         count while the sender mcasts a different count -> noc_semaphore_wait hang.
+         => Use nnz=None (runtime-inferred, the default) unless you know the exact count.
+    A deadlock is NOT a Python exception -- it hangs the process on a device sync
+    forever and wedges the board. So (defense in depth) each config runs in an isolated
+    worker subprocess with a hard wall-clock timeout; on timeout we mark it HANG, reset
+    the board (tt-smi -r), and continue. The defaults above avoid known-hang configs up
+    front so the subprocess timeout is only a last resort, not the primary mechanism.
 
-Usage:
+WHY SUBPROCESS-PER-TRIAL:
+    See mode (1)-(3) above -- a hung config would otherwise wedge the board and kill
+    the whole sweep. Subprocess isolation + timeout + board reset contains it.
+
+Examples
+  # gpt-oss-20b decode gate/up (fused [gate|up], N=5760), full knob sweep
   python models/demos/gpt_oss/tests/sweeps/moe_sparse_matmul_sweep.py --proj gate_up \
+      --K 2880 --N 5760 --experts 32 --active 4 \
+      --in0-block-ws 1 2 3 5 --out-subblock-ws 1 --fidelities LoFi HiFi2 \
       --csv models/demos/gpt_oss/tests/sweeps/out/gate_up.csv
+
+  # Arbitrary sparse GEMM: 16 experts, 2 active, K=4096 N=4096, weight sparse
+  python models/demos/gpt_oss/tests/sweeps/moe_sparse_matmul_sweep.py \
+      --sparse-input b --experts 16 --active 2 --K 4096 --N 4096
 """
 
 from __future__ import annotations
@@ -58,6 +90,23 @@ TILE = 32
 
 DTYPES = {"bfloat16": ttnn.bfloat16, "bfloat8_b": ttnn.bfloat8_b, "bfloat4_b": ttnn.bfloat4_b}
 FIDELITIES = {"LoFi": ttnn.MathFidelity.LoFi, "HiFi2": ttnn.MathFidelity.HiFi2, "HiFi4": ttnn.MathFidelity.HiFi4}
+MEMCFGS = {"dram": ttnn.DRAM_MEMORY_CONFIG, "l1": ttnn.L1_MEMORY_CONFIG}
+
+# Blackhole p150 peak DRAM BW (GDDR6). Used to report achieved BW% so sparse
+# decode configs can be compared against the ~50% MoE bandwidth target.
+PEAK_DRAM_BW = 512e9
+DTYPE_BYTES = {"bfloat16": 2.0, "bfloat8_b": 1.0625, "bfloat4_b": 0.5625}
+
+
+def achieved_bw(active, K, N, weight_dtype, act_dtype, median_ms):
+    """GB/s moved by a sparse_matmul: only `active` experts are computed, so
+    weights = active*K*N (dominant), activations = active*K, output = active*N.
+    Returns (GB/s, pct_of_peak)."""
+    wb = DTYPE_BYTES.get(weight_dtype, 2.0)
+    ab = DTYPE_BYTES.get(act_dtype, 2.0)
+    bytes_moved = active * (K * N * wb) + active * (K * ab) + active * (N * 2.0)
+    gbs = bytes_moved / (median_ms / 1e3)
+    return gbs, 100.0 * gbs / PEAK_DRAM_BW
 
 
 def pcc(a: torch.Tensor, b: torch.Tensor) -> float:
@@ -78,14 +127,20 @@ def rectangular(Nt: int, num_cores: int) -> tuple[bool, int]:
     return ok, per_core_N
 
 
-def gen_grids(Nt: int, grid_max_x: int, grid_max_y: int, extra):
-    """Enumerate (cx, cy) grids whose num_cores gives a rectangular tiling of Nt."""
+def gen_grids(Nt: int, grid_max_x: int, grid_max_y: int, extra, min_cores: int = 1):
+    """Enumerate (cx, cy) grids whose num_cores gives a rectangular tiling of Nt.
+
+    min_cores skips tiny grids: sparse_matmul (mcast_in0) with a 1x1 / very small
+    core grid DEADLOCKS the device (documented; the in0 mcast sender/receiver
+    handshake wedges). Those aren't useful configs anyway (decode uses 90 cores),
+    so filtering them out avoids burning the per-trial timeout on guaranteed hangs.
+    """
     seen = set()
     trials = []
     for cy in range(1, grid_max_y + 1):
         for cx in range(1, grid_max_x + 1):
             nc = cx * cy
-            if nc in seen:
+            if nc in seen or nc < min_cores:
                 continue
             ok, pcn = rectangular(Nt, nc)
             if not ok:
@@ -94,7 +149,7 @@ def gen_grids(Nt: int, grid_max_x: int, grid_max_y: int, extra):
             trials.append((cx, cy, nc, pcn))
     # Always include any explicitly requested core counts (as near-square grids).
     for nc in extra:
-        if nc in seen:
+        if nc in seen or nc < min_cores:
             continue
         ok, pcn = rectangular(Nt, nc)
         if not ok:
@@ -112,17 +167,31 @@ def gen_grids(Nt: int, grid_max_x: int, grid_max_y: int, extra):
     return trials
 
 
-def build_pc(cx, cy, per_core_N, in0_block_w, Kt):
-    # snap in0_block_w to a divisor of Kt (kernel asserts Kt % in0_block_w == 0)
+def snap_ibw(in0_block_w, Kt):
+    """Snap in0_block_w to a divisor of Kt (kernel asserts Kt % in0_block_w == 0)."""
     ibw = in0_block_w
     if Kt % ibw != 0:
         divs = [d for d in range(2, ibw + 1) if Kt % d == 0]
         ibw = max(divs) if divs else Kt
+    return ibw
+
+
+def build_pc(cx, cy, per_core_N, in0_block_w, Kt, out_subblock_h=1, out_subblock_w=1):
+    ibw = snap_ibw(in0_block_w, Kt)
+    # out_subblock_w must divide per_core_N; out_subblock_h must divide per_core_M (=1).
+    # Also the DST register caps out_subblock_h*out_subblock_w (<=8 for bf8/bf16 dest).
+    osw = out_subblock_w
+    if per_core_N % osw != 0:
+        divs = [d for d in range(osw, 0, -1) if per_core_N % d == 0]
+        osw = divs[0] if divs else 1
+    osh = out_subblock_h if (1 % out_subblock_h == 0) else 1
+    if osh * osw > 8:
+        osw = max(1, 8 // osh)
     return ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
         compute_with_storage_grid_size=ttnn.CoreCoord(cx, cy),
         in0_block_w=ibw,
-        out_subblock_h=1,
-        out_subblock_w=1,
+        out_subblock_h=osh,
+        out_subblock_w=osw,
         out_block_h=1,
         out_block_w=1,
         per_core_M=1,
@@ -148,7 +217,7 @@ def make_inputs(args):
     spars = torch.zeros(1, 1, 1, E, dtype=torch.bfloat16)
     spars[..., : args.active] = 1.0
     ref = torch.zeros(args.active, N, dtype=torch.float32)
-    if args.proj == "down":
+    if args.sparse_input == "a":
         # Per-expert activation; only active experts carry data.
         act = torch.zeros(1, E, 1, K, dtype=torch.bfloat16)
         act[0, : args.active, 0, :] = torch.randn(args.active, K, dtype=torch.bfloat16) * 0.05
@@ -174,23 +243,27 @@ def run_worker(args):
         E, K, N = args.experts, args.K, args.N
         Kt, Nt = K // TILE, N // TILE
         act, weight, spars, ref = make_inputs(args)
-        is_a_sparse = args.proj == "down"
+        is_a_sparse = args.sparse_input == "a"
         dev = ttnn.open_mesh_device(ttnn.MeshShape(1, 1))
         output_tile = ttnn.Tile([32, 32])
         try:
+            # Memory placement is a swept axis. Defaults match the in-model decode
+            # path: activation/output in L1, weights in DRAM (expert weights are too
+            # large to pin in L1, but a placement sweep confirms this). Pinning the
+            # reloaded weight in L1 can raise achieved BW when it fits.
             h_t = ttnn.from_torch(
                 act,
                 dtype=DTYPES[args.act_dtype],
                 layout=ttnn.TILE_LAYOUT,
                 device=dev,
-                memory_config=ttnn.L1_MEMORY_CONFIG,
+                memory_config=MEMCFGS[args.act_mem],
             )
             w_t = ttnn.from_torch(
                 weight,
                 dtype=DTYPES[args.dtype],
                 layout=ttnn.TILE_LAYOUT,
                 device=dev,
-                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                memory_config=MEMCFGS[args.weight_mem],
             )
             s_t = ttnn.from_torch(
                 spars,
@@ -199,7 +272,15 @@ def run_worker(args):
                 device=dev,
                 memory_config=ttnn.L1_MEMORY_CONFIG,
             )
-            pc = build_pc(args.cx, args.cy, args.pcn, args.in0_block_w, Kt)
+            pc = build_pc(
+                args.cx,
+                args.cy,
+                args.pcn,
+                args.in0_block_w,
+                Kt,
+                out_subblock_h=args.out_subblock_h,
+                out_subblock_w=args.out_subblock_w,
+            )
 
             # nnz semantics (see ttnn.sparse_matmul docs + decode.py):
             #   None -> inferred at runtime (what production uses; robust when the
@@ -208,6 +289,13 @@ def run_worker(args):
             #   int  -> static; MUST equal count_nonzero(sparsity) or the device
             #           deadlocks. We only ever pass args.active (== our count).
             nnz_val = None if args.nnz < 0 else args.nnz
+            ckc = ttnn.init_device_compute_kernel_config(
+                dev.arch(),
+                math_fidelity=FIDELITIES[args.fidelity],
+                math_approx_mode=False,
+                fp32_dest_acc_en=bool(args.fp32_dest),
+                packer_l1_acc=bool(args.packer_l1_acc),
+            )
 
             def once():
                 # down projection feeds the per-expert activation as the sparse input.
@@ -217,10 +305,11 @@ def run_worker(args):
                     sparsity=s_t,
                     nnz=nnz_val,
                     is_input_a_sparse=is_a_sparse,
-                    memory_config=ttnn.L1_MEMORY_CONFIG,
+                    memory_config=MEMCFGS[args.out_mem],
                     output_tile=output_tile,
                     program_config=pc,
                     dtype=DTYPES[args.act_dtype],
+                    compute_kernel_config=ckc,
                 )
 
             out = once()
@@ -242,14 +331,21 @@ def run_worker(args):
             samples.sort()
             med, mn = samples[len(samples) // 2], samples[0]
             status = "PASS" if p >= args.pcc else "LOWPCC"
+            gbs, bwpct = achieved_bw(args.active, K, N, args.dtype, args.act_dtype, med)
             result = {
                 "status": status,
                 "median_ms": round(med, 4),
                 "min_ms": round(mn, 4),
                 "pcc": round(p, 4),
+                "gbs": round(gbs / 1e9, 1),
+                "bw_pct": round(bwpct, 1),
                 "note": "",
             }
-            print(f"RESULT worker median_ms={med:.4f} min_ms={mn:.4f} pcc={p:.4f} [{status}]", flush=True)
+            print(
+                f"RESULT worker median_ms={med:.4f} min_ms={mn:.4f} pcc={p:.4f} "
+                f"GB/s={gbs/1e9:.0f} BW%={bwpct:.1f} [{status}]",
+                flush=True,
+            )
         finally:
             try:
                 ttnn.close_mesh_device(dev)
@@ -306,9 +402,72 @@ def run_orchestrator(args):
         flush=True,
     )
 
-    grids = gen_grids(Nt, args.grid[0], args.grid[1], args.extra_cores)
-    total = len(grids)
-    print(f"# {total} rectangular grids to try (per-trial timeout={args.trial_timeout}s)", flush=True)
+    import itertools as _it
+
+    grids = gen_grids(Nt, args.grid[0], args.grid[1], args.extra_cores, min_cores=args.min_cores)
+    # Full cartesian sweep: grid x in0_block_w x out_subblock_w x out_subblock_h
+    #   x fidelity x act_dtype x fp32_dest x packer_l1_acc.
+    # Each combo runs in its own worker subprocess (deadlock-isolated).
+    Kt = K // TILE
+    trials = []
+    seen_eff = set()
+    for cx, cy, nc, pcn in grids:
+        for ibw, osw, osh, fid, adt, fp32, pl1, wmem, omem, amem in _it.product(
+            args.in0_block_ws,
+            args.out_subblock_ws,
+            args.out_subblock_hs,
+            args.fidelities,
+            args.act_dtypes,
+            args.fp32_dests,
+            args.packer_l1_accs,
+            args.weight_mems,
+            args.out_mems,
+            args.act_mems,
+        ):
+            # Dedup on the EFFECTIVE (snapped) config: ibw snaps to a divisor of
+            # Kt, osw snaps to a divisor of per_core_N (capped by DST). Many raw
+            # combos collapse to the same kernel config on high-core grids, so
+            # skip the duplicates instead of re-timing them for hours.
+            eff_ibw = snap_ibw(ibw, Kt)
+            eff_osw = osw if pcn % osw == 0 else max([d for d in range(osw, 0, -1) if pcn % d == 0] or [1])
+            if osh * eff_osw > 8:
+                eff_osw = max(1, 8 // osh)
+            # DEADLOCK GUARD (empirically verified): sparse_matmul mcast_in0 wedges
+            # the device when per_core_N cannot be subdivided into >=2 N-blocks of
+            # size out_subblock_w (e.g. 90 cores -> pcn=2, osw=2 -> 1 block -> hang).
+            # It PASSes when pcn >= 2*osw (e.g. 12 cores -> pcn=15, osw=2 -> ok).
+            if eff_osw > 1 and pcn < 2 * eff_osw:
+                continue
+            key = (cx, cy, pcn, eff_ibw, eff_osw, osh, fid, adt, fp32, pl1, wmem, omem, amem)
+            if key in seen_eff:
+                continue
+            seen_eff.add(key)
+            trials.append(
+                dict(
+                    cx=cx,
+                    cy=cy,
+                    nc=nc,
+                    pcn=pcn,
+                    ibw=eff_ibw,
+                    osw=eff_osw,
+                    osh=osh,
+                    fid=fid,
+                    adt=adt,
+                    fp32=fp32,
+                    pl1=pl1,
+                    wmem=wmem,
+                    omem=omem,
+                    amem=amem,
+                )
+            )
+    if args.max_configs and len(trials) > args.max_configs:
+        print(f"# generated {len(trials)} trials, capping to --max-configs={args.max_configs}", flush=True)
+        trials = trials[: args.max_configs]
+    total = len(trials)
+    print(
+        f"# {len(grids)} rectangular grids x knobs = {total} trials (per-trial timeout={args.trial_timeout}s)",
+        flush=True,
+    )
 
     if args.progress_file:
         progress_path = Path(args.progress_file)
@@ -367,6 +526,8 @@ def run_orchestrator(args):
         "--worker",
         "--proj",
         args.proj,
+        "--sparse-input",
+        args.sparse_input,
         "--experts",
         str(E),
         "--active",
@@ -377,12 +538,6 @@ def run_orchestrator(args):
         str(N),
         "--dtype",
         args.dtype,
-        "--act-dtype",
-        args.act_dtype,
-        "--fidelity",
-        args.fidelity,
-        "--in0-block-w",
-        str(args.in0_block_w),
         "--iters",
         str(args.iters),
         "--pcc",
@@ -395,17 +550,49 @@ def run_orchestrator(args):
         str(result_file),
     ]
 
-    for gi, (cx, cy, nc, pcn) in enumerate(grids):
-        label = f"grid{cx}x{cy}_nc{nc}_pcN{pcn}"
+    for gi, t in enumerate(trials):
+        cx, cy, nc, pcn = t["cx"], t["cy"], t["nc"], t["pcn"]
+        label = (
+            f"grid{cx}x{cy}_nc{nc}_pcN{pcn}_ib{t['ibw']}_sb{t['osh']}x{t['osw']}"
+            f"_{t['fid']}_{t['adt']}_fp32d{t['fp32']}_pl1{t['pl1']}"
+            f"_w{t['wmem']}_o{t['omem']}_a{t['amem']}"
+        )
         write_progress(gi, label)  # mark 'current' before launching
-        cmd = base_cmd + ["--cx", str(cx), "--cy", str(cy), "--pcn", str(pcn)]
+        cmd = base_cmd + [
+            "--cx",
+            str(cx),
+            "--cy",
+            str(cy),
+            "--pcn",
+            str(pcn),
+            "--in0-block-w",
+            str(t["ibw"]),
+            "--out-subblock-w",
+            str(t["osw"]),
+            "--out-subblock-h",
+            str(t["osh"]),
+            "--fidelity",
+            t["fid"],
+            "--act-dtype",
+            t["adt"],
+            "--fp32-dest",
+            str(t["fp32"]),
+            "--packer-l1-acc",
+            str(t["pl1"]),
+            "--weight-mem",
+            t["wmem"],
+            "--out-mem",
+            t["omem"],
+            "--act-mem",
+            t["amem"],
+        ]
         try:
             if result_file.exists():
                 result_file.unlink()
         except Exception:
             pass
 
-        status, med, mn, p, note = "CRASH", "", "", "", ""
+        status, med, mn, p, note, gbs, bwpct = "CRASH", "", "", "", "", "", ""
         try:
             proc = subprocess.run(
                 cmd, timeout=args.trial_timeout, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True
@@ -415,6 +602,7 @@ def run_orchestrator(args):
                 r = json.loads(result_file.read_text())
                 status = r.get("status", "CRASH")
                 med, mn, p, note = r.get("median_ms", ""), r.get("min_ms", ""), r.get("pcc", ""), r.get("note", "")
+                gbs, bwpct = r.get("gbs", ""), r.get("bw_pct", "")
             else:
                 status = "CRASH"
                 tail = (proc.stdout or "").strip().splitlines()[-1:] if proc.stdout else []
@@ -428,7 +616,7 @@ def run_orchestrator(args):
         if status == "PASS":
             n_pass += 1
             if best is None or (isinstance(med, (int, float)) and med < best[0]):
-                best = (med, label, nc)
+                best = (med, label, nc, bwpct)
         elif status == "LOWPCC":
             n_lowpcc += 1
         elif status == "SKIP":
@@ -439,7 +627,10 @@ def run_orchestrator(args):
             n_crash += 1
 
         if status not in ("HANG",):
-            print(f"RESULT {label} median_ms={med} min_ms={mn} pcc={p} [{status}] {note}", flush=True)
+            print(
+                f"RESULT {label} median_ms={med} min_ms={mn} pcc={p} GB/s={gbs} BW%={bwpct} [{status}] {note}",
+                flush=True,
+            )
         rows.append(
             dict(
                 proj=args.proj,
@@ -447,9 +638,21 @@ def run_orchestrator(args):
                 cy=cy,
                 num_cores=nc,
                 per_core_N=pcn,
+                in0_block_w=t["ibw"],
+                out_subblock_w=t["osw"],
+                out_subblock_h=t["osh"],
+                fidelity=t["fid"],
+                act_dtype=t["adt"],
+                fp32_dest=t["fp32"],
+                packer_l1_acc=t["pl1"],
+                weight_mem=t["wmem"],
+                out_mem=t["omem"],
+                act_mem=t["amem"],
                 median_ms=med,
                 min_ms=mn,
                 pcc=p,
+                gbs=gbs,
+                bw_pct=bwpct,
                 status=status,
                 note=note,
             )
@@ -467,14 +670,40 @@ def run_orchestrator(args):
     print(f"\n# trials: {n_pass} pass, {n_lowpcc} lowpcc, {n_skip} skip, {n_hang} hang, {n_crash} crash", flush=True)
     print("\n# ==== BEST (fastest PCC-passing) ====")
     if best:
-        print(f"BEST {args.proj}: median_ms={best[0]:.4f}  {best[1]}  (num_cores={best[2]})")
+        bw = best[3] if len(best) > 3 else ""
+        print(
+            f"BEST {args.proj} (sparse-input {args.sparse_input}): median_ms={best[0]:.4f} BW%={bw}  {best[1]}  (num_cores={best[2]})"
+        )
     else:
         print(f"BEST {args.proj}: (no PCC-passing config)")
 
     if args.csv:
         p = Path(args.csv)
         p.parent.mkdir(parents=True, exist_ok=True)
-        cols = ["proj", "cx", "cy", "num_cores", "per_core_N", "median_ms", "min_ms", "pcc", "status", "note"]
+        cols = [
+            "proj",
+            "cx",
+            "cy",
+            "num_cores",
+            "per_core_N",
+            "in0_block_w",
+            "out_subblock_w",
+            "out_subblock_h",
+            "fidelity",
+            "act_dtype",
+            "fp32_dest",
+            "packer_l1_acc",
+            "weight_mem",
+            "out_mem",
+            "act_mem",
+            "median_ms",
+            "min_ms",
+            "pcc",
+            "gbs",
+            "bw_pct",
+            "status",
+            "note",
+        ]
         with open(p, "w", newline="") as f:
             w = csv.DictWriter(f, fieldnames=cols)
             w.writeheader()
@@ -484,7 +713,21 @@ def run_orchestrator(args):
 
 def main():
     ap = argparse.ArgumentParser(description="MoE sparse_matmul core-grid sweep (subprocess-per-trial)")
-    ap.add_argument("--proj", choices=["gate_up", "down"], default="gate_up")
+    # --sparse-input is the generic knob: 'a' => activation is the sparse/per-expert
+    # operand (is_input_a_sparse=True, gpt-oss 'down'); 'b' => weight is sparse and
+    # activation is shared (gpt-oss 'gate_up'). --proj is a gpt-oss-friendly alias.
+    ap.add_argument(
+        "--sparse-input",
+        choices=["a", "b"],
+        default=None,
+        help="which operand is sparse: a=activation/per-expert (down), b=weight/shared-act (gate_up)",
+    )
+    ap.add_argument(
+        "--proj",
+        choices=["gate_up", "down"],
+        default=None,
+        help="gpt-oss alias: gate_up=>--sparse-input b, down=>--sparse-input a",
+    )
     ap.add_argument("--experts", type=int, default=32)
     ap.add_argument("--active", type=int, default=4, help="non-zero experts in sparsity")
     ap.add_argument(
@@ -496,13 +739,84 @@ def main():
     ap.add_argument("--K", type=int, default=2880)
     ap.add_argument("--N", type=int, default=2880)
     ap.add_argument("--dtype", default="bfloat4_b", choices=list(DTYPES.keys()))
+    # These accept MULTIPLE values in the orchestrator (swept); the worker reads a
+    # single scalar (the orchestrator passes one value per subprocess).
+    ap.add_argument("--act-dtypes", nargs="+", default=["bfloat8_b"], choices=list(DTYPES.keys()))
+    ap.add_argument("--fidelities", nargs="+", default=["LoFi"], choices=list(FIDELITIES.keys()))
+    ap.add_argument(
+        "--in0-block-ws",
+        type=int,
+        nargs="+",
+        default=[1, 2, 3, 5],
+        help="in0_block_w values to sweep (snapped to a divisor of Kt)",
+    )
+    ap.add_argument(
+        "--out-subblock-ws",
+        type=int,
+        nargs="+",
+        default=[1],
+        help="out_subblock_w values to sweep. DEFAULT [1]: osw>1 frequently DEADLOCKS the "
+        "sparse mcast kernel (see 'AVOIDING DEADLOCKS' in the module docstring) and never "
+        "won in any decode sweep. Only pass >1 deliberately; expect HANGs (contained by timeout).",
+    )
+    ap.add_argument(
+        "--out-subblock-hs",
+        type=int,
+        nargs="+",
+        default=[1],
+        help="out_subblock_h values to sweep (per_core_M=1 so 1 is the only valid value)",
+    )
+    ap.add_argument(
+        "--fp32-dests", type=int, nargs="+", default=[0], choices=[0, 1], help="fp32_dest_acc_en values to sweep"
+    )
+    ap.add_argument(
+        "--packer-l1-accs", type=int, nargs="+", default=[1], choices=[0, 1], help="packer_l1_acc values to sweep"
+    )
+    # Memory placement axes (default = in-model decode placement: act/out L1, weight DRAM).
+    ap.add_argument(
+        "--weight-mems",
+        nargs="+",
+        default=["dram"],
+        choices=list(MEMCFGS.keys()),
+        help="where the weight tensor lives: dram|l1. Sweep both to test if pinning the reloaded weight in L1 raises BW (may OOM for large expert weights).",
+    )
+    ap.add_argument(
+        "--out-mems",
+        nargs="+",
+        default=["l1"],
+        choices=list(MEMCFGS.keys()),
+        help="where the output tensor lives: dram|l1",
+    )
+    ap.add_argument(
+        "--act-mems",
+        nargs="+",
+        default=["l1"],
+        choices=list(MEMCFGS.keys()),
+        help="where the activation tensor lives: dram|l1",
+    )
+    # worker-only scalars (set by orchestrator per subprocess)
     ap.add_argument("--act-dtype", default="bfloat8_b", choices=list(DTYPES.keys()))
     ap.add_argument("--fidelity", default="LoFi", choices=list(FIDELITIES.keys()))
     ap.add_argument("--in0-block-w", type=int, default=2)
+    ap.add_argument("--out-subblock-h", type=int, default=1)
+    ap.add_argument("--out-subblock-w", type=int, default=1)
+    ap.add_argument("--fp32-dest", type=int, default=0)
+    ap.add_argument("--packer-l1-acc", type=int, default=1)
+    ap.add_argument("--weight-mem", default="dram", choices=list(MEMCFGS.keys()))
+    ap.add_argument("--out-mem", default="l1", choices=list(MEMCFGS.keys()))
+    ap.add_argument("--act-mem", default="l1", choices=list(MEMCFGS.keys()))
     ap.add_argument("--iters", type=int, default=6)
     ap.add_argument("--grid", type=int, nargs=2, default=[13, 10], help="max core grid x y")
     ap.add_argument("--pcc", type=float, default=0.99)
+    ap.add_argument("--max-configs", type=int, default=0, help="cap total trials (0 = no cap)")
     ap.add_argument("--extra-cores", type=int, nargs="*", default=[12, 30, 45, 90])
+    ap.add_argument(
+        "--min-cores",
+        type=int,
+        default=12,
+        help="skip grids with fewer cores. sparse_matmul mcast_in0 DEADLOCKS on tiny grids "
+        "(<~12 cores); see 'AVOIDING DEADLOCKS' in the module docstring. Do not lower below 12.",
+    )
     ap.add_argument("--csv", type=str, default="")
     ap.add_argument(
         "--progress-file",
@@ -530,6 +844,19 @@ def main():
     ap.add_argument("--pcn", type=int, default=0, help="internal (worker): per_core_N")
     ap.add_argument("--result-file", type=str, default="", help="internal (worker): where to write result JSON")
     args = ap.parse_args()
+
+    # Reconcile --proj (gpt-oss alias) and --sparse-input (generic). Keep args.proj
+    # populated (used for labels/CSV) and derive the canonical sparse-input side.
+    if args.proj is None and args.sparse_input is None:
+        args.proj, args.sparse_input = "gate_up", "b"
+    elif args.proj is not None and args.sparse_input is None:
+        args.sparse_input = "a" if args.proj == "down" else "b"
+    elif args.proj is None and args.sparse_input is not None:
+        args.proj = "down" if args.sparse_input == "a" else "gate_up"
+    else:
+        expected = "a" if args.proj == "down" else "b"
+        if args.sparse_input != expected:
+            ap.error(f"--proj {args.proj} implies --sparse-input {expected}, got {args.sparse_input}")
 
     if args.worker:
         sys.exit(run_worker(args))

--- a/models/demos/gpt_oss/tests/sweeps/moe_sparse_matmul_sweep.py
+++ b/models/demos/gpt_oss/tests/sweeps/moe_sparse_matmul_sweep.py
@@ -1,0 +1,540 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""MoE sparse_matmul core-grid sweep for gpt-oss-20b decode.
+
+Reference: models/demos/gpt_oss/tests/sweeps/matmul_sweep.py (same RESULT/BEST/CSV
+structure). This variant targets the *sparse* matmul used by the MoE experts, whose
+dominant tunable is the compute grid (decode_gate_up_cores / decode_down_cores in
+expert_configs.py).
+
+The decode expert GEMM is, per the real op (GPTOSS_SHAPE_DBG dump):
+    hidden_states [1, 1, M=1, K=2880]   (M padded to a tile = 32 rows on device)
+    weight        [1, E=32, K=2880, N=2880]
+    sparsity      [1, 1, 1, E=32]       (4 of 32 experts active)
+    -> Nt = ceil(N/32) = 90
+
+We sweep (core_x, core_y) grids. For a 1D mcast_in0 sparse matmul the kernel needs
+    per_core_N = ceil(Nt / num_cores)   and    ceil(Nt / per_core_N) == num_cores
+(rectangularity). Grids that violate this are skipped up front.
+
+WHY SUBPROCESS-PER-TRIAL:
+    sparse_matmul (mcast_in0) can *deadlock the device* for some configs (e.g. small
+    core counts / large per_core_N, or a wrong nnz). A deadlock is NOT a Python
+    exception -- it hangs the process on a device sync forever and wedges the board,
+    which would otherwise kill the whole sweep. So each grid is run in an isolated
+    worker subprocess with a hard wall-clock timeout. If the worker exceeds it we
+    treat the config as HANG, reset the board (tt-smi -r), and continue to the next
+    grid. One bad config can no longer take down the run.
+
+Usage:
+  python models/demos/gpt_oss/tests/sweeps/moe_sparse_matmul_sweep.py --proj gate_up \
+      --csv models/demos/gpt_oss/tests/sweeps/out/gate_up.csv
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+import os
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+import torch
+
+import ttnn
+
+try:
+    from tqdm import tqdm
+except Exception:  # tqdm optional
+    tqdm = None
+
+TILE = 32
+
+DTYPES = {"bfloat16": ttnn.bfloat16, "bfloat8_b": ttnn.bfloat8_b, "bfloat4_b": ttnn.bfloat4_b}
+FIDELITIES = {"LoFi": ttnn.MathFidelity.LoFi, "HiFi2": ttnn.MathFidelity.HiFi2, "HiFi4": ttnn.MathFidelity.HiFi4}
+
+
+def pcc(a: torch.Tensor, b: torch.Tensor) -> float:
+    a = a.flatten().to(torch.float64)
+    b = b.flatten().to(torch.float64)
+    a = a - a.mean()
+    b = b - b.mean()
+    denom = (a.norm() * b.norm()).item()
+    return 1.0 if denom == 0 else (torch.dot(a, b).item() / denom)
+
+
+def rectangular(Nt: int, num_cores: int) -> tuple[bool, int]:
+    """Return (ok, per_core_N). ok iff ceil(Nt/per_core_N)==num_cores (kernel assert)."""
+    if num_cores <= 0:
+        return False, 0
+    per_core_N = (Nt + num_cores - 1) // num_cores
+    ok = ((Nt + per_core_N - 1) // per_core_N) == num_cores
+    return ok, per_core_N
+
+
+def gen_grids(Nt: int, grid_max_x: int, grid_max_y: int, extra):
+    """Enumerate (cx, cy) grids whose num_cores gives a rectangular tiling of Nt."""
+    seen = set()
+    trials = []
+    for cy in range(1, grid_max_y + 1):
+        for cx in range(1, grid_max_x + 1):
+            nc = cx * cy
+            if nc in seen:
+                continue
+            ok, pcn = rectangular(Nt, nc)
+            if not ok:
+                continue
+            seen.add(nc)
+            trials.append((cx, cy, nc, pcn))
+    # Always include any explicitly requested core counts (as near-square grids).
+    for nc in extra:
+        if nc in seen:
+            continue
+        ok, pcn = rectangular(Nt, nc)
+        if not ok:
+            continue
+        cx = min(grid_max_x, nc)
+        cy = max(1, math.ceil(nc / cx))
+        if cx * cy != nc:
+            for a in range(min(grid_max_x, nc), 0, -1):
+                if nc % a == 0 and nc // a <= grid_max_y:
+                    cx, cy = a, nc // a
+                    break
+        trials.append((cx, cy, nc, pcn))
+        seen.add(nc)
+    trials.sort(key=lambda t: t[2])
+    return trials
+
+
+def build_pc(cx, cy, per_core_N, in0_block_w, Kt):
+    # snap in0_block_w to a divisor of Kt (kernel asserts Kt % in0_block_w == 0)
+    ibw = in0_block_w
+    if Kt % ibw != 0:
+        divs = [d for d in range(2, ibw + 1) if Kt % d == 0]
+        ibw = max(divs) if divs else Kt
+    return ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+        compute_with_storage_grid_size=ttnn.CoreCoord(cx, cy),
+        in0_block_w=ibw,
+        out_subblock_h=1,
+        out_subblock_w=1,
+        out_block_h=1,
+        out_block_w=1,
+        per_core_M=1,
+        per_core_N=per_core_N,
+        fuse_batch=False,
+        fused_activation=None,
+        mcast_in0=True,
+    )
+
+
+def make_inputs(args):
+    """Deterministic torch tensors + reference (shared by worker; seeded).
+
+    Two op shapes, matching models/demos/gpt_oss/tt/experts/decode.py:
+      gate_up: act=hidden [1,1,1,K] (shared across experts, is_input_b_sparse),
+               weight [1,E,K,N]; K=hidden, N=intermediate.
+      down:    act=down_input [1,E,1,K] (per-expert, is_input_a_sparse=True),
+               weight [1,E,K,N]; K=intermediate, N=hidden.
+    """
+    E, K, N = args.experts, args.K, args.N
+    torch.manual_seed(args.seed)
+    weight = torch.randn(1, E, K, N, dtype=torch.bfloat16) * 0.05
+    spars = torch.zeros(1, 1, 1, E, dtype=torch.bfloat16)
+    spars[..., : args.active] = 1.0
+    ref = torch.zeros(args.active, N, dtype=torch.float32)
+    if args.proj == "down":
+        # Per-expert activation; only active experts carry data.
+        act = torch.zeros(1, E, 1, K, dtype=torch.bfloat16)
+        act[0, : args.active, 0, :] = torch.randn(args.active, K, dtype=torch.bfloat16) * 0.05
+        for e in range(args.active):
+            ref[e, :] = act[0, e, 0].to(torch.float32) @ weight[0, e].to(torch.float32)
+    else:
+        # Shared activation across all experts.
+        act = torch.randn(1, 1, 1, K, dtype=torch.bfloat16) * 0.05
+        for e in range(args.active):
+            ref[e, :] = act[0, 0, 0].to(torch.float32) @ weight[0, e].to(torch.float32)
+    return act, weight, spars, ref
+
+
+# ---------------------------------------------------------------------------
+# WORKER: run exactly one grid config, write a JSON result, exit.
+# Invoked as a subprocess by the orchestrator so a device deadlock can be
+# killed by wall-clock timeout without taking down the whole sweep.
+# ---------------------------------------------------------------------------
+def run_worker(args):
+    result = {"status": "CRASH", "median_ms": "", "min_ms": "", "pcc": "", "note": "worker did not finish"}
+    rf = Path(args.result_file)
+    try:
+        E, K, N = args.experts, args.K, args.N
+        Kt, Nt = K // TILE, N // TILE
+        act, weight, spars, ref = make_inputs(args)
+        is_a_sparse = args.proj == "down"
+        dev = ttnn.open_mesh_device(ttnn.MeshShape(1, 1))
+        output_tile = ttnn.Tile([32, 32])
+        try:
+            h_t = ttnn.from_torch(
+                act,
+                dtype=DTYPES[args.act_dtype],
+                layout=ttnn.TILE_LAYOUT,
+                device=dev,
+                memory_config=ttnn.L1_MEMORY_CONFIG,
+            )
+            w_t = ttnn.from_torch(
+                weight,
+                dtype=DTYPES[args.dtype],
+                layout=ttnn.TILE_LAYOUT,
+                device=dev,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            )
+            s_t = ttnn.from_torch(
+                spars,
+                dtype=ttnn.bfloat16,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+                device=dev,
+                memory_config=ttnn.L1_MEMORY_CONFIG,
+            )
+            pc = build_pc(args.cx, args.cy, args.pcn, args.in0_block_w, Kt)
+
+            # nnz semantics (see ttnn.sparse_matmul docs + decode.py):
+            #   None -> inferred at runtime (what production uses; robust when the
+            #           real non-zero count varies). Safe here since our synthetic
+            #           count is exactly args.active.
+            #   int  -> static; MUST equal count_nonzero(sparsity) or the device
+            #           deadlocks. We only ever pass args.active (== our count).
+            nnz_val = None if args.nnz < 0 else args.nnz
+
+            def once():
+                # down projection feeds the per-expert activation as the sparse input.
+                return ttnn.sparse_matmul(
+                    h_t,
+                    w_t,
+                    sparsity=s_t,
+                    nnz=nnz_val,
+                    is_input_a_sparse=is_a_sparse,
+                    memory_config=ttnn.L1_MEMORY_CONFIG,
+                    output_tile=output_tile,
+                    program_config=pc,
+                    dtype=DTYPES[args.act_dtype],
+                )
+
+            out = once()
+            ttnn.synchronize_device(dev)
+            # sparse_matmul returns a 6-D tensor [1,1,1,E,1,N]; the expert axis is dim 3.
+            # Only the first `active` expert slots are actually computed. Reshape to
+            # [E, N] and compare the active rows against the [active, N] reference.
+            got = ttnn.to_torch(out).to(torch.float32).reshape(E, N)
+            p = pcc(ref, got[: args.active, :])
+            ttnn.deallocate(out)
+
+            samples = []
+            for _ in range(args.iters):
+                t0 = time.perf_counter()
+                out = once()
+                ttnn.synchronize_device(dev)
+                samples.append((time.perf_counter() - t0) * 1e3)
+                ttnn.deallocate(out)
+            samples.sort()
+            med, mn = samples[len(samples) // 2], samples[0]
+            status = "PASS" if p >= args.pcc else "LOWPCC"
+            result = {
+                "status": status,
+                "median_ms": round(med, 4),
+                "min_ms": round(mn, 4),
+                "pcc": round(p, 4),
+                "note": "",
+            }
+            print(f"RESULT worker median_ms={med:.4f} min_ms={mn:.4f} pcc={p:.4f} [{status}]", flush=True)
+        finally:
+            try:
+                ttnn.close_mesh_device(dev)
+            except Exception:
+                pass
+    except (RuntimeError, ValueError, MemoryError) as exc:
+        result = {
+            "status": "SKIP",
+            "median_ms": "",
+            "min_ms": "",
+            "pcc": "",
+            "note": f"{type(exc).__name__}: {str(exc)[:150]}",
+        }
+        print(f"SKIP worker: {result['note']}", flush=True)
+    except BaseException as exc:  # noqa: BLE001
+        result = {
+            "status": "CRASH",
+            "median_ms": "",
+            "min_ms": "",
+            "pcc": "",
+            "note": f"{type(exc).__name__}: {str(exc)[:150]}",
+        }
+        print(f"CRASH worker: {result['note']}", flush=True)
+    finally:
+        try:
+            rf.parent.mkdir(parents=True, exist_ok=True)
+            with open(rf, "w") as f:
+                json.dump(result, f)
+        except Exception:
+            pass
+    return 0
+
+
+def reset_board(tt_smi):
+    """Hard-reset the board so a deadlocked config doesn't poison the next trial."""
+    try:
+        subprocess.run([tt_smi, "-r"], timeout=180, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        return True
+    except Exception as e:
+        print(f"# board reset FAILED: {type(e).__name__}: {e}", flush=True)
+        return False
+
+
+# ---------------------------------------------------------------------------
+# ORCHESTRATOR: generate grids, run each in a worker subprocess with a hard
+# timeout, reset the board on hang, aggregate results + live progress.
+# ---------------------------------------------------------------------------
+def run_orchestrator(args):
+    E, K, N = args.experts, args.K, args.N
+    Kt, Nt = K // TILE, N // TILE
+    print(
+        f"# MoE sparse_matmul {args.proj}: hidden[1,1,1,{K}] @ w[1,{E},{K},{N}] "
+        f"(Kt={Kt} Nt={Nt}), active={args.active}/{E}, grid_max={args.grid}",
+        flush=True,
+    )
+
+    grids = gen_grids(Nt, args.grid[0], args.grid[1], args.extra_cores)
+    total = len(grids)
+    print(f"# {total} rectangular grids to try (per-trial timeout={args.trial_timeout}s)", flush=True)
+
+    if args.progress_file:
+        progress_path = Path(args.progress_file)
+    elif args.csv:
+        progress_path = Path(args.csv).with_suffix(".progress.json")
+    else:
+        progress_path = Path("moe_sparse_sweep.progress.json")
+    progress_path.parent.mkdir(parents=True, exist_ok=True)
+
+    result_file = progress_path.with_suffix(".worker.json")
+    start_ts = time.perf_counter()
+    rows = []
+    best = None
+    n_pass = n_lowpcc = n_skip = n_hang = n_crash = 0
+
+    def write_progress(done, current_label, finished=False):
+        elapsed = time.perf_counter() - start_ts
+        rate = done / elapsed if elapsed > 0 and done > 0 else 0.0
+        remaining = total - done
+        eta = remaining / rate if rate > 0 else None
+        snap = {
+            "updated": datetime.now(timezone.utc).isoformat(),
+            "pid": os.getpid(),
+            "sweep": "moe_sparse_matmul",
+            "proj": args.proj,
+            "gemm": f"hidden[1,1,1,{K}]@w[1,{E},{K},{N}] Nt={Nt}",
+            "total": total,
+            "done": done,
+            "remaining": remaining,
+            "percent": round(100.0 * done / total, 2) if total else 100.0,
+            "pass": n_pass,
+            "lowpcc": n_lowpcc,
+            "skipped": n_skip,
+            "hang": n_hang,
+            "crash": n_crash,
+            "elapsed_s": round(elapsed, 1),
+            "eta_s": round(eta, 1) if eta is not None else None,
+            "avg_s_per_trial": round(1.0 / rate, 3) if rate > 0 else None,
+            "current": current_label,
+            "best": ({"median_ms": best[0], "label": best[1], "num_cores": best[2]} if best else None),
+            "finished": finished,
+            "csv": str(Path(args.csv)) if args.csv else None,
+        }
+        tmp = progress_path.with_suffix(progress_path.suffix + ".tmp")
+        with open(tmp, "w") as f:
+            json.dump(snap, f, indent=2)
+        os.replace(tmp, progress_path)
+
+    write_progress(0, "(starting)")
+    print(f"# progress file: {progress_path}", flush=True)
+    bar = tqdm(total=total, unit="grid", dynamic_ncols=True) if tqdm is not None else None
+
+    base_cmd = [
+        sys.executable,
+        os.path.abspath(__file__),
+        "--worker",
+        "--proj",
+        args.proj,
+        "--experts",
+        str(E),
+        "--active",
+        str(args.active),
+        "--K",
+        str(K),
+        "--N",
+        str(N),
+        "--dtype",
+        args.dtype,
+        "--act-dtype",
+        args.act_dtype,
+        "--fidelity",
+        args.fidelity,
+        "--in0-block-w",
+        str(args.in0_block_w),
+        "--iters",
+        str(args.iters),
+        "--pcc",
+        str(args.pcc),
+        "--seed",
+        str(args.seed),
+        "--nnz",
+        str(args.nnz),
+        "--result-file",
+        str(result_file),
+    ]
+
+    for gi, (cx, cy, nc, pcn) in enumerate(grids):
+        label = f"grid{cx}x{cy}_nc{nc}_pcN{pcn}"
+        write_progress(gi, label)  # mark 'current' before launching
+        cmd = base_cmd + ["--cx", str(cx), "--cy", str(cy), "--pcn", str(pcn)]
+        try:
+            if result_file.exists():
+                result_file.unlink()
+        except Exception:
+            pass
+
+        status, med, mn, p, note = "CRASH", "", "", "", ""
+        try:
+            proc = subprocess.run(
+                cmd, timeout=args.trial_timeout, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True
+            )
+            # Read the worker's structured result (survives even if stdout is noisy).
+            if result_file.exists():
+                r = json.loads(result_file.read_text())
+                status = r.get("status", "CRASH")
+                med, mn, p, note = r.get("median_ms", ""), r.get("min_ms", ""), r.get("pcc", ""), r.get("note", "")
+            else:
+                status = "CRASH"
+                tail = (proc.stdout or "").strip().splitlines()[-1:] if proc.stdout else []
+                note = f"no result file (rc={proc.returncode}) {tail}"
+        except subprocess.TimeoutExpired:
+            status = "HANG"
+            note = f"exceeded {args.trial_timeout}s -> device deadlock, board reset"
+            print(f"HANG {label}: {note}", flush=True)
+            reset_board(args.tt_smi)
+
+        if status == "PASS":
+            n_pass += 1
+            if best is None or (isinstance(med, (int, float)) and med < best[0]):
+                best = (med, label, nc)
+        elif status == "LOWPCC":
+            n_lowpcc += 1
+        elif status == "SKIP":
+            n_skip += 1
+        elif status == "HANG":
+            n_hang += 1
+        else:
+            n_crash += 1
+
+        if status not in ("HANG",):
+            print(f"RESULT {label} median_ms={med} min_ms={mn} pcc={p} [{status}] {note}", flush=True)
+        rows.append(
+            dict(
+                proj=args.proj,
+                cx=cx,
+                cy=cy,
+                num_cores=nc,
+                per_core_N=pcn,
+                median_ms=med,
+                min_ms=mn,
+                pcc=p,
+                status=status,
+                note=note,
+            )
+        )
+
+        if bar is not None:
+            bar.update(1)
+            bar.set_postfix_str(f"pass={n_pass} low={n_lowpcc} skip={n_skip} hang={n_hang}", refresh=False)
+        write_progress(gi + 1, label)
+
+    if bar is not None:
+        bar.close()
+    write_progress(total, "(done)", finished=True)
+
+    print(f"\n# trials: {n_pass} pass, {n_lowpcc} lowpcc, {n_skip} skip, {n_hang} hang, {n_crash} crash", flush=True)
+    print("\n# ==== BEST (fastest PCC-passing) ====")
+    if best:
+        print(f"BEST {args.proj}: median_ms={best[0]:.4f}  {best[1]}  (num_cores={best[2]})")
+    else:
+        print(f"BEST {args.proj}: (no PCC-passing config)")
+
+    if args.csv:
+        p = Path(args.csv)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        cols = ["proj", "cx", "cy", "num_cores", "per_core_N", "median_ms", "min_ms", "pcc", "status", "note"]
+        with open(p, "w", newline="") as f:
+            w = csv.DictWriter(f, fieldnames=cols)
+            w.writeheader()
+            w.writerows(rows)
+        print(f"# wrote {len(rows)} rows to {p}")
+
+
+def main():
+    ap = argparse.ArgumentParser(description="MoE sparse_matmul core-grid sweep (subprocess-per-trial)")
+    ap.add_argument("--proj", choices=["gate_up", "down"], default="gate_up")
+    ap.add_argument("--experts", type=int, default=32)
+    ap.add_argument("--active", type=int, default=4, help="non-zero experts in sparsity")
+    ap.add_argument(
+        "--nnz",
+        type=int,
+        default=-1,
+        help="static nnz for sparse_matmul; -1 (default) => None/runtime-inferred (production behavior)",
+    )
+    ap.add_argument("--K", type=int, default=2880)
+    ap.add_argument("--N", type=int, default=2880)
+    ap.add_argument("--dtype", default="bfloat4_b", choices=list(DTYPES.keys()))
+    ap.add_argument("--act-dtype", default="bfloat8_b", choices=list(DTYPES.keys()))
+    ap.add_argument("--fidelity", default="LoFi", choices=list(FIDELITIES.keys()))
+    ap.add_argument("--in0-block-w", type=int, default=2)
+    ap.add_argument("--iters", type=int, default=6)
+    ap.add_argument("--grid", type=int, nargs=2, default=[13, 10], help="max core grid x y")
+    ap.add_argument("--pcc", type=float, default=0.99)
+    ap.add_argument("--extra-cores", type=int, nargs="*", default=[12, 30, 45, 90])
+    ap.add_argument("--csv", type=str, default="")
+    ap.add_argument(
+        "--progress-file",
+        type=str,
+        default="",
+        help="live JSON progress file (default: <csv>.progress.json, or ./moe_sparse_sweep.progress.json)",
+    )
+    ap.add_argument("--seed", type=int, default=0)
+    # orchestration / worker plumbing
+    ap.add_argument(
+        "--trial-timeout",
+        type=float,
+        default=120.0,
+        help="per-config wall-clock timeout (s); exceeding it => HANG + board reset",
+    )
+    ap.add_argument(
+        "--tt-smi",
+        type=str,
+        default="/local/ttuser/.tenstorrent-venv/bin/tt-smi",
+        help="tt-smi binary used to reset the board after a hang",
+    )
+    ap.add_argument("--worker", action="store_true", help="internal: run a single grid config and exit")
+    ap.add_argument("--cx", type=int, default=0, help="internal (worker): grid x")
+    ap.add_argument("--cy", type=int, default=0, help="internal (worker): grid y")
+    ap.add_argument("--pcn", type=int, default=0, help="internal (worker): per_core_N")
+    ap.add_argument("--result-file", type=str, default="", help="internal (worker): where to write result JSON")
+    args = ap.parse_args()
+
+    if args.worker:
+        sys.exit(run_worker(args))
+    run_orchestrator(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/models/demos/gpt_oss/tests/sweeps/moe_sparse_matmul_sweep.py
+++ b/models/demos/gpt_oss/tests/sweeps/moe_sparse_matmul_sweep.py
@@ -193,7 +193,9 @@ def build_pc(cx, cy, per_core_N, in0_block_w, Kt, out_subblock_h=1, out_subblock
         out_subblock_h=osh,
         out_subblock_w=osw,
         out_block_h=1,
-        out_block_w=1,
+        # Lucas Chin (Anduril), PR #51514: out_block_w=1 forced in1_num_subblocks=0
+        # for osw>1, so no osw>1 config was ever really exercised. Derive from osw.
+        out_block_w=osw,
         per_core_M=1,
         per_core_N=per_core_N,
         fuse_batch=False,
@@ -436,8 +438,11 @@ def run_orchestrator(args):
             # the device when per_core_N cannot be subdivided into >=2 N-blocks of
             # size out_subblock_w (e.g. 90 cores -> pcn=2, osw=2 -> 1 block -> hang).
             # It PASSes when pcn >= 2*osw (e.g. 12 cores -> pcn=15, osw=2 -> ok).
-            if eff_osw > 1 and pcn < 2 * eff_osw:
-                continue
+            # Lucas Chin (Anduril), PR #51514: this filter was a workaround for the
+            # deadlock that out_block_w=1 caused. With out_block_w=osw it is not
+            # needed, so it is disabled to let the full osw axis run.
+            # if eff_osw > 1 and pcn < 2 * eff_osw:
+            #     continue
             key = (cx, cy, pcn, eff_ibw, eff_osw, osh, fid, adt, fp32, pl1, wmem, omem, amem)
             if key in seen_eff:
                 continue

--- a/models/demos/gpt_oss/tests/sweeps/moe_sparse_matmul_sweep.py
+++ b/models/demos/gpt_oss/tests/sweeps/moe_sparse_matmul_sweep.py
@@ -176,7 +176,7 @@ def snap_ibw(in0_block_w, Kt):
     return ibw
 
 
-def build_pc(cx, cy, per_core_N, in0_block_w, Kt, out_subblock_h=1, out_subblock_w=1):
+def build_pc(cx, cy, per_core_N, in0_block_w, Kt, out_subblock_h=1, out_subblock_w=1, obw_mult=1):
     ibw = snap_ibw(in0_block_w, Kt)
     # out_subblock_w must divide per_core_N; out_subblock_h must divide per_core_M (=1).
     # Also the DST register caps out_subblock_h*out_subblock_w (<=8 for bf8/bf16 dest).
@@ -187,6 +187,13 @@ def build_pc(cx, cy, per_core_N, in0_block_w, Kt, out_subblock_h=1, out_subblock
     osh = out_subblock_h if (1 % out_subblock_h == 0) else 1
     if osh * osw > 8:
         osw = max(1, 8 // osh)
+    # out_block_w axis. in1_num_subblocks = out_block_w / out_subblock_w, so
+    # obw_mult is that subblock count. obw_mult=1 is Lucas Chin's obw=osw;
+    # obw_mult=per_core_N/osw is obw=per_core_N. Must divide per_core_N.
+    obw = osw * max(1, obw_mult)
+    if obw > per_core_N or per_core_N % obw != 0:
+        cands = [m for m in range(max(1, obw_mult), 0, -1) if per_core_N % (osw * m) == 0]
+        obw = osw * (cands[0] if cands else 1)
     return ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
         compute_with_storage_grid_size=ttnn.CoreCoord(cx, cy),
         in0_block_w=ibw,
@@ -195,7 +202,7 @@ def build_pc(cx, cy, per_core_N, in0_block_w, Kt, out_subblock_h=1, out_subblock
         out_block_h=1,
         # Lucas Chin (Anduril), PR #51514: out_block_w=1 forced in1_num_subblocks=0
         # for osw>1, so no osw>1 config was ever really exercised. Derive from osw.
-        out_block_w=osw,
+        out_block_w=obw,
         per_core_M=1,
         per_core_N=per_core_N,
         fuse_batch=False,
@@ -282,6 +289,7 @@ def run_worker(args):
                 Kt,
                 out_subblock_h=args.out_subblock_h,
                 out_subblock_w=args.out_subblock_w,
+                obw_mult=args.obw_mult,
             )
 
             # nnz semantics (see ttnn.sparse_matmul docs + decode.py):
@@ -414,9 +422,10 @@ def run_orchestrator(args):
     trials = []
     seen_eff = set()
     for cx, cy, nc, pcn in grids:
-        for ibw, osw, osh, fid, adt, fp32, pl1, wmem, omem, amem in _it.product(
+        for ibw, osw, obwm, osh, fid, adt, fp32, pl1, wmem, omem, amem in _it.product(
             args.in0_block_ws,
             args.out_subblock_ws,
+            args.obw_mults,
             args.out_subblock_hs,
             args.fidelities,
             args.act_dtypes,
@@ -443,7 +452,12 @@ def run_orchestrator(args):
             # needed, so it is disabled to let the full osw axis run.
             # if eff_osw > 1 and pcn < 2 * eff_osw:
             #     continue
-            key = (cx, cy, pcn, eff_ibw, eff_osw, osh, fid, adt, fp32, pl1, wmem, omem, amem)
+            # effective obw_mult after the same clamping build_pc applies
+            eff_obwm = max(1, obwm)
+            if eff_osw * eff_obwm > pcn or pcn % (eff_osw * eff_obwm) != 0:
+                cands = [m for m in range(eff_obwm, 0, -1) if pcn % (eff_osw * m) == 0]
+                eff_obwm = cands[0] if cands else 1
+            key = (cx, cy, pcn, eff_ibw, eff_osw, eff_obwm, osh, fid, adt, fp32, pl1, wmem, omem, amem)
             if key in seen_eff:
                 continue
             seen_eff.add(key)
@@ -455,6 +469,7 @@ def run_orchestrator(args):
                     pcn=pcn,
                     ibw=eff_ibw,
                     osw=eff_osw,
+                    obwm=eff_obwm,
                     osh=osh,
                     fid=fid,
                     adt=adt,
@@ -558,7 +573,7 @@ def run_orchestrator(args):
     for gi, t in enumerate(trials):
         cx, cy, nc, pcn = t["cx"], t["cy"], t["nc"], t["pcn"]
         label = (
-            f"grid{cx}x{cy}_nc{nc}_pcN{pcn}_ib{t['ibw']}_sb{t['osh']}x{t['osw']}"
+            f"grid{cx}x{cy}_nc{nc}_pcN{pcn}_ib{t['ibw']}_sb{t['osh']}x{t['osw']}_obwm{t['obwm']}"
             f"_{t['fid']}_{t['adt']}_fp32d{t['fp32']}_pl1{t['pl1']}"
             f"_w{t['wmem']}_o{t['omem']}_a{t['amem']}"
         )
@@ -574,6 +589,8 @@ def run_orchestrator(args):
             str(t["ibw"]),
             "--out-subblock-w",
             str(t["osw"]),
+            "--obw-mult",
+            str(t["obwm"]),
             "--out-subblock-h",
             str(t["osh"]),
             "--fidelity",
@@ -645,6 +662,7 @@ def run_orchestrator(args):
                 per_core_N=pcn,
                 in0_block_w=t["ibw"],
                 out_subblock_w=t["osw"],
+                obw_mult=t["obwm"],
                 out_subblock_h=t["osh"],
                 fidelity=t["fid"],
                 act_dtype=t["adt"],
@@ -693,6 +711,7 @@ def run_orchestrator(args):
             "per_core_N",
             "in0_block_w",
             "out_subblock_w",
+            "obw_mult",
             "out_subblock_h",
             "fidelity",
             "act_dtype",
@@ -756,6 +775,15 @@ def main():
         help="in0_block_w values to sweep (snapped to a divisor of Kt)",
     )
     ap.add_argument(
+        "--obw-mults",
+        type=int,
+        nargs="+",
+        default=[1],
+        help="out_block_w = obw_mult * out_subblock_w (i.e. in1_num_subblocks). "
+        "1 = Lucas Chin's obw=osw. Higher explores out_block_w > out_subblock_w, "
+        "which was never tested. Must divide per_core_N.",
+    )
+    ap.add_argument(
         "--out-subblock-ws",
         type=int,
         nargs="+",
@@ -805,6 +833,7 @@ def main():
     ap.add_argument("--in0-block-w", type=int, default=2)
     ap.add_argument("--out-subblock-h", type=int, default=1)
     ap.add_argument("--out-subblock-w", type=int, default=1)
+    ap.add_argument("--obw-mult", type=int, default=1)
     ap.add_argument("--fp32-dest", type=int, default=0)
     ap.add_argument("--packer-l1-acc", type=int, default=1)
     ap.add_argument("--weight-mem", default="dram", choices=list(MEMCFGS.keys()))

--- a/models/demos/gpt_oss/tt/attention/config.py
+++ b/models/demos/gpt_oss/tt/attention/config.py
@@ -61,10 +61,15 @@ class ProgramConfig:
     decode_qkv_out_subblock_w: int = 1
 
     # Decode output projection
-    decode_out_cores: tuple[int, int] | None = None
-    decode_out_in0_block_w: int = 1
+    # o_proj [32,4096]x[4096,2880]. Swept offline (.auto/oproj_sweep.py) against the
+    # device default: 8x8 cores, in0_block_w=8, out_subblock_w=2 gives 45.13 us/op
+    # vs 93.25 us/op with no program config (-51.6%), pcc 0.9998 vs the device
+    # baseline. per_core_N = 90/64 -> 2, so num_blocks_w_dim = 2/2 = 1 and the
+    # PR #51514 wide-subblock corruption (needs nbwd>1) cannot trigger.
+    decode_out_cores: tuple[int, int] | None = (8, 8)
+    decode_out_in0_block_w: int = 8
     decode_out_out_subblock_h: int = 1
-    decode_out_out_subblock_w: int = 1
+    decode_out_out_subblock_w: int = 2
 
     # Prefill QKV projection
     prefill_qkv_cores: tuple[int, int] | None = None
@@ -149,7 +154,11 @@ class ProgramConfig:
             out_subblock_h=out_subblock_h,
             out_subblock_w=out_subblock_w,
             out_block_h=1,
-            out_block_w=1,
+            # out_block_w must follow out_subblock_w: in1_num_subblocks is
+            # out_block_w / out_subblock_w, so a hardcoded 1 makes that 0 for any
+            # out_subblock_w > 1 (the PR #51514 deadlock/corruption). Same defect
+            # that was in the expert path.
+            out_block_w=out_subblock_w,
             per_core_M=m // 32,
             per_core_N=n // 32 // (core_x * core_y),
             fuse_batch=False,

--- a/models/demos/gpt_oss/tt/attention/config.py
+++ b/models/demos/gpt_oss/tt/attention/config.py
@@ -55,10 +55,18 @@ class ProgramConfig:
 
     # Matmul program config parameters (optional - None means no program config)
     # Decode QKV projection
-    decode_qkv_cores: tuple[int, int] | None = None
-    decode_qkv_in0_block_w: int = 1
+    # qkv [32,2880]x[2880,5120], IN0 is L1_INTERLEAVED in-model -- which is the
+    # layout the offline sweep used, so the sweep result is applicable here (unlike
+    # o_proj, whose IN0 is L1_WIDTH_SHARDED and takes a different program factory).
+    # .auto/qkv_sweep.py: 8x5 cores, in0_block_w=2, out_subblock_w=4 -> 50.32 us/op
+    # vs 63.66 us/op default, pcc 0.9998 vs the device baseline.
+    # per_core_N = Nt/cores = 160/40 = 4 exactly, so the floor-division bug that
+    # silently invalidated the o_proj config does not apply. out_block_w = osw = 4
+    # gives num_blocks_w_dim = 1, so the PR #51514 corruption cannot trigger.
+    decode_qkv_cores: tuple[int, int] | None = (8, 5)
+    decode_qkv_in0_block_w: int = 2
     decode_qkv_out_subblock_h: int = 1
-    decode_qkv_out_subblock_w: int = 1
+    decode_qkv_out_subblock_w: int = 4
 
     # Decode output projection
     decode_out_cores: tuple[int, int] | None = None
@@ -149,9 +157,20 @@ class ProgramConfig:
             out_subblock_h=out_subblock_h,
             out_subblock_w=out_subblock_w,
             out_block_h=1,
-            out_block_w=1,
-            per_core_M=m // 32,
-            per_core_N=n // 32 // (core_x * core_y),
+            # out_block_w must follow out_subblock_w: in1_num_subblocks is
+            # out_block_w / out_subblock_w, so a hardcoded 1 makes that 0 for any
+            # out_subblock_w > 1 (the PR #51514 defect, also present in the expert
+            # path until it was fixed there).
+            out_block_w=out_subblock_w,
+            # CEIL on the row count too: decode passes the LOGICAL seq len (1), so
+            # floor gave per_core_M = 1//32 = 0 and the whole config was invalid --
+            # ttnn silently fell back to its default heuristic. The tensor is
+            # tile-padded to 32 rows, so 1 row still needs per_core_M = 1.
+            per_core_M=max(1, -(-m // 32)),
+            # CEIL, not floor. Nt is not always divisible by the core count, and a
+            # too-small per_core_N silently produces an invalid config that ttnn
+            # ignores (this is what made the o_proj attempt a no-op).
+            per_core_N=-(-(n // 32) // (core_x * core_y)),
             fuse_batch=False,
             fused_activation=None,
             mcast_in0=True,

--- a/models/demos/gpt_oss/tt/attention/config.py
+++ b/models/demos/gpt_oss/tt/attention/config.py
@@ -61,15 +61,10 @@ class ProgramConfig:
     decode_qkv_out_subblock_w: int = 1
 
     # Decode output projection
-    # o_proj [32,4096]x[4096,2880]. Swept offline (.auto/oproj_sweep.py) against the
-    # device default: 8x8 cores, in0_block_w=8, out_subblock_w=2 gives 45.13 us/op
-    # vs 93.25 us/op with no program config (-51.6%), pcc 0.9998 vs the device
-    # baseline. per_core_N = 90/64 -> 2, so num_blocks_w_dim = 2/2 = 1 and the
-    # PR #51514 wide-subblock corruption (needs nbwd>1) cannot trigger.
-    decode_out_cores: tuple[int, int] | None = (8, 8)
-    decode_out_in0_block_w: int = 8
+    decode_out_cores: tuple[int, int] | None = None
+    decode_out_in0_block_w: int = 1
     decode_out_out_subblock_h: int = 1
-    decode_out_out_subblock_w: int = 2
+    decode_out_out_subblock_w: int = 1
 
     # Prefill QKV projection
     prefill_qkv_cores: tuple[int, int] | None = None
@@ -154,11 +149,7 @@ class ProgramConfig:
             out_subblock_h=out_subblock_h,
             out_subblock_w=out_subblock_w,
             out_block_h=1,
-            # out_block_w must follow out_subblock_w: in1_num_subblocks is
-            # out_block_w / out_subblock_w, so a hardcoded 1 makes that 0 for any
-            # out_subblock_w > 1 (the PR #51514 deadlock/corruption). Same defect
-            # that was in the expert path.
-            out_block_w=out_subblock_w,
+            out_block_w=1,
             per_core_M=m // 32,
             per_core_N=n // 32 // (core_x * core_y),
             fuse_batch=False,

--- a/models/demos/gpt_oss/tt/attention/config.py
+++ b/models/demos/gpt_oss/tt/attention/config.py
@@ -4,6 +4,7 @@
 from dataclasses import dataclass
 
 import ttnn
+from models.demos.gpt_oss.tt.matmul_guard import check_matmul_program_config
 
 
 @dataclass
@@ -151,6 +152,18 @@ class ProgramConfig:
     ) -> ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig:
         """Build matmul program config for attention projections"""
         core_x, core_y = cores
+        # Reject configs that hit the PR #51514 reload defect before the config
+        # reaches the device. The defect is silent, so an unguarded config shows
+        # up as nonsense output several decode steps later, not as an error.
+        check_matmul_program_config(
+            name=f"attention matmul (cores={cores}, n={n})",
+            Kt=-(-k // 32),
+            in0_block_w=in0_block_w,
+            per_core_N=-(-(n // 32) // (core_x * core_y)),
+            out_block_w=out_subblock_w,
+            out_subblock_w=out_subblock_w,
+            out_subblock_h=out_subblock_h,
+        )
         return ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
             compute_with_storage_grid_size=ttnn.CoreCoord(core_x, core_y),
             in0_block_w=in0_block_w,

--- a/models/demos/gpt_oss/tt/attention/config.py
+++ b/models/demos/gpt_oss/tt/attention/config.py
@@ -152,8 +152,8 @@ class ProgramConfig:
     ) -> ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig:
         """Build matmul program config for attention projections"""
         core_x, core_y = cores
-        # Reject configs that hit the PR #51514 reload defect before the config
-        # reaches the device. The defect is silent, so an unguarded config shows
+        # Reject configs that hit the PR #51514 reload issue before the config
+        # reaches the device. The issue is silent, so an unguarded config shows
         # up as nonsense output several decode steps later, not as an error.
         check_matmul_program_config(
             name=f"attention matmul (cores={cores}, n={n})",
@@ -172,7 +172,7 @@ class ProgramConfig:
             out_block_h=1,
             # out_block_w must follow out_subblock_w: in1_num_subblocks is
             # out_block_w / out_subblock_w, so a hardcoded 1 makes that 0 for any
-            # out_subblock_w > 1 (the PR #51514 defect, also present in the expert
+            # out_subblock_w > 1 (the PR #51514 issue, also present in the expert
             # path until it was fixed there).
             out_block_w=out_subblock_w,
             # CEIL on the row count too: decode passes the LOGICAL seq len (1), so

--- a/models/demos/gpt_oss/tt/attention/decode.py
+++ b/models/demos/gpt_oss/tt/attention/decode.py
@@ -61,8 +61,15 @@ def decode_forward(
     # produced silent corruption (every odd Q/K/V head returned the previous
     # user's row).
     qkv_memory_config = ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG if mesh_config.tp > 1 else ttnn.DRAM_MEMORY_CONFIG
-    xqkv_fused = ttnn.matmul(hidden_states, weights.wqkv, dtype=ttnn.bfloat16, memory_config=qkv_memory_config)
-    ttnn.add(xqkv_fused, weights.wqkv_bias, output_tensor=xqkv_fused)
+    # Fuse the qkv bias into the matmul (ttnn.linear bias=) instead of a separate
+    # in-place add, removing one op/layer.
+    xqkv_fused = ttnn.linear(
+        hidden_states,
+        weights.wqkv,
+        bias=weights.wqkv_bias,
+        dtype=ttnn.bfloat16,
+        memory_config=qkv_memory_config,
+    )
 
     # Split into Q, K, V heads
     num_local_heads = mesh_config.shard_size(config.num_heads)

--- a/models/demos/gpt_oss/tt/attention/decode.py
+++ b/models/demos/gpt_oss/tt/attention/decode.py
@@ -1,7 +1,10 @@
 # SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
+import os
+
 import ttnn
+from models.demos.gpt_oss.kernels.qkv_headsplit_op import qkv_headsplit
 
 from .config import AttentionConfig, ProgramConfig
 from .operations import apply_rope
@@ -81,12 +84,40 @@ def decode_forward(
     num_local_kv_heads = mesh_config.shard_size(config.num_kv_heads)
     head_dim = config.head_dim
 
-    tt_q, tt_k, tt_v = ttnn.experimental.nlp_create_qkv_heads_decode(
-        xqkv_fused,
-        num_heads=num_local_heads,
-        num_kv_heads=num_local_kv_heads,
-        memory_config=ttnn.L1_HEIGHT_SHARDED_MEMORY_CONFIG,
-    )
+    # QKV head split. The stock op shards its output by LOGICAL batch, so at
+    # decode (batch=1) it runs on 1 core of 130 at 23.28us/op = 0.558 ms/tok. It is
+    # not bandwidth bound, just single-core, so a custom generic_op that splits the
+    # work by output tile-row across 4 cores is 2.6x faster (9.36 vs 24.76 us/op,
+    # bit-identical output). Set QKV_HEADSPLIT=0 to fall back to the stock op.
+    if os.environ.get("QKV_HEADSPLIT", "1") == "1" and mesh_config.tp == 1:
+        # Allocate HEIGHT_SHARDED directly: RoPE requires it, and letting the
+        # kernel write straight into that layout avoids a conversion op (a
+        # to_memory_config here costs ~22us and would erase the win).
+        def _hs(n_rows):
+            shard = ttnn.ShardSpec(
+                ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))]),
+                [max(n_rows, 32), head_dim],
+                ttnn.ShardOrientation.ROW_MAJOR,
+            )
+            return ttnn.allocate_tensor_on_device(
+                ttnn.Shape([1, 1, n_rows, head_dim]),
+                ttnn.bfloat16,
+                ttnn.TILE_LAYOUT,
+                xqkv_fused.device(),
+                ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, shard),
+            )
+
+        tt_q = _hs(num_local_heads)
+        tt_k = _hs(num_local_kv_heads)
+        tt_v = _hs(num_local_kv_heads)
+        qkv_headsplit(xqkv_fused, tt_q, tt_k, tt_v, num_local_heads, num_local_kv_heads, head_dim)
+    else:
+        tt_q, tt_k, tt_v = ttnn.experimental.nlp_create_qkv_heads_decode(
+            xqkv_fused,
+            num_heads=num_local_heads,
+            num_kv_heads=num_local_kv_heads,
+            memory_config=ttnn.L1_HEIGHT_SHARDED_MEMORY_CONFIG,
+        )
 
     xqkv_fused.deallocate(True)
 

--- a/models/demos/gpt_oss/tt/attention/decode.py
+++ b/models/demos/gpt_oss/tt/attention/decode.py
@@ -216,6 +216,9 @@ def decode_forward(
         bias=weights.o_proj_bias,
         dtype=ttnn.bfloat8_b,
         memory_config=ttnn.L1_MEMORY_CONFIG,
+        program_config=program_config.get_decode_out_config(
+            tt_sdpa_out.shape[-2], weights.o_proj.shape[-1], tt_sdpa_out.shape[-1]
+        ),
     )
 
     tt_sdpa_out.deallocate(True)

--- a/models/demos/gpt_oss/tt/attention/decode.py
+++ b/models/demos/gpt_oss/tt/attention/decode.py
@@ -60,7 +60,12 @@ def decode_forward(
     # constraint for DRAM-interleaved inputs; before that fix this path
     # produced silent corruption (every odd Q/K/V head returned the previous
     # user's row).
-    qkv_memory_config = ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG if mesh_config.tp > 1 else ttnn.DRAM_MEMORY_CONFIG
+    # TP=1: use L1_INTERLEAVED (not DRAM). nlp_create_qkv_heads_decode reads the
+    # DRAM-interleaved input on a SINGLE core at ~44us/op (tracy); reading from L1
+    # interleaved is much faster and avoids the per-core CB overflow that width-
+    # sharding the TP-larger QKV would cause. (The PR #43292 aligned-read fix applies
+    # to interleaved inputs regardless of DRAM vs L1.)
+    qkv_memory_config = ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG if mesh_config.tp > 1 else ttnn.L1_MEMORY_CONFIG
     # Fuse the qkv bias into the matmul (ttnn.linear bias=) instead of a separate
     # in-place add, removing one op/layer.
     xqkv_fused = ttnn.linear(

--- a/models/demos/gpt_oss/tt/attention/decode.py
+++ b/models/demos/gpt_oss/tt/attention/decode.py
@@ -163,13 +163,19 @@ def decode_forward(
     tt_sdpa_out = ttnn.experimental.nlp_concat_heads_decode(tt_sdpa_tensor, num_heads=num_local_heads)
     tt_sdpa_tensor.deallocate(True)
 
+    # Fuse the o_proj bias-add and the bf8 output cast into the linear (bias= and
+    # dtype=) instead of a separate add + typecast. Removes 2 ops/layer (~48 op
+    # launches/token) to cut trace-execute dispatch overhead (the dominant decode
+    # cost). Output goes to L1 interleaved (matches the prior post-add layout).
     tt_out = ttnn.linear(
-        tt_sdpa_out, weights.o_proj, dtype=ttnn.bfloat16, memory_config=ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG
+        tt_sdpa_out,
+        weights.o_proj,
+        bias=weights.o_proj_bias,
+        dtype=ttnn.bfloat8_b,
+        memory_config=ttnn.L1_MEMORY_CONFIG,
     )
 
     tt_sdpa_out.deallocate(True)
-    tt_out = ttnn.add(tt_out, weights.o_proj_bias, memory_config=ttnn.L1_MEMORY_CONFIG)
-    tt_out = ttnn.typecast(tt_out, ttnn.bfloat8_b)
 
     # Calculate padded hidden size for tile-aligned CCL operations.
     local_hidden = hidden_size // mesh_config.tp

--- a/models/demos/gpt_oss/tt/attention/decode.py
+++ b/models/demos/gpt_oss/tt/attention/decode.py
@@ -216,9 +216,6 @@ def decode_forward(
         bias=weights.o_proj_bias,
         dtype=ttnn.bfloat8_b,
         memory_config=ttnn.L1_MEMORY_CONFIG,
-        program_config=program_config.get_decode_out_config(
-            tt_sdpa_out.shape[-2], weights.o_proj.shape[-1], tt_sdpa_out.shape[-1]
-        ),
     )
 
     tt_sdpa_out.deallocate(True)

--- a/models/demos/gpt_oss/tt/attention/decode.py
+++ b/models/demos/gpt_oss/tt/attention/decode.py
@@ -77,6 +77,9 @@ def decode_forward(
         bias=weights.wqkv_bias,
         dtype=ttnn.bfloat16,
         memory_config=qkv_memory_config,
+        program_config=program_config.get_decode_qkv_config(
+            hidden_states.shape[-2], weights.wqkv.shape[-1], hidden_states.shape[-1]
+        ),
     )
 
     # Split into Q, K, V heads

--- a/models/demos/gpt_oss/tt/attention_configs.py
+++ b/models/demos/gpt_oss/tt/attention_configs.py
@@ -26,7 +26,16 @@ class GPTOSSAttentionProgramConfig(ProgramConfig):
     prefill_threshold: int = 2048
 
     # Matmul configs - None = auto-optimize (recommended)
-    decode_qkv_cores: tuple[int, int] | None = None
+    # decode qkv [32,2880]x[2880,5120]. IN0 is L1_INTERLEAVED in-model, which is the
+    # layout the offline sweep used, so the sweep result applies (unlike o_proj,
+    # whose IN0 is L1_WIDTH_SHARDED and takes a different program factory).
+    # .auto/qkv_sweep.py: 8x5 cores, in0_block_w=2, out_subblock_w=4 -> 47.79 us/op
+    # vs 62.88 default at the model's exact shape, pcc 0.9998 vs the device output.
+    # per_core_N = Nt/cores = 160/40 = 4 exactly. out_block_w = osw = 4 gives
+    # num_blocks_w_dim = 1, so the PR #51514 corruption cannot trigger.
+    decode_qkv_cores: tuple[int, int] | None = (8, 5)
+    decode_qkv_in0_block_w: int = 2
+    decode_qkv_out_subblock_w: int = 4
     decode_out_cores: tuple[int, int] | None = None
     prefill_qkv_cores: tuple[int, int] | None = None
     prefill_out_cores: tuple[int, int] | None = None

--- a/models/demos/gpt_oss/tt/expert_configs.py
+++ b/models/demos/gpt_oss/tt/expert_configs.py
@@ -27,9 +27,12 @@ class GPTOSSProgramConfig(ProgramConfig):
     decode_down_in0_block_w: int = 12
 
     # Prefill
-    prefill_gate_up_cores: tuple[int, int] = (3, 4)
+    # Same 2880x2880 expert GEMM as decode (Nt=90); on single p150 (TP=1) the old
+    # galaxy grids (12/30 cores) left prefill sparse_matmul at ~7.3ms/3.9ms per op
+    # (tracy: 888ms = ~80% of device time). Match decode's 90-core (10x9) grid.
+    prefill_gate_up_cores: tuple[int, int] = (10, 9)
     prefill_gate_up_in0_block_w: int = 30
-    prefill_down_cores: tuple[int, int] = (5, 6)
+    prefill_down_cores: tuple[int, int] = (10, 9)
     prefill_down_in0_block_w: int = 12
 
     # Memory

--- a/models/demos/gpt_oss/tt/expert_configs.py
+++ b/models/demos/gpt_oss/tt/expert_configs.py
@@ -18,13 +18,15 @@ class GPTOSSProgramConfig(ProgramConfig):
 
     # Decode
     # Grids tuned via models/demos/gpt_oss/tests/sweeps/moe_sparse_matmul_sweep.py on
-    # a single p150 (TP=1, Nt=90). Sweep found latency scales monotonically with core
-    # count; 90 cores (10x9) is the fastest PCC-passing config for both projections
-    # (gate_up 0.38ms vs 0.95ms@12cores; down 0.38ms vs 0.55ms@30cores), PCC ~0.9934.
-    decode_gate_up_cores: tuple[int, int] = (10, 9)
-    decode_gate_up_in0_block_w: int = 30
-    decode_down_cores: tuple[int, int] = (10, 9)
-    decode_down_in0_block_w: int = 12
+    # a single p150 (TP=1). A WIDER re-sweep (adding the high in0_block_w axis the
+    # original narrow {1,2,3,5} sweep missed) found in0_block_w=45 is the winning knob:
+    #   gate_up: 36 cores (12x3), ib=45 -> 0.257ms  (was 0.38ms @ 90c/ib30, ~32% faster)
+    #   down:    30 cores (10x3), ib=45 -> 0.176ms  (was 0.38ms @ 90c/ib12, ~54% faster)
+    # Both PCC ~0.9935. Standalone medians; verify in-model via signpost tracy + checks.sh.
+    decode_gate_up_cores: tuple[int, int] = (12, 3)
+    decode_gate_up_in0_block_w: int = 45
+    decode_down_cores: tuple[int, int] = (10, 3)
+    decode_down_in0_block_w: int = 45
 
     # Prefill
     # Same 2880x2880 expert GEMM as decode (Nt=90); on single p150 (TP=1) the old

--- a/models/demos/gpt_oss/tt/expert_configs.py
+++ b/models/demos/gpt_oss/tt/expert_configs.py
@@ -17,9 +17,13 @@ class GPTOSSProgramConfig(ProgramConfig):
     """
 
     # Decode
-    decode_gate_up_cores: tuple[int, int] = (3, 4)
+    # Grids tuned via models/demos/gpt_oss/tests/sweeps/moe_sparse_matmul_sweep.py on
+    # a single p150 (TP=1, Nt=90). Sweep found latency scales monotonically with core
+    # count; 90 cores (10x9) is the fastest PCC-passing config for both projections
+    # (gate_up 0.38ms vs 0.95ms@12cores; down 0.38ms vs 0.55ms@30cores), PCC ~0.9934.
+    decode_gate_up_cores: tuple[int, int] = (10, 9)
     decode_gate_up_in0_block_w: int = 30
-    decode_down_cores: tuple[int, int] = (5, 6)
+    decode_down_cores: tuple[int, int] = (10, 9)
     decode_down_in0_block_w: int = 12
 
     # Prefill

--- a/models/demos/gpt_oss/tt/expert_configs.py
+++ b/models/demos/gpt_oss/tt/expert_configs.py
@@ -18,15 +18,23 @@ class GPTOSSProgramConfig(ProgramConfig):
 
     # Decode
     # Grids tuned via models/demos/gpt_oss/tests/sweeps/moe_sparse_matmul_sweep.py on
-    # a single p150 (TP=1). A WIDER re-sweep (adding the high in0_block_w axis the
-    # original narrow {1,2,3,5} sweep missed) found in0_block_w=45 is the winning knob:
-    #   gate_up: 36 cores (12x3), ib=45 -> 0.257ms  (was 0.38ms @ 90c/ib30, ~32% faster)
-    #   down:    30 cores (10x3), ib=45 -> 0.176ms  (was 0.38ms @ 90c/ib12, ~54% faster)
-    # Both PCC ~0.9935. Standalone medians; verify in-model via signpost tracy + checks.sh.
-    decode_gate_up_cores: tuple[int, int] = (12, 3)
-    decode_gate_up_in0_block_w: int = 45
-    decode_down_cores: tuple[int, int] = (10, 3)
-    decode_down_in0_block_w: int = 45
+    # a single p150 (TP=1).
+    # Re-swept after fixing out_block_w (was hardcoded 1, which made
+    # in1_num_subblocks = out_block_w/out_subblock_w == 0, so out_subblock_w was a
+    # no-op). With the axis live, 60-config sweeps per projection found:
+    #   gate_up: 30 cores (10x3), ib=15, osw=3 -> 0.1709ms (was 0.1935 @ ib45/osw1)
+    #   down:    45 cores (9x5),  ib=30, osw=2 -> 0.1764ms (was 0.1795)
+    # In-model: SparseMatmul 6.458 -> 6.147 ms/tok, decode 16.178 -> 15.846 ms/tok,
+    # 57.95-58.11 -> 58.93-59.16 tok/s/u (n=4, no overlap). Top-1 0.9333 -> 0.9667,
+    # Top-5 1.0000 unchanged.
+    # SAFETY: both keep num_blocks_w_dim = per_core_N/out_block_w = 1, which avoids
+    # the PR #51514 wide-subblock corruption (needs osw>1 AND nbwd>1 AND nbid>1).
+    decode_gate_up_cores: tuple[int, int] = (10, 3)
+    decode_gate_up_in0_block_w: int = 15
+    decode_gate_up_subblock_w: int = 3
+    decode_down_cores: tuple[int, int] = (9, 5)
+    decode_down_in0_block_w: int = 30
+    decode_down_subblock_w: int = 2
 
     # Prefill
     # Same 2880x2880 expert GEMM as decode (Nt=90); on single p150 (TP=1) the old

--- a/models/demos/gpt_oss/tt/expert_configs.py
+++ b/models/demos/gpt_oss/tt/expert_configs.py
@@ -29,9 +29,16 @@ class GPTOSSProgramConfig(ProgramConfig):
     # Top-5 1.0000 unchanged.
     # SAFETY: both keep num_blocks_w_dim = per_core_N/out_block_w = 1, which avoids
     # the PR #51514 wide-subblock corruption (needs osw>1 AND nbwd>1 AND nbid>1).
-    decode_gate_up_cores: tuple[int, int] = (10, 3)
+    # gate+up: 45 cores (9x5), in0_block_w=15, out_subblock_w=4.
+    # Nt=180, so per_core_N = 180/45 = 4 and out_block_w = osw = 4, giving
+    # num_blocks_w_dim = 1. The previous 30-core config had per_core_N=6 with
+    # osw=3, i.e. nbwd=2, and with in0_block_w=15 (nbid=6) it met ALL THREE
+    # PR #51514 wide-subblock corruption conditions at once. This config cannot.
+    # Tracy: 4.142 -> 3.295 ms/tok (-20%), 30 -> 45 cores. Matches the down
+    # projection, which already ran 45 cores at higher efficiency (51.7% vs 43.0%).
+    decode_gate_up_cores: tuple[int, int] = (9, 5)
     decode_gate_up_in0_block_w: int = 15
-    decode_gate_up_subblock_w: int = 3
+    decode_gate_up_subblock_w: int = 4
     decode_down_cores: tuple[int, int] = (9, 5)
     decode_down_in0_block_w: int = 30
     decode_down_subblock_w: int = 2

--- a/models/demos/gpt_oss/tt/expert_configs.py
+++ b/models/demos/gpt_oss/tt/expert_configs.py
@@ -36,8 +36,16 @@ class GPTOSSProgramConfig(ProgramConfig):
     # PR #51514 wide-subblock corruption conditions at once. This config cannot.
     # Tracy: 4.142 -> 3.295 ms/tok (-20%), 30 -> 45 cores. Matches the down
     # projection, which already ran 45 cores at higher efficiency (51.7% vs 43.0%).
+    # in0_block_w=3 (num_blocks_inner_dim = 90/3 = 30). Re-tuned IN-MODEL after the
+    # core count moved 30 -> 45: the old value of 15 came from a sweep at 30 cores,
+    # where each core held per_core_N=6 output tiles. At per_core_N=4 the per-core
+    # L1 budget differs and smaller K chunks win. Measured decode ms/tok:
+    #   ib=45 13.475 | 30 13.359 | 18 13.264 | 15 13.276 | 10 13.175
+    #   ib=9  13.168 | 6  13.127 | 5  13.078 | 3  13.000 | 2  14.082
+    # Monotonic down to 3, then a sharp regression at 2 (chunk too small to
+    # amortise the per-chunk loop overhead).
     decode_gate_up_cores: tuple[int, int] = (9, 5)
-    decode_gate_up_in0_block_w: int = 15
+    decode_gate_up_in0_block_w: int = 3
     decode_gate_up_subblock_w: int = 4
     decode_down_cores: tuple[int, int] = (9, 5)
     decode_down_in0_block_w: int = 30

--- a/models/demos/gpt_oss/tt/expert_configs.py
+++ b/models/demos/gpt_oss/tt/expert_configs.py
@@ -47,8 +47,17 @@ class GPTOSSProgramConfig(ProgramConfig):
     decode_gate_up_cores: tuple[int, int] = (9, 5)
     decode_gate_up_in0_block_w: int = 3
     decode_gate_up_subblock_w: int = 4
+    # in0_block_w=9 (num_blocks_inner_dim = 90/9 = 10). Re-tuned IN-MODEL for the
+    # same reason as gate+up: the previous value of 30 was swept at a different
+    # core count, and in0_block_w is coupled to per_core_N through the per-core L1
+    # budget. Measured decode ms/tok at 45 cores:
+    #   ib=30 13.000 | 18 12.946 | 15 12.917 | 10 12.841 | 9 12.807
+    #   ib=6  13.010 | 5  13.253 | 3  14.269
+    # A real minimum at 9, not a plateau edge. Note the optimum differs from
+    # gate+up's (3) even though both run 45 cores -- down has per_core_N=2 vs 4
+    # and reads half the bytes, so its L1 tradeoff is different.
     decode_down_cores: tuple[int, int] = (9, 5)
-    decode_down_in0_block_w: int = 30
+    decode_down_in0_block_w: int = 9
     decode_down_subblock_w: int = 2
 
     # Prefill

--- a/models/demos/gpt_oss/tt/experts/__init__.py
+++ b/models/demos/gpt_oss/tt/experts/__init__.py
@@ -149,6 +149,7 @@ class Experts:
                 mesh_device=self.mesh_device,
                 ccl_manager=self.ccl_manager,
                 program_config=self.program_config,
+                topk_expert_indices=topk_expert_indices,
             )
         else:
             return prefill_forward(

--- a/models/demos/gpt_oss/tt/experts/config.py
+++ b/models/demos/gpt_oss/tt/experts/config.py
@@ -166,7 +166,11 @@ class ProgramConfig:
             out_subblock_h=1,
             out_subblock_w=out_subblock_w,
             out_block_h=1,
-            out_block_w=1,
+            # out_block_w must be derived from out_subblock_w: in1_num_subblocks =
+            # out_block_w / out_subblock_w, so a hardcoded 1 makes that 0 for any
+            # out_subblock_w > 1 (the PR #51514 deadlock). Same fix Lucas Chin
+            # applied to moe_sparse_matmul_sweep.py.
+            out_block_w=out_subblock_w,
             per_core_M=max(32, m) // 32,
             per_core_N=per_core_N,
             fuse_batch=False,

--- a/models/demos/gpt_oss/tt/experts/config.py
+++ b/models/demos/gpt_oss/tt/experts/config.py
@@ -10,6 +10,7 @@ import math
 from dataclasses import dataclass
 
 import ttnn
+from models.demos.gpt_oss.tt.matmul_guard import check_matmul_program_config
 
 
 @dataclass
@@ -159,6 +160,20 @@ class ProgramConfig:
             if Kt % in0_block_w != 0:
                 divisors = [d for d in range(2, in0_block_w + 1) if Kt % d == 0]
                 in0_block_w = max(divisors) if divisors else Kt
+
+        # Reject configs that hit the PR #51514 reload defect. That defect is
+        # silent: no crash, no warning, just wrong values that grow to infinity
+        # a few decode steps later. Checked after in0_block_w is snapped above,
+        # so the values here are the ones the kernel actually receives.
+        check_matmul_program_config(
+            name=f"expert matmul (cores={cores}, n={n})",
+            Kt=int(math.ceil((k if k is not None else n) / 32)),
+            in0_block_w=in0_block_w,
+            per_core_N=per_core_N,
+            out_block_w=out_subblock_w,
+            out_subblock_w=out_subblock_w,
+            out_subblock_h=1,
+        )
 
         return ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
             compute_with_storage_grid_size=ttnn.CoreCoord(core_x, core_y),

--- a/models/demos/gpt_oss/tt/experts/config.py
+++ b/models/demos/gpt_oss/tt/experts/config.py
@@ -161,7 +161,7 @@ class ProgramConfig:
                 divisors = [d for d in range(2, in0_block_w + 1) if Kt % d == 0]
                 in0_block_w = max(divisors) if divisors else Kt
 
-        # Reject configs that hit the PR #51514 reload defect. That defect is
+        # Reject configs that hit the PR #51514 reload issue. That issue is
         # silent: no crash, no warning, just wrong values that grow to infinity
         # a few decode steps later. Checked after in0_block_w is snapped above,
         # so the values here are the ones the kernel actually receives.

--- a/models/demos/gpt_oss/tt/experts/decode.py
+++ b/models/demos/gpt_oss/tt/experts/decode.py
@@ -66,6 +66,10 @@ def decode_forward(
 
     # Gate projection
     # Fused gate+up: one sparse_matmul over the concatenated [gate|up] weight.
+    # gate/up output kept bf16 (not bf8): the downstream transpose+slice+add+SwiGLU
+    # chain operates in bf16 and otherwise inserts bf8->bf16 typecasts around each
+    # transpose (tracy: 144 Transpose->Typecast->Transpose in decode = ~1.2ms/tok).
+    # Emitting bf16 directly from the matmul removes those casts. Verify perf+accuracy.
     gate = ttnn.sparse_matmul(
         hidden_states,
         weights.gate_up_proj,
@@ -78,7 +82,7 @@ def decode_forward(
         program_config=program_config.get_decode_gate_up_config(
             hidden_states.shape[2], weights.gate_up_proj.shape[3], k=hidden_states.shape[-1]
         ),
-        dtype=activation_dtype,
+        dtype=ttnn.bfloat16,
     )
     hidden_states.deallocate(True)
     # Fused output is [.., 2*I]; split into gate/up along the last dim after the

--- a/models/demos/gpt_oss/tt/experts/decode.py
+++ b/models/demos/gpt_oss/tt/experts/decode.py
@@ -7,7 +7,7 @@ import ttnn
 from models.demos.gpt_oss.config import Mode
 
 from .config import ExpertConfig, ProgramConfig
-from .operations import apply_expert_parallel_allreduce, apply_swiglu, apply_tensor_parallel_allreduce
+from .operations import apply_expert_parallel_allreduce, apply_tensor_parallel_allreduce
 from .weights import ExpertWeights
 
 
@@ -20,6 +20,7 @@ def decode_forward(
     mesh_device,
     ccl_manager,
     program_config: ProgramConfig,
+    topk_expert_indices=None,
 ):
     """
     Decode forward pass - optimized for single token (seq_len=1).
@@ -88,21 +89,33 @@ def decode_forward(
     # Fused output is [.., 2*I]; split into gate/up along the last dim after the
     # shared reshape/transpose (halves the gate/up sparse_matmul launches).
     I = weights.intermediate_size_per_device
-    gate = ttnn.reshape(gate, (batch_size, config.num_experts, 1, 2 * I))
-    gate = ttnn.transpose(gate, 1, 2)
-    gate = ttnn.reshape(gate, (batch_size, config.num_experts, 2 * I))
-    gate_up = gate
-    gate = ttnn.slice(gate_up, (0, 0, 0), (batch_size, config.num_experts, I))
-    up = ttnn.slice(gate_up, (0, 0, I), (batch_size, config.num_experts, 2 * I))
-    gate_up.deallocate(True)
-    gate = ttnn.add(gate, weights.gate_proj_bias, output_tensor=gate)
-    up = ttnn.add(up, weights.up_proj_bias, output_tensor=up)
+    # Fused expert-tail SwiGLU (custom generic_op): transpose-eliminating +
+    # expert-skipping + scatter. Reads gate/up directly from the raw fused matmul
+    # output [1,E,1,2I] (native layout, no transpose/slice), processes ONLY the
+    # active experts (ids from the router top-k device tensor), and scatters
+    # silu(clamp(gate,max=a*lim))*(clamp(up,-lim,lim)+1) to the active expert slots
+    # of down_input [1,E,1,I]. Bias (concat[gate|up]) added once via the prebuilt
+    # weights.gateup_bias. Replaces ~10 ops/layer (transpose+slice x2+2 bias+clamp x2
+    # +silu+ (+1)+mul) with a single generic_op over the active experts.
+    from models.demos.gpt_oss.kernels.swiglu_final_op import fused_swiglu_final
 
-    # Apply SwiGLU activation (consumes gate and up internally)
-    down_input = apply_swiglu(gate, up, config)
-    # Note: transpose/reshape operations return views - do not deallocate originals
-    down_input = ttnn.transpose(down_input, 1, 0)
-    down_input = ttnn.reshape(down_input, (1, config.num_experts, seq_len, weights.intermediate_size_per_device))
+    raw = ttnn.reshape(gate, (batch_size, config.num_experts, 1, 2 * I))
+    # Prep active-expert id list -> [1,1,1,nact] uint32 ROW_MAJOR device tensor.
+    _nact = config.num_experts_per_tok
+    _idx = ttnn.to_layout(topk_expert_indices, ttnn.ROW_MAJOR_LAYOUT)
+    _idx = ttnn.typecast(_idx, ttnn.uint32)
+    _idx = ttnn.reshape(_idx, (1, 1, 1, _nact))
+    down_input = ttnn.allocate_tensor_on_device(
+        ttnn.Shape([1, config.num_experts, seq_len, I]),
+        ttnn.bfloat16,
+        ttnn.TILE_LAYOUT,
+        mesh_device,
+        ttnn.L1_MEMORY_CONFIG,
+    )
+    _cap = config.alpha * config.swiglu_limit
+    # Bias folded inside the kernel (weights.gateup_bias), only for active experts.
+    fused_swiglu_final(raw, weights.gateup_bias, _idx, down_input, _nact, _cap, config.swiglu_limit)
+    raw.deallocate(True)
     # Down projection
     down = ttnn.sparse_matmul(
         down_input,

--- a/models/demos/gpt_oss/tt/experts/decode.py
+++ b/models/demos/gpt_oss/tt/experts/decode.py
@@ -75,9 +75,16 @@ def decode_forward(
         hidden_states,
         weights.gate_up_proj,
         sparsity=sparsity,
-        # nnz=None (runtime-inferred): static nnz deadlocks when actual non-zero
-        # sparsity count < k (BH flushes small routing weights to 0). See #45943/#45052.
-        nnz=None,
+        # Static nnz = num_experts_per_tok. The historical reason for nnz=None was a
+        # deadlock when the actual non-zero sparsity count < nnz (the in0-mcast
+        # receivers loop nnz times while the sender only mcasts for real non-zeros;
+        # see #45943/#45052). MEASURED on this model: a probe over 1704 decode
+        # sparse_matmul calls found the non-zero count is NEVER below 4
+        # (distribution {4: 1392, 32: 120, 128: 96, 1024: 48, 2048: 48}, min=4), so
+        # nnz=4 cannot under-run. Inferring it instead costs a device-side reduction
+        # + FILL per call: SparseMatmul 6.159 -> 5.827 ms/tok, decode 15.854 ->
+        # 15.518, 58.9 -> 60.0 tok/s/user, accuracy unchanged (0.9667 / 1.0000).
+        nnz=num_experts_per_tok,
         memory_config=ttnn.L1_MEMORY_CONFIG,
         output_tile=output_tile,
         program_config=program_config.get_decode_gate_up_config(
@@ -121,14 +128,11 @@ def decode_forward(
         down_input,
         weights.down_proj,
         sparsity=sparsity,
-        # nnz intentionally omitted (None -> inferred at runtime). Passing a static
-        # nnz makes the sparse_matmul in0-mcast receivers loop a fixed count while the
-        # sender only mcasts for the *actual* non-zero `sparsity` entries. The decode
-        # routing weights (softmax over top-k, scattered) frequently have <k non-zeros
-        # on Blackhole (small weights flush to 0), so a static nnz != actual count and
-        # the receivers deadlock in noc_semaphore_wait. Inferring the count is robust.
-        # See tenstorrent/tt-metal#45943 (op deadlock) / #45052 (gpt-oss hang).
-        nnz=None,
+        # Static nnz: see the gate_up call above. The measured non-zero count never
+        # falls below num_experts_per_tok on this model, so the #45943/#45052
+        # under-run deadlock cannot trigger. Verified with 6 full demo runs + the
+        # accuracy test, no hang.
+        nnz=num_experts_per_tok,
         memory_config=ttnn.L1_MEMORY_CONFIG,
         output_tile=output_tile,
         is_input_a_sparse=True,

--- a/models/demos/gpt_oss/tt/experts/decode.py
+++ b/models/demos/gpt_oss/tt/experts/decode.py
@@ -122,7 +122,9 @@ def decode_forward(
         program_config=program_config.get_decode_down_config(
             down_input.shape[2], weights.down_proj.shape[-1], k=down_input.shape[-1]
         ),
-        dtype=activation_dtype,
+        # bf16 output (not bf8): feeds the bf16 permute+add(bias)+mul(routing)+sum tail;
+        # emitting bf16 avoids the per-op bf8->bf16 recast (same win as gate/up above).
+        dtype=ttnn.bfloat16,
     )
 
     down_input.deallocate(True)

--- a/models/demos/gpt_oss/tt/experts/decode.py
+++ b/models/demos/gpt_oss/tt/experts/decode.py
@@ -65,56 +65,33 @@ def decode_forward(
     output_tile = ttnn.Tile([32, 32])
 
     # Gate projection
+    # Fused gate+up: one sparse_matmul over the concatenated [gate|up] weight.
     gate = ttnn.sparse_matmul(
         hidden_states,
-        weights.gate_proj,
+        weights.gate_up_proj,
         sparsity=sparsity,
-        # nnz intentionally omitted (None -> inferred at runtime). Passing a static
-        # nnz makes the sparse_matmul in0-mcast receivers loop a fixed count while the
-        # sender only mcasts for the *actual* non-zero `sparsity` entries. The decode
-        # routing weights (softmax over top-k, scattered) frequently have <k non-zeros
-        # on Blackhole (small weights flush to 0), so a static nnz != actual count and
-        # the receivers deadlock in noc_semaphore_wait. Inferring the count is robust.
-        # See tenstorrent/tt-metal#45943 (op deadlock) / #45052 (gpt-oss hang).
+        # nnz=None (runtime-inferred): static nnz deadlocks when actual non-zero
+        # sparsity count < k (BH flushes small routing weights to 0). See #45943/#45052.
         nnz=None,
         memory_config=ttnn.L1_MEMORY_CONFIG,
         output_tile=output_tile,
         program_config=program_config.get_decode_gate_up_config(
-            hidden_states.shape[2], weights.gate_proj.shape[3], k=hidden_states.shape[-1]
-        ),
-        dtype=activation_dtype,
-    )
-    # Note: reshape/transpose operations return views - do not deallocate originals
-    gate = ttnn.reshape(gate, (batch_size, config.num_experts, 1, weights.intermediate_size_per_device))
-    gate = ttnn.transpose(gate, 1, 2)
-    gate = ttnn.reshape(gate, (batch_size, config.num_experts, weights.intermediate_size_per_device))
-    gate = ttnn.add(gate, weights.gate_proj_bias, output_tensor=gate)
-
-    # Up projection
-    up = ttnn.sparse_matmul(
-        hidden_states,
-        weights.up_proj,
-        sparsity=sparsity,
-        # nnz intentionally omitted (None -> inferred at runtime). Passing a static
-        # nnz makes the sparse_matmul in0-mcast receivers loop a fixed count while the
-        # sender only mcasts for the *actual* non-zero `sparsity` entries. The decode
-        # routing weights (softmax over top-k, scattered) frequently have <k non-zeros
-        # on Blackhole (small weights flush to 0), so a static nnz != actual count and
-        # the receivers deadlock in noc_semaphore_wait. Inferring the count is robust.
-        # See tenstorrent/tt-metal#45943 (op deadlock) / #45052 (gpt-oss hang).
-        nnz=None,
-        memory_config=ttnn.L1_MEMORY_CONFIG,
-        output_tile=output_tile,
-        program_config=program_config.get_decode_gate_up_config(
-            hidden_states.shape[2], weights.up_proj.shape[3], k=hidden_states.shape[-1]
+            hidden_states.shape[2], weights.gate_up_proj.shape[3], k=hidden_states.shape[-1]
         ),
         dtype=activation_dtype,
     )
     hidden_states.deallocate(True)
-    # Note: reshape/transpose operations return views - do not deallocate originals
-    up = ttnn.reshape(up, (batch_size, config.num_experts, 1, weights.intermediate_size_per_device))
-    up = ttnn.transpose(up, 1, 2)
-    up = ttnn.reshape(up, (batch_size, config.num_experts, weights.intermediate_size_per_device))
+    # Fused output is [.., 2*I]; split into gate/up along the last dim after the
+    # shared reshape/transpose (halves the gate/up sparse_matmul launches).
+    I = weights.intermediate_size_per_device
+    gate = ttnn.reshape(gate, (batch_size, config.num_experts, 1, 2 * I))
+    gate = ttnn.transpose(gate, 1, 2)
+    gate = ttnn.reshape(gate, (batch_size, config.num_experts, 2 * I))
+    gate_up = gate
+    gate = ttnn.slice(gate_up, (0, 0, 0), (batch_size, config.num_experts, I))
+    up = ttnn.slice(gate_up, (0, 0, I), (batch_size, config.num_experts, 2 * I))
+    gate_up.deallocate(True)
+    gate = ttnn.add(gate, weights.gate_proj_bias, output_tensor=gate)
     up = ttnn.add(up, weights.up_proj_bias, output_tensor=up)
 
     # Apply SwiGLU activation (consumes gate and up internally)

--- a/models/demos/gpt_oss/tt/experts/operations.py
+++ b/models/demos/gpt_oss/tt/experts/operations.py
@@ -20,17 +20,17 @@ def apply_swiglu(gate, up, config: ExpertConfig):
     Returns:
         Activated tensor
     """
-    # Clamp gate and up
-    gate = ttnn.clamp(gate, min=None, max=config.swiglu_limit, output_tensor=gate)
+    # SwiGLU with build-time alpha-fold: the gate weights are pre-scaled by alpha
+    # (see weights.py), so `gate` here is already alpha*gate_raw. Thus
+    # gate_raw*sigmoid(alpha*gate_raw) = silu(alpha*gate_raw)/alpha = silu(gate)/alpha,
+    # and the 1/alpha is absorbed into the down weights. This lets us use a single
+    # fused ttnn.silu instead of (mul-by-alpha + sigmoid + mul), removing ops/layer
+    # with zero runtime correction. Clamp bound scales with alpha (clamp(alpha*g) at
+    # alpha*limit == alpha*clamp(g at limit)).
+    gate = ttnn.clamp(gate, min=None, max=config.alpha * config.swiglu_limit, output_tensor=gate)
     up = ttnn.clamp(up, min=-config.swiglu_limit, max=config.swiglu_limit, output_tensor=up)
 
-    # SwiGLU: gate * sigmoid(alpha * gate) * (up + 1)
-    gate_alpha = ttnn.mul(gate, config.alpha)
-    gate_sigmoid = ttnn.sigmoid(gate_alpha)
-    gate_alpha.deallocate(True)
-
-    glu = ttnn.mul(gate, gate_sigmoid, output_tensor=gate)
-    gate_sigmoid.deallocate(True)
+    glu = ttnn.silu(gate, output_tensor=gate)  # = alpha * gate_raw*sigmoid(alpha*gate_raw)
 
     up = ttnn.add(up, 1, output_tensor=up)
     result = ttnn.mul(up, glu, output_tensor=up)

--- a/models/demos/gpt_oss/tt/experts/prefill.py
+++ b/models/demos/gpt_oss/tt/experts/prefill.py
@@ -108,13 +108,11 @@ def _process_prefill_chunk(
 
     # # Do partial swiglu before up projection to save memory (fused gate projection + swiglu gate activation)
     # Part 1
-    gate = ttnn.clamp(gate, min=None, max=config.swiglu_limit, output_tensor=gate)
-    gate_alpha = ttnn.mul(gate, config.alpha)
-    gate_sigmoid = ttnn.sigmoid(gate_alpha)
-    gate_alpha.deallocate(True)
-    glu = ttnn.mul(gate, gate_sigmoid, output_tensor=gate)
-
-    gate_sigmoid.deallocate(True)
+    # Build-time alpha-fold (see weights.py): gate is pre-scaled by alpha, so
+    # silu(gate) = alpha*gate_raw*sigmoid(alpha*gate_raw); the 1/alpha is absorbed
+    # into the down weights. Single fused silu instead of mul+sigmoid+mul.
+    gate = ttnn.clamp(gate, min=None, max=config.alpha * config.swiglu_limit, output_tensor=gate)
+    glu = ttnn.silu(gate, output_tensor=gate)
 
     # Up projection
     up = ttnn.sparse_matmul(

--- a/models/demos/gpt_oss/tt/experts/weights.py
+++ b/models/demos/gpt_oss/tt/experts/weights.py
@@ -25,6 +25,9 @@ class ExpertWeights:
     up_proj_bias: ttnn.Tensor
     down_proj_bias: ttnn.Tensor
     intermediate_size_per_device: int
+    # Fused gate+up weight (concat along N) built ON-DEVICE from the cached gate/up
+    # tensors, so one sparse_matmul produces [gate|up]; output splits [..,:I]/[..,I:].
+    gate_up_proj: ttnn.Tensor = None
 
 
 def load_expert_weights(
@@ -152,6 +155,12 @@ def load_expert_weights(
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
 
+    # Build the fused gate+up weight on-device by concatenating the (already cached /
+    # loaded) gate and up tensors along the output dim. Works with warm cache
+    # (state_dict=None) since gate_proj_tt/up_proj_tt exist as device tensors. One-time
+    # at model build. Halves the gate/up sparse_matmul launches at inference.
+    gate_up_proj_tt = ttnn.concat([gate_proj_tt, up_proj_tt], dim=3)
+
     return ExpertWeights(
         gate_proj=gate_proj_tt,
         up_proj=up_proj_tt,
@@ -160,4 +169,5 @@ def load_expert_weights(
         up_proj_bias=up_proj_bias_tt,
         down_proj_bias=down_proj_bias_tt,
         intermediate_size_per_device=intermediate_size_per_device,
+        gate_up_proj=gate_up_proj_tt,
     )

--- a/models/demos/gpt_oss/tt/experts/weights.py
+++ b/models/demos/gpt_oss/tt/experts/weights.py
@@ -155,6 +155,18 @@ def load_expert_weights(
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
 
+    # SwiGLU alpha-fold (build-time): gate*sigmoid(a*gate)*(up+1) = silu(a*gate)/a*(up+1).
+    # Pre-scale gate weights+bias by alpha and down weights by 1/alpha ON-DEVICE so the
+    # per-token SwiGLU can use a single fused ttnn.silu (no separate mul-by-alpha op),
+    # with ZERO runtime correction (the 1/alpha is absorbed into down_proj). Block-float
+    # weights are per-block scale-invariant, so folding a scalar is quantization-neutral.
+    # Done on-device (not in torch) to stay cache-safe (warm cache = device tensors).
+    # The SwiGLU clamp becomes alpha*swiglu_limit (see operations.py / prefill.py).
+    _alpha = config.alpha
+    gate_proj_tt = ttnn.mul(gate_proj_tt, _alpha, dtype=weight_dtype)
+    gate_proj_bias_tt = ttnn.mul(gate_proj_bias_tt, _alpha, dtype=bias_dtype)
+    down_proj_tt = ttnn.mul(down_proj_tt, 1.0 / _alpha, dtype=weight_dtype)
+
     # Build the fused gate+up weight on-device by concatenating the (already cached /
     # loaded) gate and up tensors along the output dim. Works with warm cache
     # (state_dict=None) since gate_proj_tt/up_proj_tt exist as device tensors. One-time

--- a/models/demos/gpt_oss/tt/experts/weights.py
+++ b/models/demos/gpt_oss/tt/experts/weights.py
@@ -28,6 +28,7 @@ class ExpertWeights:
     # Fused gate+up weight (concat along N) built ON-DEVICE from the cached gate/up
     # tensors, so one sparse_matmul produces [gate|up]; output splits [..,:I]/[..,I:].
     gate_up_proj: ttnn.Tensor = None
+    gateup_bias: ttnn.Tensor = None  # concat[gate_bias|up_bias] [1,E,1,2I] for fused SwiGLU
 
 
 def load_expert_weights(
@@ -173,7 +174,16 @@ def load_expert_weights(
     # at model build. Halves the gate/up sparse_matmul launches at inference.
     gate_up_proj_tt = ttnn.concat([gate_proj_tt, up_proj_tt], dim=3)
 
+    # Prebuild concat[gate_bias|up_bias] as [1,E,1,2I] for the fused SwiGLU (one-time
+    # at model build, OUTSIDE the traced decode path). gate/up bias are [1,E,I].
+    _E = config.num_experts
+    _I = intermediate_size_per_device
+    gateup_bias_tt = ttnn.concat(
+        [ttnn.reshape(gate_proj_bias_tt, (1, _E, 1, _I)), ttnn.reshape(up_proj_bias_tt, (1, _E, 1, _I))], dim=3
+    )
+
     return ExpertWeights(
+        gateup_bias=gateup_bias_tt,
         gate_proj=gate_proj_tt,
         up_proj=up_proj_tt,
         down_proj=down_proj_tt,

--- a/models/demos/gpt_oss/tt/matmul_guard.py
+++ b/models/demos/gpt_oss/tt/matmul_guard.py
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 # SPDX-License-Identifier: Apache-2.0
-"""Guard against the sparse/1D matmul reload defect described in PR #51514.
+"""Guard against the sparse/1D matmul reload issue described in PR #51514.
 
 The compute kernel bmm_large_block_zm_fused_bias_activation.cpp splits the
 reduction over K into chunks when in0_block_w does not cover the whole depth.
@@ -14,7 +14,7 @@ every three are wrong (60 of 90). Nothing crashes and nothing warns: the wrong
 values feed the next layer, grow, and reach infinity a few decode steps later,
 so the model writes nonsense.
 
-The defect needs all three of these at the same time:
+The issue needs all three of these at the same time:
 
   1. out_subblock_w > 1        the subblock spans more than one tile, so a
                                later tile exists for the reload to corrupt
@@ -29,7 +29,7 @@ Remove any one condition and the result is correct. Two ways to do that:
     num_blocks_inner_dim = 1, so spill stays false and the reload never runs
   * set out_block_w equal to per_core_N, which makes num_blocks_w_dim = 1
 
-A second and separate defect: the destination register file holds 8 tiles, but
+A second and separate issue: the destination register file holds 8 tiles, but
 only 4 when fp32_dest_acc_en is set. out_subblock_h * out_subblock_w above that
 limit also corrupts the output, so that bound is checked here as well.
 """
@@ -47,7 +47,7 @@ def check_matmul_program_config(
     out_subblock_h: int = 1,
     fp32_dest_acc_en: bool = False,
 ) -> None:
-    """Raise ValueError if this program config hits the PR #51514 defect.
+    """Raise ValueError if this program config hits the PR #51514 issue.
 
     All arguments are in tiles. Kt is the reduction depth, so K / 32.
     """
@@ -62,7 +62,7 @@ def check_matmul_program_config(
 
     if out_subblock_w > 1 and num_blocks_w_dim > 1 and num_blocks_inner_dim > 1:
         raise ValueError(
-            f"{name}: this matmul program config hits the reload defect in "
+            f"{name}: this matmul program config hits the reload issue in "
             f"PR #51514 and would silently produce wrong values.\n"
             f"  out_subblock_w       = {out_subblock_w} (must be 1, or remove one condition below)\n"
             f"  num_blocks_w_dim     = {num_blocks_w_dim} (per_core_N {per_core_N} / out_block_w {out_block_w})\n"

--- a/models/demos/gpt_oss/tt/matmul_guard.py
+++ b/models/demos/gpt_oss/tt/matmul_guard.py
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+"""Guard against the sparse/1D matmul reload defect described in PR #51514.
+
+The compute kernel bmm_large_block_zm_fused_bias_activation.cpp splits the
+reduction over K into chunks when in0_block_w does not cover the whole depth.
+It spills the running total to the cb_intermed0 circular buffer in L1 after
+each chunk, then reloads it with reload_from_cb_to_dst before the next chunk.
+
+That reload restores only the first tile of a multi-tile subblock correctly.
+Later tiles are double counted. With out_subblock_w = 2, every second output
+tile is wrong (45 of 90 for gpt-oss gate_up). With out_subblock_w = 3, two of
+every three are wrong (60 of 90). Nothing crashes and nothing warns: the wrong
+values feed the next layer, grow, and reach infinity a few decode steps later,
+so the model writes nonsense.
+
+The defect needs all three of these at the same time:
+
+  1. out_subblock_w > 1        the subblock spans more than one tile, so a
+                               later tile exists for the reload to corrupt
+  2. num_blocks_w_dim > 1      per_core_N / out_block_w; the core loops over
+                               more than one w-block
+  3. num_blocks_inner_dim > 1  Kt / in0_block_w; K is split into chunks, so
+                               the spill and reload path is active
+
+Remove any one condition and the result is correct. Two ways to do that:
+
+  * set in0_block_w equal to the reduction depth in tiles (Kt), which makes
+    num_blocks_inner_dim = 1, so spill stays false and the reload never runs
+  * set out_block_w equal to per_core_N, which makes num_blocks_w_dim = 1
+
+A second and separate defect: the destination register file holds 8 tiles, but
+only 4 when fp32_dest_acc_en is set. out_subblock_h * out_subblock_w above that
+limit also corrupts the output, so that bound is checked here as well.
+"""
+
+import math
+
+
+def check_matmul_program_config(
+    name: str,
+    Kt: int,
+    in0_block_w: int,
+    per_core_N: int,
+    out_block_w: int,
+    out_subblock_w: int,
+    out_subblock_h: int = 1,
+    fp32_dest_acc_en: bool = False,
+) -> None:
+    """Raise ValueError if this program config hits the PR #51514 defect.
+
+    All arguments are in tiles. Kt is the reduction depth, so K / 32.
+    """
+    if in0_block_w <= 0 or out_block_w <= 0 or out_subblock_w <= 0:
+        raise ValueError(
+            f"{name}: in0_block_w ({in0_block_w}), out_block_w ({out_block_w}) and "
+            f"out_subblock_w ({out_subblock_w}) must all be at least 1"
+        )
+
+    num_blocks_inner_dim = math.ceil(Kt / in0_block_w)
+    num_blocks_w_dim = math.ceil(per_core_N / out_block_w)
+
+    if out_subblock_w > 1 and num_blocks_w_dim > 1 and num_blocks_inner_dim > 1:
+        raise ValueError(
+            f"{name}: this matmul program config hits the reload defect in "
+            f"PR #51514 and would silently produce wrong values.\n"
+            f"  out_subblock_w       = {out_subblock_w} (must be 1, or remove one condition below)\n"
+            f"  num_blocks_w_dim     = {num_blocks_w_dim} (per_core_N {per_core_N} / out_block_w {out_block_w})\n"
+            f"  num_blocks_inner_dim = {num_blocks_inner_dim} (Kt {Kt} / in0_block_w {in0_block_w})\n"
+            f"All three are above 1 at the same time, so the running total is "
+            f"spilled to L1 and reloaded, and the reload restores only the first "
+            f"tile of each subblock. Every tile at an index that is not a multiple "
+            f"of out_subblock_w gets the wrong value.\n"
+            f"Fix by any one of:\n"
+            f"  set in0_block_w = {Kt} (the full reduction depth) so no spill happens\n"
+            f"  set out_block_w = {per_core_N} (per_core_N) so the w loop runs once\n"
+            f"  set out_subblock_w = 1"
+        )
+
+    dest_tiles = 4 if fp32_dest_acc_en else 8
+    if out_subblock_h * out_subblock_w > dest_tiles:
+        raise ValueError(
+            f"{name}: out_subblock_h ({out_subblock_h}) times out_subblock_w "
+            f"({out_subblock_w}) is {out_subblock_h * out_subblock_w}, above the "
+            f"{dest_tiles} tiles the destination register file holds"
+            f"{' with fp32_dest_acc_en set' if fp32_dest_acc_en else ''}. "
+            f"The output would be corrupted."
+        )

--- a/models/demos/gpt_oss/tt/model.py
+++ b/models/demos/gpt_oss/tt/model.py
@@ -411,7 +411,37 @@ class Model:
 
         # Final norm and lm_head
         hidden_states = self.norm(hidden_states)
-        logits = ttnn.matmul(hidden_states, self.lm_head_weight, dtype=ttnn.bfloat8_b)
+        # lm_head 1D-mcast program config from matmul_sweep (per_core_N=64,
+        # out_subblock_w=4). Keep OUTPUT IN DRAM (default): forcing the huge
+        # [.,.,32,~262K] logits to L1 regressed wall-clock 2x (L1 pressure on the
+        # argmax tail), even though device matmul time dropped. Test config alone.
+        lm_pc = None
+        try:
+            M = hidden_states.shape[-2]
+            if M <= 32:
+                Nt = (self.lm_head_weight.shape[-1] + 31) // 32
+                per_core_N = 64
+                num_cores = (Nt + per_core_N - 1) // per_core_N
+                gx = min(13, num_cores)
+                gy = (num_cores + gx - 1) // gx
+                if 0 < gx * gy <= 130:
+                    lm_pc = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+                        compute_with_storage_grid_size=ttnn.CoreCoord(gx, gy),
+                        in0_block_w=1,
+                        out_subblock_h=1,
+                        out_subblock_w=4,
+                        per_core_M=1,
+                        per_core_N=per_core_N,
+                        fuse_batch=True,
+                        fused_activation=None,
+                        mcast_in0=True,
+                    )
+        except Exception:
+            lm_pc = None
+        if lm_pc is not None:
+            logits = ttnn.matmul(hidden_states, self.lm_head_weight, dtype=ttnn.bfloat8_b, program_config=lm_pc)
+        else:
+            logits = ttnn.matmul(hidden_states, self.lm_head_weight, dtype=ttnn.bfloat8_b)
         hidden_states.deallocate(True)
         self._prefill_sampling_active = False
         # TP all-gather is deferred to process_output_prefill / process_output_decode

--- a/models/demos/gpt_oss/tt/model.py
+++ b/models/demos/gpt_oss/tt/model.py
@@ -221,6 +221,24 @@ class Model:
 
         # Initialize on-device sampling (supported when padded per-device vocab fits in 64K)
         self._supports_on_device_sampling = per_device_padded <= 64 * 1024
+
+        # When on-device sampling is DISABLED (TP=1: pow2 per-device vocab > 64K),
+        # decode uses host-greedy ttnn.argmax (no topk), so the pow2 vocab padding
+        # (262144 vs ~201088 real) is dead weight -- the lm_head matmul computes ~23%
+        # zero columns/token. Trim the loaded weight ON-DEVICE to tile-aligned real
+        # vocab (the pow2 tail is all zeros; real vocab is a prefix, so argmax over the
+        # trimmed logits returns the identical greedy token). The lm_head program
+        # config derives Nt from shape[-1] so it adapts automatically.
+        if not self._supports_on_device_sampling and self.lm_head_weight is not None:
+            tile_vocab = ((self.vocab_size + 31) // 32) * 32
+            if self.lm_head_weight.shape[-1] > tile_vocab:
+                _shp = list(self.lm_head_weight.shape)
+                _starts = [0] * len(_shp)
+                _ends = list(_shp)
+                _ends[-1] = tile_vocab
+                _trimmed = ttnn.slice(self.lm_head_weight, _starts, _ends)
+                ttnn.deallocate(self.lm_head_weight)
+                self.lm_head_weight = _trimmed
         self._prefill_sampling_active = False
         # sampling_dp: number of independent sampling groups (one per mesh row for row-sharded users)
         self.sampling_dp = mesh_device.shape[0] if users_row_sharded else 1

--- a/models/demos/gpt_oss/tt/model.py
+++ b/models/demos/gpt_oss/tt/model.py
@@ -457,9 +457,15 @@ class Model:
         except Exception:
             lm_pc = None
         if lm_pc is not None:
-            logits = ttnn.matmul(hidden_states, self.lm_head_weight, dtype=ttnn.bfloat8_b, program_config=lm_pc)
+            # Emit bf16 logits. The host-side greedy path needs bf16/fp32 for
+            # ttnn.argmax and was typecasting bf8 -> bf16 every token (58 us of
+            # device time, plus a full host dispatch because that op runs OUTSIDE
+            # the captured decode trace). Writing bf16 here costs ~6 MB more
+            # (~0.012 ms at 512 GB/s) and removes both. bf16 is strictly more
+            # precise than bf8, so the greedy argmax result cannot get worse.
+            logits = ttnn.matmul(hidden_states, self.lm_head_weight, dtype=ttnn.bfloat16, program_config=lm_pc)
         else:
-            logits = ttnn.matmul(hidden_states, self.lm_head_weight, dtype=ttnn.bfloat8_b)
+            logits = ttnn.matmul(hidden_states, self.lm_head_weight, dtype=ttnn.bfloat16)
         hidden_states.deallocate(True)
         self._prefill_sampling_active = False
         # TP all-gather is deferred to process_output_prefill / process_output_decode

--- a/models/demos/gpt_oss/tt/rms_norm.py
+++ b/models/demos/gpt_oss/tt/rms_norm.py
@@ -126,7 +126,10 @@ class RMSNorm(nn.Module):
                         memory_config=sharded_mem,
                     )
                     x_sh.deallocate(True)
-                    tt_output = ttnn.sharded_to_interleaved(out_sh, ttnn.DRAM_MEMORY_CONFIG)
+                    # Convert back to L1 interleaved (not DRAM): keeps the norm output
+                    # on-chip for the downstream matmul/router instead of round-tripping
+                    # through DRAM. L1 has far higher aggregate BW than DRAM.
+                    tt_output = ttnn.sharded_to_interleaved(out_sh, ttnn.L1_MEMORY_CONFIG)
                     out_sh.deallocate(True)
                     return tt_output
                 except Exception:

--- a/models/demos/gpt_oss/tt/rms_norm.py
+++ b/models/demos/gpt_oss/tt/rms_norm.py
@@ -81,10 +81,48 @@ class RMSNorm(nn.Module):
             ttnn.deallocate(tt_gathered_stats)
             return tt_output
         else:
+            # Decode single-row case ([1,1,1,W] padded to [.,.,32,W]): the default
+            # interleaved path auto-selects a SINGLE core to reduce all W/32 tiles
+            # (~40us, 3% BW). Width-shard across cores + sharded program config
+            # parallelizes the reduction (swept best = 9 cores for W=2880). The
+            # shard HEIGHT must be the padded tile height (32), not the logical H=1.
+            W = x.shape[-1]
+            H = x.shape[-2]
+            TILE = ttnn.TILE_SIZE
+            Wt = W // TILE
+            ncores = 9 if Wt % 9 == 0 else next((c for c in (10, 6, 5, 3) if Wt % c == 0), 1)
+            if (
+                x.memory_config().memory_layout == ttnn.TensorMemoryLayout.INTERLEAVED
+                and H <= TILE
+                and ncores > 1
+                and W % TILE == 0
+            ):
+                grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(ncores - 1, 0))})
+                # shard shape uses padded tile height (TILE), width split across cores
+                shard_spec = ttnn.ShardSpec(grid, [TILE, W // ncores], ttnn.ShardOrientation.ROW_MAJOR)
+                sharded_mem = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, shard_spec)
+                x_sh = ttnn.to_memory_config(x, sharded_mem)
+                pc = ttnn.LayerNormShardedMultiCoreProgramConfig(
+                    compute_with_storage_grid_size=ttnn.CoreCoord(ncores, 1),
+                    subblock_w=1,
+                    block_h=1,
+                    block_w=Wt // ncores,
+                    inplace=False,
+                )
+                out_sh = ttnn.rms_norm(
+                    x_sh,
+                    weight=self.tt_weight,
+                    epsilon=self.eps,
+                    program_config=pc,
+                    memory_config=sharded_mem,
+                )
+                x_sh.deallocate(True)
+                tt_output = ttnn.sharded_to_interleaved(out_sh, ttnn.DRAM_MEMORY_CONFIG)
+                out_sh.deallocate(True)
+                return tt_output
             tt_output = ttnn.rms_norm(
                 x,
                 weight=self.tt_weight,
                 epsilon=self.eps,
-                # program_config=program_config,
             )
             return tt_output

--- a/models/demos/gpt_oss/tt/rms_norm.py
+++ b/models/demos/gpt_oss/tt/rms_norm.py
@@ -90,36 +90,47 @@ class RMSNorm(nn.Module):
             H = x.shape[-2]
             TILE = ttnn.TILE_SIZE
             Wt = W // TILE
+            Ht = max(1, -(-H // TILE))  # ceil rows in tiles (H may be 1 at decode)
             ncores = 9 if Wt % 9 == 0 else next((c for c in (10, 6, 5, 3) if Wt % c == 0), 1)
+            # Width-shard the norm across cores + sharded program config to parallelize
+            # the reduction (1-core interleaved default ~40us/op at ~3% BW). Also moves
+            # the tensor DRAM->L1 (higher aggregate BW). Wrapped in try/except: sharded
+            # program build can TT_THROW on shapes not seen at development time (e.g.
+            # multi-tile-row prefill norms), so fall back to the safe default path.
             if (
                 x.memory_config().memory_layout == ttnn.TensorMemoryLayout.INTERLEAVED
-                and H <= TILE
                 and ncores > 1
                 and W % TILE == 0
+                and Ht <= 4  # cap L1 shard footprint; larger seqs use default path
             ):
-                grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(ncores - 1, 0))})
-                # shard shape uses padded tile height (TILE), width split across cores
-                shard_spec = ttnn.ShardSpec(grid, [TILE, W // ncores], ttnn.ShardOrientation.ROW_MAJOR)
-                sharded_mem = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, shard_spec)
-                x_sh = ttnn.to_memory_config(x, sharded_mem)
-                pc = ttnn.LayerNormShardedMultiCoreProgramConfig(
-                    compute_with_storage_grid_size=ttnn.CoreCoord(ncores, 1),
-                    subblock_w=1,
-                    block_h=1,
-                    block_w=Wt // ncores,
-                    inplace=False,
-                )
-                out_sh = ttnn.rms_norm(
-                    x_sh,
-                    weight=self.tt_weight,
-                    epsilon=self.eps,
-                    program_config=pc,
-                    memory_config=sharded_mem,
-                )
-                x_sh.deallocate(True)
-                tt_output = ttnn.sharded_to_interleaved(out_sh, ttnn.DRAM_MEMORY_CONFIG)
-                out_sh.deallocate(True)
-                return tt_output
+                try:
+                    grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(ncores - 1, 0))})
+                    # shard shape: padded tile-row height, width split across cores
+                    shard_spec = ttnn.ShardSpec(grid, [Ht * TILE, W // ncores], ttnn.ShardOrientation.ROW_MAJOR)
+                    sharded_mem = ttnn.MemoryConfig(
+                        ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, shard_spec
+                    )
+                    x_sh = ttnn.to_memory_config(x, sharded_mem)
+                    pc = ttnn.LayerNormShardedMultiCoreProgramConfig(
+                        compute_with_storage_grid_size=ttnn.CoreCoord(ncores, 1),
+                        subblock_w=1,
+                        block_h=Ht,
+                        block_w=Wt // ncores,
+                        inplace=False,
+                    )
+                    out_sh = ttnn.rms_norm(
+                        x_sh,
+                        weight=self.tt_weight,
+                        epsilon=self.eps,
+                        program_config=pc,
+                        memory_config=sharded_mem,
+                    )
+                    x_sh.deallocate(True)
+                    tt_output = ttnn.sharded_to_interleaved(out_sh, ttnn.DRAM_MEMORY_CONFIG)
+                    out_sh.deallocate(True)
+                    return tt_output
+                except Exception:
+                    pass  # fall through to the robust default path
             tt_output = ttnn.rms_norm(
                 x,
                 weight=self.tt_weight,

--- a/models/demos/gpt_oss/tt/topk.py
+++ b/models/demos/gpt_oss/tt/topk.py
@@ -52,13 +52,16 @@ class TopKRouter:
         self.tensor_cache_path = tensor_cache_path
         torch_weight = state_dict["weight"].transpose(0, 1) if state_dict else None
         torch_bias = state_dict["bias"].unsqueeze(0) if state_dict else None
+        # Router weight (hidden x 32) + bias are tiny (~184KB) and read every decode
+        # token. Pin them in L1 (not DRAM) so the per-token router matmul reads from
+        # on-chip memory (far higher aggregate BW than DRAM).
         self.weight = ttnn.as_tensor(
             torch_weight,
             device=mesh_device,
             layout=ttnn.TILE_LAYOUT,
             dtype=ttnn.bfloat16,
             cache_file_name=get_cache_file_name(tensor_cache_path, "weight"),
-            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            memory_config=ttnn.L1_MEMORY_CONFIG,
         )
         self.bias = ttnn.as_tensor(
             torch_bias,
@@ -66,7 +69,7 @@ class TopKRouter:
             layout=ttnn.TILE_LAYOUT,
             dtype=ttnn.bfloat16,
             cache_file_name=get_cache_file_name(tensor_cache_path, "bias"),
-            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            memory_config=ttnn.L1_MEMORY_CONFIG,
         )
 
         # Keep compute_config=None for linear (known quality-safe default)

--- a/models/demos/gpt_oss/tt/topk.py
+++ b/models/demos/gpt_oss/tt/topk.py
@@ -133,12 +133,29 @@ class TopKRouter:
         # Use L1 for decode (small tensors), DRAM for prefill (large sequences)
         is_decode = actual_tokens <= 128
         mem_config = ttnn.L1_MEMORY_CONFIG if is_decode else ttnn.DRAM_MEMORY_CONFIG
+        # The decode router matmul (M=32,K=2880,N=32) auto-selects a SINGLE core
+        # (~62us, the N=32=1-tile output can't split, K=2880 reduced serially).
+        # Swept 1D config splits the M rows / K reduction across cores (mcast_in0=False).
+        router_pc = None
+        if is_decode and actual_tokens == 32 and hidden_states.shape[-1] % 32 == 0:
+            ncores = 10
+            router_pc = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+                compute_with_storage_grid_size=ttnn.CoreCoord(ncores, 1),
+                in0_block_w=9,
+                out_subblock_h=1,
+                out_subblock_w=1,
+                per_core_M=max(1, (actual_tokens // 32)),
+                per_core_N=1,
+                fuse_batch=True,
+                mcast_in0=False,
+            )
         router_logits = ttnn.linear(
             hidden_states,
             self.weight,
             bias=self.bias,
             memory_config=mem_config,
             compute_kernel_config=self.compute_config,
+            program_config=router_pc,
         )
 
         expert_indices, expert_weights = topk_router(

--- a/models/demos/gpt_oss/tt/topk.py
+++ b/models/demos/gpt_oss/tt/topk.py
@@ -10,9 +10,12 @@ transformation followed by top-k selection to assign tokens to experts.
 
 """
 
+import os
+
 import torch
 
 import ttnn
+from models.demos.gpt_oss.kernels.router_fused_op import fused_router
 from models.demos.gpt_oss.utils.general_utils import get_cache_file_name
 
 
@@ -149,14 +152,59 @@ class TopKRouter:
                 fuse_batch=True,
                 mcast_in0=False,
             )
+        # Emit bf16 directly. hidden_states is bf8, so ttnn.linear would otherwise
+        # produce bf8 logits and topk_router immediately typecasts them to bf16
+        # anyway (an extra op/layer). Asking for bf16 here removes that typecast and
+        # keeps full precision through the top-k comparison, which is a pure
+        # argmax-style operation where bf8's 8-bit mantissa is the weakest link.
         router_logits = ttnn.linear(
             hidden_states,
             self.weight,
             bias=self.bias,
+            dtype=ttnn.bfloat16,
             memory_config=mem_config,
             compute_kernel_config=self.compute_config,
             program_config=router_pc,
         )
+
+        # Fused router: one generic_op (reader+writer) replaces the 16-launch
+        # FillPad/Pad/FillPad/TopK/Slice/Slice/Softmax/Unary/Untilize x3/Scatter/
+        # Tilize/Untilize/Fill chain, which costs ~58.8 us/layer to do ~100 scalar
+        # ops on a single [1,32] logits row.
+        # Requires bf16 logits: the kernel reads raw bf16 halves, and a BFLOAT8_B
+        # block-float input decodes as garbage (verified: ids [0,1,2,8] instead of
+        # [26,4,22,17]). That is why router_logits above asks for bf16.
+        # Verified vs torch on the exact decode spec: 8/8 trials, worst weight
+        # error 0.00178. ROUTER_FUSED=0 falls back to the stock path.
+        if (
+            not use_throughput_experts
+            and os.environ.get("ROUTER_FUSED", "1") == "1"
+            and router_logits.dtype == ttnn.bfloat16
+            and router_logits.shape[-1] == self.num_experts
+            # The kernel processes exactly ONE token row (it reads row 0 of the
+            # tile and zeroes the rest). is_decode is true for up to 128 tokens, so
+            # gating on it would silently zero the routing weights of every row but
+            # the first. Gate on the real row count instead.
+            and router_logits.shape[0] == 1
+        ):
+            dev = router_logits.device()
+            w_out = ttnn.allocate_tensor_on_device(
+                ttnn.Shape([router_logits.shape[0], self.num_experts]),
+                ttnn.bfloat16,
+                ttnn.TILE_LAYOUT,
+                dev,
+                ttnn.L1_MEMORY_CONFIG,
+            )
+            id_out = ttnn.allocate_tensor_on_device(
+                ttnn.Shape([router_logits.shape[0], self.top_k]),
+                ttnn.uint16,
+                ttnn.TILE_LAYOUT,
+                dev,
+                ttnn.L1_MEMORY_CONFIG,
+            )
+            fused_router(router_logits, w_out, id_out, self.num_experts, self.top_k)
+            ttnn.deallocate(router_logits)
+            return id_out, w_out
 
         expert_indices, expert_weights = topk_router(
             router_logits, self.top_k, use_throughput_experts, self.softmax_compute_config


### PR DESCRIPTION
## Summary

This branch makes **gpt-oss-20b single-user decode** faster on one Blackhole **p150** (batch=1, TP=1). It also makes the MoE sparse-matmul sweep a reusable tool.

Decode speed went from **21 to 73 tok/s/user (3.5x)**. Time to first token went down 54%. Accuracy stays at **top-1 0.9667 / top-5 1.0000**.

> **Draft** — open for early review of the approach and the sweep tool. All numbers are for one p150 (TP=1). I measure wall-clock speed from the demo, then check the result with a signpost-split Tracy device profile. I keep a change only if both agree.

## How to run it

Two runs of one command. The demo prints its own throughput.

```bash
export TT_METAL_HOME=$(pwd)
export HF_MODEL=/path/to/gpt-oss-20b   # HF checkpoint
export TT_CACHE_PATH=/path/to/tt_cache # writable dir for the weight cache (~14G)

pytest "models/demos/gpt_oss/demo/text_demo.py::test_gpt_oss_demo[blackhole-1x1-prefill_128]" --timeout=0
```

The first run converts the checkpoint into the ttnn weight cache and is slow. The second run reads
that cache and prints the speed:

```
Average decode speed: 13.46ms @ 74.27 tok/s/user
```

Set `TT_CACHE_PATH`. Without it the cache is written into the `HF_MODEL` directory.

`prefill_128` is batch 1, TP 1, decode tracing on. Add `-s` to print the generated text. Ignore the
`dummy weights` log line. 
The `Warm ttnn weight cache detected` line below it means real weights
loaded from the cache.

## Speed history

Each row is a separate commit. The measurement is the median of at least 3 runs.

| Step | Change | tok/s/user |
|---|---|---|
| start | — | 21.0 |
| 1 | On-device `ttnn.argmax` for greedy decode | 29.5 |
| 2 | Faster argmax: slice to the active batch first | 38.6 |
| 3 | Multi-core config for the 1-core router matmul | 40.8 |
| 4 | Retune expert `in0_block_w` to 45 | 45.2 |
| 5 | Program config for the lm_head matmul | 49.2 |
| 6 | gate/up `sparse_matmul` writes bf16 | 50.8 |
| 7 | down `sparse_matmul` writes bf16 | 51.7 |
| 8 | qkv output in L1 instead of DRAM | 53.3 |
| 9 | Trim lm_head to the real vocabulary size | 54.9 |
| 10 | Fold the SwiGLU alpha at build time | 56.1 |
| 11 | Fused expert-tail SwiGLU megakernel | 57.8 |
| 12 | Fix `out_block_w`, then re-sweep `out_subblock_w` | 59.1 |
| 13 | Static `nnz` in the decode `sparse_matmul` | 60.0 |
| 14 | Multi-core kernel for the qkv head split | 61.4 |
| 15 | Program config for the decode qkv matmul | 63.4 |
| 16 | Fused MoE router megakernel | 66.7 |
| 17 | gate/up `sparse_matmul` 30 to 45 cores | 69.7 |
| 18 | Retune gate/up `in0_block_w` to 3 | 71.4 |
| 19 | Retune down `in0_block_w` to 9 | 72.2 |
| 20 | SwiGLU kernel 45 to 72 cores | 72.8 |
| 21 | lm_head writes bf16, so the typecast goes away | **73.0** |

Decode speed went from 21.0 to 73.0 tok/s/user. That is 3.5 times faster.
Accuracy stays at top-1 0.9667 and top-5 1.0000.

The largest single win was step 1. The old code sent the whole
`[batch, 201088]` logit tensor to the host every token. That cost about 46 ms
per token. The new code runs `ttnn.argmax` on the device. It reads back only
the winning token id.

Steps 14 and 16 replace several small operations with one kernel. The head
split kernel removes `NLPCreateQKVHeads`. The router kernel removes TopK,
Softmax, FillPad, Pad and Scatter. Together they cut the operation count from
1123 to 835 per token.

Steps 17 to 20 tune core counts and block widths. Three rules came out of this
work:

1. More cores help only when each core holds enough work. Above about
   1 MB per core the pipeline starves, so more cores help. Below about
   0.83 MB per core, more cores do nothing or they hurt. The gate/up
   projection gained 20% at 45 cores. The qkv projection lost speed at
   80 cores.
2. Retune `in0_block_w` after every core count change. The best value is
   different for each projection: 3 for gate/up, 9 for down, 2 for qkv. Do
   not share one value.
3. `ttnn` drops an invalid program config without a message and uses its own
   default. Always confirm that the core count changed in the Tracy profile.
   A change with no profile effect was probably rejected.

Step 21 is small but it shows where the remaining time goes. The greedy path
needs bf16 input for `ttnn.argmax`, so it converted the bf8 logits every
token. That conversion ran outside the captured trace, so it also paid a full
host launch. The lm_head matmul now writes bf16 directly. The wider write
costs 0.041 ms per token. The removed conversion saves 0.058 ms per token.

## Where the time goes now

Decode takes 12.66 ms per token of device time and 13.70 ms of wall time. The
gap is 1.06 ms. Only 0.07 ms of that gap is device work outside the trace. The
rest is trace launch, the token read back, and the host loop.

Two operation groups hold 72% of the decode time:

| Group | ms/token | Note |
|---|---|---|
| Matmul | 4.55 | o_proj, lm_head, qkv, router |
| SparseMatmul | 4.53 | gate/up 3.30, down 1.70 |

Both groups run at 51% to 53% of the weight-read roofline. The small
operations that remain cost about 9 us each. That is the dispatch floor, which
a 1-tile `ttnn.clone` also pays. Further model-level tuning gives very little.
The next gains need a change inside tt-metal, a lighter host loop, or more
than one chip.

## Using the sparse-matmul sweep

`models/demos/gpt_oss/tests/sweeps/moe_sparse_matmul_sweep.py` is a general CLI
for tuning any MoE `ttnn.sparse_matmul`. Give it the sparse GEMM dimensions. It
sweeps the program config (core grid, `in0_block_w`, `out_subblock_w`,
`out_block_w`), fidelity, dtype, and memory placement. It times each config on
the device, checks PCC against a torch reference, and reports achieved DRAM
bandwidth. It prints one `RESULT` line per config, writes a CSV, and prints the
fastest passing config as `BEST`.

```bash
# gpt-oss decode gate/up (fused [gate|up], N=5760)
python models/demos/gpt_oss/tests/sweeps/moe_sparse_matmul_sweep.py \
    --proj gate_up --K 2880 --N 5760 --experts 32 --active 4 \
    --in0-block-ws 15 30 45 --out-subblock-ws 1 2 3 --obw-mults 1 2 3 \
    --csv models/demos/gpt_oss/tests/sweeps/out/gate_up.csv

# gpt-oss decode down projection (the activation is the sparse operand)
python models/demos/gpt_oss/tests/sweeps/moe_sparse_matmul_sweep.py \
    --proj down --K 2880 --N 2880 --experts 32 --active 4

# any MoE sparse GEMM (weight-sparse), also sweeping weight placement
python models/demos/gpt_oss/tests/sweeps/moe_sparse_matmul_sweep.py \
    --sparse-input b --experts 16 --active 2 --K 4096 --N 4096 \
    --weight-mems dram l1
```

**Main flags**

- `--sparse-input {a,b}` — which operand is sparse. `b` means the weight is
  sparse and the activation is shared (gpt-oss gate/up). `a` means the activation
  is per-expert, `is_input_a_sparse=True` (gpt-oss down). `--proj gate_up|down`
  is a gpt-oss alias.
- `--K --N --experts --active` — the GEMM dimensions, and how many of the E
  experts are non-zero.
- Sweep axes, each taking a list: `--in0-block-ws`, `--out-subblock-ws`,
  `--obw-mults`, `--fidelities`, `--act-dtypes`, `--weight-mems`, `--out-mems`,
  `--act-mems`.
- `--csv PATH` — write results. A live `<csv>.progress.json` shows progress and
  an estimated finish time.

**`--obw-mults`** sets `out_block_w = obw_mult * out_subblock_w`, so `obw_mult`
is `in1_num_subblocks`. A value of 1 gives `out_block_w == out_subblock_w`. Use
higher values to search toward `out_block_w == per_core_N`.

## Hang safety

This applies to every MoE model, not only gpt-oss. The `mcast_in0` kernel in
`sparse_matmul` can **deadlock** the device. A deadlock is not a catchable
exception. Three known causes:

1. A very small core grid.
2. `out_subblock_w > 1` when `per_core_N` cannot be divided by it.
3. A static `nnz` that is larger than `count_nonzero(sparsity)`.

The tool avoids all three by default (`--out-subblock-ws 1`, `--min-cores 12`,
`nnz=None`). As a second layer of protection it runs every config in its own
subprocess with a wall-clock timeout. On a timeout it marks the config `HANG`,
resets the board, and continues.

Cause 3 is why the model used `nnz=None` for a long time. Step 13 above replaces
it with a static `nnz`, but only after measuring that the real count never drops
below `num_experts_per_tok` on this model. Do not copy that change to another
model without taking the same measurement.

## Testing

- **Accuracy**: `models/demos/gpt_oss/tests/accuracy/test_model.py::test_full_model_accuracy[blackhole-1x1]`
  gives top-1 0.9667 and top-5 1.0000. This runs with tracing off.
- **Speed**: the perf demo, median of at least 3 runs. Wall clock moves about 25%
  run to run, so I use the median and confirm with device time.
- **Device time**: a signpost-split Tracy profile, which is deterministic and
  separates prefill from decode with a hard boundary.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=gtobarTT/gpt_oss_opt)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:gtobarTT/gpt_oss_opt)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=gtobarTT/gpt_oss_opt)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:gtobarTT/gpt_oss_opt)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=gtobarTT/gpt_oss_opt)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:gtobarTT/gpt_oss_opt)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=gtobarTT/gpt_oss_opt)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:gtobarTT/gpt_oss_opt)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=gtobarTT/gpt_oss_opt)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:gtobarTT/gpt_oss_opt)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=gtobarTT/gpt_oss_opt)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:gtobarTT/gpt_oss_opt)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=gtobarTT/gpt_oss_opt)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:gtobarTT/gpt_oss_opt)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=gtobarTT/gpt_oss_opt)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:gtobarTT/gpt_oss_opt)



