### PR TITLE
#51133: Refuse per-core allocation instead of silently downgrading it

### DIFF
--- a/tests/pipeline_reorg/ttnn_sanity_tests.yaml
+++ b/tests/pipeline_reorg/ttnn_sanity_tests.yaml
@@ -261,7 +261,11 @@
   owner_id: U084B1CES7M # Borys Bradel
 
 - name: "core ttnn unit test group"
-  cmd: 'pytest --timeout 300 tests/ttnn/unit_tests/base_functionality tests/ttnn/unit_tests/benchmarks tests/ttnn/unit_tests/tensor -xv -m "not disable_fast_runtime_mode" && pytest --timeout 300 tests/ttnn/unit_tests/per_core_allocation -xv'
+  # per_core_allocation runs as its own pytest process: TT_METAL_ALLOCATOR_MODE_HYBRID is read
+  # once when MetalContext is first constructed, so it must be set before this process opens a
+  # device. Exporting it here rather than relying on the directory conftest's fixture also makes
+  # the requirement visible, and satisfies the requires_hybrid_allocator marker on those tests.
+  cmd: 'pytest --timeout 300 tests/ttnn/unit_tests/base_functionality tests/ttnn/unit_tests/benchmarks tests/ttnn/unit_tests/tensor -xv -m "not disable_fast_runtime_mode" && TT_METAL_ALLOCATOR_MODE_HYBRID=1 pytest --timeout 300 tests/ttnn/unit_tests/per_core_allocation -xv'
   skus:
     wh_n300_civ2:
       timeout: 40

--- a/tests/ttnn/unit_tests/gtests/test_launch_operation.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_launch_operation.cpp
@@ -183,9 +183,10 @@ TEST(LaunchOperationTest, ProgramSpecAdapterCompiles) {
     SUCCEED();
 }
 
-// PerCoreAllocationAware gates whether launch() will accept a per-core allocated input. No op
+// SupportsPerCoreAllocation gates whether launch() will accept a per-core allocated tensor. No op
 // declares supports_per_core_allocation today, so the accept path is otherwise never exercised --
-// a concept that could never match would look identical at runtime. Pin both directions here.
+// a concept that could never match would look identical at runtime. Pin all three directions here:
+// absent, true, and explicitly false.
 namespace per_core_opt_in_test {
 struct NoDeclaration {};
 struct OptedIn {
@@ -196,9 +197,9 @@ struct OptedOut {
 };
 }  // namespace per_core_opt_in_test
 
-static_assert(!device_operation::PerCoreAllocationAware<per_core_opt_in_test::NoDeclaration>);
-static_assert(device_operation::PerCoreAllocationAware<per_core_opt_in_test::OptedIn>);
-static_assert(!device_operation::PerCoreAllocationAware<per_core_opt_in_test::OptedOut>);
+static_assert(!device_operation::SupportsPerCoreAllocation<per_core_opt_in_test::NoDeclaration>);
+static_assert(device_operation::SupportsPerCoreAllocation<per_core_opt_in_test::OptedIn>);
+static_assert(!device_operation::SupportsPerCoreAllocation<per_core_opt_in_test::OptedOut>);
 
 TEST(LaunchOperationTest, MeshDeviceOperationAdapterGetName) {
     using ::ttnn::operations::examples::ExampleDeviceOperation;

--- a/tests/ttnn/unit_tests/gtests/test_launch_operation.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_launch_operation.cpp
@@ -183,6 +183,23 @@ TEST(LaunchOperationTest, ProgramSpecAdapterCompiles) {
     SUCCEED();
 }
 
+// PerCoreAllocationAware gates whether launch() will accept a per-core allocated input. No op
+// declares supports_per_core_allocation today, so the accept path is otherwise never exercised --
+// a concept that could never match would look identical at runtime. Pin both directions here.
+namespace per_core_opt_in_test {
+struct NoDeclaration {};
+struct OptedIn {
+    static constexpr bool supports_per_core_allocation = true;
+};
+struct OptedOut {
+    static constexpr bool supports_per_core_allocation = false;
+};
+}  // namespace per_core_opt_in_test
+
+static_assert(!device_operation::PerCoreAllocationAware<per_core_opt_in_test::NoDeclaration>);
+static_assert(device_operation::PerCoreAllocationAware<per_core_opt_in_test::OptedIn>);
+static_assert(!device_operation::PerCoreAllocationAware<per_core_opt_in_test::OptedOut>);
+
 TEST(LaunchOperationTest, MeshDeviceOperationAdapterGetName) {
     using ::ttnn::operations::examples::ExampleDeviceOperation;
     EXPECT_EQ(

--- a/tests/ttnn/unit_tests/per_core_allocation/conftest.py
+++ b/tests/ttnn/unit_tests/per_core_allocation/conftest.py
@@ -31,6 +31,22 @@ def device(request):
 
 
 @pytest.fixture(scope="function")
+def per_core_mesh_device():
+    """Single-device 1x1 mesh with HYBRID allocator mode.
+
+    A mesh_mapper is what selects the on-device construction branch in
+    create_tt_tensor_from_host_data; the single-device path sends any sharded config to host
+    via is_data_transformation_required. Tests that need that branch therefore need a mesh,
+    but not more than one device -- unlike `mesh_device` below, which requires two.
+    """
+    os.environ["TT_METAL_ALLOCATOR_MODE_HYBRID"] = "1"
+    mesh = ttnn.open_mesh_device(mesh_shape=ttnn.MeshShape(1, 1))
+    yield mesh
+    ttnn.close_mesh_device(mesh)
+    os.environ.pop("TT_METAL_ALLOCATOR_MODE_HYBRID", None)
+
+
+@pytest.fixture(scope="function")
 def mesh_device():
     """Function-scoped mesh device with HYBRID allocator mode for multi-device tests."""
     os.environ["TT_METAL_ALLOCATOR_MODE_HYBRID"] = "1"

--- a/tests/ttnn/unit_tests/per_core_allocation/conftest.py
+++ b/tests/ttnn/unit_tests/per_core_allocation/conftest.py
@@ -30,6 +30,39 @@ def device(request):
     os.environ.pop("TT_METAL_ALLOCATOR_MODE_HYBRID", None)
 
 
+def _width_sharded_config(grid_start, grid_end, shard_shape):
+    """Width-sharded L1 memory config over the inclusive core grid grid_start..grid_end."""
+    core_ranges = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(*grid_start), ttnn.CoreCoord(*grid_end))])
+    return ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ttnn.BufferType.L1,
+        ttnn.ShardSpec(core_ranges, list(shard_shape), ttnn.ShardOrientation.ROW_MAJOR),
+    )
+
+
+# Both test files here build width-sharded L1 configs differing only in whether per-core
+# allocation is requested. Exposed as two factories rather than one taking a boolean, so a call
+# site says which kind it is building.
+
+
+@pytest.fixture(scope="module")
+def lockstep_width_sharded_config():
+    """Factory (grid_start, grid_end, shard_shape) -> ordinary lockstep-allocated config."""
+    return _width_sharded_config
+
+
+@pytest.fixture(scope="module")
+def per_core_width_sharded_config():
+    """Factory (grid_start, grid_end, shard_shape) -> config requesting per-core L1 allocation."""
+
+    def build(grid_start, grid_end, shard_shape):
+        mem_config = _width_sharded_config(grid_start, grid_end, shard_shape)
+        mem_config.experimental_set_per_core_allocation(True)
+        return mem_config
+
+    return build
+
+
 @pytest.fixture(scope="function")
 def per_core_mesh_device():
     """Single-device 1x1 mesh with HYBRID allocator mode.

--- a/tests/ttnn/unit_tests/per_core_allocation/test_per_core_allocation.py
+++ b/tests/ttnn/unit_tests/per_core_allocation/test_per_core_allocation.py
@@ -13,6 +13,7 @@ The local conftest.py sets TT_METAL_ALLOCATOR_MODE_HYBRID=1 and creates the devi
 
 import torch
 import ttnn
+from conftest import requires_hybrid_allocator
 
 
 class PerCoreMemMap:
@@ -89,6 +90,7 @@ def _create_single_core_tensor(device, core, shard_bytes):
     )
 
 
+@requires_hybrid_allocator
 def test_per_core_tensors_get_same_address(device):
     """Two single-core tensors on different cores can share the same L1 address,
     proving they use independent per-bank allocators (not lockstep)."""
@@ -106,6 +108,7 @@ def test_per_core_tensors_get_same_address(device):
     assert addr0 == addr1, f"Expected same address on different cores (per-bank allocators), got {addr0} vs {addr1}"
 
 
+@requires_hybrid_allocator
 def test_per_core_round_trip(device):
     """Data written to a per-core allocated tensor reads back correctly."""
     shard_bytes = 2048
@@ -130,6 +133,7 @@ def test_per_core_round_trip(device):
     assert torch.equal(data, result), "Round-trip data mismatch"
 
 
+@requires_hybrid_allocator
 def test_per_core_sharded_dealloc_realloc(device):
     """Deallocate a per-core sharded tensor and reallocate — verifies deallocation frees per-core space.
 
