### PR TITLE
#51133: Refuse on-device construction when per-core allocation is requested

### DIFF
--- a/tests/ttnn/unit_tests/per_core_allocation/test_per_core_allocation_from_torch.py
+++ b/tests/ttnn/unit_tests/per_core_allocation/test_per_core_allocation_from_torch.py
@@ -1,0 +1,127 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for #51133: from_torch(device=...) must not drop per-core allocation.
+
+`create_tt_tensor_from_host_data` can build a tensor in its *source* layout on device and
+convert it there with ttnn ops. Those ops rebuild the output MemoryConfig from a few named
+fields and drop the experimental per-core allocation bit, so the caller silently received a
+lockstep buffer.
+
+The fix refuses the on-device construction path when the requested memory config asks for
+per-core allocation, so the tensor is built on host and `to_device` applies the caller's
+memory config directly — no op in between.
+"""
+
+import os
+
+import pytest
+import torch
+
+import ttnn
+
+
+@pytest.fixture(scope="function")
+def per_core_mesh():
+    """1x1 mesh with HYBRID allocator mode.
+
+    A mesh_mapper is what selects the on-device construction branch in
+    `create_tt_tensor_from_host_data`; the single-device path takes
+    `is_data_transformation_required` to host for any sharded config, so #51133 does not
+    reproduce there. A 1x1 mesh exercises the failing branch while still running on one device.
+    """
+    os.environ["TT_METAL_ALLOCATOR_MODE_HYBRID"] = "1"
+    mesh = ttnn.open_mesh_device(mesh_shape=ttnn.MeshShape(1, 1))
+    yield mesh
+    ttnn.close_mesh_device(mesh)
+    os.environ.pop("TT_METAL_ALLOCATOR_MODE_HYBRID", None)
+
+
+def _per_core_width_sharded_config(grid_start, grid_end, shard_shape):
+    crs = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(*grid_start), ttnn.CoreCoord(*grid_end))])
+    mem_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ttnn.BufferType.L1,
+        ttnn.ShardSpec(crs, list(shard_shape), ttnn.ShardOrientation.ROW_MAJOR),
+    )
+    mem_config.experimental_set_per_core_allocation(True)
+    return mem_config
+
+
+# Shapes from the sweep in #51133. The reporter established that core grid, core count and
+# range count are all irrelevant — the only thing that mattered was whether the shard was
+# small enough for has_sufficient_device_memory() to allow the on-device path. Grids here are
+# kept narrow so the test runs on any device, unlike the col-12 grids in the report.
+@pytest.mark.parametrize(
+    "grid_start, grid_end, shard_shape",
+    [
+        ((0, 0), (7, 0), (7168, 32)),  # gate_mm: the weight actually affected in tt-blaze
+        ((0, 0), (7, 0), (512, 32)),  # small shard, same grid
+        ((0, 0), (3, 0), (7168, 32)),  # 4 cores
+        ((0, 0), (7, 1), (7168, 32)),  # 16 cores, two rows
+    ],
+    ids=["gate_mm_7168x32", "small_512x32", "four_cores", "two_rows"],
+)
+def test_from_torch_on_device_preserves_per_core_allocation(per_core_mesh, grid_start, grid_end, shard_shape):
+    """from_torch(device=...) must honour a per-core memory config, not downgrade to lockstep."""
+    num_cores = (grid_end[0] - grid_start[0] + 1) * (grid_end[1] - grid_start[1] + 1)
+    mem_config = _per_core_width_sharded_config(grid_start, grid_end, shard_shape)
+
+    torch_input = torch.randn(shard_shape[0], shard_shape[1] * num_cores, dtype=torch.bfloat16)
+    tensor = ttnn.from_torch(
+        torch_input,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=mem_config,
+        tile=ttnn.Tile((32, 32)),
+        mesh_mapper=ttnn.ReplicateTensorToMesh(per_core_mesh),
+        device=per_core_mesh,
+    )
+
+    assert tensor.is_per_core_allocated(), (
+        "from_torch(device=...) silently dropped the experimental per-core allocation bit; "
+        "the buffer is lockstep-allocated even though the memory_config asked for per-core"
+    )
+    assert torch.equal(ttnn.to_torch(tensor), torch_input), "from_torch corrupted the data"
+
+
+def test_from_torch_large_shard_still_per_core(per_core_mesh):
+    """A shard above the has_sufficient_device_memory() gate already worked; keep it working.
+
+    This case took the host path on `main` and so was unaffected by #51133. It is here to catch
+    the fix breaking the branch that was already correct.
+    """
+    mem_config = _per_core_width_sharded_config((0, 0), (7, 0), (14336, 32))
+    torch_input = torch.randn(14336, 32 * 8, dtype=torch.bfloat16)
+
+    tensor = ttnn.from_torch(
+        torch_input,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=mem_config,
+        tile=ttnn.Tile((32, 32)),
+        mesh_mapper=ttnn.ReplicateTensorToMesh(per_core_mesh),
+        device=per_core_mesh,
+    )
+
+    assert tensor.is_per_core_allocated()
+    assert torch.equal(ttnn.to_torch(tensor), torch_input)
+
+
+def test_from_torch_row_major_per_core_unaffected(per_core_mesh):
+    """ROW_MAJOR needs no layout conversion, so it always preserved the bit. Pin that."""
+    mem_config = _per_core_width_sharded_config((0, 0), (7, 0), (512, 32))
+    torch_input = torch.randn(512, 32 * 8, dtype=torch.bfloat16)
+
+    tensor = ttnn.from_torch(
+        torch_input,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        memory_config=mem_config,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(per_core_mesh),
+        device=per_core_mesh,
+    )
+
+    assert tensor.is_per_core_allocated()
+    assert torch.equal(ttnn.to_torch(tensor), torch_input)

--- a/ttnn/core/tensor/py_to_tt_tensor.cpp
+++ b/ttnn/core/tensor/py_to_tt_tensor.cpp
@@ -9,6 +9,7 @@
 #include "ttnn/operations/core/core.hpp"
 
 #include <tt-metalium/allocator.hpp>
+#include <ttnn/tensor/memory_config/memory_config.hpp>
 #include <tt_stl/unreachable.hpp>
 
 #include <tracy/Tracy.hpp>
@@ -66,7 +67,18 @@ bool can_construct_on_device(
     DataType dst_dtype,
     const std::optional<Tile>& optional_tile,
     bool enable_device_typecast,
-    bool preserve_nan_values) {
+    bool preserve_nan_values,
+    const MemoryConfig& memory_config) {
+    // Constructing on device builds the tensor in the *source* layout and converts it with ttnn
+    // ops (tilize / typecast). Those ops rebuild the output MemoryConfig from a handful of named
+    // fields and drop the experimental per-core allocation bit, so the caller would silently get
+    // a lockstep-allocated buffer (#51133). No op understands per-core allocation today (#51354),
+    // so there is nothing to preserve the bit through. Build on host instead: the subsequent
+    // to_device() applies the caller's memory_config directly, with no op in between.
+    if (experimental::per_core_allocation::is_per_core_allocation(memory_config)) {
+        return false;
+    }
+
     bool res = device != nullptr && !device->is_remote_only() &&
                (device->get_active_sub_device_manager_id() == device->get_default_sub_device_manager_id()) &&
                tensor_shape.volume() > 0 && can_exec_ops_on_device(src_dtype) && can_exec_ops_on_device(dst_dtype) &&
@@ -238,7 +250,14 @@ Tensor create_tt_tensor_from_host_data(
         TensorLayout dst_tensor_layout(dst_dtype, PageConfig(layout, optional_tile), memory_config);
 
         const bool construct_on_device = can_construct_on_device(
-            device, tensor_shape, src_dtype, dst_dtype, optional_tile, enable_device_typecast, preserve_nan_values);
+            device,
+            tensor_shape,
+            src_dtype,
+            dst_dtype,
+            optional_tile,
+            enable_device_typecast,
+            preserve_nan_values,
+            memory_config);
 
         if (mesh_mapper != nullptr) {
             const auto device_shard_shape =


### PR DESCRIPTION
Fixes #51133.

## Problem

`ttnn.from_torch(device=..., memory_config=<per-core L1>)` silently returned a tensor that is **not** per-core allocated. No error, no warning. Callers branching on `is_per_core_allocated()` to choose between `buffer_address()` and `experimental_per_core_buffer_address(core)` take the wrong branch.

`create_tt_tensor_from_host_data` may build the tensor in its *source* layout on device and convert it there with ttnn ops:

```cpp
const bool construct_on_mesh_device = construct_on_device && has_sufficient_device_memory(...);
return ttnn::distributed::create_distributed_tensor(
    ..., construct_on_mesh_device ? src_tensor_layout : dst_tensor_layout, ...);
```

Those ops rebuild the output `MemoryConfig` from a handful of named fields, which discards the per-core allocation bit. The bit is private, absent from `attribute_names`/`attribute_values`, and ignored by `operator==`, so nothing flags the loss.

## Fix

Refuse the on-device path when the caller asked for per-core allocation. `can_construct_on_device()` takes the memory config and returns false for per-core, so both the mesh and single-device branches fall through to `dst_tensor_layout`. The tensor is built on host, and the subsequent `to_device()` applies the caller's memory config directly — no op in between.

```cpp
if (experimental::per_core_allocation::is_per_core_allocation(memory_config)) {
    return false;
}
```

## Why refuse rather than preserve

Carrying the bit through `tilize` would not have been correct. The sharded program factories bind one L1 address for every core — `Buffer::address()` returns the first core's address (`allocator.cpp:163`), and `cb_output.buffer = dst_buffer` resolves to that single value. The same is true of the host write and read: `Buffer::translate_page_address` is `this->address() + bank_offset` (`buffer.cpp:674`). No op is per-core aware — `grep -rn "per_core_allocat" ttnn/cpp/ttnn/operations/` returns nothing. That broader problem is tracked in #51354.

The issue reporter proposed exactly this: "refuse the on-device path when the requested `memory_config` carries the per-core bit and fall back to `dst_tensor_layout`."

This is the alternative to #51191, which fixes the same issue by preserving the bit through the ops instead. The two are mutually exclusive as fixes for #51133.

## Behaviour changes

Non-per-core behaviour is unchanged — the check is the first statement in `can_construct_on_device()` and returns early only for per-core configs.

For per-core callers, `from_torch(device=...)` now builds on host instead of on device. That trades some construction throughput for correctness on a path that previously returned a silently wrong tensor.

## Tests

`test_per_core_allocation_from_torch.py`: the `from_torch` cases from the sweep in #51133 including `gate_mm`'s `(7168, 32)` shard — the one weight actually affected in tt-blaze — plus the large shard that already took the host path, and ROW_MAJOR which never needed a conversion.

The tests use a 1×1 mesh: a `mesh_mapper` is what selects the on-device branch, and the single-device path sends any sharded config to host via `is_data_transformation_required`, so #51133 does not reproduce without one.

Validated against a control build with only the `can_construct_on_device` early return disabled — the four `from_torch` cases fail there, confirming the fixture reaches the on-device construction path rather than passing vacuously.
