### PR TITLE
Use monotonic semaphores in Quasar pipeline test kernels

### DIFF
--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dram_to_l1_pipeline.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dram_to_l1_pipeline.cpp
@@ -40,6 +40,6 @@ void kernel_main() {
             src_dram, l1_buf, sizeof(uint32_t), {.bank_id = dram_src_bank_id, .addr = dram_src_address + offset}, {});
         noc.async_read_barrier();
 
-        sem.up(1);
+        sem.set(i + 1);
     }
 }

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/l1_to_dram_pipeline.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/l1_to_dram_pipeline.cpp
@@ -26,7 +26,7 @@ void kernel_main() {
 #endif
 
     for (uint32_t i = 0; i < num_elements; i++) {
-        sem.down(1);
+        sem.wait_min(i + 1);
 
         const uint32_t offset = i * static_cast<uint32_t>(sizeof(uint32_t));
         DPRINT(

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/transform_pipeline.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/transform_pipeline.cpp
@@ -26,14 +26,14 @@ void kernel_main() {
 
     for (uint32_t i = 0; i < num_elements; i++) {
 #if defined(INCOMING_SEM)
-        sem_in.down(1);
+        sem_in.wait_min(i + 1);
 #endif
         const uint32_t val = a[i];
         const uint32_t new_val = val + 1;
         b[i] = new_val;
         DPRINT("Read the value {} and wrote the value {}\n", val, new_val);
 #if defined(OUTGOING_SEM)
-        sem_out.up(1);
+        sem_out.set(i + 1);
 #endif
     }
 }


### PR DESCRIPTION
### PR Category
Test Only

### Summary
The Quasar multi-semaphore pipeline test could hang because adjacent pipeline stages used local `Semaphore::up()` and `Semaphore::down()` on the same L1 semaphore word. Those APIs are implemented as non-atomic read/modify/write sequences, so an increment from the producer could race with a decrement from the consumer and lose a token, leaving the final stage waiting forever. The pipeline kernels now use monotonic sequence counters instead: each producer publishes completion with `set(i + 1)`, and each consumer waits with `wait_min(i + 1)`. This preserves the ordered single-producer/single-consumer dependency while avoiding any concurrent read/modify/write on the semaphore word.

### Notes for reviewers
none

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mcraighead/qsr-monotonic-semaphore)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mcraighead/qsr-monotonic-semaphore)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mcraighead/qsr-monotonic-semaphore)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mcraighead/qsr-monotonic-semaphore)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mcraighead/qsr-monotonic-semaphore)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mcraighead/qsr-monotonic-semaphore)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mcraighead/qsr-monotonic-semaphore)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mcraighead/qsr-monotonic-semaphore)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mcraighead/qsr-monotonic-semaphore)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mcraighead/qsr-monotonic-semaphore)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mcraighead/qsr-monotonic-semaphore)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mcraighead/qsr-monotonic-semaphore)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mcraighead/qsr-monotonic-semaphore)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mcraighead/qsr-monotonic-semaphore)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mcraighead/qsr-monotonic-semaphore)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mcraighead/qsr-monotonic-semaphore)