### PR TITLE
[Feature] #47500: Traceable chunked prefill — trace layer + on-device MoE padding config

### DIFF
--- a/models/demos/common/prefill/adapter.py
+++ b/models/demos/common/prefill/adapter.py
@@ -72,6 +72,12 @@ class PrefillRunParams:
     # Explicit semantic cache format selected by model/module configuration. Scaled FP8 is a packed
     # mixed-format row, so it must not be represented or inferred as a bare tensor dtype.
     sparse_kv_cache_format: Optional[object] = None
+    # Capture the per-chunk forward as a (segmented) ttnn trace and replay it every chunk, instead of
+    # re-dispatching op-by-op. Requires the mesh opened with a trace_region_size > 0. See prefill_runner.
+    use_trace: bool = False
+    # MoE shared-expert ∥ dispatch overlap (default on). Off => single-segment trace (no per-chunk
+    # sub-device swaps), faster replay at the cost of the overlap. See TtPrefillRuntimeConfig.
+    overlap_shared_expert_with_dispatch: bool = True
 
     @property
     def sp_factor(self) -> int:

--- a/models/demos/common/prefill/runners/prefill_runner.py
+++ b/models/demos/common/prefill/runners/prefill_runner.py
@@ -182,6 +182,11 @@ SYNC_PER_CHUNK = os.environ.get("PREFILL_SYNC_PER_CHUNK", "0") == "1"
 # semaphores to L1_SMALL so they don't pin the main-L1 floor and clash with the next layer's MLA static
 # CBs, which needs the mesh opened with an L1_SMALL region. The adapter owns both knobs.
 _L1_SMALL_SIZE = ADAPTER.l1_small_size
+# Capture each rank's per-chunk forward as a (segmented) ttnn trace and replay it every chunk instead of
+# re-dispatching op-by-op. Needs the mesh opened with a trace region; the segmented capture (sub-device
+# swaps + per-layer acks) is handled by SubDeviceTraceController inside the runtime.
+USE_TRACE = os.environ.get("PREFILL_USE_TRACE", "0") == "1"
+_TRACE_REGION_SIZE = int(os.environ.get("PREFILL_TRACE_REGION_SIZE", 256 * 1024 * 1024)) if USE_TRACE else 0
 
 os.environ.setdefault("PREFILL_TTNN_CACHE", ADAPTER.ttnn_cache_default)
 
@@ -461,10 +466,14 @@ def _d2d_recv(inbound) -> tuple:
     return act, meta
 
 
-def _d2d_send(outbound, activation: ttnn.Tensor, rank: int, meta: dict) -> None:
+def _d2d_send(outbound, activation: ttnn.Tensor, rank: int, meta: dict, *, deallocate: bool = True) -> None:
     """Push this rank's output hidden state + metadata to the downstream rank's receiver, then free it.
     The model already emits the activation in the sender backing's spec, and outbound_socket_service_sync
-    TT_FATALs on any spec mismatch, so no host-side relayout is needed."""
+    TT_FATALs on any spec mismatch, so no host-side relayout is needed.
+
+    deallocate=False when the activation is the traced path's persistent _trace_output buffer: the socket
+    sync copies it into the sender backing on the CQ (before the next replay, which reuses the same buffer,
+    is enqueued), so it must NOT be freed — the next chunk's replay writes into it in place."""
     t0 = time.perf_counter()
     backing = outbound.get_backing_tensor()
     import torch
@@ -483,7 +492,8 @@ def _d2d_send(outbound, activation: ttnn.Tensor, rank: int, meta: dict) -> None:
         ),
     )
     ttnn.experimental.deepseek_prefill.outbound_socket_service_sync(outbound, activation, metadata=md_tensor)
