### PR TITLE
[Performance] Fuse sparse MLA ring indexer over ND-sharded caches

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla.py
+++ b/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla.py
@@ -715,13 +715,13 @@ def test_sparse_mla_accuracy(
     ds_repo,
     monkeypatch,
 ):
-    original = ttnn.experimental.indexer_score_dsa
+    original = ttnn.experimental.ring_indexer_score_dsa
 
     def check_indexer_q_format(q, *args, **kwargs):
         assert q.dtype == ttnn.bfloat8_b
         return original(q, *args, **kwargs)
 
-    monkeypatch.setattr(ttnn.experimental, "indexer_score_dsa", check_indexer_q_format)
+    monkeypatch.setattr(ttnn.experimental, "ring_indexer_score_dsa", check_indexer_q_format)
     topology = _topology_from_device_params(device_params)
     run_sparse_mla_accuracy_case(
         variant,

--- a/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla.py
+++ b/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla.py
@@ -200,7 +200,7 @@ def _init_index_kv_cache(config, mesh_device, seq_len, mesh_shape, sp_axis, slot
     )
 
 
-def _collect_index_cache_natural(tt_index_kv_cache, mesh_device, config, chunk):
+def _collect_index_cache_natural(tt_index_kv_cache, mesh_device, config, chunk, cache_batch_idx=0):
     """Read the block-cyclic indexer key cache back to a natural-order [S, index_head_dim] tensor in the
     CPU reference's RoPE frame, so it can be PCC'd against SparseMLAReference.index_cache.
 
@@ -213,7 +213,7 @@ def _collect_index_cache_natural(tt_index_kv_cache, mesh_device, config, chunk):
     cache_sr = ttnn.to_torch(
         tt_index_kv_cache,
         mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(2, 1), mesh_shape=mesh_device.shape),
-    ).to(torch.bfloat16)[:, :1]
+    ).to(torch.bfloat16)[cache_batch_idx : cache_batch_idx + 1, :1]
     p = blockcyclic_positions(sp, chunk, cache_sr.shape[2])
     nat = torch.empty(cache_sr.shape[2], cache_sr.shape[-1], dtype=torch.bfloat16)
     nat[p] = cache_sr[0, 0]
@@ -367,7 +367,7 @@ def run_sparse_mla_determinism_case(
 def run_sparse_mla_chunked_case(
     variant, config, mesh_device, seq_len, chunk, cache_format, ds_layer, ds_checkpoint, ds_repo, ds_input
 ):
-    """Sparse chunked prefill: compare chunked ttMLA against MLACPU sparse chunked truth."""
+    """Sparse chunked prefill on nonzero user slot: compare ttMLA against MLACPU sparse chunked truth."""
     # Anchor mesh (TP>=2) and seq/SP validity are guaranteed by _sparse_cases (no runtime skips).
     #
     # CACHE-QUANTIZATION NOTE: the canonical CPU reference keeps KVPE in BF16. The BF16 device case
@@ -388,6 +388,7 @@ def run_sparse_mla_chunked_case(
 
     mesh_shape = list(mesh_device.shape)
     sp_axis, tp_axis = 0, 1
+    num_users, cache_user_id = 2, 1
     logger.debug(f"[{variant.name}] sparse MLA chunked: initializing KVPE cache mesh_shape={mesh_shape}")
     tt_kvpe_cache = init_mla_kv_cache(
         cache_format=cache_format,
@@ -397,9 +398,10 @@ def run_sparse_mla_chunked_case(
         mesh_shape=mesh_shape,
         sp_axis=sp_axis,
         num_kvpe_cache_layers=1,
+        num_users=num_users,
     )
 
-    tt_index_kv_cache = _init_index_kv_cache(config, mesh_device, seq_len, mesh_shape, sp_axis)
+    tt_index_kv_cache = _init_index_kv_cache(config, mesh_device, seq_len, mesh_shape, sp_axis, slot_num=num_users)
     logger.debug(f"[{variant.name}] sparse MLA chunked: constructing TT module and indexed RoPE tensors")
     mla_tt = ttMLA(
         config,
@@ -410,6 +412,7 @@ def run_sparse_mla_chunked_case(
         sp_axis=sp_axis,
         tp_axis=tp_axis,
         is_chunked=True,
+        slot_num=num_users,
         layer_num=1,
         sparse_kv_cache_format=cache_format,
     )
@@ -434,7 +437,14 @@ def run_sparse_mla_chunked_case(
             layout=ttnn.TILE_LAYOUT,
             mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=tuple(mesh_device.shape), dims=shard_dims),
         )
-        out = mla_tt.forward(tt_x, rope_tensors, tt_kvpe_cache, actual_start=s, index_kv_cache=tt_index_kv_cache)
+        out = mla_tt.forward(
+            tt_x,
+            rope_tensors,
+            tt_kvpe_cache,
+            actual_start=s,
+            cache_user_id=cache_user_id,
+            index_kv_cache=tt_index_kv_cache,
+        )
         outs.append(
             ttnn.to_torch(
                 out, mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=shard_dims, mesh_shape=mesh_device.shape)
@@ -454,7 +464,9 @@ def run_sparse_mla_chunked_case(
 
     sp = mesh_device.shape[0]
     logger.debug(f"[{variant.name}] sparse MLA chunked: collecting KVPE cache")
-    cache_sr = _collect_kvpe_cache(tt_kvpe_cache, mesh_device)[:, :1]
+    cache_all = _collect_kvpe_cache(tt_kvpe_cache, mesh_device)
+    assert torch.count_nonzero(cache_all[0:1]) == 0, "sparse MLA wrote KVPE into unselected user slot 0"
+    cache_sr = cache_all[cache_user_id : cache_user_id + 1, :1]
     p = blockcyclic_positions(sp, chunk, cache_sr.shape[2])
     nat = torch.empty(cache_sr.shape[2], cache_sr.shape[-1], dtype=torch.bfloat16)
     nat[p] = cache_sr[0, 0]
@@ -462,7 +474,18 @@ def run_sparse_mla_chunked_case(
     logger.info(f"[{variant.name}] kvpe prefix: {m}")
 
     logger.debug(f"[{variant.name}] sparse MLA chunked: collecting indexer key cache")
-    idx_nat = _collect_index_cache_natural(tt_index_kv_cache, mesh_device, config, chunk)
+    index_cache_layers = num_full_indexer_layers(config) or 1
+    index_cache_batch_idx = cache_user_id * index_cache_layers
+    index_cache_host = ttnn.to_torch(
+        tt_index_kv_cache,
+        mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(2, 1), mesh_shape=mesh_device.shape),
+    )
+    assert (
+        torch.count_nonzero(index_cache_host[:index_cache_layers]) == 0
+    ), "sparse MLA wrote index keys into unselected user slot 0"
+    idx_nat = _collect_index_cache_natural(
+        tt_index_kv_cache, mesh_device, config, chunk, cache_batch_idx=index_cache_batch_idx
+    )
     _, idx_pcc = assert_with_pcc(ref_index[0, :seq_len], idx_nat[:seq_len], SPARSE_INDEX_PCC)
     logger.info(f"[{variant.name}] Chunked indexer cache PCC: {idx_pcc}")
 

--- a/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_perf.py
@@ -58,8 +58,8 @@ Single test (was a two-test tracy driver+impl split):
 Three scenarios (the test sweeps all three):
   * warm — production step: one `chunk`-token forward at start=cache over a `cache`-length prefix. Both
     block-cyclic caches (indexer index_kv_cache + KVPE) are left at init — no warm-up forwards; for a perf
-    proxy only op shapes/timing matter, and those are set by the full `total` prefix width the gather+score
-    span, not the cache contents. Measures a single steady-state chunk.
+    proxy only op shapes/timing matter, and those are set by the full `total` prefix width the fused ring
+    indexer spans, not the cache contents. Measures a single steady-state chunk.
   * cold — full cold prefill: forward chunks start=0,chunk,…,cache with real forwards that grow both
     caches (both by per-chunk block-cyclic slab writes). The measured region spans ALL chunks = the
     total cold-start prefill cost; the final chunk (start=cache) is exactly the `warm` step. Besides the
@@ -472,12 +472,14 @@ def _op_label(kernel_sources) -> str:
 # existing per-call graph attribution (parse_percall + its alias sets) consumes this dump unchanged.
 # Verified against the tracy op-code counts/durations for deepseek_v32 warm/sparse.
 _OP_CODE_RULES = (
+    # The fused ring indexer includes ring-attention all-gather helper kernels. Match its defining
+    # indexer kernels first so the whole program remains attributable to IndexerScore.
+    ("/experimental/indexer_score/", "IndexerScore"),
     # ring_mla (dense) fuses a ring all-gather with the joint-SDPA compute; its compute kernel lives under
     # transformer/sdpa/ (ring_joint_sdpa.cpp), so it must be matched BEFORE the generic sparse-SDPA rule.
     ("/ring_joint_sdpa", "RingJointSDPA"),
     ("/ring_attention_all_gather", "RingJointSDPA"),
     ("/transformer/sdpa/", "SDPA"),
-    ("/indexer_score/", "IndexerScore"),
     ("/topk_large_indices/", "TopkLargeIndices"),
     ("/ccl/all_gather_async/", "AllGatherAsync"),
     ("/ccl/reduce_scatter_minimal_async/", "ReduceScatterMinimalAsync"),
@@ -696,7 +698,7 @@ def test_mla_chunked_perf(mesh_device, variant, scenario, attn_mode, kv_cache_fo
 
     # Block-cyclic indexer key cache (SPARSE only): allocated externally (same ownership as the KVPE cache)
     # and passed into forward. warm/long leave it (and the KVPE cache) at zero init — for a profiling proxy
-    # the cache CONTENTS don't affect op shapes/timing (the gather + score always cover the full
+    # the cache CONTENTS don't affect op shapes/timing (the fused ring indexer always covers the full
     # `total`-length prefix), so representing the `cache` already-processed tokens needs no warm-up write.
     # cold fills both caches for real via its own per-chunk block-cyclic slab writes (start=0,chunk,…,cache).
     # DENSE has no indexer (NullIndexer) — ring MLA reads the prefix by logical_n (= total), not by cached

--- a/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_perf.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-Realtime-profiler perf harness for the DeepSeek V3.2 / GLM-5.1 MLA (DSA) chunked-prefill layer.
+Realtime-profiler perf harness for the DeepSeek V3.2 / GLM-5.1 / GLM-5.2 MLA (DSA) chunked-prefill layer.
 
 Production scenario (defaults): process one **5k-token chunk** with **50k tokens already cached**,
 on the Galaxy **SP=8 × TP=4** mesh.
@@ -49,7 +49,7 @@ Per-forward regions are what attribute ops to each cold iteration (the per-itera
 replace the old MLA_START signpost split. The run total is the sum of per-forward criticals.
 
 Single test (was a two-test tracy driver+impl split):
-  * test_mla_chunked_perf — parametrized over [deepseek_v32, glm_5_1] × [warm, cold, long] ×
+  * test_mla_chunked_perf — parametrized over [deepseek_v32, glm_5_1, glm_5_2] × [warm, cold, long] ×
     [sparse, dense]. Builds the DSA ttMLA (variant from the ``variant`` fixture) and, per scenario,
     measures one forward over the (zero-init) block-cyclic caches (warm/long) or a chunk loop that
     fills them (cold), profiling each forward under the realtime profiler. Prints a per-op table and
@@ -70,10 +70,13 @@ Three scenarios (the test sweeps all three):
     chunk over a long prefix. Like the others the cache scales by SP/8, so per-chip depth stays
     Galaxy-equal on every box (LoudBox=128k, QuietBox=64k box-local cache).
 
-variant axis — deepseek_v32 (128 q-heads / 64 index heads) vs glm_5_1 (64 / 32). Both run the SAME TP=4
-  meshes: GLM's thin per-chip head shard (64/4=16 < 32) is handled by the head→sequence reshard in
-  ttMLA._sparse_mla (#48727) plus the head-replicated seq-sharded indexer, so GLM is no longer TP-capped.
-  All model dims come from the single-source reference config (reference/{deepseek_v3_2,glm_5_1}_config.py).
+variant axis — deepseek_v32 (128 q-heads / 64 index heads) vs glm_5_1 / glm_5_2 (64 / 32). All run the
+  SAME TP=4 meshes: GLM's thin per-chip head shard (64/4=16 < 32) is handled by the head→sequence
+  reshard in ttMLA._sparse_mla (#48727) plus the head-replicated seq-sharded indexer, so GLM is no longer
+  TP-capped. GLM-5.2's sparse case intentionally builds the final ``full`` indexer layer (layer 74), with
+  its compact 21-slot index cache. This makes the fused ring op select nonzero slot 20—the multi-slot path
+  used by the complete 78-layer model—rather than exercising only the trivial single-slot GLM-5.1 proxy.
+  All model dims come from the single-source reference configs.
 
 attn_mode axis — a baseline to compare the sparse impl against:
   * sparse — v3.2 DSA: indexer builds top-k index keys, sparse_sdpa attends only the top-k=2048 keys.
@@ -124,10 +127,12 @@ import ttnn
 from models.demos.deepseek_v3_d_p.reference.cpu_deepseek_v32 import random_mla_weights
 from models.demos.deepseek_v3_d_p.reference.deepseek_v3_2_config import deepseek_v32_hf_config
 from models.demos.deepseek_v3_d_p.reference.glm_5_1_config import glm_hf_config
+from models.demos.deepseek_v3_d_p.reference.glm_5_2_config import glm_5_2_hf_config
 from models.demos.deepseek_v3_d_p.tests.sparse_mla.sparse_mla_mesh import detect_num_devices
 from models.demos.deepseek_v3_d_p.tests.sparse_mla.sparse_mla_plugin import is_marker_explicitly_selected
 from models.demos.deepseek_v3_d_p.tests.sparse_mla.sparse_mla_reference import make_hidden
 from models.demos.deepseek_v3_d_p.tt.mla import ttMLA
+from models.demos.deepseek_v3_d_p.tt.mla.indexer import num_full_indexer_layers
 from models.demos.deepseek_v3_d_p.tt.mla.rope import RotarySetup
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import create_fabric_router_config, get_max_payload_size
 from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import MlaKvCacheFormat, init_kvpe_cache, init_mla_kv_cache
@@ -144,14 +149,18 @@ LONG_CACHE_TOKENS = int(os.environ.get("DS_PERF_LONG_CACHE", 512000))
 # indexer, no top-k), a baseline to compare the sparse impl against. Each mode writes its own profiler
 # subdir + per-scenario CSVs so the two runs never clobber and stay directly comparable.
 ATTN_MODE = os.environ.get("DS_PERF_ATTN_MODE", "sparse")  # module-level default (mesh-shape detection)
-# Model-variant axis: deepseek_v32 (128 q-heads / 64 index heads) vs glm_5_1 (64 / 32). BOTH run the
-# SAME TP=4 meshes — GLM's thin per-chip head shard (64/4=16 < 32) is handled by the head→sequence
-# reshard in ttMLA._sparse_mla (#48727) plus the head-replicated seq-sharded indexer, so no TP cap
-# applies. Every model dimension comes from the single-source reference config
-# (reference/{deepseek_v3_2,glm_5_1}_config.py), never hardcoded here.
-VARIANTS = ("deepseek_v32", "glm_5_1")
+# Model-variant axis: deepseek_v32 (128 q-heads / 64 index heads) vs glm_5_1 / glm_5_2 (64 / 32). ALL
+# run the SAME TP=4 meshes — GLM's thin per-chip head shard (64/4=16 < 32) is handled by the
+# head→sequence reshard in ttMLA._sparse_mla (#48727) plus the head-replicated seq-sharded indexer, so
+# no TP cap applies. Every model dimension comes from the single-source reference config, never hardcoded
+# here. GLM-5.2 additionally exercises a nonzero slot of its compact full-indexer cache below.
+VARIANTS = ("deepseek_v32", "glm_5_1", "glm_5_2")
 VARIANT = os.environ.get("DS_PERF_VARIANT", "deepseek_v32")
-_CONFIG_BUILDERS = {"deepseek_v32": deepseek_v32_hf_config, "glm_5_1": glm_hf_config}
+_CONFIG_BUILDERS = {
+    "deepseek_v32": deepseek_v32_hf_config,
+    "glm_5_1": glm_hf_config,
+    "glm_5_2": glm_5_2_hf_config,
+}
 
 # Fabric transport being profiled — single source for BOTH the device_params and the run manifest, so the
 # recorded provenance can never drift from what actually ran (FABRIC_2D is the production transport;
@@ -657,12 +666,26 @@ def test_mla_chunked_perf(mesh_device, variant, scenario, attn_mode, kv_cache_fo
     config.max_seq_len = total  # rope-table / buffer length (same hack as the correctness tests)
     weights = random_mla_weights(config)
 
+    # GLM-5.2 packs its index-K cache by *full* indexer layers: 21 slots for the 78-layer model. The
+    # ring score must select the right slot from that ND-sharded multi-slot tensor, but a layer-0 / one-slot
+    # proxy would only ever exercise cache_batch_idx=0. Profile the last full layer (74 -> compact slot 20)
+    # to cover the real selection path. Other variants have no reuse map and retain the simple layer-0,
+    # one-slot setup.
+    full_indexer_layers = num_full_indexer_layers(config) if has_indexer else None
+    index_cache_layers = full_indexer_layers or 1
+    if full_indexer_layers:
+        full_layer_indices = [i for i, mode in enumerate(config.indexer_types) if mode == "full"]
+        assert len(full_layer_indices) == full_indexer_layers
+        mla_layer_idx = full_layer_indices[-1]
+    else:
+        mla_layer_idx = 0
+
     # Indexer rope now scales from config.max_seq_len (set above) — no manual bump needed.
     mla = ttMLA(
         config,
         dict(weights),
         mesh_device,
-        layer_idx=0,
+        layer_idx=mla_layer_idx,
         seq_len=total,
         sp_axis=sp_axis,
         tp_axis=tp_axis,
@@ -711,7 +734,7 @@ def test_mla_chunked_perf(mesh_device, variant, scenario, attn_mode, kv_cache_fo
             seq_len=total,
             mesh_shape=list(mesh_device.shape),
             sp_axis=sp_axis,
-            num_kvpe_cache_layers=1,
+            num_kvpe_cache_layers=index_cache_layers,
             num_users=1,
             dtype=ttnn.bfloat8_b,
         )
@@ -738,7 +761,12 @@ def test_mla_chunked_perf(mesh_device, variant, scenario, attn_mode, kv_cache_fo
         f"{len(starts)} × {chunk}-token "
         f"chunk(s) filling to end_pos={total} on SP={sp}×TP={tp}; local chunk={chunk // sp}, "
         f"local MLA heads={config.num_attention_heads // tp}"
-        + (f", local indexer heads={config.index_n_heads // tp}" if has_indexer else " (dense: no indexer)")
+        + (
+            f", local indexer heads={config.index_n_heads // tp}, index-cache slots={index_cache_layers}, "
+            f"selected slot={getattr(mla._indexer, '_index_layer_idx', 0)}"
+            if has_indexer
+            else " (dense: no indexer)"
+        )
     )
 
     def _one_forward(start):

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py
@@ -40,7 +40,13 @@ from models.common.utility_functions import is_blackhole, profiler
 from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3Config
 from models.demos.deepseek_v3_d_p.reference.glm_5_1_config import GLM51Config
 from models.demos.deepseek_v3_d_p.reference.kimi_k2_6_config import KimiK26Config
-from models.demos.deepseek_v3_d_p.tt.mla.indexer import full_indexer_rank, num_full_indexer_layers, resolve_has_indexer
+from models.demos.deepseek_v3_d_p.tt.mla.indexer import (
+    full_indexer_rank,
+    get_fused_ring_host_timing,
+    num_full_indexer_layers,
+    reset_fused_ring_host_timing,
+    resolve_has_indexer,
+)
 from models.demos.deepseek_v3_d_p.tt.mla.utils import (
     blockcyclic_cache_host,
     blockcyclic_positions,
@@ -1512,6 +1518,7 @@ def run_chunked_transformer_updated(
             # forward with return_intermediates=False: nothing is cloned to host, no PCC. Chunked
             # prefill is full-chunk (all positions real) so actual_end is kv_actual + CHUNK; forward
             # uses self.indexed_rope. The small (first_token) return is discarded.
+            reset_fused_ring_host_timing()
             transformer.forward(
                 tt_tokens,
                 tt_kvpe_cache,
@@ -1523,8 +1530,16 @@ def run_chunked_transformer_updated(
                 index_kv_cache=tt_index_kv_cache,
             )
             ttnn.synchronize_device(mesh_device)
+            fused_host_calls, fused_host_seconds = get_fused_ring_host_timing()
             ttnn.deallocate(tt_tokens)
-            chunk_times.append(time.time() - chunk_start)
+            chunk_seconds = time.time() - chunk_start
+            chunk_times.append(chunk_seconds)
+            if fused_host_calls:
+                logger.info(
+                    f"[fused-indexer host timing] iter={it} chunk={c} calls={fused_host_calls} "
+                    f"host_submit={fused_host_seconds * 1000:.2f} ms "
+                    f"({fused_host_seconds / chunk_seconds * 100:.1f}% of {chunk_seconds * 1000:.2f} ms chunk)"
+                )
         iter_total = time.time() - iter_start
         iteration_chunk_times.append(chunk_times)
         logger.info(f"iter {it} done ({n_chunks} chunks) in {iter_total:.3f} seconds")

--- a/models/demos/deepseek_v3_d_p/tt/mla/indexer.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/indexer.py
@@ -260,8 +260,8 @@ class TtIndexer:
         # [num_users*layer_num, 1, T, D_idx] — the SAME layout as the MLA KVPE cache — so the flat slot
         # for (user, layer) is cache_user_id*layer_num + cache_layer_idx, where cache_layer_idx is the
         # LOCAL per-rank cache slot passed to forward (mirrors the KVPE cache; NOT self.layer_idx, which is
-        # GLOBAL and diverges from the local slot under pipeline parallelism). Computed in forward, used by
-        # write_k and _gather_index_kbuf.
+        # GLOBAL and diverges from the local slot under pipeline parallelism). Computed in forward and used
+        # by both write_k and the fused ring indexer's in-kernel slot selection.
         self.layer_num = layer_num
         self.tt_ccl = tt_ccl
         self.ccl_num_links = ccl_num_links
@@ -445,25 +445,6 @@ class TtIndexer:
         ttnn.deallocate(nope)
         return out
 
-    def _select_index_kbuf_local(self, index_kbuf: ttnn.Tensor, cache_batch_idx: int) -> ttnn.Tensor:
-        """Return this chip's batch-1 interleaved K shard for the fused ring indexer.
-
-        ``index_kbuf`` is the user-major, block-cyclic ND-sharded cache. Select the active
-        (user, layer) slot before communication so the fused op gathers only [1,1,T/sp,D_idx],
-        never every cache slot. The ring scorer dual-sources this local shard while filling its
-        shared persistent full-K scratch buffer with the remote shards.
-        """
-        cache_i = ttnn.to_memory_config(index_kbuf, ttnn.DRAM_MEMORY_CONFIG)  # ND_SHARDED → INTERLEAVED
-        if cache_i.shape[0] > 1:  # user-major slot select BEFORE the gather (single-slot cache → skip)
-            sel = ttnn.slice(
-                cache_i,
-                [cache_batch_idx, 0, 0, 0],
-                [cache_batch_idx + 1, 1, cache_i.shape[2], cache_i.shape[3]],
-            )
-            ttnn.deallocate(cache_i)
-            cache_i = sel
-        return cache_i
-
     def write_k(
         self, hidden_states, seq_len, start_pos, rope_tensors=None, cache_user_id=0, cache_layer_idx=0, index_kbuf=None
     ):
@@ -536,8 +517,8 @@ class TtIndexer:
         only ever calls self._indexer.forward — it never calls write_k directly.)
 
         ``rope_tensors`` (the MLA's block-cyclic indexed cos/sin/trans) and ``cache_user_id`` (per-user slot)
-        drive the per-user block-cyclic key cache + block-cyclic scoring. Scoring currently spans the full
-        preallocated cache width (see the kv_len TODO below)."""
+        drive the per-user block-cyclic key cache + block-cyclic scoring. Scoring and transport are bounded
+        by the written prefix, rounded to complete block-cyclic slabs for the fixed-size ring protocol."""
         a = self.index_args
         if self._is_index_compact:
             cache_layer_idx = self._index_layer_idx
@@ -551,7 +532,7 @@ class TtIndexer:
         # Flat user-major slot into the shared [num_users*_index_cache_layers, 1, T, D_idx] cache — same
         # formula as ttMLA._cache_batch_idx for the KVPE cache (cache_layer_idx is the LOCAL per-rank cache
         # slot, compacted to the full-layer rank above for GLM-5.2 cross-layer reuse). Written by write_k
-        # and sliced by _gather_index_kbuf.
+        # and selected in-kernel by the fused ring indexer.
         cache_batch_idx = cache_user_id * self._index_cache_layers + cache_layer_idx
         self.write_k(
             hidden_states,
@@ -638,15 +619,15 @@ class TtIndexer:
         # top-k below is told the valid length (valid_length=end_pos) so it never reads or ranks that
         # stale tail — which is the future top-k would drop anyway (causally -inf), so the selection is
         # unchanged.
-        k_local = self._select_index_kbuf_local(
-            index_kv_cache, cache_batch_idx
-        )  # [1,1,T/sp,D_idx], batch-1 interleaved
-        k_full = self.tt_ccl.get_indexer_ring_k_buffer(local_k=k_local, sp_axis=self.sp_axis)
+        # Pass the persistent multi-slot ND-sharded cache directly. The fused gather selects only
+        # cache_batch_idx into the batch-1 scratch and moves only the complete block-cyclic slabs touched
+        # by kv_len; the score reader addresses its own shard directly in the original ND cache.
+        k_full = self.tt_ccl.get_indexer_ring_k_buffer(local_k=index_kv_cache, sp_axis=self.sp_axis)
         logits = ttnn.experimental.ring_indexer_score_dsa(
             q_dev,
             k_full,
             weights,
-            k_local,
+            index_kv_cache,
             self.tt_ccl.get_and_cycle_ag_semaphore_handles(cluster_axis=self.sp_axis),
             cluster_axis=self.sp_axis,
             topology=self.sp_ccl_topology,
@@ -654,12 +635,11 @@ class TtIndexer:
             chunk_start_idx=start_pos,
             program_config=cfg,
             seq_subshard_axis=self.tp_axis if tpsp else None,
-            cache_batch_idx=None,
+            cache_batch_idx=cache_batch_idx,
             block_cyclic_sp_axis=self.sp_axis,
             block_cyclic_chunk_local=seq_len,
             kv_len=end_pos,
         )
-        ttnn.deallocate(k_local)
         # wq_b replicated -> each chip already holds the COMPLETE head-summed logit, so there is NO
         # partial-logit all-reduce over tp. This is the win: the removed step was a 2-CCL (RS+AG) all-reduce
         # spanning the full end_pos-wide logit (+ a TILE<->ROW_MAJOR round-trip), the indexer's dominant cost.

--- a/models/demos/deepseek_v3_d_p/tt/mla/indexer.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/indexer.py
@@ -242,7 +242,7 @@ class TtIndexer:
 
         Injected from ttMLA (the indexer keeps no back-reference): the SP×TP mesh + axes,
         compute-kernel configs, weight-cache location, and the CCL handles used by the inlined
-        collectives (_tp_rs_ag / _sp_all_gather). The indexer derives its own softmax scale
+        TP collectives and fused SP ring indexer. The indexer derives its own softmax scale
         (index_head_dim**-0.5) — it does NOT reuse MLA's qk_head_dim*mscale scale. The q_a latent
         (qr) is passed into forward(), not held here — so the indexer holds no MLA weights."""
         self.config = config
@@ -265,9 +265,9 @@ class TtIndexer:
         self.layer_num = layer_num
         self.tt_ccl = tt_ccl
         self.ccl_num_links = ccl_num_links
-        # Per-axis topology: the TP collectives (_tp_rs_ag) use tp_ccl_topology, the SP-axis
-        # all-gather (_sp_all_gather) uses sp_ccl_topology. Conflating them would deadlock the
-        # SP-axis gather under an X-only torus (TP Ring, SP has no physical wrap) — mirrors ttMLA.
+        # Per-axis topology: the TP collectives use tp_ccl_topology, while the fused ring indexer
+        # gathers on the SP axis with sp_ccl_topology. Conflating them would deadlock the SP ring
+        # under an X-only torus (TP Ring, SP has no physical wrap) — mirrors ttMLA.
         self.sp_ccl_topology = sp_ccl_topology
         self.tp_ccl_topology = tp_ccl_topology
         # Indexer geometry comes from the config with no defaults: a sparse config that omits any of these
@@ -378,21 +378,6 @@ class TtIndexer:
             t, dims=[1], output=None, compute_kernel_config=self.hifi4_fp32_compute_kernel_config
         )
 
