### PR TITLE
emule: resolve mcast semaphore increments only to worker cores

### DIFF
--- a/tt_metal/impl/emulation/emulated_program_runner.cpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.cpp
@@ -387,6 +387,24 @@ extern "C" bool __emule_noc_addr_is_dram(uint64_t noc_addr) {
     return false;
 }
 
+// True only when (noc_x,noc_y) maps to a WORKER core in this chip's core_map.
+// Used by the mcast semaphore walk to tell an *expected grid gap* (an ARC/DRAM/eth
+// node with no worker NIU — false here) from a *genuine* worker-resolve miss.
+// On the unharvested BH grid the worker columns are non-contiguous (ARC=x8,
+// DRAM=x9), so a full-grid mcast bbox legitimately straddles non-worker nodes;
+// silicon simply has no worker semaphore there. Mirrors __emule_noc_addr_is_dram.
+extern "C" bool __emule_noc_addr_is_worker(uint64_t noc_addr) {
+    emule_require_self(__func__);
+    if (!__emule_self->core_map) {
+        return false;
+    }
+    uint32_t noc_x = (noc_addr >> NOC_LOCAL_BITS) & NOC_NODE_MASK;
+    uint32_t noc_y = (noc_addr >> (NOC_LOCAL_BITS + NOC_NODE_ID_BITS)) & NOC_NODE_MASK;
+    uint64_t key = (uint64_t(noc_x) << 32) | noc_y;
+    auto it = __emule_self->core_map->find(key);
+    return it != __emule_self->core_map->end() && it->second->role() == tt_emule::CoreRole::WORKER;
+}
+
 // Resolve multicast: iterate over rectangle of cores and memcpy to each.
 // Real firmware encoding: x_start [53:48], y_start [59:54], x_end [41:36], y_end [47:42], addr [35:0]
 //


### PR DESCRIPTION
Companion to `tenstorrent/tt-emule-blaze#152` (socket bring-up `#114`). Runtime side of the emule multicast-semaphore worker-core fix.

## What
Adds `__emule_noc_addr_is_worker(noc_addr)` — mirrors `__emule_noc_addr_is_dram`, resolving `(noc_x, noc_y)` through the chip `core_map` and returning true only for `CoreRole::WORKER`. The emule mcast semaphore walk (which lives in tt-emule-blaze `jit_hw/api/dataflow/dataflow_api.h`) uses it to increment a bounding-box coord only when it maps to a worker core.

## Why
On the unharvested Blackhole grid a full-grid multicast bounding box straddles the ARC (x=8) and DRAM (x=9) columns. Without the predicate the walk warned per phantom ARC coord and applied a spurious increment to the DRAM column — benign to results (`num_dests` is exact; every worker resolves) but noisy and able to mask a real resolve miss.

## Pin linkage
This branch = the `arminale/sockets-102-103` tip + this one commit; `tenstorrent/tt-emule-blaze`'s `tt-metal-pin.txt` pins it. Land together with tt-emule-blaze#152.

Validated on the prior campaign pin (kimi socket test runs end-to-end — no crash, no deadlock; MLA PCC 0.9915). Rebased cleanly onto the current `arminale/sockets-102-103` tip.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=xchin/emule-mcast-worker-predicate)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:xchin/emule-mcast-worker-predicate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=xchin/emule-mcast-worker-predicate)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:xchin/emule-mcast-worker-predicate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=xchin/emule-mcast-worker-predicate)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:xchin/emule-mcast-worker-predicate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=xchin/emule-mcast-worker-predicate)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:xchin/emule-mcast-worker-predicate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=xchin/emule-mcast-worker-predicate)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:xchin/emule-mcast-worker-predicate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=xchin/emule-mcast-worker-predicate)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:xchin/emule-mcast-worker-predicate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=xchin/emule-mcast-worker-predicate)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:xchin/emule-mcast-worker-predicate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=xchin/emule-mcast-worker-predicate)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:xchin/emule-mcast-worker-predicate)