### PR TITLE
[Bug fix]: #51409 on splitting dfb id to be program unique and adding a device facing id that is unique within core group

### DIFF
--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_alias_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_alias_dataflow_buffer.cpp
@@ -471,6 +471,171 @@ TEST_F(MeshDeviceFixture, AliasDFBDataFlow1Sx1S) {
         /*entry_size_b=*/256, /*num_entries_b=*/16);
 }
 
+// Two WorkUnits on disjoint halves, each with its own aliased DFB pair. Slot packing must reuse
+// low slots across halves on WH/BH, and each half's alias pair must still share L1 and round-trip.
+TEST_F(MeshDeviceFixture, AliasDFBDisjointHalvesDataFlow) {
+    auto& mesh_device = devices_.at(0);
+    IDevice* device = mesh_device->get_devices()[0];
+    if (device->compute_with_storage_grid_size().x < 2) {
+        GTEST_SKIP() << "Needs at least two worker nodes in a row";
+    }
+
+    const NodeCoord node_a{0, 0};
+    const NodeCoord node_b{1, 0};
+    constexpr uint32_t kEntryA = 512;
+    constexpr uint32_t kEntriesA = 8;
+    constexpr uint32_t kEntryB = 256;
+    constexpr uint32_t kEntriesB = 16;
+
+    auto left = make_alias_dfb_program_spec(
+        mesh_device, node_a, kEntryA, kEntriesA, kEntryB, kEntriesB, /*num_producers=*/1, /*num_consumers=*/1);
+    auto right = make_alias_dfb_program_spec(
+        mesh_device, node_b, kEntryA, kEntriesA, kEntryB, kEntriesB, /*num_producers=*/1, /*num_consumers=*/1);
+
+    // Rename right-half entities so the combined ProgramSpec has unique ids.
+    auto rename_dfb = [](DataflowBufferSpec& dfb, const std::string& new_name, const std::string& alias_name) {
+        dfb.unique_id = DFBSpecName{new_name};
+        dfb.advanced_options = DFBAdvancedOptions{.alias_with = {DFBSpecName{alias_name}}};
+    };
+    auto rename_kernel = [](KernelSpec& k,
+                            const std::string& new_name,
+                            const std::string& dfb_a,
+                            const std::string& dfb_b,
+                            const std::string& in_tensor_a,
+                            const std::string& in_tensor_b,
+                            const std::string& out_tensor_a,
+                            const std::string& out_tensor_b) {
+        k.unique_id = KernelSpecName{new_name};
+        for (auto& b : k.dfb_bindings) {
+            if (b.dfb_spec_name.get() == "dfb_a") {
+                b.dfb_spec_name = DFBSpecName{dfb_a};
+            } else if (b.dfb_spec_name.get() == "dfb_b") {
+                b.dfb_spec_name = DFBSpecName{dfb_b};
+            }
+        }
+        for (auto& b : k.tensor_bindings) {
+            const auto& n = b.tensor_parameter_name.get();
+            if (n == "in_tensor_a") {
+                b.tensor_parameter_name = TensorParamName{in_tensor_a};
+            } else if (n == "in_tensor_b") {
+                b.tensor_parameter_name = TensorParamName{in_tensor_b};
+            } else if (n == "out_tensor_a") {
+                b.tensor_parameter_name = TensorParamName{out_tensor_a};
+            } else if (n == "out_tensor_b") {
+                b.tensor_parameter_name = TensorParamName{out_tensor_b};
+            }
+        }
+    };
+
+    // Left keeps dfb_a/dfb_b; right becomes dfb_c/dfb_d.
+    rename_dfb(right.spec.dataflow_buffers[0], "dfb_c", "dfb_d");
+    rename_dfb(right.spec.dataflow_buffers[1], "dfb_d", "dfb_c");
+    rename_kernel(
+        right.spec.kernels[0],
+        "producer_b",
+        "dfb_c",
+        "dfb_d",
+        "in_tensor_c",
+        "in_tensor_d",
+        "out_tensor_c",
+        "out_tensor_d");
+    rename_kernel(
+        right.spec.kernels[1],
+        "consumer_b",
+        "dfb_c",
+        "dfb_d",
+        "in_tensor_c",
+        "in_tensor_d",
+        "out_tensor_c",
+        "out_tensor_d");
+    right.spec.work_units[0].name = "wu_b";
+    right.spec.work_units[0].kernels = {KernelSpecName{"producer_b"}, KernelSpecName{"consumer_b"}};
+    right.spec.tensor_parameters[0].unique_id = TensorParamName{"in_tensor_c"};
+    right.spec.tensor_parameters[1].unique_id = TensorParamName{"in_tensor_d"};
+    right.spec.tensor_parameters[2].unique_id = TensorParamName{"out_tensor_c"};
+    right.spec.tensor_parameters[3].unique_id = TensorParamName{"out_tensor_d"};
+
+    left.spec.work_units[0].name = "wu_a";
+    left.spec.name = "alias_dfb_disjoint_halves";
+    left.spec.kernels.push_back(right.spec.kernels[0]);
+    left.spec.kernels.push_back(right.spec.kernels[1]);
+    left.spec.dataflow_buffers.push_back(right.spec.dataflow_buffers[0]);
+    left.spec.dataflow_buffers.push_back(right.spec.dataflow_buffers[1]);
+    left.spec.tensor_parameters.push_back(right.spec.tensor_parameters[0]);
+    left.spec.tensor_parameters.push_back(right.spec.tensor_parameters[1]);
+    left.spec.tensor_parameters.push_back(right.spec.tensor_parameters[2]);
+    left.spec.tensor_parameters.push_back(right.spec.tensor_parameters[3]);
+    left.spec.work_units.push_back(right.spec.work_units[0]);
+
+    // Point tensor_parameters specs at the right-half MeshTensors' layouts (already set from right).
+    Program program = MakeProgramFromSpec(*mesh_device, left.spec);
+
+    const bool is_quasar = device->arch() == ARCH::QUASAR;
+    // Each half has two aliased DFBs that conflict with each other → slots 0 and 1, reused across halves.
+    EXPECT_EQ(program.impl().get_dataflow_buffer(program.impl().get_dfb_handle("dfb_a"))->device_slot, 0u);
+    EXPECT_EQ(program.impl().get_dataflow_buffer(program.impl().get_dfb_handle("dfb_b"))->device_slot, 1u);
+    EXPECT_EQ(program.impl().get_dataflow_buffer(program.impl().get_dfb_handle("dfb_c"))->device_slot, 0u);
+    EXPECT_EQ(program.impl().get_dataflow_buffer(program.impl().get_dfb_handle("dfb_d"))->device_slot, 1u);
+
+    auto rtas = [&](const NodeCoord& node, uint32_t epc_a, uint32_t epc_b) {
+        return MakeRuntimeArgsForSingleNode(
+            node,
+            {
+                {"chunk_offset_a", 0u},
+                {"chunk_offset_b", 0u},
+                {"entries_per_core_a", epc_a},
+                {"entries_per_core_b", epc_b},
+            });
+    };
+
+    ProgramRunArgs run_params;
+    run_params.kernel_run_args = {
+        {.kernel = KernelSpecName{"producer"}, .runtime_arg_values = rtas(node_a, kEntriesA, kEntriesB)},
+        {.kernel = KernelSpecName{"consumer"}, .runtime_arg_values = rtas(node_a, kEntriesA, kEntriesB)},
+        {.kernel = KernelSpecName{"producer_b"}, .runtime_arg_values = rtas(node_b, kEntriesA, kEntriesB)},
+        {.kernel = KernelSpecName{"consumer_b"}, .runtime_arg_values = rtas(node_b, kEntriesA, kEntriesB)},
+    };
+    run_params.tensor_args = {
+        {TensorParamName{"in_tensor_a"}, TensorArgument{left.in_a}},
+        {TensorParamName{"in_tensor_b"}, TensorArgument{left.in_b}},
+        {TensorParamName{"out_tensor_a"}, TensorArgument{left.out_a}},
+        {TensorParamName{"out_tensor_b"}, TensorArgument{left.out_b}},
+        {TensorParamName{"in_tensor_c"}, TensorArgument{right.in_a}},
+        {TensorParamName{"in_tensor_d"}, TensorArgument{right.in_b}},
+        {TensorParamName{"out_tensor_c"}, TensorArgument{right.out_a}},
+        {TensorParamName{"out_tensor_d"}, TensorArgument{right.out_b}},
+    };
+    SetProgramRunArgs(program, run_params);
+
+    const uint32_t words_a = kEntriesA * kEntryA / sizeof(uint32_t);
+    const uint32_t words_b = kEntriesB * kEntryB / sizeof(uint32_t);
+    auto input_la = tt::test_utils::generate_uniform_random_vector<uint32_t>(0, 100, words_a);
+    auto input_lb = tt::test_utils::generate_uniform_random_vector<uint32_t>(0, 100, words_b);
+    auto input_ra = tt::test_utils::generate_uniform_random_vector<uint32_t>(0, 100, words_a);
+    auto input_rb = tt::test_utils::generate_uniform_random_vector<uint32_t>(0, 100, words_b);
+
+    detail::WriteToBuffer(*left.in_a.mesh_buffer().get_reference_buffer(), input_la);
+    detail::WriteToBuffer(*left.in_b.mesh_buffer().get_reference_buffer(), input_lb);
+    detail::WriteToBuffer(*right.in_a.mesh_buffer().get_reference_buffer(), input_ra);
+    detail::WriteToBuffer(*right.in_b.mesh_buffer().get_reference_buffer(), input_rb);
+    if (is_quasar) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    }
+
+    detail::LaunchProgram(device, program, /*wait_until_cores_done=*/true);
+
+    std::vector<uint32_t> out_la, out_lb, out_ra, out_rb;
+    detail::ReadFromBuffer(*left.out_a.mesh_buffer().get_reference_buffer(), out_la);
+    detail::ReadFromBuffer(*left.out_b.mesh_buffer().get_reference_buffer(), out_lb);
+    detail::ReadFromBuffer(*right.out_a.mesh_buffer().get_reference_buffer(), out_ra);
+    detail::ReadFromBuffer(*right.out_b.mesh_buffer().get_reference_buffer(), out_rb);
+
+    EXPECT_EQ(out_la, input_la) << "left half DFB_A round-trip mismatch";
+    EXPECT_EQ(out_lb, input_lb) << "left half DFB_B (alias) round-trip mismatch";
+    EXPECT_EQ(out_ra, input_ra) << "right half DFB_C round-trip mismatch";
+    EXPECT_EQ(out_rb, input_rb) << "right half DFB_D (alias) round-trip mismatch";
+}
+
 TEST_F(MeshDeviceFixture, AliasDFBDataFlow2Sx4S) {
     if (devices_.at(0)->arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "Multi-producer DFB requires Quasar TC hardware";

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_configs.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_configs.cpp
@@ -16,6 +16,7 @@
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/device.hpp>
 #include <tt-metalium/distributed.hpp>
+#include <tt-metalium/hal.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/kernel_types.hpp>
 #include <tt-metalium/program.hpp>
@@ -2190,6 +2191,112 @@ TEST_F(MeshDeviceFixture, MaxEightIntraPerNeoConfig) {
     }
 
     EXPECT_THROW(program.impl().finalize_dataflow_buffer_configs(), std::exception);
+}
+
+
+// =====================================================================================
+// Device slot assignment
+// =====================================================================================
+
+namespace {
+
+experimental::dfb::DataflowBufferConfig make_minimal_dfb_config() {
+    return experimental::dfb::DataflowBufferConfig{
+        .entry_size = 1024,
+        .num_entries = 2,
+        .producer_risc_mask = 0x1,
+        .num_producers = 1,
+        .pap = dfb::AccessPattern::STRIDED,
+        .consumer_risc_mask = 0x2,
+        .num_consumers = 1,
+        .cap = dfb::AccessPattern::STRIDED,
+        .enable_producer_implicit_sync = false,
+        .enable_consumer_implicit_sync = false};
+}
+
+// The safety property behind slot reuse: a slot indexes a per-core config table, so two DFBs may
+// share a slot only when no core hosts both of them.
+void expect_no_slot_collision_on_any_core(Program& program, const CoreRange& cores) {
+    for (auto x = cores.start_coord.x; x <= cores.end_coord.x; x++) {
+        for (auto y = cores.start_coord.y; y <= cores.end_coord.y; y++) {
+            const CoreCoord core(x, y);
+            std::set<uint32_t> slots_on_core;
+            for (const auto& dfb : program.impl().dataflow_buffers_on_core(core)) {
+                EXPECT_TRUE(slots_on_core.insert(dfb->device_slot).second)
+                    << "Core (" << x << "," << y << ") has two DFBs at device slot " << dfb->device_slot;
+            }
+        }
+    }
+}
+
+}  // namespace
+
+// A DFB created late (high program-wide id) that shares no core with the earlier DFBs should reuse a
+// low slot instead of extending the per-core config table. This is the shape that overflowed the
+// dispatch payload when the slot was just a creation counter (issue #51409).
+TEST_F(MeshDeviceFixture, DFBDeviceSlotsReusedAcrossDisjointCores) {
+    auto& mesh_device = this->devices_.at(0);
+    IDevice* device = mesh_device->get_devices()[0];
+    const CoreCoord grid = device->compute_with_storage_grid_size();
+    // Coordinator at (0,0) plus workers spanning (1,0)..(4,0).
+    if (grid.x < 5) {
+        GTEST_SKIP() << "Needs at least 5 worker cores in a row (got " << grid.x << "x" << grid.y << ")";
+    }
+    const CoreCoord coordinator(0, 0);
+    const CoreRange workers(CoreCoord(1, 0), CoreCoord(4, 0));
+    const CoreRange all_cores(CoreCoord(0, 0), CoreCoord(4, 0));
+
+    Program program = CreateProgram();
+    const auto config = make_minimal_dfb_config();
+
+    // Spans every core, so it conflicts with everything below.
+    uint32_t wide_id = experimental::dfb::CreateDataflowBuffer(program, CoreRangeSet(all_cores), config);
+
+    // Worker-only DFBs, then a coordinator-only DFB created last.
+    std::vector<uint32_t> worker_ids;
+    worker_ids.reserve(3);
+    for (int i = 0; i < 3; i++) {
+        worker_ids.push_back(experimental::dfb::CreateDataflowBuffer(program, CoreRangeSet(workers), config));
+    }
+    uint32_t coordinator_id =
+        experimental::dfb::CreateDataflowBuffer(program, CoreRangeSet(CoreRange(coordinator)), config);
+
+    const auto& impl = program.impl();
+    EXPECT_EQ(impl.get_dataflow_buffer(coordinator_id)->id, 4u) << "expected creation order to give this the last id";
+
+    expect_no_slot_collision_on_any_core(program, all_cores);
+
+    EXPECT_EQ(impl.get_dataflow_buffer(wide_id)->device_slot, 0u);
+    for (uint32_t i = 0; i < worker_ids.size(); i++) {
+        EXPECT_EQ(impl.get_dataflow_buffer(worker_ids[i])->device_slot, i + 1)
+            << "worker DFB " << i << " conflicts with the wide DFB and its worker peers";
+    }
+    // Conflicts only with the wide DFB, so it reuses slot 1 rather than taking slot 4.
+    EXPECT_EQ(impl.get_dataflow_buffer(coordinator_id)->device_slot, 1u);
+}
+
+// The per-core slot limit is on how many DFBs share a core, not on how many exist in the program:
+// DFBs on disjoint cores all fit at slot 0.
+TEST_F(MeshDeviceFixture, DFBDeviceSlotLimitIsPerCoreNotPerProgram) {
+    auto& mesh_device = this->devices_.at(0);
+    IDevice* device = mesh_device->get_devices()[0];
+    const bool is_quasar = device->arch() == ARCH::QUASAR;
+    const uint32_t max_slots =
+        is_quasar ? static_cast<uint32_t>(::dfb::NUM_DFBS) : hal::get_arch_num_circular_buffers();
+    const CoreCoord grid = device->compute_with_storage_grid_size();
+    const uint32_t num_dfbs = max_slots + 4;
+    if (grid.x * grid.y < num_dfbs) {
+        GTEST_SKIP() << "Needs at least " << num_dfbs << " cores to place one DFB per core";
+    }
+
+    Program program = CreateProgram();
+    const auto config = make_minimal_dfb_config();
+    for (uint32_t i = 0; i < num_dfbs; i++) {
+        const CoreCoord core(i % grid.x, i / grid.x);
+        uint32_t id = experimental::dfb::CreateDataflowBuffer(program, CoreRangeSet(CoreRange(core)), config);
+        EXPECT_EQ(program.impl().get_dataflow_buffer(id)->device_slot, 0u)
+            << "DFB " << i << " is alone on core (" << core.x << "," << core.y << ")";
+    }
 }
 
 }  // end namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_disjoint_slots.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_disjoint_slots.cpp
