### PR TITLE
[Cleanup] Tensor prefetcher: take a MeshCommandQueue, not a cq_id

### DIFF
--- a/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_tensor_large.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_tensor_large.py
@@ -643,10 +643,7 @@ def test_tensor_prefetcher_recv_contig_smoke(device, num_tensors, num_layers):
 # the DRAM sender cores over NOC. When it names a command queue that is mid
 # trace-capture, the request must be *captured* (not sent) and re-sent on every
 # `execute_trace` of that trace, so a captured matmul that consumes the GCB is
-# refilled on each replay. `prefetch_and_linear` names the thread's current CQ --
-# the one its `ttnn.linear` dispatches on -- so the pair is captured together. This
-# test captures that pair into a trace, replays it several times, and PCC-checks
-# every replay.
+# refilled on each replay.
 @pytest.mark.parametrize("device_params", [{"trace_region_size": 23887872}], indirect=True)
 @pytest.mark.parametrize("replay_count", [1, 3])
 def test_tensor_prefetcher_trace_replay(device, replay_count):

--- a/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_tensor_large.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_tensor_large.py
@@ -46,6 +46,7 @@ Three scopes:
 """
 
 import math
+import time
 import zlib
 import pytest
 import torch
@@ -640,141 +641,212 @@ def test_tensor_prefetcher_recv_contig_smoke(device, num_tensors, num_layers):
 # ---------------------------------------------------------------------------
 # `queue_tensor_prefetcher_request` does not go through the command queue: it
 # serializes a request into socket pages and a host worker thread fans them out to
-# the DRAM sender cores over NOC. When it names a command queue that is mid
-# trace-capture, the request must be *captured* (not sent) and re-sent on every
-# `execute_trace` of that trace, so a captured matmul that consumes the GCB is
-# refilled on each replay.
+# the DRAM sender cores over NOC. Whether a request is *captured* into a trace — held
+# back, then re-sent on every `execute_trace` of that trace — or sent immediately is a
+# host-side routing decision with two inputs: the request's `capture_into_trace` flag,
+# and whether the calling thread's current command queue is mid trace-capture.
+
+
+class _TraceCase:
+    """One gcb-fed matmul, shared by the tests in this section: a persistent activation,
+    one DRAM weight, the gcb the prefetcher fills, and `num_weight_values` sets of weight
+    values the test can write into that weight with `write_weight`, each with its own
+    torch reference.
+
+    Rewriting the weight is how the tests tell a captured request from one that was sent
+    immediately. A request reads DRAM when the DRISC processes it, so a request held for
+    replay reads the weight as it stands at replay time, while one sent during capture
+    read it as it stood then. Overwrite the weight after recording the trace, and the
+    matmul output says which happened — no reliance on a hang.
+    """
+
+    def __init__(self, device, num_weight_values=1, seed_tag=b"trace_replay", write_cq=0):
+        self.device = device
+
+        # ---- Topology (qkv_small shape; adapts to harvested DRAM bank counts) ----
+        num_dram_banks = device.dram_grid_size().x
+        num_receivers_per_bank = 1
+        ring_size = num_dram_banks * num_receivers_per_bank
+        ring_cols = num_dram_banks
+        ring_rows = num_receivers_per_bank
+        dtype = ttnn.bfloat16
+        self.ring_size = ring_size
+        self.dtype = dtype
+
+        receiver_core_range_set = ttnn.CoreRangeSet(
+            {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(ring_cols - 1, ring_rows - 1))}
+        )
+
+        M = 32
+        k_tiles_per_shard = 8
+        n_tiles_per_receiver = 1
+        K = k_tiles_per_shard * ring_size * ttnn.TILE_SIZE
+        N = ring_size * n_tiles_per_receiver * ttnn.TILE_SIZE
+
+        torch.manual_seed(zlib.crc32(seed_tag))
+        pt_weights = [torch.randn(1, 1, K, N) for _ in range(num_weight_values)]
+        pt_act = torch.randn(1, 1, M, K)
+
+        # ---- Weight (B): width-sharded in DRAM across the banks ----
+        dram_core_range_set = ttnn.CoreRangeSet(
+            {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(num_dram_banks - 1, 0))}
+        )
+        weight_mem_config = ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+            ttnn.BufferType.DRAM,
+            ttnn.ShardSpec(dram_core_range_set, [K, N // num_dram_banks], ttnn.ShardOrientation.ROW_MAJOR),
+        )
+
+        # ---- Activation (A): width-sharded on receiver cores; persistent across replays ----
+        K_per_shard = _round_up(math.ceil(K / ring_size), ttnn.TILE_SIZE)
+        act_mem_config = ttnn.create_sharded_memory_config(
+            shape=(M, K_per_shard),
+            core_grid=receiver_core_range_set,
+            strategy=ttnn.ShardStrategy.WIDTH,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+
+        # Host copies of each value set, kept so write_weight can push them into the one
+        # device weight later.
+        self.host_weights = [ttnn.from_torch(w, dtype=dtype, layout=ttnn.TILE_LAYOUT) for w in pt_weights]
+
+        # `write_cq` is the queue these host-to-device writes go out on — what
+        # wait_for_cq_on_tensor_prefetcher is asked to fence against.
+        self.write_cq = write_cq
+        with ttnn.command_queue(write_cq):
+            self.weight = ttnn.as_tensor(
+                pt_weights[0], device=device, dtype=dtype, memory_config=weight_mem_config, layout=ttnn.TILE_LAYOUT
+            )
+            self.act = ttnn.from_torch(
+                pt_act, device=device, dtype=dtype, layout=ttnn.TILE_LAYOUT, memory_config=act_mem_config
+            )
+
+        # ---- Matmul program config (1D-mcast gather_in0) ----
+        out_block_h = M // ttnn.TILE_SIZE
+        out_block_w = N // ring_size // ttnn.TILE_SIZE
+        out_subblock_w = min(out_block_w, 8)
+        while out_subblock_w > 1 and out_block_w % out_subblock_w != 0:
+            out_subblock_w -= 1
+        self.program_config = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+            compute_with_storage_grid_size=(ring_cols, ring_rows),
+            in0_block_w=1,
+            out_subblock_h=1,
+            out_subblock_w=out_subblock_w,
+            per_core_M=out_block_h,
+            per_core_N=out_block_w,
+            fuse_batch=True,
+            fused_activation=None,
+            mcast_in0=False,
+            gather_in0=True,
+            hop_cores=ttnn.CoreRangeSet([]),
+            num_global_cb_receivers=num_receivers_per_bank,
+            untilize_out=False,
+        )
+
+        # ---- DRAM-sender GlobalCircularBuffer: one layer deep ----
+        tile_bytes = _bytes_per_tile(dtype)
+        in1_block_size_bytes = k_tiles_per_shard * n_tiles_per_receiver * tile_bytes
+        gcb_size = ring_size * in1_block_size_bytes
+        bank_to_receivers = [
+            (b, _bank_receivers_row_major(b, num_receivers_per_bank, ring_cols)) for b in range(num_dram_banks)
+        ]
+        self.gcb = ttnn.experimental.create_global_circular_buffer_for_matmul_1d(
+            device, [self.program_config], [self.weight], bank_to_receivers=bank_to_receivers, size=gcb_size
+        )
+
+        self.out_mem_config = ttnn.create_sharded_memory_config(
+            shape=(M, N // ring_size),
+            core_grid=receiver_core_range_set,
+            strategy=ttnn.ShardStrategy.WIDTH,
+            orientation=ttnn.ShardOrientation.ROW_MAJOR,
+            use_height_and_width_as_shard_shape=True,
+        )
+        self.compute_kernel_config = ttnn.init_device_compute_kernel_config(
+            device.arch(),
+            math_fidelity=ttnn.MathFidelity.HiFi4,
+            math_approx_mode=False,
+            fp32_dest_acc_en=True,
+            packer_l1_acc=True,
+            dst_full_sync_en=True,
+        )
+
+        self.expected = [pt_act.float() @ w.float() for w in pt_weights]
+
+    def write_weight(self, value_index):
+        """Overwrite the DRAM weight in place with value set `value_index`, and wait for
+        the write to land. In place matters: a captured request holds the addresses it was
+        queued with, so this is what changes what a replay of it reads."""
+        # A request that already went out may still be reading this weight: the DRISC DMAs
+        # from DRAM when it processes the request, and nothing host-side reports that as
+        # finished. Sleep first so the overwrite cannot land under an in-flight read — 50 ms
+        # against a per-layer DMA measured in microseconds.
+        time.sleep(0.05)
+        ttnn.copy_host_to_device_tensor(self.host_weights[value_index], self.weight, cq_id=self.write_cq)
+        ttnn.synchronize_device(self.device)
+
+    def queue(self, **kwargs):
+        """Queue one gcb layer of the weight. Passes no `capture_into_trace` of its own
+        unless a test names one, so the binding default applies."""
+        ttnn.experimental.queue_tensor_prefetcher_request(
+            self.device, [(self.weight, self.ring_size)], global_cb=self.gcb, **kwargs
+        )
+
+    def linear(self, **kwargs):
+        """Run the matmul over one gcb layer. in1 comes from the gcb, so the output
+        reflects whatever the prefetcher put there, not the weight tensor passed here."""
+        return ttnn.linear(
+            self.act,
+            self.weight,
+            program_config=self.program_config,
+            global_cb=self.gcb,
+            memory_config=self.out_mem_config,
+            compute_kernel_config=self.compute_kernel_config,
+            dtype=self.dtype,
+            **kwargs,
+        )
+
+    def prefetch_and_linear(self, **kwargs):
+        """Queue a layer and run the matmul over it, through the paired call production
+        uses. Unlike `queue`, this one asks to be captured (`capture_into_trace=True`)."""
+        return ttnn.experimental.tensor_prefetcher_matmul.prefetch_and_linear(
+            self.act,
+            self.weight,
+            global_cb=self.gcb,
+            program_config=self.program_config,
+            memory_config=self.out_mem_config,
+            compute_kernel_config=self.compute_kernel_config,
+            dtype=self.dtype,
+            **kwargs,
+        )
+
+    def check(self, torch_out, value_index):
+        """(passing, message) for a readback against act @ weight-value-set value_index."""
+        return comp_pcc(self.expected[value_index], torch_out, 0.999)
+
+
 @pytest.mark.parametrize("device_params", [{"trace_region_size": 23887872}], indirect=True)
 @pytest.mark.parametrize("replay_count", [1, 3])
 def test_tensor_prefetcher_trace_replay(device, replay_count):
     """Capture a (prefetcher-request + linear) pair into a trace and replay it
     `replay_count` times; each replay must refill the GCB and produce the right
     matmul output."""
-    # ---- Topology (qkv_small shape; adapts to harvested DRAM bank counts) ----
-    num_dram_banks = device.dram_grid_size().x
-    num_receivers_per_bank = 1
-    ring_size = num_dram_banks * num_receivers_per_bank
-    ring_cols = num_dram_banks
-    ring_rows = num_receivers_per_bank
-    dtype = ttnn.bfloat16
-
-    receiver_core_range_set = ttnn.CoreRangeSet(
-        {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(ring_cols - 1, ring_rows - 1))}
-    )
-
-    M = 32
-    k_tiles_per_shard = 8
-    n_tiles_per_receiver = 1
-    K = k_tiles_per_shard * ring_size * ttnn.TILE_SIZE
-    N = ring_size * n_tiles_per_receiver * ttnn.TILE_SIZE
-
-    # ---- Weight (B): width-sharded in DRAM across the banks ----
-    torch.manual_seed(zlib.crc32(b"trace_replay"))
-    pt_weight = torch.randn(1, 1, K, N)
-    dram_core_range_set = ttnn.CoreRangeSet(
-        {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(num_dram_banks - 1, 0))}
-    )
-    weight_mem_config = ttnn.MemoryConfig(
-        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
-        ttnn.BufferType.DRAM,
-        ttnn.ShardSpec(dram_core_range_set, [K, N // num_dram_banks], ttnn.ShardOrientation.ROW_MAJOR),
-    )
-    tt_weight = ttnn.as_tensor(
-        pt_weight, device=device, dtype=dtype, memory_config=weight_mem_config, layout=ttnn.TILE_LAYOUT
-    )
-
-    # ---- Activation (A): width-sharded on receiver cores; persistent across replays ----
-    pt_act = torch.randn(1, 1, M, K)
-    K_per_shard = _round_up(math.ceil(K / ring_size), ttnn.TILE_SIZE)
-    act_mem_config = ttnn.create_sharded_memory_config(
-        shape=(M, K_per_shard),
-        core_grid=receiver_core_range_set,
-        strategy=ttnn.ShardStrategy.WIDTH,
-        orientation=ttnn.ShardOrientation.ROW_MAJOR,
-        use_height_and_width_as_shard_shape=True,
-    )
-    tt_act = ttnn.from_torch(pt_act, device=device, dtype=dtype, layout=ttnn.TILE_LAYOUT, memory_config=act_mem_config)
-
-    # ---- Matmul program config (1D-mcast gather_in0) ----
-    out_block_h = M // ttnn.TILE_SIZE
-    out_block_w = N // ring_size // ttnn.TILE_SIZE
-    out_subblock_w = min(out_block_w, 8)
-    while out_subblock_w > 1 and out_block_w % out_subblock_w != 0:
-        out_subblock_w -= 1
-    program_config = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
-        compute_with_storage_grid_size=(ring_cols, ring_rows),
-        in0_block_w=1,
-        out_subblock_h=1,
-        out_subblock_w=out_subblock_w,
-        per_core_M=out_block_h,
-        per_core_N=out_block_w,
-        fuse_batch=True,
-        fused_activation=None,
-        mcast_in0=False,
-        gather_in0=True,
-        hop_cores=ttnn.CoreRangeSet([]),
-        num_global_cb_receivers=num_receivers_per_bank,
-        untilize_out=False,
-    )
-
-    # ---- DRAM-sender GlobalCircularBuffer ----
-    tile_bytes = _bytes_per_tile(dtype)
-    in1_block_size_bytes = k_tiles_per_shard * n_tiles_per_receiver * tile_bytes
-    gcb_size = ring_size * in1_block_size_bytes
-    bank_to_receivers = [
-        (b, _bank_receivers_row_major(b, num_receivers_per_bank, ring_cols)) for b in range(num_dram_banks)
-    ]
-    gcb = ttnn.experimental.create_global_circular_buffer_for_matmul_1d(
-        device, [program_config], [tt_weight], bank_to_receivers=bank_to_receivers, size=gcb_size
-    )
-
-    output_mem_config = ttnn.create_sharded_memory_config(
-        shape=(M, N // ring_size),
-        core_grid=receiver_core_range_set,
-        strategy=ttnn.ShardStrategy.WIDTH,
-        orientation=ttnn.ShardOrientation.ROW_MAJOR,
-        use_height_and_width_as_shard_shape=True,
-    )
-    compute_kernel_config = ttnn.init_device_compute_kernel_config(
-        device.arch(),
-        math_fidelity=ttnn.MathFidelity.HiFi4,
-        math_approx_mode=False,
-        fp32_dest_acc_en=True,
-        packer_l1_acc=True,
-        dst_full_sync_en=True,
-    )
-
-    expected = pt_act.float() @ pt_weight.float()
-
-    def fill_and_matmul():
-        # prefetch_and_linear queues the prefetch request and runs the consuming
-        # matmul against the same gcb/program_config in one call; block_count is
-        # derived from the gcb's receiver count (no need to pass ring_size).
-        return ttnn.experimental.tensor_prefetcher_matmul.prefetch_and_linear(
-            tt_act,
-            tt_weight,
-            global_cb=gcb,
-            program_config=program_config,
-            memory_config=output_mem_config,
-            compute_kernel_config=compute_kernel_config,
-            dtype=dtype,
-        )
+    case = _TraceCase(device)
 
     with tensor_prefetcher_session(device):
         # ---- Warmup: compile kernels + balance the GCB before trace capture. The
         # queue here is sent immediately (cq 0 not capturing) and consumed by the matmul. ----
         logger.info("Warmup (compile) run")
-        tt_out = fill_and_matmul()
+        tt_out = case.prefetch_and_linear()
         ttnn.synchronize_device(device)
-        warmup_torch = ttnn.to_torch(tt_out)
-        passing, msg = comp_pcc(expected, warmup_torch, 0.999)
+        passing, msg = case.check(ttnn.to_torch(tt_out), 0)
         assert passing, f"warmup PCC failed: {msg}"
 
         # ---- Capture: the queue request is captured into the trace (cq 0 mid-capture),
         # NOT sent now. The linear is captured too. ----
         logger.info("Capturing trace")
         trace_id = ttnn.begin_trace_capture(device, cq_id=0)
-        tt_out = fill_and_matmul()
+        tt_out = case.prefetch_and_linear()
         ttnn.end_trace_capture(device, trace_id, cq_id=0)
 
         # ---- Replay: each execute_trace must replay the captured prefetcher request
@@ -782,11 +854,141 @@ def test_tensor_prefetcher_trace_replay(device, replay_count):
         for i in range(replay_count):
             logger.info(f"Replay {i + 1}/{replay_count}")
             ttnn.execute_trace(device, trace_id, cq_id=0, blocking=True)
-            out_torch = ttnn.to_torch(tt_out)
-            passing, msg = comp_pcc(expected, out_torch, 0.999)
+            passing, msg = case.check(ttnn.to_torch(tt_out), 0)
             assert passing, f"replay {i + 1} PCC failed: {msg}"
 
         ttnn.release_trace(device, trace_id)
+
+
+# The next two tests both work by overwriting the DRAM weight after recording the trace,
+# then replaying once. A request reads DRAM when the DRISC processes it, so the matmul
+# output names the moment the request went out: the post-overwrite values mean it was held
+# and replayed, the pre-overwrite values mean it went out during capture. They are each
+# other's failure signature, and neither can regress into a hang — one layer is queued and
+# one matmul runs it either way.
+#
+# The overwrite assumes a request queued during capture has already read DRAM by the time
+# the new values land; `write_weight` sleeps to guarantee it, since there is no host-visible
+# request-completion signal to wait on instead.
+@pytest.mark.parametrize("device_params", [{"trace_region_size": 23887872, "num_command_queues": 2}], indirect=True)
+@pytest.mark.parametrize("cq_id", [0, 1])
+def test_tensor_prefetcher_trace_capture_on_queue(device, cq_id):
+    """A request asking to be captured must land in the trace being recorded on the queue
+    the caller named — including a queue that is not the default 0.
+
+    Which queue is consulted follows ttnn's usual convention: the `queue_id` keyword is
+    consumed by the operation wrapper and applied by making that queue the thread's current
+    one, so the C++ layer never sees it. A keyword dropped anywhere along that chain leaves
+    the prefetch resolving against some other queue, which is not recording, and the request
+    goes out during capture instead of being held."""
+    case = _TraceCase(device, num_weight_values=2, seed_tag=b"trace_capture_on_queue")
+
+    with tensor_prefetcher_session(device):
+        # Warmup on the same queue: trace capture needs the matmul program already cached,
+        # and this leaves the gcb empty.
+        tt_out = case.prefetch_and_linear(queue_id=cq_id)
+        ttnn.synchronize_device(device)
+        passing, msg = case.check(ttnn.to_torch(tt_out), 0)
+        assert passing, f"warmup PCC failed: {msg}"
+
+        trace_id = ttnn.begin_trace_capture(device, cq_id=cq_id)
+        tt_out = case.prefetch_and_linear(queue_id=cq_id)
+        ttnn.end_trace_capture(device, trace_id, cq_id=cq_id)
+
+        case.write_weight(1)
+
+        ttnn.execute_trace(device, trace_id, cq_id=cq_id, blocking=True)
+        replayed = ttnn.to_torch(tt_out)
+        ttnn.release_trace(device, trace_id)
+
+    passing, msg = case.check(replayed, 1)
+    assert passing, (
+        f"replay on cq {cq_id} did not match the weight written after recording: {msg}. "
+        f"Matching the pre-recording weight instead means the request went out during "
+        f"capture, i.e. queue_id={cq_id} never reached the prefetch half."
+    )
+
+
+@pytest.mark.parametrize("device_params", [{"trace_region_size": 23887872}], indirect=True)
+def test_tensor_prefetcher_request_not_captured_by_default(device):
+    """Without `capture_into_trace`, a request goes out immediately even when the current
+    queue is mid trace-capture.
+
+    This is the tri-state the flag exists for: `capture_into_trace=False` means "never
+    captured", which is not the same as "no queue is recording". A caller on a thread that
+    happens to be inside a capture region can still ask for an immediate send, and that
+    request must not be re-sent on every `execute_trace`."""
+    case = _TraceCase(device, num_weight_values=2, seed_tag=b"not_captured_by_default")
+
+    with tensor_prefetcher_session(device):
+        tt_out = case.prefetch_and_linear()
+        ttnn.synchronize_device(device)
+        passing, msg = case.check(ttnn.to_torch(tt_out), 0)
+        assert passing, f"warmup PCC failed: {msg}"
+
+        trace_id = ttnn.begin_trace_capture(device, cq_id=0)
+        # Mid-capture, at the binding default: goes out now, reading the weight as it
+        # currently stands. The linear below is captured, as any op in this region is.
+        case.queue()
+        tt_out = case.linear()
+        ttnn.end_trace_capture(device, trace_id, cq_id=0)
+
+        case.write_weight(1)
+
+        ttnn.execute_trace(device, trace_id, cq_id=0, blocking=True)
+        replayed = ttnn.to_torch(tt_out)
+        ttnn.release_trace(device, trace_id)
+
+    passing, msg = case.check(replayed, 0)
+    assert passing, (
+        f"replay did not match the weight as it stood during recording: {msg}. Matching the "
+        f"weight written afterwards means the request was captured and re-read DRAM on "
+        f"replay, which capture_into_trace=False must not do."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fencing against a command queue
+# ---------------------------------------------------------------------------
+# `wait_for_cq_on_tensor_prefetcher`'s queue argument reaches the C++ layer only in its
+# positional form: a `cq_id=` keyword is consumed by the operation wrapper and applied
+# by making that queue the thread's current one. That is why the binding defaults to
+# None (resolve whatever queue is current) rather than to 0 — a `uint8_t = 0` default
+# would silently fence queue 0 for the keyword and context forms.
+@pytest.mark.parametrize("device_params", [{"num_command_queues": 2}], indirect=True)
+@pytest.mark.parametrize("cq_id", [0, 1])
+@pytest.mark.parametrize("form", ["positional", "keyword", "context"])
+def test_tensor_prefetcher_wait_for_cq_queue_forms(device, cq_id, form):
+    """All three spellings must fence the queue the weight was written on, on a
+    non-default queue as much as on queue 0."""
+    case = _TraceCase(device, seed_tag=b"wait_for_cq_forms", write_cq=cq_id)
+
+    with tensor_prefetcher_session(device):
+        if form == "positional":
+            ttnn.experimental.wait_for_cq_on_tensor_prefetcher(device, cq_id)
+        elif form == "keyword":
+            ttnn.experimental.wait_for_cq_on_tensor_prefetcher(device, cq_id=cq_id)
+        else:
+            with ttnn.command_queue(cq_id):
+                ttnn.experimental.wait_for_cq_on_tensor_prefetcher(device)
+
+        tt_out = case.prefetch_and_linear(queue_id=cq_id)
+        ttnn.synchronize_device(device)
+        out_torch = ttnn.to_torch(tt_out)
+
+    passing, msg = case.check(out_torch, 0)
+    assert passing, f"PCC failed after fencing cq {cq_id} in its {form} form: {msg}"
+
+
+@pytest.mark.parametrize("device_params", [{"num_command_queues": 2}], indirect=True)
+def test_tensor_prefetcher_wait_for_cq_rejects_unknown_queue(device, expect_error):
+    """A queue id the device does not have must raise, not fall back to queue 0."""
+    _TraceCase(device, seed_tag=b"wait_for_cq_unknown")
+
+    with tensor_prefetcher_session(device):
+        # device_params above opens 2 command queues, so 2 is one past the last.
+        with expect_error(RuntimeError, "is out of range"):
+            ttnn.experimental.wait_for_cq_on_tensor_prefetcher(device, 2)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_tensor_large.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_tensor_large.py
@@ -640,11 +640,13 @@ def test_tensor_prefetcher_recv_contig_smoke(device, num_tensors, num_layers):
 # ---------------------------------------------------------------------------
 # `queue_tensor_prefetcher_request` does not go through the command queue: it
 # serializes a request into socket pages and a host worker thread fans them out to
-# the DRAM sender cores over NOC. When called with a `cq_id` whose command queue is
-# mid trace-capture, the request must be *captured* (not sent) and re-sent on every
+# the DRAM sender cores over NOC. When it names a command queue that is mid
+# trace-capture, the request must be *captured* (not sent) and re-sent on every
 # `execute_trace` of that trace, so a captured matmul that consumes the GCB is
-# refilled on each replay. This test captures a (queue request + consuming linear)
-# pair into a trace, replays it several times, and PCC-checks every replay.
+# refilled on each replay. `prefetch_and_linear` names the thread's current CQ --
+# the one its `ttnn.linear` dispatches on -- so the pair is captured together. This
+# test captures that pair into a trace, replays it several times, and PCC-checks
+# every replay.
 @pytest.mark.parametrize("device_params", [{"trace_region_size": 23887872}], indirect=True)
 @pytest.mark.parametrize("replay_count", [1, 3])
 def test_tensor_prefetcher_trace_replay(device, replay_count):
@@ -756,7 +758,6 @@ def test_tensor_prefetcher_trace_replay(device, replay_count):
             tt_weight,
             global_cb=gcb,
             program_config=program_config,
-            cq_id=0,
             memory_config=output_mem_config,
             compute_kernel_config=compute_kernel_config,
             dtype=dtype,

--- a/tt_metal/api/tt-metalium/experimental/tensor_prefetcher.hpp
+++ b/tt_metal/api/tt-metalium/experimental/tensor_prefetcher.hpp
@@ -119,15 +119,13 @@ void StartTensorPrefetcher(distributed::MeshDevice& mesh_device, const TensorPre
 //   - Per-tensor `rotation` (on each TensorPrefetcherInput) is documented on that struct; a
 //     non-empty rotation enables streaming and sets the per-receiver delivery order, the only
 //     knob that varies delivery order within a request.
-//   - `trace_capture_cq` is the command queue on which a trace may be recording,
-//     and must belong to `mesh_device`. When it is non-null and that CQ is mid
-//     trace-capture, the request is captured into the trace instead of being sent
-//     immediately, and is (re)sent on every replay of that trace (ReplayTrace /
-//     ttnn.execute_trace). When it is non-null and that CQ is not capturing, the
-//     request is sent immediately. When it is null (the default), the request is
-//     never captured — it is always sent immediately, whatever any command queue
-//     is doing. Pass `&mesh_device.mesh_command_queue()` to opt into capture on the
-//     calling thread's current queue.
+//   - `trace_capture_cq` is the command queue on which a trace may be recording, and
+//     must belong to `mesh_device`. When it is non-null and mid trace-capture, the
+//     request is captured into the trace instead of being sent, and is (re)sent on
+//     every replay of that trace (ReplayTrace / ttnn.execute_trace). Otherwise — a
+//     non-capturing queue, or null (the default) — the request is sent immediately,
+//     whatever any command queue is doing. Pass `&mesh_device.mesh_command_queue()`
+//     to opt into capture on the calling thread's current queue.
 //
 // The caller is responsible for keeping the tensors in `input_tensors` and
 // `gcb` alive until Stop returns.

--- a/tt_metal/api/tt-metalium/experimental/tensor_prefetcher.hpp
+++ b/tt_metal/api/tt-metalium/experimental/tensor_prefetcher.hpp
@@ -26,6 +26,7 @@ class MeshTensor;
 
 namespace distributed {
 class MeshDevice;
+class MeshCommandQueue;
 class MeshCoordinateRangeSet;
 }  // namespace distributed
 
@@ -118,12 +119,15 @@ void StartTensorPrefetcher(distributed::MeshDevice& mesh_device, const TensorPre
 //   - Per-tensor `rotation` (on each TensorPrefetcherInput) is documented on that struct; a
 //     non-empty rotation enables streaming and sets the per-receiver delivery order, the only
 //     knob that varies delivery order within a request.
-//   - `cq_id` is the command queue on which a trace may be recording. When that
-//     CQ is mid trace-capture, the request is captured into the trace instead of
-//     being sent immediately, and is (re)sent on every replay of that trace
-//     (ReplayTrace / ttnn.execute_trace). When the CQ is not capturing, the
-//     request is sent immediately. Defaults (std::nullopt) to the current/default
-//     command queue.
+//   - `trace_capture_cq` is the command queue on which a trace may be recording,
+//     and must belong to `mesh_device`. When it is non-null and that CQ is mid
+//     trace-capture, the request is captured into the trace instead of being sent
+//     immediately, and is (re)sent on every replay of that trace (ReplayTrace /
+//     ttnn.execute_trace). When it is non-null and that CQ is not capturing, the
+//     request is sent immediately. When it is null (the default), the request is
+//     never captured — it is always sent immediately, whatever any command queue
+//     is doing. Pass `&mesh_device.mesh_command_queue()` to opt into capture on the
+//     calling thread's current queue.
 //
 // The caller is responsible for keeping the tensors in `input_tensors` and
 // `gcb` alive until Stop returns.
@@ -132,25 +136,23 @@ void QueueTensorPrefetcherRequest(
     const GlobalCircularBuffer& gcb,
     const std::optional<distributed::MeshCoordinateRangeSet>& device_subset,
     const std::vector<TensorPrefetcherInput>& input_tensors,
-    std::optional<uint8_t> cq_id = std::nullopt);
+    distributed::MeshCommandQueue* trace_capture_cq = nullptr);
 
-// Fence the prefetcher against command queue `cq_id`: every prefetch request queued
-// after this call waits until all work previously enqueued on `cq_id` has completed
+// Fence the prefetcher against command queue `cq`: every prefetch request queued
+// after this call waits until all work previously enqueued on `cq` has completed
 // on device before it reads DRAM. Use this to guarantee that data written over
-// `cq_id` (e.g. the EnqueueWriteBuffer that populates the weights) has landed before
+// `cq` (e.g. the EnqueueWriteBuffer that populates the weights) has landed before
 // the prefetcher streams it.
 //
 // Call this synchronously on the host thread that issued the data writes — after
 // those writes, and before the QueueTensorPrefetcherRequest that consumes them.
 //
-//   - `cq_id` selects the command queue to fence against.
+//   - The prefetcher fenced is the one active on `cq.device()`.
 //   - `device_subset` defaults to the full mesh when std::nullopt.
 //
-// Preconditions (TT_FATAL): a prefetcher is active on this mesh device.
+// Preconditions (TT_FATAL): a prefetcher is active on `cq`'s mesh device.
 void WaitForCqOnTensorPrefetcher(
-    distributed::MeshDevice& mesh_device,
-    uint8_t cq_id,
-    const std::optional<distributed::MeshCoordinateRangeSet>& device_subset);
+    distributed::MeshCommandQueue& cq, const std::optional<distributed::MeshCoordinateRangeSet>& device_subset);
 
 // Block until all previously queued requests have been delivered and the
 // kernels have exited, then release the prefetcher's resources. No-op if no

--- a/tt_metal/impl/buffers/kernels/tensor_prefetcher.cpp
+++ b/tt_metal/impl/buffers/kernels/tensor_prefetcher.cpp
@@ -218,7 +218,10 @@ void kernel_main() {
     // Base of this core's per-CQ signal slots (kNumCqSignalSlots uint32 counters).
     // WaitForCqOnTensorPrefetcher writes an incrementing value here from the
     // dispatcher; a WAIT_CQ request blocks until the requested slot reaches it.
+    // Slots are `cq_signal_slot_stride` bytes apart, not packed: each is the target of
+    // its own dispatcher write, which only lands on an L1-aligned address.
     constexpr uint32_t cq_signal_l1_base = get_compile_time_arg_val(4);
+    constexpr uint32_t cq_signal_slot_stride = get_compile_time_arg_val(5);
     constexpr uint32_t ring_half = stage_ring_size / 2;
     constexpr uint32_t stage_slot_a = stage_ring_base;
     constexpr uint32_t stage_slot_b = stage_ring_base + ring_half;
@@ -249,9 +252,11 @@ void kernel_main() {
     // (rather than from the host) because no WaitForCqOnTensorPrefetcher signal
     // can be enqueued until StartTensorPrefetcher returns to the single-threaded
     // host caller, long after this init runs.
-    volatile tt_l1_ptr uint32_t* cq_signal_slots = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cq_signal_l1_base);
+    auto cq_signal_slot = [](uint32_t index) -> volatile tt_l1_ptr uint32_t* {
+        return reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cq_signal_l1_base + index * cq_signal_slot_stride);
+    };
     for (uint32_t i = 0; i < kNumCqSignalSlots; ++i) {
-        cq_signal_slots[i] = 0;
+        *cq_signal_slot(i) = 0;
     }
 
     // ---- Request loop ----
@@ -275,9 +280,9 @@ void kernel_main() {
         if (cmd_id == tt::tt_metal::DRAM_PREFETCHER_CMD_WAIT_CQ) {
             // Block until the dispatcher has bumped this CQ's signal slot to the
             // requested value. Wrap-safe: compare the unsigned difference as signed.
-            const uint32_t idx = req->wait_cq.cq_index;
+            volatile tt_l1_ptr uint32_t* slot = cq_signal_slot(req->wait_cq.cq_index);
             const uint32_t target = req->wait_cq.cq_wait_value;
-            while ((int32_t)(cq_signal_slots[idx] - target) < 0) {
+            while ((int32_t)(*slot - target) < 0) {
                 invalidate_l1_cache();
             }
             socket_pop_pages(socket, 1);

--- a/tt_metal/impl/buffers/tensor_prefetcher_manager.cpp
+++ b/tt_metal/impl/buffers/tensor_prefetcher_manager.cpp
@@ -948,10 +948,8 @@ void TensorPrefetcherManager::queue(
         }
     }
 
-    // If the caller named a command queue and it is mid trace-capture, capture this request into
-    // the trace instead of sending it now; it is (re)sent on every replay of that trace. With no
-    // queue (nullptr) the request is never captured — it is sent immediately via the host worker,
-    // as is a named queue that is not capturing.
+    // Engaged only when the caller named a queue that is mid trace-capture; that is what
+    // routes the request into the trace below instead of out via the host worker.
     const std::optional<MeshTraceId> recording_trace_id =
         trace_capture_cq != nullptr ? trace_capture_cq->trace_id() : std::nullopt;
 
@@ -1055,10 +1053,11 @@ void TensorPrefetcherManager::enqueue_cq_signal_and_wait(
     }
 
     // (a) Dispatcher write: bump every target DRAM core's signal slot for this CQ. Runs
-    // under the api lock we already hold (the method does not re-lock).
-    auto* cq_base = dynamic_cast<MeshCommandQueueBase*>(&cq);
-    TT_FATAL(cq_base != nullptr, "MeshCommandQueue is not a MeshCommandQueueBase");
-    cq_base->enqueue_write_dram_core_counter(
+    // under the api lock we already hold (the method does not re-lock). Re-resolving by id
+    // (safe: we checked cq.device() above) gets the queue as a MeshCommandQueueBase, which
+    // is what exposes enqueue_write_dram_core_counter.
+    auto& cq_base = mesh_device_->impl().mesh_command_queue_base(static_cast<uint8_t>(cq_id));
+    cq_base.enqueue_write_dram_core_counter(
         ttsl::Span<const DeviceMemoryAddress>(targets), signal_value, /*blocking=*/false);
 
     // (b) Queue a WAIT_CQ request. It rides the same async worker path as prefetch
@@ -1251,7 +1250,6 @@ void QueueTensorPrefetcherRequest(
 void WaitForCqOnTensorPrefetcher(
     distributed::MeshCommandQueue& cq, const std::optional<distributed::MeshCoordinateRangeSet>& device_subset) {
     auto* mesh_device = cq.device();
-    TT_FATAL(mesh_device != nullptr, "WaitForCqOnTensorPrefetcher command queue has no mesh device");
     auto& manager = mesh_device->impl().tensor_prefetcher(mesh_device);
     manager.enqueue_cq_signal_and_wait(cq, device_subset);
 }

--- a/tt_metal/impl/buffers/tensor_prefetcher_manager.cpp
+++ b/tt_metal/impl/buffers/tensor_prefetcher_manager.cpp
@@ -493,6 +493,7 @@ void TensorPrefetcherManager::build_and_launch_programs(uint32_t stage_ring_base
                 kRemoteCBId,
                 socket_page_size,
                 cq_signal_l1_addr_,
+                cq_signal_slot_stride_,
             };
 
             KernelHandle kernel_id = CreateKernel(
@@ -543,10 +544,12 @@ void TensorPrefetcherManager::start() {
     const uint32_t socket_config_bytes = align_up(sizeof(receiver_socket_md), pcie_alignment_for_layout);
     const uint32_t socket_data_bytes = socket_fifo_size_for_layout + pcie_alignment_for_layout;
     const uint32_t kernel_region_base = static_cast<uint32_t>(arena.kernel_working_region_base());
-    // Per-CQ signal slots at the front of the region: a small uint32 counter per
-    // command queue, written by the dispatcher for WaitForCqOnTensorPrefetcher
-    // and polled by the kernel's WAIT_CQ handler.
-    const uint32_t cq_signal_bytes = align_up(kNumCqSignalSlots * sizeof(uint32_t), l1_alignment);
+    // Per-CQ signal slots at the front of the region: a uint32 counter per command
+    // queue, written by the dispatcher for WaitForCqOnTensorPrefetcher and polled by
+    // the kernel's WAIT_CQ handler. One L1 alignment apiece rather than packed — see
+    // cq_signal_slot_stride_.
+    cq_signal_slot_stride_ = l1_alignment;
+    const uint32_t cq_signal_bytes = kNumCqSignalSlots * cq_signal_slot_stride_;
     cq_signal_l1_addr_ = align_up(kernel_region_base, l1_alignment);
     socket_config_l1_addr_ = align_up(cq_signal_l1_addr_ + cq_signal_bytes, pcie_alignment_for_layout);
     socket_data_l1_addr_ = align_up(socket_config_l1_addr_ + socket_config_bytes, pcie_alignment_for_layout);
@@ -1049,7 +1052,7 @@ void TensorPrefetcherManager::enqueue_cq_signal_and_wait(
                                             .hal()
                                             .get_l1_noc_offset(HalProgrammableCoreType::DRAM);
     const uint64_t slot_addr = static_cast<uint64_t>(cq_signal_l1_addr_) +
-                               static_cast<uint64_t>(cq_id) * sizeof(uint32_t) + dram_l1_noc_offset;
+                               static_cast<uint64_t>(cq_id) * cq_signal_slot_stride_ + dram_l1_noc_offset;
 
     std::vector<DeviceMemoryAddress> targets;
     targets.reserve(target_devices.size() * num_senders_);

--- a/tt_metal/impl/buffers/tensor_prefetcher_manager.cpp
+++ b/tt_metal/impl/buffers/tensor_prefetcher_manager.cpp
@@ -1066,10 +1066,18 @@ void TensorPrefetcherManager::enqueue_cq_signal_and_wait(
     }
 
     // (a) Dispatcher write: bump every target DRAM core's signal slot for this CQ. Runs
-    // under the api lock we already hold (the method does not re-lock). Re-resolving by id
-    // (safe: we checked cq.device() above) gets the queue as a MeshCommandQueueBase, which
-    // is what exposes enqueue_write_dram_core_counter.
+    // under the api lock we already hold (the method does not re-lock). Re-resolving by id is
+    // what gets the queue as a MeshCommandQueueBase, which is what exposes
+    // enqueue_write_dram_core_counter; the identity check is what makes the round trip safe.
+    // It holds for every queue a mesh device owns, so a lookup that lands anywhere else fails
+    // here instead of fencing a queue the caller never named.
     auto& cq_base = mesh_device_->impl().mesh_command_queue_base(static_cast<uint8_t>(cq_id));
+    TT_FATAL(
+        &cq_base == &cq,
+        "WaitForCqOnTensorPrefetcher was given a command queue reporting id {}, but that is not mesh device {}'s "
+        "command queue for that id. Fence against a command queue obtained from the prefetcher's own mesh device.",
+        cq_id,
+        mesh_device_->id());
     cq_base.enqueue_write_dram_core_counter(
         ttsl::Span<const DeviceMemoryAddress>(targets), signal_value, /*blocking=*/false);
 

--- a/tt_metal/impl/buffers/tensor_prefetcher_manager.cpp
+++ b/tt_metal/impl/buffers/tensor_prefetcher_manager.cpp
@@ -917,9 +917,15 @@ void TensorPrefetcherManager::queue(
     MeshCommandQueue* trace_capture_cq) {
     auto lock = lock_api_function_();
     TT_FATAL(active_, "QueueTensorPrefetcherRequest called before StartTensorPrefetcher");
+    // Only reached with a non-null queue: the null case short-circuits, so the message may
+    // dereference it (TT_FATAL evaluates its arguments only when the condition fails).
     TT_FATAL(
         trace_capture_cq == nullptr || trace_capture_cq->device() == mesh_device_,
-        "QueueTensorPrefetcherRequest command queue belongs to a different mesh device than the prefetcher");
+        "QueueTensorPrefetcherRequest was given trace-capture command queue {} of mesh device {}, but this prefetcher "
+        "was started on mesh device {}. Pass a command queue of the prefetcher's own mesh device.",
+        trace_capture_cq->id(),
+        trace_capture_cq->device()->id(),
+        mesh_device_->id());
     TT_FATAL(
         experimental::sender_core_type(gcb) == experimental::SenderCoreType::Dram,
         "QueueTensorPrefetcherRequest requires a DRAM-sender GlobalCircularBuffer");
@@ -1007,7 +1013,11 @@ void TensorPrefetcherManager::enqueue_cq_signal_and_wait(
     TT_FATAL(active_, "WaitForCqOnTensorPrefetcher called before StartTensorPrefetcher");
     TT_FATAL(
         cq.device() == mesh_device_,
-        "WaitForCqOnTensorPrefetcher command queue belongs to a different mesh device than the prefetcher");
+        "WaitForCqOnTensorPrefetcher was given command queue {} of mesh device {}, but this prefetcher was started on "
+        "mesh device {}. Fence against a command queue of the prefetcher's own mesh device.",
+        cq.id(),
+        cq.device()->id(),
+        mesh_device_->id());
     const uint32_t cq_id = cq.id();
     TT_FATAL(
         cq_id < cq_signal_counter_.size(),

--- a/tt_metal/impl/buffers/tensor_prefetcher_manager.cpp
+++ b/tt_metal/impl/buffers/tensor_prefetcher_manager.cpp
@@ -914,9 +914,12 @@ void TensorPrefetcherManager::queue(
     const experimental::GlobalCircularBuffer& gcb,
     const std::optional<MeshCoordinateRangeSet>& device_subset,
     const std::vector<experimental::TensorPrefetcherInput>& tensors,
-    std::optional<uint8_t> cq_id) {
+    MeshCommandQueue* trace_capture_cq) {
     auto lock = lock_api_function_();
     TT_FATAL(active_, "QueueTensorPrefetcherRequest called before StartTensorPrefetcher");
+    TT_FATAL(
+        trace_capture_cq == nullptr || trace_capture_cq->device() == mesh_device_,
+        "QueueTensorPrefetcherRequest command queue belongs to a different mesh device than the prefetcher");
     TT_FATAL(
         experimental::sender_core_type(gcb) == experimental::SenderCoreType::Dram,
         "QueueTensorPrefetcherRequest requires a DRAM-sender GlobalCircularBuffer");
@@ -945,10 +948,12 @@ void TensorPrefetcherManager::queue(
         }
     }
 
-    // If the target command queue is mid trace-capture, capture this request into the trace
-    // instead of sending it now; it is (re)sent on every replay of that trace. Otherwise send
-    // immediately via the host worker.
-    const std::optional<MeshTraceId> recording_trace_id = mesh_device_->mesh_command_queue(cq_id).trace_id();
+    // If the caller named a command queue and it is mid trace-capture, capture this request into
+    // the trace instead of sending it now; it is (re)sent on every replay of that trace. With no
+    // queue (nullptr) the request is never captured — it is sent immediately via the host worker,
+    // as is a named queue that is not capturing.
+    const std::optional<MeshTraceId> recording_trace_id =
+        trace_capture_cq != nullptr ? trace_capture_cq->trace_id() : std::nullopt;
 
     {
         // Push all pages of this call under one lock so they stay contiguous and ordered
@@ -988,7 +993,7 @@ void TensorPrefetcherManager::replay_trace(const MeshTraceId& trace_id) {
 }
 
 void TensorPrefetcherManager::enqueue_cq_signal_and_wait(
-    uint8_t cq_id, const std::optional<MeshCoordinateRangeSet>& device_subset) {
+    MeshCommandQueue& cq, const std::optional<MeshCoordinateRangeSet>& device_subset) {
     // Hold the API lock across this whole call. Three things must be atomic together:
     //   1. the counter bump (++cq_signal_counter_[cq_id]),
     //   2. the dispatcher write that pushes that value to the device, and
@@ -1003,8 +1008,12 @@ void TensorPrefetcherManager::enqueue_cq_signal_and_wait(
     auto lock = lock_api_function_();
     TT_FATAL(active_, "WaitForCqOnTensorPrefetcher called before StartTensorPrefetcher");
     TT_FATAL(
+        cq.device() == mesh_device_,
+        "WaitForCqOnTensorPrefetcher command queue belongs to a different mesh device than the prefetcher");
+    const uint32_t cq_id = cq.id();
+    TT_FATAL(
         cq_id < cq_signal_counter_.size(),
-        "WaitForCqOnTensorPrefetcher cq_id ({}) out of range [0, {})",
+        "WaitForCqOnTensorPrefetcher command queue id ({}) out of range [0, {})",
         cq_id,
         cq_signal_counter_.size());
 
@@ -1047,7 +1056,9 @@ void TensorPrefetcherManager::enqueue_cq_signal_and_wait(
 
     // (a) Dispatcher write: bump every target DRAM core's signal slot for this CQ. Runs
     // under the api lock we already hold (the method does not re-lock).
-    mesh_device_->impl().mesh_command_queue_base(cq_id).enqueue_write_dram_core_counter(
+    auto* cq_base = dynamic_cast<MeshCommandQueueBase*>(&cq);
+    TT_FATAL(cq_base != nullptr, "MeshCommandQueue is not a MeshCommandQueueBase");
+    cq_base->enqueue_write_dram_core_counter(
         ttsl::Span<const DeviceMemoryAddress>(targets), signal_value, /*blocking=*/false);
 
     // (b) Queue a WAIT_CQ request. It rides the same async worker path as prefetch
@@ -1061,7 +1072,7 @@ void TensorPrefetcherManager::enqueue_cq_signal_and_wait(
     req.sender_pages.assign(1, std::vector<uint8_t>(page_bytes, 0));
     auto* header = reinterpret_cast<TensorPrefetcherRequestHeader*>(req.sender_pages[0].data());
     header->base.cmd_id = DRAM_PREFETCHER_CMD_WAIT_CQ;
-    header->wait_cq.cq_index = cq_id;
+    header->wait_cq.cq_index = static_cast<uint8_t>(cq_id);
     header->wait_cq.cq_wait_value = signal_value;
     req.target_devices = std::move(target_devices);
 
@@ -1232,17 +1243,17 @@ void QueueTensorPrefetcherRequest(
     const GlobalCircularBuffer& gcb,
     const std::optional<distributed::MeshCoordinateRangeSet>& device_subset,
     const std::vector<TensorPrefetcherInput>& input_tensors,
-    std::optional<uint8_t> cq_id) {
+    distributed::MeshCommandQueue* trace_capture_cq) {
     auto& manager = mesh_device.impl().tensor_prefetcher(&mesh_device);
-    manager.queue(gcb, device_subset, input_tensors, cq_id);
+    manager.queue(gcb, device_subset, input_tensors, trace_capture_cq);
 }
 
 void WaitForCqOnTensorPrefetcher(
-    distributed::MeshDevice& mesh_device,
-    uint8_t cq_id,
-    const std::optional<distributed::MeshCoordinateRangeSet>& device_subset) {
-    auto& manager = mesh_device.impl().tensor_prefetcher(&mesh_device);
-    manager.enqueue_cq_signal_and_wait(cq_id, device_subset);
+    distributed::MeshCommandQueue& cq, const std::optional<distributed::MeshCoordinateRangeSet>& device_subset) {
+    auto* mesh_device = cq.device();
+    TT_FATAL(mesh_device != nullptr, "WaitForCqOnTensorPrefetcher command queue has no mesh device");
+    auto& manager = mesh_device->impl().tensor_prefetcher(mesh_device);
+    manager.enqueue_cq_signal_and_wait(cq, device_subset);
 }
 
 void StopTensorPrefetcher(distributed::MeshDevice& mesh_device) {

--- a/tt_metal/impl/buffers/tensor_prefetcher_manager.hpp
+++ b/tt_metal/impl/buffers/tensor_prefetcher_manager.hpp
@@ -80,11 +80,9 @@ public:
 
     void start();
 
-    // When `trace_capture_cq` is non-null and mid trace-capture, the serialized request pages
-    // are captured into trace_requests_ keyed by that trace's MeshTraceId instead of being sent
-    // immediately; they are (re)sent on every replay_trace() of that trace. Otherwise — a
-    // non-capturing queue, or a null `trace_capture_cq` — the pages are queued for immediate
-    // fan-out. A non-null queue must belong to this manager's mesh device.
+    // Capture-vs-send contract, and the `trace_capture_cq` precondition: see
+    // QueueTensorPrefetcherRequest. Captured pages live in trace_requests_ keyed by the
+    // recording trace's MeshTraceId, and are re-queued by replay_trace().
     void queue(
         const experimental::GlobalCircularBuffer& gcb,
         const std::optional<MeshCoordinateRangeSet>& device_subset,

--- a/tt_metal/impl/buffers/tensor_prefetcher_manager.hpp
+++ b/tt_metal/impl/buffers/tensor_prefetcher_manager.hpp
@@ -34,6 +34,7 @@ class Program;
 
 namespace distributed {
 
+class MeshCommandQueue;
 class MeshDevice;
 
 // Long-lived Tensor prefetcher (DRISC) for a single MeshDevice. Holds the
@@ -79,16 +80,16 @@ public:
 
     void start();
 
-    // When `cq_id`'s command queue is mid trace-capture, the serialized request pages are
-    // captured into trace_requests_ keyed by that trace's MeshTraceId instead of being sent
-    // immediately; they are (re)sent on every replay_trace() of that trace. Otherwise the
-    // pages are queued for immediate fan-out. `cq_id` == std::nullopt resolves to the
-    // current/default command queue (see MeshDevice::mesh_command_queue).
+    // When `trace_capture_cq` is non-null and mid trace-capture, the serialized request pages
+    // are captured into trace_requests_ keyed by that trace's MeshTraceId instead of being sent
+    // immediately; they are (re)sent on every replay_trace() of that trace. Otherwise — a
+    // non-capturing queue, or a null `trace_capture_cq` — the pages are queued for immediate
+    // fan-out. A non-null queue must belong to this manager's mesh device.
     void queue(
         const experimental::GlobalCircularBuffer& gcb,
         const std::optional<MeshCoordinateRangeSet>& device_subset,
         const std::vector<experimental::TensorPrefetcherInput>& tensors,
-        std::optional<uint8_t> cq_id = std::nullopt);
+        MeshCommandQueue* trace_capture_cq);
 
     // Re-queue every request captured under `trace_id` for immediate fan-out. No-op if no
     // prefetcher requests were captured during that trace's capture. Called from the trace
@@ -99,13 +100,14 @@ public:
     void release_trace(const MeshTraceId& trace_id);
 
     // Make the prefetcher wait until all work currently enqueued on command queue
-    // `cq_id` has landed before it reads DRAM. Bumps a host-side per-CQ counter,
+    // `cq` has landed before it reads DRAM. Bumps a host-side per-CQ counter,
     // has the dispatcher write the new value into every DRAM core's signal slot
     // (ordered after prior CQ work), and queues a WAIT_CQ request so each kernel
     // blocks until that value is observed. Must be called synchronously on the
     // host thread that enqueues the data writes (after them, before the dependent
-    // prefetch request).
-    void enqueue_cq_signal_and_wait(uint8_t cq_id, const std::optional<MeshCoordinateRangeSet>& device_subset);
+    // prefetch request). `cq` must belong to this manager's mesh device, and its id
+    // must be within [0, kNumCqSignalSlots).
+    void enqueue_cq_signal_and_wait(MeshCommandQueue& cq, const std::optional<MeshCoordinateRangeSet>& device_subset);
 
     void stop();
 
@@ -169,7 +171,7 @@ private:
     // across all sender cores. Carved at the front of the kernel working region.
     uint32_t cq_signal_l1_addr_ = 0;
     // Host-side monotonic signal counter per command queue. enqueue_cq_signal_and_wait
-    // pre-increments cq_signal_counter_[cq_id] and uses it for both the dispatcher
+    // pre-increments cq_signal_counter_[cq.id()] and uses it for both the dispatcher
     // write and the WAIT_CQ request value.
     std::array<uint32_t, kNumCqSignalSlots> cq_signal_counter_{};
 

--- a/tt_metal/impl/buffers/tensor_prefetcher_manager.hpp
+++ b/tt_metal/impl/buffers/tensor_prefetcher_manager.hpp
@@ -168,6 +168,12 @@ private:
     // Base (local DRISC L1) of this prefetcher's per-CQ signal slots; uniform
     // across all sender cores. Carved at the front of the kernel working region.
     uint32_t cq_signal_l1_addr_ = 0;
+    // Distance between consecutive signal slots. The slots hold one uint32 each but are
+    // spaced a full L1 alignment apart: each is the destination of its own dispatcher
+    // write, and a dispatch write only lands on an L1-aligned address. Packed 4 bytes
+    // apart, every slot but the first would be misaligned and its write would go nowhere,
+    // leaving the kernel spinning on a WAIT_CQ that is never satisfied.
+    uint32_t cq_signal_slot_stride_ = 0;
     // Host-side monotonic signal counter per command queue. enqueue_cq_signal_and_wait
     // pre-increments cq_signal_counter_[cq.id()] and uses it for both the dispatcher
     // write and the WAIT_CQ request value.

--- a/ttnn/cpp/ttnn/operations/experimental/tensor_prefetcher/tensor_prefetcher.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/tensor_prefetcher/tensor_prefetcher.cpp
@@ -6,6 +6,7 @@
 
 #include <tt-metalium/experimental/tensor_prefetcher.hpp>
 #include <tt-metalium/experimental/tensor/mesh_tensor.hpp>
+#include <tt-metalium/mesh_device.hpp>
 
 namespace ttnn::operations::experimental {
 
@@ -22,7 +23,7 @@ void queue_tensor_prefetcher_request(
     const std::vector<TensorPrefetcherQueueTensor>& tensors,
     const tt::tt_metal::experimental::GlobalCircularBuffer& global_cb,
     const std::optional<tt::tt_metal::distributed::MeshCoordinateRangeSet>& device_subset,
-    std::optional<uint8_t> cq_id) {
+    bool capture_into_trace) {
     std::vector<tt::tt_metal::experimental::TensorPrefetcherInput> inputs;
     inputs.reserve(tensors.size());
     for (const auto& item : tensors) {
@@ -36,14 +37,29 @@ void queue_tensor_prefetcher_request(
             inputs.push_back({tensor.mesh_tensor(), block_count, rotation});
         }
     }
-    tt::tt_metal::experimental::QueueTensorPrefetcherRequest(*mesh_device, global_cb, device_subset, inputs, cq_id);
+    // The command queue to consider is always the calling thread's current one: ttnn's
+    // FastOperation wrapper consumes a `cq_id`/`queue_id` keyword before this function is
+    // reached and applies it by pushing that queue as the thread's current one (see
+    // ttnn/ttnn/decorators.py), which is also what ttnn.command_queue(n) does. So the
+    // caller-visible knob here is whether to consider a queue at all: with
+    // capture_into_trace false we hand metal no queue, and the request is sent immediately
+    // even if that queue is mid trace-capture.
+    tt::tt_metal::experimental::QueueTensorPrefetcherRequest(
+        *mesh_device,
+        global_cb,
+        device_subset,
+        inputs,
+        capture_into_trace ? &mesh_device->mesh_command_queue() : nullptr);
 }
 
 void wait_for_cq_on_tensor_prefetcher(
     tt::tt_metal::distributed::MeshDevice* mesh_device,
-    uint8_t cq_id,
+    std::optional<uint8_t> cq_id,
     const std::optional<tt::tt_metal::distributed::MeshCoordinateRangeSet>& device_subset) {
-    tt::tt_metal::experimental::WaitForCqOnTensorPrefetcher(*mesh_device, cq_id, device_subset);
+    // std::nullopt fences the calling thread's current queue. That covers the keyword form
+    // too: ttnn's FastOperation wrapper consumes a `cq_id=` keyword and applies it by making
+    // that queue current (ttnn/ttnn/decorators.py), so it never arrives here as a value.
+    tt::tt_metal::experimental::WaitForCqOnTensorPrefetcher(mesh_device->mesh_command_queue(cq_id), device_subset);
 }
 
 void stop_tensor_prefetcher(tt::tt_metal::distributed::MeshDevice* mesh_device) {

--- a/ttnn/cpp/ttnn/operations/experimental/tensor_prefetcher/tensor_prefetcher.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/tensor_prefetcher/tensor_prefetcher.cpp
@@ -37,13 +37,11 @@ void queue_tensor_prefetcher_request(
             inputs.push_back({tensor.mesh_tensor(), block_count, rotation});
         }
     }
-    // The command queue to consider is always the calling thread's current one: ttnn's
-    // FastOperation wrapper consumes a `cq_id`/`queue_id` keyword before this function is
-    // reached and applies it by pushing that queue as the thread's current one (see
-    // ttnn/ttnn/decorators.py), which is also what ttnn.command_queue(n) does. So the
-    // caller-visible knob here is whether to consider a queue at all: with
-    // capture_into_trace false we hand metal no queue, and the request is sent immediately
-    // even if that queue is mid trace-capture.
+    // There is no cq_id parameter to consult: a `cq_id`/`queue_id` keyword is consumed by
+    // ttnn's operation wrapper before this function runs, and applied by making that queue
+    // the thread's current one. So the knob left here is whether to consider a queue at all
+    // — with capture_into_trace false we hand metal no queue, and the request is sent
+    // immediately even mid trace-capture.
     tt::tt_metal::experimental::QueueTensorPrefetcherRequest(
         *mesh_device,
         global_cb,
@@ -56,11 +54,10 @@ void wait_for_cq_on_tensor_prefetcher(
     tt::tt_metal::distributed::MeshDevice* mesh_device,
     std::optional<uint8_t> cq_id,
     const std::optional<tt::tt_metal::distributed::MeshCoordinateRangeSet>& device_subset) {
-    // A positional cq_id arrives here as a value and names the queue directly. A keyword
-    // cq_id= does not: ttnn's FastOperation wrapper pops it and applies it by making that
-    // queue current for the call (ttnn/ttnn/decorators.py), leaving std::nullopt here.
-    // Resolving std::nullopt to the thread's current queue is what makes the two forms agree
-    // — as a plain `uint8_t cq_id = 0` the keyword form silently fenced queue 0 instead.
+    // cq_id must stay optional, not `uint8_t = 0`: only the positional form reaches here as a
+    // value, since a keyword cq_id= is consumed by the wrapper and applied by making that
+    // queue current. Resolving nullopt to the thread's current queue is what makes the two
+    // forms agree; defaulting to 0 would silently fence queue 0 for the keyword form.
     tt::tt_metal::experimental::WaitForCqOnTensorPrefetcher(mesh_device->mesh_command_queue(cq_id), device_subset);
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/tensor_prefetcher/tensor_prefetcher.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/tensor_prefetcher/tensor_prefetcher.cpp
@@ -56,9 +56,11 @@ void wait_for_cq_on_tensor_prefetcher(
     tt::tt_metal::distributed::MeshDevice* mesh_device,
     std::optional<uint8_t> cq_id,
     const std::optional<tt::tt_metal::distributed::MeshCoordinateRangeSet>& device_subset) {
-    // std::nullopt fences the calling thread's current queue. That covers the keyword form
-    // too: ttnn's FastOperation wrapper consumes a `cq_id=` keyword and applies it by making
-    // that queue current (ttnn/ttnn/decorators.py), so it never arrives here as a value.
+    // A positional cq_id arrives here as a value and names the queue directly. A keyword
+    // cq_id= does not: ttnn's FastOperation wrapper pops it and applies it by making that
+    // queue current for the call (ttnn/ttnn/decorators.py), leaving std::nullopt here.
+    // Resolving std::nullopt to the thread's current queue is what makes the two forms agree
+    // — as a plain `uint8_t cq_id = 0` the keyword form silently fenced queue 0 instead.
     tt::tt_metal::experimental::WaitForCqOnTensorPrefetcher(mesh_device->mesh_command_queue(cq_id), device_subset);
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/tensor_prefetcher/tensor_prefetcher.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/tensor_prefetcher/tensor_prefetcher.hpp
@@ -64,8 +64,7 @@ void start_tensor_prefetcher(tt::tt_metal::distributed::MeshDevice* mesh_device)
 // `capture_into_trace` selects whether this request may be captured into a trace: when true
 // and the calling thread's current command queue is mid trace-capture, the request is captured
 // and re-sent on every execute_trace of that trace; when false the request is always sent
-// immediately. Which queue that is follows ttnn's usual convention (a `cq_id`/`queue_id`
-// keyword, or ttnn.command_queue(n)) — see the note in the .cpp.
+// immediately.
 void queue_tensor_prefetcher_request(
     tt::tt_metal::distributed::MeshDevice* mesh_device,
     const std::vector<TensorPrefetcherQueueTensor>& tensors,

--- a/ttnn/cpp/ttnn/operations/experimental/tensor_prefetcher/tensor_prefetcher.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/tensor_prefetcher/tensor_prefetcher.hpp
@@ -40,13 +40,17 @@ using TensorPrefetcherQueueTensor =
 //        is per-GCB (read from each GCB's sender state block on every
 //        request), so a single prefetcher can serve GCBs with different
 //        num_receivers values.
-//   2. queue_tensor_prefetcher_request(device, tensors, global_cb, device_subset=None)
+//   2. queue_tensor_prefetcher_request(device, tensors, global_cb, device_subset=None,
+//                                      cq_id=None)
 //      - Push one request. `tensors` is the full, flattened list of weights (at
 //        least one), streamed in list order; each item is (weight, block_count)
 //        or (weight, block_count, rotation) (see TensorPrefetcherQueueTensor).
 //        block_count is the number of K-blocks to divide that tensor's K
 //        dimension into. Pass distinct tensors for distinct layers, or repeat a
-//        tensor to replay it. device_subset defaults to the full mesh.
+//        tensor to replay it. device_subset defaults to the full mesh. Set
+//        capture_into_trace=True to let the request be captured into a trace being
+//        recorded on the current command queue; by default it is always sent
+//        immediately and never captured.
 //   3. stop_tensor_prefetcher(device)
 //      - Sends the stop sentinel, joins the worker, waits for the kernels
 //        to exit. Caller must call this before destroying the device.
@@ -57,20 +61,25 @@ bool is_tensor_prefetcher_supported(tt::tt_metal::distributed::MeshDevice* mesh_
 
 void start_tensor_prefetcher(tt::tt_metal::distributed::MeshDevice* mesh_device);
 
+// `capture_into_trace` selects whether this request may be captured into a trace: when true
+// and the calling thread's current command queue is mid trace-capture, the request is captured
+// and re-sent on every execute_trace of that trace; when false the request is always sent
+// immediately. Which queue that is follows ttnn's usual convention (a `cq_id`/`queue_id`
+// keyword, or ttnn.command_queue(n)) — see the note in the .cpp.
 void queue_tensor_prefetcher_request(
     tt::tt_metal::distributed::MeshDevice* mesh_device,
     const std::vector<TensorPrefetcherQueueTensor>& tensors,
     const tt::tt_metal::experimental::GlobalCircularBuffer& global_cb,
     const std::optional<tt::tt_metal::distributed::MeshCoordinateRangeSet>& device_subset = std::nullopt,
-    std::optional<uint8_t> cq_id = std::nullopt);
+    bool capture_into_trace = false);
 
-// Fence the prefetcher against command queue `cq_id`: every prefetch request queued
-// after this call waits until all work previously enqueued on `cq_id` has completed
-// on device before the prefetcher reads DRAM. Call after the data writes and before
-// the dependent queue_tensor_prefetcher_request.
+// Fence the prefetcher against a command queue: every prefetch request queued after this
+// call waits until all work previously enqueued on that queue has completed on device before
+// the prefetcher reads DRAM. Call after the data writes and before the dependent
+// queue_tensor_prefetcher_request. `cq_id` defaults to the calling thread's current queue.
 void wait_for_cq_on_tensor_prefetcher(
     tt::tt_metal::distributed::MeshDevice* mesh_device,
-    uint8_t cq_id,
+    std::optional<uint8_t> cq_id = std::nullopt,
     const std::optional<tt::tt_metal::distributed::MeshCoordinateRangeSet>& device_subset = std::nullopt);
 
 void stop_tensor_prefetcher(tt::tt_metal::distributed::MeshDevice* mesh_device);

--- a/ttnn/cpp/ttnn/operations/experimental/tensor_prefetcher/tensor_prefetcher.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/tensor_prefetcher/tensor_prefetcher.hpp
@@ -41,7 +41,7 @@ using TensorPrefetcherQueueTensor =
 //        request), so a single prefetcher can serve GCBs with different
 //        num_receivers values.
 //   2. queue_tensor_prefetcher_request(device, tensors, global_cb, device_subset=None,
-//                                      cq_id=None)
+//                                      capture_into_trace=False)
 //      - Push one request. `tensors` is the full, flattened list of weights (at
 //        least one), streamed in list order; each item is (weight, block_count)
 //        or (weight, block_count, rotation) (see TensorPrefetcherQueueTensor).

--- a/ttnn/cpp/ttnn/operations/experimental/tensor_prefetcher/tensor_prefetcher_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/tensor_prefetcher/tensor_prefetcher_nanobind.cpp
@@ -85,10 +85,13 @@ void bind_tensor_prefetcher(nb::module_& mod) {
                     ttnn.experimental.create_global_circular_buffer_for_tensor_prefetcher).
                 device_subset (Optional[MeshCoordinateRangeSet]): subset of the mesh that
                     processes this request. Defaults to the full mesh.
-                cq_id (Optional[int]): command queue that may be recording a trace. When that
-                    CQ is mid trace-capture, the request is captured into the trace instead of
-                    being sent immediately, and is re-sent on every execute_trace of that trace.
-                    Defaults to the current/default command queue.
+                capture_into_trace (bool): whether this request may be captured into a trace.
+                    When True and the current command queue is mid trace-capture, the request
+                    is captured into the trace instead of being sent immediately, and is
+                    re-sent on every execute_trace of that trace. Defaults to False: the
+                    request is always sent immediately and is never captured, whatever any
+                    command queue is doing. Which queue counts as current follows the usual
+                    ttnn convention — pass cq_id=n, or wrap the call in ttnn.command_queue(n).
 
             Returns:
                 None
@@ -99,7 +102,7 @@ void bind_tensor_prefetcher(nb::module_& mod) {
         nb::arg("global_cb"),
         nb::kw_only(),
         nb::arg("device_subset") = std::nullopt,
-        nb::arg("cq_id") = std::nullopt);
+        nb::arg("capture_into_trace") = false);
 
     ttnn::bind_function<"wait_for_cq_on_tensor_prefetcher", "ttnn.experimental.">(
         mod,
@@ -115,7 +118,8 @@ void bind_tensor_prefetcher(nb::module_& mod) {
 
             Args:
                 mesh_device (ttnn.MeshDevice): the mesh device whose prefetcher to fence.
-                cq_id (int): the command queue to fence against.
+                cq_id (Optional[int]): the command queue to fence against. Defaults to the
+                    calling thread's current queue (also what ttnn.command_queue(n) sets).
                 device_subset (Optional[MeshCoordinateRangeSet]): subset of the mesh to
                     fence. Defaults to the full mesh.
 
@@ -124,7 +128,7 @@ void bind_tensor_prefetcher(nb::module_& mod) {
         )doc",
         &wait_for_cq_on_tensor_prefetcher,
         nb::arg("mesh_device"),
-        nb::arg("cq_id") = 0,
+        nb::arg("cq_id") = std::nullopt,
         nb::kw_only(),
         nb::arg("device_subset") = std::nullopt);
 

--- a/ttnn/ttnn/_experimental/tensor_prefetcher_matmul.py
+++ b/ttnn/ttnn/_experimental/tensor_prefetcher_matmul.py
@@ -20,14 +20,10 @@ per receiver and requires a receiver-contiguous weight.
 
 This is a host-side composition, not a device-level fusion: the prefetch still
 runs on the DRAM-core (DRISC) path off the command queue while the matmul is
-dispatched normally. Both halves act on the calling thread's current command
-queue, and ``queue_id``/``cq_id`` here selects it for the pair at once: the
-prefetch opts into capture (``capture_into_trace=True``) against that queue, and
-the matmul dispatches on it, so a call inside a capture region captures -- and
-replays -- both halves together. Taking the argument here rather than letting it
-fall through ``**linear_kwargs`` is what keeps the pair together: ttnn's operation
-decorator honours ``queue_id``/``cq_id`` on any op (it applies them by making that
-queue current), so a passed-through ``cq_id`` would have steered the matmul alone.
+dispatched normally. ``queue_id``/``cq_id`` is named here, rather than left to fall
+through ``**linear_kwargs``, so that it steers both halves: forwarded to only the
+matmul it would leave the prefetch on whatever queue was already current, and a
+capture region would then capture the halves apart.
 """
 
 import ttnn
