### PR TITLE
[Test Only] Updating Quasar regression tests to include FD; Enabling more tests to run FD

### DIFF
--- a/tests/scripts/quasar/quasar_local_tests.yaml
+++ b/tests/scripts/quasar/quasar_local_tests.yaml
@@ -1,17 +1,18 @@
+# Quasar local emulator tests
+#
+# Structure:
+#   <group>:              gtest binary under build/test/tt_metal/, or pytest file path
+#                         relative to TT_METAL_HOME
+#     - filter: <pattern> gtest filter, or pytest node id after :: (e.g. test_foo)
+#       config: <config>  Simulator grid (emu-quasar-<config>): 1x3, 2x3, 2x3_DISPATCH
+#       runner: <type>    (optional) gtest (default) or pytest
+#       env:              (optional) Extra environment variables as key: value pairs
+#       gtest_repeat:     (optional, gtest only) --gtest_repeat=N
+#       back2back:        (optional, gtest only) Batch consecutive entries that
+#                         share group, config, env, and gtest_repeat into one process.
+#                         Illegal for runner: pytest.
+
 unit_tests_legacy:
-# 2x3 tests run back-to-back
-  - filter: "*SingleDmL1Write*"
-    config: 2x3
-    back2back: true
-    env:
-      TT_METAL_SLOW_DISPATCH_MODE: 1
-
-  - filter: "*MultiDmAddTwoInts*"
-    config: 2x3
-    back2back: true
-    env:
-      TT_METAL_SLOW_DISPATCH_MODE: 1
-
 # Worker Fast Dispatch test
   - filter: "*SingleDmL1Write*"
     config: 2x3
@@ -71,17 +72,20 @@ unit_tests_api:
     back2back: true
 
 unit_tests_device:
-  - filter: "*SimulatorFixture*QuasarStaticTlbReadWrite*"
+  - filter: "*FastDispatchMeshDeviceFixture*QuasarStaticTlbReadWrite*"
     config: 2x3_DISPATCH
     back2back: true
 
-# pytest tests/tt_metal/tools/profiler/test_device_profiler.py::test_custom_cycle_count_slow_dispatch
-#     config: 1x3
-#     env:
-#       TT_METAL_DEVICE_PROFILER=1
-#       TT_METAL_SLOW_DISPATCH_MODE=1
+tests/tt_metal/tools/profiler/test_device_profiler.py:
+  - filter: test_custom_cycle_count_slow_dispatch
+    runner: pytest
+    config: 1x3
+    env:
+      TT_METAL_DEVICE_PROFILER: 1
+      TT_METAL_SLOW_DISPATCH_MODE: 1
 
-# pytest tests/tt_metal/tools/profiler/test_device_profiler.py::test_custom_cycle_count
-#     config: 2x3_DISPATCH
-#     env:
-#       TT_METAL_DEVICE_PROFILER=1
+  - filter: test_custom_cycle_count
+    runner: pytest
+    config: 2x3_DISPATCH
+    env:
+      TT_METAL_DEVICE_PROFILER: 1

--- a/tests/scripts/quasar/quasar_local_tests.yaml
+++ b/tests/scripts/quasar/quasar_local_tests.yaml
@@ -1,81 +1,38 @@
-# Quasar local emulator tests
+# Quasar emulator regression tests
 #
 # Structure:
 #   <group>:              gtest binary under build/test/tt_metal/, or pytest file path
 #                         relative to TT_METAL_HOME
-#     - filter: <pattern> gtest filter, or pytest node id after :: (e.g. test_foo)
+#     - filter: <pattern> gtest filter glob, or pytest node id after :: (e.g. test_foo)
 #       config: <config>  Simulator grid (emu-quasar-<config>): 1x3, 2x3, 2x3_DISPATCH
 #       runner: <type>    (optional) gtest (default) or pytest
 #       env:              (optional) Extra environment variables as key: value pairs
 #       gtest_repeat:     (optional, gtest only) --gtest_repeat=N
-#       back2back:        (optional, gtest only) Batch consecutive entries that
-#                         share group, config, env, and gtest_repeat into one process.
+#       back2back:        (optional, gtest only) When true, run this entry in the same
+#                         process as other consecutive back2back entries that share the
+#                         same group, config, env, and gtest_repeat. Used by
+#                         run_quasar_regression.sh. Defaults to false.
 #                         Illegal for runner: pytest.
+#
+# Example gtest entry
+#
+# unit_tests_legacy:
+#   - filter: "*SingleDmL1Write*"
+#     config: 1x3
+#     env:
+#       TT_METAL_SOMETHING: 1
+#
+# Example pytest entry
+#
+# tests/tt_metal/tools/profiler/test_device_profiler.py:
+#   - filter: test_custom_cycle_count
+#     runner: pytest
+#     config: 2x3_DISPATCH
+#     env:
+#       TT_METAL_DEVICE_PROFILER: 1
 
-unit_tests_legacy:
-# Worker Fast Dispatch test
-  - filter: "*SingleDmL1Write*"
-    config: 2x3
-    back2back: true
-    env:
-      TT_METAL_TENSIX_DISPATCH_CORES: 1
 
-# Fast Dispatch (Dispatch Engine) tests
-  - filter: "*SingleDmL1Write*"
-    config: 2x3_DISPATCH
-    back2back: true
-
-  - filter: "*DmLoopback*"
-    config: 2x3_DISPATCH
-    back2back: true
-
-  - filter: "*QuasarComputeKernelSingleThread*"
-    config: 2x3_DISPATCH
-    back2back: true
-
-  - filter: "*QuasarComputeKernelMultipleThread*"
-    config: 2x3_DISPATCH
-    back2back: true
-
-  - filter: "*QuasarCreateMultipleComputeKernelsSingleCluster*"
-    config: 2x3_DISPATCH
-    back2back: true
-
-  - filter: "*QuasarMeshDeviceSingleCardFixture*GlobalsAndTLS"
-    config: 2x3_DISPATCH
-    back2back: true
-
-  - filter: "*QuasarMeshDeviceSingleCardFixture.QuasarComputeKernelTLS*"
-    config: 2x3_DISPATCH
-    back2back: true
-
-  # - filter: "QuasarMeshDeviceSingleCardFixture.QuasarMultiSemaphorePipeline"
-  #   config: 1x3
-  #   back2back: true
-  #   env:
-
-  - filter: "*Bmm"
-    config: 2x3_DISPATCH
-    back2back: true
-
-unit_tests_api:
-  - filter: "*QuasarCRTASharedL1Address*"
-    config: 2x3_DISPATCH
-    back2back: true
-
-  - filter: "*QuasarCRTAUniqueL1Addresses*"
-    config: 2x3_DISPATCH
-    back2back: true
-
-  - filter: "*TensixSingleCoreDirectDramReaderDatacopyWriter"
-    config: 2x3_DISPATCH
-    back2back: true
-
-unit_tests_device:
-  - filter: "*FastDispatchMeshDeviceFixture*QuasarStaticTlbReadWrite*"
-    config: 2x3_DISPATCH
-    back2back: true
-
+# Profiler tests
 tests/tt_metal/tools/profiler/test_device_profiler.py:
   - filter: test_custom_cycle_count_slow_dispatch
     runner: pytest
@@ -85,6 +42,12 @@ tests/tt_metal/tools/profiler/test_device_profiler.py:
       TT_METAL_SLOW_DISPATCH_MODE: 1
 
   - filter: test_custom_cycle_count
+    runner: pytest
+    config: 2x3_DISPATCH
+    env:
+      TT_METAL_DEVICE_PROFILER: 1
+
+  - filter: test_full_buffer
     runner: pytest
     config: 2x3_DISPATCH
     env:

--- a/tests/scripts/quasar/quasar_local_tests.yaml
+++ b/tests/scripts/quasar/quasar_local_tests.yaml
@@ -52,3 +52,4 @@ tests/tt_metal/tools/profiler/test_device_profiler.py:
     config: 2x3_DISPATCH
     env:
       TT_METAL_DEVICE_PROFILER: 1
+      ARCH_NAME: quasar

--- a/tests/scripts/quasar/quasar_regression_tests.yaml
+++ b/tests/scripts/quasar/quasar_regression_tests.yaml
@@ -46,7 +46,7 @@ unit_tests_legacy:
     env:
       TT_METAL_SLOW_DISPATCH_MODE: 1
 
-  - filter: "*Bmm"
+  - filter: "*MeshDeviceSingleCardFixture.Bmm"
     config: 1x3
     back2back: true
     env:
@@ -110,7 +110,7 @@ unit_tests_legacy:
     config: 2x3_DISPATCH
     back2back: true
 
-  - filter: "*Bmm"
+  - filter: "*MeshDeviceSingleCardFixture.Bmm"
     config: 2x3_DISPATCH
     back2back: true
 

--- a/tests/scripts/quasar/quasar_regression_tests.yaml
+++ b/tests/scripts/quasar/quasar_regression_tests.yaml
@@ -1,23 +1,36 @@
 # Quasar emulator regression tests
 #
 # Structure:
-#   <group>:            Binary name under build/test/tt_metal/
-#     - filter: <glob>  GTest filter pattern
-#       config: <config>   Simulator grid config (maps to emu-quasar-<config>). Supports 1x3 and 2x3 and 2x3_DISPATCH
-#       env:            (optional) Extra environment variables as key: value pairs
-#       gtest_repeat:   (optional) Run each matched test N times (--gtest_repeat=N)
-#       back2back:      (optional) When true, run this entry in the same gtest process as
-#                       other consecutive back2back entries that share the same group,
-#                       config, env, and gtest_repeat. Used by run_quasar_regression.sh.
-#                       Defaults to false (each entry runs in its own process).
+#   <group>:              gtest binary under build/test/tt_metal/, or pytest file path
+#                         relative to TT_METAL_HOME
+#     - filter: <pattern> gtest filter glob, or pytest node id after :: (e.g. test_foo)
+#       config: <config>  Simulator grid (emu-quasar-<config>): 1x3, 2x3, 2x3_DISPATCH
+#       runner: <type>    (optional) gtest (default) or pytest
+#       env:              (optional) Extra environment variables as key: value pairs
+#       gtest_repeat:     (optional, gtest only) --gtest_repeat=N
+#       back2back:        (optional, gtest only) When true, run this entry in the same
+#                         process as other consecutive back2back entries that share the
+#                         same group, config, env, and gtest_repeat. Used by
+#                         run_quasar_regression.sh. Defaults to false.
+#                         Illegal for runner: pytest.
 #
