### PR TITLE
[backport] ttop allocation actions: converge with main (#50729 + #51647)

### DIFF
--- a/.github/actions/ttop-await-resource/action.yaml
+++ b/.github/actions/ttop-await-resource/action.yaml
@@ -1,0 +1,137 @@
+name: 'ttop await'
+description: 'OIDC-authenticated kubectl loop: poll a resource until ready, or delete it'
+
+inputs:
+  namespace:
+    description: 'Target namespace for the resource'
+    required: false
+    default: 'ttop-ci'
+  resource:
+    description: 'Resource to act on as <kind>/<name> eg allocation/<allocation_name>'
+    required: true
+  mode: #type of action: poll or delete for now
+    description: 'Operation: "poll" (wait until jsonpath == expected) or "delete" (delete until gone).'
+    required: true
+  jsonpath:
+    description: 'poll mode only: kubectl jsonpath to read (eg {.status.phase})'
+    required: false
+    default: ''
+  expected:
+    description: 'poll mode only: value the jsonpath must equal to be considered ready (eg Allocated)'
+    required: false
+    default: ''
+  timeoutSeconds:
+    description: 'Max seconds to keep retrying before failing (default 5 min).'
+    required: false
+    default: '300'
+  retries:
+    description: 'Number of retries minting the OIDC in one attempt before giving up'
+    required: false
+    default: '3'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: OIDC kubectl loop
+      shell: bash
+      env:
+        NAMESPACE: ${{ inputs.namespace }}
+        RESOURCE: ${{ inputs.resource }}
+        MODE: ${{ inputs.mode }}
+        JSONPATH: ${{ inputs.jsonpath }}
+        EXPECTED: ${{ inputs.expected }}
+        OVERALL_TIMEOUT: ${{ inputs.timeoutSeconds }}
+        RETRIES: ${{ inputs.retries }}
+      run: |
+        POLL_INTERVAL=5
+        MAX_AUTH_FAILURES=3
+        # Default 5 min: long enough to ride out a token expiry / transient blip,
+        # short enough not to pin a runner. Override via the timeoutSeconds input.
+        OVERALL_TIMEOUT="${OVERALL_TIMEOUT:-300}"
+        RETRIES="${RETRIES:-3}"
+
+        case "$MODE" in poll|delete) ;; *) echo "::error::mode must be poll or delete"; exit 1 ;; esac
+        if [[ "$MODE" == poll && ( -z "$JSONPATH" || -z "$EXPECTED" ) ]]; then
+          echo "::error::poll mode requires jsonpath and expected"; exit 1
+        fi
+
+        # Mints a fresh OIDC token into IDTOKEN and masks it, so every caller gets
+        # a masked token without having to remember to mask it. Retries in-place so
+        # a brief token-endpoint blip (e.g. a DNS "could not resolve host", exit 6 —
+        # the failure that left allocations dangling) is absorbed.
+        mint_token() {
+          local t i
+          for ((i=1; i<=RETRIES; i++)); do
+            t=$(curl -s --max-time 30 \
+              -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+              "$ACTIONS_ID_TOKEN_REQUEST_URL" \
+              -H "Accept: application/json; api-version=2.0" \
+              -H "Content-Type: application/json" -d "{}" | jq -r '.value') || t=""
+            if [[ -n "$t" && "$t" != "null" ]]; then
+              IDTOKEN="$t"
+              echo "::add-mask::${IDTOKEN}"
+              return 0
+            fi
+            sleep 2
+          done
+          IDTOKEN=""
+          return 1
+        }
+
+        mint_token || true
+
+        auth_failures=0
+        start=$SECONDS
+        while true; do
+          if (( SECONDS - start >= OVERALL_TIMEOUT )); then
+            echo "::error::Timed out after $((OVERALL_TIMEOUT / 60))m waiting for ${RESOURCE} to be (${MODE})."
+            exit 1
+          fi
+
+          # A failed mint leaves IDTOKEN empty; kubectl --token "" prints a
+          # confusing "Please enter Username" error that would NOT match the
+          # auth branch below, so we'd never re-mint. Re-mint here instead of
+          # ever calling kubectl with an empty token.
+          if [[ -z "$IDTOKEN" ]]; then
+            echo "::warning::No valid token yet; (re)minting before the ${MODE}."
+            mint_token || true
+            if [[ -z "$IDTOKEN" ]]; then
+              sleep "$POLL_INTERVAL"
+              continue
+            fi
+          fi
+
+          case "$MODE" in
+            delete)
+              output=$(kubectl --token "$IDTOKEN" -n "$NAMESPACE" delete "$RESOURCE" --ignore-not-found 2>&1) && rc=0 || rc=$?
+              if ((rc==0)); then
+                echo "::notice::$RESOURCE is deleted."
+                exit 0
+              fi
+              ;;
+            poll)
+              output=$(kubectl --token "$IDTOKEN" -n "$NAMESPACE" get "$RESOURCE" -o jsonpath="$JSONPATH" 2>&1) && rc=0 || rc=$?
+              if (( rc == 0 )); then
+                auth_failures=0                                  # successful read → auth is fine, reset streak
+                if [[ "$output" == "$EXPECTED" ]]; then
+                  echo "::notice::$RESOURCE is ready ($EXPECTED)."; exit 0
+                fi
+                echo "[info] $RESOURCE not ready (got '${output:-<empty>}', want '$EXPECTED') — waiting..."
+                sleep "$POLL_INTERVAL"; continue                 # <-- the "waiting" case: loop, DON'T fall into errors
+              fi
+              ;;                                                 # rc != 0 falls through to shared auth/transient
+          esac
+
+          if echo "$output" | grep -qiE 'unauthorized|must be logged in|401'; then
+            auth_failures=$((auth_failures + 1))
+            echo "::warning::Auth failure (${auth_failures}/${MAX_AUTH_FAILURES}) on ${RESOURCE}; reissuing token."
+            if (( auth_failures >= MAX_AUTH_FAILURES )); then
+              echo "::error::Repeated auth failures despite token reissue; failing."
+              exit 1
+            fi
+            mint_token || true
+          else
+            echo "::warning::Transient error on ${RESOURCE} (rc=${rc}): ${output}"
+          fi
+          sleep "$POLL_INTERVAL"
+        done

