### PR TITLE
[tt_dit] Fix Python 3.10 support in experimental pipelines

### DIFF
--- a/models/tt_dit/experimental/pipelines/pipeline_wan_lora.py
+++ b/models/tt_dit/experimental/pipelines/pipeline_wan_lora.py
@@ -9,6 +9,9 @@ on CPU before TT conversion so inference has no LoRA-specific runtime cost.
 See ``experimental/models/Wan2_2_LoRA.md`` for the adapter-key formats
 detected by ``fuse_lora_state_dict`` and the supported namespaces.
 """
+
+from __future__ import annotations
+
 import hashlib
 import re
 from collections.abc import Sequence

--- a/models/tt_dit/experimental/pipelines/pipeline_wan_svi.py
+++ b/models/tt_dit/experimental/pipelines/pipeline_wan_svi.py
@@ -8,6 +8,9 @@ Chains short I2V clips into long videos with latent-space continuity.
 See ``experimental/models/Wan2_2_SVI.md`` for the regime parameters,
 upstream-workflow comparison, and the documented scheduler gap.
 """
+
+from __future__ import annotations
+
 from dataclasses import dataclass
 from pathlib import Path
 from typing import List, Literal, Optional, Union


### PR DESCRIPTION
Add `from __future__ import annotations` to support Python versions used by inference server.

Related issue: https://github.com/tenstorrent/tt-metal/issues/51207

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=friedrich/wan)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:friedrich/wan)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=friedrich/wan)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:friedrich/wan)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=friedrich/wan)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:friedrich/wan)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=friedrich/wan)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:friedrich/wan)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=friedrich/wan)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:friedrich/wan)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=friedrich/wan)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:friedrich/wan)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=friedrich/wan)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:friedrich/wan)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=friedrich/wan)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:friedrich/wan)