-# Example test entry
+# Example gtest entry
 #
 # unit_tests_legacy:
 #   - filter: "*SingleDmL1Write*"
 #     config: 1x3
 #     env:
 #       TT_METAL_SOMETHING: 1
+#
+# Example pytest entry
+#
+# tests/tt_metal/tools/profiler/test_device_profiler.py:
+#   - filter: test_custom_cycle_count
+#     runner: pytest
+#     config: 2x3_DISPATCH
+#     env:
+#       TT_METAL_DEVICE_PROFILER: 1
+
 
 unit_tests_legacy:
 # 1x3 tests run back-to-back

--- a/tests/scripts/quasar/quasar_regression_tests.yaml
+++ b/tests/scripts/quasar/quasar_regression_tests.yaml
@@ -33,7 +33,7 @@
 
 
 unit_tests_legacy:
-# 1x3 tests run back-to-back
+# 1x3 tests
   - filter: "*SingleDmL1Write*"
     config: 1x3
     back2back: true
@@ -46,49 +46,20 @@ unit_tests_legacy:
     env:
       TT_METAL_SLOW_DISPATCH_MODE: 1
 
-  - filter: "*QuasarComputeKernelSingleThread*"
-    config: 1x3
-    back2back: true
-    env:
-      TT_METAL_SLOW_DISPATCH_MODE: 1
-
-  - filter: "*QuasarComputeKernelMultipleThread*"
-    config: 1x3
-    back2back: true
-    env:
-      TT_METAL_SLOW_DISPATCH_MODE: 1
-
-  - filter: "*QuasarCreateMultipleComputeKernelsSingleCluster*"
-    config: 1x3
-    back2back: true
-    env:
-      TT_METAL_SLOW_DISPATCH_MODE: 1
-
-  - filter: "*QuasarMeshDeviceSingleCardFixture*GlobalsAndTLS"
-    config: 1x3
-    back2back: true
-    env:
-      TT_METAL_SLOW_DISPATCH_MODE: 1
-
-  - filter: "*QuasarMeshDeviceSingleCardFixture.QuasarComputeKernelTLS*"
-    config: 1x3
-    back2back: true
-    env:
-      TT_METAL_SLOW_DISPATCH_MODE: 1
-
-  # - filter: "QuasarMeshDeviceSingleCardFixture.QuasarMultiSemaphorePipeline"
-  #   config: 1x3
-  #   back2back: true
-  #   env:
-  #     TT_METAL_SLOW_DISPATCH_MODE: 1
-
   - filter: "*Bmm"
     config: 1x3
     back2back: true
     env:
       TT_METAL_SLOW_DISPATCH_MODE: 1
 
-# Test fast dispatch on worker cores
+# 2x3 tests
+  - filter: "*MultiDmAddTwoInts*"
+    config: 2x3
+    back2back: true
+    env:
+      TT_METAL_SLOW_DISPATCH_MODE: 1
+
+# Fast dispatch on worker cores - target device with not dispatch engine
   - filter: "*SingleDmL1Write*"
     config: 2x3
     back2back: true
@@ -130,10 +101,14 @@ unit_tests_legacy:
     config: 2x3_DISPATCH
     back2back: true
 
-  # - filter: "QuasarMeshDeviceSingleCardFixture.QuasarMultiSemaphorePipeline"
+    # - filter: "QuasarMeshDeviceSingleCardFixture.QuasarMultiSemaphorePipeline"
   #   config: 1x3
   #   back2back: true
   #   env:
+
+  - filter: "*MultiDmAddTwoInts*"
+    config: 2x3_DISPATCH
+    back2back: true
 
   - filter: "*Bmm"
     config: 2x3_DISPATCH
@@ -224,7 +199,7 @@ unit_tests_debug_tools:
     env:
       TT_METAL_SLOW_DISPATCH_MODE: 1
 
-# Fast Dispatch (Dispatch Engine) tests
+# Dispatch Engine tests
   - filter: "*WatcherAssertTests*/DispatchDM2"
     config: 2x3_DISPATCH
     back2back: true
@@ -232,24 +207,6 @@ unit_tests_debug_tools:
       TT_METAL_SLOW_DISPATCH_MODE: 1
 
 unit_tests_api:
-  - filter: "*QuasarCRTASharedL1Address*"
-    config: 1x3
-    back2back: true
-    env:
-      TT_METAL_SLOW_DISPATCH_MODE: 1
-
-  - filter: "*QuasarCRTAUniqueL1Addresses*"
-    config: 1x3
-    back2back: true
-    env:
-      TT_METAL_SLOW_DISPATCH_MODE: 1
-
-  - filter: "*TensixSingleCoreDirectDramReaderDatacopyWriter"
-    config: 1x3
-    back2back: true
-    env:
-      TT_METAL_SLOW_DISPATCH_MODE: 1
-
   - filter: "M2ImplicitSync/DFBImplicitSyncParamFixture_2_0.DMTest1xDFB1Sx1S_2_0/ImplicitSyncTrue"
     config: 1x3
     back2back: true
@@ -403,40 +360,15 @@ unit_tests_device:
     env:
       TT_METAL_SLOW_DISPATCH_MODE: 1
 
-# Fast Dispatch (Dispatch Engine) tests
-  - filter: "*SimulatorFixture*QuasarStaticTlbReadWrite*"
-    config: 2x3_DISPATCH
-    back2back: true
-
 unit_tests_dispatch:
+# Verify dispatch_s is running when running fast dispatch on worker cores
   - filter: '*QuasarDispatchSInstantiatedAndRunning*'
     config: 2x3
     back2back: true
     env:
       TT_METAL_TENSIX_DISPATCH_CORES: 1
 
-# Fast Dispatch (Dispatch Engine) tests
+# Verify dispatch_s is running when running fast dispatch on dispatch engines
   - filter: "*QuasarDispatchSInstantiatedAndRunning*"
     config: 2x3_DISPATCH
     back2back: true
-
-# Profiler tests
-tests/tt_metal/tools/profiler/test_device_profiler.py:
-  - filter: test_custom_cycle_count_slow_dispatch
-    runner: pytest
-    config: 1x3
-    env:
-      TT_METAL_DEVICE_PROFILER: 1
-      TT_METAL_SLOW_DISPATCH_MODE: 1
-
-  - filter: test_custom_cycle_count
-    runner: pytest
-    config: 2x3_DISPATCH
-    env:
-      TT_METAL_DEVICE_PROFILER: 1
-
-  - filter: test_full_buffer
-    runner: pytest
-    config: 2x3_DISPATCH
-    env:
-      TT_METAL_DEVICE_PROFILER: 1

--- a/tests/scripts/quasar/quasar_regression_tests.yaml
+++ b/tests/scripts/quasar/quasar_regression_tests.yaml
@@ -88,38 +88,65 @@ unit_tests_legacy:
     env:
       TT_METAL_SLOW_DISPATCH_MODE: 1
 
-# 2x3 tests run back-to-back
+# Test fast dispatch on worker cores
   - filter: "*SingleDmL1Write*"
     config: 2x3
     back2back: true
     env:
-      TT_METAL_SLOW_DISPATCH_MODE: 1
+      TT_METAL_TENSIX_DISPATCH_CORES: 1
 
-  - filter: "*MultiDmAddTwoInts*"
+  - filter: "*QuasarMultiCQMeshDeviceSingleCardFixture*"
     config: 2x3
     back2back: true
     env:
-      TT_METAL_SLOW_DISPATCH_MODE: 1
+      TT_METAL_TENSIX_DISPATCH_CORES: 1
 
-# 2x3_DISPATCH tests run back-to-back
+# Fast Dispatch (Dispatch Engine) tests
   - filter: "*SingleDmL1Write*"
     config: 2x3_DISPATCH
     back2back: true
 
-  - filter: "*MultiDmAddTwoInts*"
+  - filter: "*DmLoopback*"
     config: 2x3_DISPATCH
     back2back: true
-    env:
-      TT_METAL_SLOW_DISPATCH_MODE: 1
+
+  - filter: "*QuasarComputeKernelSingleThread*"
+    config: 2x3_DISPATCH
+    back2back: true
+
+  - filter: "*QuasarComputeKernelMultipleThread*"
+    config: 2x3_DISPATCH
+    back2back: true
+
+  - filter: "*QuasarCreateMultipleComputeKernelsSingleCluster*"
+    config: 2x3_DISPATCH
+    back2back: true
+
+  - filter: "*QuasarMeshDeviceSingleCardFixture*GlobalsAndTLS"
+    config: 2x3_DISPATCH
+    back2back: true
+
+  - filter: "*QuasarMeshDeviceSingleCardFixture.QuasarComputeKernelTLS*"
+    config: 2x3_DISPATCH
+    back2back: true
+
+  # - filter: "QuasarMeshDeviceSingleCardFixture.QuasarMultiSemaphorePipeline"
+  #   config: 1x3
+  #   back2back: true
+  #   env:
+
+  - filter: "*Bmm"
+    config: 2x3_DISPATCH
+    back2back: true
 
 unit_tests_debug_tools:
