### PR TITLE
Handle unsupported dispatch microbenchmark modes cleanly

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_pgm_dispatch.cpp
@@ -64,6 +64,8 @@ using namespace tt::tt_metal::distributed;
 
 static bool dump_test_info = false;
 
+static bool slow_dispatch_enabled() { return std::getenv("TT_METAL_SLOW_DISPATCH_MODE") != nullptr; }
+
 struct TestInfo {
     uint32_t iterations = DEFAULT_ITERATIONS;
     uint32_t warmup_iterations = DEFAULT_WARMUP_ITERATIONS;
@@ -1058,8 +1060,17 @@ int main(int argc, char** argv) {
     if (test_args::has_command_option(input_args, "--custom")) {
         TestInfo info;
         init(input_args, info);
+        if (info.use_trace && slow_dispatch_enabled()) {
+            log_info(tt::LogTest, "Trace capture is not supported for slow dispatch; skipping test");
+            return 0;
+        }
         FakeBenchmarkState state;
         return pgm_dispatch(state, info);
+    }
+
+    if (slow_dispatch_enabled()) {
+        log_info(tt::LogTest, "Program dispatch trace benchmarks are not supported for slow dispatch; skipping suite");
+        return 0;
     }
 
     if (test_args::has_command_option(input_args, "--dump-test-info")) {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -464,6 +464,9 @@ protected:
 
     void SetUp() override {
         BaseTestFixture::SetUp();
+        if (IsSkipped()) {
+            return;
+        }
         dram_base_ = device_->allocator_impl()->get_base_allocator_addr(HalMemType::DRAM);
         num_banks_ = device_->allocator_impl()->get_num_banks(BufferType::DRAM);
         l1_alignment_ = tt::tt_metal::MetalContext::instance().hal().get_alignment(HalMemType::L1);
@@ -1998,6 +2001,9 @@ protected:
 
     void SetUp() override {
         BasePrefetcherTestFixture::SetUp();
+        if (IsSkipped()) {
+            return;
+        }
         if (mesh_device_->num_devices() < 2) {
             GTEST_SKIP() << "Skipping RelayLinearHTest: need MMIO+remote pair in mesh";
         }


### PR DESCRIPTION
### PR Category
Test Only

### Summary
Two dispatch perf microbenchmarks were failing in configurations where the test body was not actually runnable. The prefetcher fixture could mark itself skipped in its base setup, but derived setup continued anyway and dereferenced device state that was not valid after the skip path, leading to a segfault instead of a clean skip. The program-dispatch trace benchmarks also attempted trace capture under slow dispatch even though that mode is explicitly unsupported, causing each benchmark case to fail slowly. The change makes derived prefetcher setup return immediately after a base-fixture skip and makes the program-dispatch benchmark exit successfully with a clear log message when trace capture is requested under slow dispatch. This keeps unsupported dispatch benchmark modes from reporting as failures while preserving the existing behavior for supported fast-dispatch runs.

### Notes for reviewers
none

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mcraighead/dispatch-unsupported)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mcraighead/dispatch-unsupported)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mcraighead/dispatch-unsupported)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mcraighead/dispatch-unsupported)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mcraighead/dispatch-unsupported)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mcraighead/dispatch-unsupported)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mcraighead/dispatch-unsupported)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mcraighead/dispatch-unsupported)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mcraighead/dispatch-unsupported)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mcraighead/dispatch-unsupported)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mcraighead/dispatch-unsupported)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mcraighead/dispatch-unsupported)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mcraighead/dispatch-unsupported)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mcraighead/dispatch-unsupported)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mcraighead/dispatch-unsupported)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mcraighead/dispatch-unsupported)