### PR TITLE
[Profiler] Add back device kernel time columns in perf report on quasar

### DIFF
--- a/tools/tracy/process_ops_logs.py
+++ b/tools/tracy/process_ops_logs.py
@@ -165,11 +165,7 @@ _QUASAR_COLS_TO_REMOVE = {
     "DEVICE TRISC1 KERNEL DURATION [ns]",
     "DEVICE TRISC2 KERNEL DURATION [ns]",
     "DEVICE ERISC KERNEL DURATION [ns]",
-    # cross-clock-domain aggregate durations (span DM + Neo-TRISC) -> no single-clock ns
-    "DEVICE KERNEL DURATION [ns]",
-    "DEVICE KERNEL DURATION DM START [ns]",
-    "DEVICE KERNEL FIRST TO LAST START [ns]",
-    # DM-start op-to-op (mixes DM+Neo-TRISC cycles)
+    # Replaced on Quasar by the per-type OP TO OP DM/TRISC LATENCY columns
     "OP TO OP LATENCY BR/NRISC START [ns]",
 }
 # Stale [ns] row keys to strip so the strict DictWriter accepts the reshaped rows.
@@ -178,8 +174,7 @@ _QUASAR_STALE_ROW_KEYS = list(_QUASAR_COLS_TO_REMOVE) + list(_QUASAR_COL_REPLACE
 
 def shape_device_headers_for_quasar(headers):
     """Rewrite the fixed device-timing headers for a Quasar report: replace certain single-processor-type
-    columns in place with two per-type [ns] columns (DM / Neo-TRISC), and drop the cross-clock-domain
-    aggregate durations. All other columns are unchanged."""
+    columns in place with two per-type [ns] columns (DM / Neo-TRISC). All other columns are unchanged."""
     shaped = []
     for header in headers:
         if header in _QUASAR_COL_REPLACEMENTS:

--- a/tt_metal/impl/profiler/profiler_analysis.cpp
+++ b/tt_metal/impl/profiler/profiler_analysis.cpp
@@ -56,7 +56,32 @@ NLOHMANN_JSON_SERIALIZE_ENUM(
      {RiscType::TRISC_1, "TRISC_1"},
      {RiscType::TRISC_2, "TRISC_2"},
      {RiscType::TENSIX_RISC_AGG, "TENSIX_RISC_AGG"},
-     {RiscType::ERISC, "ERISC"}});
+     {RiscType::ERISC, "ERISC"},
+     {RiscType::NONE, "NONE"},
+     {RiscType::QUASAR_DM0, "QUASAR_DM0"},
+     {RiscType::QUASAR_DM1, "QUASAR_DM1"},
+     {RiscType::QUASAR_DM2, "QUASAR_DM2"},
+     {RiscType::QUASAR_DM3, "QUASAR_DM3"},
+     {RiscType::QUASAR_DM4, "QUASAR_DM4"},
+     {RiscType::QUASAR_DM5, "QUASAR_DM5"},
+     {RiscType::QUASAR_DM6, "QUASAR_DM6"},
+     {RiscType::QUASAR_DM7, "QUASAR_DM7"},
+     {RiscType::QUASAR_NEO0_TRISC0, "QUASAR_NEO0_TRISC0"},
+     {RiscType::QUASAR_NEO0_TRISC1, "QUASAR_NEO0_TRISC1"},
+     {RiscType::QUASAR_NEO0_TRISC2, "QUASAR_NEO0_TRISC2"},
+     {RiscType::QUASAR_NEO0_TRISC3, "QUASAR_NEO0_TRISC3"},
+     {RiscType::QUASAR_NEO1_TRISC0, "QUASAR_NEO1_TRISC0"},
+     {RiscType::QUASAR_NEO1_TRISC1, "QUASAR_NEO1_TRISC1"},
+     {RiscType::QUASAR_NEO1_TRISC2, "QUASAR_NEO1_TRISC2"},
+     {RiscType::QUASAR_NEO1_TRISC3, "QUASAR_NEO1_TRISC3"},
+     {RiscType::QUASAR_NEO2_TRISC0, "QUASAR_NEO2_TRISC0"},
+     {RiscType::QUASAR_NEO2_TRISC1, "QUASAR_NEO2_TRISC1"},
+     {RiscType::QUASAR_NEO2_TRISC2, "QUASAR_NEO2_TRISC2"},
+     {RiscType::QUASAR_NEO2_TRISC3, "QUASAR_NEO2_TRISC3"},
+     {RiscType::QUASAR_NEO3_TRISC0, "QUASAR_NEO3_TRISC0"},
+     {RiscType::QUASAR_NEO3_TRISC1, "QUASAR_NEO3_TRISC1"},
+     {RiscType::QUASAR_NEO3_TRISC2, "QUASAR_NEO3_TRISC2"},
+     {RiscType::QUASAR_NEO3_TRISC3, "QUASAR_NEO3_TRISC3"}});
 }  // namespace tracy
 
 namespace tt::tt_metal {
@@ -256,8 +281,10 @@ bool matches_start_end_config(const tracy::TTDeviceMarker& marker, const Analysi
                marker.marker_name_keyword_flags, start_end_config.marker_name_keywords);
 }
 
-// Fixed per-processor-type clock (MHz) for Quasar. A DM core targets 2.0 GHz and a Neo TRISC
-// targets 1.4 GHz; the emulator reports aiclk=0, so these fixed clocks are used instead.
+// Fixed per-processor-type clock (MHz) for Quasar. NEO TRISCs run at 1.4 GHz; DMs read the NEO TRISC
+// wall clock for now, so DM and TRISC timestamps share one timeline and can be compared directly.
+// TODO: update the DM clock frequency once the DMs read their own clock counter and the DM and TRISC
+// clock domains are synchronized.
 // Returns nullopt for non-Quasar RISCs (WH/BH), which fall back to the runtime device aiclk.
 std::optional<int> quasar_processor_clock_mhz(tracy::RiscType risc) {
     using tracy::RiscType;
@@ -266,7 +293,7 @@ std::optional<int> quasar_processor_clock_mhz(tracy::RiscType risc) {
             static_cast<int>(RiscType::QUASAR_NEO3_TRISC3) - static_cast<int>(RiscType::QUASAR_NEO0_TRISC0) == 15,
         "quasar_processor_clock_mhz relies on contiguous QUASAR_DM*/QUASAR_NEO*_TRISC* enum blocks");
     if (risc >= RiscType::QUASAR_DM0 && risc <= RiscType::QUASAR_DM7) {
-        return 2000;  // DM: 2.0 GHz
+        return 1400;  // Quasar DM: 1.4 GHz (reads the NEO TRISC wall clock for now)
     }
     if (risc >= RiscType::QUASAR_NEO0_TRISC0 && risc <= RiscType::QUASAR_NEO3_TRISC3) {
         return 1400;  // Neo TRISC: 1.4 GHz

--- a/tt_metal/tools/profiler/cpp_device_analyses.json
+++ b/tt_metal/tools/profiler/cpp_device_analyses.json
@@ -94,9 +94,9 @@
             "end_timestamp_header": "DEVICE KERNEL DM END CYCLE"
         },
         "start_config": {
-            "risc": ["BRISC", "NCRISC", "ERISC"],
+            "risc": ["BRISC", "NCRISC", "ERISC", "QUASAR_DM0", "QUASAR_DM1", "QUASAR_DM2", "QUASAR_DM3", "QUASAR_DM4", "QUASAR_DM5", "QUASAR_DM6", "QUASAR_DM7"],
             "marker_type": "ZONE_START",
-            "marker_name_keywords": ["BRISC-KERNEL", "NCRISC-KERNEL", "ERISC-KERNEL"]
+            "marker_name_keywords": ["BRISC-KERNEL", "NCRISC-KERNEL", "ERISC-KERNEL", "DM-KERNEL"]
         },
         "end_config": {
             "marker_type": "ZONE_END",

--- a/tt_metal/tools/profiler/kernel_profiler.hpp
+++ b/tt_metal/tools/profiler/kernel_profiler.hpp
@@ -212,10 +212,15 @@ inline __attribute__((always_inline)) bool bufferHasRoom(uint32_t additional_slo
 #if defined(ARCH_QUASAR)
 inline __attribute__((always_inline)) uint64_t quasar_read_wall_clock_64() {
 #if defined(COMPILE_FOR_TRISC)
+    // The wall clock counter is per-Neo. Empirically the four Neo wall clocks are synchronized and
+    // cycle-aligned, so a TRISC reading its own Neo's clock stays on the same timeline as the others.
+    // Guaranteeing that synchronization explicitly would be better, see the TODO below.
     constexpr uint32_t wall_clock_0_addr = LOCAL_REGS_BASE + NEO_REGS_0__LOCAL_REGS_DEBUG_REGS_WALL_CLOCK_0_REG_OFFSET;
     constexpr uint32_t wall_clock_1_at_addr =
         LOCAL_REGS_BASE + NEO_REGS_0__LOCAL_REGS_DEBUG_REGS_WALL_CLOCK_1_AT_REG_OFFSET;
 #else
+    // DMs read NEO0's wall clock counter, so DM and TRISC timestamps share one timeline and can be compared directly.
+    // TODO: switch to read the DM's own wall clock and synchronize DM and TRISC clock domains.
     constexpr uint32_t wall_clock_0_addr = NEO_REGS_0__LOCAL_REGS_DEBUG_REGS_WALL_CLOCK_0_REG_ADDR;
     constexpr uint32_t wall_clock_1_at_addr = NEO_REGS_0__LOCAL_REGS_DEBUG_REGS_WALL_CLOCK_1_AT_REG_ADDR;
 #endif


### PR DESCRIPTION
### Summary
Relates to #48927 
On quasar, both DM and TRISC read NEO0 's wall clock counter, so they share one timeline and can be compared directly. We can switch DMs to read their own wall clock once we have a mechanism to synchronize DM and TRISC clocks. The NEO wall clock counter register is per-NEO, however empirically the four NEO wall clock counters are aligned and synchronized. 
Since the DM and TRISC share on timeline for now, we can bring back the device kernel time columns in the ops perf report on quasar.

Testing

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-profiler.yaml/badge.svg?branch=shengxiangji/profiler-wallclock-48927)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-profiler.yaml?query=branch:shengxiangji/profiler-wallclock-48927)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml/badge.svg?branch=shengxiangji/profiler-wallclock-48927)](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml?query=branch:shengxiangji/profiler-wallclock-48927)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=shengxiangji/profiler-wallclock-48927)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:shengxiangji/profiler-wallclock-48927)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=shengxiangji/profiler-wallclock-48927)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:shengxiangji/profiler-wallclock-48927)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=shengxiangji/profiler-wallclock-48927)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:shengxiangji/profiler-wallclock-48927)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=shengxiangji/profiler-wallclock-48927)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:shengxiangji/profiler-wallclock-48927)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=shengxiangji/profiler-wallclock-48927)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:shengxiangji/profiler-wallclock-48927)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=shengxiangji/profiler-wallclock-48927)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:shengxiangji/profiler-wallclock-48927)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=shengxiangji/profiler-wallclock-48927)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:shengxiangji/profiler-wallclock-48927)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=shengxiangji/profiler-wallclock-48927)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:shengxiangji/profiler-wallclock-48927)