### PR TITLE
[Bug fix] Reject DRAM sharded buffers with bank-aliasing shard grids

### DIFF
--- a/tests/ttnn/unit_tests/tensor/test_tensor_nd_sharding.py
+++ b/tests/ttnn/unit_tests/tensor/test_tensor_nd_sharding.py
@@ -128,11 +128,8 @@ def test_nd_shardspec_construction_across_tensor_ranks(device, torch_tensor, sha
     assert tt_tensor.memory_config().nd_shard_spec is not None
 
 
-# DRAM banks are 1D: bank_id == the core's logical x-coordinate and the DRAM grid is a single row.
-# A shard grid that puts a core off row 0 or reuses an x-coordinate aliases banks and silently
-# corrupts data (tenstorrent/tt-metal#51503). Allocating such a buffer must be rejected. The
-# invariant itself is unit-tested in C++ (DramShardValidation.AcceptsSingleRowRejectsBankAliasing);
-# this exercises the end-to-end user path from the issue repro.
+# DRAM banks are 1D: bank_id is a core's logical x-coordinate and the grid is a single row. A shard
+# core off row 0, or a repeated x, aliases banks and corrupts data, so allocation must be rejected.
 @pytest.mark.parametrize(
     "grid",
     [

--- a/tests/ttnn/unit_tests/tensor/test_tensor_nd_sharding.py
+++ b/tests/ttnn/unit_tests/tensor/test_tensor_nd_sharding.py
@@ -126,3 +126,56 @@ def test_nd_shardspec_construction_across_tensor_ranks(device, torch_tensor, sha
 
     assert tt_tensor.memory_config().is_sharded()
     assert tt_tensor.memory_config().nd_shard_spec is not None
+
+
+# DRAM banks are 1D: bank_id == the core's logical x-coordinate and the DRAM grid is a single row.
+# A shard grid that puts a core off row 0 or reuses an x-coordinate aliases banks and silently
+# corrupts data (tenstorrent/tt-metal#51503). Allocating such a buffer must be rejected. The
+# invariant itself is unit-tested in C++ (DramShardValidation.AcceptsSingleRowRejectsBankAliasing);
+# this exercises the end-to-end user path from the issue repro.
+@pytest.mark.parametrize(
+    "grid",
+    [
+        # 2x2: cores (0,1)/(1,1) alias banks 0 and 1.
+        ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 1))]),
+        # Single row but off row 0: every core has y != 0.
+        ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 1), ttnn.CoreCoord(3, 1))]),
+    ],
+    ids=["two_rows", "off_row0"],
+)
+def test_reject_dram_nd_shard_bank_aliasing(device, expect_error, grid):
+    """A DRAM NdShardSpec whose grid aliases banks must fail when the buffer is allocated."""
+    mem_config = ttnn.MemoryConfig(ttnn.BufferType.DRAM, ttnn.NdShardSpec(ttnn.Shape([1, 1, 32, 64]), grid))
+    torch_input = torch.arange(0, 2 * 3 * 64 * 128, dtype=torch.float32).reshape(2, 3, 64, 128).to(torch.bfloat16)
+    with expect_error(RuntimeError, "DRAM banks are 1D"):
+        ttnn.from_torch(
+            torch_input, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device, memory_config=mem_config
+        )
+
+
+def test_accept_dram_nd_shard_single_row(device):
+    """A DRAM NdShardSpec on a single row of distinct banks (y == 0, unique x) round-trips correctly."""
+    num_banks = device.dram_grid_size().x
+    grid = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(num_banks - 1, 0))])
+    mem_config = ttnn.MemoryConfig(ttnn.BufferType.DRAM, ttnn.NdShardSpec(ttnn.Shape([1, 1, 32, 64]), grid))
+
+    torch_input = torch.arange(0, 2 * 3 * 64 * 128, dtype=torch.float32).reshape(2, 3, 64, 128).to(torch.bfloat16)
+    tt = ttnn.from_torch(
+        torch_input, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device, memory_config=mem_config
+    )
+    assert torch.equal(ttnn.to_torch(tt), torch_input)
+
+
+def test_accept_l1_nd_shard_two_dim_grid(device):
+    """The DRAM-only guard must not reject a legitimate 2D worker grid in L1."""
+    grid_size = device.compute_with_storage_grid_size()
+    if grid_size.x < 2 or grid_size.y < 2:
+        pytest.skip("Device grid too small for a 2x2 L1 shard grid")
+    grid = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 1))])
+    mem_config = ttnn.MemoryConfig(ttnn.BufferType.L1, ttnn.NdShardSpec(ttnn.Shape([1, 1, 32, 32]), grid))
+
+    torch_input = torch.arange(0, 64 * 64, dtype=torch.float32).reshape(1, 1, 64, 64).to(torch.bfloat16)
+    tt = ttnn.from_torch(
+        torch_input, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device, memory_config=mem_config
+    )
+    assert torch.equal(ttnn.to_torch(tt), torch_input)

