### PR TITLE
[skip ci] Improve deployment/test_runner.sh configs and test flow

### DIFF
--- a/tests/tt_metal/tt_metal/deployment/eth/test_runner.py
+++ b/tests/tt_metal/tt_metal/deployment/eth/test_runner.py
@@ -832,7 +832,7 @@ async def main():
         args = [f"--gtest_filter={filters}"]
 
         env = os.environ.copy()
-        env["ETH_TEST_EXPECTED_LINKS"] = str(10)
+        env["ETH_TEST_EXPECTED_LINKS"] = os.environ.get("ETH_TEST_EXPECTED_LINKS", str(10))
         if not opts.v:
             env["TT_LOGGER_TYPES"] = "Test"
 

--- a/tests/tt_metal/tt_metal/deployment/test_runner.sh
+++ b/tests/tt_metal/tt_metal/deployment/test_runner.sh
@@ -20,9 +20,9 @@ Everything printed to the console is also written to a single log file per run.
 Optional:
     -l <logdir>                             Directory where the log file is written
                                             (default: current directory)
-    --deployment                            Run $DEPLOYMENT_CYCLES deployment cycles with a board reset
-                                            between each. Stops before starting a new cycle
-                                            if the previous one failed. Forces ITERS=1.
+    --deployment                            Run $DEPLOYMENT_CYCLES deployment cycles, each starting with a
+                                            board reset. Stops after a cycle fails.
+                                            Forces ITERS=1.
     --continue-on-failure                   Run all $DEPLOYMENT_CYCLES cycles even if a cycle fails
                                             (implies --deployment)
     --no-eth-links                          Do not require a specific number of Ethernet links per
@@ -219,9 +219,26 @@ run_tests() {
 	return 0
 }
 
+RESET_CMD="tt-smi -glx_reset"
+
 if [ "$DEPLOYMENT" -eq 1 ]
 then
 	ITERS=1
+	MODE="deployment ($DEPLOYMENT_CYCLES cycles, $RESET_CMD before each)"
+else
+	MODE="single pass ($ITERS iterations per test)"
+fi
+
+emit_banner "DEPLOYMENT TEST RUN"
+emit "$(printf '%-12s %s' 'Date:' "$(date)")"
+emit "$(printf '%-12s %s' 'Host:' "$(hostname)")"
+emit "$(printf '%-12s %s' 'Tests:' 'Ethernet, DRAM, PCIe read, PCIe write')"
+emit "$(printf '%-12s %s' 'Mode:' "$MODE")"
+emit "$(printf '%-12s %s' 'Run log:' "$RUN_LOG")"
+emit "$RULE_HEAVY"
+
+if [ "$DEPLOYMENT" -eq 1 ]
+then
 	deployment_failures=0
 	cycles_run=0
 	depl_eth_pass=0
@@ -229,13 +246,10 @@ then
 	depl_pcie_read_pass=0
 	depl_pcie_write_pass=0
 
-	RESET_CMD="tt-smi -glx_reset"
-	emit "Run log: $RUN_LOG"
-	run_reset "Resetting boards before deployment ($RESET_CMD)..."
-
 	for cycle in $(seq 1 "$DEPLOYMENT_CYCLES")
 	do
 		emit_banner "DEPLOYMENT CYCLE $cycle/$DEPLOYMENT_CYCLES"
+		run_reset "Resetting boards ($RESET_CMD)..."
 		if run_tests
 		then
 			emit_banner "CYCLE $cycle PASSED"
@@ -248,14 +262,10 @@ then
 		depl_dram_pass=$((depl_dram_pass + last_dram_ok))
 		depl_pcie_read_pass=$((depl_pcie_read_pass + last_pcie_read_ok))
 		depl_pcie_write_pass=$((depl_pcie_write_pass + last_pcie_write_ok))
-		if [ "$cycle" -lt "$DEPLOYMENT_CYCLES" ]
+		if [ "$CONTINUE_ON_FAILURE" -eq 0 ] && [ "$deployment_failures" -gt 0 ]
 		then
-			run_reset "Resetting boards ($RESET_CMD)..."
-			if [ "$CONTINUE_ON_FAILURE" -eq 0 ] && [ "$deployment_failures" -gt 0 ]
-			then
-				emit "Stopping: cycle $cycle failed."
-				break
-			fi
+			emit "Stopping: cycle $cycle failed."
+			break
 		fi
 	done
 
@@ -278,5 +288,4 @@ then
 	exit 0
 fi
 
-emit "Run log: $RUN_LOG"
 run_tests

--- a/tests/tt_metal/tt_metal/deployment/test_runner.sh
+++ b/tests/tt_metal/tt_metal/deployment/test_runner.sh
@@ -3,13 +3,19 @@
 set -e
 
 LOGDIR="."
-LOGFILE="deployment_$(hostname)_$(date +%4Y-%m-%d-%H-%M-%S).log"
 ITERS="${ITERS:-5}"
 PYTHON="$(command -v python3 || command -v python)"
+DEPLOYMENT=0
+DEPLOYMENT_CYCLES=5
+CONTINUE_ON_FAILURE=0
 
 usage() {
-	echo "Usage: $0 [-l logdir]"
-	echo "	-l <logdir>		The directory where to save the log file"
+	echo "Usage: $0 [-l logdir] [--deployment] [--continue-on-failure]"
+	echo "\t-l <logdir>\t\t\tThe directory where to save the log file"
+	echo "\t--deployment\t\t\tRun $DEPLOYMENT_CYCLES deployment cycles with a board reset between each."
+	echo "\t\t\t\t\tEach cycle produces a separate log file in <logdir>."
+	echo "\t\t\t\t\tStops before starting a new cycle if the previous one failed."
+	echo "\t--continue-on-failure\t\tRun all $DEPLOYMENT_CYCLES cycles even if a cycle fails (implies --deployment)."
 	echo "	Environment variable ITERS controls the number of iterations of each test"
 	echo "		(default 5)"
 }
@@ -21,6 +27,13 @@ do
 		if [ -z "$2" ]; then echo "Missing argument to $1"; exit 1; fi
 		LOGDIR="$2"
 		shift
+		;;
+	--deployment)
+		DEPLOYMENT=1
+		;;
+	--continue-on-failure)
+		DEPLOYMENT=1
+		CONTINUE_ON_FAILURE=1
 		;;
 	-h)
 		usage
@@ -36,7 +49,6 @@ do
 done
 
 mkdir -p "$LOGDIR"
-LOGFILE="$LOGDIR/$LOGFILE"
 
 GREEN="$(printf '\033[32m')"
 RED="$(printf '\033[31m')"
@@ -51,11 +63,7 @@ then
 	PASS="$GREEN$PASS$RESET"
 fi
 
