### PR TITLE
feat: add Quasar SFPU non-approx gelu kernel

### DIFF
--- a/tests/tt_metal/tt_metal/llk/test_sfpu_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_sfpu_compute.cpp
@@ -63,6 +63,7 @@ const map<std::string, std::map<std::string, std::string>> sfpu_op_to_op_name = 
     {"exponential", {{"SFPU_OP_CHAIN_0", "exp_tile_init(); exp_tile(0);"}}},
     {"reciprocal", {{"SFPU_OP_CHAIN_0", "recip_tile_init(); recip_tile(0);"}}},
     {"gelu", {{"SFPU_OP_CHAIN_0", "gelu_tile_init(); gelu_tile(0);"}}},
+    {"gelu_accurate", {{"SFPU_OP_CHAIN_0", "gelu_tile_init<false>(); gelu_tile<false>(0);"}}},
     {"sqrt", {{"SFPU_OP_CHAIN_0", "sqrt_tile_init(); sqrt_tile(0);"}}},
     {"sigmoid", {{"SFPU_OP_CHAIN_0", "sigmoid_tile_init(); sigmoid_tile(0);"}}},
     {"silu", {{"SFPU_OP_CHAIN_0", "silu_tile_init(); silu_tile(0);"}}},
@@ -145,6 +146,9 @@ float sfpu_function(const std::string& op_name, float input) {
         static constexpr float alpha = M_2_SQRTPI * M_SQRT1_2;
         auto x3 = input * input * input;
         return input * 0.5 * (1.0 + tanhf(alpha * (input + 0.044715 * x3)));
+    }
+    if (op_name == "gelu_accurate") {
+        return 0.5f * input * (1.0f + erff(input * static_cast<float>(M_SQRT1_2)));
     }
     if (op_name == "sqrt") {
         return sqrtf(input);
@@ -289,6 +293,9 @@ vector<uint32_t> generate_packed_sfpu_input(const unsigned int numel, const std:
         auto possible_values = vector<bfloat16>({-1.0f, -0.5f, 0.5f, 1.0f});
         return generate_packed_random_vector_from_vector<uint32_t, bfloat16>(possible_values, numel, seed);
     }
+    if (op_name == "gelu_accurate") {
+        return generate_packed_uniform_random_vector<uint32_t, bfloat16>(-5.0f, 5.0f, numel, seed);
+    }
     if ((op_name == "eqz") || (op_name == "nez") || (op_name == "ltz") || (op_name == "gtz") || (op_name == "gez") ||
         (op_name == "lez")) {
         // Include exact zeros so the eqz/nez/lez/gez at-zero branches are exercised.
@@ -367,6 +374,9 @@ std::pair<float, float> sfpu_tolerance(const std::string& op_name, bool fp32_des
     }
     if ((op_name == "gelu") || (op_name == "relu")) {
         return {0.15f, 0.001f};
+    }
+    if (op_name == "gelu_accurate") {
+        return {0.01f, 0.001f};
     }
     if (op_name == "exponential") {
         // 16-bit Dest runs the approximate (HW LUT) exp; 32-bit Dest runs the fp32-accurate
@@ -1589,6 +1599,7 @@ INSTANTIATE_TEST_SUITE_P(
         std::make_tuple(1, "exponential"),
         std::make_tuple(1, "reciprocal"),
         std::make_tuple(1, "gelu"),
+        std::make_tuple(1, "gelu_accurate"),
         std::make_tuple(1, "sqrt"),
         std::make_tuple(1, "sigmoid"),
         std::make_tuple(1, "silu"),
@@ -1601,6 +1612,7 @@ INSTANTIATE_TEST_SUITE_P(
         std::make_tuple(4, "exponential"),
         std::make_tuple(4, "reciprocal"),
         std::make_tuple(4, "gelu"),
+        std::make_tuple(4, "gelu_accurate"),
         std::make_tuple(4, "sqrt"),
         std::make_tuple(4, "sigmoid"),
         std::make_tuple(4, "silu"),
@@ -1718,6 +1730,7 @@ INSTANTIATE_TEST_SUITE_P(
         std::make_tuple(1, "exponential"),
         std::make_tuple(1, "reciprocal"),
         std::make_tuple(1, "gelu"),
+        std::make_tuple(1, "gelu_accurate"),
         std::make_tuple(1, "sqrt"),
         std::make_tuple(1, "sigmoid"),
         std::make_tuple(1, "silu"),
@@ -1729,6 +1742,7 @@ INSTANTIATE_TEST_SUITE_P(
         std::make_tuple(4, "exponential"),
         std::make_tuple(4, "reciprocal"),
         std::make_tuple(4, "gelu"),
+        std::make_tuple(4, "gelu_accurate"),
         std::make_tuple(4, "sqrt"),
         std::make_tuple(4, "sigmoid"),
         std::make_tuple(4, "silu"),

--- a/tests/tt_metal/tt_metal/llk/test_sfpu_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_sfpu_compute.cpp
@@ -148,7 +148,10 @@ float sfpu_function(const std::string& op_name, float input) {
         return input * 0.5 * (1.0 + tanhf(alpha * (input + 0.044715 * x3)));
     }
     if (op_name == "gelu_accurate") {
-        return 0.5f * input * (1.0f + erff(input * static_cast<float>(M_SQRT1_2)));
+        // In double: erf(x/sqrt(2)) tends to -1 in the negative tail, so 1 + erf cancels. Computed
+        // in float the golden is already 1.8% off at x = -4.84, past this op's 1% rtol.
+        const double x = input;
+        return static_cast<float>(0.5 * x * (1.0 + erf(x * M_SQRT1_2)));
     }
     if (op_name == "sqrt") {
         return sqrtf(input);

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
@@ -29,6 +29,26 @@ sfpi_inline sfpi::vFloat _sfpu_round_to_nearest_int32_(sfpi::vFloat z, sfpi::vIn
 }
 
 /*
+ * Branch-free float->int32 conversion for the 21f exp construction, ported from the Blackhole
+ * kernel of the same name (its home there is also ckernel_sfpu_exp.h).
+ *
+ * The constraint on `val` is: 0 <= val < 128.0f
+ * Note: the value is assumed to have been divided by 2^23, so the output is scaled by 2^23
+ * compared to `val`. If that were not the case we would have to shift by `exp - 23` instead of
+ * `exp`, costing one extra SFPADDI.
+ *
+ * Portable to Quasar: the exponent is non-negative over the supported range, so the shift amount
+ * has the same encoding in sign-magnitude and two's complement.
+ */
+sfpi_inline sfpi::vInt _float_to_int32_for_exp_21f_(sfpi::vFloat val) {
+    sfpi::vInt exp = sfpi::exexp(val);
+    sfpi::vInt man =
+        sfpi::exman(val, sfpi::MantissaMode::ImplicitOne);  // get mantissa with implicit bit (man in [1; 2])
+    man = sfpi::shft(man, exp, sfpi::ShiftMode::Logical);
+    return man;
+}
+
+/*
  * The _sfpu_exp_fp32_accurate_ code is derived from code by Norbert Juffa.
  *
  * Copyright (c) 2015-2021, Norbert Juffa

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
@@ -29,16 +29,12 @@ sfpi_inline sfpi::vFloat _sfpu_round_to_nearest_int32_(sfpi::vFloat z, sfpi::vIn
 }
 
 /*
- * Branch-free float->int32 conversion for the 21f exp construction, ported from the Blackhole
- * kernel of the same name (its home there is also ckernel_sfpu_exp.h).
+ * Branch-free float->int32 conversion for the 21f exp construction, taken from the Blackhole kernel of
+ * the same name. Requires 0 <= val < 128.0f and assumes val was already divided by 2^23, so the result
+ * is scaled by 2^23 (otherwise the shift would have to be exp - 23).
  *
- * The constraint on `val` is: 0 <= val < 128.0f
- * Note: the value is assumed to have been divided by 2^23, so the output is scaled by 2^23
- * compared to `val`. If that were not the case we would have to shift by `exp - 23` instead of
- * `exp`, costing one extra SFPADDI.
- *
- * Portable to Quasar: the exponent is non-negative over the supported range, so the shift amount
- * has the same encoding in sign-magnitude and two's complement.
+ * Safe on Quasar: the exponent is non-negative over that range, so the shift amount reads the same in
+ * sign-magnitude and two's complement.
  */
 sfpi_inline sfpi::vInt _float_to_int32_for_exp_21f_(sfpi::vFloat val) {
     sfpi::vInt exp = sfpi::exexp(val);

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_gelu.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_gelu.h
@@ -133,7 +133,7 @@ sfpi_inline sfpi::vFloat calculate_gelu_piecewise(sfpi::vFloat x) {
         // Round H to the nearest multiple of 2⁻²⁵: adding 0.375 = (2²³+2²²)·2⁻²⁵ shifts H's
         // 2⁻²⁵ place to the FP32 round-to-nearest-even boundary (safe since H ∈ [3e-8, 9e-4] ≪ 0.25),
         // so (H + 0.375) - 0.375 == round(H / 2⁻²⁵) · 2⁻²⁵. In the deep tail (-5.5426, -4.828]
-        // this reproduces torch's exact float32 ercc staircase (0 BF16 ULP); above -4.828 the
+        // this reproduces torch's exact float32 erfc staircase (0 BF16 ULP); above -4.828 the
         // 2⁻²⁵ grid is far finer than BF16 so rounding is lossless. One constant serves the
         // whole exp region — no separate branch or multiply.
         constexpr float ROUND_TO_GRID = 0.375f;

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_gelu.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_gelu.h
@@ -22,34 +22,25 @@ namespace ckernel::sfpu {
 // =============================================================================
 // Approximate GELU - 6-segment piecewise-linear LUT
 // =============================================================================
-// GELU(x) ~= 0.5 * x + f(|x|), with f evaluated by the SFPU's LUT unit.
+// GELU(x) ~= 0.5 * x + f(|x|), with f evaluated by the SFPU LUT unit. Same table and same math as
+// Blackhole's calculate_gelu_appx (gelu_init has the segment breakdown); only the table location
+// differs. Quasar's SFPLUTFP32 reads the table from the constant LRegs 9-14 and the looked-up value
+// from LReg3, where WH/BH read the table from LReg0-2/LReg4-6.
 //
-// Same table, same packing and same math as Blackhole's calculate_gelu_appx (see gelu_init for the
-// segment breakdown); what differs is where the table lives. On Quasar SFPLUTFP32 reads its table from
-// the LUT/programmable constant LRegs 9-14 ("LUT constant lreg[9]" onwards in the SFPCONFIG config_dest
-// table of tt_llk_quasar/instructions/assembly.yaml) and its input from LReg3, where Wormhole/Blackhole
-// read the table from LReg0-2/LReg4-6. Two consequences:
+// So gelu_init loads the table with _sfpu_load_config32_ rather than sfpi: vCReg assignment reaches
+// SFPCONFIG, but the assembler rejects dests 9 and 10 ("permitted mask is 0xf9ff"), which is two of
+// the six table words. See tt-metal issue #51346.
 //
-//   * The table load (gelu_init) has to stay raw TTI. vCReg assignment does reach SFPCONFIG
-//     (__builtin_rvtt_sfpwriteconfig_v) and config dests 11-14 assemble, but 9 and 10 are rejected --
-//     "unsupported value '9' for mod operand (permitted mask is 0xf9ff)" -- so sfpi cannot write two of
-//     the six table words. _sfpu_load_config32_ is the only route.
+// The loop below is still plain sfpi. lut2_sign() wants six LReg operands because that is where WH/BH
+// keep the table, and it pins the looked-up value to LReg3, which is what this hardware wants anyway.
+// The LUT ignores those six registers here, so reading them back through l_reg[] (no instructions
+// emitted) is enough to satisfy the intrinsic. Loading the table into them, the way Blackhole's init
+// does, is what miscompares.
 //
-//   * This loop, however, is plain sfpi. lut2_sign() insists on six LReg operands because that is
-//     where WH/BH keep the table, and it pins the looked-up value to LReg3. That pinning is exactly
-//     what Quasar's hardware wants, and the six operand registers are ignored by the LUT here, so
-//     reading them back through l_reg[] -- which emits no instructions -- is enough to satisfy the
-//     intrinsic. Loading the table into them, as the Blackhole init does, is what miscompared on
-//     emu-quasar; leaving them alone is fine.
-//
-// Do not use vConstFloatPrgm0 for the 0.5 as Blackhole does: on Quasar that is LReg12, one of the
-// table's intercept words. An immediate (SFPMULI) costs nothing extra.
-//
-// NB: because the table covers every constant LReg, the approximate path overwrites the SFPU
-// constants 0.0/1.0/-1.0 (LReg9/10/11) that sfpi materializes and compares against. Every SFPU op's
-// init restores them (llk_math_eltwise_unary_sfpu_init -> _llk_math_sfpu_init_ ->
-// _init_sfpu_config_reg_) before programming its own constants, so a following op is unaffected —
-// but sfpi-generated code reached without an intervening init would be.
+// Two things to avoid: vConstFloatPrgm0 for the 0.5 (that is LReg12, a table intercept word; an
+// SFPMULI immediate is free), and any sfpi code between this init and the loop, since the table
+// overwrites the SFPU constants 0.0/1.0/-1.0 in LReg9/10/11. Each op's init restores them via
+// _init_sfpu_config_reg_, so a following op is unaffected.
 // =============================================================================
 
 template <int ITERATIONS = SFPU_ITERATIONS>
@@ -150,11 +141,9 @@ sfpi_inline sfpi::vFloat calculate_gelu_piecewise(sfpi::vFloat x) {
         result = x * Hs;
 
         // Core CDF region (-3.125, 2.78125]: GELU = x · Phi_core(x).
-        // Blackhole narrows with x >= -3.125f / x >= 2.78125f. Quasar uses the strict form because a
-        // float >= is only as good as the sign of the SFPMAD difference at the boundary itself, where
-        // that difference can be -0.0 and read as negative (the equality half of sfpi issue #50208).
-        // The boundaries just move to the neighbouring region, which is where each fit is closed
-        // anyway: the H-form covers (-5.54259443, -3.125] and the core polynomial [-3.125, 2.78125].
+        // Blackhole narrows with >=. Strict > here because a float >= is unreliable at the boundary
+        // itself on Quasar (issue #50208), and each fit is closed at its own end anyway: the H-form
+        // covers (-5.54259443, -3.125] and the core polynomial [-3.125, 2.78125].
         v_and(x > -3.125f);
         sfpi::vFloat odd_poly = PolynomialEvaluator::eval(
             x2,
@@ -183,9 +172,8 @@ sfpi_inline sfpi::vFloat calculate_gelu_piecewise(sfpi::vFloat x) {
  * @tparam APPROXIMATION_MODE: Select the LUT path (loads the 6-segment table), values = <true/false>
  * @tparam is_fp32_dest_acc_en: For the non-approximate path, select the fp32 rational-erf variant,
  *         which needs the Newton-Raphson constant its reciprocal refines with.
- * @note Counters are reset by the surrounding @ref llk_math_eltwise_unary_sfpu_init, so unlike the
- *       Blackhole kernel this init only programs constants. Nothing may clobber LReg0-2/LReg4-6
- *       between this call and @ref calculate_gelu_appx, which reads the table back from them.
+ * @note The surrounding @ref llk_math_eltwise_unary_sfpu_init resets the counters, so unlike the
+ *       Blackhole kernel this init only programs constants.
  */
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
 inline void gelu_init() {
@@ -296,21 +284,18 @@ inline void calculate_gelu() {
                 piecewise_rational_eval_parity_numer_denom<16, 16>(
                     GELU_ERF_NUM, GELU_ERF_DEN, scaled, x2, erf_n, erf_d);
                 sfpi::vFloat erf_val = erf_n * _sfpu_reciprocal_<2>(erf_d);
-                // Blackhole writes this as clamp(erf_val, -1, 1) followed by the stuck-erff guard
+                // Blackhole clamps erf_val to [-1, 1] and then guards the stuck-erff level with
                 //   v_if (erf_val == -1.0f) { result = x * 2^-25; }
-                // (where the rational rounds erf to -1.0 inside the computation zone, glibc/torch
-                // overestimate erfc, and the first stuck level is x * 2^-25). Both fold into min/max
-                // on phi = 0.5 + 0.5*erf_val: the same clamp expressed on [0, 1], with the 2^-25
-                // floor standing in for the guard.
+                // (where the rational rounds erf to -1.0, glibc/torch overestimate erfc, and the first
+                // stuck level is x * 2^-25). Both fold into min/max on phi = 0.5 + 0.5*erf_val: the
+                // same clamp on [0, 1], with the 2^-25 floor standing in for the guard.
                 //
-                // Reason for the rewrite is the clamp, not the guard: sfpi emits SFPSWAP with
-                // imm12 = 0, and on Quasar imm12[0] selects that instruction's compare format
-                // (tt_sfpu.sv: swap_res_srcc_is_smaller_s3 = imm12[0] ? fp_compare : int_compare).
-                // The int path is a plain two's-complement subtract of the raw words, which reverses
-                // the ordering of two negative floats — so clamp(erf_val, -1, 1) returned -1.0 for
-                // every erf_val in (-1, 0), and every negative-input lane collapsed to +-0. Bounding
-                // phi instead keeps both operands of each min/max non-negative, where the
-                // two's-complement order agrees with the float order.
+                // The clamp is what forced this, not the guard. sfpi's min/max/clamp lower to SFPSWAP
+                // without the bit that selects a float compare, so Quasar compares the raw words as
+                // two's complement. That is correct unless both operands are negative, which is
+                // exactly the erf_val vs -1.0 case: it returned -1.0 for every erf_val in (-1, 0) and
+                // collapsed every negative-input lane to +-0. Bounding phi keeps both operands of each
+                // min/max non-negative.
                 constexpr float HALF_ULP_AT_1 = 2.9802322387695313e-08f;  // 2^-25
                 sfpi::vFloat phi = 0.5f + 0.5f * erf_val;
                 phi = sfpi::max(phi, HALF_ULP_AT_1);  // erf_val <= -1, incl. the stuck level

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_gelu.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_gelu.h
@@ -4,72 +4,335 @@
 
 #pragma once
 
+#include <cstdint>
+
+#include "ckernel.h"
+#include "ckernel_defs.h"
 #include "ckernel_ops.h"
+#include "ckernel_sfpu_exp.h"  // _float_to_int32_for_exp_21f_ (BF16 CDF path)
+#include "ckernel_sfpu_piecewise_rational.h"
+#include "ckernel_sfpu_polyval.h"
+#include "ckernel_sfpu_recip.h"
 #include "ckernel_trisc_common.h"
 #include "cmath_common.h"
+#include "sfpi.h"
 
-namespace ckernel {
-namespace sfpu {
+namespace ckernel::sfpu {
 
-// Calculates GELU for number of rows of output SFPU ops (Quasar = 2 rows)
-inline void _calculate_gelu_sfp_rows_() {
-    TTI_SFPLOAD(
-        p_sfpu::LREG3,
-        p_sfpu::sfpmem::DEFAULT,
-        ADDR_MOD_7,
-        0,
-        0);  // load from dest into lreg[3], uses ADDR_MOD_7 (set to all zeroes)
-    TTI_SFPLUTFP32(
-        p_sfpu::LREG4,
-        0x2);  // Calculate piecewise part on lreg[3] and store in lreg[4], using FP16 6-entry format mode 1 LUT
-    TTI_SFPMAD(
-        p_sfpu::LREG6, p_sfpu::LREG3, p_sfpu::LREG4, p_sfpu::LREG5, 0);  // 0.5 * x + piecewise result, store in lreg[5]
-    TTI_SFPSTORE(p_sfpu::LREG5, 0, ADDR_MOD_7, 0, 0);                    // store from lreg[5] into dest register
-}
+// =============================================================================
+// Approximate GELU - 6-segment piecewise-linear LUT
+// =============================================================================
+// GELU(x) ~= 0.5 * x + f(|x|), with f evaluated by the SFPU's LUT unit.
+//
+// Same table, same packing and same math as Blackhole's calculate_gelu_appx (see gelu_init for the
+// segment breakdown); what differs is where the table lives. On Quasar SFPLUTFP32 reads its table from
+// the LUT/programmable constant LRegs 9-14 ("LUT constant lreg[9]" onwards in the SFPCONFIG config_dest
+// table of tt_llk_quasar/instructions/assembly.yaml) and its input from LReg3, where Wormhole/Blackhole
+// read the table from LReg0-2/LReg4-6. Two consequences:
+//
+//   * The table load (gelu_init) has to stay raw TTI. vCReg assignment does reach SFPCONFIG
+//     (__builtin_rvtt_sfpwriteconfig_v) and config dests 11-14 assemble, but 9 and 10 are rejected --
+//     "unsupported value '9' for mod operand (permitted mask is 0xf9ff)" -- so sfpi cannot write two of
+//     the six table words. _sfpu_load_config32_ is the only route.
+//
+//   * This loop, however, is plain sfpi. lut2_sign() insists on six LReg operands because that is
+//     where WH/BH keep the table, and it pins the looked-up value to LReg3. That pinning is exactly
+//     what Quasar's hardware wants, and the six operand registers are ignored by the LUT here, so
+//     reading them back through l_reg[] -- which emits no instructions -- is enough to satisfy the
+//     intrinsic. Loading the table into them, as the Blackhole init does, is what miscompared on
+//     emu-quasar; leaving them alone is fine.
+//
+// Do not use vConstFloatPrgm0 for the 0.5 as Blackhole does: on Quasar that is LReg12, one of the
+// table's intercept words. An immediate (SFPMULI) costs nothing extra.
+//
+// NB: because the table covers every constant LReg, the approximate path overwrites the SFPU
+// constants 0.0/1.0/-1.0 (LReg9/10/11) that sfpi materializes and compares against. Every SFPU op's
+// init restores them (llk_math_eltwise_unary_sfpu_init -> _llk_math_sfpu_init_ ->
+// _init_sfpu_config_reg_) before programming its own constants, so a following op is unaffected —
+// but sfpi-generated code reached without an intervening init would be.
+// =============================================================================
 
-template <bool APPROXIMATION_MODE = true>
-inline void gelu_init() {
-    // Need a fixed constant of 0.5 for the MAD part of the operation
-    TTI_SFPLOADI(p_sfpu::LREG6, 0x8, 0x3F00);
-    TTI_SFPLOADI(p_sfpu::LREG6, 0xA, 0x0000);
+template <int ITERATIONS = SFPU_ITERATIONS>
+inline void calculate_gelu_appx() {
+    // Operands lut2_sign() requires; their contents are irrelevant on Quasar (see above).
+    sfpi::vUInt l0 = sfpi::l_reg[sfpi::LRegs::LReg0];
+    sfpi::vUInt l1 = sfpi::l_reg[sfpi::LRegs::LReg1];
+    sfpi::vUInt l2 = sfpi::l_reg[sfpi::LRegs::LReg2];
+    sfpi::vUInt l4 = sfpi::l_reg[sfpi::LRegs::LReg4];
+    sfpi::vUInt l5 = sfpi::l_reg[sfpi::LRegs::LReg5];
+    sfpi::vUInt l6 = sfpi::l_reg[sfpi::LRegs::LReg6];
 
-    // x >= 3.0
-    // lreg11_hi =  0.50   (0x3800)
-    // lreg14_hi =  0.0    (0x7c00)
-    // 3.0 > x >= 2.0
-    // lreg11_lo =  0.5402 (0x3852)
-    // lreg14_lo = -0.1194 (0xAFA4)
-    ckernel::math::_sfpu_load_config32_(0xB, 0x3800, 0x3852);
-    ckernel::math::_sfpu_load_config32_(0xE, 0x7C00, 0xAFA4);
-
-    // 2.0 > x >= 1.5
-    // lreg10_hi =  0.6099 (0x38E1)
-    // lreg13_hi = -0.2635 (0xB437)
-    // 1.5 > x >= 1.0
-    // lreg10_lo =  0.6189 (0x38F3)
-    // lreg13_lo = -0.2797 (0xB479)
-    ckernel::math::_sfpu_load_config32_(0xA, 0x38E1, 0x38F3);
-    ckernel::math::_sfpu_load_config32_(0xD, 0xB437, 0xB479);
-
-    // 1.0 > x >= 0.5
-    // lreg9_hi  =  0.4939 (0x37E7)
-    // lreg12_hi = -0.1605 (0xB122)
-    // 0.5 > x >= 0.0
-    // lreg9_lo  =  0.1928 (0x322B)
-    // lreg12_lo = -0.0150 (0xA3AE)
-    ckernel::math::_sfpu_load_config32_(0x9, 0x37E7, 0x322B);
-    ckernel::math::_sfpu_load_config32_(0xC, 0xB122, 0xA3AE);
-}
-
-template <bool APPROXIMATION_MODE = true, int ITERATIONS = SFPU_ITERATIONS>
-inline void calculate_gelu() {
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
-        _calculate_gelu_sfp_rows_();
-        ckernel::math::_incr_counters_<0x0, 0x0, ckernel::math::SFP_ROWS, 0x0>();  // does the dest_reg++ (increments by
-                                                                                   // 2 rows)
+        sfpi::vFloat in = sfpi::dst_reg[0];
+        sfpi::vFloat piecewise = lut2_sign(in, l0, l1, l2, l4, l5, l6);
+        sfpi::dst_reg[0] = in * 0.5f + piecewise;
+        sfpi::dst_reg++;
     }
 }
 
-}  // namespace sfpu
-}  // namespace ckernel
+// =============================================================================
+// Forward GELU - Piecewise CDF Approximation
+// =============================================================================
+// GELU(x) = x * Phi(x) where Phi(x) = 0.5*(1+erf(x/sqrt(2))) is the CDF
+//
+// Three active regions (plus zero default):
+//   x >= 2.78125:                  Identity (result = x)
+//   -3.125 <= x < 2.78125:         Core CDF polynomial (degree-13 in u=x²)
+//   -5.54259443 < x < -3.125:      Moroz exp_21f: GELU = x · round_to_grid(H), H = exp(-x²/2)·corr_H
+//   x <= -5.54259443:               Zero (matches torch.gelu BF16 saturation)
+//
+// Deep-tail grid rounding: in the deep tail (-5.54259443, -4.828125] torch computes
+// GELU(x) = x · float32(½·erfc(|x|/√2)) where the float32 ½·erfc is a *staircase*
+// (multiple BF16 inputs share one float32 bucket). Every bucket is an exact integer
+// multiple of 2⁻²⁵ (k ∈ {1..21}). A smooth polynomial diverges from this staircase by
+// up to 116 BF16 ULP. Instead we compute the smooth H and round it to the nearest multiple
+// of 2⁻²⁵ before multiplying by x — reproducing torch's exact bucket at 2 ops
+// (vs a 27-op step-function cascade). Above -4.828125 the 2⁻²⁵ grid is far finer than
+// BF16 so the rounding is lossless, letting one rounded multiply serve the whole exp region.
+// Result: ULP ≤ 1 across the tail (0 ULP for almost all of it), with DKD below main.
+//
+// v_if/v_and narrowing: widest region first, each v_and overwrites for narrower set.
+// =============================================================================
+
+// Degree-13 CDF polynomial for Phi(x) over [-3.125, 2.78125]
+// Phi(x) = 0.5 + x * p(x²); only odd powers, evaluated via u=x² Horner (7 MADs).
+// Minimax-fitted with BF16-ULP weighting → MaxULP = 0.87 < 1.
+constexpr float GELU_CDF_CORE_C0 = 5.000000000e-01f;
+constexpr float GELU_CDF_CORE_C1 = 3.9894227818e-01f;
+constexpr float GELU_CDF_CORE_C3 = -6.6361041488e-02f;
+constexpr float GELU_CDF_CORE_C5 = 9.7720050615e-03f;
+constexpr float GELU_CDF_CORE_C7 = -1.0717806322e-03f;
+constexpr float GELU_CDF_CORE_C9 = 8.1812159812e-05f;
+constexpr float GELU_CDF_CORE_C11 = -3.8082057209e-06f;
+constexpr float GELU_CDF_CORE_C13 = 7.9821413868e-08f;
+
+// Degree-3 H-form correction polynomial for the exp-based region (-5.54259443, -3.125].
+// H(x) = ½·erfc(|x|/√2) ≈ exp(-x²/2) · corr_H(x), and GELU(x) = x · H(x).
+// Fitted (uniform relative error) so the deep-tail snap is exact and the smooth
+// region stays ULP ≤ 1. See deep-tail snap below for why the H-form matters.
+constexpr float GELU_HCORR_C0 = 3.0369991064e-01f;
+constexpr float GELU_HCORR_C1 = 9.5413386822e-02f;
+constexpr float GELU_HCORR_C2 = 1.3809983619e-02f;
+constexpr float GELU_HCORR_C3 = 7.5950479368e-04f;
+
+// Forward GELU Evaluation with CDF Polynomial Approximation
+// GELU(x) = x * Phi(x) where Phi is approximated piecewise
+sfpi_inline sfpi::vFloat calculate_gelu_piecewise(sfpi::vFloat x) {
+    sfpi::vFloat result = 0.0f;  // Default: 0 for x <= -5.54259443 (torch saturation)
+    sfpi::vFloat x2 = x * x;
+
+    v_if(x > -5.54259443f) {
+        // Shared smooth H ≈ ½·erfc(|x|/√2) via Moroz exp_21f · corr_H.
+        constexpr float NEG_HALF_ONE_LN2 = -0.72134752044f;  // -0.5 / ln(2)
+        sfpi::vFloat xlog2 = x2 * NEG_HALF_ONE_LN2 + 127.0f;
+
+        sfpi::vInt z = _float_to_int32_for_exp_21f_(xlog2);
+        sfpi::vInt exponential_part = sfpi::exexp(sfpi::as<sfpi::vFloat>(z), sfpi::ExponentMode::Biased);
+        sfpi::vMag fractional_part = sfpi::exman(sfpi::as<sfpi::vFloat>(z));
+
+        sfpi::vFloat frac = sfpi::convert<sfpi::vFloat>(fractional_part, sfpi::RoundMode::Nearest);
+        frac = PolynomialEvaluator::eval(frac, 1.0017248f, 7.839635491371155e-08f, 4.791750143340323e-15f);
+        sfpi::vFloat exp_val = sfpi::setexp(frac, exponential_part);
+
+        sfpi::vFloat H =
+            exp_val * PolynomialEvaluator::eval(x, GELU_HCORR_C0, GELU_HCORR_C1, GELU_HCORR_C2, GELU_HCORR_C3);
+
+        // Exp region (-5.54259443, -3.125]: GELU = x · round_to_grid(H).
+        // Round H to the nearest multiple of 2⁻²⁵: adding 0.375 = (2²³+2²²)·2⁻²⁵ shifts H's
+        // 2⁻²⁵ place to the FP32 round-to-nearest-even boundary (safe since H ∈ [3e-8, 9e-4] ≪ 0.25),
+        // so (H + 0.375) - 0.375 == round(H / 2⁻²⁵) · 2⁻²⁵. In the deep tail (-5.5426, -4.828]
+        // this reproduces torch's exact float32 ercc staircase (0 BF16 ULP); above -4.828 the
+        // 2⁻²⁵ grid is far finer than BF16 so rounding is lossless. One constant serves the
+        // whole exp region — no separate branch or multiply.
+        constexpr float ROUND_TO_GRID = 0.375f;
+        sfpi::vFloat Hs = (H + ROUND_TO_GRID) - ROUND_TO_GRID;
+        result = x * Hs;
+
+        // Core CDF region (-3.125, 2.78125]: GELU = x · Phi_core(x).
+        // Blackhole narrows with x >= -3.125f / x >= 2.78125f. Quasar uses the strict form because a
+        // float >= is only as good as the sign of the SFPMAD difference at the boundary itself, where
+        // that difference can be -0.0 and read as negative (the equality half of sfpi issue #50208).
+        // The boundaries just move to the neighbouring region, which is where each fit is closed
+        // anyway: the H-form covers (-5.54259443, -3.125] and the core polynomial [-3.125, 2.78125].
+        v_and(x > -3.125f);
+        sfpi::vFloat odd_poly = PolynomialEvaluator::eval(
+            x2,
+            GELU_CDF_CORE_C1,
+            GELU_CDF_CORE_C3,
+            GELU_CDF_CORE_C5,
+            GELU_CDF_CORE_C7,
+            GELU_CDF_CORE_C9,
+            GELU_CDF_CORE_C11,
+            GELU_CDF_CORE_C13);
+        sfpi::vFloat phi = GELU_CDF_CORE_C0 + x * odd_poly;
+        result = x * phi;
+
+        // Identity region x > 2.78125.
+        v_and(x > 2.78125f);
+        result = x;
+    }
+    v_endif;
+
+    return result;
+}
+
+/**
+ * @brief Program the constants the selected GELU implementation reads.
+ *
+ * @tparam APPROXIMATION_MODE: Select the LUT path (loads the 6-segment table), values = <true/false>
+ * @tparam is_fp32_dest_acc_en: For the non-approximate path, select the fp32 rational-erf variant,
+ *         which needs the Newton-Raphson constant its reciprocal refines with.
+ * @note Counters are reset by the surrounding @ref llk_math_eltwise_unary_sfpu_init, so unlike the
+ *       Blackhole kernel this init only programs constants. Nothing may clobber LReg0-2/LReg4-6
+ *       between this call and @ref calculate_gelu_appx, which reads the table back from them.
+ */
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
+inline void gelu_init() {
+    if constexpr (APPROXIMATION_MODE) {
+        // Segment slopes/intercepts, packed hi/lo the way SFPLUTFP32's FP16 6-entry mode 1 reads
+        // them. Same values as the Blackhole table (l_reg0 = 0x37E7322B, l_reg4 = 0xB12286D8, ...).
+        //
+        // 1.0 > x >= 0.5
+        // lreg9_hi  =  0.4939 (0x37E7)
+        // lreg12_hi = -0.1605 (0xB122)
+        // 0.5 > x >= 0.0
+        // lreg9_lo  =  0.1928 (0x322B)
+        // lreg12_lo = -7.4e-05 (0x86D8)
+        ckernel::math::_sfpu_load_config32_(0x9, 0x37E7, 0x322B);
+        ckernel::math::_sfpu_load_config32_(0xC, 0xB122, 0x86D8);
+
+        // 2.0 > x >= 1.5
+        // lreg10_hi =  0.6099 (0x38E1)
+        // lreg13_hi = -0.2635 (0xB437)
+        // 1.5 > x >= 1.0
+        // lreg10_lo =  0.6189 (0x38F3)
+        // lreg13_lo = -0.2797 (0xB479)
+        ckernel::math::_sfpu_load_config32_(0xA, 0x38E1, 0x38F3);
+        ckernel::math::_sfpu_load_config32_(0xD, 0xB437, 0xB479);
+
+        // x >= 3.0
+        // lreg11_hi =  0.50   (0x3800)
+        // lreg14_hi =  0.0    (0x7C00)
+        // 3.0 > x >= 2.0
+        // lreg11_lo =  0.5402 (0x3852)
+        // lreg14_lo = -0.1194 (0xAFA4)
+        ckernel::math::_sfpu_load_config32_(0xB, 0x3800, 0x3852);
+        ckernel::math::_sfpu_load_config32_(0xE, 0x7C00, 0xAFA4);
+    } else if constexpr (is_fp32_dest_acc_en) {
+        // FP32 accurate mode: rational erf evaluation requires reciprocal init
+        _init_reciprocal_<false>();
+    }
+    // BF16 accurate mode: no init needed (correction polynomial has no reciprocal)
+}
+
+// FP32 erf: n16/d16 parity rational coefficients, MaxULP=1 vs FP64.
+// Split from Blackhole's ERF_LUT (ckernel_sfpu_erf.h INP_FLOAT32 branch) entries [2..18] (num) and
+// [19..35] (den). piecewise_rational_eval_parity_numer_denom() takes const float* — no std::array needed.
+constexpr float GELU_ERF_NUM[17] = {  // odd powers only (c0=0, c2=0, ..., c16=0)
+    0.0f,
+    1.1283791065e+00f,
+    0.0f,
+    2.1477432549e-01f,
+    0.0f,
+    6.2133435160e-02f,
+    0.0f,
+    5.6230435148e-03f,
+    0.0f,
+    6.1307044234e-04f,
+    0.0f,
+    1.7678321456e-05f,
+    0.0f,
+    2.7384647439e-08f,
+    0.0f,
+    -2.8632063387e-10f,
+    0.0f};
+constexpr float GELU_ERF_DEN[17] = {  // even powers only (c1=0, c3=0, ..., c15=0)
+    1.0f,
+    0.0f,
+    5.2367275953e-01f,
+    0.0f,
+    1.2961706519e-01f,
+    0.0f,
+    1.9642570987e-02f,
+    0.0f,
+    1.9545555115e-03f,
+    0.0f,
+    1.3179056987e-04f,
+    0.0f,
+    1.3156344494e-06f,
+    0.0f,
+    -3.5153888689e-09f,
+    0.0f,
+    -6.7350725691e-12f};
+
+/**
+ * @brief Compute GELU in-place over a Dest tile.
+ *
+ * @tparam APPROXIMATION_MODE: Select the LUT path, values = <true/false>
+ * @tparam is_fp32_dest_acc_en: 32-bit Dest; selects the fp32 rational-erf path and skips the
+ *         round-to-nearest-bf16 conversion the 16-bit Dest store needs.
+ * @tparam ITERATIONS: Number of SFPU loop iterations over the Dest face.
+ * @note Call @ref gelu_init with matching template args first.
+ */
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS = SFPU_ITERATIONS>
+inline void calculate_gelu() {
+    if constexpr (APPROXIMATION_MODE) {
+        calculate_gelu_appx<ITERATIONS>();
+    } else if constexpr (is_fp32_dest_acc_en) {
+        // FP32 accurate mode: GELU(x) = x * 0.5 * (1 + erf(x/√2))
+        // using the n16/d16 piecewise rational erf (MaxULP=1 vs FP64).
+        constexpr float INV_SQRT2 = 0.7071067811865475f;
+        constexpr float GELU_SAT = -5.54259443f;  // 0xc0b15cef: first x where libm erff=-1.0
+#pragma GCC unroll 0
+        for (int d = 0; d < ITERATIONS; d++) {
+            sfpi::vFloat x = sfpi::dst_reg[0];
+            sfpi::vFloat result = 0.0f;  // default 0 for x <= GELU_SAT
+            v_if(x > GELU_SAT) {
+                sfpi::vFloat scaled = x * INV_SQRT2;
+                scaled = sfpi::min(scaled, 10.0f);
+                sfpi::vFloat x2 = scaled * scaled;
+                sfpi::vFloat erf_n, erf_d;
+                piecewise_rational_eval_parity_numer_denom<16, 16>(
+                    GELU_ERF_NUM, GELU_ERF_DEN, scaled, x2, erf_n, erf_d);
+                sfpi::vFloat erf_val = erf_n * _sfpu_reciprocal_<2>(erf_d);
+                // Blackhole writes this as clamp(erf_val, -1, 1) followed by the stuck-erff guard
+                //   v_if (erf_val == -1.0f) { result = x * 2^-25; }
+                // (where the rational rounds erf to -1.0 inside the computation zone, glibc/torch
+                // overestimate erfc, and the first stuck level is x * 2^-25). Both fold into min/max
+                // on phi = 0.5 + 0.5*erf_val: the same clamp expressed on [0, 1], with the 2^-25
+                // floor standing in for the guard.
+                //
+                // Reason for the rewrite is the clamp, not the guard: sfpi emits SFPSWAP with
+                // imm12 = 0, and on Quasar imm12[0] selects that instruction's compare format
+                // (tt_sfpu.sv: swap_res_srcc_is_smaller_s3 = imm12[0] ? fp_compare : int_compare).
+                // The int path is a plain two's-complement subtract of the raw words, which reverses
+                // the ordering of two negative floats — so clamp(erf_val, -1, 1) returned -1.0 for
+                // every erf_val in (-1, 0), and every negative-input lane collapsed to +-0. Bounding
+                // phi instead keeps both operands of each min/max non-negative, where the
+                // two's-complement order agrees with the float order.
+                constexpr float HALF_ULP_AT_1 = 2.9802322387695313e-08f;  // 2^-25
+                sfpi::vFloat phi = 0.5f + 0.5f * erf_val;
+                phi = sfpi::max(phi, HALF_ULP_AT_1);  // erf_val <= -1, incl. the stuck level
+                phi = sfpi::min(phi, 1.0f);           // erf_val >= 1
+                result = x * phi;
+            }
+            v_endif;
+            sfpi::dst_reg[0] = result;
+            sfpi::dst_reg++;
+        }
+    } else {
+        // BF16 accurate mode: piecewise CDF with Max ULP=1 vs true GELU.
+        // unroll 8 fills the SFPU pipeline across 8 independent dst-tile chains.
+#pragma GCC unroll 8
+        for (int d = 0; d < ITERATIONS; d++) {
+            sfpi::vFloat in = sfpi::dst_reg[0];
+            sfpi::vFloat result = calculate_gelu_piecewise(in);
+            result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::Nearest);
+            sfpi::dst_reg[0] = result;
+            sfpi::dst_reg++;
+        }
+    }
+}
+
+}  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_piecewise_rational.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_piecewise_rational.h
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+/**
+ * Shared rational P(x)/Q(x) evaluator for SFPU activations, ported from the Blackhole
+ * header of the same name (only the pieces Quasar kernels use are carried over).
+ *
+ * Parity x²-Horner: for an odd numerator / even denominator (erf, atanh, erfinv, ...) both
+ * polynomials are evaluated in the x² basis, which halves the multiply-add count. The two
+ * Horner chains are independent, so their SFPMADs interleave and hide pipeline latency.
+ */
+
+#include "sfpi.h"
+
+namespace ckernel::sfpu {
+
+// ============================================================================
+// Parity x²-Horner: odd num / even den → evaluate in x² basis
+// Coefficient arrays are indexed by power, so the unused parity's entries are zero
+// and simply skipped (NUM_TOP / DEN_TOP below).
+// ============================================================================
+
+template <uint32_t NUM_DEGREE, uint32_t DEN_DEGREE>
+sfpi_inline void piecewise_rational_eval_parity_numer_denom(
+    const float* num_coeffs,
+    const float* den_coeffs,
+    sfpi::vFloat x,
+    sfpi::vFloat x2,
+    sfpi::vFloat& out_numer,
+    sfpi::vFloat& out_denom) {
+    // NUM_TOP/DEN_TOP: highest odd/even index used in x²-Horner.
+    // If NUM_DEGREE is even, the leading (even-index) coeff must be zero — we skip it.
+    constexpr int NUM_TOP = (NUM_DEGREE % 2 == 1) ? NUM_DEGREE : NUM_DEGREE - 1;
+    constexpr int DEN_TOP = (DEN_DEGREE % 2 == 0) ? DEN_DEGREE : DEN_DEGREE - 1;
+    constexpr int NUM_STEPS = (NUM_TOP - 1) / 2;
+    constexpr int DEN_STEPS = DEN_TOP / 2;
+
+    sfpi::vFloat numer = num_coeffs[NUM_TOP];
+    sfpi::vFloat denom = den_coeffs[DEN_TOP];
+
+    if constexpr (NUM_STEPS > DEN_STEPS) {
+#pragma GCC unroll 64
+        for (int k = 0; k < NUM_STEPS - DEN_STEPS; k++) {
+            numer = numer * x2 + num_coeffs[NUM_TOP - 2 * (k + 1)];
+        }
+    } else if constexpr (DEN_STEPS > NUM_STEPS) {
+#pragma GCC unroll 64
+        for (int k = 0; k < DEN_STEPS - NUM_STEPS; k++) {
+            denom = denom * x2 + den_coeffs[DEN_TOP - 2 * (k + 1)];
+        }
+    }
+
+    constexpr int MIN_STEPS = (NUM_STEPS < DEN_STEPS) ? NUM_STEPS : DEN_STEPS;
+    constexpr int NUM_POS = NUM_TOP - 2 * ((NUM_STEPS > DEN_STEPS) ? (NUM_STEPS - DEN_STEPS) : 0);
+    constexpr int DEN_POS = DEN_TOP - 2 * ((DEN_STEPS > NUM_STEPS) ? (DEN_STEPS - NUM_STEPS) : 0);
+
+#pragma GCC unroll 64
+    for (int k = 1; k <= MIN_STEPS; k++) {
+        numer = numer * x2 + num_coeffs[NUM_POS - 2 * k];
+        denom = denom * x2 + den_coeffs[DEN_POS - 2 * k];
+    }
+
+    out_numer = numer * x;  // odd parity: P(x) = x * Horner_result
+    out_denom = denom;
+}
+
+}  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_piecewise_rational.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_piecewise_rational.h
@@ -5,23 +5,20 @@
 #pragma once
 
 /**
- * Shared rational P(x)/Q(x) evaluator for SFPU activations, ported from the Blackhole
- * header of the same name (only the pieces Quasar kernels use are carried over).
+ * Rational P(x)/Q(x) evaluator for SFPU activations. Carries over the parity evaluator from the
+ * Blackhole header of the same name; the other variants there have no Quasar users yet.
  *
- * Parity x²-Horner: for an odd numerator / even denominator (erf, atanh, erfinv, ...) both
- * polynomials are evaluated in the x² basis, which halves the multiply-add count. The two
- * Horner chains are independent, so their SFPMADs interleave and hide pipeline latency.
+ * For an odd numerator and even denominator (erf, atanh, erfinv) both polynomials are evaluated in
+ * the x^2 basis, halving the multiply-add count. The two Horner chains are independent, so their
+ * SFPMADs interleave and hide pipeline latency.
  */
 
 #include "sfpi.h"
 
 namespace ckernel::sfpu {
 
-// ============================================================================
-// Parity x²-Horner: odd num / even den → evaluate in x² basis
-// Coefficient arrays are indexed by power, so the unused parity's entries are zero
-// and simply skipped (NUM_TOP / DEN_TOP below).
-// ============================================================================
+// Coefficient arrays are indexed by power, so the unused parity's entries are zero and get skipped
+// via NUM_TOP / DEN_TOP below.
 
 template <uint32_t NUM_DEGREE, uint32_t DEN_DEGREE>
 sfpi_inline void piecewise_rational_eval_parity_numer_denom(

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_polyval.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_polyval.h
@@ -10,52 +10,116 @@ namespace ckernel::sfpu
 {
 
 /**
- * @brief Compile-time polynomial evaluator using Horner's method.
+ * @brief Compile-time polynomial evaluator.
  *
  * This template struct provides efficient polynomial evaluation at both compile-time
- * and runtime using Horner's method (synthetic division).
- * This implementation uses a recursive variadic template function to compute the polynomial value.
- *
- * The polynomial is represented by coefficients in ascending order of powers:
+ * and runtime. The polynomial is represented by coefficients in ascending order of powers:
  * coef[0] + coef[1]*x + coef[2]*x^2 + ... + coef[N-1]*x^(N-1)
  *
- * @note Uses Horner's method for numerical stability and O(N) complexity.
- * @note For N == 0, returns T{0}. For N == 1, returns the constant term.
+ * Two evaluation schemes are used:
+ *  - Horner's method (a single serial multiply-add chain) for low-degree polynomials.
+ *  - A second-order (even/odd) Horner split for high-degree polynomials. The polynomial is
+ *    factored as P(x) = E(x^2) + x * O(x^2), where E collects the even-power coefficients and
+ *    O the odd-power ones. E(x^2) and O(x^2) are independent Horner chains, so their multiply-adds
+ *    can be interleaved/pipelined by the compiler, roughly halving the critical-path latency at the
+ *    cost of one extra multiply (x^2), one final combine, and one extra live register.
+ *
+ * The split kicks in only once the number of coefficients reaches SplitThreshold, because for short
+ * chains the extra x^2 / combine overhead outweighs the shorter dependency chain.
+ *
+ * Kept in sync with the Blackhole evaluator (tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_polyval.h)
+ * so kernels ported between the two architectures evaluate their polynomials identically.
+ *
+ * @note Horner's method is used for numerical stability and O(N) complexity.
+ * @note For N == 0, returns U{0}. For N == 1, returns the constant term.
+ * @note Switching schemes changes floating-point rounding, so results for a polynomial evaluated with
+ *       the split differ slightly (in the last bits) from the pure-Horner result. Passing a
+ *       SplitThreshold above the coefficient count pins a call site to plain Horner, which
+ *       register-tight kernels need: the split keeps ~2 extra LRegs live.
  *
  * @see https://en.wikipedia.org/wiki/Horner%27s_method
+ * @see https://en.wikipedia.org/wiki/Estrin%27s_scheme
  */
 struct PolynomialEvaluator
 {
-    /**
-     * @brief Evaluates the polynomial at the given point.
-     *
-     * @param x The point at which to evaluate the polynomial
-     * @param coeff0 First coefficient in the polynomial.
-     * @param other_coefficients Rest of the polynomial coefficients in ascending order of powers.
-     * @return The value of the polynomial at the given point
-     *
-     * @note Coefficients can be either float, sfpi::vFloat, ... (scalar and sfpi typed arguments can be mixed)
-     */
+    // Number of coefficients at (or above) which the even/odd interleaved scheme is used instead of
+    // plain Horner. 6 is the crossover where the split's critical path (ceil(N/2)-1 chain + x^2 + combine)
+    // first becomes strictly shorter than Horner's N-1 serial multiply-adds.
+    static constexpr int DefaultSplitThreshold = 6;
 
-    // Base case: f(x) = 0 (empty polynomial)
+private:
+    // Holds the two independent partial results of the even/odd split. The even and odd accumulators
+    // may have different types (e.g. one purely scalar, one sfpi::vFloat), hence two type parameters.
+    template <typename E, typename O>
+    struct EvenOdd {
+        E even;
+        O odd;
+    };
+
+    // Plain Horner's method: coeff0 + x * (coeff1 + x * (...)). Serial multiply-add chain.
     template <typename U>
-    sfpi_inline static constexpr auto eval(U x)
-    {
+    sfpi_inline static constexpr auto horner([[maybe_unused]] U x) {
         return U {0};
     }
 
     template <typename U, typename Coefficient0>
-    sfpi_inline static constexpr auto eval([[maybe_unused]] U x, Coefficient0 coeff0)
-    {
-        // Base case: f(x) = coeff0 (0-th degree polynomial)
+    sfpi_inline static constexpr auto horner([[maybe_unused]] U x, Coefficient0 coeff0) {
         return coeff0;
     }
 
     template <typename U, typename Coefficient0, typename... OtherCoefficients>
-    sfpi_inline static constexpr auto eval(U x, Coefficient0 coeff0, OtherCoefficients... other_coefficients)
-    {
-        // Recursive case: Horner's method
-        return coeff0 + x * eval(x, other_coefficients...);
+    sfpi_inline static constexpr auto horner(U x, Coefficient0 coeff0, OtherCoefficients... other_coefficients) {
+        return coeff0 + x * horner(x, other_coefficients...);
+    }
+
+    // Even/odd split evaluated in y = x^2. Peels two coefficients per step (one even, one odd) and
+    // threads two independent Horner accumulators so the resulting multiply-adds can be interleaved.
+    template <typename U>
+    sfpi_inline static constexpr auto split([[maybe_unused]] U y) {
+        return EvenOdd<U, U>{U{0}, U{0}};
+    }
+
+    template <typename U, typename Coefficient0>
+    sfpi_inline static constexpr auto split([[maybe_unused]] U y, Coefficient0 coeff0) {
+        return EvenOdd<Coefficient0, U>{coeff0, U{0}};
+    }
+
+    template <typename U, typename Coefficient0, typename Coefficient1>
+    sfpi_inline static constexpr auto split([[maybe_unused]] U y, Coefficient0 coeff0, Coefficient1 coeff1) {
+        return EvenOdd<Coefficient0, Coefficient1>{coeff0, coeff1};
+    }
+
+    template <typename U, typename Coefficient0, typename Coefficient1, typename... OtherCoefficients>
+    sfpi_inline static constexpr auto split(
+        U y, Coefficient0 coeff0, Coefficient1 coeff1, OtherCoefficients... other_coefficients) {
+        auto rest = split(y, other_coefficients...);
+        auto even = coeff0 + y * rest.even;
+        auto odd = coeff1 + y * rest.odd;
+        return EvenOdd<decltype(even), decltype(odd)>{even, odd};
+    }
+
+public:
+    /**
+     * @brief Evaluates the polynomial at the given point.
+     *
+     * @tparam SplitThreshold Minimum number of coefficients required to switch from plain Horner to the
+     *         interleaved even/odd scheme. Defaults to DefaultSplitThreshold.
+     * @param x The point at which to evaluate the polynomial
+     * @param coefficients Polynomial coefficients in ascending order of powers.
+     * @return The value of the polynomial at the given point
+     *
+     * @note Coefficients can be either float, sfpi::vFloat, ... (scalar and sfpi typed arguments can be mixed)
+     */
+    template <int SplitThreshold = DefaultSplitThreshold, typename U, typename... Coefficients>
+    sfpi_inline static constexpr auto eval(U x, Coefficients... coefficients) {
+        if constexpr (static_cast<int>(sizeof...(Coefficients)) >= SplitThreshold) {
+            // P(x) = E(x^2) + x * O(x^2), with E and O evaluated as independent (interleavable) chains.
+            U x2 = x * x;
+            auto parts = split(x2, coefficients...);
+            return parts.even + x * parts.odd;
+        } else {
+            return horner(x, coefficients...);
+        }
     }
 };
 

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/gelu.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/gelu.h
@@ -16,11 +16,7 @@ namespace ckernel {
  */
 template <bool fast_and_approx = true>
 ALWI void gelu_tile_init() {
-#ifndef ARCH_QUASAR
     MATH(SFPU_UNARY_INIT_FN(gelu, sfpu::gelu_init, (fast_and_approx, DST_ACCUM_MODE)));
-#else
-    MATH(SFPU_UNARY_INIT_FN(gelu, sfpu::gelu_init, (fast_and_approx)));
-#endif
 }
 
 // clang-format off
@@ -40,18 +36,8 @@ ALWI void gelu_tile_init() {
 // clang-format on
 template <bool fast_and_approx = true>
 ALWI void gelu_tile(uint32_t idst) {
-#ifndef ARCH_QUASAR
     MATH(SFPU_UNARY_CALL(
         DST_SYNC_MODE, DST_ACCUM_MODE, calculate_gelu, (fast_and_approx, DST_ACCUM_MODE), idst, VectorMode::RC));
-#else
-    MATH(SFPU_UNARY_CALL(
-        DST_SYNC_MODE,
-        DST_ACCUM_MODE,
-        calculate_gelu,
-        (fast_and_approx, SFPU_ITERATIONS),
-        idst,
-        ::ckernel::VectorMode::RC));
-#endif
 }
 
 #ifndef ARCH_QUASAR

--- a/tt_metal/tt-llk/tests/helpers/include/sfpu_operations_quasar.h
+++ b/tt_metal/tt-llk/tests/helpers/include/sfpu_operations_quasar.h
@@ -91,14 +91,15 @@ inline constexpr bool is_trig_op(SfpuType op)
  * @brief Run the per-operation init step for a Quasar unary SFPU op.
  *
  * @tparam OPERATION The SFPU operation type (compile-time `SfpuType` constant).
+ * @tparam is_fp32_dest_acc_en 32-bit Dest; ops whose init depends on the Dest width read it (gelu).
  * @note Pair with @ref call_unary_sfpu_operation_quasar for the calculate step.
  */
-template <SfpuType OPERATION, bool is_fp32_dest_acc_en, bool APPROX = false>
+template <SfpuType OPERATION, bool APPROX = false, bool is_fp32_dest_acc_en = false>
 void init_unary_sfpu_operation_quasar()
 {
     if constexpr (OPERATION == SfpuType::gelu)
     {
-        gelu_init();
+        gelu_init<APPROX, is_fp32_dest_acc_en>();
     }
     else if constexpr (OPERATION == SfpuType::square)
     {
@@ -217,7 +218,7 @@ void call_unary_sfpu_operation_quasar(std::uint32_t dst_index, DataFormat sfpu_f
     }
     else if constexpr (OPERATION == SfpuType::gelu)
     {
-        SFPU_UNARY_CALL(DST_SYNC, is_fp32_dest_acc_en, calculate_gelu, (true /* APPROX */, ITERATIONS), dst_index, VectorMode::RC);
+        SFPU_UNARY_CALL(DST_SYNC, is_fp32_dest_acc_en, calculate_gelu, (APPROX, is_fp32_dest_acc_en, ITERATIONS), dst_index, VectorMode::RC);
     }
     else if constexpr (OPERATION == SfpuType::relu)
     {

--- a/tt_metal/tt-llk/tests/helpers/include/sfpu_operations_quasar.h
+++ b/tt_metal/tt-llk/tests/helpers/include/sfpu_operations_quasar.h
@@ -94,7 +94,7 @@ inline constexpr bool is_trig_op(SfpuType op)
  * @tparam APPROX Whether operations with approximate and accurate paths use the approximate path.
  * @tparam is_fp32_dest_acc_en 32-bit Dest; ops whose init depends on the Dest width read it (gelu).
  * @note Pair with @ref call_unary_sfpu_operation_quasar for the calculate step, which takes the same
- *       two bools in the same order.
+ *       two bools in the OPPOSITE order (is_fp32_dest_acc_en first).
  */
 template <SfpuType OPERATION, bool APPROX = false, bool is_fp32_dest_acc_en = false>
 void init_unary_sfpu_operation_quasar()
@@ -192,17 +192,17 @@ void call_zero_comp_operation_quasar(std::uint32_t dst_index, DataFormat sfpu_fo
  *
  * @tparam OPERATION The SFPU operation type (compile-time `SfpuType` constant).
  * @tparam DST_SYNC Destination synchronization mode used for bounds checking.
- * @tparam APPROX Whether operations with approximate and accurate paths use the approximate path.
  * @tparam is_fp32_dest_acc_en Whether Dest is in FP32 mode.
+ * @tparam APPROX Whether operations with approximate and accurate paths use the approximate path.
  * @tparam ITERATIONS Number of SFPU loop iterations.
  * @param dst_index Destination tile index operated on (already offset by DST_INDEX).
  * @param sfpu_format SFPU math format; only the comp family reads it (see
  *        @ref call_zero_comp_operation_quasar), float-only ops ignore it.
- * @note Must be preceded by @ref init_unary_sfpu_operation_quasar for the same op. The two bools are
- *       ordered APPROX before is_fp32_dest_acc_en to match that init and the WH/BH helpers; both are
- *       bool, so a transposed call compiles and silently selects the wrong variant.
+ * @note Must be preceded by @ref init_unary_sfpu_operation_quasar for the same op, which takes the same
+ *       two bools in the OPPOSITE order (APPROX first). Both are bool, so transposing them compiles and
+ *       silently selects the wrong variant -- copy the order from the signature, not from the init.
  */
-template <SfpuType OPERATION, DstSync DST_SYNC, bool APPROX, bool is_fp32_dest_acc_en, int ITERATIONS = SFPU_ITERATIONS>
+template <SfpuType OPERATION, DstSync DST_SYNC, bool is_fp32_dest_acc_en, bool APPROX = false, int ITERATIONS = SFPU_ITERATIONS>
 void call_unary_sfpu_operation_quasar(std::uint32_t dst_index, DataFormat sfpu_format = DataFormat::Float32)
 {
     if constexpr (OPERATION == SfpuType::abs)

--- a/tt_metal/tt-llk/tests/helpers/include/sfpu_operations_quasar.h
+++ b/tt_metal/tt-llk/tests/helpers/include/sfpu_operations_quasar.h
@@ -91,8 +91,10 @@ inline constexpr bool is_trig_op(SfpuType op)
  * @brief Run the per-operation init step for a Quasar unary SFPU op.
  *
  * @tparam OPERATION The SFPU operation type (compile-time `SfpuType` constant).
+ * @tparam APPROX Whether operations with approximate and accurate paths use the approximate path.
  * @tparam is_fp32_dest_acc_en 32-bit Dest; ops whose init depends on the Dest width read it (gelu).
- * @note Pair with @ref call_unary_sfpu_operation_quasar for the calculate step.
+ * @note Pair with @ref call_unary_sfpu_operation_quasar for the calculate step, which takes the same
+ *       two bools in the same order.
  */
 template <SfpuType OPERATION, bool APPROX = false, bool is_fp32_dest_acc_en = false>
 void init_unary_sfpu_operation_quasar()
@@ -190,15 +192,17 @@ void call_zero_comp_operation_quasar(std::uint32_t dst_index, DataFormat sfpu_fo
  *
  * @tparam OPERATION The SFPU operation type (compile-time `SfpuType` constant).
  * @tparam DST_SYNC Destination synchronization mode used for bounds checking.
- * @tparam is_fp32_dest_acc_en Whether Dest is in FP32 mode.
  * @tparam APPROX Whether operations with approximate and accurate paths use the approximate path.
+ * @tparam is_fp32_dest_acc_en Whether Dest is in FP32 mode.
  * @tparam ITERATIONS Number of SFPU loop iterations.
  * @param dst_index Destination tile index operated on (already offset by DST_INDEX).
  * @param sfpu_format SFPU math format; only the comp family reads it (see
  *        @ref call_zero_comp_operation_quasar), float-only ops ignore it.
- * @note Must be preceded by @ref init_unary_sfpu_operation_quasar for the same op.
+ * @note Must be preceded by @ref init_unary_sfpu_operation_quasar for the same op. The two bools are
+ *       ordered APPROX before is_fp32_dest_acc_en to match that init and the WH/BH helpers; both are
+ *       bool, so a transposed call compiles and silently selects the wrong variant.
  */
-template <SfpuType OPERATION, DstSync DST_SYNC, bool is_fp32_dest_acc_en, bool APPROX = false, int ITERATIONS = SFPU_ITERATIONS>
+template <SfpuType OPERATION, DstSync DST_SYNC, bool APPROX, bool is_fp32_dest_acc_en, int ITERATIONS = SFPU_ITERATIONS>
 void call_unary_sfpu_operation_quasar(std::uint32_t dst_index, DataFormat sfpu_format = DataFormat::Float32)
 {
     if constexpr (OPERATION == SfpuType::abs)

--- a/tt_metal/tt-llk/tests/helpers/include/sfpu_operations_quasar.h
+++ b/tt_metal/tt-llk/tests/helpers/include/sfpu_operations_quasar.h
@@ -91,12 +91,9 @@ inline constexpr bool is_trig_op(SfpuType op)
  * @brief Run the per-operation init step for a Quasar unary SFPU op.
  *
  * @tparam OPERATION The SFPU operation type (compile-time `SfpuType` constant).
- * @tparam APPROX Whether operations with approximate and accurate paths use the approximate path.
- * @tparam is_fp32_dest_acc_en 32-bit Dest; ops whose init depends on the Dest width read it (gelu).
- * @note Pair with @ref call_unary_sfpu_operation_quasar for the calculate step, which takes the same
- *       two bools in the OPPOSITE order (is_fp32_dest_acc_en first).
+ * @note Pair with @ref call_unary_sfpu_operation_quasar for the calculate step.
  */
-template <SfpuType OPERATION, bool APPROX = false, bool is_fp32_dest_acc_en = false>
+template <SfpuType OPERATION, bool is_fp32_dest_acc_en, bool APPROX = false>
 void init_unary_sfpu_operation_quasar()
 {
     if constexpr (OPERATION == SfpuType::gelu)
@@ -198,9 +195,7 @@ void call_zero_comp_operation_quasar(std::uint32_t dst_index, DataFormat sfpu_fo
  * @param dst_index Destination tile index operated on (already offset by DST_INDEX).
  * @param sfpu_format SFPU math format; only the comp family reads it (see
  *        @ref call_zero_comp_operation_quasar), float-only ops ignore it.
- * @note Must be preceded by @ref init_unary_sfpu_operation_quasar for the same op, which takes the same
- *       two bools in the OPPOSITE order (APPROX first). Both are bool, so transposing them compiles and
- *       silently selects the wrong variant -- copy the order from the signature, not from the init.
+ * @note Must be preceded by @ref init_unary_sfpu_operation_quasar for the same op.
  */
 template <SfpuType OPERATION, DstSync DST_SYNC, bool is_fp32_dest_acc_en, bool APPROX = false, int ITERATIONS = SFPU_ITERATIONS>
 void call_unary_sfpu_operation_quasar(std::uint32_t dst_index, DataFormat sfpu_format = DataFormat::Float32)

--- a/tt_metal/tt-llk/tests/python_tests/fuser/quasar/sfpu/unary.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/quasar/sfpu/unary.py
@@ -107,7 +107,7 @@ class UnarySfpu(Sfpu):
         sfpu_format = config.sentinel._math_format.cpp_enum_value
         return (
             f"    test_utils::call_unary_sfpu_operation_quasar<"
-            f"{op}, {dest_sync}, false, {en_32bit_dest}, {self.iterations}"
+            f"{op}, {dest_sync}, {en_32bit_dest}, false, {self.iterations}"
             f">({self.dest_idx}, {sfpu_format});\n"
         )
 

--- a/tt_metal/tt-llk/tests/python_tests/fuser/quasar/sfpu/unary.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/quasar/sfpu/unary.py
@@ -91,7 +91,7 @@ class UnarySfpu(Sfpu):
         return (
             f"    // Operation {stage}: Unary {self.operation.cpp_enum_value} SFPU\n"
             f"    _llk_math_eltwise_sfpu_init_();\n"
-            f"    test_utils::init_unary_sfpu_operation_quasar<{op}, false, {en_32bit_dest}>();\n"
+            f"    test_utils::init_unary_sfpu_operation_quasar<{op}, {en_32bit_dest}, false>();\n"
         )
 
     def calculate(

--- a/tt_metal/tt-llk/tests/python_tests/fuser/quasar/sfpu/unary.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/quasar/sfpu/unary.py
@@ -83,9 +83,6 @@ class UnarySfpu(Sfpu):
     ) -> str:
         stage = operation.stage_id
         op = f"SfpuType::{self.operation.cpp_enum_value}"
-        # Dest width has to reach the init too: ops with separate 16/32-bit Dest implementations
-        # (gelu) program different constants for each, so an init that assumed 16-bit would leave
-        # the 32-bit path running without them.
         en_32bit_dest = config.dest_acc.cpp_enum_value
 
         return (

--- a/tt_metal/tt-llk/tests/python_tests/fuser/quasar/sfpu/unary.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/quasar/sfpu/unary.py
@@ -85,10 +85,11 @@ class UnarySfpu(Sfpu):
         op = f"SfpuType::{self.operation.cpp_enum_value}"
         en_32bit_dest = config.dest_acc.cpp_enum_value
 
+        approx_mode = self.approx_mode.cpp_enum_value
         return (
             f"    // Operation {stage}: Unary {self.operation.cpp_enum_value} SFPU\n"
             f"    _llk_math_eltwise_sfpu_init_();\n"
-            f"    test_utils::init_unary_sfpu_operation_quasar<{op}, {en_32bit_dest}, false>();\n"
+            f"    test_utils::init_unary_sfpu_operation_quasar<{op}, {en_32bit_dest}, {approx_mode}>();\n"
         )
 
     def calculate(
@@ -102,9 +103,10 @@ class UnarySfpu(Sfpu):
         dest_sync = operation.dest_sync.cpp_enum_value
         en_32bit_dest = config.dest_acc.cpp_enum_value
         sfpu_format = config.sentinel._math_format.cpp_enum_value
+        approx_mode = self.approx_mode.cpp_enum_value
         return (
             f"    test_utils::call_unary_sfpu_operation_quasar<"
-            f"{op}, {dest_sync}, {en_32bit_dest}, false, {self.iterations}"
+            f"{op}, {dest_sync}, {en_32bit_dest}, {approx_mode}, {self.iterations}"
             f">({self.dest_idx}, {sfpu_format});\n"
         )
 

--- a/tt_metal/tt-llk/tests/python_tests/fuser/quasar/sfpu/unary.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/quasar/sfpu/unary.py
@@ -84,7 +84,6 @@ class UnarySfpu(Sfpu):
         stage = operation.stage_id
         op = f"SfpuType::{self.operation.cpp_enum_value}"
         en_32bit_dest = config.dest_acc.cpp_enum_value
-
         approx_mode = self.approx_mode.cpp_enum_value
         return (
             f"    // Operation {stage}: Unary {self.operation.cpp_enum_value} SFPU\n"

--- a/tt_metal/tt-llk/tests/python_tests/fuser/quasar/sfpu/unary.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/quasar/sfpu/unary.py
@@ -83,11 +83,15 @@ class UnarySfpu(Sfpu):
     ) -> str:
         stage = operation.stage_id
         op = f"SfpuType::{self.operation.cpp_enum_value}"
+        # Dest width has to reach the init too: ops with separate 16/32-bit Dest implementations
+        # (gelu) program different constants for each, so an init that assumed 16-bit would leave
+        # the 32-bit path running without them.
+        en_32bit_dest = config.dest_acc.cpp_enum_value
 
         return (
             f"    // Operation {stage}: Unary {self.operation.cpp_enum_value} SFPU\n"
             f"    _llk_math_eltwise_sfpu_init_();\n"
-            f"    test_utils::init_unary_sfpu_operation_quasar<{op}>();\n"
+            f"    test_utils::init_unary_sfpu_operation_quasar<{op}, false, {en_32bit_dest}>();\n"
         )
 
     def calculate(
@@ -103,7 +107,7 @@ class UnarySfpu(Sfpu):
         sfpu_format = config.sentinel._math_format.cpp_enum_value
         return (
             f"    test_utils::call_unary_sfpu_operation_quasar<"
-            f"{op}, {dest_sync}, {en_32bit_dest}, false, {self.iterations}"
+            f"{op}, {dest_sync}, false, {en_32bit_dest}, {self.iterations}"
             f">({self.dest_idx}, {sfpu_format});\n"
         )
 

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_unary_sfpu_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_unary_sfpu_quasar.py
@@ -643,8 +643,8 @@ OP_CONFIGS = [
     OpConfig(MathOperation.Rsqrt, TENSOR_DIMS, DEST_SYNC_MODES, uniform_spec=True),
     # Nonlinear ops: identical [32,32]/[64,64] × Half/Full × uniform-spec sweep.
     OpConfig(MathOperation.Exp, TENSOR_DIMS, DEST_SYNC_MODES, uniform_spec=True),
-    OpConfig(MathOperation.Gelu, TENSOR_DIMS, DEST_SYNC_MODES, uniform_spec=True),
     OpConfig(MathOperation.Relu, TENSOR_DIMS, DEST_SYNC_MODES, uniform_spec=True),
+    OpConfig(MathOperation.Gelu, TENSOR_DIMS, DEST_SYNC_MODES, uniform_spec=True),
     OpConfig(MathOperation.Reciprocal, TENSOR_DIMS, DEST_SYNC_MODES, uniform_spec=True),
     OpConfig(MathOperation.Sqrt, TENSOR_DIMS, DEST_SYNC_MODES, uniform_spec=True),
     OpConfig(MathOperation.Tanh, TENSOR_DIMS, DEST_SYNC_MODES, uniform_spec=True),

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_unary_sfpu_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_unary_sfpu_quasar.py
@@ -731,7 +731,12 @@ def generate_sfpu_unary_combinations():
         approx_modes = (
             (ApproximationMode.No, ApproximationMode.Yes)
             if cfg.mathop
-            in (MathOperation.Exp, MathOperation.Reciprocal, MathOperation.Rsqrt)
+            in (
+                MathOperation.Exp,
+                MathOperation.Gelu,
+                MathOperation.Reciprocal,
+                MathOperation.Rsqrt,
+            )
             else (ApproximationMode.No,)
         )
         for fmt in formats_for_op(cfg):

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_unary_sfpu_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_unary_sfpu_quasar.py
@@ -643,9 +643,9 @@ OP_CONFIGS = [
     OpConfig(MathOperation.Rsqrt, TENSOR_DIMS, DEST_SYNC_MODES, uniform_spec=True),
     # Nonlinear ops: identical [32,32]/[64,64] × Half/Full × uniform-spec sweep.
     OpConfig(MathOperation.Exp, TENSOR_DIMS, DEST_SYNC_MODES, uniform_spec=True),
+    OpConfig(MathOperation.Gelu, TENSOR_DIMS, DEST_SYNC_MODES, uniform_spec=True),
     OpConfig(MathOperation.Relu, TENSOR_DIMS, DEST_SYNC_MODES, uniform_spec=True),
     OpConfig(MathOperation.Reciprocal, TENSOR_DIMS, DEST_SYNC_MODES, uniform_spec=True),
-    OpConfig(MathOperation.Gelu, TENSOR_DIMS, DEST_SYNC_MODES, uniform_spec=True),
     OpConfig(MathOperation.Sqrt, TENSOR_DIMS, DEST_SYNC_MODES, uniform_spec=True),
     OpConfig(MathOperation.Tanh, TENSOR_DIMS, DEST_SYNC_MODES, uniform_spec=True),
     OpConfig(MathOperation.Sigmoid, TENSOR_DIMS, DEST_SYNC_MODES, uniform_spec=True),

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_unary_sfpu_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_unary_sfpu_quasar.py
@@ -644,8 +644,8 @@ OP_CONFIGS = [
     # Nonlinear ops: identical [32,32]/[64,64] × Half/Full × uniform-spec sweep.
     OpConfig(MathOperation.Exp, TENSOR_DIMS, DEST_SYNC_MODES, uniform_spec=True),
     OpConfig(MathOperation.Relu, TENSOR_DIMS, DEST_SYNC_MODES, uniform_spec=True),
-    OpConfig(MathOperation.Gelu, TENSOR_DIMS, DEST_SYNC_MODES, uniform_spec=True),
     OpConfig(MathOperation.Reciprocal, TENSOR_DIMS, DEST_SYNC_MODES, uniform_spec=True),
+    OpConfig(MathOperation.Gelu, TENSOR_DIMS, DEST_SYNC_MODES, uniform_spec=True),
     OpConfig(MathOperation.Sqrt, TENSOR_DIMS, DEST_SYNC_MODES, uniform_spec=True),
     OpConfig(MathOperation.Tanh, TENSOR_DIMS, DEST_SYNC_MODES, uniform_spec=True),
     OpConfig(MathOperation.Sigmoid, TENSOR_DIMS, DEST_SYNC_MODES, uniform_spec=True),

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_sfpu_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_sfpu_quasar_test.cpp
@@ -170,7 +170,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     // so it is offset by params.DST_INDEX.
     for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
     {
-        test_utils::call_unary_sfpu_operation_quasar<SFPU_UNARY_OPERATION, dest_sync, is_fp32_dest_acc_en, APPROX_MODE>(params.DST_INDEX + i, sfpu_format);
+        test_utils::call_unary_sfpu_operation_quasar<SFPU_UNARY_OPERATION, dest_sync, APPROX_MODE, is_fp32_dest_acc_en>(params.DST_INDEX + i, sfpu_format);
     }
 
     _llk_math_set_dvalid_<p_cleardvalid::SFPU, dest_sync>();

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_sfpu_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_sfpu_quasar_test.cpp
@@ -170,7 +170,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     // so it is offset by params.DST_INDEX.
     for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
     {
-        test_utils::call_unary_sfpu_operation_quasar<SFPU_UNARY_OPERATION, dest_sync, APPROX_MODE, is_fp32_dest_acc_en>(params.DST_INDEX + i, sfpu_format);
+        test_utils::call_unary_sfpu_operation_quasar<SFPU_UNARY_OPERATION, dest_sync, is_fp32_dest_acc_en, APPROX_MODE>(params.DST_INDEX + i, sfpu_format);
     }
 
     _llk_math_set_dvalid_<p_cleardvalid::SFPU, dest_sync>();

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_sfpu_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_sfpu_quasar_test.cpp
@@ -161,7 +161,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     }
 
     _llk_math_eltwise_sfpu_init_();
-    test_utils::init_unary_sfpu_operation_quasar<SFPU_UNARY_OPERATION, APPROX_MODE, is_fp32_dest_acc_en>();
+    test_utils::init_unary_sfpu_operation_quasar<SFPU_UNARY_OPERATION, is_fp32_dest_acc_en, APPROX_MODE>();
 
     const DataFormat sfpu_format = static_cast<DataFormat>(formats.sfpu_math);
 

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_sfpu_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_sfpu_quasar_test.cpp
@@ -161,7 +161,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     }
 
     _llk_math_eltwise_sfpu_init_();
-    test_utils::init_unary_sfpu_operation_quasar<SFPU_UNARY_OPERATION, is_fp32_dest_acc_en, APPROX_MODE>();
+    test_utils::init_unary_sfpu_operation_quasar<SFPU_UNARY_OPERATION, APPROX_MODE, is_fp32_dest_acc_en>();
 
     const DataFormat sfpu_format = static_cast<DataFormat>(formats.sfpu_math);
 

--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_relu.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_relu.h
@@ -64,7 +64,7 @@ inline void _calculate_lrelu_(const std::uint32_t slope)
         _calculate_lrelu_sfp_rows_();
         ckernel::math::_incr_counters_<0x0, 0x0, ckernel::math::SFP_ROWS, 0x0>(); // does the dest_reg++ (increments by 2 rows)
     }
-    TTI_SFPENCC(0, 2); // disable cc
+    TTI_SFPENCC(0x3, 0xA);
 }
 
 // Calculates RELU MIN for number of rows of output SFPU ops (Quasar = 2 rows)
@@ -95,7 +95,7 @@ inline void _relu_min_(const std::uint32_t threshold)
         _calculate_relu_min_sfp_rows_();
         ckernel::math::_incr_counters_<0x0, 0x0, ckernel::math::SFP_ROWS, 0x0>(); // does the dest_reg++ (increments by 2 rows)
     }
-    TTI_SFPENCC(0, 2); // disable cc
+    TTI_SFPENCC(0x3, 0xA);
 }
 
 // Calculates RELU MAX for number of rows of output SFPU ops (Quasar = 2 rows)
@@ -131,7 +131,7 @@ inline void _relu_max_(const std::uint32_t threshold)
         _calculate_relu_max_sfp_rows_();
         ckernel::math::_incr_counters_<0x0, 0x0, ckernel::math::SFP_ROWS, 0x0>(); // does the dest_reg++ (increments by 2 rows)
     }
-    TTI_SFPENCC(0, 2); // disable cc
+    TTI_SFPENCC(0x3, 0xA);
 }
 
 } // namespace sfpu

--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_relu.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_relu.h
@@ -64,6 +64,7 @@ inline void _calculate_lrelu_(const std::uint32_t slope)
         _calculate_lrelu_sfp_rows_();
         ckernel::math::_incr_counters_<0x0, 0x0, ckernel::math::SFP_ROWS, 0x0>(); // does the dest_reg++ (increments by 2 rows)
     }
+    // Leave the CC enabled with all lanes active. CC state is per-core and nothing reloads it between kernels
     TTI_SFPENCC(0x3, 0xA);
 }
 
@@ -95,7 +96,7 @@ inline void _relu_min_(const std::uint32_t threshold)
         _calculate_relu_min_sfp_rows_();
         ckernel::math::_incr_counters_<0x0, 0x0, ckernel::math::SFP_ROWS, 0x0>(); // does the dest_reg++ (increments by 2 rows)
     }
-    TTI_SFPENCC(0x3, 0xA);
+    TTI_SFPENCC(0x3, 0xA); // leave the CC enabled, see _calculate_lrelu_
 }
 
 // Calculates RELU MAX for number of rows of output SFPU ops (Quasar = 2 rows)
@@ -131,7 +132,7 @@ inline void _relu_max_(const std::uint32_t threshold)
         _calculate_relu_max_sfp_rows_();
         ckernel::math::_incr_counters_<0x0, 0x0, ckernel::math::SFP_ROWS, 0x0>(); // does the dest_reg++ (increments by 2 rows)
     }
-    TTI_SFPENCC(0x3, 0xA);
+    TTI_SFPENCC(0x3, 0xA); // leave the CC enabled, see _calculate_lrelu_
 }
 
 } // namespace sfpu


### PR DESCRIPTION
### PR Category
Feature

### Summary
Added implementation for non-approx gelu for Quasar. This PR is self-contained, end-to-end solution, going from the LLK to Compute API.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=filip/nonapprox-gelu)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:filip/nonapprox-gelu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=filip/nonapprox-gelu)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:filip/nonapprox-gelu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=filip/nonapprox-gelu)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:filip/nonapprox-gelu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=filip/nonapprox-gelu)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:filip/nonapprox-gelu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=filip/nonapprox-gelu)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:filip/nonapprox-gelu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=filip/nonapprox-gelu)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:filip/nonapprox-gelu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=filip/nonapprox-gelu)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:filip/nonapprox-gelu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=filip/nonapprox-gelu)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:filip/nonapprox-gelu)