### PR TITLE
[ttnn] quasar conv2d/slice: drop custom program hashes that key on less than the program

### DIFF
--- a/tests/ttnn/unit_tests/gtests/sources.cmake
+++ b/tests/ttnn/unit_tests/gtests/sources.cmake
@@ -30,6 +30,7 @@ set(UNIT_TESTS_TTNN_BASIC_SOURCES
     test_graph_query_op_runtime.cpp
     test_launch_operation.cpp
     test_matmul.cpp
+    test_quasar_program_keying.cpp
     test_matmul_multicore.cpp
     test_matmul_sweep.cpp
     test_reduction.cpp

--- a/tests/ttnn/unit_tests/gtests/test_quasar_program_keying.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_quasar_program_keying.cpp
@@ -1,0 +1,124 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gmock/gmock.h>
+
+#include "ttnn/operations/conv/conv2d/device/conv2d_device_operation_types.hpp"
+#include "ttnn/operations/experimental/quasar/conv2d/device/conv2d_device_operation.hpp"
+#include "ttnn/operations/experimental/quasar/slice/device/slice_device_operation.hpp"
+#include "ttnn/device_operation.hpp"
+#include "ttnn/tensor/tensor.hpp"
+
+// These ops had custom program hashes that keyed on less than the framework's reflection does. The
+// hashes are gone; these pin what the key must still discriminate, so a narrowing regression fails here.
+namespace ttnn {
+namespace {
+
+using ::ttnn::device_operation::detail::compute_program_hash;
+
+Tensor host_tensor(const ttnn::Shape& logical_shape, Layout layout = Layout::TILE) {
+    const tt::tt_metal::TensorSpec spec(
+        logical_shape, tt::tt_metal::TensorLayout(DataType::FLOAT32, layout, MemoryConfig{}));
+    return Tensor::from_vector(std::vector<float>(logical_shape.volume()), spec);
+}
+
+using ConvOp = ttnn::prim::qsr::Conv2dDeviceOperation;
+
+ttnn::prim::Conv2dInputs conv_inputs() {
+    return ttnn::prim::Conv2dInputs{
+        .a = host_tensor(ttnn::Shape{1, 1, 64, 32}), .b = host_tensor(ttnn::Shape{1, 1, 32, 32}), .bias = std::nullopt};
+}
+
+// full_inner_dim selects slice_inner_dim in the sharded factory, so it changes the program. The removed
+// custom hash left it out: these two convs shared one cache entry, and the second reused the first's
+// program. Reflection over Conv2dParams keys it.
+TEST(QuasarKeyingTest, Conv2dKeysFullInnerDim) {
+    ttnn::prim::Conv2dParams params{};
+    auto other = params;
+    other.full_inner_dim = !params.full_inner_dim;
+
+    const auto inputs = conv_inputs();
+    EXPECT_NE(compute_program_hash<ConvOp>(params, inputs), compute_program_hash<ConvOp>(other, inputs));
+}
+
+TEST(QuasarKeyingTest, Conv2dKeepsKeyingTheOldHashFields) {
+    const ttnn::prim::Conv2dParams params{};
+    const auto inputs = conv_inputs();
+    EXPECT_EQ(compute_program_hash<ConvOp>(params, inputs), compute_program_hash<ConvOp>(params, inputs));
+
+    // A sample of the fields the removed hash listed; each must still split the key.
+    auto changed_channels = params;
+    changed_channels.output_channels = params.output_channels + 1;
+    EXPECT_NE(compute_program_hash<ConvOp>(params, inputs), compute_program_hash<ConvOp>(changed_channels, inputs));
+
+    auto changed_bias = params;
+    changed_bias.has_bias = !params.has_bias;
+    EXPECT_NE(compute_program_hash<ConvOp>(params, inputs), compute_program_hash<ConvOp>(changed_bias, inputs));
+
+    auto changed_dtype = params;
+    changed_dtype.dtype = DataType::BFLOAT16;
+    EXPECT_NE(compute_program_hash<ConvOp>(params, inputs), compute_program_hash<ConvOp>(changed_dtype, inputs));
+
+    // Tensor args are keyed too — the removed hash folded them in via the default reflection hash.
+    ttnn::prim::Conv2dInputs other_inputs = conv_inputs();
+    other_inputs.a = host_tensor(ttnn::Shape{1, 1, 128, 32});
+    EXPECT_NE(compute_program_hash<ConvOp>(params, inputs), compute_program_hash<ConvOp>(params, other_inputs));
+}
+
+using SliceOp = ttnn::prim::qsr::SliceDeviceOperation;
+
+ttnn::prim::qsr::SliceParams slice_params() {
+    return ttnn::prim::qsr::SliceParams{
+        .slice_start = ttnn::Shape{0, 0, 0, 0},
+        .slice_end = ttnn::Shape{1, 1, 32, 32},
+        .step = ttnn::Shape{1, 1, 1, 1},
+        .output_mem_config = MemoryConfig{}};
+}
+
+// The removed hash listed slice params, the input spec (rank/logical/padded/layout/dtype/memory_config),
+// the derived output spec and the selected factory index. padded_shape is computed from logical_shape +
+// tensor_layout, and both derived values are pure functions of these same inputs, so reflection covers
+// them — pinned here rather than argued.
+TEST(QuasarKeyingTest, SliceKeysParamsAndInputSpec) {
+    const auto params = slice_params();
+    const ttnn::prim::qsr::SliceInputs inputs{.input = host_tensor(ttnn::Shape{1, 1, 64, 32})};
+    EXPECT_EQ(compute_program_hash<SliceOp>(params, inputs), compute_program_hash<SliceOp>(params, inputs));
+
+    auto moved_start = params;
+    moved_start.slice_start = ttnn::Shape{0, 0, 32, 0};
+    EXPECT_NE(compute_program_hash<SliceOp>(params, inputs), compute_program_hash<SliceOp>(moved_start, inputs));
+
+    auto strided = params;
+    strided.step = ttnn::Shape{1, 1, 2, 1};
+    EXPECT_NE(compute_program_hash<SliceOp>(params, inputs), compute_program_hash<SliceOp>(strided, inputs));
+
+    // Input spec: logical shape and layout both feed the factory choice and the work split.
+    const ttnn::prim::qsr::SliceInputs taller{.input = host_tensor(ttnn::Shape{1, 1, 128, 32})};
+    EXPECT_NE(compute_program_hash<SliceOp>(params, inputs), compute_program_hash<SliceOp>(params, taller));
+
+    const ttnn::prim::qsr::SliceInputs row_major{.input = host_tensor(ttnn::Shape{1, 1, 64, 32}, Layout::ROW_MAJOR)};
+    EXPECT_NE(compute_program_hash<SliceOp>(params, inputs), compute_program_hash<SliceOp>(params, row_major));
+}
+
+// start_tensor presence was keyed explicitly by the removed hash; end_tensor and preallocated_output
+// were not keyed at all. Reflection keys the shape of tensor_args, so all three split the key now.
+TEST(QuasarKeyingTest, SliceKeysOptionalTensorArgs) {
+    const auto params = slice_params();
+    const Tensor tensor = host_tensor(ttnn::Shape{1, 1, 64, 32});
+    const ttnn::prim::qsr::SliceInputs bare{.input = tensor};
+
+    ttnn::prim::qsr::SliceInputs with_start{.input = tensor};
+    with_start.start_tensor = tensor;
+    EXPECT_NE(compute_program_hash<SliceOp>(params, bare), compute_program_hash<SliceOp>(params, with_start));
+
+    ttnn::prim::qsr::SliceInputs with_end{.input = tensor};
+    with_end.end_tensor = tensor;
+    EXPECT_NE(compute_program_hash<SliceOp>(params, bare), compute_program_hash<SliceOp>(params, with_end));
+
+    // Same tensor in a different optional slot must not collide.
+    EXPECT_NE(compute_program_hash<SliceOp>(params, with_start), compute_program_hash<SliceOp>(params, with_end));
+}
+
+}  // namespace
+}  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/conv2d_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/conv2d_device_operation.cpp
@@ -142,30 +142,6 @@ void Conv2dDeviceOperation::validate_on_program_cache_miss(
     }
 }
 