--- a/tests/ttnn/unit_tests/tensor/test_tensor_nd_sharding.py
+++ b/tests/ttnn/unit_tests/tensor/test_tensor_nd_sharding.py
@@ -129,7 +129,7 @@ def test_nd_shardspec_construction_across_tensor_ranks(device, torch_tensor, sha
 
 
 # DRAM banks are 1D: bank_id is a core's logical x-coordinate and the grid is a single row. A shard
-# core off row 0, or a repeated x, aliases banks and corrupts data, so allocation must be rejected.
+# core off row 0 aliases onto an existing bank and corrupts data, so allocation must be rejected.
 @pytest.mark.parametrize(
     "grid",
     [
@@ -151,7 +151,7 @@ def test_reject_dram_nd_shard_bank_aliasing(device, expect_error, grid):
 
 
 def test_accept_dram_nd_shard_single_row(device):
-    """A DRAM NdShardSpec on a single row of distinct banks (y == 0, unique x) round-trips correctly."""
+    """A DRAM NdShardSpec on a single row of banks (y == 0) round-trips correctly."""
     num_banks = device.dram_grid_size().x
     grid = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(num_banks - 1, 0))])
     mem_config = ttnn.MemoryConfig(ttnn.BufferType.DRAM, ttnn.NdShardSpec(ttnn.Shape([1, 1, 32, 64]), grid))

--- a/tt_metal/impl/buffers/buffer.cpp
+++ b/tt_metal/impl/buffers/buffer.cpp
@@ -20,6 +20,7 @@
 #include <mutex>
 #include <string>
 #include <string_view>
+#include <unordered_set>
 #include <utility>
 #include "context/context_types.hpp"
 #include "fmt/base.h"
