### PR TITLE
Refuse a per-core allocated output in the tilize/untilize sharded factories

### DIFF
--- a/tests/ttnn/unit_tests/per_core_allocation/test_per_core_layout_op_guards.py
+++ b/tests/ttnn/unit_tests/per_core_allocation/test_per_core_layout_op_guards.py
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Layout ops must refuse a per-core allocated output rather than silently dropping the request.
+
+`tilize`, `tilize_with_val_padding` and `untilize_with_unpadding` rebuild their output
+MemoryConfig from a handful of named fields when the sharded program factory is selected.
+Everything the caller asked for that is not named there is discarded, including the
+experimental per-core allocation bit — the caller received a lockstep buffer with no signal
+(the from_torch symptom of that is #51133).
+
+These factories bind one L1 address for every core, so they could not honour a per-core
+output even if the bit were carried through; see #51354. Refusing is therefore the correct
+outcome, not a limitation to work around.
+"""
+
+import os
+
+import pytest
+import torch
+
+import ttnn
+
+
+@pytest.fixture(scope="function")
+def per_core_mesh():
+    """1x1 mesh with HYBRID allocator mode, which per-core allocation requires."""
+    os.environ["TT_METAL_ALLOCATOR_MODE_HYBRID"] = "1"
+    mesh = ttnn.open_mesh_device(mesh_shape=ttnn.MeshShape(1, 1))
+    yield mesh
+    ttnn.close_mesh_device(mesh)
+    os.environ.pop("TT_METAL_ALLOCATOR_MODE_HYBRID", None)
+
+
+def _width_sharded_config(grid_start, grid_end, shard_shape, per_core):
+    crs = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(*grid_start), ttnn.CoreCoord(*grid_end))])
+    mem_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ttnn.BufferType.L1,
+        ttnn.ShardSpec(crs, list(shard_shape), ttnn.ShardOrientation.ROW_MAJOR),
+    )
+    if per_core:
+        mem_config.experimental_set_per_core_allocation(True)
+    return mem_config
+
+
+def test_tilize_rejects_per_core_output_config(per_core_mesh, expect_error):
+    """A lockstep input with a per-core output request must fail loudly.
+
+    The input is deliberately lockstep so this exercises the op's own guard on the requested
+    output config, independent of any check on input tensors.
+    """
+    lockstep_config = _width_sharded_config((0, 0), (7, 0), (512, 32), per_core=False)
+    per_core_config = _width_sharded_config((0, 0), (7, 0), (512, 32), per_core=True)
+    torch_input = torch.randn(512, 32 * 8, dtype=torch.bfloat16)
+
+    row_major = ttnn.from_torch(
+        torch_input,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        memory_config=lockstep_config,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(per_core_mesh),
+        device=per_core_mesh,
+    )
+    assert not row_major.is_per_core_allocated(), "precondition failed: input should be lockstep"
+
+    with expect_error(RuntimeError, "per-core allocated output is not supported"):
+        ttnn.tilize(row_major, memory_config=per_core_config)
+
+
+def test_tilize_lockstep_output_unaffected(per_core_mesh):
+    """The guard must be inert for ordinary lockstep use."""
+    lockstep_config = _width_sharded_config((0, 0), (7, 0), (512, 32), per_core=False)
+    torch_input = torch.randn(512, 32 * 8, dtype=torch.bfloat16)
+
+    row_major = ttnn.from_torch(
+        torch_input,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        memory_config=lockstep_config,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(per_core_mesh),
+        device=per_core_mesh,
+    )
+
+    tiled = ttnn.tilize(row_major, memory_config=lockstep_config)
+    assert not tiled.is_per_core_allocated()
+    assert torch.equal(ttnn.to_torch(tiled), torch_input), "tilize corrupted the data"

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_device_operation.cpp
@@ -14,6 +14,7 @@
 #include <tt-metalium/constants.hpp>
 #include <tt-logger/tt-logger.hpp>
 #include <tt-metalium/hal.hpp>
+#include <ttnn/tensor/memory_config/memory_config.hpp>
 #include "ttnn/operations/core/work_split/work_split_tilize.hpp"
 #include "ttnn/tensor/tensor_ops.hpp"
 using namespace tt::tt_metal;
@@ -241,6 +242,16 @@ TilizeDeviceOperation::spec_return_value_t TilizeDeviceOperation::compute_output
             tt::LogOp,
             "ttnn::tilize: Using input shard spec for output tensor because the legacy sharded optimized program "
             "factory is being used");
+        // Rebuilding the output MemoryConfig from named fields drops everything the caller asked
+        // for that is not named here, including the experimental per-core allocation bit (#51133).
+        // Refuse rather than silently downgrade: this factory's output CB binds a single address
+        // for all cores, so it could not honour a per-core output even if the bit were carried
+        // through (#51354).
+        TT_FATAL(
+            !tt::tt_metal::experimental::per_core_allocation::is_per_core_allocation(
+                operation_attributes.output_mem_config),
+            "ttnn::tilize: per-core allocated output is not supported by the legacy sharded optimized program "
+            "factory. Build the tensor without an on-device layout conversion, or request a lockstep output.");
         auto mem_config = tt::tt_metal::MemoryConfig(
             input_tensor.memory_config().memory_layout(),
             operation_attributes.output_mem_config.buffer_type(),

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_device_operation.cpp
@@ -7,6 +7,7 @@
 #include "ttnn/tensor/tensor_ops.hpp"
 #include <tt-metalium/hal.hpp>
 #include <tt-metalium/constants.hpp>
+#include <ttnn/tensor/memory_config/memory_config.hpp>
 #include "ttnn/operations/core/work_split/work_split_tilize.hpp"
 
 using namespace tt::tt_metal;
@@ -179,6 +180,15 @@ tt::tt_metal::TensorSpec TilizeWithValPaddingDeviceOperation::compute_output_spe
         auto shard_spec = input_tensor.shard_spec().value();
         shard_spec.shape[0] =
             operation_attributes.output_padded_shape.volume() / operation_attributes.output_padded_shape[-1];
+        // See the equivalent guard in tilize_device_operation.cpp: rebuilding the output
+        // MemoryConfig here drops the per-core allocation bit (#51133), and this factory could
+        // not honour a per-core output anyway (#51354).
+        TT_FATAL(
+            !tt::tt_metal::experimental::per_core_allocation::is_per_core_allocation(
+                operation_attributes.output_mem_config),
+            "ttnn::tilize_with_val_padding: per-core allocated output is not supported by the optimized sharded "
+            "program factory. Build the tensor without an on-device layout conversion, or request a lockstep "
+            "output.");
         auto mem_config = tt::tt_metal::MemoryConfig(
             input_tensor.memory_config().memory_layout(),
             operation_attributes.output_mem_config.buffer_type(),

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_device_operation.cpp
@@ -11,6 +11,7 @@
 #include "ttnn/operations/data_movement/common/common.hpp"
 #include "ttnn/tensor/tensor_ops.hpp"
 #include <tt-metalium/constants.hpp>
+#include <ttnn/tensor/memory_config/memory_config.hpp>
 #include "ttnn/operations/core/work_split/work_split_tilize.hpp"
 
 using namespace tt::tt_metal;
@@ -450,6 +451,14 @@ tt::tt_metal::TensorSpec UntilizeWithUnpaddingDeviceOperation::compute_output_sp
             uint32_t num_cores = shard_spec.num_cores();
             shard_spec.shape = {tt::round_up(tt::div_up(fused_height, num_cores), tile_height), shard_spec.shape[1]};
         }
+        // See the equivalent guard in tilize_device_operation.cpp: rebuilding the output
+        // MemoryConfig here drops the per-core allocation bit (#51133), and this factory could
+        // not honour a per-core output anyway (#51354).
+        TT_FATAL(
+            !tt::tt_metal::experimental::per_core_allocation::is_per_core_allocation(
+                operation_attributes.output_mem_config),
+            "ttnn::untilize_with_unpadding: per-core allocated output is not supported by the sharded program "
+            "factory. Build the tensor without an on-device layout conversion, or request a lockstep output.");
         auto mem_config = tt::tt_metal::MemoryConfig(
             operation_attributes.output_mem_config.memory_layout(),
             operation_attributes.output_mem_config.buffer_type(),
@@ -517,6 +526,14 @@ tt::tt_metal::TensorSpec UntilizeWithUnpaddingDeviceOperation::compute_output_sp
             shard_shape = {fused_height, shard_spec.shape[1]};
         }
         shard_spec.shape = shard_shape;
+        // See the equivalent guard in tilize_device_operation.cpp: rebuilding the output
+        // MemoryConfig here drops the per-core allocation bit (#51133), and this factory could
+        // not honour a per-core output anyway (#51354).
+        TT_FATAL(
+            !tt::tt_metal::experimental::per_core_allocation::is_per_core_allocation(
+                operation_attributes.output_mem_config),
+            "ttnn::untilize_with_unpadding: per-core allocated output is not supported by the sharded program "
+            "factory. Build the tensor without an on-device layout conversion, or request a lockstep output.");
         auto mem_config = tt::tt_metal::MemoryConfig(
             input_tensor_a.memory_config().memory_layout(),
             operation_attributes.output_mem_config.buffer_type(),

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/tilize_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/tilize_device_operation.cpp
@@ -12,6 +12,7 @@
 #include <tt-metalium/constants.hpp>
 #include <tt-logger/tt-logger.hpp>
 #include <tt-metalium/hal.hpp>
+#include <ttnn/tensor/memory_config/memory_config.hpp>
 #include "ttnn/operations/core/work_split/work_split_tilize.hpp"
 #include "ttnn/tensor/tensor_ops.hpp"
 using namespace tt::tt_metal;
@@ -149,6 +150,15 @@ TilizeDeviceOperation::spec_return_value_t TilizeDeviceOperation::compute_output
             tt::LogOp,
             "ttnn::tilize: Using input shard spec for output tensor because the legacy sharded optimized program "
             "factory is being used");
+        // See the equivalent guard in the non-Quasar tilize_device_operation.cpp: rebuilding the
+        // output MemoryConfig here drops the per-core allocation bit (#51133), and this factory
+        // could not honour a per-core output anyway (#51354).
+        TT_FATAL(
+            !tt::tt_metal::experimental::per_core_allocation::is_per_core_allocation(
+                operation_attributes.output_mem_config),
+            "ttnn::experimental::quasar::tilize: per-core allocated output is not supported by the legacy sharded "
+            "optimized program factory. Build the tensor without an on-device layout conversion, or request a "
+            "lockstep output.");
         auto mem_config = tt::tt_metal::MemoryConfig(
             input_tensor.memory_config().memory_layout(),
             operation_attributes.output_mem_config.buffer_type(),

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/tilize_with_val_padding/device/tilize_with_val_padding_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/tilize_with_val_padding/device/tilize_with_val_padding_device_operation.cpp
@@ -7,6 +7,7 @@
 #include "ttnn/tensor/tensor_ops.hpp"
 #include <tt-metalium/hal.hpp>
 #include <tt-metalium/constants.hpp>
+#include <ttnn/tensor/memory_config/memory_config.hpp>
 #include "ttnn/operations/core/work_split/work_split_tilize.hpp"
 
 using namespace tt::tt_metal;
@@ -185,6 +186,15 @@ tt::tt_metal::TensorSpec TilizeWithValPaddingDeviceOperation::compute_output_spe
         auto shard_spec = input_tensor.shard_spec().value();
         shard_spec.shape[0] =
             operation_attributes.output_padded_shape.volume() / operation_attributes.output_padded_shape[-1];
+        // See the equivalent guard in the non-Quasar tilize_device_operation.cpp: rebuilding the
+        // output MemoryConfig here drops the per-core allocation bit (#51133), and this factory
+        // could not honour a per-core output anyway (#51354).
+        TT_FATAL(
+            !tt::tt_metal::experimental::per_core_allocation::is_per_core_allocation(
+                operation_attributes.output_mem_config),
+            "ttnn::experimental::quasar::tilize_with_val_padding: per-core allocated output is not supported by the "
+            "optimized sharded program factory. Build the tensor without an on-device layout conversion, or request "
+            "a lockstep output.");
         auto mem_config = tt::tt_metal::MemoryConfig(
             input_tensor.memory_config().memory_layout(),
             operation_attributes.output_mem_config.buffer_type(),

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/untilize_with_unpadding_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/untilize_with_unpadding/device/untilize_with_unpadding_device_operation.cpp
@@ -9,6 +9,7 @@
 #include "ttnn/operations/data_movement/common/common.hpp"
 #include "ttnn/tensor/tensor_ops.hpp"
 #include <tt-metalium/constants.hpp>
+#include <ttnn/tensor/memory_config/memory_config.hpp>
 #include "ttnn/operations/core/work_split/work_split_tilize.hpp"
 
 using namespace tt::tt_metal;
@@ -238,6 +239,15 @@ tt::tt_metal::TensorSpec UntilizeWithUnpaddingDeviceOperation::compute_output_sp
             shard_shape = {fused_height, shard_spec.shape[1]};
         }
         shard_spec.shape = shard_shape;
+        // See the equivalent guard in the non-Quasar tilize_device_operation.cpp: rebuilding the
+        // output MemoryConfig here drops the per-core allocation bit (#51133), and this factory
+        // could not honour a per-core output anyway (#51354).
+        TT_FATAL(
+            !tt::tt_metal::experimental::per_core_allocation::is_per_core_allocation(
+                operation_attributes.output_mem_config),
+            "ttnn::experimental::quasar::untilize_with_unpadding: per-core allocated output is not supported by the "
+            "sharded program factory. Build the tensor without an on-device layout conversion, or request a lockstep "
+            "output.");
         auto mem_config = tt::tt_metal::MemoryConfig(
             input_tensor_a.memory_config().memory_layout(),
             operation_attributes.output_mem_config.buffer_type(),


### PR DESCRIPTION
## Problem

`tilize`, `tilize_with_val_padding` and `untilize_with_unpadding` rebuild their output `MemoryConfig` from a handful of named fields when the sharded program factory is selected, in order to substitute the shard geometry inherited from the input:

```cpp
auto mem_config = tt::tt_metal::MemoryConfig(
    input_tensor.memory_config().memory_layout(),
    operation_attributes.output_mem_config.buffer_type(),
    input_tensor.memory_config().shard_spec());
```

Everything the caller asked for that is not named there is discarded, including the experimental per-core allocation bit. That bit is private, absent from `attribute_names`/`attribute_values`, and ignored by `operator==`, so nothing flagged the loss — the caller received a lockstep buffer with no error and no warning. The `from_torch` symptom of that is #51133.

## Fix

`TT_FATAL` when a per-core output is requested, at all four sites plus the three identical copies under `operations/experimental/quasar/`.

Refusing is the correct outcome rather than a limitation to work around: these factories bind a single L1 address for every core — `Buffer::address()` returns the first core's address (`allocator.cpp:163`) and `cb_output.buffer = dst_buffer` resolves to that one value — so they could not honour a per-core output even if the bit were carried through. See #51354 for the underlying single-address problem.

The reporter of #51133 called a `TT_FATAL` here an acceptable outcome: "Silently downgrading to lockstep is the problem — a `TT_FATAL` would at least be safe."

## Behaviour changes

Inert unless a per-core output is requested, so lockstep behaviour is unchanged. The only callers affected are those that previously received a silently downgraded tensor.

## Tests

`test_per_core_layout_op_guards.py`:

- a lockstep input with a per-core output request now raises. The input is deliberately lockstep so this exercises the op's own guard on the requested output config, independent of any check on input tensors.
- a lockstep-to-lockstep tilize still works and round-trips its data, pinning that the guard is inert for ordinary use.

Regression coverage on the ops touched, run locally on a BH galaxy node: `test_tilize.py` (419 passed, 73 skipped) and `test_untilize_with_unpadding.py` (354 passed, 6 skipped).
