### PR TITLE
[Bug fix] fused_rms_minimal: derive cross-device count from ring_size, make stats optional

### DIFF
--- a/tests/nightly/tg/ccl/test_distributed_rms_norm_decode_configs.py
+++ b/tests/nightly/tg/ccl/test_distributed_rms_norm_decode_configs.py
@@ -103,18 +103,24 @@ def run_distributed_rms_norm_decode_impl(
     # Create semaphore handles for each iteration
     ccl_semaphore_handles = [ttnn.create_global_semaphore(mesh_device, input_shard_grid, 0) for _ in range(num_iters)]
 
-    # Stats buffer configuration - single core sharding so stats.padded_shape[-1] = num_devices * TILE_WIDTH
-    # This is critical for correct RMS scaling across devices
+    # Stats buffer configuration. The op gathers one E(x^2) tile per device on the cluster axis and
+    # averages them, so the buffer must be exactly (num_devices on cluster_axis) tiles wide and
+    # REPLICATED across the mesh (every device holds the full width). Sharding dim 3 across devices
+    # (the old, buggy form here) gave each device a single 1-tile shard -> the op inferred
+    # num_distributed_devices == 1 and skipped cross-device averaging (silently wrong on
+    # heterogeneous data). The op now derives the device count from ring_size and rejects a buffer
+    # whose tile width != ring_size, so build it the production way.
+    # (Alternatively, omit `stats` entirely and the op allocates this scratch itself.)
     ag_memory_config = ttnn.create_sharded_memory_config(
-        shape=(32, 32),
+        shape=(32, num_devices * 32),
         core_grid=ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))}),
         strategy=ttnn.ShardStrategy.WIDTH,
         orientation=ttnn.ShardOrientation.ROW_MAJOR,
         use_height_and_width_as_shard_shape=True,
     )
 
-    # Create persistent stats tensor
-    ag_shape = [1, 1, 32, num_devices]
+    # Create persistent stats tensor (replicated -> each device holds the full num_devices*32 width)
+    ag_shape = [1, 1, 32, num_devices * 32]
     stats_tensor = torch.zeros(ag_shape, dtype=torch.bfloat16)
     tt_stats = ttnn.from_torch(
         stats_tensor,
@@ -122,9 +128,7 @@ def run_distributed_rms_norm_decode_impl(
         layout=ttnn.TILE_LAYOUT,
         dtype=ttnn.bfloat16,
         memory_config=ag_memory_config,
-        mesh_mapper=ttnn.ShardTensor2dMesh(
-            mesh_device, dims=(3, None), mesh_shape=list(ttnn.MeshShape(num_devices, 1))
-        ),
+        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
     )
 
     # Output memory config

--- a/tests/nightly/tg/ccl/test_distributed_rms_norm_decode_configs.py
+++ b/tests/nightly/tg/ccl/test_distributed_rms_norm_decode_configs.py
@@ -103,14 +103,9 @@ def run_distributed_rms_norm_decode_impl(
     # Create semaphore handles for each iteration
     ccl_semaphore_handles = [ttnn.create_global_semaphore(mesh_device, input_shard_grid, 0) for _ in range(num_iters)]
 
-    # Stats buffer configuration. The op gathers one E(x^2) tile per device on the cluster axis and
-    # averages them, so the buffer must be exactly (num_devices on cluster_axis) tiles wide and
-    # REPLICATED across the mesh (every device holds the full width). Sharding dim 3 across devices
-    # (the old, buggy form here) gave each device a single 1-tile shard -> the op inferred
-    # num_distributed_devices == 1 and skipped cross-device averaging (silently wrong on
-    # heterogeneous data). The op now derives the device count from ring_size and rejects a buffer
-    # whose tile width != ring_size, so build it the production way.
-    # (Alternatively, omit `stats` entirely and the op allocates this scratch itself.)
+    # Stats buffer configuration. The op gathers one E(x^2) tile per device on the cluster axis, so
+    # the buffer must be num_devices tiles wide and replicated across the mesh. Passing stats=None
+    # instead lets the op allocate this scratch itself.
     ag_memory_config = ttnn.create_sharded_memory_config(
         shape=(32, num_devices * 32),
         core_grid=ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))}),
@@ -119,7 +114,7 @@ def run_distributed_rms_norm_decode_impl(
         use_height_and_width_as_shard_shape=True,
     )
 