@@ -90,7 +91,7 @@ inline bool is_emule_device(const IDevice* device) {
 void validate_buffer_parameters(
     DeviceAddr size,
     DeviceAddr page_size,
-    const BufferType& /*buffer_type*/,
+    const BufferType& buffer_type,
     const TensorMemoryLayout& buffer_layout,
     const std::optional<ShardSpecBuffer>& shard_spec,
     const std::optional<BufferDistributionSpec>& buffer_distribution_spec) {
@@ -98,6 +99,35 @@ void validate_buffer_parameters(
         TT_FATAL(
             shard_spec.has_value() || buffer_distribution_spec.has_value(),
             "Buffer was specified as sharded but does not have shard_spec or buffer_distribution_spec specified");
+
+        // DRAM banks are 1D: bank_id == a core's logical x-coordinate and the DRAM grid is a single
+        // row. A shard grid with a core off row 0, or a repeated x, aliases multiple shards onto the
+        // same bank and silently corrupts data (tenstorrent/tt-metal#51503). Covers both the ND
+        // (BufferDistributionSpec) and legacy (ShardSpecBuffer) sharding paths.
+        if (buffer_type == BufferType::DRAM) {
+            std::vector<CoreCoord> shard_cores;
+            if (buffer_distribution_spec.has_value()) {
+                shard_cores = buffer_distribution_spec->cores();
+            } else if (shard_spec.has_value()) {
+                shard_cores = corerange_to_cores(shard_spec->grid());
+            }
+            std::unordered_set<uint32_t> seen_x;
+            seen_x.reserve(shard_cores.size());
+            for (const auto& core : shard_cores) {
+                TT_FATAL(
+                    core.y == 0,
+                    "Invalid DRAM shard grid: shard core ({}, {}) is not on row 0. DRAM banks are 1D "
+                    "(bank_id == logical x-coordinate), so every shard core must have y == 0.",
+                    core.x,
+                    core.y);
+                TT_FATAL(
+                    seen_x.insert(core.x).second,
+                    "Invalid DRAM shard grid: x-coordinate {} is used by more than one shard core. DRAM "
+                    "banks are 1D (bank_id == logical x-coordinate), so a duplicate x aliases multiple "
+                    "shards onto the same bank and corrupts data.",
+                    core.x);
+            }
+        }
     } else {
         TT_FATAL(
             shard_spec == std::nullopt && buffer_distribution_spec == std::nullopt,

--- a/tt_metal/impl/buffers/buffer.cpp
+++ b/tt_metal/impl/buffers/buffer.cpp
@@ -100,10 +100,9 @@ void validate_buffer_parameters(
             shard_spec.has_value() || buffer_distribution_spec.has_value(),
             "Buffer was specified as sharded but does not have shard_spec or buffer_distribution_spec specified");
 
-        // DRAM banks are 1D: bank_id == a core's logical x-coordinate and the DRAM grid is a single
-        // row. A shard grid with a core off row 0, or a repeated x, aliases multiple shards onto the
-        // same bank and silently corrupts data (tenstorrent/tt-metal#51503). Covers both the ND
-        // (BufferDistributionSpec) and legacy (ShardSpecBuffer) sharding paths.
+        // DRAM banks are 1D: bank_id is a core's logical x-coordinate and the grid is a single row.
+        // A shard core off row 0, or a repeated x, aliases shards onto the same bank and corrupts
+        // data. Applies to both the ND (BufferDistributionSpec) and legacy (ShardSpecBuffer) paths.
         if (buffer_type == BufferType::DRAM) {
             std::vector<CoreCoord> shard_cores;
             if (buffer_distribution_spec.has_value()) {

--- a/tt_metal/impl/buffers/buffer.cpp
+++ b/tt_metal/impl/buffers/buffer.cpp
@@ -20,7 +20,6 @@
 #include <mutex>
 #include <string>
 #include <string_view>
-#include <unordered_set>
 #include <utility>
 #include "context/context_types.hpp"
 #include "fmt/base.h"
@@ -101,8 +100,8 @@ void validate_buffer_parameters(
             "Buffer was specified as sharded but does not have shard_spec or buffer_distribution_spec specified");
 
         // DRAM banks are 1D: bank_id is a core's logical x-coordinate and the grid is a single row.
-        // A shard core off row 0, or a repeated x, aliases shards onto the same bank and corrupts
-        // data. Applies to both the ND (BufferDistributionSpec) and legacy (ShardSpecBuffer) paths.
+        // A shard core off row 0 aliases onto an existing bank and corrupts data. Applies to both the
+        // ND (BufferDistributionSpec) and legacy (ShardSpecBuffer) paths.
         if (buffer_type == BufferType::DRAM) {
             std::vector<CoreCoord> shard_cores;
             if (buffer_distribution_spec.has_value()) {
@@ -110,8 +109,6 @@ void validate_buffer_parameters(
             } else if (shard_spec.has_value()) {
                 shard_cores = corerange_to_cores(shard_spec->grid());
             }
-            std::unordered_set<uint32_t> seen_x;
-            seen_x.reserve(shard_cores.size());
             for (const auto& core : shard_cores) {
                 TT_FATAL(
                     core.y == 0,
@@ -119,12 +116,6 @@ void validate_buffer_parameters(
                     "(bank_id == logical x-coordinate), so every shard core must have y == 0.",
                     core.x,
                     core.y);
-                TT_FATAL(
-                    seen_x.insert(core.x).second,
-                    "Invalid DRAM shard grid: x-coordinate {} is used by more than one shard core. DRAM "
-                    "banks are 1D (bank_id == logical x-coordinate), so a duplicate x aliases multiple "
-                    "shards onto the same bank and corrupts data.",
-                    core.x);
             }
         }
     } else {


### PR DESCRIPTION
### PR Category
Bug fix

### Summary

Fixes #51503

Add checks to only allow 1D sharding in ND_SHARDED path.

Add pytest coverage: reject the aliasing grids from the issue repro, and confirm a valid single-row DRAM grid and a 2D L1 grid still round-trip.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ruizhang/51503)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ruizhang/51503)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ruizhang/51503)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ruizhang/51503)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ruizhang/51503)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ruizhang/51503)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ruizhang/51503)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ruizhang/51503)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ruizhang/51503)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ruizhang/51503)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ruizhang/51503)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ruizhang/51503)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ruizhang/51503)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ruizhang/51503)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ruizhang/51503)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ruizhang/51503)