### PR TITLE
Fix batch_norm running_statistics drain hang and three latent Metal 2.0 porting bugs

### DIFF
--- a/tests/ttnn/unit_tests/operations/fused/test_batch_norm.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_batch_norm.py
@@ -24,7 +24,8 @@ pytestmark = pytest.mark.use_module_device
         torch.Size([5, 8, 32, 32]),
         torch.Size([7, 3, 23, 23]),
         torch.Size([3, 5, 64, 120]),
-        # C=129: past CB depth (2) on WH n150 (64 cores) so mean-only/var-only drain hangs are covered
+        # C=129: past CB depth (2) on WH (64 cores); BH drain coverage comes from
+        # test_batch_norm_running_statistics_drain which derives C from the device grid.
         torch.Size([1, 129, 14, 14]),
         torch.Size([1, 8, 24, 42]),
     ],
@@ -1109,8 +1110,8 @@ def test_batch_norm_fpu_running_statistics(input_shapes, weight, bias, check_mea
         assert_numeric_metrics(
             ref_mean.view(1, channels, 1, 1),
             tt_updated_mean,
-            rtol=0.1,
-            atol=4.0,
+            rtol=0.05,
+            atol=0.5,
             frobenius_threshold=0.25,
             check_pcc=False,
         )
@@ -1119,8 +1120,8 @@ def test_batch_norm_fpu_running_statistics(input_shapes, weight, bias, check_mea
         assert_numeric_metrics(
             ref_var.view(1, channels, 1, 1),
             tt_updated_var,
-            rtol=0.1,
-            atol=4.0,
+            rtol=0.05,
+            atol=0.5,
             frobenius_threshold=0.25,
             check_pcc=False,
         )
@@ -1211,8 +1212,8 @@ def test_batch_norm_running_statistics_drain(check_mean, check_var, fp32_dest_ac
         assert_numeric_metrics(
             ref_mean.view(1, channels, 1, 1),
             tt_updated_mean,
-            rtol=0.1,
-            atol=4.0,
+            rtol=0.05,
+            atol=0.5,
             frobenius_threshold=frobenius_threshold,
             check_pcc=False,
         )
@@ -1221,8 +1222,8 @@ def test_batch_norm_running_statistics_drain(check_mean, check_var, fp32_dest_ac
         assert_numeric_metrics(
             ref_var.view(1, channels, 1, 1),
             tt_updated_var,
-            rtol=0.1,
-            atol=4.0,
+            rtol=0.05,
+            atol=0.5,
             frobenius_threshold=frobenius_threshold,
             check_pcc=False,
         )

--- a/tests/ttnn/unit_tests/operations/fused/test_batch_norm.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_batch_norm.py
@@ -1202,9 +1202,19 @@ def test_batch_norm_running_statistics_drain(check_mean, check_var, fp32_dest_ac
         training=True,
         momentum=0.1,
     )
-    frobenius_threshold = 0.25 if not fp32_dest_acc_en else 0.15
+    # LoFi + fp32_dest_acc_en=False is inherently lower precision than the default SFPU
+    # path, and the channel count (so also the generated data) varies with the device grid,
+    # which makes the worst-case element error backend-dependent. PCC and relative Frobenius
+    # are the real gates on the main output; allclose is a coarse outlier guard.
+    lofi = not fp32_dest_acc_en
+    frobenius_threshold = 0.25 if lofi else 0.15
     assert_numeric_metrics(
-        torch_result, tt_output, pcc_threshold=0.99, rtol=0.1, atol=4.0, frobenius_threshold=frobenius_threshold
+        torch_result,
+        tt_output,
+        pcc_threshold=0.99,
+        rtol=0.1,
+        atol=6.0 if lofi else 4.0,
+        frobenius_threshold=frobenius_threshold,
     )
 
     if check_mean:

--- a/tests/ttnn/unit_tests/operations/fused/test_batch_norm.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_batch_norm.py
@@ -1015,3 +1015,112 @@ def test_batch_norm_fp32_acc_output_typecast(
         assert_numeric_metrics(
             torch_result, tt_output, pcc_threshold=0.999, rtol=1e-2, atol=0.5, frobenius_threshold=0.05
         )
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    [
+        torch.Size([3, 5, 64, 120]),
+        torch.Size([1, 8, 24, 42]),
+    ],
+)
+@pytest.mark.parametrize("weight", [True, False])
+@pytest.mark.parametrize("bias", [True, False])
+@pytest.mark.parametrize(
+    "check_mean, check_var",
+    [
+        (True, True),
+        (True, False),
+        (False, True),
+        (False, False),
+    ],
+)
+def test_batch_norm_fpu_running_statistics(input_shapes, weight, bias, check_mean, check_var, device):
+    """Regression test for three latent defects in running_statistics_kernel.cpp (FPU path).
+
+    The FPU running-statistics compute kernel is selected when fp32_dest_acc_en=False and
+    all tensors are bfloat16.  It contained:
+      1. push_back without reserve_back on the output DFB,
+      2. a nested tile_regs_acquire wrapping helpers that run their own tile_regs cycle
+         (pack_tile reads stale/undefined DST),
+      3. undefined DST packed to output when both running stats are absent.
+
+    This test forces the FPU path via fp32_dest_acc_en=False with all-bf16 tensors in
+    training mode and validates both the main output and the updated running stats.
+    """
+    in_data, input_tensor = data_gen_with_range_batch_norm(input_shapes, 5, 10, device, is_input=True)
+    input_tensor = ttnn.fill_implicit_tile_padding(input_tensor, TEST_PADDING_VALUE)
+    mean_data, mean_tensor = data_gen_with_range_batch_norm(input_shapes, 4, 10, device) if check_mean else (None, None)
+    var_data, var_tensor = data_gen_with_range_batch_norm(input_shapes, 4, 20, device) if check_var else (None, None)
+    weight_data, weight_tensor = data_gen_with_range_batch_norm(input_shapes, 4, 10, device) if weight else (None, None)
+    bias_data, bias_tensor = data_gen_with_range_batch_norm(input_shapes, 4, 10, device) if bias else (None, None)
+
+    compute_config = ttnn.init_device_compute_kernel_config(
+        device.arch(),
+        math_fidelity=ttnn.MathFidelity.LoFi,
+        math_approx_mode=False,
+        fp32_dest_acc_en=False,
+    )
+
+    tt_mean = ttnn.clone(mean_tensor) if check_mean else None
+    tt_var = ttnn.clone(var_tensor) if check_var else None
+
+    tt_output_tensor = ttnn.batch_norm(
+        input_tensor,
+        running_mean=tt_mean,
+        running_var=tt_var,
+        weight=weight_tensor,
+        bias=bias_tensor,
+        training=True,
+        momentum=0.1,
+        compute_kernel_config=compute_config,
+    )
+    tt_output = ttnn.to_torch(tt_output_tensor)
+
+    channels = input_shapes[1]
+    torch_mean_ref = mean_data.clone() if mean_data is not None else None
+    torch_var_ref = var_data.clone() if var_data is not None else None
+    ref_mean = (
+        torch_mean_ref
+        if torch_mean_ref is not None
+        else (torch.zeros(channels, dtype=in_data.dtype) if torch_var_ref is not None else None)
+    )
+    ref_var = (
+        torch_var_ref
+        if torch_var_ref is not None
+        else (torch.ones(channels, dtype=in_data.dtype) if torch_mean_ref is not None else None)
+    )
+
+    torch_result = torch.nn.functional.batch_norm(
+        input=in_data,
+        running_mean=ref_mean,
+        running_var=ref_var,
+        weight=weight_data,
+        bias=bias_data,
+        training=True,
+        momentum=0.1,
+    )
+    # LoFi + fp32_dest_acc_en=False is inherently lower precision than the default
+    # SFPU path; widen the Frobenius threshold accordingly.
+    assert_numeric_metrics(torch_result, tt_output, pcc_threshold=0.99, rtol=0.1, atol=4.0, frobenius_threshold=0.25)
+
+    if check_mean:
+        tt_updated_mean = ttnn.to_torch(tt_mean)
+        assert_numeric_metrics(
+            ref_mean.view(1, channels, 1, 1),
+            tt_updated_mean,
+            rtol=0.1,
+            atol=4.0,
+            frobenius_threshold=0.25,
+            check_pcc=False,
+        )
+    if check_var:
+        tt_updated_var = ttnn.to_torch(tt_var)
+        assert_numeric_metrics(
+            ref_var.view(1, channels, 1, 1),
+            tt_updated_var,
+            rtol=0.1,
+            atol=4.0,
+            frobenius_threshold=0.25,
+            check_pcc=False,
+        )

--- a/tests/ttnn/unit_tests/operations/fused/test_batch_norm.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_batch_norm.py
@@ -24,7 +24,8 @@ pytestmark = pytest.mark.use_module_device
         torch.Size([5, 8, 32, 32]),
         torch.Size([7, 3, 23, 23]),
         torch.Size([3, 5, 64, 120]),
-        torch.Size([1, 128, 14, 14]),
+        # C=129: past CB depth (2) on WH n150 (64 cores) so mean-only/var-only drain hangs are covered
+        torch.Size([1, 129, 14, 14]),
         torch.Size([1, 8, 24, 42]),
     ],
 )
@@ -1032,21 +1033,20 @@ def test_batch_norm_fp32_acc_output_typecast(
         (True, True),
         (True, False),
         (False, True),
-        (False, False),
     ],
 )
 def test_batch_norm_fpu_running_statistics(input_shapes, weight, bias, check_mean, check_var, device):
-    """Regression test for three latent defects in running_statistics_kernel.cpp (FPU path).
+    """First CI coverage of the FPU running_statistics kernel (fp32_dest_acc_en=False).
 
-    The FPU running-statistics compute kernel is selected when fp32_dest_acc_en=False and
-    all tensors are bfloat16.  It contained:
-      1. push_back without reserve_back on the output DFB,
-      2. a nested tile_regs_acquire wrapping helpers that run their own tile_regs cycle
-         (pack_tile reads stale/undefined DST),
-      3. undefined DST packed to output when both running stats are absent.
+    Default resolve_compute_kernel_config sets fp32_dest_acc_en=True, which selects the
+    SFPU kernel — so running_statistics_kernel.cpp was previously untested. This forces
+    the FPU path with all-bf16 tensors in training mode and checks main output plus
+    updated running stats.
 
-    This test forces the FPU path via fp32_dest_acc_en=False with all-bf16 tensors in
-    training mode and validates both the main output and the updated running stats.
+    Note: nested tile_regs / missing reserve_back are unobservable under Metal 1.0 CBs
+    (bit-identical vs main). The both-absent case is rejected by validate_tensors
+    (at least one stat must be present). Hang coverage for absent stats lives in
+    test_batch_norm_running_statistics_drain.
     """
     in_data, input_tensor = data_gen_with_range_batch_norm(input_shapes, 5, 10, device, is_input=True)
     input_tensor = ttnn.fill_implicit_tile_padding(input_tensor, TEST_PADDING_VALUE)
@@ -1131,7 +1131,6 @@ def test_batch_norm_fpu_running_statistics(input_shapes, weight, bias, check_mea
     [
         (True, False),  # mean-only: batch_var must still be drained
         (False, True),  # var-only: batch_mean must still be drained (FPU)
-        (False, False),  # both-absent: batch_var must still be drained
     ],
 )
 @pytest.mark.parametrize("fp32_dest_acc_en", [False, True])
@@ -1141,11 +1140,13 @@ def test_batch_norm_running_statistics_drain(check_mean, check_var, fp32_dest_ac
     Reader pushes batch_mean and writer pushes batch_var every tile with no
     presence guard. When the corresponding compute block compiles out, those
     CBs fill after b_num_tiles_per_cb (=2) tiles and the producer stalls.
-    Shape (1, 192, 14, 14) is past the hang threshold used in review repros
-    (C=129 mean-only / C=192 both-absent); C=5/8 in the existing FPU test
-    complete without exercising the stall.
+
+    Channel count is derived from the device grid so some core gets ≥3 tiles on
+    both WH (64 cores) and BH (~130 cores). Hardcoding C=192 only stalls on WH.
     """
-    input_shapes = torch.Size([1, 192, 14, 14])
+    grid = device.compute_with_storage_grid_size()
+    channels = 3 * grid.x * grid.y + 1
+    input_shapes = torch.Size([1, channels, 14, 14])
     in_data, input_tensor = data_gen_with_range_batch_norm(input_shapes, 5, 10, device, is_input=True)
     input_tensor = ttnn.fill_implicit_tile_padding(input_tensor, TEST_PADDING_VALUE)
     mean_data, mean_tensor = data_gen_with_range_batch_norm(input_shapes, 4, 10, device) if check_mean else (None, None)
@@ -1178,7 +1179,6 @@ def test_batch_norm_running_statistics_drain(check_mean, check_var, fp32_dest_ac
     )
     tt_output = ttnn.to_torch(tt_output_tensor)
 
-    channels = input_shapes[1]
     torch_mean_ref = mean_data.clone() if mean_data is not None else None
     torch_var_ref = var_data.clone() if var_data is not None else None
     ref_mean = (
@@ -1205,3 +1205,24 @@ def test_batch_norm_running_statistics_drain(check_mean, check_var, fp32_dest_ac
     assert_numeric_metrics(
         torch_result, tt_output, pcc_threshold=0.99, rtol=0.1, atol=4.0, frobenius_threshold=frobenius_threshold
     )
+
+    if check_mean:
+        tt_updated_mean = ttnn.to_torch(tt_mean)
+        assert_numeric_metrics(
+            ref_mean.view(1, channels, 1, 1),
+            tt_updated_mean,
+            rtol=0.1,
+            atol=4.0,
+            frobenius_threshold=frobenius_threshold,
+            check_pcc=False,
+        )
+    if check_var:
+        tt_updated_var = ttnn.to_torch(tt_var)
+        assert_numeric_metrics(
+            ref_var.view(1, channels, 1, 1),
+            tt_updated_var,
+            rtol=0.1,
+            atol=4.0,
+            frobenius_threshold=frobenius_threshold,
+            check_pcc=False,
+        )

--- a/tests/ttnn/unit_tests/operations/fused/test_batch_norm.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_batch_norm.py
@@ -1124,3 +1124,84 @@ def test_batch_norm_fpu_running_statistics(input_shapes, weight, bias, check_mea
             frobenius_threshold=0.25,
             check_pcc=False,
         )
+
+
+@pytest.mark.parametrize(
+    "check_mean, check_var",
+    [
+        (True, False),  # mean-only: batch_var must still be drained
+        (False, True),  # var-only: batch_mean must still be drained (FPU)
+        (False, False),  # both-absent: batch_var must still be drained
+    ],
+)
+@pytest.mark.parametrize("fp32_dest_acc_en", [False, True])
+def test_batch_norm_running_statistics_drain(check_mean, check_var, fp32_dest_acc_en, device):
+    """Regression for CB drain hangs when a running stat is absent.
+
+    Reader pushes batch_mean and writer pushes batch_var every tile with no
+    presence guard. When the corresponding compute block compiles out, those
+    CBs fill after b_num_tiles_per_cb (=2) tiles and the producer stalls.
+    Shape (1, 192, 14, 14) is past the hang threshold used in review repros
+    (C=129 mean-only / C=192 both-absent); C=5/8 in the existing FPU test
+    complete without exercising the stall.
+    """
+    input_shapes = torch.Size([1, 192, 14, 14])
+    in_data, input_tensor = data_gen_with_range_batch_norm(input_shapes, 5, 10, device, is_input=True)
+    input_tensor = ttnn.fill_implicit_tile_padding(input_tensor, TEST_PADDING_VALUE)
+    mean_data, mean_tensor = data_gen_with_range_batch_norm(input_shapes, 4, 10, device) if check_mean else (None, None)
+    var_data, var_tensor = data_gen_with_range_batch_norm(input_shapes, 4, 20, device) if check_var else (None, None)
+    weight_data, weight_tensor = data_gen_with_range_batch_norm(input_shapes, 4, 10, device)
+    bias_data, bias_tensor = data_gen_with_range_batch_norm(input_shapes, 4, 10, device)
+
+    compute_config = ttnn.init_device_compute_kernel_config(
+        device.arch(),
+        math_fidelity=ttnn.MathFidelity.LoFi
+        if not fp32_dest_acc_en
+        else (ttnn.MathFidelity.HiFi3 if is_wormhole_b0() else ttnn.MathFidelity.HiFi4),
+        math_approx_mode=False,
+        fp32_dest_acc_en=fp32_dest_acc_en,
+    )
+
+    tt_mean = ttnn.clone(mean_tensor) if check_mean else None
+    tt_var = ttnn.clone(var_tensor) if check_var else None
+
+    # Completing without hang is the primary assertion; numeric check is secondary.
+    tt_output_tensor = ttnn.batch_norm(
+        input_tensor,
+        running_mean=tt_mean,
+        running_var=tt_var,
+        weight=weight_tensor,
+        bias=bias_tensor,
+        training=True,
+        momentum=0.1,
+        compute_kernel_config=compute_config,
+    )
+    tt_output = ttnn.to_torch(tt_output_tensor)
+
+    channels = input_shapes[1]
+    torch_mean_ref = mean_data.clone() if mean_data is not None else None
+    torch_var_ref = var_data.clone() if var_data is not None else None
+    ref_mean = (
+        torch_mean_ref
+        if torch_mean_ref is not None
+        else (torch.zeros(channels, dtype=in_data.dtype) if torch_var_ref is not None else None)
+    )
+    ref_var = (
+        torch_var_ref
+        if torch_var_ref is not None
+        else (torch.ones(channels, dtype=in_data.dtype) if torch_mean_ref is not None else None)
+    )
+
+    torch_result = torch.nn.functional.batch_norm(
+        input=in_data,
+        running_mean=ref_mean,
+        running_var=ref_var,
+        weight=weight_data,
+        bias=bias_data,
+        training=True,
+        momentum=0.1,
+    )
+    frobenius_threshold = 0.25 if not fp32_dest_acc_en else 0.15
+    assert_numeric_metrics(
+        torch_result, tt_output, pcc_threshold=0.99, rtol=0.1, atol=4.0, frobenius_threshold=frobenius_threshold
+    )

--- a/tests/ttnn/unit_tests/operations/fused/test_batch_norm_program_cache.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_batch_norm_program_cache.py
@@ -164,10 +164,13 @@ def test_bn_cache_miss_different_dtype(device, isolate_program_cache):
 
 
 def test_bn_cache_optional_stat_presence(device, isolate_program_cache):
-    """running_mean/running_var presence is baked into the RunningStatistics program, so each
-    present/absent combination must key a distinct program while a repeated combination reuses it.
-    Only RunningStatistics depends on this presence, so the entry growth is attributable to it
-    (the upstream reduction/batch-norm programs are identical across combinations)."""
+    """running_mean/running_var presence is baked into the RunningStatistics program.  Three
+    presence combinations dispatch RunningStatistics (both, mean-only, var-only) and each must
+    key a distinct program while a repeated combination reuses it.  The fourth combination
+    (both absent) never dispatches RunningStatistics — batch_norm.cpp skips the op — so no
+    new program entry is created.  Only RunningStatistics depends on this presence, so the
+    entry growth is attributable to it (the upstream reduction/batch-norm programs are identical
+    across combinations)."""
     # Both stats present.
     _run_bn_training(device, BASE_SHAPE, momentum=0.1, with_mean=True, with_var=True, seed=0)
     n_both = device.cache_entries_counter.total
@@ -188,10 +191,10 @@ def test_bn_cache_optional_stat_presence(device, isolate_program_cache):
     _run_bn_training(device, BASE_SHAPE, momentum=0.1, with_mean=False, with_var=True, seed=5)
     assert device.cache_entries_counter.total == n_var_only  # same combo -> reuse
 
-    # Neither stat present -> a fourth distinct combination. In training mode RunningStatistics
-    # still runs (it just has no buffers to update), so this presence combo keys its own program.
+    # Neither stat present -> batch_norm.cpp skips running_statistics entirely (no buffers
+    # to update), so no new program entry is created for this combination.
     _run_bn_training(device, BASE_SHAPE, momentum=0.1, with_mean=False, with_var=False, seed=6)
     n_neither = device.cache_entries_counter.total
-    assert n_neither > n_var_only
+    assert n_neither == n_var_only  # no running_statistics dispatch -> no new entry
     _run_bn_training(device, BASE_SHAPE, momentum=0.1, with_mean=False, with_var=False, seed=7)
-    assert device.cache_entries_counter.total == n_neither  # same combo -> reuse
+    assert device.cache_entries_counter.total == n_neither  # still no growth

--- a/ttnn/cpp/ttnn/kernel/compute/dest_format_helpers.hpp
+++ b/ttnn/cpp/ttnn/kernel/compute/dest_format_helpers.hpp
@@ -139,6 +139,49 @@ ALWI void add_tiles_to_cb(
     cb_out.push_back(onetile);
 }
 
+// Like add_tiles_to_cb, but also packs the same DST tile to a second output CB.
+ALWI void add_tiles_to_two_cbs(
+    uint32_t icb0,
+    uint32_t icb1,
+    uint32_t ocb0,
+    uint32_t ocb1,
+    uint32_t itile0 = 0,
+    uint32_t itile1 = 0,
+    uint32_t pop0 = 1,
+    uint32_t pop1 = 1) {
+    constexpr uint32_t onetile = 1;
+    constexpr int dst0 = 0;
+    CircularBuffer cb_in0(icb0);
+    CircularBuffer cb_in1(icb1);
+    CircularBuffer cb_out0(ocb0);
+    CircularBuffer cb_out1(ocb1);
+
+    cb_out0.reserve_back(onetile);
+    cb_out1.reserve_back(onetile);
+    cb_in0.wait_front(itile0 + 1);
+    cb_in1.wait_front(itile1 + 1);
+
+    tile_regs_acquire();
+    add_tiles_init_with_dt(icb0, icb1);
+    add_tiles(icb0, icb1, itile0, itile1, dst0);
+    tile_regs_commit();
+
+    tile_regs_wait();
+    pack_tile_with_dt(dst0, ocb0);
+    pack_tile_with_dt(dst0, ocb1);
+    tile_regs_release();
+
+    if (pop0) {
+        cb_in0.pop_front(pop0);
+    }
+    if (pop1) {
+        cb_in1.pop_front(pop1);
+    }
+
+    cb_out0.push_back(onetile);
+    cb_out1.push_back(onetile);
+}
+
 ALWI void sub_tiles_to_cb(
     uint32_t icb0,
     uint32_t icb1,

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/batch_norm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/batch_norm.cpp
@@ -127,7 +127,8 @@ Tensor batch_norm(
     auto output_tensor = ttnn::prim::batch_norm(
         input, batch_mean, batch_var, eps, weight, bias, output, memory_config, compute_kernel_config);
 
-    if (training) {
+    // Skip when neither running stat is provided: the return value is discarded.
+    if (training && (running_mean.has_value() || running_var.has_value())) {
         ttnn::prim::running_statistics(
             batch_mean, batch_var, momentum, running_mean, running_var, memory_config, compute_kernel_config);
     }

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/running_statistics_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/running_statistics_kernel.cpp
@@ -8,6 +8,44 @@
 #include "ttnn/kernel/compute/dest_format_helpers.hpp"
 #include "api/dataflow/dataflow_buffer.h"
 
+// Adds tmp2 + tmp3 and packs to stat_cb.  When AlsoPackToOutput is true,
+// also packs the same result to out_dfb (reserve/push handled internally).
+template <bool AlsoPackToOutput>
+ALWI void add_and_pack_stat(
+    uint32_t dfb_tmp2, uint32_t dfb_tmp3, uint32_t dfb_stat, uint32_t dfb_out, DataflowBuffer& dfb_out_obj) {
+    constexpr uint32_t onetile = 1;
+    constexpr uint32_t dst0 = 0;
+    CircularBuffer cb_tmp2(dfb_tmp2);
+    CircularBuffer cb_tmp3(dfb_tmp3);
+    CircularBuffer cb_stat(dfb_stat);
+
+    cb_stat.reserve_back(onetile);
+    if constexpr (AlsoPackToOutput) {
+        dfb_out_obj.reserve_back(onetile);
+    }
+    cb_tmp2.wait_front(1);
+    cb_tmp3.wait_front(1);
+
+    tile_regs_acquire();
+    add_tiles_init_with_dt(dfb_tmp2, dfb_tmp3);
+    add_tiles(dfb_tmp2, dfb_tmp3, 0, 0, dst0);
+    tile_regs_commit();
+
+    tile_regs_wait();
+    pack_tile_with_dt(dst0, dfb_stat);
+    if constexpr (AlsoPackToOutput) {
+        pack_tile(dst0, dfb_out);
+    }
+    tile_regs_release();
+
+    cb_tmp2.pop_front(1);
+    cb_tmp3.pop_front(1);
+    cb_stat.push_back(onetile);
+    if constexpr (AlsoPackToOutput) {
+        dfb_out_obj.push_back(onetile);
+    }
+}
+
 void kernel_main() {
     uint32_t num_tiles = get_arg_val<uint32_t>(0);
     constexpr uint32_t old_running_mean_has_value = get_compile_time_arg_val(0) == 1;
@@ -38,89 +76,25 @@ void kernel_main() {
 
     for (uint32_t tile_id = 0; tile_id < num_tiles; ++tile_id) {
         // updated_running_stat = (1 − momentum) × running_stat + momentum × batch_stat
-        //
-        // The *_tiles_to_cb helpers each run their own tile_regs_acquire/release cycle, so
-        // wrapping them in an outer tile_regs bracket is invalid (nested acquire is UB and
-        // the final pack would read stale DST). Instead, inline the last add step to keep
-        // DST live for packing to both the stat DFB and the output DFB.
 
         if constexpr (old_running_mean_has_value) {
             sub_tiles_to_cb(dfb_one, dfb_momentum, dfb_tmp1, 0, 0, 0, 0);           // 1 - momentum
             mul_tiles_to_cb(dfb_momentum, dfb_batch_mean, dfb_tmp2, 0, 0, 0, 1);    // momentum * batch_mean
             mul_tiles_to_cb(dfb_tmp1, dfb_old_running_mean, dfb_tmp3, 0, 0, 1, 1);  // (1-momentum) * running_mean
-
-            // Inline final add: tmp2 + tmp3 → updated_running_mean (and → output if var absent)
-            {
-                constexpr uint32_t dst0 = 0;
-                CircularBuffer cb_tmp2(dfb_tmp2);
-                CircularBuffer cb_tmp3(dfb_tmp3);
-                CircularBuffer cb_stat(dfb_updated_running_mean);
-
-                cb_stat.reserve_back(onetile);
-                cb_tmp2.wait_front(1);
-                cb_tmp3.wait_front(1);
-
-                tile_regs_acquire();
-                add_tiles_init_with_dt(dfb_tmp2, dfb_tmp3);
-                add_tiles(dfb_tmp2, dfb_tmp3, 0, 0, dst0);
-                tile_regs_commit();
-
-                tile_regs_wait();
-                pack_tile_with_dt(dst0, dfb_updated_running_mean);
-                if constexpr (!old_running_var_has_value) {
-                    dfb_out0_obj.reserve_back(onetile);
-                    pack_tile(dst0, dfb_out0);
-                }
-                tile_regs_release();
-
-                cb_tmp2.pop_front(1);
-                cb_tmp3.pop_front(1);
-                cb_stat.push_back(onetile);
-                if constexpr (!old_running_var_has_value) {
-                    dfb_out0_obj.push_back(onetile);
-                }
-            }
+            add_and_pack_stat<!old_running_var_has_value>(
+                dfb_tmp2, dfb_tmp3, dfb_updated_running_mean, dfb_out0, dfb_out0_obj);
         }
 
         if constexpr (old_running_var_has_value) {
             sub_tiles_to_cb(dfb_one, dfb_momentum, dfb_tmp1, 0, 0, 0, 0);          // 1 - momentum
             mul_tiles_to_cb(dfb_momentum, dfb_batch_var, dfb_tmp2, 0, 0, 0, 1);    // momentum * batch_var
             mul_tiles_to_cb(dfb_tmp1, dfb_old_running_var, dfb_tmp3, 0, 0, 1, 1);  // (1-momentum) * running_var
-
-            // Inline final add: tmp2 + tmp3 → updated_running_var and → output
-            {
-                constexpr uint32_t dst0 = 0;
-                CircularBuffer cb_tmp2(dfb_tmp2);
-                CircularBuffer cb_tmp3(dfb_tmp3);
-                CircularBuffer cb_stat(dfb_updated_running_var);
-
-                cb_stat.reserve_back(onetile);
-                dfb_out0_obj.reserve_back(onetile);
-                cb_tmp2.wait_front(1);
-                cb_tmp3.wait_front(1);
-
-                tile_regs_acquire();
-                add_tiles_init_with_dt(dfb_tmp2, dfb_tmp3);
-                add_tiles(dfb_tmp2, dfb_tmp3, 0, 0, dst0);
-                tile_regs_commit();
-
-                tile_regs_wait();
-                pack_tile_with_dt(dst0, dfb_updated_running_var);
-                pack_tile(dst0, dfb_out0);
-                tile_regs_release();
-
-                cb_tmp2.pop_front(1);
-                cb_tmp3.pop_front(1);
-                cb_stat.push_back(onetile);
-                dfb_out0_obj.push_back(onetile);
-            }
+            add_and_pack_stat<true>(dfb_tmp2, dfb_tmp3, dfb_updated_running_var, dfb_out0, dfb_out0_obj);
         }
 
         if constexpr (!old_running_mean_has_value && !old_running_var_has_value) {
-            // Neither stat present: copy batch_mean to the output rather than leaving the
-            // reserved tile uninitialised. Matches SFPU both-absent handling. The return
-            // value of running_statistics is discarded by batch_norm.cpp, but the writer
-            // kernel still consumes it.
+            // Neither stat present: copy batch_mean to the output so the writer
+            // kernel has a tile to consume.
             CircularBuffer cb_batch_mean(dfb_batch_mean);
             cb_batch_mean.wait_front(onetile);
             dfb_out0_obj.reserve_back(onetile);
@@ -133,6 +107,22 @@ void kernel_main() {
             tile_regs_release();
             cb_batch_mean.pop_front(onetile);
             dfb_out0_obj.push_back(onetile);
+        }
+
+        // Drain batch stat CBs not consumed by the blocks above.
+        // Reader pushes batch_mean and writer pushes batch_var every tile
+        // unconditionally; when a stat is absent the corresponding mul compiles
+        // out, so we must pop here to prevent the CB from filling and stalling
+        // the producer.
+        if constexpr (!old_running_mean_has_value && old_running_var_has_value) {
+            CircularBuffer cb_bm(dfb_batch_mean);
+            cb_bm.wait_front(onetile);
+            cb_bm.pop_front(onetile);
+        }
+        if constexpr (!old_running_var_has_value) {
+            CircularBuffer cb_bv(dfb_batch_var);
+            cb_bv.wait_front(onetile);
+            cb_bv.pop_front(onetile);
         }
     }
 

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/running_statistics_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/running_statistics_kernel.cpp
@@ -8,48 +8,13 @@
 #include "ttnn/kernel/compute/dest_format_helpers.hpp"
 #include "api/dataflow/dataflow_buffer.h"
 
-// Adds tmp2 + tmp3 and packs to stat_cb.  When AlsoPackToOutput is true,
-// also packs the same result to out_dfb (reserve/push handled internally).
-template <bool AlsoPackToOutput>
-ALWI void add_and_pack_stat(
-    uint32_t dfb_tmp2, uint32_t dfb_tmp3, uint32_t dfb_stat, uint32_t dfb_out, DataflowBuffer& dfb_out_obj) {
-    constexpr uint32_t onetile = 1;
-    constexpr uint32_t dst0 = 0;
-    CircularBuffer cb_tmp2(dfb_tmp2);
-    CircularBuffer cb_tmp3(dfb_tmp3);
-    CircularBuffer cb_stat(dfb_stat);
-
-    cb_stat.reserve_back(onetile);
-    if constexpr (AlsoPackToOutput) {
-        dfb_out_obj.reserve_back(onetile);
-    }
-    cb_tmp2.wait_front(1);
-    cb_tmp3.wait_front(1);
-
-    tile_regs_acquire();
-    add_tiles_init_with_dt(dfb_tmp2, dfb_tmp3);
-    add_tiles(dfb_tmp2, dfb_tmp3, 0, 0, dst0);
-    tile_regs_commit();
-
-    tile_regs_wait();
-    pack_tile_with_dt(dst0, dfb_stat);
-    if constexpr (AlsoPackToOutput) {
-        pack_tile(dst0, dfb_out);
-    }
-    tile_regs_release();
-
-    cb_tmp2.pop_front(1);
-    cb_tmp3.pop_front(1);
-    cb_stat.push_back(onetile);
-    if constexpr (AlsoPackToOutput) {
-        dfb_out_obj.push_back(onetile);
-    }
-}
-
 void kernel_main() {
     uint32_t num_tiles = get_arg_val<uint32_t>(0);
     constexpr uint32_t old_running_mean_has_value = get_compile_time_arg_val(0) == 1;
     constexpr uint32_t old_running_var_has_value = get_compile_time_arg_val(1) == 1;
+    static_assert(
+        old_running_mean_has_value || old_running_var_has_value,
+        "running_statistics requires at least one of running_mean / running_var");
 
     constexpr auto dfb_batch_mean = get_compile_time_arg_val(2);  // batch mean
     constexpr auto dfb_batch_var = get_compile_time_arg_val(3);   // batch var
@@ -64,7 +29,8 @@ void kernel_main() {
     constexpr auto dfb_tmp2 = get_compile_time_arg_val(12);                 // tmp 2
     constexpr auto dfb_tmp3 = get_compile_time_arg_val(13);                 // tmp 3
 
-    DataflowBuffer dfb_out0_obj(dfb_out0);
+    DataflowBuffer dfb_batch_mean_obj(dfb_batch_mean);
+    DataflowBuffer dfb_batch_var_obj(dfb_batch_var);
     DataflowBuffer dfb_momentum_obj(dfb_momentum);
     DataflowBuffer dfb_one_obj(dfb_one);
 
@@ -76,54 +42,38 @@ void kernel_main() {
 
     for (uint32_t tile_id = 0; tile_id < num_tiles; ++tile_id) {
         // updated_running_stat = (1 − momentum) × running_stat + momentum × batch_stat
+        //
+        // HAZARD: reader/writer push batch_mean and batch_var every tile regardless of
+        // which stats are present. Both must be waited and popped unconditionally here;
+        // omitting a pop will stall the producer after the CB fills (CB depth is 2).
+
+        dfb_batch_mean_obj.wait_front(onetile);
+        dfb_batch_var_obj.wait_front(onetile);
 
         if constexpr (old_running_mean_has_value) {
             sub_tiles_to_cb(dfb_one, dfb_momentum, dfb_tmp1, 0, 0, 0, 0);           // 1 - momentum
-            mul_tiles_to_cb(dfb_momentum, dfb_batch_mean, dfb_tmp2, 0, 0, 0, 1);    // momentum * batch_mean
+            mul_tiles_to_cb(dfb_momentum, dfb_batch_mean, dfb_tmp2, 0, 0, 0, 0);    // momentum * batch_mean
             mul_tiles_to_cb(dfb_tmp1, dfb_old_running_mean, dfb_tmp3, 0, 0, 1, 1);  // (1-momentum) * running_mean
-            add_and_pack_stat<!old_running_var_has_value>(
-                dfb_tmp2, dfb_tmp3, dfb_updated_running_mean, dfb_out0, dfb_out0_obj);
+            if constexpr (old_running_var_has_value) {
+                // Var block below will pack to dfb_out0.
+                add_tiles_to_cb(dfb_tmp2, dfb_tmp3, dfb_updated_running_mean, 0, 0, 1, 1);
+            } else {
+                // No var block — this is the last compute in the tile, so pack
+                // the mean result to both dfb_updated_running_mean and dfb_out0.
+                add_tiles_to_two_cbs(dfb_tmp2, dfb_tmp3, dfb_updated_running_mean, dfb_out0, 0, 0, 1, 1);
+            }
         }
 
         if constexpr (old_running_var_has_value) {
             sub_tiles_to_cb(dfb_one, dfb_momentum, dfb_tmp1, 0, 0, 0, 0);          // 1 - momentum
-            mul_tiles_to_cb(dfb_momentum, dfb_batch_var, dfb_tmp2, 0, 0, 0, 1);    // momentum * batch_var
+            mul_tiles_to_cb(dfb_momentum, dfb_batch_var, dfb_tmp2, 0, 0, 0, 0);    // momentum * batch_var
             mul_tiles_to_cb(dfb_tmp1, dfb_old_running_var, dfb_tmp3, 0, 0, 1, 1);  // (1-momentum) * running_var
-            add_and_pack_stat<true>(dfb_tmp2, dfb_tmp3, dfb_updated_running_var, dfb_out0, dfb_out0_obj);
+            // Last compute in the tile — pack to both dfb_updated_running_var and dfb_out0.
+            add_tiles_to_two_cbs(dfb_tmp2, dfb_tmp3, dfb_updated_running_var, dfb_out0, 0, 0, 1, 1);
         }
 
-        if constexpr (!old_running_mean_has_value && !old_running_var_has_value) {
-            // Neither stat present: copy batch_mean to the output so the writer
-            // kernel has a tile to consume.
-            CircularBuffer cb_batch_mean(dfb_batch_mean);
-            cb_batch_mean.wait_front(onetile);
-            dfb_out0_obj.reserve_back(onetile);
-            tile_regs_acquire();
-            copy_tile_init_with_dt(dfb_batch_mean);
-            copy_tile(dfb_batch_mean, 0, 0);
-            tile_regs_commit();
-            tile_regs_wait();
-            pack_tile(0, dfb_out0);
-            tile_regs_release();
-            cb_batch_mean.pop_front(onetile);
-            dfb_out0_obj.push_back(onetile);
-        }
-
-        // Drain batch stat CBs not consumed by the blocks above.
-        // Reader pushes batch_mean and writer pushes batch_var every tile
-        // unconditionally; when a stat is absent the corresponding mul compiles
-        // out, so we must pop here to prevent the CB from filling and stalling
-        // the producer.
-        if constexpr (!old_running_mean_has_value && old_running_var_has_value) {
-            CircularBuffer cb_bm(dfb_batch_mean);
-            cb_bm.wait_front(onetile);
-            cb_bm.pop_front(onetile);
-        }
-        if constexpr (!old_running_var_has_value) {
-            CircularBuffer cb_bv(dfb_batch_var);
-            cb_bv.wait_front(onetile);
-            cb_bv.pop_front(onetile);
-        }
+        dfb_batch_mean_obj.pop_front(onetile);
+        dfb_batch_var_obj.pop_front(onetile);
     }
 
     dfb_one_obj.pop_front(1);

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/running_statistics_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/running_statistics_kernel.cpp
@@ -37,26 +37,103 @@ void kernel_main() {
     dfb_momentum_obj.wait_front(1);
 
     for (uint32_t tile_id = 0; tile_id < num_tiles; ++tile_id) {
-        tile_regs_acquire();
         // updated_running_stat = (1 − momentum) × running_stat + momentum × batch_stat
+        //
+        // The *_tiles_to_cb helpers each run their own tile_regs_acquire/release cycle, so
+        // wrapping them in an outer tile_regs bracket is invalid (nested acquire is UB and
+        // the final pack would read stale DST). Instead, inline the last add step to keep
+        // DST live for packing to both the stat DFB and the output DFB.
 
         if constexpr (old_running_mean_has_value) {
-            sub_tiles_to_cb(dfb_one, dfb_momentum, dfb_tmp1, 0, 0, 0, 0);               // 1 - momentum
-            mul_tiles_to_cb(dfb_momentum, dfb_batch_mean, dfb_tmp2, 0, 0, 0, 1);        // momentum * batch stat
-            mul_tiles_to_cb(dfb_tmp1, dfb_old_running_mean, dfb_tmp3, 0, 0, 1, 1);      // cb_tmp1 * running stats
-            add_tiles_to_cb(dfb_tmp2, dfb_tmp3, dfb_updated_running_mean, 0, 0, 1, 1);  // cb_tmp2 + cb_tmp3
+            sub_tiles_to_cb(dfb_one, dfb_momentum, dfb_tmp1, 0, 0, 0, 0);           // 1 - momentum
+            mul_tiles_to_cb(dfb_momentum, dfb_batch_mean, dfb_tmp2, 0, 0, 0, 1);    // momentum * batch_mean
+            mul_tiles_to_cb(dfb_tmp1, dfb_old_running_mean, dfb_tmp3, 0, 0, 1, 1);  // (1-momentum) * running_mean
+
+            // Inline final add: tmp2 + tmp3 → updated_running_mean (and → output if var absent)
+            {
+                constexpr uint32_t dst0 = 0;
+                CircularBuffer cb_tmp2(dfb_tmp2);
+                CircularBuffer cb_tmp3(dfb_tmp3);
+                CircularBuffer cb_stat(dfb_updated_running_mean);
+
+                cb_stat.reserve_back(onetile);
+                cb_tmp2.wait_front(1);
+                cb_tmp3.wait_front(1);
+
+                tile_regs_acquire();
+                add_tiles_init_with_dt(dfb_tmp2, dfb_tmp3);
+                add_tiles(dfb_tmp2, dfb_tmp3, 0, 0, dst0);
+                tile_regs_commit();
+
+                tile_regs_wait();
+                pack_tile_with_dt(dst0, dfb_updated_running_mean);
+                if constexpr (!old_running_var_has_value) {
+                    dfb_out0_obj.reserve_back(onetile);
+                    pack_tile(dst0, dfb_out0);
+                }
+                tile_regs_release();
+
+                cb_tmp2.pop_front(1);
+                cb_tmp3.pop_front(1);
+                cb_stat.push_back(onetile);
+                if constexpr (!old_running_var_has_value) {
+                    dfb_out0_obj.push_back(onetile);
+                }
+            }
         }
+
         if constexpr (old_running_var_has_value) {
-            sub_tiles_to_cb(dfb_one, dfb_momentum, dfb_tmp1, 0, 0, 0, 0);              // 1 - momentum
-            mul_tiles_to_cb(dfb_momentum, dfb_batch_var, dfb_tmp2, 0, 0, 0, 1);        // momentum * batch stat
-            mul_tiles_to_cb(dfb_tmp1, dfb_old_running_var, dfb_tmp3, 0, 0, 1, 1);      // cb_tmp1 * running stats
-            add_tiles_to_cb(dfb_tmp2, dfb_tmp3, dfb_updated_running_var, 0, 0, 1, 1);  // cb_tmp2 + cb_tmp3
+            sub_tiles_to_cb(dfb_one, dfb_momentum, dfb_tmp1, 0, 0, 0, 0);          // 1 - momentum
+            mul_tiles_to_cb(dfb_momentum, dfb_batch_var, dfb_tmp2, 0, 0, 0, 1);    // momentum * batch_var
+            mul_tiles_to_cb(dfb_tmp1, dfb_old_running_var, dfb_tmp3, 0, 0, 1, 1);  // (1-momentum) * running_var
+
+            // Inline final add: tmp2 + tmp3 → updated_running_var and → output
+            {
+                constexpr uint32_t dst0 = 0;
+                CircularBuffer cb_tmp2(dfb_tmp2);
+                CircularBuffer cb_tmp3(dfb_tmp3);
+                CircularBuffer cb_stat(dfb_updated_running_var);
+
+                cb_stat.reserve_back(onetile);
+                dfb_out0_obj.reserve_back(onetile);
+                cb_tmp2.wait_front(1);
+                cb_tmp3.wait_front(1);
+
+                tile_regs_acquire();
+                add_tiles_init_with_dt(dfb_tmp2, dfb_tmp3);
+                add_tiles(dfb_tmp2, dfb_tmp3, 0, 0, dst0);
+                tile_regs_commit();
+
+                tile_regs_wait();
+                pack_tile_with_dt(dst0, dfb_updated_running_var);
+                pack_tile(dst0, dfb_out0);
+                tile_regs_release();
+
+                cb_tmp2.pop_front(1);
+                cb_tmp3.pop_front(1);
+                cb_stat.push_back(onetile);
+                dfb_out0_obj.push_back(onetile);
+            }
         }
-        tile_regs_commit();
-        tile_regs_wait();
-        pack_tile(0, dfb_out0);
-        tile_regs_release();
-        dfb_out0_obj.push_back(1);
+
+        if constexpr (!old_running_mean_has_value && !old_running_var_has_value) {
+            // Neither stat present: copy batch_mean to the output rather than leaving the
+            // reserved tile uninitialised. Matches SFPU both-absent handling. The return
+            // value of running_statistics is discarded by batch_norm.cpp, but the writer
+            // kernel still consumes it.
+            CircularBuffer cb_batch_mean(dfb_batch_mean);
+            cb_batch_mean.wait_front(onetile);
+            dfb_out0_obj.reserve_back(onetile);
+            tile_regs_acquire();
+            copy_tile_init_with_dt(dfb_batch_mean);
+            copy_tile(dfb_batch_mean, 0, 0);
+            tile_regs_commit();
+            tile_regs_wait();
+            pack_tile(0, dfb_out0);
+            tile_regs_release();
+            cb_batch_mean.pop_front(onetile);
+            dfb_out0_obj.push_back(onetile);
+        }
     }
 
     dfb_one_obj.pop_front(1);

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/running_statistics_sfpu_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/running_statistics_sfpu_kernel.cpp
@@ -305,6 +305,16 @@ void kernel_main() {
             dfb_tmp2_obj.pop_front(onetile);
         }
 
+        // Drain batch_var when the var block compiled out.
+        // Writer pushes batch_var every tile unconditionally; when
+        // old_running_var_has_value is false the only consumer (the var
+        // computation block above) is absent, so pop here to prevent the
+        // CB from filling and stalling the writer.
+        if constexpr (!old_running_var_has_value) {
+            dfb_batch_var_obj.wait_front(onetile);
+            dfb_batch_var_obj.pop_front(onetile);
+        }
+
         dfb_out0_obj.push_back(1);
     }
     dfb_momentum_obj.pop_front(1);

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/running_statistics_sfpu_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/running_statistics_sfpu_kernel.cpp
@@ -94,6 +94,20 @@ void kernel_main() {
         dfb_batch_mean_obj.wait_front(onetile);
         dfb_out0_obj.reserve_back(1);
 
+        if constexpr (!old_running_mean_has_value && !old_running_var_has_value) {
+            // Neither stat present: copy batch_mean to the output rather than leaving
+            // the reserved tile uninitialised. The return value of running_statistics is
+            // discarded by batch_norm.cpp, but the writer kernel still consumes it.
+            tile_regs_acquire();
+            copy_tile_to_dst_init_short_with_dt(last_srca_dfb, dfb_batch_mean);
+            last_srca_dfb = dfb_batch_mean;
+            copy_tile(dfb_batch_mean, tile_index, tile_index * 2);
+            tile_regs_commit();
+            tile_regs_wait();
+            pack_tile_with_dt(tile_index * 2, dfb_out0);
+            tile_regs_release();
+        }
+
         if constexpr (old_running_mean_has_value) {
             // 1 - momentum
             dfb_tmp1_obj.reserve_back(onetile);

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/running_statistics_sfpu_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/running_statistics_sfpu_kernel.cpp
@@ -45,6 +45,9 @@ void kernel_main() {
     uint32_t num_tiles = get_arg_val<uint32_t>(0);
     constexpr uint32_t old_running_mean_has_value = get_compile_time_arg_val(0) == 1;
     constexpr uint32_t old_running_var_has_value = get_compile_time_arg_val(1) == 1;
+    static_assert(
+        old_running_mean_has_value || old_running_var_has_value,
+        "running_statistics requires at least one of running_mean / running_var");
 
     constexpr auto dfb_batch_mean = get_compile_time_arg_val(2);  // batch mean
     constexpr auto dfb_batch_var = get_compile_time_arg_val(3);   // batch var
@@ -92,21 +95,8 @@ void kernel_main() {
         constexpr uint32_t tile_index = 0;
 
         dfb_batch_mean_obj.wait_front(onetile);
+        dfb_batch_var_obj.wait_front(onetile);
         dfb_out0_obj.reserve_back(1);
-
-        if constexpr (!old_running_mean_has_value && !old_running_var_has_value) {
-            // Neither stat present: copy batch_mean to the output rather than leaving
-            // the reserved tile uninitialised. The return value of running_statistics is
-            // discarded by batch_norm.cpp, but the writer kernel still consumes it.
-            tile_regs_acquire();
-            copy_tile_to_dst_init_short_with_dt(last_srca_dfb, dfb_batch_mean);
-            last_srca_dfb = dfb_batch_mean;
-            copy_tile(dfb_batch_mean, tile_index, tile_index * 2);
-            tile_regs_commit();
-            tile_regs_wait();
-            pack_tile_with_dt(tile_index * 2, dfb_out0);
-            tile_regs_release();
-        }
 
         if constexpr (old_running_mean_has_value) {
             // 1 - momentum
@@ -207,8 +197,6 @@ void kernel_main() {
             dfb_tmp2_obj.pop_front(onetile);
         }
 
-        dfb_batch_mean_obj.pop_front(onetile);
-
         if constexpr (old_running_var_has_value) {
             // 1 - momentum
             dfb_tmp1_obj.reserve_back(onetile);
@@ -230,7 +218,6 @@ void kernel_main() {
             dfb_tmp1_obj.push_back(onetile);
 
             // momentum * batch stat
-            dfb_batch_var_obj.wait_front(onetile);
             dfb_tmp2_obj.reserve_back(onetile);
             tile_regs_acquire();
             mul_binary_tile_init();
@@ -247,8 +234,6 @@ void kernel_main() {
             pack_tile_with_dt(tile_index * 2, dfb_tmp2);
             tile_regs_release();
             dfb_tmp2_obj.push_back(onetile);
-
-            dfb_batch_var_obj.pop_front(onetile);
 
             // cb_tmp1 * running stats --> (1 - momentum) * running stats
             dfb_tmp1_obj.wait_front(onetile);
@@ -305,16 +290,8 @@ void kernel_main() {
             dfb_tmp2_obj.pop_front(onetile);
         }
 
-        // Drain batch_var when the var block compiled out.
-        // Writer pushes batch_var every tile unconditionally; when
-        // old_running_var_has_value is false the only consumer (the var
-        // computation block above) is absent, so pop here to prevent the
-        // CB from filling and stalling the writer.
-        if constexpr (!old_running_var_has_value) {
-            dfb_batch_var_obj.wait_front(onetile);
-            dfb_batch_var_obj.pop_front(onetile);
-        }
-
+        dfb_batch_mean_obj.pop_front(onetile);
+        dfb_batch_var_obj.pop_front(onetile);
         dfb_out0_obj.push_back(1);
     }
     dfb_momentum_obj.pop_front(1);

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/running_statistics_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/running_statistics_device_operation.cpp
@@ -39,6 +39,10 @@ void RunningStatistics::validate_tensors(
     check_tensor_stat(batch_mean, "batch_mean_shape", C);
     check_tensor_stat(batch_var, "batch_var_shape", C);
 
+    TT_FATAL(
+        running_mean.has_value() || running_var.has_value(),
+        "running_statistics requires at least one of running_mean / running_var");
+
     // running_mean (1, C, 1, 1)
     if (running_mean.has_value()) {
         check_tensor_stat(running_mean.value(), "running_mean_shape", C);


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/tt-metal/issues/51563

## Summary

Fixes four bugs in the `running_statistics` FPU and SFPU compute kernels, masked by
Metal 1.0 circular-buffer semantics, that would surface as hangs or incorrect output
under Metal 2.0 dataflow buffers.

### Bugs fixed

1. **CB drain hang** (user-visible): Reader pushes `batch_mean` and writer pushes
   `batch_var` every tile unconditionally, but compute only popped each when the
   corresponding `old_running_*` was present. With one stat absent, the unpopulated
   CB filled after 2 tiles and the producer stalled, hanging the device. Fixed by
   making `wait_front`/`pop_front` unconditional at the top and bottom of every tile
   iteration in both kernels. `pop1=0` on the intervening `mul_tiles_to_cb` calls
   prevents double-pops.

2. **Nested `tile_regs_acquire`** (FPU): The kernel acquired tile registers around the
   full tile body and again inside each `*_tiles_to_cb` helper. Fixed by removing the
   outer bracket.

3. **Missing `reserve_back` on `dfb_out0`** (FPU): Packed into `dfb_out0` without
   reserving space. Fixed via `add_tiles_to_two_cbs`.

4. **Both-absent invariant**: `running_statistics` now requires at least one of
   `running_mean`/`running_var`. Enforced at three layers: `TT_FATAL` in
   `validate_tensors`, `static_assert` in both compute kernels
   (`running_statistics_kernel.cpp:15-17`, `running_statistics_sfpu_kernel.cpp:48-50`),
   and a dispatch guard in `batch_norm.cpp`. The kernel-side both-absent code blocks
   (~14 lines each) that previously handled this case are deleted — they were provably
   unreachable and would have had to be carried through the Metal 2.0 port.

### Infrastructure

- **`add_tiles_to_two_cbs`** added to `ttnn/kernel/compute/dest_format_helpers.hpp`:
  add + pack result to two output CBs with `pack_tile_with_dt` (correct under
  `FP32_DEST_ACC_EN`). Single caller today.

### Test changes

- **`test_batch_norm_running_statistics_drain`**: regression test for the drain hang.
  Channels derived from `device.compute_with_storage_grid_size()` (Blackhole-safe).
  Asserts updated stat values.
- **`test_batch_norm_fpu_running_statistics`**: dropped `(False, False)` row (rejected
  by `validate_tensors`) — 32 → 24 cases.
- **`test_batch_norm_program_cache.py`**: assertion for the both-absent case updated
  from `n_neither > n_var_only` to `n_neither == n_var_only` (no dispatch → no new
  entry). Docstring states the three-combination invariant.
- **`[1, 128, 14, 14]` → `[1, 129, 14, 14]`** in `test_batch_norm_tests`, making it a
  WH regression guard for the drain hang (129 channels → ≥3 tiles on most grids).

### Accuracy

Configs that were functional before this change produce bit-identical output. This was
verified via per-channel Frobenius / PCC / max-abs comparison on WH against the initial
kernel restructuring (4d06cd6, 2026-07-29); all 16 unique output fingerprints confirmed
bit-identical between branches. Subsequent commits added the drain fix, dispatch guard,
`TT_FATAL`, `static_assert`s, and both-absent deletion — these are compile-time or
host-side changes with no effect on the output of configs that were already functional.

The mean-only and var-only training configs that previously hung are now unblocked and
produce correct results against a torch reference, verified in
`test_batch_norm_running_statistics_drain`.

> **Verified 2026-07-29**: [test_bn_pr_verification.py](https://github.com/user-attachments/files/30513503/test_bn_pr_verification.py) run on both `virdhatchani/BN_Fix_port` and `main` — all **16 unique output fingerprints** confirmed **bit-identical** between branches (see note above: 32 CI cases, 16 distinct main-output combos). All metric tables below are from actual test output.

### Precision context for the new test

The FPU path uses `LoFi` math fidelity with `fp32_dest_acc_en=False` — this is a deliberately low-precision configuration. The test thresholds reflect this:

| Compute Path | Math Fidelity | fp32 Dest Acc | Frobenius Range | Test Threshold |
|-------------|--------------|---------------|-----------------|----------------|
| SFPU (default) | HiFi3/4 | True | 0.01 – 0.05 | 0.15 |
| **FPU (this test)** | **LoFi** | **False** | **0.03 – 0.22** | **0.25** |

The higher Frobenius values (~0.19–0.21) appear only in `bias=False` cases because the output is centered near zero (mean ≈ −0.01), making the *relative* norm sensitive to small absolute errors (~1 in bf16). With `bias=True`, the same absolute errors are tiny relative to the shifted distribution (mean ≈ 7–8), giving Frobenius ≈ 0.03–0.14. This is expected bf16 LoFi behavior, not a kernel bug.

Detailed per-case breakdown:

| weight | bias | Shape [3,5,64,120] | Shape [1,8,24,42] | Why |
|--------|------|-------------------|-------------------|-----|
| True | True | Frob=0.137, PCC=0.999 | Frob=0.147, PCC=0.998 | Bias shifts output away from zero |
| True | False | Frob=0.192, PCC=0.999 | Frob=0.207, PCC=0.998 | Zero-centered → higher relative error |
| False | True | Frob=0.027, PCC=1.000 | Frob=0.028, PCC=1.000 | No weight scaling → tiny abs errors |
| False | False | Frob=0.192, PCC=1.000 | Frob=0.215, PCC=0.998 | Zero-centered, no weight |

Running statistics accuracy (all cases):

| Stat | Shape | PyTorch Reference | TT Output | Frobenius | All within 5%? |
|------|-------|-------------------|-----------|-----------|---------------|
| Mean | [3,5,64,120] | [6.53, 9.50, 7.72, 6.25, 5.19] | [6.34, 9.25, 7.50, 6.09, 5.03] | 0.027 | Yes (5/5) |
| Var | [3,5,64,120] | [9.63, 17.63, 12.75, 8.88, 6.06] | [9.38, 17.13, 12.44, 8.63, 5.88] | 0.027 | Yes (5/5) |
| Mean | [1,8,24,42] | [6.53, 9.50, 7.72, 6.25, 5.19, 7.25, 8.38, 9.31] | [6.31, 9.25, 7.50, 6.09, 5.03, 7.03, 8.06, 9.00] | 0.031 | Yes (8/8) |
| Var | [1,8,24,42] | [9.69, 17.63, 12.75, 8.88, 6.06, 11.56, 14.38, 17.13] | [9.44, 17.13, 12.44, 8.63, 5.91, 11.25, 14.00, 16.63] | 0.027 | Yes (8/8) |

### Pipeline status

- [x] Sanity
- [x] BH Sanity
- [x] Nightly for fused category
- [x] Single card
- [x] (Runtime) Sanity

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=virdhatchani/BN_Fix_port)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:virdhatchani/BN_Fix_port)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=virdhatchani/BN_Fix_port)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:virdhatchani/BN_Fix_port)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=virdhatchani/BN_Fix_port)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:virdhatchani/BN_Fix_port)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=virdhatchani/BN_Fix_port)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:virdhatchani/BN_Fix_port)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=virdhatchani/BN_Fix_port)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:virdhatchani/BN_Fix_port)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=virdhatchani/BN_Fix_port)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:virdhatchani/BN_Fix_port)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=virdhatchani/BN_Fix_port)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:virdhatchani/BN_Fix_port)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=virdhatchani/BN_Fix_port)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:virdhatchani/BN_Fix_port)