### PR TITLE
MemoryConfig: include per_core_allocation in to_json, operator== and reflection attributes

### DIFF
--- a/tests/ttnn/unit_tests/per_core_allocation/test_per_core_allocation_memory_config.py
+++ b/tests/ttnn/unit_tests/per_core_allocation/test_per_core_allocation_memory_config.py
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Tests that per_core_allocation is part of a MemoryConfig's identity.
+
+The flag changes allocator semantics -- each core gets an independent L1 address instead of one
+lockstep address -- so anything that describes or compares a MemoryConfig has to see it. It used
+to be missing from to_json, operator==, and the reflection attributes, so two configs differing
+only in this flag compared equal, hashed equal, and serialized identically. Callers that key a
+cache on to_json() (e.g. tt-blaze's TensorCache) collided per-core and lockstep variants onto one
+artifact id.
+
+No device needed: MemoryConfig is a host-side value.
+"""
+
+import json
+
+import ttnn
+
+
+def _shard_spec():
+    return ttnn.ShardSpec(
+        ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))]),
+        [1, 1024],
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+
+
+def _configs():
+    """A lockstep config and an otherwise-identical per-core config."""
+    lockstep = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, _shard_spec())
+    per_core = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, _shard_spec())
+    per_core.experimental_set_per_core_allocation(True)
+    return lockstep, per_core
+
+
+def test_per_core_allocation_breaks_equality():
+    lockstep, per_core = _configs()
+    assert lockstep != per_core, "configs differing only in per_core_allocation must not compare equal"
+    assert not (lockstep == per_core)
+
+
+def test_per_core_allocation_changes_hash():
+    lockstep, per_core = _configs()
+    assert hash(lockstep) != hash(per_core), "per_core_allocation must participate in the reflected hash"
+
+
+def test_per_core_allocation_in_repr():
+    lockstep, per_core = _configs()
+    assert "per_core_allocation=1" in repr(per_core), repr(per_core)
+    assert "per_core_allocation=0" in repr(lockstep), repr(lockstep)
+
+
+def test_per_core_allocation_serialized_to_json():
+    lockstep, per_core = _configs()
+    assert json.loads(per_core.to_json())["per_core_allocation"] is True
+    assert json.loads(lockstep.to_json())["per_core_allocation"] is False
+    # The two must not serialize identically -- this is what collided cache keys.
+    assert per_core.to_json() != lockstep.to_json()
+
+
+def test_per_core_allocation_round_trips_through_json():
+    lockstep, per_core = _configs()
+    assert ttnn.MemoryConfig.from_json(per_core.to_json()) == per_core
+    assert ttnn.MemoryConfig.from_json(lockstep.to_json()) == lockstep
+    # Round-tripping a per-core config must not yield something equal to the lockstep one.
+    assert ttnn.MemoryConfig.from_json(per_core.to_json()) != lockstep
+
+
+def test_json_without_the_key_loads_as_lockstep():
+    """JSON serialized before per_core_allocation was emitted must still load, as lockstep."""
+    lockstep, per_core = _configs()
+    legacy = json.loads(per_core.to_json())
+    legacy.pop("per_core_allocation")
+    assert ttnn.MemoryConfig.from_json(json.dumps(legacy)) == lockstep

--- a/tt_metal/api/tt-metalium/experimental/tensor/spec/memory_config/memory_config.hpp
+++ b/tt_metal/api/tt-metalium/experimental/tensor/spec/memory_config/memory_config.hpp
@@ -47,12 +47,18 @@ public:
     bool is_dram() const;
 
     static constexpr auto attribute_names = std::forward_as_tuple(
-        "memory_layout", "buffer_type", "shard_spec", "nd_shard_spec", "created_with_nd_shard_spec");
+        "memory_layout",
+        "buffer_type",
+        "shard_spec",
+        "nd_shard_spec",
+        "created_with_nd_shard_spec",
+        "per_core_allocation");
     std::tuple<
         const TensorMemoryLayout&,
         const BufferType&,
         const std::optional<ShardSpec>&,
         const std::optional<NdShardSpec>&,
+        const bool&,
         const bool&>
     attribute_values() const;
 

--- a/tt_metal/impl/tensor/spec/memory_config/memory_config.cpp
+++ b/tt_metal/impl/tensor/spec/memory_config/memory_config.cpp
@@ -8,6 +8,7 @@
 
 #include <tt-metalium/experimental/tensor/tensor_types.hpp>
 #include <tt-metalium/experimental/tensor/spec/memory_config/memory_config.hpp>
+#include <tt-metalium/experimental/per_core_allocation/memory_config.hpp>
 
 #include "memory_config_impl.hpp"
 
@@ -80,6 +81,7 @@ std::tuple<
     const BufferType&,
     const std::optional<ShardSpec>&,
     const std::optional<NdShardSpec>&,
+    const bool&,
     const bool&>
 MemoryConfig::attribute_values() const {
     return std::forward_as_tuple(
@@ -87,7 +89,8 @@ MemoryConfig::attribute_values() const {
         impl().buffer_type_,
         impl().shard_spec_,
         impl().nd_shard_spec_,
-        impl().created_with_nd_shard_spec_);
+        impl().created_with_nd_shard_spec_,
+        impl().per_core_allocation_);
 }
 
 MemoryConfig MemoryConfig::create_with_prepopulated_shard_specs(
@@ -118,6 +121,13 @@ bool MemoryConfig::is_dram() const { return impl().buffer_type_ == BufferType::D
 
 bool operator==(const MemoryConfig& config_a, const MemoryConfig& config_b) {
     if (config_a.buffer_type() != config_b.buffer_type() || config_a.memory_layout() != config_b.memory_layout()) {
+        return false;
+    }
+    // per_core_allocation changes allocator semantics -- each core gets an independent L1 address
+    // instead of one lockstep address -- so two configs differing only in this flag are not
+    // interchangeable and must not compare equal.
+    if (experimental::per_core_allocation::is_per_core_allocation(config_a) !=
+        experimental::per_core_allocation::is_per_core_allocation(config_b)) {
         return false;
     }
     // Compare only the authoritative shard spec based on creation path.
@@ -158,6 +168,8 @@ nlohmann::json ttsl::json::to_json_t<tt::tt_metal::MemoryConfig>::operator()(
     json_object["memory_layout"] = config.memory_layout();
     json_object["buffer_type"] = config.buffer_type();
     json_object["created_with_nd_shard_spec"] = config.created_with_nd_shard_spec();
+    json_object["per_core_allocation"] =
+        tt::tt_metal::experimental::per_core_allocation::is_per_core_allocation(config);
     if (config.created_with_nd_shard_spec()) {
         if (config.nd_shard_spec().has_value()) {
             json_object["nd_shard_spec"] = ttsl::json::to_json(config.nd_shard_spec().value());
@@ -175,7 +187,11 @@ tt::tt_metal::MemoryConfig ttsl::json::from_json_t<tt::tt_metal::MemoryConfig>::
     auto memory_layout = json_object["memory_layout"].get<tt::tt_metal::TensorMemoryLayout>();
     auto buffer_type = json_object["buffer_type"].get<tt::tt_metal::BufferType>();
     auto created_with_nd_shard_spec = json_object["created_with_nd_shard_spec"].get<bool>();
+    // Absent in JSON written before per_core_allocation was serialized; those configs are lockstep.
+    const bool per_core_allocation = json_object.value("per_core_allocation", false);
     if (created_with_nd_shard_spec) {
+        TT_FATAL(
+            !per_core_allocation, "per_core_allocation is not supported with NdShardSpec, but JSON requested both");
         auto nd_shard_spec = ttsl::json::from_json<tt::tt_metal::NdShardSpec>(json_object["nd_shard_spec"]);
         return tt::tt_metal::MemoryConfig(buffer_type, std::move(nd_shard_spec));
     }
@@ -183,5 +199,9 @@ tt::tt_metal::MemoryConfig ttsl::json::from_json_t<tt::tt_metal::MemoryConfig>::
     if (json_object.contains("shard_spec")) {
         shard_spec = ttsl::json::from_json<tt::tt_metal::ShardSpec>(json_object["shard_spec"]);
     }
-    return tt::tt_metal::MemoryConfig(memory_layout, buffer_type, std::move(shard_spec));
+    auto memory_config = tt::tt_metal::MemoryConfig(memory_layout, buffer_type, std::move(shard_spec));
+    if (per_core_allocation) {
+        tt::tt_metal::experimental::per_core_allocation::set_per_core_allocation(memory_config, true);
+    }
+    return memory_config;
 }


### PR DESCRIPTION
Fixes tenstorrent/tt-blaze#2645.

### Problem

`MemoryConfig::per_core_allocation_` changes allocator semantics — each core gets an independent L1 address instead of one lockstep address — but it was absent from three of the places that are supposed to describe a `MemoryConfig` completely:

- `to_json_t<MemoryConfig>` / `from_json_t<MemoryConfig>`
- `attribute_names` / `attribute_values` (so `__hash__`, `operator<<` and every reflection-derived consumer)
- `operator==`

Meanwhile the flatbuffer path *does* round-trip it (`tensor_spec.fbs`, `tensor_spec_flatbuffer.cpp:253,271`), so serialization and description disagreed about what a `MemoryConfig` is.

Consequence: two configs differing only in this flag compared equal, hashed equal, and serialized identically. Concretely it collides cache keys — tt-blaze's `TensorCache` fingerprints a target on `json.loads(memory_config.to_json())`, so per-core and lockstep variants of the same target share an `artifact_id` and whichever was written first wins.

### Changes

- `per_core_allocation` added to `attribute_names` / `attribute_values`, to `operator==`, and to `to_json` / `from_json`.
- `from_json` defaults the flag to `false` when the key is absent, so JSON serialized before this change still loads (as lockstep, which is what it was).
- `from_json` rejects the impossible per-core + `NdShardSpec` combination rather than silently dropping the flag. That state can only arrive from hand-edited or corrupted JSON, since `to_json` cannot emit it and `set_per_core_allocation` forbids it.

### Consequences for callers

- The `MemoryConfig` repr gains a `per_core_allocation` field. It is reflection-derived, so both `__repr__` and `operator<<` change.
- Artifact ids derived from `to_json` change, which implies a **one-time cache invalidation**. The issue anticipates this.

### Tests

New host-only `test_per_core_allocation_memory_config.py` (6 tests, no device required) covers equality, hash, repr, json emission, json round-trip, and that json written without the key still loads as lockstep. All 6 pass; 5 of them fail on `main`.

Also checked that nothing else depended on the old repr. The only other place a full `MemoryConfig(...)` string appears in tests is `TestLinearModelImport::MOCK_LINEAR_GRAPH` in `test_graph_report.py`, and that is *input* to `_make_report(...)`, not an expected value — verified by running that class unchanged: 9 passed. So no goldens move in this PR.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=yugao/memory-config-per-core-allocation)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:yugao/memory-config-per-core-allocation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=yugao/memory-config-per-core-allocation)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:yugao/memory-config-per-core-allocation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=yugao/memory-config-per-core-allocation)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:yugao/memory-config-per-core-allocation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=yugao/memory-config-per-core-allocation)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:yugao/memory-config-per-core-allocation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=yugao/memory-config-per-core-allocation)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:yugao/memory-config-per-core-allocation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=yugao/memory-config-per-core-allocation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:yugao/memory-config-per-core-allocation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=yugao/memory-config-per-core-allocation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:yugao/memory-config-per-core-allocation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=yugao/memory-config-per-core-allocation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:yugao/memory-config-per-core-allocation)