-    def _sp_all_gather(self, t, dim):
-        """All-gather across the SP axis (sequence) → full-S replicated on SP. sp=1: no-op."""
-        if self.sp_factor == 1:
-            return t
-        return ttnn.experimental.all_gather_async(
-            t,
-            dim=dim,
-            multi_device_global_semaphore=self.tt_ccl.get_and_cycle_ag_semaphore_handles(cluster_axis=self.sp_axis),
-            barrier_semaphore=self.tt_ccl.get_and_cycle_barrier_semaphore_handle(cluster_axis=self.sp_axis),
-            num_links=self.ccl_num_links,
-            memory_config=ttnn.DRAM_MEMORY_CONFIG,
-            topology=self.sp_ccl_topology,
-            cluster_axis=self.sp_axis,
-        )
-
     def _tp_all_gather(self, t, dim):
         """All-gather across the TP axis → the TP-seq-shards reassembled to the SP block's full rows,
         replicated on TP. tp=1: no-op. (Spike helper for TP×SP query parallelism: regathers the top-k
@@ -460,25 +445,14 @@ class TtIndexer:
         ttnn.deallocate(nope)
         return out
 
-    def _gather_index_kbuf(self, index_kbuf: ttnn.Tensor, cache_batch_idx: int) -> ttnn.Tensor:
-        """Read the block-cyclic ND-sharded key cache back to a replicated full-T [1,1,T,D_idx]
-        (block-cyclic order preserved, bf16 TILE) for indexer_score_dsa's block-cyclic reader — the
-        analogue of ttMLA._gather_kvpe_prefix, and it uses the same fix.
+    def _select_index_kbuf_local(self, index_kbuf: ttnn.Tensor, cache_batch_idx: int) -> ttnn.Tensor:
+        """Return this chip's batch-1 interleaved K shard for the fused ring indexer.
 
-        SLOT SELECT BEFORE THE GATHER: index_kbuf is user-major [num_users*layer_num, 1, T, D_idx]
-        (same layout as the MLA KVPE cache). Slice the active (user, layer) slot out of dim 0 FIRST, then
-        SP all-gather only that single [1,1,T,D_idx] slot — NOT the whole B-slot cache. Gathering all
-        slots materializes a full-T copy of every user/layer (OOMs at high num_layers, exactly like the
-        MLA kvpe gather did). The gathered kv is then batch-1, so indexer_score needs NO cache_batch_idx
-        (the op requires kB==1 when cache_batch_idx is unset). The unwritten suffix is never scored
-        (future positions are causally masked).
-
-        PERF TODO: this SP all-gather is currently a blocking barrier — it materializes the whole full-T
-        key cache before indexer_score_dsa runs. It should instead be FUSED INTO the score op (ring-joint
-        style, like ring_mla / ring-joint SDPA fuse the KV all-gather with the attention compute): pipeline
-        the per-slab gather with the score matmul so each SP key slab is gathered and scored as it arrives,
-        overlapping the CCL with the op's own compute instead of paying a full gather up front. Op-level
-        change (ring indexer_score), not a host-side reorder."""
+        ``index_kbuf`` is the user-major, block-cyclic ND-sharded cache. Select the active
+        (user, layer) slot before communication so the fused op gathers only [1,1,T/sp,D_idx],
+        never every cache slot. The ring scorer dual-sources this local shard while filling its
+        shared persistent full-K scratch buffer with the remote shards.
+        """
         cache_i = ttnn.to_memory_config(index_kbuf, ttnn.DRAM_MEMORY_CONFIG)  # ND_SHARDED → INTERLEAVED
         if cache_i.shape[0] > 1:  # user-major slot select BEFORE the gather (single-slot cache → skip)
             sel = ttnn.slice(
@@ -488,10 +462,7 @@ class TtIndexer:
             )
             ttnn.deallocate(cache_i)
             cache_i = sel
-        full = self._sp_all_gather(cache_i, dim=2)  # [1,1,T,D_idx] replicated, block-cyclic
-        if self.sp_factor > 1:
-            ttnn.deallocate(cache_i)
-        return full
+        return cache_i
 
     def write_k(
         self, hidden_states, seq_len, start_pos, rope_tensors=None, cache_user_id=0, cache_layer_idx=0, index_kbuf=None
@@ -654,14 +625,11 @@ class TtIndexer:
         # (DSA_INDEXER_CONFIG, measured per model: DeepSeek@64h=64, GLM@32h=224; larger OOMs).
         k_chunk = get_indexer_key_chunk(a.index_n_heads)
         cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=qc, k_chunk_size=min(k_chunk, end_pos), head_group_size=0)
-        # SP-sharded queries (rotation-safe): each chip scores its S/sp rows vs the full block-cyclic key
-        # cache, with a per-device causal offset from cluster_axis=sp_axis (chip r: chunk_start = start_pos
-        # + r*Sq, Sq=S/sp=seq_len). All H_idx heads on-chip -> the logit is COMPLETE (no partial-logit
-        # all-reduce). topk stays SP-sharded ([1,1,S/sp,k]) -> fed straight to sparse_mla.
-        # _gather_index_kbuf slices this (user, layer) slot then gathers it to replicated full-T; the op
-        # reads it back in logical order via invP (batch-1, so cache_batch_idx=None) and applies the
-        # straddle for a non-slab-aligned start_pos (padded chunk). Scores the FULL preallocated width T:
-        # positions past each query are causally -inf, and top-k below drops those (-inf -> sentinel).
+        # SP-sharded queries (rotation-safe): each chip scores its S/sp rows while the fused ring indexer
+        # gathers remote block-cyclic K slabs into a shared persistent full-T buffer. The reader consumes
+        # each band as soon as its source slab arrives and dual-sources the local slab directly, overlapping
+        # the former blocking all-gather with score compute. Per-device causality remains cluster_axis=SP
+        # (chip r: chunk_start = start_pos + r*Sq). All H_idx heads are resident, so each logit is complete.
         #
         # Bound the score to the real written prefix (kv_len=end_pos) rather than the full preallocated
         # width T: end_pos = start_pos + chunk_global is the tightest legal value (the pad query rows
@@ -670,23 +638,28 @@ class TtIndexer:
         # top-k below is told the valid length (valid_length=end_pos) so it never reads or ranks that
         # stale tail — which is the future top-k would drop anyway (causally -inf), so the selection is
         # unchanged.
-        k_full = self._gather_index_kbuf(index_kv_cache, cache_batch_idx)  # [1,1,T,D_idx] bf16 TILE, block-cyclic
-        logits = ttnn.experimental.indexer_score_dsa(
+        k_local = self._select_index_kbuf_local(
+            index_kv_cache, cache_batch_idx
+        )  # [1,1,T/sp,D_idx], batch-1 interleaved
+        k_full = self.tt_ccl.get_indexer_ring_k_buffer(local_k=k_local, sp_axis=self.sp_axis)
+        logits = ttnn.experimental.ring_indexer_score_dsa(
             q_dev,
             k_full,
             weights,
+            k_local,
+            self.tt_ccl.get_and_cycle_ag_semaphore_handles(cluster_axis=self.sp_axis),
+            cluster_axis=self.sp_axis,
+            topology=self.sp_ccl_topology,
+            num_links=self.ccl_num_links,
             chunk_start_idx=start_pos,
             program_config=cfg,
-            # Seq shard axes, outermost (SP ring) first. TP×SP adds the TP axis so the score adds each
-            # device's tp_rank*Sq' block-cyclic sub-offset — rotation-EXACT (vs the flat [] path, which is
-            # linear-approximate under a mid-slab start). SP-only ([sp]) when the query stays SP-sharded.
-            seq_shard_axes=[self.sp_axis, self.tp_axis] if tpsp else [self.sp_axis],
-            cache_batch_idx=None,  # k_full is already sliced to this slot (batch-1) → no in-kernel select
+            seq_subshard_axis=self.tp_axis if tpsp else None,
+            cache_batch_idx=None,
             block_cyclic_sp_axis=self.sp_axis,
-            block_cyclic_chunk_local=seq_len,  # cache slab == chunk_size_global / sp (== Sq'·tp when TP-split)
+            block_cyclic_chunk_local=seq_len,
             kv_len=end_pos,
         )
-        ttnn.deallocate(k_full)
+        ttnn.deallocate(k_local)
         # wq_b replicated -> each chip already holds the COMPLETE head-summed logit, so there is NO
         # partial-logit all-reduce over tp. This is the win: the removed step was a 2-CCL (RS+AG) all-reduce
         # spanning the full end_pos-wide logit (+ a TILE<->ROW_MAJOR round-trip), the indexer's dominant cost.

--- a/models/demos/deepseek_v3_d_p/tt/mla/indexer.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/indexer.py
@@ -31,12 +31,17 @@ from models.demos.deepseek_v3_d_p.tt.mla.rope import interleaved_perm_matrix
 # Opt-in diagnostic for the chunked-prefill end-to-end timer. The ring-indexer call is asynchronous,
 # so this measures host operation setup / program-cache handling / command submission, not device completion.
 # The test driver resets and reads the counters once per chunk.
-_FUSED_RING_HOST_TIMING_ENABLED = os.environ.get("TT_FUSED_RING_HOST_TIMING") == "1"
 _fused_ring_host_timing = {"calls": 0, "seconds": 0.0}
 
 
+def _fused_ring_host_timing_enabled() -> bool:
+    # The focused Galaxy prefill pipeline already gives every run a unique summary directory, so enable
+    # this diagnostic there without a workflow change. Local/other CI invocations remain opt-in.
+    return os.environ.get("TT_FUSED_RING_HOST_TIMING") == "1" or bool(os.environ.get("PREFILL_SUMMARIES"))
+
+
 def reset_fused_ring_host_timing() -> None:
-    if _FUSED_RING_HOST_TIMING_ENABLED:
+    if _fused_ring_host_timing_enabled():
         _fused_ring_host_timing["calls"] = 0
         _fused_ring_host_timing["seconds"] = 0.0
 
@@ -642,7 +647,7 @@ class TtIndexer:
         # cache_batch_idx into the batch-1 scratch and moves only the complete block-cyclic slabs touched
         # by kv_len; the score reader addresses its own shard directly in the original ND cache.
         k_full = self.tt_ccl.get_indexer_ring_k_buffer(local_k=index_kv_cache, sp_axis=self.sp_axis)
-        host_start = time.perf_counter() if _FUSED_RING_HOST_TIMING_ENABLED else None
+        host_start = time.perf_counter() if _fused_ring_host_timing_enabled() else None
         logits = ttnn.experimental.ring_indexer_score_dsa(
             q_dev,
             k_full,

--- a/models/demos/deepseek_v3_d_p/tt/mla/indexer.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/indexer.py
@@ -12,6 +12,8 @@ no reference back to ttMLA (and no MLA weights) and runs its own TP/SP collectiv
 v3.1 (no indexer weights → ttMLA never builds it).
 """
 
