### PR TITLE
Post a PR comment when CodeOwners ping hits a GitHub API rate limit

### DIFF
--- a/.github/workflows/codeowners-group-analysis.yaml
+++ b/.github/workflows/codeowners-group-analysis.yaml
@@ -2929,13 +2929,24 @@ jobs:
 
             SLACK_MESSAGE="$SLACK_MESSAGE"$'\n\n'"Please review when you have a moment. Thank you! 🚀"
 
-            # A rate-limited username lookup is a real ping failure, not a cosmetic
-            # fallback — replace the (possibly wrong/incomplete) message with an
-            # explicit failure notice instead of sending something that looks like
-            # a successful ping.
-            if [ "$RATE_LIMIT_HIT" = "true" ]; then
-              echo "❌ Aborting CodeOwners Slack ping — GitHub API rate limit exceeded while resolving one or more GitHub usernames"
-              SLACK_MESSAGE="⚠️ *CodeOwners Ping Failed*"$'\n\n'"GitHub API rate limit was exceeded while resolving codeowner/author names for <${{ github.server_url }}/${{ github.repository }}/pull/$PR_NUMBER|PR #$PR_NUMBER>, so no ping was sent."$'\n\n'"Please re-run \`/codeowners ping\` once the rate limit resets."
+            # A rate-limited username lookup means some names/mentions in the
+            # message above may be wrong or incomplete — surface that visibly on
+            # the PR itself with a ⚠️ warning comment (GitHub's reaction API has
+            # no "warning" content type, so a reply comment is the closest visible
+            # equivalent) rather than silently sending a broken-looking ping with
+            # no indication anything went wrong. The Slack message still goes out.
+            if [ "$RATE_LIMIT_HIT" = "true" ] && [ "${{ github.event_name }}" = "issue_comment" ]; then
+              echo "⚠️  GitHub API rate limit hit while resolving one or more usernames — posting a warning comment on the PR"
+              WARNING_BODY="⚠️ **CodeOwners Ping Warning**"$'\n\n'"GitHub API rate limit was hit while resolving one or more codeowner/author names for this ping. The Slack notification was still sent, but it may be missing a proper Slack mention or full name for some codeowners. Re-run \`/codeowners ping\` once the rate limit resets if anyone appears to have been missed."
+              WARNING_JSON_FILE=$(mktemp)
+              jq -n --arg body "$WARNING_BODY" '{"body": $body}' > "$WARNING_JSON_FILE"
+              curl -s -X POST \
+                -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" \
+                -H "Accept: application/vnd.github.v3+json" \
+                -H "Content-Type: application/json" \
+                --data-binary @"$WARNING_JSON_FILE" \
+                "https://api.github.com/repos/${{ github.repository }}/issues/$PR_NUMBER/comments" > /dev/null
+              rm -f "$WARNING_JSON_FILE"
             fi
 
             # Debug: Show the final message being sent (truncated for large messages)
@@ -2982,12 +2993,6 @@ jobs:
 
             # Clean up temp file
             rm -f /tmp/slack_message.txt
-
-            # Fail the job on a rate-limited ping so it shows up as a real CI
-            # failure instead of a quietly-successful run.
-            if [ "$RATE_LIMIT_HIT" = "true" ]; then
-              exit 1
-            fi
 
           elif [ "$SEND_SLACK" = "true" ] && [ "$NO_OWNERS_AVAILABLE" = "true" ]; then
             echo "Slack notification enabled but no owners available for notification (only PR author is codeowner)"

--- a/.github/workflows/codeowners-group-analysis.yaml
+++ b/.github/workflows/codeowners-group-analysis.yaml
@@ -1731,7 +1731,7 @@ jobs:
                     SLACK_USER_MENTIONS="$SLACK_USER_MENTIONS <@$SLACK_USER_ID>"
                     echo "✅ Found Slack user: $USER_NAME -> $SLACK_USER_ID"
                   else
-                    SLACK_USER_MENTIONS="$SLACK_USER_MENTIONS $USER_NAME"
+                    SLACK_USER_MENTIONS="$SLACK_USER_MENTIONS $USER_NAME (@$clean_item)"
                     echo "⚠️  Slack user not found for: $USER_NAME (@$clean_item), using full name fallback"
                   fi
                 fi
@@ -2728,7 +2728,7 @@ jobs:
                     SLACK_USER_MENTIONS="$SLACK_USER_MENTIONS <@$SLACK_USER_ID>"
                     echo "✅ Found Slack user: $USER_NAME -> $SLACK_USER_ID"
                   else
-                    SLACK_USER_MENTIONS="$SLACK_USER_MENTIONS $USER_NAME"
+                    SLACK_USER_MENTIONS="$SLACK_USER_MENTIONS $USER_NAME (@$owner)"
                     echo "⚠️  Slack user not found for: $USER_NAME (@$owner), using full name fallback"
                   fi
                 fi

--- a/.github/workflows/codeowners-group-analysis.yaml
+++ b/.github/workflows/codeowners-group-analysis.yaml
@@ -2941,25 +2941,27 @@ jobs:
             # Clean up temp file
             rm -f /tmp/slack_message.txt
 
-            # Let devs know on the PR itself when the ping hit a GitHub API rate
-            # limit while resolving names (GitHub's reactions API has no "warning"
-            # type, so a comment is the closest visible equivalent).
-            if [ "$PING_RATE_LIMITED" = "true" ] && [ "${{ github.event_name }}" = "issue_comment" ]; then
-              WARNING_JSON_FILE=$(mktemp)
-              jq -n --arg body "⚠️ CodeOwners ping hit a GitHub API rate limit while resolving names above — some may be inaccurate." '{"body": $body}' > "$WARNING_JSON_FILE"
-              curl -s -X POST \
-                -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" \
-                -H "Accept: application/vnd.github.v3+json" \
-                -H "Content-Type: application/json" \
-                --data-binary @"$WARNING_JSON_FILE" \
-                "https://api.github.com/repos/${{ github.repository }}/issues/$PR_NUMBER/comments" > /dev/null
-              rm -f "$WARNING_JSON_FILE"
-            fi
-
           elif [ "$SEND_SLACK" = "true" ] && [ "$NO_OWNERS_AVAILABLE" = "true" ]; then
             echo "Slack notification enabled but no owners available for notification (only PR author is codeowner)"
           elif [ "$SEND_SLACK" = "true" ] && [ -z "$SELECTED_OWNERS" ] && [ -z "$SELECTED_SLACK_GROUPS" ]; then
             echo "Slack notification enabled but no pending owners or groups to notify"
           else
             echo "Slack notification disabled"
