### PR TITLE
[ttnn] Metal 2.0: one way to key a program cache, enforced, and the bugs it found

### DIFF
--- a/tests/ttnn/unit_tests/gtests/sources.cmake
+++ b/tests/ttnn/unit_tests/gtests/sources.cmake
@@ -30,6 +30,7 @@ set(UNIT_TESTS_TTNN_BASIC_SOURCES
     test_graph_query_op_runtime.cpp
     test_launch_operation.cpp
     test_matmul.cpp
+    test_quasar_program_keying.cpp
     test_matmul_multicore.cpp
     test_matmul_sweep.cpp
     test_reduction.cpp

--- a/tests/ttnn/unit_tests/gtests/test_launch_operation.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_launch_operation.cpp
@@ -201,6 +201,178 @@ static_assert(!device_operation::SupportsPerCoreAllocation<per_core_opt_in_test:
 static_assert(device_operation::SupportsPerCoreAllocation<per_core_opt_in_test::OptedIn>);
 static_assert(!device_operation::SupportsPerCoreAllocation<per_core_opt_in_test::OptedOut>);
 
+// Keying: which half of the key each declaration moves, and that a relaxation loosens a TensorSpec
+// comparison without letting two tensor_args layouts share a key.
+namespace keying_hooks_test {
+
+using tt::tt_metal::experimental::TensorSpecRelaxations;
+using ::ttnn::device_operation::detail::compute_op_hash;
+
+struct Attributes {
+    uint32_t knob = 0;
+    uint32_t seed = 0;
+};
+
+struct Inputs {
+    Tensor input;
+    std::optional<Tensor> first_optional;
+    std::optional<Tensor> second_optional;
+};
+
+ttsl::SmallVector<TensorSpecRelaxations> strict_for_each_tensor(
+    const Inputs& tensor_args, TensorSpecRelaxations input) {
+    ttsl::SmallVector<TensorSpecRelaxations> relaxations{input};
+    if (tensor_args.first_optional.has_value()) {
+        relaxations.emplace_back();
+    }
+    if (tensor_args.second_optional.has_value()) {
+        relaxations.emplace_back();
+    }
+    return relaxations;
+}
+
+struct DefaultKeyedOp {
+    using operation_attributes_t = Attributes;
+    using tensor_args_t = Inputs;
+};
+
+struct PaddedShapeOnlyOp {
+    using operation_attributes_t = Attributes;
+    using tensor_args_t = Inputs;
+    static ttsl::SmallVector<TensorSpecRelaxations> tensor_args_relaxations(const Inputs& tensor_args) {
+        return strict_for_each_tensor(tensor_args, TensorSpecRelaxations{.match_padded_shape_only = true});
+    }
+};
+
+// The rand pattern: one attribute out of the key.
+struct SeedDroppingAttributes {
+    uint32_t knob = 0;
+    uint32_t seed = 0;
+
+    static constexpr auto attributes_excluded_from_key = std::forward_as_tuple("seed");
+};
+
+struct SeedDroppingOp {
+    using operation_attributes_t = SeedDroppingAttributes;
+    using tensor_args_t = Inputs;
+};
+
+struct MiscountingOp {
+    using operation_attributes_t = Attributes;
+    using tensor_args_t = Inputs;
+    static ttsl::SmallVector<TensorSpecRelaxations> tensor_args_relaxations(const Inputs&) { return {}; }
+};
+
+static_assert(!device_operation::HasTensorArgsRelaxations<DefaultKeyedOp>);
+static_assert(device_operation::HasTensorArgsRelaxations<PaddedShapeOnlyOp>);
+static_assert(device_operation::HasExcludedAttributes<SeedDroppingAttributes>);
+static_assert(device_operation::excluded_attributes_are_members<SeedDroppingAttributes>());
+static_assert(device_operation::field_is_excluded<SeedDroppingAttributes, 1>());
+static_assert(!device_operation::field_is_excluded<SeedDroppingAttributes, 0>());
+static_assert(!device_operation::HasTensorArgsRelaxations<SeedDroppingOp>);
+static_assert(!device_operation::HasLegacyProgramHash<SeedDroppingOp>);
+
+// The adapter static_asserts on "spec factory AND legacy hash"; pin that conjunction is detectable.
+// The adapter is deliberately not instantiated for the bad one.
+struct SpecFactoryOp {
+    using operation_attributes_t = Attributes;
+    using tensor_args_t = Inputs;
+    using program_factory_t = std::variant<ProgramSpecFactory>;
+};
+struct SpecFactoryOpWithLegacyHash {
+    using operation_attributes_t = Attributes;
+    using tensor_args_t = Inputs;
+    using program_factory_t = std::variant<ProgramSpecFactory>;
+    static ttsl::hash::hash_t compute_program_hash(const Attributes&, const Inputs&) { return 0; }
+};
+struct LegacyFactoryOpWithLegacyHash {
+    using operation_attributes_t = Attributes;
+    using tensor_args_t = Inputs;
+    using program_factory_t = std::variant<NewInfraProgramFactory>;
+    static ttsl::hash::hash_t compute_program_hash(const Attributes&, const Inputs&) { return 0; }
+};
+
+static_assert(device_operation::HasSpecProgramFactory<SpecFactoryOp>);
+static_assert(!device_operation::HasLegacyProgramHash<SpecFactoryOp>);
+static_assert(device_operation::HasSpecProgramFactory<SpecFactoryOpWithLegacyHash>);
+static_assert(device_operation::HasLegacyProgramHash<SpecFactoryOpWithLegacyHash>);
+static_assert(!device_operation::HasSpecProgramFactory<LegacyFactoryOpWithLegacyHash>);
+static_assert(device_operation::HasLegacyProgramHash<LegacyFactoryOpWithLegacyHash>);
+static_assert(!device_operation::HasSpecProgramFactory<DefaultKeyedOp>);
+
+Tensor make_host_tensor(const ttnn::Shape& logical_shape, Layout layout = Layout::TILE) {
+    const tt::tt_metal::TensorSpec spec(
+        logical_shape, tt::tt_metal::TensorLayout(DataType::FLOAT32, layout, MemoryConfig{}));
+    return Tensor::from_vector(std::vector<float>(logical_shape.volume()), spec);
+}
+
+// Same padded_shape (TILE rounds both to 32x32), different logical_shape.
+Tensor make_logical_30x32() { return make_host_tensor(ttnn::Shape{1, 1, 30, 32}); }
+Tensor make_logical_32x32() { return make_host_tensor(ttnn::Shape{1, 1, 32, 32}); }
+
+TEST(ProgramHashTest, DefaultKeysOnEverything) {
+    const Inputs tensor_args{.input = make_logical_30x32()};
+    const Inputs other_logical_shape{.input = make_logical_32x32()};
+
+    EXPECT_NE(
+        compute_op_hash<DefaultKeyedOp>(Attributes{.knob = 1, .seed = 1}, tensor_args),
+        compute_op_hash<DefaultKeyedOp>(Attributes{.knob = 1, .seed = 2}, tensor_args));
+    EXPECT_NE(
+        compute_op_hash<DefaultKeyedOp>(Attributes{.knob = 1, .seed = 1}, tensor_args),
+        compute_op_hash<DefaultKeyedOp>(Attributes{.knob = 1, .seed = 1}, other_logical_shape));
+}
+
+TEST(ProgramHashTest, AttributesHashDropsSeedButKeepsTheRest) {
+    const Inputs tensor_args{.input = make_logical_30x32()};
+
+    EXPECT_EQ(
+        compute_op_hash<SeedDroppingOp>(SeedDroppingAttributes{.knob = 1, .seed = 1}, tensor_args),
+        compute_op_hash<SeedDroppingOp>(SeedDroppingAttributes{.knob = 1, .seed = 2}, tensor_args));
+    EXPECT_NE(
+        compute_op_hash<SeedDroppingOp>(SeedDroppingAttributes{.knob = 1, .seed = 1}, tensor_args),
+        compute_op_hash<SeedDroppingOp>(SeedDroppingAttributes{.knob = 2, .seed = 1}, tensor_args));
+    EXPECT_NE(
+        compute_op_hash<SeedDroppingOp>(SeedDroppingAttributes{}, tensor_args),
+        compute_op_hash<SeedDroppingOp>(SeedDroppingAttributes{}, Inputs{.input = make_logical_32x32()}));
+}
+
+TEST(ProgramHashTest, PaddedShapeOnlyRelaxationSharesAKey) {
+    const Attributes attrs{};
+    const Inputs logical_30{.input = make_logical_30x32()};
+    const Inputs logical_32{.input = make_logical_32x32()};
+
+    EXPECT_NE(compute_op_hash<DefaultKeyedOp>(attrs, logical_30), compute_op_hash<DefaultKeyedOp>(attrs, logical_32));
+    EXPECT_EQ(
+        compute_op_hash<PaddedShapeOnlyOp>(attrs, logical_30), compute_op_hash<PaddedShapeOnlyOp>(attrs, logical_32));
+
+    // Relaxing logical_shape relaxes nothing else.
+    const Inputs row_major{.input = make_host_tensor(ttnn::Shape{1, 1, 32, 32}, Layout::ROW_MAJOR)};
+    EXPECT_NE(
+        compute_op_hash<PaddedShapeOnlyOp>(attrs, logical_32), compute_op_hash<PaddedShapeOnlyOp>(attrs, row_major));
+}
+
+TEST(ProgramHashTest, RelaxationPreservesTensorArgsStructure) {
+    const Attributes attrs{};
+    const Tensor tensor = make_logical_32x32();
+
+    // Same tensor and count, different slot -> different program, so different key.
+    const Inputs in_first_slot{.input = tensor, .first_optional = tensor};
+    const Inputs in_second_slot{.input = tensor, .second_optional = tensor};
+    EXPECT_NE(
+        compute_op_hash<PaddedShapeOnlyOp>(attrs, in_first_slot),
+        compute_op_hash<PaddedShapeOnlyOp>(attrs, in_second_slot));
+
+    EXPECT_NE(
+        compute_op_hash<PaddedShapeOnlyOp>(attrs, Inputs{.input = tensor}),
+        compute_op_hash<PaddedShapeOnlyOp>(attrs, in_first_slot));
+}
+
+TEST(ProgramHashTest, MiscountedRelaxationsAreRejected) {
+    EXPECT_ANY_THROW(compute_op_hash<MiscountingOp>(Attributes{}, Inputs{.input = make_logical_32x32()}));
+}
+
+}  // namespace keying_hooks_test
+
 TEST(LaunchOperationTest, MeshDeviceOperationAdapterGetName) {
     using ::ttnn::operations::examples::ExampleDeviceOperation;
     EXPECT_EQ(
@@ -411,5 +583,158 @@ TEST_F(LaunchOperation2x4Test, OutputTensorTopologyMultipleShardDims) {
         (ttsl::SmallVector<distributed::MeshMapperConfig::Placement>{distributed::MeshMapperConfig::Shard{0}}));
 }
 
+// Every way a Metal 2.0 op may shape its key, and the ways it must not. Fake ops, host tensors only.
+namespace keying_gaps_test {
+
+using keying_hooks_test::Attributes;
+using keying_hooks_test::DefaultKeyedOp;
+using keying_hooks_test::Inputs;
+using keying_hooks_test::make_logical_32x32;
+using ::ttnn::device_operation::detail::canonical_declared_attributes;
+using ::ttnn::device_operation::detail::compute_op_hash;
+
+// Presence-only: the key cares whether a semaphore was supplied, not which one. Store the bool, exclude
+// the value (ccl/reduce_scatter_minimal_async keys barrier_semaphore.has_value() today).
+struct PresenceAttributes {
+    bool has_semaphore = false;
+    std::optional<uint32_t> semaphore;
+
+    static constexpr auto attributes_excluded_from_key = std::forward_as_tuple("semaphore");
+};
+struct PresenceOp {
+    using operation_attributes_t = PresenceAttributes;
+    using tensor_args_t = Inputs;
+};
+
+// Conditional neutralization: the kernels see an effective value, so store it and exclude the raw one
+// (transformer/ring_joint_sdpa keys has_kv_pad_rotation() ? 0 : logical_n today).
+struct EffectiveAttributes {
+    bool pad_rotation = false;
+    uint32_t raw_n = 0;
+    uint32_t effective_n = 0;
+
+    static constexpr auto attributes_excluded_from_key = std::forward_as_tuple("raw_n");
+};
+struct EffectiveOp {
+    using operation_attributes_t = EffectiveAttributes;
+    using tensor_args_t = Inputs;
+};
+
+// Sub-field projection: an op that keys some fields of a struct member holds those values flat and excludes
+// the member (ccl/strided_all_gather_minimal_matmul_async projects 11 fields of one member today).
+struct NestedParams {
+    uint32_t keyed = 0;
+    uint32_t ignored = 0;
+};
+struct ProjectedAttributes {
+    NestedParams params;
+    uint32_t keyed = 0;
+
+    static constexpr auto attributes_excluded_from_key = std::forward_as_tuple("params");
+};
+struct ProjectedOp {
+    using operation_attributes_t = ProjectedAttributes;
+    using tensor_args_t = Inputs;
+};
+
+// A misspelled or renamed exclusion excludes nothing; the adapter static_asserts on this predicate.
+struct TypoAttributes {
+    uint32_t knob = 0;
+
+    static constexpr auto attributes_excluded_from_key = std::forward_as_tuple("knobb");
+};
+
+// The two banned mechanisms, so the predicates the asserts use are pinned as detecting them.
+struct ToHashAttributes {
+    uint32_t knob = 0;
+    ttsl::hash::hash_t to_hash() const { return 0; }
+};
+struct TupleAttributes {
+    uint32_t knob = 0;
+
+    static constexpr auto attribute_names = std::forward_as_tuple("knob");
+    auto attribute_values() const { return std::forward_as_tuple(knob); }
+};
+
+static_assert(device_operation::excluded_attributes_are_members<PresenceAttributes>());
+static_assert(device_operation::excluded_attributes_are_members<EffectiveAttributes>());
+static_assert(!device_operation::excluded_attributes_are_members<TypoAttributes>());
+static_assert(ttsl::reflection::detail::supports_to_hash_v<ToHashAttributes>);
+static_assert(device_operation::HasAttributeNames<TupleAttributes>);
+static_assert(!device_operation::HasAttributeNames<PresenceAttributes>);
+
+TEST(KeyingGapsTest, PresenceKeysWhetherNotWhich) {
+    const Inputs tensor_args{.input = make_logical_32x32()};
+    const PresenceAttributes with_one{.has_semaphore = true, .semaphore = 1};
+    PresenceAttributes with_another = with_one;
+    with_another.semaphore = 2;
+    const PresenceAttributes without{.has_semaphore = false, .semaphore = std::nullopt};
+
+    EXPECT_EQ(
+        compute_op_hash<PresenceOp>(with_one, tensor_args), compute_op_hash<PresenceOp>(with_another, tensor_args));
+    EXPECT_NE(compute_op_hash<PresenceOp>(with_one, tensor_args), compute_op_hash<PresenceOp>(without, tensor_args));
+}
+
+TEST(KeyingGapsTest, EffectiveValueKeysInsteadOfRaw) {
+    const Inputs tensor_args{.input = make_logical_32x32()};
+    const EffectiveAttributes attrs{.pad_rotation = true, .raw_n = 8, .effective_n = 0};
+    EffectiveAttributes other_raw = attrs;
+    other_raw.raw_n = 99;
+    EffectiveAttributes other_effective = attrs;
+    other_effective.effective_n = 1;
+
+    EXPECT_EQ(compute_op_hash<EffectiveOp>(attrs, tensor_args), compute_op_hash<EffectiveOp>(other_raw, tensor_args));
+    EXPECT_NE(
+        compute_op_hash<EffectiveOp>(attrs, tensor_args), compute_op_hash<EffectiveOp>(other_effective, tensor_args));
+}
+
+TEST(KeyingGapsTest, ProjectionKeysTheFlatCopyNotTheMember) {
+    const Inputs tensor_args{.input = make_logical_32x32()};
+    const ProjectedAttributes attrs{.params = {.keyed = 3, .ignored = 4}, .keyed = 3};
+    ProjectedAttributes member_changed = attrs;
+    member_changed.params.ignored = 99;
+    member_changed.params.keyed = 99;
+    ProjectedAttributes flat_changed = attrs;
+    flat_changed.keyed = 9;
+
+    EXPECT_EQ(
+        compute_op_hash<ProjectedOp>(attrs, tensor_args), compute_op_hash<ProjectedOp>(member_changed, tensor_args));
+    EXPECT_NE(
+        compute_op_hash<ProjectedOp>(attrs, tensor_args), compute_op_hash<ProjectedOp>(flat_changed, tensor_args));
+}
+
+// The exact key must split exactly what the hash splits, or a 64-bit collision becomes a wrong cache hit.
+TEST(KeyingGapsTest, CanonicalKeyMirrorsTheHash) {
+    const PresenceAttributes with_one{.has_semaphore = true, .semaphore = 1};
+    PresenceAttributes with_another = with_one;
+    with_another.semaphore = 2;
+    PresenceAttributes without = with_one;
+    without.has_semaphore = false;
+    EXPECT_EQ(canonical_declared_attributes(with_one), canonical_declared_attributes(with_another));
+    EXPECT_NE(canonical_declared_attributes(with_one), canonical_declared_attributes(without));
+
+    const ProjectedAttributes projected{.params = {.keyed = 3, .ignored = 4}, .keyed = 3};
+    ProjectedAttributes projected_member_changed = projected;
+    projected_member_changed.params.keyed = 99;
+    ProjectedAttributes projected_flat_changed = projected;
+    projected_flat_changed.keyed = 9;
+    EXPECT_EQ(canonical_declared_attributes(projected), canonical_declared_attributes(projected_member_changed));
+    EXPECT_NE(canonical_declared_attributes(projected), canonical_declared_attributes(projected_flat_changed));
+
+    // An op that declares nothing keeps the plain encoding.
+    const Attributes plain{.knob = 1, .seed = 7};
+    EXPECT_EQ(canonical_declared_attributes(plain), ttsl::hash::canonical_key(plain));
+}
+
+// Declaring nothing must key exactly as before this mechanism existed.
+TEST(KeyingGapsTest, UndeclaredOpsKeyByPlainReflection) {
+    const Inputs tensor_args{.input = make_logical_32x32()};
+    const Attributes attrs{.knob = 3, .seed = 4};
+    EXPECT_EQ(
+        compute_op_hash<DefaultKeyedOp>(attrs, tensor_args),
+        ttsl::hash::hash_objects_with_default_seed(ttsl::hash::type_hash<DefaultKeyedOp>, attrs, tensor_args));
+}
+
+}  // namespace keying_gaps_test
 }  // namespace
 }  // namespace ttnn

--- a/tests/ttnn/unit_tests/gtests/test_launch_operation.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_launch_operation.cpp
@@ -272,8 +272,6 @@ static_assert(!device_operation::field_is_excluded<SeedDroppingAttributes, 0>())
 static_assert(!device_operation::HasTensorArgsRelaxations<SeedDroppingOp>);
 static_assert(!device_operation::HasLegacyProgramHash<SeedDroppingOp>);
 
-// The adapter static_asserts on "spec factory AND legacy hash"; pin that conjunction is detectable.
-// The adapter is deliberately not instantiated for the bad one.
 struct SpecFactoryOp {
     using operation_attributes_t = Attributes;
     using tensor_args_t = Inputs;
@@ -291,6 +289,32 @@ struct LegacyFactoryOpWithLegacyHash {
     using program_factory_t = std::variant<NewInfraProgramFactory>;
     static ttsl::hash::hash_t compute_program_hash(const Attributes&, const Inputs&) { return 0; }
 };
+
+// The emergency exit, declaring everything at once: a spec-path op with a custom hash, an exclusion and
+// a deliberately miscounted relaxation list. The custom hash must win and the rest must go unread --
+// were the framework to consult the relaxations, the count mismatch would TT_FATAL.
+struct EmergencyExitAttributes {
+    uint32_t knob = 0;
+    uint32_t seed = 0;
+
+    static constexpr auto attributes_excluded_from_key = std::forward_as_tuple("seed");
+};
+
+struct EmergencyExitOp {
+    using operation_attributes_t = EmergencyExitAttributes;
+    using tensor_args_t = Inputs;
+    using spec_return_value_t = tt::tt_metal::TensorSpec;
+    using tensor_return_value_t = Tensor;
+    using program_factory_t = std::variant<ProgramSpecFactory>;
+
+    static ttsl::SmallVector<TensorSpecRelaxations> tensor_args_relaxations(const Inputs&) { return {}; }
+    static ttsl::hash::hash_t compute_program_hash(const EmergencyExitAttributes& attrs, const Inputs&) {
+        return attrs.knob;
+    }
+};
+
+static_assert(device_operation::HasSpecProgramFactory<EmergencyExitOp>);
+static_assert(device_operation::HasLegacyProgramHash<EmergencyExitOp>);
 
 static_assert(device_operation::HasSpecProgramFactory<SpecFactoryOp>);
 static_assert(!device_operation::HasLegacyProgramHash<SpecFactoryOp>);
@@ -365,6 +389,33 @@ TEST(ProgramHashTest, RelaxationPreservesTensorArgsStructure) {
     EXPECT_NE(
         compute_op_hash<PaddedShapeOnlyOp>(attrs, Inputs{.input = tensor}),
         compute_op_hash<PaddedShapeOnlyOp>(attrs, in_first_slot));
+}
+
+TEST(ProgramHashTest, CustomHashWinsOutrightOnTheSpecPath) {
+    const Inputs tensor_args{.input = make_logical_30x32()};
+    EXPECT_EQ(compute_op_hash<EmergencyExitOp>(EmergencyExitAttributes{.knob = 7, .seed = 1}, tensor_args), 7u);
+
+    // Nothing the framework would normally key changes the result: not the excluded field, not the
+    // non-excluded one, not the tensors.
+    EXPECT_EQ(
+        compute_op_hash<EmergencyExitOp>(
+            EmergencyExitAttributes{.knob = 7, .seed = 2}, Inputs{.input = make_logical_32x32()}),
+        7u);
+    EXPECT_EQ(compute_op_hash<EmergencyExitOp>(EmergencyExitAttributes{.knob = 8}, tensor_args), 8u);
+}
+
+TEST(ProgramHashTest, CustomHashForfeitsTheExactKey) {
+    using Adapter = device_operation::MeshDeviceOperationAdapter<EmergencyExitOp>;
+    const Inputs tensor_args{.input = make_logical_30x32()};
+
+    // Prefix only, so two inputs the op hashes differently are indistinguishable once they collide:
+    // the exact key can no longer separate them and one cache entry serves both.
+    const auto key_one = Adapter::compute_mesh_workload_canonical_key(
+        nullptr, "emergency", EmergencyExitAttributes{.knob = 1}, tensor_args);
+    const auto key_two = Adapter::compute_mesh_workload_canonical_key(
+        nullptr, "emergency", EmergencyExitAttributes{.knob = 2}, tensor_args);
+    EXPECT_EQ(key_one, "emergency");
+    EXPECT_EQ(key_one, key_two);
 }
 
 TEST(ProgramHashTest, MiscountedRelaxationsAreRejected) {

--- a/tests/ttnn/unit_tests/gtests/test_quasar_program_keying.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_quasar_program_keying.cpp
@@ -1,0 +1,162 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gmock/gmock.h>
+
+#include "ttnn/operations/conv/conv2d/device/conv2d_device_operation_types.hpp"
+#include "ttnn/operations/experimental/quasar/conv2d/device/conv2d_device_operation.hpp"
+#include "ttnn/operations/experimental/quasar/binary_ng/device/binary_ng_device_operation.hpp"
+#include "ttnn/operations/experimental/quasar/slice/device/slice_device_operation.hpp"
+#include "ttnn/device_operation.hpp"
+#include "ttnn/tensor/tensor.hpp"
+
+// What these ops' keys must discriminate, so a future narrowing fails here instead of in a model.
+namespace ttnn {
+namespace {
+
+using ::ttnn::device_operation::detail::compute_program_hash;
+
+Tensor host_tensor(const ttnn::Shape& logical_shape, Layout layout = Layout::TILE) {
+    const tt::tt_metal::TensorSpec spec(
+        logical_shape, tt::tt_metal::TensorLayout(DataType::FLOAT32, layout, MemoryConfig{}));
+    return Tensor::from_vector(std::vector<float>(logical_shape.volume()), spec);
+}
+
+using ConvOp = ttnn::prim::qsr::Conv2dDeviceOperation;
+
+ttnn::prim::Conv2dInputs conv_inputs() {
+    return ttnn::prim::Conv2dInputs{
+        .a = host_tensor(ttnn::Shape{1, 1, 64, 32}), .b = host_tensor(ttnn::Shape{1, 1, 32, 32}), .bias = std::nullopt};
+}
+
+// full_inner_dim selects slice_inner_dim in the sharded factory, so two convs differing only in it need
+// two programs. Unkeyed, the second silently reused the first's.
+TEST(QuasarKeyingTest, Conv2dKeysFullInnerDim) {
+    ttnn::prim::Conv2dParams params{};
+    auto other = params;
+    other.full_inner_dim = !params.full_inner_dim;
+
+    const auto inputs = conv_inputs();
+    EXPECT_NE(compute_program_hash<ConvOp>(params, inputs), compute_program_hash<ConvOp>(other, inputs));
+}
+
+TEST(QuasarKeyingTest, Conv2dKeepsKeyingTheOldHashFields) {
+    const ttnn::prim::Conv2dParams params{};
+    const auto inputs = conv_inputs();
+    EXPECT_EQ(compute_program_hash<ConvOp>(params, inputs), compute_program_hash<ConvOp>(params, inputs));
+
+    // A sample of the keyed fields; each must split the key.
+    auto changed_channels = params;
+    changed_channels.output_channels = params.output_channels + 1;
+    EXPECT_NE(compute_program_hash<ConvOp>(params, inputs), compute_program_hash<ConvOp>(changed_channels, inputs));
+
+    auto changed_bias = params;
+    changed_bias.has_bias = !params.has_bias;
+    EXPECT_NE(compute_program_hash<ConvOp>(params, inputs), compute_program_hash<ConvOp>(changed_bias, inputs));
+
+    auto changed_dtype = params;
+    changed_dtype.dtype = DataType::BFLOAT16;
+    EXPECT_NE(compute_program_hash<ConvOp>(params, inputs), compute_program_hash<ConvOp>(changed_dtype, inputs));
+
+    // Tensor args are keyed too.
+    ttnn::prim::Conv2dInputs other_inputs = conv_inputs();
+    other_inputs.a = host_tensor(ttnn::Shape{1, 1, 128, 32});
+    EXPECT_NE(compute_program_hash<ConvOp>(params, inputs), compute_program_hash<ConvOp>(params, other_inputs));
+}
+
+using SliceOp = ttnn::prim::qsr::SliceDeviceOperation;
+
+ttnn::prim::qsr::SliceParams slice_params() {
+    return ttnn::prim::qsr::SliceParams{
+        .slice_start = ttnn::Shape{0, 0, 0, 0},
+        .slice_end = ttnn::Shape{1, 1, 32, 32},
+        .step = ttnn::Shape{1, 1, 1, 1},
+        .output_mem_config = MemoryConfig{}};
+}
+
+// padded_shape, the output spec and the factory choice are all pure functions of the slice params and the
+// input spec, so keying those two covers them.
+TEST(QuasarKeyingTest, SliceKeysParamsAndInputSpec) {
+    const auto params = slice_params();
+    const ttnn::prim::qsr::SliceInputs inputs{.input = host_tensor(ttnn::Shape{1, 1, 64, 32})};
+    EXPECT_EQ(compute_program_hash<SliceOp>(params, inputs), compute_program_hash<SliceOp>(params, inputs));
+
+    auto moved_start = params;
+    moved_start.slice_start = ttnn::Shape{0, 0, 32, 0};
+    EXPECT_NE(compute_program_hash<SliceOp>(params, inputs), compute_program_hash<SliceOp>(moved_start, inputs));
+
+    auto strided = params;
+    strided.step = ttnn::Shape{1, 1, 2, 1};
+    EXPECT_NE(compute_program_hash<SliceOp>(params, inputs), compute_program_hash<SliceOp>(strided, inputs));
+
+    // Input spec: logical shape and layout both feed the factory choice and the work split.
+    const ttnn::prim::qsr::SliceInputs taller{.input = host_tensor(ttnn::Shape{1, 1, 128, 32})};
+    EXPECT_NE(compute_program_hash<SliceOp>(params, inputs), compute_program_hash<SliceOp>(params, taller));
+
+    const ttnn::prim::qsr::SliceInputs row_major{.input = host_tensor(ttnn::Shape{1, 1, 64, 32}, Layout::ROW_MAJOR)};
+    EXPECT_NE(compute_program_hash<SliceOp>(params, inputs), compute_program_hash<SliceOp>(params, row_major));
+}
+
+// Which optional tensor args are present is part of the key, not just how many.
+TEST(QuasarKeyingTest, SliceKeysOptionalTensorArgs) {
+    const auto params = slice_params();
+    const Tensor tensor = host_tensor(ttnn::Shape{1, 1, 64, 32});
+    const ttnn::prim::qsr::SliceInputs bare{.input = tensor};
+
+    ttnn::prim::qsr::SliceInputs with_start{.input = tensor};
+    with_start.start_tensor = tensor;
+    EXPECT_NE(compute_program_hash<SliceOp>(params, bare), compute_program_hash<SliceOp>(params, with_start));
+
+    ttnn::prim::qsr::SliceInputs with_end{.input = tensor};
+    with_end.end_tensor = tensor;
+    EXPECT_NE(compute_program_hash<SliceOp>(params, bare), compute_program_hash<SliceOp>(params, with_end));
+
+    // Same tensor in a different optional slot must not collide.
+    EXPECT_NE(compute_program_hash<SliceOp>(params, with_start), compute_program_hash<SliceOp>(params, with_end));
+}
+
+using BinaryNgOp = ttnn::operations::experimental::quasar::binary_ng::BinaryNgDeviceOperation;
+
+BinaryNgOp::operation_attributes_t binary_ng_attributes(const CoreRangeSet& worker_grid) {
+    return BinaryNgOp::operation_attributes_t{
+        .binary_op_type = ttnn::operations::experimental::quasar::binary::BinaryOpType::ADD,
+        .memory_config = MemoryConfig{},
+        .input_dtype = DataType::FLOAT32,
+        .worker_grid = worker_grid};
+}
+
+// worker_grid is what split_work_to_cores is given, so it picks the core set; sub_device_id is where it
+// comes from. Both were unkeyed, and nothing keyed can recover them.
+TEST(QuasarKeyingTest, BinaryNgKeysWorkerGridAndSubDevice) {
+    const Tensor input = host_tensor(ttnn::Shape{1, 1, 32, 32});
+    const BinaryNgOp::tensor_args_t tensor_args{.input_tensor_a = input};
+
+    const auto one_core = CoreRangeSet(CoreRange({0, 0}, {0, 0}));
+    const auto four_cores = CoreRangeSet(CoreRange({0, 0}, {1, 1}));
+    EXPECT_NE(
+        compute_program_hash<BinaryNgOp>(binary_ng_attributes(one_core), tensor_args),
+        compute_program_hash<BinaryNgOp>(binary_ng_attributes(four_cores), tensor_args));
+
+    auto with_sub_device = binary_ng_attributes(one_core);
+    with_sub_device.sub_device_id = tt::tt_metal::SubDeviceId{1};
+    EXPECT_NE(
+        compute_program_hash<BinaryNgOp>(binary_ng_attributes(one_core), tensor_args),
+        compute_program_hash<BinaryNgOp>(with_sub_device, tensor_args));
+}
+
+// input_dtype is declared excluded: it is the input tensor's own dtype, already keyed through tensor_args.
+TEST(QuasarKeyingTest, BinaryNgExcludesInputDtype) {
+    const Tensor input = host_tensor(ttnn::Shape{1, 1, 32, 32});
+    const BinaryNgOp::tensor_args_t tensor_args{.input_tensor_a = input};
+    const auto one_core = CoreRangeSet(CoreRange({0, 0}, {0, 0}));
+
+    auto other_dtype = binary_ng_attributes(one_core);
+    other_dtype.input_dtype = DataType::BFLOAT16;
+    EXPECT_EQ(
+        compute_program_hash<BinaryNgOp>(binary_ng_attributes(one_core), tensor_args),
+        compute_program_hash<BinaryNgOp>(other_dtype, tensor_args));
+}
+
+}  // namespace
+}  // namespace ttnn

--- a/ttnn/api/tools/profiler/op_profiler_serialize.hpp
+++ b/ttnn/api/tools/profiler/op_profiler_serialize.hpp
@@ -27,6 +27,7 @@
 #include <tt-metalium/base_types.hpp>
 #include <tt_stl/reflection.hpp>
 #include <tt_stl/type_name.hpp>
+#include "ttnn/program_hash.hpp"
 #include "ttnn/tensor/tensor.hpp"
 
 // Forward declarations — avoid pulling in heavy headers for 1000+ TU include chain.
@@ -279,20 +280,8 @@ template <typename device_operation_t>
 inline auto compute_program_hash(
     const typename device_operation_t::operation_attributes_t& operation_attributes,
     const typename device_operation_t::tensor_args_t& tensor_args) {
-    if constexpr (requires(
-                      const typename device_operation_t::operation_attributes_t& operation_attributes,
-                      const typename device_operation_t::tensor_args_t& tensor_args) {
-                      {
-                          device_operation_t::compute_program_hash(operation_attributes, tensor_args)
-                      } -> std::convertible_to<ttsl::hash::hash_t>;
-                  }) {
-        ZoneScopedN("Op profiler Compute custom program hash");
-        return device_operation_t::compute_program_hash(operation_attributes, tensor_args);
-    } else {
-        ZoneScopedN("Op profiler Compute default program hash");
-        return ttsl::hash::hash_objects_with_default_seed(
-            ttsl::hash::type_hash<device_operation_t>, operation_attributes, tensor_args);
-    }
+    ZoneScopedN("Op profiler Compute program hash");
+    return ttnn::device_operation::detail::compute_op_hash<device_operation_t>(operation_attributes, tensor_args);
 }
 
 // ---------------------------------------------------------------------------

--- a/ttnn/api/ttnn/device_operation.hpp
+++ b/ttnn/api/ttnn/device_operation.hpp
@@ -55,18 +55,12 @@ template <typename... Ts>
     return table[i];
 }
 
+// Used by layernorm's nanobind hook to report an op's cache key from Python.
 template <typename device_operation_t>
 auto compute_program_hash(
     const typename device_operation_t::operation_attributes_t& operation_attributes,
     const typename device_operation_t::tensor_args_t& tensor_args) {
-    if constexpr (DeviceOperationWithCustomProgramCacheConcept<device_operation_t>) {
-        ZoneScopedN("Compute custom program hash");
-        return device_operation_t::compute_program_hash(operation_attributes, tensor_args);
-    } else {
-        ZoneScopedN("Compute default program hash");
-        return ttsl::hash::hash_objects_with_default_seed(
-            ttsl::hash::type_hash<device_operation_t>, operation_attributes, tensor_args);
-    }
+    return compute_op_hash<device_operation_t>(operation_attributes, tensor_args);
 }
 
 // Helper to create a mesh workload from a WorkloadFactory that may or may not

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -31,6 +31,7 @@
 #include "ttnn/metal_v2_artifacts.hpp"
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
 #include "ttnn/operation_concepts.hpp"
+#include "ttnn/program_hash.hpp"
 #include "ttnn/operation.hpp"
 #include <tt_stl/reflection.hpp>
 #include "ttnn/tensor/tensor.hpp"
@@ -247,14 +248,31 @@ public:
         return DeviceOperation::create_output_tensors(attrs, tensor_args);
     }
 
+    static_assert(
+        !(HasSpecProgramFactory<DeviceOperation> && HasLegacyProgramHash<DeviceOperation>),
+        "A Metal 2.0 spec-path operation must not define compute_program_hash(attrs, tensor_args). Express the "
+        "cache key as tensor_args_relaxations() and attributes_excluded_from_key instead, or drop the custom "
+        "hash and let the framework reflect.");
+
+    static_assert(
+        !HasSpecProgramFactory<DeviceOperation> ||
+            !ttsl::reflection::detail::supports_to_hash_v<operation_attributes_t>,
+        "operation_attributes_t::to_hash() silently replaces the whole attribute hash. A Metal 2.0 operation "
+        "declares nothing, or names the fields the key ignores in attributes_excluded_from_key.");
+    static_assert(
+        !HasSpecProgramFactory<DeviceOperation> || !std::is_aggregate_v<operation_attributes_t> ||
+            !HasAttributeNames<operation_attributes_t>,
+        "attribute_names is a hand-maintained copy of the struct: leave a field out and it silently leaves the "
+        "cache key. Delete it -- reflection names and keys every field -- and name the fields the key ignores "
+        "in attributes_excluded_from_key.");
+    static_assert(
+        !HasSpecProgramFactory<DeviceOperation> || excluded_attributes_are_members<operation_attributes_t>(),
+        "attributes_excluded_from_key names something that is not a field of operation_attributes_t, so it "
+        "excludes nothing -- a typo or a renamed field silently puts it back in the key.");
+
     static ttsl::hash::hash_t compute_program_hash(
         const operation_attributes_t& attrs, const tensor_args_t& tensor_args) {
-        if constexpr (requires { DeviceOperation::compute_program_hash(attrs, tensor_args); }) {
-            return DeviceOperation::compute_program_hash(attrs, tensor_args);
-        } else {
-            return ttsl::hash::hash_objects_with_default_seed(
-                ttsl::hash::type_hash<DeviceOperation>, attrs, tensor_args);
-        }
+        return detail::compute_op_hash<DeviceOperation>(attrs, tensor_args);
     }
 
     // An adapter for creating a factory that abides to `MeshWorkloadFactoryConcept` out of `ProgramFactoryConcept`
@@ -977,14 +995,7 @@ public:
         tt::tt_metal::distributed::MeshDevice* mesh_device,
         const operation_attributes_t& attrs,
         const tensor_args_t& tensor_args) {
-        ttsl::hash::hash_t hash;
-
-        if constexpr (requires { DeviceOperation::compute_program_hash(attrs, tensor_args); }) {
-            hash = DeviceOperation::compute_program_hash(attrs, tensor_args);
-        } else {
-            hash =
-                ttsl::hash::hash_objects_with_default_seed(ttsl::hash::type_hash<DeviceOperation>, attrs, tensor_args);
-        }
+        ttsl::hash::hash_t hash = detail::compute_op_hash<DeviceOperation>(attrs, tensor_args);
 
         // Combine with the mesh coordinates the workload is targeting.
         for (const auto& coord : mesh_device_operation_utils::extract_tensor_coordinates(tensor_args, mesh_device)) {
@@ -999,20 +1010,25 @@ public:
     //
     // The key is prefixed with op_type_name (the DeviceOperation's type name) so distinct ops can
     // never alias on a hash collision.
-    // For ops with a custom compute_program_hash we can't infer which fields it keyed on (it may
-    // deliberately exclude some, e.g. an RNG seed), so we return only the op-identity prefix --
-    // opting that op out of attribute-level collision resolution. The default reflection-hash
-    // path is mirrored exactly.
+    // A freeform compute_program_hash keys on fields we cannot enumerate, so those ops get only the
+    // op-identity prefix. Declared keying IS enumerable: the encoding below skips exactly the excluded
+    // attributes, so exact collision resolution survives.
     static std::string compute_mesh_workload_canonical_key(
         [[maybe_unused]] tt::tt_metal::distributed::MeshDevice* mesh_device,
         std::string_view op_type_name,
         const operation_attributes_t& attrs,
         const tensor_args_t& tensor_args) {
         std::string key{op_type_name};
-        if constexpr (requires { DeviceOperation::compute_program_hash(attrs, tensor_args); }) {
-            return key;  // custom hash -> opt out beyond the op-identity prefix
+        if constexpr (HasLegacyProgramHash<DeviceOperation>) {
+            return key;  // freeform hash -> nothing to mirror
+        } else if constexpr (HasTensorArgsRelaxations<DeviceOperation>) {
+            // A relaxation-aware encoding must come from the same place as the relaxation-aware hash;
+            // until Metal 2.0 exposes one, an op that relaxes a tensor opts out beyond the prefix.
+            key += detail::canonical_declared_attributes(attrs);
+            return key;
         } else {
-            key += ttsl::hash::canonical_key(attrs, tensor_args);
+            key += detail::canonical_declared_attributes(attrs);
+            key += ttsl::hash::canonical_key(tensor_args);
             for (const auto& coord :
                  mesh_device_operation_utils::extract_tensor_coordinates(tensor_args, mesh_device)) {
                 key += ttsl::hash::canonical_key(coord);

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -249,12 +249,6 @@ public:
     }
 
     static_assert(
-        !(HasSpecProgramFactory<DeviceOperation> && HasLegacyProgramHash<DeviceOperation>),
-        "A Metal 2.0 spec-path operation must not define compute_program_hash(attrs, tensor_args). Express the "
-        "cache key as tensor_args_relaxations() and attributes_excluded_from_key instead, or drop the custom "
-        "hash and let the framework reflect.");
-
-    static_assert(
         !HasSpecProgramFactory<DeviceOperation> ||
             !ttsl::reflection::detail::supports_to_hash_v<operation_attributes_t>,
         "operation_attributes_t::to_hash() silently replaces the whole attribute hash. A Metal 2.0 operation "

--- a/ttnn/api/ttnn/operation_concepts.hpp
+++ b/ttnn/api/ttnn/operation_concepts.hpp
@@ -15,8 +15,10 @@
 #include <tt-metalium/graph_tracking.hpp>
 #include <tt-metalium/program_cache.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
+#include <tt-metalium/experimental/metal2_host_api/tensor_spec_relaxations.hpp>
 
 #include <cstdint>
+#include <tt_stl/small_vector.hpp>
 
 #include "ttnn/distributed/types.hpp"
 
@@ -182,6 +184,16 @@ consteval bool all_factories_valid(std::index_sequence<Is...>) {
           CustomProgramSpecFactoryConcept<std::variant_alternative_t<Is, Variant>>) == 1) &&
         ...);
 }
+
+// "Any", not "all": once one factory of a multi-factory op is ported, the keying rules apply to the
+// whole op, because the key is shared.
+template <typename Variant, std::size_t... Is>
+consteval bool any_spec_factory(std::index_sequence<Is...>) {
+    return (
+        (ProgramSpecFactoryConcept<std::variant_alternative_t<Is, Variant>> ||
+         CustomProgramSpecFactoryConcept<std::variant_alternative_t<Is, Variant>>) ||
+        ...);
+}
 }  // namespace detail
 
 template <typename Variant>
@@ -207,16 +219,105 @@ concept DeviceOperationConcept =
     (HasDirectDescriptor<device_operation_t> ||
      (HasProgramFactoryType<device_operation_t> && AllFactoriesValid<typename device_operation_t::program_factory_t>));
 
+// True iff any of the operation's program factories builds a Metal 2.0 ProgramSpec.
+template <typename device_operation_t>
+concept HasSpecProgramFactory =
+    HasProgramFactoryType<device_operation_t> &&
+    requires { std::variant_size_v<typename device_operation_t::program_factory_t>; } &&
+    detail::any_spec_factory<typename device_operation_t::program_factory_t>(
+        std::make_index_sequence<std::variant_size_v<typename device_operation_t::program_factory_t>>{});
+
+// A Metal 2.0 operation declares nothing to be keyed correctly: reflection keys every attribute and every
+// tensor arg. It may declare two things, and nothing else:
+//   attributes_excluded_from_key -- names of attributes the key ignores (rand's seed rides in as a runtime arg)
+//   tensor_args_relaxations()    -- one relaxation per Tensor reached in tensor_args (engaged optionals only),
+//                                   so keying and Metal 2.0's argument validation stay in step.
+template <typename device_operation_t>
+concept HasTensorArgsRelaxations = requires(const typename device_operation_t::tensor_args_t& tensor_args) {
+    {
+        device_operation_t::tensor_args_relaxations(tensor_args)
+    } -> std::convertible_to<ttsl::SmallVector<tt::tt_metal::experimental::TensorSpecRelaxations>>;
+};
+
+template <typename T>
+concept HasAttributeNames = requires { T::attribute_names; };
+
+template <typename T>
+concept HasExcludedAttributes = requires { T::attributes_excluded_from_key; };
+
+template <typename attributes_t>
+consteval std::size_t excluded_attribute_count() {
+    if constexpr (HasExcludedAttributes<attributes_t>) {
+        return std::tuple_size_v<std::decay_t<decltype(attributes_t::attributes_excluded_from_key)>>;
+    } else {
+        return 0;
+    }
+}
+
+template <typename attributes_t>
+consteval std::string_view excluded_attribute_name(std::size_t index) {
+    std::array<std::string_view, excluded_attribute_count<attributes_t>()> names{};
+    [&]<std::size_t... Es>(std::index_sequence<Es...>) {
+        ((names[Es] = std::string_view{std::get<Es>(attributes_t::attributes_excluded_from_key)}), ...);
+    }(std::make_index_sequence<excluded_attribute_count<attributes_t>()>{});
+    return names[index];
+}
+
+// The only thing an op can get wrong is the name, so it is checked against the real members.
+template <typename attributes_t>
+consteval bool excluded_attributes_are_members() {
+    if constexpr (!HasExcludedAttributes<attributes_t> || !std::is_aggregate_v<attributes_t>) {
+        return true;
+    } else {
+        constexpr std::size_t num_fields = reflect::size<attributes_t>();
+        std::array<std::string_view, num_fields> members{};
+        [&]<std::size_t... Is>(std::index_sequence<Is...>) {
+            ((members[Is] = reflect::member_name<Is, attributes_t>()), ...);
+        }(std::make_index_sequence<num_fields>{});
+        for (std::size_t e = 0; e < excluded_attribute_count<attributes_t>(); ++e) {
+            const std::string_view excluded = excluded_attribute_name<attributes_t>(e);
+            bool found = false;
+            for (const auto& member : members) {
+                found = found || (member == excluded);
+            }
+            if (!found) {
+                return false;
+            }
+        }
+        return true;
+    }
+}
+
+// Is field I of attributes_t excluded from the key? Resolved at compile time against the field's real name,
+// so the fold in program_hash.hpp skips it with no runtime comparison.
+template <typename attributes_t, std::size_t I>
+consteval bool field_is_excluded() {
+    if constexpr (!HasExcludedAttributes<attributes_t> || !std::is_aggregate_v<attributes_t>) {
+        return false;
+    } else {
+        constexpr std::string_view name = reflect::member_name<I, attributes_t>();
+        for (std::size_t e = 0; e < excluded_attribute_count<attributes_t>(); ++e) {
+            if (excluded_attribute_name<attributes_t>(e) == name) {
+                return true;
+            }
+        }
+        return false;
+    }
+}
+
+// The legacy freeform hash: superseded by the declarations above, and forbidden on the spec path.
+template <typename device_operation_t>
+concept HasLegacyProgramHash = requires(
+    const typename device_operation_t::operation_attributes_t& operation_attributes,
+    const typename device_operation_t::tensor_args_t& tensor_args) {
+    {
+        device_operation_t::compute_program_hash(operation_attributes, tensor_args)
+    } -> std::convertible_to<std::uint64_t>;
+};
+
 template <typename device_operation_t>
 concept DeviceOperationWithCustomProgramCacheConcept =
-    DeviceOperationConcept<device_operation_t> &&
-    requires(
-        const typename device_operation_t::operation_attributes_t& operation_attributes,
-        const typename device_operation_t::tensor_args_t& tensor_args) {
-        {
-            device_operation_t::compute_program_hash(operation_attributes, tensor_args)
-        } -> std::convertible_to<std::uint64_t>;
-    };
+    DeviceOperationConcept<device_operation_t> && HasLegacyProgramHash<device_operation_t>;
 
 template <typename device_operation_t>
 concept HasSkipLaunch = requires(

--- a/ttnn/api/ttnn/operation_concepts.hpp
+++ b/ttnn/api/ttnn/operation_concepts.hpp
@@ -305,7 +305,8 @@ consteval bool field_is_excluded() {
     }
 }
 
-// The legacy freeform hash: superseded by the declarations above, and forbidden on the spec path.
+// The freeform hash. Defining it wins outright: the framework hashes nothing for you and derives no exact
+// key, so hash collisions silently share a cache entry. Emergency exit only -- see #51765.
 template <typename device_operation_t>
 concept HasLegacyProgramHash = requires(
     const typename device_operation_t::operation_attributes_t& operation_attributes,

--- a/ttnn/api/ttnn/program_hash.hpp
+++ b/ttnn/api/ttnn/program_hash.hpp
@@ -1,0 +1,187 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <array>
+#include <ranges>
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <span>
+#include <variant>
+#include <string>
+#include <tuple>
+#include <vector>
+
+#include <tt-metalium/experimental/metal2_host_api/tensor_spec_relaxations.hpp>
+#include <tracy/Tracy.hpp>
+#include <tt_stl/assert.hpp>
+#include <tt_stl/concepts.hpp>
+#include <tt_stl/reflection.hpp>
+#include <tt_stl/small_vector.hpp>
+
+#include "ttnn/operation_concepts.hpp"
+#include "ttnn/tensor/tensor.hpp"
+
+// The one definition of an op's program-cache hash: cache key, canonical key and profiler all call it.
+namespace ttnn::device_operation::detail {
+
+namespace hash_traits {
+
+template <typename T>
+concept HasAttributeNames = requires { std::decay_t<T>::attribute_names; };
+
+}  // namespace hash_traits
+
+// Mirrors hash_object's branches so tensor_args keeps its structure in the key: a flat tensor fold
+// would let {bias, no residual} collide with {no bias, residual}. Only the Tensor leaf is relaxed.
+class TensorArgsHasher {
+public:
+    explicit TensorArgsHasher(std::span<const tt::tt_metal::experimental::TensorSpecRelaxations> relaxations) :
+        relaxations_(relaxations) {}
+
+    template <typename T>
+    ttsl::hash::hash_t operator()(const T& object) {
+        using decayed_t = std::decay_t<T>;
+        if constexpr (std::same_as<decayed_t, ::ttnn::Tensor>) {
+            return hash_tensor(object);
+        } else if constexpr (ttsl::is_specialization_v<decayed_t, std::reference_wrapper>) {
+            return (*this)(object.get());
+        } else if constexpr (ttsl::is_specialization_v<decayed_t, std::optional>) {
+            return object.has_value() ? (*this)(*object) : 0;
+        } else if constexpr (std::ranges::input_range<decayed_t>) {
+            // Any container of elements, so a Tensor cannot hide in a SmallVector, span or set and skip
+            // its relaxation.
+            ttsl::hash::hash_t hash = 0;
+            for (const auto& element : object) {
+                hash = ttsl::hash::hash_objects(hash, (*this)(element));
+            }
+            return hash;
+        } else if constexpr (ttsl::is_specialization_v<decayed_t, std::pair>) {
+            return ttsl::hash::hash_objects((*this)(object.first), (*this)(object.second));
+        } else if constexpr (ttsl::is_specialization_v<decayed_t, std::variant>) {
+            return std::visit(
+                [&](const auto& value) { return ttsl::hash::hash_objects(object.index(), (*this)(value)); }, object);
+        } else if constexpr (ttsl::is_specialization_v<decayed_t, std::tuple>) {
+            ttsl::hash::hash_t hash = 0;
+            std::apply(
+                [&](const auto&... elements) { ((hash = ttsl::hash::hash_objects(hash, (*this)(elements))), ...); },
+                object);
+            return hash;
+        } else if constexpr (hash_traits::HasAttributeNames<decayed_t>) {
+            return (*this)(object.attribute_values());
+        } else if constexpr (ttsl::concepts::Reflectable<decayed_t>) {
+            ttsl::hash::hash_t hash = 0;
+            reflect::for_each(
+                [&](auto I) { hash = ttsl::hash::hash_objects(hash, (*this)(reflect::get<I>(object))); }, object);
+            return hash;
+        } else {
+            return ttsl::hash::hash_objects_with_default_seed(object);
+        }
+    }
+
+    std::size_t tensors_hashed() const { return next_relaxation_; }
+
+private:
+    ttsl::hash::hash_t hash_tensor(const ::ttnn::Tensor& tensor) {
+        TT_FATAL(
+            next_relaxation_ < relaxations_.size(),
+            "tensor_args_relaxations() returned {} relaxation(s), fewer than the tensors in tensor_args. Return one "
+            "per Tensor, counting only engaged std::optionals.",
+            relaxations_.size());
+        const auto& relaxation = relaxations_[next_relaxation_++];
+        return ttsl::hash::hash_objects(
+            static_cast<ttsl::hash::hash_t>(tensor.storage_type()),
+            tt::tt_metal::experimental::hash_tensorspec_with_relaxation(tensor.tensor_spec(), relaxation));
+    }
+
+    std::span<const tt::tt_metal::experimental::TensorSpecRelaxations> relaxations_;
+    std::size_t next_relaxation_ = 0;
+};
+
+template <typename TensorArgs>
+ttsl::hash::hash_t hash_tensor_args_with_relaxations(
+    const TensorArgs& tensor_args, std::span<const tt::tt_metal::experimental::TensorSpecRelaxations> relaxations) {
+    TensorArgsHasher hasher(relaxations);
+    const auto hash = hasher(tensor_args);
+    TT_FATAL(
+        hasher.tensors_hashed() == relaxations.size(),
+        "tensor_args_relaxations() returned {} relaxation(s) but {} tensor(s) were reached. Return one per Tensor, "
+        "counting only engaged std::optionals.",
+        relaxations.size(),
+        hasher.tensors_hashed());
+    return hash;
+}
+
+// Folds the attributes exactly as ttsl::hash::hash_object's Reflectable branch does, skipping the fields
+// named in attributes_excluded_from_key. Flat by design: a struct member is keyed whole or excluded whole.
+template <typename attributes_t>
+ttsl::hash::hash_t hash_declared_attributes(const attributes_t& attributes) {
+    if constexpr (!HasExcludedAttributes<attributes_t>) {
+        return ttsl::hash::hash_objects_with_default_seed(attributes);
+    } else {
+        ttsl::hash::hash_t hash = 0;
+        reflect::for_each(
+            [&](auto I) {
+                if constexpr (!field_is_excluded<attributes_t, I>()) {
+                    hash = ttsl::hash::hash_objects(hash, reflect::get<I>(attributes));
+                }
+            },
+            attributes);
+        return hash;
+    }
+}
+
+// The exact-key companion to hash_declared_attributes: same traversal, same skips, so two keys that differ
+// only in an excluded attribute encode identically and two that differ anywhere else do not.
+template <typename attributes_t>
+std::string canonical_declared_attributes(const attributes_t& attributes) {
+    if constexpr (!HasExcludedAttributes<attributes_t>) {
+        return ttsl::hash::canonical_key(attributes);
+    } else {
+        std::string key;
+        reflect::for_each(
+            [&](auto I) {
+                if constexpr (!field_is_excluded<attributes_t, I>()) {
+                    key += ttsl::hash::canonical_key(reflect::get<I>(attributes));
+                }
+            },
+            attributes);
+        return key;
+    }
+}
+
+template <typename device_operation_t>
+ttsl::hash::hash_t compute_op_hash(
+    const typename device_operation_t::operation_attributes_t& operation_attributes,
+    const typename device_operation_t::tensor_args_t& tensor_args) {
+    if constexpr (HasLegacyProgramHash<device_operation_t>) {
+        ZoneScopedN("Compute custom program hash");
+        return device_operation_t::compute_program_hash(operation_attributes, tensor_args);
+    } else if constexpr (
+        !HasExcludedAttributes<typename device_operation_t::operation_attributes_t> &&
+        !HasTensorArgsRelaxations<device_operation_t>) {
+        ZoneScopedN("Compute default program hash");
+        return ttsl::hash::hash_objects_with_default_seed(
+            ttsl::hash::type_hash<device_operation_t>, operation_attributes, tensor_args);
+    } else {
+        ZoneScopedN("Compute declared program hash");
+        const ttsl::hash::hash_t attributes_hash = hash_declared_attributes(operation_attributes);
+
+        ttsl::hash::hash_t tensors_hash = 0;
+        if constexpr (HasTensorArgsRelaxations<device_operation_t>) {
+            const ttsl::SmallVector<tt::tt_metal::experimental::TensorSpecRelaxations> relaxations =
+                device_operation_t::tensor_args_relaxations(tensor_args);
+            tensors_hash = hash_tensor_args_with_relaxations(tensor_args, relaxations);
+        } else {
+            tensors_hash = ttsl::hash::hash_objects_with_default_seed(tensor_args);
+        }
+
+        return ttsl::hash::hash_objects_with_default_seed(
+            ttsl::hash::type_hash<device_operation_t>, attributes_hash, tensors_hash);
+    }
+}
+
+}  // namespace ttnn::device_operation::detail

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_device_operation_types.hpp
@@ -219,47 +219,9 @@ struct Conv2dParams {
     uint32_t pre_op_l1_allocation_size_bytes = 0;
     std::optional<bool> force_split_reader;
 
-    static constexpr auto attribute_names = std::make_tuple(
-        "sliding_window_config",
-        "output_channels",
-        "groups",
-        "untilize_out",
-        "has_bias",
-        "activation",
-        "parallelization_config",
-        "block_config",
-        "memory_config",
-        "dtype",
-        "input_tensor_shape",
-        "compute_kernel_config",
-        "enable_act_double_buffer",
-        "enable_weights_double_buffer",
-        "full_inner_dim",
-        "enable_activation_reuse",
-        "config_tensors_in_dram",
-        "force_split_reader");
-
-    auto attribute_values() const {
-        return std::make_tuple(
-            std::cref(this->sliding_window_config),
-            this->output_channels,
-            this->groups,
-            this->untilize_out,
-            this->has_bias,
-            std::cref(this->activation),
-            this->parallelization_config,
-            this->block_config,
-            std::cref(this->memory_config),
-            this->dtype,
-            this->input_tensor_shape,
-            std::cref(this->compute_kernel_config),
-            this->enable_act_double_buffer,
-            this->enable_weights_double_buffer,
-            this->full_inner_dim,
-            this->enable_activation_reuse,
-            this->config_tensors_in_dram,
-            this->force_split_reader);
-    }
+    // Recomputed per call from live allocator state and only read by the L1-accounting assertion in
+    // conv2d_op_program_factory_common.cpp -- keying it would give every call its own program.
+    static constexpr auto attributes_excluded_from_key = std::forward_as_tuple("pre_op_l1_allocation_size_bytes");
 };
 
 struct Conv2dHashableParams {

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/binary_ng_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/binary_ng_device_operation.hpp
@@ -56,48 +56,9 @@ struct BinaryNgDeviceOperation {
         Layout input_layout_b = Layout::TILE;
         Layout output_layout = Layout::TILE;
 
-        static constexpr auto attribute_names = std::forward_as_tuple(
-            "binary_op_type",
-            "lhs_activations",
-            "rhs_activations",
-            "post_activations",
-            "memory_config",
-            "dtype",
-            "compute_kernel_config",
-            "sub_core_grids",
-            "subtile_broadcast_type",
-            "is_sfpu",
-            "is_quant_op",
-            "is_where_op",
-            "input_layout_a",
-            "input_layout_b",
-            "output_layout",
-            "equal_nan",
-            "scalar",
-            "rtol",
-            "atol");
-        auto attribute_values() const {
-            return std::make_tuple(
-                binary_op_type,
-                lhs_activations,
-                rhs_activations,
-                (is_where_op || is_quant_op) ? ttsl::SmallVector<unary::EltwiseUnaryWithParam>{} : post_activations,
-                memory_config,
-                get_dtype(),
-                compute_kernel_config,
-                sub_core_grids,
-                subtile_broadcast_type,
-                is_sfpu,
-                is_quant_op,
-                is_where_op,
-                input_layout_a,
-                input_layout_b,
-                output_layout,
-                equal_nan,
-                scalar,
-                rtol,
-                atol);
-        }
+        // input_dtype is the input tensor's own dtype, already keyed through tensor_args.
+        static constexpr auto attributes_excluded_from_key = std::forward_as_tuple("input_dtype");
+
         DataType get_dtype() const;
     };
 

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/conv2d_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/conv2d_device_operation.cpp
@@ -226,30 +226,6 @@ void Conv2dDeviceOperation::validate_on_program_cache_miss(
     }
 }
 
-ttsl::hash::hash_t Conv2dDeviceOperation::compute_program_hash(
-    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    hashable_operation_attributes_t hashable_args = {
-        .sliding_window_config = args.sliding_window_config,
-        .output_channels = args.output_channels,
-        .groups = args.groups,
-        .untilize_out = args.untilize_out,
-        .has_bias = args.has_bias,
-        .activation = args.activation,
-        .parallelization_config = args.parallelization_config,
-        .block_config = args.block_config,
-        .memory_config = args.memory_config,
-        .dtype = args.dtype,
-        .input_tensor_shape = args.input_tensor_shape,
-        .compute_kernel_config = args.compute_kernel_config,
-        .enable_act_double_buffer = args.enable_act_double_buffer,
-        .enable_weights_double_buffer = args.enable_weights_double_buffer,
-        .enable_activation_reuse = args.enable_activation_reuse,
-        .config_tensors_in_dram = args.config_tensors_in_dram,
-        .force_split_reader = args.force_split_reader,
-    };
-    return ttsl::hash::hash_objects_with_default_seed(hashable_args, tensor_args);
-}
-
 tt::tt_metal::operation::OpPerformanceModelGeneral<Tensor> Conv2dDeviceOperation::create_op_performance_model(
     const operation_attributes_t& args, const tensor_args_t& tensor_args, tensor_return_value_t& output_tensor) {
     const auto& input_tensor_a_shape = args.input_tensor_shape;

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/conv2d_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/conv2d_device_operation.hpp
@@ -28,7 +28,6 @@ namespace sliding_window = ttnn::operations::sliding_window;
 
 struct Conv2dDeviceOperation {
     using operation_attributes_t = Conv2dParams;
-    using hashable_operation_attributes_t = Conv2dHashableParams;
     using tensor_args_t = Conv2dInputs;
     using spec_return_value_t = tt::tt_metal::TensorSpec;
     using tensor_return_value_t = Tensor;
@@ -41,8 +40,6 @@ struct Conv2dDeviceOperation {
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& args, const tensor_args_t& tensor_args);
     static void validate_on_program_cache_miss(const operation_attributes_t& args, const tensor_args_t& tensor_args);
-    static ttsl::hash::hash_t compute_program_hash(
-        const operation_attributes_t& args, const tensor_args_t& tensor_args);
     static tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> create_op_performance_model(
         const operation_attributes_t& args, const tensor_args_t& tensor_args, tensor_return_value_t& output_tensor);
 };

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/matmul_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/matmul/device/matmul_device_operation_types.hpp
@@ -46,38 +46,6 @@ struct MatmulParams {
     // distinguishes pure vs bias_relu) is here; program_config (a variant) is encoded by its
     // active index + alternative. Bias PRESENCE lives in tensor_args (MatmulInputs), not here --
     // it is keyed by the same canonical-key traversal of tensor_args (see MatmulInputs).
-    static constexpr auto attribute_names = std::forward_as_tuple(
-        "program_config",
-        "bcast_batch",
-        "output_mem_config",
-        "output_dtype",
-        "compute_kernel_config",
-        "untilize_out",
-        "user_core_coord",
-        "user_fused_activation",
-        "user_run_batched",
-        "transpose_a",
-        "transpose_b",
-        "output_tile",
-        "global_cb",
-        "sub_device_id");
-    auto attribute_values() const {
-        return std::make_tuple(
-            std::cref(this->program_config),
-            std::cref(this->bcast_batch),
-            std::cref(this->output_mem_config),
-            std::cref(this->output_dtype),
-            std::cref(this->compute_kernel_config),
-            this->untilize_out,
-            std::cref(this->user_core_coord),
-            std::cref(this->user_fused_activation),
-            this->user_run_batched,
-            this->transpose_a,
-            this->transpose_b,
-            std::cref(this->output_tile),
-            std::cref(this->global_cb),
-            std::cref(this->sub_device_id));
-    }
 };
 
 struct MatmulInputs {

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/reshape_view/device/reshape_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/reshape_view/device/reshape_device_operation.cpp
@@ -57,23 +57,6 @@ ttnn::Tensor ReshapeViewDeviceOperation::create_output_tensors(
     return create_device_tensor(compute_output_specs(operation_attributes, tensor_args), tensor_args.input.device());
 }
 
-ttsl::hash::hash_t ReshapeViewDeviceOperation::compute_program_hash(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    log_trace(tt::LogOp, "ReshapeViewDeviceOperation::compute_program_hash is called");
-
-    auto program_factory = select_program_factory(operation_attributes, tensor_args);
-
-    // don't hash on operation_attributes_t::recreate_mapping_tensor
-    return tt::tt_metal::operation::hash_operation<ReshapeViewDeviceOperation>(
-        operation_attributes.logical_output_shape,
-        operation_attributes.output_mem_config,
-        operation_attributes.sub_core_grid.has_value(),
-        operation_attributes.sub_core_grid.has_value() ? operation_attributes.sub_core_grid.value()
-                                                       : CoreRangeSet(CoreRange({0, 0}, {0, 0})),
-        tensor_args,
-        program_factory.index());
-}
-
 ttnn::Tensor reshape_view(
     const Tensor& input,
     const ttnn::Shape& logical_output_shape,

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/reshape_view/device/reshape_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/reshape_view/device/reshape_device_operation.hpp
@@ -34,9 +34,6 @@ struct ReshapeViewDeviceOperation {
 
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
-
-    static ttsl::hash::hash_t compute_program_hash(
-        const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
 };
 
 ttnn::Tensor reshape_view(

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/reshape_view/device/reshape_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/reshape_view/device/reshape_device_operation_types.hpp
@@ -17,6 +17,9 @@ struct ReshapeViewParams {
     tt::tt_metal::MemoryConfig output_mem_config;
     bool recreate_mapping_tensor;
     std::optional<CoreRangeSet> sub_core_grid;
+
+    // Both factories ignore it: the mapping tensor depends only on the keyed shapes.
+    static constexpr auto attributes_excluded_from_key = std::forward_as_tuple("recreate_mapping_tensor");
 };
 
 struct ReshapeViewInputs {

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/slice_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/slice_device_operation.cpp
@@ -295,60 +295,6 @@ SliceDeviceOperation::program_factory_t SliceDeviceOperation::select_program_fac
     return SliceTileProgramFactory{};
 }
 
-// Port of tt-metal e517beb3f41 (#47602): the default program hash (boost::hash_combine style) has weak
-// distribution for small-integer shape sequences, causing false cache hits when shapes differ but
-// collide -> TT_FATAL on back-to-back slices with differing shapes. Mix in full input/output specs and
-// slice params so distinct invocations get distinct keys.
-ttsl::hash::hash_t SliceDeviceOperation::compute_program_hash(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    auto factory = select_program_factory(operation_attributes, tensor_args);
-    auto hash = tt::tt_metal::operation::hash_operation<SliceDeviceOperation>(
-        operation_attributes.slice_start,
-        operation_attributes.slice_end,
-        operation_attributes.step,
-        operation_attributes.use_tensor_args,
-        operation_attributes.slice_dim,
-        operation_attributes.num_devices,
-        operation_attributes.output_mem_config,
-        operation_attributes.sub_core_grids,
-        factory.index(),
-        tensor_args.start_tensor.has_value());
-
-    const auto& input = tensor_args.input;
-    hash = ttsl::hash::hash_objects(
-        hash,
-        input.logical_shape().rank(),
-        input.logical_shape(),
-        input.padded_shape(),
-        input.layout(),
-        input.dtype(),
-        input.memory_config());
-
-    if (tensor_args.start_tensor.has_value()) {
-        const auto& st = tensor_args.start_tensor.value();
-        hash = ttsl::hash::hash_objects(
-            hash,
-            st.logical_shape().rank(),
-            st.logical_shape(),
-            st.padded_shape(),
-            st.layout(),
-            st.dtype(),
-            st.memory_config());
-    }
-
-    const auto output_spec = compute_output_specs(operation_attributes, tensor_args);
-    hash = ttsl::hash::hash_objects(
-        hash,
-        output_spec.logical_shape().rank(),
-        output_spec.logical_shape(),
-        output_spec.padded_shape(),
-        output_spec.layout(),
-        output_spec.data_type(),
-        output_spec.memory_config());
-
-    return hash;
-}
-
 tt::tt_metal::operation::OpPerformanceModelGeneral<SliceDeviceOperation::tensor_return_value_t>
 SliceDeviceOperation::create_op_performance_model(
     const operation_attributes_t& /*args*/, const tensor_args_t& tensor_args, const Tensor& output) {

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/slice_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/slice_device_operation.hpp
@@ -42,9 +42,6 @@ struct SliceDeviceOperation {
 
     static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
 
-    // Port of tt-metal e517beb3f41 (#47602): custom hash to avoid false program-cache hits on colliding shapes.
-    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
-
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
 
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/slice_program_factory_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/slice_program_factory_rm.cpp
@@ -237,8 +237,9 @@ ttnn::device_operation::ProgramArtifacts SliceRmProgramFactory::create_program_a
 
     tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input.dtype());
 
-    // DFB sizing varies with slice_start; padded_shape folds into compute_program_hash() so each
-    // unique DFB layout gets its own cache entry (entry_size/num_entries are not patched on cache hit).
+    // DFB sizing varies with slice_start; slice_start and padded_shape are both part of the
+    // program-cache key so each unique DFB layout gets its own cache entry (entry_size/num_entries
+    // are not patched on cache hit).
     const auto [cb_page_size, num_read_per_barrier, misalignment] =
         ttnn::operations::experimental::quasar::compute_cb_size(
             input, output, args.slice_start, num_sticks_per_core_group_1, num_sticks_per_core_group_2);

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/slice_program_factory_rm.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/slice_program_factory_rm.hpp
@@ -11,8 +11,8 @@ namespace ttnn::prim::qsr {
 
 struct SliceRmProgramFactory {
     // The src0 DFB's entry_size / num_entries depend on slice_start (via misalignment /
-    // unpadded_row_size_bytes), so padded_shape is folded into compute_program_hash() — each
-    // unique DFB sizing keeps its own cache entry.
+    // unpadded_row_size_bytes), and both slice_start and the input's padded_shape are part of the
+    // program-cache key — each unique DFB sizing keeps its own cache entry.
     static ttnn::device_operation::ProgramArtifacts create_program_artifacts(
         const SliceParams& args, const SliceInputs& tensor_args, Tensor& output);
 };

--- a/ttnn/sources.cmake
+++ b/ttnn/sources.cmake
@@ -216,6 +216,7 @@ set(TTNNCPP_API_HEADERS
     api/ttnn/metal_v2_artifacts.hpp
     api/ttnn/operation.hpp
     api/ttnn/operation_concepts.hpp
+    api/ttnn/program_hash.hpp
     api/ttnn/reports.hpp
     api/ttnn/tensor/host_buffer/functions.hpp
     api/ttnn/tensor/layout/alignment.hpp


### PR DESCRIPTION
### What this changes

A Metal 2.0 operation's attributes struct declares **nothing** to be keyed correctly — reflection names and
keys every field. An operation that needs a field kept out of the cache key writes one line, and that line is
the entire dev-facing surface:

```cpp
static constexpr auto attributes_excluded_from_key = std::forward_as_tuple("from", "to", "seed");
```

The tensor half stays where Metal 2.0 owns it: `tensor_args_relaxations()` returns one `TensorSpecRelaxations`
per tensor argument, and each tensor enters the key through `hash_tensorspec_with_relaxation` (#51043) — the
same function the backend validates arguments with, so the key can never claim a generality the program does
not have.

There is no hash function to write anywhere, and four `static_assert`s make sure nobody writes one.

### Why the old way had to go

ttnn had **three** ways to change an op's key, and only one of them looked like it:

| mechanism | how it hides |
|---|---|
| `compute_program_hash(attrs, tensor_args)` | the obvious one |
| narrowing `attribute_names` | `hash_object` hashes only `attribute_values()` when the tuple exists (`tt_stl/reflection.hpp:1319`), otherwise it reflects every field (`:1418`) — so omitting a name drops the field from the key with nothing at the call site to read |
| `to_hash()` on the attributes struct | outranks even `attribute_names` (`:1314`) and replaces the attribute hash wholesale |

All three are **inclusion lists**: they state what *is* keyed, so a field added later silently stops being
keyed and no test fails. Ten operations narrow `attribute_names` today — seven re-apply the omitted values
every dispatch and are correct, three have no re-application mechanism and are simply wrong. A 30% failure
rate on a mechanism whose misuse is invisible in review is the argument for deleting it rather than
documenting it.

Naming the **exclusions** inverts the failure mode. Everything is keyed by construction; a new field is keyed
unless somebody says otherwise; and there is no second list to forget.

### How it works

Every dispatch computes one key through `detail::compute_op_hash` in the new `ttnn/api/ttnn/program_hash.hpp`.
That function is the only definition of an op's hash — the mesh cache key, the canonical key and the profiler's
reported hash all call it, where each previously had its own copy of the same `if constexpr`. It takes one of
three paths:

**1. The op wrote its own hash.** `compute_op_hash` returns `compute_program_hash(attrs, tensor_args)` verbatim
and does nothing else. Legal off the spec path only.

**2. The op declared nothing.** The existing expression runs unchanged —
`hash_objects_with_default_seed(type_hash<Op>, attrs, tensor_args)` — so an op that declares nothing keys
bit-for-bit as it does on `main` today. This is the overwhelming majority of ops, and the path is untouched.

**3. The op declared something.** The key becomes `type_hash<Op>` combined with two halves:

- *Attributes.* `hash_declared_attributes` folds the struct with `reflect::for_each`, skipping any field whose
  name appears in `attributes_excluded_from_key`. The skip is decided at compile time by
  `field_is_excluded<T, I>()`, which compares `reflect::member_name<I, T>()` against the declared names — so an
  excluded field costs nothing at dispatch, and a name that matches no field is a build error.
- *Tensor args.* `TensorArgsHasher` walks `tensor_args` mirroring `ttsl::hash::hash_object` branch for branch
  (optional, any container, pair, variant, tuple, aggregate), and at each `Tensor` leaf hashes
  `hash_tensorspec_with_relaxation(spec, relaxation)` with the next relaxation from
  `tensor_args_relaxations()`. Mirroring matters: a flat fold over just the tensors would let
  `{bias, no residual}` collide with `{no bias, residual}` whenever the two specs match. A relaxation count
  that doesn't match the tensors reached is a `TT_FATAL`, not a quietly misaligned key.

  The relaxations are **positional** rather than keyed by field name, and that is a hard constraint, not a
  preference: `reflect::member_name<I, T>()` reads names off the type via `template<class T> extern const T
  ext{};` (`reflect:530`), which requires every member to be implicitly default-constructible. `ttnn::Tensor`
  declares `explicit Tensor() = default` (`tensor.hpp:42`), so a by-value `Tensor` member does not compile, and
  a `const Tensor&` member does not either. 78 of the 89 `tensor_args_t` structs in ttnn are one of those two
  shapes. `reflect::for_each` over an object is unaffected, which is why the existing hash path never hit it.
  Names *are* available on `operation_attributes_t`, whose members are all implicitly default-constructible —
  that asymmetry is what makes `attributes_excluded_from_key` viable while a relaxation map is not.

**The exact key follows the same traversal.** `canonical_declared_attributes` skips exactly the same fields, so
the byte-exact companion key from #45821 keeps distinguishing every equivalence class the hash does. Two cases
still fall back to the op-name prefix: a hand-written `compute_program_hash`, because the framework cannot know
which fields went in, and an op that relaxes a *tensor*, because a relaxation-aware canonical encoding has to
come from the same place as the relaxation-aware hash and Metal 2.0 does not expose one yet.

Keying is deliberately **flat**: a struct member is keyed whole or excluded whole. No recursion, no nesting,
nothing transitive to reason about.

### The four checks

All gated on `HasSpecProgramFactory`, so descriptor and legacy operations keep every freedom they have today.

| check | the mistake — and the hack — it stops |
|---|---|
| no `compute_program_hash` | a hand-rolled key the framework cannot reason about |
| no `to_hash()` | silently replaces the whole attribute hash, outranking `attribute_names` |
| no `attribute_names` on a reflectable struct | a hand-maintained copy of the struct that quietly loses fields; its `attribute_values()` can also return *computed* values, coarsening the key inside what reads as a field list |
| every excluded name is a real field, per `reflect::member_name` | a typo or a renamed field excludes nothing while looking compliant |

Off the spec path nothing is forbidden. A descriptor or legacy operation may keep `compute_program_hash`, and if
it does, that hash wins outright — `compute_op_hash` returns it verbatim and the framework contributes nothing,
including no exact key. Computing the hash by hand means owning the result; the rules above exist for ops that
would rather not.

### How the gaps are covered

Partial keying of a non-tensor argument is real — three distinct shapes of it exist in the tree today. All
three are expressed by the same rule: **store the value you key on, exclude the raw member.**

| in-tree case | expressed as |
|---|---|
| `barrier_semaphore.has_value()` — presence, not value (`reduce_scatter_minimal_async_op_device_operation_types.hpp:75`) | store `bool has_barrier_semaphore`, exclude the semaphore |
| `has_kv_pad_rotation() ? 0 : logical_n` — conditional (`ring_joint_sdpa_device_operation_types.hpp:116`) | store the effective `n`, exclude the raw one |
| 11 sub-fields of one member (`strided_all_gather_minimal_matmul_async_..._types.hpp:48-53`) | store those values flat, exclude the member |

A `Shape` attribute keyed only on its volume or its innermost dims works the same way. All three cases are
descriptor-path, so nothing in this PR forces them to change; each converts in its own file when it ports, and
whoever ports it still has to decide which fields actually change the program. The declaration only moves that
decision somewhere a reviewer sees it.

**What this does not cover:** the same coarsening on the *tensor* side. Keying a tensor on volume rather than
shape needs a relaxation that does not exist yet — `match_padded_shape_only` is too strict (32×64 and 64×32
differ) and `dynamic_tensor_shape` drops volume entirely, which would reuse a program whose work split was
baked from tile count. The relaxation set is a work in progress by design and grows as ops need it; the
elementwise family needs that mode before it can port.

### The bugs this found

Every one is an inclusion list that stopped covering its struct:

- **quasar `conv2d`** excluded `full_inner_dim`, which selects `slice_inner_dim` in the sharded factory
  (`conv2d_op_sharded_program_factory.cpp:364`). Two convolutions differing only in that flag built different
  programs under one key, so the second reused the first's.
- **quasar `binary_ng`** hid `worker_grid` and `sub_device_id`. `worker_grid` is what `split_work_to_cores`
  receives (`binary_ng_metal_v2_factory.cpp:941`) — it picks the core set — and it comes from
  `device->worker_cores(TENSIX, sub_device_id)`. Nothing keyed can recover either, since tensor specs do not
  encode sub-device, so the same shapes on a different sub-device configuration hit a program built for the
  wrong cores.
- **quasar `slice`** hand-rolled a hash to work around weak small-integer hash distribution (#47602), fixed
  since #46385. Everything it listed is derived from `SliceParams` and the input specs, and having a custom
  hash opted the op out of the exact-key check and left the `end_tensor` / `preallocated_output` specs unkeyed.

- **quasar `reshape_view`** (ported to the spec path by #51591, while this PR was open) omitted
  `padded_output_shape`. It is caller-supplied, not derivable from the logical shape, and feeds
  `TensorLayout::fromPaddedShape` in `compute_output_specs` — so it changes the output buffer geometry while
  leaving the key unchanged. Its documented omission, `recreate_mapping_tensor`, is now a declared exclusion
  (both factories carry comments confirming the mapping depends only on keyed shapes).

Deliberate exclusions are now declared instead of implied: `conv2d` names `pre_op_l1_allocation_size_bytes`,
which is recomputed per call from live allocator state and read only by the L1-accounting assertion in
`conv2d_op_program_factory_common.cpp:866-889` — keying it would give every call its own program.

### Why this is better

1. **The failure mode is inverted.** Adding a field to an attributes struct is keyed by default. Under all
   three old mechanisms it silently was not.
2. **One place to look.** An op's key is its struct minus a named list, so review is reading a list of strings
   rather than auditing a function.
3. **No code on the dispatch path.** The exclusion is compile-time; there is no per-call hash function and no
   allocation (the relaxation list is a `ttsl::SmallVector`, because the hash is recomputed every dispatch).
4. **Keying and validation cannot drift.** The tensor half delegates to the function the Metal 2.0 backend
   validates with, so a key cannot claim a generality the program lacks.
5. **The exact key survives.** Declared keying keeps #45821 collision resolution instead of falling back to the
   op-name prefix, which is what a custom hash does today.
6. **Three loopholes closed for good**, with the compiler as the enforcement rather than review discipline.

### Testing

- `./build_metal.sh --build-tests` clean, and **zero static-assert failures tree-wide** — which is itself the
  audit: no spec-path operation keys itself any other way.
- **18 gtests, all passing** (`tt-nn-validation-basic`, already in `UNIT_TESTS_TTNN_BASIC_SOURCES`, host tensors
  only so they run on the PR gate rather than nightly):
  - `KeyingGapsTest` — one fake op per gap: presence-only keys *whether* not *which*; the effective value keys
    instead of the raw one; a projected member is excluded while its flat copy keys; the canonical key mirrors
    the hash for each; an op that declares nothing keys by plain reflection.
  - `ProgramHashTest` — declared exclusions, `match_padded_shape_only` sharing a key while dtype/layout still
    split it, the optional-slot structure case, and the relaxation-count `TT_FATAL`.
  - `QuasarKeyingTest` — `full_inner_dim` splits the conv key (**this test fails on today's `main`**);
    `worker_grid` and `sub_device_id` split binary_ng's; excluded `input_dtype` does not; slice's params, input
    spec and optional tensor args each still split it.
  - Compile-time assertions pinning the predicates behind all four checks, including a misspelled exclusion.
- Full `tt-nn-validation-basic` on device: **534 passed, 0 failed** (387 skipped are T3K-mesh suites).
- Python program-cache regression set (`test_cumsum.py`, `test_nlp_create_qkv_heads_program_cache.py`,
  `test_slice.py`): **517 passed, 0 failed**.

### Notes for reviewers

- **Keying changes for quasar owners to confirm.** All produce *more* cache entries, never fewer: `binary_ng`
  keys `worker_grid`/`sub_device_id` (the fix) and, with its `attribute_values` transform gone, `post_activations`
  and the raw `dtype` member; `conv2d` gains `full_inner_dim`. `quasar.conv2d` is exercised by
  `models/demos/vision/classification/resnet50/quasar`, which deserves a run by someone with the hardware —
  neither quasar op has a functional test in the repo.
- `Conv2dParams` is shared with the non-quasar conv2d. Its keying is unchanged: reflection over 19 fields minus
  the declared exclusion is the same 18 it keyed before. quasar `MatmulParams` listed 14 names for 14 fields —
  pure duplication of what reflection does — so both tuples are deleted with no keying change.
- **This PR is rebase-sensitive by nature.** The asserts fail on any spec-path op that still keys the old way,
  so every newly ported op that lands on `main` can turn CI red until this rebases. That already happened once:
  #51591 ported `reshape_view` and added `attribute_names` to `MatmulParams` after this branch was cut, which
  is how the `padded_output_shape` bug above surfaced. Now rebased onto `24a680b6039` with both migrated, and
  worth landing promptly rather than letting it sit.
- The `rand` port stacked on top is the first consumer of the declarative form.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/ttnn-relaxation-hash)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/ttnn-relaxation-hash)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/ttnn-relaxation-hash)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/ttnn-relaxation-hash)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=dgomez/ttnn-relaxation-hash)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:dgomez/ttnn-relaxation-hash)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/ttnn-relaxation-hash)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/ttnn-relaxation-hash)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/ttnn-relaxation-hash)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/ttnn-relaxation-hash)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/ttnn-relaxation-hash)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/ttnn-relaxation-hash)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/ttnn-relaxation-hash)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/ttnn-relaxation-hash)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/ttnn-relaxation-hash)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/ttnn-relaxation-hash)