+import os
+import time
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -24,6 +26,23 @@ from models.demos.deepseek_v3_d_p.tt.mla.rope import interleaved_perm_matrix
 
 # DSA indexer weight names are owned by TtIndexer.WEIGHT_NAMES (single source of truth). A
 # module-level INDEXER_WEIGHT_NAMES alias is defined at the bottom of this file for back-compat.
+
+
+# Opt-in diagnostic for the chunked-prefill end-to-end timer. The ring-indexer call is asynchronous,
+# so this measures host operation setup / program-cache handling / command submission, not device completion.
+# The test driver resets and reads the counters once per chunk.
+_FUSED_RING_HOST_TIMING_ENABLED = os.environ.get("TT_FUSED_RING_HOST_TIMING") == "1"
+_fused_ring_host_timing = {"calls": 0, "seconds": 0.0}
+
+
+def reset_fused_ring_host_timing() -> None:
+    if _FUSED_RING_HOST_TIMING_ENABLED:
+        _fused_ring_host_timing["calls"] = 0
+        _fused_ring_host_timing["seconds"] = 0.0
+
+
+def get_fused_ring_host_timing() -> tuple[int, float]:
+    return _fused_ring_host_timing["calls"], _fused_ring_host_timing["seconds"]
 
 
 class TtIndexer:
