### PR TITLE
ttop-create-allocation: never poll with an empty token, never miss a phase flip

### DIFF
--- a/.github/actions/ttop-create-allocation/action.yaml
+++ b/.github/actions/ttop-create-allocation/action.yaml
@@ -59,14 +59,15 @@ runs:
       run: |
         echo "[info] Waiting for allocation to be ready..."
 
-        # GitHub OIDC tokens are short-lived (~10-15 min). A single token cannot
-        # cover a long placement wait: once it expires mid-`kubectl wait`, the
-        # client-go watch loops "Unauthorized" forever and never observes the
-        # phase flip. Instead, poll every few seconds and reissue the token
-        # whenever the API server rejects it as unauthenticated.
-        POLL_INTERVAL=5          # seconds between polls
-        OVERALL_TIMEOUT=59940    # seconds (== 999m); matches the previous 999m cap
-        MAX_AUTH_FAILURES=3      # consecutive auth failures (despite reissue) before giving up
+        # GitHub OIDC tokens are short-lived (~10-15 min) and a placement wait can
+        # run far longer than one -- a Count:16 SC16 request sat Pending for 60 min
+        # on 2026-07-30 -- so the token WILL expire mid-wait and has to be reissued.
+        # Poll rather than `kubectl wait`: a client-go watch that goes unauthenticated
+        # loops forever and never observes the phase flip.
+        POLL_INTERVAL=5             # seconds between polls
+        OVERALL_TIMEOUT=59940       # seconds (== 999m); matches the previous 999m cap
+        MAX_CONSECUTIVE_ERRORS=60   # 60 x 5s == 5 min of unbroken failure before giving up
+        HEARTBEAT_EVERY=60          # re-log an UNCHANGED phase at most this often (seconds)
 
         mint_token() {
           curl -s -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
@@ -75,37 +76,73 @@ runs:
             -H "Content-Type: application/json" -d "{}" | jq -r '.value'
         }
 
+        # Dump whatever the API will tell us about the object before failing. Without
+        # this the log says only "waiting..." and diagnosing needs a human with
+        # cluster credentials -- after the run is over and the allocation is gone.
+        dump_status() {
+          echo "[info] Final allocation status:"
+          kubectl --token "$IDTOKEN" -n "$NAMESPACE" get "allocation/${ALLOCATION_NAME}" \
+            -o jsonpath='{"  phase="}{.status.phase}{"\n  result="}{.status.result}{"\n  message="}{.status.message}{"\n  nodes="}{.status.nodes}{"\n"}' 2>&1 \
+            | sed 's/^/  /' || true
+        }
+
         IDTOKEN=$(mint_token) || true
         echo "::add-mask::${IDTOKEN}"
 
-        auth_failures=0
+        errors=0
         start=$SECONDS
+        last_phase=""
+        last_log=0
+        stderr_file=$(mktemp)
+        trap 'rm -f "$stderr_file"' EXIT
+
         while true; do
           if (( SECONDS - start >= OVERALL_TIMEOUT )); then
-            echo "::error::Timed out after $((OVERALL_TIMEOUT / 60))m waiting for allocation to reach Allocated."
+            echo "::error::Timed out after $((OVERALL_TIMEOUT / 60))m waiting for allocation to reach Allocated. Last phase seen: '${last_phase:-<none>}'."
+            dump_status
             exit 1
           fi
 
-          output=$(kubectl --token "$IDTOKEN" -n "$NAMESPACE" get "allocation/${ALLOCATION_NAME}" -o jsonpath='{.status.phase}' 2>&1) && rc=0 || rc=$?
+          # stdout ONLY -- deliberately not `2>&1`. Merging stderr into this capture
+          # meant any kubectl warning printed on an otherwise-SUCCESSFUL call landed
+          # in the variable, so the exact-match test below compared e.g.
+          # "W0730 ... deprecated\nAllocated" against "Allocated" and failed while the
+          # allocation really was Allocated. Success condition already met, loop still
+          # spinning, until the caller's step timeout.
+          phase=$(kubectl --token "$IDTOKEN" -n "$NAMESPACE" get "allocation/${ALLOCATION_NAME}" \
+                    -o jsonpath='{.status.phase}' 2>"$stderr_file") && rc=0 || rc=$?
+          phase="${phase//[[:space:]]/}"
 
           if (( rc == 0 )); then
