### PR TITLE
floor_div: collapse the Inf guard into a single isinf check

### DIFF
--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
@@ -550,11 +550,12 @@ Tensor floor_div(
 Tensor floor_div(const Tensor& input_a, const Tensor& input_b, const std::optional<MemoryConfig>& output_mem_config) {
     Tensor temp = ttnn::div(input_a, input_b, false, std::nullopt, std::nullopt, output_mem_config);
     Tensor result = ttnn::div(input_a, input_b, false, "floor", std::nullopt, output_mem_config);
-    // floor(nan, inf, -inf) = nan, inf, -inf. isfinite tests all three in a
-    // single SFPU pass, replacing three eq's and two logical_or's. Note that
-    // eq(temp, nan) was always false under IEEE, so the NaN case previously
-    // fell through to the floored value.
-    return ttnn::where(ttnn::isfinite(temp, output_mem_config), result, temp);
+    // floor(inf, -inf) = inf, -inf. isinf tests both in a single SFPU pass,
+    // replacing two eq's and a logical_or. The dropped eq(temp, nan) term was
+    // always false under IEEE, so NaN selects the floored value here exactly as
+    // it did before; isinf (rather than !isfinite) keeps that branch identical
+    // without relying on floor propagating NaN.
+    return ttnn::where(ttnn::isinf(temp, output_mem_config), temp, result);
 }
 
 // outer(a, b) treats each input's last dim as a vector and broadcasts the

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
@@ -434,7 +434,7 @@ Tensor prelu(const Tensor& input_a, const Tensor& input_b, const std::optional<M
         s_a[1]);
     Tensor b = input_b;
     if (s_a.rank() > 2) {
-        ttsl::SmallVector<uint32_t> reshape(s_a.rank(), 1);
+        ttsl::SmallVector<std::uint32_t> reshape(s_a.rank(), 1);
         reshape[1] = s_a[1];
         b = ttnn::reshape(input_b, ttnn::Shape(reshape));
     }
@@ -550,15 +550,11 @@ Tensor floor_div(
 Tensor floor_div(const Tensor& input_a, const Tensor& input_b, const std::optional<MemoryConfig>& output_mem_config) {
     Tensor temp = ttnn::div(input_a, input_b, false, std::nullopt, std::nullopt, output_mem_config);
     Tensor result = ttnn::div(input_a, input_b, false, "floor", std::nullopt, output_mem_config);
-    // floor(nan, inf, -inf) = nan, inf, -inf
-    return ttnn::where(
-        ttnn::logical_or(
-            ttnn::eq(temp, std::nanf("")),
-            ttnn::logical_or(
-                ttnn::eq(temp, std::numeric_limits<float>::infinity()),
-                ttnn::eq(temp, -std::numeric_limits<float>::infinity()))),
-        temp,
-        result);
+    // floor(nan, inf, -inf) = nan, inf, -inf. isfinite tests all three in a
+    // single SFPU pass, replacing three eq's and two logical_or's. Note that
+    // eq(temp, nan) was always false under IEEE, so the NaN case previously
+    // fell through to the floored value.
+    return ttnn::where(ttnn::isfinite(temp, output_mem_config), result, temp);
 }
 
 // outer(a, b) treats each input's last dim as a vector and broadcasts the
@@ -630,15 +626,15 @@ Tensor outer(const Tensor& input_a, const Tensor& input_b, const std::optional<M
     // Effective batch is the product of leading dims (everything except the
     // vector dim); a scalar leading shape means batch=1. Uses logical shape so
     // padded tile geometry doesn't leak into the dispatch decision.
-    auto leading_volume = [](const Tensor& t) -> uint64_t {
+    auto leading_volume = [](const Tensor& t) -> std::uint64_t {
         const auto& shape = t.logical_shape();
-        uint64_t v = 1;
+        std::uint64_t v = 1;
         for (int i = 0; i + 1 < static_cast<int>(shape.rank()); ++i) {
-            v *= static_cast<uint64_t>(shape[i]);
+            v *= static_cast<std::uint64_t>(shape[i]);
         }
         return v;
     };
-    const uint64_t batch = std::max<uint64_t>(leading_volume(input_a), leading_volume(input_b));
+    const std::uint64_t batch = std::max<std::uint64_t>(leading_volume(input_a), leading_volume(input_b));
     const bool use_matmul = !is_integer && !is_fp32 && batch == 1;
     if (use_matmul) {
         // matmul requires TILE inputs and, unlike the binary_ng multiply path,
@@ -717,8 +713,8 @@ Tensor pow(
     const std::optional<MemoryConfig>& output_mem_config,
     const std::optional<Tensor>& output_tensor) {
     float exponent_floor = std::floor(exponent);
-    if (static_cast<int32_t>(exponent_floor) == exponent) {
-        int32_t exp = exponent;
+    if (static_cast<std::int32_t>(exponent_floor) == exponent) {
+        std::int32_t exp = exponent;
         return pow(input_a, exp, output_mem_config, output_tensor);
     }
     return ttnn::power(input_a, exponent, output_mem_config, output_tensor);
@@ -727,12 +723,12 @@ Tensor pow(
 // power - integer exponent
 Tensor pow(
     const Tensor& input,
-    int32_t exponent,
+    std::int32_t exponent,
     const std::optional<MemoryConfig>& output_mem_config,
     const std::optional<Tensor>& output_tensor) {
     // For exponents 0, 1, 2, 3: use iterative approach
     if (exponent == 0 || exponent == 1 || exponent == 2 || exponent == 3) {
-        uint32_t exp = exponent;
+        std::uint32_t exp = exponent;
         return ttnn::power_iterative(input, exp, output_mem_config, output_tensor);
     }
     return ttnn::power(input, unary::ScalarVariant(exponent), output_mem_config, output_tensor);


### PR DESCRIPTION
Closes #51436

### Problem

`ttnn.floor_div(tensor, tensor)` dispatches **9 device kernels**. Only two divides and a select are actual work; the other five exist purely to detect non-finite values:

```cpp
return ttnn::where(
    ttnn::logical_or(
        ttnn::eq(temp, std::nanf("")),
        ttnn::logical_or(
            ttnn::eq(temp, std::numeric_limits<float>::infinity()),
            ttnn::eq(temp, -std::numeric_limits<float>::infinity()))),
    temp,
    result);
```

Three `eq` plus two `logical_or` are five separate dispatches, each paying kernel launch overhead plus a full DRAM read + write of the tensor. At `1x1x32x32` that guard alone is 15994 ns of a 23698 ns op.

### Change

`ttnn::isinf` is a single SFPU unary covering both ±Inf:

```cpp
return ttnn::where(ttnn::isinf(temp, output_mem_config), temp, result);
```

9 dispatches -> 5.

Note the guard tests three conditions but only needs two. The `eq(temp, nan)` term **can never be true**, because NaN compares unequal to everything under IEEE 754, so NaN already fell through to `result`. `isinf` selects `temp` for ±Inf and `result` for both finite and NaN, reproducing the original selection in all three cases exactly.

### Performance

Measured on **p150b (Blackhole)**, bfloat16, summing `DEVICE KERNEL DURATION [ns]` across every kernel the op dispatches. Before/after are separate builds of the same branch, baseline taken by stashing this commit only.

| shape | kernels before | kernels after | before | after | change |
|---|---|---|---|---|---|
| `1x1x32x32` | 9 | 5 | 23698 ns | 8974 ns | **-62.1%** |
| `1x1x512x1024` | 9 | 5 | 81475 ns | 45969 ns | **-43.6%** |

Per-kernel at `1x1x32x32`:

| | before | after |
|---|---|---|
| `div` (no rounding) | 2333 | 2320 |
| `div` (floor) | 2228 + 1356 | 2261 + 1359 |
| guard | 3901 + 3861 + 3887 + 2204 + 2141 | 1257 (`isinf`) |
| `where` | 1787 | 1777 |
| **total** | **23698** | **8974** |

### Correctness

Equivalent to the previous expression. Two checks were run.

**1. Driven through `div`, matching real `floor_div` inputs** (finite, division by zero, `0/0`):

```
       num ['7', '-7', '5', '0', '6', '-6', '1', '0']
       den ['2', '2', '-2', '3', '0', '0', '0', '0']
       OLD ['3', '-4', '-3', '0', 'inf', '-inf', 'inf', 'inf']
       NEW ['3', '-4', '-3', '0', 'inf', '-inf', 'inf', 'inf']
OLD == NEW everywhere: True
```

**2. With `temp` constructed directly**, because `ttnn.div(0, 0)` returns `inf` on device and so never produces a NaN `temp`. Using float32, where NaN survives the round-trip:

```
      temp(in) ['3.5', '-3.5', '0', 'inf', '-inf', 'nan', '7.25', '-0.75']
   floor(temp) ['3', '-4', '0', 'inf', '-inf', 'nan', '7', '-1']
           OLD ['3', '-4', '0', 'inf', '-inf', 'nan', '7', '-1']
     NEW isinf ['3', '-4', '0', 'inf', '-inf', 'nan', '7', '-1']
  OLD == isinf : True
```

The second check is why this uses `isinf` rather than `!isfinite`. `isfinite` is also false for NaN, so it would select `temp` where the original selected `result`. The emitted values still agree, since `floor(NaN)` is NaN on device, but that makes the rewrite depend on an invariant of the `floor` kernel rather than on the branch structure. `isinf` avoids that dependency at identical cost. Thanks to @copilot for catching this.

Unrelated to this change, `ttnn.div(0, 0)` returns `inf` on device where torch returns `nan` (last column of the first table). That comes from `div` itself and is untouched here.

### Tests

- `tests/ttnn/unit_tests/operations/eltwise/test_div_ops.py` — 116 passed, 8 skipped, 2 xfailed
- `test_composite.py`, `test_binary_composite.py`, `test_activation.py` filtered to div/floor_div — passing

### Note on diff noise

The `std::` prefixes on integer types elsewhere in the file were applied automatically by the `fix-cstdint` pre-commit hook to pre-existing lines once the file was touched. They are unrelated to the logic change; the functional diff is the five lines in `floor_div`.