### PR TITLE
Add MiniMax-M3 Blaze chunked-prefill throughput regression

### DIFF
--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -393,8 +393,8 @@ models:
     bh_galaxy: 470
     # blaze_models_prefill_tests.yaml sum of bh_sc1 job timeouts (tightened from 840)
     bh_sc1: 437
-    # blaze_models_prefill_tests.yaml sum of bh_sc1_high_power timeouts (SDPA 23 + Kimi 40 + GLM 45 + MiniMax perf 60)
-    bh_sc1_high_power: 168
+    # blaze_models_prefill_tests.yaml sum of bh_sc1_high_power timeouts (SDPA 23 + Kimi 40 + GLM 45 + MiniMax perf 120)
+    bh_sc1_high_power: 228
     wh_n150: 500
     wh_n150_civ2: 300
     wh_n300: 600

--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -392,8 +392,8 @@ models:
     wh_galaxy_perf: 150
     bh_galaxy: 470
     # blaze_models_prefill_tests.yaml sum of bh_sc1 job timeouts (tightened from 840)
-    bh_sc1: 489
-    bh_sc1_high_power: 168
+    bh_sc1: 429
+    bh_sc1_high_power: 164
     wh_n150: 500
     wh_n150_civ2: 300
     wh_n300: 600

--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -393,8 +393,8 @@ models:
     bh_galaxy: 470
     # blaze_models_prefill_tests.yaml sum of bh_sc1 job timeouts (tightened from 840)
     bh_sc1: 437
-    # blaze_models_prefill_tests.yaml sum of bh_sc1_high_power timeouts (SDPA 23 + Kimi 40 + GLM 45 + MiniMax perf 120)
-    bh_sc1_high_power: 228
+    # blaze_models_prefill_tests.yaml sum of bh_sc1_high_power timeouts (SDPA 23 + Kimi 40 + GLM 45 + MiniMax perf 60)
+    bh_sc1_high_power: 168
     wh_n150: 500
     wh_n150_civ2: 300
     wh_n300: 600

--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -392,8 +392,8 @@ models:
     wh_galaxy_perf: 150
     bh_galaxy: 470
     # blaze_models_prefill_tests.yaml sum of bh_sc1 job timeouts (tightened from 840)
-    bh_sc1: 429
-    bh_sc1_high_power: 164
+    bh_sc1: 437
+    bh_sc1_high_power: 143
     wh_n150: 500
     wh_n150_civ2: 300
     wh_n300: 600

--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -392,7 +392,7 @@ models:
     wh_galaxy_perf: 150
     bh_galaxy: 470
     # blaze_models_prefill_tests.yaml sum of bh_sc1 job timeouts (tightened from 840)
-    bh_sc1: 437
+    bh_sc1: 489
     bh_sc1_high_power: 168
     wh_n150: 500
     wh_n150_civ2: 300

--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -393,7 +393,6 @@ models:
     bh_galaxy: 470
     # blaze_models_prefill_tests.yaml sum of bh_sc1 job timeouts (tightened from 840)
     bh_sc1: 437
-    # blaze_models_prefill_tests.yaml sum of bh_sc1_high_power timeouts (SDPA 23 + Kimi 40 + GLM 45 + MiniMax perf 60)
     bh_sc1_high_power: 168
     wh_n150: 500
     wh_n150_civ2: 300

--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -393,7 +393,8 @@ models:
     bh_galaxy: 470
     # blaze_models_prefill_tests.yaml sum of bh_sc1 job timeouts (tightened from 840)
     bh_sc1: 437
-    bh_sc1_high_power: 108
+    # blaze_models_prefill_tests.yaml sum of bh_sc1_high_power timeouts (SDPA 23 + Kimi 40 + GLM 45 + MiniMax perf 60)
+    bh_sc1_high_power: 168
     wh_n150: 500
     wh_n150_civ2: 300
     wh_n300: 600