-    ttnn.deallocate(activation)
+    if deallocate:
+        ttnn.deallocate(activation)
     logger.info(
         f"[pp rank {rank}] SEND-d2d [{meta['actual_start']},{meta['actual_end']}) "
         f"[xfer] push={(time.perf_counter() - t0) * 1000.0:.2f}ms"
@@ -554,7 +564,9 @@ def _compute_and_send(runtime, kv_caches, rank: int, c: int, inp, meta: dict, d2
         ttnn.synchronize_device(runtime.mesh_device)
         logger.info(f"[pp rank {rank}] CHUNK_COMPUTE c={c} compute_ms={(time.time() - t_start) * 1000.0:.3f}")
     if not runtime.config.is_last_rank:
-        _d2d_send(d2d_out, out, rank, meta)  # push + free; the grant below forwards it over fabric
+        # Traced: `out` is the runtime's persistent _trace_output (the next replay overwrites it in place),
+        # so the send copies it into the socket backing but must not free it. Eager: `out` is fresh — free it.
+        _d2d_send(d2d_out, out, rank, meta, deallocate=not runtime.config.use_trace)  # grant below ships it
     if d2d_out is not None:
         d2d_out.release_fabric_links()
     return t_start
@@ -567,9 +579,10 @@ def _drain_and_log_e2e(runtime, rank: int, d2d_out, first_compute_start, n_done:
     if d2d_out is not None:
         d2d_out.wait_for_fabric_links()
     ttnn.synchronize_device(runtime.mesh_device)
-    logger.info(
-        f"[pp rank {rank}] E2E_CLOCK first_compute_start={first_compute_start:.6f} last_compute_end={time.time():.6f}"
-    )
+    # first_compute_start is None if the loop exited before any chunk was computed (e.g. an immediate
+    # shutdown sentinel, or SIGINT during the initial socket wait) — guard the float format.
+    fcs = f"{first_compute_start:.6f}" if first_compute_start is not None else "n/a"
+    logger.info(f"[pp rank {rank}] E2E_CLOCK first_compute_start={fcs} last_compute_end={time.time():.6f}")
     logger.info(f"[pp rank {rank}] processed {n_done} chunks in {(time.perf_counter() - t0) * 1000.0:.2f} ms")
 
 
@@ -588,13 +601,17 @@ def run_request_loop(
     """Production serving loop — UNBOUNDED. rank 0 reads each chunk from the H2D socket (the external
     producer decides the count); downstream ranks read from D2D. Runs until the producer/scheduler
     closes the stream with the all -1 shutdown sentinel (each rank forwards it and exits gracefully) or,
-    as a hard fallback, until SIGTERM/SIGKILL. No fixed NUM_CHUNKS bound, no trace input, no PCC — see
-    run_standalone_loop for those.
+    as a hard fallback, until SIGTERM/SIGKILL. No fixed NUM_CHUNKS bound, no trace input — see
+    run_standalone_loop for the bounded/trace variant.
 
     Exception: in migration-validation mode (PREFILL_VALIDATE_MIGRATION=1) the scheduler driver never
     pushes the shutdown sentinel — it pushes PREFILL_STANDALONE_CHUNKED_NCHUNKS chunks, migrates, then
     writes the DONE sentinel for the runner to poll. So the loop exits after that many chunks and returns
-    to validate_after_prefill. Returns (chunks_per_slot, real_end_per_slot, total_chunks)."""
+    to validate_after_prefill. Returns (chunks_per_slot, real_end_per_slot, total_chunks).
+
+    PREFILL_REQUEST_LOOP_PCC=1 (single-rank, bring-up only) PCC-checks the populated KV against the golden
+    trace once the stream closes — the production analogue of standalone's per-rank KV check, driven by the
+    real H2D producer path (and, under use_trace, the replayed forward + post-compile LayerAck)."""
     cfg = runtime.config
     if cfg.is_first_rank and h2d_service is None:
         raise ValueError("request mode requires the H2D service on the first rank for input")
@@ -621,6 +638,7 @@ def run_request_loop(
         if os.environ.get("PREFILL_VALIDATE_MIGRATION", "0") == "1"
         else 0
     )
+    slot_id = 0  # last chunk's slot — the PREFILL_REQUEST_LOOP_PCC check below reads the slice this rank populated
     while not _shutdown:
         if n_selftest and c >= n_selftest:
             break
@@ -638,6 +656,7 @@ def run_request_loop(
                 _forward_shutdown(d2d_out, rank, hidden_size)
             break
         slot = meta["slot_id"]
+        slot_id = slot  # for the PREFILL_REQUEST_LOOP_PCC check after the loop
         chunks_per_slot[slot] = chunks_per_slot.get(slot, 0) + 1
         real_end_per_slot[slot] = max(real_end_per_slot.get(slot, 0), meta["actual_end"])
         t = _compute_and_send(runtime, kv_caches, rank, c, inp, meta, d2d_out)
@@ -668,6 +687,29 @@ def run_request_loop(
     if num_ranks > 1 and n_selftest:
         ttnn.distributed_context_barrier()
     _drain_and_log_e2e(runtime, rank, d2d_out, first, c, t0)
+
+    # MUST stay above the return: this block sat BELOW it and was silently dead, so
+    # PREFILL_REQUEST_LOOP_PCC=1 ran no check at all and reported nothing — a green run that had
+    # verified nothing. Runs after _drain_and_log_e2e so the chunk's KV writes are flushed first.
+    if os.environ.get("PREFILL_REQUEST_LOOP_PCC", "0") == "1" and c > 0:
+        # Bring-up validation of the production path (golden-trace input): the same optional runtime hook
+        # standalone uses. n_chunks = the count the producer actually pushed. Single-rank only (a pipeline
+        # rank owns a layer slice; kv_cache_pcc_check offsets by first_layer_idx, but multi-rank KV PCC is
+        # driven via the standalone loop).
+        pcc_check = getattr(runtime, "kv_cache_pcc_check", None)
+        if pcc_check is None:
+            raise RuntimeError(
+                f"PREFILL_REQUEST_LOOP_PCC=1 but {type(runtime).__name__} implements no kv_cache_pcc_check "
+                "(optional bring-up hook; see ADDING_A_PREFILL_MODEL.md §2)."
+            )
+        pcc_check(
+            kv_caches,
+            slot_id=slot_id,
+            n_chunks=c,
+            trace_dir=os.environ.get("PREFILL_TRACE_DIR", ADAPTER.prefill_trace_default),
+            first_layer_idx=cfg.first_layer_idx,
+        )
+
     return chunks_per_slot, real_end_per_slot, c
 
 
@@ -758,6 +800,7 @@ def _print_config() -> None:
         ("PREFILL_NUM_LAYERS", str(NUM_LAYERS)),
         ("PREFILL_PP_LAYER_COUNTS", os.environ.get("PREFILL_PP_LAYER_COUNTS", "<even split>")),
         ("PREFILL_KV_ONLY_LAST_LAYER", str(KV_ONLY_LAST_LAYER)),
+        ("PREFILL_USE_TRACE", f"{USE_TRACE} (trace_region={_TRACE_REGION_SIZE >> 20} MB)"),
         ("PREFILL_CHUNK_SIZE", str(CHUNK_SIZE)),
         ("PREFILL_STANDALONE_NCHUNKS", str(NUM_CHUNKS)),
         ("PREFILL_MAX_SEQ_LEN", str(MAX_SEQ_LEN)),
@@ -778,6 +821,7 @@ def _print_config() -> None:
         ),
         ("PREFILL_ENABLE_MIGRATION", os.environ.get("PREFILL_ENABLE_MIGRATION", "0")),
         ("PREFILL_MOCK_MIGRATION", os.environ.get("PREFILL_MOCK_MIGRATION", "0")),
+        ("PREFILL_REQUEST_LOOP_PCC", os.environ.get("PREFILL_REQUEST_LOOP_PCC", "0")),
         (
             "PREFILL_MIGRATION_TABLE_PATH",
             os.environ.get("PREFILL_MIGRATION_TABLE_PATH", "/tmp/prefill_kv_chunk_table.pb"),
@@ -815,7 +859,9 @@ def main() -> None:
         f"chunk_size={CHUNK_SIZE} max_seq_len={MAX_SEQ_LEN} num_users={NUM_USERS}"
     )
 
-    mesh_device = open_mesh_device(GLOBAL_MESH_SHAPE, MODEL_CFG, l1_small_size=_L1_SMALL_SIZE)
+    mesh_device = open_mesh_device(
+        GLOBAL_MESH_SHAPE, MODEL_CFG, l1_small_size=_L1_SMALL_SIZE, trace_region_size=_TRACE_REGION_SIZE
+    )
 
     hf_config = ADAPTER.load_hf_config()
     hf_config.max_seq_len = MAX_SEQ_LEN
@@ -838,6 +884,8 @@ def main() -> None:
         kv_only_last_layer=is_last_rank and KV_ONLY_LAST_LAYER,
         weight_cache_path=ADAPTER.weight_cache_path(GLOBAL_MESH_SHAPE),
         sparse_kv_cache_format=ADAPTER.default_sparse_kv_cache_format,
+        use_trace=USE_TRACE,
+        overlap_shared_expert_with_dispatch=os.environ.get("PREFILL_OVERLAP_SHARED_EXPERT", "1") == "1",
     )
 
     runtime = ADAPTER.build_runtime(mesh_device=mesh_device, hf_config=hf_config, params=params)
@@ -853,6 +901,14 @@ def main() -> None:
         _serve_standalone(runtime, kv_caches, mesh_device, hf_config, rank, num_ranks, is_first_rank)
     else:
         _serve_request(runtime, kv_caches, mesh_device, hf_config, rank, num_ranks, is_first_rank)
+
+    # Release captured traces + the sub-device managers that own them BEFORE closing the mesh: the
+    # trace buffers live inside the MoE-overlap SubDeviceManagers, so closing with both registered
+    # frees them in the wrong order and segfaults in BankManager::deallocate_buffer (see
+    # TtPrefillRuntime.release_trace). Optional hook — models without it are unaffected.
+    _release_trace = getattr(runtime, "release_trace", None)
+    if _release_trace is not None:
+        _release_trace()
 
     ttnn.set_fabric_config(ttnn.FabricConfig.DISABLED)
     ttnn.close_mesh_device(mesh_device)
@@ -880,6 +936,12 @@ def _serve_standalone(
         # rank 0 enters its produce loop first, fills the socket, and stalls ~6s waiting for the
         # downstream ranks to enter their consume loops — moving that skew out of the timed chunk loop.
         ttnn.distributed_context_barrier()
+
+    # Capture the trace (use_trace) HERE — after D2D endpoints are built (their receiver-socket L1 must be
+    # allocated before the trace records, or it corrupts replay on the last rank) and before the chunk loop,
+    # so the one-time capture stays out of the timed loop.
+    if getattr(runtime, "capture_trace", None) and runtime.config.use_trace:
+        runtime.capture_trace(kv_caches)
 
     logger.info(f"[pp rank {rank}] setup complete, entering standalone loop")
     run_standalone_loop(runtime, kv_caches, rank, num_ranks, d2d_in=d2d_in, d2d_out=d2d_out)
@@ -980,6 +1042,11 @@ def _serve_request(runtime, kv_caches, mesh_device, hf_config, rank: int, num_ra
     # table publish it depends on, so you don't also have to set PREFILL_ENABLE_MIGRATION. The latter
     # still works on its own for production publish-without-selftest.
     _selftest = os.environ.get("PREFILL_MIGRATION_SELFTEST", "0") == "1"
+    # Mock integration: publish the KV chunk table + device map for an external reader
+    # (prefill_producer.py's PREFILL_PRODUCER_CHECK_PCC) with NO migration worker. It must open this
+    # block ON ITS OWN — gating it behind _migration_enabled made it unreachable, since
+    # PREFILL_ENABLE_MIGRATION additionally drives the publish-and-block-on-WORKER_READY path below.
+    _mock_migration = os.environ.get("PREFILL_MOCK_MIGRATION", "0") == "1"
     _migration_enabled = os.environ.get("PREFILL_ENABLE_MIGRATION", "0") == "1" or _selftest
     _interleaved = os.environ.get("PREFILL_MIGRATION_INTERLEAVED", "0") == "1"
 
@@ -994,6 +1061,25 @@ def _serve_request(runtime, kv_caches, mesh_device, hf_config, rank: int, num_ra
             f"pipeline mode (num_ranks={num_ranks}): both consume {ack_shm_name}, so each sees only part "
             "of the ack stream (the completion check can still report PASS while interleaved migration "
             "silently drops its tail chunks). Set exactly one."
+        )
+
+    # Mock integration (prefill_producer.py's PREFILL_PRODUCER_CHECK_PCC): publish the KV chunk table +
+    # device map for an external device-less reader, with NO migration worker. Deliberately OUTSIDE the
+    # _migration_enabled block below: that block's first step is
+    # deliver_device_map_and_gather_stage_layout(), which imports the _migration_client .so and joins a
+    # cross-rank all-gather. Mock has neither a client nor peers, so routing it through there raises
+    # ImportError(_migration_client) — which is exactly what happens if you only make the old in-block
+    # `elif PREFILL_MOCK_MIGRATION` reachable. Both writes here are local (build table + serialize map).
+    if _mock_migration and not _migration_enabled:
+        _mock_table_path = os.environ.get("PREFILL_MIGRATION_TABLE_PATH", "/tmp/prefill_kv_chunk_table.pb")
+        _mock_map_path = os.environ.get("PREFILL_MIGRATION_DEVICE_MAP_PATH", "/tmp/prefill_kv_device_map.json")
+        runtime.build_kv_chunk_table(kv_caches, path=_mock_table_path)
+        # fabric_node -> ASIC unique_id, so the producer can resolve chips for read_dram_umd without
+        # touching the ControlPlane.
+        serialize_device_map(mesh_device, _mock_map_path)
+        logger.info(
+            f"[mock-migration] KV chunk table -> {_mock_table_path}, device map -> {_mock_map_path} "
+            f"(no migration worker); prefill_producer can import them"
         )
 
     if _migration_enabled:
@@ -1179,6 +1265,14 @@ def _serve_request(runtime, kv_caches, mesh_device, hf_config, rank: int, num_ra
             "[interleave] migration mode = BULK (single post-loop migrate); set PREFILL_MIGRATION_INTERLEAVED=1 "
             "to interleave migrates with prefill"
         )
+
+    # Capture the trace (use_trace) after the D2D endpoints AND the per-layer completion wiring
+    # (LayerAck channel / layer-completion sink) are set up, but before the request loop: the capture
+    # must split at each completion point, and doing it here keeps the one-time cost out of the loop.
+    # No-op if already captured. See _serve_standalone / TtPrefillRuntime.capture_trace().
+    if getattr(runtime, "capture_trace", None) and runtime.config.use_trace:
+        runtime.capture_trace(kv_caches)
+
     logger.info(f"[pp rank {rank}] setup complete, entering request loop")
 
     try:

--- a/models/demos/common/prefill/runners/runner_utils.py
+++ b/models/demos/common/prefill/runners/runner_utils.py
@@ -33,7 +33,9 @@ def _create_fabric_router_config(max_payload_size):
 # ---------------------------------------------------------------------------
 # Device / H2D-service setup
 # ---------------------------------------------------------------------------
-def open_mesh_device(mesh_shape: tuple, model_cfg: type, l1_small_size: int = 0) -> ttnn.MeshDevice:
+def open_mesh_device(
+    mesh_shape: tuple, model_cfg: type, l1_small_size: int = 0, trace_region_size: int = 0
+) -> ttnn.MeshDevice:
     """Configure fabric and open the mesh device.
 
     Default fabric is 1D for sp<=8, else 2D. PREFILL_FABRIC_MODE overrides this: the D2D-socket
@@ -45,7 +47,10 @@ def open_mesh_device(mesh_shape: tuple, model_cfg: type, l1_small_size: int = 0)
     the opened fabric via tt_ccl.per_axis_topology().
 
     `l1_small_size` > 0 carves an L1_SMALL region (needed when an op routes its
-    semaphores there, e.g. the Kimi MoE routing all-gather with use_l1_small_for_semaphores)."""
+    semaphores there, e.g. the Kimi MoE routing all-gather with use_l1_small_for_semaphores).
+
+    `trace_region_size` > 0 reserves device DRAM for ttnn trace capture — needed when the runtime
+    replays a captured forward (TtPrefillRuntime use_trace). 0 = no trace region (default)."""
     sp = mesh_shape[0]
     fabric_mode = os.environ.get("PREFILL_FABRIC_MODE", "").strip().lower()
     fabric_mode_map = {
@@ -77,7 +82,9 @@ def open_mesh_device(mesh_shape: tuple, model_cfg: type, l1_small_size: int = 0)
         ttnn.FabricManagerMode.DEFAULT,
         fabric_router_config,
     )
-    return ttnn.open_mesh_device(mesh_shape=ttnn.MeshShape(*mesh_shape), l1_small_size=l1_small_size)
+    return ttnn.open_mesh_device(
+        mesh_shape=ttnn.MeshShape(*mesh_shape), l1_small_size=l1_small_size, trace_region_size=trace_region_size
+    )
 
 
 def make_global_spec(mesh_shape: tuple, chunk_size: int) -> ttnn.TensorSpec:

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_moe_padding_config.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_moe_padding_config.py
@@ -1,0 +1,199 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""On-device validation for the moe_padding_config experimental op.
+
+The op is the trace-safe producer of the MoE padding config: it derives each chip's
+``[local_real_tokens, pad_side]`` row on-device from two 1-element uint32 tensors (this chunk's
+``actual_start`` / ``actual_end``), replacing the host builder's ``ttnn.from_torch`` — which cannot
+run inside a trace capture.
+
+The host builder (``TtMoEGatePrefill.build_padding_config``, via ``rotated_chip_real_token_counts``)
+is the reference: these tests assert the device op reproduces it EXACTLY (integer counts, so exact
+equality, not PCC) across the rotated and sequential layouts.
+
+Also covers the two properties the trace path depends on:
+  * one cached program serves every chunk (the per-chunk values are read on-device, so they must not
+    enter the program hash) — otherwise a capture could not replay across chunks;
+  * refreshing the metadata tensors in place and re-running yields the new chunk's config.
+"""
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+from models.demos.deepseek_v3_d_p.tt.mla.utils import rotated_chip_real_token_counts
+
+# Galaxy-shaped SP=8 config (chunk_size_global 5120 -> tokens_per_chip 640) plus a small 2x4 case so
+# the op is exercised on boxes that cannot host 32 chips.
+_MESHES = [
+    pytest.param((8, 4), marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4")),
+    pytest.param((2, 4), marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="mesh-2x4")),
+]
+_MESH_IDS = ["8x4", "2x4"]
+
+# (actual_start, actual_isl) pairs. Chosen to cover every branch of the rotation:
+#   * start == 0                -> sequential layout (the degenerate case)
+#   * start slab-aligned        -> rotation is the identity
+#   * start mid-slab            -> boundary chip splits across two slabs (the 2-segment case)
+#   * isl == full chunk         -> no padding at all (every chip full)
+#   * isl == 0                  -> everything is pad (every chip zero)
+# The 15k-style starts (2592, 4160, 9280, 10080, 13440) are the ones the rotated-padded CI test uses.
+_CASES = [
+    (0, 0),
+    (0, 640),
+    (0, 2592),
+    (0, 5120),
+    (2592, 1568),
+    (2592, 5120),
+    (4160, 5120),
+    (4160, 800),
+    (5120, 3360),
+    (9280, 800),
+    (10080, 3360),
+    (13440, 1920),
+]
+_IDS = [f"start{s}_isl{i}" for (s, i) in _CASES]
+
+
+def _meta1(mesh_device, val: int) -> ttnn.Tensor:
+    """1-element uint32 DRAM tensor ([1,1,1,1], ROW_MAJOR, replicated) — the metadata form the op reads."""
+    return ttnn.from_torch(
+        torch.tensor([val], dtype=torch.int64).reshape(1, 1, 1, 1),
+        device=mesh_device,
+        dtype=ttnn.uint32,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+    )
+
+
+def _alloc_config(mesh_device, sp_factor: int) -> ttnn.Tensor:
+    """Persistent [sp_factor, 2] uint32 config row, sharded along the SP axis (one row per chip)."""
+    return ttnn.from_torch(
+        torch.zeros((sp_factor, 2), dtype=torch.int32),
+        device=mesh_device,
+        dtype=ttnn.uint32,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=(0, None), mesh_shape=mesh_device.shape),
+    )
+
+
+def _read_counts(config: ttnn.Tensor, mesh_device, sp_factor: int) -> tuple[list[int], list[int]]:
+    """Gather the per-chip rows back to host -> (local_real_tokens per chip, pad_side per chip)."""
+    host = ttnn.to_torch(
+        config,
+        mesh_composer=ttnn.ConcatMesh2dToTensor(mesh_device, dims=(0, 1), mesh_shape=mesh_device.shape),
+    )
+    # dim 1 replicates across the TP axis; take one replica. Rows are SP-major.
+    rows = host[:sp_factor, :2].to(torch.int64)
+    return rows[:, 0].tolist(), rows[:, 1].tolist()
+
+
+def _run_case(mesh_device, actual_start: int, actual_isl: int, padding_side: str = "right"):
+    sp_factor = int(mesh_device.shape[0])
+    tokens_per_chip = 640
+    chunk_global = sp_factor * tokens_per_chip
+
+    config = _alloc_config(mesh_device, sp_factor)
+    start_t = _meta1(mesh_device, actual_start)
+    end_t = _meta1(mesh_device, actual_start + actual_isl)
+
+    ttnn.experimental.deepseek_prefill.moe_padding_config(
+        config,
+        start_t,
+        end_t,
+        tokens_per_chip=tokens_per_chip,
+        pad_side=0 if padding_side == "right" else 1,
+        cluster_axis=0,
+    )
+    ttnn.synchronize_device(mesh_device)
+
+    got_counts, got_sides = _read_counts(config, mesh_device, sp_factor)
+    expected = rotated_chip_real_token_counts(actual_start, actual_isl, sp_factor, tokens_per_chip)
+
+    logger.info(
+        f"start={actual_start} isl={actual_isl} sp={sp_factor} chunk_global={chunk_global}\n"
+        f"  expected={expected}\n  device  ={got_counts}"
+    )
+    assert got_counts == expected, f"per-chip real-token counts differ: device={got_counts} host={expected}"
+    assert got_sides == [0 if padding_side == "right" else 1] * sp_factor, f"pad_side mismatch: {got_sides}"
+    return config, start_t, end_t
+
+
+@pytest.mark.parametrize("mesh_device", _MESHES, ids=_MESH_IDS, indirect=True)
+@pytest.mark.parametrize("actual_start,actual_isl", _CASES, ids=_IDS)
+def test_moe_padding_config_matches_host(mesh_device, actual_start, actual_isl):
+    """The device op reproduces the host builder's per-chip counts exactly."""
+    sp_factor = int(mesh_device.shape[0])
+    if actual_start + actual_isl > sp_factor * 640 * 8:
+        pytest.skip("case exceeds this mesh's addressable range")
+    _run_case(mesh_device, actual_start, actual_isl)
+
+
+@pytest.mark.parametrize("mesh_device", _MESHES, ids=_MESH_IDS, indirect=True)
+def test_moe_padding_config_left_padding(mesh_device):
+    """pad_side is written through for left padding (start 0 only: rotation implies right padding)."""
+    _run_case(mesh_device, 0, 2592, padding_side="left")
+
+
+@pytest.mark.parametrize("mesh_device", [(2, 4)], ids=["2x4"], indirect=True)
+def test_moe_padding_config_one_program_across_chunks(mesh_device):
+    """The per-chunk values must stay OUT of the program hash, and refreshing the metadata tensors in
+    place must change the result — together these are exactly what lets one capture replay across
+    chunks. Asserts a single cached program serves a sequence of different chunks, each still correct."""
+    sp_factor = int(mesh_device.shape[0])
+    tokens_per_chip = 640
+
+    config = _alloc_config(mesh_device, sp_factor)
+    start_t = _meta1(mesh_device, 0)
+    end_t = _meta1(mesh_device, 0)
+
+    mesh_device.enable_program_cache()
+    entries_before = mesh_device.num_program_cache_entries()
+
+    chunks = [(0, 640), (640, 1280), (1280, 300), (2592, 1568)]
+    for actual_start, actual_isl in chunks:
+        # Refresh the SAME metadata buffers in place — the trace path's mechanism.
+        ttnn.copy_host_to_device_tensor(
+            ttnn.from_torch(
+                torch.tensor([actual_start], dtype=torch.int64).reshape(1, 1, 1, 1),
+                dtype=ttnn.uint32,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+                mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+            ),
+            start_t,
+        )
+        ttnn.copy_host_to_device_tensor(
+            ttnn.from_torch(
+                torch.tensor([actual_start + actual_isl], dtype=torch.int64).reshape(1, 1, 1, 1),
+                dtype=ttnn.uint32,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+                mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+            ),
+            end_t,
+        )
+        ttnn.experimental.deepseek_prefill.moe_padding_config(
+            config,
+            start_t,
+            end_t,
+            tokens_per_chip=tokens_per_chip,
+            pad_side=0,
+            cluster_axis=0,
+        )
+        ttnn.synchronize_device(mesh_device)
+
+        got_counts, _ = _read_counts(config, mesh_device, sp_factor)
+        expected = rotated_chip_real_token_counts(actual_start, actual_isl, sp_factor, tokens_per_chip)
+        assert got_counts == expected, (
+            f"chunk (start={actual_start}, isl={actual_isl}): device={got_counts} host={expected} "
+            "-- the op read stale metadata (missing L1-cache invalidate?) or the config went unrefreshed"
+        )
+
+    # Exactly ONE program for all four chunks: the per-chunk values are read on-device, so they must
+    # not be hashed. More than one entry means a capture could not replay across chunks.
+    assert mesh_device.num_program_cache_entries() == entries_before + 1, (
+        f"expected 1 cached program for {len(chunks)} chunks, got "
+        f"{mesh_device.num_program_cache_entries() - entries_before}"
+    )

--- a/models/demos/deepseek_v3_d_p/tests/test_mla.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_mla.py
@@ -560,6 +560,7 @@ def _run_chunked_prefill(
     num_users=1,
     use_pretrained=False,
     topology=ttnn.Topology.Linear,
+    use_metadata_tensor=False,
 ):
     """Unified chunked-prefill scenario, decoupled from the reference.
 
@@ -761,13 +762,35 @@ def _run_chunked_prefill(
                     mesh_device, mesh_shape=tuple(mesh_device.shape), dims=hidden_shard_dims
                 ),
             )
+            # Trace-safe metadata variant: build the runner's canonical [slot_id, actual_start, actual_end]
+            # uint32 DRAM tensor here (the "outside") and hand it to forward verbatim -- ttMLA threads it
+            # to all chunked ops (update/rope/zero_pad/ring_mla), which read their per-chunk scalars
+            # on-device. slot_id = cache_user_id (layer_num=1, so it is also the flat cache slot).
+            kv_pad_metadata = None
+            if use_metadata_tensor:
+                meta_payload = torch.tensor([u, kv_actual, valid_end, 0], dtype=torch.int64).reshape(1, 1, 1, 4)
+                kv_pad_metadata = ttnn.from_torch(
+                    meta_payload,
+                    device=mesh_device,
+                    dtype=ttnn.uint32,
+                    layout=ttnn.ROW_MAJOR_LAYOUT,
+                    memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                    mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+                )
+            # Metadata path: pass ONLY the metadata tensor (the runner hands tt_metadata straight from
+            # inbound_socket_service_sync) -- actual_start/actual_end are read on-device, so leave them
+            # None to prove forward needs no host per-chunk scalars. cache_user_id is unused on this path
+            # (slot comes from metadata[0]).
             tt_out = mla_tt.forward(
                 hidden_states=tt_h,
                 rope_tensors=indexed_rope,
                 kvpe_cache=tt_kvpe_cache,
-                actual_start=kv_actual,
+                actual_start=None if use_metadata_tensor else kv_actual,
                 cache_user_id=u,
+                metadata=kv_pad_metadata,
             )
+            if kv_pad_metadata is not None:
+                ttnn.deallocate(kv_pad_metadata)
             out_flat = ttnn.to_torch(
                 tt_out,
                 mesh_composer=ttnn.ConcatMesh2dToTensor(
@@ -884,8 +907,9 @@ _CHUNKED_SCENARIOS = (
 @pytest.mark.parametrize("reference", ["cpu", "trace", None], ids=["cpu", "trace", "func"])
 @pytest.mark.parametrize("kwargs", [kw for _, kw in _CHUNKED_SCENARIOS], ids=[sid for sid, _ in _CHUNKED_SCENARIOS])
 @pytest.mark.parametrize("variant", ["deepseek_v3_d_p", "kimi_k2_6"], indirect=True, ids=["dsv3", "kimi"])
+@pytest.mark.parametrize("use_metadata_tensor", [False, True], ids=["scalar", "metadata"])
 @pytest.mark.timeout(0)
-def test_mla_chunked_prefill(request, mesh_device, kwargs, reference, device_params, variant):
+def test_mla_chunked_prefill(request, mesh_device, kwargs, reference, device_params, variant, use_metadata_tensor):
     """Unified chunked-prefill driver crossed with independent mesh and reference axes. Each
     functionality scenario (rotation edges, production depth, multi-user, deep prefix) runs on any mesh
     and is validated against the CPU torch reference ('cpu'), the GPU trace ('trace', skips without
@@ -912,4 +936,6 @@ def test_mla_chunked_prefill(request, mesh_device, kwargs, reference, device_par
         if device_params.get("fabric_config") == ttnn.FabricConfig.FABRIC_1D_RING
         else ttnn.Topology.Linear
     )
-    _run_chunked_prefill(request, mesh_device, reference=reference, topology=topology, **kwargs)
+    _run_chunked_prefill(
+        request, mesh_device, reference=reference, topology=topology, use_metadata_tensor=use_metadata_tensor, **kwargs
+    )

--- a/models/demos/deepseek_v3_d_p/tests/test_mla.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_mla.py
@@ -762,20 +762,23 @@ def _run_chunked_prefill(
                     mesh_device, mesh_shape=tuple(mesh_device.shape), dims=hidden_shard_dims
                 ),
             )
-            # Trace-safe metadata variant: build the runner's canonical [slot_id, actual_start, actual_end]
-            # uint32 DRAM tensor here (the "outside") and hand it to forward verbatim -- ttMLA threads it
-            # to all chunked ops (update/rope/zero_pad/ring_mla), which read their per-chunk scalars
-            # on-device. slot_id = cache_user_id (layer_num=1, so it is also the flat cache slot).
+            # Trace-safe metadata variant: build the runner's canonical metadata and hand it to forward
+            # verbatim -- ttMLA threads it to all chunked ops (update/rope/zero_pad/ring_mla), which read
+            # their per-chunk scalars on-device. The contract is a 3-tuple of separate 1-element uint32
+            # tensors indexed as metadata[0]=slot_id, [1]=actual_start, [2]=actual_end -- NOT one packed
+            # tensor. slot_id = cache_user_id (layer_num=1, so it is also the flat cache slot).
             kv_pad_metadata = None
             if use_metadata_tensor:
-                meta_payload = torch.tensor([u, kv_actual, valid_end, 0], dtype=torch.int64).reshape(1, 1, 1, 4)
-                kv_pad_metadata = ttnn.from_torch(
-                    meta_payload,
-                    device=mesh_device,
-                    dtype=ttnn.uint32,
-                    layout=ttnn.ROW_MAJOR_LAYOUT,
-                    memory_config=ttnn.DRAM_MEMORY_CONFIG,
-                    mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+                kv_pad_metadata = tuple(
+                    ttnn.from_torch(
+                        torch.tensor([val], dtype=torch.int64).reshape(1, 1, 1, 1),
+                        device=mesh_device,
+                        dtype=ttnn.uint32,
+                        layout=ttnn.ROW_MAJOR_LAYOUT,
+                        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+                    )
+                    for val in (u, kv_actual, valid_end)
                 )
             # Metadata path: pass ONLY the metadata tensor (the runner hands tt_metadata straight from
             # inbound_socket_service_sync) -- actual_start/actual_end are read on-device, so leave them
@@ -790,7 +793,8 @@ def _run_chunked_prefill(
                 metadata=kv_pad_metadata,
             )
             if kv_pad_metadata is not None:
-                ttnn.deallocate(kv_pad_metadata)
+                for meta_tensor in kv_pad_metadata:
+                    ttnn.deallocate(meta_tensor)
             out_flat = ttnn.to_torch(
                 tt_out,
                 mesh_composer=ttnn.ConcatMesh2dToTensor(

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py
@@ -1759,6 +1759,7 @@ def test_kimi_prefill_transformer_chunked_perf(
         use_trace=use_trace,
     )
 
+
 # ids: "traced" not "trace" — "notrace" CONTAINS "trace", so a -k "trace" term would match BOTH
 # modes and silently double a CI job. Matches the padded test's convention.
 @pytest.mark.parametrize("use_trace", [False, True], ids=["notrace", "traced"])

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py
@@ -53,6 +53,7 @@ from models.demos.deepseek_v3_d_p.tt.tt_prefill_transformer import TtPrefillTran
 from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import MlaKvCacheFormat, init_kvpe_cache, init_mla_kv_cache
 from models.demos.deepseek_v3_d_p.utils.prefill_summary_utils import emit_summary, render_table
 from models.demos.deepseek_v3_d_p.utils.smbus_telemetry import is_high_power
+from models.demos.deepseek_v3_d_p.utils.sub_device_trace import SubDeviceTraceController
 from models.demos.deepseek_v3_d_p.utils.test_utils import (
     cache_half_pccs,
     gather_cache_tp0,
@@ -146,6 +147,15 @@ KIMI_NO_PCC_BASELINE_CHUNK_TIMES_S = {
 # perf_margin pytest argument (see test_prefill_block_perf.py's `margin` column for the design).
 DEFAULT_PERF_MARGIN = 0.05
 
+# Deepest config whose per-layer PCC is asserted; deeper runs (L61) stay record-only until their
+# accumulation headroom is pinned.
+GATED_LAYER_DEPTH = 10
+# KV-cache PCC bar for the trace-correctness tests (_record_kv_cache_pcc with
+# assert_layer_depth=GATED_LAYER_DEPTH): the KV the traced forward wrote vs the golden
+# kv_post_transform, over the SHALLOW gated layers only. Distinct from KV_CACHE_PCC_THRESHOLD above,
+# which is the full-depth floor (deep bf8_b layers drift well below this bar).
+TRACE_KV_CACHE_PCC_THRESHOLD = 0.96
+
 
 def _load_metadata_token_ids(trace_dir: Path, total_len: int) -> torch.Tensor:
     with open(trace_dir / "metadata.json") as f:
@@ -186,11 +196,28 @@ def _ref_layer_slice(trace_dir: Path, layout: str, layer: int, start: int, end: 
 
 
 def _record_kv_cache_pcc(
-    trace_dir, layout, tt_kvpe_cache, mesh_device, sp, num_layers, seq_len_cache, total_len, kv_lora
+    trace_dir,
+    layout,
+    tt_kvpe_cache,
+    mesh_device,
+    sp,
+    num_layers,
+    seq_len_cache,
+    total_len,
+    kv_lora,
+    assert_threshold=KV_CACHE_PCC_THRESHOLD,
+    assert_layer_depth=None,
+    return_per_layer=False,
 ):
     """Gather the device KV cache, un-rotate the block-cyclic layout, and PCC each layer's valid region
     [:total_len] against the golden kv_post_transform trace ([nope | pe], the pe half re-based to the
-    device Meta interleave via cache_half_pccs). Per-layer cache — slot == layer."""
+    device Meta interleave via cache_half_pccs). Per-layer cache — slot == layer.
+
+    Returns the min PCC across all layers (or `(min, per_layer_dict)` with return_per_layer). The min
+    is asserted >= `assert_threshold`; pass None to make the check record-only. With
+    `assert_layer_depth` set, only layers 0..assert_layer_depth (inclusive) are asserted — deeper
+    layers are recorded only, mirroring the decoder-output GATED_LAYER_DEPTH policy (deep KV PCC
+    drifts under bf8_b)."""
     logger.info("Device KV cache vs golden kv_post_transform:")
     cache_full = gather_cache_tp0(tt_kvpe_cache.storage, mesh_device)  # [num_layers, seq_len_cache, kvpe]
     p = blockcyclic_positions(sp, CHUNK, seq_len_cache)
@@ -201,11 +228,25 @@ def _record_kv_cache_pcc(
         pcc_nope, pcc_pe = cache_half_pccs(g_post, dev_cache, kv_lora, pe_interleave=True)
         cache_min_pcc[i] = min(pcc_nope, pcc_pe)
         logger.info(f"  cache layer {i} PCC: nope={pcc_nope:.6f} pe(interleaved)={pcc_pe:.6f}")
-        if cache_min_pcc[i] < KV_CACHE_PCC_THRESHOLD:
-            logger.warning(f"  KV cache layer {i} PCC {cache_min_pcc[i]:.6f} below {KV_CACHE_PCC_THRESHOLD}")
+        if assert_threshold is not None and cache_min_pcc[i] < assert_threshold:
+            logger.warning(f"  KV cache layer {i} PCC {cache_min_pcc[i]:.6f} below {assert_threshold}")
     kv_min = min(cache_min_pcc.values())
     logger.info(f"KV cache min PCC across layers: {kv_min:.6f}")
-    assert kv_min >= KV_CACHE_PCC_THRESHOLD, f"KV cache min PCC {kv_min:.6f} < {KV_CACHE_PCC_THRESHOLD}"
+    if assert_threshold is not None:
+        if assert_layer_depth is not None:
+            gated_min = min(v for i, v in cache_min_pcc.items() if i <= assert_layer_depth)
+            logger.info(
+                f"KV cache min PCC over asserted layers 0..{assert_layer_depth}: {gated_min:.6f} "
+                f"(layers >{assert_layer_depth} recorded only)"
+            )
+            assert (
+                gated_min >= assert_threshold
+            ), f"KV cache min PCC {gated_min:.6f} (layers 0..{assert_layer_depth}) < {assert_threshold}"
+        else:
+            assert kv_min >= assert_threshold, f"KV cache min PCC {kv_min:.6f} < {assert_threshold}"
+    if return_per_layer:
+        return kv_min, cache_min_pcc
+    return kv_min
 
 
 def _record_indexer_k_cache_pcc(
@@ -895,67 +936,20 @@ def test_ds_prefill_transformer_chunked_padded(
     )
 
 
-# ---------------------------------------------------------------------------
-# Kimi K2.6 variants
-# ---------------------------------------------------------------------------
-# Same chunked-prefill validation as the DeepSeek tests, with the kimi_k2_6 variant and the on-device
-# gate (GateComputeMode.DEVICE_FP32 — Kimi has a single expert group, so it uses the grouped-topk
-# fp32 device path) + KimiK26Config fabric payload. These skip until the Kimi golden trace lands (set
-# PREFILL_TRACE_DIR; see tt/runners/adapters/).
+# Execution modes for the padded chunked test (pytest param `mode`). Both run the SAME splits through
+# the SAME harness (run_chunked_transformer_padded_trace) and assert the same thing — per-layer
+# KV-cache PCC vs the golden — so the pair is a direct trace-vs-no-trace comparison:
+#   notrace — the harness's "scalar" variant: per-chunk actual_start/actual_end passed as host
+#             scalars (metadata=None), forward run eagerly per split.
+#   traced  — the metadata variant: per-chunk scalars read on-device from the metadata tensors, and
+#             the forward captured ONCE as a ttnn trace and replayed per split.
+#
+# NOTE when selecting with -k: "notrace" CONTAINS the substring "trace", so `-k trace` matches BOTH
+# modes. Use `-k notrace` / `-k traced` to pin one.
+_PADDED_MODES = ["notrace", "traced"]
 
 
-@pytest.mark.parametrize("n_chunks", [11], ids=["chunks11"])
-@pytest.mark.parametrize("num_layers", [1, 10, 61], ids=["L1", "L10", "L61"])
-@pytest.mark.parametrize(
-    "mesh_device, device_params, num_links, topology",
-    [
-        pytest.param(
-            (8, 4),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=KimiK26Config.FABRIC_PAYLOAD_SIZE),
-                # Carve a small L1_SMALL region so the MoE routing all-gather can place its global
-                # semaphores there (use_l1_small_for_semaphores) instead of pinning the main-L1 floor.
-                # Kept minimal: L1_SMALL is carved from the top of L1, so a large value would shift the
-                # main-L1 buffer floor down and could re-introduce the clash.
-                "l1_small_size": 512,
-            },
-            2,
-            ttnn.Topology.Linear,
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
-            id="mesh-8x4",
-        ),
-    ],
-    indirect=["mesh_device", "device_params"],
-)
-@pytest.mark.parametrize("variant", ["kimi_k2_6"], indirect=True, ids=["kimi"])
-@pytest.mark.skipif(not is_blackhole(), reason="Kimi requires Blackhole")
-@pytest.mark.timeout(0)
-def test_kimi_prefill_transformer_chunked(
-    variant,
-    config_only,
-    mesh_device,
-    device_params,
-    weight_cache_path,
-    num_layers,
-    n_chunks,
-    num_links,
-    topology,
-):
-    run_chunked_transformer(
-        variant,
-        config_only,
-        mesh_device,
-        weight_cache_path,
-        num_layers,
-        n_chunks,
-        GateComputeMode.DEVICE_FP32,
-        num_links,
-        topology,
-        routing_use_l1_small_for_semaphores=True,
-    )
-
-
+@pytest.mark.parametrize("mode", _PADDED_MODES, ids=_PADDED_MODES)
 @pytest.mark.parametrize("splits", [_PADDED_MID_15K, _PADDED_FULL_55K], ids=["mid15k", "full55k"])
 @pytest.mark.parametrize("num_layers", [1, 10, 61], ids=["L1", "L10", "L61"])
 @pytest.mark.parametrize(
@@ -971,6 +965,11 @@ def test_kimi_prefill_transformer_chunked(
                 # Kept minimal: L1_SMALL is carved from the top of L1, so a large value would shift the
                 # main-L1 buffer floor down and could re-introduce the clash.
                 "l1_small_size": 512,
+                # Needed only by mode="traced"; device_params is a separate parametrize axis so it
+                # cannot be conditioned on `mode`. Reserving it for every mode costs DRAM headroom the
+                # non-traced modes do not use — harmless here (the traced L61/full55k case, which has
+                # the largest KV cache of the matrix, already runs with this reservation).
+                "trace_region_size": 256 * 1024 * 1024,
             },
             2,
             ttnn.Topology.Linear,
@@ -987,6 +986,7 @@ def test_kimi_prefill_transformer_chunked(
                 "fabric_router_config": create_fabric_router_config(max_payload_size=KimiK26Config.FABRIC_PAYLOAD_SIZE),
                 "reliability_mode": ttnn.FabricReliabilityMode.RELAXED_INIT,
                 "l1_small_size": 512,
+                "trace_region_size": 256 * 1024 * 1024,
             },
             2,
             ttnn.Topology.Linear,
@@ -1009,8 +1009,12 @@ def test_kimi_prefill_transformer_chunked_padded(
     splits,
     num_links,
     topology,
+    mode,
 ):
-    run_chunked_transformer_padded(
+    """Padded/rotated chunked prefill, traced vs untraced (see _PADDED_MODES). Both modes exercise
+    padding-aware MoE over the same `splits` and assert per-layer KV-cache PCC against the golden, so
+    a traced-vs-notrace diff isolates the trace/metadata path itself rather than harness differences."""
+    common = (
         variant,
         config_only,
         mesh_device,
@@ -1020,7 +1024,12 @@ def test_kimi_prefill_transformer_chunked_padded(
         GateComputeMode.DEVICE_FP32,
         num_links,
         topology,
+    )
+    # The harness names its untraced variant "scalar"; here the only question is trace or no trace.
+    run_chunked_transformer_padded_trace(
+        *common,
         routing_use_l1_small_for_semaphores=True,
+        mode="traced" if mode == "traced" else "scalar",
     )
 
 
@@ -1090,7 +1099,7 @@ def test_glm_prefill_transformer_chunked(
     )
 
 
-def run_chunked_transformer_no_pcc(
+def run_chunked_transformer_updated(
     variant,
     config,
     mesh_device,
@@ -1105,6 +1114,8 @@ def run_chunked_transformer_no_pcc(
     baseline_chunk_times_s=None,
     perf_margin=None,
     preload_isl=0,
+    check_pcc=False,
+    use_trace=False,
 ):
     """No-PCC perf/smoke variant of run_chunked_transformer: build the transformer ONCE, then drive the
     full n_chunks-chunk prefill `num_iters` times with return_intermediates=False (no per-layer host
@@ -1211,6 +1222,17 @@ def run_chunked_transformer_no_pcc(
         f"num_iters={num_iters}"
     )
 
+    # Trace is DENSE-MLA ONLY. Asserted here (not just deep in set_trace_controller) so a sparse model
+    # fails before the multi-minute weight load. GLM (glm_5_1 / glm_5_2) carries the DSA indexer fields,
+    # whose ops have no per-element-tensor metadata overload yet — and the captured forward never threads
+    # index_kv_cache, so a traced sparse run would silently skip the indexer and write wrong KV.
+    if use_trace:
+        assert not resolve_has_indexer(config), (
+            "use_trace=True is not supported for sparse/DSA (indexer) attention — GLM (glm_5_1 / "
+            "glm_5_2) and friends. Supported traced models are the dense-MLA ones (deepseek_v3, "
+            "kimi_k2_6, kimi_k2_7); port the indexer ops to the metadata form first."
+        )
+
     iteration_chunk_times: list[list[float]] = []
 
     # Token ids: prefer the real (code_debug/longbook) ids from the golden trace (same source as the PCC
@@ -1270,6 +1292,13 @@ def run_chunked_transformer_no_pcc(
         lm_head_is_column_parallel=True,
         is_chunked=True,
         slot_num=1,
+        # Strip the tail (LM head + final norm + sampling): the populated KV cache is this runner's
+        # output, so the tail is dead work that would otherwise land inside the measured per-chunk
+        # time. It is also what makes the forward DEVICE-ONLY and therefore capturable — the LM head
+        # does an all-gather + a host read, and a read inside begin_capture() is a hard TT_FATAL
+        # ("Reads are not supported during trace capture"). Set for BOTH modes, not just use_trace,
+        # so traced and untraced timings measure the same work and stay comparable.
+        kv_only_last_layer=True,
         routing_use_l1_small_for_semaphores=routing_use_l1_small_for_semaphores,
     )
     ttnn.synchronize_device(mesh_device)
@@ -1387,12 +1416,90 @@ def run_chunked_transformer_no_pcc(
         logger.info("[profile] warmup chunk 0 complete (kernels JITted); measured region begins")
         signpost("PROFILE_MEASURE_START")
 
+    # use_trace: capture the chunk forward ONCE, then replay it per chunk. The per-chunk scalars
+    # (slot_id / actual_start / actual_end) cannot be host arguments on a captured program, so they move
+    # into 1-element uint32 DRAM tensors the metadata ops read on-device; the token input moves into a
+    # persistent buffer refreshed in place. kv_only_last_layer=True (set on the transformer above) is what makes the forward
+    # device-only and therefore capturable at all.
+    trace_controller = None
+    trace_input = None
+    trace_metadata = None
+    if use_trace:
+        rep = ttnn.ReplicateTensorToMesh(mesh_device)
+
+        def _meta1(val, on_device=True):
+            t = torch.tensor([val], dtype=torch.int64).reshape(1, 1, 1, 1)
+            kw = dict(dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT, mesh_mapper=rep)
+            if on_device:
+                kw.update(device=mesh_device, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+            return ttnn.from_torch(t, **kw)
+
+        trace_input = ttnn.from_torch(
+            chunk_tok_host[0],
+            device=mesh_device,
+            dtype=ttnn.uint32,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=tuple(mesh_shape), dims=(0, None)),
+        )
+        trace_metadata = (_meta1(0), _meta1(preload_isl), _meta1(preload_isl + CHUNK))
+        host_tok = [
+            ttnn.from_torch(
+                chunk_tok_host[c],
+                dtype=ttnn.uint32,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+                mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=tuple(mesh_shape), dims=(0, None)),
+            )
+            for c in range(n_chunks)
+        ]
+        host_meta = [
+            (_meta1(0, False), _meta1(preload_isl + c * CHUNK, False), _meta1(preload_isl + (c + 1) * CHUNK, False))
+            for c in range(n_chunks)
+        ]
+
+        def _fwd_meta():
+            return transformer.forward(
+                trace_input,
+                tt_kvpe_cache,
+                actual_isl=CHUNK,
+                actual_start=None,
+                actual_end=None,
+                cache_user_id=0,
+                return_intermediates=False,
+                metadata=trace_metadata,
+            )
+
+        trace_controller = SubDeviceTraceController(mesh_device)
+        transformer.set_trace_controller(trace_controller)
+        _fwd_meta()  # warm/compile the metadata-variant programs before recording
+        ttnn.synchronize_device(mesh_device)
+        trace_controller.begin_capture()
+        _fwd_meta()
+        trace_controller.end_capture()
+        ttnn.synchronize_device(mesh_device)
+        logger.info(
+            f"[no-pcc trace] captured {num_layers}-layer forward = {trace_controller.num_segments} segments, "
+            f"{trace_controller.trace_bytes() / 1024 / 1024:.2f} MB"
+        )
+        # A zero-segment capture would make every replay a no-op: the timings would collapse and any
+        # check_pcc would compare the warm pass's (correct) KV. Fail instead of reporting that.
+        assert trace_controller.num_segments > 0, "use_trace captured 0 segments — nothing to replay"
+
     profiler.start("tt_forward")
     for it in range(num_iters):
         iter_start = time.time()
         chunk_times: list[float] = []
         for c in range(n_chunks):
             kv_actual = preload_isl + c * CHUNK
+            if use_trace:
+                ttnn.copy_host_to_device_tensor(host_tok[c], trace_input)
+                for src, dst in zip(host_meta[c], trace_metadata):
+                    ttnn.copy_host_to_device_tensor(src, dst)
+                chunk_start = time.time()
+                trace_controller.replay()
+                ttnn.synchronize_device(mesh_device)
+                chunk_times.append(time.time() - chunk_start)
+                continue
             tt_tokens = ttnn.from_torch(
                 chunk_tok_host[c],
                 device=mesh_device,
@@ -1507,6 +1614,43 @@ def run_chunked_transformer_no_pcc(
         logger.info(render(rows[-1]))
         logger.info(sep)
 
+    # Optional accuracy check on the same run that produced the timings, so a perf number is never
+    # reported for a functionally wrong prefill. Off by default: this runner's whole point is to need no
+    # golden trace, and enabling it makes one mandatory.
+    if check_pcc:
+        assert (
+            trace_dir is not None and trace_dir.exists()
+        ), "check_pcc=True needs the golden trace (set PREFILL_TRACE_DIR); this runner does not require it otherwise"
+        # This runner only ever reads token_ids from the trace, so it never resolved the tensor layout;
+        # the KV comparison needs it.
+        layout = variant.prefill_trace_layout
+        _record_kv_cache_pcc(
+            trace_dir,
+            layout,
+            tt_kvpe_cache,
+            mesh_device,
+            sp,
+            num_layers,
+            # SEQ_CACHE_NOPCC, not SEQ_CACHE: this runner allocates the 100k cache, and
+            # _record_kv_cache_pcc derives blockcyclic_positions from this length — passing the 55k
+            # constant made the un-rotate scatter a [102400, 576] gather into a [56320, 576] index.
+            SEQ_CACHE_NOPCC,
+            total_len,
+            config.kv_lora_rank,
+            assert_threshold=TRACE_KV_CACHE_PCC_THRESHOLD,
+            assert_layer_depth=GATED_LAYER_DEPTH,
+        )
+
+    # Release the captured trace + the sub-device managers that own its buffers BEFORE the mesh
+    # closes. Without this the MeshTraceBuffers are freed via SubDeviceManager's dtor after the
+    # allocator is gone and teardown segfaults in BankManager::deallocate_buffer — the test itself
+    # PASSES and the process still exits 139, which reads as a red CI job. Same failure the runner
+    # hit (see TtPrefillRuntime.release_trace); the trace path needs the release wherever it lives.
+    if trace_controller is not None:
+        trace_controller.release()
+        transformer.set_trace_controller(None)
+    transformer.release_sub_device_managers()
+
     # Assert AFTER the table is logged so the full per-chunk breakdown is always visible on failure.
     assert not perf_failures, "chunk timing out of baseline tolerance:\n  " + "\n  ".join(perf_failures)
 
@@ -1514,6 +1658,15 @@ def run_chunked_transformer_no_pcc(
 # No-PCC perf/smoke variant: runs the full n_chunks-chunk prefill `num_iters` times with no golden
 # trace dependency, no intermediate readback, and no PCC. Requires only the Kimi TTNN weight cache (set
 # TT_KIMI_PREFILL_TTNN_CACHE + KIMI_K2_6_HF_MODEL); the golden trace is optional.
+# Two independent axes on top of the existing perf sweep:
+#   check_pcc — also PCC the populated KV against the golden (needs PREFILL_TRACE_DIR)
+#   use_trace — capture the chunk forward once and replay it per chunk
+# The nopcc x {trace, notrace} pair is what CI runs: it times the real path and passes on
+# completion, with no golden dependency. Renamed from *_no_pcc now that PCC is optional, so the
+# name no longer contradicts the flag.
+# ids: "traced" not "trace" — "notrace" CONTAINS "trace", so a -k "trace" term would match BOTH
+# modes and silently double a CI job. Matches the padded test's convention.
+@pytest.mark.parametrize("use_trace", [False, True], ids=["notrace", "traced"])
 @pytest.mark.parametrize("perf_margin", [DEFAULT_PERF_MARGIN], ids=["margin5pct"])
 @pytest.mark.parametrize(
     "num_iters", [1, 2, 10, 20, 25], ids=["iters1", "two_iters", "ten_iters", "iters20", "iters25"]
@@ -1544,6 +1697,10 @@ def run_chunked_transformer_no_pcc(
                 "fabric_router_config": create_fabric_router_config(max_payload_size=KimiK26Config.FABRIC_PAYLOAD_SIZE),
                 # L1_SMALL region for the MoE routing all-gather's semaphores (see TtMoERoutingSetup).
                 "l1_small_size": 512,
+                # Required by mode="traced": without it conftest logs "No trace region size" and the
+                # captured trace buffers come out of general DRAM instead of a reserved region —
+                # unbounded, and trace_bytes() then reports 0.00 MB because the TRACE pool is empty.
+                "trace_region_size": 256 * 1024 * 1024,
             },
             2,
             ttnn.Topology.Linear,
@@ -1560,7 +1717,7 @@ def run_chunked_transformer_no_pcc(
     reason="perf job requires a high-power (>=130W TDP) galaxy; guards the exabox.tenstorrent.com/power=14kw label",
 )
 @pytest.mark.timeout(0)
-def test_kimi_prefill_transformer_chunked_no_pcc(
+def test_kimi_prefill_transformer_chunked_perf(
     variant,
     config_only,
     mesh_device,
@@ -1572,6 +1729,7 @@ def test_kimi_prefill_transformer_chunked_no_pcc(
     num_links,
     topology,
     perf_margin,
+    use_trace,
     preload_isl,
 ):
     if preload_isl + n_chunks * CHUNK > SEQ_CACHE_NOPCC:
@@ -1582,7 +1740,7 @@ def test_kimi_prefill_transformer_chunked_no_pcc(
     baseline_chunk_times_s = (
         KIMI_NO_PCC_BASELINE_CHUNK_TIMES_S.get((num_layers, n_chunks, num_iters)) if preload_isl == 0 else None
     )
-    run_chunked_transformer_no_pcc(
+    run_chunked_transformer_updated(
         variant,
         config_only,
         mesh_device,
@@ -1597,6 +1755,99 @@ def test_kimi_prefill_transformer_chunked_no_pcc(
         baseline_chunk_times_s=baseline_chunk_times_s,
         perf_margin=perf_margin,
         preload_isl=preload_isl,
+        check_pcc=False,  # timing only — accuracy lives in test_kimi_prefill_transformer_chunked
+        use_trace=use_trace,
+    )
+
+# ids: "traced" not "trace" — "notrace" CONTAINS "trace", so a -k "trace" term would match BOTH
+# modes and silently double a CI job. Matches the padded test's convention.
+@pytest.mark.parametrize("use_trace", [False, True], ids=["notrace", "traced"])
+@pytest.mark.parametrize("perf_margin", [DEFAULT_PERF_MARGIN], ids=["margin5pct"])
+@pytest.mark.parametrize(
+    "num_iters", [1, 2, 10, 20, 25], ids=["iters1", "two_iters", "ten_iters", "iters20", "iters25"]
+)
+@pytest.mark.parametrize(
+    "n_chunks",
+    [1, 2, 5, 10, 11, 20],
+    ids=["chunks1", "chunks2", "chunks5", "chunks10", "chunks_eleven", "chunks20"],
+)
+# preload_isl (multiple of CHUNK): pretend the cache already holds this many prior KV tokens so the
+# measured chunks run at KV depth [preload_isl, preload_isl + n_chunks*CHUNK) WITHOUT first running prefill
+# up to that point. Pair with n_chunks=1 to sweep the single-chunk MLA/MoE ratio vs depth. 0 = start from
+# empty cache. Depths within the golden trace use real KV; the rest fill random KV beyond the trace (still
+# non-degenerate for routing) so larger ISLs than the trace can be measured. Requires a golden trace when >0.
+@pytest.mark.parametrize(
+    "preload_isl",
+    [0, 5 * CHUNK, 10 * CHUNK, 19 * CHUNK],
+    ids=["preload0", "preload25k", "preload50k", "preload95k"],
+)
+@pytest.mark.parametrize("num_layers", [1, 10, 61], ids=["L1", "L10", "L61"])
+@pytest.mark.parametrize(
+    "mesh_device, device_params, num_links, topology",
+    [
+        pytest.param(
+            (8, 4),
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+                "fabric_router_config": create_fabric_router_config(max_payload_size=KimiK26Config.FABRIC_PAYLOAD_SIZE),
+                # L1_SMALL region for the MoE routing all-gather's semaphores (see TtMoERoutingSetup).
+                "l1_small_size": 512,
+                # Required by mode="traced": without it conftest logs "No trace region size" and the
+                # captured trace buffers come out of general DRAM instead of a reserved region —
+                # unbounded, and trace_bytes() then reports 0.00 MB because the TRACE pool is empty.
+                "trace_region_size": 256 * 1024 * 1024,
+            },
+            2,
+            ttnn.Topology.Linear,
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
+            id="mesh-8x4",
+        ),
+    ],
+    indirect=["mesh_device", "device_params"],
+)
+@pytest.mark.parametrize("variant", ["kimi_k2_6"], indirect=True, ids=["kimi"])
+@pytest.mark.skipif(not is_blackhole(), reason="Kimi requires Blackhole")
+@pytest.mark.timeout(0)
+def test_kimi_prefill_transformer_chunked(
+    variant,
+    config_only,
+    mesh_device,
+    device_params,
+    weight_cache_path,
+    num_layers,
+    n_chunks,
+    num_iters,
+    num_links,
+    topology,
+    perf_margin,
+    use_trace,
+    preload_isl,
+):
+    if preload_isl + n_chunks * CHUNK > SEQ_CACHE_NOPCC:
+        pytest.skip(f"preload_isl {preload_isl} + {n_chunks} chunks exceeds the {SEQ_CACHE_NOPCC}-token cache")
+    # Gate against the CI baseline only for the exact config we have a recorded number for; every other
+    # combo in the sweep stays record-only (baseline None -> print_duration_table does not assert). The
+    # baseline is only meaningful at preload_isl=0 (the recorded runs started from an empty cache).
+    baseline_chunk_times_s = (
+        KIMI_NO_PCC_BASELINE_CHUNK_TIMES_S.get((num_layers, n_chunks, num_iters)) if preload_isl == 0 else None
+    )
+    run_chunked_transformer_updated(
+        variant,
+        config_only,
+        mesh_device,
+        weight_cache_path,
+        num_layers,
+        n_chunks,
+        GateComputeMode.DEVICE_FP32,
+        num_links,
+        topology,
+        num_iters,
+        routing_use_l1_small_for_semaphores=True,
+        baseline_chunk_times_s=baseline_chunk_times_s,
+        perf_margin=perf_margin,
+        preload_isl=preload_isl,
+        check_pcc=True,  # this test exists for the KV PCC; the timing table is incidental
+        use_trace=use_trace,
     )
 
 
@@ -1646,7 +1897,7 @@ def test_ds_prefill_transformer_chunked_no_pcc(
     num_links,
     topology,
 ):
-    run_chunked_transformer_no_pcc(
+    run_chunked_transformer_updated(
         variant,
         config_only,
         mesh_device,
@@ -1732,7 +1983,7 @@ def test_glm_prefill_transformer_chunked_no_pcc(
 ):
     if preload_isl + n_chunks * CHUNK > SEQ_CACHE_NOPCC:
         pytest.skip(f"preload_isl {preload_isl} + {n_chunks} chunks exceeds the {SEQ_CACHE_NOPCC}-token cache")
-    run_chunked_transformer_no_pcc(
+    run_chunked_transformer_updated(
         variant,
         config_only,
         mesh_device,
@@ -1746,3 +1997,338 @@ def test_glm_prefill_transformer_chunked_no_pcc(
         routing_use_l1_small_for_semaphores=True,
         preload_isl=preload_isl,
     )
+
+
+def run_chunked_transformer_padded_trace(
+    variant,
+    config,
+    mesh_device,
+    weight_cache_path,
+    num_layers,
+    splits,
+    gate_fallback_mode,
+    num_links,
+    topology,
+    routing_use_l1_small_for_semaphores=False,
+    mode="traced",
+):
+    """VARIABLE/partial-chunk prefill on ONE kv_only build, in one of three independent modes (pytest
+    param `mode`), each asserted ONLY against the golden kv_post_transform (no cross-path comparison):
+      - "scalar":  untraced scalar path (host actual_start/actual_end, metadata=None);
+      - "eager":   metadata path run eagerly per split (per-chunk scalars read on-device from a
+                   persistent metadata tensor), no capture;
+      - "traced":  the SAME metadata forward captured once as a ttnn trace and replayed per split.
+    Each mode runs a single pass and asserts its per-layer KV-cache PCC (vs the golden) meets
+    LAYER_PCC_THRESHOLD for the asserted layer depth.
+
+    All three modes DO exercise padding-aware MoE (they did not while the trace layer force-disabled it
+    by clearing actual_isl), and they cover both producers of the padding config:
+      * "scalar" builds it on HOST (build_padding_config, rotated branch: metadata=None with a real
+        partial actual_isl and actual_start). `splits` repeats ISLs at different starts (e.g. 5120 at
+        10240/20480/35168), so this also covers the build_padding_config memo being keyed on
+        actual_start -- keying on actual_isl alone silently reused the first chunk's rotated config.
+      * "eager"/"traced" build it ON DEVICE (moe_padding_config) from the actual_start/actual_end
+        metadata tensors. They pass actual_isl=CHUNK, which now only flags padding awareness as ON --
+        the real per-chunk bound comes from those tensors, which is what makes ONE capture replay
+        correctly across chunks."""
+    if weight_cache_path is None:
+        pytest.skip(f"pretrained weights unavailable (set {variant.ttnn_cache_env} + {variant.env_var})")
+    trace_dir = _resolve_trace_dir(variant)
+    if not trace_dir.exists():
+        pytest.skip(f"golden trace not found: {trace_dir}")
+    layout = variant.prefill_trace_layout
+
+    sp_axis, tp_axis = 0, 1
+    mesh_shape = list(mesh_device.shape)
+    sp, tp = mesh_shape[sp_axis], mesh_shape[tp_axis]
+    assert (sp, tp) == (8, 4), f"this test targets mesh-8x4, got {mesh_shape}"
+    tile = ttnn.TILE_SIZE
+    chunk_local = CHUNK // sp
+    total_len = sum(splits)
+    for v in splits:
+        assert 0 < v <= CHUNK and v % tile == 0, f"split {v} must be tile-aligned and <= {CHUNK}"
+
+    # Slab-aligned cache covering the largest rotated write (mirror run_chunked_transformer_padded).
+    max_window, ka = CHUNK * 2, 0
+    for v in splits:
+        max_window = max(max_window, ka + CHUNK)
+        ka += v
+    seq_len_cache = ((max_window + CHUNK - 1) // CHUNK) * CHUNK
+
+    kvpe_dim = config.qk_rope_head_dim + config.kv_lora_rank
+    config.max_seq_len = seq_len_cache
+    logger.info(
+        f"chunked-padded TRACE: num_layers={num_layers} mesh={mesh_shape} splits={splits} "
+        f"total_len={total_len} cache={seq_len_cache} chunk={CHUNK}"
+    )
+    token_ids_full = _load_metadata_token_ids(trace_dir, total_len)
+
+    effective_cache_path = weight_cache_path / f"{sp}x{tp}"
+    experts_per_chip = variant.model_config.NUM_ROUTED_EXPERTS // (sp * tp)
+    assert TtPrefillTransformer.check_cache_complete(
+        effective_cache_path,
+        num_layers,
+        experts_per_chip=experts_per_chip,
+        first_k_dense=variant.model_config.NUM_DENSE_LAYERS,
+    ), f"TTNN cache incomplete for {num_layers} layers at {effective_cache_path}"
+
+    transformer = TtPrefillTransformer(
+        mesh_device=mesh_device,
+        config=config,
+        model_cfg=variant.model_config,
+        state_dict={},
+        num_layers=num_layers,
+        seq_len=CHUNK,
+        max_seq_len=seq_len_cache,
+        dispatch_buffer_capacity_factor=8,
+        num_links=num_links,
+        topology=topology,
+        sp_axis=sp_axis,
+        tp_axis=tp_axis,
+        is_balanced=False,
+        gate_fallback_mode=gate_fallback_mode,
+        weight_cache_path=effective_cache_path,
+        lm_head_is_column_parallel=True,
+        is_chunked=True,
+        slot_num=1,
+        # kv_only_last_layer -> device-only forward (no host readback) so ttnn trace can capture it.
+        kv_only_last_layer=True,
+        overlap_shared_expert_with_dispatch=True,
+        routing_use_l1_small_for_semaphores=routing_use_l1_small_for_semaphores,
+    )
+    ttnn.synchronize_device(mesh_device)
+    gc.collect()
+    mesh_device.enable_program_cache()
+
+    # Per-split padded token tile (block-cyclic gather; positions >= valid_end -> pad token 0) + scalars.
+    def _padded_chunk_tok(kv_actual, isl):
+        valid_end = kv_actual + isl
+        positions = rotated_chip_positions(kv_actual, sp, chunk_local)
+        flat = [positions[ch][r] for ch in range(sp) for r in range(chunk_local)]
+        gather_idx = torch.tensor([min(gp, total_len - 1) for gp in flat], dtype=torch.long)
+        tok = token_ids_full[gather_idx].clone()
+        tok[torch.tensor([gp >= valid_end for gp in flat])] = 0
+        return tok.reshape(sp, 1, chunk_local)
+
+    starts, ka = [], 0
+    for isl in splits:
+        starts.append((ka, ka + isl))  # (kv_actual, valid_end)
+        ka += isl
+    chunk_tok_host = [_padded_chunk_tok(ks, e - ks) for (ks, e) in starts]
+
+    def _make_cache():
+        return init_mla_kv_cache(
+            cache_format=MlaKvCacheFormat.BFP8_TILE,
+            hf_config=config,
+            mesh_device=mesh_device,
+            seq_len=seq_len_cache,
+            mesh_shape=mesh_shape,
+            sp_axis=sp_axis,
+            num_kvpe_cache_layers=num_layers,
+            num_users=1,
+        )
+
+    sp_mapper = ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=tuple(mesh_shape), dims=(0, None))
+    rep_mapper = ttnn.ReplicateTensorToMesh(mesh_device)
+
+    # Each mode runs a SINGLE pass and asserts its own per-layer KV-cache PCC against the GOLDEN trace.
+    # There is no scalar-vs-metadata cross-comparison: the scalar, metadata(eager) and trace(replay)
+    # paths are independent tests, each validated only against the golden.
+
+    # ---- SCALAR mode: untraced scalar path (host actual_start/actual_end), asserted vs GOLDEN. ----
+    if mode == "scalar":
+        cache = _make_cache()
+        # UNTRACED ONLY: also PCC each layer's DECODER OUTPUT, not just the KV cache. This needs
+        # return_intermediates=True, whose _to_host(h) + synchronize_device is a host readback and so
+        # cannot live inside a trace capture — which is why the metadata/traced modes below assert KV
+        # PCC alone. Running it here keeps the stronger check on the untraced reference rather than
+        # losing it entirely.
+        #
+        # Layers 0..num_layers-2 only: the transformer is built kv_only_last_layer=True, so the LAST
+        # layer is kv_only (attn_norm + the KV branch) and never produces a hidden state — the loop
+        # returns before snapshotting it (tt_prefill_transformer: `if self.kv_only_last_layer and
+        # i == len(self.layers)-1: return None, None, intermediates`). Its correctness is covered by
+        # the KV PCC below. The norm / LM head / logits tail is likewise not built in this config.
+        emb_dim = config.hidden_size
+        n_decoder_layers = num_layers - 1
+        layer_min_pcc = {i: 1.0 for i in range(n_decoder_layers)}
+        for c, ((ks, e), tok) in enumerate(zip(starts, chunk_tok_host)):
+            isl = e - ks
+            # Same rotated layout _padded_chunk_tok gathered with: recomputed here (cheap, host-side)
+            # so the valid rows can be un-rotated back to natural order for the golden comparison.
+            positions = rotated_chip_positions(ks, sp, chunk_local)
+            flat = [positions[ch][r] for ch in range(sp) for r in range(chunk_local)]
+            valid_pairs = [(row, gp) for row, gp in enumerate(flat) if gp < e]
+            src = torch.tensor([row for row, _ in valid_pairs], dtype=torch.long)
+            dst = torch.tensor([gp - ks for _, gp in valid_pairs], dtype=torch.long)  # 0..isl-1
+            tt_tokens = ttnn.from_torch(
+                tok,
+                device=mesh_device,
+                dtype=ttnn.uint32,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+                mesh_mapper=sp_mapper,
+            )
+            _, _, layer_outputs = transformer.forward(
+                tt_tokens,
+                cache,
+                actual_isl=isl,
+                actual_start=ks,
+                actual_end=e,
+                cache_user_id=0,
+                metadata=None,
+                return_intermediates=True,
+            )
+            ttnn.deallocate(tt_tokens)
+            ttnn.synchronize_device(mesh_device)
+            for i in range(n_decoder_layers):
+                # host snapshot [1, CHUNK, emb] (SP-seq + TP-hidden concatenated); [0] -> [CHUNK, emb].
+                out_flat = layer_outputs[f"layer_{i}"][0].to(torch.float32)
+                natural = torch.zeros(isl, emb_dim, dtype=torch.float32)
+                natural[dst] = out_flat[src]  # un-rotate valid rows -> natural [ks, e)
+                ref = _ref_layer_slice(trace_dir, layout, i, ks, e)
+                _, pcc = comp_pcc(ref, natural)
+                layer_min_pcc[i] = min(layer_min_pcc[i], pcc)
+                logger.info(f"  chunk {c} (kv_actual={ks} isl={isl}) layer {i} decoder PCC: {pcc:.6f}")
+                if pcc < LAYER_PCC_THRESHOLD:
+                    logger.warning(f"  chunk {c} layer {i} decoder PCC {pcc:.6f} below {LAYER_PCC_THRESHOLD}")
+        ttnn.synchronize_device(mesh_device)
+
+        logger.info("[padded-trace] NOTRACE per-layer min decoder-output PCC across chunks:")
+        for i in range(n_decoder_layers):
+            logger.info(f"  layer {i}: {layer_min_pcc[i]:.6f}")
+        if layer_min_pcc:
+            decoder_min = min(layer_min_pcc.values())
+            logger.info(f"[padded-trace] NOTRACE decoder-output min PCC across all layers = {decoder_min:.6f}")
+            # FULL DEPTH, not gated to GATED_LAYER_DEPTH: this mirrors run_chunked_transformer_padded,
+            # which asserts min decoder PCC over every layer and runs at L61 in the Blaze CI job — so a
+            # full-depth decoder bar is known stable. The KV check below deliberately stays gated: deep
+            # KV PCC is the quantity with unpinned accumulation headroom (and a known L61 run-to-run
+            # spread), not the decoder output.
+            assert (
+                decoder_min >= LAYER_PCC_THRESHOLD
+            ), f"decoder-output min PCC {decoder_min:.6f} < {LAYER_PCC_THRESHOLD}"
+
+        logger.info("[padded-trace] SCALAR path done; recording per-layer KV PCC vs GOLDEN")
+        _record_kv_cache_pcc(
+            trace_dir,
+            layout,
+            cache,
+            mesh_device,
+            sp,
+            num_layers,
+            seq_len_cache,
+            total_len,
+            config.kv_lora_rank,
+            assert_threshold=LAYER_PCC_THRESHOLD,
+            assert_layer_depth=(GATED_LAYER_DEPTH if num_layers > GATED_LAYER_DEPTH else None),
+        )
+        ttnn.deallocate(cache.storage)
+        transformer.release_sub_device_managers()
+        logger.success("[padded-trace] SCALAR run complete (asserted vs golden)")
+        return
+
+    # ---- METADATA modes (eager / traced): on-device per-split scalars, asserted vs GOLDEN. ----
+    cache_B = _make_cache()  # persistent (captured) cache
+    trace_input = ttnn.from_torch(
+        chunk_tok_host[0],
+        device=mesh_device,
+        dtype=ttnn.uint32,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        mesh_mapper=sp_mapper,
+    )
+
+    # Per-element-tensor metadata: 3 persistent 1-element tensors (slot_id, actual_start, actual_end).
+    def _meta1_dev(val):
+        return ttnn.from_torch(
+            torch.tensor([val], dtype=torch.int64).reshape(1, 1, 1, 1),
+            device=mesh_device,
+            dtype=ttnn.uint32,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            mesh_mapper=rep_mapper,
+        )
+
+    def _meta1_host(val):
+        return ttnn.from_torch(
+            torch.tensor([val], dtype=torch.int64).reshape(1, 1, 1, 1),
+            dtype=ttnn.uint32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            mesh_mapper=rep_mapper,
+        )
+
+    trace_metadata = (_meta1_dev(0), _meta1_dev(starts[0][0]), _meta1_dev(starts[0][1]))
+    tok_host_tt = [
+        ttnn.from_torch(t, dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT, mesh_mapper=sp_mapper)
+        for t in chunk_tok_host
+    ]
+    meta_host_tt = [(_meta1_host(0), _meta1_host(ks), _meta1_host(e)) for (ks, e) in starts]
+
+    def _fwd_meta():
+        transformer.forward(
+            trace_input,
+            cache_B,
+            actual_isl=CHUNK,
+            actual_start=None,
+            actual_end=None,
+            cache_user_id=0,
+            metadata=trace_metadata,
+        )
+
+    # Metadata execution mode (pytest param `mode`). "traced" captures the metadata forward ONCE and
+    # replays it per split (the traced-metadata path). "eager" runs the SAME metadata forward EAGERLY
+    # per split (no capture/replay). ("scalar" mode returned above and never reaches here.)
+    _PADDED_TRACE = mode == "traced"
+    if _PADDED_TRACE:
+        controller = SubDeviceTraceController(mesh_device)
+        transformer.set_trace_controller(controller)
+        _fwd_meta()  # warmup (compile metadata program variants)
+        ttnn.synchronize_device(mesh_device)
+        logger.info(f"[padded-trace] TRACED metadata: capturing {num_layers}-layer forward...")
+        controller.begin_capture()
+        _fwd_meta()
+        controller.end_capture()
+        ttnn.synchronize_device(mesh_device)
+        logger.info(f"[padded-trace] {controller.num_segments} segments, {controller.trace_bytes()/1024/1024:.2f} MB")
+        # Prove we are actually testing the traced path. Without this, a capture that recorded nothing
+        # would still "pass": every replay would be a no-op, the KV cache would keep whatever the warm
+        # pass left in it, and the KV PCC below would compare that stale-but-correct data against the
+        # golden and succeed — a green run that exercised no trace at all.
+        assert controller.num_segments > 0, "traced mode captured 0 segments — nothing was recorded to replay"
+
+        for c, (ks, e) in enumerate(starts):
+            ttnn.copy_host_to_device_tensor(tok_host_tt[c], trace_input)
+            for src, dst in zip(meta_host_tt[c], trace_metadata):
+                ttnn.copy_host_to_device_tensor(src, dst)
+            controller.replay()
+        ttnn.synchronize_device(mesh_device)
+        controller.release()
+        transformer.set_trace_controller(None)
+    else:
+        logger.info("[padded-trace] EAGER metadata (eager mode): per-split forward, no capture")
+        for c, (ks, e) in enumerate(starts):
+            ttnn.copy_host_to_device_tensor(tok_host_tt[c], trace_input)
+            for src, dst in zip(meta_host_tt[c], trace_metadata):
+                ttnn.copy_host_to_device_tensor(src, dst)
+            _fwd_meta()
+        ttnn.synchronize_device(mesh_device)
+    ttnn.deallocate(trace_input)
+    for t in trace_metadata:
+        ttnn.deallocate(t)
+    logger.info(f"[padded-trace] {mode} metadata path done; recording per-layer KV PCC vs GOLDEN")
+    _record_kv_cache_pcc(
+        trace_dir,
+        layout,
+        cache_B,
+        mesh_device,
+        sp,
+        num_layers,
+        seq_len_cache,
+        total_len,
+        config.kv_lora_rank,
+        assert_threshold=LAYER_PCC_THRESHOLD,
+        assert_layer_depth=(GATED_LAYER_DEPTH if num_layers > GATED_LAYER_DEPTH else None),
+    )
+    transformer.release_sub_device_managers()
+    logger.success(f"[padded-trace] {mode} metadata run complete (asserted vs golden)")

--- a/models/demos/deepseek_v3_d_p/tt/mla/mla.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/mla.py
@@ -685,12 +685,26 @@ class ttMLA:
             exp_approx_mode=False,
         )
 
-    def _apply_rope_padded(self, t: ttnn.Tensor, rope_tensors: dict, kv_actual_isl: int) -> ttnn.Tensor:
+    def _apply_rope_padded(
+        self, t: ttnn.Tensor, rope_tensors: dict, kv_actual_isl: int, metadata: Optional[ttnn.Tensor] = None
+    ) -> ttnn.Tensor:
         """Chunked rotated RoPE via the indexed op. rope_tensors carry the whole-cache,
         block-cyclic-sharded cos/sin (built once via RotarySetup.get_rope_tensors_indexed); the op
         derives this chunk's per-chip shard offset on-device from kv_actual_global -- the same
         update_idxt math the KV-cache writer uses, keeping rotation and cache write consistent.
+
+        Per-element-tensor (trace-safe) path: `metadata` is a 3-tuple of 1-element uint32 tensors
+        (slot_id, actual_start, actual_end); rope reads kv_actual_global = actual_start = metadata[1].
         """
+        if metadata is not None:
+            return ttnn.experimental.deepseek_prefill.rotary_embedding_indexed(
+                t,
+                rope_tensors["cos_matrix"],
+                rope_tensors["sin_matrix"],
+                rope_tensors["trans_matrix"],
+                metadata[1],  # actual_start = kv_actual_global (1-element tensor)
+                cluster_axis=self.sp_axis,
+            )
         return ttnn.experimental.deepseek_prefill.rotary_embedding_indexed(
             t,
             rope_tensors["cos_matrix"],
@@ -701,9 +715,14 @@ class ttMLA:
         )
 
     def _apply_rope_one_shot(
-        self, t: ttnn.Tensor, rope_tensors: dict, kv_actual_isl: Optional[int] = None
+        self,
+        t: ttnn.Tensor,
+        rope_tensors: dict,
+        kv_actual_isl: Optional[int] = None,
+        metadata: Optional[ttnn.Tensor] = None,
     ) -> ttnn.Tensor:
-        """Single-shot RoPE: natural-order rope_tensors + rotary_embedding_llama."""
+        """Single-shot RoPE: natural-order rope_tensors + rotary_embedding_llama. (metadata unused --
+        single-shot has no chunked rotation; accepted so callers can pass it uniformly.)"""
         return ttnn.experimental.rotary_embedding_llama(
             t,
             rope_tensors["cos_matrix"],
@@ -723,6 +742,7 @@ class ttMLA:
         cache_layer_idx: int,
         cache_user_id: int,
         seq_len_local: int,
+        metadata: Optional[ttnn.Tensor] = None,
     ) -> ttnn.Tensor:
         """Chunked-prefill attention via update_padded_kv_cache + ring_mla.
 
@@ -741,29 +761,50 @@ class ttMLA:
             f"chunk_size_global ({chunk_size_global}) must be a multiple of "
             f"TILE_SIZE * sp_factor ({tile_size * self.sp_factor})"
         )
-        assert kv_actual_isl % tile_size == 0, f"kv_actual_isl ({kv_actual_isl}) must be tile-aligned"
+        # Metadata path: kv_actual_isl is read on-device from metadata[1] and may be omitted host-side.
+        assert (
+            metadata is not None or kv_actual_isl % tile_size == 0
+        ), f"kv_actual_isl ({kv_actual_isl}) must be tile-aligned"
 
         # Write this chunk into the cache. update_padded_kv_cache derives each chip's local write
         # offset on-device from kv_actual_global (chunk-aligned kv_actual -> uniform per-chip write).
-        ttnn.experimental.deepseek_prefill.update_padded_kv_cache(
-            kvpe_cache.storage,
+        # Metadata (trace-safe) path reads slot_idx/kv_actual_global on-device from the metadata tensor.
+        self._update_kv_cache(
+            kvpe_cache,
             tt_kvpe,
-            slot_idx=cache_user_id,
-            layer_idx=cache_layer_idx,
-            num_layers=self.layer_num,
-            kv_actual_global=kv_actual_isl,
-            cluster_axis=self.sp_axis,
+            cache_user_id=cache_user_id,
+            cache_layer_idx=cache_layer_idx,
+            kv_actual_isl=kv_actual_isl,
+            metadata=metadata,
         )
 
         # K and V are the single latent kvpe cache (V = first kv_lora_rank columns, materialized
         # in-op). logical_n = prior valid length + this chunk; cache_batch_idx selects this
         # user/layer's slot; kv_actual_isl drives the on-device rotation/causality offset.
+        #
+        # Trace-safe metadata path: ring_mla reads its per-chunk scalars on-device -- the all-gather +
+        # SDPA readers take the cache slot from metadata[0] and derive logical_nt / masks from
+        # kv_actual_isl = metadata[1]. Every kernel derives logical_n on-device on this path, so the host
+        # logical_n is a placeholder = global cache capacity. metadata[0] holds only the user slot, so pass
+        # the per-layer factor (kv_cache_num_layers/kv_cache_layer_idx) so the readers recompute the full
+        # (user, layer) slot on-device -- otherwise every layer would read layer 0's KV cache.
+        if metadata is not None:
+            meta_slot_kwargs = {
+                "slot_id": metadata[0],
+                "kv_actual_isl_tensor": metadata[1],
+                "kv_cache_num_layers": self.layer_num,
+                "kv_cache_layer_idx": cache_layer_idx,
+            }
+            ring_logical_n = kvpe_cache.storage.shape[2] * self.sp_factor  # global cache capacity
+        else:
+            meta_slot_kwargs = {"kv_cache_batch_idx": cache_batch_idx, "kv_actual_isl": kv_actual_isl}
+            ring_logical_n = kv_actual_isl + chunk_size_global
         attn_out, _ = ttnn.transformer.ring_mla(
             tt_q,
             kvpe_cache.storage,
             persistent_output_buffer_kv=self._chunked_kv_buf,
             head_dim_v=self.kv_lora_rank,
-            logical_n=kv_actual_isl + chunk_size_global,
+            logical_n=ring_logical_n,
             program_config=self._get_sdpa_program_config(seq_len_local),
             scale=self.scale,
             compute_kernel_config=self.default_compute_kernel_config,
@@ -776,8 +817,7 @@ class ttMLA:
             ccl_core_grid_offset=self.tt_ccl.ring_attention_ccl_core_grid_offset,
             use_column_major_ccl=True,
             is_balanced=self.is_balanced,
-            kv_cache_batch_idx=cache_batch_idx,
-            kv_actual_isl=kv_actual_isl,
+            **meta_slot_kwargs,
         )
 
         # ring_mla output is in kv_lora_rank (latent V) space; expand to v_head_dim per head. Unlike the
@@ -845,6 +885,7 @@ class ttMLA:
         rope_tensors: dict,
         kv_actual_isl: Optional[int],
         seq_len_local: int,
+        metadata: Optional[ttnn.Tensor] = None,
     ) -> ttnn.Tensor:
         """Absorbed-Q stem from the q_a latent: q_b_proj → heads → split → wkv_b1(nope) → RoPE(rope)
         → concat. Consumes qr (the indexer, if any, has already read it by this point)."""
@@ -881,7 +922,7 @@ class ttMLA:
             **self._get_mm_kwargs("wkv_b1", seq_len_local),
         )
 
-        tt_q_rope = self._apply_rope(tt_q_rope, rope_tensors, kv_actual_isl)
+        tt_q_rope = self._apply_rope(tt_q_rope, rope_tensors, kv_actual_isl, metadata=metadata)
 
         # TODO: concat rope and nope, workaround remove with ttnn.narrow or fusion
         tt_q = ttnn.concat([tt_q_nope, tt_q_rope], dim=-1)
@@ -897,6 +938,7 @@ class ttMLA:
         seq_len_local: int,
         return_kv_intermediates: bool,
         kvpe_cache: MlaKvCache,
+        metadata: Optional[ttnn.Tensor] = None,
     ) -> tuple[ttnn.Tensor, Optional[ttnn.Tensor], dict | None]:
         """Shared KV stem.
 
@@ -945,7 +987,7 @@ class ttMLA:
             compute_kernel_config=self.default_compute_kernel_config,
         )
 
-        tt_kv_rope = self._apply_rope(tt_kv_rope, rope_tensors, kv_actual_isl)
+        tt_kv_rope = self._apply_rope(tt_kv_rope, rope_tensors, kv_actual_isl, metadata=metadata)
 
         if return_kv_intermediates:
             # post-RMSNorm latent ([.., 512]) and post-RoPE k_pe ([.., 64]); clone before concat.
@@ -991,16 +1033,30 @@ class ttMLA:
         cache_user_id: int,
         cache_layer_idx: int,
         kv_actual_isl: int,
+        metadata: Optional[ttnn.Tensor] = None,
     ) -> None:
-        ttnn.experimental.deepseek_prefill.update_padded_kv_cache(
-            cache.storage,
-            values,
-            slot_idx=cache_user_id,
-            layer_idx=cache_layer_idx,
-            num_layers=self.layer_num,
-            kv_actual_global=kv_actual_isl,
-            cluster_axis=self.sp_axis,
-        )
+        # Metadata (trace-safe) path: slot_idx (metadata[0]) + kv_actual_global (metadata[1]) read
+        # on-device, each its own 1-element tensor. Scalar path passes host slot/kv_actual_global.
+        if metadata is not None:
+            ttnn.experimental.deepseek_prefill.update_padded_kv_cache(
+                cache.storage,
+                values,
+                metadata[0],  # slot_idx tensor
+                metadata[1],  # kv_actual_global tensor
+                layer_idx=cache_layer_idx,
+                num_layers=self.layer_num,
+                cluster_axis=self.sp_axis,
+            )
+        else:
+            ttnn.experimental.deepseek_prefill.update_padded_kv_cache(
+                cache.storage,
+                values,
+                slot_idx=cache_user_id,
+                layer_idx=cache_layer_idx,
+                num_layers=self.layer_num,
+                kv_actual_global=kv_actual_isl,
+                cluster_axis=self.sp_axis,
+            )
 
     def _o_proj_epilogue(self, attn_out: ttnn.Tensor, seq_len_local: int) -> ttnn.Tensor:
         """Shared nlp_concat_heads -> o_proj -> TP reduce-scatter epilogue."""
@@ -1038,11 +1094,18 @@ class ttMLA:
         index_kv_cache: Optional[ttnn.Tensor] = None,
         indexer_indices: Optional[ttnn.Tensor] = None,
         return_indexer_indices: bool = False,
+        metadata: Optional[ttnn.Tensor] = None,
     ) -> "ttnn.Tensor | tuple[ttnn.Tensor, Optional[dict]]":
+        # Trace-safe metadata path: a 3-tuple of 1-element uint32 DRAM tensors (slot_id, actual_start,
+        # actual_end) passed in from outside. When provided, the chunked-prefill ops (update_padded_kv_cache,
+        # rotary_embedding_indexed, ring_mla) read their per-chunk scalars on-device from it instead of from
+        # host actual_start/cache_user_id. Threaded through verbatim -- ttMLA never reads/reconstructs it.
+        #
         # Chunked-prefill mode is fixed at construction: self.is_chunked drives buffer allocation in
         # __init__ and the rope variant, and forward honors that flag -- it does not infer the mode from
-        # the arguments. actual_start is the chunk parameter, supplied iff chunked.
-        assert (actual_start is not None) == self.is_chunked, (
+        # the arguments. actual_start is the chunk parameter, supplied iff chunked (EXCEPT the metadata
+        # path, where the per-chunk scalars are read on-device and host actual_start may be None).
+        assert metadata is not None or (actual_start is not None) == self.is_chunked, (
             f"actual_start ({'set' if actual_start is not None else 'None'}) does not match construction "
             f"(self.is_chunked={self.is_chunked}); pass actual_start iff built with is_chunked=True"
         )
@@ -1058,6 +1121,7 @@ class ttMLA:
                 kv_actual_isl=actual_start or 0,
                 cache_user_id=cache_user_id,
                 index_kv_cache=index_kv_cache,
+                metadata=metadata,
             )
 
         seq_len_local = hidden_states.shape[2]
@@ -1106,7 +1170,7 @@ class ttMLA:
             )
         )
 
-        tt_q = self._q_stem(qr, rope_tensors, kv_actual_isl, seq_len_local)
+        tt_q = self._q_stem(qr, rope_tensors, kv_actual_isl, seq_len_local, metadata=metadata)
         tt_kvpe, tt_kv_nope, kv_intermediates = self._kv_stem(
             hidden_states,
             rope_tensors,
@@ -1114,6 +1178,7 @@ class ttMLA:
             seq_len_local,
             return_kv_intermediates,
             kvpe_cache,
+            metadata=metadata,
         )
 
         attn_out = self._attention(
@@ -1126,6 +1191,7 @@ class ttMLA:
             cache_user_id=cache_user_id,
             seq_len_local=seq_len_local,
             kv_actual_isl=kv_actual_isl,
+            metadata=metadata,
         )
 
         out = self._o_proj_epilogue(attn_out, seq_len_local)
@@ -1192,6 +1258,7 @@ class ttMLA:
         cache_layer_idx,
         cache_user_id,
         seq_len_local,
+        metadata=None,
         **_,
     ):
         cache_batch_idx = self._cache_batch_idx(cache_user_id, cache_layer_idx)
@@ -1204,6 +1271,7 @@ class ttMLA:
             cache_layer_idx=cache_layer_idx,
             cache_user_id=cache_user_id,
             seq_len_local=seq_len_local,
+            metadata=metadata,
         )
 
     def _sparse_chunked_attn(
@@ -1262,6 +1330,7 @@ class ttMLA:
         kv_actual_isl: int,
         cache_user_id: int,
         index_kv_cache: Optional[ttnn.Tensor],
+        metadata: Optional[ttnn.Tensor] = None,
     ) -> None:
         """Last-layer fast path: fill the migratable KVPE cache, then stop before query/attention/output.
 
@@ -1296,6 +1365,7 @@ class ttMLA:
             seq_len_local,
             return_kv_intermediates=False,
             kvpe_cache=kvpe_cache,
+            metadata=metadata,
         )
         if tt_kv_nope is not None:
             ttnn.deallocate(tt_kv_nope)
@@ -1308,6 +1378,7 @@ class ttMLA:
             cache_user_id=cache_user_id,
             cache_layer_idx=cache_layer_idx,
             kv_actual_isl=kv_actual_isl,
+            metadata=metadata,
         )
         ttnn.deallocate(tt_kvpe)
 

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_moe.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_moe.py
@@ -211,6 +211,7 @@ class TtMoe(LightweightModule):
         self.seq_len_per_chip = seq_len_per_chip
         self.emb_dim = emb_dim
         self.hidden_dim = hidden_dim
+
         # Unpack row/col CCL config
         if isinstance(num_links, tuple):
             self.row_num_links, self.col_num_links = num_links
@@ -223,6 +224,10 @@ class TtMoe(LightweightModule):
             self.row_topology = self.col_topology = topology
 
         self.overlap_shared_expert_with_dispatch = overlap_shared_expert_with_dispatch
+        # Optional SubDeviceTraceController (capture phase): the shared-expert/dispatch overlap's
+        # sub-device load/clear go through it so the trace can be split at those boundaries instead of
+        # resetting worker state mid-capture. None => load/clear the mesh device directly.
+        self._trace_controller = None
 
         # The shared expert, WHEN OVERLAPPED with dispatch, runs on disjoint Tensix sub-devices that
         # still SHARE the EDM fabric routers. In that case its TP-axis reduce-scatter must stay Linear
@@ -438,6 +443,20 @@ class TtMoe(LightweightModule):
 
         logger.debug("TtMoe initialization complete")
 
+    def set_trace_controller(self, controller):
+        """Attach (or clear with None) a SubDeviceTraceController. While set, the shared-expert/
+        dispatch overlap routes its sub-device load/clear through the controller so a ttnn trace can
+        be split at those boundaries (see utils/sub_device_trace.py)."""
+        self._trace_controller = controller
+
+    def release_sub_device_manager(self):
+        """Remove the overlap sub-device manager this MoE created (no-op if overlap is off). Call
+        before closing the mesh device — leaving managers registered at close has been observed to
+        segfault the teardown. Idempotent."""
+        if getattr(self, "sd_manager_id", None) is not None:
+            self.mesh_device.remove_sub_device_manager(self.sd_manager_id)
+            self.sd_manager_id = None
+
     def forward(
         self,
         x: ttnn.Tensor,
@@ -445,6 +464,7 @@ class TtMoe(LightweightModule):
         actual_isl: int = None,
         padding_side: str = "right",
         actual_start: Optional[int] = None,
+        metadata: Optional[tuple] = None,
     ) -> tuple[ttnn.Tensor, Optional[TtMoEIntermediates]]:
         """
         Forward pass through the full MoE pipeline.
@@ -454,12 +474,21 @@ class TtMoe(LightweightModule):
                - For 2D mesh: sharded dims=(0, -1) - dim 0 across axis 0, dim -1 across axis 1
                - Shape per device: (dispatch_group_size/axis0, seq_len_per_chip, emb_dim/axis1)
             return_intermediates: If True, return intermediate tensors for debugging
-            actual_isl: Actual ISL of the sequence (None = no padding)
+            actual_isl: Actual ISL of the sequence (None = no padding). Doubles as the padding-config
+                GUARD: not-None enables padding awareness. On the traced path (`metadata` set) that is
+                its ONLY role — pass the full chunk, since the real per-chunk bound is read on-device
+                from the metadata tensors and this value is unused.
             padding_side: Padding side of the sequence
             actual_start: chunked-prefill absolute KV position of this chunk's first real token
                 (None/0 = single-shot, sequential SP layout). Required for correct per-chip real-token
                 counts: chunked prefill feeds the KV-pad-aware ROTATED block-cyclic layout, where a
                 chip's real rows are NOT its slice of the natural sequence. See build_padding_config.
+            metadata: the traced path's (slot_id, actual_start, actual_end) tuple of 1-element uint32
+                device tensors. When given, the padding config is built ON DEVICE from them
+                (build_padding_config_device) instead of on host — the host builder's from_torch is
+                illegal inside a trace capture, and a config baked in at capture time would be wrong
+                for every later chunk. Ignored unless padding awareness is active (actual_isl set and
+                a DEVICE_FP32 gate).
 
         Returns:
             Tuple of (final_output, intermediates):
@@ -480,6 +509,12 @@ class TtMoe(LightweightModule):
         # gate modes) are dispatched first, so a shortened bound could drop real tokens.
         # Disable padding awareness for left padding and process the full (always-correct)
         # token range by clearing actual_isl for the rest of this forward.
+        #
+        # Under trace this stays ON: the captured (metadata) forward always passes the FULL chunk as
+        # actual_isl, so build_padding_config yields a single full-range config that the memoization
+        # below builds once during warm-up — the replayed command stream contains no host transfer.
+        # Only the eager/scalar paths pass a partial actual_isl, and that is the rotated-padded path
+        # #51440 fixed.
         if actual_isl is not None and padding_side != "right":
             logger.warning(
                 "[TtMoe.forward] padding-aware MoE is only supported for right padding; "
@@ -493,9 +528,30 @@ class TtMoe(LightweightModule):
         # actually sentinel-marks padded tokens so routing_setup/combine stay consistent
         # with a shortened dispatch loop. In other gate modes padded tokens keep real
         # expert indices, so dispatch must process the full range -> padding_config=None.
+        #
+        # NOTE on `actual_isl` in this guard: it plays two DIFFERENT roles depending on the path.
+        #   * eager/scalar: it is BOTH the guard (not-None => padding awareness on) AND the actual
+        #     bound handed to the host builder below.
+        #   * traced (metadata set): it is ONLY the guard. The real per-chunk bound is read on-device
+        #     from the metadata tensors, so the caller passes the FULL chunk here (see
+        #     TtPrefillRuntime._forward_traced, actual_isl=chunk_size) purely to say "padding
+        #     awareness is ON" — its VALUE is deliberately unused. That is what keeps the guard
+        #     itself trace-safe: it is a static, capture-time decision (one captured program either
+        #     has the padding-aware ops or it does not), while the values that change per chunk stay
+        #     on-device. A caller that wanted padding awareness OFF under trace would pass
+        #     actual_isl=None and get a capture with no padding-aware path at all.
         padding_config = None
         if actual_isl is not None and self.gate.fallback_mode == GateComputeMode.DEVICE_FP32:
-            padding_config = self.gate.build_padding_config(actual_isl, padding_side, actual_start or 0)
+            if metadata is not None:
+                # Traced path: the per-chunk scalars live on-device in the metadata tensors, so build
+                # the config with the device op. The host builder's from_torch cannot run inside a
+                # capture, and a config baked in at capture time would be wrong for every later chunk.
+                # `actual_isl` is NOT forwarded here — only the guard above consumed it; the op derives
+                # the real bound from actual_start/actual_end itself.
+                # Raises for is_balanced=True (not expressible in the op's closed form).
+                padding_config = self.gate.build_padding_config_device(metadata, padding_side)
+            else:
+                padding_config = self.gate.build_padding_config(actual_isl, padding_side, actual_start or 0)
 
         scores, indices, gate_logits = self.gate(
             ttnn.view(x, (x.shape[0] * x.shape[1], x.shape[2])),
@@ -562,7 +618,10 @@ class TtMoe(LightweightModule):
 
         signpost("shared_expert_and_dispatch_start")
         if self.overlap_shared_expert_with_dispatch:
-            self.mesh_device.load_sub_device_manager(self.sd_manager_id)
+            if self._trace_controller is not None:
+                self._trace_controller.sub_device_load(self.sd_manager_id)
+            else:
+                self.mesh_device.load_sub_device_manager(self.sd_manager_id)
 
         # ========================================
         # Step 1: Shared expert (enabled)
@@ -588,11 +647,14 @@ class TtMoe(LightweightModule):
             padding_config=padding_config,
         )
         if self.overlap_shared_expert_with_dispatch:
-            self.mesh_device.clear_loaded_sub_device_manager()
-        # padding_config was shared with both the gate and dispatch; free it now that
-        # dispatch (its last consumer) has been issued.
-        if padding_config is not None:
-            ttnn.deallocate(padding_config)
+            if self._trace_controller is not None:
+                self._trace_controller.sub_device_clear()
+            else:
+                self.mesh_device.clear_loaded_sub_device_manager()
+        # NOTE: padding_config is memoized + owned by the gate (build_padding_config caches it per
+        # actual_isl so a captured trace's replay reuses the same device tensor instead of re-issuing a
+        # host from_torch). Do NOT deallocate it here — it is reused across forwards/replays; freeing it
+        # would leave the cache holding a deallocated tensor (next forward's cache hit fails is_allocated()).
         x = ttnn.deallocate(x)
         scores = ttnn.to_memory_config(scores, ttnn.DRAM_MEMORY_CONFIG)
         indices = ttnn.to_memory_config(indices, ttnn.DRAM_MEMORY_CONFIG)

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_moe_gate_prefill.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_moe_gate_prefill.py
@@ -313,6 +313,15 @@ class TtMoEGatePrefill(LightweightModule):
         self.tt_ccl = get_tt_ccl(mesh_device)
         self.fallback_mode = fallback_mode
         self.is_balanced = is_balanced
+        # Memoization of the per-(actual_isl, padding_side, actual_start) padding_config built on HOST.
+        # build_padding_config ends in a ttnn.from_torch, so re-issuing it per chunk costs a host
+        # transfer; caching the device tensor avoids that. Owned here => callers must NOT deallocate it.
+        self._padding_config_cache: dict = {}
+        # Persistent output row for the DEVICE-built padding config (build_padding_config_device). A
+        # host from_torch is illegal inside a trace capture, so the traced path derives the config
+        # on-device instead and refreshes THIS buffer in place — a stable address the capture can keep
+        # writing across replays. Allocated lazily on first use (warm-up, before any capture).
+        self._padding_config_device: Optional[ttnn.Tensor] = None
 
         if weight is not None and bias is not None:
             weights = self._convert_and_cache_gate_weights(
@@ -608,6 +617,16 @@ class TtMoEGatePrefill(LightweightModule):
         if padding_side not in ("right", "left"):
             raise ValueError(f"padding_side must be 'right' or 'left', got {padding_side!r}")
 
+        # actual_start MUST be part of the key: under rotated chunked prefill the per-chip real-token
+        # counts are derived from it (rotated_chip_real_token_counts below), so two chunks with the same
+        # actual_isl but different starts need different configs. Keying on (actual_isl, padding_side)
+        # alone returned the first chunk's config for every later chunk of equal length, sentinel-marking
+        # real tokens and dispatching pad rows as real.
+        cache_key = (actual_isl, padding_side, actual_start or 0)
+        cached = self._padding_config_cache.get(cache_key)
+        if cached is not None:
+            return cached
+
         sp_factor = self.mesh_device.shape[0]
         seq_len_per_chip = self.config.sp_dim
         total_tokens = sp_factor * seq_len_per_chip
@@ -662,7 +681,7 @@ class TtMoEGatePrefill(LightweightModule):
 
                 padding_config.append([local_real_tokens, pad_side])
 
-        return ttnn.from_torch(
+        config_tensor = ttnn.from_torch(
             torch.tensor(padding_config, dtype=torch.int32),
             device=self.mesh_device,
             dtype=ttnn.uint32,
@@ -673,6 +692,68 @@ class TtMoEGatePrefill(LightweightModule):
                 dims=(0, None),
                 mesh_shape=self.mesh_device.shape,
             ),
+        )
+        self._padding_config_cache[cache_key] = config_tensor
+        return config_tensor
+
+    def build_padding_config_device(self, metadata, padding_side: str = "right") -> ttnn.Tensor:
+        """Trace-safe twin of build_padding_config: derive the per-device
+        ``[local_real_tokens, pad_side]`` row ON DEVICE from this chunk's metadata tensors.
+
+        The host builder ends in a ``ttnn.from_torch``, which is an illegal host->device write inside a
+        trace capture, so a captured program can only ever replay the config of the chunk it was
+        captured with. This path instead hands the op the two 1-element uint32 tensors the runtime
+        already advances per chunk, and the kernel recomputes the row on-device — so one capture
+        replays correctly across chunks with padding awareness left ON.
+
+        ``metadata`` is the runtime's ``(slot_id, actual_start, actual_end)`` tuple; only actual_start
+        and actual_end are read (the count needs no separate ISL — valid_end == actual_end).
+
+        The output is a persistent buffer allocated once here and refreshed in place, so its address is
+        stable across replays. Owned here => callers must NOT deallocate it.
+
+        is_balanced=True is rejected: the zigzag per-device count is not expressible in the op's
+        closed form. Rotated chunked prefill implies is_balanced=False (ttMLA._chunked_attn asserts
+        it), so a traced run can never legitimately need it — fail loudly rather than silently
+        compute a wrong config.
+        """
+        if padding_side not in ("right", "left"):
+            raise ValueError(f"padding_side must be 'right' or 'left', got {padding_side!r}")
+        if self.is_balanced:
+            raise ValueError(
+                "build_padding_config_device (the traced padding-config path) does not support "
+                "is_balanced=True: the zigzag placement's per-device real-token count is not "
+                "expressible in the device op's closed form. Run with is_balanced=False, or run "
+                "untraced so the host builder (build_padding_config) handles the balanced layout."
+            )
+
+        sp_factor = self.mesh_device.shape[0]
+        if self._padding_config_device is None:
+            # Allocate the persistent row once. Same spec the host builder produces, so the consumers
+            # (moe_grouped_topk / dispatch) see an identical tensor either way.
+            self._padding_config_device = ttnn.from_torch(
+                torch.zeros((sp_factor, 2), dtype=torch.int32),
+                device=self.mesh_device,
+                dtype=ttnn.uint32,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+                mesh_mapper=ttnn.ShardTensor2dMesh(
+                    self.mesh_device,
+                    dims=(0, None),
+                    mesh_shape=self.mesh_device.shape,
+                ),
+            )
+
+        _, actual_start, actual_end = metadata
+        return ttnn.experimental.deepseek_prefill.moe_padding_config(
+            self._padding_config_device,
+            actual_start,
+            actual_end,
+            tokens_per_chip=self.config.sp_dim,
+            pad_side=0 if padding_side == "right" else 1,
+            # SP is mesh axis 0 — the same axis sp_factor is read from above and that the config is
+            # sharded along, so the op's per-chip coordinate matches the host builder's row order.
+            cluster_axis=0,
         )
 
     def _device_grouped_gate_fp32(
@@ -694,9 +775,10 @@ class TtMoEGatePrefill(LightweightModule):
         combine skip them.  For SP > 1, the padding config tensor carries
         per-device local real-token counts.
 
-        If a caller-owned ``padding_config`` is provided it is used as-is (and the
-        caller is responsible for deallocating it, since it may be shared with the
-        dispatch op). Otherwise one is built locally and freed here.
+        A caller-supplied ``padding_config`` is used as-is; otherwise one is fetched from
+        build_padding_config. Either way the tensor is owned by build_padding_config's memo cache
+        (it is reused across forwards and trace replays), so neither this method nor the caller
+        deallocates it.
         """
         owns_padding_config = padding_config is None
         if owns_padding_config:
@@ -720,8 +802,8 @@ class TtMoEGatePrefill(LightweightModule):
             score_func=self.config.score_func,
             padding_config=padding_config,
         )
-        if owns_padding_config and padding_config is not None:
-            ttnn.deallocate(padding_config)
+        # padding_config is memoized + owned by build_padding_config (reused across forwards/replays). Do
+        # NOT deallocate it here even on the owns_padding_config path — freeing it breaks the next cache hit.
         return ttnn_scores, ttnn_top_k_experts_indices
 
     def _device_hash_gate(
@@ -762,8 +844,8 @@ class TtMoEGatePrefill(LightweightModule):
         )
         ttnn.deallocate(logits_f32)
         ttnn.deallocate(input_ids_dev)
-        if owns_padding_config and padding_config is not None:
-            ttnn.deallocate(padding_config)
+        # padding_config is memoized + owned by build_padding_config (reused across forwards/replays). Do
+        # NOT deallocate it here even on the owns_padding_config path — freeing it breaks the next cache hit.
         return ttnn_scores, ttnn_top_k_experts_indices
 
     def _host_grouped_gate(self, host_logits: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:

--- a/models/demos/deepseek_v3_d_p/tt/runners/adapters/mla.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/adapters/mla.py
@@ -141,6 +141,8 @@ class MLAPrefillAdapter(PrefillModelAdapter):
             kv_only_last_layer=params.kv_only_last_layer,
             routing_use_l1_small_for_semaphores=self.routing_use_l1_small_for_semaphores,
             sparse_kv_cache_format=self.resolve_sparse_kv_cache_format(params.sparse_kv_cache_format),
+            use_trace=params.use_trace,
+            overlap_shared_expert_with_dispatch=params.overlap_shared_expert_with_dispatch,
         )
         return TtPrefillRuntime(
             mesh_device=mesh_device,

--- a/models/demos/deepseek_v3_d_p/tt/tt_prefill_block.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_prefill_block.py
@@ -227,9 +227,14 @@ class TtPrefillBlock(LightweightModule):
         kv_only: bool = False,
         routing_use_l1_small_for_semaphores: bool = False,
         sparse_kv_cache_format: MlaKvCacheFormat = MlaKvCacheFormat.BF16_RM,
+        overlap_shared_expert_with_dispatch: bool = True,
     ):
         super().__init__()
         self.routing_use_l1_small_for_semaphores = routing_use_l1_small_for_semaphores
+        # Overlap the shared expert with dispatch via a sub-device manager (default). Must be False
+        # for ttnn trace capture: load/clear_sub_device_manager resets worker state inside forward,
+        # which begin_trace_capture forbids.
+        self.overlap_shared_expert_with_dispatch = overlap_shared_expert_with_dispatch
         # In chunked prefill the flat KV-cache slot is cache_user_id * layer_num + cache_layer_idx, so
         # layer_num must be the model's actual layer count — there is no safe default to fall back to.
         assert not is_chunked or layer_num is not None, "chunked prefill requires layer_num (model layer count)"
@@ -332,6 +337,7 @@ class TtPrefillBlock(LightweightModule):
                 dispatch_buffer_capacity_factor=dispatch_buffer_capacity_factor,
                 routing_use_l1_small_for_semaphores=routing_use_l1_small_for_semaphores,
                 is_balanced=is_balanced,
+                overlap_shared_expert_with_dispatch=self.overlap_shared_expert_with_dispatch,
             )
         else:
             # emb_dim/hidden_dim default to DSv3/Kimi's 7168/18432 in TtFfn; pass the variant's real dims
@@ -372,6 +378,7 @@ class TtPrefillBlock(LightweightModule):
         layer_idx=0,
         routing_use_l1_small_for_semaphores=False,
         is_balanced=False,
+        overlap_shared_expert_with_dispatch=True,
     ):
         mesh_config = extract_mesh_config(mesh_device)
         sp_factor = mesh_device.shape[sp_axis]
@@ -419,10 +426,43 @@ class TtPrefillBlock(LightweightModule):
             route_scale=model_cfg.ROUTE_SCALE,
             weight_cache_path=weight_cache_path,
             layer_idx=layer_idx,
-            overlap_shared_expert_with_dispatch=True,
+            overlap_shared_expert_with_dispatch=overlap_shared_expert_with_dispatch,
             routing_use_l1_small_for_semaphores=routing_use_l1_small_for_semaphores,
             is_balanced=is_balanced,
         )
+
+    def set_trace_controller(self, controller):
+        """Forward a SubDeviceTraceController to this block's MoE (sub-device-swap segmentation) and to
+        its MLA (per-layer migration-ack segmentation; only acts when the controller carries an ack
+        callback). No-op for dense / kv-only FFNs, whose FFN has no sub-device overlap to trace around.
+
+        DENSE-MLA ONLY — see TtPrefillTransformer.set_trace_controller for why. Re-asserted here so a
+        caller that drives a single block (the block-level tests) is caught too, not just whole-model
+        callers."""
+        mla = getattr(self, "mla", None)
+        if controller is not None and mla is not None and getattr(mla, "_has_indexer", False):
+            raise AssertionError(
+                f"trace capture is not supported for sparse/DSA (indexer) attention (layer "
+                f"{getattr(self.mla, 'layer_idx', '?')} resolved has_indexer=True). Supported today: "
+                "the dense-MLA models (deepseek_v3, kimi_k2_6, kimi_k2_7). GLM (glm_5_1 / glm_5_2) and "
+                "other sparse variants need their indexer ops ported to the per-element-tensor metadata "
+                "form first — run them untraced until then."
+            )
+        # Stored so the block's migration-ack site (below, in forward) can route through the controller
+        # (trace path) instead of calling on_layer_complete directly — see the ack comment in forward.
+        self._trace_controller = controller
+        ffn = getattr(self, "ffn", None)
+        if ffn is not None and hasattr(ffn, "set_trace_controller"):
+            ffn.set_trace_controller(controller)
+        mla = getattr(self, "mla", None)
+        if mla is not None and hasattr(mla, "set_trace_controller"):
+            mla.set_trace_controller(controller)
+
+    def release_sub_device_managers(self):
+        """Remove this block's MoE overlap sub-device manager before mesh close (no-op otherwise)."""
+        ffn = getattr(self, "ffn", None)
+        if ffn is not None and hasattr(ffn, "release_sub_device_manager"):
+            ffn.release_sub_device_manager()
 
     def forward(
         self,
@@ -443,6 +483,7 @@ class TtPrefillBlock(LightweightModule):
         indexer_indices: Optional[ttnn.Tensor] = None,
         return_indexer_indices: bool = False,
         index_kv_cache: Optional[ttnn.Tensor] = None,
+        metadata: Optional[ttnn.Tensor] = None,
     ):
         """
         Args:
@@ -498,6 +539,7 @@ class TtPrefillBlock(LightweightModule):
             indexer_indices=indexer_indices,
             return_indexer_indices=return_indexer_indices,
             index_kv_cache=index_kv_cache,
+            metadata=metadata,
         )
         kv_intermediates = None
         mla_indices = None  # GLM-5.2 reuse: this layer's top-k indices (full layer) for downstream shared layers
@@ -517,23 +559,46 @@ class TtPrefillBlock(LightweightModule):
         # without the flush it could copy pre-zero data. layer_idx is GLOBAL (the scheduler orders acks
         # across pipeline ranks); cache_layer_idx is the LOCAL per-rank cache slot.
         if on_layer_complete is not None:
-            assert actual_end is not None, "actual_end required when on_layer_complete is set"
+            assert actual_end is not None or metadata is not None, "actual_end or metadata required for zero_pad"
             # zero_padded_kv_cache is a DENSE (TILE) kvpe-cache op. A DSA-sparse model's kvpe cache is
             # bf16/fp8 ROW_MAJOR (sparse_sdpa reads it natively) and the op asserts TILE, so skip it for
             # sparse.
             cache_tensor = kvpe_cache.storage
             if cache_tensor.layout == ttnn.TILE_LAYOUT:
-                ttnn.experimental.deepseek_prefill.zero_padded_kv_cache(
-                    cache_tensor,
-                    cache_user_id,
-                    cache_layer_idx,
-                    self.mla.layer_num,
-                    actual_end,
-                    seq_len_local * self.mla.sp_factor,
-                    self.mla.sp_axis,
-                )
-            ttnn.synchronize_device(self.mesh_device)
-            on_layer_complete(self.mla.layer_idx)
+                if metadata is not None:
+                    # Per-element-tensor (trace-safe) path: slot_idx (metadata[0]) + valid_global=actual_end
+                    # (metadata[2]), each its own 1-element uint32 tensor read on-device.
+                    ttnn.experimental.deepseek_prefill.zero_padded_kv_cache(
+                        cache_tensor,
+                        metadata[0],  # slot_idx tensor
+                        metadata[2],  # valid_global (= actual_end) tensor
+                        cache_layer_idx,
+                        self.mla.layer_num,
+                        seq_len_local * self.mla.sp_factor,
+                        self.mla.sp_axis,
+                    )
+                else:
+                    ttnn.experimental.deepseek_prefill.zero_padded_kv_cache(
+                        cache_tensor,
+                        cache_user_id,
+                        cache_layer_idx,
+                        self.mla.layer_num,
+                        actual_end,
+                        seq_len_local * self.mla.sp_factor,
+                        self.mla.sp_axis,
+                    )
+            # Trace path: route the ack through the controller. At capture it splits the trace here (a host
+            # shm bump cannot live inside a trace); at replay the controller fires the ack between the two
+            # segments, after the first segment's writes flush (execute_trace blocking). Non-trace:
+            # synchronize then call directly. The controller takes precedence iff it carries an ack callback
+            # (runner trace path); the test path sets a controller WITHOUT an ack callback, so has_layer_ack()
+            # is False (and on_layer_complete is None there, so neither fires).
+            tc = getattr(self, "_trace_controller", None)
+            if tc is not None and tc.has_layer_ack():
+                tc.layer_ack(self.mla.layer_idx)
+            else:
+                ttnn.synchronize_device(self.mesh_device)
+                on_layer_complete(self.mla.layer_idx)
 
         if self.kv_only:
             # KV cache filled (by MLA), migration callback fired. The block
@@ -565,6 +630,7 @@ class TtPrefillBlock(LightweightModule):
                 actual_isl=actual_isl,
                 padding_side=padding_side,
                 actual_start=actual_start,
+                metadata=metadata,
             )
         else:
             ffn_out = self._dense_ffn_path(ffn_norm_out)
@@ -602,8 +668,12 @@ class TtPrefillBlock(LightweightModule):
         actual_isl: Optional[int] = None,
         padding_side: str = "right",
         actual_start: Optional[int] = None,
+        metadata: Optional[ttnn.Tensor] = None,
     ) -> ttnn.Tensor:
-        """MoE FFN path: 4D TILE → 3D ROW_MAJOR → MoE → 3D TILE → 4D TILE."""
+        """MoE FFN path: 4D TILE → 3D ROW_MAJOR → MoE → 3D TILE → 4D TILE.
+
+        `metadata` is forwarded so the traced path can build the padding config on-device (see
+        TtMoe.forward); it is unused on the eager/scalar path."""
         moe_input = ttnn.squeeze(ffn_norm_out, dim=0)
 
         moe_out, _ = self.ffn(
@@ -612,6 +682,7 @@ class TtPrefillBlock(LightweightModule):
             actual_isl=actual_isl,
             padding_side=padding_side,
             actual_start=actual_start,
+            metadata=metadata,
         )
 
         moe_out = ttnn.unsqueeze(moe_out, dim=0)

--- a/models/demos/deepseek_v3_d_p/tt/tt_prefill_block.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_prefill_block.py
@@ -543,12 +543,15 @@ class TtPrefillBlock(LightweightModule):
         )
         kv_intermediates = None
         mla_indices = None  # GLM-5.2 reuse: this layer's top-k indices (full layer) for downstream shared layers
-        if return_kv_intermediates and return_indexer_indices:
-            mla_out, kv_intermediates, mla_indices = mla_out
-        elif return_kv_intermediates:
-            mla_out, kv_intermediates = mla_out
-        elif return_indexer_indices:
-            mla_out, mla_indices = mla_out
+        # A kv_only layer's MLA returns None (it fills the cache and stops before attention/output), so it
+        # has nothing to unpack; the kv_only short-circuit below returns the matching (None, ...) arity.
+        if not self.kv_only:
+            if return_kv_intermediates and return_indexer_indices:
+                mla_out, kv_intermediates, mla_indices = mla_out
+            elif return_kv_intermediates:
+                mla_out, kv_intermediates = mla_out
+            elif return_indexer_indices:
+                mla_out, mla_indices = mla_out
         ttnn.deallocate(attn_norm_out)
 
         # Chunked-prefill migration handoff. MLA's update_padded_kv_cache wrote this chunk as full

--- a/models/demos/deepseek_v3_d_p/tt/tt_prefill_runtime.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_prefill_runtime.py
@@ -17,6 +17,7 @@ from models.demos.deepseek_v3_d_p.tt.runners.input_prep import prepare_prefill_i
 from models.demos.deepseek_v3_d_p.tt.runners.kv_caches import MlaKvCaches
 from models.demos.deepseek_v3_d_p.tt.tt_prefill_transformer import TtPrefillTransformer
 from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import MlaKvCacheFormat
+from models.demos.deepseek_v3_d_p.utils.sub_device_trace import SubDeviceTraceController
 
 
 @dataclass
@@ -63,6 +64,17 @@ class TtPrefillRuntimeConfig:
     is_first_rank: bool = True
     is_last_rank: bool = True
     sparse_kv_cache_format: MlaKvCacheFormat = MlaKvCacheFormat.BF16_RM
+    # Trace-safe metadata prefill: capture the per-chunk forward ONCE as a (segmented) ttnn trace during
+    # compile(), then replay it every chunk — advancing the per-chunk scalars (slot_id, actual_start,
+    # actual_end) on-device via an in-place host update of a persistent per-element metadata tensor, so the
+    # captured command stream carries no host transfers. Collapses the per-op host-dispatch (op2op) gaps.
+    # Requires the mesh opened with trace_region_size > 0. Off by default (eager per-op dispatch).
+    use_trace: bool = False
+    # MoE shared-expert ∥ dispatch overlap. Keeps the optimization ON by default, but it loads/clears a
+    # 2-sub-device manager around each MoE layer — which forces the segmented trace to split there, adding
+    # ~2*(MoE layers) host load/clear round-trips per replay. Set False (PREFILL_OVERLAP_SHARED_EXPERT=0) to
+    # capture the forward as ONE trace segment (no per-chunk swaps -> faster replay); costs the overlap.
+    overlap_shared_expert_with_dispatch: bool = True
 
     @property
     def sp_factor(self) -> int:
@@ -109,6 +121,28 @@ class TtPrefillRuntime:
 
         self.model_built = False
         self.compiled = False
+
+        # Trace-safe metadata prefill state (config.use_trace). compile() allocates the buffers and
+        # warm-compiles the metadata programs; the capture itself is recorded later by capture_trace(),
+        # after the driver has built any D2D endpoints and registered the per-layer ack/completion
+        # callback. Everything happens before the first request; there is no lazy or repeat capture.
+        #   _controller       — SubDeviceTraceController driving the segmented capture/replay
+        #   _trace_input      — persistent per-chunk input buffer (captured address; updated in place)
+        #   _trace_metadata   — 3 persistent 1-element uint32 tensors (slot_id, actual_start, actual_end)
+        #   _trace_output     — persistent output activation (non-last rank only; read by the D2D send)
+        #   _trace_captured   — flips True once capture_trace() records the segmented capture (single-shot)
+        #   _kv_cache         — the engine cache handle from compile(), used by capture_trace()
+        #   _trace_request_id — the request/chunk id of the replay in flight. The controller's per-layer
+        #                       callback is fixed at capture time, so a traced run cannot bind request_id
+        #                       into a fresh closure per call (the eager path does); prefill_chunk()
+        #                       publishes it here and set_layer_completion_sink()'s callback reads it.
+        self._controller = None
+        self._trace_input = None
+        self._trace_metadata = None
+        self._trace_output = None
+        self._trace_captured = False
+        self._kv_cache = None
+        self._trace_request_id = 0
 
         self._build_model(state_dict)
 
@@ -170,6 +204,7 @@ class TtPrefillRuntime:
             is_first_rank=self.config.is_first_rank,
             is_last_rank=self.config.is_last_rank,
             sparse_kv_cache_format=self.config.sparse_kv_cache_format,
+            overlap_shared_expert_with_dispatch=self.config.overlap_shared_expert_with_dispatch,
         )
         self.model_built = True
 
@@ -212,19 +247,143 @@ class TtPrefillRuntime:
     def compile(self, kv_caches: MlaKvCaches) -> None:
         """Warm up one chunk so the per-chunk loop hits no first-run cost. The engine passes the
         `MlaKvCaches` it owns; the warm-up writes into it (slot 0) and is harmless. The runtime holds NO
-        cache state — the same `kv_caches` is passed back into every prefill_chunk."""
+        cache state — the same `kv_caches` is passed back into every prefill_chunk.
+
+        use_trace: set up the persistent buffers + controller and warm-compile the metadata programs here,
+        but do NOT record the capture yet — the driver calls capture_trace() AFTER any pipeline D2D
+        endpoints are built and after set_layer_ack_channel(); prefill_chunk() then only replays."""
         assert self.model_built
         chunk = self.config.chunk_size
-        logger.info(f"TtPrefillRuntime.compile() — warming up one {chunk}-token chunk")
         t0 = time.perf_counter()
-        tt_input = self.make_chunk_input([0] * chunk)
-        self.prefill_chunk(tt_input, kv_caches, slot_id=0, actual_start=0, actual_end=chunk)
-        ttnn.synchronize_device(self.mesh_device)
+        if self.config.use_trace:
+            # Cache-level companion to the config-level guard in TtPrefillTransformer.set_trace_controller
+            # (which rejects a sparse/DSA model outright). Checked separately because it catches the other
+            # direction: a sparse INDEX cache handed to a model that resolved as dense. _forward_traced
+            # never threads index_kv_cache, so such a run would replay without the indexer cache and
+            # produce wrong KV silently instead of failing.
+            assert kv_caches.index is None, (
+                "use_trace=True with a sparse/DSA index KV cache is not supported: the captured forward "
+                "does not thread index_kv_cache, so the indexer would be skipped silently. Supported "
+                "traced models are the dense-MLA ones (deepseek_v3, kimi_k2_6, kimi_k2_7); GLM and other "
+                "sparse variants need their indexer ops ported to the metadata form first — run them "
+                "with use_trace=False (PREFILL_USE_TRACE=0) until then."
+            )
+            logger.info(
+                f"TtPrefillRuntime.compile() — warming traced {chunk}-token chunk (metadata path); capture deferred to capture_trace()"
+            )
+            self._kv_cache = kv_caches  # kept so capture_trace() can record after the ack is registered
+            self._prepare_trace(kv_caches)
+        else:
+            logger.info(f"TtPrefillRuntime.compile() — warming up one {chunk}-token chunk")
+            tt_input = self.make_chunk_input([0] * chunk)
+            self.prefill_chunk(tt_input, kv_caches, slot_id=0, actual_start=0, actual_end=chunk)
+            ttnn.synchronize_device(self.mesh_device)
         warmup_ms = (time.perf_counter() - t0) * 1000.0
         logger.info(
-            f"[prefill timing] task_id=WARMUP num_tokens={chunk} runtime.prefill_chunk(chunk) = {warmup_ms:.2f} ms"
+            f"[prefill timing] task_id={'PREPARE' if self.config.use_trace else 'WARMUP'} num_tokens={chunk} "
+            f"runtime.compile() = {warmup_ms:.2f} ms"
         )
         self.compiled = True
+
+    def capture_trace(self, kv_cache: ttnn.Tensor) -> None:
+        """Record the segmented trace, ONCE, before the chunk loop opens.
+
+        The driver must call this AFTER building any D2D pipeline endpoints (their receiver-socket L1 must
+        be allocated first, or it lands on the captured trace buffers on the last rank and corrupts replay)
+        and AFTER set_layer_ack_channel() / set_layer_completion_sink() (the ack callback has to be known
+        here so the capture splits at each ack point — a host shm bump cannot live inside a trace).
+        No-op if not use_trace or already captured. See compile().
+
+        The SubDeviceTraceController chops the capture at the MoE sub-device swaps (and, with an ack
+        callback registered, at each migration ack). On a non-last rank the captured forward's output
+        activation stays at its captured address in _trace_output so the driver can read it (and forward it
+        over D2D) after every replay."""
+        if not self.config.use_trace or self._trace_captured:
+            return
+        controller = self._controller
+        assert controller is not None, "capture_trace(): compile() must run first (prepares the trace)"
+
+        # Ack registered after compile: the block runs the metadata zero_padded_kv_cache + ack routing
+        # ONLY when on_layer_complete is set (tt_prefill_block.forward), so those programs were NOT
+        # compiled by _prepare_trace's warm pass (which ran with on_layer_complete=None). Warm them now —
+        # with a NO-OP ack so this warm pass fires no real migration acks — then register the real ack so
+        # the capture splits at each ack point. No ack (standalone) => nothing extra to warm.
+        if self._on_layer_complete is not None:
+            controller.set_layer_ack_callback(lambda _layer_idx: None)
+            self._forward_traced(kv_cache)  # compile zero_padded_kv_cache + ack path (no real ack fires)
+            ttnn.synchronize_device(self.mesh_device)
+            controller.set_layer_ack_callback(self._on_layer_complete)
+
+        controller.begin_capture()
+        out = self._forward_traced(kv_cache)
+        controller.end_capture()
+        ttnn.synchronize_device(self.mesh_device)
+        # Non-last rank: the persistent output activation the replay refreshes each chunk.
+        self._trace_output = out if not self.config.is_last_rank else None
+        self._trace_captured = True
+        logger.info(
+            f"[trace] captured {self.config.num_layers}-layer chunk forward = {controller.num_segments} segments, "
+            f"{controller.trace_bytes() / (1024 * 1024):.2f} MB"
+        )
+
+    def _meta1_dev(self, val: int) -> ttnn.Tensor:
+        """One persistent 1-element uint32 replicated-DRAM metadata scalar (captured address)."""
+        return ttnn.from_torch(
+            torch.tensor([val], dtype=torch.int64).reshape(1, 1, 1, 1),
+            device=self.mesh_device,
+            dtype=ttnn.uint32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
+        )
+
+    def _meta1_host(self, val: int) -> ttnn.Tensor:
+        """Host-side 1-element uint32 tensor for the cheap in-place metadata update (copy_host_to_device)."""
+        return ttnn.from_torch(
+            torch.tensor([val], dtype=torch.int64).reshape(1, 1, 1, 1),
+            dtype=ttnn.uint32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
+        )
+
+    def _forward_traced(self, kv_cache: ttnn.Tensor):
+        """The captured/warmed metadata forward: per-chunk scalars come from the persistent metadata
+        tensor on-device (actual_start/actual_end = None host-side). Writes user slot metadata[0].
+        Returns the forward output — a hidden-state activation on a non-last rank (forwarded downstream
+        over D2D), or the last/single rank's ignored KV-only tuple."""
+        return self.model.forward(
+            self._trace_input,
+            kv_cache.kvpe,  # unwrap the engine-owned container to the primary MLA cache (mirrors prefill_chunk)
+            # FULL chunk on purpose: downstream (TtMoe.forward) uses actual_isl only as the
+            # padding-config GUARD on this path — a static capture-time "padding awareness is ON" —
+            # while the real per-chunk bound is read on-device from `metadata` (actual_start/
+            # actual_end). Passing the true partial ISL here would bake one chunk's value into the
+            # capture; passing None would capture a program with no padding-aware path at all.
+            actual_isl=self.config.chunk_size,
+            on_layer_complete=self._on_layer_complete,
+            actual_start=None,
+            actual_end=None,
+            cache_user_id=0,
+            metadata=self._trace_metadata,
+        )
+
+    def _prepare_trace(self, kv_cache: ttnn.Tensor) -> None:
+        """Set up the persistent input + per-element metadata buffers and the controller, then warm-compile
+        the metadata-variant programs (a full forward). Does NOT begin/end the capture — the driver calls
+        capture_trace() later, once any ack/completion callback is registered. Called once from compile()."""
+        chunk = self.config.chunk_size
+        # Persistent input at a stable (captured) address; seeded with zeros, overwritten per chunk. On a
+        # non-first rank make_chunk_input yields a placeholder hidden-state activation (the D2D-received one).
+        self._trace_input = self.make_chunk_input([0] * chunk)
+        # Per-element metadata: (slot_id, actual_start, actual_end), seeded for chunk 0.
+        self._trace_metadata = (self._meta1_dev(0), self._meta1_dev(0), self._meta1_dev(chunk))
+
+        controller = SubDeviceTraceController(self.mesh_device)
+        self.model.set_trace_controller(controller)
+        self._controller = controller
+
+        self._forward_traced(kv_cache)  # warm/compile the metadata-variant programs
+        ttnn.synchronize_device(self.mesh_device)
 
     def prefill_chunk(
         self,
@@ -277,6 +436,34 @@ class TtPrefillRuntime:
             actual_start <= actual_end <= actual_start + self.config.chunk_size
         ), f"[actual_start={actual_start}, actual_end={actual_end}) not within one chunk of {self.config.chunk_size}"
 
+        if self.config.use_trace:
+            # Traced path: update the persistent input + per-element metadata IN PLACE, then replay the
+            # captured segmented forward. The metadata (slot_id, actual_start, actual_end) drives every
+            # per-chunk scalar on-device, so the single capture fills the correct KV for this chunk.
+            assert self._controller is not None, "use_trace: compile() must prepare the trace before prefill_chunk"
+            # Capture must ALREADY have happened (capture_trace(), before the loop opens). This used to
+            # fall back to capturing here, which silently moved a full warm pass + capture into the FIRST
+            # request — a ~20s stall that is near-impossible to attribute from a latency graph. Everything
+            # trace-related is required to be done before request #1, so make that a precondition.
+            assert self._trace_captured, (
+                "use_trace: capture_trace() must run before the first prefill_chunk(); capturing here "
+                "would stall the first request by a warm pass + capture"
+            )
+            # Per-layer completion callbacks live on the CONTROLLER, registered once at capture time (a
+            # host-side callback cannot execute inside a trace, so the capture splits at each ack point).
+            # That means the pipelined sink's request_id cannot be re-bound per call the way the eager
+            # path does below — publish this chunk's id instead; the captured callback built by
+            # set_layer_completion_sink() reads it at replay time.
+            self._trace_request_id = request_id
+            ttnn.copy(input_tensor, self._trace_input)
+            for dst, val in zip(self._trace_metadata, (slot_id, actual_start, actual_end)):
+                ttnn.copy_host_to_device_tensor(self._meta1_host(val), dst)
+            self._controller.replay()
+            ttnn.deallocate(input_tensor)
+            # Non-last rank: return the persistent output activation (replay just refreshed it) for the
+            # driver to forward downstream over D2D. Last/single rank: the populated KV cache is the output.
+            return None if self.config.is_last_rank else self._trace_output
+
         # Bind this chunk's request_id into a fresh per-call callback. The pipelined sink needs it to
         # build a globally-dense key (seq = request_id*num_layers + layer_idx); capturing by value per
         # call means there is no shared mutable chunk-index for the synchronously-fired callback to race
@@ -306,6 +493,33 @@ class TtPrefillRuntime:
         # KV-output path ignores.
         return out if not self.config.is_last_rank else None
 
+    def release_trace(self) -> None:
+        """Free the captured trace segments and the sub-device managers that own them, BEFORE the
+        driver closes the mesh device. Idempotent; safe to call when use_trace is off.
+
+        Required, not hygiene: the captured MeshTraceBuffers live inside the MoE-overlap
+        SubDeviceManagers, so closing the mesh with both still registered tears them down in the wrong
+        order and segfaults —
+
+            MeshDevice::close -> SubDeviceManagerTracker::~SubDeviceManagerTracker
+              -> SubDeviceManager::~SubDeviceManager
+                -> hashtable<MeshTraceId, MeshTraceBuffer>::~_Hashtable
+                  -> MeshTraceBuffer::~MeshTraceBuffer -> MeshBuffer::deallocate
+                    -> BankManager::deallocate_buffer   [SIGSEGV]
+
+        The model tests never hit this because their harness calls
+        TtPrefillTransformer.release_sub_device_managers() itself; the runner had no equivalent, so a
+        traced runner run always segfaulted at shutdown (after a fully successful chunk loop).
+        """
+        if self._controller is not None:
+            self._controller.release()
+            self._trace_captured = False
+        # Drop the overlap sub-device managers too: they are what the trace buffers hang off, and
+        # leaving them registered at close has been observed to segfault teardown on its own.
+        release = getattr(self.model, "release_sub_device_managers", None)
+        if release is not None:
+            release()
+
     def set_layer_ack_channel(self, layer_ack_channel) -> None:
         """Register the per-layer-ack channel (docs/scheduler/prefill.md §3.11).
 
@@ -317,13 +531,26 @@ class TtPrefillRuntime:
 
         Per-layer cadence means NUM_LAYERS acks per chunk, so the scheduler must
         be configured with layers_per_chunk == NUM_LAYERS.
+
+        use_trace: the capture splits the trace at each ack point (a host shm bump cannot live inside a
+        trace), so the ack callback must be known at CAPTURE time. Call this BEFORE capture_trace() — it
+        only registers the callback on the controller and asserts nothing has been captured yet.
         """
-        assert self.compiled, "Call compile() before set_layer_ack_channel()"
+        assert self.compiled or self.config.use_trace, "Call compile() before set_layer_ack_channel()"
 
         def on_layer_complete(layer_idx: int) -> None:
             layer_ack_channel.inject(1)
 
         self._on_layer_complete = on_layer_complete
+        if self.config.use_trace and self._controller is not None:
+            # Register on the controller so the (later) capture splits at each ack point. Ordering is a
+            # precondition, not something to recover from: re-capturing here would throw away the
+            # recorded segments and record a second time, and the caller can simply register first.
+            assert not self._trace_captured, (
+                "use_trace: set_layer_ack_channel() must run BEFORE capture_trace() — the ack callback has "
+                "to be known at capture time so the segments split at each ack point"
+            )
+            self._controller.set_layer_ack_callback(on_layer_complete)
 
     def kv_migration_base_address(self, kv_caches: MlaKvCaches) -> int:
         """This stage's KV base DRAM address — the engine's per-rank anchor for the migration
@@ -445,6 +672,34 @@ class TtPrefillRuntime:
         LayerCompletionQueue, and the LayerCompletionRouter routes it to the
         master host and re-emits it (in seq order) into the scheduler-facing
         counter channel (see ttnn._experimental.layer_completion).
+
+        use_trace: same constraint as set_layer_ack_channel — the callback must be known at CAPTURE
+        time (a host push cannot live inside a trace), so it is registered on the controller and the
+        eager capture is re-recorded to split at each ack point. The per-call request_id closure the
+        eager path uses is not available there, so the captured callback reads _trace_request_id,
+        which prefill_chunk() publishes before each replay.
         """
-        assert self.compiled, "Call compile() before set_layer_completion_sink()"
+        assert self.compiled or self.config.use_trace, "Call compile() before set_layer_completion_sink()"
         self._layer_completion_sink = sink
+        if not self.config.use_trace:
+            return
+
+        def on_layer_complete(layer_idx: int) -> None:
+            sink(layer_idx, self._trace_request_id)
+
+        # Route the traced path through the same controller hook the LayerAck channel uses, so the
+        # capture is segmented at every completion point.
+        self._on_layer_complete = on_layer_complete
+        # No silent no-op here: use_trace means compile() ran _prepare_trace and built the controller.
+        # Returning quietly if it is missing would register the sink and then never fire it, so a
+        # pipelined traced run would emit ZERO completions and the scheduler would simply hang.
+        assert self._controller is not None, (
+            "use_trace: compile() must run (building the trace controller) before "
+            "set_layer_completion_sink(); without it the sink would never fire under trace replay."
+        )
+        # Same ordering precondition as set_layer_ack_channel: register before capture_trace().
+        assert not self._trace_captured, (
+            "use_trace: set_layer_completion_sink() must run BEFORE capture_trace() — the completion "
+            "callback has to be known at capture time so the segments split at each completion point"
+        )
+        self._controller.set_layer_ack_callback(on_layer_complete)

--- a/models/demos/deepseek_v3_d_p/tt/tt_prefill_transformer.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_prefill_transformer.py
@@ -138,6 +138,7 @@ class TtPrefillTransformer(LightweightModule):
         is_first_rank: bool = True,
         is_last_rank: bool = True,
         sparse_kv_cache_format: MlaKvCacheFormat = MlaKvCacheFormat.BF16_RM,
+        overlap_shared_expert_with_dispatch: bool = True,
     ):
         super().__init__()
         self.mesh_device = mesh_device
@@ -226,6 +227,7 @@ class TtPrefillTransformer(LightweightModule):
                 kv_only=kv_only_last_layer and is_last,
                 routing_use_l1_small_for_semaphores=routing_use_l1_small_for_semaphores,
                 sparse_kv_cache_format=sparse_kv_cache_format,
+                overlap_shared_expert_with_dispatch=overlap_shared_expert_with_dispatch,
             )
             self.layers.append(layer)
 
@@ -292,6 +294,35 @@ class TtPrefillTransformer(LightweightModule):
 
         logger.info(f"TtPrefillTransformer construction complete ({num_layers} layers)")
 
+    def set_trace_controller(self, controller):
+        """Attach (or clear with None) a SubDeviceTraceController on every layer's MoE, so a ttnn
+        trace captured over forward() is split at the shared-expert/dispatch sub-device boundaries
+        (see utils/sub_device_trace.py). Pass None to restore plain eager load/clear.
+
+        DENSE-MLA ONLY. Tracing a sparse/DSA (indexer) model is rejected: the traced forward advances
+        its per-chunk scalars through the metadata ops, and the indexer path has no metadata overload
+        yet — the captured forward also never threads index_kv_cache, so a sparse model would replay
+        silently WITHOUT its indexer cache and produce wrong KV rather than failing. Porting the
+        indexer ops is out of scope here."""
+        if controller is not None:
+            assert not self._has_indexer, (
+                "trace capture is not supported for sparse/DSA (indexer) attention. Supported today: "
+                "the dense-MLA models (deepseek_v3, kimi_k2_6, kimi_k2_7). GLM (glm_5_1 / glm_5_2) and "
+                "any other indexer/sparse-attention variant need their indexer ops ported to the "
+                "per-element-tensor metadata form first — until then run them untraced (use_trace=False "
+                "/ PREFILL_USE_TRACE=0)."
+            )
+        for layer in self.layers:
+            layer.set_trace_controller(controller)
+
+    def release_sub_device_managers(self):
+        """Remove every MoE-created overlap sub-device manager before closing the mesh device.
+        Ensures none is loaded first (clear is idempotent). Leaving managers registered at mesh close
+        has been observed to segfault the teardown. Safe/idempotent — call once at end of a run."""
+        self.mesh_device.clear_loaded_sub_device_manager()
+        for layer in self.layers:
+            layer.release_sub_device_managers()
+
     def _to_host(self, tt_tensor):
         """Bring SP+TP sharded tensor to host as [1, seq, emb] bfloat16."""
         host = ttnn.to_torch(
@@ -316,6 +347,7 @@ class TtPrefillTransformer(LightweightModule):
         actual_end: Optional[int] = None,
         cache_user_id: int = 0,
         index_kv_cache: Optional[ttnn.Tensor] = None,
+        metadata: Optional[ttnn.Tensor] = None,
     ):
         """
         Forward pass: [embed] -> [block x N] -> [norm -> lm_head -> sample].
@@ -361,8 +393,11 @@ class TtPrefillTransformer(LightweightModule):
         # and writes this chunk at the actual_start offset of user cache_user_id's slot; the single-shot
         # path builds per-call rope for this seq_len. The norm/lm_head/sample tail still runs and a token
         # is returned, but the chunked caller ignores it (the populated cache is the output).
-        if actual_start is not None:
-            assert self.is_chunked, "actual_start requires the transformer to be built with is_chunked=True"
+        if actual_start is not None or metadata is not None:
+            # metadata path: per-chunk actual_start/actual_end live on-device in the metadata tensor
+            # (read by the trace-safe MLA ops), so actual_start is None here -- still chunked prefill,
+            # still the prebuilt whole-cache indexed rope.
+            assert self.is_chunked, "chunked prefill (actual_start or metadata) requires is_chunked=True"
             rope_tensors = self.indexed_rope
         elif self._has_indexer:
             # Sparse single-shot is folded onto the block-cyclic path (one full-seq chunk at offset 0),
@@ -414,6 +449,7 @@ class TtPrefillTransformer(LightweightModule):
                 indexer_indices=inject,
                 return_indexer_indices=reuse,
                 index_kv_cache=index_kv_cache,
+                metadata=metadata,
             )
             if reuse:
                 h, _, new_idx = ret

--- a/models/demos/deepseek_v3_d_p/utils/sub_device_trace.py
+++ b/models/demos/deepseek_v3_d_p/utils/sub_device_trace.py
@@ -1,0 +1,176 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Segmented ttnn-trace capture across sub-device-manager swaps.
+
+Problem: ttnn forbids loading/clearing a sub-device manager *inside* a trace capture
+(`begin_trace_capture`..`end_trace_capture`) — it resets worker state. But the MoE wants to keep the
+shared-expert/dispatch overlap, which loads a 2-sub-device manager around that region and clears it
+after. So a single trace cannot span the whole forward.
+
+Solution: capture the forward as *several* traces, split exactly at the load/clear points, and perform
+the load/clear on the host *between* the trace segments (legal — we are not capturing at that instant).
+At replay we walk the recorded program, executing each trace segment and doing the load/clear between
+them. Validated bit-exact in scratch PoC (3 chained traces, load/clear between captures and replays).
+
+Usage (capture once, replay many) — the forward runs ONCE during capture; this controller chops it:
+
+    controller = SubDeviceTraceController(mesh_device)
+    transformer.set_trace_controller(controller)   # MoE consults it for load/clear
+    transformer.forward(...)                         # WARMUP (controller idle) -> compiles programs
+    controller.begin_capture()
+    transformer.forward(...)                         # captured + auto-split at each load/clear
+    controller.end_capture()
+    ...                                              # controller.trace_bytes() for memory
+    for _ in range(n): controller.replay()           # each replay = full segmented forward
+    controller.release()
+    transformer.set_trace_controller(None)
+
+Boundary tensors (produced in one segment, read by the next) stay valid because the forward keeps them
+referenced across the end/begin split; trace replay reproduces them at the same addresses.
+"""
+
+import ttnn
+
+
+class SubDeviceTraceController:
+    """Drives multi-segment trace capture/replay around sub-device-manager load/clear calls.
+
+    MoE.forward calls `sub_device_load(mgr_id)` / `sub_device_clear()` instead of touching the mesh
+    device directly. This object decides what those mean based on its mode:
+      - idle (not capturing): pass straight through to the real device load/clear (eager behavior).
+      - capturing: end the in-progress trace, do the real host load/clear, begin the next trace —
+        i.e. split the capture here and record the boundary action.
+    """
+
+    # Program step kinds.
+    _TRACE = "trace"
+    _LOAD = "load"
+    _CLEAR = "clear"
+    _ACK = "ack"  # per-layer migration ack (host shm bump): split the capture here, call the callback at replay
+
+    def __init__(self, mesh_device, cq_id=0):
+        self.mesh_device = mesh_device
+        self.cq_id = cq_id
+        self._program = []  # ordered (kind, payload): (_TRACE, tid)|(_LOAD, mgr_id)|(_CLEAR, None)|(_ACK, layer_idx)
+        self._current_tid = None
+        self._capturing = False
+        # Optional per-layer ack callback (runner: layer_ack_channel.inject(1)). When set, MLA routes its
+        # on_layer_complete through layer_ack() so the migration ack stays correct under trace replay: the
+        # capture splits the trace at the ack point (a host shm bump cannot be inside a trace), and replay
+        # calls the callback BETWEEN the two trace segments (after the first segment's KV writes flush,
+        # before the next). None => no ack boundaries (test path: pure sub-device-swap segmentation).
+        self._on_layer_complete = None
+
+    def set_layer_ack_callback(self, on_layer_complete):
+        """Register the per-layer migration-ack callback. See layer_ack()."""
+        self._on_layer_complete = on_layer_complete
+
+    def has_layer_ack(self):
+        return self._on_layer_complete is not None
+
+    # ------------------------------------------------------------------ capture
+    def begin_capture(self):
+        """Open the first trace segment. The next forward() will be recorded and auto-split."""
+        assert not self._capturing, "already capturing"
+        self._program = []
+        self._capturing = True
+        self._current_tid = ttnn.begin_trace_capture(self.mesh_device, cq_id=self.cq_id)
+
+    def end_capture(self):
+        """Close the final trace segment."""
+        assert self._capturing, "begin_capture() was not called"
+        ttnn.end_trace_capture(self.mesh_device, self._current_tid, cq_id=self.cq_id)
+        self._program.append((self._TRACE, self._current_tid))
+        self._current_tid = None
+        self._capturing = False
+
+    # ----------------------------------------------------- MoE-facing hooks
+    def sub_device_load(self, sd_manager_id):
+        """MoE entered the overlap region. Capturing -> split + record + real load; else just load."""
+        if self._capturing:
+            self._split(self._LOAD, sd_manager_id)
+        else:
+            self.mesh_device.load_sub_device_manager(sd_manager_id)
+
+    def sub_device_clear(self):
+        """MoE left the overlap region. Capturing -> split + record + real clear; else just clear."""
+        if self._capturing:
+            self._split(self._CLEAR, None)
+        else:
+            self.mesh_device.clear_loaded_sub_device_manager()
+
+    def layer_ack(self, layer_idx):
+        """MLA finished this layer's KV write (post zero-pad). Capturing -> split + record the ack
+        boundary (NO host action during capture: the capture pass is not a real chunk, so we must not
+        bump the ack counter). Eager (not capturing) -> call the callback directly (matches the
+        non-trace runner). At replay the ack callback fires between the two trace segments. No-op if no
+        callback is registered."""
+        if self._on_layer_complete is None:
+            return
+        if self._capturing:
+            self._split(self._ACK, layer_idx)
+        else:
+            # Eager (idle controller): flush this layer's KV before the ack, same as the non-trace path —
+            # the migration worker reads it out-of-band from the CQ.
+            ttnn.synchronize_device(self.mesh_device)
+            self._on_layer_complete(layer_idx)
+
+    def _split(self, kind, payload):
+        # Close the current segment, perform the real host action (load/clear only; ACK has no
+        # capture-time action), open the next segment.
+        ttnn.end_trace_capture(self.mesh_device, self._current_tid, cq_id=self.cq_id)
+        self._program.append((self._TRACE, self._current_tid))
+        if kind == self._LOAD:
+            self.mesh_device.load_sub_device_manager(payload)
+        elif kind == self._CLEAR:
+            self.mesh_device.clear_loaded_sub_device_manager()
+        # kind == _ACK: no host action at capture time (the ack fires at replay, between segments).
+        self._program.append((kind, payload))
+        self._current_tid = ttnn.begin_trace_capture(self.mesh_device, cq_id=self.cq_id)
+
+    # ------------------------------------------------------------------ replay
+    def replay(self):
+        """Run the whole segmented forward: execute each trace, load/clear between segments.
+
+        Segments are enqueued NON-blocking on one CQ: the device runs them in enqueue order, and the
+        load/clear between them are host-side registry switches (they pick which manager's trace the next
+        execute_trace looks up; per-manager trace buffers persist), so they do not need the prior segment
+        to have finished on device. We force a device sync in only two places:
+          - BEFORE each per-layer migration ack — the migration worker reads the just-written KV over NoC,
+            out-of-band from the CQ, so that segment's writes must be on-device first; and
+          - ONCE after the last segment — so the chunk's KV is fully written before replay() returns.
+        This replaces the old block-every-segment (which serialized dispatch for no reason but the ack)."""
+        assert not self._capturing, "still capturing"
+        assert self._program, "nothing captured"
+        for kind, payload in self._program:
+            if kind == self._TRACE:
+                ttnn.execute_trace(self.mesh_device, payload, cq_id=self.cq_id, blocking=False)
+            elif kind == self._LOAD:
+                self.mesh_device.load_sub_device_manager(payload)
+            elif kind == self._CLEAR:
+                self.mesh_device.clear_loaded_sub_device_manager()
+            else:  # _ACK: per-layer migration ack (callback set => non-None here). Flush the preceding
+                # segment(s) so the out-of-band migration worker sees post-write KV, THEN fire the ack.
+                ttnn.synchronize_device(self.mesh_device)
+                self._on_layer_complete(payload)
+
+        ttnn.synchronize_device(self.mesh_device)
+
+    # ------------------------------------------------------------------ stats / cleanup
+    @property
+    def num_segments(self):
+        return sum(1 for kind, _ in self._program if kind == self._TRACE)
+
+    def trace_bytes(self):
+        """Total device memory used by all captured trace segments (bytes per device)."""
+        mv = ttnn.get_memory_view(self.mesh_device, ttnn.BufferType.TRACE)
+        return mv.total_bytes_allocated_per_bank * mv.num_banks
+
+    def release(self):
+        """Release every captured trace. Safe to call repeatedly."""
+        for kind, payload in self._program:
+            if kind == self._TRACE:
+                ttnn.release_trace(self.mesh_device, payload)
+        self._program = []

--- a/tests/pipeline_reorg/blackhole_e2e_tests.yaml
+++ b/tests/pipeline_reorg/blackhole_e2e_tests.yaml
@@ -201,7 +201,7 @@
     exit_code=0
     # Cheap host-side coverage for the mixed-format cache contract and producer decoding.
     pytest models/demos/common/prefill/tests/test_prefill_producer_kv_decode.py models/demos/deepseek_v3_d_p/tests/test_sparse_kv_cache_contract.py -vvv --tb=short || exit_code=$?
-    pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/ -vvv --tb=short -k "(not test_ring_joint_mla or (4x2 and pcc_check and not fabric2d)) and (not test_rope_prefill or 4x2) and (not update_padded_kv_cache or 2x4) and (not rotary_embedding_indexed or 2x4) and (not zero_padded or linear-8 or 2x4) and not single-1 and (not test_prefill_dispatch or ((bf16_in and tile and bf16_out) or (fp8_scaled_in and row_major and fp8_out)))" -m "not extended_model" || exit_code=$?
+    pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/ -vvv --tb=short -k "(not test_ring_joint_mla or (4x2 and pcc_check and not fabric2d)) and (not test_rope_prefill or 4x2) and (not update_padded_kv_cache or 2x4) and (not rotary_embedding_indexed or 2x4) and (not moe_padding_config or 2x4) and (not zero_padded or linear-8 or 2x4) and not single-1 and (not test_prefill_dispatch or ((bf16_in and tile and bf16_out) or (fp8_scaled_in and row_major and fp8_out)))" -m "not extended_model" || exit_code=$?
     exit $exit_code
   skus:
     bh_loudbox:

--- a/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
+++ b/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
@@ -121,7 +121,7 @@
   team: models
   sp_config: sc1
 
-- name: "Blaze - Chunked Kimi Padded Accuracy (15k)"
+- name: "Blaze - Chunked Kimi Padded Accuracy (15k, no trace)"
   cmd: |
     export MESH_DEVICE=TG
     export LOGURU_LEVEL=INFO
@@ -130,7 +130,31 @@
     export PREFILL_TRACE_DIR=/mnt/models/deepseek-prefill-cache/golden/structured_traces/kimi_debug_55k_vllm
     mpirun --bind-to none --pernode --tag-output bash -lc '
       export OMP_NUM_THREADS=$(nproc)
-      python3 -m pytest models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py::test_kimi_prefill_transformer_chunked_padded -k "kimi and fabric2d-mesh-8x4 and L61 and mid15k" -vvv --tb=short
+      python3 -m pytest models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py::test_kimi_prefill_transformer_chunked_padded -k "kimi and fabric2d-mesh-8x4 and L61 and mid15k and notrace" -vvv --tb=short
+    '
+  test_type: kimi_chunked_padded
+  test_group: module
+  skus:
+    bh_sc1:
+      timeout: 40
+  owner_id: U07N3CUUN05  # Iva Potkonjak
+  team: models
+  sp_config: sc1
+
+# Trace twin of the entry above: SAME splits, SAME golden, SAME KV-PCC bar — the only difference is
+# that the padded forward is captured once as a ttnn trace and replayed per chunk. Run as its own
+# entry (not a second -k term) so a trace-only regression is attributed on the CI dashboard instead
+# of being hidden inside a two-case job.
+- name: "Blaze - Chunked Kimi Padded Accuracy (15k, trace)"
+  cmd: |
+    export MESH_DEVICE=TG
+    export LOGURU_LEVEL=INFO
+    export KIMI_K2_6_HF_MODEL=/mnt/models/Kimi-K2_6-dequantized
+    export TT_KIMI_PREFILL_TTNN_CACHE=/mnt/models/Kimi-K2_6-Cache/Kimi-K2_6-Cache-prefill
+    export PREFILL_TRACE_DIR=/mnt/models/deepseek-prefill-cache/golden/structured_traces/kimi_debug_55k_vllm
+    mpirun --bind-to none --pernode --tag-output bash -lc '
+      export OMP_NUM_THREADS=$(nproc)
+      python3 -m pytest models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py::test_kimi_prefill_transformer_chunked_padded -k "kimi and fabric2d-mesh-8x4 and L61 and mid15k and traced" -vvv --tb=short
     '
   test_type: kimi_chunked_padded
   test_group: module
@@ -350,7 +374,7 @@
   team: models
   sp_config: sc1
 
-- name: "Blaze - Chunked Kimi (code_debug 55k)"
+- name: "Blaze - Chunked Kimi perf (code_debug 55k, no trace)"
   # 55k-ISL chunked-prefill perf/smoke for Kimi: full 61 layers, 11 chunks x 5120 = 56320 tokens
   # (the full code_debug trace), 10 iterations. No-PCC: it drives the real chunked-prefill path end to
   # end (build once, forward 10x) and passes on completion -- no golden readback, no accuracy compare.
@@ -368,7 +392,40 @@
     export PREFILL_TRACE_DIR=/mnt/models/deepseek-prefill-cache/golden/structured_traces/kimi_debug_55k_vllm
     mpirun --bind-to none --pernode --tag-output bash -lc '
       export OMP_NUM_THREADS=$(nproc)
-      python3 -m pytest models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py::test_kimi_prefill_transformer_chunked_no_pcc[blackhole-kimi-mesh-8x4-L61-preload0-chunks_eleven-ten_iters-margin5pct] -xvs
+      python3 -m pytest models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py::test_kimi_prefill_transformer_chunked_perf -k "L61 and preload0 and chunks_eleven and ten_iters and notrace" -xvs
+    '
+  test_type: kimi_chunked
+  test_group: module
+  skus:
+    bh_sc1_high_power:
+      # Job takes under 20 minutes; 40 minute timeout provides buffer for variance and machines with less power.
+      timeout: 40
+  owner_id: U08RL15T4N8
+  team: models
+  sp_config: sc1
+
+# Trace twin of the entry above: same 61 layers / 11 chunks / 10 iterations, but the chunk forward
+# is captured once and replayed. Separate entry so the two per-chunk timing tables are attributed
+# independently -- a traced-vs-untraced perf delta is the number this pair exists to surface.
+- name: "Blaze - Chunked Kimi perf (code_debug 55k, trace)"
+  # 55k-ISL chunked-prefill perf/smoke for Kimi: full 61 layers, 11 chunks x 5120 = 56320 tokens
+  # (the full code_debug trace), 10 iterations. No-PCC: it drives the real chunked-prefill path end to
+  # end (build once, forward 10x) and passes on completion -- no golden readback, no accuracy compare.
+  #
+  # Paths:
+  #   KIMI_K2_6_HF_MODEL         -> HF checkpoint (config + safetensors index; needed by weight_cache_path fixture)
+  #   TT_KIMI_PREFILL_TTNN_CACHE -> prebuilt .tensorbin cache (…/kimi_k2_6_bh_32dev/8x4); required —
+  #     without it, conftest falls back under model_path and CI may invent HF hub downloads
+  #   PREFILL_TRACE_DIR          -> code_debug (56320) golden trace; metadata.json token_ids feed the prefill
+  cmd: |
+    export MESH_DEVICE=TG
+    export LOGURU_LEVEL=INFO
+    export KIMI_K2_6_HF_MODEL=/mnt/models/Kimi-K2_6-dequantized
+    export TT_KIMI_PREFILL_TTNN_CACHE=/mnt/models/Kimi-K2_6-Cache/Kimi-K2_6-Cache-prefill
+    export PREFILL_TRACE_DIR=/mnt/models/deepseek-prefill-cache/golden/structured_traces/kimi_debug_55k_vllm
+    mpirun --bind-to none --pernode --tag-output bash -lc '
+      export OMP_NUM_THREADS=$(nproc)
+      python3 -m pytest models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py::test_kimi_prefill_transformer_chunked_perf -k "L61 and preload0 and chunks_eleven and ten_iters and traced" -xvs
     '
   test_type: kimi_chunked
   test_group: module

--- a/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
+++ b/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
@@ -136,7 +136,10 @@
   test_group: module
   skus:
     bh_sc1:
-      timeout: 40
+      # Measured 9.9 min at L61/mid15k (the untraced mode also does the per-layer decoder-output PCC,
+      # which is a host readback per layer per chunk). 20 min is ~2x headroom. Was 40; the (team, sku)
+      # time budget is a SUM, so the traced twin has to come out of the same allowance.
+      timeout: 20
   owner_id: U07N3CUUN05  # Iva Potkonjak
   team: models
   sp_config: sc1
@@ -160,7 +163,9 @@
   test_group: module
   skus:
     bh_sc1:
-      timeout: 40
+      # Measured 5.2 min at L61/mid15k — cheaper than its untraced twin because the traced mode asserts
+      # KV PCC only (a host readback cannot live inside a capture). ~2.3x headroom.
+      timeout: 12
   owner_id: U07N3CUUN05  # Iva Potkonjak
   team: models
   sp_config: sc1
@@ -398,8 +403,9 @@
   test_group: module
   skus:
     bh_sc1_high_power:
-      # Job takes under 20 minutes; 40 minute timeout provides buffer for variance and machines with less power.
-      timeout: 40
+      # Measured 4.7 min at two_iters on a galaxy; ten_iters adds ~8x13.4s -> ~6.5 min. 18 min is ~2.7x
+      # headroom. Was 40, but the (team, sku) time budget is a SUM and the traced twin needs room too.
+      timeout: 18
   owner_id: U08RL15T4N8
   team: models
   sp_config: sc1
@@ -431,8 +437,9 @@
   test_group: module
   skus:
     bh_sc1_high_power:
-      # Job takes under 20 minutes; 40 minute timeout provides buffer for variance and machines with less power.
-      timeout: 40
+      # Measured 4.0 min at two_iters; ten_iters adds ~8x10.6s -> ~5.5 min. Trace replay is faster per
+      # chunk than eager dispatch, so this needs no more than its untraced twin.
+      timeout: 18
   owner_id: U08RL15T4N8
   team: models
   sp_config: sc1

--- a/tests/pipeline_reorg/t3k_e2e_tests.yaml
+++ b/tests/pipeline_reorg/t3k_e2e_tests.yaml
@@ -137,7 +137,7 @@
 - name: t3k_DeepSeek_PREFILL_OP_TESTS
   cmd: |
     exit_code=0
-    pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/ -vvv --tb=short -k "(not test_prefill_dispatch or (random and (linear-8-1link or mesh-4x2 or mesh-2x4) and not fabric2d- and bf16_in and tile and bf16_out)) and (not test_prefill_combine or (random and (linear-8-1link or mesh-4x2 or mesh-2x4) and not fabric2d-)) and (not test_reduce or (2048 and (linear-4x1 or mesh-4x2 or mesh-2x4))) and (not test_ttnn_dispatch_combine or (random and (linear-8-1link or mesh-4x2 or mesh-2x4) and not fabric2d-)) and (not test_ring_joint_mla or (4x2 and single_run and pcc_check and not fabric2d)) and (not update_padded_kv_cache or 2x4) and (not rotary_embedding_indexed or 2x4) and not test_dispatch_combine_l1_small_semaphores" -m "not extended_model" || exit_code=$?
+    pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/ -vvv --tb=short -k "(not test_prefill_dispatch or (random and (linear-8-1link or mesh-4x2 or mesh-2x4) and not fabric2d- and bf16_in and tile and bf16_out)) and (not test_prefill_combine or (random and (linear-8-1link or mesh-4x2 or mesh-2x4) and not fabric2d-)) and (not test_reduce or (2048 and (linear-4x1 or mesh-4x2 or mesh-2x4))) and (not test_ttnn_dispatch_combine or (random and (linear-8-1link or mesh-4x2 or mesh-2x4) and not fabric2d-)) and (not test_ring_joint_mla or (4x2 and single_run and pcc_check and not fabric2d)) and (not update_padded_kv_cache or 2x4) and (not rotary_embedding_indexed or 2x4) and (not moe_padding_config or 2x4) and not test_dispatch_combine_l1_small_semaphores" -m "not extended_model" || exit_code=$?
     exit $exit_code
   skus:
     wh_llmbox:

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/CMakeLists.txt
@@ -8,6 +8,7 @@ add_subdirectory(insert)
 add_subdirectory(masked_bincount)
 add_subdirectory(moe_grouped_topk)
 add_subdirectory(moe_hash_gate)
+add_subdirectory(moe_padding_config)
 add_subdirectory(offset_cumsum)
 add_subdirectory(outbound_socket_service_sync)
 add_subdirectory(pack_scaled_fp8_kv_cache)
@@ -34,6 +35,7 @@ target_link_libraries(
         TTNN::Ops::Experimental::DeepSeekPrefill::MaskedBincount
         TTNN::Ops::Experimental::DeepSeekPrefill::MoeGroupedTopk
         TTNN::Ops::Experimental::DeepSeekPrefill::MoeHashGate
+        TTNN::Ops::Experimental::DeepSeekPrefill::MoePaddingConfig
         TTNN::Ops::Experimental::DeepSeekPrefill::OffsetCumsum
         TTNN::Ops::Experimental::DeepSeekPrefill::D2dSocketSync
         TTNN::Ops::Experimental::DeepSeekPrefill::PackScaledFp8KvCache
@@ -67,6 +69,7 @@ target_sources(
         $<TARGET_OBJECTS:TTNN::Ops::Experimental::DeepSeekPrefill::MaskedBincount>
         $<TARGET_OBJECTS:TTNN::Ops::Experimental::DeepSeekPrefill::MoeGroupedTopk>
         $<TARGET_OBJECTS:TTNN::Ops::Experimental::DeepSeekPrefill::MoeHashGate>
+        $<TARGET_OBJECTS:TTNN::Ops::Experimental::DeepSeekPrefill::MoePaddingConfig>
         $<TARGET_OBJECTS:TTNN::Ops::Experimental::DeepSeekPrefill::OffsetCumsum>
         $<TARGET_OBJECTS:TTNN::Ops::Experimental::DeepSeekPrefill::D2dSocketSync>
         $<TARGET_OBJECTS:TTNN::Ops::Experimental::DeepSeekPrefill::PackScaledFp8KvCache>

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/moe_padding_config/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/moe_padding_config/CMakeLists.txt
@@ -1,0 +1,72 @@
+include(sources.cmake)
+
+add_library(ttnn_op_experimental_deepseek_prefill_moe_padding_config ${LIB_TYPE})
+add_library(
+    TTNN::Ops::Experimental::DeepSeekPrefill::MoePaddingConfig
+    ALIAS ttnn_op_experimental_deepseek_prefill_moe_padding_config
+)
+
+target_precompile_headers(ttnn_op_experimental_deepseek_prefill_moe_padding_config REUSE_FROM TTNN::PCHFull)
+TT_ENABLE_UNITY_BUILD(ttnn_op_experimental_deepseek_prefill_moe_padding_config)
+
+set_target_properties(
+    ttnn_op_experimental_deepseek_prefill_moe_padding_config
+    PROPERTIES
+        INTERFACE_HEADER_SETS_TO_VERIFY
+            api
+)
+
+file(GLOB_RECURSE kernels device/kernels/*.cpp)
+
+target_sources(
+    ttnn_op_experimental_deepseek_prefill_moe_padding_config
+    PUBLIC
+        FILE_SET api
+        TYPE HEADERS
+        BASE_DIRS ${FixmeOpAPIDir}
+        FILES ${TTNN_OP_EXPERIMENTAL_DEEPSEEK_PREFILL_MOE_PADDING_CONFIG_API_HEADERS}
+        FILE_SET kernels
+        TYPE HEADERS
+        BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}
+        FILES ${kernels}
+    PRIVATE
+        ${TTNN_OP_EXPERIMENTAL_DEEPSEEK_PREFILL_MOE_PADDING_CONFIG_SRCS}
+)
+
+target_link_libraries(ttnn_op_experimental_deepseek_prefill_moe_padding_config PRIVATE TT::Metalium PUBLIC TTNN::Core)
+
+install(
+    TARGETS
+        ttnn_op_experimental_deepseek_prefill_moe_padding_config
+    FILE_SET
+    kernels
+        DESTINATION
+            ${CMAKE_INSTALL_LIBEXECDIR}/tt-metalium/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/moe_padding_config
+        COMPONENT ttnn-runtime
+)
+
+install(
+    TARGETS
+        ttnn_op_experimental_deepseek_prefill_moe_padding_config
+    FILE_SET
+    api
+        COMPONENT ttnn-dev
+    LIBRARY
+        COMPONENT tar
+)
+
+# Python bindings for this op are registered directly on the shared `ttnn`
+# Python module target here, rather than in the centrally-owned
+# ttnn/sources.cmake — the target itself is necessarily shared (nanobind
+# builds one Python extension module), but which file lists a given op's
+# own registration source doesn't need to be. `ttnn` only exists when
+# WITH_PYTHON_BINDINGS is on, hence the guard.
+#
+# The actual file list (TTNN_OP_EXPERIMENTAL_DEEPSEEK_PREFILL_MOE_PADDING_CONFIG_NANOBIND_SRCS) lives in sources.cmake, not here: this
+# file carries metalium-developers-infra as a required co-owner (so infra
+# can land sweeping build-system changes), and routine add/remove/rename of
+# a nanobind source shouldn't need to go through infra. This wiring line
+# itself is build logic and is expected to change rarely.
+if(TARGET ttnn)
+    target_sources(ttnn PRIVATE ${TTNN_OP_EXPERIMENTAL_DEEPSEEK_PREFILL_MOE_PADDING_CONFIG_NANOBIND_SRCS})
+endif()

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/moe_padding_config/device/kernels/dataflow/writer_moe_padding_config.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/moe_padding_config/device/kernels/dataflow/writer_moe_padding_config.cpp
@@ -1,0 +1,143 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
+
+// Builds this chip's [local_real_tokens, pad_side] MoE padding-config row entirely on-device.
+//
+// The per-chunk values arrive as two 1-element uint32 DRAM tensors (raw addresses in common args 3
+// and 4) — `actual_start` (absolute KV position of this chunk's first real token) and `actual_end`
+// (one past its last real token). Reading them on-device keeps them off the host dispatch path, so
+// this op is trace-safe: one captured program recomputes the correct config on every replay.
+//
+// Why this exists: the host builder (TtMoEGatePrefill.build_padding_config) ends in a ttnn.from_torch,
+// which is an illegal host->device write inside a trace capture. Consumers (moe_grouped_topk, dispatch)
+// already read padding_config as a device tensor, so moving only its PRODUCER on-device makes the
+// whole path traceable with no change downstream.
+//
+// Compile args: [0]=cb_id_out, [1]=cb_id_meta, [2]=pad_side, [3..]=config accessor, then ONE metadata
+// accessor (the two 1-element tensors share an identical layout, so one accessor serves both reads).
+//
+// Common runtime args: [0]=my_sp_coord, [1]=sp_factor, [2]=tokens_per_chip,
+//                      [3]=actual_start tensor DRAM addr, [4]=actual_end tensor DRAM addr.
+// Per-core runtime args: [0]=config output buffer address (Buffer* binding).
+
+namespace {
+
+// Number of positions in [base, base+len) that fall below `valid_end`. All-unsigned (no signed
+// underflow): the rotated layout guarantees every position is >= actual_start, so only the upper
+// bound matters.
+inline uint32_t prefix_count(uint32_t valid_end, uint32_t base, uint32_t len) {
+    if (valid_end <= base) {
+        return 0;
+    }
+    const uint32_t n = valid_end - base;
+    return n < len ? n : len;
+}
+
+}  // namespace
+
+void kernel_main() {
+    const uint32_t config_addr = get_arg_val<uint32_t>(0);
+
+    const uint32_t my_sp_coord = get_common_arg_val<uint32_t>(0);
+    const uint32_t sp_factor = get_common_arg_val<uint32_t>(1);
+    const uint32_t tokens_per_chip = get_common_arg_val<uint32_t>(2);
+    const uint32_t actual_start_addr = get_common_arg_val<uint32_t>(3);
+    const uint32_t actual_end_addr = get_common_arg_val<uint32_t>(4);
+
+    constexpr uint32_t cb_id_out = get_compile_time_arg_val(0);
+    constexpr uint32_t cb_id_meta = get_compile_time_arg_val(1);
+    constexpr uint32_t pad_side = get_compile_time_arg_val(2);
+    constexpr auto config_args = TensorAccessorArgs<3>();
+    constexpr auto meta_args = TensorAccessorArgs<config_args.next_compile_time_args_offset()>();
+
+    constexpr uint32_t kMetadataReadBytes = 4;
+    constexpr uint32_t onepage = 1;
+
+    Noc noc;
+
+    // ---- read actual_start / actual_end (element [0] of each 1-element tensor) ----
+    // Both reads target dst offset 0 of the same scratch slot (a 4-byte DRAM read into a
+    // non-16B-aligned dst offset lands wrong), so read start, extract, then overwrite with end.
+    // Single reserve_back/push_back: a second reserve_back on a single-page CB with no intervening
+    // pop would deadlock.
+    CircularBuffer cb_meta(cb_id_meta);
+    cb_meta.reserve_back(onepage);
+
+    const auto s_start = TensorAccessor(meta_args, actual_start_addr);
+    noc.async_read(s_start, cb_meta, kMetadataReadBytes, {.page_id = 0}, {.offset_bytes = 0});
+    noc.async_read_barrier();
+    // The metadata tensors sit at FIXED DRAM addresses reused every chunk, so the RISC data cache may
+    // still hold the previous chunk's value for this L1 line (the barrier orders the DMA; volatile
+    // still reads through the cache). Force a refetch, else a stale read silently produces the prior
+    // chunk's config.
+    invalidate_l1_cache();
+    const uint32_t actual_start = CoreLocalMem<volatile uint32_t>(cb_meta.get_write_ptr())[0];
+
+    const auto s_end = TensorAccessor(meta_args, actual_end_addr);
+    noc.async_read(s_end, cb_meta, kMetadataReadBytes, {.page_id = 0}, {.offset_bytes = 0});
+    noc.async_read_barrier();
+    invalidate_l1_cache();  // same fresh-metadata refetch as above
+    const uint32_t actual_end = CoreLocalMem<volatile uint32_t>(cb_meta.get_write_ptr())[0];
+    cb_meta.push_back(onepage);
+
+    // ---- per-chip real-token count under the KV-pad-aware rotation ----
+    // Chip c's chunk_local rows carry global positions that are a strictly increasing sequence, so its
+    // real rows are a contiguous PREFIX and one count describes the split. The rotation mirrors
+    // update_padded_kv_cache's writer exactly (same boundary_slab/boundary_chip/boundary_offset), and
+    // the sequence is piecewise-linear in the local row with at most two segments — so the count is
+    // closed-form, no per-row loop.
+    //
+    // valid_end == actual_start + actual_isl == actual_end, so the ISL never has to be formed.
+    const uint32_t valid_end = actual_end;
+    const uint32_t chunk_global = sp_factor * tokens_per_chip;
+    const uint32_t boundary_slab = actual_start / chunk_global;
+    const uint32_t boundary_chip = (actual_start / tokens_per_chip) % sp_factor;
+    const uint32_t boundary_offset = actual_start % tokens_per_chip;
+
+    uint32_t local_real_tokens;
+    if (my_sp_coord != boundary_chip) {
+        // One linear run: chips before the boundary have had their pad consumed and start a slab
+        // later; chips after it stay at the current slab base.
+        const uint32_t slab = (my_sp_coord < boundary_chip) ? (boundary_slab + 1) : boundary_slab;
+        const uint32_t base = slab * chunk_global + my_sp_coord * tokens_per_chip;
+        local_real_tokens = prefix_count(valid_end, base, tokens_per_chip);
+    } else {
+        // The boundary chip starts mid-slab at boundary_offset, so its rows wrap into the next slab:
+        // two linear runs.
+        const uint32_t base_lo = boundary_slab * chunk_global + my_sp_coord * tokens_per_chip + boundary_offset;
+        const uint32_t len_lo = tokens_per_chip - boundary_offset;
+        const uint32_t base_hi = (boundary_slab + 1) * chunk_global + my_sp_coord * tokens_per_chip;
+        const uint32_t len_hi = boundary_offset;
+        local_real_tokens = prefix_count(valid_end, base_lo, len_lo) + prefix_count(valid_end, base_hi, len_hi);
+    }
+
+    // ---- write this chip's [local_real_tokens, pad_side] row ----
+    // The consumers read page 0 and take element [0] as the real-token count and [1] as the pad side.
+    const uint32_t out_page_bytes = get_local_cb_interface(cb_id_out).fifo_page_size;
+    CircularBuffer cb_out(cb_id_out);
+    cb_out.reserve_back(onepage);
+    {
+        // Zero the whole page first: the row may be padded up to the buffer's aligned page size, and
+        // the full page is written below, so trailing bytes must be deterministic rather than stale L1.
+        auto out = CoreLocalMem<volatile uint32_t>(cb_out.get_write_ptr());
+        for (uint32_t i = 0; i < out_page_bytes / sizeof(uint32_t); ++i) {
+            out[i] = 0;
+        }
+        out[0] = local_real_tokens;
+        out[1] = pad_side;
+    }
+    cb_out.push_back(onepage);
+
+    cb_out.wait_front(onepage);
+    const auto s_out = TensorAccessor(config_args, config_addr);
+    noc.async_write(cb_out, s_out, out_page_bytes, {}, {.page_id = 0});
+    noc.async_write_barrier();
+    cb_out.pop_front(onepage);
+}

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/moe_padding_config/device/moe_padding_config_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/moe_padding_config/device/moe_padding_config_device_operation.cpp
@@ -1,0 +1,269 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "moe_padding_config_device_operation.hpp"
+
+#include <cstdint>
+#include <utility>
+
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+
+#include "ttnn/operations/ccl/ccl_common.hpp"
+#include "ttnn/tensor/tensor.hpp"
+
+namespace ttnn::operations::experimental::deepseek_prefill::moe_padding_config {
+
+using namespace tt::tt_metal;
+using namespace tt::constants;
+
+namespace {
+
+constexpr auto kWriterKernelPath =
+    "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/moe_padding_config/device/kernels/dataflow/"
+    "writer_moe_padding_config.cpp";
+
+constexpr uint32_t kOutCbIndex = 0;
+constexpr uint32_t kMetaCbIndex = 1;
+// L1-scratch slot the kernel reads each 1-element metadata tensor into (element [0], 4 bytes).
+// Rounded up to a 16B alignment-friendly slot.
+constexpr uint32_t kMetadataBytes = 16;
+
+// Index of the first per-call common runtime arg (the two metadata tensor addresses).
+constexpr uint32_t kArgActualStartAddr = 3;
+constexpr uint32_t kArgActualEndAddr = 4;
+
+// Checks re-run on BOTH the cache-miss and cache-hit paths: none of these are hashed, so a caller
+// could otherwise change them behind a cached program. The per-chunk VALUES live in device tensors
+// and cannot be read host-side without a read-back, so they stay the caller's responsibility (the
+// kernel's arithmetic is total over uint32 regardless — an out-of-range start just yields 0).
+void validate_runtime_args(
+    const MoePaddingConfigDeviceOperation::operation_attributes_t& args,
+    const MoePaddingConfigDeviceOperation::tensor_args_t& tensor_args) {
+    TT_FATAL(args.cluster_axis == 0 || args.cluster_axis == 1, "cluster_axis ({}) must be 0 or 1", args.cluster_axis);
+    TT_FATAL(args.tokens_per_chip > 0, "tokens_per_chip must be positive");
+    TT_FATAL(args.pad_side == 0 || args.pad_side == 1, "pad_side ({}) must be 0 (right) or 1 (left)", args.pad_side);
+
+    const auto& config = tensor_args.config;
+    const auto& mesh_view = config.device()->get_view();
+    TT_FATAL(mesh_view.is_mesh_2d(), "moe_padding_config requires a 2D mesh");
+
+    // Output: what the consumers (moe_grouped_topk / dispatch) require of padding_config, asserted
+    // here so a malformed buffer fails with a clear message instead of a bad on-device read.
+    TT_FATAL(config.storage_type() == StorageType::DEVICE, "config must be on device");
+    TT_FATAL(config.buffer() != nullptr, "config must be allocated");
+    TT_FATAL(config.dtype() == DataType::UINT32, "config must be UINT32");
+    TT_FATAL(config.layout() == Layout::ROW_MAJOR, "config must be ROW_MAJOR");
+    TT_FATAL(
+        config.logical_shape()[-1] >= 2,
+        "config last dim ({}) must hold at least [local_real_tokens, pad_side]",
+        config.logical_shape()[-1]);
+    TT_FATAL(!config.is_sharded(), "config must not be L1-sharded (it is a per-device DRAM row)");
+
+    // Structural properties the kernel assumes of each metadata tensor.
+    auto validate_meta = [&config](const Tensor& meta, const char* name) {
+        TT_FATAL(meta.storage_type() == StorageType::DEVICE, "metadata tensor {} must be on device", name);
+        TT_FATAL(meta.buffer() != nullptr, "metadata tensor {} must be allocated", name);
+        TT_FATAL(meta.dtype() == DataType::UINT32, "metadata tensor {} must be UINT32", name);
+        TT_FATAL(meta.layout() == Layout::ROW_MAJOR, "metadata tensor {} must be ROW_MAJOR", name);
+        TT_FATAL(
+            meta.logical_volume() == 1,
+            "metadata tensor {} must be a single element (got {})",
+            name,
+            meta.logical_volume());
+        TT_FATAL(!meta.is_sharded(), "metadata tensor {} must not be sharded", name);
+        // The kernel resolves meta.buffer()->address() against config.device(); a tensor on a
+        // different mesh device would bake the wrong address and fail obscurely on device.
+        TT_FATAL(meta.device() == config.device(), "metadata tensor {} must be on the same device as config", name);
+    };
+    validate_meta(tensor_args.actual_start, "actual_start");
+    validate_meta(tensor_args.actual_end, "actual_end");
+}
+
+}  // namespace
+
+MoePaddingConfigDeviceOperation::program_factory_t MoePaddingConfigDeviceOperation::select_program_factory(
+    const operation_attributes_t& /*args*/, const tensor_args_t& /*tensor_args*/) {
+    return MeshWorkloadFactory{};
+}
+
+void MoePaddingConfigDeviceOperation::validate_on_program_cache_miss(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    validate_runtime_args(args, tensor_args);
+}
+
+void MoePaddingConfigDeviceOperation::validate_on_program_cache_hit(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    validate_runtime_args(args, tensor_args);
+}
+
+MoePaddingConfigDeviceOperation::spec_return_value_t MoePaddingConfigDeviceOperation::compute_output_specs(
+    const operation_attributes_t& /*args*/, const tensor_args_t& tensor_args) {
+    // In-place: output spec = config spec.
+    return tensor_args.config.tensor_spec();
+}
+
+MoePaddingConfigDeviceOperation::tensor_return_value_t MoePaddingConfigDeviceOperation::create_output_tensors(
+    const operation_attributes_t& /*args*/, const tensor_args_t& tensor_args) {
+    // In-place: return a handle to the caller-owned config tensor.
+    return tensor_args.config;
+}
+
+ttsl::hash::hash_t MoePaddingConfigDeviceOperation::compute_program_hash(
+    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    // The per-chunk values are NEVER hashed: they are read on-device from the metadata tensors, whose
+    // raw addresses live in common runtime args refreshed by override_runtime_arguments. That is the
+    // whole point — one cached program serves every chunk, so it can be captured once and replayed.
+    const auto& config = tensor_args.config;
+    return tt::tt_metal::operation::hash_operation<MoePaddingConfigDeviceOperation>(
+        args.tokens_per_chip,
+        args.pad_side,
+        args.cluster_axis,
+        config.dtype(),
+        config.layout(),
+        config.memory_config(),
+        config.padded_shape());
+}
+
+tt::tt_metal::ProgramDescriptor MoePaddingConfigDeviceOperation::ProgramFactory::create_descriptor(
+    const operation_attributes_t& args,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& /*output*/,
+    const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate) {
+    TT_FATAL(
+        mesh_dispatch_coordinate.has_value(), "MoePaddingConfig::create_descriptor requires a mesh dispatch coordinate");
+    const auto& coord = mesh_dispatch_coordinate.value();
+
+    const auto& config = tensor_args.config;
+    auto* device = config.device();
+
+    // This chip's position along the SP axis — the only thing that distinguishes one chip's config row
+    // from another's. Same derivation as update_padded_kv_cache's writer, so the two cannot drift.
+    const auto& mesh_view = device->get_view();
+    const uint32_t sp_factor = (args.cluster_axis == 0) ? mesh_view.num_rows() : mesh_view.num_cols();
+    const uint32_t my_sp_coord =
+        ::ttnn::ccl::get_linearized_index_from_physical_coord(config, coord, args.cluster_axis);
+
+    // One row of output on one core: there is nothing to parallelize.
+    const CoreCoord core{0, 0};
+    const CoreRangeSet single_core{CoreRange{core, core}};
+
+    // Write the config row a full page at a time (the row may be padded up to the buffer's aligned
+    // page size); the kernel zeroes the slot first so the padding bytes are deterministic.
+    const uint32_t out_page_size = config.buffer()->aligned_page_size();
+
+    tt::tt_metal::ProgramDescriptor desc;
+
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = out_page_size,
+        .core_ranges = single_core,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = kOutCbIndex,
+            .data_format = tt::DataFormat::UInt32,
+            .page_size = out_page_size,
+        }}},
+    });
+
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = kMetadataBytes,
+        .core_ranges = single_core,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = kMetaCbIndex,
+            .data_format = tt::DataFormat::UInt32,
+            .page_size = kMetadataBytes,
+        }}},
+    });
+
+    // Compile args: [0]=cb_out, [1]=cb_meta, [2]=pad_side, [3..]=config accessor, then ONE metadata
+    // accessor (both 1-element tensors share an identical layout, so one accessor serves both reads).
+    KernelDescriptor::CompileTimeArgs writer_compile_args = {kOutCbIndex, kMetaCbIndex, args.pad_side};
+    TensorAccessorArgs(config.buffer()).append_to(writer_compile_args);
+    TensorAccessorArgs(tensor_args.actual_start.buffer()).append_to(writer_compile_args);
+
+    KernelDescriptor writer_kernel;
+    writer_kernel.kernel_source = kWriterKernelPath;
+    writer_kernel.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_kernel.core_ranges = single_core;
+    writer_kernel.compile_time_args = std::move(writer_compile_args);
+    writer_kernel.config = WriterConfigDescriptor{};
+
+    // Common rt-args: [0..2] structural (this chip's mesh position + the rotation period), [3..4] the
+    // per-call metadata tensor addresses that override_runtime_arguments refreshes on cache hits.
+    writer_kernel.emplace_common_runtime_args({
+        my_sp_coord,
+        sp_factor,
+        args.tokens_per_chip,
+        tensor_args.actual_start.buffer()->address(),  // smuggled-rta-ok: 1-element metadata tensor DRAM
+                                                       // addr; read on-device (trace-safe, unhashed)
+        tensor_args.actual_end.buffer()->address(),    // smuggled-rta-ok: as above
+    });
+
+    // The config buffer is passed as a Buffer* binding (not a raw address) so cache hits take the fast
+    // path that patches its address and skips create_descriptor.
+    writer_kernel.emplace_runtime_args(core, {config.buffer()});
+
+    desc.kernels.push_back(std::move(writer_kernel));
+    return desc;
+}
+
+MoePaddingConfigDeviceOperation::MeshWorkloadFactory::cached_mesh_workload_t
+MoePaddingConfigDeviceOperation::MeshWorkloadFactory::create_mesh_workload(
+    const operation_attributes_t& args,
+    const ttnn::MeshCoordinateRangeSet& tensor_coords,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& output) {
+    return descriptor_adapter_t::create_mesh_workload(args, tensor_coords, tensor_args, output);
+}
+
+void MoePaddingConfigDeviceOperation::MeshWorkloadFactory::override_runtime_arguments(
+    cached_mesh_workload_t& cached_workload,
+    const operation_attributes_t& args,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& output) {
+    // Default adapter behaviour: patch operand buffer-binding addresses on cache hits.
+    descriptor_adapter_t::apply_descriptor(cached_workload, args, tensor_args, output);
+    // The metadata addresses are raw scalars in common runtime args, which the buffer-binding fast
+    // path does not refresh — patch them on every cached program or the kernel would keep reading a
+    // stale (possibly freed) address.
+    constexpr uint32_t kWriterKernelHandle = 0;  // the only kernel pushed in create_descriptor
+    const uint32_t start_addr = tensor_args.actual_start.buffer()->address();
+    const uint32_t end_addr = tensor_args.actual_end.buffer()->address();
+    for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
+        auto& writer_common = GetCommonRuntimeArgs(program, kWriterKernelHandle);
+        TT_FATAL(
+            kArgActualEndAddr < writer_common.size(),
+            "moe_padding_config writer is missing its per-call common runtime args");
+        writer_common[kArgActualStartAddr] = start_addr;
+        writer_common[kArgActualEndAddr] = end_addr;
+    }
+}
+
+}  // namespace ttnn::operations::experimental::deepseek_prefill::moe_padding_config
+
+namespace ttnn::prim {
+
+ttnn::Tensor moe_padding_config(
+    const ttnn::Tensor& config,
+    const ttnn::Tensor& actual_start,
+    const ttnn::Tensor& actual_end,
+    uint32_t tokens_per_chip,
+    uint32_t pad_side,
+    uint32_t cluster_axis) {
+    using OperationType =
+        ttnn::operations::experimental::deepseek_prefill::moe_padding_config::MoePaddingConfigDeviceOperation;
+    auto attrs = OperationType::operation_attributes_t{
+        .tokens_per_chip = tokens_per_chip,
+        .pad_side = pad_side,
+        .cluster_axis = cluster_axis,
+    };
+    auto tensor_args = OperationType::tensor_args_t{
+        .config = config,
+        .actual_start = actual_start,
+        .actual_end = actual_end,
+    };
+    return ttnn::device_operation::launch<OperationType>(attrs, tensor_args);
+}
+
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/moe_padding_config/device/moe_padding_config_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/moe_padding_config/device/moe_padding_config_device_operation.hpp
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <variant>
+
+#include <tt-metalium/program.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+
+#include "ttnn/device_operation.hpp"
+#include "ttnn/distributed/types.hpp"
+#include "ttnn/mesh_device_operation_adapter.hpp"
+#include "ttnn/tensor/tensor.hpp"
+
+namespace ttnn::operations::experimental::deepseek_prefill::moe_padding_config {
+
+struct MoePaddingConfigDeviceOperation {
+    struct operation_attributes_t {
+        // Tokens this chip carries per chunk (the MoE's sp_dim). Structural: fixed for the workload,
+        // and the rotation math is expressed in it, so it is hashed.
+        uint32_t tokens_per_chip;
+        // 0 = right, 1 = left. Structural (rotated chunked prefill is right-padded by construction).
+        uint32_t pad_side;
+        // Mesh axis the config is sharded along (the SP axis). Structural.
+        uint32_t cluster_axis;
+    };
+
+    struct tensor_args_t {
+        // In-place output: the per-device [.., 2] UINT32 ROW_MAJOR config row the consumers read.
+        // Caller-owned and persistent, so its address is stable across trace replays.
+        const Tensor& config;
+        // Two 1-element uint32 DRAM tensors ([1,1,1,1], ROW_MAJOR, replicated across the mesh):
+        // absolute KV position of this chunk's first real token, and one past its last. The kernel
+        // reads element [0] of each on-device, keeping the per-chunk values off the host dispatch
+        // path (trace-safe).
+        const Tensor& actual_start;
+        const Tensor& actual_end;
+    };
+
+    using spec_return_value_t = tt::tt_metal::TensorSpec;
+    using tensor_return_value_t = Tensor;
+
+    struct ProgramFactory {
+        static tt::tt_metal::ProgramDescriptor create_descriptor(
+            const operation_attributes_t& args,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& output,
+            const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate);
+    };
+
+    // Minimal operation-shaped helper so the descriptor factory can be adapted into a mesh workload.
+    struct DescriptorAdapterOperation {
+        using operation_attributes_t = MoePaddingConfigDeviceOperation::operation_attributes_t;
+        using tensor_args_t = MoePaddingConfigDeviceOperation::tensor_args_t;
+        using spec_return_value_t = MoePaddingConfigDeviceOperation::spec_return_value_t;
+        using tensor_return_value_t = MoePaddingConfigDeviceOperation::tensor_return_value_t;
+    };
+
+    // Wraps the ProgramDescriptor factory so the default adapter patches buffer bindings on cache
+    // hits, and override_runtime_arguments additionally refreshes the two metadata tensors' raw DRAM
+    // addresses (common runtime args, which the buffer-binding fast path would leave stale).
+    struct MeshWorkloadFactory {
+        using descriptor_adapter_t = ttnn::device_operation::MeshDeviceOperationAdapter<
+            DescriptorAdapterOperation>::DescriptorMeshWorkloadAdapter<ProgramFactory>;
+        using cached_mesh_workload_t = typename descriptor_adapter_t::cached_mesh_workload_t;
+
+        static cached_mesh_workload_t create_mesh_workload(
+            const operation_attributes_t& args,
+            const ttnn::MeshCoordinateRangeSet& tensor_coords,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& output);
+
+        static void override_runtime_arguments(
+            cached_mesh_workload_t& cached_workload,
+            const operation_attributes_t& args,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& output);
+    };
+
+    using program_factory_t = std::variant<MeshWorkloadFactory>;
+
+    static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
+    static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
+    static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
+    static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+};
+
+}  // namespace ttnn::operations::experimental::deepseek_prefill::moe_padding_config
+
+namespace ttnn::prim {
+
+ttnn::Tensor moe_padding_config(
+    const ttnn::Tensor& config,
+    const ttnn::Tensor& actual_start,
+    const ttnn::Tensor& actual_end,
+    uint32_t tokens_per_chip,
+    uint32_t pad_side,
+    uint32_t cluster_axis);
+
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/moe_padding_config/moe_padding_config.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/moe_padding_config/moe_padding_config.cpp
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "moe_padding_config.hpp"
+
+#include "device/moe_padding_config_device_operation.hpp"
+
+namespace ttnn::operations::experimental::deepseek_prefill::moe_padding_config {
+
+ttnn::Tensor moe_padding_config(
+    const ttnn::Tensor& config,
+    const ttnn::Tensor& actual_start,
+    const ttnn::Tensor& actual_end,
+    uint32_t tokens_per_chip,
+    uint32_t pad_side,
+    uint32_t cluster_axis) {
+    return ttnn::prim::moe_padding_config(config, actual_start, actual_end, tokens_per_chip, pad_side, cluster_axis);
+}
+
+}  // namespace ttnn::operations::experimental::deepseek_prefill::moe_padding_config

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/moe_padding_config/moe_padding_config.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/moe_padding_config/moe_padding_config.hpp
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+#include "ttnn/tensor/tensor.hpp"
+
+namespace ttnn::operations::experimental::deepseek_prefill::moe_padding_config {
+
+// Builds the per-device MoE padding config — [local_real_tokens, pad_side] — ON DEVICE, from this
+// chunk's `actual_start` / `actual_end` held in two 1-element uint32 tensors.
+//
+// This is the traceable counterpart of the host builder (TtMoEGatePrefill.build_padding_config), which
+// ends in a ttnn.from_torch and so cannot run inside a trace capture. The consumers
+// (moe_grouped_topk's gate and the dispatch op) already read padding_config as a device tensor, so
+// moving only its producer on-device makes the whole padding-aware path traceable with no downstream
+// change: one captured program recomputes the correct config on every replay.
+//
+// Counts are derived for the KV-pad-aware ROTATED block-cyclic layout, mirroring
+// update_padded_kv_cache's writer (same boundary_slab / boundary_chip / boundary_offset), and reduce
+// exactly to the sequential formula when `actual_start` is slab-aligned (including 0) — so one op
+// covers both the rotated and non-rotated cases.
+//
+// NOT covered: the `is_balanced=True` zigzag placement, whose per-device count is not expressible in
+// this form. Rotated chunked prefill implies is_balanced=False (ttMLA._chunked_attn asserts it), so
+// that combination is unreachable here; balanced callers must keep using the host builder.
+//
+// In-place: returns a handle to `config`. `config` is caller-owned and must be persistent (a stable
+// address) for a captured trace to keep writing the same buffer across replays.
+//
+// Args:
+//   config:          per-device [.., 2] UINT32 ROW_MAJOR DRAM tensor (the global tensor is
+//                    [sp_factor, 2] sharded along `cluster_axis`, so each chip holds one row).
+//   actual_start:    1-element uint32 DRAM tensor ([1,1,1,1], ROW_MAJOR, replicated) — absolute KV
+//                    position of this chunk's first real token.
+//   actual_end:      1-element uint32 DRAM tensor (same layout) — one past its last real token.
+//   tokens_per_chip: tokens this chip carries per chunk (the MoE's sp_dim).
+//   pad_side:        0 = right, 1 = left.
+//   cluster_axis:    mesh axis the config is sharded along (the SP axis).
+ttnn::Tensor moe_padding_config(
+    const ttnn::Tensor& config,
+    const ttnn::Tensor& actual_start,
+    const ttnn::Tensor& actual_end,
+    uint32_t tokens_per_chip,
+    uint32_t pad_side,
+    uint32_t cluster_axis);
+
+}  // namespace ttnn::operations::experimental::deepseek_prefill::moe_padding_config
+
+namespace ttnn {
+using operations::experimental::deepseek_prefill::moe_padding_config::moe_padding_config;
+}  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/moe_padding_config/moe_padding_config_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/moe_padding_config/moe_padding_config_nanobind.cpp
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "moe_padding_config_nanobind.hpp"
+
+#include <nanobind/nanobind.h>
+
+#include "ttnn-nanobind/bind_function.hpp"
+#include "moe_padding_config.hpp"
+
+namespace ttnn::operations::experimental::deepseek_prefill::moe_padding_config::detail {
+
+void bind_moe_padding_config(nb::module_& mod) {
+    ttnn::bind_function<"moe_padding_config", "ttnn.experimental.deepseek_prefill.">(
+        mod,
+        R"doc(
+            Build the per-device MoE padding config -- ``[local_real_tokens, pad_side]`` -- ON DEVICE
+            from this chunk's ``actual_start`` / ``actual_end``.
+
+            This is the traceable counterpart of the host builder
+            (``TtMoEGatePrefill.build_padding_config``), which ends in a ``ttnn.from_torch`` and so
+            cannot run inside a trace capture. The consumers (the ``moe_grouped_topk`` gate and the
+            ``dispatch`` op) already read ``padding_config`` as a device tensor, so moving only its
+            producer on-device makes the whole padding-aware path traceable with no downstream change:
+            one captured program recomputes the correct config on every replay.
+
+            Counts are derived for the KV-pad-aware ROTATED block-cyclic layout, mirroring
+            ``update_padded_kv_cache``'s writer, and reduce exactly to the sequential formula when
+            ``actual_start`` is slab-aligned (including 0) -- so one op covers the rotated and
+            non-rotated cases alike.
+
+            NOT covered: the ``is_balanced=True`` zigzag placement, whose per-device count is not
+            expressible in this form. Rotated chunked prefill implies ``is_balanced=False``, so that
+            combination is unreachable here; balanced callers must keep using the host builder.
+
+            In place: returns a handle to ``config``.
+
+            Args:
+                config (ttnn.Tensor): per-device [.., 2] UINT32 ROW_MAJOR DRAM tensor written in
+                    place. The global tensor is [sp_factor, 2] sharded along ``cluster_axis``, so each
+                    chip holds one row. Caller-owned; must be PERSISTENT (a stable address) for a
+                    captured trace to keep writing the same buffer across replays.
+                actual_start (ttnn.Tensor): 1-element uint32 DRAM tensor ([1,1,1,1], ROW_MAJOR,
+                    replicated across the mesh) holding the absolute KV position of this chunk's
+                    first real token. Read on-device (element [0]).
+                actual_end (ttnn.Tensor): 1-element uint32 DRAM tensor (same layout) holding one past
+                    this chunk's last real token. Read on-device (element [0]).
+                tokens_per_chip (int): tokens this chip carries per chunk (the MoE's sp_dim).
+                    Structural.
+                pad_side (int): 0 = right, 1 = left. Structural.
+                cluster_axis (int): mesh axis the config is sharded along (the SP axis, 0 or 1).
+                    Structural.
+
+            Returns:
+                ttnn.Tensor: handle to ``config``, with this chip's row written.
+        )doc",
+        &moe_padding_config,
+        nb::arg("config").noconvert(),
+        nb::arg("actual_start").noconvert(),
+        nb::arg("actual_end").noconvert(),
+        nb::arg("tokens_per_chip"),
+        nb::arg("pad_side"),
+        nb::arg("cluster_axis"));
+}
+
+}  // namespace ttnn::operations::experimental::deepseek_prefill::moe_padding_config::detail

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/moe_padding_config/moe_padding_config_nanobind.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/moe_padding_config/moe_padding_config_nanobind.hpp
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn-nanobind/nanobind_fwd.hpp"
+
+namespace ttnn::operations::experimental::deepseek_prefill::moe_padding_config::detail {
+
+namespace nb = nanobind;
+
+void bind_moe_padding_config(nb::module_& mod);
+
+}  // namespace ttnn::operations::experimental::deepseek_prefill::moe_padding_config::detail

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/moe_padding_config/sources.cmake
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/moe_padding_config/sources.cmake
@@ -1,0 +1,16 @@
+# Source files for ttnn_op_experimental_deepseek_prefill_moe_padding_config.
+# Module owners should update this file when adding/removing/renaming source files.
+
+set(TTNN_OP_EXPERIMENTAL_DEEPSEEK_PREFILL_MOE_PADDING_CONFIG_API_HEADERS moe_padding_config.hpp)
+
+set(TTNN_OP_EXPERIMENTAL_DEEPSEEK_PREFILL_MOE_PADDING_CONFIG_SRCS
+    device/moe_padding_config_device_operation.cpp
+    moe_padding_config.cpp
+)
+
+# Registered on the shared `ttnn` Python module target from
+# ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/moe_padding_config/CMakeLists.txt (see the `if(TARGET ttnn)` block there).
+# Listed here rather than inline in CMakeLists.txt so that
+# add/remove/rename doesn't touch a file with metalium-developers-infra
+# as a required co-owner.
+set(TTNN_OP_EXPERIMENTAL_DEEPSEEK_PREFILL_MOE_PADDING_CONFIG_NANOBIND_SRCS moe_padding_config_nanobind.cpp)

--- a/ttnn/cpp/ttnn/operations/experimental/experimental_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/experimental_nanobind.cpp
@@ -81,6 +81,7 @@
 #include "ttnn/operations/experimental/deepseek_prefill/post_combine_reduce/post_combine_reduce_nanobind.hpp"
 #include "ttnn/operations/experimental/deepseek_prefill/masked_bincount/masked_bincount_nanobind.hpp"
 #include "ttnn/operations/experimental/deepseek_prefill/offset_cumsum/offset_cumsum_nanobind.hpp"
+#include "ttnn/operations/experimental/deepseek_prefill/moe_padding_config/moe_padding_config_nanobind.hpp"
 #include "ttnn/operations/experimental/deepseek_prefill/outbound_socket_service_sync/outbound_socket_service_sync_nanobind.hpp"
 #include "ttnn/operations/experimental/deepseek_prefill/per_token_cast_to_fp8/per_token_cast_to_fp8_nanobind.hpp"
 #include "ttnn/operations/experimental/deepseek_prefill/pack_scaled_fp8_kv_cache/pack_scaled_fp8_kv_cache_nanobind.hpp"
@@ -154,6 +155,7 @@ void py_module(nb::module_& mod) {
     matmul_decode::detail::bind_matmul_decode_operation(mod);
     deepseek_prefill::masked_bincount::detail::bind_experimental_masked_bincount_operation(mod);
     deepseek_prefill::offset_cumsum::detail::bind_experimental_offset_cumsum_operation(mod);
+    deepseek_prefill::moe_padding_config::detail::bind_moe_padding_config(mod);
     deepseek_prefill::detail::bind_outbound_socket_service_sync(mod);
     deepseek_prefill::detail::bind_post_combine_reduce(mod);
     deepseek_prefill::moe_grouped_topk::detail::bind_moe_grouped_topk(mod);


### PR DESCRIPTION
Relates to #47500.

Replays the DeepSeek/Kimi chunked-prefill forward from a single ttnn trace capture instead of re-dispatching op-by-op every chunk. On Kimi K2.6 / 61 layers this removes a fixed ~0.5 s/chunk host-dispatch cost (mean per chunk 1.219 s → 0.963 s, −21 %).

A captured program can't contain host transfers or reads, so every per-chunk value (slot_id, actual_start, actual_end) must be readable on-device. The four metadata overloads that enable that — rotary_embedding_indexed, update_padded_kv_cache, zero_padded_kv_cache, ring_mla — are already on main. This PR adds the trace layer that uses them, plus the one op they were missing.

- SubDeviceTraceController — records the forward as several segments, split at the MoE sub-device load/clear and at each per-layer ack. Both are host actions illegal inside a capture, so they run between segments at replay. This is what keeps the MoE overlap on under trace.
- TtPrefillRuntime traced path — capture_trace() records once before the request loop; prefill_chunk() refreshes metadata in place and replays.
- moe_padding_config — new device op, the only one not on main. Builds the per-chip padding config on-device; the host builder ends in ttnn.from_torch, illegal in a capture, so without it padding-aware MoE can't survive a trace. Count is closed-form and reduces to the sequential formula when slab-aligned, so one kernel covers rotated and non-rotated.
- Runner — PREFILL_USE_TRACE, capture after D2D + LayerAck wiring, release_trace() before close_mesh_device.
- Tests — op unit test; three Kimi tests (padded / chunked / perf), each notrace|traced. CI runs the padded and perf pairs, one case per entry.

Validation (galaxy, Kimi K2.6, 61 layers, 8x4, code_debug 55k golden) — traced == untraced to six decimals:

┌─────────────────────────────────────┬────────────┬────────────────┐
│              geometry               │ full depth │ asserted 0..10 │
├─────────────────────────────────────┼────────────┼────────────────┤
│ padded/rotated (18 variable chunks) │ 0.935070   │ 0.992248       │
├─────────────────────────────────────┼────────────┼────────────────┤
│ aligned (11 × 5120)                 │ 0.932384   │ 0.991887       │
└─────────────────────────────────────┴────────────┴────────────────┘

Padded untraced also asserts decoder-output PCC 0.949096. Runner end-to-end with the real H2D producer (180-segment capture / 45.62 MB): KV min PCC 0.932384 from both the runner-side check and the
producer's device-less read-back; per-chunk 720 ms → 1355 ms.

Notes for reviewers

Full text is in the file — the four points I'd most want scrutinised:

1. Dense-MLA only is an assert, not a preference. The captured forward never threads replay without its indexer cache and emit plausible-but-wrong KV. Rejected in three
places.
2. #51440 / #48826 coexistence exposed real bugs — a memo keyed without actual_start (equal-length chunks at different starts reused the first chunk's config), a freed cache-owned tensor, and use_trace + num_ranks>1 silently emitting zero completions.
3. The pipeline router is unrun on hardware (needs 2 galaxies), and replay() syncs bhat pipeline cost is unmeasured.
4. The perf gate is inert and its key can't distinguish traced from untraced, so donperf numbers came from a 75 W host so absolutes aren't baseline material.

- [ ] [![blackhole-e2e-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=ppopovic/trace_merge_rebase)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:ppopovic/trace_merge_rebase)
- [ ] [![t3k e2e](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml/badge.svg?branch=ppopovic/trace_merge_rebase)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml?query=branch:ppopovic/trace_merge_rebase)
- [ ] [![blaze prefill](https://github.com/tenstorrent/tt-metal/actions/workflows/blaze-models-prefill-tests.yaml/badge.svg?branch=ppopovic/trace_merge_rebase)](https://github.com/tenstorrent/tt-metal/actions/workflows/blaze-models-prefill-tests.yaml?query=branch:ppopovic/trace_merge_rebase)
### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ppopovic/trace_merge_rebase)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ppopovic/trace_merge_rebase)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ppopovic/trace_merge_rebase)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ppopovic/trace_merge_rebase)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ppopovic/trace_merge_rebase)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ppopovic/trace_merge_rebase)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ppopovic/trace_merge_rebase)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ppopovic/trace_merge_rebase)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ppopovic/trace_merge_rebase)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ppopovic/trace_merge_rebase)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ppopovic/trace_merge_rebase)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ppopovic/trace_merge_rebase)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ppopovic/trace_merge_rebase)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ppopovic/trace_merge_rebase)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ppopovic/trace_merge_rebase)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ppopovic/trace_merge_rebase)