-            auth_failures=0
-            if [[ "$output" == "Allocated" ]]; then
-              echo "::notice::Allocation ${ALLOCATION_NAME} is Allocated."
+            errors=0
+            if [[ "$phase" == "Allocated" ]]; then
+              echo "::notice::Allocation ${ALLOCATION_NAME} is Allocated after $(( (SECONDS - start) / 60 ))m."
               exit 0
             fi
-            echo "[info] Allocation phase: '${output:-<empty>}' — waiting..."
-          elif echo "$output" | grep -qiE 'unauthorized|must be logged in|401'; then
-            auth_failures=$((auth_failures + 1))
-            echo "::warning::Auth failure (${auth_failures}/${MAX_AUTH_FAILURES}) while polling allocation; reissuing token."
-            if (( auth_failures >= MAX_AUTH_FAILURES )); then
-              echo "::error::Repeated auth failures despite token reissue; failing."
+            # Log on CHANGE plus a heartbeat. At 5s intervals a 60-minute wait was
+            # 720 identical lines, which is real log bloat on a shared runner disk.
+            if [[ "$phase" != "$last_phase" ]] || (( SECONDS - last_log >= HEARTBEAT_EVERY )); then
+              echo "[info] Allocation phase: '${phase:-<empty>}' ($(( (SECONDS - start) / 60 ))m elapsed) -- waiting..."
+              last_log=$SECONDS
+            fi
+            last_phase="$phase"
+          else
+            errors=$((errors + 1))
+            # Reissue on ANY error instead of only on ones matching an auth regex.
+            # The old classifier grepped 'unauthorized|must be logged in|401' and sent
+            # everything else to a warn-and-retry branch that never reissued -- but an
+            # expired token often surfaces as "error: the server has asked for the
+            # client to provide credentials", which matches none of those three. That
+            # run polled with a dead token until the step timeout. Minting is cheap and
+            # idempotent, so there is nothing to gain by classifying first.
+            echo "::warning::Poll failed (${errors}/${MAX_CONSECUTIVE_ERRORS}, rc=${rc}): $(tr '\n' ' ' < "$stderr_file" | cut -c1-300)"
+            if (( errors >= MAX_CONSECUTIVE_ERRORS )); then
+              echo "::error::Giving up after ${errors} consecutive failed polls ($(( errors * POLL_INTERVAL ))s). Last phase seen: '${last_phase:-<none>}'."
+              dump_status
               exit 1
             fi
             IDTOKEN=$(mint_token) || true
             echo "::add-mask::${IDTOKEN}"
-          else
-            echo "::warning::Transient error polling allocation (rc=${rc}): ${output}"
           fi
 
           sleep "$POLL_INTERVAL"

--- a/.github/actions/ttop-create-allocation/action.yaml
+++ b/.github/actions/ttop-create-allocation/action.yaml
@@ -69,11 +69,38 @@ runs:
         MAX_CONSECUTIVE_ERRORS=60   # 60 x 5s == 5 min of unbroken failure before giving up
         HEARTBEAT_EVERY=60          # re-log an UNCHANGED phase at most this often (seconds)
 
