### PR TITLE
[skip ci] produce data: fix epoch timestamps being uploaded to cicd_test

### DIFF
--- a/infra/data_collection/cicd.py
+++ b/infra/data_collection/cicd.py
@@ -9,6 +9,7 @@ from loguru import logger
 from infra.data_collection import pydantic_models
 from infra.data_collection.github.utils import (
     get_data_pipeline_datetime_from_datetime,
+    get_datetime_from_github_datetime,
     get_job_rows_from_github_info,
     get_pipeline_row_from_github_info,
 )
@@ -78,13 +79,16 @@ def create_cicd_json_for_data_analysis(
             logger.info(f"Job id:{github_job_id} is skipped. Skipping job upload.")
             continue
 
+        # Used as the fallback test timestamp when a report carries gtest's not-run epoch sentinel.
+        job_start_timestamp = get_datetime_from_github_datetime(raw_job["job_start_ts"])
+
         test_report_exists = github_job_id in github_job_id_to_test_reports
         if test_report_exists:
             tests = []
             test_reports = github_job_id_to_test_reports[github_job_id]
             for test_report_path in test_reports:
                 logger.info(f"Job id:{github_job_id} Analyzing test report {test_report_path}")
-                tests += get_tests_from_test_report_path(test_report_path)
+                tests += get_tests_from_test_report_path(test_report_path, job_start_timestamp)
             tests = deduplicate_tests_by_full_name(tests)
         else:
             tests = []

--- a/infra/data_collection/github/workflows.py
+++ b/infra/data_collection/github/workflows.py
@@ -685,7 +685,7 @@ def parse_report_timestamp_(raw_timestamp, fallback):
     return parsed
 
 
-def get_tests_from_test_report_path(test_report_path):
+def get_tests_from_test_report_path(test_report_path, job_start_timestamp):
     report_root_tree = junit_xml_utils.get_xml_file_root_element_tree(test_report_path)
 
     report_root = report_root_tree.getroot()
@@ -694,7 +694,7 @@ def get_tests_from_test_report_path(test_report_path):
     if report_root.tag == "testsuite":
         logger.info("Root tag is testsuite, found ctest xml")
         tests = []
-        default_timestamp = parse_report_timestamp_(report_root.attrib.get("timestamp"), fallback=datetime.now())
+        default_timestamp = parse_report_timestamp_(report_root.attrib.get("timestamp"), fallback=job_start_timestamp)
         for testcase in report_root.findall("testcase"):
             if is_valid_testcase_(testcase):
                 # Process ctest testcase
@@ -710,13 +710,12 @@ def get_tests_from_test_report_path(test_report_path):
     if is_pytest or is_gtest:
         logger.info(f"Found {len(report_root)} testsuites")
         tests = []
-        # The run-level timestamp on the <testsuites> root is a valid fallback for any individual
-        # <testsuite> that gtest stamped with the not-run epoch sentinel (all-DISABLED_ suites).
-        run_timestamp = parse_report_timestamp_(report_root.attrib.get("timestamp"), fallback=datetime.now())
         for i in range(len(report_root)):
             testsuite = report_root[i]
             testsuite_name = testsuite.attrib.get("name") if is_gtest else None
-            default_timestamp = parse_report_timestamp_(testsuite.attrib.get("timestamp"), fallback=run_timestamp)
+            # Fall back to the job start timestamp for any <testsuite> that gtest stamped with the
+            # not-run epoch sentinel (all-DISABLED_ suites) instead of a real timestamp.
+            default_timestamp = parse_report_timestamp_(testsuite.attrib.get("timestamp"), fallback=job_start_timestamp)
             get_pydantic_test = partial(
                 get_pydantic_test_from_testcase_,
                 default_timestamp=default_timestamp,

--- a/infra/data_collection/github/workflows.py
+++ b/infra/data_collection/github/workflows.py
@@ -668,6 +668,23 @@ def deduplicate_tests_by_full_name(tests):
     return deduplicated_tests
 
 
+# gtest stamps suites/testcases that never actually ran (e.g. a testsuite made up entirely
+# of DISABLED_ tests) with this epoch sentinel instead of a real timestamp. datetime.fromisoformat
+# parses it without complaint, so it otherwise flows downstream as a bogus 1970-01-01 timestamp.
+GTEST_NOT_RUN_TIMESTAMP = datetime(1970, 1, 1)
+
+
+def parse_report_timestamp_(raw_timestamp, fallback):
+    """Parse a junit/gtest timestamp attribute, substituting a fallback when the attribute is
+    missing or set to gtest's not-run epoch sentinel (1970-01-01T00:00:00)."""
+    if not raw_timestamp:
+        return fallback
+    parsed = datetime.fromisoformat(raw_timestamp)
+    if parsed.replace(tzinfo=None) == GTEST_NOT_RUN_TIMESTAMP:
+        return fallback
+    return parsed
+
+
 def get_tests_from_test_report_path(test_report_path):
     report_root_tree = junit_xml_utils.get_xml_file_root_element_tree(test_report_path)
 
@@ -677,7 +694,7 @@ def get_tests_from_test_report_path(test_report_path):
     if report_root.tag == "testsuite":
         logger.info("Root tag is testsuite, found ctest xml")
         tests = []
-        default_timestamp = datetime.fromisoformat(report_root.attrib["timestamp"])
+        default_timestamp = parse_report_timestamp_(report_root.attrib.get("timestamp"), fallback=datetime.now())
         for testcase in report_root.findall("testcase"):
             if is_valid_testcase_(testcase):
                 # Process ctest testcase
@@ -693,10 +710,13 @@ def get_tests_from_test_report_path(test_report_path):
     if is_pytest or is_gtest:
         logger.info(f"Found {len(report_root)} testsuites")
         tests = []
+        # The run-level timestamp on the <testsuites> root is a valid fallback for any individual
+        # <testsuite> that gtest stamped with the not-run epoch sentinel (all-DISABLED_ suites).
+        run_timestamp = parse_report_timestamp_(report_root.attrib.get("timestamp"), fallback=datetime.now())
         for i in range(len(report_root)):
             testsuite = report_root[i]
             testsuite_name = testsuite.attrib.get("name") if is_gtest else None
-            default_timestamp = datetime.fromisoformat(testsuite.attrib["timestamp"])
+            default_timestamp = parse_report_timestamp_(testsuite.attrib.get("timestamp"), fallback=run_timestamp)
             get_pydantic_test = partial(
                 get_pydantic_test_from_testcase_,
                 default_timestamp=default_timestamp,

--- a/infra/tests/_data/data_collection/cicd/gtest_disabled_epoch_timestamp/report.xml
+++ b/infra/tests/_data/data_collection/cicd/gtest_disabled_epoch_timestamp/report.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites tests="3" failures="0" disabled="3" errors="0" time="1.5" timestamp="2026-07-30T13:24:31.000" name="AllTests">
+  <testsuite name="RealFixture" tests="1" failures="0" disabled="0" skipped="0" errors="0" time="1.5" timestamp="2026-07-30T13:24:31.500">
+    <testcase name="RunsForReal" file="/work/tests/foo_test.cpp" line="10" status="run" result="completed" time="1.5" timestamp="2026-07-30T13:24:31.500" classname="RealFixture" />
+  </testsuite>
+  <testsuite name="MemoryUtilsTest" tests="1" failures="0" disabled="1" skipped="0" errors="0" time="0" timestamp="1970-01-01T00:00:00">
+    <testcase name="DISABLED_L1Usage" file="/work/tests/utils/memory_utils_test.cpp" line="20" status="notrun" result="suppressed" time="0" timestamp="1970-01-01T00:00:00" classname="MemoryUtilsTest" />
+  </testsuite>
+  <testsuite name="DISABLED_MemoryUtilsTest" tests="1" failures="0" disabled="1" skipped="0" errors="0" time="0" timestamp="1970-01-01T00:00:00">
+    <testcase name="SnapshotFeature" file="/work/tests/utils/memory_utils_test.cpp" line="30" status="notrun" result="suppressed" time="0" timestamp="1970-01-01T00:00:00" classname="DISABLED_MemoryUtilsTest" />
+  </testsuite>
+</testsuites>

--- a/infra/tests/data_collection/test_cicd.py
+++ b/infra/tests/data_collection/test_cicd.py
@@ -175,31 +175,39 @@ def test_create_pipeline_json_for_gtest_testcases(
 
 def test_gtest_disabled_tests_do_not_get_epoch_timestamp():
     """gtest stamps not-run suites (e.g. all-DISABLED_ suites) with a 1970-01-01 epoch sentinel.
-    The producer should substitute the run-level timestamp instead of emitting epoch timestamps."""
+    The producer should substitute the job start timestamp instead of emitting epoch timestamps."""
     report_path = (INFRA_TESTS_DIR / "_data/data_collection/cicd/gtest_disabled_epoch_timestamp/report.xml").resolve()
 
-    tests = workflows.get_tests_from_test_report_path(report_path)
+    job_start_timestamp = datetime.fromisoformat("2026-07-30T13:00:00")
+    tests = workflows.get_tests_from_test_report_path(report_path, job_start_timestamp)
 
     assert len(tests) == 3
-    run_timestamp = datetime.fromisoformat("2026-07-30T13:24:31.000")
     for test in tests:
         assert test.test_start_ts != workflows.GTEST_NOT_RUN_TIMESTAMP
         assert test.test_end_ts != workflows.GTEST_NOT_RUN_TIMESTAMP
 
-    # The two not-run (disabled) suites fall back to the run-level timestamp. Note DISABLED_ can
+    # The two not-run (disabled) suites fall back to the job start timestamp. Note DISABLED_ can
     # sit on the testcase name (DISABLED_L1Usage) or on the fixture/suite (DISABLED_MemoryUtilsTest).
     disabled_tests = [t for t in tests if t.test_case_name in ("DISABLED_L1Usage", "SnapshotFeature")]
     assert len(disabled_tests) == 2
     for test in disabled_tests:
-        assert test.test_start_ts == run_timestamp
-        assert test.test_end_ts == run_timestamp
+        assert test.test_start_ts == job_start_timestamp
+        assert test.test_end_ts == job_start_timestamp
+
+    # A real (run) test keeps its own suite timestamp, not the job start fallback.
+    real_test = next(t for t in tests if t.test_case_name == "RunsForReal")
+    assert real_test.test_start_ts == datetime.fromisoformat("2026-07-30T13:24:31.500")
 
 
 def test_empty_gtest_xml(workflow_run_gh_environment):
     github_runner_environment = workflow_run_gh_environment
     workflow_outputs_dir = (INFRA_TESTS_DIR / "_data/data_collection/cicd/all_post_commit_job_37712709106/").resolve()
+    job_start_timestamp = datetime.fromisoformat("2026-07-30T13:00:00")
     assert (
-        workflows.get_tests_from_test_report_path(workflow_outputs_dir / "distributed_unit_tests_wormhole_b0.xml") == []
+        workflows.get_tests_from_test_report_path(
+            workflow_outputs_dir / "distributed_unit_tests_wormhole_b0.xml", job_start_timestamp
+        )
+        == []
     )
 
 

--- a/infra/tests/data_collection/test_cicd.py
+++ b/infra/tests/data_collection/test_cicd.py
@@ -1,5 +1,6 @@
 import pytest
 import pathlib
+from datetime import datetime
 
 from infra.data_collection.github import workflows
 from infra.data_collection.cicd import create_cicd_json_for_data_analysis
@@ -170,6 +171,27 @@ def test_create_pipeline_json_for_gtest_testcases(
     assert job.job_status == JobStatus.success if job_success else JobStatus.failure
     if check_failing_tests:
         assert len([x for x in job.tests if not x.success]) > 0
+
+
+def test_gtest_disabled_tests_do_not_get_epoch_timestamp():
+    """gtest stamps not-run suites (e.g. all-DISABLED_ suites) with a 1970-01-01 epoch sentinel.
+    The producer should substitute the run-level timestamp instead of emitting epoch timestamps."""
+    report_path = (INFRA_TESTS_DIR / "_data/data_collection/cicd/gtest_disabled_epoch_timestamp/report.xml").resolve()
+
+    tests = workflows.get_tests_from_test_report_path(report_path)
+
+    assert len(tests) == 3
+    run_timestamp = datetime.fromisoformat("2026-07-30T13:24:31.000")
+    for test in tests:
+        assert test.test_start_ts != workflows.GTEST_NOT_RUN_TIMESTAMP
+        assert test.test_end_ts != workflows.GTEST_NOT_RUN_TIMESTAMP
+
+    # The two not-run (disabled) suites fall back to the run-level timestamp
+    disabled_tests = [t for t in tests if t.test_case_name in ("L1Usage", "SnapshotFeature")]
+    assert len(disabled_tests) == 2
+    for test in disabled_tests:
+        assert test.test_start_ts == run_timestamp
+        assert test.test_end_ts == run_timestamp
 
 
 def test_empty_gtest_xml(workflow_run_gh_environment):

--- a/infra/tests/data_collection/test_cicd.py
+++ b/infra/tests/data_collection/test_cicd.py
@@ -186,8 +186,9 @@ def test_gtest_disabled_tests_do_not_get_epoch_timestamp():
         assert test.test_start_ts != workflows.GTEST_NOT_RUN_TIMESTAMP
         assert test.test_end_ts != workflows.GTEST_NOT_RUN_TIMESTAMP
 
-    # The two not-run (disabled) suites fall back to the run-level timestamp
-    disabled_tests = [t for t in tests if t.test_case_name in ("L1Usage", "SnapshotFeature")]
+    # The two not-run (disabled) suites fall back to the run-level timestamp. Note DISABLED_ can
+    # sit on the testcase name (DISABLED_L1Usage) or on the fixture/suite (DISABLED_MemoryUtilsTest).
+    disabled_tests = [t for t in tests if t.test_case_name in ("DISABLED_L1Usage", "SnapshotFeature")]
     assert len(disabled_tests) == 2
     for test in disabled_tests:
         assert test.test_start_ts == run_timestamp


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->
Bug fix

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->
When epoch timestamps (1970-01-01) are detected in the test start/end ts (when gtests are disabled), use the job start timestamp instead.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->
Produce data run: https://github.com/tenstorrent/tt-metal/actions/runs/30580195080

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=williamly/fix-epoch-ts)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:williamly/fix-epoch-ts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=williamly/fix-epoch-ts)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:williamly/fix-epoch-ts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=williamly/fix-epoch-ts)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:williamly/fix-epoch-ts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=williamly/fix-epoch-ts)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:williamly/fix-epoch-ts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=williamly/fix-epoch-ts)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:williamly/fix-epoch-ts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=williamly/fix-epoch-ts)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:williamly/fix-epoch-ts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=williamly/fix-epoch-ts)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:williamly/fix-epoch-ts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=williamly/fix-epoch-ts)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:williamly/fix-epoch-ts)