### PR TITLE
[Test Only] Add Quasar 8x4 full-grid integration tests

### DIFF
--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/grid_barrier.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/grid_barrier.cpp
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Grid all-to-one barrier. Every non-target node does one remote hardware-atomic increment of the
+// target node's barrier semaphore over the NoC; the target drains all num_signalers increments with
+// a single down(num_signalers) (race-free wait-for-threshold) then wait(0) (confirms EXACTLY N
+// arrived), and only then records a RELEASED sentinel in L1 for the host to verify. Exercises max
+// semaphore fan-in onto a single counter. Non-DFB: pure cross-node semaphore + NoC.
+
+#include <cstdint>
+#include "api/dataflow/noc.h"
+#include "api/core_local_mem.h"
+#include "api/dataflow/endpoints.h"
+#include "api/dataflow/noc_semaphore.h"
+#include "experimental/kernel_args.h"
+#include "risc_common.h"
+
+void kernel_main() {
+    const uint32_t target_noc_x = get_arg(args::remote_noc_x);
+    const uint32_t target_noc_y = get_arg(args::remote_noc_y);
+    const uint32_t is_target = get_arg(args::is_target);
+    const uint32_t num_signalers = get_arg(args::num_elements);
+    const uint32_t result_addr = get_arg(args::result_addr);
+
+    Noc noc;
+    Semaphore barrier_sem(sem::barrier_sem);
+
+    if (is_target) {
+        // Wait for all signalers with a SINGLE decrement: down(N) blocks until the counter
+        // reaches N, then subtracts N once. This avoids the lost-update race of N separate
+        // non-atomic down(1) read-modify-writes racing the signalers' hardware-atomic
+        // increments; and because there are exactly num_signalers signalers, no increment
+        // arrives after the threshold, so the single subtract is race-free.
+        barrier_sem.down(num_signalers);
+        // Confirm EXACTLY num_signalers arrived: after subtracting N the counter must be 0. A
+        // stray/duplicate increment (over-count) leaves it > 0 and wait(0) hangs (detected).
+        barrier_sem.wait(0);
+        // Record RELEASED only once both checks pass -- an OBSERVED property, not an input echo.
+        CoreLocalMem<uint32_t> result(result_addr);
+        result[0] = 0xC0DEBA11u;
+        flush_l2_cache_line(result_addr);
+    } else {
+        // Signal the target exactly once (hardware-atomic remote increment).
+        barrier_sem.up(noc, target_noc_x, target_noc_y, 1);
+    }
+}

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/grid_barrier.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/grid_barrier.cpp
@@ -2,11 +2,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 //
-// Grid all-to-one barrier. Every non-target node does one remote hardware-atomic increment of the
-// target node's barrier semaphore over the NoC; the target drains all num_signalers increments with
-// a single down(num_signalers) (race-free wait-for-threshold) then wait(0) (confirms EXACTLY N
-// arrived), and only then records a RELEASED sentinel in L1 for the host to verify. Exercises max
-// semaphore fan-in onto a single counter. Non-DFB: pure cross-node semaphore + NoC.
+// Grid all-to-one barrier. Every node except the target increments the target's barrier semaphore
+// once over the NoC. The target waits for all of them to arrive, then writes a "released" marker to
+// L1 so the host can confirm the barrier completed. Exercises max semaphore fan-in onto one counter.
 
 #include <cstdint>
 #include "api/dataflow/noc.h"
@@ -27,21 +25,15 @@ void kernel_main() {
     Semaphore barrier_sem(sem::barrier_sem);
 
     if (is_target) {
-        // Wait for all signalers with a SINGLE decrement: down(N) blocks until the counter
-        // reaches N, then subtracts N once. This avoids the lost-update race of N separate
-        // non-atomic down(1) read-modify-writes racing the signalers' hardware-atomic
-        // increments; and because there are exactly num_signalers signalers, no increment
-        // arrives after the threshold, so the single subtract is race-free.
+        // Wait for all N signalers.
         barrier_sem.down(num_signalers);
-        // Confirm EXACTLY num_signalers arrived: after subtracting N the counter must be 0. A
-        // stray/duplicate increment (over-count) leaves it > 0 and wait(0) hangs (detected).
         barrier_sem.wait(0);
-        // Record RELEASED only once both checks pass -- an OBSERVED property, not an input echo.
+        // Write the "released" marker for the host to read.
         CoreLocalMem<uint32_t> result(result_addr);
         result[0] = 0xC0DEBA11u;
         flush_l2_cache_line(result_addr);
     } else {
-        // Signal the target exactly once (hardware-atomic remote increment).
+        // Signal the target once.
         barrier_sem.up(noc, target_noc_x, target_noc_y, 1);
     }
 }

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/grid_multicast_writer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/grid_multicast_writer.cpp
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Grid multicast fan-out (source-side). Stages `value` in local L1, then NoC-multicasts it to
+// `result_addr` on every node in the [x_start,y_start]-[x_end,y_end] physical rectangle. This
+// drives the actual NoC multicast path (get_noc_multicast_addr -> for_each_multicast_coordinate),
+// so a dropped row/column shows up as an un-updated node in the host readback. num_dests excludes
+// the source (plain multicast); the source covers its own slot via the local write above.
+// Non-DFB: pure NoC data multicast.
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/core_local_mem.h"
+#include "experimental/kernel_args.h"
+#include "risc_common.h"
+
+void kernel_main() {
+    const uint32_t value = get_arg(args::value);
+    const uint32_t result_addr = get_arg(args::result_addr);
+    const uint32_t x_start = get_arg(args::mcast_x_start);
+    const uint32_t y_start = get_arg(args::mcast_y_start);
+    const uint32_t x_end = get_arg(args::mcast_x_end);
+    const uint32_t y_end = get_arg(args::mcast_y_end);
+    const uint32_t num_dests = get_arg(args::num_dests);
+
+    // Stage the value locally (covers the source's own slot).
+    CoreLocalMem<uint32_t> buf(result_addr);
+    buf[0] = value;
+    flush_l2_cache_line(result_addr);
+
+    // Multicast it to result_addr on every OTHER node in the rectangle.
+    const uint64_t mcast = get_noc_multicast_addr(x_start, y_start, x_end, y_end, result_addr);
+    noc_async_write_multicast(result_addr, mcast, sizeof(uint32_t), num_dests);
+    noc_async_write_barrier();
+}

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/grid_multicast_writer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/grid_multicast_writer.cpp
@@ -2,12 +2,10 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 //
-// Grid multicast fan-out (source-side). Stages `value` in local L1, then NoC-multicasts it to
-// `result_addr` on every node in the [x_start,y_start]-[x_end,y_end] physical rectangle. This
-// drives the actual NoC multicast path (get_noc_multicast_addr -> for_each_multicast_coordinate),
-// so a dropped row/column shows up as an un-updated node in the host readback. num_dests excludes
-// the source (plain multicast); the source covers its own slot via the local write above.
-// Non-DFB: pure NoC data multicast.
+// Grid multicast fan-out (source-side). Writes `value` into local L1, then NoC-multicasts it to
+// `result_addr` on every other node in the [x_start,y_start]-[x_end,y_end] rectangle. The host
+// reads back every node's slot, so a dropped row or column shows up as a node that never updated.
+// The source covers its own slot with the local write, so num_dests counts only the other nodes.
 
 #include "api/dataflow/dataflow_api.h"
 #include "api/core_local_mem.h"