@@ -623,6 +642,7 @@ class TtIndexer:
         # cache_batch_idx into the batch-1 scratch and moves only the complete block-cyclic slabs touched
         # by kv_len; the score reader addresses its own shard directly in the original ND cache.
         k_full = self.tt_ccl.get_indexer_ring_k_buffer(local_k=index_kv_cache, sp_axis=self.sp_axis)
+        host_start = time.perf_counter() if _FUSED_RING_HOST_TIMING_ENABLED else None
         logits = ttnn.experimental.ring_indexer_score_dsa(
             q_dev,
             k_full,
@@ -640,6 +660,9 @@ class TtIndexer:
             block_cyclic_chunk_local=seq_len,
             kv_len=end_pos,
         )
+        if host_start is not None:
+            _fused_ring_host_timing["calls"] += 1
+            _fused_ring_host_timing["seconds"] += time.perf_counter() - host_start
         # wq_b replicated -> each chip already holds the COMPLETE head-summed logit, so there is NO
         # partial-logit all-reduce over tp. This is the win: the removed step was a 2-CCL (RS+AG) all-reduce
         # spanning the full end_pos-wide logit (+ a TILE<->ROW_MAJOR round-trip), the indexer's dominant cost.

--- a/models/demos/deepseek_v3_d_p/tt/mla/mla.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/mla.py
@@ -1148,11 +1148,12 @@ class ttMLA:
         qr = self._q_a_latent(hidden_states, seq_len_local, q_norm_mem_config)
 
         # DSA dispatch (v3.2 / GLM): the op graph is fixed by CONFIG — self._indexer and self._attention
-        # are bound once at construction (sparsity × chunking), never by the runtime sequence length — so
-        # a single recorded op trace replays identically for any input. (At seq_len <= index_topk the
-        # indexer top-k simply selects all available causal keys, so sparse is numerically equal to dense
-        # there.) The indexer's forward also writes its K-cache (a no-op on the dense null-indexer), so no
-        # separate warm-up write is needed.
+        # are bound once at construction (sparsity × chunking), never by the runtime sequence length.
+        # Host-scalar cache slot/start/length arguments are still rebound on each eager dispatch; a captured
+        # device trace therefore remains specific to the values used during capture. (At seq_len <=
+        # index_topk the indexer top-k simply selects all available causal keys, so sparse is numerically
+        # equal to dense there.) The indexer's forward also writes its K-cache (a no-op on the dense
+        # null-indexer), so no separate warm-up write is needed.
         # GLM-5.2 reuse: a shared layer receives a prior full layer's top-k indices and skips its own
         # indexer (its ReuseIndexer.forward would raise). Absent injection -> compute as usual.
         indices = (

--- a/models/demos/deepseek_v3_d_p/tt/tt_ccl.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_ccl.py
@@ -224,10 +224,11 @@ class TT_CCL:
     def get_indexer_ring_k_buffer(self, *, local_k, sp_axis):
         """Return the persistent full-K output buffer for the fused ring indexer.
 
-        ``local_k`` is the active batch-1 cache shard [1,1,T/sp,D]. The fused op gathers it over
-        ``sp_axis`` into [1,1,T,D] while scoring arriving bands. All MLA layers execute serially and
-        share the same index-cache geometry, so one stable-address scratch buffer per shape/dtype is
-        sufficient for the whole model instead of allocating a full gathered cache per layer.
+        ``local_k`` is the persistent local cache [B,1,T/sp,D]. In indexed mode the fused op gathers
+        only the selected slot over ``sp_axis`` into [1,1,T,D] while scoring arriving bands. All layers
+        execute serially and share the same index-cache geometry, so one stable-address scratch buffer
+        per shape/dtype is sufficient for the whole model instead of allocating a full gathered cache
+        per layer.
         """
         import torch
 

--- a/models/demos/deepseek_v3_d_p/tt/tt_ccl.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_ccl.py
@@ -131,6 +131,10 @@ class TT_CCL:
         # MLA, keyed by shape signature. See get_mla_chunked_kv_buffer.
         self.mla_chunked_kv_buffers: dict[tuple, "ttnn.Tensor"] = {}
 
+        # Persistent ring-indexer gathered-K scratch buffers shared by every layer's DSA indexer,
+        # keyed by shape signature. See get_indexer_ring_k_buffer.
+        self.indexer_ring_k_buffers: dict[tuple, "ttnn.Tensor"] = {}
+
     def get_mla_ring_attention_buffers(
         self,
         *,
@@ -216,6 +220,30 @@ class TT_CCL:
                 ),
             )
         return self.mla_chunked_kv_buffers[key]
