### PR TITLE
#51472: add quasar ops tests that exercise ops/inputs that would be exercised by yolo8

### DIFF
--- a/models/experimental/ops/quasar/tests/conftest.py
+++ b/models/experimental/ops/quasar/tests/conftest.py
@@ -1,0 +1,293 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+
+import contextlib
+import fcntl
+import os
+import tempfile
+import time
+
+import pytest
+
+import ttnn
+
+# ==============================================================================
+# Device Lock - Coordinates exclusive access to TT devices across processes
+# ==============================================================================
+
+
+def _sanitize_lock_path(raw: str) -> str:
+    """Confine the (env-derived, untrusted) lock path to the system temp directory.
+
+    ``TT_DEVICE_LOCK_PATH`` is operator-controlled input, so it is treated as
+    untrusted: only its basename is kept and anchored under the trusted temp dir,
+    preventing path traversal or writes outside the intended location. All
+    processes on a host still resolve to the same lock file, so cross-process
+    coordination is preserved.
+    """
+    base = os.path.realpath(tempfile.gettempdir())
+    name = os.path.basename(raw) or "tt_device.lock"
+    resolved = os.path.realpath(os.path.join(base, name))
+    # Defense in depth: never allow the resolved path to escape the trusted base.
+    if os.path.commonpath([base, resolved]) != base:
+        resolved = os.path.join(base, "tt_device.lock")
+    return resolved
+
+
+_TT_DEVICE_LOCK_PATH = _sanitize_lock_path(os.environ.get("TT_DEVICE_LOCK_PATH", "/tmp/tt_device.lock"))
+_TT_DEVICE_LOCK_TIMEOUT = float(os.environ.get("TT_DEVICE_LOCK_TIMEOUT", "60"))  # 1 min default
+
+
+class DeviceLockTimeout(Exception):
+    """Raised when acquiring the device lock times out."""
+
+
+# todo)) the UMD already provides a lock mechanism -- use it instead of this?
+@contextlib.contextmanager
+def tt_device_lock(lock_path: str = _TT_DEVICE_LOCK_PATH, timeout: float = _TT_DEVICE_LOCK_TIMEOUT):
+    """
+    Context manager for exclusive access to TT devices.
+
+    Uses flock for cross-process coordination. Blocks until lock is acquired
+    or timeout is reached.
+
+    Usage:
+        with tt_device_lock():
+            mesh = ttnn.open_mesh_device(...)
+            # ... do work ...
+            ttnn.close_mesh_device(mesh)
+
+    Debug stuck locks with: lsof /tmp/tt_device.lock
+
+    Environment variables:
+        TT_DEVICE_LOCK_PATH: Override lock file NAME (its basename is anchored under
+            the system temp dir; directory/traversal components are stripped)
+        TT_DEVICE_LOCK_TIMEOUT: Override timeout in seconds (default: 300)
+    """
+    # Re-sanitize at the sink: guarantee the path reaching the filesystem is
+    # confined to the trusted temp dir, regardless of what the caller passed.
+    lock_path = _sanitize_lock_path(lock_path)
+    lock_dir = os.path.dirname(lock_path)
+    if lock_dir and not os.path.exists(lock_dir):
+        os.makedirs(lock_dir, exist_ok=True)
+
+    lock_file = open(lock_path, "a+")  # open the file in append mode to avoid truncation race condition among processes
+    start_time = time.monotonic()
+    lock_acquired = False
+
+    try:
+        # Poll for lock with timeout
+        logged_waiting = False
+        while True:
+            try:
+                fcntl.flock(lock_file, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                lock_acquired = True
+                break
+            except BlockingIOError:
+                pass  # Lock held by another process
+
+            if not logged_waiting:
+                print(f"[tt_device_lock] Waiting for device lock (held by another process)...")
+                print(f"[tt_device_lock] Debug with: lsof {lock_path}")
+                logged_waiting = True
+
+            if time.monotonic() - start_time >= timeout:
+                lock_file.close()
+                raise DeviceLockTimeout(
+                    f"Timed out after {timeout}s waiting for device lock. " f"Check: lsof {lock_path}"
+                )
+
+            time.sleep(1)  # sleep for 1 second to avoid busy-waiting
+
+        if logged_waiting:
+            print(f"[tt_device_lock] Lock acquired after {time.monotonic() - start_time:.1f}s")
+
+        # Write PID for debugging
+        lock_file.truncate(0)  # clear the file
+        lock_file.write(f"{os.getpid()}\n")
+        lock_file.flush()
+
+        yield
+
+    finally:
+        if lock_acquired:
+            fcntl.flock(lock_file, fcntl.LOCK_UN)
+        lock_file.close()
+
+
+def pytest_collection_modifyitems(config, items):
+    """Deselect tests where ttnn_mesh_device fixture doesn't match mesh_shape param.
+
+    This enables tests to use cross-product parametrization (all meshes × all cases)
+    while only running the valid combinations, without noisy skip messages.
+    """
+    selected = []
+    deselected = []
+
+    for item in items:
+        if not hasattr(item, "callspec"):
+            selected.append(item)
+            continue
+
+        params = item.callspec.params
+        fixture_mesh = params.get("ttnn_mesh_device")
+        required_mesh = params.get("mesh_shape")
+
+        # Keep test if no mesh_shape param or if meshes match
+        if required_mesh is None or fixture_mesh == required_mesh:
+            selected.append(item)
+        else:
+            deselected.append(item)
+
+    items[:] = selected
+    if deselected:
+        config.hook.pytest_deselected(items=deselected)
+
+
+@pytest.fixture(scope="module")
+def ttnn_mesh_device(request):
+    """Create and yield a mesh device for a given mesh shape, cleanup on teardown."""
+    if not hasattr(request, "param"):
+        pytest.skip(f"{__file__}: mesh_device fixture called without parametrization")
+
+    if ttnn.device.is_blackhole():
+        pytest.skip(f"{__file__}: Blackhole device is not supported for this test yet")
+
+    # request.param is either a Sequence of ints or a dict with fabric_config and etc.
+    params = getattr(request, "param", tuple())
+    if isinstance(params, tuple):
+        mesh_shape = params
+        updated_params = dict()
+    else:
+        try:
+            updated_params = params.copy()
+            mesh_shape = updated_params.pop("mesh_shape")
+        except Exception as e:
+            pytest.skip(f"{__file__}: mesh_shape is required: {e}")
+
+    # Pre-check: if no devices at all, skip without invoking C++ open.
+    # Some environments can throw here (e.g. transient driver/UMD issues); treat as "device unavailable".
+    try:
+        num_pcie = ttnn.get_num_pcie_devices()
+    except Exception as e:
+        pytest.skip(f"{__file__}: Unable to query TT devices on this system: {e}")
+
+    if isinstance(num_pcie, int) and num_pcie == 0:
+        pytest.skip(f"{__file__}: No TT devices detected on this system")
+
+    # Pre-check: skip shapes that cannot fit into the SystemMesh to avoid native exceptions
+    sys_desc = ttnn._ttnn.multi_device.SystemMeshDescriptor()  # type: ignore[attr-defined]
+    sys_shape = tuple(sys_desc.shape())
+    req_shape = tuple(mesh_shape)
+    allowed = _allowed_req_shapes_for_system(sys_shape)
+    if req_shape not in allowed:
+        pytest.skip(
+            f"{__file__}: Requested mesh {req_shape} unsupported on system {sys_shape}. "
+            f"Allowed for this system: {allowed}"
+        )
+
+    parent_shape = _pick_parent_shape_for_submesh(sys_shape, req_shape)
+
+    # config fabric config
+    fabric_config = updated_params.pop("fabric_config", None)
+    if parent_shape == (1, 1):
+        # Single device does not need fabric config.
+        pass
+    else:
+        # Provide default fabric config for the mesh we actually open (full system mesh).
+        num_devices = parent_shape[0] * parent_shape[1]
+        if fabric_config is None:
+            if num_devices >= 8:
+                fabric_config = ttnn.FabricConfig.FABRIC_1D_RING
+            else:
+                fabric_config = ttnn.FabricConfig.FABRIC_1D
+        # set all other input arguments to default values by top-level conftest.py
+        ttnn.set_fabric_config(
+            fabric_config, ttnn.FabricReliabilityMode.STRICT_INIT, None, ttnn.FabricTensixConfig.DISABLED
+        )
+
+    # config dispatch core to default values by conftest.py
+    updated_params["dispatch_core_config"] = ttnn.DispatchCoreConfig(type=None, axis=None, fabric_tensix_config=None)
+
+    # If a test requests a submesh of a larger system mesh (e.g. request 2x4 on a 8x4 system),
+    # fabric cannot be initialized on only the subset of devices. In that case, open the full
+    # system mesh first, then return the "first" submesh. We intentionally rely on the default
+    # offset behavior here (i.e. no explicit offset selection).
+    parent_device = None
+    submesh_device = None
+
+    # Acquire exclusive lock to prevent concurrent device access across processes
+    with tt_device_lock():
+        try:
+            # Device *setup* only inside this inner try/except: a failure here means the
+            # device is unavailable or the configuration is unsupported, which is a
+            # legitimate skip. The yield is deliberately kept OUTSIDE the skip-converting
+            # except so that exceptions raised by the test body propagate as real
+            # failures instead of being masked as skips.
+            try:
+                parent_device = ttnn.open_mesh_device(mesh_shape=ttnn.MeshShape(parent_shape), **updated_params)
+                if req_shape != parent_shape:
+                    submesh_device = parent_device.create_submesh(ttnn.MeshShape(req_shape))
+            except Exception as e:
+                pytest.skip(f"{__file__}: Mesh device unavailable or unsupported for this configuration: {e}")
+
+            yield submesh_device if submesh_device is not None else parent_device
+        finally:
+            if submesh_device is not None:
+                ttnn.close_mesh_device(submesh_device)
+            if parent_device is not None:
+                ttnn.close_mesh_device(parent_device)
+            if fabric_config:
+                ttnn.set_fabric_config(ttnn.FabricConfig.DISABLED)
+            del parent_device
+
+
+def _allowed_req_shapes_for_system(sys_shape: tuple[int, int]) -> set[tuple[int, int]]:
+    # todo)) Different cluster has potentially different physical interconnects (in terms of number of links, topology, etc.).
+    #        Thus, a tuple of ints may not be enough to fingerprint the parent/system mesh device. We need to use a more sophisticated fingerprinting mechanism so we can base the allowed list of (sub)mesh shapes on the parent/system mesh device.
+    # [INFO] The most robust way to identify the underlying system is to use ttnn.cluster.get_cluster_type(), which returns a ClusterType enum that precisely identifies your hardware configuration. cluster.cpp:16-37
+
+    _CANDIDATE_REQ_SHAPES = {
+        (1, 1): ((1, 1),),
+        (1, 2): ((1, 2), (1, 1)),
+        (2, 4): ((2, 4), (1, 8), (1, 4), (1, 2), (1, 1)),
+        (8, 4): ((8, 4), (4, 8), (1, 8), (1, 4), (1, 2), (1, 1)),
+        # [INFO] add more system shapes here
+    }
+
+    allowed: set[tuple[int, int]] = set()
+
+    if sys_shape in _CANDIDATE_REQ_SHAPES:
+        for mesh_shape in _CANDIDATE_REQ_SHAPES[sys_shape]:
+            allowed.add(mesh_shape)
+
+    return allowed
+
+
+def _pick_parent_shape_for_submesh(system_shape: tuple[int, int], requested_shape: tuple[int, int]) -> tuple[int, int]:
+    # For multi-device workloads we always open the full system mesh (fabric cannot be launched on a subset),
+    # but we may choose the *orientation* of the full mesh such that the requested submesh fits with the
+    # default offset (i.e. "first submesh").
+    if requested_shape == (1, 1):
+        return (1, 1)
+
+    # If the request uses all devices, treat it as a "full-mesh view" shape and open the parent mesh in that view.
+    # This enables shapes like (1,32) on a system whose SystemMeshDescriptor reports (8,4).
+    system_num_devices = system_shape[0] * system_shape[1]
+    requested_num_devices = requested_shape[0] * requested_shape[1]
+    if requested_num_devices == system_num_devices:
+        return requested_shape
+
+    if requested_shape[0] <= system_shape[0] and requested_shape[1] <= system_shape[1]:
+        return system_shape
+
+    rotated = (system_shape[1], system_shape[0])
+    if requested_shape[0] <= rotated[0] and requested_shape[1] <= rotated[1]:
+        return rotated
+
+    # No orientation can fit this request without an explicit offset / mapping.
+    pytest.skip(
+        f"{__file__}: Requested submesh {requested_shape} does not fit within system mesh {system_shape} "
+        f"(or its rotated view {rotated}) with default offset."
+    )

--- a/models/experimental/ops/quasar/tests/conftest.py
+++ b/models/experimental/ops/quasar/tests/conftest.py
@@ -152,7 +152,6 @@ def ttnn_mesh_device(request):
     if not hasattr(request, "param"):
         pytest.skip(f"{__file__}: mesh_device fixture called without parametrization")
 
-
     # request.param is either a Sequence of ints or a dict with fabric_config and etc.
     params = getattr(request, "param", tuple())
     if isinstance(params, tuple):

--- a/models/experimental/ops/quasar/tests/conftest.py
+++ b/models/experimental/ops/quasar/tests/conftest.py
@@ -260,6 +260,12 @@ def _allowed_req_shapes_for_system(sys_shape: tuple[int, int]) -> set[tuple[int,
         for mesh_shape in _CANDIDATE_REQ_SHAPES[sys_shape]:
             allowed.add(mesh_shape)
 
+    # A single-device (1, 1) submesh is valid on ANY system, so always allow it —
+    # otherwise the suite's universal (1, 1) request silently skips on a topology
+    # whose system shape isn't in the table above (e.g. a new/differently-oriented
+    # Blackhole). (Ideal fix per repo guidance: fingerprint via ttnn.cluster.get_cluster_type.)
+    allowed.add((1, 1))
+
     return allowed
 
 

--- a/models/experimental/ops/quasar/tests/conftest.py
+++ b/models/experimental/ops/quasar/tests/conftest.py
@@ -72,7 +72,8 @@ def tt_device_lock(lock_path: str = _TT_DEVICE_LOCK_PATH, timeout: float = _TT_D
     if lock_dir and not os.path.exists(lock_dir):
         os.makedirs(lock_dir, exist_ok=True)
 
-    lock_file = open(lock_path, "a+")  # open the file in append mode to avoid truncation race condition among processes
+    lock_fd = os.open(lock_path, os.O_RDWR | os.O_CREAT | os.O_APPEND | os.O_NOFOLLOW, 0o600)
+    lock_file = os.fdopen(lock_fd, "a+")
     start_time = time.monotonic()
     lock_acquired = False
 

--- a/models/experimental/ops/quasar/tests/conftest.py
+++ b/models/experimental/ops/quasar/tests/conftest.py
@@ -151,8 +151,6 @@ def ttnn_mesh_device(request):
     if not hasattr(request, "param"):
         pytest.skip(f"{__file__}: mesh_device fixture called without parametrization")
 
-    if ttnn.device.is_blackhole():
-        pytest.skip(f"{__file__}: Blackhole device is not supported for this test yet")
 
     # request.param is either a Sequence of ints or a dict with fabric_config and etc.
     params = getattr(request, "param", tuple())

--- a/models/experimental/ops/quasar/tests/conftest.py
+++ b/models/experimental/ops/quasar/tests/conftest.py
@@ -63,7 +63,7 @@ def tt_device_lock(lock_path: str = _TT_DEVICE_LOCK_PATH, timeout: float = _TT_D
     Environment variables:
         TT_DEVICE_LOCK_PATH: Override lock file NAME (its basename is anchored under
             the system temp dir; directory/traversal components are stripped)
-        TT_DEVICE_LOCK_TIMEOUT: Override timeout in seconds (default: 300)
+        TT_DEVICE_LOCK_TIMEOUT: Override timeout in seconds (default: 60)
     """
     # Re-sanitize at the sink: guarantee the path reaching the filesystem is
     # confined to the trusted temp dir, regardless of what the caller passed.

--- a/models/experimental/ops/quasar/tests/yolo_ops/README.md
+++ b/models/experimental/ops/quasar/tests/yolo_ops/README.md
@@ -1,0 +1,43 @@
+# YOLOv8 per-op tests (`tests/yolo_ops/`)
+
+Isolated tests for **every ttnn op the YOLOv8 model executes**, with the shapes the
+model uses (yolov8l + yolov8s, 640×640, batch 1).
+
+## Licensing
+
+The YOLOv8 model **is not** in main — it lives on branch `sdawle/yolov8_bh` and can't
+be merged (licensing). These tests import **no** YOLOv8 code: each calls the raw `ttnn`
+op directly with shapes extracted read-only from that branch
+(`models/demos/yolov8{l,s}/tt/*`), cited by `file:line` in each test's docstring. So this
+suite demonstrates the ops run on Quasar without landing any model code in main.
+
+## Running
+
+```bash
+# Full suite (real Blackhole — most feature maps are large):
+pytest models/experimental/ops/quasar/tests/yolo_ops/ -v
+
+# Emulator subset (small feature maps / tensors that fit the 2-node emulator):
+pytest models/experimental/ops/quasar/tests/yolo_ops/ -m emulator -v
+```
+
+## Conventions
+
+- Shared helpers/constants in `op_utils.py` (re-exports the generic `tests/ops/op_utils`
+  helpers + YOLO dims + `nhwc_to_tt`). One file per op.
+- `conftest.py` adds the `emulator` marker from each case's params: `hw` ≤ 40 (feature-map
+  side) or a `shape`/`out_shape` tuple under `EMU_MAX_ELEMS`, single-device only. YOLO's
+  large 320/160/80² maps are excluded (they run on Blackhole); small detect/anchor tensors,
+  20/40² maps, and layout round-trips are included. Thresholds in `op_utils.py` are
+  heuristics — tune on the emulator.
+- Correctness: `assert_pcc` vs a torch reference where one exists (conv → `F.conv2d`,
+  pool/upsample, elementwise, and value-preserving data-movement round-trips); no op is
+  shape/dtype-only here.
+
+## Status
+
+Authored from static analysis of the branch (no device at authoring). A few shapes are
+noted inline as approximate where they come from runtime config dicts not recoverable from
+the source (some yolov8s neck channel widths, one neck concat width, the bottleneck residual
+channel) — harmless for the channel-independent value-preserving ops. `conv2d` covers 69
+distinct shapes; expect first-run touch-ups on conv/sharded cases.

--- a/models/experimental/ops/quasar/tests/yolo_ops/conftest.py
+++ b/models/experimental/ops/quasar/tests/yolo_ops/conftest.py
@@ -1,0 +1,74 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Local conftest for the YOLOv8 per-op suite: tags emulator-appropriate cases.
+
+Same mechanism as tests/ops/conftest.py — an ``emulator`` marker inferred from each
+case's actual parametrized values, so:
+
+    pytest models/experimental/ops/quasar/tests/yolo_ops/ -m emulator
+
+selects the subset small enough for the 2-node emulator. For YOLO most feature maps
+are large; a case is emulator-appropriate only when its spatial size / element count
+is small (see op_utils.EMU_MAX_HW / EMU_MAX_ELEMS) and it targets a single (1,1) mesh.
+
+Classification (a case is NOT emulator when any of):
+  * it targets a non-(1,1) mesh,
+  * an ``hw`` / ``h`` / ``w`` / ``res`` int param exceeds EMU_MAX_HW,
+  * a ``shape`` / ``in_shape`` / ``out_shape`` tuple's element count exceeds EMU_MAX_ELEMS.
+"""
+
+from models.experimental.ops.quasar.tests.yolo_ops.op_utils import EMU_MAX_ELEMS, EMU_MAX_HW
+
+_HW_PARAMS = ("hw", "h", "w", "height", "width", "res", "resolution", "in_h", "in_w")
+_SHAPE_PARAMS = ("shape", "in_shape", "out_shape")
+
+
+def _elems(shape) -> int:
+    n = 1
+    for d in shape:
+        if isinstance(d, int):
+            n *= d
+    return n
+
+
+def _fits_emulator(item) -> bool:
+    # Model-faithful tests reproduce the model's real sharded/TILE/L1 state (often on
+    # 25-80 core grids) — Blackhole-scale, never the 2-node emulator subset.
+    if item.get_closest_marker("blackhole_scale") is not None:
+        return False
+    callspec = getattr(item, "callspec", None)
+    if callspec is None:
+        return True
+    params = callspec.params
+    mesh = params.get("ttnn_mesh_device")
+    if isinstance(mesh, dict):  # {"mesh_shape": (..), "l1_small_size": ..} form
+        mesh = mesh.get("mesh_shape")
+    if mesh is not None and tuple(mesh) != (1, 1):
+        return False
+    for name, val in params.items():
+        if name in _HW_PARAMS and isinstance(val, int) and val > EMU_MAX_HW:
+            return False
+        if name in _SHAPE_PARAMS and isinstance(val, (tuple, list)) and _elems(val) > EMU_MAX_ELEMS:
+            return False
+    return True
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers",
+        "emulator: YOLOv8 op-test case that fits the 2-node Quasar emulator (small feature map / single-device)",
+    )
+    config.addinivalue_line(
+        "markers",
+        "blackhole_scale: reproduces the model's exact sharded/TILE/L1 input state (Blackhole-scale; excluded from -m emulator)",
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    import pytest
+
+    for item in items:
+        if _fits_emulator(item):
+            item.add_marker(pytest.mark.emulator)

--- a/models/experimental/ops/quasar/tests/yolo_ops/op_utils.py
+++ b/models/experimental/ops/quasar/tests/yolo_ops/op_utils.py
@@ -1,0 +1,200 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Shared helpers for the YOLOv8 per-op test suite (``tests/yolo_ops/``).
+
+Goal
+----
+Demonstrate that every ttnn op the YOLOv8 model runs — *with that model's shapes* —
+works on Quasar, without landing any YOLOv8 model code in main (licensing). These
+tests import NO YOLOv8 code; they call the raw ttnn ops directly with the shapes the
+model uses (extracted from the ``sdawle/yolov8_bh`` branch:
+``models/demos/yolov8{l,s}/tt/*``). Shapes cover the yolov8l and yolov8s variants at
+640x640 input, batch 1.
+
+Conventions (mirror tests/ops/):
+  * import dims/helpers from here; ground each shape in a real model call site
+    (cite the branch file:line in a comment),
+  * use the ``ttnn_mesh_device`` fixture (from tests/conftest.py), parametrized
+    ``indirect`` — default ``[(1, 1)]``,
+  * compare against a torch reference with ``assert_pcc`` where a reference exists;
+    otherwise ``assert_shape_dtype`` (shape/dtype/finite).
+
+Emulator subset: the ``emulator`` marker (added by tests/yolo_ops/conftest.py) selects
+cases small enough for the 2-node emulator. For YOLO most activations are large
+(320/160/80x80 feature maps), so only the smallest (≈ resolution ≤ 40) fit; the rest
+run on real Blackhole. Parametrize spatially-sized ops with an int ``hw`` (input
+H == W) and/or a ``shape`` tuple so the conftest can classify them.
+"""
+
+from __future__ import annotations
+
+import pytest  # noqa: F401  (re-exported convenience for op files)
+import torch
+
+import ttnn
+
+# Reuse the generic tensor/assert helpers from the llama op suite (arch-agnostic).
+from models.experimental.llama32_1b_quasar.tests.ops.op_utils import (  # noqa: F401
+    assert_pcc,
+    assert_shape_dtype,
+    comp_pcc,
+    from_tt,
+    to_tt,
+    torch_rand,
+    with_default_mesh,
+)
+
+# =============================================================================
+# YOLOv8 (640x640, batch 1) constants
+# =============================================================================
+
+BATCH = 1
+INPUT_RES = 640
+IMG_CH = 3
+IMG_CH_PADDED = 16  # model pads the 3-channel input to 16 (test_yolov8l.py: F.pad ... 0,13)
+TILE = 32
+
+# Feature-map resolutions the 640x640 backbone/neck operate at (stride 2 halving):
+#   640 -> 320 -> 160 -> 80 -> 40 -> 20.  Detect head runs at {80, 40, 20}.
+RESOLUTIONS = [320, 160, 80, 40, 20]
+
+# Emulator classification thresholds (heuristic; tune on the emulator).
+# A case fits the 2-node emulator when its spatial size / element count is small.
+EMU_MAX_HW = 40  # input H==W (feature-map side) that still fits 2 cores
+EMU_MAX_ELEMS = 40 * 40 * 512  # ~0.8M elements — fallback for shape-tuple params
+
+# conv2d / max_pool2d allocate from the device L1-small region; the model opens the
+# device with this size (yolov8l common.py: _YOLOV8L_L1_SMALL_BASE_640). The default
+# test fixture opens with l1_small_size=0, so those ops OOM ("L1_SMALL ... bank size is
+# 0 B") unless the device is opened with a nonzero l1_small_size. 32768 gives headroom
+# over the model's 24576 base for a single isolated op.
+YOLOV8_L1_SMALL_SIZE = 32768
+
+
+def with_mesh_l1small(l1_small_size=YOLOV8_L1_SMALL_SIZE, mesh=(1, 1)):
+    """Parametrize ``ttnn_mesh_device`` to open the device with a nonzero l1_small_size.
+
+    Needed by conv2d / max_pool2d (they allocate from the L1-small region). The fixture
+    accepts a dict param ``{"mesh_shape", ...device kwargs}``; conftest._fits_emulator
+    reads ``mesh_shape`` out of it for emulator classification.
+    """
+    return pytest.mark.parametrize(
+        "ttnn_mesh_device",
+        [pytest.param({"mesh_shape": mesh, "l1_small_size": l1_small_size}, id="mesh")],
+        indirect=True,
+    )
+
+
+def to_tile_l1(torch_tensor, mesh_device, *, dtype=ttnn.bfloat16):
+    """TILE tensor in L1 — generated via DRAM to dodge the tilize-into-L1 NOC bug.
+
+    ``from_torch(..., layout=TILE, memory_config=L1)`` tilizes on device; for
+    non-tile-aligned shapes (e.g. dist2bbox (1,2,8400) — the 2/4 row dim padded to 32)
+    the device tilize_with_val_padding into L1 overflows NOC ("NOC target address
+    overflow"). Tilizing into DRAM works (the existing DRAM tests pass), so we tilize
+    into DRAM and then relocate DRAM->L1 (a plain copy, no re-tilize). The model never
+    tilizes these from host anyway — they arrive in L1 via graph ops — so this produces
+    the same TILE/L1 state the op under test consumes.
+    """
+    x = to_tt(torch_tensor, mesh_device, dtype=dtype, layout=ttnn.TILE_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+    return ttnn.to_memory_config(x, ttnn.L1_MEMORY_CONFIG)
+
+
+def _corerangeset(mesh_device, num_cores):
+    """CoreRangeSet of ``num_cores`` (row-major) on this device; skip if it can't fit."""
+    grid = mesh_device.compute_with_storage_grid_size()
+    if num_cores > grid.x * grid.y:
+        pytest.skip(f"model-faithful shard needs {num_cores} cores; device has {grid.x * grid.y}")
+    return ttnn.num_cores_to_corerangeset(num_cores, grid, row_wise=True)
+
+
+def height_sharded_memcfg(mesh_device, num_cores, shape, *, buffer_type=ttnn.BufferType.L1):
+    """HEIGHT_SHARDED memory config over ``num_cores`` — the model's neck/SPPF sharding.
+
+    ``shape`` is the full logical shape; it's HEIGHT-sharded over ``num_cores`` — each
+    core holds ``(prod(shape[:-1]) / num_cores, shape[-1])``. ttnn requires the explicit
+    per-core shard shape (use_height_and_width_as_shard_shape=True) when the grid is a
+    CoreRangeSet, which ``num_cores_to_corerangeset`` produces for non-rectangular core
+    counts (e.g. 20/40). Skips when the device lacks ``num_cores`` or the rows don't
+    divide evenly.
+    """
+    total_rows = 1
+    for d in shape[:-1]:
+        total_rows *= d
+    width = shape[-1]
+    if total_rows % num_cores != 0:
+        pytest.skip(f"height {total_rows} not divisible by {num_cores} cores")
+    shard_shape = (total_rows // num_cores, width)
+    return ttnn.create_sharded_memory_config(
+        shape=shard_shape,
+        core_grid=_corerangeset(mesh_device, num_cores),
+        strategy=ttnn.ShardStrategy.HEIGHT,
+        orientation=ttnn.ShardOrientation.ROW_MAJOR,
+        use_height_and_width_as_shard_shape=True,
+    )
+
+
+def height_sharded_tile_memcfg(mesh_device, shape, *, max_cores=None):
+    """HEIGHT_SHARDED memcfg for a **TILE** tensor — picks the largest core count whose
+    per-core shard height is a multiple of TILE (32), which TILE sharding requires
+    ("Physical shard shape must be tile sized").
+
+    Use this for TILE conv-output tensors (e.g. the bottleneck residual add); use
+    ``height_sharded_memcfg`` for ROW_MAJOR feature maps where the shard height is free.
+    The exact model grid isn't recoverable statically, so we pick a valid tile-aligned
+    grid — faithful in layout/strategy/buffer, approximate only in core count.
+    """
+    total_rows = 1
+    for d in shape[:-1]:
+        total_rows *= d
+    width = shape[-1]
+    grid = mesh_device.compute_with_storage_grid_size()
+    avail = grid.x * grid.y
+    if max_cores is not None:
+        avail = min(avail, max_cores)
+    chosen = next(
+        (nc for nc in range(avail, 0, -1) if total_rows % nc == 0 and (total_rows // nc) % TILE == 0),
+        None,
+    )
+    if chosen is None:
+        pytest.skip(f"no tile-aligned height shard for {total_rows} rows on <= {avail} cores")
+    return ttnn.create_sharded_memory_config(
+        shape=(total_rows // chosen, width),
+        core_grid=ttnn.num_cores_to_corerangeset(chosen, grid, row_wise=True),
+        strategy=ttnn.ShardStrategy.HEIGHT,
+        orientation=ttnn.ShardOrientation.ROW_MAJOR,
+        use_height_and_width_as_shard_shape=True,
+    )
+
+
+def block_sharded_memcfg(mesh_device, grid_y, grid_x, shape):
+    """BLOCK_SHARDED memory config on a (grid_y, grid_x) core grid — the model's
+    ``block_shard=True`` conv outputs. Skips if the grid doesn't fit the device."""
+    grid = mesh_device.compute_with_storage_grid_size()
+    if grid_y > grid.y or grid_x > grid.x:
+        pytest.skip(f"model-faithful block shard needs {grid_y}x{grid_x}; device has {grid.y}x{grid.x}")
+    return ttnn.create_sharded_memory_config(
+        shape=tuple(shape),
+        core_grid=ttnn.CoreGrid(y=grid_y, x=grid_x),
+        strategy=ttnn.ShardStrategy.BLOCK,
+        orientation=ttnn.ShardOrientation.ROW_MAJOR,
+    )
+
+
+def nhwc_to_tt(torch_nchw: torch.Tensor, mesh_device, *, dtype=ttnn.bfloat16, memory_config=ttnn.DRAM_MEMORY_CONFIG):
+    """torch NCHW -> ttnn NHWC row-major (the layout ttnn.conv2d / max_pool2d consume).
+
+    YOLOv8 activations enter conv/pool as [N, H, W, C] row-major on device. We permute
+    NCHW->NHWC on the host and upload row-major.
+    """
+    nhwc = torch_nchw.permute(0, 2, 3, 1).contiguous()
+    return ttnn.from_torch(
+        nhwc,
+        dtype=dtype,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=mesh_device,
+        memory_config=memory_config,
+        mesh_mapper=ttnn.replicate_tensor_to_mesh_mapper(mesh_device),
+    )

--- a/models/experimental/ops/quasar/tests/yolo_ops/op_utils.py
+++ b/models/experimental/ops/quasar/tests/yolo_ops/op_utils.py
@@ -110,7 +110,7 @@ def _corerangeset(mesh_device, num_cores):
     return ttnn.num_cores_to_corerangeset(num_cores, grid, row_wise=True)
 
 
-def height_sharded_memcfg(mesh_device, num_cores, shape, *, buffer_type=ttnn.BufferType.L1):
+def height_sharded_memcfg(mesh_device, num_cores, shape):
     """HEIGHT_SHARDED memory config over ``num_cores`` — the model's neck/SPPF sharding.
 
     ``shape`` is the full logical shape; it's HEIGHT-sharded over ``num_cores`` — each

--- a/models/experimental/ops/quasar/tests/yolo_ops/op_utils.py
+++ b/models/experimental/ops/quasar/tests/yolo_ops/op_utils.py
@@ -183,6 +183,27 @@ def block_sharded_memcfg(mesh_device, grid_y, grid_x, shape):
     )
 
 
+def assert_lossless(torch_ref, tt_out, *, mesh_device=None):
+    """Exact-equality check for **value-preserving** ops (clone, reshape, permute, slice,
+    split, pad, concat, transpose, untilize, layout/sharding moves, reallocate...).
+
+    Those ops must not alter data, so a PCC check is too weak — on the large tensors here
+    it can pass even when values are corrupted. We require the logical data to be bit-exact
+    (bf16 in == bf16 out). Compare in float32; align on the reference's element count when
+    the device output is tile-padded (logical data comes first, row-major).
+    """
+    got = from_tt(tt_out, mesh_device)
+    ref = torch_ref.float()
+    if got.shape != ref.shape and got.numel() >= ref.numel():
+        got = got.reshape(-1)[: ref.numel()].reshape(ref.shape)
+    if not torch.equal(got, ref):
+        diff = (got - ref).abs()
+        raise AssertionError(
+            f"value-preserving op changed data: {(got != ref).sum().item()}/{ref.numel()} "
+            f"elements differ, max|diff|={diff.max().item():.6g}"
+        )
+
+
 def nhwc_to_tt(torch_nchw: torch.Tensor, mesh_device, *, dtype=ttnn.bfloat16, memory_config=ttnn.DRAM_MEMORY_CONFIG):
     """torch NCHW -> ttnn NHWC row-major (the layout ttnn.conv2d / max_pool2d consume).
 

--- a/models/experimental/ops/quasar/tests/yolo_ops/test_add.py
+++ b/models/experimental/ops/quasar/tests/yolo_ops/test_add.py
@@ -1,0 +1,131 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Per-op test: ``ttnn.add``  (YOLOv8 dist2bbox math + bottleneck residual).
+
+Model call sites:
+  * dist2bbox (tt_yolov8l_utils.py:95,97 / tt_yolov8s_utils.py:93,95)
+        x2y2 = anchor_points + rb     # [1,2,A] + [1,2,A]  (ttnn.add via `+`)
+        c_xy = x1y1 + x2y2            # [1,2,A] + [1,2,A]
+    ``lt, rb = ttnn.split(distance, 2, 1)`` -> each [1,2,A]; ``anchor_points`` is
+    make_anchors' ``a`` = [1,2,A] (tt_yolov8l_utils.py:80,84).
+  * bottleneck residual add (ttnn_yolov8l.py:330 / ttnn_yolov8s.py:330)
+        return ttnn.add(x, cv2) if self.shortcut else cv2   # spatial [1,1,hw^2,C]
+
+A = total detect anchors: 8400 @ 640, 33600 @ 1280 (yolov8l only). Detect head is
+identical for yolov8l/yolov8s. Model runs these in bfloat8_b; we use the default
+bfloat16 to exercise the op cleanly. Reference: torch a + b.  PCC 0.999.
+"""
+
+import pytest
+
+import ttnn
+from models.experimental.ops.quasar.tests.yolo_ops import op_utils as U
+
+
+# dist2bbox adds operate on [1, 2, A] operands. shape tuple param -> element-count
+# classification (both are small enough to fit the emulator at 640).
+_ANCHOR_SITES = [
+    pytest.param((1, 2, 8400), id="dist2bbox-640"),  # yolov8l & yolov8s
+    pytest.param((1, 2, 33600), id="dist2bbox-1280"),  # yolov8l only
+]
+
+
+@U.with_default_mesh()
+@pytest.mark.parametrize("shape", _ANCHOR_SITES)
+def test_add_dist2bbox(ttnn_mesh_device, reset_seeds, shape):
+    """anchor+rb / x1y1+x2y2 (tt_yolov8l_utils.py:95,97)."""
+    mesh = ttnn_mesh_device
+
+    a_torch = U.torch_rand(shape)
+    b_torch = U.torch_rand(shape)
+    a = U.to_tt(a_torch, mesh)
+    b = U.to_tt(b_torch, mesh)
+
+    out = ttnn.add(a, b)
+
+    ref = a_torch.float() + b_torch.float()
+    U.assert_pcc(ref, out, pcc=0.999, mesh_device=mesh)
+
+
+# ---------------------------------------------------------------------------
+# Model-faithful (class C): dist2bbox adds on L1-interleaved TILE inputs. dist2bbox
+# runs inside the detect head; anchor_points/rb/x1y1/x2y2 live on
+# _DETECT_MEM_CONFIG = L1_MEMORY_CONFIG for res <= 640 (ttnn_yolov8l.py:772-773).
+# Same shapes as test_add_dist2bbox, DRAM -> L1 input only.
+# ---------------------------------------------------------------------------
+@pytest.mark.blackhole_scale
+@U.with_default_mesh()
+@pytest.mark.parametrize("shape", _ANCHOR_SITES)
+def test_add_dist2bbox_l1(ttnn_mesh_device, reset_seeds, shape):
+    """anchor+rb / x1y1+x2y2 on L1 detect buffers (tt_yolov8l_utils.py:95,97; mem cfg ttnn_yolov8l.py:772-773)."""
+    mesh = ttnn_mesh_device
+
+    a_torch = U.torch_rand(shape)
+    b_torch = U.torch_rand(shape)
+    a = U.to_tile_l1(a_torch, mesh)
+    b = U.to_tile_l1(b_torch, mesh)
+
+    out = ttnn.add(a, b)
+
+    ref = a_torch.float() + b_torch.float()
+    U.assert_pcc(ref, out, pcc=0.999, mesh_device=mesh)
+
+
+# ---------------------------------------------------------------------------
+# Model-faithful (structural): bottleneck residual add on HEIGHT_SHARDED L1 operands.
+# ttnn_yolov8l.py:330  return ttnn.add(x, cv2) if self.shortcut else cv2
+# Both operands are regular-conv outputs produced with memory_config=None
+# (ttnn_yolov8l.py:255) => the conv leaves them HEIGHT_SHARDED in L1; the add runs
+# on that sharded state (no interleaving in between). We rebuild that state directly
+# via U.height_sharded_memcfg at a neck feature-map shape [1,1,hw*hw,C].
+# ---------------------------------------------------------------------------
+# hw is the feature-map side; C=128 representative (per-block width is model-config
+# specific, see test_add_residual note). num_cores mirrors the neck HEIGHT shard
+# (SPPF grid is 64 on WH / 80 on BH, ttnn_yolov8l.py:777-781); 64 fits both and
+# divides hw*hw evenly at these sizes (6400/64=100, 1600/64=25, 400/64 -> use 80).
+@pytest.mark.blackhole_scale
+@U.with_default_mesh()
+@pytest.mark.parametrize("hw", [80, 40], ids=["hw80", "hw40"])
+def test_add_residual_sharded(ttnn_mesh_device, reset_seeds, hw):
+    """bottleneck shortcut add on HEIGHT_SHARDED L1 conv outputs (ttnn_yolov8l.py:330, conv mem cfg :255)."""
+    mesh = ttnn_mesh_device
+    C = 128  # representative bottleneck channel width (see test_add_residual note)
+    shape = (1, 1, hw * hw, C)
+
+    # Conv outputs are TILE, so the HEIGHT shard height must be tile-aligned (a plain
+    # 64-core grid gives shard height 100/25 -> "shard shape must be tile sized").
+    memcfg = U.height_sharded_tile_memcfg(mesh, shape)
+
+    a_torch = U.torch_rand(shape)
+    b_torch = U.torch_rand(shape)
+    a = U.to_tt(a_torch, mesh, memory_config=memcfg)  # TILE (default) — model's conv-output layout
+    b = U.to_tt(b_torch, mesh, memory_config=memcfg)
+
+    out = ttnn.add(a, b)
+
+    ref = a_torch.float() + b_torch.float()
+    U.assert_pcc(ref, out, pcc=0.999, mesh_device=mesh)
+
+
+# Bottleneck residual: ttnn.add(x, cv2), spatial [1,1,hw*hw,C]. hw is the feature-map
+# side -> int `hw` param (hw<=40 fits emulator). C is a bottleneck channel width; the
+# exact per-block value is model-config-specific (NOTE: 128 is a representative
+# stand-in), but the op is same-shape elementwise regardless of C.
+@U.with_default_mesh()
+@pytest.mark.parametrize("hw", [80, 40, 20], ids=["hw80", "hw40", "hw20"])
+def test_add_residual(ttnn_mesh_device, reset_seeds, hw):
+    """bottleneck shortcut add (ttnn_yolov8l.py:330)."""
+    mesh = ttnn_mesh_device
+    shape = (1, 1, hw * hw, 128)  # C=128 representative (see note)
+
+    a_torch = U.torch_rand(shape)
+    b_torch = U.torch_rand(shape)
+    a = U.to_tt(a_torch, mesh)
+    b = U.to_tt(b_torch, mesh)
+
+    out = ttnn.add(a, b)
+
+    ref = a_torch.float() + b_torch.float()
+    U.assert_pcc(ref, out, pcc=0.999, mesh_device=mesh)

--- a/models/experimental/ops/quasar/tests/yolo_ops/test_clone.py
+++ b/models/experimental/ops/quasar/tests/yolo_ops/test_clone.py
@@ -1,0 +1,89 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Per-op test: ``ttnn.clone`` (YOLOv8, 640x640, batch 1).
+
+The neck saves bf16 copies of the C2f outputs (twelve/fifteen/eighteen) for the
+skip connections that feed the detect head:
+
+    twelve = ttnn.clone(c2f_12, dtype=ttnn.bfloat16, memory_config=ttnn.L1_MEMORY_CONFIG)
+
+``ttnn.clone`` is a value-preserving copy (here a bf16->bf16 copy into L1), so the
+cloned tensor must equal the input; PCC 0.999.
+
+Model call sites (branch ``origin/sdawle/yolov8_bh``):
+  * models/demos/yolov8l/tt/ttnn_yolov8l.py:1044 (twelve), :1082 (fifteen), :1096 (eighteen)
+  * models/demos/yolov8s/tt/ttnn_yolov8s.py:776 (twelve), :803 (fifteen), :817 (eighteen)
+
+The tensors are flattened neck feature maps [1, 1, H*W, C]. H==W is the spatial
+size (parametrized by ``hw``: 20/40 fit the emulator, 80 runs on real Blackhole).
+Neck channel widths are the standard YOLOv8l/s neck sizes; clone is
+channel-independent so the exact value is not load-bearing.
+"""
+
+import pytest
+
+import ttnn
+from models.experimental.ops.quasar.tests.yolo_ops import op_utils as U
+
+# (hw, C, id) — neck feature-map resolution/channels for yolov8l (l_*) and yolov8s (s_*).
+_FMAPS = [
+    (20, 512, "l_p5_20x512"),
+    (40, 512, "l_p4_40x512"),
+    (80, 256, "l_p3_80x256"),
+    (20, 256, "s_p5_20x256"),
+    (40, 256, "s_p4_40x256"),
+    (80, 128, "s_p3_80x128"),
+]
+
+
+@U.with_default_mesh()
+@pytest.mark.parametrize("hw, c", [pytest.param(hw, c, id=i) for (hw, c, i) in _FMAPS])
+def test_clone(ttnn_mesh_device, reset_seeds, hw, c):
+    mesh = ttnn_mesh_device
+
+    x_torch = U.torch_rand((1, 1, hw * hw, c))
+    x = U.to_tt(x_torch, mesh)  # TILE, bf16, DRAM interleaved
+
+    out = ttnn.clone(x, dtype=ttnn.bfloat16, memory_config=ttnn.L1_MEMORY_CONFIG)
+
+    U.assert_pcc(x_torch, out, pcc=0.999, mesh_device=mesh)
+
+
+# =============================================================================
+# Model-faithful variant: reproduce the model's REAL layout / buffer state.
+# =============================================================================
+
+
+@pytest.mark.blackhole_scale
+@U.with_default_mesh()
+@pytest.mark.parametrize("hw, c", [pytest.param(hw, c, id=i + "_rm_l1") for (hw, c, i) in _FMAPS])
+def test_clone_rm_l1(ttnn_mesh_device, reset_seeds, hw, c):
+    """Model-faithful ``ttnn.clone`` — ROW_MAJOR input in L1 (the model's real state).
+
+    In the neck, ``c2f_12`` is brought to ROW_MAJOR in L1 (``sharded_to_interleaved``
+    into ``ttnn.L1_MEMORY_CONFIG`` then ``to_row_major_if_needed``) immediately before
+    it is cloned for the skip connection:
+
+        c2f_12 = ttnn.sharded_to_interleaved(c2f_12, ttnn.L1_MEMORY_CONFIG)
+        c2f_12 = to_row_major_if_needed(c2f_12)
+        twelve = ttnn.clone(c2f_12, dtype=ttnn.bfloat16, memory_config=ttnn.L1_MEMORY_CONFIG)
+
+    So the clone's input is ROW_MAJOR_LAYOUT in L1 (not the TILE/DRAM state the
+    existing ``test_clone`` uses). Clone is a value-preserving bf16->bf16 L1 copy;
+    the round-trip must equal the input at PCC 0.999.
+
+    Model call sites (branch ``origin/sdawle/yolov8_bh``):
+      * models/demos/yolov8l/tt/ttnn_yolov8l.py:1044 (twelve)
+        (same pattern at :1082 fifteen, :1096 eighteen; yolov8s.py:776 / :803 / :817)
+    """
+    mesh = ttnn_mesh_device
+
+    x_torch = U.torch_rand((1, 1, hw * hw, c))
+    # ROW_MAJOR, bf16, in L1 — the model's exact clone-input buffer state.
+    x = U.to_tt(x_torch, mesh, layout=ttnn.ROW_MAJOR_LAYOUT, memory_config=ttnn.L1_MEMORY_CONFIG)
+
+    out = ttnn.clone(x, dtype=ttnn.bfloat16, memory_config=ttnn.L1_MEMORY_CONFIG)
+
+    U.assert_pcc(x_torch, out, pcc=0.999, mesh_device=mesh)

--- a/models/experimental/ops/quasar/tests/yolo_ops/test_clone.py
+++ b/models/experimental/ops/quasar/tests/yolo_ops/test_clone.py
@@ -48,7 +48,7 @@ def test_clone(ttnn_mesh_device, reset_seeds, hw, c):
 
     out = ttnn.clone(x, dtype=ttnn.bfloat16, memory_config=ttnn.L1_MEMORY_CONFIG)
 
-    U.assert_pcc(x_torch, out, pcc=0.999, mesh_device=mesh)
+    U.assert_lossless(x_torch, out, mesh_device=mesh)
 
 
 # =============================================================================
@@ -86,4 +86,4 @@ def test_clone_rm_l1(ttnn_mesh_device, reset_seeds, hw, c):
 
     out = ttnn.clone(x, dtype=ttnn.bfloat16, memory_config=ttnn.L1_MEMORY_CONFIG)
 
-    U.assert_pcc(x_torch, out, pcc=0.999, mesh_device=mesh)
+    U.assert_lossless(x_torch, out, mesh_device=mesh)

--- a/models/experimental/ops/quasar/tests/yolo_ops/test_concat.py
+++ b/models/experimental/ops/quasar/tests/yolo_ops/test_concat.py
@@ -1,0 +1,182 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Per-op test: ``ttnn.concat``  (YOLOv8 backbone / neck / detect head).
+
+Model call sites (many). The fully-determinable ones live in the detect head and
+dist2bbox; the neck/backbone channel-concats depend on per-block conv widths that
+are not recoverable from the read-only source without tracing every conv, so one
+representative channel-concat is included and marked uncertain inline.
+
+Detect-head concats (identical for yolov8l & yolov8s):
+  * cv2/cv3 join, dim=3   ttnn_yolov8l.py:734 / ttnn_yolov8s.py:555
+        x[i] = ttnn.concat((a, b), dim=3)   # a=[.,.,hw^2,64], b=[.,.,hw^2,80] -> 144
+        (64 = reg_max*4, 80 = nc; no = 144 at ttnn_yolov8l.py:729)
+  * per-scale flatten join, dim=1   ttnn_yolov8l.py:744 / ttnn_yolov8s.py:565
+        x_cat = ttnn.concat(xi, 1)          # [1,6400,144]+[1,1600,144]+[1,400,144]
+  * final output join, dim=1   ttnn_yolov8l.py:757 / ttnn_yolov8s.py:578
+        ttnn.concat((dbox, sigmoid(cls)), dim=1)   # [1,4,A] + [1,80,A] -> [1,84,A]
+
+dist2bbox concat, dim=1   tt_yolov8l_utils.py:100 / tt_yolov8s_utils.py:98
+        ttnn.concat([c_xy, wh], 1)          # [1,2,A] + [1,2,A] -> [1,4,A]
+
+Neck channel-concats, dim=-1   ttnn_yolov8l.py:494/499 (C2f) and sharded_concat*
+(ttnn_yolov8l.py:1034/1074/1087/1102, SPPF :542): channel widths model-specific.
+
+A = total detect anchors: 8400 @ 640 (80/40/20), 33600 @ 1280 (160/80/40).
+Reference: torch.cat.  PCC 0.999 (value-preserving).
+"""
+
+import pytest
+import torch
+
+import ttnn
+from models.experimental.ops.quasar.tests.yolo_ops import op_utils as U
+
+_NC = 80
+_NO = 144  # nc + reg_max*4 = 80 + 64
+
+
+# ---------------------------------------------------------------------------
+# Spatial detect cv2/cv3 concat (dim=3): [1,1,hw*hw,64] + [1,1,hw*hw,80] -> 144.
+# hw is the feature-map side -> int `hw` param so conftest classifies (hw<=40 fits).
+# yolov8l/yolov8s @ 640 -> hw in {80,40,20}; yolov8l @ 1280 -> hw in {160,80,40}.
+# ---------------------------------------------------------------------------
+@U.with_default_mesh()
+@pytest.mark.parametrize("hw", [80, 40, 20, 160], ids=["hw80", "hw40", "hw20", "hw160-l1280"])
+def test_concat_detect_cv2cv3(ttnn_mesh_device, reset_seeds, hw):
+    """cv2/cv3 join per scale, dim=3 (ttnn_yolov8l.py:734)."""
+    mesh = ttnn_mesh_device
+    hh = hw * hw
+
+    a_torch = U.torch_rand((1, 1, hh, 64))  # cv2 (box) -> reg_max*4
+    b_torch = U.torch_rand((1, 1, hh, _NC))  # cv3 (cls) -> nc
+    a = U.to_tt(a_torch, mesh)
+    b = U.to_tt(b_torch, mesh)
+
+    out = ttnn.concat([a, b], dim=3)
+
+    ref = torch.cat([a_torch.float(), b_torch.float()], dim=3)
+    U.assert_pcc(ref, out, pcc=0.999, mesh_device=mesh)
+
+
+# ---------------------------------------------------------------------------
+# Channel-wise / anchor-wise concats (non-spatial). `out_shape` tuple param so the
+# conftest classifies by element count.  (id, dim, in_shapes, out_shape)
+# ---------------------------------------------------------------------------
+_CHANNEL_SITES = [
+    # per-scale flatten join, dim=1 (ttnn_yolov8l.py:744) @ 640
+    ("detect_xi-640", 1, ((1, 6400, _NO), (1, 1600, _NO), (1, 400, _NO)), (1, 8400, _NO)),
+    # per-scale flatten join @ 1280 (yolov8l only)
+    ("detect_xi-1280", 1, ((1, 25600, _NO), (1, 6400, _NO), (1, 1600, _NO)), (1, 33600, _NO)),
+    # dist2bbox c_xy/wh join, dim=1 (tt_yolov8l_utils.py:100) @ 640
+    ("dist2bbox-640", 1, ((1, 2, 8400), (1, 2, 8400)), (1, 4, 8400)),
+    ("dist2bbox-1280", 1, ((1, 2, 33600), (1, 2, 33600)), (1, 4, 33600)),
+    # final detect output join dbox+sigmoid(cls), dim=1 (ttnn_yolov8l.py:757) @ 640
+    ("detect_out-640", 1, ((1, 4, 8400), (1, _NC, 8400)), (1, 84, 8400)),
+    ("detect_out-1280", 1, ((1, 4, 33600), (1, _NC, 33600)), (1, 84, 33600)),
+    # Representative neck channel-concat, dim=-1 (ttnn_yolov8l.py:499 C2f / :1034
+    # sharded_concat).  NOTE: exact channel widths are model-config-specific and not
+    # derivable from the read-only source; 320/640 mirror the detect-head input
+    # widths (ch=(320,640,640), ttnn_yolov8l.py:663) as a stand-in shape only.
+    ("neck_channel-640", -1, ((1, 1, 6400, 320), (1, 1, 6400, 320)), (1, 1, 6400, 640)),
+]
+
+
+@U.with_default_mesh()
+@pytest.mark.parametrize(
+    "name, dim, in_shapes, out_shape",
+    [pytest.param(*s, id=s[0]) for s in _CHANNEL_SITES],
+)
+def test_concat_channel(ttnn_mesh_device, reset_seeds, name, dim, in_shapes, out_shape):
+    mesh = ttnn_mesh_device
+
+    parts_torch = [U.torch_rand(s) for s in in_shapes]
+    parts_tt = [U.to_tt(p, mesh) for p in parts_torch]
+
+    out = ttnn.concat(parts_tt, dim=dim)
+
+    ref = torch.cat([p.float() for p in parts_torch], dim=dim)
+    assert tuple(ref.shape) == tuple(out_shape), f"{name}: torch.cat -> {tuple(ref.shape)} != {out_shape}"
+    U.assert_pcc(ref, out, pcc=0.999, mesh_device=mesh)
+
+
+# ---------------------------------------------------------------------------
+# Model-faithful (class C): detect-head concats on L1-interleaved TILE inputs.
+# All detect-head concats run on _DETECT_MEM_CONFIG = L1_MEMORY_CONFIG for res <= 640
+# (ttnn_yolov8l.py:772-773): detect_xi join (:744), dist2bbox c_xy/wh (tt_yolov8l_utils.py:100),
+# final detect_out (:757). The cv2/cv3 join (:734) consumes detect-cv2 outputs that
+# are sharded_to_interleaved into L1 (ttnn_yolov8l.py:261-265), so it is L1-fed even
+# at 1280. Same shapes as the DRAM detect cases, input memory_config DRAM -> L1.
+# (id, dim, in_shapes, out_shape)
+# ---------------------------------------------------------------------------
+_DETECT_L1_SITES = [
+    # cv2/cv3 spatial join, dim=3 (ttnn_yolov8l.py:734); L1-fed via :261-265 even @ 1280
+    ("cv2cv3-640", 3, ((1, 1, 6400, 64), (1, 1, 6400, _NC)), (1, 1, 6400, _NO)),  # hw=80
+    ("cv2cv3-1280", 3, ((1, 1, 25600, 64), (1, 1, 25600, _NC)), (1, 1, 25600, _NO)),  # hw=160
+    # per-scale flatten join, dim=1 (ttnn_yolov8l.py:744) @ 640
+    ("detect_xi-640", 1, ((1, 6400, _NO), (1, 1600, _NO), (1, 400, _NO)), (1, 8400, _NO)),
+    # dist2bbox c_xy/wh join, dim=1 (tt_yolov8l_utils.py:100) @ 640
+    ("dist2bbox-640", 1, ((1, 2, 8400), (1, 2, 8400)), (1, 4, 8400)),
+    # final detect output join dbox+sigmoid(cls), dim=1 (ttnn_yolov8l.py:757) @ 640
+    ("detect_out-640", 1, ((1, 4, 8400), (1, _NC, 8400)), (1, 84, 8400)),
+]
+
+
+@pytest.mark.blackhole_scale
+@U.with_default_mesh()
+@pytest.mark.parametrize(
+    "name, dim, in_shapes, out_shape",
+    [pytest.param(*s, id=s[0]) for s in _DETECT_L1_SITES],
+)
+def test_concat_detect_l1(ttnn_mesh_device, reset_seeds, name, dim, in_shapes, out_shape):
+    """detect-head concats on L1 buffers (ttnn_yolov8l.py:734/744/757, tt_yolov8l_utils.py:100; mem cfg :772-773)."""
+    mesh = ttnn_mesh_device
+
+    parts_torch = [U.torch_rand(s) for s in in_shapes]
+    parts_tt = [U.to_tile_l1(p, mesh) for p in parts_torch]
+
+    out = ttnn.concat(parts_tt, dim=dim)
+
+    ref = torch.cat([p.float() for p in parts_torch], dim=dim)
+    assert tuple(ref.shape) == tuple(out_shape), f"{name}: torch.cat -> {tuple(ref.shape)} != {out_shape}"
+    U.assert_pcc(ref, out, pcc=0.999, mesh_device=mesh)
+
+
+# ---------------------------------------------------------------------------
+# Model-faithful (structural): neck channel-concat on HEIGHT_SHARDED L1 operands.
+# sharded_concat (ttnn_yolov8l.py:80-93, def at :47-64 for the SPPF variant), called
+# at ttnn_yolov8l.py:1034/1074/1087/1102, shards each operand HEIGHT-wise over the
+# _SPPF_CORE_GRID (64 cores WH / 80 cores BH, ttnn_yolov8l.py:777-781) in L1 with
+# shard shape (shard_height, C), then concats along the channel dim (dim=3). We
+# rebuild that sharded input state via U.height_sharded_memcfg and concat dim=-1.
+# ---------------------------------------------------------------------------
+# Neck feature-map [1,1,hw*hw,C]; exact channel widths are model-config specific
+# (see the neck_channel note above) so 320/320 mirrors the detect-input widths as a
+# stand-in shape only. num_cores=64 = SPPF grid best-estimate (64 WH / 80 BH), fits
+# both and divides 6400 evenly (6400/64=100).
+@pytest.mark.blackhole_scale
+@U.with_default_mesh()
+def test_concat_neck_sharded(ttnn_mesh_device, reset_seeds):
+    """neck channel-concat on HEIGHT_SHARDED L1 operands (sharded_concat, ttnn_yolov8l.py:1034; def :47-64)."""
+    mesh = ttnn_mesh_device
+    hw = 80
+    C = 320  # per-operand channel width stand-in (model-config specific, see note)
+    shape = (1, 1, hw * hw, C)
+    num_cores = 64  # _SPPF_CORE_GRID best-estimate (64 WH / 80 BH); 6400 % 64 == 0
+
+    memcfg = U.height_sharded_memcfg(mesh, num_cores, shape)
+
+    a_torch = U.torch_rand(shape)
+    b_torch = U.torch_rand(shape)
+    # ROW_MAJOR: the neck's sharded feature maps are row-major, so the shard height need
+    # not be tile-aligned (a TILE shard here would trip "shard shape must be tile sized").
+    a = U.to_tt(a_torch, mesh, layout=ttnn.ROW_MAJOR_LAYOUT, memory_config=memcfg)
+    b = U.to_tt(b_torch, mesh, layout=ttnn.ROW_MAJOR_LAYOUT, memory_config=memcfg)
+
+    out = ttnn.concat([a, b], dim=-1)
+
+    ref = torch.cat([a_torch.float(), b_torch.float()], dim=-1)
+    assert tuple(ref.shape) == (1, 1, hw * hw, 2 * C), f"neck concat -> {tuple(ref.shape)}"
+    U.assert_pcc(ref, out, pcc=0.999, mesh_device=mesh)

--- a/models/experimental/ops/quasar/tests/yolo_ops/test_concat.py
+++ b/models/experimental/ops/quasar/tests/yolo_ops/test_concat.py
@@ -25,7 +25,7 @@ Neck channel-concats, dim=-1   ttnn_yolov8l.py:494/499 (C2f) and sharded_concat*
 (ttnn_yolov8l.py:1034/1074/1087/1102, SPPF :542): channel widths model-specific.
 
 A = total detect anchors: 8400 @ 640 (80/40/20), 33600 @ 1280 (160/80/40).
-Reference: torch.cat.  PCC 0.999 (value-preserving).
+Reference: torch.cat; concat is value-preserving so we require exact equality (assert_lossless).
 """
 
 import pytest
@@ -58,7 +58,7 @@ def test_concat_detect_cv2cv3(ttnn_mesh_device, reset_seeds, hw):
     out = ttnn.concat([a, b], dim=3)
 
     ref = torch.cat([a_torch.float(), b_torch.float()], dim=3)
-    U.assert_pcc(ref, out, pcc=0.999, mesh_device=mesh)
+    U.assert_lossless(ref, out, mesh_device=mesh)
 
 
 # ---------------------------------------------------------------------------
@@ -96,7 +96,7 @@ def test_concat_channel(ttnn_mesh_device, reset_seeds, name, dim, in_shapes, out
 
     ref = torch.cat([p.float() for p in parts_torch], dim=dim)
     assert tuple(ref.shape) == tuple(out_shape), f"{name}: torch.cat -> {tuple(ref.shape)} != {out_shape}"
-    U.assert_pcc(ref, out, pcc=0.999, mesh_device=mesh)
+    U.assert_lossless(ref, out, mesh_device=mesh)
 
 
 # ---------------------------------------------------------------------------
@@ -138,7 +138,7 @@ def test_concat_detect_l1(ttnn_mesh_device, reset_seeds, name, dim, in_shapes, o
 
     ref = torch.cat([p.float() for p in parts_torch], dim=dim)
     assert tuple(ref.shape) == tuple(out_shape), f"{name}: torch.cat -> {tuple(ref.shape)} != {out_shape}"
-    U.assert_pcc(ref, out, pcc=0.999, mesh_device=mesh)
+    U.assert_lossless(ref, out, mesh_device=mesh)
 
 
 # ---------------------------------------------------------------------------
@@ -158,22 +158,33 @@ def test_concat_detect_l1(ttnn_mesh_device, reset_seeds, name, dim, in_shapes, o
 def test_concat_neck_sharded(ttnn_mesh_device, reset_seeds):
     """neck channel-concat on HEIGHT_SHARDED L1 operands (sharded_concat, ttnn_yolov8l.py:1034; def :47-64)."""
     mesh = ttnn_mesh_device
-    hw = 80
-    C = 320  # per-operand channel width stand-in (model-config specific, see note)
-    shape = (1, 1, hw * hw, C)
+    hw = 80  # neck concat feeding model.15 runs at the 80x80 (P3) level
+    # The real neck concat is UNEQUAL width: upsample(512) + backbone skip(256) -> 768
+    # (model.15.cv1 in_ch = 768; branch configs.json c2f model.15 cv1 = [1,1,0,256,768]).
+    Ca, Cb = 512, 256
+    rows = hw * hw
     num_cores = 64  # _SPPF_CORE_GRID best-estimate (64 WH / 80 BH); 6400 % 64 == 0
 
-    memcfg = U.height_sharded_memcfg(mesh, num_cores, shape)
-
-    a_torch = U.torch_rand(shape)
-    b_torch = U.torch_rand(shape)
-    # ROW_MAJOR: the neck's sharded feature maps are row-major, so the shard height need
-    # not be tile-aligned (a TILE shard here would trip "shard shape must be tile sized").
-    a = U.to_tt(a_torch, mesh, layout=ttnn.ROW_MAJOR_LAYOUT, memory_config=memcfg)
-    b = U.to_tt(b_torch, mesh, layout=ttnn.ROW_MAJOR_LAYOUT, memory_config=memcfg)
+    a_torch = U.torch_rand((1, 1, rows, Ca))
+    b_torch = U.torch_rand((1, 1, rows, Cb))
+    # ROW_MAJOR HEIGHT-sharded (neck feature maps are row-major, so the shard height need
+    # not be tile-aligned); each operand keeps its own channel width and the concat is on
+    # the non-sharded channel dim -> 512 + 256 = 768.
+    a = U.to_tt(
+        a_torch,
+        mesh,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        memory_config=U.height_sharded_memcfg(mesh, num_cores, (1, 1, rows, Ca)),
+    )
+    b = U.to_tt(
+        b_torch,
+        mesh,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        memory_config=U.height_sharded_memcfg(mesh, num_cores, (1, 1, rows, Cb)),
+    )
 
     out = ttnn.concat([a, b], dim=-1)
 
     ref = torch.cat([a_torch.float(), b_torch.float()], dim=-1)
-    assert tuple(ref.shape) == (1, 1, hw * hw, 2 * C), f"neck concat -> {tuple(ref.shape)}"
-    U.assert_pcc(ref, out, pcc=0.999, mesh_device=mesh)
+    assert tuple(ref.shape) == (1, 1, rows, Ca + Cb), f"neck concat -> {tuple(ref.shape)}"
+    U.assert_lossless(ref, out, mesh_device=mesh)

--- a/models/experimental/ops/quasar/tests/yolo_ops/test_concat.py
+++ b/models/experimental/ops/quasar/tests/yolo_ops/test_concat.py
@@ -76,11 +76,8 @@ _CHANNEL_SITES = [
     # final detect output join dbox+sigmoid(cls), dim=1 (ttnn_yolov8l.py:757) @ 640
     ("detect_out-640", 1, ((1, 4, 8400), (1, _NC, 8400)), (1, 84, 8400)),
     ("detect_out-1280", 1, ((1, 4, 33600), (1, _NC, 33600)), (1, 84, 33600)),
-    # Representative neck channel-concat, dim=-1 (ttnn_yolov8l.py:499 C2f / :1034
-    # sharded_concat).  NOTE: exact channel widths are model-config-specific and not
-    # derivable from the read-only source; 320/640 mirror the detect-head input
-    # widths (ch=(320,640,640), ttnn_yolov8l.py:663) as a stand-in shape only.
-    ("neck_channel-640", -1, ((1, 1, 6400, 320), (1, 1, 6400, 320)), (1, 1, 6400, 640)),
+    # YOLOv8l model.15 input: upsampled 512-channel tensor + 256-channel skip -> 768.
+    ("neck_channel-640", -1, ((1, 1, 6400, 512), (1, 1, 6400, 256)), (1, 1, 6400, 768)),
 ]
 
 

--- a/models/experimental/ops/quasar/tests/yolo_ops/test_conv2d.py
+++ b/models/experimental/ops/quasar/tests/yolo_ops/test_conv2d.py
@@ -1,0 +1,259 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Per-op test: ``ttnn.conv2d`` — every distinct conv shape YOLOv8 runs (yolov8l + yolov8s,
+640x640, batch 1).
+
+Imports NO YOLOv8 model code. The shapes below were extracted read-only from the
+``sdawle/yolov8_bh`` branch and are reproduced here as raw conv parameters so the op can
+be exercised in isolation on Quasar / Blackhole.
+
+Shape source (branch ``origin/sdawle/yolov8_bh``)
+-------------------------------------------------
+* Conv wrapper — ``models/demos/yolov8l/tt/ttnn_yolov8l.py:231-262`` (``TtConv.__call__``):
+  ``ttnn.conv2d(in_channels=x.shape[-1], out_channels=input_params[3],
+  kernel_size=(input_params[0],)*2, stride=(input_params[1],)*2,
+  padding=(input_params[2],)*2, batch_size=1, input_height/width from the tensor)``.
+  So each config entry is ``input_params = [kernel, stride, pad, out_ch, in_ch]``.
+* Numeric params — ``models/demos/yolov8{l,s}/tt/configs.json`` groups
+  ``conv_config`` / ``c2f_configs`` / ``sppf_configs`` / ``detect_config``.
+* Which conv runs where + model.5's inline params — ``ttnn_yolov8l.py:820-970`` (l) and
+  ``ttnn_yolov8s.py:591-706`` (s) ``__init__``; forward wiring ``ttnn_yolov8l.py:973-1118``.
+
+Resolution tracing (input H==W per conv)
+----------------------------------------
+The config does NOT store each conv's feature-map size, so it was traced through the
+forward pass. At 640x640 the stride-2 convs halve the side: 640→320→160→80→40→20.
+Backbone (each ``model.N``): model.0 @640 → model.1 @320 → c2f model.2 @160 →
+model.3 @160 → c2f model.4 @80 → model.5 @80 → c2f model.6 @40 → model.7 @40 →
+c2f model.8 @20 → sppf model.9 @20. Neck: upsample(20→40) → c2f model.12 @40 →
+upsample(40→80) → c2f model.15 @80 → model.16 @80 (down to 40) → c2f model.18 @40 →
+model.19 @40 (down to 20) → c2f model.21 @20. Detect head (``model.22``) runs its three
+branches on P3/P4/P5 = {80, 40, 20} (ttnn_yolov8l.py:1109 ``ch=(320,640,640)``,
+3 detection levels; standard YOLOv8 strides 8/16/32 at 640).
+
+* A C2f (``TtC2f``, ttnn_yolov8l.py:333-505) is spatially stride-1 throughout, so all its
+  sub-convs run at the block's resolution. Its real conv call sites are
+  ``cv1_a=input_params[3]``, ``cv1_b=input_params[4]`` (identical params → collapse),
+  ``cv2=input_params[1]`` and the bottleneck ``m.cv=input_params[2]`` (bottleneck cv1==cv2
+  share params; ``input_params[0]`` is dead config, never passed to ttnn.conv2d — excluded).
+* SPPF (``TtSppf``, :507) sub-convs cv1=input_params[0], cv2=input_params[1], both @20.
+* Detect (``TtDetect``/``TtDetectCv2``, :550-757): cv2 (box) and cv3 (cls) branches each run
+  3 convs (input_params[0..2]) at the branch resolution; the DFL conv (``TtDFL``, :618) is a
+  1x1 over the decoded box distribution — see note on that param below.
+
+First conv channel padding (ttnn_yolov8l.py:973-989): the 3-channel image is padded to
+16 channels (``min_channels=16``) before ``permute``+conv, so ``model.0`` runs with
+in_channels=16 (config's ``in_ch`` field — 3 for l, 8 for s — is the pre-pad value and is
+ignored at runtime). ``raw_in_ch`` below carries that pre-pad count so the test zero-pads
+exactly as the model does.
+
+Deduplication: 60 conv call sites per variant (120 total) collapse to 69 distinct
+``(in_ch, out_ch, kernel, stride, pad, input_h, input_w)`` tuples — 41 first-seen in
+yolov8l, 28 more unique to yolov8s. Each param id is ``<variant>-<name>-<res>``.
+
+Reference / tolerance
+---------------------
+Reference is ``torch.nn.functional.conv2d`` on the same random weights/bias/input (the
+canonical conv test ``tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py``
+``run_conv`` does exactly this). bf16 activations+weights with LoFi fidelity: PCC ~0.98,
+relaxed to ~0.97 for very large reduction depth (in_ch*k*k > 10000), matching run_conv's
+own thresholds.
+"""
+
+import pytest
+import torch
+
+import ttnn
+from models.experimental.ops.quasar.tests.yolo_ops import op_utils as U
+
+# fmt: off
+# (hw, in_ch, out_ch, kernel, stride, padding, input_h, input_w, raw_in_ch)
+#   hw       = feature-map side used by tests/yolo_ops/conftest.py for emulator gating.
+#   raw_in_ch= pre-pad in_ch for the first conv (3 for l, 8 for s), else 0 (no pad).
+# See module docstring for the full shape-source + resolution-trace citation.
+CONV_CASES = [
+    pytest.param(640, 16, 64, 3, 2, 1, 640, 640, 3, id="l-model.0-640"),
+    pytest.param(320, 64, 128, 3, 2, 1, 320, 320, 0, id="l-model.1-320"),
+    pytest.param(160, 128, 256, 3, 2, 1, 160, 160, 0, id="l-model.3-160"),
+    pytest.param(80, 256, 512, 3, 2, 1, 80, 80, 0, id="l-model.5-80"),
+    pytest.param(40, 512, 512, 3, 2, 1, 40, 40, 0, id="l-model.7-40"),
+    pytest.param(80, 256, 256, 3, 2, 1, 80, 80, 0, id="l-model.16-80"),
+    pytest.param(160, 128, 64, 1, 1, 0, 160, 160, 0, id="l-model.2.cv1_a-160"),
+    pytest.param(160, 320, 128, 1, 1, 0, 160, 160, 0, id="l-model.2.cv2-160"),
+    pytest.param(160, 64, 64, 3, 1, 1, 160, 160, 0, id="l-model.2.m-160"),
+    pytest.param(80, 256, 128, 1, 1, 0, 80, 80, 0, id="l-model.4.cv1_a-80"),
+    pytest.param(80, 1024, 256, 1, 1, 0, 80, 80, 0, id="l-model.4.cv2-80"),
+    pytest.param(80, 128, 128, 3, 1, 1, 80, 80, 0, id="l-model.4.m-80"),
+    pytest.param(40, 512, 256, 1, 1, 0, 40, 40, 0, id="l-model.6.cv1_a-40"),
+    pytest.param(40, 2048, 512, 1, 1, 0, 40, 40, 0, id="l-model.6.cv2-40"),
+    pytest.param(40, 256, 256, 3, 1, 1, 40, 40, 0, id="l-model.6.m-40"),
+    pytest.param(20, 512, 256, 1, 1, 0, 20, 20, 0, id="l-model.8.cv1_a-20"),
+    pytest.param(20, 1280, 512, 1, 1, 0, 20, 20, 0, id="l-model.8.cv2-20"),
+    pytest.param(20, 256, 256, 3, 1, 1, 20, 20, 0, id="l-model.8.m-20"),
+    pytest.param(40, 1024, 256, 1, 1, 0, 40, 40, 0, id="l-model.12.cv1_a-40"),
+    pytest.param(40, 1280, 512, 1, 1, 0, 40, 40, 0, id="l-model.12.cv2-40"),
+    pytest.param(80, 768, 128, 1, 1, 0, 80, 80, 0, id="l-model.15.cv1_a-80"),
+    pytest.param(80, 640, 256, 1, 1, 0, 80, 80, 0, id="l-model.15.cv2-80"),
+    pytest.param(40, 768, 256, 1, 1, 0, 40, 40, 0, id="l-model.18.cv1_a-40"),
+    pytest.param(20, 1024, 256, 1, 1, 0, 20, 20, 0, id="l-model.21.cv1_a-20"),
+    pytest.param(20, 1024, 512, 1, 1, 0, 20, 20, 0, id="l-model.9.cv2-20"),
+    pytest.param(80, 256, 64, 3, 1, 1, 80, 80, 0, id="l-model.22.cv2.0.0-80"),
+    pytest.param(80, 64, 64, 3, 1, 1, 80, 80, 0, id="l-model.22.cv2.0.1-80"),
+    pytest.param(80, 64, 64, 1, 1, 0, 80, 80, 0, id="l-model.22.cv2.0.2-80"),
+    pytest.param(80, 256, 256, 3, 1, 1, 80, 80, 0, id="l-model.22.cv3.0.0-80"),
+    pytest.param(80, 256, 80, 1, 1, 0, 80, 80, 0, id="l-model.22.cv3.0.2-80"),
+    pytest.param(40, 512, 64, 3, 1, 1, 40, 40, 0, id="l-model.22.cv2.1.0-40"),
+    pytest.param(40, 64, 64, 3, 1, 1, 40, 40, 0, id="l-model.22.cv2.1.1-40"),
+    pytest.param(40, 64, 64, 1, 1, 0, 40, 40, 0, id="l-model.22.cv2.1.2-40"),
+    pytest.param(40, 512, 256, 3, 1, 1, 40, 40, 0, id="l-model.22.cv3.1.0-40"),
+    pytest.param(40, 256, 80, 1, 1, 0, 40, 40, 0, id="l-model.22.cv3.1.2-40"),
+    pytest.param(20, 512, 64, 3, 1, 1, 20, 20, 0, id="l-model.22.cv2.2.0-20"),
+    pytest.param(20, 64, 64, 3, 1, 1, 20, 20, 0, id="l-model.22.cv2.2.1-20"),
+    pytest.param(20, 64, 64, 1, 1, 0, 20, 20, 0, id="l-model.22.cv2.2.2-20"),
+    pytest.param(20, 512, 256, 3, 1, 1, 20, 20, 0, id="l-model.22.cv3.2.0-20"),
+    pytest.param(20, 256, 80, 1, 1, 0, 20, 20, 0, id="l-model.22.cv3.2.2-20"),
+    # DFL: 1x1 conv over the box distribution. TtDFL (ttnn_yolov8l.py:642-654) reshapes to
+    # (b,4,16,a), softmaxes, permutes to (b,4,a,16) => NHWC N=1,H=4,W=a,C=16, then conv2d
+    # in=16 out=1 k1s1p0. a = #anchors = 80*80+40*40+20*20 = 8400 @640. Non-square (H=4).
+    pytest.param(8400, 16, 1, 1, 1, 0, 4, 8400, 0, id="l-model.22.dfl-8400"),
+    pytest.param(640, 16, 32, 3, 2, 1, 640, 640, 8, id="s-model.0-640"),
+    pytest.param(320, 32, 64, 3, 2, 1, 320, 320, 0, id="s-model.1-320"),
+    pytest.param(160, 64, 128, 3, 2, 1, 160, 160, 0, id="s-model.3-160"),
+    pytest.param(80, 128, 256, 3, 2, 1, 80, 80, 0, id="s-model.5-80"),
+    pytest.param(40, 256, 512, 3, 2, 1, 40, 40, 0, id="s-model.7-40"),
+    pytest.param(80, 128, 128, 3, 2, 1, 80, 80, 0, id="s-model.16-80"),
+    pytest.param(40, 256, 256, 3, 2, 1, 40, 40, 0, id="s-model.19-40"),
+    pytest.param(160, 64, 32, 1, 1, 0, 160, 160, 0, id="s-model.2.cv1_a-160"),
+    pytest.param(160, 96, 64, 1, 1, 0, 160, 160, 0, id="s-model.2.cv2-160"),
+    pytest.param(160, 32, 32, 3, 1, 1, 160, 160, 0, id="s-model.2.m-160"),
+    pytest.param(80, 128, 64, 1, 1, 0, 80, 80, 0, id="s-model.4.cv1_a-80"),
+    pytest.param(40, 256, 128, 1, 1, 0, 40, 40, 0, id="s-model.6.cv1_a-40"),
+    pytest.param(40, 128, 128, 3, 1, 1, 40, 40, 0, id="s-model.6.m-40"),
+    pytest.param(20, 768, 512, 1, 1, 0, 20, 20, 0, id="s-model.8.cv2-20"),
+    pytest.param(40, 768, 128, 1, 1, 0, 40, 40, 0, id="s-model.12.cv1_a-40"),
+    pytest.param(40, 384, 256, 1, 1, 0, 40, 40, 0, id="s-model.12.cv2-40"),
+    pytest.param(80, 384, 64, 1, 1, 0, 80, 80, 0, id="s-model.15.cv1_a-80"),
+    pytest.param(80, 192, 128, 1, 1, 0, 80, 80, 0, id="s-model.15.cv2-80"),
+    pytest.param(40, 384, 128, 1, 1, 0, 40, 40, 0, id="s-model.18.cv1_a-40"),
+    pytest.param(20, 768, 256, 1, 1, 0, 20, 20, 0, id="s-model.21.cv1_a-20"),
+    pytest.param(80, 128, 64, 3, 1, 1, 80, 80, 0, id="s-model.22.cv2.0.0-80"),
+    pytest.param(80, 128, 80, 1, 1, 0, 80, 80, 0, id="s-model.22.cv3.0.2-80"),
+    pytest.param(40, 256, 64, 3, 1, 1, 40, 40, 0, id="s-model.22.cv2.1.0-40"),
+    pytest.param(40, 256, 128, 3, 1, 1, 40, 40, 0, id="s-model.22.cv3.1.0-40"),
+    pytest.param(40, 128, 80, 1, 1, 0, 40, 40, 0, id="s-model.22.cv3.1.2-40"),
+    pytest.param(20, 512, 128, 3, 1, 1, 20, 20, 0, id="s-model.22.cv3.2.0-20"),
+    pytest.param(20, 128, 128, 3, 1, 1, 20, 20, 0, id="s-model.22.cv3.2.1-20"),
+    pytest.param(20, 128, 80, 1, 1, 0, 20, 20, 0, id="s-model.22.cv3.2.2-20"),
+]
+# fmt: on
+
+
+@U.with_mesh_l1small()  # conv2d allocates from the L1-small region (default l1_small_size=0 OOMs)
+@pytest.mark.parametrize(
+    "hw, in_ch, out_ch, kernel, stride, padding, input_h, input_w, raw_in_ch",
+    CONV_CASES,
+)
+def test_conv2d(
+    ttnn_mesh_device,
+    reset_seeds,
+    hw,
+    in_ch,
+    out_ch,
+    kernel,
+    stride,
+    padding,
+    input_h,
+    input_w,
+    raw_in_ch,
+):
+    mesh = ttnn_mesh_device
+
+    # --- build torch input / weights / bias exactly like run_conv (canonical conv test) ---
+    # First conv: create the raw (pre-pad) channels then zero-pad to `in_ch`, mirroring the
+    # model's ttnn.pad on the channel dim (ttnn_yolov8l.py:979-986, value=0.0).
+    src_ch = raw_in_ch if raw_in_ch else in_ch
+    torch_input_nchw = torch.randn(U.BATCH, src_ch, input_h, input_w, dtype=torch.float32)
+    if raw_in_ch:
+        torch_input_nchw = torch.nn.functional.pad(
+            torch_input_nchw, (0, 0, 0, 0, 0, in_ch - raw_in_ch), mode="constant", value=0.0
+        )
+
+    torch_weight = torch.randn(out_ch, in_ch, kernel, kernel, dtype=torch.float32)
+    torch_bias = torch.randn(1, 1, 1, out_ch, dtype=torch.float32)
+
+    # torch reference (NCHW), symmetric padding on H/W as the model uses (padding,)*2.
+    ref_nchw = torch.nn.functional.conv2d(
+        torch_input_nchw,
+        torch_weight,
+        bias=torch_bias.reshape(-1),
+        stride=(stride, stride),
+        padding=(padding, padding),
+        dilation=(1, 1),
+        groups=1,
+    )
+    out_height = ref_nchw.shape[2]
+    out_width = ref_nchw.shape[3]
+    ref_nhwc = ref_nchw.permute(0, 2, 3, 1).contiguous()  # NHWC, the layout conv2d returns
+
+    # --- ttnn inputs: activation NHWC row-major; weights/bias on host (conv2d prepares them) ---
+    torch_input_nhwc = torch_input_nchw.permute(0, 2, 3, 1).contiguous()
+    tt_input = ttnn.from_torch(torch_input_nhwc, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT)
+    tt_weight = ttnn.from_torch(torch_weight, dtype=ttnn.bfloat16)
+    tt_bias = ttnn.from_torch(torch_bias, dtype=ttnn.bfloat16)
+
+    conv_config = ttnn.Conv2dConfig(
+        weights_dtype=ttnn.bfloat16,
+        # let conv2d auto-pick the shard layout (model varies HEIGHT/BLOCK per conv; this
+        # op-level test only checks numerics, not the model's exact sharding choice).
+        shard_layout=None,
+    )
+    # Mirror the model's compute config (ttnn_yolov8l.py:203-210): LoFi, no fp32 dest acc.
+    compute_config = ttnn.init_device_compute_kernel_config(
+        mesh.arch(),
+        math_fidelity=ttnn.MathFidelity.LoFi,
+        math_approx_mode=False,
+        fp32_dest_acc_en=False,
+        packer_l1_acc=False,
+    )
+
+    [tt_out, [tt_out_h, tt_out_w], [_, _]] = ttnn.conv2d(
+        input_tensor=tt_input,
+        weight_tensor=tt_weight,
+        in_channels=in_ch,
+        out_channels=out_ch,
+        device=mesh,
+        bias_tensor=tt_bias,
+        kernel_size=(kernel, kernel),
+        stride=(stride, stride),
+        padding=(padding, padding),
+        dilation=(1, 1),
+        batch_size=U.BATCH,
+        input_height=input_h,
+        input_width=input_w,
+        conv_config=conv_config,
+        compute_config=compute_config,
+        groups=1,
+        memory_config=None,
+        return_weights_and_bias=True,
+        return_output_dim=True,
+        dtype=ttnn.bfloat16,
+    )
+
+    assert (tt_out_h, tt_out_w) == (
+        out_height,
+        out_width,
+    ), f"conv output dims {(tt_out_h, tt_out_w)} != torch {(out_height, out_width)}"
+
+    # conv2d returns a flattened row-major [1, 1, N*H_out*W_out, out_ch] (padded to tiles).
+    # Bring to host and reshape to the reference NHWC for PCC.
+    out = ttnn.from_device(tt_out)
+    out = ttnn.to_torch(out).float()
+    out = out.reshape(U.BATCH, out_height, out_width, out.shape[-1])
+    out = out[:, :, :, :out_ch].contiguous()
+
+    # bf16 conv @ LoFi: ~0.98; relax for very large reduction depth (matches run_conv).
+    pcc = 0.97 if in_ch * kernel * kernel > 10000 else 0.98
+    passing, msg = U.comp_pcc(ref_nhwc, out, pcc)
+    assert passing, f"conv2d PCC below {pcc}: {msg}"

--- a/models/experimental/ops/quasar/tests/yolo_ops/test_conv2d.py
+++ b/models/experimental/ops/quasar/tests/yolo_ops/test_conv2d.py
@@ -118,7 +118,7 @@ CONV_CASES = [
     # (b,4,16,a), softmaxes, permutes to (b,4,a,16) => NHWC N=1,H=4,W=a,C=16, then conv2d
     # in=16 out=1 k1s1p0. a = #anchors = 80*80+40*40+20*20 = 8400 @640. Non-square (H=4).
     pytest.param(8400, 16, 1, 1, 1, 0, 4, 8400, 0, id="l-model.22.dfl-8400"),
-    pytest.param(640, 16, 32, 3, 2, 1, 640, 640, 8, id="s-model.0-640"),
+    pytest.param(640, 16, 32, 3, 2, 1, 640, 640, 3, id="s-model.0-640"),
     pytest.param(320, 32, 64, 3, 2, 1, 320, 320, 0, id="s-model.1-320"),
     pytest.param(160, 64, 128, 3, 2, 1, 160, 160, 0, id="s-model.3-160"),
     pytest.param(80, 128, 256, 3, 2, 1, 80, 80, 0, id="s-model.5-80"),

--- a/models/experimental/ops/quasar/tests/yolo_ops/test_div.py
+++ b/models/experimental/ops/quasar/tests/yolo_ops/test_div.py
@@ -58,7 +58,7 @@ def test_div_l1(ttnn_mesh_device, reset_seeds, shape):
     x_torch = U.torch_rand(shape)
     x = U.to_tile_l1(x_torch, mesh)
 
-    out = ttnn.div(x, 2)
+    out = ttnn.div(x, 2, dtype=ttnn.bfloat8_b)
 
     ref = x_torch.float() / 2
     U.assert_pcc(ref, out, pcc=0.99, mesh_device=mesh)

--- a/models/experimental/ops/quasar/tests/yolo_ops/test_div.py
+++ b/models/experimental/ops/quasar/tests/yolo_ops/test_div.py
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Per-op test: ``ttnn.div``  (YOLOv8 dist2bbox center computation).
+
+Model call site:
+  * tt_yolov8l_utils.py:98   c_xy = ttnn.div(c_xy, 2, dtype=bfloat8_b, ...)
+  * tt_yolov8s_utils.py:96   c_xy = ttnn.div(c_xy, 2, dtype=bfloat8_b)
+
+``c_xy = x1y1 + x2y2`` is the summed box-center tensor ``[1, 2, A]``
+(tt_yolov8l_utils.py:97), divided by the python scalar 2 to get the mean center.
+
+A = total detect anchors: 8400 @ 640, 33600 @ 1280 (yolov8l only). dist2bbox is
+identical for yolov8l/yolov8s. Model uses bfloat8_b; we use default bfloat16.
+Reference: torch x / 2.  PCC 0.99.
+"""
+
+import pytest
+
+import ttnn
+from models.experimental.ops.quasar.tests.yolo_ops import op_utils as U
+
+# c_xy = [1, 2, A]. shape tuple param -> element-count classification.
+_SITES = [
+    pytest.param((1, 2, 8400), id="640"),  # yolov8l & yolov8s
+    pytest.param((1, 2, 33600), id="1280"),  # yolov8l only
+]
+
+
+@U.with_default_mesh()
+@pytest.mark.parametrize("shape", _SITES)
+def test_div_scalar(ttnn_mesh_device, reset_seeds, shape):
+    """c_xy / 2 (tt_yolov8l_utils.py:98)."""
+    mesh = ttnn_mesh_device
+
+    x_torch = U.torch_rand(shape)
+    x = U.to_tt(x_torch, mesh)
+
+    out = ttnn.div(x, 2)
+
+    ref = x_torch.float() / 2
+    U.assert_pcc(ref, out, pcc=0.99, mesh_device=mesh)
+
+
+# ---------------------------------------------------------------------------
+# Model-faithful (class C): L1-interleaved TILE input. dist2bbox runs inside the
+# detect head; its c_xy tensor lives on _DETECT_MEM_CONFIG = L1_MEMORY_CONFIG for
+# res <= 640 (ttnn_yolov8l.py:772-773). Same shapes as test_div_scalar, DRAM -> L1.
+# ---------------------------------------------------------------------------
+@pytest.mark.blackhole_scale
+@U.with_default_mesh()
+@pytest.mark.parametrize("shape", _SITES)
+def test_div_l1(ttnn_mesh_device, reset_seeds, shape):
+    """c_xy / 2 on L1 detect buffer (tt_yolov8l_utils.py:98, mem cfg ttnn_yolov8l.py:772-773)."""
+    mesh = ttnn_mesh_device
+
+    x_torch = U.torch_rand(shape)
+    x = U.to_tile_l1(x_torch, mesh)
+
+    out = ttnn.div(x, 2)
+
+    ref = x_torch.float() / 2
+    U.assert_pcc(ref, out, pcc=0.99, mesh_device=mesh)

--- a/models/experimental/ops/quasar/tests/yolo_ops/test_interleaved_to_sharded.py
+++ b/models/experimental/ops/quasar/tests/yolo_ops/test_interleaved_to_sharded.py
@@ -59,7 +59,7 @@ def test_interleaved_to_sharded(ttnn_mesh_device, reset_seeds, shape, strategy):
     out = ttnn.interleaved_to_sharded(x, memcfg)
 
     assert out.is_sharded(), "expected a sharded output"
-    U.assert_pcc(x_torch, out, pcc=0.999, mesh_device=mesh)
+    U.assert_lossless(x_torch, out, mesh_device=mesh)
 
 
 # --- model-faithful: interleaved L1 RM -> HEIGHT sharded on the real multi-core grid. -----
@@ -95,4 +95,4 @@ def test_interleaved_to_sharded_multicore(ttnn_mesh_device, reset_seeds, site, n
     out = ttnn.interleaved_to_sharded(x, memcfg)
 
     assert out.is_sharded(), "expected a sharded output"
-    U.assert_pcc(x_torch, out, pcc=0.999, mesh_device=mesh)
+    U.assert_lossless(x_torch, out, mesh_device=mesh)

--- a/models/experimental/ops/quasar/tests/yolo_ops/test_interleaved_to_sharded.py
+++ b/models/experimental/ops/quasar/tests/yolo_ops/test_interleaved_to_sharded.py
@@ -1,0 +1,98 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Per-op test: ``ttnn.interleaved_to_sharded`` (YOLOv8, 640x640, batch 1).
+
+Before each upsample the neck moves an interleaved NHWC feature map into a
+HEIGHT-sharded config:
+
+    sppf_9 = ttnn.interleaved_to_sharded(sppf_9, shardspec)   # HEIGHT shard over N*H*W
+
+It only re-lays-out data, so moving an interleaved tensor into a sharded config
+and reading it back must preserve values (PCC 0.999).
+
+Model call sites (branch ``origin/sdawle/yolov8_bh``):
+  * models/demos/yolov8l/tt/ttnn_yolov8l.py:1027 (sppf_9), :1059 (c2f_12)
+  * models/demos/yolov8s/tt/ttnn_yolov8s.py:758 (sppf_9), :789 (c2f_12)
+
+Single-core grid, so the passed shape [1,1,32,C] is the exact per-core shard
+shape. The model uses HEIGHT sharding here; a WIDTH case is added for coverage.
+Neck channel widths are the standard YOLOv8l/s sizes (not load-bearing).
+"""
+
+import pytest
+
+import ttnn
+from models.experimental.ops.quasar.tests.yolo_ops import op_utils as U
+
+_GRID = ttnn.CoreGrid(y=1, x=1)
+
+
+def _sharded_cfg(h, w, strategy):
+    return ttnn.create_sharded_memory_config(
+        (h, w),
+        _GRID,
+        strategy,
+        ttnn.ShardOrientation.ROW_MAJOR,
+        use_height_and_width_as_shard_shape=True,
+    )
+
+
+# (id, shape, strategy)
+_CASES = [
+    pytest.param((1, 1, U.TILE, 512), ttnn.ShardStrategy.HEIGHT, id="l-sppf-height-32x512"),  # ttnn_yolov8l.py:1027
+    pytest.param((1, 1, U.TILE, 256), ttnn.ShardStrategy.HEIGHT, id="s-sppf-height-32x256"),  # ttnn_yolov8s.py:758
+    pytest.param((1, 1, U.TILE, 512), ttnn.ShardStrategy.WIDTH, id="width-32x512"),  # width-shard coverage
+]
+
+
+@U.with_default_mesh()
+@pytest.mark.parametrize("shape, strategy", _CASES)
+def test_interleaved_to_sharded(ttnn_mesh_device, reset_seeds, shape, strategy):
+    mesh = ttnn_mesh_device
+
+    x_torch = U.torch_rand(shape)
+    x = U.to_tt(x_torch, mesh)  # interleaved DRAM
+
+    memcfg = _sharded_cfg(shape[-2], shape[-1], strategy)
+    out = ttnn.interleaved_to_sharded(x, memcfg)
+
+    assert out.is_sharded(), "expected a sharded output"
+    U.assert_pcc(x_torch, out, pcc=0.999, mesh_device=mesh)
+
+
+# --- model-faithful: interleaved L1 RM -> HEIGHT sharded on the real multi-core grid. -----
+#
+# The single-core case above is a shape-only stand-in. Before each neck upsample the model
+# moves an interleaved L1 row-major feature map (reshaped to (batch, out_h, out_w, C)) into
+# a HEIGHT-sharded config over a MULTI-core grid (ttnn_yolov8l.py:1017-1028 sppf_9,
+# :1051-1061 c2f_12):
+#
+#     num_cores = determine_num_cores(nhw, sppf_9.shape[2])   # width arg = out_w, NOT C
+#     shardspec = create_sharded_memory_config_(shape, get_core_grid_from_num_cores(...), HEIGHT)
+#     sppf_9    = ttnn.interleaved_to_sharded(sppf_9, shardspec)
+#
+# determine_num_cores (yolo_utils.py:17) with width=out_w yields one image row per core:
+# sppf_9 nhw=400,w=20 -> 20 cores; c2f_12 nhw=1600,w=40 -> 40 cores.
+@U.with_default_mesh()
+@pytest.mark.blackhole_scale
+@pytest.mark.parametrize(
+    "site, num_cores, shape",
+    [
+        # sppf_9 @20x20, C=512 (ttnn_yolov8l.py:1027); determine_num_cores(400, out_w=20)=20.
+        pytest.param("sppf_9", 20, (1, 20, 20, 512), id="sppf9-height-20c-20x20x512"),
+        # c2f_12 @40x40, C=512 (ttnn_yolov8l.py:1059); determine_num_cores(1600, out_w=40)=40.
+        pytest.param("c2f_12", 40, (1, 40, 40, 512), id="c2f12-height-40c-40x40x512"),
+    ],
+)
+def test_interleaved_to_sharded_multicore(ttnn_mesh_device, reset_seeds, site, num_cores, shape):
+    mesh = ttnn_mesh_device
+    x_torch = U.torch_rand(shape)
+    x = U.to_tt(x_torch, mesh, layout=ttnn.ROW_MAJOR_LAYOUT, memory_config=ttnn.L1_MEMORY_CONFIG)
+
+    memcfg = U.height_sharded_memcfg(mesh, num_cores, shape)  # skips if device < num_cores
+    out = ttnn.interleaved_to_sharded(x, memcfg)
+
+    assert out.is_sharded(), "expected a sharded output"
+    U.assert_pcc(x_torch, out, pcc=0.999, mesh_device=mesh)

--- a/models/experimental/ops/quasar/tests/yolo_ops/test_max_pool2d.py
+++ b/models/experimental/ops/quasar/tests/yolo_ops/test_max_pool2d.py
@@ -125,7 +125,9 @@ def test_max_pool2d_sharded(ttnn_mesh_device, reset_seeds, variant, channels, hw
 
     x_nchw = U.torch_rand((n, c, h, w))
     x_nhwc_flat = x_nchw.permute(0, 2, 3, 1).reshape(1, 1, n * h * w, c).contiguous()
-    x = U.to_tt(x_nhwc_flat, mesh, layout=ttnn.ROW_MAJOR_LAYOUT)
+    x = U.to_tt(
+        x_nhwc_flat, mesh, layout=ttnn.ROW_MAJOR_LAYOUT, memory_config=ttnn.L1_MEMORY_CONFIG
+    )
 
     pool_kwargs = dict(
         batch_size=n,

--- a/models/experimental/ops/quasar/tests/yolo_ops/test_max_pool2d.py
+++ b/models/experimental/ops/quasar/tests/yolo_ops/test_max_pool2d.py
@@ -90,12 +90,11 @@ def test_max_pool2d(ttnn_mesh_device, reset_seeds, variant, channels, hw):
     U.assert_pcc(ref, out, pcc=0.99, mesh_device=mesh)
 
 
-def _torch_max_pool2d_twice(x_nchw: torch.Tensor) -> torch.Tensor:
-    """Golden for two stacked SPPF pools (5x5/s1/p2 is size-preserving), NHWC flat."""
-    y = torch.nn.functional.max_pool2d(
-        x_nchw.float(), kernel_size=_KERNEL, stride=_STRIDE, padding=_PADDING, dilation=_DILATION
-    )
-    y = torch.nn.functional.max_pool2d(y, kernel_size=_KERNEL, stride=_STRIDE, padding=_PADDING, dilation=_DILATION)
+def _torch_max_pool2d_thrice(x_nchw: torch.Tensor) -> torch.Tensor:
+    """Golden for the SPPF's three stacked pools (5x5/s1/p2 is size-preserving), NHWC flat."""
+    y = x_nchw.float()
+    for _ in range(3):
+        y = torch.nn.functional.max_pool2d(y, kernel_size=_KERNEL, stride=_STRIDE, padding=_PADDING, dilation=_DILATION)
     n, c, h, w = y.shape
     return y.permute(0, 2, 3, 1).reshape(1, 1, n * h * w, c)
 
@@ -125,9 +124,7 @@ def test_max_pool2d_sharded(ttnn_mesh_device, reset_seeds, variant, channels, hw
 
     x_nchw = U.torch_rand((n, c, h, w))
     x_nhwc_flat = x_nchw.permute(0, 2, 3, 1).reshape(1, 1, n * h * w, c).contiguous()
-    x = U.to_tt(
-        x_nhwc_flat, mesh, layout=ttnn.ROW_MAJOR_LAYOUT, memory_config=ttnn.L1_MEMORY_CONFIG
-    )
+    x = U.to_tt(x_nhwc_flat, mesh, layout=ttnn.ROW_MAJOR_LAYOUT, memory_config=ttnn.L1_MEMORY_CONFIG)
 
     pool_kwargs = dict(
         batch_size=n,
@@ -146,6 +143,11 @@ def test_max_pool2d_sharded(ttnn_mesh_device, reset_seeds, variant, channels, hw
 
     # Pool #2: consumes the HEIGHT_SHARDED L1 tensor directly, exactly as the model loop does.
     out2 = ttnn.max_pool2d(input_tensor=out1, **pool_kwargs)
+    assert out2.is_sharded(), "pool #2 output should be HEIGHT_SHARDED (the pool #3 input state)"
 
-    ref = _torch_max_pool2d_twice(x_nchw)
-    U.assert_pcc(ref, out2, pcc=0.99, mesh_device=mesh)
+    # Pool #3: the SPPF applies max_pool2d three times; verify the 2nd sharded output can
+    # feed the 3rd invocation (catches a state/layout issue that only shows on the last pool).
+    out3 = ttnn.max_pool2d(input_tensor=out2, **pool_kwargs)
+
+    ref = _torch_max_pool2d_thrice(x_nchw)
+    U.assert_pcc(ref, out3, pcc=0.99, mesh_device=mesh)

--- a/models/experimental/ops/quasar/tests/yolo_ops/test_max_pool2d.py
+++ b/models/experimental/ops/quasar/tests/yolo_ops/test_max_pool2d.py
@@ -1,0 +1,149 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Per-op test: ``ttnn.max_pool2d`` — the YOLOv8 SPPF pooling.
+
+Model call site (SPPF module, kernel/stride/pad/dilation copied verbatim):
+  * yolov8l: models/demos/yolov8l/tt/ttnn_yolov8l.py  L529  (class TtSppf ~L508)
+  * yolov8s: models/demos/yolov8s/tt/ttnn_yolov8s.py  L445  (class TtSppf ~L423)
+
+Both variants run, in ``TtSppf.__call__``:
+    ttnn.max_pool2d(input_tensor=..., batch_size=1, input_h=out_h, input_w=out_w,
+                    channels=y[-1].shape[-1], kernel_size=[5, 5], stride=[1, 1],
+                    padding=[2, 2], dilation=[1, 1])
+applied THREE times in sequence (each pool keeps H/W: 5x5, stride 1, pad 2 is
+size-preserving), on the SPPF cv1 output.
+
+Shapes (both variants identical at the SPPF stage — SPPF cv1 out_ch = 256):
+  * channels = sppf cv1 out = input_params[0][3] = 256
+      configs.json sppf_configs.input_params[0] = [1,1,0,256,512]  (=[k,s,p,out,in])
+      identical for yolov8l and yolov8s (both files' configs.json).
+  * resolution = SPPF stage = 20x20 at 640x640 input
+      backbone stride-2 chain 640->320->160->80->40->20; SPPF is model.9 (deepest).
+      (traced through ttnn_yolov8l.py neck __call__ conv_0/3/5/7 stride-2 convs.)
+
+Reference: torch.nn.functional.max_pool2d on the NCHW input. Input prep mirrors the
+canonical op test tests/ttnn/nightly/unit_tests/operations/pool/test_maxpool2d.py
+(row-major (1, 1, N*H*W, C) activation).
+"""
+
+import pytest
+import torch
+
+import ttnn
+from models.experimental.ops.quasar.tests.yolo_ops import op_utils as U
+
+# SPPF pool params, copied verbatim from the model call site (identical l & s).
+_KERNEL = [5, 5]
+_STRIDE = [1, 1]
+_PADDING = [2, 2]
+_DILATION = [1, 1]
+
+
+def _torch_max_pool2d(x_nchw: torch.Tensor) -> torch.Tensor:
+    """Golden: F.max_pool2d on NCHW, returned as (1, 1, N*H*W_out, C) row-major NHWC."""
+    ref_nchw = torch.nn.functional.max_pool2d(
+        x_nchw.float(),
+        kernel_size=_KERNEL,
+        stride=_STRIDE,
+        padding=_PADDING,
+        dilation=_DILATION,
+    )
+    n, c, h, w = ref_nchw.shape
+    return ref_nchw.permute(0, 2, 3, 1).reshape(1, 1, n * h * w, c)
+
+
+@U.with_mesh_l1small()  # max_pool2d allocates from the L1-small region (default l1_small_size=0 OOMs)
+@pytest.mark.parametrize(
+    "variant, channels, hw",
+    [
+        # yolov8l SPPF: ttnn_yolov8l.py:529, configs.json sppf_configs[0]=[1,1,0,256,512]
+        pytest.param("yolov8l", 256, 20, id="yolov8l-sppf-256x20x20"),
+        # yolov8s SPPF: ttnn_yolov8s.py:445, configs.json sppf_configs[0]=[1,1,0,256,512]
+        pytest.param("yolov8s", 256, 20, id="yolov8s-sppf-256x20x20"),
+    ],
+)
+def test_max_pool2d(ttnn_mesh_device, reset_seeds, variant, channels, hw):
+    mesh = ttnn_mesh_device
+    n, c, h, w = U.BATCH, channels, hw, hw
+
+    # NCHW host input, uploaded as row-major (1, 1, N*H*W, C) — the layout ttnn.max_pool2d
+    # consumes (canonical test_maxpool2d.py:76-93).
+    x_nchw = U.torch_rand((n, c, h, w))
+    x_nhwc_flat = x_nchw.permute(0, 2, 3, 1).reshape(1, 1, n * h * w, c).contiguous()
+    x = U.to_tt(x_nhwc_flat, mesh, layout=ttnn.ROW_MAJOR_LAYOUT)
+
+    out = ttnn.max_pool2d(
+        input_tensor=x,
+        batch_size=n,
+        input_h=h,
+        input_w=w,
+        channels=c,
+        kernel_size=_KERNEL,
+        stride=_STRIDE,
+        padding=_PADDING,
+        dilation=_DILATION,
+    )
+
+    ref = _torch_max_pool2d(x_nchw)
+    U.assert_pcc(ref, out, pcc=0.99, mesh_device=mesh)
+
+
+def _torch_max_pool2d_twice(x_nchw: torch.Tensor) -> torch.Tensor:
+    """Golden for two stacked SPPF pools (5x5/s1/p2 is size-preserving), NHWC flat."""
+    y = torch.nn.functional.max_pool2d(
+        x_nchw.float(), kernel_size=_KERNEL, stride=_STRIDE, padding=_PADDING, dilation=_DILATION
+    )
+    y = torch.nn.functional.max_pool2d(y, kernel_size=_KERNEL, stride=_STRIDE, padding=_PADDING, dilation=_DILATION)
+    n, c, h, w = y.shape
+    return y.permute(0, 2, 3, 1).reshape(1, 1, n * h * w, c)
+
+
+# --- model-faithful: pool #2/#3 consume a HEIGHT_SHARDED L1 input (the REAL SPPF state). ---
+#
+# In the SPPF loop (ttnn_yolov8l.py:529 / ttnn_yolov8s.py:445) the FIRST max_pool2d consumes
+# the interleaved-L1 cv1 output (the case above) but returns a HEIGHT_SHARDED L1 tensor. The
+# next two pools then consume that HEIGHT_SHARDED L1 output directly (``y[-1]`` in the loop).
+# We reproduce that exact state by stacking two pools: out1 (HEIGHT_SHARDED L1) is asserted
+# sharded and fed as the input of pool #2 — no memory_config / applied_shard_scheme args, so
+# the sharding is chosen internally exactly as the model leaves it.
+@U.with_mesh_l1small()  # max_pool2d allocates from the L1-small region (default l1_small_size=0 OOMs)
+@pytest.mark.blackhole_scale
+@pytest.mark.parametrize(
+    "variant, channels, hw",
+    [
+        # yolov8l SPPF: ttnn_yolov8l.py:529, configs.json sppf_configs[0]=[1,1,0,256,512]
+        pytest.param("yolov8l", 256, 20, id="yolov8l-sppf-sharded-256x20x20"),
+        # yolov8s SPPF: ttnn_yolov8s.py:445, configs.json sppf_configs[0]=[1,1,0,256,512]
+        pytest.param("yolov8s", 256, 20, id="yolov8s-sppf-sharded-256x20x20"),
+    ],
+)
+def test_max_pool2d_sharded(ttnn_mesh_device, reset_seeds, variant, channels, hw):
+    mesh = ttnn_mesh_device
+    n, c, h, w = U.BATCH, channels, hw, hw
+
+    x_nchw = U.torch_rand((n, c, h, w))
+    x_nhwc_flat = x_nchw.permute(0, 2, 3, 1).reshape(1, 1, n * h * w, c).contiguous()
+    x = U.to_tt(x_nhwc_flat, mesh, layout=ttnn.ROW_MAJOR_LAYOUT)
+
+    pool_kwargs = dict(
+        batch_size=n,
+        input_h=h,
+        input_w=w,
+        channels=c,
+        kernel_size=_KERNEL,
+        stride=_STRIDE,
+        padding=_PADDING,
+        dilation=_DILATION,
+    )
+
+    # Pool #1: interleaved -> HEIGHT_SHARDED L1 (this sharded output is what pools #2/#3 eat).
+    out1 = ttnn.max_pool2d(input_tensor=x, **pool_kwargs)
+    assert out1.is_sharded(), "pool #1 output should be HEIGHT_SHARDED (the pool #2/#3 input state)"
+
+    # Pool #2: consumes the HEIGHT_SHARDED L1 tensor directly, exactly as the model loop does.
+    out2 = ttnn.max_pool2d(input_tensor=out1, **pool_kwargs)
+
+    ref = _torch_max_pool2d_twice(x_nchw)
+    U.assert_pcc(ref, out2, pcc=0.99, mesh_device=mesh)

--- a/models/experimental/ops/quasar/tests/yolo_ops/test_multiply.py
+++ b/models/experimental/ops/quasar/tests/yolo_ops/test_multiply.py
@@ -69,7 +69,7 @@ def test_multiply_l1(ttnn_mesh_device, reset_seeds, shape):
     dbox = U.to_tile_l1(dbox_torch, mesh)
     strides = U.to_tile_l1(strides_torch, mesh)
 
-    out = ttnn.multiply(dbox, strides)
+    out = ttnn.multiply(dbox, strides, dtype=ttnn.bfloat8_b)
 
     ref = dbox_torch.float() * strides_torch.float()
     U.assert_pcc(ref, out, pcc=0.99, mesh_device=mesh)

--- a/models/experimental/ops/quasar/tests/yolo_ops/test_multiply.py
+++ b/models/experimental/ops/quasar/tests/yolo_ops/test_multiply.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Per-op test: ``ttnn.multiply``  (YOLOv8 detect-head box de-scaling).
+
+Model call site:
+  * yolov8l  ttnn_yolov8l.py:755   dbox = ttnn.multiply(dbox, strides, dtype=bfloat8_b)
+  * yolov8s  ttnn_yolov8s.py:576   (identical)
+
+``dbox`` is the decoded box tensor ``[1, 4, A]`` (dist2bbox output,
+tt_yolov8l_utils.py:100). ``strides`` is make_anchors' ``b`` = per-anchor stride,
+``torch.cat(stride_tensor).transpose(0,1)`` -> logical ``[1, A]``
+(tt_yolov8l_utils.py:81,85); it broadcasts across the 4 box coords. Here strides is
+built as ``[1, 1, A]`` (rank-aligned equivalent of the model's ``[1, A]``) so the
+broadcast over dim=1 (4 vs 1) is unambiguous.
+
+A = total detect anchors: 8400 @ 640, 33600 @ 1280 (yolov8l only). Detect head is
+identical for yolov8l/yolov8s. Model uses bfloat8_b; we use default bfloat16.
+Reference: torch broadcast multiply.  PCC 0.99.
+"""
+
+import pytest
+
+import ttnn
+from models.experimental.ops.quasar.tests.yolo_ops import op_utils as U
+
+# dbox=[1,4,A], strides=[1,1,A]. shape tuple param -> element-count classification.
+_SITES = [
+    pytest.param((1, 4, 8400), id="640"),  # yolov8l & yolov8s
+    pytest.param((1, 4, 33600), id="1280"),  # yolov8l only
+]
+
+
+@U.with_default_mesh()
+@pytest.mark.parametrize("shape", _SITES)
+def test_multiply_dbox_strides(ttnn_mesh_device, reset_seeds, shape):
+    """dbox * strides (ttnn_yolov8l.py:755)."""
+    mesh = ttnn_mesh_device
+    a = shape[-1]
+
+    dbox_torch = U.torch_rand(shape)  # [1, 4, A]
+    strides_torch = U.torch_rand((1, 1, a))  # broadcasts over the 4 coords
+    dbox = U.to_tt(dbox_torch, mesh)
+    strides = U.to_tt(strides_torch, mesh)
+
+    out = ttnn.multiply(dbox, strides)
+
+    ref = dbox_torch.float() * strides_torch.float()
+    U.assert_pcc(ref, out, pcc=0.99, mesh_device=mesh)
+
+
+# ---------------------------------------------------------------------------
+# Model-faithful (class C): L1-interleaved TILE inputs, matching the real detect
+# head buffer state. dbox * strides (ttnn_yolov8l.py:755) runs inside the detect
+# head, whose tensors live on _DETECT_MEM_CONFIG = L1_MEMORY_CONFIG for res <= 640
+# (ttnn_yolov8l.py:772-773). Same shapes as test_multiply_dbox_strides, DRAM -> L1.
+# ---------------------------------------------------------------------------
+@pytest.mark.blackhole_scale
+@U.with_default_mesh()
+@pytest.mark.parametrize("shape", _SITES)
+def test_multiply_l1(ttnn_mesh_device, reset_seeds, shape):
+    """dbox * strides on L1 detect buffers (ttnn_yolov8l.py:755, mem cfg :772-773)."""
+    mesh = ttnn_mesh_device
+    a = shape[-1]
+
+    dbox_torch = U.torch_rand(shape)  # [1, 4, A]
+    strides_torch = U.torch_rand((1, 1, a))  # broadcasts over the 4 coords
+    dbox = U.to_tile_l1(dbox_torch, mesh)
+    strides = U.to_tile_l1(strides_torch, mesh)
+
+    out = ttnn.multiply(dbox, strides)
+
+    ref = dbox_torch.float() * strides_torch.float()
+    U.assert_pcc(ref, out, pcc=0.99, mesh_device=mesh)

--- a/models/experimental/ops/quasar/tests/yolo_ops/test_pad.py
+++ b/models/experimental/ops/quasar/tests/yolo_ops/test_pad.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Per-op test: ``ttnn.pad`` (YOLOv8, 640x640, batch 1).
+
+The stem pads the 3-channel NCHW input up to 16 channels (conv min-channel
+requirement) before the NCHW->NHWC permute:
+
+    channel_padding_needed = 16 - C                 # 13 for C=3
+    x = ttnn.pad(x, ((0,0),(0,channel_padding_needed),(0,0),(0,0)), value=0.0)
+
+Value-preserving (pad value 0.0) -> torch reference is ``F.pad`` on the channel
+dim; PCC 0.999. Uploaded ROW_MAJOR so the compare is exact.
+
+Model call sites (branch ``origin/sdawle/yolov8_bh``):
+  * models/demos/yolov8l/tt/ttnn_yolov8l.py:978
+  * models/demos/yolov8s/tt/ttnn_yolov8s.py:711  (spelled ((0,0),(0,pad),(0,0),(0,0)))
+
+The stem input is (1, 3, 640, 640); it is padded to (1, 16, 640, 640). H==W is a
+spatial feature map, so this is parametrized by ``hw`` (hw=20 fits the emulator,
+hw=640 is the real stem resolution and runs on real Blackhole).
+"""
+
+import pytest
+import torch.nn.functional as F
+
+import ttnn
+from models.experimental.ops.quasar.tests.yolo_ops import op_utils as U
+
+
+@U.with_default_mesh()
+@pytest.mark.parametrize("hw", [20, 640])
+def test_pad_stem_channels(ttnn_mesh_device, reset_seeds, hw):
+    """ttnn_yolov8l.py:978 / ttnn_yolov8s.py:711 — pad C: 3 -> 16."""
+    mesh = ttnn_mesh_device
+    pad_c = U.IMG_CH_PADDED - U.IMG_CH  # 16 - 3 = 13
+
+    x_torch = U.torch_rand((1, U.IMG_CH, hw, hw))
+    x = U.to_tt(x_torch, mesh, layout=ttnn.ROW_MAJOR_LAYOUT)
+
+    out = ttnn.pad(x, ((0, 0), (0, pad_c), (0, 0), (0, 0)), value=0.0)
+
+    # F.pad pads from the last dim outward: (W_l,W_r, H_l,H_r, C_l,C_r).
+    ref = F.pad(x_torch.float(), (0, 0, 0, 0, 0, pad_c), value=0.0)
+    U.assert_pcc(ref, out, pcc=0.999, mesh_device=mesh)

--- a/models/experimental/ops/quasar/tests/yolo_ops/test_pad.py
+++ b/models/experimental/ops/quasar/tests/yolo_ops/test_pad.py
@@ -43,4 +43,4 @@ def test_pad_stem_channels(ttnn_mesh_device, reset_seeds, hw):
 
     # F.pad pads from the last dim outward: (W_l,W_r, H_l,H_r, C_l,C_r).
     ref = F.pad(x_torch.float(), (0, 0, 0, 0, 0, pad_c), value=0.0)
-    U.assert_pcc(ref, out, pcc=0.999, mesh_device=mesh)
+    U.assert_lossless(ref, out, mesh_device=mesh)

--- a/models/experimental/ops/quasar/tests/yolo_ops/test_permute.py
+++ b/models/experimental/ops/quasar/tests/yolo_ops/test_permute.py
@@ -43,7 +43,7 @@ def test_permute_nchw_to_nhwc(ttnn_mesh_device, reset_seeds, hw):
     out = ttnn.permute(x, dims)
 
     ref = torch.permute(x_torch.float(), dims).contiguous()
-    U.assert_pcc(ref, out, pcc=0.999, mesh_device=mesh)
+    U.assert_lossless(ref, out, mesh_device=mesh)
 
 
 # =============================================================================
@@ -97,7 +97,7 @@ def test_permute_tile(ttnn_mesh_device, reset_seeds, name, shape, dims, model_li
     out = ttnn.permute(x, dims)
 
     ref = torch.permute(x_torch.float(), dims).contiguous()
-    U.assert_pcc(ref, out, pcc=0.999, mesh_device=mesh)
+    U.assert_lossless(ref, out, mesh_device=mesh)
 
 
 # --- DFL / detect-head permutes: non-spatial (H != W) -> shape-tuple params. --
@@ -125,4 +125,4 @@ def test_permute_detect(ttnn_mesh_device, reset_seeds, name, shape, dims):
     out = ttnn.permute(x, dims)
 
     ref = torch.permute(x_torch.float(), dims).contiguous()
-    U.assert_pcc(ref, out, pcc=0.999, mesh_device=mesh)
+    U.assert_lossless(ref, out, mesh_device=mesh)

--- a/models/experimental/ops/quasar/tests/yolo_ops/test_permute.py
+++ b/models/experimental/ops/quasar/tests/yolo_ops/test_permute.py
@@ -1,0 +1,128 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Per-op test: ``ttnn.permute`` (YOLOv8, 640x640, batch 1).
+
+YOLOv8 uses ``ttnn.permute`` for NCHW<->NHWC layout swaps at the stem and inside
+the DFL / detect head. It is a value-preserving axis permutation, so the torch
+reference is ``torch.permute``. Uploaded ROW_MAJOR to avoid tile-padding effects.
+
+Model call sites (branch ``origin/sdawle/yolov8_bh``):
+  * models/demos/yolov8l/tt/ttnn_yolov8l.py:986  stem NCHW->NHWC permute(0,2,3,1) of (1,16,H,W)
+    (same at models/demos/yolov8s/tt/ttnn_yolov8s.py:714)
+  * ttnn_yolov8l.py:646  DFL permute(0,1,3,2) of (1,4,16,8400) -> (1,4,8400,16)
+    (same at ttnn_yolov8s.py:509)
+  * ttnn_yolov8l.py:649  DFL post-conv NHWC->NCHW permute(0,3,1,2)
+  * ttnn_yolov8l.py:745  detect x_cat permute(0,2,1) of (1,8400,144) -> (1,144,8400)
+    (same at ttnn_yolov8s.py:566)
+
+Detect head at 640 input -> anchor count 8400, no = nc + reg_max*4 = 144.
+"""
+
+import pytest
+import torch
+
+import ttnn
+from models.experimental.ops.quasar.tests.yolo_ops import op_utils as U
+
+
+# --- Stem NCHW->NHWC: spatial feature map (H==W) -> parametrize by `hw`. ------
+# hw=20 fits the emulator; hw=640 is the real stem resolution (real-BH only).
+# Channel dim is 16 (3-channel input already padded to 16 upstream).
+@U.with_default_mesh()
+@pytest.mark.parametrize("hw", [20, 640])
+def test_permute_nchw_to_nhwc(ttnn_mesh_device, reset_seeds, hw):
+    """ttnn_yolov8l.py:986 / ttnn_yolov8s.py:714 — permute(0,2,3,1)."""
+    mesh = ttnn_mesh_device
+    dims = (0, 2, 3, 1)
+
+    x_torch = U.torch_rand((1, U.IMG_CH_PADDED, hw, hw))
+    x = U.to_tt(x_torch, mesh, layout=ttnn.ROW_MAJOR_LAYOUT)
+
+    out = ttnn.permute(x, dims)
+
+    ref = torch.permute(x_torch.float(), dims).contiguous()
+    U.assert_pcc(ref, out, pcc=0.999, mesh_device=mesh)
+
+
+# =============================================================================
+# Model-faithful variant: reproduce the model's REAL layout / buffer state.
+# =============================================================================
+
+# The DFL / detect permutes run on TILE_LAYOUT in L1 (memory_config=_DETECT_MEM_CONFIG,
+# == ttnn.L1_MEMORY_CONFIG at 640x640). The existing tests above cover ROW_MAJOR; these
+# reproduce the model's actual TILE/L1 state.
+#
+# (id, shape, dims, model_line).
+_PERMUTE_TILE_SITES = [
+    # ttnn_yolov8l.py:646 / ttnn_yolov8s.py:509 — DFL (1,4,16,8400) -> (1,4,8400,16)
+    ("dfl_transpose_tile", (1, 4, 16, 8400), (0, 1, 3, 2), 646),
+    # ttnn_yolov8l.py:649 — DFL post-conv NHWC->NCHW (1,4,8400,1) -> (1,1,4,8400)
+    ("dfl_nhwc_to_nchw_tile", (1, 4, 8400, 1), (0, 3, 1, 2), 649),
+    # ttnn_yolov8l.py:745 / ttnn_yolov8s.py:566 — detect x_cat (1,8400,144) -> (1,144,8400)
+    ("detect_xcat_tile", (1, 8400, 144), (0, 2, 1), 745),
+]
+
+
+@pytest.mark.blackhole_scale
+@U.with_default_mesh()
+@pytest.mark.parametrize(
+    "name, shape, dims, model_line",
+    [pytest.param(*s, id=s[0]) for s in _PERMUTE_TILE_SITES],
+)
+def test_permute_tile(ttnn_mesh_device, reset_seeds, name, shape, dims, model_line):
+    """Model-faithful ``ttnn.permute`` on TILE / L1 — the DFL / detect-head permutes.
+
+    Every detect-head permute passes ``memory_config=_DETECT_MEM_CONFIG`` (== L1 at
+    640x640) and runs while the tensor is in TILE_LAYOUT:
+
+        x     = ttnn.permute(x, (0, 1, 3, 2), memory_config=_DETECT_MEM_CONFIG)  # :646
+        x     = ttnn.permute(x, (0, 3, 1, 2))                                    # :649
+        x_cat = ttnn.permute(x_cat, (0, 2, 1), memory_config=_DETECT_MEM_CONFIG) # :745
+
+    The anchor dim (8400) is not tile-aligned, so these transpose the padded row/col
+    dims of a non-tile-aligned tensor. Permute is value-preserving; reference is
+    ``torch.permute`` at PCC 0.999.
+
+    Model call sites (branch ``origin/sdawle/yolov8_bh``):
+      * models/demos/yolov8l/tt/ttnn_yolov8l.py:646, :649, :745
+        (:646/:745 also at models/demos/yolov8s/tt/ttnn_yolov8s.py:509 / :566)
+    """
+    mesh = ttnn_mesh_device
+
+    x_torch = U.torch_rand(shape)
+    x = U.to_tile_l1(x_torch, mesh)
+
+    out = ttnn.permute(x, dims)
+
+    ref = torch.permute(x_torch.float(), dims).contiguous()
+    U.assert_pcc(ref, out, pcc=0.999, mesh_device=mesh)
+
+
+# --- DFL / detect-head permutes: non-spatial (H != W) -> shape-tuple params. --
+_PERMUTE_SITES = [
+    # ttnn_yolov8l.py:646 / ttnn_yolov8s.py:509 — DFL (1,4,16,8400) -> (1,4,8400,16)
+    ("dfl_transpose", (1, 4, 16, 8400), (0, 1, 3, 2)),
+    # ttnn_yolov8l.py:649 — DFL post-conv NHWC->NCHW (1,4,8400,1) -> (1,1,4,8400)
+    ("dfl_nhwc_to_nchw", (1, 4, 8400, 1), (0, 3, 1, 2)),
+    # ttnn_yolov8l.py:745 / ttnn_yolov8s.py:566 — detect x_cat (1,8400,144) -> (1,144,8400)
+    ("detect_xcat", (1, 8400, 144), (0, 2, 1)),
+]
+
+
+@U.with_default_mesh()
+@pytest.mark.parametrize(
+    "name, shape, dims",
+    [pytest.param(*s, id=s[0]) for s in _PERMUTE_SITES],
+)
+def test_permute_detect(ttnn_mesh_device, reset_seeds, name, shape, dims):
+    mesh = ttnn_mesh_device
+
+    x_torch = U.torch_rand(shape)
+    x = U.to_tt(x_torch, mesh, layout=ttnn.ROW_MAJOR_LAYOUT)
+
+    out = ttnn.permute(x, dims)
+
+    ref = torch.permute(x_torch.float(), dims).contiguous()
+    U.assert_pcc(ref, out, pcc=0.999, mesh_device=mesh)

--- a/models/experimental/ops/quasar/tests/yolo_ops/test_reallocate.py
+++ b/models/experimental/ops/quasar/tests/yolo_ops/test_reallocate.py
@@ -40,4 +40,4 @@ def test_reallocate(ttnn_mesh_device, reset_seeds, hw):
 
     out = ttnn.reallocate(x)
 
-    U.assert_pcc(x_torch, out, pcc=0.999, mesh_device=mesh)
+    U.assert_lossless(x_torch, out, mesh_device=mesh)

--- a/models/experimental/ops/quasar/tests/yolo_ops/test_reallocate.py
+++ b/models/experimental/ops/quasar/tests/yolo_ops/test_reallocate.py
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Per-op test: ``ttnn.reallocate`` (YOLOv8, 640x640, batch 1).
+
+After padding the stem input to 16 channels and permuting NCHW->NHWC, the model
+defragments the tensor before reshaping it into the conv input:
+
+    nhwc = ttnn.permute(nchw, (0, 2, 3, 1))   # NCHW -> NHWC
+    nhwc = ttnn.reallocate(nhwc)
+
+``reallocate`` just moves a tensor to a fresh (defragmented) allocation; it is a
+pure value-preserving relocation, so the result must equal the input (PCC 0.999).
+
+Model call site (branch ``origin/sdawle/yolov8_bh``):
+  * models/demos/yolov8s/tt/ttnn_yolov8s.py:717
+    (yolov8l performs the same NCHW->NHWC prep at ttnn_yolov8l.py:986-987 via
+    permute + to_memory_config; reallocate is the yolov8s spelling.)
+
+The tensor is the row-major NHWC stem input (1, H, W, 16). H==W is a spatial
+feature map, parametrized by ``hw`` (20 fits the emulator, 640 is the real stem
+resolution and runs on real Blackhole).
+"""
+
+import pytest
+
+import ttnn
+from models.experimental.ops.quasar.tests.yolo_ops import op_utils as U
+
+
+@U.with_default_mesh()
+@pytest.mark.parametrize("hw", [20, 640])
+def test_reallocate(ttnn_mesh_device, reset_seeds, hw):
+    """ttnn_yolov8s.py:717 — reallocate the NHWC stem input (1, hw, hw, 16)."""
+    mesh = ttnn_mesh_device
+
+    x_torch = U.torch_rand((1, hw, hw, U.IMG_CH_PADDED))
+    x = U.to_tt(x_torch, mesh, layout=ttnn.ROW_MAJOR_LAYOUT)
+
+    out = ttnn.reallocate(x)
+
+    U.assert_pcc(x_torch, out, pcc=0.999, mesh_device=mesh)

--- a/models/experimental/ops/quasar/tests/yolo_ops/test_reshape.py
+++ b/models/experimental/ops/quasar/tests/yolo_ops/test_reshape.py
@@ -75,7 +75,7 @@ def test_reshape(ttnn_mesh_device, reset_seeds, name, in_shape, out_shape):
     out = ttnn.reshape(x, list(out_shape))
 
     ref = torch.reshape(x_torch.float(), out_shape)
-    U.assert_pcc(ref, out, pcc=0.999, mesh_device=mesh)
+    U.assert_lossless(ref, out, mesh_device=mesh)
 
 
 # =============================================================================
@@ -132,4 +132,4 @@ def test_reshape_tile_dfl(ttnn_mesh_device, reset_seeds, name, in_shape, out_sha
     out = ttnn.reshape(x, list(out_shape))
 
     ref = torch.reshape(x_torch.float(), out_shape)
-    U.assert_pcc(ref, out, pcc=0.999, mesh_device=mesh)
+    U.assert_lossless(ref, out, mesh_device=mesh)

--- a/models/experimental/ops/quasar/tests/yolo_ops/test_reshape.py
+++ b/models/experimental/ops/quasar/tests/yolo_ops/test_reshape.py
@@ -1,0 +1,135 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Per-op test: ``ttnn.reshape`` (YOLOv8, 640x640, batch 1).
+
+``ttnn.reshape`` in YOLOv8 only folds / unfolds axes (DFL reg reshape, detect
+flatten, NHWC<->flattened neck reshapes, bias reshape); it is value-preserving,
+so the torch reference is ``torch.reshape``. Uploaded ROW_MAJOR so no tile
+padding perturbs the flat value comparison.
+
+Model call sites (branch ``origin/sdawle/yolov8_bh``):
+  * models/demos/yolov8l/tt/ttnn_yolov8l.py:644  DFL reg reshape (b,64,a)->(b,4,c1,a), c1=16
+    (same op at models/demos/yolov8s/tt/ttnn_yolov8s.py:507)
+  * ttnn_yolov8l.py:650  DFL post-conv reshape (b,1,4,a4)
+  * ttnn_yolov8l.py:651  DFL final reshape (b, 1*4, a)
+  * ttnn_yolov8l.py:741  detect flatten x[i] -> (b, -1, no)  (no = nc+reg_max*4 = 144)
+    (same at ttnn_yolov8s.py:562)
+  * ttnn_yolov8l.py:1017 SPPF NHWC reshape (b, out_h, out_w, C)
+    (same at ttnn_yolov8s.py:748)
+  * ttnn_yolov8l.py:1031 post-upsample flatten (1,1,b*H*W,C)
+    (same at ttnn_yolov8s.py:762)
+  * models/demos/yolov8l/tt/tt_yolov8l_utils.py:110 conv-bias reshape (C,)->(1,1,1,-1)
+    (same at tt_yolov8s_utils.py:108)
+
+Detect head runs at feature-map sizes {80,40,20} for a 640 input, so the anchor
+count is 80*80+40*40+20*20 = 8400 and no = 80 + 16*4 = 144.
+"""
+
+import pytest
+import torch
+
+import ttnn
+from models.experimental.ops.quasar.tests.yolo_ops import op_utils as U
+
+# (id, in_shape, out_shape). -1 is resolved by both torch.reshape and ttnn.reshape.
+# Neck channel widths are the standard YOLOv8l/s neck sizes; reshape is
+# channel-independent so the exact value is not load-bearing.
+_RESHAPE_SITES = [
+    # ttnn_yolov8l.py:644 — DFL reg reshape (1,64,8400) -> (1,4,16,8400)
+    ("dfl_reg_split", (1, 64, 8400), (1, 4, 16, 8400)),
+    # ttnn_yolov8l.py:650 — DFL post-conv reshape (1,1,4,8400) -> (1,1,4,8400) width-fold form
+    ("dfl_post_conv", (1, 1, 4, 8400), (1, 1, 4, 8400)),
+    # ttnn_yolov8l.py:651 — DFL final reshape (1,1,4,8400) -> (1,4,8400)
+    ("dfl_final", (1, 1, 4, 8400), (1, 4, 8400)),
+    # ttnn_yolov8l.py:741 — detect flatten per scale (p3/p4/p5): [1,1,H*W,144] -> (1,H*W,144)
+    ("detect_flatten_p3", (1, 1, 6400, 144), (1, 6400, 144)),
+    ("detect_flatten_p4", (1, 1, 1600, 144), (1, 1600, 144)),
+    ("detect_flatten_p5", (1, 1, 400, 144), (1, 400, 144)),
+    # ttnn_yolov8l.py:1017 — SPPF NHWC reshape (1,1,400,512) -> (1,20,20,512)  [P5, C=512]
+    ("sppf_nhwc_l", (1, 1, 400, 512), (1, 20, 20, 512)),
+    # ttnn_yolov8s.py:748 — SPPF NHWC reshape (yolov8s narrower neck, C=256)
+    ("sppf_nhwc_s", (1, 1, 400, 256), (1, 20, 20, 256)),
+    # ttnn_yolov8l.py:1031 — post-upsample flatten (1,40,40,512) -> (1,1,1600,512)
+    ("upsample_flatten_l", (1, 40, 40, 512), (1, 1, 1600, 512)),
+    # ttnn_yolov8s.py:762 — post-upsample flatten (yolov8s C=256)
+    ("upsample_flatten_s", (1, 40, 40, 256), (1, 1, 1600, 256)),
+    # tt_yolov8l_utils.py:110 — conv-bias reshape (C,) -> (1,1,1,C)
+    ("bias_reshape_l", (512,), (1, 1, 1, 512)),
+    ("bias_reshape_s", (256,), (1, 1, 1, 256)),
+]
+
+
+@U.with_default_mesh()
+@pytest.mark.parametrize(
+    "name, in_shape, out_shape",
+    [pytest.param(*s, id=s[0]) for s in _RESHAPE_SITES],
+)
+def test_reshape(ttnn_mesh_device, reset_seeds, name, in_shape, out_shape):
+    mesh = ttnn_mesh_device
+
+    x_torch = U.torch_rand(in_shape)
+    x = U.to_tt(x_torch, mesh, layout=ttnn.ROW_MAJOR_LAYOUT)
+
+    out = ttnn.reshape(x, list(out_shape))
+
+    ref = torch.reshape(x_torch.float(), out_shape)
+    U.assert_pcc(ref, out, pcc=0.999, mesh_device=mesh)
+
+
+# =============================================================================
+# Model-faithful variant: reproduce the model's REAL layout / buffer state.
+# =============================================================================
+
+# The DFL reshapes run on TILE_LAYOUT in L1 (memory_config=_DETECT_MEM_CONFIG, which
+# is ttnn.L1_MEMORY_CONFIG at 640x640). The existing ``test_reshape`` covers the safe
+# ROW_MAJOR path; these reproduce the model's actual TILE/L1 state.
+#
+# (id, in_shape, out_shape, model_line).
+_DFL_RESHAPE_SITES = [
+    # ttnn_yolov8l.py:644 — DFL reg reshape (b,64,a)->(b,4,c1,a), c1=16: (1,64,8400)->(1,4,16,8400)
+    ("dfl_reg_split_tile", (1, 64, 8400), (1, 4, 16, 8400), 644),
+    # ttnn_yolov8l.py:651 — DFL final reshape (b,1,4,a)->(b,4,a): (1,1,4,8400)->(1,4,8400)
+    ("dfl_final_tile", (1, 1, 4, 8400), (1, 4, 8400), 651),
+]
+
+
+@pytest.mark.blackhole_scale
+@U.with_default_mesh()
+@pytest.mark.parametrize(
+    "name, in_shape, out_shape, model_line",
+    [pytest.param(*s, id=s[0]) for s in _DFL_RESHAPE_SITES],
+)
+def test_reshape_tile_dfl(ttnn_mesh_device, reset_seeds, name, in_shape, out_shape, model_line):
+    """Model-faithful ``ttnn.reshape`` on TILE / L1 — the DFL reg / final reshapes.
+
+    The DFL head reshapes the reg-distance tensor while still in TILE_LAYOUT in L1:
+
+        x = ttnn.reshape(x, (b, 4, c1, a), memory_config=_DETECT_MEM_CONFIG)   # :644
+        ...
+        x = ttnn.reshape(x, (x.shape[0], x.shape[1] * x.shape[2], x.shape[3])) # :651
+
+    At 640x640 ``_DETECT_MEM_CONFIG == ttnn.L1_MEMORY_CONFIG``. The anchor dim (8400)
+    is NOT tile-aligned (8400 = 262.5 * 32), so a TILE-layout reshape that re-splits
+    the row/channel dims of this tensor is finicky (the same class of hazard as the
+    split issue #17017). We build it exactly as the model does; reshape is
+    value-preserving so the reference is ``torch.reshape`` at PCC 0.999.
+
+    If a Quasar/ttnn TILE reshape rejects the non-tile-aligned shape at runtime, this
+    documents that the isolated op cannot reproduce the layout the model relies on
+    (the reason surfaces as the op's own tile-alignment error).
+
+    Model call sites (branch ``origin/sdawle/yolov8_bh``):
+      * models/demos/yolov8l/tt/ttnn_yolov8l.py:644 (reg split), :651 (final)
+        (same op at models/demos/yolov8s/tt/ttnn_yolov8s.py:507 / :519)
+    """
+    mesh = ttnn_mesh_device
+
+    x_torch = U.torch_rand(in_shape)
+    x = U.to_tile_l1(x_torch, mesh)
+
+    out = ttnn.reshape(x, list(out_shape))
+
+    ref = torch.reshape(x_torch.float(), out_shape)
+    U.assert_pcc(ref, out, pcc=0.999, mesh_device=mesh)

--- a/models/experimental/ops/quasar/tests/yolo_ops/test_reshard.py
+++ b/models/experimental/ops/quasar/tests/yolo_ops/test_reshard.py
@@ -1,0 +1,117 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Per-op test: ``ttnn.reshard`` (YOLOv8, 640x640, batch 1).
+
+When a pre-upsample feature map is already sharded, the neck reshards it into the
+target HEIGHT-shard config instead of going through interleaved:
+
+    if sppf_9.is_sharded():
+        sppf_9 = ttnn.reshard(sppf_9, shardspec)     # sharded -> sharded (new grid)
+    else:
+        sppf_9 = ttnn.interleaved_to_sharded(sppf_9, shardspec)
+
+``reshard`` moves shards between core grids without changing values, so a
+round-trip interleaved -> shard(grid A) -> reshard(grid B) -> interleaved must
+return the original (PCC 0.999).
+
+Model call sites (branch ``origin/sdawle/yolov8_bh``):
+  * models/demos/yolov8l/tt/ttnn_yolov8l.py:1025 (sppf_9), :1057 (c2f_12)
+  * models/demos/yolov8s/tt/ttnn_yolov8s.py:756 (sppf_9), :787 (c2f_12)
+
+Uses HEIGHT sharding of a [1,1,64,C] tensor across 2 cores, then reshards onto a
+single core (shard height 32 -> 64). Requires a device with >=2 cores. Neck
+channel widths are the standard YOLOv8l/s sizes (not load-bearing).
+"""
+
+import pytest
+
+import ttnn
+from models.experimental.ops.quasar.tests.yolo_ops import op_utils as U
+
+
+def _height_sharded(core_grid, shard_h, shard_w):
+    return ttnn.create_sharded_memory_config(
+        (shard_h, shard_w),
+        core_grid,
+        ttnn.ShardStrategy.HEIGHT,
+        ttnn.ShardOrientation.ROW_MAJOR,
+        use_height_and_width_as_shard_shape=True,
+    )
+
+
+@U.with_default_mesh()
+@pytest.mark.parametrize(
+    "shape",
+    [
+        pytest.param((1, 1, 64, 512), id="l-64x512"),  # ttnn_yolov8l.py:1025 (yolov8l neck)
+        pytest.param((1, 1, 64, 256), id="s-64x256"),  # ttnn_yolov8s.py:756 (yolov8s neck)
+    ],
+)
+def test_reshard(ttnn_mesh_device, reset_seeds, shape):
+    mesh = ttnn_mesh_device
+
+    grid = mesh.compute_with_storage_grid_size()
+    if grid.x * grid.y < 2:
+        pytest.skip("reshard round-trip needs >=2 cores")
+
+    h, w = shape[-2], shape[-1]
+    x_torch = U.torch_rand(shape)
+    x = U.to_tt(x_torch, mesh)  # interleaved DRAM
+
+    # grid A: 2 cores (shard height h//2); grid B: 1 core (shard height h).
+    cfg_a = _height_sharded(ttnn.CoreGrid(y=1, x=2), h // 2, w)
+    cfg_b = _height_sharded(ttnn.CoreGrid(y=1, x=1), h, w)
+
+    x_sharded = ttnn.interleaved_to_sharded(x, cfg_a)
+    x_reshard = ttnn.reshard(x_sharded, cfg_b)
+    assert x_reshard.is_sharded(), "expected a sharded output"
+
+    out = ttnn.sharded_to_interleaved(x_reshard, ttnn.L1_MEMORY_CONFIG)
+    U.assert_pcc(x_torch, out, pcc=0.999, mesh_device=mesh)
+
+
+# --- model-faithful: HEIGHT-shard -> reshard to the real neck HEIGHT grid. ----------------
+#
+# When a pre-upsample feature map is already sharded, the neck reshards it (HEIGHT -> HEIGHT
+# on a new grid) instead of going through interleaved (ttnn_yolov8l.py:1024-1028 sppf_9,
+# :1056-1061 c2f_12):
+#
+#     num_cores = determine_num_cores(nhw, sppf_9.shape[2])   # width arg = out_w, NOT C
+#     shardspec = create_sharded_memory_config_(shape, get_core_grid_from_num_cores(...), HEIGHT)
+#     if sppf_9.is_sharded():
+#         sppf_9 = ttnn.reshard(sppf_9, shardspec)
+#
+# The model target grids are 20 cores (sppf_9 nhw=400,w=20) and 40 cores (c2f_12 nhw=1600,
+# w=40). The prior (source) shard grid isn't uniquely recoverable, so we shard onto a
+# coarser grid first, then reshard onto the model's target grid; both grids divide nhw
+# evenly (one/several image rows per core). Value-preserving, so the interleaved round-trip
+# must return the original.
+@U.with_default_mesh()
+@pytest.mark.blackhole_scale
+@pytest.mark.parametrize(
+    "site, src_cores, dst_cores, shape",
+    [
+        # sppf_9 @20x20, C=512 (ttnn_yolov8l.py:1025); target determine_num_cores(400,20)=20.
+        # source 10 cores (400/10=40 -> 2 rows/core) -> reshard to 20 cores (1 row/core).
+        pytest.param("sppf_9", 10, 20, (1, 1, 400, 512), id="sppf9-reshard-10c-to-20c-400x512"),
+        # c2f_12 @40x40, C=512 (ttnn_yolov8l.py:1057); target determine_num_cores(1600,40)=40.
+        # source 20 cores (1600/20=80 -> 2 rows/core) -> reshard to 40 cores (1 row/core).
+        pytest.param("c2f_12", 20, 40, (1, 1, 1600, 512), id="c2f12-reshard-20c-to-40c-1600x512"),
+    ],
+)
+def test_reshard_multicore(ttnn_mesh_device, reset_seeds, site, src_cores, dst_cores, shape):
+    mesh = ttnn_mesh_device
+    x_torch = U.torch_rand(shape)
+    x = U.to_tt(x_torch, mesh, layout=ttnn.ROW_MAJOR_LAYOUT, memory_config=ttnn.L1_MEMORY_CONFIG)
+
+    cfg_src = U.height_sharded_memcfg(mesh, src_cores, shape)  # skips if device < src_cores
+    cfg_dst = U.height_sharded_memcfg(mesh, dst_cores, shape)  # skips if device < dst_cores
+
+    x_sharded = ttnn.interleaved_to_sharded(x, cfg_src)
+    x_reshard = ttnn.reshard(x_sharded, cfg_dst)
+    assert x_reshard.is_sharded(), "expected a sharded output"
+
+    out = ttnn.sharded_to_interleaved(x_reshard, ttnn.L1_MEMORY_CONFIG)
+    U.assert_pcc(x_torch, out, pcc=0.999, mesh_device=mesh)

--- a/models/experimental/ops/quasar/tests/yolo_ops/test_reshard.py
+++ b/models/experimental/ops/quasar/tests/yolo_ops/test_reshard.py
@@ -69,7 +69,7 @@ def test_reshard(ttnn_mesh_device, reset_seeds, shape):
     assert x_reshard.is_sharded(), "expected a sharded output"
 
     out = ttnn.sharded_to_interleaved(x_reshard, ttnn.L1_MEMORY_CONFIG)
-    U.assert_pcc(x_torch, out, pcc=0.999, mesh_device=mesh)
+    U.assert_lossless(x_torch, out, mesh_device=mesh)
 
 
 # --- model-faithful: HEIGHT-shard -> reshard to the real neck HEIGHT grid. ----------------
@@ -114,4 +114,4 @@ def test_reshard_multicore(ttnn_mesh_device, reset_seeds, site, src_cores, dst_c
     assert x_reshard.is_sharded(), "expected a sharded output"
 
     out = ttnn.sharded_to_interleaved(x_reshard, ttnn.L1_MEMORY_CONFIG)
-    U.assert_pcc(x_torch, out, pcc=0.999, mesh_device=mesh)
+    U.assert_lossless(x_torch, out, mesh_device=mesh)

--- a/models/experimental/ops/quasar/tests/yolo_ops/test_sharded_to_interleaved.py
+++ b/models/experimental/ops/quasar/tests/yolo_ops/test_sharded_to_interleaved.py
@@ -1,0 +1,129 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Per-op test: ``ttnn.sharded_to_interleaved`` (YOLOv8, 640x640, batch 1).
+
+Every neck stage un-shards its conv output back to an interleaved L1/DRAM tensor
+before the next reshape / concat:
+
+    c2f_6 = ttnn.sharded_to_interleaved(c2f_6, ttnn.L1_MEMORY_CONFIG)
+
+It is the inverse of ``interleaved_to_sharded`` and value-preserving, so the full
+round-trip interleaved -> shard -> unshard must return the original (PCC 0.999).
+
+Model call sites (branch ``origin/sdawle/yolov8_bh``, representative):
+  * models/demos/yolov8l/tt/ttnn_yolov8l.py:65,72,76,88,106,131,265,319,609,
+    1004,1042,1063,1081,1085,1088,1095,1099,1107
+  * models/demos/yolov8s/tt/ttnn_yolov8s.py:68,105,235,737,774,802,806,809,816,820,829
+
+Single-core grid, so the passed shape [1,1,32,C] is the exact per-core shard
+shape. Neck channel widths are the standard YOLOv8l/s sizes (not load-bearing).
+"""
+
+import pytest
+
+import ttnn
+from models.experimental.ops.quasar.tests.yolo_ops import op_utils as U
+
+_GRID = ttnn.CoreGrid(y=1, x=1)
+
+
+def _sharded_cfg(h, w, strategy):
+    return ttnn.create_sharded_memory_config(
+        (h, w),
+        _GRID,
+        strategy,
+        ttnn.ShardOrientation.ROW_MAJOR,
+        use_height_and_width_as_shard_shape=True,
+    )
+
+
+# (id, shape, strategy) — shard shape is (shape[-2], shape[-1]).
+_CASES = [
+    pytest.param((1, 1, U.TILE, 512), ttnn.ShardStrategy.WIDTH, id="l-width-32x512"),  # yolov8l neck
+    pytest.param((1, 1, U.TILE, 256), ttnn.ShardStrategy.WIDTH, id="s-width-32x256"),  # yolov8s neck
+    pytest.param((1, 1, U.TILE, 128), ttnn.ShardStrategy.HEIGHT, id="height-32x128"),  # height-shard round-trip
+]
+
+
+@U.with_default_mesh()
+@pytest.mark.parametrize("shape, strategy", _CASES)
+def test_sharded_to_interleaved(ttnn_mesh_device, reset_seeds, shape, strategy):
+    mesh = ttnn_mesh_device
+
+    x_torch = U.torch_rand(shape)
+    x = U.to_tt(x_torch, mesh)  # interleaved DRAM
+
+    memcfg = _sharded_cfg(shape[-2], shape[-1], strategy)
+    x_sharded = ttnn.interleaved_to_sharded(x, memcfg)
+    out = ttnn.sharded_to_interleaved(x_sharded, ttnn.L1_MEMORY_CONFIG)
+
+    assert not out.is_sharded(), "expected an interleaved output"
+    U.assert_pcc(x_torch, out, pcc=0.999, mesh_device=mesh)
+
+
+# --- model-faithful: un-shard a HEIGHT-sharded concat output on the SPPF grid. ------------
+#
+# Every ``sharded_concat`` ends by un-sharding its HEIGHT-sharded output back to
+# interleaved L1 (ttnn_yolov8l.py:65,88,131 ... ``sharded_to_interleaved(out, L1)``). The
+# source is HEIGHT-sharded over the full SPPF grid (_SPPF_NUM_CORES = 64 / 80,
+# ttnn_yolov8l.py:21-22,777-781) at the neck's flattened feature shape [1,1,H*W,C].
+# Value-preserving, so interleaved -> HEIGHT-shard -> unshard must return the original.
+@U.with_default_mesh()
+@pytest.mark.blackhole_scale
+@pytest.mark.parametrize(
+    "variant, num_cores, shape",
+    [
+        # yolov8l: _SPPF_NUM_CORES=64 (8x8), sppf concat @40x40 -> 1600 // 64 = 25.
+        pytest.param("yolov8l", 64, (1, 1, 1600, 512), id="l-height-64c-1600x512"),
+        # yolov8s: _SPPF_NUM_CORES=80 (10x8), 1600 // 80 = 20.
+        pytest.param("yolov8s", 80, (1, 1, 1600, 256), id="s-height-80c-1600x256"),
+    ],
+)
+def test_sharded_to_interleaved_height(ttnn_mesh_device, reset_seeds, variant, num_cores, shape):
+    mesh = ttnn_mesh_device
+    x_torch = U.torch_rand(shape)
+    x = U.to_tt(x_torch, mesh, layout=ttnn.ROW_MAJOR_LAYOUT, memory_config=ttnn.L1_MEMORY_CONFIG)
+
+    sharded = U.height_sharded_memcfg(mesh, num_cores, shape)  # skips if device < num_cores
+    x_sharded = ttnn.to_memory_config(x, sharded)
+    assert x_sharded.is_sharded(), "expected a HEIGHT_SHARDED source"
+
+    out = ttnn.sharded_to_interleaved(x_sharded, ttnn.L1_MEMORY_CONFIG)
+    assert not out.is_sharded(), "expected an interleaved output"
+    U.assert_pcc(x_torch, out, pcc=0.999, mesh_device=mesh)
+
+
+# --- model-faithful: un-shard a BLOCK-sharded conv output. -------------------------------
+#
+# The ``block_shard=True`` convs (c2f_6 :1004, c2f_12 :1042, conv_16 :1085, conv_19 :1099,
+# c2f_21 :1107) emit BLOCK-sharded activations that the neck un-shards to interleaved L1
+# right after (ttnn_yolov8l.py:1004 ``sharded_to_interleaved(c2f_6, L1)``). We reproduce a
+# BLOCK-sharded source on the compute grid and round-trip it. The exact conv block grid is
+# chosen internally by conv2d and not recoverable here, so we use the full 8x8 grid (a
+# documented best estimate; the helper skips if the device is smaller) with a flattened
+# feature shape whose H*W and C divide the grid.
+@U.with_default_mesh()
+@pytest.mark.blackhole_scale
+@pytest.mark.parametrize(
+    "site, grid_y, grid_x, shape",
+    [
+        # c2f_6 @40x40, C=512 (configs.json c2f_configs["model.6"].cv2 out=512); 1600/8=200, 512/8=64.
+        pytest.param("c2f_6", 8, 8, (1, 1, 1600, 512), id="c2f6-block-8x8-1600x512"),
+        # c2f_21 @20x20, C=512 (configs.json c2f_configs["model.21"].cv2 out=512); 400/8=50, 512/8=64.
+        pytest.param("c2f_21", 8, 8, (1, 1, 400, 512), id="c2f21-block-8x8-400x512"),
+    ],
+)
+def test_sharded_to_interleaved_block(ttnn_mesh_device, reset_seeds, site, grid_y, grid_x, shape):
+    mesh = ttnn_mesh_device
+    x_torch = U.torch_rand(shape)
+    x = U.to_tt(x_torch, mesh, layout=ttnn.ROW_MAJOR_LAYOUT, memory_config=ttnn.L1_MEMORY_CONFIG)
+
+    sharded = U.block_sharded_memcfg(mesh, grid_y, grid_x, shape)  # skips if grid doesn't fit
+    x_sharded = ttnn.to_memory_config(x, sharded)
+    assert x_sharded.is_sharded(), "expected a BLOCK_SHARDED source"
+
+    out = ttnn.sharded_to_interleaved(x_sharded, ttnn.L1_MEMORY_CONFIG)
+    assert not out.is_sharded(), "expected an interleaved output"
+    U.assert_pcc(x_torch, out, pcc=0.999, mesh_device=mesh)

--- a/models/experimental/ops/quasar/tests/yolo_ops/test_sharded_to_interleaved.py
+++ b/models/experimental/ops/quasar/tests/yolo_ops/test_sharded_to_interleaved.py
@@ -60,7 +60,7 @@ def test_sharded_to_interleaved(ttnn_mesh_device, reset_seeds, shape, strategy):
     out = ttnn.sharded_to_interleaved(x_sharded, ttnn.L1_MEMORY_CONFIG)
 
     assert not out.is_sharded(), "expected an interleaved output"
-    U.assert_pcc(x_torch, out, pcc=0.999, mesh_device=mesh)
+    U.assert_lossless(x_torch, out, mesh_device=mesh)
 
 
 # --- model-faithful: un-shard a HEIGHT-sharded concat output on the SPPF grid. ------------
@@ -92,7 +92,7 @@ def test_sharded_to_interleaved_height(ttnn_mesh_device, reset_seeds, variant, n
 
     out = ttnn.sharded_to_interleaved(x_sharded, ttnn.L1_MEMORY_CONFIG)
     assert not out.is_sharded(), "expected an interleaved output"
-    U.assert_pcc(x_torch, out, pcc=0.999, mesh_device=mesh)
+    U.assert_lossless(x_torch, out, mesh_device=mesh)
 
 
 # --- model-faithful: un-shard a BLOCK-sharded conv output. -------------------------------
@@ -126,4 +126,4 @@ def test_sharded_to_interleaved_block(ttnn_mesh_device, reset_seeds, site, grid_
 
     out = ttnn.sharded_to_interleaved(x_sharded, ttnn.L1_MEMORY_CONFIG)
     assert not out.is_sharded(), "expected an interleaved output"
-    U.assert_pcc(x_torch, out, pcc=0.999, mesh_device=mesh)
+    U.assert_lossless(x_torch, out, mesh_device=mesh)

--- a/models/experimental/ops/quasar/tests/yolo_ops/test_sigmoid.py
+++ b/models/experimental/ops/quasar/tests/yolo_ops/test_sigmoid.py
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Per-op test: ``ttnn.sigmoid``  (YOLOv8 detect head).
+
+Model call site:
+  * yolov8l  ttnn_yolov8l.py:757  return [ttnn.concat((dbox, ttnn.sigmoid(cls)), dim=1, ...), x]
+  * yolov8s  ttnn_yolov8s.py:578  (identical detect head)
+
+``cls`` is the class-logits half of the concatenated detect output, sliced out at
+ttnn_yolov8l.py:748 (``cls = ttnn.slice(x_cat, [0, 64, 0], [1, 144, A])``), i.e.
+shape ``[1, nc=80, A]`` where ``A`` is the total anchor count over the 3 detect
+scales (80/40/20 for 640x640 -> 8400; 160/80/40 for 1280x1280 -> 33600).
+
+nc/reg_max come from TtDetect.__call__ (yolov8l.py:725-729: nc=80, no=nc+reg_max*4).
+The detect head is IDENTICAL for yolov8l and yolov8s; only yolov8l also runs at
+1280 (test_yolov8l.py parametrizes input_res [640, 1280]); yolov8s is 640 only
+(test_yolov8s.py: torch.rand((1, 3, 640, 640))).
+
+Reference: torch.sigmoid.  PCC 0.99.
+"""
+
+import pytest
+import torch
+
+import ttnn
+from models.experimental.ops.quasar.tests.yolo_ops import op_utils as U
+
+# Total detect-head anchor count A = sum(h*w) over the 3 scales, per input res.
+#   640  -> 80^2 + 40^2 + 20^2  = 8400
+#   1280 -> 160^2 + 80^2 + 40^2 = 33600
+_NC = 80  # yolov8{l,s} TtDetect nc (ttnn_yolov8l.py:662 / ttnn_yolov8s.py:519)
+
+# (id, cls_shape) — cls = [1, nc, A]. shape tuple param so conftest classifies by
+# element count (only the 640 case is small enough for the emulator).
+_CLS_SITES = [
+    pytest.param((1, _NC, 8400), id="l_s-640-cls"),  # yolov8l & yolov8s @ 640
+    pytest.param((1, _NC, 33600), id="l-1280-cls"),  # yolov8l @ 1280 only
+]
+
+
+@U.with_default_mesh()
+@pytest.mark.parametrize("shape", _CLS_SITES)
+def test_sigmoid(ttnn_mesh_device, reset_seeds, shape):
+    mesh = ttnn_mesh_device
+
+    x_torch = U.torch_rand(shape)
+    x = U.to_tt(x_torch, mesh)
+
+    out = ttnn.sigmoid(x)
+
+    ref = torch.sigmoid(x_torch.float())
+    U.assert_pcc(ref, out, pcc=0.99, mesh_device=mesh)
+
+
+# ---------------------------------------------------------------------------
+# Model-faithful (class C): L1-interleaved TILE input, matching the real detect
+# head buffer state. TtDetectionModel sets _DETECT_MEM_CONFIG = L1_MEMORY_CONFIG
+# for res <= 640 (ttnn_yolov8l.py:772-773); the sigmoid at ttnn_yolov8l.py:757
+# runs on _DETECT_MEM_CONFIG, i.e. L1 (not DRAM) at 640. Same shapes as
+# test_sigmoid, only the input memory_config changes DRAM -> L1.
+# ---------------------------------------------------------------------------
+@pytest.mark.blackhole_scale
+@U.with_default_mesh()
+@pytest.mark.parametrize("shape", _CLS_SITES)
+def test_sigmoid_l1(ttnn_mesh_device, reset_seeds, shape):
+    """sigmoid(cls) on L1 detect buffer (ttnn_yolov8l.py:757, mem cfg :772-773)."""
+    mesh = ttnn_mesh_device
+
+    x_torch = U.torch_rand(shape)
+    x = U.to_tile_l1(x_torch, mesh)
+
+    out = ttnn.sigmoid(x)
+
+    ref = torch.sigmoid(x_torch.float())
+    U.assert_pcc(ref, out, pcc=0.99, mesh_device=mesh)

--- a/models/experimental/ops/quasar/tests/yolo_ops/test_slice.py
+++ b/models/experimental/ops/quasar/tests/yolo_ops/test_slice.py
@@ -51,7 +51,7 @@ def test_slice(ttnn_mesh_device, reset_seeds, name, start_c, end_c):
     out = ttnn.slice(x, [0, start_c, 0], [1, end_c, _N])
 
     ref = x_torch.float()[0:1, start_c:end_c, 0:_N]
-    U.assert_pcc(ref, out, pcc=0.999, mesh_device=mesh)
+    U.assert_lossless(ref, out, mesh_device=mesh)
 
 
 # =============================================================================
@@ -91,4 +91,4 @@ def test_slice_tile(ttnn_mesh_device, reset_seeds, name, start_c, end_c):
     out = ttnn.slice(x, [0, start_c, 0], [1, end_c, _N])
 
     ref = x_torch.float()[0:1, start_c:end_c, 0:_N]
-    U.assert_pcc(ref, out, pcc=0.999, mesh_device=mesh)
+    U.assert_lossless(ref, out, mesh_device=mesh)

--- a/models/experimental/ops/quasar/tests/yolo_ops/test_slice.py
+++ b/models/experimental/ops/quasar/tests/yolo_ops/test_slice.py
@@ -1,0 +1,94 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Per-op test: ``ttnn.slice`` (YOLOv8, 640x640, batch 1).
+
+The detect head splits the concatenated per-anchor prediction tensor
+``x_cat`` [1, 144, 8400] along the channel dim into the 64 box-regression
+channels and the 80 class channels:
+
+    box = ttnn.slice(x_cat, [0, 0, 0],  [1, 64, N])
+    cls = ttnn.slice(x_cat, [0, 64, 0], [1, 144, N])
+
+``ttnn.slice`` end coords are exclusive, so this is a plain channel narrow.
+Value-preserving -> torch reference is ``x[..., start:end, :]``; PCC 0.999.
+Uploaded ROW_MAJOR so the narrow is exact.
+
+Model call sites (branch ``origin/sdawle/yolov8_bh``):
+  * models/demos/yolov8l/tt/ttnn_yolov8l.py:747 (box), :748 (cls)
+  * models/demos/yolov8s/tt/ttnn_yolov8s.py:568 (box), :569 (cls)
+
+Detect head at 640 input -> anchor count 8400 (80*80+40*40+20*20),
+no = nc + reg_max*4 = 80 + 64 = 144.
+"""
+
+import pytest
+
+import ttnn
+from models.experimental.ops.quasar.tests.yolo_ops import op_utils as U
+
+_N = 8400  # anchor count at 640x640
+
+# (id, start_c, end_c) — channel slice of x_cat [1, 144, 8400].
+_SLICE_SITES = [
+    ("box_0_64", 0, 64),  # ttnn_yolov8l.py:747 / ttnn_yolov8s.py:568
+    ("cls_64_144", 64, 144),  # ttnn_yolov8l.py:748 / ttnn_yolov8s.py:569
+]
+
+
+@U.with_default_mesh()
+@pytest.mark.parametrize(
+    "name, start_c, end_c",
+    [pytest.param(*s, id=s[0]) for s in _SLICE_SITES],
+)
+def test_slice(ttnn_mesh_device, reset_seeds, name, start_c, end_c):
+    mesh = ttnn_mesh_device
+
+    x_torch = U.torch_rand((1, 144, _N))
+    x = U.to_tt(x_torch, mesh, layout=ttnn.ROW_MAJOR_LAYOUT)
+
+    out = ttnn.slice(x, [0, start_c, 0], [1, end_c, _N])
+
+    ref = x_torch.float()[0:1, start_c:end_c, 0:_N]
+    U.assert_pcc(ref, out, pcc=0.999, mesh_device=mesh)
+
+
+# =============================================================================
+# Model-faithful variant: reproduce the model's REAL layout / buffer state.
+# =============================================================================
+
+
+@pytest.mark.blackhole_scale
+@U.with_default_mesh()
+@pytest.mark.parametrize(
+    "name, start_c, end_c",
+    [pytest.param(*s, id=s[0] + "_tile") for s in _SLICE_SITES],
+)
+def test_slice_tile(ttnn_mesh_device, reset_seeds, name, start_c, end_c):
+    """Model-faithful ``ttnn.slice`` on TILE / L1 — the detect box/cls channel split.
+
+    The detect head slices ``x_cat`` while it is in TILE_LAYOUT, passing
+    ``memory_config=_DETECT_MEM_CONFIG`` (== ttnn.L1_MEMORY_CONFIG at 640x640):
+
+        box = ttnn.slice(x_cat, [0, 0, 0],  [1, 64, N],  memory_config=_DETECT_MEM_CONFIG)  # :747
+        cls = ttnn.slice(x_cat, [0, 64, 0], [1, 144, N], memory_config=_DETECT_MEM_CONFIG)  # :748
+
+    This narrows the channel dim (dim 1) of a TILE-padded, non-tile-aligned (N=8400)
+    tensor. The box slice (0:64) and cls slice (64:144) both start on a 32-aligned
+    channel boundary. Slice is value-preserving; reference is the torch narrow at
+    PCC 0.999. The existing ``test_slice`` covers the ROW_MAJOR path.
+
+    Model call sites (branch ``origin/sdawle/yolov8_bh``):
+      * models/demos/yolov8l/tt/ttnn_yolov8l.py:747 (box), :748 (cls)
+        (same at models/demos/yolov8s/tt/ttnn_yolov8s.py:568 / :569)
+    """
+    mesh = ttnn_mesh_device
+
+    x_torch = U.torch_rand((1, 144, _N))
+    x = U.to_tile_l1(x_torch, mesh)
+
+    out = ttnn.slice(x, [0, start_c, 0], [1, end_c, _N])
+
+    ref = x_torch.float()[0:1, start_c:end_c, 0:_N]
+    U.assert_pcc(ref, out, pcc=0.999, mesh_device=mesh)

--- a/models/experimental/ops/quasar/tests/yolo_ops/test_softmax.py
+++ b/models/experimental/ops/quasar/tests/yolo_ops/test_softmax.py
@@ -1,0 +1,73 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Per-op test: ``ttnn.softmax``  (YOLOv8 detect-head DFL).
+
+Model call site (Distribution Focal Loss decode):
+  * yolov8l  ttnn_yolov8l.py:644-645
+        x = ttnn.reshape(x, (b, 4, c1, a), ...)   # c1 = reg_max = 16
+        x = ttnn.softmax(x, dim=2, ...)           # softmax over the reg_max axis
+  * yolov8s  ttnn_yolov8s.py:507-508  (identical)
+
+The DFL input is ``box`` = ``[1, 64, A]`` (ttnn_yolov8l.py:747, 64 = reg_max*4),
+reshaped to ``[b, 4, c1=16, a=A]`` (TtDFL.__call__, c1=16 default at :642) and
+softmaxed over dim=2 (the reg_max=16 axis). ``A`` = total detect anchors
+(8400 @ 640, 33600 @ 1280). Detect head is identical for yolov8l/yolov8s; only
+yolov8l also runs 1280.
+
+Note: reg_max=16 is not tile-aligned; ttnn pads to 32 in TILE layout but tracks the
+logical width, so the softmax reduction must respect the logical 16. Reference is
+torch.softmax over the same logical shape.  PCC 0.99.
+"""
+
+import pytest
+import torch
+
+import ttnn
+from models.experimental.ops.quasar.tests.yolo_ops import op_utils as U
+
+_REG_MAX = 16  # c1 (TtDFL.__call__ default, ttnn_yolov8l.py:642)
+
+# (id, dfl_shape) — [b, 4, reg_max, A]; softmax dim=2. shape tuple param -> conftest
+# classifies by element count (both are large -> Blackhole, not emulator).
+_DFL_SITES = [
+    pytest.param((1, 4, _REG_MAX, 8400), id="l_s-640-dfl"),  # yolov8l & yolov8s @ 640
+    pytest.param((1, 4, _REG_MAX, 33600), id="l-1280-dfl"),  # yolov8l @ 1280 only
+]
+
+
+@U.with_default_mesh()
+@pytest.mark.parametrize("shape", _DFL_SITES)
+def test_softmax(ttnn_mesh_device, reset_seeds, shape):
+    mesh = ttnn_mesh_device
+
+    x_torch = U.torch_rand(shape)
+    x = U.to_tt(x_torch, mesh)
+
+    out = ttnn.softmax(x, dim=2)
+
+    ref = torch.softmax(x_torch.float(), dim=2)
+    U.assert_pcc(ref, out, pcc=0.99, mesh_device=mesh)
+
+
+# ---------------------------------------------------------------------------
+# Model-faithful (class C): L1-interleaved TILE input, matching the real DFL
+# buffer state. The DFL softmax at ttnn_yolov8l.py:645 runs on _DETECT_MEM_CONFIG,
+# which TtDetectionModel pins to L1_MEMORY_CONFIG for res <= 640
+# (ttnn_yolov8l.py:772-773). Same shapes as test_softmax, DRAM -> L1 input only.
+# ---------------------------------------------------------------------------
+@pytest.mark.blackhole_scale
+@U.with_default_mesh()
+@pytest.mark.parametrize("shape", _DFL_SITES)
+def test_softmax_l1(ttnn_mesh_device, reset_seeds, shape):
+    """DFL softmax(dim=2) on L1 detect buffer (ttnn_yolov8l.py:645, mem cfg :772-773)."""
+    mesh = ttnn_mesh_device
+
+    x_torch = U.torch_rand(shape)
+    x = U.to_tile_l1(x_torch, mesh)
+
+    out = ttnn.softmax(x, dim=2)
+
+    ref = torch.softmax(x_torch.float(), dim=2)
+    U.assert_pcc(ref, out, pcc=0.99, mesh_device=mesh)

--- a/models/experimental/ops/quasar/tests/yolo_ops/test_split.py
+++ b/models/experimental/ops/quasar/tests/yolo_ops/test_split.py
@@ -49,7 +49,7 @@ def test_split(ttnn_mesh_device, reset_seeds, shape):
 
     refs = torch.split(x_torch.float(), split_size, dim=dim)
     for ref, part in zip(refs, parts):
-        U.assert_pcc(ref, part, pcc=0.999, mesh_device=mesh)
+        U.assert_lossless(ref, part, mesh_device=mesh)
 
 
 # =============================================================================
@@ -96,4 +96,4 @@ def test_split_tile(ttnn_mesh_device, reset_seeds, shape):
 
     refs = torch.split(x_torch.float(), split_size, dim=dim)
     for ref, part in zip(refs, parts):
-        U.assert_pcc(ref, part, pcc=0.999, mesh_device=mesh)
+        U.assert_lossless(ref, part, mesh_device=mesh)

--- a/models/experimental/ops/quasar/tests/yolo_ops/test_split.py
+++ b/models/experimental/ops/quasar/tests/yolo_ops/test_split.py
@@ -1,0 +1,99 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Per-op test: ``ttnn.split`` (YOLOv8, 640x640, batch 1).
+
+``dist2bbox`` (``ttnn_decode_bboxes``) splits the DFL distance tensor
+[1, 4, 8400] along dim 1 into the left-top and right-bottom offset pairs
+(2 coords each):
+
+    lt, rb = ttnn.split(distance, 2, 1)   # split_size=2, dim=1 -> two [1,2,8400]
+
+``ttnn.split`` here is value-preserving (a straight partition), so each half is
+compared against ``torch.split`` with PCC 0.999. Uploaded ROW_MAJOR so the
+partition is exact.
+
+Model call sites (branch ``origin/sdawle/yolov8_bh``):
+  * models/demos/yolov8l/tt/tt_yolov8l_utils.py:92
+  * models/demos/yolov8s/tt/tt_yolov8s_utils.py:90
+
+The DFL distance tensor is (1, 4, 8400): 4 = reg_max(16) reduced to 1 per each of
+the 4 box edges, over 8400 anchors at 640x640.
+"""
+
+import pytest
+import torch
+
+import ttnn
+from models.experimental.ops.quasar.tests.yolo_ops import op_utils as U
+
+
+@U.with_default_mesh()
+@pytest.mark.parametrize(
+    "shape",
+    [
+        # tt_yolov8l_utils.py:92 / tt_yolov8s_utils.py:90 — distance (1,4,8400)
+        pytest.param((1, 4, 8400), id="dist2bbox_4x8400"),
+    ],
+)
+def test_split(ttnn_mesh_device, reset_seeds, shape):
+    mesh = ttnn_mesh_device
+    split_size, dim = 2, 1
+
+    x_torch = U.torch_rand(shape)
+    x = U.to_tt(x_torch, mesh, layout=ttnn.ROW_MAJOR_LAYOUT)
+
+    parts = ttnn.split(x, split_size, dim)
+    assert len(parts) == 2, f"expected 2 splits, got {len(parts)}"
+
+    refs = torch.split(x_torch.float(), split_size, dim=dim)
+    for ref, part in zip(refs, parts):
+        U.assert_pcc(ref, part, pcc=0.999, mesh_device=mesh)
+
+
+# =============================================================================
+# Model-faithful variant: reproduce the model's REAL layout / buffer state.
+# =============================================================================
+
+
+@pytest.mark.blackhole_scale
+@U.with_default_mesh()
+@pytest.mark.parametrize(
+    "shape",
+    [
+        # tt_yolov8l_utils.py:92 / tt_yolov8s_utils.py:90 — distance (1,4,8400)
+        pytest.param((1, 4, 8400), id="dist2bbox_4x8400_tile_l1"),
+    ],
+)
+def test_split_tile(ttnn_mesh_device, reset_seeds, shape):
+    """Model-faithful ``ttnn.split`` on TILE / L1 (the model's actual layout).
+
+    ``dist2bbox`` runs ``lt, rb = ttnn.split(distance, 2, 1, memory_config=_DETECT_MEM_CONFIG)``
+    where at 640x640 ``_DETECT_MEM_CONFIG == ttnn.L1_MEMORY_CONFIG`` and ``distance``
+    reaches this call still in TILE_LAYOUT — the source itself flags this as risky:
+
+        lt, rb = ttnn.split(distance, 2, 1, ...)  # if done in tile : tt-metal issue #17017
+
+    This deliberately exercises that flagged TILE/L1 state (the existing ``test_split``
+    covers the safe ROW_MAJOR path). Split is value-preserving; each half is compared
+    against ``torch.split`` at PCC 0.999. Note the split is along dim=1 (size 4, split
+    size 2), i.e. across the tile-padded row dim of a non-tile-aligned (8400) tensor —
+    exactly the configuration issue #17017 warns about.
+
+    Model call sites (branch ``origin/sdawle/yolov8_bh``):
+      * models/demos/yolov8l/tt/tt_yolov8l_utils.py:92
+      * models/demos/yolov8s/tt/tt_yolov8s_utils.py:90
+    """
+    mesh = ttnn_mesh_device
+    split_size, dim = 2, 1
+
+    x_torch = U.torch_rand(shape)
+    x = U.to_tile_l1(x_torch, mesh)
+
+    parts = ttnn.split(x, split_size, dim)
+    assert len(parts) == 2, f"expected 2 splits, got {len(parts)}"
+
+    refs = torch.split(x_torch.float(), split_size, dim=dim)
+    for ref, part in zip(refs, parts):
+        U.assert_pcc(ref, part, pcc=0.999, mesh_device=mesh)

--- a/models/experimental/ops/quasar/tests/yolo_ops/test_subtract.py
+++ b/models/experimental/ops/quasar/tests/yolo_ops/test_subtract.py
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Per-op test: ``ttnn.subtract``  (YOLOv8 dist2bbox math).
+
+Model call sites:
+  * x1y1 = anchor_points - lt   (tt_yolov8l_utils.py:94 / tt_yolov8s_utils.py:92)
+        via `-` operator -> ttnn.subtract; [1,2,A] - [1,2,A]
+  * wh   = ttnn.subtract(x2y2, x1y1, dtype=bfloat8_b, ...)
+        (tt_yolov8l_utils.py:99 / tt_yolov8s_utils.py:97); [1,2,A] - [1,2,A]
+
+``lt, rb = ttnn.split(distance, 2, 1)`` -> each [1,2,A]; ``anchor_points`` /
+``x1y1`` / ``x2y2`` are all [1,2,A] (make_anchors ``a``, tt_yolov8l_utils.py:80).
+
+A = total detect anchors: 8400 @ 640, 33600 @ 1280 (yolov8l only). dist2bbox is
+identical for yolov8l/yolov8s. Model uses bfloat8_b; we use default bfloat16.
+Reference: torch a - b.  PCC 0.999.
+"""
+
+import pytest
+
+import ttnn
+from models.experimental.ops.quasar.tests.yolo_ops import op_utils as U
+
+# All subtract operands are [1, 2, A]. shape tuple param -> element-count classification.
+_SITES = [
+    pytest.param((1, 2, 8400), id="640"),  # yolov8l & yolov8s
+    pytest.param((1, 2, 33600), id="1280"),  # yolov8l only
+]
+
+
+@U.with_default_mesh()
+@pytest.mark.parametrize("shape", _SITES)
+def test_subtract(ttnn_mesh_device, reset_seeds, shape):
+    """anchor-lt / x2y2-x1y1 (tt_yolov8l_utils.py:94,99)."""
+    mesh = ttnn_mesh_device
+
+    a_torch = U.torch_rand(shape)
+    b_torch = U.torch_rand(shape)
+    a = U.to_tt(a_torch, mesh)
+    b = U.to_tt(b_torch, mesh)
+
+    out = ttnn.subtract(a, b)
+
+    ref = a_torch.float() - b_torch.float()
+    U.assert_pcc(ref, out, pcc=0.999, mesh_device=mesh)
+
+
+# ---------------------------------------------------------------------------
+# Model-faithful (class C): L1-interleaved TILE inputs. dist2bbox runs inside the
+# detect head; its operands live on _DETECT_MEM_CONFIG = L1_MEMORY_CONFIG for
+# res <= 640 (ttnn_yolov8l.py:772-773). Same shapes as test_subtract, DRAM -> L1.
+# ---------------------------------------------------------------------------
+@pytest.mark.blackhole_scale
+@U.with_default_mesh()
+@pytest.mark.parametrize("shape", _SITES)
+def test_subtract_l1(ttnn_mesh_device, reset_seeds, shape):
+    """anchor-lt / x2y2-x1y1 on L1 detect buffers (tt_yolov8l_utils.py:94,99; mem cfg ttnn_yolov8l.py:772-773)."""
+    mesh = ttnn_mesh_device
+
+    a_torch = U.torch_rand(shape)
+    b_torch = U.torch_rand(shape)
+    a = U.to_tile_l1(a_torch, mesh)
+    b = U.to_tile_l1(b_torch, mesh)
+
+    out = ttnn.subtract(a, b)
+
+    ref = a_torch.float() - b_torch.float()
+    U.assert_pcc(ref, out, pcc=0.999, mesh_device=mesh)

--- a/models/experimental/ops/quasar/tests/yolo_ops/test_subtract.py
+++ b/models/experimental/ops/quasar/tests/yolo_ops/test_subtract.py
@@ -64,7 +64,7 @@ def test_subtract_l1(ttnn_mesh_device, reset_seeds, shape):
     a = U.to_tile_l1(a_torch, mesh)
     b = U.to_tile_l1(b_torch, mesh)
 
-    out = ttnn.subtract(a, b)
+    out = ttnn.subtract(a, b, dtype=ttnn.bfloat8_b)
 
     ref = a_torch.float() - b_torch.float()
-    U.assert_pcc(ref, out, pcc=0.999, mesh_device=mesh)
+    U.assert_pcc(ref, out, pcc=0.99, mesh_device=mesh)

--- a/models/experimental/ops/quasar/tests/yolo_ops/test_to_dtype.py
+++ b/models/experimental/ops/quasar/tests/yolo_ops/test_to_dtype.py
@@ -8,12 +8,17 @@ The detect head casts decoded boxes to bfloat8_b before the stride multiply:
 
     # dbox = ttnn.to_dtype(dbox, dtype=ttnn.bfloat8_b)
 
-Note: in the shipped source this exact ``ttnn.to_dtype`` line is commented out
-(the cast is folded into the following ``ttnn.multiply(..., dtype=bfloat8_b)`` /
-``ttnn.to_memory_config(..., dtype=bfloat8_b)`` calls). It is still the model's
-declared dtype-conversion of ``dbox``, so it is exercised here directly. The cast
-is value-preserving up to precision, so the reference is ``x`` compared at PCC
-0.99 (bfloat8_b block-float target).
+Note: in the shipped source this exact ``ttnn.to_dtype`` line is commented out — the
+model's LIVE bf16->bfloat8_b cast is done via ``ttnn.to_memory_config(..., dtype=bfloat8_b)``
+(anchors/strides, ttnn_yolov8l.py:751,754) and ``ttnn.multiply(..., dtype=bfloat8_b)``,
+which are covered by ``test_to_memory_config_dtype_cast`` (test_to_memory_config.py) and
+``test_multiply``. This file keeps a direct check of the ``ttnn.to_dtype`` op itself for
+the model's declared dtype-conversion of ``dbox``.
+
+``ttnn.to_dtype`` is a **host-side** op — it operates on a host tensor (a device tensor
+trips ``host_storage != nullptr``), so this test does NOT exercise the device; it just
+verifies the host dtype conversion. The cast is value-preserving up to precision, so the
+reference is ``x`` compared at PCC 0.99 (bfloat8_b block-float target).
 
 Model call sites (branch ``origin/sdawle/yolov8_bh``):
   * models/demos/yolov8l/tt/ttnn_yolov8l.py:753  (# dbox = ttnn.to_dtype(dbox, dtype=ttnn.bfloat8_b))

--- a/models/experimental/ops/quasar/tests/yolo_ops/test_to_dtype.py
+++ b/models/experimental/ops/quasar/tests/yolo_ops/test_to_dtype.py
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Per-op test: ``ttnn.to_dtype`` (YOLOv8, 640x640, batch 1).
+
+The detect head casts decoded boxes to bfloat8_b before the stride multiply:
+
+    # dbox = ttnn.to_dtype(dbox, dtype=ttnn.bfloat8_b)
+
+Note: in the shipped source this exact ``ttnn.to_dtype`` line is commented out
+(the cast is folded into the following ``ttnn.multiply(..., dtype=bfloat8_b)`` /
+``ttnn.to_memory_config(..., dtype=bfloat8_b)`` calls). It is still the model's
+declared dtype-conversion of ``dbox``, so it is exercised here directly. The cast
+is value-preserving up to precision, so the reference is ``x`` compared at PCC
+0.99 (bfloat8_b block-float target).
+
+Model call sites (branch ``origin/sdawle/yolov8_bh``):
+  * models/demos/yolov8l/tt/ttnn_yolov8l.py:753  (# dbox = ttnn.to_dtype(dbox, dtype=ttnn.bfloat8_b))
+  * models/demos/yolov8s/tt/ttnn_yolov8s.py:574  (same, commented)
+  * live equivalents: ttnn_yolov8l.py:751,754 to_memory_config(..., dtype=bfloat8_b);
+    :1044 ttnn.clone(..., dtype=bfloat16)
+
+``dbox`` is (1, 4, 8400) at 640x640 (4 box coords over 8400 anchors); a neck
+feature-map case is also covered.
+"""
+
+import pytest
+
+import ttnn
+from models.experimental.ops.quasar.tests.yolo_ops import op_utils as U
+
+# (id, shape) — bf16 -> bf8 dtype cast targets.
+_CASES = [
+    ("dbox_1x4x8400", (1, 4, 8400)),  # ttnn_yolov8l.py:753 / ttnn_yolov8s.py:574 (dbox)
+    ("fmap_1x1x400x512", (1, 1, 400, 512)),  # neck fmap (P5, C=512); clone/memcfg dtype casts
+]
+
+
+@U.with_default_mesh()
+@pytest.mark.parametrize("name, shape", [pytest.param(*c, id=c[0]) for c in _CASES])
+def test_to_dtype_bf16_to_bf8(ttnn_mesh_device, reset_seeds, name, shape):
+    mesh = ttnn_mesh_device
+
+    x_torch = U.torch_rand(shape)
+    # ttnn.to_dtype operates on a HOST tensor — a device tensor trips "host_storage != nullptr".
+    x = ttnn.from_torch(
+        x_torch,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,  # bfloat8_b requires TILE
+        mesh_mapper=ttnn.replicate_tensor_to_mesh_mapper(mesh),
+    )
+
+    out = ttnn.to_dtype(x, ttnn.bfloat8_b)
+    assert out.dtype == ttnn.bfloat8_b, f"expected bfloat8_b, got {out.dtype}"
+
+    U.assert_pcc(x_torch, out, pcc=0.99, mesh_device=mesh)  # 0.99: lower-precision target

--- a/models/experimental/ops/quasar/tests/yolo_ops/test_to_layout.py
+++ b/models/experimental/ops/quasar/tests/yolo_ops/test_to_layout.py
@@ -50,7 +50,7 @@ def test_to_layout_tile_rowmajor_roundtrip(ttnn_mesh_device, reset_seeds, hw, c)
     assert rm.layout == ttnn.ROW_MAJOR_LAYOUT
     back = ttnn.to_layout(rm, ttnn.TILE_LAYOUT)
 
-    U.assert_pcc(x_torch, back, pcc=0.999, mesh_device=mesh)
+    U.assert_lossless(x_torch, back, mesh_device=mesh)
 
 
 # ROW_MAJOR -> TILE (+ bf8 cast) into L1. ttnn_yolov8l.py:327 / ttnn_yolov8s.py:288

--- a/models/experimental/ops/quasar/tests/yolo_ops/test_to_layout.py
+++ b/models/experimental/ops/quasar/tests/yolo_ops/test_to_layout.py
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Per-op test: ``ttnn.to_layout`` (YOLOv8, 640x640, batch 1).
+
+YOLOv8 flips activations between ROW_MAJOR and TILE layouts around the neck
+concats / detect head:
+
+    tensor = ttnn.to_layout(tensor, ttnn.ROW_MAJOR_LAYOUT)                 # to RM
+    x = ttnn.to_layout(x, ttnn.TILE_LAYOUT, memory_config=L1, dtype=bf8)   # to TILE (+bf8)
+
+``to_layout`` is a value-preserving re-tiling, so a TILE<->ROW_MAJOR round-trip
+must return the original values. The plain bf16 round-trip is checked at PCC
+0.999; the bf8 TILE variant (matching :327 which also casts to bfloat8_b) at 0.99.
+
+Model call sites (branch ``origin/sdawle/yolov8_bh``):
+  * models/demos/yolov8l/tt/ttnn_yolov8l.py:35   to_layout(tensor, ROW_MAJOR_LAYOUT)
+  * ttnn_yolov8l.py:327  to_layout(x, TILE_LAYOUT, memory_config=L1, dtype=bfloat8_b)
+  * models/demos/yolov8s/tt/ttnn_yolov8s.py:441,747,764,775,794,807,821,822  to_layout(..., ROW_MAJOR_LAYOUT)
+  * ttnn_yolov8s.py:288  to_layout(x, TILE_LAYOUT, memory_config=L1, dtype=bfloat8_b)
+
+Tensors are flattened neck feature maps [1, 1, H*W, C]; H==W parametrized by
+``hw`` (20/40 emulator, 80 real-BH). Neck channels are the standard YOLOv8l/s
+sizes and are not load-bearing (to_layout is channel-independent).
+"""
+
+import pytest
+
+import ttnn
+from models.experimental.ops.quasar.tests.yolo_ops import op_utils as U
+
+_FMAPS = [
+    (20, 512, "l_p5_20x512"),
+    (40, 256, "s_p4_40x256"),
+    (80, 256, "l_p3_80x256"),
+]
+
+
+# TILE -> ROW_MAJOR -> TILE round-trip (bf16). ttnn_yolov8l.py:35 / ttnn_yolov8s.py:441
+@U.with_default_mesh()
+@pytest.mark.parametrize("hw, c", [pytest.param(hw, c, id=i) for (hw, c, i) in _FMAPS])
+def test_to_layout_tile_rowmajor_roundtrip(ttnn_mesh_device, reset_seeds, hw, c):
+    mesh = ttnn_mesh_device
+
+    x_torch = U.torch_rand((1, 1, hw * hw, c))
+    x = U.to_tt(x_torch, mesh)  # TILE, bf16
+
+    rm = ttnn.to_layout(x, ttnn.ROW_MAJOR_LAYOUT)
+    assert rm.layout == ttnn.ROW_MAJOR_LAYOUT
+    back = ttnn.to_layout(rm, ttnn.TILE_LAYOUT)
+
+    U.assert_pcc(x_torch, back, pcc=0.999, mesh_device=mesh)
+
+
+# ROW_MAJOR -> TILE (+ bf8 cast) into L1. ttnn_yolov8l.py:327 / ttnn_yolov8s.py:288
+@U.with_default_mesh()
+@pytest.mark.parametrize("hw, c", [pytest.param(hw, c, id=i) for (hw, c, i) in _FMAPS])
+def test_to_layout_rowmajor_to_tile_bf8(ttnn_mesh_device, reset_seeds, hw, c):
+    mesh = ttnn_mesh_device
+
+    x_torch = U.torch_rand((1, 1, hw * hw, c))
+    x = U.to_tt(x_torch, mesh, layout=ttnn.ROW_MAJOR_LAYOUT)
+
+    out = ttnn.to_layout(x, ttnn.TILE_LAYOUT, memory_config=ttnn.L1_MEMORY_CONFIG, dtype=ttnn.bfloat8_b)
+    assert out.layout == ttnn.TILE_LAYOUT
+
+    U.assert_pcc(x_torch, out, pcc=0.99, mesh_device=mesh)  # 0.99: bfloat8_b block-float cast

--- a/models/experimental/ops/quasar/tests/yolo_ops/test_to_memory_config.py
+++ b/models/experimental/ops/quasar/tests/yolo_ops/test_to_memory_config.py
@@ -6,7 +6,7 @@ Per-op test: ``ttnn.to_memory_config`` (YOLOv8, 640x640, batch 1).
 
 YOLOv8 uses ``to_memory_config`` all over the neck to relocate activations
 (DRAM<->L1) and to move interleaved tensors into sharded configs before conv /
-concat. It only relocates data, so a round-trip must preserve values (PCC 0.999).
+concat. It only relocates data, so a round-trip must preserve values exactly (assert_lossless).
 
 Model call sites (branch ``origin/sdawle/yolov8_bh``):
   * DRAM <-> L1 placement:
@@ -64,7 +64,7 @@ def test_to_memory_config_placement(ttnn_mesh_device, reset_seeds, target_memcfg
     source_memcfg = ttnn.DRAM_MEMORY_CONFIG if target_memcfg == ttnn.L1_MEMORY_CONFIG else ttnn.L1_MEMORY_CONFIG
     x = U.to_tt(x_torch, mesh, memory_config=source_memcfg)
     out = ttnn.to_memory_config(x, target_memcfg)
-    U.assert_pcc(x_torch, out, pcc=0.999, mesh_device=mesh)
+    U.assert_lossless(x_torch, out, mesh_device=mesh)
 
 
 # --- interleaved -> WIDTH-sharded move (per-core conv input config). ---------
@@ -84,7 +84,7 @@ def test_to_memory_config_interleaved_to_sharded(ttnn_mesh_device, reset_seeds, 
     x = U.to_tt(x_torch, mesh)  # interleaved DRAM
     out = ttnn.to_memory_config(x, _width_sharded(U.TILE, width))
     assert out.is_sharded(), "expected a sharded output"
-    U.assert_pcc(x_torch, out, pcc=0.999, mesh_device=mesh)
+    U.assert_lossless(x_torch, out, mesh_device=mesh)
 
 
 # --- model-faithful: interleaved L1 RM -> HEIGHT_SHARDED on the SPPF core grid. -----------
@@ -115,4 +115,30 @@ def test_to_memory_config_to_height_sharded(ttnn_mesh_device, reset_seeds, varia
     sharded = U.height_sharded_memcfg(mesh, num_cores, shape)  # skips if device < num_cores
     out = ttnn.to_memory_config(x, sharded)
     assert out.is_sharded(), "expected a HEIGHT_SHARDED output"
-    U.assert_pcc(x_torch, out, pcc=0.999, mesh_device=mesh)
+    U.assert_lossless(x_torch, out, mesh_device=mesh)
+
+
+# Fused relocation + dtype cast: to_memory_config(..., dtype=bfloat8_b). The model casts
+# the detect-head anchors/strides to bfloat8_b *during* the L1 relocation
+# (ttnn_yolov8l.py:751,754 / ttnn_yolov8s.py:572,575) — a distinct overload from the
+# plain relocation and from the separate ttnn.to_dtype path.
+@U.with_default_mesh()
+@pytest.mark.parametrize(
+    "shape",
+    [
+        pytest.param((1, 2, 8400), id="anchors-640"),
+        pytest.param((1, 1, 8400), id="strides-640"),
+    ],
+)
+def test_to_memory_config_dtype_cast(ttnn_mesh_device, reset_seeds, shape):
+    """relocation fused with bf16->bfloat8_b cast (ttnn_yolov8l.py:751,754)."""
+    mesh = ttnn_mesh_device
+    x_torch = U.torch_rand(shape)
+    # Source in DRAM (tilize into DRAM works for these odd shapes). The cast must ride a
+    # REAL relocation: an L1->L1 no-op short-circuits and ignores dtype, leaving bf16.
+    x = U.to_tt(x_torch, mesh, layout=ttnn.TILE_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+
+    out = ttnn.to_memory_config(x, memory_config=ttnn.L1_MEMORY_CONFIG, dtype=ttnn.bfloat8_b)
+
+    assert out.dtype == ttnn.bfloat8_b, f"expected bfloat8_b, got {out.dtype}"
+    U.assert_pcc(x_torch, out, pcc=0.99, mesh_device=mesh)  # 0.99: bfloat8_b precision

--- a/models/experimental/ops/quasar/tests/yolo_ops/test_to_memory_config.py
+++ b/models/experimental/ops/quasar/tests/yolo_ops/test_to_memory_config.py
@@ -61,7 +61,8 @@ def _width_sharded(h, w):
 def test_to_memory_config_placement(ttnn_mesh_device, reset_seeds, target_memcfg, shape):
     mesh = ttnn_mesh_device
     x_torch = U.torch_rand(shape)
-    x = U.to_tt(x_torch, mesh)  # interleaved DRAM
+    source_memcfg = ttnn.DRAM_MEMORY_CONFIG if target_memcfg == ttnn.L1_MEMORY_CONFIG else ttnn.L1_MEMORY_CONFIG
+    x = U.to_tt(x_torch, mesh, memory_config=source_memcfg)
     out = ttnn.to_memory_config(x, target_memcfg)
     U.assert_pcc(x_torch, out, pcc=0.999, mesh_device=mesh)
 

--- a/models/experimental/ops/quasar/tests/yolo_ops/test_to_memory_config.py
+++ b/models/experimental/ops/quasar/tests/yolo_ops/test_to_memory_config.py
@@ -1,0 +1,117 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Per-op test: ``ttnn.to_memory_config`` (YOLOv8, 640x640, batch 1).
+
+YOLOv8 uses ``to_memory_config`` all over the neck to relocate activations
+(DRAM<->L1) and to move interleaved tensors into sharded configs before conv /
+concat. It only relocates data, so a round-trip must preserve values (PCC 0.999).
+
+Model call sites (branch ``origin/sdawle/yolov8_bh``):
+  * DRAM <-> L1 placement:
+      - models/demos/yolov8l/tt/ttnn_yolov8l.py:74,90,321,447,451,459,524,611,987,1006,1015,1065,1112
+      - models/demos/yolov8s/tt/ttnn_yolov8s.py:379,387,440,746,765
+  * interleaved -> sharded (per-core conv input configs):
+      - ttnn_yolov8l.py:55,119  to_memory_config(tensor, input_sharded_memory_configs[i])
+      - ttnn_yolov8s.py:56,92
+  * with dtype cast (anchors/strides -> bfloat8_b):
+      - ttnn_yolov8l.py:751,754 ; ttnn_yolov8s.py:572,575
+
+Neck activations are flattened feature maps [1, 1, H*W, C]; the placement cases
+use those shapes, the interleaved->sharded cases use a per-tile-row width shard
+[1,1,32,C] (single-core, so the shard shape equals the tensor). Neck channel
+widths are the standard YOLOv8l/s sizes and are not load-bearing here.
+"""
+
+import pytest
+
+import ttnn
+from models.experimental.ops.quasar.tests.yolo_ops import op_utils as U
+
+_GRID = ttnn.CoreGrid(y=1, x=1)
+
+
+def _width_sharded(h, w):
+    return ttnn.create_sharded_memory_config(
+        (h, w),
+        _GRID,
+        ttnn.ShardStrategy.WIDTH,
+        ttnn.ShardOrientation.ROW_MAJOR,
+        use_height_and_width_as_shard_shape=True,
+    )
+
+
+# --- DRAM <-> L1 placement round-trip (neck feature maps). -------------------
+@U.with_default_mesh()
+@pytest.mark.parametrize(
+    "target_memcfg",
+    [
+        pytest.param(ttnn.L1_MEMORY_CONFIG, id="to-l1"),  # ttnn_yolov8l.py:451,987,1015
+        pytest.param(ttnn.DRAM_MEMORY_CONFIG, id="to-dram"),  # ttnn_yolov8l.py:74,321,611,1065
+    ],
+)
+@pytest.mark.parametrize(
+    "shape",
+    [
+        pytest.param((1, 1, 400, 512), id="p5-400x512"),  # yolov8l P5
+        pytest.param((1, 1, 1600, 256), id="p4-1600x256"),  # yolov8s neck
+    ],
+)
+def test_to_memory_config_placement(ttnn_mesh_device, reset_seeds, target_memcfg, shape):
+    mesh = ttnn_mesh_device
+    x_torch = U.torch_rand(shape)
+    x = U.to_tt(x_torch, mesh)  # interleaved DRAM
+    out = ttnn.to_memory_config(x, target_memcfg)
+    U.assert_pcc(x_torch, out, pcc=0.999, mesh_device=mesh)
+
+
+# --- interleaved -> WIDTH-sharded move (per-core conv input config). ---------
+@U.with_default_mesh()
+@pytest.mark.parametrize(
+    "width",
+    [
+        pytest.param(512, id="width-512"),  # yolov8l neck channels
+        pytest.param(256, id="width-256"),  # yolov8s neck channels
+        pytest.param(128, id="width-128"),  # yolov8s shallow neck channels
+    ],
+)
+def test_to_memory_config_interleaved_to_sharded(ttnn_mesh_device, reset_seeds, width):
+    mesh = ttnn_mesh_device
+    shape = (1, 1, U.TILE, width)
+    x_torch = U.torch_rand(shape)
+    x = U.to_tt(x_torch, mesh)  # interleaved DRAM
+    out = ttnn.to_memory_config(x, _width_sharded(U.TILE, width))
+    assert out.is_sharded(), "expected a sharded output"
+    U.assert_pcc(x_torch, out, pcc=0.999, mesh_device=mesh)
+
+
+# --- model-faithful: interleaved L1 RM -> HEIGHT_SHARDED on the SPPF core grid. -----------
+#
+# The single-core WIDTH shard above is a shape-only stand-in. The model's real
+# ``to_memory_config`` sharding happens inside ``sharded_concat`` /
+# ``sharded_concat_sppf`` (ttnn_yolov8l.py:55, :119): each concat input is a flattened
+# neck feature map [1, 1, H*W, C] moved from interleaved L1 into a HEIGHT-sharded config
+# over the full SPPF grid — ``_SPPF_NUM_CORES`` = 64 (yolov8l, 8x8) / 80 (yolov8s, 10x8)
+# (ttnn_yolov8l.py:21-22, :777-781). Value-preserving relocation, so PCC vs the original.
+@U.with_default_mesh()
+@pytest.mark.blackhole_scale
+@pytest.mark.parametrize(
+    "variant, num_cores, shape",
+    [
+        # yolov8l sharded_concat: _SPPF_NUM_CORES=64 (8x8); sppf concat @40x40 -> H*W=1600.
+        # shard_height = 1600 // 64 = 25 (ttnn_yolov8l.py:55,119).
+        pytest.param("yolov8l", 64, (1, 1, 1600, 512), id="l-height-64c-1600x512"),
+        # yolov8s sharded_concat: _SPPF_NUM_CORES=80 (10x8); 1600 // 80 = 20 (ttnn_yolov8s.py:56,92).
+        pytest.param("yolov8s", 80, (1, 1, 1600, 256), id="s-height-80c-1600x256"),
+    ],
+)
+def test_to_memory_config_to_height_sharded(ttnn_mesh_device, reset_seeds, variant, num_cores, shape):
+    mesh = ttnn_mesh_device
+    x_torch = U.torch_rand(shape)
+    x = U.to_tt(x_torch, mesh, layout=ttnn.ROW_MAJOR_LAYOUT, memory_config=ttnn.L1_MEMORY_CONFIG)
+
+    sharded = U.height_sharded_memcfg(mesh, num_cores, shape)  # skips if device < num_cores
+    out = ttnn.to_memory_config(x, sharded)
+    assert out.is_sharded(), "expected a HEIGHT_SHARDED output"
+    U.assert_pcc(x_torch, out, pcc=0.999, mesh_device=mesh)

--- a/models/experimental/ops/quasar/tests/yolo_ops/test_upsample.py
+++ b/models/experimental/ops/quasar/tests/yolo_ops/test_upsample.py
@@ -1,0 +1,128 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Per-op test: ``ttnn.upsample`` — the YOLOv8 neck (FPN top-down) upsamples.
+
+Model call sites (all scale (2, 2), default mode "nearest"):
+  * yolov8l: models/demos/yolov8l/tt/ttnn_yolov8l.py
+      L1029  ttnn.upsample(sppf_9, (2, 2), ...)    # SPPF out (20x20) -> 40x40
+      L1067/L1070  ttnn.upsample(c2f_12, (2, 2), ...)  # C2f model.12 (40x40) -> 80x80
+                   (two branches of the same logical upsample: DRAM vs sharded)
+  * yolov8s: models/demos/yolov8s/tt/ttnn_yolov8s.py
+      L760  ttnn.upsample(sppf_9, (2, 2), ...)     # SPPF out (20x20) -> 40x40
+      L791  ttnn.upsample(c2f_12, (2, 2), ...)     # C2f model.12 (40x40) -> 80x80
+
+Per-variant there are 2 distinct upsample sites; across both variants they dedupe to
+3 distinct input shapes:
+
+  1. (hw=20, ch=512)  SPPF-out upsample  — yolov8l AND yolov8s (identical)
+       ch = SPPF cv2 out = sppf_configs.input_params[1][3] = 512
+            (configs.json sppf_configs[1]=[1,1,0,512,1024]; identical l & s)
+       hw = SPPF stage = 20x20 at 640 input.
+  2. (hw=40, ch=512)  C2f model.12 upsample — yolov8l
+       ch = C2f cv2 out = c2f_configs["model.12"].input_params[1][3] = 512
+            (yolov8l configs.json model.12 cv2 = [1,1,0,512,1280])
+  3. (hw=40, ch=256)  C2f model.12 upsample — yolov8s
+       ch = c2f_configs["model.12"].input_params[1][3] = 256
+            (yolov8s configs.json model.12 cv2 = [1,1,0,256,384])
+       hw = 40x40 (upsampled SPPF level in the top-down path).
+
+(C2f output conv = cv2 = input_params[1]; see TtC2f.__init__ ttnn_yolov8l.py:396.)
+
+Reference: torch nearest upsample (nn.functional.interpolate, mode="nearest").
+Input prep mirrors the canonical op test
+tests/ttnn/unit_tests/operations/pool/test_upsample.py (NHWC row-major activation).
+"""
+
+import pytest
+import torch
+
+import ttnn
+from models.experimental.ops.quasar.tests.yolo_ops import op_utils as U
+
+_SCALE = (2, 2)  # (scale_h, scale_w) — every neck upsample is (2, 2) nearest.
+
+
+def _torch_upsample_nearest(x_nchw: torch.Tensor) -> torch.Tensor:
+    """Golden: nearest upsample on NCHW, returned NHWC to match the ttnn output."""
+    ref_nchw = torch.nn.functional.interpolate(x_nchw.float(), scale_factor=_SCALE, mode="nearest")
+    return ref_nchw.permute(0, 2, 3, 1).contiguous()
+
+
+@U.with_default_mesh()
+@pytest.mark.parametrize(
+    "sites, channels, hw",
+    [
+        # SPPF-out upsample, shared by both variants (ttnn_yolov8l.py:1029 / ttnn_yolov8s.py:760)
+        pytest.param("yolov8l+yolov8s", 512, 20, id="sppf9-upsample-512x20x20"),
+        # C2f model.12 upsample, yolov8l (ttnn_yolov8l.py:1067/1070)
+        pytest.param("yolov8l", 512, 40, id="yolov8l-c2f12-upsample-512x40x40"),
+        # C2f model.12 upsample, yolov8s (ttnn_yolov8s.py:791)
+        pytest.param("yolov8s", 256, 40, id="yolov8s-c2f12-upsample-256x40x40"),
+    ],
+)
+def test_upsample(ttnn_mesh_device, reset_seeds, sites, channels, hw):
+    mesh = ttnn_mesh_device
+    n, c, h, w = U.BATCH, channels, hw, hw
+
+    # NCHW host input -> NHWC [N, H, W, C] row-major on device (the layout ttnn.upsample
+    # consumes; canonical test_upsample.py:576-591).
+    x_nchw = U.torch_rand((n, c, h, w))
+    x = U.nhwc_to_tt(x_nchw, mesh)
+
+    out = ttnn.upsample(x, _SCALE)  # default mode="nearest", matching the model.
+
+    ref = _torch_upsample_nearest(x_nchw)
+    U.assert_pcc(ref, out, pcc=0.99, mesh_device=mesh)
+
+
+# --- model-faithful: HEIGHT_SHARDED L1 input (the REAL neck upsample state). -------------
+#
+# The model does NOT upsample an interleaved DRAM tensor (the case above): right before
+# each upsample it reshapes the feature map to (batch, out_h, out_w, C) row-major and moves
+# it into a HEIGHT_SHARDED **L1** config, then upsamples in place, passing the shard config
+# straight through (ttnn_yolov8l.py:1017-1029 for sppf_9, :1051-1070 for c2f_12):
+#
+#     nhw       = batch * out_h * out_w
+#     num_cores = determine_num_cores(nhw, sppf_9.shape[2])   # width arg = out_w, NOT C
+#     shardspec = create_sharded_memory_config_(shape, grid, HEIGHT, ROW_MAJOR)
+#     sppf_9    = ttnn.interleaved_to_sharded(sppf_9, shardspec)
+#     sppf_9    = ttnn.upsample(sppf_9, (2, 2), memory_config=sppf_9.memory_config())
+#
+# determine_num_cores (yolo_utils.py:17 gcd logic) with width=out_w gives one image row
+# per core: sppf_9 nhw=400,w=20 -> gcd(400,20)=20 cores; c2f_12 nhw=1600,w=40 -> 40 cores.
+@U.with_mesh_l1small()  # the sharded upsample program factory allocates from the L1-small region
+@pytest.mark.blackhole_scale
+@pytest.mark.parametrize(
+    "sites, channels, hw, num_cores",
+    [
+        # SPPF-out upsample, HEIGHT_SHARDED L1 (ttnn_yolov8l.py:1027-1029 / ttnn_yolov8s.py:758-760)
+        # determine_num_cores(400, out_w=20) = 400 // gcd(400,20) = 20 cores.
+        pytest.param("yolov8l+yolov8s", 512, 20, 20, id="sppf9-sharded-512x20x20-20c"),
+        # C2f model.12 upsample, HEIGHT_SHARDED L1, yolov8l (ttnn_yolov8l.py:1057-1070)
+        # determine_num_cores(1600, out_w=40) = 1600 // gcd(1600,40) = 40 cores.
+        pytest.param("yolov8l", 512, 40, 40, id="yolov8l-c2f12-sharded-512x40x40-40c"),
+        # C2f model.12 upsample, HEIGHT_SHARDED L1, yolov8s (ttnn_yolov8s.py:789-791)
+        pytest.param("yolov8s", 256, 40, 40, id="yolov8s-c2f12-sharded-256x40x40-40c"),
+    ],
+)
+def test_upsample_sharded(ttnn_mesh_device, reset_seeds, sites, channels, hw, num_cores):
+    mesh = ttnn_mesh_device
+    n, c, h, w = U.BATCH, channels, hw, hw
+
+    # NCHW host input -> NHWC (batch, H, W, C) row-major, uploaded to interleaved L1, then
+    # moved into the model's HEIGHT_SHARDED L1 config (ttnn_yolov8l.py:1016-1028).
+    x_nchw = U.torch_rand((n, c, h, w))
+    x_nhwc = x_nchw.permute(0, 2, 3, 1).contiguous()  # (batch, H, W, C)
+    x = U.to_tt(x_nhwc, mesh, layout=ttnn.ROW_MAJOR_LAYOUT, memory_config=ttnn.L1_MEMORY_CONFIG)
+
+    sharded = U.height_sharded_memcfg(mesh, num_cores, (n, h, w, c))  # skips if device < num_cores
+    x = ttnn.to_memory_config(x, sharded)
+    assert x.is_sharded(), "expected a HEIGHT_SHARDED L1 upsample input"
+
+    # Upsample in place through the shard config, exactly as the model does.
+    out = ttnn.upsample(x, _SCALE, memory_config=x.memory_config())
+
+    ref = _torch_upsample_nearest(x_nchw)
+    U.assert_pcc(ref, out, pcc=0.99, mesh_device=mesh)


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

Feature, Test Only

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

Closes #51472 

Tested locally that tests pass:
```
SKIPPED [2] models/experimental/ops/quasar/tests/yolo_ops/op_utils.py:109: model-faithful shard needs 80 cores; device has 64
===================================================== 200 passed, 2 skipped in 69.46s (0:01:09)
```

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=bbradel-51472_yolo_qsr_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:bbradel-51472_yolo_qsr_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=bbradel-51472_yolo_qsr_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:bbradel-51472_yolo_qsr_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=bbradel-51472_yolo_qsr_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:bbradel-51472_yolo_qsr_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bbradel-51472_yolo_qsr_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bbradel-51472_yolo_qsr_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=bbradel-51472_yolo_qsr_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:bbradel-51472_yolo_qsr_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bbradel-51472_yolo_qsr_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bbradel-51472_yolo_qsr_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bbradel-51472_yolo_qsr_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bbradel-51472_yolo_qsr_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bbradel-51472_yolo_qsr_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bbradel-51472_yolo_qsr_tests)