@@ -23,12 +21,12 @@ void kernel_main() {
     const uint32_t y_end = get_arg(args::mcast_y_end);
     const uint32_t num_dests = get_arg(args::num_dests);
 
-    // Stage the value locally (covers the source's own slot).
+    // Write the value into our own L1 slot first.
     CoreLocalMem<uint32_t> buf(result_addr);
     buf[0] = value;
     flush_l2_cache_line(result_addr);
 
-    // Multicast it to result_addr on every OTHER node in the rectangle.
+    // Multicast it to the same address on every other node in the rectangle.
     const uint64_t mcast = get_noc_multicast_addr(x_start, y_start, x_end, y_end, result_addr);
     noc_async_write_multicast(result_addr, mcast, sizeof(uint32_t), num_dests);
     noc_async_write_barrier();

--- a/tests/tt_metal/tt_metal/test_quasar_semaphores.cpp
+++ b/tests/tt_metal/tt_metal/test_quasar_semaphores.cpp
@@ -11,6 +11,7 @@
 #include <tt-metalium/tt_metal.hpp>
 #include "hal.hpp"
 #include "llrt/rtoptions.hpp"
+#include <algorithm>
 
 #ifndef OVERRIDE_KERNEL_PREFIX
 #define OVERRIDE_KERNEL_PREFIX ""
@@ -382,4 +383,648 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarMultipleClustersMultiSemaphorePi
     const std::vector<uint32_t> expected_data = {2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
 
     ASSERT_EQ(actual_data, expected_data);
+}
+
+// ---------------------------------------------------------------------------
+// L3: semaphore + DRAM-staged SNAKE CHAIN across an arbitrary ordered node list.
+// Data flows node[0] -> node[1] -> ... -> node[N-1]. Each hop: node[i]'s writer
+// stages its (transformed) buffer to DRAM stage[i+1] and increments node[i+1]'s
+// cross-node semaphore; node[i+1]'s reader waits on it, reads stage[i+1], transforms
+// (+1), and relays onward. Final DRAM stage = seed + N. Proves every node in the
+// list can receive-from-prev and send-to-next. Generalizes QuasarMultipleClusters...
+// (the proven 2-node cross-node pipeline) to N nodes.
+// ---------------------------------------------------------------------------
+static void run_snake_chain(
+    const std::shared_ptr<distributed::MeshDevice>& mesh_device,
+    const std::vector<experimental::NodeCoord>& nodes,
+    bool ring = false,
+    uint32_t num_elements = 10) {
+    using experimental::KernelSpec;
+    using experimental::KernelSpecName;
+    using experimental::SemaphoreSpec;
+    using experimental::SemaphoreSpecName;
+    using experimental::WorkUnitSpec;
+    const uint32_t N = static_cast<uint32_t>(nodes.size());
+    ASSERT_GE(N, 2u);
+    IDevice* dev = mesh_device->get_devices()[0];
+
+    const uint32_t buf_a = MetalContext::instance().hal().get_dev_addr(
+        HalProgrammableCoreType::TENSIX, HalL1MemAddrType::DEFAULT_UNRESERVED);
+    const uint32_t buf_b = buf_a + num_elements * sizeof(uint32_t);
+    const uint32_t buf_wrap = buf_b + num_elements * sizeof(uint32_t);  // ring: node[0] receives the wrapped token here
+    const SemaphoreSpecName WRAP{"wrap_sem"};                           // ring: node[N-1] -> node[0] closing edge
+    const SemaphoreSpecName WRAP_L0{"wrap_l0"};                         // ring: local sem for node[0]'s wrap reader
+    const uint32_t dram_base = MetalContext::instance().hal().get_dev_addr(HalDramMemAddrType::UNRESERVED);
+    constexpr uint32_t stage_stride = 4096;  // per-hop DRAM staging spacing
+    auto stage_addr = [&](uint32_t i) { return dram_base + i * stage_stride; };
+    // Each hop stages num_elements words at stage_addr(i); guard against a payload that would
+    // overflow one stage into the next (stages are stage_stride bytes apart).
+    ASSERT_LE(num_elements * sizeof(uint32_t), stage_stride);
+
+    // Seed stage 0 with [0..num_elements).
+    std::vector<uint32_t> seed(num_elements);
+    for (uint32_t i = 0; i < num_elements; ++i) {
+        seed[i] = i;
+    }
+    tt_metal::detail::WriteToDeviceDRAMChannel(dev, 0, stage_addr(0), seed);
+    // Sentinel the OUTPUT stage so a stale-data pass is impossible: callers reuse identical
+    // stage addresses across runs, so the final EXPECT_EQ must be forced to observe fresh data
+    // written by THIS run's chain (not leftover values from a prior same-N run).
+    std::vector<uint32_t> out_sentinel(num_elements, 0xdeadbeefu);
+    tt_metal::detail::WriteToDeviceDRAMChannel(dev, 0, stage_addr(N), out_sentinel);
+    // Ring mode additionally verifies the wrapped token in node[0]'s buf_wrap; sentinel it too so
+    // the ring-edge assertion cannot pass on stale/uninitialized data.
+    if (ring) {
+        tt_metal::detail::WriteToDeviceL1(dev, nodes[0], buf_wrap, out_sentinel);
+    }
+
+    experimental::ProgramSpec spec{.name = "snake_chain"};
+    experimental::ProgramRunArgs params;
+
+    for (uint32_t i = 0; i < N; ++i) {
+        const bool is_src = (i == 0);
+        const bool is_sink = (i == N - 1);
+        const std::string si = std::to_string(i);
+        const KernelSpecName READER{"reader_" + si};
+        const KernelSpecName XFORM{"xform_" + si};
+        const KernelSpecName WRITER{"writer_" + si};
+        const SemaphoreSpecName L0{"l0_" + si};
+        const SemaphoreSpecName L1{"l1_" + si};
+        const SemaphoreSpecName CROSS_IN{"cross_" + std::to_string(i == 0 ? 0 : i - 1)};  // hop (i-1)->i
+        const SemaphoreSpecName CROSS_OUT{"cross_" + si};                                 // hop i->(i+1)
+
+        // Local intra-node sems (reader->xform, xform->writer).
+        spec.semaphores.push_back(SemaphoreSpec{.unique_id = L0, .target_nodes = nodes[i]});
+        spec.semaphores.push_back(SemaphoreSpec{.unique_id = L1, .target_nodes = nodes[i]});
+        // Cross-node sem for the hop i->i+1, allocated on both endpoints (same L1 addr).
+        // NodeRange is a bounding box (end >= start), so order the two adjacent coords by
+        // componentwise min/max — the snake's right->left rows have nodes[i].x > nodes[i+1].x.
+        if (!is_sink) {
+            const auto a = nodes[i];
+            const auto b = nodes[i + 1];
+            const experimental::NodeCoord lo{std::min(a.x, b.x), std::min(a.y, b.y)};
+            const experimental::NodeCoord hi{std::max(a.x, b.x), std::max(a.y, b.y)};
+            spec.semaphores.push_back(
+                SemaphoreSpec{.unique_id = CROSS_OUT, .target_nodes = experimental::NodeRange{lo, hi}});
+        } else if (ring) {
+            // Wrap edge node[N-1] -> node[0] (may be a non-adjacent long hop; bbox may span a column).
+            const auto a = nodes[i];
+            const auto b = nodes[0];
+            const experimental::NodeCoord lo{std::min(a.x, b.x), std::min(a.y, b.y)};
+            const experimental::NodeCoord hi{std::max(a.x, b.x), std::max(a.y, b.y)};
+            spec.semaphores.push_back(
+                SemaphoreSpec{.unique_id = WRAP, .target_nodes = experimental::NodeRange{lo, hi}});
+        }
+
+        // Reader: source reads without waiting; others wait on the incoming cross sem.
+        KernelSpec reader{
+            .unique_id = READER,
+            .source = OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/dram_to_l1_pipeline.cpp",
+            .num_threads = 1,
+            .runtime_arg_schema = {.runtime_arg_names = {"dram_addr", "l1_addr", "num_elements", "dram_bank_id"}},
+            .hw_config = experimental::DataMovementGen2Config{}};
+        if (is_src) {
+            reader.semaphore_bindings = {{.semaphore_spec_name = L0, .accessor_name = "sem"}};
+        } else {
+            reader.compiler_options = {.defines = {{"WAIT_FOR_REMOTE_SEM", "1"}}};
+            reader.semaphore_bindings = {
+                {.semaphore_spec_name = L0, .accessor_name = "sem"},
+                {.semaphore_spec_name = CROSS_IN, .accessor_name = "remote_sem"}};
+        }
+        spec.kernels.push_back(reader);
+
+        // Transform: +1 per element, buf_a -> buf_b.
+        spec.kernels.push_back(KernelSpec{
+            .unique_id = XFORM,
+            .source = OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/transform_pipeline.cpp",
+            .num_threads = 1,
+            .compiler_options = {.defines = {{"INCOMING_SEM", "1"}, {"OUTGOING_SEM", "1"}}},
+            .semaphore_bindings =
+                {{.semaphore_spec_name = L0, .accessor_name = "sem_in"},
+                 {.semaphore_spec_name = L1, .accessor_name = "sem_out"}},
+            .compile_time_args = {{"num_elements", num_elements}, {"buf_a", buf_a}, {"buf_b", buf_b}},
+            .hw_config = experimental::DataMovementGen2Config{}});
+
+        // Writer: sink writes final; others also increment the next node's cross sem.
+        KernelSpec writer{
+            .unique_id = WRITER,
+            .source = OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/l1_to_dram_pipeline.cpp",
+            .num_threads = 1,
+            .hw_config = experimental::DataMovementGen2Config{}};
+        const bool writer_relays = (!is_sink) || ring;  // ring: last node relays back to node[0]
+        if (!writer_relays) {
+            writer.runtime_arg_schema = {.runtime_arg_names = {"dram_addr", "l1_addr", "num_elements", "dram_bank_id"}};
+            writer.semaphore_bindings = {{.semaphore_spec_name = L1, .accessor_name = "sem"}};
+        } else {
+            const SemaphoreSpecName rsem = is_sink ? WRAP : CROSS_OUT;
+            writer.compiler_options = {.defines = {{"INCREMENT_REMOTE_SEM", "1"}}};
+            writer.runtime_arg_schema = {
+                .runtime_arg_names = {
+                    "dram_addr", "l1_addr", "num_elements", "dram_bank_id", "remote_noc_x", "remote_noc_y"}};
+            writer.semaphore_bindings = {
+                {.semaphore_spec_name = L1, .accessor_name = "sem"},
+                {.semaphore_spec_name = rsem, .accessor_name = "remote_sem"}};
+        }
+        spec.kernels.push_back(writer);
+
+        std::vector<KernelSpecName> wu_kernels = {READER, XFORM, WRITER};
+        if (ring && is_src) {
+            // Ring: node[0] also hosts the wrap-reader. It MUST live in node[0]'s own work unit —
+            // two work units may not target the same node (program_spec.cpp:1830).
+            const KernelSpecName WRAP_READER{"wrap_reader"};
+            spec.semaphores.push_back(SemaphoreSpec{.unique_id = WRAP_L0, .target_nodes = nodes[0]});
+            spec.kernels.push_back(KernelSpec{
+                .unique_id = WRAP_READER,
+                .source =
+                    OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/dram_to_l1_pipeline.cpp",
+                .num_threads = 1,
+                .compiler_options = {.defines = {{"WAIT_FOR_REMOTE_SEM", "1"}}},
+                .semaphore_bindings =
+                    {{.semaphore_spec_name = WRAP_L0, .accessor_name = "sem"},
+                     {.semaphore_spec_name = WRAP, .accessor_name = "remote_sem"}},
+                .runtime_arg_schema = {.runtime_arg_names = {"dram_addr", "l1_addr", "num_elements", "dram_bank_id"}},
+                .hw_config = experimental::DataMovementGen2Config{}});
+            wu_kernels.push_back(WRAP_READER);
+            params.kernel_run_args.push_back(experimental::ProgramRunArgs::KernelRunArgs{
+                .kernel = WRAP_READER,
+                .runtime_arg_values = experimental::MakeRuntimeArgsForSingleNode(
+                    nodes[0],
+                    {{"dram_addr", stage_addr(N)},
+                     {"l1_addr", buf_wrap},
+                     {"num_elements", num_elements},
+                     {"dram_bank_id", 0u}})});
+        }
+        spec.work_units.push_back(WorkUnitSpec{.name = "wu_" + si, .kernels = wu_kernels, .target_nodes = nodes[i]});
+
+        // Runtime args.
+        params.kernel_run_args.push_back(experimental::ProgramRunArgs::KernelRunArgs{
+            .kernel = READER,
+            .runtime_arg_values = experimental::MakeRuntimeArgsForSingleNode(
+                nodes[i],
+                {{"dram_addr", stage_addr(i)},
+                 {"l1_addr", buf_a},
+                 {"num_elements", num_elements},
+                 {"dram_bank_id", 0u}})});
+        params.kernel_run_args.push_back(experimental::ProgramRunArgs::KernelRunArgs{.kernel = XFORM});
+        if (!writer_relays) {
+            params.kernel_run_args.push_back(experimental::ProgramRunArgs::KernelRunArgs{
+                .kernel = WRITER,
+                .runtime_arg_values = experimental::MakeRuntimeArgsForSingleNode(
+                    nodes[i],
+                    {{"dram_addr", stage_addr(i + 1)},
+                     {"l1_addr", buf_b},
+                     {"num_elements", num_elements},
+                     {"dram_bank_id", 0u}})});
+        } else {
+            const CoreCoord nxt = mesh_device->worker_core_from_logical_core(is_sink ? nodes[0] : nodes[i + 1]);
+            params.kernel_run_args.push_back(experimental::ProgramRunArgs::KernelRunArgs{
+                .kernel = WRITER,
+                .runtime_arg_values = experimental::MakeRuntimeArgsForSingleNode(
+                    nodes[i],
+                    {{"dram_addr", stage_addr(i + 1)},
+                     {"l1_addr", buf_b},
+                     {"num_elements", num_elements},
+                     {"dram_bank_id", 0u},
+                     {"remote_noc_x", static_cast<uint32_t>(nxt.x)},
+                     {"remote_noc_y", static_cast<uint32_t>(nxt.y)}})});
+        }
+    }
+
+    distributed::MeshCommandQueue& cq = mesh_device->mesh_command_queue();
+    distributed::MeshWorkload workload;
+    distributed::MeshCoordinateRange device_range(mesh_device->shape());
+    Program program = experimental::MakeProgramFromSpec(*mesh_device, spec);
+    experimental::SetProgramRunArgs(program, params);
+    workload.add_program(device_range, std::move(program));
+    distributed::EnqueueMeshWorkload(cq, workload, true);
+
+    std::vector<uint32_t> out(num_elements, 0);
+    tt_metal::detail::ReadFromDeviceDRAMChannel(dev, 0, stage_addr(N), num_elements * sizeof(uint32_t), out);
+    std::vector<uint32_t> expected(num_elements);
+    for (uint32_t i = 0; i < num_elements; ++i) {
+        expected[i] = i + N;  // +1 per hop
+    }
+    std::cout << "[snake] N=" << N << " hops, final stage[0]=" << out[0] << " expected=" << expected[0]
+              << (out == expected ? "  PASS" : "  FAIL") << std::endl;
+    EXPECT_EQ(out, expected);
+
+    if (ring) {
+        std::vector<uint32_t> wrapped(num_elements, 0);
+        tt_metal::detail::ReadFromDeviceL1(dev, nodes[0], buf_wrap, num_elements * sizeof(uint32_t), wrapped);
+        std::cout << "[snake] RING wrap-back to node0 L1[0]=" << wrapped[0] << " expected=" << expected[0]
+                  << (wrapped == expected ? "  PASS" : "  FAIL") << std::endl;
+        EXPECT_EQ(wrapped, expected);
+    }
+}
+
+TEST_F(QuasarMeshDeviceSingleCardFixture, RingChainFull) {
+    if (!MetalContext::instance().rtoptions().is_simulator_or_emulated()) {
+        GTEST_SKIP() << "simulator/emulator only";
+    }
+    auto md = devices_[0];
+    const auto g = md->compute_with_storage_grid_size();
+    if (g.x < 8 || g.y < 4) {
+        GTEST_SKIP() << "need the full 8x4 grid";
+    }
+    std::vector<experimental::NodeCoord> nodes;
+    for (uint32_t y = 0; y < g.y; ++y) {
+        if (y % 2 == 0) {
+            for (uint32_t x = 0; x < g.x; ++x) {
+                nodes.push_back(experimental::NodeCoord{x, y});
+            }
+        } else {
+            for (int x = static_cast<int>(g.x) - 1; x >= 0; --x) {
+                nodes.push_back(experimental::NodeCoord{static_cast<uint32_t>(x), y});
+            }
+        }
+    }
+    run_snake_chain(md, nodes, /*ring=*/true);  // 32-node snake + wrap edge back to node[0]
+}
+
+// L6 stress: longest single cross-node hop, opposite corners {0,0} <-> {7,3}.
+TEST_F(QuasarMeshDeviceSingleCardFixture, SnakeCornerToCorner) {
+    if (!MetalContext::instance().rtoptions().is_simulator_or_emulated()) {
+        GTEST_SKIP() << "simulator/emulator only";
+    }
+    auto md = devices_[0];
+    const auto g = md->compute_with_storage_grid_size();
+    if (g.x < 8 || g.y < 4) {
+        GTEST_SKIP() << "need the full 8x4 grid";
+    }
+    run_snake_chain(md, {experimental::NodeCoord{0, 0}, experimental::NodeCoord{7, 3}});
+}
+
+// L6 stress: payload-size sweep across the full 32-node snake.
+TEST_F(QuasarMeshDeviceSingleCardFixture, SnakePayloadSweep) {
+    if (!MetalContext::instance().rtoptions().is_simulator_or_emulated()) {
+        GTEST_SKIP() << "simulator/emulator only";
+    }
+    auto md = devices_[0];
+    const auto g = md->compute_with_storage_grid_size();
+    if (g.x < 8 || g.y < 4) {
+        GTEST_SKIP() << "need the full 8x4 grid";
+    }
+    std::vector<experimental::NodeCoord> nodes;
+    for (uint32_t y = 0; y < g.y; ++y) {
+        if (y % 2 == 0) {
+            for (uint32_t x = 0; x < g.x; ++x) {
+                nodes.push_back(experimental::NodeCoord{x, y});
+            }
+        } else {
+            for (int x = static_cast<int>(g.x) - 1; x >= 0; --x) {
+                nodes.push_back(experimental::NodeCoord{static_cast<uint32_t>(x), y});
+            }
+        }
+    }
+    for (uint32_t ne : {64u, 256u}) {
+        std::cout << "[L6] payload sweep: num_elements=" << ne << std::endl;
+        run_snake_chain(md, nodes, /*ring=*/false, ne);
+    }
+}
+
+// L5 FAN-OUT: one DRAM root value read concurrently by ALL 32 nodes (broadcast via shared DRAM).
+TEST_F(QuasarMeshDeviceSingleCardFixture, FanOutBroadcast) {
+    if (!MetalContext::instance().rtoptions().is_simulator_or_emulated()) {
+        GTEST_SKIP() << "simulator/emulator only";
+    }
+    auto md = devices_[0];
+    const auto g = md->compute_with_storage_grid_size();
+    if (g.x < 8 || g.y < 4) {
+        GTEST_SKIP() << "need the full 8x4 grid";
+    }
+    IDevice* dev = md->get_devices()[0];
+    constexpr uint32_t ne = 8;
+    const uint32_t buf_a = MetalContext::instance().hal().get_dev_addr(
+        HalProgrammableCoreType::TENSIX, HalL1MemAddrType::DEFAULT_UNRESERVED);
+    const uint32_t dram_bcast = MetalContext::instance().hal().get_dev_addr(HalDramMemAddrType::UNRESERVED);
+    std::vector<uint32_t> seed(ne);
+    for (uint32_t i = 0; i < ne; ++i) {
+        seed[i] = 0xa000 + i;
+    }
+    tt_metal::detail::WriteToDeviceDRAMChannel(dev, 0, dram_bcast, seed);
+    for (uint32_t y = 0; y < g.y; ++y) {
+        for (uint32_t x = 0; x < g.x; ++x) {
+            std::vector<uint32_t> sentinel(ne, 0xffffffffu);
+            tt_metal::detail::WriteToDeviceL1(dev, experimental::NodeCoord{x, y}, buf_a, sentinel);
+        }
+    }
+
+    const experimental::SemaphoreSpecName SEM{"sem"};
+    const experimental::KernelSpecName READER{"reader"};
+    const experimental::NodeRange all_nodes(experimental::NodeCoord{0, 0}, experimental::NodeCoord{g.x - 1, g.y - 1});
+    experimental::ProgramSpec spec{.name = "fanout"};
+    spec.semaphores.push_back(experimental::SemaphoreSpec{.unique_id = SEM, .target_nodes = all_nodes});
+    spec.kernels.push_back(experimental::KernelSpec{
+        .unique_id = READER,
+        .source = std::string(OVERRIDE_KERNEL_PREFIX) +
+                  "tests/tt_metal/tt_metal/test_kernels/dataflow/dram_to_l1_pipeline.cpp",
+        .num_threads = 1,
+        .semaphore_bindings = {{.semaphore_spec_name = SEM, .accessor_name = "sem"}},
+        .runtime_arg_schema = {.runtime_arg_names = {"dram_addr", "l1_addr", "num_elements", "dram_bank_id"}},
+        .hw_config = experimental::DataMovementGen2Config{}});
+    spec.work_units.push_back(experimental::WorkUnitSpec{.name = "wu", .kernels = {READER}, .target_nodes = all_nodes});
+    experimental::ProgramRunArgs params;
+    experimental::ProgramRunArgs::KernelRunArgs kra{.kernel = READER};
+    for (uint32_t y = 0; y < g.y; ++y) {
+        for (uint32_t x = 0; x < g.x; ++x) {
+            experimental::AddRuntimeArgsForNode(
+                kra.runtime_arg_values,
+                experimental::NodeCoord{x, y},
+                {{"dram_addr", dram_bcast}, {"l1_addr", buf_a}, {"num_elements", ne}, {"dram_bank_id", 0u}});
+        }
+    }
+    params.kernel_run_args = {kra};
+    distributed::MeshWorkload workload;
+    Program program = experimental::MakeProgramFromSpec(*md, spec);
+    experimental::SetProgramRunArgs(program, params);
+    workload.add_program(distributed::MeshCoordinateRange(md->shape()), std::move(program));
+    distributed::EnqueueMeshWorkload(md->mesh_command_queue(), workload, true);
+
+    uint32_t ok = 0, fail = 0;
+    for (uint32_t y = 0; y < g.y; ++y) {
+        for (uint32_t x = 0; x < g.x; ++x) {
+            std::vector<uint32_t> r(ne, 0);
+            tt_metal::detail::ReadFromDeviceL1(dev, experimental::NodeCoord{x, y}, buf_a, ne * sizeof(uint32_t), r);
+            (r == seed) ? ++ok : ++fail;
+        }
+    }
+    std::cout << "[L5-fanout] broadcast to all nodes: ok=" << ok << " fail=" << fail << std::endl;
+    EXPECT_EQ(fail, 0u);
+}
+
+// L5 FAN-IN / GATHER: all 32 nodes concurrently write a coord-unique value into a shared DRAM
+// gather region (each node -> its own slot). Reader reads a per-node DRAM seed, writer stages it out.
+TEST_F(QuasarMeshDeviceSingleCardFixture, FanInGather) {
+    if (!MetalContext::instance().rtoptions().is_simulator_or_emulated()) {
+        GTEST_SKIP() << "simulator/emulator only";
+    }
+    auto md = devices_[0];
+    const auto g = md->compute_with_storage_grid_size();
+    if (g.x < 8 || g.y < 4) {
+        GTEST_SKIP() << "need the full 8x4 grid";
+    }
+    IDevice* dev = md->get_devices()[0];
+    constexpr uint32_t ne = 8;
+    constexpr uint32_t stride = 4096;
+    const uint32_t buf_a = MetalContext::instance().hal().get_dev_addr(
+        HalProgrammableCoreType::TENSIX, HalL1MemAddrType::DEFAULT_UNRESERVED);
+    const uint32_t dram_src = MetalContext::instance().hal().get_dev_addr(HalDramMemAddrType::UNRESERVED);
+    const uint32_t dram_gather = dram_src + 64u * stride;  // gather region well past the per-node src slots
+    auto sig_of = [&](uint32_t x, uint32_t y) { return 0xb000u + x + y * g.x; };
+
+    // Seed each node's own DRAM src slot with its coord-unique value, and sentinel its gather
+    // destination so the post-run gather check cannot pass on stale data from a prior run.
+    for (uint32_t y = 0; y < g.y; ++y) {
+        for (uint32_t x = 0; x < g.x; ++x) {
+            const uint32_t idx = x + y * g.x;
+            std::vector<uint32_t> s(ne, sig_of(x, y));
+            tt_metal::detail::WriteToDeviceDRAMChannel(dev, 0, dram_src + idx * stride, s);
+            std::vector<uint32_t> sentinel(ne, 0xffffffffu);
+            tt_metal::detail::WriteToDeviceDRAMChannel(dev, 0, dram_gather + idx * stride, sentinel);
+        }
+    }
+
+    const experimental::SemaphoreSpecName SEM{"sem"};
+    const experimental::KernelSpecName READER{"reader"};
+    const experimental::KernelSpecName WRITER{"writer"};
+    const experimental::NodeRange all_nodes(experimental::NodeCoord{0, 0}, experimental::NodeCoord{g.x - 1, g.y - 1});
+    experimental::ProgramSpec spec{.name = "fanin"};
+    spec.semaphores.push_back(experimental::SemaphoreSpec{.unique_id = SEM, .target_nodes = all_nodes});
+    spec.kernels.push_back(experimental::KernelSpec{
+        .unique_id = READER,
+        .source = OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/dram_to_l1_pipeline.cpp",
+        .num_threads = 1,
+        .semaphore_bindings = {{.semaphore_spec_name = SEM, .accessor_name = "sem"}},
+        .runtime_arg_schema = {.runtime_arg_names = {"dram_addr", "l1_addr", "num_elements", "dram_bank_id"}},
+        .hw_config = experimental::DataMovementGen2Config{}});
+    spec.kernels.push_back(experimental::KernelSpec{
+        .unique_id = WRITER,
+        .source = OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/l1_to_dram_pipeline.cpp",
+        .num_threads = 1,
+        .semaphore_bindings = {{.semaphore_spec_name = SEM, .accessor_name = "sem"}},
+        .runtime_arg_schema = {.runtime_arg_names = {"dram_addr", "l1_addr", "num_elements", "dram_bank_id"}},
+        .hw_config = experimental::DataMovementGen2Config{}});
+    spec.work_units.push_back(
+        experimental::WorkUnitSpec{.name = "wu", .kernels = {READER, WRITER}, .target_nodes = all_nodes});
+
+    experimental::ProgramRunArgs params;
+    experimental::ProgramRunArgs::KernelRunArgs kr{.kernel = READER};
+    experimental::ProgramRunArgs::KernelRunArgs kw{.kernel = WRITER};
+    for (uint32_t y = 0; y < g.y; ++y) {
+        for (uint32_t x = 0; x < g.x; ++x) {
+            const uint32_t idx = x + y * g.x;
+            experimental::AddRuntimeArgsForNode(
+                kr.runtime_arg_values,
+                experimental::NodeCoord{x, y},
+                {{"dram_addr", dram_src + idx * stride},
+                 {"l1_addr", buf_a},
+                 {"num_elements", ne},
+                 {"dram_bank_id", 0u}});
+            experimental::AddRuntimeArgsForNode(
+                kw.runtime_arg_values,
+                experimental::NodeCoord{x, y},
+                {{"dram_addr", dram_gather + idx * stride},
+                 {"l1_addr", buf_a},
+                 {"num_elements", ne},
+                 {"dram_bank_id", 0u}});
+        }
+    }
+    params.kernel_run_args = {kr, kw};
+    distributed::MeshWorkload workload;
+    Program program = experimental::MakeProgramFromSpec(*md, spec);
+    experimental::SetProgramRunArgs(program, params);
+    workload.add_program(distributed::MeshCoordinateRange(md->shape()), std::move(program));
+    distributed::EnqueueMeshWorkload(md->mesh_command_queue(), workload, true);
+
+    uint32_t ok = 0, fail = 0;
+    for (uint32_t y = 0; y < g.y; ++y) {
+        for (uint32_t x = 0; x < g.x; ++x) {
+            const uint32_t idx = x + y * g.x;
+            std::vector<uint32_t> r(ne, 0);
+            tt_metal::detail::ReadFromDeviceDRAMChannel(dev, 0, dram_gather + idx * stride, ne * sizeof(uint32_t), r);
+            (r == std::vector<uint32_t>(ne, sig_of(x, y))) ? ++ok : ++fail;
+        }
+    }
+    std::cout << "[L5-fanin] gather from all nodes: ok=" << ok << " fail=" << fail << std::endl;
+    EXPECT_EQ(fail, 0u);
+}
+
+// L6 per-row chains: exercise each of the 4 rows as its own independent chain.
+TEST_F(QuasarMeshDeviceSingleCardFixture, PerRowChains) {
+    if (!MetalContext::instance().rtoptions().is_simulator_or_emulated()) {
+        GTEST_SKIP() << "simulator/emulator only";
+    }
+    auto md = devices_[0];
+    const auto g = md->compute_with_storage_grid_size();
+    if (g.x < 8 || g.y < 4) {
+        GTEST_SKIP() << "need the full 8x4 grid";
+    }
+    for (uint32_t y = 0; y < g.y; ++y) {
+        std::vector<experimental::NodeCoord> row;
+        row.reserve(g.x);
+        for (uint32_t x = 0; x < g.x; ++x) {
+            row.push_back(experimental::NodeCoord{x, y});
+        }
+        std::cout << "[L6] per-row chain y=" << y << std::endl;
+        run_snake_chain(md, row);
+    }
+}
+
+// Vertical analog of PerRowChains: each of the 8 columns is a top->bottom 4-node chain.
+// run_snake_chain blocks per call (EnqueueMeshWorkload is blocking), so the 8 column chains
+// run SEQUENTIALLY -- one completes (enqueue + readback + assert) before the next starts.
+// This adds vertical-NoC-path coverage vs PerRowChains' horizontal hops; it is NOT
+// concurrent-chain contention (which the single-NoC functional sim would not model anyway).
+TEST_F(QuasarMeshDeviceSingleCardFixture, PerColumnChains) {
+    if (!MetalContext::instance().rtoptions().is_simulator_or_emulated()) {
+        GTEST_SKIP() << "simulator/emulator only";
+    }
+    auto md = devices_[0];
+    const auto g = md->compute_with_storage_grid_size();
+    if (g.x < 8 || g.y < 4) {
+        GTEST_SKIP() << "need the full 8x4 grid";
+    }
+    for (uint32_t x = 0; x < g.x; ++x) {
+        std::vector<experimental::NodeCoord> col;
+        col.reserve(g.y);
+        for (uint32_t y = 0; y < g.y; ++y) {
+            col.push_back(experimental::NodeCoord{x, y});
+        }
+        std::cout << "[L6] per-column chain x=" << x << std::endl;
+        run_snake_chain(md, col);
+    }
+}
+
+// Grid all-to-one barrier: every node except the target (logical {0,0}) remote-increments the
+// target's barrier semaphore once; the target waits for all N-1 increments (one down() each) and
+// records completion in L1. Exercises maximum semaphore fan-in onto a single counter. Non-DFB.
+TEST_F(QuasarMeshDeviceSingleCardFixture, GridBarrierAllToOne) {
+    if (!MetalContext::instance().rtoptions().is_simulator_or_emulated()) {
+        GTEST_SKIP() << "simulator/emulator only";
+    }
+    auto md = devices_[0];
+    IDevice* dev = md->get_devices()[0];
+    const auto g = md->compute_with_storage_grid_size();
+    if (g.x != 8 || g.y != 4) {
+        GTEST_SKIP() << "need the full 8x4 grid";
+    }
+    const experimental::NodeCoord target{0, 0};
+    const uint32_t num_signalers = g.x * g.y - 1;  // everyone except the target
+    const uint32_t result_addr = MetalContext::instance().hal().get_dev_addr(
+        HalProgrammableCoreType::TENSIX, HalL1MemAddrType::DEFAULT_UNRESERVED);
+
+    // Seed the target's result slot so an incomplete barrier is detectable.
+    std::vector<uint32_t> seed{0xffffffffu};
+    tt_metal::detail::WriteToDeviceL1(dev, target, result_addr, seed);
+
+    const experimental::SemaphoreSpecName BARRIER{"barrier_sem"};
+    const experimental::KernelSpecName BK{"barrier_kernel"};
+    const CoreCoord tgt_phys = md->worker_core_from_logical_core(target);
+    const experimental::NodeRange all_nodes{experimental::NodeCoord{0, 0}, experimental::NodeCoord{g.x - 1, g.y - 1}};
+
+    experimental::ProgramSpec spec{.name = "grid_barrier"};
+    // One barrier semaphore, allocated at the same L1 address on all 32 nodes (so the remote-inc
+    // address computation and the target's local read agree).
+    spec.semaphores.push_back(experimental::SemaphoreSpec{.unique_id = BARRIER, .target_nodes = all_nodes});
+    experimental::KernelSpec bk{
+        .unique_id = BK,
+        .source = OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/grid_barrier.cpp",
+        .num_threads = 1,
+        .semaphore_bindings = {{.semaphore_spec_name = BARRIER, .accessor_name = "barrier_sem"}},
+        .runtime_arg_schema =
+            {.runtime_arg_names = {"remote_noc_x", "remote_noc_y", "is_target", "num_elements", "result_addr"}},
+        .hw_config = experimental::DataMovementGen2Config{}};
+    spec.kernels.push_back(bk);
+    spec.work_units.push_back(experimental::WorkUnitSpec{.name = "wu", .kernels = {BK}, .target_nodes = all_nodes});
+
+    Program program = experimental::MakeProgramFromSpec(*md, spec);
+
+    experimental::ProgramRunArgs params;
+    experimental::ProgramRunArgs::KernelRunArgs kra{.kernel = BK};
+    for (uint32_t y = 0; y < g.y; ++y) {
+        for (uint32_t x = 0; x < g.x; ++x) {
+            const bool is_tgt = (x == 0 && y == 0);
+            experimental::AddRuntimeArgsForNode(
+                kra.runtime_arg_values,
+                experimental::NodeCoord{x, y},
+                {{"remote_noc_x", static_cast<uint32_t>(tgt_phys.x)},
+                 {"remote_noc_y", static_cast<uint32_t>(tgt_phys.y)},
+                 {"is_target", is_tgt ? 1u : 0u},
+                 {"num_elements", num_signalers},
+                 {"result_addr", result_addr}});
+        }
+    }
+    params.kernel_run_args = {kra};
+    experimental::SetProgramRunArgs(program, params);
+
+    distributed::MeshCommandQueue& cq = md->mesh_command_queue();
+    distributed::MeshWorkload workload;
+    distributed::MeshCoordinateRange device_range(md->shape());
+    workload.add_program(device_range, std::move(program));
+    distributed::EnqueueMeshWorkload(cq, workload, true);
+
+    std::vector<uint32_t> r(1, 0u);
+    tt_metal::detail::ReadFromDeviceL1(dev, target, result_addr, sizeof(uint32_t), r);
+    // The target writes the RELEASED sentinel only after down(num_signalers) AND wait(0) both
+    // pass -- i.e. exactly num_signalers increments arrived and the counter drained to 0. An
+    // under-count blocks in down() (hang/timeout); an over-count blocks in wait(0). So this
+    // asserts an OBSERVED device property, not the input constant it was seeded/sent. (A single
+    // counting semaphore cannot verify signaler identity/distinctness -- inherent to a counter.)
+    constexpr uint32_t kReleased = 0xC0DEBA11u;
+    std::cout << "[BARRIER] target result=0x" << std::hex << r[0] << " expected released=0x" << kReleased << std::dec
+              << (r[0] == kReleased ? "  PASS" : "  FAIL") << std::endl;
+    EXPECT_EQ(r[0], kReleased);
+}
+
+TEST_F(QuasarMeshDeviceSingleCardFixture, SnakeChain3) {
+    if (!MetalContext::instance().rtoptions().is_simulator_or_emulated()) {
+        GTEST_SKIP() << "simulator/emulator only";
+    }
+    // Uses logical nodes {0,0},{1,0},{2,0}; skip (don't fault) on grids narrower than 3 (e.g. 1x3 CI).
+    if (devices_[0]->compute_with_storage_grid_size().x < 3) {
+        GTEST_SKIP() << "need a >=3-wide grid";
+    }
+    // First rung: source -> relay -> sink (3 adjacent nodes in row 0).
+    run_snake_chain(devices_[0], {{0, 0}, {1, 0}, {2, 0}});
+}
+
+TEST_F(QuasarMeshDeviceSingleCardFixture, SnakeChainRow) {
+    if (!MetalContext::instance().rtoptions().is_simulator_or_emulated()) {
+        GTEST_SKIP() << "simulator/emulator only";
+    }
+    auto md = devices_[0];
+    if (md->compute_with_storage_grid_size().x < 8) {
+        GTEST_SKIP() << "need an 8-wide grid";
+    }
+    std::vector<experimental::NodeCoord> nodes;  // full row 0, left->right (8 hops)
+    nodes.reserve(8);
+    for (uint32_t x = 0; x < 8; ++x) {
+        nodes.push_back(experimental::NodeCoord{x, 0});
+    }
+    run_snake_chain(md, nodes);
+}
+
+TEST_F(QuasarMeshDeviceSingleCardFixture, SnakeChainFull) {
+    if (!MetalContext::instance().rtoptions().is_simulator_or_emulated()) {
+        GTEST_SKIP() << "simulator/emulator only";
+    }
+    auto md = devices_[0];
+    const auto g = md->compute_with_storage_grid_size();
+    if (g.x < 8 || g.y < 4) {
+        GTEST_SKIP() << "need the full 8x4 grid";
+    }
+    // Boustrophedon: row0 L->R, row1 R->L, ... so every hop is nearest-neighbor.
+    std::vector<experimental::NodeCoord> nodes;
+    for (uint32_t y = 0; y < g.y; ++y) {
+        if (y % 2 == 0) {
+            for (uint32_t x = 0; x < g.x; ++x) {
+                nodes.push_back(experimental::NodeCoord{x, y});
+            }
+        } else {
+            for (int x = static_cast<int>(g.x) - 1; x >= 0; --x) {
+                nodes.push_back(experimental::NodeCoord{static_cast<uint32_t>(x), y});
+            }
+        }
+    }
+    run_snake_chain(md, nodes);  // all 32 nodes, one continuous snake
 }

--- a/tests/tt_metal/tt_metal/test_quasar_semaphores.cpp
+++ b/tests/tt_metal/tt_metal/test_quasar_semaphores.cpp
@@ -8,6 +8,7 @@
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
+#include <tt-metalium/mesh_buffer.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include "hal.hpp"
 #include "llrt/rtoptions.hpp"
@@ -42,14 +43,25 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarMultiSemaphorePipeline) {
     const uint32_t buf_a_addr = MetalContext::instance().hal().get_dev_addr(
         HalProgrammableCoreType::TENSIX, HalL1MemAddrType::DEFAULT_UNRESERVED);
     const uint32_t buf_b_addr = buf_a_addr + num_elements * sizeof(uint32_t);
-    const uint32_t dram_src_addr = MetalContext::instance().hal().get_dev_addr(HalDramMemAddrType::UNRESERVED);
-    const uint32_t dram_dst_addr = dram_src_addr + (1000 * 1024);
+
+    // Source/destination live in DRAM MeshBuffers (single contiguous page in bank 0); the kernels
+    // read/write them at {bank 0, buf->address()} and host I/O goes through the mesh command queue.
+    constexpr uint32_t dram_bytes = num_elements * sizeof(uint32_t);
+    auto make_dram_buf = [&] {
+        distributed::DeviceLocalBufferConfig lc{.page_size = dram_bytes, .buffer_type = BufferType::DRAM};
+        distributed::ReplicatedBufferConfig gc{.size = dram_bytes};
+        return distributed::MeshBuffer::create(gc, lc, mesh_device.get());
+    };
+    auto dram_src_buf = make_dram_buf();
+    auto dram_dst_buf = make_dram_buf();
+    const uint32_t dram_src_addr = dram_src_buf->address();
+    const uint32_t dram_dst_addr = dram_dst_buf->address();
 
     std::vector<uint32_t> initial_data(num_elements, 0);
     for (uint32_t i = 0; i < num_elements; i++) {
         initial_data[i] = i;
     }
-    tt_metal::detail::WriteToDeviceDRAMChannel(mesh_device->get_devices()[0], 0, dram_src_addr, initial_data);
+    distributed::EnqueueWriteMeshBuffer(cq, dram_src_buf, initial_data);
 
     const experimental::KernelSpecName DM_READER{"dm_reader"};
     const experimental::KernelSpecName DM_TRANSFORM{"dm_transform"};
@@ -156,9 +168,8 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarMultiSemaphorePipeline) {
     workload.add_program(device_range, std::move(program));
     distributed::EnqueueMeshWorkload(cq, workload, true);
 
-    std::vector<uint32_t> actual_data(num_elements, 0);
-    tt_metal::detail::ReadFromDeviceDRAMChannel(
-        mesh_device->get_devices()[0], 0, dram_dst_addr, num_elements * sizeof(uint32_t), actual_data);
+    std::vector<uint32_t> actual_data;
+    distributed::EnqueueReadMeshBuffer(cq, actual_data, dram_dst_buf, /*blocking=*/true);
 
     const std::vector<uint32_t> expected_data = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
 
@@ -894,19 +905,34 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, GridBarrierAllToOne) {
         GTEST_SKIP() << "simulator/emulator only";
     }
     auto md = devices_[0];