-ttsl::hash::hash_t Conv2dDeviceOperation::compute_program_hash(
-    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    hashable_operation_attributes_t hashable_args = {
-        .sliding_window_config = args.sliding_window_config,
-        .output_channels = args.output_channels,
-        .groups = args.groups,
-        .untilize_out = args.untilize_out,
-        .has_bias = args.has_bias,
-        .activation = args.activation,
-        .parallelization_config = args.parallelization_config,
-        .block_config = args.block_config,
-        .memory_config = args.memory_config,
-        .dtype = args.dtype,
-        .input_tensor_shape = args.input_tensor_shape,
-        .compute_kernel_config = args.compute_kernel_config,
-        .enable_act_double_buffer = args.enable_act_double_buffer,
-        .enable_weights_double_buffer = args.enable_weights_double_buffer,
-        .enable_activation_reuse = args.enable_activation_reuse,
-        .config_tensors_in_dram = args.config_tensors_in_dram,
-        .force_split_reader = args.force_split_reader,
-    };
-    return ttsl::hash::hash_objects_with_default_seed(hashable_args, tensor_args);
-}
-
 tt::tt_metal::operation::OpPerformanceModelGeneral<Tensor> Conv2dDeviceOperation::create_op_performance_model(
     const operation_attributes_t& args, const tensor_args_t& tensor_args, tensor_return_value_t& output_tensor) {
     const auto& input_tensor_a_shape = args.input_tensor_shape;

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/conv2d_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/conv2d_device_operation.hpp
@@ -28,7 +28,6 @@ namespace sliding_window = ttnn::operations::sliding_window;
 
 struct Conv2dDeviceOperation {
     using operation_attributes_t = Conv2dParams;
-    using hashable_operation_attributes_t = Conv2dHashableParams;
     using tensor_args_t = Conv2dInputs;
     using spec_return_value_t = tt::tt_metal::TensorSpec;
     using tensor_return_value_t = Tensor;
@@ -41,8 +40,8 @@ struct Conv2dDeviceOperation {
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& args, const tensor_args_t& tensor_args);
     static void validate_on_program_cache_miss(const operation_attributes_t& args, const tensor_args_t& tensor_args);
-    static ttsl::hash::hash_t compute_program_hash(
-        const operation_attributes_t& args, const tensor_args_t& tensor_args);
+    // No custom hash: Conv2dParams::attribute_names is the exclusion list (it omits
+    // pre_op_l1_allocation_size_bytes) and the framework reflects over it.
     static tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> create_op_performance_model(
         const operation_attributes_t& args, const tensor_args_t& tensor_args, tensor_return_value_t& output_tensor);
 };

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/slice_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/slice_device_operation.cpp
@@ -295,60 +295,6 @@ SliceDeviceOperation::program_factory_t SliceDeviceOperation::select_program_fac
     return SliceTileProgramFactory{};
 }
 