@@ -172,6 +176,7 @@ def test_per_core_sharded_dealloc_realloc(device):
     ), f"Expected same addresses after dealloc/realloc:\n  first:  {[f'{a:#x}' for a in addrs1]}\n  second: {[f'{a:#x}' for a in addrs2]}"
 
 
+@requires_hybrid_allocator
 def test_per_core_tetris_allocation(device):
     """Tetris-style allocation across 4 cores with alloc/free/realloc patterns.
 
@@ -252,6 +257,7 @@ def _addr_ranges_overlap(addr_a, size_a, addr_b, size_b):
     return addr_a < addr_b + size_b and addr_b < addr_a + size_a
 
 
+@requires_hybrid_allocator
 def test_per_core_and_lockstep_coexist(device):
     """Interleave per-core and lockstep allocations across multiple cores.
 
@@ -329,6 +335,7 @@ def test_per_core_and_lockstep_coexist(device):
         assert t.is_allocated(), f"{label} should still be allocated"
 
 
+@requires_hybrid_allocator
 def test_all_cores_lockstep_then_per_core_then_reverse(device):
     """Allocate on ALL L1 cores: lockstep first then per-core, then deallocate and reverse order.
 
@@ -396,6 +403,7 @@ def test_all_cores_lockstep_then_per_core_then_reverse(device):
         assert per_core_tensors[i].is_allocated()
 
 
+@requires_hybrid_allocator
 def test_triangle_allocation_then_uniform_sharded(device):
     """Triangle per-core allocation on ALL compute cores, then a per-core sharded tensor.
 

--- a/tests/ttnn/unit_tests/per_core_allocation/test_per_core_allocation_from_torch.py
+++ b/tests/ttnn/unit_tests/per_core_allocation/test_per_core_allocation_from_torch.py
@@ -14,28 +14,11 @@ per-core allocation, so the tensor is built on host and `to_device` applies the 
 memory config directly — no op in between.
 """
 
-import os
-
 import pytest
 import torch
 
 import ttnn
-
-
-@pytest.fixture(scope="function")
-def per_core_mesh():
-    """1x1 mesh with HYBRID allocator mode.
-
-    A mesh_mapper is what selects the on-device construction branch in
-    `create_tt_tensor_from_host_data`; the single-device path takes
-    `is_data_transformation_required` to host for any sharded config, so #51133 does not
-    reproduce there. A 1x1 mesh exercises the failing branch while still running on one device.
-    """
-    os.environ["TT_METAL_ALLOCATOR_MODE_HYBRID"] = "1"
-    mesh = ttnn.open_mesh_device(mesh_shape=ttnn.MeshShape(1, 1))
-    yield mesh
-    ttnn.close_mesh_device(mesh)
-    os.environ.pop("TT_METAL_ALLOCATOR_MODE_HYBRID", None)
+from conftest import requires_hybrid_allocator
 
 
 def _per_core_width_sharded_config(grid_start, grid_end, shard_shape):
@@ -53,6 +36,7 @@ def _per_core_width_sharded_config(grid_start, grid_end, shard_shape):
 # range count are all irrelevant — the only thing that mattered was whether the shard was
 # small enough for has_sufficient_device_memory() to allow the on-device path. Grids here are
 # kept narrow so the test runs on any device, unlike the col-12 grids in the report.
+@requires_hybrid_allocator
 @pytest.mark.parametrize(
     "grid_start, grid_end, shard_shape",
     [
@@ -63,7 +47,7 @@ def _per_core_width_sharded_config(grid_start, grid_end, shard_shape):
     ],
     ids=["gate_mm_7168x32", "small_512x32", "four_cores", "two_rows"],
 )
-def test_from_torch_on_device_preserves_per_core_allocation(per_core_mesh, grid_start, grid_end, shard_shape):
+def test_from_torch_on_device_preserves_per_core_allocation(per_core_mesh_device, grid_start, grid_end, shard_shape):
     """from_torch(device=...) must honour a per-core memory config, not downgrade to lockstep."""
     num_cores = (grid_end[0] - grid_start[0] + 1) * (grid_end[1] - grid_start[1] + 1)
     mem_config = _per_core_width_sharded_config(grid_start, grid_end, shard_shape)
@@ -75,8 +59,8 @@ def test_from_torch_on_device_preserves_per_core_allocation(per_core_mesh, grid_
         layout=ttnn.TILE_LAYOUT,
         memory_config=mem_config,
         tile=ttnn.Tile((32, 32)),
-        mesh_mapper=ttnn.ReplicateTensorToMesh(per_core_mesh),
-        device=per_core_mesh,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(per_core_mesh_device),
+        device=per_core_mesh_device,
     )
 
     assert tensor.is_per_core_allocated(), (
@@ -86,7 +70,8 @@ def test_from_torch_on_device_preserves_per_core_allocation(per_core_mesh, grid_
     assert torch.equal(ttnn.to_torch(tensor), torch_input), "from_torch corrupted the data"
 
 
-def test_from_torch_large_shard_still_per_core(per_core_mesh):
+@requires_hybrid_allocator
+def test_from_torch_large_shard_still_per_core(per_core_mesh_device):
     """A shard above the has_sufficient_device_memory() gate already worked; keep it working.
 
     This case took the host path on `main` and so was unaffected by #51133. It is here to catch
@@ -101,15 +86,16 @@ def test_from_torch_large_shard_still_per_core(per_core_mesh):
         layout=ttnn.TILE_LAYOUT,
         memory_config=mem_config,
         tile=ttnn.Tile((32, 32)),
-        mesh_mapper=ttnn.ReplicateTensorToMesh(per_core_mesh),
-        device=per_core_mesh,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(per_core_mesh_device),
+        device=per_core_mesh_device,
     )
 
     assert tensor.is_per_core_allocated()
     assert torch.equal(ttnn.to_torch(tensor), torch_input)
 
 
-def test_from_torch_row_major_per_core_unaffected(per_core_mesh):
+@requires_hybrid_allocator
+def test_from_torch_row_major_per_core_unaffected(per_core_mesh_device):
     """ROW_MAJOR needs no layout conversion, so it always preserved the bit. Pin that."""
     mem_config = _per_core_width_sharded_config((0, 0), (7, 0), (512, 32))
     torch_input = torch.randn(512, 32 * 8, dtype=torch.bfloat16)
@@ -119,8 +105,8 @@ def test_from_torch_row_major_per_core_unaffected(per_core_mesh):
         dtype=ttnn.bfloat16,
         layout=ttnn.ROW_MAJOR_LAYOUT,
         memory_config=mem_config,
-        mesh_mapper=ttnn.ReplicateTensorToMesh(per_core_mesh),
-        device=per_core_mesh,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(per_core_mesh_device),
+        device=per_core_mesh_device,
     )
 
     assert tensor.is_per_core_allocated()

--- a/tests/ttnn/unit_tests/per_core_allocation/test_per_core_allocation_from_torch.py
+++ b/tests/ttnn/unit_tests/per_core_allocation/test_per_core_allocation_from_torch.py
@@ -21,15 +21,9 @@ import ttnn
 from conftest import requires_hybrid_allocator
 
 
-def _per_core_width_sharded_config(grid_start, grid_end, shard_shape):
-    crs = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(*grid_start), ttnn.CoreCoord(*grid_end))])
-    mem_config = ttnn.MemoryConfig(
-        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
-        ttnn.BufferType.L1,
-        ttnn.ShardSpec(crs, list(shard_shape), ttnn.ShardOrientation.ROW_MAJOR),
-    )
-    mem_config.experimental_set_per_core_allocation(True)
-    return mem_config
+# A single row of this many cores, used for the fixed-grid tests below. Spelling it once keeps
+# the grid, the shard width and the tensor width from drifting apart.
+NUM_CORES = 8
 
 
 # Shapes from the sweep in #51133. The reporter established that core grid, core count and
@@ -47,10 +41,12 @@ def _per_core_width_sharded_config(grid_start, grid_end, shard_shape):
     ],
     ids=["gate_mm_7168x32", "small_512x32", "four_cores", "two_rows"],
 )
