### PR TITLE
[SFPU] Quasar exp: restore the fp32 overflow/underflow guards

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
@@ -340,6 +340,9 @@ sfpi_inline sfpi::vFloat _sfpu_round_to_nearest_int32_(sfpi::vFloat z, sfpi::vIn
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// Non-finite behaviour of the guarded form (unsafe = false), measured on Blackhole silicon:
+//   +-NaN (either sign, quiet or signalling) -> NaN    +Inf -> +Inf    -Inf -> +0
+// unsafe = true drops both guards and preserves none of this.
 template <bool unsafe = false>
 sfpi_inline sfpi::vFloat _sfpu_exp_fp32_accurate_(sfpi::vFloat a) {
     sfpi::vInt i, e;

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
@@ -59,6 +59,11 @@ sfpi_inline sfpi::vFloat _sfpu_round_to_nearest_int32_(sfpi::vFloat z, sfpi::vIn
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+// Non-finite behaviour of this path:
+//   +NaN -> NaN    -NaN -> 0    +Inf -> +Inf    -Inf -> 0
+// -NaN diverges from Blackhole, which returns NaN for either sign: a negative-signed NaN drives i
+// negative, so the lane lands in the underflow arm. Derived from simulation of this routine, NOT
+// silicon-verified -- no Quasar target available.
 sfpi_inline sfpi::vFloat _sfpu_exp_fp32_accurate_(sfpi::vFloat a) {
     sfpi::vInt i;
     sfpi::vFloat f, r, j;

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
@@ -80,22 +80,28 @@ sfpi_inline sfpi::vFloat _sfpu_exp_fp32_accurate_(sfpi::vFloat a) {
     r = r * f + 1.0f;
     r = r * f + 1.0f;
 
-    // exp(a) = 2^i * exp(f), applied via the result's biased exponent. e is that exponent; the
-    // legal IEEE-754 range is 1..254, and i pushes it outside for |a| beyond ~88. Writing
-    // (i + 127) << 23 directly would wrap into the sign bit there -- Quasar's integer adder is
-    // 32-bit two's complement and SHFT discards the high bits (Quasar/Trinity SFPU MAS), so
-    // a = -100 yields i + 127 = -17 -> 0xF7800000 = -2^112 rather than ~0. Clamp both ends, as
-    // the Blackhole source does; nothing routes large-magnitude inputs away from this path
-    // (calculate_exponential selects purely on EN_32BIT_DEST / APPROXIMATION_MODE).
+    // exp(a) = 2^i * exp(f), applied via the result's biased exponent e. The legal IEEE-754 range
+    // is 1..254, and i pushes e outside it for |a| beyond ~88. Writing (i + 127) << 23 directly
+    // would wrap into the sign bit there -- Quasar's integer adder is 32-bit two's complement and
+    // SHFT discards the high bits (Quasar/Trinity SFPU MAS), so a = -100 yields i + 127 = -17 ->
+    // 0xF7800000 = -2^112 rather than ~0. Nothing routes large-magnitude inputs away from this
+    // path (calculate_exponential selects purely on EN_32BIT_DEST / APPROXIMATION_MODE).
+    //
+    // Seed y with the overflow result unpredicated, as the Blackhole source does, and take the
+    // exponent path only when e is in range. Seeding from a (not from the polynomial, which is
+    // NaN for a = +-Inf because f = j*-ln2 + a is -Inf + Inf) keeps exp(+Inf) = +Inf.
     //
     // NB: the earlier Quasar port bug was elsewhere -- the Blackhole kernel's sign-magnitude
     // rounding (abs(as<vInt>(convert<vSMag16>(x))) + copysgn feeding a two's-complement add),
     // which relies on Blackhole's integer-format behaviour. _sfpu_round_to_nearest_int32_ above
     // replaces that.
+    sfpi::vFloat y = a * std::numeric_limits<float>::infinity();
     sfpi::vInt e = sfpi::exexp(r, sfpi::ExponentMode::Biased) + i;
-    sfpi::vFloat y = sfpi::setexp(r, e);
-    v_if(e > 254) { y = std::numeric_limits<float>::infinity(); }  // overflow
-    v_elseif(e < 1) { y = 0.0f; }                                  // underflow, incl. subnormals
+    v_if(e < 255) {
+        y = sfpi::setexp(r, e);
+        v_if(e < 1) { y = 0.0f; }  // underflow, incl. subnormals
+        v_endif;
+    }
     v_endif;
     return y;
 }

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <limits>
+
 #include "ckernel.h"
 #include "ckernel_ops.h"
 #include "ckernel_trisc_common.h"
@@ -78,18 +80,24 @@ sfpi_inline sfpi::vFloat _sfpu_exp_fp32_accurate_(sfpi::vFloat a) {
     r = r * f + 1.0f;
     r = r * f + 1.0f;
 
-    // exp(a) = 2^i * exp(f). Construct 2^i by writing the biased exponent (i + 127) directly into
-    // the IEEE-754 exponent field. This is equivalent to sfpi::setexp on top of a 1.0 seed (setexp
-    // and exexp are correct on Quasar); the int add / shift-left / reinterpret used here are simply
-    // cheaper and keep the whole path in fp32 / two's-complement. Correct across fp32 exp's
-    // representable domain (|a| < ~88); larger-magnitude inputs are the LUT/approx path's concern.
+    // exp(a) = 2^i * exp(f), applied via the result's biased exponent. e is that exponent; the
+    // legal IEEE-754 range is 1..254, and i pushes it outside for |a| beyond ~88. Writing
+    // (i + 127) << 23 directly would wrap into the sign bit there -- Quasar's integer adder is
+    // 32-bit two's complement and SHFT discards the high bits (Quasar/Trinity SFPU MAS), so
+    // a = -100 yields i + 127 = -17 -> 0xF7800000 = -2^112 rather than ~0. Clamp both ends, as
+    // the Blackhole source does; nothing routes large-magnitude inputs away from this path
+    // (calculate_exponential selects purely on EN_32BIT_DEST / APPROXIMATION_MODE).
     //
-    // NB: the Quasar port bug was NOT here. It was the Blackhole kernel's sign-magnitude rounding
-    // (abs(as<vInt>(convert<vSMag16>(x))) + copysgn feeding a two's-complement add), which relies on
-    // Blackhole's integer-format behaviour. _sfpu_round_to_nearest_int32_ above replaces that and is
-    // the actual fix.
-    sfpi::vFloat two_i = sfpi::as<sfpi::vFloat>((i + 127) << 23);
-    return r * two_i;
+    // NB: the earlier Quasar port bug was elsewhere -- the Blackhole kernel's sign-magnitude
+    // rounding (abs(as<vInt>(convert<vSMag16>(x))) + copysgn feeding a two's-complement add),
+    // which relies on Blackhole's integer-format behaviour. _sfpu_round_to_nearest_int32_ above
+    // replaces that.
+    sfpi::vInt e = sfpi::exexp(r, sfpi::ExponentMode::Biased) + i;
+    sfpi::vFloat y = sfpi::setexp(r, e);
+    v_if(e > 254) { y = std::numeric_limits<float>::infinity(); }  // overflow
+    v_elseif(e < 1) { y = 0.0f; }                                  // underflow, incl. subnormals
+    v_endif;
+    return y;
 }
 
 // Calculates EXP over a full tile. Quasar exposes exactly two implementations:

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
@@ -75,6 +75,11 @@ sfpi_inline sfpi::vInt _float_to_int32_for_exp_21f_(sfpi::vFloat val) {
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+// Non-finite behaviour of this path:
+//   +NaN -> NaN    -NaN -> 0    +Inf -> +Inf    -Inf -> 0
+// -NaN diverges from Blackhole, which returns NaN for either sign: a negative-signed NaN drives i
+// negative, so the lane lands in the underflow arm. Derived from simulation of this routine, NOT
+// silicon-verified -- no Quasar target available.
 sfpi_inline sfpi::vFloat _sfpu_exp_fp32_accurate_(sfpi::vFloat a) {
     sfpi::vInt i;
     sfpi::vFloat f, r, j;

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <limits>
+
 #include "ckernel.h"
 #include "ckernel_ops.h"
 #include "ckernel_trisc_common.h"
@@ -94,18 +96,24 @@ sfpi_inline sfpi::vFloat _sfpu_exp_fp32_accurate_(sfpi::vFloat a) {
     r = r * f + 1.0f;
     r = r * f + 1.0f;
 
-    // exp(a) = 2^i * exp(f). Construct 2^i by writing the biased exponent (i + 127) directly into
-    // the IEEE-754 exponent field. This is equivalent to sfpi::setexp on top of a 1.0 seed (setexp
-    // and exexp are correct on Quasar); the int add / shift-left / reinterpret used here are simply
-    // cheaper and keep the whole path in fp32 / two's-complement. Correct across fp32 exp's
-    // representable domain (|a| < ~88); larger-magnitude inputs are the LUT/approx path's concern.
+    // exp(a) = 2^i * exp(f), applied via the result's biased exponent. e is that exponent; the
+    // legal IEEE-754 range is 1..254, and i pushes it outside for |a| beyond ~88. Writing
+    // (i + 127) << 23 directly would wrap into the sign bit there -- Quasar's integer adder is
+    // 32-bit two's complement and SHFT discards the high bits (Quasar/Trinity SFPU MAS), so
+    // a = -100 yields i + 127 = -17 -> 0xF7800000 = -2^112 rather than ~0. Clamp both ends, as
+    // the Blackhole source does; nothing routes large-magnitude inputs away from this path
+    // (calculate_exponential selects purely on EN_32BIT_DEST / APPROXIMATION_MODE).
     //
-    // NB: the Quasar port bug was NOT here. It was the Blackhole kernel's sign-magnitude rounding
-    // (abs(as<vInt>(convert<vSMag16>(x))) + copysgn feeding a two's-complement add), which relies on
-    // Blackhole's integer-format behaviour. _sfpu_round_to_nearest_int32_ above replaces that and is
-    // the actual fix.
-    sfpi::vFloat two_i = sfpi::as<sfpi::vFloat>((i + 127) << 23);
-    return r * two_i;
+    // NB: the earlier Quasar port bug was elsewhere -- the Blackhole kernel's sign-magnitude
+    // rounding (abs(as<vInt>(convert<vSMag16>(x))) + copysgn feeding a two's-complement add),
+    // which relies on Blackhole's integer-format behaviour. _sfpu_round_to_nearest_int32_ above
+    // replaces that.
+    sfpi::vInt e = sfpi::exexp(r, sfpi::ExponentMode::Biased) + i;
+    sfpi::vFloat y = sfpi::setexp(r, e);
+    v_if(e > 254) { y = std::numeric_limits<float>::infinity(); }  // overflow
+    v_elseif(e < 1) { y = 0.0f; }                                  // underflow, incl. subnormals
+    v_endif;
+    return y;
 }
 
 // Calculates EXP over a full tile. Quasar exposes exactly two implementations:

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
@@ -96,22 +96,28 @@ sfpi_inline sfpi::vFloat _sfpu_exp_fp32_accurate_(sfpi::vFloat a) {
     r = r * f + 1.0f;
     r = r * f + 1.0f;
 
-    // exp(a) = 2^i * exp(f), applied via the result's biased exponent. e is that exponent; the
-    // legal IEEE-754 range is 1..254, and i pushes it outside for |a| beyond ~88. Writing
-    // (i + 127) << 23 directly would wrap into the sign bit there -- Quasar's integer adder is
-    // 32-bit two's complement and SHFT discards the high bits (Quasar/Trinity SFPU MAS), so
-    // a = -100 yields i + 127 = -17 -> 0xF7800000 = -2^112 rather than ~0. Clamp both ends, as
-    // the Blackhole source does; nothing routes large-magnitude inputs away from this path
-    // (calculate_exponential selects purely on EN_32BIT_DEST / APPROXIMATION_MODE).
+    // exp(a) = 2^i * exp(f), applied via the result's biased exponent e. The legal IEEE-754 range
+    // is 1..254, and i pushes e outside it for |a| beyond ~88. Writing (i + 127) << 23 directly
+    // would wrap into the sign bit there -- Quasar's integer adder is 32-bit two's complement and
+    // SHFT discards the high bits (Quasar/Trinity SFPU MAS), so a = -100 yields i + 127 = -17 ->
+    // 0xF7800000 = -2^112 rather than ~0. Nothing routes large-magnitude inputs away from this
+    // path (calculate_exponential selects purely on EN_32BIT_DEST / APPROXIMATION_MODE).
+    //
+    // Seed y with the overflow result unpredicated, as the Blackhole source does, and take the
+    // exponent path only when e is in range. Seeding from a (not from the polynomial, which is
+    // NaN for a = +-Inf because f = j*-ln2 + a is -Inf + Inf) keeps exp(+Inf) = +Inf.
     //
     // NB: the earlier Quasar port bug was elsewhere -- the Blackhole kernel's sign-magnitude
     // rounding (abs(as<vInt>(convert<vSMag16>(x))) + copysgn feeding a two's-complement add),
     // which relies on Blackhole's integer-format behaviour. _sfpu_round_to_nearest_int32_ above
     // replaces that.
+    sfpi::vFloat y = a * std::numeric_limits<float>::infinity();
     sfpi::vInt e = sfpi::exexp(r, sfpi::ExponentMode::Biased) + i;
-    sfpi::vFloat y = sfpi::setexp(r, e);
-    v_if(e > 254) { y = std::numeric_limits<float>::infinity(); }  // overflow
-    v_elseif(e < 1) { y = 0.0f; }                                  // underflow, incl. subnormals
+    v_if(e < 255) {
+        y = sfpi::setexp(r, e);
+        v_if(e < 1) { y = 0.0f; }  // underflow, incl. subnormals
+        v_endif;
+    }
     v_endif;
     return y;
 }


### PR DESCRIPTION
Fixes #51543 — sub-issue of #51220, item 3.

### Problem

`_sfpu_exp_fp32_accurate_` builds `2^i` by writing the biased exponent straight into the IEEE-754 field:

```cpp
sfpi::vFloat two_i = sfpi::as<sfpi::vFloat>((i + 127) << 23);
```

That is valid only while `i + 127` lands in the legal range `1…254`. Per the [Quasar/Trinity SFPU Micro-Architecture Spec](https://tenstorrent.atlassian.net/wiki/spaces/TA/pages/1256423592), the SFPU integer adder is *"a standard 32-bit 2's complement signed integer adder"* used for `IADD`, and the Bit Shifter's `SHFT` operates on 32-bit words. So for `|a|` beyond ~88 the value wraps into the **sign bit** and is truncated:

| `a` | `i+127` | bits | before | true |
|---|---|---|---|---|
| −100.0 | −17 | `0xF7800000` | **−4.31e33** | 3.72e−44 |
| −88.5 | −1 | `0xFF800000` | **−inf** | 3.67e−39 |
| +89.5 | 256 | `0x80000000` | **−0** | 7.40e38 |
| +100.0 | 271 | `0x87800000` | **−2.32e−34** | +inf |

Over a ±200 sweep, **28,878 of 100,000 sampled inputs disagreed with a correct implementation**, and a large share returned a negative "exponential." For softmax that is the worst possible failure: masked logits become large negative numbers that poison the row sum instead of vanishing. The adder's own overflow detection does not help — `i + 127 = −17` is a valid 32-bit result; the violation is of the exponent field's range, which the adder has no notion of, so the failure is silent.

### Fix

Restore the guards using Blackhole's shape — seed `y` with the overflow result unpredicated, then take the `exexp`/`setexp` path only when the exponent is in range:

```cpp
sfpi::vFloat y = a * std::numeric_limits<float>::infinity();
sfpi::vInt e = sfpi::exexp(r, sfpi::ExponentMode::Biased) + i;
v_if(e < 255) {
    y = sfpi::setexp(r, e);
    v_if(e < 1) { y = 0.0f; }
    v_endif;
}
v_endif;
```

One deliberate difference from Blackhole: the seed is `a * inf`, not the polynomial value. Quasar's `f = j*-ln2 + a` evaluates to `-Inf + Inf = NaN` for infinite input, so Blackhole's seed would make `exp(+Inf)` return `NaN`. Blackhole gets away with it only because `SFPSTOCHRND` clamps its rounded exponent to ±32767, keeping `j` finite — Quasar's `_sfpu_round_to_nearest_int32_` has no such clamp.

Hoisting the overflow value out of the predicate also removes `SFPSETCC`, `SFPCOMPC` and a predicated `SFPLOADI`: both conditions become `SFPIADD` with its own CC mode. Deriving the exponent as `exexp(r) + i` rather than assuming 127 additionally fixes an **early-saturation** bug — `exp(88.4)` and `exp(88.7)` previously returned `inf` where the true values (2.46e38, 3.33e38) are representable in fp32.

`exexp`/`setexp` are already in active Quasar use (`ckernel_sfpu_log.h:23,46`, `ckernel_sfpu_trigonometry.h:339`), as is `std::numeric_limits<float>::infinity()` (`ckernel_sfpu_log.h:60`).

I did **not** take #51220's alternative suggestion of clamping the input to `[−88.5, 88.5]`: that is wrong on the positive side, yielding a finite `~2.7e38` where `exp(100)` must be `+inf`.

### Deliberate divergence on `-NaN`

This path returns `0` for `exp(-NaN)` rather than `NaN`: `exexp(NaN)` is 255 and `i` carries the input's sign, so a negative-signed NaN lands in the underflow arm.

**Blackhole does not share this — it returns `NaN` for a NaN of either sign.** Measured on Blackhole silicon (p100a) via `ttnn.exp` with a float32 input, which selects `_sfpu_exp_fp32_accurate_<unsafe = false>`: `+qNaN`, `-qNaN`, `+sNaN` and `-sNaN`, with either payload, all produce `NaN`. An earlier revision of this description claimed Blackhole returned `0` here; that came from a simulation of the Blackhole tail which was wrong on exactly this case, and is corrected here.

So this leaves **Quasar as the only architecture that gets `-NaN` wrong** — a knowing divergence, not parity. A fully-IEEE tail is available for **192 instructions** (+60% over this one) by adding an `exexp(a)==255 && exman(a)!=0` test in the underflow arm. Not taken here: the cost is real and the input is a NaN whose *sign* IEEE-754 treats as insignificant, so the practical exposure is a NaN that arrives with its sign bit set and leaves as `0` instead of propagating. Reviewers who disagree with that trade should say so — switching to the 192-instruction form is a small, self-contained change.

For reference, Blackhole reaches the correct answer because `SFPSTOCHRND` clamps its rounded exponent to ±32767, keeping the front end finite, and its overflow default carries NaN. Wormhole handles it via a `bits-1` then `×0` trick that makes its *underflow* default carry NaN too; that depends on Wormhole producing non-canonical NaNs with mantissa exactly 1 and is not portable here.

Non-finite behaviour, this PR vs the two other arches:

| input | this PR (simulated) | BH shipped (measured) | WH shipped (simulated) |
|---|---|---|---|
| `+NaN` | `nan` | `nan` | `nan` |
| `-NaN` | **`0`** | **`nan`** | `nan` |
| `+Inf` | `inf` | `inf` | `inf` |
| `-Inf` | `0` | `+0` | `-0` |

The Blackhole column is measured on silicon. The Quasar column is simulated (no Quasar target available) and
the Wormhole column is derived from the ISA functional models, not run on a WH board.

### Verification — code-correct only

**No Quasar target available on my box (WH n150), so this needs simulator validation before merge** (tracked on #51543).

- **Compiles clean** for `-mcpu=tt-qsr32-tensix` with `-Wall -Werror`. Generated code confirms the shape: `SFPEXEXP` ×8, `SFPSETEXP` ×8, one hoisted `SFPMULI`, and `SFPSHFT`/`SFPSETCC`/`SFPCOMPC` all absent.
- **Identical to shipped Blackhole on every input except `-NaN`.** Checked against a simulation built on the ISA functional models for `SFPSTOCHRND`/`SFPABS`/`SFPSETSGN`/`SFPEXEXP`/`SFPIADD`, validated at 1 ULP against libm: `+NaN`, `±Inf`, the ±88 clamp boundaries, `±1e7` and `±3.4e38` all agree, and **0 of 200,000 random finite inputs differ**. Max in-domain relative error 9.27e-08, matching Blackhole. The `-NaN` cell was the one place that simulation got Blackhole wrong — silicon says `NaN`, the model said `0` — so treat the simulated Quasar `-NaN` value as unverified rather than established.

### Trade-offs

- **72 → 120 SFPU instructions.** The two-clamp form this replaces cost 144, so the restructure pays for a quarter of the guard.
- Like Blackhole, the guarded path **flushes subnormal results to 0**, so inputs in roughly `[−88.03, −87.34]` now return `0` instead of a subnormal. Deliberate, for parity, and strictly better than `−inf`.

### Why it was never caught

The tt-llk unary stimulus default is `StimuliSpec.uniform(low=0.0, high=1.0)` and `exp` has no per-op range override, so it is only exercised on `[0, 1]` — nowhere near ±88, and nothing in CI executes either guard. Adding large-magnitude coverage to the Quasar exp test is worth doing as a follow-up; I left it out here because I cannot run the Quasar suite to confirm a new case passes.

CODEOWNERS: @rtawfik01 @rdjogoTT @nvelickovicTT

🤖 Generated with [Claude Code](https://claude.com/claude-code)
### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=fix-quasar-exp-range-guards)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:fix-quasar-exp-range-guards)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=fix-quasar-exp-range-guards)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:fix-quasar-exp-range-guards)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fix-quasar-exp-range-guards)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fix-quasar-exp-range-guards)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=fix-quasar-exp-range-guards)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:fix-quasar-exp-range-guards)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=fix-quasar-exp-range-guards)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:fix-quasar-exp-range-guards)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=fix-quasar-exp-range-guards)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:fix-quasar-exp-range-guards)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=fix-quasar-exp-range-guards)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:fix-quasar-exp-range-guards)

