### PR TITLE
Expose MGD-inferred fabric type to Python (get_all_mgd_fabric_types)

### DIFF
--- a/tt_metal/api/tt-metalium/internal/fabric.hpp
+++ b/tt_metal/api/tt-metalium/internal/fabric.hpp
@@ -67,4 +67,6 @@ void append_routing_plane_connection_rt_args_no_defines(
 // returns the local rank's meshes). Intended for inter-mesh topology discovery.
 std::vector<tt::tt_fabric::MeshId> get_all_fabric_mesh_ids();
 
+std::vector<tt::tt_fabric::FabricType> get_all_mgd_fabric_types();
+
 }  // namespace tt::tt_metal::internal

--- a/tt_metal/fabric/fabric.cpp
+++ b/tt_metal/fabric/fabric.cpp
@@ -10,6 +10,7 @@
 #include <tt-metalium/experimental/fabric/fabric.hpp>
 #include <tt-metalium/internal/fabric.hpp>
 #include <tt-metalium/experimental/fabric/mesh_graph.hpp>
+#include <tt-metalium/experimental/fabric/mesh_graph_descriptor.hpp>
 #include <tt_stl/assert.hpp>
 #include <tt-metalium/experimental/fabric/control_plane.hpp>
 #include <tt-metalium/mesh_device.hpp>
@@ -648,6 +649,18 @@ namespace tt::tt_metal::internal {
 
 std::vector<tt::tt_fabric::MeshId> get_all_fabric_mesh_ids() {
     return tt::tt_metal::MetalContext::instance().get_control_plane().get_mesh_graph().get_mesh_ids();
+}
+
+std::vector<tt::tt_fabric::FabricType> get_all_mgd_fabric_types() {
+    const auto& mesh_graph = tt::tt_metal::MetalContext::instance().get_control_plane().get_mesh_graph();
+    const auto& mgd = mesh_graph.get_mesh_graph_descriptor();
+    std::vector<tt::tt_fabric::FabricType> fabric_types;
+    for (const auto mesh : mgd.all_meshes()) {
+        const auto& instance = mgd.get_instance(mesh);
+        const auto* mesh_desc = std::get<const tt::tt_fabric::proto::MeshDescriptor*>(instance.desc);
+        fabric_types.push_back(tt::tt_fabric::MeshGraphDescriptor::infer_fabric_type_from_dim_types(mesh_desc));
+    }
+    return fabric_types;
 }
 
 // Query the kernel defines required by the current fabric configuration.

--- a/ttnn/cpp/ttnn-nanobind/fabric.cpp
+++ b/ttnn/cpp/ttnn-nanobind/fabric.cpp
@@ -67,6 +67,12 @@ void bind_fabric_api(nb::module_& mod) {
         .value(
             "CUSTOM", tt::tt_fabric::FabricConfig::CUSTOM);  // DISABLED = 0, FABRIC_1D = 1, FABRIC_2D = 2, CUSTOM = 4
 
+    nb::enum_<tt::tt_fabric::FabricType>(mod, "FabricType", nb::is_arithmetic())
+        .value("MESH", tt::tt_fabric::FabricType::MESH)
+        .value("TORUS_X", tt::tt_fabric::FabricType::TORUS_X)
+        .value("TORUS_Y", tt::tt_fabric::FabricType::TORUS_Y)
+        .value("TORUS_XY", tt::tt_fabric::FabricType::TORUS_XY);
+
     // custom mapping here for interface stability
     nb::enum_<tt::tt_fabric::FabricReliabilityMode>(mod, "FabricReliabilityMode", R"(
         Specifies how the fabric initialization handles system health and configuration.
@@ -379,6 +385,15 @@ void bind_fabric_api(nb::module_& mod) {
 
             Unlike get_user_physical_mesh_ids (which is scoped to the local rank's meshes),
             this enumerates peer meshes as well, enabling multi-mesh topology discovery.
+        )");
+
+    mod.def(
+        "get_all_mgd_fabric_types",
+        &tt::tt_metal::internal::get_all_mgd_fabric_types,
+        R"(
+            Returns the FabricType each compute mesh's dim_types imply, one entry per mesh in
+            the active mesh graph descriptor. Callers can map these to a FabricConfig to match
+            the wired topology (RING/LINE) instead of inferring it from process count.
         )");
 }
 

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -164,6 +164,7 @@ from ttnn._ttnn.global_circular_buffer import (
 
 from ttnn._ttnn.fabric import (
     FabricConfig,
+    FabricType,
     FabricReliabilityMode,
     FabricTensixConfig,
     FabricUDMMode,
@@ -176,6 +177,7 @@ from ttnn._ttnn.fabric import (
     get_physical_mesh_shapes,
     get_eth_forwarding_direction,
     get_all_fabric_mesh_ids,
+    get_all_mgd_fabric_types,
     MeshId,
     FabricNodeId,
     setup_fabric_connection,


### PR DESCRIPTION


Expose the MGD-inferred fabric topology to Python so callers can select a `FabricConfig` from the wired topology instead of heuristics like the MPI process count.

#### Why
- Blaze's CLI infers `FabricConfig` from `num_procs` (e.g. `num_procs in (16, 40, 64, 80)`), a brittle proxy: a single galaxy can be represented with different mesh counts, and process count doesn't encode RING vs LINE.
- The determining signal is the MGD's `dim_types`, which isn't reachable from Python today. Exposing it lets the CLI pick the fabric that matches the topology.

#### Key changes
- Add `tt::tt_fabric::get_all_mgd_fabric_types()`: the `FabricType` each compute mesh's `dim_types` imply, one entry per mesh. Reuses `MeshGraphDescriptor::infer_fabric_type_from_dim_types` and reaches the active MGD via the control plane (same path as `get_all_fabric_mesh_ids`).
- Bind `FabricType` (`MESH / TORUS_X / TORUS_Y / TORUS_XY`) and the new function in `ttnn`.

#### Notes
- One entry per mesh; callers map to `FabricConfig` and assert uniformity, keeping fabric policy out of Metal.
- Throws if there is no active MGD (same assumption as `get_all_fabric_mesh_ids`).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nkodkani/expose-mgd-fabric-type)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nkodkani/expose-mgd-fabric-type)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nkodkani/expose-mgd-fabric-type)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nkodkani/expose-mgd-fabric-type)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nkodkani/expose-mgd-fabric-type)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nkodkani/expose-mgd-fabric-type)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nkodkani/expose-mgd-fabric-type)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nkodkani/expose-mgd-fabric-type)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nkodkani/expose-mgd-fabric-type)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nkodkani/expose-mgd-fabric-type)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nkodkani/expose-mgd-fabric-type)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nkodkani/expose-mgd-fabric-type)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nkodkani/expose-mgd-fabric-type)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nkodkani/expose-mgd-fabric-type)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nkodkani/expose-mgd-fabric-type)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nkodkani/expose-mgd-fabric-type)