-def test_from_torch_on_device_preserves_per_core_allocation(per_core_mesh_device, grid_start, grid_end, shard_shape):
+def test_from_torch_on_device_preserves_per_core_allocation(
+    per_core_mesh_device, per_core_width_sharded_config, grid_start, grid_end, shard_shape
+):
     """from_torch(device=...) must honour a per-core memory config, not downgrade to lockstep."""
     num_cores = (grid_end[0] - grid_start[0] + 1) * (grid_end[1] - grid_start[1] + 1)
-    mem_config = _per_core_width_sharded_config(grid_start, grid_end, shard_shape)
+    mem_config = per_core_width_sharded_config(grid_start, grid_end, shard_shape)
 
     torch_input = torch.randn(shard_shape[0], shard_shape[1] * num_cores, dtype=torch.bfloat16)
     tensor = ttnn.from_torch(
@@ -71,14 +67,15 @@ def test_from_torch_on_device_preserves_per_core_allocation(per_core_mesh_device
 
 
 @requires_hybrid_allocator
-def test_from_torch_large_shard_still_per_core(per_core_mesh_device):
+def test_from_torch_large_shard_still_per_core(per_core_mesh_device, per_core_width_sharded_config):
     """A shard above the has_sufficient_device_memory() gate already worked; keep it working.
 
     This case took the host path on `main` and so was unaffected by #51133. It is here to catch
     the fix breaking the branch that was already correct.
     """
-    mem_config = _per_core_width_sharded_config((0, 0), (7, 0), (14336, 32))
-    torch_input = torch.randn(14336, 32 * 8, dtype=torch.bfloat16)
+    shard_height, shard_width = 14336, 32
+    mem_config = per_core_width_sharded_config((0, 0), (NUM_CORES - 1, 0), (shard_height, shard_width))
+    torch_input = torch.randn(shard_height, shard_width * NUM_CORES, dtype=torch.bfloat16)
 
     tensor = ttnn.from_torch(
         torch_input,
@@ -95,10 +92,11 @@ def test_from_torch_large_shard_still_per_core(per_core_mesh_device):
 
 
 @requires_hybrid_allocator
-def test_from_torch_row_major_per_core_unaffected(per_core_mesh_device):
+def test_from_torch_row_major_per_core_unaffected(per_core_mesh_device, per_core_width_sharded_config):
     """ROW_MAJOR needs no layout conversion, so it always preserved the bit. Pin that."""
-    mem_config = _per_core_width_sharded_config((0, 0), (7, 0), (512, 32))
-    torch_input = torch.randn(512, 32 * 8, dtype=torch.bfloat16)
+    shard_height, shard_width = 512, 32
+    mem_config = per_core_width_sharded_config((0, 0), (NUM_CORES - 1, 0), (shard_height, shard_width))
+    torch_input = torch.randn(shard_height, shard_width * NUM_CORES, dtype=torch.bfloat16)
 
     tensor = ttnn.from_torch(
         torch_input,

--- a/tests/ttnn/unit_tests/per_core_allocation/test_per_core_allocation_from_torch.py
+++ b/tests/ttnn/unit_tests/per_core_allocation/test_per_core_allocation_from_torch.py
@@ -1,0 +1,127 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for #51133: from_torch(device=...) must not drop per-core allocation.
+
+`create_tt_tensor_from_host_data` can build a tensor in its *source* layout on device and
+convert it there with ttnn ops. Those ops rebuild the output MemoryConfig from a few named
+fields and drop the experimental per-core allocation bit, so the caller silently received a
+lockstep buffer.
+
+The fix refuses the on-device construction path when the requested memory config asks for
+per-core allocation, so the tensor is built on host and `to_device` applies the caller's
+memory config directly — no op in between.
+"""
+
+import os
+
+import pytest
+import torch
+
+import ttnn
+
+
+@pytest.fixture(scope="function")
+def per_core_mesh():
+    """1x1 mesh with HYBRID allocator mode.
+
+    A mesh_mapper is what selects the on-device construction branch in
+    `create_tt_tensor_from_host_data`; the single-device path takes
+    `is_data_transformation_required` to host for any sharded config, so #51133 does not
+    reproduce there. A 1x1 mesh exercises the failing branch while still running on one device.
+    """
+    os.environ["TT_METAL_ALLOCATOR_MODE_HYBRID"] = "1"
+    mesh = ttnn.open_mesh_device(mesh_shape=ttnn.MeshShape(1, 1))
+    yield mesh
+    ttnn.close_mesh_device(mesh)
+    os.environ.pop("TT_METAL_ALLOCATOR_MODE_HYBRID", None)
+
+
+def _per_core_width_sharded_config(grid_start, grid_end, shard_shape):
+    crs = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(*grid_start), ttnn.CoreCoord(*grid_end))])
+    mem_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ttnn.BufferType.L1,
+        ttnn.ShardSpec(crs, list(shard_shape), ttnn.ShardOrientation.ROW_MAJOR),
+    )
+    mem_config.experimental_set_per_core_allocation(True)
+    return mem_config
+
+
+# Shapes from the sweep in #51133. The reporter established that core grid, core count and
+# range count are all irrelevant — the only thing that mattered was whether the shard was
+# small enough for has_sufficient_device_memory() to allow the on-device path. Grids here are
+# kept narrow so the test runs on any device, unlike the col-12 grids in the report.
+@pytest.mark.parametrize(
+    "grid_start, grid_end, shard_shape",
+    [
+        ((0, 0), (7, 0), (7168, 32)),  # gate_mm: the weight actually affected in tt-blaze
+        ((0, 0), (7, 0), (512, 32)),  # small shard, same grid
+        ((0, 0), (3, 0), (7168, 32)),  # 4 cores
+        ((0, 0), (7, 1), (7168, 32)),  # 16 cores, two rows
+    ],
+    ids=["gate_mm_7168x32", "small_512x32", "four_cores", "two_rows"],
+)
+def test_from_torch_on_device_preserves_per_core_allocation(per_core_mesh, grid_start, grid_end, shard_shape):
+    """from_torch(device=...) must honour a per-core memory config, not downgrade to lockstep."""
+    num_cores = (grid_end[0] - grid_start[0] + 1) * (grid_end[1] - grid_start[1] + 1)
+    mem_config = _per_core_width_sharded_config(grid_start, grid_end, shard_shape)
+
+    torch_input = torch.randn(shard_shape[0], shard_shape[1] * num_cores, dtype=torch.bfloat16)
+    tensor = ttnn.from_torch(
+        torch_input,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=mem_config,
+        tile=ttnn.Tile((32, 32)),
+        mesh_mapper=ttnn.ReplicateTensorToMesh(per_core_mesh),
+        device=per_core_mesh,
+    )
+
+    assert tensor.is_per_core_allocated(), (
+        "from_torch(device=...) silently dropped the experimental per-core allocation bit; "
+        "the buffer is lockstep-allocated even though the memory_config asked for per-core"
+    )
+    assert torch.equal(ttnn.to_torch(tensor), torch_input), "from_torch corrupted the data"
+
+
+def test_from_torch_large_shard_still_per_core(per_core_mesh):
+    """A shard above the has_sufficient_device_memory() gate already worked; keep it working.
+
+    This case took the host path on `main` and so was unaffected by #51133. It is here to catch
+    the fix breaking the branch that was already correct.
+    """
+    mem_config = _per_core_width_sharded_config((0, 0), (7, 0), (14336, 32))
+    torch_input = torch.randn(14336, 32 * 8, dtype=torch.bfloat16)
+
+    tensor = ttnn.from_torch(
+        torch_input,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=mem_config,
+        tile=ttnn.Tile((32, 32)),
+        mesh_mapper=ttnn.ReplicateTensorToMesh(per_core_mesh),
+        device=per_core_mesh,
+    )
+
+    assert tensor.is_per_core_allocated()
+    assert torch.equal(ttnn.to_torch(tensor), torch_input)
+
+
+def test_from_torch_row_major_per_core_unaffected(per_core_mesh):
+    """ROW_MAJOR needs no layout conversion, so it always preserved the bit. Pin that."""
+    mem_config = _per_core_width_sharded_config((0, 0), (7, 0), (512, 32))
+    torch_input = torch.randn(512, 32 * 8, dtype=torch.bfloat16)
+
+    tensor = ttnn.from_torch(
+        torch_input,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        memory_config=mem_config,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(per_core_mesh),
+        device=per_core_mesh,
+    )
+
+    assert tensor.is_per_core_allocated()
+    assert torch.equal(ttnn.to_torch(tensor), torch_input)

--- a/tests/ttnn/unit_tests/per_core_allocation/test_per_core_allocation_multi_device.py
+++ b/tests/ttnn/unit_tests/per_core_allocation/test_per_core_allocation_multi_device.py
@@ -14,6 +14,7 @@ import torch
 from loguru import logger
 
 import ttnn
+from conftest import requires_hybrid_allocator
 
 
 # --- Helpers ---
@@ -101,6 +102,7 @@ def _assert_no_overlap_per_device(pc_tensor, pc_core, pc_size, ls_tensor, ls_siz
 # --- Basic tests ---
 
 
+@requires_hybrid_allocator
 def test_per_core_independent_addresses_across_devices(mesh_device):
     """Per-core allocations on different devices get same address when allocator states match."""
     shard_bytes = 2048
@@ -116,6 +118,7 @@ def test_per_core_independent_addresses_across_devices(mesh_device):
     ), f"Expected same initial address on all devices, got {[f'{a:#x}' for a in addrs]}"
 
 
+@requires_hybrid_allocator
 def test_per_core_then_lockstep_no_overlap(mesh_device):
     """Per-core first, then lockstep. No overlap on any device."""
     core = ttnn.CoreCoord(0, 0)
@@ -129,6 +132,7 @@ def test_per_core_then_lockstep_no_overlap(mesh_device):
     _assert_cross_device_consistency(t_pc, [core])
 
 
+@requires_hybrid_allocator
 def test_lockstep_then_per_core_no_overlap(mesh_device):
     """Lockstep first, then per-core. No overlap on any device."""
     core = ttnn.CoreCoord(0, 0)
@@ -145,6 +149,7 @@ def test_lockstep_then_per_core_no_overlap(mesh_device):
 # --- Multi-core tests ---
 
 
+@requires_hybrid_allocator
 def test_multi_core_per_core_all_cores(mesh_device):
     """Per-core allocation across all compute cores on mesh, each core independent."""
     grid = mesh_device.compute_with_storage_grid_size()
@@ -167,6 +172,7 @@ def test_multi_core_per_core_all_cores(mesh_device):
     assert t.is_allocated()
 
 
+@requires_hybrid_allocator
 def test_multi_core_per_core_then_lockstep_no_overlap(mesh_device):
     """Per-core on 4 cores, then lockstep on same 4 cores. No overlap on any device/core."""
     num_cores = 4
@@ -190,6 +196,7 @@ def test_multi_core_per_core_then_lockstep_no_overlap(mesh_device):
 # --- Interleaved alloc/free patterns ---
 
 
+@requires_hybrid_allocator
 def test_interleaved_per_core_and_lockstep(mesh_device):
     """Interleave per-core and lockstep allocations across multiple cores.
     Verify no overlaps on any core on any device."""
@@ -242,6 +249,7 @@ def test_interleaved_per_core_and_lockstep(mesh_device):
         assert t.is_allocated(), f"{label} should still be allocated"
 
 
+@requires_hybrid_allocator
 def test_tetris_allocation_on_mesh(mesh_device):
     """Tetris-style alloc/free/realloc across 4 cores on mesh.
     Validates no overlap on same core and cross-device consistency."""
@@ -302,6 +310,7 @@ def test_tetris_allocation_on_mesh(mesh_device):
 # --- Dealloc/realloc tests ---
 
 
+@requires_hybrid_allocator
 def test_dealloc_per_core_then_lockstep_reuses_space(mesh_device):
     """Allocate per-core, deallocate, then lockstep gets the same address (space reused)."""
     core = ttnn.CoreCoord(0, 0)
@@ -316,6 +325,7 @@ def test_dealloc_per_core_then_lockstep_reuses_space(mesh_device):
     assert ls_addr == pc_addr, f"Expected lockstep to reuse freed per-core address {pc_addr:#x}, got {ls_addr:#x}"
 
 
+@requires_hybrid_allocator
 def test_dealloc_lockstep_then_per_core_reuses_space(mesh_device):
     """Allocate lockstep, deallocate, then per-core gets the same address (space reused)."""
     core = ttnn.CoreCoord(0, 0)
@@ -330,6 +340,7 @@ def test_dealloc_lockstep_then_per_core_reuses_space(mesh_device):
     assert pc_addr == ls_addr, f"Expected per-core to reuse freed lockstep address {ls_addr:#x}, got {pc_addr:#x}"
 
 
+@requires_hybrid_allocator
 def test_multi_core_dealloc_realloc(mesh_device):
     """Allocate per-core across all cores, dealloc, realloc — same addresses per device."""
     grid = mesh_device.compute_with_storage_grid_size()
@@ -360,6 +371,7 @@ def test_multi_core_dealloc_realloc(mesh_device):
 # --- All cores stress test ---
 
 
+@requires_hybrid_allocator
 def test_all_cores_lockstep_then_per_core_then_reverse(mesh_device):
     """Phase 1: lockstep → per-core on all cores (no overlap per device).
     Phase 2: deallocate all → per-core → lockstep (deps non-empty)."""
@@ -407,6 +419,7 @@ def test_all_cores_lockstep_then_per_core_then_reverse(mesh_device):
 # --- Triangle pattern (proves independent per-bank state) ---
 
 
+@requires_hybrid_allocator
 def test_triangle_per_core_then_uniform(mesh_device):
     """Triangle per-core on all cores, then uniform per-core.
     Addresses form inverse triangle, consistent across devices, no overlap."""
@@ -480,6 +493,7 @@ def _allocate_per_core_on_device(mesh_device, coord, core, shard_bytes):
     return ttnn._ttnn.tensor.experimental_to_single_device(host_tensor, mesh_device, coord, mem_config)
 
 
+@requires_hybrid_allocator
 def test_single_device_loopback(mesh_device):
     """Write data to a single device within the mesh and read it back.
     Verifies the full round-trip: host → single device → host."""
@@ -499,6 +513,7 @@ def test_single_device_loopback(mesh_device):
         )
 
 
+@requires_hybrid_allocator
 def test_divergent_per_device_then_lockstep(mesh_device):
     """Allocate different-sized per-core tensors on each device independently,
     causing divergent allocator states. Then lockstep must get the same address
@@ -549,6 +564,7 @@ def test_divergent_per_device_then_lockstep(mesh_device):
     ), f"Device 1: overlap per_core=[{addr1:#x}, +{per_device_sizes[1]}) vs lockstep=[{ls_addrs[1]:#x}, +{ls_size})"
 
 
+@requires_hybrid_allocator
 def test_divergent_multi_core_per_device_then_lockstep(mesh_device):
     """Multiple cores, different sizes per device, then lockstep.
     Simulates TP compressed weights across cores."""

--- a/tests/ttnn/unit_tests/per_core_allocation/test_per_core_allocation_op_opt_in.py
+++ b/tests/ttnn/unit_tests/per_core_allocation/test_per_core_allocation_op_opt_in.py
@@ -21,23 +21,18 @@ import ttnn
 from conftest import requires_hybrid_allocator
 
 
-def _width_sharded_config(grid_start, grid_end, shard_shape, per_core):
-    crs = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(*grid_start), ttnn.CoreCoord(*grid_end))])
-    mem_config = ttnn.MemoryConfig(
-        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
-        ttnn.BufferType.L1,
-        ttnn.ShardSpec(crs, list(shard_shape), ttnn.ShardOrientation.ROW_MAJOR),
-    )
-    if per_core:
-        mem_config.experimental_set_per_core_allocation(True)
-    return mem_config
+# One row of cores, width-sharded. Spelled once so the grid, the shard width and the tensor
+# width cannot drift apart: tensor width must be shard_width * NUM_CORES for the shard to tile.
+NUM_CORES = 8
+SHARD_HEIGHT, SHARD_WIDTH = 512, 32
+GRID_START, GRID_END = (0, 0), (NUM_CORES - 1, 0)
 
 
 @requires_hybrid_allocator
