### PR TITLE
Expose MGD-inferred fabric type to Python (get_all_mgd_fabric_types)

### DIFF
--- a/tests/tt_metal/tt_fabric/fabric_router/test_mesh_graph_descriptor.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_mesh_graph_descriptor.cpp
@@ -132,6 +132,32 @@ void check_connections(
         }
     }
 }
+
+// Mirror of internal::get_all_mgd_fabric_types(): pull each mesh instance's MeshDescriptor out
+// of the parsed MGD and infer its FabricType from the wired dim_types, one entry per mesh.
+std::vector<FabricType> infer_fabric_types(const MeshGraphDescriptor& desc) {
+    std::vector<FabricType> types;
+    for (const auto mesh : desc.all_meshes()) {
+        const auto& instance = desc.get_instance(mesh);
+        const auto* mesh_desc = std::get<const proto::MeshDescriptor*>(instance.desc);
+        types.push_back(MeshGraphDescriptor::infer_fabric_type_from_dim_types(mesh_desc));
+    }
+    return types;
+}
+
+std::string single_mesh_proto(const std::string& dim_types) {
+    return R"proto(
+               mesh_descriptors: { name: "M0" arch: WORMHOLE_B0
+                                   device_topology: { dims: [ 4, 4 ]
+                                                      dim_types:)proto" +
+           dim_types + R"proto(
+        }
+        channels: { count: 1 }
+          host_topology: { dims: [ 1, 1 ] }
+        }
+        top_level_instance: { mesh: { mesh_descriptor: "M0" mesh_id: 0 } }
+    )proto";
+}
 }
 
 namespace tt::tt_fabric::fabric_router_tests {
@@ -169,6 +195,74 @@ TEST(MeshGraphDescriptorTests, ParsesBhGalaxySp4TorusXY) {
     const std::filesystem::path text_proto_file_path =
         "tt_metal/fabric/mesh_graph_descriptors/bh_galaxy_sp4_torus_xy_graph_descriptor.textproto";
     EXPECT_NO_THROW(MeshGraphDescriptor desc(text_proto_file_path));
+}
+
+// Covers the dim_types -> FabricType inference behind get_all_mgd_fabric_types() (the Python API
+// exposed in tt-blaze). dim_types are [Y, X]; a RING axis makes that axis a torus.
+TEST(MeshGraphDescriptorTests, InferFabricTypeFromDimTypes) {
+    struct Case {
+        std::string dim_types;
+        FabricType expected;
+    };
+    const std::vector<Case> cases = {
+        {"[ LINE, LINE ]", FabricType::MESH},
+        {"[ LINE, RING ]", FabricType::TORUS_X},
+        {"[ RING, LINE ]", FabricType::TORUS_Y},
+        {"[ RING, RING ]", FabricType::TORUS_XY},
+    };
+    for (const auto& c : cases) {
+        MeshGraphDescriptor desc(single_mesh_proto(c.dim_types));
+        const auto types = infer_fabric_types(desc);
+        ASSERT_EQ(types.size(), 1u) << "dim_types " << c.dim_types;
+        EXPECT_EQ(types[0], c.expected) << "dim_types " << c.dim_types;
+    }
+}
+
+// One FabricType per compute mesh: a graph of two meshes with different topologies must yield
+// both meshes' inferred types.
+TEST(MeshGraphDescriptorTests, InferFabricTypePerMeshInMultiMeshGraph) {
+    const std::string text_proto = R"proto(
+        mesh_descriptors: {
+          name: "M_TX"
+          arch: WORMHOLE_B0
+          device_topology: {
+            dims: [ 4, 4 ]
+            dim_types: [ LINE, RING ]
+          }
+          channels: { count: 1 }
+          host_topology: { dims: [ 1, 1 ] }
+        }
+        mesh_descriptors: {
+          name: "M_TY"
+          arch: WORMHOLE_B0
+          device_topology: {
+            dims: [ 4, 4 ]
+            dim_types: [ RING, LINE ]
+          }
+          channels: { count: 1 }
+          host_topology: { dims: [ 1, 1 ] }
+        }
+
+        graph_descriptors: {
+          name: "G0"
+          type: "FABRIC"
+          instances: { mesh: { mesh_descriptor: "M_TX" mesh_id: 0 } }
+          instances: { mesh: { mesh_descriptor: "M_TY" mesh_id: 1 } }
+          connections: {
+            nodes: { mesh: { mesh_descriptor: "M_TX" mesh_id: 0 } }
+            nodes: { mesh: { mesh_descriptor: "M_TY" mesh_id: 1 } }
+            channels: { count: 1 }
+          }
+        }
+
+        top_level_instance: { graph: { graph_descriptor: "G0" graph_id: 0 } }
+    )proto";
+
+    MeshGraphDescriptor desc(text_proto);
+    const auto types = infer_fabric_types(desc);
+    ASSERT_EQ(types.size(), 2u) << "one FabricType per compute mesh";
+    const std::set<FabricType> got(types.begin(), types.end());
+    EXPECT_EQ(got, (std::set<FabricType>{FabricType::TORUS_X, FabricType::TORUS_Y}));
 }
 
 TEST(MeshGraphDescriptorTests, InvalidProtoNoMeshDescriptors) {

--- a/tests/ttnn/unit_tests/base_functionality/test_fabric_type_binding.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_fabric_type_binding.py
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""Device-free checks for the FabricType binding and the get_all_mgd_fabric_types export.
+
+The dim_types -> FabricType inference itself is covered by the C++ offline test
+(test_mesh_graph_descriptor.cpp). These guard the Python surface: that both symbols are
+exported from ttnn and that the enum keeps its expected members and bitflag relationship,
+so a binding/enum regression is caught before the Blaze consumer relies on it.
+"""
+
+import ttnn
+
+
+def test_fabric_type_exported():
+    for name in ("MESH", "TORUS_X", "TORUS_Y", "TORUS_XY"):
+        assert hasattr(ttnn.FabricType, name), f"ttnn.FabricType missing {name}"
+
+
+def test_fabric_type_is_bitflag():
+    # Bound with nb::is_arithmetic(); TORUS_XY is the OR of the single-axis torus flags.
+    assert int(ttnn.FabricType.TORUS_XY) == int(ttnn.FabricType.TORUS_X) | int(ttnn.FabricType.TORUS_Y)
+
+
+def test_get_all_mgd_fabric_types_exported():
+    assert callable(ttnn.get_all_mgd_fabric_types)

--- a/tt_metal/api/tt-metalium/experimental/fabric/fabric.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/fabric.hpp
@@ -122,6 +122,8 @@ std::vector<chan_id_t> get_active_fabric_eth_routing_planes_in_direction(
 
 std::unordered_map<MeshId, tt::tt_metal::distributed::MeshShape> get_physical_mesh_shapes();
 
+std::vector<FabricType> get_all_mgd_fabric_types();
+
 tt::tt_fabric::Topology get_fabric_topology();
 
 struct FabricEriscDatamoverKernelConfig {

--- a/tt_metal/api/tt-metalium/internal/fabric.hpp
+++ b/tt_metal/api/tt-metalium/internal/fabric.hpp
@@ -67,6 +67,4 @@ void append_routing_plane_connection_rt_args_no_defines(
 // returns the local rank's meshes). Intended for inter-mesh topology discovery.
 std::vector<tt::tt_fabric::MeshId> get_all_fabric_mesh_ids();
 
-std::vector<tt::tt_fabric::FabricType> get_all_mgd_fabric_types();
-
 }  // namespace tt::tt_metal::internal

--- a/tt_metal/api/tt-metalium/internal/fabric.hpp
+++ b/tt_metal/api/tt-metalium/internal/fabric.hpp
@@ -67,4 +67,6 @@ void append_routing_plane_connection_rt_args_no_defines(
 // returns the local rank's meshes). Intended for inter-mesh topology discovery.
 std::vector<tt::tt_fabric::MeshId> get_all_fabric_mesh_ids();
 
+std::vector<tt::tt_fabric::FabricType> get_all_mgd_fabric_types();
+
 }  // namespace tt::tt_metal::internal

--- a/tt_metal/fabric/fabric.cpp
+++ b/tt_metal/fabric/fabric.cpp
@@ -95,6 +95,18 @@ std::unordered_map<MeshId, MeshShape> get_physical_mesh_shapes() {
     return mesh_shapes;
 }
 
+std::vector<FabricType> get_all_mgd_fabric_types() {
+    const auto& mesh_graph = tt::tt_metal::MetalContext::instance().get_control_plane().get_mesh_graph();
+    const auto& mgd = mesh_graph.get_mesh_graph_descriptor();
+    std::vector<FabricType> fabric_types;
+    for (const auto mesh : mgd.all_meshes()) {
+        const auto& instance = mgd.get_instance(mesh);
+        const auto* mesh_desc = std::get<const proto::MeshDescriptor*>(instance.desc);
+        fabric_types.push_back(MeshGraphDescriptor::infer_fabric_type_from_dim_types(mesh_desc));
+    }
+    return fabric_types;
+}
+
 #if defined(TT_METAL_USE_EMULE)
 // emule has no fabric router, so the device-L1 connection table is never populated. Record the
 // fwd/bwd-to-neighbor binding host-side for the teleport's 1D dst resolution. Defined in the emule runner.
@@ -649,18 +661,6 @@ namespace tt::tt_metal::internal {
 
 std::vector<tt::tt_fabric::MeshId> get_all_fabric_mesh_ids() {
     return tt::tt_metal::MetalContext::instance().get_control_plane().get_mesh_graph().get_mesh_ids();
-}
-
-std::vector<tt::tt_fabric::FabricType> get_all_mgd_fabric_types() {
-    const auto& mesh_graph = tt::tt_metal::MetalContext::instance().get_control_plane().get_mesh_graph();
-    const auto& mgd = mesh_graph.get_mesh_graph_descriptor();
-    std::vector<tt::tt_fabric::FabricType> fabric_types;
-    for (const auto mesh : mgd.all_meshes()) {
-        const auto& instance = mgd.get_instance(mesh);
-        const auto* mesh_desc = std::get<const tt::tt_fabric::proto::MeshDescriptor*>(instance.desc);
-        fabric_types.push_back(tt::tt_fabric::MeshGraphDescriptor::infer_fabric_type_from_dim_types(mesh_desc));
-    }
-    return fabric_types;
 }
 
 // Query the kernel defines required by the current fabric configuration.

--- a/tt_metal/fabric/fabric.cpp
+++ b/tt_metal/fabric/fabric.cpp
@@ -10,6 +10,7 @@
 #include <tt-metalium/experimental/fabric/fabric.hpp>
 #include <tt-metalium/internal/fabric.hpp>
 #include <tt-metalium/experimental/fabric/mesh_graph.hpp>
+#include <tt-metalium/experimental/fabric/mesh_graph_descriptor.hpp>
 #include <tt_stl/assert.hpp>
 #include <tt-metalium/experimental/fabric/control_plane.hpp>
 #include <tt-metalium/mesh_device.hpp>
@@ -648,6 +649,18 @@ namespace tt::tt_metal::internal {
 
 std::vector<tt::tt_fabric::MeshId> get_all_fabric_mesh_ids() {
     return tt::tt_metal::MetalContext::instance().get_control_plane().get_mesh_graph().get_mesh_ids();
+}
+
+std::vector<tt::tt_fabric::FabricType> get_all_mgd_fabric_types() {
+    const auto& mesh_graph = tt::tt_metal::MetalContext::instance().get_control_plane().get_mesh_graph();
+    const auto& mgd = mesh_graph.get_mesh_graph_descriptor();
+    std::vector<tt::tt_fabric::FabricType> fabric_types;
+    for (const auto mesh : mgd.all_meshes()) {
+        const auto& instance = mgd.get_instance(mesh);
+        const auto* mesh_desc = std::get<const tt::tt_fabric::proto::MeshDescriptor*>(instance.desc);
+        fabric_types.push_back(tt::tt_fabric::MeshGraphDescriptor::infer_fabric_type_from_dim_types(mesh_desc));
+    }
+    return fabric_types;
 }
 
 // Query the kernel defines required by the current fabric configuration.

--- a/ttnn/cpp/ttnn-nanobind/fabric.cpp
+++ b/ttnn/cpp/ttnn-nanobind/fabric.cpp
@@ -389,7 +389,7 @@ void bind_fabric_api(nb::module_& mod) {
 
     mod.def(
         "get_all_mgd_fabric_types",
-        &tt::tt_metal::internal::get_all_mgd_fabric_types,
+        &tt::tt_fabric::get_all_mgd_fabric_types,
         R"(
             Returns the FabricType each compute mesh's dim_types imply, one entry per mesh in
             the active mesh graph descriptor. Callers can map these to a FabricConfig to match

--- a/ttnn/cpp/ttnn-nanobind/fabric.cpp
+++ b/ttnn/cpp/ttnn-nanobind/fabric.cpp
@@ -67,6 +67,12 @@ void bind_fabric_api(nb::module_& mod) {
         .value(
             "CUSTOM", tt::tt_fabric::FabricConfig::CUSTOM);  // DISABLED = 0, FABRIC_1D = 1, FABRIC_2D = 2, CUSTOM = 4
 
+    nb::enum_<tt::tt_fabric::FabricType>(mod, "FabricType", nb::is_arithmetic())
+        .value("MESH", tt::tt_fabric::FabricType::MESH)
+        .value("TORUS_X", tt::tt_fabric::FabricType::TORUS_X)
+        .value("TORUS_Y", tt::tt_fabric::FabricType::TORUS_Y)
+        .value("TORUS_XY", tt::tt_fabric::FabricType::TORUS_XY);
+
     // custom mapping here for interface stability
     nb::enum_<tt::tt_fabric::FabricReliabilityMode>(mod, "FabricReliabilityMode", R"(
         Specifies how the fabric initialization handles system health and configuration.
@@ -379,6 +385,15 @@ void bind_fabric_api(nb::module_& mod) {
 
             Unlike get_user_physical_mesh_ids (which is scoped to the local rank's meshes),
             this enumerates peer meshes as well, enabling multi-mesh topology discovery.
+        )");
+
+    mod.def(
+        "get_all_mgd_fabric_types",
+        &tt::tt_metal::internal::get_all_mgd_fabric_types,
+        R"(
+            Returns the FabricType each compute mesh's dim_types imply, one entry per mesh in
+            the active mesh graph descriptor. Callers can map these to a FabricConfig to match
+            the wired topology (RING/LINE) instead of inferring it from process count.
         )");
 }
 

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -164,6 +164,7 @@ from ttnn._ttnn.global_circular_buffer import (
 
 from ttnn._ttnn.fabric import (
     FabricConfig,
+    FabricType,
     FabricReliabilityMode,
     FabricTensixConfig,
     FabricUDMMode,
@@ -176,6 +177,7 @@ from ttnn._ttnn.fabric import (
     get_physical_mesh_shapes,
     get_eth_forwarding_direction,
     get_all_fabric_mesh_ids,
+    get_all_mgd_fabric_types,
     MeshId,
     FabricNodeId,
     setup_fabric_connection,


### PR DESCRIPTION

Expose the MGD-inferred fabric topology (RING/LINE per dimension) to Python so callers can select a `FabricConfig` from the wired topology instead of the MPI process count.

#### Why
- Blaze's CLI infers `FabricConfig` from `num_procs` ( `num_procs in (16, 40, 64, 80)`). a single galaxy can be represented with different mesh counts, and process count doesn't encode RING vs LINE.
- The determining signal is the MGD's `dim_types`, which isn't reachable from Python today. Exposing it lets the CLI pick the fabric that matches the topology.

#### Key changes
- Add `tt::tt_metal::internal::get_all_mgd_fabric_types()`: the `FabricType` each compute mesh's `dim_types` imply, one entry per mesh. Reuses `MeshGraphDescriptor::infer_fabric_type_from_dim_types` and reaches the active MGD via the control plane (same path as `get_all_fabric_mesh_ids`).
- Bind `FabricType` (`MESH / TORUS_X / TORUS_Y / TORUS_XY`) and the new function in `ttnn`.

#### Notes
- Throws if there is no active MGD (same assumption as `get_all_fabric_mesh_ids`).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nkodkani/get-all-mgd-fabric-types)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nkodkani/get-all-mgd-fabric-types)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nkodkani/get-all-mgd-fabric-types)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nkodkani/get-all-mgd-fabric-types)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=nkodkani/get-all-mgd-fabric-types)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:nkodkani/get-all-mgd-fabric-types)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nkodkani/get-all-mgd-fabric-types)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nkodkani/get-all-mgd-fabric-types)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nkodkani/get-all-mgd-fabric-types)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nkodkani/get-all-mgd-fabric-types)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nkodkani/get-all-mgd-fabric-types)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nkodkani/get-all-mgd-fabric-types)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nkodkani/get-all-mgd-fabric-types)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nkodkani/get-all-mgd-fabric-types)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nkodkani/get-all-mgd-fabric-types)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nkodkani/get-all-mgd-fabric-types)