### PR TITLE
[Cleanup] MeshDeviceFixture simplification

### DIFF
--- a/tests/tt_metal/tt_metal/api/allocator/test_per_core_allocation.cpp
+++ b/tests/tt_metal/tt_metal/api/allocator/test_per_core_allocation.cpp
@@ -39,7 +39,6 @@ protected:
         for (const auto& [device_id, device] : id_to_device_) {
             devices_.push_back(device);
         }
-        this->num_devices_ = this->devices_.size();
         init_max_cbs();
     }
 

--- a/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_allocation.cpp
+++ b/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_allocation.cpp
@@ -85,7 +85,7 @@ void validate_cb_address(
 }
 
 TEST_F(MeshDeviceFixture, TensixTestCircularBuffersSequentiallyPlaced) {
-    for (unsigned int id = 0; id < num_devices_; id++) {
+    for (auto& device : this->devices_) {
         distributed::MeshWorkload workload;
         auto zero_coord = distributed::MeshCoordinate(0, 0);
         auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
@@ -99,7 +99,7 @@ TEST_F(MeshDeviceFixture, TensixTestCircularBuffersSequentiallyPlaced) {
         CoreRangeSet cr_set({cr});
 
         std::map<uint8_t, uint32_t> expected_addresses;
-        auto expected_cb_addr = devices_.at(id)->allocator()->get_base_allocator_addr(HalMemType::L1);
+        auto expected_cb_addr = device->allocator()->get_base_allocator_addr(HalMemType::L1);
         for (uint32_t cb_id = 0; cb_id < max_cbs_; cb_id++) {
             CircularBufferConfig config1 = CircularBufferConfig(cb_config.page_size, {{cb_id, cb_config.data_format}})
                                                .set_page_size(cb_id, cb_config.page_size);
@@ -112,12 +112,12 @@ TEST_F(MeshDeviceFixture, TensixTestCircularBuffersSequentiallyPlaced) {
 
         std::map<CoreCoord, std::map<uint8_t, uint32_t>> golden_addresses = {{core, expected_addresses}};
 
-        validate_cb_address(workload, this->devices_.at(id), cr_set, golden_addresses);
+        validate_cb_address(workload, device, cr_set, golden_addresses);
     }
 }
 
 TEST_F(MeshDeviceFixture, TensixTestCircularBufferSequentialAcrossAllCores) {
-    for (unsigned int id = 0; id < num_devices_; id++) {
+    for (auto& device : this->devices_) {
         distributed::MeshWorkload workload;
         auto zero_coord = distributed::MeshCoordinate(0, 0);
         auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
@@ -135,7 +135,7 @@ TEST_F(MeshDeviceFixture, TensixTestCircularBufferSequentialAcrossAllCores) {
 
         uint32_t max_num_cbs = 0;
         for (const auto& [core, num_cbs] : core_to_num_cbs) {
-            auto expected_cb_addr = devices_.at(id)->allocator()->get_base_allocator_addr(HalMemType::L1);
+            auto expected_cb_addr = device->allocator()->get_base_allocator_addr(HalMemType::L1);
             max_num_cbs = std::max(max_num_cbs, num_cbs);
             std::map<uint8_t, uint32_t> expected_addresses;
             for (uint32_t buffer_id = 0; buffer_id < num_cbs; buffer_id++) {
@@ -153,7 +153,7 @@ TEST_F(MeshDeviceFixture, TensixTestCircularBufferSequentialAcrossAllCores) {
         CoreRangeSet cr_set({cr});
 
         auto expected_multi_core_address =
-            devices_.at(id)->allocator()->get_base_allocator_addr(HalMemType::L1) + (max_num_cbs * cb_config.page_size);
+            device->allocator()->get_base_allocator_addr(HalMemType::L1) + (max_num_cbs * cb_config.page_size);
         uint32_t multicore_buffer_idx = max_cbs_ - 1;
         CircularBufferConfig config2 =
             CircularBufferConfig(cb_config.page_size, {{multicore_buffer_idx, cb_config.data_format}})
@@ -164,12 +164,12 @@ TEST_F(MeshDeviceFixture, TensixTestCircularBufferSequentialAcrossAllCores) {
         golden_addresses_per_core[core2][multicore_buffer_idx] = expected_multi_core_address;
 
         initialize_program(program_, cr_set);
-        validate_cb_address(workload, this->devices_.at(id), cr_set, golden_addresses_per_core);
+        validate_cb_address(workload, device, cr_set, golden_addresses_per_core);
     }
 }
 
 TEST_F(MeshDeviceFixture, TensixTestValidCircularBufferAddress) {
-    for (unsigned int id = 0; id < num_devices_; id++) {
+    for (auto& device : this->devices_) {
         distributed::MeshWorkload workload;
         auto zero_coord = distributed::MeshCoordinate(0, 0);
         auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
@@ -180,7 +180,7 @@ TEST_F(MeshDeviceFixture, TensixTestValidCircularBufferAddress) {
 
         auto buffer_size = cb_config.page_size;
         tt::tt_metal::InterleavedBufferConfig buff_config{
-            .device = this->devices_.at(id)->get_devices()[0],
+            .device = device->get_devices()[0],
             .size = buffer_size,
             .page_size = buffer_size,
             .buffer_type = tt::tt_metal::BufferType::L1};
@@ -213,13 +213,12 @@ TEST_F(MeshDeviceFixture, TensixTestValidCircularBufferAddress) {
         }
 
         initialize_program(program_, cr_set);
-        validate_cb_address(workload, this->devices_.at(id), cr_set, golden_addresses_per_core);
+        validate_cb_address(workload, device, cr_set, golden_addresses_per_core);
     }
 }
 
 TEST_F(MeshDeviceFixture, TensixTestCircularBuffersAndL1BuffersCollision) {
-    for (unsigned int id = 0; id < num_devices_; id++) {
-        auto& mesh_device = devices_.at(id);
+    for (auto& mesh_device : this->devices_) {
         auto& cq = mesh_device->mesh_command_queue();
         distributed::MeshWorkload workload;
         auto zero_coord = distributed::MeshCoordinate(0, 0);
@@ -266,7 +265,7 @@ TEST_F(MeshDeviceFixture, TensixTestCircularBuffersAndL1BuffersCollision) {
 }
 
 TEST_F(MeshDeviceFixture, TensixTestValidUpdateCircularBufferSize) {
-    for (unsigned int id = 0; id < num_devices_; id++) {
+    for (auto& device : this->devices_) {
         distributed::MeshWorkload workload;
         auto zero_coord = distributed::MeshCoordinate(0, 0);
         auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
@@ -283,7 +282,7 @@ TEST_F(MeshDeviceFixture, TensixTestValidUpdateCircularBufferSize) {
         const uint32_t core0_num_cbs = 2;
         std::map<CoreCoord, std::map<uint8_t, uint32_t>> golden_addresses_per_core;
         std::vector<CBHandle> cb_ids;
-        uint32_t l1_unreserved_base = devices_.at(id)->allocator()->get_base_allocator_addr(HalMemType::L1);
+        uint32_t l1_unreserved_base = device->allocator()->get_base_allocator_addr(HalMemType::L1);
         auto expected_cb_addr = l1_unreserved_base;
         for (uint32_t buffer_idx = 0; buffer_idx < core0_num_cbs; buffer_idx++) {
             CircularBufferConfig config1 =
@@ -295,20 +294,20 @@ TEST_F(MeshDeviceFixture, TensixTestValidUpdateCircularBufferSize) {
             expected_cb_addr += cb_config.page_size;
         }
 
-        validate_cb_address(workload, this->devices_.at(id), cr_set, golden_addresses_per_core);
+        validate_cb_address(workload, device, cr_set, golden_addresses_per_core);
 
         // Update size of the first CB
         UpdateCircularBufferTotalSize(program_, cb_ids[0], cb_config.page_size * 2);
         golden_addresses_per_core[core0][0] = l1_unreserved_base;
         golden_addresses_per_core[core0][1] = (l1_unreserved_base + (cb_config.page_size * 2));
 
-        validate_cb_address(workload, this->devices_.at(id), cr_set, golden_addresses_per_core);
+        validate_cb_address(workload, device, cr_set, golden_addresses_per_core);
     }
 }
 
 TEST_F(MeshDeviceFixture, TensixTestInvalidUpdateCircularBufferSize) {
-    for (unsigned int id = 0; id < num_devices_; id++) {
-        auto& cq = devices_.at(id)->mesh_command_queue();
+    for (auto& device : this->devices_) {
+        auto& cq = device->mesh_command_queue();
         distributed::MeshWorkload workload;
         auto zero_coord = distributed::MeshCoordinate(0, 0);
         auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
@@ -325,7 +324,7 @@ TEST_F(MeshDeviceFixture, TensixTestInvalidUpdateCircularBufferSize) {
         const uint32_t core0_num_cbs = 2;
         std::map<CoreCoord, std::map<uint8_t, uint32_t>> golden_addresses_per_core;
         std::vector<CBHandle> cb_ids;
-        auto expected_cb_addr = devices_.at(id)->allocator()->get_base_allocator_addr(HalMemType::L1);
+        auto expected_cb_addr = device->allocator()->get_base_allocator_addr(HalMemType::L1);
         for (uint32_t buffer_idx = 0; buffer_idx < core0_num_cbs; buffer_idx++) {
             CircularBufferConfig config1 =
                 CircularBufferConfig(cb_config.page_size, {{buffer_idx, cb_config.data_format}})
@@ -336,7 +335,7 @@ TEST_F(MeshDeviceFixture, TensixTestInvalidUpdateCircularBufferSize) {
             expected_cb_addr += cb_config.page_size;
         }
 
-        validate_cb_address(workload, this->devices_.at(id), cr_set, golden_addresses_per_core);
+        validate_cb_address(workload, device, cr_set, golden_addresses_per_core);
 
         // Update size of the first CB
         UpdateCircularBufferTotalSize(program_, cb_ids[0], cb_config.page_size / 2);
@@ -345,7 +344,7 @@ TEST_F(MeshDeviceFixture, TensixTestInvalidUpdateCircularBufferSize) {
 }
 
 TEST_F(MeshDeviceFixture, TensixTestUpdateCircularBufferAddress) {
-    for (unsigned int id = 0; id < num_devices_; id++) {
+    for (auto& device : this->devices_) {
         distributed::MeshWorkload workload;
         auto zero_coord = distributed::MeshCoordinate(0, 0);
         auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
@@ -359,7 +358,7 @@ TEST_F(MeshDeviceFixture, TensixTestUpdateCircularBufferAddress) {
 
         auto buffer_size = cb_config.page_size;
         tt::tt_metal::InterleavedBufferConfig buff_config{
-            .device = this->devices_.at(id)->get_devices()[0],
+            .device = device->get_devices()[0],
             .size = buffer_size,
             .page_size = buffer_size,
             .buffer_type = tt::tt_metal::BufferType::L1};
@@ -370,7 +369,7 @@ TEST_F(MeshDeviceFixture, TensixTestUpdateCircularBufferAddress) {
         const uint32_t core0_num_cbs = 2;
         std::map<CoreCoord, std::map<uint8_t, uint32_t>> golden_addresses_per_core;
         std::vector<CBHandle> cb_ids;
-        auto expected_cb_addr = devices_.at(id)->allocator()->get_base_allocator_addr(HalMemType::L1);
+        auto expected_cb_addr = device->allocator()->get_base_allocator_addr(HalMemType::L1);
         for (uint32_t buffer_idx = 0; buffer_idx < core0_num_cbs; buffer_idx++) {
             CircularBufferConfig config1 =
                 CircularBufferConfig(cb_config.page_size, {{buffer_idx, cb_config.data_format}})
@@ -381,16 +380,16 @@ TEST_F(MeshDeviceFixture, TensixTestUpdateCircularBufferAddress) {
             expected_cb_addr += cb_config.page_size;
         }
 
-        validate_cb_address(workload, this->devices_.at(id), cr_set, golden_addresses_per_core);
+        validate_cb_address(workload, device, cr_set, golden_addresses_per_core);
         // Update address of the first CB
         UpdateDynamicCircularBufferAddress(program_, cb_ids[0], *l1_buffer);
         golden_addresses_per_core[core0][0] = l1_buffer->address();
-        validate_cb_address(workload, this->devices_.at(id), cr_set, golden_addresses_per_core);
+        validate_cb_address(workload, device, cr_set, golden_addresses_per_core);
     }
 }
 
 TEST_F(MeshDeviceFixture, TensixTestUpdateCircularBufferAddressFromMeshTensor) {
-    for (unsigned int id = 0; id < num_devices_; id++) {
+    for (auto& mesh_device : this->devices_) {
         distributed::MeshWorkload workload;
         auto zero_coord = distributed::MeshCoordinate(0, 0);
         auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
@@ -402,7 +401,6 @@ TEST_F(MeshDeviceFixture, TensixTestUpdateCircularBufferAddressFromMeshTensor) {
         CoreRange cr(core0, core0);
         CoreRangeSet cr_set({cr});
 
-        auto& mesh_device = devices_.at(id);
         auto tensor_layout = TensorLayout(
             DataType::BFLOAT16,
             PageConfig(Layout::TILE),
@@ -417,7 +415,7 @@ TEST_F(MeshDeviceFixture, TensixTestUpdateCircularBufferAddressFromMeshTensor) {
         const uint32_t core0_num_cbs = 2;
         std::map<CoreCoord, std::map<uint8_t, uint32_t>> golden_addresses_per_core;
         std::vector<CBHandle> cb_ids;
-        auto expected_cb_addr = devices_.at(id)->allocator()->get_base_allocator_addr(HalMemType::L1);
+        auto expected_cb_addr = mesh_device->allocator()->get_base_allocator_addr(HalMemType::L1);
         for (uint32_t buffer_idx = 0; buffer_idx < core0_num_cbs; buffer_idx++) {
             CircularBufferConfig config1 =
                 CircularBufferConfig(cb_config.page_size, {{buffer_idx, cb_config.data_format}})
@@ -428,10 +426,10 @@ TEST_F(MeshDeviceFixture, TensixTestUpdateCircularBufferAddressFromMeshTensor) {
             expected_cb_addr += cb_config.page_size;
         }
 
-        validate_cb_address(workload, this->devices_.at(id), cr_set, golden_addresses_per_core);
+        validate_cb_address(workload, mesh_device, cr_set, golden_addresses_per_core);
         UpdateDynamicCircularBufferAddress(program_, cb_ids[0], tensor);
         golden_addresses_per_core[core0][0] = tensor_buffer->address();
-        validate_cb_address(workload, this->devices_.at(id), cr_set, golden_addresses_per_core);
+        validate_cb_address(workload, mesh_device, cr_set, golden_addresses_per_core);
     }
 }
 
@@ -440,8 +438,7 @@ TEST_F(MeshDeviceFixture, TensixTestUpdateCircularBufferAddressFromMeshTensor) {
 // operator== compares total_size, globally_allocated_address, data_formats, page_sizes, tiles, and
 // shadow_global_buffer.
 TEST_F(MeshDeviceFixture, TensixTestSetGloballyAllocatedAddressFromMeshTensorMatchesBuffer) {
-    for (unsigned int id = 0; id < num_devices_; id++) {
-        auto& mesh_device = devices_.at(id);
+    for (auto& mesh_device : this->devices_) {
         CBConfig cb_config;
 
         // Single-tile BFLOAT16 tensor → exactly one L1 page of cb_config.page_size (2048 B) bytes in one bank,
@@ -468,8 +465,7 @@ TEST_F(MeshDeviceFixture, TensixTestSetGloballyAllocatedAddressFromMeshTensorMat
 }
 
 TEST_F(MeshDeviceFixture, TensixTestSetGloballyAllocatedAddressAndTotalSizeFromMeshTensorMatchesBuffer) {
-    for (unsigned int id = 0; id < num_devices_; id++) {
-        auto& mesh_device = devices_.at(id);
+    for (auto& mesh_device : this->devices_) {
         CBConfig cb_config;
 
         auto tensor_layout = TensorLayout(
@@ -502,8 +498,8 @@ TEST_F(MeshDeviceFixture, TensixTestSetGloballyAllocatedAddressAndTotalSizeFromM
 }
 
 TEST_F(MeshDeviceFixture, TensixTestUpdateCircularBufferPageSize) {
-    for (unsigned int id = 0; id < num_devices_; id++) {
-        auto& cq = devices_.at(id)->mesh_command_queue();
+    for (auto& device : this->devices_) {
+        auto& cq = device->mesh_command_queue();
         distributed::MeshWorkload workload;
         auto zero_coord = distributed::MeshCoordinate(0, 0);
         auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
@@ -521,7 +517,7 @@ TEST_F(MeshDeviceFixture, TensixTestUpdateCircularBufferPageSize) {
         std::map<CoreCoord, std::map<uint8_t, uint32_t>> golden_addresses_per_core;
         std::map<CoreCoord, std::map<uint8_t, uint32_t>> golden_num_pages_per_core;
         std::vector<CBHandle> cb_ids;
-        auto expected_cb_addr = devices_.at(id)->allocator()->get_base_allocator_addr(HalMemType::L1);
+        auto expected_cb_addr = device->allocator()->get_base_allocator_addr(HalMemType::L1);
         for (uint32_t buffer_idx = 0; buffer_idx < core0_num_cbs; buffer_idx++) {
             CircularBufferConfig config1 =
                 CircularBufferConfig(cb_config.page_size, {{buffer_idx, cb_config.data_format}})
@@ -542,14 +538,10 @@ TEST_F(MeshDeviceFixture, TensixTestUpdateCircularBufferPageSize) {
             for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; x++) {
                 for (auto y = core_range.start_coord.y; y <= core_range.end_coord.y; y++) {
                     CoreCoord core_coord(x, y);
-                    auto address = program_.impl().get_cb_base_addr(
-                        this->devices_.at(id)->get_devices()[0], core_coord, tt::CoreType::WORKER);
+                    auto address =
+                        program_.impl().get_cb_base_addr(device->get_devices()[0], core_coord, tt::CoreType::WORKER);
                     tt::tt_metal::detail::ReadFromDeviceL1(
-                        this->devices_.at(id)->get_devices()[0],
-                        core_coord,
-                        address,
-                        cb_config_buffer_size,
-                        cb_config_vector);
+                        device->get_devices()[0], core_coord, address, cb_config_buffer_size, cb_config_vector);
 
                     std::map<uint8_t, uint32_t> address_per_buffer_index = golden_addresses_per_core.at(core_coord);
                     const std::map<uint8_t, uint32_t>& num_pages_per_buffer_index =
@@ -577,14 +569,10 @@ TEST_F(MeshDeviceFixture, TensixTestUpdateCircularBufferPageSize) {
             for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; x++) {
                 for (auto y = core_range.start_coord.y; y <= core_range.end_coord.y; y++) {
                     CoreCoord core_coord(x, y);
-                    auto address = program_.impl().get_cb_base_addr(
-                        this->devices_.at(id)->get_devices()[0], core_coord, tt::CoreType::WORKER);
+                    auto address =
+                        program_.impl().get_cb_base_addr(device->get_devices()[0], core_coord, tt::CoreType::WORKER);
                     tt::tt_metal::detail::ReadFromDeviceL1(
-                        this->devices_.at(id)->get_devices()[0],
-                        core_coord,
-                        address,
-                        cb_config_buffer_size,
-                        cb_config_vector);
+                        device->get_devices()[0], core_coord, address, cb_config_buffer_size, cb_config_vector);
 
                     std::map<uint8_t, uint32_t> address_per_buffer_index = golden_addresses_per_core.at(core_coord);
                     const std::map<uint8_t, uint32_t>& num_pages_per_buffer_index =
@@ -605,8 +593,8 @@ TEST_F(MeshDeviceFixture, TensixTestUpdateCircularBufferPageSize) {
 }
 
 TEST_F(MeshDeviceFixture, TensixTestDataCopyWithUpdatedCircularBufferConfig) {
-    for (unsigned int id = 0; id < num_devices_; id++) {
-        auto& cq = devices_.at(id)->mesh_command_queue();
+    for (auto& device : this->devices_) {
+        auto& cq = device->mesh_command_queue();
         distributed::MeshWorkload workload;
         auto zero_coord = distributed::MeshCoordinate(0, 0);
         auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
@@ -620,13 +608,13 @@ TEST_F(MeshDeviceFixture, TensixTestDataCopyWithUpdatedCircularBufferConfig) {
         uint32_t buffer_size = single_tile_size * num_tiles;
 
         tt::tt_metal::InterleavedBufferConfig dram_config{
-            .device = this->devices_.at(id)->get_devices()[0],
+            .device = device->get_devices()[0],
             .size = buffer_size,
             .page_size = buffer_size,
             .buffer_type = tt::tt_metal::BufferType::DRAM};
 
         tt::tt_metal::InterleavedBufferConfig l1_config{
-            .device = this->devices_.at(id)->get_devices()[0],
+            .device = device->get_devices()[0],
             .size = buffer_size,
             .page_size = buffer_size,
             .buffer_type = tt::tt_metal::BufferType::L1};
@@ -695,9 +683,9 @@ TEST_F(MeshDeviceFixture, TensixTestDataCopyWithUpdatedCircularBufferConfig) {
 
         std::vector<uint32_t> input_cb_data;
         detail::ReadFromDeviceL1(
-            this->devices_.at(id)->get_devices()[0],
+            device->get_devices()[0],
             core,
-            devices_.at(id)->allocator()->get_base_allocator_addr(HalMemType::L1),
+            device->allocator()->get_base_allocator_addr(HalMemType::L1),
             buffer_size,
             input_cb_data);
         EXPECT_EQ(src_vec, input_cb_data);
@@ -719,7 +707,7 @@ TEST_F(MeshDeviceFixture, TensixTestDataCopyWithUpdatedCircularBufferConfig) {
 
         std::vector<uint32_t> second_cb_data;
         detail::ReadFromDeviceL1(
-            this->devices_.at(id)->get_devices()[0], core, global_cb_buffer->address(), buffer_size, second_cb_data);
+            device->get_devices()[0], core, global_cb_buffer->address(), buffer_size, second_cb_data);
         EXPECT_EQ(src_vec, second_cb_data);
     }
 }

--- a/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_creation.cpp
+++ b/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_creation.cpp
@@ -120,9 +120,9 @@ TEST_F(MeshDeviceFixture, TensixTestCreateCircularBufferAtValidIndices) {
 
     CreateCircularBuffer(program_, cr_set, actual_config);
 
-    for (unsigned int id = 0; id < num_devices_; id++) {
-        distributed::EnqueueMeshWorkload(this->devices_.at(id)->mesh_command_queue(), workload, false);
-        EXPECT_TRUE(test_cb_config_written_to_core(workload, this->devices_.at(id), cr_set, golden_cb_config));
+    for (auto& device : this->devices_) {
+        distributed::EnqueueMeshWorkload(device->mesh_command_queue(), workload, false);
+        EXPECT_TRUE(test_cb_config_written_to_core(workload, device, cr_set, golden_cb_config));
     }
 }
 
@@ -205,8 +205,8 @@ TEST_F(MeshDeviceFixture, TensixTestCreateCircularBufferWithTooManyPages) {
 }
 
 TEST_F(MeshDeviceFixture, TensixTestCreateCircularBufferOnOutOfRangeCores) {
-    for (unsigned int id = 0; id < num_devices_; id++) {
-        auto& cq = devices_.at(id)->mesh_command_queue();
+    for (auto& device : this->devices_) {
+        auto& cq = device->mesh_command_queue();
         distributed::MeshWorkload workload;
         auto zero_coord = distributed::MeshCoordinate(0, 0);
         auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
@@ -214,7 +214,7 @@ TEST_F(MeshDeviceFixture, TensixTestCreateCircularBufferOnOutOfRangeCores) {
         workload.add_program(device_range, std::move(program));
         auto& program_ = workload.get_programs().at(device_range);
 
-        auto grid_size = devices_.at(id)->compute_with_storage_grid_size();
+        auto grid_size = device->compute_with_storage_grid_size();
         // Extend one column beyond the compute grid into dispatch core territory
         CoreRange cr({0, 0}, {grid_size.x, grid_size.y - 1});
         CoreRangeSet cr_set({cr});

--- a/tests/tt_metal/tt_metal/api/test_banked.cpp
+++ b/tests/tt_metal/tt_metal/api/test_banked.cpp
@@ -316,16 +316,16 @@ bool reader_datacopy_writer(const std::shared_ptr<distributed::MeshDevice>& mesh
 }  // end namespace local_test_functions
 
 TEST_F(MeshDeviceFixture, TensixTestSingleCoreSingleTileBankedL1ReaderOnly) {
-    for (unsigned int id = 0; id < num_devices_; id++) {
+    for (auto& device : this->devices_) {
         BankedConfig test_config;
-        EXPECT_TRUE(local_test_functions::reader_cb_writer(this->devices_.at(id), test_config, true, false));
+        EXPECT_TRUE(local_test_functions::reader_cb_writer(device, test_config, true, false));
     }
 }
 
 TEST_F(MeshDeviceFixture, TensixTestSingleCoreMultiTileBankedL1ReaderOnly) {
-    for (unsigned int id = 0; id < num_devices_; id++) {
+    for (auto& device : this->devices_) {
         BankedConfig test_config;
-        auto num_banks = devices_.at(id)->allocator()->get_num_banks(BufferType::L1);
+        auto num_banks = device->allocator()->get_num_banks(BufferType::L1);
         TT_FATAL(num_banks % 2 == 0, "Number of banks ({}) must be even for this test", num_banks);
         size_t num_tiles = num_banks / 2;
         size_t tile_increment = num_tiles;
@@ -333,7 +333,7 @@ TEST_F(MeshDeviceFixture, TensixTestSingleCoreMultiTileBankedL1ReaderOnly) {
         uint32_t index = 0;
         while (index < num_iterations) {
             test_config.update_num_tiles(num_tiles);
-            EXPECT_TRUE(local_test_functions::reader_cb_writer(this->devices_.at(id), test_config, true, false));
+            EXPECT_TRUE(local_test_functions::reader_cb_writer(device, test_config, true, false));
             num_tiles += tile_increment;
             index++;
         }
@@ -341,18 +341,18 @@ TEST_F(MeshDeviceFixture, TensixTestSingleCoreMultiTileBankedL1ReaderOnly) {
 }
 
 TEST_F(MeshDeviceFixture, TensixTestSingleCoreSingleTileBankedDramReaderOnly) {
-    for (unsigned int id = 0; id < num_devices_; id++) {
+    for (auto& device : this->devices_) {
         BankedConfig test_config;
         test_config.input_buffer_type = BufferType::DRAM;
         test_config.output_buffer_type = BufferType::DRAM;
-        EXPECT_TRUE(local_test_functions::reader_cb_writer(this->devices_.at(id), test_config, true, false));
+        EXPECT_TRUE(local_test_functions::reader_cb_writer(device, test_config, true, false));
     }
 }
 
 TEST_F(MeshDeviceFixture, TensixTestSingleCoreMultiTileBankedDramReaderOnly) {
-    for (unsigned int id = 0; id < num_devices_; id++) {
+    for (auto& device : this->devices_) {
         BankedConfig test_config;
-        auto num_banks = devices_.at(id)->allocator()->get_num_banks(BufferType::DRAM);
+        auto num_banks = device->allocator()->get_num_banks(BufferType::DRAM);
         size_t num_tiles = num_banks / 2;
         size_t tile_increment = num_tiles;
         uint32_t num_iterations = 6;
@@ -361,7 +361,7 @@ TEST_F(MeshDeviceFixture, TensixTestSingleCoreMultiTileBankedDramReaderOnly) {
         test_config.output_buffer_type = BufferType::DRAM;
         while (index < num_iterations) {
             test_config.update_num_tiles(num_tiles);
-            EXPECT_TRUE(local_test_functions::reader_cb_writer(this->devices_.at(id), test_config, true, false));
+            EXPECT_TRUE(local_test_functions::reader_cb_writer(device, test_config, true, false));
             num_tiles += tile_increment;
             index++;
         }
@@ -369,16 +369,16 @@ TEST_F(MeshDeviceFixture, TensixTestSingleCoreMultiTileBankedDramReaderOnly) {
 }
 
 TEST_F(MeshDeviceFixture, TensixTestSingleCoreSingleTileBankedL1WriterOnly) {
-    for (unsigned int id = 0; id < num_devices_; id++) {
+    for (auto& device : this->devices_) {
         BankedConfig test_config;
-        EXPECT_TRUE(local_test_functions::reader_cb_writer(this->devices_.at(id), test_config, false, true));
+        EXPECT_TRUE(local_test_functions::reader_cb_writer(device, test_config, false, true));
     }
 }
 
 TEST_F(MeshDeviceFixture, TensixTestSingleCoreMultiTileBankedL1WriterOnly) {
-    for (unsigned int id = 0; id < num_devices_; id++) {
+    for (auto& device : this->devices_) {
         BankedConfig test_config;
-        auto num_banks = devices_.at(id)->allocator()->get_num_banks(BufferType::L1);
+        auto num_banks = device->allocator()->get_num_banks(BufferType::L1);
         TT_FATAL(num_banks % 2 == 0, "Number of banks ({}) must be even for this test", num_banks);
         size_t num_tiles = num_banks / 2;
         size_t tile_increment = num_tiles;
@@ -386,7 +386,7 @@ TEST_F(MeshDeviceFixture, TensixTestSingleCoreMultiTileBankedL1WriterOnly) {
         uint32_t index = 0;
         while (index < num_iterations) {
             test_config.update_num_tiles(num_tiles);
-            EXPECT_TRUE(local_test_functions::reader_cb_writer(this->devices_.at(id), test_config, false, true));
+            EXPECT_TRUE(local_test_functions::reader_cb_writer(device, test_config, false, true));
             num_tiles += tile_increment;
             index++;
         }
@@ -394,18 +394,18 @@ TEST_F(MeshDeviceFixture, TensixTestSingleCoreMultiTileBankedL1WriterOnly) {
 }
 
 TEST_F(MeshDeviceFixture, TensixTestSingleCoreSingleTileBankedDramWriterOnly) {
-    for (unsigned int id = 0; id < num_devices_; id++) {
+    for (auto& device : this->devices_) {
         BankedConfig test_config;
         test_config.input_buffer_type = BufferType::DRAM;
         test_config.output_buffer_type = BufferType::DRAM;
-        EXPECT_TRUE(local_test_functions::reader_cb_writer(this->devices_.at(id), test_config, false, true));
+        EXPECT_TRUE(local_test_functions::reader_cb_writer(device, test_config, false, true));
     }
 }
 
 TEST_F(MeshDeviceFixture, TensixTestSingleCoreMultiTileBankedDramWriterOnly) {
-    for (unsigned int id = 0; id < num_devices_; id++) {
+    for (auto& device : this->devices_) {
         BankedConfig test_config;
-        auto num_banks = devices_.at(id)->allocator()->get_num_banks(BufferType::DRAM);
+        auto num_banks = device->allocator()->get_num_banks(BufferType::DRAM);
         size_t num_tiles = num_banks / 2;
         size_t tile_increment = num_tiles;
         uint32_t num_iterations = 6;
@@ -414,7 +414,7 @@ TEST_F(MeshDeviceFixture, TensixTestSingleCoreMultiTileBankedDramWriterOnly) {
         test_config.output_buffer_type = BufferType::DRAM;
         while (index < num_iterations) {
             test_config.update_num_tiles(num_tiles);
-            EXPECT_TRUE(local_test_functions::reader_cb_writer(this->devices_.at(id), test_config, false, true));
+            EXPECT_TRUE(local_test_functions::reader_cb_writer(device, test_config, false, true));
             num_tiles += tile_increment;
             index++;
         }
@@ -422,22 +422,22 @@ TEST_F(MeshDeviceFixture, TensixTestSingleCoreMultiTileBankedDramWriterOnly) {
 }
 
 TEST_F(MeshDeviceFixture, TensixTestSingleCoreSingleTileBankedL1ReaderAndWriter) {
-    for (unsigned int id = 0; id < num_devices_; id++) {
+    for (auto& device : this->devices_) {
         BankedConfig test_config;
-        EXPECT_TRUE(local_test_functions::reader_cb_writer(this->devices_.at(id), test_config, true, true));
+        EXPECT_TRUE(local_test_functions::reader_cb_writer(device, test_config, true, true));
     }
 }
 
 TEST_F(MeshDeviceFixture, TensixTestSingleCoreMultiTileBankedL1ReaderAndWriter) {
-    for (unsigned int id = 0; id < num_devices_; id++) {
+    for (auto& device : this->devices_) {
         BankedConfig test_config;
-        size_t num_tiles = devices_.at(id)->allocator()->get_num_banks(BufferType::L1);
+        size_t num_tiles = device->allocator()->get_num_banks(BufferType::L1);
         size_t tile_increment = num_tiles / 2;
         uint32_t num_iterations = 6;
         uint32_t index = 0;
         while (index < num_iterations) {
             test_config.update_num_tiles(num_tiles);
-            EXPECT_TRUE(local_test_functions::reader_cb_writer(this->devices_.at(id), test_config, true, true));
+            EXPECT_TRUE(local_test_functions::reader_cb_writer(device, test_config, true, true));
             num_tiles += tile_increment;
             index++;
         }
@@ -445,18 +445,18 @@ TEST_F(MeshDeviceFixture, TensixTestSingleCoreMultiTileBankedL1ReaderAndWriter) 
 }
 
 TEST_F(MeshDeviceFixture, TensixTestSingleCoreSingleTileBankedDramReaderAndWriter) {
-    for (unsigned int id = 0; id < num_devices_; id++) {
+    for (auto& device : this->devices_) {
         BankedConfig test_config;
         test_config.input_buffer_type = BufferType::DRAM;
         test_config.output_buffer_type = BufferType::DRAM;
-        EXPECT_TRUE(local_test_functions::reader_cb_writer(this->devices_.at(id), test_config, true, true));
+        EXPECT_TRUE(local_test_functions::reader_cb_writer(device, test_config, true, true));
     }
 }
 
 TEST_F(MeshDeviceFixture, TensixTestSingleCoreMultiTileBankedDramReaderAndWriter) {
-    for (unsigned int id = 0; id < num_devices_; id++) {
+    for (auto& device : this->devices_) {
         BankedConfig test_config;
-        size_t num_tiles = devices_.at(id)->allocator()->get_num_banks(BufferType::L1);
+        size_t num_tiles = device->allocator()->get_num_banks(BufferType::L1);
         TT_FATAL(num_tiles % 2 == 0, "Number of tiles ({}) must be even for this test", num_tiles);
         size_t tile_increment = num_tiles / 2;
         uint32_t num_iterations = 6;
@@ -465,7 +465,7 @@ TEST_F(MeshDeviceFixture, TensixTestSingleCoreMultiTileBankedDramReaderAndWriter
         test_config.output_buffer_type = BufferType::DRAM;
         while (index < num_iterations) {
             test_config.update_num_tiles(num_tiles);
-            EXPECT_TRUE(local_test_functions::reader_cb_writer(this->devices_.at(id), test_config, true, true));
+            EXPECT_TRUE(local_test_functions::reader_cb_writer(device, test_config, true, true));
             num_tiles += tile_increment;
             index++;
         }
@@ -473,26 +473,26 @@ TEST_F(MeshDeviceFixture, TensixTestSingleCoreMultiTileBankedDramReaderAndWriter
 }
 
 TEST_F(MeshDeviceFixture, TensixTestSingleCoreSingleTileBankedDramReaderAndL1Writer) {
-    for (unsigned int id = 0; id < num_devices_; id++) {
+    for (auto& device : this->devices_) {
         BankedConfig test_config;
         test_config.input_buffer_type = BufferType::DRAM;
-        EXPECT_TRUE(local_test_functions::reader_cb_writer(this->devices_.at(id), test_config, true, true));
+        EXPECT_TRUE(local_test_functions::reader_cb_writer(device, test_config, true, true));
     }
 }
 
 TEST_F(MeshDeviceFixture, TensixTestSingleCoreMultiTileBankedDramReaderAndL1Writer) {
-    for (unsigned int id = 0; id < num_devices_; id++) {
+    for (auto& device : this->devices_) {
         BankedConfig test_config;
         test_config.input_buffer_type = BufferType::DRAM;
 
-        size_t num_tiles = devices_.at(id)->allocator()->get_num_banks(BufferType::L1);
+        size_t num_tiles = device->allocator()->get_num_banks(BufferType::L1);
         TT_FATAL(num_tiles % 2 == 0, "Number of tiles ({}) must be even for this test", num_tiles);
         size_t tile_increment = num_tiles / 2;
         uint32_t num_iterations = 6;
         uint32_t index = 0;
         while (index < num_iterations) {
             test_config.update_num_tiles(num_tiles);
-            EXPECT_TRUE(local_test_functions::reader_cb_writer(this->devices_.at(id), test_config, true, true));
+            EXPECT_TRUE(local_test_functions::reader_cb_writer(device, test_config, true, true));
             num_tiles += tile_increment;
             index++;
         }
@@ -500,26 +500,26 @@ TEST_F(MeshDeviceFixture, TensixTestSingleCoreMultiTileBankedDramReaderAndL1Writ
 }
 
 TEST_F(MeshDeviceFixture, TensixTestSingleCoreSingleTileBankedL1ReaderAndDramWriter) {
-    for (unsigned int id = 0; id < num_devices_; id++) {
+    for (auto& device : this->devices_) {
         BankedConfig test_config;
         test_config.output_buffer_type = BufferType::DRAM;
-        EXPECT_TRUE(local_test_functions::reader_cb_writer(this->devices_.at(id), test_config, true, true));
+        EXPECT_TRUE(local_test_functions::reader_cb_writer(device, test_config, true, true));
     }
 }
 
 TEST_F(MeshDeviceFixture, TensixTestSingleCoreMultiTileBankedL1ReaderAndDramWriter) {
-    for (unsigned int id = 0; id < num_devices_; id++) {
+    for (auto& device : this->devices_) {
         BankedConfig test_config;
         test_config.output_buffer_type = BufferType::DRAM;
 
-        size_t num_tiles = devices_.at(id)->allocator()->get_num_banks(BufferType::L1);
+        size_t num_tiles = device->allocator()->get_num_banks(BufferType::L1);
         TT_FATAL(num_tiles % 2 == 0, "Number of tiles ({}) must be even for this test", num_tiles);
         size_t tile_increment = num_tiles / 2;
         uint32_t num_iterations = 6;
         uint32_t index = 0;
         while (index < num_iterations) {
             test_config.update_num_tiles(num_tiles);
-            EXPECT_TRUE(local_test_functions::reader_cb_writer(this->devices_.at(id), test_config, true, true));
+            EXPECT_TRUE(local_test_functions::reader_cb_writer(device, test_config, true, true));
             num_tiles += tile_increment;
             index++;
         }
@@ -527,17 +527,17 @@ TEST_F(MeshDeviceFixture, TensixTestSingleCoreMultiTileBankedL1ReaderAndDramWrit
 }
 
 TEST_F(MeshDeviceFixture, TensixTestSingleCoreMultiTileBankedL1ReaderDataCopyL1Writer) {
-    for (unsigned int id = 0; id < num_devices_; id++) {
+    for (auto& device : this->devices_) {
         BankedConfig test_config;
-        size_t num_tiles = devices_.at(id)->allocator()->get_num_banks(BufferType::L1);
+        size_t num_tiles = device->allocator()->get_num_banks(BufferType::L1);
         TT_FATAL(num_tiles % 2 == 0, "Number of tiles ({}) must be even for this test", num_tiles);
         size_t tile_increment = num_tiles / 2;
         uint32_t num_iterations = 6;
         uint32_t index = 0;
-        test_config.logical_core = this->devices_.at(id)->allocator()->get_logical_core_from_bank_id(0);
+        test_config.logical_core = device->allocator()->get_logical_core_from_bank_id(0);
         while (index < num_iterations) {
             test_config.update_num_tiles(num_tiles);
-            EXPECT_TRUE(local_test_functions::reader_datacopy_writer(this->devices_.at(id), test_config));
+            EXPECT_TRUE(local_test_functions::reader_datacopy_writer(device, test_config));
             num_tiles += tile_increment;
             index++;
         }
@@ -545,9 +545,9 @@ TEST_F(MeshDeviceFixture, TensixTestSingleCoreMultiTileBankedL1ReaderDataCopyL1W
 }
 
 TEST_F(MeshDeviceFixture, TensixTestSingleCoreMultiTileBankedDramReaderDataCopyDramWriter) {
-    for (unsigned int id = 0; id < num_devices_; id++) {
+    for (auto& device : this->devices_) {
         BankedConfig test_config;
-        size_t num_tiles = devices_.at(id)->allocator()->get_num_banks(BufferType::DRAM);
+        size_t num_tiles = device->allocator()->get_num_banks(BufferType::DRAM);
         size_t tile_increment = num_tiles / 2;
         uint32_t num_iterations = 6;
         uint32_t index = 0;
@@ -555,7 +555,7 @@ TEST_F(MeshDeviceFixture, TensixTestSingleCoreMultiTileBankedDramReaderDataCopyD
         test_config.output_buffer_type = BufferType::DRAM;
         while (index < num_iterations) {
             test_config.update_num_tiles(num_tiles);
-            EXPECT_TRUE(local_test_functions::reader_datacopy_writer(this->devices_.at(id), test_config));
+            EXPECT_TRUE(local_test_functions::reader_datacopy_writer(device, test_config));
             num_tiles += tile_increment;
             index++;
         }
@@ -563,19 +563,19 @@ TEST_F(MeshDeviceFixture, TensixTestSingleCoreMultiTileBankedDramReaderDataCopyD
 }
 
 TEST_F(MeshDeviceFixture, TensixTestSingleCoreMultiTileBankedL1ReaderDataCopyDramWriter) {
-    for (unsigned int id = 0; id < num_devices_; id++) {
+    for (auto& device : this->devices_) {
         BankedConfig test_config;
-        size_t num_tiles = devices_.at(id)->allocator()->get_num_banks(BufferType::L1);
+        size_t num_tiles = device->allocator()->get_num_banks(BufferType::L1);
         TT_FATAL(num_tiles % 2 == 0, "Number of tiles ({}) must be even for this test", num_tiles);
         size_t tile_increment = num_tiles / 2;
         uint32_t num_iterations = 6;
         uint32_t index = 0;
-        test_config.logical_core = this->devices_.at(id)->allocator()->get_logical_core_from_bank_id(0);
+        test_config.logical_core = device->allocator()->get_logical_core_from_bank_id(0);
         test_config.input_buffer_type = BufferType::L1;
         test_config.output_buffer_type = BufferType::DRAM;
         while (index < num_iterations) {
             test_config.update_num_tiles(num_tiles);
-            EXPECT_TRUE(local_test_functions::reader_datacopy_writer(this->devices_.at(id), test_config));
+            EXPECT_TRUE(local_test_functions::reader_datacopy_writer(device, test_config));
             num_tiles += tile_increment;
             index++;
         }
@@ -583,9 +583,9 @@ TEST_F(MeshDeviceFixture, TensixTestSingleCoreMultiTileBankedL1ReaderDataCopyDra
 }
 
 TEST_F(MeshDeviceFixture, TensixTestSingleCoreMultiTileBankedDramReaderDataCopyL1Writer) {
-    for (unsigned int id = 0; id < num_devices_; id++) {
+    for (auto& device : this->devices_) {
         BankedConfig test_config;
-        size_t num_tiles = devices_.at(id)->allocator()->get_num_banks(BufferType::L1);
+        size_t num_tiles = device->allocator()->get_num_banks(BufferType::L1);
         TT_FATAL(num_tiles % 2 == 0, "Number of tiles ({}) must be even for this test", num_tiles);
         size_t tile_increment = num_tiles / 2;
         uint32_t num_iterations = 6;
@@ -594,7 +594,7 @@ TEST_F(MeshDeviceFixture, TensixTestSingleCoreMultiTileBankedDramReaderDataCopyL
         test_config.output_buffer_type = BufferType::L1;
         while (index < num_iterations) {
             test_config.update_num_tiles(num_tiles);
-            EXPECT_TRUE(local_test_functions::reader_datacopy_writer(this->devices_.at(id), test_config));
+            EXPECT_TRUE(local_test_functions::reader_datacopy_writer(device, test_config));
             num_tiles += tile_increment;
             index++;
         }

--- a/tests/tt_metal/tt_metal/api/test_direct.cpp
+++ b/tests/tt_metal/tt_metal/api/test_direct.cpp
@@ -551,25 +551,19 @@ bool reader_datacopy_writer(
 namespace tt::tt_metal {
 
 TEST_F(MeshDeviceFixture, TensixSingleCoreDirectDramReaderOnly) {
-    for (unsigned int id = 0; id < num_devices_; id++) {
-        uint32_t l1_unreserved_base = devices_.at(id)->allocator()->get_base_allocator_addr(HalMemType::L1);
-        ASSERT_TRUE(
-            unit_tests::dram::direct::reader_only(devices_.at(id), 1 * 1024, l1_unreserved_base, CoreCoord(0, 0)));
-        ASSERT_TRUE(
-            unit_tests::dram::direct::reader_only(devices_.at(id), 2 * 1024, l1_unreserved_base, CoreCoord(0, 0)));
-        ASSERT_TRUE(
-            unit_tests::dram::direct::reader_only(devices_.at(id), 16 * 1024, l1_unreserved_base, CoreCoord(0, 0)));
+    for (auto& device : this->devices_) {
+        uint32_t l1_unreserved_base = device->allocator()->get_base_allocator_addr(HalMemType::L1);
+        ASSERT_TRUE(unit_tests::dram::direct::reader_only(device, 1 * 1024, l1_unreserved_base, CoreCoord(0, 0)));
+        ASSERT_TRUE(unit_tests::dram::direct::reader_only(device, 2 * 1024, l1_unreserved_base, CoreCoord(0, 0)));
+        ASSERT_TRUE(unit_tests::dram::direct::reader_only(device, 16 * 1024, l1_unreserved_base, CoreCoord(0, 0)));
     }
 }
 TEST_F(MeshDeviceFixture, TensixSingleCoreDirectDramWriterOnly) {
-    for (unsigned int id = 0; id < num_devices_; id++) {
-        uint32_t l1_unreserved_base = devices_.at(id)->allocator()->get_base_allocator_addr(HalMemType::L1);
-        ASSERT_TRUE(
-            unit_tests::dram::direct::writer_only(devices_.at(id), 1 * 1024, l1_unreserved_base, CoreCoord(0, 0)));
-        ASSERT_TRUE(
-            unit_tests::dram::direct::writer_only(devices_.at(id), 2 * 1024, l1_unreserved_base, CoreCoord(0, 0)));
-        ASSERT_TRUE(
-            unit_tests::dram::direct::writer_only(devices_.at(id), 16 * 1024, l1_unreserved_base, CoreCoord(0, 0)));
+    for (auto& device : this->devices_) {
+        uint32_t l1_unreserved_base = device->allocator()->get_base_allocator_addr(HalMemType::L1);
+        ASSERT_TRUE(unit_tests::dram::direct::writer_only(device, 1 * 1024, l1_unreserved_base, CoreCoord(0, 0)));
+        ASSERT_TRUE(unit_tests::dram::direct::writer_only(device, 2 * 1024, l1_unreserved_base, CoreCoord(0, 0)));
+        ASSERT_TRUE(unit_tests::dram::direct::writer_only(device, 16 * 1024, l1_unreserved_base, CoreCoord(0, 0)));
     }
 }
 TEST_F(MeshDeviceFixture, TensixSingleCoreDirectDramReaderWriter) {
@@ -578,13 +572,13 @@ TEST_F(MeshDeviceFixture, TensixSingleCoreDirectDramReaderWriter) {
         .tile_byte_size = 2 * 32 * 32,
         .l1_data_format = tt::DataFormat::Float16_b,
         .node = experimental::NodeCoord(0, 0)};
-    for (unsigned int id = 0; id < num_devices_; id++) {
+    for (auto& device : this->devices_) {
         test_config.num_tiles = 1;
-        ASSERT_TRUE(unit_tests::dram::direct::reader_writer(devices_.at(id), test_config));
+        ASSERT_TRUE(unit_tests::dram::direct::reader_writer(device, test_config));
         test_config.num_tiles = 4;
-        ASSERT_TRUE(unit_tests::dram::direct::reader_writer(devices_.at(id), test_config));
+        ASSERT_TRUE(unit_tests::dram::direct::reader_writer(device, test_config));
         test_config.num_tiles = 8;
-        ASSERT_TRUE(unit_tests::dram::direct::reader_writer(devices_.at(id), test_config));
+        ASSERT_TRUE(unit_tests::dram::direct::reader_writer(device, test_config));
     }
 }
 TEST_F(MeshDeviceFixture, TensixSingleCoreDirectDramReaderDatacopyWriter) {
@@ -594,15 +588,15 @@ TEST_F(MeshDeviceFixture, TensixSingleCoreDirectDramReaderDatacopyWriter) {
         .l1_input_data_format = tt::DataFormat::Float16_b,
         .l1_output_data_format = tt::DataFormat::Float16_b,
         .node = experimental::NodeCoord(0, 0)};
-    for (unsigned int id = 0; id < num_devices_; id++) {
-        if (devices_.at(id)->arch() != ARCH::QUASAR) { // Remove when we can run back to back tests on Quasar VCS (on CI)
+    for (auto& device : this->devices_) {
+        if (device->arch() != ARCH::QUASAR) {  // Remove when we can run back to back tests on Quasar VCS (on CI)
             test_config.num_tiles = 1;
-            ASSERT_TRUE(unit_tests::dram::direct::reader_datacopy_writer(devices_.at(id), test_config));
+            ASSERT_TRUE(unit_tests::dram::direct::reader_datacopy_writer(device, test_config));
             test_config.num_tiles = 4;
-            ASSERT_TRUE(unit_tests::dram::direct::reader_datacopy_writer(devices_.at(id), test_config));
+            ASSERT_TRUE(unit_tests::dram::direct::reader_datacopy_writer(device, test_config));
         }
         test_config.num_tiles = 8;
-        ASSERT_TRUE(unit_tests::dram::direct::reader_datacopy_writer(devices_.at(id), test_config));
+        ASSERT_TRUE(unit_tests::dram::direct::reader_datacopy_writer(device, test_config));
     }
 }
 
@@ -620,8 +614,8 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarDatacopyToDestWriter) {
                 .l1_output_data_format = data_format,
                 .node = experimental::NodeCoord(0, 0),
                 .dst_full_sync_en = dst_full_sync_en};
-            for (unsigned int id = 0; id < num_devices_; id++) {
-                EXPECT_TRUE(unit_tests::dram::direct::reader_datacopy_writer(devices_.at(id), test_config));
+            for (auto& device : this->devices_) {
+                EXPECT_TRUE(unit_tests::dram::direct::reader_datacopy_writer(device, test_config));
             }
         }
     }

--- a/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
+++ b/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
@@ -490,16 +490,14 @@ namespace tt::tt_metal {
 
 // Write unique and common runtime args to device and readback to verify written correctly.
 TEST_F(MeshDeviceFixture, TensixLegallyModifyRTArgsDataMovement) {
-    for (unsigned int id = 0; id < num_devices_; id++) {
+    for (auto& mesh_device : this->devices_) {
         // First run the program with the initial runtime args
         CoreRange first_core_range(CoreCoord(0, 0), CoreCoord(1, 1));
         CoreRange second_core_range(CoreCoord(3, 3), CoreCoord(5, 5));
         CoreRangeSet core_range_set(std::vector{first_core_range, second_core_range});
-        auto mesh_device = this->devices_.at(id);
         auto& cq = mesh_device->mesh_command_queue();
-        auto* device = this->devices_.at(id)->get_devices()[0];
-        auto workload =
-            unit_tests::runtime_args::initialize_program_data_movement_rta(this->devices_.at(id), core_range_set, 2);
+        auto* device = mesh_device->get_devices()[0];
+        auto workload = unit_tests::runtime_args::initialize_program_data_movement_rta(mesh_device, core_range_set, 2);
         auto zero_coord = distributed::MeshCoordinate(0, 0);
         auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
         auto& program = workload.get_programs().at(device_range);
@@ -552,8 +550,7 @@ TEST_F(MeshDeviceFixture, TensixLegallyModifyRTArgsDataMovement) {
 }
 
 TEST_F(MeshDeviceFixture, TensixLegallyModifyRTArgsCompute) {
-    for (unsigned int id = 0; id < num_devices_; id++) {
-        auto mesh_device = this->devices_.at(id);
+    for (auto& mesh_device : this->devices_) {
         auto& cq = mesh_device->mesh_command_queue();
         auto zero_coord = distributed::MeshCoordinate(0, 0);
         auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
@@ -590,8 +587,7 @@ TEST_F(MeshDeviceFixture, TensixLegallyModifyRTArgsCompute) {
 
 // Don't cover all cores of kernel with SetRuntimeArgs. Verify that correct offset used to access common runtime args.
 TEST_F(MeshDeviceFixture, TensixSetRuntimeArgsSubsetOfCoresCompute) {
-    for (unsigned int id = 0; id < num_devices_; id++) {
-        auto mesh_device = this->devices_.at(id);
+    for (auto& mesh_device : this->devices_) {
         auto& cq = mesh_device->mesh_command_queue();
         auto zero_coord = distributed::MeshCoordinate(0, 0);
         auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
@@ -625,8 +621,7 @@ TEST_F(MeshDeviceFixture, TensixSetRuntimeArgsSubsetOfCoresCompute) {
 
 // Different unique runtime args per core. Not overly special, but verify that it works.
 TEST_F(MeshDeviceFixture, TensixSetRuntimeArgsUniqueValuesCompute) {
-    for (unsigned int id = 0; id < num_devices_; id++) {
-        auto mesh_device = this->devices_.at(id);
+    for (auto& mesh_device : this->devices_) {
         auto& cq = mesh_device->mesh_command_queue();
         auto zero_coord = distributed::MeshCoordinate(0, 0);
         auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
@@ -665,8 +660,7 @@ TEST_F(MeshDeviceFixture, TensixSetRuntimeArgsUniqueValuesCompute) {
 // Some cores have more unique runtime args than others. Unused in kernel, but API supports it, so verify it works and
 // that common runtime args are appropriately offset by amount from core(s) with most unique runtime args.
 TEST_F(MeshDeviceFixture, TensixSetRuntimeArgsVaryingLengthPerCore) {
-    for (unsigned int id = 0; id < num_devices_; id++) {
-        auto mesh_device = this->devices_.at(id);
+    for (auto& mesh_device : this->devices_) {
         auto& cq = mesh_device->mesh_command_queue();
         auto zero_coord = distributed::MeshCoordinate(0, 0);
         auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
@@ -724,8 +718,7 @@ TEST_F(MeshDeviceFixture, TensixSetRuntimeArgsVaryingLengthPerCore) {
 // Too many unique and common runtime args, overflows allowed space and throws expected exception from both
 // unique/common APIs.
 TEST_F(MeshDeviceFixture, TensixIllegalTooManyRuntimeArgs) {
-    for (unsigned int id = 0; id < num_devices_; id++) {
-        auto mesh_device = this->devices_.at(id);
+    for (auto& mesh_device : this->devices_) {
         auto zero_coord = distributed::MeshCoordinate(0, 0);
         auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
         CoreRange first_core_range(CoreCoord(1, 1), CoreCoord(2, 2));
@@ -755,8 +748,7 @@ TEST_F(MeshDeviceFixture, TensixIllegalTooManyRuntimeArgs) {
 }
 
 TEST_F(MeshDeviceFixture, TensixIllegallyModifyRTArgs) {
-    for (unsigned int id = 0; id < num_devices_; id++) {
-        auto mesh_device = this->devices_.at(id);
+    for (auto& mesh_device : this->devices_) {
         auto& cq = mesh_device->mesh_command_queue();
         auto zero_coord = distributed::MeshCoordinate(0, 0);
         auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
@@ -836,12 +828,11 @@ TEST_F(MeshDeviceFixture, Metal2RejectsLegacyRuntimeArgsAPIs) {
 }
 
 TEST_F(MeshDeviceFixture, TensixSetCommonRuntimeArgsMultipleCreateKernel) {
-    for (unsigned int id = 0; id < num_devices_; id++) {
-        auto mesh_device = this->devices_.at(id);
+    for (auto& mesh_device : this->devices_) {
         auto& cq = mesh_device->mesh_command_queue();
         auto zero_coord = distributed::MeshCoordinate(0, 0);
         auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
-        auto grid_size = this->devices_.at(id)->logical_grid_size();
+        auto grid_size = mesh_device->logical_grid_size();
         auto max_x = grid_size.x - 1;
         auto max_y = grid_size.y - 1;
 
@@ -879,8 +870,7 @@ TEST_F(MeshDeviceFixture, ActiveEthIllegalTooManyRuntimeArgs) {
     uint32_t active_eth_max_runtime_args =
         hal.get_dev_size(HalProgrammableCoreType::ACTIVE_ETH, HalL1MemAddrType::KERNEL_CONFIG) / sizeof(uint32_t) -
         watcher_reserved_count_words;
-    for (unsigned int id = 0; id < num_devices_; id++) {
-        auto mesh_device = this->devices_.at(id);
+    for (auto& mesh_device : this->devices_) {
         auto* device = mesh_device->get_devices()[0];
         auto active_eth_cores = device->get_active_ethernet_cores(true);
 
@@ -965,8 +955,7 @@ TEST_F(MeshDeviceFixture, IdleEthIllegalTooManyRuntimeArgs) {
     uint32_t idle_eth_max_runtime_args =
         hal.get_dev_size(HalProgrammableCoreType::IDLE_ETH, HalL1MemAddrType::KERNEL_CONFIG) / sizeof(uint32_t) -
         watcher_reserved_count_words;
-    for (unsigned int id = 0; id < num_devices_; id++) {
-        auto mesh_device = this->devices_.at(id);
+    for (auto& mesh_device : this->devices_) {
         auto* device = mesh_device->get_devices()[0];
         auto idle_eth_cores = device->get_inactive_ethernet_cores();
 

--- a/tests/tt_metal/tt_metal/api/test_semaphores.cpp
+++ b/tests/tt_metal/tt_metal/api/test_semaphores.cpp
@@ -160,28 +160,27 @@ void try_creating_semaphores_out_of_bounds(
 namespace tt::tt_metal {
 
 TEST_F(MeshDeviceFixture, TensixInitializeLegalSemaphores) {
-    for (unsigned int id = 0; id < num_devices_; id++) {
+    for (auto& device : this->devices_) {
         distributed::MeshWorkload workload;
         auto zero_coord = distributed::MeshCoordinate(0, 0);
         auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
         tt_metal::Program program = tt_metal::CreateProgram();
         workload.add_program(device_range, std::move(program));
         CoreRange core_range({0, 0}, {1, 1});
-        unit_tests::initialize_semaphores::create_and_read_max_num_semaphores(devices_.at(id), workload, core_range);
+        unit_tests::initialize_semaphores::create_and_read_max_num_semaphores(device, workload, core_range);
     }
 }
 
 TEST_F(MeshDeviceFixture, TensixInitializeIllegalSemaphores) {
-    for (unsigned int id = 0; id < num_devices_; id++) {
+    for (auto& device : this->devices_) {
         distributed::MeshWorkload workload;
         auto zero_coord = distributed::MeshCoordinate(0, 0);
         auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
         tt_metal::Program program = tt_metal::CreateProgram();
         workload.add_program(device_range, std::move(program));
         CoreRange core_range({0, 0}, {1, 1});
-        unit_tests::initialize_semaphores::try_creating_semaphores_out_of_bounds(devices_.at(id), workload);
-        unit_tests::initialize_semaphores::try_creating_more_than_max_num_semaphores(
-            devices_.at(id), workload, core_range);
+        unit_tests::initialize_semaphores::try_creating_semaphores_out_of_bounds(device, workload);
+        unit_tests::initialize_semaphores::try_creating_more_than_max_num_semaphores(device, workload, core_range);
     }
 }
 

--- a/tests/tt_metal/tt_metal/api/test_sharded_l1_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/test_sharded_l1_buffer.cpp
@@ -184,27 +184,26 @@ std::vector<uint32_t> expected_host_after_filtered_write(
 }  // end namespace local_test_functions
 
 TEST_F(MeshDeviceFixture, TestInterleavedReadWrite) {
-    for (unsigned int id = 0; id < num_devices_; id++) {
+    for (auto& device : this->devices_) {
         L1Config test_config(*this);
         test_config.buffer_layout = TensorMemoryLayout::INTERLEAVED;
         test_config.sharded = false;
-        EXPECT_TRUE(local_test_functions::l1_buffer_read_write(this->devices_.at(id), test_config));
+        EXPECT_TRUE(local_test_functions::l1_buffer_read_write(device, test_config));
     }
 }
 
 TEST_F(MeshDeviceFixture, TestHeightShardReadWrite) {
-    for (unsigned int id = 0; id < num_devices_; id++) {
+    for (auto& device : this->devices_) {
         L1Config test_config(*this);
-        EXPECT_TRUE(local_test_functions::l1_buffer_read_write(this->devices_.at(id), test_config));
+        EXPECT_TRUE(local_test_functions::l1_buffer_read_write(device, test_config));
     }
 }
 
 TEST_F(MeshDeviceFixture, TestHeightShardFilteredWrite_WritesOnlyFilteredCores) {
     constexpr uint32_t k_sentinel = 0x11111111u;
     constexpr uint32_t k_new = 0x22222222u;
-    for (unsigned int id = 0; id < num_devices_; id++) {
+    for (auto& mesh_device : this->devices_) {
         L1Config test_config(*this);
-        auto mesh_device = this->devices_.at(id);
         auto buffer = local_test_functions::make_height_sharded_l1_buffer(mesh_device, test_config);
         const uint32_t num_u32 = test_config.size_bytes / sizeof(uint32_t);
         std::vector<uint32_t> sentinel(num_u32, k_sentinel);
@@ -227,9 +226,8 @@ TEST_F(MeshDeviceFixture, TestHeightShardFilteredWrite_WritesOnlyFilteredCores) 
 
 TEST_F(MeshDeviceFixture, TestHeightShardFilteredWrite_EmptyFilterIsNoop) {
     constexpr uint32_t k_sentinel = 0xABCDEF01u;
-    for (unsigned int id = 0; id < num_devices_; id++) {
+    for (auto& mesh_device : this->devices_) {
         L1Config test_config(*this);
-        auto mesh_device = this->devices_.at(id);
         auto buffer = local_test_functions::make_height_sharded_l1_buffer(mesh_device, test_config);
         const uint32_t num_u32 = test_config.size_bytes / sizeof(uint32_t);
         std::vector<uint32_t> sentinel(num_u32, k_sentinel);
@@ -250,9 +248,8 @@ TEST_F(MeshDeviceFixture, TestHeightShardFilteredWrite_EmptyFilterIsNoop) {
 
 TEST_F(MeshDeviceFixture, TestHeightShardFilteredWrite_FullFilterMatchesUnfiltered) {
     constexpr uint32_t k_pattern = 0x50505050u;
-    for (unsigned int id = 0; id < num_devices_; id++) {
+    for (auto& mesh_device : this->devices_) {
         L1Config test_config(*this);
-        auto mesh_device = this->devices_.at(id);
         auto buffer_a = local_test_functions::make_height_sharded_l1_buffer(mesh_device, test_config);
         auto buffer_b = local_test_functions::make_height_sharded_l1_buffer(mesh_device, test_config);
         const uint32_t num_u32 = test_config.size_bytes / sizeof(uint32_t);
@@ -278,37 +275,37 @@ TEST_F(MeshDeviceFixture, TestHeightShardFilteredWrite_FullFilterMatchesUnfilter
 }
 
 TEST_F(MeshDeviceFixtureWithL1Small, TestHeightShardReadWrite) {
-    for (unsigned int id = 0; id < num_devices_; id++) {
+    for (auto& device : this->devices_) {
         L1Config test_config(*this);
         test_config.buffer_type = BufferType::L1;
-        auto l1_write_info = local_test_functions::l1_buffer_write_wait(this->devices_.at(id), test_config);
+        auto l1_write_info = local_test_functions::l1_buffer_write_wait(device, test_config);
         test_config.buffer_type = BufferType::L1_SMALL;
-        auto l1small_write_info = local_test_functions::l1_buffer_write_wait(this->devices_.at(id), test_config);
+        auto l1small_write_info = local_test_functions::l1_buffer_write_wait(device, test_config);
 
-        EXPECT_TRUE(local_test_functions::l1_buffer_read(this->devices_.at(id), test_config, l1_write_info));
-        EXPECT_TRUE(local_test_functions::l1_buffer_read(this->devices_.at(id), test_config, l1small_write_info));
+        EXPECT_TRUE(local_test_functions::l1_buffer_read(device, test_config, l1_write_info));
+        EXPECT_TRUE(local_test_functions::l1_buffer_read(device, test_config, l1small_write_info));
     }
 }
 
 TEST_F(MeshDeviceFixture, TestWidthShardReadWrite) {
-    for (unsigned int id = 0; id < num_devices_; id++) {
+    for (auto& device : this->devices_) {
         L1Config test_config(*this);
         test_config.buffer_layout = TensorMemoryLayout::WIDTH_SHARDED;
-        EXPECT_TRUE(local_test_functions::l1_buffer_read_write(this->devices_.at(id), test_config));
+        EXPECT_TRUE(local_test_functions::l1_buffer_read_write(device, test_config));
     }
 }
 
 TEST_F(MeshDeviceFixtureWithL1Small, TestWidthShardReadWrite) {
-    for (unsigned int id = 0; id < num_devices_; id++) {
+    for (auto& device : this->devices_) {
         L1Config test_config(*this);
         test_config.buffer_layout = TensorMemoryLayout::WIDTH_SHARDED;
         test_config.buffer_type = BufferType::L1;
-        auto l1_write_info = local_test_functions::l1_buffer_write_wait(this->devices_.at(id), test_config);
+        auto l1_write_info = local_test_functions::l1_buffer_write_wait(device, test_config);
         test_config.buffer_type = BufferType::L1_SMALL;
-        auto l1small_write_info = local_test_functions::l1_buffer_write_wait(this->devices_.at(id), test_config);
+        auto l1small_write_info = local_test_functions::l1_buffer_write_wait(device, test_config);
 
-        EXPECT_TRUE(local_test_functions::l1_buffer_read(this->devices_.at(id), test_config, l1_write_info));
-        EXPECT_TRUE(local_test_functions::l1_buffer_read(this->devices_.at(id), test_config, l1small_write_info));
+        EXPECT_TRUE(local_test_functions::l1_buffer_read(device, test_config, l1_write_info));
+        EXPECT_TRUE(local_test_functions::l1_buffer_read(device, test_config, l1small_write_info));
     }
 }
 
@@ -333,8 +330,7 @@ TEST_F(MeshDeviceFixture, TestUnorderedHeightShardReadWrite) {
         ShardOrientation::ROW_MAJOR,
         {tt::constants::TILE_HEIGHT, tt::constants::TILE_WIDTH},
         {(uint32_t)cores.size(), 1});
-    for (unsigned int id = 0; id < num_devices_; id++) {
-        auto mesh_device = this->devices_.at(id);
+    for (auto& mesh_device : this->devices_) {
         std::vector<CoreCoord> physical_cores;
         physical_cores.reserve(cores.size());
         for (const auto& core : cores) {

--- a/tests/tt_metal/tt_metal/api/test_simple_dram_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/test_simple_dram_buffer.cpp
@@ -42,29 +42,29 @@ bool SimpleDramLoopback(
 namespace tt::tt_metal {
 
 TEST_F(MeshDeviceFixture, TestSimpleDramBufferLo) {
-    for (unsigned int id = 0; id < num_devices_; id++) {
-        size_t lo_address = devices_.at(id)->allocator()->get_base_allocator_addr(HalMemType::DRAM);
-        ASSERT_TRUE(SimpleDramLoopback(this->devices_.at(id), lo_address, 1));
-        ASSERT_TRUE(SimpleDramLoopback(this->devices_.at(id), lo_address, 2));
-        ASSERT_TRUE(SimpleDramLoopback(this->devices_.at(id), lo_address, 4));
-        ASSERT_TRUE(SimpleDramLoopback(this->devices_.at(id), lo_address, 8));
-        ASSERT_TRUE(SimpleDramLoopback(this->devices_.at(id), lo_address, 16));
-        ASSERT_TRUE(SimpleDramLoopback(this->devices_.at(id), lo_address, 32));
-        ASSERT_TRUE(SimpleDramLoopback(this->devices_.at(id), lo_address, 1024));
-        ASSERT_TRUE(SimpleDramLoopback(this->devices_.at(id), lo_address, 16 * 1024));
+    for (auto& device : this->devices_) {
+        size_t lo_address = device->allocator()->get_base_allocator_addr(HalMemType::DRAM);
+        ASSERT_TRUE(SimpleDramLoopback(device, lo_address, 1));
+        ASSERT_TRUE(SimpleDramLoopback(device, lo_address, 2));
+        ASSERT_TRUE(SimpleDramLoopback(device, lo_address, 4));
+        ASSERT_TRUE(SimpleDramLoopback(device, lo_address, 8));
+        ASSERT_TRUE(SimpleDramLoopback(device, lo_address, 16));
+        ASSERT_TRUE(SimpleDramLoopback(device, lo_address, 32));
+        ASSERT_TRUE(SimpleDramLoopback(device, lo_address, 1024));
+        ASSERT_TRUE(SimpleDramLoopback(device, lo_address, 16 * 1024));
     }
 }
 TEST_F(MeshDeviceFixture, TestSimpleDramBufferHi) {
-    for (unsigned int id = 0; id < num_devices_; id++) {
-        size_t hi_address = this->devices_.at(id)->dram_size_per_channel() - (16 * 1024);
-        ASSERT_TRUE(SimpleDramLoopback(this->devices_.at(id), hi_address, 1));
-        ASSERT_TRUE(SimpleDramLoopback(this->devices_.at(id), hi_address, 2));
-        ASSERT_TRUE(SimpleDramLoopback(this->devices_.at(id), hi_address, 4));
-        ASSERT_TRUE(SimpleDramLoopback(this->devices_.at(id), hi_address, 8));
-        ASSERT_TRUE(SimpleDramLoopback(this->devices_.at(id), hi_address, 16));
-        ASSERT_TRUE(SimpleDramLoopback(this->devices_.at(id), hi_address, 32));
-        ASSERT_TRUE(SimpleDramLoopback(this->devices_.at(id), hi_address, 1024));
-        ASSERT_TRUE(SimpleDramLoopback(this->devices_.at(id), hi_address, 16 * 1024));
+    for (auto& device : this->devices_) {
+        size_t hi_address = device->dram_size_per_channel() - (16 * 1024);
+        ASSERT_TRUE(SimpleDramLoopback(device, hi_address, 1));
+        ASSERT_TRUE(SimpleDramLoopback(device, hi_address, 2));
+        ASSERT_TRUE(SimpleDramLoopback(device, hi_address, 4));
+        ASSERT_TRUE(SimpleDramLoopback(device, hi_address, 8));
+        ASSERT_TRUE(SimpleDramLoopback(device, hi_address, 16));
+        ASSERT_TRUE(SimpleDramLoopback(device, hi_address, 32));
+        ASSERT_TRUE(SimpleDramLoopback(device, hi_address, 1024));
+        ASSERT_TRUE(SimpleDramLoopback(device, hi_address, 16 * 1024));
     }
 }
 

--- a/tests/tt_metal/tt_metal/api/test_simple_l1_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/test_simple_l1_buffer.cpp
@@ -145,78 +145,66 @@ bool SimpleTiledL1WriteCBRead(
 namespace tt::tt_metal {
 
 TEST_F(MeshDeviceFixture, TestSimpleL1BufferLo) {
-    for (unsigned int id = 0; id < num_devices_; id++) {
-        size_t lo_address = this->devices_.at(id)->l1_size_per_core() -
-                            this->devices_.at(id)->allocator()->get_bank_size(tt::tt_metal::BufferType::L1);
-        ASSERT_TRUE(SimpleL1Loopback(this->devices_.at(id), lo_address, 1));
-        ASSERT_TRUE(SimpleL1Loopback(this->devices_.at(id), lo_address, 2));
-        ASSERT_TRUE(SimpleL1Loopback(this->devices_.at(id), lo_address, 4));
-        ASSERT_TRUE(SimpleL1Loopback(this->devices_.at(id), lo_address, 8));
-        ASSERT_TRUE(SimpleL1Loopback(this->devices_.at(id), lo_address, 16));
-        ASSERT_TRUE(SimpleL1Loopback(this->devices_.at(id), lo_address, 32));
-        ASSERT_TRUE(SimpleL1Loopback(this->devices_.at(id), lo_address, 1024));
-        ASSERT_TRUE(SimpleL1Loopback(this->devices_.at(id), lo_address, 16 * 1024));
+    for (auto& device : this->devices_) {
+        size_t lo_address =
+            device->l1_size_per_core() - device->allocator()->get_bank_size(tt::tt_metal::BufferType::L1);
+        ASSERT_TRUE(SimpleL1Loopback(device, lo_address, 1));
+        ASSERT_TRUE(SimpleL1Loopback(device, lo_address, 2));
+        ASSERT_TRUE(SimpleL1Loopback(device, lo_address, 4));
+        ASSERT_TRUE(SimpleL1Loopback(device, lo_address, 8));
+        ASSERT_TRUE(SimpleL1Loopback(device, lo_address, 16));
+        ASSERT_TRUE(SimpleL1Loopback(device, lo_address, 32));
+        ASSERT_TRUE(SimpleL1Loopback(device, lo_address, 1024));
+        ASSERT_TRUE(SimpleL1Loopback(device, lo_address, 16 * 1024));
     }
 }
 TEST_F(MeshDeviceFixture, TestSimpleL1BufferHi) {
-    for (unsigned int id = 0; id < num_devices_; id++) {
-        size_t hi_address = this->devices_.at(id)->l1_size_per_core() - (16 * 1024);
-        ASSERT_TRUE(SimpleL1Loopback(this->devices_.at(id), hi_address, 1));
-        ASSERT_TRUE(SimpleL1Loopback(this->devices_.at(id), hi_address, 2));
-        ASSERT_TRUE(SimpleL1Loopback(this->devices_.at(id), hi_address, 4));
-        ASSERT_TRUE(SimpleL1Loopback(this->devices_.at(id), hi_address, 8));
-        ASSERT_TRUE(SimpleL1Loopback(this->devices_.at(id), hi_address, 16));
-        ASSERT_TRUE(SimpleL1Loopback(this->devices_.at(id), hi_address, 32));
-        ASSERT_TRUE(SimpleL1Loopback(this->devices_.at(id), hi_address, 1024));
-        ASSERT_TRUE(SimpleL1Loopback(this->devices_.at(id), hi_address, 16 * 1024));
+    for (auto& device : this->devices_) {
+        size_t hi_address = device->l1_size_per_core() - (16 * 1024);
+        ASSERT_TRUE(SimpleL1Loopback(device, hi_address, 1));
+        ASSERT_TRUE(SimpleL1Loopback(device, hi_address, 2));
+        ASSERT_TRUE(SimpleL1Loopback(device, hi_address, 4));
+        ASSERT_TRUE(SimpleL1Loopback(device, hi_address, 8));
+        ASSERT_TRUE(SimpleL1Loopback(device, hi_address, 16));
+        ASSERT_TRUE(SimpleL1Loopback(device, hi_address, 32));
+        ASSERT_TRUE(SimpleL1Loopback(device, hi_address, 1024));
+        ASSERT_TRUE(SimpleL1Loopback(device, hi_address, 16 * 1024));
     }
 }
 
 TEST_F(MeshDeviceFixture, TensixTestSimpleL1ReadWriteTileLo) {
-    for (unsigned int id = 0; id < num_devices_; id++) {
+    for (auto& device : this->devices_) {
         size_t lo_address = 768 * 1024;
-        ASSERT_TRUE(SimpleTiledL1WriteCBRead(
-            this->devices_.at(id), {0, 0}, lo_address + 8 * 1024, lo_address + 16 * 1024, 2 * 1024));
-        ASSERT_TRUE(SimpleTiledL1WriteCBRead(
-            this->devices_.at(id), {0, 0}, lo_address + 8 * 1024, lo_address + 16 * 1024, 4 * 1024));
-        ASSERT_TRUE(SimpleTiledL1WriteCBRead(
-            this->devices_.at(id), {0, 0}, lo_address + 8 * 1024, lo_address + 16 * 1024, 6 * 1024));
+        ASSERT_TRUE(SimpleTiledL1WriteCBRead(device, {0, 0}, lo_address + 8 * 1024, lo_address + 16 * 1024, 2 * 1024));
+        ASSERT_TRUE(SimpleTiledL1WriteCBRead(device, {0, 0}, lo_address + 8 * 1024, lo_address + 16 * 1024, 4 * 1024));
+        ASSERT_TRUE(SimpleTiledL1WriteCBRead(device, {0, 0}, lo_address + 8 * 1024, lo_address + 16 * 1024, 6 * 1024));
     }
 }
 
 TEST_F(MeshDeviceFixture, TensixTestSimpleL1ReadWriteTileHi) {
-    for (unsigned int id = 0; id < num_devices_; id++) {
-        size_t hi_address = this->devices_.at(id)->l1_size_per_core() - (24 * 1024);
-        ASSERT_TRUE(SimpleTiledL1WriteCBRead(
-            this->devices_.at(id), {0, 0}, hi_address + 8 * 1024, hi_address + 16 * 1024, 2 * 1024));
-        ASSERT_TRUE(SimpleTiledL1WriteCBRead(
-            this->devices_.at(id), {0, 0}, hi_address + 8 * 1024, hi_address + 16 * 1024, 4 * 1024));
-        ASSERT_TRUE(SimpleTiledL1WriteCBRead(
-            this->devices_.at(id), {0, 0}, hi_address + 8 * 1024, hi_address + 16 * 1024, 6 * 1024));
+    for (auto& device : this->devices_) {
+        size_t hi_address = device->l1_size_per_core() - (24 * 1024);
+        ASSERT_TRUE(SimpleTiledL1WriteCBRead(device, {0, 0}, hi_address + 8 * 1024, hi_address + 16 * 1024, 2 * 1024));
+        ASSERT_TRUE(SimpleTiledL1WriteCBRead(device, {0, 0}, hi_address + 8 * 1024, hi_address + 16 * 1024, 4 * 1024));
+        ASSERT_TRUE(SimpleTiledL1WriteCBRead(device, {0, 0}, hi_address + 8 * 1024, hi_address + 16 * 1024, 6 * 1024));
     }
 }
 
 TEST_F(MeshDeviceFixture, TensixTestSimpleL1ReadWritex2y2TileLo) {
-    for (unsigned int id = 0; id < num_devices_; id++) {
+    for (auto& device : this->devices_) {
         size_t lo_address = 768 * 1024;
-        ASSERT_TRUE(SimpleTiledL1WriteCBRead(
-            this->devices_.at(id), {2, 2}, lo_address + 8 * 1024, lo_address + 16 * 1024, 2 * 1024));
-        ASSERT_TRUE(SimpleTiledL1WriteCBRead(
-            this->devices_.at(id), {2, 2}, lo_address + 8 * 1024, lo_address + 16 * 1024, 4 * 1024));
-        ASSERT_TRUE(SimpleTiledL1WriteCBRead(
-            this->devices_.at(id), {2, 2}, lo_address + 8 * 1024, lo_address + 16 * 1024, 6 * 1024));
+        ASSERT_TRUE(SimpleTiledL1WriteCBRead(device, {2, 2}, lo_address + 8 * 1024, lo_address + 16 * 1024, 2 * 1024));
+        ASSERT_TRUE(SimpleTiledL1WriteCBRead(device, {2, 2}, lo_address + 8 * 1024, lo_address + 16 * 1024, 4 * 1024));
+        ASSERT_TRUE(SimpleTiledL1WriteCBRead(device, {2, 2}, lo_address + 8 * 1024, lo_address + 16 * 1024, 6 * 1024));
     }
 }
 
 TEST_F(MeshDeviceFixture, TensixTestSimpleL1ReadWritex2y2TileHi) {
-    for (unsigned int id = 0; id < num_devices_; id++) {
-        size_t hi_address = this->devices_.at(id)->l1_size_per_core() - (24 * 1024);
-        ASSERT_TRUE(SimpleTiledL1WriteCBRead(
-            this->devices_.at(id), {2, 2}, hi_address + 8 * 1024, hi_address + 16 * 1024, 2 * 1024));
-        ASSERT_TRUE(SimpleTiledL1WriteCBRead(
-            this->devices_.at(id), {2, 2}, hi_address + 8 * 1024, hi_address + 16 * 1024, 4 * 1024));
-        ASSERT_TRUE(SimpleTiledL1WriteCBRead(
-            this->devices_.at(id), {2, 2}, hi_address + 8 * 1024, hi_address + 16 * 1024, 6 * 1024));
+    for (auto& device : this->devices_) {
+        size_t hi_address = device->l1_size_per_core() - (24 * 1024);
+        ASSERT_TRUE(SimpleTiledL1WriteCBRead(device, {2, 2}, hi_address + 8 * 1024, hi_address + 16 * 1024, 2 * 1024));
+        ASSERT_TRUE(SimpleTiledL1WriteCBRead(device, {2, 2}, hi_address + 8 * 1024, hi_address + 16 * 1024, 4 * 1024));
+        ASSERT_TRUE(SimpleTiledL1WriteCBRead(device, {2, 2}, hi_address + 8 * 1024, hi_address + 16 * 1024, 6 * 1024));
     }
 }
 

--- a/tests/tt_metal/tt_metal/common/device_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/device_fixture.hpp
@@ -30,12 +30,6 @@ protected:
         }
         this->arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());
 
-        // Some CI machines have lots of cards, running all tests on all cards is slow
-        // Coverage for multidevices is decent if we just confirm 2 work
-        this->num_devices_ = tt::tt_metal::GetNumAvailableDevices();
-        if (num_devices_ > 2) {
-            this->num_devices_ = 2;
-        }
         std::vector<ChipId> ids;
         for (ChipId id : tt::tt_metal::MetalContext::instance().get_cluster().all_chip_ids()) {
             ids.push_back(id);
@@ -67,20 +61,19 @@ protected:
     void create_devices(const std::vector<ChipId>& device_ids) {
         const auto& dispatch_core_config =
             tt::tt_metal::MetalContext::instance().rtoptions().get_dispatch_core_config();
+        // TODO: Some CI machines have lots of cards, running all tests on all the cards is slow.
+        // Coverage for multidevices should be decent if we just confirm 2 work.
         id_to_device_ = distributed::MeshDevice::create_unit_meshes(
             device_ids, l1_small_size_, trace_region_size_, 1, dispatch_core_config);
         devices_.clear();
         for (const auto& [device_id, device] : id_to_device_) {
             devices_.push_back(device);
         }
-        this->num_devices_ = this->devices_.size();
     }
 
     explicit MeshDeviceFixture(
         size_t l1_small_size = DEFAULT_L1_SMALL_SIZE, size_t trace_region_size = DEFAULT_TRACE_REGION_SIZE) :
         MeshDispatchFixture(l1_small_size, trace_region_size) {}
-
-    size_t num_devices_{};
 
 public:
     std::pair<unsigned, unsigned> worker_grid_minimum_dims() {
@@ -143,12 +136,10 @@ protected:
         for (const auto& [device_id, device] : id_to_device_) {
             devices_.push_back(device);
         }
-        this->num_devices_ = this->devices_.size();
     }
 
     std::vector<std::shared_ptr<distributed::MeshDevice>> devices_;
     std::map<ChipId, std::shared_ptr<distributed::MeshDevice>> id_to_device_;
-    size_t num_devices_{};
 };
 
 class MeshDeviceSingleCardBufferFixture : public MeshDeviceSingleCardFixture {};

--- a/tests/tt_metal/tt_metal/data_movement/interleaved_to_sharded_hardcoded/test_interleaved_to_sharded_hardcoded.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/interleaved_to_sharded_hardcoded/test_interleaved_to_sharded_hardcoded.cpp
@@ -415,10 +415,10 @@ TEST_F(MeshDeviceFixture, TensixDataMovementI2SWriterShardedDramRowMajor) {
         .master_core_coord = master_core_coord};
 
     // Run
-    for (unsigned int id = 0; id < num_devices_; id++) {
-        log_info(tt::LogTest, "Running test on device {}", id);
+    for (auto& device : this->devices_) {
+        log_info(tt::LogTest, "Running test on device {}", device->id());
         EXPECT_TRUE(unit_tests::dm::interleaved_to_sharded_hardcoded::test1_writer_sharded_dram_row_major::run_dm(
-            devices_.at(id), test_config));
+            device, test_config));
     }
 }
 
@@ -463,9 +463,9 @@ TEST_F(MeshDeviceFixture, TensixDataMovementI2SWriterShardedDramTile) {
         .master_core_coord = master_core_coord};
 
     // Run
-    for (unsigned int id = 0; id < num_devices_; id++) {
+    for (auto& device : this->devices_) {
         EXPECT_TRUE(unit_tests::dm::interleaved_to_sharded_hardcoded::test2_writer_sharded_dram_tile::run_dm(
-            devices_.at(id), test_config));
+            device, test_config));
     }
 }
 
@@ -505,9 +505,9 @@ TEST_F(MeshDeviceFixture, TensixDataMovementI2SDRAMInterleavedReaderTile) {
         .input_data_format = tt::DataFormat::Float16_b};
 
     // Run
-    for (unsigned int id = 0; id < num_devices_; id++) {
+    for (auto& device : this->devices_) {
         EXPECT_TRUE(unit_tests::dm::interleaved_to_sharded_hardcoded::test3_interleaved_reader_tile_dram::run_dm(
-            devices_.at(id), test_config));
+            device, test_config));
     }
 }
 
@@ -547,9 +547,9 @@ TEST_F(MeshDeviceFixture, TensixDataMovementI2SL1InterleavedReaderTile) {
         .input_data_format = tt::DataFormat::Float16_b};
 
     // Run
-    for (unsigned int id = 0; id < num_devices_; id++) {
+    for (auto& device : this->devices_) {
         EXPECT_TRUE(unit_tests::dm::interleaved_to_sharded_hardcoded::test4_interleaved_reader_tile_l1::run_dm(
-            devices_.at(id), test_config));
+            device, test_config));
     }
 }
 
@@ -593,9 +593,9 @@ TEST_F(MeshDeviceFixture, TensixDataMovementI2SDRAMInterleavedReaderRowMajor) {
         .master_core_coord = master_core_coord};
 
     // Run
-    for (unsigned int id = 0; id < num_devices_; id++) {
+    for (auto& device : this->devices_) {
         EXPECT_TRUE(unit_tests::dm::interleaved_to_sharded_hardcoded::test5_interleaved_reader_row_major_dram::run_dm(
-            devices_.at(id), test_config));
+            device, test_config));
     }
 }
 
@@ -639,9 +639,9 @@ TEST_F(MeshDeviceFixture, TensixDataMovementI2SL1InterleavedReaderRowMajor) {
         .master_core_coord = master_core_coord};
 
     // Run
-    for (unsigned int id = 0; id < num_devices_; id++) {
+    for (auto& device : this->devices_) {
         EXPECT_TRUE(unit_tests::dm::interleaved_to_sharded_hardcoded::test6_interleaved_reader_row_major_l1::run_dm(
-            devices_.at(id), test_config));
+            device, test_config));
     }
 }
 

--- a/tests/tt_metal/tt_metal/device/test_device.cpp
+++ b/tests/tt_metal/tt_metal/device/test_device.cpp
@@ -262,7 +262,7 @@ TEST_F(MeshDeviceFixture, TensixValidateKernelDoesNotTargetHarvestedCores) {
 // For a given collection of MMIO device and remote devices, ensure that channels are unique
 TEST_F(MeshDeviceFixture, TestDeviceToHostMemChannelAssignment) {
     std::unordered_map<ChipId, std::set<ChipId>> mmio_device_to_device_group;
-    for (unsigned int dev_id = 0; dev_id < num_devices_; dev_id++) {
+    for (unsigned int dev_id = 0; dev_id < this->devices_.size(); dev_id++) {
         ChipId assoc_mmio_dev_id =
             tt::tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(dev_id);
         std::set<ChipId>& device_ids = mmio_device_to_device_group[assoc_mmio_dev_id];

--- a/tests/tt_metal/tt_metal/device/test_device.cpp
+++ b/tests/tt_metal/tt_metal/device/test_device.cpp
@@ -115,90 +115,88 @@ bool dram_ping(
 }  // namespace unit_tests::basic::device
 
 TEST_F(MeshDeviceFixture, PingAllLegalDramChannels) {
-    for (unsigned int id = 0; id < num_devices_; id++) {
+    for (auto& device : this->devices_) {
         {
-            size_t start_byte_address = devices_.at(id)->allocator()->get_base_allocator_addr(HalMemType::DRAM);
+            size_t start_byte_address = device->allocator()->get_base_allocator_addr(HalMemType::DRAM);
+            ASSERT_TRUE(
+                unit_tests::basic::device::dram_ping(device, 4, start_byte_address, device->num_dram_channels()));
+            ASSERT_TRUE(
+                unit_tests::basic::device::dram_ping(device, 12, start_byte_address, device->num_dram_channels()));
+            ASSERT_TRUE(
+                unit_tests::basic::device::dram_ping(device, 16, start_byte_address, device->num_dram_channels()));
+            ASSERT_TRUE(
+                unit_tests::basic::device::dram_ping(device, 1024, start_byte_address, device->num_dram_channels()));
             ASSERT_TRUE(unit_tests::basic::device::dram_ping(
-                devices_.at(id), 4, start_byte_address, devices_.at(id)->num_dram_channels()));
+                device, 2 * 1024, start_byte_address, device->num_dram_channels()));
             ASSERT_TRUE(unit_tests::basic::device::dram_ping(
-                devices_.at(id), 12, start_byte_address, devices_.at(id)->num_dram_channels()));
-            ASSERT_TRUE(unit_tests::basic::device::dram_ping(
-                devices_.at(id), 16, start_byte_address, devices_.at(id)->num_dram_channels()));
-            ASSERT_TRUE(unit_tests::basic::device::dram_ping(
-                devices_.at(id), 1024, start_byte_address, devices_.at(id)->num_dram_channels()));
-            ASSERT_TRUE(unit_tests::basic::device::dram_ping(
-                devices_.at(id), 2 * 1024, start_byte_address, devices_.at(id)->num_dram_channels()));
-            ASSERT_TRUE(unit_tests::basic::device::dram_ping(
-                devices_.at(id), 32 * 1024, start_byte_address, devices_.at(id)->num_dram_channels()));
+                device, 32 * 1024, start_byte_address, device->num_dram_channels()));
         }
         {
-            size_t start_byte_address = devices_.at(id)->dram_size_per_channel() - (32 * 1024);
+            size_t start_byte_address = device->dram_size_per_channel() - (32 * 1024);
+            ASSERT_TRUE(
+                unit_tests::basic::device::dram_ping(device, 4, start_byte_address, device->num_dram_channels()));
+            ASSERT_TRUE(
+                unit_tests::basic::device::dram_ping(device, 12, start_byte_address, device->num_dram_channels()));
+            ASSERT_TRUE(
+                unit_tests::basic::device::dram_ping(device, 16, start_byte_address, device->num_dram_channels()));
+            ASSERT_TRUE(
+                unit_tests::basic::device::dram_ping(device, 1024, start_byte_address, device->num_dram_channels()));
             ASSERT_TRUE(unit_tests::basic::device::dram_ping(
-                devices_.at(id), 4, start_byte_address, devices_.at(id)->num_dram_channels()));
+                device, 2 * 1024, start_byte_address, device->num_dram_channels()));
             ASSERT_TRUE(unit_tests::basic::device::dram_ping(
-                devices_.at(id), 12, start_byte_address, devices_.at(id)->num_dram_channels()));
-            ASSERT_TRUE(unit_tests::basic::device::dram_ping(
-                devices_.at(id), 16, start_byte_address, devices_.at(id)->num_dram_channels()));
-            ASSERT_TRUE(unit_tests::basic::device::dram_ping(
-                devices_.at(id), 1024, start_byte_address, devices_.at(id)->num_dram_channels()));
-            ASSERT_TRUE(unit_tests::basic::device::dram_ping(
-                devices_.at(id), 2 * 1024, start_byte_address, devices_.at(id)->num_dram_channels()));
-            ASSERT_TRUE(unit_tests::basic::device::dram_ping(
-                devices_.at(id), 32 * 1024, start_byte_address, devices_.at(id)->num_dram_channels()));
+                device, 32 * 1024, start_byte_address, device->num_dram_channels()));
         }
     }
 }
 TEST_F(MeshDeviceFixture, PingIllegalDramChannels) {
-    for (unsigned int id = 0; id < num_devices_; id++) {
-        auto num_channels = devices_.at(id)->num_dram_channels() + 1;
-        size_t start_byte_address = devices_.at(id)->allocator()->get_base_allocator_addr(HalMemType::DRAM);
+    for (auto& device : this->devices_) {
+        auto num_channels = device->num_dram_channels() + 1;
+        size_t start_byte_address = device->allocator()->get_base_allocator_addr(HalMemType::DRAM);
         ;
-        ASSERT_ANY_THROW(unit_tests::basic::device::dram_ping(devices_.at(id), 4, start_byte_address, num_channels));
+        ASSERT_ANY_THROW(unit_tests::basic::device::dram_ping(device, 4, start_byte_address, num_channels));
     }
 }
 
 TEST_F(MeshDeviceFixture, TensixPingAllLegalL1Cores) {
-    for (unsigned int id = 0; id < num_devices_; id++) {
+    for (auto& device : this->devices_) {
         {
-            size_t start_byte_address = devices_.at(id)->allocator()->get_base_allocator_addr(HalMemType::L1);
-            ASSERT_TRUE(unit_tests::basic::device::l1_ping(
-                devices_.at(id), 4, start_byte_address, devices_.at(id)->logical_grid_size()));
-            ASSERT_TRUE(unit_tests::basic::device::l1_ping(
-                devices_.at(id), 12, start_byte_address, devices_.at(id)->logical_grid_size()));
-            ASSERT_TRUE(unit_tests::basic::device::l1_ping(
-                devices_.at(id), 16, start_byte_address, devices_.at(id)->logical_grid_size()));
-            ASSERT_TRUE(unit_tests::basic::device::l1_ping(
-                devices_.at(id), 1024, start_byte_address, devices_.at(id)->logical_grid_size()));
-            ASSERT_TRUE(unit_tests::basic::device::l1_ping(
-                devices_.at(id), 2 * 1024, start_byte_address, devices_.at(id)->logical_grid_size()));
-            ASSERT_TRUE(unit_tests::basic::device::l1_ping(
-                devices_.at(id), 32 * 1024, start_byte_address, devices_.at(id)->logical_grid_size()));
+            size_t start_byte_address = device->allocator()->get_base_allocator_addr(HalMemType::L1);
+            ASSERT_TRUE(unit_tests::basic::device::l1_ping(device, 4, start_byte_address, device->logical_grid_size()));
+            ASSERT_TRUE(
+                unit_tests::basic::device::l1_ping(device, 12, start_byte_address, device->logical_grid_size()));
+            ASSERT_TRUE(
+                unit_tests::basic::device::l1_ping(device, 16, start_byte_address, device->logical_grid_size()));
+            ASSERT_TRUE(
+                unit_tests::basic::device::l1_ping(device, 1024, start_byte_address, device->logical_grid_size()));
+            ASSERT_TRUE(
+                unit_tests::basic::device::l1_ping(device, 2 * 1024, start_byte_address, device->logical_grid_size()));
+            ASSERT_TRUE(
+                unit_tests::basic::device::l1_ping(device, 32 * 1024, start_byte_address, device->logical_grid_size()));
         }
         {
-            size_t start_byte_address = devices_.at(id)->l1_size_per_core() - (32 * 1024);
-            ASSERT_TRUE(unit_tests::basic::device::l1_ping(
-                devices_.at(id), 4, start_byte_address, devices_.at(id)->logical_grid_size()));
-            ASSERT_TRUE(unit_tests::basic::device::l1_ping(
-                devices_.at(id), 12, start_byte_address, devices_.at(id)->logical_grid_size()));
-            ASSERT_TRUE(unit_tests::basic::device::l1_ping(
-                devices_.at(id), 16, start_byte_address, devices_.at(id)->logical_grid_size()));
-            ASSERT_TRUE(unit_tests::basic::device::l1_ping(
-                devices_.at(id), 1024, start_byte_address, devices_.at(id)->logical_grid_size()));
-            ASSERT_TRUE(unit_tests::basic::device::l1_ping(
-                devices_.at(id), 2 * 1024, start_byte_address, devices_.at(id)->logical_grid_size()));
-            ASSERT_TRUE(unit_tests::basic::device::l1_ping(
-                devices_.at(id), 32 * 1024, start_byte_address, devices_.at(id)->logical_grid_size()));
+            size_t start_byte_address = device->l1_size_per_core() - (32 * 1024);
+            ASSERT_TRUE(unit_tests::basic::device::l1_ping(device, 4, start_byte_address, device->logical_grid_size()));
+            ASSERT_TRUE(
+                unit_tests::basic::device::l1_ping(device, 12, start_byte_address, device->logical_grid_size()));
+            ASSERT_TRUE(
+                unit_tests::basic::device::l1_ping(device, 16, start_byte_address, device->logical_grid_size()));
+            ASSERT_TRUE(
+                unit_tests::basic::device::l1_ping(device, 1024, start_byte_address, device->logical_grid_size()));
+            ASSERT_TRUE(
+                unit_tests::basic::device::l1_ping(device, 2 * 1024, start_byte_address, device->logical_grid_size()));
+            ASSERT_TRUE(
+                unit_tests::basic::device::l1_ping(device, 32 * 1024, start_byte_address, device->logical_grid_size()));
         }
     }
 }
 
 TEST_F(MeshDeviceFixture, TensixPingIllegalL1Cores) {
-    for (unsigned int id = 0; id < num_devices_; id++) {
-        auto grid_size = devices_.at(id)->logical_grid_size();
+    for (auto& device : this->devices_) {
+        auto grid_size = device->logical_grid_size();
         grid_size.x++;
         grid_size.y++;
-        size_t start_byte_address = devices_.at(id)->allocator()->get_base_allocator_addr(HalMemType::L1);
-        ASSERT_ANY_THROW(unit_tests::basic::device::l1_ping(devices_.at(id), 4, start_byte_address, grid_size));
+        size_t start_byte_address = device->allocator()->get_base_allocator_addr(HalMemType::L1);
+        ASSERT_ANY_THROW(unit_tests::basic::device::l1_ping(device, 4, start_byte_address, grid_size));
     }
 }
 
@@ -210,8 +208,7 @@ TEST_F(MeshDeviceFixture, TensixPingIllegalL1Cores) {
 // 3. Host validates that the value from step 1 has been incremented
 // Purpose of this test is to ensure that L1 reader/writer APIs do not target harvested cores
 TEST_F(MeshDeviceFixture, TensixValidateKernelDoesNotTargetHarvestedCores) {
-    for (unsigned int id = 0; id < num_devices_; id++) {
-        auto mesh_device = this->devices_.at(id);
+    for (auto& mesh_device : this->devices_) {
         auto* device = mesh_device->get_devices()[0];
         uint32_t num_l1_banks = mesh_device->allocator()->get_num_banks(BufferType::L1);
         std::vector<uint32_t> host_input(1);
@@ -233,7 +230,7 @@ TEST_F(MeshDeviceFixture, TensixValidateKernelDoesNotTargetHarvestedCores) {
 
         std::string kernel_name = "tests/tt_metal/tt_metal/test_kernels/misc/ping_legal_l1s.cpp";
         CoreCoord logical_target_core(0, 0);
-        uint32_t intermediate_l1_addr = devices_.at(id)->allocator()->get_base_allocator_addr(HalMemType::L1);
+        uint32_t intermediate_l1_addr = mesh_device->allocator()->get_base_allocator_addr(HalMemType::L1);
         uint32_t size_bytes = host_input.size() * sizeof(uint32_t);
         tt_metal::CreateKernel(
             program,

--- a/tests/tt_metal/tt_metal/device/test_simulator_device.cpp
+++ b/tests/tt_metal/tt_metal/device/test_simulator_device.cpp
@@ -56,9 +56,7 @@ protected:
 
 TEST_F(SimulatorFixture, SimulatorDeviceInitialization) {
     // Verify that all devices are properly initialized in simulator mode
-    for (unsigned int id = 0; id < num_devices_; id++) {
-        auto mesh_device = devices_.at(id);
-
+    for (auto& mesh_device : this->devices_) {
         // Check that device is valid
         EXPECT_NE(mesh_device, nullptr);
 
@@ -85,8 +83,7 @@ TEST_F(SimulatorFixture, QuasarStaticTlbReadWrite) {
         hal.get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::DEFAULT_UNRESERVED);
     constexpr uint32_t value32 = 0xDEADBEEF;
 
-    for (unsigned int id = 0; id < num_devices_; id++) {
-        const auto mesh_device = devices_.at(id);
+    for (auto& mesh_device : this->devices_) {
         const ChipId chip_id = mesh_device->get_devices()[0]->id();
         const auto& sdesc = cluster.get_soc_desc(chip_id);
 

--- a/tests/tt_metal/tt_metal/llk/llk_device_fixture.hpp
+++ b/tests/tt_metal/tt_metal/llk/llk_device_fixture.hpp
@@ -90,7 +90,6 @@ void apply_shared_state(Fixture& f, const LLKSharedDevices& s) {
     f.arch_ = s.arch;
     f.devices_ = s.devices;
     f.max_cbs_ = s.max_cbs;
-    f.num_devices_ = s.devices.size();
 }
 
 }  // namespace detail

--- a/tests/tt_metal/tt_metal/llk/test_reconfig.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_reconfig.cpp
@@ -1103,9 +1103,8 @@ TEST_F(LLKMeshDeviceFixture, TensixTileCopyReconfigExplicitSplitDstAcc) {
                             .fp32_dest_acc_en = fp32_dest_acc_en,
                             .block_copy = block_copy,
                             .dst_full_sync_en = dst_full_sync_en};
-                        for (unsigned int id = 0; id < num_devices_; id++) {
-                            ASSERT_TRUE(
-                                unit_tests::compute::reconfig::single_core_reconfig(devices_.at(id), test_config));
+                        for (auto& device : this->devices_) {
+                            ASSERT_TRUE(unit_tests::compute::reconfig::single_core_reconfig(device, test_config));
                         }
                     }
                 }
@@ -1120,22 +1119,22 @@ TEST_F(LLKMeshDeviceFixture, TensixTileCopyReconfigL1Acc) {
             log_info(LogTest, "L1 accumulation is {}, DstSyncFull = {}", l1_acc ? "on." : "off.", dst_full_sync_en);
             unit_tests::compute::reconfig::ReconfigConfig test_config = {
                 .num_tiles = 1, .ublock_size_tiles = 1, .dst_full_sync_en = dst_full_sync_en};
-            for (unsigned int id = 0; id < num_devices_; id++) {
-                ASSERT_TRUE(unit_tests::compute::reconfig::single_core_reconfig(devices_.at(id), test_config));
+            for (auto& device : this->devices_) {
+                ASSERT_TRUE(unit_tests::compute::reconfig::single_core_reconfig(device, test_config));
             }
         }
     }
 }
 
 TEST_F(LLKQuasarMeshDeviceSingleCardFixture, TensixUnpackReconfigQuasarDfb) {
-    for (unsigned int id = 0; id < num_devices_; id++) {
-        ASSERT_TRUE(unit_tests::compute::reconfig::single_core_unpack_reconfig_quasar(devices_.at(id)));
+    for (auto& device : this->devices_) {
+        ASSERT_TRUE(unit_tests::compute::reconfig::single_core_unpack_reconfig_quasar(device));
     }
 }
 
 TEST_F(LLKQuasarMeshDeviceSingleCardFixture, TensixPackReconfigQuasarDfb) {
-    for (unsigned int id = 0; id < num_devices_; id++) {
-        ASSERT_TRUE(unit_tests::compute::reconfig::single_core_pack_reconfig_quasar(devices_.at(id)));
+    for (auto& device : this->devices_) {
+        ASSERT_TRUE(unit_tests::compute::reconfig::single_core_pack_reconfig_quasar(device));
     }
 }
 

--- a/tests/tt_metal/tt_metal/llk/test_sfpu_binary_bcast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_sfpu_binary_bcast.cpp
@@ -364,8 +364,8 @@ TEST_P(SfpuBinaryBcastFixture, TensixSfpuBinaryBcast) {
         binop_name.at(cfg.binop),
         unit_tests::compute::sfpu_binary_bcast::df_name.at(cfg.df));
 
-    for (unsigned int id = 0; id < this->num_devices_; ++id) {
-        ASSERT_TRUE(unit_tests::compute::sfpu_binary_bcast::run_sfpu_binary_bcast(this->devices_.at(id), cfg));
+    for (auto& device : this->devices_) {
+        ASSERT_TRUE(unit_tests::compute::sfpu_binary_bcast::run_sfpu_binary_bcast(device, cfg));
     }
 }
 

--- a/tests/tt_metal/tt_metal/llk/test_sfpu_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_sfpu_compute.cpp
@@ -1568,8 +1568,8 @@ TEST_P(SingleCoreSingleMeshDeviceSfpuParameterizedFixture, TensixSfpuCompute) {
         .sfpu_op = sfpu_op,
         .approx_mode = false};
     log_info(tt::LogTest, "Testing SFPU_OP={} num_tiles={}", sfpu_op, num_tiles);
-    for (unsigned int id = 0; id < num_devices_; id++) {
-        EXPECT_TRUE(run_sfpu_all_same_buffer(devices_.at(id), test_config));
+    for (auto& device : this->devices_) {
+        EXPECT_TRUE(run_sfpu_all_same_buffer(device, test_config));
     }
 }
 
@@ -1654,8 +1654,8 @@ TEST_P(SingleCoreSingleMeshDeviceSfpuParameterizedApproxFixture, TensixSfpuCompu
         .sfpu_op = sfpu_op,
         .approx_mode = true};
     log_info(tt::LogTest, "Testing SFPU_OP={} num_tiles={}", sfpu_op, num_tiles);
-    for (unsigned int id = 0; id < num_devices_; id++) {
-        EXPECT_TRUE(run_sfpu_all_same_buffer(devices_.at(id), test_config));
+    for (auto& device : this->devices_) {
+        EXPECT_TRUE(run_sfpu_all_same_buffer(device, test_config));
     }
 }
 INSTANTIATE_TEST_SUITE_P(
@@ -1713,8 +1713,8 @@ TEST_P(SingleCoreSingleMeshDeviceSfpuParameterized32BitDestFixture, TensixSfpuCo
         .approx_mode = false,
         .en_32bit_dest = true};
     log_info(tt::LogTest, "Testing SFPU_OP={} num_tiles={}", sfpu_op, num_tiles);
-    for (unsigned int id = 0; id < num_devices_; id++) {
-        EXPECT_TRUE(run_sfpu_all_same_buffer(devices_.at(id), test_config));
+    for (auto& device : this->devices_) {
+        EXPECT_TRUE(run_sfpu_all_same_buffer(device, test_config));
     }
 }
 
@@ -1784,8 +1784,8 @@ TEST_P(SingleCoreSingleMeshDeviceSfpuParameterized32BitDestApproxFixture, Tensix
         .approx_mode = true,
         .en_32bit_dest = true};
     log_info(tt::LogTest, "Testing SFPU_OP={} num_tiles={}", sfpu_op, num_tiles);
-    for (unsigned int id = 0; id < num_devices_; id++) {
-        EXPECT_TRUE(run_sfpu_all_same_buffer(devices_.at(id), test_config));
+    for (auto& device : this->devices_) {
+        EXPECT_TRUE(run_sfpu_all_same_buffer(device, test_config));
     }
 }
 INSTANTIATE_TEST_SUITE_P(
@@ -1856,8 +1856,8 @@ TEST_P(SingleCoreSingleMeshDeviceSfpuBinaryParameterizedFixture, TensixSfpuBinar
         .sfpu_op = sfpu_op,
         .approx_mode = false};
     log_info(tt::LogTest, "Testing binary SFPU_OP={} num_tiles={}", sfpu_op, num_tiles);
-    for (unsigned int id = 0; id < num_devices_; id++) {
-        EXPECT_TRUE(unit_tests::compute::sfpu::run_sfpu_binary_two_input_buffer(devices_.at(id), test_config));
+    for (auto& device : this->devices_) {
+        EXPECT_TRUE(unit_tests::compute::sfpu::run_sfpu_binary_two_input_buffer(device, test_config));
     }
 }
 
@@ -1903,8 +1903,8 @@ TEST_P(SingleCoreSingleMeshDeviceSfpuTernaryParameterizedFixture, TensixSfpuTern
         .sfpu_op = sfpu_op,
         .approx_mode = false};
     log_info(tt::LogTest, "Testing ternary SFPU_OP={} num_tiles={}", sfpu_op, num_tiles);
-    for (unsigned int id = 0; id < num_devices_; id++) {
-        EXPECT_TRUE(unit_tests::compute::sfpu::run_sfpu_ternary_three_input_buffer(devices_.at(id), test_config));
+    for (auto& device : this->devices_) {
+        EXPECT_TRUE(unit_tests::compute::sfpu::run_sfpu_ternary_three_input_buffer(device, test_config));
     }
 }
 
@@ -1976,8 +1976,8 @@ TEST_P(SingleCoreSingleMeshDeviceSfpuTypecastFixture, TensixSfpuTypecast) {
         "Testing typecast {} -> {}",
         unit_tests::sfpu_util::typecast_device_format_name(in_fmt),
         unit_tests::sfpu_util::typecast_device_format_name(out_fmt));
-    for (unsigned int id = 0; id < num_devices_; id++) {
-        EXPECT_TRUE(unit_tests::compute::sfpu::run_sfpu_typecast(devices_.at(id), in_fmt, out_fmt, 1));
+    for (auto& device : this->devices_) {
+        EXPECT_TRUE(unit_tests::compute::sfpu::run_sfpu_typecast(device, in_fmt, out_fmt, 1));
     }
 }
 

--- a/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
@@ -473,8 +473,8 @@ TEST_F(LLKMeshDeviceFixtureSlowDispatchOnly, TensixBinaryComputeSingleCoreSingle
             .math_fidelity = MathFidelity(i)};
         test_config.num_tiles = 1;
         log_info(tt::LogTest, "Math Fidelity = {}", i);
-        for (unsigned int id = 0; id < num_devices_; id++) {
-            ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
+        for (auto& device : this->devices_) {
+            ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(device, test_config));
         }
     }
 }
@@ -493,8 +493,8 @@ TEST_F(LLKMeshDeviceFixtureSlowDispatchOnly, TensixBinaryComputeSingleCoreSingle
             .math_fidelity = MathFidelity(i)};
         test_config.num_tiles = 1;
         log_info(tt::LogTest, "Math Fidelity = {}", i);
-        for (unsigned int id = 0; id < num_devices_; id++) {
-            ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
+        for (auto& device : this->devices_) {
+            ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(device, test_config));
         }
     }
 }
@@ -513,8 +513,8 @@ TEST_F(LLKMeshDeviceFixtureSlowDispatchOnly, TensixBinaryComputeSingleCoreSingle
             .math_fidelity = MathFidelity(i)};
         test_config.num_tiles = 1;
         log_info(tt::LogTest, "Math Fidelity = {}", i);
-        for (unsigned int id = 0; id < num_devices_; id++) {
-            ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
+        for (auto& device : this->devices_) {
+            ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(device, test_config));
         }
     }
 }
@@ -534,8 +534,8 @@ TEST_F(LLKMeshDeviceFixtureSlowDispatchOnly, TensixBinaryComputeSingleCoreSingle
             .math_fidelity = MathFidelity(i)};
         test_config.num_tiles = 1;
         log_info(tt::LogTest, "Math Fidelity = {}", i);
-        for (unsigned int id = 0; id < num_devices_; id++) {
-            ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
+        for (auto& device : this->devices_) {
+            ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(device, test_config));
         }
     }
 }
@@ -555,8 +555,8 @@ TEST_F(LLKMeshDeviceFixtureSlowDispatchOnly, TensixBinaryComputeSingleCoreSingle
             .math_fidelity = MathFidelity(i)};
         test_config.num_tiles = 1;
         log_info(tt::LogTest, "Math Fidelity = {}", i);
-        for (unsigned int id = 0; id < num_devices_; id++) {
-            ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
+        for (auto& device : this->devices_) {
+            ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(device, test_config));
         }
     }
 }
@@ -576,8 +576,8 @@ TEST_F(LLKMeshDeviceFixtureSlowDispatchOnly, TensixBinaryComputeSingleCoreSingle
             .math_fidelity = MathFidelity(i)};
         test_config.num_tiles = 1;
         log_info(tt::LogTest, "Math Fidelity = {}", i);
-        for (unsigned int id = 0; id < num_devices_; id++) {
-            ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
+        for (auto& device : this->devices_) {
+            ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(device, test_config));
         }
     }
 }
@@ -596,8 +596,8 @@ TEST_F(LLKMeshDeviceFixtureSlowDispatchOnly, TensixBinaryComputeSingleCoreMultiT
             .math_fidelity = MathFidelity(i)};
         test_config.num_tiles = 4;
         log_info(tt::LogTest, "Math Fidelity = {}", i);
-        for (unsigned int id = 0; id < num_devices_; id++) {
-            ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
+        for (auto& device : this->devices_) {
+            ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(device, test_config));
             // TODO: Remove early return once back-to-back tests are passing on Quasar
             if (this->arch_ == ARCH::QUASAR) {
                 return;
@@ -620,8 +620,8 @@ TEST_F(LLKMeshDeviceFixtureSlowDispatchOnly, TensixBinaryComputeSingleCoreMultiT
             .math_fidelity = MathFidelity(i)};
         test_config.num_tiles = 4;
         log_info(tt::LogTest, "Math Fidelity = {}", i);
-        for (unsigned int id = 0; id < num_devices_; id++) {
-            ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
+        for (auto& device : this->devices_) {
+            ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(device, test_config));
             // TODO: Remove early return once back-to-back tests are passing on Quasar
             if (this->arch_ == ARCH::QUASAR) {
                 return;
@@ -644,8 +644,8 @@ TEST_F(LLKMeshDeviceFixtureSlowDispatchOnly, TensixBinaryComputeSingleCoreMultiT
             .math_fidelity = MathFidelity(i)};
         test_config.num_tiles = 4;
         log_info(tt::LogTest, "Math Fidelity = {}", i);
-        for (unsigned int id = 0; id < num_devices_; id++) {
-            ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
+        for (auto& device : this->devices_) {
+            ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(device, test_config));
             // TODO: Remove early return once back-to-back tests are passing on Quasar
             if (this->arch_ == ARCH::QUASAR) {
                 return;
@@ -668,8 +668,8 @@ TEST_F(LLKMeshDeviceFixtureSlowDispatchOnly, TensixBinaryComputeSingleCoreMultiT
             .math_fidelity = MathFidelity(i)};
         test_config.num_tiles = 4;
         log_info(tt::LogTest, "Math Fidelity = {}", i);
-        for (unsigned int id = 0; id < num_devices_; id++) {
-            ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
+        for (auto& device : this->devices_) {
+            ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(device, test_config));
             // TODO: Remove early return once back-to-back tests are passing on Quasar
             if (this->arch_ == ARCH::QUASAR) {
                 return;
@@ -692,8 +692,8 @@ TEST_F(LLKMeshDeviceFixtureSlowDispatchOnly, TensixBinaryComputeSingleCoreMultiT
             .math_fidelity = MathFidelity(i)};
         test_config.num_tiles = 4;
         log_info(tt::LogTest, "Math Fidelity = {}", i);
-        for (unsigned int id = 0; id < num_devices_; id++) {
-            ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
+        for (auto& device : this->devices_) {
+            ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(device, test_config));
             // TODO: Remove early return once back-to-back tests are passing on Quasar
             if (this->arch_ == ARCH::QUASAR) {
                 return;
@@ -716,8 +716,8 @@ TEST_F(LLKMeshDeviceFixtureSlowDispatchOnly, TensixBinaryComputeSingleCoreMultiT
             .math_fidelity = MathFidelity(i)};
         test_config.num_tiles = 4;
         log_info(tt::LogTest, "Math Fidelity = {}", i);
-        for (unsigned int id = 0; id < num_devices_; id++) {
-            ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
+        for (auto& device : this->devices_) {
+            ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(device, test_config));
             // TODO: Remove early return once back-to-back tests are passing on Quasar
             if (this->arch_ == ARCH::QUASAR) {
                 return;
@@ -742,8 +742,8 @@ TEST_F(LLKMeshDeviceFixtureSlowDispatchOnly, TensixBinaryComputeSingleCoreMultiT
             .math_fidelity = MathFidelity(i),
         };
         log_info(tt::LogTest, "Math Fidelity = {}", i);
-        for (unsigned int id = 0; id < num_devices_; id++) {
-            ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
+        for (auto& device : this->devices_) {
+            ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(device, test_config));
             // TODO: Remove early return once back-to-back tests are passing on Quasar
             if (this->arch_ == ARCH::QUASAR) {
                 return;
@@ -768,8 +768,8 @@ TEST_F(LLKMeshDeviceFixtureSlowDispatchOnly, TensixBinaryComputeSingleCoreMultiT
             .math_fidelity = MathFidelity(i),
         };
         log_info(tt::LogTest, "Math Fidelity = {}", i);
-        for (unsigned int id = 0; id < num_devices_; id++) {
-            ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
+        for (auto& device : this->devices_) {
+            ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(device, test_config));
             // TODO: Remove early return once back-to-back tests are passing on Quasar
             if (this->arch_ == ARCH::QUASAR) {
                 return;
@@ -794,8 +794,8 @@ TEST_F(LLKMeshDeviceFixtureSlowDispatchOnly, TensixBinaryComputeSingleCoreMultiT
             .math_fidelity = MathFidelity(i),
         };
         log_info(tt::LogTest, "Math Fidelity = {}", i);
-        for (unsigned int id = 0; id < num_devices_; id++) {
-            ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
+        for (auto& device : this->devices_) {
+            ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(device, test_config));
             // TODO: Remove early return once back-to-back tests are passing on Quasar
             if (this->arch_ == ARCH::QUASAR) {
                 return;

--- a/tests/tt_metal/tt_metal/llk/test_single_core_matmul_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_single_core_matmul_compute.cpp
@@ -983,37 +983,37 @@ bool blocked_matmul(const std::shared_ptr<distributed::MeshDevice>& mesh_device,
 }  // namespace unit_tests::compute::matmul
 
 TEST_F(LLKMeshDeviceFixture, TensixTestSingleCoreSingleTileComputeMatmul) {
-    for (unsigned int id = 0; id < num_devices_; id++) {
-        ASSERT_TRUE(unit_tests::compute::matmul::single_tile_matmul(this->devices_.at(id)));
+    for (auto& device : this->devices_) {
+        ASSERT_TRUE(unit_tests::compute::matmul::single_tile_matmul(device));
     }
 }
 TEST_F(LLKMeshDeviceFixture, TensixTestSingleCoreSingleBlockSingleTileComputeMatmul) {
-    for (unsigned int id = 0; id < num_devices_; id++) {
-        ASSERT_TRUE(unit_tests::compute::matmul::single_block_matmul(this->devices_.at(id), 1, 1, 1));
+    for (auto& device : this->devices_) {
+        ASSERT_TRUE(unit_tests::compute::matmul::single_block_matmul(device, 1, 1, 1));
     }
 }
 TEST_F(LLKMeshDeviceFixture, TensixTestSingleCoreSingleBlockSingleTileAccumulationComputeMatmul) {
-    for (unsigned int id = 0; id < num_devices_; id++) {
-        ASSERT_TRUE(unit_tests::compute::matmul::single_block_matmul(this->devices_.at(id), 1, 2, 1));
+    for (auto& device : this->devices_) {
+        ASSERT_TRUE(unit_tests::compute::matmul::single_block_matmul(device, 1, 2, 1));
     }
 }
 TEST_F(LLKMeshDeviceFixture, TensixTestSingleCoreSingleBlockSingleTileNoAccumulationComputeMatmul) {
-    for (unsigned int id = 0; id < num_devices_; id++) {
-        ASSERT_TRUE(unit_tests::compute::matmul::single_block_matmul(this->devices_.at(id), 2, 1, 2));
+    for (auto& device : this->devices_) {
+        ASSERT_TRUE(unit_tests::compute::matmul::single_block_matmul(device, 2, 1, 2));
     }
 }
 TEST_F(LLKMeshDeviceFixture, TensixTestSingleCoreMultiBlockSpillReloadComputeMatmul) {
     unit_tests::compute::matmul::BlockedMatmulConfig config{
         .M = 2, .K = 2, .N = 2, .num_blocks = 4, .packer_l1_acc = false};
-    for (unsigned int id = 0; id < num_devices_; id++) {
-        ASSERT_TRUE(unit_tests::compute::matmul::blocked_matmul(this->devices_.at(id), config));
+    for (auto& device : this->devices_) {
+        ASSERT_TRUE(unit_tests::compute::matmul::blocked_matmul(device, config));
     }
 }
 TEST_F(LLKMeshDeviceFixture, TensixTestSingleCoreMultiBlockL1AccComputeMatmul) {
     unit_tests::compute::matmul::BlockedMatmulConfig config{
         .M = 2, .K = 2, .N = 2, .num_blocks = 4, .packer_l1_acc = true};
-    for (unsigned int id = 0; id < num_devices_; id++) {
-        ASSERT_TRUE(unit_tests::compute::matmul::blocked_matmul(this->devices_.at(id), config));
+    for (auto& device : this->devices_) {
+        ASSERT_TRUE(unit_tests::compute::matmul::blocked_matmul(device, config));
     }
 }
 


### PR DESCRIPTION
### PR Category
Cleanup, Test Only

### Summary

MeshDeviceFixture stores `num_devices_`, which always duplicates `devices_.size()`.
Maintaining them together adds extra error-prone work, and we'll need to update this fixture for the `IDevice` cleanup.

* `num_devices_` is removed from MeshDeviceFixture and its derived classes.
* Most usages looked like this
```c++
    for (unsigned int id = 0; id < num_devices_; id++) {
        auto mesh_device = this->devices_.at(id);
```
They are simplified to
```c++
    for (auto& mesh_device : this->devices_) {
```

### Notes for reviewers
The only meaningful changes are in one file
https://github.com/tenstorrent/tt-metal/pull/51644/changes#diff-b6299b240d5d24a992c2a5db41cb75278dde61be939786787c12286dd9c0ef61

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=obacherikov-tests-num_devices)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:obacherikov-tests-num_devices)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=obacherikov-tests-num_devices)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:obacherikov-tests-num_devices)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=obacherikov-tests-num_devices)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:obacherikov-tests-num_devices)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=obacherikov-tests-num_devices)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:obacherikov-tests-num_devices)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=obacherikov-tests-num_devices)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:obacherikov-tests-num_devices)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=obacherikov-tests-num_devices)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:obacherikov-tests-num_devices)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=obacherikov-tests-num_devices)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:obacherikov-tests-num_devices)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=obacherikov-tests-num_devices)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:obacherikov-tests-num_devices)