### PR TITLE
Change test_dispatch_combine_perf baselines from 25k single-shot to 5k chunked captured picks; DSv3, Kimi2.6, GLM5.2

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/perf/test_dispatch_combine_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_dispatch_combine_perf.py
@@ -3,70 +3,82 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-Device performance tests for DeepSeek V3 MoE dispatch and combine operations.
+Device performance tests for DeepSeek/Kimi MoE dispatch and combine operations.
 
-Replays the 4 hottest (layer, col) pairs from the real longbook_qa_eng_25600
-prefill capture on LB 8x1 — one worker spawn per (layer, col, topology) runs
-TtDispatchModule → production layout transform (squeeze → TILE+bfp8 → unsqueeze)
-→ TtCombineModule(init_zeros=True) end-to-end on device. Tracy captures
-DispatchDeviceOperation, the layout op(s), and CombineDeviceOperation in one CSV;
-the perf wrapper asserts dispatch and combine independently so a regression
-localizes to the responsible kernel.
+Runs test_prefill_dispatch_combine.py::test_ttnn_dispatch_combine[perf_real_indices]
+on an LB 8x1 mesh. It replays the hottest (layer, col) pairs from a real prefill
+capture. The operation sequence is the same as the production workflow.
+Tests that were ran in order to capture the routing data:
 
