### PR TITLE
Update DSv3 weights path in CI after deletion

### DIFF
--- a/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
+++ b/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
@@ -15,7 +15,7 @@
 # Blackhole Galaxy DeepSeek Prefill tests
 - name: "Blaze - MoE Gate"
   cmd: |
-    export DEEPSEEK_V3_HF_MODEL=/mnt/models/deepseek-ai/DeepSeek-R1-0528
+    export DEEPSEEK_V3_HF_MODEL=/mnt/models/deepseek-ai/DeepSeek-R1-0528-dequantized/DeepSeek-R1-dequantized/
     export DEEPSEEK_V3_CACHE=/mnt/models/DeepSeek-R1-0528-Cache/CI
     export TT_DS_PREFILL_TTNN_CACHE=/mnt/models/DeepSeek-R1-0528-Cache/DeepSeek-R1-0528-Cache-prefill_secure
     export TT_DS_PREFILL_HOST_REF_CACHE=/mnt/models/deepseek-prefill-cache/golden/
@@ -37,7 +37,7 @@
 
 - name: "Blaze - MLA"
   cmd: |
-    export DEEPSEEK_V3_HF_MODEL=/mnt/models/deepseek-ai/DeepSeek-R1-0528
+    export DEEPSEEK_V3_HF_MODEL=/mnt/models/deepseek-ai/DeepSeek-R1-0528-dequantized/DeepSeek-R1-dequantized/
     export DEEPSEEK_V3_CACHE=/mnt/models/DeepSeek-R1-0528-Cache/CI
     export TT_DS_PREFILL_TTNN_CACHE=/mnt/models/DeepSeek-R1-0528-Cache/DeepSeek-R1-0528-Cache-prefill_secure
     export TT_DS_PREFILL_HOST_REF_CACHE=/mnt/models/deepseek-prefill-cache/golden/
@@ -100,7 +100,7 @@
 
 - name: "Blaze - Prefill Block"
   cmd: |
-    export DEEPSEEK_V3_HF_MODEL=/mnt/models/deepseek-ai/DeepSeek-R1-0528
+    export DEEPSEEK_V3_HF_MODEL=/mnt/models/deepseek-ai/DeepSeek-R1-0528-dequantized/DeepSeek-R1-dequantized/
     export DEEPSEEK_V3_CACHE=/mnt/models/DeepSeek-R1-0528-Cache/CI
     export TT_DS_PREFILL_TTNN_CACHE=/mnt/models/DeepSeek-R1-0528-Cache/DeepSeek-R1-0528-Cache-prefill_secure
     export TT_DS_PREFILL_HOST_REF_CACHE=/mnt/models/deepseek-prefill-cache/golden/
@@ -160,7 +160,7 @@
 
 - name: "Blaze - DSA MLA (V3.2)"
   cmd: |
-    export DEEPSEEK_V3_HF_MODEL=/mnt/models/deepseek-ai/DeepSeek-R1-0528
+    export DEEPSEEK_V3_HF_MODEL=/mnt/models/deepseek-ai/DeepSeek-R1-0528-dequantized/DeepSeek-R1-dequantized/
     export DEEPSEEK_V32_MLA_REF_CACHE=/tmp/deepseek_v32_mla_ref_cache
     export DS_SPARSE_FABRIC=fabric2d
 
@@ -280,7 +280,7 @@
 
 - name: "Blaze - Prefill Block Determinism"
   cmd: |
-    export DEEPSEEK_V3_HF_MODEL=/mnt/models/deepseek-ai/DeepSeek-R1-0528
+    export DEEPSEEK_V3_HF_MODEL=/mnt/models/deepseek-ai/DeepSeek-R1-0528-dequantized/DeepSeek-R1-dequantized/
     export DEEPSEEK_V3_CACHE=/mnt/models/DeepSeek-R1-0528-Cache/CI
     export TT_DS_PREFILL_TTNN_CACHE=/mnt/models/DeepSeek-R1-0528-Cache/DeepSeek-R1-0528-Cache-prefill_secure
     export TT_DS_PREFILL_HOST_REF_CACHE=/mnt/models/deepseek-prefill-cache/golden/
@@ -304,7 +304,7 @@
 
 - name: "Blaze - Transformer Determinism"
   cmd: |
-    export DEEPSEEK_V3_HF_MODEL=/mnt/models/deepseek-ai/DeepSeek-R1-0528
+    export DEEPSEEK_V3_HF_MODEL=/mnt/models/deepseek-ai/DeepSeek-R1-0528-dequantized/DeepSeek-R1-dequantized/
     export DEEPSEEK_V3_CACHE=/mnt/models/DeepSeek-R1-0528-Cache/CI
     export TT_DS_PREFILL_TTNN_CACHE=/mnt/models/DeepSeek-R1-0528-Cache/DeepSeek-R1-0528-Cache-prefill_secure
     export TT_DS_PREFILL_HOST_REF_CACHE=/mnt/models/deepseek-prefill-cache/golden/