-    # Create persistent stats tensor (replicated -> each device holds the full num_devices*32 width)
+    # Create persistent stats tensor
     ag_shape = [1, 1, 32, num_devices * 32]
     stats_tensor = torch.zeros(ag_shape, dtype=torch.bfloat16)
     tt_stats = ttnn.from_torch(

--- a/tests/nightly/tg/ccl/test_rms_internal_stats.py
+++ b/tests/nightly/tg/ccl/test_rms_internal_stats.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/nightly/tg/ccl/test_rms_internal_stats.py
+++ b/tests/nightly/tg/ccl/test_rms_internal_stats.py
@@ -3,25 +3,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-The op-allocated stats scratch in ttnn.fused_rms_minimal (the rms_allgather op).
+Test the op-allocated stats scratch in ttnn.fused_rms_minimal (the rms_allgather op).
 
-fused_rms_minimal computes a per-device E(x^2) partial, all-gathers the partials across cluster_axis
-and averages them for the global E(x^2). The count of partials averaged used to be inferred from the
-caller-provided stats buffer's tile width, so a 1-tile-wide buffer silently collapsed it to 1 and
-each device normalized by its own E(x^2). The op now derives the count from ring_size and allocates
-the scratch itself when stats is omitted.
-
-Covered here:
-  * the averaging is correct across all devices on cluster_axis. Every device's E(x^2) is roughly
-    equal on near-homogeneous data, which is why the bug was invisible, so these tests scale device
-    d's hidden slice by (d + 1) to spread E(x^2) by ~64x and compare against both a full-hidden and
-    a per-device golden.
-  * the scratch survives program cache hits, where a fresh allocation must be repointed.
-  * the scratch survives trace capture and replay, which is the case the optional-stats change
-    exists for.
-  * a stats buffer too narrow per core is rejected rather than silently degraded.
-
-Requires a TG (8x4 wormhole_b0) galaxy.
+Covers cross-device E(x^2) averaging, program cache hits and trace replay against a freshly
+allocated scratch, and rejection of an undersized caller-provided buffer. Requires a TG (8x4).
 """
 
 import torch
@@ -40,10 +25,7 @@ def get_torch_rms(x, gamma, eps):
 
 
 def get_torch_rms_per_device(x, gamma, eps, num_devices):
-    """RMSNorm where each device's hidden slice is normalized by only that device's E(x^2).
-
-    Reproduces what the op computed when the averaged device count collapsed to 1.
-    """
+    """RMSNorm where each device's slice is normalized by only its own E(x^2), i.e. the buggy output."""
     x = x.to(torch.float32)
     per = x.shape[-1] // num_devices
     out = torch.empty_like(x)
@@ -131,12 +113,7 @@ def build_heterogeneous_inputs(mesh_device, num_devices, hidden_size, seq_len, i
 @pytest.mark.parametrize("mesh_device", [pytest.param((8, 4), id="8x4_grid")], indirect=True)
 @pytest.mark.parametrize("num_iters", [3])
 def test_rms_heterogeneous_internal_stats(mesh_device, topology, num_iters, function_level_defaults):
-    """Omitting stats lets the op allocate a correctly sized scratch, so the output matches the golden.
-
-    Runs several iterations so that every call after the first is a program cache hit: the op-allocated
-    scratch is a fresh tensor each time, so override_runtime_arguments has to repoint both the writer's
-    stats address and the cb_stats CB. Outputs are held alive to keep the allocator moving between calls.
-    """
+    """Omitting stats gives a correctly sized scratch, on the first call and on program cache hits."""
     num_devices = 8  # cluster_axis=0 -> 8 rows on the 8x4 mesh
     hidden_size = 896 * num_devices
     seq_len = 32
@@ -171,9 +148,8 @@ def test_rms_heterogeneous_internal_stats(mesh_device, topology, num_iters, func
         cache_entries.append(mesh_device.num_program_cache_entries())
     ttnn.synchronize_device(mesh_device)
 
-    # Every call after the first must reuse the cached program, which is what forces
-    # override_runtime_arguments to repoint the freshly allocated scratch. Without this the loop
-    # could silently be recompiling each time and never exercise that path.
+    # Assert the calls were cache hits, otherwise the loop could be recompiling each time and never
+    # exercise override_runtime_arguments repointing the freshly allocated scratch.
     logger.info(f"program cache entries per iteration: {cache_entries}")
     assert (
         cache_entries[1:] == cache_entries[:-1]
@@ -190,9 +166,8 @@ def test_rms_heterogeneous_internal_stats(mesh_device, topology, num_iters, func
         logger.info(f"[iter {i}] PCC vs full-hidden golden: {pcc}, vs per-device golden: {pcc_per_device}")
 
         assert passing, f"iter {i}: {output}"
-        # The two references are far apart on 64x-heterogeneous data, so tracking the full-hidden one is
-        # a decisive check that all devices on cluster_axis were averaged. There is no Python-visible
-        # device count to assert on directly.
+        # The two goldens are far apart on 64x-heterogeneous data, so tracking the full-hidden one
+        # shows all devices were averaged. There is no Python-visible device count to assert on.
         assert pcc > pcc_per_device + 0.05, (
             f"iter {i}: output is not clearly closer to the full-hidden golden ({pcc}) than to the "
             f"single-device reference ({pcc_per_device}); cross-device averaging may have collapsed"
@@ -213,11 +188,8 @@ def test_rms_heterogeneous_internal_stats(mesh_device, topology, num_iters, func
 def test_rms_internal_stats_trace(mesh_device, topology, num_iters, function_level_defaults):
     """The op-allocated scratch survives trace capture and replay.
 
-    This is the case the optional-stats change exists for: under trace the caller cannot allocate or
-    free anything, so the scratch is allocated during capture and the recorded program keeps its
-    address. Unlike the existing trace tests, this checks the output *after* execute_trace, so a stale
-    cb_stats/writer address or a scratch whose L1 was reissued between capture and replay would fail
-    here rather than pass silently.
+    Checks the output after execute_trace, unlike the existing trace tests, so a stale cb_stats or
+    writer address would fail here rather than pass silently.
     """
     num_devices = 8
     hidden_size = 896 * num_devices

--- a/tests/nightly/tg/ccl/test_rms_internal_stats.py
+++ b/tests/nightly/tg/ccl/test_rms_internal_stats.py
@@ -3,14 +3,23 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-Correctness of the cross-device E(x^2) averaging in ttnn.fused_rms_minimal (the rms_allgather op).
+The op-allocated stats scratch in ttnn.fused_rms_minimal (the rms_allgather op).
 
-The op computes a per-device E(x^2) partial, all-gathers the partials across cluster_axis and
-averages them for the global E(x^2). The number of partials averaged used to be inferred from the
-caller-provided stats buffer's tile width, so a 1-tile-wide buffer silently collapsed that count to
-1 and each device normalized by its own E(x^2). On near-homogeneous data every device's E(x^2) is
-roughly equal, so that is invisible; only heterogeneous per-device data exposes it. These tests give
-device d a hidden slice scaled by (d + 1), spreading E(x^2) by ~64x across 8 devices.
+fused_rms_minimal computes a per-device E(x^2) partial, all-gathers the partials across cluster_axis
+and averages them for the global E(x^2). The count of partials averaged used to be inferred from the
+caller-provided stats buffer's tile width, so a 1-tile-wide buffer silently collapsed it to 1 and
+each device normalized by its own E(x^2). The op now derives the count from ring_size and allocates
+the scratch itself when stats is omitted.
+
+Covered here:
+  * the averaging is correct across all devices on cluster_axis. Every device's E(x^2) is roughly
+    equal on near-homogeneous data, which is why the bug was invisible, so these tests scale device
+    d's hidden slice by (d + 1) to spread E(x^2) by ~64x and compare against both a full-hidden and
+    a per-device golden.
+  * the scratch survives program cache hits, where a fresh allocation must be repointed.
+  * the scratch survives trace capture and replay, which is the case the optional-stats change
+    exists for.
+  * a stats buffer too narrow per core is rejected rather than silently degraded.
 
 Requires a TG (8x4 wormhole_b0) galaxy.
 """
@@ -120,8 +129,14 @@ def build_heterogeneous_inputs(mesh_device, num_devices, hidden_size, seq_len, i
 @pytest.mark.parametrize("topology", [ttnn.Topology.Linear])
 @pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
 @pytest.mark.parametrize("mesh_device", [pytest.param((8, 4), id="8x4_grid")], indirect=True)
-def test_rms_heterogeneous_internal_stats(mesh_device, topology, function_level_defaults):
-    """Omitting stats lets the op allocate a correctly sized scratch, so the output matches the golden."""
+@pytest.mark.parametrize("num_iters", [3])
+def test_rms_heterogeneous_internal_stats(mesh_device, topology, num_iters, function_level_defaults):
+    """Omitting stats lets the op allocate a correctly sized scratch, so the output matches the golden.
+
+    Runs several iterations so that every call after the first is a program cache hit: the op-allocated
+    scratch is a fresh tensor each time, so override_runtime_arguments has to repoint both the writer's
+    stats address and the cb_stats CB. Outputs are held alive to keep the allocator moving between calls.
+    """
     num_devices = 8  # cluster_axis=0 -> 8 rows on the 8x4 mesh
     hidden_size = 896 * num_devices
     seq_len = 32
@@ -130,22 +145,118 @@ def test_rms_heterogeneous_internal_stats(mesh_device, topology, function_level_
 
     ctx = build_heterogeneous_inputs(mesh_device, num_devices, hidden_size, seq_len, input_shard_grid)
 
-    tt_out = ttnn.fused_rms_minimal(
-        ctx["input_tensor"],
-        ctx["layer_norm_config"],
-        0,  # cluster_axis
-        mesh_device,
-        ctx["semaphore"],
-        topology=topology,
-        memory_config=ctx["output_memory_config"],
-        epsilon=epsilon,
-        dtype=ttnn.bfloat16,
-        weight=ctx["gamma_tensor"],
-        residual_input_tensor=None,
-        stats=None,  # op allocates its own stats scratch
-        use_noc1_only=False,
-    )
+    golden = get_torch_rms(ctx["x_torch"], ctx["gamma_torch"], epsilon)
+    golden_per_device = get_torch_rms_per_device(ctx["x_torch"], ctx["gamma_torch"], epsilon, num_devices)
+
+    outputs = []
+    cache_entries = []
+    for i in range(num_iters):
+        outputs.append(
+            ttnn.fused_rms_minimal(
+                ctx["input_tensor"],
+                ctx["layer_norm_config"],
+                0,  # cluster_axis
+                mesh_device,
+                ctx["semaphore"],
+                topology=topology,
+                memory_config=ctx["output_memory_config"],
+                epsilon=epsilon,
+                dtype=ttnn.bfloat16,
+                weight=ctx["gamma_tensor"],
+                residual_input_tensor=None,
+                stats=None,  # op allocates its own stats scratch
+                use_noc1_only=False,
+            )
+        )
+        cache_entries.append(mesh_device.num_program_cache_entries())
     ttnn.synchronize_device(mesh_device)
+
+    # Every call after the first must reuse the cached program, which is what forces
+    # override_runtime_arguments to repoint the freshly allocated scratch. Without this the loop
+    # could silently be recompiling each time and never exercise that path.
+    logger.info(f"program cache entries per iteration: {cache_entries}")
+    assert (
+        cache_entries[1:] == cache_entries[:-1]
+    ), f"expected program cache hits after the first call, but entry count grew: {cache_entries}"
+
+    for i, tt_out in enumerate(outputs):
+        tt_out_torch = ttnn.to_torch(
+            tt_out,
+            mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(3, 0), mesh_shape=(num_devices, 1)),
+        )[0].unsqueeze(0)
+
+        passing, output, pcc = comp_and_get_pcc(tt_out_torch, golden, 0.999)
+        _, _, pcc_per_device = comp_and_get_pcc(tt_out_torch, golden_per_device, 0.0)
+        logger.info(f"[iter {i}] PCC vs full-hidden golden: {pcc}, vs per-device golden: {pcc_per_device}")
+
+        assert passing, f"iter {i}: {output}"
+        # The two references are far apart on 64x-heterogeneous data, so tracking the full-hidden one is
+        # a decisive check that all devices on cluster_axis were averaged. There is no Python-visible
+        # device count to assert on directly.
+        assert pcc > pcc_per_device + 0.05, (
+            f"iter {i}: output is not clearly closer to the full-hidden golden ({pcc}) than to the "
+            f"single-device reference ({pcc_per_device}); cross-device averaging may have collapsed"
+        )
+
+    mesh_device.reset_sub_device_stall_group()
+
+
+@skip_for_blackhole("This is a wormhole test")
+@pytest.mark.parametrize("topology", [ttnn.Topology.Linear])
+@pytest.mark.parametrize(
+    "device_params",
+    [{"trace_region_size": 23887872, "fabric_config": ttnn.FabricConfig.FABRIC_1D}],
+    indirect=True,
+)
+@pytest.mark.parametrize("mesh_device", [pytest.param((8, 4), id="8x4_grid")], indirect=True)
+@pytest.mark.parametrize("num_iters", [3])
+def test_rms_internal_stats_trace(mesh_device, topology, num_iters, function_level_defaults):
+    """The op-allocated scratch survives trace capture and replay.
+
+    This is the case the optional-stats change exists for: under trace the caller cannot allocate or
+    free anything, so the scratch is allocated during capture and the recorded program keeps its
+    address. Unlike the existing trace tests, this checks the output *after* execute_trace, so a stale
+    cb_stats/writer address or a scratch whose L1 was reissued between capture and replay would fail
+    here rather than pass silently.
+    """
+    num_devices = 8
+    hidden_size = 896 * num_devices
+    seq_len = 32
+    epsilon = 1e-6
+    input_shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 6))})
+
+    ctx = build_heterogeneous_inputs(mesh_device, num_devices, hidden_size, seq_len, input_shard_grid)
+
+    def run_op():
+        return ttnn.fused_rms_minimal(
+            ctx["input_tensor"],
+            ctx["layer_norm_config"],
+            0,  # cluster_axis
+            mesh_device,
+            ctx["semaphore"],
+            topology=topology,
+            memory_config=ctx["output_memory_config"],
+            epsilon=epsilon,
+            dtype=ttnn.bfloat16,
+            weight=ctx["gamma_tensor"],
+            residual_input_tensor=None,
+            stats=None,  # op allocates its own stats scratch
+            use_noc1_only=False,
+        )
+
+    # Compile outside the trace so capture only records device commands.
+    run_op().deallocate(True)
+    ttnn.synchronize_device(mesh_device)
+
+    trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+    for _ in range(num_iters - 1):
+        run_op().deallocate(True)
+    tt_out = run_op()  # keep the last output alive so it can be read back after replay
+    ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
+
+    ttnn.execute_trace(mesh_device, trace_id, blocking=False)
+    ttnn.synchronize_device(mesh_device)
+    ttnn.release_trace(mesh_device, trace_id)
 
     tt_out_torch = ttnn.to_torch(
         tt_out,
@@ -157,15 +268,12 @@ def test_rms_heterogeneous_internal_stats(mesh_device, topology, function_level_
 
     passing, output, pcc = comp_and_get_pcc(tt_out_torch, golden, 0.999)
     _, _, pcc_per_device = comp_and_get_pcc(tt_out_torch, golden_per_device, 0.0)
-    logger.info(f"PCC vs full-hidden golden: {pcc}, vs per-device golden: {pcc_per_device}")
+    logger.info(f"[trace] PCC vs full-hidden golden: {pcc}, vs per-device golden: {pcc_per_device}")
 
     assert passing, output
-    # The two references are far apart on 64x-heterogeneous data, so tracking the full-hidden one is
-    # a decisive check that all devices on cluster_axis were averaged. There is no Python-visible
-    # device count to assert on directly.
     assert pcc > pcc_per_device + 0.05, (
-        f"output is not clearly closer to the full-hidden golden ({pcc}) than to the single-device "
-        f"reference ({pcc_per_device}); cross-device averaging may have collapsed to one device"
+        f"traced output is not clearly closer to the full-hidden golden ({pcc}) than to the "
+        f"single-device reference ({pcc_per_device}); cross-device averaging may have collapsed"
     )
 
     mesh_device.reset_sub_device_stall_group()
@@ -203,7 +311,7 @@ def test_rms_undersized_stats_rejected(mesh_device, topology, function_level_def
         ),
     )
 
-    with expect_error(RuntimeError, "requires a stats buffer at least ring_size"):
+    with expect_error(RuntimeError, "stats buffer of at least ring_size"):
         ttnn.fused_rms_minimal(
             ctx["input_tensor"],
             ctx["layer_norm_config"],

--- a/tests/nightly/tg/ccl/test_rms_internal_stats_heterogeneous.py
+++ b/tests/nightly/tg/ccl/test_rms_internal_stats_heterogeneous.py
@@ -1,0 +1,223 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Correctness of the cross-device E(x^2) averaging in ttnn.fused_rms_minimal (the rms_allgather op).
+
+The op computes a per-device E(x^2) partial, all-gathers the partials across cluster_axis and
+averages them for the global E(x^2). The number of partials averaged used to be inferred from the
+caller-provided stats buffer's tile width, so a 1-tile-wide buffer silently collapsed that count to
+1 and each device normalized by its own E(x^2). On near-homogeneous data every device's E(x^2) is
+roughly equal, so that is invisible; only heterogeneous per-device data exposes it. These tests give
+device d a hidden slice scaled by (d + 1), spreading E(x^2) by ~64x across 8 devices.
+
+Requires a TG (8x4 wormhole_b0) galaxy.
+"""
+
+import torch
+import pytest
+from loguru import logger
+import ttnn
+
+from models.common.utility_functions import skip_for_blackhole
+from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_and_get_pcc
+
+
+def get_torch_rms(x, gamma, eps):
+    """fp32 RMSNorm over the last dim."""
+    x = x.to(torch.float32)
+    return x * torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + eps) * gamma.to(torch.float32)
+
+
+def get_torch_rms_per_device(x, gamma, eps, num_devices):
+    """RMSNorm where each device's hidden slice is normalized by only that device's E(x^2).
+
+    Reproduces what the op computed when the averaged device count collapsed to 1.
+    """
+    x = x.to(torch.float32)
+    per = x.shape[-1] // num_devices
+    out = torch.empty_like(x)
+    for d in range(num_devices):
+        sl = slice(d * per, (d + 1) * per)
+        xd = x[..., sl]
+        out[..., sl] = xd * torch.rsqrt(xd.pow(2).mean(-1, keepdim=True) + eps)
+    return out * gamma.to(torch.float32)
+
+
+def build_heterogeneous_inputs(mesh_device, num_devices, hidden_size, seq_len, input_shard_grid):
+    """Heterogeneous input, gamma, memory/program configs and semaphore for one fused_rms_minimal call."""
+    ccl_sub_device_crs = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(4, 7))})
+    worker_sub_device = ttnn.SubDevice([ccl_sub_device_crs])
+    sub_device_manager = mesh_device.create_sub_device_manager([worker_sub_device], 0)
+    mesh_device.load_sub_device_manager(sub_device_manager)
+    mesh_device.set_sub_device_stall_group([ttnn.SubDeviceId(0)])
+
+    torch.manual_seed(1234)
+
+    total_cores = input_shard_grid.num_cores() * num_devices
+    shard_width_per_core = ttnn.core.roundup(hidden_size // total_cores, ttnn.TILE_SIZE)
+    shard_height = ttnn.core.roundup(seq_len, ttnn.TILE_SIZE)
+
+    # Device d owns hidden columns [d*per : (d+1)*per] (dims=(3, None), cluster_axis=0). Scale each
+    # device's slice by (d + 1) so E_d(x^2) ~ (d + 1)^2.
+    x_torch = torch.randn((1, 1, seq_len, hidden_size))
+    hidden_per_device = hidden_size // num_devices
+    for d in range(num_devices):
+        x_torch[..., d * hidden_per_device : (d + 1) * hidden_per_device] *= d + 1
+
+    gamma_torch = torch.randn((1, 1, 1, hidden_size))
+
+    input_memory_config = ttnn.create_sharded_memory_config(
+        shape=(shard_height, shard_width_per_core),
+        core_grid=input_shard_grid,
+        strategy=ttnn.ShardStrategy.WIDTH,
+        orientation=ttnn.ShardOrientation.ROW_MAJOR,
+        use_height_and_width_as_shard_shape=True,
+    )
+
+    layer_norm_config = ttnn.LayerNormShardedMultiCoreProgramConfig(
+        compute_with_storage_grid_size=(4, 8),
+        subblock_w=1,
+        block_h=1,
+        block_w=shard_width_per_core // ttnn.TILE_SIZE,
+        inplace=False,
+    )
+
+    input_tensor = ttnn.as_tensor(
+        x_torch,
+        dtype=ttnn.bfloat16,
+        device=mesh_device,
+        mesh_mapper=ttnn.ShardTensor2dMesh(
+            mesh_device=mesh_device, dims=(3, None), mesh_shape=list(ttnn.MeshShape(num_devices, 1))
+        ),
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=input_memory_config,
+    )
+    gamma_tensor = ttnn.as_tensor(
+        gamma_torch.reshape([1, 1, hidden_size // 32, 32]),
+        dtype=ttnn.bfloat16,
+        device=mesh_device,
+        mesh_mapper=ttnn.ShardTensor2dMesh(
+            mesh_device=mesh_device, dims=(2, None), mesh_shape=list(ttnn.MeshShape(num_devices, 1))
+        ),
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    return {
+        "x_torch": x_torch,
+        "gamma_torch": gamma_torch,
+        "input_tensor": input_tensor,
+        "gamma_tensor": gamma_tensor,
+        "layer_norm_config": layer_norm_config,
+        "output_memory_config": input_memory_config,
+        "semaphore": ttnn.create_global_semaphore(mesh_device, input_shard_grid, 0),
+    }
+
+
+@skip_for_blackhole("This is a wormhole test")
+@pytest.mark.parametrize("topology", [ttnn.Topology.Linear])
+@pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
+@pytest.mark.parametrize("mesh_device", [pytest.param((8, 4), id="8x4_grid")], indirect=True)
+def test_rms_heterogeneous_internal_stats(mesh_device, topology, function_level_defaults):
+    """Omitting stats lets the op allocate a correctly sized scratch, so the output matches the golden."""
+    num_devices = 8  # cluster_axis=0 -> 8 rows on the 8x4 mesh
+    hidden_size = 896 * num_devices
+    seq_len = 32
+    epsilon = 1e-6
+    input_shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 6))})
+
+    ctx = build_heterogeneous_inputs(mesh_device, num_devices, hidden_size, seq_len, input_shard_grid)
+
+    tt_out = ttnn.fused_rms_minimal(
+        ctx["input_tensor"],
+        ctx["layer_norm_config"],
+        0,  # cluster_axis
+        mesh_device,
+        ctx["semaphore"],
+        topology=topology,
+        memory_config=ctx["output_memory_config"],
+        epsilon=epsilon,
+        dtype=ttnn.bfloat16,
+        weight=ctx["gamma_tensor"],
+        residual_input_tensor=None,
+        stats=None,  # op allocates its own stats scratch
+        use_noc1_only=False,
+    )
+    ttnn.synchronize_device(mesh_device)
+
+    tt_out_torch = ttnn.to_torch(
+        tt_out,
+        mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(3, 0), mesh_shape=(num_devices, 1)),
+    )[0].unsqueeze(0)
+
+    golden = get_torch_rms(ctx["x_torch"], ctx["gamma_torch"], epsilon)
+    golden_per_device = get_torch_rms_per_device(ctx["x_torch"], ctx["gamma_torch"], epsilon, num_devices)
+
+    passing, output, pcc = comp_and_get_pcc(tt_out_torch, golden, 0.999)
+    _, _, pcc_per_device = comp_and_get_pcc(tt_out_torch, golden_per_device, 0.0)
+    logger.info(f"PCC vs full-hidden golden: {pcc}, vs per-device golden: {pcc_per_device}")
+
+    assert passing, output
+    # The two references are far apart on 64x-heterogeneous data, so tracking the full-hidden one is
+    # a decisive check that all devices on cluster_axis were averaged. There is no Python-visible
+    # device count to assert on directly.
+    assert pcc > pcc_per_device + 0.05, (
+        f"output is not clearly closer to the full-hidden golden ({pcc}) than to the single-device "
+        f"reference ({pcc_per_device}); cross-device averaging may have collapsed to one device"
+    )
+
+    mesh_device.reset_sub_device_stall_group()
+
+
+@skip_for_blackhole("This is a wormhole test")
+@pytest.mark.parametrize("topology", [ttnn.Topology.Linear])
+@pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
+@pytest.mark.parametrize("mesh_device", [pytest.param((8, 4), id="8x4_grid")], indirect=True)
+def test_rms_undersized_stats_rejected(mesh_device, topology, function_level_defaults, expect_error):
+    """A stats buffer narrower than the cluster-axis device count is rejected, not silently degraded."""
+    num_devices = 8
+    hidden_size = 896 * num_devices
+    seq_len = 32
+    epsilon = 1e-6
+    input_shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 6))})
+
+    ctx = build_heterogeneous_inputs(mesh_device, num_devices, hidden_size, seq_len, input_shard_grid)
+
+    # Sharding dim 3 across devices leaves each device a single 1-tile shard.
+    undersized_stats = ttnn.from_torch(
+        torch.zeros([1, 1, 32, num_devices], dtype=torch.bfloat16),
+        device=mesh_device,
+        layout=ttnn.TILE_LAYOUT,
+        dtype=ttnn.bfloat16,
+        memory_config=ttnn.create_sharded_memory_config(
+            shape=(32, 32),
+            core_grid=ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))}),
+            strategy=ttnn.ShardStrategy.WIDTH,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        ),
+        mesh_mapper=ttnn.ShardTensor2dMesh(
+            mesh_device, dims=(3, None), mesh_shape=list(ttnn.MeshShape(num_devices, 1))
+        ),
+    )
+
+    with expect_error(RuntimeError, "requires a stats buffer at least ring_size"):
+        ttnn.fused_rms_minimal(
+            ctx["input_tensor"],
+            ctx["layer_norm_config"],
+            0,
+            mesh_device,
+            ctx["semaphore"],
+            topology=topology,
+            memory_config=ctx["output_memory_config"],
+            epsilon=epsilon,
+            dtype=ttnn.bfloat16,
+            weight=ctx["gamma_tensor"],
+            residual_input_tensor=None,
+            stats=undersized_stats,
+            use_noc1_only=False,
+        )
+
+    mesh_device.reset_sub_device_stall_group()

