### PR TITLE
ci(fabric): fix undeclared runs-on-sku input in tm-fabric cpu-only call

### DIFF
--- a/.github/workflows/tm-fabric-tests-impl.yaml
+++ b/.github/workflows/tm-fabric-tests-impl.yaml
@@ -64,7 +64,7 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/fabric-cpu-only-tests-impl.yaml
     with:
-      runs-on-sku: cpu_medium
+      arch: blackhole
       docker-image: ${{ inputs.docker-image }}
       build-artifact-name: ${{ inputs.build-artifact-name }}
       wheel-artifact-name: ${{ inputs.wheel-artifact-name }}


### PR DESCRIPTION
## Summary
- `fabric-cpu-only-tests-impl.yaml`'s `workflow_call` only declares `arch` (plus `timeout`/`build-artifact-name`/`docker-image`/`wheel-artifact-name`) — no `runs-on-sku` input exists.
- `tm-fabric-tests-impl.yaml` was passing `runs-on-sku: cpu_medium`, which GitHub Actions rejects as an undeclared input, so this call fails validation whenever it runs.
- Verified the rest of the carry (input declaration, `fabric-cpu-only-unit-tests` job, matrix wiring in `tm-fabric-tests.yaml`) is already fully and correctly re-applied on this branch — this was the only mismatch. Fix: pass `arch: blackhole` instead, matching both the callee's declared input and the original carry commit (`4af46da6071` on `blaze-metal-main-uplift-june-2-rev2`).

Fixes tenstorrent/tt-blaze#2697

## Test plan
- [ ] `workflow_dispatch` this branch's `(TM-Fabric) Fabric Tests` workflow with `run-fabric-cpu-only-unit-tests: true` and confirm the `fabric-cpu-only-unit-tests` job in `tm-fabric-tests-impl.yaml` passes validation and runs (rather than failing at dispatch with an undeclared-input error).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=fix/tm-fabric-cpu-only-arch-input)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:fix/tm-fabric-cpu-only-arch-input)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=fix/tm-fabric-cpu-only-arch-input)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:fix/tm-fabric-cpu-only-arch-input)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=fix/tm-fabric-cpu-only-arch-input)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:fix/tm-fabric-cpu-only-arch-input)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fix/tm-fabric-cpu-only-arch-input)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fix/tm-fabric-cpu-only-arch-input)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=fix/tm-fabric-cpu-only-arch-input)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:fix/tm-fabric-cpu-only-arch-input)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=fix/tm-fabric-cpu-only-arch-input)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:fix/tm-fabric-cpu-only-arch-input)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=fix/tm-fabric-cpu-only-arch-input)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:fix/tm-fabric-cpu-only-arch-input)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=fix/tm-fabric-cpu-only-arch-input)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:fix/tm-fabric-cpu-only-arch-input)