-    IDevice* dev = md->get_devices()[0];
     const auto g = md->compute_with_storage_grid_size();
     if (g.x != 8 || g.y != 4) {
         GTEST_SKIP() << "need the full 8x4 grid";
     }
     const experimental::NodeCoord target{0, 0};
     const uint32_t num_signalers = g.x * g.y - 1;  // everyone except the target
-    const uint32_t result_addr = MetalContext::instance().hal().get_dev_addr(
-        HalProgrammableCoreType::TENSIX, HalL1MemAddrType::DEFAULT_UNRESERVED);
+    // The target's result slot is a single-core L1 MeshBuffer on the target node, result_addr is
+    // threaded into the kernel and host I/O (seed + read-back) goes through the mesh command queue.
+    distributed::MeshCommandQueue& cq = md->mesh_command_queue();
+    const CoreRangeSet result_grid(CoreRange(target, target));
+    const ShardSpecBuffer result_shard(
+        result_grid,
+        /*shard_shape=*/{1, 1},
+        ShardOrientation::ROW_MAJOR,
+        /*page_shape=*/{1, 1},
+        /*tensor2d_shape_in_pages=*/{1, 1});
+    distributed::DeviceLocalBufferConfig result_local{
+        .page_size = sizeof(uint32_t),
+        .buffer_type = BufferType::L1,
+        .sharding_args = BufferShardingArgs(result_shard, TensorMemoryLayout::HEIGHT_SHARDED),
+    };
+    distributed::ReplicatedBufferConfig result_global{.size = sizeof(uint32_t)};
+    auto result_buf = distributed::MeshBuffer::create(result_global, result_local, md.get());
+    const uint32_t result_addr = result_buf->address();
 
     // Seed the target's result slot so an incomplete barrier is detectable.
     std::vector<uint32_t> seed{0xffffffffu};