-def test_op_rejects_per_core_input(per_core_mesh_device, expect_error):
+def test_op_rejects_per_core_input(per_core_mesh_device, per_core_width_sharded_config, expect_error):
     """Handing a per-core tensor to an op that has not opted in must fail loudly."""
-    mem_config = _width_sharded_config((0, 0), (7, 0), (512, 32), per_core=True)
-    torch_input = torch.randn(512, 32 * 8, dtype=torch.bfloat16)
+    mem_config = per_core_width_sharded_config(GRID_START, GRID_END, (SHARD_HEIGHT, SHARD_WIDTH))
+    torch_input = torch.randn(SHARD_HEIGHT, SHARD_WIDTH * NUM_CORES, dtype=torch.bfloat16)
 
     row_major = ttnn.from_torch(
         torch_input,
@@ -54,10 +49,10 @@ def test_op_rejects_per_core_input(per_core_mesh_device, expect_error):
 
 
 @requires_hybrid_allocator
-def test_lockstep_input_unaffected(per_core_mesh_device):
+def test_lockstep_input_unaffected(per_core_mesh_device, lockstep_width_sharded_config):
     """The check must be inert for ordinary lockstep tensors."""
-    lockstep_config = _width_sharded_config((0, 0), (7, 0), (512, 32), per_core=False)
-    torch_input = torch.randn(512, 32 * 8, dtype=torch.bfloat16)
+    lockstep_config = lockstep_width_sharded_config(GRID_START, GRID_END, (SHARD_HEIGHT, SHARD_WIDTH))
+    torch_input = torch.randn(SHARD_HEIGHT, SHARD_WIDTH * NUM_CORES, dtype=torch.bfloat16)
 
     row_major = ttnn.from_torch(
         torch_input,

--- a/tests/ttnn/unit_tests/per_core_allocation/test_per_core_allocation_op_opt_in.py
+++ b/tests/ttnn/unit_tests/per_core_allocation/test_per_core_allocation_op_opt_in.py
@@ -14,22 +14,11 @@ shared the first core's allocation, which is silently wrong whenever those addre
 no op under ttnn/cpp/ttnn/operations resolves per-core addresses.
 """
 
-import os
-
 import pytest
 import torch
 
 import ttnn
-
-
-@pytest.fixture(scope="function")
-def per_core_mesh():
-    """1x1 mesh with HYBRID allocator mode, which per-core allocation requires."""
-    os.environ["TT_METAL_ALLOCATOR_MODE_HYBRID"] = "1"
-    mesh = ttnn.open_mesh_device(mesh_shape=ttnn.MeshShape(1, 1))
-    yield mesh
-    ttnn.close_mesh_device(mesh)
-    os.environ.pop("TT_METAL_ALLOCATOR_MODE_HYBRID", None)
+from conftest import requires_hybrid_allocator
 
 
 def _width_sharded_config(grid_start, grid_end, shard_shape, per_core):
@@ -44,7 +33,8 @@ def _width_sharded_config(grid_start, grid_end, shard_shape, per_core):
     return mem_config
 
 
-def test_op_rejects_per_core_input(per_core_mesh, expect_error):
+@requires_hybrid_allocator
+def test_op_rejects_per_core_input(per_core_mesh_device, expect_error):
     """Handing a per-core tensor to an op that has not opted in must fail loudly."""
     mem_config = _width_sharded_config((0, 0), (7, 0), (512, 32), per_core=True)
     torch_input = torch.randn(512, 32 * 8, dtype=torch.bfloat16)
@@ -54,8 +44,8 @@ def test_op_rejects_per_core_input(per_core_mesh, expect_error):
         dtype=ttnn.bfloat16,
         layout=ttnn.ROW_MAJOR_LAYOUT,
         memory_config=mem_config,
-        mesh_mapper=ttnn.ReplicateTensorToMesh(per_core_mesh),
-        device=per_core_mesh,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(per_core_mesh_device),
+        device=per_core_mesh_device,
     )
     assert row_major.is_per_core_allocated(), "precondition failed: ROW_MAJOR input is not per-core"
 
@@ -63,7 +53,8 @@ def test_op_rejects_per_core_input(per_core_mesh, expect_error):
         ttnn.tilize(row_major, memory_config=mem_config)
 
 
-def test_lockstep_input_unaffected(per_core_mesh):
+@requires_hybrid_allocator
+def test_lockstep_input_unaffected(per_core_mesh_device):
     """The check must be inert for ordinary lockstep tensors."""
     lockstep_config = _width_sharded_config((0, 0), (7, 0), (512, 32), per_core=False)
     torch_input = torch.randn(512, 32 * 8, dtype=torch.bfloat16)
@@ -73,8 +64,8 @@ def test_lockstep_input_unaffected(per_core_mesh):
         dtype=ttnn.bfloat16,
         layout=ttnn.ROW_MAJOR_LAYOUT,
         memory_config=lockstep_config,
-        mesh_mapper=ttnn.ReplicateTensorToMesh(per_core_mesh),
-        device=per_core_mesh,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(per_core_mesh_device),
+        device=per_core_mesh_device,
     )
 
     tiled = ttnn.tilize(row_major, memory_config=lockstep_config)

--- a/tests/ttnn/unit_tests/per_core_allocation/test_per_core_allocation_op_opt_in.py
+++ b/tests/ttnn/unit_tests/per_core_allocation/test_per_core_allocation_op_opt_in.py
@@ -1,0 +1,81 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Ops must opt in before they can be handed a per-core allocated tensor.
+
+Ops address a buffer by a single L1 address — `Buffer::address()` is the first core's, and
+CB binding, runtime-arg patching and the host write/read all resolve through it (#51354). An
+op that has not been taught to resolve per-core addresses would read every core as though it
+shared the first core's allocation, which is silently wrong whenever those addresses differ.
+
+`launch()` therefore refuses a per-core input to any op that has not declared
+`supports_per_core_allocation`. Nothing declares it today, which matches the current state:
+no op under ttnn/cpp/ttnn/operations resolves per-core addresses.
+"""
+
+import os
+
+import pytest
+import torch
+
+import ttnn
+
+
+@pytest.fixture(scope="function")
+def per_core_mesh():
+    """1x1 mesh with HYBRID allocator mode, which per-core allocation requires."""
+    os.environ["TT_METAL_ALLOCATOR_MODE_HYBRID"] = "1"
+    mesh = ttnn.open_mesh_device(mesh_shape=ttnn.MeshShape(1, 1))
+    yield mesh
+    ttnn.close_mesh_device(mesh)
+    os.environ.pop("TT_METAL_ALLOCATOR_MODE_HYBRID", None)
+
+
+def _width_sharded_config(grid_start, grid_end, shard_shape, per_core):
+    crs = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(*grid_start), ttnn.CoreCoord(*grid_end))])
+    mem_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ttnn.BufferType.L1,
+        ttnn.ShardSpec(crs, list(shard_shape), ttnn.ShardOrientation.ROW_MAJOR),
+    )
+    if per_core:
+        mem_config.experimental_set_per_core_allocation(True)
+    return mem_config
+
+
+def test_op_rejects_per_core_input(per_core_mesh, expect_error):
+    """Handing a per-core tensor to an op that has not opted in must fail loudly."""
+    mem_config = _width_sharded_config((0, 0), (7, 0), (512, 32), per_core=True)
+    torch_input = torch.randn(512, 32 * 8, dtype=torch.bfloat16)
+
+    row_major = ttnn.from_torch(
+        torch_input,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        memory_config=mem_config,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(per_core_mesh),
+        device=per_core_mesh,
+    )
+    assert row_major.is_per_core_allocated(), "precondition failed: ROW_MAJOR input is not per-core"
+
+    with expect_error(RuntimeError, "has not opted in to per-core allocation"):
+        ttnn.tilize(row_major, memory_config=mem_config)
+
+
+def test_lockstep_input_unaffected(per_core_mesh):
+    """The check must be inert for ordinary lockstep tensors."""
+    lockstep_config = _width_sharded_config((0, 0), (7, 0), (512, 32), per_core=False)
+    torch_input = torch.randn(512, 32 * 8, dtype=torch.bfloat16)
+
+    row_major = ttnn.from_torch(
+        torch_input,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        memory_config=lockstep_config,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(per_core_mesh),
+        device=per_core_mesh,
+    )
+
+    tiled = ttnn.tilize(row_major, memory_config=lockstep_config)
+    assert torch.equal(ttnn.to_torch(tiled), torch_input), "tilize corrupted the data"

