### PR TITLE
Per-core allocation: one address API, per (device, core)

### DIFF
--- a/models/demos/deepseek_v3_b1/compressed_tensor/compressed_tensor.py
+++ b/models/demos/deepseek_v3_b1/compressed_tensor/compressed_tensor.py
@@ -581,7 +581,7 @@ class CompressedTensor:
             per_core = self._multi_device_data_per_core.get(device_coord, {})
             key = (core_coord.x, core_coord.y)
             assert key in per_core, f"Core {core_coord} not found in per-core data for device {device_coord}"
-            return per_core[key].experimental_per_core_buffer_address(core_coord)
+            return per_core[key].experimental_per_core_buffer_address(device_coord, core_coord)
         return self.data.buffer_address()
 
     def get_assignment_l1_address(self) -> int:
@@ -596,7 +596,7 @@ class CompressedTensor:
         per_core = self._multi_device_assignment_per_core.get(device_coord, {})
         key = (core_coord.x, core_coord.y)
         assert key in per_core, f"Core {core_coord} not found in per-core assignment for device {device_coord}"
-        return per_core[key].experimental_per_core_buffer_address(core_coord)
+        return per_core[key].experimental_per_core_buffer_address(device_coord, core_coord)
 
     @property
     def data_bytes(self) -> int:

--- a/models/demos/deepseek_v3_b1/fused_ops/attention_block/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/attention_block/op.py
@@ -3494,10 +3494,14 @@ class AttentionBlock:
                 # query a specific core via experimental_per_core_buffer_address. Per-core
                 # addresses are uniform across the shard grid (asserted by
                 # assert_uniform_per_core_addresses), so any core returns the same base.
+                # The address is per (device, core), so a device is named too: this takes the
+                # tensor's first device and uses that base for the whole mesh. Nothing checks
+                # that the devices agree -- assert_uniform_per_core_addresses covers cores
+                # within a device, not devices against each other.
                 def _fused_base_addr(t):
                     if t.is_per_core_allocated():
                         core = t.memory_config().shard_spec.grid.bounding_box().start
-                        return t.experimental_per_core_buffer_address(core)
+                        return t.experimental_per_core_buffer_address(t.device_coords()[0], core)
                     return t.buffer_address()
 
                 fused_weights_base_addr = _fused_base_addr(ref_fused_weights_tensor)

--- a/models/demos/deepseek_v3_b1/fused_ops/moe/op.py
+++ b/models/demos/deepseek_v3_b1/fused_ops/moe/op.py
@@ -52,10 +52,15 @@ def _fused_base_addr(t):
     ``experimental_per_core_buffer_address`` on any core in the shard grid; per-core
     addresses are asserted to be uniform across the grid at allocation time
     (``assert_uniform_per_core_addresses``), so any core returns the same base.
+
+    The address is per (device, core), so a device must be named as well. This takes the
+    tensor's first device and uses that base for the whole mesh. Nothing verifies the
+    devices agree: ``assert_uniform_per_core_addresses`` checks cores within a device,
+    not devices against each other. So this is an assumption, not a guarantee.
     """
     if hasattr(t, "is_per_core_allocated") and t.is_per_core_allocated():
         core = t.memory_config().shard_spec.grid.bounding_box().start
-        return t.experimental_per_core_buffer_address(core)
+        return t.experimental_per_core_buffer_address(t.device_coords()[0], core)
     return t.buffer_address()
 
 

--- a/models/demos/deepseek_v3_b1/weights/overlap/packing.py
+++ b/models/demos/deepseek_v3_b1/weights/overlap/packing.py
@@ -20,19 +20,25 @@ def assert_uniform_per_core_addresses(tensor: ttnn.Tensor, cores: list[tuple[int
     address.  The overlap system relies on CB setup broadcasting a single base
     address to all cores, so addresses *must* be uniform.  This holds when the
     tensor is the first per-core allocation on the device.
+
+    The address is per (device, core), so this checks every device the tensor spans.
+    A fused overlap buffer is built with a mesh mapper, so on a multi-device run
+    ``tensor`` covers the whole mesh and uniformity has to hold on each device
+    independently -- each device allocates from its own L1 frontier.
     """
     if not cores:
         return
     first = ttnn.CoreCoord(*cores[0])
-    addr0 = tensor.experimental_per_core_buffer_address(first)
-    for x, y in cores[1:]:
-        cc = ttnn.CoreCoord(x, y)
-        addr = tensor.experimental_per_core_buffer_address(cc)
-        assert addr == addr0, (
-            f"Per-core overlap buffer has non-uniform L1 addresses: "
-            f"core ({first.x},{first.y})=0x{addr0:x} vs core ({x},{y})=0x{addr:x}. "
-            f"Ensure this is the first per-core allocation on the device."
-        )
+    for coord in tensor.device_coords():
+        addr0 = tensor.experimental_per_core_buffer_address(coord, first)
+        for x, y in cores[1:]:
+            cc = ttnn.CoreCoord(x, y)
+            addr = tensor.experimental_per_core_buffer_address(coord, cc)
+            assert addr == addr0, (
+                f"Per-core overlap buffer has non-uniform L1 addresses on device {coord}: "
+                f"core ({first.x},{first.y})=0x{addr0:x} vs core ({x},{y})=0x{addr:x}. "
+                f"Ensure this is the first per-core allocation on the device."
+            )
 
 
 def tilize_and_pack(data_2d: torch.Tensor, spec: OverlappedTensorSpec) -> bytes:

--- a/models/demos/deepseek_v3_b1/weights/sram_slots.py
+++ b/models/demos/deepseek_v3_b1/weights/sram_slots.py
@@ -183,8 +183,10 @@ def per_core_l1_lowest_addr_on_cores(
 
     Lockstep tensors (the common case for attention weights) report the
     same address on every core in their grid via ``buffer_address()``.
-    Per-core-allocated tensors report a distinct address per core via
-    ``experimental_per_core_buffer_address(core)``.
+    Per-core-allocated tensors report a distinct address per (device, core) via
+    ``experimental_per_core_buffer_address(device_coord, core)``.  This reads the
+    tensor's first device only, so the headroom below describes that device; it
+    assumes the address is the same on every device, and does not check.
 
     Tensors that are not on device (host-only) are silently skipped --
     address queries are only meaningful post-allocation.
@@ -217,7 +219,9 @@ def per_core_l1_lowest_addr_on_cores(
             if c_xy not in target:
                 continue
             if is_per_core:
-                addr = tt_tensor.experimental_per_core_buffer_address(ttnn.CoreCoord(c_xy[0], c_xy[1]))
+                addr = tt_tensor.experimental_per_core_buffer_address(
+                    tt_tensor.device_coords()[0], ttnn.CoreCoord(c_xy[0], c_xy[1])
+                )
             else:
                 addr = tt_tensor.buffer_address()
             prev = lowest.get(c_xy)

--- a/tests/ttnn/unit_tests/per_core_allocation/test_per_core_allocation.py
+++ b/tests/ttnn/unit_tests/per_core_allocation/test_per_core_allocation.py
@@ -15,6 +15,19 @@ import torch
 import ttnn
 
 
+def _per_core_addr(tensor, core):
+    """Per-core L1 address of ``core`` on the tensor's own device.
+
+    Per-core allocation gives a different address per (device, core), so the query needs a
+    device.  Every tensor passed here is single-device -- a plain device, or one narrowed out
+    of a mesh with ``get_device_tensors`` -- so its one coordinate is the device to ask.  The
+    unpacking enforces that: a mesh tensor raises here instead of silently reporting whichever
+    device happens to come first.
+    """
+    (coord,) = tensor.device_coords()
+    return tensor.experimental_per_core_buffer_address(coord, core)
+
+
 class PerCoreMemMap:
     """Track expected per-core allocator addresses for test validation.
 
@@ -101,8 +114,8 @@ def test_per_core_tensors_get_same_address(device):
 
     # Per-bank allocators are independent — both cores can get the same address
     # With lockstep, t1 would get a different address since t0 consumed it
-    addr0 = t0.experimental_per_core_buffer_address(core0)
-    addr1 = t1.experimental_per_core_buffer_address(core1)
+    addr0 = _per_core_addr(t0, core0)
+    addr1 = _per_core_addr(t1, core1)
     assert addr0 == addr1, f"Expected same address on different cores (per-bank allocators), got {addr0} vs {addr1}"
 
 
@@ -158,14 +171,14 @@ def test_per_core_sharded_dealloc_realloc(device):
 
     # First allocation
     t1 = ttnn.from_torch(data, dtype=ttnn.uint8, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, memory_config=mem_config)
-    addrs1 = [t1.experimental_per_core_buffer_address(c) for c in cores]
+    addrs1 = [_per_core_addr(t1, c) for c in cores]
 
     # Deallocate
     del t1
 
     # Second allocation — should reuse the same per-core space
     t2 = ttnn.from_torch(data, dtype=ttnn.uint8, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, memory_config=mem_config)
-    addrs2 = [t2.experimental_per_core_buffer_address(c) for c in cores]
+    addrs2 = [_per_core_addr(t2, c) for c in cores]
 
     assert (
         addrs1 == addrs2
@@ -215,9 +228,9 @@ def test_per_core_tetris_allocation(device):
         if action == "alloc":
             t = _create_single_core_tensor(device, cores[core_idx], size)
             if mem is None:
-                mem = PerCoreMemMap(t.experimental_per_core_buffer_address(cores[core_idx]), size)
+                mem = PerCoreMemMap(_per_core_addr(t, cores[core_idx]), size)
             mem.alloc(label, core_idx, size)
-            actual[label] = t.experimental_per_core_buffer_address(cores[core_idx])
+            actual[label] = _per_core_addr(t, cores[core_idx])
             tensors[label] = t
         elif action == "free":
             freed_addr = mem.expected[label]
@@ -274,7 +287,7 @@ def test_per_core_and_lockstep_coexist(device):
         label = f"pc_c{i}_{size}"
         t = _create_single_core_tensor(device, cores[i], size)
         tensors[label] = t
-        allocs.append((label, t.experimental_per_core_buffer_address(cores[i]), size, "per_core"))
+        allocs.append((label, _per_core_addr(t, cores[i]), size, "per_core"))
 
     # Round 2: lockstep allocations on same cores
     ls_sizes = [1024, 2048, 512, 1024]
@@ -289,7 +302,7 @@ def test_per_core_and_lockstep_coexist(device):
         label = f"pc2_c{i}_{size}"
         t = _create_single_core_tensor(device, cores[i], size)
         tensors[label] = t
-        allocs.append((label, t.experimental_per_core_buffer_address(cores[i]), size, "per_core"))
+        allocs.append((label, _per_core_addr(t, cores[i]), size, "per_core"))
 
     # Round 4: free some per-core, allocate lockstep in the freed cores
     del tensors["pc_c0_2048"]
@@ -309,7 +322,7 @@ def test_per_core_and_lockstep_coexist(device):
         label = f"pc_after_free_c{i+2}_{size}"
         t = _create_single_core_tensor(device, cores[i + 2], size)
         tensors[label] = t
-        allocs.append((label, t.experimental_per_core_buffer_address(cores[i + 2]), size, "per_core"))
+        allocs.append((label, _per_core_addr(t, cores[i + 2]), size, "per_core"))
 
     # Validate: no per-core allocation overlaps with any lockstep allocation on the same core
     # (Per-core allocs on different cores CAN share addresses — that's the point)
@@ -361,7 +374,7 @@ def test_all_cores_lockstep_then_per_core_then_reverse(device):
     # Validate: no overlaps between lockstep and per-core on same core
     for i in range(num_cores):
         ls_addr = lockstep_tensors[i].buffer_address()
-        pc_addr = per_core_tensors[i].experimental_per_core_buffer_address(cores[i])
+        pc_addr = _per_core_addr(per_core_tensors[i], cores[i])
         assert not _addr_ranges_overlap(
             ls_addr, shard_bytes, pc_addr, shard_bytes
         ), f"Phase 1 overlap on core {i}: lockstep={ls_addr:#x} per_core={pc_addr:#x}"
@@ -385,7 +398,7 @@ def test_all_cores_lockstep_then_per_core_then_reverse(device):
     # Validate: no overlaps
     for i in range(num_cores):
         ls_addr = lockstep_tensors[i].buffer_address()
-        pc_addr = per_core_tensors[i].experimental_per_core_buffer_address(cores[i])
+        pc_addr = _per_core_addr(per_core_tensors[i], cores[i])
         assert not _addr_ranges_overlap(ls_addr, shard_bytes, pc_addr, pc_sizes[i]), (
             f"Phase 2 overlap on core {i}: lockstep={ls_addr:#x}+{shard_bytes} " f"per_core={pc_addr:#x}+{pc_sizes[i]}"
         )
@@ -441,7 +454,7 @@ def test_triangle_allocation_then_uniform_sharded(device):
     # Verify: per-core addresses form an inverse triangle
     # Core at flat index 0 consumed least → highest address
     # Core at flat index N-1 consumed most → lowest address
-    addrs = [sharded_tensor.experimental_per_core_buffer_address(c) for c in cores]
+    addrs = [_per_core_addr(sharded_tensor, c) for c in cores]
     for i in range(num_cores - 1):
         assert addrs[i] > addrs[i + 1], (
             f"Expected inverse triangle: core {i} ({cores[i].x},{cores[i].y}) addr={addrs[i]:#x} "

--- a/tests/ttnn/unit_tests/per_core_allocation/test_per_core_allocation_multi_device.py
+++ b/tests/ttnn/unit_tests/per_core_allocation/test_per_core_allocation_multi_device.py
@@ -19,6 +19,19 @@ import ttnn
 # --- Helpers ---
 
 
+def _per_core_addr(tensor, core):
+    """Per-core L1 address of ``core`` on the tensor's own device.
+
+    Per-core allocation gives a different address per (device, core), so the query needs a
+    device.  Every tensor passed here is single-device -- a plain device, or one narrowed out
+    of a mesh with ``get_device_tensors`` -- so its one coordinate is the device to ask.  The
+    unpacking enforces that: a mesh tensor raises here instead of silently reporting whichever
+    device happens to come first.
+    """
+    (coord,) = tensor.device_coords()
+    return tensor.experimental_per_core_buffer_address(coord, core)
+
+
 def _create_per_core_tensor_on_mesh(
     mesh_device, core_grid, shard_shape, tensor_shape, layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED
 ):
@@ -78,7 +91,7 @@ def _assert_cross_device_consistency(tensor, cores, label=""):
     """Assert all devices have the same per-core addresses."""
     device_tensors = ttnn.get_device_tensors(tensor)
     for core in cores:
-        dev_addrs = [dt.experimental_per_core_buffer_address(core) for dt in device_tensors]
+        dev_addrs = [_per_core_addr(dt, core) for dt in device_tensors]
         assert all(a == dev_addrs[0] for a in dev_addrs), (
             f"{label}Core ({core.x},{core.y}): expected same addr across devices, "
             f"got {[f'{a:#x}' for a in dev_addrs]}"
@@ -90,7 +103,7 @@ def _assert_no_overlap_per_device(pc_tensor, pc_core, pc_size, ls_tensor, ls_siz
     pc_devs = ttnn.get_device_tensors(pc_tensor)
     ls_devs = ttnn.get_device_tensors(ls_tensor)
     for dev_idx, (pc_dt, ls_dt) in enumerate(zip(pc_devs, ls_devs)):
-        pc_addr = pc_dt.experimental_per_core_buffer_address(pc_core)
+        pc_addr = _per_core_addr(pc_dt, pc_core)
         ls_addr = ls_dt.buffer_address()
         assert not _addr_ranges_overlap(pc_addr, pc_size, ls_addr, ls_size), (
             f"{label}Device {dev_idx}: overlap per_core=[{pc_addr:#x}, +{pc_size}) vs "
@@ -109,7 +122,7 @@ def test_per_core_independent_addresses_across_devices(mesh_device):
     t1 = _create_per_core_single(mesh_device, core, shard_bytes)
 
     device_tensors = ttnn.get_device_tensors(t1)
-    addrs = [dt.experimental_per_core_buffer_address(core) for dt in device_tensors]
+    addrs = [_per_core_addr(dt, core) for dt in device_tensors]
 
     assert all(
         a == addrs[0] for a in addrs
@@ -158,7 +171,7 @@ def test_multi_core_per_core_all_cores(mesh_device):
 
     # All per-device tensors: all cores same address (fresh allocator, independent per-bank)
     for dev_idx, dt in enumerate(ttnn.get_device_tensors(t)):
-        addrs = [dt.experimental_per_core_buffer_address(c) for c in cores]
+        addrs = [_per_core_addr(dt, c) for c in cores]
         assert all(
             a == addrs[0] for a in addrs
         ), f"Device {dev_idx}: expected same address on all cores, got unique: {set(f'{a:#x}' for a in addrs)}"
@@ -281,8 +294,8 @@ def test_tetris_allocation_on_mesh(mesh_device):
                     pc_devs = ttnn.get_device_tensors(t)
                     other_devs = ttnn.get_device_tensors(tensors[other_label])
                     for dev_idx, (dt, odt) in enumerate(zip(pc_devs, other_devs)):
-                        addr = dt.experimental_per_core_buffer_address(cores[core_idx])
-                        other_addr = odt.experimental_per_core_buffer_address(cores[core_idx])
+                        addr = _per_core_addr(dt, cores[core_idx])
+                        other_addr = _per_core_addr(odt, cores[core_idx])
                         assert not _addr_ranges_overlap(addr, size, other_addr, other_size), (
                             f"Device {dev_idx}: overlap on core {core_idx}: "
                             f"{label}=[{addr:#x}, +{size}) vs {other_label}=[{other_addr:#x}, +{other_size})"
@@ -308,12 +321,16 @@ def test_dealloc_per_core_then_lockstep_reuses_space(mesh_device):
     size = 4096
 
     t_pc = _create_per_core_single(mesh_device, core, size)
-    pc_addr = t_pc.experimental_per_core_buffer_address(core)
+    # Per-core addresses are per (device, core), so read one per device off the narrowed tensors.
+    pc_addrs = [_per_core_addr(dt, core) for dt in ttnn.get_device_tensors(t_pc)]
     t_pc.deallocate(force=True)
 
     t_ls = _create_lockstep_single(mesh_device, core, size)
-    ls_addr = t_ls.buffer_address()
-    assert ls_addr == pc_addr, f"Expected lockstep to reuse freed per-core address {pc_addr:#x}, got {ls_addr:#x}"
+    ls_addr = t_ls.buffer_address()  # lockstep: one address for every device
+    for dev_idx, pc_addr in enumerate(pc_addrs):
+        assert (
+            ls_addr == pc_addr
+        ), f"Device {dev_idx}: expected lockstep to reuse freed per-core address {pc_addr:#x}, got {ls_addr:#x}"
 
 
 def test_dealloc_lockstep_then_per_core_reuses_space(mesh_device):
@@ -322,12 +339,16 @@ def test_dealloc_lockstep_then_per_core_reuses_space(mesh_device):
     size = 4096
 
     t_ls = _create_lockstep_single(mesh_device, core, size)
-    ls_addr = t_ls.buffer_address()
+    ls_addr = t_ls.buffer_address()  # lockstep: one address for every device
     t_ls.deallocate(force=True)
 
     t_pc = _create_per_core_single(mesh_device, core, size)
-    pc_addr = t_pc.experimental_per_core_buffer_address(core)
-    assert pc_addr == ls_addr, f"Expected per-core to reuse freed lockstep address {ls_addr:#x}, got {pc_addr:#x}"
+    # Per-core addresses are per (device, core), so read one per device off the narrowed tensors.
+    pc_addrs = [_per_core_addr(dt, core) for dt in ttnn.get_device_tensors(t_pc)]
+    for dev_idx, pc_addr in enumerate(pc_addrs):
+        assert (
+            pc_addr == ls_addr
+        ), f"Device {dev_idx}: expected per-core to reuse freed lockstep address {ls_addr:#x}, got {pc_addr:#x}"
 
 
 def test_multi_core_dealloc_realloc(mesh_device):
@@ -343,13 +364,13 @@ def test_multi_core_dealloc_realloc(mesh_device):
     t1 = _create_per_core_tensor_on_mesh(mesh_device, core_grid, [1, SHARD_BYTES], [num_cores, SHARD_BYTES])
     addrs1_per_dev = []
     for dt in ttnn.get_device_tensors(t1):
-        addrs1_per_dev.append([dt.experimental_per_core_buffer_address(c) for c in cores])
+        addrs1_per_dev.append([_per_core_addr(dt, c) for c in cores])
     t1.deallocate(force=True)
 
     # Second allocation — should reuse same addresses on each device
     t2 = _create_per_core_tensor_on_mesh(mesh_device, core_grid, [1, SHARD_BYTES], [num_cores, SHARD_BYTES])
     for dev_idx, dt in enumerate(ttnn.get_device_tensors(t2)):
-        addrs2 = [dt.experimental_per_core_buffer_address(c) for c in cores]
+        addrs2 = [_per_core_addr(dt, c) for c in cores]
         assert addrs1_per_dev[dev_idx] == addrs2, (
             f"Device {dev_idx}: expected same addresses after dealloc/realloc:\n"
             f"  first:  {[f'{a:#x}' for a in addrs1_per_dev[dev_idx]]}\n"
@@ -427,7 +448,7 @@ def test_triangle_per_core_then_uniform(mesh_device):
 
     # Validate inverse triangle per device
     for dev_idx, dt in enumerate(ttnn.get_device_tensors(sharded_tensor)):
-        addrs = [dt.experimental_per_core_buffer_address(c) for c in cores]
+        addrs = [_per_core_addr(dt, c) for c in cores]
         for i in range(num_cores - 1):
             assert addrs[i] > addrs[i + 1], (
                 f"Device {dev_idx}: expected inverse triangle: "
@@ -445,8 +466,8 @@ def test_triangle_per_core_then_uniform(mesh_device):
         tri_devs = ttnn.get_device_tensors(triangle_tensors[i])
         uni_devs = ttnn.get_device_tensors(sharded_tensor)
         for dev_idx, (tri_dt, uni_dt) in enumerate(zip(tri_devs, uni_devs)):
-            tri_addr = tri_dt.experimental_per_core_buffer_address(core)
-            uni_addr = uni_dt.experimental_per_core_buffer_address(core)
+            tri_addr = _per_core_addr(tri_dt, core)
+            uni_addr = _per_core_addr(uni_dt, core)
             assert not _addr_ranges_overlap(tri_addr, tri_size, uni_addr, TILE_BYTES), (
                 f"Device {dev_idx} core {i}: triangle=[{tri_addr:#x}, +{tri_size}) vs "
                 f"uniform=[{uni_addr:#x}, +{TILE_BYTES})"
@@ -516,8 +537,8 @@ def test_divergent_per_device_then_lockstep(mesh_device):
     t0 = _allocate_per_core_on_device(mesh_device, dev0_coord, core, per_device_sizes[0])
     t1 = _allocate_per_core_on_device(mesh_device, dev1_coord, core, per_device_sizes[1])
 
-    addr0 = t0.experimental_per_core_buffer_address(core)
-    addr1 = t1.experimental_per_core_buffer_address(core)
+    addr0 = _per_core_addr(t0, core)
+    addr1 = _per_core_addr(t1, core)
     logger.info(f"Device 0: per-core size={per_device_sizes[0]}, addr={addr0:#x}")
     logger.info(f"Device 1: per-core size={per_device_sizes[1]}, addr={addr1:#x}")
 
@@ -571,8 +592,8 @@ def test_divergent_multi_core_per_device_then_lockstep(mesh_device):
         t1 = _allocate_per_core_on_device(mesh_device, dev1_coord, core, dev1_sizes[core_idx])
         dev0_tensors.append(t0)
         dev1_tensors.append(t1)
-        dev0_addrs.append(t0.experimental_per_core_buffer_address(core))
-        dev1_addrs.append(t1.experimental_per_core_buffer_address(core))
+        dev0_addrs.append(_per_core_addr(t0, core))
+        dev1_addrs.append(_per_core_addr(t1, core))
 
     # Verify address differences match size differences
     for core_idx in range(num_cores):
@@ -605,3 +626,49 @@ def test_divergent_multi_core_per_device_then_lockstep(mesh_device):
             f"Device 1 core {core_idx}: overlap "
             f"per_core=[{dev1_addrs[core_idx]:#x}, +{dev1_sizes[core_idx]}) vs lockstep=[{ls_addrs[1]:#x}, +{ls_size})"
         )
+
+
+def test_per_core_address_resolves_per_device_after_skew(mesh_device):
+    """A per-core tensor whose L1 address diverges across devices must report each device's OWN
+    address — both when the device is named explicitly and when it comes from ``device_coords()``
+    on a tensor narrowed out of the mesh.
+
+    REGRESSION test. The address used to be resolved through the mesh buffer's *reference*
+    (first-local) buffer, so every device reported device 0's address, and narrowing with
+    ``get_device_tensors()[i]`` did not help: it shares the same MeshBuffer and only replaces the
+    coord list, which that path never read. The cross-device assertions elsewhere in this file
+    were therefore comparing device 0's address to itself and could not fail.
+
+    Skewing only device 1's frontier makes the two devices' addresses differ, which is what makes
+    the difference observable.
+    """
+    core = ttnn.CoreCoord(0, 0)
+    dev0 = ttnn.MeshCoordinate(0, 0)
+    dev1 = ttnn.MeshCoordinate(0, 1)
+
+    # Skew ONLY device 1: its per-bank allocator on `core` starts lower than device 0's.
+    # Held in a local so the allocation (and therefore the skew) outlives the queries below.
+    skew = _allocate_per_core_on_device(mesh_device, dev1, core, 4096)
+
+    SHARD_BYTES = 1024
+    w = _create_per_core_tensor_on_mesh(mesh_device, _single_core_grid(core), [1, SHARD_BYTES], [1, SHARD_BYTES])
+
+    # (1) The setup produced genuine per-device divergence.
+    per_device = [w.experimental_per_core_buffer_address(coord, core) for coord in (dev0, dev1)]
+    assert per_device[0] != per_device[1], (
+        f"expected divergent per-device addresses after skewing device 1; got " f"{[f'{a:#x}' for a in per_device]}"
+    )
+
+    # (2) A tensor narrowed out of the mesh names its own device via device_coords(), so it
+    #     reports that device's address rather than the reference device's.
+    narrowed = [_per_core_addr(dt, core) for dt in ttnn.get_device_tensors(w)]
+    assert narrowed == per_device, (
+        f"narrowed per-device addresses {[f'{a:#x}' for a in narrowed]} != "
+        f"per-(device, core) addresses {[f'{a:#x}' for a in per_device]} — narrowing did not "
+        f"carry the device through to the address query"
+    )
+
+    # (3) device_coords() enumerates the mesh in the same order, so it reproduces (1).
+    assert [w.experimental_per_core_buffer_address(c, core) for c in w.device_coords()] == per_device
+
+    assert skew.is_allocated()

--- a/tt_metal/api/tt-metalium/experimental/per_core_allocation/mesh_buffer.hpp
+++ b/tt_metal/api/tt-metalium/experimental/per_core_allocation/mesh_buffer.hpp
@@ -12,9 +12,10 @@
 
 namespace tt::tt_metal::experimental::per_core_allocation {
 
-DeviceAddr get_per_core_address(const distributed::MeshBuffer& mesh_buffer, const CoreCoord& core);
-
-// Multi-device per-core address: get the address for a specific core on a specific device.
+// Per-core address for a core on a specific device. A per-core-allocated MeshBuffer allocates
+// each device independently, so the address is only defined once a device is named: there is
+// deliberately no (mesh_buffer, core) overload, which could only answer for the reference
+// (first-local) device and would silently be wrong on every other one.
 DeviceAddr get_per_core_address(
     const distributed::MeshBuffer& mesh_buffer, const distributed::MeshCoordinate& device_coord, const CoreCoord& core);
 

--- a/tt_metal/impl/per_core_allocation/mesh_buffer.cpp
+++ b/tt_metal/impl/per_core_allocation/mesh_buffer.cpp
@@ -11,12 +11,6 @@
 
 namespace tt::tt_metal::experimental::per_core_allocation {
 
-DeviceAddr get_per_core_address(const distributed::MeshBuffer& mesh_buffer, const CoreCoord& core) {
-    auto* buffer = mesh_buffer.get_reference_buffer();
-    TT_FATAL(is_per_core_allocation(*buffer), "Buffer does not use per-core allocation");
-    return get_per_core_address(*buffer, core);
-}
-
 DeviceAddr get_per_core_address(
     const distributed::MeshBuffer& mesh_buffer,
     const distributed::MeshCoordinate& device_coord,

--- a/ttnn/cpp/ttnn-nanobind/pytensor.cpp
+++ b/ttnn/cpp/ttnn-nanobind/pytensor.cpp
@@ -1342,7 +1342,7 @@ void pytensor_module(nb::module_& mod) {
                     !experimental::per_core_allocation::is_per_core_allocation(
                         self.mesh_buffer().device_local_config().sharding_args),
                     "Per-core allocated tensors do not have a single address. Use "
-                    "experimental_per_core_buffer_address(core) instead.");
+                    "experimental_per_core_buffer_address(device_coord, core) instead.");
                 return self.mesh_buffer().address();
             },
             R"doc(
@@ -1356,22 +1356,50 @@ void pytensor_module(nb::module_& mod) {
 
         )doc")
         .def(
+            "device_coords",
+            [](const Tensor& self) -> std::vector<tt::tt_metal::distributed::MeshCoordinate> {
+                TT_FATAL(is_device_tensor(self), "{} doesn't support device_coords", self.storage_type());
+                const auto coords = self.device_storage().get_coords();
+                return {coords.begin(), coords.end()};
+            },
+            R"doc(
+            The mesh coordinates this tensor's storage spans.
+
+            One entry for a single-device tensor (whichever coordinate it was built at), and one
+            per device for a mesh tensor, in row-major order. Use it to name a device when
+            querying per-(device, core) state:
+
+            .. code-block:: python
+
+                addr = t.experimental_per_core_buffer_address(t.device_coords()[0], core)
+                per_dev = [t.experimental_per_core_buffer_address(c, core) for c in t.device_coords()]
+
+        )doc")
+        .def(
             "experimental_per_core_buffer_address",
-            [](const Tensor& self, const CoreCoord& core) -> uint32_t {
+            [](const Tensor& self,
+               const tt::tt_metal::distributed::MeshCoordinate& device_coord,
+               const CoreCoord& core) -> uint32_t {
                 TT_FATAL(
                     is_device_tensor(self),
                     "{} doesn't support experimental_per_core_buffer_address",
                     self.storage_type());
                 TT_FATAL(self.is_allocated(), "Tensor is not allocated.");
-                return experimental::per_core_allocation::get_per_core_address(self.mesh_buffer(), core);
+                return experimental::per_core_allocation::get_per_core_address(self.mesh_buffer(), device_coord, core);
             },
+            nb::arg("device_coord"),
             nb::arg("core"),
             R"doc(
-            Get the per-core L1 address for a specific core (experimental per-core allocation).
+            Get the per-(device, core) L1 address for a core on a specific mesh device
+            (experimental per-core allocation).
+
+            Per-core allocation gives a different address per (device, core), so this is the
+            correct query for a multi-device tensor.
 
             .. code-block:: python
 
-                address = tt_tensor.experimental_per_core_buffer_address(ttnn.CoreCoord(0, 0))
+                address = tt_tensor.experimental_per_core_buffer_address(
+                    ttnn.MeshCoordinate(0, 1), ttnn.CoreCoord(0, 0))
 
         )doc")
         .def(
@@ -1386,14 +1414,14 @@ void pytensor_module(nb::module_& mod) {
             R"doc(
             Returns True if this tensor was allocated with experimental per-core L1 allocation.
 
-            Per-core allocated tensors have a different physical address per core, so they
-            cannot be queried with ``buffer_address()``. Use this property to branch between
-            ``buffer_address()`` and ``experimental_per_core_buffer_address(core)``.
+            Per-core allocated tensors have a different physical address per (device, core), so
+            they cannot be queried with ``buffer_address()``. Use this property to branch between
+            ``buffer_address()`` and ``experimental_per_core_buffer_address(device_coord, core)``.
 
             .. code-block:: python
 
                 if tensor.is_per_core_allocated():
-                    addr = tensor.experimental_per_core_buffer_address(core)
+                    addr = tensor.experimental_per_core_buffer_address(tensor.device_coords()[0], core)
                 else:
                     addr = tensor.buffer_address()
 


### PR DESCRIPTION
### Problem

Per-core allocation gives a different L1 address per **(device, core)** — every device allocates from its own frontier (`mesh_buffer.cpp:116-129`). But the Python API let you ask for a core alone, and that form resolved the mesh buffer's *reference* (first-local) buffer, so on a multi-device tensor it silently returned device 0's address for every device.

Narrowing didn't help either. `DeviceStorage(const DeviceStorage&, coords)` shares the same `MeshBuffer` and only replaces the coord list (`storage.cpp:133`), and `get_mesh_buffer()` never reads that list — so `get_device_tensors(t)[i].experimental_per_core_buffer_address(core)` still went through `get_reference_buffer()` (`mesh_buffer.cpp:319`) and still answered for device 0.

Net effect: there was no way to obtain a correct per-core address for a mesh tensor, and no error when you got a wrong one. Existing cross-device assertions in the per-core suite were comparing device 0's address to itself and could not fail.

### Approach: remove the ambiguous form rather than guard it

The binding now offers exactly one query:

```python
addr = t.experimental_per_core_buffer_address(device_coord, core)
```

A caller cannot ask a question that has no single answer, so no guard is needed. The single-argument overload is gone.

To make that practical, `Tensor.device_coords()` is added — the coordinates a tensor's storage spans (one entry for a single-device tensor, one per device for a mesh tensor, row-major). Without it, leaf helpers that receive only a tensor would need a coordinate threaded through their callers; with it they stay self-contained:

```python
addr = t.experimental_per_core_buffer_address(t.device_coords()[0], core)
per_dev = [t.experimental_per_core_buffer_address(c, core) for c in t.device_coords()]
```

The C++ `get_per_core_address(const MeshBuffer&, CoreCoord)` overload is dropped for the same reason — a `MeshBuffer` carries no coordinate, so it could only ever pick a device for the caller. `get_per_core_address(const Buffer&, CoreCoord)` is untouched: a `Buffer` belongs to exactly one device, so there is nothing to disambiguate.

### Caller migration

| how the device is named | sites |
|---|---|
| passed explicitly, already in scope | `compressed_tensor.py:584,599` — the per-device store looked the tensor up **by coordinate** and then queried a different one by luck |
| loop over every device | `packing.py` (`assert_uniform_per_core_addresses`), and the new regression test |
| `device_coords()[0]` — one address for a whole mesh, preserving exactly what the reference buffer returned | `moe/op.py:58`, `attention_block/op.py:3500`, `sram_slots.py:221`, and a `_per_core_addr` helper backing 31 test call sites |

`grep -rn "device_coords()\[0\]"` now lists every place that assumes device-0 uniformity — previously that assumption was invisible inside the binding.

**`assert_uniform_per_core_addresses` was a real break, not a hypothetical.** Overlap buffers are built with a mesh mapper (`packing.py:193`), so the check ran on a multi-device tensor. Confirmed by direct probe against the pre-migration build:

```
PROBE mesh-2dev  (2 devices): RuntimeError: coords.size() == 1
PROBE single-dev (1 devices): NO EXCEPTION
```

It was also a check that could never see what it was looking for: uniformity was verified only on device 0, while the overlap system broadcasts one base address per device and so needs it to hold on each device independently. It now loops the tensor's devices around its core loop.

### Behaviour

Unchanged everywhere we run. "First local buffer" and `device_coords()[0]` are the same coordinate whenever every device is local — `get_reference_buffer()` iterates `buffers_` row-major and `get_all_mesh_coordinates()` enumerates row-major — which is every single-host mesh.

Two cases differ deliberately:

1. A **narrowed** tensor now reports its own device instead of device 0 — the fix.
2. A **multi-host** mesh whose (0, 0) is remote now raises (`is_local` FATAL, `mesh_buffer.cpp:24-29`) instead of silently answering for whichever device happened to be first-local.

### Tests

New `test_per_core_address_resolves_per_device_after_skew` skews only device 1's frontier, then pins that (1) the per-device addresses genuinely diverge, (2) a tensor narrowed out of the mesh reports its own device, and (3) `device_coords()` enumeration reproduces the explicit per-device addresses. Assertion (2) fails on `main`, where both entries are device 0's address.

Run on a 32-chip Blackhole Galaxy host:

| suite | result |
|---|---|
| `tests/ttnn/unit_tests/per_core_allocation` | **23 passed** |
| DeepSeek-V3 B1 per-core suite | **4 failed, 66 passed, 5 skipped** |
| `assert_uniform_per_core_addresses` probe (2-device mesh + single-device) | **both pass** (mesh case FATAL'd before this change) |

The four DeepSeek failures are **pre-existing and unrelated** — `test_hybrid_expert_multi_device_{2sram_2dram,sparse,sparse_2cores_per_bank,sparse_accum_experts}[blackhole-True]`, all asserting `Device 1 ... (SRAM) failed: 0.0`. They reproduce identically on stock `origin/main` (verified by building `0fb47949a27` and rerunning just those four), and that op resolves addresses only via `buffer_address()`, which this PR does not touch. Worth a separate look by the DeepSeek owners, since `sanity-tests.yaml` runs that suite on every push to main.

### Notes for reviewers

- **Known remaining gap, deliberately out of scope.** `DeviceStorage::get_buffer()` is `get_mesh_buffer().get_reference_buffer()` (`storage.cpp:154`), so a C++ caller doing `get_per_core_address(*tensor.device_storage().get_buffer(), core)` still gets device 0's buffer for a mesh tensor. Closing that means guarding `Buffer::address()` / the acquisition path, which fails loudly across dispatch, dynamic CBs, DFB attach and runtime-arg binding at once, and cannot land until each has a per-core path. Tracked in #51354.
- **The three `device_coords()[0]` model sites are explicit now, not correct.** They still assume the address is uniform across devices. Making them correct means asserting agreement or threading the real coordinate — a DeepSeek-side change independent of this PR.
- **CI placement.** `tests/ttnn/unit_tests/per_core_allocation` runs from `tests/pipeline_reorg/ttnn_sanity_tests.yaml` ("core ttnn unit test group") via `sanity-tests.yaml`, which triggers on push to main and by dispatch — not on pull requests. The new test runs on `wh_n300_civ2` (2 chips) and skips on the single-chip Blackhole SKUs via the `mesh_device` fixture guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=yugao/per-core-buffer-address-per-device)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:yugao/per-core-buffer-address-per-device)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=yugao/per-core-buffer-address-per-device)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:yugao/per-core-buffer-address-per-device)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=yugao/per-core-buffer-address-per-device)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:yugao/per-core-buffer-address-per-device)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=yugao/per-core-buffer-address-per-device)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:yugao/per-core-buffer-address-per-device)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=yugao/per-core-buffer-address-per-device)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:yugao/per-core-buffer-address-per-device)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=yugao/per-core-buffer-address-per-device)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:yugao/per-core-buffer-address-per-device)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=yugao/per-core-buffer-address-per-device)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:yugao/per-core-buffer-address-per-device)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=yugao/per-core-buffer-address-per-device)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:yugao/per-core-buffer-address-per-device)