--- a/.github/actions/ttop-await-resource/action.yaml
+++ b/.github/actions/ttop-await-resource/action.yaml
@@ -44,7 +44,9 @@ runs:
         RETRIES: ${{ inputs.retries }}
       run: |
         POLL_INTERVAL=5
-        MAX_AUTH_FAILURES=3
+        # Was MAX_AUTH_FAILURES=3; any failure now counts, and 3 would abort on a
+        # 15s blip. Bounds a hopeless case to ~5 min vs timeoutSeconds (999m).
+        MAX_CONSECUTIVE_ERRORS=60
         # Default 5 min: long enough to ride out a token expiry / transient blip,
         # short enough not to pin a runner. Override via the timeoutSeconds input.
         OVERALL_TIMEOUT="${OVERALL_TIMEOUT:-300}"
@@ -80,8 +82,9 @@ runs:
 
         mint_token || true
 
-        auth_failures=0
+        errors=0
         start=$SECONDS
+        errfile=$(mktemp)
         while true; do
           if (( SECONDS - start >= OVERALL_TIMEOUT )); then
             echo "::error::Timed out after $((OVERALL_TIMEOUT / 60))m waiting for ${RESOURCE} to be (${MODE})."
@@ -101,37 +104,40 @@ runs:
             fi
           fi
 
+          # stderr to a file, NOT 2>&1: merged, a warning on a successful call lands
+          # in $output and the $EXPECTED compare below fails on a ready resource.
           case "$MODE" in
             delete)
