### PR TITLE
[Feature][Profiler] Bringup `DeviceTimestampedData` + `DeviceRecordEvent` on quasar

### DIFF
--- a/tests/tt_metal/tools/profiler/test_device_profiler.py
+++ b/tests/tt_metal/tools/profiler/test_device_profiler.py
@@ -1119,21 +1119,34 @@ def test_timestamped_events():
         for E in BH_ERISC_COUNTS:
             BH_COMBO_COUNTS.append((T, E))
 
+    # Quasar's profiler is L1-only, the buffer fills and remaining markers are dropped, only the
+    # iterations that fit are captured. Each iteration writes 10 words (zone start + TS_DATA +
+    # TS_EVENT + zone end), so (PROFILER_L1_VECTOR_SIZE - CUSTOM_MARKERS) / 10 = 500 / 10 = 50
+    # iterations per risc, each contributing two event markers.
+    QUASAR_RISC_COUNT = 6 + 4 * 4  # DM2-7 + Neo0-3 * TRISC0-3
+    QUASAR_ITER_COUNT = 50
+    QUASAR_EVENTS_PER_ITER = 2  # DeviceTimestampedData + DeviceRecordEvent
+
     REF_COUNT_DICT = {
         "wormhole_b0": [(T * RISC_COUNT + E) * OP_COUNT * ZONE_COUNT for T, E in WH_COMBO_COUNTS],
         "blackhole": [(T * RISC_COUNT + E) * OP_COUNT * ZONE_COUNT for T, E in BH_COMBO_COUNTS],
+        # Note: using emu-quasar-2x3_DISPATCH for both dispatch modes
+        "quasar": [2 * QUASAR_RISC_COUNT * QUASAR_ITER_COUNT * QUASAR_EVENTS_PER_ITER],
     }
     REF_ERISC_COUNT = {
         "wormhole_b0": [C * OP_COUNT * ZONE_COUNT for C in WH_ERISC_COUNTS],
         "blackhole": [C * OP_COUNT * ZONE_COUNT for C in BH_ERISC_COUNTS],
     }
+    TEST_BIN_DICT = {
+        "wormhole_b0": "build/test/tt_metal/tools/profiler/test_timestamped_events",
+        "blackhole": "build/test/tt_metal/tools/profiler/test_timestamped_events",
+        "quasar": "build/programming_examples/profiler/test_timestamped_events",
+    }
 
     ENV_VAR_ARCH_NAME = os.getenv("ARCH_NAME")
     assert ENV_VAR_ARCH_NAME in REF_COUNT_DICT.keys()
 
