### PR TITLE
[Bug fix] ttnn.move: hold input memory config by value across deallocate

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/move/move.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/move/move.cpp
@@ -36,6 +36,7 @@ inline Tensor move_impl(const Tensor& input_tensor, const std::optional<MemoryCo
     TT_ASSERT(input_tensor.is_allocated(), "Expected input tensor to be allocated");
     // Hold the memory config by value, not by reference: input_tensor is deallocated below, which
     // destroys the TensorSpec (and the MemoryConfig inside it) that memory_config() refers into.
+    // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
     const auto input_mem_config = input_tensor.memory_config();
     auto input_address = input_tensor.buffer()->address();
     tt::tt_metal::TensorSpec output_tensor_spec = input_tensor.tensor_spec();

--- a/ttnn/cpp/ttnn/operations/data_movement/move/move.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/move/move.cpp
@@ -34,10 +34,9 @@ Tensor create_ghost_tensor(const Tensor& input_tensor) {
 
 inline Tensor move_impl(const Tensor& input_tensor, const std::optional<MemoryConfig>& mem_config) {
     TT_ASSERT(input_tensor.is_allocated(), "Expected input tensor to be allocated");
-    // Hold the memory config by value, not by reference: input_tensor is deallocated below, which
-    // destroys the TensorSpec (and the MemoryConfig inside it) that memory_config() refers into.
-    // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
-    const auto input_mem_config = input_tensor.memory_config();
+    // Deliberate copy: input_tensor is deallocated below, which destroys the TensorSpec (and the
+    // MemoryConfig inside it) that memory_config() returns a reference to.
+    const auto input_mem_config = MemoryConfig(input_tensor.memory_config());
     auto input_address = input_tensor.buffer()->address();
     tt::tt_metal::TensorSpec output_tensor_spec = input_tensor.tensor_spec();
 

--- a/ttnn/cpp/ttnn/operations/data_movement/move/move.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/move/move.cpp
@@ -34,7 +34,9 @@ Tensor create_ghost_tensor(const Tensor& input_tensor) {
 
 inline Tensor move_impl(const Tensor& input_tensor, const std::optional<MemoryConfig>& mem_config) {
     TT_ASSERT(input_tensor.is_allocated(), "Expected input tensor to be allocated");
-    const auto& input_mem_config = input_tensor.memory_config();
+    // Hold the memory config by value, not by reference: input_tensor is deallocated below, which
+    // destroys the TensorSpec (and the MemoryConfig inside it) that memory_config() refers into.
+    const auto input_mem_config = input_tensor.memory_config();
     auto input_address = input_tensor.buffer()->address();
     tt::tt_metal::TensorSpec output_tensor_spec = input_tensor.tensor_spec();
 

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/move/move.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/move/move.cpp
@@ -33,7 +33,9 @@ Tensor create_ghost_tensor(const Tensor& input_tensor) {
 
 inline Tensor move_impl(const Tensor& input_tensor, const std::optional<MemoryConfig>& mem_config) {
     TT_ASSERT(input_tensor.is_allocated(), "Expected input tensor to be allocated");
-    const auto& input_mem_config = input_tensor.memory_config();
+    // Hold the memory config by value, not by reference: input_tensor is deallocated below, which
+    // destroys the TensorSpec (and the MemoryConfig inside it) that memory_config() refers into.
+    const auto input_mem_config = input_tensor.memory_config();
     auto input_address = input_tensor.buffer()->address();
     tt::tt_metal::TensorSpec output_tensor_spec = input_tensor.tensor_spec();
 

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/move/move.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/move/move.cpp
@@ -35,6 +35,7 @@ inline Tensor move_impl(const Tensor& input_tensor, const std::optional<MemoryCo
     TT_ASSERT(input_tensor.is_allocated(), "Expected input tensor to be allocated");
     // Hold the memory config by value, not by reference: input_tensor is deallocated below, which
     // destroys the TensorSpec (and the MemoryConfig inside it) that memory_config() refers into.
+    // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
     const auto input_mem_config = input_tensor.memory_config();
     auto input_address = input_tensor.buffer()->address();
     tt::tt_metal::TensorSpec output_tensor_spec = input_tensor.tensor_spec();

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/move/move.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/move/move.cpp
@@ -33,10 +33,9 @@ Tensor create_ghost_tensor(const Tensor& input_tensor) {
 
 inline Tensor move_impl(const Tensor& input_tensor, const std::optional<MemoryConfig>& mem_config) {
     TT_ASSERT(input_tensor.is_allocated(), "Expected input tensor to be allocated");
-    // Hold the memory config by value, not by reference: input_tensor is deallocated below, which
-    // destroys the TensorSpec (and the MemoryConfig inside it) that memory_config() refers into.
-    // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
-    const auto input_mem_config = input_tensor.memory_config();
+    // Deliberate copy: input_tensor is deallocated below, which destroys the TensorSpec (and the
+    // MemoryConfig inside it) that memory_config() returns a reference to.
+    const auto input_mem_config = MemoryConfig(input_tensor.memory_config());
     auto input_address = input_tensor.buffer()->address();
     tt::tt_metal::TensorSpec output_tensor_spec = input_tensor.tensor_spec();
 


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

`move_impl` bound the input's memory config by reference, then deallocated the input and kept reading it:

```cpp
const auto& input_mem_config = input_tensor.memory_config();       // :37 ref into input_tensor
const_cast<Tensor&>(input_tensor).deallocate(/* force = */ false); // :43 referent destroyed
input_mem_config.buffer_type()                                    // :63 use-after-destroy
```

Fix: take a copy. Latent since #41224; #47732 pimpl'd `MemoryConfig`, turning the stale read into a null deref behind a new assert:

```
TT_FATAL @ memory_config.cpp:64: impl_ != nullptr
MemoryConfig is in a moved-from state.
 --- ttnn::move(...)  <-  ttnn::operations::core::reallocate(...)
```

Same fix in `experimental/quasar/move/move.cpp`, a verbatim copy of this logic (thanks @Copilot).

Unblocks stable_diffusion in [model perf](https://github.com/tenstorrent/tt-metal/actions/runs/30433431739) (N300 WH, P150 BH) and stable_diffusion + segformer in [demos](https://github.com/tenstorrent/tt-metal/actions/runs/30426829731) (N150, N300).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mstaletovic/fix-move-dangling-memory-config)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mstaletovic/fix-move-dangling-memory-config)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mstaletovic/fix-move-dangling-memory-config)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mstaletovic/fix-move-dangling-memory-config)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mstaletovic/fix-move-dangling-memory-config)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mstaletovic/fix-move-dangling-memory-config)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mstaletovic/fix-move-dangling-memory-config)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mstaletovic/fix-move-dangling-memory-config)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mstaletovic/fix-move-dangling-memory-config)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mstaletovic/fix-move-dangling-memory-config)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mstaletovic/fix-move-dangling-memory-config)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mstaletovic/fix-move-dangling-memory-config)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mstaletovic/fix-move-dangling-memory-config)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mstaletovic/fix-move-dangling-memory-config)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mstaletovic/fix-move-dangling-memory-config)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mstaletovic/fix-move-dangling-memory-config)