-              output=$(kubectl --token "$IDTOKEN" -n "$NAMESPACE" delete "$RESOURCE" --ignore-not-found 2>&1) && rc=0 || rc=$?
+              output=$(kubectl --token "$IDTOKEN" -n "$NAMESPACE" delete "$RESOURCE" --ignore-not-found 2>"$errfile") && rc=0 || rc=$?
               if ((rc==0)); then
                 echo "::notice::$RESOURCE is deleted."
                 exit 0
               fi
               ;;
             poll)
-              output=$(kubectl --token "$IDTOKEN" -n "$NAMESPACE" get "$RESOURCE" -o jsonpath="$JSONPATH" 2>&1) && rc=0 || rc=$?
+              output=$(kubectl --token "$IDTOKEN" -n "$NAMESPACE" get "$RESOURCE" -o jsonpath="$JSONPATH" 2>"$errfile") && rc=0 || rc=$?
               if (( rc == 0 )); then
-                auth_failures=0                                  # successful read → auth is fine, reset streak
+                errors=0                                         # successful read → reset the failure streak
                 if [[ "$output" == "$EXPECTED" ]]; then
-                  echo "::notice::$RESOURCE is ready ($EXPECTED)."; exit 0
+                  echo "::notice::$RESOURCE is ready ($EXPECTED) after $(( (SECONDS - start) / 60 ))m."; exit 0
                 fi
                 echo "[info] $RESOURCE not ready (got '${output:-<empty>}', want '$EXPECTED') — waiting..."
                 sleep "$POLL_INTERVAL"; continue                 # <-- the "waiting" case: loop, DON'T fall into errors
               fi
-              ;;                                                 # rc != 0 falls through to shared auth/transient
+              ;;                                                 # rc != 0 falls through to the shared error path
           esac
 
-          if echo "$output" | grep -qiE 'unauthorized|must be logged in|401'; then
-            auth_failures=$((auth_failures + 1))
-            echo "::warning::Auth failure (${auth_failures}/${MAX_AUTH_FAILURES}) on ${RESOURCE}; reissuing token."
-            if (( auth_failures >= MAX_AUTH_FAILURES )); then
-              echo "::error::Repeated auth failures despite token reissue; failing."
-              exit 1
-            fi
-            mint_token || true
-          else
-            echo "::warning::Transient error on ${RESOURCE} (rc=${rc}): ${output}"
+          # Re-mint on ANY failure, no error-message classifier. An expired token
+          # often says "the server has asked for the client to provide credentials",
+          # which the old auth regex missed, so it kept polling with a dead token.
+          # The empty-token guard above can't catch it: not empty, just dead.
+          # The token lives ~5 min, so this path runs on every non-trivial wait.
+          errors=$((errors + 1))
+          echo "::warning::${MODE} failed on ${RESOURCE} (${errors}/${MAX_CONSECUTIVE_ERRORS}, rc=${rc}); reissuing token: $(tr '\n' ' ' < "$errfile" | cut -c1-300)"
+          if (( errors >= MAX_CONSECUTIVE_ERRORS )); then
+            echo "::error::Giving up on ${RESOURCE} after ${errors} consecutive failures ($(( errors * POLL_INTERVAL ))s). Last error: $(tr '\n' ' ' < "$errfile" | cut -c1-300)"
+            exit 1
           fi
+          mint_token || true
           sleep "$POLL_INTERVAL"
         done

--- a/.github/actions/ttop-create-allocation/action.yaml
+++ b/.github/actions/ttop-create-allocation/action.yaml
@@ -14,6 +14,14 @@ inputs:
     description: 'Target namespace for the allocation'
     required: false
     default: 'ttop-ci'
+  timeoutSeconds:
+    description: 'Max seconds to keep retrying for allocation before failing.'
+    required: false
+    default: '59940'
+  retries:
+    description: 'Number of retries minting the OIDC in one attempt before giving up'
+    required: false
+    default: '3'
 
 runs:
   using: 'composite'
