### PR TITLE
Hide Noc zeroing APIs on Quasar V1

### DIFF
--- a/tt_metal/hw/inc/api/core_local_mem.h
+++ b/tt_metal/hw/inc/api/core_local_mem.h
@@ -199,10 +199,12 @@ struct noc_traits_t<CoreLocalMem<T, AddressType>> {
 
 template <typename T, typename AddressType>
 inline constexpr bool noc_zero_l1_endpoint_v<CoreLocalMem<T, AddressType>> = true;
-#ifdef ARCH_QUASAR
+#if defined(ARCH_QUASAR) && !defined(NOC_API_V1)
 #include "internal/tt-2xx/noc_zero_l1.inl"
-#else
+#elif !defined(ARCH_QUASAR)
 #include "internal/tt-1xx/noc_zero_l1.inl"
 #endif
+#if !defined(ARCH_QUASAR) || !defined(NOC_API_V1)
 #include "internal/noc_zero_dram.inl"
+#endif
 #endif  // !defined(COMPILE_FOR_TRISC)

--- a/tt_metal/hw/inc/api/dataflow/circular_buffer.h
+++ b/tt_metal/hw/inc/api/dataflow/circular_buffer.h
@@ -258,12 +258,12 @@ private:
 template <>
 inline constexpr bool noc_zero_l1_endpoint_v<CircularBuffer> = true;
 
-#if defined(ARCH_QUASAR) && defined(NOC_API_V2)
+#if defined(ARCH_QUASAR) && !defined(NOC_API_V1)
 #include "internal/tt-2xx/noc_zero_l1.inl"
-#elif !defined(ARCH_QUASAR)
+#else
 #include "internal/tt-1xx/noc_zero_l1.inl"
 #endif
-#if !defined(ARCH_QUASAR) || defined(NOC_API_V2)
+#if !defined(ARCH_QUASAR) || !defined(NOC_API_V1)
 #include "internal/noc_zero_dram.inl"
 #endif
 

--- a/tt_metal/hw/inc/api/dataflow/circular_buffer.h
+++ b/tt_metal/hw/inc/api/dataflow/circular_buffer.h
@@ -258,11 +258,13 @@ private:
 template <>
 inline constexpr bool noc_zero_l1_endpoint_v<CircularBuffer> = true;
 
-#ifdef ARCH_QUASAR
+#if defined(ARCH_QUASAR) && defined(NOC_API_V2)
 #include "internal/tt-2xx/noc_zero_l1.inl"
-#else
+#elif !defined(ARCH_QUASAR)
 #include "internal/tt-1xx/noc_zero_l1.inl"
 #endif
+#if !defined(ARCH_QUASAR) || defined(NOC_API_V2)
 #include "internal/noc_zero_dram.inl"
+#endif
 
 #endif  // !COMPILE_FOR_TRISC

--- a/tt_metal/hw/inc/api/dataflow/circular_buffer.h
+++ b/tt_metal/hw/inc/api/dataflow/circular_buffer.h
@@ -256,11 +256,13 @@ private:
     }
 };
 
-#ifdef ARCH_QUASAR
+#if defined(ARCH_QUASAR) && defined(NOC_API_V2)
 #include "internal/tt-2xx/noc_zero_l1.inl"
-#else
+#elif !defined(ARCH_QUASAR)
 #include "internal/tt-1xx/noc_zero_l1.inl"
 #endif
+#if !defined(ARCH_QUASAR) || defined(NOC_API_V2)
 #include "internal/noc_zero_dram.inl"
+#endif
 
 #endif  // !COMPILE_FOR_TRISC

--- a/tt_metal/hw/inc/api/dataflow/dataflow_buffer.h
+++ b/tt_metal/hw/inc/api/dataflow/dataflow_buffer.h
@@ -488,19 +488,19 @@ inline constexpr bool noc_zero_l1_endpoint_v<DataflowBuffer> = true;
 #endif
 
 // Arch-specific _impl bodies for DataflowBuffer member functions
-#ifdef ARCH_QUASAR
+#if defined(ARCH_QUASAR) && !defined(NOC_API_V1)
 #include "internal/tt-2xx/dataflow_buffer.inl"
 #else
 #include "internal/tt-1xx/dataflow_buffer.inl"
 #endif
 
 #ifndef COMPILE_FOR_TRISC
-#if defined(ARCH_QUASAR) && defined(NOC_API_V2)
+#if defined(ARCH_QUASAR) && !defined(NOC_API_V1)
 #include "internal/tt-2xx/noc_zero_l1.inl"
-#elif !defined(ARCH_QUASAR)
+#else
 #include "internal/tt-1xx/noc_zero_l1.inl"
 #endif
-#if !defined(ARCH_QUASAR) || defined(NOC_API_V2)
+#if !defined(ARCH_QUASAR) || !defined(NOC_API_V1)
 #include "internal/noc_zero_dram.inl"
 #endif
 #endif

--- a/tt_metal/hw/inc/api/dataflow/dataflow_buffer.h
+++ b/tt_metal/hw/inc/api/dataflow/dataflow_buffer.h
@@ -495,10 +495,12 @@ inline constexpr bool noc_zero_l1_endpoint_v<DataflowBuffer> = true;
 #endif
 
 #ifndef COMPILE_FOR_TRISC
-#ifdef ARCH_QUASAR
+#if defined(ARCH_QUASAR) && defined(NOC_API_V2)
 #include "internal/tt-2xx/noc_zero_l1.inl"
-#else
+#elif !defined(ARCH_QUASAR)
 #include "internal/tt-1xx/noc_zero_l1.inl"
 #endif