-    tt_metal::detail::WriteToDeviceL1(dev, target, result_addr, seed);
+    distributed::EnqueueWriteMeshBuffer(cq, result_buf, seed);
 
     const experimental::SemaphoreSpecName BARRIER{"barrier_sem"};
     const experimental::KernelSpecName BK{"barrier_kernel"};
@@ -948,14 +974,13 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, GridBarrierAllToOne) {
     params.kernel_run_args = {kra};
     experimental::SetProgramRunArgs(program, params);
 
-    distributed::MeshCommandQueue& cq = md->mesh_command_queue();
     distributed::MeshWorkload workload;
     distributed::MeshCoordinateRange device_range(md->shape());
     workload.add_program(device_range, std::move(program));
     distributed::EnqueueMeshWorkload(cq, workload, true);
 
-    std::vector<uint32_t> r(1, 0u);
-    tt_metal::detail::ReadFromDeviceL1(dev, target, result_addr, sizeof(uint32_t), r);
+    std::vector<uint32_t> r;
+    distributed::EnqueueReadMeshBuffer(cq, r, result_buf, /*blocking=*/true);
     constexpr uint32_t kReleased = 0xC0DEBA11u;
     std::cout << "[BARRIER] target result=0x" << std::hex << r[0] << " expected released=0x" << kReleased << std::dec
               << (r[0] == kReleased ? "  PASS" : "  FAIL") << std::endl;

--- a/tests/tt_metal/tt_metal/test_quasar_semaphores.cpp
+++ b/tests/tt_metal/tt_metal/test_quasar_semaphores.cpp
@@ -385,15 +385,12 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarMultipleClustersMultiSemaphorePi
     ASSERT_EQ(actual_data, expected_data);
 }
 