-truncate -s0 "$LOGFILE"
-
-failures=0
-passes=0
-
+# run_test: runs a command $ITERS times, appending output to $LOGFILE.
 run_test() {
 	for i in $(seq "$ITERS")
 	do
@@ -71,25 +79,103 @@ run_test() {
 	done
 }
 
-MESSAGE='Ethernet tests\t'
-run_test $PYTHON tests/tt_metal/tt_metal/deployment/eth/test_runner.py
+# run_tests <logfile>: runs all tests and writes output to <logfile>.
+# Sets last_eth_ok, last_dram_ok, last_pcie_read_ok, last_pcie_write_ok (1=pass, 0=fail).
+# Returns 1 if any test failed, 0 otherwise.
+run_tests() {
+	LOGFILE="$1"
+	failures=0
+	passes=0
+	prev_failures=0
 
-MESSAGE='DRAM tests\t'
-run_test $PYTHON tests/tt_metal/tt_metal/deployment/dram/test_runner.py
+	truncate -s0 "$LOGFILE"
 
-MESSAGE='PCIe read test\t'
-run_test ./build/tools/mem_bench --benchmark_filter='Device Reading Host/1073741824/32768/1/0/0/iterations:5/manual_time' --device-id=0
+	MESSAGE='Ethernet tests\t'
+	run_test $PYTHON tests/tt_metal/tt_metal/deployment/eth/test_runner.py
+	last_eth_ok=$([ "$failures" -eq "$prev_failures" ] && echo 1 || echo 0)
+	prev_failures=$failures
 
-MESSAGE='PCIe write test\t'
-run_test ./build/tools/mem_bench --benchmark_filter='Device Writing Host/1073741824/32768/0/1/0/iterations:5/manual_time' --device-id=0
+	MESSAGE='DRAM tests\t'
+	run_test $PYTHON tests/tt_metal/tt_metal/deployment/dram/test_runner.py
+	last_dram_ok=$([ "$failures" -eq "$prev_failures" ] && echo 1 || echo 0)
+	prev_failures=$failures
 
-if [ "$passes" -gt 0 ]
+	MESSAGE='PCIe read test\t'
+	run_test ./build/tools/mem_bench --benchmark_filter='Device Reading Host/1073741824/32768/1/0/0/iterations:5/manual_time' --device-id=0
+	last_pcie_read_ok=$([ "$failures" -eq "$prev_failures" ] && echo 1 || echo 0)
+	prev_failures=$failures
+
+	MESSAGE='PCIe write test\t'
+	run_test ./build/tools/mem_bench --benchmark_filter='Device Writing Host/1073741824/32768/0/1/0/iterations:5/manual_time' --device-id=0
+	last_pcie_write_ok=$([ "$failures" -eq "$prev_failures" ] && echo 1 || echo 0)
+
+	if [ "$passes" -gt 0 ]
+	then
+		echo "$passes tests $PASS"
+	fi
+
+	if [ "$failures" -gt 0 ]
+	then
+		echo "$failures tests $FAIL"
+		return 1
+	fi
+
+	return 0
+}
+
+if [ "$DEPLOYMENT" -eq 1 ]
 then
-	echo "$passes tests $PASS"
+	ITERS=1
+	deployment_failures=0
+	depl_eth_pass=0
+	depl_dram_pass=0
+	depl_pcie_read_pass=0
+	depl_pcie_write_pass=0
+
+	echo "Resetting boards before deployment..."
+	tt-smi -glx_reset
+
+	for cycle in $(seq 1 "$DEPLOYMENT_CYCLES")
+	do
+		cycle_log="$LOGDIR/deployment_$(hostname)_cycle_${cycle}_$(date +%4Y-%m-%d-%H-%M-%S).log"
+		echo "=== Deployment cycle $cycle/$DEPLOYMENT_CYCLES (log: $(basename "$cycle_log")) ==="
+		if run_tests "$cycle_log"
+		then
+			echo "Cycle $cycle PASSED"
+		else
+			deployment_failures=$((deployment_failures + 1))
+			echo "Cycle $cycle FAILED"
+		fi
+		depl_eth_pass=$((depl_eth_pass + last_eth_ok))
+		depl_dram_pass=$((depl_dram_pass + last_dram_ok))
+		depl_pcie_read_pass=$((depl_pcie_read_pass + last_pcie_read_ok))
+		depl_pcie_write_pass=$((depl_pcie_write_pass + last_pcie_write_ok))
+		if [ "$cycle" -lt "$DEPLOYMENT_CYCLES" ]
+		then
+			echo "Resetting boards..."
+			tt-smi -glx_reset
+			if [ "$CONTINUE_ON_FAILURE" -eq 0 ] && [ "$deployment_failures" -gt 0 ]
+			then
+				echo "Stopping: cycle $cycle failed."
+				break
+			fi
+		fi
+	done
+
+	echo ""
+	echo "=== Deployment Results Summary ==="
+	printf "%-20s %s\n" "Ethernet tests:"   "$depl_eth_pass/$DEPLOYMENT_CYCLES cycles passed"
+	printf "%-20s %s\n" "DRAM tests:"       "$depl_dram_pass/$DEPLOYMENT_CYCLES cycles passed"
+	printf "%-20s %s\n" "PCIe read test:"   "$depl_pcie_read_pass/$DEPLOYMENT_CYCLES cycles passed"
+	printf "%-20s %s\n" "PCIe write test:"  "$depl_pcie_write_pass/$DEPLOYMENT_CYCLES cycles passed"
+	echo ""
+	if [ "$deployment_failures" -gt 0 ]
+	then
+		printf "%-20s %s\n" "Overall:" "$((DEPLOYMENT_CYCLES - deployment_failures))/$DEPLOYMENT_CYCLES cycles passed"
+		exit 1
+	fi
+	printf "%-20s %s\n" "Overall:" "All $DEPLOYMENT_CYCLES cycles passed"
+	exit 0
 fi
 
-if [ "$failures" -gt 0 ]
-then
-	echo "$failures tests $FAIL"
-	exit 1
-fi
+run_tests "$LOGDIR/deployment_$(hostname)_$(date +%4Y-%m-%d-%H-%M-%S).log"

--- a/tests/tt_metal/tt_metal/deployment/test_runner.sh
+++ b/tests/tt_metal/tt_metal/deployment/test_runner.sh
@@ -10,14 +10,41 @@ DEPLOYMENT_CYCLES=5
 CONTINUE_ON_FAILURE=0
 
 usage() {
-	echo "Usage: $0 [-l logdir] [--deployment] [--continue-on-failure]"
-	echo "\t-l <logdir>\t\t\tThe directory where to save the log file"
-	echo "\t--deployment\t\t\tRun $DEPLOYMENT_CYCLES deployment cycles with a board reset between each."
-	echo "\t\t\t\t\tEach cycle produces a separate log file in <logdir>."
-	echo "\t\t\t\t\tStops before starting a new cycle if the previous one failed."
-	echo "\t--continue-on-failure\t\tRun all $DEPLOYMENT_CYCLES cycles even if a cycle fails (implies --deployment)."
-	echo "	Environment variable ITERS controls the number of iterations of each test"
-	echo "		(default 5)"
+	cat << EOF
+Usage: $0 [-l <logdir>] [--deployment] [--continue-on-failure] [--no-eth-links]
+
+Run the deployment test suite (Ethernet, DRAM, PCIe read/write).
+Must be run from the repository root with the tests already built.
+Everything printed to the console is also written to the log files.
+
+Optional:
+    -l <logdir>                             Directory where log files are written
+                                            (default: current directory)
+    --deployment                            Run $DEPLOYMENT_CYCLES deployment cycles with a board reset
+                                            between each. Each cycle also produces a separate log
+                                            file in <logdir>. Stops before starting a new cycle
+                                            if the previous one failed. Forces ITERS=1.
+    --continue-on-failure                   Run all $DEPLOYMENT_CYCLES cycles even if a cycle fails
+                                            (implies --deployment)
+    --no-eth-links                          Do not require a specific number of Ethernet links per
+                                            chip (sets ETH_TEST_EXPECTED_LINKS=0). Use on partially
+                                            cabled systems, otherwise 10 links per chip are expected.
+    -h                                      Display this help message and exit
+
+Environment variables:
+    ITERS                                   Number of iterations of each test (default: 5,
+                                            ignored in deployment mode)
+
+Examples:
+    Regular run (all tests, $ITERS iterations each, logs in ./logs):
+        $0 -l ./logs
+
+    Deployment run ($DEPLOYMENT_CYCLES reset cycles, one iteration per test per cycle):
+        $0 -l ./logs --deployment
+
+    Deployment run on a partially cabled system, without stopping on failure:
+        $0 -l ./logs --continue-on-failure --no-eth-links
+EOF
 }
 
 while [ -n "$1" ]
@@ -35,6 +62,10 @@ do
 		DEPLOYMENT=1
 		CONTINUE_ON_FAILURE=1
 		;;
+	--no-eth-links)
+		ETH_TEST_EXPECTED_LINKS=0
+		export ETH_TEST_EXPECTED_LINKS
+		;;
 	-h)
 		usage
 		exit
@@ -50,6 +81,14 @@ done
 
 mkdir -p "$LOGDIR"
 
+RUN_LOG="$LOGDIR/deployment_$(hostname)_$(date +%4Y-%m-%d-%H-%M-%S).log"
+: > "$RUN_LOG"
+LOGFILES="$RUN_LOG"
+
+# Carries a command's exit status out of the tee pipeline
+RCFILE="$(mktemp)"
+trap 'rm -f "$RCFILE"' EXIT HUP INT TERM
+
 GREEN="$(printf '\033[32m')"
 RED="$(printf '\033[31m')"
 RESET="$(printf '\033[m')"