-The 256-experts indexing space, top-k=8, experts_per_chip=8 explicit override are
-needed because the captures are Galaxy-global IDs in [0, 256); the loader
-(`load_captured_routing`) remaps them to [0, 64) ∪ {255} so the LB single-col
-combine kernel (first_expert_id=0) interprets them correctly, then slices the
-gate outputs to [0:1] for LB's single dispatch group.
+Ran on Galaxy:
+
+  - test_ds_prefill_transformer_chunked_no_pcc[blackhole-deepseek_v3-mesh-8x4-L61-chunks_eleven-iters1]
+  - test_kimi_prefill_transformer_chunked_no_pcc[blackhole-kimi-mesh-8x4-L61-preload0-chunks_eleven-iters1-margin5pct]
+
+The captures hold Galaxy-global expert IDs; the loader (`load_captured_routing`)
+shifts a column's own experts down to [0, experts_per_col) and sends the rest to
+sentinel (num_routed_experts-1), so the LB single-col combine kernel (first_expert_id=0) interprets
+them correctly, then slices the gate outputs to [0:1] for LB's single dispatch
+group. The per-model kernel config lives in the worker's parametrize entries.
 """
 
 import pytest
 
 from models.demos.deepseek_v3_d_p.utils.perf_utils import run_model_device_perf_test_per_op
 
-# Top 4 absolute hottest (layer, col) pairs from LONGBOOK_QA_ENG_25600.
-# Each token picks 8 of 256 experts; "in-col share" = fraction of those picks
-# landing in the column's 64 experts (uniform random would be 25%).
-_REAL_INDICES_PICKS: list[tuple[int, int]] = [
-    # (layer, col)
-    (27, 2),  # 43.2% in-col share — hottest in the corpus
-    (38, 0),  # 41.2%
-    (50, 0),  # 39.9%
-    (28, 1),  # 39.5%
-]
 _REAL_INDICES_TOPOS = [("linear", 2), ("ring", 2)]
 
-# Per-(topo, nlinks, layer, col) baselines in nanoseconds. Dispatch and combine
-# are developed separately, so each is asserted against its own baseline —
-# a regression localizes to the responsible kernel.
-_DISPATCH_REAL_INDICES_EXPECTED_NS: dict[tuple[str, int, int, int], int] = {
-    # (topo, nlinks, layer, col): expected_ns. Re-centered to the midpoint of the observed
-    # min/max across 16 main-branch CI runs (2026-06-13..18) spanning 5 LB runners
-    # (f01cs01/02/08, f04cs03/04), against LONGBOOK_QA_ENG_25600/expert_routing.safetensors.
-    # Percent comment = dispatch-group in-col share for that layer/col.
-    ("linear", 2, 27, 2): 12_129_621,  # 43.2%
-    ("linear", 2, 38, 0): 7_158_222,  # 41.2%
-    ("linear", 2, 50, 0): 8_484_394,  # 39.9%
-    ("linear", 2, 28, 1): 11_039_234,  # 39.5%
-    ("ring", 2, 27, 2): 7_216_744,
-    ("ring", 2, 38, 0): 5_130_980,
-    ("ring", 2, 50, 0): 4_848_732,
-    ("ring", 2, 28, 1): 5_595_338,
+# Picks come from the production 11x5120 chunked-prefill run (code_debug), for DSv3 and KimiK2.6.
+# One chunk per case: 5120 tokens over the 8-chip dispatch group => seq_len_per_chip 640.
+
+_DS_CHUNK_PICKS = [(19, 2), (29, 0), (42, 3), (24, 1)]  # 37.2 / 37.0 / 36.9 / 36.7 % in-col share
+_KIMI_CHUNK_PICKS = [(45, 2), (48, 0), (44, 1), (50, 1)]  # 38.6 / 38.1 / 37.4 / 37.1 %
+# Baselines are medians over 5 tracy runs on LB 8x1. Key is (topo, nlinks, layer, col).
+_DISPATCH_DS_CHUNK_EXPECTED_NS: dict[tuple[str, int, int, int], int] = {
+    ("linear", 2, 19, 2): 1_533_332,
+    ("linear", 2, 29, 0): 1_926_464,
+    ("linear", 2, 42, 3): 1_552_909,
+    ("linear", 2, 24, 1): 1_308_836,
+    ("ring", 2, 19, 2): 1_042_299,
+    ("ring", 2, 29, 0): 1_071_193,
+    ("ring", 2, 42, 3): 881_885,
+    ("ring", 2, 24, 1): 819_476,
 }
-_COMBINE_REAL_INDICES_EXPECTED_NS: dict[tuple[str, int, int, int], int] = {
-    # Re-baselined to the 2026-06-24 measurement after a combine-kernel speedup.
-    # 2026-06-25: the two linear-8-2link entries below were set from a single optimistic
-    # 06-24 run; real CI measures higher (l27-col2 8.49 ms, l28-col1 9.75 ms), so they are
-    # bumped to the observed values (margin 0.03). Unrelated to the routed-expert FFN change
-    # (it does not touch combine); recheck if a real combine regression is suspected.
-    ("linear", 2, 27, 2): 8_490_000,
-    ("linear", 2, 38, 0): 7_139_837,
-    ("linear", 2, 50, 0): 7_341_465,
-    ("linear", 2, 28, 1): 9_750_000,
-    ("ring", 2, 27, 2): 8_294_634,
-    ("ring", 2, 38, 0): 5_308_695,
-    ("ring", 2, 50, 0): 5_711_088,
-    ("ring", 2, 28, 1): 7_746_036,
+_COMBINE_DS_CHUNK_EXPECTED_NS: dict[tuple[str, int, int, int], int] = {
+    ("linear", 2, 19, 2): 1_749_833,
+    ("linear", 2, 29, 0): 1_874_665,
+    ("linear", 2, 42, 3): 1_376_552,
+    ("linear", 2, 24, 1): 1_318_127,
+    ("ring", 2, 19, 2): 1_412_458,
+    ("ring", 2, 29, 0): 1_377_090,
+    ("ring", 2, 42, 3): 1_042_437,
+    ("ring", 2, 24, 1): 1_030_253,
+}
+_DISPATCH_KIMI_CHUNK_EXPECTED_NS: dict[tuple[str, int, int, int], int] = {
+    ("linear", 2, 45, 2): 1_443_912,
+    ("linear", 2, 48, 0): 1_962_610,
+    ("linear", 2, 44, 1): 1_494_259,
+    ("linear", 2, 50, 1): 1_461_172,
+    ("ring", 2, 45, 2): 1_017_684,
+    ("ring", 2, 48, 0): 1_012_791,
+    ("ring", 2, 44, 1): 1_374_257,
+    ("ring", 2, 50, 1): 1_038_540,
+}
+_COMBINE_KIMI_CHUNK_EXPECTED_NS: dict[tuple[str, int, int, int], int] = {
+    ("linear", 2, 45, 2): 1_489_780,
+    ("linear", 2, 48, 0): 1_673_044,
+    ("linear", 2, 44, 1): 1_795_140,
+    ("linear", 2, 50, 1): 1_410_634,
+    ("ring", 2, 45, 2): 1_213_800,
+    ("ring", 2, 48, 0): 1_238_818,
+    ("ring", 2, 44, 1): 1_600_527,
+    ("ring", 2, 50, 1): 1_166_319,
+}
+
+# model -> (picks, dispatch baselines, combine baselines).
+_MODELS = {
+    "dsv3": (_DS_CHUNK_PICKS, _DISPATCH_DS_CHUNK_EXPECTED_NS, _COMBINE_DS_CHUNK_EXPECTED_NS),
+    "kimi26": (_KIMI_CHUNK_PICKS, _DISPATCH_KIMI_CHUNK_EXPECTED_NS, _COMBINE_KIMI_CHUNK_EXPECTED_NS),
 }
 
 
@@ -80,6 +92,7 @@ def _perf_param_per_op(
     margin: float = 0.03,
     captured_layer: int | None = None,
     captured_col: int | None = None,
+    model: str = "",
     worker_filter_extras: str | None = "",
     worker_dir: str = "models/demos/deepseek_v3_d_p/tests/perf",
 ):
@@ -97,12 +110,13 @@ def _perf_param_per_op(
     worker_id = f"{topo}-8-{nlinks}link"
     model_name = f"deepseek_v3_{op}_{topo}_8_{nlinks}link"
     use_captured = captured_layer is not None and captured_col is not None
-    parametrize_id = "perf_real_indices" if use_captured else "perf_no_pcc"
+    parametrize_id = f"perf_captured_{model}_chunk" if use_captured else "perf_no_pcc"
     k_filter = f"{parametrize_id} and {worker_id}"
     if worker_filter_extras:
         k_filter += f" and {worker_filter_extras}"
     if use_captured:
-        model_name += f"_real_l{captured_layer:02d}_col{captured_col}"
+        model_name += f"_{model}_l{captured_layer:02d}_col{captured_col}"
+        # TT_DS_USE_CAPTURED_INDICES is not forwarded: the worker reads the same var and inherits it.
         extra_env = {"TT_DS_CAPTURED_LAYER": str(captured_layer), "TT_DS_CAPTURED_COL": str(captured_col)}
     else:
         extra_env = {}
@@ -126,16 +140,19 @@ _DISPATCH_COMBINE_PERF_PARAMS = [
         topo,
         nlinks,
         expected_per_op={
-            "DispatchDeviceOperation": _DISPATCH_REAL_INDICES_EXPECTED_NS[(topo, nlinks, layer, col)],
-            "CombineDeviceOperation": _COMBINE_REAL_INDICES_EXPECTED_NS[(topo, nlinks, layer, col)],
+            "DispatchDeviceOperation": dispatch_ns[(topo, nlinks, layer, col)],
+            "CombineDeviceOperation": combine_ns[(topo, nlinks, layer, col)],
         },
         margin=0.045 if topo == "ring" else 0.03,
         captured_layer=layer,
         captured_col=col,
+        model=model,
         worker_dir="models/demos/deepseek_v3_d_p/tests/perf",
     )
+    for model, (picks, dispatch_ns, combine_ns) in _MODELS.items()
     for topo, nlinks in _REAL_INDICES_TOPOS
-    for layer, col in _REAL_INDICES_PICKS
+    for layer, col in picks
+    if (topo, nlinks, layer, col) in dispatch_ns and (topo, nlinks, layer, col) in combine_ns
 ]
 
 

--- a/models/demos/deepseek_v3_d_p/tests/perf/test_dispatch_combine_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_dispatch_combine_perf.py
@@ -3,17 +3,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-Device performance tests for DeepSeek/Kimi MoE dispatch and combine operations.
+Device performance tests for DeepSeekv3/KimiK2.6/GLM5.2 MoE dispatch and combine operations.
 
-Runs test_prefill_dispatch_combine.py::test_ttnn_dispatch_combine[perf_real_indices]
-on an LB 8x1 mesh. It replays the hottest (layer, col) pairs from a real prefill
+Runs test_prefill_dispatch_combine.py::test_ttnn_dispatch_combine[perf_captured_<model>_chunk]
+(<model> in {dsv3, kimi26, glm52}) on an LB 8x1 mesh. It replays the hottest (layer, col) pairs from a real prefill
 capture. The operation sequence is the same as the production workflow.
 Tests that were ran in order to capture the routing data:
-
-Ran on Galaxy:
-
-  - test_ds_prefill_transformer_chunked_no_pcc[blackhole-deepseek_v3-mesh-8x4-L61-chunks_eleven-iters1]
-  - test_kimi_prefill_transformer_chunked_no_pcc[blackhole-kimi-mesh-8x4-L61-preload0-chunks_eleven-iters1-margin5pct]
 
 The captures hold Galaxy-global expert IDs; the loader (`load_captured_routing`)
 shifts a column's own experts down to [0, experts_per_col) and sends the rest to
@@ -31,96 +26,88 @@ _REAL_INDICES_TOPOS = [("linear", 2), ("ring", 2)]
 # Picks come from the production 11x5120 chunked-prefill run (code_debug), for DSv3 and KimiK2.6.
 # One chunk per case: 5120 tokens over the 8-chip dispatch group => seq_len_per_chip 640.
 
-_DS_CHUNK_PICKS = [(19, 2), (29, 0), (42, 3), (24, 1)]  # 37.2 / 37.0 / 36.9 / 36.7 % in-col share
-_KIMI_CHUNK_PICKS = [(45, 2), (48, 0), (44, 1), (50, 1)]  # 38.6 / 38.1 / 37.4 / 37.1 %
-# Baselines are medians over 5 tracy runs on LB 8x1. Key is (topo, nlinks, layer, col).
-_DISPATCH_DS_CHUNK_EXPECTED_NS: dict[tuple[str, int, int, int], int] = {
-    ("linear", 2, 19, 2): 1_533_332,
-    ("linear", 2, 29, 0): 1_926_464,
-    ("linear", 2, 42, 3): 1_552_909,
-    ("linear", 2, 24, 1): 1_308_836,
-    ("ring", 2, 19, 2): 1_042_299,
-    ("ring", 2, 29, 0): 1_071_193,
-    ("ring", 2, 42, 3): 881_885,
-    ("ring", 2, 24, 1): 819_476,
-}
-_COMBINE_DS_CHUNK_EXPECTED_NS: dict[tuple[str, int, int, int], int] = {
-    ("linear", 2, 19, 2): 1_749_833,
-    ("linear", 2, 29, 0): 1_874_665,
-    ("linear", 2, 42, 3): 1_376_552,
-    ("linear", 2, 24, 1): 1_318_127,
-    ("ring", 2, 19, 2): 1_412_458,
-    ("ring", 2, 29, 0): 1_377_090,
-    ("ring", 2, 42, 3): 1_042_437,
-    ("ring", 2, 24, 1): 1_030_253,
-}
-_DISPATCH_KIMI_CHUNK_EXPECTED_NS: dict[tuple[str, int, int, int], int] = {
-    ("linear", 2, 45, 2): 1_443_912,
-    ("linear", 2, 48, 0): 1_962_610,
-    ("linear", 2, 44, 1): 1_494_259,
-    ("linear", 2, 50, 1): 1_461_172,
-    ("ring", 2, 45, 2): 1_017_684,
-    ("ring", 2, 48, 0): 1_012_791,
-    ("ring", 2, 44, 1): 1_374_257,
-    ("ring", 2, 50, 1): 1_038_540,
-}
-_COMBINE_KIMI_CHUNK_EXPECTED_NS: dict[tuple[str, int, int, int], int] = {
-    ("linear", 2, 45, 2): 1_489_780,
-    ("linear", 2, 48, 0): 1_673_044,
-    ("linear", 2, 44, 1): 1_795_140,
-    ("linear", 2, 50, 1): 1_410_634,
-    ("ring", 2, 45, 2): 1_213_800,
-    ("ring", 2, 48, 0): 1_238_818,
-    ("ring", 2, 44, 1): 1_600_527,
-    ("ring", 2, 50, 1): 1_166_319,
-}
-
-# GLM5.2 picks from its own chunked-prefill capture: 4 worst-case in-col shares + 4 nominal (25%).
+# Column send volume (in-col picks × token bytes) drives device time; ranked by
+# analyze_routing_send.py. Each model gets its 2 hottest columns + 2 at uniform.
+_DS_CHUNK_PICKS = [
+    (19, 2),  # 37.2%
+    (29, 0),  # 37.0%
+    (4, 2),  # 25.0%
+    (56, 3),  # 25.0%
+]
+_KIMI_CHUNK_PICKS = [
+    (45, 2),  # 38.6%
+    (48, 0),  # 38.1%
+    (30, 3),  # 25.0%
+    (32, 1),  # 25.0%
+]
 _GLM52_CHUNK_PICKS = [
-    (3, 0),  # 47.3% in-col share
+    (3, 0),  # 47.3%
     (8, 0),  # 38.5%
-    (6, 1),  # 37.9%
-    (59, 2),  # 37.5%
     (14, 2),  # 25.0%
     (10, 0),  # 25.0%
-    (15, 0),  # 25.0%
-    (55, 3),  # 25.0%
 ]
+# Key is (topo, nlinks, layer, col). Baselines are single tracy runs on LB 8x1
+# (run-to-run spread measured at ~0.5%, well inside the margins below).
+_DISPATCH_DS_CHUNK_EXPECTED_NS: dict[tuple[str, int, int, int], int] = {
+    ("linear", 2, 19, 2): 1_532_188,
+    ("linear", 2, 29, 0): 2_013_572,
+    ("linear", 2, 4, 2): 868_328,
+    ("linear", 2, 56, 3): 1_195_248,
+    ("ring", 2, 19, 2): 969_226,
+    ("ring", 2, 29, 0): 1_074_814,
+    ("ring", 2, 4, 2): 561_040,
+    ("ring", 2, 56, 3): 753_133,
+}
+_COMBINE_DS_CHUNK_EXPECTED_NS: dict[tuple[str, int, int, int], int] = {
+    ("linear", 2, 19, 2): 1_716_614,
+    ("linear", 2, 29, 0): 1_690_610,
+    ("linear", 2, 4, 2): 1_012_207,
+    ("linear", 2, 56, 3): 1_179_193,
+    ("ring", 2, 19, 2): 1_433_990,
+    ("ring", 2, 29, 0): 1_372_652,
+    ("ring", 2, 4, 2): 749_534,
+    ("ring", 2, 56, 3): 905_037,
+}
+_DISPATCH_KIMI_CHUNK_EXPECTED_NS: dict[tuple[str, int, int, int], int] = {
+    ("linear", 2, 45, 2): 1_525_048,
+    ("linear", 2, 48, 0): 2_051_422,
+    ("linear", 2, 30, 3): 984_699,
+    ("linear", 2, 32, 1): 813_274,
+    ("ring", 2, 45, 2): 1_011_584,
+    ("ring", 2, 48, 0): 995_205,
+    ("ring", 2, 30, 3): 594_741,
+    ("ring", 2, 32, 1): 623_676,
+}
+_COMBINE_KIMI_CHUNK_EXPECTED_NS: dict[tuple[str, int, int, int], int] = {
+    ("linear", 2, 45, 2): 1_558_296,
+    ("linear", 2, 48, 0): 1_642_857,
+    ("linear", 2, 30, 3): 1_068_094,
+    ("linear", 2, 32, 1): 1_123_141,
+    ("ring", 2, 45, 2): 1_267_431,
+    ("ring", 2, 48, 0): 1_291_803,
+    ("ring", 2, 30, 3): 870_001,
+    ("ring", 2, 32, 1): 848_981,
+}
+
 _DISPATCH_GLM52_CHUNK_EXPECTED_NS: dict[tuple[str, int, int, int], int] = {
-    ("linear", 2, 3, 0): 3_215_681,
-    ("linear", 2, 8, 0): 1_397_709,
-    ("linear", 2, 6, 1): 1_358_103,
-    ("linear", 2, 59, 2): 1_415_496,
-    ("linear", 2, 14, 2): 833_831,
-    ("linear", 2, 10, 0): 798_669,
-    ("linear", 2, 15, 0): 1_134_878,
-    ("linear", 2, 55, 3): 1_083_619,
-    ("ring", 2, 3, 0): 1_996_679,
-    ("ring", 2, 8, 0): 971_199,
-    ("ring", 2, 6, 1): 858_434,
-    ("ring", 2, 59, 2): 810_205,
-    ("ring", 2, 14, 2): 537_239,
-    ("ring", 2, 10, 0): 505_346,
-    ("ring", 2, 15, 0): 614_447,
-    ("ring", 2, 55, 3): 747_346,
+    ("linear", 2, 3, 0): 3_219_833,
+    ("linear", 2, 8, 0): 1_399_270,
+    ("linear", 2, 14, 2): 838_546,
+    ("linear", 2, 10, 0): 809_860,
+    ("ring", 2, 3, 0): 2_006_807,
+    ("ring", 2, 8, 0): 977_686,
+    ("ring", 2, 14, 2): 543_524,
+    ("ring", 2, 10, 0): 512_407,
 }
 _COMBINE_GLM52_CHUNK_EXPECTED_NS: dict[tuple[str, int, int, int], int] = {
-    ("linear", 2, 3, 0): 2_064_644,
-    ("linear", 2, 8, 0): 1_539_358,
-    ("linear", 2, 6, 1): 1_210_064,
-    ("linear", 2, 59, 2): 1_514_169,
-    ("linear", 2, 14, 2): 885_887,
-    ("linear", 2, 10, 0): 970_758,
-    ("linear", 2, 15, 0): 1_005_250,
-    ("linear", 2, 55, 3): 953_341,
-    ("ring", 2, 3, 0): 1_549_368,
-    ("ring", 2, 8, 0): 1_208_534,
-    ("ring", 2, 6, 1): 1_022_902,
-    ("ring", 2, 59, 2): 1_176_984,
-    ("ring", 2, 14, 2): 685_226,
-    ("ring", 2, 10, 0): 792_624,
-    ("ring", 2, 15, 0): 716_709,
-    ("ring", 2, 55, 3): 830_004,
+    ("linear", 2, 3, 0): 2_071_561,
+    ("linear", 2, 8, 0): 1_543_287,
+    ("linear", 2, 14, 2): 898_859,
+    ("linear", 2, 10, 0): 977_011,
+    ("ring", 2, 3, 0): 1_576_451,
+    ("ring", 2, 8, 0): 1_218_739,
+    ("ring", 2, 14, 2): 692_124,
+    ("ring", 2, 10, 0): 806_988,
 }
 
 # model -> (picks, dispatch baselines, combine baselines).

--- a/models/demos/deepseek_v3_d_p/tests/perf/test_dispatch_combine_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_dispatch_combine_perf.py
@@ -75,10 +75,59 @@ _COMBINE_KIMI_CHUNK_EXPECTED_NS: dict[tuple[str, int, int, int], int] = {
     ("ring", 2, 50, 1): 1_166_319,
 }
 
+# GLM5.2 picks from its own chunked-prefill capture: 4 worst-case in-col shares + 4 nominal (25%).
+_GLM52_CHUNK_PICKS = [
+    (3, 0),  # 47.3% in-col share
+    (8, 0),  # 38.5%
+    (6, 1),  # 37.9%
+    (59, 2),  # 37.5%
+    (14, 2),  # 25.0%
+    (10, 0),  # 25.0%
+    (15, 0),  # 25.0%
+    (55, 3),  # 25.0%
+]
+_DISPATCH_GLM52_CHUNK_EXPECTED_NS: dict[tuple[str, int, int, int], int] = {
+    ("linear", 2, 3, 0): 3_215_681,
+    ("linear", 2, 8, 0): 1_397_709,
+    ("linear", 2, 6, 1): 1_358_103,
+    ("linear", 2, 59, 2): 1_415_496,
+    ("linear", 2, 14, 2): 833_831,
+    ("linear", 2, 10, 0): 798_669,
+    ("linear", 2, 15, 0): 1_134_878,
+    ("linear", 2, 55, 3): 1_083_619,
+    ("ring", 2, 3, 0): 1_996_679,
+    ("ring", 2, 8, 0): 971_199,
+    ("ring", 2, 6, 1): 858_434,
+    ("ring", 2, 59, 2): 810_205,
+    ("ring", 2, 14, 2): 537_239,
+    ("ring", 2, 10, 0): 505_346,
+    ("ring", 2, 15, 0): 614_447,
+    ("ring", 2, 55, 3): 747_346,
+}
+_COMBINE_GLM52_CHUNK_EXPECTED_NS: dict[tuple[str, int, int, int], int] = {
+    ("linear", 2, 3, 0): 2_064_644,
+    ("linear", 2, 8, 0): 1_539_358,
+    ("linear", 2, 6, 1): 1_210_064,
+    ("linear", 2, 59, 2): 1_514_169,
+    ("linear", 2, 14, 2): 885_887,
+    ("linear", 2, 10, 0): 970_758,
+    ("linear", 2, 15, 0): 1_005_250,
+    ("linear", 2, 55, 3): 953_341,
+    ("ring", 2, 3, 0): 1_549_368,
+    ("ring", 2, 8, 0): 1_208_534,
+    ("ring", 2, 6, 1): 1_022_902,
+    ("ring", 2, 59, 2): 1_176_984,
+    ("ring", 2, 14, 2): 685_226,
+    ("ring", 2, 10, 0): 792_624,
+    ("ring", 2, 15, 0): 716_709,
+    ("ring", 2, 55, 3): 830_004,
+}
+
 # model -> (picks, dispatch baselines, combine baselines).
 _MODELS = {
     "dsv3": (_DS_CHUNK_PICKS, _DISPATCH_DS_CHUNK_EXPECTED_NS, _COMBINE_DS_CHUNK_EXPECTED_NS),
     "kimi26": (_KIMI_CHUNK_PICKS, _DISPATCH_KIMI_CHUNK_EXPECTED_NS, _COMBINE_KIMI_CHUNK_EXPECTED_NS),
+    "glm52": (_GLM52_CHUNK_PICKS, _DISPATCH_GLM52_CHUNK_EXPECTED_NS, _COMBINE_GLM52_CHUNK_EXPECTED_NS),
 }
 
 

--- a/models/demos/deepseek_v3_d_p/tests/perf/test_prefill_dispatch_combine.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_prefill_dispatch_combine.py
@@ -13,7 +13,9 @@ one CSV; the perf wrapper asserts each independently.
 Required env vars (set by the parent perf test via extra_env):
     TT_DS_CAPTURED_LAYER          int, MoE layer index
     TT_DS_CAPTURED_COL            int, Galaxy column [0, 4)
-    TT_DS_USE_CAPTURED_INDICES    optional path override (defaults to LONGBOOK_QA_ENG_25600)
+    TT_DS_USE_CAPTURED_INDICES    path to expert_routing_dispatch_combine_perf.safetensors, the
+                                  chunked-prefill capture holding every model's cases
+                                  (required; there is no default capture)
 """
 
 import os