+          fi
+
+          # Let devs know directly on the GitHub PR when resolving codeowner names
+          # hit a GitHub API rate limit — this is a GitHub-side signal about GitHub
+          # API failures, unrelated to whether the Slack notification above ran or
+          # succeeded. GitHub's reactions API has no "warning" content type, so a
+          # comment is the closest visible equivalent.
+          if [ "$PING_RATE_LIMITED" = "true" ] && [ "${{ github.event_name }}" = "issue_comment" ]; then
+            WARNING_JSON_FILE=$(mktemp)
+            jq -n --arg body "⚠️ CodeOwners ping hit a GitHub API rate limit while resolving names above — some may be inaccurate." '{"body": $body}' > "$WARNING_JSON_FILE"
+            curl -s -X POST \
+              -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" \
+              -H "Accept: application/vnd.github.v3+json" \
+              -H "Content-Type: application/json" \
+              --data-binary @"$WARNING_JSON_FILE" \
+              "https://api.github.com/repos/${{ github.repository }}/issues/$PR_NUMBER/comments" > /dev/null
+            rm -f "$WARNING_JSON_FILE"
           fi

--- a/.github/workflows/codeowners-group-analysis.yaml
+++ b/.github/workflows/codeowners-group-analysis.yaml
@@ -2958,7 +2958,7 @@ jobs:
             WARNING_JSON_FILE=$(mktemp)
             jq -n --arg body "⚠️ CodeOwners ping hit a GitHub API rate limit while resolving names above — some may be inaccurate." '{"body": $body}' > "$WARNING_JSON_FILE"
             curl -s -X POST \
-              -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" \
+              -H "Authorization: Bearer ${{ github.token }}" \
               -H "Accept: application/vnd.github.v3+json" \
               -H "Content-Type: application/json" \
               --data-binary @"$WARNING_JSON_FILE" \

--- a/.github/workflows/codeowners-group-analysis.yaml
+++ b/.github/workflows/codeowners-group-analysis.yaml
@@ -2464,6 +2464,88 @@ jobs:
           echo "selected-slack-groups=$SELECTED_SLACK_GROUPS" >> $GITHUB_OUTPUT
           echo "no-owners-available=$NO_OWNERS_AVAILABLE" >> $GITHUB_OUTPUT
 