--- a/.github/workflows/blaze-models-prefill-tests.yaml
+++ b/.github/workflows/blaze-models-prefill-tests.yaml
@@ -12,7 +12,8 @@ on:
           Empty or "all" runs every stage. Valid stages: moe_gate, mla, mla_chunked,
           kv_cache_table, prefill_block, kimi_mla, kimi_moe,
           kimi_prefill_block, kimi_chunked, kimi_chunked_padded, kimi_dflash, glm_chunked, dsa_mla, dsa_mla_glm, glm_moe, glm_prefill_block, glm_chunked_accuracy, prefill_block_determinism,
-          prefill_transformer_determinism, prefill_runner, minimax_prefill_kv_pcc.
+          prefill_transformer_determinism, prefill_runner, minimax_prefill_kv_pcc,
+          minimax_prefill_perf.
           The "module" group also runs every stage; the "sdpa_perf" group runs the
           ring joint SDPA perf checks.
         required: false

--- a/models/demos/minimax_m3/tests/galaxy_prefill_kv_pcc.py
+++ b/models/demos/minimax_m3/tests/galaxy_prefill_kv_pcc.py
@@ -244,10 +244,8 @@ def main():
             f"[prefill-pcc] expert_dtype={expert_dtype} (EXPERT_DTYPE={os.getenv('EXPERT_DTYPE', 'bf4')})", flush=True
         )
         force_load = os.getenv("M3_FORCE_LOAD_WEIGHTS") == "1"
-        cache_only = not force_load and (
-            os.getenv("M3_WEIGHTS_FROM_CACHE") == "1"
-            or weight_cache_is_complete(cache_path, hf_config, num_layers, expert_dtype)
-        )
+        cache_complete = weight_cache_is_complete(cache_path, hf_config, num_layers, expert_dtype)
+        cache_only = not force_load and (os.getenv("M3_WEIGHTS_FROM_CACHE") == "1" or cache_complete)
         if cache_only:
             print(
                 "[prefill-pcc] tilized weight cache complete -> loading from cache, "
@@ -256,6 +254,18 @@ def main():
             )
             state_dict = {}
         else:
+            bang = "!" * 80
+            print(
+                f"\n{bang}\n"
+                f"[prefill-pcc] WARNING: warm tilized weight cache NOT available at\n"
+                f"  {cache_path}\n"
+                f"  (complete={cache_complete}, M3_FORCE_LOAD_WEIGHTS={force_load}).\n"
+                f"  Falling back to the ~869GB bf16 source read + cache build — expect multi-hour\n"
+                f"  wall time; CI timeouts (even 2h) will usually fire. Prefill tensor_cache_bfp8_*\n"
+                f"  under HF_MODEL / TT_CACHE_PATH on this host before relying on this job.\n"
+                f"{bang}\n",
+                flush=True,
+            )
             print("[prefill-pcc] loading real bf16 weights + EP placement (slow: bf16 source read) ...", flush=True)
             state_dict = ModelArgs.load_state_dict(model_args.weights_path)
         cfg = TtPrefillRuntimeConfig(

--- a/models/demos/minimax_m3/tests/galaxy_prefill_kv_pcc.py
+++ b/models/demos/minimax_m3/tests/galaxy_prefill_kv_pcc.py
@@ -17,6 +17,8 @@ Env:
   PREFILL_EXPECTED_TPS  whole-sequence tok/s baseline; when set, assert measured median is
                         within +/- PREFILL_PERF_MARGIN of this value                           [default: unset]
   PREFILL_PERF_MARGIN fraction tolerance around PREFILL_EXPECTED_TPS (e.g. 0.05 = +/-5%)     [default 0.05]
+  PREFILL_REQUIRE_HIGH_POWER  "1" -> require is_high_power() (>=130W TDP via tt-smi); skip
+                        otherwise. Used by the Blaze perf job; leave unset for accuracy/KV PCC   [default 0]
   PREFILL_STANDALONE_CHUNKED_PCC  min K/V/index_k PCC gate (fail below this)                 [default 0.88]
   PREFILL_NUM_LAYERS  build/run only the first N decoder layers (faster partial-model runs; also auto-sets
                       M3_LOAD_NLAYERS so only those layers' weight shards are read)          [default: all]
@@ -150,6 +152,20 @@ def main():
     from models.demos.minimax_m3.tt.weight_cache import weight_cache_is_complete
 
     _raise_nproc_limit()  # tt-metal parallel kernel JIT needs a high process limit (see fn docstring)
+
+    # Perf CI only: same guard as Kimi/GLM no_pcc / ring-joint SDPA (pytest skipif is_high_power).
+    # Accuracy/KV-PCC leaves PREFILL_REQUIRE_HIGH_POWER unset so bh_sc1 hosts are fine.
+    if os.getenv("PREFILL_REQUIRE_HIGH_POWER", "0") == "1":
+        from models.demos.deepseek_v3_d_p.utils.smbus_telemetry import get_tdp_limit_max, is_high_power
+
+        if not is_high_power():
+            tdp = get_tdp_limit_max()
+            print(
+                f"[prefill-pcc] SKIP: PREFILL_REQUIRE_HIGH_POWER=1 but host is not high-power "
+                f"(TDP_LIMIT_MAX={tdp}; need >=130W). Guards exabox.tenstorrent.com/power=14kw.",
+                flush=True,
+            )
+            return 0
 
     golden_dir = os.environ.get("PREFILL_TRACE_DIR")
     if not golden_dir:

--- a/models/demos/minimax_m3/tests/galaxy_prefill_kv_pcc.py
+++ b/models/demos/minimax_m3/tests/galaxy_prefill_kv_pcc.py
@@ -14,6 +14,9 @@ Env:
   PREFILL_CHUNK_SIZE  chunk size in tokens (chunked mode)                                  [default 5120]
   PREFILL_TPS_ITERS   prefill repetitions for the throughput measurement (less noise)      [default 1]
   PREFILL_SKIP_PCC    "1" -> perf only: skip the per-layer golden KV PCC (no kv_cache/ needed) [default 0]
+  PREFILL_EXPECTED_TPS  whole-sequence tok/s baseline; when set, assert measured median is
+                        within +/- PREFILL_PERF_MARGIN of this value                           [default: unset]
+  PREFILL_PERF_MARGIN fraction tolerance around PREFILL_EXPECTED_TPS (e.g. 0.05 = +/-5%)     [default 0.05]
   PREFILL_STANDALONE_CHUNKED_PCC  min K/V/index_k PCC gate (fail below this)                 [default 0.88]
   PREFILL_NUM_LAYERS  build/run only the first N decoder layers (faster partial-model runs; also auto-sets
                       M3_LOAD_NLAYERS so only those layers' weight shards are read)          [default: all]
@@ -302,9 +305,10 @@ def main():
             )
 
         w = statistics.median(whole_times)
+        whole_tps = n_tokens / w
         print(
             f"[prefill-pcc] WHOLE SEQUENCE over {tps_iters} iters: {n_tokens} tok @ 0 cache, "
-            f"median {n_tokens / w:.1f} tok/s (real prompt), {total / w:.1f} tok/s (processed); "
+            f"median {whole_tps:.1f} tok/s (real prompt), {total / w:.1f} tok/s (processed); "
             f"wall median {w * 1000:.1f} ms [min {min(whole_times) * 1000:.1f}, max {max(whole_times) * 1000:.1f}]",
             flush=True,
         )
@@ -315,6 +319,23 @@ def main():
             f"wall median {lc * 1000:.1f} ms [min {min(last_times) * 1000:.1f}, max {max(last_times) * 1000:.1f}]",
             flush=True,
         )
+
+        # --- perf gate: whole-sequence tok/s vs PREFILL_EXPECTED_TPS +/- PREFILL_PERF_MARGIN ---
+        expected_tps_env = os.environ.get("PREFILL_EXPECTED_TPS")
+        if expected_tps_env is not None:
+            expected_tps = float(expected_tps_env)
+            margin = float(os.environ.get("PREFILL_PERF_MARGIN", "0.05"))
+            low = expected_tps * (1.0 - margin)
+            high = expected_tps * (1.0 + margin)
+            print(
+                f"[prefill-pcc] PERF GATE: measured {whole_tps:.1f} tok/s vs baseline "
+                f"{expected_tps:.1f} +/- {margin * 100:.1f}% band [{low:.1f}, {high:.1f}]",
+                flush=True,
+            )
+            assert low <= whole_tps <= high, (
+                f"whole-sequence throughput {whole_tps:.1f} tok/s outside baseline "
+                f"{expected_tps:.1f} tok/s +/- {margin * 100:.1f}% band [{low:.1f}, {high:.1f}]"
+            )
 
         # --- accuracy: per-layer KV PCC vs golden (skipped in perf-only mode; synthetic
         # traces carry only metadata.json, so there is no golden KV cache to compare against) ---

--- a/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
+++ b/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
@@ -575,6 +575,7 @@
     export PREFILL_CHUNK_SIZE=5120
     export PREFILL_TPS_ITERS=5
     export PREFILL_SKIP_PCC=1
+    export PREFILL_REQUIRE_HIGH_POWER=1
     export PREFILL_EXPECTED_TPS=3600
     export PREFILL_PERF_MARGIN=0.05
     mpirun --pernode --tag-output bash -lc '

--- a/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
+++ b/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
@@ -584,7 +584,7 @@
   test_type: minimax_prefill_perf
   test_group: module
   skus:
-    bh_sc1:
+    bh_sc1_high_power:
       # Warm tilized-cache + chunked prefill (5120) x5 timed iters, no PCC; cold cache build will exceed this.
       timeout: 60
   owner_id: U08ECJQ848G # Viacheslav Melnykov

--- a/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
+++ b/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
@@ -586,7 +586,7 @@
   skus:
     bh_sc1_high_power:
       # Warm tilized-cache + chunked prefill (5120) x5 timed iters, no PCC; cold cache build will exceed this.
-      timeout: 60
+      timeout: 35
   owner_id: U08ECJQ848G # Viacheslav Melnykov
   team: models
   sp_config: sc1

--- a/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
+++ b/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
@@ -559,3 +559,33 @@
   owner_id: U08ECJQ848G # Viacheslav Melnykov
   team: models
   sp_config: sc1
+
+# MiniMax-M3 full-model chunked-prefill throughput regression (same harness as KV PCC, PCC skipped).
+# Gates whole-sequence tok/s against PREFILL_EXPECTED_TPS +/- PREFILL_PERF_MARGIN on high-power Galaxy.
+- name: "Blaze - MiniMax-M3 Prefill Perf"
+  cmd: |
+    export LOGURU_LEVEL=INFO
+    export TT_METAL_HOME=${TT_METAL_HOME:-$PWD}
+    export PYTHONPATH=${TT_METAL_HOME}${PYTHONPATH:+:$PYTHONPATH}
+    export HF_MODEL=/mnt/models/MiniMaxAI/MiniMax-M3-ref/
+    export PREFILL_TRACE_DIR=/mnt/models/MiniMaxAI/MiniMax-M3-ref/golden/longbook_56320
+    export TT_MESH_GRAPH_DESC_PATH=$TT_METAL_HOME/tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_mesh_graph_descriptor.textproto
+    export EXPERT_DTYPE=bf4
+    export PREFILL_CHUNKED=1
+    export PREFILL_CHUNK_SIZE=5120
+    export PREFILL_TPS_ITERS=5
+    export PREFILL_SKIP_PCC=1
+    export PREFILL_EXPECTED_TPS=3600
+    export PREFILL_PERF_MARGIN=0.05
+    mpirun --pernode --tag-output bash -lc '
+      python3 models/demos/minimax_m3/tests/galaxy_prefill_kv_pcc.py
+    '
+  test_type: minimax_prefill_perf
+  test_group: module
+  skus:
+    bh_sc1_high_power:
+      # Warm tilized-cache + chunked prefill (5120) x5 timed iters, no PCC; cold cache build will exceed this.
+      timeout: 60
+  owner_id: U08ECJQ848G # Viacheslav Melnykov
+  team: models
+  sp_config: sc1

--- a/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
+++ b/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
@@ -584,7 +584,7 @@
   test_type: minimax_prefill_perf
   test_group: module
   skus:
-    bh_sc1_high_power:
+    bh_sc1:
       # Warm tilized-cache + chunked prefill (5120) x5 timed iters, no PCC; cold cache build will exceed this.
       timeout: 60
   owner_id: U08ECJQ848G # Viacheslav Melnykov

--- a/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
+++ b/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
@@ -585,8 +585,8 @@
   test_group: module
   skus:
     bh_sc1_high_power:
-      # Warm tilized-cache + chunked prefill (5120) x5 timed iters, no PCC; cold cache build can take hours.
-      timeout: 120
+      # Warm tilized-cache + chunked prefill (5120) x5 timed iters, no PCC; cold cache build will exceed this.
+      timeout: 60
   owner_id: U08ECJQ848G # Viacheslav Melnykov
   team: models
   sp_config: sc1

--- a/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
+++ b/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
@@ -585,8 +585,8 @@
   test_group: module
   skus:
     bh_sc1_high_power:
-      # Warm tilized-cache + chunked prefill (5120) x5 timed iters, no PCC; cold cache build will exceed this.
-      timeout: 60
+      # Warm tilized-cache + chunked prefill (5120) x5 timed iters, no PCC; cold cache build can take hours.
+      timeout: 120
   owner_id: U08ECJQ848G # Viacheslav Melnykov
   team: models
   sp_config: sc1


### PR DESCRIPTION
Adds MiniMax-M3 Blaze chunked-prefill throughput regression on BH SC1 high-power: same standalone galaxy_prefill_kv_pcc harness as the KV-PCC job, against longbook_56320 (chunk size 5120), with PCC skipped and a whole-sequence tok/s gate (baseline 3600, ±5% over 5 timed iters).

Extends galaxy_prefill_kv_pcc.py with optional PREFILL_EXPECTED_TPS / PREFILL_PERF_MARGIN env asserts (accuracy job unchanged when unset).

Wires minimax_prefill_perf into Blaze prefill stages / workflow_dispatch.

Raises time_budget.yaml Blaze bh_sc1_high_power 108→143 for the new job timeout.

Test plan
- [ ] [![blaze-models-prefill-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blaze-models-prefill-tests.yaml/badge.svg?branch=lgalasTT/minmax3_perf_ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/blaze-models-prefill-tests.yaml?query=branch:lgalasTT/minmax3_perf_ci)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=lgalasTT/minmax3_perf_ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:lgalasTT/minmax3_perf_ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=lgalasTT/minmax3_perf_ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:lgalasTT/minmax3_perf_ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=lgalasTT/minmax3_perf_ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:lgalasTT/minmax3_perf_ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=lgalasTT/minmax3_perf_ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:lgalasTT/minmax3_perf_ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=lgalasTT/minmax3_perf_ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:lgalasTT/minmax3_perf_ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=lgalasTT/minmax3_perf_ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:lgalasTT/minmax3_perf_ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=lgalasTT/minmax3_perf_ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:lgalasTT/minmax3_perf_ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=lgalasTT/minmax3_perf_ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:lgalasTT/minmax3_perf_ci)