-  - filter: "*WatcherAssertTests*DM2"
+  - filter: "*WatcherAssertTests*/DM2"
     config: 1x3
     back2back: true
     env:
       TT_METAL_SLOW_DISPATCH_MODE: 1
 
-  - filter: "*WatcherAssertTests*DM7"
+  - filter: "*WatcherAssertTests*/DM7"
     config: 1x3
     back2back: true
     env:
@@ -193,6 +220,13 @@ unit_tests_debug_tools:
 
   - filter: "DevicePrintOutputFixture.PrintConcurrentAllRiscs"
     config: 1x3
+    back2back: true
+    env:
+      TT_METAL_SLOW_DISPATCH_MODE: 1
+
+# Fast Dispatch (Dispatch Engine) tests
+  - filter: "*WatcherAssertTests*/DispatchDM2"
+    config: 2x3_DISPATCH
     back2back: true
     env:
       TT_METAL_SLOW_DISPATCH_MODE: 1
@@ -349,9 +383,60 @@ unit_tests_api:
   #   env:
   #     TT_METAL_SLOW_DISPATCH_MODE: 1
 
+# Fast Dispatch (Dispatch Engine) tests
+  - filter: "*QuasarCRTASharedL1Address*"
+    config: 2x3_DISPATCH
+    back2back: true
+
+  - filter: "*QuasarCRTAUniqueL1Addresses*"
+    config: 2x3_DISPATCH
+    back2back: true
+
+  - filter: "*TensixSingleCoreDirectDramReaderDatacopyWriter"
+    config: 2x3_DISPATCH
+    back2back: true
+
 unit_tests_device:
   - filter: "*SimulatorFixture*QuasarStaticTlbReadWrite*"
     config: 1x3
     back2back: true
     env:
       TT_METAL_SLOW_DISPATCH_MODE: 1
+
+# Fast Dispatch (Dispatch Engine) tests
+  - filter: "*SimulatorFixture*QuasarStaticTlbReadWrite*"
+    config: 2x3_DISPATCH
+    back2back: true
+
+unit_tests_dispatch:
+  - filter: '*QuasarDispatchSInstantiatedAndRunning*'
+    config: 2x3
+    back2back: true
+    env:
+      TT_METAL_TENSIX_DISPATCH_CORES: 1
+
+# Fast Dispatch (Dispatch Engine) tests
+  - filter: "*QuasarDispatchSInstantiatedAndRunning*"
+    config: 2x3_DISPATCH
+    back2back: true
+
+# Profiler tests
+tests/tt_metal/tools/profiler/test_device_profiler.py:
+  - filter: test_custom_cycle_count_slow_dispatch
+    runner: pytest
+    config: 1x3
+    env:
+      TT_METAL_DEVICE_PROFILER: 1
+      TT_METAL_SLOW_DISPATCH_MODE: 1
+
+  - filter: test_custom_cycle_count
+    runner: pytest
+    config: 2x3_DISPATCH
+    env:
+      TT_METAL_DEVICE_PROFILER: 1
+
+  - filter: test_full_buffer
+    runner: pytest
+    config: 2x3_DISPATCH
+    env:
+      TT_METAL_DEVICE_PROFILER: 1

--- a/tests/scripts/quasar/run_quasar_regression.sh
+++ b/tests/scripts/quasar/run_quasar_regression.sh
@@ -10,7 +10,6 @@ export TT_METAL_RUNTIME_ROOT="$TT_METAL_HOME"
 # Defaults
 TESTS_FILE="$SCRIPT_DIR/quasar_regression_tests.yaml"
 BUILD=false
-FAST_DISPATCH=false
 FILTER_CONFIG=""
 FILTER_GROUP=""
 BUILD_DIR="$TT_METAL_HOME/build"
@@ -28,7 +27,7 @@ fi
 EMU_HOSTNAME_RETRY_DELAY="${QUASAR_EMU_HOSTNAME_RETRY_DELAY:-30}"
 EMU_MONITOR_POLL_INTERVAL="${QUASAR_EMU_HOSTNAME_POLL_INTERVAL:-2}"
 EMU_LOG_GLOB='emu_*_.log'
-EMU_HOSTNAME_CONFLICT_REGEX='zServer : ERROR.*Hostname = .* is used by'
+EMU_HOSTNAME_CONFLICT_REGEX='zServer : ERROR.* is used by'
 SIMULATOR_PID_REGEX='Simulator process spawned with PID: ([0-9]+)'
 
 usage() {
@@ -36,8 +35,12 @@ usage() {
 Usage: $(basename "$0") [OPTIONS]
 
 Run Quasar emulator regression tests defined in a YAML file, batching entries
-marked back2back: true into single gtest invocations when they share the same
-binary, config, env, and gtest_repeat settings.
+marked back2back: true into single invocations when they share the same group,
+config, env, runner, and gtest_repeat settings.
+
+YAML entries default to runner: gtest (binary under build/test/tt_metal/<group>).
+Set runner: pytest for Python tests (group is a .py path relative to TT_METAL_HOME;
+filter is the pytest node id after ::). back2back is not supported for pytest.
 
 Required environment variables:
   TT_METAL_SIMULATOR_BASE   Base path containing simulator build directories
@@ -55,10 +58,8 @@ Options:
   --group <name>                   Only run tests from the specified test group
   --tests <path>                   Path to YAML test file (default: quasar_regression_tests.yaml)
   --build-dir <path>               Path to build directory (default: $BUILD_DIR)
-  --log-dir <path>                 Save per-test gtest JSON results to this directory
-  --no-back2back                   Run each test in a separate gtest process
-  --fast-dispatch                  Do not set TT_METAL_SLOW_DISPATCH_MODE by default (fast dispatch).
-                                   Per-test env in the YAML file can still set TT_METAL_SLOW_DISPATCH_MODE.
+  --log-dir <path>                 Save per-test results (gtest JSON / pytest JUnit XML)
+  --no-back2back                   Run each test in a separate process
   --dry-run                        Print commands without executing
   -h, --help                       Show this help message
 
@@ -80,18 +81,11 @@ while [[ $# -gt 0 ]]; do
         --build-dir)   need_arg "$1" "${2:-}"; BUILD_DIR="$2"; shift 2 ;;
         --log-dir)     need_arg "$1" "${2:-}"; LOG_DIR="$2"; shift 2 ;;
         --no-back2back) BACK2BACK=false; shift ;;
-        --fast-dispatch) FAST_DISPATCH=true; shift ;;
         --dry-run)     DRY_RUN=true; shift ;;
         -h|--help)     usage ;;
         *) echo "Unknown option: $1"; usage ;;
     esac
 done
-
-if [[ "$FAST_DISPATCH" == true ]]; then
-    unset TT_METAL_SLOW_DISPATCH_MODE
-else
-    export TT_METAL_SLOW_DISPATCH_MODE="${TT_METAL_SLOW_DISPATCH_MODE:-1}"
-fi
 
 if [[ -n "$FILTER_CONFIG" && "$FILTER_CONFIG" != "1x3" && "$FILTER_CONFIG" != "2x3" && "$FILTER_CONFIG" != "2x3_DISPATCH" ]]; then
     echo "ERROR: invalid --config value '$FILTER_CONFIG'. Supported: 1x3, 2x3, 2x3_DISPATCH"
@@ -180,10 +174,33 @@ SEP=$'\x1f'   # field separator for test entry records
 ENV_SEP='|'  # separator between env KEY=value pairs (yq join() does not interpret \u escapes)
 EMPTY_ENV='-'  # TSV placeholder for empty env (bash read collapses consecutive tab fields)
 EMPTY_GTEST_REPEAT='-'  # TSV placeholder for empty gtest_repeat (same issue as env)
+VALID_RUNNERS=("gtest" "pytest")
+
+is_valid_runner() {
+    local runner="$1"
+    for valid in "${VALID_RUNNERS[@]}"; do
+        [[ "$runner" == "$valid" ]] && return 0
+    done
+    return 1
+}
+
 declare -a test_entries=()
-while IFS=$'\t' read -r group filter configs envvars gtest_repeat back2back; do
+while IFS=$'\t' read -r group filter configs envvars gtest_repeat back2back runner; do
     [[ -z "$group" ]] && continue
     [[ "$gtest_repeat" == "$EMPTY_GTEST_REPEAT" ]] && gtest_repeat=""
+    if ! is_valid_runner "$runner"; then
+        echo "ERROR: invalid runner '$runner' for test '$filter' in group '$group'"
+        echo "       Supported runners: ${VALID_RUNNERS[*]}"
+        exit 1
+    fi
+    if [[ "$runner" == "pytest" && "$back2back" == "true" ]]; then
+        echo "ERROR: back2back is not supported for pytest (group '$group', filter '$filter')"
+        exit 1
+    fi
+    if [[ "$runner" == "pytest" && -n "$gtest_repeat" ]]; then
+        echo "WARNING: gtest_repeat is ignored for pytest entry '$filter' in group '$group'"
+        gtest_repeat=""
+    fi
     # Split comma-separated configs and create one entry per config
     IFS=',' read -ra config_list <<< "$configs"
     for config in "${config_list[@]}"; do
@@ -193,9 +210,9 @@ while IFS=$'\t' read -r group filter configs envvars gtest_repeat back2back; do
             echo "       Supported configs: ${VALID_CONFIGS[*]}"
             exit 1
         fi
-        test_entries+=("${group}${SEP}${filter}${SEP}${config}${SEP}${envvars}${SEP}${gtest_repeat}${SEP}${back2back}")
+        test_entries+=("${group}${SEP}${filter}${SEP}${config}${SEP}${envvars}${SEP}${gtest_repeat}${SEP}${back2back}${SEP}${runner}")
     done