@@ -63,60 +102,103 @@ then
 	PASS="$GREEN$PASS$RESET"
 fi
 
-# run_test: runs a command $ITERS times, appending output to $LOGFILE.
+# emit: print a line.
+emit() {
+	printf '%s\n' "$*"
+	for f in $LOGFILES
+	do
+		printf '%s\n' "$*" >> "$f"
+	done
+}
+
+# emit_status <text> <passed|failed>: print a line ending in a pass/fail verdict.
+emit_status() {
+	case "$2" in
+	passed) colored="$PASS" ;;
+	*) colored="$FAIL" ;;
+	esac
+	printf '%s %s\n' "$1" "$colored"
+	for f in $LOGFILES
+	do
+		printf '%s %s\n' "$1" "$2" >> "$f"
+	done
+}
+
+# run_logged: run a command and set $rc to its exit status.
+run_logged() {
+	echo 0 > "$RCFILE"
+	{ "$@" 2>&1 || echo "$?" > "$RCFILE"; } | tee -a $LOGFILES
+	rc="$(cat "$RCFILE")"
+}
+
+# run_reset <message>: reset the boards, aborting the run if the reset fails.
+run_reset() {
+	emit ""
+	emit "$1"
+	run_logged $RESET_CMD
+	if [ "$rc" -ne 0 ]
+	then
+		emit "Reset failed (exit code $rc)"
+		exit "$rc"
+	fi
+}
+
+# run_test: runs a command $ITERS times.
 run_test() {
 	for i in $(seq "$ITERS")
 	do
-		printf "$MESSAGE loop $i "
-		if ! "$@" >> "$LOGFILE" 2>&1
+		emit ""
+		emit "--- $MESSAGE: iteration $i/$ITERS ---"
+		run_logged "$@"
+		if [ "$rc" -ne 0 ]
 		then
 			failures=$((failures + 1))
-			echo "$FAIL"
+			emit_status "$MESSAGE iteration $i:" failed
 		else
 			passes=$((passes + 1))
-			echo "$PASS"
+			emit_status "$MESSAGE iteration $i:" passed
 		fi
 	done
 }
 
