### PR TITLE
[Feature] Add shared wide nullable perf-report schema (v1)

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/helpers/perf.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/perf.py
@@ -600,6 +600,65 @@ class PerfConfig(TestConfig):
         """Return (name, value) pairs for dataclass fields, used as columns for the report."""
         return [(f.name, getattr(obj, f.name)) for f in fields(obj)]
 
+    @staticmethod
+    def build_report_frame(
+        results,
+        code_sizes,
+        formats_config,
+        unpack_to_dest,
+        dest_acc,
+        passed_templates,
+        passed_runtimes,
+    ):
+        """Assemble the per-test report frame from the computed per-run-type results.
+
+        Pure (no hardware): given the stat/metric frames, the ELF code sizes and
+        the config's parameters, it merges the per-run-type results and cross-joins
+        the sweep columns onto them. This is the seam a hardware-free report test
+        drives with synthetic ``results`` to validate the produced column set.
+        """
+        run_results = reduce(
+            lambda left, right: pd.merge(
+                left, right, on=MARKER, how="outer", validate="1:1"
+            ),
+            results,
+        )
+
+        # Setting header fields that are always there
+        names = list(FORMAT_HEADERS) if formats_config else []
+        values = (
+            [
+                formats_config[0].unpack_A_src,
+                formats_config[0].unpack_B_src,
+                formats_config[0].unpack_A_dst,
+                formats_config[0].unpack_B_dst,
+                formats_config[0].output_format,
+                formats_config[0].sfpu_math,
+            ]
+            if formats_config and formats_config[0]
+            else []
+        )
+
+        names += list(FLAG_HEADERS)
+        values += [unpack_to_dest, dest_acc]
+
+        for param in passed_templates + passed_runtimes:
+            for name, value in PerfConfig._dataclass_name_and_values(param):
+                if value is not None:
+                    names.append(name)
+                    values.append(value)
+
+        for run_type, size in code_sizes.items():
+            names.append(text_size_column(run_type.name))
+            values.append(size)
+
+        sweep = pd.DataFrame([values], columns=names)
+        combined = sweep.merge(run_results, how="cross")
+
+        text_size_cols = [c for c in combined.columns if c.startswith(TEXT_SIZE_PREFIX)]
+        other_cols = [c for c in combined.columns if not c.startswith(TEXT_SIZE_PREFIX)]
+        return combined[other_cols + text_size_cols]
+
     def run(self, perf_report: PerfReport, run_count=1):
         results = []
         counter_results_list = []
@@ -721,51 +780,16 @@ class PerfConfig(TestConfig):
                     if not counter_csv_df.empty:
                         counter_results_list.append(counter_csv_df)
 
-        # Merge results with validation
-        # how="outer" keeps all markers (some may not appear in all run types)
-        # validate="1:1" catches duplicate markers within each run type
-        run_results = reduce(
-            lambda left, right: pd.merge(
-                left, right, on=MARKER, how="outer", validate="1:1"
-            ),
+        # Assemble the per-test report frame (pure — see build_report_frame).
+        combined = PerfConfig.build_report_frame(
             results,
+            code_sizes,
+            self.formats_config,
+            self.unpack_to_dest,
+            self.dest_acc,
+            self.passed_templates,
+            self.passed_runtimes,
         )
-
-        # Setting header fields that are always there
-        names = list(FORMAT_HEADERS) if self.formats_config else []
-        values = (
-            [
-                self.formats_config[0].unpack_A_src,
-                self.formats_config[0].unpack_B_src,
-                self.formats_config[0].unpack_A_dst,
-                self.formats_config[0].unpack_B_dst,
-                self.formats_config[0].output_format,
-                self.formats_config[0].sfpu_math,
-            ]
-            if self.formats_config[0]
-            else []
-        )
-
-        names += list(FLAG_HEADERS)
-        values += [self.unpack_to_dest, self.dest_acc]
-
-        for param in self.passed_templates + self.passed_runtimes:
-            for name, value in PerfConfig._dataclass_name_and_values(param):
-                if value is not None:
-                    names.append(name)
-                    values.append(value)
-
-        for run_type, size in code_sizes.items():
-            names.append(text_size_column(run_type.name))
-            values.append(size)
-
-        sweep = pd.DataFrame([values], columns=names)
-        combined = sweep.merge(run_results, how="cross")
-
-        text_size_cols = [c for c in combined.columns if c.startswith(TEXT_SIZE_PREFIX)]
-        other_cols = [c for c in combined.columns if not c.startswith(TEXT_SIZE_PREFIX)]
-        combined = combined[other_cols + text_size_cols]
-
         perf_report.append(combined, label=self.test_name)
 
         # Append raw counter data to the separate counter report

--- a/tt_metal/tt-llk/tests/python_tests/helpers/perf.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/perf.py
@@ -631,6 +631,11 @@ class PerfConfig(TestConfig):
         names += list(FLAG_HEADERS)
         values += [unpack_to_dest, dest_acc]
 
+        # Run mode: whether this run compiled everything as speed-of-light. Kept in
+        # the report so SoL and non-SoL measurements are never compared together.
+        names.append("speed_of_light")
+        values.append(TestConfig.SPEED_OF_LIGHT)
+
         for param in passed_templates + passed_runtimes:
             for name, value in PerfConfig._dataclass_name_and_values(param):
                 if value is not None:

--- a/tt_metal/tt-llk/tests/python_tests/helpers/perf.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/perf.py
@@ -610,9 +610,8 @@ class PerfConfig(TestConfig):
         passed_runtimes,
     ):
         """Single-row frame of the sweep columns (formats, flags, non-None params,
-        code sizes) that are cross-joined onto every per-run-type result. Shared by
-        the main report (build_report_frame) and the separate counter report so
-        both carry an identical set of sweep columns.
+        code sizes) cross-joined onto every per-run-type result. Shared by the main
+        report and the counter report so both carry the same sweep columns.
         """
         # Setting header fields that are always there
         names = list(FORMAT_HEADERS) if formats_config else []
@@ -654,12 +653,11 @@ class PerfConfig(TestConfig):
         passed_templates,
         passed_runtimes,
     ):
-        """Assemble the per-test report frame from the computed per-run-type results.
+        """Merge the per-run-type results and cross-join the sweep columns onto them.
 
-        Pure (no hardware): given the stat/metric frames, the ELF code sizes and
-        the config's parameters, it merges the per-run-type results and cross-joins
-        the sweep columns onto them. This is the seam a hardware-free report test
-        drives with synthetic ``results`` to validate the produced column set.
+        Pure (no hardware): takes the stat/metric frames, ELF code sizes and the
+        config's parameters. Called by run(); also driven directly by the
+        hardware-free report test.
         """
         run_results = reduce(
             lambda left, right: pd.merge(

--- a/tt_metal/tt-llk/tests/python_tests/helpers/perf.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/perf.py
@@ -600,6 +600,91 @@ class PerfConfig(TestConfig):
         """Return (name, value) pairs for dataclass fields, used as columns for the report."""
         return [(f.name, getattr(obj, f.name)) for f in fields(obj)]
 
+    @staticmethod
+    def _build_sweep_frame(
+        code_sizes,
+        formats_config,
+        unpack_to_dest,
+        dest_acc,
+        passed_templates,
+        passed_runtimes,
+    ):
+        """Single-row frame of the sweep columns (formats, flags, non-None params,
+        code sizes) cross-joined onto every per-run-type result. Shared by the main
+        report and the counter report so both carry the same sweep columns.
+        """
+        # Setting header fields that are always there
+        names = list(FORMAT_HEADERS) if formats_config else []
+        values = (
+            [
+                formats_config[0].unpack_A_src,
+                formats_config[0].unpack_B_src,
+                formats_config[0].unpack_A_dst,
+                formats_config[0].unpack_B_dst,
+                formats_config[0].output_format,
+                formats_config[0].sfpu_math,
+            ]
+            if formats_config and formats_config[0]
+            else []
+        )
+
+        names += list(FLAG_HEADERS)
+        values += [unpack_to_dest, dest_acc]
+
+        # Run mode: whether this run compiled everything as speed-of-light. Kept in
+        # the report so SoL and non-SoL measurements are never compared together.
+        names.append("speed_of_light")
+        values.append(TestConfig.SPEED_OF_LIGHT)
+
+        for param in passed_templates + passed_runtimes:
+            for name, value in PerfConfig._dataclass_name_and_values(param):
+                if value is not None:
+                    names.append(name)
+                    values.append(value)
+
+        for run_type, size in code_sizes.items():
+            names.append(text_size_column(run_type.name))
+            values.append(size)
+
+        return pd.DataFrame([values], columns=names)
+
+    @staticmethod
+    def build_report_frame(
+        results,
+        code_sizes,
+        formats_config,
+        unpack_to_dest,
+        dest_acc,
+        passed_templates,
+        passed_runtimes,
+    ):
+        """Merge the per-run-type results and cross-join the sweep columns onto them.
+
+        Pure (no hardware): takes the stat/metric frames, ELF code sizes and the
+        config's parameters. Called by run(); also driven directly by the
+        hardware-free report test.
+        """
+        run_results = reduce(
+            lambda left, right: pd.merge(
+                left, right, on=MARKER, how="outer", validate="1:1"
+            ),
+            results,
+        )
+
+        sweep = PerfConfig._build_sweep_frame(
+            code_sizes,
+            formats_config,
+            unpack_to_dest,
+            dest_acc,
+            passed_templates,
+            passed_runtimes,
+        )
+        combined = sweep.merge(run_results, how="cross")
+
+        text_size_cols = [c for c in combined.columns if c.startswith(TEXT_SIZE_PREFIX)]
+        other_cols = [c for c in combined.columns if not c.startswith(TEXT_SIZE_PREFIX)]
+        return combined[other_cols + text_size_cols]
+
     def run(self, perf_report: PerfReport, run_count=1):
         results = []
         counter_results_list = []
@@ -721,55 +806,16 @@ class PerfConfig(TestConfig):
                     if not counter_csv_df.empty:
                         counter_results_list.append(counter_csv_df)
 
-        # Merge results with validation
-        # how="outer" keeps all markers (some may not appear in all run types)
-        # validate="1:1" catches duplicate markers within each run type
-        run_results = reduce(
-            lambda left, right: pd.merge(
-                left, right, on=MARKER, how="outer", validate="1:1"
-            ),
+        # Assemble the per-test report frame (pure — see build_report_frame).
+        combined = PerfConfig.build_report_frame(
             results,
+            code_sizes,
+            self.formats_config,
+            self.unpack_to_dest,
+            self.dest_acc,
+            self.passed_templates,
+            self.passed_runtimes,
         )
-
-        # Setting header fields that are always there
-        has_formats = bool(self.formats_config) and bool(self.formats_config[0])
-        names = list(FORMAT_HEADERS) if has_formats else []
-        values = (
-            [
-                self.formats_config[0].unpack_A_src,
-                self.formats_config[0].unpack_B_src,
-                self.formats_config[0].unpack_A_dst,
-                self.formats_config[0].unpack_B_dst,
-                self.formats_config[0].output_format,
-                self.formats_config[0].sfpu_math,
-            ]
-            if has_formats
-            else []
-        )
-        assert len(names) == len(
-            values
-        ), f"perf report header/value drift: {len(names)} names vs {len(values)} values"
-
-        names += list(FLAG_HEADERS)
-        values += [self.unpack_to_dest, self.dest_acc]
-
-        for param in self.passed_templates + self.passed_runtimes:
-            for name, value in PerfConfig._dataclass_name_and_values(param):
-                if value is not None:
-                    names.append(name)
-                    values.append(value)
-
-        for run_type, size in code_sizes.items():
-            names.append(text_size_column(run_type.name))
-            values.append(size)
-
-        sweep = pd.DataFrame([values], columns=names)
-        combined = sweep.merge(run_results, how="cross")
-
-        text_size_cols = [c for c in combined.columns if c.startswith(TEXT_SIZE_PREFIX)]
-        other_cols = [c for c in combined.columns if not c.startswith(TEXT_SIZE_PREFIX)]
-        combined = combined[other_cols + text_size_cols]
-
         perf_report.append(combined, label=self.test_name)
 
         # Append raw counter data to the separate counter report
@@ -779,6 +825,14 @@ class PerfConfig(TestConfig):
                     left, right, on=MARKER, how="outer", validate="1:1"
                 ),
                 counter_results_list,
+            )
+            sweep = PerfConfig._build_sweep_frame(
+                code_sizes,
+                self.formats_config,
+                self.unpack_to_dest,
+                self.dest_acc,
+                self.passed_templates,
+                self.passed_runtimes,
             )
             counter_combined = sweep.merge(counter_run_results, how="cross")
             PerfConfig.COUNTER_REPORT.append(counter_combined, label=self.test_name)

--- a/tt_metal/tt-llk/tests/python_tests/helpers/perf.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/perf.py
@@ -601,8 +601,7 @@ class PerfConfig(TestConfig):
         return [(f.name, getattr(obj, f.name)) for f in fields(obj)]
 
     @staticmethod
-    def build_report_frame(
-        results,
+    def _build_sweep_frame(
         code_sizes,
         formats_config,
         unpack_to_dest,
@@ -610,20 +609,11 @@ class PerfConfig(TestConfig):
         passed_templates,
         passed_runtimes,
     ):
-        """Assemble the per-test report frame from the computed per-run-type results.
-
-        Pure (no hardware): given the stat/metric frames, the ELF code sizes and
-        the config's parameters, it merges the per-run-type results and cross-joins
-        the sweep columns onto them. This is the seam a hardware-free report test
-        drives with synthetic ``results`` to validate the produced column set.
+        """Single-row frame of the sweep columns (formats, flags, non-None params,
+        code sizes) that are cross-joined onto every per-run-type result. Shared by
+        the main report (build_report_frame) and the separate counter report so
+        both carry an identical set of sweep columns.
         """