@@ -1,0 +1,562 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Tests for DFB device-slot packing across disjoint core sets.
+
+#include <cstdint>
+#include <optional>
+#include <set>
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+#include <tt-metalium/device.hpp>
+#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/tt_metal.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+#include <tt-metalium/experimental/tensor/mesh_tensor.hpp>
+
+#include "device_fixture.hpp"
+#include "dfb_test_common.hpp"
+#include "impl/dataflow_buffer/dataflow_buffer_impl.hpp"
+#include "impl/program/program_impl.hpp"
+#include "tt_metal/test_utils/stimulus.hpp"
+#include "../metal2_host_api/test_helpers.hpp"
+
+namespace tt::tt_metal {
+namespace {
+
+namespace m2 = experimental;
+using experimental::test_helpers::MakeMinimalDFB;
+using experimental::test_helpers::MakeMinimalWorkUnit;
+
+void require_at_least_two_nodes(IDevice* device) {
+    if (device->compute_with_storage_grid_size().x < 2) {
+        GTEST_SKIP() << "Needs at least two worker nodes in a row (got " << device->compute_with_storage_grid_size().x
+                     << "x" << device->compute_with_storage_grid_size().y << ")";
+    }
+}
+
+void apply_gen1_dm_configs(m2::KernelSpec& producer, m2::KernelSpec& consumer, IDevice* device) {
+    if (device->arch() == ARCH::QUASAR) {
+        return;
+    }
+    producer.hw_config = m2::DataMovementGen1Config{.processor = DataMovementProcessor::RISCV_0};
+    consumer.hw_config = m2::DataMovementGen1Config{.processor = DataMovementProcessor::RISCV_1, .noc = NOC::NOC_1};
+}
+
+void expect_half_grid_slots_packed(Program& program, uint32_t num_dfbs_per_half, bool /*is_quasar*/) {
+    for (uint32_t i = 0; i < num_dfbs_per_half * 2; ++i) {
+        const std::string name = "dfb_" + std::to_string(i);
+        const uint32_t id = program.impl().get_dfb_handle(name);
+        const auto dfb = program.impl().get_dataflow_buffer(id);
+        EXPECT_EQ(dfb->id, i);
+        // Both Quasar and WH/BH pack device slots per core, so disjoint halves reuse 0..N-1.
+        EXPECT_EQ(dfb->device_slot, i % num_dfbs_per_half) << name;
+    }
+}
+
+void expect_no_slot_collision_on_core(Program& program, const CoreCoord& core) {
+    std::set<uint32_t> slots;
+    for (const auto& dfb : program.impl().dataflow_buffers_on_core(core)) {
+        EXPECT_TRUE(slots.insert(dfb->device_slot).second)
+            << "Core (" << core.x << "," << core.y << ") has two DFBs at device slot " << dfb->device_slot;
+    }
+}
+
+m2::KernelSpec make_touch_producer(const std::string& name, uint32_t num_dfbs, IDevice* device) {
+    const bool implicit_sync = device->arch() == ARCH::QUASAR;
+    auto kernel = make_dm_kernel(
+        m2::KernelSpecName{name}, "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_multi_touch_producer.cpp");
+    kernel.compiler_options = {.defines = {{"TEST_NUM_DFBS", std::to_string(num_dfbs)}}};
+    kernel.compile_time_args = {{"implicit_sync", implicit_sync ? 1u : 0u}};
+    if (!implicit_sync) {
+        kernel.hw_config = m2::DataMovementGen1Config{.processor = DataMovementProcessor::RISCV_0};
+    }
+    return kernel;
+}
+
+m2::KernelSpec make_touch_consumer(
+    const std::string& name, uint32_t num_dfbs, uint32_t touched_magic, IDevice* device) {
+    const bool implicit_sync = device->arch() == ARCH::QUASAR;
+    auto kernel = make_dm_kernel(
+        m2::KernelSpecName{name}, "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_multi_touch_consumer.cpp");
+    kernel.compiler_options = {.defines = {{"TEST_NUM_DFBS", std::to_string(num_dfbs)}}};
+    kernel.compile_time_args = {{"implicit_sync", implicit_sync ? 1u : 0u}, {"touched_magic", touched_magic}};
+    kernel.runtime_arg_schema = {.runtime_arg_names = {"result_l1_addr"}};
+    if (!implicit_sync) {
+        kernel.hw_config = m2::DataMovementGen1Config{.processor = DataMovementProcessor::RISCV_1, .noc = NOC::NOC_1};
+    }
+    return kernel;
+}
+
+uint32_t touch_result_l1_addr(IDevice* device, uint32_t num_dfbs) {
+    const uint32_t bytes = num_dfbs * 3 * sizeof(uint32_t);
+    const uint32_t align = device->allocator()->get_alignment(BufferType::L1);
+    const uint32_t aligned = (bytes + align - 1) / align * align;
+    return static_cast<uint32_t>(device->l1_size_per_core()) - aligned;
+}
+
+void expect_touch_results(
+    IDevice* device,
+    const CoreCoord& core,
+    uint32_t result_l1_addr,
+    uint32_t num_dfbs,
+    uint32_t expected_entry_size,
+    uint32_t touched_magic,
+    const std::vector<uint32_t>& expected_device_slots) {
+    ASSERT_EQ(expected_device_slots.size(), num_dfbs);
+    std::vector<uint32_t> got;
+    detail::ReadFromDeviceL1(device, core, result_l1_addr, num_dfbs * 3 * sizeof(uint32_t), got);
+    ASSERT_EQ(got.size(), num_dfbs * 3);
+    for (uint32_t i = 0; i < num_dfbs; ++i) {
+        EXPECT_EQ(got[i * 3 + 0], expected_entry_size) << "DFB local " << i << " entry_size";
+        EXPECT_EQ(got[i * 3 + 1], expected_device_slots[i]) << "DFB local " << i << " device slot (get_id)";
+        EXPECT_EQ(got[i * 3 + 2], touched_magic | i) << "DFB local " << i << " touched magic";
+    }
+}
+
+void bind_touch_dfbs(
+    m2::KernelSpec& prod, m2::KernelSpec& cons, const std::string& dfb_spec_name, uint32_t local_index) {
+    const std::string accessor = "dfb_" + std::to_string(local_index);
+    const m2::DFBSpecName dfb{dfb_spec_name};
+    prod.dfb_bindings.push_back(m2::DFBBinding{
+        .dfb_spec_name = dfb,
+        .accessor_name = accessor,
+        .endpoint_type = m2::DFBEndpointType::PRODUCER,
+    });
+    cons.dfb_bindings.push_back(m2::DFBBinding{
+        .dfb_spec_name = dfb,
+        .accessor_name = accessor,
+        .endpoint_type = m2::DFBEndpointType::CONSUMER,
+    });
+}
+
+// Two WorkUnits on (0,0)/(1,0); each half owns `num_dfbs_per_half` DFBs and touches every one
+// (credit handshake on Gen1; config probe under Quasar).
+//
+// Quasar TxnIdAllocator is program-wide over DFB pool [8, 31] (24 IDs); each implicit-sync
+// DFB takes 4 IDs. Large programs (16+16) disable host implicit sync entirely and keep the
+// kernel on the probe path so we never exhaust the pool or hang in finish()/ISR drain.
+m2::ProgramSpec make_split_touch_spec(IDevice* device, uint32_t num_dfbs_per_half) {
+    const m2::NodeCoord node_a{0, 0};
+    const m2::NodeCoord node_b{1, 0};
+    constexpr uint32_t touched_magic = 0xA11CED00u;
+
+    auto prod_a = make_touch_producer("prod_a", num_dfbs_per_half, device);
+    auto cons_a = make_touch_consumer("cons_a", num_dfbs_per_half, touched_magic, device);
+    auto prod_b = make_touch_producer("prod_b", num_dfbs_per_half, device);
+    auto cons_b = make_touch_consumer("cons_b", num_dfbs_per_half, touched_magic, device);
+
+    m2::ProgramSpec spec;
+    spec.name = "dfb_disjoint_split_touch";
+    const bool is_quasar = device->arch() == ARCH::QUASAR;
+    for (uint32_t i = 0; i < num_dfbs_per_half * 2; ++i) {
+        const std::string name = "dfb_" + std::to_string(i);
+        auto dfb = MakeMinimalDFB(name, /*entry_size=*/32, /*num_entries=*/2);
+        dfb.data_format_metadata = tt::DataFormat::Float16_b;
+        spec.dataflow_buffers.push_back(dfb);
+
+        const uint32_t local = i % num_dfbs_per_half;
+        auto& prod = i < num_dfbs_per_half ? prod_a : prod_b;
+        auto& cons = i < num_dfbs_per_half ? cons_a : cons_b;
+        bind_touch_dfbs(prod, cons, name, local);
+
+        // 16+16 exhausts TxnIdAllocator if every DFB stays on implicit sync; probe path
+        // does not need host ISR credits.
+        if (is_quasar) {
+            disable_implicit_sync_for(prod, m2::DFBSpecName{name});
+            disable_implicit_sync_for(cons, m2::DFBSpecName{name});
+        }
+    }
+    spec.kernels = {prod_a, cons_a, prod_b, cons_b};
+    spec.work_units = {
+        MakeMinimalWorkUnit("work_unit_a", node_a, {"prod_a", "cons_a"}),
+        MakeMinimalWorkUnit("work_unit_b", node_b, {"prod_b", "cons_b"}),
+    };
+    return spec;
+}
+
+TEST_F(MeshDeviceFixture, HalfGrid3Plus3DFBsOnDevice) {
+    auto& mesh_device = this->devices_.at(0);
+    IDevice* device = mesh_device->get_devices()[0];
+    require_at_least_two_nodes(device);
+    const bool is_quasar = device->arch() == ARCH::QUASAR;
+
+    constexpr uint32_t per_half = 3;
+    constexpr uint32_t entry_size = 256;
+    constexpr uint32_t num_entries = 4;
+    const m2::NodeCoord node_a{0, 0};
+    const m2::NodeCoord node_b{1, 0};
+
+    const auto tensor_spec = make_flat_dram_tensor_spec(entry_size, num_entries, DataType::UINT32);
+    std::vector<MeshTensor> inputs;
+    std::vector<MeshTensor> outputs;
+    inputs.reserve(per_half * 2);
+    outputs.reserve(per_half * 2);
+    for (uint32_t i = 0; i < per_half * 2; ++i) {
+        inputs.push_back(MeshTensor::allocate_on_device(*mesh_device, tensor_spec));
+        outputs.push_back(MeshTensor::allocate_on_device(*mesh_device, tensor_spec));
+    }
+
+    auto make_triple_prod = [&](const std::string& name) {
+        auto kernel = make_dm_kernel(
+            m2::KernelSpecName{name}, "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_triple_producer.cpp");
+        kernel.compile_time_args = {{"num_entries_per_producer", num_entries}, {"implicit_sync", is_quasar ? 1u : 0u}};
+        kernel.runtime_arg_schema = {.runtime_arg_names = {"chunk_offset", "entries_per_core"}};
+        return kernel;
+    };
+    auto make_triple_cons = [&](const std::string& name) {
+        auto kernel = make_dm_kernel(
+            m2::KernelSpecName{name}, "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_triple_consumer.cpp");
+        kernel.compile_time_args = {{"num_entries_per_consumer", num_entries}, {"implicit_sync", is_quasar ? 1u : 0u}};
+        kernel.runtime_arg_schema = {.runtime_arg_names = {"chunk_offset", "entries_per_core"}};
+        return kernel;
+    };
+
+    auto prod_a = make_triple_prod("prod_a");
+    auto cons_a = make_triple_cons("cons_a");
+    auto prod_b = make_triple_prod("prod_b");
+    auto cons_b = make_triple_cons("cons_b");
+    apply_gen1_dm_configs(prod_a, cons_a, device);
+    apply_gen1_dm_configs(prod_b, cons_b, device);
+
+    m2::ProgramSpec spec;
+    spec.name = "half_grid_3plus3_dataflow";
+    std::vector<m2::TensorParameter> tensor_params;
+    for (uint32_t i = 0; i < per_half * 2; ++i) {
+        const std::string dfb_name = "dfb_" + std::to_string(i);
+        const uint32_t local = i % per_half;
+        const bool left = i < per_half;
+        auto& prod = left ? prod_a : prod_b;
+        auto& cons = left ? cons_a : cons_b;
+
+        spec.dataflow_buffers.push_back({
+            .unique_id = m2::DFBSpecName{dfb_name},
+            .entry_size = entry_size,
+            .num_entries = num_entries,
+            .data_format_metadata = tt::DataFormat::Float16_b,
+        });
+        const m2::DFBSpecName dfb{dfb_name};
+        prod.dfb_bindings.push_back({
+            .dfb_spec_name = dfb,
+            .accessor_name = "out_" + std::to_string(local),
+            .endpoint_type = m2::DFBEndpointType::PRODUCER,
+        });
+        cons.dfb_bindings.push_back({
+            .dfb_spec_name = dfb,
+            .accessor_name = "in_" + std::to_string(local),
+            .endpoint_type = m2::DFBEndpointType::CONSUMER,
+        });
+
+        const std::string in_name = "in_" + std::to_string(i);
+        const std::string out_name = "out_" + std::to_string(i);
+        tensor_params.push_back({.unique_id = m2::TensorParamName{in_name}, .spec = inputs[i].tensor_spec()});
+        tensor_params.push_back({.unique_id = m2::TensorParamName{out_name}, .spec = outputs[i].tensor_spec()});
+        prod.tensor_bindings.push_back({
+            .tensor_parameter_name = m2::TensorParamName{in_name},
+            .accessor_name = "src_" + std::to_string(local),
+        });
+        cons.tensor_bindings.push_back({
+            .tensor_parameter_name = m2::TensorParamName{out_name},
+            .accessor_name = "dst_" + std::to_string(local),
+        });
+    }
+    spec.kernels = {prod_a, cons_a, prod_b, cons_b};
+    spec.tensor_parameters = std::move(tensor_params);
+    spec.work_units = {
+        {.name = "wu_a",
+         .kernels = {m2::KernelSpecName{"prod_a"}, m2::KernelSpecName{"cons_a"}},
+         .target_nodes = node_a},
+        {.name = "wu_b",
+         .kernels = {m2::KernelSpecName{"prod_b"}, m2::KernelSpecName{"cons_b"}},
+         .target_nodes = node_b},
+    };
+
+    Program program = m2::MakeProgramFromSpec(*mesh_device, spec);
+    expect_half_grid_slots_packed(program, per_half, is_quasar);
+    expect_no_slot_collision_on_core(program, CoreCoord{0, 0});
+    expect_no_slot_collision_on_core(program, CoreCoord{1, 0});
+
+    auto rtas = [&](const m2::NodeCoord& node) {
+        return m2::MakeRuntimeArgsForSingleNode(node, {{"chunk_offset", 0u}, {"entries_per_core", num_entries}});
+    };
+    m2::ProgramRunArgs params;
+    params.kernel_run_args = {
+        {.kernel = m2::KernelSpecName{"prod_a"}, .runtime_arg_values = rtas(node_a)},
+        {.kernel = m2::KernelSpecName{"cons_a"}, .runtime_arg_values = rtas(node_a)},
+        {.kernel = m2::KernelSpecName{"prod_b"}, .runtime_arg_values = rtas(node_b)},
+        {.kernel = m2::KernelSpecName{"cons_b"}, .runtime_arg_values = rtas(node_b)},
+    };
+    const uint32_t words = num_entries * entry_size / sizeof(uint32_t);
+    std::vector<std::vector<uint32_t>> expected(per_half * 2);
+    for (uint32_t i = 0; i < per_half * 2; ++i) {
+        expected[i] = tt::test_utils::generate_uniform_random_vector<uint32_t>(0, 1000000, words);
+        detail::WriteToBuffer(*inputs[i].mesh_buffer().get_reference_buffer(), expected[i]);
+        m2_writeshard_barrier_uint32(device, inputs[i], expected[i]);
+        params.tensor_args.insert({m2::TensorParamName{"in_" + std::to_string(i)}, std::cref(inputs[i])});
+        params.tensor_args.insert({m2::TensorParamName{"out_" + std::to_string(i)}, std::cref(outputs[i])});
+    }
+    m2::SetProgramRunArgs(program, params);
+
+    detail::LaunchProgram(device, program, /*wait_until_cores_done=*/true);
+
+    for (uint32_t i = 0; i < per_half * 2; ++i) {
+        std::vector<uint32_t> got;
+        detail::ReadFromBuffer(*outputs[i].mesh_buffer().get_reference_buffer(), got);
+        EXPECT_EQ(got, expected[i]) << "DFB " << i << " round-trip mismatch";
+    }
+}
+
+// Stress: 16+16 DFBs. Credit-handshake over every buffer; host checks entry_size + device slot
+// written back from each consumer.
+TEST_F(MeshDeviceFixture, HalfGrid16Plus16DFBsOnDevice) {
+    auto& mesh_device = this->devices_.at(0);
+    IDevice* device = mesh_device->get_devices()[0];
+    require_at_least_two_nodes(device);
+    const bool is_quasar = device->arch() == ARCH::QUASAR;
+
+    constexpr uint32_t per_half = 16;
+    constexpr uint32_t touched_magic = 0xA11CED00u;
+    m2::ProgramSpec spec = make_split_touch_spec(device, per_half);
+    Program program = m2::MakeProgramFromSpec(*mesh_device, spec);
+
+    expect_half_grid_slots_packed(program, per_half, is_quasar);
+    expect_no_slot_collision_on_core(program, CoreCoord{0, 0});
+    expect_no_slot_collision_on_core(program, CoreCoord{1, 0});
+
+    const uint32_t result_addr = touch_result_l1_addr(device, per_half);
+    auto cons_rtas = [&](const m2::NodeCoord& node) {
+        return m2::MakeRuntimeArgsForSingleNode(node, {{"result_l1_addr", result_addr}});
+    };
+    m2::ProgramRunArgs params;
+    params.kernel_run_args = {
+        {.kernel = m2::KernelSpecName{"prod_a"}},
+        {.kernel = m2::KernelSpecName{"cons_a"}, .runtime_arg_values = cons_rtas(m2::NodeCoord{0, 0})},
+        {.kernel = m2::KernelSpecName{"prod_b"}},
+        {.kernel = m2::KernelSpecName{"cons_b"}, .runtime_arg_values = cons_rtas(m2::NodeCoord{1, 0})},
+    };
+    m2::SetProgramRunArgs(program, params);
+    detail::LaunchProgram(device, program, /*wait_until_cores_done=*/true);
+
+    std::vector<uint32_t> left_slots(per_half), right_slots(per_half);
+    for (uint32_t i = 0; i < per_half; ++i) {
+        left_slots[i] =
+            program.impl().get_dataflow_buffer(program.impl().get_dfb_handle("dfb_" + std::to_string(i)))->device_slot;
+        right_slots[i] = program.impl()
+                             .get_dataflow_buffer(program.impl().get_dfb_handle("dfb_" + std::to_string(per_half + i)))
+                             ->device_slot;
+    }
+    expect_touch_results(
+        device, CoreCoord{0, 0}, result_addr, per_half, /*expected_entry_size=*/32, touched_magic, left_slots);
+    expect_touch_results(
+        device, CoreCoord{1, 0}, result_addr, per_half, /*expected_entry_size=*/32, touched_magic, right_slots);
+}
+
+// End-to-end identity across two disjoint halves: one DFB + producer/consumer pair per half.
+TEST_F(MeshDeviceFixture, HalfGridOnDeviceDataflow1DFBEach) {
+    auto& mesh_device = this->devices_.at(0);
+    IDevice* device = mesh_device->get_devices()[0];
+    require_at_least_two_nodes(device);
+    const bool is_quasar = device->arch() == ARCH::QUASAR;
+
+    constexpr uint32_t entry_size = 1024;
+    constexpr uint32_t num_entries = 8;
+    const m2::NodeCoord node_a{0, 0};
+    const m2::NodeCoord node_b{1, 0};
+
+    const auto tensor_spec = make_flat_dram_tensor_spec(entry_size, num_entries, DataType::UINT32);
+    auto in_a = MeshTensor::allocate_on_device(*mesh_device, tensor_spec);
+    auto out_a = MeshTensor::allocate_on_device(*mesh_device, tensor_spec);
+    auto in_b = MeshTensor::allocate_on_device(*mesh_device, tensor_spec);
+    auto out_b = MeshTensor::allocate_on_device(*mesh_device, tensor_spec);
+
+    const m2::DFBSpecName dfb_a{"dfb_a"};
+    const m2::DFBSpecName dfb_b{"dfb_b"};
+    const m2::KernelSpecName prod_a{"producer_a"};
+    const m2::KernelSpecName cons_a{"consumer_a"};
+    const m2::KernelSpecName prod_b{"producer_b"};
+    const m2::KernelSpecName cons_b{"consumer_b"};
+    const m2::TensorParamName in_a_name{"in_a"};
+    const m2::TensorParamName out_a_name{"out_a"};
+    const m2::TensorParamName in_b_name{"in_b"};
+    const m2::TensorParamName out_b_name{"out_b"};
+
+    auto producer_a = make_dm_dfb_producer(prod_a, dfb_a, in_a_name, num_entries, is_quasar);
+    auto consumer_a =
+        make_dm_dfb_consumer(cons_a, dfb_a, out_a_name, num_entries, /*blocked_consumer=*/false, is_quasar);
+    auto producer_b = make_dm_dfb_producer(prod_b, dfb_b, in_b_name, num_entries, is_quasar);
+    auto consumer_b =
+        make_dm_dfb_consumer(cons_b, dfb_b, out_b_name, num_entries, /*blocked_consumer=*/false, is_quasar);
+    apply_gen1_dm_configs(producer_a, consumer_a, device);
+    apply_gen1_dm_configs(producer_b, consumer_b, device);
+
+    m2::ProgramSpec spec{
+        .name = "half_grid_dataflow_1dfb",
+        .kernels = {producer_a, consumer_a, producer_b, consumer_b},
+        .dataflow_buffers =
+            {
+                {.unique_id = dfb_a,
+                 .entry_size = entry_size,
+                 .num_entries = num_entries,
+                 .data_format_metadata = tt::DataFormat::Float16_b},
+                {.unique_id = dfb_b,
+                 .entry_size = entry_size,
+                 .num_entries = num_entries,
+                 .data_format_metadata = tt::DataFormat::Float16_b},
+            },
+        .tensor_parameters =
+            {
+                {.unique_id = in_a_name, .spec = in_a.tensor_spec()},
+                {.unique_id = out_a_name, .spec = out_a.tensor_spec()},
+                {.unique_id = in_b_name, .spec = in_b.tensor_spec()},
+                {.unique_id = out_b_name, .spec = out_b.tensor_spec()},
+            },
+        .work_units =
+            {
+                {.name = "wu_a", .kernels = {prod_a, cons_a}, .target_nodes = node_a},
+                {.name = "wu_b", .kernels = {prod_b, cons_b}, .target_nodes = node_b},
+            },
+    };
+
+    Program program = m2::MakeProgramFromSpec(*mesh_device, spec);
+    EXPECT_EQ(program.impl().get_dataflow_buffer(program.impl().get_dfb_handle("dfb_a"))->device_slot, 0u);
+    EXPECT_EQ(program.impl().get_dataflow_buffer(program.impl().get_dfb_handle("dfb_b"))->device_slot, 0u);
+
+    auto rtas = [&](const m2::NodeCoord& node) {
+        return m2::MakeRuntimeArgsForSingleNode(node, {{"chunk_offset", 0u}, {"entries_per_core", num_entries}});
+    };
+    m2::ProgramRunArgs params;
+    params.kernel_run_args = {
+        {.kernel = prod_a, .runtime_arg_values = rtas(node_a)},
+        {.kernel = cons_a, .runtime_arg_values = rtas(node_a)},
+        {.kernel = prod_b, .runtime_arg_values = rtas(node_b)},
+        {.kernel = cons_b, .runtime_arg_values = rtas(node_b)},
+    };
+    params.tensor_args = {
+        {in_a_name, std::cref(in_a)},
+        {out_a_name, std::cref(out_a)},
+        {in_b_name, std::cref(in_b)},
+        {out_b_name, std::cref(out_b)},
+    };
+    m2::SetProgramRunArgs(program, params);
+
+    const uint32_t words = num_entries * entry_size / sizeof(uint32_t);
+    auto input_a = tt::test_utils::generate_uniform_random_vector<uint32_t>(0, 1000000, words);
+    auto input_b = tt::test_utils::generate_uniform_random_vector<uint32_t>(0, 1000000, words);
+    detail::WriteToBuffer(*in_a.mesh_buffer().get_reference_buffer(), input_a);
+    detail::WriteToBuffer(*in_b.mesh_buffer().get_reference_buffer(), input_b);
+    m2_writeshard_barrier_uint32(device, in_a, input_a);
+    m2_writeshard_barrier_uint32(device, in_b, input_b);
+
+    detail::LaunchProgram(device, program, /*wait_until_cores_done=*/true);
+
+    std::vector<uint32_t> result_a, result_b;
+    detail::ReadFromBuffer(*out_a.mesh_buffer().get_reference_buffer(), result_a);
+    detail::ReadFromBuffer(*out_b.mesh_buffer().get_reference_buffer(), result_b);
+    EXPECT_EQ(result_a, input_a) << "left-half DFB round-trip mismatch";
+    EXPECT_EQ(result_b, input_b) << "right-half DFB round-trip mismatch";
+}
+
+TEST_F(MeshDeviceFixture, CoordinatorWorkerSlotReuseOnDevice) {
+    auto& mesh_device = this->devices_.at(0);
+    IDevice* device = mesh_device->get_devices()[0];
+    const CoreCoord grid = device->compute_with_storage_grid_size();
+    if (grid.x < 3) {
+        GTEST_SKIP() << "Needs at least coordinator + 2 workers (got " << grid.x << "x" << grid.y << ")";
+    }
+
+    const m2::NodeCoord coordinator{0, 0};
+    const m2::NodeCoord worker_start{1, 0};
+    const m2::NodeCoord worker_end{static_cast<size_t>(grid.x - 1), 0};
+
+    // Coordinator: wide + coord-only (2). Workers: wide + 3 worker-only (4).
+    constexpr uint32_t touched_magic = 0xA11CED00u;
+    auto coord_prod = make_touch_producer("coord_prod", 2, device);
+    auto coord_cons = make_touch_consumer("coord_cons", 2, touched_magic, device);
+    auto worker_prod = make_touch_producer("worker_prod", 4, device);
+    auto worker_cons = make_touch_consumer("worker_cons", 4, touched_magic, device);
+
+    m2::ProgramSpec spec;
+    spec.name = "dfb_sort_shape_touch";
+
+    auto add_dfb = [&](const std::string& name) {
+        auto dfb = MakeMinimalDFB(name, 32, 2);
+        dfb.data_format_metadata = tt::DataFormat::Float16_b;
+        spec.dataflow_buffers.push_back(dfb);
+    };
+    add_dfb("dfb_wide");
+    add_dfb("dfb_worker_0");
+    add_dfb("dfb_worker_1");
+    add_dfb("dfb_worker_2");
+    add_dfb("dfb_coord");
+
+    bind_touch_dfbs(coord_prod, coord_cons, "dfb_wide", 0);
+    bind_touch_dfbs(coord_prod, coord_cons, "dfb_coord", 1);
+    bind_touch_dfbs(worker_prod, worker_cons, "dfb_wide", 0);
+    bind_touch_dfbs(worker_prod, worker_cons, "dfb_worker_0", 1);
+    bind_touch_dfbs(worker_prod, worker_cons, "dfb_worker_1", 2);
+    bind_touch_dfbs(worker_prod, worker_cons, "dfb_worker_2", 3);
+
+    spec.kernels = {coord_prod, coord_cons, worker_prod, worker_cons};
+    spec.work_units = {
+        MakeMinimalWorkUnit("wu_coord", coordinator, {"coord_prod", "coord_cons"}),
+        MakeMinimalWorkUnit("wu_workers", m2::NodeRange{worker_start, worker_end}, {"worker_prod", "worker_cons"}),
+    };
+
+    Program program = m2::MakeProgramFromSpec(*mesh_device, spec);
+    const auto& impl = program.impl();
+    EXPECT_EQ(impl.get_dataflow_buffer(impl.get_dfb_handle("dfb_coord"))->id, 4u);
+    EXPECT_EQ(impl.get_dataflow_buffer(impl.get_dfb_handle("dfb_wide"))->device_slot, 0u);
+    EXPECT_EQ(impl.get_dataflow_buffer(impl.get_dfb_handle("dfb_worker_0"))->device_slot, 1u);
+    EXPECT_EQ(impl.get_dataflow_buffer(impl.get_dfb_handle("dfb_worker_1"))->device_slot, 2u);
+    EXPECT_EQ(impl.get_dataflow_buffer(impl.get_dfb_handle("dfb_worker_2"))->device_slot, 3u);
+    EXPECT_EQ(impl.get_dataflow_buffer(impl.get_dfb_handle("dfb_coord"))->device_slot, 1u);
+    expect_no_slot_collision_on_core(program, CoreCoord{0, 0});
+    expect_no_slot_collision_on_core(program, CoreCoord{1, 0});
+
+    m2::ProgramRunArgs params;
+    const uint32_t coord_result_addr = touch_result_l1_addr(device, 2);
+    const uint32_t worker_result_addr = touch_result_l1_addr(device, 4);
+    m2::KernelRunArgs::RuntimeArgValues worker_cons_rtas;
+    for (size_t x = worker_start.x; x <= worker_end.x; ++x) {
+        m2::AddRuntimeArgsForNode(worker_cons_rtas, m2::NodeCoord{x, 0}, {{"result_l1_addr", worker_result_addr}});
+    }
+    params.kernel_run_args = {
+        {.kernel = m2::KernelSpecName{"coord_prod"}},
+        {.kernel = m2::KernelSpecName{"coord_cons"},
+         .runtime_arg_values = m2::MakeRuntimeArgsForSingleNode(coordinator, {{"result_l1_addr", coord_result_addr}})},
+        {.kernel = m2::KernelSpecName{"worker_prod"}},
+        {.kernel = m2::KernelSpecName{"worker_cons"}, .runtime_arg_values = std::move(worker_cons_rtas)},
+    };
+    m2::SetProgramRunArgs(program, params);
+    detail::LaunchProgram(device, program, /*wait_until_cores_done=*/true);
+
+    expect_touch_results(
+        device,
+        CoreCoord{0, 0},
+        coord_result_addr,
+        2,
+        /*expected_entry_size=*/32,
+        touched_magic,
+        {impl.get_dataflow_buffer(impl.get_dfb_handle("dfb_wide"))->device_slot,
+         impl.get_dataflow_buffer(impl.get_dfb_handle("dfb_coord"))->device_slot});
+    expect_touch_results(
+        device,
+        CoreCoord{1, 0},
+        worker_result_addr,
+        4,
+        /*expected_entry_size=*/32,
+        touched_magic,
+        {impl.get_dataflow_buffer(impl.get_dfb_handle("dfb_wide"))->device_slot,
+         impl.get_dataflow_buffer(impl.get_dfb_handle("dfb_worker_0"))->device_slot,
+         impl.get_dataflow_buffer(impl.get_dfb_handle("dfb_worker_1"))->device_slot,
+         impl.get_dataflow_buffer(impl.get_dfb_handle("dfb_worker_2"))->device_slot});
+}
+
+}  // namespace
+}  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -46,6 +46,7 @@
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/experimental/context/metal_env.hpp>
 #include <tt-metalium/experimental/mock_device/mock_device.hpp>