+        # Returns non-zero rather than an empty string on failure. This is THE bug
+        # from tt-blaze run 30573758666: minting started failing mid-wait, the caller
+        # was `IDTOKEN=$(mint_token) || true` so IDTOKEN silently became empty, and
+        # `kubectl --token ""` does not error -- it falls back to the runner pod's
+        # AMBIENT in-cluster credentials. On that runner
+        # (runs-on: exabox-multihost-with-nfs) that is
+        # system:serviceaccount:ttop-ci:multihost-with-nfs, which has no RBAC for
+        # allocations, so every subsequent poll returned Forbidden. Deterministic,
+        # unrecoverable, and invisible: 578 polls over 49 minutes while the
+        # allocation had in fact been Allocated for 20 of them.
         mint_token() {
-          curl -s -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+          local t
+          t=$(curl -s -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
             "$ACTIONS_ID_TOKEN_REQUEST_URL" \
             -H "Accept: application/json; api-version=2.0" \
-            -H "Content-Type: application/json" -d "{}" | jq -r '.value'
+            -H "Content-Type: application/json" -d "{}" | jq -r '.value') || return 1
+          [[ -n "$t" && "$t" != "null" ]] || return 1
+          printf '%s' "$t"
+        }
+
+        # Only ever REPLACES a good token with another good one. On failure the
+        # previous token is kept and the caller's error counter decides when to stop
+        # -- never blank it, or the poll silently changes identity (see mint_token).
+        reissue_token() {
+          local t
+          if t=$(mint_token); then
+            IDTOKEN="$t"
+            echo "::add-mask::${IDTOKEN}"
+            return 0
+          fi
+          echo "::warning::OIDC token mint failed; retaining the previous token."
+          return 1
         }
 
         # Dump whatever the API will tell us about the object before failing. Without
@@ -86,7 +113,10 @@ runs:
             | sed 's/^/  /' || true
         }
 
-        IDTOKEN=$(mint_token) || true
+        if ! IDTOKEN=$(mint_token); then
+          echo "::error::Could not mint a GitHub OIDC token. Refusing to poll with an empty --token: kubectl would fall back to the runner pod's in-cluster service account, which has no RBAC for allocations, and every poll would return Forbidden until the caller's step timeout."
+          exit 1
+        fi
         echo "::add-mask::${IDTOKEN}"
 
         errors=0
@@ -130,19 +160,22 @@ runs:
             errors=$((errors + 1))
             # Reissue on ANY error instead of only on ones matching an auth regex.
             # The old classifier grepped 'unauthorized|must be logged in|401' and sent
-            # everything else to a warn-and-retry branch that never reissued -- but an
-            # expired token often surfaces as "error: the server has asked for the
-            # client to provide credentials", which matches none of those three. That
+            # everything else to a warn-and-retry branch that never reissued -- but the
+            # error that actually stalled run 30573758666 was
+            #   Error from server (Forbidden): ... User
+            #   "system:serviceaccount:ttop-ci:multihost-with-nfs" cannot get resource
+            #   "allocations" ...
+            # which matches none of those three, as does an expired token's "the server
+            # has asked for the client to provide credentials". That
             # run polled with a dead token until the step timeout. Minting is cheap and
             # idempotent, so there is nothing to gain by classifying first.
             echo "::warning::Poll failed (${errors}/${MAX_CONSECUTIVE_ERRORS}, rc=${rc}): $(tr '\n' ' ' < "$stderr_file" | cut -c1-300)"
             if (( errors >= MAX_CONSECUTIVE_ERRORS )); then
-              echo "::error::Giving up after ${errors} consecutive failed polls ($(( errors * POLL_INTERVAL ))s). Last phase seen: '${last_phase:-<none>}'."
+              echo "::error::Giving up after ${errors} consecutive failed polls ($(( errors * POLL_INTERVAL ))s). Last phase seen: '${last_phase:-<none>}'. A persistent 'Forbidden' naming a system:serviceaccount means the poll lost its OIDC identity; anything else, see the warnings above."
               dump_status
               exit 1
             fi
-            IDTOKEN=$(mint_token) || true
-            echo "::add-mask::${IDTOKEN}"
+            reissue_token || true
           fi
 
           sleep "$POLL_INTERVAL"

