### PR TITLE
[quasar] binary_ng: re-enable ROW_A_COL_B mixed broadcast on the DFB path (craq-sim #205 fixed)

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/experimental/quasar/test_binary_ng_bcast.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/quasar/test_binary_ng_bcast.py
@@ -137,9 +137,9 @@ def test_bcast_scalar_interleaved(device, op_name, a_shape, b_shape, bcast):
 # and they ALSO mutually outer-broadcast (a's C=1 against b's C=2, b's N=1 against a's N=2), so the golden
 # output is [2,2,64,128] -- a mixed subtile broadcast layered on an asymmetric outer broadcast. ROW_B_COL_A
 # is the exact mirror (a col, b row). add/subtract are bf16-FPU (eltwise_binary_row_col_bcast_dfb.cpp);
-# multiply/divide/maximum are bf16-SFPU (eltwise_binary_sfpu_row_col_bcast_dfb.cpp). subtract/divide
+# multiply/divide/maximum/minimum are bf16-SFPU (eltwise_binary_sfpu_row_col_bcast_dfb.cpp). subtract/divide
 # (non-commutative) guard against an lhs/rhs (BCAST_INPUT) operand swap; divide keeps the relaxed 0.99 bf16
-# threshold. maximum (always-SFPU) proves the widened gate admits the generic SFPU mixed path.
+# threshold. maximum/minimum (always-SFPU) prove the widened gate admits the generic SFPU mixed path.
 @pytest.mark.parametrize("op_name", ["add", "subtract", "multiply", "divide", "maximum", "minimum"])
 @pytest.mark.parametrize(
     "a_shape,b_shape,bcast",
@@ -149,16 +149,9 @@ def test_bcast_scalar_interleaved(device, op_name, a_shape, b_shape, bcast):
     ],
 )
 def test_bcast_mixed_interleaved(device, op_name, a_shape, b_shape, bcast):
-    # ROW_A_COL_B is carved out of the DFB path (matches_metal_v2_slice routes it to the descriptor, which
-    # is unsupported/throws on Quasar) due to a residual INTERMITTENT Quasar substrate race: in ROW_A_COL_B
-    # the binary op's srcA is the llk_post (unary_bcast<ROW>) operand and srcB is the reader-filled+held COL
-    # operand; ~1 of the 5 ops fails per run (which op varies -- a race) with srcA reading 0 (a's
-    # contribution missing, PCC ~0.73). The mirror ROW_B_COL_A (llk_post is srcB) is rock-solid (20/20
-    # across runs), as is single-operand ROW_A -- so it is a craq-sim/LLK substrate race in the
-    # llk_post-as-srcA path, not an op-code bug. Skipped here; unskip + remove the gate carve-out once the
-    # LLK/sim race is fixed. ROW_B_COL_A (all 5 ops) runs on the DFB path and passes. See task-9-report.md.
-    if bcast == "ROW_A_COL_B":
-        pytest.skip("ROW_A_COL_B: intermittent Quasar llk_post-as-srcA race (see task-9-report.md)")
+    # Both mixed orientations run on the DFB path. ROW_A_COL_B (llk_post as the binary srcA) additionally
+    # covers the operand order in which the reader delivers the COL operand before the ROW operand, so the
+    # consumer must not be credited for the ROW operand until its own data has landed.
     pcc = 0.99 if op_name == "divide" else None
     _run(device, op_name, ttnn.DRAM_MEMORY_CONFIG, ttnn.bfloat16, (a_shape, b_shape), pcc=pcc)
 

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/QUASAR_PARITY_GAPS.md
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/QUASAR_PARITY_GAPS.md
@@ -2,7 +2,7 @@
 
 Scope: the TILE binary op in `ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/` — tensor-tensor
 `SubtileBroadcastType::NONE`, the single-operand subtile broadcast types (`SCALAR_A/B`, `ROW_A/B`,
-`COL_A/B`), the mixed type `ROW_B_COL_A` (§6), and tensor-scalar (§7). "Gap" = works on Wormhole but does
+`COL_A/B`), both mixed types (`ROW_B_COL_A`, `ROW_A_COL_B`) (§6), and tensor-scalar (§7). "Gap" = works on Wormhole but does
 **not** (yet) work / is not validated on **Quasar**. Branch `dchen/next_bcast_quasar`.
 
 This is the **op-author's view** (gate / structural / arch / test-coverage). For **which LLK primitive
