### PR TITLE
[GroupNorm][Welford] Re-land receiver store-before-signal L1 drain, using a 32-bit load

### DIFF
--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_reader_mcast_receiver_unary_gn.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_reader_mcast_receiver_unary_gn.cpp
@@ -6,6 +6,7 @@
 #include "api/dataflow/dataflow_api.h"
 #include "hostdevcommon/common_values.hpp"
 #include "welford_combine.h"
+#include "ckernel.h"
 #include "noc_parameters.h"
 #include "api/dataflow/noc.h"
 #include "api/dataflow/dataflow_buffer.h"
@@ -176,6 +177,13 @@ void kernel_main() {
             auto p_global_vars = reinterpret_cast<volatile uint16_t*>(global_vars_ptr);
             p_global_means[0] = local_result.mean;
             p_global_vars[0] = local_result.variance;
+
+            // Drain both stores into their L1 banks before signalling; the sender NoC-reads these
+            // exact addresses back, and a baby-RISC store retires before its write-request is
+            // processed (MemoryOrdering.md). A blocking load starting at the store's exact byte
+            // address orders after it and stalls until the stored value has landed.
+            ckernel::load_blocking(reinterpret_cast<volatile uint32_t*>(p_global_means));
+            ckernel::load_blocking(reinterpret_cast<volatile uint32_t*>(p_global_vars));
 
             // Signal to sender that our partial data is ready
             reduce_receiver_sem.up(noc, mcast_sender_noc_x, mcast_sender_noc_y, 1);

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_reader_mcast_receiver_unary_sharded_gn_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_reader_mcast_receiver_unary_sharded_gn_v2.cpp
@@ -6,6 +6,7 @@
 #include "api/dataflow/dataflow_api.h"
 #include "hostdevcommon/common_values.hpp"
 #include "welford_combine.h"
+#include "ckernel.h"
 #include "api/dataflow/noc.h"
 #include "api/dataflow/dataflow_buffer.h"
 #include "api/dataflow/noc_semaphore.h"
@@ -101,6 +102,13 @@ void kernel_main() {
             auto p_global_vars = reinterpret_cast<volatile uint16_t*>(global_vars_ptr);
             p_global_means[0] = local_result.mean;
             p_global_vars[0] = local_result.variance;
+
+            // Drain both stores into their L1 banks before signalling; the sender NoC-reads these
+            // exact addresses back, and a baby-RISC store retires before its write-request is
+            // processed (MemoryOrdering.md). A blocking load starting at the store's exact byte
+            // address orders after it and stalls until the stored value has landed.
+            ckernel::load_blocking(reinterpret_cast<volatile uint32_t*>(p_global_means));
+            ckernel::load_blocking(reinterpret_cast<volatile uint32_t*>(p_global_vars));
 
             // Signal to sender that our partial data is ready
             reduce_receiver_sem.up(noc, mcast_sender_noc_x, mcast_sender_noc_y, 1);


### PR DESCRIPTION
Fixes #50304. Re-lands #50305 (reverted in #50553) with a **32-bit** drain instead of a 16-bit one.

cc @mcraigheadTT — per your comments on tenstorrent/ttsim-private#605, this removes the halfword load from the drain path. Please see the "Why 32-bit" caveat below: I could not establish that the drain was the misaligned access.

### Problem
The Welford group-norm **reduce receivers** write their combined per-group mean/var into `dfb_ex_global` with plain `volatile uint16_t` stores, then **immediately** signal the sender, which NoC-reads those exact L1 addresses back to aggregate the global statistic (`welford_reader_mcast_sender_unary_sharded_gn_v2.cpp`).

Per `WormholeB0/TensixTile/BabyRISCV/MemoryOrdering.md`, a baby-RISC store **retires before its write-request is processed** into the L1 bank, and NoC write barriers/flushes drain NoC *writes*, not a RISC store to local L1. So the receiver's store can still be in flight when the sender's read-back reaches the L1 bank → the sender aggregates a **stale partial → wrong global mean/var → intermittent PCC failure**.

### Fix
Drain each just-written address with `ckernel::load_blocking` before signalling. The drain is a **32-bit** load (`volatile uint32_t*`, selecting the `lw` arm of the helper — `tt_llk_wormhole_b0/common/inc/ckernel.h:149`, same in `tt_llk_blackhole`).

**Why widening preserves the ordering guarantee.** `MemoryOrdering.md`'s store-then-load pairing keys on the *starting* byte address only:

> If the starting byte address of the store *exactly* equals the starting byte address of the load, then the store will emit a write-request *before* the load emits a read-request.

Both drains start at exactly the stored address, so `lw` orders after the `sh` just as `lhu` did. (The doc's "Sub-word load not observing previous store" example is the converse: differing start addresses do *not* order.) The helper's `and` on the loaded value supplies the second half of the doc's idiom — consuming the result so the read-response is obtained before the semaphore store is emitted.

### Why 32-bit — and what I could *not* establish
The 16-bit form made `sim_wormhole_b0` report `NonContractualBehavior: rv32_mem_rd: unaligned addr=0x3da7 size=2` (#50539), which forced the revert.

**That failure is not established to be these drains.** Instrumented on n150, both drain addresses are 64-byte aligned — low 2 bits zero, e.g. `gm=0x358c0 gv=0x360c0`, `tile=2048` — on every core. So the halfword load was **not** misaligned at these pointers. Two further points against the original diagnosis: the pre-revert code already performed 16-bit accesses at these same circular-buffer addresses without the model objecting, and `0x3da7` does not correspond to these addresses at all.

So the honest framing: 32-bit is the wider, plainly word-aligned access and removes the halfword load from this path, but **whether it clears the `sim_wormhole_b0` job is UNVERIFIED** — no simulator run was performed for this PR. If the misaligned access lives elsewhere (e.g. a pre-existing 16-bit read in `welford_combine.h`), this PR will not fix #50539 and the sim job will fail again; that would itself be useful information, and the CI badges below are the check.

Note also that `BabyRISCV/README.md` § Faults / exceptions states unaligned accesses are *silently rounded down to the nearest aligned address* and are `NonContractualBehavior` — i.e. wherever the misaligned read is, it is a software defect worth finding independently of this PR.

### Verification
- Both receiver kernels JIT-compile clean (kernels build `-Wall -Werror`, `tt_metal/jit_build/build.cpp:162`).
- `test_group_norm.py::test_group_norm_with_block_sharded_v2_8x4_grid` welford — **passed on n150** with the 32-bit drain in place. (That run also carried a temporary DPRINT alignment probe, since removed; it is what produced the address measurements above.)
- Drain-address alignment measured on n150 across all participating cores: low 2 bits zero for both `global_means_ptr` and `global_vars_ptr`.
- Not run for this PR: the DRAM-path welford suite (`test_group_norm_DRAM.py`), and any simulator job. The change to `welford_reader_mcast_receiver_unary_gn.cpp` is line-for-line identical to the v2 one, so it is covered by review rather than by a local run here. CI below is the gate.

As with #50305, this does not add a perturbation test: the race is timing/L1-bank-contention dependent and not deterministically forceable. The acceptance basis is the ISA memory-ordering contract plus the sibling data-before-signal idioms.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amahmud/reland-groupnorm-welford-32bit-drain)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amahmud/reland-groupnorm-welford-32bit-drain)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amahmud/reland-groupnorm-welford-32bit-drain)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amahmud/reland-groupnorm-welford-32bit-drain)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=amahmud/reland-groupnorm-welford-32bit-drain)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:amahmud/reland-groupnorm-welford-32bit-drain)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amahmud/reland-groupnorm-welford-32bit-drain)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amahmud/reland-groupnorm-welford-32bit-drain)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amahmud/reland-groupnorm-welford-32bit-drain)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amahmud/reland-groupnorm-welford-32bit-drain)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amahmud/reland-groupnorm-welford-32bit-drain)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amahmud/reland-groupnorm-welford-32bit-drain)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amahmud/reland-groupnorm-welford-32bit-drain)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amahmud/reland-groupnorm-welford-32bit-drain)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amahmud/reland-groupnorm-welford-32bit-drain)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amahmud/reland-groupnorm-welford-32bit-drain)