+#include "tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_config.h"
 
 #include "test_helpers.hpp"
 
@@ -1957,9 +1958,8 @@ TEST_F(ProgramSpecTestQuasar, DataFormatNotSupportedOnTargetArchitectureFails) {
 }
 
 TEST_F(ProgramSpecTestQuasar, TooManyDFBsFailsValidation) {
-    // The hard upper limit on DFBs is hal::get_arch_num_circular_buffers().
-    // Exceeding it should fail validation with a clear error, rather than blowing
-    // up downstream during JIT.
+    // Device slots are per-core: exceeding the per-node slot count on a single node must fail
+    // validation rather than blowing up downstream during JIT / enqueue.
     NodeCoord node{0, 0};
 
     ProgramSpec spec;
@@ -1968,7 +1968,7 @@ TEST_F(ProgramSpecTestQuasar, TooManyDFBsFailsValidation) {
     auto producer = MakeMinimalGen2DMKernel("producer");
     auto consumer = MakeMinimalGen2ComputeKernel("consumer");
 
-    const uint32_t too_many = tt::tt_metal::hal::get_arch_num_circular_buffers() + 1;
+    const uint32_t too_many = static_cast<uint32_t>(::dfb::NUM_DFBS) + 1;
     for (uint32_t i = 0; i < too_many; ++i) {
         std::string name = "dfb_" + std::to_string(i);
         auto dfb = MakeMinimalDFB(name);
@@ -1981,7 +1981,7 @@ TEST_F(ProgramSpecTestQuasar, TooManyDFBsFailsValidation) {
     spec.kernels = {producer, consumer};
     spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"producer", "consumer"})};
 
-    const std::string expected_substr = "too many DataflowBufferSpecs (" + std::to_string(too_many) + ")";
+    const std::string expected_substr = "places " + std::to_string(too_many) + " DataflowBufferSpecs on node (0, 0)";
     EXPECT_THAT(
         [&] { MakeProgramFromSpec(*mesh_device_, spec); },
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr(expected_substr)));
@@ -3141,6 +3141,72 @@ TEST_F(ProgramSpecTestGen1, ComputeGen1ConfigDefaultsMapToInternalDefaults) {
 TEST_F(ProgramSpecTestGen1, MinimalValidProgramSpecSucceeds) {
     ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
     EXPECT_NO_THROW(MakeProgramFromSpec(*mesh_device_, spec));
+}
+
+// Device slots are per-core: a ProgramSpec may declare more DFBs than
+// get_arch_num_circular_buffers() when each core hosts at most one. This is the Metal 2.0
+// path that issue #51409 needs — previously ValidateProgramSpec rejected on total count.
+TEST_F(ProgramSpecTestGen1, DisjointNodeDFBsExceedSlotCountSucceeds) {
+    const uint32_t max_slots = tt::tt_metal::hal::get_arch_num_circular_buffers();
+    const uint32_t num_dfbs = max_slots + 1;
+    constexpr uint32_t grid_x = 8;  // WH mock worker grid width
+    ASSERT_GE(grid_x * 9u, num_dfbs) << "mock WH grid too small for this packing check";
+
+    ProgramSpec spec;
+    spec.name = "disjoint_dfb_slot_reuse";
+    for (uint32_t i = 0; i < num_dfbs; ++i) {
+        const NodeCoord node{i % grid_x, i / grid_x};
+        const std::string pname = "prod_" + std::to_string(i);
+        const std::string cname = "cons_" + std::to_string(i);
+        const std::string dname = "dfb_" + std::to_string(i);
+
+        auto prod = MakeMinimalGen1DMKernel(pname, DataMovementProcessor::RISCV_0);
+        auto cons = MakeMinimalGen1DMKernel(cname, DataMovementProcessor::RISCV_1);
+        auto dfb = MakeMinimalDFB(dname);
+        dfb.data_format_metadata = tt::DataFormat::Float16_b;
+        prod.dfb_bindings.push_back(ProducerOf(DFBSpecName{dname}, "out"));
+        cons.dfb_bindings.push_back(ConsumerOf(DFBSpecName{dname}, "in"));
+
+        spec.kernels.push_back(std::move(prod));
+        spec.kernels.push_back(std::move(cons));
+        spec.dataflow_buffers.push_back(std::move(dfb));
+        spec.work_units.push_back(MakeMinimalWorkUnit("wu_" + std::to_string(i), node, {pname, cname}));
+    }
+
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
+    for (uint32_t i = 0; i < num_dfbs; ++i) {
+        const std::string dname = "dfb_" + std::to_string(i);
+        EXPECT_EQ(program.impl().get_dataflow_buffer(program.impl().get_dfb_handle(dname))->device_slot, 0u)
+            << dname << " is alone on its node and should reuse device slot 0";
+    }
+}
+
+TEST_F(ProgramSpecTestGen1, TooManyDFBsOnSameNodeFails) {
+    NodeCoord node{0, 0};
+
+    ProgramSpec spec;
+    spec.name = "too_many_dfbs_one_node";
+
+    auto producer = MakeMinimalGen1DMKernel("producer", DataMovementProcessor::RISCV_0);
+    auto consumer = MakeMinimalGen1DMKernel("consumer", DataMovementProcessor::RISCV_1);
+
+    const uint32_t too_many = tt::tt_metal::hal::get_arch_num_circular_buffers() + 1;
+    for (uint32_t i = 0; i < too_many; ++i) {
+        const std::string name = "dfb_" + std::to_string(i);
+        auto dfb = MakeMinimalDFB(name);
+        dfb.data_format_metadata = tt::DataFormat::Float16_b;
+        spec.dataflow_buffers.push_back(dfb);
+        producer.dfb_bindings.push_back(ProducerOf(DFBSpecName{name}, "p_" + std::to_string(i)));
+        consumer.dfb_bindings.push_back(ConsumerOf(DFBSpecName{name}, "c_" + std::to_string(i)));
+    }
+
+    spec.kernels = {producer, consumer};
+    spec.work_units = std::vector<WorkUnitSpec>{MakeMinimalWorkUnit("work_unit", node, {"producer", "consumer"})};
+
+    const std::string expected_substr = "places " + std::to_string(too_many) + " DataflowBufferSpecs on node (0, 0)";
+    EXPECT_THAT(
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
+        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr(expected_substr)));
 }
 
 TEST_F(ProgramSpecTestGen1, ConsumerUnpackToDestBelow32BitWithoutEnableFailsForPerf) {

--- a/tests/tt_metal/tt_metal/api/sources.cmake
+++ b/tests/tt_metal/tt_metal/api/sources.cmake
@@ -27,6 +27,7 @@ set(UNIT_TESTS_API_SOURCES
     dataflow_buffer/test_dataflow_buffer_edge_cases.cpp
     dataflow_buffer/test_dataflow_buffer_overrides.cpp
     dataflow_buffer/test_dataflow_buffer_configs.cpp
+    dataflow_buffer/test_dataflow_buffer_disjoint_slots.cpp
     dataflow_buffer/test_borrowed_memory_dataflow_buffer.cpp
     distribution_spec/test_buffer_distribution_spec.cpp
     metal2_host_api/test_mesh_workload_factories_hw.cpp

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_multi_touch_consumer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_multi_touch_consumer.cpp
@@ -1,0 +1,131 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Consumer half of dfb_multi_touch_producer.cpp. Every bound DFB is constructed from its
+// generated dfb::dfb_<n> accessor, so the interface it touches is the device slot the host
+// assigned rather than the binding's position. Each one writes a validation record to L1:
+//   results[i*3 + 0] = entry_size
+//   results[i*3 + 1] = get_id()   // device slot baked into the accessor
+//   results[i*3 + 2] = touched_magic | i
+//
+// Explicit sync: wait/pop handshake. Implicit sync (Quasar default): config probe only.
+//
+// TEST_NUM_DFBS is a host-provided define rather than a compile-time arg: it guards references to
+// dfb::dfb_<n> names, which only exist in the generated bindings header for accessors this
+// kernel actually binds.
+
+#include "api/dataflow/dataflow_buffer.h"
+#include "api/debug/dprint.h"
+#include "dev_mem_map.h"
+#include "experimental/kernel_args.h"
+
+#ifndef TEST_NUM_DFBS
+#error "TEST_NUM_DFBS must be defined by the host (KernelSpec compiler_options.defines)"
+#endif
+
+namespace {
+
+// Quasar host readback must go through the uncached L1 window.
+inline uint32_t l1_ptr_addr(uint32_t byte_addr) {
+#ifdef ARCH_QUASAR
+    return byte_addr + MEM_L1_UNCACHED_BASE;
+#else
+    return byte_addr;
+#endif
+}
+
+}  // namespace
+
+template <bool ImplicitSync>
+static inline void touch_one(
+    DFBBindingToken token, uint32_t index, volatile tt_l1_ptr uint32_t* results, uint32_t touched_magic) {
+    DPRINT("touch[{}] enter implicit={}\n", index, ImplicitSync ? 1u : 0u);
+    DPRINT("touch[{}] before DataflowBuffer ctor\n", index);
+    DataflowBuffer dfb(token);
+    DPRINT("touch[{}] after ctor id={} entry_size={}\n", index, (uint32_t)dfb.get_id(), dfb.get_entry_size());
+    if constexpr (ImplicitSync) {
+        DPRINT("touch[{}] probe path (skip wait/pop/finish)\n", index);
+    } else {
+        DPRINT("touch[{}] before wait_front\n", index);
+        dfb.wait_front(1);
+        DPRINT("touch[{}] before pop_front\n", index);
+        dfb.pop_front(1);
+        DPRINT("touch[{}] before finish\n", index);
+        dfb.finish();
+        DPRINT("touch[{}] after finish\n", index);
+    }
+    const uint32_t entry_size = dfb.get_entry_size();
+    const uint32_t id = dfb.get_id();
+    const uint32_t magic = touched_magic | index;
+    results[index * 3 + 0] = entry_size;
+    results[index * 3 + 1] = id;
+    results[index * 3 + 2] = magic;
+    DPRINT("touch[{}] wrote es={} id={} magic={:#x} @results+{}\n", index, entry_size, id, magic, index * 3);
+}
+
+void kernel_main() {
+    constexpr bool implicit_sync = get_arg(args::implicit_sync);
+    constexpr uint32_t touched_magic = get_arg(args::touched_magic);
+    const uint32_t result_l1_addr = get_arg(args::result_l1_addr);
+    volatile tt_l1_ptr uint32_t* results = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(l1_ptr_addr(result_l1_addr));
+
+    DPRINT(
+        "cons_main enter TEST_NUM_DFBS={} implicit={} magic={:#x} results_cached={:#x} results_uncached={:#x}\n",
+        (uint32_t)TEST_NUM_DFBS,
+        implicit_sync ? 1u : 0u,
+        touched_magic,
+        result_l1_addr,
+        (uint32_t)reinterpret_cast<uintptr_t>(results));
+
+#if TEST_NUM_DFBS > 0
+    touch_one<implicit_sync>(dfb::dfb_0, 0, results, touched_magic);
+#endif
+#if TEST_NUM_DFBS > 1
+    touch_one<implicit_sync>(dfb::dfb_1, 1, results, touched_magic);
+#endif
+#if TEST_NUM_DFBS > 2
+    touch_one<implicit_sync>(dfb::dfb_2, 2, results, touched_magic);
+#endif
+#if TEST_NUM_DFBS > 3
+    touch_one<implicit_sync>(dfb::dfb_3, 3, results, touched_magic);
+#endif
+#if TEST_NUM_DFBS > 4
+    touch_one<implicit_sync>(dfb::dfb_4, 4, results, touched_magic);
+#endif
+#if TEST_NUM_DFBS > 5
+    touch_one<implicit_sync>(dfb::dfb_5, 5, results, touched_magic);
+#endif
+#if TEST_NUM_DFBS > 6
+    touch_one<implicit_sync>(dfb::dfb_6, 6, results, touched_magic);
+#endif
+#if TEST_NUM_DFBS > 7
+    touch_one<implicit_sync>(dfb::dfb_7, 7, results, touched_magic);
+#endif
+#if TEST_NUM_DFBS > 8
+    touch_one<implicit_sync>(dfb::dfb_8, 8, results, touched_magic);
+#endif
+#if TEST_NUM_DFBS > 9
+    touch_one<implicit_sync>(dfb::dfb_9, 9, results, touched_magic);
+#endif
+#if TEST_NUM_DFBS > 10
+    touch_one<implicit_sync>(dfb::dfb_10, 10, results, touched_magic);
+#endif
+#if TEST_NUM_DFBS > 11
+    touch_one<implicit_sync>(dfb::dfb_11, 11, results, touched_magic);
+#endif
+#if TEST_NUM_DFBS > 12
+    touch_one<implicit_sync>(dfb::dfb_12, 12, results, touched_magic);
+#endif
+#if TEST_NUM_DFBS > 13
+    touch_one<implicit_sync>(dfb::dfb_13, 13, results, touched_magic);
+#endif
+#if TEST_NUM_DFBS > 14
+    touch_one<implicit_sync>(dfb::dfb_14, 14, results, touched_magic);
+#endif
+#if TEST_NUM_DFBS > 15
+    touch_one<implicit_sync>(dfb::dfb_15, 15, results, touched_magic);
+#endif
+
+    DPRINT("cons_main done\n");
+}

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_multi_touch_producer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_multi_touch_producer.cpp
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Exercises every bound DFB, each constructed from its generated dfb::dfb_<n> accessor so the
+// interface it touches is the device slot the host assigned rather than the binding's position.
+// Explicit sync (WH/BH): one-entry credit handshake with the consumer. Implicit sync (Quasar
+// default): probe the config only.
+//
+// TEST_NUM_DFBS is a host-provided define rather than a compile-time arg: it guards references to
+// dfb::dfb_<n> names, which only exist in the generated bindings header for accessors this
+// kernel actually binds. Prefixed to avoid colliding with dfb::NUM_DFBS in
+// dataflow_buffer_config.h.
+
+#include "api/dataflow/dataflow_buffer.h"
+#include "experimental/kernel_args.h"
+
+#ifndef TEST_NUM_DFBS
+#error "TEST_NUM_DFBS must be defined by the host (KernelSpec compiler_options.defines)"
+#endif
+
+template <bool ImplicitSync>
+static inline void touch_one(DFBBindingToken token) {
+    DataflowBuffer dfb(token);
+    (void)dfb.get_entry_size();
+    if constexpr (ImplicitSync) {
+        // Probe-only: no credits and no finish(). finish() can spin waiting for ISR/TC drain
+        // even when this kernel never posted traffic (common with host-disabled implicit sync).
+        (void)dfb.get_id();
+    } else {
+        dfb.reserve_back(1);
+        dfb.push_back(1);
+        dfb.finish();
+    }
+}
+
+void kernel_main() {
+    constexpr bool implicit_sync = get_arg(args::implicit_sync);
+
+#if TEST_NUM_DFBS > 0
+    touch_one<implicit_sync>(dfb::dfb_0);
+#endif
+#if TEST_NUM_DFBS > 1
+    touch_one<implicit_sync>(dfb::dfb_1);
+#endif
+#if TEST_NUM_DFBS > 2
+    touch_one<implicit_sync>(dfb::dfb_2);
+#endif
+#if TEST_NUM_DFBS > 3
+    touch_one<implicit_sync>(dfb::dfb_3);
+#endif
+#if TEST_NUM_DFBS > 4
+    touch_one<implicit_sync>(dfb::dfb_4);
+#endif
+#if TEST_NUM_DFBS > 5
+    touch_one<implicit_sync>(dfb::dfb_5);
+#endif
+#if TEST_NUM_DFBS > 6
+    touch_one<implicit_sync>(dfb::dfb_6);
+#endif
+#if TEST_NUM_DFBS > 7
+    touch_one<implicit_sync>(dfb::dfb_7);
+#endif
+#if TEST_NUM_DFBS > 8
+    touch_one<implicit_sync>(dfb::dfb_8);
+#endif
+#if TEST_NUM_DFBS > 9
+    touch_one<implicit_sync>(dfb::dfb_9);
+#endif
+#if TEST_NUM_DFBS > 10
+    touch_one<implicit_sync>(dfb::dfb_10);
+#endif
+#if TEST_NUM_DFBS > 11
+    touch_one<implicit_sync>(dfb::dfb_11);
+#endif
+#if TEST_NUM_DFBS > 12
+    touch_one<implicit_sync>(dfb::dfb_12);
+#endif
+#if TEST_NUM_DFBS > 13
+    touch_one<implicit_sync>(dfb::dfb_13);
+#endif
+#if TEST_NUM_DFBS > 14
+    touch_one<implicit_sync>(dfb::dfb_14);
+#endif
+#if TEST_NUM_DFBS > 15
+    touch_one<implicit_sync>(dfb::dfb_15);
+#endif
+}

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_triple_consumer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_triple_consumer.cpp
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "api/dataflow/dataflow_buffer.h"
+#include "api/dataflow/noc.h"
+#include "api/tensor/noc_traits.h"
+#include "api/kernel_thread_globals.h"
+#include "experimental/kernel_args.h"
+
+template <bool ImplicitSync, typename Dfb, typename Acc>
+static inline void consume_one(
+    Dfb& dfb, const Acc& dst, Noc& noc, uint32_t num_entries, uint32_t chunk_offset, uint32_t entries_per_core) {
+    const uint32_t consumer_idx = get_my_thread_id();
+    const uint32_t num_consumers = get_num_threads();
+    const uint32_t entry_size = dfb.get_entry_size();
+    for (uint32_t tile = 0; tile < num_entries; ++tile) {
+        const uint32_t page_id = chunk_offset + tile * num_consumers + consumer_idx;
+        if (page_id >= chunk_offset + entries_per_core) {
+            break;
+        }
+        if constexpr (ImplicitSync) {
+#ifdef ARCH_QUASAR
+            noc.async_write<NocOptions::TXN_ID>(dfb, dst, {}, {.page_id = page_id});
+#endif
+        } else {
+            dfb.wait_front(1);
+            noc.async_write(dfb, dst, entry_size, {}, {.page_id = page_id});
+            noc.async_write_barrier();
+            dfb.pop_front(1);
+        }
+    }
+    dfb.finish();
+    dfb.write_barrier(noc);
+}
+
+void kernel_main() {
+    constexpr uint32_t num_entries = get_arg(args::num_entries_per_consumer);
+    constexpr bool implicit_sync = get_arg(args::implicit_sync);
+
+    const uint32_t chunk_offset = get_arg(args::chunk_offset);
+    const uint32_t entries_per_core = get_arg(args::entries_per_core);
+
+    Noc noc;
+    DataflowBuffer dfb_0(dfb::in_0);
+    DataflowBuffer dfb_1(dfb::in_1);
+    DataflowBuffer dfb_2(dfb::in_2);
+    const auto dst_0 = TensorAccessor(tensor::dst_0);
+    const auto dst_1 = TensorAccessor(tensor::dst_1);
+    const auto dst_2 = TensorAccessor(tensor::dst_2);
+
+    consume_one<implicit_sync>(dfb_0, dst_0, noc, num_entries, chunk_offset, entries_per_core);
+    consume_one<implicit_sync>(dfb_1, dst_1, noc, num_entries, chunk_offset, entries_per_core);
+    consume_one<implicit_sync>(dfb_2, dst_2, noc, num_entries, chunk_offset, entries_per_core);
+}

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_triple_producer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_triple_producer.cpp
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "api/dataflow/dataflow_buffer.h"
+#include "api/dataflow/noc.h"
+#include "api/tensor/noc_traits.h"
+#include "api/kernel_thread_globals.h"
+#include "experimental/kernel_args.h"
+
+template <bool ImplicitSync, typename Dfb, typename Acc>
+static inline void produce_one(
+    Dfb& dfb, const Acc& src, Noc& noc, uint32_t num_entries, uint32_t chunk_offset, uint32_t entries_per_core) {
+    const uint32_t producer_idx = get_my_thread_id();
+    const uint32_t num_producers = get_num_threads();
+    const uint32_t entry_size = dfb.get_entry_size();
+    for (uint32_t tile = 0; tile < num_entries; ++tile) {
+        const uint32_t page_id = chunk_offset + tile * num_producers + producer_idx;
+        if (page_id >= chunk_offset + entries_per_core) {
+            break;
+        }
+        if constexpr (ImplicitSync) {
+#ifdef ARCH_QUASAR
+            noc.async_read<NocOptions::TXN_ID>(src, dfb, {.page_id = page_id}, {});
+#endif
+        } else {
+            dfb.reserve_back(1);
+            noc.async_read(src, dfb, entry_size, {.page_id = page_id}, {});
+            noc.async_read_barrier();
+            dfb.push_back(1);
+        }
+    }
+    dfb.finish();
+}
+
+void kernel_main() {
+    constexpr uint32_t num_entries = get_arg(args::num_entries_per_producer);
+    constexpr bool implicit_sync = get_arg(args::implicit_sync);
+
+    const uint32_t chunk_offset = get_arg(args::chunk_offset);
+    const uint32_t entries_per_core = get_arg(args::entries_per_core);
+
+    Noc noc;
+    DataflowBuffer dfb_0(dfb::out_0);
+    DataflowBuffer dfb_1(dfb::out_1);
+    DataflowBuffer dfb_2(dfb::out_2);
+    const auto src_0 = TensorAccessor(tensor::src_0);
+    const auto src_1 = TensorAccessor(tensor::src_1);
+    const auto src_2 = TensorAccessor(tensor::src_2);
+
+    produce_one<implicit_sync>(dfb_0, src_0, noc, num_entries, chunk_offset, entries_per_core);
+    produce_one<implicit_sync>(dfb_1, src_1, noc, num_entries, chunk_offset, entries_per_core);
+    produce_one<implicit_sync>(dfb_2, src_2, noc, num_entries, chunk_offset, entries_per_core);
+}

--- a/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
+++ b/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
@@ -282,11 +282,16 @@ void populate_dfb_global_header_participation(
         ::dfb::NUM_DFBS);
     uint32_t id_mask = 0;
     for (const auto& dfb : dfbs_on_core) {
-        TT_FATAL(dfb->id < ghdr.num_dfbs, "DFB id {} out of range (num_dfbs {})", dfb->id, ghdr.num_dfbs);
-        id_mask |= (1u << dfb->id);
+        TT_FATAL(
+            dfb->device_slot < ghdr.num_dfbs,
+            "DFB {} device slot {} out of range (num_dfbs {})",
+            dfb->id,
+            dfb->device_slot,
+            ghdr.num_dfbs);
+        id_mask |= (1u << dfb->device_slot);
         for (uint8_t hartid = 0; hartid < ::dfb::NUM_PARTICIPATING_HARTIDS; ++hartid) {
             if (dfb->risc_mask & (1u << hartid)) {
-                ghdr.participation_mask[hartid] |= (1u << dfb->id);
+                ghdr.participation_mask[hartid] |= (1u << dfb->device_slot);
             }
         }
     }
@@ -294,7 +299,7 @@ void populate_dfb_global_header_participation(
         ghdr.num_dfbs >= 32 ? ~0u : ((1u << ghdr.num_dfbs) - 1u);
     TT_FATAL(
         id_mask == expected_id_mask,
-        "DFB ids must be contiguous 0..{}-1 (id_mask=0x{:x})",
+        "DFB device slots must be contiguous 0..{}-1 (id_mask=0x{:x})",
         ghdr.num_dfbs,
         id_mask);
 }
@@ -379,7 +384,7 @@ void verify_dfb_global_header_participation(
         uint32_t expected = 0;
         for (const auto& dfb : dfbs_on_core) {
             if (dfb->risc_mask & (1u << hartid)) {
-                expected |= (1u << dfb->id);
+                expected |= (1u << dfb->device_slot);
             }
         }
         TT_FATAL(
@@ -427,7 +432,7 @@ size_t serialize_dfb_config_for_core(
     next_producer_bit.fill(0u);
     for (size_t di = 0; di < dfbs_on_core.size(); di++) {
         const auto& dfb = dfbs_on_core[di];
-        const uint8_t logical_dfb_id = static_cast<uint8_t>(dfb->id);
+        const uint8_t logical_dfb_id = static_cast<uint8_t>(dfb->device_slot);
         for (uint8_t h = 0; h < ::dfb::NUM_PARTICIPATING_HARTIDS; h++) {
             if (!(dfb->risc_mask & (1u << h))) { continue; }
             const auto& rcs = per_core_configs[di];
@@ -584,7 +589,7 @@ size_t serialize_dfb_config_for_core(
 
             // Header (28B fixed).
             dfb_hart_init_entry_t entry = {};
-            entry.logical_dfb_id = static_cast<uint8_t>(dfb->id);
+            entry.logical_dfb_id = static_cast<uint8_t>(dfb->device_slot);
             entry.num_tcs        = num_tcs;
             entry.capacity       = rc.is_producer ? static_cast<uint8_t>(dfb->capacity) : 0u;
             entry.entry_size = dfb->config.entry_size;
@@ -1090,6 +1095,8 @@ static std::pair<uint8_t, uint8_t> get_tc_counts(const DfbGroup& group) {
     return {num_producer_tcs, num_consumer_tcs};
 }
 
+// Recompute {capacity, stride_in_entries} from the DFB's num_entries / access pattern. Re-validates the
+// producer/consumer divisibility constraints.
 static std::pair<uint16_t, uint32_t> compute_capacity_and_stride(const DataflowBufferImpl& dfb) {
     const DataflowBufferConfig& config = dfb.config;
     uint32_t capacity = 0;
@@ -1618,6 +1625,11 @@ uint32_t finalize_dfbs(
 
     const auto& hal = MetalContext::instance().hal();
 
+    // WH/BH addresses a DFB's config by its device slot (slot N starts at N * serialized_size), so the
+    // region has to span the highest slot in use on the kernel group, not just hold one entry per DFB.
+    // Quasar uses a single program-wide packed layout sized by compute_dfb_config_serialized_size.
+    const bool slot_addressed = !hal.has_tile_counter_registers();
+
     dfb_offset = base_offset;
     dfb_size = 0;
 
@@ -1626,10 +1638,17 @@ uint32_t finalize_dfbs(
         kernel_config.local_cb_offset() = base_offset;
 
         bool kg_has_dfb = false;
+        uint32_t max_slot_plus_one = 0;
         for (const auto& dfb : dataflow_buffers) {
             TT_ASSERT(dfb->configs_finalized, "DFB {} configs not finalized before serialization", dfb->id);
             for (const CoreRange& kg_range : kg->core_ranges.ranges()) {
-                if (dfb->core_ranges.intersects(kg_range)) { kg_has_dfb = true; break; }
+                if (dfb->core_ranges.intersects(kg_range)) {
+                    kg_has_dfb = true;
+                    if (slot_addressed) {
+                        max_slot_plus_one = std::max(max_slot_plus_one, dfb->device_slot + 1);
+                    }
+                    break;
+                }
             }
         }
         // compute_dfb_config_serialized_size covers the full layout: header + DM1/DM0 blobs +
@@ -1637,9 +1656,9 @@ uint32_t finalize_dfbs(
         uint32_t kg_dfb_size = (kg_has_dfb && hal.has_tile_counter_registers())
                                    ? compute_dfb_config_serialized_size(dataflow_buffers)
                                    : 0u;
-        if (!hal.has_tile_counter_registers() && kg_has_dfb) {
-            // WH/BH: one 4-word CB-format entry per DFB.
-            kg_dfb_size = static_cast<uint32_t>(dataflow_buffers.size()) * dfb_wh_bh_serialized_size();
+        if (slot_addressed && kg_has_dfb) {
+            // WH/BH: region spans the highest device slot used by DFBs on this kernel group.
+            kg_dfb_size = max_slot_plus_one * dfb_wh_bh_serialized_size();
         }
 
         if (hal.has_tile_counter_registers() && kg_dfb_size > 0) {
@@ -1666,6 +1685,35 @@ namespace tt::tt_metal::detail {
 
 using namespace tt::tt_metal::experimental::dfb;
 using namespace tt::tt_metal::experimental::dfb::detail;
+
+// Picks the device-facing slot for a DFB whose core_ranges are already set.
+//
+// The slot is the index firmware and kernel accessors use for this DFB on a core. The only
+// constraint is that no core sees two DFBs at the same slot. Two DFBs conflict iff their core
+// ranges intersect, so assignment takes the lowest slot not claimed by a conflicting DFB.
+// DFBs on disjoint cores reuse low slots, so a core's config table stays as small as its own
+// DFB count rather than growing with the number of DFBs elsewhere in the program.
+uint32_t ProgramImpl::assign_dfb_device_slot(const DataflowBufferImpl& dfb) const {
+    const auto& hal = MetalContext::instance().hal();
+    const uint32_t max_slots = hal.has_tile_counter_registers() ? ::dfb::NUM_DFBS : hal.get_arch_num_circular_buffers();
+
+    uint64_t used_slots = 0;
+    for (const auto& other : this->dataflow_buffers_) {
+        if (other->core_ranges.intersects(dfb.core_ranges)) {
+            used_slots |= (uint64_t(1) << other->device_slot);
+        }
+    }
+
+    const uint64_t free_slots = ~used_slots;
+    const uint32_t slot = free_slots ? static_cast<uint32_t>(__builtin_ctzll(free_slots)) : max_slots;
+    TT_FATAL(
+        slot < max_slots,
+        "Cannot create DFB {}: every one of the {} slots this arch supports per core is already taken by a dataflow "
+        "buffer sharing a core with it",
+        dfb.id,
+        max_slots);
+    return slot;
+}
 
 uint32_t ProgramImpl::add_dataflow_buffer(const CoreRangeSet& core_range_set, const DataflowBufferConfig& config) {
     TT_FATAL(this->compiled_.empty(), "Cannot add dataflow buffer to an already compiled program {}", this->id);
@@ -1707,23 +1755,16 @@ uint32_t ProgramImpl::add_dataflow_buffer(const CoreRangeSet& core_range_set, co
 
     dfb->id = static_cast<uint32_t>(this->dataflow_buffers_.size());
 
-    // DFB IDs are auto-assigned contiguously from 0, so enforce the limit here.
-    if (!MetalContext::instance().hal().has_tile_counter_registers()) {
-        uint32_t max_dfb_id = MetalContext::instance().hal().get_arch_num_circular_buffers();
-        TT_FATAL(
-            dfb->id < max_dfb_id,
-            "Cannot create DFB {}: WH/BH supports at most {} dataflow buffers",
-            dfb->id,
-            max_dfb_id);
-    }
-
     dfb->core_ranges = core_range_set.merge_ranges();
     dfb->config = config;
 
+    dfb->device_slot = this->assign_dfb_device_slot(*dfb);
+
     log_debug(
         tt::LogMetal,
-        "Creating DFB {} with {} producers and {} consumers",
+        "Creating DFB {} (device slot {}) with {} producers and {} consumers",
         dfb->id,
+        dfb->device_slot,
         config.num_producers,
         config.num_consumers);
 
@@ -2670,11 +2711,11 @@ std::vector<CoreRange> ProgramImpl::dataflow_buffers_unique_coreranges() const {
 
 void ProgramImpl::set_dfb_data_fmt_and_tile(const std::vector<CoreRange>& crs, JitBuildOptions& build_options) const {
     TTZoneScopedD(PROGRAM);
-    // Match detail::ProgramImpl::set_cb_data_fmt_and_tile: DFB logical ids map to CBIndex slots for HLK unpack/pack.
+    // Match detail::ProgramImpl::set_cb_data_fmt_and_tile: DFB device slots map to CBIndex slots for HLK unpack/pack.
     for (const auto& logical_cr : crs) {
         const auto& dfbs_on_core = this->dataflow_buffers_on_corerange(logical_cr);
         for (const auto& dfb : dfbs_on_core) {
-            const CBIndex cb_index = static_cast<CBIndex>(dfb->id);
+            const CBIndex cb_index = static_cast<CBIndex>(dfb->device_slot);
             const DataFormat data_format = dfb->config.data_format;
             // Populate this DFB's CB-indexed JIT metadata only when a format was specified.
             // A format-less DFB has no compute consumer, so its JIT slot is intentionally left

--- a/tt_metal/impl/dataflow_buffer/dataflow_buffer_impl.hpp
+++ b/tt_metal/impl/dataflow_buffer/dataflow_buffer_impl.hpp
@@ -61,7 +61,11 @@ struct DfbGroup {
 };
 
 struct DataflowBufferImpl {
+    // Unique, program-wide handle
     uint32_t id{};
+    // Device-facing slot number, baked into kernel binaries as the dfb::<name> accessor value and
+    // used as the config-table index in the dispatch payload.
+    uint32_t device_slot{};
     CoreRangeSet core_ranges;
     DataflowBufferConfig config;
 

--- a/tt_metal/impl/emulation/emulated_program_runner.cpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.cpp
@@ -589,13 +589,15 @@ struct PendingKernelInfo {
     std::string kernel_name;  // kernel source path, for the ASAN trace
 };
 
-// DFB allocation info for a single DFB on a core. Only dfb_id and base_addr
+// DFB allocation info for a single DFB on a core. Only device_slot and base_addr
 // are genuinely new per-core state; everything else (entry_size, num_entries,
 // risc masks, num_producers/consumers, cap) is read from the borrowed config
 // pointer, whose backing DataflowBufferImpl is owned by ProgramImpl and
 // outlives one program execution.
 struct DFBAllocInfo {
-    uint32_t dfb_id = 0;
+    // Matches the dfb::<name> accessor value the emulated kernel uses, so all per-core tables
+    // (CB sync, tile counters, interface slots) are keyed by slot rather than by program-wide id.
+    uint32_t device_slot = 0;
     uint32_t base_addr = 0;
     const tt::tt_metal::experimental::dfb::DataflowBufferConfig* cfg = nullptr;
 };
@@ -2829,7 +2831,7 @@ static std::vector<DFBAllocInfo> allocate_dfbs_on_core(
     constexpr uint16_t TENSIX_MASK = 0xFF00u;  // bits 8-15
     std::unordered_map<uint64_t, uint32_t> bridge_consumer_alloc;
     for (auto& dfb_impl : dfb_impls) {
-        uint32_t dfb_id = dfb_impl->id;
+        uint32_t device_slot = dfb_impl->device_slot;
         auto& cfg = dfb_impl->config;
         uint32_t total = cfg.entry_size * cfg.num_entries;
         uint64_t dim_key = (static_cast<uint64_t>(cfg.entry_size) << 32) | cfg.num_entries;
@@ -2861,21 +2863,21 @@ static std::vector<DFBAllocInfo> allocate_dfbs_on_core(
         bool is_all = (cfg.cap == ::dfb::AccessPattern::ALL);
         uint32_t M = is_all ? cfg.num_producers : std::max<uint32_t>(cfg.num_producers, cfg.num_consumers);
         uint32_t capacity = cfg.num_entries / M;
-        core->init_dfb_sync(dfb_id, base, cfg.entry_size, cfg.num_entries, capacity);
+        core->init_dfb_sync(device_slot, base, cfg.entry_size, cfg.num_entries, capacity);
 
         // Also populate CB sync state for this DFB so compute ops (pack_tile,
         // matmul_tiles) can reuse the same L1 buffer via cb_read_ptr/cb_write_ptr.
-        if (dfb_id < EMULE_NUM_CBS) {
-            core->init_cb_sync(static_cast<uint8_t>(dfb_id), base, cfg.entry_size, cfg.num_entries);
+        if (device_slot < EMULE_NUM_CBS) {
+            core->init_cb_sync(static_cast<uint8_t>(device_slot), base, cfg.entry_size, cfg.num_entries);
         }
 
         // Initialize tile counters for this DFB.
         // STRIDED: M TCs. ALL DM-DM: P*C TCs. Counter IDs are spaced by
         // MAX_TC_SLOTS_PER_DFB to prevent cross-DFB collisions.
-        if (dfb_id >= (tt_emule::TILE_COUNTERS_PER_NEO / tt_emule::MAX_TC_SLOTS_PER_DFB)) {
-            throw std::out_of_range("dfb_id exceeds safe TC range (max 8 DFBs per NEO with neo_id=0)");
+        if (device_slot >= (tt_emule::TILE_COUNTERS_PER_NEO / tt_emule::MAX_TC_SLOTS_PER_DFB)) {
+            throw std::out_of_range("DFB device slot exceeds safe TC range (max 8 DFBs per NEO with neo_id=0)");
         }
-        uint8_t counter_base = static_cast<uint8_t>(dfb_id * tt_emule::MAX_TC_SLOTS_PER_DFB);
+        uint8_t counter_base = static_cast<uint8_t>(device_slot * tt_emule::MAX_TC_SLOTS_PER_DFB);
         uint32_t num_tcs_to_init = is_all ? static_cast<uint32_t>(cfg.num_producers) * cfg.num_consumers : M;
         for (uint32_t tc_idx = 0; tc_idx < num_tcs_to_init; ++tc_idx) {
             auto& tc = core->tile_counters()->get(0, counter_base + static_cast<uint8_t>(tc_idx));
@@ -2884,13 +2886,13 @@ static std::vector<DFBAllocInfo> allocate_dfbs_on_core(
             tc.acked.store(0, std::memory_order_relaxed);
         }
 
-        dfb_allocs.push_back({dfb_id, base_addr, &cfg});
+        dfb_allocs.push_back({device_slot, base_addr, &cfg});
         log_debug(
             tt::LogMetal,
             "  Core({},{}) DFB[{}]: addr=0x{:x} entry_size={} num_entries={} total={}",
             logical_core.x,
             logical_core.y,
-            dfb_id,
+            device_slot,
             base_addr,
             cfg.entry_size,
             cfg.num_entries,
@@ -2964,10 +2966,10 @@ static void populate_dfb_interface_slots(
     bool is_all = (cfg.cap == ::dfb::AccessPattern::ALL);
     uint32_t M = is_all ? cfg.num_producers : std::max<uint32_t>(cfg.num_producers, cfg.num_consumers);
     uint32_t stride_size = M * cfg.entry_size;
-    if (alloc.dfb_id >= (tt_emule::TILE_COUNTERS_PER_NEO / tt_emule::MAX_TC_SLOTS_PER_DFB)) {
+    if (alloc.device_slot >= (tt_emule::TILE_COUNTERS_PER_NEO / tt_emule::MAX_TC_SLOTS_PER_DFB)) {
         return;
     }
-    uint8_t counter_base = static_cast<uint8_t>(alloc.dfb_id * tt_emule::MAX_TC_SLOTS_PER_DFB);
+    uint8_t counter_base = static_cast<uint8_t>(alloc.device_slot * tt_emule::MAX_TC_SLOTS_PER_DFB);
 
     bool is_producer = (cfg.producer_risc_mask & proc_bit) != 0;
     bool is_consumer = (cfg.consumer_risc_mask & proc_bit) != 0;
@@ -3056,11 +3058,11 @@ static std::vector<std::unique_ptr<tt_emule::EmuleDFBInterface[]>> build_per_thr
     for (size_t t = 0; t < ki_list.size(); t++) {
         per_thread_dfbs[t] = std::make_unique<tt_emule::EmuleDFBInterface[]>(tt_emule::MAX_DFBS);
         for (const auto& alloc : dfb_allocs) {
-            if (alloc.dfb_id >= tt_emule::MAX_DFBS) {
+            if (alloc.device_slot >= tt_emule::MAX_DFBS) {
                 continue;
             }
             populate_dfb_interface_slots(
-                per_thread_dfbs[t][alloc.dfb_id], alloc, ki_list[t].processor_id, ki_list[t].is_tensix);
+                per_thread_dfbs[t][alloc.device_slot], alloc, ki_list[t].processor_id, ki_list[t].is_tensix);
         }
     }
     return per_thread_dfbs;

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -9,6 +9,7 @@
 #include <numeric>
 #include <set>
 #include <string_view>
+#include <unordered_map>
 #include <unordered_set>
 
 #include <tt-logger/tt-logger.hpp>
@@ -30,6 +31,7 @@
 #include "impl/context/metal_env_accessor.hpp"
 #include "impl/dispatch/dispatch_core_manager.hpp"
 #include "distributed/mesh_workload_impl.hpp"
+#include "tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_config.h"
 #include <core_descriptor.hpp>
 #include <llrt/tt_cluster.hpp>
 #include <variant>
@@ -148,8 +150,11 @@ using ComputeEngineMaskMap = std::unordered_map<const KernelSpec*, ComputeEngine
 //   Gen2: bits 0-7 = DM processors, bits 8-15 = Tensix compute engines
 using KernelRiscMaskMap = std::unordered_map<const KernelSpec*, uint16_t>;
 
-// DFB name -> DFB ID map (for unpack_to_dest_mode indexing)
+// DFB name -> program-wide DFB ID map (host-side identity: aliasing, borrowed bindings)
 using DFBNameToIdMap = std::unordered_map<DFBSpecName, uint32_t>;
+// DFB name -> device slot map. The slot is what a kernel sees (the dfb::<name> accessor value) and
+// what indexes the per-core config table, so it is what device-facing lowering must use.
+using DFBNameToSlotMap = std::unordered_map<DFBSpecName, uint32_t>;
 using SemaphoreNameToIdMap = std::unordered_map<SemaphoreSpecName, uint32_t>;
 
 // ============================================================================
@@ -1164,37 +1169,48 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
     // Validate DataflowBufferSpecs
     //////////////////////////////////
 
-    // Validate the total number of DFBs in the ProgramSpec:
-    //  - For Gen1, there's a hard limit (hal::get_arch_num_circular_buffers())
-    //  - For Gen2, the true DFB limit is configuration-dependent, based on the availability
-    //    of tile counters. This won't actually get checked until the Program is enqueued :(
-    //  - However, the Gen1 check actually DOES apply to Gen2 as a strict upper limit.
-    //    In practice, we'll run out of tile counters long before we hit the HAL CB limit,
-    //    but then runtime software sizes some buffers based on this.
-    //
-    // For Quasar, this is a partial validation only!
-    // The true number of available DFBs depends on the tile counters, which are consumed in
-    // a DFB configuration-dependent way.
-    // Unfortunately, those checks won't trigger until the DFB code runs... not until the
-    // Program is actually enqueued :(
+    // Device slots are allocated per core (two DFBs may share a slot iff their node sets are
+    // disjoint), so the arch limit is on how many DFBs land on any single node — not on
+    // ProgramSpec::dataflow_buffers.size(). Gen1 lowers each slot to a circular buffer; Gen2
+    // indexes the packed config by device slot up to dfb::NUM_DFBS. Tile-counter exhaustion on
+    // Gen2 is still checked later at enqueue.
     {
-        const uint32_t max_dfbs = tt::tt_metal::hal::get_arch_num_circular_buffers();
-        if (spec.dataflow_buffers.size() > max_dfbs) {
+        const auto& hal = tt::tt_metal::MetalContext::instance().hal();
+        const uint32_t max_slots_per_core = hal.has_tile_counter_registers()
+                                                ? static_cast<uint32_t>(::dfb::NUM_DFBS)
+                                                : tt::tt_metal::hal::get_arch_num_circular_buffers();
+
+        std::unordered_map<NodeCoord, uint32_t> dfbs_per_node;
+        for (const auto& dfb : spec.dataflow_buffers) {
+            for (const NodeCoord& node : corerange_to_cores(collected.dfb_node_set.at(dfb.unique_id))) {
+                dfbs_per_node[node]++;
+            }
+        }
+
+        for (const auto& [node, count] : dfbs_per_node) {
+            if (count <= max_slots_per_core) {
+                continue;
+            }
             if (is_gen1_arch()) {
                 TT_THROW(
-                    "ProgramSpec '{}' has too many DataflowBufferSpecs ({}). The target "
-                    "architecture supports up to {}.",
+                    "ProgramSpec '{}' places {} DataflowBufferSpecs on node ({}, {}), but Gen1 "
+                    "supports at most {} device slots per core (disjoint cores may reuse slots).",
                     spec.name,
-                    spec.dataflow_buffers.size(),
-                    max_dfbs);
+                    count,
+                    node.x,
+                    node.y,
+                    max_slots_per_core);
             } else if (is_gen2_arch()) {
                 TT_THROW(
-                    "ProgramSpec '{}' has too many DataflowBufferSpecs ({}). The permitted "
-                    "number of DFBs for the target architecture is configuration-dependent, "
-                    "but {} is a hard upper limit.",
+                    "ProgramSpec '{}' places {} DataflowBufferSpecs on node ({}, {}), but the "
+                    "target architecture supports at most {} device slots per core. The true "
+                    "limit is also configuration-dependent (tile counters) and is checked at "
+                    "enqueue.",
                     spec.name,
-                    spec.dataflow_buffers.size(),
-                    max_dfbs);
+                    count,
+                    node.x,
+                    node.y,
+                    max_slots_per_core);
             } else {
                 TT_FATAL(false, "Unknown architecture");
             }
@@ -2462,20 +2478,21 @@ ScratchpadBindingsForKernel ResolveScratchpadBindingsForKernel(
     return out;
 }
 
-// Create map of accessor name -> logical DFB id
+// Create map of local accessor name -> DFB device slot. This is the value baked into the kernel's
+// dfb::<name> accessor, so it must be the device slot rather than the program-wide id.
 tt::tt_metal::DataflowBufferBindingHandleMap MakeDataflowBufferBindingHandles(
-    const KernelSpec& kernel_spec, const DFBNameToIdMap& dfb_name_to_id) {
+    const KernelSpec& kernel_spec, const DFBNameToSlotMap& dfb_name_to_slot) {
     tt::tt_metal::DataflowBufferBindingHandleMap out;
     out.reserve(kernel_spec.dfb_bindings.size());
     for (const auto& dfb_binding : kernel_spec.dfb_bindings) {
-        const uint32_t id = dfb_name_to_id.at(dfb_binding.dfb_spec_name);
+        const uint32_t slot = dfb_name_to_slot.at(dfb_binding.dfb_spec_name);
         TT_FATAL(
-            id <= std::numeric_limits<uint16_t>::max(),
-            "Kernel '{}' DFB '{}' logical id {} does not fit uint16_t",
+            slot <= std::numeric_limits<uint16_t>::max(),
+            "Kernel '{}' DFB '{}' device slot {} does not fit uint16_t",
             kernel_spec.unique_id,
             dfb_binding.dfb_spec_name,
-            id);
-        out.emplace(dfb_binding.accessor_name, static_cast<uint16_t>(id));
+            slot);
+        out.emplace(dfb_binding.accessor_name, static_cast<uint16_t>(slot));
     }
     return out;
 }
@@ -2671,22 +2688,24 @@ DataMovementConfig MakeGen1DataMovementConfig(const KernelSpec& kernel_spec) {
 // ----------------------------------------------------------------------------
 
 std::vector<UnpackToDestMode> BuildUnpackToDestModeVector(
-    const ComputeUnpackModes& user_modes, const DFBNameToIdMap& dfb_name_to_id) {
+    const ComputeUnpackModes& user_modes, const DFBNameToSlotMap& dfb_name_to_slot) {
     const uint32_t max_cbs = tt::tt_metal::hal::get_arch_num_circular_buffers();
     std::vector<UnpackToDestMode> unpack_modes(max_cbs, UnpackToDestMode::Default);
     for (const auto& [dfb_name, mode] : user_modes) {
-        uint32_t dfb_id = dfb_name_to_id.at(dfb_name);
+        // Indexed by device slot: this vector is consumed by the HLK alongside the CB-indexed data
+        // formats, which set_dfb_data_fmt_and_tile also keys by slot.
+        uint32_t dfb_slot = dfb_name_to_slot.at(dfb_name);
         // This TT_FATAL is unreachable, provided that validation wasn't skipped.
         TT_FATAL(
-            dfb_id < max_cbs,
-            "Internal Error: DFB '{}' has id {} which exceeds the JIT data-format "
+            dfb_slot < max_cbs,
+            "Internal Error: DFB '{}' has device slot {} which exceeds the JIT data-format "
             "slot count ({}); compute kernels cannot reference DFBs past this limit",
             dfb_name,
-            dfb_id,
+            dfb_slot,
             max_cbs);
         // Public UnpackMode -> internal UnpackToDestMode. UnpackToDest keeps full FP32 by
         // unpacking straight to Dest; UnpackToSrc is the SrcA/B path (the internal "Default").
-        unpack_modes[dfb_id] =
+        unpack_modes[dfb_slot] =
             (mode == UnpackMode::UnpackToDest) ? UnpackToDestMode::UnpackToDestFp32 : UnpackToDestMode::Default;
     }
     return unpack_modes;
@@ -2696,7 +2715,7 @@ std::vector<UnpackToDestMode> BuildUnpackToDestModeVector(
 // MakeGen1ComputeConfig: Create a ComputeConfig (WH/BH) from a KernelSpec
 // ----------------------------------------------------------------------------
 
-ComputeConfig MakeGen1ComputeConfig(const KernelSpec& kernel_spec, const DFBNameToIdMap& dfb_name_to_id) {
+ComputeConfig MakeGen1ComputeConfig(const KernelSpec& kernel_spec, const DFBNameToSlotMap& dfb_name_to_slot) {
     TT_FATAL(kernel_spec.is_compute_kernel(), "Expected a compute kernel");
     const auto& compute_config = std::get<ComputeHardwareConfig>(kernel_spec.hw_config);
 
@@ -2706,7 +2725,7 @@ ComputeConfig MakeGen1ComputeConfig(const KernelSpec& kernel_spec, const DFBName
         "ComputeGen1Config, generation mismatch, please provide the correctly typed hardware config.");
     const auto& gen1 = std::get<ComputeGen1Config>(compute_config);
 
-    std::vector<UnpackToDestMode> unpack_dst_modes = BuildUnpackToDestModeVector(gen1.unpack_modes, dfb_name_to_id);
+    std::vector<UnpackToDestMode> unpack_dst_modes = BuildUnpackToDestModeVector(gen1.unpack_modes, dfb_name_to_slot);
 
     return ComputeConfig{
         .math_fidelity = gen1.fpu_math_fidelity,
@@ -2746,7 +2765,7 @@ experimental::quasar::QuasarDataMovementConfig MakeQuasarDataMovementConfig(cons
 // ----------------------------------------------------------------------------
 
 experimental::quasar::QuasarComputeConfig MakeGen2ComputeConfig(
-    const KernelSpec& kernel_spec, const DFBNameToIdMap& dfb_name_to_id) {
+    const KernelSpec& kernel_spec, const DFBNameToSlotMap& dfb_name_to_slot) {
     TT_FATAL(kernel_spec.is_compute_kernel(), "Expected a compute kernel");
     const auto& compute_config = std::get<ComputeHardwareConfig>(kernel_spec.hw_config);
     TT_FATAL(
@@ -2755,7 +2774,7 @@ experimental::quasar::QuasarComputeConfig MakeGen2ComputeConfig(
         "ComputeGen2Config, generation mismatch, please provide the correctly typed hardware config.");
     const auto& gen2 = std::get<ComputeGen2Config>(compute_config);
 
-    std::vector<UnpackToDestMode> unpack_dst_modes = BuildUnpackToDestModeVector(gen2.unpack_modes, dfb_name_to_id);
+    std::vector<UnpackToDestMode> unpack_dst_modes = BuildUnpackToDestModeVector(gen2.unpack_modes, dfb_name_to_slot);
 
     return experimental::quasar::QuasarComputeConfig{
         .num_threads_per_cluster = kernel_spec.num_threads,
@@ -2932,6 +2951,7 @@ Program BuildProgramFromSpec(distributed::MeshDevice& mesh_device, const Program
     // NOTE: Iterate over spec.dataflow_buffers (not collected.dfb_endpoints) to ensure
     //       deterministic DFB ID assignment based on user-specified order.
     DFBNameToIdMap dfb_name_to_id;
+    DFBNameToSlotMap dfb_name_to_slot;
     for (const auto& dfb_spec : spec.dataflow_buffers) {
         const DFBSpecName& dfb_name = dfb_spec.unique_id;
         const auto& dfb_endpoint_info = collected.dfb_endpoints.at(dfb_name);
@@ -2945,6 +2965,7 @@ Program BuildProgramFromSpec(distributed::MeshDevice& mesh_device, const Program
         uint32_t dfb_id = program_impl->add_dataflow_buffer(collected.dfb_node_set.at(dfb_name), config);
         program_impl->register_dfb_spec_name(dfb_name.get(), dfb_id);
         dfb_name_to_id[dfb_name] = dfb_id;
+        dfb_name_to_slot[dfb_name] = program_impl->get_dataflow_buffer(dfb_id)->device_slot;
 
         // Borrowed-memory DFB: record the dfb_id ↔ TensorParamName binding so that
         // SetProgramRunArgs / UpdateTensorArgs can resolve and attach the actual L1 Buffer
@@ -2998,9 +3019,9 @@ Program BuildProgramFromSpec(distributed::MeshDevice& mesh_device, const Program
         KernelSource kernel_src = MakeKernelSource(kernel_spec);
         const NodeRangeSet& node_ranges = collected.kernel_node_set.at(kernel_spec.unique_id);
 
-        // Make the accessor name -> DFB ID map for this kernel
+        // Make the local accessor name -> DFB device slot map for this kernel
         const tt::tt_metal::DataflowBufferBindingHandleMap dfb_handles =
-            MakeDataflowBufferBindingHandles(kernel_spec, dfb_name_to_id);
+            MakeDataflowBufferBindingHandles(kernel_spec, dfb_name_to_slot);
         const tt::tt_metal::SemaphoreBindingHandleMap semaphore_handles =
             MakeSemaphoreBindingHandles(kernel_spec, semaphore_name_to_id);
 
@@ -3056,7 +3077,7 @@ Program BuildProgramFromSpec(distributed::MeshDevice& mesh_device, const Program
                     tensor_binding_handles,
                     ta_bindings.crta_layout);
             } else {
-                auto config = MakeGen2ComputeConfig(kernel_spec, dfb_name_to_id);
+                auto config = MakeGen2ComputeConfig(kernel_spec, dfb_name_to_slot);
                 config.compile_args = ta_bindings.cta_words;
                 auto processors = GetComputeProcessorSet(ComputeEngineMask{(uint8_t)(risc_mask >> 8)});
                 kernel = std::make_shared<experimental::quasar::QuasarComputeKernel>(
@@ -3088,7 +3109,7 @@ Program BuildProgramFromSpec(distributed::MeshDevice& mesh_device, const Program
                     tensor_binding_handles,
                     ta_bindings.crta_layout);
             } else {
-                auto config = MakeGen1ComputeConfig(kernel_spec, dfb_name_to_id);
+                auto config = MakeGen1ComputeConfig(kernel_spec, dfb_name_to_slot);
                 config.compile_args = ta_bindings.cta_words;
                 kernel = std::make_shared<ComputeKernel>(
                     kernel_src,

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -341,7 +341,7 @@ void finalize_dfb_masks(
         for (const auto& dfb : dataflow_buffers) {
             for (const CoreRange& kg_range : kg->core_ranges.ranges()) {
                 if (dfb->core_ranges.intersects(kg_range)) {
-                    kg_dfb_mask |= (uint64_t(1) << dfb->id);
+                    kg_dfb_mask |= (uint64_t(1) << dfb->device_slot);
                     break;
                 }
             }
@@ -1377,12 +1377,19 @@ public:
 
             size_t max_byte_end = 0;
             if (!hal.has_tile_counter_registers()) {
-                // WH/BH: DFBs reuse the CB slot format; slot N starts at N * 4 words.
+                // WH/BH: DFBs reuse the CB slot format; device slot N starts at N * 4 words.
                 for (const auto& dfb : dfbs_on_corerange) {
-                    size_t dfb_byte_offset =
-                        static_cast<size_t>(dfb->id) * UINT32_WORDS_PER_LOCAL_CIRCULAR_BUFFER_CONFIG * sizeof(uint32_t);
+                    size_t dfb_byte_offset = static_cast<size_t>(dfb->device_slot) *
+                                            UINT32_WORDS_PER_LOCAL_CIRCULAR_BUFFER_CONFIG * sizeof(uint32_t);
                     auto serialized = dfb->serialize_for_core(logical_representative);
-                    TT_ASSERT(dfb_byte_offset + serialized.size() <= payload.size());
+                    TT_FATAL(
+                        dfb_byte_offset + serialized.size() <= payload.size(),
+                        "DFB {} (device slot {}) config at byte offset {} does not fit in the {}-byte config payload "
+                        "sized by finalize_dfbs",
+                        dfb->id,
+                        dfb->device_slot,
+                        dfb_byte_offset,
+                        payload.size());
                     std::copy(serialized.begin(), serialized.end(), payload.begin() + dfb_byte_offset);
                     max_byte_end = std::max(max_byte_end, dfb_byte_offset + serialized.size());
                 }
@@ -2564,7 +2571,7 @@ void update_program_dispatch_commands(
             if (!hal.has_tile_counter_registers()) {
                 // WH/BH: overwrite the 4 uint32 words for each DFB slot in-place.
                 for (const auto& dfb : dfbs_on_core_range) {
-                    uint32_t base_index = dfb->id * UINT32_WORDS_PER_LOCAL_CIRCULAR_BUFFER_CONFIG;
+                    uint32_t base_index = dfb->device_slot * UINT32_WORDS_PER_LOCAL_CIRCULAR_BUFFER_CONFIG;
                     uint32_t* words = reinterpret_cast<uint32_t*>(dfb_config_payload) + base_index;
                     words[0] = dfb->uniform_alloc_addr();
                     words[1] = dfb->config.entry_size * dfb->config.num_entries;
@@ -3040,7 +3047,8 @@ TraceNode create_trace_node(
                 max_cbs * UINT32_WORDS_PER_LOCAL_CIRCULAR_BUFFER_CONFIG * sizeof(uint32_t), 0);
             size_t first_unused_byte = 0;
             for (const auto& dfb : dfbs_on_core_range) {
-                size_t base_index = static_cast<size_t>(dfb->id) * UINT32_WORDS_PER_LOCAL_CIRCULAR_BUFFER_CONFIG;
+                size_t base_index =
+                    static_cast<size_t>(dfb->device_slot) * UINT32_WORDS_PER_LOCAL_CIRCULAR_BUFFER_CONFIG;
                 size_t byte_offset = base_index * sizeof(uint32_t);
                 uint32_t* words = reinterpret_cast<uint32_t*>(dfb_config_payload.data()) + base_index;
                 words[0] = dfb->uniform_alloc_addr();

--- a/tt_metal/impl/program/program_impl.hpp
+++ b/tt_metal/impl/program/program_impl.hpp
@@ -290,6 +290,8 @@ public:
     uint32_t add_dataflow_buffer(
         const CoreRangeSet& core_range_set, const experimental::dfb::DataflowBufferConfig& config);
 
+    uint32_t assign_dfb_device_slot(const experimental::dfb::detail::DataflowBufferImpl& dfb) const;
+
     // Declare an alias relationship: secondary shares primary's L1 address.
     void set_dfb_alias(uint32_t primary_id, uint32_t secondary_id);
 


### PR DESCRIPTION
### PR Category
Bug fix


### Summary
Fixes [#51409](https://github.com/tenstorrent/tt-metal/issues/51409): dispatch sized / indexed per-core DFB config using the program-wide DFB id, so WH/BH programs with many DFBs on disjoint cores either hit the arch CB-count cap incorrectly or wrote slot configs past a payload sized only for the local DFB count.

Split DFB identity into:
- id: program-unique host handle (aliasing, borrowed bindings, etc.)
- device_slot: device-facing index: unique among DFBs whose core ranges intersect; WH/BH packs the lowest free slot so disjoint cores reuse low slots; Quasar keeps device_slot == id

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=abhullar/dfb-ids)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:abhullar/dfb-ids)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=abhullar/dfb-ids)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:abhullar/dfb-ids)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=abhullar/dfb-ids)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:abhullar/dfb-ids)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=abhullar/dfb-ids)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:abhullar/dfb-ids)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=abhullar/dfb-ids)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:abhullar/dfb-ids)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=abhullar/dfb-ids)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:abhullar/dfb-ids)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=abhullar/dfb-ids)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:abhullar/dfb-ids)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=abhullar/dfb-ids)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:abhullar/dfb-ids)