--- a/.github/actions/ttop-create-allocation/test-wait-loop.sh
+++ b/.github/actions/ttop-create-allocation/test-wait-loop.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+#
+# Regression test for the "Wait for allocation" poll loop in action.yaml.
+#
+#   ./test-wait-loop.sh
+#
+# No cluster, no credentials, no network: fake kubectl/curl/jq go on PATH and the
+# loop body is lifted straight out of action.yaml, so this tests the shipped code
+# rather than a copy that can drift.
+#
+# Each scenario reproduces a way the loop has actually failed or could fail. Every
+# one of the first three HANGS on the pre-2026-07-30 version of this action, which
+# is why they are here: the bug class is "the loop spins with its success condition
+# already met, or with an unrecoverable error it will never classify", and nothing
+# in CI could see it. tt-blaze run 30573758666 burned 79 minutes on a superpod that
+# way and was only diagnosed by hand from kubectl after the fact.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ACTION="$HERE/action.yaml"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# Lift the `run:` block of the "Wait for allocation" step. awk rather than a YAML
+# parser so this needs nothing but bash+awk -- a test that is awkward to run is a
+# test nobody runs.
+awk '
+  /^    - name: Wait for allocation$/ { instep = 1; next }
+  instep && /^      run: \|$/         { inrun = 1; next }
+  inrun {
+    if ($0 != "" && $0 !~ /^        /) exit   # dedent => end of the block
+    sub(/^        /, "")
+    print
+  }
+' "$ACTION" > "$WORK/loop.sh"
+
+[ -s "$WORK/loop.sh" ] || { echo "FAIL: could not extract the wait loop from $ACTION"; exit 1; }
+
+# Speed the loop up and shrink the give-up threshold so the suite runs in seconds.
+sed -i.bak -e 's/^POLL_INTERVAL=.*/POLL_INTERVAL=1/' \
+           -e 's/^MAX_CONSECUTIVE_ERRORS=.*/MAX_CONSECUTIVE_ERRORS=4/' \
+           -e 's/^HEARTBEAT_EVERY=.*/HEARTBEAT_EVERY=2/' "$WORK/loop.sh"
+
+mkdir -p "$WORK/bin"
+
+# curl is only ever piped into jq here; jq is where mint success/failure is decided.
+printf '#!/usr/bin/env bash\ncat >/dev/null 2>&1 || true\necho "{}"\n' > "$WORK/bin/curl"
+
+# Minting returns a fresh token each call, or nothing once SCENARIO says it dies.
+cat > "$WORK/bin/jq" <<'EOF'
+#!/usr/bin/env bash
+cat >/dev/null
+m=$(cat "$MINTS" 2>/dev/null || echo 0); m=$((m + 1)); echo "$m" > "$MINTS"
+if [ "$SCENARIO" = "mint_dies" ] && [ "$m" -gt 1 ]; then echo ""; exit 0; fi
+echo "tok-$m"
+EOF
+
+cat > "$WORK/bin/kubectl" <<'EOF'
+#!/usr/bin/env bash
+tok=""; prev=""
+for a in "$@"; do [ "$prev" = "--token" ] && tok="$a"; prev="$a"; done
+n=$(cat "$COUNTER" 2>/dev/null || echo 0); n=$((n + 1)); echo "$n" > "$COUNTER"
+[ -s "$FIRSTTOK" ] || printf '%s' "$tok" > "$FIRSTTOK"
+first="$(cat "$FIRSTTOK")"
+
+case "$SCENARIO" in
+  # A warning on an otherwise-SUCCESSFUL call. Observed live in run 30573758666 at
+  # 19:41 and 19:46. Fails if the phase capture merges stderr (`2>&1`).
+  stderr_noise)
+    echo 'E0730 19:41:24.707535 3470 memcache.go:265] "Unhandled Error" err="couldn'"'"'t get current server API group list"' >&2
+    if [ "$n" -ge 3 ]; then printf 'Allocated'; else printf 'NotAvailable'; fi ;;
+
+  # The real 30573758666 failure: once minting dies the token goes empty, and
+  # `kubectl --token ""` does NOT error -- it silently falls back to ambient
+  # in-cluster credentials (verified: `kubectl --token "" auth whoami` exits 0 and
+  # reports the kubeconfig identity). On that runner it landed on the pod's own
+  # service account, which has no allocation RBAC, so every poll was Forbidden.
+  mint_dies)
+    if [ -z "$tok" ]; then
+      echo 'Error from server (Forbidden): allocations.tenstorrent.com "a" is forbidden: User "system:serviceaccount:ttop-ci:multihost-with-nfs" cannot get resource "allocations" in API group "tenstorrent.com" in the namespace "ttop-ci"' >&2
+      exit 1
+    fi
+    if [ "$n" -gt 2 ]; then
+      echo 'error: the server has asked for the client to provide credentials' >&2; exit 1
+    fi
+    printf 'NotAvailable' ;;
+
+  # Token expires mid-wait and ONLY a reissued one is accepted. Fails if reissue is
+  # gated on an error-message regex, since this text matches no obvious auth pattern.
+  expired_token)
+    if [ "$n" -gt 2 ] && [ "$tok" = "$first" ]; then
+      echo 'error: the server has asked for the client to provide credentials' >&2; exit 1
+    fi
+    if [ "$n" -gt 2 ]; then printf 'Allocated'; else printf 'NotAvailable'; fi ;;
+
+  # Unrecoverable. Must give up rather than spin to the caller's step timeout.
+  always_fail)
+    echo 'Error from server (Forbidden): nope' >&2; exit 1 ;;
+
+  # Ordinary happy path -- guards against the fix breaking normal operation.
+  happy)
+    if [ "$n" -ge 2 ]; then printf 'Allocated'; else printf 'NotAvailable'; fi ;;
+esac
+EOF
+chmod +x "$WORK/bin/"*
+
+failures=0
+
+run_scenario() {
+  local scenario="$1" want_rc="$2" want_text="$3"
+  local out="$WORK/$scenario.out"
+
+  (
+    SCENARIO="$scenario" \
+    COUNTER="$(mktemp)" MINTS="$(mktemp)" FIRSTTOK="$(mktemp)" \
+    NAMESPACE=ttop-ci ALLOCATION_NAME=a \
+    ACTIONS_ID_TOKEN_REQUEST_TOKEN=x ACTIONS_ID_TOKEN_REQUEST_URL=http://example.invalid \
+    PATH="$WORK/bin:/usr/bin:/bin" \
+    bash -eo pipefail "$WORK/loop.sh"
+  ) > "$out" 2>&1 &
+  local pid=$! waited=0
+
+  # Not `timeout`: absent on macOS, where this gets run before it gets pushed.
+  while kill -0 "$pid" 2>/dev/null && [ "$waited" -lt 20 ]; do sleep 1; waited=$((waited + 1)); done
+  local rc verdict
+  if kill -0 "$pid" 2>/dev/null; then
+    kill -9 "$pid" 2>/dev/null; wait "$pid" 2>/dev/null
+    rc="hung"; verdict="HUNG after ${waited}s -- the loop never reached a decision"
+  else
+    wait "$pid"; rc=$?; verdict="exit $rc"
+  fi
+
+  if [ "$rc" != "$want_rc" ]; then
+    printf 'FAIL  %-14s expected exit %s, got %s\n' "$scenario" "$want_rc" "$verdict"
+    sed 's/^/        /' "$out" | tail -6
+    failures=$((failures + 1))
+    return
+  fi
+  if [ -n "$want_text" ] && ! grep -q "$want_text" "$out"; then
+    printf 'FAIL  %-14s exit %s as expected, but no %s in output\n' "$scenario" "$want_rc" "$want_text"
+    sed 's/^/        /' "$out" | tail -6
+    failures=$((failures + 1))
+    return
+  fi
+  printf 'ok    %-14s exit %s\n' "$scenario" "$rc"
+}
+
+echo "== ttop-create-allocation: wait-loop scenarios =="
+run_scenario happy         0 '::notice::'
+run_scenario stderr_noise  0 '::notice::'
+run_scenario expired_token 0 '::notice::'
+run_scenario mint_dies     1 'Forbidden'
+run_scenario always_fail   1 '::error::'
+
+echo
+if [ "$failures" -ne 0 ]; then
+  echo "$failures scenario(s) failed"
+  exit 1
+fi
+echo "all scenarios passed"