--- a/ttnn/api/ttnn/device_operation.hpp
+++ b/ttnn/api/ttnn/device_operation.hpp
@@ -22,6 +22,7 @@
 #include "ttnn/distributed/api.hpp"
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/experimental/inspector.hpp>
+#include <tt-metalium/experimental/per_core_allocation/mesh_buffer.hpp>
 #include <type_traits>
 #include "ttnn/mesh_device_operation_adapter.hpp"
 #include "ttnn/operation_concepts.hpp"
@@ -43,10 +44,54 @@ using AdaptedCachedMeshWorkload = tt::tt_metal::program_cache::detail::AdaptedCa
 template <typename T>
 using CachedMeshWorkload = tt::tt_metal::program_cache::detail::CachedMeshWorkload<T>;
 
+// Opt-in marker for per-core L1 allocation.
+//
+// A per-core allocated buffer has an independent L1 address on every core, but ops address a
+// buffer by a single value -- Buffer::address() is the first core's address, and CB binding,
+// runtime-arg patching and the host write/read all resolve through it (#51354). An op that has
+// not been taught to resolve `get_per_core_address()` per core would therefore address every
+// core as though it shared the first core's allocation, which is silently wrong whenever those
+// addresses differ.
+//
+// Ops are refused per-core inputs and outputs unless they declare support:
+//
+//     struct MyDeviceOperation {
+//         static constexpr bool supports_per_core_allocation = true;
+//         ...
+//     };
+//
+// Declaring it is a promise that the op resolves per-core addresses at every point it binds the
+// buffer -- circular buffers, runtime args, and any borrowed-memory attachment.
+template <typename T>
+concept PerCoreAllocationAware = requires {
+    { T::supports_per_core_allocation } -> std::convertible_to<bool>;
+} && T::supports_per_core_allocation;
+
 namespace detail {
 
 using ::tt::tt_metal::program_cache::detail::CachedProgramFactory;
 using ::tt::tt_metal::program_cache::detail::ProgramCacheKey;
+
+// Refuse a per-core allocated input on an op that has not opted in. See PerCoreAllocationAware.
+//
+// Only inputs are checked here. Checking the requested *output* memory config would mean walking
+// operation_attributes, and ttsl::reflection's visitor throws on any leaf that is neither the
+// target type nor reflectable (reflection.hpp:696) -- fine for tensor_args, which holds nothing
+// but tensors, but not for attributes structs full of scalars. Ops that rebuild their output
+// MemoryConfig therefore still need their own guard; see the ones in tilize / untilize.
+inline void reject_per_core_allocation(const Tensor& tensor, std::string_view operation_name) {
+    if (!is_device_tensor(tensor) || !tensor.is_allocated()) {
+        return;
+    }
+    TT_FATAL(
+        !tt::tt_metal::experimental::per_core_allocation::is_per_core_allocation(tensor.mesh_buffer()),
+        "{}: input tensor is per-core allocated, but this operation has not opted in to per-core allocation. "
+        "Ops address a buffer by a single L1 address, so a per-core buffer would be read as though every core "
+        "shared the first core's allocation (#51354). If the operation resolves per-core addresses, declare "
+        "`static constexpr bool supports_per_core_allocation = true` on it; otherwise build the tensor with a "
+        "lockstep memory config.",
+        operation_name);
+}
 
 template <typename... Ts>
 [[nodiscard]] std::variant<Ts...> map_index_to_variant(std::size_t i, std::variant<Ts...>) {
@@ -454,6 +499,9 @@ typename device_operation_t::tensor_return_value_t launch(
         const auto& input_tensor = input_tensor_ref.get();
         TT_FATAL(is_device_tensor(input_tensor), "Device Operations expect device tensors as inputs");
         TT_FATAL(input_tensor.is_allocated(), "Input Tensor is not allocated");
+        if constexpr (!PerCoreAllocationAware<device_operation_t>) {
+            reject_per_core_allocation(input_tensor, operation_name);
+        }
     }
 
     auto tensor_return_value = device_operation_t::create_output_tensors(operation_attributes, tensor_args);

--- a/ttnn/api/ttnn/device_operation.hpp
+++ b/ttnn/api/ttnn/device_operation.hpp
@@ -53,7 +53,7 @@ using CachedMeshWorkload = tt::tt_metal::program_cache::detail::CachedMeshWorklo
 // core as though it shared the first core's allocation, which is silently wrong whenever those
 // addresses differ.
 //
-// Ops are refused per-core inputs and outputs unless they declare support:
+// Ops are refused per-core *inputs* unless they declare support (the output side is #51482):
 //
 //     struct MyDeviceOperation {
 //         static constexpr bool supports_per_core_allocation = true;

--- a/ttnn/api/ttnn/device_operation.hpp
+++ b/ttnn/api/ttnn/device_operation.hpp
@@ -22,7 +22,6 @@
 #include "ttnn/distributed/api.hpp"
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/experimental/inspector.hpp>
-#include <tt-metalium/experimental/per_core_allocation/buffer.hpp>
 #include <type_traits>
 #include "ttnn/mesh_device_operation_adapter.hpp"
 #include "ttnn/operation_concepts.hpp"
@@ -44,60 +43,10 @@ using AdaptedCachedMeshWorkload = tt::tt_metal::program_cache::detail::AdaptedCa
 template <typename T>
 using CachedMeshWorkload = tt::tt_metal::program_cache::detail::CachedMeshWorkload<T>;
 
-// Opt-in marker for per-core L1 allocation.
-//
-// A per-core allocated buffer has an independent L1 address on every core, but ops address a
-// buffer by a single value -- Buffer::address() is the first core's address, and CB binding,
-// runtime-arg patching and the host write/read all resolve through it (#51354). An op that has
-// not been taught to resolve `get_per_core_address()` per core would therefore address every
-// core as though it shared the first core's allocation, which is silently wrong whenever those
-// addresses differ.
-//
-// Ops are refused per-core *inputs* unless they declare support (the output side is #51482):
-//
-//     struct MyDeviceOperation {
-//         static constexpr bool supports_per_core_allocation = true;
-//         ...
-//     };
-//
-// Declaring it is a promise that the op resolves per-core addresses at every point it binds the
-// buffer -- circular buffers, runtime args, and any borrowed-memory attachment.
-template <typename T>
-concept PerCoreAllocationAware = requires {
-    { T::supports_per_core_allocation } -> std::convertible_to<bool>;
-} && T::supports_per_core_allocation;
-
 namespace detail {
 
 using ::tt::tt_metal::program_cache::detail::CachedProgramFactory;
 using ::tt::tt_metal::program_cache::detail::ProgramCacheKey;
-
-// Refuse a per-core allocated input on an op that has not opted in. See PerCoreAllocationAware.
-//
-// Only inputs are checked here. Checking the requested *output* memory config would mean walking
-// operation_attributes, and ttsl::reflection's visitor throws on any leaf that is neither the
-// target type nor reflectable (reflection.hpp:696) -- fine for tensor_args, which holds nothing
-// but tensors, but not for attributes structs full of scalars. An op that rebuilds its output
-// MemoryConfig from named fields can therefore still drop the per-core bit unnoticed; that is
-// tracked in #51482, and needs an input that is itself lockstep, which no current path produces.
-inline void reject_per_core_allocation(const Tensor& tensor, std::string_view operation_name) {
-    // Ask via device_local_config().sharding_args, not the MeshBuffer overload of
-    // is_per_core_allocation. That overload resolves MeshBuffer::get_reference_buffer(), which
-    // TT_THROWs "no local buffer found" when no shard is local -- and this runs before launch()'s
-    // inactive-MeshDevice short-circuit, which exists precisely because most MeshDevice calls fail
-    // there. A guard meant to be inert must not be able to throw.
-    // This is also the expression behind Tensor.is_per_core_allocated(), so the check and the
-    // accessor the caller branches on cannot disagree.
-    TT_FATAL(
-        !tt::tt_metal::experimental::per_core_allocation::is_per_core_allocation(
-            tensor.mesh_buffer().device_local_config().sharding_args),
-        "{}: input tensor is per-core allocated, but this operation has not opted in to per-core allocation. "
-        "Ops address a buffer by a single L1 address, so a per-core buffer would be read as though every core "
-        "shared the first core's allocation (#51354). If the operation resolves per-core addresses, declare "
-        "`static constexpr bool supports_per_core_allocation = true` on it; otherwise build the tensor with a "
-        "lockstep memory config.",
-        operation_name);
-}
 
 template <typename... Ts>
 [[nodiscard]] std::variant<Ts...> map_index_to_variant(std::size_t i, std::variant<Ts...>) {
@@ -505,8 +454,13 @@ typename device_operation_t::tensor_return_value_t launch(
         const auto& input_tensor = input_tensor_ref.get();
         TT_FATAL(is_device_tensor(input_tensor), "Device Operations expect device tensors as inputs");
         TT_FATAL(input_tensor.is_allocated(), "Input Tensor is not allocated");
-        if constexpr (!PerCoreAllocationAware<device_operation_t>) {
-            reject_per_core_allocation(input_tensor, operation_name);
+    }
+
+    // Whether the op accepts per-core allocation is a property of the op, not of any one tensor,
+    // so ask it once rather than inside the loop above.
+    if constexpr (!SupportsPerCoreAllocation<device_operation_t>) {
+        for (size_t i = 0; i < input_tensors.size(); ++i) {
+            detail::validate_no_per_core_allocation(input_tensors[i].get(), operation_name, i);
         }
     }
 

--- a/ttnn/api/ttnn/device_operation.hpp
+++ b/ttnn/api/ttnn/device_operation.hpp
@@ -77,8 +77,9 @@ using ::tt::tt_metal::program_cache::detail::ProgramCacheKey;
 // Only inputs are checked here. Checking the requested *output* memory config would mean walking
 // operation_attributes, and ttsl::reflection's visitor throws on any leaf that is neither the
 // target type nor reflectable (reflection.hpp:696) -- fine for tensor_args, which holds nothing
-// but tensors, but not for attributes structs full of scalars. Ops that rebuild their output
-// MemoryConfig therefore still need their own guard; see the ones in tilize / untilize.
+// but tensors, but not for attributes structs full of scalars. An op that rebuilds its output
+// MemoryConfig from named fields can therefore still drop the per-core bit unnoticed; that is
+// tracked in #51482, and needs an input that is itself lockstep, which no current path produces.
 inline void reject_per_core_allocation(const Tensor& tensor, std::string_view operation_name) {
     if (!is_device_tensor(tensor) || !tensor.is_allocated()) {
         return;

--- a/ttnn/api/ttnn/device_operation.hpp
+++ b/ttnn/api/ttnn/device_operation.hpp
@@ -22,7 +22,7 @@
 #include "ttnn/distributed/api.hpp"
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/experimental/inspector.hpp>
-#include <tt-metalium/experimental/per_core_allocation/mesh_buffer.hpp>
+#include <tt-metalium/experimental/per_core_allocation/buffer.hpp>
 #include <type_traits>
 #include "ttnn/mesh_device_operation_adapter.hpp"
 #include "ttnn/operation_concepts.hpp"
@@ -81,11 +81,16 @@ using ::tt::tt_metal::program_cache::detail::ProgramCacheKey;
 // MemoryConfig from named fields can therefore still drop the per-core bit unnoticed; that is
 // tracked in #51482, and needs an input that is itself lockstep, which no current path produces.
 inline void reject_per_core_allocation(const Tensor& tensor, std::string_view operation_name) {
-    if (!is_device_tensor(tensor) || !tensor.is_allocated()) {
-        return;
-    }
+    // Ask via device_local_config().sharding_args, not the MeshBuffer overload of
+    // is_per_core_allocation. That overload resolves MeshBuffer::get_reference_buffer(), which
+    // TT_THROWs "no local buffer found" when no shard is local -- and this runs before launch()'s
+    // inactive-MeshDevice short-circuit, which exists precisely because most MeshDevice calls fail
+    // there. A guard meant to be inert must not be able to throw.
+    // This is also the expression behind Tensor.is_per_core_allocated(), so the check and the
+    // accessor the caller branches on cannot disagree.
     TT_FATAL(
-        !tt::tt_metal::experimental::per_core_allocation::is_per_core_allocation(tensor.mesh_buffer()),
+        !tt::tt_metal::experimental::per_core_allocation::is_per_core_allocation(
+            tensor.mesh_buffer().device_local_config().sharding_args),
         "{}: input tensor is per-core allocated, but this operation has not opted in to per-core allocation. "
         "Ops address a buffer by a single L1 address, so a per-core buffer would be read as though every core "
         "shared the first core's allocation (#51354). If the operation resolves per-core addresses, declare "

--- a/ttnn/api/ttnn/device_operation_detail.hpp
+++ b/ttnn/api/ttnn/device_operation_detail.hpp
@@ -4,7 +4,9 @@
 
 #pragma once
 
+#include <cstddef>
 #include <functional>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -46,5 +48,23 @@ compute_output_placements_and_shape(const std::vector<std::reference_wrapper<con
 std::vector<tt::tt_metal::distributed::MeshCoordinate> extract_tensor_coordinates_impl(
     const std::vector<std::reference_wrapper<const ttnn::Tensor>>& tensors,
     tt::tt_metal::distributed::MeshDevice* mesh_device);
+
+/**
+ * Fail if `tensor` is per-core allocated. Called by launch() for every tensor in tensor_args when
+ * the operation does not satisfy SupportsPerCoreAllocation.
+ *
+ * `input_index` is the tensor's position in the visit order of tensor_args, reported so the
+ * message names which one of an op's several tensors is at fault.
+ *
+ * tensor_args holds preallocated output tensors as well as inputs, so those are covered too --
+ * an op that cannot resolve per-core addresses cannot write to a per-core output either. What is
+ * *not* covered is the output MemoryConfig requested through operation_attributes: reaching it
+ * would mean walking an attributes struct, and the non-matching overload of
+ * ttsl::reflection::visit_object_of_type_t throws on any leaf that is neither the target type
+ * nor reflectable. Fine for tensor_args, which holds nothing but tensors; not for attributes
+ * structs full of scalars. An op that rebuilds its output MemoryConfig from named fields can
+ * therefore still drop the per-core bit unnoticed; tracked in #51482.
+ */
+void validate_no_per_core_allocation(const ttnn::Tensor& tensor, std::string_view operation_name, size_t input_index);
 
 }  // namespace ttnn::device_operation::detail

--- a/ttnn/api/ttnn/operation_concepts.hpp
+++ b/ttnn/api/ttnn/operation_concepts.hpp
@@ -229,4 +229,30 @@ concept HasSkipLaunch = requires(
     } -> std::convertible_to<bool>;
 };
 
+// Opt-in marker for per-core L1 allocation.
+//
+// A per-core allocated buffer has an independent L1 address on every core, but ops address a
+// buffer by a single value -- Buffer::address() is the first core's address, and CB binding,
+// runtime-arg patching and the host write/read all resolve through it (#51354). An op that has
+// not been taught to resolve `get_per_core_address()` per core would therefore address every
+// core as though it shared the first core's allocation, which is silently wrong whenever those
+// addresses differ.
+//
+// launch() refuses per-core allocated tensors in tensor_args unless the op declares support:
+//
+//     struct MyDeviceOperation {
+//         static constexpr bool supports_per_core_allocation = true;
+//         ...
+//     };
+//
+// Declaring it is a promise that the op resolves per-core addresses at every point it binds the
+// buffer -- circular buffers, runtime args, and any borrowed-memory attachment.
+//
+// Satisfied only when the member is present *and* true, so an op can opt back out with
+// `= false` without removing the declaration.
+template <typename device_operation_t>
+concept SupportsPerCoreAllocation = requires {
+    { device_operation_t::supports_per_core_allocation } -> std::convertible_to<bool>;
+} && device_operation_t::supports_per_core_allocation;
+
 }  // namespace ttnn::device_operation

--- a/ttnn/core/device_operation_detail.cpp
+++ b/ttnn/core/device_operation_detail.cpp
@@ -27,14 +27,6 @@ using MeshCoordinate = tt::tt_metal::distributed::MeshCoordinate;
 using MeshCoordinateRange = tt::tt_metal::distributed::MeshCoordinateRange;
 using MeshCoordinateRangeSet = tt::tt_metal::distributed::MeshCoordinateRangeSet;
 
-// ─────────────────────────────────────────────────────────────────────
-// compute_output_placements_and_shape
-// ─────────────────────────────────────────────────────────────────────
-//
-// Factored from the former template get_output_placements_and_shape<device_operation_t>.
-// The only reason it was templated was to call visit_object_of_type<Tensor> on tensor_args.
-// Callers now extract tensors first and pass them as a vector.
-
 static bool is_fully_replicated(const ttnn::Tensor& tensor) {
     for (const auto& placement : tensor.tensor_topology().placements()) {
         if (std::holds_alternative<tt::tt_metal::distributed::MeshMapperConfig::Shard>(placement)) {
@@ -44,6 +36,9 @@ static bool is_fully_replicated(const ttnn::Tensor& tensor) {
     return true;
 }
 
+// Factored from the former template get_output_placements_and_shape<device_operation_t>. The only
+// reason it was templated was to call visit_object_of_type<Tensor> on tensor_args; callers now
+// extract the tensors first and pass them as a vector.
 std::pair<
     ttsl::SmallVector<tt::tt_metal::distributed::MeshMapperConfig::Placement>,
     tt::tt_metal::distributed::MeshShape>
@@ -145,10 +140,6 @@ compute_output_placements_and_shape(const std::vector<std::reference_wrapper<con
     return {result_placements, tt::tt_metal::distributed::MeshShape(result_strides)};
 }
 
-// ─────────────────────────────────────────────────────────────────────
-// extract_tensor_coordinates_impl
-// ─────────────────────────────────────────────────────────────────────
-
 // Checks if the MeshCoordinateRangeSet containing all coordinates in b is a subset of a.
 static bool is_subset_of(const std::vector<MeshCoordinate>& a, const std::vector<MeshCoordinate>& b) {
     MeshCoordinateRangeSet a_set;
@@ -223,10 +214,6 @@ std::vector<MeshCoordinate> extract_tensor_coordinates_impl(
     }
     return tensor_coordinates;
 }
-
-// ─────────────────────────────────────────────────────────────────────
-// validate_no_per_core_allocation
-// ─────────────────────────────────────────────────────────────────────
 
 void validate_no_per_core_allocation(const ttnn::Tensor& tensor, std::string_view operation_name, size_t input_index) {
     // Ask device_local_config().sharding_args, not the MeshBuffer overload of

--- a/ttnn/core/device_operation_detail.cpp
+++ b/ttnn/core/device_operation_detail.cpp
@@ -13,6 +13,7 @@
 #include <vector>
 
 #include <tt-metalium/distributed.hpp>
+#include <tt-metalium/experimental/per_core_allocation/buffer.hpp>
 #include <tt-metalium/mesh_coord.hpp>
 #include <tt_stl/small_vector.hpp>
 
@@ -221,6 +222,31 @@ std::vector<MeshCoordinate> extract_tensor_coordinates_impl(
         }
     }
     return tensor_coordinates;
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// validate_no_per_core_allocation
+// ─────────────────────────────────────────────────────────────────────
+
+void validate_no_per_core_allocation(const ttnn::Tensor& tensor, std::string_view operation_name, size_t input_index) {
+    // Ask device_local_config().sharding_args, not the MeshBuffer overload of
+    // is_per_core_allocation. That overload resolves MeshBuffer::get_reference_buffer(), which
+    // TT_THROWs "no local buffer found" when no shard is local -- and this runs before launch()'s
+    // inactive-MeshDevice short-circuit, which exists precisely because most MeshDevice calls fail
+    // there. A guard whose contract is to be inert must not be able to throw.
+    // This is also the expression behind Tensor.is_per_core_allocated(), so the guard and the
+    // accessor callers branch on cannot disagree about what per-core means.
+    TT_FATAL(
+        !tt::tt_metal::experimental::per_core_allocation::is_per_core_allocation(
+            tensor.mesh_buffer().device_local_config().sharding_args),
+        "{}: tensor {} is per-core allocated, but this operation has not opted in to per-core "
+        "allocation. Ops address a buffer by a single L1 address, so a per-core buffer would be read as "
+        "though every core shared the first core's allocation (#51354). If the operation resolves "
+        "per-core addresses, declare `static constexpr bool supports_per_core_allocation = true` on it; "
+        "otherwise build the tensor with a lockstep memory config. Memory config: {}",
+        operation_name,
+        input_index,
+        tensor.memory_config());
 }
 
 }  // namespace ttnn::device_operation::detail

--- a/ttnn/core/tensor/py_to_tt_tensor.cpp
+++ b/ttnn/core/tensor/py_to_tt_tensor.cpp
@@ -9,6 +9,7 @@
 #include "ttnn/operations/core/core.hpp"
 
 #include <tt-metalium/allocator.hpp>
+#include <ttnn/tensor/memory_config/memory_config.hpp>
 #include <tt_stl/unreachable.hpp>
 
 #include <tracy/Tracy.hpp>
@@ -66,7 +67,18 @@ bool can_construct_on_device(
     DataType dst_dtype,
     const std::optional<Tile>& optional_tile,
     bool enable_device_typecast,
-    bool preserve_nan_values) {
+    bool preserve_nan_values,
+    const MemoryConfig& memory_config) {
+    // Constructing on device builds the tensor in the *source* layout and converts it with ttnn
+    // ops (tilize / typecast). Those ops rebuild the output MemoryConfig from a handful of named
+    // fields and drop the experimental per-core allocation bit, so the caller would silently get
+    // a lockstep-allocated buffer (#51133). No op understands per-core allocation today (#51354),
+    // so there is nothing to preserve the bit through. Build on host instead: the subsequent
+    // to_device() applies the caller's memory_config directly, with no op in between.
+    if (experimental::per_core_allocation::is_per_core_allocation(memory_config)) {
+        return false;
+    }
+
     bool res = device != nullptr && !device->is_remote_only() &&
                (device->get_active_sub_device_manager_id() == device->get_default_sub_device_manager_id()) &&
                tensor_shape.volume() > 0 && can_exec_ops_on_device(src_dtype) && can_exec_ops_on_device(dst_dtype) &&
@@ -238,7 +250,14 @@ Tensor create_tt_tensor_from_host_data(
         TensorLayout dst_tensor_layout(dst_dtype, PageConfig(layout, optional_tile), memory_config);
 
         const bool construct_on_device = can_construct_on_device(
-            device, tensor_shape, src_dtype, dst_dtype, optional_tile, enable_device_typecast, preserve_nan_values);
+            device,
+            tensor_shape,
+            src_dtype,
+            dst_dtype,
+            optional_tile,
+            enable_device_typecast,
+            preserve_nan_values,
+            memory_config);
 
         if (mesh_mapper != nullptr) {
             const auto device_shard_shape =

--- a/ttnn/core/tensor/py_to_tt_tensor.cpp
+++ b/ttnn/core/tensor/py_to_tt_tensor.cpp
@@ -9,7 +9,7 @@
 #include "ttnn/operations/core/core.hpp"
 
 #include <tt-metalium/allocator.hpp>
-#include <ttnn/tensor/memory_config/memory_config.hpp>
+#include <tt-metalium/experimental/per_core_allocation/memory_config.hpp>
 #include <tt_stl/unreachable.hpp>
 
 #include <tracy/Tracy.hpp>


### PR DESCRIPTION
Using per-core L1 allocation has two issues today:

1. `ttnn.from_torch(device=..., memory_config=<per-core L1>)` silently returns a tensor that is **not** per-core allocated (#51133).
2. Nothing stops anyone passing a per-core tensor to any TTNN op, and no op handles one correctly.

The Python bindings already guard this: `buffer_address()` raises for a per-core tensor and points you at `experimental_per_core_buffer_address(core)`. But ops call the C++ API directly, where there is no equivalent check, so the guard does not apply on the path that matters.

## Cause of (1)

Calling `from_torch` can build the tensor as ROW_MAJOR on device and tilize it there. Tilize rebuilds the output `MemoryConfig` from three named fields, discarding everything else the caller asked for, including the per-core bit. Nothing catches it: the bit is private, missing from `attribute_names`, and ignored by `operator==`.

## Changes

**1. `from_torch` never dispatches on-device ops for per-core tensors.** `can_construct_on_device()` now takes the memory config and returns false for per-core, so the tensor is built on host and `to_device()` applies the caller's config directly. Host tilize handles per-core fine.

**2. Ops must opt in to per-core support; passing one to an op that hasn't crashes.** `launch()` is the single entry point for device ops and already walks every input tensor. It now rejects a per-core input to any op that has not declared:

```cpp
static constexpr bool supports_per_core_allocation = true;
```

Nothing declares it. No op under `ttnn/cpp/ttnn/operations` resolves per-core addresses, so an op handed one would read every core at the first core's address.

## Why crash rather than support it

Making every op per-core aware is not realistic, each would have to resolve `get_per_core_address()` per core at every CB binding and runtime arg. Crashing is a good default, and an op that does the work can opt in.

## Tests

`test_per_core_allocation_from_torch.py` and `test_per_core_allocation_op_opt_in.py`: the shapes from the issue including `gate_mm`'s 7168x32 (the one weight affected in tt-blaze), the large shard that already took the host path, ROW_MAJOR, a per-core input reaching an op, and lockstep paths through both changes to show they are inert for ordinary use.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=esmal/per-core-allocation-op-opt-in)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:esmal/per-core-allocation-op-opt-in)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=esmal/per-core-allocation-op-opt-in)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:esmal/per-core-allocation-op-opt-in)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=esmal/per-core-allocation-op-opt-in)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:esmal/per-core-allocation-op-opt-in)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=esmal/per-core-allocation-op-opt-in)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:esmal/per-core-allocation-op-opt-in)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=esmal/per-core-allocation-op-opt-in)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:esmal/per-core-allocation-op-opt-in)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=esmal/per-core-allocation-op-opt-in)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:esmal/per-core-allocation-op-opt-in)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=esmal/per-core-allocation-op-opt-in)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:esmal/per-core-allocation-op-opt-in)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=esmal/per-core-allocation-op-opt-in)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:esmal/per-core-allocation-op-opt-in)