### PR TITLE
[deepseek_v3_d_p] Fix MoE padding config under rotated chunked prefill

### DIFF
--- a/models/demos/deepseek_v3_d_p/tt/mla/utils.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/utils.py
@@ -111,6 +111,28 @@ def rotated_chip_positions(kv_actual_isl: int, sp: int, chunk_local: int) -> lis
     return positions
 
 
+def rotated_chip_real_token_counts(kv_actual_isl: int, actual_isl: int, sp: int, chunk_local: int) -> list[int]:
+    """Per-chip count of REAL (non-pad) rows carried by a rotated chunk, keyed off
+    rotated_chip_positions so it cannot drift from the writer kernel.
+
+    A rotated chunk's `chunk_size_global` rows tile [kv_actual_isl, kv_actual_isl + chunk_size_global)
+    but are spread across chips by the KV-pad-aware rotation, so a chip's real-row count is NOT
+    ``min(chunk_local, actual_isl - c * chunk_local)`` -- that formula only holds for the SEQUENTIAL
+    layout (which is the degenerate kv_actual_isl == 0 / slab-aligned case, where this function
+    reduces to it exactly).
+
+    Positions increase monotonically with the chip-local row (a slab step adds chunk_size_global
+    while the within-slab offset rewinds by at most chunk_local < chunk_size_global), so each chip's
+    real rows are a contiguous PREFIX of its local rows. That is what lets a single count per chip
+    describe the split, and why the consumers' RIGHT-padding contract still holds under rotation.
+    """
+    valid_end = kv_actual_isl + actual_isl
+    return [
+        sum(1 for p in row if kv_actual_isl <= p < valid_end)
+        for row in rotated_chip_positions(kv_actual_isl, sp, chunk_local)
+    ]
+
+
 def blockcyclic_positions(sp: int, chunk_size_global: int, seq_len_cache: int) -> torch.Tensor:
     """Global natural position held by each block-cyclic shard row (device-major: an SP-contiguous
     split of the cache's seq dim yields each chip's rows).

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_moe.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_moe.py
@@ -444,6 +444,7 @@ class TtMoe(LightweightModule):
         return_intermediates: bool = False,
         actual_isl: int = None,
         padding_side: str = "right",
+        actual_start: Optional[int] = None,
     ) -> tuple[ttnn.Tensor, Optional[TtMoEIntermediates]]:
         """
         Forward pass through the full MoE pipeline.
@@ -455,6 +456,10 @@ class TtMoe(LightweightModule):
             return_intermediates: If True, return intermediate tensors for debugging
             actual_isl: Actual ISL of the sequence (None = no padding)
             padding_side: Padding side of the sequence
+            actual_start: chunked-prefill absolute KV position of this chunk's first real token
+                (None/0 = single-shot, sequential SP layout). Required for correct per-chip real-token
+                counts: chunked prefill feeds the KV-pad-aware ROTATED block-cyclic layout, where a
+                chip's real rows are NOT its slice of the natural sequence. See build_padding_config.
 
         Returns:
             Tuple of (final_output, intermediates):
@@ -490,13 +495,14 @@ class TtMoe(LightweightModule):
         # expert indices, so dispatch must process the full range -> padding_config=None.
         padding_config = None
         if actual_isl is not None and self.gate.fallback_mode == GateComputeMode.DEVICE_FP32:
-            padding_config = self.gate.build_padding_config(actual_isl, padding_side)
+            padding_config = self.gate.build_padding_config(actual_isl, padding_side, actual_start or 0)
 
         scores, indices, gate_logits = self.gate(
             ttnn.view(x, (x.shape[0] * x.shape[1], x.shape[2])),
             actual_isl=actual_isl,
             padding_side=padding_side,
             padding_config=padding_config,
+            actual_start=actual_start or 0,
         )
 
         tt_expert_offsets, tt_expert_token_counts, tt_expert_region_offsets, _ = self.routing_setup(

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_moe_gate_prefill.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_moe_gate_prefill.py
@@ -17,6 +17,7 @@ from models.common.lightweightmodule import LightweightModule
 from models.common.utility_functions import is_blackhole
 from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3Config
 from models.demos.deepseek_v3_d_p.reference.kimi_k2_6_config import KimiK26Config
+from models.demos.deepseek_v3_d_p.tt.mla.utils import rotated_chip_real_token_counts
 from models.demos.deepseek_v3_d_p.tt.tt_ccl import get_tt_ccl
 
 
@@ -580,11 +581,20 @@ class TtMoEGatePrefill(LightweightModule):
             epsilon=1e-20,
         )
 