-        run_results = reduce(
-            lambda left, right: pd.merge(
-                left, right, on=MARKER, how="outer", validate="1:1"
-            ),
-            results,
-        )
-
         # Setting header fields that are always there
         names = list(FORMAT_HEADERS) if formats_config else []
         values = (
@@ -652,7 +642,40 @@ class PerfConfig(TestConfig):
             names.append(text_size_column(run_type.name))
             values.append(size)
 
-        sweep = pd.DataFrame([values], columns=names)
+        return pd.DataFrame([values], columns=names)
+
+    @staticmethod
+    def build_report_frame(
+        results,
+        code_sizes,
+        formats_config,
+        unpack_to_dest,
+        dest_acc,
+        passed_templates,
+        passed_runtimes,
+    ):
+        """Assemble the per-test report frame from the computed per-run-type results.
+
+        Pure (no hardware): given the stat/metric frames, the ELF code sizes and
+        the config's parameters, it merges the per-run-type results and cross-joins
+        the sweep columns onto them. This is the seam a hardware-free report test
+        drives with synthetic ``results`` to validate the produced column set.
+        """
+        run_results = reduce(
+            lambda left, right: pd.merge(
+                left, right, on=MARKER, how="outer", validate="1:1"
+            ),
+            results,
+        )
+
+        sweep = PerfConfig._build_sweep_frame(
+            code_sizes,
+            formats_config,
+            unpack_to_dest,
+            dest_acc,
+            passed_templates,
+            passed_runtimes,
+        )
         combined = sweep.merge(run_results, how="cross")
 
         text_size_cols = [c for c in combined.columns if c.startswith(TEXT_SIZE_PREFIX)]
@@ -799,6 +822,14 @@ class PerfConfig(TestConfig):
                     left, right, on=MARKER, how="outer", validate="1:1"
                 ),
                 counter_results_list,
+            )
+            sweep = PerfConfig._build_sweep_frame(
+                code_sizes,
+                self.formats_config,
+                self.unpack_to_dest,
+                self.dest_acc,
+                self.passed_templates,
+                self.passed_runtimes,
             )
             counter_combined = sweep.merge(counter_run_results, how="cross")
             PerfConfig.COUNTER_REPORT.append(counter_combined, label=self.test_name)

--- a/tt_metal/tt-llk/tests/python_tests/helpers/perf_schema.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/perf_schema.py
@@ -4,14 +4,10 @@
 
 
 class PerfSchemaError(AssertionError):
-    """
-    Raised when a perf report's columns are not a valid, unique schema.
-
-    Two failure modes share this error: a single CSV that accumulates more than
-    one column schema (ragged, NaN-filled rows), and a report with two columns
-    that carry the same header name (a duplicate that would be silently mangled
-    into a ``<name>.1`` phantom). Both are fail-loud so the bad CSV never ships.
-    """
+    """Raised when a perf report's columns aren't a valid, unique schema: either a
+    CSV that mixes more than one column schema, or two columns sharing a header
+    name (which pandas would mangle into a ``<name>.1`` phantom). Fail loud so the
+    bad CSV never ships."""
 
 
 MARKER = "marker"
@@ -88,12 +84,9 @@ def assert_unique_columns(columns, context: str = "") -> None:
         )
 
 