@@ -151,15 +151,15 @@ stride path) · interleaved program-cache-hit. (Uneven height/block shards ARE c
 
 ## 6. Subtile broadcast (`unary_bcast`) — validated on Quasar
 
-Single-operand subtile broadcast (`SCALAR_A/B`, `ROW_A/B`, `COL_A/B`) **and** the mixed type `ROW_B_COL_A`
-are wired through the DFB factory and sim-certified **through the op itself**
+Single-operand subtile broadcast (`SCALAR_A/B`, `ROW_A/B`, `COL_A/B`) **and** both mixed types
+(`ROW_B_COL_A`, `ROW_A_COL_B`) are wired through the DFB factory and sim-certified **through the op itself**
 (`test_binary_ng_bcast.py`), not just the standalone LLK test — see
 `qualification/QUASAR_LLK_GAPS.md` Table 3 for the primitive-level (`unary_bcast`) status.
 
 - **Mechanism (single-operand):** `unary_bcast<BroadcastType::{ROW,COL,SCALAR}>` all lower to the MOVB2D
   srcB→dest datacopy, differentiated only by broadcast constants (`dst_lo`/`bcast0`/`srcb_col_inc`); there
   is no `ELWADD` on the `unary_bcast` path.
-- **Mechanism (mixed `ROW_B_COL_A`):** a HYBRID, deliberately NOT a third `unary_bcast` pass. The ROW
+- **Mechanism (mixed, both directions):** a HYBRID, deliberately NOT a third `unary_bcast` pass. The ROW
   operand goes through compute `unary_bcast<ROW>`; the COL operand is software-filled by the reader
   (`FILL_TILE_WITH_FIRST_COLUMN`, `reader_row_col_mixed_bcast_dfb.cpp`), delivered once per tile-row and
   reused across the row — a reader/compute load-balance that keeps compute at 2 LLK passes. The reader fill
@@ -176,8 +176,8 @@ are wired through the DFB factory and sim-certified **through the op itself**
   independence.
 - **Activation fusion:** lhs/rhs/post × `relu`/`gelu`/`tanh`/`sigmoid` compose with broadcast (`relu` uses
   the SFPU post chain; the PACK_RELU fast path is disabled under subtile broadcast).
-- **Validation:** 112 broadcast cases green on the QSR sim (`test_binary_ng_bcast.py`); 88 no-bcast
-  regression cases green (`test_binary_ng_no_bcast.py`).
+- **Validation:** 130 broadcast cases green on the QSR sim, 0 skipped (`test_binary_ng_bcast.py`); 88
+  no-bcast regression cases green (`test_binary_ng_no_bcast.py`).
 - **Two facts that make this work:** the `bcast.h` Quasar `unary_bcast` branch does not reference
   `DataFormat::UInt32` (Quasar has no uint32 device format — its 32-bit formats are `Float32`/`Int32`; the
   enum slot WH/BH use for `UInt32` is `MxFp4_2x_B` on Quasar) · the Quasar bcast compute inserts

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/QUASAR_PARITY_GAPS.md
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/QUASAR_PARITY_GAPS.md
@@ -52,10 +52,9 @@ tensor-tensor · add/subtract (FPU) + multiply/divide/maximum/minimum (SFPU) · 
 broadcast operand (NoC-read path) **and** mixed a/b/out layouts, i.e. full per-operand layout
 independence · lhs/rhs/post activation fusion with `relu`/`gelu`/`tanh`/`sigmoid` (see §6).
 
-**Subtile broadcast (mixed):** `ROW_B_COL_A` — same dtype/op/layout/fusion envelope as the single-operand
-types, realized as a HYBRID (compute `unary_bcast<ROW>` for the ROW operand, reader software-fill for the
-COL operand). Its mirror `ROW_A_COL_B` is **carved out** — gate-rejected over an intermittent sim-only
-race, not an LLK gap (see §6).
+**Subtile broadcast (mixed):** `ROW_B_COL_A` **and** `ROW_A_COL_B` — same dtype/op/layout/fusion envelope as
+the single-operand types, realized as a HYBRID (compute `unary_bcast<ROW>` for the ROW operand, reader
+software-fill for the COL operand). Both orientations run on the DFB path (see §6).
 
 **Tensor-scalar:** bf16 and fp32 · TILE · add/subtract (FPU for bf16, SFPU for fp32) + multiply/divide
 (SFPU) · a writer-fills-`in1`-once mechanism (the writer produces the RHS input DFB and fills it with the
@@ -71,7 +70,6 @@ Quasar** column is the key per-request signal: *capable* = Quasar LLK could do i
 
 | Config | LLK on Quasar | Class |
 |---|---|---|
-| **Mixed subtile broadcast, `ROW_A_COL_B` only** (`ROW_B_COL_A` ships on the DFB path — §6) | **capable** — same ROW/COL primitives `ROW_B_COL_A` uses | **sim bug** — gate rejects over an intermittent craq-sim race (`llk_post`-as-srcA), not an LLK/op gap; WH via descriptor (§6) |
 | Tensor-scalar, int32 (`add(t_int32, 5)`) | **capable** in isolation (int32 add/mul compile, matrix `✓`) but the DFB *compute* path returns wrong results for int32 — see §7 | **bug** — the `is_scalar` branch deliberately excludes every int32 op, not a plain LLK/gate gap |
 | where / select (ternary) | **capable** — `where` bridge is `✓` in the matrix | **B** — gate rejects ternary |
 | Row-major (non-TILE) in/out | needs op dataflow work | op (gate + RM kernels), not a pure LLK gap |
@@ -185,14 +183,10 @@ are wired through the DFB factory and sim-certified **through the op itself**
   enum slot WH/BH use for `UInt32` is `MxFp4_2x_B` on Quasar) · the Quasar bcast compute inserts
   `pack_init` under `#ifdef ARCH_QUASAR` after `pack_reconfig_data_format`, which is gasket-only on Quasar
   (§4).
+- **Both mixed directions ship on the DFB path.** `ROW_A_COL_B` and `ROW_B_COL_A` use the same primitives and
+  the same hybrid kernel pair, differing only in which operand the `unary_bcast<ROW>` result (`llk_post`)
+  feeds — the binary `srcA` for `ROW_A_COL_B`, `srcB` for `ROW_B_COL_A`.
 - **Still deferred:**
-  - Mixed subtile type `ROW_A_COL_B` — the ONE mixed direction still gate-rejected (no Quasar path; WH runs
-    via descriptor) → §1. Not an LLK or op gap: it uses exactly the primitives `ROW_B_COL_A` ships with, but
-    is INTERMITTENTLY wrong on the current craq-sim (~1 of 5 ops per run reads srcA = 0, PCC ~0.73). The
-    difference is which operand the `unary_bcast<ROW>` result (`llk_post`) feeds: srcA (`c_5`) for
-    `ROW_A_COL_B`, srcB (`c_6`) for `ROW_B_COL_A` — and only the srcA form races. Routed to the descriptor
-    for a loud "unsupported" over a silent-intermittent wrong answer; remove the carve-out once the sim/LLK
-    race is fixed (craq-sim #205).
   - Tensor-scalar (`add(t, 5.0)`) is a separate, now-supported path (§7) — a scalar operand is always
     `SubtileBroadcastType::NONE`, so it never engages subtile broadcast and has no interaction with this
     section.
@@ -277,11 +271,7 @@ tensor and a scalar never subtile-broadcasts (`SubtileBroadcastType::NONE` alway
    unary clamp path (`UnaryOpType::MAXIMUM`/`MINIMUM`), not `invoke_binary_ng`, so they never reach this
    factory and hard-throw on Quasar (`DataMovementKernel` not supported); reroute to
    `invoke_binary_ng(BinaryOpType::MAXIMUM/MINIMUM)`.
-4. **Un-carve `ROW_A_COL_B`** (§1, §6) — the last mixed-broadcast direction without a Quasar path (WH runs
-   it via the descriptor). Blocked on the craq-sim `llk_post`-as-srcA race (#205), not on op or LLK work:
-   its mirror `ROW_B_COL_A` already ships on the DFB path with the same primitives. Drop the gate's
-   `ROW_A_COL_B` `return false` once the sim fix lands.
-5. **Gate hygiene** (§2, §6) — optionally reject Quasar-unsupported formats/ops with a clear message;
+4. **Gate hygiene** (§2, §6) — optionally reject Quasar-unsupported formats/ops with a clear message;
    applies under broadcast too, not just the no-broadcast slice.
 
 ## Systemic lesson

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/binary_ng_device_operation.cpp
@@ -555,9 +555,9 @@ bool BinaryNgDeviceOperation::matches_metal_v2_slice(
     // is software-filled by the reader (a deliberate reader/compute load-balance keeping compute at 2 LLK
     // passes). The reader fill uses a COHERENT store (non-cacheable L1 alias) because the Quasar DM core's
     // write-back L1 D$ is incoherent with the TL1 SRAM the compute consumer reads -- a plain cacheable fill
-    // is invisible to the consumer and corrupts the neighbor DFB (see reader_row_col_mixed_bcast_dfb.cpp /
-    // task-9-report.md). All are admitted only for bf16, on both the FPU (add/subtract) and SFPU
-    // (multiply/divide/maximum) compute kernels (fp32/int bcast paths are later tasks). Admitting a type
+    // is invisible to the consumer and corrupts the neighbor DFB (see reader_row_col_mixed_bcast_dfb.cpp).
+    // All are admitted only for bf16, on both the FPU (add/subtract) and SFPU
+    // (multiply/divide/maximum/minimum) compute kernels (fp32/int bcast paths are later tasks). Admitting a type
     // here without a matching factory kernel would route it to an unwired factory path, so keep every
     // not-yet-wired type on the descriptor.
     switch (attributes.subtile_broadcast_type) {
@@ -574,18 +574,6 @@ bool BinaryNgDeviceOperation::matches_metal_v2_slice(
                 return false;  // bf16 only (FPU + SFPU) until the fp32 / int bcast paths are wired
             }
             break;
-    }
-    // WORKAROUND (Quasar substrate, tracked in task-9-report.md): ROW_A_COL_B is INTERMITTENTLY wrong on
-    // the current craq-sim. In ROW_A_COL_B the binary op's srcA is the llk_post (unary_bcast<ROW>) operand
-    // (c_5) and srcB is the reader-filled+held COL operand; ~1 of the 5 ops fails per run (which op varies
-    // -- a race), with srcA reading 0 (a's contribution missing, PCC ~0.73). It is specific to
-    // llk_post-as-srcA: the mirror ROW_B_COL_A (llk_post is srcB, c_6) is rock-solid (20/20 across runs), as
-    // is single-operand ROW_A (srcA=llk_post but a streamed full srcB). So it is a craq-sim/LLK substrate
-    // race in the llk_post-as-srcA + filled-held-COL-srcB path, not an op-code bug. Route ALL of
-    // ROW_A_COL_B to the descriptor (loud "unsupported" on Quasar) rather than an intermittently wrong
-    // result; ROW_B_COL_A stays on the reliable DFB path. Remove once the LLK/sim race is fixed.
-    if (attributes.subtile_broadcast_type == SubtileBroadcastType::ROW_A_COL_B) {
-        return false;
     }
     // TILE layout (32x32) in and out (row-major routes to the descriptor).
     if (attributes.input_layout_a != Layout::TILE || attributes.input_layout_b != Layout::TILE ||

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/binary_ng_metal_v2_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/binary_ng_metal_v2_factory.cpp
@@ -223,15 +223,14 @@ DfbKernelSources select_dfb_kernel_sources(SubtileBroadcastType subtile_broadcas
             // MIXED subtile broadcast: the mixed reader software-fills the COL operand and delivers the ROW
             // operand as a raw partial tile; the mixed compute expands the ROW operand via unary_bcast<ROW>
             // (through llk_post, freq=Wt reuse loop) and reads the reader-filled COL operand directly, then
-            // runs the binary op -- FPU (add/subtract) or SFPU (multiply/divide/maximum). The COL operand
-            // uses reader software-fill (NOT a compute unary_bcast<COL>) as a deliberate reader/compute
+            // runs the binary op -- FPU (add/subtract) or SFPU (multiply/divide/maximum/minimum). The COL
+            // operand uses reader software-fill (NOT a compute unary_bcast<COL>) as a deliberate reader/compute
             // load-balance keeping compute at 2 LLK passes. On Quasar the reader fill uses a COHERENT store
             // (non-cacheable L1 alias) because the DM core's write-back L1 D$ is incoherent with the TL1 SRAM
             // the compute consumer reads -- a plain cacheable fill is invisible to the consumer and corrupts
             // the neighbor llk_post DFB (see reader_row_col_mixed_bcast_dfb.cpp). matches_metal_v2_slice
-            // restricts this to bf16, and currently ONLY ROW_B_COL_A reaches here (llk_post is srcB, c_6 --
-            // stable); ROW_A_COL_B (llk_post is srcA, c_5) is gated to the descriptor pending a craq-sim/LLK
-            // fix of a residual intermittent llk_post-as-srcA race (see the gate + task-9-report.md).
+            // restricts this to bf16; both orientations reach here (llk_post is the binary srcA for
+            // ROW_A_COL_B, srcB for ROW_B_COL_A).
             return DfbKernelSources{
                 .reader = kReaderRowColMixedBcastDfb,
                 .writer = kWriterDfb,

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/qualification/QUASAR_LLK_GAPS.md
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/qualification/QUASAR_LLK_GAPS.md
@@ -45,10 +45,9 @@ itself lacks.
   every op `unary_op_utils.cpp::get_op_init_and_func` handles (nearly the whole enum).
 - **Broadcast rows** (Table 3) = the `unary_bcast<BroadcastType>` primitive `binary_ng`'s Quasar DFB
   factory uses to realize `SubtileBroadcastType != NONE` for a **single** operand
-  (`SCALAR`/`ROW`/`COL`). The mixed types need **no new primitive** — `ROW_B_COL_A` is op-wired and
-  sim-certified using the same ROW body plus a reader software-fill for the COL operand, so it adds no row
-  here. `ROW_A_COL_B` is carved out **op-side** (gate `return false`) over an intermittent craq-sim race,
-  **not** for a missing LLK primitive — do not read its absence from Table 3 as an LLK gap. Both tracked in
+  (`SCALAR`/`ROW`/`COL`). The mixed types need **no new primitive** — both `ROW_B_COL_A` and `ROW_A_COL_B`
+  are op-wired and sim-certified using the same ROW body plus a reader software-fill for the COL operand, so
+  they add no row here. Do not read their absence from Table 3 as an LLK gap. Tracked in
   `../QUASAR_PARITY_GAPS.md` §6.
 - **Which `tt_llk_quasar` tree is authoritative** — there are **two** and they disagree. The build uses
   **`tt_metal/tt-llk/tt_llk_quasar/`** (on the kernel `-I` path — `tt_metal/hw/CMakeLists.txt`). The other,
@@ -261,11 +260,10 @@ All three dimensions lower to the same Quasar LLK path — the MOVB2D srcB→des
 `add_tiles_bcast_rows`/`mul_tiles_bcast_cols`/etc. shorthand family further down `bcast.h` (`ELWADD`-style,
 `llk_unpack_AB<BroadcastType>`), which is WH/BH-only and not used by the Quasar DFB kernels.
 
-**Mixed broadcast types need no row of their own.** `ROW_B_COL_A` is op-wired and sim-certified on the DFB
-path using the ROW row above — its COL half is a reader software-fill, not a second `unary_bcast` pass (a
-deliberate reader/compute load-balance that keeps compute at 2 LLK passes). Its mirror `ROW_A_COL_B` is
-gate-rejected **op-side** for an intermittent craq-sim race in the `llk_post`-as-srcA path (#205), not for a
-missing primitive: the LLK side is `✓*` for both directions.
+**Mixed broadcast types need no row of their own.** `ROW_B_COL_A` and `ROW_A_COL_B` are both op-wired and
+sim-certified on the DFB path using the ROW row above — the COL half is a reader software-fill, not a second
+`unary_bcast` pass (a deliberate reader/compute load-balance that keeps compute at 2 LLK passes). The LLK
+side is `✓*` for both directions.
 
 - **32-bit formats are gated off:** the Quasar branch's `enable_unpack_to_dest` check omits
   `DataFormat::UInt32` — Quasar has no uint32 device format (its 32-bit formats are `Float32`/`Int32`; the

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/qualification/QUASAR_LLK_GAPS.md
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/qualification/QUASAR_LLK_GAPS.md
@@ -271,10 +271,11 @@ side is `✓*` for both directions.
   the A2D unpack-to-dest path, which isn't implemented on Quasar. bf16 only for now.
 - `reconfigure_unary_bcast` (mid-program bcast-type/format switch) is `#ifndef ARCH_QUASAR`-only; Quasar
   re-`init`s per broadcast type instead.
-- No sim/LLK bug surfaced while certifying SCALAR/ROW/COL through the op — all 112 broadcast cases in
-  `test_binary_ng_bcast.py` pass on the QSR sim alongside the 88-case no-bcast regression suite. The one
-  race that DID surface is in the mixed `ROW_A_COL_B` composition (`llk_post` as binary srcA), not in any
-  single-operand dimension above; see the mixed-type note under Table 3.
+- No sim/LLK bug surfaced while certifying SCALAR/ROW/COL through the op — all 130 broadcast cases in
+  `test_binary_ng_bcast.py` pass on the QSR sim (0 skipped) alongside the 88-case no-bcast regression suite.
+  The one race that DID surface was in the mixed `ROW_A_COL_B` composition and was a **simulator**
+  credit-attribution bug (fixed by craq-sim #218), never an LLK or op defect — no single-operand dimension
+  above was implicated; see the mixed-type note under Table 3.
 
 ## Priorities (by model impact)
 
@@ -288,7 +289,8 @@ side is `✓*` for both directions.
 — all sim-certified — plus the arithmetic/`where`/compare-to-zero core (bf16/fp32 add/sub/mul/div now
 sim-certified through both `binary_ng`'s tensor-tensor no-broadcast path AND its tensor-scalar path, the
 latter via a writer-filled RHS tile) and subtile broadcast `unary_bcast` SCALAR/ROW/COL — single-operand
-plus the mixed `ROW_B_COL_A` composition (Table 3) — sim-certified through `binary_ng` itself.
+plus BOTH mixed compositions, `ROW_B_COL_A` and `ROW_A_COL_B` (Table 3) — sim-certified through
+`binary_ng` itself.
 
 ## Closing a gap — the pattern
 


### PR DESCRIPTION
## Summary

Re-enables **mixed subtile broadcast `ROW_A_COL_B`** on the experimental Quasar `binary_ng` DFB path. The
carve-out existed only to work around a **simulator** bug that has since been fixed upstream, so this PR is
a net simplification (−32 lines): it removes the workaround, its post-mortem comments, and the internal
report references that documented it.

Experimental / Quasar-only — **no production (`eltwise/binary_ng`, WH/BH) impact.**

## Why it can be removed

craq-sim [#205](https://github.com/tenstorrent/craq-sim/issues/205) was a **sim-only** NoC-completion credit
misattribution: on the unbound legacy path the address-blind fallback could credit counter 0 (operand `a`)
when operand `b`'s earlier completion arrived, so compute unpacked `a` before its data landed and read 0 →
output equalled `b` (PCC ~0.73). It hit `ROW_A_COL_B` and not the mirror `ROW_B_COL_A` purely because of
which operand sits on counter 0.

Fixed by craq-sim **#218 `fix(quasar): bind legacy DFB completions by descriptor`** — completions are now
bound by descriptor address range before the generic fallback can misattribute them. (Prereq #215 DFB ring
addressing; sibling #219 DM L1D sibling-cache masks landed in the same wave.)

The op and LLK were never at fault: the identical kernels already shipped as single-operand `ROW_A` and as
the mirror `ROW_B_COL_A`.

## Changes

- **Gate** (`binary_ng_device_operation.cpp`): drop the `ROW_A_COL_B → return false` rejection in
  `matches_metal_v2_slice`, so both mixed orientations reach the DFB factory.
- **Test** (`test_binary_ng_bcast.py`): drop the `pytest.skip`; the comment now states what the case
  *covers* (`ROW_A_COL_B` exercises the COL-before-ROW delivery order) rather than the historical bug.
- **Comment hygiene**: removed references to an internal, not-in-repo report (`task-9-report.md`) and the
  stale "only `ROW_B_COL_A` reaches here" claim. Also corrected three comments that listed 5 ops where the
  parametrize and kernels carry 6 (`minimum` was missing).
- **Docs**: `QUASAR_PARITY_GAPS.md` + `qualification/QUASAR_LLK_GAPS.md` now list both mixed orientations as
  supported on the DFB path (removed the gap-table row and the "un-carve" roadmap item).

## Validation (QSR sim, craq-sim `e2fe565e` incl. #215/#218/#219)

- **`ROW_A_COL_B`: 30/30** — all 6 ops (add/subtract/multiply/divide/maximum/minimum) × **5 fresh
  processes**. Fresh processes matter: the old failure was deterministic *first-op-in-process* (the window
  closed as the device warmed).
- **Full `test_binary_ng_bcast.py`: 130 passed, 0 skipped** (was 6 skipped).
- Mirror `ROW_B_COL_A` and all sharded / activation / mixed-layout cases still green ⇒ no regression from
  #219's coherence rework.
- Since the descriptor path hard-throws on Quasar, every pass is also proof the op took the DFB/metal_v2
  factory.
- **Re-confirmed on this PR's actual base** (current `main` + this diff): full `test_binary_ng_bcast.py`
  **130 passed / 0 skipped** — see the simulator note below.

## Simulator prerequisite (not caused by this PR)

Running the Quasar sim suite on current `main` needs a **one-line craq-sim fix that is not yet upstream**.
Without it, *every* Quasar op aborts at dispatch with
`UnimplementedFunctionality: coord_to_tile: coord (4,0)`.

Root cause: tt-metal `fef6fde2c66` ("Fix coordinate for 2nd DRAM channel in QSR", #47730) moved DRAM
channel 1 from **(3,7) → (4,0)**, but craq-sim's `coord_to_tile` still hardcodes the pre-#47730 coordinate,
so (4,0) falls through to its Tensix range check and raises. tt-metal is correct; the simulator is stale.

**Verified pre-existing and unrelated to this change:** it reproduces on pristine `main` with this diff
stashed, in `test_binary_ng_no_bcast.py` (a file this PR does not touch), while bare `open_device` succeeds
(grid 8×4). Filed to craq-sim with the one-line fix; with that fix applied locally the suite is 130/130 on
this base.

## Draft — before ready-for-review

- [x] **Re-validate on this base** — 130/130 on current `main` (with the craq-sim fix above applied locally).
- [ ] **craq-sim fix upstream** — so the Quasar sim suite is reproducible for everyone on current `main`.
      Does not affect WH/BH CI.
- [ ] **WH/BH silicon validation** — the DFB path remains sim-validated only; Quasar LLK CI is compile-only.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dchen/quasar_row_a_col_b_uncarve)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dchen/quasar_row_a_col_b_uncarve)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dchen/quasar_row_a_col_b_uncarve)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dchen/quasar_row_a_col_b_uncarve)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=dchen/quasar_row_a_col_b_uncarve)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:dchen/quasar_row_a_col_b_uncarve)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dchen/quasar_row_a_col_b_uncarve)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dchen/quasar_row_a_col_b_uncarve)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dchen/quasar_row_a_col_b_uncarve)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dchen/quasar_row_a_col_b_uncarve)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dchen/quasar_row_a_col_b_uncarve)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dchen/quasar_row_a_col_b_uncarve)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dchen/quasar_row_a_col_b_uncarve)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dchen/quasar_row_a_col_b_uncarve)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dchen/quasar_row_a_col_b_uncarve)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dchen/quasar_row_a_col_b_uncarve)