### PR TITLE
Reject too large per-core M values in multicast matmul

### DIFF
--- a/tests/ttnn/unit_tests/operations/matmul/test_matmul_per_core_m_validation.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_matmul_per_core_m_validation.py
@@ -1,0 +1,118 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Validator tests for mcast reuse matmul program configs.
+
+The 2D reuse-mcast sender-writer path (used by every core in the M-column
+when ``num_blocks_y == 1``) always emits ``per_core_M`` tile-rows and does
+not clamp its H-loop to ``Mt``. When ``per_core_M > Mt`` those extra rows
+land past the end of the output DRAM buffer and silently corrupt whichever
+allocations follow it in the interleaved DRAM page stream. The 1D
+``mcast_in1`` path has the analogous bug at ``start_core``.
+
+These tests exercise the validator asserts added in
+``matmul_device_operation.cpp`` that reject those configs up front.
+"""
+
+import pytest
+import torch
+
+import ttnn
+
+
+M = 128  # Mt = M / TILE = 4
+K = 32
+N = 32
+TILE = 32
+
+
+def _from_torch(t: torch.Tensor, device) -> ttnn.Tensor:
+    return ttnn.from_torch(
+        t,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+
+def _make_inputs(device):
+    torch.manual_seed(0)
+    a = torch.zeros((1, 1, M, K), dtype=torch.bfloat16)
+    b = torch.zeros((1, 1, K, N), dtype=torch.bfloat16)
+    return _from_torch(a, device), _from_torch(b, device)
+
+
+@pytest.mark.parametrize(
+    "per_core_M",
+    [
+        pytest.param(7, id="per_core_M=7"),
+        pytest.param(8, id="per_core_M=8"),
+    ],
+)
+def test_mcast_2d_rejects_per_core_M_gt_Mt(device, expect_error, per_core_M):
+    """2D reuse-mcast must reject ``per_core_M > Mt`` at validate time.
+
+    Otherwise the sender-writer's H-loop overruns the output DRAM buffer by
+    ``(per_core_M - Mt)`` tile-rows per core.
+    """
+    activation_tt, weight_tt = _make_inputs(device)
+    program_config = ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+        compute_with_storage_grid_size=ttnn.CoreCoord(1, 1),
+        in0_block_w=1,
+        out_subblock_h=1,
+        out_subblock_w=1,
+        per_core_M=per_core_M,
+        per_core_N=1,
+        transpose_mcast=False,
+        fused_activation=None,
+        fuse_batch=True,
+    )
+
+    with expect_error(RuntimeError, "per_core_M .* must be <= Mt"):
+        ttnn.matmul(
+            activation_tt,
+            weight_tt,
+            program_config=program_config,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            dtype=ttnn.bfloat16,
+        )
+
+
+@pytest.mark.parametrize(
+    "per_core_M",
+    [
+        pytest.param(7, id="per_core_M=7"),
+        pytest.param(8, id="per_core_M=8"),
+    ],
+)
+def test_mcast_1d_mcast_in1_rejects_per_core_M_gt_Mt(device, expect_error, per_core_M):
+    """1D reuse-mcast with ``mcast_in0=False`` (mcast_in1) must reject
+    ``per_core_M > Mt``. ``mcast_in0`` is unaffected — its factory clamps
+    ``in0_last_per_core_M = min(M, per_core_M)`` and pushes the clamped H
+    count into the sender-writer runtime args, which is why the existing
+    ``num_blocks_y == 1`` check for that mode is safe.
+    """
+    activation_tt, weight_tt = _make_inputs(device)
+    program_config = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+        compute_with_storage_grid_size=ttnn.CoreCoord(1, 1),
+        in0_block_w=1,
+        out_subblock_h=1,
+        out_subblock_w=1,
+        per_core_M=per_core_M,
+        per_core_N=1,
+        fuse_batch=True,
+        fused_activation=None,
+        mcast_in0=False,
+        gather_in0=False,
+    )
+
+    with expect_error(RuntimeError, "mcast_in1 requires per_core_M .* <= Mt"):
+        ttnn.matmul(
+            activation_tt,
+            weight_tt,
+            program_config=program_config,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            dtype=ttnn.bfloat16,
+        )

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
@@ -757,6 +757,21 @@ void validate_matmul_work_distribution_and_gather_ring_topology(
                             Mt,
                             per_core_M,
                             num_blocks_y);
+                    } else {
+                        // mcast_in1's sender-writer at start_core does not clamp its H-loop to Mt;
+                        // it always emits per_core_M tile-rows. When per_core_M > Mt the tail rows
+                        // land past the end of the output DRAM buffer and silently corrupt
+                        // neighboring allocations. mcast_in0 is safe here because its factory
+                        // explicitly derives in0_last_per_core_M = min(M, per_core_M) and pushes
+                        // the clamped H count into the sender-writer runtime args.
+                        TT_FATAL(
+                            per_core_M <= Mt,
+                            "{}: mcast_in1 requires per_core_M ({}) <= Mt ({}); the mcast_in1 "
+                            "sender-writer path does not clamp H at start_core and would write "
+                            "out of bounds.",
+                            config_name,
+                            per_core_M,
+                            Mt);
                     }
                     check_output_shard_grid_within_extent(output_mem_config, grid, config_name);
                 }
@@ -792,6 +807,18 @@ void validate_matmul_work_distribution_and_gather_ring_topology(
                     config_name,
                     num_blocks_y,
                     grid.y);
+                // The 2D reuse-mcast sender-writer path (used by every core in the M-column when
+                // num_blocks_y == 1) does not clamp its H-loop to Mt; it always emits per_core_M
+                // tile-rows. When per_core_M > Mt the tail (per_core_M - Mt) rows land past the
+                // end of the output DRAM buffer and silently corrupt whatever is allocated after
+                // it. Reject the config here rather than let it OOB at runtime.
+                TT_FATAL(
+                    program_config.per_core_M <= Mt,
+                    "{}: per_core_M ({}) must be <= Mt ({}); the 2D reuse-mcast sender-writer "
+                    "path does not clamp H for last-row cores and would write out of bounds.",
+                    config_name,
+                    program_config.per_core_M,
+                    Mt);
                 check_output_shard_grid_within_extent(output_mem_config, grid, config_name);
             } else if constexpr (std::is_same_v<
                                      ProgramConfigType,


### PR DESCRIPTION
### PR Category
Fixes

### Summary
* Adds an assertion `per_core_M <= Mt` for mcast program factories that was previously missing, causing issue #51550
* Adds a unit test with expected assertion fail for `per_core_M > Mt`

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ichovpan/matmul-oob-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ichovpan/matmul-oob-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ichovpan/matmul-oob-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ichovpan/matmul-oob-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ichovpan/matmul-oob-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ichovpan/matmul-oob-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ichovpan/matmul-oob-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ichovpan/matmul-oob-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ichovpan/matmul-oob-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ichovpan/matmul-oob-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ichovpan/matmul-oob-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ichovpan/matmul-oob-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ichovpan/matmul-oob-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ichovpan/matmul-oob-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ichovpan/matmul-oob-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ichovpan/matmul-oob-fix)