### PR TITLE
[kernel-sync] repeat_interleave: sync codegen kernels to origin/device-2.0-kernel-port-301@74af2c55e

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/repeat_interleave/codegen/kernels/reader_repeat_interleave_lastdim_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat_interleave/codegen/kernels/reader_repeat_interleave_lastdim_rm.cpp
@@ -25,6 +25,9 @@
 //     TensorAccessorArgs(in_t), cb_id, BATCH
 // RT: src_addr, num_out_pages, out_start_page   (src_page == out_page)
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/core_local_mem.h"
 
 void kernel_main() {
     uint32_t src_addr = get_arg_val<uint32_t>(0);
@@ -47,30 +50,37 @@ void kernel_main() {
 
     const auto s = TensorAccessor(src_args, src_addr, input_page_size);
 
+    Noc noc;
+    CircularBuffer cb_in(cb_id);
+
     uint32_t page = out_start_page;
     uint32_t pages_left = num_out_pages;
 
     while (pages_left > 0) {
         uint32_t batch = (pages_left < BATCH) ? pages_left : BATCH;
-        cb_reserve_back(cb_id, batch);
-        uint32_t l1 = get_write_ptr(cb_id);
+        cb_in.reserve_back(batch);
+        // Absolute L1 base is still needed: the staging address is alignment-
+        // rounded off the slot address, and the in-place expansion below walks
+        // raw L1. CB-relative NoC offsets are derived as (stage - l1).
+        uint32_t l1 = cb_in.get_write_ptr();
 
         // Read all sticks in the batch into the tail of their slots first.
         uint32_t rd = l1;
         for (uint32_t t = 0; t < batch; t++) {
             uint32_t stage = (rd + src_min_off + input_alignment - 1) & ~(input_alignment - 1);
-            noc_async_read(s.get_noc_addr(page + t), stage, in_read_size);
+            noc.async_read(
+                s, cb_in, in_read_size, {.page_id = page + t, .offset_bytes = 0}, {.offset_bytes = stage - l1});
             rd += l1_slot_stride;
         }
-        noc_async_read_barrier();
+        noc.async_read_barrier();
 
         // Expand each stick front-to-back, in place.
         uint32_t slot = l1;
         for (uint32_t t = 0; t < batch; t++) {
             if constexpr (ELEM_SIZE == 2) {
-                volatile tt_l1_ptr uint16_t* b = (volatile tt_l1_ptr uint16_t*)slot;
+                CoreLocalMem<volatile uint16_t> b(slot);
                 uint32_t stage = (slot + src_min_off + input_alignment - 1) & ~(input_alignment - 1);
-                volatile tt_l1_ptr uint16_t* src = (volatile tt_l1_ptr uint16_t*)stage;
+                CoreLocalMem<volatile uint16_t> src(stage);
                 uint32_t o = 0;
                 for (uint32_t i = 0; i < W_in; i++) {
                     uint16_t v = src[i];
@@ -79,9 +89,9 @@ void kernel_main() {
                     }
                 }
             } else {  // ELEM_SIZE == 4
-                volatile tt_l1_ptr uint32_t* b = (volatile tt_l1_ptr uint32_t*)slot;
+                CoreLocalMem<volatile uint32_t> b(slot);
                 uint32_t stage = (slot + src_min_off + input_alignment - 1) & ~(input_alignment - 1);
-                volatile tt_l1_ptr uint32_t* src = (volatile tt_l1_ptr uint32_t*)stage;
+                CoreLocalMem<volatile uint32_t> src(stage);
                 uint32_t o = 0;
                 for (uint32_t i = 0; i < W_in; i++) {
                     uint32_t v = src[i];
@@ -93,7 +103,7 @@ void kernel_main() {
             slot += l1_slot_stride;
         }
 
-        cb_push_back(cb_id, batch);
+        cb_in.push_back(batch);
         page += batch;
         pages_left -= batch;
     }

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat_interleave/codegen/kernels/reader_repeat_interleave_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat_interleave/codegen/kernels/reader_repeat_interleave_rm.cpp
@@ -25,6 +25,8 @@
 //          cb_id, NUM_REPEATS, LOWER_PAGES, REP_DIM_PAGES, BATCH
 // RT args: src_addr, num_out_pages, out_start_page
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
 
 void kernel_main() {
     uint32_t src_addr = get_arg_val<uint32_t>(0);
@@ -43,6 +45,9 @@ void kernel_main() {
 
     const auto s = TensorAccessor(src_args, src_addr, input_page_size);
 
+    Noc noc;
+    CircularBuffer cb_in(cb_id);
+
     constexpr uint32_t SRC_LOWER = REP_DIM_PAGES * LOWER_PAGES;
     constexpr uint32_t DST_LOWER = NUM_REPEATS * SRC_LOWER;
 
@@ -51,8 +56,8 @@ void kernel_main() {
 
     while (pages_left > 0) {
         uint32_t batch = (pages_left < BATCH) ? pages_left : BATCH;
-        cb_reserve_back(cb_id, batch);
-        uint32_t l1_addr = get_write_ptr(cb_id);
+        cb_in.reserve_back(batch);
+        uint32_t l1_offset = 0;
 
         for (uint32_t t = 0; t < batch; t++) {
             uint32_t block = out_page / DST_LOWER;
@@ -62,13 +67,12 @@ void kernel_main() {
             uint32_t in_rep = out_rep / NUM_REPEATS;
             uint32_t src_page = block * SRC_LOWER + in_rep * LOWER_PAGES + lo;
 
-            uint64_t noc_addr = s.get_noc_addr(src_page);
-            noc_async_read(noc_addr, l1_addr, stick_size);
-            l1_addr += l1_slot_stride;
+            noc.async_read(s, cb_in, stick_size, {.page_id = src_page, .offset_bytes = 0}, {.offset_bytes = l1_offset});
+            l1_offset += l1_slot_stride;
             out_page++;
         }
-        noc_async_read_barrier();
-        cb_push_back(cb_id, batch);
+        noc.async_read_barrier();
+        cb_in.push_back(batch);
         pages_left -= batch;
     }
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat_interleave/codegen/kernels/reader_tile_interleaved_unified.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat_interleave/codegen/kernels/reader_tile_interleaved_unified.cpp
@@ -19,6 +19,11 @@
 //   [2] start_id    — starting page ID (meaning varies by sequencer)
 //   [3..] sequencer-specific params (see SeqArgs structs in sequencers.h)
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/endpoints.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
 #include "sequencers.h"
 
 // A caller may supply an authoritative source-pitch override via the named CT
@@ -101,7 +106,8 @@ struct ArgsConcat : ArgsBase {
 
 // ── Transport loop (written ONCE) ───────────────────────────────────
 // For simple sequencers (identity, repeat, slice, permute, transpose_wh):
-//   each page = bounded noc_async_read(accessor.get_noc_addr(next_page), l1)
+//   each page = bounded noc.async_read(accessor, cb, source_read_size,
+//                                      {.page_id = next_page}, {.offset_bytes})
 // PAD and CONCAT have different loop bodies (conditional reads / 2 accessors).
 
 template <typename Accessor, typename State, typename NextFn>
@@ -114,18 +120,26 @@ FORCE_INLINE void read_pages(
     uint32_t num_pages,
     State& state,
     NextFn next_fn) {
+    Noc noc;
+    CircularBuffer cb(cb_id);
+
     uint32_t pages_left = num_pages;
     while (pages_left > 0) {
         uint32_t batch = (pages_left < BATCH) ? pages_left : BATCH;
-        cb_reserve_back(cb_id, batch);
-        uint32_t l1_addr = get_write_ptr(cb_id);
+        cb.reserve_back(batch);
+        uint32_t l1_offset = 0;
         for (uint32_t t = 0; t < batch; t++) {
             const uint32_t source_page = next_fn(state);
-            noc_async_read(accessor.get_noc_addr(source_page), l1_addr, source_read_size);
-            l1_addr += cb_page_size;
+            noc.async_read(
+                accessor,
+                cb,
+                source_read_size,
+                {.page_id = source_page, .offset_bytes = 0},
+                {.offset_bytes = l1_offset});
+            l1_offset += cb_page_size;
         }
-        noc_async_read_barrier();
-        cb_push_back(cb_id, batch);
+        noc.async_read_barrier();
+        cb.push_back(batch);
         pages_left -= batch;
     }
 }
@@ -210,14 +224,21 @@ void kernel_main() {
     else if constexpr (SEQ_ID == SEQ_PAD) {
         const auto* a = reinterpret_cast<const ArgsPad*>(get_arg_addr(0));
 
+        Noc noc;
+        CircularBuffer cb(cb_id);
+        CircularBuffer cb_pad(a->cb_pad);
+
         // Fill pad tile in scratch CB
         {
-            volatile tt_l1_ptr uint32_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(a->cb_pad));
+            CoreLocalMem<volatile uint32_t> ptr(cb_pad.get_write_ptr());
             for (uint32_t i = 0; i < a->tile_bytes / 4; ++i) {
                 ptr[i] = a->packed_pad_val;
             }
         }
-        uint64_t pad_noc_addr = get_noc_addr(get_read_ptr(a->cb_pad));
+        const uint32_t pad_l1 = cb_pad.get_read_ptr();
+        UnicastEndpoint self_ep;
+        const uint32_t my_noc_x = my_x[noc.get_noc_id()];
+        const uint32_t my_noc_y = my_y[noc.get_noc_id()];
 
         auto st = seq_pad_init(
             a->start_id,
@@ -241,19 +262,25 @@ void kernel_main() {
         uint32_t pages_left = a->num_pages;
         while (pages_left > 0) {
             uint32_t batch = (pages_left < BATCH) ? pages_left : BATCH;
-            cb_reserve_back(cb_id, batch);
-            uint32_t l1_addr = get_write_ptr(cb_id);
+            cb.reserve_back(batch);
+            uint32_t l1_offset = 0;
             for (uint32_t t = 0; t < batch; t++) {
                 uint32_t src_page = seq_pad_next(st);
                 if (st.is_data) {
-                    noc_async_read(s.get_noc_addr(src_page), l1_addr, source_read_size);
+                    noc.async_read(
+                        s, cb, source_read_size, {.page_id = src_page, .offset_bytes = 0}, {.offset_bytes = l1_offset});
                 } else {
-                    noc_async_read(pad_noc_addr, l1_addr, a->tile_bytes);
+                    noc.async_read(
+                        self_ep,
+                        cb,
+                        a->tile_bytes,
+                        {.noc_x = my_noc_x, .noc_y = my_noc_y, .addr = pad_l1},
+                        {.offset_bytes = l1_offset});
                 }
-                l1_addr += cb_page_size;
+                l1_offset += cb_page_size;
             }
-            noc_async_read_barrier();
-            cb_push_back(cb_id, batch);
+            noc.async_read_barrier();
+            cb.push_back(batch);
             pages_left -= batch;
         }
     }
@@ -264,25 +291,34 @@ void kernel_main() {
         const auto* a = reinterpret_cast<const ArgsConcat*>(get_arg_addr(0));
         const auto s1 = TensorAccessor(src_args, a->src_addr_1, source_page_size);
 
+        Noc noc;
+        CircularBuffer cb(cb_id);
+
         auto st = seq_concat_init(a->start_tensor, a->start_tensor_id, a->page_id_0, a->page_id_1, a->ppb_0, a->ppb_1);
 
         uint32_t pages_left = a->num_pages;
         while (pages_left > 0) {
             uint32_t batch = (pages_left < BATCH) ? pages_left : BATCH;
-            cb_reserve_back(cb_id, batch);
-            uint32_t l1_addr = get_write_ptr(cb_id);
+            cb.reserve_back(batch);
+            uint32_t l1_offset = 0;
             for (uint32_t t = 0; t < batch; t++) {
                 uint32_t read_tensor = st.curr_tensor;
                 uint32_t src_page = seq_concat_next(st);
                 if (read_tensor == 0) {
-                    noc_async_read(s.get_noc_addr(src_page), l1_addr, source_read_size);
+                    noc.async_read(
+                        s, cb, source_read_size, {.page_id = src_page, .offset_bytes = 0}, {.offset_bytes = l1_offset});
                 } else {
-                    noc_async_read(s1.get_noc_addr(src_page), l1_addr, source_read_size);
+                    noc.async_read(
+                        s1,
+                        cb,
+                        source_read_size,
+                        {.page_id = src_page, .offset_bytes = 0},
+                        {.offset_bytes = l1_offset});
                 }
-                l1_addr += cb_page_size;
+                l1_offset += cb_page_size;
             }
-            noc_async_read_barrier();
-            cb_push_back(cb_id, batch);
+            noc.async_read_barrier();
+            cb.push_back(batch);
             pages_left -= batch;
         }
     }

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat_interleave/codegen/kernels/writer_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat_interleave/codegen/kernels/writer_interleaved.cpp
@@ -7,6 +7,9 @@
 // When BATCH > 1: pipelined — overlaps NOC DMA of batch N with compute
 // delivering batch N+1. Requires cb_out depth >= 2 * BATCH.
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc.h"
+#include "api/tensor/noc_traits.h"
 
 void kernel_main() {
     uint32_t dst_addr = get_arg_val<uint32_t>(0);
@@ -41,6 +44,9 @@ void kernel_main() {
         REQUESTED_WRITE_SIZE < destination_page_size ? REQUESTED_WRITE_SIZE : destination_page_size;
     const uint32_t write_size = write_size_dst < l1_page_stride ? write_size_dst : l1_page_stride;
 
+    Noc noc;
+    CircularBuffer cb(cb_out);
+
     uint32_t tile_id = start_id;
 
     if constexpr (BATCH > 1) {
@@ -52,11 +58,12 @@ void kernel_main() {
 
         // Prime the pipeline: issue first batch without prior flush
         uint32_t batch = (tiles_left < BATCH) ? tiles_left : BATCH;
-        cb_wait_front(cb_out, batch);
-        uint32_t l1_addr = get_read_ptr(cb_out);
+        cb.wait_front(batch);
+        uint32_t l1_read_offset = 0;
         for (uint32_t t = 0; t < batch; t++) {
-            noc_async_write_page(tile_id++, d, l1_addr, write_size);
-            l1_addr += l1_page_stride;
+            noc.async_write(
+                cb, d, write_size, {.offset_bytes = l1_read_offset}, {.page_id = tile_id++, .offset_bytes = 0});
+            l1_read_offset += l1_page_stride;
         }
         tiles_left -= batch;
         uint32_t prev_batch = batch;
@@ -66,29 +73,30 @@ void kernel_main() {
         // been popped yet and are still counted as "available" by cb_wait_front.
         while (tiles_left > 0) {
             batch = (tiles_left < BATCH) ? tiles_left : BATCH;
-            cb_wait_front(cb_out, prev_batch + batch);  // wait for NEW batch to arrive
-            noc_async_writes_flushed();                 // flush prev (NOC drained during wait)
-            cb_pop_front(cb_out, prev_batch);           // reclaim prev batch space
+            cb.wait_front(prev_batch + batch);  // wait for NEW batch to arrive
+            noc.async_writes_flushed();         // flush prev (NOC drained during wait)
+            cb.pop_front(prev_batch);           // reclaim prev batch space
 
-            l1_addr = get_read_ptr(cb_out);
+            l1_read_offset = 0;
             for (uint32_t t = 0; t < batch; t++) {
-                noc_async_write_page(tile_id++, d, l1_addr, write_size);
-                l1_addr += l1_page_stride;
+                noc.async_write(
+                    cb, d, write_size, {.offset_bytes = l1_read_offset}, {.page_id = tile_id++, .offset_bytes = 0});
+                l1_read_offset += l1_page_stride;
             }
             tiles_left -= batch;
             prev_batch = batch;
         }
 
         // Drain final batch
-        noc_async_writes_flushed();
-        cb_pop_front(cb_out, prev_batch);
+        noc.async_writes_flushed();
+        cb.pop_front(prev_batch);
     } else {
         for (uint32_t i = 0; i < num_tiles; i++) {
-            cb_wait_front(cb_out, 1);
-            noc_async_write_page(tile_id++, d, get_read_ptr(cb_out), write_size);
-            noc_async_writes_flushed();
-            cb_pop_front(cb_out, 1);
+            cb.wait_front(1);
+            noc.async_write(cb, d, write_size, {.offset_bytes = 0}, {.page_id = tile_id++, .offset_bytes = 0});
+            noc.async_writes_flushed();
+            cb.pop_front(1);
         }
     }
-    noc_async_write_barrier();
+    noc.async_write_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat_interleave/codegen/kernels/writer_repeat_interleave_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat_interleave/codegen/kernels/writer_repeat_interleave_rm.cpp
@@ -9,6 +9,8 @@
 //          TensorAccessorArgs(out_t), BATCH
 // RT args: dst_addr, num_pages, start_id
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
 
 void kernel_main() {
     uint32_t dst_addr = get_arg_val<uint32_t>(0);
@@ -24,6 +26,9 @@ void kernel_main() {
 
     const auto d = TensorAccessor(dst_args, dst_addr, aligned_page_size);
 
+    Noc noc;
+    CircularBuffer cb(cb_out);
+
     uint32_t page_id = start_id;
 
     if constexpr (BATCH > 1) {
@@ -31,11 +36,11 @@ void kernel_main() {
 
         // Prime the pipeline
         uint32_t batch = (pages_left < BATCH) ? pages_left : BATCH;
-        cb_wait_front(cb_out, batch);
-        uint32_t l1_addr = get_read_ptr(cb_out);
+        cb.wait_front(batch);
+        uint32_t l1_offset = 0;
         for (uint32_t t = 0; t < batch; t++) {
-            noc_async_write_page(page_id++, d, l1_addr, stick_size);
-            l1_addr += l1_slot_stride;
+            noc.async_write(cb, d, stick_size, {.offset_bytes = l1_offset}, {.page_id = page_id++, .offset_bytes = 0});
+            l1_offset += l1_slot_stride;
         }
         pages_left -= batch;
         uint32_t prev_batch = batch;
@@ -43,29 +48,30 @@ void kernel_main() {
         // Steady state
         while (pages_left > 0) {
             batch = (pages_left < BATCH) ? pages_left : BATCH;
-            cb_wait_front(cb_out, prev_batch + batch);
-            noc_async_write_barrier();
-            cb_pop_front(cb_out, prev_batch);
+            cb.wait_front(prev_batch + batch);
+            noc.async_write_barrier();
+            cb.pop_front(prev_batch);
 
-            l1_addr = get_read_ptr(cb_out);
+            l1_offset = 0;
             for (uint32_t t = 0; t < batch; t++) {
-                noc_async_write_page(page_id++, d, l1_addr, stick_size);
-                l1_addr += l1_slot_stride;
+                noc.async_write(
+                    cb, d, stick_size, {.offset_bytes = l1_offset}, {.page_id = page_id++, .offset_bytes = 0});
+                l1_offset += l1_slot_stride;
             }
             pages_left -= batch;
             prev_batch = batch;
         }
 
         // Drain
-        noc_async_write_barrier();
-        cb_pop_front(cb_out, prev_batch);
+        noc.async_write_barrier();
+        cb.pop_front(prev_batch);
     } else {
         for (uint32_t i = 0; i < num_pages; i++) {
-            cb_wait_front(cb_out, 1);
-            noc_async_write_page(page_id++, d, get_read_ptr(cb_out), stick_size);
-            noc_async_write_barrier();
-            cb_pop_front(cb_out, 1);
+            cb.wait_front(1);
+            noc.async_write(cb, d, stick_size, {.offset_bytes = 0}, {.page_id = page_id++, .offset_bytes = 0});
+            noc.async_write_barrier();
+            cb.pop_front(1);
         }
     }
-    noc_async_write_barrier();
+    noc.async_write_barrier();
 }


### PR DESCRIPTION
## kernel sync — `repeat_interleave`

- codegen ref: `origin/device-2.0-kernel-port-301@74af2c55e`
- tt-metal ref: `origin/port/repeat_interleave-fp32native-fix-20260722T073419Z@75608bb48`
- kernels: 6 listed · 6 changed · 0 unchanged · 0 formatting-only · 0 new · 0 missing upstream

| kernel | status | drift | +/- |
|---|---|---|---:|
| `reader_tile_interleaved_unified.cpp` | changed | device-2.0 (11h) | +85/-61 |
| `writer_interleaved.cpp` | changed | device-2.0 (5h) | +34/-21 |
| `sequencers.h` | changed | other-drift (2h) | +93/-78 |
| `reader_repeat_interleave_rm.cpp` | changed | device-2.0 (4h) | +12/-7 |
| `reader_repeat_interleave_lastdim_rm.cpp` | changed | device-2.0 (7h), other-drift (1h) | +27/-18 |
| `writer_repeat_interleave_rm.cpp` | changed | device-2.0 (5h) | +27/-17 |

**Drift is not all one thing.** A ref branched off a moved `main` carries both.
- Device 2.0 *and* unrelated drift: `reader_repeat_interleave_lastdim_rm.cpp`
- unrelated drift only (no Device 2.0 content): `sequencers.h`

### Attribution against `eb000b31d`

`from ref` is what the named ref contributes on its own; `pre-existing` means codegen `main` moved under this port independently. The two are inseparable in the diff above wherever they rewrite the same lines.

| kernel | from ref | pre-existing drift |
|---|---|---|
| `reader_tile_interleaved_unified.cpp` | device-2.0 (11h) | no |
| `writer_interleaved.cpp` | device-2.0 (5h) | no |
| `sequencers.h` | other-drift | yes |
| `reader_repeat_interleave_rm.cpp` | device-2.0 (4h) | no |
| `reader_repeat_interleave_lastdim_rm.cpp` | device-2.0 (7h) | yes |
| `writer_repeat_interleave_rm.cpp` | device-2.0 (5h) | no |

**Templates present upstream but absent from the manifest's `kernel_paths`** — not synced:
- `reader_repeat_interleave_bf8_h_tile.cpp`
- `reader_repeat_interleave_bf8_w_tile.cpp`
- `writer_repeat_interleave_bf8_h_tile.cpp`
- `writer_repeat_interleave_bf8_w_tile.cpp`

**Not verified.** This is a byte-level template sync: no build, no PCC, no device sweep. Numerics are settled by a sweep, not by this diff.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sync/repeat_interleave-device2-20260729)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sync/repeat_interleave-device2-20260729)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=sync/repeat_interleave-device2-20260729)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:sync/repeat_interleave-device2-20260729)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=sync/repeat_interleave-device2-20260729)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:sync/repeat_interleave-device2-20260729)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sync/repeat_interleave-device2-20260729)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sync/repeat_interleave-device2-20260729)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=sync/repeat_interleave-device2-20260729)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:sync/repeat_interleave-device2-20260729)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=sync/repeat_interleave-device2-20260729)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:sync/repeat_interleave-device2-20260729)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sync/repeat_interleave-device2-20260729)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sync/repeat_interleave-device2-20260729)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=sync/repeat_interleave-device2-20260729)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:sync/repeat_interleave-device2-20260729)