-    def build_padding_config(self, actual_isl: int, padding_side: str = "right") -> ttnn.Tensor:
+    def build_padding_config(self, actual_isl: int, padding_side: str = "right", actual_start: int = 0) -> ttnn.Tensor:
         """Create the per-SP-shard [local_num_real_tokens, pad_side] config for moe_grouped_topk.
 
         Public so callers (TtMoe) can build the config once and share the same tensor between
         the gate topk and the dispatch op.
+
+        ``actual_start`` is the chunked-prefill absolute KV position of this chunk's first real
+        token (0 for single-shot / non-chunked). It is REQUIRED to get the per-chip counts right:
+        chunked prefill hands the MoE the KV-pad-aware ROTATED block-cyclic layout, in which chip c
+        does NOT hold global tokens [c*seq_len_per_chip, (c+1)*seq_len_per_chip). Deriving the count
+        as min(seq_len_per_chip, actual_isl - c*seq_len_per_chip) there sentinel-marks real tokens
+        (dropping them from MoE entirely) while dispatching pad rows as real. The rotated layout is
+        the identity exactly when actual_start is slab-aligned, so actual_start=0 reproduces the
+        sequential result bit-for-bit and every pre-existing caller is unaffected.
 
         When is_balanced=True, the sequence uses zigzag placement: the original sequence
         is split into 2*sp_factor chunks and device d holds chunks d and (2*sp_factor-1-d),
@@ -602,7 +612,24 @@ class TtMoEGatePrefill(LightweightModule):
 
         padding_config = []
 
-        if self.is_balanced:
+        if actual_start:
+            # Rotated chunked prefill. Both branches below assume the sequential layout, so neither
+            # is valid here; fail loudly rather than silently drop tokens. Rotation implies
+            # is_balanced=False (ttMLA._chunked_attn asserts it) and produces right-padding WITHIN
+            # each chip by construction, so those two combinations are unreachable, not merely
+            # unsupported.
+            if self.is_balanced:
+                raise ValueError("rotated chunked prefill (actual_start != 0) does not support is_balanced=True")
+            if padding_side != "right":
+                raise ValueError(
+                    f"rotated chunked prefill (actual_start != 0) is right-padded by construction; "
+                    f"got padding_side={padding_side!r}"
+                )
+            for local_real_tokens in rotated_chip_real_token_counts(
+                actual_start, actual_isl, sp_factor, seq_len_per_chip
+            ):
+                padding_config.append([local_real_tokens, pad_side])
+        elif self.is_balanced:
             num_chunks = 2 * sp_factor
             chunk_size = total_tokens // num_chunks
 
@@ -651,6 +678,7 @@ class TtMoEGatePrefill(LightweightModule):
         actual_isl: int = None,
         padding_side: str = "right",
         padding_config: ttnn.Tensor = None,
+        actual_start: int = 0,
     ) -> tuple[ttnn.Tensor, ttnn.Tensor]:
         """Run moe_grouped_topk on device.
 
@@ -669,7 +697,9 @@ class TtMoEGatePrefill(LightweightModule):
         """
         owns_padding_config = padding_config is None
         if owns_padding_config:
-            padding_config = self.build_padding_config(actual_isl, padding_side) if actual_isl is not None else None
+            padding_config = (
+                self.build_padding_config(actual_isl, padding_side, actual_start) if actual_isl is not None else None
+            )
 
         # moe_grouped_topk upcasts the (bf16) logits and bias to fp32 inside the kernel, so the
         # previous host-side ttnn.typecast ops are gone. They were very short (2-5us) and created
@@ -698,6 +728,7 @@ class TtMoEGatePrefill(LightweightModule):
         actual_isl: int = None,
         padding_side: str = "right",
         padding_config: ttnn.Tensor = None,
+        actual_start: int = 0,
     ) -> tuple[ttnn.Tensor, ttnn.Tensor]:
         """Run moe_hash_gate on device: fused tid2eid[input_ids] routing + score_func/normalize/scale.
 
@@ -710,7 +741,9 @@ class TtMoEGatePrefill(LightweightModule):
 
         owns_padding_config = padding_config is None
         if owns_padding_config:
-            padding_config = self.build_padding_config(actual_isl, padding_side) if actual_isl is not None else None
+            padding_config = (
+                self.build_padding_config(actual_isl, padding_side, actual_start) if actual_isl is not None else None
+            )
 
         logits_f32 = ttnn.typecast(logits, ttnn.float32)
         input_ids_dev = self._input_ids_to_device(input_ids)
@@ -754,6 +787,7 @@ class TtMoEGatePrefill(LightweightModule):
         padding_side: str = "right",
         padding_config: ttnn.Tensor = None,
         input_ids: torch.Tensor = None,
