### PR TITLE
Skip NOC debugging tests before slow-dispatch setup

### DIFF
--- a/tests/tt_metal/tt_metal/noc_debugging/noc_debugging_fixture.hpp
+++ b/tests/tt_metal/tt_metal/noc_debugging/noc_debugging_fixture.hpp
@@ -22,6 +22,10 @@ public:
 #if !defined(TRACY_ENABLE)
         return;
 #endif
+        if (getenv("TT_METAL_SLOW_DISPATCH_MODE")) {
+            return;
+        }
+
         // NOC debugging requires profiler + NOC event infrastructure, which is
         // created during MetalContext::initialize_impl() only when profiler_enabled
         // is true at that time.  Setting the env var before create_shared_devices()
@@ -138,11 +142,11 @@ protected:
 #if !defined(TRACY_ENABLE)
         GTEST_SKIP() << "NOC debugging tests require a Tracy-enabled build (build with ENABLE_TRACY=ON)";
 #endif
-        MeshDispatchFixture::SetUp();
-
-        if (this->IsSlowDispatch()) {
+        if (getenv("TT_METAL_SLOW_DISPATCH_MODE")) {
             GTEST_SKIP() << "NOC debugging tests require fast dispatch mode";
         }
+
+        MeshDispatchFixture::SetUp();
 
         if (tt::tt_metal::MetalContext::instance().rtoptions().get_watcher_enabled() ||
             tt::tt_metal::MetalContext::instance().rtoptions().get_feature_enabled(
@@ -159,6 +163,9 @@ protected:
 #if !defined(TRACY_ENABLE)
         return;
 #endif
+        if (IsSkipped()) {
+            return;
+        }
         if (auto& noc_debug_state = tt::tt_metal::MetalContext::instance().noc_debug_state()) {
             noc_debug_state->reset_state();
         }


### PR DESCRIPTION
### PR Category
Test Only

### Summary
The NOC debugging fixture was still performing profiler/NOC-debug setup in slow-dispatch configurations even though the tests require fast dispatch. That let unsupported runs initialize partial state and later fail during fixture setup or teardown instead of reporting a clean skip. The change checks `TT_METAL_SLOW_DISPATCH_MODE` before enabling NOC debugging or constructing the mesh fixture, and avoids teardown work after a skipped setup. This keeps the fixture's unsupported slow-dispatch path side-effect-free while preserving the existing Tracy/profiler behavior for supported fast-dispatch runs.

### Notes for reviewers
none

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mcraighead/noc-debugging)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mcraighead/noc-debugging)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mcraighead/noc-debugging)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mcraighead/noc-debugging)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mcraighead/noc-debugging)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mcraighead/noc-debugging)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mcraighead/noc-debugging)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mcraighead/noc-debugging)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mcraighead/noc-debugging)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mcraighead/noc-debugging)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mcraighead/noc-debugging)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mcraighead/noc-debugging)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mcraighead/noc-debugging)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mcraighead/noc-debugging)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mcraighead/noc-debugging)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mcraighead/noc-debugging)