@@ -51,62 +59,13 @@ runs:
         echo "Creating allocation..."
         printf "%s" "${ALLOCATION_MANIFEST}" | kubectl --token ${{ steps.token.outputs.idToken }} -n ${{ inputs.namespace }} apply -f -
 
-    - name: Wait for allocation
-      shell: bash
-      env:
-        NAMESPACE: ${{ inputs.namespace }}
-        ALLOCATION_NAME: ${{ inputs.allocationName }}
-      run: |
-        echo "[info] Waiting for allocation to be ready..."
-
-        # GitHub OIDC tokens are short-lived (~10-15 min). A single token cannot
-        # cover a long placement wait: once it expires mid-`kubectl wait`, the
-        # client-go watch loops "Unauthorized" forever and never observes the
-        # phase flip. Instead, poll every few seconds and reissue the token
-        # whenever the API server rejects it as unauthenticated.
-        POLL_INTERVAL=5          # seconds between polls
-        OVERALL_TIMEOUT=59940    # seconds (== 999m); matches the previous 999m cap
-        MAX_AUTH_FAILURES=3      # consecutive auth failures (despite reissue) before giving up
-
-        mint_token() {
-          curl -s -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
-            "$ACTIONS_ID_TOKEN_REQUEST_URL" \
-            -H "Accept: application/json; api-version=2.0" \
-            -H "Content-Type: application/json" -d "{}" | jq -r '.value'
-        }
-
-        IDTOKEN=$(mint_token) || true
-        echo "::add-mask::${IDTOKEN}"
-
-        auth_failures=0
-        start=$SECONDS
-        while true; do
-          if (( SECONDS - start >= OVERALL_TIMEOUT )); then
-            echo "::error::Timed out after $((OVERALL_TIMEOUT / 60))m waiting for allocation to reach Allocated."
-            exit 1
-          fi
-
-          output=$(kubectl --token "$IDTOKEN" -n "$NAMESPACE" get "allocation/${ALLOCATION_NAME}" -o jsonpath='{.status.phase}' 2>&1) && rc=0 || rc=$?
-
-          if (( rc == 0 )); then
-            auth_failures=0
-            if [[ "$output" == "Allocated" ]]; then
-              echo "::notice::Allocation ${ALLOCATION_NAME} is Allocated."
-              exit 0
-            fi
-            echo "[info] Allocation phase: '${output:-<empty>}' — waiting..."
-          elif echo "$output" | grep -qiE 'unauthorized|must be logged in|401'; then
-            auth_failures=$((auth_failures + 1))
-            echo "::warning::Auth failure (${auth_failures}/${MAX_AUTH_FAILURES}) while polling allocation; reissuing token."
-            if (( auth_failures >= MAX_AUTH_FAILURES )); then
-              echo "::error::Repeated auth failures despite token reissue; failing."
-              exit 1
-            fi
-            IDTOKEN=$(mint_token) || true
-            echo "::add-mask::${IDTOKEN}"
-          else
-            echo "::warning::Transient error polling allocation (rc=${rc}): ${output}"
-          fi
-
-          sleep "$POLL_INTERVAL"
-        done
+    - name: Wait for Allocation
+      uses: ./.github/actions/ttop-await-resource
+      with:
+        namespace: ${{ inputs.namespace }}
+        resource: allocation/${{ inputs.allocationName }}
+        mode: poll
+        jsonpath: '{.status.phase}'
+        expected: Allocated
+        timeoutSeconds: ${{ inputs.timeoutSeconds }}
+        retries: ${{ inputs.retries }}

--- a/.github/actions/ttop-delete-allocation/action.yaml
+++ b/.github/actions/ttop-delete-allocation/action.yaml
@@ -9,19 +9,23 @@ inputs:
     description: 'Target namespace for the allocation'
     required: false
     default: 'ttop-ci'
