### PR TITLE
Let the generic op accept per-core allocated tensors

### DIFF
--- a/ttnn/cpp/ttnn/operations/generic/device/generic_op_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/generic/device/generic_op_device_operation.hpp
@@ -17,6 +17,10 @@
 namespace ttnn::operations::generic {
 
 struct GenericOpDeviceOperation {
+    // This op never derives an address from a tensor: create_descriptor returns the caller's
+    // ProgramDescriptor verbatim, so resolving per-core addresses is the caller's job
+    static constexpr bool supports_per_core_allocation = true;
+
     using operation_attributes_t = generic::operation_attributes_t;
     using tensor_args_t = generic::tensor_args_t;
     using spec_return_value_t = generic::spec_return_value_t;


### PR DESCRIPTION
### Summary

Fixes `main` which was broken by #51430 (5601e076708).

The generic op never derives an address from a tensor — `create_descriptor` returns the caller's `ProgramDescriptor` verbatim — so per-core resolution belongs to the caller, and deepseek does it via `experimental_per_core_buffer_address()`. The opt-in is correct here, not a workaround.

### CI

| Job | Before | After |
|---|---|---|
| deepseek per-core (slow dispatch) | [❌ failed](https://github.com/tenstorrent/tt-metal/actions/runs/30488081020/job/90702363325) | [✅ passed](https://github.com/tenstorrent/tt-metal/actions/runs/30540778046/job/90867863926) |
| deepseek per-core (fast dispatch) | [❌ failed](https://github.com/tenstorrent/tt-metal/actions/runs/30488081020/job/90702363361) | [✅ passed](https://github.com/tenstorrent/tt-metal/actions/runs/30540778046/job/90867863988) |

Before: 4 tests fail with `GenericOpDeviceOperation: tensor 1 is per-core allocated, but this operation has not opted in`.
After ([run 30540778046](https://github.com/tenstorrent/tt-metal/actions/runs/30540778046)): all 4 pass — `42 passed, 33 skipped, 0 failed`.

<details>
<summary>One unrelated failure in that run — already failing on <code>main</code></summary>

[`ttnn reduce group [bh_p150b_civ2]`](https://github.com/tenstorrent/tt-metal/actions/runs/30540778046/job/90867824802): `test_reduce_on_batch[interleaved=False-dim=0-...]` fails with `Tensor shape rank (3) can't be less than shard shape rank (4)!` in `BufferDistributionSpec`.

Same test, same error on `main` in the last three runs of this workflow — e.g. [main @ c4aa939e1ee](https://github.com/tenstorrent/tt-metal/actions/runs/30529042105/job/90833742810). No per-core allocation involved; not touched by this change.
</details>