+      - name: Send notifications
+        if: needs.parse-comment.outputs.is-direct-ping != 'true'
+        run: |
+          PING_OWNERS="${{ steps.generate-comment.outputs.ping-owners }}"
+          SEND_SLACK="${{ steps.generate-comment.outputs.send-slack }}"
+          SELECTED_OWNERS="${{ steps.select-owners.outputs.selected-owners }}"
+          PR_AUTHOR_LOGIN="${{ steps.setup-notifications.outputs.pr-author-login }}"
+          PR_AUTHOR_NAME="${{ steps.setup-notifications.outputs.pr-author-name }}"
+          AUTHOR_NOTES="${{ steps.generate-comment.outputs.author-notes }}"
+          PR_NUMBER="${{ steps.generate-comment.outputs.pr-number }}"
+
+          # Fetch PR title safely to avoid shell injection
+          PR_API="https://api.github.com/repos/${{ github.repository }}/pulls/$PR_NUMBER"
+          PR_DATA=$(curl -s --max-time 30 -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" \
+                         -H "Accept: application/vnd.github.v3+json" \
+                         "$PR_API")
+          PR_TITLE=$(echo "$PR_DATA" | jq -r '.title')
+          # Escape angle brackets so Slack mrkdwn link text is not malformed
+          PR_TITLE=$(echo "$PR_TITLE" | sed 's/</\&lt;/g; s/>/\&gt;/g')
+
+          # Use #tt-metal-pr-review-requests Slack channel
+          SLACK_CHANNEL="C07G47JMQHM"
+
+          # Define API endpoint
+          COMMENTS_API="https://api.github.com/repos/${{ github.repository }}/issues/$PR_NUMBER/comments"
+
+          # Check if we have any owners to ping
+          if [ -n "$SELECTED_OWNERS" ]; then
+            # Get full names for selected owners and build ping message
+            # NOTE: Do NOT use GitHub mention syntax [@username] as it subscribes users to the PR
+            PING_MESSAGE="Hi"
+            IFS=',' read -ra SELECTED_ARRAY <<< "$SELECTED_OWNERS"
+            OWNER_COUNT=${#SELECTED_ARRAY[@]}
+            for i in "${!SELECTED_ARRAY[@]}"; do
+              owner="${SELECTED_ARRAY[$i]}"
+              if [ -n "$owner" ]; then
+                # Get user info
+                USER_API="https://api.github.com/users/$owner"
+                USER_DATA=$(curl -s -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" \
+                               -H "Accept: application/vnd.github.v3+json" \
+                               "$USER_API" 2>/dev/null)
+                USER_NAME=$(echo "$USER_DATA" | jq -r '.name // empty' 2>/dev/null)
+                if [ -n "$USER_NAME" ] && [ "$USER_NAME" != "null" ]; then
+                  PING_MESSAGE="$PING_MESSAGE $USER_NAME (@$owner)"
+                else
+                  PING_MESSAGE="$PING_MESSAGE (@$owner)"
+                fi
+
+                # Add comma if not the last owner
+                if [ $((i + 1)) -lt $OWNER_COUNT ]; then
+                  PING_MESSAGE="$PING_MESSAGE,"
+                fi
+              fi
+            done
+
+            # Get full name for PR author
+            PR_AUTHOR_FULL_NAME="$PR_AUTHOR_NAME"  # Default to what we got from PR API
+            if [ "$PR_AUTHOR_FULL_NAME" = "$PR_AUTHOR_LOGIN" ] || [ -z "$PR_AUTHOR_FULL_NAME" ] || [ "$PR_AUTHOR_FULL_NAME" = "null" ]; then
+              # Try to fetch full name from GitHub API
+              AUTHOR_USER_API="https://api.github.com/users/$PR_AUTHOR_LOGIN"
+              AUTHOR_USER_DATA=$(curl -s -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" \
+                                     -H "Accept: application/vnd.github.v3+json" \
+                                     "$AUTHOR_USER_API" 2>/dev/null)
+              AUTHOR_FULL_NAME=$(echo "$AUTHOR_USER_DATA" | jq -r '.name // empty' 2>/dev/null)
+              if [ -n "$AUTHOR_FULL_NAME" ] && [ "$AUTHOR_FULL_NAME" != "null" ]; then
+                PR_AUTHOR_FULL_NAME="$AUTHOR_FULL_NAME"
+              fi
+            fi
+
+            PING_MESSAGE="$PING_MESSAGE, this PR **[""$PR_TITLE""](${{ github.server_url }}/${{ github.repository }}/pull/$PR_NUMBER)** by $PR_AUTHOR_FULL_NAME (@$PR_AUTHOR_LOGIN) needs your approval/review to merge this."
+
+            # Log the ping message (comment posting to PR is disabled)
+            echo "Ping message (comment posting disabled, Slack-only):"
+            if [ ${#PING_MESSAGE} -gt 2000 ]; then
+              echo "${PING_MESSAGE:0:2000}... (truncated)"
+            else
+              echo "$PING_MESSAGE"
+            fi
+          else
+            echo "No pending owners to ping"
+          fi
+
       - name: Send Slack notifications
         if: needs.parse-comment.outputs.is-direct-ping != 'true'
         run: |
@@ -2481,6 +2563,47 @@ jobs:
           CHANGED_FILES_COUNT="${{ needs.analyze-codeowners.outputs.changed-files-count || 0 }}"
           REQUESTER_LOGIN="${{ needs.parse-comment.outputs.comment-author || '' }}"
           REQUESTER_NAME="$REQUESTER_LOGIN"
+          RATE_LIMIT_HIT=false
+
+          # Checking quota does not itself count against the rate limit.
+          RATE_LIMIT_INFO=$(curl -s -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" \
+                                 -H "Accept: application/vnd.github.v3+json" \
+                                 "https://api.github.com/rate_limit")
+          echo "GitHub API quota (CODEOWNERS_GROUP_ANALYSIS_PAT): $(echo "$RATE_LIMIT_INFO" | jq -r '.resources.core.remaining // -1')/$(echo "$RATE_LIMIT_INFO" | jq -r '.resources.core.limit // -1') remaining, resets at $(echo "$RATE_LIMIT_INFO" | jq -r '.resources.core.reset // 0')"
+
+          # Look up a GitHub user's display name, retrying with the default Actions
+          # token (a separate rate-limit bucket from the shared PAT) if the PAT is
+          # exhausted. Sets RATE_LIMIT_HIT=true when both tokens are rate limited, so
+          # callers can treat this as a real ping error instead of silently falling
+          # back to a name that was never actually resolved.
+          lookup_github_user_name() {
+            local login="$1"
+            local response http_code body
+
+            response=$(curl -s -w '\n%{http_code}' -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" \
+                           -H "Accept: application/vnd.github.v3+json" \
+                           "https://api.github.com/users/$login" 2>/dev/null)
+            http_code=$(echo "$response" | tail -n1)
+            body=$(echo "$response" | sed '$d')
+
+            if [ "$http_code" = "403" ] && echo "$body" | grep -qi "rate limit"; then
+              echo "⚠️  PAT rate-limited looking up $login, retrying with default Actions token" >&2
+              response=$(curl -s -w '\n%{http_code}' -H "Authorization: Bearer ${{ github.token }}" \
+                             -H "Accept: application/vnd.github.v3+json" \
+                             "https://api.github.com/users/$login" 2>/dev/null)
+              http_code=$(echo "$response" | tail -n1)
+              body=$(echo "$response" | sed '$d')
+            fi
+
+            if [ "$http_code" = "403" ] && echo "$body" | grep -qi "rate limit"; then
+              echo "❌ GitHub API rate limit exceeded on both tokens looking up $login" >&2
+              RATE_LIMIT_HIT=true
+              echo ""
+              return
+            fi
+
+            echo "$body" | jq -r '.name // empty' 2>/dev/null
+          }
 
           # Load Slack users from file (set in Setup for notifications step)
           ALL_SLACK_USERS=$(cat "${RUNNER_TEMP}/slack_users.json")
@@ -2642,11 +2765,7 @@ jobs:
               for owner in "${SELECTED_ARRAY[@]}"; do
                 if [ -n "$owner" ]; then
                   # Get full name for this owner
-                  USER_API="https://api.github.com/users/$owner"
-                  USER_DATA=$(curl -s -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" \
-                                 -H "Accept: application/vnd.github.v3+json" \
-                                 "$USER_API" 2>/dev/null)
-                  USER_NAME=$(echo "$USER_DATA" | jq -r '.name // empty' 2>/dev/null)
+                  USER_NAME=$(lookup_github_user_name "$owner")
                   if [ -z "$USER_NAME" ] || [ "$USER_NAME" = "null" ]; then
                     USER_NAME="$owner"
                   fi
@@ -2670,11 +2789,7 @@ jobs:
             # Get PR author Slack ID
             PR_AUTHOR_FULL_NAME="$PR_AUTHOR_NAME"
             if [ "$PR_AUTHOR_FULL_NAME" = "$PR_AUTHOR_LOGIN" ] || [ -z "$PR_AUTHOR_FULL_NAME" ] || [ "$PR_AUTHOR_FULL_NAME" = "null" ]; then
-              AUTHOR_USER_API="https://api.github.com/users/$PR_AUTHOR_LOGIN"
-              AUTHOR_USER_DATA=$(curl -s -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" \
-                                     -H "Accept: application/vnd.github.v3+json" \
-                                     "$AUTHOR_USER_API" 2>/dev/null)
-              AUTHOR_FULL_NAME=$(echo "$AUTHOR_USER_DATA" | jq -r '.name // empty' 2>/dev/null)
+              AUTHOR_FULL_NAME=$(lookup_github_user_name "$PR_AUTHOR_LOGIN")
               if [ -n "$AUTHOR_FULL_NAME" ] && [ "$AUTHOR_FULL_NAME" != "null" ]; then
                 PR_AUTHOR_FULL_NAME="$AUTHOR_FULL_NAME"
               fi
@@ -2692,11 +2807,7 @@ jobs:
             # Add author and requested by information (combine on same line if different)
             if [ -n "$REQUESTER_LOGIN" ] && [ "$REQUESTER_LOGIN" != "$PR_AUTHOR_LOGIN" ]; then
               # Get full name for requester if available
-              REQUESTER_USER_API="https://api.github.com/users/$REQUESTER_LOGIN"
-              REQUESTER_USER_DATA=$(curl -s -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" \
-                                     -H "Accept: application/vnd.github.v3+json" \
-                                     "$REQUESTER_USER_API" 2>/dev/null)
-              REQUESTER_FULL_NAME=$(echo "$REQUESTER_USER_DATA" | jq -r '.name // empty' 2>/dev/null)
+              REQUESTER_FULL_NAME=$(lookup_github_user_name "$REQUESTER_LOGIN")
               if [ -n "$REQUESTER_FULL_NAME" ] && [ "$REQUESTER_FULL_NAME" != "null" ]; then
                 REQUESTER_NAME="$REQUESTER_FULL_NAME"
               fi
@@ -2761,11 +2872,7 @@ jobs:
                     fi
 
                     # Get full name from GitHub API
-                    USER_API="https://api.github.com/users/$clean_username"
-                    USER_DATA=$(curl -s -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" \
-                                   -H "Accept: application/vnd.github.v3+json" \
-                                   "$USER_API" 2>/dev/null)
-                    USER_NAME=$(echo "$USER_DATA" | jq -r '.name // empty' 2>/dev/null)
+                    USER_NAME=$(lookup_github_user_name "$clean_username")
                     if [ -z "$USER_NAME" ] || [ "$USER_NAME" = "null" ]; then
                       USER_NAME="$clean_username"
                     fi
@@ -2822,6 +2929,15 @@ jobs:
 
             SLACK_MESSAGE="$SLACK_MESSAGE"$'\n\n'"Please review when you have a moment. Thank you! 🚀"
 
+            # A rate-limited username lookup is a real ping failure, not a cosmetic
+            # fallback — replace the (possibly wrong/incomplete) message with an
+            # explicit failure notice instead of sending something that looks like
+            # a successful ping.
+            if [ "$RATE_LIMIT_HIT" = "true" ]; then
+              echo "❌ Aborting CodeOwners Slack ping — GitHub API rate limit exceeded while resolving one or more GitHub usernames"
+              SLACK_MESSAGE="⚠️ *CodeOwners Ping Failed*"$'\n\n'"GitHub API rate limit was exceeded while resolving codeowner/author names for <${{ github.server_url }}/${{ github.repository }}/pull/$PR_NUMBER|PR #$PR_NUMBER>, so no ping was sent."$'\n\n'"Please re-run \`/codeowners ping\` once the rate limit resets."
+            fi
+
             # Debug: Show the final message being sent (truncated for large messages)
             echo "🔍 Final Slack message:"
             echo "================================"
@@ -2866,6 +2982,12 @@ jobs:
 
             # Clean up temp file
             rm -f /tmp/slack_message.txt
+
+            # Fail the job on a rate-limited ping so it shows up as a real CI
+            # failure instead of a quietly-successful run.
+            if [ "$RATE_LIMIT_HIT" = "true" ]; then
+              exit 1
+            fi
 
           elif [ "$SEND_SLACK" = "true" ] && [ "$NO_OWNERS_AVAILABLE" = "true" ]; then
             echo "Slack notification enabled but no owners available for notification (only PR author is codeowner)"

--- a/.github/workflows/codeowners-group-analysis.yaml
+++ b/.github/workflows/codeowners-group-analysis.yaml
@@ -969,9 +969,10 @@ jobs:
               team=$(echo "$team_entry" | cut -d':' -f1)
               clean_team=$(echo "$team" | sed 's/^@[^\/]*\///')
               MEMBERS_API="https://api.github.com/orgs/tenstorrent/teams/$clean_team/members"
-              MEMBERS_HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" -H "Accept: application/vnd.github.v3+json" "$MEMBERS_API")
+              MEMBERS_RESPONSE=$(curl -s -w '\n%{http_code}' -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" -H "Accept: application/vnd.github.v3+json" "$MEMBERS_API")
+              MEMBERS_HTTP_CODE=$(echo "$MEMBERS_RESPONSE" | tail -n1)
+              MEMBERS_DATA=$(echo "$MEMBERS_RESPONSE" | sed '$d')
               if [ "$MEMBERS_HTTP_CODE" = "200" ]; then
-                MEMBERS_DATA=$(curl -s -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" -H "Accept: application/vnd.github.v3+json" "$MEMBERS_API" 2>/dev/null)
                 TEAM_MEMBER_LOGINS=$(echo "$MEMBERS_DATA" | jq -r '.[].login' 2>/dev/null | tr '\n' ',' | sed 's/,$//')
                 [ -n "$TEAM_MEMBER_LOGINS" ] && TEAM_MEMBERS="$TEAM_MEMBERS$team:$TEAM_MEMBER_LOGINS|" || TEAM_MEMBERS="$TEAM_MEMBERS$team:no-members|"
               elif [ "$MEMBERS_HTTP_CODE" = "404" ]; then
@@ -1356,40 +1357,53 @@ jobs:
           if [ "$CREATE_NEW" = "true" ]; then
             # Create new comment
             echo "Creating new comment..."
-            curl -s -X POST \
+            COMMENT_RESPONSE=$(curl -s -w '\n%{http_code}' -X POST \
               -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" \
               -H "Accept: application/vnd.github.v3+json" \
               -H "Content-Type: application/json" \
               --data-binary @"$TEMP_JSON_FILE" \
-              "$COMMENTS_API"
+              "$COMMENTS_API")
+            COMMENT_HTTP_CODE=$(echo "$COMMENT_RESPONSE" | tail -n1)
+            if [ "$COMMENT_HTTP_CODE" != "201" ]; then
+              echo "❌ Failed to create comment (HTTP $COMMENT_HTTP_CODE): $(echo "$COMMENT_RESPONSE" | sed '$d')"
+            fi
           elif [ -z "$EXISTING_COMMENT_ID" ] || [ "$EXISTING_COMMENT_ID" = "null" ]; then
             # No existing comment found - create new for all commands except explicit "new"
             if [ "$CREATE_NEW" = "false" ]; then
               echo "No existing CodeOwners analysis found. Creating new summary comment..."
               # Create new comment for bare commands and ping commands
-              curl -s -X POST \
+              COMMENT_RESPONSE=$(curl -s -w '\n%{http_code}' -X POST \
                 -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" \
                 -H "Accept: application/vnd.github.v3+json" \
                 -H "Content-Type: application/json" \
                 --data-binary @"$TEMP_JSON_FILE" \
-                "$COMMENTS_API"
-              echo "Created new CodeOwners summary comment"
+                "$COMMENTS_API")
+              COMMENT_HTTP_CODE=$(echo "$COMMENT_RESPONSE" | tail -n1)
+              if [ "$COMMENT_HTTP_CODE" = "201" ]; then
+                echo "Created new CodeOwners summary comment"
+              else
+                echo "❌ Failed to create CodeOwners summary comment (HTTP $COMMENT_HTTP_CODE): $(echo "$COMMENT_RESPONSE" | sed '$d')"
+              fi
             else
               echo "No existing comment found and CREATE_NEW=true - this shouldn't happen"
             fi
           else
             # Edit existing comment
             echo "Updating existing comment (ID: $EXISTING_COMMENT_ID)..."
-            curl -s -X PATCH \
+            COMMENT_RESPONSE=$(curl -s -w '\n%{http_code}' -X PATCH \
               -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" \
               -H "Accept: application/vnd.github.v3+json" \
               -H "Content-Type: application/json" \
               --data-binary @"$TEMP_JSON_FILE" \
-              "https://api.github.com/repos/${{ github.repository }}/issues/comments/$EXISTING_COMMENT_ID"
+              "https://api.github.com/repos/${{ github.repository }}/issues/comments/$EXISTING_COMMENT_ID")
+            COMMENT_HTTP_CODE=$(echo "$COMMENT_RESPONSE" | tail -n1)
+            if [ "$COMMENT_HTTP_CODE" != "200" ]; then
+              echo "❌ Failed to update comment (HTTP $COMMENT_HTTP_CODE): $(echo "$COMMENT_RESPONSE" | sed '$d')"
+            fi
           fi
 
           rm -f "$TEMP_JSON_FILE"
-          echo "Comment updated for PR #$PR_NUMBER"
+          echo "Comment update attempt finished for PR #$PR_NUMBER"
 
           # If we updated an existing comment, post an acknowledgment (but not for manual workflow runs)
           if [ "$CREATE_NEW" = "false" ] && [ -n "$EXISTING_COMMENT_ID" ] && [ "$EXISTING_COMMENT_ID" != "null" ] && [ "${{ github.event_name }}" != "workflow_dispatch" ]; then
@@ -1889,13 +1903,11 @@ jobs:
           # Get members of thirdparty-moreh team to exclude from selection (they're not in Slack)
           MOREH_TEAM_MEMBERS=""
           MOREH_MEMBERS_API="https://api.github.com/orgs/tenstorrent/teams/thirdparty-moreh/members"
-          MOREH_MEMBERS_DATA=$(curl -s -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" \
+          MOREH_RESPONSE=$(curl -s -w '\n%{http_code}' -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" \
                                    -H "Accept: application/vnd.github.v3+json" \
                                    "$MOREH_MEMBERS_API" 2>/dev/null)
-
-          MOREH_HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" \
-                                   -H "Accept: application/vnd.github.v3+json" \
-                                   "$MOREH_MEMBERS_API")
+          MOREH_HTTP_CODE=$(echo "$MOREH_RESPONSE" | tail -n1)
+          MOREH_MEMBERS_DATA=$(echo "$MOREH_RESPONSE" | sed '$d')
 
           if [ "$MOREH_HTTP_CODE" = "200" ] && [ -n "$MOREH_MEMBERS_DATA" ] && [ "$MOREH_MEMBERS_DATA" != "null" ]; then
             MOREH_TEAM_MEMBERS=$(echo "$MOREH_MEMBERS_DATA" | jq -r '.[].login' 2>/dev/null | tr '\n' ',' | sed 's/,$//')
@@ -2451,88 +2463,6 @@ jobs:
           echo "selected-owners=$SELECTED_OWNERS" >> $GITHUB_OUTPUT
           echo "selected-slack-groups=$SELECTED_SLACK_GROUPS" >> $GITHUB_OUTPUT
           echo "no-owners-available=$NO_OWNERS_AVAILABLE" >> $GITHUB_OUTPUT
-
-      - name: Send notifications
-        if: needs.parse-comment.outputs.is-direct-ping != 'true'
-        run: |
-          PING_OWNERS="${{ steps.generate-comment.outputs.ping-owners }}"
-          SEND_SLACK="${{ steps.generate-comment.outputs.send-slack }}"
-          SELECTED_OWNERS="${{ steps.select-owners.outputs.selected-owners }}"
-          PR_AUTHOR_LOGIN="${{ steps.setup-notifications.outputs.pr-author-login }}"
-          PR_AUTHOR_NAME="${{ steps.setup-notifications.outputs.pr-author-name }}"
-          AUTHOR_NOTES="${{ steps.generate-comment.outputs.author-notes }}"
-          PR_NUMBER="${{ steps.generate-comment.outputs.pr-number }}"
-
-          # Fetch PR title safely to avoid shell injection
-          PR_API="https://api.github.com/repos/${{ github.repository }}/pulls/$PR_NUMBER"
-          PR_DATA=$(curl -s --max-time 30 -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" \
-                         -H "Accept: application/vnd.github.v3+json" \
-                         "$PR_API")
-          PR_TITLE=$(echo "$PR_DATA" | jq -r '.title')
-          # Escape angle brackets so Slack mrkdwn link text is not malformed
-          PR_TITLE=$(echo "$PR_TITLE" | sed 's/</\&lt;/g; s/>/\&gt;/g')
-
-          # Use #tt-metal-pr-review-requests Slack channel
-          SLACK_CHANNEL="C07G47JMQHM"
-
-          # Define API endpoint
-          COMMENTS_API="https://api.github.com/repos/${{ github.repository }}/issues/$PR_NUMBER/comments"
-
-          # Check if we have any owners to ping
-          if [ -n "$SELECTED_OWNERS" ]; then
-            # Get full names for selected owners and build ping message
-            # NOTE: Do NOT use GitHub mention syntax [@username] as it subscribes users to the PR
-            PING_MESSAGE="Hi"
-            IFS=',' read -ra SELECTED_ARRAY <<< "$SELECTED_OWNERS"
-            OWNER_COUNT=${#SELECTED_ARRAY[@]}
-            for i in "${!SELECTED_ARRAY[@]}"; do
-              owner="${SELECTED_ARRAY[$i]}"
-              if [ -n "$owner" ]; then
-                # Get user info
-                USER_API="https://api.github.com/users/$owner"
-                USER_DATA=$(curl -s -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" \
-                               -H "Accept: application/vnd.github.v3+json" \
-                               "$USER_API" 2>/dev/null)
-                USER_NAME=$(echo "$USER_DATA" | jq -r '.name // empty' 2>/dev/null)
-                if [ -n "$USER_NAME" ] && [ "$USER_NAME" != "null" ]; then
-                  PING_MESSAGE="$PING_MESSAGE $USER_NAME (@$owner)"
-                else
-                  PING_MESSAGE="$PING_MESSAGE (@$owner)"
-                fi
-
-                # Add comma if not the last owner
-                if [ $((i + 1)) -lt $OWNER_COUNT ]; then
-                  PING_MESSAGE="$PING_MESSAGE,"
-                fi
-              fi
-            done
-
-            # Get full name for PR author
-            PR_AUTHOR_FULL_NAME="$PR_AUTHOR_NAME"  # Default to what we got from PR API
-            if [ "$PR_AUTHOR_FULL_NAME" = "$PR_AUTHOR_LOGIN" ] || [ -z "$PR_AUTHOR_FULL_NAME" ] || [ "$PR_AUTHOR_FULL_NAME" = "null" ]; then
-              # Try to fetch full name from GitHub API
-              AUTHOR_USER_API="https://api.github.com/users/$PR_AUTHOR_LOGIN"
-              AUTHOR_USER_DATA=$(curl -s -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" \
-                                     -H "Accept: application/vnd.github.v3+json" \
-                                     "$AUTHOR_USER_API" 2>/dev/null)
-              AUTHOR_FULL_NAME=$(echo "$AUTHOR_USER_DATA" | jq -r '.name // empty' 2>/dev/null)
-              if [ -n "$AUTHOR_FULL_NAME" ] && [ "$AUTHOR_FULL_NAME" != "null" ]; then
-                PR_AUTHOR_FULL_NAME="$AUTHOR_FULL_NAME"
-              fi
-            fi
-
-            PING_MESSAGE="$PING_MESSAGE, this PR **[""$PR_TITLE""](${{ github.server_url }}/${{ github.repository }}/pull/$PR_NUMBER)** by $PR_AUTHOR_FULL_NAME (@$PR_AUTHOR_LOGIN) needs your approval/review to merge this."
-
-            # Log the ping message (comment posting to PR is disabled)
-            echo "Ping message (comment posting disabled, Slack-only):"
-            if [ ${#PING_MESSAGE} -gt 2000 ]; then
-              echo "${PING_MESSAGE:0:2000}... (truncated)"
-            else
-              echo "$PING_MESSAGE"
-            fi
-          else
-            echo "No pending owners to ping"
-          fi
 
       - name: Send Slack notifications
         if: needs.parse-comment.outputs.is-direct-ping != 'true'

--- a/.github/workflows/codeowners-group-analysis.yaml
+++ b/.github/workflows/codeowners-group-analysis.yaml
@@ -969,10 +969,9 @@ jobs:
               team=$(echo "$team_entry" | cut -d':' -f1)
               clean_team=$(echo "$team" | sed 's/^@[^\/]*\///')
               MEMBERS_API="https://api.github.com/orgs/tenstorrent/teams/$clean_team/members"
-              MEMBERS_RESPONSE=$(curl -s -w '\n%{http_code}' -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" -H "Accept: application/vnd.github.v3+json" "$MEMBERS_API")
-              MEMBERS_HTTP_CODE=$(echo "$MEMBERS_RESPONSE" | tail -n1)
-              MEMBERS_DATA=$(echo "$MEMBERS_RESPONSE" | sed '$d')
+              MEMBERS_HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" -H "Accept: application/vnd.github.v3+json" "$MEMBERS_API")
               if [ "$MEMBERS_HTTP_CODE" = "200" ]; then
+                MEMBERS_DATA=$(curl -s -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" -H "Accept: application/vnd.github.v3+json" "$MEMBERS_API" 2>/dev/null)
                 TEAM_MEMBER_LOGINS=$(echo "$MEMBERS_DATA" | jq -r '.[].login' 2>/dev/null | tr '\n' ',' | sed 's/,$//')
                 [ -n "$TEAM_MEMBER_LOGINS" ] && TEAM_MEMBERS="$TEAM_MEMBERS$team:$TEAM_MEMBER_LOGINS|" || TEAM_MEMBERS="$TEAM_MEMBERS$team:no-members|"
               elif [ "$MEMBERS_HTTP_CODE" = "404" ]; then
@@ -1357,53 +1356,40 @@ jobs:
           if [ "$CREATE_NEW" = "true" ]; then
             # Create new comment
             echo "Creating new comment..."
-            COMMENT_RESPONSE=$(curl -s -w '\n%{http_code}' -X POST \
+            curl -s -X POST \
               -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" \
               -H "Accept: application/vnd.github.v3+json" \
               -H "Content-Type: application/json" \
               --data-binary @"$TEMP_JSON_FILE" \
-              "$COMMENTS_API")
-            COMMENT_HTTP_CODE=$(echo "$COMMENT_RESPONSE" | tail -n1)
-            if [ "$COMMENT_HTTP_CODE" != "201" ]; then
-              echo "❌ Failed to create comment (HTTP $COMMENT_HTTP_CODE): $(echo "$COMMENT_RESPONSE" | sed '$d')"
-            fi
+              "$COMMENTS_API"
           elif [ -z "$EXISTING_COMMENT_ID" ] || [ "$EXISTING_COMMENT_ID" = "null" ]; then
             # No existing comment found - create new for all commands except explicit "new"
             if [ "$CREATE_NEW" = "false" ]; then
               echo "No existing CodeOwners analysis found. Creating new summary comment..."
               # Create new comment for bare commands and ping commands
-              COMMENT_RESPONSE=$(curl -s -w '\n%{http_code}' -X POST \
+              curl -s -X POST \
                 -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" \
                 -H "Accept: application/vnd.github.v3+json" \
                 -H "Content-Type: application/json" \
                 --data-binary @"$TEMP_JSON_FILE" \
-                "$COMMENTS_API")
-              COMMENT_HTTP_CODE=$(echo "$COMMENT_RESPONSE" | tail -n1)
-              if [ "$COMMENT_HTTP_CODE" = "201" ]; then
-                echo "Created new CodeOwners summary comment"
-              else
-                echo "❌ Failed to create CodeOwners summary comment (HTTP $COMMENT_HTTP_CODE): $(echo "$COMMENT_RESPONSE" | sed '$d')"
-              fi
+                "$COMMENTS_API"
+              echo "Created new CodeOwners summary comment"
             else
               echo "No existing comment found and CREATE_NEW=true - this shouldn't happen"
             fi
           else
             # Edit existing comment
             echo "Updating existing comment (ID: $EXISTING_COMMENT_ID)..."
-            COMMENT_RESPONSE=$(curl -s -w '\n%{http_code}' -X PATCH \
+            curl -s -X PATCH \
               -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" \
               -H "Accept: application/vnd.github.v3+json" \
               -H "Content-Type: application/json" \
               --data-binary @"$TEMP_JSON_FILE" \
-              "https://api.github.com/repos/${{ github.repository }}/issues/comments/$EXISTING_COMMENT_ID")
-            COMMENT_HTTP_CODE=$(echo "$COMMENT_RESPONSE" | tail -n1)
-            if [ "$COMMENT_HTTP_CODE" != "200" ]; then
-              echo "❌ Failed to update comment (HTTP $COMMENT_HTTP_CODE): $(echo "$COMMENT_RESPONSE" | sed '$d')"
-            fi
+              "https://api.github.com/repos/${{ github.repository }}/issues/comments/$EXISTING_COMMENT_ID"
           fi
 
           rm -f "$TEMP_JSON_FILE"
-          echo "Comment update attempt finished for PR #$PR_NUMBER"
+          echo "Comment updated for PR #$PR_NUMBER"
 
           # If we updated an existing comment, post an acknowledgment (but not for manual workflow runs)
           if [ "$CREATE_NEW" = "false" ] && [ -n "$EXISTING_COMMENT_ID" ] && [ "$EXISTING_COMMENT_ID" != "null" ] && [ "${{ github.event_name }}" != "workflow_dispatch" ]; then
@@ -1745,7 +1731,7 @@ jobs:
                     SLACK_USER_MENTIONS="$SLACK_USER_MENTIONS <@$SLACK_USER_ID>"
                     echo "✅ Found Slack user: $USER_NAME -> $SLACK_USER_ID"
                   else
-                    SLACK_USER_MENTIONS="$SLACK_USER_MENTIONS $USER_NAME (@$clean_item)"
+                    SLACK_USER_MENTIONS="$SLACK_USER_MENTIONS $USER_NAME"
                     echo "⚠️  Slack user not found for: $USER_NAME (@$clean_item), using full name fallback"
                   fi
                 fi
@@ -1903,11 +1889,13 @@ jobs:
           # Get members of thirdparty-moreh team to exclude from selection (they're not in Slack)
           MOREH_TEAM_MEMBERS=""
           MOREH_MEMBERS_API="https://api.github.com/orgs/tenstorrent/teams/thirdparty-moreh/members"
-          MOREH_RESPONSE=$(curl -s -w '\n%{http_code}' -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" \
+          MOREH_MEMBERS_DATA=$(curl -s -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" \
                                    -H "Accept: application/vnd.github.v3+json" \
                                    "$MOREH_MEMBERS_API" 2>/dev/null)
-          MOREH_HTTP_CODE=$(echo "$MOREH_RESPONSE" | tail -n1)
-          MOREH_MEMBERS_DATA=$(echo "$MOREH_RESPONSE" | sed '$d')
+
+          MOREH_HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" \
+                                   -H "Accept: application/vnd.github.v3+json" \
+                                   "$MOREH_MEMBERS_API")
 
           if [ "$MOREH_HTTP_CODE" = "200" ] && [ -n "$MOREH_MEMBERS_DATA" ] && [ "$MOREH_MEMBERS_DATA" != "null" ]; then
             MOREH_TEAM_MEMBERS=$(echo "$MOREH_MEMBERS_DATA" | jq -r '.[].login' 2>/dev/null | tr '\n' ',' | sed 's/,$//')
@@ -2563,47 +2551,6 @@ jobs:
           CHANGED_FILES_COUNT="${{ needs.analyze-codeowners.outputs.changed-files-count || 0 }}"
           REQUESTER_LOGIN="${{ needs.parse-comment.outputs.comment-author || '' }}"
           REQUESTER_NAME="$REQUESTER_LOGIN"
-          RATE_LIMIT_HIT=false
-
-          # Checking quota does not itself count against the rate limit.
-          RATE_LIMIT_INFO=$(curl -s -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" \
-                                 -H "Accept: application/vnd.github.v3+json" \
-                                 "https://api.github.com/rate_limit")
-          echo "GitHub API quota (CODEOWNERS_GROUP_ANALYSIS_PAT): $(echo "$RATE_LIMIT_INFO" | jq -r '.resources.core.remaining // -1')/$(echo "$RATE_LIMIT_INFO" | jq -r '.resources.core.limit // -1') remaining, resets at $(echo "$RATE_LIMIT_INFO" | jq -r '.resources.core.reset // 0')"
-
-          # Look up a GitHub user's display name, retrying with the default Actions
-          # token (a separate rate-limit bucket from the shared PAT) if the PAT is
-          # exhausted. Sets RATE_LIMIT_HIT=true when both tokens are rate limited, so
-          # callers can treat this as a real ping error instead of silently falling
-          # back to a name that was never actually resolved.
-          lookup_github_user_name() {
-            local login="$1"
-            local response http_code body
-
-            response=$(curl -s -w '\n%{http_code}' -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" \
-                           -H "Accept: application/vnd.github.v3+json" \
-                           "https://api.github.com/users/$login" 2>/dev/null)
-            http_code=$(echo "$response" | tail -n1)
-            body=$(echo "$response" | sed '$d')
-
-            if [ "$http_code" = "403" ] && echo "$body" | grep -qi "rate limit"; then
-              echo "⚠️  PAT rate-limited looking up $login, retrying with default Actions token" >&2
-              response=$(curl -s -w '\n%{http_code}' -H "Authorization: Bearer ${{ github.token }}" \
-                             -H "Accept: application/vnd.github.v3+json" \
-                             "https://api.github.com/users/$login" 2>/dev/null)
-              http_code=$(echo "$response" | tail -n1)
-              body=$(echo "$response" | sed '$d')
-            fi
-
-            if [ "$http_code" = "403" ] && echo "$body" | grep -qi "rate limit"; then
-              echo "❌ GitHub API rate limit exceeded on both tokens looking up $login" >&2
-              RATE_LIMIT_HIT=true
-              echo ""
-              return
-            fi
-
-            echo "$body" | jq -r '.name // empty' 2>/dev/null
-          }
 
           # Load Slack users from file (set in Setup for notifications step)
           ALL_SLACK_USERS=$(cat "${RUNNER_TEMP}/slack_users.json")
@@ -2760,12 +2707,20 @@ jobs:
 
             # Add individual user mentions
             SLACK_USER_MENTIONS=""
+            PING_RATE_LIMITED=false
             if [ -n "$SELECTED_OWNERS" ]; then
               IFS=',' read -ra SELECTED_ARRAY <<< "$SELECTED_OWNERS"
               for owner in "${SELECTED_ARRAY[@]}"; do
                 if [ -n "$owner" ]; then
                   # Get full name for this owner
-                  USER_NAME=$(lookup_github_user_name "$owner")
+                  USER_API="https://api.github.com/users/$owner"
+                  USER_RESPONSE=$(curl -s -w '\n%{http_code}' -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" \
+                                 -H "Accept: application/vnd.github.v3+json" \
+                                 "$USER_API" 2>/dev/null)
+                  USER_HTTP_CODE=$(echo "$USER_RESPONSE" | tail -n1)
+                  USER_DATA=$(echo "$USER_RESPONSE" | sed '$d')
+                  [ "$USER_HTTP_CODE" = "403" ] && PING_RATE_LIMITED=true
+                  USER_NAME=$(echo "$USER_DATA" | jq -r '.name // empty' 2>/dev/null)
                   if [ -z "$USER_NAME" ] || [ "$USER_NAME" = "null" ]; then
                     USER_NAME="$owner"
                   fi
@@ -2777,7 +2732,7 @@ jobs:
                     SLACK_USER_MENTIONS="$SLACK_USER_MENTIONS <@$SLACK_USER_ID>"
                     echo "✅ Found Slack user: $USER_NAME -> $SLACK_USER_ID"
                   else
-                    SLACK_USER_MENTIONS="$SLACK_USER_MENTIONS $USER_NAME (@$owner)"
+                    SLACK_USER_MENTIONS="$SLACK_USER_MENTIONS $USER_NAME"
                     echo "⚠️  Slack user not found for: $USER_NAME (@$owner), using full name fallback"
                   fi
                 fi
@@ -2789,7 +2744,11 @@ jobs:
             # Get PR author Slack ID
             PR_AUTHOR_FULL_NAME="$PR_AUTHOR_NAME"
             if [ "$PR_AUTHOR_FULL_NAME" = "$PR_AUTHOR_LOGIN" ] || [ -z "$PR_AUTHOR_FULL_NAME" ] || [ "$PR_AUTHOR_FULL_NAME" = "null" ]; then
-              AUTHOR_FULL_NAME=$(lookup_github_user_name "$PR_AUTHOR_LOGIN")
+              AUTHOR_USER_API="https://api.github.com/users/$PR_AUTHOR_LOGIN"
+              AUTHOR_USER_DATA=$(curl -s -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" \
+                                     -H "Accept: application/vnd.github.v3+json" \
+                                     "$AUTHOR_USER_API" 2>/dev/null)
+              AUTHOR_FULL_NAME=$(echo "$AUTHOR_USER_DATA" | jq -r '.name // empty' 2>/dev/null)
               if [ -n "$AUTHOR_FULL_NAME" ] && [ "$AUTHOR_FULL_NAME" != "null" ]; then
                 PR_AUTHOR_FULL_NAME="$AUTHOR_FULL_NAME"
               fi
@@ -2807,7 +2766,11 @@ jobs:
             # Add author and requested by information (combine on same line if different)
             if [ -n "$REQUESTER_LOGIN" ] && [ "$REQUESTER_LOGIN" != "$PR_AUTHOR_LOGIN" ]; then
               # Get full name for requester if available
-              REQUESTER_FULL_NAME=$(lookup_github_user_name "$REQUESTER_LOGIN")
+              REQUESTER_USER_API="https://api.github.com/users/$REQUESTER_LOGIN"
+              REQUESTER_USER_DATA=$(curl -s -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" \
+                                     -H "Accept: application/vnd.github.v3+json" \
+                                     "$REQUESTER_USER_API" 2>/dev/null)
+              REQUESTER_FULL_NAME=$(echo "$REQUESTER_USER_DATA" | jq -r '.name // empty' 2>/dev/null)
               if [ -n "$REQUESTER_FULL_NAME" ] && [ "$REQUESTER_FULL_NAME" != "null" ]; then
                 REQUESTER_NAME="$REQUESTER_FULL_NAME"
               fi
@@ -2872,7 +2835,11 @@ jobs:
                     fi
 
                     # Get full name from GitHub API
-                    USER_NAME=$(lookup_github_user_name "$clean_username")
+                    USER_API="https://api.github.com/users/$clean_username"
+                    USER_DATA=$(curl -s -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" \
+                                   -H "Accept: application/vnd.github.v3+json" \
+                                   "$USER_API" 2>/dev/null)
+                    USER_NAME=$(echo "$USER_DATA" | jq -r '.name // empty' 2>/dev/null)
                     if [ -z "$USER_NAME" ] || [ "$USER_NAME" = "null" ]; then
                       USER_NAME="$clean_username"
                     fi
@@ -2929,26 +2896,6 @@ jobs:
 
             SLACK_MESSAGE="$SLACK_MESSAGE"$'\n\n'"Please review when you have a moment. Thank you! 🚀"
 
-            # A rate-limited username lookup means some names/mentions in the
-            # message above may be wrong or incomplete — surface that visibly on
-            # the PR itself with a ⚠️ warning comment (GitHub's reaction API has
-            # no "warning" content type, so a reply comment is the closest visible
-            # equivalent) rather than silently sending a broken-looking ping with
-            # no indication anything went wrong. The Slack message still goes out.
-            if [ "$RATE_LIMIT_HIT" = "true" ] && [ "${{ github.event_name }}" = "issue_comment" ]; then
-              echo "⚠️  GitHub API rate limit hit while resolving one or more usernames — posting a warning comment on the PR"
-              WARNING_BODY="⚠️ **CodeOwners Ping Warning**"$'\n\n'"GitHub API rate limit was hit while resolving one or more codeowner/author names for this ping. The Slack notification was still sent, but it may be missing a proper Slack mention or full name for some codeowners. Re-run \`/codeowners ping\` once the rate limit resets if anyone appears to have been missed."
-              WARNING_JSON_FILE=$(mktemp)
-              jq -n --arg body "$WARNING_BODY" '{"body": $body}' > "$WARNING_JSON_FILE"
-              curl -s -X POST \
-                -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" \
-                -H "Accept: application/vnd.github.v3+json" \
-                -H "Content-Type: application/json" \
-                --data-binary @"$WARNING_JSON_FILE" \
-                "https://api.github.com/repos/${{ github.repository }}/issues/$PR_NUMBER/comments" > /dev/null
-              rm -f "$WARNING_JSON_FILE"
-            fi
-
             # Debug: Show the final message being sent (truncated for large messages)
             echo "🔍 Final Slack message:"
             echo "================================"
@@ -2993,6 +2940,21 @@ jobs:
 
             # Clean up temp file
             rm -f /tmp/slack_message.txt
+
+            # Let devs know on the PR itself when the ping hit a GitHub API rate
+            # limit while resolving names (GitHub's reactions API has no "warning"
+            # type, so a comment is the closest visible equivalent).
+            if [ "$PING_RATE_LIMITED" = "true" ] && [ "${{ github.event_name }}" = "issue_comment" ]; then
+              WARNING_JSON_FILE=$(mktemp)
+              jq -n --arg body "⚠️ CodeOwners ping hit a GitHub API rate limit while resolving names above — some may be inaccurate." '{"body": $body}' > "$WARNING_JSON_FILE"
+              curl -s -X POST \
+                -H "Authorization: Bearer ${{ secrets.CODEOWNERS_GROUP_ANALYSIS_PAT }}" \
+                -H "Accept: application/vnd.github.v3+json" \
+                -H "Content-Type: application/json" \
+                --data-binary @"$WARNING_JSON_FILE" \
+                "https://api.github.com/repos/${{ github.repository }}/issues/$PR_NUMBER/comments" > /dev/null
+              rm -f "$WARNING_JSON_FILE"
+            fi
 
           elif [ "$SEND_SLACK" = "true" ] && [ "$NO_OWNERS_AVAILABLE" = "true" ]; then
             echo "Slack notification enabled but no owners available for notification (only PR author is codeowner)"


### PR DESCRIPTION
### PR Category
Bug Fix

### Summary
On PR [#50282](https://github.com/tenstorrent/tt-metal/pull/50282), `/codeowners ping` sent a Slack notification where six codeowners appeared as bare names with no `@` at all. Root cause: the shared `CODEOWNERS_GROUP_ANALYSIS_PAT` hit GitHub's REST API rate limit (`403 API rate limit exceeded for user ID 123498312`) while resolving those owners' display names — confirmed directly in the workflow run logs.

### Fix (minimal, single change)
In `Send Slack notifications`, the existing per-owner GitHub lookup now also captures the HTTP status code from the response it already receives. If any lookup comes back `403`, the workflow posts one `⚠️` **comment directly on the GitHub PR** letting devs know some of the names above may be inaccurate.

This is purely a GitHub-side signal — it posts to `api.github.com/.../issues/$PR_NUMBER/comments`, not Slack, and it fires independent of whether Slack notifications are enabled or whether the Slack post succeeded (moved it out from inside the Slack-send conditional so that's structurally clear, not just incidentally true).

No fallback token, no attempt to reduce API call volume or otherwise mitigate the rate limit itself, no changes anywhere else in the file — everything else is untouched from the original.

Note: GitHub's Reactions API has no "warning" content type (only `+1`, `-1`, `laugh`, `confused`, `heart`, `hooray`, `rocket`, `eyes`), so a comment is the closest visible equivalent to flag this on the PR.

### Testing
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/codeowners-group-analysis.yaml'))"` — parses cleanly.
- Extracted every step's `run:` script and ran `bash -n` against each (with `${{ }}` expressions stubbed) — all 16 steps pass syntax validation.
- Not able to trigger the `issue_comment` workflow path directly outside a real PR comment; reviewers should sanity-check with `/codeowners ping` on a low-traffic PR once merged.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=brain/fix-codeowners-ping-missing-at)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:brain/fix-codeowners-ping-missing-at)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=brain/fix-codeowners-ping-missing-at)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:brain/fix-codeowners-ping-missing-at)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=brain/fix-codeowners-ping-missing-at)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:brain/fix-codeowners-ping-missing-at)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=brain/fix-codeowners-ping-missing-at)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:brain/fix-codeowners-ping-missing-at)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=brain/fix-codeowners-ping-missing-at)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:brain/fix-codeowners-ping-missing-at)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=brain/fix-codeowners-ping-missing-at)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:brain/fix-codeowners-ping-missing-at)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=brain/fix-codeowners-ping-missing-at)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:brain/fix-codeowners-ping-missing-at)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=brain/fix-codeowners-ping-missing-at)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:brain/fix-codeowners-ping-missing-at)