### PR TITLE
Centralize perf-CSV header construction in perf_schema.py

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/fuser/fuser_config.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/fuser_config.py
@@ -13,6 +13,11 @@ from helpers.chip_architecture import ChipArchitecture
 from helpers.llk_params import DestAccumulation, PerfRunType
 from helpers.logger import logger
 from helpers.perf import PerfReport
+from helpers.perf_schema import (
+    LOOP_FACTOR_COLUMN,
+    MARKER,
+    TEST_NAME_COLUMN,
+)
 from helpers.profiler import Profiler, ProfilerData
 from helpers.test_config import BuildMode, ProfilerBuild, StimuliMode, TestConfig
 from ttexalens.tt_exalens_lib import read_words_from_device
@@ -175,12 +180,12 @@ class FuserConfig(TestConfig):
         if self.BUILD_MODE != BuildMode.PRODUCE and all_results:
             results = reduce(
                 lambda left, right: pd.merge(
-                    left, right, on="marker", how="outer", validate="1:1"
+                    left, right, on=MARKER, how="outer", validate="1:1"
                 ),
                 all_results,
             )
-            results["test_name"] = self.global_config.test_name
-            results["loop_factor"] = self.global_config.loop_factor
+            results[TEST_NAME_COLUMN] = self.global_config.test_name
+            results[LOOP_FACTOR_COLUMN] = self.global_config.loop_factor
             perf_report.append(results)
             logger.info("Perf results:\n{}", results)
 

--- a/tt_metal/tt-llk/tests/python_tests/helpers/metrics.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/metrics.py
@@ -54,6 +54,14 @@ All metrics are bounded 0-100% unless noted otherwise.
 import pandas as pd
 from loguru import logger
 
+from .perf_schema import (
+    MARKER,
+    counter_base,
+    cycles_of,
+    metric_column,
+    stat_column,
+)
+
 # ── Helpers ──────────────────────────────────────────────────────────
 
 