-# run_tests <logfile>: runs all tests and writes output to <logfile>.
+# run_tests [cycle_logfile]: runs all tests.
 # Sets last_eth_ok, last_dram_ok, last_pcie_read_ok, last_pcie_write_ok (1=pass, 0=fail).
 # Returns 1 if any test failed, 0 otherwise.
 run_tests() {
-	LOGFILE="$1"
+	LOGFILES="$RUN_LOG${1:+ $1}"
 	failures=0
 	passes=0
 	prev_failures=0
 
-	truncate -s0 "$LOGFILE"
-
-	MESSAGE='Ethernet tests\t'
+	MESSAGE='Ethernet tests'
 	run_test $PYTHON tests/tt_metal/tt_metal/deployment/eth/test_runner.py
 	last_eth_ok=$([ "$failures" -eq "$prev_failures" ] && echo 1 || echo 0)
 	prev_failures=$failures
 
-	MESSAGE='DRAM tests\t'
+	MESSAGE='DRAM tests'
 	run_test $PYTHON tests/tt_metal/tt_metal/deployment/dram/test_runner.py
 	last_dram_ok=$([ "$failures" -eq "$prev_failures" ] && echo 1 || echo 0)
 	prev_failures=$failures
 
-	MESSAGE='PCIe read test\t'
+	MESSAGE='PCIe read test'
 	run_test ./build/tools/mem_bench --benchmark_filter='Device Reading Host/1073741824/32768/1/0/0/iterations:5/manual_time' --device-id=0
 	last_pcie_read_ok=$([ "$failures" -eq "$prev_failures" ] && echo 1 || echo 0)
 	prev_failures=$failures
 
-	MESSAGE='PCIe write test\t'
+	MESSAGE='PCIe write test'
 	run_test ./build/tools/mem_bench --benchmark_filter='Device Writing Host/1073741824/32768/0/1/0/iterations:5/manual_time' --device-id=0
 	last_pcie_write_ok=$([ "$failures" -eq "$prev_failures" ] && echo 1 || echo 0)
 
+	emit ""
+
 	if [ "$passes" -gt 0 ]
 	then
-		echo "$passes tests $PASS"
+		emit_status "$passes tests" passed
 	fi
 
 	if [ "$failures" -gt 0 ]
 	then
-		echo "$failures tests $FAIL"
+		emit_status "$failures tests" failed
 		return 1
 	fi
 
@@ -133,27 +215,25 @@ then
 	depl_pcie_read_pass=0
 	depl_pcie_write_pass=0
 
-	if tt-smi -s 2>/dev/null | grep -q '"board_type": "tt-galaxy-bh"'; then
-		RESET_CMD="tt-smi -glx_reset"
-	else
-		RESET_CMD="tt-smi -r"
-	fi
-	echo "Running: $RESET_CMD"
-
-	echo "Resetting boards before deployment..."
-	$RESET_CMD
+	RESET_CMD="tt-smi -glx_reset"
+	emit "Run log: $RUN_LOG"
+	run_reset "Resetting boards before deployment ($RESET_CMD)..."
 
 	for cycle in $(seq 1 "$DEPLOYMENT_CYCLES")
 	do
 		cycle_log="$LOGDIR/deployment_$(hostname)_cycle_${cycle}_$(date +%4Y-%m-%d-%H-%M-%S).log"
-		echo "=== Deployment cycle $cycle/$DEPLOYMENT_CYCLES (log: $(basename "$cycle_log")) ==="
+		: > "$cycle_log"
+		LOGFILES="$RUN_LOG $cycle_log"
+		emit ""
+		emit "=== Deployment cycle $cycle/$DEPLOYMENT_CYCLES (log: $(basename "$cycle_log")) ==="
 		if run_tests "$cycle_log"
 		then
-			echo "Cycle $cycle PASSED"
+			emit "Cycle $cycle PASSED"
 		else
 			deployment_failures=$((deployment_failures + 1))
-			echo "Cycle $cycle FAILED"
+			emit "Cycle $cycle FAILED"
 		fi
+		LOGFILES="$RUN_LOG"
 		cycles_run=$((cycles_run + 1))
 		depl_eth_pass=$((depl_eth_pass + last_eth_ok))
 		depl_dram_pass=$((depl_dram_pass + last_dram_ok))
@@ -161,30 +241,32 @@ then
 		depl_pcie_write_pass=$((depl_pcie_write_pass + last_pcie_write_ok))
 		if [ "$cycle" -lt "$DEPLOYMENT_CYCLES" ]
 		then
-			echo "Resetting boards..."
-			$RESET_CMD
+			run_reset "Resetting boards ($RESET_CMD)..."
 			if [ "$CONTINUE_ON_FAILURE" -eq 0 ] && [ "$deployment_failures" -gt 0 ]
 			then
-				echo "Stopping: cycle $cycle failed."
+				emit "Stopping: cycle $cycle failed."
 				break
 			fi
 		fi
 	done
 
-	echo ""
-	echo "=== Deployment Results Summary (${cycles_run}/${DEPLOYMENT_CYCLES} cycles ran) ==="
-	printf "%-20s %s\n" "Ethernet tests:"   "$depl_eth_pass/$cycles_run cycles passed"
-	printf "%-20s %s\n" "DRAM tests:"       "$depl_dram_pass/$cycles_run cycles passed"
-	printf "%-20s %s\n" "PCIe read test:"   "$depl_pcie_read_pass/$cycles_run cycles passed"
-	printf "%-20s %s\n" "PCIe write test:"  "$depl_pcie_write_pass/$cycles_run cycles passed"
-	echo ""
+	emit ""
+	emit "=== Deployment Results Summary (${cycles_run}/${DEPLOYMENT_CYCLES} cycles ran) ==="
+	emit "$(printf '%-20s %s' 'Ethernet tests:'  "$depl_eth_pass/$cycles_run cycles passed")"
+	emit "$(printf '%-20s %s' 'DRAM tests:'      "$depl_dram_pass/$cycles_run cycles passed")"
+	emit "$(printf '%-20s %s' 'PCIe read test:'  "$depl_pcie_read_pass/$cycles_run cycles passed")"
+	emit "$(printf '%-20s %s' 'PCIe write test:' "$depl_pcie_write_pass/$cycles_run cycles passed")"
+	emit ""
 	if [ "$deployment_failures" -gt 0 ]
 	then
-		printf "%-20s %s\n" "Overall:" "$((cycles_run - deployment_failures))/$cycles_run cycles passed"
+		emit "$(printf '%-20s %s' 'Overall:' "$((cycles_run - deployment_failures))/$cycles_run cycles passed")"
+		emit "Run log: $RUN_LOG"
 		exit 1
 	fi
-	printf "%-20s %s\n" "Overall:" "All $cycles_run cycles passed"
+	emit "$(printf '%-20s %s' 'Overall:' "All $cycles_run cycles passed")"
+	emit "Run log: $RUN_LOG"
 	exit 0
 fi
 
-run_tests "$LOGDIR/deployment_$(hostname)_$(date +%4Y-%m-%d-%H-%M-%S).log"
+emit "Run log: $RUN_LOG"
+run_tests

--- a/tests/tt_metal/tt_metal/deployment/test_runner.sh
+++ b/tests/tt_metal/tt_metal/deployment/test_runner.sh
@@ -15,14 +15,13 @@ Usage: $0 [-l <logdir>] [--deployment] [--continue-on-failure] [--no-eth-links]
 
 Run the deployment test suite (Ethernet, DRAM, PCIe read/write).
 Must be run from the repository root with the tests already built.
-Everything printed to the console is also written to the log files.
+Everything printed to the console is also written to a single log file per run.
 
 Optional:
-    -l <logdir>                             Directory where log files are written
+    -l <logdir>                             Directory where the log file is written
                                             (default: current directory)
     --deployment                            Run $DEPLOYMENT_CYCLES deployment cycles with a board reset
-                                            between each. Each cycle also produces a separate log
-                                            file in <logdir>. Stops before starting a new cycle
+                                            between each. Stops before starting a new cycle
                                             if the previous one failed. Forces ITERS=1.
     --continue-on-failure                   Run all $DEPLOYMENT_CYCLES cycles even if a cycle fails
                                             (implies --deployment)
@@ -83,32 +82,53 @@ mkdir -p "$LOGDIR"
 
 RUN_LOG="$LOGDIR/deployment_$(hostname)_$(date +%4Y-%m-%d-%H-%M-%S).log"
 : > "$RUN_LOG"
-LOGFILES="$RUN_LOG"
 
 # Carries a command's exit status out of the tee pipeline
 RCFILE="$(mktemp)"
 trap 'rm -f "$RCFILE"' EXIT HUP INT TERM
 
-GREEN="$(printf '\033[32m')"
-RED="$(printf '\033[31m')"
-RESET="$(printf '\033[m')"
+RULE_HEAVY='=============================================================================='
+RULE_LIGHT='------------------------------------------------------------------------------'
 
+BOLD=""
+NORM=""
 FAIL=failed
 PASS=passed
 
 if [ -t 1 ]
 then
-	FAIL="$RED$FAIL$RESET"
-	PASS="$GREEN$PASS$RESET"
+	BOLD="$(printf '\033[1m')"
+	NORM="$(printf '\033[m')"
+	FAIL="$(printf '\033[31m')$FAIL$NORM"
+	PASS="$(printf '\033[32m')$PASS$NORM"
 fi
 
 # emit: print a line.
 emit() {
 	printf '%s\n' "$*"
-	for f in $LOGFILES
-	do
-		printf '%s\n' "$*" >> "$f"
-	done
+	printf '%s\n' "$*" >> "$RUN_LOG"
+}
+
+# emit_bold: print a highlighted line.
+emit_bold() {
+	printf '%s%s%s\n' "$BOLD" "$*" "$NORM"
+	printf '%s\n' "$*" >> "$RUN_LOG"
+}
+
+# emit_banner: print a heading delimited by heavy rules.
+emit_banner() {
+	emit ""
+	emit "$RULE_HEAVY"
+	emit_bold "$*"
+	emit "$RULE_HEAVY"
+}
+
+# emit_section: print a heading delimited by light rules.
+emit_section() {
+	emit ""
+	emit "$RULE_LIGHT"
+	emit_bold "$*"
+	emit "$RULE_LIGHT"
 }
 
 # emit_status <text> <passed|failed>: print a line ending in a pass/fail verdict.
@@ -118,23 +138,19 @@ emit_status() {
 	*) colored="$FAIL" ;;
 	esac
 	printf '%s %s\n' "$1" "$colored"
-	for f in $LOGFILES
-	do
-		printf '%s %s\n' "$1" "$2" >> "$f"
-	done
+	printf '%s %s\n' "$1" "$2" >> "$RUN_LOG"
 }
 
 # run_logged: run a command and set $rc to its exit status.
 run_logged() {
 	echo 0 > "$RCFILE"
-	{ "$@" 2>&1 || echo "$?" > "$RCFILE"; } | tee -a $LOGFILES
+	{ "$@" 2>&1 || echo "$?" > "$RCFILE"; } | tee -a "$RUN_LOG"
 	rc="$(cat "$RCFILE")"
 }
 
 # run_reset <message>: reset the boards, aborting the run if the reset fails.
 run_reset() {
-	emit ""
-	emit "$1"
+	emit_section "$1"
 	run_logged $RESET_CMD
 	if [ "$rc" -ne 0 ]
 	then
@@ -147,8 +163,7 @@ run_reset() {
 run_test() {
 	for i in $(seq "$ITERS")
 	do
-		emit ""
-		emit "--- $MESSAGE: iteration $i/$ITERS ---"
+		emit_section "$MESSAGE: iteration $i/$ITERS"
 		run_logged "$@"
 		if [ "$rc" -ne 0 ]
 		then
@@ -161,11 +176,10 @@ run_test() {
 	done
 }
 
-# run_tests [cycle_logfile]: runs all tests.
+# run_tests: runs all tests.
 # Sets last_eth_ok, last_dram_ok, last_pcie_read_ok, last_pcie_write_ok (1=pass, 0=fail).
 # Returns 1 if any test failed, 0 otherwise.
 run_tests() {
-	LOGFILES="$RUN_LOG${1:+ $1}"
 	failures=0
 	passes=0
 	prev_failures=0
@@ -189,7 +203,7 @@ run_tests() {
 	run_test ./build/tools/mem_bench --benchmark_filter='Device Writing Host/1073741824/32768/0/1/0/iterations:5/manual_time' --device-id=0
 	last_pcie_write_ok=$([ "$failures" -eq "$prev_failures" ] && echo 1 || echo 0)
 
-	emit ""
+	emit_section 'Test results'
 
 	if [ "$passes" -gt 0 ]
 	then
@@ -221,19 +235,14 @@ then
 
 	for cycle in $(seq 1 "$DEPLOYMENT_CYCLES")
 	do
-		cycle_log="$LOGDIR/deployment_$(hostname)_cycle_${cycle}_$(date +%4Y-%m-%d-%H-%M-%S).log"
-		: > "$cycle_log"
-		LOGFILES="$RUN_LOG $cycle_log"
-		emit ""
-		emit "=== Deployment cycle $cycle/$DEPLOYMENT_CYCLES (log: $(basename "$cycle_log")) ==="
-		if run_tests "$cycle_log"
+		emit_banner "DEPLOYMENT CYCLE $cycle/$DEPLOYMENT_CYCLES"
+		if run_tests
 		then
-			emit "Cycle $cycle PASSED"
+			emit_banner "CYCLE $cycle PASSED"
 		else
 			deployment_failures=$((deployment_failures + 1))
-			emit "Cycle $cycle FAILED"
+			emit_banner "CYCLE $cycle FAILED"
 		fi
-		LOGFILES="$RUN_LOG"
 		cycles_run=$((cycles_run + 1))
 		depl_eth_pass=$((depl_eth_pass + last_eth_ok))
 		depl_dram_pass=$((depl_dram_pass + last_dram_ok))
@@ -250,20 +259,21 @@ then
 		fi
 	done
 
-	emit ""
-	emit "=== Deployment Results Summary (${cycles_run}/${DEPLOYMENT_CYCLES} cycles ran) ==="
+	emit_banner "DEPLOYMENT RESULTS SUMMARY (${cycles_run}/${DEPLOYMENT_CYCLES} cycles ran)"
 	emit "$(printf '%-20s %s' 'Ethernet tests:'  "$depl_eth_pass/$cycles_run cycles passed")"
 	emit "$(printf '%-20s %s' 'DRAM tests:'      "$depl_dram_pass/$cycles_run cycles passed")"
 	emit "$(printf '%-20s %s' 'PCIe read test:'  "$depl_pcie_read_pass/$cycles_run cycles passed")"
 	emit "$(printf '%-20s %s' 'PCIe write test:' "$depl_pcie_write_pass/$cycles_run cycles passed")"
-	emit ""
+	emit "$RULE_LIGHT"
 	if [ "$deployment_failures" -gt 0 ]
 	then
-		emit "$(printf '%-20s %s' 'Overall:' "$((cycles_run - deployment_failures))/$cycles_run cycles passed")"
+		emit_bold "$(printf '%-20s %s' 'Overall:' "$((cycles_run - deployment_failures))/$cycles_run cycles passed")"
+		emit "$RULE_HEAVY"
 		emit "Run log: $RUN_LOG"
 		exit 1
 	fi
-	emit "$(printf '%-20s %s' 'Overall:' "All $cycles_run cycles passed")"
+	emit_bold "$(printf '%-20s %s' 'Overall:' "All $cycles_run cycles passed")"
+	emit "$RULE_HEAVY"
 	emit "Run log: $RUN_LOG"
 	exit 0
 fi

--- a/tests/tt_metal/tt_metal/deployment/test_runner.sh
+++ b/tests/tt_metal/tt_metal/deployment/test_runner.sh
@@ -5,6 +5,7 @@ set -e
 LOGDIR="."
 LOGFILE="deployment_$(hostname)_$(date +%4Y-%m-%d-%H-%M-%S).log"
 ITERS="${ITERS:-5}"
+PYTHON="$(command -v python3 || command -v python)"
 
 usage() {
 	echo "Usage: $0 [-l logdir]"
@@ -71,10 +72,10 @@ run_test() {
 }
 
 MESSAGE='Ethernet tests\t'
-run_test python tests/tt_metal/tt_metal/deployment/eth/test_runner.py
+run_test $PYTHON tests/tt_metal/tt_metal/deployment/eth/test_runner.py
 
 MESSAGE='DRAM tests\t'
-run_test python tests/tt_metal/tt_metal/deployment/dram/test_runner.py
+run_test $PYTHON tests/tt_metal/tt_metal/deployment/dram/test_runner.py
 
 MESSAGE='PCIe read test\t'
 run_test ./build/tools/mem_bench --benchmark_filter='Device Reading Host/1073741824/32768/1/0/0/iterations:5/manual_time' --device-id=0

--- a/tests/tt_metal/tt_metal/deployment/test_runner.sh
+++ b/tests/tt_metal/tt_metal/deployment/test_runner.sh
@@ -11,14 +11,14 @@ CONTINUE_ON_FAILURE=0
 
 usage() {
 	cat << EOF
-Usage: $0 [-l <logdir>] [--deployment] [--continue-on-failure] [--no-eth-links]
+Usage: $0 [--output <logdir>] [--deployment] [--continue-on-failure] [--no-eth-links]
 
 Run the deployment test suite (Ethernet, DRAM, PCIe read/write).
 Must be run from the repository root with the tests already built.
 Everything printed to the console is also written to a single log file per run.
 
 Optional:
-    -l <logdir>                             Directory where the log file is written
+    --output <logdir>                       Directory where the log file is written
                                             (default: current directory)
     --deployment                            Run $DEPLOYMENT_CYCLES deployment cycles, each starting with a
                                             board reset. Stops after a cycle fails.
@@ -36,20 +36,20 @@ Environment variables:
 
 Examples:
     Regular run (all tests, $ITERS iterations each, logs in ./logs):
-        $0 -l ./logs
+        $0 --output ./logs
 
     Deployment run ($DEPLOYMENT_CYCLES reset cycles, one iteration per test per cycle):
-        $0 -l ./logs --deployment
+        $0 --output ./logs --deployment
 
     Deployment run on a partially cabled system, without stopping on failure:
-        $0 -l ./logs --continue-on-failure --no-eth-links
+        $0 --output ./logs --continue-on-failure --no-eth-links
 EOF
 }
 
 while [ -n "$1" ]
 do
 	case "$1" in
-	-l)
+	--output)
 		if [ -z "$2" ]; then echo "Missing argument to $1"; exit 1; fi
 		LOGDIR="$2"
 		shift
@@ -269,7 +269,9 @@ then
 		fi
 	done
 
-	emit_banner "DEPLOYMENT RESULTS SUMMARY (${cycles_run}/${DEPLOYMENT_CYCLES} cycles ran)"
+	emit_banner "DEPLOYMENT TEST SUITE - RESULTS SUMMARY (${cycles_run}/${DEPLOYMENT_CYCLES} cycles ran)"
+	emit "$(printf '%-20s %s' 'Host:'            "$(hostname)")"
+	emit "$RULE_LIGHT"
 	emit "$(printf '%-20s %s' 'Ethernet tests:'  "$depl_eth_pass/$cycles_run cycles passed")"
 	emit "$(printf '%-20s %s' 'DRAM tests:'      "$depl_dram_pass/$cycles_run cycles passed")"
 	emit "$(printf '%-20s %s' 'PCIe read test:'  "$depl_pcie_read_pass/$cycles_run cycles passed")"

--- a/tests/tt_metal/tt_metal/deployment/test_runner.sh
+++ b/tests/tt_metal/tt_metal/deployment/test_runner.sh
@@ -127,13 +127,21 @@ if [ "$DEPLOYMENT" -eq 1 ]
 then
 	ITERS=1
 	deployment_failures=0
+	cycles_run=0
 	depl_eth_pass=0
 	depl_dram_pass=0
 	depl_pcie_read_pass=0
 	depl_pcie_write_pass=0
 
+	if tt-smi -s 2>/dev/null | grep -q '"board_type": "tt-galaxy-bh"'; then
+		RESET_CMD="tt-smi -glx_reset"
+	else
+		RESET_CMD="tt-smi -r"
+	fi
+	echo "Running: $RESET_CMD"
+
 	echo "Resetting boards before deployment..."
-	tt-smi -glx_reset
+	$RESET_CMD
 
 	for cycle in $(seq 1 "$DEPLOYMENT_CYCLES")
 	do
@@ -146,6 +154,7 @@ then
 			deployment_failures=$((deployment_failures + 1))
 			echo "Cycle $cycle FAILED"
 		fi
+		cycles_run=$((cycles_run + 1))
 		depl_eth_pass=$((depl_eth_pass + last_eth_ok))
 		depl_dram_pass=$((depl_dram_pass + last_dram_ok))
 		depl_pcie_read_pass=$((depl_pcie_read_pass + last_pcie_read_ok))
@@ -153,7 +162,7 @@ then
 		if [ "$cycle" -lt "$DEPLOYMENT_CYCLES" ]
 		then
 			echo "Resetting boards..."
-			tt-smi -glx_reset
+			$RESET_CMD
 			if [ "$CONTINUE_ON_FAILURE" -eq 0 ] && [ "$deployment_failures" -gt 0 ]
 			then
 				echo "Stopping: cycle $cycle failed."
@@ -163,18 +172,18 @@ then
 	done
 
 	echo ""
-	echo "=== Deployment Results Summary ==="
-	printf "%-20s %s\n" "Ethernet tests:"   "$depl_eth_pass/$DEPLOYMENT_CYCLES cycles passed"
-	printf "%-20s %s\n" "DRAM tests:"       "$depl_dram_pass/$DEPLOYMENT_CYCLES cycles passed"
-	printf "%-20s %s\n" "PCIe read test:"   "$depl_pcie_read_pass/$DEPLOYMENT_CYCLES cycles passed"
-	printf "%-20s %s\n" "PCIe write test:"  "$depl_pcie_write_pass/$DEPLOYMENT_CYCLES cycles passed"
+	echo "=== Deployment Results Summary (${cycles_run}/${DEPLOYMENT_CYCLES} cycles ran) ==="
+	printf "%-20s %s\n" "Ethernet tests:"   "$depl_eth_pass/$cycles_run cycles passed"
+	printf "%-20s %s\n" "DRAM tests:"       "$depl_dram_pass/$cycles_run cycles passed"
+	printf "%-20s %s\n" "PCIe read test:"   "$depl_pcie_read_pass/$cycles_run cycles passed"
+	printf "%-20s %s\n" "PCIe write test:"  "$depl_pcie_write_pass/$cycles_run cycles passed"
 	echo ""
 	if [ "$deployment_failures" -gt 0 ]
 	then
-		printf "%-20s %s\n" "Overall:" "$((DEPLOYMENT_CYCLES - deployment_failures))/$DEPLOYMENT_CYCLES cycles passed"
+		printf "%-20s %s\n" "Overall:" "$((cycles_run - deployment_failures))/$cycles_run cycles passed"
 		exit 1
 	fi
-	printf "%-20s %s\n" "Overall:" "All $DEPLOYMENT_CYCLES cycles passed"
+	printf "%-20s %s\n" "Overall:" "All $cycles_run cycles passed"
 	exit 0
 fi
 

--- a/tests/tt_metal/tt_metal/deployment/test_runner.sh
+++ b/tests/tt_metal/tt_metal/deployment/test_runner.sh
@@ -3,46 +3,47 @@
 set -e
 
 LOGDIR="."
-ITERS="${ITERS:-5}"
+ITERATIONS=5
 PYTHON="$(command -v python3 || command -v python)"
-DEPLOYMENT=0
-DEPLOYMENT_CYCLES=5
+SKIP_RESET=0
 CONTINUE_ON_FAILURE=0
+RESET_CMD="tt-smi -glx_reset"
 
 usage() {
 	cat << EOF
-Usage: $0 [--output <logdir>] [--deployment] [--continue-on-failure] [--no-eth-links]
+Usage: $0 [--output <logdir>] [--iterations <n>] [--skip-reset] [--continue-on-failure] [--no-eth-links]
 
 Run the deployment test suite (Ethernet, DRAM, PCIe read/write).
 Must be run from the repository root with the tests already built.
 Everything printed to the console is also written to a single log file per run.
 
+An iteration is a board reset followed by one run of each test.
+
 Optional:
     --output <logdir>                       Directory where the log file is written
                                             (default: current directory)
-    --deployment                            Run $DEPLOYMENT_CYCLES deployment cycles, each starting with a
-                                            board reset. Stops after a cycle fails.
-                                            Forces ITERS=1.
-    --continue-on-failure                   Run all $DEPLOYMENT_CYCLES cycles even if a cycle fails
-                                            (implies --deployment)
+    --iterations <n>                        Number of iterations to run (default: $ITERATIONS).
+                                            Stops after an iteration fails.
+    --skip-reset                            Do not reset the boards before each iteration.
+                                            Use to stress the tests without resets in between.
+    --continue-on-failure                   Run all iterations even if one fails
     --no-eth-links                          Do not require a specific number of Ethernet links per
-                                            chip (sets ETH_TEST_EXPECTED_LINKS=0). Use on partially
-                                            cabled systems, otherwise 10 links per chip are expected.
+                                            chip. Use on partially cabled systems, otherwise
+                                            10 links per chip are expected.
     -h                                      Display this help message and exit
 
-Environment variables:
-    ITERS                                   Number of iterations of each test (default: 5,
-                                            ignored in deployment mode)
-
 Examples:
-    Regular run (all tests, $ITERS iterations each, logs in ./logs):
+    Deployment qualification ($ITERATIONS reset-and-test iterations), logs in ./logs:
         $0 --output ./logs
 
-    Deployment run ($DEPLOYMENT_CYCLES reset cycles, one iteration per test per cycle):
-        $0 --output ./logs --deployment
+    Quick health check (one reset-and-test iteration):
+        $0 --output ./logs --iterations 1
 
-    Deployment run on a partially cabled system, without stopping on failure:
-        $0 --output ./logs --continue-on-failure --no-eth-links
+    Stress run of 20 iterations without resets, collecting every failure:
+        $0 --output ./logs --iterations 20 --skip-reset --continue-on-failure
+
+    Run on a partially cabled system:
+        $0 --output ./logs --no-eth-links
 EOF
 }
 
@@ -54,11 +55,18 @@ do
 		LOGDIR="$2"
 		shift
 		;;
-	--deployment)
-		DEPLOYMENT=1
+	--iterations)
+		if [ -z "$2" ]; then echo "Missing argument to $1"; exit 1; fi
+		case "$2" in
+		''|*[!0-9]*|0) echo "$1 must be a positive integer, got '$2'"; exit 1 ;;
+		esac
+		ITERATIONS="$2"
+		shift
+		;;
+	--skip-reset)
+		SKIP_RESET=1
 		;;
 	--continue-on-failure)