### PR DESCRIPTION
### Problem

The poll loop added in #49552 can spin **with its success condition already met**.

Observed on tt-blaze run [30573758666](https://github.com/tenstorrent/tt-blaze/actions/runs/30573758666/job/90979661911). A `Count:16` SC16 allocation:

- `19:26:01` created, sat `Pending` (the superpod was contended)
- `20:25:46` → **`Allocated`**, `PLACEMENT_COUNT_SUCCESS`, 16 nodes
- `20:42+` step still `in_progress`, polling on a 5-second interval

It never observed the flip. Left alone it would have burned the caller's full 120m step timeout while holding 16 idle nodes of a contended superpod — with another SC16 run queued behind it.

### Root cause

The cancelled run's log became readable after cancellation. It names the mechanism:

```
19:26-19:56  350 successful polls, phase 'NotAvailable'
19:41,19:46  2 polls where klog stderr noise landed in the phase variable
19:56:59+    578 x Forbidden, until cancelled 49 min later
20:25:46     allocation reached Allocated -- invisible to the loop
```

```
Error from server (Forbidden): allocations.tenstorrent.com "ci-30573758666-kimi-sp1" is forbidden:
User "system:serviceaccount:ttop-ci:multihost-with-nfs" cannot get resource "allocations"
in API group "tenstorrent.com" in the namespace "ttop-ci"
```

That identity is the **runner pod's own service account** (`runs-on: exabox-multihost-with-nfs`), not an OIDC identity. The chain:

1. `mint_token` began failing mid-wait (visible at 19:41/19:46 as klog noise about credentials)
2. `IDTOKEN=$(mint_token) || true` → IDTOKEN silently **empty**
3. `kubectl --token ""` does not error — it falls back to **ambient in-cluster credentials**
4. That SA has no allocation RBAC → `Forbidden` on every poll, deterministically
5. `Forbidden` matches none of `unauthorized|must be logged in|401` → warn-and-retry, **no reissue** → 49 minutes of spinning

No amount of reissuing would have recovered it — the identity, not the token, was wrong.

Two further defects, both real, found while diagnosing:

**`2>&1` on the phase capture** — merges stderr in, so a warning on an *otherwise-successful* call lands in the variable and `[[ "$output" == "Allocated" ]]` compares `E0730 … memcache.go …` against `Allocated`. **Confirmed live**: the 19:41 and 19:46 polls in this run show exactly that. It wasn't what stalled the run, but it is a second independent way to miss a flip.

**The classifier itself** — any error it doesn't recognize falls through to a branch that never reissues, so the loop can spin forever on a message nobody anticipated. `Forbidden` was that message here.

### Fix

- **`mint_token` returns non-zero instead of an empty string**, `reissue_token` only ever replaces a good token with another good one (never blanks it), and an initial mint failure is fatal with an explicit message. The poll can no longer silently change identity.
- **stdout only** for the phase; stderr captured separately for diagnostics; whitespace trimmed.
- **Classifier deleted, not extended.** Any failed poll reissues the token — minting is cheap and idempotent, so there is no error string left to get wrong — and the loop aborts after `MAX_CONSECUTIVE_ERRORS` (60 polls ≈ 5 min of unbroken failure) rather than retrying forever.
- **Dump phase/result/message/nodes before failing.** Diagnosing 30573758666 required a human with cluster credentials, after the run had ended and the allocation was already deleted. A timeout should be readable from the log alone.
- **Log on phase change + a 60s heartbeat** instead of every poll. That 60-minute wait would otherwise have been 720 identical lines.

Phase handling is otherwise unchanged — only `Allocated` exits 0, and the observed waiting phase is `NotAvailable`. I deliberately did **not** add a bail-out on terminal phases: the Allocation CRD's phase enum isn't readable without cluster-admin, and guessing which values are terminal risks aborting on one that's merely transient. Worth a follow-up by someone who can read the CRD, since a genuinely failed allocation still waits out the caller's timeout.

### What this does NOT fix

This makes the failure **fast and legible**, not impossible. If minting keeps failing the step now dies in ~5 min with the reason on screen instead of burning the caller's full timeout — but the allocation still doesn't get waited on. Why minting failed at 19:41 on that runner is unresolved and is the real reliability question; this PR just stops it from presenting as a silent 79-minute hang.

Also note `MAX_CONSECUTIVE_ERRORS` (60 polls ≈ 5 min) is a behaviour change in the other direction: an API outage longer than that during a legitimate long wait now fails where the old loop would have kept waiting. That seemed clearly right given the alternative is an unbounded hang, but it is a judgement call worth a second opinion.

### Verification

Ran both the current loop and this one against a fake token-aware `kubectl` over three scenarios:

| scenario | current (#49552) | this PR |
|---|---|---|
| **minting dies mid-wait** → empty token → ambient-SA `Forbidden` (replays this incident) | **HUNG** | `exit 1` with the Forbidden text + status dump |
| stderr warning on a successful call | **HUNG** | `exit 0` |
| token dies mid-wait, only a reissued one accepted | **HUNG** | `exit 0` |
| permanent hard failure | (spins) | `exit 1` after N |

The incident replay uses a fake `jq` whose minting returns empty after the first call — the same degradation the log shows. The production loop hangs on all of it. The harness is a ~60-line script with a fake `kubectl`/`curl`/`jq` on `PATH`; happy to commit it alongside the action if you'd like a regression test there — I left it out to keep the diff surgical.

### Verified in production

tt-blaze run [30585556114](https://github.com/tenstorrent/tt-blaze/actions/runs/30585556114) ran the full Kimi 64-rank ladder against this branch (submodule pinned to `b0b70be0370`). The allocation sat `NotAvailable` for **64 minutes** behind another team's job, then:

```
##[notice]Allocation ci-30585556114-kimi-sp1 is Allocated after 64m.
```

During that wait the OIDC token expired and was reissued **12 times**, every one recovered on the very next poll:

```
gaps between expiries (s): 306 301 307 316 307 311 301 307 316 311 301
mean 308s  min 301s  max 316s
```

Each one surfaced as exactly the message the old classifier does not match:

```
err="couldn't get current server API group list: the server has asked for the client to provide credentials"
```

**The measured token lifetime is ~5 minutes, not the ~10-15 min this action's comment assumed.** So an expiry is not an edge case on a long placement wait — it is guaranteed every ~5 minutes, and the loop's ability to recover from it is load-bearing rather than defensive.

To be precise about the old behaviour: it was not uniformly broken above 5 minutes. In run 30573758666 it recovered 7 expiries (those whose text happened to match the regex) and mishandled others — 2 surfaced as rc=0-with-stderr-noise, and the final one blanked the token and pinned it to the ambient service account, which was terminal. This branch recovered 12/12 and never lost its identity.

Downstream of the wait, the run then went green end to end: decode liveness passed (7639 tokens on 64 ranks), teacher-forcing `1 passed` at 90.44% (6336/7006), teardown clean, no leaked allocation.

### Notes for merging

- Opened against **`blaze-metal-main-uplift-july-15-rev0`** because that is what tt-blaze pins today (`ca0f7801fe`, whose copy of this action is blob-identical to #49552's). **This needs forward-porting to `main`** or the next uplift drops it — same cherry-pick shape as #49552 itself.
- tt-blaze needs a submodule pin bump to pick it up.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ci/ttop-alloc-wait-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ci/ttop-alloc-wait-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ci/ttop-alloc-wait-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ci/ttop-alloc-wait-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ci/ttop-alloc-wait-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ci/ttop-alloc-wait-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ci/ttop-alloc-wait-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ci/ttop-alloc-wait-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ci/ttop-alloc-wait-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ci/ttop-alloc-wait-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ci/ttop-alloc-wait-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ci/ttop-alloc-wait-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ci/ttop-alloc-wait-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ci/ttop-alloc-wait-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ci/ttop-alloc-wait-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ci/ttop-alloc-wait-fix)

