### PR TITLE
Release notes: list the full PR set (fetchViaCommits)

### DIFF
--- a/.github/workflows/package-and-release.yaml
+++ b/.github/workflows/package-and-release.yaml
@@ -239,7 +239,7 @@ jobs:
       - name: Create changelog
         if: ${{ !inputs.dry-run }}
         id: create-changelog
-        uses: mikepenz/release-changelog-builder-action@v4
+        uses: mikepenz/release-changelog-builder-action@32e3c96f29a6532607f638797455e9e98cfc703d # v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           configuration: infra/release-changelog-config.json

--- a/.github/workflows/package-and-release.yaml
+++ b/.github/workflows/package-and-release.yaml
@@ -245,6 +245,12 @@ jobs:
           configuration: infra/release-changelog-config.json
           fromTag: ${{ steps.get-previous-tag.outputs.previous-tag }}
           toTag: ${{ needs.create-tag.outputs.version }}
+          # Resolve each commit in the range to its PR via the commits API instead
+          # of matching PR merge_commit_sha within a merge-date window. Our release
+          # branch re-creates commits (new SHAs) and lands PRs later than they
+          # merged to main, so the default matching only associated a handful of
+          # PRs (e.g. v0.74.0 listed 8 of ~600). One API call per commit.
+          fetchViaCommits: true
           failOnError: true
           outputFile: CHANGELOG.txt
       - name: Create empty changelog for dry run


### PR DESCRIPTION
## Problem

The `v0.74.0` release notes listed only **8 PRs**. The changelog builder (`mikepenz/release-changelog-builder-action`) logged, for that run:

```
Found 664 commits ... Fetching PRs between dates 2026-06-15 .. 2026-07-09
Retrieved 276 PRs in date range from API
Retrieved 8 merged PRs
Wrote 8 non categorized pull requests down
```

So the range was not short (664 commits, 276 candidate PRs) — the builder just could not **associate** them. Its default keys each PR by `merge_commit_sha` within the tag-date window. Our release branch re-creates commits with new SHAs and lands PRs later than they merged to `main` (PRs merged to `main` in that window are `diverged` from the release tag, not ancestors), so only 8 of 276 matched. The rest of the release-line commits resolve to real PRs fine via the per-commit API (verified: e.g. commit `f46cbac7` → #46853).

## Fix

Set `fetchViaCommits: true`, which resolves each commit in the range to its PR via the commits API instead of the merge-date + `merge_commit_sha` match. That surfaces the full set (~600 for v0.74.0). Cost is one API call per commit.

Applies to dev/rc/prod (shared step); dev/rc ranges are small so the extra calls are negligible and only make those lists more accurate. Previous-tag logic is unchanged (prod still bases off the previous prod tag, e.g. `v0.73.1`).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgnidash/release-notes-full-changelog)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgnidash/release-notes-full-changelog)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgnidash/release-notes-full-changelog)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgnidash/release-notes-full-changelog)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=dgnidash/release-notes-full-changelog)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:dgnidash/release-notes-full-changelog)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgnidash/release-notes-full-changelog)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgnidash/release-notes-full-changelog)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgnidash/release-notes-full-changelog)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgnidash/release-notes-full-changelog)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgnidash/release-notes-full-changelog)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgnidash/release-notes-full-changelog)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgnidash/release-notes-full-changelog)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgnidash/release-notes-full-changelog)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgnidash/release-notes-full-changelog)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgnidash/release-notes-full-changelog)