--- a/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
+++ b/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
@@ -77,7 +77,7 @@
 
 - name: "Blaze - KV cache table"
   cmd: |
-    export DEEPSEEK_V3_HF_MODEL=/mnt/models/deepseek-ai/DeepSeek-R1-0528-dequantized
+    export DEEPSEEK_V3_HF_MODEL=/mnt/models/deepseek-ai/DeepSeek-R1-0528
     export DEEPSEEK_V3_CACHE=/mnt/models/DeepSeek-R1-0528-Cache/CI
     export TT_DS_PREFILL_TTNN_CACHE=/mnt/models/DeepSeek-R1-0528-Cache/DeepSeek-R1-0528-Cache-prefill_secure
     export TT_DS_PREFILL_HOST_REF_CACHE=/mnt/models/deepseek-prefill-cache/golden/

--- a/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
+++ b/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
@@ -77,7 +77,7 @@
 
 - name: "Blaze - KV cache table"
   cmd: |
-    export DEEPSEEK_V3_HF_MODEL=/mnt/models/deepseek-ai/DeepSeek-R1-0528
+    export DEEPSEEK_V3_HF_MODEL=/mnt/models/deepseek-ai/DeepSeek-R1-0528-dequantized/DeepSeek-R1-dequantized/
     export DEEPSEEK_V3_CACHE=/mnt/models/DeepSeek-R1-0528-Cache/CI
     export TT_DS_PREFILL_TTNN_CACHE=/mnt/models/DeepSeek-R1-0528-Cache/DeepSeek-R1-0528-Cache-prefill_secure
     export TT_DS_PREFILL_HOST_REF_CACHE=/mnt/models/deepseek-prefill-cache/golden/


### PR DESCRIPTION
## PR Category

CI fix / bug fix

## Summary

Two independent breakages were stacking on the Blaze DeepSeek prefill jobs. The second one was invisible until the first was fixed.

1. **Stale weight paths.** The `/mnt/models/deepseek-ai/` store was rebuilt on 2026-07-28. Both paths the Blaze matrix exported stopped being checkpoint roots, so weight resolution fell silently through to a ~240 GiB HuggingFace download and every affected job burned its entire step budget. 7 `DEEPSEEK_V3_HF_MODEL` exports are repointed at the real nested checkpoint.
2. **A broken keyword argument on `main`.** #48826 renamed the KV chunk-table builders' `tt_kvpe_cache` parameter to `kvpe_cache` and updated none of the 9 callers, so every call raises `TypeError`. This is broken on `main` today, not just on this branch. 9 call sites fixed.

Net change: **4 files, 15 insertions, 15 deletions.** No production model code, no device code.

| File | Lines | What |
|---|---|---|
| `tests/pipeline_reorg/blaze_models_prefill_tests.yaml` | 7 | repoint `DEEPSEEK_V3_HF_MODEL` |
| `models/demos/deepseek_v3_d_p/tests/test_kv_cache_table.py` | 5 | `tt_kvpe_cache=` → `kvpe_cache=` |
| `models/demos/deepseek_v3_d_p/tt/runners/kv_chunk_table.py` | 2 | `tt_kvpe_cache=` → `kvpe_cache=` |
| `models/demos/deepseek_v3_d_p/tests/test_disaggregation.py` | 1 | `tt_kvpe_cache=` → `kvpe_cache=` |

---

## Change 1 — repoint the DeepSeek weight paths

### What broke

On 2026-07-28 (dirs stamped 17:24 / 17:34, shard files 16:59–18:29, owner `jvega`) the store was restructured. Before, CI used two sibling checkpoint roots. After, there is a single **container** directory holding two nested checkpoints:

```
/mnt/models/deepseek-ai/
└── DeepSeek-R1-0528-dequantized/          <- was a checkpoint root, now just a container
    ├── DeepSeek-R1/                       <- 163 shards, 45808 weight_scale_inv keys  (fp8)
    └── DeepSeek-R1-dequantized/           <- 163 shards, 0 weight_scale_inv keys      (bf16)
```

`/mnt/models/deepseek-ai/DeepSeek-R1-0528` no longer exists at all, and `…/DeepSeek-R1-0528-dequantized` no longer holds `model.safetensors.index.json`. Both spellings were in use by the matrix.

### Why it manifested as a silent 10-minute timeout

`get_or_download_model` (`models/demos/deepseek_v3_d_p/tests/conftest.py:531`) tries four sources in order and **treats a bad env path as a warning, not an error**:

| Step | Source | Result after the restructure |
|---|---|---|
| 1 | `$DEEPSEEK_V3_HF_MODEL` | path exists, but `_resolve_hf_snapshot_dir` (`:508`) only descends into an HF-hub `snapshots/` layout — it does **not** glob nested checkpoint dirs. No index found → `logger.warning` at `:562` → **falls through** |
| 2 | `default_local_path` = `models/demos/deepseek_v3/reference` | has `config.json` but no index → skip |
| 3 | `shared_path` = `/proj_sw/user_dev/deepseek-ai/DeepSeek-R1-0528` | not mounted on Blaze → skip |
| 4 | `download_model_weights(...)` (`:394`) | `snapshot_download("deepseek-ai/DeepSeek-R1-0528")` into a pod-local `HF_HOME` |

