### PR TITLE
[ttnn] pre-commit: forbid ProgramDescriptor rebuilds inside override_runtime_arguments

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -104,6 +104,13 @@ repos:
       types: [file]
       files: ^ttnn/.*/device/.*\.(cpp|hpp)$
       pass_filenames: true
+    - id: detect-override-rebuild
+      name: Detect ProgramDescriptor rebuilds inside override_runtime_arguments
+      entry: python3 scripts/detect_override_rebuild.py
+      language: system
+      types: [file]
+      files: ^ttnn/.*/device/.*\.(cpp|hpp)$
+      pass_filenames: true
 - repo: local
   hooks:
     - id: validate-golden-csv-columns

--- a/scripts/detect_override_rebuild.py
+++ b/scripts/detect_override_rebuild.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Pre-commit guard: forbid rebuilding a ProgramDescriptor from a cache-hit hook.
+
+``override_runtime_arguments()`` runs on EVERY program-cache hit. Calling ``create_descriptor()``
+there — usually paired with ``apply_descriptor_runtime_args()``, and usually justified as "re-derive
+from the single source of truth so the re-applied args can't drift" — pays the entire cache-MISS host
+cost on every hit: the work split, ``CoreRangeSet`` construction, arch queries via
+``get_compute_kernel_config_args``, ``TensorAccessorArgs`` building, kernel-source strings,
+compile-time arg vectors, and a freshly heap-allocated runtime-arg vector for every core, followed by
+a walk over every kernel x core x arg plus every CB. It is strictly slower than the
+``get_dynamic_runtime_args`` the hook replaced, and it is the slow-path-rebuild-on-hit anti-pattern
+behind the ResNet50 regressions (#46506, #50347).
+
+The drift concern is real but has a cheaper answer: express each kernel's arg order ONCE in an
+emitter templated on its sink, and instantiate it with ``KernelDescriptor::RTArgList`` on the miss
+path and ``ttnn::RuntimeArgPatcher`` (``ttnn/api/ttnn/descriptor_arg_patcher.hpp``) on the hit path.
+No arg index is written by hand, nothing is allocated on a hit, and the result is byte-identical to a
+rebuild by construction.
+
+This is a BUILD-TIME text check (no runtime cost). It scans the body of every
+``override_runtime_arguments`` definition and rejects a descriptor rebuild inside it. Ops that
+legitimately delegate to the framework's cheap binding path (``descriptor_adapter_t::apply_descriptor``)
+are unaffected. A genuinely unavoidable case suppresses a line with a trailing
+``// override-rebuild-ok: <reason>``.
+"""
+
+import os
+import re
+import sys
+
+BASELINE_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "detect_override_rebuild_baseline.txt")
+
+
+def _baseline():
+    """Repo-relative paths that still contain the anti-pattern.
+
+    Pre-existing violations are listed so this hook blocks NEW ones without obstructing unrelated
+    edits to those files. Fixing an op means deleting its line from the baseline.
+    """
+    try:
+        with open(BASELINE_PATH) as f:
+            return {line.strip() for line in f if line.strip() and not line.lstrip().startswith("#")}
+    except OSError:
+        return set()
+
+
+HOOK = re.compile(r"\boverride_runtime_arguments\s*\(")
+# A descriptor rebuild, or the framework's bulk copy-everything applier (which only makes sense when
+# handed a freshly built descriptor, so it is the same defect wearing a different hat).
+REBUILD = re.compile(r"\b(?:[A-Za-z_]\w*::)?create_(?:\w+_)?descriptor\s*\(|\bapply_descriptor_runtime_args\s*\(")
+SUPPRESS = re.compile(r"//\s*override-rebuild-ok\b")
+
+
+def _mask_comments(text):
+    """Blank out comment and string-literal contents, preserving length and newlines, so a rebuild
+    merely *described* in a comment is not flagged."""
+    out = list(text)
+    i, n = 0, len(text)
+    while i < n:
+        two = text[i : i + 2]
+        if two == "//":
+            j = text.find("\n", i)
+            j = n if j < 0 else j
+            for k in range(i, j):
+                out[k] = " "
+            i = j
+        elif two == "/*":
+            j = text.find("*/", i + 2)
+            j = n if j < 0 else j + 2
+            for k in range(i, j):
+                if out[k] != "\n":
+                    out[k] = " "
+            i = j
+        elif text[i] == '"':
+            j = i + 1
+            while j < n and text[j] != '"':
+                j += 2 if text[j] == "\\" else 1
+            for k in range(i, min(j + 1, n)):
+                if out[k] != "\n":
+                    out[k] = " "
+            i = j + 1
+        else:
+            i += 1
+    return "".join(out)
+
+
+def _body_span(text, open_paren_idx):
+    """Return (start, end) of the brace-delimited body following a declaration, or None if it is a
+    declaration only (ends in ``;``)."""
+    depth = 0
+    i = open_paren_idx
+    while i < len(text):
+        if text[i] == "(":
+            depth += 1
+        elif text[i] == ")":
+            depth -= 1
+            if depth == 0:
+                break
+        i += 1
+    # Skip trailing qualifiers/whitespace to the first '{' or ';'.
+    j = i + 1
+    while j < len(text) and text[j] not in "{;":
+        j += 1
+    if j >= len(text) or text[j] == ";":
+        return None  # declaration, no body
+    start = j
+    depth = 0
+    while j < len(text):
+        if text[j] == "{":
+            depth += 1
+        elif text[j] == "}":
+            depth -= 1
+            if depth == 0:
+                return (start, j)
+        j += 1
+    return (start, len(text))
+
+
+def check(path):
+    try:
+        with open(path, errors="ignore") as f:
+            text = f.read()
+    except OSError:
+        return []
+    if "override_runtime_arguments" not in text:
+        return []
+    # Match against a comment-free view; report against the original.
+    scan = _mask_comments(text)
+
+    line_starts = [0]
+    for m in re.finditer(r"\n", text):
+        line_starts.append(m.end())
+
+    def line_of(pos):
+        lo, hi = 0, len(line_starts) - 1
+        while lo < hi:
+            mid = (lo + hi + 1) // 2
+            if line_starts[mid] <= pos:
+                lo = mid
+            else:
+                hi = mid - 1
+        return lo + 1
+
+    findings = []
+    for hook in HOOK.finditer(scan):
+        span = _body_span(scan, scan.index("(", hook.end() - 1))
+        if span is None:
+            continue
+        body = scan[span[0] : span[1]]
+        for bad in REBUILD.finditer(body):
+            pos = span[0] + bad.start()
+            lineno = line_of(pos)
+            line = text[line_starts[lineno - 1] : (line_starts[lineno] if lineno < len(line_starts) else len(text))]
+            if SUPPRESS.search(line):
+                continue
+            findings.append((lineno, bad.group(0).rstrip("("), line.strip()))
+    return findings
+
+
+def main(argv):
+    failed = False
+    baseline = _baseline()
+    for path in argv[1:]:
+        if os.path.normpath(path) in baseline:
+            continue
+        for lineno, what, line in check(path):
+            failed = True
+            print(f"{path}:{lineno}: error: '{what}' called inside override_runtime_arguments")
+            print(f"    {line}")
+    if failed:
+        print()
+        print("override_runtime_arguments runs on EVERY program-cache hit; rebuilding the descriptor there pays the")
+        print("full cache-MISS host cost per dispatch. Express each kernel's arg order once in an emitter templated")
+        print("on its sink: KernelDescriptor::RTArgList on the miss path, ttnn::RuntimeArgPatcher on the hit path")
+        print("(ttnn/api/ttnn/descriptor_arg_patcher.hpp). No hand-written arg indices, no allocation on a hit.")
+        print("Re-point globally-allocated CB addresses with UpdateDynamicCircularBufferAddress, matched by CBIndex.")
+        print("Verify with -DENABLE_DESCRIPTOR_PATCHING_PARITY_CHECK=ON.")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/detect_override_rebuild.py
+++ b/scripts/detect_override_rebuild.py
@@ -15,11 +15,12 @@ a walk over every kernel x core x arg plus every CB. It is strictly slower than 
 ``get_dynamic_runtime_args`` the hook replaced, and it is the slow-path-rebuild-on-hit anti-pattern
 behind the ResNet50 regressions (#46506, #50347).
 
-The drift concern is real but has a cheaper answer: express each kernel's arg order ONCE in an
-emitter templated on its sink, and instantiate it with ``KernelDescriptor::RTArgList`` on the miss
-path and ``ttnn::RuntimeArgPatcher`` (``ttnn/api/ttnn/descriptor_arg_patcher.hpp``) on the hit path.
-No arg index is written by hand, nothing is allocated on a hit, and the result is byte-identical to a
-rebuild by construction.
+The drift concern is real but has a cheaper answer, used by the merged reference fixes
+(#50351 sparse_sdpa, #50894 slice): on a cache hit, patch only the slots that actually vary. Overwrite
+scalar/address runtime args in place with ``tt::tt_metal::GetRuntimeArgs(program, kernel_idx, core)``,
+and re-point CB-backed addresses through a MINIMAL (CB-only) ``ProgramDescriptor`` +
+``apply_descriptor_runtime_args`` (mark that one line ``// override-rebuild-ok: cb-addr-only`` — it is
+O(1), not a rebuild). Nothing is re-split, no per-core arg vector is reallocated, and the hit stays O(1).
 
 This is a BUILD-TIME text check (no runtime cost). It scans the body of every
 ``override_runtime_arguments`` definition and rejects a descriptor rebuild inside it. Ops that
@@ -32,20 +33,48 @@ import os
 import re
 import sys
 
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 BASELINE_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "detect_override_rebuild_baseline.txt")
 
 
-def _baseline():
-    """Repo-relative paths that still contain the anti-pattern.
+def _safe_path(path):
+    """Resolve a caller-supplied path under the repo root and reject anything that escapes it.
 
-    Pre-existing violations are listed so this hook blocks NEW ones without obstructing unrelated
-    edits to those files. Fixing an op means deleting its line from the baseline.
+    pre-commit passes repo-relative paths from a trusted, git-tracked file list, but the path is still
+    dynamic input, so normalize it and bound the result to the tree before opening. Returns the resolved
+    absolute path, or ``None`` if it points outside the repo (which the caller then skips)."""
+    joined = path if os.path.isabs(path) else os.path.join(REPO_ROOT, path)
+    resolved = os.path.realpath(joined)
+    if resolved != REPO_ROOT and not resolved.startswith(REPO_ROOT + os.sep):
+        return None
+    return resolved
+
+
+def _baseline():
+    """Pre-existing violations, keyed per offender so the guard is never disabled for a whole file.
+
+    Each entry grandfathers ONE known hit as a ``<repo-relative-path>\\t<symbol>\\t<source-line>``
+    fingerprint (line-number independent, so unrelated edits above it don't churn the baseline). A
+    baselined file is still fully scanned: any NEW or additional violation whose fingerprint is not
+    listed is blocked. Fixing an op means deleting its line(s) here (or ``--update-baseline``).
+
+    Returns ``{normpath: {(symbol, source_line), ...}}``.
     """
+    result = {}
     try:
         with open(BASELINE_PATH) as f:
-            return {line.strip() for line in f if line.strip() and not line.lstrip().startswith("#")}
+            for raw in f:
+                stripped = raw.strip()
+                if not stripped or stripped.startswith("#"):
+                    continue
+                parts = raw.rstrip("\n").split("\t")
+                if len(parts) != 3:
+                    continue
+                path, what, src = parts
+                result.setdefault(os.path.normpath(path), set()).add((what, src))
     except OSError:
-        return set()
+        pass
+    return result
 
 
 HOOK = re.compile(r"\boverride_runtime_arguments\s*\(")
@@ -56,8 +85,9 @@ SUPPRESS = re.compile(r"//\s*override-rebuild-ok\b")
 
 
 def _mask_comments(text):
-    """Blank out comment and string-literal contents, preserving length and newlines, so a rebuild
-    merely *described* in a comment is not flagged."""
+    """Blank out comment, string-literal and char-literal contents, preserving length and newlines, so
+    a rebuild merely *described* in a comment — or a brace/quote inside a literal such as ``'}'`` or
+    ``'"'`` — cannot corrupt brace/parse tracking or be flagged."""
     out = list(text)
     i, n = 0, len(text)
     while i < n:
@@ -75,9 +105,15 @@ def _mask_comments(text):
                 if out[k] != "\n":
                     out[k] = " "
             i = j
-        elif text[i] == '"':
+        elif text[i] == '"' or (
+            # A char literal opener, e.g. ' } ' or '\''. Guard against the C++14 digit separator
+            # (1'000, 0xFF'FF): a separator quote directly follows an alphanumeric, a literal never does.
+            text[i] == "'"
+            and (i == 0 or not (text[i - 1].isalnum() or text[i - 1] == "_"))
+        ):
+            quote = text[i]
             j = i + 1
-            while j < n and text[j] != '"':
+            while j < n and text[j] != quote:
                 j += 2 if text[j] == "\\" else 1
             for k in range(i, min(j + 1, n)):
                 if out[k] != "\n":
@@ -121,8 +157,11 @@ def _body_span(text, open_paren_idx):
 
 
 def check(path):
+    safe = _safe_path(path)
+    if safe is None:
+        return []
     try:
-        with open(path, errors="ignore") as f:
+        with open(safe, errors="ignore") as f:
             text = f.read()
     except OSError:
         return []
@@ -161,24 +200,139 @@ def check(path):
     return findings
 
 
+def _selftest():
+    """Fast, self-contained checks of the detector's own behavior (run: --selftest)."""
+    import tempfile
+
+    ok = True
+
+    def expect(cond, msg):
+        nonlocal ok
+        if not cond:
+            ok = False
+            print(f"SELFTEST FAIL: {msg}")
+
+    # --- masker: char literals must not corrupt brace tracking, digit separators must survive ---
+    masked = _mask_comments("void override_runtime_arguments() { char c = '}'; create_descriptor(x); }")
+    expect("create_descriptor" in masked, "char literal '}' truncated the body before create_descriptor")
+    expect("1'000'000" in _mask_comments("int n = 1'000'000; create_descriptor(y);"), "digit separator mis-masked")
+    expect(
+        "create_descriptor" in _mask_comments('const char* s = "}"; create_descriptor(z);'),
+        "string literal masking regressed",
+    )
+
+    # --- path guard: traversal is rejected, an in-repo path resolves ---
+    expect(_safe_path("../../../../etc/passwd") is None, "path traversal not rejected")
+    expect(_safe_path("scripts/detect_override_rebuild.py") is not None, "in-repo path wrongly rejected")
+
+    # A body that rebuilds, plus a legitimately-suppressed line and a bare comment mention.
+    good = (
+        "void Op::override_runtime_arguments(Program& p) {\n"
+        "    // create_descriptor(a) mentioned in a comment must NOT flag\n"
+        "    auto& r = GetRuntimeArgs(p, 0, core);\n"
+        "    create_descriptor(b);\n"
+        "    apply_descriptor_runtime_args(p, cb);  // override-rebuild-ok: cb-addr-only\n"
+        "}\n"
+    )
+    with tempfile.NamedTemporaryFile("w", dir=REPO_ROOT, suffix=".cpp", delete=False) as tf:
+        tf.write(good)
+        tmp = tf.name
+    try:
+        findings = check(tmp)
+        symbols = sorted(w for _l, w, _line in findings)
+        expect(symbols == ["create_descriptor"], f"expected only create_descriptor flagged, got {symbols}")
+
+        # (c) grandfathering the known offender must NOT hide a NEW, differently-worded violation.
+        rel = os.path.relpath(tmp, REPO_ROOT)
+        base = {os.path.normpath(rel): {("create_descriptor", "create_descriptor(b);")}}
+        new_hits = [(w, line) for _l, w, line in check(tmp) if (w, line) not in base[os.path.normpath(rel)]]
+        expect(new_hits == [], "baseline fingerprint failed to grandfather the exact known offender")
+
+        with open(tmp, "a") as f:
+            f.write("void Op2::override_runtime_arguments(Program& p) { create_descriptor(NEW); }\n")
+        new_hits = [(w, line) for _l, w, line in check(tmp) if (w, line) not in base[os.path.normpath(rel)]]
+        expect(any("NEW" in line for _w, line in new_hits), "baselined file did not catch a NEW violation")
+    finally:
+        os.unlink(tmp)
+
+    if ok:
+        print("SELFTEST OK")
+    return 0 if ok else 1
+
+
+BASELINE_HEADER = """\
+# Baseline for scripts/detect_override_rebuild.py
+#
+# Pre-existing rebuilds of a ProgramDescriptor inside override_runtime_arguments, grandfathered one
+# offender at a time. Every listed file is still FULLY scanned: any new or additional violation not
+# already fingerprinted below is blocked, so a baselined file keeps its guard.
+#
+# Each entry is a live per-dispatch cost: override_runtime_arguments runs on EVERY program-cache hit,
+# so calling create_descriptor() there pays the full cache-MISS host cost (work split, CoreRangeSet
+# construction, arch queries, TensorAccessorArgs, kernel-source strings, compile-time arg vectors, a
+# heap-allocated arg vector per core) on every dispatch. Fixing an op means deleting its line(s) here.
+#
+# For reference, the equivalent fix measured on the ops migrated in #49889 / #50338:
+#   rotary_embedding cache hit  35.1 -> 27.2 us
+#   uniform          cache hit  23.2 -> 13.8 us
+#
+# Format: one tab-separated <repo-relative-path>\\t<symbol>\\t<source-line> per offender. Regenerate
+# with:  python3 scripts/detect_override_rebuild.py --update-baseline <files...>
+# Comments (#) and blank lines are ignored.
+"""
+
+
+def _write_baseline(baseline):
+    entries = []
+    for path in sorted(baseline):
+        for what, src in sorted(baseline[path]):
+            entries.append(f"{path}\t{what}\t{src}\n")
+    with open(BASELINE_PATH, "w") as f:
+        f.write(BASELINE_HEADER)
+        if entries:
+            f.write("\n")
+            f.writelines(entries)
+
+
+def _update_baseline(paths):
+    """Refresh baseline fingerprints for the given files, preserving entries for all others."""
+    baseline = _baseline()
+    for path in paths:
+        np = os.path.normpath(path)
+        found = {(what, line) for _lineno, what, line in check(path)}
+        if found:
+            baseline[np] = found
+        else:
+            baseline.pop(np, None)
+    _write_baseline(baseline)
+    return 0
+
+
 def main(argv):
+    if argv[1:2] == ["--update-baseline"]:
+        return _update_baseline(argv[2:])
+    if argv[1:2] == ["--selftest"]:
+        return _selftest()
     failed = False
     baseline = _baseline()
     for path in argv[1:]:
-        if os.path.normpath(path) in baseline:
-            continue
+        known = baseline.get(os.path.normpath(path), set())
         for lineno, what, line in check(path):
+            if (what, line) in known:
+                continue  # grandfathered pre-existing offender; new hits in this file still fail
             failed = True
             print(f"{path}:{lineno}: error: '{what}' called inside override_runtime_arguments")
             print(f"    {line}")
     if failed:
         print()
         print("override_runtime_arguments runs on EVERY program-cache hit; rebuilding the descriptor there pays the")
-        print("full cache-MISS host cost per dispatch. Express each kernel's arg order once in an emitter templated")
-        print("on its sink: KernelDescriptor::RTArgList on the miss path, ttnn::RuntimeArgPatcher on the hit path")
-        print("(ttnn/api/ttnn/descriptor_arg_patcher.hpp). No hand-written arg indices, no allocation on a hit.")
-        print("Re-point globally-allocated CB addresses with UpdateDynamicCircularBufferAddress, matched by CBIndex.")
-        print("Verify with -DENABLE_DESCRIPTOR_PATCHING_PARITY_CHECK=ON.")
+        print("full cache-MISS host cost per dispatch. Patch only what varies instead (see #50351 sparse_sdpa and")
+        print("#50894 slice): overwrite scalar/address args in place with")
+        print("tt::tt_metal::GetRuntimeArgs(program, kernel_idx, core), and re-point CB-backed addresses via a")
+        print("minimal CB-only ProgramDescriptor + apply_descriptor_runtime_args (mark that one line")
+        print("'// override-rebuild-ok: cb-addr-only' -- it is O(1), not a full rebuild), or with")
+        print("UpdateDynamicCircularBufferAddress matched by CBIndex. No per-core reallocation on a hit.")
+        print("Verify parity with -DENABLE_DESCRIPTOR_PATCHING_PARITY_CHECK=ON.")
         return 1
     return 0
 

--- a/scripts/detect_override_rebuild_baseline.txt
+++ b/scripts/detect_override_rebuild_baseline.txt
@@ -1,24 +1,36 @@
 # Baseline for scripts/detect_override_rebuild.py
 #
-# Files that still rebuild a ProgramDescriptor inside override_runtime_arguments. The hook skips
-# them so it can block NEW violations without obstructing unrelated edits to these files.
+# Pre-existing rebuilds of a ProgramDescriptor inside override_runtime_arguments, grandfathered one
+# offender at a time. Every listed file is still FULLY scanned: any new or additional violation not
+# already fingerprinted below is blocked, so a baselined file keeps its guard.
 #
-# Every entry is a live per-dispatch cost: override_runtime_arguments runs on EVERY program-cache
-# hit, so calling create_descriptor() there pays the full cache-MISS host cost (work split,
-# CoreRangeSet construction, arch queries, TensorAccessorArgs, kernel-source strings, compile-time
-# arg vectors, a heap-allocated arg vector per core) on every dispatch. Fixing an op means deleting
-# its line here.
+# Each entry is a live per-dispatch cost: override_runtime_arguments runs on EVERY program-cache hit,
+# so calling create_descriptor() there pays the full cache-MISS host cost (work split, CoreRangeSet
+# construction, arch queries, TensorAccessorArgs, kernel-source strings, compile-time arg vectors, a
+# heap-allocated arg vector per core) on every dispatch. Fixing an op means deleting its line(s) here.
 #
 # For reference, the equivalent fix measured on the ops migrated in #49889 / #50338:
 #   rotary_embedding cache hit  35.1 -> 27.2 us
 #   uniform          cache hit  23.2 -> 13.8 us
 #
-# Format: one repo-relative path per line. Comments and blank lines ignored.
+# Format: one tab-separated <repo-relative-path>\t<symbol>\t<source-line> per offender. Regenerate
+# with:  python3 scripts/detect_override_rebuild.py --update-baseline <files...>
+# Comments (#) and blank lines are ignored.
 
-ttnn/cpp/ttnn/operations/ccl/mesh_partition/device/mesh_partition_program_factory.cpp
-ttnn/cpp/ttnn/operations/data_movement/move/device/move_sharded_program_factory.cpp
-ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm_sharded.cpp
-ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_device_operation.cpp
-ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_program_factory.cpp
-ttnn/cpp/ttnn/operations/moreh/moreh_adam/device/moreh_adam_program_factory.cpp
-ttnn/cpp/ttnn/operations/moreh/moreh_adamw/device/multi_core_program_factory.cpp
+ttnn/cpp/ttnn/operations/ccl/mesh_partition/device/mesh_partition_program_factory.cpp	Factory::create_descriptor	auto descriptor = Factory::create_descriptor(slice_attrs, slice_tensor_args, tensor_return_value);
+ttnn/cpp/ttnn/operations/ccl/mesh_partition/device/mesh_partition_program_factory.cpp	apply_descriptor_runtime_args	tt::tt_metal::apply_descriptor_runtime_args(program, descriptor);
+ttnn/cpp/ttnn/operations/data_movement/move/device/move_sharded_program_factory.cpp	MoveOverlapProgramFactory::create_descriptor	desc = MoveOverlapProgramFactory::create_descriptor(operation_attributes, tensor_args, tensor_return_value);
+ttnn/cpp/ttnn/operations/data_movement/move/device/move_sharded_program_factory.cpp	MoveProgramFactory::create_descriptor	desc = MoveProgramFactory::create_descriptor(operation_attributes, tensor_args, tensor_return_value);
+ttnn/cpp/ttnn/operations/data_movement/move/device/move_sharded_program_factory.cpp	MoveShardedProgramFactory::create_descriptor	desc = MoveShardedProgramFactory::create_descriptor(operation_attributes, tensor_args, tensor_return_value);
+ttnn/cpp/ttnn/operations/data_movement/move/device/move_sharded_program_factory.cpp	apply_descriptor_runtime_args	tt::tt_metal::apply_descriptor_runtime_args(program, desc);
+ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm_sharded.cpp	apply_descriptor_runtime_args	tt::tt_metal::apply_descriptor_runtime_args(program, cb_addr_only);
+ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm_sharded.cpp	apply_descriptor_runtime_args	tt::tt_metal::apply_descriptor_runtime_args(program, desc);
+ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm_sharded.cpp	create_descriptor	return std::decay_t<decltype(f)>::create_descriptor(operation_attributes, tensor_args, tensor_return_value);
+ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_device_operation.cpp	apply_descriptor_runtime_args	tt::tt_metal::apply_descriptor_runtime_args(program, desc);
+ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_device_operation.cpp	create_descriptor	return factory.create_descriptor(operation_attributes, tensor_args, tensor_return_value);
+ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_program_factory.cpp	ProgramFactory::create_descriptor	auto desc = ProgramFactory::create_descriptor(operation_attributes, tensor_args, output);
+ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_program_factory.cpp	apply_descriptor_runtime_args	tt::tt_metal::apply_descriptor_runtime_args(program, desc);
+ttnn/cpp/ttnn/operations/moreh/moreh_adam/device/moreh_adam_program_factory.cpp	apply_descriptor_runtime_args	tt::tt_metal::apply_descriptor_runtime_args(program, desc);
+ttnn/cpp/ttnn/operations/moreh/moreh_adam/device/moreh_adam_program_factory.cpp	create_descriptor	auto desc = create_descriptor(operation_attributes, tensor_args, output_tensor);
+ttnn/cpp/ttnn/operations/moreh/moreh_adamw/device/multi_core_program_factory.cpp	apply_descriptor_runtime_args	tt::tt_metal::apply_descriptor_runtime_args(program, desc);
+ttnn/cpp/ttnn/operations/moreh/moreh_adamw/device/multi_core_program_factory.cpp	create_descriptor	auto desc = create_descriptor(operation_attributes, tensor_args, tensor_return_value);

--- a/scripts/detect_override_rebuild_baseline.txt
+++ b/scripts/detect_override_rebuild_baseline.txt
@@ -1,0 +1,24 @@
+# Baseline for scripts/detect_override_rebuild.py
+#
+# Files that still rebuild a ProgramDescriptor inside override_runtime_arguments. The hook skips
+# them so it can block NEW violations without obstructing unrelated edits to these files.
+#
+# Every entry is a live per-dispatch cost: override_runtime_arguments runs on EVERY program-cache
+# hit, so calling create_descriptor() there pays the full cache-MISS host cost (work split,
+# CoreRangeSet construction, arch queries, TensorAccessorArgs, kernel-source strings, compile-time
+# arg vectors, a heap-allocated arg vector per core) on every dispatch. Fixing an op means deleting
+# its line here.
+#
+# For reference, the equivalent fix measured on the ops migrated in #49889 / #50338:
+#   rotary_embedding cache hit  35.1 -> 27.2 us
+#   uniform          cache hit  23.2 -> 13.8 us
+#
+# Format: one repo-relative path per line. Comments and blank lines ignored.
+
+ttnn/cpp/ttnn/operations/ccl/mesh_partition/device/mesh_partition_program_factory.cpp
+ttnn/cpp/ttnn/operations/data_movement/move/device/move_sharded_program_factory.cpp
+ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm_sharded.cpp
+ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_device_operation.cpp
+ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_program_factory.cpp
+ttnn/cpp/ttnn/operations/moreh/moreh_adam/device/moreh_adam_program_factory.cpp
+ttnn/cpp/ttnn/operations/moreh/moreh_adamw/device/multi_core_program_factory.cpp


### PR DESCRIPTION
## Problem

`override_runtime_arguments` runs on **every program-cache hit**. Calling `create_descriptor()` there — usually paired with `apply_descriptor_runtime_args()`, and usually justified as "re-derive from the single source of truth so the re-applied args can't drift" — pays the entire cache-**miss** host cost on every **hit**: the work split, `CoreRangeSet` construction, arch queries via `get_compute_kernel_config_args`, `TensorAccessorArgs` building, kernel-source `std::string`s, compile-time arg vectors, and a freshly heap-allocated runtime-arg vector for *every* core, followed by a walk over every kernel × core × arg plus every CB — to change two or three values.

It is **strictly slower than the `get_dynamic_runtime_args` hook it replaced**, which inverts the point of that migration, and it is the same slow-path-rebuild-on-hit anti-pattern behind the ResNet50 regressions (#46506, #50347).

This was not hypothetical: the pattern reached **11 open PRs** before being caught by review rather than by tooling.

## The correct shape

What legacy `override_runtime_arguments` already does (`GeluBwProgramFactory::override_runtime_arguments`): re-derive the work split, then write the slots in place via `GetRuntimeArgs`, re-pointing globally-allocated CB base addresses with `UpdateDynamicCircularBufferAddress` (matched by CBIndex, not by position in `desc.cbs`). These methods get long, and that is fine — the cost that mattered was the rebuild, not the line count.

Measured on ops migrated that way, per cache-hit dispatch, medians of 3 runs:

| op | rebuild-in-override | patch in place | |
|---|---|---|---|
| `rotary_embedding` decode | 35.1 µs | 27.2 µs | −23% |
| `uniform` | 23.2 µs | 13.8 µs | −41% |

## What this adds

`scripts/detect_override_rebuild.py` + a `detect-override-rebuild` pre-commit hook over `ttnn/*/device/*.{cpp,hpp}`, modelled on the existing `detect-smuggled-rta` hook. Text-only, so no runtime cost. It masks comments and string literals, so *describing* the anti-pattern stays legal, and a genuinely unavoidable case can suppress one line with `// override-rebuild-ok: <reason>`.

## Pre-existing violations are baselined, not ignored

Seven ops on `main` still contain the pattern. They are listed in `scripts/detect_override_rebuild_baseline.txt` so the hook blocks **new** violations without obstructing unrelated edits to those files:

- `ccl/mesh_partition` (partially addressed by #50918)
- `data_movement/move` (`move_sharded`)
- `data_movement/slice` (`slice_program_factory_rm_sharded`)
- `data_movement/tilize`
- `eltwise/unary`
- `moreh/moreh_adam`
- `moreh/moreh_adamw`

Each baseline line is a live per-dispatch cost, not a style nit. Fixing an op means deleting its line — the baseline doubles as the work list.

## Verification

Run against all 2941 `ttnn/*/device/*.{cpp,hpp}` files on `main`: exit 0 with the baseline, and it reports exactly those 7 files without it. Behaviour checks:

- flags a new `create_descriptor` / `apply_descriptor_runtime_args` inside an override body ✅
- skips baselined files ✅
- leaves the ops migrated in #49889 / #50338 / #50340 / #50343 / #50344 / #50345 / #50350 clean ✅
- does **not** flag the anti-pattern merely mentioned in a comment ✅

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/lint-forbid-override-rebuild)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/lint-forbid-override-rebuild)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/lint-forbid-override-rebuild)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/lint-forbid-override-rebuild)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=dgomez/lint-forbid-override-rebuild)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:dgomez/lint-forbid-override-rebuild)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/lint-forbid-override-rebuild)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/lint-forbid-override-rebuild)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/lint-forbid-override-rebuild)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/lint-forbid-override-rebuild)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/lint-forbid-override-rebuild)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/lint-forbid-override-rebuild)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/lint-forbid-override-rebuild)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/lint-forbid-override-rebuild)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/lint-forbid-override-rebuild)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/lint-forbid-override-rebuild)