+
+    def get_indexer_ring_k_buffer(self, *, local_k, sp_axis):
+        """Return the persistent full-K output buffer for the fused ring indexer.
+
+        ``local_k`` is the active batch-1 cache shard [1,1,T/sp,D]. The fused op gathers it over
+        ``sp_axis`` into [1,1,T,D] while scoring arriving bands. All MLA layers execute serially and
+        share the same index-cache geometry, so one stable-address scratch buffer per shape/dtype is
+        sufficient for the whole model instead of allocating a full gathered cache per layer.
+        """
+        import torch
+
+        local_shape = tuple(local_k.shape)
+        global_seq_len = local_shape[2] * self.mesh_device.shape[sp_axis]
+        key = (global_seq_len, local_shape[3], local_k.dtype, sp_axis)
+        if key not in self.indexer_ring_k_buffers:
+            self.indexer_ring_k_buffers[key] = ttnn.from_torch(
+                torch.zeros(1, 1, global_seq_len, local_shape[3]),
+                device=self.mesh_device,
+                layout=ttnn.TILE_LAYOUT,
+                dtype=local_k.dtype,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
+            )
+        return self.indexer_ring_k_buffers[key]
 
     def get_shared_rs_intermediate(self, input_tensor, topology):
         """Lazily allocate (once per mesh) and return the shared reduce_scatter intermediate

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/ring4_ccl_helpers.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/ring4_ccl_helpers.py
@@ -32,12 +32,12 @@ _INPUT_DIMS = (None, 2)
 _BUF_DIMS = (1, None)
 
 
-def _open_ring4_ccl(fabric_config=ttnn.FabricConfig.FABRIC_1D):
-    """Open the full 2x4 with the requested 1D fabric, carve a 1x4 submesh, load a worker sub-device, make 2 CCL semaphores
+def _open_ring4_ccl():
+    """Open the full 2x4 with 2D fabric, carve a 1x4 submesh, load a worker sub-device, make 2 CCL semaphores
     (the two ring directions, as ring_attention_all_gather_async needs). Returns
     (submesh, parent, ccl_semaphores, worker_sub_device_id, stall_group)."""
     ttnn.set_fabric_config(
-        fabric_config,
+        ttnn.FabricConfig.FABRIC_2D,
         ttnn.FabricReliabilityMode.STRICT_INIT,
         None,
         ttnn.FabricTensixConfig.DISABLED,

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/test_ring_indexer_score_dsa.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/test_ring_indexer_score_dsa.py
@@ -21,6 +21,7 @@ from tests.ttnn.nightly.unit_tests.operations.experimental.test_indexer_score im
     assert_indexer_match,
     glx_config,
     _global_inputs,
+    _nd_sharded_dram_config,
     _per_sp_ref,
     _straddle_ref,
     _to_slab,
@@ -57,7 +58,8 @@ def _fused_dev_inputs(submesh, q_g, w_g, k_host, *, k_dtype=ttnn.bfloat16):
     q_dev = ttnn.from_torch(q_g, device=submesh, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, mesh_mapper=shard)
     w_dev = ttnn.from_torch(w_g, device=submesh, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, mesh_mapper=shard)
     k_local = _shard_k(submesh, k_host, dtype=k_dtype)  # [B,1,sll,D] per chip (the all-gather INPUT)
-    k_gathered = _persistent_buffer(submesh, torch.zeros_like(k_host), dtype=k_dtype)  # [B,1,T,D] AG OUTPUT
+    # Indexed mode gathers one selected input slot into slot 0; batch-1 scratch also covers the ordinary B=1 path.
+    k_gathered = _persistent_buffer(submesh, torch.zeros_like(k_host[:1]), dtype=k_dtype)
     return q_dev, w_dev, k_local, k_gathered
 
 
@@ -67,12 +69,10 @@ def _run_fused(
     block_cyclic,
     num_links=1,
     k_dtype=ttnn.bfloat16,
-    topology=ttnn.Topology.Linear,
-    fabric_config=ttnn.FabricConfig.FABRIC_1D,
 ):
     """Run the one fused op and check vs the per-SP reference. num_links only changes fabric routing, never
     the gathered result -> same reference."""
-    submesh, parent, ccl_semaphores, subdevice_id, stall_group = _open_ring4_ccl(fabric_config)
+    submesh, parent, ccl_semaphores, subdevice_id, stall_group = _open_ring4_ccl()
     try:
         q_g, k_nat, w_g = _global_inputs(heads, CHUNK_GLOBAL, T, seed=42)
         k_host = _to_slab(k_nat, RING, CHUNK_GLOBAL) if block_cyclic else k_nat
@@ -86,7 +86,7 @@ def _run_fused(
             k_local,
             ccl_semaphores,
             cluster_axis=SP_AXIS,
-            topology=topology,
+            topology=ttnn.Topology.Linear,
             num_links=num_links,
             ag_sub_device_id=subdevice_id,
             program_config=glx_config(heads),
@@ -108,17 +108,6 @@ def _run_fused(
 def test_indexer_score_ring4_fused(case_id, heads, block_cyclic):
     """Base fused path, num_links=2 (the production Blackhole link count)."""
     _run_fused(heads, block_cyclic=block_cyclic, num_links=2)
-
-
-def test_indexer_score_ring4_fused_ring_topology():
-    """Exercise the distinct wraparound neighbor/threshold path under a genuine 1D ring fabric."""
-    _run_fused(
-        16,
-        block_cyclic=True,
-        num_links=1,
-        topology=ttnn.Topology.Ring,
-        fabric_config=ttnn.FabricConfig.FABRIC_1D_RING,
-    )
 
 
 @pytest.mark.parametrize("block_cyclic", [False, True], ids=["contiguous", "block_cyclic"])
@@ -174,11 +163,9 @@ def test_indexer_score_ring4_fused_production_shape(case_id, heads):
 
 
 def _run_fused_multiuser(heads, *, num_users, cache_batch_idx, num_links=1):
-    """Multi-user indexed cache: k_local [num_users,1,sll,D] + gathered [num_users,1,T,D]; cache_batch_idx
-    selects the slot in-kernel. Regression guard for the local-shard offset fix -- the reader must offset BOTH
-    the remote and the local reads by the slot (pre-fix it read the local band from slot 0, mixing users; slots
-    hold distinct K so any cache_batch_idx>0 fails PCC). An op capability the model itself doesn't use (it
-    slices to batch-1 before the AG), guarded here for other callers."""
+    """Multi-user indexed cache: k_local [num_users,1,sll,D] and batch-1 gathered scratch. cache_batch_idx
+    selects the single gathered slot and the reader applies the corresponding local-cache offset. Distinct
+    user K values make either a gather-slot or local-slot addressing error fail PCC."""
     submesh, parent, ccl_semaphores, subdevice_id, stall_group = _open_ring4_ccl()
     try:
         # Shared q/w scoring distinct per-user caches (distinct seed per slot -> a wrong-slot read changes the score).
@@ -214,6 +201,91 @@ def _run_fused_multiuser(heads, *, num_users, cache_batch_idx, num_links=1):
 def test_indexer_score_ring4_fused_indexed_cache():
     """cache_batch_idx=1 (2nd user slot). One representative case (dsv32) -- the slot offset is head-independent."""
     _run_fused_multiuser(16, num_users=2, cache_batch_idx=1)
+
+
+@pytest.mark.parametrize("rows_per_shard", [32, 96], ids=["prod_rows32", "padded_rows96"])
+def test_indexer_score_ring4_fused_nd_indexed_bounded_gather_cache_hit(rows_per_shard):
+    """Production cache contract in one regression:
+
+    * multi-slot k_local is ND-sharded across DRAM banks;
+    * the gather selects one slot into a batch-1 scratch;
+    * kv_len bounds transport to complete touched block-cyclic slabs; and
+    * a second dispatch changes both slot and kv_len on the same cached program.
+    """
+    heads, num_users = 16, 3
+    t_alloc = 4 * CHUNK_GLOBAL
+    local_t = t_alloc // RING
+    submesh, parent, ccl_semaphores, subdevice_id, stall_group = _open_ring4_ccl()
+    try:
+        q_g, _, w_g = _global_inputs(heads, CHUNK_GLOBAL, t_alloc, seed=42)
+        k_nat = torch.cat(
+            [_global_inputs(heads, CHUNK_GLOBAL, t_alloc, seed=100 + u)[1] for u in range(num_users)], dim=0
+        )
+        k_bc = torch.cat([_to_slab(k_nat[u : u + 1], RING, CHUNK_GLOBAL) for u in range(num_users)], dim=0)
+        q_dev, w_dev, k_local_i, k_gathered = _fused_dev_inputs(submesh, q_g, w_g, k_bc, k_dtype=ttnn.bfloat8_b)
+        k_local = ttnn.to_memory_config(k_local_i, _nd_sharded_dram_config(submesh, rows_per_shard=rows_per_shard))
+        ttnn.deallocate(k_local_i)
+
+        def _score(slot, chunk_start, kv_len):
+            out = ttnn.experimental.ring_indexer_score_dsa(
+                q_dev,
+                k_gathered,
+                w_dev,
+                k_local,
+                ccl_semaphores,
+                cluster_axis=SP_AXIS,
+                topology=ttnn.Topology.Linear,
+                num_links=1,
+                ag_sub_device_id=subdevice_id,
+                chunk_start_idx=chunk_start,
+                cache_batch_idx=slot,
+                kv_len=kv_len,
+                block_cyclic_sp_axis=SP_AXIS,
+                block_cyclic_chunk_local=QB_SQ,
+                program_config=glx_config(heads),
+            )
+            ttnn.synchronize_device(submesh, sub_device_ids=stall_group)
+            return ttnn.to_torch(out, mesh_composer=ttnn.ConcatMeshToTensor(submesh, dim=2))
+
+        # A tile past the first global-slab boundary requires TWO complete local slabs per rank. This
+        # specifically exercises ceil(kv_len/chunk_global), not just exact-boundary truncation.
+        large_kv_len = CHUNK_GLOBAL + 32
+        out0 = _score(slot=1, chunk_start=32, kv_len=large_kv_len)
+        entries_after_first = submesh.num_program_cache_entries()
+        scratch_after_large = [ttnn.to_torch(t).clone() for t in ttnn.get_device_tensors(k_gathered.cpu())]
+        ref0 = _straddle_ref(q_g, k_nat[1:2, :, :large_kv_len, :], w_g, RING, CHUNK_GLOBAL, 32, large_kv_len)
+        assert_indexer_match(out0[:, :, :, :large_kv_len], ref0, CHUNK_GLOBAL, large_kv_len, check_neg=True)
+
+        valid_local_large = 2 * QB_SQ
+        for scratch_t in scratch_after_large:
+            for rank in range(RING):
+                tail = scratch_t[:, :, rank * local_t + valid_local_large : (rank + 1) * local_t, :]
+                assert torch.count_nonzero(tail) == 0, "gather wrote beyond the slab-rounded kv_len extent"
+
+        # Shrink the extent and switch users. Both are runtime values: this must reuse the same compiled
+        # program, overwrite only slab 0 from slot 2, and leave slab 1 exactly as slot 1 wrote it.
+        out1 = _score(slot=2, chunk_start=0, kv_len=CHUNK_GLOBAL)
+        assert (
+            submesh.num_program_cache_entries() == entries_after_first
+        ), "slot/kv_len change recompiled instead of exercising the cache-hit runtime-arg patch"
+        scratch_after_small = [ttnn.to_torch(t) for t in ttnn.get_device_tensors(k_gathered.cpu())]
+        ref1 = _per_sp_ref(q_g, k_nat[2:3, :, :CHUNK_GLOBAL, :], w_g, RING, 0)
+        assert_indexer_match(out1[:, :, :, :CHUNK_GLOBAL], ref1, CHUNK_GLOBAL, CHUNK_GLOBAL, check_neg=True)
+
+        any_first_slab_changed = False
+        for before, after in zip(scratch_after_large, scratch_after_small):
+            for rank in range(RING):
+                base = rank * local_t
+                any_first_slab_changed |= not torch.equal(
+                    before[:, :, base : base + QB_SQ, :], after[:, :, base : base + QB_SQ, :]
+                )
+                assert torch.equal(
+                    before[:, :, base + QB_SQ : base + 2 * QB_SQ, :],
+                    after[:, :, base + QB_SQ : base + 2 * QB_SQ, :],
+                ), "shrinking kv_len rewrote the second slab on a cache hit"
+        assert any_first_slab_changed, "switching cache slots did not update any gathered first-slab data"
+    finally:
+        _close_ring4_ccl(parent, submesh, stall_group)
 
 
 @pytest.mark.parametrize("case_id, heads", QB_CASES, ids=QB_IDS)

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_multi_core_with_workers_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_multi_core_with_workers_program_factory.cpp
@@ -727,14 +727,12 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
         const auto build_tensor_descriptor_args = [&]() {
             std::vector<uint32_t> tensor_descriptor_args;
             for (uint32_t i = 0; i < num_inputs; i++) {
-                const auto input_tensor_num_pages = input_tensor[i].buffer()->num_pages();
                 const auto input_tensor_shape = input_tensor[i].padded_shape();
                 const auto output_tensor_shape = output_tensor[i].padded_shape();
                 const uint32_t num_heads = input_tensor_shape[1];
                 // single_batch_head_num_pages is always pages-per-(batch,head); independent of slicing.
                 const uint32_t full_batch_head_size = input_tensor_shape[0] * num_heads;
 
-                uint32_t single_batch_head_num_pages = input_tensor_num_pages / full_batch_head_size;
                 const uint32_t input_tensor_Wt = input_tensor_shape[3] / tt::constants::TILE_WIDTH;
                 const uint32_t input_tensor_Ht = input_tensor_shape[2] / tt::constants::TILE_HEIGHT;
                 const uint32_t output_tensor_Wt = output_tensor_shape[3] / tt::constants::TILE_WIDTH;
@@ -742,6 +740,11 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
                 TT_ASSERT(!(input_tensor_shape[3] % tt::constants::TILE_WIDTH));
                 TT_ASSERT(!(output_tensor_shape[3] % tt::constants::TILE_WIDTH));
 
+                // TensorAccessor page IDs address the logical padded tensor volume. For ND-sharded buffers,
+                // buffer()->num_pages() can additionally include physical padding in the final shard; treating
+                // those pages as tensor data would overrun a selected batch/head slice and can write past the
+                // corresponding logical output band.
+                const uint32_t single_batch_head_num_pages = input_tensor_Ht * input_tensor_Wt;
                 const uint32_t base_pages_per_worker = single_batch_head_num_pages / num_links;
                 const uint32_t remainder = single_batch_head_num_pages % num_links;
                 const uint32_t input_tile_id_start = (link * base_pages_per_worker) + std::min(link, remainder);

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.cpp
@@ -80,9 +80,13 @@ void validate_static(const operation_attributes_t& attrs, const tensor_args_t& t
 void validate_runtime_values(const operation_attributes_t& attrs, const tensor_args_t& t) {
     const auto& k = t.k;
 
-    // Indexed KV cache: cache_batch_idx picks a slot of [B,1,T,D] k; an out-of-range slot offsets pages OOB.
+    // Indexed KV cache: on the fused path the full multi-slot cache is k_local while k is the batch-1
+    // gathered scratch. On the classic path k itself is the cache.
     if (attrs.cache_batch_idx.has_value()) {
-        const uint32_t kB = k.logical_shape()[0];
+        TT_FATAL(
+            !attrs.has_fused_ring() || t.k_local.has_value(), "indexer_score fused indexed cache requires k_local");
+        const auto& indexed_k = attrs.has_fused_ring() ? *t.k_local : k;
+        const uint32_t kB = indexed_k.logical_shape()[0];
         TT_FATAL(
             attrs.cache_batch_idx.value() < kB,
             "indexer_score cache_batch_idx ({}) must be < k batch slots ({})",
@@ -192,9 +196,15 @@ void validate_fused_runtime_values(const operation_attributes_t& attrs, const te
     TT_FATAL(
         k_local.storage_type() == StorageType::DEVICE && k_local.buffer() != nullptr,
         "indexer_score fused: k_local must be allocated on device");
+    const auto& kl_mem = k_local.memory_config();
+    const bool nd_sharded_dram =
+        (kl_mem.memory_layout() == TensorMemoryLayout::ND_SHARDED ||
+         (kl_mem.memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED && kl_mem.created_with_nd_shard_spec())) &&
+        kl_mem.is_dram();
     TT_FATAL(
-        k_local.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED,
-        "indexer_score fused: k_local must use interleaved memory");
+        kl_mem.memory_layout() == TensorMemoryLayout::INTERLEAVED || nd_sharded_dram,
+        "indexer_score fused: k_local must be interleaved or ND-sharded DRAM (got {})",
+        kl_mem.memory_layout());
     TT_FATAL(k_local.device() == t.q.device(), "indexer_score fused: k_local must be on the same mesh device as q");
 
     const auto& semaphores = attrs.fused_ring->ag_semaphore;
@@ -324,11 +334,17 @@ void IndexerScoreDeviceOperation::validate_on_program_cache_miss(
         const auto& ks = k.logical_shape();
         TT_FATAL(ks.rank() == 4, "indexer_score fused: gathered k must be rank 4");  // guard before indexing ks below
         TT_FATAL(kls.rank() == 4 && kls[1] == 1, "indexer_score fused: k_local must be [B,1,sll,D]");
-        // k_local and the gathered k must share the batch dim: the reader offsets the LOCAL shard read by
-        // cache_batch_idx * (Tt/ring_size) tiles, bounded only against k's batch (validate_runtime_values).
-        // A smaller k_local batch would read OOB on the local shard for a cache_batch_idx valid for k.
-        TT_FATAL(
-            kls[0] == ks[0], "indexer_score fused: k_local batch {} must equal gathered k batch {}", kls[0], ks[0]);
+        // Indexed fused mode gathers exactly one selected k_local slot into slot 0 of a batch-1 scratch.
+        // Non-indexed mode retains the original equal-batch contract.
+        if (attrs.cache_batch_idx.has_value()) {
+            TT_FATAL(ks[0] == 1, "indexer_score fused indexed cache requires gathered k batch 1 (got {})", ks[0]);
+        } else {
+            TT_FATAL(
+                kls[0] == ks[0],
+                "indexer_score fused: k_local batch {} must equal gathered k batch {} when cache_batch_idx is unset",
+                kls[0],
+                ks[0]);
+        }
         TT_FATAL(kls[3] == ks[3], "indexer_score fused: k_local head dim {} != k head dim {}", kls[3], ks[3]);
         TT_FATAL(
             kl.dtype() == k.dtype(),

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.hpp
@@ -131,7 +131,8 @@ ttnn::Tensor indexer_score_msa(
 
 // FUSED DSA (ttnn.experimental.ring_indexer_score_dsa): subsumes the SP all-gather. Instead of pre-gathering
 // K, the caller hands this chip's LOCAL K shard `k_local` [B,1,sll,D] (the all-gather input) plus a
-// pre-allocated `k` [B,1,T,D] persistent buffer (the gather output). One program
+// pre-allocated `k` persistent buffer (the gather output). With cache_batch_idx, k_local may be a multi-slot
+// ND-sharded cache and k is [1,1,T,D]; only the selected slot and populated block-cyclic slabs are gathered.
 // co-schedules the ring_attention all-gather + the indexer compute, overlapping fabric transport with scoring:
 // the reader gates each K band on only the SP shards its tiles land in (per-band overlap, not a coarse whole-
 // gather barrier), then scores exactly as indexer_score_dsa. Same score semantics +

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation_types.hpp
@@ -37,8 +37,9 @@ inline uint32_t resolve_head_group(const IndexerScoreProgramConfig& cfg, uint32_
 using ttnn::prim::BlockCyclicLayout;
 
 // Ring-fused indexer: the op subsumes the SP all-gather. Instead of the caller pre-gathering K, it hands the
-// per-chip LOCAL K shard (tensor_args.k_local) as the all-gather INPUT and the full [B,1,T,D] persistent buffer
-// (tensor_args.k) as the all-gather OUTPUT; the fused program factory co-schedules the ring_attention all-gather
+// per-chip LOCAL K shard (tensor_args.k_local) as the all-gather INPUT and the full persistent buffer
+// (tensor_args.k) as the all-gather OUTPUT. In indexed mode k_local may be a multi-slot ND-sharded cache and k
+// is batch-1 scratch; only cache_batch_idx is gathered. The fused program factory co-schedules the all-gather
 // (the only Linear+fuse-capable AG) into the SAME program as the indexer compute, wiring a producer->consumer
 // semaphore handshake so the reader starts scoring once the gather lands. Scalar AG config only (tensors live in
 // tensor_args). All fields and semaphore addresses are hashed because the descriptor embeds them in AG worker
@@ -114,9 +115,9 @@ struct operation_attributes_t {
 
 struct tensor_args_t {
     const Tensor& q;
-    const Tensor& k;  // fused: the [B,1,T,D] persistent all-gather OUTPUT buffer the reader scores against
+    const Tensor& k;  // fused: persistent all-gather OUTPUT; batch 1 in indexed mode
     const Tensor& weights;
-    // Fused only: this device's per-chip LOCAL K shard [B,1,sll,D] = the all-gather INPUT. nullopt unfused.
+    // Fused only: per-chip LOCAL K [B,1,sll,D], interleaved or ND-sharded. nullopt unfused.
     std::optional<Tensor> k_local{std::nullopt};
 };
 

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/reader_indexer_score.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/reader_indexer_score.cpp
@@ -288,7 +288,8 @@ inline void read_k_chunk(
  *  (k_local_acc) -- the all-gather omits the local band from the gathered buffer. shard(logical tile L) =
  *  bc_ktile(L)/tiles_per_shard; local page = k_batch_page_offset/ring_size +
  *  (bc_ktile(L) - ring_index*tiles_per_shard)*head_dim_tiles (the slot offset is 1/ring of the gathered
- *  buffer's since k_local holds only sll=T/ring keys per slot). Same mcast wrapper + pad/stale as read_k_chunk. */
+ *  buffer's since k_local holds only sll=T/ring keys per slot). In indexed fused mode the gathered buffer is
+ *  batch-1 (remote offset 0) while local_batch_page_offset selects the original cache slot. */
 template <typename KAcc, typename KLocalAcc>
 inline void read_k_chunk_fused(
     Noc noc,
@@ -300,7 +301,8 @@ inline void read_k_chunk_fused(
     uint32_t k_tile_start,
     uint32_t k_tiles_in_unit,
     const McastDir& k_dir,
-    uint32_t k_batch_page_offset) {
+    uint32_t gathered_batch_page_offset,
+    uint32_t local_batch_page_offset) {
     read_block_or_mcast<cb_k, k_mcast_on, k_send_sem, k_recv_sem, k_valid_sem>(
         noc, k_chunk_tiles, k_chunk_tiles * k_tile_bytes, k_dir, [&](uint32_t addr) {
             uint32_t ptr = addr;
@@ -308,19 +310,12 @@ inline void read_k_chunk_fused(
                 const uint32_t seq_tile = bc_ktile(k_tile_start + k_col);
                 const uint32_t shard = seq_tile / tiles_per_shard;
                 if (shard == ring_index) {
-                    // Indexed multi-user cache: the remote branch adds k_batch_page_offset (= cache_batch_idx *
-                    // Tt * Dt, a full-T slot stride) into the gathered [B,1,T,D] buffer. k_local is [B,1,sll,D]
-                    // with sll = T/ring_size, so its per-slot stride is 1/ring_size of the gathered one; T =
-                    // ring_size * sll EXACTLY (validate-pinned), so the division is integral. Offset 0 when not
-                    // indexed. ASSERT the integrality as a REQUIREMENT (not just an observation): if the offset
-                    // were ever derived from a non-slot-aligned quantity the local pages would silently shift.
-                    ASSERT(k_batch_page_offset % ring_size == 0);
-                    const uint32_t local_batch_offset = k_batch_page_offset / ring_size;
                     const uint32_t local_base =
-                        local_batch_offset + (seq_tile - ring_index * tiles_per_shard) * head_dim_tiles;
+                        local_batch_page_offset + (seq_tile - ring_index * tiles_per_shard) * head_dim_tiles;
                     read_ktile_dims(noc, k_local_acc, ptr, local_base);  // OWN shard from the SP-local cache
                 } else {
-                    read_ktile_dims(noc, k_acc, ptr, k_batch_page_offset + seq_tile * head_dim_tiles);  // remote slab
+                    read_ktile_dims(
+                        noc, k_acc, ptr, gathered_batch_page_offset + seq_tile * head_dim_tiles);  // remote slab
                 }
             }
         });
@@ -345,6 +340,7 @@ struct FusedRingGate {
     uint32_t tiles_per_shard;           // tiles per SP shard in the gathered buffer
     uint32_t sem_id[2];                 // the two direction semaphore ids
     KLocalAcc k_local_acc;              // local SP shard cache (the all-gather INPUT; AG omits it from gathered)
+    uint32_t local_batch_page_offset;   // selected slot in k_local; gathered k may be batch-1
     uint32_t perm_base;                 // rt slot of the band-visit permutation (one entry per band)
     uint32_t shard_dir[max_ring_size];  // shard -> direction semaphore index
     uint32_t shard_val[max_ring_size];  // shard -> wait threshold
@@ -357,6 +353,7 @@ struct FusedRingGate {
         tiles_per_shard(k_len_tiles / recv.seq.ring_size),
         sem_id{recv.signal_op_semaphore_ids[0], recv.signal_op_semaphore_ids[1]},
         k_local_acc(TensorAccessor(kl_args, get_arg_val<uint32_t>(argidx++), k_tile_bytes)),
+        local_batch_page_offset(get_arg_val<uint32_t>(argidx++)),
         perm_base(argidx),
         shard_dir{},
         shard_val{} {
@@ -413,7 +410,8 @@ struct FusedRingGate {
             k_tile_start,
             k_tiles_in_unit,
             k_dir,
-            k_batch_page_offset);
+            k_batch_page_offset,
+            local_batch_page_offset);
     }
 };
 

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/ring_indexer_score_dsa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/ring_indexer_score_dsa_program_factory.cpp
@@ -20,7 +20,7 @@
 #include "hostdevcommon/kernel_structs.h"  // tt::CBIndex
 
 #include "ttnn/operations/transformer/sdpa/device/sdpa_subblock_utils.hpp"
-#include "ttnn/operations/transformer/sdpa/device/ring_fusion.hpp"        // RingSDPAFusedOpSignaler
+#include "ttnn/operations/transformer/sdpa/device/ring_fusion.hpp"                // RingSDPAFusedOpSignaler
 #include "ttnn/operations/transformer/sdpa/device/kernels/ring_id_sequencer.hpp"  // host replay for band arrival order
 #include "ttnn/operations/ccl/ccl_common.hpp"     // linearized index / neighbor / fwd-bwd config
 #include "ttnn/operations/ccl/ccl_op_fusion.hpp"  // AllGatherFusedOpSignaler
@@ -32,6 +32,8 @@
 #include "kernels/indexer_score_work_split.hpp"
 
 namespace ttnn::operations::experimental::indexer_score::program {
+
+namespace ag_rt = ttnn::ring_attention_all_gather_async_detail;
 
 using tt::tt_metal::CBDescriptor;
 using tt::tt_metal::CBFormatDescriptor;
@@ -57,7 +59,8 @@ constexpr uint32_t reader_k_batch_offset = reader_num_scalars + reader_num_mcast
 constexpr uint32_t reader_kv_len_tiles = reader_k_batch_offset + 1;                                          // 26
 constexpr uint32_t reader_fused_rt_base = reader_kv_len_tiles + 1;                                           // 27
 constexpr uint32_t reader_k_local_addr = reader_fused_rt_base + fused_rt_width;                              // 33
-constexpr uint32_t reader_band_perm_base = reader_k_local_addr + 1;                                          // 34
+constexpr uint32_t reader_k_local_batch_offset = reader_k_local_addr + 1;                                    // 34
+constexpr uint32_t reader_band_perm_base = reader_k_local_batch_offset + 1;                                  // 35
 // Compute RT: schedule(6), kv_len_tiles, chunk_start_tiles, straddle_q_tile, straddle_jump_tiles, then perm.
 constexpr uint32_t compute_band_perm_base = 6 + 4;  // 10
 // Writer RT: out addr, schedule(6), kv_len_tiles, chunk_start_tiles, straddle_q_tile, straddle_jump_tiles, perm.
@@ -66,8 +69,8 @@ constexpr uint32_t writer_band_perm_base = 1 + 6 + 4;  // 11
 // compute/writer read their perm at 10/11). A drift here would silently desync the kernels -> this fails to build.
 static_assert(
     reader_k_batch_offset == 25 && reader_kv_len_tiles == 26 && reader_fused_rt_base == 27 &&
-        reader_k_local_addr == 33 && reader_band_perm_base == 34 && compute_band_perm_base == 10 &&
-        writer_band_perm_base == 11,
+        reader_k_local_addr == 33 && reader_k_local_batch_offset == 34 && reader_band_perm_base == 35 &&
+        compute_band_perm_base == 10 && writer_band_perm_base == 11,
     "indexer_score fused rt_arg slot layout drifted from the kernel-side expectations");
 }  // namespace rt_arg
 
@@ -88,6 +91,20 @@ RingWrites ring_writes_for(uint32_t ring_size, uint32_t ring_index, ttnn::ccl::T
         return {static_cast<uint32_t>(num_targets_backward), static_cast<uint32_t>(num_targets_forward)};
     }
     return {static_cast<uint32_t>(num_targets_forward), static_cast<uint32_t>(num_targets_backward)};
+}
+
+// Block-cyclic caches are slab-major on every SP rank. A global valid prefix can end partway through a
+// global slab, whose valid row count differs by rank, so gather complete touched slabs. This is the smallest
+// uniform per-rank prefix that preserves the fixed-size ring protocol and contains every valid key.
+std::optional<uint32_t> gather_valid_height_tiles(const operation_attributes_t& args, const Tensor& k_local) {
+    if (!args.kv_len.has_value() || !args.block_cyclic.has_value()) {
+        return std::nullopt;
+    }
+    const uint32_t chunk_local = args.block_cyclic->chunk_local;
+    const uint32_t chunk_global = args.block_cyclic->sp * chunk_local;
+    const uint32_t valid_slabs = (*args.kv_len + chunk_global - 1) / chunk_global;
+    const uint32_t valid_local_rows = valid_slabs * chunk_local;
+    return std::min<uint32_t>(valid_local_rows, k_local.logical_shape()[2]) / tt::constants::TILE_HEIGHT;
 }
 
 // One device's fused program: indexer compute (banded schedule, DSA path) + co-scheduled ring_attention AG.
@@ -454,8 +471,13 @@ ProgramDescriptor build_ring_program_descriptor(
             rt.push_back(v);
         }
     };
-    const auto pcache = persistent_cache_args(args, k);  // shared with the classic factory
-    const uint32_t k_batch_page_offset = pcache.k_batch_page_offset;
+    const auto pcache = persistent_cache_args(args, k);  // kv_len derivation shared with the classic factory
+    // Indexed fused mode gathers the selected cache slot into slot 0 of batch-1 k. Keep the gathered and
+    // local offsets independent: remote reads start at zero, own-shard reads select the original k_local slot.
+    const uint32_t k_batch_page_offset = args.cache_batch_idx.has_value() ? 0u : pcache.k_batch_page_offset;
+    const uint32_t local_slot_pages = (k_local.logical_shape()[2] / tt::constants::TILE_HEIGHT) *
+                                      (k_local.logical_shape()[3] / tt::constants::TILE_WIDTH);
+    const uint32_t k_local_batch_page_offset = args.cache_batch_idx.value_or(0) * local_slot_pages;
     const uint32_t kv_len_tiles = pcache.kv_len_tiles;
 
     std::vector<uint32_t> fused_rt;
@@ -531,11 +553,12 @@ ProgramDescriptor build_ring_program_descriptor(
                 q_sender,
                 cols_used - 1);
             // Reader tail (sequential push; slots named in rt_arg, matched positionally by the kernel).
-            reader_rt.push_back(k_batch_page_offset);  // rt_arg::reader_k_batch_offset (25)
-            reader_rt.push_back(kv_len_tiles);         // rt_arg::reader_kv_len_tiles (26)
-            reader_rt.append(fused_rt);                // rt_arg::reader_fused_rt_base (27..32): ring/dir/sems
-            reader_rt.push_back(k_local.buffer());     // rt_arg::reader_k_local_addr (33): local SP shard address
-            reader_rt.append(band_perm);               // rt_arg::reader_band_perm_base (34..): band-visit perm
+            reader_rt.push_back(k_batch_page_offset);        // rt_arg::reader_k_batch_offset (25)
+            reader_rt.push_back(kv_len_tiles);               // rt_arg::reader_kv_len_tiles (26)
+            reader_rt.append(fused_rt);                      // rt_arg::reader_fused_rt_base (27..32): ring/dir/sems
+            reader_rt.push_back(k_local.buffer());           // rt_arg::reader_k_local_addr (33): local SP shard address
+            reader_rt.push_back(k_local_batch_page_offset);  // selected slot in the original local cache
+            reader_rt.append(band_perm);                     // rt_arg::reader_band_perm_base (35..): band-visit perm
             reader_kernel.emplace_runtime_args(core, reader_rt);
 
             KernelDescriptor::RTArgList compute_rt;
@@ -601,7 +624,9 @@ ProgramDescriptor build_ring_program_descriptor(
             ccl_core_grid_offset,
             // COL_MAJOR so the reserved-column offset lays the workers DOWN the free column ((compute_cols_x,0),
             // (compute_cols_x,1), ...) instead of running off the right grid edge as row-major would.
-            ttnn::ccl::CoreAllocationStrategy::COL_MAJOR);
+            ttnn::ccl::CoreAllocationStrategy::COL_MAJOR,
+            args.cache_batch_idx,
+            gather_valid_height_tiles(args, k_local));
     }
 
     log_debug(
@@ -696,14 +721,47 @@ void RingIndexerScoreDsaMeshWorkloadFactory::override_runtime_arguments(
     for (auto& [range, program] : cached.workload.get_programs()) {
         const auto desc =
             build_ring_program_descriptor(args, tensors, out, range.start_coord(), /*consumers_only=*/true);
-        // kernel_idx: reader=0, writer=1, compute=2 (AG worker kernels 3.. carry no per-dispatch scalars).
+        // kernel_idx: reader=0, writer=1, compute=2; AG workers are 3..6.
         // Slots are literals (matching the file-local rt_arg static_assert: reader_k_batch_offset==25,
         // reader_kv_len_tiles==26) -- rt_arg is in an anonymous namespace not visible here.
-        patch_scalars(program, desc, 0, {25u, 26u});  // reader: k_batch_page_offset, kv_len_tiles
+        patch_scalars(program, desc, 0, {25u, 26u, 34u});  // gathered offset, kv_len, local selected-slot offset
         // compute: kv_len_tiles, chunk_start_tiles, straddle_q_tile, straddle_jump_tiles (slots [6, perm_base)).
         patch_scalars(program, desc, 2, {6u, 7u, 8u, 9u});
         // writer: same four scalars after out-addr(0) + schedule(1..6) (slots [7, perm_base)).
         patch_scalars(program, desc, 1, {7u, 8u, 9u, 10u});
+
+        // The descriptor fast path patches buffer bindings but not scalar fields embedded in the fused AG
+        // workers. cache_batch_idx and kv_len are hash-excluded, so update the selected input slot and the
+        // slab-rounded gather extent on every cache hit (same protocol as ring_joint_sdpa).
+        const auto& k_local = *tensors.k_local;
+        const auto& shape = k_local.padded_shape();
+        const uint32_t Ht = shape[2] / tt::constants::TILE_HEIGHT;
+        const uint32_t Wt = shape[3] / tt::constants::TILE_WIDTH;
+        const uint32_t input_batch_base =
+            ag_rt::input_batch_base_pages(args.cache_batch_idx.value_or(0), shape[1], Ht, Wt);
+        const auto valid_Ht = gather_valid_height_tiles(args, k_local);
+        const uint32_t valid_pages = std::min(valid_Ht.value_or(Ht), Ht) * Wt;
+
+        const auto patch_ag_field = [&](uint32_t kernel_idx, uint32_t slot, uint32_t value) {
+            auto& grid_args = GetRuntimeArgs(program, kernel_idx);
+            for (auto& col_args : grid_args) {
+                for (auto& core_args : col_args) {
+                    if (core_args.size() > slot) {
+                        core_args[slot] = value;
+                    }
+                }
+            }
+        };
+        constexpr uint32_t ag_reader_input_base =
+            ag_rt::kReaderRuntimeArgHeaderCount + ag_rt::kInputBatchBaseFieldOffset;
+        constexpr uint32_t ag_reader_valid_pages = ag_rt::kReaderRuntimeArgHeaderCount + ag_rt::kValidPagesFieldOffset;
+        constexpr uint32_t ag_writer_valid_pages = ag_rt::kWriterRuntimeArgHeaderCount + ag_rt::kValidPagesFieldOffset;
+        patch_ag_field(/*reader forward=*/3, ag_reader_input_base, input_batch_base);
+        patch_ag_field(/*reader backward=*/5, ag_reader_input_base, input_batch_base);
+        patch_ag_field(/*reader forward=*/3, ag_reader_valid_pages, valid_pages);
+        patch_ag_field(/*reader backward=*/5, ag_reader_valid_pages, valid_pages);
+        patch_ag_field(/*writer forward=*/4, ag_writer_valid_pages, valid_pages);
+        patch_ag_field(/*writer backward=*/6, ag_writer_valid_pages, valid_pages);
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/ring_indexer_score_dsa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/ring_indexer_score_dsa_program_factory.cpp
@@ -689,51 +689,65 @@ void RingIndexerScoreDsaMeshWorkloadFactory::override_runtime_arguments(
     // compute_program_hash: one cached program is reused across chunked-prefill chunks and decode steps that
     // differ only in these), so on a program-cache HIT the WorkloadDescriptor fast path above leaves them
     // frozen at the FIRST dispatch's values -- a stale causal offset (chunk_start_tiles/straddle) and valid
-    // length (kv_len_tiles), which silently corrupts every chunk after the first (the classic Program-model
-    // factory re-applies them in its own override; the descriptor fast path does not). Re-derive them per
-    // coord by rebuilding the CONSUMER kernels only (consumers_only=true skips the AG helper -- its per-hit
-    // fabric-worker setup is not needed here and this drops any dependence on it being alloc-free) and copy
-    // ONLY the scalar slots back. Rebuilding via the same builder as create() keeps the scalar values/slots
-    // byte-identical between the two paths (the invariant the historical stale-scalar bug violated), while the
-    // buffers stay owned by the fast path above; the schedule + band-visit permutation are geometry-only
-    // (independent of chunk_start/kv_len), so they are stable across dispatches and need no re-patch.
+    // length (kv_len_tiles), which silently corrupts every chunk after the first. Patch the fields directly
+    // into the cached programs, as the classic Program-model factory does. Rebuilding the descriptor here was
+    // correct but expensive: it reconstructed geometry, schedules, descriptors and consumer runtime args for
+    // every mesh coordinate even though only these scalar fields vary between cache hits.
     using tt::tt_metal::GetRuntimeArgs;
-    const auto patch_scalars = [](tt::tt_metal::Program& program,
-                                  const ProgramDescriptor& desc,
-                                  uint32_t kernel_idx,
-                                  std::initializer_list<uint32_t> slots) {
-        for (const auto& [core, src] : desc.kernels[kernel_idx].runtime_args) {
-            auto& dst = GetRuntimeArgs(program, kernel_idx, core);
-            for (uint32_t s : slots) {
-                // Guard the literal slot indices (matching the classic factory's patch_arg) so a future
-                // arg-layout drift fails loudly here instead of silently reading/writing past the arg vector.
-                TT_FATAL(
-                    s < dst.size() && s < src.size(),
-                    "indexer_score fused override: scalar slot {} out of range (dst {}, src {}) for kernel {}",
-                    s,
-                    dst.size(),
-                    src.size(),
-                    kernel_idx);
-                dst[s] = src[s];
-            }
-        }
-    };
+
+    const auto& q = tensors.q;
+    const auto& k = tensors.k;
+    const auto& k_local = *tensors.k_local;
+    const auto pcache = persistent_cache_args(args, k);
+    const uint32_t k_batch_page_offset = args.cache_batch_idx.has_value() ? 0u : pcache.k_batch_page_offset;
+    const auto& k_local_shape = k_local.logical_shape();
+    const uint32_t local_slot_pages =
+        (k_local_shape[2] / tt::constants::TILE_HEIGHT) * (k_local_shape[3] / tt::constants::TILE_WIDTH);
+    const uint32_t k_local_batch_page_offset = args.cache_batch_idx.value_or(0) * local_slot_pages;
+
     for (auto& [range, program] : cached.workload.get_programs()) {
-        const auto desc =
-            build_ring_program_descriptor(args, tensors, out, range.start_coord(), /*consumers_only=*/true);
+        const uint32_t device_index = device_index_for(args, range.start_coord(), q);
+        const uint32_t tp_index =
+            (args.tp_axis().has_value() && q.device_storage().get_coords().size() > 1)
+                ? ttnn::ccl::get_linearized_index_from_physical_coord(q, range.start_coord(), args.tp_axis())
+                : 0u;
+        const auto geom = device_causal_geometry(args, device_index, tp_index, q.logical_shape()[2]);
+
+        const auto patch_field = [&](uint32_t kernel_idx, uint32_t slot, uint32_t value) {
+            auto& grid_args = GetRuntimeArgs(program, kernel_idx);
+            for (auto& col_args : grid_args) {
+                for (auto& core_args : col_args) {
+                    TT_FATAL(
+                        slot < core_args.size(),
+                        "indexer_score fused override: scalar slot {} out of range (size {}) for kernel {}",
+                        slot,
+                        core_args.size(),
+                        kernel_idx);
+                    core_args[slot] = value;
+                }
+            }
+        };
+
         // kernel_idx: reader=0, writer=1, compute=2; AG workers are 3..6.
-        // Slots are literals (matching the file-local rt_arg static_assert: reader_k_batch_offset==25,
-        // reader_kv_len_tiles==26) -- rt_arg is in an anonymous namespace not visible here.
-        patch_scalars(program, desc, 0, {25u, 26u, 34u});  // gathered offset, kv_len, local selected-slot offset
+        // The fused rt_arg namespace is file-local, but this .cpp participates in unity builds alongside
+        // the classic factory's same-named namespace. Keep these literals synchronized with its static_assert.
+        patch_field(0, 25u, k_batch_page_offset);
+        patch_field(0, 26u, pcache.kv_len_tiles);
+        patch_field(0, 34u, k_local_batch_page_offset);
         // compute: kv_len_tiles, chunk_start_tiles, straddle_q_tile, straddle_jump_tiles (slots [6, perm_base)).
-        patch_scalars(program, desc, 2, {6u, 7u, 8u, 9u});
+        patch_field(2, 6u, pcache.kv_len_tiles);
+        patch_field(2, 7u, geom.chunk_start_tiles);
+        patch_field(2, 8u, geom.straddle_q_tile);
+        patch_field(2, 9u, geom.straddle_jump_tiles);
         // writer: same four scalars after out-addr(0) + schedule(1..6) (slots [7, perm_base)).
-        patch_scalars(program, desc, 1, {7u, 8u, 9u, 10u});
+        patch_field(1, 7u, pcache.kv_len_tiles);
+        patch_field(1, 8u, geom.chunk_start_tiles);
+        patch_field(1, 9u, geom.straddle_q_tile);
+        patch_field(1, 10u, geom.straddle_jump_tiles);
 
         // The descriptor fast path patches buffer bindings but not scalar fields embedded in the fused AG
         // workers. cache_batch_idx and kv_len are hash-excluded, so update the selected input slot and the
         // slab-rounded gather extent on every cache hit (same protocol as ring_joint_sdpa).
-        const auto& k_local = *tensors.k_local;
         const auto& shape = k_local.padded_shape();
         const uint32_t Ht = shape[2] / tt::constants::TILE_HEIGHT;
         const uint32_t Wt = shape[3] / tt::constants::TILE_WIDTH;

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/indexer_score_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/indexer_score_nanobind.cpp
@@ -192,18 +192,20 @@ void bind_indexer_score(nb::module_& mod) {
 
         Identical score semantics to ``indexer_score_dsa`` but SUBSUMES the SP all-gather: rather than the
         caller pre-gathering K, it takes this chip's LOCAL K shard ``k_local`` [B,1,sll,D] (the all-gather
-        input) plus a pre-allocated ``k`` [B,1,T,D] persistent buffer (the gather output). One program
+        input) plus a pre-allocated ``k`` persistent buffer (the gather output). In indexed-cache mode,
+        ``k_local`` may be a multi-slot ND-sharded cache and ``k`` is batch-1 scratch; only the selected slot
+        and the complete block-cyclic slabs touched by ``kv_len`` are gathered. One program
         co-schedules the ring_attention all-gather with the indexer compute so fabric transport overlaps
         scoring; the reader gates each K band on ONLY the SP shards that band touches, so it scores already-
         arrived shards while farther slabs are still in flight. DSA only -- there is no fused MSA variant.
 
         Args:
             q: [B, Hi, Sq, D] bf16/bfp8_b tiled (post non-interleaved RoPE); see indexer_score_dsa
-            k: [B, 1, T, D] bf16/bfp8_b tiled PERSISTENT all-gather OUTPUT buffer, T = sp*sll; the gather fills
-                the remote SP shards in place (the local slab is read from k_local, not k)
+            k: [B, 1, T, D] bf16/bfp8_b tiled PERSISTENT all-gather OUTPUT buffer, T = sp*sll. B must be 1
+                when cache_batch_idx is set; the gather fills remote SP shards in place
             weights: [B, Hi, Sq, 1] bf16 tiled learned per-head gates (scale pre-folded)
-            k_local: [B, 1, sll, D] bf16/bfp8_b tiled -- this chip's SP shard and the all-gather INPUT,
-                sll = T/sp; must match k's dtype
+            k_local: [B, 1, sll, D] bf16/bfp8_b tiled, interleaved or ND-sharded DRAM -- this chip's SP
+                shard and the all-gather INPUT; sll = T/sp; must match k's dtype
             ag_multi_device_global_semaphore: list of the all-gather's out-ready global semaphores; requires
                 >= 2 (the forward and backward ring directions)
             cluster_axis: mesh axis that is the SP ring -- both the gather axis and the causality axis.
@@ -216,8 +218,10 @@ void bind_indexer_score(nb::module_& mod) {
             program_config: IndexerScoreProgramConfig work-unit knobs; see indexer_score_dsa.
                 head_group_size must be 0 (all Hi resident) or Hi -- head streaming is not supported here
             compute_kernel_config: optional DeviceComputeKernelConfig (only math_fidelity honored)
-            cache_batch_idx: optional int, batch slot of a shared K cache; see indexer_score_dsa
-            kv_len: optional int, valid tile-aligned key prefix in (0, T]; see indexer_score_dsa
+            cache_batch_idx: optional int selecting one k_local cache slot; only that slot is gathered into
+                k slot 0. See indexer_score_dsa.
+            kv_len: optional int, valid tile-aligned key prefix in (0, T]. With block-cyclic K, transport is
+                bounded to the complete per-rank slabs touched by this prefix.
             seq_subshard_axis: optional int, 2D SP×TP -- the (TP) mesh axis the query rows are ALSO block-cyclic
                 sub-sharded over, on top of the SP shard. The K cache stays SP-sharded + TP-replicated (the ring
                 AG still gathers along cluster_axis), so only the causal query geometry gains the tp_rank*Sq


### PR DESCRIPTION
### Done in the latest commit
- Accept the persistent multi-user ND-sharded DRAM index cache directly.
- Select `cache_batch_idx` in-kernel into shared batch-1 scratch.
- Gather only complete block-cyclic slabs covering `kv_len`.
- Patch the selected slot and valid page extent on program-cache hits.
- Address logical ND pages independently of padded physical shard pages.
- Add BFP8 ND, padded-shard, mid-slab, cache-hit, scratch-isolation, and two-user tests.

### Deleted
- Model-side index-cache all-gather and standalone score path.
- Per-forward ND-to-interleaved conversion, user-slot slicing, and temporary tensor lifetime.

### Validation
- Full Release build and static checks pass.
- `FABRIC_2D` fused-indexer suite: 19 passed.
- SP=2/TP=4 sparse-MLA integration: 6 passed.

| Pipeline | Coverage | New run |
|---|---|---|
| Blackhole e2e | LoudBox `deepseek_prefill` | [#30635302146](https://github.com/tenstorrent/tt-metal/actions/runs/30635302146) |
| Blaze Prefill | `dsa_mla,dsa_mla_glm` | [#30635304583](https://github.com/tenstorrent/tt-metal/actions/runs/30635304583) |
| Blackhole sanity | Standard sanity matrix | [#30635306862](https://github.com/tenstorrent/tt-metal/actions/runs/30635306862) |

### Performance
**These results were collected before ND-sharded input, multi-batch user selection, and reduced all-gather were added. They have not been rerun for the current implementation.**

Times are critical-path device-kernel durations for one full MLA block. The 500k and 50k labels are Galaxy-equivalent workloads; LoudBox proxies used 256k/25.6k prefixes and a 2.56k chunk on FW 19.12.

The fused ring uses a 10x10 worker grid on LoudBox. The separate path is shown with both its natural 11x10 grid and a comparable fixed 10x10 grid.

#### 500k prefix, SP=2 TP=4

| Variant | Full MLA block | All-gather | Indexer | Combined indexing path |
|---|---:|---:|---:|---:|
| Fused | **18.260 ms** | fused | Ring: **1.124 ms** | **1.124 ms** |
| Separate on main, 11x10 | 18.374 ms | 0.353 ms | 0.865 ms | 1.218 ms |
| Separate, fixed 10x10 | 18.454 ms | 0.353 ms | 0.949 ms | 1.302 ms |

#### 50k prefix, SP=2 TP=4

| Variant | Full MLA block | All-gather | Indexer | Combined indexing path |
|---|---:|---:|---:|---:|
| Fused | **8.856 ms** | fused | Ring: **0.160 ms** | **0.160 ms** |
| Separate on main, 11x10 | 8.930 ms | 0.082 ms | 0.110 ms | 0.192 ms |
| Separate, fixed 10x10 | 9.010 ms | 0.072 ms | 0.119 ms | 0.191 ms |

#### 500k prefix, SP=4 TP=2

| Variant | Full MLA block | All-gather | Indexer | Combined indexing path |
|---|---:|---:|---:|---:|
| Fused | **31.913 ms** | fused | Ring: **4.730 ms** | **4.730 ms** |
| Separate on main, 11x10 | 32.558 ms | 1.000 ms | 4.310 ms | 5.310 ms |
| Separate, fixed 10x10 | 33.022 ms | 1.006 ms | 4.727 ms | 5.733 ms |

#### 50k prefix, SP=4 TP=2

| Variant | Full MLA block | All-gather | Indexer | Combined indexing path |
|---|---:|---:|---:|---:|
| Fused | **11.675 ms** | fused | Ring: **0.566 ms** | **0.566 ms** |
| Separate on main, 11x10 | 11.766 ms | 0.149 ms | 0.516 ms | 0.665 ms |
| Separate, fixed 10x10 | 11.892 ms | 0.141 ms | 0.562 ms | 0.703 ms |

#### Effective all-gather overlap using the comparable 10x10 standalone indexer

`AG effectively hidden = (standalone AG + 10x10 standalone indexer - fused ring) / standalone AG`

| Prefix | SP/TP | Standalone AG | 10x10 indexer | Separate path | Fused ring | Net saved | AG effectively hidden |
|---|---:|---:|---:|---:|---:|---:|---:|
| 500k | 2x4 | 353 us | 949 us | 1,302 us | 1,124 us | 178 us | ~50% |
| 500k | 4x2 | 1,006 us | 4,727 us | 5,733 us | 4,730 us | 1,003 us | **~99.7%** |
| 50k | 2x4 | 72 us | 119 us | 191 us | 160 us | 32 us | ~44% |
| 50k | 4x2 | 141 us | 562 us | 703 us | 566 us | 137 us | **~97%** |

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=skrstic/mla-ring-indexer)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:skrstic/mla-ring-indexer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=skrstic/mla-ring-indexer)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:skrstic/mla-ring-indexer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=skrstic/mla-ring-indexer)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:skrstic/mla-ring-indexer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=skrstic/mla-ring-indexer)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:skrstic/mla-ring-indexer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=skrstic/mla-ring-indexer)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:skrstic/mla-ring-indexer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=skrstic/mla-ring-indexer)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:skrstic/mla-ring-indexer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=skrstic/mla-ring-indexer)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:skrstic/mla-ring-indexer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=skrstic/mla-ring-indexer)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:skrstic/mla-ring-indexer)