### PR TITLE
[Cleanup] Rename Metal 2.0 kernel-side binding tokens to *BindingToken

### DIFF
--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -2591,7 +2591,7 @@ TEST_F(ProgramSpecTestQuasar, ComputeGen2ConfigInversionAndEnumMapToInternal) {
 //    coupling through the shared DFB binding induces additional DM solver constraints.
 //
 //    NOTE: The original plan called for lifting this artificial constraint once LLK adopted
-//    DFBBindingToken using implicit RTAs. However, to realize performance gains, we're
+//    DFBBindingToken using implicit RTAs. However, to realize performance gains, we've
 //    chosen instead to GUARANTEE using implicit CTAs for DFBBindingToken. This
 //    constraint is therefore permanent.
 //

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -2591,8 +2591,8 @@ TEST_F(ProgramSpecTestQuasar, ComputeGen2ConfigInversionAndEnumMapToInternal) {
 //    coupling through the shared DFB binding induces additional DM solver constraints.
 //
 //    NOTE: The original plan called for lifting this artificial constraint once LLK adopted
-//    DFBAccessor using implicit RTAs. However, to realize performance gains, we're
-//    chosen instead to GUARANTEE using implicit CTAs for DFBAccessor. This
+//    DFBBindingToken using implicit RTAs. However, to realize performance gains, we're
+//    chosen instead to GUARANTEE using implicit CTAs for DFBBindingToken. This
 //    constraint is therefore permanent.
 //
 //    If we were ever to start encountering serious unsolvable-Program issues as a result
@@ -3913,8 +3913,8 @@ void kernel_main() {
 // ----------------------------------------------------------------------------
 //
 // Like the TensorAccessor smoke above, these JIT-compile a kernel that constructs a Scratchpad from
-// its binding accessor (scratch::<name>) and reads the CRTA-injected base address — exercising the
-// generated scratch:: namespace + ScratchpadAccessor object and the device-side Scratchpad ctor. Compile-only on
+// its binding token (scratch::<name>) and reads the CRTA-injected base address — exercising the
+// generated scratch:: namespace + ScratchpadBindingToken object and the device-side Scratchpad ctor. Compile-only on
 // the mock Wormhole device (Gen1: the Quasar TRISC firmware isn't built in this checkout, so a
 // Quasar JIT-compile would fail at link).
 

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
@@ -65,7 +65,7 @@ protected:
 //
 // Proves that DFB local accessor names work end-to-end on real WH/BH hardware:
 //   1. kernel_bindings_generated.h is emitted correctly (dfb::buf resolves at compile time)
-//   2. The DFBAccessor mechanism works (DFB ID maps to the correct underlying CB)
+//   2. The DFBBindingToken mechanism works (DFB ID maps to the correct underlying CB)
 //   3. Data flows correctly through the DFB from producer to consumer
 //
 // Pipeline:

--- a/tests/tt_metal/tt_metal/test_kernels/compute/dfb_t6.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/dfb_t6.cpp
@@ -7,7 +7,7 @@
 #include "api/debug/dprint.h"
 #include "experimental/kernel_args.h"
 
-// Quick check that DFBAccessor implicitly converts to uint32_t at compile time.
+// Quick check that DFBBindingToken implicitly converts to uint32_t at compile time.
 // This is a shim to enable DFB to work with WH/BH LLK compute APIs that expect raw CB ids.
 // If implicit conversion (or its constexpr-ness) regressed, this line would fail to compile.
 // NOTE: This check is piggybacking along on an unrelated test kernel.

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
@@ -124,7 +124,8 @@ struct KernelSpec {
 
     // DFB bindings
     // Declares that this kernel requires a DFB resource (declared at the ProgramSpec level)
-    // The kernel constructs the accessor via DataflowBuffer(dfb::<accessor_name>)
+    // The kernel constructs a DataflowBuffer from the binding token:
+    //   DataflowBuffer(dfb::<accessor_name>)
     struct DFBBinding {
         // Endpoint role this binding plays for the DFB.
         enum class EndpointType { PRODUCER, CONSUMER };
@@ -145,7 +146,7 @@ struct KernelSpec {
 
     // Semaphore bindings
     // Declares that this kernel accesses a semaphore resource (declared at the ProgramSpec level)
-    // The kernel constructs the accessor via Semaphore(sem::<accessor_name>)
+    // The kernel constructs a Semaphore from the emitted id: Semaphore(sem::<accessor_name>)
     struct SemaphoreBinding {
         SemaphoreSpecName semaphore_spec_name;  // identify the semaphore within the ProgramSpec
         std::string accessor_name;              // semaphore accessor name (used in the kernel source code)
@@ -154,7 +155,8 @@ struct KernelSpec {
 
     // Scratchpad bindings
     // Declares that this kernel uses a scratchpad resource (declared at the ProgramSpec level)
-    // The kernel constructs the accessor via Scratchpad(scratch::<accessor_name>)
+    // The kernel constructs a Scratchpad from the binding token:
+    //   Scratchpad(scratch::<accessor_name>)
     struct ScratchpadBinding {
         ScratchpadSpecName scratchpad_spec_name;  // identify the scratchpad within the ProgramSpec
         std::string accessor_name;                // scratchpad accessor name (used in the kernel source code)
@@ -167,7 +169,8 @@ struct KernelSpec {
 
     // Tensor bindings
     // Declares that this kernel accesses a tensor parameter (declared at the ProgramSpec level)
-    // The kernel constructs the accessor via TensorAccessor(tensor::<accessor_name>)
+    // The kernel constructs a TensorAccessor (or LocalTensorAccessor) from the binding token:
+    //   TensorAccessor(tensor::<accessor_name>)
     struct TensorBinding {
         TensorParamName tensor_parameter_name;  // identify the TensorParameter within the ProgramSpec
         std::string accessor_name;              // tensor accessor name (used in the kernel source code)

--- a/tt_metal/hw/inc/api/dataflow/dataflow_buffer.h
+++ b/tt_metal/hw/inc/api/dataflow/dataflow_buffer.h
@@ -37,19 +37,19 @@
 // The user then uses that accessor_name to construct a DataflowBuffer in the kernel code.
 //
 // Usage example:
-//   // (Host code declares "my_dfb_name" as the DFB local accessor name for this kernel.)
+//   // (Host code declares "my_dfb_name" as the DFB accessor name for this kernel.)
 //   // In the kernel code:
 //   DataflowBuffer my_dfb(dfb::my_dfb_name);
 //
-// Here my_dfb_name is a constexpr DFBAccessor, auto-included in kernel_bindings_generated.h.
+// Here my_dfb_name is a constexpr DFBBindingToken, auto-included in kernel_bindings_generated.h.
 //
-struct DFBAccessor {
-    explicit constexpr DFBAccessor(uint16_t id) noexcept : id_(id) {}
+struct DFBBindingToken {
+    explicit constexpr DFBBindingToken(uint16_t id) noexcept : id_(id) {}
 
-    // DFBAccessor is backed by a compile-time ID (an implicit CTA).
+    // DFBBindingToken is backed by a compile-time ID (an implicit CTA).
 
     // Implicit conversion to uint32_t:
-    // This lets a Metal 2.0 kernel pass a DFBAccessor directly to Gen1 (WH/BH) LLK
+    // This lets a Metal 2.0 kernel pass a DFBBindingToken directly to Gen1 (WH/BH) LLK
     // compute APIs that expect a raw CB id.
     // This conversion is constexpr; it's intended for Gen1 use only.
     constexpr operator uint32_t() const noexcept { return id_; }
@@ -69,9 +69,9 @@ public:
     // Preferred constructor for Metal 2.0 / ProgramSpec kernels.
     // Pass the named binding constant from kernel_bindings_generated.h:
     //   DataflowBuffer dfb(my_dfb_name);
-    DataflowBuffer(DFBAccessor accessor) : DataflowBuffer(static_cast<uint16_t>(accessor)) {}
+    DataflowBuffer(DFBBindingToken token) : DataflowBuffer(static_cast<uint16_t>(token)) {}
 
-    // Low-level constructor: prefer DFBAccessor overload above for new kernel code.
+    // Low-level constructor: prefer DFBBindingToken overload above for new kernel code.
     DataflowBuffer(uint16_t logical_dfb_id);
 
     uint16_t get_id() const { return logical_dfb_id_; }

--- a/tt_metal/hw/inc/api/scratchpad.h
+++ b/tt_metal/hw/inc/api/scratchpad.h
@@ -22,11 +22,11 @@
 //   // In the kernel code:
 //   Scratchpad<int32_t> my_pad(scratch::my_scratchpad_name);
 //
-// Here my_scratchpad_name is a constexpr ScratchpadAccessor, auto-included in
+// Here my_scratchpad_name is a constexpr ScratchpadBindingToken, auto-included in
 // kernel_bindings_generated.h.
-class ScratchpadAccessor {
+class ScratchpadBindingToken {
 public:
-    explicit constexpr ScratchpadAccessor(uint32_t crta_offset, uint32_t size_in_bytes) noexcept :
+    explicit constexpr ScratchpadBindingToken(uint32_t crta_offset, uint32_t size_in_bytes) noexcept :
         crta_offset_(crta_offset), size_in_bytes_(size_in_bytes) {}
 
 private:
@@ -43,7 +43,7 @@ private:
  * A Scratchpad is the device-side counterpart to the host ScratchpadSpec: it provides indexed
  * access to the scratchpad region reserved in per-node SRAM ("L1") for the duration of a Program.
  *
- * Construct one from the accessor your host code declared on the kernel's scratchpad binding:
+ * Construct one from the binding token your host code declared on the kernel's scratchpad binding:
  * @code
  *   // Host code declares the accessor name "my_scratchpad_name" for this kernel.
  *   // In the kernel:
@@ -75,10 +75,10 @@ public:
     using reference = T&;
     using const_reference = const T&;
 
-    // Resolve a scratchpad from its accessor token: read the per-node base SRAM (L1) address from the CRTA
-    // slot at the accessor token's CRTA word offset; size is the static spec value.
-    [[nodiscard]] explicit Scratchpad(const ScratchpadAccessor& accessor) noexcept :
-        Scratchpad(pointer{get_common_arg_val<uint32_t>(accessor.crta_offset_)}, accessor.size_in_bytes_) {}
+    // Resolve a scratchpad from its binding token: read the per-node base SRAM (L1) address from the CRTA
+    // slot at the token's CRTA word offset; size is the static spec value.
+    [[nodiscard]] explicit Scratchpad(const ScratchpadBindingToken& token) noexcept :
+        Scratchpad(pointer{get_common_arg_val<uint32_t>(token.crta_offset_)}, token.size_in_bytes_) {}
 
     [[nodiscard]] Scratchpad(pointer base_addr, size_type size_in_bytes) noexcept :
         start_addr_(base_addr), sentinel_addr_(pointer{base_addr.get_address() + uintptr_t{size_in_bytes}}) {

--- a/tt_metal/impl/emulation/emulated_program_runner.cpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.cpp
@@ -750,9 +750,9 @@ static Metal2BindingsSnapshot build_metal2_snapshot(const tt::tt_metal::Kernel& 
     s.is_metal2 = kernel.is_metal2_kernel();
     s.runtime_arg_names = kernel.get_runtime_arg_names();
     s.common_runtime_arg_names = kernel.get_common_runtime_arg_names();
-    kernel.process_dataflow_buffer_local_accessor_handles(
+    kernel.process_dataflow_buffer_binding_handles(
         [&s](const std::string& name, uint16_t id) { s.dfb_accessors[name] = id; });
-    kernel.process_semaphore_local_accessor_handles(
+    kernel.process_semaphore_binding_handles(
         [&s](const std::string& name, uint16_t id) { s.sem_accessors[name] = id; });
     kernel.process_tensor_binding_handles(
         // Match the genfiles.cpp pattern: drop num_runtime_field_crta_words. Emule's
@@ -844,7 +844,7 @@ static void emit_metal2_namespaces(
     if (!s.dfb_accessors.empty()) {
         f << "namespace dfb {\n";
         for (const auto& [name, id] : s.dfb_accessors) {
-            f << "constexpr DFBAccessor " << name << "{" << id << "};\n";
+            f << "constexpr DFBBindingToken " << name << "{" << id << "};\n";
         }
         f << "}  // namespace dfb\n";
     }
@@ -867,7 +867,7 @@ static void emit_metal2_namespaces(
     if (!s.scratch_accessors.empty()) {
         f << "namespace scratch {\n";
         for (const auto& sp : s.scratch_accessors) {
-            f << "constexpr ScratchpadAccessor " << sp.name << "{" << sp.addr_crta_word << "u, " << sp.size_bytes
+            f << "constexpr ScratchpadBindingToken " << sp.name << "{" << sp.addr_crta_word << "u, " << sp.size_bytes
               << "u};\n";
         }
         f << "}  // namespace scratch\n";

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -128,8 +128,8 @@ Kernel::Kernel(
     const std::map<std::string, std::string>& defines,
     const std::unordered_map<std::string, uint32_t>& named_compile_args,
     bool is_metal2_kernel,
-    const DataflowBufferLocalAccessorHandleMap& dataflow_buffer_local_accessor_handles,
-    const SemaphoreLocalAccessorHandleMap& semaphore_local_accessor_handles,
+    const DataflowBufferBindingHandleMap& dataflow_buffer_binding_handles,
+    const SemaphoreBindingHandleMap& semaphore_binding_handles,
     const std::vector<std::string>& runtime_arg_names,
     const std::vector<std::string>& common_runtime_arg_names,
     const std::vector<TensorBindingHandle>& tensor_binding_handles,
@@ -141,8 +141,8 @@ Kernel::Kernel(
     compile_time_args_(compile_args),
     named_compile_time_args_(named_compile_args),
     is_metal2_kernel_(is_metal2_kernel),
-    dataflow_buffer_local_accessor_handles_(dataflow_buffer_local_accessor_handles),
-    semaphore_local_accessor_handles_(semaphore_local_accessor_handles),
+    dataflow_buffer_binding_handles_(dataflow_buffer_binding_handles),
+    semaphore_binding_handles_(semaphore_binding_handles),
     runtime_arg_names_(runtime_arg_names),
     common_runtime_arg_names_(common_runtime_arg_names),
     tensor_binding_handles_(tensor_binding_handles),
@@ -306,16 +306,16 @@ void Kernel::process_named_compile_time_args(
     callback(this->named_compile_time_args());
 }
 
-void Kernel::process_dataflow_buffer_local_accessor_handles(
+void Kernel::process_dataflow_buffer_binding_handles(
     const std::function<void(const std::string& accessor_name, uint16_t logical_dfb_id)> callback) const {
-    for (const auto& [accessor_name, logical_dfb_id] : this->dataflow_buffer_local_accessor_handles_) {
+    for (const auto& [accessor_name, logical_dfb_id] : this->dataflow_buffer_binding_handles_) {
         callback(accessor_name, logical_dfb_id);
     }
 }
 
-void Kernel::process_semaphore_local_accessor_handles(
+void Kernel::process_semaphore_binding_handles(
     const std::function<void(const std::string& accessor_name, uint16_t semaphore_id)> callback) const {
-    for (const auto& [accessor_name, semaphore_id] : this->semaphore_local_accessor_handles_) {
+    for (const auto& [accessor_name, semaphore_id] : this->semaphore_binding_handles_) {
         callback(accessor_name, semaphore_id);
     }
 }
@@ -546,11 +546,11 @@ uint64_t Kernel::compute_hash() const {
         hasher.update(it->first);
         hasher.update(static_cast<uint64_t>(it->second));
     }
-    for (const auto& it : sorted_iters(this->dataflow_buffer_local_accessor_handles_)) {
+    for (const auto& it : sorted_iters(this->dataflow_buffer_binding_handles_)) {
         hasher.update(it->first);
         hasher.update(static_cast<uint64_t>(it->second));
     }
-    for (const auto& it : sorted_iters(this->semaphore_local_accessor_handles_)) {
+    for (const auto& it : sorted_iters(this->semaphore_binding_handles_)) {
         hasher.update(it->first);
         hasher.update(static_cast<uint64_t>(it->second));
     }

--- a/tt_metal/impl/kernels/kernel.hpp
+++ b/tt_metal/impl/kernels/kernel.hpp
@@ -90,10 +90,10 @@ KernelHandle CreateKernelFromString(
     const std::variant<CoreCoord, CoreRange, CoreRangeSet>& core_spec,
     const DramConfig& config);
 
-// Metal 2.0: local DFB accessor names -> logical DFB ids
-using DataflowBufferLocalAccessorHandleMap = std::unordered_map<std::string, uint16_t>;
-// Metal 2.0: local semaphore accessor names -> semaphore ids
-using SemaphoreLocalAccessorHandleMap = std::unordered_map<std::string, uint16_t>;
+// Metal 2.0: DFB accessor names -> logical DFB ids
+using DataflowBufferBindingHandleMap = std::unordered_map<std::string, uint16_t>;
+// Metal 2.0: semaphore accessor names -> semaphore ids
+using SemaphoreBindingHandleMap = std::unordered_map<std::string, uint16_t>;
 
 // Metal 2.0: per-kernel resolved TensorBinding.
 // Carries the offsets the kernel-side codegen needs to emit a token, plus the program-level
@@ -218,9 +218,9 @@ public:
     void process_compile_time_args(std::function<void(const std::vector<uint32_t>& values)>) const override;
     void process_named_compile_time_args(
         std::function<void(const std::unordered_map<std::string, uint32_t>& named_args)>) const override;
-    void process_dataflow_buffer_local_accessor_handles(
+    void process_dataflow_buffer_binding_handles(
         std::function<void(const std::string& accessor_name, uint16_t logical_dfb_id)>) const override;
-    void process_semaphore_local_accessor_handles(
+    void process_semaphore_binding_handles(
         std::function<void(const std::string& accessor_name, uint16_t semaphore_id)>) const override;
     void process_tensor_binding_handles(std::function<void(
                                             const std::string& accessor_name,
@@ -306,8 +306,8 @@ protected:
         // Metal 2.0-only parameters below.
         // If is_metal2_kernel is false, the remaining parameters are ignored and should be left default.
         bool is_metal2_kernel = false,
-        const DataflowBufferLocalAccessorHandleMap& dataflow_buffer_local_accessor_handles = {},
-        const SemaphoreLocalAccessorHandleMap& semaphore_local_accessor_handles = {},
+        const DataflowBufferBindingHandleMap& dataflow_buffer_binding_handles = {},
+        const SemaphoreBindingHandleMap& semaphore_binding_handles = {},
         const std::vector<std::string>& runtime_arg_names = {},
         const std::vector<std::string>& common_runtime_arg_names = {},
         const std::vector<TensorBindingHandle>& tensor_binding_handles = {},
@@ -326,8 +326,8 @@ protected:
     // populated only when is_metal2_kernel_ is true. Order of runtime_arg_names_ /
     // common_runtime_arg_names_ determines byte-offset layout in the dispatch buffer.
     const bool is_metal2_kernel_;
-    const DataflowBufferLocalAccessorHandleMap dataflow_buffer_local_accessor_handles_;
-    const SemaphoreLocalAccessorHandleMap semaphore_local_accessor_handles_;
+    const DataflowBufferBindingHandleMap dataflow_buffer_binding_handles_;
+    const SemaphoreBindingHandleMap semaphore_binding_handles_;
     const std::vector<std::string> runtime_arg_names_;
     const std::vector<std::string> common_runtime_arg_names_;
     const std::vector<TensorBindingHandle> tensor_binding_handles_;
@@ -379,8 +379,8 @@ public:
         const DataMovementConfig& config,
         // Metal 2.0-only parameters below.
         bool is_metal2_kernel = false,
-        const DataflowBufferLocalAccessorHandleMap& dataflow_buffer_local_accessor_handles = {},
-        const SemaphoreLocalAccessorHandleMap& semaphore_local_accessor_handles = {},
+        const DataflowBufferBindingHandleMap& dataflow_buffer_binding_handles = {},
+        const SemaphoreBindingHandleMap& semaphore_binding_handles = {},
         const std::vector<std::string>& runtime_arg_names = {},
         const std::vector<std::string>& common_runtime_arg_names = {},
         const std::vector<TensorBindingHandle>& tensor_binding_handles = {},
@@ -394,8 +394,8 @@ public:
             config.defines,
             config.named_compile_args,
             is_metal2_kernel,
-            dataflow_buffer_local_accessor_handles,
-            semaphore_local_accessor_handles,
+            dataflow_buffer_binding_handles,
+            semaphore_binding_handles,
             runtime_arg_names,
             common_runtime_arg_names,
             tensor_binding_handles,
@@ -574,8 +574,8 @@ public:
         const ComputeConfig& config,
         // Metal 2.0-only parameters below.
         bool is_metal2_kernel = false,
-        const DataflowBufferLocalAccessorHandleMap& dataflow_buffer_local_accessor_handles = {},
-        const SemaphoreLocalAccessorHandleMap& semaphore_local_accessor_handles = {},
+        const DataflowBufferBindingHandleMap& dataflow_buffer_binding_handles = {},
+        const SemaphoreBindingHandleMap& semaphore_binding_handles = {},
         const std::vector<std::string>& runtime_arg_names = {},
         const std::vector<std::string>& common_runtime_arg_names = {},
         const std::vector<TensorBindingHandle>& tensor_binding_handles = {},
@@ -589,8 +589,8 @@ public:
             config.defines,
             config.named_compile_args,
             is_metal2_kernel,
-            dataflow_buffer_local_accessor_handles,
-            semaphore_local_accessor_handles,
+            dataflow_buffer_binding_handles,
+            semaphore_binding_handles,
             runtime_arg_names,
             common_runtime_arg_names,
             tensor_binding_handles,
@@ -660,8 +660,8 @@ public:
         const std::set<DataMovementProcessor>& dm_processors,
         // Metal 2.0-only parameters below.
         bool is_metal2_kernel = false,
-        const DataflowBufferLocalAccessorHandleMap& dataflow_buffer_local_accessor_handles = {},
-        const SemaphoreLocalAccessorHandleMap& semaphore_local_accessor_handles = {},
+        const DataflowBufferBindingHandleMap& dataflow_buffer_binding_handles = {},
+        const SemaphoreBindingHandleMap& semaphore_binding_handles = {},
         const std::vector<std::string>& runtime_arg_names = {},
         const std::vector<std::string>& common_runtime_arg_names = {},
         const std::vector<TensorBindingHandle>& tensor_binding_handles = {},
@@ -675,8 +675,8 @@ public:
             config.defines,
             config.named_compile_args,
             is_metal2_kernel,
-            dataflow_buffer_local_accessor_handles,
-            semaphore_local_accessor_handles,
+            dataflow_buffer_binding_handles,
+            semaphore_binding_handles,
             runtime_arg_names,
             common_runtime_arg_names,
             tensor_binding_handles,
@@ -732,8 +732,8 @@ public:
         const std::set<QuasarComputeProcessor>& compute_processors,
         // Metal 2.0-only parameters below.
         bool is_metal2_kernel = false,
-        const DataflowBufferLocalAccessorHandleMap& dataflow_buffer_local_accessor_handles = {},
-        const SemaphoreLocalAccessorHandleMap& semaphore_local_accessor_handles = {},
+        const DataflowBufferBindingHandleMap& dataflow_buffer_binding_handles = {},
+        const SemaphoreBindingHandleMap& semaphore_binding_handles = {},
         const std::vector<std::string>& runtime_arg_names = {},
         const std::vector<std::string>& common_runtime_arg_names = {},
         const std::vector<TensorBindingHandle>& tensor_binding_handles = {},
@@ -747,8 +747,8 @@ public:
             config.defines,
             config.named_compile_args,
             is_metal2_kernel,
-            dataflow_buffer_local_accessor_handles,
-            semaphore_local_accessor_handles,
+            dataflow_buffer_binding_handles,
+            semaphore_binding_handles,
             runtime_arg_names,
             common_runtime_arg_names,
             tensor_binding_handles,

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -2462,10 +2462,10 @@ ScratchpadBindingsForKernel ResolveScratchpadBindingsForKernel(
     return out;
 }
 
-// Create map of local accessor name -> logical DFB id
-tt::tt_metal::DataflowBufferLocalAccessorHandleMap MakeDataflowBufferLocalAccessorHandles(
+// Create map of accessor name -> logical DFB id
+tt::tt_metal::DataflowBufferBindingHandleMap MakeDataflowBufferBindingHandles(
     const KernelSpec& kernel_spec, const DFBNameToIdMap& dfb_name_to_id) {
-    tt::tt_metal::DataflowBufferLocalAccessorHandleMap out;
+    tt::tt_metal::DataflowBufferBindingHandleMap out;
     out.reserve(kernel_spec.dfb_bindings.size());
     for (const auto& dfb_binding : kernel_spec.dfb_bindings) {
         const uint32_t id = dfb_name_to_id.at(dfb_binding.dfb_spec_name);
@@ -2480,10 +2480,10 @@ tt::tt_metal::DataflowBufferLocalAccessorHandleMap MakeDataflowBufferLocalAccess
     return out;
 }
 
-// Create map of local accessor name -> logical Semaphore id
-tt::tt_metal::SemaphoreLocalAccessorHandleMap MakeSemaphoreLocalAccessorHandles(
+// Create map of accessor name -> logical Semaphore id
+tt::tt_metal::SemaphoreBindingHandleMap MakeSemaphoreBindingHandles(
     const KernelSpec& kernel_spec, const SemaphoreNameToIdMap& semaphore_name_to_id) {
-    tt::tt_metal::SemaphoreLocalAccessorHandleMap out;
+    tt::tt_metal::SemaphoreBindingHandleMap out;
     out.reserve(kernel_spec.semaphore_bindings.size());
     for (const auto& semaphore_binding : kernel_spec.semaphore_bindings) {
         const uint32_t id = semaphore_name_to_id.at(semaphore_binding.semaphore_spec_name);
@@ -2999,11 +2999,11 @@ Program BuildProgramFromSpec(distributed::MeshDevice& mesh_device, const Program
         KernelSource kernel_src = MakeKernelSource(kernel_spec);
         const NodeRangeSet& node_ranges = collected.kernel_node_set.at(kernel_spec.unique_id);
 
-        // Make the local accessor name -> DFB ID map for this kernel
-        const tt::tt_metal::DataflowBufferLocalAccessorHandleMap dfb_handles =
-            MakeDataflowBufferLocalAccessorHandles(kernel_spec, dfb_name_to_id);
-        const tt::tt_metal::SemaphoreLocalAccessorHandleMap semaphore_handles =
-            MakeSemaphoreLocalAccessorHandles(kernel_spec, semaphore_name_to_id);
+        // Make the accessor name -> DFB ID map for this kernel
+        const tt::tt_metal::DataflowBufferBindingHandleMap dfb_handles =
+            MakeDataflowBufferBindingHandles(kernel_spec, dfb_name_to_id);
+        const tt::tt_metal::SemaphoreBindingHandleMap semaphore_handles =
+            MakeSemaphoreBindingHandles(kernel_spec, semaphore_name_to_id);
 
         // Resolve TensorBindings for this kernel:
         //  - pack each binding's pre-resolved CTA payload into the kernel's positional CTA buffer

--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -109,14 +109,14 @@ void write_kernel_bindings_generated_header(const string& out_dir, const JitBuil
     // Sort them to ensure the file output is deterministic for the JIT build cache
     // (aka the on-disk per-object dephash cache)
     vector<pair<string, uint16_t>> dfb_entries;
-    settings.process_dataflow_buffer_local_accessor_handles(
+    settings.process_dataflow_buffer_binding_handles(
         [&dfb_entries](const string& name, uint16_t id) { dfb_entries.emplace_back(name, id); });
     sort(dfb_entries.begin(), dfb_entries.end(), [](const auto& a, const auto& b) { return a.first < b.first; });
 
     // Get the semaphore bindings from the settings callback
     // Sort them to ensure the file output is deterministic, as explained above
     vector<pair<string, uint16_t>> sem_entries;
-    settings.process_semaphore_local_accessor_handles(
+    settings.process_semaphore_binding_handles(
         [&sem_entries](const string& name, uint16_t id) { sem_entries.emplace_back(name, id); });
     sort(sem_entries.begin(), sem_entries.end(), [](const auto& a, const auto& b) { return a.first < b.first; });
 
@@ -149,18 +149,20 @@ void write_kernel_bindings_generated_header(const string& out_dir, const JitBuil
         });
 
     // Emit the header content:
-    //  - DFB accessors are emitted into the dfb namespace
-    //  - Semaphore accessors are emitted into the sem namespace
+    //  - DFB binding tokens are emitted into the dfb namespace
+    //  - Semaphore ids are emitted into the sem namespace (semaphores have no binding-token type;
+    //    the kernel constructs a Semaphore straight from the bare id)
     //  - TensorBindings are emitted into the tensor namespace
+    //  - Scratchpad binding tokens are emitted into the scratch namespace
     //
-    // NOTE: DFB and Semaphore accessors are emitted as constexpr variables, i.e. as implicit CTAs.
+    // NOTE: DFB tokens and semaphore ids are emitted as constexpr variables, i.e. as implicit CTAs.
     //       This is a design decision; we could alternatively emit them as implicit CRTAs.
-    //       (Or, we could give the user the choice via the Metal 2.0 host API, on a per-kernel or per-accessor basis.)
+    //       (Or, we could give the user the choice via the Metal 2.0 host API, on a per-kernel or per-binding basis.)
     //       Implicit CTA is simpler and cheaper, but could theoretically cause unnecessary kernel cache hit misses.
     //       We are starting simple and can adjust later if problems arise.
     //       Legacy kernels passed semaphores both ways, kernel folks think this was more random than intentional.
     //
-    //       TensorBindings are the first accessor category to use implicit CRTAs (for the tensor base address).
+    //       TensorBindings are the first binding category to use implicit CRTAs (for the tensor base address).
     //       Each binding's tensor base address is specified per-enqueue, from the corresponding TensorArgument.
     //       The static layout tensor metadata (rank, shape, bank coords, etc.) comes in through positional CTAs,
     //       added automatically by the Metal 2.0 host API machinery.
@@ -182,8 +184,8 @@ void write_kernel_bindings_generated_header(const string& out_dir, const JitBuil
             content << "#include \"api/tensor/tensor_binding_token.h\"\n";
         }
         if (!scratch_entries.empty()) {
-            // The full Scratchpad accessor (NOC-free, so it compiles on both data-movement and
-            // compute/TRISC builds), which also pulls in the ScratchpadAccessor binding type.
+            // The full Scratchpad type (NOC-free, so it compiles on both data-movement and
+            // compute/TRISC builds), which also pulls in the ScratchpadBindingToken type.
             content << "#include \"api/scratchpad.h\"\n";
         }
         content << "\n";
@@ -191,7 +193,7 @@ void write_kernel_bindings_generated_header(const string& out_dir, const JitBuil
         if (!dfb_entries.empty()) {
             content << "namespace dfb {\n";
             for (const auto& [name, id] : dfb_entries) {
-                content << "constexpr DFBAccessor " << name << "{" << id << "};\n";
+                content << "constexpr DFBBindingToken " << name << "{" << id << "};\n";
             }
             content << "}  // namespace dfb\n";
         }
@@ -222,15 +224,15 @@ void write_kernel_bindings_generated_header(const string& out_dir, const JitBuil
         }
 
         if (!scratch_entries.empty()) {
-            // ScratchpadAccessor scratchpad_accessor_name{ADDR_CRTA_WORD, SIZE_BYTES}
+            // ScratchpadBindingToken scratchpad_accessor_name{ADDR_CRTA_WORD, SIZE_BYTES}
             // Carries the word index of the scratchpad's (framework-allocated) base-address CRTA
             // and the scratchpad's compile-time per-node size.
-            // The kernel-side Scratchpad(accessor) constructor unpacks both.
-            // The accessor's members are opaque, so the framework can extend it later without touching
+            // The kernel-side Scratchpad(token) constructor unpacks both.
+            // The token's members are opaque, so the framework can extend it later without touching
             // kernel source.
             content << "namespace scratch {\n";
             for (const auto& entry : scratch_entries) {
-                content << "constexpr ScratchpadAccessor " << entry.name << "{" << entry.addr_crta_word << "u, "
+                content << "constexpr ScratchpadBindingToken " << entry.name << "{" << entry.addr_crta_word << "u, "
                         << entry.size_bytes << "u};\n";
             }
             content << "}  // namespace scratch\n";

--- a/tt_metal/jit_build/jit_build_settings.hpp
+++ b/tt_metal/jit_build/jit_build_settings.hpp
@@ -93,12 +93,12 @@ public:
         std::function<void(const std::unordered_map<std::string, uint32_t>& named_args)>) const = 0;
 
     // Called to process the user kernel resource bindings (Metal 2.0 APIs)
-    //  - DFB accessors
-    //  - Semaphore accessors
-    //  - Tensor accessors
-    virtual void process_dataflow_buffer_local_accessor_handles(
+    //  - DFB bindings
+    //  - Semaphore bindings
+    //  - Tensor bindings
+    virtual void process_dataflow_buffer_binding_handles(
         std::function<void(const std::string& accessor_name, uint16_t logical_dfb_id)>) const {}
-    virtual void process_semaphore_local_accessor_handles(
+    virtual void process_semaphore_binding_handles(
         std::function<void(const std::string& accessor_name, uint16_t semaphore_id)>) const {}
 
     // TensorBinding callback emits the codegen-relevant fields only:
@@ -120,7 +120,7 @@ public:
 
     // Scratchpad binding callback emits the codegen-relevant fields:
     //  - accessor_name: kernel-side identifier, used as the symbol name in the `scratch::` namespace
-    //  - size_bytes: the scratchpad's per-node size, emitted as the accessor's compile-time size
+    //  - size_bytes: the scratchpad's per-node size, emitted as the binding token's compile-time size
     //  - addr_crta_word: word index, within the kernel's CRTA buffer, of the word holding the
     //    scratchpad's (framework-allocated) L1 base address
     virtual void process_scratchpad_binding_handles(

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_sfpu_no_bcast_dfb.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_binary_sfpu_no_bcast_dfb.cpp
@@ -8,7 +8,7 @@
 // CB->DFB swap. Handles the SFPU binary ops (int add/sub/mul, compares, bitwise/shift, div/remainder,
 // quant, gcd/lcm, xlogy, atan2, isclose, max/min, …) using the same define machinery the descriptor
 // factory builds: BINARY_SFPU_OP / BINARY_SFPU_INIT, HAS_ACTIVATIONS / PREPROCESS /
-// PROCESS_POST_ACTIVATIONS, ISCLOSE_* runtime args. Operand ids come from DFBAccessor's
+// PROCESS_POST_ACTIVATIONS, ISCLOSE_* runtime args. Operand ids come from DFBBindingToken's
 // `operator uint32_t()`. Layout-agnostic (reader/writer absorb sharded/interleaved/mixed).
 
 #include <cstdint>

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_utils_dfb.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_utils_dfb.hpp
@@ -7,7 +7,7 @@
 // DataflowBuffer (DFB) port of kernels/compute/eltwise_utils.hpp (FPU preprocess).
 //
 // Mechanically identical to the CircularBuffer helper, with the CB->DFB swap: the LLK operand id
-// comes from DFBAccessor's `operator uint32_t()` (a `dfb::<name>` token converts directly to the cb
+// comes from DFBBindingToken's `operator uint32_t()` (a `dfb::<name>` token converts directly to the cb
 // id every LLK call takes), and FIFO sync goes through a DataflowBuffer instance. See the CB original
 // for the rationale on the pre -> activation -> post reconfigure dance.
 

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_utils_sfpu_dfb.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/kernels_dfb/compute/eltwise_utils_sfpu_dfb.hpp
@@ -8,7 +8,7 @@
 //
 // Mechanically identical to the CircularBuffer helper, with the CB->DFB swap. SFPU variant: no
 // unpacker srca reconfigure here (the downstream binary SFPU op selects each operand before its
-// copy_tile loop). LLK operand ids come from DFBAccessor's `operator uint32_t()`.
+// copy_tile loop). LLK operand ids come from DFBBindingToken's `operator uint32_t()`.
 
 #include "api/compute/common.h"
 #include "api/compute/pack.h"

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/fold/device/kernels/compute/untilize.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/fold/device/kernels/compute/untilize.cpp
@@ -11,7 +11,7 @@ void kernel_main() {
     constexpr uint32_t per_core_block_cnt = get_arg(args::per_core_block_cnt);
     constexpr uint32_t per_core_block_tile_cnt = get_arg(args::per_core_block_tile_cnt);
     // src_cb_id / out_cb_id are DFB bindings (dfb::src0 / dfb::src1); they flow into the
-    // compute-kernel-lib helper via DFBAccessor's implicit (constexpr) uint32_t conversion.
+    // compute-kernel-lib helper via DFBBindingToken's implicit (constexpr) uint32_t conversion.
     compute_kernel_hw_startup(dfb::src0, dfb::src1);
     compute_kernel_lib::untilize<
         per_core_block_tile_cnt,


### PR DESCRIPTION
## PR Category
Cleanup

## Summary
This is a simple type renaming PR.

In Metal 2.0, all device-side resources have named bindings. These are declared on the host, then the kernel code retrieves the resource using the named binding, which is emitted in an autogenerated header. (e.g. `DataflowBuffer(dfb::my_dfb_binding_name)`).

These named binding tokens have a type. I had originally named the type `DFBAccessor`, but this collides with the (semantically very different) `TensorAccessor`. This becomes doubly confusing under the planned LLK API expansion.

This PR aligns the named binding types with the tensor's convention:
 - `DFBAccessor` --> `DFBBindingToken`
 - `ScratchpadAccessor` --> `ScratchpadBindingToken`

The rest of this diff is propagating the name change to use sites.

## Notes for reviewers
Normally, user kernels never directly reference the binding token type. The handful of kernels affected by this change refer to the binding token type only in comments.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=akertesz/rename-DFBAccessor)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:akertesz/rename-DFBAccessor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=akertesz/rename-DFBAccessor)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:akertesz/rename-DFBAccessor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=akertesz/rename-DFBAccessor)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:akertesz/rename-DFBAccessor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=akertesz/rename-DFBAccessor)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:akertesz/rename-DFBAccessor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=akertesz/rename-DFBAccessor)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:akertesz/rename-DFBAccessor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=akertesz/rename-DFBAccessor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:akertesz/rename-DFBAccessor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=akertesz/rename-DFBAccessor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:akertesz/rename-DFBAccessor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=akertesz/rename-DFBAccessor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:akertesz/rename-DFBAccessor)