+  timeoutSeconds:
+    description: 'Max seconds to keep retrying the delete before failing.'
+    required: false
+    default: '300'
+  retries:
+    description: 'Number of retries minting the OIDC in one attempt before giving up'
+    required: false
+    default: '3'
 
 runs:
   using: 'composite'
   steps:
-    - name: Get github ID token
-      shell: bash
-      id: token
-      run: |
-        IDTOKEN=$(curl -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" $ACTIONS_ID_TOKEN_REQUEST_URL -H "Accept: application/json; api-version=2.0" -H "Content-Type: application/json" -d "{}" | jq -r '.value')
-        echo "::add-mask::${IDTOKEN}"
-        echo "idToken=${IDTOKEN}" >> $GITHUB_OUTPUT
-
     - name: Delete Allocation
-      shell: bash
-      run: |
-        kubectl --token ${{ steps.token.outputs.idToken }} -n ${{ inputs.namespace }} delete allocation/${{ inputs.allocationName }}
+      uses: ./.github/actions/ttop-await-resource
+      with:
+        namespace: ${{ inputs.namespace }}
+        resource: allocation/${{ inputs.allocationName }}
+        mode: delete
+        timeoutSeconds: ${{ inputs.timeoutSeconds }}
+        retries: ${{ inputs.retries }}


### PR DESCRIPTION
### PR Category
Bug fix (backport)

### Summary

Straight cherry-pick of #50729 (`7d8cafb6244`, merged to main 2026-07-24) onto `blaze-metal-main-uplift-july-15-rev0`. **No modifications** — all three action files are byte-identical to `origin/main`:

| file | vs main |
|---|---|
| `ttop-await-resource/action.yaml` | identical |
| `ttop-create-allocation/action.yaml` | identical |
| `ttop-delete-allocation/action.yaml` | identical |

### Why this branch needs it

The uplift branch still carries the pre-#50729 inline poll loop, and it hung tt-blaze run [30573758666](https://github.com/tenstorrent/tt-blaze/actions/runs/30573758666/job/90979661911) for 79 minutes while holding a 16-node SC16 superpod.

Root cause matches what #50729 set out to eliminate — *"never calls kubectl with an empty token"*:

1. `mint_token` began failing mid-wait
2. `IDTOKEN=$(mint_token) || true` left `IDTOKEN` **empty**
3. `kubectl --token ""` does not error — it silently falls back to ambient in-cluster credentials (verified: `kubectl --token "" auth whoami` exits 0 and reports the kubeconfig identity)
4. On that runner (`runs-on: exabox-multihost-with-nfs`) that is `system:serviceaccount:ttop-ci:multihost-with-nfs`, which has no allocation RBAC → **578 consecutive `Forbidden` polls over 49 minutes**
5. The allocation had in fact been `Allocated` for the last 20 of them

#50729 was motivated by the opposite end of the same fragile token flow — dangling allocations when the token endpoint had a DNS blip during `delete` (`curl: (6) Could not resolve host`) — and generalised the fix, so it covers this too.

Taking upstream's fix rather than patching the old inline loop (which was my initial approach in #51634, now closed): it avoids maintaining a parallel implementation of code upstream has deleted, it additionally hardens `ttop-delete-allocation` — directly relevant, since a leaked allocation holds hardware until someone releases it by hand — and it converges this branch with main so the next uplift is a no-op here instead of re-acquiring the divergence.

### Compatibility

Backward-compatible for existing callers. The new inputs all default, and `ttop-create-allocation` sets `timeoutSeconds: 59940`, preserving the previous 999m wait:

```
allocationName  required            spec  required
namespace       default ttop-ci     timeoutSeconds  default 59940     retries  default 3
```

tt-blaze calls it with `allocationName` / `namespace` / `spec` only, so no downstream change is needed. In-tree callers on this branch (`demo-sp-multihost-impl.yaml`, `fabric-multihost-exabox.yaml`) go through the thin wrappers and are unaffected. All three files parse.

### Now carries #51647 too

Second commit cherry-picks #51647 (`9e8204b685b`, merged to main 2026-07-31), which fixes the two defects this PR originally left open. **All three action files are now byte-identical to `origin/main`** — this branch is fully converged, so the next uplift is a no-op here.

The "not sufficient alone" caveat below is therefore resolved: both the empty-token root cause and the expiry-recovery path are covered.

### The bug recurred while this PR sat open

tt-blaze [run 30604693615](https://github.com/tenstorrent/tt-blaze/actions/runs/30604693615) (scheduled, on main's pin `ca0f7801fe`) burned its full 120m step timeout:

```
 117  successful polls (phase NotAvailable)
   3  Auth failure   -> regex matched, reissued, recovered
1285  Forbidden      -> went blind, spun ~107 min to the step timeout
```

Same chain as 30573758666: healthy for ~10 min, 3 expiries recovered because their text happened to match, then a mint failure blanked the token and every later poll hit the ambient service account. **Second confirmed occurrence.** It also settles the question I flagged earlier — the regex matches only sometimes (3 times here), so recovery was a coin flip, exactly as suspected.

That run had an independent capacity problem too (`PLACEMENT_COUNT_INSUFFICIENT_NODES` — single-node `sc1-module` jobs fragmenting the SC16 pool), so it would have failed regardless. But the loop went blind first and would have missed the allocation had capacity freed.

### Not fixed by this PR

Two defects survive in `ttop-await-resource` **on main as well**, so this backport does not introduce them and does not remove them:

- **`2>&1` on the poll capture** (line 113): `output=$(kubectl … -o jsonpath="$JSONPATH" 2>&1)` then `[[ "$output" == "$EXPECTED" ]]`. A warning printed on an otherwise-successful call corrupts the comparison, so a ready resource reads as not-ready. Observed live in run 30573758666 at 19:41 and 19:46, where `E0730 … memcache.go …` appeared where a phase belonged.
- **Fail-open error classifier** (line 125): reissue fires only for `unauthorized|must be logged in|401`; anything else goes to a `Transient error` branch that does not re-mint. An expired-but-non-empty token is not caught by the empty-token guard, so if its message does not match, the loop re-polls with a dead token.

That second one matters more than it looks. On a real 64-minute wait ([tt-blaze run 30585556114](https://github.com/tenstorrent/tt-blaze/actions/runs/30585556114)) the OIDC token expired **12 times, every ~308s** (min 301, max 316) — so the measured token lifetime is ~5 minutes, not the ~10-15 min the original comment assumed. Expiry-recovery is load-bearing on any non-trivial placement wait, not a defensive nicety.

I could not determine from that run's log whether those expiries would have matched main's regex: the warning text is truncated to 300 chars by the logging code itself, so a matching `Unauthorized` line further into stderr would be invisible. Run 30573758666 logged 7 `Auth failure` events against the same regex, which suggests it does match at least sometimes. **So whether this backport alone survives a long wait is genuinely unresolved.** A follow-up against main for those two lines is the safe answer, and a long-wait validation run on this branch is worth doing before relying on it.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ci/backport-50729-ttop-await)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ci/backport-50729-ttop-await)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ci/backport-50729-ttop-await)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ci/backport-50729-ttop-await)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ci/backport-50729-ttop-await)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ci/backport-50729-ttop-await)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ci/backport-50729-ttop-await)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ci/backport-50729-ttop-await)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ci/backport-50729-ttop-await)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ci/backport-50729-ttop-await)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ci/backport-50729-ttop-await)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ci/backport-50729-ttop-await)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ci/backport-50729-ttop-await)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ci/backport-50729-ttop-await)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ci/backport-50729-ttop-await)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ci/backport-50729-ttop-await)
