### PR TITLE
Use pytest-managed temp paths for multi-device as_tensor cache tests

### DIFF
--- a/tests/ttnn/unit_tests/base_functionality/test_multi_device.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_multi_device.py
@@ -5,7 +5,6 @@ import torch
 import typing
 import pytest
 import ttnn
-import tempfile
 from loguru import logger
 from tests.ttnn.utils_for_testing import assert_with_pcc
 from models.common.utility_functions import is_single_chip, ti_skip
@@ -333,7 +332,7 @@ def test_multi_device_data_parallel_matmul_op(mesh_device):
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT])
 @pytest.mark.parametrize("memory_config", [ttnn.DRAM_MEMORY_CONFIG])
 @pytest.mark.parametrize("dtype", [ttnn.bfloat8_b, ttnn.bfloat4_b])
-def test_multi_device_as_tensor_api(mesh_device, layout, memory_config, dtype):
+def test_multi_device_as_tensor_api(mesh_device, layout, memory_config, dtype, tmp_path):
     """Multidevice API: Data Parallel on matmul using cached tensor"""
     torch.manual_seed(0)
     torch_input_a_tensor = torch.rand((mesh_device.get_num_devices(), 1, 32, 32), dtype=torch.bfloat16)
@@ -349,36 +348,36 @@ def test_multi_device_as_tensor_api(mesh_device, layout, memory_config, dtype):
         mesh_mapper=ShardTensorToMesh(mesh_device, dim=0),
     )
 
-    with tempfile.NamedTemporaryFile() as temp_file:
-        save_tensor = ttnn.as_tensor(
-            torch_input_b_tensor,
-            dtype=dtype,
-            layout=layout,
-            device=mesh_device,
-            memory_config=memory_config,
-            cache_file_name=f"{temp_file.name}.weight",
-            mesh_mapper=ReplicateTensorToMesh(mesh_device),
-        )
+    cache_file_name = tmp_path / "weight"
+    save_tensor = ttnn.as_tensor(
+        torch_input_b_tensor,
+        dtype=dtype,
+        layout=layout,
+        device=mesh_device,
+        memory_config=memory_config,
+        cache_file_name=cache_file_name,
+        mesh_mapper=ReplicateTensorToMesh(mesh_device),
+    )
 
-        ttnn_input_b_tensor = ttnn.as_tensor(
-            torch_input_b_tensor,
-            dtype=dtype,
-            layout=layout,
-            device=mesh_device,
-            memory_config=memory_config,
-            cache_file_name=f"{temp_file.name}.weight",
-            mesh_mapper=ReplicateTensorToMesh(mesh_device),
-        )
+    ttnn_input_b_tensor = ttnn.as_tensor(
+        torch_input_b_tensor,
+        dtype=dtype,
+        layout=layout,
+        device=mesh_device,
+        memory_config=memory_config,
+        cache_file_name=cache_file_name,
+        mesh_mapper=ReplicateTensorToMesh(mesh_device),
+    )
 
-        ttnn_output_tensor = ttnn_input_a_tensor @ ttnn_input_b_tensor
+    ttnn_output_tensor = ttnn_input_a_tensor @ ttnn_input_b_tensor
 
-        ttnn_torch_output_tensor = ttnn.to_torch(
-            ttnn_output_tensor, mesh_composer=ConcatMeshToTensor(mesh_device, dim=0)
-        )
-        if dtype == ttnn.bfloat4_b:
-            assert_with_pcc(ttnn_torch_output_tensor, torch_output_golden, pcc=0.87)
-        else:
-            assert_with_pcc(ttnn_torch_output_tensor, torch_output_golden, pcc=0.991)
+    ttnn_torch_output_tensor = ttnn.to_torch(
+        ttnn_output_tensor, mesh_composer=ConcatMeshToTensor(mesh_device, dim=0)
+    )
+    if dtype == ttnn.bfloat4_b:
+        assert_with_pcc(ttnn_torch_output_tensor, torch_output_golden, pcc=0.87)
+    else:
+        assert_with_pcc(ttnn_torch_output_tensor, torch_output_golden, pcc=0.991)
 
 
 @pytest.mark.parametrize(
@@ -389,32 +388,32 @@ def test_multi_device_as_tensor_api(mesh_device, layout, memory_config, dtype):
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT])
 @pytest.mark.parametrize("memory_config", [ttnn.DRAM_MEMORY_CONFIG])
 @pytest.mark.parametrize("dtype", [ttnn.bfloat8_b, ttnn.bfloat4_b])
-def test_multi_device_as_tensor_api_sharded_tensor(mesh_device, layout, memory_config, dtype):
+def test_multi_device_as_tensor_api_sharded_tensor(mesh_device, layout, memory_config, dtype, tmp_path):
     """Multidevice API: Data Parallel on matmul using cached tensor"""
     input_tensor = torch.rand((mesh_device.get_num_devices(), 1, 32, 32), dtype=torch.bfloat16)
 