-    devicesData = run_device_profiler_test(
-        testName="build/test/tt_metal/tools/profiler/test_timestamped_events", setupAutoExtract=True
-    )
+    devicesData = run_device_profiler_test(testName=TEST_BIN_DICT[ENV_VAR_ARCH_NAME], setupAutoExtract=True)
 
     if ENV_VAR_ARCH_NAME in REF_ERISC_COUNT.keys():
         eventCount = len(

--- a/tt_metal/programming_examples/profiler/test_timestamped_events/test_timestamped_events.cpp
+++ b/tt_metal/programming_examples/profiler/test_timestamped_events/test_timestamped_events.cpp
@@ -3,13 +3,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <cstdint>
-#include <map>
 #include <string>
 #include <vector>
 
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/device.hpp>
 #include <tt-metalium/distributed.hpp>
+#include <tt-metalium/tt_metal_profiler.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program.hpp>
 
 using namespace tt;
 using namespace tt::tt_metal;
@@ -17,45 +19,96 @@ using namespace tt::tt_metal;
 void RunFillUpAllBuffers(
     const std::shared_ptr<distributed::MeshDevice>& mesh_device, int loop_count, bool fast_dispatch) {
     CoreCoord compute_with_storage_size = mesh_device->compute_with_storage_grid_size();
-    CoreCoord start_core = {0, 0};
-    CoreCoord end_core = {compute_with_storage_size.x - 1, compute_with_storage_size.y - 1};
-    CoreRange all_cores(start_core, end_core);
+    const experimental::NodeRange all_nodes(
+        experimental::NodeCoord{0, 0},
+        experimental::NodeCoord{compute_with_storage_size.x - 1, compute_with_storage_size.y - 1});
 
     // Mesh workload + device range span the mesh; program encapsulates kernels
     distributed::MeshWorkload workload;
     distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(mesh_device->shape());
-    tt_metal::Program program = tt_metal::CreateProgram();
 
     constexpr int loop_size = 200;
     constexpr int enqueue_times = 2;
-    std::map<std::string, std::string> kernel_defines = {
+    const experimental::KernelSpec::CompilerOptions::Defines defines = {
         {"LOOP_COUNT", std::to_string(loop_count)}, {"LOOP_SIZE", std::to_string(loop_size)}};
 
-    tt_metal::CreateKernel(
-        program,
-        "tt_metal/programming_examples/profiler/test_timestamped_events/kernels/timestamped_events.cpp",
-        all_cores,
-        tt_metal::DataMovementConfig{
-            .processor = tt_metal::DataMovementProcessor::RISCV_0,
-            .noc = tt_metal::NOC::RISCV_0_default,
-            .defines = kernel_defines});
-    tt_metal::CreateKernel(
-        program,
-        "tt_metal/programming_examples/profiler/test_timestamped_events/kernels/timestamped_events.cpp",
-        all_cores,
-        tt_metal::DataMovementConfig{
-            .processor = tt_metal::DataMovementProcessor::RISCV_1,
-            .noc = tt_metal::NOC::RISCV_1_default,
-            .defines = kernel_defines});
-    std::vector<uint32_t> trisc_kernel_args = {};
-    tt_metal::CreateKernel(
-        program,
-        "tt_metal/programming_examples/profiler/test_timestamped_events/kernels/timestamped_events_compute.cpp",
-        all_cores,
-        tt_metal::ComputeConfig{.compile_args = trisc_kernel_args, .defines = kernel_defines});
+    const std::string dm_src =
+        "tt_metal/programming_examples/profiler/test_timestamped_events/kernels/timestamped_events.cpp";
+    const std::string compute_src =
+        "tt_metal/programming_examples/profiler/test_timestamped_events/kernels/timestamped_events_compute.cpp";
+
+    std::vector<experimental::KernelSpec> kernel_specs;
+    std::vector<experimental::KernelSpecName> wu_kernels;
+    if (mesh_device->arch() == tt::ARCH::QUASAR) {
+        const experimental::KernelSpecName DM_KERNEL{"timestamped_events_dm"};
+        const experimental::KernelSpecName COMPUTE_KERNEL{"timestamped_events_compute"};
+        kernel_specs = {
+            experimental::KernelSpec{
+                .unique_id = DM_KERNEL,
+                .source = dm_src,
+                .num_threads = 6,
+                .compiler_options = {.defines = defines},
+                .hw_config = experimental::DataMovementHardwareConfig{experimental::DataMovementGen2Config{}},
+            },
+            experimental::KernelSpec{
+                .unique_id = COMPUTE_KERNEL,
+                .source = compute_src,
+                .num_threads = 4,
+                .compiler_options = {.defines = defines},
+                .hw_config = experimental::ComputeGen2Config{},
+            },
+        };
+        wu_kernels = {DM_KERNEL, COMPUTE_KERNEL};
+    } else {
+        const experimental::KernelSpecName BRISC_KERNEL{"timestamped_events_brisc"};
+        const experimental::KernelSpecName NCRISC_KERNEL{"timestamped_events_ncrisc"};
+        const experimental::KernelSpecName COMPUTE_KERNEL{"timestamped_events_compute"};
+        kernel_specs = {
+            experimental::KernelSpec{
+                .unique_id = BRISC_KERNEL,
+                .source = dm_src,
+                .num_threads = 1,
+                .compiler_options = {.defines = defines},
+                .hw_config = experimental::DataMovementHardwareConfig{experimental::DataMovementGen1Config{
+                    .processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default}},
+            },
+            experimental::KernelSpec{
+                .unique_id = NCRISC_KERNEL,
+                .source = dm_src,
+                .num_threads = 1,
+                .compiler_options = {.defines = defines},
+                .hw_config = experimental::DataMovementHardwareConfig{experimental::DataMovementGen1Config{
+                    .processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default}},
+            },
+            experimental::KernelSpec{
+                .unique_id = COMPUTE_KERNEL,
+                .source = compute_src,
+                .num_threads = 1,
+                .compiler_options = {.defines = defines},
+                .hw_config = experimental::ComputeGen1Config{},
+            },
+        };
+        wu_kernels = {BRISC_KERNEL, NCRISC_KERNEL, COMPUTE_KERNEL};
+    }
+
+    experimental::WorkUnitSpec wu{
+        .name = "timestamped_events",
+        .kernels = wu_kernels,
+        .target_nodes = all_nodes,
+    };
+    experimental::ProgramSpec spec{
+        .name = "timestamped_events",
+        .kernels = kernel_specs,
+        .work_units = {wu},
+    };
+
+    Program program = experimental::MakeProgramFromSpec(*mesh_device, spec);
+    experimental::ProgramRunArgs params;  // kernels take no runtime args
+    experimental::SetProgramRunArgs(program, params);
 
     workload.add_program(device_range, std::move(program));
-    if (fast_dispatch) {
+    // One enqueue is enough to fill the L1 profiler buffer on Quasar
+    if (fast_dispatch && mesh_device->arch() != tt::ARCH::QUASAR) {
         for (int i = 0; i < enqueue_times; i++) {
             // Enqueue the same mesh workload multiple times to generate profiler events
             distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), workload, false);

--- a/tt_metal/tools/profiler/kernel_profiler.hpp
+++ b/tt_metal/tools/profiler/kernel_profiler.hpp
@@ -916,9 +916,10 @@ inline __attribute__((always_inline)) void timeStampedData(uint64_t data, Args..
         expected_size == 0 || total_data_count == expected_size,
         "Number of arguments does not match expected size for this PacketType");
 
-    constexpr uint32_t additional_slots = sizeof...(trailers);
+    // Total number of words to write: 2 for the marker + 2 for each trailer
+    constexpr uint32_t words_written = PROFILER_L1_MARKER_UINT32_SIZE * (2 + sizeof...(trailers));
 
-    if (bufferHasRoom<dispatch>(additional_slots)) {
+    if (bufferHasRoom<dispatch>(words_written - 1)) {
         mark_time_at_index_inlined(wIndex, get_const_id(data_id, packet_type));
         wIndex += PROFILER_L1_MARKER_UINT32_SIZE;
 

--- a/tt_metal/tools/profiler/kernel_profiler.hpp
+++ b/tt_metal/tools/profiler/kernel_profiler.hpp
@@ -916,7 +916,7 @@ inline __attribute__((always_inline)) void timeStampedData(uint64_t data, Args..
         expected_size == 0 || total_data_count == expected_size,
         "Number of arguments does not match expected size for this PacketType");
 
-    // Total number of words to write: 2 for the marker + 2 for each trailer
+    // Total number of words to write: 2 for the marker + 2 for the data + 2 for each trailer
     constexpr uint32_t words_written = PROFILER_L1_MARKER_UINT32_SIZE * (2 + sizeof...(trailers));
 
     if (bufferHasRoom<dispatch>(words_written - 1)) {


### PR DESCRIPTION
### PR Category
Feature

### Summary
Relates to #48927 
Fixed a latent bug with not reserving sufficient room for timestamped data.
Updated the test_timestamped_events programming example and the expected numbers on quasar

Testing

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-profiler.yaml/badge.svg?branch=shengxiangji/profiler-timestamp-48927)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-profiler.yaml?query=branch:shengxiangji/profiler-timestamp-48927)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml/badge.svg?branch=shengxiangji/profiler-timestamp-48927)](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml?query=branch:shengxiangji/profiler-timestamp-48927)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=shengxiangji/profiler-timestamp-48927)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:shengxiangji/profiler-timestamp-48927)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=shengxiangji/profiler-timestamp-48927)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:shengxiangji/profiler-timestamp-48927)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=shengxiangji/profiler-timestamp-48927)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:shengxiangji/profiler-timestamp-48927)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=shengxiangji/profiler-timestamp-48927)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:shengxiangji/profiler-timestamp-48927)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=shengxiangji/profiler-timestamp-48927)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:shengxiangji/profiler-timestamp-48927)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=shengxiangji/profiler-timestamp-48927)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:shengxiangji/profiler-timestamp-48927)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=shengxiangji/profiler-timestamp-48927)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:shengxiangji/profiler-timestamp-48927)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=shengxiangji/profiler-timestamp-48927)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:shengxiangji/profiler-timestamp-48927)