### PR TITLE
Prepare moreh_mean for Device 2.0 port

### DIFF
--- a/ttnn/cpp/ttnn/kernel/dataflow/moreh_common.hpp
+++ b/ttnn/cpp/ttnn/kernel/dataflow/moreh_common.hpp
@@ -97,7 +97,7 @@ FORCE_INLINE void generate_bcast_scaler(DataflowBuffer cb_scaler, uint32_t scale
 
 FORCE_INLINE void fill_cb_with_value(DataflowBuffer cb, uint32_t value, int32_t num_of_elems = 1024) {
     cb.reserve_back(1);
-    const DataFormat data_format = get_dataformat(cb.get_id());
+    const DataFormat data_format = cb.get_dataformat();
     switch ((uint)data_format & 0x1F) {
         case ((uint8_t)DataFormat::Float32):
         case ((uint8_t)DataFormat::Int32):


### PR DESCRIPTION
### Issue 
https://github.com/tenstorrent/tt-metal/issues/51401

### Summary
`fill_cb_with_value` already takes a DataflowBuffer by value, but reached back through `cb.get_id()` to a free function to read its data format. This was the one Device 2.0 holdover in the shared moreh dataflow pool, and it failed the Device 2.0 gate of the moreh_mean Metal 2.0 pre-port audit.

By Replacing the last Device 1.0 free-function idiom in `moreh_common.hpp`, the audit is GREEN.
```cpp
- const DataFormat data_format = get_dataformat(cb.get_id());
+ const DataFormat data_format = cb.get_dataformat();
```

## Test
pytest tests/ttnn/nightly/unit_tests/operations/moreh — 1478 passed, 0 failed

### Notes for reviewers
There is no functional change, only calling convention change.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=anasuya/migrate_2.0_moreh_mean)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:anasuya/migrate_2.0_moreh_mean)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=anasuya/migrate_2.0_moreh_mean)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:anasuya/migrate_2.0_moreh_mean)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=anasuya/migrate_2.0_moreh_mean)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:anasuya/migrate_2.0_moreh_mean)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=anasuya/migrate_2.0_moreh_mean)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:anasuya/migrate_2.0_moreh_mean)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=anasuya/migrate_2.0_moreh_mean)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:anasuya/migrate_2.0_moreh_mean)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=anasuya/migrate_2.0_moreh_mean)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:anasuya/migrate_2.0_moreh_mean)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=anasuya/migrate_2.0_moreh_mean)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:anasuya/migrate_2.0_moreh_mean)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=anasuya/migrate_2.0_moreh_mean)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:anasuya/migrate_2.0_moreh_mean)