### PR TITLE
Check for reset buffer magic in device simulation

### DIFF
--- a/tt_metal/impl/debug/dprint_server.cpp
+++ b/tt_metal/impl/debug/dprint_server.cpp
@@ -617,6 +617,12 @@ bool DPrintServer::Impl::poll_print_buffer(
             from_dev = cluster.read_core(device_id, virtual_core, read_write_pointer_address, eightbytes);
             wpos = from_dev[0];
             rpos = from_dev[1];
+
+            // Device should be much faster than host, but in case we are running simulation,
+            // we should check if device has reset buffer and we have caught up to it.
+            if (rpos == DEVICE_PRINT_RESET_BUFFER_MAGIC) {
+                return false;
+            }
             continue;
         }
 

--- a/tt_metal/impl/debug/dprint_server.cpp
+++ b/tt_metal/impl/debug/dprint_server.cpp
@@ -574,7 +574,8 @@ bool DPrintServer::Impl::poll_print_buffer(
     auto from_dev = cluster.read_core(device_id, virtual_core, read_write_pointer_address, eightbytes);
     uint32_t wpos = from_dev[0], rpos = from_dev[1];
 
-    if (wpos == DEBUG_PRINT_SERVER_DISABLED_MAGIC || wpos == DEBUG_PRINT_SERVER_STARTING_MAGIC || wpos == rpos) {
+    if (wpos == DEBUG_PRINT_SERVER_DISABLED_MAGIC || wpos == DEBUG_PRINT_SERVER_STARTING_MAGIC ||
+        rpos == DEVICE_PRINT_RESET_BUFFER_MAGIC || wpos == rpos) {
         return false;
     }
 


### PR DESCRIPTION
Small bug fix on how reset buffer magic is being handled on host.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=vjovanovic/fix_reset_buffer_magic_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:vjovanovic/fix_reset_buffer_magic_check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=vjovanovic/fix_reset_buffer_magic_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:vjovanovic/fix_reset_buffer_magic_check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=vjovanovic/fix_reset_buffer_magic_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:vjovanovic/fix_reset_buffer_magic_check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=vjovanovic/fix_reset_buffer_magic_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:vjovanovic/fix_reset_buffer_magic_check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=vjovanovic/fix_reset_buffer_magic_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:vjovanovic/fix_reset_buffer_magic_check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=vjovanovic/fix_reset_buffer_magic_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vjovanovic/fix_reset_buffer_magic_check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=vjovanovic/fix_reset_buffer_magic_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vjovanovic/fix_reset_buffer_magic_check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=vjovanovic/fix_reset_buffer_magic_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vjovanovic/fix_reset_buffer_magic_check)