### PR TITLE
[SFPU] isclose: compare Inf/NaN bit patterns as vInt, not float magnitudes

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_relational.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_relational.py
@@ -421,6 +421,7 @@ _ISCLOSE_SPECIAL_VALUES = [
     float("inf"),
     float("-inf"),
     float("nan"),
+    float("-nan"),  # sign-bit-set NaN survives in float32; bfloat16 canonicalizes it
     2.0e9,  # below _INF_BIT_PATTERN_AS_FLOAT
     _INF_BIT_PATTERN_AS_FLOAT,
     3.0e9,  # above it
@@ -502,6 +503,24 @@ def test_isclose_large_finite_magnitudes(device, magnitude, sign):
     """
     x = torch.full((1, 1, 32, 32), sign * magnitude, dtype=torch.float32)
     _assert_isclose_matches_torch(device, x, x.clone(), ttnn.float32, rtol=1e-5, atol=1e-8)
+
+
+@pytest.mark.parametrize("equal_nan", [True, False])
+def test_isclose_negative_nan(device, equal_nan):
+    """Sign-bit-set NaN must classify as NaN.
+
+    SFPABS in float mode deliberately leaves -NaN as -NaN instead of clearing the
+    sign bit (see the SFPABS functional model in tt-isa-documentation), so the
+    kernel cannot derive the abs bit pattern from sfpi::abs() -- it has to mask.
+    Built from raw bits because bfloat16 canonicalizes -NaN to +NaN.
+    """
+    neg_nan = torch.tensor([-4194304], dtype=torch.int32).view(torch.float32)  # 0xFFC00000
+    pos_nan = torch.tensor([0x7FC00000], dtype=torch.int64).to(torch.int32).view(torch.float32)
+    assert neg_nan.view(torch.int32).item() & 0xFFFFFFFF == 0xFFC00000, "expected sign-bit-set NaN"
+
+    lhs = torch.tensor([neg_nan, neg_nan, neg_nan, pos_nan], dtype=torch.float32).reshape(1, 1, 1, 4)
+    rhs = torch.tensor([neg_nan, pos_nan, 1.0, pos_nan], dtype=torch.float32).reshape(1, 1, 1, 4)
+    _assert_isclose_matches_torch(device, lhs, rhs, ttnn.float32, rtol=1e-5, atol=1e-8, equal_nan=equal_nan)
 
 
 def test_isclose_inf_bit_pattern_boundary(device):

--- a/tests/ttnn/unit_tests/operations/eltwise/test_relational.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_relational.py
@@ -407,19 +407,117 @@ def test_isclose_zero_tolerance(device, shape):
     assert torch.equal(z_torch, ttnn.to_torch(z_tt).bool())
 
 
-def test_isclose_inf_divergence(device):
-    # Hardware correctly returns False for unequal infinities, matching torch.isclose semantics.
-    a = torch.tensor([[[[float("inf"), float("-inf")]]]]).to(torch.bfloat16)
-    b = torch.tensor([[[[float("-inf"), float("inf")]]]]).to(torch.bfloat16)
+# The isclose kernel classifies a lane as Inf/NaN by comparing the operand's abs
+# *bit pattern* against 0x7F800000. Reading that constant as a float value instead
+# yields the finite 2139095040.0, so coverage must include both Inf signs, NaN, and
+# finite magnitudes that bracket 2139095040.0 from both sides.
+_INF_BIT_PATTERN_AS_FLOAT = 2139095040.0  # float(0x7F800000)
 
-    z_torch = torch.isclose(a.float(), b.float(), rtol=1e-5, atol=1e-8)
+_ISCLOSE_SPECIAL_VALUES = [
+    0.0,
+    -0.0,
+    1.0,
+    -1.0,
+    float("inf"),
+    float("-inf"),
+    float("nan"),
+    2.0e9,  # below _INF_BIT_PATTERN_AS_FLOAT
+    _INF_BIT_PATTERN_AS_FLOAT,
+    3.0e9,  # above it
+    -3.0e9,
+    1.0e10,
+    torch.finfo(torch.float32).max,
+]
 
-    a_tt = ttnn.from_torch(a, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
-    b_tt = ttnn.from_torch(b, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
-    result = ttnn.isclose(a_tt, b_tt, rtol=1e-5, atol=1e-8)
-    out = ttnn.to_torch(result)
 
-    assert torch.equal(z_torch, out.bool())
+def _isclose_value_matrix(values, dtype):
+    """Every ordered pair of `values`, packed into a single (1, 1, 32, 32) tile pair."""
+    pairs = [(x, y) for x in values for y in values]
+    slots = 32 * 32
+    assert len(pairs) <= slots, f"{len(pairs)} pairs exceeds one {slots}-element tile"
+    pad = slots - len(pairs)
+    a = torch.tensor([p[0] for p in pairs] + [0.0] * pad, dtype=dtype).reshape(1, 1, 32, 32)
+    b = torch.tensor([p[1] for p in pairs] + [0.0] * pad, dtype=dtype).reshape(1, 1, 32, 32)
+    return a, b
+
+
+def _assert_isclose_matches_torch(device, a, b, ttnn_dtype, rtol, atol, equal_nan=False):
+    """Run ttnn.isclose and diff against torch.isclose on the same (post-rounding) values."""
+    expected = torch.isclose(a.float(), b.float(), rtol=rtol, atol=atol, equal_nan=equal_nan)
+
+    a_tt = ttnn.from_torch(a, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    b_tt = ttnn.from_torch(b, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    actual = ttnn.to_torch(ttnn.isclose(a_tt, b_tt, rtol=rtol, atol=atol, equal_nan=equal_nan)).bool()
+
+    if not torch.equal(expected, actual):
+        exp_flat, act_flat = expected.flatten(), actual.flatten()
+        a_flat, b_flat = a.float().flatten(), b.float().flatten()
+        wrong = (exp_flat != act_flat).nonzero().flatten().tolist()
+        detail = "\n".join(
+            f"  a={a_flat[i].item():<24} b={b_flat[i].item():<24} "
+            f"torch={exp_flat[i].item()} ttnn={act_flat[i].item()}"
+            for i in wrong[:16]
+        )
+        raise AssertionError(f"{len(wrong)} mismatch(es) vs torch.isclose:\n{detail}")
+
+
+@pytest.mark.parametrize("equal_nan", [True, False])
+@pytest.mark.parametrize("ttnn_dtype, torch_dtype", [(ttnn.float32, torch.float32), (ttnn.bfloat16, torch.bfloat16)])
+def test_isclose_special_values(device, ttnn_dtype, torch_dtype, equal_nan):
+    """Full cross product of signed zeros, signed Inf, NaN and large finite magnitudes.
+
+    Covers matching Inf (isclose(inf, inf) is True) and divergent Inf (False), plus
+    finite values on both sides of the +Inf bit pattern read as a float.
+    """
+    a, b = _isclose_value_matrix(_ISCLOSE_SPECIAL_VALUES, torch_dtype)
+    _assert_isclose_matches_torch(device, a, b, ttnn_dtype, rtol=1e-5, atol=1e-8, equal_nan=equal_nan)
+
+
+@pytest.mark.parametrize("ttnn_dtype, torch_dtype", [(ttnn.float32, torch.float32), (ttnn.bfloat16, torch.bfloat16)])
+def test_isclose_matching_infinities(device, ttnn_dtype, torch_dtype):
+    """isclose(+inf, +inf) and isclose(-inf, -inf) are True; mismatched signs are False."""
+    inf = float("inf")
+    a = torch.tensor([[[[inf, -inf, inf, -inf]]]], dtype=torch_dtype)
+    b = torch.tensor([[[[inf, -inf, -inf, inf]]]], dtype=torch_dtype)
+    _assert_isclose_matches_torch(device, a, b, ttnn_dtype, rtol=1e-5, atol=1e-8)
+
+
+@pytest.mark.parametrize(
+    "magnitude",
+    [
+        2.0e9,
+        _INF_BIT_PATTERN_AS_FLOAT,
+        3.0e9,
+        1.0e10,
+        1.0e20,
+        torch.finfo(torch.float32).max,
+    ],
+)
+@pytest.mark.parametrize("sign", [1.0, -1.0])
+def test_isclose_large_finite_magnitudes(device, magnitude, sign):
+    """Equal finite values stay close no matter how large the magnitude.
+
+    Regression for treating the +Inf bit pattern as the float 2139095040.0, which
+    misclassified every finite operand above that value as a special lane.
+    """
+    x = torch.full((1, 1, 32, 32), sign * magnitude, dtype=torch.float32)
+    _assert_isclose_matches_torch(device, x, x.clone(), ttnn.float32, rtol=1e-5, atol=1e-8)
+
+
+def test_isclose_inf_bit_pattern_boundary(device):
+    """Bit-exact ulp sweep of isclose(x, x) across float(0x7F800000).
+
+    The three values are consecutive float32s straddling the constant, so a float
+    magnitude compare against it changes answer mid-sweep while a bit compare
+    does not.
+    """
+    boundary = _INF_BIT_PATTERN_AS_FLOAT
+    ulp = 128.0  # spacing of float32 in [2^30, 2^31)
+    values = [boundary - ulp, boundary, boundary + ulp]
+
+    a = torch.tensor(values, dtype=torch.float32).repeat(32 * 32 // len(values) + 1)[: 32 * 32]
+    a = a.reshape(1, 1, 32, 32)
+    _assert_isclose_matches_torch(device, a, a.clone(), ttnn.float32, rtol=0.0, atol=0.0)
 
 
 @pytest.mark.parametrize(

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_isclose.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_isclose.h
@@ -44,13 +44,15 @@ inline void calculate_sfpu_isclose(
         sfpi::vFloat a = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
         sfpi::vFloat b = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi];
 
-        // Integer views of a, b and their abs bit patterns. The abs bits must stay
-        // vInt: comparing a vFloat against inf_bits would bind to the float overload
-        // and convert the bit pattern to the finite value 2139095040.0f.
+        // Integer views of a, b and their abs bit patterns. Two constraints: the abs
+        // bits must stay vInt (a vFloat against inf_bits binds to the float overload,
+        // converting it to 2139095040.0f), and the mask cannot be replaced by
+        // bit-casting sfpi::abs() because SFPABS float mode leaves -NaN sign-set.
+        // vConstIntPrgm0 holds 0x7FFFFFFF, programmed in isclose_init.
         sfpi::vInt a_bits = sfpi::as<sfpi::vInt>(a);
         sfpi::vInt b_bits = sfpi::as<sfpi::vInt>(b);
-        sfpi::vInt a_abs_bits = a_bits & 0x7FFFFFFF;
-        sfpi::vInt b_abs_bits = b_bits & 0x7FFFFFFF;
+        sfpi::vInt a_abs_bits = a_bits & sfpi::vConstIntPrgm0;
+        sfpi::vInt b_abs_bits = b_bits & sfpi::vConstIntPrgm0;
         sfpi::vFloat b_abs = sfpi::abs(b);
 
         // abs(a - b) via sign-bit clear.
@@ -93,5 +95,9 @@ inline void calculate_sfpu_isclose(
         sfpi::dst_reg++;
     }
 }
+
+// Programs the sign-clear mask into a constant register so the hot loop does not
+// rebuild it with a per-element SFPLOADI inside the replay block.
+inline void isclose_init() { sfpi::vConstIntPrgm0 = 0x7FFFFFFF; }
 
 }  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_isclose.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_isclose.h
@@ -44,13 +44,13 @@ inline void calculate_sfpu_isclose(
         sfpi::vFloat a = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
         sfpi::vFloat b = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi];
 
-        // Cache integer views of a, b and their abs bits up front. These feed
-        // both the |b| computation for the tolerance and the merged Inf/NaN
-        // fix-up branch below, so computing them once avoids any duplicated
-        // bit-mask work.
+        // Integer views of a, b and their abs bit patterns. The abs bits must stay
+        // vInt: comparing a vFloat against inf_bits would bind to the float overload
+        // and convert the bit pattern to the finite value 2139095040.0f.
         sfpi::vInt a_bits = sfpi::as<sfpi::vInt>(a);
         sfpi::vInt b_bits = sfpi::as<sfpi::vInt>(b);
-        sfpi::vFloat a_abs = sfpi::abs(a);
+        sfpi::vInt a_abs_bits = a_bits & 0x7FFFFFFF;
+        sfpi::vInt b_abs_bits = b_bits & 0x7FFFFFFF;
         sfpi::vFloat b_abs = sfpi::abs(b);
 
         // abs(a - b) via sign-bit clear.
@@ -72,18 +72,18 @@ inline void calculate_sfpu_isclose(
         // Single fix-up branch covering every "special" lane (Inf or NaN).
         // Detected by `abs_bits >= inf_bits` which holds iff exp == 0xFF.
         // Inside, we discard the tolerance result and rebuild from scratch:
-        //   * matching-sign Inf  -> 1     (a_abs == inf AND a_bits == b_bits)
-        //   * both NaN, EQUAL_NAN -> 1    (a_abs >  inf AND b_abs >  inf)
+        //   * matching-sign Inf  -> 1     (a_abs_bits == inf AND a_bits == b_bits)
+        //   * both NaN, EQUAL_NAN -> 1    (a_abs_bits >  inf AND b_abs_bits >  inf)
         //   * everything else (mismatched Inf, one-sided NaN, EQUAL_NAN=false
         //     NaN) stays at 0.
         // Folding both old fix-ups into one v_if removes two predicate-stack
         // push/pop pairs from the hot loop.
-        v_if(a_abs >= inf_bits || b_abs >= inf_bits) {
+        v_if(a_abs_bits >= inf_bits || b_abs_bits >= inf_bits) {
             result = 0.0f;
-            v_if(a_abs == inf_bits && a_bits == b_bits) { result = 1.0f; }
+            v_if(a_abs_bits == inf_bits && a_bits == b_bits) { result = 1.0f; }
             v_endif;
             if constexpr (EQUAL_NAN) {
-                v_if(a_abs > inf_bits && b_abs > inf_bits) { result = 1.0f; }
+                v_if(a_abs_bits > inf_bits && b_abs_bits > inf_bits) { result = 1.0f; }
                 v_endif;
             }
         }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_isclose.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_isclose.h
@@ -44,13 +44,15 @@ inline void calculate_sfpu_isclose(
         sfpi::vFloat a = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
         sfpi::vFloat b = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi];
 
-        // Integer views of a, b and their abs bit patterns. The abs bits must stay
-        // vInt: comparing a vFloat against inf_bits would bind to the float overload
-        // and convert the bit pattern to the finite value 2139095040.0f.
+        // Integer views of a, b and their abs bit patterns. Two constraints: the abs
+        // bits must stay vInt (a vFloat against inf_bits binds to the float overload,
+        // converting it to 2139095040.0f), and the mask cannot be replaced by
+        // bit-casting sfpi::abs() because SFPABS float mode leaves -NaN sign-set.
+        // vConstIntPrgm0 holds 0x7FFFFFFF, programmed in isclose_init.
         sfpi::vInt a_bits = sfpi::as<sfpi::vInt>(a);
         sfpi::vInt b_bits = sfpi::as<sfpi::vInt>(b);
-        sfpi::vInt a_abs_bits = a_bits & 0x7FFFFFFF;
-        sfpi::vInt b_abs_bits = b_bits & 0x7FFFFFFF;
+        sfpi::vInt a_abs_bits = a_bits & sfpi::vConstIntPrgm0;
+        sfpi::vInt b_abs_bits = b_bits & sfpi::vConstIntPrgm0;
         sfpi::vFloat b_abs = sfpi::abs(b);
 
         // abs(a - b) via sign-bit clear.
@@ -93,5 +95,9 @@ inline void calculate_sfpu_isclose(
         sfpi::dst_reg++;
     }
 }
+
+// Programs the sign-clear mask into a constant register so the hot loop does not
+// rebuild it with a per-element SFPLOADI inside the replay block.
+inline void isclose_init() { sfpi::vConstIntPrgm0 = 0x7FFFFFFF; }
 
 }  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_isclose.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_isclose.h
@@ -44,13 +44,13 @@ inline void calculate_sfpu_isclose(
         sfpi::vFloat a = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
         sfpi::vFloat b = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi];
 
-        // Cache integer views of a, b and their abs bits up front. These feed
-        // both the |b| computation for the tolerance and the merged Inf/NaN
-        // fix-up branch below, so computing them once avoids any duplicated
-        // bit-mask work.
+        // Integer views of a, b and their abs bit patterns. The abs bits must stay
+        // vInt: comparing a vFloat against inf_bits would bind to the float overload
+        // and convert the bit pattern to the finite value 2139095040.0f.
         sfpi::vInt a_bits = sfpi::as<sfpi::vInt>(a);
         sfpi::vInt b_bits = sfpi::as<sfpi::vInt>(b);
-        sfpi::vFloat a_abs = sfpi::abs(a);
+        sfpi::vInt a_abs_bits = a_bits & 0x7FFFFFFF;
+        sfpi::vInt b_abs_bits = b_bits & 0x7FFFFFFF;
         sfpi::vFloat b_abs = sfpi::abs(b);
 
         // abs(a - b) via sign-bit clear.
@@ -72,18 +72,18 @@ inline void calculate_sfpu_isclose(
         // Single fix-up branch covering every "special" lane (Inf or NaN).
         // Detected by `abs_bits >= inf_bits` which holds iff exp == 0xFF.
         // Inside, we discard the tolerance result and rebuild from scratch:
-        //   * matching-sign Inf  -> 1     (a_abs == inf AND a_bits == b_bits)
-        //   * both NaN, EQUAL_NAN -> 1    (a_abs >  inf AND b_abs >  inf)
+        //   * matching-sign Inf  -> 1     (a_abs_bits == inf AND a_bits == b_bits)
+        //   * both NaN, EQUAL_NAN -> 1    (a_abs_bits >  inf AND b_abs_bits >  inf)
         //   * everything else (mismatched Inf, one-sided NaN, EQUAL_NAN=false
         //     NaN) stays at 0.
         // Folding both old fix-ups into one v_if removes two predicate-stack
         // push/pop pairs from the hot loop.
-        v_if(a_abs >= inf_bits || b_abs >= inf_bits) {
+        v_if(a_abs_bits >= inf_bits || b_abs_bits >= inf_bits) {
             result = 0.0f;
-            v_if(a_abs == inf_bits && a_bits == b_bits) { result = 1.0f; }
+            v_if(a_abs_bits == inf_bits && a_bits == b_bits) { result = 1.0f; }
             v_endif;
             if constexpr (EQUAL_NAN) {
-                v_if(a_abs > inf_bits && b_abs > inf_bits) { result = 1.0f; }
+                v_if(a_abs_bits > inf_bits && b_abs_bits > inf_bits) { result = 1.0f; }
                 v_endif;
             }
         }

--- a/tt_metal/hw/inc/api/compute/isclose.h
+++ b/tt_metal/hw/inc/api/compute/isclose.h
@@ -74,6 +74,6 @@ ALWI void isclose_binary_tile(uint32_t idst0, uint32_t idst1, uint32_t odst, uin
 /**
  * Please refer to documentation for any_init.
  */
-ALWI void isclose_binary_tile_init() { MATH((SFPU_BINARY_INIT(isclose))); }
+ALWI void isclose_binary_tile_init() { MATH((SFPU_BINARY_INIT_FN_NO_ARGS(isclose, sfpu::isclose_init))); }
 
 }  // namespace ckernel


### PR DESCRIPTION
### Problem

`isclose`'s Inf/NaN fix-up compared **float magnitudes** against `inf_bits`, which is declared as an integer bit pattern:

```cpp
constexpr int32_t inf_bits = 0x7F800000;   // documented as "IEEE-754 abs(+inf)"
...
sfpi::vFloat a_abs = sfpi::abs(a);
v_if(a_abs >= inf_bits || b_abs >= inf_bits) {   // <-- float compare, not bit compare
```

sfpi declares `operator>=(vFloat, vFloat)` and `operator>=(vFloat, float)` (`sfpi.h:490/498`) but **no** `(vFloat, int32_t)`, and `vFloat` has no conversion to `vInt`. The only viable overload is the float one, so `0x7F800000` was converted to the finite value `2139095040.0f`. The intended exponent test (`exp == 0xFF`) silently became a plain magnitude test.

Wrong results on both Wormhole and Blackhole:

| Input | `torch.isclose` | before | after |
|---|---|---|---|
| `isclose(+inf, +inf)` | True | **False** | True |
| `isclose(-inf, -inf)` | True | **False** | True |
| `isclose(3e9, 3e9)` | True | **False** | True |
| `isclose(1e10, 1e10)` | True | **False** | True |
| `isclose(-NaN, -NaN)`, `equal_nan=True` | True | **False** | True |
| `isclose(+inf, -inf)` | False | False | False |

The finite-value failures are the wider blast radius: any two bit-identical operands with `|x| > 2139095040.0f` compared as *not close*.

### Fix

Mask the already-computed integer views to abs bit patterns and compare those, so the three special-case predicates bind to `operator>=/>/==(vInt, int32_t)` (`sfpi.h:517/520/522`):

```cpp
sfpi::vInt a_abs_bits = a_bits & sfpi::vConstIntPrgm0;   // 0x7FFFFFFF
sfpi::vInt b_abs_bits = b_bits & sfpi::vConstIntPrgm0;
```

The mask lives in a programmable constant register, programmed once by a new `isclose_init` wired through `SFPU_BINARY_INIT_FN_NO_ARGS`, following the `ckernel_sfpu_sqrt.h:120` / `recip_init` precedent. An inline `& 0x7FFFFFFF` would rebuild the mask with a per-element `SFPLOADI` inside the replay block — the cost `ckernel_sfpu_abs.h:30-32` records as +30% cyc/tile for that kernel. Static SFPU instruction count in `calculate_sfpu_isclose`, measured by compiling the real math TU with the JIT's own command:

| | pre-fix | inline mask | bit-cast `abs()` | **const reg (this PR)** |
|---|---|---|---|---|
| SFPLOADI | 6 | 32 | 12 | 12 |
| TOTAL | 120 | 139 | 83 | **107** |

This is safe because the three `BINARY_SFPU_INIT` guards in the binary_ng compute kernels are mutually exclusive and exhaustive, LHS/RHS activations run in `PREPROCESS` *before* the init, POST activations force a per-tile re-init, and `invoke_binary_ng_isclose` passes no activations at all today.

**The mask cannot be replaced by bit-casting `sfpi::abs()`.** Per the [`SFPABS` functional model](https://github.com/tenstorrent/tt-isa-documentation/blob/main/WormholeB0/TensixTile/TensixCoprocessor/SFPABS.md) (shared verbatim by Wormhole and Blackhole), float mode deliberately leaves `-NaN` as `-NaN` instead of clearing the sign bit:

```c
if (Mod1 & SFPABS_MOD1_FLOAT) {
  if (x > 0xff800000u) { /* Value is -NaN; leave it as -NaN. */ }
  else { x &= 0x7fffffffu; }
}
```

A bit-cast `abs()` therefore yields a negative int32 for `-NaN`, `a_abs_bits >= inf_bits` is false, and the fix-up is skipped — measured on n150 as `isclose(-NaN, 1.0) == True` with `equal_nan=False`. The kernel comment records this so it does not get "optimized" into the broken form. `b_abs` stays a `vFloat`; it is still needed for the `atol + rtol * |b|` term.

The sibling kernel `ckernel_sfpu_log1p.h:123` uses the same bit-compare idiom and notes it can skip masking only *"since u>=0"*; `isclose` operands can be negative, hence the explicit sign-bit clear.

Applies to the Wormhole and Blackhole copies, which were and remain byte-identical. **Quasar is not affected** — it has no `ckernel_sfpu_isclose.h`, so there is nothing to port.

### Tests

`test_isclose_inf_divergence` only checked *mismatched* infinities (expected `False`), which the broken kernel happened to produce, and every other isclose test stayed within ±150. It is replaced with:

- `test_isclose_special_values` — full cross product of signed zeros, ±Inf, ±NaN and large finite magnitudes, over fp32/bf16 × `equal_nan` ∈ {True, False}. Subsumes the old divergent-Inf case and adds matching Inf.
- `test_isclose_matching_infinities` — `isclose(±inf, ±inf)` True, mismatched signs False.
- `test_isclose_large_finite_magnitudes` — equal finite operands across `2e9 … FLT_MAX`, both signs.
- `test_isclose_negative_nan` — bit-exact `0xFFC00000`, both `equal_nan` modes. `-NaN` was untested and already broken before this branch.
- `test_isclose_inf_bit_pattern_boundary` — bit-exact ulp sweep straddling `float(0x7F800000)` with `rtol=atol=0`, the tightest anchor for this defect.

Failures now carry the offending `a`/`b` values instead of a bare `torch.equal` assert.

### Verification (n150, WormholeB0)

- Without the kernel change: **17 failed / 49 passed** — the new tests genuinely fail without the fix.
- With it: all isclose tests pass; full `test_relational.py` **218/218**.
- Also green: `test_binary_dtype_validation.py -k isclose`, `docs_examples/test_pointwise_binary_examples.py -k isclose`.
- Boundary confirmed empirically at exactly `2139095040.0` before the fix (`2139094912.0` → True, `2139095168.0` → False), matching `float(0x7F800000)` to the ulp.
- Op-level throughput unchanged: `isclose` is DRAM-bandwidth bound (fp32 0.2614ms vs `add` 0.2582ms / `eq` 0.2575ms over 4096 tiles at ~185 GB/s; bf16 1.9× faster, tracking bytes). All variants land within noise.

Blackhole is code-identical to the verified Wormhole path but has not been run on BH silicon.

Fixes #51540 — sub-issue of #51220, covering items 1 and 2. Item 3 of #51220 (Quasar `exp` range guards) is a separate defect and is not touched here.

CODEOWNERS: @rtawfik01 @rdjogoTT @nvelickovicTT

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=fix-isclose-inf-bit-pattern-compare)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:fix-isclose-inf-bit-pattern-compare)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=fix-isclose-inf-bit-pattern-compare)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:fix-isclose-inf-bit-pattern-compare)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=fix-isclose-inf-bit-pattern-compare)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:fix-isclose-inf-bit-pattern-compare)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fix-isclose-inf-bit-pattern-compare)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fix-isclose-inf-bit-pattern-compare)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=fix-isclose-inf-bit-pattern-compare)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:fix-isclose-inf-bit-pattern-compare)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=fix-isclose-inf-bit-pattern-compare)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:fix-isclose-inf-bit-pattern-compare)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=fix-isclose-inf-bit-pattern-compare)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:fix-isclose-inf-bit-pattern-compare)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=fix-isclose-inf-bit-pattern-compare)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:fix-isclose-inf-bit-pattern-compare)