@@ -60,7 +56,7 @@ def prefetch_and_linear(
         queue_id: Command queue for both halves -- the prefetch is captured against it
             (when it is recording a trace) and the matmul dispatches on it. Defaults to
             the calling thread's current queue, as set by ``ttnn.command_queue(n)``.
-        cq_id: Alias for ``queue_id``, accepted because ttnn operations take either.
+        cq_id: Alias for ``queue_id``, accepted because ttnn operations take either;
             ``queue_id`` wins if both are given, matching ttnn's own precedence.
         **linear_kwargs: Forwarded to ``ttnn.linear`` (e.g. ``memory_config``,
             ``compute_kernel_config``, ``dtype``, ``bias``).
@@ -84,28 +80,25 @@ def prefetch_and_linear(
         request = (weight, block_count, list(range(block_count)))
     else:
         request = (weight, block_count)
-    # queue_id wins over cq_id, matching the precedence in ttnn's operation decorator -- which
-    # is also what applies it: both calls below are ttnn operations, so each one makes this
-    # queue current for its own duration. Forwarding it to both is the whole point of taking
-    # the argument here; reaching ttnn.linear alone (as it would through **linear_kwargs) would
-    # steer the matmul and leave the prefetch on whatever queue was already current.
-    selected_cq_id = queue_id if queue_id is not None else cq_id
+    # queue_id wins, matching the precedence in ttnn's operation decorator -- which is also
+    # what applies it: both calls below are ttnn operations, so each makes this queue current
+    # for its own duration.
+    cq_id = queue_id if queue_id is not None else cq_id
     ttnn.experimental.queue_tensor_prefetcher_request(
         device,
         [request],
         global_cb=global_cb,
-        # Let the prefetch be captured against the queue the matmul below dispatches on: under
-        # trace capture both halves land in the one trace and replay together. Leaving this
-        # False would capture the matmul but send the prefetch immediately, so a replay would
-        # never refill the GCB and the matmul would hang.
+        # Capture against the queue the matmul below dispatches on, so both halves land in the
+        # one trace. Left False, a capture region would take the matmul but send the prefetch
+        # immediately -- a replay would never refill the GCB and the matmul would hang.
         capture_into_trace=True,
-        cq_id=selected_cq_id,
+        cq_id=cq_id,
     )
     return ttnn.linear(
         input_tensor_a,
         weight,
         program_config=program_config,
         global_cb=global_cb,
-        cq_id=selected_cq_id,
+        cq_id=cq_id,
         **linear_kwargs,
     )

--- a/ttnn/ttnn/_experimental/tensor_prefetcher_matmul.py
+++ b/ttnn/ttnn/_experimental/tensor_prefetcher_matmul.py
@@ -20,10 +20,10 @@ per receiver and requires a receiver-contiguous weight.
 
 This is a host-side composition, not a device-level fusion: the prefetch still
 runs on the DRAM-core (DRISC) path off the command queue while the matmul is
-dispatched normally. ``queue_id``/``cq_id`` is named here, rather than left to fall
-through ``**linear_kwargs``, so that it steers both halves: forwarded to only the
-matmul it would leave the prefetch on whatever queue was already current, and a
-capture region would then capture the halves apart.
+dispatched normally. A ``queue_id``/``cq_id`` in ``**linear_kwargs`` still reaches
+``ttnn.linear``, but is read out here as well so that it steers both halves: applied
+to only the matmul it would leave the prefetch on whatever queue was already current,
+and a capture region would then capture the halves apart.
 """
 
 import ttnn
@@ -35,8 +35,6 @@ def prefetch_and_linear(
     *,
     global_cb,
     program_config,
-    queue_id=None,
-    cq_id=None,
     **linear_kwargs,
 ):
     """Queue a DRAM-core prefetch of ``weight`` into ``global_cb``, then run the
@@ -53,13 +51,13 @@ def prefetch_and_linear(
         global_cb: DRAM-sender GlobalCircularBuffer shared by the prefetch and
             the matmul.
         program_config: 1D matmul program config driving the matmul.
-        queue_id: Command queue for both halves -- the prefetch is captured against it
-            (when it is recording a trace) and the matmul dispatches on it. Defaults to
-            the calling thread's current queue, as set by ``ttnn.command_queue(n)``.
-        cq_id: Alias for ``queue_id``, accepted because ttnn operations take either;
-            ``queue_id`` wins if both are given, matching ttnn's own precedence.
         **linear_kwargs: Forwarded to ``ttnn.linear`` (e.g. ``memory_config``,
-            ``compute_kernel_config``, ``dtype``, ``bias``).
+            ``compute_kernel_config``, ``dtype``, ``bias``). A ``queue_id``/``cq_id``
+            here steers both halves -- the prefetch is captured against that queue (when
+            it is recording a trace) and the matmul dispatches on it -- and defaults to
+            the calling thread's current queue, as set by ``ttnn.command_queue(n)``.
+            Either spelling is accepted, as for any ttnn operation; ``queue_id`` wins if
+            both are given, matching ttnn's own precedence.
 
     Returns:
         The ``ttnn.linear`` output tensor.
@@ -80,10 +78,16 @@ def prefetch_and_linear(
         request = (weight, block_count, list(range(block_count)))
     else:
         request = (weight, block_count)
-    # queue_id wins, matching the precedence in ttnn's operation decorator -- which is also
-    # what applies it: both calls below are ttnn operations, so each makes this queue current
-    # for its own duration.
-    cq_id = queue_id if queue_id is not None else cq_id
+    # Read (not popped) out of the kwargs the way ttnn's own operation wrapper resolves it
+    # -- FastOperation.__call__ in ttnn/decorators.py picks on the keyword being present, not
+    # on its value, so an explicit queue_id=None wins over a cq_id rather than falling through
+    # to it. Only the prefetch half needs it named here; the keyword itself stays in
+    # linear_kwargs and reaches ttnn.linear as the caller wrote it.
+    cq_id = None
+    if "queue_id" in linear_kwargs:
+        cq_id = linear_kwargs["queue_id"]
+    elif "cq_id" in linear_kwargs:
+        cq_id = linear_kwargs["cq_id"]
     ttnn.experimental.queue_tensor_prefetcher_request(
         device,
         [request],
@@ -99,6 +103,5 @@ def prefetch_and_linear(
         weight,
         program_config=program_config,
         global_cb=global_cb,
-        cq_id=cq_id,
         **linear_kwargs,
     )

--- a/ttnn/ttnn/_experimental/tensor_prefetcher_matmul.py
+++ b/ttnn/ttnn/_experimental/tensor_prefetcher_matmul.py
@@ -30,8 +30,6 @@ decorator honours ``queue_id``/``cq_id`` on any op (it applies them by making th
 queue current), so a passed-through ``cq_id`` would have steered the matmul alone.
 """
 
-from contextlib import nullcontext
-
 import ttnn
 
 
@@ -86,25 +84,28 @@ def prefetch_and_linear(
         request = (weight, block_count, list(range(block_count)))
     else:
         request = (weight, block_count)
-    # queue_id wins over cq_id, as in ttnn's operation decorator. Making the queue current
-    # for the whole block is what ties the two halves to it -- both read the thread's current
-    # queue, so neither can end up on a different one.
+    # queue_id wins over cq_id, matching the precedence in ttnn's operation decorator -- which
+    # is also what applies it: both calls below are ttnn operations, so each one makes this
+    # queue current for its own duration. Forwarding it to both is the whole point of taking
+    # the argument here; reaching ttnn.linear alone (as it would through **linear_kwargs) would
+    # steer the matmul and leave the prefetch on whatever queue was already current.
     selected_cq_id = queue_id if queue_id is not None else cq_id
-    with ttnn.command_queue(selected_cq_id) if selected_cq_id is not None else nullcontext():
-        ttnn.experimental.queue_tensor_prefetcher_request(
-            device,
-            [request],
-            global_cb=global_cb,
-            # Let the prefetch be captured against the queue the matmul below dispatches on:
-            # under trace capture both halves land in the one trace and replay together.
-            # Leaving this False would capture the matmul but send the prefetch immediately,
-            # so a replay would never refill the GCB and the matmul would hang.
-            capture_into_trace=True,
-        )
-        return ttnn.linear(
-            input_tensor_a,
-            weight,
-            program_config=program_config,
-            global_cb=global_cb,
-            **linear_kwargs,
-        )
+    ttnn.experimental.queue_tensor_prefetcher_request(
+        device,
+        [request],
+        global_cb=global_cb,
+        # Let the prefetch be captured against the queue the matmul below dispatches on: under
+        # trace capture both halves land in the one trace and replay together. Leaving this
+        # False would capture the matmul but send the prefetch immediately, so a replay would
+        # never refill the GCB and the matmul would hang.
+        capture_into_trace=True,
+        cq_id=selected_cq_id,
+    )
+    return ttnn.linear(
+        input_tensor_a,
+        weight,
+        program_config=program_config,
+        global_cb=global_cb,
+        cq_id=selected_cq_id,
+        **linear_kwargs,
+    )

--- a/ttnn/ttnn/_experimental/tensor_prefetcher_matmul.py
+++ b/ttnn/ttnn/_experimental/tensor_prefetcher_matmul.py
@@ -20,10 +20,17 @@ per receiver and requires a receiver-contiguous weight.
 
 This is a host-side composition, not a device-level fusion: the prefetch still
 runs on the DRAM-core (DRISC) path off the command queue while the matmul is
-dispatched normally. The pairing does compose with trace capture -- pass the
-recording CQ as ``cq_id`` and the request is captured (and replayed) alongside
-the matmul.
+dispatched normally. Both halves act on the calling thread's current command
+queue, and ``queue_id``/``cq_id`` here selects it for the pair at once: the
+prefetch opts into capture (``capture_into_trace=True``) against that queue, and
+the matmul dispatches on it, so a call inside a capture region captures -- and
+replays -- both halves together. Taking the argument here rather than letting it
+fall through ``**linear_kwargs`` is what keeps the pair together: ttnn's operation
+decorator honours ``queue_id``/``cq_id`` on any op (it applies them by making that
+queue current), so a passed-through ``cq_id`` would have steered the matmul alone.
 """
+
+from contextlib import nullcontext
 
 import ttnn
 
@@ -34,6 +41,7 @@ def prefetch_and_linear(
     *,
     global_cb,
     program_config,
+    queue_id=None,
     cq_id=None,
     **linear_kwargs,
 ):
@@ -51,9 +59,11 @@ def prefetch_and_linear(
         global_cb: DRAM-sender GlobalCircularBuffer shared by the prefetch and
             the matmul.
         program_config: 1D matmul program config driving the matmul.
-        cq_id: Command queue for the prefetch request. When that CQ is mid
-            trace-capture the request is captured into the trace. Defaults to the
-            current command queue.
+        queue_id: Command queue for both halves -- the prefetch is captured against it
+            (when it is recording a trace) and the matmul dispatches on it. Defaults to
+            the calling thread's current queue, as set by ``ttnn.command_queue(n)``.
+        cq_id: Alias for ``queue_id``, accepted because ttnn operations take either.
+            ``queue_id`` wins if both are given, matching ttnn's own precedence.
         **linear_kwargs: Forwarded to ``ttnn.linear`` (e.g. ``memory_config``,
             ``compute_kernel_config``, ``dtype``, ``bias``).
 
@@ -76,16 +86,25 @@ def prefetch_and_linear(
         request = (weight, block_count, list(range(block_count)))
     else:
         request = (weight, block_count)
-    ttnn.experimental.queue_tensor_prefetcher_request(
-        device,
-        [request],
-        global_cb=global_cb,
-        cq_id=cq_id,
-    )
-    return ttnn.linear(
-        input_tensor_a,
-        weight,
-        program_config=program_config,
-        global_cb=global_cb,
-        **linear_kwargs,
-    )
+    # queue_id wins over cq_id, as in ttnn's operation decorator. Making the queue current
+    # for the whole block is what ties the two halves to it -- both read the thread's current
+    # queue, so neither can end up on a different one.
+    selected_cq_id = queue_id if queue_id is not None else cq_id
+    with ttnn.command_queue(selected_cq_id) if selected_cq_id is not None else nullcontext():
+        ttnn.experimental.queue_tensor_prefetcher_request(
+            device,
+            [request],
+            global_cb=global_cb,
+            # Let the prefetch be captured against the queue the matmul below dispatches on:
+            # under trace capture both halves land in the one trace and replay together.
+            # Leaving this False would capture the matmul but send the prefetch immediately,
+            # so a replay would never refill the GCB and the matmul would hang.
+            capture_into_trace=True,
+        )
+        return ttnn.linear(
+            input_tensor_a,
+            weight,
+            program_config=program_config,
+            global_cb=global_cb,
+            **linear_kwargs,
+        )


### PR DESCRIPTION
### PR Category

Cleanup, Bug fix

### Summary

`WaitForCqOnTensorPrefetcher` and `QueueTensorPrefetcherRequest` took a raw `uint8_t` / `std::optional<uint8_t> cq_id`, unlike the rest of Metalium — `distributed.hpp` (`EnqueueMeshWorkload`, `WriteShard`, `Finish`), `experimental/tensor/tensor_apis.hpp` and `experimental/core_subset_write` all pass `distributed::MeshCommandQueue&` and recover the device with `cq.device()`. Raw cq ids survive only where no queue object exists yet (thread-local resolution, trace begin/end).

```cpp
void QueueTensorPrefetcherRequest(
    distributed::MeshDevice& mesh_device,
    const GlobalCircularBuffer& gcb,
    const std::optional<distributed::MeshCoordinateRangeSet>& device_subset,
    const std::vector<TensorPrefetcherInput>& input_tensors,
    distributed::MeshCommandQueue* trace_capture_cq = nullptr);

void WaitForCqOnTensorPrefetcher(
    distributed::MeshCommandQueue& cq,
    const std::optional<distributed::MeshCoordinateRangeSet>& device_subset);
```

Passing the queue object also fills a functional gap and closes two silent-failure modes:

- **"No command queue" is now expressible.** A null `trace_capture_cq` means the request is never captured into a trace and is always sent immediately. Before, `std::nullopt` meant "the calling thread's current queue", so a caller on a thread that happened to be mid trace-capture had no way to ask for an immediate send.
- Both functions re-resolved the id through `MeshDeviceImpl::mesh_command_queue(_base)`, which silently returns `mesh_command_queues_[0]` on a mesh with no local devices. `enqueue_cq_signal_and_wait` still re-resolves by id — that is how it reaches the queue as a `MeshCommandQueueBase`, the interface exposing `enqueue_write_dram_core_counter` — but now `TT_FATAL`s that the lookup landed on the object it was handed, so the round trip is checked rather than argued.

`WaitForCqOnTensorPrefetcher` drops its `mesh_device` parameter, deriving it from `cq.device()`.

### Notes for reviewers

**The ttnn knob could not be `cq_id`, and that is the one non-obvious part of this PR.** `ttnn.decorators.FastOperation.__call__` (`ttnn/ttnn/decorators.py:635-653`) pops `cq_id`/`queue_id` out of kwargs for *every* registered ttnn op and applies it by pushing that queue as the thread's current one. `queue_tensor_prefetcher_request`'s `cq_id` is keyword-only, so it was always popped — the C++ layer has never received it. Trace capture worked purely because metal resolved `nullopt` to the thread-current queue.

Consequences, all reflected here:

- `queue_tensor_prefetcher_request` now takes `capture_into_trace: bool = False` instead of `cq_id`. *Which* queue is considered still follows the normal ttnn convention (`cq_id=n`, or `ttnn.command_queue(n)`); the new argument only decides whether a queue is consulted at all.
- `wait_for_cq_on_tensor_prefetcher`'s `cq_id` becomes `Optional[int] = None`. Its positional form always worked (positional args are not popped), but as a bare `uint8_t` defaulting to `0`, a keyword `cq_id=1` was eaten by the decorator and silently fenced queue 0. Resolving `nullopt` to the thread-current queue makes both forms correct.
- `prefetch_and_linear` takes `queue_id`/`cq_id` (`queue_id` wins, matching ttnn's precedence) and makes that queue current for both halves. This matters: `ttnn.linear` accepts those kwargs through the same decorator even though its C++ binding has no such parameter, so an argument passed through `**linear_kwargs` would have steered the matmul alone and split it from the prefetch that fills its GCB.

### Bug found while testing this: the fence never worked on cq != 0

Writing the `cq_id=1` coverage this PR was missing turned up a hang, fixed here in its own
commit. `WaitForCqOnTensorPrefetcher`'s per-CQ signal slots were packed 4 bytes apart, so slot
0 sat on an L1-aligned address and no other slot did. **A dispatch write to a non-L1-aligned
destination is silently dropped** — no host `TT_FATAL`, no device assert, not even in a Debug
build — so the counter for cq 1 never arrived and every DRISC sender spun in `WAIT_CQ` forever.
Fencing cq 0 was fine, which is why nothing caught it.

Isolated before fixing: the fence's own dispatch command completes (a `synchronize_device`
right after it returns in ~6 ms) while the DRISCs never advance, i.e. the write went out and
hit nothing. The slots are now one L1 alignment apart, indexed by that stride on both sides,
with the stride passed to the kernel as a compile-time arg. Costs 16 more bytes of the DRISC
kernel working region; FF1 ring=64 dual-sender, the tightest stage-ring case, still passes.

This is pre-existing on `main` — nothing in this PR touched that layout, and the positional
`cq_id` form always reached the C++ layer — so **this PR is no longer behavior-neutral.**

### Test coverage

The trace section's setup is now a `_TraceCase` harness shared by the existing
`trace_replay` test and the new ones. It holds one DRAM weight plus N sets of values that
`write_weight()` writes into it in place, which is what makes the capture-vs-send decision
observable: a request reads DRAM when the DRISC processes it, so overwriting the weight after
recording a trace tells you when the request went out — a held request replays the new values,
one sent during capture read the old ones. Both directions fail on PCC instead of starving a
matmul into a hang.

- `trace_capture_on_queue[cq_id=0,1]` — a capture-eligible request lands in the trace being
  recorded on the queue the caller named, on a non-default queue as much as on 0. Nothing in
  the suite ran two command queues before, so the `queue_id` → thread-current → capture chain
  was entirely untested.
- `request_not_captured_by_default` — at the binding default a request goes out immediately
  even mid-capture, and is not re-sent on replay. The tri-state `capture_into_trace` exists for.
- `wait_for_cq_queue_forms[cq_id=0,1 × positional,keyword,context]` — all three spellings fence
  the queue the weight was written on. The keyword and context forms are the ones the `nullopt`
  default fixed.
- `wait_for_cq_rejects_unknown_queue` — an unknown queue id raises instead of falling back to 0.

51/51 in `test_prefetcher_BH_tensor_large.py` and 30/30 in the validator suite on p150b.
Injecting each routing regression makes the two ordering tests fail with PCC ~0.005 / -0.001
and no hang.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jbauman/prefetcher-cq-object-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jbauman/prefetcher-cq-object-api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jbauman/prefetcher-cq-object-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jbauman/prefetcher-cq-object-api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=jbauman/prefetcher-cq-object-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:jbauman/prefetcher-cq-object-api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jbauman/prefetcher-cq-object-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jbauman/prefetcher-cq-object-api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jbauman/prefetcher-cq-object-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jbauman/prefetcher-cq-object-api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jbauman/prefetcher-cq-object-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jbauman/prefetcher-cq-object-api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jbauman/prefetcher-cq-object-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jbauman/prefetcher-cq-object-api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jbauman/prefetcher-cq-object-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jbauman/prefetcher-cq-object-api)
