### PR TITLE
[ttnn] Add GPT-OSS sliding prefill to RingJointSDPA

### DIFF
--- a/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
+++ b/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
@@ -541,8 +541,10 @@ class RingJointSDPARuntime:
     compute_kernel_config: object
 
 
-def open_ring_joint_sdpa_runtime(mesh_config, *, fp32_dest_acc_en: bool = False, trace_region_size: int = 0):
-    use_ring = mesh_config.sp_size > 2
+def open_ring_joint_sdpa_runtime(
+    mesh_config, *, fp32_dest_acc_en: bool = False, trace_region_size: int = 0, topology: Topology = None
+):
+    use_ring = mesh_config.sp_size > 2 if topology is None else topology == Topology.Ring
     fabric_config = ttnn.FabricConfig.FABRIC_1D_RING if use_ring else ttnn.FabricConfig.FABRIC_1D
     topology = Topology.Ring if use_ring else Topology.Linear
 
@@ -4875,8 +4877,8 @@ def test_ring_joint_attention_sdpa_chunked_accuracy(model_name, qk_configs, chun
     )
 
 
-def test_ring_joint_attention_gpt_oss_chunked_sliding_native_ring_gqa_accuracy():
-    """Validate the GPT-OSS grouped schedule on the detected SP4 or SP8 native ring."""
+def test_ring_joint_attention_gpt_oss_chunked_sliding_native_ring_gqa_accuracy_and_determinism():
+    """Validate GPT-OSS grouped-schedule accuracy and cache-hit determinism on the native ring."""
     batch_size = gpt_oss_native_ring_batch_size(MESH_CONFIG)
     chunk_size = 1024
     total_seq = 3 * chunk_size
@@ -4921,6 +4923,74 @@ def test_ring_joint_attention_gpt_oss_chunked_sliding_native_ring_gqa_accuracy()
             )
     finally:
         close_ring_joint_sdpa_runtime(runtime, clear_program_cache=True)
+
+
+def test_ring_joint_attention_gpt_oss_chunked_sliding_indexed_kv_cache_accuracy():
+    """Validate sliding halo reads from each requested indexed K/V-cache slot on a cache hit."""
+    chunk_size = 1024
+    total_seq = 2 * chunk_size
+    final_chunk = total_seq // chunk_size - 1
+    model = replace(
+        GPT_OSS_CHUNKED_MODEL,
+        name="gpt_oss_chunked_sliding_indexed_kv_cache",
+        q_chunk_sizes=[64],
+        seq_len=chunk_size,
+    )
+
+    runtime = open_ring_joint_sdpa_runtime(MESH_CONFIG)
+    runtime.mesh_device.enable_program_cache()
+    try:
+        with mock.patch.dict(os.environ, {CHUNKED_PREFILL_CHUNK_ID_ENV: str(final_chunk)}):
+            for kv_cache_batch_idx in (0, 1):
+                # The runner fills non-selected slots with conspicuously different data. Both calls
+                # have identical program-cache keys (the key records only that indexing is enabled),
+                # so slot 1 verifies that the cached neighbor-halo reader patches its batch base.
+                run_ring_joint_sdpa_chunked(
+                    MESH_CONFIG,
+                    model,
+                    batch_size=1,
+                    chunk_size=chunk_size,
+                    total_seq=total_seq,
+                    qk_configs=[(64, 128)],
+                    indexed_nd_sharded_kv_cache=True,
+                    kv_cache_batch_idx=kv_cache_batch_idx,
+                    cache_batch=2,
+                    persistent_buffer_mode="exact_per_chunk",
+                    sliding_window_size=GPT_OSS_RING_SINK_CONFIG.sliding_window_size,
+                    runtime=runtime,
+                )
+    finally:
+        close_ring_joint_sdpa_runtime(runtime, clear_program_cache=True)
+
+
+def test_ring_joint_attention_gpt_oss_chunked_sliding_linear_topology_accuracy():
+    """Validate the compact cyclic predecessor halo over a physical linear fabric."""
+    chunk_size = 1024
+    total_seq = 2 * chunk_size
+    final_chunk = total_seq // chunk_size - 1
+    model = replace(
+        GPT_OSS_CHUNKED_MODEL,
+        name="gpt_oss_chunked_sliding_linear",
+        q_chunk_sizes=[64],
+        seq_len=chunk_size,
+    )
+
+    runtime = open_ring_joint_sdpa_runtime(MESH_CONFIG, topology=Topology.Linear)
+    try:
+        with mock.patch.dict(os.environ, {CHUNKED_PREFILL_CHUNK_ID_ENV: str(final_chunk)}):
+            run_ring_joint_sdpa_chunked(
+                MESH_CONFIG,
+                model,
+                batch_size=1,
+                chunk_size=chunk_size,
+                total_seq=total_seq,
+                qk_configs=[(64, 128)],
+                persistent_buffer_mode="exact_per_chunk",
+                sliding_window_size=GPT_OSS_RING_SINK_CONFIG.sliding_window_size,
+                runtime=runtime,
+            )
+    finally:
+        close_ring_joint_sdpa_runtime(runtime)
 
 
 def test_ring_joint_attention_gpt_oss_chunked_sliding_production_accuracy():

--- a/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
+++ b/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
@@ -830,6 +830,18 @@ def gpt_oss_chunked_mesh_config():
     return replace(MESH_CONFIG, tp_size=1, sp_size=MESH_CONFIG.num_devices)
 
 
+def gpt_oss_native_ring_batch_size(mesh_config: MeshConfig) -> int:
+    """Scale the native-ring GPT-OSS surrogate batch with its SP ring size.
+
+    QuietBox's SP4 ring covers the B1 surrogate; LoudBox's SP8 ring covers the
+    corresponding B2 schedule.  Keeping the total work per ring group constant
+    lets the same coverage run on both systems.
+    """
+    if mesh_config.sp_size not in (4, 8):
+        pytest.skip(f"GPT-OSS native-ring surrogate requires SP4 or SP8, got SP{mesh_config.sp_size}")
+    return mesh_config.sp_size // 4
+
+
 def run_ring_joint_sdpa(
     mesh_config,
     b,
@@ -3437,9 +3449,9 @@ def test_ring_joint_attention_kv_pad_aware_rotation_accuracy(case_name):
     )
 
 
-@pytest.mark.parametrize("batch_size", [1, 2], ids=["b1_production", "b2_sp8_sim"])
-def test_ring_joint_attention_sliding_kv_pad_reuse_gqa_accuracy_and_determinism(batch_size, expect_error):
+def test_ring_joint_attention_sliding_kv_pad_reuse_gqa_accuracy_and_determinism(expect_error):
     """Validate GPT-OSS sliding GQA against garbage-padded KV and cache-hit scalar updates."""
+    batch_size = gpt_oss_native_ring_batch_size(MESH_CONFIG)
     run_ring_joint_sdpa_sliding_kv_pad_reuse_case(MESH_CONFIG, batch_size=batch_size, expect_error=expect_error)
 
 
@@ -4863,32 +4875,9 @@ def test_ring_joint_attention_sdpa_chunked_accuracy(model_name, qk_configs, chun
     )
 
 
-def test_ring_joint_attention_gpt_oss_chunked_sliding_boundary_accuracy():
-    """Validate the chunked sliding-window path across the cyclic device boundary."""
-    chunk_size = 2048
-    total_seq = 3 * chunk_size
-    final_chunk = total_seq // chunk_size - 1
-    model = replace(
-        GPT_OSS_CHUNKED_MODEL,
-        name="gpt_oss_chunked_sliding_boundary",
-        q_chunk_sizes=[64],
-        seq_len=chunk_size,
-    )
-
-    with mock.patch.dict(os.environ, {CHUNKED_PREFILL_CHUNK_ID_ENV: str(final_chunk)}):
-        run_ring_joint_sdpa_chunked(
-            MESH_CONFIG,
-            model,
-            chunk_size=chunk_size,
-            total_seq=total_seq,
-            qk_configs=[(64, 128)],
-            persistent_buffer_mode="exact_per_chunk",
-            sliding_window_size=GPT_OSS_RING_SINK_CONFIG.sliding_window_size,
-        )
-
-
-def test_ring_joint_attention_gpt_oss_chunked_sliding_multibatch_gqa_accuracy():
-    """Validate the B2 grouped schedule used by the native-SP8 GPT-OSS CI simulation."""
+def test_ring_joint_attention_gpt_oss_chunked_sliding_native_ring_gqa_accuracy():
+    """Validate the GPT-OSS grouped schedule on the detected SP4 or SP8 native ring."""
+    batch_size = gpt_oss_native_ring_batch_size(MESH_CONFIG)
     chunk_size = 1024
     total_seq = 3 * chunk_size
     final_chunk = total_seq // chunk_size - 1
@@ -4899,32 +4888,39 @@ def test_ring_joint_attention_gpt_oss_chunked_sliding_multibatch_gqa_accuracy():
         seq_len=chunk_size,
     )
 
-    with mock.patch.dict(os.environ, {CHUNKED_PREFILL_CHUNK_ID_ENV: str(final_chunk)}):
-        run_ring_joint_sdpa_chunked(
-            MESH_CONFIG,
-            model,
-            batch_size=2,
-            chunk_size=chunk_size,
-            total_seq=total_seq,
-            qk_configs=[(64, 128)],
-            persistent_buffer_mode="exact_per_chunk",
-            sliding_window_size=GPT_OSS_RING_SINK_CONFIG.sliding_window_size,
-        )
+    runtime = open_ring_joint_sdpa_runtime(MESH_CONFIG)
+    runtime.mesh_device.enable_program_cache()
+    try:
+        with mock.patch.dict(os.environ, {CHUNKED_PREFILL_CHUNK_ID_ENV: str(final_chunk)}):
+            run_ring_joint_sdpa_chunked(
+                MESH_CONFIG,
+                model,
+                batch_size=batch_size,
+                chunk_size=chunk_size,
+                total_seq=total_seq,
+                qk_configs=[(64, 128)],
+                persistent_buffer_mode="exact_per_chunk",
+                sliding_window_size=GPT_OSS_RING_SINK_CONFIG.sliding_window_size,
+                runtime=runtime,
+            )
 
-        # Exercise cached-program replay separately from the PCC pass. Consuming the compact
-        # collective's readiness tokens per dispatch prevents a later call from observing a
-        # stale semaphore value before its one-hop K/V halo payload has arrived.
-        run_ring_joint_sdpa_chunked(
-            MESH_CONFIG,
-            model,
-            batch_size=2,
-            chunk_size=chunk_size,
-            total_seq=total_seq,
-            qk_configs=[(64, 128)],
-            num_iterations=3,
-            persistent_buffer_mode="exact_per_chunk",
-            sliding_window_size=GPT_OSS_RING_SINK_CONFIG.sliding_window_size,
-        )
+            # Reuse the exact runtime and physical shapes from the PCC pass. This is a real
+            # program-cache hit, rather than merely a disk-JIT-cache hit after reopening the mesh.
+            # The determinism comparison itself adds its own tiny comparison program.
+            run_ring_joint_sdpa_chunked(
+                MESH_CONFIG,
+                model,
+                batch_size=batch_size,
+                chunk_size=chunk_size,
+                total_seq=total_seq,
+                qk_configs=[(64, 128)],
+                num_iterations=3,
+                persistent_buffer_mode="exact_per_chunk",
+                sliding_window_size=GPT_OSS_RING_SINK_CONFIG.sliding_window_size,
+                runtime=runtime,
+            )
+    finally:
+        close_ring_joint_sdpa_runtime(runtime, clear_program_cache=True)
 
 
 def test_ring_joint_attention_gpt_oss_chunked_sliding_production_accuracy():
@@ -5769,6 +5765,7 @@ GPT_OSS_CHUNKED_PERF_CHECK_CONFIGS = [
 
 
 @pytest.mark.timeout(600)
+@pytest.mark.skipif(os.environ.get("CI") == "true", reason="Performance gate is not part of CI correctness coverage")
 @pytest.mark.parametrize(
     "q_chunk_size,k_chunk_size,expected_util,margin",
     GPT_OSS_CHUNKED_PERF_CHECK_CONFIGS,

--- a/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
+++ b/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
@@ -8,6 +8,7 @@ Ring Joint Attention SDPA Tests for Video Generation and MLA Models on Blackhole
 Tests Ring Joint Attention accuracy and determinism using:
 - WAN 2.2 model shapes: standard attention with non-causal, non-balanced mode
 - DeepSeek MLA (Multi-Latent Attention): causal attention with balanced zigzag work distribution
+- GPT-OSS attention sinks: 64Q/8KV/64D causal GQA on a dedicated TP8/SP4 mesh
 
 Runs on BH multi-chip setups (single ring 1xN or Galaxy 4x8 mesh).
 Perf table generation is included but skipped on CI.
@@ -16,6 +17,7 @@ Model Configurations:
 - WAN: nhq == nhk == nhv, d_q == d_k == d_v == 128, bfloat16 for all tensors
 - MLA: nhk == 1, d_q == d_k == 576, d_v == 128, bfloat16 for Q, bfloat8_b for K/V
 - Minimax3 GQA: nhk == nhv < nhq, d_q == d_k == d_v == 128, bfloat16 for Q, bfloat8_b for K/V
+- GPT-OSS: 64Q/8KV, d_q == d_k == d_v == 64, bfloat16 for Q, bfloat8_b for K/V
 
 BH adaptation: uses init_device_compute_kernel_config instead of WormholeComputeKernelConfig.
 """
@@ -56,6 +58,27 @@ MESH_CONFIG = MeshConfig.detect()
 # See test_instructions.md for full parallelization context.
 
 BATCH_SIZE = 1
+
+
+@dataclass(frozen=True)
+class GPTOSSRingSinkConfig:
+    """Operator-only GPT-OSS attention geometry; intentionally separate from MODEL_CONFIGS."""
+
+    global_q_heads: int = 64
+    global_kv_heads: int = 8
+    head_dim: int = 64
+    tp_size: int = 8
+    sp_size: int = 4
+    sliding_window_size: int = 128
+    q_dtype: ttnn.DataType = ttnn.bfloat16
+    kv_dtype: ttnn.DataType = ttnn.bfloat8_b
+
+
+GPT_OSS_RING_SINK_CONFIG = GPTOSSRingSinkConfig()
+GPT_OSS_Q_CHUNK_SIZE = 128
+GPT_OSS_K_CHUNK_SIZE = 128
+GPT_OSS_CHUNKED_CHUNK_SIZE = 5120
+GPT_OSS_CHUNKED_TOTAL_SEQ = 56320
 
 
 @dataclass
@@ -363,7 +386,7 @@ def deterministic_input_tensor(*shape, offset=0.0):
     return (seq_pattern + head_pattern + dim_pattern + offset).expand(shape).contiguous()
 
 
-def torch_sdpa_reference(q, k, v, is_causal=False):
+def torch_sdpa_reference(q, k, v, is_causal=False, attention_sink=None):
     """
     Memory-efficient PyTorch reference for ring joint attention.
 
@@ -385,7 +408,33 @@ def torch_sdpa_reference(q, k, v, is_causal=False):
         kv_indices = torch.arange(h_start, h_end, device=t.device) // heads_per_kv
         return t[:, kv_indices]
 
-    if total_seq <= SEQ_CHUNK and H <= HEAD_CHUNK:
+    if attention_sink is not None:
+        assert is_causal, "attention sink reference is defined for causal attention only"
+        # Unlike PyTorch SDPA, the virtual sink key has no V row. Compute the
+        # sink-aware softmax explicitly, using compact blocks to keep the
+        # full-causal M3 reference bounded in host memory.
+        SEQ_CHUNK = 512
+        HEAD_CHUNK = 4
+        scale = q.shape[-1] ** -0.5
+        attn_out = torch.empty(B, H, total_seq, Dv, dtype=q.dtype)
+        for h_start in range(0, H, HEAD_CHUNK):
+            h_end = min(h_start + HEAD_CHUNK, H)
+            q_heads = q[:, h_start:h_end]
+            k_heads = take_heads(k, h_start, h_end)
+            v_heads = take_heads(v, h_start, h_end)
+            sink_scores = attention_sink[:, h_start:h_end].float() * scale
+            for seq_start in range(0, total_seq, SEQ_CHUNK):
+                seq_end = min(seq_start + SEQ_CHUNK, total_seq)
+                scores = (
+                    q_heads[:, :, seq_start:seq_end].float() @ k_heads[:, :, :seq_end].transpose(-2, -1).float()
+                ) * scale
+                q_pos = torch.arange(seq_start, seq_end, device=q.device).unsqueeze(1)
+                k_pos = torch.arange(seq_end, device=q.device).unsqueeze(0)
+                scores = scores.masked_fill(k_pos > q_pos, float("-inf"))
+                expanded_sink = sink_scores.expand(B, h_end - h_start, seq_end - seq_start, 1)
+                weights = torch.softmax(torch.cat([scores, expanded_sink], dim=-1), dim=-1)[..., :-1]
+                attn_out[:, h_start:h_end, seq_start:seq_end] = (weights @ v_heads[:, :, :seq_end].float()).to(q.dtype)
+    elif total_seq <= SEQ_CHUNK and H <= HEAD_CHUNK:
         attn_out = torch.nn.functional.scaled_dot_product_attention(
             q,
             take_heads(k, 0, H),
@@ -721,6 +770,8 @@ def call_sdpa(
     kv_cache_batch_idx=None,
     kv_actual_isl=None,
     is_cross=False,
+    attention_sink=None,
+    sliding_window_size=None,
 ):
     tt_out, _, _ = ttnn.transformer.ring_joint_scaled_dot_product_attention(
         tt_q,
@@ -750,8 +801,33 @@ def call_sdpa(
         scale=scale,
         kv_cache_batch_idx=kv_cache_batch_idx,
         kv_actual_isl=kv_actual_isl,
+        attention_sink=attention_sink,
+        sliding_window_size=sliding_window_size,
     )
     return tt_out
+
+
+def gpt_oss_tp8_sp4_mesh_config():
+    cfg = GPT_OSS_RING_SINK_CONFIG
+    if MESH_CONFIG.num_devices != cfg.tp_size * cfg.sp_size:
+        pytest.skip(
+            f"GPT-OSS ring-sink tests require {cfg.tp_size * cfg.sp_size} devices for "
+            f"TP={cfg.tp_size}, SP={cfg.sp_size}; detected {MESH_CONFIG.num_devices}"
+        )
+    mesh_config = replace(MESH_CONFIG, tp_size=cfg.tp_size, sp_size=cfg.sp_size)
+    assert mesh_config.num_devices == mesh_config.tp_size * mesh_config.sp_size
+    assert cfg.global_q_heads % mesh_config.tp_size == 0
+    assert cfg.global_kv_heads % mesh_config.tp_size == 0
+    return mesh_config
+
+
+def gpt_oss_chunked_mesh_config():
+    """Use production TP8/SP4 on Galaxy and the supported native-ring surrogate elsewhere."""
+    if MESH_CONFIG.num_devices == GPT_OSS_RING_SINK_CONFIG.tp_size * GPT_OSS_RING_SINK_CONFIG.sp_size:
+        return gpt_oss_tp8_sp4_mesh_config()
+    if MESH_CONFIG.num_devices not in (4, 8):
+        pytest.skip(f"GPT-OSS chunked sliding requires a 4- or 8-device ring, got {MESH_CONFIG.num_devices}")
+    return replace(MESH_CONFIG, tp_size=1, sp_size=MESH_CONFIG.num_devices)
 
 
 def run_ring_joint_sdpa(
@@ -1035,6 +1111,7 @@ def run_ring_joint_sdpa_model_configs(
     num_iterations=1,
     runtime: RingJointSDPARuntime = None,
     fp32_dest_acc_en: bool = False,
+    use_attention_sink: bool = False,
 ):
     """Run all q/k configs for one model while reusing shared inputs, mesh setup, and reference data."""
     qk_configs = list(qk_configs)
@@ -1048,6 +1125,8 @@ def run_ring_joint_sdpa_model_configs(
     d_q, d_k, d_v = model.d_q, model.d_k, model.d_v
     q_dtype, kv_dtype = model.q_dtype, model.kv_dtype
     is_causal, is_balanced = model.is_causal, model.is_balanced
+    if use_attention_sink:
+        assert is_causal, "attention sink coverage requires causal attention"
 
     logger.debug(
         f"run_ring_joint_sdpa_model_configs params: model={model.name}, b={b}, "
@@ -1091,6 +1170,11 @@ def run_ring_joint_sdpa_model_configs(
             K = fa_rand(b, nhk, sq, d_k)
             V = fa_rand(b, nhv, sq, d_v)
         Q_original, K_original, V_original = Q, K, V
+        operator_sink = None
+        if use_attention_sink:
+            scale = d_q**-0.5
+            model_sink = torch.linspace(-4.0, 12.0, nhq).reshape(1, nhq, 1, 1)
+            operator_sink = model_sink / scale
 
         chunk_order = None
         if is_balanced:
@@ -1146,6 +1230,20 @@ def run_ring_joint_sdpa_model_configs(
                 mesh_device, mesh_shape=tuple(mesh_device.shape), dims=sdpa_input_shard_dims
             ),
         )
+        tt_attention_sink = None
+        if operator_sink is not None:
+            sink_shard_dims = [None, None]
+            if mesh_config.tp_size > 1:
+                sink_shard_dims[tp_axis] = 1
+            tt_attention_sink = ttnn.from_torch(
+                operator_sink,
+                dtype=ttnn.bfloat16,
+                layout=ttnn.TILE_LAYOUT,
+                device=mesh_device,
+                mesh_mapper=ttnn.ShardTensor2dMesh(
+                    mesh_device, mesh_shape=tuple(mesh_device.shape), dims=sink_shard_dims
+                ),
+            )
 
         main_row_dim = sdpa_input_shard_dims[0] if sdpa_input_shard_dims[0] is not None else -1
         main_col_dim = sdpa_input_shard_dims[1] if sdpa_input_shard_dims[1] is not None else -1
@@ -1153,7 +1251,9 @@ def run_ring_joint_sdpa_model_configs(
 
         gt_main = None
         if do_check and num_iterations == 1:
-            gt_main = torch_sdpa_reference(Q_original, K_original, V_original, is_causal=is_causal)
+            gt_main = torch_sdpa_reference(
+                Q_original, K_original, V_original, is_causal=is_causal, attention_sink=operator_sink
+            )
 
         use_device_determinism_compare = num_iterations > 1 and sq % ttnn.TILE_SIZE == 0 and d_v % ttnn.TILE_SIZE == 0
 
@@ -1215,6 +1315,7 @@ def run_ring_joint_sdpa_model_configs(
                     topology=topology,
                     worker_sub_device_id=worker_sub_device_id,
                     ccl_column=ccl_column,
+                    attention_sink=tt_attention_sink,
                 )
 
                 if use_device_determinism_compare:
@@ -1479,6 +1580,7 @@ def get_chunked_only_chunk_id(n_chunks: int):
 def run_ring_joint_sdpa_chunked(
     mesh_config,
     model: ModelConfig,
+    batch_size: int = BATCH_SIZE,
     chunk_size: int = CHUNKED_PREFILL_CHUNK_SIZE,
     total_seq: int = CHUNKED_PREFILL_TOTAL_SEQ,
     pcc_threshold: float = CHUNKED_PREFILL_PCC_THRESHOLD,
@@ -1495,6 +1597,8 @@ def run_ring_joint_sdpa_chunked(
     do_check: bool = True,
     reuse_kv_buffer: bool = False,
     fp32_dest_acc_en: bool = False,
+    sliding_window_size: int = None,
+    use_attention_sink: bool = False,
     runtime: RingJointSDPARuntime = None,
 ):
     """
@@ -1530,6 +1634,8 @@ def run_ring_joint_sdpa_chunked(
         assert model.nhk == 1, f"ring_mla requires one shared latent K/V head, got nhk={model.nhk}"
         assert not indexed_nd_sharded_kv_cache, "ring_mla chunked path here does not use the indexed ND-sharded cache"
         assert model.d_v <= model.d_k, f"latent V (d_v={model.d_v}) must fit within the K/V latent (d_k={model.d_k})"
+    if use_attention_sink:
+        assert not use_ring_mla, "attention sink coverage requires separate K/V ring joint SDPA"
 
     # reuse_kv_buffer: reuse one fixed, oversized KV cache across all chunks (logical_n / kv_actual_isl
     # grow per chunk) instead of a fresh right-sized input each chunk. Perf-only (pad-rotation permutes
@@ -1540,7 +1646,7 @@ def run_ring_joint_sdpa_chunked(
         assert num_iterations == 1, "reuse_kv_buffer is a single-pass perf path"
         assert not indexed_nd_sharded_kv_cache, "reuse_kv_buffer uses its own oversized cache layout"
     if indexed_nd_sharded_kv_cache:
-        assert BATCH_SIZE == 1, "Indexed K/V cache test path assumes query batch is 1"
+        assert batch_size == 1, "Indexed K/V cache test path assumes query batch is 1"
         assert (
             0 <= kv_cache_batch_idx < cache_batch
         ), f"kv_cache_batch_idx {kv_cache_batch_idx} must be in [0, {cache_batch})"
@@ -1574,7 +1680,7 @@ def run_ring_joint_sdpa_chunked(
     # Chunked cache growth is linear in sequence order; balanced zigzag applies only to full prefill.
     is_balanced = False
 
-    b = BATCH_SIZE
+    b = batch_size
 
     owns_runtime = runtime is None
     if runtime is None:
@@ -1607,12 +1713,34 @@ def run_ring_joint_sdpa_chunked(
         else:
             V_full = fa_rand(b, nhv, total_seq, d_v)
 
+        operator_sink = None
+        if use_attention_sink:
+            scale = d_q**-0.5
+            model_sink = torch.linspace(-4.0, 12.0, nhq).reshape(1, nhq, 1, 1)
+            operator_sink = model_sink / scale
+
         # do_check=False (perf/profiling) skips the full-sequence CPU torch reference: it is an
         # O(total_seq^2) host SDPA that dominates wall-clock, while the device kernel — the only
         # thing the profiler measures — still runs below. Mirrors run_ring_joint_sdpa's do_check.
         ref_full = None
         if num_iterations == 1 and do_check:
-            ref_full = torch_sdpa_reference(Q_full, K_full, V_full, is_causal=True)
+            if sliding_window_size is None and operator_sink is None:
+                ref_full = torch_sdpa_reference(Q_full, K_full, V_full, is_causal=True)
+            else:
+                ref_full = torch.cat(
+                    [
+                        torch_chunked_causal_sdpa_reference(
+                            Q_full[:, :, s:e, :],
+                            K_full[:, :, :e, :],
+                            V_full[:, :, :e, :],
+                            s,
+                            sliding_window_size=sliding_window_size,
+                            attention_sink=operator_sink,
+                        )
+                        for s, e in ((i * chunk_size, (i + 1) * chunk_size) for i in range(n_chunks))
+                    ],
+                    dim=2,
+                )
 
         sdpa_input_shard_dims = [None, None]
         sdpa_input_shard_dims[sp_axis] = 2
@@ -1690,6 +1818,21 @@ def run_ring_joint_sdpa_chunked(
                     mesh_device, mesh_shape=tuple(mesh_device.shape), dims=sdpa_input_shard_dims
                 ),
                 **kwargs,
+            )
+
+        tt_attention_sink = None
+        if operator_sink is not None:
+            sink_shard_dims = [None, None]
+            if mesh_config.tp_size > 1:
+                sink_shard_dims[tp_axis] = 1
+            tt_attention_sink = ttnn.from_torch(
+                operator_sink,
+                dtype=ttnn.bfloat16,
+                layout=ttnn.TILE_LAYOUT,
+                device=mesh_device,
+                mesh_mapper=ttnn.ShardTensor2dMesh(
+                    mesh_device, mesh_shape=tuple(mesh_device.shape), dims=sink_shard_dims
+                ),
             )
 
         def to_host(tt_out, expected_q_len):
@@ -1910,6 +2053,8 @@ def run_ring_joint_sdpa_chunked(
                     ccl_column=ccl_column,
                     kv_cache_batch_idx=kv_cache_batch_idx_arg,
                     kv_actual_isl=s if reuse_kv_buffer else None,
+                    sliding_window_size=sliding_window_size,
+                    attention_sink=tt_attention_sink,
                 )
             except Exception as exc:
                 op_name = "ring_mla" if use_ring_mla else "SDPA"
@@ -1928,15 +2073,37 @@ def run_ring_joint_sdpa_chunked(
                 f"{config_id} chunk {i:2d} [{s:6d}, {e:6d}) logical_n={e}: PCC={pcc} RMSE={rmse:.6f} "
                 f"-> {'PASS' if pcc_passed and rmse_passed else 'FAIL'}"
             )
+            if sliding_window_size is not None and not (pcc_passed and rmse_passed):
+                q_rows_per_device = chunk_size // sp_size
+                for device_index in range(sp_size):
+                    row_start = device_index * q_rows_per_device
+                    row_end = row_start + q_rows_per_device
+                    device_pcc, device_rmse = compute_pcc_rmse(
+                        expected_i[:, :, row_start:row_end, :], out_i[:, :, row_start:row_end, :]
+                    )
+                    logger.info(
+                        f"{config_id} device {device_index}: rows=[{row_start}, {row_end}), "
+                        f"PCC={device_pcc}, RMSE={device_rmse:.6f}"
+                    )
             per_chunk_results.append((i, e, pcc_passed, pcc, rmse_passed, rmse))
 
         config_ids = {(q, k): get_test_case_id(model, q, k) for q, k in qk_configs}
         per_chunk_results_by_config = {config_id: [] for config_id in config_ids.values()}
         determinism_mismatch_marker = None
         shared_persistent_buffers = None
+        compact_sliding_seq = None
+        if sliding_window_size is not None:
+            max_halo_tokens = max(math.ceil((sliding_window_size - 1) / k_chunk) * k_chunk for _, k_chunk in qk_configs)
+            compact_sliding_seq = max(max_halo_tokens, ttnn.TILE_SIZE)
         if persistent_buffer_mode == "reuse_max":
             # The gather buffer must hold the full physical input — the oversized cache under reuse_kv_buffer.
-            reuse_seq = reuse_kv_stable_seq if reuse_kv_buffer else total_seq
+            reuse_seq = (
+                compact_sliding_seq
+                if compact_sliding_seq is not None
+                else reuse_kv_stable_seq
+                if reuse_kv_buffer
+                else total_seq
+            )
             shared_persistent_buffers = (
                 create_ring_mla_kv_buffer(reuse_seq, b) if use_ring_mla else create_persistent_buffers(reuse_seq, b)
             )
@@ -1957,9 +2124,9 @@ def run_ring_joint_sdpa_chunked(
             chunk_persistent_buffers = None
             if persistent_buffer_mode != "reuse_max":
                 chunk_persistent_buffers = (
-                    create_ring_mla_kv_buffer(e, kv_buffer_batch)
+                    create_ring_mla_kv_buffer(compact_sliding_seq or e, kv_buffer_batch)
                     if use_ring_mla
-                    else create_persistent_buffers(e, kv_buffer_batch)
+                    else create_persistent_buffers(compact_sliding_seq or e, kv_buffer_batch)
                 )
 
             for q_chunk_size, k_chunk_size in qk_configs:
@@ -2079,20 +2246,65 @@ def run_ring_joint_sdpa_chunked(
             close_ring_joint_sdpa_runtime(runtime)
 
 
-def torch_chunked_causal_sdpa_reference(q, k, v, q_abs_offset, scale=None):
+def torch_chunked_causal_sdpa_reference(
+    q, k, v, q_abs_offset, scale=None, sliding_window_size=None, attention_sink=None
+):
     """Chunked causal SDPA reference where Q rows start at absolute position q_abs_offset."""
     nhq = q.shape[1]
-    k = k.expand(-1, nhq, -1, -1) if k.shape[1] == 1 else k
-    v = v.expand(-1, nhq, -1, -1) if v.shape[1] == 1 else v
+
+    def take_q_heads(t):
+        if t.shape[1] == nhq:
+            return t
+        assert nhq % t.shape[1] == 0
+        heads_per_kv = nhq // t.shape[1]
+        kv_indices = torch.arange(nhq) // heads_per_kv
+        return t[:, kv_indices]
+
     if scale is None:
         scale = q.shape[-1] ** -0.5
 
     sq = q.shape[2]
     sk = k.shape[2]
+    if sliding_window_size is not None:
+        block_size = 256
+        out = torch.empty_like(q)
+        for q_start in range(0, sq, block_size):
+            q_end = min(q_start + block_size, sq)
+            abs_q_start = q_abs_offset + q_start
+            abs_q_end = q_abs_offset + q_end
+            k_start = max(0, abs_q_start - sliding_window_size + 1)
+            k_end = min(sk, abs_q_end)
+            q_block = q[:, :, q_start:q_end, :].float()
+            k_block = take_q_heads(k[:, :, k_start:k_end, :]).float()
+            v_block = take_q_heads(v[:, :, k_start:k_end, :]).float()
+            scores = (q_block @ k_block.transpose(-2, -1)) * scale
+            q_pos = torch.arange(abs_q_start, abs_q_end)
+            k_pos = torch.arange(k_start, k_end)
+            scores = scores.masked_fill(k_pos.unsqueeze(0) > q_pos.unsqueeze(1), float("-inf"))
+            scores = scores.masked_fill(
+                k_pos.unsqueeze(0) < q_pos.unsqueeze(1) - sliding_window_size + 1,
+                float("-inf"),
+            )
+            if attention_sink is not None:
+                sink_scores = attention_sink.float() * scale
+                sink_scores = sink_scores.expand(q.shape[0], nhq, q_end - q_start, 1)
+                weights = torch.softmax(torch.cat([scores, sink_scores], dim=-1), dim=-1)[..., :-1]
+            else:
+                weights = torch.softmax(scores, dim=-1)
+            out[:, :, q_start:q_end, :] = (weights @ v_block).to(q.dtype)
+        return out
+
+    k = take_q_heads(k)
+    v = take_q_heads(v)
     scores = (q.float() @ k.transpose(-2, -1).float()) * scale
     q_pos = torch.arange(sq) + q_abs_offset
     k_pos = torch.arange(sk)
     scores = scores.masked_fill(k_pos.unsqueeze(0) > q_pos.unsqueeze(1), float("-inf"))
+    if attention_sink is not None:
+        sink_scores = attention_sink.float() * scale
+        sink_scores = sink_scores.expand(q.shape[0], nhq, sq, 1)
+        weights = torch.softmax(torch.cat([scores, sink_scores], dim=-1), dim=-1)[..., :-1]
+        return (weights @ v.float()).to(q.dtype)
     return (torch.softmax(scores, dim=-1) @ v.float()).to(q.dtype)
 
 
@@ -2128,9 +2340,11 @@ def build_kv_pad_rotation_inputs(
     chunk_size_local,
 ):
     """Build padded Q/K/V host tensors for one KV-pad-aware Ring SDPA call."""
-    assert old_cache_k.shape[0] == 1
-    assert old_cache_v.shape[0] == 1
-    assert new_tokens_q.shape[0] == 1
+    batch_size = new_tokens_q.shape[0]
+    assert old_cache_k.shape[0] == batch_size
+    assert old_cache_v.shape[0] == batch_size
+    assert new_tokens_k.shape[0] == batch_size
+    assert new_tokens_v.shape[0] == batch_size
 
     nhq = new_tokens_q.shape[1]
     nhk = new_tokens_k.shape[1]
@@ -2144,30 +2358,30 @@ def build_kv_pad_rotation_inputs(
     num_cache_slabs = max(2, math.ceil(logical_n / chunk_size_global))
     cache_seq_per_dev = num_cache_slabs * chunk_size_local
 
-    k_per_dev = torch.zeros(sp_size, nhk, cache_seq_per_dev, d_k, dtype=torch.bfloat16)
-    v_per_dev = torch.zeros(sp_size, nhv, cache_seq_per_dev, d_v, dtype=torch.bfloat16)
+    k_per_dev = torch.zeros(batch_size, sp_size, nhk, cache_seq_per_dev, d_k, dtype=torch.bfloat16)
+    v_per_dev = torch.zeros(batch_size, sp_size, nhv, cache_seq_per_dev, d_v, dtype=torch.bfloat16)
     for global_pos in range(kv_actual_isl):
         group = global_pos // chunk_size_global
         within_group = global_pos % chunk_size_global
         dev = within_group // chunk_size_local
         cell = within_group % chunk_size_local
         cache_row = group * chunk_size_local + cell
-        k_per_dev[dev, :, cache_row, :] = old_cache_k[0, :, global_pos, :]
-        v_per_dev[dev, :, cache_row, :] = old_cache_v[0, :, global_pos, :]
+        k_per_dev[:, dev, :, cache_row, :] = old_cache_k[:, :, global_pos, :]
+        v_per_dev[:, dev, :, cache_row, :] = old_cache_v[:, :, global_pos, :]
 
-    q_per_dev = torch.zeros(sp_size, nhq, chunk_size_local, d_q, dtype=torch.bfloat16)
+    q_per_dev = torch.zeros(batch_size, sp_size, nhq, chunk_size_local, d_q, dtype=torch.bfloat16)
     q_global_pos_per_dev = [[None] * chunk_size_local for _ in range(sp_size)]
     destinations = kv_pad_rotation_destinations(kv_actual_isl, new_actual_isl, sp_size, chunk_size_local)
     assert len(destinations) == new_actual_isl
     for token_idx, dev, cache_row, q_row, global_pos in destinations:
-        k_per_dev[dev, :, cache_row, :] = new_tokens_k[0, :, token_idx, :]
-        v_per_dev[dev, :, cache_row, :] = new_tokens_v[0, :, token_idx, :]
-        q_per_dev[dev, :, q_row, :] = new_tokens_q[0, :, token_idx, :]
+        k_per_dev[:, dev, :, cache_row, :] = new_tokens_k[:, :, token_idx, :]
+        v_per_dev[:, dev, :, cache_row, :] = new_tokens_v[:, :, token_idx, :]
+        q_per_dev[:, dev, :, q_row, :] = new_tokens_q[:, :, token_idx, :]
         q_global_pos_per_dev[dev][q_row] = global_pos
 
-    q_host = q_per_dev.permute(1, 0, 2, 3).reshape(1, nhq, chunk_size_global, d_q)
-    k_host = k_per_dev.permute(1, 0, 2, 3).reshape(1, nhk, sp_size * cache_seq_per_dev, d_k)
-    v_host = v_per_dev.permute(1, 0, 2, 3).reshape(1, nhv, sp_size * cache_seq_per_dev, d_v)
+    q_host = q_per_dev.permute(0, 2, 1, 3, 4).reshape(batch_size, nhq, chunk_size_global, d_q)
+    k_host = k_per_dev.permute(0, 2, 1, 3, 4).reshape(batch_size, nhk, sp_size * cache_seq_per_dev, d_k)
+    v_host = v_per_dev.permute(0, 2, 1, 3, 4).reshape(batch_size, nhv, sp_size * cache_seq_per_dev, d_v)
 
     combined_q_global_pos = []
     for dev in range(sp_size):
@@ -2405,6 +2619,266 @@ def run_ring_joint_sdpa_kv_pad_rotation_case(
 
     finally:
         close_ring_joint_sdpa_runtime(runtime)
+
+
+def run_ring_joint_sdpa_sliding_kv_pad_reuse_case(
+    mesh_config,
+    batch_size,
+    expect_error,
+    chunk_size_local=128,
+    sliding_window_size=128,
+    num_iterations=2,
+    pcc_threshold=CHUNKED_PREFILL_PCC_THRESHOLD,
+    rmse_threshold=DEFAULT_RMSE_THRESHOLD,
+):
+    """Validate compact sliding attention over one fixed, garbage-padded KV cache."""
+    sp_size = mesh_config.sp_size
+    if sp_size < 2:
+        pytest.skip(f"sliding KV-pad reuse requires at least 2 devices in ring, got SP={sp_size}")
+
+    tile_height = ttnn.TILE_SIZE
+    assert chunk_size_local % tile_height == 0
+    assert sliding_window_size > 0
+
+    local_q_heads = 8
+    local_kv_heads = 1
+    nhq = local_q_heads * mesh_config.tp_size
+    nhk = local_kv_heads * mesh_config.tp_size
+    nhv = nhk
+    gqa_ratio = local_q_heads // local_kv_heads
+    d_q = GPT_OSS_RING_SINK_CONFIG.head_dim
+    d_k = d_q
+    d_v = d_q
+    q_dtype = GPT_OSS_RING_SINK_CONFIG.q_dtype
+    kv_dtype = GPT_OSS_RING_SINK_CONFIG.kv_dtype
+    chunk_size_global = chunk_size_local * sp_size
+    # Compact chunked sliding consumes the current complete ring group plus its predecessor.
+    # Exercise early cache growth and the production chunk index (5K Q after ten 5K groups).
+    # Partial/wrapped Q groups are outside the compact GPT-OSS specialization and are covered
+    # by the pre-existing non-sliding KV-pad rotation tests.
+    prefix_lengths = (chunk_size_global, 2 * chunk_size_global, 10 * chunk_size_global)
+    logical_lengths = tuple(prefix + chunk_size_global for prefix in prefix_lengths)
+    max_logical_n = max(logical_lengths)
+
+    # Keep one physical input shape across every logical length and leave a complete extra slab
+    # filled with high-magnitude garbage. Correct logical_n/kv_actual_isl runtime patching must keep
+    # every trailing invalid slab out of the result.
+    stable_cache_slabs = math.ceil(max_logical_n / chunk_size_global) + 1
+    stable_cache_seq_per_dev = stable_cache_slabs * chunk_size_local
+    stable_kv_seq_len = sp_size * stable_cache_seq_per_dev
+    k_chunk_size = 128
+    q_chunk_size = 64
+    halo_tokens = math.ceil((sliding_window_size - 1) / k_chunk_size) * k_chunk_size
+    compact_persistent_seq_len = max(halo_tokens, tile_height)
+
+    torch.manual_seed(CHUNKED_PREFILL_SEED + batch_size)
+    q_full = fa_rand(batch_size, nhq, max_logical_n, d_q)
+    k_full = fa_rand(batch_size, nhk, max_logical_n, d_k)
+    v_full = fa_rand(batch_size, nhv, max_logical_n, d_v)
+
+    runtime = open_ring_joint_sdpa_runtime(mesh_config)
+    mesh_device = runtime.mesh_device
+    try:
+        input_shard_dims = [None, None]
+        input_shard_dims[runtime.sp_axis] = 2
+        if mesh_config.tp_size > 1:
+            input_shard_dims[runtime.tp_axis] = 1
+        persistent_shard_dims = [None, None]
+        if mesh_config.tp_size > 1:
+            persistent_shard_dims[runtime.tp_axis] = 1
+
+        def upload(host_tensor, dtype, shard_dims):
+            return ttnn.from_torch(
+                host_tensor,
+                dtype=dtype,
+                layout=ttnn.TILE_LAYOUT,
+                device=mesh_device,
+                mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=tuple(mesh_device.shape), dims=shard_dims),
+            )
+
+        persistent_output_buffer_k = upload(
+            torch.zeros(batch_size, nhk, compact_persistent_seq_len, d_k),
+            kv_dtype,
+            persistent_shard_dims,
+        )
+        persistent_output_buffer_v = upload(
+            torch.zeros(batch_size, nhv, compact_persistent_seq_len, d_v),
+            kv_dtype,
+            persistent_shard_dims,
+        )
+        mesh_device.enable_program_cache()
+        mesh_device.clear_program_cache()
+
+        program_config = ttnn.SDPAProgramConfig(
+            compute_with_storage_grid_size=runtime.sdpa_compute_grid,
+            q_chunk_size=q_chunk_size,
+            k_chunk_size=k_chunk_size,
+            exp_approx_mode=False,
+        )
+        main_row_dim = input_shard_dims[0] if input_shard_dims[0] is not None else -1
+        main_col_dim = input_shard_dims[1] if input_shard_dims[1] is not None else -1
+
+        logger.info(
+            f"sliding KV-pad reuse: B={batch_size}, TP={mesh_config.tp_size}, SP={sp_size}, "
+            f"local_heads={local_q_heads}Q/{local_kv_heads}KV, chunk_global={chunk_size_global}, "
+            f"window={sliding_window_size}, prefixes={prefix_lengths}, "
+            f"physical_kv={stable_kv_seq_len}, compact_persistent={compact_persistent_seq_len}"
+        )
+
+        reference_outputs = None
+        accuracy_results = []
+        cache_entries_after_first_call = None
+        for iteration in range(num_iterations):
+            iteration_outputs = []
+            for case_index, kv_actual_isl in enumerate(prefix_lengths):
+                logical_n = logical_lengths[case_index]
+                new_tokens_q = q_full[:, :, kv_actual_isl:logical_n, :].contiguous()
+                new_tokens_k = k_full[:, :, kv_actual_isl:logical_n, :].contiguous()
+                new_tokens_v = v_full[:, :, kv_actual_isl:logical_n, :].contiguous()
+                q_host, k_host, v_host, valid_rows, num_cache_slabs = build_kv_pad_rotation_inputs(
+                    k_full[:, :, :kv_actual_isl, :],
+                    v_full[:, :, :kv_actual_isl, :],
+                    new_tokens_q,
+                    new_tokens_k,
+                    new_tokens_v,
+                    kv_actual_isl,
+                    sp_size,
+                    chunk_size_local,
+                )
+                cache_seq_per_dev = k_host.shape[2] // sp_size
+                assert stable_cache_seq_per_dev > cache_seq_per_dev
+
+                valid_per_dev = torch.zeros(sp_size, cache_seq_per_dev, dtype=torch.bool)
+                for global_pos in range(kv_actual_isl):
+                    group = global_pos // chunk_size_global
+                    within_group = global_pos % chunk_size_global
+                    dev = within_group // chunk_size_local
+                    cache_row = group * chunk_size_local + within_group % chunk_size_local
+                    valid_per_dev[dev, cache_row] = True
+                for _, dev, cache_row, _, _ in kv_pad_rotation_destinations(
+                    kv_actual_isl, chunk_size_global, sp_size, chunk_size_local
+                ):
+                    valid_per_dev[dev, cache_row] = True
+
+                def add_garbage_tail(host, num_heads, head_dim):
+                    padded = (
+                        torch.randn(
+                            batch_size,
+                            num_heads,
+                            sp_size,
+                            stable_cache_seq_per_dev,
+                            head_dim,
+                            dtype=host.dtype,
+                        )
+                        * 100
+                    )
+                    active = padded[:, :, :, :cache_seq_per_dev, :]
+                    source = host.reshape(batch_size, num_heads, sp_size, cache_seq_per_dev, head_dim)
+                    active.copy_(
+                        torch.where(
+                            valid_per_dev.reshape(1, 1, sp_size, cache_seq_per_dev, 1),
+                            source,
+                            active,
+                        )
+                    )
+                    return padded.reshape(batch_size, num_heads, stable_kv_seq_len, head_dim)
+
+                tt_q = upload(q_host, q_dtype, input_shard_dims)
+                tt_k = upload(add_garbage_tail(k_host, nhk, d_k), kv_dtype, input_shard_dims)
+                tt_v = upload(add_garbage_tail(v_host, nhv, d_v), kv_dtype, input_shard_dims)
+
+                def run_device_call(logical_n_arg, kv_actual_isl_arg):
+                    return call_sdpa(
+                        tt_q,
+                        tt_k,
+                        tt_v,
+                        logical_n_arg,
+                        is_causal=True,
+                        is_balanced=False,
+                        p_buf_k=persistent_output_buffer_k,
+                        p_buf_v=persistent_output_buffer_v,
+                        program_config=program_config,
+                        compute_kernel_config=runtime.compute_kernel_config,
+                        ccl_semaphore_handles=runtime.ccl_semaphore_handles,
+                        num_links=runtime.num_links,
+                        sp_axis=runtime.sp_axis,
+                        mesh_device=mesh_device,
+                        topology=runtime.topology,
+                        worker_sub_device_id=runtime.worker_sub_device_id,
+                        ccl_column=runtime.ccl_column,
+                        kv_actual_isl=kv_actual_isl_arg,
+                        sliding_window_size=sliding_window_size,
+                    )
+
+                tt_out = run_device_call(logical_n, kv_actual_isl)
+
+                if iteration == 0 and case_index == 1:
+                    with expect_error(RuntimeError, "complete ring-group boundary"):
+                        # Same tensor specs and KV-pad specialization: this must be rejected by
+                        # cache-hit scalar validation before the halo source group can underflow.
+                        run_device_call(logical_n - tile_height, kv_actual_isl)
+                if iteration == 0 and case_index == 2:
+                    with expect_error(RuntimeError, "complete ring-group boundary"):
+                        # Without KV-pad rotation logical_n is hash-pinned, so this exercises the
+                        # ordinary cache-miss validation for a partial final ring group.
+                        run_device_call(logical_n - tile_height, None)
+
+                cache_entries = mesh_device.num_program_cache_entries()
+                if cache_entries_after_first_call is None:
+                    assert cache_entries > 0
+                    cache_entries_after_first_call = cache_entries
+                else:
+                    assert cache_entries == cache_entries_after_first_call, (
+                        f"sliding KV-pad calls must reuse one physical-shape program; got {cache_entries} entries "
+                        f"for kv_actual_isl={kv_actual_isl}, expected {cache_entries_after_first_call}"
+                    )
+
+                out_host = ttnn.to_torch(
+                    tt_out,
+                    mesh_composer=ttnn.create_mesh_composer(
+                        mesh_device, ttnn.MeshComposerConfig(main_row_dim, main_col_dim)
+                    ),
+                )
+                out_valid_natural = out_host[:, :, valid_rows, :]
+                iteration_outputs.append(out_valid_natural)
+
+                if iteration == 0:
+                    natural_k = k_full[:, :, :logical_n, :].repeat_interleave(gqa_ratio, dim=1)
+                    natural_v = v_full[:, :, :logical_n, :].repeat_interleave(gqa_ratio, dim=1)
+                    ref_out = torch_chunked_causal_sdpa_reference(
+                        new_tokens_q,
+                        natural_k,
+                        natural_v,
+                        kv_actual_isl,
+                        sliding_window_size=sliding_window_size,
+                    )
+                    passed, pcc = comp_pcc(ref_out, out_valid_natural, pcc_threshold)
+                    rmse = torch.sqrt(((ref_out - out_valid_natural) ** 2).mean()).item()
+                    rmse_passed = rmse_threshold is None or rmse < rmse_threshold
+                    logger.info(
+                        f"sliding KV-pad B{batch_size} case {case_index}: kv_actual_isl={kv_actual_isl}, "
+                        f"logical_n={logical_n}, cache_slabs={num_cache_slabs}, "
+                        f"PCC={pcc}, RMSE={rmse:.6f} -> "
+                        f"{'PASS' if passed and rmse_passed else 'FAIL'}"
+                    )
+                    accuracy_results.append((case_index, kv_actual_isl, logical_n, passed, pcc, rmse_passed, rmse))
+
+            if reference_outputs is None:
+                reference_outputs = iteration_outputs
+            else:
+                for case_index, (expected, actual) in enumerate(zip(reference_outputs, iteration_outputs)):
+                    assert torch.equal(expected, actual), (
+                        f"sliding KV-pad cache replay is not bit-exact for B{batch_size}, "
+                        f"case={case_index}, iteration={iteration}"
+                    )
+
+        failures = [result for result in accuracy_results if not result[3] or not result[5]]
+        assert not failures, f"sliding KV-pad GQA accuracy failures for B{batch_size}: " + "; ".join(
+            f"case={case_index}, kv_actual_isl={kv_actual_isl}, logical_n={logical_n}, " f"PCC={pcc}, RMSE={rmse:.6f}"
+            for case_index, kv_actual_isl, logical_n, _, pcc, _, rmse in failures
+        )
+    finally:
+        close_ring_joint_sdpa_runtime(runtime, clear_program_cache=True)
 
 
 def run_ring_mla_sdpa_chunked_kv_actual_isl_reuse_max_case(
@@ -2961,6 +3435,12 @@ def test_ring_joint_attention_kv_pad_aware_rotation_accuracy(case_name):
         seed=4321 + list(cases).index(case_name),
         chunk_size_local=chunk_size_local,
     )
+
+
+@pytest.mark.parametrize("batch_size", [1, 2], ids=["b1_production", "b2_sp8_sim"])
+def test_ring_joint_attention_sliding_kv_pad_reuse_gqa_accuracy_and_determinism(batch_size, expect_error):
+    """Validate GPT-OSS sliding GQA against garbage-padded KV and cache-hit scalar updates."""
+    run_ring_joint_sdpa_sliding_kv_pad_reuse_case(MESH_CONFIG, batch_size=batch_size, expect_error=expect_error)
 
 
 def test_ring_mla_chunked_kv_actual_isl_indexed_reuse_max_accuracy_and_determinism():
@@ -4291,6 +4771,22 @@ MINIMAX3_GQA_CHUNKED_MODEL_CONFIGS = {
     ),
 }
 
+GPT_OSS_CHUNKED_MODEL = ModelConfig(
+    name="gpt_oss_55k_sliding",
+    nhq=8,
+    nhk=1,
+    nhv=1,
+    d_q=GPT_OSS_RING_SINK_CONFIG.head_dim,
+    d_k=GPT_OSS_RING_SINK_CONFIG.head_dim,
+    d_v=GPT_OSS_RING_SINK_CONFIG.head_dim,
+    is_causal=True,
+    q_dtype=GPT_OSS_RING_SINK_CONFIG.q_dtype,
+    kv_dtype=GPT_OSS_RING_SINK_CONFIG.kv_dtype,
+    q_chunk_sizes=[GPT_OSS_Q_CHUNK_SIZE],
+    k_chunk_sizes=[GPT_OSS_K_CHUNK_SIZE],
+    seq_len=GPT_OSS_CHUNKED_CHUNK_SIZE,
+)
+
 
 def _generate_chunked_configs(model_configs):
     configs = []
@@ -4367,6 +4863,111 @@ def test_ring_joint_attention_sdpa_chunked_accuracy(model_name, qk_configs, chun
     )
 
 
+def test_ring_joint_attention_gpt_oss_chunked_sliding_boundary_accuracy():
+    """Validate the chunked sliding-window path across the cyclic device boundary."""
+    chunk_size = 2048
+    total_seq = 3 * chunk_size
+    final_chunk = total_seq // chunk_size - 1
+    model = replace(
+        GPT_OSS_CHUNKED_MODEL,
+        name="gpt_oss_chunked_sliding_boundary",
+        q_chunk_sizes=[64],
+        seq_len=chunk_size,
+    )
+
+    with mock.patch.dict(os.environ, {CHUNKED_PREFILL_CHUNK_ID_ENV: str(final_chunk)}):
+        run_ring_joint_sdpa_chunked(
+            MESH_CONFIG,
+            model,
+            chunk_size=chunk_size,
+            total_seq=total_seq,
+            qk_configs=[(64, 128)],
+            persistent_buffer_mode="exact_per_chunk",
+            sliding_window_size=GPT_OSS_RING_SINK_CONFIG.sliding_window_size,
+        )
+
+
+def test_ring_joint_attention_gpt_oss_chunked_sliding_multibatch_gqa_accuracy():
+    """Validate the B2 grouped schedule used by the native-SP8 GPT-OSS CI simulation."""
+    chunk_size = 1024
+    total_seq = 3 * chunk_size
+    final_chunk = total_seq // chunk_size - 1
+    model = replace(
+        GPT_OSS_CHUNKED_MODEL,
+        name="gpt_oss_chunked_sliding_multibatch_gqa",
+        q_chunk_sizes=[64],
+        seq_len=chunk_size,
+    )
+
+    with mock.patch.dict(os.environ, {CHUNKED_PREFILL_CHUNK_ID_ENV: str(final_chunk)}):
+        run_ring_joint_sdpa_chunked(
+            MESH_CONFIG,
+            model,
+            batch_size=2,
+            chunk_size=chunk_size,
+            total_seq=total_seq,
+            qk_configs=[(64, 128)],
+            persistent_buffer_mode="exact_per_chunk",
+            sliding_window_size=GPT_OSS_RING_SINK_CONFIG.sliding_window_size,
+        )
+
+        # Exercise cached-program replay separately from the PCC pass. Consuming the compact
+        # collective's readiness tokens per dispatch prevents a later call from observing a
+        # stale semaphore value before its one-hop K/V halo payload has arrived.
+        run_ring_joint_sdpa_chunked(
+            MESH_CONFIG,
+            model,
+            batch_size=2,
+            chunk_size=chunk_size,
+            total_seq=total_seq,
+            qk_configs=[(64, 128)],
+            num_iterations=3,
+            persistent_buffer_mode="exact_per_chunk",
+            sliding_window_size=GPT_OSS_RING_SINK_CONFIG.sliding_window_size,
+        )
+
+
+def test_ring_joint_attention_gpt_oss_chunked_sliding_production_accuracy():
+    """Validate the final 5K Q chunk against the 55K KV cache with the GPT-OSS sink and dtypes."""
+    mesh_config = gpt_oss_chunked_mesh_config()
+    final_chunk = GPT_OSS_CHUNKED_TOTAL_SEQ // GPT_OSS_CHUNKED_CHUNK_SIZE - 1
+    with mock.patch.dict(os.environ, {CHUNKED_PREFILL_CHUNK_ID_ENV: str(final_chunk)}):
+        run_ring_joint_sdpa_chunked(
+            mesh_config,
+            GPT_OSS_CHUNKED_MODEL,
+            chunk_size=GPT_OSS_CHUNKED_CHUNK_SIZE,
+            total_seq=GPT_OSS_CHUNKED_TOTAL_SEQ,
+            qk_configs=[(GPT_OSS_Q_CHUNK_SIZE, GPT_OSS_K_CHUNK_SIZE)],
+            persistent_buffer_mode="exact_per_chunk",
+            sliding_window_size=GPT_OSS_RING_SINK_CONFIG.sliding_window_size,
+            use_attention_sink=True,
+        )
+
+
+def test_ring_joint_attention_gpt_oss_chunked_full_causal_attention_sink_accuracy():
+    """GPT-OSS-shaped full-attention layer: no window, but the same per-head sink as sliding layers."""
+    chunk_size = 1024
+    total_seq = 3 * chunk_size
+    final_chunk = total_seq // chunk_size - 1
+    model = replace(
+        GPT_OSS_CHUNKED_MODEL,
+        name="gpt_oss_chunked_full_causal_sink",
+        q_chunk_sizes=[64],
+        seq_len=chunk_size,
+    )
+
+    with mock.patch.dict(os.environ, {CHUNKED_PREFILL_CHUNK_ID_ENV: str(final_chunk)}):
+        run_ring_joint_sdpa_chunked(
+            gpt_oss_chunked_mesh_config(),
+            model,
+            chunk_size=chunk_size,
+            total_seq=total_seq,
+            qk_configs=[(64, 128)],
+            persistent_buffer_mode="exact_per_chunk",
+            use_attention_sink=True,
+        )
+
+
 @pytest.mark.parametrize(
     "nhq, nhk, nhv, supported",
     [
@@ -4391,10 +4992,19 @@ def test_is_supported_ring_joint_head_mode(nhq, nhk, nhv, supported):
     assert is_supported_ring_joint_head_mode(nhq, nhk, nhv) == supported
 
 
-def test_ring_joint_attention_gqa_with_joint_tensors_rejected(expect_error):
-    """GQA grouped-K/V is unsupported with joint tensors; the device op must reject it (validation-only,
-    so no kernel runs). Covers ring_joint_sdpa_device_operation.cpp's GQA-with-joint TT_FATAL, which the
-    host head-mode guard does not catch."""
+@pytest.mark.parametrize(
+    "use_attention_sink,include_joint_tensors,is_causal,expected_message",
+    [
+        (False, True, False, "GQA with joint tensors"),
+        (True, True, True, "attention_sink does not support joint attention tensors"),
+        (True, False, False, "attention_sink is supported only for causal attention"),
+    ],
+    ids=["gqa_joint", "sink_joint", "sink_noncausal"],
+)
+def test_ring_joint_attention_gqa_with_joint_tensors_rejected(
+    expect_error, use_attention_sink, include_joint_tensors, is_causal, expected_message
+):
+    """Validation-only coverage for GQA joints and unsupported attention-sink combinations."""
     mesh_config = MESH_CONFIG
     b, nhq, nhk, nhv, d = 1, 16, 2, 2, 128  # GQA grouped K/V (nhk == nhv < nhq)
     sq = 512 * mesh_config.sp_size
@@ -4442,11 +5052,23 @@ def test_ring_joint_attention_gqa_with_joint_tensors_rejected(expect_error):
         tt_q = sharded(fa_rand(b, nhq, sq, d), shard_heads=True)
         tt_k = sharded(fa_rand(b, nhk, sq, d), shard_heads=True)
         tt_v = sharded(fa_rand(b, nhv, sq, d), shard_heads=True)
-        # Joint tensors only need to exist with valid shapes to reach the GQA-with-joint check.
-        joint_q = replicated(fa_rand(b, nhq, joint_l, d))
-        joint_k = replicated(fa_rand(b, nhk, joint_l, d))
-        joint_v = replicated(fa_rand(b, nhv, joint_l, d))
+        # Joint tensors only need to exist with valid shapes to reach the validation checks.
+        joint_q = replicated(fa_rand(b, nhq, joint_l, d)) if include_joint_tensors else None
+        joint_k = replicated(fa_rand(b, nhk, joint_l, d)) if include_joint_tensors else None
+        joint_v = replicated(fa_rand(b, nhv, joint_l, d)) if include_joint_tensors else None
         p_buf_k, p_buf_v = persistent(torch.zeros(b, nhk, sq, d)), persistent(torch.zeros(b, nhv, sq, d))
+        tt_attention_sink = None
+        if use_attention_sink:
+            sink_shard_dims = [None, None]
+            if mesh_config.tp_size > 1:
+                sink_shard_dims[tp_axis] = 1
+            tt_attention_sink = ttnn.from_torch(
+                torch.zeros(1, nhq, 1, 1),
+                dtype=ttnn.bfloat16,
+                layout=ttnn.TILE_LAYOUT,
+                device=mesh_device,
+                mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=mesh_shape, dims=sink_shard_dims),
+            )
 
         program_config = ttnn.SDPAProgramConfig(
             compute_with_storage_grid_size=runtime.sdpa_compute_grid,
@@ -4455,9 +5077,7 @@ def test_ring_joint_attention_gqa_with_joint_tensors_rejected(expect_error):
             exp_approx_mode=False,
         )
 
-        # Joint tensors require non-causal (causal+joint is rejected earlier), so this is the
-        # non-causal GQA + joint case that the GQA-with-joint TT_FATAL is meant to catch.
-        with expect_error(RuntimeError, "GQA with joint tensors"):
+        with expect_error(RuntimeError, expected_message):
             ttnn.transformer.ring_joint_scaled_dot_product_attention(
                 tt_q,
                 tt_k,
@@ -4469,8 +5089,9 @@ def test_ring_joint_attention_gqa_with_joint_tensors_rejected(expect_error):
                 persistent_output_buffer_v=p_buf_v,
                 joint_strategy="rear",
                 logical_n=sq,
-                is_causal=False,
+                is_causal=is_causal,
                 is_balanced=False,
+                attention_sink=tt_attention_sink,
                 program_config=program_config,
                 compute_kernel_config=runtime.compute_kernel_config,
                 dim=2,
@@ -4497,6 +5118,46 @@ def test_ring_joint_attention_minimax3_gqa_chunked_accuracy():
         qk_configs=[(128, 512)],
         persistent_buffer_mode="reuse_max",
     )
+
+
+def test_ring_joint_attention_minimax3_gqa_full_causal_attention_sink_accuracy_and_determinism():
+    """Balanced M3 full-causal GQA consumes sinks without the sliding-window specialization."""
+    model = replace(MODEL_CONFIGS["minimax3_gqa_smoke"], name="minimax3_gqa_full_causal_sink", seq_len=512)
+    runtime = open_ring_joint_sdpa_runtime(MESH_CONFIG)
+    runtime.mesh_device.enable_program_cache()
+    try:
+        # Accuracy covers the balanced normalize-only path on the final ring iteration.
+        run_ring_joint_sdpa_model_configs(
+            MESH_CONFIG,
+            model,
+            qk_configs=[(128, 256)],
+            runtime=runtime,
+            use_attention_sink=True,
+        )
+        cache_entries = runtime.mesh_device.num_program_cache_entries()
+        assert cache_entries > 0, "full-causal attention-sink dispatch did not populate the program cache"
+        # A fresh sink allocation on the cached program validates runtime-address rebinding.
+        run_ring_joint_sdpa_model_configs(
+            MESH_CONFIG,
+            model,
+            qk_configs=[(128, 256)],
+            runtime=runtime,
+            use_attention_sink=True,
+            do_check=False,
+        )
+        assert runtime.mesh_device.num_program_cache_entries() == cache_entries
+        # The deterministic replay below also adds device comparison programs to the cache.
+        run_ring_joint_sdpa_model_configs(
+            MESH_CONFIG,
+            model,
+            qk_configs=[(128, 256)],
+            runtime=runtime,
+            use_attention_sink=True,
+            do_check=False,
+            num_iterations=3,
+        )
+    finally:
+        close_ring_joint_sdpa_runtime(runtime, clear_program_cache=True)
 
 
 def test_ring_joint_attention_minimax3_gqa_chunked_reuse_kv_hang_regression():
@@ -5093,6 +5754,79 @@ def test_ring_joint_attention_minimax3_gqa_chunked_perf_check(
     assert lower <= utilization <= upper, (
         f"Math utilization {utilization:.2f}% outside band [{lower:.2f}, {upper:.2f}] "
         f"(expected {expected_util:.2f}%, margin +/- {RING_JOINT_PERF_MARGIN*100:.1f}%)"
+    )
+
+
+# Calibrated on the 8-chip single-ring CI target. Keep this separate from Minimax: GPT-OSS uses
+# D=64, 8Q:1KV per chip, a 128-token window, and an attention sink. Direct per-core K/V reads
+# measure about 35 us / 1.75% median utilization; the wider band reflects quantization and host
+# noise at this very short duration.
+GPT_OSS_CHUNKED_PERF_MARGIN = 0.10
+GPT_OSS_CHUNKED_PERF_CHECK_CONFIGS = [
+    # (q_chunk_size, k_chunk_size, expected_util, margin)
+    (128, 128, 1.75, GPT_OSS_CHUNKED_PERF_MARGIN),
+]
+
+
+@pytest.mark.timeout(600)
+@pytest.mark.parametrize(
+    "q_chunk_size,k_chunk_size,expected_util,margin",
+    GPT_OSS_CHUNKED_PERF_CHECK_CONFIGS,
+    ids=[f"gpt-oss-55k-q{q}-k{k}" for q, k, _, _ in GPT_OSS_CHUNKED_PERF_CHECK_CONFIGS],
+)
+@skip_with_llk_assert("No need to verify LLK asserts for performance tests.")
+@skip_with_watcher("Watcher perturbs kernel timing; perf checks are not meaningful with it enabled.")
+def test_ring_joint_attention_gpt_oss_chunked_sliding_perf_check(q_chunk_size, k_chunk_size, expected_util, margin):
+    """Measure the final 5K GPT-OSS Q chunk against its 55K sliding KV cache on the CI target."""
+    if MESH_CONFIG.num_devices != 8:
+        pytest.skip(f"GPT-OSS sliding perf target is calibrated for the 8-chip CI ring, got {MESH_CONFIG.num_devices}")
+    mesh_config = gpt_oss_chunked_mesh_config()
+    final_chunk = GPT_OSS_CHUNKED_TOTAL_SEQ // GPT_OSS_CHUNKED_CHUNK_SIZE - 1
+    runtime = open_ring_joint_sdpa_runtime(mesh_config)
+    try:
+        with mock.patch.dict(os.environ, {CHUNKED_PREFILL_CHUNK_ID_ENV: str(final_chunk)}):
+            duration_ns, perf_records = profile_ring_joint_runtime_duration_ns(
+                runtime.mesh_device,
+                lambda: run_ring_joint_sdpa_chunked(
+                    mesh_config,
+                    GPT_OSS_CHUNKED_MODEL,
+                    chunk_size=GPT_OSS_CHUNKED_CHUNK_SIZE,
+                    total_seq=GPT_OSS_CHUNKED_TOTAL_SEQ,
+                    qk_configs=[(q_chunk_size, k_chunk_size)],
+                    persistent_buffer_mode="reuse_max",
+                    do_check=False,
+                    reuse_kv_buffer=True,
+                    sliding_window_size=GPT_OSS_RING_SINK_CONFIG.sliding_window_size,
+                    use_attention_sink=True,
+                    runtime=runtime,
+                ),
+            )
+    finally:
+        close_ring_joint_sdpa_runtime(runtime)
+
+    q_per_device = GPT_OSS_CHUNKED_CHUNK_SIZE // mesh_config.sp_size
+    utilization = compute_ring_joint_utilization(
+        q_per_device,
+        GPT_OSS_RING_SINK_CONFIG.sliding_window_size,
+        GPT_OSS_RING_SINK_CONFIG.head_dim,
+        GPT_OSS_RING_SINK_CONFIG.head_dim,
+        GPT_OSS_CHUNKED_MODEL.nhq,
+        duration_ns,
+        mesh_config.sdpa_cores,
+        is_causal=False,
+    )
+    lower = expected_util * (1 - margin)
+    upper = expected_util * (1 + margin)
+    logger.info(
+        f"GPT-OSS sliding 5K-on-55K perf: q={q_chunk_size}, k={k_chunk_size}, "
+        f"duration={duration_ns/1e6:.3f} ms, math_util={utilization:.2f}%, "
+        f"expected={expected_util:.2f}% [{lower:.2f}, {upper:.2f}], "
+        f"profiler_records={len(perf_records)}"
+    )
+
+    assert lower <= utilization <= upper, (
+        f"Math utilization {utilization:.2f}% outside band [{lower:.2f}, {upper:.2f}] "
+        f"(expected {expected_util:.2f}%, margin +/- {margin*100:.1f}%)"
     )
 
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/CMakeLists.txt
@@ -27,6 +27,7 @@ file(
     neighbor_pad_async/device/kernels/*.cpp
     reduce_scatter_minimal_async/device/kernels/*.cpp
     ring_attention_all_gather_async/device/kernels/*.cpp
+    ring_attention_all_gather_async/device/kernels/*.hpp
     rms_allgather/device/kernels/*.cpp
     rms_allgather/device/kernels/*.hpp
     dit_fused_distributed_rmsnorm/device/kernels/*.cpp

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_reader.cpp
@@ -10,6 +10,8 @@
 #include "api/tensor/noc_traits.h"
 #include "cpp/ttnn/operations/ccl/kernel_common/worker_sync_utils.hpp"
 #include "cpp/ttnn/operations/ccl/ccl_host_types.hpp"
+#include "cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/metadata_scalar_read.hpp"
+#include "ring_attention_all_gather_metadata.hpp"
 #include "ring_attention_prefetch_utils.hpp"
 #include <cstdint>
 #include <utility>
@@ -31,6 +33,8 @@ constexpr uint32_t contig_pages_advanced = get_compile_time_arg_val(7);  // 2
 constexpr uint32_t num_inputs = get_compile_time_arg_val(8);
 constexpr bool direction = get_compile_time_arg_val(9);  // 1 is forward, 0 is backward
 constexpr bool fuse_op = get_compile_time_arg_val(10);
+constexpr bool has_metadata = get_compile_time_arg_val(11);
+constexpr uint32_t cb_meta_id = get_compile_time_arg_val(12);
 
 // Prefetch: batch multiple packets of DRAM reads before a single barrier.
 // This keeps more reads in flight across interleaved DRAM banks, hiding latency.
@@ -38,11 +42,17 @@ constexpr bool fuse_op = get_compile_time_arg_val(10);
 constexpr uint32_t PREFETCH_PACKETS = 4;
 
 void kernel_main() {
-    constexpr uint32_t page_size_base_idx = 11;
+    constexpr uint32_t page_size_base_idx = 13;
     constexpr auto inputs_args = make_tensor_accessor_args_tuple<num_inputs, page_size_base_idx + num_inputs>();
     constexpr auto outputs_args = make_tensor_accessor_args_tuple<
         num_inputs,
         std::get<num_inputs - 1>(inputs_args).next_compile_time_args_offset()>();
+    constexpr uint32_t kMetaArgsOffset = has_metadata
+                                             ? std::get<num_inputs - 1>(outputs_args).next_compile_time_args_offset()
+                                             : (page_size_base_idx + num_inputs);
+    constexpr auto meta_args = TensorAccessorArgs<kMetaArgsOffset>();
+    constexpr uint32_t kKvMetaArgsOffset = has_metadata ? meta_args.next_compile_time_args_offset() : kMetaArgsOffset;
+    constexpr auto kv_meta_args = TensorAccessorArgs<kKvMetaArgsOffset>();
 
     ///////////////////////////////////////////////////
     // ARGS
@@ -88,6 +98,31 @@ void kernel_main() {
     auto outputs_tuple = make_tensor_accessor_tuple(outputs_args, arg_idx);
     arg_idx += num_inputs;
     auto output_tensor_addrgens = make_abstract_tensor_accessor_wrappers(outputs_tuple);
+
+    if constexpr (has_metadata) {
+        const uint32_t slot_id_addr = get_arg_val<uint32_t>(arg_idx++);
+        const uint32_t kv_actual_isl_addr = get_arg_val<uint32_t>(arg_idx++);
+        const uint32_t chunk_local_tiles = get_arg_val<uint32_t>(arg_idx++);
+        const uint32_t kv_cache_num_layers = get_arg_val<uint32_t>(arg_idx++);
+        const uint32_t kv_cache_layer_idx = get_arg_val<uint32_t>(arg_idx++);
+        Noc meta_noc;
+        // Use the data CB as temporary metadata scratch. It is empty at this point and avoids
+        // a separate tiny-CB read race on the all-gather worker cores.
+        CircularBuffer cb_meta(cb_output_id);
+        const uint32_t slot_id =
+            trace_metadata::read_metadata_scalar_u32(meta_noc, meta_args, slot_id_addr, cb_meta.get_write_ptr());
+        const uint32_t cache_batch_idx = slot_id * kv_cache_num_layers + kv_cache_layer_idx;
+        for (uint32_t input_idx = 0; input_idx < num_inputs; input_idx++) {
+            input_batch_base[input_idx] = cache_batch_idx * input_batch_head_count[input_idx] *
+                                          input_tensor_Ht[input_idx] * input_tensor_Wt[input_idx];
+        }
+        const uint32_t kv_actual = trace_metadata::read_metadata_scalar_u32(
+            meta_noc, kv_meta_args, kv_actual_isl_addr, cb_meta.get_write_ptr());
+        const uint32_t gather_valid_Ht =
+            ring_attention_all_gather::compute_gather_valid_Ht(kv_actual, chunk_local_tiles, ring_size);
+        ring_attention_all_gather::clamp_input_ranges_to_gather_extent(
+            gather_valid_Ht, input_tensor_Ht, input_tensor_Wt, input_tile_id_end);
+    }
 
     OpSignaler op_signaler;
     if constexpr (fuse_op) {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_reader.cpp
@@ -10,8 +10,7 @@
 #include "api/tensor/noc_traits.h"
 #include "cpp/ttnn/operations/ccl/kernel_common/worker_sync_utils.hpp"
 #include "cpp/ttnn/operations/ccl/ccl_host_types.hpp"
-#include "cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/metadata_scalar_read.hpp"
-#include "ring_attention_all_gather_metadata.hpp"
+#include "ring_attention_prefetch_utils.hpp"
 #include <cstdint>
 #include <utility>
 
@@ -32,93 +31,18 @@ constexpr uint32_t contig_pages_advanced = get_compile_time_arg_val(7);  // 2
 constexpr uint32_t num_inputs = get_compile_time_arg_val(8);
 constexpr bool direction = get_compile_time_arg_val(9);  // 1 is forward, 0 is backward
 constexpr bool fuse_op = get_compile_time_arg_val(10);
-// Trace-safe metadata path: when set, the single-slot gather offset (input_batch_base) is recomputed
-// on-device from slot = slot_id[0] instead of taken from the (trace-frozen) runtime arg. cb_meta_id
-// is a tiny L1 CB for the read page; the metadata accessor's compile args follow the output accessors.
-// slot_id / kv_actual_isl are 1-element uint32 DRAM tensors sharing one accessor. When has_metadata is
-// false neither is emitted and this kernel is bit-identical.
-constexpr bool has_metadata = get_compile_time_arg_val(11);
-constexpr uint32_t cb_meta_id = get_compile_time_arg_val(12);
 
 // Prefetch: batch multiple packets of DRAM reads before a single barrier.
 // This keeps more reads in flight across interleaved DRAM banks, hiding latency.
 // CB depth must be >= 2 * PREFETCH_PACKETS * packet_size_in_pages (see program_factory cb_num_pages).
 constexpr uint32_t PREFETCH_PACKETS = 4;
 
-// Batch-read tiles into the output CB with DRAM prefetch and FIFO wrapping.
-// next_page_id is called once per tile-group read; it returns the source TensorAccessor
-// page id and may perform per-tile side effects (e.g. row-stride tracking).
-//
-// Manual ring-buffer wrapping: batched reads may write across the FIFO boundary, which
-// bypasses the CB's normal contiguous-write assumption (see cb_push_back). This is safe because
-// reads target raw L1 addresses via CoreLocalMem and cb_push_back is called per-packet
-// (packet_size_in_pages always divides cb_num_pages evenly).
-template <typename Accessor, typename PageIdFn>
-FORCE_INLINE void prefetch_batch_read_tiles(
-    const Noc& noc_obj,
-    CircularBuffer& cb_output,
-    uint32_t& tiles_read,
-    uint32_t tiles_to_read,
-    uint32_t cb_fifo_limit,
-    uint32_t cb_fifo_size,
-    const Accessor& accessor,
-    PageIdFn&& next_page_id) {
-    constexpr uint32_t payload_size_bytes = input_tensor_page_size * contig_pages_advanced;
-    while (tiles_read < tiles_to_read) {
-        uint32_t remaining_tiles = tiles_to_read - tiles_read;
-        uint32_t remaining_packets = (remaining_tiles + packet_size_in_pages - 1) / packet_size_in_pages;
-        uint32_t batch_packets = std::min(remaining_packets, PREFETCH_PACKETS);
-        uint32_t batch_pages = batch_packets * packet_size_in_pages;
-
-        cb_output.reserve_back(batch_pages);
-        uint32_t l1_write_addr = cb_output.get_write_ptr();
-
-        for (uint32_t p = 0; p < batch_packets; p++) {
-            uint32_t num_pages_to_read = std::min(tiles_to_read - tiles_read, packet_size_in_pages);
-            for (uint32_t j = 0; j < num_pages_to_read; j += contig_pages_advanced) {
-                if (l1_write_addr >= cb_fifo_limit) {
-                    l1_write_addr -= cb_fifo_size;
-                }
-                noc_obj.async_read(
-                    accessor,
-                    CoreLocalMem<uint8_t>(l1_write_addr),
-                    input_tensor_page_size,
-                    {.page_id = next_page_id(tiles_read)},
-                    {});
-                l1_write_addr += payload_size_bytes;
-                tiles_read += contig_pages_advanced;
-            }
-            l1_write_addr += (packet_size_in_pages - num_pages_to_read) * input_tensor_page_size;
-        }
-        noc_obj.async_read_barrier();
-        for (uint32_t p = 0; p < batch_packets; p++) {
-            cb_output.push_back(packet_size_in_pages);
-        }
-    }
-}
-
 void kernel_main() {
-    constexpr uint32_t page_size_base_idx = 13;
+    constexpr uint32_t page_size_base_idx = 11;
     constexpr auto inputs_args = make_tensor_accessor_args_tuple<num_inputs, page_size_base_idx + num_inputs>();
     constexpr auto outputs_args = make_tensor_accessor_args_tuple<
         num_inputs,
         std::get<num_inputs - 1>(inputs_args).next_compile_time_args_offset()>();
-    // The metadata accessor's compile args follow the output accessors (metadata path only). When
-    // has_metadata is false the metadata accessor is NOT emitted, so fall back to a VALID (but unused)
-    // accessor offset -- the inputs-accessor start -- rather than 0: TensorAccessorArgs<> is instantiated
-    // here unconditionally (it is not a dependent template), and offset 0 names my_chip_id, which fails
-    // the accessor's internal static_assert. meta_args is only *used* inside `if constexpr(has_metadata)`.
-    constexpr uint32_t kMetaArgsOffset = has_metadata
-                                             ? std::get<num_inputs - 1>(outputs_args).next_compile_time_args_offset()
-                                             : (page_size_base_idx + num_inputs);
-    constexpr auto meta_args = TensorAccessorArgs<kMetaArgsOffset>();  // slot_id accessor
-    // kv_actual_isl gets its OWN accessor: a separately-allocated single-page DRAM tensor can land in a
-    // DIFFERENT DRAM bank than slot_id, so reusing slot_id's dspec would read the wrong bank for it (the
-    // kv read silently returns 0). Mirrors the SDPA reader's kv_meta_args. The program factory appends it
-    // right after slot_id's accessor when has_metadata; otherwise fall back to meta_args' (valid, unused)
-    // offset so the unconditional TensorAccessorArgs<> never names a non-accessor compile arg.
-    constexpr uint32_t kKvMetaArgsOffset = has_metadata ? meta_args.next_compile_time_args_offset() : kMetaArgsOffset;
-    constexpr auto kv_meta_args = TensorAccessorArgs<kKvMetaArgsOffset>();  // kv_actual_isl accessor
 
     ///////////////////////////////////////////////////
     // ARGS
@@ -165,73 +89,6 @@ void kernel_main() {
     arg_idx += num_inputs;
     auto output_tensor_addrgens = make_abstract_tensor_accessor_wrappers(outputs_tuple);
 
-    // Trace-safe single-slot gather: recompute input_batch_base from slot = slot_id[0] on-device,
-    // so a captured trace replays across cache slots (the host runtime-arg input_batch_base, set for the
-    // capture-time slot, would otherwise be frozen). input_batch_base = slot * num_heads * Ht * Wt,
-    // matching ring_attention_all_gather_async_detail::input_batch_base_pages. The slot_id and
-    // kv_actual_isl DRAM addresses are the next two runtime args (emitted before the optional signaler args).
-    if constexpr (has_metadata) {
-        // Two 1-element uint32 DRAM tensors: slot_id (was metadata[0]) and kv_actual_isl (was
-        // metadata[1]). Each gets its OWN accessor (meta_args / kv_meta_args): they are separately
-        // allocated and can land in different DRAM banks, so a shared accessor reads the wrong bank for
-        // one (the kv_actual read silently returned 0).
-        // Read all metadata runtime args first, in emission order (slot addr, kv addr, chunk_local_tiles,
-        // then the per-layer factor) so OpSignaler downstream sees the correct arg_idx.
-        const uint32_t slot_id_addr = get_arg_val<uint32_t>(arg_idx++);
-        const uint32_t kv_actual_isl_addr = get_arg_val<uint32_t>(arg_idx++);
-        // chunk_local_tiles (per-device Q slab in tiles): recompute the gather extent on-device so the
-        // gather moves only the logical_n-valid prefix even when the host logical_n is a placeholder.
-        const uint32_t chunk_local_tiles = get_arg_val<uint32_t>(arg_idx++);
-        // (user, layer)-major KV-cache batch dim: cache_batch_idx = slot_id * kv_cache_num_layers +
-        // kv_cache_layer_idx (mirrors the SDPA reader / update_padded_kv_cache). slot_id holds only the
-        // user slot. Defaults (1, 0) reduce to slot_id, keeping callers bit-identical.
-        const uint32_t kv_cache_num_layers = get_arg_val<uint32_t>(arg_idx++);
-        const uint32_t kv_cache_layer_idx = get_arg_val<uint32_t>(arg_idx++);
-        Noc meta_noc;
-        // Read the metadata scalars into the OUTPUT CB's L1 as scratch (it is allocated but not yet
-        // reserved/filled here; the gather loop below reserves + overwrites it before first use). The tiny
-        // dedicated meta CB (cb_meta_id) gave an intermittent drop-to-zero on ~10% of cores; reading into
-        // the real output CB (as the proven SDPA ring_joint_reader does with cb_q_in) is reliable.
-        //
-        // Scope of the empirical workarounds here (read-into-output-CB + single-read below): they hold for
-        // the tested configuration -- full worker core grids, ring sizes 1..8, on Blackhole, single dispatch
-        // and captured-trace replay. The two KNOWN root causes are handled deterministically, not
-        // empirically: the wrong-DRAM-bank read is fixed by kv_meta_args (its own accessor, above), and
-        // cross-chunk L1 staleness under trace by the invalidate_l1_cache() inside
-        // read_metadata_scalar_u32. The remaining empirical part is the op-start NoC
-        // drop-to-zero on the FIRST read; a change to core allocation / ring size / dispatch timing could
-        // resurface it, so it is not guaranteed outside the above envelope and wants a silicon root-cause
-        // before this path is relied on under those changes.
-        CircularBuffer cb_meta(cb_output_id);
-        const uint32_t meta_l1 = cb_meta.get_write_ptr();
-        // read_metadata_scalar_u32 is the shared protocol (async_read page 0 -> barrier ->
-        // invalidate_l1_cache -> volatile load); the invalidate matters because this tensor sits at a
-        // fixed DRAM address the host refreshes in place between trace replays, so a cached L1 line would
-        // hand back the prior chunk's slot.
-        const uint32_t slot_id = trace_metadata::read_metadata_scalar_u32(meta_noc, meta_args, slot_id_addr, meta_l1);
-        const uint32_t cache_batch_idx = slot_id * kv_cache_num_layers + kv_cache_layer_idx;
-        for (uint32_t input_idx = 0; input_idx < num_inputs; input_idx++) {
-            input_batch_base[input_idx] = cache_batch_idx * input_batch_head_count[input_idx] *
-                                          input_tensor_Ht[input_idx] * input_tensor_Wt[input_idx];
-        }
-        // Now read kv_actual_isl (reusing meta_l1) and clamp the gather extent. kv_actual_isl has its OWN
-        // accessor (kv_meta_args): it is a separately-allocated single-page tensor that can land in a
-        // different DRAM bank than slot_id, and a shared accessor's dspec bakes page 0's bank from one
-        // buffer -- reusing meta_args here silently returned the wrong bank's data.
-        //
-        // Only the slot read (the kernel's FIRST NoC read, issued at peak op-start contention) suffers the
-        // drop-to-zero corruption; this kv read runs a few instructions later once the storm subsides and
-        // is reliable with a single read (verified: the rotation tests, which exercise kv_actual != 0, pass
-        // with a single read and regress under the max-of-K re-read).
-        const uint32_t kv_actual = trace_metadata::read_metadata_scalar_u32(
-            meta_noc, kv_meta_args, kv_actual_isl_addr, meta_l1);  // kv_actual_isl (tile-aligned)
-        // Shared with the writer, which must clamp to the same prefix (see the header's KEEP IN SYNC note).
-        const uint32_t gather_valid_Ht =
-            ring_attention_all_gather::compute_gather_valid_Ht(kv_actual, chunk_local_tiles, ring_size);
-        ring_attention_all_gather::clamp_input_ranges_to_gather_extent(
-            gather_valid_Ht, input_tensor_Ht, input_tensor_Wt, input_tile_id_end);
-    }
-
     OpSignaler op_signaler;
     if constexpr (fuse_op) {
         op_signaler = OpSignaler(arg_idx);
@@ -252,7 +109,11 @@ void kernel_main() {
         uint32_t tiles_read = input_tile_id_start[input_idx];
         uint32_t tiles_to_read = input_tile_id_end[input_idx];
         for (uint32_t bh_idx = 0; bh_idx < input_batch_head_count[input_idx]; bh_idx++) {
-            prefetch_batch_read_tiles(
+            prefetch_batch_read_tiles<
+                input_tensor_page_size,
+                packet_size_in_pages,
+                PREFETCH_PACKETS,
+                contig_pages_advanced>(
                 noc_obj,
                 cb_output,
                 tiles_read,
@@ -345,7 +206,11 @@ void kernel_main() {
                         actual_sender_chip_id * input_tensor_Ht[input_idx] * input_tensor_Wt[input_idx];
                 }
                 for (uint32_t bh_idx = 0; bh_idx < input_batch_head_count[input_idx]; bh_idx++) {
-                    prefetch_batch_read_tiles(
+                    prefetch_batch_read_tiles<
+                        input_tensor_page_size,
+                        packet_size_in_pages,
+                        PREFETCH_PACKETS,
+                        contig_pages_advanced>(
                         noc_obj,
                         cb_output,
                         tiles_read,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_writer.cpp
@@ -266,9 +266,8 @@ void kernel_main() {
     uint64_t out_ready_sem_noc_addr_in_pkt =
         safe_get_noc_addr(out_ready_sem_noc0_x, out_ready_sem_noc0_y, out_ready_sem, 0);
     auto* pkt_hdr_sem_inc = reinterpret_cast<PACKET_HEADER_TYPE*>(packet_header_buffer_seminc);
-    pkt_hdr_sem_inc->to_noc_unicast_atomic_inc(
-        tt::tt_fabric::NocUnicastAtomicIncCommandHeader{
-            out_ready_sem_noc_addr_in_pkt, static_cast<uint32_t>(1)});  // increment 1
+    pkt_hdr_sem_inc->to_noc_unicast_atomic_inc(tt::tt_fabric::NocUnicastAtomicIncCommandHeader{
+        out_ready_sem_noc_addr_in_pkt, static_cast<uint32_t>(1)});  // increment 1
 
     // Write the unicast packet. num_hops=1 is correct under both topologies: 1D ring-AG always
     // targets the immediate neighbor; 2D ignores num_hops (HybridMesh::to_chip_unicast is a no-op

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_neighbor_halo_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_neighbor_halo_reader.cpp
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "api/core_local_mem.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/tensor/noc_traits.h"
+#include "cpp/ttnn/operations/ccl/kernel_common/worker_sync_utils.hpp"
+#include "ring_attention_prefetch_utils.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <cstdint>
+
+constexpr uint32_t my_ring_id = get_compile_time_arg_val(0);
+constexpr uint32_t ring_size = get_compile_time_arg_val(1);
+constexpr uint32_t cb_output_id = get_compile_time_arg_val(2);
+constexpr uint32_t packet_size_in_pages = get_compile_time_arg_val(3);
+constexpr uint32_t input_page_size = get_compile_time_arg_val(4);
+constexpr uint32_t num_inputs = get_compile_time_arg_val(5);
+constexpr uint32_t page_size_base_idx = 6;
+constexpr uint32_t prefetch_packets = 4;
+
+void kernel_main() {
+    constexpr auto input_accessor_args = make_tensor_accessor_args_tuple<num_inputs, page_size_base_idx + num_inputs>();
+
+    uint32_t arg_idx = 0;
+    const size_t incoming_ready_sem = get_arg_val<uint32_t>(arg_idx++);
+
+    std::array<uint32_t, num_inputs> input_stride_pages;
+    std::array<uint32_t, num_inputs> input_batch_head_count;
+    std::array<uint32_t, num_inputs> input_tile_start;
+    std::array<uint32_t, num_inputs> input_tile_end;
+    std::array<uint32_t, num_inputs> input_batch_base;
+    for (uint32_t input = 0; input < num_inputs; ++input) {
+        input_stride_pages[input] = get_arg_val<uint32_t>(arg_idx++);
+        input_batch_head_count[input] = get_arg_val<uint32_t>(arg_idx++);
+        input_tile_start[input] = get_arg_val<uint32_t>(arg_idx++);
+        input_tile_end[input] = get_arg_val<uint32_t>(arg_idx++);
+        input_batch_base[input] = get_arg_val<uint32_t>(arg_idx++);
+    }
+
+    auto input_accessors_tuple = make_tensor_accessor_tuple(input_accessor_args, arg_idx);
+    arg_idx += num_inputs;
+    auto input_accessors = make_abstract_tensor_accessor_wrappers(input_accessors_tuple);
+
+    OpSignaler op_signaler(arg_idx);
+
+    Noc noc;
+    CircularBuffer cb_output(cb_output_id);
+    const uint32_t cb_fifo_limit = get_local_cb_interface(cb_output_id).fifo_limit;
+    const uint32_t cb_fifo_size = get_local_cb_interface(cb_output_id).fifo_size;
+    for (uint32_t input = 0; input < num_inputs; ++input) {
+        for (uint32_t bh = 0; bh < input_batch_head_count[input]; ++bh) {
+            uint32_t tiles_read = input_tile_start[input];
+            prefetch_batch_read_tiles<input_page_size, packet_size_in_pages, prefetch_packets, 1>(
+                noc,
+                cb_output,
+                tiles_read,
+                input_tile_end[input],
+                cb_fifo_limit,
+                cb_fifo_size,
+                input_accessors[input],
+                [&](uint32_t tile) { return input_batch_base[input] + bh * input_stride_pages[input] + tile; });
+        }
+    }
+
+    noc_semaphore_wait_min(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(incoming_ready_sem), 1);
+    constexpr uint32_t predecessor_ring_id = my_ring_id == 0 ? ring_size - 1 : my_ring_id - 1;
+    op_signaler.synchronize_workers_and_signal_op(predecessor_ring_id);
+    noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(incoming_ready_sem), 0);
+}

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_neighbor_halo_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_neighbor_halo_writer.cpp
@@ -1,0 +1,167 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_manager.hpp"
+#include "tt_metal/fabric/hw/inc/linear/api.h"
+#include "tt_metal/fabric/hw/inc/noc_addr.h"
+#include "tt_metal/fabric/hw/inc/tt_fabric_api.h"
+#include "cpp/ttnn/operations/ccl/kernel_common/worker_routing_utils.hpp"
+#include "cpp/ttnn/operations/ccl/common/kernels/minimal_ccl_common.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <cstdint>
+///////////////////////////////////////////////////
+// COMPILE TIME ARGS
+///////////////////////////////////////////////////
+
+constexpr uint32_t reserved_packet_header_cb_id = get_compile_time_arg_val(0);
+constexpr uint32_t cb_output_id = get_compile_time_arg_val(1);
+constexpr uint32_t packet_size_in_pages = get_compile_time_arg_val(2);
+constexpr uint32_t output_page_size = get_compile_time_arg_val(3);
+constexpr uint32_t num_inputs = get_compile_time_arg_val(4);
+constexpr uint32_t unicast_route_arg0 = get_compile_time_arg_val(5);
+constexpr uint32_t unicast_route_arg1 = get_compile_time_arg_val(6);
+
+constexpr uint32_t page_size_base_idx = 7;
+
+void kernel_main() {
+    constexpr auto outputs_args = make_tensor_accessor_args_tuple<num_inputs, page_size_base_idx + num_inputs>();
+
+    ///////////////////////////////////////////////////
+    // ARGS
+    ///////////////////////////////////////////////////
+    uint32_t arg_idx = 0;
+    const uint8_t out_ready_sem_noc0_x = get_arg_val<uint32_t>(arg_idx++);
+    const uint8_t out_ready_sem_noc0_y = get_arg_val<uint32_t>(arg_idx++);
+    size_t out_ready_sem = get_arg_val<uint32_t>(arg_idx++);
+
+    std::array<uint32_t, num_inputs> output_batch_head_stride_pages;
+    std::array<uint32_t, num_inputs> input_batch_head_count;
+    std::array<uint32_t, num_inputs> input_tile_id_start;
+    std::array<uint32_t, num_inputs> input_tile_id_end;
+    std::array<uint32_t, num_inputs> input_origin_page;
+
+    for (uint32_t input_idx = 0; input_idx < num_inputs; input_idx++) {
+        output_batch_head_stride_pages[input_idx] = get_arg_val<uint32_t>(arg_idx++);
+        input_batch_head_count[input_idx] = get_arg_val<uint32_t>(arg_idx++);
+        input_tile_id_start[input_idx] = get_arg_val<uint32_t>(arg_idx++);
+        input_tile_id_end[input_idx] = get_arg_val<uint32_t>(arg_idx++);
+        input_origin_page[input_idx] = get_arg_val<uint32_t>(arg_idx++);
+    }
+
+    auto outputs_tuple = make_tensor_accessor_tuple(outputs_args, arg_idx);
+    arg_idx += num_inputs;
+    auto output_addrgens = make_abstract_tensor_accessor_wrappers(outputs_tuple);
+    size_t fabric_args_idx = arg_idx;
+    auto fabric_connection = FabricConnectionManager::build_from_args(fabric_args_idx);
+
+    Noc noc_obj;
+    CircularBuffer cb_packet_header(reserved_packet_header_cb_id);
+    CircularBuffer cb_output(cb_output_id);
+
+    // packet header cb
+    cb_packet_header.reserve_back(1);
+    auto packet_header_buffer_addr = cb_packet_header.get_write_ptr();
+    cb_packet_header.push_back(1);
+
+    // pre-populate packet headers
+    constexpr ccl_routing_utils::line_unicast_route_info_t unicast_route_info = {
+        .dst_mesh_id = static_cast<uint16_t>(unicast_route_arg0),
+        .dst_chip_id = static_cast<uint16_t>(unicast_route_arg1)};
+
+    volatile PACKET_HEADER_TYPE* pkt_hdr = reinterpret_cast<volatile PACKET_HEADER_TYPE*>(packet_header_buffer_addr);
+    ccl_routing_utils::fabric_set_line_unicast_route(pkt_hdr, unicast_route_info);
+
+    fabric_connection.open();
+
+    tt::tt_fabric::WorkerToFabricEdmSender& fabric_direction_connection = fabric_connection.get_forward_connection();
+    const uint64_t out_ready_sem_noc_addr_in_pkt =
+        safe_get_noc_addr(out_ready_sem_noc0_x, out_ready_sem_noc0_y, out_ready_sem, 0);
+
+    for (uint32_t input_idx = 0; input_idx < num_inputs; input_idx++) {
+        // Send the local halo tail directly to the next device's compact output buffer.
+
+        for (uint32_t bh_idx = 0; bh_idx < input_batch_head_count[input_idx]; bh_idx++) {
+            uint32_t tiles_read = input_tile_id_start[input_idx];
+            const uint32_t tiles_to_read = input_tile_id_end[input_idx];
+            const uint32_t output_batch_head_base = bh_idx * output_batch_head_stride_pages[input_idx];
+            while (tiles_read < tiles_to_read) {
+                const uint32_t num_pages_to_read = std::min(tiles_to_read - tiles_read, packet_size_in_pages);
+                cb_output.wait_front(packet_size_in_pages);
+                const size_t l1_read_addr = cb_output.get_read_ptr();
+                const uint32_t tile_id = output_batch_head_base + tiles_read - input_origin_page[input_idx];
+
+                if (num_pages_to_read == 2) {
+                    const uint32_t second_tile_id = tile_id + 1;
+                    const bool is_last_source_packet = input_idx + 1 == num_inputs &&
+                                                       bh_idx + 1 == input_batch_head_count[input_idx] &&
+                                                       tiles_read + num_pages_to_read >= tiles_to_read;
+
+                    if (is_last_source_packet) {
+                        const uint64_t first_noc_addr = output_addrgens[input_idx].get_noc_addr(tile_id);
+                        const uint64_t second_noc_addr = output_addrgens[input_idx].get_noc_addr(second_tile_id);
+                        pkt_hdr->to_noc_fused_unicast_scatter_write_atomic_inc(
+                            tt::tt_fabric::NocUnicastScatterAtomicIncFusedCommandHeader{
+                                {first_noc_addr, second_noc_addr},
+                                out_ready_sem_noc_addr_in_pkt,
+                                {static_cast<uint16_t>(output_page_size)},
+                                1,
+                                true},
+                            output_page_size * 2);
+                        perform_payload_send(fabric_direction_connection, l1_read_addr, output_page_size * 2, pkt_hdr);
+                        noc_async_writes_flushed();
+                    } else {
+                        scatter_fabric_write_unidir(
+                            tile_id,
+                            second_tile_id,
+                            output_addrgens[input_idx],
+                            pkt_hdr,
+                            fabric_direction_connection,
+                            l1_read_addr,
+                            output_page_size);
+                    }
+                } else {
+                    ASSERT(num_pages_to_read == 1);
+
+                    const bool is_last_source_packet = input_idx + 1 == num_inputs &&
+                                                       bh_idx + 1 == input_batch_head_count[input_idx] &&
+                                                       tiles_read + num_pages_to_read >= tiles_to_read;
+                    if (is_last_source_packet) {
+                        tt::tt_fabric::linear::to_noc_fused_unicast_write_atomic_inc(
+                            output_page_size,
+                            pkt_hdr,
+                            tt::tt_fabric::NocUnicastAtomicIncCommandHeader{out_ready_sem_noc_addr_in_pkt, 1, true},
+                            tile_id,
+                            output_addrgens[input_idx]);
+                        perform_payload_send(fabric_direction_connection, l1_read_addr, output_page_size, pkt_hdr);
+                        noc_async_writes_flushed();
+                    } else {
+                        fabric_write_unidir(
+                            tile_id,
+                            output_addrgens[input_idx],
+                            pkt_hdr,
+                            fabric_direction_connection,
+                            l1_read_addr,
+                            output_page_size);
+                    }
+                }
+
+                tiles_read += num_pages_to_read;
+                cb_output.pop_front(packet_size_in_pages);
+            }
+        }
+    }
+
+    noc_obj.async_write_barrier();
+    // Drain in-flight writes BEFORE closing the EDM connections.
+    noc_obj.async_atomic_barrier();
+    noc_obj.async_write_barrier();
+
+    fabric_connection.close();
+}

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_neighbor_halo_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_neighbor_halo_writer.cpp
@@ -27,8 +27,9 @@ constexpr uint32_t output_page_size = get_compile_time_arg_val(3);
 constexpr uint32_t num_inputs = get_compile_time_arg_val(4);
 constexpr uint32_t unicast_route_arg0 = get_compile_time_arg_val(5);
 constexpr uint32_t unicast_route_arg1 = get_compile_time_arg_val(6);
+constexpr bool send_backward = get_compile_time_arg_val(7);
 
-constexpr uint32_t page_size_base_idx = 7;
+constexpr uint32_t page_size_base_idx = 8;
 
 void kernel_main() {
     constexpr auto outputs_args = make_tensor_accessor_args_tuple<num_inputs, page_size_base_idx + num_inputs>();
@@ -80,7 +81,8 @@ void kernel_main() {
 
     fabric_connection.open();
 
-    tt::tt_fabric::WorkerToFabricEdmSender& fabric_direction_connection = fabric_connection.get_forward_connection();
+    tt::tt_fabric::WorkerToFabricEdmSender& fabric_direction_connection =
+        send_backward ? fabric_connection.get_backward_connection() : fabric_connection.get_forward_connection();
     const uint64_t out_ready_sem_noc_addr_in_pkt =
         safe_get_noc_addr(out_ready_sem_noc0_x, out_ready_sem_noc0_y, out_ready_sem, 0);
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_prefetch_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_prefetch_utils.hpp
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+
+#include "api/core_local_mem.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc.h"
+
+// Batch packetized DRAM reads into a CB while keeping multiple packets in flight.  The caller
+// provides the source page mapping; this supports both the dense reader's contiguous two-page
+// reads and the neighbor-halo reader's one-page reads without duplicating FIFO-wrap arithmetic.
+template <
+    uint32_t input_page_size,
+    uint32_t packet_size_in_pages,
+    uint32_t prefetch_packets,
+    uint32_t contig_pages_advanced,
+    typename Accessor,
+    typename PageIdFn>
+FORCE_INLINE void prefetch_batch_read_tiles(
+    const Noc& noc,
+    CircularBuffer& cb_output,
+    uint32_t& tiles_read,
+    uint32_t tiles_to_read,
+    uint32_t cb_fifo_limit,
+    uint32_t cb_fifo_size,
+    const Accessor& accessor,
+    PageIdFn&& next_page_id) {
+    constexpr uint32_t payload_size_bytes = input_page_size * contig_pages_advanced;
+    while (tiles_read < tiles_to_read) {
+        const uint32_t remaining_tiles = tiles_to_read - tiles_read;
+        const uint32_t remaining_packets = (remaining_tiles + packet_size_in_pages - 1) / packet_size_in_pages;
+        const uint32_t batch_packets = std::min(remaining_packets, prefetch_packets);
+        const uint32_t batch_pages = batch_packets * packet_size_in_pages;
+
+        cb_output.reserve_back(batch_pages);
+        uint32_t l1_write_addr = cb_output.get_write_ptr();
+        for (uint32_t packet = 0; packet < batch_packets; ++packet) {
+            const uint32_t pages_to_read = std::min(tiles_to_read - tiles_read, packet_size_in_pages);
+            for (uint32_t page = 0; page < pages_to_read; page += contig_pages_advanced) {
+                if (l1_write_addr >= cb_fifo_limit) {
+                    l1_write_addr -= cb_fifo_size;
+                }
+                noc.async_read(
+                    accessor,
+                    CoreLocalMem<uint8_t>(l1_write_addr),
+                    input_page_size,
+                    {.page_id = next_page_id(tiles_read)},
+                    {});
+                l1_write_addr += payload_size_bytes;
+                tiles_read += contig_pages_advanced;
+            }
+            l1_write_addr += (packet_size_in_pages - pages_to_read) * input_page_size;
+        }
+        noc.async_read_barrier();
+        for (uint32_t packet = 0; packet < batch_packets; ++packet) {
+            cb_output.push_back(packet_size_in_pages);
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_multi_core_with_workers_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_multi_core_with_workers_program_factory.cpp
@@ -109,7 +109,8 @@ void ring_attention_neighbor_halo_exchange_helper(
     tt::tt_metal::ProgramDescriptor& desc,
     const std::vector<Tensor>& input_tensors,
     const MeshCoordinate& target_device_coord,
-    const MeshCoordinate& forward_device_coord,
+    const MeshCoordinate& transport_device_coord,
+    const MeshCoordinate& unicast_destination_coord,
     std::vector<Tensor>& output_tensors,
     uint32_t num_links,
     uint32_t ring_size,
@@ -131,15 +132,18 @@ void ring_attention_neighbor_halo_exchange_helper(
     using tt::tt_metal::WriterConfigDescriptor;
 
     TT_FATAL(!input_tensors.empty() && input_tensors.size() == output_tensors.size(), "Invalid halo tensor list");
-    TT_FATAL(semaphores.size() >= 1, "Neighbor halo requires an incoming-ready semaphore");
+    TT_FATAL(!semaphores.empty(), "Neighbor halo requires an incoming-ready semaphore");
 
     auto* mesh_device = input_tensors.front().device();
     const bool wrap_endpoint = ring_index == 0 || ring_index + 1 == ring_size;
     const auto transport_topology = wrap_endpoint ? topology : ttnn::ccl::Topology::Linear;
     auto mutable_input_tensors = input_tensors;
     const auto op_config = ttnn::ccl::CCLOpConfig(mutable_input_tensors, output_tensors, transport_topology);
-    const auto unicast_forward_args = std::get<0>(ccl::get_forward_backward_line_unicast_configuration(
-        target_device_coord, forward_device_coord, std::nullopt, mesh_device));
+    auto unicast_forward_args = std::get<0>(ccl::get_forward_backward_line_unicast_configuration(
+        target_device_coord, unicast_destination_coord, std::nullopt, mesh_device));
+    if (tt::tt_fabric::is_1d_fabric_config(tt::tt_fabric::GetFabricConfig())) {
+        unicast_forward_args[1] = halo.unicast_hops;
+    }
 
     const auto [worker_core_range, worker_cores] = ttnn::ccl::choose_worker_cores(
         num_links, 1, mesh_device, sub_device_id, core_grid_offset, std::nullopt, core_allocation_strategy);
@@ -201,6 +205,7 @@ void ring_attention_neighbor_halo_exchange_helper(
         num_inputs,
         unicast_forward_args[0],
         unicast_forward_args[1],
+        static_cast<uint32_t>(halo.send_backward),
     };
     for (uint32_t input = 0; input < num_inputs; ++input) {
         writer_kernel.compile_time_args.push_back(page_size);
@@ -316,17 +321,25 @@ void ring_attention_neighbor_halo_exchange_helper(
         for (const auto& output : output_tensors) {
             writer_args.push_back(output.buffer());
         }
-        writer_args.push_back(1u);
         std::vector<uint32_t> fabric_args;
+        // FabricConnectionManager consumes flags in forward-then-backward order. The linear
+        // wrap sender uses the backward connection, so its sender descriptor must follow the
+        // backward flag instead of the forward one.
+        writer_args.push_back(halo.send_backward ? 0u : 1u);
+        if (halo.send_backward) {
+            writer_args.push_back(1u);
+        }
         tt::tt_fabric::append_fabric_connection_rt_args(
             mesh_device->get_fabric_node_id(target_device_coord),
-            mesh_device->get_fabric_node_id(forward_device_coord),
+            mesh_device->get_fabric_node_id(transport_device_coord),
             link,
             desc,
             worker_cores[link],
             fabric_args);
         writer_args.append(fabric_args);
-        writer_args.push_back(0u);
+        if (!halo.send_backward) {
+            writer_args.push_back(0u);
+        }
         writer_kernel.emplace_runtime_args(worker_cores[link], writer_args);
     }
 
@@ -352,7 +365,12 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
     const CoreCoord core_grid_offset,
     ttnn::ccl::CoreAllocationStrategy core_allocation_strategy,
     std::optional<uint32_t> input_batch_slice_idx,
-    std::optional<uint32_t> gather_valid_Ht) {
+    std::optional<uint32_t> gather_valid_Ht,
+    std::optional<Tensor> slot_id,
+    std::optional<Tensor> kv_actual_isl,
+    uint32_t chunk_local_tiles,
+    uint32_t kv_cache_num_layers,
+    uint32_t kv_cache_layer_idx) {
     using tt::tt_metal::CBDescriptor;
     using tt::tt_metal::CBFormatDescriptor;
     using tt::tt_metal::KernelDescriptor;
@@ -480,6 +498,25 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
         }}},
     });
 
+    // The host value is a structural placeholder for the indexed gather. On the
+    // trace-safe path the reader derives the actual cache slot from slot_id.
+    const bool has_metadata = slot_id.has_value();
+    const uint32_t meta_cb_index = tt::CB::c_in3;
+    if (has_metadata) {
+        constexpr uint32_t meta_cb_page_size_bytes = 32;
+        for (const auto& core_ranges : {sender_forward_core_ranges, sender_backward_core_ranges}) {
+            desc.cbs.push_back(CBDescriptor{
+                .total_size = meta_cb_page_size_bytes,
+                .core_ranges = core_ranges,
+                .format_descriptors = {{CBFormatDescriptor{
+                    .buffer_index = static_cast<uint8_t>(meta_cb_index),
+                    .data_format = tt::DataFormat::RawUInt32,
+                    .page_size = meta_cb_page_size_bytes,
+                }}},
+            });
+        }
+    }
+
     // Tensor Info
     const uint32_t num_inputs = input_tensor.size();
     constexpr const char* exchange_writer_kernel_source =
@@ -509,6 +546,8 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
         num_inputs,                       // num_inputs
         1,                                // direction
         fuse_op,                          // fused op
+        static_cast<uint32_t>(has_metadata),
+        meta_cb_index,
     };
     for (uint32_t i = 0; i < num_inputs; i++) {
         sender_reader_forward_kernel.compile_time_args.push_back(op_config.get_page_size());
@@ -519,6 +558,11 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
     }
     for (uint32_t i = 0; i < num_inputs; i++) {
         tt::tt_metal::TensorAccessorArgs(output_tensor[i].buffer())
+            .append_to(sender_reader_forward_kernel.compile_time_args);
+    }
+    if (has_metadata) {
+        tt::tt_metal::TensorAccessorArgs(slot_id->buffer()).append_to(sender_reader_forward_kernel.compile_time_args);
+        tt::tt_metal::TensorAccessorArgs(kv_actual_isl->buffer())
             .append_to(sender_reader_forward_kernel.compile_time_args);
     }
 
@@ -545,12 +589,18 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
         1,                                        // direction
         unicast_backward_args[0],                 // unicast route arg0 (dst_mesh_id or 0)
         unicast_backward_args[1],                 // unicast route arg1 (dst_chip_id or distance_in_hops)
+        static_cast<uint32_t>(has_metadata),
+        meta_cb_index,
     };
     for (uint32_t i = 0; i < num_inputs; i++) {
         sender_writer_forward_kernel.compile_time_args.push_back(op_config.get_page_size());
     }
     for (uint32_t i = 0; i < num_inputs; i++) {
         tt::tt_metal::TensorAccessorArgs(output_tensor[i].buffer())
+            .append_to(sender_writer_forward_kernel.compile_time_args);
+    }
+    if (has_metadata) {
+        tt::tt_metal::TensorAccessorArgs(kv_actual_isl->buffer())
             .append_to(sender_writer_forward_kernel.compile_time_args);
     }
 
@@ -575,6 +625,8 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
         num_inputs,                       // num_inputs
         0,                                // direction
         fuse_op,                          // fused op
+        static_cast<uint32_t>(has_metadata),
+        meta_cb_index,
     };
     for (uint32_t i = 0; i < num_inputs; i++) {
         sender_reader_backward_kernel.compile_time_args.push_back(op_config.get_page_size());
@@ -585,6 +637,11 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
     }
     for (uint32_t i = 0; i < num_inputs; i++) {
         tt::tt_metal::TensorAccessorArgs(output_tensor[i].buffer())
+            .append_to(sender_reader_backward_kernel.compile_time_args);
+    }
+    if (has_metadata) {
+        tt::tt_metal::TensorAccessorArgs(slot_id->buffer()).append_to(sender_reader_backward_kernel.compile_time_args);
+        tt::tt_metal::TensorAccessorArgs(kv_actual_isl->buffer())
             .append_to(sender_reader_backward_kernel.compile_time_args);
     }
 
@@ -611,12 +668,18 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
         0,                                         // direction
         unicast_forward_args[0],                   // unicast route arg0 (dst_mesh_id or 0)
         unicast_forward_args[1],                   // unicast route arg1 (dst_chip_id or distance_in_hops)
+        static_cast<uint32_t>(has_metadata),
+        meta_cb_index,
     };
     for (uint32_t i = 0; i < num_inputs; i++) {
         sender_writer_backward_kernel.compile_time_args.push_back(op_config.get_page_size());
     }
     for (uint32_t i = 0; i < num_inputs; i++) {
         tt::tt_metal::TensorAccessorArgs(output_tensor[i].buffer())
+            .append_to(sender_writer_backward_kernel.compile_time_args);
+    }
+    if (has_metadata) {
+        tt::tt_metal::TensorAccessorArgs(kv_actual_isl->buffer())
             .append_to(sender_writer_backward_kernel.compile_time_args);
     }
 
@@ -736,6 +799,13 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
         for (uint32_t input_idx = 0; input_idx < num_inputs; input_idx++) {
             reader_forward_rt_args.push_back(output_tensor[input_idx].buffer());
         }
+        if (has_metadata) {
+            reader_forward_rt_args.push_back(slot_id->buffer());
+            reader_forward_rt_args.push_back(kv_actual_isl->buffer());
+            reader_forward_rt_args.push_back(chunk_local_tiles);
+            reader_forward_rt_args.push_back(kv_cache_num_layers);
+            reader_forward_rt_args.push_back(kv_cache_layer_idx);
+        }
         if (fuse_op) {
             std::vector<uint32_t> reader_forward_signaler_args;
             fused_op_signaler_forward->push_all_gather_fused_op_rt_args(
@@ -755,6 +825,13 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
         }
         for (uint32_t input_idx = 0; input_idx < num_inputs; input_idx++) {
             reader_backward_rt_args.push_back(output_tensor[input_idx].buffer());
+        }
+        if (has_metadata) {
+            reader_backward_rt_args.push_back(slot_id->buffer());
+            reader_backward_rt_args.push_back(kv_actual_isl->buffer());
+            reader_backward_rt_args.push_back(chunk_local_tiles);
+            reader_backward_rt_args.push_back(kv_cache_num_layers);
+            reader_backward_rt_args.push_back(kv_cache_layer_idx);
         }
         if (fuse_op) {
             std::vector<uint32_t> reader_backward_signaler_args;
@@ -782,6 +859,10 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
         writer_forward_rt_args.append(tensor_descriptor_args);
         for (uint32_t input_idx = 0; input_idx < num_inputs; input_idx++) {
             writer_forward_rt_args.push_back(output_tensor[input_idx].buffer());
+        }
+        if (has_metadata) {
+            writer_forward_rt_args.push_back(kv_actual_isl->buffer());
+            writer_forward_rt_args.push_back(chunk_local_tiles);
         }
         writer_forward_rt_args.push_back(0u);
         writer_forward_rt_args.push_back(static_cast<uint32_t>(backward_device_coord.has_value()));
@@ -818,6 +899,10 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
         writer_backward_rt_args.append(tensor_descriptor_args);
         for (uint32_t input_idx = 0; input_idx < num_inputs; input_idx++) {
             writer_backward_rt_args.push_back(output_tensor[input_idx].buffer());
+        }
+        if (has_metadata) {
+            writer_backward_rt_args.push_back(kv_actual_isl->buffer());
+            writer_backward_rt_args.push_back(chunk_local_tiles);
         }
         writer_backward_rt_args.push_back(static_cast<uint32_t>(forward_device_coord.has_value()));
         std::vector<uint32_t> writer_backward_extra_args;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_multi_core_with_workers_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_multi_core_with_workers_program_factory.cpp
@@ -24,10 +24,8 @@
 #include "cpp/ttnn/operations/ccl/common/uops/command_lowering.hpp"
 #include "cpp/ttnn/operations/ccl/common/host/ccl_worker_builder.hpp"
 #include "cpp/ttnn/operations/ccl/common/host/command_backend_runtime_args_overrider.hpp"
-#include <sstream>
-#include <type_traits>
-#include <ranges>
 #include <optional>
+#include <tuple>
 
 namespace ttnn::experimental::prim {
 
@@ -107,6 +105,235 @@ RingAttentionAllGatherAsyncMultiCoreWithWorkersProgramFactory::create_workload_d
 
 namespace ttnn {
 
+void ring_attention_neighbor_halo_exchange_helper(
+    tt::tt_metal::ProgramDescriptor& desc,
+    const std::vector<Tensor>& input_tensors,
+    const MeshCoordinate& target_device_coord,
+    const MeshCoordinate& forward_device_coord,
+    std::vector<Tensor>& output_tensors,
+    uint32_t num_links,
+    uint32_t ring_size,
+    uint32_t ring_index,
+    ttnn::ccl::Topology topology,
+    const std::vector<GlobalSemaphore>& semaphores,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id,
+    const ttnn::experimental::ccl::AllGatherFusedOpSignaler& fused_op_signaler,
+    CoreCoord core_grid_offset,
+    ttnn::ccl::CoreAllocationStrategy core_allocation_strategy,
+    std::optional<uint32_t> input_batch_slice_idx,
+    std::optional<uint32_t> gather_valid_Ht,
+    const RingAttentionNeighborHaloConfig& halo) {
+    using tt::tt_metal::CBDescriptor;
+    using tt::tt_metal::CBFormatDescriptor;
+    using tt::tt_metal::KernelDescriptor;
+    using tt::tt_metal::ReaderConfigDescriptor;
+    using tt::tt_metal::SemaphoreDescriptor;
+    using tt::tt_metal::WriterConfigDescriptor;
+
+    TT_FATAL(!input_tensors.empty() && input_tensors.size() == output_tensors.size(), "Invalid halo tensor list");
+    TT_FATAL(semaphores.size() >= 1, "Neighbor halo requires an incoming-ready semaphore");
+
+    auto* mesh_device = input_tensors.front().device();
+    const bool wrap_endpoint = ring_index == 0 || ring_index + 1 == ring_size;
+    const auto transport_topology = wrap_endpoint ? topology : ttnn::ccl::Topology::Linear;
+    auto mutable_input_tensors = input_tensors;
+    const auto op_config = ttnn::ccl::CCLOpConfig(mutable_input_tensors, output_tensors, transport_topology);
+    const auto unicast_forward_args = std::get<0>(ccl::get_forward_backward_line_unicast_configuration(
+        target_device_coord, forward_device_coord, std::nullopt, mesh_device));
+
+    const auto [worker_core_range, worker_cores] = ttnn::ccl::choose_worker_cores(
+        num_links, 1, mesh_device, sub_device_id, core_grid_offset, std::nullopt, core_allocation_strategy);
+    const CoreRangeSet workers(worker_core_range);
+
+    const uint32_t page_size = op_config.get_page_size();
+    const uint32_t packet_buffer_bytes = tt::tt_fabric::get_tt_fabric_channel_buffer_size_bytes();
+    const uint32_t pages_per_packet = std::min(packet_buffer_bytes / page_size, 2u);
+    const uint32_t cb_pages = 8 * pages_per_packet;
+    const auto data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensors.front().dtype());
+    constexpr uint32_t data_cb = tt::CB::c_in2;
+    constexpr uint32_t packet_header_cb = tt::CB::c_in1;
+    constexpr uint32_t packet_headers = 8;
+    const uint32_t packet_header_bytes = tt::tt_fabric::get_tt_fabric_packet_header_size_bytes();
+
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = cb_pages * page_size,
+        .core_ranges = workers,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(data_cb), .data_format = data_format, .page_size = page_size}}},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = packet_headers * packet_header_bytes * 2,
+        .core_ranges = workers,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(packet_header_cb),
+            .data_format = tt::DataFormat::RawUInt32,
+            .page_size = packet_header_bytes}}},
+    });
+
+    const uint32_t num_inputs = input_tensors.size();
+    KernelDescriptor reader_kernel{};
+    reader_kernel.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/"
+        "ring_attention_neighbor_halo_reader.cpp";
+    reader_kernel.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_kernel.core_ranges = workers;
+    reader_kernel.config = WriterConfigDescriptor{};
+    reader_kernel.compile_time_args = {ring_index, ring_size, data_cb, pages_per_packet, page_size, num_inputs};
+    for (uint32_t input = 0; input < num_inputs; ++input) {
+        reader_kernel.compile_time_args.push_back(page_size);
+    }
+    for (const auto& input : input_tensors) {
+        tt::tt_metal::TensorAccessorArgs(input.buffer()).append_to(reader_kernel.compile_time_args);
+    }
+
+    KernelDescriptor writer_kernel{};
+    writer_kernel.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/"
+        "ring_attention_neighbor_halo_writer.cpp";
+    writer_kernel.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_kernel.core_ranges = workers;
+    writer_kernel.config = ReaderConfigDescriptor{};
+    writer_kernel.compile_time_args = {
+        packet_header_cb,
+        data_cb,
+        pages_per_packet,
+        page_size,
+        num_inputs,
+        unicast_forward_args[0],
+        unicast_forward_args[1],
+    };
+    for (uint32_t input = 0; input < num_inputs; ++input) {
+        writer_kernel.compile_time_args.push_back(page_size);
+    }
+    for (const auto& output : output_tensors) {
+        tt::tt_metal::TensorAccessorArgs(output.buffer()).append_to(writer_kernel.compile_time_args);
+    }
+
+    auto halo_signaler = fused_op_signaler;
+    const auto worker_list = corerange_to_cores(workers, std::nullopt, true);
+    if (worker_list.size() > 1) {
+        const uint32_t sem_id = desc.semaphores.size();
+        desc.semaphores.push_back(SemaphoreDescriptor{
+            .id = sem_id,
+            .core_type = tt::CoreType::WORKER,
+            .core_ranges = workers,
+            .initial_value = 0,
+        });
+        halo_signaler.all_gather_worker_sync_semaphore = sem_id;
+    }
+    halo_signaler.all_gather_worker_cores_noc.clear();
+    for (const auto& worker : worker_list) {
+        halo_signaler.all_gather_worker_cores_noc.push_back(mesh_device->worker_core_from_logical_core(worker));
+    }
+    halo_signaler.initialized_all_gather = true;
+
+    for (uint32_t link = 0; link < num_links; ++link) {
+        KernelDescriptor::RTArgList reader_args;
+        reader_args.push_back(static_cast<uint32_t>(
+            semaphores.front().address()));  // smuggled-rta-ok: persistent GlobalSemaphore address
+        KernelDescriptor::RTArgList writer_args;
+        const CoreCoord worker_physical = mesh_device->worker_core_from_logical_core(worker_cores[link]);
+        writer_args.push_back(worker_physical.x);
+        writer_args.push_back(worker_physical.y);
+        writer_args.push_back(static_cast<uint32_t>(
+            semaphores.front().address()));  // smuggled-rta-ok: persistent GlobalSemaphore address
+
+        for (uint32_t input = 0; input < num_inputs; ++input) {
+            const auto input_shape = input_tensors[input].padded_shape();
+            const auto output_shape = output_tensors[input].padded_shape();
+            const uint32_t input_heads = input_shape[1];
+            const uint32_t input_Wt = input_shape[3] / tt::constants::TILE_WIDTH;
+            const uint32_t input_Ht = input_shape[2] / tt::constants::TILE_HEIGHT;
+            const uint32_t output_Wt = output_shape[3] / tt::constants::TILE_WIDTH;
+            const uint32_t output_Ht = output_shape[2] / tt::constants::TILE_HEIGHT;
+            TT_FATAL(
+                output_Wt == input_Wt,
+                "Neighbor halo requires matching input/output tile widths, got input Wt={} and output Wt={}",
+                input_Wt,
+                output_Wt);
+            TT_FATAL(
+                output_Ht >= halo.send_to_next_count_Ht,
+                "Neighbor halo output has {} tile rows but requires {}",
+                output_Ht,
+                halo.send_to_next_count_Ht);
+            TT_FATAL(
+                halo.send_to_next_start_Ht <= input_Ht &&
+                    halo.send_to_next_count_Ht <= input_Ht - halo.send_to_next_start_Ht,
+                "Neighbor halo [{}, {}) exceeds input Ht={}",
+                halo.send_to_next_start_Ht,
+                halo.send_to_next_start_Ht + halo.send_to_next_count_Ht,
+                input_Ht);
+
+            const uint32_t range_start_page = halo.send_to_next_start_Ht * input_Wt;
+            const uint32_t range_page_count = halo.send_to_next_count_Ht * input_Wt;
+            const uint32_t valid_pages = std::min(gather_valid_Ht.value_or(input_Ht), input_Ht) * input_Wt;
+            TT_FATAL(
+                range_start_page <= valid_pages && range_page_count <= valid_pages - range_start_page,
+                "Neighbor halo [{}, {}) exceeds the valid per-head page prefix {}",
+                range_start_page,
+                range_start_page + range_page_count,
+                valid_pages);
+            TT_FATAL(
+                range_page_count >= num_links,
+                "Neighbor halo has {} pages for {} links; every worker must send at least one page",
+                range_page_count,
+                num_links);
+            const uint32_t pages_per_worker = range_page_count / num_links;
+            const uint32_t remainder = range_page_count % num_links;
+            const uint32_t input_tile_start = range_start_page + link * pages_per_worker + std::min(link, remainder);
+            const uint32_t input_tile_end =
+                range_start_page + (link + 1) * pages_per_worker + std::min(link + 1, remainder);
+            TT_FATAL(
+                !input_batch_slice_idx.has_value() || *input_batch_slice_idx < input_shape[0],
+                "input_batch_slice_idx={} out of range for input batch={}",
+                input_batch_slice_idx.value_or(0),
+                input_shape[0]);
+            const uint32_t batch_head_count =
+                input_batch_slice_idx.has_value() ? input_heads : input_shape[0] * input_heads;
+            const uint32_t input_batch_base = ttnn::ring_attention_all_gather_async_detail::input_batch_base_pages(
+                input_batch_slice_idx.value_or(0), input_heads, input_Ht, input_Wt);
+
+            reader_args.push_back(input_Ht * input_Wt);
+            reader_args.push_back(batch_head_count);
+            reader_args.push_back(input_tile_start);
+            reader_args.push_back(input_tile_end);
+            reader_args.push_back(input_batch_base);
+
+            writer_args.push_back(output_Ht * output_Wt);
+            writer_args.push_back(batch_head_count);
+            writer_args.push_back(input_tile_start);
+            writer_args.push_back(input_tile_end);
+            writer_args.push_back(range_start_page);
+        }
+        for (const auto& input : input_tensors) {
+            reader_args.push_back(input.buffer());
+        }
+        std::vector<uint32_t> signaler_args;
+        halo_signaler.push_all_gather_fused_op_rt_args(signaler_args, num_links, link, 0);
+        reader_args.append(signaler_args);
+        reader_kernel.emplace_runtime_args(worker_cores[link], reader_args);
+
+        for (const auto& output : output_tensors) {
+            writer_args.push_back(output.buffer());
+        }
+        writer_args.push_back(1u);
+        std::vector<uint32_t> fabric_args;
+        tt::tt_fabric::append_fabric_connection_rt_args(
+            mesh_device->get_fabric_node_id(target_device_coord),
+            mesh_device->get_fabric_node_id(forward_device_coord),
+            link,
+            desc,
+            worker_cores[link],
+            fabric_args);
+        writer_args.append(fabric_args);
+        writer_args.push_back(0u);
+        writer_kernel.emplace_runtime_args(worker_cores[link], writer_args);
+    }
+
+    desc.kernels.push_back(std::move(reader_kernel));
+    desc.kernels.push_back(std::move(writer_kernel));
+}
+
 void ring_attention_all_gather_async_multi_core_with_workers_helper(
     tt::tt_metal::ProgramDescriptor& desc,
     const std::vector<Tensor>& input_tensor,
@@ -125,12 +352,7 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
     const CoreCoord core_grid_offset,
     ttnn::ccl::CoreAllocationStrategy core_allocation_strategy,
     std::optional<uint32_t> input_batch_slice_idx,
-    std::optional<uint32_t> gather_valid_Ht,
-    std::optional<Tensor> slot_id,
-    std::optional<Tensor> kv_actual_isl,
-    uint32_t chunk_local_tiles,
-    uint32_t kv_cache_num_layers,
-    uint32_t kv_cache_layer_idx) {
+    std::optional<uint32_t> gather_valid_Ht) {
     using tt::tt_metal::CBDescriptor;
     using tt::tt_metal::CBFormatDescriptor;
     using tt::tt_metal::KernelDescriptor;
@@ -156,9 +378,9 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
     std::optional<ttnn::experimental::ccl::AllGatherFusedOpSignaler> fused_op_signaler_backward;
 
     if (fuse_op) {
+        fused_op_signaler_backward = fused_op_signaler.value();
         fused_op_signaler_sender_workers = fused_op_signaler.value();
         fused_op_signaler_forward = fused_op_signaler.value();
-        fused_op_signaler_backward = fused_op_signaler.value();
     }
 
     // Get OP Config, topology config
@@ -173,8 +395,7 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
         std::swap(num_targets_forward, num_targets_backward);
     }
     // Get worker cores
-    // 2 sender (forward/backward, each with a reader/writer)
-    uint32_t num_senders_per_link = 2;
+    const uint32_t num_senders_per_link = 2;
     const auto [sender_worker_core_range, sender_worker_cores] = ttnn::ccl::choose_worker_cores(
         num_links,
         num_senders_per_link,
@@ -259,36 +480,11 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
         }}},
     });
 
-    // Trace-safe metadata path: when slot_id / kv_actual_isl tensors are supplied, the readers recompute
-    // the single-slot gather offset from slot = slot_id[0] on-device (and the gather extent from
-    // kv_actual_isl[0]). A tiny dedicated CB (c_in3) holds the read page on both the forward and backward
-    // reader cores. Created only when present, so non-metadata callers' programs are bit-identical.
-    const bool has_metadata = slot_id.has_value();
-    const uint32_t meta_cb_index = tt::CB::c_in3;
-    if (has_metadata) {
-        constexpr uint32_t meta_cb_page_size_bytes = 32;  // holds a 1-element uint32 page with headroom
-        desc.cbs.push_back(CBDescriptor{
-            .total_size = meta_cb_page_size_bytes,
-            .core_ranges = sender_forward_core_ranges,
-            .format_descriptors = {{CBFormatDescriptor{
-                .buffer_index = static_cast<uint8_t>(meta_cb_index),
-                .data_format = tt::DataFormat::RawUInt32,
-                .page_size = meta_cb_page_size_bytes,
-            }}},
-        });
-        desc.cbs.push_back(CBDescriptor{
-            .total_size = meta_cb_page_size_bytes,
-            .core_ranges = sender_backward_core_ranges,
-            .format_descriptors = {{CBFormatDescriptor{
-                .buffer_index = static_cast<uint8_t>(meta_cb_index),
-                .data_format = tt::DataFormat::RawUInt32,
-                .page_size = meta_cb_page_size_bytes,
-            }}},
-        });
-    }
-
     // Tensor Info
     const uint32_t num_inputs = input_tensor.size();
+    constexpr const char* exchange_writer_kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/"
+        "ring_attention_all_gather_writer.cpp";
 
     uint32_t tiles_to_write_per_packet = 1;
     // KERNEL CREATION
@@ -302,19 +498,17 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
     sender_reader_forward_kernel.core_ranges = sender_forward_core_ranges;
     sender_reader_forward_kernel.config = WriterConfigDescriptor{};
     sender_reader_forward_kernel.compile_time_args = {
-        ring_index,                           // my_chip_id
-        sender_forward_cb_index,              // cb_forward_id
-        num_pages_per_packet,                 // packet_size_in_pages
-        op_config.get_page_size(),            // tensor0_page_size
-        num_targets_forward,                  // num_slices_forward_direction
-        num_targets_backward,                 // num_slices_backward_direction
-        static_cast<uint32_t>(topology),      // topology
-        tiles_to_write_per_packet,            // contig_pages_advanced
-        num_inputs,                           // num_inputs
-        1,                                    // direction
-        fuse_op,                              // fused op
-        static_cast<uint32_t>(has_metadata),  // 11 == has_metadata (trace-safe slot select)
-        meta_cb_index,                        // 12 == cb_meta_id
+        ring_index,                       // my_chip_id
+        sender_forward_cb_index,          // cb_forward_id
+        num_pages_per_packet,             // packet_size_in_pages
+        op_config.get_page_size(),        // tensor0_page_size
+        num_targets_forward,              // num_slices_forward_direction
+        num_targets_backward,             // num_slices_backward_direction
+        static_cast<uint32_t>(topology),  // topology
+        tiles_to_write_per_packet,        // contig_pages_advanced
+        num_inputs,                       // num_inputs
+        1,                                // direction
+        fuse_op,                          // fused op
     };
     for (uint32_t i = 0; i < num_inputs; i++) {
         sender_reader_forward_kernel.compile_time_args.push_back(op_config.get_page_size());
@@ -327,22 +521,10 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
         tt::tt_metal::TensorAccessorArgs(output_tensor[i].buffer())
             .append_to(sender_reader_forward_kernel.compile_time_args);
     }
-    // Metadata accessor follows the output accessors (metadata path only); matches the reader kernel's
-    // kMetaArgsOffset, which is gated on has_metadata. slot_id and kv_actual_isl each get their OWN
-    // accessor (appended in this order): they are separately-allocated single-page DRAM tensors that can
-    // land in different DRAM banks, so a shared accessor would read the wrong bank for one (the reader's
-    // kv_actual read silently returned 0). See the reader's meta_args / kv_meta_args.
-    if (has_metadata) {
-        tt::tt_metal::TensorAccessorArgs(slot_id->buffer()).append_to(sender_reader_forward_kernel.compile_time_args);
-        tt::tt_metal::TensorAccessorArgs(kv_actual_isl->buffer())
-            .append_to(sender_reader_forward_kernel.compile_time_args);
-    }
 
     // Writer
     KernelDescriptor sender_writer_forward_kernel{};
-    sender_writer_forward_kernel.kernel_source =
-        "ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/"
-        "ring_attention_all_gather_writer.cpp";
+    sender_writer_forward_kernel.kernel_source = exchange_writer_kernel_source;
     sender_writer_forward_kernel.source_type = KernelDescriptor::SourceType::FILE_PATH;
     sender_writer_forward_kernel.core_ranges = sender_forward_core_ranges;
     sender_writer_forward_kernel.config = ReaderConfigDescriptor{};
@@ -363,19 +545,12 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
         1,                                        // direction
         unicast_backward_args[0],                 // unicast route arg0 (dst_mesh_id or 0)
         unicast_backward_args[1],                 // unicast route arg1 (dst_chip_id or distance_in_hops)
-        static_cast<uint32_t>(has_metadata),      // 16 == has_metadata (trace-safe gather-extent recompute)
-        meta_cb_index,                            // 17 == cb_meta_id
     };
     for (uint32_t i = 0; i < num_inputs; i++) {
         sender_writer_forward_kernel.compile_time_args.push_back(op_config.get_page_size());
     }
     for (uint32_t i = 0; i < num_inputs; i++) {
         tt::tt_metal::TensorAccessorArgs(output_tensor[i].buffer())
-            .append_to(sender_writer_forward_kernel.compile_time_args);
-    }
-    // Writer reads kv_actual_isl[0] only; append its accessor (same layout as slot_id).
-    if (has_metadata) {
-        tt::tt_metal::TensorAccessorArgs(kv_actual_isl->buffer())
             .append_to(sender_writer_forward_kernel.compile_time_args);
     }
 
@@ -389,19 +564,17 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
     sender_reader_backward_kernel.core_ranges = sender_backward_core_ranges;
     sender_reader_backward_kernel.config = WriterConfigDescriptor{};
     sender_reader_backward_kernel.compile_time_args = {
-        ring_index,                           // my_chip_id
-        sender_backward_cb_index,             // cb_backward_id
-        num_pages_per_packet,                 // packet_size_in_pages
-        op_config.get_page_size(),            // tensor0_page_size
-        num_targets_forward,                  // num_slices_forward_direction
-        num_targets_backward,                 // num_slices_backward_direction
-        static_cast<uint32_t>(topology),      // topology
-        tiles_to_write_per_packet,            // contig_pages_advanced
-        num_inputs,                           // num_inputs
-        0,                                    // direction
-        fuse_op,                              // fused op
-        static_cast<uint32_t>(has_metadata),  // 11 == has_metadata (trace-safe slot select)
-        meta_cb_index,                        // 12 == cb_meta_id
+        ring_index,                       // my_chip_id
+        sender_backward_cb_index,         // cb_backward_id
+        num_pages_per_packet,             // packet_size_in_pages
+        op_config.get_page_size(),        // tensor0_page_size
+        num_targets_forward,              // num_slices_forward_direction
+        num_targets_backward,             // num_slices_backward_direction
+        static_cast<uint32_t>(topology),  // topology
+        tiles_to_write_per_packet,        // contig_pages_advanced
+        num_inputs,                       // num_inputs
+        0,                                // direction
+        fuse_op,                          // fused op
     };
     for (uint32_t i = 0; i < num_inputs; i++) {
         sender_reader_backward_kernel.compile_time_args.push_back(op_config.get_page_size());
@@ -414,18 +587,10 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
         tt::tt_metal::TensorAccessorArgs(output_tensor[i].buffer())
             .append_to(sender_reader_backward_kernel.compile_time_args);
     }
-    if (has_metadata) {
-        tt::tt_metal::TensorAccessorArgs(slot_id->buffer()).append_to(sender_reader_backward_kernel.compile_time_args);
-        // kv_actual_isl gets its OWN accessor (different DRAM bank possible; see the reader's kv_meta_args).
-        tt::tt_metal::TensorAccessorArgs(kv_actual_isl->buffer())
-            .append_to(sender_reader_backward_kernel.compile_time_args);
-    }
 
     // Writer
     KernelDescriptor sender_writer_backward_kernel{};
-    sender_writer_backward_kernel.kernel_source =
-        "ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/"
-        "ring_attention_all_gather_writer.cpp";
+    sender_writer_backward_kernel.kernel_source = exchange_writer_kernel_source;
     sender_writer_backward_kernel.source_type = KernelDescriptor::SourceType::FILE_PATH;
     sender_writer_backward_kernel.core_ranges = sender_backward_core_ranges;
     sender_writer_backward_kernel.config = ReaderConfigDescriptor{};
@@ -446,18 +611,12 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
         0,                                         // direction
         unicast_forward_args[0],                   // unicast route arg0 (dst_mesh_id or 0)
         unicast_forward_args[1],                   // unicast route arg1 (dst_chip_id or distance_in_hops)
-        static_cast<uint32_t>(has_metadata),       // 16 == has_metadata (trace-safe gather-extent recompute)
-        meta_cb_index,                             // 17 == cb_meta_id
     };
     for (uint32_t i = 0; i < num_inputs; i++) {
         sender_writer_backward_kernel.compile_time_args.push_back(op_config.get_page_size());
     }
     for (uint32_t i = 0; i < num_inputs; i++) {
         tt::tt_metal::TensorAccessorArgs(output_tensor[i].buffer())
-            .append_to(sender_writer_backward_kernel.compile_time_args);
-    }
-    if (has_metadata) {
-        tt::tt_metal::TensorAccessorArgs(kv_actual_isl->buffer())
             .append_to(sender_writer_backward_kernel.compile_time_args);
     }
 
@@ -467,7 +626,6 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
     // to `desc.semaphores` and update the signaler's noc-coord and semaphore-id state
     // directly. Semaphore IDs are sequential and start at the current desc.semaphores.size().
     if (fuse_op) {
-        auto sender_workers_forward = corerange_to_cores(sender_forward_core_ranges, std::nullopt, true);
         auto sender_workers_backward = corerange_to_cores(sender_backward_core_ranges, std::nullopt, true);
 
         auto init_all_gather_descriptor =
@@ -493,8 +651,9 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
                 signaler->initialized_all_gather = true;
             };
 
-        init_all_gather_descriptor(fused_op_signaler_forward, sender_forward_core_ranges, sender_workers_forward);
         init_all_gather_descriptor(fused_op_signaler_backward, sender_backward_core_ranges, sender_workers_backward);
+        auto sender_workers_forward = corerange_to_cores(sender_forward_core_ranges, std::nullopt, true);
+        init_all_gather_descriptor(fused_op_signaler_forward, sender_forward_core_ranges, sender_workers_forward);
         init_all_gather_descriptor(
             fused_op_signaler_sender_workers, sender_forward_core_ranges, sender_workers_forward);
     }
@@ -502,86 +661,80 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
     for (uint32_t link = 0; link < num_links; link++) {
         // Set Sender Reader runtime args
 
-        std::vector<uint32_t> tensor_descriptor_args;
-        for (uint32_t i = 0; i < num_inputs; i++) {
-            const auto input_tensor_num_pages = input_tensor[i].buffer()->num_pages();
-            const auto input_tensor_shape = input_tensor[i].padded_shape();
-            const auto output_tensor_shape = output_tensor[i].padded_shape();
-            const uint32_t num_heads = input_tensor_shape[1];
-            // single_batch_head_num_pages is always pages-per-(batch,head); independent of slicing.
-            const uint32_t full_batch_head_size = input_tensor_shape[0] * num_heads;
+        const auto build_tensor_descriptor_args = [&]() {
+            std::vector<uint32_t> tensor_descriptor_args;
+            for (uint32_t i = 0; i < num_inputs; i++) {
+                const auto input_tensor_num_pages = input_tensor[i].buffer()->num_pages();
+                const auto input_tensor_shape = input_tensor[i].padded_shape();
+                const auto output_tensor_shape = output_tensor[i].padded_shape();
+                const uint32_t num_heads = input_tensor_shape[1];
+                // single_batch_head_num_pages is always pages-per-(batch,head); independent of slicing.
+                const uint32_t full_batch_head_size = input_tensor_shape[0] * num_heads;
 
-            uint32_t single_batch_head_num_pages = input_tensor_num_pages / full_batch_head_size;
-            const uint32_t base_pages_per_worker = single_batch_head_num_pages / num_links;
-            const uint32_t remainder = single_batch_head_num_pages % num_links;
-            const uint32_t input_tile_id_start = (link * base_pages_per_worker) + std::min(link, remainder);
-            const uint32_t input_tile_id_end = ((link + 1) * base_pages_per_worker) + std::min(link + 1, remainder);
+                uint32_t single_batch_head_num_pages = input_tensor_num_pages / full_batch_head_size;
+                const uint32_t input_tensor_Wt = input_tensor_shape[3] / tt::constants::TILE_WIDTH;
+                const uint32_t input_tensor_Ht = input_tensor_shape[2] / tt::constants::TILE_HEIGHT;
+                const uint32_t output_tensor_Wt = output_tensor_shape[3] / tt::constants::TILE_WIDTH;
+                const uint32_t output_tensor_Ht = output_tensor_shape[2] / tt::constants::TILE_HEIGHT;
+                TT_ASSERT(!(input_tensor_shape[3] % tt::constants::TILE_WIDTH));
+                TT_ASSERT(!(output_tensor_shape[3] % tt::constants::TILE_WIDTH));
 
-            const uint32_t input_tensor_Wt = input_tensor_shape[3] / tt::constants::TILE_WIDTH;
-            const uint32_t input_tensor_Ht = input_tensor_shape[2] / tt::constants::TILE_HEIGHT;
-            const uint32_t output_tensor_Wt = output_tensor_shape[3] / tt::constants::TILE_WIDTH;
-            const uint32_t output_tensor_Ht = output_tensor_shape[2] / tt::constants::TILE_HEIGHT;
-            TT_ASSERT(!(input_tensor_shape[3] % tt::constants::TILE_WIDTH));
-            TT_ASSERT(!(output_tensor_shape[3] % tt::constants::TILE_WIDTH));
+                const uint32_t base_pages_per_worker = single_batch_head_num_pages / num_links;
+                const uint32_t remainder = single_batch_head_num_pages % num_links;
+                const uint32_t input_tile_id_start = (link * base_pages_per_worker) + std::min(link, remainder);
+                const uint32_t input_tile_id_end = ((link + 1) * base_pages_per_worker) + std::min(link + 1, remainder);
 
-            // Single-slot gather: read only slot `input_batch_slice_idx`'s `num_heads` blocks (from
-            // `input_batch_base`); the writer emits them to output slot 0. A batch-1 output suffices,
-            // but a full-batch output also works (only slot 0 written). std::nullopt => full batch.
-            uint32_t batch_head_size = full_batch_head_size;
-            uint32_t input_batch_base = 0;
-            if (input_batch_slice_idx.has_value()) {
-                TT_FATAL(
-                    *input_batch_slice_idx < input_tensor_shape[0],
-                    "input_batch_slice_idx={} out of range for input batch={}",
-                    *input_batch_slice_idx,
-                    input_tensor_shape[0]);
-                batch_head_size = num_heads;
-                input_batch_base = ring_attention_all_gather_async_detail::input_batch_base_pages(
-                    *input_batch_slice_idx, num_heads, input_tensor_Ht, input_tensor_Wt);
+                // Single-slot gather: read only slot `input_batch_slice_idx`'s `num_heads` blocks (from
+                // `input_batch_base`); the writer emits them to output slot 0. A batch-1 output suffices,
+                // but a full-batch output also works (only slot 0 written). std::nullopt => full batch.
+                uint32_t batch_head_size = full_batch_head_size;
+                uint32_t input_batch_base = 0;
+                if (input_batch_slice_idx.has_value()) {
+                    TT_FATAL(
+                        *input_batch_slice_idx < input_tensor_shape[0],
+                        "input_batch_slice_idx={} out of range for input batch={}",
+                        *input_batch_slice_idx,
+                        input_tensor_shape[0]);
+                    batch_head_size = num_heads;
+                    input_batch_base = ttnn::ring_attention_all_gather_async_detail::input_batch_base_pages(
+                        *input_batch_slice_idx, num_heads, input_tensor_Ht, input_tensor_Wt);
+                }
+
+                tensor_descriptor_args.push_back(input_tensor_Wt);      // 0 == input_tensor_Wt
+                tensor_descriptor_args.push_back(input_tensor_Ht);      // 1 == input_tensor_Ht
+                tensor_descriptor_args.push_back(output_tensor_Wt);     // 2 == output_tensor_Wt
+                tensor_descriptor_args.push_back(output_tensor_Ht);     // 3 == output_tensor_Ht
+                tensor_descriptor_args.push_back(batch_head_size);      // 4 == batch_head_size (bh-loop count)
+                tensor_descriptor_args.push_back(input_tile_id_start);  // 5 == input_tile_id_start
+                tensor_descriptor_args.push_back(input_tile_id_end);    // 6 == input_tile_id_end
+                tensor_descriptor_args.push_back(
+                    input_batch_base);  // 7 == input_batch_base (phase-1 input page offset)
+                // 8 == valid pages per (batch,head) to gather. Default: full input slab (no clamp). When
+                // gather_valid_Ht is set (fused ring_joint_sdpa with an oversized cache), bound it to the
+                // first gather_valid_Ht tile-rows so only kv_actual-sized data moves. The fused path also
+                // re-patches this per dispatch on cache hits (apply_ring_joint_scalar_runtime_args); setting
+                // it here makes the cache-miss (first) dispatch bounded too.
+                const uint32_t valid_pages_per_batch_head =
+                    gather_valid_Ht.has_value() ? std::min(*gather_valid_Ht, input_tensor_Ht) * input_tensor_Wt
+                                                : single_batch_head_num_pages;
+                tensor_descriptor_args.push_back(valid_pages_per_batch_head);  // 8 == valid_pages_per_batch_head
             }
+            return tensor_descriptor_args;
+        };
 
-            tensor_descriptor_args.push_back(input_tensor_Wt);      // 0 == input_tensor_Wt
-            tensor_descriptor_args.push_back(input_tensor_Ht);      // 1 == input_tensor_Ht
-            tensor_descriptor_args.push_back(output_tensor_Wt);     // 2 == output_tensor_Wt
-            tensor_descriptor_args.push_back(output_tensor_Ht);     // 3 == output_tensor_Ht
-            tensor_descriptor_args.push_back(batch_head_size);      // 4 == batch_head_size (bh-loop count)
-            tensor_descriptor_args.push_back(input_tile_id_start);  // 5 == input_tile_id_start
-            tensor_descriptor_args.push_back(input_tile_id_end);    // 6 == input_tile_id_end
-            tensor_descriptor_args.push_back(input_batch_base);     // 7 == input_batch_base (phase-1 input page offset)
-            // 8 == valid pages per (batch,head) to gather. Default: full input slab (no clamp). When
-            // gather_valid_Ht is set (fused ring_joint_sdpa with an oversized cache), bound it to the
-            // first gather_valid_Ht tile-rows so only kv_actual-sized data moves. The fused path also
-            // re-patches this per dispatch on cache hits (apply_ring_joint_scalar_runtime_args); setting
-            // it here makes the cache-miss (first) dispatch bounded too.
-            const uint32_t valid_pages_per_batch_head =
-                gather_valid_Ht.has_value() ? std::min(*gather_valid_Ht, input_tensor_Ht) * input_tensor_Wt
-                                            : single_batch_head_num_pages;
-            tensor_descriptor_args.push_back(valid_pages_per_batch_head);  // 8 == valid_pages_per_batch_head
-        }
+        const auto tensor_descriptor_args = build_tensor_descriptor_args();
 
         KernelDescriptor::RTArgList reader_forward_rt_args;
         reader_forward_rt_args.push_back(static_cast<uint32_t>(dim));  // dim to gather on
         reader_forward_rt_args.push_back(ring_size);                   // ring_size
         reader_forward_rt_args.push_back(
-            static_cast<uint32_t>(semaphore.at(1).address()));  // smuggled-rta-ok: CCL out-ready semaphore addr
+            static_cast<uint32_t>(semaphore.at(1).address()));  // smuggled-rta-ok: persistent GlobalSemaphore address
         reader_forward_rt_args.append(tensor_descriptor_args);
         for (uint32_t input_idx = 0; input_idx < num_inputs; input_idx++) {
             reader_forward_rt_args.push_back(input_tensor[input_idx].buffer());
         }
         for (uint32_t input_idx = 0; input_idx < num_inputs; input_idx++) {
             reader_forward_rt_args.push_back(output_tensor[input_idx].buffer());
-        }
-        // slot_id + kv_actual_isl DRAM addresses + chunk_local_tiles (read by the reader before the
-        // optional signaler args; metadata path only). The reader reads slot = slot_id[0] for the gather
-        // slot and kv_actual = kv_actual_isl[0] for the gather extent; chunk_local_tiles lets it recompute
-        // the gather extent on-device.
-        if (has_metadata) {
-            reader_forward_rt_args.push_back(slot_id->buffer());
-            reader_forward_rt_args.push_back(kv_actual_isl->buffer());
-            reader_forward_rt_args.push_back(chunk_local_tiles);
-            // (user, layer)-major slot factor; read by the reader right after chunk_local_tiles.
-            reader_forward_rt_args.push_back(kv_cache_num_layers);
-            reader_forward_rt_args.push_back(kv_cache_layer_idx);
         }
         if (fuse_op) {
             std::vector<uint32_t> reader_forward_signaler_args;
@@ -595,7 +748,7 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
         reader_backward_rt_args.push_back(static_cast<uint32_t>(dim));  // dim to gather on
         reader_backward_rt_args.push_back(ring_size);                   // ring_size
         reader_backward_rt_args.push_back(
-            static_cast<uint32_t>(semaphore.at(0).address()));  // smuggled-rta-ok: CCL out-ready semaphore addr
+            static_cast<uint32_t>(semaphore.at(0).address()));  // smuggled-rta-ok: persistent GlobalSemaphore address
         reader_backward_rt_args.append(tensor_descriptor_args);
         for (uint32_t input_idx = 0; input_idx < num_inputs; input_idx++) {
             reader_backward_rt_args.push_back(input_tensor[input_idx].buffer());
@@ -603,44 +756,32 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
         for (uint32_t input_idx = 0; input_idx < num_inputs; input_idx++) {
             reader_backward_rt_args.push_back(output_tensor[input_idx].buffer());
         }
-        if (has_metadata) {
-            reader_backward_rt_args.push_back(slot_id->buffer());
-            reader_backward_rt_args.push_back(kv_actual_isl->buffer());
-            reader_backward_rt_args.push_back(chunk_local_tiles);
-            // (user, layer)-major slot factor; read by the reader right after chunk_local_tiles.
-            reader_backward_rt_args.push_back(kv_cache_num_layers);
-            reader_backward_rt_args.push_back(kv_cache_layer_idx);
-        }
         if (fuse_op) {
             std::vector<uint32_t> reader_backward_signaler_args;
             fused_op_signaler_backward->push_all_gather_fused_op_rt_args(
                 reader_backward_signaler_args, num_links, link, 0);
             reader_backward_rt_args.append(reader_backward_signaler_args);
         }
-        sender_reader_backward_kernel.emplace_runtime_args(sender_worker_cores[link * 2], reader_backward_rt_args);
+        const uint32_t backward_worker_index = link * 2;
+        sender_reader_backward_kernel.emplace_runtime_args(
+            sender_worker_cores[backward_worker_index], reader_backward_rt_args);
 
-        const CoreCoord sender_forward_worker_core =
-            mesh_device->worker_core_from_logical_core(sender_worker_cores[(link * 2) + 1]);
         const CoreCoord sender_backward_worker_core =
-            mesh_device->worker_core_from_logical_core(sender_worker_cores[link * 2]);
+            mesh_device->worker_core_from_logical_core(sender_worker_cores[backward_worker_index]);
 
         // Writer
+        const CoreCoord sender_forward_worker_core =
+            mesh_device->worker_core_from_logical_core(sender_worker_cores[(link * 2) + 1]);
         KernelDescriptor::RTArgList writer_forward_rt_args;
         writer_forward_rt_args.push_back(static_cast<uint32_t>(dim));                           // dim to gather on
         writer_forward_rt_args.push_back(static_cast<uint32_t>(sender_forward_worker_core.x));  // out_ready_sem_noc0_x
         writer_forward_rt_args.push_back(static_cast<uint32_t>(sender_forward_worker_core.y));  // out_ready_sem_noc0_y
         writer_forward_rt_args.push_back(ring_size);                                            // ring_size
         writer_forward_rt_args.push_back(
-            static_cast<uint32_t>(semaphore.at(1).address()));  // smuggled-rta-ok: CCL out-ready semaphore addr
+            static_cast<uint32_t>(semaphore.at(1).address()));  // smuggled-rta-ok: persistent GlobalSemaphore address
         writer_forward_rt_args.append(tensor_descriptor_args);
         for (uint32_t input_idx = 0; input_idx < num_inputs; input_idx++) {
             writer_forward_rt_args.push_back(output_tensor[input_idx].buffer());
-        }
-        // kv_actual_isl DRAM address + chunk_local_tiles (read by the writer after the output-buffer addrs
-        // and before the fabric args; metadata path only) for the on-device gather-extent recompute.
-        if (has_metadata) {
-            writer_forward_rt_args.push_back(kv_actual_isl->buffer());
-            writer_forward_rt_args.push_back(chunk_local_tiles);
         }
         writer_forward_rt_args.push_back(0u);
         writer_forward_rt_args.push_back(static_cast<uint32_t>(backward_device_coord.has_value()));
@@ -673,14 +814,10 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
             static_cast<uint32_t>(sender_backward_worker_core.y));  // out_ready_sem_noc0_y
         writer_backward_rt_args.push_back(ring_size);               // ring_size
         writer_backward_rt_args.push_back(
-            static_cast<uint32_t>(semaphore.at(0).address()));  // smuggled-rta-ok: CCL out-ready semaphore addr
+            static_cast<uint32_t>(semaphore.at(0).address()));  // smuggled-rta-ok: persistent GlobalSemaphore address
         writer_backward_rt_args.append(tensor_descriptor_args);
         for (uint32_t input_idx = 0; input_idx < num_inputs; input_idx++) {
             writer_backward_rt_args.push_back(output_tensor[input_idx].buffer());
-        }
-        if (has_metadata) {
-            writer_backward_rt_args.push_back(kv_actual_isl->buffer());
-            writer_backward_rt_args.push_back(chunk_local_tiles);
         }
         writer_backward_rt_args.push_back(static_cast<uint32_t>(forward_device_coord.has_value()));
         std::vector<uint32_t> writer_backward_extra_args;
@@ -692,7 +829,7 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
                 forward_fabric_node_id,
                 link,
                 desc,
-                sender_worker_cores[link * 2],
+                sender_worker_cores[backward_worker_index],
                 writer_backward_extra_args);
         }
         writer_backward_rt_args.append(writer_backward_extra_args);
@@ -702,7 +839,8 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
             fused_op_signaler_sender_workers->push_all_gather_fused_op_rt_args(writer_backward_signaler_args, 1, 0, 0);
             writer_backward_rt_args.append(writer_backward_signaler_args);
         }
-        sender_writer_backward_kernel.emplace_runtime_args(sender_worker_cores[link * 2], writer_backward_rt_args);
+        sender_writer_backward_kernel.emplace_runtime_args(
+            sender_worker_cores[backward_worker_index], writer_backward_rt_args);
     }
 
     // Kernel descriptors are pushed last, with their runtime args fully populated.

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_multi_core_with_workers_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_multi_core_with_workers_program_factory.hpp
@@ -38,6 +38,10 @@ namespace ttnn {
 struct RingAttentionNeighborHaloConfig {
     uint32_t send_to_next_start_Ht;
     uint32_t send_to_next_count_Ht;
+    // A linear topology has no physical wrap link. The final device sends its
+    // predecessor tail back to device 0 over the backward fabric direction.
+    bool send_backward = false;
+    uint32_t unicast_hops = 1;
 };
 
 namespace ring_attention_all_gather_async_detail {
@@ -129,7 +133,8 @@ void ring_attention_neighbor_halo_exchange_helper(
     tt::tt_metal::ProgramDescriptor& desc,
     const std::vector<Tensor>& input_tensors,
     const MeshCoordinate& target_device_coord,
-    const MeshCoordinate& forward_device_coord,
+    const MeshCoordinate& transport_device_coord,
+    const MeshCoordinate& unicast_destination_coord,
     std::vector<Tensor>& output_tensors,
     uint32_t num_links,
     uint32_t ring_size,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_multi_core_with_workers_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_multi_core_with_workers_program_factory.hpp
@@ -32,6 +32,14 @@ struct RingAttentionAllGatherAsyncMultiCoreWithWorkersProgramFactory {
 
 namespace ttnn {
 
+// Sparse cyclic predecessor exchange used by chunked GPT-OSS sliding attention.
+// Each device sends one local tile-row range to its logical next device and
+// receives the predecessor's corresponding range into compact output slot 0.
+struct RingAttentionNeighborHaloConfig {
+    uint32_t send_to_next_start_Ht;
+    uint32_t send_to_next_count_Ht;
+};
+
 namespace ring_attention_all_gather_async_detail {
 
 // All-gather reader runtime-arg layout: [0]=dim, [1]=ring_size, [2]=out_ready_sem,
@@ -46,10 +54,20 @@ constexpr uint32_t kInputBatchBaseFieldOffset = 7;
 // (input_Ht * input_Wt); the fused ring_joint_sdpa path patches it down to the logical_n-valid
 // slab prefix so the gather moves only kv_actual-sized data, not the whole oversized cache.
 constexpr uint32_t kValidPagesFieldOffset = 8;
+constexpr uint32_t kNeighborReaderRuntimeArgHeaderCount = 1;
+constexpr uint32_t kNeighborReaderTensorDescriptorFieldCount = 5;
+constexpr uint32_t kNeighborReaderInputTileStartFieldOffset = 2;
+constexpr uint32_t kNeighborReaderInputTileEndFieldOffset = 3;
+constexpr uint32_t kNeighborReaderInputBatchBaseFieldOffset = 4;
 
-inline uint32_t input_batch_base_pages(
-    uint32_t batch_idx, uint32_t num_heads, uint32_t tensor_height_tiles, uint32_t tensor_width_tiles) {
-    return batch_idx * num_heads * tensor_height_tiles * tensor_width_tiles;
+constexpr uint32_t kNeighborWriterRuntimeArgHeaderCount = 3;
+constexpr uint32_t kNeighborWriterTensorDescriptorFieldCount = 5;
+constexpr uint32_t kNeighborWriterInputTileStartFieldOffset = 2;
+constexpr uint32_t kNeighborWriterInputTileEndFieldOffset = 3;
+constexpr uint32_t kNeighborWriterInputOriginPageFieldOffset = 4;
+
+inline uint32_t input_batch_base_pages(uint32_t batch_idx, uint32_t num_heads, uint32_t Ht, uint32_t Wt) {
+    return batch_idx * num_heads * Ht * Wt;
 }
 
 }  // namespace ring_attention_all_gather_async_detail
@@ -106,5 +124,24 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
     // update_padded_kv_cache. Defaults (1, 0) reduce to slot, so single-layer callers are unaffected.
     uint32_t kv_cache_num_layers = 1,
     uint32_t kv_cache_layer_idx = 0);
+
+void ring_attention_neighbor_halo_exchange_helper(
+    tt::tt_metal::ProgramDescriptor& desc,
+    const std::vector<Tensor>& input_tensors,
+    const MeshCoordinate& target_device_coord,
+    const MeshCoordinate& forward_device_coord,
+    std::vector<Tensor>& output_tensors,
+    uint32_t num_links,
+    uint32_t ring_size,
+    uint32_t ring_index,
+    ttnn::ccl::Topology topology,
+    const std::vector<GlobalSemaphore>& semaphores,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id,
+    const ttnn::experimental::ccl::AllGatherFusedOpSignaler& fused_op_signaler,
+    CoreCoord core_grid_offset,
+    ttnn::ccl::CoreAllocationStrategy core_allocation_strategy,
+    std::optional<uint32_t> input_batch_slice_idx,
+    std::optional<uint32_t> gather_valid_Ht,
+    const RingAttentionNeighborHaloConfig& halo);
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
@@ -13,6 +13,7 @@
 #include "cpp/ttnn/operations/transformer/sdpa/device/kernels/sdpa_streaming_qktv.hpp"
 #include "cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/chunked_prefill_utils.hpp"
 #include "cpp/ttnn/operations/transformer/sdpa/device/kernels/sliding_window_geometry.hpp"
+#include "cpp/ttnn/operations/transformer/sdpa/device/kernels/sliding_window_work_plan.hpp"
 
 #if defined(ARCH_BLACKHOLE) || defined(ARCH_WORMHOLE)
 #include "api/compute/experimental/matmul_custom.h"
@@ -702,12 +703,10 @@ static __attribute__((noinline, noclone)) void normalize_row_streaming(
     uint32_t sbh,
     [[maybe_unused]] uint32_t cur_max_cb_rt = 0,
     [[maybe_unused]] uint32_t sink_row_offset = 0) {
-    // Attention sink: cb_attention_sink holds raw per-head sink logits (column 0, zeros elsewhere).
-    // exp((sink - max)*scale) is computed inline per-row via sub_bcast_cols+exp, then folded into
-    // the col-reduced denominator (DST[0]). sbh tiles consumed per call, popped once at end;
-    // across all normalize calls for the chunk this consumes exactly Sq_chunk_t tiles.
+    // Attention sink: cb_attention_sink holds one raw per-head scalar tile. Broadcast it for each
+    // row, compute exp((sink - max)*scale), and fold it into the col-reduced denominator (DST[0]).
     if constexpr (use_attention_sink) {
-        CircularBuffer(cb_attention_sink).wait_front(sbh);
+        CircularBuffer(cb_attention_sink).wait_front(1);
         CircularBuffer(cur_max_cb_rt).wait_front(sink_row_offset + sbh);
     }
     configure_single_tile_pack(scratch_cb);
@@ -730,13 +729,16 @@ static __attribute__((noinline, noclone)) void normalize_row_streaming(
             matmul_block(cur_sum_cb, col_identity_cb, 0, 0, 0, 0, N, 1, N);
             if constexpr (use_attention_sink) {
                 // DST[1] = exp((sink[s] - max[row_offset+s]) * scale); DST[0] += DST[1].
-                sub_bcast_cols_init_short(cb_attention_sink, cur_max_cb_rt);
-                sub_tiles_bcast_cols(cb_attention_sink, cur_max_cb_rt, s, sink_row_offset + s, 1);
+                // max - sink with a negated scale is equivalent and avoids expanding the sink
+                // scalar to a first-column vector for every Q tile.
+                sub_tiles_bcast_scalar_init_short(cur_max_cb_rt, cb_attention_sink);
+                sub_tiles_bcast_scalar(cur_max_cb_rt, cb_attention_sink, sink_row_offset + s, 0, 1);
                 // The custom first-column exp needs generic unary SFPU addrmod state, but not the
                 // Blackhole approximate exp_init macro/replay setup used by exp_tile<true>.
                 MATH((llk_math_eltwise_unary_sfpu_init<SfpuType::exponential>()));
                 constexpr uint16_t scale_bf16 = scale_fp32 >> 16;
-                MATH((exp_tile_first_column<EXP_APPROX_MODE, scale_bf16>(1)));
+                constexpr uint16_t negated_scale_bf16 = scale_bf16 ^ 0x8000;
+                MATH((exp_tile_first_column<EXP_APPROX_MODE, negated_scale_bf16>(1)));
                 add_binary_tile_init();
                 add_binary_tile(0, 1, 0);
             }
@@ -788,9 +790,6 @@ static __attribute__((noinline, noclone)) void normalize_row_streaming(
             CircularBuffer(scratch_cb).pop_front(1);
             CircularBuffer(cur_out_cb).pop_front(head_dim_t_);
         }
-    }
-    if constexpr (use_attention_sink) {
-        CircularBuffer(cb_attention_sink).pop_front(sbh);
     }
     // Restore pack format to scratch_cb (im_df = Float16_b) so that subsequent ops
     // (e.g. salad_correct_fused on the next K-chunk's drain row) pack to F16b CBs
@@ -1191,7 +1190,8 @@ inline bool sdpa_first_half_unmasked(
     if (no_mask_this_iter) {
         return true;
     }
-    if constexpr (is_causal_sdpa && !kv_pad_rotation_enabled && sliding_window_size == 0 && !use_provided_mask) {
+    constexpr bool has_sliding_window = sliding_window_size > 0;
+    if constexpr (is_causal_sdpa && !kv_pad_rotation_enabled && !has_sliding_window && !use_provided_mask) {
         const bool plain_causal_stamp = apply_causal && !apply_sliding_window && mask_straddle_col == 0 &&
                                         active_Sk == Sk_chunk_t && !(apply_mask && lw_partial_tile_idx > 0);
         const int32_t first_diag_col =
@@ -1273,7 +1273,6 @@ static void sdpa_inner_loop_step(
     constexpr uint32_t q_num_subblocks = Sq_chunk_t / qkt_subblock_h;
     constexpr uint32_t q_subblock_num_tiles = qkt_subblock_h * in0_block_w;
     constexpr uint32_t row_tiles = qkt_subblock_h * KT_stride;  // Use KT_stride for cb_qkt_im row width
-
     static_assert(!(use_padded_mask && ring_mode), "use_padded_mask and ring_mode are mutually exclusive");
 
     uint32_t pushed_rows = 0;
@@ -1862,6 +1861,12 @@ static void sdpa_inner_loop_step(
 
         // All rows pushed individually — no bulk push needed.
 
+        if constexpr (use_attention_sink) {
+            if (is_last_iter) {
+                CircularBuffer(cb_attention_sink).pop_front(1);
+            }
+        }
+
         // For kt_inplace_v this is the deferred K^T pop: cb_v_in aliases cb_kt_in (v_shares_k_buffer),
         // and v_cb_physical_width_t == DHt, so this pops the same Sk_chunk_t*DHt entry that Phase 1
         // skipped. For the materialized path it pops the V entry as usual. Either way: one entry/chunk.
@@ -2257,6 +2262,10 @@ template <
     uint32_t v_cb_physical_width_t = vDHt,
     bool v_shares_k_buffer = false,
     bool kt_inplace_v = false,
+    uint32_t sliding_window_size = 0,
+    uint32_t ring_size = 1,
+    bool use_attention_sink = false,
+    uint32_t cb_attention_sink = INVALID_CB,
     typename MaskCtx = LightweightMaskContext>
 void sdpa_ring_v2(
     const uint32_t global_q_start,
@@ -2284,6 +2293,8 @@ void sdpa_ring_v2(
     init_sdpa_streaming_semaphores();
 
     constexpr uint32_t out_chunk_tiles = Sq_chunk_t * vDHt;
+    constexpr bool has_sliding_window = sliding_window_size > 0;
+    static_assert(!has_sliding_window || chunked_enabled, "Sliding windows require chunked prefill");
     // is_causal: diagonal stamp only on iter 0 (K is local-frame). Chunked: every iter (absolute coords).
     const bool is_causal_iter = (is_causal_sdpa && (ring_iter == 0)) || chunked_enabled;
 
@@ -2335,27 +2346,37 @@ void sdpa_ring_v2(
         return false;
     };
 
+    auto normalize_only = [&]() {
+        AccumulatorHalf q_prev_norm = acc_state.prev;
+        if (q_per_core > 1 && ring_iter > 0) {
+            q_prev_norm = {cb_sum_in, cb_max_in, cb_prev_out};
+        }
+        constexpr uint32_t norm_dst_size = compute_kernel_lib::DEST_AUTO_LIMIT;
+        normalize_row_streaming<
+            false,
+            vDHt,
+            norm_dst_size,
+            cb_col_identity,
+            cb_recip_scratch,
+            cb_normalized_out,
+            scale_fp32,
+            use_attention_sink,
+            cb_attention_sink>(q_prev_norm.sum, q_prev_norm.out, Sq_chunk_t, q_prev_norm.max);
+        if constexpr (use_attention_sink) {
+            CircularBuffer(cb_attention_sink).pop_front(1);
+        }
+        sdpa_cb_pop_front_out_of_line(q_prev_norm.max, Sq_chunk_t);
+        if (q_per_core > 1) {
+            CircularBuffer(cb_signal).reserve_back(1);
+            sdpa_cb_push_back_out_of_line(cb_signal, 1);
+        }
+    };
+
     // Last ring iter: normalize accumulated state and signal writer, then skip K-loop.
     auto try_normalize_only = [&](uint32_t q_chunk) -> bool {
         if constexpr (is_balanced_sdpa) {
             if (skip_first_half_q && q_chunk < num_q_chunks / 2 && is_last_ring_iter) {
-                AccumulatorHalf q_prev_norm = acc_state.prev;
-                if (q_per_core > 1 && ring_iter > 0) {
-                    q_prev_norm = {cb_sum_in, cb_max_in, cb_prev_out};
-                }
-                constexpr uint32_t norm_dst_size = compute_kernel_lib::DEST_AUTO_LIMIT;
-                normalize_row_streaming<
-                    false,
-                    vDHt,
-                    norm_dst_size,
-                    cb_col_identity,
-                    cb_recip_scratch,
-                    cb_normalized_out>(q_prev_norm.sum, q_prev_norm.out, Sq_chunk_t);
-                sdpa_cb_pop_front_out_of_line(q_prev_norm.max, Sq_chunk_t);
-                if (q_per_core > 1) {
-                    CircularBuffer(cb_signal).reserve_back(1);
-                    sdpa_cb_push_back_out_of_line(cb_signal, 1);
-                }
+                normalize_only();
                 return true;
             }
         }
@@ -2365,7 +2386,7 @@ void sdpa_ring_v2(
     // ---- K-loop helpers ---------------------------------------------------
 
     // Skip KV chunks beyond the logical sequence length (padding tiles).
-    auto try_skip_oob_kv = [&](uint32_t k_chunk, bool kv_chunk_is_joint) -> bool {
+    auto try_skip_oob_kv = [&](uint32_t source_ring_id, uint32_t k_chunk, bool kv_chunk_is_joint) -> bool {
         if (kv_chunk_is_joint) {
             return false;
         }
@@ -2374,22 +2395,24 @@ void sdpa_ring_v2(
             chunked_enabled,
             local_padded_Nt,
             chunk_size_t,
-            q_local_padded_Nt>(ring_id, k_chunk * Sk_chunk_t, logical_nt);
+            q_local_padded_Nt>(source_ring_id, k_chunk * Sk_chunk_t, logical_nt);
     };
 
     // Causal skip: K chunks fully above the diagonal — drain K/V from CBs and skip.
     auto try_skip_causal_above_diag = [&](uint32_t k_chunk, uint32_t causal_k_limit) -> bool {
         if constexpr (is_causal_sdpa) {
-            if (is_causal_iter && k_chunk >= causal_k_limit) {
-                CircularBuffer(cb_kt_in).wait_front(DHt * Sk_chunk_t);
-                sdpa_cb_pop_front_out_of_line(cb_kt_in, DHt * Sk_chunk_t);
-                // In-place latent-V never pushes a V entry, so only K^T needs draining.
-                if constexpr (!kt_inplace_v) {
-                    CircularBuffer(cb_v_in).wait_front(Sk_chunk_t * v_cb_physical_width_t);
-                    sdpa_cb_pop_front_out_of_line(cb_v_in, Sk_chunk_t * v_cb_physical_width_t);
+            if constexpr (!has_sliding_window) {
+                if (is_causal_iter && k_chunk >= causal_k_limit) {
+                    CircularBuffer(cb_kt_in).wait_front(DHt * Sk_chunk_t);
+                    sdpa_cb_pop_front_out_of_line(cb_kt_in, DHt * Sk_chunk_t);
+                    // In-place latent-V never pushes a V entry, so only K^T needs draining.
+                    if constexpr (!kt_inplace_v) {
+                        CircularBuffer(cb_v_in).wait_front(Sk_chunk_t * v_cb_physical_width_t);
+                        sdpa_cb_pop_front_out_of_line(cb_v_in, Sk_chunk_t * v_cb_physical_width_t);
+                    }
+                    KV_chunks_processed_in_iter++;
+                    return true;
                 }
-                KV_chunks_processed_in_iter++;
-                return true;
             }
         }
         return false;
@@ -2406,7 +2429,10 @@ void sdpa_ring_v2(
         // Causal K-chunk limit and Q start tile for this Q chunk
         uint32_t causal_k_limit = num_kv_chunks;
         uint32_t q_start_tile = 0;
-        if constexpr (is_causal_sdpa) {
+        if constexpr (has_sliding_window) {
+            q_start_tile = logical_nt - ring_size * q_local_padded_Nt + chunked.ring_index * q_local_padded_Nt +
+                           q_chunk * Sq_chunk_t;
+        } else if constexpr (is_causal_sdpa) {
             if (is_causal_iter) {
                 q_start_tile = q_chunk * Sq_chunk_t;
                 causal_k_limit = (q_start_tile + Sq_chunk_t + Sk_chunk_t - 1) / Sk_chunk_t;
@@ -2423,12 +2449,30 @@ void sdpa_ring_v2(
             continue;
         }
 
+        ttnn::operations::transformer::sdpa::ring_joint::SlidingQWorkPlan sliding_q_plan;
+        if constexpr (has_sliding_window) {
+            sliding_q_plan = ttnn::operations::transformer::sdpa::ring_joint::build_sliding_q_work_plan(
+                q_chunk * Sq_chunk_t,
+                Sq_chunk_t,
+                chunked.ring_index,
+                q_local_padded_Nt,
+                ring_size,
+                sliding_window_size,
+                TILE_HEIGHT,
+                local_padded_Nt,
+                Sk_chunk_t,
+                logical_nt);
+            ASSERT(sliding_q_plan.is_valid);
+            ASSERT(sliding_q_plan.total_k_chunk_count > 0);
+        }
         // Per-Q pre-scan: count K chunks that will actually be processed.
         // Placed after balanced-skip guards so skipped Q chunks don't pay for the scan.
-        uint32_t per_q_valid_kv = 0;
-        for (uint32_t k = 0; k < num_kv_chunks; ++k) {
+        uint32_t per_q_valid_kv = has_sliding_window ? sliding_q_plan.total_k_chunk_count : 0;
+        for (uint32_t k = 0; !has_sliding_window && k < num_kv_chunks; ++k) {
+            const uint32_t source_ring_id = ring_id;
+            const uint32_t source_k_chunk = k;
             const bool is_joint = k >= num_local_k_chunks;
-            if (try_skip_oob_kv(k, is_joint)) {
+            if (try_skip_oob_kv(source_ring_id, source_k_chunk, is_joint)) {
                 continue;
             }
             if constexpr (is_causal_sdpa) {
@@ -2438,7 +2482,6 @@ void sdpa_ring_v2(
             }
             per_q_valid_kv++;
         }
-
         // Use persistent accumulator state from caller (single Q-chunk)
         // or restore from DRAM (multi Q-chunk).
         AccumulatorHalf q_prev = acc_state.prev, q_cur = acc_state.cur;
@@ -2450,21 +2493,28 @@ void sdpa_ring_v2(
         // After K0's swap, reset q_cur to original accumulator CBs for normal ping-pong.
         const AccumulatorHalf original_prev = q_prev;
         const bool restore_from_staging = (q_per_core > 1 && !is_first_active_iter);
+        ASSERT(!has_sliding_window || !restore_from_staging);
         if (restore_from_staging) {
             q_prev = {cb_sum_in, cb_max_in, cb_prev_out};
         }
 
         uint32_t KV_chunks_processed = 0;
 
-        for (uint32_t k_chunk = 0; k_chunk < num_kv_chunks; ++k_chunk) {
-            const bool kv_chunk_is_joint = k_chunk >= num_local_k_chunks;
-            if (try_skip_oob_kv(k_chunk, kv_chunk_is_joint)) {
+        const uint32_t q_k_loop_count = has_sliding_window ? per_q_valid_kv : num_kv_chunks;
+        for (uint32_t k_chunk = 0; k_chunk < q_k_loop_count; ++k_chunk) {
+            const auto sliding_k_chunk = sliding_q_plan.k_chunk_at(k_chunk);
+            const uint32_t source_ring_id = has_sliding_window ? sliding_k_chunk.source_ring_id : ring_id;
+            const uint32_t source_k_chunk = has_sliding_window ? sliding_k_chunk.source_k_chunk : k_chunk;
+            const bool kv_chunk_is_joint = !has_sliding_window && k_chunk >= num_local_k_chunks;
+            if (try_skip_oob_kv(source_ring_id, source_k_chunk, kv_chunk_is_joint)) {
+                // Sliding plans are clipped to logical_n before chunking. Treat a future mismatch
+                // as a device failure rather than leaving the writer waiting for a missing signal.
+                ASSERT(!has_sliding_window);
                 continue;
             }
-            if (try_skip_causal_above_diag(k_chunk, causal_k_limit)) {
+            if (try_skip_causal_above_diag(source_k_chunk, causal_k_limit)) {
                 continue;
             }
-
             KV_chunks_processed++;
             KV_chunks_processed_in_iter++;
 
@@ -2485,10 +2535,10 @@ void sdpa_ring_v2(
             bool is_local_n_mask_chunk = false;
             bool is_joint_n_mask_chunk = false;
             if constexpr (global_n_mask_enabled) {
-                is_global_n_mask_chunk = ring_iter_needs_global_n_mask && k_chunk == global_n_mask_chunk_id;
+                is_global_n_mask_chunk = ring_iter_needs_global_n_mask && source_k_chunk == global_n_mask_chunk_id;
             }
             if constexpr (local_n_mask_enabled) {
-                is_local_n_mask_chunk = local_n_needs_masking && k_chunk == local_n_mask_chunk_id;
+                is_local_n_mask_chunk = local_n_needs_masking && source_k_chunk == local_n_mask_chunk_id;
             }
             if constexpr (joint_n_mask_enabled) {
                 is_joint_n_mask_chunk = ring_iter_needs_joint_n_mask && kv_chunk_is_joint &&
@@ -2500,7 +2550,7 @@ void sdpa_ring_v2(
             bool is_straddle_mask_chunk = false;
             if constexpr (straddle_mask_enabled) {
                 is_straddle_mask_chunk =
-                    lw_mask.straddle_num_padded_tiles > 0 && k_chunk == lw_mask.straddle_mask_chunk_id;
+                    lw_mask.straddle_num_padded_tiles > 0 && source_k_chunk == lw_mask.straddle_mask_chunk_id;
             }
 
             bool apply_mask = kv_pad_rotation_enabled;
@@ -2568,7 +2618,16 @@ void sdpa_ring_v2(
             // diag tile are -inf for every row in the Q-chunk, so skip matmul/sub_exp/V there.
             // Composes with any prior padding narrowing via min().
             if constexpr (is_causal_sdpa && !kv_pad_rotation_enabled) {
-                if (is_causal_iter && k_chunk == causal_k_limit - 1) {
+                if constexpr (has_sliding_window) {
+                    const uint32_t k_global_start =
+                        kv_global_tile_for_local<true, local_padded_Nt, chunk_size_t, q_local_padded_Nt>(
+                            source_ring_id, source_k_chunk * Sk_chunk_t);
+                    const uint32_t q_global_end = q_start_tile + Sq_chunk_t;
+                    if (k_global_start < q_global_end && q_global_end - k_global_start < active_Sk_param) {
+                        active_Sk_param = q_global_end - k_global_start;
+                        chunk_sbw = largest_factor_le(active_Sk_param, qkt_subblock_w);
+                    }
+                } else if (is_causal_iter && k_chunk == causal_k_limit - 1) {
                     const uint32_t causal_active = q_start_tile + Sq_chunk_t - k_chunk * Sk_chunk_t;
                     if (causal_active < active_Sk_param) {
                         active_Sk_param = causal_active;
@@ -2581,6 +2640,7 @@ void sdpa_ring_v2(
             // to writer-staging CBs, eliminating post-loop copy_block calls.
             // Writer drains cb_out row-by-row during SALAD; cb_sum_out and cb_max_out bulk after.
             const bool save_to_staging = is_last_k && !is_last_ring_iter && q_per_core > 1;
+            ASSERT(!has_sliding_window || !save_to_staging);
             const uint32_t step_save_out_cb = save_to_staging ? cb_out : INVALID_CB;
             const uint32_t step_save_max_cb = save_to_staging ? cb_max_out : INVALID_CB;
             if (save_to_staging) {
@@ -2588,10 +2648,24 @@ void sdpa_ring_v2(
             }
 
             // K start tile fed to diag stamp must share Q's coord frame (local for is_causal, global for chunked).
-            const uint32_t step_k_start_tile =
-                chunked_enabled ? kv_global_tile_for_local<true, local_padded_Nt, chunk_size_t, q_local_padded_Nt>(
-                                      ring_id, k_chunk * Sk_chunk_t)
-                                : (k_chunk * Sk_chunk_t);
+            const uint32_t step_k_start_tile = [&]() {
+                if constexpr (has_sliding_window) {
+                    return kv_global_tile_for_local<true, local_padded_Nt, chunk_size_t, q_local_padded_Nt>(
+                        source_ring_id, source_k_chunk * Sk_chunk_t);
+                } else if constexpr (chunked_enabled) {
+                    return kv_global_tile_for_local<true, local_padded_Nt, chunk_size_t, q_local_padded_Nt>(
+                        ring_id, k_chunk * Sk_chunk_t);
+                } else {
+                    return k_chunk * Sk_chunk_t;
+                }
+            }();
+            const bool step_apply_causal = [&]() {
+                if constexpr (has_sliding_window) {
+                    return q_start_tile < step_k_start_tile + Sk_chunk_t &&
+                           q_start_tile + Sq_chunk_t > step_k_start_tile;
+                }
+                return is_causal_iter;
+            }();
 
             // Chunked-prefill straddle. Background: each device's K cache holds the per-chunk
             // K region for every chunk back-to-back, q_local_padded_Nt tiles per region. When
@@ -2611,7 +2685,7 @@ void sdpa_ring_v2(
             uint32_t step_straddle_jump = 0;
             if constexpr (chunked_enabled) {
                 if (q_local_padded_Nt > 0) {
-                    const uint32_t local_start = k_chunk * Sk_chunk_t;
+                    const uint32_t local_start = source_k_chunk * Sk_chunk_t;
                     const uint32_t slab_end_local = (local_start / q_local_padded_Nt + 1) * q_local_padded_Nt;
                     if (local_start + Sk_chunk_t > slab_end_local) {
                         step_straddle_col = slab_end_local - local_start;
@@ -2620,8 +2694,8 @@ void sdpa_ring_v2(
                 }
             }
             KVPadRotationContext step_kv_pad_rotation = chunked.kv_pad_rotation;
-            step_kv_pad_rotation.k_local_start_tile = k_chunk * Sk_chunk_t;
-            step_kv_pad_rotation.ring_id = ring_id;
+            step_kv_pad_rotation.k_local_start_tile = source_k_chunk * Sk_chunk_t;
+            step_kv_pad_rotation.ring_id = source_ring_id;
             step_kv_pad_rotation.logical_tile_count = logical_nt;
 
             sdpa_inner_loop_step<
@@ -2655,7 +2729,11 @@ void sdpa_ring_v2(
                 chunk_size_t,
                 local_padded_Nt,
                 v_cb_physical_width_t,
-                kt_inplace_v>(
+                kt_inplace_v,
+                sliding_window_size,
+                use_attention_sink,
+                cb_attention_sink,
+                false>(  // use_provided_mask
                 q_prev,
                 q_cur,
                 is_last_k_of_last_ring_iter,
@@ -2667,15 +2745,15 @@ void sdpa_ring_v2(
                 chunk_sbw,
                 step_save_out_cb,
                 step_save_max_cb,
-                is_causal_iter,
+                step_apply_causal,
                 kv_pad_rotation_enabled ? q_chunk * Sq_chunk_t : q_start_tile,
                 step_k_start_tile,
                 lw_mask.neginf_tile_idx,
-                lw_mask.causal_diag_tile_idx,
-                0,      // sliding_leading_prev_idx (not used in ring)
-                0,      // sliding_leading_idx (not used in ring)
-                0,      // sliding_trailing_next_idx (not used in ring)
-                false,  // apply_sliding_window
+                has_sliding_window ? 1 : lw_mask.causal_diag_tile_idx,
+                has_sliding_window ? 2 : 0,
+                has_sliding_window ? 3 : 0,
+                has_sliding_window ? 4 : 0,
+                has_sliding_window,
                 step_straddle_col,
                 step_straddle_jump,
                 step_kv_pad_rotation);
@@ -2698,6 +2776,7 @@ void sdpa_ring_v2(
                 }
             }
         }
+        ASSERT(!has_sliding_window || KV_chunks_processed == per_q_valid_kv);
 
         // Pop Q — not popped inside step since ring_mode gates the early Q pop.
         // When q_per_core == 1, Q is identical across ring iterations so we keep it
@@ -2724,16 +2803,20 @@ void sdpa_ring_v2(
         // On last ring_iter: normalized output already in cb_out from normalize_row_streaming
     }
 
-    // Dummy KV pop for CB write-pointer phase alignment across chained reader cores.
-    for (uint32_t dummy_chunk = 0; dummy_chunk < dummy_kv_chunks_for_phase_alignment<v_shares_k_buffer, kt_inplace_v>(
-                                                     KV_chunks_processed_in_iter);
-         ++dummy_chunk) {
-        CircularBuffer(cb_kt_in).wait_front(DHt * Sk_chunk_t);
-        sdpa_cb_pop_front_out_of_line(cb_kt_in, DHt * Sk_chunk_t);
-        // In-place latent-V never pushes a V entry, so there is nothing extra to drain.
-        if constexpr (!kt_inplace_v) {
-            CircularBuffer(cb_v_in).wait_front(Sk_chunk_t * v_cb_physical_width_t);
-            sdpa_cb_pop_front_out_of_line(cb_v_in, Sk_chunk_t * v_cb_physical_width_t);
+    // Dummy KV traffic exists only to align chained readers. Sliding mode uses independent
+    // per-core reads so each core can prune a different K range and needs no phase padding.
+    if constexpr (!has_sliding_window) {
+        for (uint32_t dummy_chunk = 0;
+             dummy_chunk <
+             dummy_kv_chunks_for_phase_alignment<v_shares_k_buffer, kt_inplace_v>(KV_chunks_processed_in_iter);
+             ++dummy_chunk) {
+            CircularBuffer(cb_kt_in).wait_front(DHt * Sk_chunk_t);
+            sdpa_cb_pop_front_out_of_line(cb_kt_in, DHt * Sk_chunk_t);
+            // In-place latent-V never pushes a V entry, so there is nothing extra to drain.
+            if constexpr (!kt_inplace_v) {
+                CircularBuffer(cb_v_in).wait_front(Sk_chunk_t * v_cb_physical_width_t);
+                sdpa_cb_pop_front_out_of_line(cb_v_in, Sk_chunk_t * v_cb_physical_width_t);
+            }
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/ring_joint_sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/ring_joint_sdpa.cpp
@@ -117,12 +117,12 @@ void kernel_main() {
     const uint32_t ring_index_runtime = get_arg_val<uint32_t>(argidx++);
     const uint32_t forward_writes_expected = get_arg_val<uint32_t>(argidx++);
     const uint32_t backward_writes_expected = get_arg_val<uint32_t>(argidx++);
-    const uint32_t logical_nt = get_arg_val<uint32_t>(argidx++);
-    const uint32_t kv_pad_q_pre_wrap_start_tile = get_arg_val<uint32_t>(argidx++);
-    const uint32_t kv_pad_q_pre_wrap_tile_count = get_arg_val<uint32_t>(argidx++);
-    const uint32_t kv_pad_q_post_wrap_start_tile = get_arg_val<uint32_t>(argidx++);
-    const uint32_t kv_pad_q_valid_tile_count = get_arg_val<uint32_t>(argidx++);
-    const uint32_t active_ring_iter_mask = get_arg_val<uint32_t>(argidx++);
+    uint32_t logical_nt = get_arg_val<uint32_t>(argidx++);
+    uint32_t kv_pad_q_pre_wrap_start_tile = get_arg_val<uint32_t>(argidx++);
+    uint32_t kv_pad_q_pre_wrap_tile_count = get_arg_val<uint32_t>(argidx++);
+    uint32_t kv_pad_q_post_wrap_start_tile = get_arg_val<uint32_t>(argidx++);
+    uint32_t kv_pad_q_valid_tile_count = get_arg_val<uint32_t>(argidx++);
+    uint32_t active_ring_iter_mask = get_arg_val<uint32_t>(argidx++);
 
     RingSDPAOpIndexer fused_op_indexer(
         ring_size_runtime, ring_index_runtime, forward_writes_expected, backward_writes_expected);
@@ -133,7 +133,8 @@ void kernel_main() {
     constexpr uint32_t qk_chunk_tiles = Sq_chunk_t * Sk_chunk_t;
     constexpr uint32_t out_chunk_tiles = Sq_chunk_t * vDHt;
 
-    constexpr uint32_t cb_arg_offset = 51;
+    constexpr bool kv_pad_from_metadata = get_compile_time_arg_val(51) == 1;
+    constexpr uint32_t cb_arg_offset = 52;
     constexpr uint32_t cb_q_in = get_compile_time_arg_val(cb_arg_offset + 0);
     constexpr uint32_t cb_k_in = get_compile_time_arg_val(cb_arg_offset + 1);
     constexpr uint32_t cb_v_in = get_compile_time_arg_val(cb_arg_offset + 2);
@@ -160,7 +161,20 @@ void kernel_main() {
     constexpr uint32_t cb_sum_A = get_compile_time_arg_val(cb_arg_offset + 20);
     constexpr uint32_t cb_sum_B = get_compile_time_arg_val(cb_arg_offset + 21);
     constexpr uint32_t cb_exp_max_diff = get_compile_time_arg_val(cb_arg_offset + 22);
-    constexpr uint32_t cb_attention_sink = get_compile_time_arg_val(cb_arg_offset + 23);
+    constexpr uint32_t cb_kv_pad_derived = get_compile_time_arg_val(cb_arg_offset + 23);
+    constexpr uint32_t cb_attention_sink = get_compile_time_arg_val(cb_arg_offset + 24);
+
+    if constexpr (kv_pad_from_metadata) {
+        CircularBuffer cb_derived(cb_kv_pad_derived);
+        cb_derived.wait_front(1);
+        logical_nt = ckernel::read_tile_value(cb_kv_pad_derived, 0, 0);
+        kv_pad_q_pre_wrap_start_tile = ckernel::read_tile_value(cb_kv_pad_derived, 0, 1);
+        kv_pad_q_pre_wrap_tile_count = ckernel::read_tile_value(cb_kv_pad_derived, 0, 2);
+        kv_pad_q_post_wrap_start_tile = ckernel::read_tile_value(cb_kv_pad_derived, 0, 3);
+        kv_pad_q_valid_tile_count = ckernel::read_tile_value(cb_kv_pad_derived, 0, 4);
+        active_ring_iter_mask = ckernel::read_tile_value(cb_kv_pad_derived, 0, 5);
+        cb_derived.pop_front(1);
+    }
 
     compute_kernel_hw_startup<SrcOrder::Reverse>(cb_q_in, cb_k_in, cb_qk_im);
     matmul_init(cb_q_in, cb_k_in);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/ring_joint_sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/ring_joint_sdpa.cpp
@@ -9,7 +9,6 @@
 
 #include "api/compute/compute_kernel_api.h"
 #include "api/compute/compute_kernel_hw_startup.h"
-#include "api/compute/cb_api.h"  // ckernel::read_tile_value (UNPACK-mailbox CB scalar read; no cb_interface)
 #include <tt-metalium/constants.hpp>
 #include "compute_common.hpp"
 #include "compute_streaming.hpp"
@@ -76,6 +75,9 @@ void kernel_main() {
     constexpr uint32_t active_ring_iter_mask_compile [[maybe_unused]] = get_compile_time_arg_val(46);
     constexpr uint32_t last_active_ring_iter_compile [[maybe_unused]] = get_compile_time_arg_val(47);
     constexpr bool v_shares_k_buffer = get_compile_time_arg_val(48) == 1;
+    constexpr bool use_attention_sink = get_compile_time_arg_val(49) == 1;
+    constexpr uint32_t sliding_window_size = get_compile_time_arg_val(50);
+    constexpr bool has_sliding_window = sliding_window_size > 0;
     constexpr uint32_t v_cb_physical_width_t = v_shares_k_buffer ? DHt : vDHt;
     // In-place latent-V (single-tile Q): read V straight from K^T instead of materializing it.
     // Shared with the program factory and reader via kt_inplace_v_enabled().
@@ -83,7 +85,7 @@ void kernel_main() {
     // Diagonal-mask tile slot is shared by the kernel's is_causal path and the chunked-prefill
     // path. kernel_is_causal is masked off by the program factory when chunked is on, so only
     // one of the two paths drives the stamp per program — but they share the CB slot layout.
-    constexpr bool diag_tile_enabled = is_causal || chunked_enabled;
+    constexpr bool diag_tile_enabled = (is_causal || chunked_enabled) && !has_sliding_window;
 
     // Lightweight mask: all mask tiles live in cb_mask_in.
     // Layout: [neginf(0)] [causal_diag?(1)] [global_n_partial?] [joint_l_partial?]
@@ -91,16 +93,17 @@ void kernel_main() {
     constexpr bool global_n_has_padding = logical_n_compile % (Sk_chunk_t * tt::constants::TILE_HEIGHT) != 0;
     constexpr bool joint_has_padding = L > 0 && L % (Sk_chunk_t * tt::constants::TILE_HEIGHT) != 0;
     constexpr bool needs_lightweight_mask =
-        (local_n_has_padding || global_n_has_padding || joint_has_padding) || diag_tile_enabled;
+        (local_n_has_padding || global_n_has_padding || joint_has_padding) || diag_tile_enabled || has_sliding_window;
 
     constexpr uint32_t neginf_tile_idx = 0;
     constexpr uint32_t causal_diag_tile_idx = diag_tile_enabled ? 1 : 0;
-    constexpr uint32_t base_partial_offset = 1 + (diag_tile_enabled ? 1 : 0);
+    constexpr uint32_t edge_mask_tiles = has_sliding_window ? kSlidingWindowEdgeTiles : (diag_tile_enabled ? 1 : 0);
+    constexpr uint32_t base_partial_offset = 1 + edge_mask_tiles;
     constexpr uint32_t global_n_partial_tile_idx = (global_n_partial_col > 0) ? base_partial_offset : 0;
     constexpr uint32_t joint_l_partial_tile_idx =
         (joint_l_partial_col > 0) ? (base_partial_offset + (global_n_partial_col > 0 ? 1 : 0)) : 0;
     constexpr uint32_t total_mask_tiles =
-        1 + (diag_tile_enabled ? 1 : 0) + (global_n_partial_col > 0 ? 1 : 0) + (joint_l_partial_col > 0 ? 1 : 0);
+        1 + edge_mask_tiles + (global_n_partial_col > 0 ? 1 : 0) + (joint_l_partial_col > 0 ? 1 : 0);
 
     constexpr uint32_t q_start_idx_t =
         chunked_enabled && !kv_pad_rotation_enabled ? logical_nt_compile - q_local_padded_Nt * ring_size : 0;
@@ -114,14 +117,12 @@ void kernel_main() {
     const uint32_t ring_index_runtime = get_arg_val<uint32_t>(argidx++);
     const uint32_t forward_writes_expected = get_arg_val<uint32_t>(argidx++);
     const uint32_t backward_writes_expected = get_arg_val<uint32_t>(argidx++);
-    // Mutable: on the kv_pad_from_metadata path these are overridden below from cb_kv_pad_derived
-    // (produced by the reader from metadata[1]), since compute cannot NoC-read the metadata DRAM tensor.
-    uint32_t logical_nt = get_arg_val<uint32_t>(argidx++);
-    uint32_t kv_pad_q_pre_wrap_start_tile = get_arg_val<uint32_t>(argidx++);
-    uint32_t kv_pad_q_pre_wrap_tile_count = get_arg_val<uint32_t>(argidx++);
-    uint32_t kv_pad_q_post_wrap_start_tile = get_arg_val<uint32_t>(argidx++);
-    uint32_t kv_pad_q_valid_tile_count = get_arg_val<uint32_t>(argidx++);
-    uint32_t active_ring_iter_mask = get_arg_val<uint32_t>(argidx++);
+    const uint32_t logical_nt = get_arg_val<uint32_t>(argidx++);
+    const uint32_t kv_pad_q_pre_wrap_start_tile = get_arg_val<uint32_t>(argidx++);
+    const uint32_t kv_pad_q_pre_wrap_tile_count = get_arg_val<uint32_t>(argidx++);
+    const uint32_t kv_pad_q_post_wrap_start_tile = get_arg_val<uint32_t>(argidx++);
+    const uint32_t kv_pad_q_valid_tile_count = get_arg_val<uint32_t>(argidx++);
+    const uint32_t active_ring_iter_mask = get_arg_val<uint32_t>(argidx++);
 
     RingSDPAOpIndexer fused_op_indexer(
         ring_size_runtime, ring_index_runtime, forward_writes_expected, backward_writes_expected);
@@ -132,9 +133,7 @@ void kernel_main() {
     constexpr uint32_t qk_chunk_tiles = Sq_chunk_t * Sk_chunk_t;
     constexpr uint32_t out_chunk_tiles = Sq_chunk_t * vDHt;
 
-    // Compute fixed slot 49: trace-safe KV-pad derivation flag (cb_arg_offset bumped 49 -> 50).
-    constexpr bool kv_pad_from_metadata = get_compile_time_arg_val(49) == 1;
-    constexpr uint32_t cb_arg_offset = 50;
+    constexpr uint32_t cb_arg_offset = 51;
     constexpr uint32_t cb_q_in = get_compile_time_arg_val(cb_arg_offset + 0);
     constexpr uint32_t cb_k_in = get_compile_time_arg_val(cb_arg_offset + 1);
     constexpr uint32_t cb_v_in = get_compile_time_arg_val(cb_arg_offset + 2);
@@ -161,26 +160,7 @@ void kernel_main() {
     constexpr uint32_t cb_sum_A = get_compile_time_arg_val(cb_arg_offset + 20);
     constexpr uint32_t cb_sum_B = get_compile_time_arg_val(cb_arg_offset + 21);
     constexpr uint32_t cb_exp_max_diff = get_compile_time_arg_val(cb_arg_offset + 22);
-    constexpr uint32_t cb_kv_pad_derived = get_compile_time_arg_val(cb_arg_offset + 23);
-
-    // Trace-safe KV-pad derivation: the reader computed logical_nt / q-mapping / active_ring_iter_mask
-    // from metadata[1] and handed them over via cb_kv_pad_derived (compute can't NoC-read DRAM). Override
-    // the (trace-frozen) runtime args with the reader's values before the ring loop uses them.
-    if constexpr (kv_pad_from_metadata) {
-        // Read the reader-produced scalars via ckernel::read_tile_value (UNPACK-mailbox CB read) -- the
-        // TRISC-safe way to pull a scalar out of a CB, mirroring sparse_sdpa_compute's cb_ctrl. The
-        // CircularBuffer::get_read_ptr() path references the cb_interface global which does not link on
-        // this compute kernel. wait_front/pop_front are LLK intrinsics and link fine.
-        CircularBuffer cb_derived(cb_kv_pad_derived);
-        cb_derived.wait_front(1);
-        logical_nt = ckernel::read_tile_value(cb_kv_pad_derived, /*tile=*/0, /*element_offset=*/0);
-        kv_pad_q_pre_wrap_start_tile = ckernel::read_tile_value(cb_kv_pad_derived, 0, 1);
-        kv_pad_q_pre_wrap_tile_count = ckernel::read_tile_value(cb_kv_pad_derived, 0, 2);
-        kv_pad_q_post_wrap_start_tile = ckernel::read_tile_value(cb_kv_pad_derived, 0, 3);
-        kv_pad_q_valid_tile_count = ckernel::read_tile_value(cb_kv_pad_derived, 0, 4);
-        active_ring_iter_mask = ckernel::read_tile_value(cb_kv_pad_derived, 0, 5);
-        cb_derived.pop_front(1);
-    }
+    constexpr uint32_t cb_attention_sink = get_compile_time_arg_val(cb_arg_offset + 23);
 
     compute_kernel_hw_startup<SrcOrder::Reverse>(cb_q_in, cb_k_in, cb_qk_im);
     matmul_init(cb_q_in, cb_k_in);
@@ -224,11 +204,14 @@ void kernel_main() {
             kv_pad_q_valid_tile_count}};
     // The first active iter starts with fresh accumulators; restoring would read stale staging.
     bool seen_active_iter = false;
-    for (uint32_t ring_iter = 0; ring_iter < ring_size; ++ring_iter) {
-        uint32_t ring_id = fused_op_indexer.get_next_ring_id_and_sync();
+    constexpr uint32_t sdpa_ring_iterations = has_sliding_window ? 1 : ring_size;
+    for (uint32_t ring_iter = 0; ring_iter < sdpa_ring_iterations; ++ring_iter) {
+        // Sliding folds all local/halo source ranges into one synthetic local iteration.
+        // The dataflow reader has already waited for the required halo completion signals.
+        uint32_t ring_id = has_sliding_window ? ring_index : fused_op_indexer.get_next_ring_id_and_sync();
         // Host precomputes which ring iterations have useful SDPA work; sync/ring-id sequencing
         // still advances above so compute stays aligned with reader, writer, and all-gather.
-        if (((active_ring_iter_mask >> ring_iter) & 1u) == 0) {
+        if (!has_sliding_window && ((active_ring_iter_mask >> ring_iter) & 1u) == 0) {
             continue;
         }
         const bool do_joint_kv = ring_id == ring_size - 1;
@@ -282,7 +265,7 @@ void kernel_main() {
             lw_mask.global_n_padded_tiles = Sk_chunk_t - valid_tiles;
         }
 
-        const bool is_last_ring_iter = is_last_active_ring_iter(active_ring_iter_mask, ring_iter);
+        const bool is_last_ring_iter = has_sliding_window || is_last_active_ring_iter(active_ring_iter_mask, ring_iter);
 
         // Per-ring-iter K-chunk count and Q-skip flag — shared by v1 (sdpa_ring) and v2
         // (sdpa_ring_v2) paths.
@@ -291,14 +274,16 @@ void kernel_main() {
         //     late-half columns are -inf-masked via lw_mask.straddle_*).
         //   rix < rid && balanced (Case 2): skip first-half (L) Q-chunks.
         uint32_t iter_num_kv_chunks = num_kv_chunks;
-        if (is_causal && is_balanced && ring_index > ring_id) {
-            if constexpr (has_straddle) {
-                iter_num_kv_chunks = straddle_chunk_id + 1;
-            } else {
-                iter_num_kv_chunks /= 2;
+        if constexpr (!has_sliding_window) {
+            if (is_causal && is_balanced && ring_index > ring_id) {
+                if constexpr (has_straddle) {
+                    iter_num_kv_chunks = straddle_chunk_id + 1;
+                } else {
+                    iter_num_kv_chunks /= 2;
+                }
             }
         }
-        const bool skip_first_half_q = (ring_index >= ring_id ? false : is_balanced);
+        const bool skip_first_half_q = !has_sliding_window && (ring_index >= ring_id ? false : is_balanced);
 
         if constexpr (use_streaming_compute) {
             sdpa_ring_v2<
@@ -344,7 +329,11 @@ void kernel_main() {
                 kv_pad_rotation_enabled,
                 v_cb_physical_width_t,
                 v_shares_k_buffer,
-                kt_inplace_v>(
+                kt_inplace_v,
+                sliding_window_size,
+                ring_size,
+                use_attention_sink,
+                cb_attention_sink>(
                 global_q_start,
                 global_q_end,
                 iter_num_kv_chunks,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/chain_link.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/chain_link.hpp
@@ -19,12 +19,11 @@
 struct ChainConfig {
     static constexpr uint32_t kRuntimeArgCount =
         ttnn::operations::transformer::sdpa::ring_joint::kChainConfigRuntimeArgCount;
-    static_assert(kRuntimeArgCount == 18, "ChainConfig::read_from_args must match the shared runtime arg layout");
+    static_assert(kRuntimeArgCount == 16, "ChainConfig::read_from_args must match the shared runtime arg layout");
 
     bool participates = false;
     bool is_injector = false;
     bool is_sink = false;
-    uint32_t batch = 0;
     uint32_t head = 0;
     uint32_t prev_physical_x = 0;
     uint32_t prev_physical_y = 0;
@@ -38,7 +37,6 @@ struct ChainConfig {
     uint32_t injector_physical_x = 0;
     uint32_t injector_physical_y = 0;
     uint32_t mcast_num_dests = 0;
-    uint32_t mcast_sender_wait = 0;
 
     // Read kRuntimeArgCount args in canonical order matching append_to_args().
     static ChainConfig read_from_args(uint32_t& argidx) {
@@ -46,7 +44,6 @@ struct ChainConfig {
         cfg.participates = static_cast<bool>(get_arg_val<uint32_t>(argidx++));
         cfg.is_injector = static_cast<bool>(get_arg_val<uint32_t>(argidx++));
         cfg.is_sink = static_cast<bool>(get_arg_val<uint32_t>(argidx++));
-        cfg.batch = get_arg_val<uint32_t>(argidx++);
         cfg.head = get_arg_val<uint32_t>(argidx++);
         cfg.prev_physical_x = get_arg_val<uint32_t>(argidx++);
         cfg.prev_physical_y = get_arg_val<uint32_t>(argidx++);
@@ -60,7 +57,6 @@ struct ChainConfig {
         cfg.injector_physical_x = get_arg_val<uint32_t>(argidx++);
         cfg.injector_physical_y = get_arg_val<uint32_t>(argidx++);
         cfg.mcast_num_dests = get_arg_val<uint32_t>(argidx++);
-        cfg.mcast_sender_wait = get_arg_val<uint32_t>(argidx++);
         return cfg;
     }
 
@@ -83,7 +79,7 @@ struct ChainConfig {
  *
  * Template parameters:
  * - mcast_enabled: selects multicast vs unicast forwarding at compile time
- * - is_head_level: true = head chain (matches batch AND head), false = batch chain (matches batch only)
+ * - is_head_level: true = head chain (matches head), false = shared-K chain
  *
  * Constructor stores semaphore IDs and target coords.
  *
@@ -99,7 +95,6 @@ public:
     const bool is_sink;
 
     // Chain scope matching
-    const uint32_t chain_batch;
     const uint32_t chain_head;  // Only checked when is_head_level
     const uint32_t next_core_q_chunks;
 
@@ -119,16 +114,13 @@ public:
         uint32_t mcast_end_x,
         uint32_t mcast_end_y,
         uint32_t mcast_num_dests,
-        uint32_t mcast_sender_wait,
         uint32_t chunk_tiles,
         uint32_t tile_bytes,
-        uint32_t chain_batch,
         uint32_t chain_head,
         uint32_t next_core_q_chunks) :
         is_participant(is_participant),
         is_injector(is_injector),
         is_sink(is_sink),
-        chain_batch(chain_batch),
         chain_head(chain_head),
         next_core_q_chunks(next_core_q_chunks),
         sender_sem_id_(sender_sem_id),
@@ -142,7 +134,7 @@ public:
         mcast_start_y_(mcast_start_y),
         mcast_end_x_(mcast_end_x),
         mcast_end_y_(mcast_end_y),
-        sender_wait_count_((mcast_enabled && is_injector) ? mcast_sender_wait : 1),
+        sender_wait_count_((mcast_enabled && is_injector) ? mcast_num_dests : 1),
         mcast_num_dests_(mcast_num_dests),
         chunk_tiles_(chunk_tiles),
         tile_bytes_(tile_bytes) {
@@ -154,18 +146,11 @@ public:
 
     /**
      * Check if this core should receive data from upstream.
-     * Head-level chains match (batch, head), batch-level chains match batch only.
-     * In mcast mode, skip batch check: mcast is only enabled for B=1, and padded
-     * iterations may have garbage nb values from out-of-bounds global_q_chunk.
+     * Head-level chains match the head; shared-K chains apply to every iteration.
      */
-    bool should_receive(uint32_t nb, uint32_t nq) const {
+    bool should_receive(uint32_t nq) const {
         if (!is_participant || is_injector) {
             return false;
-        }
-        if constexpr (!mcast_enabled) {
-            if (nb != chain_batch) {
-                return false;
-            }
         }
         if constexpr (is_head_level) {
             if (nq != chain_head) {
@@ -178,16 +163,10 @@ public:
     /**
      * Check if this core should forward data to downstream.
      * Also checks iteration count against next core's expected reads.
-     * In mcast mode, skip batch check (see should_receive comment).
      */
-    bool should_forward(uint32_t nb, uint32_t nq, uint32_t q_iter_local) const {
+    bool should_forward(uint32_t nq, uint32_t q_iter_local) const {
         if (!is_participant || is_sink) {
             return false;
-        }
-        if constexpr (!mcast_enabled) {
-            if (nb != chain_batch) {
-                return false;
-            }
         }
         if constexpr (is_head_level) {
             if (nq != chain_head) {
@@ -262,8 +241,7 @@ public:
                 {.offset_bytes = 0},
                 {.noc_x = next_core_x_, .noc_y = next_core_y_, .addr = cb_addr});
             noc.async_writes_flushed();
-            Semaphore<>(valid_sem_id_)
-                .relay_unicast(noc, Semaphore<>(receiver_sem_id_), next_core_x_, next_core_y_);
+            Semaphore<>(valid_sem_id_).relay_unicast(noc, Semaphore<>(receiver_sem_id_), next_core_x_, next_core_y_);
         }
     }
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/fused_op_receiver.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/fused_op_receiver.hpp
@@ -43,4 +43,14 @@ struct RingSDPAOpReceiver {
             }
         });
     }
+
+    uint32_t get_next_ring_id_and_consume_one_signal() {
+        ASSERT(initialized);
+        return seq.get_next_ring_id([&](uint32_t dir, uint32_t val) {
+            if (this->wait_for_op_signal && val > 0) {
+                ASSERT(val == 1);
+                Semaphore<>(this->signal_op_semaphore_ids[dir]).down(1);
+            }
+        });
+    }
 };

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/reader_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/reader_interleaved.cpp
@@ -318,7 +318,8 @@ void kernel_main() {
                 prev_nq = decoded.nq;
             }
             if constexpr (use_attention_sink) {
-                cb_attn_sink.reserve_back(Sq_chunk_t);
+                constexpr uint32_t sink_tiles = use_streaming_compute ? 1 : Sq_chunk_t;
+                cb_attn_sink.reserve_back(sink_tiles);
                 uint32_t attention_sink_write_ptr = cb_attn_sink.get_write_ptr();
                 const uint32_t sink_tile_id = attention_sink_tile_shape.id_of(0, decoded.nq, 0, 0);
                 noc.async_read(
@@ -328,9 +329,11 @@ void kernel_main() {
                     {.page_id = sink_tile_id},
                     {});
                 noc.async_read_barrier();
-                fill_attention_sink_tiles<attention_sink_tile_bytes>(
-                    cb_attention_sink, Sq_chunk_t, attention_sink_write_ptr);
-                cb_attn_sink.push_back(Sq_chunk_t);
+                if constexpr (!use_streaming_compute) {
+                    fill_attention_sink_tiles<attention_sink_tile_bytes>(
+                        cb_attention_sink, sink_tiles, attention_sink_write_ptr);
+                }
+                cb_attn_sink.push_back(sink_tiles);
             }
 
             const uint32_t nb = decoded.nb;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_reader.cpp
@@ -10,6 +10,8 @@
 #include "api/core_local_mem.h"
 #include "dataflow_common.hpp"
 #include "chunked_prefill_utils.hpp"
+#include "ring_joint_kv_pad_derivation.hpp"
+#include "metadata_scalar_read.hpp"
 #include "chain_link.hpp"
 #include "fused_op_receiver.hpp"
 #include "ring_utils.hpp"
@@ -206,6 +208,10 @@ void kernel_main() {
     constexpr bool has_sliding_window = sliding_window_size > 0;
     constexpr bool enable_kv_chains = !has_sliding_window;
     constexpr uint32_t gathered_padded_Nt = get_compile_time_arg_val(34);
+    // Slots 35/36 are trace-safe metadata controls. Attention-sink and sliding-window
+    // fields occupy 32..34 in this branch.
+    constexpr bool slot_from_metadata = get_compile_time_arg_val(35) == 1;
+    constexpr bool kv_pad_from_metadata = get_compile_time_arg_val(36) == 1;
     constexpr bool gqa_grouped_kv = ring_joint::is_gqa_grouped_kv_head_mode(v_shares_k_buffer, NH, NHK, NHV);
     constexpr bool k_uses_batch_chain = ring_joint::uses_shared_k_batch_chain(gqa_grouped_kv, NHK);
     constexpr bool use_head_chain = enable_kv_chains && !gqa_grouped_kv;
@@ -220,7 +226,7 @@ void kernel_main() {
     constexpr bool has_joint_k = num_joint_k_chunks > 0;
     constexpr bool has_joint_inputs = has_joint_q || has_joint_k;
 
-    constexpr auto q_args = TensorAccessorArgs<35>();
+    constexpr auto q_args = TensorAccessorArgs<37>();
     constexpr auto k_args = TensorAccessorArgs<q_args.next_compile_time_args_offset()>();
     constexpr auto v_args = TensorAccessorArgs<k_args.next_compile_time_args_offset()>();
     constexpr auto gathered_k_args = TensorAccessorArgs<v_args.next_compile_time_args_offset()>();
@@ -230,6 +236,15 @@ void kernel_main() {
         get_post_tensor_args_offset<has_joint_inputs, joint_tensor_args_offset>();
     constexpr auto attention_sink_args = TensorAccessorArgs<post_joint_tensor_args_offset>();
     constexpr uint32_t post_tensor_args_offset = attention_sink_args.next_compile_time_args_offset();
+    constexpr uint32_t meta_args_offset = slot_from_metadata ? post_tensor_args_offset : 37;
+    constexpr auto meta_args = TensorAccessorArgs<meta_args_offset>();
+    constexpr uint32_t kv_meta_args_offset =
+        kv_pad_from_metadata ? meta_args.next_compile_time_args_offset() : meta_args_offset;
+    constexpr auto kv_meta_args = TensorAccessorArgs<kv_meta_args_offset>();
+    constexpr uint32_t chains_base_no_kv_pad =
+        slot_from_metadata ? meta_args.next_compile_time_args_offset() : post_tensor_args_offset;
+    constexpr uint32_t chains_base_offset =
+        kv_pad_from_metadata ? kv_meta_args.next_compile_time_args_offset() : chains_base_no_kv_pad;
 
     uint32_t argidx = 0;
     const uint32_t q_addr = get_arg_val<uint32_t>(argidx++);
@@ -248,7 +263,7 @@ void kernel_main() {
     const uint32_t attention_sink_addr = get_arg_val<uint32_t>(argidx++);
     const uint32_t global_q_start = get_arg_val<uint32_t>(argidx++);
     const uint32_t global_q_end = get_arg_val<uint32_t>(argidx++);
-    const uint32_t kv_cache_batch_idx = get_arg_val<uint32_t>(argidx++);
+    uint32_t kv_cache_batch_idx = get_arg_val<uint32_t>(argidx++);
     const uint32_t q_per_core = global_q_end - global_q_start;
 
     ChainConfig head_cfg;
@@ -270,8 +285,8 @@ void kernel_main() {
         gqa_max_q_per_core = get_arg_val<uint32_t>(argidx++);
     }
 
-    const uint32_t logical_nt = get_arg_val<uint32_t>(argidx++);
-    const uint32_t active_ring_iter_mask = get_arg_val<uint32_t>(argidx++);
+    uint32_t logical_nt = get_arg_val<uint32_t>(argidx++);
+    uint32_t active_ring_iter_mask = get_arg_val<uint32_t>(argidx++);
     RingSDPAOpReceiver fused_op_receiver = RingSDPAOpReceiver(
         true, /* wait_for_op_signal */
         argidx);
@@ -289,21 +304,19 @@ void kernel_main() {
     uint32_t head_valid_semaphore_id = 0;
     constexpr bool head_mcast_enabled = []() {
         if constexpr (use_head_chain) {
-            return get_compile_time_arg_val(post_tensor_args_offset + chain_mcast_enabled_arg_offset) == 1;
+            return get_compile_time_arg_val(chains_base_offset + chain_mcast_enabled_arg_offset) == 1;
         }
         return false;
     }();
     if constexpr (use_head_chain) {
-        head_sender_semaphore_id =
-            get_compile_time_arg_val(post_tensor_args_offset + chain_sender_semaphore_arg_offset);
-        head_receiver_semaphore_id =
-            get_compile_time_arg_val(post_tensor_args_offset + chain_receiver_semaphore_arg_offset);
-        head_valid_semaphore_id = get_compile_time_arg_val(post_tensor_args_offset + chain_valid_semaphore_arg_offset);
+        head_sender_semaphore_id = get_compile_time_arg_val(chains_base_offset + chain_sender_semaphore_arg_offset);
+        head_receiver_semaphore_id = get_compile_time_arg_val(chains_base_offset + chain_receiver_semaphore_arg_offset);
+        head_valid_semaphore_id = get_compile_time_arg_val(chains_base_offset + chain_valid_semaphore_arg_offset);
     }
     constexpr uint32_t head_chain_arg_count = use_head_chain ? chain_compile_arg_count : 0;
     constexpr uint32_t batch_chain_arg_count = enable_kv_chains && k_uses_batch_chain ? chain_compile_arg_count : 0;
     constexpr uint32_t gqa_chain_arg_count = enable_kv_chains && gqa_grouped_kv ? chain_compile_arg_count : 0;
-    constexpr uint32_t batch_chain_ct_offset = post_tensor_args_offset + head_chain_arg_count;
+    constexpr uint32_t batch_chain_ct_offset = chains_base_offset + head_chain_arg_count;
     constexpr uint32_t gqa_chain_ct_offset = batch_chain_ct_offset + batch_chain_arg_count;
 
     // Batch chain semaphores (only present for non-GQA shared-K modes).
@@ -343,11 +356,60 @@ void kernel_main() {
     }
 
     constexpr uint32_t cb_arg_offset =
-        post_tensor_args_offset + head_chain_arg_count + batch_chain_arg_count + gqa_chain_arg_count;
+        chains_base_offset + head_chain_arg_count + batch_chain_arg_count + gqa_chain_arg_count;
     constexpr uint32_t cb_q_in = get_compile_time_arg_val(cb_arg_offset + 0);
     constexpr uint32_t cb_k_in = get_compile_time_arg_val(cb_arg_offset + 1);
     constexpr uint32_t cb_v_in = get_compile_time_arg_val(cb_arg_offset + 2);
     constexpr uint32_t cb_attention_sink = get_compile_time_arg_val(cb_arg_offset + 3);
+    constexpr uint32_t cb_kv_pad_derived = get_compile_time_arg_val(cb_arg_offset + 4);
+
+    if constexpr (slot_from_metadata || kv_pad_from_metadata) {
+        Noc meta_noc;
+        CircularBuffer cb_q_scratch(cb_q_in);
+        const uint32_t meta_l1 = cb_q_scratch.get_write_ptr();
+        if constexpr (slot_from_metadata) {
+            const uint32_t slot_id =
+                trace_metadata::read_metadata_scalar_u32(meta_noc, meta_args, get_common_arg_val<uint32_t>(0), meta_l1);
+            kv_cache_batch_idx = slot_id * get_common_arg_val<uint32_t>(1) + get_common_arg_val<uint32_t>(2);
+        }
+        if constexpr (kv_pad_from_metadata) {
+            const uint32_t kv_actual_isl = trace_metadata::read_metadata_scalar_u32(
+                meta_noc, kv_meta_args, get_common_arg_val<uint32_t>(3), meta_l1);
+            const uint32_t kv_actual_tile_count = kv_actual_isl / 32;
+            logical_nt = ring_joint::compute_logical_nt(kv_actual_isl, chunk_size_t * 32, 32);
+            const auto qmap = ring_joint::build_kv_pad_q_mapping_device(
+                kv_actual_tile_count, logical_nt, ring_size, q_local_padded_Nt, fused_op_receiver.seq.ring_index);
+            const auto masks = ring_joint::build_ring_work_masks_device(
+                fused_op_receiver.seq.ring_index,
+                ring_size,
+                fused_op_receiver.seq.expected[0],
+                fused_op_receiver.seq.expected[1],
+                num_local_k_chunks,
+                Sk_chunk_t,
+                kv_local_padded_Nt,
+                chunked_enabled,
+                chunk_size_t,
+                q_local_padded_Nt,
+                logical_nt,
+                num_joint_k_chunks,
+                L,
+                kv_pad_rotation_enabled,
+                is_causal != 0,
+                is_balanced != 0);
+            active_ring_iter_mask = masks.active_ring_iter_mask;
+
+            CircularBuffer cb_derived(cb_kv_pad_derived);
+            cb_derived.reserve_back(1);
+            CoreLocalMem<volatile uint32_t> d(cb_derived.get_write_ptr());
+            d[0] = logical_nt;
+            d[1] = qmap.q_pre_wrap_start_tile;
+            d[2] = qmap.q_pre_wrap_tile_count;
+            d[3] = qmap.q_post_wrap_start_tile;
+            d[4] = qmap.q_valid_tile_count;
+            d[5] = active_ring_iter_mask;
+            cb_derived.push_back(1);
+        }
+    }
 
     constexpr uint32_t q_tile_bytes = get_tile_size(cb_q_in);
     constexpr uint32_t k_tile_bytes = get_tile_size(cb_k_in);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_reader.cpp
@@ -10,11 +10,11 @@
 #include "api/core_local_mem.h"
 #include "dataflow_common.hpp"
 #include "chunked_prefill_utils.hpp"
-#include "ring_joint_kv_pad_derivation.hpp"
-#include "metadata_scalar_read.hpp"
 #include "chain_link.hpp"
 #include "fused_op_receiver.hpp"
+#include "ring_utils.hpp"
 #include "ttnn/operations/transformer/sdpa/device/kernels/ring_joint_chain_layout.hpp"
+#include "ttnn/operations/transformer/sdpa/device/kernels/sliding_window_work_plan.hpp"
 
 namespace ring_joint = ttnn::operations::transformer::sdpa::ring_joint;
 
@@ -201,8 +201,14 @@ void kernel_main() {
     constexpr uint32_t NHV = get_compile_time_arg_val(30);
     // Latent-V mode: absent V is materialized from the prefix of K tiles already in L1.
     constexpr bool v_shares_k_buffer = get_compile_time_arg_val(31) == 1;
+    constexpr bool use_attention_sink = get_compile_time_arg_val(32) == 1;
+    constexpr uint32_t sliding_window_size = get_compile_time_arg_val(33);
+    constexpr bool has_sliding_window = sliding_window_size > 0;
+    constexpr bool enable_kv_chains = !has_sliding_window;
+    constexpr uint32_t gathered_padded_Nt = get_compile_time_arg_val(34);
     constexpr bool gqa_grouped_kv = ring_joint::is_gqa_grouped_kv_head_mode(v_shares_k_buffer, NH, NHK, NHV);
     constexpr bool k_uses_batch_chain = ring_joint::uses_shared_k_batch_chain(gqa_grouped_kv, NHK);
+    constexpr bool use_head_chain = enable_kv_chains && !gqa_grouped_kv;
     // In-place latent-V (single-tile Q): the compute kernel reads V straight from K^T, so the
     // reader never materializes V. Shared with the program factory and compute kernel.
     constexpr bool kt_inplace_v = kt_inplace_v_enabled(v_shares_k_buffer, Sq_chunk_t);
@@ -214,43 +220,16 @@ void kernel_main() {
     constexpr bool has_joint_k = num_joint_k_chunks > 0;
     constexpr bool has_joint_inputs = has_joint_q || has_joint_k;
 
-    // Slot 32: trace-safe slot select. When set, kv_cache_batch_idx is read from the slot_id tensor[0]
-    // on-device (common runtime arg 0 = slot_id DRAM addr) instead of the per-core runtime arg, so a
-    // captured trace replays across cache slots. Tensor accessors therefore start at compile-arg slot 33.
-    constexpr bool slot_from_metadata = get_compile_time_arg_val(32) == 1;
-    // Slot 33: trace-safe KV-pad derivation. When set, the reader reads kv_actual_isl from the
-    // kv_actual_isl tensor[0] (common runtime arg 3 = its DRAM addr), derives logical_nt / q-mapping /
-    // ring masks on-device, and hands the compute-needed values to the compute kernel via
-    // cb_kv_pad_derived (compute cannot NoC-read the DRAM tensor).
-    constexpr bool kv_pad_from_metadata = get_compile_time_arg_val(33) == 1;
-    constexpr auto q_args = TensorAccessorArgs<34>();
+    constexpr auto q_args = TensorAccessorArgs<35>();
     constexpr auto k_args = TensorAccessorArgs<q_args.next_compile_time_args_offset()>();
     constexpr auto v_args = TensorAccessorArgs<k_args.next_compile_time_args_offset()>();
     constexpr auto gathered_k_args = TensorAccessorArgs<v_args.next_compile_time_args_offset()>();
     constexpr auto gathered_v_args = TensorAccessorArgs<gathered_k_args.next_compile_time_args_offset()>();
     constexpr uint32_t joint_tensor_args_offset = gathered_v_args.next_compile_time_args_offset();
-    constexpr uint32_t post_tensor_args_offset =
+    constexpr uint32_t post_joint_tensor_args_offset =
         get_post_tensor_args_offset<has_joint_inputs, joint_tensor_args_offset>();
-    // The metadata accessor (metadata path only) follows the tensor accessors and precedes the chain
-    // semaphore compile args. Gate its offset on slot_from_metadata: when absent, fall back to a VALID
-    // (unused) accessor offset (q_args' slot 34) so TensorAccessorArgs<> -- instantiated unconditionally
-    // here -- never names a non-accessor compile arg (which would fail its internal static_assert).
-    // The chain/CB compile args then start after the metadata accessor when present.
-    constexpr uint32_t meta_args_offset = slot_from_metadata ? post_tensor_args_offset : 34;
-    constexpr auto meta_args = TensorAccessorArgs<meta_args_offset>();  // slot_id accessor
-    // kv_actual_isl gets its OWN accessor (a separately-allocated single-page DRAM tensor can land in a
-    // different DRAM bank than slot_id, so the slot accessor's dspec reads the wrong bank for it -- the kv
-    // read silently returned 0). Appended right after slot's when kv_pad_from_metadata; otherwise fall back
-    // to a VALID accessor offset so the unconditional TensorAccessorArgs<> never names a non-accessor arg.
-    constexpr uint32_t kv_meta_args_offset =
-        kv_pad_from_metadata ? meta_args.next_compile_time_args_offset() : meta_args_offset;
-    constexpr auto kv_meta_args = TensorAccessorArgs<kv_meta_args_offset>();
-    // Split to avoid a nested conditional operator: first resolve the base when kv_pad is absent, then
-    // override it when kv_pad_from_metadata appends kv_actual_isl's accessor after slot's.
-    constexpr uint32_t chains_base_no_kv_pad =
-        slot_from_metadata ? meta_args.next_compile_time_args_offset() : post_tensor_args_offset;
-    constexpr uint32_t chains_base_offset =
-        kv_pad_from_metadata ? kv_meta_args.next_compile_time_args_offset() : chains_base_no_kv_pad;
+    constexpr auto attention_sink_args = TensorAccessorArgs<post_joint_tensor_args_offset>();
+    constexpr uint32_t post_tensor_args_offset = attention_sink_args.next_compile_time_args_offset();
 
     uint32_t argidx = 0;
     const uint32_t q_addr = get_arg_val<uint32_t>(argidx++);
@@ -266,33 +245,33 @@ void kernel_main() {
         joint_k_addr = get_arg_val<uint32_t>(argidx++);
         joint_v_addr = get_arg_val<uint32_t>(argidx++);
     }
+    const uint32_t attention_sink_addr = get_arg_val<uint32_t>(argidx++);
     const uint32_t global_q_start = get_arg_val<uint32_t>(argidx++);
     const uint32_t global_q_end = get_arg_val<uint32_t>(argidx++);
-    // Trace-safe slot select: kv_cache_batch_idx is read from metadata[0] on-device below (after the CB
-    // ids are known); the per-core arg here is a placeholder 0 on the metadata path.
-    uint32_t kv_cache_batch_idx = get_arg_val<uint32_t>(argidx++);
+    const uint32_t kv_cache_batch_idx = get_arg_val<uint32_t>(argidx++);
     const uint32_t q_per_core = global_q_end - global_q_start;
 
-    // Head chain runtime args (always present)
-    const ChainConfig head_cfg = ChainConfig::read_from_args(argidx);
+    ChainConfig head_cfg;
+    if constexpr (use_head_chain) {
+        head_cfg = ChainConfig::read_from_args(argidx);
+    }
 
     // Batch chain runtime args (only present for non-GQA shared-K modes).
     ChainConfig batch_cfg;  // default zero-initialized
     uint32_t max_q_per_core = 0;
-    if constexpr (k_uses_batch_chain) {
+    if constexpr (enable_kv_chains && k_uses_batch_chain) {
         batch_cfg = ChainConfig::read_from_args(argidx);
         max_q_per_core = get_arg_val<uint32_t>(argidx++);
     }
     ChainConfig gqa_cfg;  // default zero-initialized
     uint32_t gqa_max_q_per_core = 0;
-    if constexpr (gqa_grouped_kv) {
+    if constexpr (enable_kv_chains && gqa_grouped_kv) {
         gqa_cfg = ChainConfig::read_from_args(argidx);
         gqa_max_q_per_core = get_arg_val<uint32_t>(argidx++);
     }
 
-    // Mutable: on the kv_pad_from_metadata path these are recomputed on-device below from metadata[1].
-    uint32_t logical_nt = get_arg_val<uint32_t>(argidx++);
-    uint32_t active_ring_iter_mask = get_arg_val<uint32_t>(argidx++);
+    const uint32_t logical_nt = get_arg_val<uint32_t>(argidx++);
+    const uint32_t active_ring_iter_mask = get_arg_val<uint32_t>(argidx++);
     RingSDPAOpReceiver fused_op_receiver = RingSDPAOpReceiver(
         true, /* wait_for_op_signal */
         argidx);
@@ -305,17 +284,26 @@ void kernel_main() {
     constexpr uint32_t chain_mcast_enabled_arg_offset = ring_joint::kChainMcastEnabledCompileArgOffset;
     constexpr uint32_t chain_compile_arg_count = ring_joint::kChainCompileArgCount;
 
-    uint32_t head_sender_semaphore_id =
-        get_compile_time_arg_val(chains_base_offset + chain_sender_semaphore_arg_offset);
-    uint32_t head_receiver_semaphore_id =
-        get_compile_time_arg_val(chains_base_offset + chain_receiver_semaphore_arg_offset);
-    uint32_t head_valid_semaphore_id = get_compile_time_arg_val(chains_base_offset + chain_valid_semaphore_arg_offset);
-    constexpr bool head_mcast_enabled =
-        get_compile_time_arg_val(chains_base_offset + chain_mcast_enabled_arg_offset) == 1;
-    constexpr uint32_t head_chain_arg_count = chain_compile_arg_count;
-    constexpr uint32_t batch_chain_arg_count = k_uses_batch_chain ? chain_compile_arg_count : 0;
-    constexpr uint32_t gqa_chain_arg_count = gqa_grouped_kv ? chain_compile_arg_count : 0;
-    constexpr uint32_t batch_chain_ct_offset = chains_base_offset + head_chain_arg_count;
+    uint32_t head_sender_semaphore_id = 0;
+    uint32_t head_receiver_semaphore_id = 0;
+    uint32_t head_valid_semaphore_id = 0;
+    constexpr bool head_mcast_enabled = []() {
+        if constexpr (use_head_chain) {
+            return get_compile_time_arg_val(post_tensor_args_offset + chain_mcast_enabled_arg_offset) == 1;
+        }
+        return false;
+    }();
+    if constexpr (use_head_chain) {
+        head_sender_semaphore_id =
+            get_compile_time_arg_val(post_tensor_args_offset + chain_sender_semaphore_arg_offset);
+        head_receiver_semaphore_id =
+            get_compile_time_arg_val(post_tensor_args_offset + chain_receiver_semaphore_arg_offset);
+        head_valid_semaphore_id = get_compile_time_arg_val(post_tensor_args_offset + chain_valid_semaphore_arg_offset);
+    }
+    constexpr uint32_t head_chain_arg_count = use_head_chain ? chain_compile_arg_count : 0;
+    constexpr uint32_t batch_chain_arg_count = enable_kv_chains && k_uses_batch_chain ? chain_compile_arg_count : 0;
+    constexpr uint32_t gqa_chain_arg_count = enable_kv_chains && gqa_grouped_kv ? chain_compile_arg_count : 0;
+    constexpr uint32_t batch_chain_ct_offset = post_tensor_args_offset + head_chain_arg_count;
     constexpr uint32_t gqa_chain_ct_offset = batch_chain_ct_offset + batch_chain_arg_count;
 
     // Batch chain semaphores (only present for non-GQA shared-K modes).
@@ -326,13 +314,13 @@ void kernel_main() {
 
     // batch_mcast_enabled: read from compile-time args if present, else false (for template instantiation)
     constexpr bool batch_mcast_enabled = []() {
-        if constexpr (k_uses_batch_chain) {
+        if constexpr (enable_kv_chains && k_uses_batch_chain) {
             return get_compile_time_arg_val(batch_chain_ct_offset + chain_mcast_enabled_arg_offset) == 1;
         }
         return false;
     }();
 
-    if constexpr (k_uses_batch_chain) {
+    if constexpr (enable_kv_chains && k_uses_batch_chain) {
         batch_sender_semaphore_id = get_compile_time_arg_val(batch_chain_ct_offset + chain_sender_semaphore_arg_offset);
         batch_receiver_semaphore_id =
             get_compile_time_arg_val(batch_chain_ct_offset + chain_receiver_semaphore_arg_offset);
@@ -343,119 +331,28 @@ void kernel_main() {
     uint32_t gqa_receiver_semaphore_id = 0;
     uint32_t gqa_valid_semaphore_id = 0;
     constexpr bool gqa_mcast_enabled = []() {
-        if constexpr (gqa_grouped_kv) {
+        if constexpr (enable_kv_chains && gqa_grouped_kv) {
             return get_compile_time_arg_val(gqa_chain_ct_offset + chain_mcast_enabled_arg_offset) == 1;
         }
         return false;
     }();
-    if constexpr (gqa_grouped_kv) {
+    if constexpr (enable_kv_chains && gqa_grouped_kv) {
         gqa_sender_semaphore_id = get_compile_time_arg_val(gqa_chain_ct_offset + chain_sender_semaphore_arg_offset);
         gqa_receiver_semaphore_id = get_compile_time_arg_val(gqa_chain_ct_offset + chain_receiver_semaphore_arg_offset);
         gqa_valid_semaphore_id = get_compile_time_arg_val(gqa_chain_ct_offset + chain_valid_semaphore_arg_offset);
     }
 
     constexpr uint32_t cb_arg_offset =
-        chains_base_offset + head_chain_arg_count + batch_chain_arg_count + gqa_chain_arg_count;
+        post_tensor_args_offset + head_chain_arg_count + batch_chain_arg_count + gqa_chain_arg_count;
     constexpr uint32_t cb_q_in = get_compile_time_arg_val(cb_arg_offset + 0);
     constexpr uint32_t cb_k_in = get_compile_time_arg_val(cb_arg_offset + 1);
     constexpr uint32_t cb_v_in = get_compile_time_arg_val(cb_arg_offset + 2);
-
-    // Trace-safe slot select: read the cache slot from the slot_id tensor[0] on-device (the per-core
-    // kv_cache_batch_idx above is a placeholder 0 on the metadata path and would be frozen by a captured
-    // trace). The slot_id DRAM address is common runtime arg 0 and the kv_actual_isl DRAM address is
-    // common runtime arg 3; the shared accessor (meta_args) sits between the tensor accessors and the
-    // chain semaphores.
-    if constexpr (slot_from_metadata || kv_pad_from_metadata) {
-        // Two 1-element uint32 DRAM tensors: slot_id (common arg 0, was metadata[0]) and kv_actual_isl
-        // (common arg 3, was metadata[1]). They share one layout, so ONE accessor (meta_args) reads each
-        // tensor's page 0 (4B). Read into cb_q_in's L1 as scratch -- it is allocated but not yet filled
-        // here, and the main loop overwrites it before first use. (A NoC read into a kernel stack buffer
-        // hangs; the destination must be a real L1 CB address.)
-        Noc meta_noc;
-        CircularBuffer cb_q_scratch(cb_q_in);
-        const uint32_t meta_l1 = cb_q_scratch.get_write_ptr();
-        // slot_id and kv_actual_isl both read into the SAME CB base offset (0), sequentially: slot is read,
-        // barrier'd, and FULLY consumed into kv_cache_batch_idx before the kv read reuses the slot. These
-        // small DRAM reads only land correctly at the CB page base (offset 0) on this platform -- a read
-        // into ANY nonzero offset (+16, +32) of the same CB silently lands zero (verified: kv_actual_isl at
-        // +32 deterministically returned 0, breaking the rotation q-mapping; +0 fixes it). Mirrors the
-        // proven all-gather reader, which also reads both scalars into offset 0.
-        constexpr uint32_t kSlotDstOffset = 0;
-        constexpr uint32_t kKvDstOffset = 0;
-        if constexpr (slot_from_metadata) {
-            const uint32_t slot_id_addr = get_common_arg_val<uint32_t>(0);
-            // read_metadata_scalar_u32 is the shared read protocol: async_read page 0 -> barrier ->
-            // invalidate_l1_cache -> volatile load. The invalidate is load-bearing -- the metadata tensor is
-            // at a FIXED DRAM address reused every chunk, so the RISC data cache may still hold the prior
-            // chunk's value for this L1 line (the barrier orders the DMA; a volatile load still reads cache),
-            // and an intermittently stale slot read corrupts the gather.
-            const uint32_t slot_id =
-                trace_metadata::read_metadata_scalar_u32(meta_noc, meta_args, slot_id_addr, meta_l1 + kSlotDstOffset);
-            // The KV-cache batch dim is (user, layer)-major:
-            //   cache_batch_idx = slot_id * kv_cache_num_layers + kv_cache_layer_idx
-            // (matches update_padded_kv_cache's writer: batch_idx = slot_idx * num_layers + layer_idx).
-            // slot_id holds only the cache user id; the per-layer factor comes from common runtime args
-            // 1/2. Defaults (num_layers=1, layer_idx=0) reduce this to slot_id, keeping single-layer
-            // callers bit-identical to the original slot_id behavior.
-            const uint32_t kv_cache_num_layers = get_common_arg_val<uint32_t>(1);
-            const uint32_t kv_cache_layer_idx = get_common_arg_val<uint32_t>(2);
-            kv_cache_batch_idx = slot_id * kv_cache_num_layers + kv_cache_layer_idx;
-        }
-        if constexpr (kv_pad_from_metadata) {
-            // kv_actual_isl tensor (common arg 3) holds actual_start = kv_actual_isl (tile-aligned).
-            // Derive the per-chunk values the host would otherwise have computed from the kv_actual_isl
-            // scalar, and hand the compute-needed subset to the compute kernel via cb_kv_pad_derived
-            // (compute can't NoC-read DRAM). chunk_size_t == q_chunk_group_tile_count (ring_size *
-            // q_local_padded_Nt).
-            const uint32_t kv_actual_isl_addr = get_common_arg_val<uint32_t>(3);
-            // Its OWN accessor (kv_meta_args): slot_id and kv_actual_isl are separately allocated and can
-            // land in different DRAM banks, and a shared accessor's dspec bakes page 0's bank from one of
-            // them -- sharing silently returned the wrong bank's data.
-            const uint32_t kv_actual_isl = trace_metadata::read_metadata_scalar_u32(
-                meta_noc, kv_meta_args, kv_actual_isl_addr, meta_l1 + kKvDstOffset);
-            const uint32_t kv_actual_tile_count = kv_actual_isl / 32;
-            const uint32_t chunk_global = chunk_size_t * 32;
-            logical_nt = ring_joint::compute_logical_nt(kv_actual_isl, chunk_global, 32);
-            const auto qmap = ring_joint::build_kv_pad_q_mapping_device(
-                kv_actual_tile_count, logical_nt, ring_size, q_local_padded_Nt, fused_op_receiver.seq.ring_index);
-            const auto masks = ring_joint::build_ring_work_masks_device(
-                fused_op_receiver.seq.ring_index,
-                ring_size,
-                fused_op_receiver.seq.expected[0],  // backward_writes_expected
-                fused_op_receiver.seq.expected[1],  // forward_writes_expected
-                num_local_k_chunks,
-                Sk_chunk_t,
-                kv_local_padded_Nt,
-                chunked_enabled,
-                chunk_size_t,
-                q_local_padded_Nt,
-                logical_nt,
-                num_joint_k_chunks,
-                L,
-                kv_pad_rotation_enabled,
-                is_causal != 0,
-                is_balanced != 0);
-            active_ring_iter_mask = masks.active_ring_iter_mask;
-
-            // Hand [logical_nt, q_pre_wrap_start, q_pre_wrap_count, q_post_wrap_start, q_valid_count,
-            // active_ring_iter_mask] to compute via cb_kv_pad_derived (cb_arg_offset + 3).
-            constexpr uint32_t cb_kv_pad_derived = get_compile_time_arg_val(cb_arg_offset + 3);
-            CircularBuffer cb_derived(cb_kv_pad_derived);
-            cb_derived.reserve_back(1);
-            CoreLocalMem<volatile uint32_t> d(cb_derived.get_write_ptr());
-            d[0] = logical_nt;
-            d[1] = qmap.q_pre_wrap_start_tile;
-            d[2] = qmap.q_pre_wrap_tile_count;
-            d[3] = qmap.q_post_wrap_start_tile;
-            d[4] = qmap.q_valid_tile_count;
-            d[5] = active_ring_iter_mask;
-            cb_derived.push_back(1);
-        }
-    }
+    constexpr uint32_t cb_attention_sink = get_compile_time_arg_val(cb_arg_offset + 3);
 
     constexpr uint32_t q_tile_bytes = get_tile_size(cb_q_in);
     constexpr uint32_t k_tile_bytes = get_tile_size(cb_k_in);
     constexpr uint32_t v_tile_bytes = get_tile_size(cb_v_in);
+    constexpr uint32_t attention_sink_tile_bytes = get_tile_size(cb_attention_sink);
 
     constexpr uint32_t k_chunk_tiles = Sk_chunk_t * DHt;
     constexpr uint32_t v_chunk_tiles = Sk_chunk_t * vDHt;
@@ -480,14 +377,12 @@ void kernel_main() {
         head_cfg.mcast_end_x,
         head_cfg.mcast_end_y,
         head_cfg.mcast_num_dests,
-        head_cfg.mcast_sender_wait,
         v_chunk_tiles,
         v_tile_bytes,
-        head_cfg.batch,
         head_cfg.head,
         head_cfg.next_core_q_chunks);
 
-    // Batch chain (batch-level): matches batch only, used by K in non-GQA shared-K modes.
+    // Shared-K chain used by K in non-GQA shared-K modes.
     ChainLink<batch_mcast_enabled, false> batch_chain(
         batch_cfg.participates,
         batch_cfg.is_injector,
@@ -504,11 +399,9 @@ void kernel_main() {
         batch_cfg.mcast_end_x,
         batch_cfg.mcast_end_y,
         batch_cfg.mcast_num_dests,
-        batch_cfg.mcast_sender_wait,
         k_chunk_tiles,
         k_tile_bytes,
-        batch_cfg.batch,
-        0,  // chain_head unused for batch-level chain
+        0,  // chain_head unused for the shared-K chain
         batch_cfg.next_core_q_chunks);
 
     // GQA grouped chain (head-level where head means KV head): used by both K and V in GQA_GROUPED_KV.
@@ -528,10 +421,8 @@ void kernel_main() {
         gqa_cfg.mcast_end_x,
         gqa_cfg.mcast_end_y,
         gqa_cfg.mcast_num_dests,
-        gqa_cfg.mcast_sender_wait,
         v_chunk_tiles,
         v_tile_bytes,
-        gqa_cfg.batch,
         gqa_cfg.head,
         gqa_cfg.next_core_q_chunks);
 
@@ -544,7 +435,7 @@ void kernel_main() {
         }
     }();
 
-    // K uses the grouped GQA chain, the batch chain for shared-K modes, otherwise the query-head chain.
+    // K uses the grouped GQA chain, the shared-K chain, or the query-head chain.
     auto& k_chain = [&]() -> auto& {
         if constexpr (gqa_grouped_kv) {
             return gqa_chain;
@@ -558,6 +449,8 @@ void kernel_main() {
     constexpr uint32_t q_num_subblocks = Sq_chunk_t / qk_subblock_h;
     constexpr bool use_q_subblock_push = (q_num_subblocks > 1);
     constexpr uint32_t q_heads_per_k = NH / NHK;
+    static_assert(!has_sliding_window || !gqa_mcast_enabled, "Sliding windows use direct per-core K/V reads");
+    static_assert(!has_sliding_window || chunked_enabled, "Sliding windows require chunked prefill");
 
     // Throttle Q DRAM reads so many readers don't saturate the NoC outstanding-read budget.
     constexpr uint32_t q_barrier_threshold = get_barrier_read_threshold<q_tile_bytes, num_q_readers>();
@@ -571,7 +464,7 @@ void kernel_main() {
     const uint32_t gathered_kv_batch_dim = indexed_kv_cache ? 1 : B;
     const auto input_q_tile_logical = TensorTileShape(B, NH, q_local_padded_Nt, DHt);
     const auto input_k_tile_logical = TensorTileShape(kv_batch_dim, NHK, kv_local_padded_Nt, DHt);
-    const auto gathered_k_input_tile_logical = TensorTileShape(gathered_kv_batch_dim, NHK, padded_Nt, DHt);
+    const auto gathered_k_input_tile_logical = TensorTileShape(gathered_kv_batch_dim, NHK, gathered_padded_Nt, DHt);
     const auto joint_input_tile_logical = TensorTileShape(B, NH, Lt, DHt);
 
     const auto q_generator = PaddedAddrGenerator(q_reader, input_q_tile_logical);
@@ -580,12 +473,15 @@ void kernel_main() {
     const auto local_v_reader = TensorAccessor(v_args, v_addr);
     const auto input_v_tile_logical = TensorTileShape(kv_batch_dim, NHV, kv_local_padded_Nt, vDHt);
     const auto gathered_v_reader = TensorAccessor(gathered_v_args, gathered_v_addr);
-    const auto gathered_v_input_tile_logical = TensorTileShape(gathered_kv_batch_dim, NHV, padded_Nt, vDHt);
+    const auto gathered_v_input_tile_logical = TensorTileShape(gathered_kv_batch_dim, NHV, gathered_padded_Nt, vDHt);
     const auto local_v_generator = PaddedAddrGenerator(local_v_reader, input_v_tile_logical);
     const auto gathered_v_generator = PaddedAddrGenerator(gathered_v_reader, gathered_v_input_tile_logical);
     [[maybe_unused]] const auto v_generators =
         VSourceGenerators<decltype(local_v_generator), decltype(gathered_v_generator)>{
             local_v_generator, gathered_v_generator};
+    const auto attention_sink_reader = TensorAccessor(attention_sink_args, attention_sink_addr);
+    const auto attention_sink_tile_shape = TensorTileShape(1, NH, 1, 1);
+    CircularBuffer cb_attn_sink(cb_attention_sink);
 
     // Tracks whether Q has been pushed for q_per_core == 1 optimization.
     // When q_per_core == 1, Q is identical across ring iterations so we only push it once.
@@ -598,14 +494,33 @@ void kernel_main() {
      */
     uint32_t ring_index = fused_op_receiver.seq.ring_index;
     uint32_t half_sequence = num_q_chunks / 2;
-    for (uint32_t ring_iter = 0; ring_iter < ring_size; ++ring_iter) {
-        // find out which is the latest ring_id that synchronized
-        uint32_t ring_id = fused_op_receiver.get_next_ring_id_and_sync();
+    // Sliding consumes local and halo ranges in one logical Q pass. Wait for every halo that
+    // the host work plan selected before starting that pass; this keeps the hot loop free of
+    // device-wide ring phases and makes Q/accumulator state single-lifetime.
+    if constexpr (has_sliding_window) {
+        // Sliding has a compact one-hop write plan (local slab + cyclic predecessor). Consume
+        // its signal so a cached program cannot observe the previous invocation's token.
+        const uint32_t synchronization_iters =
+            1 + fused_op_receiver.seq.expected[0] + fused_op_receiver.seq.expected[1];
+        for (uint32_t ring_iter = 0; ring_iter < synchronization_iters; ++ring_iter) {
+            fused_op_receiver.get_next_ring_id_and_consume_one_signal();
+        }
+    }
+    constexpr uint32_t sdpa_ring_iterations = has_sliding_window ? 1 : ring_size;
+    for (uint32_t ring_iter = 0; ring_iter < sdpa_ring_iterations; ++ring_iter) {
+        const bool ring_iter_is_active = has_sliding_window || ((active_ring_iter_mask >> ring_iter) & 1u) != 0;
+        // Sliding already advanced/synchronized the sequencer above and uses a synthetic local
+        // iteration whose K loop decodes the real source ring ID for each chunk.
+        uint32_t ring_id = has_sliding_window ? ring_index : fused_op_receiver.get_next_ring_id_and_sync();
         // Host precomputes which ring iterations have useful SDPA work; sync/ring-id sequencing
         // still advances above so reader stays aligned with compute, writer, and all-gather.
-        if (((active_ring_iter_mask >> ring_iter) & 1u) == 0) {
+        if (!ring_iter_is_active) {
             continue;
         }
+        // Compute consumes one sink tile for each real Q only when it normalizes on the
+        // final active ring iteration. Keep the producer cadence identical, including
+        // balanced Q chunks whose final iteration takes the normalize-only path.
+        const bool is_last_ring_iter = has_sliding_window || is_last_active_ring_iter(active_ring_iter_mask, ring_iter);
         // Iterate over KV blocks gathered on ring.
         // Only the last ring ID will append joint_K, joint_V to K, V.
         const bool do_joint_kv = ring_id == ring_size - 1;
@@ -613,17 +528,6 @@ void kernel_main() {
         if constexpr (has_joint_k) {
             if (do_joint_kv) {
                 num_kv_chunks += num_joint_k_chunks;
-            }
-        }
-
-        uint32_t ring_iter_valid_kv_tiles = kv_local_padded_Nt;
-        if constexpr (!chunked_enabled) {
-            const uint32_t ring_iter_kv_start_tile = ring_id * kv_local_padded_Nt;
-            ring_iter_valid_kv_tiles = 0;
-            if (ring_iter_kv_start_tile < logical_nt) {
-                const uint32_t remaining_kv_tiles = logical_nt - ring_iter_kv_start_tile;
-                ring_iter_valid_kv_tiles =
-                    remaining_kv_tiles < kv_local_padded_Nt ? remaining_kv_tiles : kv_local_padded_Nt;
             }
         }
 
@@ -639,13 +543,15 @@ void kernel_main() {
         // - 1st part of the sequence precedes both chunks on the sender device, 2nd part attends to both
         // - both chunks preced 2nd part of the sequence in received KV
         // Indexes are updated accordingly; compute is skipped
-        if (is_causal && is_balanced && ring_index > ring_id) {
-            iter_num_kv_chunks /= 2;
-            // Mirror compute's K-loop extension: include the straddle chunk so K/V tiles
-            // for it get loaded. Compute -inf-masks its late-half columns via lw_mask.
-            using Straddle = KCausalStraddleInfo<kv_local_padded_Nt, Sk_chunk_t>;
-            if constexpr (Straddle::has_straddle) {
-                iter_num_kv_chunks = Straddle::straddle_chunk_id + 1;
+        if constexpr (!has_sliding_window) {
+            if (is_causal && is_balanced && ring_index > ring_id) {
+                iter_num_kv_chunks /= 2;
+                // Mirror compute's K-loop extension: include the straddle chunk so K/V tiles
+                // for it get loaded. Compute -inf-masks its late-half columns via lw_mask.
+                using Straddle = KCausalStraddleInfo<kv_local_padded_Nt, Sk_chunk_t>;
+                if constexpr (Straddle::has_straddle) {
+                    iter_num_kv_chunks = Straddle::straddle_chunk_id + 1;
+                }
             }
         }
 
@@ -664,32 +570,53 @@ void kernel_main() {
             // Check if this is a real iteration or only padded chain/mcast synchronization.
             const bool is_padded_iter = (q_iter >= q_per_core);
 
-            // Calculate global_q_chunk for all iterations (including padded).
-            // For padded iterations, global index may be out of bounds, but q_chunk = global_q_chunk % num_q_chunks
-            // gives a valid position that correctly determines whether to skip this iteration.
-            uint32_t global_q_chunk = remap_q_index(global_q_start + q_iter, num_q_chunks, use_zigzag_balancing);
-
-            // global_q_chunk is index into `B * NH * num_q_chunks`. Need to get nb, nq, q_chunk from this.
-            const uint32_t nb = global_q_chunk / (NH * num_q_chunks);
-            const uint32_t nq = (global_q_chunk % (NH * num_q_chunks)) / num_q_chunks;
-            const uint32_t q_chunk = global_q_chunk % num_q_chunks;
+            // Same-core GQA uses group-major (batch, Q chunk, head) scheduling so consecutive
+            // iterations reuse one K/V window.  Every other specialization retains the ordinary
+            // head-major flat order and optional causal zigzag remap.
+            const auto decoded_q =
+                decompose_global_q_index(global_q_start + q_iter, num_q_chunks, NH, use_zigzag_balancing);
+            const uint32_t nb = decoded_q.nb;
+            const uint32_t nq = decoded_q.nq;
+            const uint32_t q_chunk = decoded_q.q_chunk;
             const uint32_t nk = nq / q_heads_per_k;
             const auto q_row_start_tile = q_chunk * Sq_chunk_t;
             const bool is_joint_q = has_joint_q ? (q_chunk >= num_local_q_chunks) : false;
             const uint32_t q_iter_local = [&]() {
-                if constexpr (gqa_grouped_kv) {
+                if constexpr (enable_kv_chains && gqa_grouped_kv) {
                     return gqa_group_q_iter;
                 } else {
                     return q_iter;
                 }
             }();
-            if constexpr (gqa_grouped_kv) {
-                if (nb == gqa_cfg.batch && nk == gqa_cfg.head) {
+            if constexpr (enable_kv_chains && gqa_grouped_kv) {
+                if (nk == gqa_cfg.head) {
                     gqa_group_q_iter++;
                 }
             }
 
-            const bool balanced_skip_q = q_chunk < half_sequence && is_balanced && ring_index < ring_id;
+            const bool balanced_skip_q =
+                !has_sliding_window && q_chunk < half_sequence && is_balanced && ring_index < ring_id;
+
+            // A sink is one virtual key in the global softmax. It is consumed exactly once,
+            // during final-iteration normalization; retain it in the one-tile CB across all
+            // preceding full-causal ring iterations. Padded chain/mcast iterations have no
+            // compute consumer and must not produce a sink tile.
+            if constexpr (use_attention_sink) {
+                if (is_last_ring_iter && !is_padded_iter) {
+                    constexpr uint32_t sink_tiles = 1;
+                    cb_attn_sink.reserve_back(sink_tiles);
+                    const uint32_t sink_write_ptr = cb_attn_sink.get_write_ptr();
+                    const uint32_t sink_tile_id = attention_sink_tile_shape.id_of(0, nq, 0, 0);
+                    noc.async_read(
+                        attention_sink_reader,
+                        CoreLocalMem<uint32_t>(sink_write_ptr),
+                        attention_sink_tile_bytes,
+                        {.page_id = sink_tile_id},
+                        {});
+                    noc.async_read_barrier();
+                    cb_attn_sink.push_back(sink_tiles);
+                }
+            }
 
             // Balanced causal skip: this Q chunk is handled by the paired device. Reader sends
             // nothing (no Q, no K/V) — compute's normalize-only path on the last ring iter does
@@ -715,41 +642,79 @@ void kernel_main() {
             // fronted in the CB, so we only need to read it once on the first active ring iteration.
             const bool need_q_read = (q_per_core > 1) || !q_pushed;
 
-            for (uint32_t k_chunk = 0; k_chunk < iter_num_kv_chunks; ++k_chunk) {
+            ring_joint::SlidingQWorkPlan sliding_q_plan;
+            if constexpr (has_sliding_window) {
+                sliding_q_plan = ring_joint::build_sliding_q_work_plan(
+                    q_chunk * Sq_chunk_t,
+                    Sq_chunk_t,
+                    ring_index,
+                    q_local_padded_Nt,
+                    ring_size,
+                    sliding_window_size,
+                    tt::constants::TILE_HEIGHT,
+                    kv_local_padded_Nt,
+                    Sk_chunk_t,
+                    logical_nt);
+                ASSERT(sliding_q_plan.is_valid);
+                ASSERT(sliding_q_plan.total_k_chunk_count > 0);
+            }
+            const uint32_t q_k_loop_count =
+                has_sliding_window ? sliding_q_plan.total_k_chunk_count : iter_num_kv_chunks;
+            bool first_k_for_q = true;
+            for (uint32_t k_chunk = 0; k_chunk < q_k_loop_count; ++k_chunk) {
+                const auto sliding_k_chunk = sliding_q_plan.k_chunk_at(k_chunk);
+                const uint32_t source_ring_id = has_sliding_window ? sliding_k_chunk.source_ring_id : ring_id;
+                const uint32_t source_k_chunk = has_sliding_window ? sliding_k_chunk.source_k_chunk : k_chunk;
                 /**
                  * Iterate over all KV chunks for this Q chunk.
                  * If this is the last ring ID, we will also read from joint KV.
                  * If this k chunk is in the spatial input and beyond the logical N, we will skip it.
                  */
-                const bool kv_chunk_is_joint = has_joint_k ? (k_chunk >= num_local_k_chunks) : false;
+                const bool kv_chunk_is_joint = !has_sliding_window && has_joint_k && k_chunk >= num_local_k_chunks;
                 const bool kv_chunk_is_beyond_logical_n =
-                    !kv_chunk_is_joint && !kv_chunk_starts_before_logical_end<
-                                              kv_pad_rotation_enabled,
-                                              chunked_enabled,
-                                              kv_local_padded_Nt,
-                                              chunk_size_t,
-                                              q_local_padded_Nt>(ring_id, k_chunk * Sk_chunk_t, logical_nt);
+                    !kv_chunk_is_joint &&
+                    !kv_chunk_starts_before_logical_end<
+                        kv_pad_rotation_enabled,
+                        chunked_enabled,
+                        kv_local_padded_Nt,
+                        chunk_size_t,
+                        q_local_padded_Nt>(source_ring_id, source_k_chunk * Sk_chunk_t, logical_nt);
 
                 if (kv_chunk_is_beyond_logical_n) {
                     // This is a KV chunk on spatial input beyond the logical N, and not joint KV. Skip it.
+                    // A sliding work plan is already clipped to logical_n, so this would otherwise
+                    // desynchronize reader and compute K-loop counts.
+                    ASSERT(!has_sliding_window);
                     continue;
                 }
 
                 // Default to local/gathered KV; override below for joint KV when applicable.
                 Slice k_slice;
                 uint32_t end_seq_tile;
+                uint32_t source_valid_kv_tiles = kv_local_padded_Nt;
+                if constexpr (!chunked_enabled) {
+                    const uint32_t source_start_tile = source_ring_id * kv_local_padded_Nt;
+                    source_valid_kv_tiles = logical_nt > source_start_tile
+                                                ? std::min(logical_nt - source_start_tile, kv_local_padded_Nt)
+                                                : 0;
+                }
                 // Local KV reads the indexed cache slot; gathered KV is at slot 0 of the scratch buffer.
                 const uint32_t kv_batch = indexed_kv_cache ? kv_cache_batch_idx : nb;
                 const uint32_t gathered_kv_batch = indexed_kv_cache ? 0 : nb;
-                if (ring_iter == 0) {
-                    const uint32_t local_k_start_tile = k_chunk * Sk_chunk_t;
+                const bool source_is_local = source_ring_id == ring_index;
+                if (source_is_local) {
+                    const uint32_t local_k_start_tile = source_k_chunk * Sk_chunk_t;
                     k_slice = Slice(kv_batch, nk, local_k_start_tile, local_k_start_tile + Sk_chunk_t, 0, DHt);
-                    end_seq_tile = ring_iter_valid_kv_tiles;
+                    end_seq_tile = source_valid_kv_tiles;
                 } else {
-                    const uint32_t gathered_start_tile = ring_id * kv_local_padded_Nt + k_chunk * Sk_chunk_t;
+                    uint32_t gathered_start_tile = source_ring_id * kv_local_padded_Nt + source_k_chunk * Sk_chunk_t;
+                    if constexpr (has_sliding_window) {
+                        gathered_start_tile = sliding_k_chunk.compact_k_chunk * Sk_chunk_t;
+                    }
                     k_slice =
                         Slice(gathered_kv_batch, nk, gathered_start_tile, gathered_start_tile + Sk_chunk_t, 0, DHt);
-                    end_seq_tile = ring_id * kv_local_padded_Nt + ring_iter_valid_kv_tiles;
+                    end_seq_tile = has_sliding_window ? gathered_padded_Nt
+                                                      : source_ring_id * kv_local_padded_Nt + source_valid_kv_tiles;
                 }
                 if constexpr (has_joint_k) {
                     if (kv_chunk_is_joint) {
@@ -777,9 +742,14 @@ void kernel_main() {
                     cb_k.reserve_back(k_chunk_tiles);
                 }
                 uint32_t cb_k_start_address = cb_k.get_write_ptr();
-                if (k_chain.should_receive(nb, k_chain_head)) {
-                    k_chain.receive(noc);
-                } else {
+                bool received_k_from_chain = false;
+                if constexpr (!has_sliding_window) {
+                    if (k_chain.should_receive(k_chain_head)) {
+                        k_chain.receive(noc);
+                        received_k_from_chain = true;
+                    }
+                }
+                if (!received_k_from_chain) {
                     // Injector or non-participant: read K from DRAM. Dispatch directly so
                     // local and gathered tensors may use different accessor types.
                     const auto fetch_k = [&](const auto& k_gen) {
@@ -794,7 +764,7 @@ void kernel_main() {
                     };
                     fetch_k_from_source<has_joint_k, joint_tensor_args_offset>(
                         kv_chunk_is_joint,
-                        ring_iter,
+                        source_is_local ? 0 : 1,
                         joint_k_addr,
                         local_k_generator,
                         gathered_k_generator,
@@ -803,8 +773,10 @@ void kernel_main() {
                 }
 
                 // Forward K chunk via chain (uses K's data size explicitly)
-                if (k_chain.should_forward(nb, k_chain_head, q_iter_local)) {
-                    k_chain.forward(noc, cb_k_start_address, k_chunk_tiles, k_tile_bytes);
+                if constexpr (!has_sliding_window) {
+                    if (k_chain.should_forward(k_chain_head, q_iter_local)) {
+                        k_chain.forward(noc, cb_k_start_address, k_chunk_tiles, k_tile_bytes);
+                    }
                 }
 
                 // Skip Q and compute-visible pushes for padded mcast iterations.
@@ -819,7 +791,7 @@ void kernel_main() {
                         const uint32_t nv = nq / q_heads_per_v;
                         CircularBuffer cb_v(cb_v_in);
                         cb_v.reserve_back(2 * v_cb_entry_tiles);
-                        if (v_chain.should_receive(nb, nv)) {
+                        if (v_chain.should_receive(nv)) {
                             v_chain.receive(noc);
                         }
                     }
@@ -834,7 +806,7 @@ void kernel_main() {
                 // Push Q one subblock at a time so compute can start QK matmul incrementally.
                 // Placed after K forward so no outstanding NOC writes remain
                 // (noc_async_read_barrier inside subblock read would deadlock with in-flight writes).
-                if (k_chunk == 0 && need_q_read) {
+                if (first_k_for_q && need_q_read) {
                     const auto read_q = [&](const auto& q_gen) {
                         if constexpr (use_q_subblock_push) {
                             for (uint32_t q_sub = 0; q_sub < q_num_subblocks; ++q_sub) {
@@ -865,13 +837,14 @@ void kernel_main() {
                         is_joint_q, joint_q_addr, q_generator, joint_input_tile_logical, read_q);
                     q_pushed = true;
                 }
+                first_k_for_q = false;
 
                 // In-place latent-V (kt_inplace_v) materializes nothing: compute reads V straight
                 // from the K^T already pushed above, so neither branch below runs for that case.
                 if constexpr (v_shares_k_buffer && !kt_inplace_v) {
                     bool skip_v_materialization = false;
                     uint32_t v_rows_to_materialize = Sk_chunk_t;
-                    if constexpr (is_causal && !chunked_enabled) {
+                    if constexpr (is_causal && !chunked_enabled && !has_sliding_window) {
                         if (ring_iter == 0) {
                             // Local causal chunks beyond this limit are fully masked. Compute still
                             // advances the K/V FIFO phase, but does not consume V values for them.
@@ -908,9 +881,14 @@ void kernel_main() {
                     CircularBuffer cb_v(cb_v_in);
                     cb_v.reserve_back(v_cb_entry_tiles);
                     uint32_t cb_v_start_address = cb_v.get_write_ptr();
-                    if (v_chain.should_receive(nb, nv)) {
-                        v_chain.receive(noc);
-                    } else {
+                    bool received_v_from_chain = false;
+                    if constexpr (!has_sliding_window) {
+                        if (v_chain.should_receive(nv)) {
+                            v_chain.receive(noc);
+                            received_v_from_chain = true;
+                        }
+                    }
+                    if (!received_v_from_chain) {
                         const auto fetch_v = [&](const auto& v_gen) {
                             fetch_block(
                                 v_gen,
@@ -923,7 +901,7 @@ void kernel_main() {
                         };
                         fetch_v_from_source<has_joint_k, joint_tensor_args_offset>(
                             kv_chunk_is_joint,
-                            ring_iter,
+                            source_is_local ? 0 : 1,
                             joint_v_addr,
                             v_generators.local,
                             v_generators.gathered,
@@ -933,8 +911,10 @@ void kernel_main() {
 
                     // Forward V to next core(s) before push_back — prevents compute from
                     // popping the buffer while the mcast is still reading from it.
-                    if (v_chain.should_forward(nb, nv, q_iter_local)) {
-                        v_chain.forward(noc, cb_v_start_address);
+                    if constexpr (!has_sliding_window) {
+                        if (v_chain.should_forward(nv, q_iter_local)) {
+                            v_chain.forward(noc, cb_v_start_address);
+                        }
                     }
 
                     // Make V available to compute.
@@ -942,17 +922,19 @@ void kernel_main() {
                 }
             }
         }
-        for (uint32_t dummy_chunk = 0;
-             dummy_chunk <
-             dummy_kv_chunks_for_phase_alignment<v_shares_k_buffer, kt_inplace_v>(KV_chunks_processed_in_iter);
-             ++dummy_chunk) {
-            CircularBuffer cb_k_dummy(cb_k_in);
-            cb_k_dummy.reserve_back(k_chunk_tiles);
-            cb_k_dummy.push_back(k_chunk_tiles);
-            if constexpr (!kt_inplace_v) {
-                CircularBuffer cb_v_dummy(cb_v_in);
-                cb_v_dummy.reserve_back(v_cb_entry_tiles);
-                cb_v_dummy.push_back(v_cb_entry_tiles);
+        if constexpr (!has_sliding_window) {
+            for (uint32_t dummy_chunk = 0;
+                 dummy_chunk <
+                 dummy_kv_chunks_for_phase_alignment<v_shares_k_buffer, kt_inplace_v>(KV_chunks_processed_in_iter);
+                 ++dummy_chunk) {
+                CircularBuffer cb_k_dummy(cb_k_in);
+                cb_k_dummy.reserve_back(k_chunk_tiles);
+                cb_k_dummy.push_back(k_chunk_tiles);
+                if constexpr (!kt_inplace_v) {
+                    CircularBuffer cb_v_dummy(cb_v_in);
+                    cb_v_dummy.reserve_back(v_cb_entry_tiles);
+                    cb_v_dummy.push_back(v_cb_entry_tiles);
+                }
             }
         }
     }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_writer.cpp
@@ -10,8 +10,12 @@
 #include "ttnn/kernel/dataflow/generate_bcast_scalar.hpp"
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_dataflow.hpp"
 #include "dataflow_common.hpp"
+#include "ring_joint_kv_pad_derivation.hpp"
+#include "metadata_scalar_read.hpp"
 #include "fused_op_receiver.hpp"
 #include "ring_utils.hpp"
+
+namespace ring_joint = ttnn::operations::transformer::sdpa::ring_joint;
 
 // Eager-path reader: reads the previous ring iteration's normalized output and LSE from DRAM.
 // Used by the non-streaming (old sdpa_ring) path for sigmoid-based inter-iteration merging.
@@ -433,6 +437,7 @@ void kernel_main() {
     constexpr uint32_t single_valid_kv_chunk_mask_compile [[maybe_unused]] = get_compile_time_arg_val(33);
     constexpr uint32_t sliding_window_size = get_compile_time_arg_val(34);
     constexpr bool has_sliding_window = sliding_window_size > 0;
+    constexpr bool kv_pad_from_metadata = get_compile_time_arg_val(35) == 1;
     // Diagonal-mask tile slot is shared by the kernel's is_causal path and the chunked-prefill
     // path. The program factory masks kernel_is_causal off when chunked is on, so only one of
     // the two paths drives the stamp per program — but they share the CB slot layout.
@@ -443,9 +448,11 @@ void kernel_main() {
     constexpr bool has_joint_q = num_joint_q_chunks > 0;
     constexpr bool has_joint_k = num_joint_k_chunks > 0;
 
-    constexpr auto out_args = TensorAccessorArgs<35>();
+    constexpr auto out_args = TensorAccessorArgs<36>();
     constexpr auto joint_out_args = TensorAccessorArgs<out_args.next_compile_time_args_offset()>();
     constexpr auto stats_args = TensorAccessorArgs<joint_out_args.next_compile_time_args_offset()>();
+    constexpr uint32_t meta_args_offset = kv_pad_from_metadata ? stats_args.next_compile_time_args_offset() : 36;
+    constexpr auto meta_args = TensorAccessorArgs<meta_args_offset>();
 
     uint32_t argidx = 0;
     const uint32_t out_addr = get_arg_val<uint32_t>(argidx++);
@@ -453,15 +460,16 @@ void kernel_main() {
     const uint32_t stats_addr = get_arg_val<uint32_t>(argidx++);
     const uint32_t global_q_start = get_arg_val<uint32_t>(argidx++);
     const uint32_t global_q_end = get_arg_val<uint32_t>(argidx++);
-    const uint32_t logical_nt = get_arg_val<uint32_t>(argidx++);
-    const uint32_t active_ring_iter_mask = get_arg_val<uint32_t>(argidx++);
-    const uint32_t single_valid_kv_chunk_mask = get_arg_val<uint32_t>(argidx++);
+    uint32_t logical_nt = get_arg_val<uint32_t>(argidx++);
+    uint32_t active_ring_iter_mask = get_arg_val<uint32_t>(argidx++);
+    uint32_t single_valid_kv_chunk_mask = get_arg_val<uint32_t>(argidx++);
     RingSDPAOpReceiver fused_op_receiver = RingSDPAOpReceiver(
         false, /* wait_for_op_signal */
         argidx);
 
     // The stats CB is aliased by role: cb_max_* for deferred norm, cb_lse_* for eager norm.
-    constexpr uint32_t cb_arg_offset = stats_args.next_compile_time_args_offset();
+    constexpr uint32_t cb_arg_offset =
+        kv_pad_from_metadata ? meta_args.next_compile_time_args_offset() : stats_args.next_compile_time_args_offset();
     constexpr uint32_t cb_mask_in = get_compile_time_arg_val(cb_arg_offset + 3);
     constexpr uint32_t cb_scale_in = get_compile_time_arg_val(cb_arg_offset + 4);
     constexpr uint32_t cb_identity_scale_in = get_compile_time_arg_val(cb_arg_offset + 5);
@@ -480,6 +488,32 @@ void kernel_main() {
     constexpr uint32_t stats_tile_bytes = get_tile_size(cb_max_in);
 
     Noc noc;
+
+    if constexpr (kv_pad_from_metadata) {
+        CircularBuffer cb_meta_scratch(cb_out);
+        const uint32_t kv_actual_isl = trace_metadata::read_metadata_scalar_u32(
+            noc, meta_args, get_common_arg_val<uint32_t>(0), cb_meta_scratch.get_write_ptr());
+        logical_nt = ring_joint::compute_logical_nt(kv_actual_isl, chunk_size_t * 32, 32);
+        const auto masks = ring_joint::build_ring_work_masks_device(
+            fused_op_receiver.seq.ring_index,
+            ring_size,
+            fused_op_receiver.seq.expected[0],
+            fused_op_receiver.seq.expected[1],
+            num_local_k_chunks,
+            Sk_chunk_t,
+            kv_local_padded_Nt,
+            chunked_enabled,
+            chunk_size_t,
+            q_local_padded_Nt,
+            logical_nt,
+            num_joint_k_chunks,
+            L,
+            true,
+            is_causal != 0,
+            is_balanced != 0);
+        active_ring_iter_mask = masks.active_ring_iter_mask;
+        single_valid_kv_chunk_mask = masks.single_valid_kv_chunk_mask;
+    }
 
     const auto out_writer = TensorAccessor(out_args, out_addr);
     const auto joint_out_writer = TensorAccessor(joint_out_args, joint_out_addr);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_writer.cpp
@@ -10,11 +10,8 @@
 #include "ttnn/kernel/dataflow/generate_bcast_scalar.hpp"
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_dataflow.hpp"
 #include "dataflow_common.hpp"
-#include "ring_joint_kv_pad_derivation.hpp"
-#include "metadata_scalar_read.hpp"
 #include "fused_op_receiver.hpp"
-
-namespace ring_joint = ttnn::operations::transformer::sdpa::ring_joint;
+#include "ring_utils.hpp"
 
 // Eager-path reader: reads the previous ring iteration's normalized output and LSE from DRAM.
 // Used by the non-streaming (old sdpa_ring) path for sigmoid-based inter-iteration merging.
@@ -434,15 +431,12 @@ void kernel_main() {
     constexpr uint32_t active_ring_iter_mask_compile [[maybe_unused]] = get_compile_time_arg_val(31);
     constexpr uint32_t last_active_ring_iter_compile [[maybe_unused]] = get_compile_time_arg_val(32);
     constexpr uint32_t single_valid_kv_chunk_mask_compile [[maybe_unused]] = get_compile_time_arg_val(33);
+    constexpr uint32_t sliding_window_size = get_compile_time_arg_val(34);
+    constexpr bool has_sliding_window = sliding_window_size > 0;
     // Diagonal-mask tile slot is shared by the kernel's is_causal path and the chunked-prefill
     // path. The program factory masks kernel_is_causal off when chunked is on, so only one of
     // the two paths drives the stamp per program — but they share the CB slot layout.
-    constexpr bool diag_tile_enabled = (is_causal == 1) || chunked_enabled;
-    // Slot 34: trace-safe KV-pad derivation. When set, the writer reads kv_actual_isl from the
-    // kv_actual_isl tensor[0] (common runtime arg 0 = its DRAM addr) and recomputes logical_nt + ring
-    // masks on-device (it's a dataflow kernel, can NoC-read), so a captured trace replays across chunks.
-    // Output accessors therefore start at compile-arg slot 35.
-    constexpr bool kv_pad_from_metadata = get_compile_time_arg_val(34) == 1;
+    constexpr bool diag_tile_enabled = ((is_causal == 1) || chunked_enabled) && !has_sliding_window;
 
     // Joint-path compile-time gating. When zero, joint Q/K branches are statically dead
     // and dropped by the compiler, eliminating runtime ternaries and the joint_out_generator.
@@ -452,11 +446,6 @@ void kernel_main() {
     constexpr auto out_args = TensorAccessorArgs<35>();
     constexpr auto joint_out_args = TensorAccessorArgs<out_args.next_compile_time_args_offset()>();
     constexpr auto stats_args = TensorAccessorArgs<joint_out_args.next_compile_time_args_offset()>();
-    // Metadata accessor (metadata path only) follows the output accessors and precedes the CB compile
-    // args; gate the offset on kv_pad_from_metadata so the no-metadata program never names a non-accessor
-    // compile arg (fall back to a valid unused accessor offset = out_args' slot 35).
-    constexpr uint32_t meta_args_offset = kv_pad_from_metadata ? stats_args.next_compile_time_args_offset() : 35;
-    constexpr auto meta_args = TensorAccessorArgs<meta_args_offset>();
 
     uint32_t argidx = 0;
     const uint32_t out_addr = get_arg_val<uint32_t>(argidx++);
@@ -464,18 +453,15 @@ void kernel_main() {
     const uint32_t stats_addr = get_arg_val<uint32_t>(argidx++);
     const uint32_t global_q_start = get_arg_val<uint32_t>(argidx++);
     const uint32_t global_q_end = get_arg_val<uint32_t>(argidx++);
-    // Mutable: on the kv_pad_from_metadata path these are recomputed on-device below from metadata[1].
-    uint32_t logical_nt = get_arg_val<uint32_t>(argidx++);
-    uint32_t active_ring_iter_mask = get_arg_val<uint32_t>(argidx++);
-    uint32_t single_valid_kv_chunk_mask = get_arg_val<uint32_t>(argidx++);
+    const uint32_t logical_nt = get_arg_val<uint32_t>(argidx++);
+    const uint32_t active_ring_iter_mask = get_arg_val<uint32_t>(argidx++);
+    const uint32_t single_valid_kv_chunk_mask = get_arg_val<uint32_t>(argidx++);
     RingSDPAOpReceiver fused_op_receiver = RingSDPAOpReceiver(
         false, /* wait_for_op_signal */
         argidx);
 
-    // The stats CB is aliased by role: cb_max_* for deferred norm, cb_lse_* for eager norm. The CB
-    // compile args start after the metadata accessor when it is present (kv_pad_from_metadata).
-    constexpr uint32_t cb_arg_offset =
-        kv_pad_from_metadata ? meta_args.next_compile_time_args_offset() : stats_args.next_compile_time_args_offset();
+    // The stats CB is aliased by role: cb_max_* for deferred norm, cb_lse_* for eager norm.
+    constexpr uint32_t cb_arg_offset = stats_args.next_compile_time_args_offset();
     constexpr uint32_t cb_mask_in = get_compile_time_arg_val(cb_arg_offset + 3);
     constexpr uint32_t cb_scale_in = get_compile_time_arg_val(cb_arg_offset + 4);
     constexpr uint32_t cb_identity_scale_in = get_compile_time_arg_val(cb_arg_offset + 5);
@@ -494,46 +480,6 @@ void kernel_main() {
     constexpr uint32_t stats_tile_bytes = get_tile_size(cb_max_in);
 
     Noc noc;
-
-    // Trace-safe KV-pad derivation: recompute logical_nt + ring masks on-device from kv_actual_isl =
-    // kv_actual_isl tensor[0] (the per-core logical_nt/masks args are placeholders on the metadata path
-    // and would be frozen by a captured trace). The writer is a dataflow kernel, so it reads the tensor
-    // directly via NoC into cb_out's L1 scratch (free before the output write loop). chunk_size_t ==
-    // q_chunk_group.
-    if constexpr (kv_pad_from_metadata) {
-        // kv_actual_isl is a 1-element uint32 DRAM tensor (was metadata[1]); its DRAM address is common
-        // runtime arg 0. Read its page 0 (4B).
-        const uint32_t kv_actual_isl_addr = get_common_arg_val<uint32_t>(0);
-        CircularBuffer cb_meta_scratch(cb_out);
-        const uint32_t meta_l1 = cb_meta_scratch.get_write_ptr();
-        // Shared read protocol (async_read page 0 -> barrier -> invalidate_l1_cache -> volatile load). The
-        // invalidate matters here for the same reason it does in the reader, and was previously missing on
-        // this path: the tensor is at a FIXED DRAM address the host refreshes in place between trace
-        // replays, so without it the writer can derive logical_nt / the ring masks from the PRIOR chunk's
-        // kv_actual_isl while the reader uses the fresh one -- a silent reader/writer disagreement.
-        const uint32_t kv_actual_isl =
-            trace_metadata::read_metadata_scalar_u32(noc, meta_args, kv_actual_isl_addr, meta_l1);
-        logical_nt = ring_joint::compute_logical_nt(kv_actual_isl, chunk_size_t * 32, 32);
-        const auto masks = ring_joint::build_ring_work_masks_device(
-            fused_op_receiver.seq.ring_index,
-            ring_size,
-            fused_op_receiver.seq.expected[0],  // backward_writes_expected
-            fused_op_receiver.seq.expected[1],  // forward_writes_expected
-            num_local_k_chunks,
-            Sk_chunk_t,
-            kv_local_padded_Nt,
-            chunked_enabled,
-            chunk_size_t,
-            q_local_padded_Nt,
-            logical_nt,
-            num_joint_k_chunks,
-            L,
-            /*kv_pad_rotation_enabled=*/true,
-            is_causal != 0,
-            is_balanced != 0);
-        active_ring_iter_mask = masks.active_ring_iter_mask;
-        single_valid_kv_chunk_mask = masks.single_valid_kv_chunk_mask;
-    }
 
     const auto out_writer = TensorAccessor(out_args, out_addr);
     const auto joint_out_writer = TensorAccessor(joint_out_args, joint_out_addr);
@@ -566,9 +512,14 @@ void kernel_main() {
     constexpr bool global_n_has_padding = logical_n % (Sk_chunk_t * tt::constants::TILE_HEIGHT) != 0;
     constexpr bool joint_has_padding = L > 0 && L % (Sk_chunk_t * tt::constants::TILE_HEIGHT) != 0;
     constexpr bool needs_lightweight_mask =
-        (local_n_has_padding || global_n_has_padding || joint_has_padding) || diag_tile_enabled;
+        (local_n_has_padding || global_n_has_padding || joint_has_padding) || diag_tile_enabled || has_sliding_window;
     if constexpr (needs_lightweight_mask) {
-        generate_lightweight_mask_tiles<global_n_partial_col, joint_l_partial_col, cb_mask_in, diag_tile_enabled>(noc);
+        generate_lightweight_mask_tiles<
+            global_n_partial_col,
+            joint_l_partial_col,
+            cb_mask_in,
+            (is_causal == 1) || chunked_enabled,
+            sliding_window_size>(noc);
     }
 
     uint32_t ring_index = fused_op_receiver.seq.ring_index;
@@ -586,11 +537,14 @@ void kernel_main() {
 
     // Track non-skipped iters so the first active iter starts with fresh accumulators (matches compute).
     bool seen_active_iter = false;
-    for (uint32_t ring_iter = 0; ring_iter < ring_size; ++ring_iter) {
-        uint32_t ring_id = fused_op_receiver.get_next_ring_id_and_sync();
+    constexpr uint32_t sdpa_ring_iterations = has_sliding_window ? 1 : ring_size;
+    for (uint32_t ring_iter = 0; ring_iter < sdpa_ring_iterations; ++ring_iter) {
+        // Sliding compute consumes all local/halo source ranges in one logical pass, so the
+        // writer sees exactly one final output per Q and never enters deferred staging.
+        uint32_t ring_id = has_sliding_window ? ring_index : fused_op_receiver.get_next_ring_id_and_sync();
         // Host precomputes which ring iterations have useful SDPA work; sync/ring-id sequencing
         // still advances above so writer stays aligned with reader, compute, and all-gather.
-        if (((active_ring_iter_mask >> ring_iter) & 1u) == 0) {
+        if (!has_sliding_window && ((active_ring_iter_mask >> ring_iter) & 1u) == 0) {
             continue;
         }
         const bool do_joint_kv = ring_id == ring_size - 1;
@@ -649,7 +603,41 @@ void kernel_main() {
 
         // Deferred normalization is always paired with streaming compute.
         constexpr bool use_deferred_norm = use_streaming_compute;
-        if constexpr (use_deferred_norm) {
+
+        if constexpr (has_sliding_window) {
+            // Sliding compute consumes every local/halo source for a Q in one pass. There is
+            // therefore no intermediate state to restore or save: wait for the final result,
+            // write it once, and advance directly to the next assigned Q.
+            const bool single_q_chunk = (global_q_end - global_q_start == 1);
+            for (uint32_t q_index = 0; q_index + global_q_start < global_q_end; ++q_index) {
+                const auto decoded_q =
+                    decompose_global_q_index(global_q_start + q_index, num_q_chunks, NH, use_zigzag_balancing);
+                const uint32_t nb = decoded_q.nb;
+                const uint32_t nq = decoded_q.nq;
+                const uint32_t q_chunk = decoded_q.q_chunk;
+                const auto qi = get_q_chunk_info<has_joint_q>(
+                    q_chunk, nb, nq, num_local_q_chunks, Sq_chunk_t, vDHt, Lt, q_local_padded_Nt);
+                const uint32_t end_seq_tile = get_end_seq_tile<has_joint_q>(qi, ring_id, Lt, q_local_padded_Nt);
+
+                if (!single_q_chunk) {
+                    CircularBuffer cb_sig(cb_signal);
+                    cb_sig.wait_front(1);
+                    cb_sig.pop_front(1);
+                }
+
+                const auto& gen = [&]() -> const auto& {
+                    if constexpr (has_joint_q) {
+                        if (qi.is_joint_q) {
+                            return joint_out_generator;
+                        }
+                    }
+                    return out_generator;
+                }();
+                write_block_row_grouped_trid<output_has_no_padding>(
+                    noc, gen, qi.out_slice, end_seq_tile, cb_out, tile_bytes, out_subblock_h, /*flush_trid=*/0);
+            }
+            noc.async_write_barrier();
+        } else if constexpr (use_deferred_norm) {
             // Deferred norm: accumulates across ring iterations with exponential rescaling.
             // Single Q-chunk: accumulators persist in L1, write final output on last ring_iter.
             // Multi Q-chunk: raw accumulators round-trip through DRAM between ring iterations.
@@ -676,10 +664,11 @@ void kernel_main() {
                 if (barrier_first) {
                     noc.async_write_barrier<NocOptions::TXN_ID>({.trid = pf_trid});
                 }
-                const uint32_t gq = remap_q_index(global_q_start + pf_q_index, num_q_chunks, use_zigzag_balancing);
-                const uint32_t nb_pf = gq / (NH * num_q_chunks);
-                const uint32_t nq_pf = (gq % (NH * num_q_chunks)) / num_q_chunks;
-                const uint32_t qc_pf = gq % num_q_chunks;
+                const auto decoded_q =
+                    decompose_global_q_index(global_q_start + pf_q_index, num_q_chunks, NH, use_zigzag_balancing);
+                const uint32_t nb_pf = decoded_q.nb;
+                const uint32_t nq_pf = decoded_q.nq;
+                const uint32_t qc_pf = decoded_q.q_chunk;
                 const auto qi_pf = get_q_chunk_info<has_joint_q>(
                     qc_pf, nb_pf, nq_pf, num_local_q_chunks, Sq_chunk_t, vDHt, Lt, q_local_padded_Nt);
                 const auto& gen_pf = [&]() -> const auto& {
@@ -759,11 +748,11 @@ void kernel_main() {
             };
 
             for (uint32_t q_index = 0; q_index + global_q_start < global_q_end; ++q_index) {
-                uint32_t global_q_chunk = remap_q_index(global_q_start + q_index, num_q_chunks, use_zigzag_balancing);
-
-                const uint32_t nb = global_q_chunk / (NH * num_q_chunks);
-                const uint32_t nq = (global_q_chunk % (NH * num_q_chunks)) / num_q_chunks;
-                const uint32_t q_chunk = global_q_chunk % num_q_chunks;
+                const auto decoded_q =
+                    decompose_global_q_index(global_q_start + q_index, num_q_chunks, NH, use_zigzag_balancing);
+                const uint32_t nb = decoded_q.nb;
+                const uint32_t nq = decoded_q.nq;
+                const uint32_t q_chunk = decoded_q.q_chunk;
 
                 const bool balanced_skip_q = q_chunk < half_sequence && is_balanced && ring_index < ring_id;
 
@@ -872,12 +861,11 @@ void kernel_main() {
             }
         } else {
             for (uint32_t q_iter = 0; q_iter + global_q_start < global_q_end; ++q_iter) {
-                uint32_t global_q_chunk = remap_q_index(global_q_start + q_iter, num_q_chunks, use_zigzag_balancing);
-
-                // global_q_chunk is index into `B * NH * num_q_chunks`. Need to get nb, nq, q_chunk from this.
-                const uint32_t nb = global_q_chunk / (NH * num_q_chunks);
-                const uint32_t nq = (global_q_chunk % (NH * num_q_chunks)) / num_q_chunks;
-                const uint32_t q_chunk = global_q_chunk % num_q_chunks;
+                const auto decoded_q =
+                    decompose_global_q_index(global_q_start + q_iter, num_q_chunks, NH, use_zigzag_balancing);
+                const uint32_t nb = decoded_q.nb;
+                const uint32_t nq = decoded_q.nq;
+                const uint32_t q_chunk = decoded_q.q_chunk;
 
                 const auto qi = get_q_chunk_info<has_joint_q>(
                     q_chunk, nb, nq, num_local_q_chunks, Sq_chunk_t, vDHt, Lt, q_local_padded_Nt);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/ring_joint_chain_layout.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/ring_joint_chain_layout.hpp
@@ -8,7 +8,7 @@
 
 namespace ttnn::operations::transformer::sdpa::ring_joint {
 
-constexpr uint32_t kChainConfigRuntimeArgCount = 18;
+constexpr uint32_t kChainConfigRuntimeArgCount = 16;
 
 constexpr uint32_t kChainSenderSemaphoreCompileArgOffset = 0;
 constexpr uint32_t kChainReceiverSemaphoreCompileArgOffset = 1;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/sliding_window_work_plan.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/sliding_window_work_plan.hpp
@@ -1,0 +1,172 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <array>
+#include <cstdint>
+
+namespace ttnn::operations::transformer::sdpa::ring_joint {
+
+struct SlidingKVSourceRange {
+    uint32_t source_ring_id = 0;
+    uint32_t first_k_chunk = 0;
+    uint32_t last_k_chunk = 0;
+    uint32_t first_compact_k_chunk = 0;
+
+    constexpr uint32_t k_chunk_count() const { return last_k_chunk - first_k_chunk; }
+};
+
+struct SlidingKChunkRef {
+    uint32_t source_ring_id = 0;
+    uint32_t source_k_chunk = 0;
+    uint32_t compact_k_chunk = 0;
+};
+
+constexpr uint32_t chunked_sliding_halo_tile_rows(
+    uint32_t sliding_window_tokens, uint32_t tile_height, uint32_t k_chunk_tile_rows) {
+    if (tile_height == 0 || k_chunk_tile_rows == 0) {
+        return 0;
+    }
+    const uint32_t left_window_tokens = sliding_window_tokens > 0 ? sliding_window_tokens - 1 : 0;
+    const uint32_t k_chunk_tokens = k_chunk_tile_rows * tile_height;
+    return ((left_window_tokens + k_chunk_tokens - 1) / k_chunk_tokens) * k_chunk_tile_rows;
+}
+
+constexpr uint32_t chunked_sliding_halo_source_start_tile(
+    uint32_t source_device,
+    uint32_t q_local_tile_rows,
+    uint32_t ring_size,
+    uint32_t logical_k_tile_rows,
+    uint32_t halo_tile_rows) {
+    const uint32_t q_group_tile_rows = q_local_tile_rows * ring_size;
+    if (q_group_tile_rows == 0 || logical_k_tile_rows < 2 * q_group_tile_rows || halo_tile_rows > q_local_tile_rows) {
+        return 0;
+    }
+    const uint32_t current_group = logical_k_tile_rows / q_group_tile_rows - 1;
+    const uint32_t source_group = source_device + 1 == ring_size ? current_group - 1 : current_group;
+    return source_group * q_local_tile_rows + q_local_tile_rows - halo_tile_rows;
+}
+
+// Device-compatible work plan for one Q chunk. The supported 128-token window
+// touches at most the Q-owned region and its predecessor, so two fixed ranges
+// cover the chunked layout without a dynamic container.
+struct SlidingQWorkPlan {
+    static constexpr uint32_t max_source_ranges = 2;
+
+    std::array<SlidingKVSourceRange, max_source_ranges> source_ranges{};
+    uint32_t source_range_count = 0;
+    uint32_t total_k_chunk_count = 0;
+    bool is_valid = false;
+
+    constexpr SlidingKChunkRef k_chunk_at(uint32_t work_index) const {
+        for (uint32_t range_index = 0; range_index < source_range_count; ++range_index) {
+            const auto& range = source_ranges[range_index];
+            if (work_index < range.k_chunk_count()) {
+                return SlidingKChunkRef{
+                    .source_ring_id = range.source_ring_id,
+                    .source_k_chunk = range.first_k_chunk + work_index,
+                    .compact_k_chunk = range.first_compact_k_chunk + work_index,
+                };
+            }
+            work_index -= range.k_chunk_count();
+        }
+        return {};
+    }
+};
+
+// Chunked prefill stores each global Q-sized group as one local slab per ring
+// device. A window can need only the local slab and the cyclic predecessor's
+// tail; device 0 consumes the final device's tail from the preceding group.
+constexpr SlidingQWorkPlan build_sliding_q_work_plan(
+    uint32_t q_local_start_tile,
+    uint32_t q_chunk_tile_rows,
+    uint32_t q_device_index,
+    uint32_t q_local_tile_rows,
+    uint32_t ring_size,
+    uint32_t sliding_window_tokens,
+    uint32_t tile_height,
+    uint32_t k_local_tile_rows,
+    uint32_t k_chunk_tile_rows,
+    uint32_t logical_k_tile_rows) {
+    SlidingQWorkPlan plan;
+    if (q_chunk_tile_rows == 0 || q_local_tile_rows == 0 || ring_size == 0 || sliding_window_tokens == 0 ||
+        tile_height == 0 || k_chunk_tile_rows == 0 || q_local_tile_rows % k_chunk_tile_rows != 0) {
+        return plan;
+    }
+
+    const uint32_t q_group_tile_rows = ring_size * q_local_tile_rows;
+    if (logical_k_tile_rows < 2 * q_group_tile_rows || q_local_start_tile + q_chunk_tile_rows > q_local_tile_rows) {
+        return plan;
+    }
+
+    const uint32_t halo_tile_rows =
+        chunked_sliding_halo_tile_rows(sliding_window_tokens, tile_height, k_chunk_tile_rows);
+    if (halo_tile_rows > q_local_tile_rows) {
+        return plan;
+    }
+
+    const uint32_t current_q_group_start = logical_k_tile_rows - q_group_tile_rows;
+    const uint32_t global_q_start_tile =
+        current_q_group_start + q_device_index * q_local_tile_rows + q_local_start_tile;
+    const uint32_t left_window_tokens = sliding_window_tokens > 0 ? sliding_window_tokens - 1 : 0;
+    const uint32_t left_window_tile_rows = tile_height == 0 ? 0 : (left_window_tokens + tile_height - 1) / tile_height;
+    const uint32_t window_start_tile =
+        global_q_start_tile > left_window_tile_rows ? global_q_start_tile - left_window_tile_rows : 0;
+    const uint32_t window_end_tile = global_q_start_tile + q_chunk_tile_rows;
+
+    const uint32_t clipped_window_start =
+        window_start_tile < logical_k_tile_rows ? window_start_tile : logical_k_tile_rows;
+    const uint32_t clipped_window_end = window_end_tile < logical_k_tile_rows ? window_end_tile : logical_k_tile_rows;
+    if (clipped_window_start >= clipped_window_end) {
+        return plan;
+    }
+
+    const uint32_t first_slab = clipped_window_start / q_local_tile_rows;
+    const uint32_t last_slab = (clipped_window_end - 1) / q_local_tile_rows;
+    for (uint32_t slab = first_slab; slab <= last_slab; ++slab) {
+        const uint32_t source_ring_id = slab % ring_size;
+        const uint32_t source_group = slab / ring_size;
+        const uint32_t slab_global_start = slab * q_local_tile_rows;
+        const uint32_t range_global_start =
+            clipped_window_start > slab_global_start ? clipped_window_start : slab_global_start;
+        const uint32_t slab_global_end = slab_global_start + q_local_tile_rows;
+        const uint32_t range_global_end = clipped_window_end < slab_global_end ? clipped_window_end : slab_global_end;
+        const uint32_t source_local_base = source_group * q_local_tile_rows;
+        const uint32_t range_local_start = source_local_base + range_global_start - slab_global_start;
+        const uint32_t range_local_end = source_local_base + range_global_end - slab_global_start;
+        if (range_local_start >= k_local_tile_rows) {
+            continue;
+        }
+        const uint32_t clipped_range_local_end =
+            range_local_end < k_local_tile_rows ? range_local_end : k_local_tile_rows;
+        if (range_local_start >= clipped_range_local_end) {
+            continue;
+        }
+
+        const uint32_t first_k_chunk = range_local_start / k_chunk_tile_rows;
+        const uint32_t last_k_chunk = (clipped_range_local_end + k_chunk_tile_rows - 1) / k_chunk_tile_rows;
+        uint32_t first_compact_k_chunk = 0;
+        if (source_ring_id != q_device_index) {
+            const uint32_t halo_source_start = chunked_sliding_halo_source_start_tile(
+                source_ring_id, q_local_tile_rows, ring_size, logical_k_tile_rows, halo_tile_rows);
+            first_compact_k_chunk = (first_k_chunk * k_chunk_tile_rows - halo_source_start) / k_chunk_tile_rows;
+        }
+        if (plan.source_range_count == SlidingQWorkPlan::max_source_ranges) {
+            return SlidingQWorkPlan{};
+        }
+        auto& range = plan.source_ranges[plan.source_range_count++];
+        range = SlidingKVSourceRange{
+            .source_ring_id = source_ring_id,
+            .first_k_chunk = first_k_chunk,
+            .last_k_chunk = last_k_chunk,
+            .first_compact_k_chunk = first_compact_k_chunk,
+        };
+        plan.total_k_chunk_count += range.k_chunk_count();
+    }
+    plan.is_valid = plan.total_k_chunk_count != 0;
+    return plan;
+}
+
+}  // namespace ttnn::operations::transformer::sdpa::ring_joint

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation.cpp
@@ -15,6 +15,7 @@
 #include "ttnn/operations/ccl/ccl_common.hpp"
 #include "ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_device_operation.hpp"
 #include "ttnn/operations/transformer/sdpa/device/kernels/ring_joint_chain_layout.hpp"
+#include "ttnn/operations/transformer/sdpa/device/kernels/sliding_window_work_plan.hpp"
 #include "ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation_types.hpp"
 #include "ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.hpp"
 #include "ttnn/operations/transformer/sdpa/device/sdpa_perf_model.hpp"
@@ -29,6 +30,12 @@ using namespace experimental::ccl;
 namespace {
 
 namespace ring_joint = ttnn::operations::transformer::sdpa::ring_joint;
+
+uint32_t sliding_halo_token_count(uint32_t sliding_window_size, uint32_t k_chunk_size) {
+    return ring_joint::chunked_sliding_halo_tile_rows(
+               sliding_window_size, tt::constants::TILE_HEIGHT, k_chunk_size / tt::constants::TILE_HEIGHT) *
+           tt::constants::TILE_HEIGHT;
+}
 
 // Chunked causal prefill does not have the same valid-pair geometry as a full causal
 // Sq x Sk attention window. A new Q chunk attends to all prior K/V tokens as a full
@@ -61,11 +68,41 @@ int compute_chunked_causal_sdpa_ideal_cycles(
         batch_size, num_heads_q, valid_pairs_per_device, DH, DV, math_fidelity, num_cores);
 }
 
+int compute_sliding_window_sdpa_ideal_cycles(
+    uint32_t batch_size,
+    uint32_t num_heads_q,
+    uint32_t q_rows_per_device,
+    uint32_t ring_size,
+    uint32_t q_global_start,
+    uint32_t window_size,
+    uint32_t DH,
+    uint32_t DV,
+    tt::tt_metal::MathFidelity math_fidelity,
+    int num_cores) {
+    if (ring_size == 0 || num_cores <= 0 || q_rows_per_device == 0 || window_size == 0) {
+        return 0;
+    }
+
+    const uint64_t global_q_rows = static_cast<uint64_t>(q_rows_per_device) * ring_size;
+    const auto valid_pair_prefix = [window_size](uint64_t q_end) -> double {
+        const uint64_t ramp_rows = std::min<uint64_t>(q_end, window_size);
+        const double ramp_pairs = static_cast<double>(ramp_rows) * static_cast<double>(ramp_rows + 1) / 2.0;
+        const double steady_pairs = static_cast<double>(q_end - ramp_rows) * static_cast<double>(window_size);
+        return ramp_pairs + steady_pairs;
+    };
+    const double valid_pairs_global =
+        valid_pair_prefix(static_cast<uint64_t>(q_global_start) + global_q_rows) - valid_pair_prefix(q_global_start);
+    const double valid_pairs_per_device = valid_pairs_global / static_cast<double>(ring_size);
+    return operations::transformer::sdpa::compute_sdpa_ideal_cycles_for_valid_pairs(
+        batch_size, num_heads_q, valid_pairs_per_device, DH, DV, math_fidelity, num_cores);
+}
+
 void validate_ring_joint_all_gather_on_program_cache_miss(
     const ttnn::experimental::prim::RingAttentionAllGatherAsyncParams& operation_attributes,
     const ttnn::experimental::prim::RingAttentionAllGatherAsyncInputs& tensor_args,
     // Single-slot gather writes one cache slot to gathered slot 0, so allow a batch-1 output.
-    bool allow_single_slot_output) {
+    bool allow_single_slot_output,
+    std::optional<uint32_t> compact_gather_dim_minimum) {
     const auto& input_tensors = tensor_args.input_tensor;
     TT_FATAL(
         !input_tensors.empty(), "Error, Input tensor size should be greater than 0 but has {}", input_tensors.size());
@@ -133,15 +170,15 @@ void validate_ring_joint_all_gather_on_program_cache_miss(
             expected_output_shape[operation_attributes.dim] *= operation_attributes.ring_size;
             for (int d = 0; d < static_cast<int>(output_shape.rank()); ++d) {
                 if (d == operation_attributes.dim) {
+                    const uint32_t minimum =
+                        compact_gather_dim_minimum.value_or(static_cast<uint32_t>(expected_output_shape[d]));
                     TT_FATAL(
-                        output_shape[d] >= expected_output_shape[d],
-                        "Output tensor {} gather dim {} too small: got {}, expected >= {} "
-                        "(= input_dim * ring_size {})",
+                        output_shape[d] >= minimum,
+                        "Output tensor {} gather dim {} too small: got {}, expected >= {}",
                         i,
                         d,
                         output_shape[d],
-                        expected_output_shape[d],
-                        operation_attributes.ring_size);
+                        minimum);
                 } else if (allow_single_slot_output && d == 0) {
                     // Single-slot gather targets gathered slot 0: batch-1 expected, full-batch also ok.
                     TT_FATAL(
@@ -223,6 +260,24 @@ void validate_runtime_patched_scalars(const RingJointSDPAParams& args, const Rin
             new_actual_isl,
             chunk_capacity);
     }
+
+    if (args.has_sliding_window() && tensor_args.is_chunked()) {
+        const auto q_group_size = tensor_args.input_q.logical_shape()[2] * args.ring_size;
+        TT_FATAL(
+            args.logical_n >= 2 * q_group_size,
+            "Chunked sliding attention requires a complete predecessor and current Q group");
+        TT_FATAL(
+            args.logical_n % q_group_size == 0,
+            "Chunked sliding attention requires logical_n to end on a complete ring-group boundary. Got "
+            "logical_n={}, group size={}",
+            args.logical_n,
+            q_group_size);
+        if (args.has_kv_pad_rotation()) {
+            TT_FATAL(
+                args.logical_n - args.kv_actual_isl.value() == q_group_size,
+                "Chunked sliding KV-pad rotation requires the new Q chunk to fill exactly one ring group");
+        }
+    }
 }
 
 }  // namespace
@@ -231,6 +286,10 @@ void RingJointSDPADeviceOperation::validate_on_program_cache_miss(
     const RingJointSDPAParams& args, const RingJointSDPAInputs& tensor_args) {
     const auto& input_tensor_q = tensor_args.input_q;
     const auto& gathered_input_tensor_k = tensor_args.gathered_k;
+
+    TT_FATAL(
+        !args.sliding_window_size.has_value() || args.has_sliding_window(),
+        "RingJointSDPA sliding_window_size must be greater than zero when provided");
 
     const bool has_input_v = tensor_args.input_v.has_value();
     const bool has_gathered_v = tensor_args.gathered_v.has_value();
@@ -242,14 +301,36 @@ void RingJointSDPADeviceOperation::validate_on_program_cache_miss(
             tensor_args.joint_v.has_value() == has_joint_tensors,
         "Joint tensors must be provided all together or omitted altogether");
 
-    // Metadata path: the two per-request tensors are supplied together or not at all. has_metadata() and
-    // the SDPA/all-gather program factories otherwise nullopt-deref kv_actual_isl when only slot_id is set
-    // (the public API always sets both, but a direct prim caller could pass one).
-    TT_FATAL(
-        tensor_args.slot_id.has_value() == tensor_args.kv_actual_isl.has_value(),
-        "metadata tensors slot_id and kv_actual_isl must be supplied together (got slot_id={}, kv_actual_isl={})",
-        tensor_args.slot_id.has_value(),
-        tensor_args.kv_actual_isl.has_value());
+    if (tensor_args.attention_sink.has_value()) {
+        const auto& attention_sink = tensor_args.attention_sink.value();
+        TT_FATAL(args.is_causal, "RingJointSDPA attention_sink is supported only for causal attention");
+        TT_FATAL(!has_joint_tensors, "RingJointSDPA attention_sink does not support joint attention tensors");
+        TT_FATAL(!has_latent_v, "RingJointSDPA attention_sink does not support latent-V / Ring-MLA attention");
+        TT_FATAL(attention_sink.storage_type() == StorageType::DEVICE, "Attention sink tensor must be on device");
+        TT_FATAL(attention_sink.buffer() != nullptr, "Attention sink tensor must be allocated on device");
+        TT_FATAL(
+            input_tensor_q.device() == attention_sink.device(),
+            "Attention sink must be on the same mesh device as Q/K/V");
+        TT_FATAL(attention_sink.layout() == Layout::TILE, "Attention sink must be tilized");
+        TT_FATAL(attention_sink.dtype() == DataType::BFLOAT16, "GPT-OSS attention sink must be BF16");
+        TT_FATAL(
+            attention_sink.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM, "Attention sink must be in DRAM");
+
+        const auto& sink_shape = attention_sink.logical_shape();
+        const auto& q_shape = input_tensor_q.logical_shape();
+        TT_FATAL(sink_shape.rank() == 4, "Attention sink must have rank 4, got rank {}", sink_shape.rank());
+        TT_FATAL(sink_shape[0] == 1, "Attention sink batch dimension must be 1, got {}", sink_shape[0]);
+        TT_FATAL(
+            sink_shape[1] == q_shape[1],
+            "Attention sink local num_heads must match Q. Got sink: {}, Q: {}",
+            sink_shape[1],
+            q_shape[1]);
+        TT_FATAL(sink_shape[2] == 1, "Attention sink sequence dimension must be 1, got {}", sink_shape[2]);
+        TT_FATAL(sink_shape[3] == 1, "Attention sink hidden dimension must be 1, got {}", sink_shape[3]);
+        TT_FATAL(
+            !get_fp32_dest_acc_en(args.compute_kernel_config),
+            "RingJointSDPA attention_sink requires streaming compute; set fp32_dest_acc_en=false");
+    }
 
     std::vector<Tensor> sdpa_input_tensors = {input_tensor_q, gathered_input_tensor_k};
     if (has_gathered_v) {
@@ -261,10 +342,16 @@ void RingJointSDPADeviceOperation::validate_on_program_cache_miss(
         sdpa_input_tensors.push_back(tensor_args.joint_v.value());
     }
 
+    std::optional<uint32_t> compact_gather_dim_minimum;
+    if (args.has_sliding_window()) {
+        compact_gather_dim_minimum =
+            sliding_halo_token_count(args.sliding_window_size.value(), args.get_k_chunk_size());
+    }
     validate_ring_joint_all_gather_on_program_cache_miss(
         args.all_gather_operation_attributes,
         args.all_gather_tensor_args,
-        args.has_indexed_kv_cache() || tensor_args.has_metadata());
+        args.has_indexed_kv_cache(),
+        compact_gather_dim_minimum);
 
     // Check that SDPA coregrid does not overlap with AllGather coregrid
     TT_FATAL(args.program_config.has_value(), "Program config must be provided");
@@ -289,9 +376,7 @@ void RingJointSDPADeviceOperation::validate_on_program_cache_miss(
     const auto joint_q_shape = has_joint_tensors ? tensor_args.joint_q.value().logical_shape() : q_shape;
     const auto joint_k_shape = has_joint_tensors ? tensor_args.joint_k.value().logical_shape() : q_shape;
     const auto joint_v_shape = has_joint_tensors ? tensor_args.joint_v.value().logical_shape() : q_shape;
-    // Metadata path is indexed (single-slot) too -- the slot is read on-device from metadata[0] instead
-    // of the host kv_cache_batch_idx scalar -- so the same K/V-cache-batch shape exemptions apply.
-    const bool has_indexed_kv_cache = args.has_indexed_kv_cache() || tensor_args.has_metadata();
+    const bool has_indexed_kv_cache = args.has_indexed_kv_cache();
     const uint32_t NVH = tensor_args.v_num_heads();
     const uint32_t VDH = tensor_args.v_head_dim(args.latent_v_head_dim);
 
@@ -331,7 +416,8 @@ void RingJointSDPADeviceOperation::validate_on_program_cache_miss(
     const auto NKH = k_shape[1];
     const auto N_local_q = q_shape[2];
     const auto N_local_kv = tensor_args.local_kv_seq_len();
-    const auto N_global = k_shape[2];
+    const auto gathered_buffer_n = k_shape[2];
+    const auto N_global = args.has_sliding_window() ? N_local_kv * args.ring_size : gathered_buffer_n;
     const auto L = has_joint_tensors ? joint_q_shape[2] : 0;
     const auto DH = q_shape[3];
     const uint32_t v_local_seq =
@@ -340,6 +426,77 @@ void RingJointSDPADeviceOperation::validate_on_program_cache_miss(
     auto q_chunk_size = args.get_q_chunk_size();
     auto k_chunk_size = args.get_k_chunk_size();
     const bool has_kv_pad_rotation = args.has_kv_pad_rotation();
+
+    if (args.has_sliding_window()) {
+        constexpr uint32_t gpt_oss_window_size = 128;
+        constexpr uint32_t gpt_oss_local_q_heads = 8;
+        constexpr uint32_t gpt_oss_local_kv_heads = 1;
+        constexpr uint32_t gpt_oss_head_dim = 64;
+        const bool supported_q_chunk = q_chunk_size == 64 || q_chunk_size == 128;
+        const bool supported_k_chunk = k_chunk_size == 128;
+        TT_FATAL(
+            args.sliding_window_size.value() == gpt_oss_window_size,
+            "Ring sliding-window attention supports the GPT-OSS {}-token window, got {}",
+            gpt_oss_window_size,
+            args.sliding_window_size.value());
+        TT_FATAL(
+            args.ring_size == 4 || args.ring_size == 8,
+            "GPT-OSS sliding attention supports the SP4 production ring or SP8 test ring, got SP{}",
+            args.ring_size);
+        TT_FATAL(
+            B == 1 || (B == 2 && args.ring_size == 8),
+            "GPT-OSS sliding attention supports batch 1 or the SP8 batch-2 surrogate, got B={} SP{}",
+            B,
+            args.ring_size);
+        TT_FATAL(
+            NQH == gpt_oss_local_q_heads && NKH == gpt_oss_local_kv_heads && tensor_args.v_num_heads() == 1,
+            "GPT-OSS sliding attention requires local heads 8Q:1K:1V, got {}Q:{}K:{}V",
+            NQH,
+            NKH,
+            tensor_args.v_num_heads());
+        TT_FATAL(
+            DH == gpt_oss_head_dim && tensor_args.v_head_dim(args.latent_v_head_dim) == gpt_oss_head_dim,
+            "GPT-OSS sliding attention requires Q/K/V head dimension {}, got Q={} V={}",
+            gpt_oss_head_dim,
+            DH,
+            tensor_args.v_head_dim(args.latent_v_head_dim));
+        TT_FATAL(has_input_v && has_gathered_v && !has_latent_v, "GPT-OSS sliding attention requires separate K and V");
+        TT_FATAL(
+            input_tensor_q.dtype() == DataType::BFLOAT16 && tensor_args.input_k.dtype() == DataType::BFLOAT8_B &&
+                tensor_args.input_v->dtype() == DataType::BFLOAT8_B &&
+                gathered_input_tensor_k.dtype() == DataType::BFLOAT8_B &&
+                tensor_args.gathered_v->dtype() == DataType::BFLOAT8_B,
+            "GPT-OSS sliding attention requires BF16 Q and BFP8_B K/V");
+        TT_FATAL(
+            gathered_buffer_n < N_local_kv * args.ring_size,
+            "GPT-OSS sliding attention requires a compact halo buffer, got gathered rows {} for {} global rows",
+            gathered_buffer_n,
+            N_local_kv * args.ring_size);
+        TT_FATAL(
+            supported_q_chunk && supported_k_chunk,
+            "GPT-OSS sliding attention supports Q chunks 64/128 and K chunk 128, got Q={} K={}",
+            q_chunk_size,
+            k_chunk_size);
+        TT_FATAL(args.is_causal, "Ring sliding-window attention is currently causal-only");
+        TT_FATAL(is_chunked, "Ring sliding-window attention requires chunked prefill");
+        TT_FATAL(!args.is_balanced, "Chunked ring sliding-window attention requires is_balanced=false");
+        TT_FATAL(!args.is_cross, "Ring sliding-window attention does not support cross attention");
+        TT_FATAL(L == 0, "Ring sliding-window attention does not support joint tokens");
+        const uint32_t halo_tokens = sliding_halo_token_count(gpt_oss_window_size, k_chunk_size);
+        TT_FATAL(
+            N_local_q % q_chunk_size == 0,
+            "q_chunk_size must divide the per-device Q slab for chunked sliding attention");
+        TT_FATAL(
+            N_local_q % k_chunk_size == 0,
+            "k_chunk_size must divide the per-device Q slab for chunked sliding attention");
+        TT_FATAL(
+            halo_tokens <= N_local_q,
+            "Chunked GPT-OSS halo {} exceeds the per-device Q slab {}",
+            halo_tokens,
+            N_local_q);
+    } else {
+        TT_FATAL(B == 1, "Non-sliding RingJointSDPA supports batch size 1, got B={}", B);
+    }
 
     TT_FATAL(!(L != 0 && args.is_causal), "Causality is enabled only for ring attention");
 
@@ -648,60 +805,6 @@ RingJointSDPAResult RingJointSDPADeviceOperation::create_output_tensors(
     };
 }
 
-ttsl::hash::hash_t RingJointSDPADeviceOperation::compute_program_hash(
-    const RingJointSDPAParams& args, const RingJointSDPAInputs& tensor_args) {
-    const bool kv_pad_rotation_enabled = args.has_kv_pad_rotation();
-    const auto cache_key_logical_n = kv_pad_rotation_enabled ? 0 : args.logical_n;
-
-    std::vector<Tensor> input_tensors = {tensor_args.input_q, tensor_args.input_k};
-    if (tensor_args.input_v.has_value()) {
-        input_tensors.emplace_back(tensor_args.input_v.value());
-    }
-    if (tensor_args.joint_q.has_value()) {
-        input_tensors.emplace_back(tensor_args.joint_q.value());
-        input_tensors.emplace_back(tensor_args.joint_k.value());
-    }
-    if (tensor_args.joint_v.has_value()) {
-        input_tensors.emplace_back(tensor_args.joint_v.value());
-    }
-    input_tensors.emplace_back(tensor_args.gathered_k);
-    if (tensor_args.gathered_v.has_value()) {
-        input_tensors.emplace_back(tensor_args.gathered_v.value());
-    }
-    return tt::tt_metal::operation::hash_operation<RingJointSDPADeviceOperation>(
-        input_tensors,
-        args.joint_strategy,
-        args.scale,
-        args.is_causal,
-        args.is_balanced,
-        args.is_cross,
-        cache_key_logical_n,
-        args.ring_size,
-        args.compute_kernel_config,
-        args.program_config,
-        args.ccl_core_grid_offset,
-        args.kv_cache_batch_idx.has_value(),
-        kv_pad_rotation_enabled,
-        // Metadata presence (never the per-chunk VALUES) keeps the trace-safe metadata program from
-        // colliding with the scalar program; one cached program is reused across all chunks/users.
-        tensor_args.has_metadata(),
-        // (user, layer)-major KV-cache batch factor. Unlike kv_cache_batch_idx (re-patched per dispatch),
-        // these are baked into the readers' create-time args (common arg 1/2 on SDPA; reader rt-args on
-        // all-gather) and are NOT re-patched on the metadata path. So each (num_layers, layer_idx) must
-        // key a distinct cached program -- otherwise layer N would replay layer M's baked layer_idx. With
-        // the defaults (1, 0) the hash is unchanged from before, so single-layer callers reuse one program.
-        args.kv_cache_num_layers,
-        args.kv_cache_layer_idx,
-        tensor_args.has_latent_v(),
-        tensor_args.v_num_heads(),
-        tensor_args.v_head_dim(args.latent_v_head_dim),
-        // all_gather sub-op: hash its attributes + inputs by reflection (main removed the explicit
-        // RingAttentionAllGatherAsyncDeviceOperation::compute_program_hash; its default hash crefs these two,
-        // exactly as RingJointSDPAParams::attribute_values does).
-        args.all_gather_operation_attributes,
-        args.all_gather_tensor_args);
-}
-
 tt::tt_metal::operation::OpPerformanceModelGeneral<Tensors> RingJointSDPADeviceOperation::create_op_performance_model(
     const RingJointSDPAParams& args, const RingJointSDPAInputs& tensor_args, RingJointSDPAResult& output_tensors) {
     Tensors input_tensors = {tensor_args.input_q, tensor_args.input_k};
@@ -718,6 +821,9 @@ tt::tt_metal::operation::OpPerformanceModelGeneral<Tensors> RingJointSDPADeviceO
     input_tensors.emplace_back(tensor_args.gathered_k);
     if (tensor_args.gathered_v.has_value()) {
         input_tensors.emplace_back(tensor_args.gathered_v.value());
+    }
+    if (tensor_args.attention_sink.has_value()) {
+        input_tensors.emplace_back(tensor_args.attention_sink.value());
     }
 
     auto& output_tensor = output_tensors[RING_JOINT_SDPA_OUTPUT_IDX];
@@ -745,6 +851,26 @@ tt::tt_metal::operation::OpPerformanceModelGeneral<Tensors> RingJointSDPADeviceO
     const uint32_t L = tensor_args.joint_q.has_value() ? tensor_args.joint_q.value().logical_shape()[2] : 0;
     const uint32_t DH = q_shape[3];
     const uint32_t DV = tensor_args.v_head_dim(args.latent_v_head_dim);
+
+    if (args.has_sliding_window() && !has_joint_tensors) {
+        const uint32_t q_chunks = tt::div_up(N_local, args.get_q_chunk_size());
+        const uint32_t scheduled_q_work = B * NQH * q_chunks;
+        const uint32_t active_cores = std::min<uint32_t>(grid.x * grid.y, scheduled_q_work);
+        const uint32_t q_global_start =
+            static_cast<uint32_t>(args.logical_n) - N_local * static_cast<uint32_t>(args.ring_size);
+        int ideal_cycles = compute_sliding_window_sdpa_ideal_cycles(
+            B,
+            NQH,
+            N_local,
+            static_cast<uint32_t>(args.ring_size),
+            q_global_start,
+            args.sliding_window_size.value(),
+            DH,
+            DV,
+            fidelity,
+            active_cores);
+        return operation::OpPerformanceModelGeneral<Tensors>(input_tensors, output_tensors, ideal_cycles);
+    }
 
     if (args.is_causal && args.has_kv_pad_rotation() && !has_joint_tensors) {
         const uint32_t logical_n = static_cast<uint32_t>(args.logical_n);
@@ -797,10 +923,8 @@ RingJointSDPAResult ring_joint_scaled_dot_product_attention(
     const std::optional<uint32_t> kv_cache_batch_idx,
     const std::optional<uint32_t> kv_actual_isl,
     const std::optional<uint32_t> latent_v_head_dim,
-    const std::optional<ttnn::Tensor>& slot_id,
-    const std::optional<ttnn::Tensor>& kv_actual_isl_tensor,
-    const uint32_t kv_cache_num_layers,
-    const uint32_t kv_cache_layer_idx) {
+    const std::optional<ttnn::Tensor>& attention_sink,
+    const std::optional<uint32_t> sliding_window_size) {
     using OperationType = ttnn::prim::RingJointSDPADeviceOperation;
 
     auto kernel_config_val = init_device_compute_kernel_config(
@@ -882,8 +1006,7 @@ RingJointSDPAResult ring_joint_scaled_dot_product_attention(
         kv_cache_batch_idx,
         kv_actual_isl,
         latent_v_head_dim.value_or(0),
-        kv_cache_num_layers,
-        kv_cache_layer_idx);
+        sliding_window_size);
 
     auto tensor_args = OperationType::tensor_args_t{
         .input_q = input_tensor_q,
@@ -894,8 +1017,7 @@ RingJointSDPAResult ring_joint_scaled_dot_product_attention(
         .joint_v = joint_tensor_v,
         .gathered_k = persistent_output_buffer_k,
         .gathered_v = persistent_output_buffer_v,
-        .slot_id = slot_id,
-        .kv_actual_isl = kv_actual_isl_tensor};
+        .attention_sink = attention_sink};
 
     return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation.cpp
@@ -300,6 +300,9 @@ void RingJointSDPADeviceOperation::validate_on_program_cache_miss(
         tensor_args.joint_q.has_value() == has_joint_tensors && tensor_args.joint_k.has_value() == has_joint_tensors &&
             tensor_args.joint_v.has_value() == has_joint_tensors,
         "Joint tensors must be provided all together or omitted altogether");
+    TT_FATAL(
+        tensor_args.slot_id.has_value() == tensor_args.kv_actual_isl.has_value(),
+        "metadata tensors slot_id and kv_actual_isl must be supplied together, or neither supplied");
 
     if (tensor_args.attention_sink.has_value()) {
         const auto& attention_sink = tensor_args.attention_sink.value();
@@ -350,7 +353,7 @@ void RingJointSDPADeviceOperation::validate_on_program_cache_miss(
     validate_ring_joint_all_gather_on_program_cache_miss(
         args.all_gather_operation_attributes,
         args.all_gather_tensor_args,
-        args.has_indexed_kv_cache(),
+        args.has_indexed_kv_cache() || tensor_args.has_metadata(),
         compact_gather_dim_minimum);
 
     // Check that SDPA coregrid does not overlap with AllGather coregrid
@@ -376,7 +379,7 @@ void RingJointSDPADeviceOperation::validate_on_program_cache_miss(
     const auto joint_q_shape = has_joint_tensors ? tensor_args.joint_q.value().logical_shape() : q_shape;
     const auto joint_k_shape = has_joint_tensors ? tensor_args.joint_k.value().logical_shape() : q_shape;
     const auto joint_v_shape = has_joint_tensors ? tensor_args.joint_v.value().logical_shape() : q_shape;
-    const bool has_indexed_kv_cache = args.has_indexed_kv_cache();
+    const bool has_indexed_kv_cache = args.has_indexed_kv_cache() || tensor_args.has_metadata();
     const uint32_t NVH = tensor_args.v_num_heads();
     const uint32_t VDH = tensor_args.v_head_dim(args.latent_v_head_dim);
 
@@ -805,6 +808,54 @@ RingJointSDPAResult RingJointSDPADeviceOperation::create_output_tensors(
     };
 }
 
+ttsl::hash::hash_t RingJointSDPADeviceOperation::compute_program_hash(
+    const RingJointSDPAParams& args, const RingJointSDPAInputs& tensor_args) {
+    const bool kv_pad_rotation_enabled = args.has_kv_pad_rotation();
+    const auto cache_key_logical_n = kv_pad_rotation_enabled ? 0 : args.logical_n;
+
+    std::vector<Tensor> input_tensors = {tensor_args.input_q, tensor_args.input_k};
+    if (tensor_args.input_v.has_value()) {
+        input_tensors.emplace_back(tensor_args.input_v.value());
+    }
+    if (tensor_args.joint_q.has_value()) {
+        input_tensors.emplace_back(tensor_args.joint_q.value());
+        input_tensors.emplace_back(tensor_args.joint_k.value());
+    }
+    if (tensor_args.joint_v.has_value()) {
+        input_tensors.emplace_back(tensor_args.joint_v.value());
+    }
+    input_tensors.emplace_back(tensor_args.gathered_k);
+    if (tensor_args.gathered_v.has_value()) {
+        input_tensors.emplace_back(tensor_args.gathered_v.value());
+    }
+    if (tensor_args.attention_sink.has_value()) {
+        input_tensors.emplace_back(tensor_args.attention_sink.value());
+    }
+
+    return tt::tt_metal::operation::hash_operation<RingJointSDPADeviceOperation>(
+        input_tensors,
+        args.joint_strategy,
+        args.scale,
+        args.is_causal,
+        args.is_balanced,
+        args.is_cross,
+        cache_key_logical_n,
+        args.ring_size,
+        args.compute_kernel_config,
+        args.program_config,
+        args.ccl_core_grid_offset,
+        args.kv_cache_batch_idx.has_value(),
+        kv_pad_rotation_enabled,
+        tensor_args.has_metadata(),
+        args.kv_cache_num_layers,
+        args.kv_cache_layer_idx,
+        tensor_args.has_latent_v(),
+        tensor_args.v_num_heads(),
+        tensor_args.v_head_dim(args.latent_v_head_dim),
+        args.all_gather_operation_attributes,
+        args.all_gather_tensor_args);
+}
+
 tt::tt_metal::operation::OpPerformanceModelGeneral<Tensors> RingJointSDPADeviceOperation::create_op_performance_model(
     const RingJointSDPAParams& args, const RingJointSDPAInputs& tensor_args, RingJointSDPAResult& output_tensors) {
     Tensors input_tensors = {tensor_args.input_q, tensor_args.input_k};
@@ -924,6 +975,10 @@ RingJointSDPAResult ring_joint_scaled_dot_product_attention(
     const std::optional<uint32_t> kv_actual_isl,
     const std::optional<uint32_t> latent_v_head_dim,
     const std::optional<ttnn::Tensor>& attention_sink,
+    const std::optional<ttnn::Tensor>& slot_id,
+    const std::optional<ttnn::Tensor>& kv_actual_isl_tensor,
+    const uint32_t kv_cache_num_layers,
+    const uint32_t kv_cache_layer_idx,
     const std::optional<uint32_t> sliding_window_size) {
     using OperationType = ttnn::prim::RingJointSDPADeviceOperation;
 
@@ -1006,6 +1061,8 @@ RingJointSDPAResult ring_joint_scaled_dot_product_attention(
         kv_cache_batch_idx,
         kv_actual_isl,
         latent_v_head_dim.value_or(0),
+        kv_cache_num_layers,
+        kv_cache_layer_idx,
         sliding_window_size);
 
     auto tensor_args = OperationType::tensor_args_t{
@@ -1017,7 +1074,9 @@ RingJointSDPAResult ring_joint_scaled_dot_product_attention(
         .joint_v = joint_tensor_v,
         .gathered_k = persistent_output_buffer_k,
         .gathered_v = persistent_output_buffer_v,
-        .attention_sink = attention_sink};
+        .attention_sink = attention_sink,
+        .slot_id = slot_id,
+        .kv_actual_isl = kv_actual_isl_tensor};
 
     return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation.hpp
@@ -29,10 +29,6 @@ struct RingJointSDPADeviceOperation {
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
     static tt::tt_metal::operation::OpPerformanceModelGeneral<Tensors> create_op_performance_model(
         const operation_attributes_t& args, const tensor_args_t& tensor_args, tensor_return_value_t& output_tensors);
-    // Explicit override (rather than the default attribute-reflection hash): the trace-safe metadata path
-    // must key distinct programs on tensor_args.has_metadata() and on the per-layer (kv_cache_num_layers,
-    // kv_cache_layer_idx) that are baked into the readers' create-time args and NOT re-patched per dispatch.
-    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 RingJointSDPAResult ring_joint_scaled_dot_product_attention(
@@ -64,9 +60,7 @@ RingJointSDPAResult ring_joint_scaled_dot_product_attention(
     std::optional<uint32_t> kv_cache_batch_idx = std::nullopt,
     std::optional<uint32_t> kv_actual_isl = std::nullopt,
     std::optional<uint32_t> latent_v_head_dim = std::nullopt,
-    const std::optional<ttnn::Tensor>& slot_id = std::nullopt,
-    const std::optional<ttnn::Tensor>& kv_actual_isl_tensor = std::nullopt,
-    uint32_t kv_cache_num_layers = 1,
-    uint32_t kv_cache_layer_idx = 0);
+    const std::optional<ttnn::Tensor>& attention_sink = std::nullopt,
+    std::optional<uint32_t> sliding_window_size = std::nullopt);
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation.hpp
@@ -27,6 +27,7 @@ struct RingJointSDPADeviceOperation {
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
     static tt::tt_metal::operation::OpPerformanceModelGeneral<Tensors> create_op_performance_model(
         const operation_attributes_t& args, const tensor_args_t& tensor_args, tensor_return_value_t& output_tensors);
 };
@@ -61,6 +62,10 @@ RingJointSDPAResult ring_joint_scaled_dot_product_attention(
     std::optional<uint32_t> kv_actual_isl = std::nullopt,
     std::optional<uint32_t> latent_v_head_dim = std::nullopt,
     const std::optional<ttnn::Tensor>& attention_sink = std::nullopt,
+    const std::optional<ttnn::Tensor>& slot_id = std::nullopt,
+    const std::optional<ttnn::Tensor>& kv_actual_isl_tensor = std::nullopt,
+    uint32_t kv_cache_num_layers = 1,
+    uint32_t kv_cache_layer_idx = 0,
     std::optional<uint32_t> sliding_window_size = std::nullopt);
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation_types.hpp
@@ -35,6 +35,8 @@ struct RingJointSDPAParams {
     std::optional<std::uint32_t> kv_cache_batch_idx = std::nullopt;
     std::optional<std::uint32_t> kv_actual_isl = std::nullopt;
     uint32_t latent_v_head_dim = 0;
+    uint32_t kv_cache_num_layers = 1;
+    uint32_t kv_cache_layer_idx = 0;
     std::optional<uint32_t> sliding_window_size = std::nullopt;
 
     // We need a constructor, because all_gather_struct is not default initializable.
@@ -55,6 +57,8 @@ struct RingJointSDPAParams {
         std::optional<std::uint32_t> kv_cache_batch_idx = std::nullopt,
         std::optional<std::uint32_t> kv_actual_isl = std::nullopt,
         uint32_t latent_v_head_dim = 0,
+        uint32_t kv_cache_num_layers = 1,
+        uint32_t kv_cache_layer_idx = 0,
         std::optional<uint32_t> sliding_window_size = std::nullopt) :
         joint_strategy(std::move(joint_strategy)),
         scale(scale),
@@ -72,6 +76,8 @@ struct RingJointSDPAParams {
         kv_cache_batch_idx(kv_cache_batch_idx),
         kv_actual_isl(kv_actual_isl),
         latent_v_head_dim(latent_v_head_dim),
+        kv_cache_num_layers(kv_cache_num_layers),
+        kv_cache_layer_idx(kv_cache_layer_idx),
         sliding_window_size(sliding_window_size) {}
 
     std::uint32_t get_q_chunk_size() const { return program_config.has_value() ? program_config->q_chunk_size : 32; }
@@ -132,6 +138,10 @@ struct RingJointSDPAInputs {
     Tensor gathered_k;
     std::optional<Tensor> gathered_v;
     std::optional<Tensor> attention_sink;
+    std::optional<Tensor> slot_id;
+    std::optional<Tensor> kv_actual_isl;
+
+    bool has_metadata() const { return slot_id.has_value() && kv_actual_isl.has_value(); }
 
     // Chunked-prefill is signalled implicitly by Q being shorter than the per-device K shard:
     // Q is the latest slab, K is the populated prefix from chunk 0 through the current chunk.

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation_types.hpp
@@ -35,13 +35,7 @@ struct RingJointSDPAParams {
     std::optional<std::uint32_t> kv_cache_batch_idx = std::nullopt;
     std::optional<std::uint32_t> kv_actual_isl = std::nullopt;
     uint32_t latent_v_head_dim = 0;
-    // (user, layer)-major KV-cache batch dim (metadata path). The SDPA + all-gather readers compute the
-    // cache slot on-device as metadata[0] * kv_cache_num_layers + kv_cache_layer_idx (mirrors
-    // update_padded_kv_cache). Defaults (1, 0) reduce to metadata[0], so existing callers are unaffected.
-    // Hashed by compute_program_hash: each distinct (kv_cache_num_layers, kv_cache_layer_idx) gets its own
-    // cached program, so different layers can't collide onto one cached program and gather the wrong slot.
-    uint32_t kv_cache_num_layers = 1;
-    uint32_t kv_cache_layer_idx = 0;
+    std::optional<uint32_t> sliding_window_size = std::nullopt;
 
     // We need a constructor, because all_gather_struct is not default initializable.
     RingJointSDPAParams(
@@ -61,8 +55,7 @@ struct RingJointSDPAParams {
         std::optional<std::uint32_t> kv_cache_batch_idx = std::nullopt,
         std::optional<std::uint32_t> kv_actual_isl = std::nullopt,
         uint32_t latent_v_head_dim = 0,
-        uint32_t kv_cache_num_layers = 1,
-        uint32_t kv_cache_layer_idx = 0) :
+        std::optional<uint32_t> sliding_window_size = std::nullopt) :
         joint_strategy(std::move(joint_strategy)),
         scale(scale),
         is_causal(is_causal),
@@ -79,8 +72,7 @@ struct RingJointSDPAParams {
         kv_cache_batch_idx(kv_cache_batch_idx),
         kv_actual_isl(kv_actual_isl),
         latent_v_head_dim(latent_v_head_dim),
-        kv_cache_num_layers(kv_cache_num_layers),
-        kv_cache_layer_idx(kv_cache_layer_idx) {}
+        sliding_window_size(sliding_window_size) {}
 
     std::uint32_t get_q_chunk_size() const { return program_config.has_value() ? program_config->q_chunk_size : 32; }
 
@@ -89,6 +81,8 @@ struct RingJointSDPAParams {
     bool has_indexed_kv_cache() const { return kv_cache_batch_idx.has_value(); }
 
     bool has_kv_pad_rotation() const { return kv_actual_isl.has_value(); }
+
+    bool has_sliding_window() const { return sliding_window_size.value_or(0) > 0; }
 
     static constexpr auto attribute_names = std::forward_as_tuple(
         "joint_strategy",
@@ -104,6 +98,7 @@ struct RingJointSDPAParams {
         "has_kv_cache_batch_idx",
         "kv_pad_rotation_enabled",
         "latent_v_head_dim",
+        "sliding_window_size",
         "all_gather_operation_attributes",
         "all_gather_tensor_args");
     auto attribute_values() const {
@@ -121,6 +116,7 @@ struct RingJointSDPAParams {
             kv_cache_batch_idx.has_value(),
             has_kv_pad_rotation(),
             std::cref(latent_v_head_dim),
+            std::cref(sliding_window_size),
             std::cref(all_gather_operation_attributes),
             std::cref(all_gather_tensor_args));
     }
@@ -135,21 +131,7 @@ struct RingJointSDPAInputs {
     std::optional<Tensor> joint_v;
     Tensor gathered_k;
     std::optional<Tensor> gathered_v;
-
-    // Trace-safe metadata path (opt-in): two 1-element uint32 DRAM tensors holding the per-chunk
-    // scalars that would otherwise be host-computed and frozen by a ttnn trace. slot_id holds the
-    // cache-user slot (was metadata[0]); kv_actual_isl holds the prior valid global KV length (was
-    // metadata[1]). When present (both together), the readers/writer compute
-    // kv_cache_batch_idx = slot_id * kv_cache_num_layers + kv_cache_layer_idx and derive
-    // logical_nt / q-mapping / ring masks on-device from kv_actual_isl, so one captured program
-    // replays across chunks. std::nullopt => classic host-scalar path (unchanged).
-    std::optional<Tensor> slot_id;
-    std::optional<Tensor> kv_actual_isl;
-
-    // Both metadata tensors are supplied together or not at all (enforced in validate_on_program_cache_miss);
-    // require both here so a caller that set only one takes the scalar path instead of nullopt-derefing the
-    // missing tensor downstream.
-    bool has_metadata() const { return slot_id.has_value() && kv_actual_isl.has_value(); }
+    std::optional<Tensor> attention_sink;
 
     // Chunked-prefill is signalled implicitly by Q being shorter than the per-device K shard:
     // Q is the latest slab, K is the populated prefix from chunk 0 through the current chunk.

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
@@ -4,6 +4,8 @@
 
 #include "ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.hpp"
 #include "kernels/dataflow/chunked_prefill_utils.hpp"
+#include "kernels/sliding_window_geometry.hpp"
+#include "sliding_halo_layout.hpp"
 #include "ttnn/operations/transformer/sdpa/device/kernels/ring_joint_chain_layout.hpp"
 #include "ttnn/operations/transformer/sdpa/device/kernels/ring_id_sequencer.hpp"
 #include "ttnn/operations/transformer/sdpa/device/sdpa_subblock_utils.hpp"
@@ -27,8 +29,6 @@
 #include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <hostdevcommon/common_values.hpp>
-#include "ttnn/operations/math.hpp"
-#include "ttnn/operation.hpp"
 
 using namespace tt::tt_metal;
 using ttnn::Tensor;
@@ -60,13 +60,6 @@ struct KVPadQMapping {
 struct TileSegment {
     uint32_t start_tile = 0;
     uint32_t tile_count = 0;
-};
-
-struct RingJointRuntimeValues {
-    uint32_t logical_nt = 0;
-    uint32_t active_ring_iter_mask = 0;
-    uint32_t single_valid_kv_chunk_mask = 0;
-    KVPadQMapping kv_pad_q_mapping;
 };
 
 struct RingJointRuntimePlan {
@@ -118,16 +111,19 @@ constexpr uint32_t kReaderKernelIndex = 0;
 constexpr uint32_t kWriterKernelIndex = 1;
 constexpr uint32_t kComputeKernelIndex = 2;
 
-// The helper appends 4 kernels after the 3 SDPA kernels above, in order: reader_forward (3),
-// writer_forward (4), reader_backward (5), writer_backward (6) (helper desc.kernels.push_back order).
+// Dense all-gather appends reader-forward, writer-forward, reader-backward, writer-backward.
+// Compact sliding appends only its predecessor reader/writer pair at indices 3 and 4.
 constexpr uint32_t kAllGatherReaderForwardKernelIndex = 3;
 constexpr uint32_t kAllGatherWriterForwardKernelIndex = 4;
 constexpr uint32_t kAllGatherReaderBackwardKernelIndex = 5;
 constexpr uint32_t kAllGatherWriterBackwardKernelIndex = 6;
+constexpr uint32_t kNeighborHaloReaderKernelIndex = 3;
+constexpr uint32_t kNeighborHaloWriterKernelIndex = 4;
 
 // Runtime-arg offsets used by cache-hit patching. Descriptor construction appends the same slots through
 // CheckedRuntimeArgList, so future layout edits fail on program creation instead of corrupting cache hits.
-constexpr uint32_t kReaderBaseBufferArgCount = 5;
+// Q, K, V, gathered K, gathered V, and attention sink (nullable).
+constexpr uint32_t kReaderBaseBufferArgCount = 6;
 constexpr uint32_t kReaderJointBufferArgCount = 3;
 constexpr uint32_t kReaderQWorkArgCount = 3;
 constexpr uint32_t kRingJointChainConfigArgCount = ring_joint::kChainConfigRuntimeArgCount;
@@ -184,13 +180,7 @@ uint32_t kv_global_tile_for_host_ring_plan(
 // Build the per-device ring-loop masks passed to reader/compute/writer. This mirrors the kernel
 // ring-id order, marks ring_iter entries that have non-padded spatial or joint KV work, and applies
 // the same causal unbalanced skip rule used by compute.
-//
-// KEEP IN SYNC with the on-device port in kernels/dataflow/ring_joint_kv_pad_derivation.hpp (SDPA reader
-// + writer read it): these host functions are the reference, so any change to the KV-pad derivation here
-// must be mirrored there, or the metadata (traced) path silently diverges from the scalar path outside
-// the points the bit-exact test exercises. See that header's KEEP IN SYNC note.
-template <bool TrackLastActiveIter>
-RingWorkPlan build_ring_work_plan_impl(
+RingWorkPlan build_ring_work_plan(
     const RingWritePlan& ring_write_plan, const RingJointRuntimeDerivation& derivation, bool is_balanced) {
     RingWorkPlan plan;
     RingIdSequencer seq(
@@ -233,9 +223,7 @@ RingWorkPlan build_ring_work_plan_impl(
             !(derivation.kernel_is_causal && ring_write_plan.device_index < ring_id && !is_balanced);
         if (ring_iter_does_work) {
             plan.masks.active_ring_iter_mask |= (1u << ring_iter);
-            if constexpr (TrackLastActiveIter) {
-                plan.last_active_ring_iter = ring_iter;
-            }
+            plan.last_active_ring_iter = ring_iter;
         }
         if (valid_kv_chunks <= 1) {
             plan.masks.single_valid_kv_chunk_mask |= (1u << ring_iter);
@@ -243,16 +231,6 @@ RingWorkPlan build_ring_work_plan_impl(
     }
 
     return plan;
-}
-
-RingWorkMasks build_ring_work_masks(
-    const RingWritePlan& ring_write_plan, const RingJointRuntimeDerivation& derivation, bool is_balanced) {
-    return build_ring_work_plan_impl<false>(ring_write_plan, derivation, is_balanced).masks;
-}
-
-RingWorkPlan build_ring_work_plan(
-    const RingWritePlan& ring_write_plan, const RingJointRuntimeDerivation& derivation, bool is_balanced) {
-    return build_ring_work_plan_impl<true>(ring_write_plan, derivation, is_balanced);
 }
 
 KVPadQMapping build_kv_pad_q_mapping(
@@ -313,6 +291,15 @@ RingWritePlan build_ring_write_plan(
     plan.device_index = ttnn::ccl::get_linearized_index_from_physical_coord(
         tensor_args.input_q, coord, args.all_gather_operation_attributes.cluster_axis);
 
+    // Chunked sliding consumes the local slab followed by its cyclic
+    // predecessor. Keep that dependency on direction 1 for every device,
+    // independent of the dense ring's parity-based split.
+    if (args.has_sliding_window() && tensor_args.is_chunked() && !args.is_cross) {
+        plan.forward_writes_expected = 1;
+        plan.backward_writes_expected = 0;
+        return plan;
+    }
+
     auto [num_targets_forward, num_targets_backward, dynamic_alternate] = ttnn::ccl::get_forward_backward_configuration(
         args.all_gather_operation_attributes.ring_size,
         plan.device_index,
@@ -358,9 +345,7 @@ RingJointRuntimeDerivation build_runtime_derivation(
     // Cross is non-causal on chunked-shaped tensors, so kernels and the work planner use the
     // non-chunked path.
     derivation.kernel_chunked = tensor_args.is_chunked() && !args.is_cross;
-    // Metadata path enables rotation on the chunked case too (kv_actual read on-device from metadata[1]).
-    derivation.kv_pad_rotation_enabled =
-        args.has_kv_pad_rotation() || (tensor_args.has_metadata() && tensor_args.is_chunked());
+    derivation.kv_pad_rotation_enabled = args.has_kv_pad_rotation();
     derivation.kernel_is_causal = args.is_causal && !derivation.kernel_chunked;
 
     TT_FATAL(
@@ -380,11 +365,9 @@ RingJointRuntimePlan build_runtime_plan(
 
     RingJointRuntimePlan plan;
     plan.logical_nt = derivation.logical_nt;
-    // On the metadata path kv_actual_isl is absent and the q-mapping is computed on-device from
-    // metadata[1]; only the scalar path computes it host-side here.
     const uint32_t kv_actual_tile_count =
-        args.kv_actual_isl.has_value() ? args.kv_actual_isl.value() / tt::constants::TILE_HEIGHT : 0;
-    if (args.kv_actual_isl.has_value()) {
+        derivation.kv_pad_rotation_enabled ? args.kv_actual_isl.value() / tt::constants::TILE_HEIGHT : 0;
+    if (derivation.kv_pad_rotation_enabled) {
         plan.kv_pad_q_mapping = build_kv_pad_q_mapping(
             kv_actual_tile_count,
             derivation.logical_nt,
@@ -393,34 +376,15 @@ RingJointRuntimePlan build_runtime_plan(
             ring_write_plan.device_index);
     }
 
-    plan.ring_work_plan = build_ring_work_plan(ring_write_plan, derivation, args.is_balanced);
+    if (args.has_sliding_window()) {
+        // Sliding folds its local and predecessor ranges into one synthetic ring iteration.
+        plan.ring_work_plan.masks.active_ring_iter_mask = 1;
+    } else {
+        plan.ring_work_plan = build_ring_work_plan(ring_write_plan, derivation, args.is_balanced);
+    }
     plan.kernel_chunked = derivation.kernel_chunked;
     plan.kernel_is_causal = derivation.kernel_is_causal;
     return plan;
-}
-
-RingJointRuntimeValues build_runtime_values(
-    const ttnn::prim::RingJointSDPAParams& args,
-    const ttnn::prim::RingJointSDPAInputs& tensor_args,
-    const ttnn::MeshCoordinate& coord) {
-    const RingWritePlan ring_write_plan = build_ring_write_plan(args, tensor_args, coord);
-    const RingJointRuntimeDerivation derivation = build_runtime_derivation(args, tensor_args);
-
-    RingJointRuntimeValues values;
-    values.logical_nt = derivation.logical_nt;
-    if (args.kv_actual_isl.has_value()) {
-        const uint32_t kv_actual_tile_count = args.kv_actual_isl.value() / tt::constants::TILE_HEIGHT;
-        values.kv_pad_q_mapping = build_kv_pad_q_mapping(
-            kv_actual_tile_count,
-            derivation.logical_nt,
-            derivation.ring_size,
-            derivation.q_local_padded_Nt,
-            ring_write_plan.device_index);
-    }
-    const RingWorkMasks ring_work_masks = build_ring_work_masks(ring_write_plan, derivation, args.is_balanced);
-    values.active_ring_iter_mask = ring_work_masks.active_ring_iter_mask;
-    values.single_valid_kv_chunk_mask = ring_work_masks.single_valid_kv_chunk_mask;
-    return values;
 }
 
 RingJointRuntimeArgLayout get_runtime_arg_layout(
@@ -440,12 +404,16 @@ RingJointRuntimeArgLayout get_runtime_arg_layout(
                                                        : tensor_args.input_q.device()->compute_with_storage_grid_size();
 
     const uint32_t joint_buffer_args = (L != 0) ? kReaderJointBufferArgCount : 0;
+    const bool enable_kv_chains = !args.has_sliding_window();
+    const bool use_head_chain = enable_kv_chains && !gqa_grouped_kv;
+    const uint32_t head_chain_args = use_head_chain ? kRingJointChainConfigArgCount : 0;
     const uint32_t batch_chain_args =
-        k_uses_batch_chain ? (kRingJointChainConfigArgCount + kReaderBatchChainExtraArgCount) : 0;
-    const uint32_t gqa_chain_args = gqa_grouped_kv ? (kRingJointChainConfigArgCount + kReaderGQAChainExtraArgCount) : 0;
+        enable_kv_chains && k_uses_batch_chain ? (kRingJointChainConfigArgCount + kReaderBatchChainExtraArgCount) : 0;
+    const uint32_t gqa_chain_args =
+        enable_kv_chains && gqa_grouped_kv ? (kRingJointChainConfigArgCount + kReaderGQAChainExtraArgCount) : 0;
     layout.reader_kv_cache_batch_idx = kReaderBaseBufferArgCount + joint_buffer_args + 2;
-    layout.reader_logical_nt = kReaderBaseBufferArgCount + joint_buffer_args + kReaderQWorkArgCount +
-                               kRingJointChainConfigArgCount + batch_chain_args + gqa_chain_args;
+    layout.reader_logical_nt = kReaderBaseBufferArgCount + joint_buffer_args + kReaderQWorkArgCount + head_chain_args +
+                               batch_chain_args + gqa_chain_args;
     layout.reader_active_ring_iter_mask = layout.reader_logical_nt + 1;
     layout.writer_logical_nt = kWriterBaseArgCount;
     layout.writer_active_ring_iter_mask = layout.writer_logical_nt + 1;
@@ -472,8 +440,7 @@ void write_runtime_arg(RuntimeArgsData& args, uint32_t index, uint32_t value, co
 // dispatch is bounded) and the cache-hit override path.
 std::optional<uint32_t> compute_gather_valid_Ht(
     const ttnn::prim::RingJointSDPAParams& args, const ttnn::prim::RingJointSDPAInputs& tensor_args) {
-    // Bound the gather whenever rotation is active -- scalar kv_actual_isl or the chunked metadata path.
-    if (!args.has_kv_pad_rotation() && !(tensor_args.has_metadata() && tensor_args.is_chunked())) {
+    if (!args.has_kv_pad_rotation()) {
         return std::nullopt;
     }
     const uint32_t ring_size = static_cast<uint32_t>(args.all_gather_operation_attributes.ring_size);
@@ -494,9 +461,12 @@ void apply_ring_joint_scalar_runtime_args(
         return;
     }
 
-    const RingJointRuntimeValues values = patch_kv_pad_rotation
-                                              ? build_runtime_values(args, tensor_args, mesh_dispatch_coordinate)
-                                              : RingJointRuntimeValues{};
+    // Indexed KV-cache hits also need the current device index and logical sequence geometry for
+    // the compact sliding halo. Build these plans for either kind of runtime patch; using default
+    // plans here would incorrectly select device 0's halo tail when no KV-pad rotation is present.
+    const RingWritePlan ring_write_plan = build_ring_write_plan(args, tensor_args, mesh_dispatch_coordinate);
+    const RingJointRuntimePlan runtime_plan = build_runtime_plan(args, tensor_args, ring_write_plan);
+    const RingWorkMasks& ring_work_masks = runtime_plan.ring_work_plan.masks;
     const RingJointRuntimeArgLayout layout = get_runtime_arg_layout(args, tensor_args);
     const uint32_t num_cores = layout.grid_size.x * layout.grid_size.y;
     const uint32_t kv_cache_batch_idx = args.kv_cache_batch_idx.value_or(0);
@@ -507,25 +477,27 @@ void apply_ring_joint_scalar_runtime_args(
     const uint32_t num_ag_inputs = tensor_args.has_latent_v() ? 1u : (tensor_args.input_v.has_value() ? 2u : 1u);
     const std::array<const Tensor*, 2> ag_inputs = {
         &input_k, tensor_args.input_v.has_value() ? &tensor_args.input_v.value() : &input_k};
+    const bool uses_neighbor_halo = args.has_sliding_window();
 
     // Re-patch the fused all-gather readers to gather the single cache slot `kv_cache_batch_idx`.
     // input_batch_base is uniform across all gather cores/links, so patch every core that runs the
     // reader. Mirrors the helper's create-time arithmetic so miss and hit paths agree.
     if (patch_indexed_kv_cache) {
-        const auto patch_all_gather_reader = [&](uint32_t kernel_id) {
+        const auto patch_reader_batch_base = [&](uint32_t kernel_id,
+                                                 uint32_t header_count,
+                                                 uint32_t descriptor_field_count,
+                                                 uint32_t batch_base_offset) {
             auto& grid_args = GetRuntimeArgs(program, kernel_id);  // [x][y] per-core args
             for (auto& col_args : grid_args) {
                 for (auto& core_args : col_args) {
                     for (uint32_t in = 0; in < num_ag_inputs; ++in) {
                         const auto& shape = ag_inputs[in]->padded_shape();
                         const uint32_t num_heads = shape[1];
-                        const uint32_t Ht = shape[2] / tt::constants::TILE_WIDTH;
+                        const uint32_t Ht = shape[2] / tt::constants::TILE_HEIGHT;
                         const uint32_t Wt = shape[3] / tt::constants::TILE_WIDTH;
                         const uint32_t input_batch_base =
                             ag_rt::input_batch_base_pages(kv_cache_batch_idx, num_heads, Ht, Wt);
-                        const uint32_t idx = ag_rt::kReaderRuntimeArgHeaderCount +
-                                             in * ag_rt::kTensorDescriptorFieldCount +
-                                             ag_rt::kInputBatchBaseFieldOffset;
+                        const uint32_t idx = header_count + in * descriptor_field_count + batch_base_offset;
                         if (core_args.size() > idx) {  // skip cores that don't run this kernel
                             write_runtime_arg(core_args, idx, input_batch_base, "all_gather_reader.input_batch_base");
                         }
@@ -533,8 +505,24 @@ void apply_ring_joint_scalar_runtime_args(
                 }
             }
         };
-        patch_all_gather_reader(kAllGatherReaderForwardKernelIndex);
-        patch_all_gather_reader(kAllGatherReaderBackwardKernelIndex);
+        if (uses_neighbor_halo) {
+            patch_reader_batch_base(
+                kNeighborHaloReaderKernelIndex,
+                ag_rt::kNeighborReaderRuntimeArgHeaderCount,
+                ag_rt::kNeighborReaderTensorDescriptorFieldCount,
+                ag_rt::kNeighborReaderInputBatchBaseFieldOffset);
+        } else {
+            patch_reader_batch_base(
+                kAllGatherReaderForwardKernelIndex,
+                ag_rt::kReaderRuntimeArgHeaderCount,
+                ag_rt::kTensorDescriptorFieldCount,
+                ag_rt::kInputBatchBaseFieldOffset);
+            patch_reader_batch_base(
+                kAllGatherReaderBackwardKernelIndex,
+                ag_rt::kReaderRuntimeArgHeaderCount,
+                ag_rt::kTensorDescriptorFieldCount,
+                ag_rt::kInputBatchBaseFieldOffset);
+        }
     }
 
     // Bound the fused all-gather to the logical_n-valid slab prefix so an oversized (growing) KV
@@ -544,9 +532,12 @@ void apply_ring_joint_scalar_runtime_args(
     // across cores/links/devices, so producer/consumer page counts and the ring slice protocol stay
     // matched (the AG kernels clamp input_tile_id_end to it). Patch readers AND writers — both key
     // their loops off input_tile_id_end — at their respective header offsets (3 vs 5).
-    const std::optional<uint32_t> gather_valid_Ht = compute_gather_valid_Ht(args, tensor_args);
-    if (gather_valid_Ht.has_value()) {
-        const auto patch_all_gather_valid_pages = [&](uint32_t kernel_id, uint32_t header_count) {
+    if (patch_kv_pad_rotation && !uses_neighbor_halo) {
+        const uint32_t gather_valid_Ht = compute_gather_valid_Ht(args, tensor_args).value();
+        const auto patch_valid_pages = [&](uint32_t kernel_id,
+                                           uint32_t header_count,
+                                           uint32_t descriptor_field_count,
+                                           uint32_t valid_pages_offset) {
             auto& grid_args = GetRuntimeArgs(program, kernel_id);  // [x][y] per-core args
             for (auto& col_args : grid_args) {
                 for (auto& core_args : col_args) {
@@ -554,10 +545,9 @@ void apply_ring_joint_scalar_runtime_args(
                         const auto& shape = ag_inputs[in]->padded_shape();
                         const uint32_t Ht = shape[2] / tt::constants::TILE_HEIGHT;
                         const uint32_t Wt = shape[3] / tt::constants::TILE_WIDTH;
-                        const uint32_t valid_Ht = std::min(*gather_valid_Ht, Ht);
+                        const uint32_t valid_Ht = std::min(gather_valid_Ht, Ht);
                         const uint32_t valid_pages = valid_Ht * Wt;
-                        const uint32_t idx =
-                            header_count + in * ag_rt::kTensorDescriptorFieldCount + ag_rt::kValidPagesFieldOffset;
+                        const uint32_t idx = header_count + in * descriptor_field_count + valid_pages_offset;
                         if (core_args.size() > idx) {  // skip cores that don't run this kernel
                             write_runtime_arg(core_args, idx, valid_pages, "all_gather.valid_pages");
                         }
@@ -565,10 +555,93 @@ void apply_ring_joint_scalar_runtime_args(
                 }
             }
         };
-        patch_all_gather_valid_pages(kAllGatherReaderForwardKernelIndex, ag_rt::kReaderRuntimeArgHeaderCount);
-        patch_all_gather_valid_pages(kAllGatherReaderBackwardKernelIndex, ag_rt::kReaderRuntimeArgHeaderCount);
-        patch_all_gather_valid_pages(kAllGatherWriterForwardKernelIndex, ag_rt::kWriterRuntimeArgHeaderCount);
-        patch_all_gather_valid_pages(kAllGatherWriterBackwardKernelIndex, ag_rt::kWriterRuntimeArgHeaderCount);
+        patch_valid_pages(
+            kAllGatherReaderForwardKernelIndex,
+            ag_rt::kReaderRuntimeArgHeaderCount,
+            ag_rt::kTensorDescriptorFieldCount,
+            ag_rt::kValidPagesFieldOffset);
+        patch_valid_pages(
+            kAllGatherWriterForwardKernelIndex,
+            ag_rt::kWriterRuntimeArgHeaderCount,
+            ag_rt::kTensorDescriptorFieldCount,
+            ag_rt::kValidPagesFieldOffset);
+        patch_valid_pages(
+            kAllGatherReaderBackwardKernelIndex,
+            ag_rt::kReaderRuntimeArgHeaderCount,
+            ag_rt::kTensorDescriptorFieldCount,
+            ag_rt::kValidPagesFieldOffset);
+        patch_valid_pages(
+            kAllGatherWriterBackwardKernelIndex,
+            ag_rt::kWriterRuntimeArgHeaderCount,
+            ag_rt::kTensorDescriptorFieldCount,
+            ag_rt::kValidPagesFieldOffset);
+    }
+
+    if (args.has_sliding_window() && (patch_indexed_kv_cache || patch_kv_pad_rotation)) {
+        const uint32_t runtime_ring_size = static_cast<uint32_t>(args.all_gather_operation_attributes.ring_size);
+        const auto runtime_chunked_sliding_layout = ring_joint::build_chunked_sliding_halo_layout(
+            tensor_args.input_q.padded_shape()[2] / tt::constants::TILE_HEIGHT,
+            args.get_k_chunk_size() / tt::constants::TILE_HEIGHT,
+            args.sliding_window_size.value(),
+            tt::constants::TILE_HEIGHT,
+            runtime_ring_size,
+            runtime_plan.logical_nt);
+        TT_FATAL(runtime_chunked_sliding_layout.uses_neighbor_halo(), "Sliding attention requires a neighbor halo");
+        // logical_n/kv_actual_isl are runtime-patched and excluded from the program hash. For
+        // compact chunked sliding they also choose which cache-group tail the one-hop gather reads.
+        // Relocate every per-link reader/writer slice from the descriptor's previous group to the current group.
+        const uint32_t runtime_tail_start_Ht =
+            runtime_chunked_sliding_layout.send_tail_start_tile(ring_write_plan.device_index);
+        auto& reader_grid_args = GetRuntimeArgs(program, kNeighborHaloReaderKernelIndex);
+        auto& writer_grid_args = GetRuntimeArgs(program, kNeighborHaloWriterKernelIndex);
+        TT_FATAL(reader_grid_args.size() == writer_grid_args.size(), "Directional gather runtime grids disagree");
+        for (uint32_t x = 0; x < reader_grid_args.size(); ++x) {
+            TT_FATAL(
+                reader_grid_args[x].size() == writer_grid_args[x].size(),
+                "Directional gather runtime grid columns disagree");
+            for (uint32_t y = 0; y < reader_grid_args[x].size(); ++y) {
+                auto& reader_args = reader_grid_args[x][y];
+                auto& writer_args = writer_grid_args[x][y];
+                if (reader_args.size() == 0 && writer_args.size() == 0) {
+                    continue;
+                }
+                TT_FATAL(
+                    reader_args.size() != 0 && writer_args.size() != 0, "Directional gather worker pair is incomplete");
+                for (uint32_t in = 0; in < num_ag_inputs; ++in) {
+                    const uint32_t reader_base = ag_rt::kNeighborReaderRuntimeArgHeaderCount +
+                                                 in * ag_rt::kNeighborReaderTensorDescriptorFieldCount;
+                    const uint32_t writer_base = ag_rt::kNeighborWriterRuntimeArgHeaderCount +
+                                                 in * ag_rt::kNeighborWriterTensorDescriptorFieldCount;
+                    const uint32_t writer_origin_idx = writer_base + ag_rt::kNeighborWriterInputOriginPageFieldOffset;
+                    TT_FATAL(
+                        writer_args.size() > writer_origin_idx, "Directional gather writer descriptor is incomplete");
+                    const uint32_t input_Wt = ag_inputs[in]->padded_shape()[3] / tt::constants::TILE_WIDTH;
+                    const uint32_t runtime_origin_page = runtime_tail_start_Ht * input_Wt;
+                    const uint32_t previous_origin_page = writer_args[writer_origin_idx];
+                    if (previous_origin_page != runtime_origin_page) {
+                        const int64_t page_delta = static_cast<int64_t>(runtime_origin_page) - previous_origin_page;
+                        const auto relocate_pages = [&](auto& runtime_args, uint32_t start_idx, uint32_t end_idx) {
+                            const int64_t relocated_start = static_cast<int64_t>(runtime_args[start_idx]) + page_delta;
+                            const int64_t relocated_end = static_cast<int64_t>(runtime_args[end_idx]) + page_delta;
+                            TT_FATAL(
+                                relocated_start >= 0 && relocated_end >= relocated_start,
+                                "Invalid cached neighbor-halo relocation");
+                            runtime_args[start_idx] = static_cast<uint32_t>(relocated_start);
+                            runtime_args[end_idx] = static_cast<uint32_t>(relocated_end);
+                        };
+                        relocate_pages(
+                            reader_args,
+                            reader_base + ag_rt::kNeighborReaderInputTileStartFieldOffset,
+                            reader_base + ag_rt::kNeighborReaderInputTileEndFieldOffset);
+                        relocate_pages(
+                            writer_args,
+                            writer_base + ag_rt::kNeighborWriterInputTileStartFieldOffset,
+                            writer_base + ag_rt::kNeighborWriterInputTileEndFieldOffset);
+                    }
+                    writer_args[writer_origin_idx] = runtime_origin_page;
+                }
+            }
+        }
     }
 
     for (uint32_t i = 0; i < num_cores; ++i) {
@@ -596,51 +669,51 @@ void apply_ring_joint_scalar_runtime_args(
             continue;
         }
 
-        write_runtime_arg(reader_args, layout.reader_logical_nt, values.logical_nt, "reader.logical_nt");
+        write_runtime_arg(reader_args, layout.reader_logical_nt, runtime_plan.logical_nt, "reader.logical_nt");
         write_runtime_arg(
             reader_args,
             layout.reader_active_ring_iter_mask,
-            values.active_ring_iter_mask,
+            ring_work_masks.active_ring_iter_mask,
             "reader.active_ring_iter_mask");
 
         auto& writer_args = GetRuntimeArgs(program, kWriterKernelIndex, core);
-        write_runtime_arg(writer_args, layout.writer_logical_nt, values.logical_nt, "writer.logical_nt");
+        write_runtime_arg(writer_args, layout.writer_logical_nt, runtime_plan.logical_nt, "writer.logical_nt");
         write_runtime_arg(
             writer_args,
             layout.writer_active_ring_iter_mask,
-            values.active_ring_iter_mask,
+            ring_work_masks.active_ring_iter_mask,
             "writer.active_ring_iter_mask");
         write_runtime_arg(
             writer_args,
             layout.writer_single_valid_kv_chunk_mask,
-            values.single_valid_kv_chunk_mask,
+            ring_work_masks.single_valid_kv_chunk_mask,
             "writer.single_valid_kv_chunk_mask");
 
-        write_runtime_arg(compute_args, layout.compute_logical_nt, values.logical_nt, "compute.logical_nt");
+        write_runtime_arg(compute_args, layout.compute_logical_nt, runtime_plan.logical_nt, "compute.logical_nt");
         write_runtime_arg(
             compute_args,
             layout.compute_q_pre_wrap_start_tile,
-            values.kv_pad_q_mapping.q_pre_wrap_start_tile,
+            runtime_plan.kv_pad_q_mapping.q_pre_wrap_start_tile,
             "compute.q_pre_wrap_start_tile");
         write_runtime_arg(
             compute_args,
             layout.compute_q_pre_wrap_tile_count,
-            values.kv_pad_q_mapping.q_pre_wrap_tile_count,
+            runtime_plan.kv_pad_q_mapping.q_pre_wrap_tile_count,
             "compute.q_pre_wrap_tile_count");
         write_runtime_arg(
             compute_args,
             layout.compute_q_post_wrap_start_tile,
-            values.kv_pad_q_mapping.q_post_wrap_start_tile,
+            runtime_plan.kv_pad_q_mapping.q_post_wrap_start_tile,
             "compute.q_post_wrap_start_tile");
         write_runtime_arg(
             compute_args,
             layout.compute_q_valid_tile_count,
-            values.kv_pad_q_mapping.q_valid_tile_count,
+            runtime_plan.kv_pad_q_mapping.q_valid_tile_count,
             "compute.q_valid_tile_count");
         write_runtime_arg(
             compute_args,
             layout.compute_active_ring_iter_mask,
-            values.active_ring_iter_mask,
+            ring_work_masks.active_ring_iter_mask,
             "compute.active_ring_iter_mask");
     }
 }
@@ -655,12 +728,6 @@ namespace {
 // create_workload_descriptor() can loop coords and reuse this body verbatim. The
 // op-specific name suffix avoids Unity-build collisions with the sibling ring
 // sdpa factories that share the same helper signature.
-//
-// This is a single-pass builder whose branches (chunked vs full, metadata vs scalar, forward/backward
-// ring halves) are tightly coupled through shared local offsets, so it reads clearest as one body. The
-// per-element-tensor metadata overload added the last few branches that nudged it just past the repo
-// cognitive-complexity threshold; suppress here rather than split the coupled body.
-// NOLINTNEXTLINE(readability-function-cognitive-complexity)
 tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
     const RingJointSDPAParams& args,
     const RingJointSDPAInputs& tensor_args,
@@ -730,6 +797,8 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
     const auto& gathered_input_tensor_k = tensor_args.gathered_k;
     const auto& gathered_input_tensor_v =
         tensor_args.gathered_v.has_value() ? tensor_args.gathered_v.value() : gathered_input_tensor_k;
+    const auto& attention_sink = tensor_args.attention_sink;
+    const bool use_attention_sink = attention_sink.has_value();
 
     auto& output_tensor = output_tensors[RING_JOINT_SDPA_OUTPUT_IDX];
     auto& joint_output_tensor = output_tensors[RING_JOINT_SDPA_JOINT_OUTPUT_IDX];
@@ -794,10 +863,7 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
     }
 
     // q_local_padded_N (Q rows per device) can be shorter than kv_local_padded_N for chunked prefill.
-    // Indexed (single-slot) mode is also engaged on the trace-safe metadata path, where the slot is read
-    // on-device from metadata[0] instead of the host kv_cache_batch_idx scalar.
-    const bool slot_from_metadata = tensor_args.has_metadata();
-    const bool indexed_kv_cache = args.has_indexed_kv_cache() || slot_from_metadata;
+    const bool indexed_kv_cache = args.has_indexed_kv_cache();
     // Latent-V mode: V tensors are omitted; the reader reuses K's buffer and
     // reads only the first vDHt head-dim tiles.
     const uint32_t B = q_shape[0];
@@ -808,26 +874,29 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
     const uint32_t q_local_padded_N = q_shape[2];
     const uint32_t kv_local_padded_N = tensor_args.local_kv_seq_len();
     const uint32_t ring_size = static_cast<uint32_t>(args.all_gather_operation_attributes.ring_size);
-    const uint32_t padded_N = k_shape[2];
+    const uint32_t gathered_padded_N = k_shape[2];
+    const uint32_t global_padded_N = kv_local_padded_N * ring_size;
+    const uint32_t sliding_window_size = args.sliding_window_size.value_or(0);
+    const bool has_sliding_window = sliding_window_size > 0;
+    const bool enable_kv_chains = !has_sliding_window;
+    // The supported sliding specialization always uses a compact neighbor-halo buffer.
+    const uint32_t padded_N = has_sliding_window ? global_padded_N : gathered_padded_N;
     const uint32_t kv_cache_batch_idx = args.kv_cache_batch_idx.value_or(0);
     const uint32_t L = has_joint_tensors ? joint_tensor_q->logical_shape()[2] : 0;
     const uint32_t vDH = tensor_args.v_head_dim(args.latent_v_head_dim);
     const bool gqa_grouped_kv = ring_joint::is_gqa_grouped_kv_head_mode(v_shares_k_buffer, NH, NHK, NHV);
     const bool k_uses_batch_chain = ring_joint::uses_shared_k_batch_chain(gqa_grouped_kv, NHK);
+    const bool use_head_chain = enable_kv_chains && !gqa_grouped_kv;
 
     const uint32_t q_local_padded_Nt = q_local_padded_N / tt::constants::TILE_HEIGHT;
     const uint32_t kv_local_padded_Nt = kv_local_padded_N / tt::constants::TILE_HEIGHT;
     const uint32_t padded_Nt = padded_N / tt::constants::TILE_HEIGHT;
+    const uint32_t gathered_padded_Nt = gathered_padded_N / tt::constants::TILE_HEIGHT;
     // Find unpadded sequence lengths in tiles
     const uint32_t Lt = tt::div_up(L, tt::constants::TILE_HEIGHT);
     const uint32_t DHt = DH / tt::constants::TILE_WIDTH;
     const uint32_t vDHt = vDH / tt::constants::TILE_WIDTH;
-    // Rotation is enabled by a host kv_actual_isl scalar OR by the trace-safe metadata path (chunked
-    // only -- `&& is_chunked()` keeps the non-rotation indexed-cache metadata case off). On the metadata
-    // path the per-chunk derived values (logical_nt / q-mapping / masks) are computed in the kernels from
-    // metadata[1]; kv_pad_from_metadata gates that on-device derivation.
-    [[maybe_unused]] const bool kv_pad_from_metadata = tensor_args.has_metadata() && tensor_args.is_chunked();
-    const bool kv_pad_rotation_enabled = args.has_kv_pad_rotation() || kv_pad_from_metadata;
+    const bool kv_pad_rotation_enabled = args.has_kv_pad_rotation();
     const RingJointRuntimePlan runtime_plan = build_runtime_plan(args, tensor_args, ring_write_plan);
     const RingJointRuntimeArgLayout runtime_arg_layout = get_runtime_arg_layout(args, tensor_args);
     const uint32_t logical_nt = runtime_plan.logical_nt;
@@ -854,7 +923,27 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
     // prefill supersedes it via absolute-coords stamps). Both are derived once in build_runtime_plan.
     const bool kernel_chunked = runtime_plan.kernel_chunked;
     const bool kernel_is_causal = runtime_plan.kernel_is_causal;
-    const bool diag_tile_enabled = args.is_causal || kernel_chunked;
+    ring_joint::ChunkedSlidingHaloLayout chunked_sliding_halo_layout;
+    if (has_sliding_window) {
+        chunked_sliding_halo_layout = ring_joint::build_chunked_sliding_halo_layout(
+            q_local_padded_Nt, Sk_chunk_t, sliding_window_size, tt::constants::TILE_HEIGHT, ring_size, logical_nt);
+        TT_FATAL(
+            kernel_chunked && chunked_sliding_halo_layout.uses_neighbor_halo(),
+            "Sliding K/V requires neighbor-halo geometry; gathered rows={}, global rows={}",
+            gathered_padded_N,
+            global_padded_N);
+        TT_FATAL(
+            gathered_padded_N < global_padded_N,
+            "Sliding K/V requires a compact halo buffer; gathered rows={}, global rows={}",
+            gathered_padded_N,
+            global_padded_N);
+        TT_FATAL(
+            gathered_padded_Nt >= chunked_sliding_halo_layout.halo_tile_rows,
+            "Compact sliding K/V buffer has {} tile rows but requires at least {}",
+            gathered_padded_Nt,
+            chunked_sliding_halo_layout.halo_tile_rows);
+    }
+    const bool diag_tile_enabled = (args.is_causal || kernel_chunked) && !has_sliding_window;
 
     // Lightweight mask: needed when any K/joint dimension has padding, or when causal/chunked
     // masking is active.
@@ -867,15 +956,15 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
     const bool global_n_has_padding = (compile_time_logical_n % (Sk_chunk_t * tt::constants::TILE_HEIGHT)) != 0;
     const bool joint_has_padding = L > 0 && (L % (Sk_chunk_t * tt::constants::TILE_HEIGHT)) != 0;
     const bool needs_lightweight_mask =
-        (local_n_has_padding || global_n_has_padding || joint_has_padding) || diag_tile_enabled;
+        (local_n_has_padding || global_n_has_padding || joint_has_padding) || diag_tile_enabled || has_sliding_window;
 
     // Partial tile support when padding boundary falls inside a tile.
     const uint32_t joint_l_partial_col = L % tt::constants::TILE_HEIGHT;
     const uint32_t partial_mask_tiles =
         (compile_time_global_n_partial_col != 0 ? 1 : 0) + (joint_l_partial_col != 0 ? 1 : 0);
-    const uint32_t causal_diag_tiles = diag_tile_enabled ? 1 : 0;
-    // Single CB holds: 1 neginf tile + optional causal diagonal + up to 2 partial mask tiles
-    const uint32_t total_lightweight_mask_tiles = 1 + causal_diag_tiles + partial_mask_tiles;
+    const uint32_t edge_mask_tiles = has_sliding_window ? kSlidingWindowEdgeTiles : (diag_tile_enabled ? 1 : 0);
+    // Single CB holds neginf, either the causal diagonal or sliding edge palette, and partial masks.
+    const uint32_t total_lightweight_mask_tiles = 1 + edge_mask_tiles + partial_mask_tiles;
 
     const uint32_t num_local_q_chunks = tt::div_up(q_local_padded_N, q_chunk_size);
     const uint32_t num_joint_q_chunks = tt::div_up(L, q_chunk_size);
@@ -1161,6 +1250,8 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
     const uint32_t compile_time_single_valid_kv_chunk_mask = kv_pad_rotation_enabled ? 0 : single_valid_kv_chunk_mask;
     const KVPadQMapping compile_time_kv_pad_q_mapping = kv_pad_rotation_enabled ? KVPadQMapping{} : kv_pad_q_mapping;
 
+    const uint32_t q_heads_per_kv = NH / NHK;
+
     // Cores actually issuing Q reads. When the flat q-chunk distribution is smaller
     // than the grid the trailing cores get zero work; zigzag distributes pairs, so
     // the unit count is total_pairs = all_heads_num_q_chunks / 2.
@@ -1201,13 +1292,9 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
         compile_time_active_ring_iter_mask,
         NHV,
         static_cast<uint32_t>(v_shares_k_buffer),
-        // Slot 32: trace-safe slot select. When set, the reader reads kv_cache_batch_idx from
-        // metadata[0] on-device (common runtime arg 0) instead of the per-core kv_cache_batch_idx arg.
-        static_cast<uint32_t>(slot_from_metadata),
-        // Slot 33: trace-safe KV-pad derivation. When set, the reader reads kv_actual_isl from
-        // metadata[1], derives logical_nt / q-mapping / ring masks on-device, overrides its own
-        // logical_nt+active_ring_iter_mask, and pushes the compute-needed values to cb_kv_pad_derived.
-        static_cast<uint32_t>(kv_pad_from_metadata),
+        static_cast<uint32_t>(use_attention_sink),
+        sliding_window_size,
+        gathered_padded_Nt,
     };
 
     TensorAccessorArgs(input_tensor_q.buffer()).append_to(reader_compile_time_args);
@@ -1220,19 +1307,8 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
         TensorAccessorArgs(joint_tensor_k->buffer()).append_to(reader_compile_time_args);
         TensorAccessorArgs(joint_tensor_v->buffer()).append_to(reader_compile_time_args);
     }
-    // Metadata accessors follow the tensor accessors (metadata path only) and precede the chain semaphore
-    // compile args; the reader kernel gates their offsets on slot_from_metadata / kv_pad_from_metadata.
-    // sem_args_offset below is computed after this append, so the chain/CB compile-arg indices stay correct.
-    // slot_id and kv_actual_isl are SEPARATELY allocated single-page DRAM tensors that can land in different
-    // DRAM banks, so each needs its OWN accessor -- a shared accessor's dspec (bank for page 0) is baked
-    // from one buffer and reads the wrong bank for the other (kv read silently returned 0, breaking the
-    // rotation derivation). The writer already appends kv_actual_isl's own accessor for the same reason.
-    if (slot_from_metadata) {
-        TensorAccessorArgs(tensor_args.slot_id->buffer()).append_to(reader_compile_time_args);
-        if (kv_pad_from_metadata) {
-            TensorAccessorArgs(tensor_args.kv_actual_isl->buffer()).append_to(reader_compile_time_args);
-        }
-    }
+    TensorAccessorArgs(attention_sink.has_value() ? attention_sink->buffer() : nullptr)
+        .append_to(reader_compile_time_args);
 
     /**
      * Create semaphores used for L1-L1 store-and-forward of KV between cores.
@@ -1284,27 +1360,36 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
         }
     };
 
-    const auto head_sems = ChainSemaphores::create(desc, core_grid_set);  // head chain (MHA or separate-V V)
+    std::optional<ChainSemaphores> head_sems;
     std::optional<ChainSemaphores> batch_sems;
-    if (k_uses_batch_chain) {
-        batch_sems = ChainSemaphores::create(desc, core_grid_set);  // batch chain (shared K)
-    }
     std::optional<ChainSemaphores> gqa_sems;
-    if (gqa_grouped_kv) {
-        gqa_sems = ChainSemaphores::create(desc, core_grid_set);  // grouped K/V chain
+    if (use_head_chain) {
+        head_sems = ChainSemaphores::create(desc, core_grid_set);  // head chain (MHA or separate-V V)
+    }
+    if (enable_kv_chains) {
+        if (k_uses_batch_chain) {
+            batch_sems = ChainSemaphores::create(desc, core_grid_set);  // shared-K chain
+        }
+        if (gqa_grouped_kv) {
+            gqa_sems = ChainSemaphores::create(desc, core_grid_set);  // grouped K/V chain
+        }
     }
 
     // Append semaphore ids to reader compile-time args (must match reader kernel expectations)
     const auto sem_args_offset = reader_compile_time_args.size();
-    head_sems.append_to_compile_args(reader_compile_time_args);
-    reader_compile_time_args.push_back(0);  // head_mcast_enabled placeholder (patched after chain construction)
-    if (k_uses_batch_chain) {
-        batch_sems->append_to_compile_args(reader_compile_time_args);
-        reader_compile_time_args.push_back(0);  // batch_mcast_enabled placeholder (patched after chain construction)
+    if (use_head_chain) {
+        head_sems->append_to_compile_args(reader_compile_time_args);
+        reader_compile_time_args.push_back(0);  // head_mcast_enabled placeholder (patched after chain construction)
     }
-    if (gqa_grouped_kv) {
-        gqa_sems->append_to_compile_args(reader_compile_time_args);
-        reader_compile_time_args.push_back(0);  // gqa_mcast_enabled placeholder (patched after chain construction)
+    if (enable_kv_chains) {
+        if (k_uses_batch_chain) {
+            batch_sems->append_to_compile_args(reader_compile_time_args);
+            reader_compile_time_args.push_back(0);  // shared-K mcast placeholder
+        }
+        if (gqa_grouped_kv) {
+            gqa_sems->append_to_compile_args(reader_compile_time_args);
+            reader_compile_time_args.push_back(0);  // GQA mcast placeholder
+        }
     }
 
     std::vector<uint32_t> writer_compile_time_args = {
@@ -1342,20 +1427,12 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
         compile_time_active_ring_iter_mask,
         compile_time_last_active_ring_iter,
         compile_time_single_valid_kv_chunk_mask,
-        // Slot 34: trace-safe KV-pad derivation -- the writer recomputes logical_nt + masks from
-        // metadata[1] on-device (it's dataflow). New writer fixed slot -> output accessors shift to 35.
-        static_cast<uint32_t>(kv_pad_from_metadata),
+        sliding_window_size,
     };
 
     TensorAccessorArgs(output_tensor.buffer()).append_to(writer_compile_time_args);
     TensorAccessorArgs(joint_output_tensor.buffer()).append_to(writer_compile_time_args);
     TensorAccessorArgs(stats_output_tensor.buffer()).append_to(writer_compile_time_args);
-    // Metadata accessor follows the output accessors (metadata path only); matches the writer kernel's
-    // meta_args_offset, which is gated on kv_pad_from_metadata. The writer reads kv_actual_isl on-device,
-    // so it uses the kv_actual_isl tensor's accessor (same layout as slot_id).
-    if (kv_pad_from_metadata) {
-        TensorAccessorArgs(tensor_args.kv_actual_isl->buffer()).append_to(writer_compile_time_args);
-    }
 
     std::vector<uint32_t> compute_compile_time_args = {
         B,
@@ -1407,10 +1484,9 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
         compile_time_active_ring_iter_mask,
         compile_time_last_active_ring_iter,
         static_cast<uint32_t>(v_shares_k_buffer),
-        // Trace-safe KV-pad derivation: when set, compute reads logical_nt / q-mapping /
-        // active_ring_iter_mask from cb_kv_pad_derived (produced by the reader) instead of its runtime
-        // args, so a captured trace replays across chunks. New compute fixed slot -> cb_arg_offset += 1.
-        static_cast<uint32_t>(kv_pad_from_metadata)};
+        static_cast<uint32_t>(use_attention_sink),
+        sliding_window_size,
+    };
 
     std::map<std::string, std::string> defines;
     defines["STATS_GRANULARITY"] = std::to_string(stats_granularity);
@@ -1494,10 +1570,19 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
     const uint32_t cb_mask_in =
         needs_lightweight_mask ? allocate_tile_cb(total_lightweight_mask_tiles, mask_tile_size, mask_df) : inactive_cb;
 
+    // Streaming normalization broadcasts the per-head sink scalar directly.
+    // Alias a valid CB while disabled so compile-time tile-size queries remain valid;
+    // sink producer/consumer code is removed by if constexpr in that specialization.
+    const uint32_t cb_attention_sink = [&]() {
+        if (!use_attention_sink) {
+            return cb_q_in;
+        }
+        const tt::DataFormat sink_df = tt::tt_metal::datatype_to_dataformat_converter(attention_sink.value().dtype());
+        return allocate_tile_cb(1, tt::tile_size(sink_df), sink_df);
+    }();
+
     const uint32_t cb_scale_in = allocate_tile_cb(scale_tiles, scalar_tile_size, scalar_df);
     const uint32_t cb_identity_scale_in = allocate_tile_cb(scale_tiles, scalar_tile_size, scalar_df);
-    const uint32_t cb_stats_in = allocate_tile_cb(statistics_tiles, im_tile_size, im_df);
-    const uint32_t cb_prev_out = allocate_tile_cb(out_im_tiles, out_tile_size, out_df);
     const uint32_t cb_col_identity = allocate_tile_cb(scale_tiles, scalar_tile_size, scalar_df);
 
     const uint32_t cb_qk_im = allocate_tile_cb(qk_tiles, qk_im_tile_size, qk_im_df);
@@ -1510,7 +1595,17 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
     const uint32_t cb_exp_max_diff = allocate_tile_cb(statistics_tiles, stats_tile_size, stats_df);
 
     const uint32_t cb_out = allocate_tile_cb(out0_t, out_tile_size, out_df);
-    const uint32_t cb_stats_out = allocate_tile_cb(statistics_tiles, im_tile_size, im_df);
+
+    // Sliding folds every local/halo K/V range into one final pass per Q, so it never saves
+    // or restores accumulators through DRAM. Keep valid, format-compatible CB indices in the
+    // compile-time ABI without reserving separate L1 storage for those unreachable paths.
+    const bool needs_dram_accumulator_staging = !has_sliding_window;
+    const uint32_t cb_stats_in =
+        needs_dram_accumulator_staging ? allocate_tile_cb(statistics_tiles, im_tile_size, im_df) : cb_max_A;
+    const uint32_t cb_prev_out =
+        needs_dram_accumulator_staging ? allocate_tile_cb(out_im_tiles, out_tile_size, out_df) : cb_out;
+    const uint32_t cb_stats_out =
+        needs_dram_accumulator_staging ? allocate_tile_cb(statistics_tiles, im_tile_size, im_df) : cb_max_B;
 
     // Streaming compute v2: 1-tile recip scratch CB for normalize_row_streaming.
     // cb_scale_in is live in ring joint, so streaming uses a dedicated scratch CB.
@@ -1520,9 +1615,15 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
     // cb_sum_out = compute pushes sum for writer to save to DRAM.
     // cb_sum_in = writer pushes restored sum from DRAM for compute to read.
     const uint32_t cb_sum_out =
-        use_streaming_compute ? allocate_tile_cb(statistics_tiles, stats_tile_size, stats_df) : inactive_cb;
+        use_streaming_compute
+            ? (needs_dram_accumulator_staging ? allocate_tile_cb(statistics_tiles, stats_tile_size, stats_df)
+                                              : cb_sum_A)
+            : inactive_cb;
     const uint32_t cb_sum_in =
-        use_streaming_compute ? allocate_tile_cb(statistics_tiles, stats_tile_size, stats_df) : inactive_cb;
+        use_streaming_compute
+            ? (needs_dram_accumulator_staging ? allocate_tile_cb(statistics_tiles, stats_tile_size, stats_df)
+                                              : cb_sum_B)
+            : inactive_cb;
 
     // Signal CB: compute signals writer when last K-chunk starts.
     // 1 page suffices: writer pops during SALAD before compute pushes the next Q's signal.
@@ -1530,67 +1631,40 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
     const uint32_t cb_signal =
         use_streaming_compute ? allocate_cb(signal_page_size, 1, tt::DataFormat::UInt16) : inactive_cb;
 
-    // Trace-safe KV-pad path: 1-page L1 CB the reader uses to hand the on-device-derived per-chunk
-    // scalars (logical_nt, 4 q-mapping tiles, active_ring_iter_mask) to the compute kernel, which cannot
-    // NoC-read the metadata DRAM tensor itself. Allocated unconditionally (tiny); only used when
-    // kv_pad_from_metadata. 64B page holds the 6 uint32 with headroom.
-    const uint32_t cb_kv_pad_derived = allocate_cb(64, 1, tt::DataFormat::UInt32);
-
     const std::vector<uint32_t> cb_compile_time_args = {
-        cb_q_in,
-        cb_k_in,
-        cb_v_in,
-        cb_mask_in,
-        cb_scale_in,
-        cb_identity_scale_in,
-        cb_stats_in,
-        cb_prev_out,
-        cb_col_identity,
-        cb_recip_scratch,
-        cb_sum_out,
-        cb_sum_in,
-        cb_signal,
-        cb_out,
-        cb_stats_out,
-        cb_qk_im,
-        cb_out_im_A,
-        cb_out_im_B,
-        cb_max_A,
-        cb_max_B,
-        cb_sum_A,
-        cb_sum_B,
-        cb_exp_max_diff,
-        // index 23: compute reads the reader-produced KV-pad scalars from here (cb_arg_offset + 23).
-        cb_kv_pad_derived};
-    const std::vector<uint32_t> reader_cb_compile_time_args = {cb_q_in, cb_k_in, cb_v_in, cb_kv_pad_derived};
+        cb_q_in,     cb_k_in,     cb_v_in,         cb_mask_in,       cb_scale_in,    cb_identity_scale_in,
+        cb_stats_in, cb_prev_out, cb_col_identity, cb_recip_scratch, cb_sum_out,     cb_sum_in,
+        cb_signal,   cb_out,      cb_stats_out,    cb_qk_im,         cb_out_im_A,    cb_out_im_B,
+        cb_max_A,    cb_max_B,    cb_sum_A,        cb_sum_B,         cb_exp_max_diff};
+    const std::vector<uint32_t> reader_cb_compile_time_args = {cb_q_in, cb_k_in, cb_v_in, cb_attention_sink};
     reader_compile_time_args.insert(
         reader_compile_time_args.end(), reader_cb_compile_time_args.begin(), reader_cb_compile_time_args.end());
     writer_compile_time_args.insert(
         writer_compile_time_args.end(), cb_compile_time_args.begin(), cb_compile_time_args.end());
+    auto compute_cb_compile_time_args = cb_compile_time_args;
+    compute_cb_compile_time_args.push_back(cb_attention_sink);
     compute_compile_time_args.insert(
-        compute_compile_time_args.end(), cb_compile_time_args.begin(), cb_compile_time_args.end());
+        compute_compile_time_args.end(), compute_cb_compile_time_args.begin(), compute_cb_compile_time_args.end());
 
     auto* const q_buf = input_tensor_q.buffer();
     auto* const k_buf = input_tensor_k.buffer();
     auto* const v_buf = input_tensor_v.buffer();
     auto* const gathered_k_buf = gathered_input_tensor_k.buffer();
     auto* const gathered_v_buf = gathered_input_tensor_v.buffer();
+    auto* const attention_sink_buf = attention_sink.has_value() ? attention_sink->buffer() : nullptr;
     auto* const out_buf = output_tensor.buffer();
     auto* const joint_out_buf = joint_output_tensor.buffer();
     auto* const stats_buf = stats_output_tensor.buffer();
 
     /**
-     * Build chain selection for store-and-forward across cores per (batch, head).
+     * Build chain selection for store-and-forward across cores per head.
      */
     struct CoreHeadWork {
-        uint32_t batch = 0;
         uint32_t head = 0;
-        uint32_t q_chunk_start = 0;
         uint32_t q_chunk_count = 0;
     };
 
     struct CoreWork {
-        CoreCoord logical_core;
         CoreCoord physical_core;
         uint32_t global_q_start = 0;
         uint32_t global_q_count = 0;
@@ -1602,16 +1676,15 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
         uint32_t head_work_index = 0;
     };
 
-    // Unified chain configuration for both head-level (V chain, K in non-MLA) and batch-level (K in MLA) chains
+    // Unified chain configuration for head-level and shared-K chains.
     struct ChainConfig {
         // Core participation flags
         bool participates = false;
         bool is_injector = false;
         bool is_sink = false;
 
-        // Chain scope: batch is always used; head distinguishes head-level vs batch-level
-        uint32_t batch = 0;
-        uint32_t head = 0;  // 0 for batch-level shared-K chains
+        // Chain scope: head distinguishes head-level from shared-K chains.
+        uint32_t head = 0;  // 0 for shared-K chains
 
         // Linear chain topology
         CoreCoord prev_physical = CoreCoord{0, 0};
@@ -1623,7 +1696,6 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
         CoreCoord mcast_end = CoreCoord{0, 0};          // Rectangle end (physical)
         CoreCoord injector_physical = CoreCoord{0, 0};  // Injector's coords (for receiver sem addr in mcast)
         uint32_t mcast_num_dests = 0;                   // Receivers count (excludes self)
-        uint32_t mcast_sender_wait = 0;                 // Semaphore wait count
 
         // Append runtime args in canonical order
         void append_to_args(std::vector<uint32_t>& args) const {
@@ -1631,7 +1703,6 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
             args.push_back(static_cast<uint32_t>(participates));
             args.push_back(static_cast<uint32_t>(is_injector));
             args.push_back(static_cast<uint32_t>(is_sink));
-            args.push_back(batch);
             args.push_back(head);
             args.push_back(static_cast<uint32_t>(prev_physical.x));
             args.push_back(static_cast<uint32_t>(prev_physical.y));
@@ -1645,7 +1716,6 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
             args.push_back(static_cast<uint32_t>(injector_physical.x));
             args.push_back(static_cast<uint32_t>(injector_physical.y));
             args.push_back(mcast_num_dests);
-            args.push_back(mcast_sender_wait);
             TT_FATAL(
                 args.size() == start_size + kRingJointChainConfigArgCount,
                 "RingJoint ChainConfig expected to append {} runtime args, appended {}",
@@ -1655,11 +1725,13 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
     };
 
     std::vector<CoreWork> core_work(num_cores);
-    std::vector<ChainConfig> head_chain_configs(num_cores);   // MHA K/V chain or separate-V V chain
-    std::vector<ChainConfig> batch_chain_configs(num_cores);  // Shared-K chain for separate-V/latent modes
-    std::vector<ChainConfig> gqa_chain_configs(num_cores);    // Grouped K/V chain for GQA_GROUPED_KV
-    const uint32_t total_heads = B * NH;
-    std::vector<std::vector<HeadSegmentRef>> head_segments(total_heads);
+    std::vector<ChainConfig> head_chain_configs(use_head_chain ? num_cores : 0);  // MHA K/V or separate-V V
+    std::vector<ChainConfig> batch_chain_configs(
+        enable_kv_chains && k_uses_batch_chain ? num_cores : 0);  // Shared K for separate-V/latent modes
+    std::vector<ChainConfig> gqa_chain_configs(
+        enable_kv_chains && gqa_grouped_kv ? num_cores : 0);  // Grouped K/V for GQA
+    // Sliding attention reads K/V independently on every core and does not build chains.
+    std::vector<std::vector<HeadSegmentRef>> head_segments(use_head_chain ? NH : 0);
 
     // Evenly distribute flat global q chunks across cores
     const uint32_t total_q_chunks = B * NH * num_q_chunks;
@@ -1685,9 +1757,8 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
         const uint32_t head_span = num_q_chunks;
         const uint32_t head_index = head_span == 0 ? 0 : (flat_chunk_index / head_span);
         const uint32_t q_chunk = head_span == 0 ? 0 : (flat_chunk_index % head_span);
-        const uint32_t batch = (NH == 0) ? 0 : (head_index / NH);
         const uint32_t head = (NH == 0) ? 0 : (head_index % NH);
-        return std::tuple<uint32_t, uint32_t, uint32_t>{batch, head, q_chunk};
+        return std::pair<uint32_t, uint32_t>{head, q_chunk};
     };
 
     for (uint32_t i = 0; i < num_cores; ++i) {
@@ -1700,7 +1771,6 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
         }
 
         auto& work = core_work.at(i);
-        work.logical_core = core;
         work.physical_core = device->worker_core_from_logical_core(core);
         work.global_q_start = next_global_chunk;
         work.global_q_count = chunk_count;
@@ -1708,21 +1778,22 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
         uint32_t remaining = chunk_count;
         uint32_t flat_chunk = next_global_chunk;
         while (remaining > 0) {
-            auto [batch_idx, head_idx, q_chunk_idx] = decode_flat_chunk(flat_chunk);
+            auto [head_idx, q_chunk_idx] = decode_flat_chunk(flat_chunk);
             uint32_t chunk_capacity_in_head = num_q_chunks - q_chunk_idx;
             uint32_t chunk_take = std::min(remaining, chunk_capacity_in_head);
 
-            work.head_work.push_back(CoreHeadWork{
-                .batch = batch_idx,
-                .head = head_idx,
-                .q_chunk_start = q_chunk_idx,
-                .q_chunk_count = chunk_take,
-            });
-
-            if (!head_segments.empty()) {
-                uint32_t head_id = (batch_idx * NH) + head_idx;
-                if (head_id < head_segments.size()) {
-                    head_segments[head_id].push_back(HeadSegmentRef{
+            if (enable_kv_chains) {
+                work.head_work.push_back(CoreHeadWork{
+                    .head = head_idx,
+                    .q_chunk_count = chunk_take,
+                });
+                if (use_head_chain) {
+                    TT_FATAL(
+                        head_idx < head_segments.size(),
+                        "Head-chain segment index {} is outside {} configured query heads",
+                        head_idx,
+                        head_segments.size());
+                    head_segments[head_idx].push_back(HeadSegmentRef{
                         .core_idx = i, .head_work_index = static_cast<uint32_t>(work.head_work.size() - 1)});
                 }
             }
@@ -1741,7 +1812,6 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
     // - injector reselection for mcast is done separately in the mcast eligibility pass
     using ChainSegment = std::pair<uint32_t, uint32_t>;  // (core_idx, q_chunk_count)
     auto build_linear_chain = [](const std::vector<ChainSegment>& chain_segs,
-                                 uint32_t batch,
                                  uint32_t head,
                                  std::vector<ChainConfig>& chain_configs,
                                  const std::vector<CoreWork>& core_work,
@@ -1767,7 +1837,6 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
             uint32_t ci = chain_segs[idx].first;
             auto& cfg = chain_configs[ci];
             cfg.participates = true;
-            cfg.batch = batch;
             cfg.head = head;
             cfg.is_injector = (idx == start);
             cfg.is_sink = (idx == chain_segs.size() - 1);
@@ -1846,15 +1915,12 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
     };
 
     auto configure_row_wide_chain_mcast = [&](const RowWideChainMcastSelection& selection,
-                                              uint32_t batch,
                                               uint32_t head,
                                               std::vector<ChainConfig>& chain_configs,
                                               std::vector<uint32_t>& chain_max_q) {
-        for (uint32_t col = 0; col < grid_size.x; ++col) {
-            const uint32_t ci = selection.row * grid_size.x + col;
+        const auto configure_core = [&](uint32_t ci) {
             auto& cfg = chain_configs[ci];
             cfg.participates = true;
-            cfg.batch = batch;
             cfg.head = head;
             cfg.prev_physical = CoreCoord{0, 0};
             cfg.next_physical = CoreCoord{0, 0};
@@ -1865,19 +1931,20 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
             cfg.is_sink = !cfg.is_injector;
             if (cfg.is_injector) {
                 cfg.mcast_num_dests = selection.num_receivers;
-                cfg.mcast_sender_wait = selection.num_receivers;
                 cfg.next_core_q_chunks = selection.max_q;
             } else {
                 cfg.mcast_num_dests = 0;
-                cfg.mcast_sender_wait = 0;
                 cfg.next_core_q_chunks = 0;
             }
             chain_max_q[ci] = selection.max_q;
+        };
+        for (uint32_t col = 0; col < grid_size.x; ++col) {
+            configure_core(selection.row * grid_size.x + col);
         }
     };
 
     // Build head chains for MHA and separate-V shared-K. GQA uses KV-head-grouped chains instead.
-    if (!gqa_grouped_kv) {
+    if (use_head_chain) {
         for (uint32_t head_id = 0; head_id < static_cast<uint32_t>(head_segments.size()); ++head_id) {
             const auto& segs = head_segments[head_id];
             if (segs.size() < 2) {
@@ -1889,13 +1956,13 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
                 chain_segs.emplace_back(
                     seg.core_idx, core_work[seg.core_idx].head_work[seg.head_work_index].q_chunk_count);
             }
-            build_linear_chain(chain_segs, head_id / NH, head_id % NH, head_chain_configs, core_work);
+            build_linear_chain(chain_segs, head_id, head_chain_configs, core_work);
         }
     }
 
     // Check query-head chain multicast eligibility and configure mcast for eligible chains.
     uint32_t mcast_chains = 0;
-    {
+    if (use_head_chain) {
         struct McastCandidate {
             std::vector<uint32_t> core_indices;
             uint32_t ref_q_chunks;
@@ -1914,8 +1981,7 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
             std::vector<uint32_t> chain_q_counts;
             for (const auto& seg : segments) {
                 if (seg.core_idx < head_chain_configs.size() && head_chain_configs[seg.core_idx].participates &&
-                    head_chain_configs[seg.core_idx].batch == (head_id / NH) &&
-                    head_chain_configs[seg.core_idx].head == (head_id % NH)) {
+                    head_chain_configs[seg.core_idx].head == head_id) {
                     chain_core_indices.push_back(seg.core_idx);
                     chain_q_counts.push_back(core_work[seg.core_idx].head_work[seg.head_work_index].q_chunk_count);
                 }
@@ -2043,7 +2109,6 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
                 injector_chain.mcast_end = rect_end;
                 injector_chain.injector_physical = injector_phys;
                 injector_chain.mcast_num_dests = num_receivers;
-                injector_chain.mcast_sender_wait = num_receivers;
                 injector_chain.next_core_q_chunks = cand.ref_q_chunks;
 
                 for (const auto& ci : cand.core_indices) {
@@ -2085,10 +2150,9 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
     uint32_t gqa_local_fallback_cores = 0;
     bool gqa_mcast_enabled = false;
     std::string gqa_mcast_fallback_reason;
-    std::vector<uint32_t> gqa_chain_max_q(num_cores, 0);  // per-core loop-padding count
-    if (gqa_grouped_kv) {
-        const uint32_t q_heads_per_kv = NH / NHK;
-        std::vector<std::vector<ChainSegment>> kv_group_segments(B * NHK);
+    std::vector<uint32_t> gqa_chain_max_q(gqa_chain_configs.size(), 0);  // per-core loop-padding count
+    if (gqa_grouped_kv && enable_kv_chains) {
+        std::vector<std::vector<ChainSegment>> kv_group_segments(NHK);
 
         for (uint32_t ci = 0; ci < num_cores; ++ci) {
             if (core_work[ci].global_q_count == 0) {
@@ -2101,11 +2165,10 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
             uint32_t q_chunk_count = 0;
             for (const auto& hw : core_work[ci].head_work) {
                 const uint32_t kv_head = hw.head / q_heads_per_kv;
-                const uint32_t group_id = hw.batch * NHK + kv_head;
                 if (!has_single_group) {
                     has_single_group = true;
-                    single_group_id = group_id;
-                } else if (single_group_id != group_id) {
+                    single_group_id = kv_head;
+                } else if (single_group_id != kv_head) {
                     spans_multiple_groups = true;
                     break;
                 }
@@ -2120,25 +2183,20 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
             }
         }
 
-        for (uint32_t group_id = 0; group_id < static_cast<uint32_t>(kv_group_segments.size()); ++group_id) {
-            const auto& chain_segs = kv_group_segments[group_id];
+        for (uint32_t kv_head = 0; kv_head < static_cast<uint32_t>(kv_group_segments.size()); ++kv_head) {
+            const auto& chain_segs = kv_group_segments[kv_head];
             if (chain_segs.size() < 2) {
                 continue;
             }
-            const uint32_t batch = group_id / NHK;
-            const uint32_t kv_head = group_id % NHK;
-            if (build_linear_chain(chain_segs, batch, kv_head, gqa_chain_configs, core_work, false)) {
+            if (build_linear_chain(chain_segs, kv_head, gqa_chain_configs, core_work, false)) {
                 gqa_grouped_chains++;
             }
         }
 
         // Production Minimax3 GQA has one local K/V head per chip (B=1, NHK=NHV=1). In that case every
-        // active Q-head core consumes the same K and V chunks, so use row-wide multicast instead of
-        // the store-and-forward grouped chain. Idle cores inside an active row also participate with
-        // padded iterations so the multicast rectangle never writes into a non-participating worker.
-        if (B > 1) {
-            gqa_mcast_fallback_reason = "B > 1 (multi-batch GQA mcast not supported)";
-        } else if (NHK != 1) {
+        // active Q-head core consumes the same K and V chunks, so use row-wide multicast instead
+        // of the store-and-forward grouped chain. Idle cores in an active row participate in padded iterations.
+        if (NHK != 1) {
             gqa_mcast_fallback_reason = "NHK != 1 (multi-KV-head GQA mcast not supported)";
         } else if (num_cores < 2) {
             gqa_mcast_fallback_reason = "num_cores < 2";
@@ -2149,14 +2207,12 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
             uint32_t gqa_mcast_rows = 0;
 
             for (uint32_t row = 0; row < grid_size.y; ++row) {
-                const std::optional<RowWideChainMcastSelection> selection =
-                    select_row_wide_chain_mcast(row, recent_cols);
+                const auto selection = select_row_wide_chain_mcast(row, recent_cols);
                 if (!selection.has_value()) {
                     continue;
                 }
-                configure_row_wide_chain_mcast(*selection, 0, 0, gqa_chain_configs, gqa_chain_max_q);
+                configure_row_wide_chain_mcast(*selection, 0, gqa_chain_configs, gqa_chain_max_q);
                 gqa_mcast_rows++;
-
                 log_debug(
                     tt::LogOp,
                     "GQA K/V mcast row {}: injector core {} phys=({},{}) max_q={}, rect ({},{})-({},{})",
@@ -2173,55 +2229,47 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
 
             gqa_mcast_enabled = gqa_mcast_rows > 0;
             if (!gqa_mcast_enabled) {
-                gqa_mcast_fallback_reason = "no active rows";
+                gqa_mcast_fallback_reason = "no active groups";
             }
         }
     }
 
-    // Build batch chains (K chain): one per batch for shared-K separate-V/latent cases.
-    // K is shared across all heads, so all active cores in a batch form one chain.
+    // Build the shared-K chain for separate-V/latent cases.
+    // K is shared across all heads, so all active cores form one chain.
     // Sorted by physical position for a stable unicast ordering (overwritten by mcast pass if eligible).
-    if (k_uses_batch_chain) {
-        std::map<uint32_t, std::vector<uint32_t>> batch_to_cores;
+    if (k_uses_batch_chain && enable_kv_chains) {
+        std::vector<uint32_t> core_indices;
         for (uint32_t i = 0; i < num_cores; ++i) {
             if (core_work[i].global_q_count == 0) {
                 continue;
             }
-            for (const auto& hw : core_work[i].head_work) {
-                batch_to_cores[hw.batch].push_back(i);
-                break;  // Each core only counted once per batch
-            }
+            core_indices.push_back(i);
         }
 
-        for (auto& [batch, core_indices] : batch_to_cores) {
-            std::sort(core_indices.begin(), core_indices.end(), [&](uint32_t a, uint32_t b) {
-                const auto& pa = core_work[a].physical_core;
-                const auto& pb = core_work[b].physical_core;
-                return (pa.y < pb.y) || (pa.y == pb.y && pa.x < pb.x);
-            });
+        std::sort(core_indices.begin(), core_indices.end(), [&](uint32_t a, uint32_t b) {
+            const auto& pa = core_work[a].physical_core;
+            const auto& pb = core_work[b].physical_core;
+            return (pa.y < pb.y) || (pa.y == pb.y && pa.x < pb.x);
+        });
 
-            // K scope is per-batch (head=0 unused); work count = total q iterations per core
-            std::vector<ChainSegment> chain_segs;
-            chain_segs.reserve(core_indices.size());
-            for (uint32_t ci : core_indices) {
-                chain_segs.emplace_back(ci, core_work[ci].global_q_count);
-            }
-            if (build_linear_chain(chain_segs, batch, 0, batch_chain_configs, core_work)) {
-                log_debug(tt::LogOp, "K unicast chain for batch {}: {} cores", batch, chain_segs.size());
-            }
+        std::vector<ChainSegment> chain_segs;
+        chain_segs.reserve(core_indices.size());
+        for (uint32_t ci : core_indices) {
+            chain_segs.emplace_back(ci, core_work[ci].global_q_count);
+        }
+        if (build_linear_chain(chain_segs, 0, batch_chain_configs, core_work)) {
+            log_debug(tt::LogOp, "K unicast chain: {} cores", chain_segs.size());
         }
     }
 
-    // K multicast pass: one mcast chain per logical row. Shared-K keeps the legacy all-or-nothing policy:
-    // every row must contain work, otherwise the previously built linear batch chain remains active.
+    // K multicast pass: one mcast chain per logical row. Shared-K keeps the all-or-nothing policy:
+    // every row must contain work, otherwise the previously built linear chain remains active.
     bool k_mcast_enabled = false;
     std::string k_mcast_fallback_reason;
-    std::vector<uint32_t> k_chain_max_q(num_cores, 0);  // per-core loop-padding count
+    std::vector<uint32_t> k_chain_max_q(batch_chain_configs.size(), 0);  // per-core loop-padding count
 
-    if (!k_uses_batch_chain) {
-        // No non-GQA shared-K batch chain to multicast.
-    } else if (B > 1) {
-        k_mcast_fallback_reason = "B > 1 (multi-batch not supported)";
+    if (!k_uses_batch_chain || !enable_kv_chains) {
+        // No non-GQA shared-K chain to multicast.
     } else if (num_cores < 2) {
         k_mcast_fallback_reason = "num_cores < 2";
     } else if (grid_size.x < 2) {
@@ -2247,7 +2295,7 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
             k_mcast_enabled = true;
 
             for (const auto& selection : row_mcast_selections) {
-                configure_row_wide_chain_mcast(selection, 0, 0, batch_chain_configs, k_chain_max_q);
+                configure_row_wide_chain_mcast(selection, 0, batch_chain_configs, k_chain_max_q);
 
                 log_debug(
                     tt::LogOp,
@@ -2268,25 +2316,31 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
     // Update mcast compile-time args
     const bool head_mcast_enabled = (mcast_chains > 0);
 
-    reader_compile_time_args[sem_args_offset + kRingJointChainMcastEnabledCompileArgOffset] =
-        head_mcast_enabled ? 1 : 0;
-    // Batch chain args only present when k_uses_batch_chain.
-    if (k_uses_batch_chain) {
-        const uint32_t batch_mcast_arg_index =
-            sem_args_offset + kRingJointChainCompileArgCount + kRingJointChainMcastEnabledCompileArgOffset;
-        reader_compile_time_args[batch_mcast_arg_index] = k_mcast_enabled ? 1 : 0;
+    if (use_head_chain) {
+        reader_compile_time_args[sem_args_offset + kRingJointChainMcastEnabledCompileArgOffset] =
+            head_mcast_enabled ? 1 : 0;
     }
-    if (gqa_grouped_kv) {
-        const uint32_t gqa_mcast_arg_index =
-            sem_args_offset + kRingJointChainCompileArgCount + kRingJointChainMcastEnabledCompileArgOffset;
-        reader_compile_time_args[gqa_mcast_arg_index] = gqa_mcast_enabled ? 1 : 0;
+    if (enable_kv_chains) {
+        const uint32_t head_chain_compile_args = use_head_chain ? kRingJointChainCompileArgCount : 0;
+        if (k_uses_batch_chain) {
+            const uint32_t batch_mcast_arg_index =
+                sem_args_offset + head_chain_compile_args + kRingJointChainMcastEnabledCompileArgOffset;
+            reader_compile_time_args[batch_mcast_arg_index] = k_mcast_enabled ? 1 : 0;
+        }
+        if (gqa_grouped_kv) {
+            const uint32_t batch_chain_compile_args = k_uses_batch_chain ? kRingJointChainCompileArgCount : 0;
+            const uint32_t gqa_mcast_arg_index = sem_args_offset + head_chain_compile_args + batch_chain_compile_args +
+                                                 kRingJointChainMcastEnabledCompileArgOffset;
+            reader_compile_time_args[gqa_mcast_arg_index] = gqa_mcast_enabled ? 1 : 0;
+        }
     }
 
     if (gqa_grouped_kv) {
         log_debug(
             tt::LogOp,
             "K/V chain mode: grouped GQA {} (chains={}, participant_cores={}, local_fallback_cores={})",
-            gqa_mcast_enabled ? "mcast" : fmt::format("unicast, {}", gqa_mcast_fallback_reason),
+            enable_kv_chains ? (gqa_mcast_enabled ? "mcast" : fmt::format("unicast, {}", gqa_mcast_fallback_reason))
+                             : "independent per-core sliding reads",
             gqa_grouped_chains,
             gqa_grouped_participant_cores,
             gqa_local_fallback_cores);
@@ -2314,25 +2368,6 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
     reader_kernel.compile_time_args = reader_compile_time_args;
     reader_kernel.defines = kernel_defines;
     reader_kernel.config = ReaderConfigDescriptor{};
-    // Trace-safe slot select: the slot_id tensor's raw DRAM address is common runtime arg 0; the reader
-    // reads slot = slot_id[0] from it on-device. Raw address (not a Buffer* binding) mirrors the proven
-    // update_padded_kv_cache pattern. The address is constant across chunks (persistent tensor), so a
-    // captured trace replays correctly without re-patching.
-    if (slot_from_metadata) {
-        // Common arg 0: slot_id DRAM address (reader reads slot = slot_id[0]).
-        // Common args 1/2: (user, layer)-major KV-cache batch factor, so the reader computes the slot as
-        // slot_id[0] * kv_cache_num_layers + kv_cache_layer_idx (matches update_padded_kv_cache). These
-        // are structural per-layer constants -- one program per layer -- so they're set once at create
-        // time and need no per-dispatch re-patch (a captured trace replays correctly). Defaults (1, 0)
-        // reduce the slot to slot_id[0], keeping single-layer callers bit-identical.
-        // Common arg 3: kv_actual_isl DRAM address (reader reads kv_actual_isl = kv_actual_isl_tensor[0]
-        // when kv_pad_from_metadata). Both 1-element tensors share one accessor (meta_args).
-        reader_kernel.emplace_common_runtime_args(
-            {tensor_args.slot_id->buffer()->address(),  // smuggled-rta-ok: metadata tensor addr (on-device)
-             args.kv_cache_num_layers,
-             args.kv_cache_layer_idx,
-             tensor_args.kv_actual_isl->buffer()->address()});  // smuggled-rta-ok: metadata tensor addr (on-device)
-    }
 
     KernelDescriptor writer_kernel{};
     writer_kernel.kernel_source =
@@ -2342,12 +2377,6 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
     writer_kernel.compile_time_args = writer_compile_time_args;
     writer_kernel.defines = kernel_defines;
     writer_kernel.config = WriterConfigDescriptor{};
-    // Trace-safe KV-pad derivation: the kv_actual_isl tensor's raw DRAM address is common runtime arg 0;
-    // the writer reads kv_actual_isl = kv_actual_isl_tensor[0] from it on-device (mirrors the reader).
-    if (kv_pad_from_metadata) {
-        writer_kernel.emplace_common_runtime_args(
-            {tensor_args.kv_actual_isl->buffer()->address()});  // smuggled-rta-ok: metadata tensor addr (on-device)
-    }
 
     KernelDescriptor compute_kernel{};
     compute_kernel.kernel_source =
@@ -2388,55 +2417,50 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
             reader_args.push_back(joint_tensor_k->buffer());
             reader_args.push_back(joint_tensor_v->buffer());
         }
+        reader_args.push_back(attention_sink_buf);
         reader_args.push_back(global_q_start);
         reader_args.push_back(global_q_end);
         reader_args.push_checked(
             runtime_arg_layout.reader_kv_cache_batch_idx, kv_cache_batch_idx, "reader.kv_cache_batch_idx");
-        // Append chain runtime args for store-and-forward
-        const auto& head_chain = head_chain_configs.at(i);
-        const auto& batch_chain = batch_chain_configs.at(i);
-        const auto& gqa_chain = gqa_chain_configs.at(i);
+        if (use_head_chain) {
+            const auto& head_chain = head_chain_configs.at(i);
+            log_debug(
+                tt::LogOp,
+                "core logical=({},{})->phys=({},{}), q=[{},{}), head_chain={{part:{}, inj:{}, sink:{}, "
+                "h:{}, next_cnt:{}}}",
+                core.x,
+                core.y,
+                core_work.at(i).physical_core.x,
+                core_work.at(i).physical_core.y,
+                global_q_start,
+                global_q_end,
+                head_chain.participates,
+                head_chain.is_injector,
+                head_chain.is_sink,
+                head_chain.head,
+                head_chain.next_core_q_chunks);
 
-        log_debug(
-            tt::LogOp,
-            "core logical=({},{})->phys=({},{}), q=[{},{}), head_chain={{part:{}, inj:{}, sink:{}, "
-            "b:{}, h:{}, next_cnt:{}}}, gqa_chain={{part:{}, inj:{}, sink:{}, b:{}, kvh:{}, next_cnt:{}}}",
-            core.x,
-            core.y,
-            core_work.at(i).physical_core.x,
-            core_work.at(i).physical_core.y,
-            global_q_start,
-            global_q_end,
-            head_chain.participates,
-            head_chain.is_injector,
-            head_chain.is_sink,
-            head_chain.batch,
-            head_chain.head,
-            head_chain.next_core_q_chunks,
-            gqa_chain.participates,
-            gqa_chain.is_injector,
-            gqa_chain.is_sink,
-            gqa_chain.batch,
-            gqa_chain.head,
-            gqa_chain.next_core_q_chunks);
-
-        // Head chain: 18 args via unified layout. MHA uses it for K/V; separate-V shared-K uses it for V only.
-        std::vector<uint32_t> head_chain_args;
-        head_chain.append_to_args(head_chain_args);
-        reader_args.append(head_chain_args);
-
-        // Batch chain: 18 args + 1 for loop padding (only for shared-K separate-V/latent modes).
-        if (k_uses_batch_chain) {
-            std::vector<uint32_t> batch_chain_args;
-            batch_chain.append_to_args(batch_chain_args);
-            reader_args.append(batch_chain_args);
-            reader_args.push_back(k_chain_max_q[i]);  // For K mcast loop padding (per-chain)
+            // Head chain: MHA uses it for K/V; separate-V shared-K uses it for V only.
+            std::vector<uint32_t> head_chain_args;
+            head_chain.append_to_args(head_chain_args);
+            reader_args.append(head_chain_args);
         }
-        if (gqa_grouped_kv) {
-            std::vector<uint32_t> gqa_chain_args;
-            gqa_chain.append_to_args(gqa_chain_args);
-            reader_args.append(gqa_chain_args);
-            reader_args.push_back(gqa_chain_max_q[i]);  // For GQA K/V mcast loop padding (per row).
+
+        if (enable_kv_chains) {
+            if (k_uses_batch_chain) {
+                const auto& batch_chain = batch_chain_configs.at(i);
+                std::vector<uint32_t> batch_chain_args;
+                batch_chain.append_to_args(batch_chain_args);
+                reader_args.append(batch_chain_args);
+                reader_args.push_back(k_chain_max_q[i]);
+            }
+            if (gqa_grouped_kv) {
+                const auto& gqa_chain = gqa_chain_configs.at(i);
+                std::vector<uint32_t> gqa_chain_args;
+                gqa_chain.append_to_args(gqa_chain_args);
+                reader_args.append(gqa_chain_args);
+                reader_args.push_back(gqa_chain_max_q[i]);
+            }
         }
 
         reader_args.push_checked(runtime_arg_layout.reader_logical_nt, logical_nt, "reader.logical_nt");
@@ -2520,47 +2544,59 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
         all_gather_input_tensors.push_back(input_tensor_v);
         all_gather_output_tensors.push_back(gathered_input_tensor_v);
     }
-    // Append the all-gather portion to `desc`. Buffer addresses are auto-patched on cache hits; the
-    // indexed-mode input_batch_base scalar is re-patched in apply_ring_joint_scalar_runtime_args.
-    // Single-slot gather is engaged whenever the op is in indexed mode -- either a host kv_cache_batch_idx
-    // (scalar path) or a metadata tensor (trace-safe path, where the slot is read on-device from
-    // metadata[0]). On the metadata path the host slot is absent, so pass a valid placeholder (0) to turn
-    // on single-slot structure; the all-gather reader recomputes the real offset from metadata.
-    const bool ag_indexed = args.has_indexed_kv_cache() || tensor_args.has_metadata();
-    const std::optional<uint32_t> gather_slice_idx =
-        ag_indexed ? std::optional<uint32_t>(args.kv_cache_batch_idx.value_or(0)) : std::nullopt;
-    // The trailing kv_cache_batch_idx makes the gather collect only that cache slot (std::nullopt =>
-    // full batch). When metadata is supplied the readers read slot_id from metadata[0] on-device.
-    ring_attention_all_gather_async_multi_core_with_workers_helper(
-        desc,
-        all_gather_input_tensors,
-        coord,
-        forward_coord,
-        backward_coord,
-        all_gather_output_tensors,
-        args.all_gather_operation_attributes.dim,
-        args.all_gather_operation_attributes.num_links,
-        args.all_gather_operation_attributes.ring_size,
-        device_index,
-        args.all_gather_operation_attributes.topology,
-        args.all_gather_operation_attributes.semaphore,
-        args.all_gather_operation_attributes.sub_device_id,
-        all_gather_fused_op_signaler,
-        args.ccl_core_grid_offset,
-        args.all_gather_operation_attributes.core_allocation_strategy,
-        gather_slice_idx,
-        // Bound the gather to the logical_n-valid prefix at create time so the first (cache-miss)
-        // dispatch moves only kv_actual-sized data, not the whole oversized cache. Re-patched per
-        // dispatch on cache hits in apply_ring_joint_scalar_runtime_args.
-        compute_gather_valid_Ht(args, tensor_args),
-        tensor_args.slot_id,
-        tensor_args.kv_actual_isl,
-        // chunk_local_tiles: per-device Q slab in tiles, for the reader's on-device gather-extent recompute.
-        tensor_args.input_q.padded_shape()[2] / tt::constants::TILE_HEIGHT,
-        // (user, layer)-major KV-cache batch factor: the all-gather reader computes the gathered slot as
-        // slot_id[0] * kv_cache_num_layers + kv_cache_layer_idx. Defaults (1, 0) keep callers unaffected.
-        args.kv_cache_num_layers,
-        args.kv_cache_layer_idx);
+    if (has_sliding_window) {
+        TT_FATAL(forward_coord.has_value(), "Sliding attention requires a cyclic next-device route");
+        const RingAttentionNeighborHaloConfig neighbor_halo{
+            .send_to_next_start_Ht = chunked_sliding_halo_layout.send_tail_start_tile(device_index),
+            .send_to_next_count_Ht = chunked_sliding_halo_layout.halo_tile_rows,
+        };
+        log_debug(
+            tt::LogOp,
+            "Chunked sliding K/V halo: device={}, predecessor={}, tail=[{}, {}), payload_rows={}",
+            device_index,
+            (device_index + ring_size - 1) % ring_size,
+            neighbor_halo.send_to_next_start_Ht,
+            neighbor_halo.send_to_next_start_Ht + neighbor_halo.send_to_next_count_Ht,
+            neighbor_halo.send_to_next_count_Ht);
+        ring_attention_neighbor_halo_exchange_helper(
+            desc,
+            all_gather_input_tensors,
+            coord,
+            forward_coord.value(),
+            all_gather_output_tensors,
+            args.all_gather_operation_attributes.num_links,
+            args.all_gather_operation_attributes.ring_size,
+            device_index,
+            args.all_gather_operation_attributes.topology,
+            args.all_gather_operation_attributes.semaphore,
+            args.all_gather_operation_attributes.sub_device_id,
+            all_gather_fused_op_signaler.value(),
+            args.ccl_core_grid_offset,
+            args.all_gather_operation_attributes.core_allocation_strategy,
+            args.kv_cache_batch_idx,
+            compute_gather_valid_Ht(args, tensor_args),
+            neighbor_halo);
+    } else {
+        ring_attention_all_gather_async_multi_core_with_workers_helper(
+            desc,
+            all_gather_input_tensors,
+            coord,
+            forward_coord,
+            backward_coord,
+            all_gather_output_tensors,
+            args.all_gather_operation_attributes.dim,
+            args.all_gather_operation_attributes.num_links,
+            args.all_gather_operation_attributes.ring_size,
+            device_index,
+            args.all_gather_operation_attributes.topology,
+            args.all_gather_operation_attributes.semaphore,
+            args.all_gather_operation_attributes.sub_device_id,
+            all_gather_fused_op_signaler,
+            args.ccl_core_grid_offset,
+            args.all_gather_operation_attributes.core_allocation_strategy,
+            args.kv_cache_batch_idx,
+            compute_gather_valid_Ht(args, tensor_args));
+    }
 
     return desc;
 }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
@@ -345,7 +345,9 @@ RingJointRuntimeDerivation build_runtime_derivation(
     // Cross is non-causal on chunked-shaped tensors, so kernels and the work planner use the
     // non-chunked path.
     derivation.kernel_chunked = tensor_args.is_chunked() && !args.is_cross;
-    derivation.kv_pad_rotation_enabled = args.has_kv_pad_rotation();
+    // The metadata path derives kv_actual_isl on-device for chunked prefill.
+    derivation.kv_pad_rotation_enabled =
+        args.has_kv_pad_rotation() || (tensor_args.has_metadata() && tensor_args.is_chunked());
     derivation.kernel_is_causal = args.is_causal && !derivation.kernel_chunked;
 
     TT_FATAL(
@@ -366,8 +368,8 @@ RingJointRuntimePlan build_runtime_plan(
     RingJointRuntimePlan plan;
     plan.logical_nt = derivation.logical_nt;
     const uint32_t kv_actual_tile_count =
-        derivation.kv_pad_rotation_enabled ? args.kv_actual_isl.value() / tt::constants::TILE_HEIGHT : 0;
-    if (derivation.kv_pad_rotation_enabled) {
+        args.kv_actual_isl.has_value() ? args.kv_actual_isl.value() / tt::constants::TILE_HEIGHT : 0;
+    if (args.kv_actual_isl.has_value()) {
         plan.kv_pad_q_mapping = build_kv_pad_q_mapping(
             kv_actual_tile_count,
             derivation.logical_nt,
@@ -440,7 +442,7 @@ void write_runtime_arg(RuntimeArgsData& args, uint32_t index, uint32_t value, co
 // dispatch is bounded) and the cache-hit override path.
 std::optional<uint32_t> compute_gather_valid_Ht(
     const ttnn::prim::RingJointSDPAParams& args, const ttnn::prim::RingJointSDPAInputs& tensor_args) {
-    if (!args.has_kv_pad_rotation()) {
+    if (!args.has_kv_pad_rotation() && !(tensor_args.has_metadata() && tensor_args.is_chunked())) {
         return std::nullopt;
     }
     const uint32_t ring_size = static_cast<uint32_t>(args.all_gather_operation_attributes.ring_size);
@@ -728,6 +730,8 @@ namespace {
 // create_workload_descriptor() can loop coords and reuse this body verbatim. The
 // op-specific name suffix avoids Unity-build collisions with the sibling ring
 // sdpa factories that share the same helper signature.
+// Descriptor construction must keep host/runtime argument layouts together.
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
 tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
     const RingJointSDPAParams& args,
     const RingJointSDPAInputs& tensor_args,
@@ -863,7 +867,9 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
     }
 
     // q_local_padded_N (Q rows per device) can be shorter than kv_local_padded_N for chunked prefill.
-    const bool indexed_kv_cache = args.has_indexed_kv_cache();
+    // Metadata uses an on-device cache-slot value, but needs the same single-slot program structure.
+    const bool slot_from_metadata = tensor_args.has_metadata();
+    const bool indexed_kv_cache = args.has_indexed_kv_cache() || slot_from_metadata;
     // Latent-V mode: V tensors are omitted; the reader reuses K's buffer and
     // reads only the first vDHt head-dim tiles.
     const uint32_t B = q_shape[0];
@@ -896,7 +902,8 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
     const uint32_t Lt = tt::div_up(L, tt::constants::TILE_HEIGHT);
     const uint32_t DHt = DH / tt::constants::TILE_WIDTH;
     const uint32_t vDHt = vDH / tt::constants::TILE_WIDTH;
-    const bool kv_pad_rotation_enabled = args.has_kv_pad_rotation();
+    const bool kv_pad_from_metadata = tensor_args.has_metadata() && tensor_args.is_chunked();
+    const bool kv_pad_rotation_enabled = args.has_kv_pad_rotation() || kv_pad_from_metadata;
     const RingJointRuntimePlan runtime_plan = build_runtime_plan(args, tensor_args, ring_write_plan);
     const RingJointRuntimeArgLayout runtime_arg_layout = get_runtime_arg_layout(args, tensor_args);
     const uint32_t logical_nt = runtime_plan.logical_nt;
@@ -1295,6 +1302,8 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
         static_cast<uint32_t>(use_attention_sink),
         sliding_window_size,
         gathered_padded_Nt,
+        static_cast<uint32_t>(slot_from_metadata),
+        static_cast<uint32_t>(kv_pad_from_metadata),
     };
 
     TensorAccessorArgs(input_tensor_q.buffer()).append_to(reader_compile_time_args);
@@ -1309,6 +1318,13 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
     }
     TensorAccessorArgs(attention_sink.has_value() ? attention_sink->buffer() : nullptr)
         .append_to(reader_compile_time_args);
+    // These metadata tensors may use separate DRAM banks, so each gets its own accessor.
+    if (slot_from_metadata) {
+        TensorAccessorArgs(tensor_args.slot_id->buffer()).append_to(reader_compile_time_args);
+        if (kv_pad_from_metadata) {
+            TensorAccessorArgs(tensor_args.kv_actual_isl->buffer()).append_to(reader_compile_time_args);
+        }
+    }
 
     /**
      * Create semaphores used for L1-L1 store-and-forward of KV between cores.
@@ -1428,11 +1444,15 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
         compile_time_last_active_ring_iter,
         compile_time_single_valid_kv_chunk_mask,
         sliding_window_size,
+        static_cast<uint32_t>(kv_pad_from_metadata),
     };
 
     TensorAccessorArgs(output_tensor.buffer()).append_to(writer_compile_time_args);
     TensorAccessorArgs(joint_output_tensor.buffer()).append_to(writer_compile_time_args);
     TensorAccessorArgs(stats_output_tensor.buffer()).append_to(writer_compile_time_args);
+    if (kv_pad_from_metadata) {
+        TensorAccessorArgs(tensor_args.kv_actual_isl->buffer()).append_to(writer_compile_time_args);
+    }
 
     std::vector<uint32_t> compute_compile_time_args = {
         B,
@@ -1486,6 +1506,7 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
         static_cast<uint32_t>(v_shares_k_buffer),
         static_cast<uint32_t>(use_attention_sink),
         sliding_window_size,
+        static_cast<uint32_t>(kv_pad_from_metadata),
     };
 
     std::map<std::string, std::string> defines;
@@ -1630,13 +1651,16 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
     constexpr uint32_t signal_page_size = 16;
     const uint32_t cb_signal =
         use_streaming_compute ? allocate_cb(signal_page_size, 1, tt::DataFormat::UInt16) : inactive_cb;
+    // Reader-to-compute mailbox for the metadata-derived logical geometry.
+    const uint32_t cb_kv_pad_derived = allocate_cb(64, 1, tt::DataFormat::UInt32);
 
     const std::vector<uint32_t> cb_compile_time_args = {
-        cb_q_in,     cb_k_in,     cb_v_in,         cb_mask_in,       cb_scale_in,    cb_identity_scale_in,
-        cb_stats_in, cb_prev_out, cb_col_identity, cb_recip_scratch, cb_sum_out,     cb_sum_in,
-        cb_signal,   cb_out,      cb_stats_out,    cb_qk_im,         cb_out_im_A,    cb_out_im_B,
-        cb_max_A,    cb_max_B,    cb_sum_A,        cb_sum_B,         cb_exp_max_diff};
-    const std::vector<uint32_t> reader_cb_compile_time_args = {cb_q_in, cb_k_in, cb_v_in, cb_attention_sink};
+        cb_q_in,     cb_k_in,     cb_v_in,         cb_mask_in,       cb_scale_in,     cb_identity_scale_in,
+        cb_stats_in, cb_prev_out, cb_col_identity, cb_recip_scratch, cb_sum_out,      cb_sum_in,
+        cb_signal,   cb_out,      cb_stats_out,    cb_qk_im,         cb_out_im_A,     cb_out_im_B,
+        cb_max_A,    cb_max_B,    cb_sum_A,        cb_sum_B,         cb_exp_max_diff, cb_kv_pad_derived};
+    const std::vector<uint32_t> reader_cb_compile_time_args = {
+        cb_q_in, cb_k_in, cb_v_in, cb_attention_sink, cb_kv_pad_derived};
     reader_compile_time_args.insert(
         reader_compile_time_args.end(), reader_cb_compile_time_args.begin(), reader_cb_compile_time_args.end());
     writer_compile_time_args.insert(
@@ -2368,6 +2392,13 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
     reader_kernel.compile_time_args = reader_compile_time_args;
     reader_kernel.defines = kernel_defines;
     reader_kernel.config = ReaderConfigDescriptor{};
+    if (slot_from_metadata) {
+        reader_kernel.emplace_common_runtime_args(
+            {tensor_args.slot_id->buffer()->address(),  // smuggled-rta-ok: metadata tensor addr (on-device)
+             args.kv_cache_num_layers,
+             args.kv_cache_layer_idx,
+             tensor_args.kv_actual_isl->buffer()->address()});  // smuggled-rta-ok: metadata tensor addr (on-device)
+    }
 
     KernelDescriptor writer_kernel{};
     writer_kernel.kernel_source =
@@ -2377,6 +2408,10 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
     writer_kernel.compile_time_args = writer_compile_time_args;
     writer_kernel.defines = kernel_defines;
     writer_kernel.config = WriterConfigDescriptor{};
+    if (kv_pad_from_metadata) {
+        writer_kernel.emplace_common_runtime_args(
+            {tensor_args.kv_actual_isl->buffer()->address()});  // smuggled-rta-ok: metadata tensor addr (on-device)
+    }
 
     KernelDescriptor compute_kernel{};
     compute_kernel.kernel_source =
@@ -2545,10 +2580,30 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
         all_gather_output_tensors.push_back(gathered_input_tensor_v);
     }
     if (has_sliding_window) {
-        TT_FATAL(forward_coord.has_value(), "Sliding attention requires a cyclic next-device route");
+        const bool linear_wrap_halo = args.all_gather_operation_attributes.topology == ttnn::ccl::Topology::Linear &&
+                                      device_index + 1 == ring_size;
+        std::optional<MeshCoordinate> halo_transport_coord = forward_coord;
+        std::optional<MeshCoordinate> halo_destination_coord = forward_coord;
+        if (linear_wrap_halo) {
+            // Preserve the cyclic logical Q/K layout on a physical line: send device N-1's
+            // predecessor tail backward over N-1 hops to device 0. The transport connection is
+            // its immediate backward neighbor; the packet route names the actual endpoint.
+            TT_FATAL(backward_coord.has_value(), "Linear sliding halo wrap requires a backward neighbor");
+            TT_FATAL(
+                args.all_gather_operation_attributes.cluster_axis.has_value(),
+                "Linear sliding halo wrap requires cluster_axis");
+            halo_transport_coord = backward_coord;
+            halo_destination_coord = coord;
+            halo_destination_coord->operator[](args.all_gather_operation_attributes.cluster_axis.value()) = 0;
+        }
+        TT_FATAL(
+            halo_transport_coord.has_value() && halo_destination_coord.has_value(),
+            "Sliding attention requires a next-device route");
         const RingAttentionNeighborHaloConfig neighbor_halo{
             .send_to_next_start_Ht = chunked_sliding_halo_layout.send_tail_start_tile(device_index),
             .send_to_next_count_Ht = chunked_sliding_halo_layout.halo_tile_rows,
+            .send_backward = linear_wrap_halo,
+            .unicast_hops = linear_wrap_halo ? ring_size - 1 : 1,
         };
         log_debug(
             tt::LogOp,
@@ -2562,7 +2617,8 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
             desc,
             all_gather_input_tensors,
             coord,
-            forward_coord.value(),
+            halo_transport_coord.value(),
+            halo_destination_coord.value(),
             all_gather_output_tensors,
             args.all_gather_operation_attributes.num_links,
             args.all_gather_operation_attributes.ring_size,
@@ -2577,6 +2633,9 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
             compute_gather_valid_Ht(args, tensor_args),
             neighbor_halo);
     } else {
+        const bool ag_indexed = args.has_indexed_kv_cache() || tensor_args.has_metadata();
+        const std::optional<uint32_t> gather_slice_idx =
+            ag_indexed ? std::optional<uint32_t>(args.kv_cache_batch_idx.value_or(0)) : std::nullopt;
         ring_attention_all_gather_async_multi_core_with_workers_helper(
             desc,
             all_gather_input_tensors,
@@ -2594,8 +2653,13 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
             all_gather_fused_op_signaler,
             args.ccl_core_grid_offset,
             args.all_gather_operation_attributes.core_allocation_strategy,
-            args.kv_cache_batch_idx,
-            compute_gather_valid_Ht(args, tensor_args));
+            gather_slice_idx,
+            compute_gather_valid_Ht(args, tensor_args),
+            tensor_args.slot_id,
+            tensor_args.kv_actual_isl,
+            tensor_args.input_q.padded_shape()[2] / tt::constants::TILE_HEIGHT,
+            args.kv_cache_num_layers,
+            args.kv_cache_layer_idx);
     }
 
     return desc;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
@@ -438,8 +438,10 @@ ProgramDescriptor SDPAOperation::SDPAProgramFactory::create_descriptor(
     uint32_t out_im_tiles = Sq_chunk_t * vDHt;
     uint32_t out0_t = Sq_chunk_t * vDHt;  // finalized below once out_out_subblock_h is known
     uint32_t scale_tiles = 1;
-    uint32_t statistics_tiles = Sq_chunk_t;                               // Single column of values in each iteration
-    uint32_t attention_sink_tiles = use_attention_sink ? Sq_chunk_t : 0;  // One column vector per Q chunk
+    uint32_t statistics_tiles = Sq_chunk_t;  // Single column of values in each iteration
+    // Streaming compute broadcasts the per-head scalar directly; legacy compute consumes one
+    // expanded first-column tile per Q row.
+    uint32_t attention_sink_tiles = use_attention_sink ? (use_streaming_compute ? 1 : Sq_chunk_t) : 0;
 
     // log all values
     log_debug(tt::LogOp, "q_tiles: {}", q_tiles);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_program_factory.cpp
@@ -174,6 +174,13 @@ tt::DataFormat fp32_dest_intermediate_dataformat(bool fp32_dest_acc_en) {
     return fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b;
 }
 
+uint32_t attention_sink_tile_count(bool use_attention_sink, bool use_streaming_compute, uint32_t q_chunk_tiles) {
+    if (!use_attention_sink) {
+        return 0;
+    }
+    return use_streaming_compute ? 1 : q_chunk_tiles;
+}
+
 }  // namespace
 
 ProgramDescriptor SDPAOperation::SDPAProgramFactory::create_descriptor(
@@ -441,7 +448,7 @@ ProgramDescriptor SDPAOperation::SDPAProgramFactory::create_descriptor(
     uint32_t statistics_tiles = Sq_chunk_t;  // Single column of values in each iteration
     // Streaming compute broadcasts the per-head scalar directly; legacy compute consumes one
     // expanded first-column tile per Q row.
-    uint32_t attention_sink_tiles = use_attention_sink ? (use_streaming_compute ? 1 : Sq_chunk_t) : 0;
+    uint32_t attention_sink_tiles = attention_sink_tile_count(use_attention_sink, use_streaming_compute, Sq_chunk_t);
 
     // log all values
     log_debug(tt::LogOp, "q_tiles: {}", q_tiles);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sliding_halo_layout.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sliding_halo_layout.cpp
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sliding_halo_layout.hpp"
+#include "kernels/sliding_window_work_plan.hpp"
+
+namespace ttnn::operations::transformer::sdpa::ring_joint {
+bool ChunkedSlidingHaloLayout::uses_neighbor_halo() const { return ring_size > 1 && halo_tile_rows > 0; }
+
+uint32_t ChunkedSlidingHaloLayout::send_tail_start_tile(uint32_t source_device) const {
+    return chunked_sliding_halo_source_start_tile(
+        source_device, q_local_tile_rows, ring_size, logical_k_tile_rows, halo_tile_rows);
+}
+
+ChunkedSlidingHaloLayout build_chunked_sliding_halo_layout(
+    uint32_t q_local_tile_rows,
+    uint32_t k_chunk_tile_rows,
+    uint32_t sliding_window_tokens,
+    uint32_t tile_height,
+    uint32_t ring_size,
+    uint32_t logical_k_tile_rows) {
+    ChunkedSlidingHaloLayout layout;
+    layout.q_local_tile_rows = q_local_tile_rows;
+    layout.logical_k_tile_rows = logical_k_tile_rows;
+    layout.ring_size = ring_size;
+    const uint32_t q_group_tile_rows = q_local_tile_rows * ring_size;
+    if (q_group_tile_rows == 0 || logical_k_tile_rows < 2 * q_group_tile_rows) {
+        return layout;
+    }
+
+    layout.halo_tile_rows = chunked_sliding_halo_tile_rows(sliding_window_tokens, tile_height, k_chunk_tile_rows);
+    return layout;
+}
+
+}  // namespace ttnn::operations::transformer::sdpa::ring_joint

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sliding_halo_layout.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sliding_halo_layout.hpp
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+namespace ttnn::operations::transformer::sdpa::ring_joint {
+
+// Chunked prefill needs one cyclic predecessor tail. Device 0 receives the
+// final device's tail from the preceding complete Q group.
+struct ChunkedSlidingHaloLayout {
+    uint32_t q_local_tile_rows = 0;
+    uint32_t halo_tile_rows = 0;
+    uint32_t logical_k_tile_rows = 0;
+    uint32_t ring_size = 0;
+
+    bool uses_neighbor_halo() const;
+    uint32_t send_tail_start_tile(uint32_t source_device) const;
+};
+
+ChunkedSlidingHaloLayout build_chunked_sliding_halo_layout(
+    uint32_t q_local_tile_rows,
+    uint32_t k_chunk_tile_rows,
+    uint32_t sliding_window_tokens,
+    uint32_t tile_height,
+    uint32_t ring_size,
+    uint32_t logical_k_tile_rows);
+
+}  // namespace ttnn::operations::transformer::sdpa::ring_joint

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa.cpp
@@ -225,7 +225,9 @@ std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> ring_joint_scaled_dot_produ
     std::optional<DeviceComputeKernelConfig> compute_kernel_config,
     ttnn::ccl::CoreAllocationStrategy core_allocation_strategy,
     std::optional<uint32_t> kv_cache_batch_idx,
-    std::optional<uint32_t> kv_actual_isl) {
+    std::optional<uint32_t> kv_actual_isl,
+    const std::optional<ttnn::Tensor>& attention_sink,
+    std::optional<uint32_t> sliding_window_size) {
     // Normalize empty joints to nullopt (see drop_if_empty).
     const std::optional<ttnn::Tensor> joint_q = drop_if_empty(joint_tensor_q);
     const std::optional<ttnn::Tensor> joint_k = drop_if_empty(joint_tensor_k);
@@ -259,7 +261,10 @@ std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> ring_joint_scaled_dot_produ
         compute_kernel_config,
         core_allocation_strategy,
         kv_cache_batch_idx,
-        kv_actual_isl);
+        kv_actual_isl,
+        std::nullopt,  // latent_v_head_dim
+        attention_sink,
+        sliding_window_size);
     return {
         output_tensors[prim::RING_JOINT_SDPA_OUTPUT_IDX],
         output_tensors[prim::RING_JOINT_SDPA_JOINT_OUTPUT_IDX],

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa.cpp
@@ -264,6 +264,10 @@ std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> ring_joint_scaled_dot_produ
         kv_actual_isl,
         std::nullopt,  // latent_v_head_dim
         attention_sink,
+        std::nullopt,  // slot_id
+        std::nullopt,  // kv_actual_isl_tensor
+        1,             // kv_cache_num_layers
+        0,             // kv_cache_layer_idx
         sliding_window_size);
     return {
         output_tensors[prim::RING_JOINT_SDPA_OUTPUT_IDX],
@@ -325,10 +329,12 @@ std::tuple<ttnn::Tensor, ttnn::Tensor> ring_mla(
         kv_cache_batch_idx,
         kv_actual_isl,
         head_dim_v,
+        std::nullopt,  // attention_sink
         slot_id,
         kv_actual_isl_tensor,
         kv_cache_num_layers.value_or(1),
-        kv_cache_layer_idx.value_or(0));
+        kv_cache_layer_idx.value_or(0),
+        std::nullopt);  // sliding_window_size
     return {output_tensors[prim::RING_JOINT_SDPA_OUTPUT_IDX], output_tensors[prim::RING_JOINT_SDPA_STATS_OUTPUT_IDX]};
 }
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa.hpp
@@ -98,7 +98,9 @@ std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> ring_joint_scaled_dot_produ
     std::optional<DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
     ttnn::ccl::CoreAllocationStrategy core_allocation_strategy = ttnn::ccl::CoreAllocationStrategy::ROW_MAJOR,
     std::optional<uint32_t> kv_cache_batch_idx = std::nullopt,
-    std::optional<uint32_t> kv_actual_isl = std::nullopt);
+    std::optional<uint32_t> kv_actual_isl = std::nullopt,
+    const std::optional<ttnn::Tensor>& attention_sink = std::nullopt,
+    std::optional<uint32_t> sliding_window_size = std::nullopt);
 
 std::tuple<ttnn::Tensor, ttnn::Tensor> ring_mla(
     const ttnn::Tensor& input_tensor_q,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa_nanobind.cpp
@@ -52,7 +52,9 @@ std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> ring_joint_scaled_dot_produ
     bool is_balanced,
     bool is_cross,
     std::optional<uint32_t> kv_cache_batch_idx,
-    std::optional<uint32_t> kv_actual_isl) {
+    std::optional<uint32_t> kv_actual_isl,
+    const std::optional<ttnn::Tensor>& attention_sink,
+    std::optional<uint32_t> sliding_window_size) {
     auto strategy = use_column_major_ccl ? ttnn::ccl::CoreAllocationStrategy::COL_MAJOR
                                          : ttnn::ccl::CoreAllocationStrategy::ROW_MAJOR;
 
@@ -83,7 +85,9 @@ std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> ring_joint_scaled_dot_produ
         compute_kernel_config,
         strategy,
         kv_cache_batch_idx,
-        kv_actual_isl);
+        kv_actual_isl,
+        attention_sink,
+        sliding_window_size);
     return outputs;
 }
 
@@ -611,6 +615,15 @@ void bind_sdpa(nb::module_& mod) {
             kv_actual_isl (int, optional): Prior valid global KV length before this fixed-size chunk.
                 When passed, enables KV-pad-aware rotation and derives current valid tokens as
                 logical_n - kv_actual_isl.
+            attention_sink (ttnn.Tensor, optional): Per-query-head attention sink with logical shape
+                [1 x nqh x 1 x 1], sharded across the tensor-parallel head axis and replicated across
+                the sequence-parallel ring. The ring-attention sink path requires BF16, streaming
+                compute, causal separate-K/V attention, and supports both full-causal and
+                sliding-window attention. Defaults to None.
+            sliding_window_size (int, optional): Causal attention window in tokens. The ring reader and
+                compute kernels prune K chunks outside the window. Ring attention currently supports the
+                GPT-OSS specialization: a 128-token window, local 8Q:1K:1V heads with D64, BF16 Q,
+                BFP8_B K/V, SP4 production or SP8 test topology, and chunked prefill without joint tokens.
 
         Chunked-prefill mode is entered implicitly when input_tensor_q's per-device seq
         length is less than input_tensor_k's (Q is the latest slab; K is the populated
@@ -661,7 +674,9 @@ void bind_sdpa(nb::module_& mod) {
         nb::arg("is_balanced").noconvert() = false,
         nb::arg("is_cross").noconvert() = false,
         nb::arg("kv_cache_batch_idx").noconvert() = nb::none(),
-        nb::arg("kv_actual_isl").noconvert() = nb::none());
+        nb::arg("kv_actual_isl").noconvert() = nb::none(),
+        nb::arg("attention_sink") = nb::none(),
+        nb::arg("sliding_window_size") = nb::none());
 
     const auto* const ring_mla_doc = R"doc(
         Causal Ring MLA attention over a single KV tensor.

--- a/ttnn/cpp/ttnn/operations/transformer/sources.cmake
+++ b/ttnn/cpp/ttnn/operations/transformer/sources.cmake
@@ -9,6 +9,7 @@ set(TTNN_OP_TRANSFORMER_SRCS
     sdpa/device/joint_sdpa_program_factory.cpp
     sdpa/device/ring_joint_sdpa_device_operation.cpp
     sdpa/device/ring_joint_sdpa_program_factory.cpp
+    sdpa/device/sliding_halo_layout.cpp
     sdpa/device/exp_ring_joint_sdpa_device_operation.cpp
     sdpa/device/exp_ring_joint_sdpa_program_factory.cpp
     sdpa/device/ring_distributed_sdpa_device_operation.cpp


### PR DESCRIPTION
## Interactive reviewer guide

[Open the animated HTML presentation](https://htmlpreview.github.io/?https://gist.githubusercontent.com/pavlejosipovic/19911a26c4d6b290f6e3a63629254d6e/raw/673e3721ee6437e33afa18f9210e3d522ee71f0b/ring_joint_sliding_prefill_review.html) · [View the source gist](https://gist.github.com/pavlejosipovic/19911a26c4d6b290f6e3a63629254d6e)

## Summary

Add causal sliding prefill to RingJointSDPA for the GPT-OSS geometry: local 8Q:1K:1V GQA at D64, BF16 Q, BFP8_B K/V, optional per-head attention sinks, and SP4 production / SP8 test-ring configurations.

The change removes the fixed `W=128` validation. The compact CCL path derives its one-hop predecessor halo from the runtime window and supports every `W > 1` whose K-chunk-rounded predecessor tail fits one local Q/KV slab:

```
ceil((W - 1) / k_chunk_size) * k_chunk_size <= local_slab_size
```

With 128-token K chunks and a 640-token local slab, this supports `W <= 641`. GPT-OSS W=128 is a target configuration, not an interface limit. Wider windows require a multi-hop halo and are rejected explicitly.

## Why halo CCL instead of all-gather

Dense ring attention all-gathers the growing K/V cache. A bounded sliding window needs only the predecessor tail at a sequence-parallel boundary, so this path sends that tail to the next device and receives the predecessor tail. The K/V tail is rounded to the K chunk; the per-Q work plan prunes chunks outside the runtime window.

For B1 production prefill with 5K Q tokens against 56,320 K/V tokens, one local K/V head, and D64:

| Path | Retained K/V rows | BFP8_B tiles | Persistent memory / device |
| --- | ---: | ---: | ---: |
| Full all-gather | 56,320 | 7,040 | 7,659,520 bytes (7.30 MiB) |
| GPT-OSS W=128 neighbor halo | 128 | 16 | 17,408 bytes (17 KiB) |

The W=128 halo is 440x smaller, saving about 7.29 MiB per device. B2 doubles both absolute sizes while retaining the ratio.

## Tensix scheduling, balancing, and K/V sharing

The factory flattens `(batch, Q head, Q chunk)` and assigns contiguous units evenly across active Tensix cores; each receives either the base count or one additional Q chunk. Sliding uses one synthetic SDPA iteration: every Q chunk visits only its local K/V range and, where needed, the predecessor halo, then finalizes without device-wide ring phases or DRAM accumulator save/restore.

`is_balanced=false` is required intentionally. Dense causal attention has a triangular prefix-cost gradient: early Q chunks see short prefixes and late chunks see long prefixes. The existing balanced/zigzag scheduler addresses that by pairing early and late Q chunks and by halving or skipping dense K/V work in selected ring phases.

That strategy is not useful—or correct—for one-hop sliding. The complete-predecessor requirement and `W <= local_slab` geometry mean every Q has a full bounded window; the triangle is gone. Local and halo K/V are consumed in a single pass, so dense ring-phase skip/halve transformations would omit valid window chunks. Flat Q-chunk distribution is therefore the relevant local balance; there is no dynamic reweighting for K-chunk alignment effects.

Sliding also disables grouped-GQA K/V chains and row multicast. Full-ring GQA can multicast one K/V chunk to the cores processing its Q-head group, but all receivers—including padded iterations—must participate in ready/receive handshakes. Sliding has each Tensix reader load its local or halo chunk directly, removing chain topology and padded multicast work. This is separate from inter-device CCL: CCL is a unidirectional next-device halo send / predecessor receive, not a Tensix multicast or all-gather.

## Implementation and coverage

- Add sliding-window and attention-sink API plumbing, one-hop geometry validation, compact-halo descriptors/kernels, and cache-hit patching.
- Cache hits relocate the halo source to the current cache-group tail and refresh logical length and active-ring masks.
- Add accuracy, determinism, cache-reuse, long-context, and performance coverage; native-ring tests are topology-aware for B1/SP4 and B2/SP8.
- Exercise W=129 in the existing native-ring test, proving the window is not fixed to the GPT-OSS W=128 target without adding CI test cases.
- Reuse the mesh runtime for an actual program-cache replay, remove redundant boundary coverage, and skip the utilization-only performance gate in CI.

## Validation

```
./build_metal.sh --release

CI=true scripts/run_safe_pytest.sh --run-all \
  tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py -svv -k \
  'test_ring_joint_attention_gpt_oss_chunked_sliding_native_ring_gqa_accuracy'
# 1 passed; W=129, PCC 0.9996727, deterministic 3-run replay
```

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/ring-joint-sdpa-attention-sinks)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/ring-joint-sdpa-attention-sinks)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/ring-joint-sdpa-attention-sinks)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/ring-joint-sdpa-attention-sinks)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=pjosipovic/ring-joint-sdpa-attention-sinks)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:pjosipovic/ring-joint-sdpa-attention-sinks)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/ring-joint-sdpa-attention-sinks)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/ring-joint-sdpa-attention-sinks)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/ring-joint-sdpa-attention-sinks)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/ring-joint-sdpa-attention-sinks)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/ring-joint-sdpa-attention-sinks)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/ring-joint-sdpa-attention-sinks)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/ring-joint-sdpa-attention-sinks)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/ring-joint-sdpa-attention-sinks)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/ring-joint-sdpa-attention-sinks)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/ring-joint-sdpa-attention-sinks)