@@ -259,7 +267,7 @@ def export_metrics(
     for zone in zones:
         zone_metrics = [m for m in computed if m["zone"] == zone]
         marker_name = zone_to_marker.get(zone, zone)
-        row = {"marker": marker_name}
+        row = {MARKER: marker_name}
 
         # Only export efficiency percentages to the main CSV
         def _exportable(key: str) -> bool:
@@ -272,13 +280,17 @@ def export_metrics(
                     continue
                 values = metrics_df[col].dropna()
                 if len(values) >= 2:
-                    row[f"{run_type_name}_mean({col})"] = float(values.mean())
-                    row[f"{run_type_name}_std({col})"] = float(values.std())
+                    row[metric_column(run_type_name, stat_column(col, "mean"))] = float(
+                        values.mean()
+                    )
+                    row[metric_column(run_type_name, stat_column(col, "std"))] = float(
+                        values.std()
+                    )
         else:
             for k, v in zone_metrics[0].items():
                 if not _exportable(k):
                     continue
-                row[f"{run_type_name}_{k}"] = v
+                row[metric_column(run_type_name, k)] = v
 
         rows.append(row)
 
@@ -324,7 +336,7 @@ def export_counters(
     for zone in zones:
         zone_df = all_counters[all_counters["zone"] == zone]
         marker_name = zone_to_marker.get(zone, zone)
-        row = {"marker": marker_name}
+        row = {MARKER: marker_name}
 
         # Get unique counters in this zone (preserving discovery order)
         counter_keys = (
@@ -333,33 +345,41 @@ def export_counters(
 
         for bank, counter_name in counter_keys:
             mask = (zone_df["bank"] == bank) & (zone_df["counter_name"] == counter_name)
-            col_name = f"{bank}.{counter_name}"
+            col_name = counter_base(bank, counter_name)
 
             if has_runs:
                 per_run = zone_df.loc[mask].groupby("run_index")["count"].mean()
                 if len(per_run) >= 2:
-                    row[f"{run_type_name}_mean({col_name})"] = float(per_run.mean())
-                    row[f"{run_type_name}_std({col_name})"] = float(per_run.std())
+                    row[metric_column(run_type_name, stat_column(col_name, "mean"))] = (
+                        float(per_run.mean())
+                    )
+                    row[metric_column(run_type_name, stat_column(col_name, "std"))] = (
+                        float(per_run.std())
+                    )
                 elif len(per_run) == 1:
-                    row[f"{run_type_name}_{col_name}"] = float(per_run.iloc[0])
+                    row[metric_column(run_type_name, col_name)] = float(per_run.iloc[0])
             else:
                 values = zone_df.loc[mask, "count"]
-                row[f"{run_type_name}_{col_name}"] = float(values.mean())
+                row[metric_column(run_type_name, col_name)] = float(values.mean())
 
             # Also export cycles for this counter
-            col_cycles = f"{col_name}.cycles"
+            col_cycles = cycles_of(col_name)
             if has_runs:
                 per_run_cyc = zone_df.loc[mask].groupby("run_index")["cycles"].mean()
                 if len(per_run_cyc) >= 2:
-                    row[f"{run_type_name}_mean({col_cycles})"] = float(
-                        per_run_cyc.mean()
-                    )
-                    row[f"{run_type_name}_std({col_cycles})"] = float(per_run_cyc.std())
+                    row[
+                        metric_column(run_type_name, stat_column(col_cycles, "mean"))
+                    ] = float(per_run_cyc.mean())
+                    row[
+                        metric_column(run_type_name, stat_column(col_cycles, "std"))
+                    ] = float(per_run_cyc.std())
                 elif len(per_run_cyc) == 1:
-                    row[f"{run_type_name}_{col_cycles}"] = float(per_run_cyc.iloc[0])
+                    row[metric_column(run_type_name, col_cycles)] = float(
+                        per_run_cyc.iloc[0]
+                    )
             else:
                 cyc_values = zone_df.loc[mask, "cycles"]
-                row[f"{run_type_name}_{col_cycles}"] = float(cyc_values.mean())
+                row[metric_column(run_type_name, col_cycles)] = float(cyc_values.mean())
 
         rows.append(row)
 

--- a/tt_metal/tt-llk/tests/python_tests/helpers/perf.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/perf.py
@@ -19,6 +19,19 @@ from .format_config import FormatConfig
 from .llk_params import DestAccumulation, L1Accumulation, PerfRunType
 from .logger import logger
 from .metrics import compute_metrics, export_counters, export_metrics, print_metrics
+from .perf_schema import (
+    FLAG_HEADERS,
+    FORMAT_HEADERS,
+    LOOP_FACTOR_COLUMN,
+    MARKER,
+    MEAN,
+    STD,
+    TEXT_SIZE_PREFIX,
+    TILE_CNT_COLUMN,
+    PerfSchemaError,
+    stat_prefix,
+    text_size_column,
+)
 from .profiler import Profiler, ProfilerData
 from .stimuli_config import StimuliConfig
 from .test_config import BuildMode, ProfilerBuild, TestConfig
@@ -64,24 +77,24 @@ def _postprocess_tile_loop(frame: pd.DataFrame) -> pd.DataFrame:
     if frame.empty:
         return pd.DataFrame()
 
-    mask = frame["marker"] == "TILE_LOOP"
+    mask = frame[MARKER] == "TILE_LOOP"
 
     if not mask.any():
         return frame
 
     # Ensure columns exist and default missing values only for masked rows
-    for col in ["loop_factor", "tile_cnt"]:
+    for col in [LOOP_FACTOR_COLUMN, TILE_CNT_COLUMN]:
         if col not in frame.columns:
-            col_idx = frame.columns.get_loc("marker")
+            col_idx = frame.columns.get_loc(MARKER)
             frame.insert(col_idx, col, 1)
         frame[col] = frame[col].fillna(1)
 
     # Compute divisor as Series aligned with masked rows
-    divisor = frame.loc[mask, "loop_factor"] * frame.loc[mask, "tile_cnt"]
+    divisor = frame.loc[mask, LOOP_FACTOR_COLUMN] * frame.loc[mask, TILE_CNT_COLUMN]
 
     # Select only mean/std columns
-    mean_columns = [c for c in frame.columns if c.startswith("mean(")]
-    std_columns = [c for c in frame.columns if c.startswith("std(")]
+    mean_columns = [c for c in frame.columns if c.startswith(stat_prefix(MEAN))]
+    std_columns = [c for c in frame.columns if c.startswith(stat_prefix(STD))]
 
     # Apply division
     for cols in (mean_columns, std_columns):
@@ -89,15 +102,6 @@ def _postprocess_tile_loop(frame: pd.DataFrame) -> pd.DataFrame:
             frame.loc[mask, cols] = frame.loc[mask, cols].div(divisor, axis=0)
 
     return frame
-
-
-class PerfSchemaError(AssertionError):
-    """
-    Raised when a single perf report (one CSV) accumulates more than one column
-    schema. Stacking rows with different column sets NaN-fills the gaps, producing
-    a ragged, schema-contaminated artifact that breaks strict-JSON dashboards and
-    the compare feature. We fail loud so the contaminated CSV is never shipped.
-    """
 
 
 class PerfReport:
@@ -133,9 +137,9 @@ class PerfReport:
         if sig in self._schema_registry:
             return
         # Identify a frame by its sweep-parameter columns (everything before the
-        # "marker" column) so the error can point the author at the offending test.
-        if "marker" in frame.columns:
-            sweep_cols = list(frame.columns[: frame.columns.get_loc("marker")])
+        # marker column) so the error can point the author at the offending test.
+        if MARKER in frame.columns:
+            sweep_cols = list(frame.columns[: frame.columns.get_loc(MARKER)])
         else:
             sweep_cols = list(frame.columns)
         sample = frame.iloc[0][sweep_cols].to_dict() if sweep_cols else {}
@@ -219,7 +223,7 @@ class PerfReport:
 
     def marker(self, marker: str) -> "PerfReport":
         """Filter: Marker"""
-        return self.filter("marker", marker)
+        return self.filter(MARKER, marker)
 
     def post_process(self):
         frame = pd.concat(self._frames, ignore_index=True)
@@ -327,11 +331,11 @@ def _collapse_duplicate_keys(frame: pd.DataFrame, label: str) -> pd.DataFrame:
     record a parameter that actually changes the kernel, so it should not pass
     silently.
     """
-    if frame.empty or "marker" not in frame.columns:
+    if frame.empty or MARKER not in frame.columns:
         return frame
 
     try:
-        marker_pos = frame.columns.get_loc("marker")
+        marker_pos = frame.columns.get_loc(MARKER)
         key_cols = list(frame.columns[: marker_pos + 1])
         value_cols = [c for c in frame.columns if c not in key_cols]
 
@@ -707,23 +711,13 @@ class PerfConfig(TestConfig):
         # validate="1:1" catches duplicate markers within each run type
         run_results = reduce(
             lambda left, right: pd.merge(
-                left, right, on="marker", how="outer", validate="1:1"
+                left, right, on=MARKER, how="outer", validate="1:1"
             ),
             results,
         )
 
         # Setting header fields that are always there
-        names = (
-            [
-                "formats.input_A",
-                "formats.input_B",
-                "formats.register_A",
-                "formats.register_B",
-                "formats.output",
-            ]
-            if self.formats_config
-            else []
-        )
+        names = list(FORMAT_HEADERS) if self.formats_config else []
         values = (
             [
                 self.formats_config[0].unpack_A_src,
@@ -736,7 +730,7 @@ class PerfConfig(TestConfig):
             else []
         )
 
-        names += ["unpack_to_dest", "dest_acc"]
+        names += list(FLAG_HEADERS)
         values += [self.unpack_to_dest, self.dest_acc]
 
         for param in self.passed_templates + self.passed_runtimes:
@@ -746,14 +740,14 @@ class PerfConfig(TestConfig):
                     values.append(value)
 
         for run_type, size in code_sizes.items():
-            names.append(f"TEXT_SIZE({run_type.name})")
+            names.append(text_size_column(run_type.name))
             values.append(size)
 
         sweep = pd.DataFrame([values], columns=names)
         combined = sweep.merge(run_results, how="cross")
 
-        text_size_cols = [c for c in combined.columns if c.startswith("TEXT_SIZE(")]
-        other_cols = [c for c in combined.columns if not c.startswith("TEXT_SIZE(")]
+        text_size_cols = [c for c in combined.columns if c.startswith(TEXT_SIZE_PREFIX)]
+        other_cols = [c for c in combined.columns if not c.startswith(TEXT_SIZE_PREFIX)]
         combined = combined[other_cols + text_size_cols]
 
         perf_report.append(combined, label=self.test_name)
@@ -762,7 +756,7 @@ class PerfConfig(TestConfig):
         if counter_results_list and PerfConfig.COUNTER_REPORT is not None:
             counter_run_results = reduce(
                 lambda left, right: pd.merge(
-                    left, right, on="marker", how="outer", validate="1:1"
+                    left, right, on=MARKER, how="outer", validate="1:1"
                 ),
                 counter_results_list,
             )

--- a/tt_metal/tt-llk/tests/python_tests/helpers/perf_schema.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/perf_schema.py
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+
+class PerfSchemaError(AssertionError):
+    """
+    Raised when a perf report accumulates more than one column schema in a
+    single CSV (ragged, NaN-filled rows that break strict-JSON dashboards and
+    the compare feature). Fail-loud so the contaminated CSV never ships.
+    """
+
+
+MARKER = "marker"
+
+FORMAT_HEADERS = (
+    "formats.input_A",
+    "formats.input_B",
+    "formats.register_A",
+    "formats.register_B",
+    "formats.output",
+)
+FLAG_HEADERS = ("unpack_to_dest", "dest_acc")
+
+FIXED_SWEEP_HEADERS = FORMAT_HEADERS + FLAG_HEADERS
+
+LOOP_FACTOR_COLUMN = "loop_factor"
+TILE_CNT_COLUMN = "tile_cnt"
+TEST_NAME_COLUMN = "test_name"
+
+MEAN = "mean"
+STD = "std"
+TEXT_SIZE_PREFIX = "TEXT_SIZE("
+
+
+def stat_prefix(kind: str) -> str:
+    """Prefix of a stat column, e.g. stat_prefix("mean") -> "mean(" (for startswith)."""
+    return f"{kind}("
+
+
+def stat_column(base: str, kind: str) -> str:
+    """Timing stat column, e.g. stat_column("L1_TO_L1", "mean") -> "mean(L1_TO_L1)"."""
+    return f"{stat_prefix(kind)}{base})"
+
+
+def metric_column(run_type_name: str, base: str) -> str:
+    """Run-type-prefixed column, e.g. metric_column("L1_TO_L1", "x") -> "L1_TO_L1_x"."""
+    return f"{run_type_name}_{base}"
+
+
+def text_size_column(run_type_name: str) -> str:
+    """Kernel code-size column, e.g. -> "TEXT_SIZE(L1_TO_L1)"."""
+    return f"{TEXT_SIZE_PREFIX}{run_type_name})"
+
+
+def counter_base(bank: str, counter: str) -> str:
+    """Raw HW-counter base name, e.g. counter_base("FPU", "FPU_COUNTER") -> "FPU.FPU_COUNTER"."""
+    return f"{bank}.{counter}"
+
+
+def cycles_of(base: str) -> str:
+    """Cycles variant of a counter base name, e.g. -> "FPU.FPU_COUNTER.cycles"."""
+    return f"{base}.cycles"

--- a/tt_metal/tt-llk/tests/python_tests/helpers/profiler.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/profiler.py
@@ -11,6 +11,7 @@ import pandas as pd
 from ttexalens.tt_exalens_lib import read_words_from_device
 
 from .llk_params import PerfRunType
+from .perf_schema import MARKER, MEAN, STD, stat_column
 from .test_config import TestConfig
 
 
@@ -121,7 +122,7 @@ class ProfilerData:
             [
                 "thread",
                 "type",
-                "marker",
+                MARKER,
                 "timestamp",
                 "duration",
                 "data",
@@ -167,7 +168,7 @@ class ProfilerData:
     # Filter by marker
     def marker(self, marker: str) -> "ProfilerData":
         """Filter: Marker"""
-        return ProfilerData(self.df, self.mask & (self.df["marker"] == marker))
+        return ProfilerData(self.df, self.mask & (self.df[MARKER] == marker))
 
     def __str__(self):
         return f"{self.raw()}"
@@ -175,11 +176,11 @@ class ProfilerData:
 
 def _stats_timings(perf_data: pd.DataFrame) -> pd.DataFrame:
     # don't aggregate marker column
-    timings = perf_data.columns.drop("marker")
-    result = perf_data.groupby("marker", as_index=False)[timings].agg(["mean", "std"])
+    timings = perf_data.columns.drop(MARKER)
+    result = perf_data.groupby(MARKER, as_index=False)[timings].agg(["mean", "std"])
 
-    columns = ["marker"]
-    columns += [f"{stat}({col})" for col in timings for stat in ["mean", "std"]]
+    columns = [MARKER]
+    columns += [stat_column(col, stat) for col in timings for stat in (MEAN, STD)]
 
     result.columns = columns
 
@@ -215,7 +216,7 @@ def _stats_l1_to_l1(data: ProfilerData) -> pd.DataFrame:
         )
 
     # Group by both marker and run_index to ensure events from the same run are paired
-    groups = raw_data.groupby(["marker", "run_index"])
+    groups = raw_data.groupby([MARKER, "run_index"])
 
     timings = []
     for (marker, run_index), group in groups:
@@ -244,7 +245,7 @@ def _stats_l1_to_l1(data: ProfilerData) -> pd.DataFrame:
 
         marker_timings = pd.DataFrame(
             {
-                "marker": marker,
+                MARKER: marker,
                 PerfRunType.L1_TO_L1.name: durations,
             }
         )
@@ -271,7 +272,7 @@ def _stats_thread(stat: str, raw_thread: pd.DataFrame) -> pd.DataFrame:
 
     timings = pd.DataFrame(
         {
-            "marker": start_entries["marker"],
+            MARKER: start_entries[MARKER],
             stat: end_entries["timestamp"] - start_entries["timestamp"],
         }
     )
@@ -304,7 +305,7 @@ def _stats_l1_congestion(data: ProfilerData) -> pd.DataFrame:
         return pd.DataFrame()
     result = frames[0]
     for df in frames[1:]:
-        result = pd.merge(result, df, on="marker", how="outer", validate="1:1")
+        result = pd.merge(result, df, on=MARKER, how="outer", validate="1:1")
     return result
 
 
@@ -417,7 +418,7 @@ class Profiler:
             "type": pd.CategoricalDtype(
                 categories=["TIMESTAMP", "ZONE_START", "ZONE_END"]
             ),
-            "marker": "string",
+            MARKER: "string",
             "timestamp": "int64",
             "data": "Int64",  # nullable
             "marker_id": "int32",
@@ -507,7 +508,7 @@ class Profiler:
         return {
             "thread": thread,
             "type": type,
-            "marker": marker.marker,
+            MARKER: marker.marker,
             "timestamp": timestamp,
             "data": data,
             "marker_id": marker.id,


### PR DESCRIPTION
Move header names and builders (MARKER, stat_column, metric_column, counter_base, cycles_of, text_size_column) plus PerfSchemaError into a new helpers/perf_schema.py, and route metrics.py, perf.py, profiler.py, and fuser_config.py through them instead of scattered string literals.

Pure refactor: no change to CSV output.