### PR TITLE
Improve SDXL VAE accuracy

### DIFF
--- a/models/demos/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_attention.py
+++ b/models/demos/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_attention.py
@@ -28,7 +28,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
     "block_name, pcc",
     [
         ("encoder", 0.999),
-        ("decoder", 0.997),
+        ("decoder", 0.999),
     ],
 )
 def test_vae_attention(

--- a/models/demos/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_attention.py
+++ b/models/demos/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_attention.py
@@ -78,7 +78,7 @@ def test_vae_attention(
         dtype=ttnn.bfloat16,
         device=device,
         layout=ttnn.TILE_LAYOUT,
-        memory_config=ttnn.L1_MEMORY_CONFIG,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
     B, C, H, W = list(ttnn_input_tensor.shape)
 
@@ -91,7 +91,7 @@ def test_vae_attention(
             dtype=ttnn.bfloat16,
             device=device,
             layout=ttnn.TILE_LAYOUT,
-            memory_config=ttnn.L1_MEMORY_CONFIG,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
         )
         if encoder_shape is not None
         else None

--- a/models/demos/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_autoencoder_kl.py
+++ b/models/demos/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_autoencoder_kl.py
@@ -20,12 +20,11 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
     "image_resolution, input_shape, pcc, vae_block",
     [
         # 1024x1024 image resolution
-        ((1024, 1024), (1, 4, 128, 128), 0.930 if is_wormhole_b0() else 0.905, "decoder"),
-        # Blackhole has lower PCC due to DRAM groupnorm numerical differences
-        ((1024, 1024), (1, 3, 1024, 1024), 0.9769 if is_wormhole_b0() else 0.964, "encoder"),
+        ((1024, 1024), (1, 4, 128, 128), 0.946 if is_wormhole_b0() else 0.935, "decoder"),
+        ((1024, 1024), (1, 3, 1024, 1024), 0.981, "encoder"),
         # 512x512 image resolution
-        ((512, 512), (1, 4, 64, 64), 0.931, "decoder"),
-        ((512, 512), (1, 3, 512, 512), 0.9796, "encoder"),
+        ((512, 512), (1, 4, 64, 64), 0.946, "decoder"),
+        ((512, 512), (1, 3, 512, 512), 0.981, "encoder"),
     ],
     ids=("test_1024x1024_decode", "test_1024x1024_encode", "test_512x512_decode", "test_512x512_encode"),
 )

--- a/models/demos/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_decoder.py
+++ b/models/demos/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_decoder.py
@@ -20,9 +20,9 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
     "image_resolution, input_shape, pcc",
     [
         # 1024x1024 image resolution
-        ((1024, 1024), (1, 4, 128, 128), 0.93),
+        ((1024, 1024), (1, 4, 128, 128), 0.954),
         # 512x512 image resolution
-        ((512, 512), (1, 4, 64, 64), 0.95),
+        ((512, 512), (1, 4, 64, 64), 0.963),
     ],
 )
 def test_vae_decoder(

--- a/models/demos/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_downblock2d.py
+++ b/models/demos/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_downblock2d.py
@@ -9,7 +9,7 @@ from diffusers import AutoencoderKL
 from loguru import logger
 
 import ttnn
-from models.common.utility_functions import is_blackhole, is_wormhole_b0, torch_random
+from models.common.utility_functions import is_blackhole, torch_random
 from models.demos.stable_diffusion_xl_base.vae.tt.model_configs import load_vae_model_optimisations
 from models.demos.stable_diffusion_xl_base.vae.tt.tt_downblock2d import TtDownEncoderBlock2D
 from tests.ttnn.utils_for_testing import assert_with_pcc
@@ -19,14 +19,13 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
     "image_resolution, input_shape, block_id, pcc",
     [
         # 1024x1024 image resolution
-        # Blackhole has lower PCC due to DRAM groupnorm numerical differences
-        ((1024, 1024), (1, 128, 1024, 1024), 0, 0.999 if is_wormhole_b0() else 0.998),
-        ((1024, 1024), (1, 128, 512, 512), 1, 0.998 if is_wormhole_b0() else 0.996),
+        ((1024, 1024), (1, 128, 1024, 1024), 0, 0.999),
+        ((1024, 1024), (1, 128, 512, 512), 1, 0.999),
         ((1024, 1024), (1, 256, 256, 256), 2, 0.999),
         ((1024, 1024), (1, 512, 128, 128), 3, 0.999),
         # 512x512 image resolution
         ((512, 512), (1, 128, 512, 512), 0, 0.999),
-        ((512, 512), (1, 128, 256, 256), 1, 0.998),
+        ((512, 512), (1, 128, 256, 256), 1, 0.999),
         ((512, 512), (1, 256, 128, 128), 2, 0.999),
         ((512, 512), (1, 512, 64, 64), 3, 0.999),
     ],

--- a/models/demos/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_encoder.py
+++ b/models/demos/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_encoder.py
@@ -9,7 +9,7 @@ from diffusers import AutoencoderKL
 from loguru import logger
 
 import ttnn
-from models.common.utility_functions import is_blackhole, is_wormhole_b0, torch_random
+from models.common.utility_functions import is_blackhole, torch_random
 from models.demos.stable_diffusion_xl_base.vae.tt.model_configs import load_vae_model_optimisations
 from models.demos.stable_diffusion_xl_base.vae.tt.tt_encoder import TtEncoder
 from tests.ttnn.utils_for_testing import assert_with_pcc
@@ -20,10 +20,9 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
     "image_resolution, input_shape, pcc",
     [
         # 1024x1024 image resolution
-        # Blackhole has lower PCC due to DRAM groupnorm numerical differences
-        ((1024, 1024), (1, 3, 1024, 1024), 0.97 if is_wormhole_b0() else 0.968),
+        ((1024, 1024), (1, 3, 1024, 1024), 0.983),
         # 512x512 image resolution
-        ((512, 512), (1, 3, 512, 512), 0.98),
+        ((512, 512), (1, 3, 512, 512), 0.982),
     ],
 )
 def test_vae_encoder(

--- a/models/demos/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_resnetblock2d.py
+++ b/models/demos/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_resnetblock2d.py
@@ -17,22 +17,19 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 @pytest.mark.parametrize(
     "image_resolution, input_shape, block_id, resnet_id, conv_shortcut, block, pcc",
     [
-        # NOTE: https://github.com/tenstorrent/tt-metal/issues/39225
-        # PCC lowered for some input until the mentioned issue with DRAM GN is resolved
-        # TODO: once DRAM GN is fixed, update the PCC values accordingly and remove skips
         # 1024x1024 image resolution
         ((1024, 1024), (1, 512, 128, 128), 0, 0, False, "mid_block", 0.999),
         ((1024, 1024), (1, 512, 128, 128), 0, 0, False, "up_blocks", 0.999),
-        ((1024, 1024), (1, 512, 256, 256), 1, 0, False, "up_blocks", 0.999),  # skipped; PCC=0.91
+        ((1024, 1024), (1, 512, 256, 256), 1, 0, False, "up_blocks", 0.999),
         ((1024, 1024), (1, 512, 512, 512), 2, 0, True, "up_blocks", 0.999),
         ((1024, 1024), (1, 256, 512, 512), 2, 1, False, "up_blocks", 0.999),
-        ((1024, 1024), (1, 256, 1024, 1024), 3, 0, True, "up_blocks", 0.999 if not is_blackhole() else 0.998),
+        ((1024, 1024), (1, 256, 1024, 1024), 3, 0, True, "up_blocks", 0.999),
         ((1024, 1024), (1, 128, 1024, 1024), 3, 1, False, "up_blocks", 0.999),
-        ((1024, 1024), (1, 128, 1024, 1024), 0, 0, False, "down_blocks", 0.998 if not is_blackhole() else 0.97),
+        ((1024, 1024), (1, 128, 1024, 1024), 0, 0, False, "down_blocks", 0.998),
         ((1024, 1024), (1, 128, 512, 512), 1, 0, True, "down_blocks", 0.999),
         ((1024, 1024), (1, 256, 512, 512), 1, 1, False, "down_blocks", 0.999),
-        ((1024, 1024), (1, 256, 256, 256), 2, 0, True, "down_blocks", 0.999),  # skipped; PCC=0.88
-        ((1024, 1024), (1, 512, 256, 256), 2, 1, False, "down_blocks", 0.999 if not is_blackhole() else 0.99),
+        ((1024, 1024), (1, 256, 256, 256), 2, 0, True, "down_blocks", 0.999),
+        ((1024, 1024), (1, 512, 256, 256), 2, 1, False, "down_blocks", 0.999),
         ((1024, 1024), (1, 512, 128, 128), 3, 0, False, "down_blocks", 0.999),
         # 512x512 image resolution
         ((512, 512), (1, 512, 64, 64), 0, 0, False, "mid_block", 0.999),
@@ -65,14 +62,8 @@ def test_vae_resnetblock2d(
     sdxl_base_vae_location,
     reset_seeds,
 ):
-    if is_blackhole():
-        if image_resolution == (512, 512):
-            pytest.skip("512x512 resolution not supported on Blackhole")
-        dram_gn_skip = (block == "up_blocks" and block_id == 1 and resnet_id == 0) or (
-            block == "down_blocks" and block_id == 2 and resnet_id == 0
-        )
-        if dram_gn_skip:
-            pytest.skip("Skipping on Blackhole due to PCC issue with DRAM group_norm")
+    if image_resolution == (512, 512) and is_blackhole():
+        pytest.skip("512x512 resolution not supported on Blackhole")
     vae = AutoencoderKL.from_pretrained(
         sdxl_base_vae_location,
         torch_dtype=torch.float32,

--- a/models/demos/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_upblock2d.py
+++ b/models/demos/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_upblock2d.py
@@ -17,17 +17,14 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 @pytest.mark.parametrize(
     "image_resolution, input_shape, block_id, pcc",
     [
-        # NOTE: https://github.com/tenstorrent/tt-metal/issues/39225
-        # PCC lowered for some input until the mentioned issue with DRAM GN is resolved
-        # TODO: once DRAM GN is fixed, update the PCC values accordingly and remove skips
         # 1024x1024 image resolution
-        ((1024, 1024), (1, 512, 128, 128), 0, 0.999),  # skipped; PCC=0.74
-        ((1024, 1024), (1, 512, 256, 256), 1, 0.995),  # skipped; PCC=0.62
-        ((1024, 1024), (1, 512, 512, 512), 2, 0.998),  # skipped; PCC=0.59
-        ((1024, 1024), (1, 256, 1024, 1024), 3, 0.999 if not is_blackhole() else 0.99),
+        ((1024, 1024), (1, 512, 128, 128), 0, 0.999),
+        ((1024, 1024), (1, 512, 256, 256), 1, 0.997),
+        ((1024, 1024), (1, 512, 512, 512), 2, 0.999),
+        ((1024, 1024), (1, 256, 1024, 1024), 3, 0.999),
         # 512x512 image resolution
         ((512, 512), (1, 512, 64, 64), 0, 0.999),
-        ((512, 512), (1, 512, 128, 128), 1, 0.995),
+        ((512, 512), (1, 512, 128, 128), 1, 0.998),
         ((512, 512), (1, 512, 256, 256), 2, 0.998),
         ((512, 512), (1, 256, 512, 512), 3, 0.999),
     ],
@@ -44,12 +41,8 @@ def test_vae_upblock(
     sdxl_base_vae_location,
     reset_seeds,
 ):
-    if is_blackhole():
-        if image_resolution == (512, 512):
-            pytest.skip("512x512 resolution not supported on Blackhole")
-
-        if input_shape != (1, 256, 1024, 1024):
-            pytest.skip("Skipping on Blackhole due to PCC issue with DRAM group_norm")
+    if image_resolution == (512, 512) and is_blackhole():
+        pytest.skip("512x512 resolution not supported on Blackhole")
     vae = AutoencoderKL.from_pretrained(
         sdxl_base_vae_location,
         torch_dtype=torch.float32,

--- a/models/demos/stable_diffusion_xl_base/vae/tt/model_configs/model_configs_1024x1024.py
+++ b/models/demos/stable_diffusion_xl_base/vae/tt/model_configs/model_configs_1024x1024.py
@@ -73,6 +73,15 @@ class VAEModelOptimisations(ModelOptimisations1024x1024):
             "negative_mask": False,
         }
 
+        groupnorm_compute_config = ttnn.WormholeComputeKernelConfig(
+            math_fidelity=ttnn.MathFidelity.HiFi4,
+            math_approx_mode=False,
+            fp32_dest_acc_en=True,
+            packer_l1_acc=True,
+        )
+        for groupnorm_config in self.groupnorm_configs.values():
+            groupnorm_config["op_config"]["compute_kernel_config"] = groupnorm_compute_config
+
     def get_matmul_config(self, matmul_path):
         return None
 

--- a/models/demos/stable_diffusion_xl_base/vae/tt/model_configs/model_configs_1024x1024.py
+++ b/models/demos/stable_diffusion_xl_base/vae/tt/model_configs/model_configs_1024x1024.py
@@ -16,10 +16,10 @@ class VAEModelOptimisations(ModelOptimisations1024x1024):
     ):
         super().__init__(conv_act_dtype, conv_w_dtype, attention_weights_dtype, ff_weights_dtype)
 
-        self.sdpa_configs["64_K"] = ttnn.SDPAProgramConfig(
+        self.sdpa_configs["128_K"] = ttnn.SDPAProgramConfig(
             compute_with_storage_grid_size=(8, 8),
             q_chunk_size=64,
-            k_chunk_size=64,
+            k_chunk_size=128,
             exp_approx_mode=False,
         )
 
@@ -194,4 +194,4 @@ class VAEModelOptimisations(ModelOptimisations1024x1024):
         return None
 
     def get_sdpa_config(self, module_path, is_self_attention):
-        return self.sdpa_configs["64_K"]
+        return self.sdpa_configs["128_K"]

--- a/models/demos/stable_diffusion_xl_base/vae/tt/model_configs/model_configs_1024x1024BH.py
+++ b/models/demos/stable_diffusion_xl_base/vae/tt/model_configs/model_configs_1024x1024BH.py
@@ -77,6 +77,15 @@ class VAEModelOptimisationsBH(ModelOptimisations1024x1024BH):
             "negative_mask": False,
         }
 
+        groupnorm_compute_config = ttnn.WormholeComputeKernelConfig(
+            math_fidelity=ttnn.MathFidelity.HiFi4,
+            math_approx_mode=False,
+            fp32_dest_acc_en=True,
+            packer_l1_acc=True,
+        )
+        for groupnorm_config in self.groupnorm_configs.values():
+            groupnorm_config["op_config"]["compute_kernel_config"] = groupnorm_compute_config
+
     def get_matmul_config(self, matmul_path):
         return None
 

--- a/models/demos/stable_diffusion_xl_base/vae/tt/model_configs/model_configs_1024x1024BH.py
+++ b/models/demos/stable_diffusion_xl_base/vae/tt/model_configs/model_configs_1024x1024BH.py
@@ -20,10 +20,10 @@ class VAEModelOptimisationsBH(ModelOptimisations1024x1024BH):
     ):
         super().__init__(conv_act_dtype, conv_w_dtype, attention_weights_dtype, ff_weights_dtype)
 
-        self.sdpa_configs["64_K"] = ttnn.SDPAProgramConfig(
+        self.sdpa_configs["128_K"] = ttnn.SDPAProgramConfig(
             compute_with_storage_grid_size=(8, 8),
             q_chunk_size=64,
-            k_chunk_size=64,
+            k_chunk_size=128,
             exp_approx_mode=False,
         )
 
@@ -201,4 +201,4 @@ class VAEModelOptimisationsBH(ModelOptimisations1024x1024BH):
         return None
 
     def get_sdpa_config(self, module_path, is_self_attention):
-        return self.sdpa_configs["64_K"]
+        return self.sdpa_configs["128_K"]


### PR DESCRIPTION
The change to `sum_df` from `bf16` to `fp32` in https://github.com/tenstorrent/tt-metal/pull/49948 caused PCC values in the SDXL VAE tests to change slightly. Some got better, some got worse. One particular case (`k_chunk_size = 64`), however, got considerably worse. This PR solves it not by addressing the SDPA accuracy directly, which is already very good, but by increasing the group-norm accuracy.

These tests showed a drop in PCC, which is depicted in the table:

- `pytest models/demos/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_decoder.py -k image_resolution0`
- `pytest models/demos/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_autoencoder_kl.py -k test_512x512_decode`
- `pytest models/demos/stable_diffusion_xl_base/vae/tests/pcc/test_module_tt_autoencoder_kl.py -k test_1024x1024_decode`

| PCC before regression | PCC regressed | PCC in this PR |
|--|--|--|
| 96.4 % | 93.4 % | 96.5 % |
| 93.9 % | 93.3 % | 95.6 % |
| 93.9 % | 93.2 % | 95.5 % |

PCC requirements were relaxed in https://github.com/tenstorrent/tt-metal/pull/50930. This PR tightens them to be the same or stronger than before. Fixes https://github.com/tenstorrent/tt-metal/issues/50999 without relaxing any PCC requirement.

The same group-norm change is applied to the Blackhole config, and the skips and lowered PCC values left behind by https://github.com/tenstorrent/tt-metal/issues/39225 are removed.

### Background: the `k_chunk_size = 64` case

An fp32 sum improves accuracy most of the time. The SDXL VAE is an exception, for two reasons: (1) the common mode in V, and (2) the large chunk count (256). Here the accumulated inaccuracy of the online-softmax numerator is partly cancelled by inaccuracy in the denominator when the denominator uses a bf16 sum datatype. This happens beyond a chunk count of roughly 190.

**Possible mitigation:** the common mode in V is approximately data-independent, so it can be removed by editing the V-projection bias and adding it back into the O-projection bias. However, SDPA accuracy is high anyway, so a much more effective fix is to improve group-norm accuracy, which makes the slight SDPA inaccuracy moot.

See also the in-depth analysis in [SDPA accumulation error in the SDXL VAE decoder](https://gist.github.com/friedrich/78170e3371d6e95d7b6a06dcd212757e).

[![](https://github.com/tenstorrent/tt-metal/actions/workflows/models-t2-unit-tests.yaml/badge.svg?branch=friedrich/sdxl-vae-pcc)](https://github.com/tenstorrent/tt-metal/actions/workflows/models-t2-unit-tests.yaml?query=branch:friedrich/sdxl-vae-pcc)
[![](https://github.com/tenstorrent/tt-metal/actions/workflows/models-t2-e2e-tests.yaml/badge.svg?branch=friedrich/sdxl-vae-pcc)](https://github.com/tenstorrent/tt-metal/actions/workflows/models-t2-e2e-tests.yaml?query=branch:friedrich/sdxl-vae-pcc)
[![](https://github.com/tenstorrent/tt-metal/actions/workflows/models-t1-device-perf-tests.yaml/badge.svg?branch=friedrich/sdxl-vae-pcc)](https://github.com/tenstorrent/tt-metal/actions/workflows/models-t1-device-perf-tests.yaml?query=branch:friedrich/sdxl-vae-pcc)