-done < <(yq -r 'to_entries[] | .key as $group | .value[] | [$group, .filter, .config, ((.env // {} | to_entries | map(.key + "=" + (.value | tostring)) | join("|") | sub("^$"; "-"))), ((.gtest_repeat // "" | tostring) | sub("^$"; "-")), (.back2back // false | tostring)] | @tsv' "$TESTS_FILE")
+done < <(yq -r 'to_entries[] | .key as $group | .value[] | [$group, .filter, .config, ((.env // {} | to_entries | map(.key + "=" + (.value | tostring)) | join("|") | sub("^$"; "-"))), ((.gtest_repeat // "" | tostring) | sub("^$"; "-")), (.back2back // false | tostring), (.runner // "gtest")] | @tsv' "$TESTS_FILE")
 
 total_tests=${#test_entries[@]}
 
@@ -425,13 +442,14 @@ cleanup_emu_attempt() {
     refresh_emu_logs_baseline
 }
 
-# Run gtest in the background and poll emu_<date>_<time>_.log for hostname conflicts.
+# Run a test command in the background and poll emu_<date>_<time>_.log for hostname
+# conflicts. Command argv is taken from emu_run_cmd; env from gtest_cmd_env.
 # Sets gtest_emu_hostname_conflict=1 when the emulator log reports a conflict.
-# Returns the gtest exit code (1 when terminated due to conflict).
+# Returns the command exit code (1 when terminated due to conflict).
 # Tracks active_gtest_pid / active_tracked_sim_pid for INT cleanup (setsid isolates
-# the gtest process group from the terminal's Ctrl-C).
-run_gtest_with_emu_monitor() {
-    local gtest_pid rc=0
+# the process group from the terminal's Ctrl-C).
+run_cmd_with_emu_monitor() {
+    local cmd_pid rc=0
     local emu_log="" emu_offset=0 metal_offset=0 conflict_lines=""
     local tracked_sim_pid=""
 
@@ -441,15 +459,15 @@ run_gtest_with_emu_monitor() {
     snapshot_simulator_pids
 
     if command -v setsid &>/dev/null; then
-        setsid "${gtest_cmd_env[@]}" "$binary" --gtest_filter="$combined_filter" "${gtest_repeat_args[@]}" "${gtest_log_args[@]}" &
+        setsid "${gtest_cmd_env[@]}" "${emu_run_cmd[@]}" &
     else
-        "${gtest_cmd_env[@]}" "$binary" --gtest_filter="$combined_filter" "${gtest_repeat_args[@]}" "${gtest_log_args[@]}" &
+        "${gtest_cmd_env[@]}" "${emu_run_cmd[@]}" &
     fi
-    gtest_pid=$!
-    active_gtest_pid=$gtest_pid
+    cmd_pid=$!
+    active_gtest_pid=$cmd_pid
     active_tracked_sim_pid=""
 
-    while kill -0 "$gtest_pid" 2>/dev/null; do
+    while kill -0 "$cmd_pid" 2>/dev/null; do
         if [[ -n "$log_file" ]]; then
             poll_metal_log_for_simulator_pid "$log_file" metal_offset tracked_sim_pid || true
             active_tracked_sim_pid="$tracked_sim_pid"
@@ -464,8 +482,8 @@ run_gtest_with_emu_monitor() {
             if conflict_lines="$(poll_emu_log_for_hostname_conflict "$emu_log" emu_offset)"; then
                 gtest_emu_hostname_conflict=1
                 gtest_emu_conflict_lines="$conflict_lines"
-                echo "  EMU HOSTNAME CONFLICT in $emu_log (terminating hung gtest)"
-                cleanup_emu_attempt "$gtest_pid" "$tracked_sim_pid"
+                echo "  EMU HOSTNAME CONFLICT in $emu_log (terminating hung test)"
+                cleanup_emu_attempt "$cmd_pid" "$tracked_sim_pid"
                 active_gtest_pid=""
                 active_tracked_sim_pid=""
                 break
@@ -476,7 +494,7 @@ run_gtest_with_emu_monitor() {
     done
 
     if [[ $gtest_emu_hostname_conflict -eq 0 ]]; then
-        wait "$gtest_pid" || rc=$?
+        wait "$cmd_pid" || rc=$?
     else
         rc=1
     fi
@@ -536,8 +554,9 @@ record_gtest_result() {
             local no_match_status=SKIP
             [[ $rc -ne 0 ]] && no_match_status=FAIL
             if [[ ${#filters[@]} -gt 0 ]]; then
-                for filter in "${filters[@]}"; do
-                    record_one_result "$no_match_status" "[$config] $group --gtest_filter=$filter" "$(fmt_duration "$elapsed"), no tests ran"
+                local f
+                for f in "${filters[@]}"; do
+                    record_one_result "$no_match_status" "[$config] $group --gtest_filter=$f" "$(fmt_duration "$elapsed"), no tests ran"
                 done
             else
                 record_one_result "$no_match_status" "$label" "$(fmt_duration "$elapsed"), no tests ran"
@@ -547,8 +566,96 @@ record_gtest_result() {
         local status=PASS
         [[ $rc -ne 0 ]] && status=FAIL
         if [[ ${#filters[@]} -gt 0 ]]; then
-            for filter in "${filters[@]}"; do
-                record_one_result "$status" "[$config] $group --gtest_filter=$filter" "$(fmt_duration "$elapsed")"
+            local f
+            for f in "${filters[@]}"; do
+                record_one_result "$status" "[$config] $group --gtest_filter=$f" "$(fmt_duration "$elapsed")"
+            done
+        else
+            record_one_result "$status" "$label" "$(fmt_duration "$elapsed")"
+        fi
+    fi
+
+    if [[ $rc -ne 0 && $inv_failed -eq 0 ]]; then
+        record_one_result FAIL "$label" "$(fmt_duration "$elapsed"), process exited with status $rc"
+    fi
+    if [[ $inv_failed -gt 0 ]]; then
+        echo "  RESULT: ${inv_passed} passed, ${inv_failed} failed, ${inv_skipped} skipped"
+    elif [[ $inv_skipped -gt 0 && $inv_passed -eq 0 ]]; then
+        echo "  RESULT: ${inv_skipped} skipped"
+    else
+        echo "  RESULT: ${inv_passed} passed, ${inv_skipped} skipped"
+    fi
+}
+
+# Parse pytest --junitxml and record one summary line per test case.
+record_pytest_result() {
+    local config="$1" group="$2" label="$3" elapsed="$4" rc="$5" junit_file="$6"
+    shift 6
+    local filters=("$@")
+
+    local inv_passed=0 inv_failed=0 inv_skipped=0
+
+    record_one_result() {
+        local status="$1" test_label="$2" test_time="$3"
+        case "$status" in
+            PASS)
+                passed=$((passed + 1))
+                inv_passed=$((inv_passed + 1))
+                results+=("PASS  $test_label  ($test_time)")
+                ;;
+            FAIL)
+                failed=$((failed + 1))
+                inv_failed=$((inv_failed + 1))
+                results+=("FAIL  $test_label  ($test_time)")
+                ;;
+            SKIP)
+                skipped=$((skipped + 1))
+                inv_skipped=$((inv_skipped + 1))
+                results+=("SKIP  $test_label  ($test_time)")
+                ;;
+        esac
+    }
+
+    if [[ -f "$junit_file" ]]; then
+        local count=0
+        while IFS=$'\t' read -r classname testname test_time has_failure has_skipped; do
+            [[ -z "$testname" ]] && continue
+            local status=PASS
+            if [[ "$has_skipped" == "true" ]]; then
+                status=SKIP
+            elif [[ "$has_failure" == "true" ]]; then
+                status=FAIL
+            fi
+            record_one_result "$status" "[$config] $group $testname" "$test_time"
+            count=$((count + 1))
+        done < <(yq -p=xml -oy -r '
+            .testsuites.testsuite.testcase
+            | (select(type == "!!seq") // [.])
+            | .[]
+            | [(.["+@classname"] // ""), (.["+@name"] // ""), (.["+@time"] // ""),
+               ((has("failure") or has("error")) | tostring), (has("skipped") | tostring)]
+            | @tsv
+        ' "$junit_file" 2>/dev/null || true)
+
+        if [[ $count -eq 0 ]]; then
+            local no_match_status=SKIP
+            [[ $rc -ne 0 ]] && no_match_status=FAIL
+            if [[ ${#filters[@]} -gt 0 ]]; then
+                local f
+                for f in "${filters[@]}"; do
+                    record_one_result "$no_match_status" "[$config] pytest $group::$f" "$(fmt_duration "$elapsed"), no tests ran"
+                done
+            else
+                record_one_result "$no_match_status" "$label" "$(fmt_duration "$elapsed"), no tests ran"
+            fi
+        fi
+    else
+        local status=PASS
+        [[ $rc -ne 0 ]] && status=FAIL
+        if [[ ${#filters[@]} -gt 0 ]]; then
+            local f
+            for f in "${filters[@]}"; do
+                record_one_result "$status" "[$config] pytest $group::$f" "$(fmt_duration "$elapsed")"
             done
         else
             record_one_result "$status" "$label" "$(fmt_duration "$elapsed")"
@@ -591,21 +698,18 @@ print_summary() {
 }
 
 batch_key() {
-    local group="$1" config="$2" envvars="$3" gtest_repeat="$4"
-    echo "${group}${SEP}${config}${SEP}${envvars}${SEP}${gtest_repeat}"
+    local group="$1" config="$2" envvars="$3" gtest_repeat="$4" runner="$5"
+    echo "${group}${SEP}${config}${SEP}${envvars}${SEP}${gtest_repeat}${SEP}${runner}"
 }
 
 apply_env_vars() {
     local envvars="$1"
-    extra_env_keys=()
     extra_env_pairs=()
     [[ "$envvars" == "$EMPTY_ENV" ]] && envvars=""
     if [[ -n "$envvars" ]]; then
         while IFS= read -r -d "$ENV_SEP" untrimmed_pair || [[ -n "$untrimmed_pair" ]]; do
             pair="${untrimmed_pair%"${untrimmed_pair##*[![:space:]]}"}"
             [[ -z "$pair" ]] && continue
-            key="${pair%%=*}"
-            extra_env_keys+=("$key")
             extra_env_pairs+=("$pair")
         done <<< "$envvars"
     fi
@@ -613,18 +717,8 @@ apply_env_vars() {
 
 build_gtest_cmd_env() {
     local log_file="${1:-}"
-    local has_slow_dispatch_override=false
-    for key in "${extra_env_keys[@]}"; do
-        if [[ "$key" == "TT_METAL_SLOW_DISPATCH_MODE" ]]; then
-            has_slow_dispatch_override=true
-            break
-        fi
-    done
 
     gtest_cmd_env=(env)
-    if [[ "$FAST_DISPATCH" == true && "$has_slow_dispatch_override" == false ]]; then
-        gtest_cmd_env+=(-u TT_METAL_SLOW_DISPATCH_MODE)
-    fi
     if [[ -n "$log_file" ]]; then
         gtest_cmd_env+=("TT_METAL_LOGGER_FILE=${log_file}")
     fi
@@ -637,50 +731,85 @@ print_run_env() {
     echo "  TT_METAL_SIMULATOR=$TT_METAL_SIMULATOR"
     echo "  NNG_SOCKET_ADDR=$NNG_SOCKET_ADDR"
     echo "  NNG_SOCKET_LOCAL_PORT=$NNG_SOCKET_LOCAL_PORT"
-    if [[ -n "${TT_METAL_SLOW_DISPATCH_MODE+x}" ]]; then
-        echo "  TT_METAL_SLOW_DISPATCH_MODE=$TT_METAL_SLOW_DISPATCH_MODE"
-    fi
     for pair in "${extra_env_pairs[@]}"; do
         echo "  ENV: $pair"
     done
 }
 
 combine_gtest_filters() {
-    local combined=""
-    for filter in "$@"; do
+    # Use a local loop var — a bare `for filter in` would clobber the caller's
+    # `filter` via bash dynamic scoping (e.g. after flush_back2back_batch).
+    local combined="" f
+    for f in "$@"; do
         if [[ -z "$combined" ]]; then
-            combined="$filter"
+            combined="$f"
         else
-            combined="${combined}:${filter}"
+            combined="${combined}:${f}"
         fi
     done
     echo "$combined"
 }
 
-run_gtest_invocation() {
-    local group="$1" config="$2" envvars="$3" gtest_repeat="$4" label="$5"
-    shift 5
+pytest_node_id() {
+    local pyfile="$1" filter="$2"
+    if [[ -n "$filter" ]]; then
+        echo "${pyfile}::${filter}"
+    else
+        echo "$pyfile"
+    fi
+}
+
+format_test_label() {
+    local runner="$1" config="$2" group="$3" filter_summary="$4" gtest_repeat="$5"
+    local label
+    if [[ "$runner" == "pytest" ]]; then
+        label="[$config] pytest $(pytest_node_id "$group" "$filter_summary")"
+    else
+        label="[$config] $group --gtest_filter=$filter_summary"
+        if [[ -n "$gtest_repeat" ]]; then
+            label="$label --gtest_repeat=$gtest_repeat"
+        fi
+    fi
+    echo "$label"
+}
+
+run_test_invocation() {
+    local runner="$1" group="$2" config="$3" envvars="$4" gtest_repeat="$5" label="$6"
+    shift 6
     local filters=("$@")
 
-    local combined_filter
-    combined_filter="$(combine_gtest_filters "${filters[@]}")"
-
-    local sim_path binary
+    local sim_path
     sim_path="$(simulator_path_for_config "$config")"
-    binary="$BUILD_DIR/test/tt_metal/$group"
 
     local gtest_repeat_args=()
-    if [[ -n "$gtest_repeat" ]]; then
+    if [[ "$runner" == "gtest" && -n "$gtest_repeat" ]]; then
         gtest_repeat_args+=("--gtest_repeat=$gtest_repeat")
     fi
 
     echo "--- [$run_num] $label ---"
 
-    if [[ ! -f "$binary" ]]; then
-        echo "  SKIP: binary not found: $binary"
-        skipped=$((skipped + 1))
-        results+=("SKIP  $label  (binary not found)")
-        return
+    if [[ "$runner" == "pytest" ]]; then
+        local pyfile="$TT_METAL_HOME/$group"
+        if [[ ! -f "$pyfile" ]]; then
+            echo "  SKIP: pytest file not found: $pyfile"
+            skipped=$((skipped + 1))
+            results+=("SKIP  $label  (pytest file not found)")
+            return
+        fi
+        if ! command -v pytest &>/dev/null; then
+            echo "  SKIP: pytest not found on PATH"
+            skipped=$((skipped + 1))
+            results+=("SKIP  $label  (pytest not found)")
+            return
+        fi
+    else
+        local binary="$BUILD_DIR/test/tt_metal/$group"
+        if [[ ! -f "$binary" ]]; then
+            echo "  SKIP: binary not found: $binary"
+            skipped=$((skipped + 1))
+            results+=("SKIP  $label  (binary not found)")
+            return
+        fi
     fi
 
     if [[ ! -d "$sim_path" ]]; then
@@ -693,17 +822,32 @@ run_gtest_invocation() {
     export TT_METAL_SIMULATOR="$sim_path/"
     apply_env_vars "$envvars"
     print_run_env
-    echo "  CMD: $binary --gtest_filter=$combined_filter${gtest_repeat_args[*]:+ ${gtest_repeat_args[*]}}"
+
+    local -a node_ids=()
+    local combined_filter="" cmd_display=""
+    if [[ "$runner" == "pytest" ]]; then
+        local f
+        for f in "${filters[@]}"; do
+            node_ids+=("$(pytest_node_id "$group" "$f")")
+        done
+        cmd_display="pytest ${node_ids[*]}"
+        echo "  CMD: $cmd_display"
+    else
+        combined_filter="$(combine_gtest_filters "${filters[@]}")"
+        cmd_display="$BUILD_DIR/test/tt_metal/$group --gtest_filter=$combined_filter${gtest_repeat_args[*]:+ ${gtest_repeat_args[*]}}"
+        echo "  CMD: $cmd_display"
+    fi
 
     if [[ "$DRY_RUN" == true ]]; then
         results+=("DRY   $label")
         return
     fi
 
-    local gtest_log_args=()
-    local json_file=""
+    local result_file=""
     local log_file=""
     local log_stem
+    local group_stem
+    group_stem="$(sanitize_name "$group")"
     if [[ ${#filters[@]} -eq 1 ]]; then
         log_stem="$(sanitize_name "${filters[0]}")"
     else
@@ -719,27 +863,44 @@ run_gtest_invocation() {
             echo "  RETRY: attempt $attempt/$max_attempts after emulator hostname conflict"
         fi
 
-        gtest_log_args=()
-        json_file=""
+        emu_run_cmd=()
+        result_file=""
         log_file=""
         if [[ -n "$LOG_DIR" ]]; then
-            local log_base="$LOG_DIR/${config}_${group}_${log_stem}"
+            local log_base="$LOG_DIR/${config}_${group_stem}_${log_stem}"
             local count="${log_base_counts["$log_base"]-0}"
             count=$((count + 1))
             log_base_counts["$log_base"]=$count
             if [[ $count -gt 1 ]]; then
                 log_base="${log_base}_${count}"
             fi
-            json_file="${log_base}.json"
             log_file="${log_base}.log"
-            gtest_log_args=("--gtest_output=json:${json_file}")
             echo "  TT_METAL_LOGGER_FILE=${log_file}"
+            if [[ "$runner" == "pytest" ]]; then
+                result_file="${log_base}.xml"
+            else
+                result_file="${log_base}.json"
+            fi
         fi
         build_gtest_cmd_env "$log_file"
 
+        if [[ "$runner" == "pytest" ]]; then
+            emu_run_cmd=(pytest -vv)
+            emu_run_cmd+=("${node_ids[@]}")
+            if [[ -n "$result_file" ]]; then
+                emu_run_cmd+=(--junitxml="$result_file")
+            fi
+        else
+            emu_run_cmd=("$BUILD_DIR/test/tt_metal/$group" --gtest_filter="$combined_filter")
+            emu_run_cmd+=("${gtest_repeat_args[@]}")
+            if [[ -n "$result_file" ]]; then
+                emu_run_cmd+=("--gtest_output=json:${result_file}")
+            fi
+        fi
+
         rc=0
         gtest_emu_hostname_conflict=0
-        run_gtest_with_emu_monitor || rc=$?
+        run_cmd_with_emu_monitor || rc=$?
 
         if [[ $gtest_emu_hostname_conflict -eq 1 ]]; then
             if [[ $attempt -lt $max_attempts ]]; then
@@ -763,7 +924,11 @@ run_gtest_invocation() {
     done
 
     local elapsed=$((SECONDS - test_start))
-    record_gtest_result "$config" "$group" "$label" "$elapsed" "$rc" "$json_file" "${filters[@]}"
+    if [[ "$runner" == "pytest" ]]; then
+        record_pytest_result "$config" "$group" "$label" "$elapsed" "$rc" "$result_file" "${filters[@]}"
+    else
+        record_gtest_result "$config" "$group" "$label" "$elapsed" "$rc" "$result_file" "${filters[@]}"
+    fi
     if [[ $rc -ne 0 && -n "$log_file" ]]; then
         echo "  LOG: $log_file"
     fi
@@ -777,6 +942,7 @@ clear_back2back_batch() {
     batch_config=""
     batch_envvars=""
     batch_gtest_repeat=""
+    batch_runner=""
     batch_key_current=""
 }
 
@@ -784,30 +950,37 @@ flush_back2back_batch() {
     [[ ${#batch_filters[@]} -eq 0 ]] && return
 
     run_num=$((run_num + 1))
-    local filter_summary="${batch_filters[0]}"
-    if [[ ${#batch_filters[@]} -gt 1 ]]; then
-        filter_summary="back2back(${#batch_filters[@]}): $(combine_gtest_filters "${batch_filters[@]}")"
-    fi
-
-    local label="[$batch_config] $batch_group --gtest_filter=$filter_summary"
-    if [[ -n "$batch_gtest_repeat" ]]; then
-        label="$label --gtest_repeat=$batch_gtest_repeat"
+    local label
+    if [[ "$batch_runner" == "pytest" && ${#batch_filters[@]} -gt 1 ]]; then
+        local -a nodes=()
+        local f
+        for f in "${batch_filters[@]}"; do
+            nodes+=("$(pytest_node_id "$batch_group" "$f")")
+        done
+        label="[$batch_config] pytest back2back(${#batch_filters[@]}): ${nodes[*]}"
+    else
+        local filter_summary="${batch_filters[0]}"
+        if [[ ${#batch_filters[@]} -gt 1 ]]; then
+            filter_summary="back2back(${#batch_filters[@]}): $(combine_gtest_filters "${batch_filters[@]}")"
+        fi
+        label="$(format_test_label "$batch_runner" "$batch_config" "$batch_group" "$filter_summary" "$batch_gtest_repeat")"
     fi
 
     # Capture and clear before invoking so an INT mid-run cannot re-enter with
-    # the same filters and launch a duplicate gtest/emulator.
+    # the same filters and launch a duplicate test/emulator.
     local -a filters_to_run=("${batch_filters[@]}")
     local group="$batch_group" config="$batch_config"
     local envvars="$batch_envvars" gtest_repeat="$batch_gtest_repeat"
+    local runner="$batch_runner"
     clear_back2back_batch
 
-    run_gtest_invocation "$group" "$config" "$envvars" "$gtest_repeat" "$label" "${filters_to_run[@]}"
+    run_test_invocation "$runner" "$group" "$config" "$envvars" "$gtest_repeat" "$label" "${filters_to_run[@]}"
 }
 
 # Ctrl-C must not flush/re-run a batch: batch_filters used to remain set until
-# run_gtest_invocation returned, so the INT trap re-entered flush and started
-# duplicate work. gtest is also launched under setsid, so the terminal signal
-# never reaches it — explicit cleanup is required to avoid leaking the detached
+# run_test_invocation returned, so the INT trap re-entered flush and started
+# duplicate work. Tests are also launched under setsid, so the terminal signal
+# never reaches them — explicit cleanup is required to avoid leaking the detached
 # simulator (UV_PROCESS_DETACHED).
 on_interrupt() {
     trap - INT
@@ -817,7 +990,7 @@ on_interrupt() {
     clear_back2back_batch
 
     if [[ -n "${active_gtest_pid:-}" ]]; then
-        echo "  cleaning up active gtest (pid $active_gtest_pid) and simulator..."
+        echo "  cleaning up active test (pid $active_gtest_pid) and simulator..."
         cleanup_emu_attempt "$active_gtest_pid" "${active_tracked_sim_pid:-}"
         active_gtest_pid=""
         active_tracked_sim_pid=""
@@ -832,9 +1005,9 @@ trap on_interrupt INT
 run_num=0
 
 declare -A log_base_counts=()
-declare -a extra_env_keys=()
 declare -a extra_env_pairs=()
 declare -a gtest_cmd_env=()
+declare -a emu_run_cmd=()
 gtest_emu_hostname_conflict=0
 gtest_emu_conflict_lines=""
 active_gtest_pid=""
@@ -846,10 +1019,11 @@ batch_group=""
 batch_config=""
 batch_envvars=""
 batch_gtest_repeat=""
+batch_runner=""
 batch_key_current=""
 
 for entry in "${test_entries[@]}"; do
-    IFS="$SEP" read -r group filter config envvars gtest_repeat back2back <<< "$entry"
+    IFS="$SEP" read -r group filter config envvars gtest_repeat back2back runner <<< "$entry"
 
     if [[ -n "$FILTER_CONFIG" && "$config" != "$FILTER_CONFIG" ]]; then
         skipped=$((skipped + 1))
@@ -861,7 +1035,7 @@ for entry in "${test_entries[@]}"; do
     fi
 
     if [[ "$BACK2BACK" == true && "$back2back" == "true" ]]; then
-        local_key="$(batch_key "$group" "$config" "$envvars" "$gtest_repeat")"
+        local_key="$(batch_key "$group" "$config" "$envvars" "$gtest_repeat" "$runner")"
         if [[ -n "$batch_key_current" && "$local_key" != "$batch_key_current" ]]; then
             flush_back2back_batch
         fi
@@ -870,15 +1044,13 @@ for entry in "${test_entries[@]}"; do
         batch_config="$config"
         batch_envvars="$envvars"
         batch_gtest_repeat="$gtest_repeat"
+        batch_runner="$runner"
         batch_filters+=("$filter")
     else
         flush_back2back_batch
         run_num=$((run_num + 1))
-        label="[$config] $group --gtest_filter=$filter"
-        if [[ -n "$gtest_repeat" ]]; then
-            label="$label --gtest_repeat=$gtest_repeat"
-        fi
-        run_gtest_invocation "$group" "$config" "$envvars" "$gtest_repeat" "$label" "$filter"
+        label="$(format_test_label "$runner" "$config" "$group" "$filter" "$gtest_repeat")"
+        run_test_invocation "$runner" "$group" "$config" "$envvars" "$gtest_repeat" "$label" "$filter"
     fi
 done
 

--- a/tests/scripts/quasar/run_quasar_regression.sh
+++ b/tests/scripts/quasar/run_quasar_regression.sh
@@ -828,7 +828,9 @@ run_test_invocation() {
     if [[ "$runner" == "pytest" ]]; then
         local f
         for f in "${filters[@]}"; do
-            node_ids+=("$(pytest_node_id "$group" "$f")")
+            # Use absolute $pyfile (same path as the existence check) so pytest
+            # collects correctly even when cwd is not TT_METAL_HOME.
+            node_ids+=("$(pytest_node_id "$pyfile" "$f")")
         done
         cmd_display="pytest ${node_ids[*]}"
         echo "  CMD: $cmd_display"

--- a/tests/tt_metal/tt_metal/api/test_direct.cpp
+++ b/tests/tt_metal/tt_metal/api/test_direct.cpp
@@ -514,7 +514,8 @@ bool reader_datacopy_writer(
         .work_units = {wu},
     };
 
-    Program program = experimental::MakeProgramFromSpec(*mesh_device, spec);
+    distributed::MeshWorkload workload = experimental::MakeMeshWorkloadFromSpec(*mesh_device, spec);
+    Program& program = workload.get_programs().begin()->second;
 
     log_info(tt::LogTest, "Num tiles per thread: {}", num_tiles_per_thread);
 
@@ -542,7 +543,7 @@ bool reader_datacopy_writer(
     };
     experimental::SetProgramRunArgs(program, params);
 
-    tt_metal::detail::LaunchProgram(device, program, /*wait_until_cores_done=*/true);
+    distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), workload, /*blocking=*/true);
 
     return verify_reader_datacopy_writer_output(ctx);
 }
@@ -587,7 +588,7 @@ TEST_F(MeshDeviceFixture, TensixSingleCoreDirectDramReaderWriter) {
         ASSERT_TRUE(unit_tests::dram::direct::reader_writer(devices_.at(id), test_config));
     }
 }
-TEST_F(MeshDeviceFixture, TensixSingleCoreDirectDramReaderDatacopyWriter) {
+TEST_F(FastDispatchMeshDeviceFixture, TensixSingleCoreDirectDramReaderDatacopyWriter) {
     unit_tests::dram::direct::ReaderDatacopyWriterConfig test_config = {
         .num_tiles = 1,
         .tile_byte_size = 2 * 32 * 32,

--- a/tests/tt_metal/tt_metal/api/test_direct.cpp
+++ b/tests/tt_metal/tt_metal/api/test_direct.cpp
@@ -588,7 +588,7 @@ TEST_F(MeshDeviceFixture, TensixSingleCoreDirectDramReaderWriter) {
         ASSERT_TRUE(unit_tests::dram::direct::reader_writer(devices_.at(id), test_config));
     }
 }
-TEST_F(FastDispatchMeshDeviceFixture, TensixSingleCoreDirectDramReaderDatacopyWriter) {
+TEST_F(AnyDispatchMeshDeviceFixture, TensixSingleCoreDirectDramReaderDatacopyWriter) {
     unit_tests::dram::direct::ReaderDatacopyWriterConfig test_config = {
         .num_tiles = 1,
         .tile_byte_size = 2 * 32 * 32,

--- a/tests/tt_metal/tt_metal/common/device_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/device_fixture.hpp
@@ -15,7 +15,7 @@
 
 namespace tt::tt_metal {
 
-class MeshDeviceFixture : public MeshDispatchFixture {
+class FastDispatchMeshDeviceFixture : public MeshDispatchFixture {
 private:
     std::map<ChipId, std::shared_ptr<distributed::MeshDevice>> id_to_device_;
 
@@ -24,10 +24,6 @@ protected:
     static void TearDownTestSuite() {}
 
     void SetUp() override {
-        // Save time. Don't do any setup if invalid dispatch mode
-        if (!this->validate_dispatch_mode()) {
-            GTEST_SKIP();
-        }
         this->arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
 
         // Some CI machines have lots of cards, running all tests on all cards is slow
@@ -53,17 +49,6 @@ protected:
         }
     }
 
-    bool validate_dispatch_mode() {
-        this->slow_dispatch_ = true;
-        auto* slow_dispatch = getenv("TT_METAL_SLOW_DISPATCH_MODE");
-        if (!slow_dispatch) {
-            log_info(tt::LogTest, "This suite can only be run with slow dispatch or TT_METAL_SLOW_DISPATCH_MODE set");
-            this->slow_dispatch_ = false;
-            return false;
-        }
-        return true;
-    }
-
     void create_devices(const std::vector<ChipId>& device_ids) {
         const auto& dispatch_core_config =
             tt::tt_metal::MetalContext::instance().rtoptions().get_dispatch_core_config();
@@ -76,7 +61,7 @@ protected:
         this->num_devices_ = this->devices_.size();
     }
 
-    explicit MeshDeviceFixture(
+    explicit FastDispatchMeshDeviceFixture(
         size_t l1_small_size = DEFAULT_L1_SMALL_SIZE, size_t trace_region_size = DEFAULT_TRACE_REGION_SIZE) :
         MeshDispatchFixture(l1_small_size, trace_region_size) {}
 
@@ -95,15 +80,38 @@ public:
     }
 };
 
-class MeshDeviceSingleCardFixture : public MeshDispatchFixture {
+class MeshDeviceFixture : public FastDispatchMeshDeviceFixture {
+protected:
+    void SetUp() override {
+        // Save time. Don't do any setup if invalid dispatch mode
+        if (!this->validate_dispatch_mode()) {
+            GTEST_SKIP();
+        }
+        FastDispatchMeshDeviceFixture::SetUp();
+    }
+
+    bool validate_dispatch_mode() {
+        this->slow_dispatch_ = true;
+        auto* slow_dispatch = getenv("TT_METAL_SLOW_DISPATCH_MODE");
+        if (!slow_dispatch) {
+            log_info(tt::LogTest, "This suite can only be run with slow dispatch or TT_METAL_SLOW_DISPATCH_MODE set");
+            this->slow_dispatch_ = false;
+            return false;
+        }
+        return true;
+    }
+
+    explicit MeshDeviceFixture(
+        size_t l1_small_size = DEFAULT_L1_SMALL_SIZE, size_t trace_region_size = DEFAULT_TRACE_REGION_SIZE) :
+        FastDispatchMeshDeviceFixture(l1_small_size, trace_region_size) {}
+};
+
+class FastDispatchMeshDeviceSingleCardFixture : public MeshDispatchFixture {
 protected:
     static void SetUpTestSuite() {}
     static void TearDownTestSuite() {}
 
     void SetUp() override {
-        if (!this->validate_dispatch_mode()) {
-            GTEST_SKIP();
-        }
         this->arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
         this->create_devices();
         init_max_cbs();
@@ -115,17 +123,6 @@ protected:
                 device.reset();
             }
         }
-    }
-
-    virtual bool validate_dispatch_mode() {
-        this->slow_dispatch_ = true;
-        auto* slow_dispatch = getenv("TT_METAL_SLOW_DISPATCH_MODE");
-        if (!slow_dispatch) {
-            log_info(tt::LogTest, "This suite can only be run with slow dispatch or TT_METAL_SLOW_DISPATCH_MODE set");
-            this->slow_dispatch_ = false;
-            return false;
-        }
-        return true;
     }
 
     virtual size_t num_command_queues() const { return 1; }
@@ -149,6 +146,28 @@ protected:
     std::vector<std::shared_ptr<distributed::MeshDevice>> devices_;
     std::map<ChipId, std::shared_ptr<distributed::MeshDevice>> id_to_device_;
     size_t num_devices_{};
+};
+
+// Same as MeshDeviceSingleCardFixture but remove the check for slow dispatch mode
+class MeshDeviceSingleCardFixture : public FastDispatchMeshDeviceSingleCardFixture {
+protected:
+    void SetUp() override {
+        if (!this->validate_dispatch_mode()) {
+            GTEST_SKIP();
+        }
+        FastDispatchMeshDeviceSingleCardFixture::SetUp();
+    }
+
+    virtual bool validate_dispatch_mode() {
+        this->slow_dispatch_ = true;
+        auto* slow_dispatch = getenv("TT_METAL_SLOW_DISPATCH_MODE");
+        if (!slow_dispatch) {
+            log_info(tt::LogTest, "This suite can only be run with slow dispatch or TT_METAL_SLOW_DISPATCH_MODE set");
+            this->slow_dispatch_ = false;
+            return false;
+        }
+        return true;
+    }
 };
 
 class MeshDeviceSingleCardBufferFixture : public MeshDeviceSingleCardFixture {};

--- a/tests/tt_metal/tt_metal/common/device_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/device_fixture.hpp
@@ -15,7 +15,7 @@
 
 namespace tt::tt_metal {
 
-class FastDispatchMeshDeviceFixture : public MeshDispatchFixture {
+class AnyDispatchMeshDeviceFixture : public MeshDispatchFixture {
 private:
     std::map<ChipId, std::shared_ptr<distributed::MeshDevice>> id_to_device_;
 
@@ -24,6 +24,7 @@ protected:
     static void TearDownTestSuite() {}
 
     void SetUp() override {
+        this->DetectDispatchMode();
         this->arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
 
         // Some CI machines have lots of cards, running all tests on all cards is slow
@@ -61,7 +62,7 @@ protected:
         this->num_devices_ = this->devices_.size();
     }
 
-    explicit FastDispatchMeshDeviceFixture(
+    explicit AnyDispatchMeshDeviceFixture(
         size_t l1_small_size = DEFAULT_L1_SMALL_SIZE, size_t trace_region_size = DEFAULT_TRACE_REGION_SIZE) :
         MeshDispatchFixture(l1_small_size, trace_region_size) {}
 
@@ -80,14 +81,14 @@ public:
     }
 };
 
-class MeshDeviceFixture : public FastDispatchMeshDeviceFixture {
+class MeshDeviceFixture : public AnyDispatchMeshDeviceFixture {
 protected:
     void SetUp() override {
         // Save time. Don't do any setup if invalid dispatch mode
         if (!this->validate_dispatch_mode()) {
             GTEST_SKIP();
         }
-        FastDispatchMeshDeviceFixture::SetUp();
+        AnyDispatchMeshDeviceFixture::SetUp();
     }
 
     bool validate_dispatch_mode() {
@@ -103,15 +104,16 @@ protected:
 
     explicit MeshDeviceFixture(
         size_t l1_small_size = DEFAULT_L1_SMALL_SIZE, size_t trace_region_size = DEFAULT_TRACE_REGION_SIZE) :
-        FastDispatchMeshDeviceFixture(l1_small_size, trace_region_size) {}
+        AnyDispatchMeshDeviceFixture(l1_small_size, trace_region_size) {}
 };
 
-class FastDispatchMeshDeviceSingleCardFixture : public MeshDispatchFixture {
+class AnyDispatchMeshDeviceSingleCardFixture : public MeshDispatchFixture {
 protected:
     static void SetUpTestSuite() {}
     static void TearDownTestSuite() {}
 
     void SetUp() override {
+        this->DetectDispatchMode();
         this->arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
         this->create_devices();
         init_max_cbs();
@@ -149,13 +151,13 @@ protected:
 };
 
 // Same as MeshDeviceSingleCardFixture but remove the check for slow dispatch mode
-class MeshDeviceSingleCardFixture : public FastDispatchMeshDeviceSingleCardFixture {
+class MeshDeviceSingleCardFixture : public AnyDispatchMeshDeviceSingleCardFixture {
 protected:
     void SetUp() override {
         if (!this->validate_dispatch_mode()) {
             GTEST_SKIP();
         }
-        FastDispatchMeshDeviceSingleCardFixture::SetUp();
+        AnyDispatchMeshDeviceSingleCardFixture::SetUp();
     }
 
     virtual bool validate_dispatch_mode() {

--- a/tests/tt_metal/tt_metal/device/test_simulator_device.cpp
+++ b/tests/tt_metal/tt_metal/device/test_simulator_device.cpp
@@ -74,7 +74,7 @@ TEST_F(SimulatorFixture, SimulatorDeviceInitialization) {
     }
 }
 
-TEST_F(SimulatorFixture, QuasarStaticTlbReadWrite) {
+TEST_F(FastDispatchMeshDeviceFixture, QuasarStaticTlbReadWrite) {
     auto& cluster = MetalContext::instance().get_cluster();
     if (cluster.arch() != tt::ARCH::QUASAR) {
         GTEST_SKIP();

--- a/tests/tt_metal/tt_metal/device/test_simulator_device.cpp
+++ b/tests/tt_metal/tt_metal/device/test_simulator_device.cpp
@@ -40,6 +40,20 @@ namespace tt::tt_metal {
 using namespace tt;
 using namespace tt::test_utils;
 
+class FastDispatchSimulatorFixture : public FastDispatchMeshDeviceFixture {
+protected:
+    void SetUp() override {
+        // Check if simulator mode is enabled
+        if (!tt::tt_metal::MetalContext::instance().rtoptions().get_simulator_enabled()) {
+            GTEST_SKIP()
+                << "Simulator mode not enabled. Set TT_METAL_SIMULATOR environment variable to run simulator tests.";
+        }
+
+        // Call parent SetUp to initialize devices
+        FastDispatchMeshDeviceFixture::SetUp();
+    }
+};
+
 class SimulatorFixture : public MeshDeviceFixture {
 protected:
     void SetUp() override {
@@ -74,7 +88,7 @@ TEST_F(SimulatorFixture, SimulatorDeviceInitialization) {
     }
 }
 
-TEST_F(FastDispatchMeshDeviceFixture, QuasarStaticTlbReadWrite) {
+TEST_F(FastDispatchSimulatorFixture, QuasarStaticTlbReadWrite) {
     auto& cluster = MetalContext::instance().get_cluster();
     if (cluster.arch() != tt::ARCH::QUASAR) {
         GTEST_SKIP();

--- a/tests/tt_metal/tt_metal/device/test_simulator_device.cpp
+++ b/tests/tt_metal/tt_metal/device/test_simulator_device.cpp
@@ -40,7 +40,7 @@ namespace tt::tt_metal {
 using namespace tt;
 using namespace tt::test_utils;
 
-class FastDispatchSimulatorFixture : public FastDispatchMeshDeviceFixture {
+class AnyDispatchSimulatorFixture : public AnyDispatchMeshDeviceFixture {
 protected:
     void SetUp() override {
         // Check if simulator mode is enabled
@@ -50,7 +50,7 @@ protected:
         }
 
         // Call parent SetUp to initialize devices
-        FastDispatchMeshDeviceFixture::SetUp();
+        AnyDispatchMeshDeviceFixture::SetUp();
     }
 };
 
@@ -88,7 +88,7 @@ TEST_F(SimulatorFixture, SimulatorDeviceInitialization) {
     }
 }
 
-TEST_F(FastDispatchSimulatorFixture, QuasarStaticTlbReadWrite) {
+TEST_F(AnyDispatchSimulatorFixture, QuasarStaticTlbReadWrite) {
     auto& cluster = MetalContext::instance().get_cluster();
     if (cluster.arch() != tt::ARCH::QUASAR) {
         GTEST_SKIP();

--- a/tests/tt_metal/tt_metal/test_bmm.cpp
+++ b/tests/tt_metal/tt_metal/test_bmm.cpp
@@ -257,14 +257,14 @@ TEST_F(AnyDispatchMeshDeviceSingleCardFixture, Bmm) {
     auto& cq = mesh_device.mesh_command_queue();
     auto src0_vec = create_random_vector_of_bfloat16(bytesA, 1.0f, 0x1234);
     auto src1_vec = create_random_vector_of_bfloat16(bytesB, 1.0f, 0x1234, -0.45f);
-    enqueue_write_tensor(cq, reinterpret_cast<const std::byte*>(src0_vec.data()), tensors.src0);
-    enqueue_write_tensor(cq, reinterpret_cast<const std::byte*>(src1_vec.data()), tensors.src1);
+    auto src0_host = HostTensor::from_vector(src0_vec, tensors.src0.tensor_spec());
+    auto src1_host = HostTensor::from_vector(src1_vec, tensors.src1.tensor_spec());
+    enqueue_write_tensor(cq, src0_host, tensors.src0);
+    enqueue_write_tensor(cq, src1_host, tensors.src1);
 
     distributed::EnqueueMeshWorkload(cq, workload, /*blocking=*/true);
 
-    const uint32_t bytesC = p.single_tile_size * p.Mt * p.Nt * p.B_total;
-    std::vector<uint32_t> result_vec(bytesC / sizeof(uint32_t));
-    enqueue_read_tensor(cq, tensors.dst, reinterpret_cast<std::byte*>(result_vec.data()));
+    auto result_vec = enqueue_read_tensor(cq, tensors.dst).to_vector<uint32_t>();
 
     int argfail = -1;
     bool pass = validate_bmm_result(p, src0_vec, src1_vec, result_vec, &argfail);

--- a/tests/tt_metal/tt_metal/test_bmm.cpp
+++ b/tests/tt_metal/tt_metal/test_bmm.cpp
@@ -199,7 +199,7 @@ bool validate_bmm_result(
 
 }  // namespace
 
-TEST_F(FastDispatchMeshDeviceSingleCardFixture, Bmm) {
+TEST_F(AnyDispatchMeshDeviceSingleCardFixture, Bmm) {
     auto& mesh_device = *devices_[0];
     IDevice* dev = mesh_device.get_devices()[0];
 

--- a/tests/tt_metal/tt_metal/test_bmm.cpp
+++ b/tests/tt_metal/tt_metal/test_bmm.cpp
@@ -17,6 +17,7 @@
 #include <tt-metalium/tilize_utils.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
 #include <tt-metalium/experimental/tensor/mesh_tensor.hpp>
+#include <tt-metalium/experimental/tensor/tensor_apis.hpp>
 #include "test_gold_impls.hpp"
 #include "impl/data_format/bfloat16_utils.hpp"
 
@@ -198,7 +199,7 @@ bool validate_bmm_result(
 
 }  // namespace
 
-TEST_F(MeshDeviceSingleCardFixture, Bmm) {
+TEST_F(FastDispatchMeshDeviceSingleCardFixture, Bmm) {
     auto& mesh_device = *devices_[0];
     IDevice* dev = mesh_device.get_devices()[0];
 
@@ -221,7 +222,8 @@ TEST_F(MeshDeviceSingleCardFixture, Bmm) {
     const experimental::NodeCoord node{0, 0};
     const bool use_implicit_sync = (dev->arch() == ARCH::QUASAR);
     auto spec = build_bmm_program_spec(p, tensors, node, use_implicit_sync);
-    auto program = experimental::MakeProgramFromSpec(mesh_device, spec);
+    auto workload = experimental::MakeMeshWorkloadFromSpec(mesh_device, spec);
+    Program& program = workload.get_programs().begin()->second;
 
     constexpr uint32_t do_bcast = 0;
     experimental::ProgramRunArgs params;
@@ -252,17 +254,17 @@ TEST_F(MeshDeviceSingleCardFixture, Bmm) {
     };
     experimental::SetProgramRunArgs(program, params);
 
+    auto& cq = mesh_device.mesh_command_queue();
     auto src0_vec = create_random_vector_of_bfloat16(bytesA, 1.0f, 0x1234);
     auto src1_vec = create_random_vector_of_bfloat16(bytesB, 1.0f, 0x1234, -0.45f);
-    // MeshTensor doesn't yet expose slow-dispatch read/write APIs, so route through the
-    // underlying reference buffer to populate / read back DRAM.
-    detail::WriteToBuffer(*tensors.src0.mesh_buffer().get_reference_buffer(), src0_vec);
-    detail::WriteToBuffer(*tensors.src1.mesh_buffer().get_reference_buffer(), src1_vec);
+    enqueue_write_tensor(cq, reinterpret_cast<const std::byte*>(src0_vec.data()), tensors.src0);
+    enqueue_write_tensor(cq, reinterpret_cast<const std::byte*>(src1_vec.data()), tensors.src1);
 
-    detail::LaunchProgram(dev, program, true);
+    distributed::EnqueueMeshWorkload(cq, workload, /*blocking=*/true);
 
-    std::vector<uint32_t> result_vec;
-    detail::ReadFromBuffer(*tensors.dst.mesh_buffer().get_reference_buffer(), result_vec);
+    const uint32_t bytesC = p.single_tile_size * p.Mt * p.Nt * p.B_total;
+    std::vector<uint32_t> result_vec(bytesC / sizeof(uint32_t));
+    enqueue_read_tensor(cq, tensors.dst, reinterpret_cast<std::byte*>(result_vec.data()));
 
     int argfail = -1;
     bool pass = validate_bmm_result(p, src0_vec, src1_vec, result_vec, &argfail);


### PR DESCRIPTION
### PR Category
[Test Only]

### Summary
Updates to Quasar regression test script:
- Removing option to automatically run with TT_METAL_SLOW_DISPATCH_MODE. Env var must always be explicit now.
- Adding support to run pytests (e.g. ttnn tests). Required for profiler regression tests.
- Verified locally that both .yaml files run successfully with these changes.

Updates to Quasar regression test list:
- Moved all 2x3 & 2x3_DISPATCH tests to nightly run.
- Moved fast-dispatch related tests to nightly run.
- Added additional profiler test to local run yaml. Cannot be run automatically until pipeline support is added.
- Verified nightly yaml by manually running pipeline regression run: [LINK](https://yyz-gitlab.local.tenstorrent.com/tensix/tt-umd-simulators/-/pipelines/1013173)

Updates to unit tests - Prototype to enable runtime unit tests with fast dispatch:
- Replaced existing unit test classes (MeshDeviceFixture, MeshDeviceSingleCardFixture & SimulatorFixture) that require slow dispatch with "AllDispatch*" version. New class is identical existing class, except the new class does not check if slow dispatch is enabled.
  - Longer term, I want a better naming convention, but that may require changing the class name for all existing tests as well. I want to keep this initial prototype change small, so I am not making that change here. Long-term naming convention will be discussed in the near future - for now, I am just looking for whether this naming convention is acceptable short-term to enable a few tests in fast-dispatch.
- Made new version of existing unit test classes that inherit "FastDispatch*" version & check that slow dispatch is enabled.
  - Existing tests using existing unit test classes will remain unchanged.
- Updated 3 unit tests as initial trial porting them to be able to run with both fast dispatch or slow dispatch.
  - FastDispatchMeshDeviceFixture.TensixSingleCoreDirectDramReaderDatacopyWriter
  - FastDispatchSimulatorFixture.QuasarStaticTlbReadWrite
  - FastDispatchMeshDeviceSingleCardFixture.Bmm
- All 3 tests manually run with both slow dispatch & fast dispatch targeting Quasar

### Notes for reviewers

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=kstevens/quasar_tests_pr)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:kstevens/quasar_tests_pr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=kstevens/quasar_tests_pr)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:kstevens/quasar_tests_pr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=kstevens/quasar_tests_pr)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:kstevens/quasar_tests_pr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=kstevens/quasar_tests_pr)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:kstevens/quasar_tests_pr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=kstevens/quasar_tests_pr)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:kstevens/quasar_tests_pr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=kstevens/quasar_tests_pr)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:kstevens/quasar_tests_pr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=kstevens/quasar_tests_pr)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:kstevens/quasar_tests_pr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=kstevens/quasar_tests_pr)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:kstevens/quasar_tests_pr)