-		DEPLOYMENT=1
 		CONTINUE_ON_FAILURE=1
 		;;
 	--no-eth-links)
@@ -159,49 +167,41 @@ run_reset() {
 	fi
 }
 
-# run_test: runs a command $ITERS times.
+# run_test <label> <command...>: runs a test once and records its result.
 run_test() {
-	for i in $(seq "$ITERS")
-	do
-		emit_section "$MESSAGE: iteration $i/$ITERS"
-		run_logged "$@"
-		if [ "$rc" -ne 0 ]
-		then
-			failures=$((failures + 1))
-			emit_status "$MESSAGE iteration $i:" failed
-		else
-			passes=$((passes + 1))
-			emit_status "$MESSAGE iteration $i:" passed
-		fi
-	done
+	label="$1"
+	shift
+	emit_section "$label"
+	run_logged "$@"
+	if [ "$rc" -ne 0 ]
+	then
+		failures=$((failures + 1))
+		emit_status "$label:" failed
+		return 1
+	fi
+	passes=$((passes + 1))
+	emit_status "$label:" passed
+	return 0
 }
 
-# run_tests: runs all tests.
+# run_tests: runs one round of every test.
 # Sets last_eth_ok, last_dram_ok, last_pcie_read_ok, last_pcie_write_ok (1=pass, 0=fail).
 # Returns 1 if any test failed, 0 otherwise.
 run_tests() {
 	failures=0
 	passes=0
-	prev_failures=0
 
-	MESSAGE='Ethernet tests'
-	run_test $PYTHON tests/tt_metal/tt_metal/deployment/eth/test_runner.py
-	last_eth_ok=$([ "$failures" -eq "$prev_failures" ] && echo 1 || echo 0)
-	prev_failures=$failures
+	run_test 'Ethernet tests' $PYTHON tests/tt_metal/tt_metal/deployment/eth/test_runner.py &&
+		last_eth_ok=1 || last_eth_ok=0
 
-	MESSAGE='DRAM tests'
-	run_test $PYTHON tests/tt_metal/tt_metal/deployment/dram/test_runner.py
-	last_dram_ok=$([ "$failures" -eq "$prev_failures" ] && echo 1 || echo 0)
-	prev_failures=$failures
+	run_test 'DRAM tests' $PYTHON tests/tt_metal/tt_metal/deployment/dram/test_runner.py &&
+		last_dram_ok=1 || last_dram_ok=0
 
-	MESSAGE='PCIe read test'
-	run_test ./build/tools/mem_bench --benchmark_filter='Device Reading Host/1073741824/32768/1/0/0/iterations:5/manual_time' --device-id=0
-	last_pcie_read_ok=$([ "$failures" -eq "$prev_failures" ] && echo 1 || echo 0)
-	prev_failures=$failures
+	run_test 'PCIe read test' ./build/tools/mem_bench --benchmark_filter='Device Reading Host/1073741824/32768/1/0/0/iterations:5/manual_time' --device-id=0 &&
+		last_pcie_read_ok=1 || last_pcie_read_ok=0
 
-	MESSAGE='PCIe write test'
-	run_test ./build/tools/mem_bench --benchmark_filter='Device Writing Host/1073741824/32768/0/1/0/iterations:5/manual_time' --device-id=0
-	last_pcie_write_ok=$([ "$failures" -eq "$prev_failures" ] && echo 1 || echo 0)
+	run_test 'PCIe write test' ./build/tools/mem_bench --benchmark_filter='Device Writing Host/1073741824/32768/0/1/0/iterations:5/manual_time' --device-id=0 &&
+		last_pcie_write_ok=1 || last_pcie_write_ok=0
 
 	emit_section 'Test results'
 
@@ -219,17 +219,14 @@ run_tests() {
 	return 0
 }
 
-RESET_CMD="tt-smi -glx_reset"
-
-if [ "$DEPLOYMENT" -eq 1 ]
+if [ "$SKIP_RESET" -eq 1 ]
 then
-	ITERS=1
-	MODE="deployment ($DEPLOYMENT_CYCLES cycles, $RESET_CMD before each)"
+	MODE="$ITERATIONS iteration(s), no board reset"
 else
-	MODE="single pass ($ITERS iterations per test)"
+	MODE="$ITERATIONS iteration(s), $RESET_CMD before each"
 fi
 
-emit_banner "DEPLOYMENT TEST RUN"
+emit_banner "DEPLOYMENT TESTS RUN"
 emit "$(printf '%-12s %s' 'Date:' "$(date)")"
 emit "$(printf '%-12s %s' 'Host:' "$(hostname)")"
 emit "$(printf '%-12s %s' 'Tests:' 'Ethernet, DRAM, PCIe read, PCIe write')"
@@ -237,57 +234,54 @@ emit "$(printf '%-12s %s' 'Mode:' "$MODE")"
 emit "$(printf '%-12s %s' 'Run log:' "$RUN_LOG")"
 emit "$RULE_HEAVY"
 
-if [ "$DEPLOYMENT" -eq 1 ]
-then
-	deployment_failures=0
-	cycles_run=0
-	depl_eth_pass=0
-	depl_dram_pass=0
-	depl_pcie_read_pass=0
-	depl_pcie_write_pass=0
+iteration_failures=0
+iterations_run=0
+eth_pass=0
+dram_pass=0
+pcie_read_pass=0
+pcie_write_pass=0
 
-	for cycle in $(seq 1 "$DEPLOYMENT_CYCLES")
-	do
-		emit_banner "DEPLOYMENT CYCLE $cycle/$DEPLOYMENT_CYCLES"
-		run_reset "Resetting boards ($RESET_CMD)..."
-		if run_tests
-		then
-			emit_banner "CYCLE $cycle PASSED"
-		else
-			deployment_failures=$((deployment_failures + 1))
-			emit_banner "CYCLE $cycle FAILED"
-		fi
-		cycles_run=$((cycles_run + 1))
-		depl_eth_pass=$((depl_eth_pass + last_eth_ok))
-		depl_dram_pass=$((depl_dram_pass + last_dram_ok))
-		depl_pcie_read_pass=$((depl_pcie_read_pass + last_pcie_read_ok))
-		depl_pcie_write_pass=$((depl_pcie_write_pass + last_pcie_write_ok))
-		if [ "$CONTINUE_ON_FAILURE" -eq 0 ] && [ "$deployment_failures" -gt 0 ]
-		then
-			emit "Stopping: cycle $cycle failed."
-			break
-		fi
-	done
-
-	emit_banner "DEPLOYMENT TEST SUITE - RESULTS SUMMARY (${cycles_run}/${DEPLOYMENT_CYCLES} cycles ran)"
-	emit "$(printf '%-20s %s' 'Host:'            "$(hostname)")"
-	emit "$RULE_LIGHT"
-	emit "$(printf '%-20s %s' 'Ethernet tests:'  "$depl_eth_pass/$cycles_run cycles passed")"
-	emit "$(printf '%-20s %s' 'DRAM tests:'      "$depl_dram_pass/$cycles_run cycles passed")"
-	emit "$(printf '%-20s %s' 'PCIe read test:'  "$depl_pcie_read_pass/$cycles_run cycles passed")"
-	emit "$(printf '%-20s %s' 'PCIe write test:' "$depl_pcie_write_pass/$cycles_run cycles passed")"
-	emit "$RULE_LIGHT"
-	if [ "$deployment_failures" -gt 0 ]
+for iteration in $(seq 1 "$ITERATIONS")
+do
+	emit_banner "ITERATION $iteration/$ITERATIONS"
+	if [ "$SKIP_RESET" -eq 0 ]
 	then
-		emit_bold "$(printf '%-20s %s' 'Overall:' "$((cycles_run - deployment_failures))/$cycles_run cycles passed")"
-		emit "$RULE_HEAVY"
-		emit "Run log: $RUN_LOG"
-		exit 1
+		run_reset "Resetting boards ($RESET_CMD)..."
 	fi
-	emit_bold "$(printf '%-20s %s' 'Overall:' "All $cycles_run cycles passed")"
+	if run_tests
+	then
+		emit_banner "ITERATION $iteration PASSED"
+	else
+		iteration_failures=$((iteration_failures + 1))
+		emit_banner "ITERATION $iteration FAILED"
+	fi
+	iterations_run=$((iterations_run + 1))
+	eth_pass=$((eth_pass + last_eth_ok))
+	dram_pass=$((dram_pass + last_dram_ok))
+	pcie_read_pass=$((pcie_read_pass + last_pcie_read_ok))
+	pcie_write_pass=$((pcie_write_pass + last_pcie_write_ok))
+	if [ "$CONTINUE_ON_FAILURE" -eq 0 ] && [ "$iteration_failures" -gt 0 ]
+	then
+		emit "Stopping: iteration $iteration failed."
+		break
+	fi
+done
+
+emit_banner "DEPLOYMENT TEST SUITE - RESULTS SUMMARY (${iterations_run}/${ITERATIONS} iterations ran)"
+emit "$(printf '%-20s %s' 'Host:'            "$(hostname)")"
+emit "$RULE_LIGHT"
+emit "$(printf '%-20s %s' 'Ethernet tests:'  "$eth_pass/$iterations_run iterations passed")"
+emit "$(printf '%-20s %s' 'DRAM tests:'      "$dram_pass/$iterations_run iterations passed")"
+emit "$(printf '%-20s %s' 'PCIe read test:'  "$pcie_read_pass/$iterations_run iterations passed")"
+emit "$(printf '%-20s %s' 'PCIe write test:' "$pcie_write_pass/$iterations_run iterations passed")"
+emit "$RULE_LIGHT"
+if [ "$iteration_failures" -gt 0 ]
+then
+	emit_bold "$(printf '%-20s %s' 'Overall:' "$((iterations_run - iteration_failures))/$iterations_run iterations passed")"
 	emit "$RULE_HEAVY"
 	emit "Run log: $RUN_LOG"
-	exit 0
+	exit 1
 fi
-
-run_tests
+emit_bold "$(printf '%-20s %s' 'Overall:' "All $iterations_run iterations passed")"
+emit "$RULE_HEAVY"
+emit "Run log: $RUN_LOG"

--- a/tests/tt_metal/tt_metal/deployment/test_runner.sh
+++ b/tests/tt_metal/tt_metal/deployment/test_runner.sh
@@ -143,7 +143,7 @@ emit_section() {
 emit_setup() {
 	if [ "$SKIP_RESET" -eq 1 ]; then using_board_resets=false; else using_board_resets=true; fi
 	if [ "${ETH_TEST_EXPECTED_LINKS:-10}" -eq 0 ]; then checking_eth_links=false; else checking_eth_links=true; fi
-	emit "$(printf '%-24s %s' 'Output:' "$LOGDIR")"
+	emit "$(printf '%-24s %s' 'Output:' "$RUN_LOG")"
 	emit "$(printf '%-24s %s' 'Number of iterations:' "$ITERATIONS")"
 	emit "$(printf '%-24s %s' 'Using board resets:' "$using_board_resets")"
 	emit "$(printf '%-24s %s' 'Continue on failure:' "$([ "$CONTINUE_ON_FAILURE" -eq 1 ] && echo true || echo false)")"
@@ -236,7 +236,6 @@ emit "$(printf '%-12s %s' 'Date:' "$(date)")"
 emit "$(printf '%-12s %s' 'Host:' "$(hostname)")"
 emit "$(printf '%-12s %s' 'Tests:' 'Ethernet, DRAM, PCIe read, PCIe write')"
 emit_setup
-emit "$(printf '%-12s %s' 'Run log:' "$RUN_LOG")"
 emit "$RULE_HEAVY"
 
 iteration_failures=0
@@ -300,9 +299,7 @@ if [ "$iteration_failures" -gt 0 ]
 then
 	emit_bold "$(printf '%-20s %s' 'Overall:' "$((iterations_run - iteration_failures))/$iterations_run iterations passed")"
 	emit "$RULE_HEAVY"
-	emit "Run log: $RUN_LOG"
 	exit 1
 fi
 emit_bold "$(printf '%-20s %s' 'Overall:' "All $iterations_run iterations passed")"
 emit "$RULE_HEAVY"
-emit "Run log: $RUN_LOG"

--- a/tests/tt_metal/tt_metal/deployment/test_runner.sh
+++ b/tests/tt_metal/tt_metal/deployment/test_runner.sh
@@ -139,6 +139,17 @@ emit_section() {
 	emit "$RULE_LIGHT"
 }
 
+# emit_setup: print the effective configuration for this run.
+emit_setup() {
+	if [ "$SKIP_RESET" -eq 1 ]; then using_board_resets=false; else using_board_resets=true; fi
+	if [ "${ETH_TEST_EXPECTED_LINKS:-10}" -eq 0 ]; then checking_eth_links=false; else checking_eth_links=true; fi
+	emit "$(printf '%-24s %s' 'Output:' "$LOGDIR")"
+	emit "$(printf '%-24s %s' 'Number of iterations:' "$ITERATIONS")"
+	emit "$(printf '%-24s %s' 'Using board resets:' "$using_board_resets")"
+	emit "$(printf '%-24s %s' 'Continue on failure:' "$([ "$CONTINUE_ON_FAILURE" -eq 1 ] && echo true || echo false)")"
+	emit "$(printf '%-24s %s' 'Checking eth links:' "$checking_eth_links")"
+}
+
 # emit_status <text> <passed|failed>: print a line ending in a pass/fail verdict.
 emit_status() {
 	case "$2" in
@@ -220,18 +231,11 @@ run_tests() {
 	return 0
 }
 
-if [ "$SKIP_RESET" -eq 1 ]
-then
-	MODE="$ITERATIONS iteration(s), no board reset"
-else
-	MODE="$ITERATIONS iteration(s), $RESET_CMD before each"
-fi
-
 emit_banner "DEPLOYMENT TESTS RUN"
 emit "$(printf '%-12s %s' 'Date:' "$(date)")"
 emit "$(printf '%-12s %s' 'Host:' "$(hostname)")"
 emit "$(printf '%-12s %s' 'Tests:' 'Ethernet, DRAM, PCIe read, PCIe write')"
-emit "$(printf '%-12s %s' 'Mode:' "$MODE")"
+emit_setup
 emit "$(printf '%-12s %s' 'Run log:' "$RUN_LOG")"
 emit "$RULE_HEAVY"
 
@@ -284,6 +288,7 @@ done
 
 emit_banner "DEPLOYMENT TEST SUITE - RESULTS SUMMARY (${iterations_run}/${ITERATIONS} iterations ran)"
 emit "$(printf '%-20s %s' 'Host:'            "$(hostname)")"
+emit_setup
 emit "$RULE_LIGHT"
 emit "$(printf '%-20s %s' 'Board resets:'     "$((iterations_run - reset_failures))/$iterations_run iterations passed")"
 emit "$(printf '%-20s %s' 'Ethernet tests:'  "$eth_pass/$iterations_run iterations passed")"

--- a/tests/tt_metal/tt_metal/deployment/test_runner.sh
+++ b/tests/tt_metal/tt_metal/deployment/test_runner.sh
@@ -156,15 +156,16 @@ run_logged() {
 	rc="$(cat "$RCFILE")"
 }
 
-# run_reset <message>: reset the boards, aborting the run if the reset fails.
+# run_reset <message>: reset the boards and return its exit status.
 run_reset() {
 	emit_section "$1"
 	run_logged $RESET_CMD
 	if [ "$rc" -ne 0 ]
 	then
 		emit "Reset failed (exit code $rc)"
-		exit "$rc"
+		return "$rc"
 	fi
+	return 0
 }
 
 # run_test <label> <command...>: runs a test once and records its result.
@@ -235,6 +236,7 @@ emit "$(printf '%-12s %s' 'Run log:' "$RUN_LOG")"
 emit "$RULE_HEAVY"
 
 iteration_failures=0
+reset_failures=0
 iterations_run=0
 eth_pass=0
 dram_pass=0
@@ -244,11 +246,24 @@ pcie_write_pass=0
 for iteration in $(seq 1 "$ITERATIONS")
 do
 	emit_banner "ITERATION $iteration/$ITERATIONS"
+	reset_ok=1
 	if [ "$SKIP_RESET" -eq 0 ]
 	then
-		run_reset "Resetting boards ($RESET_CMD)..."
+		if ! run_reset "Resetting boards ($RESET_CMD)..."
+		then
+			reset_ok=0
+			reset_failures=$((reset_failures + 1))
+		fi
 	fi
-	if run_tests
+	if [ "$reset_ok" -eq 0 ]
+	then
+		last_eth_ok=0
+		last_dram_ok=0
+		last_pcie_read_ok=0
+		last_pcie_write_ok=0
+		iteration_failures=$((iteration_failures + 1))
+		emit_banner "ITERATION $iteration FAILED (reset failed)"
+	elif run_tests
 	then
 		emit_banner "ITERATION $iteration PASSED"
 	else
@@ -270,6 +285,7 @@ done
 emit_banner "DEPLOYMENT TEST SUITE - RESULTS SUMMARY (${iterations_run}/${ITERATIONS} iterations ran)"
 emit "$(printf '%-20s %s' 'Host:'            "$(hostname)")"
 emit "$RULE_LIGHT"
+emit "$(printf '%-20s %s' 'Reset failures:'   "$reset_failures/$iterations_run iterations failed")"
 emit "$(printf '%-20s %s' 'Ethernet tests:'  "$eth_pass/$iterations_run iterations passed")"
 emit "$(printf '%-20s %s' 'DRAM tests:'      "$dram_pass/$iterations_run iterations passed")"
 emit "$(printf '%-20s %s' 'PCIe read test:'  "$pcie_read_pass/$iterations_run iterations passed")"

--- a/tests/tt_metal/tt_metal/deployment/test_runner.sh
+++ b/tests/tt_metal/tt_metal/deployment/test_runner.sh
@@ -285,7 +285,7 @@ done
 emit_banner "DEPLOYMENT TEST SUITE - RESULTS SUMMARY (${iterations_run}/${ITERATIONS} iterations ran)"
 emit "$(printf '%-20s %s' 'Host:'            "$(hostname)")"
 emit "$RULE_LIGHT"
-emit "$(printf '%-20s %s' 'Reset failures:'   "$reset_failures/$iterations_run iterations failed")"
+emit "$(printf '%-20s %s' 'Board resets:'     "$((iterations_run - reset_failures))/$iterations_run iterations passed")"
 emit "$(printf '%-20s %s' 'Ethernet tests:'  "$eth_pass/$iterations_run iterations passed")"
 emit "$(printf '%-20s %s' 'DRAM tests:'      "$dram_pass/$iterations_run iterations passed")"
 emit "$(printf '%-20s %s' 'PCIe read test:'  "$pcie_read_pass/$iterations_run iterations passed")"


### PR DESCRIPTION
### Summary
Updated the deployment test wrapper with consistent logging, configurable iteration behavior through flags, and support for partially cabled systems.

### Usage

`./tests/tt_metal/tt_metal/deployment/test_runner.sh [options]`

Options
--output <logdir>: Write the timestamped run log to the specified directory. Defaults to the current directory.
--iterations <n>: Set the number of iterations. Defaults to 5.
--skip-reset: Skip the board reset before each iteration.
--continue-on-failure: Run all requested iterations instead of stopping after the first failed iteration.
--no-eth-links: Disable the expected Ethernet-link-count check for partially cabled systems.
-h: Display usage information.

#### Fix env var override to allow eth tests to skip QSFP checks (when machine is not cabled for this test)
- Changed env["ETH_TEST_EXPECTED_LINKS"] = str(10) to env["ETH_TEST_EXPECTED_LINKS"] = os.environ.get("ETH_TEST_EXPECTED_LINKS", str(10)) to allow overriding the expected link count while still defaulting to 10 when not set