-# Golden CSV-header catalog
-#
-# This catalog is HAND-MAINTAINED on purpose: a header changes ONLY when someone
-# edits a set below, so a rename becomes a reviewed diff instead of a silent
-# drift. When a test legitimately adds or renames a header, update the matching
-# set below in the SAME pull request.
+# Golden CSV-header catalog. Hand-maintained: a header changes only when someone
+# edits a set below, so a rename shows up as a reviewed diff. When a test adds or
+# renames a header, update the matching set in the same PR.
 
 # Run-type names — mirror helpers/llk_params.py::PerfRunType.
 RUN_TYPE_NAMES = frozenset(

--- a/tt_metal/tt-llk/tests/python_tests/helpers/perf_test_schemas.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/perf_test_schemas.py
@@ -4,11 +4,10 @@
 
 """Per-perf-test CSV schema catalog.
 
-One entry per perf test: the deliberate, reviewed set of CSV columns that test
-emits, plus a ``version`` bumped whenever those columns change, and an
-``aliases`` map (old_column -> new_column) that bridges a renamed column FOR
-THAT TEST only. The gate in test_perf_csv_header_gate.py re-derives each test's
-live columns and fails, per test, on any drift from this catalog.
+One entry per perf test: its reviewed set of CSV columns, a ``version`` bumped
+when those columns change, and an ``aliases`` map (old -> new) for a column
+renamed in that test. The gate in test_perf_csv_header_gate.py re-derives each
+test's columns and fails on any drift from this catalog.
 """
 
 

--- a/tt_metal/tt-llk/tests/python_tests/helpers/perf_wide_schema.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/perf_wide_schema.py
@@ -1,0 +1,145 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared wide nullable schema for LLK performance reports (v1).
+
+Two layers compose the published table:
+
+  OUTPUT_SCHEMA  what a perf test PRODUCES (config + timings + counters +
+                 code size + marker). This is the "expected output" contract a
+                 test report is validated against. Emitted by the test.
+  PROVENANCE     run context (commit, arch, run id, ...) added by the CI/publish
+                 layer, NOT by the test. Broadcast onto every output row.
+  DB_SCHEMA      = OUTPUT_SCHEMA + PROVENANCE — one published row per test
+                 configuration per execution context.
+
+Every OUTPUT column is nullable: a test fills the columns it uses and leaves the
+rest NULL. New columns (Quasar, counters/metrics, new params) are added later as
+nullable — a non-breaking change — so this v1 need not be complete.
+
+Import-free on purpose (no device libraries) so it loads/validates without hardware.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Column:
+    name: str
+    dtype: str  # int64 | float64 | bool | string
+    nullable: bool
+    category: str
+
+
+# ── Output schema: columns a perf test produces (validate reports against this) ──
+# TODO: counters/metrics (counter-enabled runs) and Quasar columns join here as
+# nullable once captured.
+OUTPUT_SCHEMA = [
+    Column("marker", "string", False, "identity"),
+    # formats
+    Column("formats.input_A", "string", True, "formats"),
+    Column("formats.input_B", "string", True, "formats"),
+    Column("formats.output", "string", True, "formats"),
+    Column("formats.register_A", "string", True, "formats"),
+    Column("formats.register_B", "string", True, "formats"),
+    # flags
+    Column("dest_acc", "string", True, "flags"),
+    Column("unpack_to_dest", "string", True, "flags"),
+    # key
+    Column("loop_factor", "int64", True, "key"),
+    Column("tile_cnt", "int64", True, "key"),
+    # configuration
+    Column("approx_mode", "string", True, "configuration"),
+    Column("block_ct_dim", "int64", True, "configuration"),
+    Column("block_rt_dim", "int64", True, "configuration"),
+    Column("broadcast_type", "string", True, "configuration"),
+    Column("c_dimm", "int64", True, "configuration"),
+    Column("clamp_negative", "bool", True, "configuration"),
+    Column("ct_dim", "int64", True, "configuration"),
+    Column("dest_sync", "string", True, "configuration"),
+    Column("dst_index", "int64", True, "configuration"),
+    Column("fast_mode", "string", True, "configuration"),
+    Column("full_ct_dim", "int64", True, "configuration"),
+    Column("full_rt_dim", "int64", True, "configuration"),
+    Column("in0_c_dim", "int64", True, "configuration"),
+    Column("in0_r_dim", "int64", True, "configuration"),
+    Column("in1_c_dim", "int64", True, "configuration"),
+    Column("in1_r_dim", "int64", True, "configuration"),
+    Column("input_format", "string", True, "configuration"),
+    Column("input_num_blocks", "int64", True, "configuration"),
+    Column("input_num_tiles_in_block", "int64", True, "configuration"),
+    Column("iterations", "int64", True, "configuration"),
+    Column("k_dimm", "int64", True, "configuration"),
+    Column("l1_acc", "string", True, "configuration"),
+    Column("math_fidelity", "string", True, "configuration"),
+    Column("math_transpose_faces", "string", True, "configuration"),
+    Column("mathop", "string", True, "configuration"),
+    Column("num_blocks", "int64", True, "configuration"),
+    Column("num_faces", "int64", True, "configuration"),
+    Column("num_faces_A", "int64", True, "configuration"),
+    Column("num_faces_B", "int64", True, "configuration"),
+    Column("num_tiles_in_block", "int64", True, "configuration"),
+    Column("output_format", "string", True, "configuration"),
+    Column("output_num_blocks", "int64", True, "configuration"),
+    Column("output_num_tiles_in_block", "int64", True, "configuration"),
+    Column("partial_a", "bool", True, "configuration"),
+    Column("partial_b", "bool", True, "configuration"),
+    Column("partial_face_math", "bool", True, "configuration"),
+    Column("partial_face_pack", "bool", True, "configuration"),
+    Column("pool_type", "string", True, "configuration"),
+    Column("r_dimm", "int64", True, "configuration"),
+    Column("reduce_pool_type", "string", True, "configuration"),
+    Column("srca_reuse_count", "int64", True, "configuration"),
+    Column("stable_sort", "string", True, "configuration"),
+    Column("throttle_level", "int64", True, "configuration"),
+    Column("tilize", "string", True, "configuration"),
+    Column("unpack_transpose_faces", "string", True, "configuration"),
+    Column("unpack_transpose_within_face", "string", True, "configuration"),
+    Column("value_bits", "int64", True, "configuration"),
+    # timing
+    Column("mean(L1_CONGESTION[PACK])", "float64", True, "timing"),
+    Column("mean(L1_CONGESTION[UNPACK])", "float64", True, "timing"),
+    Column("mean(L1_TO_L1)", "float64", True, "timing"),
+    Column("mean(MATH_ISOLATE)", "float64", True, "timing"),
+    Column("mean(PACK_ISOLATE)", "float64", True, "timing"),
+    Column("mean(UNPACK_ISOLATE)", "float64", True, "timing"),
+    Column("std(L1_TO_L1)", "float64", True, "timing"),
+    Column("std(PACK_ISOLATE)", "float64", True, "timing"),
+    # code_size
+    Column("TEXT_SIZE(L1_TO_L1)", "int64", True, "code_size"),
+    Column("TEXT_SIZE(MATH_ISOLATE)", "int64", True, "code_size"),
+    Column("TEXT_SIZE(PACK_ISOLATE)", "int64", True, "code_size"),
+    Column("TEXT_SIZE(UNPACK_ISOLATE)", "int64", True, "code_size"),
+]
+
+# ── Provenance: run context added by CI/publish layer (NOT produced by tests) ──
+PROVENANCE = [
+    Column("test_name", "string", False, "identity"),
+    Column("commit_sha", "string", False, "provenance"),
+    Column("arch", "string", False, "provenance"),
+    Column("run_id", "string", False, "provenance"),
+    Column("timestamp", "string", False, "provenance"),
+    Column("pipeline", "string", False, "provenance"),  # PR | nightly
+    Column("pr_number", "string", True, "provenance"),  # NULL for nightly
+]
+
+# ── Published table = test output + provenance ──
+DB_SCHEMA = OUTPUT_SCHEMA + PROVENANCE
+
+MANDATORY = [c.name for c in DB_SCHEMA if not c.nullable]
+
+# ── Row identity ──
+# A published row = one test configuration in one execution context, uniquely
+# identified by: test + its full sweep configuration + commit + arch + run.
+# The fixed part of the key (the configuration columns that complete it vary
+# per test and are the sweep-parameter values that row carries):
+ROW_KEY = ["test_name", "commit_sha", "arch", "run_id"]
+
+# TODO(canonicalization — deferred, see #51245): same-purpose columns still use
+# divergent names across tests and are NOT yet unified here, e.g.
+#   - c_dimm / k_dimm / r_dimm  vs  in0_c_dim / ct_dim   (`_dimm` vs `_dim`)
+#   - formats.input_A / formats.output  vs  input_format / output_format
+#   - num_blocks  vs  input_num_blocks / output_num_blocks
+# Aligning to one canonical name per concept needs sign-off; ambiguous fields
+# must not be merged automatically.

--- a/tt_metal/tt-llk/tests/python_tests/helpers/perf_wide_schema.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/perf_wide_schema.py
@@ -18,10 +18,13 @@ Every OUTPUT column is nullable: a test fills the columns it uses and leaves the
 rest NULL. New columns (Quasar, counters/metrics, new params) are added later as
 nullable — a non-breaking change — so this v1 need not be complete.
 
-Import-free on purpose (no device libraries) so it loads/validates without hardware.
+No device libraries (only the pure ``perf_schema`` helpers) so it loads/validates
+without hardware.
 """
 
 from dataclasses import dataclass
+
+from .perf_schema import MEAN, STD, stat_column
 
 
 @dataclass(frozen=True)
@@ -30,6 +33,28 @@ class Column:
     dtype: str  # int64 | float64 | bool | string
     nullable: bool
     category: str
+
+
+# Timing columns are FORMULA-DRIVEN, not sampled: the profiler emits
+# ``mean(<base>)`` for every run type and ``std(<base>)`` whenever that run type
+# runs >= 2 iterations. Different tests/configs run different iteration counts,
+# so across the corpus std can appear for ANY base. We therefore enumerate the
+# COMPLETE {mean, std} x base grid rather than whatever one nightly happened to
+# produce — otherwise the schema is an accidental subset (e.g. it once lacked
+# ``std(MATH_ISOLATE)``, which a real multi-run report legitimately emits).
+_TIMING_BASES = (
+    "L1_TO_L1",
+    "UNPACK_ISOLATE",
+    "MATH_ISOLATE",
+    "PACK_ISOLATE",
+    "L1_CONGESTION[UNPACK]",
+    "L1_CONGESTION[PACK]",
+)
+_TIMING_COLUMNS = [
+    Column(stat_column(base, kind), "float64", True, "timing")
+    for base in _TIMING_BASES
+    for kind in (MEAN, STD)
+]
 
 
 # ── Output schema: columns a perf test produces (validate reports against this) ──
@@ -97,15 +122,8 @@ OUTPUT_SCHEMA = [
     Column("unpack_transpose_faces", "string", True, "configuration"),
     Column("unpack_transpose_within_face", "string", True, "configuration"),
     Column("value_bits", "int64", True, "configuration"),
-    # timing
-    Column("mean(L1_CONGESTION[PACK])", "float64", True, "timing"),
-    Column("mean(L1_CONGESTION[UNPACK])", "float64", True, "timing"),
-    Column("mean(L1_TO_L1)", "float64", True, "timing"),
-    Column("mean(MATH_ISOLATE)", "float64", True, "timing"),
-    Column("mean(PACK_ISOLATE)", "float64", True, "timing"),
-    Column("mean(UNPACK_ISOLATE)", "float64", True, "timing"),
-    Column("std(L1_TO_L1)", "float64", True, "timing"),
-    Column("std(PACK_ISOLATE)", "float64", True, "timing"),
+    # timing (complete {mean, std} x base grid — see _TIMING_COLUMNS above)
+    *_TIMING_COLUMNS,
     # code_size
     Column("TEXT_SIZE(L1_TO_L1)", "int64", True, "code_size"),
     Column("TEXT_SIZE(MATH_ISOLATE)", "int64", True, "code_size"),

--- a/tt_metal/tt-llk/tests/python_tests/helpers/perf_wide_schema.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/perf_wide_schema.py
@@ -4,22 +4,17 @@
 
 """Shared wide nullable schema for LLK performance reports (v1).
 
-Two layers compose the published table:
+Two layers make up the published table:
 
-  OUTPUT_SCHEMA  what a perf test PRODUCES (config + timings + counters +
-                 code size + marker). This is the "expected output" contract a
-                 test report is validated against. Emitted by the test.
-  PROVENANCE     run context (commit, arch, run id, ...) added by the CI/publish
-                 layer, NOT by the test. Broadcast onto every output row.
-  DB_SCHEMA      = OUTPUT_SCHEMA + PROVENANCE — one published row per test
-                 configuration per execution context.
+  OUTPUT_SCHEMA  columns a perf test produces (config, timings, counters, code
+                 size, marker). Reports are validated against this.
+  PROVENANCE     run context (commit, arch, run id, ...) added by CI, not the test.
+  DB_SCHEMA      OUTPUT_SCHEMA + PROVENANCE, one row per test config per run.
 
-Every OUTPUT column is nullable: a test fills the columns it uses and leaves the
-rest NULL. New columns (Quasar, counters/metrics, new params) are added later as
-nullable — a non-breaking change — so this v1 need not be complete.
+Every OUTPUT column is nullable: a test fills what it uses, the rest stay NULL.
+New columns are added later as nullable, so v1 need not be complete.
 
-No device libraries (only the pure ``perf_schema`` helpers) so it loads/validates
-without hardware.
+Imports no device libraries, so it loads without hardware.
 """
 
 from dataclasses import dataclass
@@ -35,13 +30,9 @@ class Column:
     category: str
 
 
-# Timing columns are FORMULA-DRIVEN, not sampled: the profiler emits
-# ``mean(<base>)`` for every run type and ``std(<base>)`` whenever that run type
-# runs >= 2 iterations. Different tests/configs run different iteration counts,
-# so across the corpus std can appear for ANY base. We therefore enumerate the
-# COMPLETE {mean, std} x base grid rather than whatever one nightly happened to
-# produce — otherwise the schema is an accidental subset (e.g. it once lacked
-# ``std(MATH_ISOLATE)``, which a real multi-run report legitimately emits).
+# Timing columns are formula-driven: mean(<base>) for every run type, std(<base>)
+# once a run type runs >=2 iterations. Enumerate the full {mean, std} x base grid
+# so the schema is a superset of any run config, not just what one nightly sampled.
 _TIMING_BASES = (
     "L1_TO_L1",
     "UNPACK_ISOLATE",
@@ -147,17 +138,13 @@ DB_SCHEMA = OUTPUT_SCHEMA + PROVENANCE
 
 MANDATORY = [c.name for c in DB_SCHEMA if not c.nullable]
 
-# ── Row identity ──
-# A published row = one test configuration in one execution context, uniquely
-# identified by: test + its full sweep configuration + commit + arch + run.
-# The fixed part of the key (the configuration columns that complete it vary
-# per test and are the sweep-parameter values that row carries):
+# Row identity: one test config in one run. The sweep-parameter columns (which
+# vary per test) complete the key on top of these fixed columns.
 ROW_KEY = ["test_name", "commit_sha", "arch", "run_id"]
 
-# TODO(canonicalization — deferred, see #51245): same-purpose columns still use
-# divergent names across tests and are NOT yet unified here, e.g.
-#   - c_dimm / k_dimm / r_dimm  vs  in0_c_dim / ct_dim   (`_dimm` vs `_dim`)
+# TODO(canonicalization, deferred — see #51245): some columns name the same thing
+# differently across tests and are not yet unified, e.g.
+#   - c_dimm / k_dimm / r_dimm  vs  in0_c_dim / ct_dim
 #   - formats.input_A / formats.output  vs  input_format / output_format
 #   - num_blocks  vs  input_num_blocks / output_num_blocks
-# Aligning to one canonical name per concept needs sign-off; ambiguous fields
-# must not be merged automatically.
+# Picking one canonical name per concept needs sign-off, so don't merge them here.

--- a/tt_metal/tt-llk/tests/python_tests/helpers/perf_wide_schema.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/perf_wide_schema.py
@@ -1,0 +1,164 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared wide nullable schema for LLK performance reports (v1).
+
+DB_SCHEMA is the one published table: every column, and the exact schema the
+Parquet is written with and handed to the data team. Each column declares its
+``origin`` — ``"test"`` (a perf test emits it) or ``"ci"`` (the publish layer
+stamps it). Two views derive from that single source of truth:
+
+  OUTPUT_SCHEMA  the origin=="test" columns — what a report is validated against.
+  PROVENANCE     the origin=="ci" columns — run context (commit, arch, run id, ...).
+
+One row per test config per run. Every column except ``marker`` and the mandatory
+provenance keys is nullable: a test fills the columns it uses, the rest stay NULL.
+New columns are added later as nullable, so v1 need not be complete.
+
+Imports no device libraries, so it loads without hardware.
+"""
+
+from dataclasses import dataclass
+
+from .perf_schema import MEAN, STD, stat_column
+
+
+@dataclass(frozen=True)
+class Column:
+    name: str
+    dtype: str  # int64 | float64 | bool | string
+    nullable: bool
+    category: str
+    origin: str = "test"  # who fills the column: "test" | "ci"
+
+
+# Timing columns are formula-driven: mean(<base>) for every run type, std(<base>)
+# once a run type runs >=2 iterations. Enumerate the full {mean, std} x base grid
+# so the schema is a superset of any run config, not just what one nightly sampled.
+_TIMING_BASES = (
+    "L1_TO_L1",
+    "UNPACK_ISOLATE",
+    "MATH_ISOLATE",
+    "PACK_ISOLATE",
+    "L1_CONGESTION[UNPACK]",
+    "L1_CONGESTION[PACK]",
+)
+_TIMING_COLUMNS = [
+    Column(stat_column(base, kind), "float64", True, "timing")
+    for base in _TIMING_BASES
+    for kind in (MEAN, STD)
+]
+
+
+# ── The one published table: every column, headers + provenance ─────────────
+# This IS the table handed to the data team; the Parquet is written with it. Each
+# column's `origin` says who fills it — "test" (default) or "ci".
+# TODO(counters/Quasar, deferred — see #51249): counter/metric and Quasar columns
+# join here as nullable once a counter/Quasar run captures their exact names.
+DB_SCHEMA = [
+    Column("marker", "string", False, "identity"),
+    # formats
+    Column("formats.input_A", "string", True, "formats"),
+    Column("formats.input_B", "string", True, "formats"),
+    Column("formats.output", "string", True, "formats"),
+    Column("formats.register_A", "string", True, "formats"),
+    Column("formats.register_B", "string", True, "formats"),
+    Column("formats.sfpu_math", "string", True, "formats"),
+    # flags
+    Column("dest_acc", "string", True, "flags"),
+    Column("speed_of_light", "bool", True, "flags"),
+    Column("unpack_to_dest", "string", True, "flags"),
+    # key
+    Column("loop_factor", "int64", True, "key"),
+    Column("tile_cnt", "int64", True, "key"),
+    # configuration
+    Column("approx_mode", "string", True, "configuration"),
+    Column("binop_mathop", "string", True, "configuration"),
+    Column("block_ct_dim", "int64", True, "configuration"),
+    Column("block_rt_dim", "int64", True, "configuration"),
+    Column("broadcast_type", "string", True, "configuration"),
+    Column("c_dimm", "int64", True, "configuration"),
+    Column("clamp_negative", "bool", True, "configuration"),
+    Column("ct_dim", "int64", True, "configuration"),
+    Column("dest_sync", "string", True, "configuration"),
+    Column("dst_index", "int64", True, "configuration"),
+    Column("fast_mode", "string", True, "configuration"),
+    Column("full_ct_dim", "int64", True, "configuration"),
+    Column("full_rt_dim", "int64", True, "configuration"),
+    Column("in0_c_dim", "int64", True, "configuration"),
+    Column("in0_r_dim", "int64", True, "configuration"),
+    Column("in1_c_dim", "int64", True, "configuration"),
+    Column("in1_r_dim", "int64", True, "configuration"),
+    Column("input_format", "string", True, "configuration"),
+    Column("input_num_blocks", "int64", True, "configuration"),
+    Column("input_num_tiles_in_block", "int64", True, "configuration"),
+    Column("iterations", "int64", True, "configuration"),
+    Column("k_dimm", "int64", True, "configuration"),
+    Column("l1_acc", "string", True, "configuration"),
+    Column("math_fidelity", "string", True, "configuration"),
+    Column("math_transpose_faces", "string", True, "configuration"),
+    Column("mathop", "string", True, "configuration"),
+    Column("num_blocks", "int64", True, "configuration"),
+    Column("num_faces", "int64", True, "configuration"),
+    Column("num_faces_A", "int64", True, "configuration"),
+    Column("num_faces_B", "int64", True, "configuration"),
+    Column("num_tiles_in_block", "int64", True, "configuration"),
+    Column("output_format", "string", True, "configuration"),
+    Column("output_num_blocks", "int64", True, "configuration"),
+    Column("output_num_tiles_in_block", "int64", True, "configuration"),
+    Column("partial_a", "bool", True, "configuration"),
+    Column("partial_b", "bool", True, "configuration"),
+    Column("partial_face_math", "bool", True, "configuration"),
+    Column("partial_face_pack", "bool", True, "configuration"),
+    Column("pool_type", "string", True, "configuration"),
+    Column("r_dimm", "int64", True, "configuration"),
+    Column("reduce_pool_type", "string", True, "configuration"),
+    Column("srca_reuse_count", "int64", True, "configuration"),
+    Column("stable_sort", "string", True, "configuration"),
+    Column("ternary_mathop", "string", True, "configuration"),
+    Column("ternary_scalar_bits", "int64", True, "configuration"),
+    Column("throttle_level", "int64", True, "configuration"),
+    Column("tilize", "string", True, "configuration"),
+    Column("unpack_transpose_faces", "string", True, "configuration"),
+    Column("unpack_transpose_within_face", "string", True, "configuration"),
+    Column("value_bits", "int64", True, "configuration"),
+    # timing (complete {mean, std} x base grid — see _TIMING_COLUMNS above)
+    *_TIMING_COLUMNS,
+    # ── provenance: stamped by the publish layer, never emitted by a test ──
+    Column("test_name", "string", False, "identity", origin="ci"),
+    Column("commit_sha", "string", False, "provenance", origin="ci"),
+    Column("arch", "string", False, "provenance", origin="ci"),
+    Column("run_id", "string", False, "provenance", origin="ci"),
+    Column("timestamp", "string", False, "provenance", origin="ci"),
+    Column("pipeline", "string", False, "provenance", origin="ci"),  # PR | nightly
+    Column("pr_number", "string", True, "provenance", origin="ci"),  # NULL for nightly
+]
+
+# Views onto the one schema, by who fills each column. The converter validates a
+# test's report against OUTPUT_SCHEMA; the publish layer stamps PROVENANCE. Both
+# derive from DB_SCHEMA, so there is a single source of truth.
+OUTPUT_SCHEMA = [c for c in DB_SCHEMA if c.origin == "test"]
+PROVENANCE = [c for c in DB_SCHEMA if c.origin == "ci"]
+
+MANDATORY = [c.name for c in DB_SCHEMA if not c.nullable]
+
+# Columns a test emits but the published table intentionally drops. The converter
+# removes them instead of failing on an unknown column.
+#   TEXT_SIZE(...)  — per-stage ELF code size; not used by the gate
+DROPPED_COLUMNS = {
+    "TEXT_SIZE(L1_TO_L1)",
+    "TEXT_SIZE(MATH_ISOLATE)",
+    "TEXT_SIZE(PACK_ISOLATE)",
+    "TEXT_SIZE(UNPACK_ISOLATE)",
+}
+
+# Row identity: one test config in one run. The sweep-parameter columns (which
+# vary per test) complete the key on top of these fixed columns.
+ROW_KEY = ["test_name", "commit_sha", "arch", "run_id"]
+
+# TODO(canonicalization, deferred — see #51245): some columns name the same thing
+# differently across tests and are not yet unified, e.g.
+#   - c_dimm / k_dimm / r_dimm  vs  in0_c_dim / ct_dim
+#   - formats.input_A / formats.output  vs  input_format / output_format
+# Picking one canonical name per concept needs sign-off, so don't merge them here.

--- a/tt_metal/tt-llk/tests/python_tests/helpers/perf_wide_schema.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/perf_wide_schema.py
@@ -89,7 +89,6 @@ DB_SCHEMA = [
     Column("in1_c_dim", "int64", True, "configuration"),
     Column("in1_r_dim", "int64", True, "configuration"),
     Column("input_format", "string", True, "configuration"),
-    Column("input_num_blocks", "int64", True, "configuration"),
     Column("input_num_tiles_in_block", "int64", True, "configuration"),
     Column("iterations", "int64", True, "configuration"),
     Column("k_dimm", "int64", True, "configuration"),
@@ -103,7 +102,6 @@ DB_SCHEMA = [
     Column("num_faces_B", "int64", True, "configuration"),
     Column("num_tiles_in_block", "int64", True, "configuration"),
     Column("output_format", "string", True, "configuration"),
-    Column("output_num_blocks", "int64", True, "configuration"),
     Column("output_num_tiles_in_block", "int64", True, "configuration"),
     Column("partial_a", "bool", True, "configuration"),
     Column("partial_b", "bool", True, "configuration"),
@@ -144,6 +142,13 @@ PROVENANCE = [c for c in DB_SCHEMA if c.origin == "ci"]
 
 MANDATORY = [c.name for c in DB_SCHEMA if not c.nullable]
 
+# Columns a test emits but the published table intentionally drops: each is
+# provably always equal to a column we keep (verified — no perf test ever sets
+# them apart), so it carries no information. The converter removes these instead
+# of failing on an unknown column.
+#   input_num_blocks, output_num_blocks  ==  num_blocks
+REDUNDANT_COLUMNS = {"input_num_blocks", "output_num_blocks"}
+
 # Row identity: one test config in one run. The sweep-parameter columns (which
 # vary per test) complete the key on top of these fixed columns.
 ROW_KEY = ["test_name", "commit_sha", "arch", "run_id"]
@@ -152,5 +157,4 @@ ROW_KEY = ["test_name", "commit_sha", "arch", "run_id"]
 # differently across tests and are not yet unified, e.g.
 #   - c_dimm / k_dimm / r_dimm  vs  in0_c_dim / ct_dim
 #   - formats.input_A / formats.output  vs  input_format / output_format
-#   - num_blocks  vs  input_num_blocks / output_num_blocks
 # Picking one canonical name per concept needs sign-off, so don't merge them here.

--- a/tt_metal/tt-llk/tests/python_tests/helpers/perf_wide_schema.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/perf_wide_schema.py
@@ -59,6 +59,7 @@ OUTPUT_SCHEMA = [
     Column("formats.output", "string", True, "formats"),
     Column("formats.register_A", "string", True, "formats"),
     Column("formats.register_B", "string", True, "formats"),
+    Column("formats.sfpu_math", "string", True, "formats"),
     # flags
     Column("dest_acc", "string", True, "flags"),
     Column("unpack_to_dest", "string", True, "flags"),

--- a/tt_metal/tt-llk/tests/python_tests/helpers/perf_wide_schema.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/perf_wide_schema.py
@@ -4,14 +4,16 @@
 
 """Shared wide nullable schema for LLK performance reports (v1).
 
-Two layers make up the published table:
+DB_SCHEMA is the one published table: every column, and the exact schema the
+Parquet is written with and handed to the data team. Each column declares its
+``origin`` — ``"test"`` (a perf test emits it) or ``"ci"`` (the publish layer
+stamps it). Two views derive from that single source of truth:
 
-  OUTPUT_SCHEMA  columns a perf test produces (config, timings, counters, code
-                 size, marker). Reports are validated against this.
-  PROVENANCE     run context (commit, arch, run id, ...) added by CI, not the test.
-  DB_SCHEMA      OUTPUT_SCHEMA + PROVENANCE, one row per test config per run.
+  OUTPUT_SCHEMA  the origin=="test" columns — what a report is validated against.
+  PROVENANCE     the origin=="ci" columns — run context (commit, arch, run id, ...).
 
-Every OUTPUT column is nullable: a test fills what it uses, the rest stay NULL.
+One row per test config per run. Every column except ``marker`` and the mandatory
+provenance keys is nullable: a test fills the columns it uses, the rest stay NULL.
 New columns are added later as nullable, so v1 need not be complete.
 
 Imports no device libraries, so it loads without hardware.
@@ -28,6 +30,7 @@ class Column:
     dtype: str  # int64 | float64 | bool | string
     nullable: bool
     category: str
+    origin: str = "test"  # who fills the column: "test" | "ci"
 
 
 # Timing columns are formula-driven: mean(<base>) for every run type, std(<base>)
@@ -48,10 +51,12 @@ _TIMING_COLUMNS = [
 ]
 
 
-# ── Output schema: columns a perf test produces (validate reports against this) ──
-# TODO: counters/metrics (counter-enabled runs) and Quasar columns join here as
-# nullable once captured.
-OUTPUT_SCHEMA = [
+# ── The one published table: every column, headers + provenance ─────────────
+# This IS the table handed to the data team; the Parquet is written with it. Each
+# column's `origin` says who fills it — "test" (default) or "ci".
+# TODO(counters/Quasar, deferred — see #51249): counter/metric and Quasar columns
+# join here as nullable once a counter/Quasar run captures their exact names.
+DB_SCHEMA = [
     Column("marker", "string", False, "identity"),
     # formats
     Column("formats.input_A", "string", True, "formats"),
@@ -121,21 +126,21 @@ OUTPUT_SCHEMA = [
     Column("TEXT_SIZE(MATH_ISOLATE)", "int64", True, "code_size"),
     Column("TEXT_SIZE(PACK_ISOLATE)", "int64", True, "code_size"),
     Column("TEXT_SIZE(UNPACK_ISOLATE)", "int64", True, "code_size"),
+    # ── provenance: stamped by the publish layer, never emitted by a test ──
+    Column("test_name", "string", False, "identity", origin="ci"),
+    Column("commit_sha", "string", False, "provenance", origin="ci"),
+    Column("arch", "string", False, "provenance", origin="ci"),
+    Column("run_id", "string", False, "provenance", origin="ci"),
+    Column("timestamp", "string", False, "provenance", origin="ci"),
+    Column("pipeline", "string", False, "provenance", origin="ci"),  # PR | nightly
+    Column("pr_number", "string", True, "provenance", origin="ci"),  # NULL for nightly
 ]
 
-# ── Provenance: run context added by CI/publish layer (NOT produced by tests) ──
-PROVENANCE = [
-    Column("test_name", "string", False, "identity"),
-    Column("commit_sha", "string", False, "provenance"),
-    Column("arch", "string", False, "provenance"),
-    Column("run_id", "string", False, "provenance"),
-    Column("timestamp", "string", False, "provenance"),
-    Column("pipeline", "string", False, "provenance"),  # PR | nightly
-    Column("pr_number", "string", True, "provenance"),  # NULL for nightly
-]
-
-# ── Published table = test output + provenance ──
-DB_SCHEMA = OUTPUT_SCHEMA + PROVENANCE
+# Views onto the one schema, by who fills each column. The converter validates a
+# test's report against OUTPUT_SCHEMA; the publish layer stamps PROVENANCE. Both
+# derive from DB_SCHEMA, so there is a single source of truth.
+OUTPUT_SCHEMA = [c for c in DB_SCHEMA if c.origin == "test"]
+PROVENANCE = [c for c in DB_SCHEMA if c.origin == "ci"]
 
 MANDATORY = [c.name for c in DB_SCHEMA if not c.nullable]
 

--- a/tt_metal/tt-llk/tests/python_tests/helpers/perf_wide_schema.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/perf_wide_schema.py
@@ -73,6 +73,7 @@ DB_SCHEMA = [
     Column("tile_cnt", "int64", True, "key"),
     # configuration
     Column("approx_mode", "string", True, "configuration"),
+    Column("binop_mathop", "string", True, "configuration"),
     Column("block_ct_dim", "int64", True, "configuration"),
     Column("block_rt_dim", "int64", True, "configuration"),
     Column("broadcast_type", "string", True, "configuration"),
@@ -112,6 +113,8 @@ DB_SCHEMA = [
     Column("reduce_pool_type", "string", True, "configuration"),
     Column("srca_reuse_count", "int64", True, "configuration"),
     Column("stable_sort", "string", True, "configuration"),
+    Column("ternary_mathop", "string", True, "configuration"),
+    Column("ternary_scalar_bits", "int64", True, "configuration"),
     Column("throttle_level", "int64", True, "configuration"),
     Column("tilize", "string", True, "configuration"),
     Column("unpack_transpose_faces", "string", True, "configuration"),

--- a/tt_metal/tt-llk/tests/python_tests/helpers/perf_wide_schema.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/perf_wide_schema.py
@@ -67,6 +67,7 @@ DB_SCHEMA = [
     Column("formats.sfpu_math", "string", True, "formats"),
     # flags
     Column("dest_acc", "string", True, "flags"),
+    Column("speed_of_light", "bool", True, "flags"),
     Column("unpack_to_dest", "string", True, "flags"),
     # key
     Column("loop_factor", "int64", True, "key"),
@@ -122,11 +123,6 @@ DB_SCHEMA = [
     Column("value_bits", "int64", True, "configuration"),
     # timing (complete {mean, std} x base grid — see _TIMING_COLUMNS above)
     *_TIMING_COLUMNS,
-    # code_size
-    Column("TEXT_SIZE(L1_TO_L1)", "int64", True, "code_size"),
-    Column("TEXT_SIZE(MATH_ISOLATE)", "int64", True, "code_size"),
-    Column("TEXT_SIZE(PACK_ISOLATE)", "int64", True, "code_size"),
-    Column("TEXT_SIZE(UNPACK_ISOLATE)", "int64", True, "code_size"),
     # ── provenance: stamped by the publish layer, never emitted by a test ──
     Column("test_name", "string", False, "identity", origin="ci"),
     Column("commit_sha", "string", False, "provenance", origin="ci"),
@@ -145,12 +141,19 @@ PROVENANCE = [c for c in DB_SCHEMA if c.origin == "ci"]
 
 MANDATORY = [c.name for c in DB_SCHEMA if not c.nullable]
 
-# Columns a test emits but the published table intentionally drops: each is
-# provably always equal to a column we keep (verified — no perf test ever sets
-# them apart), so it carries no information. The converter removes these instead
-# of failing on an unknown column.
-#   input_num_blocks, output_num_blocks  ==  num_blocks
-REDUNDANT_COLUMNS = {"input_num_blocks", "output_num_blocks"}
+# Columns a test emits but the published table intentionally drops. The converter
+# removes them instead of failing on an unknown column.
+#   input_num_blocks, output_num_blocks  — always == num_blocks (redundant; no
+#                                          perf test ever sets them apart)
+#   TEXT_SIZE(...)                        — ELF code size; not used by the gate
+DROPPED_COLUMNS = {
+    "input_num_blocks",
+    "output_num_blocks",
+    "TEXT_SIZE(L1_TO_L1)",
+    "TEXT_SIZE(MATH_ISOLATE)",
+    "TEXT_SIZE(PACK_ISOLATE)",
+    "TEXT_SIZE(UNPACK_ISOLATE)",
+}
 
 # Row identity: one test config in one run. The sweep-parameter columns (which
 # vary per test) complete the key on top of these fixed columns.

--- a/tt_metal/tt-llk/tests/python_tests/test_perf_report_hw_free.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_perf_report_hw_free.py
@@ -1,0 +1,112 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Hardware-free test of PerfConfig report generation (#51244).
+
+Drives ``PerfConfig.build_report_frame`` — the pure report-assembly seam of
+``run()`` — with synthetic per-run-type results and parameters, so the report is
+produced with **no chip**. Then it checks that the produced column set conforms
+to the shared output schema (``perf_wide_schema.OUTPUT_SCHEMA``).
+
+This is the exact validation the static gate only approximates: the columns come
+from the real assembly code path, so it catches the optional-None and
+dynamic-param cases that static reading cannot. Needs the LLK env (pandas,
+ttexalens importable) but no hardware.
+"""
+
+from types import SimpleNamespace
+
+import pandas as pd
+from helpers.llk_params import ApproximationMode, DestAccumulation, PerfRunType
+from helpers.perf import PerfConfig
+from helpers.perf_schema import MEAN, STD, assert_unique_columns, stat_column
+from helpers.perf_wide_schema import OUTPUT_SCHEMA
+from helpers.test_variant_parameters import APPROX_MODE, LOOP_FACTOR, TILE_COUNT
+
+_SCHEMA_NAMES = {c.name for c in OUTPUT_SCHEMA}
+
+
+def _fake_formats():
+    """A stand-in for a formats_config entry: only the attributes the assembly reads."""
+    fmt = SimpleNamespace(
+        unpack_A_src="Float16_b",
+        unpack_B_src="Float16_b",
+        unpack_A_dst="Float16_b",
+        unpack_B_dst="Float16_b",
+        output_format="Float16_b",
+    )
+    return [fmt]
+
+
+def _timing_result(run_type: PerfRunType) -> pd.DataFrame:
+    """What get_stats would emit for one run type: marker + mean/std timing columns."""
+    rt = run_type.name
+    return pd.DataFrame(
+        {
+            "marker": ["INIT", "TILE_LOOP"],
+            stat_column(rt, MEAN): [10.0, 20.0],
+            stat_column(rt, STD): [1.0, 2.0],
+        }
+    )
+
+
+def _build(formats_config):
+    results = [
+        _timing_result(PerfRunType.L1_TO_L1),
+        _timing_result(PerfRunType.MATH_ISOLATE),
+    ]
+    code_sizes = {PerfRunType.L1_TO_L1: 4096, PerfRunType.MATH_ISOLATE: 2048}
+    templates = [APPROX_MODE(ApproximationMode.No)]
+    runtimes = [TILE_COUNT(tile_cnt=4), LOOP_FACTOR(loop_factor=1)]
+    return PerfConfig.build_report_frame(
+        results,
+        code_sizes,
+        formats_config,
+        False,  # unpack_to_dest
+        DestAccumulation.No,  # dest_acc
+        templates,
+        runtimes,
+    )
+
+
+def test_report_columns_conform_to_output_schema():
+    combined = _build(_fake_formats())
+
+    # Every produced column must be a known output-schema column.
+    unknown = sorted(set(combined.columns) - _SCHEMA_NAMES)
+    assert not unknown, (
+        f"PerfConfig produced columns not in perf_wide_schema.OUTPUT_SCHEMA: "
+        f"{unknown}. Either the report changed (add them to OUTPUT_SCHEMA as "
+        f"nullable) or a column is malformed."
+    )
+
+    # No duplicate headers, and the expected columns are present.
+    assert_unique_columns(combined.columns, context="hw-free report")
+    for expected in [
+        "marker",
+        "tile_cnt",
+        "loop_factor",
+        "approx_mode",
+        "formats.input_A",
+        "unpack_to_dest",
+        "dest_acc",
+        "TEXT_SIZE(L1_TO_L1)",
+        stat_column("L1_TO_L1", MEAN),
+        stat_column("MATH_ISOLATE", STD),
+    ]:
+        assert expected in combined.columns, f"missing expected column {expected!r}"
+
+
+def test_report_without_formats_still_conforms():
+    # formats_config=None → no format columns; the rest must still be schema-clean.
+    combined = _build(None)
+    unknown = sorted(set(combined.columns) - _SCHEMA_NAMES)
+    assert not unknown, f"columns not in OUTPUT_SCHEMA: {unknown}"
+    assert not any(c.startswith("formats.") for c in combined.columns)
+
+
+def test_single_row_per_config():
+    # One test configuration -> exactly one sweep row cross-joined onto the markers.
+    combined = _build(_fake_formats())
+    assert len(combined) == 2  # INIT + TILE_LOOP markers

--- a/tt_metal/tt-llk/tests/python_tests/test_perf_report_hw_free.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_perf_report_hw_free.py
@@ -15,13 +15,16 @@ dynamic-param cases that static reading cannot. Needs the LLK env (pandas,
 ttexalens importable) but no hardware.
 """
 
+from pathlib import Path
 from types import SimpleNamespace
 
 import pandas as pd
 from helpers.llk_params import ApproximationMode, DestAccumulation, PerfRunType
-from helpers.perf import PerfConfig
-from helpers.perf_schema import MEAN, STD, assert_unique_columns, stat_column
+from helpers.perf import PerfConfig, PerfReport
+from helpers.perf_schema import MARKER, MEAN, STD, assert_unique_columns, stat_column
 from helpers.perf_wide_schema import OUTPUT_SCHEMA
+from helpers.profiler import Profiler, ProfilerData
+from helpers.test_config import BuildMode, TestConfig
 from helpers.test_variant_parameters import APPROX_MODE, LOOP_FACTOR, TILE_COUNT
 
 _SCHEMA_NAMES = {c.name for c in OUTPUT_SCHEMA}
@@ -110,3 +113,122 @@ def test_single_row_per_config():
     # One test configuration -> exactly one sweep row cross-joined onto the markers.
     combined = _build(_fake_formats())
     assert len(combined) == 2  # INIT + TILE_LOOP markers
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# End-to-end: drive the REAL PerfConfig.run() with every hardware/build seam
+# stubbed and Profiler.get_data returning synthetic events. Unlike the tests
+# above (which hand-build stat frames and only exercise build_report_frame),
+# this runs the real per-run-type loop AND the real stat aggregation
+# (Profiler.STATS_FUNCTION) — the profiler-events -> mean/std math — with no chip.
+# ─────────────────────────────────────────────────────────────────────────────
+
+_MARKERS = (("INIT", 0), ("TILE_LOOP", 1))
+_THREADS = ("unpack", "math", "pack")
+
+
+def _one_run_events(seed: int) -> pd.DataFrame:
+    """One run's raw profiler events: a ZONE_START/ZONE_END pair per (thread,
+    marker), in the raw-event shape Profiler.get_data returns on hardware.
+    Durations vary with ``seed`` so repeated runs give real (non-NaN) mean/std.
+    """
+    rows = []
+    ts = 100
+    for thread in _THREADS:
+        for marker, mid in _MARKERS:
+            dur = 10 + mid * 5 + seed  # distinct per marker, varies per run
+            for etype, offset in (("ZONE_START", 0), ("ZONE_END", dur)):
+                rows.append(
+                    {
+                        "thread": thread,
+                        "type": etype,
+                        MARKER: marker,
+                        "timestamp": ts + offset,
+                        "data": 0,
+                        "marker_id": mid,
+                        "file": "perf.cpp",
+                        "line": 1,
+                    }
+                )
+            ts += dur + 5
+    return pd.DataFrame(rows)
+
+
+def _run_hw_free(monkeypatch, run_types, run_count):
+    """Run PerfConfig.run() end-to-end with no chip; return the produced frame."""
+    # Class-level execution config: execute-only (skip build, don't pytest.skip),
+    # counters off, artefacts dir unused (get_elf_text_size is stubbed).
+    monkeypatch.setattr(TestConfig, "BUILD_MODE", BuildMode.CONSUME)
+    monkeypatch.setattr(TestConfig, "SPEED_OF_LIGHT", False)
+    monkeypatch.setattr(TestConfig, "ENABLE_PERF_COUNTERS", False)
+    monkeypatch.setattr(TestConfig, "ARTEFACTS_DIR", Path("/tmp/hwfree"), raising=False)
+    monkeypatch.setattr(TestConfig, "TENSIX_LOCATION", None, raising=False)
+    monkeypatch.setattr(
+        TestConfig, "get_elf_text_size", staticmethod(lambda path: 4096)
+    )
+
+    # Profiler read seam: synthetic events, a fresh seed per call (call = run).
+    calls = {"n": 0}
+
+    def fake_get_data(test_name, variant_id, location):
+        df = _one_run_events(calls["n"])
+        calls["n"] += 1
+        return ProfilerData(df)
+
+    monkeypatch.setattr(Profiler, "get_data", staticmethod(fake_get_data))
+
+    cfg = PerfConfig(
+        test_name="perf_hwfree",
+        formats=None,  # no format inference; formats path covered by _build tests
+        run_types=run_types,
+        templates=[APPROX_MODE(ApproximationMode.No)],
+        runtimes=[TILE_COUNT(tile_cnt=4), LOOP_FACTOR(loop_factor=1)],
+    )
+    # Device seams on the instance: no-ops.
+    for seam in (
+        "write_runtimes_to_L1",
+        "run_elf_files",
+        "wait_for_tensix_operations_finished",
+    ):
+        monkeypatch.setattr(cfg, seam, lambda *a, **k: None)
+
+    report = PerfReport()
+    cfg.run(report, run_count=run_count)
+    return report._frames[-1]
+
+
+def test_run_end_to_end_conforms_to_output_schema(monkeypatch):
+    frame = _run_hw_free(
+        monkeypatch,
+        [PerfRunType.MATH_ISOLATE, PerfRunType.UNPACK_ISOLATE],
+        run_count=2,
+    )
+
+    unknown = sorted(set(frame.columns) - _SCHEMA_NAMES)
+    assert not unknown, f"run() produced columns not in OUTPUT_SCHEMA: {unknown}"
+
+    assert_unique_columns(frame.columns, context="hw-free run()")
+    for expected in [
+        MARKER,
+        "approx_mode",
+        "tile_cnt",
+        "loop_factor",
+        stat_column("MATH_ISOLATE", MEAN),
+        stat_column("UNPACK_ISOLATE", MEAN),
+    ]:
+        assert expected in frame.columns, f"missing expected column {expected!r}"
+
+
+def test_run_multi_run_populates_std_columns(monkeypatch):
+    # run_count>=2 -> std is defined per marker, so the std column is kept AND full.
+    frame = _run_hw_free(monkeypatch, [PerfRunType.MATH_ISOLATE], run_count=2)
+    std_col = stat_column("MATH_ISOLATE", STD)
+    assert std_col in frame.columns, "multi-run should emit the std column"
+    assert frame[std_col].notna().all(), "std must be populated with >=2 samples"
+
+
+def test_run_single_run_drops_empty_std(monkeypatch):
+    # run_count==1 -> std is NaN for every marker, so the std column is dropped.
+    frame = _run_hw_free(monkeypatch, [PerfRunType.MATH_ISOLATE], run_count=1)
+    assert stat_column("MATH_ISOLATE", MEAN) in frame.columns
+    assert stat_column("MATH_ISOLATE", STD) not in frame.columns

--- a/tt_metal/tt-llk/tests/python_tests/test_perf_report_hw_free.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_perf_report_hw_free.py
@@ -4,15 +4,16 @@
 
 """Hardware-free test of PerfConfig report generation (#51244).
 
-Drives ``PerfConfig.build_report_frame`` — the pure report-assembly seam of
-``run()`` — with synthetic per-run-type results and parameters, so the report is
-produced with **no chip**. Then it checks that the produced column set conforms
-to the shared output schema (``perf_wide_schema.OUTPUT_SCHEMA``).
+Runs the real report code with no chip and checks the produced columns against
+perf_wide_schema.OUTPUT_SCHEMA. Two levels:
+  - build_report_frame directly, with synthetic per-run-type stat frames;
+  - the full PerfConfig.run(), with the device/build seams stubbed and
+    Profiler.get_data returning synthetic events (so the real stat aggregation
+    runs too).
 
-This is the exact validation the static gate only approximates: the columns come
-from the real assembly code path, so it catches the optional-None and
-dynamic-param cases that static reading cannot. Needs the LLK env (pandas,
-ttexalens importable) but no hardware.
+Unlike the static gate, the columns come from the real code path, so this catches
+the optional-None and dynamic-param cases static reading can't. Needs the LLK env
+(pandas, ttexalens importable) but no hardware.
 """
 
 from pathlib import Path
@@ -115,13 +116,10 @@ def test_single_row_per_config():
     assert len(combined) == 2  # INIT + TILE_LOOP markers
 
 
-# ─────────────────────────────────────────────────────────────────────────────
-# End-to-end: drive the REAL PerfConfig.run() with every hardware/build seam
-# stubbed and Profiler.get_data returning synthetic events. Unlike the tests
-# above (which hand-build stat frames and only exercise build_report_frame),
-# this runs the real per-run-type loop AND the real stat aggregation
-# (Profiler.STATS_FUNCTION) — the profiler-events -> mean/std math — with no chip.
-# ─────────────────────────────────────────────────────────────────────────────
+# End-to-end: run the real PerfConfig.run() with the device/build seams stubbed
+# and Profiler.get_data returning synthetic events. The tests above hand-build
+# stat frames; these also run the real stat aggregation (Profiler.STATS_FUNCTION,
+# i.e. the profiler-events -> mean/std math), still with no chip.
 
 _MARKERS = (("INIT", 0), ("TILE_LOOP", 1))
 _THREADS = ("unpack", "math", "pack")

--- a/tt_metal/tt-llk/tests/python_tests/test_perf_report_hw_free.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_perf_report_hw_free.py
@@ -1,0 +1,239 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Hardware-free test of PerfConfig report generation (#51244).
+
+Runs the real report code with no chip and checks the produced columns against
+perf_wide_schema.OUTPUT_SCHEMA. Two levels:
+  - build_report_frame directly, with synthetic per-run-type stat frames;
+  - the full PerfConfig.run(), with the device/build seams stubbed and
+    Profiler.get_data returning synthetic events (so the real stat aggregation
+    runs too).
+
+Unlike the static gate, the columns come from the real code path, so this catches
+the optional-None and dynamic-param cases static reading can't. Needs the LLK env
+(pandas, ttexalens importable) but no hardware.
+"""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pandas as pd
+from helpers.llk_params import ApproximationMode, DestAccumulation, PerfRunType
+from helpers.perf import PerfConfig, PerfReport
+from helpers.perf_schema import MARKER, MEAN, STD, assert_unique_columns, stat_column
+from helpers.perf_wide_schema import DROPPED_COLUMNS, OUTPUT_SCHEMA
+from helpers.profiler import Profiler, ProfilerData
+from helpers.test_config import BuildMode, TestConfig
+from helpers.test_variant_parameters import APPROX_MODE, LOOP_FACTOR, TILE_COUNT
+
+_SCHEMA_NAMES = {c.name for c in OUTPUT_SCHEMA}
+
+
+def _fake_formats():
+    """A stand-in for a formats_config entry: only the attributes the assembly reads."""
+    fmt = SimpleNamespace(
+        unpack_A_src="Float16_b",
+        unpack_B_src="Float16_b",
+        unpack_A_dst="Float16_b",
+        unpack_B_dst="Float16_b",
+        output_format="Float16_b",
+        sfpu_math="Float16_b",
+    )
+    return [fmt]
+
+
+def _timing_result(run_type: PerfRunType) -> pd.DataFrame:
+    """What get_stats would emit for one run type: marker + mean/std timing columns."""
+    rt = run_type.name
+    return pd.DataFrame(
+        {
+            "marker": ["INIT", "TILE_LOOP"],
+            stat_column(rt, MEAN): [10.0, 20.0],
+            stat_column(rt, STD): [1.0, 2.0],
+        }
+    )
+
+
+def _build(formats_config):
+    results = [
+        _timing_result(PerfRunType.L1_TO_L1),
+        _timing_result(PerfRunType.MATH_ISOLATE),
+    ]
+    code_sizes = {PerfRunType.L1_TO_L1: 4096, PerfRunType.MATH_ISOLATE: 2048}
+    templates = [APPROX_MODE(ApproximationMode.No)]
+    runtimes = [TILE_COUNT(tile_cnt=4), LOOP_FACTOR(loop_factor=1)]
+    return PerfConfig.build_report_frame(
+        results,
+        code_sizes,
+        formats_config,
+        False,  # unpack_to_dest
+        DestAccumulation.No,  # dest_acc
+        templates,
+        runtimes,
+    )
+
+
+def test_report_columns_conform_to_output_schema():
+    combined = _build(_fake_formats())
+
+    # Every produced column must be a known output-schema column.
+    unknown = sorted(set(combined.columns) - _SCHEMA_NAMES - DROPPED_COLUMNS)
+    assert not unknown, (
+        f"PerfConfig produced columns not in perf_wide_schema.OUTPUT_SCHEMA: "
+        f"{unknown}. Either the report changed (add them to OUTPUT_SCHEMA as "
+        f"nullable) or a column is malformed."
+    )
+
+    # No duplicate headers, and the expected columns are present.
+    assert_unique_columns(combined.columns, context="hw-free report")
+    for expected in [
+        "marker",
+        "tile_cnt",
+        "loop_factor",
+        "approx_mode",
+        "formats.input_A",
+        "unpack_to_dest",
+        "dest_acc",
+        "TEXT_SIZE(L1_TO_L1)",
+        stat_column("L1_TO_L1", MEAN),
+        stat_column("MATH_ISOLATE", STD),
+    ]:
+        assert expected in combined.columns, f"missing expected column {expected!r}"
+
+
+def test_report_without_formats_still_conforms():
+    # formats_config=None → no format columns; the rest must still be schema-clean.
+    combined = _build(None)
+    unknown = sorted(set(combined.columns) - _SCHEMA_NAMES - DROPPED_COLUMNS)
+    assert not unknown, f"columns not in OUTPUT_SCHEMA: {unknown}"
+    assert not any(c.startswith("formats.") for c in combined.columns)
+
+
+def test_single_row_per_config():
+    # One test configuration -> exactly one sweep row cross-joined onto the markers.
+    combined = _build(_fake_formats())
+    assert len(combined) == 2  # INIT + TILE_LOOP markers
+
+
+# End-to-end: run the real PerfConfig.run() with the device/build seams stubbed
+# and Profiler.get_data returning synthetic events. The tests above hand-build
+# stat frames; these also run the real stat aggregation (Profiler.STATS_FUNCTION,
+# i.e. the profiler-events -> mean/std math), still with no chip.
+
+_MARKERS = (("INIT", 0), ("TILE_LOOP", 1))
+_THREADS = ("unpack", "math", "pack")
+
+
+def _one_run_events(seed: int) -> pd.DataFrame:
+    """One run's raw profiler events: a ZONE_START/ZONE_END pair per (thread,
+    marker), in the raw-event shape Profiler.get_data returns on hardware.
+    Durations vary with ``seed`` so repeated runs give real (non-NaN) mean/std.
+    """
+    rows = []
+    ts = 100
+    for thread in _THREADS:
+        for marker, mid in _MARKERS:
+            dur = 10 + mid * 5 + seed  # distinct per marker, varies per run
+            for etype, offset in (("ZONE_START", 0), ("ZONE_END", dur)):
+                rows.append(
+                    {
+                        "thread": thread,
+                        "type": etype,
+                        MARKER: marker,
+                        "timestamp": ts + offset,
+                        "data": 0,
+                        "marker_id": mid,
+                        "file": "perf.cpp",
+                        "line": 1,
+                    }
+                )
+            ts += dur + 5
+    return pd.DataFrame(rows)
+
+
+def _run_hw_free(monkeypatch, run_types, run_count):
+    """Run PerfConfig.run() end-to-end with no chip; return the produced frame."""
+    # Class-level execution config: execute-only (skip build, don't pytest.skip),
+    # counters off, artefacts dir unused (get_elf_text_size is stubbed).
+    monkeypatch.setattr(TestConfig, "BUILD_MODE", BuildMode.CONSUME)
+    monkeypatch.setattr(TestConfig, "SPEED_OF_LIGHT", False)
+    monkeypatch.setattr(TestConfig, "ENABLE_PERF_COUNTERS", False)
+    monkeypatch.setattr(TestConfig, "ARTEFACTS_DIR", Path("/tmp/hwfree"), raising=False)
+    monkeypatch.setattr(TestConfig, "TENSIX_LOCATION", None, raising=False)
+    monkeypatch.setattr(
+        TestConfig, "get_elf_text_size", staticmethod(lambda path: 4096)
+    )
+    # run() bumps the PerfConfig.TEST_COUNTER ClassVar, which the autouse
+    # perf_report fixture reads to decide whether to write a CSV. This module
+    # carries no perf marker, so it runs in the ordinary CI session; restore the
+    # counter on teardown so we do not leave empty perf_data artefacts for every
+    # later module on the worker (register it with monkeypatch to auto-restore).
+    monkeypatch.setattr(PerfConfig, "TEST_COUNTER", PerfConfig.TEST_COUNTER)
+
+    # Profiler read seam: synthetic events, a fresh seed per call (call = run).
+    calls = {"n": 0}
+
+    def fake_get_data(test_name, variant_id, location):
+        df = _one_run_events(calls["n"])
+        calls["n"] += 1
+        return ProfilerData(df)
+
+    monkeypatch.setattr(Profiler, "get_data", staticmethod(fake_get_data))
+
+    cfg = PerfConfig(
+        test_name="perf_hwfree",
+        formats=None,  # no format inference; formats path covered by _build tests
+        run_types=run_types,
+        templates=[APPROX_MODE(ApproximationMode.No)],
+        runtimes=[TILE_COUNT(tile_cnt=4), LOOP_FACTOR(loop_factor=1)],
+    )
+    # Device seams on the instance: no-ops.
+    for seam in (
+        "write_runtimes_to_L1",
+        "run_elf_files",
+        "wait_for_tensix_operations_finished",
+    ):
+        monkeypatch.setattr(cfg, seam, lambda *a, **k: None)
+
+    report = PerfReport()
+    cfg.run(report, run_count=run_count)
+    return report._frames[-1]
+
+
+def test_run_end_to_end_conforms_to_output_schema(monkeypatch):
+    frame = _run_hw_free(
+        monkeypatch,
+        [PerfRunType.MATH_ISOLATE, PerfRunType.UNPACK_ISOLATE],
+        run_count=2,
+    )
+
+    unknown = sorted(set(frame.columns) - _SCHEMA_NAMES - DROPPED_COLUMNS)
+    assert not unknown, f"run() produced columns not in OUTPUT_SCHEMA: {unknown}"
+
+    assert_unique_columns(frame.columns, context="hw-free run()")
+    for expected in [
+        MARKER,
+        "approx_mode",
+        "tile_cnt",
+        "loop_factor",
+        stat_column("MATH_ISOLATE", MEAN),
+        stat_column("UNPACK_ISOLATE", MEAN),
+    ]:
+        assert expected in frame.columns, f"missing expected column {expected!r}"
+
+
+def test_run_multi_run_populates_std_columns(monkeypatch):
+    # run_count>=2 -> std is defined per marker, so the std column is kept AND full.
+    frame = _run_hw_free(monkeypatch, [PerfRunType.MATH_ISOLATE], run_count=2)
+    std_col = stat_column("MATH_ISOLATE", STD)
+    assert std_col in frame.columns, "multi-run should emit the std column"
+    assert frame[std_col].notna().all(), "std must be populated with >=2 samples"
+
+
+def test_run_single_run_drops_empty_std(monkeypatch):
+    # run_count==1 -> std is NaN for every marker, so the std column is dropped.
+    frame = _run_hw_free(monkeypatch, [PerfRunType.MATH_ISOLATE], run_count=1)
+    assert stat_column("MATH_ISOLATE", MEAN) in frame.columns
+    assert stat_column("MATH_ISOLATE", STD) not in frame.columns

--- a/tt_metal/tt-llk/tests/python_tests/test_perf_report_hw_free.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_perf_report_hw_free.py
@@ -165,6 +165,12 @@ def _run_hw_free(monkeypatch, run_types, run_count):
     monkeypatch.setattr(
         TestConfig, "get_elf_text_size", staticmethod(lambda path: 4096)
     )
+    # run() bumps the PerfConfig.TEST_COUNTER ClassVar, which the autouse
+    # perf_report fixture reads to decide whether to write a CSV. This module
+    # carries no perf marker, so it runs in the ordinary CI session; restore the
+    # counter on teardown so we do not leave empty perf_data artefacts for every
+    # later module on the worker (register it with monkeypatch to auto-restore).
+    monkeypatch.setattr(PerfConfig, "TEST_COUNTER", PerfConfig.TEST_COUNTER)
 
     # Profiler read seam: synthetic events, a fresh seed per call (call = run).
     calls = {"n": 0}

--- a/tt_metal/tt-llk/tests/python_tests/test_perf_report_hw_free.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_perf_report_hw_free.py
@@ -23,7 +23,7 @@ import pandas as pd
 from helpers.llk_params import ApproximationMode, DestAccumulation, PerfRunType
 from helpers.perf import PerfConfig, PerfReport
 from helpers.perf_schema import MARKER, MEAN, STD, assert_unique_columns, stat_column
-from helpers.perf_wide_schema import OUTPUT_SCHEMA
+from helpers.perf_wide_schema import DROPPED_COLUMNS, OUTPUT_SCHEMA
 from helpers.profiler import Profiler, ProfilerData
 from helpers.test_config import BuildMode, TestConfig
 from helpers.test_variant_parameters import APPROX_MODE, LOOP_FACTOR, TILE_COUNT
@@ -79,7 +79,7 @@ def test_report_columns_conform_to_output_schema():
     combined = _build(_fake_formats())
 
     # Every produced column must be a known output-schema column.
-    unknown = sorted(set(combined.columns) - _SCHEMA_NAMES)
+    unknown = sorted(set(combined.columns) - _SCHEMA_NAMES - DROPPED_COLUMNS)
     assert not unknown, (
         f"PerfConfig produced columns not in perf_wide_schema.OUTPUT_SCHEMA: "
         f"{unknown}. Either the report changed (add them to OUTPUT_SCHEMA as "
@@ -106,7 +106,7 @@ def test_report_columns_conform_to_output_schema():
 def test_report_without_formats_still_conforms():
     # formats_config=None → no format columns; the rest must still be schema-clean.
     combined = _build(None)
-    unknown = sorted(set(combined.columns) - _SCHEMA_NAMES)
+    unknown = sorted(set(combined.columns) - _SCHEMA_NAMES - DROPPED_COLUMNS)
     assert not unknown, f"columns not in OUTPUT_SCHEMA: {unknown}"
     assert not any(c.startswith("formats.") for c in combined.columns)
 
@@ -209,7 +209,7 @@ def test_run_end_to_end_conforms_to_output_schema(monkeypatch):
         run_count=2,
     )
 
-    unknown = sorted(set(frame.columns) - _SCHEMA_NAMES)
+    unknown = sorted(set(frame.columns) - _SCHEMA_NAMES - DROPPED_COLUMNS)
     assert not unknown, f"run() produced columns not in OUTPUT_SCHEMA: {unknown}"
 
     assert_unique_columns(frame.columns, context="hw-free run()")

--- a/tt_metal/tt-llk/tests/python_tests/test_perf_report_hw_free.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_perf_report_hw_free.py
@@ -39,6 +39,7 @@ def _fake_formats():
         unpack_A_dst="Float16_b",
         unpack_B_dst="Float16_b",
         output_format="Float16_b",
+        sfpu_math="Float16_b",
     )
     return [fmt]
 


### PR DESCRIPTION
Define the shared wide schema for LLK performance reports as an import-free Python module: 68 nullable report columns observed in real nightly output (WH+BH) plus a mandatory metadata block (commit, arch, run id, timestamp, pipeline, test_name, marker). One row = one test config in one execution context; each test fills the columns it uses and NULLs the rest.

v1 foundation on purpose — new columns (Quasar, counters/metrics, new params) are added later as nullable, which is non-breaking. Naming canonicalization and constant-column pruning are deliberately deferred.

Part of #51245 / #51249.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nstojictt/perf-wide-schema)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nstojictt/perf-wide-schema)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nstojictt/perf-wide-schema)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nstojictt/perf-wide-schema)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=nstojictt/perf-wide-schema)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:nstojictt/perf-wide-schema)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nstojictt/perf-wide-schema)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nstojictt/perf-wide-schema)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nstojictt/perf-wide-schema)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nstojictt/perf-wide-schema)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nstojictt/perf-wide-schema)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nstojictt/perf-wide-schema)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nstojictt/perf-wide-schema)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nstojictt/perf-wide-schema)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nstojictt/perf-wide-schema)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nstojictt/perf-wide-schema)