### PR TITLE
Avoid optimized sharded tilize for row-major tiny-tile inputs

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_device_operation.cpp
@@ -59,6 +59,10 @@ bool can_use_sharded_optimized_factories(
         return false;
     }
 
+    if (input_tensor.layout() == Layout::ROW_MAJOR && operation_attributes.tile.get_height() < tt::constants::TILE_HEIGHT) {
+        return false;
+    }
+
     if (memory_layout == TensorMemoryLayout::WIDTH_SHARDED) {
         if (operation_attributes.output_mem_config.memory_layout() == TensorMemoryLayout::ND_SHARDED ||
             operation_attributes.output_mem_config.memory_layout() == TensorMemoryLayout::INTERLEAVED) {


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
The sharded optimized tilize factory was being selected for row-major inputs using tiny tiles, which aliases the input shard buffer directly as a tile circular buffer even though that layout does not provide the tile-page geometry the unpacker expects. This can make the generated kernel read past the valid shard data for cases such as row-major `FLOAT32` tilize to an 8x32 tile with width sharding. The change adds a narrow factory-selection guard so row-major inputs with sub-32 tile height use the default tilize program factory instead. That path stages row-major data explicitly through the reader before unpacking, so the unpacker sees a valid tile-shaped stream while the existing optimized path remains available for full-height tiles and other already-supported sharded tilize cases.

### Notes for reviewers
none

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mcraighead/sharded-tilize)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mcraighead/sharded-tilize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mcraighead/sharded-tilize)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mcraighead/sharded-tilize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mcraighead/sharded-tilize)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mcraighead/sharded-tilize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mcraighead/sharded-tilize)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mcraighead/sharded-tilize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mcraighead/sharded-tilize)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mcraighead/sharded-tilize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mcraighead/sharded-tilize)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mcraighead/sharded-tilize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mcraighead/sharded-tilize)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mcraighead/sharded-tilize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mcraighead/sharded-tilize)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mcraighead/sharded-tilize)