### PR TITLE
[Bug Fix] Fix use after free for MemoryConfig in move op

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/move/move.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/move/move.cpp
@@ -121,8 +121,6 @@ inline Tensor move_impl(const Tensor& input_tensor, const std::optional<MemoryCo
 inline Tensor move_sharded(const Tensor& input_tensor, const std::optional<MemoryConfig>& mem_config) {
     TT_ASSERT(input_tensor.is_allocated(), "Expected input tensor to be allocated");
     TT_FATAL(input_tensor.memory_config().is_sharded(), "Expected input tensor to be sharded");
-    [[maybe_unused]] auto input_address = input_tensor.buffer()->address();
-    auto shard_spec = input_tensor.shard_spec().value();
 
     // Construct a ghost tensor so we can pass an deallocated tensor through the TTNN infrastructure.
     auto ghost_input_tensor = create_ghost_tensor(input_tensor);
@@ -136,6 +134,9 @@ inline Tensor move_sharded(const Tensor& input_tensor, const std::optional<Memor
         // TODO: Should this throw error?
         return {input_tensor};
     }
+
+    [[maybe_unused]] auto input_address = ghost_input_tensor.buffer()->address();
+    auto shard_spec = ghost_input_tensor.shard_spec().value();
 
     auto output_tensor_spec = ghost_input_tensor.tensor_spec();
     if (mem_config) {

--- a/ttnn/cpp/ttnn/operations/data_movement/move/move.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/move/move.cpp
@@ -34,9 +34,6 @@ Tensor create_ghost_tensor(const Tensor& input_tensor) {
 
 inline Tensor move_impl(const Tensor& input_tensor, const std::optional<MemoryConfig>& mem_config) {
     TT_ASSERT(input_tensor.is_allocated(), "Expected input tensor to be allocated");
-    const auto& input_mem_config = input_tensor.memory_config();
-    auto input_address = input_tensor.buffer()->address();
-    tt::tt_metal::TensorSpec output_tensor_spec = input_tensor.tensor_spec();
 
     // Construct a ghost tensor so we can pass an deallocated tensor through the TTNN infrastructure.
     auto ghost_input_tensor = create_ghost_tensor(input_tensor);
@@ -45,6 +42,10 @@ inline Tensor move_impl(const Tensor& input_tensor, const std::optional<MemoryCo
         // TODO: Should this throw error?
         return input_tensor;
     }
+
+    auto input_address = ghost_input_tensor.buffer()->address();
+    tt::tt_metal::TensorSpec output_tensor_spec = ghost_input_tensor.tensor_spec();
+    const auto& input_mem_config = ghost_input_tensor.memory_config();
 
     if (mem_config) {
         output_tensor_spec = tt::tt_metal::TensorSpec(

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/move/move.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/move/move.cpp
@@ -33,9 +33,6 @@ Tensor create_ghost_tensor(const Tensor& input_tensor) {
 
 inline Tensor move_impl(const Tensor& input_tensor, const std::optional<MemoryConfig>& mem_config) {
     TT_ASSERT(input_tensor.is_allocated(), "Expected input tensor to be allocated");
-    const auto& input_mem_config = input_tensor.memory_config();
-    auto input_address = input_tensor.buffer()->address();
-    tt::tt_metal::TensorSpec output_tensor_spec = input_tensor.tensor_spec();
 
     // Construct a ghost tensor so we can pass an deallocated tensor through the TTNN infrastructure.
     auto ghost_input_tensor = create_ghost_tensor(input_tensor);
@@ -44,6 +41,10 @@ inline Tensor move_impl(const Tensor& input_tensor, const std::optional<MemoryCo
         // TODO: Should this throw error?
         return input_tensor;
     }
+
+    auto input_address = ghost_input_tensor.buffer()->address();
+    tt::tt_metal::TensorSpec output_tensor_spec = ghost_input_tensor.tensor_spec();
+    const auto& input_mem_config = ghost_input_tensor.memory_config();
 
     if (mem_config) {
         output_tensor_spec = tt::tt_metal::TensorSpec(
@@ -120,8 +121,6 @@ inline Tensor move_impl(const Tensor& input_tensor, const std::optional<MemoryCo
 inline Tensor move_sharded(const Tensor& input_tensor, const std::optional<MemoryConfig>& mem_config) {
     TT_ASSERT(input_tensor.is_allocated(), "Expected input tensor to be allocated");
     TT_FATAL(input_tensor.memory_config().is_sharded(), "Expected input tensor to be sharded");
-    [[maybe_unused]] auto input_address = input_tensor.buffer()->address();
-    auto shard_spec = input_tensor.shard_spec().value();
 
     // Construct a ghost tensor so we can pass an deallocated tensor through the TTNN infrastructure.
     auto ghost_input_tensor = create_ghost_tensor(input_tensor);
@@ -135,6 +134,9 @@ inline Tensor move_sharded(const Tensor& input_tensor, const std::optional<Memor
         // TODO: Should this throw error?
         return {input_tensor};
     }
+
+    [[maybe_unused]] auto input_address = ghost_input_tensor.buffer()->address();
+    auto shard_spec = ghost_input_tensor.shard_spec().value();
 
     auto output_tensor_spec = ghost_input_tensor.tensor_spec();
     if (mem_config) {


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

Bug Fix

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->
     
Move op depends deallocating and reallocating the tensor.

However the op maintains a reference to the `MemoryConfig` of the tensor before deallocation, and trys to use it after deallocation. Which is a latent use-after-free that was discovered after #47732 , where moved from state is now explicitly checked.

This PR fixes these use-after-free by reordering operations.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

Verification (stable difusion):
Was: https://github.com/tenstorrent/tt-metal/actions/runs/30475386074/job/90661737521
Now: https://github.com/tenstorrent/tt-metal/actions/runs/30493796641

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=riverwu/move-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:riverwu/move-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=riverwu/move-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:riverwu/move-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=riverwu/move-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:riverwu/move-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=riverwu/move-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:riverwu/move-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=riverwu/move-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:riverwu/move-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=riverwu/move-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:riverwu/move-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=riverwu/move-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:riverwu/move-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=riverwu/move-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:riverwu/move-fix)