### PR TITLE
#51520: Bug fix: Exclude UInt32 from Quasar broadcast format checks

### DIFF
--- a/tt_metal/hw/inc/api/compute/bcast.h
+++ b/tt_metal/hw/inc/api/compute/bcast.h
@@ -35,7 +35,10 @@ ALWI void unary_bcast_init(uint32_t icb, uint32_t ocb, uint32_t call_line = __bu
 #if defined(TRISC_UNPACK) || defined(TRISC_MATH)
     const std::uint32_t dst_format = get_operand_dst_format(icb);
     const bool enable_unpack_to_dest = (dst_format == (std::uint32_t)DataFormat::Float32) ||
+#ifndef ARCH_QUASAR
+                                       // Quasar's DataFormat enum has no UInt32
                                        (dst_format == (std::uint32_t)DataFormat::UInt32) ||
+#endif
                                        (dst_format == (std::uint32_t)DataFormat::Int32);
 
     // Will configure A & B in similar way
@@ -89,7 +92,10 @@ ALWI void unary_bcast(uint32_t icb, uint32_t in_tile_index, uint32_t dst_tile_in
     // 32bit formats are implemented using unpack to dest, since SrcB is only 19bits wide
     const std::uint32_t dst_format = get_operand_dst_format(icb);
     const bool enable_unpack_to_dest = (dst_format == (std::uint32_t)DataFormat::Float32) ||
+#ifndef ARCH_QUASAR
+                                       // Quasar's DataFormat enum has no UInt32
                                        (dst_format == (std::uint32_t)DataFormat::UInt32) ||
+#endif
                                        (dst_format == (std::uint32_t)DataFormat::Int32);
 
     if (enable_unpack_to_dest) {
@@ -123,7 +129,10 @@ ALWI void unary_bcast_uninit(uint32_t icb) {
 #if defined(TRISC_UNPACK) || defined(TRISC_MATH)
     const std::uint32_t dst_format = get_operand_dst_format(icb);
     const bool enable_unpack_to_dest = (dst_format == (std::uint32_t)DataFormat::Float32) ||
+#ifndef ARCH_QUASAR
+                                       // Quasar's DataFormat enum has no UInt32
                                        (dst_format == (std::uint32_t)DataFormat::UInt32) ||
+#endif
                                        (dst_format == (std::uint32_t)DataFormat::Int32);
 
     UNPACK((llk_unpack_A_uninit<bcast_type>()));


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

Bug fix

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

Closes #51520 

Quasar does not support UInt32 data. Therefore put an ifndef to avoid compile time errors on Quasar. This file is reached by quasar resnet.
### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=bbradel-51520_qsr_bcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:bbradel-51520_qsr_bcast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=bbradel-51520_qsr_bcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:bbradel-51520_qsr_bcast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=bbradel-51520_qsr_bcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:bbradel-51520_qsr_bcast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bbradel-51520_qsr_bcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bbradel-51520_qsr_bcast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=bbradel-51520_qsr_bcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:bbradel-51520_qsr_bcast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bbradel-51520_qsr_bcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bbradel-51520_qsr_bcast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bbradel-51520_qsr_bcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bbradel-51520_qsr_bcast)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bbradel-51520_qsr_bcast)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bbradel-51520_qsr_bcast)