@@ -24,6 +26,8 @@ from loguru import logger
 from tracy import signpost
 
 import ttnn
+from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3Config
+from models.demos.deepseek_v3_d_p.reference.kimi_k2_6_config import KimiK26Config
 from models.demos.deepseek_v3_d_p.tests.pcc.mesh_configs import ALL_MESH_CONFIGS
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import (
     compute_constants,
@@ -36,11 +40,40 @@ from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import (
 from models.demos.deepseek_v3_d_p.tt.moe.tt_combine import TtCombineModule
 from models.demos.deepseek_v3_d_p.tt.moe.tt_dispatch import TtDispatchModule
 
+# Geometry of the replay, not of any model: LB 8x1 stands in for ONE column of the Galaxy the
+# capture was taken on, which has 4 columns of 8 chips.
+GALAXY_NUM_DISPATCH_GROUPS = 4
+DISPATCH_GROUP_SIZE = 8
+CHUNK = 5 * 1024  # tokens per chunk in the chunked-prefill run the captures come from
+DISPATCH_BUFFER_CAPACITY_FACTOR = 8
 
+
+# One entry per model whose chunked-prefill capture we replay; add a model by extending this list.
+_CHUNK_MODELS = [("dsv3", DeepSeekV3Config), ("kimi26", KimiK26Config)]
+
+
+# One chunk (5120 tokens) spread over the 8-chip dispatch group => seq_len_per_chip 640. Expert
+# count / embedding size come off each reference config, so they live in one place;
+# experts_per_chip = experts_per_col / 8 (dsv3 256/4/8 = 8, kimi26 384/4/8 = 12), and
+# model selects the per-model capture file (expert_routing_dispatch_combine_perf_<model>.safetensors).
+# The parametrize id is what test_dispatch_combine_perf selects with `-k "<id> and ..."`; since -k
+# matches substrings, no id may be a prefix of another or it would silently pull in the wrong entry too.
 @pytest.mark.parametrize(
     "seq_len_per_chip, emb_dim, num_routed_experts, num_experts_per_tok, "
-    "dispatch_buffer_capacity_factor, experts_per_chip_override",
-    [pytest.param(3200, 7168, 256, 8, 8, 8, id="perf_real_indices")],
+    "dispatch_buffer_capacity_factor, experts_per_chip_override, model",
+    [
+        pytest.param(
+            CHUNK // DISPATCH_GROUP_SIZE,
+            cfg.EMB_SIZE,
+            cfg.NUM_ROUTED_EXPERTS,
+            cfg.NUM_EXPERTS_PER_TOKEN,
+            DISPATCH_BUFFER_CAPACITY_FACTOR,
+            cfg.NUM_ROUTED_EXPERTS // GALAXY_NUM_DISPATCH_GROUPS // DISPATCH_GROUP_SIZE,
+            model,
+            id=f"perf_captured_{model}_chunk",
+        )
+        for model, cfg in _CHUNK_MODELS
+    ],
 )
 @pytest.mark.parametrize(
     "mesh_device, device_params, num_links, topology",
@@ -58,6 +91,7 @@ def test_ttnn_dispatch_combine(
     num_links,
     topology,
     experts_per_chip_override,
+    model,
 ):
     layer_str = os.getenv("TT_DS_CAPTURED_LAYER")
     col_str = os.getenv("TT_DS_CAPTURED_COL")
@@ -98,7 +132,8 @@ def test_ttnn_dispatch_combine(
         f"num_dispatch_groups(mesh)={num_dispatch_groups}"
     )
 
-    # Load captured routing (indices remapped to [0, 64) ∪ {255}, col-0 dispatch table).
+    # Load captured routing (in-col indices shifted to [0, experts_per_col), rest -> sentinel 255,
+    # col-0 dispatch table).
     indices, expert_dispatch_table = load_captured_routing(
         dispatch_group_size=dispatch_group_size,
         seq_len_per_chip=seq_len_per_chip,
@@ -106,6 +141,7 @@ def test_ttnn_dispatch_combine(
         num_experts_per_tok=num_experts_per_tok,
         layer=int(layer_str),
         col=int(col_str),
+        model=model,
         captured_indices_path=os.getenv("TT_DS_USE_CAPTURED_INDICES"),
     )
 

--- a/models/demos/deepseek_v3_d_p/tests/perf/test_prefill_dispatch_combine.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_prefill_dispatch_combine.py
@@ -27,6 +27,7 @@ from tracy import signpost
 
 import ttnn
 from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3Config
+from models.demos.deepseek_v3_d_p.reference.glm_5_2_config import GLM52Config
 from models.demos.deepseek_v3_d_p.reference.kimi_k2_6_config import KimiK26Config
 from models.demos.deepseek_v3_d_p.tests.pcc.mesh_configs import ALL_MESH_CONFIGS
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import (
@@ -49,7 +50,7 @@ DISPATCH_BUFFER_CAPACITY_FACTOR = 8
 
 
 # One entry per model whose chunked-prefill capture we replay; add a model by extending this list.
-_CHUNK_MODELS = [("dsv3", DeepSeekV3Config), ("kimi26", KimiK26Config)]
+_CHUNK_MODELS = [("dsv3", DeepSeekV3Config), ("kimi26", KimiK26Config), ("glm52", GLM52Config)]
 
 
 # One chunk (5120 tokens) spread over the 8-chip dispatch group => seq_len_per_chip 640. Expert

--- a/models/demos/deepseek_v3_d_p/tt/moe/init_helpers.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/init_helpers.py
@@ -647,6 +647,7 @@ def load_captured_routing(
     num_experts_per_tok: int,
     layer: int,
     col: int,
+    model: str,
     captured_indices_path: str = None,
 ):
     """Load real captured Galaxy gate indices, remapped to run one Galaxy column on LB 8x1.
@@ -654,37 +655,38 @@ def load_captured_routing(
     What the capture contains
     -------------------------
     `expert_routing.safetensors[expert_ids_layer_<L>]` holds one tensor per MoE layer
-    of shape `(total_tokens=25600, top_k=8)` int32, with values in `[0, num_routed_experts=256)`.
+    of shape `(total_tokens=5120, top_k=num_experts_per_tok)` int32, with values in `[0, num_routed_experts)`.
     Those are **Galaxy-global expert IDs**. We `view` it into the worker's expected
-    `(dispatch_group_size=8, seq_len_per_chip=3200, top_k=8)` layout.
+    `(dispatch_group_size=8, seq_len_per_chip=640, top_k=num_experts_per_tok)` layout.
 
-    Galaxy 8x4 owns 256 experts split across 4 dispatch columns × 8 chips:
+    Galaxy 8x4 owns num_routed_experts experts split across 4 dispatch columns × 8 chips:
 
-        col 0:  expert IDs [  0,  64), 8 experts per chip (chips 0..7 = ids 0..7, 8..15, ...)
-        col 1:  expert IDs [ 64, 128)
-        col 2:  expert IDs [128, 192)
-        col 3:  expert IDs [192, 256)
+        offset = num_routed_experts / 4
+        col 0:  expert IDs [  0,  offset), num_routed_experts/32 experts per chip (chip 0 = ids [0, num_routed_experts/32), chip 1 = [num_routed_experts/32, 2*num_routed_experts/32), ...)
+        col 1:  expert IDs [ offset, 2*offset)
+        col 2:  expert IDs [2*offset, 3*offset)
+        col 3:  expert IDs [3*offset, 4*offset)
 
-    LB 8x1 has only one column, 8 chips, 8 experts/chip = 64 physical experts.
+    LB 8x1 has only one column, 8 chips, num_routed_experts/32 experts/chip = num_routed_experts/4 physical experts.
     The LB combine kernel hard-codes `first_expert_id=0`, so every expert ID it
-    sees in metadata must fit in `[0, num_routed_experts_per_col=64)` or be a
-    skip-sentinel — anything in `[64, 256)` would index past the per-chip
+    sees in metadata must fit in `[0, num_routed_experts_per_col)` or be a
+    skip-sentinel — anything in `[num_routed_experts_per_col, num_routed_experts)` would index past the per-chip
     `expert_token_counts` array and silently corrupt outputs.
 
     The remap
     ---------
     For a chosen Galaxy column `k`, we transform every captured value `v`:
 
-        in-col routes (v in [k*64, (k+1)*64))   →  v - k*64      (shifts into [0, 64))
-        out-of-col routes (everything else)     →  255           (sentinel)
+        in-col routes (v in [k*num_routed_experts_per_col, (k+1)*num_routed_experts_per_col))   →  v - k*num_routed_experts_per_col      (shifts into [0, num_routed_experts_per_col))
+        out-of-col routes (everything else)     →  num_routed_experts - 1           (sentinel)
 
-    We then build the dispatch table.  `ExpertMapping.create_dispatch_table(256, 8, 4)`
-    returns the full Galaxy 4-row table of shape `(4, 256)`; we slice `[0:1]` to get a
-    `(1, 256)` tensor — one row, to match LB's single-col mesh.  The slice's contents:
+    We then build the dispatch table.  `ExpertMapping.create_dispatch_table(num_routed_experts, 8, 4)`
+    returns the full Galaxy 4-row table of shape `(4, num_routed_experts)`; we slice `[0:1]` to get a
+    `(1, num_routed_experts)` tensor — one row, to match LB's single-col mesh.  The slice's contents:
 
-        table[0,  0..63]   = [0,0,0,0,0,0,0,0, 1,1,...,1, ..., 7,7,7,7,7,7,7,7]   (chip ids, 8 per chip)
-        table[0, 64..255]  = -1                                                    (kernel reads -1 → skip)
-        table[0, 255]      = -1                                                    (== sentinel target)
+        table[0,  0..num_routed_experts_per_col-1]   = [0,0,0,0,0,0,0,0, 1,1,...,1, ..., 7,7,7,7,7,7,7,7]   (chip ids, 8 per chip)
+        table[0, num_routed_experts_per_col..num_routed_experts-1]  = -1                                                    (kernel reads -1 → skip)
+        table[0, num_routed_experts-1]      = -1                                                    (== sentinel target)
 
     The chip-assignment function `chip_id = local_id // 8` is identical across every
     Galaxy column's row, so using row 0 against remapped (in-col-shifted) indices
@@ -693,20 +695,29 @@ def load_captured_routing(
         Galaxy expert 135 (col 2 local 7)  →  Galaxy table[2, 135] = chip 0
         After remap:        value becomes 7  →  LB table[0,   7]   = chip 0   (match)
 
-    Out-of-col routes (sentinel 255) hit `table[0, 255] = -1` and the kernel skips
+    Out-of-col routes (sentinel num_routed_experts-1) hit `table[0, num_routed_experts-1] = -1` and the kernel skips
     them — preserving Galaxy col k's true per-col routing share 1:1 with no spurious
-    work on the other 192 globals.
+    work on the other X globals.
 
-    Worked example: longbook L27 token 0, captured-col=2
-    ----------------------------------------------------
-    The 8 picks for chip 0 token 0 in longbook_qa_eng_25600 L27 are::
+    Worked example: captured column k = 2
+    -------------------------------------
+    Symbols: E = experts_per_col = num_routed_experts // 4; G = dispatch_group_size = 8
+    (chips per column, so G experts per chip); sentinel = num_routed_experts - 1. Column k
+    owns global IDs [k*E, (k+1)*E); the remap shifts an in-col pick v to v - k*E and sends
+    everything else to the sentinel. Its chip is then (v - k*E) // G.
+
+    dsv3 (num_routed_experts=256 → E=64, sentinel=255), one token's 8 picks::
 
         raw   :  [138, 147,  79,  30, 150, 120,  72, 154]
         in-col:  [ ✓,   ✓,   ✗,   ✗,   ✓,   ✗,   ✗,   ✓ ]    (col 2 range = [128, 192))
-        remap :  [ 10,  19, 255, 255,  22, 255, 255,  26]
+        remap :  [ 10,  19, 255, 255,  22, 255, 255,  26]    (out-of-col → sentinel 255)
         route :  [ch1, ch2, skip, skip, ch2, skip, skip, ch3]   (chip_id = remap_value // 8)
 
-    Verification — Galaxy would have routed the same picks via its col-2 row::
+    kimi26 (num_routed_experts=384 → E=96, sentinel=383) is the same mechanic with a wider
+    column: col 2 range = [192, 288); in-col pick 200 → 200-192 = 8 → chip 1; out-of-col
+    pick 138 → sentinel 383 → skip.
+
+    Verification — Galaxy would have routed the dsv3 picks the same way via its own col-2 row::
 
         table[2, 138] = (138 - 128)//8 = chip 1   (same as our remapped 10 // 8)
         table[2, 147] = (147 - 128)//8 = chip 2   (same as our remapped 19 // 8)
@@ -717,16 +728,18 @@ def load_captured_routing(
     ---------------------------------------------
         layer:                  int, MoE layer index (e.g. 27)
         col:                    int, Galaxy column [0, 4) to simulate
-        captured_indices_path:  optional path override for the safetensors;
-                                defaults to LONGBOOK_QA_ENG_25600/expert_routing.safetensors
+        model:                  str, model name ("dsv3", "kimi26"); selects the per-model
+                                capture file when captured_indices_path is unset
+        captured_indices_path:  path to the capture safetensors; if falsy, falls back to
+                                CODE_DEBUG_5K_CHUNKED / "expert_routing_MODELNAME.safetensors"
 
     Returns
     -------
     (indices, expert_dispatch_table) where:
         indices                 (dispatch_group_size, seq_len_per_chip, num_experts_per_tok)
-                                int32, values in [0, 64) ∪ {255}.
-        expert_dispatch_table   (1, 256) int32 — col 0's row of the Galaxy 4-col table,
-                                with chip IDs [0, 8) for [0, 64) and -1 elsewhere.
+                                int32, values in [0, experts_per_col) ∪ {num_routed_experts-1}.
+        expert_dispatch_table   (1, num_routed_experts) int32 — col 0's row of the Galaxy 4-col
+                                table, with chip IDs [0, 8) for [0, experts_per_col) and -1 elsewhere.
     """
     from pathlib import Path
 
@@ -734,23 +747,20 @@ def load_captured_routing(
 
     if not 0 <= col < GALAXY_NUM_DISPATCH_GROUPS:
         raise ValueError(f"col must be in [0, {GALAXY_NUM_DISPATCH_GROUPS}), got {col}")
-    if num_routed_experts != 256:
-        raise ValueError(
-            f"Captured indices require num_routed_experts=256, got {num_routed_experts}. "
-            "Use a parametrize entry with the matching kernel config (perf_real_indices)."
-        )
 
     if captured_indices_path:
         path = Path(captured_indices_path)
     else:
-        # Lazy import: transformer_helpers itself imports from this module in places.
-        from models.demos.deepseek_v3_d_p.utils.transformer_helpers import LONGBOOK_QA_ENG_25600
+        # Lazy import: transformer_helpers imports from this module in places.
+        from models.demos.deepseek_v3_d_p.utils.transformer_helpers import CODE_DEBUG_5K_CHUNKED
 
-        path = LONGBOOK_QA_ENG_25600 / "expert_routing.safetensors"
+        if model == "kimi26":
+            path = CODE_DEBUG_5K_CHUNKED / "expert_routing_kimi26.safetensors"
+        else:
+            path = CODE_DEBUG_5K_CHUNKED / "expert_routing_dsv3.safetensors"
     if not path.exists():
         raise FileNotFoundError(
-            f"Captured indices file not found at {path}. "
-            "Pass captured_indices_path to override, or configure DEEPSEEK_V3_TRACE_DIR."
+            f"Captured indices file not found at {path} (set TT_DS_USE_CAPTURED_INDICES to override)"
         )
 
     from safetensors import safe_open
@@ -775,13 +785,15 @@ def load_captured_routing(
     if max_idx >= num_routed_experts:
         raise ValueError(f"Captured indices contain expert ID {max_idx} >= num_routed_experts={num_routed_experts}")
 
-    # Remap captured Galaxy-global expert IDs [0, 256) → LB-local [0, 64) ∪ {sentinel}.
-    # LB's combine kernel uses first_expert_id=0 on a single-col mesh, so metadata expert
-    # IDs must fit in [0, num_routed_experts_per_col=64). In-col routings get shifted to
-    # [0, 64); out-of-col routings get sentinel 255 which maps to -1 in col 0's dispatch
-    # table → kernel skips (preserving the per-col routing share 1:1 with Galaxy col k).
-    SENTINEL = 255
+    # Remap captured Galaxy-global expert IDs [0, num_routed_experts) → LB-local
+    # [0, experts_per_col) ∪ {sentinel}. LB's combine kernel uses first_expert_id=0 on a
+    # single-col mesh, so metadata expert IDs must fit in [0, num_routed_experts_per_col).
+    # In-col routings get shifted to [0, experts_per_col); out-of-col routings get the
+    # sentinel num_routed_experts-1 — the last dispatch-table column, which is always -1 in
+    # col 0's table (it is above experts_per_col) → kernel skips, preserving the per-col
+    # routing share 1:1 with Galaxy col k. It is model-dependent (dsv3=255, kimi26=383).
     experts_per_col = num_routed_experts // GALAXY_NUM_DISPATCH_GROUPS
+    SENTINEL = num_routed_experts - 1
     in_col_mask = (indices >= col * experts_per_col) & (indices < (col + 1) * experts_per_col)
     in_col_share = in_col_mask.float().mean().item() * 100.0
     indices = torch.where(
@@ -790,8 +802,8 @@ def load_captured_routing(
         torch.tensor(SENTINEL, dtype=indices.dtype),
     ).contiguous()
 
-    # Always use col 0's row of the (4, 256) Galaxy dispatch table — chip IDs [0, 8) for
-    # experts [0, 64), and -1 for [64, 256). Combined with the remap above, this routes
+    # Always use col 0's row of the (4, num_routed_experts) Galaxy dispatch table — chip IDs [0, 8) for
+    # experts [0, num_routed_experts_per_col), and -1 for [num_routed_experts_per_col, num_routed_experts). Combined with the remap above, this routes
     # in-col indices correctly and skips out-of-col (sentinel) ones.
     galaxy_table = ExpertMapping.create_dispatch_table(
         num_routed_experts=num_routed_experts,

--- a/models/demos/deepseek_v3_d_p/tt/moe/init_helpers.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/init_helpers.py
@@ -756,6 +756,8 @@ def load_captured_routing(
 
         if model == "kimi26":
             path = CODE_DEBUG_5K_CHUNKED / "expert_routing_kimi26.safetensors"
+        elif model == "glm52":
+            path = CODE_DEBUG_5K_CHUNKED / "expert_routing_glm52.safetensors"
         else:
             path = CODE_DEBUG_5K_CHUNKED / "expert_routing_dsv3.safetensors"
     if not path.exists():

--- a/models/demos/deepseek_v3_d_p/tt/moe/init_helpers.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/init_helpers.py
@@ -684,11 +684,11 @@ def load_captured_routing(
     returns the full Galaxy 4-row table of shape `(4, num_routed_experts)`; we slice `[0:1]` to get a
     `(1, num_routed_experts)` tensor — one row, to match LB's single-col mesh.  The slice's contents:
 
-        table[0,  0..num_routed_experts_per_col-1]   = [0,0,0,0,0,0,0,0, 1,1,...,1, ..., 7,7,7,7,7,7,7,7]   (chip ids, 8 per chip)
+        table[0,  0..num_routed_experts_per_col-1]   = [0,0,0,0,0,0,0,0, 1,1,...,1, ..., 7,7,7,7,7,7,7,7]   (chip ids 0..7, experts_per_chip = num_routed_experts/32 per chip)
         table[0, num_routed_experts_per_col..num_routed_experts-1]  = -1                                                    (kernel reads -1 → skip)
         table[0, num_routed_experts-1]      = -1                                                    (== sentinel target)
 
-    The chip-assignment function `chip_id = local_id // 8` is identical across every
+    The chip-assignment function `chip_id = local_id // experts_per_chip` is identical across every
     Galaxy column's row, so using row 0 against remapped (in-col-shifted) indices
     routes each expert to the same chip Galaxy would have:
 
@@ -702,9 +702,10 @@ def load_captured_routing(
     Worked example: captured column k = 2
     -------------------------------------
     Symbols: E = experts_per_col = num_routed_experts // 4; G = dispatch_group_size = 8
-    (chips per column, so G experts per chip); sentinel = num_routed_experts - 1. Column k
-    owns global IDs [k*E, (k+1)*E); the remap shifts an in-col pick v to v - k*E and sends
-    everything else to the sentinel. Its chip is then (v - k*E) // G.
+    (chips per column); experts_per_chip = E // G (8 for dsv3, 12 for kimi26);
+    sentinel = num_routed_experts - 1. Column k owns global IDs [k*E, (k+1)*E); the remap
+    shifts an in-col pick v to v - k*E and sends everything else to the sentinel. Its chip
+    is then (v - k*E) // experts_per_chip.
 
     dsv3 (num_routed_experts=256 → E=64, sentinel=255), one token's 8 picks::
 
@@ -713,9 +714,9 @@ def load_captured_routing(
         remap :  [ 10,  19, 255, 255,  22, 255, 255,  26]    (out-of-col → sentinel 255)
         route :  [ch1, ch2, skip, skip, ch2, skip, skip, ch3]   (chip_id = remap_value // 8)
 
-    kimi26 (num_routed_experts=384 → E=96, sentinel=383) is the same mechanic with a wider
-    column: col 2 range = [192, 288); in-col pick 200 → 200-192 = 8 → chip 1; out-of-col
-    pick 138 → sentinel 383 → skip.
+    kimi26 (num_routed_experts=384 → E=96, experts_per_chip=12, sentinel=383) is the same
+    mechanic with a wider column: col 2 range = [192, 288); in-col pick 200 → 200-192 = 8
+    → 8 // 12 = chip 0; out-of-col pick 138 → sentinel 383 → skip.
 
     Verification — Galaxy would have routed the dsv3 picks the same way via its own col-2 row::
 
@@ -728,7 +729,7 @@ def load_captured_routing(
     ---------------------------------------------
         layer:                  int, MoE layer index (e.g. 27)
         col:                    int, Galaxy column [0, 4) to simulate
-        model:                  str, model name ("dsv3", "kimi26"); selects the per-model
+        model:                  str, model name ("dsv3", "kimi26", "glm52"); selects the per-model
                                 capture file when captured_indices_path is unset
         captured_indices_path:  path to the capture safetensors; if falsy, falls back to
                                 CODE_DEBUG_5K_CHUNKED / "expert_routing_MODELNAME.safetensors"
@@ -793,7 +794,7 @@ def load_captured_routing(
     # In-col routings get shifted to [0, experts_per_col); out-of-col routings get the
     # sentinel num_routed_experts-1 — the last dispatch-table column, which is always -1 in
     # col 0's table (it is above experts_per_col) → kernel skips, preserving the per-col
-    # routing share 1:1 with Galaxy col k. It is model-dependent (dsv3=255, kimi26=383).
+    # routing share 1:1 with Galaxy col k. It is model-dependent.
     experts_per_col = num_routed_experts // GALAXY_NUM_DISPATCH_GROUPS
     SENTINEL = num_routed_experts - 1
     in_col_mask = (indices >= col * experts_per_col) & (indices < (col + 1) * experts_per_col)

--- a/models/demos/deepseek_v3_d_p/tt/moe/init_helpers.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/init_helpers.py
@@ -751,16 +751,24 @@ def load_captured_routing(
 
     if captured_indices_path:
         path = Path(captured_indices_path)
+        # Capture file must be named expert_routing_<model>.safetensors; model comes from the
+        # test_dispatch_combine_perf parametrization.
+        expected = f"expert_routing_{model}.safetensors"
+        if path.name != expected:
+            raise ValueError(
+                f"TT_DS_USE_CAPTURED_INDICES={path} does not match model={model!r} "
+                f"(expected a file named {expected!r}). Point at the matching capture, "
+                f"or unset the env var to use the per-model default."
+            )
     else:
         # Lazy import: transformer_helpers imports from this module in places.
         from models.demos.deepseek_v3_d_p.utils.transformer_helpers import CODE_DEBUG_5K_CHUNKED
 
-        if model == "kimi26":
-            path = CODE_DEBUG_5K_CHUNKED / "expert_routing_kimi26.safetensors"
-        elif model == "glm52":
-            path = CODE_DEBUG_5K_CHUNKED / "expert_routing_glm52.safetensors"
-        else:
-            path = CODE_DEBUG_5K_CHUNKED / "expert_routing_dsv3.safetensors"
+        if model not in {"dsv3", "kimi26", "glm52"}:
+            raise ValueError(f"Unknown model {model!r}; expected one of dsv3, kimi26, glm52")
+
+        # Keep naming in this convention in order for other models to be consistent.
+        path = CODE_DEBUG_5K_CHUNKED / f"expert_routing_{model}.safetensors"
     if not path.exists():
         raise FileNotFoundError(
             f"Captured indices file not found at {path} (set TT_DS_USE_CAPTURED_INDICES to override)"

--- a/models/demos/deepseek_v3_d_p/utils/transformer_helpers.py
+++ b/models/demos/deepseek_v3_d_p/utils/transformer_helpers.py
@@ -71,6 +71,7 @@ ABC_1K_PAD_LEFT_1024 = TRACE_DIR_BASE / "ABC_1k_prefill_padd_left_1024"
 LONGBOOK_QA_ENG_25600 = TRACE_DIR_BASE / "longbook_qa_eng_prefill_25600_nopad"
 LONGBOOK_QA_ENG_5120 = TRACE_DIR_BASE / "longbook_qa_eng_prefill_5120_nopad"
 LONGBOOK_QA_ENG_56320 = TRACE_DIR_BASE / "longbook_qa_eng_prefill_56320_nopad"
+CODE_DEBUG_5K_CHUNKED = TRACE_DIR_BASE / "code_debug_5k_chunked"
 
 # Identity-based trace lookup: (input_source, isl_total, padding_side) -> Path, where
 # isl_total is the trace's NATIVE (generated) sequence length.


### PR DESCRIPTION
[expert_routing_glm52.safetensors.zip](https://github.com/user-attachments/files/30638973/expert_routing_glm52.safetensors.zip)
[expert_routing_dsv3.safetensors.zip](https://github.com/user-attachments/files/30638974/expert_routing_dsv3.safetensors.zip)
[expert_routing_kimi26.safetensors.zip](https://github.com/user-attachments/files/30638975/expert_routing_kimi26.safetensors.zip)

CI path is : /mnt/MLPerf/deepseek-prefill-cache/code_debug_5k_chunked

### Summary

Switches `test_dispatch_combine_perf` baselines from the old 25k single-shot input to captured picks from the **5k chunked** (`code_debug`) prefill run, and extends coverage from DSv3/Kimi2.6 to **DSv3, Kimi2.6, and GLM5.2**.

Each model replays one Galaxy column of a real prefill routing capture on an LB 8x1 mesh, exercising `DispatchDeviceOperation` + `CombineDeviceOperation` in the production op sequence. Picks are the columns that dominate device time: **2 hottest columns + 2 at uniform (~25%)** per model, per topology (`linear`/`ring`, 2 links)

Code changes:
- `tests/perf/test_dispatch_combine_perf.py` — picks + single-run baselines (run-to-run spread ~0.5%, well inside the 3% linear / 4.5% ring margins)
- `tests/perf/test_prefill_dispatch_combine.py` — worker replaying one column on LB 8x1; parametrize id `perf_captured_<model>_chunk`.
- `tt/moe/init_helpers.py` — `load_captured_routing` unknown/`None` model raises instead of silently loading dsv3; a hand-set `TT_DS_USE_CAPTURED_INDICES` must be named `expert_routing_<model>.safetensors`.
- `utils/transformer_helpers.py` — adds the `CODE_DEBUG_5K_CHUNKED` capture-dir constant.

## What the safetensors hold

Each file holds the MoE expert routing for one model — the top-8 experts per token.

Each file has **8 keys**, one per captured MoE layer, named `expert_ids_layer_{N}`. Each key holds a `40960` int32 tensor = 8 chips × 640 tokens × top-8. Each file is ~1.3 MB. No `__metadata__` (the filename carries the model).

Captured layers per file:

| Model (routed experts) | 8 captured layers |
|---|---|
| **DeepSeek V3** (256) | 4, 5, 8, 19, 24, 29, 42, 56 |
| **Kimi K2.6** (384) | 6, 20, 30, 32, 44, 45, 48, 50 |
| **GLM 5.2** (256) | 3, 6, 8, 10, 14, 15, 55, 59 |

## Which picks the perf test baselines

From those layers, the perf test baselines **2 hottest + 2 average** `(layer, col)` picks per model (in-col share in parentheses):

| Model | 2 hottest | 2 average (~25%) |
|---|---|---|
| **DeepSeek V3** | (19, 2) 37.2% · (29, 0) 37.0% | (4, 2) · (56, 3) |
| **Kimi K2.6** | (45, 2) 38.6% · (48, 0) 38.1% | (30, 3) · (32, 1) |
| **GLM 5.2** | (3, 0) 47.3% · (8, 0) 38.5% | (14, 2) · (10, 0) |

Every pick has a `dispatch` + `combine` baseline for both `linear` and `ring`.

## What tests were run to capture the routing data

Ran on Galaxy (`test_prefill_transformer_chunked.py`):

- **DeepSeek V3** — `test_ds_prefill_transformer_chunked_no_pcc[blackhole-deepseek_v3-mesh-8x4-L61-chunks_eleven-iters1]`
- **Kimi K2.6** — `test_kimi_prefill_transformer_chunked_no_pcc[blackhole-kimi-mesh-8x4-L61-preload0-chunks_eleven-iters1-margin5pct]`
- **GLM 5.2** — `test_glm_prefill_transformer_chunked_no_pcc[blackhole-glm52-mesh-8x4-L78-preload0-chunks_eleven-iters1]`

## What the text input was

The `code_debug` 55k trace, one per model (56320 token ids = 11 chunks × 5120):

- DeepSeek V3 — `deepseek_debug_55k_vllm`
- Kimi K2.6 — `kimi_debug_55k_vllm`
- GLM 5.2 — `vllm-glm52-indexer-kcache-55k`

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nostojic/dispatch-combine-perf-captured-picks)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nostojic/dispatch-combine-perf-captured-picks)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nostojic/dispatch-combine-perf-captured-picks)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nostojic/dispatch-combine-perf-captured-picks)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=nostojic/dispatch-combine-perf-captured-picks)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:nostojic/dispatch-combine-perf-captured-picks)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nostojic/dispatch-combine-perf-captured-picks)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nostojic/dispatch-combine-perf-captured-picks)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nostojic/dispatch-combine-perf-captured-picks)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nostojic/dispatch-combine-perf-captured-picks)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nostojic/dispatch-combine-perf-captured-picks)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nostojic/dispatch-combine-perf-captured-picks)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nostojic/dispatch-combine-perf-captured-picks)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nostojic/dispatch-combine-perf-captured-picks)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nostojic/dispatch-combine-perf-captured-picks)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nostojic/dispatch-combine-perf-captured-picks)