-// Port of tt-metal e517beb3f41 (#47602): the default program hash (boost::hash_combine style) has weak
-// distribution for small-integer shape sequences, causing false cache hits when shapes differ but
-// collide -> TT_FATAL on back-to-back slices with differing shapes. Mix in full input/output specs and
-// slice params so distinct invocations get distinct keys.
-ttsl::hash::hash_t SliceDeviceOperation::compute_program_hash(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    auto factory = select_program_factory(operation_attributes, tensor_args);
-    auto hash = tt::tt_metal::operation::hash_operation<SliceDeviceOperation>(
-        operation_attributes.slice_start,
-        operation_attributes.slice_end,
-        operation_attributes.step,
-        operation_attributes.use_tensor_args,
-        operation_attributes.slice_dim,
-        operation_attributes.num_devices,
-        operation_attributes.output_mem_config,
-        operation_attributes.sub_core_grids,
-        factory.index(),
-        tensor_args.start_tensor.has_value());
-
-    const auto& input = tensor_args.input;
-    hash = ttsl::hash::hash_objects(
-        hash,
-        input.logical_shape().rank(),
-        input.logical_shape(),
-        input.padded_shape(),
-        input.layout(),
-        input.dtype(),
-        input.memory_config());
-
-    if (tensor_args.start_tensor.has_value()) {
-        const auto& st = tensor_args.start_tensor.value();
-        hash = ttsl::hash::hash_objects(
-            hash,
-            st.logical_shape().rank(),
-            st.logical_shape(),
-            st.padded_shape(),
-            st.layout(),
-            st.dtype(),
-            st.memory_config());
-    }
-
-    const auto output_spec = compute_output_specs(operation_attributes, tensor_args);
-    hash = ttsl::hash::hash_objects(
-        hash,
-        output_spec.logical_shape().rank(),
-        output_spec.logical_shape(),
-        output_spec.padded_shape(),
-        output_spec.layout(),
-        output_spec.data_type(),
-        output_spec.memory_config());
-
-    return hash;
-}
-
 tt::tt_metal::operation::OpPerformanceModelGeneral<SliceDeviceOperation::tensor_return_value_t>
 SliceDeviceOperation::create_op_performance_model(
     const operation_attributes_t& /*args*/, const tensor_args_t& tensor_args, const Tensor& output) {

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/slice_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/slice_device_operation.hpp
@@ -42,8 +42,8 @@ struct SliceDeviceOperation {
 
     static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
 
-    // Port of tt-metal e517beb3f41 (#47602): custom hash to avoid false program-cache hits on colliding shapes.
-    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+    // The hash ported in #47602 worked around weak hash distribution, fixed by #46385. All it listed
+    // is derived from SliceParams + the input specs, and reflection keeps the exact-key check.
 
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
 

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/slice_program_factory_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/slice_program_factory_rm.cpp
@@ -237,8 +237,9 @@ ttnn::device_operation::ProgramArtifacts SliceRmProgramFactory::create_program_a
 
     tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input.dtype());
 
-    // DFB sizing varies with slice_start; padded_shape folds into compute_program_hash() so each
-    // unique DFB layout gets its own cache entry (entry_size/num_entries are not patched on cache hit).
+    // DFB sizing varies with slice_start; slice_start and padded_shape are both part of the
+    // program-cache key so each unique DFB layout gets its own cache entry (entry_size/num_entries
+    // are not patched on cache hit).
     const auto [cb_page_size, num_read_per_barrier, misalignment] =
         ttnn::operations::experimental::quasar::compute_cb_size(
             input, output, args.slice_start, num_sticks_per_core_group_1, num_sticks_per_core_group_2);

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/slice_program_factory_rm.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/slice_program_factory_rm.hpp
@@ -11,8 +11,8 @@ namespace ttnn::prim::qsr {
 
 struct SliceRmProgramFactory {
     // The src0 DFB's entry_size / num_entries depend on slice_start (via misalignment /
-    // unpadded_row_size_bytes), so padded_shape is folded into compute_program_hash() — each
-    // unique DFB sizing keeps its own cache entry.
+    // unpadded_row_size_bytes), and both slice_start and the input's padded_shape are part of the
+    // program-cache key — each unique DFB sizing keeps its own cache entry.
     static ttnn::device_operation::ProgramArtifacts create_program_artifacts(
         const SliceParams& args, const SliceInputs& tensor_args, Tensor& output);
 };


### PR DESCRIPTION
### What

Two quasar operations key their program cache on less than what actually builds the program. Both
custom hashes are removed; reflection over the attributes and tensor args covers what they listed.

**`quasar/conv2d` — latent false cache hit.** `Conv2dHashableParams` is `Conv2dParams::attribute_names`
**minus `full_inner_dim`**, and `full_inner_dim` selects `slice_inner_dim` in
`conv2d_op_sharded_program_factory.cpp:364`. Two convolutions differing only in that flag build
different programs but hash identically, so the second silently reuses the first one's program.
Dropping the custom hash keys it. Attribute exclusion stays where it belongs — `attribute_names` still
omits `pre_op_l1_allocation_size_bytes`.

**`quasar/slice` — obsolete workaround.** The hash was ported in #47602 because the default hash then
combined small-integer shape sequences weakly enough to collide. #46385 fixed that (splitmix64 mixer
plus an exact canonical key resolving any surviving collision). Everything the hand-rolled hash listed
— rank, `padded_shape`, the output spec, `factory.index()` — is derived from `SliceParams` and the
input specs, so reflection already keys it. Two side effects, both improvements: a custom hash opts the
op out of the exact-key collision check, and this one silently ignored the `end_tensor` /
`preallocated_output` specs.

### Testing

Built with `./build_metal.sh --build-tests`. Neither op has a dedicated test in the repo (only quasar
`binary_ng` does), so behaviour here is argued from the factories rather than measured — see the note
below.

### Notes for reviewers

- `quasar.conv2d` is used by `models/demos/vision/classification/resnet50/quasar`. `full_inner_dim`
  entering the cache key is a behaviour change for that model (correctness fix: it stops reusing the
  wrong program), and it deserves a sanity run by someone with the hardware.
- Keying gets strictly finer in both cases — no new cache hits are introduced, only removed.
- This is the first of a stack: the follow-up restricts op-declared keying so a spec-path op cannot
  write a freeform hash at all, which is what surfaced these two.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/quasar-drop-custom-hashes)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/quasar-drop-custom-hashes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/quasar-drop-custom-hashes)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/quasar-drop-custom-hashes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=dgomez/quasar-drop-custom-hashes)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:dgomez/quasar-drop-custom-hashes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/quasar-drop-custom-hashes)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/quasar-drop-custom-hashes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/quasar-drop-custom-hashes)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/quasar-drop-custom-hashes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/quasar-drop-custom-hashes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/quasar-drop-custom-hashes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/quasar-drop-custom-hashes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/quasar-drop-custom-hashes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/quasar-drop-custom-hashes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/quasar-drop-custom-hashes)