--- a/tests/ttnn/unit_tests/gtests/test_graph_query_op_constraints.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_graph_query_op_constraints.cpp
@@ -1307,10 +1307,11 @@ TYPED_TEST(DistributedTensorOpIfTest, FusedRmsMinimalWithShardedTopology) {
     //   - block_w * tile_width(32) == shard_spec.shape[1]
     //   - Kt(=N/32) / num_cores == block_w
     //   - weight: ROW_MAJOR, padded_shape[-1]==32, volume == N
-    //   - stats: required by program factory unconditionally (must be TILE + WIDTH_SHARDED)
+    //   - stats: TILE + WIDTH_SHARDED, exactly ring_size tiles wide (or omitted, letting the op
+    //     allocate its own scratch)
     //   - output_mem_config: sharded ROW_MAJOR matching input
     // 8 cores × 2 tiles each: N=512, Kt=16, block_w=2, Kt/cores=2
-    // Stats on 1 core: stats_cb_size = Kt*tile_size = bank_size (no overflow).
+    // Stats on 1 core: stats_cb_size = ring_size*tile_size = bank_size (no overflow).
     static constexpr uint32_t kNumCores = 8;
     static constexpr uint32_t kTilesPerCore = 2;
     static constexpr uint32_t kTileWidth = 32;
@@ -1345,15 +1346,19 @@ TYPED_TEST(DistributedTensorOpIfTest, FusedRmsMinimalWithShardedTopology) {
             ttnn::L1_MEMORY_CONFIG));
 
     // Stats: pre-allocated buffer for intermediate RMS stats gathered across devices.