+        actual_start: int = 0,
     ) -> tuple[ttnn.Tensor, ttnn.Tensor, ttnn.Tensor]:
         mode = self.fallback_mode
         logger.debug(f"[MoeGate] fallback_mode={mode.value}")
@@ -788,6 +822,7 @@ class TtMoEGatePrefill(LightweightModule):
                 actual_isl=actual_isl,
                 padding_side=padding_side,
                 padding_config=padding_config,
+                actual_start=actual_start,
             )
 
         elif mode == GateComputeMode.HOST_GROUPED_GATE:
@@ -823,6 +858,7 @@ class TtMoEGatePrefill(LightweightModule):
                 actual_isl=actual_isl,
                 padding_side=padding_side,
                 padding_config=padding_config,
+                actual_start=actual_start,
             )
 
         return (

--- a/models/demos/deepseek_v3_d_p/tt/tt_prefill_block.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_prefill_block.py
@@ -467,7 +467,9 @@ class TtPrefillBlock(LightweightModule):
                 tt_kv_rope, tt_kvpe) and this returns (output_tensor, kv_intermediates_dict) — also
                 carrying post_mla_residual + post_attn_norm — instead of (output_tensor, kv_cache).
             actual_isl: actual (unpadded) count of real tokens; threaded to the MoE FFN for
-                padding-aware routing.
+                padding-aware routing. Paired with actual_start there: under chunked prefill the MoE
+                sees the ROTATED block-cyclic layout, so the per-chip real-token split depends on
+                BOTH values (see MoeGate.build_padding_config).
             padding_side: "right" or "left"; threaded to the MoE FFN for padding-aware routing.
 
         Returns:
@@ -562,6 +564,7 @@ class TtPrefillBlock(LightweightModule):
                 return_intermediates=return_intermediates,
                 actual_isl=actual_isl,
                 padding_side=padding_side,
+                actual_start=actual_start,
             )
         else:
             ffn_out = self._dense_ffn_path(ffn_norm_out)
@@ -598,6 +601,7 @@ class TtPrefillBlock(LightweightModule):
         return_intermediates: bool = False,
         actual_isl: Optional[int] = None,
         padding_side: str = "right",
+        actual_start: Optional[int] = None,
     ) -> ttnn.Tensor:
         """MoE FFN path: 4D TILE → 3D ROW_MAJOR → MoE → 3D TILE → 4D TILE."""
         moe_input = ttnn.squeeze(ffn_norm_out, dim=0)
@@ -607,6 +611,7 @@ class TtPrefillBlock(LightweightModule):
             return_intermediates=return_intermediates,
             actual_isl=actual_isl,
             padding_side=padding_side,
+            actual_start=actual_start,
         )
 
         moe_out = ttnn.unsqueeze(moe_out, dim=0)


### PR DESCRIPTION
## Summary
- Under rotated chunked prefill, the MoE gate's per-chip real-token count was derived assuming the sequential SP layout (`min(seq_len_per_chip, actual_isl - c*seq_len_per_chip)`), which silently drops real tokens from MoE routing when the KV-pad-aware rotation is in play.
- Adds `rotated_chip_real_token_counts` (keyed off the existing `rotated_chip_positions`, so it can't drift from the writer kernel) and threads a new `actual_start` (chunked-prefill absolute KV position of the chunk's first real token) through `TtMoe.forward` → `TtMoEGatePrefill.build_padding_config`/`__call__` → `TtPrefillBlock`.
- `actual_start=0` (the default) reproduces the prior sequential-layout result bit-for-bit, so existing (non-chunked) callers are unaffected.
- Rotation is asserted incompatible with `is_balanced=True` and non-right padding, since both are unreachable under rotated chunked prefill by construction.

## Test plan
- [ ] Existing MoE/prefill unit tests pass
- [ ] Chunked prefill accuracy (PCC) test passes with rotation enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ipotkonjak/pr_pcc_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ipotkonjak/pr_pcc_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ipotkonjak/pr_pcc_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ipotkonjak/pr_pcc_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ipotkonjak/pr_pcc_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ipotkonjak/pr_pcc_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ipotkonjak/pr_pcc_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ipotkonjak/pr_pcc_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ipotkonjak/pr_pcc_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ipotkonjak/pr_pcc_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ipotkonjak/pr_pcc_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ipotkonjak/pr_pcc_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ipotkonjak/pr_pcc_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ipotkonjak/pr_pcc_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ipotkonjak/pr_pcc_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ipotkonjak/pr_pcc_fix)