### PR TITLE
[ttnn] Metal 2.0: one enforced way to key a program cache, and only one

### DIFF
--- a/tests/ttnn/unit_tests/gtests/sources.cmake
+++ b/tests/ttnn/unit_tests/gtests/sources.cmake
@@ -30,6 +30,7 @@ set(UNIT_TESTS_TTNN_BASIC_SOURCES
     test_graph_query_op_runtime.cpp
     test_launch_operation.cpp
     test_matmul.cpp
+    test_quasar_program_keying.cpp
     test_matmul_multicore.cpp
     test_matmul_sweep.cpp
     test_reduction.cpp

--- a/tests/ttnn/unit_tests/gtests/test_launch_operation.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_launch_operation.cpp
@@ -201,6 +201,178 @@ static_assert(!device_operation::SupportsPerCoreAllocation<per_core_opt_in_test:
 static_assert(device_operation::SupportsPerCoreAllocation<per_core_opt_in_test::OptedIn>);
 static_assert(!device_operation::SupportsPerCoreAllocation<per_core_opt_in_test::OptedOut>);
 
+// Program-cache keying hooks: which half of the key each hook moves, and that a relaxation loosens a
+// TensorSpec comparison without letting two tensor_args layouts share a key.
+namespace keying_hooks_test {
+
+using tt::tt_metal::experimental::TensorSpecRelaxations;
+using ::ttnn::device_operation::detail::compute_op_hash;
+
+struct Attributes {
+    uint32_t knob = 0;
+    uint32_t seed = 0;
+};
+
+struct Inputs {
+    Tensor input;
+    std::optional<Tensor> first_optional;
+    std::optional<Tensor> second_optional;
+};
+
+ttsl::SmallVector<TensorSpecRelaxations> strict_for_each_tensor(
+    const Inputs& tensor_args, TensorSpecRelaxations input) {
+    ttsl::SmallVector<TensorSpecRelaxations> relaxations{input};
+    if (tensor_args.first_optional.has_value()) {
+        relaxations.emplace_back();
+    }
+    if (tensor_args.second_optional.has_value()) {
+        relaxations.emplace_back();
+    }
+    return relaxations;
+}
+
+struct DefaultKeyedOp {
+    using operation_attributes_t = Attributes;
+    using tensor_args_t = Inputs;
+};
+
+struct PaddedShapeOnlyOp {
+    using operation_attributes_t = Attributes;
+    using tensor_args_t = Inputs;
+    static ttsl::SmallVector<TensorSpecRelaxations> tensor_args_relaxations(const Inputs& tensor_args) {
+        return strict_for_each_tensor(tensor_args, TensorSpecRelaxations{.match_padded_shape_only = true});
+    }
+};
+
+// The rand pattern: names every field, declares the one the key ignores.
+struct SeedDroppingAttributes {
+    uint32_t knob = 0;
+    uint32_t seed = 0;
+
+    static constexpr auto attribute_names = std::forward_as_tuple("knob", "seed");
+    auto attribute_values() const { return std::forward_as_tuple(knob, seed); }
+    static constexpr auto attributes_excluded_from_key = std::forward_as_tuple("seed");
+};
+
+struct SeedDroppingOp {
+    using operation_attributes_t = SeedDroppingAttributes;
+    using tensor_args_t = Inputs;
+};
+
+struct MiscountingOp {
+    using operation_attributes_t = Attributes;
+    using tensor_args_t = Inputs;
+    static ttsl::SmallVector<TensorSpecRelaxations> tensor_args_relaxations(const Inputs&) { return {}; }
+};
+
+static_assert(!device_operation::HasTensorArgsRelaxations<DefaultKeyedOp>);
+static_assert(device_operation::HasTensorArgsRelaxations<PaddedShapeOnlyOp>);
+static_assert(device_operation::HasExcludedAttributes<SeedDroppingAttributes>);
+static_assert(device_operation::attributes_fully_declared<SeedDroppingAttributes>());
+static_assert(!device_operation::HasTensorArgsRelaxations<SeedDroppingOp>);
+static_assert(!device_operation::HasLegacyProgramHash<SeedDroppingOp>);
+
+// The adapter static_asserts on "spec factory AND legacy hash"; pin that conjunction as detectable
+// (the adapter is deliberately not instantiated for the bad one).
+struct SpecFactoryOp {
+    using operation_attributes_t = Attributes;
+    using tensor_args_t = Inputs;
+    using program_factory_t = std::variant<ProgramSpecFactory>;
+};
+struct SpecFactoryOpWithLegacyHash {
+    using operation_attributes_t = Attributes;
+    using tensor_args_t = Inputs;
+    using program_factory_t = std::variant<ProgramSpecFactory>;
+    static ttsl::hash::hash_t compute_program_hash(const Attributes&, const Inputs&) { return 0; }
+};
+struct LegacyFactoryOpWithLegacyHash {
+    using operation_attributes_t = Attributes;
+    using tensor_args_t = Inputs;
+    using program_factory_t = std::variant<NewInfraProgramFactory>;
+    static ttsl::hash::hash_t compute_program_hash(const Attributes&, const Inputs&) { return 0; }
+};
+
+static_assert(device_operation::HasSpecProgramFactory<SpecFactoryOp>);
+static_assert(!device_operation::HasLegacyProgramHash<SpecFactoryOp>);
+static_assert(device_operation::HasSpecProgramFactory<SpecFactoryOpWithLegacyHash>);
+static_assert(device_operation::HasLegacyProgramHash<SpecFactoryOpWithLegacyHash>);
+static_assert(!device_operation::HasSpecProgramFactory<LegacyFactoryOpWithLegacyHash>);
+static_assert(device_operation::HasLegacyProgramHash<LegacyFactoryOpWithLegacyHash>);
+static_assert(!device_operation::HasSpecProgramFactory<DefaultKeyedOp>);
+
+Tensor make_host_tensor(const ttnn::Shape& logical_shape, Layout layout = Layout::TILE) {
+    const tt::tt_metal::TensorSpec spec(
+        logical_shape, tt::tt_metal::TensorLayout(DataType::FLOAT32, layout, MemoryConfig{}));
+    return Tensor::from_vector(std::vector<float>(logical_shape.volume()), spec);
+}
+
+// Same padded_shape (TILE rounds both to 32x32), different logical_shape.
+Tensor make_logical_30x32() { return make_host_tensor(ttnn::Shape{1, 1, 30, 32}); }
+Tensor make_logical_32x32() { return make_host_tensor(ttnn::Shape{1, 1, 32, 32}); }
+
+TEST(ProgramHashTest, DefaultKeysOnEverything) {
+    const Inputs tensor_args{.input = make_logical_30x32()};
+    const Inputs other_logical_shape{.input = make_logical_32x32()};
+
+    EXPECT_NE(
+        compute_op_hash<DefaultKeyedOp>(Attributes{.knob = 1, .seed = 1}, tensor_args),
+        compute_op_hash<DefaultKeyedOp>(Attributes{.knob = 1, .seed = 2}, tensor_args));
+    EXPECT_NE(
+        compute_op_hash<DefaultKeyedOp>(Attributes{.knob = 1, .seed = 1}, tensor_args),
+        compute_op_hash<DefaultKeyedOp>(Attributes{.knob = 1, .seed = 1}, other_logical_shape));
+}
+
+TEST(ProgramHashTest, AttributesHashDropsSeedButKeepsTheRest) {
+    const Inputs tensor_args{.input = make_logical_30x32()};
+
+    EXPECT_EQ(
+        compute_op_hash<SeedDroppingOp>(SeedDroppingAttributes{.knob = 1, .seed = 1}, tensor_args),
+        compute_op_hash<SeedDroppingOp>(SeedDroppingAttributes{.knob = 1, .seed = 2}, tensor_args));
+    EXPECT_NE(
+        compute_op_hash<SeedDroppingOp>(SeedDroppingAttributes{.knob = 1, .seed = 1}, tensor_args),
+        compute_op_hash<SeedDroppingOp>(SeedDroppingAttributes{.knob = 2, .seed = 1}, tensor_args));
+    EXPECT_NE(
+        compute_op_hash<SeedDroppingOp>(SeedDroppingAttributes{}, tensor_args),
+        compute_op_hash<SeedDroppingOp>(SeedDroppingAttributes{}, Inputs{.input = make_logical_32x32()}));
+}
+
+TEST(ProgramHashTest, PaddedShapeOnlyRelaxationSharesAKey) {
+    const Attributes attrs{};
+    const Inputs logical_30{.input = make_logical_30x32()};
+    const Inputs logical_32{.input = make_logical_32x32()};
+
+    EXPECT_NE(compute_op_hash<DefaultKeyedOp>(attrs, logical_30), compute_op_hash<DefaultKeyedOp>(attrs, logical_32));
+    EXPECT_EQ(
+        compute_op_hash<PaddedShapeOnlyOp>(attrs, logical_30), compute_op_hash<PaddedShapeOnlyOp>(attrs, logical_32));
+
+    // Relaxing logical_shape relaxes nothing else.
+    const Inputs row_major{.input = make_host_tensor(ttnn::Shape{1, 1, 32, 32}, Layout::ROW_MAJOR)};
+    EXPECT_NE(
+        compute_op_hash<PaddedShapeOnlyOp>(attrs, logical_32), compute_op_hash<PaddedShapeOnlyOp>(attrs, row_major));
+}
+
+TEST(ProgramHashTest, RelaxationPreservesTensorArgsStructure) {
+    const Attributes attrs{};
+    const Tensor tensor = make_logical_32x32();
+
+    // Same tensor and count, different slot -> different program, so different key.
+    const Inputs in_first_slot{.input = tensor, .first_optional = tensor};
+    const Inputs in_second_slot{.input = tensor, .second_optional = tensor};
+    EXPECT_NE(
+        compute_op_hash<PaddedShapeOnlyOp>(attrs, in_first_slot),
+        compute_op_hash<PaddedShapeOnlyOp>(attrs, in_second_slot));
+
+    EXPECT_NE(
+        compute_op_hash<PaddedShapeOnlyOp>(attrs, Inputs{.input = tensor}),
+        compute_op_hash<PaddedShapeOnlyOp>(attrs, in_first_slot));
+}
+
+TEST(ProgramHashTest, MiscountedRelaxationsAreRejected) {
+    EXPECT_ANY_THROW(compute_op_hash<MiscountingOp>(Attributes{}, Inputs{.input = make_logical_32x32()}));
+}
+
+}  // namespace keying_hooks_test
+
 TEST(LaunchOperationTest, MeshDeviceOperationAdapterGetName) {
     using ::ttnn::operations::examples::ExampleDeviceOperation;
     EXPECT_EQ(

--- a/tests/ttnn/unit_tests/gtests/test_quasar_program_keying.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_quasar_program_keying.cpp
@@ -1,0 +1,124 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gmock/gmock.h>
+
+#include "ttnn/operations/conv/conv2d/device/conv2d_device_operation_types.hpp"
+#include "ttnn/operations/experimental/quasar/conv2d/device/conv2d_device_operation.hpp"
+#include "ttnn/operations/experimental/quasar/slice/device/slice_device_operation.hpp"
+#include "ttnn/device_operation.hpp"
+#include "ttnn/tensor/tensor.hpp"
+
+// These ops had custom program hashes that keyed on less than the framework's reflection does. The
+// hashes are gone; these pin what the key must still discriminate, so a narrowing regression fails here.
+namespace ttnn {
+namespace {
+
+using ::ttnn::device_operation::detail::compute_program_hash;
+
+Tensor host_tensor(const ttnn::Shape& logical_shape, Layout layout = Layout::TILE) {
+    const tt::tt_metal::TensorSpec spec(
+        logical_shape, tt::tt_metal::TensorLayout(DataType::FLOAT32, layout, MemoryConfig{}));
+    return Tensor::from_vector(std::vector<float>(logical_shape.volume()), spec);
+}
+
+using ConvOp = ttnn::prim::qsr::Conv2dDeviceOperation;
+
+ttnn::prim::Conv2dInputs conv_inputs() {
+    return ttnn::prim::Conv2dInputs{
+        .a = host_tensor(ttnn::Shape{1, 1, 64, 32}), .b = host_tensor(ttnn::Shape{1, 1, 32, 32}), .bias = std::nullopt};
+}
+
+// full_inner_dim selects slice_inner_dim in the sharded factory, so it changes the program. The removed
+// custom hash left it out: these two convs shared one cache entry, and the second reused the first's
+// program. Reflection over Conv2dParams keys it.
+TEST(QuasarKeyingTest, Conv2dKeysFullInnerDim) {
+    ttnn::prim::Conv2dParams params{};
+    auto other = params;
+    other.full_inner_dim = !params.full_inner_dim;
+
+    const auto inputs = conv_inputs();
+    EXPECT_NE(compute_program_hash<ConvOp>(params, inputs), compute_program_hash<ConvOp>(other, inputs));
+}
+
+TEST(QuasarKeyingTest, Conv2dKeepsKeyingTheOldHashFields) {
+    const ttnn::prim::Conv2dParams params{};
+    const auto inputs = conv_inputs();
+    EXPECT_EQ(compute_program_hash<ConvOp>(params, inputs), compute_program_hash<ConvOp>(params, inputs));
+
+    // A sample of the fields the removed hash listed; each must still split the key.
+    auto changed_channels = params;
+    changed_channels.output_channels = params.output_channels + 1;
+    EXPECT_NE(compute_program_hash<ConvOp>(params, inputs), compute_program_hash<ConvOp>(changed_channels, inputs));
+
+    auto changed_bias = params;
+    changed_bias.has_bias = !params.has_bias;
+    EXPECT_NE(compute_program_hash<ConvOp>(params, inputs), compute_program_hash<ConvOp>(changed_bias, inputs));
+
+    auto changed_dtype = params;
+    changed_dtype.dtype = DataType::BFLOAT16;
+    EXPECT_NE(compute_program_hash<ConvOp>(params, inputs), compute_program_hash<ConvOp>(changed_dtype, inputs));
+
+    // Tensor args are keyed too — the removed hash folded them in via the default reflection hash.
+    ttnn::prim::Conv2dInputs other_inputs = conv_inputs();
+    other_inputs.a = host_tensor(ttnn::Shape{1, 1, 128, 32});
+    EXPECT_NE(compute_program_hash<ConvOp>(params, inputs), compute_program_hash<ConvOp>(params, other_inputs));
+}
+
+using SliceOp = ttnn::prim::qsr::SliceDeviceOperation;
+
+ttnn::prim::qsr::SliceParams slice_params() {
+    return ttnn::prim::qsr::SliceParams{
+        .slice_start = ttnn::Shape{0, 0, 0, 0},
+        .slice_end = ttnn::Shape{1, 1, 32, 32},
+        .step = ttnn::Shape{1, 1, 1, 1},
+        .output_mem_config = MemoryConfig{}};
+}
+
+// The removed hash listed slice params, the input spec (rank/logical/padded/layout/dtype/memory_config),
+// the derived output spec and the selected factory index. padded_shape is computed from logical_shape +
+// tensor_layout, and both derived values are pure functions of these same inputs, so reflection covers
+// them — pinned here rather than argued.
+TEST(QuasarKeyingTest, SliceKeysParamsAndInputSpec) {
+    const auto params = slice_params();
+    const ttnn::prim::qsr::SliceInputs inputs{.input = host_tensor(ttnn::Shape{1, 1, 64, 32})};
+    EXPECT_EQ(compute_program_hash<SliceOp>(params, inputs), compute_program_hash<SliceOp>(params, inputs));
+
+    auto moved_start = params;
+    moved_start.slice_start = ttnn::Shape{0, 0, 32, 0};
+    EXPECT_NE(compute_program_hash<SliceOp>(params, inputs), compute_program_hash<SliceOp>(moved_start, inputs));
+
+    auto strided = params;
+    strided.step = ttnn::Shape{1, 1, 2, 1};
+    EXPECT_NE(compute_program_hash<SliceOp>(params, inputs), compute_program_hash<SliceOp>(strided, inputs));
+
+    // Input spec: logical shape and layout both feed the factory choice and the work split.
+    const ttnn::prim::qsr::SliceInputs taller{.input = host_tensor(ttnn::Shape{1, 1, 128, 32})};
+    EXPECT_NE(compute_program_hash<SliceOp>(params, inputs), compute_program_hash<SliceOp>(params, taller));
+
+    const ttnn::prim::qsr::SliceInputs row_major{.input = host_tensor(ttnn::Shape{1, 1, 64, 32}, Layout::ROW_MAJOR)};
+    EXPECT_NE(compute_program_hash<SliceOp>(params, inputs), compute_program_hash<SliceOp>(params, row_major));
+}
+
+// start_tensor presence was keyed explicitly by the removed hash; end_tensor and preallocated_output
+// were not keyed at all. Reflection keys the shape of tensor_args, so all three split the key now.
+TEST(QuasarKeyingTest, SliceKeysOptionalTensorArgs) {
+    const auto params = slice_params();
+    const Tensor tensor = host_tensor(ttnn::Shape{1, 1, 64, 32});
+    const ttnn::prim::qsr::SliceInputs bare{.input = tensor};
+
+    ttnn::prim::qsr::SliceInputs with_start{.input = tensor};
+    with_start.start_tensor = tensor;
+    EXPECT_NE(compute_program_hash<SliceOp>(params, bare), compute_program_hash<SliceOp>(params, with_start));
+
+    ttnn::prim::qsr::SliceInputs with_end{.input = tensor};
+    with_end.end_tensor = tensor;
+    EXPECT_NE(compute_program_hash<SliceOp>(params, bare), compute_program_hash<SliceOp>(params, with_end));
+
+    // Same tensor in a different optional slot must not collide.
+    EXPECT_NE(compute_program_hash<SliceOp>(params, with_start), compute_program_hash<SliceOp>(params, with_end));
+}
+
+}  // namespace
+}  // namespace ttnn

--- a/ttnn/api/tools/profiler/op_profiler_serialize.hpp
+++ b/ttnn/api/tools/profiler/op_profiler_serialize.hpp
@@ -27,6 +27,7 @@
 #include <tt-metalium/base_types.hpp>
 #include <tt_stl/reflection.hpp>
 #include <tt_stl/type_name.hpp>
+#include "ttnn/program_hash.hpp"
 #include "ttnn/tensor/tensor.hpp"
 
 // Forward declarations — avoid pulling in heavy headers for 1000+ TU include chain.
@@ -279,20 +280,8 @@ template <typename device_operation_t>
 inline auto compute_program_hash(
     const typename device_operation_t::operation_attributes_t& operation_attributes,
     const typename device_operation_t::tensor_args_t& tensor_args) {
-    if constexpr (requires(
-                      const typename device_operation_t::operation_attributes_t& operation_attributes,
-                      const typename device_operation_t::tensor_args_t& tensor_args) {
-                      {
-                          device_operation_t::compute_program_hash(operation_attributes, tensor_args)
-                      } -> std::convertible_to<ttsl::hash::hash_t>;
-                  }) {
-        ZoneScopedN("Op profiler Compute custom program hash");
-        return device_operation_t::compute_program_hash(operation_attributes, tensor_args);
-    } else {
-        ZoneScopedN("Op profiler Compute default program hash");
-        return ttsl::hash::hash_objects_with_default_seed(
-            ttsl::hash::type_hash<device_operation_t>, operation_attributes, tensor_args);
-    }
+    ZoneScopedN("Op profiler Compute program hash");
+    return ttnn::device_operation::detail::compute_op_hash<device_operation_t>(operation_attributes, tensor_args);
 }
 
 // ---------------------------------------------------------------------------

--- a/ttnn/api/ttnn/device_operation.hpp
+++ b/ttnn/api/ttnn/device_operation.hpp
@@ -55,18 +55,12 @@ template <typename... Ts>
     return table[i];
 }
 
+// Used by layernorm's nanobind hook to report an op's cache key from Python.
 template <typename device_operation_t>
 auto compute_program_hash(
     const typename device_operation_t::operation_attributes_t& operation_attributes,
     const typename device_operation_t::tensor_args_t& tensor_args) {
-    if constexpr (DeviceOperationWithCustomProgramCacheConcept<device_operation_t>) {
-        ZoneScopedN("Compute custom program hash");
-        return device_operation_t::compute_program_hash(operation_attributes, tensor_args);
-    } else {
-        ZoneScopedN("Compute default program hash");
-        return ttsl::hash::hash_objects_with_default_seed(
-            ttsl::hash::type_hash<device_operation_t>, operation_attributes, tensor_args);
-    }
+    return compute_op_hash<device_operation_t>(operation_attributes, tensor_args);
 }
 
 // Helper to create a mesh workload from a WorkloadFactory that may or may not

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -31,6 +31,7 @@
 #include "ttnn/metal_v2_artifacts.hpp"
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
 #include "ttnn/operation_concepts.hpp"
+#include "ttnn/program_hash.hpp"
 #include "ttnn/operation.hpp"
 #include <tt_stl/reflection.hpp>
 #include "ttnn/tensor/tensor.hpp"
@@ -247,14 +248,20 @@ public:
         return DeviceOperation::create_output_tensors(attrs, tensor_args);
     }
 
+    static_assert(
+        !(HasSpecProgramFactory<DeviceOperation> && HasLegacyProgramHash<DeviceOperation>),
+        "A Metal 2.0 spec-path operation must not define compute_program_hash(attrs, tensor_args). Express the "
+        "cache key as tensor_args_relaxations() and attributes_excluded_from_key instead, or drop the custom "
+        "hash and let the framework reflect.");
+    static_assert(
+        !(HasLegacyProgramHash<DeviceOperation> &&
+          (HasExcludedAttributes<operation_attributes_t> || HasTensorArgsRelaxations<DeviceOperation>)),
+        "An operation must not define both compute_program_hash and the declarative keying that supersedes it -- "
+        "only compute_program_hash would be used.");
+
     static ttsl::hash::hash_t compute_program_hash(
         const operation_attributes_t& attrs, const tensor_args_t& tensor_args) {
-        if constexpr (requires { DeviceOperation::compute_program_hash(attrs, tensor_args); }) {
-            return DeviceOperation::compute_program_hash(attrs, tensor_args);
-        } else {
-            return ttsl::hash::hash_objects_with_default_seed(
-                ttsl::hash::type_hash<DeviceOperation>, attrs, tensor_args);
-        }
+        return detail::compute_op_hash<DeviceOperation>(attrs, tensor_args);
     }
 
     // An adapter for creating a factory that abides to `MeshWorkloadFactoryConcept` out of `ProgramFactoryConcept`
@@ -977,14 +984,7 @@ public:
         tt::tt_metal::distributed::MeshDevice* mesh_device,
         const operation_attributes_t& attrs,
         const tensor_args_t& tensor_args) {
-        ttsl::hash::hash_t hash;
-
-        if constexpr (requires { DeviceOperation::compute_program_hash(attrs, tensor_args); }) {
-            hash = DeviceOperation::compute_program_hash(attrs, tensor_args);
-        } else {
-            hash =
-                ttsl::hash::hash_objects_with_default_seed(ttsl::hash::type_hash<DeviceOperation>, attrs, tensor_args);
-        }
+        ttsl::hash::hash_t hash = detail::compute_op_hash<DeviceOperation>(attrs, tensor_args);
 
         // Combine with the mesh coordinates the workload is targeting.
         for (const auto& coord : mesh_device_operation_utils::extract_tensor_coordinates(tensor_args, mesh_device)) {
@@ -999,18 +999,18 @@ public:
     //
     // The key is prefixed with op_type_name (the DeviceOperation's type name) so distinct ops can
     // never alias on a hash collision.
-    // For ops with a custom compute_program_hash we can't infer which fields it keyed on (it may
-    // deliberately exclude some, e.g. an RNG seed), so we return only the op-identity prefix --
-    // opting that op out of attribute-level collision resolution. The default reflection-hash
-    // path is mirrored exactly.
+    // Op-declared keying excludes fields we can't enumerate here, so those ops get only the
+    // op-identity prefix. The default reflection-hash path is mirrored exactly.
     static std::string compute_mesh_workload_canonical_key(
         [[maybe_unused]] tt::tt_metal::distributed::MeshDevice* mesh_device,
         std::string_view op_type_name,
         const operation_attributes_t& attrs,
         const tensor_args_t& tensor_args) {
         std::string key{op_type_name};
-        if constexpr (requires { DeviceOperation::compute_program_hash(attrs, tensor_args); }) {
-            return key;  // custom hash -> opt out beyond the op-identity prefix
+        if constexpr (
+            HasLegacyProgramHash<DeviceOperation> || HasExcludedAttributes<operation_attributes_t> ||
+            HasTensorArgsRelaxations<DeviceOperation>) {
+            return key;  // op-declared key -> opt out beyond the op-identity prefix
         } else {
             key += ttsl::hash::canonical_key(attrs, tensor_args);
             for (const auto& coord :

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -964,6 +964,19 @@ public:
         using Base = ProgramSpecMeshWorkloadFactoryAdapter<CustomSpecFactory>;
         using typename Base::cached_mesh_workload_t;
 
+        // create_program_artifacts takes no coordinate, so the miss build stamps ONE set of run args across
+        // every coordinate range: a per-coordinate arg (rand's per-device seed) would be wrong on the miss
+        // dispatch and only correct from the first hit. Run the override here too, so miss and hit agree.
+        static cached_mesh_workload_t create_mesh_workload(
+            const operation_attributes_t& attrs,
+            const ttnn::MeshCoordinateRangeSet& tensor_coords,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& tensor_return_value) {
+            auto cached_workload = Base::create_mesh_workload(attrs, tensor_coords, tensor_args, tensor_return_value);
+            apply_descriptor(cached_workload, attrs, tensor_args, tensor_return_value);
+            return cached_workload;
+        }
+
         static void apply_descriptor(
             cached_mesh_workload_t& cached_workload,
             const operation_attributes_t& attrs,

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -259,6 +259,29 @@ public:
         "An operation must not define both compute_program_hash and the declarative keying that supersedes it -- "
         "only compute_program_hash would be used.");
 
+    static_assert(
+        !HasSpecProgramFactory<DeviceOperation> ||
+            !ttsl::reflection::detail::supports_to_hash_v<operation_attributes_t>,
+        "operation_attributes_t::to_hash() silently replaces the whole attribute hash (it outranks "
+        "attribute_names). A Metal 2.0 operation states its key through attributes_excluded_from_key instead.");
+    static_assert(
+        !HasSpecProgramFactory<DeviceOperation> || attributes_fully_declared<operation_attributes_t>(),
+        "attribute_names leaves fields out of operation_attributes_t, which silently drops them from the cache "
+        "key. List every field in attribute_names, and name the deliberate omissions in "
+        "attributes_excluded_from_key.");
+    static_assert(
+        !HasSpecProgramFactory<DeviceOperation> || attribute_names_are_distinct<operation_attributes_t>(),
+        "attribute_names repeats a name, so the count can match while a field goes unnamed.");
+    static_assert(
+        !HasSpecProgramFactory<DeviceOperation> || excluded_attributes_exist<operation_attributes_t>(),
+        "attributes_excluded_from_key names something that is not in attribute_names -- a typo or a rename "
+        "excludes nothing and silently puts the field back in the key.");
+    static_assert(
+        !HasSpecProgramFactory<DeviceOperation> || attribute_values_are_fields<operation_attributes_t>(),
+        "attribute_values() returns values computed from the fields rather than the fields themselves, which "
+        "coarsens the cache key inside what reads as a field list. Return std::forward_as_tuple of the members; "
+        "state exclusions in attributes_excluded_from_key.");
+
     static ttsl::hash::hash_t compute_program_hash(
         const operation_attributes_t& attrs, const tensor_args_t& tensor_args) {
         return detail::compute_op_hash<DeviceOperation>(attrs, tensor_args);

--- a/ttnn/api/ttnn/operation_concepts.hpp
+++ b/ttnn/api/ttnn/operation_concepts.hpp
@@ -263,8 +263,77 @@ consteval bool attributes_fully_declared() {
     if constexpr (!HasAttributeNames<attributes_t> || !ttsl::concepts::Reflectable<attributes_t>) {
         return true;  // no tuple at all -> full reflection already keys every field
     } else {
-        return std::tuple_size_v<decltype(attributes_t::attribute_names)> + excluded_attribute_count<attributes_t>() ==
-               reflect::size<attributes_t>();
+        // attribute_names is the op's identity: printing and graph capture read it too, so it names every
+        // field. Fields the key ignores stay named here and are listed again in attributes_excluded_from_key.
+        return std::tuple_size_v<decltype(attributes_t::attribute_names)> == reflect::size<attributes_t>();
+    }
+}
+
+// Counting alone is hackable: duplicate a name and the count matches while a field goes unnamed. Names must
+// be distinct.
+template <typename attributes_t>
+consteval bool attribute_names_are_distinct() {
+    if constexpr (!HasAttributeNames<attributes_t>) {
+        return true;
+    } else {
+        constexpr std::size_t n = std::tuple_size_v<decltype(attributes_t::attribute_names)>;
+        std::array<std::string_view, n> names{};
+        [&]<std::size_t... Is>(std::index_sequence<Is...>) {
+            ((names[Is] = std::string_view{std::get<Is>(attributes_t::attribute_names)}), ...);
+        }(std::make_index_sequence<n>{});
+        for (std::size_t i = 0; i < n; ++i) {
+            for (std::size_t j = i + 1; j < n; ++j) {
+                if (names[i] == names[j]) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+}
+
+// An exclusion naming something that is not an attribute silently excludes nothing -- a rename or a typo
+// would quietly put a field back in the key, or claim to have removed one that was never there.
+template <typename attributes_t>
+consteval bool excluded_attributes_exist() {
+    if constexpr (!HasExcludedAttributes<attributes_t> || !HasAttributeNames<attributes_t>) {
+        return true;
+    } else {
+        constexpr std::size_t num_names = std::tuple_size_v<decltype(attributes_t::attribute_names)>;
+        constexpr std::size_t num_excluded = excluded_attribute_count<attributes_t>();
+        std::array<std::string_view, num_names> names{};
+        std::array<std::string_view, num_excluded> excluded{};
+        [&]<std::size_t... Is>(std::index_sequence<Is...>) {
+            ((names[Is] = std::string_view{std::get<Is>(attributes_t::attribute_names)}), ...);
+        }(std::make_index_sequence<num_names>{});
+        [&]<std::size_t... Es>(std::index_sequence<Es...>) {
+            ((excluded[Es] = std::string_view{std::get<Es>(attributes_t::attributes_excluded_from_key)}), ...);
+        }(std::make_index_sequence<num_excluded>{});
+        for (const auto& excluded_name : excluded) {
+            bool found = false;
+            for (const auto& name : names) {
+                found = found || (name == excluded_name);
+            }
+            if (!found) {
+                return false;
+            }
+        }
+        return true;
+    }
+}
+
+// attribute_values() must hand back the fields themselves, not values computed from them: std::forward_as_tuple
+// over members yields lvalue references, while a copy or a computed expression cannot. Without this, an op can
+// coarsen its key inside what reads as a field list -- a fourth way to key, invisible to the count check.
+template <typename attributes_t>
+consteval bool attribute_values_are_fields() {
+    if constexpr (!HasAttributeNames<attributes_t>) {
+        return true;
+    } else {
+        using values_t = decltype(std::declval<const attributes_t&>().attribute_values());
+        return []<std::size_t... Is>(std::index_sequence<Is...>) {
+            return (std::is_lvalue_reference_v<std::tuple_element_t<Is, values_t>> && ...);
+        }(std::make_index_sequence<std::tuple_size_v<values_t>>{});
     }
 }
 

--- a/ttnn/api/ttnn/operation_concepts.hpp
+++ b/ttnn/api/ttnn/operation_concepts.hpp
@@ -15,8 +15,10 @@
 #include <tt-metalium/graph_tracking.hpp>
 #include <tt-metalium/program_cache.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
+#include <tt-metalium/experimental/metal2_host_api/tensor_spec_relaxations.hpp>
 
 #include <cstdint>
+#include <tt_stl/small_vector.hpp>
 
 #include "ttnn/distributed/types.hpp"
 
@@ -182,6 +184,17 @@ consteval bool all_factories_valid(std::index_sequence<Is...>) {
           CustomProgramSpecFactoryConcept<std::variant_alternative_t<Is, Variant>>) == 1) &&
         ...);
 }
+
+// True iff at least one alternative builds a Metal 2.0 ProgramSpec. "Any", not "all": once one
+// factory of a multi-factory operation is ported, the operation's cache key is the spec path's
+// concern, so the keying restriction applies to the whole operation.
+template <typename Variant, std::size_t... Is>
+consteval bool any_spec_factory(std::index_sequence<Is...>) {
+    return (
+        (ProgramSpecFactoryConcept<std::variant_alternative_t<Is, Variant>> ||
+         CustomProgramSpecFactoryConcept<std::variant_alternative_t<Is, Variant>>) ||
+        ...);
+}
 }  // namespace detail
 
 template <typename Variant>
@@ -207,16 +220,82 @@ concept DeviceOperationConcept =
     (HasDirectDescriptor<device_operation_t> ||
      (HasProgramFactoryType<device_operation_t> && AllFactoriesValid<typename device_operation_t::program_factory_t>));
 
+// True iff any of the operation's program factories builds a Metal 2.0 ProgramSpec.
+template <typename device_operation_t>
+concept HasSpecProgramFactory =
+    HasProgramFactoryType<device_operation_t> &&
+    requires { std::variant_size_v<typename device_operation_t::program_factory_t>; } &&
+    detail::any_spec_factory<typename device_operation_t::program_factory_t>(
+        std::make_index_sequence<std::variant_size_v<typename device_operation_t::program_factory_t>>{});
+
+// A Metal 2.0 operation states its cache key in exactly two declarative places, and nowhere else:
+//   tensor half     -- tensor_args_relaxations(), one relaxation per Tensor reached in tensor_args
+//                      (engaged optionals only), so keying and Metal 2.0 validation stay in step.
+//   non-tensor half -- attribute_names lists every field; attributes_excluded_from_key names the ones
+//                      the key ignores. Key = names minus excluded, folded by the framework.
+template <typename device_operation_t>
+concept HasTensorArgsRelaxations = requires(const typename device_operation_t::tensor_args_t& tensor_args) {
+    {
+        device_operation_t::tensor_args_relaxations(tensor_args)
+    } -> std::convertible_to<ttsl::SmallVector<tt::tt_metal::experimental::TensorSpecRelaxations>>;
+};
+
+template <typename T>
+concept HasAttributeNames = requires { T::attribute_names; };
+
+template <typename T>
+concept HasExcludedAttributes = requires { T::attributes_excluded_from_key; };
+
+template <typename attributes_t>
+consteval std::size_t excluded_attribute_count() {
+    if constexpr (HasExcludedAttributes<attributes_t>) {
+        return std::tuple_size_v<std::decay_t<decltype(attributes_t::attributes_excluded_from_key)>>;
+    } else {
+        return 0;
+    }
+}
+
+// Every field is accounted for: named in the identity tuple, or named as excluded. Adding a field to a
+// spec-path attributes struct therefore breaks the build until someone decides which it is, rather than
+// silently dropping out of the cache key.
+template <typename attributes_t>
+consteval bool attributes_fully_declared() {
+    if constexpr (!HasAttributeNames<attributes_t> || !ttsl::concepts::Reflectable<attributes_t>) {
+        return true;  // no tuple at all -> full reflection already keys every field
+    } else {
+        return std::tuple_size_v<decltype(attributes_t::attribute_names)> + excluded_attribute_count<attributes_t>() ==
+               reflect::size<attributes_t>();
+    }
+}
+
+// Is attribute_names[I] listed in attributes_excluded_from_key? Resolved at compile time, so the fold in
+// program_hash.hpp skips excluded fields with no runtime name comparison.
+template <typename attributes_t, std::size_t I>
+consteval bool attribute_is_excluded() {
+    if constexpr (!HasExcludedAttributes<attributes_t>) {
+        return false;
+    } else {
+        return []<std::size_t... Es>(std::index_sequence<Es...>) {
+            constexpr std::string_view name{std::get<I>(attributes_t::attribute_names)};
+            return ((name == std::string_view{std::get<Es>(attributes_t::attributes_excluded_from_key)}) || ...);
+        }(std::make_index_sequence<excluded_attribute_count<attributes_t>()>{});
+    }
+}
+
+// The legacy freeform hash hook: one method keyed on both halves at once. Superseded by the two
+// hooks above, and forbidden on the spec path.
+template <typename device_operation_t>
+concept HasLegacyProgramHash = requires(
+    const typename device_operation_t::operation_attributes_t& operation_attributes,
+    const typename device_operation_t::tensor_args_t& tensor_args) {
+    {
+        device_operation_t::compute_program_hash(operation_attributes, tensor_args)
+    } -> std::convertible_to<std::uint64_t>;
+};
+
 template <typename device_operation_t>
 concept DeviceOperationWithCustomProgramCacheConcept =
-    DeviceOperationConcept<device_operation_t> &&
-    requires(
-        const typename device_operation_t::operation_attributes_t& operation_attributes,
-        const typename device_operation_t::tensor_args_t& tensor_args) {
-        {
-            device_operation_t::compute_program_hash(operation_attributes, tensor_args)
-        } -> std::convertible_to<std::uint64_t>;
-    };
+    DeviceOperationConcept<device_operation_t> && HasLegacyProgramHash<device_operation_t>;
 
 template <typename device_operation_t>
 concept HasSkipLaunch = requires(

--- a/ttnn/api/ttnn/program_hash.hpp
+++ b/ttnn/api/ttnn/program_hash.hpp
@@ -1,0 +1,168 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <span>
+#include <tuple>
+#include <vector>
+
+#include <tt-metalium/experimental/metal2_host_api/tensor_spec_relaxations.hpp>
+#include <tracy/Tracy.hpp>
+#include <tt_stl/assert.hpp>
+#include <tt_stl/concepts.hpp>
+#include <tt_stl/reflection.hpp>
+#include <tt_stl/small_vector.hpp>
+
+#include "ttnn/operation_concepts.hpp"
+#include "ttnn/tensor/tensor.hpp"
+
+// The one definition of an op's program-cache hash: cache key, canonical key and profiler all call it.
+namespace ttnn::device_operation::detail {
+
+namespace hash_traits {
+
+// std::array is not a specialization of template<typename...>, so ttsl::is_specialization_v can't see it.
+template <typename T>
+struct is_array : std::false_type {};
+template <typename T, std::size_t N>
+struct is_array<std::array<T, N>> : std::true_type {};
+
+template <typename T>
+concept HasAttributeNames = requires { std::decay_t<T>::attribute_names; };
+
+}  // namespace hash_traits
+
+// Mirrors hash_object's branches so tensor_args keeps its structure in the key: a flat tensor fold
+// would let {bias, no residual} collide with {no bias, residual}. Only the Tensor leaf is relaxed.
+class TensorArgsHasher {
+public:
+    explicit TensorArgsHasher(std::span<const tt::tt_metal::experimental::TensorSpecRelaxations> relaxations) :
+        relaxations_(relaxations) {}
+
+    template <typename T>
+    ttsl::hash::hash_t operator()(const T& object) {
+        using decayed_t = std::decay_t<T>;
+        if constexpr (std::same_as<decayed_t, ::ttnn::Tensor>) {
+            return hash_tensor(object);
+        } else if constexpr (ttsl::is_specialization_v<decayed_t, std::reference_wrapper>) {
+            return (*this)(object.get());
+        } else if constexpr (ttsl::is_specialization_v<decayed_t, std::optional>) {
+            return object.has_value() ? (*this)(*object) : 0;
+        } else if constexpr (
+            ttsl::is_specialization_v<decayed_t, std::vector> || hash_traits::is_array<decayed_t>::value) {
+            ttsl::hash::hash_t hash = 0;
+            for (const auto& element : object) {
+                hash = ttsl::hash::hash_objects(hash, (*this)(element));
+            }
+            return hash;
+        } else if constexpr (ttsl::is_specialization_v<decayed_t, std::tuple>) {
+            ttsl::hash::hash_t hash = 0;
+            std::apply(
+                [&](const auto&... elements) { ((hash = ttsl::hash::hash_objects(hash, (*this)(elements))), ...); },
+                object);
+            return hash;
+        } else if constexpr (hash_traits::HasAttributeNames<decayed_t>) {
+            return (*this)(object.attribute_values());
+        } else if constexpr (ttsl::concepts::Reflectable<decayed_t>) {
+            ttsl::hash::hash_t hash = 0;
+            reflect::for_each(
+                [&](auto I) { hash = ttsl::hash::hash_objects(hash, (*this)(reflect::get<I>(object))); }, object);
+            return hash;
+        } else {
+            return ttsl::hash::hash_objects_with_default_seed(object);
+        }
+    }
+
+    std::size_t tensors_hashed() const { return next_relaxation_; }
+
+private:
+    ttsl::hash::hash_t hash_tensor(const ::ttnn::Tensor& tensor) {
+        TT_FATAL(
+            next_relaxation_ < relaxations_.size(),
+            "tensor_args_relaxations() returned {} relaxation(s), fewer than the tensors in tensor_args. Return one "
+            "per Tensor, counting only engaged std::optionals.",
+            relaxations_.size());
+        const auto& relaxation = relaxations_[next_relaxation_++];
+        return ttsl::hash::hash_objects(
+            static_cast<ttsl::hash::hash_t>(tensor.storage_type()),
+            tt::tt_metal::experimental::hash_tensorspec_with_relaxation(tensor.tensor_spec(), relaxation));
+    }
+
+    std::span<const tt::tt_metal::experimental::TensorSpecRelaxations> relaxations_;
+    std::size_t next_relaxation_ = 0;
+};
+
+template <typename TensorArgs>
+ttsl::hash::hash_t hash_tensor_args_with_relaxations(
+    const TensorArgs& tensor_args, std::span<const tt::tt_metal::experimental::TensorSpecRelaxations> relaxations) {
+    TensorArgsHasher hasher(relaxations);
+    const auto hash = hasher(tensor_args);
+    TT_FATAL(
+        hasher.tensors_hashed() == relaxations.size(),
+        "tensor_args_relaxations() returned {} relaxation(s) but {} tensor(s) were reached. Return one per Tensor, "
+        "counting only engaged std::optionals.",
+        relaxations.size(),
+        hasher.tensors_hashed());
+    return hash;
+}
+
+// Folds attribute_values() exactly as ttsl::hash::hash_object's attribute_names branch does, skipping the
+// fields named in attributes_excluded_from_key. With nothing excluded this reproduces the default hash.
+template <typename attributes_t>
+ttsl::hash::hash_t hash_declared_attributes(const attributes_t& attributes) {
+    if constexpr (!HasExcludedAttributes<attributes_t>) {
+        return ttsl::hash::hash_objects_with_default_seed(attributes);
+    } else {
+        const auto values = attributes.attribute_values();
+        ttsl::hash::hash_t hash = 0;
+        [&]<std::size_t... Is>(std::index_sequence<Is...>) {
+            (
+                [&] {
+                    if constexpr (!attribute_is_excluded<attributes_t, Is>()) {
+                        hash = ttsl::hash::hash_objects(hash, std::get<Is>(values));
+                    }
+                }(),
+                ...);
+        }(std::make_index_sequence<std::tuple_size_v<decltype(attributes_t::attribute_names)>>{});
+        return hash;
+    }
+}
+
+template <typename device_operation_t>
+ttsl::hash::hash_t compute_op_hash(
+    const typename device_operation_t::operation_attributes_t& operation_attributes,
+    const typename device_operation_t::tensor_args_t& tensor_args) {
+    if constexpr (HasLegacyProgramHash<device_operation_t>) {
+        ZoneScopedN("Compute custom program hash");
+        return device_operation_t::compute_program_hash(operation_attributes, tensor_args);
+    } else if constexpr (
+        !HasExcludedAttributes<typename device_operation_t::operation_attributes_t> &&
+        !HasTensorArgsRelaxations<device_operation_t>) {
+        ZoneScopedN("Compute default program hash");
+        return ttsl::hash::hash_objects_with_default_seed(
+            ttsl::hash::type_hash<device_operation_t>, operation_attributes, tensor_args);
+    } else {
+        ZoneScopedN("Compute declared program hash");
+        const ttsl::hash::hash_t attributes_hash = hash_declared_attributes(operation_attributes);
+
+        ttsl::hash::hash_t tensors_hash = 0;
+        if constexpr (HasTensorArgsRelaxations<device_operation_t>) {
+            const ttsl::SmallVector<tt::tt_metal::experimental::TensorSpecRelaxations> relaxations =
+                device_operation_t::tensor_args_relaxations(tensor_args);
+            tensors_hash = hash_tensor_args_with_relaxations(tensor_args, relaxations);
+        } else {
+            tensors_hash = ttsl::hash::hash_objects_with_default_seed(tensor_args);
+        }
+
+        return ttsl::hash::hash_objects_with_default_seed(
+            ttsl::hash::type_hash<device_operation_t>, attributes_hash, tensors_hash);
+    }
+}
+
+}  // namespace ttnn::device_operation::detail

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_device_operation_types.hpp
@@ -237,28 +237,34 @@ struct Conv2dParams {
         "full_inner_dim",
         "enable_activation_reuse",
         "config_tensors_in_dram",
-        "force_split_reader");
+        "force_split_reader",
+        "pre_op_l1_allocation_size_bytes");
+
+    // Recomputed per call from live allocator state and only read by the L1-accounting assertion in
+    // conv2d_op_program_factory_common.cpp -- keying it would give every call its own program.
+    static constexpr auto attributes_excluded_from_key = std::forward_as_tuple("pre_op_l1_allocation_size_bytes");
 
     auto attribute_values() const {
-        return std::make_tuple(
-            std::cref(this->sliding_window_config),
+        return std::forward_as_tuple(
+            this->sliding_window_config,
             this->output_channels,
             this->groups,
             this->untilize_out,
             this->has_bias,
-            std::cref(this->activation),
+            this->activation,
             this->parallelization_config,
             this->block_config,
-            std::cref(this->memory_config),
+            this->memory_config,
             this->dtype,
             this->input_tensor_shape,
-            std::cref(this->compute_kernel_config),
+            this->compute_kernel_config,
             this->enable_act_double_buffer,
             this->enable_weights_double_buffer,
             this->full_inner_dim,
             this->enable_activation_reuse,
             this->config_tensors_in_dram,
-            this->force_split_reader);
+            this->force_split_reader,
+            this->pre_op_l1_allocation_size_bytes);
     }
 };
 

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/binary_ng_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/binary_ng/device/binary_ng_device_operation.hpp
@@ -75,15 +75,20 @@ struct BinaryNgDeviceOperation {
             "equal_nan",
             "scalar",
             "rtol",
-            "atol");
+            "atol",
+            "worker_grid",
+            "sub_device_id",
+            "input_dtype");
+        // input_dtype is the input tensor's own dtype, already keyed through tensor_args.
+        static constexpr auto attributes_excluded_from_key = std::forward_as_tuple("input_dtype");
         auto attribute_values() const {
-            return std::make_tuple(
+            return std::forward_as_tuple(
                 binary_op_type,
                 lhs_activations,
                 rhs_activations,
-                (is_where_op || is_quant_op) ? ttsl::SmallVector<unary::EltwiseUnaryWithParam>{} : post_activations,
+                post_activations,
                 memory_config,
-                get_dtype(),
+                dtype,
                 compute_kernel_config,
                 sub_core_grids,
                 subtile_broadcast_type,
@@ -96,7 +101,10 @@ struct BinaryNgDeviceOperation {
                 equal_nan,
                 scalar,
                 rtol,
-                atol);
+                atol,
+                worker_grid,
+                sub_device_id,
+                input_dtype);
         }
         DataType get_dtype() const;
     };

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/conv2d_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/conv2d_device_operation.cpp
@@ -142,30 +142,6 @@ void Conv2dDeviceOperation::validate_on_program_cache_miss(
     }
 }
 
-ttsl::hash::hash_t Conv2dDeviceOperation::compute_program_hash(
-    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    hashable_operation_attributes_t hashable_args = {
-        .sliding_window_config = args.sliding_window_config,
-        .output_channels = args.output_channels,
-        .groups = args.groups,
-        .untilize_out = args.untilize_out,
-        .has_bias = args.has_bias,
-        .activation = args.activation,
-        .parallelization_config = args.parallelization_config,
-        .block_config = args.block_config,
-        .memory_config = args.memory_config,
-        .dtype = args.dtype,
-        .input_tensor_shape = args.input_tensor_shape,
-        .compute_kernel_config = args.compute_kernel_config,
-        .enable_act_double_buffer = args.enable_act_double_buffer,
-        .enable_weights_double_buffer = args.enable_weights_double_buffer,
-        .enable_activation_reuse = args.enable_activation_reuse,
-        .config_tensors_in_dram = args.config_tensors_in_dram,
-        .force_split_reader = args.force_split_reader,
-    };
-    return ttsl::hash::hash_objects_with_default_seed(hashable_args, tensor_args);
-}
-
 tt::tt_metal::operation::OpPerformanceModelGeneral<Tensor> Conv2dDeviceOperation::create_op_performance_model(
     const operation_attributes_t& args, const tensor_args_t& tensor_args, tensor_return_value_t& output_tensor) {
     const auto& input_tensor_a_shape = args.input_tensor_shape;

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/conv2d_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/conv2d_device_operation.hpp
@@ -28,7 +28,6 @@ namespace sliding_window = ttnn::operations::sliding_window;
 
 struct Conv2dDeviceOperation {
     using operation_attributes_t = Conv2dParams;
-    using hashable_operation_attributes_t = Conv2dHashableParams;
     using tensor_args_t = Conv2dInputs;
     using spec_return_value_t = tt::tt_metal::TensorSpec;
     using tensor_return_value_t = Tensor;
@@ -41,8 +40,8 @@ struct Conv2dDeviceOperation {
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& args, const tensor_args_t& tensor_args);
     static void validate_on_program_cache_miss(const operation_attributes_t& args, const tensor_args_t& tensor_args);
-    static ttsl::hash::hash_t compute_program_hash(
-        const operation_attributes_t& args, const tensor_args_t& tensor_args);
+    // No custom hash: Conv2dParams::attribute_names is the exclusion list (it omits
+    // pre_op_l1_allocation_size_bytes) and the framework reflects over it.
     static tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> create_op_performance_model(
         const operation_attributes_t& args, const tensor_args_t& tensor_args, tensor_return_value_t& output_tensor);
 };

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/slice_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/slice_device_operation.cpp
@@ -295,60 +295,6 @@ SliceDeviceOperation::program_factory_t SliceDeviceOperation::select_program_fac
     return SliceTileProgramFactory{};
 }
 
-// Port of tt-metal e517beb3f41 (#47602): the default program hash (boost::hash_combine style) has weak
-// distribution for small-integer shape sequences, causing false cache hits when shapes differ but
-// collide -> TT_FATAL on back-to-back slices with differing shapes. Mix in full input/output specs and
-// slice params so distinct invocations get distinct keys.
-ttsl::hash::hash_t SliceDeviceOperation::compute_program_hash(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    auto factory = select_program_factory(operation_attributes, tensor_args);
-    auto hash = tt::tt_metal::operation::hash_operation<SliceDeviceOperation>(
-        operation_attributes.slice_start,
-        operation_attributes.slice_end,
-        operation_attributes.step,
-        operation_attributes.use_tensor_args,
-        operation_attributes.slice_dim,
-        operation_attributes.num_devices,
-        operation_attributes.output_mem_config,
-        operation_attributes.sub_core_grids,
-        factory.index(),
-        tensor_args.start_tensor.has_value());
-
-    const auto& input = tensor_args.input;
-    hash = ttsl::hash::hash_objects(
-        hash,
-        input.logical_shape().rank(),
-        input.logical_shape(),
-        input.padded_shape(),
-        input.layout(),
-        input.dtype(),
-        input.memory_config());
-
-    if (tensor_args.start_tensor.has_value()) {
-        const auto& st = tensor_args.start_tensor.value();
-        hash = ttsl::hash::hash_objects(
-            hash,
-            st.logical_shape().rank(),
-            st.logical_shape(),
-            st.padded_shape(),
-            st.layout(),
-            st.dtype(),
-            st.memory_config());
-    }
-
-    const auto output_spec = compute_output_specs(operation_attributes, tensor_args);
-    hash = ttsl::hash::hash_objects(
-        hash,
-        output_spec.logical_shape().rank(),
-        output_spec.logical_shape(),
-        output_spec.padded_shape(),
-        output_spec.layout(),
-        output_spec.data_type(),
-        output_spec.memory_config());
-
-    return hash;
-}
-
 tt::tt_metal::operation::OpPerformanceModelGeneral<SliceDeviceOperation::tensor_return_value_t>
 SliceDeviceOperation::create_op_performance_model(
     const operation_attributes_t& /*args*/, const tensor_args_t& tensor_args, const Tensor& output) {

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/slice_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/slice_device_operation.hpp
@@ -42,8 +42,8 @@ struct SliceDeviceOperation {
 
     static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
 
-    // Port of tt-metal e517beb3f41 (#47602): custom hash to avoid false program-cache hits on colliding shapes.
-    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+    // The hash ported in #47602 worked around weak hash distribution, fixed by #46385. All it listed
+    // is derived from SliceParams + the input specs, and reflection keeps the exact-key check.
 
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
 

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/slice_program_factory_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/slice_program_factory_rm.cpp
@@ -237,8 +237,9 @@ ttnn::device_operation::ProgramArtifacts SliceRmProgramFactory::create_program_a
 
     tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input.dtype());
 
-    // DFB sizing varies with slice_start; padded_shape folds into compute_program_hash() so each
-    // unique DFB layout gets its own cache entry (entry_size/num_entries are not patched on cache hit).
+    // DFB sizing varies with slice_start; slice_start and padded_shape are both part of the
+    // program-cache key so each unique DFB layout gets its own cache entry (entry_size/num_entries
+    // are not patched on cache hit).
     const auto [cb_page_size, num_read_per_barrier, misalignment] =
         ttnn::operations::experimental::quasar::compute_cb_size(
             input, output, args.slice_start, num_sticks_per_core_group_1, num_sticks_per_core_group_2);

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/slice_program_factory_rm.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/slice/device/slice_program_factory_rm.hpp
@@ -11,8 +11,8 @@ namespace ttnn::prim::qsr {
 
 struct SliceRmProgramFactory {
     // The src0 DFB's entry_size / num_entries depend on slice_start (via misalignment /
-    // unpadded_row_size_bytes), so padded_shape is folded into compute_program_hash() — each
-    // unique DFB sizing keeps its own cache entry.
+    // unpadded_row_size_bytes), and both slice_start and the input's padded_shape are part of the
+    // program-cache key — each unique DFB sizing keeps its own cache entry.
     static ttnn::device_operation::ProgramArtifacts create_program_artifacts(
         const SliceParams& args, const SliceInputs& tensor_args, Tensor& output);
 };

--- a/ttnn/cpp/ttnn/operations/rand/device/kernels/compute_rand_spec.cpp
+++ b/ttnn/cpp/ttnn/operations/rand/device/kernels/compute_rand_spec.cpp
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Metal 2.0 (ProgramSpec) compute kernel for rand: producer of the intermediate DFB.
+// Port of operations/uniform/device/kernels/compute_uniform.cpp to named accessors.
+// seed/from/to are DYNAMIC runtime args (re-applied every dispatch via override_runtime_arguments);
+// tile_offset/units_per_core are enqueue-invariant runtime args.
+#include "api/compute/compute_kernel_api.h"
+#include "api/compute/eltwise_unary/eltwise_unary.h"
+#include "api/compute/eltwise_unary/rand.h"
+#include "api/dataflow/dataflow_buffer.h"
+#include "experimental/kernel_args.h"
+
+void kernel_main() {
+    const uint32_t seed = get_arg(args::seed);
+    union {
+        float f;
+        uint32_t u;
+    } f2u_from, f2u_to, f2u_scale;
+    f2u_from.u = get_arg(args::from);
+    f2u_to.u = get_arg(args::to);
+    f2u_scale.f = f2u_to.f - f2u_from.f;
+    const uint32_t start_id = get_arg(args::tile_offset);
+    const uint32_t num_tiles = get_arg(args::units_per_core);
+    const uint32_t end_id = start_id + num_tiles;
+
+    DataflowBuffer cb_intermed(dfb::intermed);
+
+    init_sfpu(dfb::intermed, dfb::intermed);
+
+    rand_tile_init(seed);
+    for (uint32_t i = start_id; i < end_id; ++i) {
+        cb_intermed.reserve_back(1);
+
+        tile_regs_acquire();
+        rand_tile(0, f2u_from.u, f2u_scale.u);
+        tile_regs_commit();
+
+        tile_regs_wait();
+        pack_tile(0, dfb::intermed, 0);
+        tile_regs_release();
+
+        cb_intermed.push_back(1);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/rand/device/kernels/writer_rand_spec.cpp
+++ b/ttnn/cpp/ttnn/operations/rand/device/kernels/writer_rand_spec.cpp
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Metal 2.0 (ProgramSpec) writer kernel for rand: consumer of the intermediate DFB, writes the
+// generated tiles to the interleaved output. Port of
+// operations/uniform/device/kernels/writer_uniform.cpp to named accessors:
+//   - dst buffer address RTA -> TensorAccessor(tensor::output)
+//   - CircularBuffer(cb_id)  -> DataflowBuffer(dfb::name)
+//   - positional RTAs        -> get_arg(args::name)
+// tile_offset/units_per_core are enqueue-invariant runtime args (unchanged across dispatches).
+#include <tt-metalium/constants.hpp>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/dataflow_buffer.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
+
+using namespace tt;
+
+void kernel_main() {
+    const uint32_t start_id = get_arg(args::tile_offset);
+    const uint32_t num_tiles = get_arg(args::units_per_core);
+    const uint32_t end_id = start_id + num_tiles;
+
+    const auto output_addrg = TensorAccessor(tensor::output);
+
+    DataflowBuffer cb_intermed(dfb::intermed);
+
+    Noc noc;
+
+#ifdef OUTPUT_DTYPE_BFLOAT16
+    // bfloat16 output: convert each Float32 intermediate tile into the dst staging DFB (a
+    // writer self-loop DFB), then NOC-write the packed bf16 page to the output.
+    DataflowBuffer cb_dst(dfb::dst);
+    const uint32_t page_bytes = cb_dst.get_entry_size();
+    cb_dst.reserve_back(1);
+    uint32_t dst_cb_write_ptr = cb_dst.get_write_ptr();
+
+    for (uint32_t i = start_id; i < end_id; ++i) {
+        cb_intermed.wait_front(1);
+        uint32_t intermed_cb_read_ptr = cb_intermed.get_read_ptr();
+        auto intermed_cb_addr = reinterpret_cast<float*>(intermed_cb_read_ptr);
+
+        auto dst_cb_addr = reinterpret_cast<uint8_t*>(dst_cb_write_ptr);
+        for (uint32_t k = 0; k < constants::TILE_WIDTH; k++) {
+            for (uint32_t j = 0; j < constants::TILE_HEIGHT; j++) {
+                float rand_float = *intermed_cb_addr;
+                uint16_t* uint16_ptr = reinterpret_cast<uint16_t*>(&rand_float) + 1;
+                *(uint16_t*)dst_cb_addr = *uint16_ptr;
+                dst_cb_addr += 2;
+                intermed_cb_addr += 1;
+            }
+        }
+        cb_intermed.pop_front(1);
+
+        noc.async_write(CoreLocalMem<uint32_t>(dst_cb_write_ptr), output_addrg, page_bytes, {}, {.page_id = i});
+        noc.async_write_barrier();
+    }
+    // dst_cb is a conversion-staging region (consumed only by direct NOC writes); commit the
+    // reservation so the self-loop DFB is left balanced.
+    cb_dst.push_back(1);
+#else
+    // float32 output: NOC-write the Float32 intermediate tile directly.
+    const uint32_t page_bytes = cb_intermed.get_entry_size();
+    for (uint32_t i = start_id; i < end_id; ++i) {
+        cb_intermed.wait_front(1);
+        uint32_t intermed_cb_read_ptr = cb_intermed.get_read_ptr();
+        noc.async_write(CoreLocalMem<uint32_t>(intermed_cb_read_ptr), output_addrg, page_bytes, {}, {.page_id = i});
+        noc.async_write_barrier();
+        cb_intermed.pop_front(1);
+    }
+#endif
+}

--- a/ttnn/cpp/ttnn/operations/rand/device/rand_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/rand/device/rand_device_operation.hpp
@@ -11,8 +11,8 @@
 
 #include "ttnn/device_operation.hpp"
 #include "ttnn/distributed/types.hpp"
-#include <tt-metalium/program_descriptors.hpp>
-#include <tt-metalium/experimental/program_descriptor_patching.hpp>
+#include "ttnn/metal_v2_artifacts.hpp"
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
 
 namespace ttnn::operations::rand {
 
@@ -28,13 +28,19 @@ struct RandDeviceOperation {
         uint32_t seed;
         ttsl::SmallVector<bool> mesh_dim_is_sharded;
 
-        // Cache key. seed/from/to are omitted (re-applied per dispatch via override_runtime_arguments,
-        // so calls differing only in those values reuse the cached program). `device` must be FIRST:
-        // rand has no input tensor, so the framework discovers the mesh device via
-        // get_first_object_of_type over attribute_values(), whose tuple path inspects only element 0.
-        static constexpr auto attribute_names =
-            std::forward_as_tuple("device", "shape", "dtype", "layout", "memory_config");
-        auto attribute_values() const { return std::forward_as_tuple(device, shape, dtype, layout, memory_config); }
+        // `device` must be FIRST: rand has no input tensor, so the framework discovers the mesh device
+        // via get_first_object_of_type over attribute_values(), whose tuple path inspects only element 0.
+        static constexpr auto attribute_names = std::forward_as_tuple(
+            "device", "shape", "dtype", "layout", "memory_config", "from", "to", "seed", "mesh_dim_is_sharded");
+        auto attribute_values() const {
+            return std::forward_as_tuple(
+                device, shape, dtype, layout, memory_config, from, to, seed, mesh_dim_is_sharded);
+        }
+
+        // from/to/seed ride in as runtime args, re-applied per dispatch, so keying them would compile a
+        // program per seed. mesh_dim_is_sharded only shifts the per-device seed.
+        static constexpr auto attributes_excluded_from_key =
+            std::forward_as_tuple("from", "to", "seed", "mesh_dim_is_sharded");
     };
 
     struct tensor_args_t {};
@@ -42,15 +48,19 @@ struct RandDeviceOperation {
     using spec_return_value_t = tt::tt_metal::TensorSpec;
     using tensor_return_value_t = Tensor;
 
+    // Metal 2.0 spec factory (CustomProgramSpecFactoryConcept): create_program_artifacts returns a
+    // ProgramSpec + ProgramRunArgs; override_runtime_arguments re-applies the DYNAMIC seed/from/to
+    // runtime args (omitted from the cache key) on every cache hit via UpdateProgramRunArgs, so calls
+    // differing only in seed/from/to reuse the cached program instead of recompiling. The seed/from/to
+    // values built in create_program_artifacts must mirror those in override_runtime_arguments — the
+    // test_rand_different_seed_values regression test enforces this.
     struct RandProgramFactory {
-        static tt::tt_metal::ProgramDescriptor create_descriptor(
+        static ttnn::device_operation::ProgramArtifacts create_program_artifacts(
             const operation_attributes_t& operation_attributes,
             const tensor_args_t& tensor_args,
-            tensor_return_value_t& output,
-            const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate = std::nullopt);
+            tensor_return_value_t& output);
 
-        static void override_runtime_arguments(
-            tt::tt_metal::Program& program,
+        static tt::tt_metal::experimental::ProgramRunArgs override_runtime_arguments(
             const operation_attributes_t& operation_attributes,
             const tensor_args_t& tensor_args,
             tensor_return_value_t& output,

--- a/ttnn/cpp/ttnn/operations/rand/device/rand_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/rand/device/rand_program_factory.cpp
@@ -8,15 +8,19 @@
 
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/work_split.hpp>
-#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
 #include "ttnn/tensor/types.hpp"
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+#include "ttnn/operations/core/data_movement_kernel/datamovement_kernel_config.hpp"
 #include "rand_device_operation.hpp"
-#include <tt-metalium/tensor_accessor_args.hpp>
 
 namespace ttnn::operations::rand {
 
 using namespace tt;
 using namespace tt::tt_metal;
+using namespace tt::tt_metal::experimental;
 
 namespace {
 
@@ -25,10 +29,17 @@ std::uniform_int_distribution distribution(1, std::numeric_limits<int32_t>::max(
 
 auto get_random_seed() -> uint32_t { return distribution(rng); }
 
-constexpr const char* WRITER_KERNEL_PATH = "ttnn/cpp/ttnn/operations/uniform/device/kernels/writer_uniform.cpp";
-constexpr const char* COMPUTE_KERNEL_PATH = "ttnn/cpp/ttnn/operations/uniform/device/kernels/compute_uniform.cpp";
+constexpr const char* WRITER_KERNEL_PATH = "ttnn/cpp/ttnn/operations/rand/device/kernels/writer_rand_spec.cpp";
+constexpr const char* COMPUTE_KERNEL_PATH = "ttnn/cpp/ttnn/operations/rand/device/kernels/compute_rand_spec.cpp";
 
-// Work split + per-device seed offset, shared by create_descriptor (cache miss) and
+// Spec resource names (prefixed to stay distinct under unity builds).
+const KernelSpecName RAND_COMPUTE{"rand_compute"};
+const KernelSpecName RAND_WRITER{"rand_writer"};
+const DFBSpecName RAND_INTERMED{"rand_intermed"};
+const DFBSpecName RAND_DST{"rand_dst"};
+const TensorParamName RAND_OUTPUT{"rand_output"};
+
+// Work split + per-device seed offset, shared by create_program_artifacts (cache miss) and
 // override_runtime_arguments (cache hit) so both derive the identical core list and seed offset.
 struct RandWorkSplit {
     uint32_t num_cores = 0;
@@ -84,9 +95,8 @@ uint32_t rand_seed_for_core(
     return attrs.seed != 0 ? attrs.seed + i + device_seed_offset : get_random_seed();
 }
 
-// Per-core work assignment. Single-sourced so the cache-miss build (create_descriptor) and the
-// cache-hit patch (override_runtime_arguments) can never drift on core-group selection or tile_offset
-// accumulation — each derives its runtime args from the same layout.
+// Per-core work assignment (core, units_per_core, tile_offset). Single-sourced so the cache-miss
+// build and the cache-hit override can never drift on core-group selection or tile_offset.
 struct RandCoreWork {
     CoreCoord core;
     uint32_t units_per_core;
@@ -113,144 +123,151 @@ std::vector<RandCoreWork> rand_core_layout(const RandWorkSplit& ws) {
 
 }  // namespace
 
-ProgramDescriptor RandDeviceOperation::RandProgramFactory::create_descriptor(
+ttnn::device_operation::ProgramArtifacts RandDeviceOperation::RandProgramFactory::create_program_artifacts(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& /*tensor_args*/,
-    tensor_return_value_t& output,
-    const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate) {
-    const auto ws = compute_rand_work_split(operation_attributes, output, mesh_dispatch_coordinate);
-    const auto& all_cores = ws.all_cores;
-    const auto num_cores_total = ws.cores.size();
+    tensor_return_value_t& output) {
+    // create_program_artifacts is called once and the resulting spec is stamped across the mesh, so the
+    // (per-device) seed offset is baked at the zero coordinate here; override_runtime_arguments re-applies
+    // the correct per-coordinate seeds on every cache hit.
+    const auto ws = compute_rand_work_split(operation_attributes, output, std::nullopt);
 
-    DataType output_dtype = output.dtype();
-    auto out_data_format = datatype_to_dataformat_converter(output_dtype);
+    const DataType output_dtype = output.dtype();
+    const auto out_data_format = datatype_to_dataformat_converter(output_dtype);
     const uint32_t dtype_tile_size = tile_size(out_data_format);
     const uint32_t intermed_tile_size = tile_size(tt::DataFormat::Float32);
-
-    constexpr uint32_t in_out_num_tiles = 1;
-    constexpr uint32_t intermed_num_tiles = 2;
-
-    constexpr uint32_t intermed_cb_id = CBIndex::c_24;
-    constexpr uint32_t dst_cb_id = CBIndex::c_0;
-
-    ProgramDescriptor desc;
-
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = intermed_num_tiles * intermed_tile_size,
-        .core_ranges = all_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = intermed_cb_id,
-            .data_format = tt::DataFormat::Float32,
-            .page_size = intermed_tile_size,
-        }}},
-    });
-
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = in_out_num_tiles * dtype_tile_size,
-        .core_ranges = all_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = dst_cb_id,
-            .data_format = out_data_format,
-            .page_size = dtype_tile_size,
-        }}},
-    });
-
-    KernelDescriptor::CompileTimeArgs writer_ct_args;
-    writer_ct_args.reserve(8);
-    writer_ct_args.push_back(intermed_cb_id);
-    writer_ct_args.push_back(dst_cb_id);
-    TensorAccessorArgs(*output.buffer()).append_to(writer_ct_args);
-
-    KernelDescriptor writer_desc;
-    writer_desc.kernel_source = WRITER_KERNEL_PATH;
-    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    writer_desc.core_ranges = all_cores;
-    writer_desc.compile_time_args = std::move(writer_ct_args);
-    writer_desc.config = WriterConfigDescriptor{};
+    const bool is_bfloat16 = output_dtype == DataType::BFLOAT16;
     switch (output_dtype) {
-        case DataType::BFLOAT16: writer_desc.defines.emplace_back("OUTPUT_DTYPE_BFLOAT16", "1"); break;
-        case DataType::FLOAT32: writer_desc.defines.emplace_back("OUTPUT_DTYPE_FLOAT32", "1"); break;
+        case DataType::BFLOAT16:
+        case DataType::FLOAT32: break;
         default:
             // The writer kernel only implements float32 and bfloat16 output paths.
-            // Fail fast here so we never instantiate a program that can hang at runtime.
             TT_THROW("RandDeviceOperation: unsupported output dtype for writer kernel");
     }
-    writer_desc.runtime_args.reserve(num_cores_total);
-
-    KernelDescriptor compute_desc;
-    compute_desc.kernel_source = COMPUTE_KERNEL_PATH;
-    compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    compute_desc.core_ranges = all_cores;
-    compute_desc.compile_time_args = {intermed_cb_id};
-    compute_desc.config = ComputeConfigDescriptor{
-        .math_fidelity = tt::tt_metal::MathFidelity::HiFi4,
-        .fp32_dest_acc_en = true,  // if fp32_dest_acc_en set to false a precision error may occur which makes
-                                   // generated number out of range [from, to)
-        .dst_full_sync_en = false,
-        .math_approx_mode = true,
-    };
-    compute_desc.runtime_args.reserve(num_cores_total);
 
     const float eps = 1e-6f;
     const uint32_t from_bits = std::bit_cast<uint32_t>(operation_attributes.from);
     const uint32_t to_bits = std::bit_cast<uint32_t>(operation_attributes.to - eps);
+
+    // ---- ProgramSpec ----
+    ProgramSpec spec;
+    spec.name = "rand";
+
+    spec.tensor_parameters = {TensorParameter{.unique_id = RAND_OUTPUT, .spec = output.tensor_spec()}};
+
+    // Intermediate DFB: compute PRODUCES Float32 tiles, writer CONSUMES them (double-buffered).
+    spec.dataflow_buffers.push_back(DataflowBufferSpec{
+        .unique_id = RAND_INTERMED,
+        .entry_size = intermed_tile_size,
+        .num_entries = 2,
+        .data_format_metadata = tt::DataFormat::Float32,
+    });
+    // bfloat16 output uses a writer-local staging DFB (self-loop) for the fp32->bf16 conversion.
+    if (is_bfloat16) {
+        spec.dataflow_buffers.push_back(DataflowBufferSpec{
+            .unique_id = RAND_DST,
+            .entry_size = dtype_tile_size,
+            .num_entries = 1,
+            .data_format_metadata = out_data_format,
+        });
+    }
+
+    // Compute kernel: producer of the intermediate DFB.
+    KernelSpec compute{
+        .unique_id = RAND_COMPUTE,
+        .source = COMPUTE_KERNEL_PATH,
+        .dfb_bindings = {ProducerOf(RAND_INTERMED, "intermed")},
+        .runtime_arg_schema = {.runtime_arg_names = {"seed", "from", "to", "tile_offset", "units_per_core"}},
+        .hw_config = ttnn::to_compute_hardware_config(
+            output.device()->arch(),
+            ttnn::ComputeKernelConfig{
+                .math_fidelity = MathFidelity::HiFi4,
+                // if fp32_dest_acc_en is false a precision error may make numbers out of range [from, to)
+                .math_approx_mode = true,
+                .fp32_dest_acc_en = true,
+                .dst_full_sync_en = false,
+            }),
+    };
+    // Only seed/from/to change per dispatch; UpdateProgramRunArgs retains the args the override omits.
+
+    // Writer kernel: consumer of the intermediate DFB; writes to the interleaved output.
+    KernelSpec writer{
+        .unique_id = RAND_WRITER,
+        .source = WRITER_KERNEL_PATH,
+        .dfb_bindings = {ConsumerOf(RAND_INTERMED, "intermed")},
+        .tensor_bindings = {TensorBinding{.tensor_parameter_name = RAND_OUTPUT, .accessor_name = "output"}},
+        .runtime_arg_schema = {.runtime_arg_names = {"tile_offset", "units_per_core"}},
+        .hw_config = ttnn::create_writer_datamovement_config(output.device()->arch()),
+    };
+    if (is_bfloat16) {
+        writer.compiler_options.defines.emplace("OUTPUT_DTYPE_BFLOAT16", "1");
+        // Writer-local self-loop staging DFB (one PRODUCER + one CONSUMER on the same kernel).
+        writer.dfb_bindings.push_back(ProducerOf(RAND_DST, "dst"));
+        writer.dfb_bindings.push_back(ConsumerOf(RAND_DST, "dst"));
+    }
+
+    spec.kernels.push_back(compute);
+    spec.kernels.push_back(writer);
+
+    Group<KernelSpecName> wu_kernels = {RAND_COMPUTE, RAND_WRITER};
+    spec.work_units = {WorkUnitSpec{.name = "main", .kernels = wu_kernels, .target_nodes = ws.all_cores}};
+
+    // ---- ProgramRunArgs ----
+    ProgramRunArgs run_args;
+    KernelRunArgs compute_run{.kernel = RAND_COMPUTE};
+    KernelRunArgs writer_run{.kernel = RAND_WRITER};
 
     const auto layout = rand_core_layout(ws);
     for (int i = 0; i < static_cast<int>(layout.size()); ++i) {
         const auto& [core, units_per_core, tile_offset] = layout[i];
         const uint32_t seed = rand_seed_for_core(operation_attributes, i, ws.device_seed_offset);
 
-        // seed/from/to are DYNAMIC (omitted from the cache key / attribute_names): baked here for the
-        // cache-miss build, and re-applied on every cache hit via override_runtime_arguments().
-        compute_desc.runtime_args.emplace_back(
-            core, KernelDescriptor::CoreRuntimeArgs{seed, from_bits, to_bits, tile_offset, units_per_core});
-
-        // Register the output address as a Buffer* binding so rand takes the fast cache-hit path
-        // (real program caching) with the address correctly re-patched each dispatch.
-        writer_desc.emplace_runtime_args(core, {output.buffer(), tile_offset, units_per_core});
+        AddRuntimeArgsForNode(
+            compute_run.runtime_arg_values,
+            core,
+            {{"seed", seed},
+             {"from", from_bits},
+             {"to", to_bits},
+             {"tile_offset", tile_offset},
+             {"units_per_core", units_per_core}});
+        AddRuntimeArgsForNode(
+            writer_run.runtime_arg_values, core, {{"tile_offset", tile_offset}, {"units_per_core", units_per_core}});
     }
 
-    desc.kernels.push_back(std::move(writer_desc));
-    desc.kernels.push_back(std::move(compute_desc));
+    run_args.kernel_run_args.push_back(compute_run);
+    run_args.kernel_run_args.push_back(writer_run);
+    run_args.tensor_args.emplace(RAND_OUTPUT, TensorArgument{output.mesh_tensor()});
 
-    return desc;
+    return ttnn::device_operation::ProgramArtifacts{.spec = std::move(spec), .run_params = std::move(run_args)};
 }
 
-void RandDeviceOperation::RandProgramFactory::override_runtime_arguments(
-    tt::tt_metal::Program& program,
+tt::tt_metal::experimental::ProgramRunArgs RandDeviceOperation::RandProgramFactory::override_runtime_arguments(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& /*tensor_args*/,
     tensor_return_value_t& output,
     const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate) {
-    // Re-derive every per-dispatch arg on each cache hit from the same builder create_descriptor uses:
-    // compute's seed/from/to and the writer's output address. override replaces resolve_bindings, so
-    // the address is ours to re-apply too. Push order in create_descriptor: writer 0, compute 1.
-    constexpr uint32_t writer_kernel_idx = 0;
-    constexpr uint32_t compute_kernel_idx = 1;
-
+    // seed/from/to are DYNAMIC (omitted from the cache key) and re-applied every dispatch; the static
+    // tile_offset/units_per_core args are enqueue-invariant and retained from the cache-miss
+    // SetProgramRunArgs. The output tensor arg is re-supplied so its (freshly allocated) address is
+    // re-patched (UpdateProgramRunArgs applies both).
     const auto ws = compute_rand_work_split(operation_attributes, output, mesh_dispatch_coordinate);
+
     const float eps = 1e-6f;
     const uint32_t from_bits = std::bit_cast<uint32_t>(operation_attributes.from);
     const uint32_t to_bits = std::bit_cast<uint32_t>(operation_attributes.to - eps);
-    const uint32_t out_addr = output.buffer()->address();
 
+    ProgramRunArgs run_args;
+    KernelRunArgs compute_run{.kernel = RAND_COMPUTE};
     const auto layout = rand_core_layout(ws);
     for (int i = 0; i < static_cast<int>(layout.size()); ++i) {
-        const auto& [core, units_per_core, tile_offset] = layout[i];
+        const auto& core = layout[i].core;
         const uint32_t seed = rand_seed_for_core(operation_attributes, i, ws.device_seed_offset);
-
-        auto& compute_args = tt::tt_metal::GetRuntimeArgs(program, compute_kernel_idx, core);
-        compute_args[0] = seed;
-        compute_args[1] = from_bits;
-        compute_args[2] = to_bits;
-        compute_args[3] = tile_offset;
-        compute_args[4] = units_per_core;
-
-        auto& writer_args = tt::tt_metal::GetRuntimeArgs(program, writer_kernel_idx, core);
-        writer_args[0] = out_addr;
-        writer_args[1] = tile_offset;
-        writer_args[2] = units_per_core;
+        AddRuntimeArgsForNode(
+            compute_run.runtime_arg_values, core, {{"seed", seed}, {"from", from_bits}, {"to", to_bits}});
     }
+    run_args.kernel_run_args.push_back(compute_run);
+    run_args.tensor_args.emplace(RAND_OUTPUT, TensorArgument{output.mesh_tensor()});
+    return run_args;
 }
 
 }  // namespace ttnn::operations::rand

--- a/ttnn/sources.cmake
+++ b/ttnn/sources.cmake
@@ -216,6 +216,7 @@ set(TTNNCPP_API_HEADERS
     api/ttnn/metal_v2_artifacts.hpp
     api/ttnn/operation.hpp
     api/ttnn/operation_concepts.hpp
+    api/ttnn/program_hash.hpp
     api/ttnn/reports.hpp
     api/ttnn/tensor/host_buffer/functions.hpp
     api/ttnn/tensor/layout/alignment.hpp


### PR DESCRIPTION
### What

**A Metal 2.0 operation has exactly one way to define its program-cache key. One, and only one.**

That way is declarative, and there is no function to write:

```cpp
static ttsl::SmallVector<TensorSpecRelaxations> tensor_args_relaxations(const tensor_args_t&);  // tensor half
static constexpr auto attributes_excluded_from_key = std::forward_as_tuple("seed");             // non-tensor half
```

Declare neither and the framework reflects over everything. There is no third option, no fourth, and no
back door. Every other route is a compile error on the spec path.

Before this PR ttnn had **three** ways to change an op's key, only one of which looked like it:

1. `compute_program_hash(attrs, tensor_args)` — the obvious one. Already banned on the spec path.
2. **Narrowing `attribute_names`** — `hash_object` hashes only `attribute_values()` when the tuple exists
   (`tt_stl/reflection.hpp:1319`) and otherwise reflects over every field (`:1418`). Omitting a field from
   the tuple therefore drops it from the cache key, silently, with nothing at the call site to read.
3. **`to_hash()` on the attributes struct** — outranks even `attribute_names` (`:1314`) and replaces the
   attribute hash wholesale.

Routes 2 and 3 are not theoretical. They are how two shipped Metal 2.0 operations were already keyed, and
one of them was wrong (below).

### The rule, enforced

Four `static_assert`s in `MeshDeviceOperationAdapter`, all gated on `HasSpecProgramFactory`, so descriptor
and legacy operations are untouched. Each closes a specific hack, not just an honest mistake:

| check | what it stops |
|---|---|
| no `compute_program_hash` | a hand-rolled key the framework cannot read |
| no `operation_attributes_t::to_hash()` | outranks `attribute_names` and replaces the attribute hash wholesale |
| `attribute_names` names **every** field, names are **distinct**, every excluded name **exists** in it | omitting a field drops it from the key silently; a duplicated name makes the count match while a field goes unnamed; a misspelled exclusion excludes nothing |
| `attribute_values()` is `std::forward_as_tuple` of the members | returning computed values coarsens the key inside what reads as a field list |

The counting is `std::tuple_size_v<attribute_names> + std::tuple_size_v<attributes_excluded_from_key> ==
reflect::size<operation_attributes_t>()`. The point is the failure mode: **adding a field to a Metal 2.0
attributes struct now breaks the build** until somebody says whether it belongs in the key. Previously it
silently did not.

Exclusion stays possible — it has to: `rand` must not key its seed, and conv2d must not key a value derived
from live allocator state. But it is now stated in a named, greppable place instead of being the absence of
a string in a tuple, and it is the *only* place.

A cost worth naming: `std::make_tuple` of a scalar field is semantically identical to `forward_as_tuple`,
and the shape rule rejects it anyway, because by type it is indistinguishable from a computed value. That
is the price of a check that cannot be argued around.

### The bug this found

`experimental/quasar/binary_ng` hid `worker_grid` and `sub_device_id` from its key. `worker_grid` is what
`split_work_to_cores` is given in the Metal 2.0 factory
(`binary_ng_metal_v2_factory.cpp:941`) — it decides the core set and the per-core work split — and it comes
from `device->worker_cores(TENSIX, sub_device_id)`. Neither field is recoverable from anything that *is*
keyed, since tensor specs do not encode sub-device.

Same shapes on a different sub-device configuration therefore produced the same cache key while requiring a
different core set: a cache hit returning a program built for the wrong cores. Both fields are now keyed.
`input_dtype` stays out, declared in `attributes_excluded_from_key` — it is the input tensor's own dtype and
is already keyed through `tensor_args`.

`conv2d` (shared `Conv2dParams`) declares `pre_op_l1_allocation_size_bytes` excluded: it is recomputed per
call from live allocator state and is only read by the L1-accounting assertion in
`conv2d_op_program_factory_common.cpp:866-889`, so keying it would give every call its own program.

### Testing

- `./build_metal.sh --build-tests` green: the three asserts compiling across the tree means no spec-path
  operation keys itself any other way.
- Existing keying gtests (`QuasarKeyingTest`, `ProgramHashTest`, `LaunchOperationTest`): 11/11 pass.
- Zero static-assert failures tree-wide, which is the audit: every other spec-path operation either has no
  `attribute_names` (fully reflected) or already returns raw fields. The migration really is these two ops.

### Notes for reviewers

- Legacy and descriptor operations keep all three routes. This is deliberate: the rule applies to what we
  are porting *to*, not to what we are porting *from*.
- The `binary_ng` fix means a genuine keying change for that op — same-shape calls on different sub-devices
  now build separate programs, which is the correct behaviour and the point of the fix.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/metal2-one-keying-way-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/metal2-one-keying-way-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/metal2-one-keying-way-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/metal2-one-keying-way-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=dgomez/metal2-one-keying-way-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:dgomez/metal2-one-keying-way-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/metal2-one-keying-way-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/metal2-one-keying-way-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/metal2-one-keying-way-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/metal2-one-keying-way-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/metal2-one-keying-way-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/metal2-one-keying-way-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/metal2-one-keying-way-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/metal2-one-keying-way-v2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/metal2-one-keying-way-v2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/metal2-one-keying-way-v2)