-// ---------------------------------------------------------------------------
-// L3: semaphore + DRAM-staged SNAKE CHAIN across an arbitrary ordered node list.
-// Data flows node[0] -> node[1] -> ... -> node[N-1]. Each hop: node[i]'s writer
-// stages its (transformed) buffer to DRAM stage[i+1] and increments node[i+1]'s
-// cross-node semaphore; node[i+1]'s reader waits on it, reads stage[i+1], transforms
-// (+1), and relays onward. Final DRAM stage = seed + N. Proves every node in the
-// list can receive-from-prev and send-to-next. Generalizes QuasarMultipleClusters...
-// (the proven 2-node cross-node pipeline) to N nodes.
-// ---------------------------------------------------------------------------
+// Semaphore + DRAM-staged snake chain across an ordered list of nodes.
+// Data flows node[0] -> node[1] -> ... -> node[N-1]. At each hop node[i]'s writer
+// stages its transformed buffer to DRAM and bumps the next node's cross-node semaphore;
+// node[i+1]'s reader waits on it, reads the stage, adds 1, and passes it along.
+// Final DRAM stage = seed + N. Shows every node can both receive from the previous node
+// and send to the next, the 2-node cross-node pipeline generalized to N nodes.
 static void run_snake_chain(
     const std::shared_ptr<distributed::MeshDevice>& mesh_device,
     const std::vector<experimental::NodeCoord>& nodes,
@@ -411,14 +408,13 @@ static void run_snake_chain(
     const uint32_t buf_a = MetalContext::instance().hal().get_dev_addr(
         HalProgrammableCoreType::TENSIX, HalL1MemAddrType::DEFAULT_UNRESERVED);
     const uint32_t buf_b = buf_a + num_elements * sizeof(uint32_t);
-    const uint32_t buf_wrap = buf_b + num_elements * sizeof(uint32_t);  // ring: node[0] receives the wrapped token here
-    const SemaphoreSpecName WRAP{"wrap_sem"};                           // ring: node[N-1] -> node[0] closing edge
-    const SemaphoreSpecName WRAP_L0{"wrap_l0"};                         // ring: local sem for node[0]'s wrap reader
+    const uint32_t buf_wrap = buf_b + num_elements * sizeof(uint32_t);
+    const SemaphoreSpecName WRAP{"wrap_sem"};
+    const SemaphoreSpecName WRAP_L0{"wrap_l0"};
     const uint32_t dram_base = MetalContext::instance().hal().get_dev_addr(HalDramMemAddrType::UNRESERVED);
     constexpr uint32_t stage_stride = 4096;  // per-hop DRAM staging spacing
     auto stage_addr = [&](uint32_t i) { return dram_base + i * stage_stride; };
-    // Each hop stages num_elements words at stage_addr(i); guard against a payload that would
-    // overflow one stage into the next (stages are stage_stride bytes apart).
+
     ASSERT_LE(num_elements * sizeof(uint32_t), stage_stride);
 
     // Seed stage 0 with [0..num_elements).
@@ -427,13 +423,11 @@ static void run_snake_chain(
         seed[i] = i;
     }
     tt_metal::detail::WriteToDeviceDRAMChannel(dev, 0, stage_addr(0), seed);
-    // Sentinel the OUTPUT stage so a stale-data pass is impossible: callers reuse identical
-    // stage addresses across runs, so the final EXPECT_EQ must be forced to observe fresh data
-    // written by THIS run's chain (not leftover values from a prior same-N run).
+    // Pre-fill the output stage with a sentinel value.
     std::vector<uint32_t> out_sentinel(num_elements, 0xdeadbeefu);
     tt_metal::detail::WriteToDeviceDRAMChannel(dev, 0, stage_addr(N), out_sentinel);
-    // Ring mode additionally verifies the wrapped token in node[0]'s buf_wrap; sentinel it too so
-    // the ring-edge assertion cannot pass on stale/uninitialized data.
+    // Ring mode also checks the token that wraps back to node[0]'s buf_wrap; pre-fill it with a
+    // sentinel too so that check can't pass on stale or uninitialized data.
     if (ring) {
         tt_metal::detail::WriteToDeviceL1(dev, nodes[0], buf_wrap, out_sentinel);
     }
@@ -453,12 +447,10 @@ static void run_snake_chain(
         const SemaphoreSpecName CROSS_IN{"cross_" + std::to_string(i == 0 ? 0 : i - 1)};  // hop (i-1)->i
         const SemaphoreSpecName CROSS_OUT{"cross_" + si};                                 // hop i->(i+1)
 
-        // Local intra-node sems (reader->xform, xform->writer).
+        // Local intra-node sems.
         spec.semaphores.push_back(SemaphoreSpec{.unique_id = L0, .target_nodes = nodes[i]});
         spec.semaphores.push_back(SemaphoreSpec{.unique_id = L1, .target_nodes = nodes[i]});
-        // Cross-node sem for the hop i->i+1, allocated on both endpoints (same L1 addr).
-        // NodeRange is a bounding box (end >= start), so order the two adjacent coords by
-        // componentwise min/max — the snake's right->left rows have nodes[i].x > nodes[i+1].x.
+
         if (!is_sink) {
             const auto a = nodes[i];
             const auto b = nodes[i + 1];
@@ -467,7 +459,6 @@ static void run_snake_chain(
             spec.semaphores.push_back(
                 SemaphoreSpec{.unique_id = CROSS_OUT, .target_nodes = experimental::NodeRange{lo, hi}});
         } else if (ring) {
-            // Wrap edge node[N-1] -> node[0] (may be a non-adjacent long hop; bbox may span a column).
             const auto a = nodes[i];
             const auto b = nodes[0];
             const experimental::NodeCoord lo{std::min(a.x, b.x), std::min(a.y, b.y)};
@@ -529,8 +520,8 @@ static void run_snake_chain(
 
         std::vector<KernelSpecName> wu_kernels = {READER, XFORM, WRITER};
         if (ring && is_src) {
-            // Ring: node[0] also hosts the wrap-reader. It MUST live in node[0]'s own work unit —
-            // two work units may not target the same node (program_spec.cpp:1830).
+            // Ring: node[0] also runs the wrap-reader. It must go in node[0]'s existing work unit
+            // because two work units are not allowed to target the same node.
             const KernelSpecName WRAP_READER{"wrap_reader"};
             spec.semaphores.push_back(SemaphoreSpec{.unique_id = WRAP_L0, .target_nodes = nodes[0]});
             spec.kernels.push_back(KernelSpec{
@@ -641,7 +632,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, RingChainFull) {
     run_snake_chain(md, nodes, /*ring=*/true);  // 32-node snake + wrap edge back to node[0]
 }
 
-// L6 stress: longest single cross-node hop, opposite corners {0,0} <-> {7,3}.
+// Longest single cross-node hop: opposite corners {0,0} <-> {7,3}.
 TEST_F(QuasarMeshDeviceSingleCardFixture, SnakeCornerToCorner) {
     if (!MetalContext::instance().rtoptions().is_simulator_or_emulated()) {
         GTEST_SKIP() << "simulator/emulator only";
@@ -654,7 +645,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, SnakeCornerToCorner) {
     run_snake_chain(md, {experimental::NodeCoord{0, 0}, experimental::NodeCoord{7, 3}});
 }
 
-// L6 stress: payload-size sweep across the full 32-node snake.
+// Sweep a few payload sizes across the full 32-node snake.
 TEST_F(QuasarMeshDeviceSingleCardFixture, SnakePayloadSweep) {
     if (!MetalContext::instance().rtoptions().is_simulator_or_emulated()) {
         GTEST_SKIP() << "simulator/emulator only";
@@ -682,7 +673,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, SnakePayloadSweep) {
     }
 }
 
-// L5 FAN-OUT: one DRAM root value read concurrently by ALL 32 nodes (broadcast via shared DRAM).
+// Fan-out: all 32 nodes read the same DRAM value at once (broadcast through shared DRAM).
 TEST_F(QuasarMeshDeviceSingleCardFixture, FanOutBroadcast) {
     if (!MetalContext::instance().rtoptions().is_simulator_or_emulated()) {
         GTEST_SKIP() << "simulator/emulator only";
@@ -752,8 +743,9 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, FanOutBroadcast) {
     EXPECT_EQ(fail, 0u);
 }
 
-// L5 FAN-IN / GATHER: all 32 nodes concurrently write a coord-unique value into a shared DRAM
-// gather region (each node -> its own slot). Reader reads a per-node DRAM seed, writer stages it out.
+// Fan-in / gather: all 32 nodes write at once into a shared DRAM gather region, each into its
+// own slot with a value unique to its coordinates. Reader loads a per-node DRAM seed, writer
+// stages it back out.
 TEST_F(QuasarMeshDeviceSingleCardFixture, FanInGather) {
     if (!MetalContext::instance().rtoptions().is_simulator_or_emulated()) {
         GTEST_SKIP() << "simulator/emulator only";
@@ -772,8 +764,9 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, FanInGather) {
     const uint32_t dram_gather = dram_src + 64u * stride;  // gather region well past the per-node src slots
     auto sig_of = [&](uint32_t x, uint32_t y) { return 0xb000u + x + y * g.x; };
 
-    // Seed each node's own DRAM src slot with its coord-unique value, and sentinel its gather
-    // destination so the post-run gather check cannot pass on stale data from a prior run.
+    // Seed each node's own DRAM source slot with a value unique to its coordinates, and pre-fill
+    // its gather destination with a sentinel so the gather check can't pass on stale data from a
+    // prior run.
     for (uint32_t y = 0; y < g.y; ++y) {
         for (uint32_t x = 0; x < g.x; ++x) {
             const uint32_t idx = x + y * g.x;
@@ -849,7 +842,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, FanInGather) {
     EXPECT_EQ(fail, 0u);
 }
 
-// L6 per-row chains: exercise each of the 4 rows as its own independent chain.
+// Run each of the 4 rows as its own independent chain.
 TEST_F(QuasarMeshDeviceSingleCardFixture, PerRowChains) {
     if (!MetalContext::instance().rtoptions().is_simulator_or_emulated()) {
         GTEST_SKIP() << "simulator/emulator only";
@@ -870,11 +863,9 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, PerRowChains) {
     }
 }
 
-// Vertical analog of PerRowChains: each of the 8 columns is a top->bottom 4-node chain.
-// run_snake_chain blocks per call (EnqueueMeshWorkload is blocking), so the 8 column chains
-// run SEQUENTIALLY -- one completes (enqueue + readback + assert) before the next starts.
-// This adds vertical-NoC-path coverage vs PerRowChains' horizontal hops; it is NOT
-// concurrent-chain contention (which the single-NoC functional sim would not model anyway).
+// Column version of PerRowChains: each of the 8 columns is a top->bottom 4-node chain.
+// Each run_snake_chain call blocks, so the 8 columns run one after another, each finishes its
+// enqueue, readback, and check before the next starts.
 TEST_F(QuasarMeshDeviceSingleCardFixture, PerColumnChains) {
     if (!MetalContext::instance().rtoptions().is_simulator_or_emulated()) {
         GTEST_SKIP() << "simulator/emulator only";
@@ -895,9 +886,9 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, PerColumnChains) {
     }
 }
 
-// Grid all-to-one barrier: every node except the target (logical {0,0}) remote-increments the
-// target's barrier semaphore once; the target waits for all N-1 increments (one down() each) and
-// records completion in L1. Exercises maximum semaphore fan-in onto a single counter. Non-DFB.
+// Grid all-to-one barrier: every node except the target (logical {0,0}) increments the target's
+// barrier semaphore once over the NoC. The target waits for all N-1 increments, then records
+// completion in L1. Exercises maximum semaphore fan-in onto a single counter.
 TEST_F(QuasarMeshDeviceSingleCardFixture, GridBarrierAllToOne) {
     if (!MetalContext::instance().rtoptions().is_simulator_or_emulated()) {
         GTEST_SKIP() << "simulator/emulator only";
@@ -923,8 +914,8 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, GridBarrierAllToOne) {
     const experimental::NodeRange all_nodes{experimental::NodeCoord{0, 0}, experimental::NodeCoord{g.x - 1, g.y - 1}};
 
     experimental::ProgramSpec spec{.name = "grid_barrier"};
-    // One barrier semaphore, allocated at the same L1 address on all 32 nodes (so the remote-inc
-    // address computation and the target's local read agree).
+    // One barrier semaphore at the same L1 address on all 32 nodes, so the remote increments and
+    // the target's local read all land on the same location.
     spec.semaphores.push_back(experimental::SemaphoreSpec{.unique_id = BARRIER, .target_nodes = all_nodes});
     experimental::KernelSpec bk{
         .unique_id = BK,
@@ -965,11 +956,6 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, GridBarrierAllToOne) {
 
     std::vector<uint32_t> r(1, 0u);
     tt_metal::detail::ReadFromDeviceL1(dev, target, result_addr, sizeof(uint32_t), r);
-    // The target writes the RELEASED sentinel only after down(num_signalers) AND wait(0) both
-    // pass -- i.e. exactly num_signalers increments arrived and the counter drained to 0. An
-    // under-count blocks in down() (hang/timeout); an over-count blocks in wait(0). So this
-    // asserts an OBSERVED device property, not the input constant it was seeded/sent. (A single
-    // counting semaphore cannot verify signaler identity/distinctness -- inherent to a counter.)
     constexpr uint32_t kReleased = 0xC0DEBA11u;
     std::cout << "[BARRIER] target result=0x" << std::hex << r[0] << " expected released=0x" << kReleased << std::dec
               << (r[0] == kReleased ? "  PASS" : "  FAIL") << std::endl;
@@ -984,7 +970,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, SnakeChain3) {
     if (devices_[0]->compute_with_storage_grid_size().x < 3) {
         GTEST_SKIP() << "need a >=3-wide grid";
     }
-    // First rung: source -> relay -> sink (3 adjacent nodes in row 0).
+    // Source -> relay -> sink across 3 adjacent nodes in row 0.
     run_snake_chain(devices_[0], {{0, 0}, {1, 0}, {2, 0}});
 }
 
@@ -1013,7 +999,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, SnakeChainFull) {
     if (g.x < 8 || g.y < 4) {
         GTEST_SKIP() << "need the full 8x4 grid";
     }
-    // Boustrophedon: row0 L->R, row1 R->L, ... so every hop is nearest-neighbor.
+    // Snake order: row0 left->right, row1 right->left, ... so every hop is to a neighbor.
     std::vector<experimental::NodeCoord> nodes;
     for (uint32_t y = 0; y < g.y; ++y) {
         if (y % 2 == 0) {

--- a/tests/tt_metal/tt_metal/test_single_dm_l1_write.cpp
+++ b/tests/tt_metal/tt_metal/test_single_dm_l1_write.cpp
@@ -95,3 +95,333 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, SingleDmL1Write) {
 
     ASSERT_EQ(outputs[0], value) << "Got the value " << std::hex << outputs[0] << " instead of " << value;
 }
+
+// STEP 0 empirical gate for the full-grid test campaign:
+//  (a) report compute_with_storage_grid_size() -> expect 8x4 (=32 nodes)
+//  (b) host-side write+read L1 on EVERY node from origin {0,0} -> confirms extent, origin, and
+//      per-node L1 addressability across the whole grid, with per-node diagnostics on failure.
+TEST_F(QuasarMeshDeviceSingleCardFixture, GridProbeStep0) {
+    if (std::getenv("TT_METAL_SIMULATOR") == nullptr) {
+        GTEST_SKIP() << "This test can only be run using a simulator.";
+    }
+    IDevice* dev = devices_[0]->get_devices()[0];
+    auto mesh_device = devices_[0];
+
+    const auto grid = mesh_device->compute_with_storage_grid_size();
+    std::cout << "[STEP0] compute_with_storage_grid_size = " << grid.x << " x " << grid.y
+              << "  (nodes=" << (grid.x * grid.y) << ")" << std::endl;
+
+    // This suite targets the full 8x4 Quasar sim grid. Skip (don't fail) on the smaller
+    // 1x3/2x3 CI configs so it no-ops cleanly there instead of asserting.
+    if (grid.x != 8u || grid.y != 4u) {
+        GTEST_SKIP() << "grid-test suite targets the 8x4 Quasar sim config (got " << grid.x << "x" << grid.y << ")";
+    }
+
+    const uint32_t address = MetalContext::instance().hal().get_dev_addr(
+        HalProgrammableCoreType::TENSIX, HalL1MemAddrType::DEFAULT_UNRESERVED);
+
+    uint32_t ok = 0, fail = 0;
+    for (uint32_t y = 0; y < grid.y; ++y) {
+        for (uint32_t x = 0; x < grid.x; ++x) {
+            const experimental::NodeCoord node{x, y};
+            const uint32_t sig = x + y * grid.x;  // coord-unique signature (tile_id)
+            std::vector<uint32_t> w{sig};
+            std::vector<uint32_t> r(1, 0xdeadbeefu);
+            try {
+                tt_metal::detail::WriteToDeviceL1(dev, node, address, w);
+                tt_metal::detail::ReadFromDeviceL1(dev, node, address, sizeof(uint32_t), r);
+                if (r[0] == sig) {
+                    ++ok;
+                } else {
+                    ++fail;
+                    std::cout << "[STEP0] MISMATCH node(" << x << "," << y << ") got 0x" << std::hex << r[0]
+                              << " expected 0x" << sig << std::dec << std::endl;
+                }
+            } catch (const std::exception& e) {
+                ++fail;
+                std::cout << "[STEP0] EXCEPTION node(" << x << "," << y << "): " << e.what() << std::endl;
+            }
+        }
+    }
+    std::cout << "[STEP0] per-node host L1 write/read: ok=" << ok << " fail=" << fail << " total=" << (grid.x * grid.y)
+              << std::endl;
+    EXPECT_EQ(fail, 0u);
+    EXPECT_EQ(grid.x, 8u) << "expected 8-wide grid";
+    EXPECT_EQ(grid.y, 4u) << "expected 4-tall grid";
+}
+
+// L1a (STEP 1): full-grid replicated DM->L1 smoke. Fan ONE kernel to all 32 nodes via
+// target_nodes = NodeRange{{0,0},{7,3}} with a per-node coord-unique signature RTA, then read
+// back per node and print a PASS/FAIL grid map. Exercises the (declared-but-unexercised-at-32)
+// kernel + per-node-RTA fan-out path.
+TEST_F(QuasarMeshDeviceSingleCardFixture, FullGridDmL1Write_L1a) {
+    if (std::getenv("TT_METAL_SIMULATOR") == nullptr) {
+        GTEST_SKIP() << "This test can only be run using a simulator.";
+    }
+    IDevice* dev = devices_[0]->get_devices()[0];
+    auto mesh_device = devices_[0];
+    const auto grid = mesh_device->compute_with_storage_grid_size();
+    // Skip (don't fail) on the smaller 1x3/2x3 CI configs; this test targets the 8x4 grid.
+    if (grid.x != 8u || grid.y != 4u) {
+        GTEST_SKIP() << "full-grid test targets the 8x4 Quasar sim config (got " << grid.x << "x" << grid.y << ")";
+    }
+
+    const uint32_t address = MetalContext::instance().hal().get_dev_addr(
+        HalProgrammableCoreType::TENSIX, HalL1MemAddrType::DEFAULT_UNRESERVED);
+    auto sig_of = [&](uint32_t x, uint32_t y) -> uint32_t { return static_cast<uint32_t>(x + y * grid.x); };
+
+    // Seed every node with a sentinel so a node the kernel never reached shows up as unwritten.
+    for (uint32_t y = 0; y < grid.y; ++y) {
+        for (uint32_t x = 0; x < grid.x; ++x) {
+            std::vector<uint32_t> z{0xffffffffu};
+            tt_metal::detail::WriteToDeviceL1(dev, experimental::NodeCoord{x, y}, address, z);
+        }
+    }
+
+    distributed::MeshCommandQueue& cq = mesh_device->mesh_command_queue();
+    distributed::MeshWorkload workload;
+    distributed::MeshCoordinateRange device_range(mesh_device->shape());
+
+    const experimental::KernelSpecName DM_KERNEL{"dm_kernel"};
+    experimental::KernelSpec dm_kernel_spec{
+        .unique_id = DM_KERNEL,
+        .source = OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/simple_l1_write.cpp",
+        .num_threads = 2,
+        .runtime_arg_schema = {.runtime_arg_names = {"address", "value"}},
+        .hw_config = experimental::DataMovementGen2Config{},
+    };
+
+    // Fan the SAME kernel to ALL 32 nodes.
+    const experimental::NodeRange all_nodes(
+        experimental::NodeCoord{0, 0}, experimental::NodeCoord{grid.x - 1, grid.y - 1});
+    experimental::WorkUnitSpec main_wu{.name = "main", .kernels = {DM_KERNEL}, .target_nodes = all_nodes};
+    experimental::ProgramSpec spec{.name = "full_grid_l1a", .kernels = {dm_kernel_spec}, .work_units = {main_wu}};
+    Program program = experimental::MakeProgramFromSpec(*mesh_device, spec);
+
+    // Per-node distinct signature via the per-node RTA table.
+    experimental::ProgramRunArgs params;
+    experimental::ProgramRunArgs::KernelRunArgs kra{.kernel = DM_KERNEL};
+    for (uint32_t y = 0; y < grid.y; ++y) {
+        for (uint32_t x = 0; x < grid.x; ++x) {
+            experimental::AddRuntimeArgsForNode(
+                kra.runtime_arg_values, experimental::NodeCoord{x, y}, {{"address", address}, {"value", sig_of(x, y)}});
+        }
+    }
+    params.kernel_run_args = {kra};
+    experimental::SetProgramRunArgs(program, params);
+
+    workload.add_program(device_range, std::move(program));
+    distributed::EnqueueMeshWorkload(cq, workload, true);
+
+    // Verify per node + print a PASS/FAIL grid map (top row = highest y).
+    uint32_t ok = 0, fail = 0;
+    std::string map_str;
+    for (int y = static_cast<int>(grid.y) - 1; y >= 0; --y) {
+        std::string row;
+        for (uint32_t x = 0; x < grid.x; ++x) {
+            std::vector<uint32_t> r(1, 0xdeadbeefu);
+            tt_metal::detail::ReadFromDeviceL1(
+                dev, experimental::NodeCoord{x, static_cast<uint32_t>(y)}, address, sizeof(uint32_t), r);
+            const uint32_t sig = sig_of(x, static_cast<uint32_t>(y));
+            if (r[0] == sig) {
+                row += ". ";
+                ++ok;
+            } else {
+                row += "X ";
+                ++fail;
+                std::cout << "[L1a] FAIL node(" << x << "," << y << ") got 0x" << std::hex << r[0] << " expected 0x"
+                          << sig << std::dec << std::endl;
+            }
+        }
+        map_str += "[L1a] y=" + std::to_string(y) + "  " + row + "\n";
+    }
+    std::cout << "[L1a] " << grid.x << "x" << grid.y << " kernel-fan map (. ok / X fail):\n" << map_str;
+    std::cout << "[L1a] ok=" << ok << " fail=" << fail << " total=" << (grid.x * grid.y) << std::endl;
+    EXPECT_EQ(fail, 0u);
+}
+
+// L1c (STEP 3): full-grid COMPUTE smoke. Fan the known-good risc_math compute kernel to all 32
+// nodes; every node must produce the same fixed 16-value output vector. Exercises the compute
+// datapath (UNPACK/MATH/PACK) on the whole grid.
+TEST_F(QuasarMeshDeviceSingleCardFixture, FullGridCompute_L1c) {
+    if (std::getenv("TT_METAL_SIMULATOR") == nullptr) {
+        GTEST_SKIP() << "This test can only be run using a simulator.";
+    }
+    IDevice* dev = devices_[0]->get_devices()[0];
+    auto mesh_device = devices_[0];
+    const auto grid = mesh_device->compute_with_storage_grid_size();
+    // Skip (don't fail) on the smaller 1x3/2x3 CI configs; this test targets the 8x4 grid.
+    if (grid.x != 8u || grid.y != 4u) {
+        GTEST_SKIP() << "full-grid test targets the 8x4 Quasar sim config (got " << grid.x << "x" << grid.y << ")";
+    }
+
+    const uint32_t l1_address = MetalContext::instance().hal().get_dev_addr(
+        HalProgrammableCoreType::TENSIX, HalL1MemAddrType::DEFAULT_UNRESERVED);
+    const std::vector<uint32_t> expected = {4, 6, 5, 9, 8, 10, 9, 13, 12, 14, 13, 17, 16, 18, 17, 21};
+
+    // Seed every node's 16-word output slot with a sentinel that never appears in `expected`, so a
+    // node whose compute never ran (or whose output was misrouted to a different node) reads back
+    // the sentinel and FAILS rather than silently passing. Note: risc_math's output is node-
+    // independent, so this test cannot by itself distinguish WHICH node produced a value; per-node
+    // output identity is covered separately by FullGridDmL1Write_L1a's coord-unique signatures.
+    for (uint32_t y = 0; y < grid.y; ++y) {
+        for (uint32_t x = 0; x < grid.x; ++x) {
+            std::vector<uint32_t> z(16, 0xC0FFEEu);
+            tt_metal::detail::WriteToDeviceL1(dev, experimental::NodeCoord{x, y}, l1_address, z);
+        }
+    }
+
+    distributed::MeshCommandQueue& cq = mesh_device->mesh_command_queue();
+    distributed::MeshWorkload workload;
+    distributed::MeshCoordinateRange device_range(mesh_device->shape());
+
+    const experimental::KernelSpecName COMPUTE_KERNEL{"risc_math"};
+    experimental::KernelSpec compute_kernel_spec{
+        .unique_id = COMPUTE_KERNEL,
+        .source = OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/compute/risc_math.cpp",
+        .num_threads = 4,
+        .runtime_arg_schema = {.runtime_arg_names = {"l1_address"}},
+        .hw_config = experimental::ComputeGen2Config{},
+    };
+
+    const experimental::NodeRange all_nodes(
+        experimental::NodeCoord{0, 0}, experimental::NodeCoord{grid.x - 1, grid.y - 1});
+    experimental::WorkUnitSpec main_wu{.name = "main", .kernels = {COMPUTE_KERNEL}, .target_nodes = all_nodes};
+    experimental::ProgramSpec spec{
+        .name = "full_grid_compute", .kernels = {compute_kernel_spec}, .work_units = {main_wu}};
+    Program program = experimental::MakeProgramFromSpec(*mesh_device, spec);
+
+    experimental::ProgramRunArgs params;
+    experimental::ProgramRunArgs::KernelRunArgs kra{.kernel = COMPUTE_KERNEL};
+    for (uint32_t y = 0; y < grid.y; ++y) {
+        for (uint32_t x = 0; x < grid.x; ++x) {
+            experimental::AddRuntimeArgsForNode(
+                kra.runtime_arg_values, experimental::NodeCoord{x, y}, {{"l1_address", l1_address}});
+        }
+    }
+    params.kernel_run_args = {kra};
+    experimental::SetProgramRunArgs(program, params);
+
+    workload.add_program(device_range, std::move(program));
+    distributed::EnqueueMeshWorkload(cq, workload, true);
+
+    uint32_t ok = 0, fail = 0;
+    std::string map_str;
+    for (int y = static_cast<int>(grid.y) - 1; y >= 0; --y) {
+        std::string row;
+        for (uint32_t x = 0; x < grid.x; ++x) {
+            std::vector<uint32_t> r(16, 0xdeadbeefu);
+            tt_metal::detail::ReadFromDeviceL1(
+                dev, experimental::NodeCoord{x, static_cast<uint32_t>(y)}, l1_address, 16 * sizeof(uint32_t), r);
+            if (r == expected) {
+                row += ". ";
+                ++ok;
+            } else {
+                row += "X ";
+                ++fail;
+                std::cout << "[L1c] FAIL node(" << x << "," << y << ") first=" << r[0] << " (expected " << expected[0]
+                          << ")" << std::endl;
+            }
+        }
+        map_str += "[L1c] y=" + std::to_string(y) + "  " + row + "\n";
+    }
+    std::cout << "[L1c] " << grid.x << "x" << grid.y << " compute map (. ok / X fail):\n" << map_str;
+    std::cout << "[L1c] ok=" << ok << " fail=" << fail << " total=" << (grid.x * grid.y) << std::endl;
+    EXPECT_EQ(fail, 0u);
+}
+
+// Grid NoC multicast fan-out: one source node (logical {0,0}) multicasts a value to the same L1
+// address on every node in the full-grid rectangle, driving the actual NoC multicast path
+// (get_noc_multicast_addr -> for_each_multicast_coordinate). Host pre-seeds a sentinel on every
+// node and reads all 32 back, printing a PASS/FAIL grid map — a dropped row/column shows up as an
+// un-updated node (guards the historical multicast column-drop bug). Non-DFB.
+TEST_F(QuasarMeshDeviceSingleCardFixture, GridMulticastFanOut) {
+    if (std::getenv("TT_METAL_SIMULATOR") == nullptr) {
+        GTEST_SKIP() << "This test can only be run using a simulator.";
+    }
+    IDevice* dev = devices_[0]->get_devices()[0];
+    auto mesh_device = devices_[0];
+    const auto grid = mesh_device->compute_with_storage_grid_size();
+    if (grid.x != 8u || grid.y != 4u) {
+        GTEST_SKIP() << "full-grid test targets the 8x4 Quasar sim config (got " << grid.x << "x" << grid.y << ")";
+    }
+
+    const uint32_t address = MetalContext::instance().hal().get_dev_addr(
+        HalProgrammableCoreType::TENSIX, HalL1MemAddrType::DEFAULT_UNRESERVED);
+    const uint32_t value = 0x5eeded42u;
+    const uint32_t sentinel = 0xdeadbeefu;
+
+    // Seed every node with a sentinel so a node the multicast never reached shows as unwritten.
+    for (uint32_t y = 0; y < grid.y; ++y) {
+        for (uint32_t x = 0; x < grid.x; ++x) {
+            std::vector<uint32_t> z{sentinel};
+            tt_metal::detail::WriteToDeviceL1(dev, experimental::NodeCoord{x, y}, address, z);
+        }
+    }
+
+    // Source at logical {0,0}; multicast rectangle = physical coords spanning the whole 8x4 grid.
+    const experimental::NodeCoord src_node{0, 0};
+    const CoreCoord p_lo = mesh_device->worker_core_from_logical_core(experimental::NodeCoord{0, 0});
+    const CoreCoord p_hi = mesh_device->worker_core_from_logical_core(experimental::NodeCoord{grid.x - 1, grid.y - 1});
+    const uint32_t num_dests = grid.x * grid.y - 1;  // rectangle minus the (auto-excluded) source
+
+    distributed::MeshCommandQueue& cq = mesh_device->mesh_command_queue();
+    distributed::MeshWorkload workload;
+    distributed::MeshCoordinateRange device_range(mesh_device->shape());
+
+    const experimental::KernelSpecName MCAST{"mcast_writer"};
+    experimental::KernelSpec mcast_spec{
+        .unique_id = MCAST,
+        .source = OVERRIDE_KERNEL_PREFIX "tests/tt_metal/tt_metal/test_kernels/dataflow/grid_multicast_writer.cpp",
+        .num_threads = 1,
+        .runtime_arg_schema =
+            {.runtime_arg_names =
+                 {"value", "result_addr", "mcast_x_start", "mcast_y_start", "mcast_x_end", "mcast_y_end", "num_dests"}},
+        .hw_config = experimental::DataMovementGen2Config{},
+    };
+    experimental::WorkUnitSpec wu{.name = "main", .kernels = {MCAST}, .target_nodes = src_node};
+    experimental::ProgramSpec spec{.name = "grid_mcast_fanout", .kernels = {mcast_spec}, .work_units = {wu}};
+    Program program = experimental::MakeProgramFromSpec(*mesh_device, spec);
+
+    experimental::ProgramRunArgs params;
+    params.kernel_run_args = {experimental::ProgramRunArgs::KernelRunArgs{
+        .kernel = MCAST,
+        .runtime_arg_values = experimental::MakeRuntimeArgsForSingleNode(
+            src_node,
+            {{"value", value},
+             {"result_addr", address},
+             {"mcast_x_start", static_cast<uint32_t>(p_lo.x)},
+             {"mcast_y_start", static_cast<uint32_t>(p_lo.y)},
+             {"mcast_x_end", static_cast<uint32_t>(p_hi.x)},
+             {"mcast_y_end", static_cast<uint32_t>(p_hi.y)},
+             {"num_dests", num_dests}})}};
+    experimental::SetProgramRunArgs(program, params);
+
+    workload.add_program(device_range, std::move(program));
+    distributed::EnqueueMeshWorkload(cq, workload, true);
+
+    // Verify per node + print a PASS/FAIL grid map (top row = highest y).
+    uint32_t ok = 0, fail = 0;
+    std::string map_str;
+    for (int y = static_cast<int>(grid.y) - 1; y >= 0; --y) {
+        std::string row;
+        for (uint32_t x = 0; x < grid.x; ++x) {
+            std::vector<uint32_t> r(1, 0u);
+            tt_metal::detail::ReadFromDeviceL1(
+                dev, experimental::NodeCoord{x, static_cast<uint32_t>(y)}, address, sizeof(uint32_t), r);
+            if (r[0] == value) {
+                row += ". ";
+                ++ok;
+            } else {
+                row += "X ";
+                ++fail;
+                std::cout << "[MCAST] FAIL node(" << x << "," << y << ") got 0x" << std::hex << r[0] << " expected 0x"
+                          << value << std::dec << std::endl;
+            }
+        }
+        map_str += "[MCAST] y=" + std::to_string(y) + "  " + row + "\n";
+    }
+    std::cout << "[MCAST] " << grid.x << "x" << grid.y << " multicast map (. ok / X fail):\n" << map_str;
+    std::cout << "[MCAST] ok=" << ok << " fail=" << fail << " total=" << (grid.x * grid.y) << std::endl;
+    EXPECT_EQ(fail, 0u);
+}

--- a/tests/tt_metal/tt_metal/test_single_dm_l1_write.cpp
+++ b/tests/tt_metal/tt_metal/test_single_dm_l1_write.cpp
@@ -96,10 +96,9 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, SingleDmL1Write) {
     ASSERT_EQ(outputs[0], value) << "Got the value " << std::hex << outputs[0] << " instead of " << value;
 }
 
-// STEP 0 empirical gate for the full-grid test campaign:
-//  (a) report compute_with_storage_grid_size() -> expect 8x4 (=32 nodes)
-//  (b) host-side write+read L1 on EVERY node from origin {0,0} -> confirms extent, origin, and
-//      per-node L1 addressability across the whole grid, with per-node diagnostics on failure.
+// First check for the full-grid tests: confirm the grid is 8x4 (32 nodes), then host-write and
+// read back L1 on every node from origin {0,0}. Proves the grid size and that every node's L1 is
+// reachable, printing which node failed if any.
 TEST_F(QuasarMeshDeviceSingleCardFixture, GridProbeStep0) {
     if (std::getenv("TT_METAL_SIMULATOR") == nullptr) {
         GTEST_SKIP() << "This test can only be run using a simulator.";
@@ -111,8 +110,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, GridProbeStep0) {
     std::cout << "[STEP0] compute_with_storage_grid_size = " << grid.x << " x " << grid.y
               << "  (nodes=" << (grid.x * grid.y) << ")" << std::endl;
 
-    // This suite targets the full 8x4 Quasar sim grid. Skip (don't fail) on the smaller
-    // 1x3/2x3 CI configs so it no-ops cleanly there instead of asserting.
+    // Skip on the smaller 1x3/2x3 configs; this suite targets the 8x4 Quasar grid.
     if (grid.x != 8u || grid.y != 4u) {
         GTEST_SKIP() << "grid-test suite targets the 8x4 Quasar sim config (got " << grid.x << "x" << grid.y << ")";
     }
@@ -124,7 +122,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, GridProbeStep0) {
     for (uint32_t y = 0; y < grid.y; ++y) {
         for (uint32_t x = 0; x < grid.x; ++x) {
             const experimental::NodeCoord node{x, y};
-            const uint32_t sig = x + y * grid.x;  // coord-unique signature (tile_id)
+            const uint32_t sig = x + y * grid.x;  // value unique to each node
             std::vector<uint32_t> w{sig};
             std::vector<uint32_t> r(1, 0xdeadbeefu);
             try {
@@ -150,10 +148,10 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, GridProbeStep0) {
     EXPECT_EQ(grid.y, 4u) << "expected 4-tall grid";
 }
 
-// L1a (STEP 1): full-grid replicated DM->L1 smoke. Fan ONE kernel to all 32 nodes via
-// target_nodes = NodeRange{{0,0},{7,3}} with a per-node coord-unique signature RTA, then read
-// back per node and print a PASS/FAIL grid map. Exercises the (declared-but-unexercised-at-32)
-// kernel + per-node-RTA fan-out path.
+// Full-grid DM->L1 smoke test. Run one kernel on all 32 nodes at once (target_nodes spans
+// {0,0}..{7,3}), giving each node a runtime arg that writes a value unique to that node. Read
+// every node back and print a PASS/FAIL grid map. Checks that the kernel and per-node runtime
+// args fan out correctly across the whole grid.
 TEST_F(QuasarMeshDeviceSingleCardFixture, FullGridDmL1Write_L1a) {
     if (std::getenv("TT_METAL_SIMULATOR") == nullptr) {
         GTEST_SKIP() << "This test can only be run using a simulator.";
@@ -161,7 +159,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, FullGridDmL1Write_L1a) {
     IDevice* dev = devices_[0]->get_devices()[0];
     auto mesh_device = devices_[0];
     const auto grid = mesh_device->compute_with_storage_grid_size();
-    // Skip (don't fail) on the smaller 1x3/2x3 CI configs; this test targets the 8x4 grid.
+    // Skip on the smaller 1x3/2x3 configs; this suite targets the 8x4 Quasar grid.
     if (grid.x != 8u || grid.y != 4u) {
         GTEST_SKIP() << "full-grid test targets the 8x4 Quasar sim config (got " << grid.x << "x" << grid.y << ")";
     }
@@ -198,7 +196,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, FullGridDmL1Write_L1a) {
     experimental::ProgramSpec spec{.name = "full_grid_l1a", .kernels = {dm_kernel_spec}, .work_units = {main_wu}};
     Program program = experimental::MakeProgramFromSpec(*mesh_device, spec);
 
-    // Per-node distinct signature via the per-node RTA table.
+    // Give each node its own value through its per-node runtime args.
     experimental::ProgramRunArgs params;
     experimental::ProgramRunArgs::KernelRunArgs kra{.kernel = DM_KERNEL};
     for (uint32_t y = 0; y < grid.y; ++y) {
@@ -240,9 +238,9 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, FullGridDmL1Write_L1a) {
     EXPECT_EQ(fail, 0u);
 }
 
-// L1c (STEP 3): full-grid COMPUTE smoke. Fan the known-good risc_math compute kernel to all 32
-// nodes; every node must produce the same fixed 16-value output vector. Exercises the compute
-// datapath (UNPACK/MATH/PACK) on the whole grid.
+// Full-grid compute smoke test. Run the known-good risc_math compute kernel on all 32 nodes;
+// every node must produce the same fixed 16-value output. Exercises the compute pipeline
+// (unpack/math/pack) across the whole grid.
 TEST_F(QuasarMeshDeviceSingleCardFixture, FullGridCompute_L1c) {
     if (std::getenv("TT_METAL_SIMULATOR") == nullptr) {
         GTEST_SKIP() << "This test can only be run using a simulator.";
@@ -250,7 +248,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, FullGridCompute_L1c) {
     IDevice* dev = devices_[0]->get_devices()[0];
     auto mesh_device = devices_[0];
     const auto grid = mesh_device->compute_with_storage_grid_size();
-    // Skip (don't fail) on the smaller 1x3/2x3 CI configs; this test targets the 8x4 grid.
+    // Skip on the smaller 1x3/2x3 configs; this suite targets the 8x4 Quasar grid.
     if (grid.x != 8u || grid.y != 4u) {
         GTEST_SKIP() << "full-grid test targets the 8x4 Quasar sim config (got " << grid.x << "x" << grid.y << ")";
     }
@@ -259,11 +257,9 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, FullGridCompute_L1c) {
         HalProgrammableCoreType::TENSIX, HalL1MemAddrType::DEFAULT_UNRESERVED);
     const std::vector<uint32_t> expected = {4, 6, 5, 9, 8, 10, 9, 13, 12, 14, 13, 17, 16, 18, 17, 21};
 
-    // Seed every node's 16-word output slot with a sentinel that never appears in `expected`, so a
-    // node whose compute never ran (or whose output was misrouted to a different node) reads back
-    // the sentinel and FAILS rather than silently passing. Note: risc_math's output is node-
-    // independent, so this test cannot by itself distinguish WHICH node produced a value; per-node
-    // output identity is covered separately by FullGridDmL1Write_L1a's coord-unique signatures.
+    // Pre-fill every node's 16-word output slot with a sentinel that never appears in `expected`,
+    // so a node whose compute never ran (or whose output landed on the wrong node) reads back the
+    // sentinel and fails instead of silently passing.
     for (uint32_t y = 0; y < grid.y; ++y) {
         for (uint32_t x = 0; x < grid.x; ++x) {
             std::vector<uint32_t> z(16, 0xC0FFEEu);
@@ -330,11 +326,10 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, FullGridCompute_L1c) {
     EXPECT_EQ(fail, 0u);
 }
 
-// Grid NoC multicast fan-out: one source node (logical {0,0}) multicasts a value to the same L1
-// address on every node in the full-grid rectangle, driving the actual NoC multicast path
-// (get_noc_multicast_addr -> for_each_multicast_coordinate). Host pre-seeds a sentinel on every
-// node and reads all 32 back, printing a PASS/FAIL grid map — a dropped row/column shows up as an
-// un-updated node (guards the historical multicast column-drop bug). Non-DFB.
+// Grid NoC multicast fan-out. One source node (logical {0,0}) multicasts a value to the same L1
+// address on every node in the full-grid rectangle, exercising the NoC multicast path. Host
+// pre-seeds a sentinel on every node and reads all 32 back, printing a PASS/FAIL grid map: a
+// dropped row or column shows up as a node that never updated.
 TEST_F(QuasarMeshDeviceSingleCardFixture, GridMulticastFanOut) {
     if (std::getenv("TT_METAL_SIMULATOR") == nullptr) {
         GTEST_SKIP() << "This test can only be run using a simulator.";

--- a/tests/tt_metal/tt_metal/test_single_dm_l1_write.cpp
+++ b/tests/tt_metal/tt_metal/test_single_dm_l1_write.cpp
@@ -9,7 +9,9 @@
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
+#include <tt-metalium/mesh_buffer.hpp>
 #include <tt-metalium/tt_metal.hpp>
+#include <numeric>
 
 #ifndef OVERRIDE_KERNEL_PREFIX
 #define OVERRIDE_KERNEL_PREFIX ""
@@ -26,14 +28,26 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, SingleDmL1Write) {
         GTEST_SKIP() << "This test can only be run using a simulator. Set TT_METAL_SIMULATOR environment variable.";
     }
 
-    IDevice* dev = devices_[0]->get_devices()[0];
     auto mesh_device = devices_[0];
 
-    const uint32_t address = MetalContext::instance().hal().get_dev_addr(
-        HalProgrammableCoreType::TENSIX, HalL1MemAddrType::DEFAULT_UNRESERVED);
+    // Single-core L1 MeshBuffer on node {0,0}: the kernel writes `value` to buf->address() and we
+    // read it back through the mesh command queue.
+    const CoreRangeSet shard_grid(CoreRange({0, 0}, {0, 0}));
+    const ShardSpecBuffer shard_spec(
+        shard_grid,
+        /*shard_shape=*/{1, 1},
+        ShardOrientation::ROW_MAJOR,
+        /*page_shape=*/{1, 1},
+        /*tensor2d_shape_in_pages=*/{1, 1});
+    distributed::DeviceLocalBufferConfig local_cfg{
+        .page_size = sizeof(uint32_t),
+        .buffer_type = BufferType::L1,
+        .sharding_args = BufferShardingArgs(shard_spec, TensorMemoryLayout::HEIGHT_SHARDED),
+    };
+    distributed::ReplicatedBufferConfig global_cfg{.size = sizeof(uint32_t)};
+    auto buf = distributed::MeshBuffer::create(global_cfg, local_cfg, mesh_device.get());
+    const uint32_t address = buf->address();
     const uint32_t value = 0x12345678;
-    std::vector<uint32_t> outputs(1);
-    outputs[0] = 0;
     env_var = std::getenv("TT_METAL_DPRINT_CORES");
     if (env_var == nullptr) {
         std::cerr << "WARNING: Please set the environment variable TT_METAL_DPRINT_CORES to 0,0 to see the output of "
@@ -44,7 +58,6 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, SingleDmL1Write) {
 
     // We are going to use the first device (0) and the first core (0, 0) on the device.
     const experimental::NodeCoord node{0, 0};
-    tt_metal::detail::WriteToDeviceL1(dev, node, address, outputs);
     // Command queue lets us submit work (execute programs and read/write buffers) to the device.
     distributed::MeshCommandQueue& cq = mesh_device->mesh_command_queue();
     // Prepare a workload and a device coordinate range that spans the mesh.
@@ -91,7 +104,8 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, SingleDmL1Write) {
 
     workload.add_program(device_range, std::move(program));
     distributed::EnqueueMeshWorkload(cq, workload, true);
-    tt_metal::detail::ReadFromDeviceL1(dev, node, address, 4, outputs);
+    std::vector<uint32_t> outputs;
+    distributed::EnqueueReadMeshBuffer(cq, outputs, buf, /*blocking=*/true);
 
     ASSERT_EQ(outputs[0], value) << "Got the value " << std::hex << outputs[0] << " instead of " << value;
 }
@@ -103,7 +117,6 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, GridProbeStep0) {
     if (std::getenv("TT_METAL_SIMULATOR") == nullptr) {
         GTEST_SKIP() << "This test can only be run using a simulator.";
     }
-    IDevice* dev = devices_[0]->get_devices()[0];
     auto mesh_device = devices_[0];
 
     const auto grid = mesh_device->compute_with_storage_grid_size();
@@ -115,33 +128,40 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, GridProbeStep0) {
         GTEST_SKIP() << "grid-test suite targets the 8x4 Quasar sim config (got " << grid.x << "x" << grid.y << ")";
     }
 
-    const uint32_t address = MetalContext::instance().hal().get_dev_addr(
-        HalProgrammableCoreType::TENSIX, HalL1MemAddrType::DEFAULT_UNRESERVED);
+    const uint32_t num_nodes = grid.x * grid.y;
+    const CoreRangeSet shard_grid(CoreRange({0, 0}, {grid.x - 1, grid.y - 1}));
+    const ShardSpecBuffer shard_spec(
+        shard_grid,
+        /*shard_shape=*/{1, 1},
+        ShardOrientation::ROW_MAJOR,
+        /*page_shape=*/{1, 1},
+        /*tensor2d_shape_in_pages=*/{num_nodes, 1});
+    distributed::DeviceLocalBufferConfig local_cfg{
+        .page_size = sizeof(uint32_t),
+        .buffer_type = BufferType::L1,
+        .sharding_args = BufferShardingArgs(shard_spec, TensorMemoryLayout::HEIGHT_SHARDED),
+    };
+    distributed::ReplicatedBufferConfig global_cfg{.size = num_nodes * sizeof(uint32_t)};
+    auto buf = distributed::MeshBuffer::create(global_cfg, local_cfg, mesh_device.get());
+
+    std::vector<uint32_t> src(num_nodes);
+    std::iota(src.begin(), src.end(), 0u);
+    distributed::MeshCommandQueue& cq = mesh_device->mesh_command_queue();
+    distributed::EnqueueWriteMeshBuffer(cq, buf, src);
+    std::vector<uint32_t> dst;
+    distributed::EnqueueReadMeshBuffer(cq, dst, buf, /*blocking=*/true);
 
     uint32_t ok = 0, fail = 0;
-    for (uint32_t y = 0; y < grid.y; ++y) {
-        for (uint32_t x = 0; x < grid.x; ++x) {
-            const experimental::NodeCoord node{x, y};
-            const uint32_t sig = x + y * grid.x;  // value unique to each node
-            std::vector<uint32_t> w{sig};
-            std::vector<uint32_t> r(1, 0xdeadbeefu);
-            try {
-                tt_metal::detail::WriteToDeviceL1(dev, node, address, w);
-                tt_metal::detail::ReadFromDeviceL1(dev, node, address, sizeof(uint32_t), r);
-                if (r[0] == sig) {
-                    ++ok;
-                } else {
-                    ++fail;
-                    std::cout << "[STEP0] MISMATCH node(" << x << "," << y << ") got 0x" << std::hex << r[0]
-                              << " expected 0x" << sig << std::dec << std::endl;
-                }
-            } catch (const std::exception& e) {
-                ++fail;
-                std::cout << "[STEP0] EXCEPTION node(" << x << "," << y << "): " << e.what() << std::endl;
-            }
+    for (uint32_t i = 0; i < num_nodes; ++i) {
+        if (i < dst.size() && dst[i] == src[i]) {
+            ++ok;
+        } else {
+            ++fail;
+            std::cout << "[STEP0] MISMATCH node index " << i << " got " << (i < dst.size() ? dst[i] : 0u)
+                      << " expected " << src[i] << std::endl;
         }
     }
-    std::cout << "[STEP0] per-node host L1 write/read: ok=" << ok << " fail=" << fail << " total=" << (grid.x * grid.y)
+    std::cout << "[STEP0] per-node L1 MeshBuffer write/read: ok=" << ok << " fail=" << fail << " total=" << num_nodes
               << std::endl;
     EXPECT_EQ(fail, 0u);
     EXPECT_EQ(grid.x, 8u) << "expected 8-wide grid";


### PR DESCRIPTION
### PR Category
Test Only

### Summary
Adds an integration-test suite that exercises all 32 Tensix worker nodes of the Quasar 8×4 craq-sim grid. Covers per-node fan-out (host/kernel L1 writes, compute), cross-node semaphore snake/ring/corner chains, per-row and per-column chains, DRAM fan-out/fan-in, an all-to-one semaphore barrier, and a NoC multicast broadcast. All tests use only semaphore + DRAM-staging + DM/compute + NoC-multicast paths. 

### Notes for reviewers
- 15 tests, all passing on craq-sim

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ymoussa/quasar-grid-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ymoussa/quasar-grid-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ymoussa/quasar-grid-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ymoussa/quasar-grid-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ymoussa/quasar-grid-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ymoussa/quasar-grid-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ymoussa/quasar-grid-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ymoussa/quasar-grid-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ymoussa/quasar-grid-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ymoussa/quasar-grid-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ymoussa/quasar-grid-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ymoussa/quasar-grid-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ymoussa/quasar-grid-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ymoussa/quasar-grid-tests)