The download is not small. With `num_layers_to_download = 24` (`tt/runners/adapters/deepseek_v3.py:28`) the required shard set is embeddings + layers 0–23 + `model.norm`, which is **61 of the checkpoint's 163 shards = 241 GiB** (measured against the equivalent fp8 checkpoint on the share). The log understates this by 14×: `conftest.py:489` hardcodes `estimated_size_gb = len(required_shards) * 0.28`, so it prints `~17.1GB`.

Nothing inside pytest ever stops it, because `test_kv_cache_table` carries `@pytest.mark.timeout(0)` (`test_kv_cache_table.py:57`) — pytest-timeout is disabled for exactly the scenario where the first run must build a large CPU reference. So the only limit left is the job's `timeout: 10` → `timeout-minutes` on the test step, and GitHub kills the step with `The action has timed out.` and **no pytest output at all**. That is why the job looked like a mysterious hang rather than a missing-weights error.

### The fix

All 7 `DEEPSEEK_V3_HF_MODEL` exports now point at the real checkpoint dir:

```diff
-    export DEEPSEEK_V3_HF_MODEL=/mnt/models/deepseek-ai/DeepSeek-R1-0528
+    export DEEPSEEK_V3_HF_MODEL=/mnt/models/deepseek-ai/DeepSeek-R1-0528-dequantized/DeepSeek-R1-dequantized/
```

Affected jobs (`bh_sc1` budget in minutes):

| Job | Budget | Old path |
|---|---|---|
| Blaze - MoE Gate | 8 | `…/DeepSeek-R1-0528` |
| Blaze - MLA | 16 | `…/DeepSeek-R1-0528` |
| Blaze - KV cache table | 10 | `…/DeepSeek-R1-0528-dequantized` |
| Blaze - Prefill Block | 20 | `…/DeepSeek-R1-0528` |
| Blaze - DSA MLA (V3.2) | 15 | `…/DeepSeek-R1-0528` |
| Blaze - Prefill Block Determinism | 15 | `…/DeepSeek-R1-0528` |
| Blaze - Transformer Determinism | 49 | `…/DeepSeek-R1-0528` |

The target satisfies the resolver: it has both `config.json` and `model.safetensors.index.json`, so `_resolve_hf_snapshot_dir` returns it unchanged and step 1 succeeds.

### Evidence

`Blaze - KV cache table`, step 14 duration (the pytest step):

| Run | Head | Weight path | Step 14 |
|---|---|---|---|
| [#205](https://github.com/tenstorrent/tt-metal/actions/runs/30434521216) | `50fefa675` | old | ✗ **failure 10:13** — hit the 10-min budget |
| [#209](https://github.com/tenstorrent/tt-metal/actions/runs/30439736198) | `b6db7feb3` | new nested | ✓ **success 2:32** |
| [#210](https://github.com/tenstorrent/tt-metal/actions/runs/30441444020) | `9bb76e272` | new nested | ✓ **success 2:34** |
| [#219](https://github.com/tenstorrent/tt-metal/actions/runs/30543509771) | `4604ec90b` | new nested, rebased | ✗ failure 1:59 — change 2's `TypeError` |
| [#224](https://github.com/tenstorrent/tt-metal/actions/runs/30550426461) | `2ce12a529` | new nested + caller fix | ✗ infra, see below |

A 10:13 timeout collapsing to 2:32 is the signature of the download disappearing. For scale, the last green pre-restructure run of this job on `main` was 2:43 with *more* cases selected.

Run #224 is **not a verdict on this PR**: 8 of its jobs failed in `Set up job` (step 1) with `Failed to download archive 'https://codeload.github.com/tenstorrent/tt-metal/tar.gz/3c19327…' after 3 attempts` — a GitHub Actions runner network failure, before any repo code ran. It needs a re-run.


### CI
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blaze-models-prefill-tests.yaml/badge.svg?branch=nbabin/kv_cache_test_in_ci_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blaze-models-prefill-tests.yaml?query=branch:nbabin/kv_cache_test_in_ci_fix)


### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nbabin/kv_cache_test_in_ci_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nbabin/kv_cache_test_in_ci_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nbabin/kv_cache_test_in_ci_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nbabin/kv_cache_test_in_ci_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=nbabin/kv_cache_test_in_ci_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:nbabin/kv_cache_test_in_ci_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nbabin/kv_cache_test_in_ci_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nbabin/kv_cache_test_in_ci_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nbabin/kv_cache_test_in_ci_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nbabin/kv_cache_test_in_ci_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nbabin/kv_cache_test_in_ci_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nbabin/kv_cache_test_in_ci_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nbabin/kv_cache_test_in_ci_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nbabin/kv_cache_test_in_ci_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nbabin/kv_cache_test_in_ci_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nbabin/kv_cache_test_in_ci_fix)