-    with tempfile.NamedTemporaryFile() as temp_file:
-        save_tensor = ttnn.as_tensor(
-            input_tensor,
-            dtype=dtype,
-            layout=layout,
-            device=mesh_device,
-            memory_config=memory_config,
-            cache_file_name=f"{temp_file.name}.weight",
-            mesh_mapper=ShardTensorToMesh(mesh_device, dim=0),
-        )
-        load_tensor = ttnn.as_tensor(
-            input_tensor,
-            dtype=dtype,
-            layout=layout,
-            device=mesh_device,
-            memory_config=memory_config,
-            cache_file_name=f"{temp_file.name}.weight",
-            mesh_mapper=ShardTensorToMesh(mesh_device, dim=0),
-        )
-        torch_loaded_tensor = ttnn.to_torch(load_tensor, mesh_composer=ConcatMeshToTensor(mesh_device, dim=0))
-        expected_pcc = 0.98 if dtype == ttnn.bfloat4_b else 0.99
-        assert_with_pcc(input_tensor, torch_loaded_tensor, pcc=expected_pcc)
+    cache_file_name = tmp_path / "weight"
+    save_tensor = ttnn.as_tensor(
+        input_tensor,
+        dtype=dtype,
+        layout=layout,
+        device=mesh_device,
+        memory_config=memory_config,
+        cache_file_name=cache_file_name,
+        mesh_mapper=ShardTensorToMesh(mesh_device, dim=0),
+    )
+    load_tensor = ttnn.as_tensor(
+        input_tensor,
+        dtype=dtype,
+        layout=layout,
+        device=mesh_device,
+        memory_config=memory_config,
+        cache_file_name=cache_file_name,
+        mesh_mapper=ShardTensorToMesh(mesh_device, dim=0),
+    )
+    torch_loaded_tensor = ttnn.to_torch(load_tensor, mesh_composer=ConcatMeshToTensor(mesh_device, dim=0))
+    expected_pcc = 0.98 if dtype == ttnn.bfloat4_b else 0.99
+    assert_with_pcc(input_tensor, torch_loaded_tensor, pcc=expected_pcc)
 
 
 def test_tensor_file_extension_validation(tmp_path, expect_error):

--- a/tests/ttnn/unit_tests/base_functionality/test_multi_device.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_multi_device.py
@@ -371,9 +371,7 @@ def test_multi_device_as_tensor_api(mesh_device, layout, memory_config, dtype, t
 
     ttnn_output_tensor = ttnn_input_a_tensor @ ttnn_input_b_tensor
 
-    ttnn_torch_output_tensor = ttnn.to_torch(
-        ttnn_output_tensor, mesh_composer=ConcatMeshToTensor(mesh_device, dim=0)
-    )
+    ttnn_torch_output_tensor = ttnn.to_torch(ttnn_output_tensor, mesh_composer=ConcatMeshToTensor(mesh_device, dim=0))
     if dtype == ttnn.bfloat4_b:
         assert_with_pcc(ttnn_torch_output_tensor, torch_output_golden, pcc=0.87)
     else:


### PR DESCRIPTION
### PR Category
Test Only

### Summary
The multi-device `as_tensor` cache tests used `NamedTemporaryFile().name` as a cache filename prefix, but `ttnn.as_tensor` appends dtype/layout metadata and writes a separate `.tensorbin` cache file next to that prefix. The `NamedTemporaryFile` context only removed the original empty temp file, leaving files like `/tmp/tmp*.weight_dtype_BFLOAT8_B_layout_TILE.tensorbin` behind after test runs. This change switches the two cache tests to pytest's `tmp_path` fixture and passes a stable cache prefix inside that per-test directory, so the generated `.tensorbin` files remain under pytest-managed temporary storage instead of leaking as top-level `/tmp` artifacts. Verified on WH ttsim by running the two affected parametrized tests; all 8 cases passed and no top-level `/tmp/tmp*.tensorbin` files were created.

### Notes for reviewers
Diff is mostly whitespace, it's a very small diff if you look at it with git diff/show -b.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mcraighead/pytest-tensor-temps)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mcraighead/pytest-tensor-temps)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mcraighead/pytest-tensor-temps)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mcraighead/pytest-tensor-temps)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mcraighead/pytest-tensor-temps)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mcraighead/pytest-tensor-temps)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mcraighead/pytest-tensor-temps)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mcraighead/pytest-tensor-temps)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mcraighead/pytest-tensor-temps)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mcraighead/pytest-tensor-temps)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mcraighead/pytest-tensor-temps)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mcraighead/pytest-tensor-temps)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mcraighead/pytest-tensor-temps)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mcraighead/pytest-tensor-temps)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mcraighead/pytest-tensor-temps)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mcraighead/pytest-tensor-temps)