+#if !defined(ARCH_QUASAR) || defined(NOC_API_V2)
 #include "internal/noc_zero_dram.inl"
+#endif
 #endif

--- a/tt_metal/hw/inc/api/dataflow/dataflow_buffer.h
+++ b/tt_metal/hw/inc/api/dataflow/dataflow_buffer.h
@@ -413,10 +413,12 @@ struct noc_traits_t<DataflowBuffer> {
 #endif
 
 #ifndef COMPILE_FOR_TRISC
-#ifdef ARCH_QUASAR
+#if defined(ARCH_QUASAR) && defined(NOC_API_V2)
 #include "internal/tt-2xx/noc_zero_l1.inl"
-#else
+#elif !defined(ARCH_QUASAR)
 #include "internal/tt-1xx/noc_zero_l1.inl"
 #endif
+#if !defined(ARCH_QUASAR) || defined(NOC_API_V2)
 #include "internal/noc_zero_dram.inl"
+#endif
 #endif

--- a/tt_metal/hw/inc/api/dataflow/noc.h
+++ b/tt_metal/hw/inc/api/dataflow/noc.h
@@ -721,6 +721,7 @@ public:
      */
     void async_full_barrier() const { noc_async_full_barrier(noc_id_); }
 
+#if !defined(ARCH_QUASAR) || defined(NOC_API_V2)
     /**
      * @brief Zeroes a local-L1 destination buffer (overload 1).
      *
@@ -818,6 +819,7 @@ public:
      * @see async_write_zeros (overload 2).
      */
     void write_zeros_dram_barrier() const;
+#endif
 
 #ifdef ARCH_QUASAR
     /**

--- a/tt_metal/hw/inc/api/dataflow/noc.h
+++ b/tt_metal/hw/inc/api/dataflow/noc.h
@@ -721,7 +721,6 @@ public:
      */
     void async_full_barrier() const { noc_async_full_barrier(noc_id_); }
 
-#if !defined(ARCH_QUASAR) || defined(NOC_API_V2)
     /**
      * @brief Zeroes a local-L1 destination buffer (overload 1).
      *
@@ -819,7 +818,6 @@ public:
      * @see async_write_zeros (overload 2).
      */
     void write_zeros_dram_barrier() const;
-#endif
 
 #ifdef ARCH_QUASAR
     /**

--- a/tt_metal/hw/inc/api/dataflow/noc.h
+++ b/tt_metal/hw/inc/api/dataflow/noc.h
@@ -685,6 +685,7 @@ public:
      */
     void async_full_barrier() const { noc_async_full_barrier(noc_id_); }
 
+#if !defined(ARCH_QUASAR) || defined(NOC_API_V2)
     /**
      * @brief Zeroes a local-L1 destination buffer (overload 1).
      *
@@ -761,6 +762,7 @@ public:
      * @see async_write_zeros (overload 2).
      */
     void write_zeros_dram_barrier() const;
+#endif
 
 #ifdef ARCH_QUASAR
     /**

--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/noc_nonblocking_api.h
@@ -42,11 +42,10 @@
 //
 // =============================================================================
 
-#define NOC_API_V2
-
-#if !defined(NOC_API_V2)
+#if defined(NOC_API_V1)
 #include "noc_nonblocking_api_v1.h"
 #else
+#define NOC_API_V2
 #include "noc_nonblocking_api_v2.h"
 
 // Legacy per-processor cmd_buf aliases for dataflow_cmd_bufs.h compatibility.

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -217,6 +217,10 @@ void JitBuildEnv::init(
         this->defines_ += "-D" + device_kernel_define.first + "=" + device_kernel_define.second + " ";
     }
     this->defines_ += "-DTENSIX_FIRMWARE -DLOCAL_MEM_EN=0 ";
+    if (this->arch_ == tt::ARCH::QUASAR && rtoptions.get_simulator_enabled() &&
+        rtoptions.get_simulator_path().extension() == ".so") {
+        this->defines_ += "-DNOC_API_V1 ";
+    }
 
     if (rtoptions.get_profiler_enabled()) {
         uint32_t profiler_options = 1;


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Quasar currently needs to build against the V1 NoC API, but the `Noc::async_write_zeros` implementation included by the public dataflow headers is Quasar V2-specific: it uses overlay iDMA zero-mode helpers such as `noc_local_xy()` and `init_wr_cmd_buf()` that are only provided by `noc_nonblocking_api_v2.h`. Because the implementation was included unconditionally for Quasar dataflow kernels, unrelated kernels that merely included `dataflow_buffer.h` could fail JIT compilation under V1. This change guards the zeroing API declarations and implementation includes so WH/BH remain unchanged, Quasar V2 continues to expose the zeroing APIs, and Quasar V1 no longer advertises or compiles unsupported zeroing code. The `QuasarMeshDeviceSingleCardFixture.PackReluZero` test now gets past the JIT compile failure; its remaining failure is a separate simulator `tensix_stallwait` coverage issue.

### Notes for reviewers
none

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mcraighead/qsr-v1-zero-apis)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mcraighead/qsr-v1-zero-apis)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mcraighead/qsr-v1-zero-apis)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mcraighead/qsr-v1-zero-apis)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mcraighead/qsr-v1-zero-apis)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mcraighead/qsr-v1-zero-apis)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mcraighead/qsr-v1-zero-apis)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mcraighead/qsr-v1-zero-apis)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mcraighead/qsr-v1-zero-apis)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mcraighead/qsr-v1-zero-apis)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mcraighead/qsr-v1-zero-apis)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mcraighead/qsr-v1-zero-apis)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mcraighead/qsr-v1-zero-apis)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mcraighead/qsr-v1-zero-apis)