-    // Must be TILE to avoid buffer->page_size() call in the program factory.
+    // Must be TILE to avoid buffer->page_size() call in the program factory, and exactly one tile per
+    // device on cluster_axis 1 so the op averages over the right device count.
     // Stats lives on 1 core (the aggregation point for multicast from all input cores).
-    // stats_cb_size = Kt * tile_size; bank_size = total_stats / 1 core = Kt * tile_size → equal
-    // If spread across kNumCores: bank_size = Kt*tile_size/kNumCores < stats_cb_size → FATAL.
+    // stats_cb_size = ring_size * tile_size; bank_size = total_stats / 1 core → equal.
+    // If spread across kNumCores: bank_size = stats_cb_size/kNumCores < stats_cb_size → FATAL.
+    const uint32_t stats_width = mesh_shape[1] * kTileWidth;
     const tt::tt_metal::ShardSpec stats_shard_spec{
-        CoreRangeSet{CoreRange{CoreCoord{0, 0}, CoreCoord{0, 0}}}, {kTileHeight, kN}, ShardOrientation::ROW_MAJOR};
+        CoreRangeSet{CoreRange{CoreCoord{0, 0}, CoreCoord{0, 0}}},
+        {kTileHeight, stats_width},
+        ShardOrientation::ROW_MAJOR};
     const tt::tt_metal::MemoryConfig stats_mem_cfg{TensorMemoryLayout::WIDTH_SHARDED, BufferType::L1, stats_shard_spec};
     const auto stats_spec = tt::tt_metal::TensorSpec(
-        ttnn::Shape(ttnn::Array4D{1, 1, kTileHeight, kN}),
+        ttnn::Shape(ttnn::Array4D{1, 1, kTileHeight, stats_width}),
         tt::tt_metal::TensorLayout(
             tt::tt_metal::DataType::BFLOAT16, tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE), stats_mem_cfg));
 

--- a/tests/ttnn/unit_tests/operations/ccl/fusion_subtests/rms_test.py
+++ b/tests/ttnn/unit_tests/operations/ccl/fusion_subtests/rms_test.py
@@ -76,17 +76,19 @@ def run_rms_trace_deepseek(
 
     ccl_semaphore_handles = ttnn.create_global_semaphore(mesh_device, input_shard_grid, 0)
 
+    # Stats buffer: one E(x^2) tile per device on the cluster axis, replicated so every device holds
+    # the full width. Passing stats=None instead lets the op allocate this scratch itself.
     ag_memory_config = ttnn.create_sharded_memory_config(
         shape=(
             32,
-            32,
+            num_devices * 32,
         ),
         core_grid=ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))}),
         strategy=ttnn.ShardStrategy.WIDTH,
         orientation=ttnn.ShardOrientation.ROW_MAJOR,
         use_height_and_width_as_shard_shape=True,
     )
