### PR TITLE
Initialize reduce block max trigger semaphores in LLK test

### DIFF
--- a/tt_metal/tt-llk/tests/sources/reduce_block_max_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/reduce_block_max_test.cpp
@@ -277,8 +277,10 @@ void run_kernel(RUNTIME_PARAMETERS params)
     //   * UNPACK_MATH_DONE - the early first-half token (runtime overlap path only).
     if constexpr (RESPECT_TRIGGER)
     {
+        t6_semaphore_init(ckernel::semaphore::FPU_SFPU, 0, 1);
         if constexpr (USE_RUNTIME && OVERLAP_FIRST_HALF)
         {
+            t6_semaphore_init(ckernel::semaphore::UNPACK_MATH_DONE, 0, 1);
             t6_semaphore_post<>(ckernel::semaphore::UNPACK_MATH_DONE);
         }
         t6_semaphore_post<>(ckernel::semaphore::FPU_SFPU);


### PR DESCRIPTION
### PR Category
Test Only

### Summary
The `reduce_block_max` LLK trigger test posts the custom `FPU_SFPU` semaphore, and in the runtime overlap path also posts `UNPACK_MATH_DONE`, to model the pack-side half of the split-unpack trigger protocol. Those semaphores are outside the standard LLK sync setup, so they were not initialized before the test posted them; on WH this violates the T6 semaphore contract and fails with `tensix_sempost: sem=0 sem_max=0`. Initialize each trigger semaphore to `0..1` immediately before the test posts it, matching the explicit producer/consumer protocol already described by the test and avoiding any change to the normal non-trigger path.

### Notes for reviewers
none

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mcraighead/llk-seminit)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mcraighead/llk-seminit)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mcraighead/llk-seminit)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mcraighead/llk-seminit)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mcraighead/llk-seminit)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mcraighead/llk-seminit)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mcraighead/llk-seminit)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mcraighead/llk-seminit)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mcraighead/llk-seminit)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mcraighead/llk-seminit)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mcraighead/llk-seminit)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mcraighead/llk-seminit)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mcraighead/llk-seminit)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mcraighead/llk-seminit)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mcraighead/llk-seminit)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mcraighead/llk-seminit)