### PR TITLE
feat: enhance error logs on quasar wrt hw faults

### DIFF
--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_assert.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_assert.cpp
@@ -573,7 +573,8 @@ INSTANTIATE_TEST_SUITE_P(
         // These report the PC up front, same as the DM faults.
         HwFaultMessageParams{
             "Trisc0TtiBufferHang", 0x0016, 0x1234, {"at PC 0x00001234", "Neo 0 TRISC0", "TTI_BUFFER_HANG"}, {}},
-        HwFaultMessageParams{"Trisc1MemAccessHang", 0x0119, 0x1234, {"Neo 0 TRISC1", "MEM_ACCESS_HANG"}, {}},
+        HwFaultMessageParams{
+            "Trisc1MemReadNoResponse", 0x0119, 0x1234, {"Neo 0 TRISC1", "MEM_READ_NO_RESPONSE"}, {}},
         HwFaultMessageParams{"Trisc2StackOverflow", 0x021f, 0x1234, {"Neo 0 TRISC2", "STACK_OVERFLOW"}, {}},
         HwFaultMessageParams{"Trisc3L1IllegalAccess", 0x0328, 0x1234, {"Neo 0 TRISC3", "L1_ILLEGAL_ACCESS"}, {}},
         HwFaultMessageParams{"Neo3Trisc1", 0xc128, 0x1234, {"Neo 3 TRISC1", "L1_ILLEGAL_ACCESS"}, {}},
@@ -668,7 +669,7 @@ TEST(WatcherHwFaultMessage, ExactMessages) {
         // 0x19 and 0x16 are the pair that's easy to mix up, so pin both.
         {0x0119,
          0x00001234,
-         "hardware fault occurred at PC 0x00001234 on Neo 0 TRISC1 with cause: ERROR_TRISC1 (MEM_ACCESS_HANG), "
+         "hardware fault occurred at PC 0x00001234 on Neo 0 TRISC1 with cause: ERROR_TRISC1 (MEM_READ_NO_RESPONSE), "
          "error_code 0x0119"},
         {0x0016,
          0x00001234,

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_assert.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_assert.cpp
@@ -337,7 +337,7 @@ static void RunTest(
             << "Expected pattern: " << pattern << "\nActual: " << exception;
     } else if (assert_type == dev_msgs::DebugAssertHwFault) {
         // Build regex pattern from string expected, replacing PC 0x0 with PC 0x[\da-fA-F]+
-        // or instruction: 0x00000000 with instruction: 0x[\da-fA-F]+
+        // or the trailing ERR_DATA value 0x00000000 with 0x[\da-fA-F]+
         std::string pattern = regex_escape(expected);
         if (processor.processor_class == HalProcessorClassType::DM) {
             const std::string pc_placeholder = "PC 0x0";
@@ -346,11 +346,14 @@ static void RunTest(
                 << "Expected placeholder '" << pc_placeholder << "' not found in escaped pattern: " << pattern;
             pattern.replace(pos, pc_placeholder.length(), "PC 0x[\\da-fA-F]+");
         } else if (processor.processor_class == HalProcessorClassType::COMPUTE) {
-            const std::string instruction_placeholder = "instruction: 0x00000000";
-            size_t pos = pattern.find(instruction_placeholder);
+            // Where ERR_DATA appears and what it's called both depend on the error block: a
+            // leading PC for per-TRISC errors, otherwise a trailing semaphore index, counter
+            // index or instruction. Match on the value, which is the only 8-digit field.
+            const std::string data_placeholder = "0x00000000";
+            size_t pos = pattern.rfind(data_placeholder);
             ASSERT_NE(pos, std::string::npos)
-                << "Expected placeholder '" << instruction_placeholder << "' not found in escaped pattern: " << pattern;
-            pattern.replace(pos, instruction_placeholder.length(), "instruction: 0x[\\da-fA-F]+");
+                << "Expected placeholder '" << data_placeholder << "' not found in escaped pattern: " << pattern;
+            pattern.replace(pos, data_placeholder.length(), "0x[\\da-fA-F]+");
         }
         EXPECT_TRUE(std::regex_match(exception, std::regex(pattern)))
             << "Expected pattern: " << pattern << "\nActual: " << exception;

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_assert.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_assert.cpp
@@ -655,6 +655,55 @@ TEST(WatcherHwFaultMessage, IllegalInstructionThreadOrderIsReversed) {
     }
 }
 
+// Full expected strings for a handful of codes. The table above covers breadth but only checks
+// pieces, so a scrambled field order or stray text would slip through it. Deliberately short:
+// every message reword has to touch these by hand.
+TEST(WatcherHwFaultMessage, ExactMessages) {
+    struct Golden {
+        uint32_t error_code;
+        uint32_t err_data;
+        std::string expected;
+    };
+    const std::vector<Golden> golden = {
+        // 0x19 and 0x16 are the pair that's easy to mix up, so pin both.
+        {0x0119,
+         0x00001234,
+         "hardware fault occurred at PC 0x00001234 on Neo 0 TRISC1 with cause: ERROR_TRISC1 (MEM_ACCESS_HANG), "
+         "error_code 0x0119"},
+        {0x0016,
+         0x00001234,
+         "hardware fault occurred at PC 0x00001234 on Neo 0 TRISC0 with cause: ERROR_TRISC0 (TTI_BUFFER_HANG), "
+         "error_code 0x0016"},
+        // Backwards thread numbering plus the trailing-field shape.
+        {0x2041,
+         0x00001234,
+         "hardware fault occurred on Neo 0 TRISC3 with cause: ILLEGAL_INSTRUCTION_TRISC3 (opcode 0x41), "
+         "error_code 0x2041, offending instruction: 0x00001234"},
+        // Both sticky bits joined.
+        {0x0e03,
+         0,
+         "hardware fault occurred on Neo 0 with cause: SFPU (CC_STACK_OVERFLOW + CC_STACK_UNDERFLOW), "
+         "error_code 0x0e03, faulting address or instruction: 0x00000000"},
+        {0x0c03,
+         0x00000100,
+         "hardware fault occurred on Neo 0 with cause: NEO_SEMAPHORES (GET_ON_UNINITIALIZED), error_code 0x0c03, "
+         "semaphore index: 0x00000100"},
+        {0x3f00,
+         0,
+         "hardware fault occurred on Neo 0 with cause: unknown code 0x3f, error_code 0x3f00, "
+         "faulting address or instruction: 0x00000000"},
+        // A DM mcause, which takes the other branch entirely.
+        {static_cast<uint32_t>(DmErrors::LOAD_ACCESS_FAULT),
+         0x00001234,
+         "hardware fault occurred at PC 0x0. Cause: LOAD_ACCESS_FAULT, faulting address or instruction: 0x00001234"},
+    };
+    for (const auto& g : golden) {
+        const uint64_t hw_fault_info = (static_cast<uint64_t>(g.err_data) << 32) | g.error_code;
+        EXPECT_EQ(get_debug_assert_message(dev_msgs::DebugAssertHwFault, 0, hw_fault_info), g.expected)
+            << "error_code 0x" << std::hex << g.error_code;
+    }
+}
+
 // The caller reads an empty message as data corruption, so nothing should produce one.
 TEST(WatcherHwFaultMessage, NeverEmptyForAnyErrorCode) {
     for (uint32_t error_code = 0; error_code <= 0xffff; error_code++) {

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_assert.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_assert.cpp
@@ -285,12 +285,27 @@ static void RunTest(
     // DM errors are using the error values, as they are directly returned by the hardware
     // TRISC errors are spread and have different meanings, so using 5,7 the same as DM (illegal access)
     // and adding new cases 8 and 9.
+    //
+    // Build the compute codes from the TRISC under test instead of hardcoding them, so a cause
+    // can run on any TRISC. Layout is [13:8] block, [7:0] index.
     if (processor.processor_class == HalProcessorClassType::COMPUTE) {
+        const uint32_t trisc = static_cast<uint32_t>(processor.processor_type);
         switch (hw_assert_cause) {
+            // ERROR_TRISC<n>, illegal access.
             case 5:
-            case 7: hw_assert_cause = 0x128; break;
-            case 8: hw_assert_cause = 0x23bc; break;
-            case 9: hw_assert_cause = 0xc03; break;
+            case 7:
+                hw_assert_cause = (trisc << 8) | static_cast<uint32_t>(TriscRiscErrors::L1_ILLEGAL_ACCESS);
+                break;
+            // ILLEGAL_INSTRUCTION_TRISC<n>, backwards numbered, plus the opcode the kernel hits.
+            case 8:
+                hw_assert_cause =
+                    ((static_cast<uint32_t>(TriscErrors::ILLEGAL_INSTRUCTION_TRISC0) - trisc) << 8) | 0xbc;
+                break;
+            // Neo level, so the same code on every TRISC.
+            case 9:
+                hw_assert_cause = (static_cast<uint32_t>(TriscErrors::NEO_SEMAPHORES) << 8) |
+                                  static_cast<uint32_t>(SemaphoreErrors::GET_ON_UNINITIALIZED);
+                break;
             default: hw_assert_cause = 0; break;
         }
     } else {
@@ -502,6 +517,11 @@ INSTANTIATE_TEST_SUITE_P(
         WatcherTestParams{"ComputeHWFaultWrite", {TENSIX, COMPUTE, 1}, dev_msgs::DebugAssertHwFault, 7},
         WatcherTestParams{"ComputeHWFaultIllegalInstruction", {TENSIX, COMPUTE, 0}, dev_msgs::DebugAssertHwFault, 8},
         WatcherTestParams{"ComputeHWFaultSemaphore", {TENSIX, COMPUTE, 0}, dev_msgs::DebugAssertHwFault, 9},
+        // Both ends of the block numbering on real silicon: block 0, and block 32 where the
+        // backwards ordering starts. These hang the board, so keep it to two.
+        WatcherTestParams{"ComputeHWFaultReadTrisc0", {TENSIX, COMPUTE, 0}, dev_msgs::DebugAssertHwFault, 5},
+        WatcherTestParams{
+            "ComputeHWFaultIllegalInstructionTrisc3", {TENSIX, COMPUTE, 3}, dev_msgs::DebugAssertHwFault, 8},
         WatcherTestParams{"Trisc0", {TENSIX, COMPUTE, 0}, dev_msgs::DebugAssertNCriscNOCNonpostedWritesSentTripped},
         WatcherTestParams{"Trisc1", {TENSIX, COMPUTE, 1}, dev_msgs::DebugAssertNCriscNOCPostedWritesSentTripped},
         WatcherTestParams{"Trisc2", {TENSIX, COMPUTE, 2}, dev_msgs::DebugAssertNCriscNOCReadsFlushedTripped},
@@ -512,5 +532,135 @@ INSTANTIATE_TEST_SUITE_P(
         WatcherTestParams{"Drisc", {DRAM, DM, 0}, dev_msgs::DebugAssertTripped},
         WatcherTestParams{"DispatchDM2", {DISPATCH, DM, 2}, dev_msgs::DebugAssertTripped}),
     [](const ::testing::TestParamInfo<WatcherTestParams>& info) { return info.param.test_name; });
+
+}  // namespace
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// Decoding of the Quasar hw fault error codes. No device needed here, so we can cover the
+// codes the tests above can't reach: the kernel only knows how to trigger a few real faults.
+// Checking substrings, otherwise every reworded message churns the whole table.
+//////////////////////////////////////////////////////////////////////////////////////////
+namespace {
+
+struct HwFaultMessageParams {
+    std::string test_name;
+    uint32_t error_code;
+    uint32_t err_data;
+    std::vector<std::string> expected;
+    std::vector<std::string> forbidden;
+};
+
+class WatcherHwFaultMessageTest : public ::testing::TestWithParam<HwFaultMessageParams> {};
+
+TEST_P(WatcherHwFaultMessageTest, Decodes) {
+    const auto& p = GetParam();
+    const uint64_t hw_fault_info = (static_cast<uint64_t>(p.err_data) << 32) | p.error_code;
+    const std::string msg = get_debug_assert_message(dev_msgs::DebugAssertHwFault, 0, hw_fault_info);
+
+    ASSERT_FALSE(msg.empty()) << "no message for error_code 0x" << std::hex << p.error_code;
+    for (const auto& s : p.expected) {
+        EXPECT_NE(msg.find(s), std::string::npos) << "missing \"" << s << "\" in: " << msg;
+    }
+    for (const auto& s : p.forbidden) {
+        EXPECT_EQ(msg.find(s), std::string::npos) << "unexpected \"" << s << "\" in: " << msg;
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    WatcherHwFaultMessageTests,
+    WatcherHwFaultMessageTest,
+    ::testing::Values(
+        // These report the PC up front, same as the DM faults.
+        HwFaultMessageParams{
+            "Trisc0TtiBufferHang", 0x0016, 0x1234, {"at PC 0x00001234", "Neo 0 TRISC0", "TTI_BUFFER_HANG"}, {}},
+        HwFaultMessageParams{"Trisc1MemAccessHang", 0x0119, 0x1234, {"Neo 0 TRISC1", "MEM_ACCESS_HANG"}, {}},
+        HwFaultMessageParams{"Trisc2StackOverflow", 0x021f, 0x1234, {"Neo 0 TRISC2", "STACK_OVERFLOW"}, {}},
+        HwFaultMessageParams{"Trisc3L1IllegalAccess", 0x0328, 0x1234, {"Neo 0 TRISC3", "L1_ILLEGAL_ACCESS"}, {}},
+        HwFaultMessageParams{"Neo3Trisc1", 0xc128, 0x1234, {"Neo 3 TRISC1", "L1_ILLEGAL_ACCESS"}, {}},
+        HwFaultMessageParams{"TriscUnknownIndex", 0x0099, 0x1234, {"Neo 0 TRISC0", "unknown code 0x99"}, {}},
+
+        // Blocks 32..35 run backwards: 32 is TRISC3, 35 is TRISC0.
+        HwFaultMessageParams{
+            "IllegalInstructionTrisc3",
+            0x2041,
+            0x1234,
+            {"Neo 0 TRISC3", "ILLEGAL_INSTRUCTION_TRISC3", "opcode 0x41", "offending instruction: 0x00001234"},
+            {"at PC"}},
+        HwFaultMessageParams{
+            "IllegalInstructionTrisc0", 0x2341, 0x1234, {"Neo 0 TRISC0", "ILLEGAL_INSTRUCTION_TRISC0"}, {}},
+
+        // Blocks 5,6,7 are the unpackers, 8,9 the packers.
+        HwFaultMessageParams{"Unpacker0BadFormat", 0x0500, 0, {"UNPACKER_0", "ILLEGAL_FORMAT_CONVERSION"}, {"TRISC"}},
+        HwFaultMessageParams{"Unpacker2LimitBelowStart", 0x0701, 0, {"UNPACKER_2", "BUFFER_LIMIT_BELOW_START"}, {}},
+        HwFaultMessageParams{"Packer0BadTileSize", 0x0802, 0, {"PACKER_0", "ILLEGAL_TILE_SIZE"}, {}},
+        HwFaultMessageParams{"Packer1BadFormat", 0x0900, 0, {"PACKER_1", "ILLEGAL_FORMAT_CONVERSION"}, {}},
+
+        // Semaphore number comes back in ERR_DATA.
+        HwFaultMessageParams{
+            "NeoSemaphoreGetUninit",
+            0x0c03,
+            0x0100,
+            {"NEO_SEMAPHORES", "GET_ON_UNINITIALIZED", "semaphore index: 0x00000100"},
+            {"TRISC", "at PC"}},
+        HwFaultMessageParams{"NeoSemaphoreWaitUninit", 0x0c01, 0, {"WAIT_ON_UNINITIALIZED"}, {}},
+        HwFaultMessageParams{"GlobalSemaphoreGetUnderflow", 0x0d05, 0, {"GLOBAL_SEMAPHORES", "GET_UNDERFLOW"}, {}},
+        HwFaultMessageParams{"GlobalSemaphorePostOverflow", 0x0d04, 0, {"GLOBAL_SEMAPHORES", "POST_OVERFLOW"}, {}},
+        HwFaultMessageParams{"SemaphoreUnknownIndex", 0x0c07, 0, {"NEO_SEMAPHORES", "unknown code 0x07"}, {}},
+
+        // Sticky bitmask, so both bits can be set at once.
+        HwFaultMessageParams{"SfpuCcStackOverflow", 0x0e01, 0, {"SFPU", "CC_STACK_OVERFLOW"}, {"CC_STACK_UNDERFLOW"}},
+        HwFaultMessageParams{"SfpuCcStackUnderflow", 0x0e02, 0, {"SFPU", "CC_STACK_UNDERFLOW"}, {}},
+        HwFaultMessageParams{
+            "SfpuCcStackBothBits", 0x0e03, 0, {"SFPU", "CC_STACK_OVERFLOW + CC_STACK_UNDERFLOW"}, {}},
+
+        // No error index on these, so nothing in parens.
+        HwFaultMessageParams{"EdcFatal", 0x0a00, 0, {"EDC_FATAL_ERROR"}, {"(", "TRISC"}},
+        HwFaultMessageParams{"EdcCorrectable", 0x0b00, 0, {"EDC_CORRECTABLE_ERROR"}, {"("}},
+
+        // Index is which counter tripped, not a reason code.
+        HwFaultMessageParams{
+            "TileCounter7", 0x0f07, 0x0008, {"TILE_COUNTERS", "counter 7", "tile counter index: 0x00000008"}, {}},
+        HwFaultMessageParams{"TileCounter31", 0x0f1f, 0, {"counter 31"}, {}},
+
+        // Should still print something instead of a blank cause.
+        HwFaultMessageParams{"UnallocatedBlock04", 0x0400, 0, {"unknown code 0x04"}, {}},
+        HwFaultMessageParams{"UnallocatedBlock3f", 0x3f00, 0, {"unknown code 0x3f"}, {}},
+
+        // Anything <= 7 is a DM mcause, not a block code.
+        HwFaultMessageParams{
+            "DmLoadAccessFault",
+            static_cast<uint32_t>(DmErrors::LOAD_ACCESS_FAULT),
+            0x1234,
+            {"at PC", "LOAD_ACCESS_FAULT"},
+            {"Neo"}}),
+    [](const ::testing::TestParamInfo<HwFaultMessageParams>& info) { return info.param.test_name; });
+
+// Neo used to be read from the wrong bits and always came out as 0.
+TEST(WatcherHwFaultMessage, ReportsEveryNeoAndTrisc) {
+    for (uint32_t neo = 0; neo < 4; neo++) {
+        for (uint32_t trisc = 0; trisc < 4; trisc++) {
+            const uint32_t error_code = (neo << 14) | (trisc << 8) | 0x28;  // L1_ILLEGAL_ACCESS
+            const std::string msg = get_debug_assert_message(dev_msgs::DebugAssertHwFault, 0, error_code);
+            EXPECT_NE(msg.find(fmt::format("Neo {} TRISC{}", neo, trisc)), std::string::npos) << msg;
+        }
+    }
+}
+
+// Block 32 is the one an exclusive bound misses.
+TEST(WatcherHwFaultMessage, IllegalInstructionThreadOrderIsReversed) {
+    for (uint32_t block = 32; block <= 35; block++) {
+        const std::string msg =
+            get_debug_assert_message(dev_msgs::DebugAssertHwFault, 0, (block << 8) | 0x41);
+        EXPECT_NE(msg.find(fmt::format("Neo 0 TRISC{}", 35 - block)), std::string::npos) << msg;
+    }
+}
+
+// The caller reads an empty message as data corruption, so nothing should produce one.
+TEST(WatcherHwFaultMessage, NeverEmptyForAnyErrorCode) {
+    for (uint32_t error_code = 0; error_code <= 0xffff; error_code++) {
+        ASSERT_FALSE(get_debug_assert_message(dev_msgs::DebugAssertHwFault, 0, error_code).empty())
+            << "empty message for error_code 0x" << std::hex << error_code;
+    }
+}
 
 }  // namespace

--- a/tt_metal/hw/inc/api/debug/assert.h
+++ b/tt_metal/hw/inc/api/debug/assert.h
@@ -44,16 +44,15 @@ inline void assert_and_hang(uint32_t line_num, debug_assert_type_t assert_type =
             // error_code[15:14] = Neo ID, [13:8] = block ID, [7:0] = error index.
             // See TriscErrors in internal/tt-2xx/quasar/error_handling.h.
             //
-            // Read the register once. It's volatile, so re-reading per field costs extra
-            // MMIO and can mix fields from different samples if a new error arrives.
+            // Grab the register once. It's volatile, so a read per field is extra MMIO and can
+            // end up mixing fields from different samples if another error shows up.
             uint32_t error_reg = RISC_PIC_BRISC_EX_REG_BASE(internal_::get_trisc_id())[HW_ERROR_INTERRUPT_INDEX];
             uint32_t neo_id = (error_reg >> 14) & 0x3;
             uint32_t error_code = (error_reg >> 8) & 0x3f;
             v->hw_fault_info =
                 (static_cast<uint64_t>(RISCV_DEBUG_REGS->ERR_DATA) << 32) | static_cast<uint64_t>(error_reg);
-            // Get the TRISC ID from the block ID for errors 0-3 and 32-35. For 32-35 the
-            // TRISC order is reversed, so subtract from 35. Other blocks are Neo-level and
-            // are attributed to TRISC 0.
+            // TRISC ID comes from the block ID for errors 0-3 and 32-35. 32-35 count backwards
+            // so subtract from 35. The rest are Neo-level, put those on TRISC 0.
             uint32_t trisc_id = 0;
             if (error_code <= 3) {
                 trisc_id = error_code;

--- a/tt_metal/hw/inc/api/debug/assert.h
+++ b/tt_metal/hw/inc/api/debug/assert.h
@@ -7,6 +7,9 @@
 #include "internal/debug/watcher_common.h"
 #include "internal/hw_thread.h"
 #include "risc_common.h"
+#if defined(ARCH_QUASAR)
+#include "internal/tt-2xx/quasar/error_handling.h"
+#endif
 
 #if defined(WATCHER_ENABLED) && !defined(WATCHER_DISABLE_ASSERT) && !defined(FORCE_WATCHER_OFF)
 
@@ -41,23 +44,25 @@ inline void assert_and_hang(uint32_t line_num, debug_assert_type_t assert_type =
             v->line_num = mepc;  // mepc is the instruction address that caused the fault
             v->hw_fault_info = mtval << 32 | (mcause & 0xffffffff);  // mtval is the faulting address or instruction
 #elif defined(ARCH_QUASAR) && defined(COMPILE_FOR_TRISC)
-            // error_code[15:14] = Neo ID, [13:8] = block ID, [7:0] = error index.
-            // See TriscErrors in internal/tt-2xx/quasar/error_handling.h.
+            // Layout constants and block IDs both come from error_handling.h, shared with the
+            // host decoder so the two can't drift.
             //
             // Grab the register once. It's volatile, so a read per field is extra MMIO and can
             // end up mixing fields from different samples if another error shows up.
             uint32_t error_reg = RISC_PIC_BRISC_EX_REG_BASE(internal_::get_trisc_id())[HW_ERROR_INTERRUPT_INDEX];
-            uint32_t neo_id = (error_reg >> 14) & 0x3;
-            uint32_t error_code = (error_reg >> 8) & 0x3f;
+            uint32_t neo_id = (error_reg >> kQuasarErrNeoShift) & kQuasarErrNeoMask;
+            uint32_t block_id = (error_reg >> kQuasarErrBlockShift) & kQuasarErrBlockMask;
             v->hw_fault_info =
                 (static_cast<uint64_t>(RISCV_DEBUG_REGS->ERR_DATA) << 32) | static_cast<uint64_t>(error_reg);
-            // TRISC ID comes from the block ID for errors 0-3 and 32-35. 32-35 count backwards
-            // so subtract from 35. The rest are Neo-level, put those on TRISC 0.
+            // Only the per-TRISC blocks name a thread. The illegal-instruction ones count
+            // backwards, so subtract. Everything else is Neo-level, put those on TRISC 0.
             uint32_t trisc_id = 0;
-            if (error_code <= 3) {
-                trisc_id = error_code;
-            } else if (error_code >= 32 && error_code <= 35) {
-                trisc_id = 35 - error_code;
+            if (block_id <= static_cast<uint32_t>(TriscErrors::ERROR_TRISC3)) {
+                trisc_id = block_id;
+            } else if (
+                block_id >= static_cast<uint32_t>(TriscErrors::ILLEGAL_INSTRUCTION_TRISC3) &&
+                block_id <= static_cast<uint32_t>(TriscErrors::ILLEGAL_INSTRUCTION_TRISC0)) {
+                trisc_id = static_cast<uint32_t>(TriscErrors::ILLEGAL_INSTRUCTION_TRISC0) - block_id;
             }
             v->which = neo_id * NUM_TRISC_CORES + trisc_id + NUM_DM_CORES;
 #endif

--- a/tt_metal/hw/inc/api/debug/assert.h
+++ b/tt_metal/hw/inc/api/debug/assert.h
@@ -41,17 +41,26 @@ inline void assert_and_hang(uint32_t line_num, debug_assert_type_t assert_type =
             v->line_num = mepc;  // mepc is the instruction address that caused the fault
             v->hw_fault_info = mtval << 32 | (mcause & 0xffffffff);  // mtval is the faulting address or instruction
 #elif defined(ARCH_QUASAR) && defined(COMPILE_FOR_TRISC)
-            uint32_t error_code =
-                RISC_PIC_BRISC_EX_REG_BASE(internal_::get_trisc_id())[HW_ERROR_INTERRUPT_INDEX] >> 8 & 0x3f;
+            // error_code[15:14] = Neo ID, [13:8] = block ID, [7:0] = error index.
+            // See TriscErrors in internal/tt-2xx/quasar/error_handling.h.
+            //
+            // Read the register once. It's volatile, so re-reading per field costs extra
+            // MMIO and can mix fields from different samples if a new error arrives.
+            uint32_t error_reg = RISC_PIC_BRISC_EX_REG_BASE(internal_::get_trisc_id())[HW_ERROR_INTERRUPT_INDEX];
+            uint32_t neo_id = (error_reg >> 14) & 0x3;
+            uint32_t error_code = (error_reg >> 8) & 0x3f;
             v->hw_fault_info =
-                (static_cast<uint64_t>(RISCV_DEBUG_REGS->ERR_DATA) << 32) |
-                static_cast<uint64_t>(RISC_PIC_BRISC_EX_REG_BASE(internal_::get_trisc_id())[HW_ERROR_INTERRUPT_INDEX]);
-            // use error code to get the TRISC ID for errors 0-3 and 32-35.
-            // NOTE: for errors 32-35, the TRISC order is reversed, so we need to subtract the error code from 35.
-            uint32_t trisc_id = error_code < 4 ? error_code : error_code > 32 ? 35 - error_code : 0;
-            v->which = (RISC_PIC_BRISC_EX_REG_BASE(internal_::get_trisc_id())[HW_ERROR_INTERRUPT_INDEX] >> 30) *
-                           NUM_TRISC_CORES +
-                       trisc_id + NUM_DM_CORES;
+                (static_cast<uint64_t>(RISCV_DEBUG_REGS->ERR_DATA) << 32) | static_cast<uint64_t>(error_reg);
+            // Get the TRISC ID from the block ID for errors 0-3 and 32-35. For 32-35 the
+            // TRISC order is reversed, so subtract from 35. Other blocks are Neo-level and
+            // are attributed to TRISC 0.
+            uint32_t trisc_id = 0;
+            if (error_code <= 3) {
+                trisc_id = error_code;
+            } else if (error_code >= 32 && error_code <= 35) {
+                trisc_id = 35 - error_code;
+            }
+            v->which = neo_id * NUM_TRISC_CORES + trisc_id + NUM_DM_CORES;
 #endif
         }
         v->tripped = assert_type;

--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/error_handling.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/error_handling.h
@@ -24,9 +24,8 @@ enum class DmErrors : uint32_t {
 // Values are taken from https://tenstorrent.atlassian.net/wiki/spaces/TA/pages/564527286/Error+Aggregator, additional
 // error information is available in `ERR_DATA` register for errors 0-3.
 //
-// This is the block ID in error_code[13:8]. The other fields are error_code[15:14] = compute
-// core (Neo) ID and error_code[7:0] = error index within the block. The index is decoded by
-// one of the per-block enums below; it has no meaning on its own.
+// Block ID, error_code[13:8]. The rest of the word is [15:14] = Neo ID and [7:0] = error index
+// within the block. The index only means anything alongside its block, see the enums below.
 enum class TriscErrors : uint32_t {
     ERROR_TRISC0 = 0,
     ERROR_TRISC1 = 1,
@@ -53,17 +52,17 @@ enum class TriscErrors : uint32_t {
 
 // Index for TriscErrors::ERROR_TRISC0..3. Values come from
 // https://tenstorrent.atlassian.net/wiki/spaces/TA/pages/461602877 via
-// https://tenstorrent.atlassian.net/wiki/spaces/TA/pages/565445671, which defines the
-// per-TRISC error report. They are the bases of the legacy ranges on the former page
-// (22-26, 31-34, 40-44). Those ranges are no longer a per-TRISC spread, so read the TRISC
-// from error_code[13:8], not from here. The faulting PC is in `ERR_DATA`.
+// https://tenstorrent.atlassian.net/wiki/spaces/TA/pages/565445671.
 //
-// Only one is reported at a time, in this priority order:
+// These are the bases of the old 22-26 / 31-34 / 40-44 ranges. Those ranges used to spread
+// across the TRISCs, they don't any more, so take the TRISC from error_code[13:8] and not from
+// the value here. Faulting PC lands in `ERR_DATA`.
+//
+// Only one gets reported, in this order:
 //   L1_ILLEGAL_ACCESS > STACK_OVERFLOW > MEM_ACCESS_HANG > TTI_BUFFER_HANG
-// If several conditions are live, the higher one wins and the lower is never seen. Note that
-// MEM_ACCESS_HANG (25) outranks TTI_BUFFER_HANG (22) and the two can overlap: a store to a
-// full instruction buffer stalls the load/store queue, so it may report as 25. Use the PC in
-// `ERR_DATA` to tell them apart.
+// so a lower one is invisible while a higher one is live. Watch out for 25 vs 22: a store to a
+// full instruction buffer stalls the load/store queue, so it can come back as 25 even though
+// it started as an instruction buffer problem. The PC is the way to tell.
 enum class TriscRiscErrors : uint32_t {
     TTI_BUFFER_HANG = 22,  // TT instruction buffer is full
     // A load/store did not complete. Can also be a blocked instruction buffer push, since

--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/error_handling.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/error_handling.h
@@ -23,6 +23,10 @@ enum class DmErrors : uint32_t {
 // TRISC errors
 // Values are taken from https://tenstorrent.atlassian.net/wiki/spaces/TA/pages/564527286/Error+Aggregator, additional
 // error information is available in `ERR_DATA` register for errors 0-3.
+//
+// This is the block ID in error_code[13:8]. The other fields are error_code[15:14] = compute
+// core (Neo) ID and error_code[7:0] = error index within the block. The index is decoded by
+// one of the per-block enums below; it has no meaning on its own.
 enum class TriscErrors : uint32_t {
     ERROR_TRISC0 = 0,
     ERROR_TRISC1 = 1,
@@ -43,4 +47,54 @@ enum class TriscErrors : uint32_t {
     ILLEGAL_INSTRUCTION_TRISC2 = 33,
     ILLEGAL_INSTRUCTION_TRISC1 = 34,
     ILLEGAL_INSTRUCTION_TRISC0 = 35,
+};
+
+// Below: error_code[7:0], the error index within the block named by TriscErrors.
+
+// Index for TriscErrors::ERROR_TRISC0..3. Values come from
+// https://tenstorrent.atlassian.net/wiki/spaces/TA/pages/461602877 via
+// https://tenstorrent.atlassian.net/wiki/spaces/TA/pages/565445671, which defines the
+// per-TRISC error report. They are the bases of the legacy ranges on the former page
+// (22-26, 31-34, 40-44). Those ranges are no longer a per-TRISC spread, so read the TRISC
+// from error_code[13:8], not from here. The faulting PC is in `ERR_DATA`.
+//
+// Only one is reported at a time, in this priority order:
+//   L1_ILLEGAL_ACCESS > STACK_OVERFLOW > MEM_ACCESS_HANG > TTI_BUFFER_HANG
+// If several conditions are live, the higher one wins and the lower is never seen. Note that
+// MEM_ACCESS_HANG (25) outranks TTI_BUFFER_HANG (22) and the two can overlap: a store to a
+// full instruction buffer stalls the load/store queue, so it may report as 25. Use the PC in
+// `ERR_DATA` to tell them apart.
+enum class TriscRiscErrors : uint32_t {
+    TTI_BUFFER_HANG = 22,  // TT instruction buffer is full
+    // A load/store did not complete. Can also be a blocked instruction buffer push, since
+    // this outranks TTI_BUFFER_HANG.
+    MEM_ACCESS_HANG = 25,
+    STACK_OVERFLOW = 31,     // stack pointer dropped below the stack limit
+    L1_ILLEGAL_ACCESS = 40,  // L1 address check failed
+};
+
+// Index for TriscErrors::UNPACKER_0..2 and PACKER_0..1.
+// Hardware reports only one at a time: 0 masks 1, and 1:0 mask 2.
+enum class TdmaErrors : uint32_t {
+    ILLEGAL_FORMAT_CONVERSION = 0,
+    BUFFER_LIMIT_BELOW_START = 1,  // buffer limit addr < buffer start addr
+    ILLEGAL_TILE_SIZE = 2,
+};
+
+// Index for TriscErrors::NEO_SEMAPHORES and GLOBAL_SEMAPHORES (error_code[2:0]).
+// The offending semaphore number is captured in `ERR_DATA`.
+// WAIT_ON_UNINITIALIZED is not supported for GLOBAL_SEMAPHORES.
+enum class SemaphoreErrors : uint32_t {
+    WAIT_ON_UNINITIALIZED = 1,
+    POST_ON_UNINITIALIZED = 2,
+    GET_ON_UNINITIALIZED = 3,
+    POST_OVERFLOW = 4,
+    GET_UNDERFLOW = 5,
+};
+
+// Index for TriscErrors::SFPU. Unlike the others this is a BITMASK and it is sticky,
+// so both bits can be set at once. error_code[7:2] are reserved.
+enum class SfpuErrors : uint32_t {
+    CC_STACK_OVERFLOW = 0x1,
+    CC_STACK_UNDERFLOW = 0x2,
 };

--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/error_handling.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/error_handling.h
@@ -20,12 +20,23 @@ enum class DmErrors : uint32_t {
 
 };
 
+// Error code layout. Both sides decode these bits: the device to work out which Neo/TRISC to
+// blame, the host to render the message. Keep them here so the two can't drift apart.
+//   [15:14] Neo ID
+//   [13:8]  block ID, see TriscErrors
+//   [7:0]   error index within the block, see the per-block enums further down
+constexpr uint32_t kQuasarErrNeoShift = 14;
+constexpr uint32_t kQuasarErrNeoMask = 0x3;
+constexpr uint32_t kQuasarErrBlockShift = 8;
+constexpr uint32_t kQuasarErrBlockMask = 0x3f;
+constexpr uint32_t kQuasarErrIndexMask = 0xff;
+
 // TRISC errors
 // Values are taken from https://tenstorrent.atlassian.net/wiki/spaces/TA/pages/564527286/Error+Aggregator, additional
 // error information is available in `ERR_DATA` register for errors 0-3.
 //
-// Block ID, error_code[13:8]. The rest of the word is [15:14] = Neo ID and [7:0] = error index
-// within the block. The index only means anything alongside its block, see the enums below.
+// Block ID, error_code[13:8]. The index in [7:0] only means anything alongside its block, see
+// the enums below.
 enum class TriscErrors : uint32_t {
     ERROR_TRISC0 = 0,
     ERROR_TRISC1 = 1,

--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/error_handling.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/error_handling.h
@@ -61,24 +61,25 @@ enum class TriscErrors : uint32_t {
 
 // Below: error_code[7:0], the error index within the block named by TriscErrors.
 
-// Index for TriscErrors::ERROR_TRISC0..3. Values come from
-// https://tenstorrent.atlassian.net/wiki/spaces/TA/pages/461602877 via
-// https://tenstorrent.atlassian.net/wiki/spaces/TA/pages/565445671.
-//
-// These are the bases of the old 22-26 / 31-34 / 40-44 ranges. Those ranges used to spread
-// across the TRISCs, they don't any more, so take the TRISC from error_code[13:8] and not from
-// the value here. Faulting PC lands in `ERR_DATA`.
+// Index for TriscErrors::ERROR_TRISC0..3. These are the bases of the old 22-26 / 31-34 / 40-44
+// ranges on https://tenstorrent.atlassian.net/wiki/spaces/TA/pages/461602877. Those ranges used
+// to spread across the TRISCs, they don't any more, so take the TRISC from error_code[13:8] and
+// not from the value here. Note that page predates the current encoding, so treat the value
+// meanings below as the reference rather than its table. Reported PC lands in `ERR_DATA`.
 //
 // Only one gets reported, in this order:
-//   L1_ILLEGAL_ACCESS > STACK_OVERFLOW > MEM_ACCESS_HANG > TTI_BUFFER_HANG
-// so a lower one is invisible while a higher one is live. Watch out for 25 vs 22: a store to a
-// full instruction buffer stalls the load/store queue, so it can come back as 25 even though
-// it started as an instruction buffer problem. The PC is the way to tell.
+//   L1_ILLEGAL_ACCESS > STACK_OVERFLOW > MEM_READ_NO_RESPONSE > TTI_BUFFER_HANG
+// so a lower one is invisible while a higher one is live.
 enum class TriscRiscErrors : uint32_t {
-    TTI_BUFFER_HANG = 22,  // TT instruction buffer is full
-    // A load/store did not complete. Can also be a blocked instruction buffer push, since
-    // this outranks TTI_BUFFER_HANG.
-    MEM_ACCESS_HANG = 25,
+    // Instruction buffer sat idle for DBG_IBUFFER_TIMEOUT cycles. Opt-in: nothing is counted
+    // unless DBG_IBUFFER_CNT_EN is set, so this stays quiet on a normal run.
+    TTI_BUFFER_HANG = 22,
+    // A read went out and nothing answered within CSR_TIMEOUT_COUNT cycles (65536 after reset).
+    // Look at the target rather than the core: a bad NOC address, a core that isn't running,
+    // unmapped L1. Beware that the load still completes, with zero data, so the kernel carries
+    // on with a bogus value and whatever breaks next is a knock-on. Nothing to do with
+    // TTI_BUFFER_HANG despite sitting inside the old 22-26 range.
+    MEM_READ_NO_RESPONSE = 25,
     STACK_OVERFLOW = 31,     // stack pointer dropped below the stack limit
     L1_ILLEGAL_ACCESS = 40,  // L1 address check failed
 };

--- a/tt_metal/impl/debug/debug_helpers.hpp
+++ b/tt_metal/impl/debug/debug_helpers.hpp
@@ -137,9 +137,9 @@ inline bool quasar_error_data_is_pc(TriscErrors block) {
 }
 
 // What's in ERR_DATA, which depends on the block. For the per-TRISC errors it's a PC, the last
-// instruction to commit. On a hang that's where the thread stopped rather than the actual
-// culprit, so disassemble around it: that's how you tell a MEM_ACCESS_HANG that was a blocked
-// instruction buffer push from one that was a load/store that never came back.
+// instruction to commit, so for a timeout it's roughly where the thread gave up rather than the
+// exact culprit. Disassemble around it: on a MEM_READ_NO_RESPONSE that points at the load whose
+// response never arrived.
 inline std::string_view get_quasar_error_data_name(TriscErrors block) {
     switch (block) {
         case TriscErrors::ERROR_TRISC0:

--- a/tt_metal/impl/debug/debug_helpers.hpp
+++ b/tt_metal/impl/debug/debug_helpers.hpp
@@ -113,15 +113,8 @@ inline std::string_view get_core_type_name(CoreType ct) {
     }
 }
 
-// Quasar error_code layout (see TriscErrors in error_handling.h):
-//   [15:14] compute core (Neo) ID
-//   [13:8]  block ID, decoded by TriscErrors
-//   [7:0]   error index within that block, decoded by the per-block enums
-inline constexpr uint32_t kQuasarErrNeoShift = 14;
-inline constexpr uint32_t kQuasarErrNeoMask = 0x3;
-inline constexpr uint32_t kQuasarErrBlockShift = 8;
-inline constexpr uint32_t kQuasarErrBlockMask = 0x3f;
-inline constexpr uint32_t kQuasarErrIndexMask = 0xff;
+// The kQuasarErr* shifts and masks for the error code layout live in error_handling.h, shared
+// with the device side so both decode the same bits.
 
 // enchantum::to_string gives back an empty view for unnamed values, which ends up as a blank
 // field in the watcher log.

--- a/tt_metal/impl/debug/debug_helpers.hpp
+++ b/tt_metal/impl/debug/debug_helpers.hpp
@@ -123,17 +123,16 @@ inline constexpr uint32_t kQuasarErrBlockShift = 8;
 inline constexpr uint32_t kQuasarErrBlockMask = 0x3f;
 inline constexpr uint32_t kQuasarErrIndexMask = 0xff;
 
-// enchantum::to_string returns an empty view for unnamed values, which would show up as a
-// blank field in the watcher log.
+// enchantum::to_string gives back an empty view for unnamed values, which ends up as a blank
+// field in the watcher log.
 template <typename E>
 inline std::string quasar_enum_name_or_hex(uint32_t raw) {
     const auto name = enchantum::to_string(static_cast<E>(raw));
     return name.empty() ? fmt::format("unknown code 0x{:02x}", raw) : std::string{name};
 }
 
-// ERR_DATA is a PC only for the per-TRISC blocks, where it gets reported up front like the DM
-// faults do. Everything else reports it as a trailing field named by
-// get_quasar_error_data_name().
+// Only the per-TRISC blocks put a PC in ERR_DATA, and those print it up front like the DM
+// faults. Everything else gets it as a trailing field, see get_quasar_error_data_name().
 inline bool quasar_error_data_is_pc(TriscErrors block) {
     switch (block) {
         case TriscErrors::ERROR_TRISC0:
@@ -144,10 +143,10 @@ inline bool quasar_error_data_is_pc(TriscErrors block) {
     }
 }
 
-// What ERR_DATA holds, which varies by block. For the per-TRISC errors it's a PC: the last
-// instruction that committed, which for a hang is where the thread stopped rather than the
-// exact culprit. Disassemble there to find the real cause, e.g. whether a MEM_ACCESS_HANG was
-// a blocked instruction buffer push or a load/store that never returned.
+// What's in ERR_DATA, which depends on the block. For the per-TRISC errors it's a PC, the last
+// instruction to commit. On a hang that's where the thread stopped rather than the actual
+// culprit, so disassemble around it: that's how you tell a MEM_ACCESS_HANG that was a blocked
+// instruction buffer push from one that was a load/store that never came back.
 inline std::string_view get_quasar_error_data_name(TriscErrors block) {
     switch (block) {
         case TriscErrors::ERROR_TRISC0:
@@ -165,11 +164,11 @@ inline std::string_view get_quasar_error_data_name(TriscErrors block) {
     }
 }
 
-// Reporting TRISC, or nullopt for the Neo-level blocks (TDMA, EDC, semaphores, SFPU, tile
-// counters) which aren't tied to one thread.
+// Which TRISC reported, or nullopt for the Neo-level blocks (TDMA, EDC, semaphores, SFPU, tile
+// counters) since those aren't tied to a single thread.
 //
-// The illegal-instruction blocks number threads in reverse (32 = TRISC3 ... 35 = TRISC0),
-// opposite to ERROR_TRISC0..3. Keep that mapping here only; don't open-code it.
+// Careful: the illegal-instruction blocks count backwards, 32 is TRISC3 and 35 is TRISC0, the
+// opposite way round to ERROR_TRISC0..3. Keep that in here rather than open-coding it.
 inline std::optional<uint32_t> get_quasar_error_trisc_id(TriscErrors block) {
     const auto raw = static_cast<uint32_t>(block);
     if (raw <= static_cast<uint32_t>(TriscErrors::ERROR_TRISC3)) {
@@ -182,8 +181,8 @@ inline std::optional<uint32_t> get_quasar_error_trisc_id(TriscErrors block) {
     return std::nullopt;
 }
 
-// Decodes error_code[7:0]. Needs the block too, since the index means nothing on its own.
-// Returns empty for blocks that carry no index (EDC, unallocated IDs).
+// Decodes error_code[7:0]. Takes the block as well because the index means nothing on its own.
+// Empty for the blocks that don't carry an index (EDC, unallocated IDs).
 inline std::string get_quasar_error_index_description(TriscErrors block, uint32_t index) {
     switch (block) {
         case TriscErrors::ERROR_TRISC0:
@@ -200,7 +199,7 @@ inline std::string get_quasar_error_index_description(TriscErrors block, uint32_
         case TriscErrors::NEO_SEMAPHORES:
         case TriscErrors::GLOBAL_SEMAPHORES: return quasar_enum_name_or_hex<SemaphoreErrors>(index & 0x7);
 
-        // Sticky bitmask, not an enumerated value, so both bits may be set.
+        // Sticky bitmask rather than a single value, so both bits can be up at once.
         case TriscErrors::SFPU: {
             std::vector<std::string_view> flags;
             if (index & static_cast<uint32_t>(SfpuErrors::CC_STACK_OVERFLOW)) {
@@ -213,13 +212,13 @@ inline std::string get_quasar_error_index_description(TriscErrors block, uint32_
                                  : fmt::format("{}", fmt::join(flags, " + "));
         }
 
-        // Counter number that saw an invalid event, not a cause code.
+        // Which counter went bad, not a reason code.
         case TriscErrors::TILE_COUNTERS: return fmt::format("counter {}", index);
 
         case TriscErrors::EDC_FATAL_ERROR:
         case TriscErrors::EDC_CORRECTABLE_ERROR: return {};
 
-        // Just the opcode; the caller prints the full instruction from ERR_DATA.
+        // Only the opcode here, the caller prints the whole instruction out of ERR_DATA.
         case TriscErrors::ILLEGAL_INSTRUCTION_TRISC0:
         case TriscErrors::ILLEGAL_INSTRUCTION_TRISC1:
         case TriscErrors::ILLEGAL_INSTRUCTION_TRISC2:
@@ -276,8 +275,8 @@ inline std::string get_debug_assert_message(
                     quasar_enum_name_or_hex<TriscErrors>((error_code >> kQuasarErrBlockShift) & kQuasarErrBlockMask);
                 const std::string detail = get_quasar_error_index_description(block, index);
 
-                // Omitted for Neo-level blocks rather than defaulted to 0, so "no thread" and
-                // "thread 0" stay distinguishable.
+                // Left off entirely for Neo-level blocks instead of defaulting to 0, otherwise
+                // "no thread" and "thread 0" look the same.
                 const auto trisc = get_quasar_error_trisc_id(block);
                 const std::string where = fmt::format(
                     "Neo {}{}", neo, trisc.has_value() ? fmt::format(" TRISC{}", *trisc) : std::string{});

--- a/tt_metal/impl/debug/debug_helpers.hpp
+++ b/tt_metal/impl/debug/debug_helpers.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <algorithm>
+#include <optional>
 #include <set>
 #include <vector>
 #include <cctype>
@@ -112,6 +113,122 @@ inline std::string_view get_core_type_name(CoreType ct) {
     }
 }
 
+// Quasar error_code layout (see TriscErrors in error_handling.h):
+//   [15:14] compute core (Neo) ID
+//   [13:8]  block ID, decoded by TriscErrors
+//   [7:0]   error index within that block, decoded by the per-block enums
+inline constexpr uint32_t kQuasarErrNeoShift = 14;
+inline constexpr uint32_t kQuasarErrNeoMask = 0x3;
+inline constexpr uint32_t kQuasarErrBlockShift = 8;
+inline constexpr uint32_t kQuasarErrBlockMask = 0x3f;
+inline constexpr uint32_t kQuasarErrIndexMask = 0xff;
+
+// enchantum::to_string returns an empty view for unnamed values, which would show up as a
+// blank field in the watcher log.
+template <typename E>
+inline std::string quasar_enum_name_or_hex(uint32_t raw) {
+    const auto name = enchantum::to_string(static_cast<E>(raw));
+    return name.empty() ? fmt::format("unknown code 0x{:02x}", raw) : std::string{name};
+}
+
+// ERR_DATA is a PC only for the per-TRISC blocks, where it gets reported up front like the DM
+// faults do. Everything else reports it as a trailing field named by
+// get_quasar_error_data_name().
+inline bool quasar_error_data_is_pc(TriscErrors block) {
+    switch (block) {
+        case TriscErrors::ERROR_TRISC0:
+        case TriscErrors::ERROR_TRISC1:
+        case TriscErrors::ERROR_TRISC2:
+        case TriscErrors::ERROR_TRISC3: return true;
+        default: return false;
+    }
+}
+
+// What ERR_DATA holds, which varies by block. For the per-TRISC errors it's a PC: the last
+// instruction that committed, which for a hang is where the thread stopped rather than the
+// exact culprit. Disassemble there to find the real cause, e.g. whether a MEM_ACCESS_HANG was
+// a blocked instruction buffer push or a load/store that never returned.
+inline std::string_view get_quasar_error_data_name(TriscErrors block) {
+    switch (block) {
+        case TriscErrors::ERROR_TRISC0:
+        case TriscErrors::ERROR_TRISC1:
+        case TriscErrors::ERROR_TRISC2:
+        case TriscErrors::ERROR_TRISC3: return "PC";
+        case TriscErrors::NEO_SEMAPHORES:
+        case TriscErrors::GLOBAL_SEMAPHORES: return "semaphore index";
+        case TriscErrors::TILE_COUNTERS: return "tile counter index";
+        case TriscErrors::ILLEGAL_INSTRUCTION_TRISC0:
+        case TriscErrors::ILLEGAL_INSTRUCTION_TRISC1:
+        case TriscErrors::ILLEGAL_INSTRUCTION_TRISC2:
+        case TriscErrors::ILLEGAL_INSTRUCTION_TRISC3: return "offending instruction";
+        default: return "faulting address or instruction";
+    }
+}
+
+// Reporting TRISC, or nullopt for the Neo-level blocks (TDMA, EDC, semaphores, SFPU, tile
+// counters) which aren't tied to one thread.
+//
+// The illegal-instruction blocks number threads in reverse (32 = TRISC3 ... 35 = TRISC0),
+// opposite to ERROR_TRISC0..3. Keep that mapping here only; don't open-code it.
+inline std::optional<uint32_t> get_quasar_error_trisc_id(TriscErrors block) {
+    const auto raw = static_cast<uint32_t>(block);
+    if (raw <= static_cast<uint32_t>(TriscErrors::ERROR_TRISC3)) {
+        return raw;
+    }
+    if (raw >= static_cast<uint32_t>(TriscErrors::ILLEGAL_INSTRUCTION_TRISC3) &&
+        raw <= static_cast<uint32_t>(TriscErrors::ILLEGAL_INSTRUCTION_TRISC0)) {
+        return static_cast<uint32_t>(TriscErrors::ILLEGAL_INSTRUCTION_TRISC0) - raw;
+    }
+    return std::nullopt;
+}
+
+// Decodes error_code[7:0]. Needs the block too, since the index means nothing on its own.
+// Returns empty for blocks that carry no index (EDC, unallocated IDs).
+inline std::string get_quasar_error_index_description(TriscErrors block, uint32_t index) {
+    switch (block) {
+        case TriscErrors::ERROR_TRISC0:
+        case TriscErrors::ERROR_TRISC1:
+        case TriscErrors::ERROR_TRISC2:
+        case TriscErrors::ERROR_TRISC3: return quasar_enum_name_or_hex<TriscRiscErrors>(index);
+
+        case TriscErrors::UNPACKER_0:
+        case TriscErrors::UNPACKER_1:
+        case TriscErrors::UNPACKER_2:
+        case TriscErrors::PACKER_0:
+        case TriscErrors::PACKER_1: return quasar_enum_name_or_hex<TdmaErrors>(index);
+
+        case TriscErrors::NEO_SEMAPHORES:
+        case TriscErrors::GLOBAL_SEMAPHORES: return quasar_enum_name_or_hex<SemaphoreErrors>(index & 0x7);
+
+        // Sticky bitmask, not an enumerated value, so both bits may be set.
+        case TriscErrors::SFPU: {
+            std::vector<std::string_view> flags;
+            if (index & static_cast<uint32_t>(SfpuErrors::CC_STACK_OVERFLOW)) {
+                flags.emplace_back("CC_STACK_OVERFLOW");
+            }
+            if (index & static_cast<uint32_t>(SfpuErrors::CC_STACK_UNDERFLOW)) {
+                flags.emplace_back("CC_STACK_UNDERFLOW");
+            }
+            return flags.empty() ? fmt::format("unknown code 0x{:02x}", index)
+                                 : fmt::format("{}", fmt::join(flags, " + "));
+        }
+
+        // Counter number that saw an invalid event, not a cause code.
+        case TriscErrors::TILE_COUNTERS: return fmt::format("counter {}", index);
+
+        case TriscErrors::EDC_FATAL_ERROR:
+        case TriscErrors::EDC_CORRECTABLE_ERROR: return {};
+
+        // Just the opcode; the caller prints the full instruction from ERR_DATA.
+        case TriscErrors::ILLEGAL_INSTRUCTION_TRISC0:
+        case TriscErrors::ILLEGAL_INSTRUCTION_TRISC1:
+        case TriscErrors::ILLEGAL_INSTRUCTION_TRISC2:
+        case TriscErrors::ILLEGAL_INSTRUCTION_TRISC3: return fmt::format("opcode 0x{:02x}", index);
+
+        default: return {};
+    }
+}
+
 // Returns the assert message portion for a given assert type
 // Returns empty string for unknown types (callers must handle this)
 // For DebugAssertTripped, line_num is used in the message
@@ -149,12 +266,40 @@ inline std::string get_debug_assert_message(
                     enchantum::to_string(static_cast<DmErrors>(hw_fault_info & 0xffffffff)),
                     (hw_fault_info >> 32) & 0xffffffff);
             } else {
+                const uint32_t error_code = hw_fault_info & 0xffffffff;
+                const uint32_t neo = (error_code >> kQuasarErrNeoShift) & kQuasarErrNeoMask;
+                const auto block =
+                    static_cast<TriscErrors>((error_code >> kQuasarErrBlockShift) & kQuasarErrBlockMask);
+                const uint32_t index = error_code & kQuasarErrIndexMask;
+
+                const std::string block_name =
+                    quasar_enum_name_or_hex<TriscErrors>((error_code >> kQuasarErrBlockShift) & kQuasarErrBlockMask);
+                const std::string detail = get_quasar_error_index_description(block, index);
+
+                // Omitted for Neo-level blocks rather than defaulted to 0, so "no thread" and
+                // "thread 0" stay distinguishable.
+                const auto trisc = get_quasar_error_trisc_id(block);
+                const std::string where = fmt::format(
+                    "Neo {}{}", neo, trisc.has_value() ? fmt::format(" TRISC{}", *trisc) : std::string{});
+                const std::string cause = fmt::format(
+                    "{}{}", block_name, detail.empty() ? std::string{} : fmt::format(" ({})", detail));
+                const uint32_t err_data = (hw_fault_info >> 32) & 0xffffffff;
+
+                if (quasar_error_data_is_pc(block)) {
+                    return fmt::format(
+                        "hardware fault occurred at PC 0x{:08x} on {} with cause: {}, error_code 0x{:04x}",
+                        err_data,
+                        where,
+                        cause,
+                        error_code & 0xffff);
+                }
                 return fmt::format(
-                    "hardware fault occurred with cause: {}, additional code: 0x{:08x}, faulting address or "
-                    "instruction: 0x{:08x}",
-                    enchantum::to_string(static_cast<TriscErrors>((hw_fault_info >> 8) & 0x3f)),
-                    hw_fault_info & 0xff,
-                    (hw_fault_info >> 32) & 0xffffffff);
+                    "hardware fault occurred on {} with cause: {}, error_code 0x{:04x}, {}: 0x{:08x}",
+                    where,
+                    cause,
+                    error_code & 0xffff,
+                    get_quasar_error_data_name(block),
+                    err_data);
             }
         default: return "";
     }


### PR DESCRIPTION
### PR Category
Feature

### Summary
Quasar compute core faults previously logged the error code's low byte as raw hex, with no interpretation:
```
hardware fault occurred with cause: ERROR_TRISC0, additional code: 0x19, faulting address or instruction: 0x1234
```
That `0x19` is the only thing identifying the actual failure, and reading it meant looking the number up in a confluence table whose ranges no longer match how the field is encoded, which led us to misread it as an instruction-buffer error when it's a memory-access hang.

Now:
```
hardware fault occurred at PC 0x00001234 on Neo 0 TRISC0 with cause: ERROR_TRISC0 (MEM_READ_NO_RESPONSE), error_code 0x0019
```

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=filip/more-detailed-error-logs)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:filip/more-detailed-error-logs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=filip/more-detailed-error-logs)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:filip/more-detailed-error-logs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=filip/more-detailed-error-logs)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:filip/more-detailed-error-logs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=filip/more-detailed-error-logs)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:filip/more-detailed-error-logs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=filip/more-detailed-error-logs)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:filip/more-detailed-error-logs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=filip/more-detailed-error-logs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:filip/more-detailed-error-logs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=filip/more-detailed-error-logs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:filip/more-detailed-error-logs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=filip/more-detailed-error-logs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:filip/more-detailed-error-logs)