-    ag_shape = [1, 1, 32, num_devices]
+    ag_shape = [1, 1, 32, num_devices * 32]
     stats_tensor = torch.zeros(ag_shape, dtype=torch.bfloat16)
     tt_stats = ttnn.from_torch(
         stats_tensor,
@@ -94,9 +96,7 @@ def run_rms_trace_deepseek(
         layout=ttnn.TILE_LAYOUT,
         dtype=ttnn.bfloat16,
         memory_config=ag_memory_config,
-        mesh_mapper=ttnn.ShardTensor2dMesh(
-            mesh_device, dims=(3, None), mesh_shape=list(ttnn.MeshShape(num_devices, 1))
-        ),
+        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
     )
 
     if output_shard_grid is None:
@@ -310,17 +310,19 @@ def run_rms_trace(
 
     ccl_semaphore_handles = ttnn.create_global_semaphore(mesh_device, input_shard_grid, 0)
 
+    # Stats buffer: one E(x^2) tile per device on the cluster axis, replicated so every device holds
+    # the full width. Passing stats=None instead lets the op allocate this scratch itself.
     ag_memory_config = ttnn.create_sharded_memory_config(
         shape=(
             32,
-            128,
+            num_devices * 32,
         ),
         core_grid=ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))}),
         strategy=ttnn.ShardStrategy.WIDTH,
         orientation=ttnn.ShardOrientation.ROW_MAJOR,
         use_height_and_width_as_shard_shape=True,
     )
-    ag_shape = [1, 1, 32, 256]
+    ag_shape = [1, 1, 32, num_devices * 32]
     stats_tensor = torch.zeros(ag_shape, dtype=torch.bfloat16)
     tt_stats = ttnn.from_torch(
         stats_tensor,
@@ -328,9 +330,7 @@ def run_rms_trace(
         layout=ttnn.TILE_LAYOUT,
         dtype=ttnn.bfloat16,
         memory_config=ag_memory_config,
-        mesh_mapper=ttnn.ShardTensor2dMesh(
-            mesh_device, dims=(None, 3), mesh_shape=list(ttnn.MeshShape(1, num_devices))
-        ),
+        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
     )
 
     output_pad_width = math.ceil(padded_dim_per_core / num_devices / 32) * 32
@@ -591,17 +591,19 @@ def run_rms_trace_qwen(
 
     ccl_semaphore_handles = ttnn.create_global_semaphore(mesh_device, input_shard_grid, 0)
 
+    # Stats buffer: one E(x^2) tile per device on the cluster axis, replicated so every device holds
+    # the full width. Passing stats=None instead lets the op allocate this scratch itself.
     ag_memory_config = ttnn.create_sharded_memory_config(
         shape=(
             32,
-            128,
+            num_devices * 32,
         ),
         core_grid=ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(1, 0))}),
         strategy=ttnn.ShardStrategy.WIDTH,
         orientation=ttnn.ShardOrientation.ROW_MAJOR,
         use_height_and_width_as_shard_shape=True,
     )
-    ag_shape = [1, 1, 32, 160]
+    ag_shape = [1, 1, 32, num_devices * 32]
     stats_tensor = torch.zeros(ag_shape, dtype=torch.bfloat16)
     tt_stats = ttnn.from_torch(
         stats_tensor,
@@ -609,9 +611,7 @@ def run_rms_trace_qwen(
         layout=ttnn.TILE_LAYOUT,
         dtype=ttnn.bfloat16,
         memory_config=ag_memory_config,
-        mesh_mapper=ttnn.ShardTensor2dMesh(
-            mesh_device, dims=(None, 3), mesh_shape=list(ttnn.MeshShape(1, num_devices))
-        ),
+        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
     )
 
     output_pad_width = math.ceil(padded_dim_per_core / num_devices / 32) * 32
@@ -883,13 +883,14 @@ def run_rms_fuse_impl_deepseek(
     ccl_semaphore_handles = [ttnn.create_global_semaphore(mesh_device, input_shard_grid, 0) for _ in range(num_iters)]
 
     # Stats buffer must use single-core sharding so stats.padded_shape[-1] = num_devices * TILE_WIDTH.
-    # fused_rmsnorm_post_all_gather infers num_distributed_devices = stats.padded_shape[-1] / TILE_WIDTH;
-    # if we shard over input_shard_grid, padded_shape[-1] scales with num_cores and the kernel gets wrong
-    # num_devices, skewing RMS scaling and failing PCC on multi-device. Match run_rms_trace_deepseek.
+    # Stats buffer: one E(x^2) tile per device on the cluster axis, replicated so every device holds
+    # the full width, on a single core. Sharding it over input_shard_grid instead would give each core
+    # a fraction of a tile and undersize the cb_stats bank. Passing stats=None instead lets the op
+    # allocate this scratch itself.
     ag_memory_config = ttnn.create_sharded_memory_config(
         shape=(
             32,
-            32,
+            num_devices * 32,
         ),
         core_grid=ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))}),
         strategy=ttnn.ShardStrategy.WIDTH,
@@ -903,7 +904,7 @@ def run_rms_fuse_impl_deepseek(
         else ttnn.bfloat16
     )
     stats_torch_dtype = torch.float32 if stats_dtype == ttnn.float32 else torch.bfloat16
-    ag_shape = [1, 1, 32, num_devices]
+    ag_shape = [1, 1, 32, num_devices * 32]
     stats_tensor = torch.ones(ag_shape, dtype=stats_torch_dtype)
     tt_stats = ttnn.from_torch(
         stats_tensor,
@@ -911,9 +912,7 @@ def run_rms_fuse_impl_deepseek(
         layout=ttnn.TILE_LAYOUT,
         dtype=stats_dtype,
         memory_config=ag_memory_config,
-        mesh_mapper=ttnn.ShardTensor2dMesh(
-            mesh_device, dims=(3, None), mesh_shape=list(ttnn.MeshShape(num_devices, 1))
-        ),
+        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
     )
 
     if output_shard_grid is None:
@@ -1102,17 +1101,19 @@ def run_rms_fuse_impl(
         inplace=False,
     )
     ccl_semaphore_handles = [ttnn.create_global_semaphore(mesh_device, input_shard_grid, 0) for _ in range(num_iters)]
+    # Stats buffer: one E(x^2) tile per device on the cluster axis, replicated so every device holds
+    # the full width. Passing stats=None instead lets the op allocate this scratch itself.
     ag_memory_config = ttnn.create_sharded_memory_config(
         shape=(
             32,
-            128,
+            num_devices * 32,
         ),
         core_grid=input_shard_grid,
         strategy=ttnn.ShardStrategy.WIDTH,
         orientation=ttnn.ShardOrientation.ROW_MAJOR,
         use_height_and_width_as_shard_shape=True,
     )
-    ag_shape = [1, 1, 32, 128]
+    ag_shape = [1, 1, 32, num_devices * 32]
     stats_tensor = torch.ones(ag_shape, dtype=torch.bfloat16)
     tt_stats = ttnn.from_torch(
         stats_tensor,
@@ -1120,9 +1121,7 @@ def run_rms_fuse_impl(
         layout=ttnn.TILE_LAYOUT,
         dtype=ttnn.bfloat16,
         memory_config=ag_memory_config,
-        mesh_mapper=ttnn.ShardTensor2dMesh(
-            mesh_device, dims=(None, 3), mesh_shape=list(ttnn.MeshShape(1, num_devices))
-        ),
+        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
     )
     output_pad_width = math.ceil(padded_dim_per_core / num_devices / 32) * 32
     if output_shard_grid is None:
@@ -1296,17 +1295,19 @@ def run_rms_fuse_impl_qwen(
         inplace=False,
     )
     ccl_semaphore_handles = [ttnn.create_global_semaphore(mesh_device, input_shard_grid, 0) for _ in range(num_iters)]
+    # Stats buffer: one E(x^2) tile per device on the cluster axis, replicated so every device holds
+    # the full width. Passing stats=None instead lets the op allocate this scratch itself.
     ag_memory_config = ttnn.create_sharded_memory_config(
         shape=(
             32,
-            128,
+            num_devices * 32,
         ),
         core_grid=input_shard_grid,
         strategy=ttnn.ShardStrategy.WIDTH,
         orientation=ttnn.ShardOrientation.ROW_MAJOR,
         use_height_and_width_as_shard_shape=True,
     )
-    ag_shape = [1, 1, 32, 128]
+    ag_shape = [1, 1, 32, num_devices * 32]
     stats_tensor = torch.ones(ag_shape, dtype=torch.bfloat16)
     tt_stats = ttnn.from_torch(
         stats_tensor,
@@ -1314,9 +1315,7 @@ def run_rms_fuse_impl_qwen(
         layout=ttnn.TILE_LAYOUT,
         dtype=ttnn.bfloat16,
         memory_config=ag_memory_config,
-        mesh_mapper=ttnn.ShardTensor2dMesh(
-            mesh_device, dims=(None, 3), mesh_shape=list(ttnn.MeshShape(1, num_devices))
-        ),
+        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
     )
     output_pad_width = math.ceil(padded_dim_per_core / num_devices / 32) * 32
     if output_shard_grid is None:

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/rms_allgather_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/rms_allgather_device_operation.cpp
@@ -23,10 +23,27 @@ void RMSAllGatherDeviceOperation::validate_on_program_cache_miss(
     const auto& b = tensor_args.residual_input_tensor;
     const auto& gamma = tensor_args.weight;
 
+    // stats is always populated by the time we get here: either the caller supplied one, or
+    // ttnn::prim::rms_allgather allocated an op-managed transient scratch when stats == nullopt
+    // (see the stats-scratch block below). It backs the globally-allocated cb_stats circular
+    // buffer, so it must still be present.
     TT_FATAL(
         tensor_args.stats.has_value(),
-        "fused_rms_minimal requires a pre-allocated stats tensor; passing stats=None is not supported. It backs "
-        "an internal globally-allocated circular buffer.");
+        "fused_rms_minimal internal error: the stats scratch tensor was not populated before launch.");
+    // The op gathers exactly one E(x^2) partial tile per device on the cluster axis (ring_size of
+    // them) into the stats buffer and averages them. The number of tiles the buffer holds must
+    // therefore equal ring_size; otherwise the AVG reduce would divide by the wrong device count
+    // (a stats buffer that is 1 tile wide silently collapses to num_distributed_devices == 1 and
+    // each device normalizes by its own E(x^2) instead of the mesh mean). Fail loudly on mismatch.
+    const uint32_t stats_tiles_wide = tensor_args.stats.value().padded_shape()[-1] / TILE_WIDTH;
+    TT_FATAL(
+        stats_tiles_wide == args.ring_size,
+        "fused_rms_minimal: the stats buffer must be exactly ring_size ({}) tiles wide (padded width "
+        "{} -> {} tiles). A caller-provided stats buffer must be replicated across the mesh and sized "
+        "(32, ring_size * 32); a width of 1 tile silently disables cross-device averaging.",
+        args.ring_size,
+        tensor_args.stats.value().padded_shape()[-1],
+        stats_tiles_wide);
 
     {
         const bool fp32_dest_acc_en =
@@ -358,11 +375,51 @@ ttnn::experimental::prim::RMSAllGatherDeviceOperation::tensor_return_value_t rms
         cluster_axis,
         use_noc1_only);
 
+    // Stats scratch. The op all-gathers each device's E(x^2) partial (one tile per device on the
+    // cluster axis, num_devices == ring_size of them) into this buffer and averages it to obtain
+    // the global E(x^2). It MUST be single-core width-sharded in L1 (the writer fabric-mcasts each
+    // partial into the peers' L1 stats buffers, and the compute reads it back through a globally
+    // allocated CB), and it must live on the input shard grid's first core (where cb_stats is
+    // placed).
+    //
+    // Historically the caller had to build and pass this buffer, which forced it to be persistent
+    // for the whole program (a host-side allocation cannot live inside a trace body, and reusing
+    // one buffer across every norm keeps it resident in L1 for the entire decode). When the caller
+    // does not supply one, allocate it here as a normal op-managed transient device tensor: it is
+    // freed when this Tensor goes out of scope after launch (the deallocation is ordered on the
+    // command queue after the program that uses it) and is trace-native. Every tile of it is
+    // overwritten by the gather before the reduce reads it (semaphore-synced), so it does not need
+    // to be zero-initialized.
+    std::optional<const ttnn::Tensor> stats_scratch = stats;
+    if (!stats_scratch.has_value()) {
+        auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
+            get_compute_kernel_config_args(arch, kernel_config_val);
+        // The globally-allocated cb_stats CB (program factory) is mapped directly onto this buffer
+        // and its page size follows cb_data_format = fp32_dest_acc_en ? Float32 : Float16_b, so the
+        // buffer's tile size must match. Default is bf16 (matches production and halves the L1).
+        const DataType stats_dtype = fp32_dest_acc_en ? DataType::FLOAT32 : DataType::BFLOAT16;
+        const uint32_t stats_width = static_cast<uint32_t>(num_devices) * TILE_WIDTH;
+        TT_FATAL(
+            input_tensor.shard_spec().has_value(),
+            "fused_rms_minimal requires a sharded input to place the internal stats scratch.");
+        const CoreCoord stats_core = input_tensor.shard_spec().value().grid.bounding_box().start_coord;
+        const ShardSpec stats_shard_spec(
+            CoreRangeSet(CoreRange(stats_core, stats_core)), {TILE_HEIGHT, stats_width}, ShardOrientation::ROW_MAJOR);
+        const MemoryConfig stats_mem_config(TensorMemoryLayout::WIDTH_SHARDED, BufferType::L1, stats_shard_spec);
+        const TensorSpec stats_spec(
+            ttnn::Shape({1, 1, TILE_HEIGHT, stats_width}),
+            TensorLayout(stats_dtype, PageConfig(Layout::TILE), stats_mem_config));
+        // emplace (construct in place), not assign: std::optional<const Tensor> has a deleted
+        // copy-assignment operator (const Tensor is not assignable), so `stats_scratch = ...` fails
+        // to compile. emplace constructs the contained value directly, which is allowed.
+        stats_scratch.emplace(create_device_tensor(stats_spec, input_tensor.device()));
+    }
+
     auto tensor_args = OperationType::tensor_args_t{
         .input = input_tensor,
         .residual_input_tensor = residual_input_tensor,
         .weight = weight,
-        .stats = stats,
+        .stats = stats_scratch,
         .preallocated_output = persistent_output_tensor};
 
     return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/rms_allgather_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/rms_allgather_device_operation.cpp
@@ -23,26 +23,18 @@ void RMSAllGatherDeviceOperation::validate_on_program_cache_miss(
     const auto& b = tensor_args.residual_input_tensor;
     const auto& gamma = tensor_args.weight;
 
-    // stats is always populated by the time we get here: either the caller supplied one, or
-    // ttnn::prim::rms_allgather allocated an op-managed transient scratch when stats == nullopt
-    // (see the stats-scratch block below). It backs the globally-allocated cb_stats circular
-    // buffer, so it must still be present.
-    TT_FATAL(
-        tensor_args.stats.has_value(),
-        "fused_rms_minimal internal error: the stats scratch tensor was not populated before launch.");
-    // The op gathers exactly one E(x^2) partial tile per device on the cluster axis (ring_size of
-    // them) into the stats buffer and averages them. The number of tiles the buffer holds must
-    // therefore equal ring_size; otherwise the AVG reduce would divide by the wrong device count
-    // (a stats buffer that is 1 tile wide silently collapses to num_distributed_devices == 1 and
-    // each device normalizes by its own E(x^2) instead of the mesh mean). Fail loudly on mismatch.
+    // Populated by ttnn::prim::rms_allgather even when the caller passes stats=None (it allocates an
+    // op-managed scratch), and it backs the globally-allocated cb_stats circular buffer.
+    TT_FATAL(tensor_args.stats.has_value(), "fused_rms_minimal: the stats scratch tensor was not populated.");
+    // The op gathers one E(x^2) partial tile per device on the cluster axis, writing it at slot
+    // device_index % stats_tiles_wide. A narrower buffer wraps those slots, so devices clobber each
+    // other's partials; a wider one only leaves the tail unused. Hence a lower bound, not equality.
     const uint32_t stats_tiles_wide = tensor_args.stats.value().padded_shape()[-1] / TILE_WIDTH;
     TT_FATAL(
-        stats_tiles_wide == args.ring_size,
-        "fused_rms_minimal: the stats buffer must be exactly ring_size ({}) tiles wide (padded width "
-        "{} -> {} tiles). A caller-provided stats buffer must be replicated across the mesh and sized "
-        "(32, ring_size * 32); a width of 1 tile silently disables cross-device averaging.",
+        stats_tiles_wide >= args.ring_size,
+        "fused_rms_minimal requires a stats buffer at least ring_size ({}) tiles wide but got {}; a caller-provided "
+        "buffer must be replicated across the mesh with per-device shape (32, ring_size * 32).",
         args.ring_size,
-        tensor_args.stats.value().padded_shape()[-1],
         stats_tiles_wide);
 
     {
@@ -375,28 +367,16 @@ ttnn::experimental::prim::RMSAllGatherDeviceOperation::tensor_return_value_t rms
         cluster_axis,
         use_noc1_only);
 
-    // Stats scratch. The op all-gathers each device's E(x^2) partial (one tile per device on the
-    // cluster axis, num_devices == ring_size of them) into this buffer and averages it to obtain
-    // the global E(x^2). It MUST be single-core width-sharded in L1 (the writer fabric-mcasts each
-    // partial into the peers' L1 stats buffers, and the compute reads it back through a globally
-    // allocated CB), and it must live on the input shard grid's first core (where cb_stats is
-    // placed).
-    //
-    // Historically the caller had to build and pass this buffer, which forced it to be persistent
-    // for the whole program (a host-side allocation cannot live inside a trace body, and reusing
-    // one buffer across every norm keeps it resident in L1 for the entire decode). When the caller
-    // does not supply one, allocate it here as a normal op-managed transient device tensor: it is
-    // freed when this Tensor goes out of scope after launch (the deallocation is ordered on the
-    // command queue after the program that uses it) and is trace-native. Every tile of it is
-    // overwritten by the gather before the reduce reads it (semaphore-synced), so it does not need
-    // to be zero-initialized.
+    // Allocate the stats scratch when the caller does not supply one. Each device's E(x^2) partial is
+    // fabric-written into it (one tile per device on the cluster axis) and then averaged, so it must
+    // be single-core width-sharded in L1 on the input shard grid's first core, where cb_stats is
+    // placed. An op-managed transient tensor is trace-native, unlike a caller-side persistent one.
     std::optional<const ttnn::Tensor> stats_scratch = stats;
     if (!stats_scratch.has_value()) {
         auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
             get_compute_kernel_config_args(arch, kernel_config_val);
-        // The globally-allocated cb_stats CB (program factory) is mapped directly onto this buffer
-        // and its page size follows cb_data_format = fp32_dest_acc_en ? Float32 : Float16_b, so the
-        // buffer's tile size must match. Default is bf16 (matches production and halves the L1).
+        // cb_stats is mapped onto this buffer and its page size follows cb_data_format, so the tile
+        // size must match.
         const DataType stats_dtype = fp32_dest_acc_en ? DataType::FLOAT32 : DataType::BFLOAT16;
         const uint32_t stats_width = static_cast<uint32_t>(num_devices) * TILE_WIDTH;
         TT_FATAL(
@@ -409,9 +389,7 @@ ttnn::experimental::prim::RMSAllGatherDeviceOperation::tensor_return_value_t rms
         const TensorSpec stats_spec(
             ttnn::Shape({1, 1, TILE_HEIGHT, stats_width}),
             TensorLayout(stats_dtype, PageConfig(Layout::TILE), stats_mem_config));
-        // emplace (construct in place), not assign: std::optional<const Tensor> has a deleted
-        // copy-assignment operator (const Tensor is not assignable), so `stats_scratch = ...` fails
-        // to compile. emplace constructs the contained value directly, which is allowed.
+        // emplace, not assign: std::optional<const Tensor> has no copy-assignment operator.
         stats_scratch.emplace(create_device_tensor(stats_spec, input_tensor.device()));
     }
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/rms_allgather_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/rms_allgather_device_operation.cpp
@@ -26,16 +26,27 @@ void RMSAllGatherDeviceOperation::validate_on_program_cache_miss(
     // Populated by ttnn::prim::rms_allgather even when the caller passes stats=None (it allocates an
     // op-managed scratch), and it backs the globally-allocated cb_stats circular buffer.
     TT_FATAL(tensor_args.stats.has_value(), "fused_rms_minimal: the stats scratch tensor was not populated.");
-    // The op gathers one E(x^2) partial tile per device on the cluster axis, writing it at slot
-    // device_index % stats_tiles_wide. A narrower buffer wraps those slots, so devices clobber each
-    // other's partials; a wider one only leaves the tail unused. Hence a lower bound, not equality.
-    const uint32_t stats_tiles_wide = tensor_args.stats.value().padded_shape()[-1] / TILE_WIDTH;
+    const auto& stats = tensor_args.stats.value();
+    // The program factory binds cb_stats onto this buffer and reads its shard spec, so the layout is
+    // part of the contract rather than a preference.
     TT_FATAL(
-        stats_tiles_wide >= args.ring_size,
-        "fused_rms_minimal requires a stats buffer at least ring_size ({}) tiles wide but got {}; a caller-provided "
-        "buffer must be replicated across the mesh with per-device shape (32, ring_size * 32).",
+        stats.memory_config().buffer_type() == BufferType::L1,
+        "fused_rms_minimal requires the stats buffer in L1 but got buffer type {}.",
+        stats.memory_config().buffer_type());
+    TT_FATAL(
+        stats.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED,
+        "fused_rms_minimal requires a width-sharded stats buffer but got memory layout {}.",
+        stats.memory_config().memory_layout());
+    // One E(x^2) partial tile is gathered per device on the cluster axis, at slot
+    // device_index % tiles_per_core, and cb_stats is bound to a single core's bank, so the bound is on
+    // the per-core shard width rather than the tensor width. A wider bank only leaves the tail unused.
+    const uint32_t stats_tiles_per_core = stats.shard_spec().value().shape[1] / TILE_WIDTH;
+    TT_FATAL(
+        stats_tiles_per_core >= args.ring_size,
+        "fused_rms_minimal requires a stats buffer of at least ring_size ({}) tiles per core but got {}; a "
+        "caller-provided buffer must be replicated across the mesh with per-core shard shape (32, ring_size * 32).",
         args.ring_size,
-        stats_tiles_wide);
+        stats_tiles_per_core);
 
     {
         const bool fp32_dest_acc_en =
@@ -367,10 +378,9 @@ ttnn::experimental::prim::RMSAllGatherDeviceOperation::tensor_return_value_t rms
         cluster_axis,
         use_noc1_only);
 
-    // Allocate the stats scratch when the caller does not supply one. Each device's E(x^2) partial is
-    // fabric-written into it (one tile per device on the cluster axis) and then averaged, so it must
-    // be single-core width-sharded in L1 on the input shard grid's first core, where cb_stats is
-    // placed. An op-managed transient tensor is trace-native, unlike a caller-side persistent one.
+    // Allocate the stats scratch when the caller omits it. Each device fabric-writes its E(x^2) partial
+    // into one tile of this buffer, so it must be width-sharded L1 on the first core of the input shard
+    // grid, where the program factory places cb_stats. An op-managed transient is trace-native.
     std::optional<const ttnn::Tensor> stats_scratch = stats;
     if (!stats_scratch.has_value()) {
         auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/rms_allgather_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/rms_allgather_program_factory.cpp
@@ -249,13 +249,21 @@ RMSAllGatherMeshWorkloadFactory::cached_program_t RMSAllGatherMeshWorkloadFactor
     ////////////////////////////////////////////////////////////////////////////
     // block size for in0 (tensor a)
     uint32_t in0_block_tiles = block_wt;
-    // post_all_gather_stats_block_tiles
-    uint32_t post_all_gather_stats_block_tiles = 1;
-    uint32_t num_distributed_devices = 1;
-    if (stats.has_value()) {
-        post_all_gather_stats_block_tiles = stats.value().padded_shape()[-1] / TILE_WIDTH;
-        num_distributed_devices = post_all_gather_stats_block_tiles;
-    }
+    // Number of per-device E(x^2) partials averaged across the cluster axis. This is authoritative
+    // from ring_size (the device count on cluster_axis, from the mesh view), NOT inferred from the
+    // stats buffer width: reading it off the buffer silently collapses to 1 when the buffer is a
+    // single tile wide, disabling cross-device averaging (see validate_on_program_cache_miss, which
+    // asserts the buffer is exactly ring_size tiles wide).
+    uint32_t num_distributed_devices = ring_size;
+    // post_all_gather_stats_block_tiles sizes the globally-allocated cb_stats CB, which is mapped
+    // directly onto the stats buffer, so it must match the buffer's tile count. Validation
+    // guarantees that count equals ring_size.
+    uint32_t post_all_gather_stats_block_tiles = stats.value().padded_shape()[-1] / TILE_WIDTH;
+    TT_FATAL(
+        post_all_gather_stats_block_tiles == num_distributed_devices,
+        "fused_rms_minimal: stats buffer holds {} tiles but ring_size is {}; they must match.",
+        post_all_gather_stats_block_tiles,
+        num_distributed_devices);
 
     uint32_t in0_CB_size = in0_block_tiles * in_single_tile_size;
     // block size for in1 (tensor b)

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/rms_allgather_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/rms_allgather_program_factory.cpp
@@ -249,21 +249,11 @@ RMSAllGatherMeshWorkloadFactory::cached_program_t RMSAllGatherMeshWorkloadFactor
     ////////////////////////////////////////////////////////////////////////////
     // block size for in0 (tensor a)
     uint32_t in0_block_tiles = block_wt;
-    // Number of per-device E(x^2) partials averaged across the cluster axis. This is authoritative
-    // from ring_size (the device count on cluster_axis, from the mesh view), NOT inferred from the
-    // stats buffer width: reading it off the buffer silently collapses to 1 when the buffer is a
-    // single tile wide, disabling cross-device averaging (see validate_on_program_cache_miss, which
-    // asserts the buffer is exactly ring_size tiles wide).
+    // One E(x^2) partial tile per device on the cluster axis. Taken from ring_size rather than from
+    // the stats buffer width, which silently collapses to 1 for a 1-tile-wide buffer and disables
+    // cross-device averaging; validation asserts the buffer is ring_size tiles wide.
     uint32_t num_distributed_devices = ring_size;
-    // post_all_gather_stats_block_tiles sizes the globally-allocated cb_stats CB, which is mapped
-    // directly onto the stats buffer, so it must match the buffer's tile count. Validation
-    // guarantees that count equals ring_size.
-    uint32_t post_all_gather_stats_block_tiles = stats.value().padded_shape()[-1] / TILE_WIDTH;
-    TT_FATAL(
-        post_all_gather_stats_block_tiles == num_distributed_devices,
-        "fused_rms_minimal: stats buffer holds {} tiles but ring_size is {}; they must match.",
-        post_all_gather_stats_block_tiles,
-        num_distributed_devices);
+    uint32_t post_all_gather_stats_block_tiles = ring_size;
 
     uint32_t in0_CB_size = in0_block_tiles * in_single_tile_size;
     // block size for in1 (tensor b)

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/rms_allgather_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/rms_allgather_nanobind.cpp
@@ -33,14 +33,12 @@ void bind_fused_rms_minimal(nb::module_& mod) {
               Blackhole DRAM is unsupported.
             - weight (gamma): required. ROW_MAJOR layout with 2-D shape (N/32, 32); dtype FLOAT32 or
               BFLOAT16. Passing weight=None is not supported.
-            - stats: optional. Backs the op's internal all-gather circular buffer. When omitted
-              (the default), the op allocates its own transient, trace-native L1 scratch sized to
-              the number of devices on ``cluster_axis`` -- prefer this. If provided, it must be a
-              tiled, width-sharded L1 tensor replicated across the mesh with per-device shape
-              (1, 1, 32, num_devices_on_cluster_axis * 32) on a single core, and its dtype MUST match 
-              the compute accumulation format: FLOAT32 when fp32_dest_acc_en is enabled, otherwise 
-              BFLOAT16. A stats buffer whose tile width does not equal the cluster-axis device count 
-              is rejected.
+            - stats: optional. Backs the op's internal all-gather circular buffer. Prefer omitting it
+              (the default), in which case the op allocates its own transient, trace-native L1
+              scratch. If provided, it must be a tiled, width-sharded L1 tensor replicated across the
+              mesh on a single core, with per-device shape (1, 1, 32, 32 * number of devices on
+              ``cluster_axis``); a narrower buffer is rejected. Its dtype MUST match the compute 
+              accumulation format: FLOAT32 when fp32_dest_acc_en is enabled, otherwise BFLOAT16.
             - memory_config (output): must be a sharded config whose buffer type and memory layout
               match the input's. Interleaved output configs are not accepted; reshard the result
               afterward if a downstream consumer needs interleaved/DRAM.

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/rms_allgather_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/rms_allgather_nanobind.cpp
@@ -36,9 +36,10 @@ void bind_fused_rms_minimal(nb::module_& mod) {
             - stats: optional. Backs the op's internal all-gather circular buffer. Prefer omitting it
               (the default), in which case the op allocates its own transient, trace-native L1
               scratch. If provided, it must be a tiled, width-sharded L1 tensor replicated across the
-              mesh on a single core, with per-device shape (1, 1, 32, 32 * number of devices on
-              ``cluster_axis``); a narrower buffer is rejected. Its dtype MUST match the compute 
-              accumulation format: FLOAT32 when fp32_dest_acc_en is enabled, otherwise BFLOAT16.
+              mesh, with a per-core shard shape of (32, 32 * number of devices on ``cluster_axis``);
+              a narrower shard is rejected, since the circular buffer is bound to a single core's
+              bank. Its dtype must be consistent with the compute config accumulation (FLOAT32 when
+              fp32_dest_acc_en is enabled, else BFLOAT16).
             - memory_config (output): must be a sharded config whose buffer type and memory layout
               match the input's. Interleaved output configs are not accepted; reshard the result
               afterward if a downstream consumer needs interleaved/DRAM.

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/rms_allgather_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/rms_allgather_nanobind.cpp
@@ -33,10 +33,14 @@ void bind_fused_rms_minimal(nb::module_& mod) {
               Blackhole DRAM is unsupported.
             - weight (gamma): required. ROW_MAJOR layout with 2-D shape (N/32, 32); dtype FLOAT32 or
               BFLOAT16. Passing weight=None is not supported.
-            - stats: required. A pre-allocated tiled, width-sharded tensor of shape
-              (1, 1, 32, num_devices) that backs the op's internal all-gather circular buffer.
-              Passing stats=None is not supported, and its dtype MUST match the compute accumulation format:
-              FLOAT32 when fp32_dest_acc_en is enabled, otherwise BFLOAT16.
+            - stats: optional. Backs the op's internal all-gather circular buffer. When omitted
+              (the default), the op allocates its own transient, trace-native L1 scratch sized to
+              the number of devices on ``cluster_axis`` -- prefer this. If provided, it must be a
+              tiled, width-sharded L1 tensor replicated across the mesh with per-device shape
+              (1, 1, 32, num_devices_on_cluster_axis * 32) on a single core, and its dtype MUST match 
+              the compute accumulation format: FLOAT32 when fp32_dest_acc_en is enabled, otherwise 
+              BFLOAT16. A stats buffer whose tile width does not equal the cluster-axis device count 
+              is rejected.
             - memory_config (output): must be a sharded config whose buffer type and memory layout
               match the input's. Interleaved output configs are not accepted; reshard the result
               afterward if a downstream consumer needs interleaved/DRAM.


### PR DESCRIPTION
### PR Category
Bug fix

### Summary

Two fixes to the `stats` buffer in `fused_rms_minimal`.

**1. The cross-device count now comes from `ring_size` instead of the caller's buffer width.**
This op does an `all_gather` to get the local `E[x²]` partial from each device on its `cluster_axis`. It currently determines how many devices are on each `cluster_axis` by the size of the allocated `stats` cb:
```
num_distributed_devices = stats.padded_shape()[-1] / TILE_WIDTH;
```

This means in order to properly `all_gather`, the stats buffer size must be `[1,1,32,num_distributed_devices * TILE_WIDTH]` and replicated on each device. However, in most unit tests (and in tt-mlir) this is set incorrectly resulting in incorrect `all_gather` results. **This causes a drop in PCC** for a 2 layer kimi-k2 test in tt-xla (0.988 fused vs 0.995 decomposed).

Now use `ring_size` directly to determine `num_distributed_devices`. A `stats` buffer narrower than `ring_size` tiles is now a `TT_FATAL` rather than silently disabling cross-device averaging.

**2. `stats` is now optional.** 
When `nullopt`, the op allocates and releases it itself. This can be done since `stats` is not an input or an output and its size, dtype, layout and core placement can all be determined by the op's own program construction.

tt-mlir previously had to pre-allocate it as a hoisted `ttnn::empty`, and since it emitted no matching `ttnn::deallocate` the buffer stayed in L1 for the whole program. In a 2 layers of Kimi-K2 it eventually collides with a later op's circular buffers.

With this change tt-mlir can now allow the op to handle creation and deallocation of the `stats` buffer. A caller-side `ttnn::deallocate` wouldn't fix the L1 OOM when trace is enabled since anything the caller allocates must exist before capture and stay resident for the life of the trace.

Relates to: https://github.com/tenstorrent/tt-xla/issues/5558
Companion tt-mlir change: `gengelage/kimi-k2-fix-testing-v3`

### Why the tests changed

All six stats buffers in `rms_test.py` were narrower than `ring_size`, and now hit the new assert. Changed to build `(32, num_devices * 32)` replicated, matching _models/demos/llama3_70b_galaxy/tt/llama_ccl.py_. Same fix in `test_distributed_rms_norm_decode_configs.py`. The gtest in `test_graph_query_op_constraints.cpp` hardcoded 16 tiles on an 8-device mesh; it now derives the width from the mesh.

**New:** _tests/nightly/tg/ccl/test_rms_internal_stats_heterogeneous.py_. No existing test could catch this bug, because they all use near-homogeneous data where the wrong divisor barely changes the answer. This test scales device `d`'s hidden slice by `(d+1)`, spreading `E[x²]` ~64× across 8 devices, then checks the output against the true full-hidden golden and against a per-device golden. It also asserts an undersized buffer is now rejected.


### Notes for reviewers

This fixes the dominant low PCC cause only. The fused kernel also hardcodes the legacy rsqrt while the decomposed path uses the accurate default, so fused lands at ~0.99992 against decompose's 0.999997. Tracked separately in https://github.com/tenstorrent/tt-metal/issues/51420.

These changes have been tested locally for the kimi-k2 2 layer benchmark test in tt-xla and restore PCC to what is expected (what decomposed op produces).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=gengelage/distributed-rms-norm-stats-buffer-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:gengelage/distributed-rms-norm-stats-buffer-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=gengelage/distributed-rms-norm-stats-buffer-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:gengelage/distributed-rms-norm-stats-buffer-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=gengelage/distributed-rms-norm-stats-buffer-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:gengelage/distributed-rms-norm-stats-buffer-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=gengelage/distributed-rms-norm-stats-buffer-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:gengelage/distributed-rms-norm-stats-buffer-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=gengelage/distributed-rms-norm-stats-buffer-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:gengelage/distributed-rms-norm-stats-buffer-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=gengelage/distributed-rms-norm-stats-buffer-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:gengelage/distributed-rms-norm-stats-buffer-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=gengelage/distributed-rms-norm-stats-buffer-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:gengelage/distributed-rms-norm-stats-buffer-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=gengelage/distributed-rms-norm-stats-buffer-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:gengelage/distributed-rms-norm-stats-buffer-fix)