### PR TITLE
[vLLM] Require explicit decode reload commands

### DIFF
--- a/models/common/demos/llama31_8B_demo.py
+++ b/models/common/demos/llama31_8B_demo.py
@@ -653,15 +653,20 @@ def test_mlp1d_llama_demo(
             out_tok[0] = token_acc.collect_predicted_tokens(out_tok[0].item())
 
         # Decode forward
+        decode_enable_trace = not measure_accuracy
         logits, _ = generator.decode_forward(
             out_tok,
             current_pos,
-            enable_trace=not measure_accuracy,  # Disable trace for accuracy (teacher forcing)
+            enable_trace=decode_enable_trace,  # Disable trace for accuracy (teacher forcing)
             page_table=page_table,
             kv_cache=tt_kv_cache_list,
             sampling_params=device_sampling_params,
             prompt_tokens=input_tokens_prefill_pt,
             output_tokens=out_tok,
+            reload_inputs=iteration == 0 or not decode_enable_trace or device_sampling_params is None,
+            reload_page_table=False,
+            reload_sampling_params=device_sampling_params is not None,
+            reset_sampling_state=device_sampling_params is not None and iteration == 0,
         )
 
         # Get next token

--- a/models/common/models/executor.py
+++ b/models/common/models/executor.py
@@ -391,6 +391,7 @@ class EagerLLMExecutor:
         self._iter_named_modules = iter_named_modules
         self.mode = None
         self._kv_cache: list | None = None
+        self._decode_seed_state_needs_reset = True
 
         # todo)) this could be a composed optional for debug!
         # Output specs captured during compile (for multi-CQ pre-allocation)
@@ -829,6 +830,7 @@ class EagerLLMExecutor:
             assert start_pos.dim() == 1, f"start_pos must be [batch_size], got {start_pos.dim()}D"
         self.mode = Mode.PREFILL
         self._assert_kv_cache_identity(kv_cache)
+        self._decode_seed_state_needs_reset = True
 
         batch_size, batch_seq_len = tokens.shape
         vocab_size = self.model.vocab_size
@@ -1267,9 +1269,28 @@ class EagerLLMExecutor:
             per_request_params = format_sampling_params(broadcast_sampling_params(sampling_params, 0, slot_len=B), B)
             self.model.sampling.apply_decode_state(
                 [per_request_params],
-                reset_batch=False,
+                reload_sampling_params=True,
+                reset_sampling_state=False,
             )
-            self.model.sampling.seed_manager.get_new_values()
+            seed_manager = self.model.sampling.seed_manager
+            seed_slots = list(range(B))
+            if self._decode_seed_state_needs_reset:
+                seed_manager.reset_seed_from_slots(
+                    per_request_params.seed,
+                    seed_slots,
+                )
+                self._decode_seed_state_needs_reset = False
+            else:
+                seed_manager.reset_seed_from_slots_if_needed(
+                    per_request_params.seed,
+                    seed_slots,
+                )
+            seed_manager.align_seed_counters_to_positions(
+                per_request_params.seed,
+                seed_slots,
+                start_pos,
+            )
+            seed_manager.get_new_values(seed_slots)
 
         tt_tokens, tt_current_pos, tt_rot_mat_idxs, tt_page_table = self.prepare_decode_inputs_device(
             tokens, start_pos, page_table
@@ -1408,6 +1429,7 @@ class TracedLLMExecutor:
         # (correct first token + start position). Set after every prefill and at init; cleared once
         # the device has been seeded, after which steady-state steps carry state on device.
         self._decode_needs_reseed: dict[bool, bool] = defaultdict(lambda: True)
+        self._decode_seed_state_needs_reset: dict[bool, bool] = defaultdict(lambda: True)
         # Keyed per sampling-mode (True=on-device sampling, False=host), matching the per-key
         # decode trace + device page_table buffer in trace_inputs_decode. A single shared tensor
         # would let one mode's page-table update mask a needed copy on the other mode's trace
@@ -1732,6 +1754,7 @@ class TracedLLMExecutor:
         # can carry state on its own. Mark all sampling modes stale, and drop the cached page
         # tables so the first post-prefill step always re-copies (device buffers are reused).
         self._decode_needs_reseed = defaultdict(lambda: True)
+        self._decode_seed_state_needs_reset = defaultdict(lambda: True)
         self._prev_decode_page_table = defaultdict(lambda: None)
 
         batch_size, batch_seq_len = tokens.shape
@@ -2174,9 +2197,28 @@ class TracedLLMExecutor:
             per_request_params = format_sampling_params(broadcast_sampling_params(sampling_params, 0, slot_len=B), B)
             self.model.sampling.apply_decode_state(
                 [per_request_params],
-                reset_batch=False,
+                reload_sampling_params=True,
+                reset_sampling_state=False,
             )
-            self.model.sampling.seed_manager.get_new_values()
+            seed_manager = self.model.sampling.seed_manager
+            seed_slots = list(range(B))
+            if self._decode_seed_state_needs_reset[sampling_on_device]:
+                seed_manager.reset_seed_from_slots(
+                    per_request_params.seed,
+                    seed_slots,
+                )
+                self._decode_seed_state_needs_reset[sampling_on_device] = False
+            else:
+                seed_manager.reset_seed_from_slots_if_needed(
+                    per_request_params.seed,
+                    seed_slots,
+                )
+            seed_manager.align_seed_counters_to_positions(
+                per_request_params.seed,
+                seed_slots,
+                start_pos,
+            )
+            seed_manager.get_new_values(seed_slots)
 
         if not self.trace_ids_decode[sampling_on_device]:
             self._capture_decode_trace(tokens, start_pos, page_table, kv_cache, sampling_on_device, sampling_params)

--- a/models/common/sampling/README.md
+++ b/models/common/sampling/README.md
@@ -99,7 +99,7 @@ formats/merges and uploads parameters; `reset_sampling_state=True` rebuilds
 prompt/output penalty state. The flags are independent. The method does NOT
 advance seeds — callers apply slot remaps first, reset/align seeds when state is
 reset, and call `seed_manager.get_new_values()` exactly once per sampled token.
-The legacy `reset_batch=` keyword remains as a compatibility alias.
+Both command flags are required at every decode call.
 
 This contract includes the unconditional first-decode reseed for `seed=None`
 also addressed by
@@ -123,8 +123,8 @@ Generators execute these commands without adding page-table comparisons,
 sampling-mode checks, or model-specific forced reloads. The corresponding
 vLLM and tt-metal revisions are deployed as a pinned pair; there is no
 per-model contract version or old-vLLM compatibility path. Direct non-vLLM
-callers may omit all four commands and retain their existing local behavior.
-Supplying only a subset is an error.
+callers, including demos and warmup code, must also provide all four commands.
+Any demo-side decision to retain traced inputs is made at the call site.
 
 `model_capabilities["supports_async_decode"]` is separate from contract
 versioning. It certifies that a vLLM wrapper supports split async readback and

--- a/models/common/sampling/README.md
+++ b/models/common/sampling/README.md
@@ -93,7 +93,29 @@ plus `apply_decode_state(...)`.
 
 **`SamplingGenerator.apply_prefill_state(...)`**: Reset params, seeds, prompt tokens, and output state for a prefill request.
 
-**`SamplingGenerator.apply_decode_state(chunks, ...)`**: Format/merge params and apply for one model instance. Handles both simple (1 chunk) and row-sharded (multiple chunks) cases. Does NOT advance seeds — callers manage `seed_manager.get_new_values()` separately.
+**`SamplingGenerator.apply_decode_state(chunks, ...)`**: Execute the sampling
+half of vLLM's explicit decode update contract. `reload_sampling_params=True`
+formats/merges and uploads parameters; `reset_sampling_state=True` rebuilds
+prompt/output penalty state. The flags are independent. The method does NOT
+advance seeds — callers apply slot remaps first, reset/align seeds when state is
+reset, and call `seed_manager.get_new_values()` exactly once per sampled token.
+The legacy `reset_batch=` keyword remains as a compatibility alias.
+
+## vLLM Decode Update Contract
+
+Generators that set `decode_input_update_contract = 1` accept four boolean
+commands from the vLLM TT plugin:
+
+- `reload_inputs`: copy every forward trace input.
+- `reload_page_table`: copy only page-table inputs while preserving
+  device-produced token/position state.
+- `reload_sampling_params`: upload sampling configuration.
+- `reset_sampling_state`: rebuild mutable penalty/RNG state for the layout.
+
+When all four are present, generators execute them without adding page-table
+comparisons, sampling-mode checks, or model-specific forced reloads. When all
+are absent, the previous generator heuristics remain available to older vLLM
+versions and demos. Supplying only a subset is an error.
 
 ## Pitfalls
 

--- a/models/common/sampling/README.md
+++ b/models/common/sampling/README.md
@@ -128,6 +128,23 @@ before the forward reads it. This is broader than sampler state: recurrent or
 convolution state indexed by decode slot must be remapped too. Stateless
 adapters accept and may ignore the value.
 
+There are two distinct ways to implement this incompletely:
+
+1. Sending `slot_remap` only on device-sampling decodes leaves model-owned
+   recurrent/conv/RoPE state in the old slot when host sampling changes the
+   layout.
+2. Sending it on every decode but consuming it only inside the active device
+   sampling call leaves dormant seed/RNG/penalty state in the old slot during
+   host sampling. A later switch back to device sampling then resumes the wrong
+   request's state.
+
+Every slot-owning subsystem must therefore consume the remap exactly once on
+every accepted version-1 decode. State read by the forward is remapped before
+that read. A dormant sampler may consume it after successful decode/readback,
+which preserves retry safety because slot remaps are non-idempotent. An
+authoritative rebuild may replace the remap for that subsystem; inactivity may
+not. Empty-batch handling resets the composed layout to identity.
+
 Generators execute these commands without adding page-table comparisons,
 sampling-mode checks, or model-specific forced reloads. The corresponding
 vLLM plugin falls back to the legacy `reset_batch` interface for adapters that
@@ -159,10 +176,11 @@ A model wrapper may opt in only if all of the following hold:
   RoPE trace inputs.
 - All four reload commands are honored independently, without model-local
   heuristics escalating page-table-only refresh into a full reload.
-- Slot remap applies before the forward to every persistent slot-indexed model
-  state in both sampling modes. For device sampling, parameter upload,
-  penalty/RNG reset, and seed advancement follow in that order, with one seed
-  advance per sampled token.
+- Slot remap applies before the forward to every persistent slot-indexed state
+  that the forward reads, in both sampling modes. Dormant sampler state is also
+  remapped exactly once after a successful host-sampling decode. For device
+  sampling, parameter upload, penalty/RNG reset, and seed advancement follow
+  in that order, with one seed advance per sampled token.
 - Persistent buffers remain valid through deferred readback and until an
   explicit reload replaces them.
 

--- a/models/common/sampling/README.md
+++ b/models/common/sampling/README.md
@@ -103,8 +103,7 @@ The legacy `reset_batch=` keyword remains as a compatibility alias.
 
 ## vLLM Decode Update Contract
 
-Generators that set `decode_input_update_contract = 1` accept four boolean
-commands from the vLLM TT plugin:
+The paired vLLM TT plugin sends four boolean commands on every decode:
 
 - `reload_inputs`: copy every forward trace input.
 - `reload_page_table`: copy only page-table inputs while preserving
@@ -112,10 +111,17 @@ commands from the vLLM TT plugin:
 - `reload_sampling_params`: upload sampling configuration.
 - `reset_sampling_state`: rebuild mutable penalty/RNG state for the layout.
 
-When all four are present, generators execute them without adding page-table
-comparisons, sampling-mode checks, or model-specific forced reloads. When all
-are absent, the previous generator heuristics remain available to older vLLM
-versions and demos. Supplying only a subset is an error.
+Generators execute these commands without adding page-table comparisons,
+sampling-mode checks, or model-specific forced reloads. The corresponding
+vLLM and tt-metal revisions are deployed as a pinned pair; there is no
+per-model contract version or old-vLLM compatibility path. Direct non-vLLM
+callers may omit all four commands and retain their existing local behavior.
+Supplying only a subset is an error.
+
+`model_capabilities["supports_async_decode"]` is separate from contract
+versioning. It certifies that a vLLM wrapper supports split async readback and
+device-resident sampled-token feedback; wrappers without it receive explicit
+full-input reload commands instead.
 
 ## Pitfalls
 

--- a/models/common/sampling/README.md
+++ b/models/common/sampling/README.md
@@ -123,6 +123,32 @@ versioning. It certifies that a vLLM wrapper supports split async readback and
 device-resident sampled-token feedback; wrappers without it receive explicit
 full-input reload commands instead.
 
+### Requirements for `supports_async_decode=True`
+
+A model wrapper may opt in only if all of the following hold:
+
+- `decode_forward(..., read_from_device=False)` and
+  `read_decode_output(..., async_read=True)` split submission from observational
+  readback.
+- Device sampling writes the selected token into the persistent token input
+  consumed by the next decode.
+- Decode forward advances the persistent position exactly once; sampling and
+  readback never advance it.
+- Page tables can be refreshed without copying or rebinding token, position, or
+  RoPE trace inputs.
+- All four reload commands are honored independently, without model-local
+  heuristics escalating page-table-only refresh into a full reload.
+- Slot remap, sampling-parameter upload, penalty/RNG reset, and seed advancement
+  occur in that order, with one seed advance per sampled token.
+- Persistent buffers remain valid through deferred readback and until an
+  explicit reload replaces them.
+
+If any item is unsupported, leave the capability absent or `False`. vLLM will
+disable async scheduling and issue a full input reload for every decode. The
+authoritative mode definitions, transition matrix, and correctness invariant
+live in the paired vLLM plugin document
+`plugins/vllm-tt-plugin/docs/decode-reload-contract.md`.
+
 ## Pitfalls
 
 **`padded_vocab_size` vs `vocab_size`**: TTSampling device offsets for global token IDs must use the padded vocab size to match how the LM head shards logits across devices. Using unpadded `vocab_size` for offsets shifts token IDs from devices 1+ and produces garbled output.

--- a/models/common/sampling/README.md
+++ b/models/common/sampling/README.md
@@ -143,7 +143,7 @@ every accepted version-1 decode. State read by the forward is remapped before
 that read. A dormant sampler may consume it after successful decode/readback,
 which preserves retry safety because slot remaps are non-idempotent. An
 authoritative rebuild may replace the remap for that subsystem; inactivity may
-not. Empty-batch handling resets the composed layout to identity.
+not. Version-0 adapters retain their historical remap behavior unchanged.
 
 Generators execute these commands without adding page-table comparisons,
 sampling-mode checks, or model-specific forced reloads. The corresponding

--- a/models/common/sampling/README.md
+++ b/models/common/sampling/README.md
@@ -121,6 +121,13 @@ four boolean commands on every decode:
 - `reload_sampling_params`: upload sampling configuration.
 - `reset_sampling_state`: rebuild mutable penalty/RNG state for the layout.
 
+The plugin also sends `slot_remap` as layout data on every version-1 decode,
+including host-sampling steps. `slot_remap[i] = j` means every persistent state
+owned by new slot `i` must take the continuing request state from old slot `j`
+before the forward reads it. This is broader than sampler state: recurrent or
+convolution state indexed by decode slot must be remapped too. Stateless
+adapters accept and may ignore the value.
+
 Generators execute these commands without adding page-table comparisons,
 sampling-mode checks, or model-specific forced reloads. The corresponding
 vLLM plugin falls back to the legacy `reset_batch` interface for adapters that
@@ -152,8 +159,10 @@ A model wrapper may opt in only if all of the following hold:
   RoPE trace inputs.
 - All four reload commands are honored independently, without model-local
   heuristics escalating page-table-only refresh into a full reload.
-- Slot remap, sampling-parameter upload, penalty/RNG reset, and seed advancement
-  occur in that order, with one seed advance per sampled token.
+- Slot remap applies before the forward to every persistent slot-indexed model
+  state in both sampling modes. For device sampling, parameter upload,
+  penalty/RNG reset, and seed advancement follow in that order, with one seed
+  advance per sampled token.
 - Persistent buffers remain valid through deferred readback and until an
   explicit reload replaces them.
 

--- a/models/common/sampling/README.md
+++ b/models/common/sampling/README.md
@@ -101,6 +101,14 @@ advance seeds — callers apply slot remaps first, reset/align seeds when state 
 reset, and call `seed_manager.get_new_values()` exactly once per sampled token.
 The legacy `reset_batch=` keyword remains as a compatibility alias.
 
+This contract includes the unconditional first-decode reseed for `seed=None`
+also addressed by
+[tt-metal#51556](https://github.com/tenstorrent/tt-metal/pull/51556).
+It does not depend on that PR.
+`reset_sampling_state=True` calls `reset_seed_from_slots(...)` rather than the
+conditional helper, ensuring decode-only sampling actually initializes and
+uploads fresh device seeds when both the requested and cached seed are `None`.
+
 ## vLLM Decode Update Contract
 
 The paired vLLM TT plugin sends four boolean commands on every decode:

--- a/models/common/sampling/README.md
+++ b/models/common/sampling/README.md
@@ -111,7 +111,9 @@ uploads fresh device seeds when both the requested and cached seed are `None`.
 
 ## vLLM Decode Update Contract
 
-The paired vLLM TT plugin sends four boolean commands on every decode:
+Refactored vLLM model adapters advertise
+`decode_input_update_contract = 1`. The vLLM TT plugin sends these adapters
+four boolean commands on every decode:
 
 - `reload_inputs`: copy every forward trace input.
 - `reload_page_table`: copy only page-table inputs while preserving
@@ -121,10 +123,14 @@ The paired vLLM TT plugin sends four boolean commands on every decode:
 
 Generators execute these commands without adding page-table comparisons,
 sampling-mode checks, or model-specific forced reloads. The corresponding
-vLLM and tt-metal revisions are deployed as a pinned pair; there is no
-per-model contract version or old-vLLM compatibility path. Direct non-vLLM
-callers, including demos and warmup code, must also provide all four commands.
-Any demo-side decision to retain traced inputs is made at the call site.
+vLLM plugin falls back to the legacy `reset_batch` interface for adapters that
+do not advertise the contract, preserving their existing reload and overlap
+behavior. vLLM warns that correctness is not guaranteed on that compatibility
+path. This lets vLLM land first and adapters opt in as they are refactored. The
+marker is negotiation metadata on vLLM-facing adapters only; all refactored
+generator APIs require direct callers, including demos and warmup code, to
+provide all four commands. No model-side fallback heuristics are restored. Any
+demo-side decision to retain traced inputs is made at the call site.
 
 `model_capabilities["supports_async_decode"]` is separate from contract
 versioning. It certifies that a vLLM wrapper supports split async readback and

--- a/models/common/sampling/README.md
+++ b/models/common/sampling/README.md
@@ -93,7 +93,147 @@ plus `apply_decode_state(...)`.
 
 **`SamplingGenerator.apply_prefill_state(...)`**: Reset params, seeds, prompt tokens, and output state for a prefill request.
 
-**`SamplingGenerator.apply_decode_state(chunks, ...)`**: Format/merge params and apply for one model instance. Handles both simple (1 chunk) and row-sharded (multiple chunks) cases. Does NOT advance seeds — callers manage `seed_manager.get_new_values()` separately.
+**`SamplingGenerator.apply_decode_state(chunks, ...)`**: Execute the sampling
+half of vLLM's explicit decode update contract. `reload_sampling_params=True`
+formats/merges and uploads parameters; `reset_sampling_state=True` rebuilds
+prompt/output penalty state. The flags are independent. The method does NOT
+advance seeds — callers apply slot remaps first, reset/align seeds when state is
+reset, and call `seed_manager.get_new_values()` exactly once per sampled token.
+Both command flags are required at every decode call.
+
+This contract includes the unconditional first-decode reseed for `seed=None`
+also addressed by
+[tt-metal#51556](https://github.com/tenstorrent/tt-metal/pull/51556).
+It does not depend on that PR.
+`reset_sampling_state=True` calls `reset_seed_from_slots(...)` rather than the
+conditional helper, ensuring decode-only sampling actually initializes and
+uploads fresh device seeds when both the requested and cached seed are `None`.
+
+## vLLM Decode Update Contract
+
+Refactored vLLM model adapters advertise
+`decode_input_update_contract = 1`. The vLLM TT plugin sends these adapters
+four boolean commands on every decode:
+
+- `reload_inputs`: copy every forward trace input.
+- `reload_page_table`: copy only page-table inputs while preserving
+  device-produced token/position state.
+- `reload_sampling_params`: upload sampling configuration.
+- `reset_sampling_state`: rebuild mutable penalty/RNG state for the layout.
+
+When a version-1 layout transition produces a non-identity `slot_remap`, the
+plugin sends it in either sampling mode, including host-sampling steps.
+`slot_remap[i] = j` means every persistent state owned by new slot `i` must take
+the continuing request state from old slot `j` before the forward reads it.
+This is broader than sampler state: recurrent or convolution state indexed by
+decode slot must be remapped too. Stateless adapters accept and may ignore the
+value.
+
+There are two distinct ways to implement this incompletely:
+
+1. Sending `slot_remap` only on device-sampling decodes leaves model-owned
+   recurrent/conv/RoPE state in the old slot when host sampling changes the
+   layout.
+2. Sending it on every decode but neither remapping nor invalidating dormant
+   sampler state leaves seed/RNG/parameter/penalty state in the old slot during
+   host sampling. A later switch back to device sampling can then resume the
+   wrong request's state.
+
+Every slot-owning subsystem must therefore consume each supplied remap exactly
+once on the accepted version-1 decode that carries it. State read by the
+forward is remapped before that read. A dormant sampler consumes it after
+successful decode/readback, which preserves retry safety because slot remaps
+are non-idempotent. Its slot-addressable host RNG state is remapped immediately.
+The sharded device parameter and penalty buffers are instead marked invalid:
+their next activation must command both `reload_sampling_params` and
+`reset_sampling_state`, rebuilding them from authoritative host state before
+they are read. A slot-scoped prefill may rebuild only its newly admitted rows,
+but it does not clear the whole-device invalidation; a later decode still needs
+a whole-device penalty reset together with the parameter upload. The plugin
+issues both commands on every layout or sampling-mode transition, and the
+sampling generator rejects a later direct caller that omits that full rebuild.
+This authoritative rebuild replaces a physical remap for those buffers;
+inactivity alone does not silently accept stale state.
+Version-0 adapters retain their historical remap behavior unchanged.
+
+For a merged lane-DP call the remap uses global lane-major slots, while each
+model replica's seed manager owns a rank-local padded array. The shared
+generator splits by the actual scheduler lane stride, subtracts the lane base,
+and pads the untouched tail with a local identity mapping. Splitting by the
+sampler's padded width instead is incorrect whenever scheduler capacity is
+smaller than that width, and passing absolute lane-1+ indices to a local seed
+manager is out of bounds.
+
+State that is not addressable by vLLM slot cannot be remapped. Unseeded
+on-device RNG is the known exception: its state lives in per-core hardware PRNG
+registers with no slot-to-slot move primitive. A commanded
+`reset_sampling_state` therefore reinitializes it instead. Explicitly seeded,
+slot-addressable counters still follow the request through `slot_remap`. Any
+additional exception must be documented beside the code that skips it and must
+be physically unmovable, not merely inconvenient to move.
+
+Generators execute these commands without adding page-table comparisons,
+sampling-mode checks, or model-specific forced reloads. The corresponding
+vLLM plugin falls back to the legacy `reset_batch` interface for adapters that
+do not advertise the contract, preserving their existing reload and overlap
+behavior. vLLM warns that correctness is not guaranteed on that compatibility
+path. This lets vLLM land first and adapters opt in as they are refactored. The
+marker is negotiation metadata on vLLM-facing adapters only; all refactored
+generator APIs require direct callers, including demos and warmup code, to
+provide all four commands. No model-side fallback heuristics are restored. Any
+demo-side decision to retain traced inputs is made at the call site. Warmup
+reloads each device-sampling parameter configuration but does not request a
+sampling-state reset because it has no request-owned prompt/output history.
+The SGLang bridge explicitly uses host sampling and reloads its authoritative
+token, position, and page table every step.
+
+Stable-slot adapters must also preserve unscheduled rows when admitting a
+prefill. DeepSeek starts from its cached full-batch sampling parameters and
+scatters only the incoming requests into their assigned slots; filling every
+other row from an incoming request silently changes live decodes. Its partial
+prefill also resets prompt/output penalty history and seed state only for the
+incoming slots. Those slots are not the full live set, so continuing seeds are
+not retired. Reset-only sampling commands still need slot-indexed seeds:
+Galaxy formats/pads the request-ordered parameters whenever either
+`reload_sampling_params` or `reset_sampling_state` needs their seed values.
+When Galaxy condenses slots during host sampling, it remaps its cached
+per-slot parameter vectors with the same snapshot as its seed state so a later
+partial prefill starts from the current layout.
+
+`model_capabilities["supports_async_decode"]` is separate from contract
+versioning. It certifies that a vLLM wrapper supports split async readback and
+device-resident sampled-token feedback; wrappers without it receive explicit
+full-input reload commands instead.
+
+### Requirements for `supports_async_decode=True`
+
+A model wrapper may opt in only if all of the following hold:
+
+- `decode_forward(..., read_from_device=False)` and
+  `read_decode_output(..., async_read=True)` split submission from observational
+  readback.
+- Device sampling writes the selected token into the persistent token input
+  consumed by the next decode.
+- Decode forward advances the persistent position exactly once; sampling and
+  readback never advance it.
+- Page tables can be refreshed without copying or rebinding token, position, or
+  RoPE trace inputs.
+- All four reload commands are honored independently, without model-local
+  heuristics escalating page-table-only refresh into a full reload.
+- Slot remap applies before the forward to every persistent slot-indexed state
+  that the forward reads, in both sampling modes. After a successful
+  host-sampling decode, dormant RNG state is remapped and device sampler state
+  is invalidated exactly once. Before device sampling reads that state, an
+  authoritative parameter upload and penalty reset rebuild it. Seed advancement
+  follows, once per sampled token.
+- Persistent buffers remain valid through deferred readback and until an
+  explicit reload replaces them.
+
+If any item is unsupported, leave the capability absent or `False`. vLLM will
+disable async scheduling and issue a full input reload for every decode. The
+authoritative mode definitions, transition matrix, and correctness invariant
+live in the paired standalone plugin document
+[`docs/DECODE_RELOAD_CONTRACT.md`](https://github.com/tenstorrent/vllm-tt-plugin/blob/main/docs/DECODE_RELOAD_CONTRACT.md).
 
 ## Pitfalls
 

--- a/models/common/sampling/README.md
+++ b/models/common/sampling/README.md
@@ -187,6 +187,14 @@ sampling-state reset because it has no request-owned prompt/output history.
 The SGLang bridge explicitly uses host sampling and reloads its authoritative
 token, position, and page table every step.
 
+Trace selection does not authorize a reload. Direct callers switching sampling
+mode or a Gemma4 decode batch bucket must explicitly reload inputs for the
+selected trace. The plugin commands full reloads on sampling-mode and request
+layout transitions; its decode bucket is derived from that request layout.
+Galaxy also carries `reload_inputs` from forward to separated sampling so it
+can realign seeded RNG counters on any authoritative full reload, even without
+a penalty-state reset. It never realigns from stale steady-decode positions.
+
 Stable-slot adapters must also preserve unscheduled rows when admitting a
 prefill. DeepSeek starts from its cached full-batch sampling parameters and
 scatters only the incoming requests into their assigned slots; filling every

--- a/models/common/sampling/__init__.py
+++ b/models/common/sampling/__init__.py
@@ -2,20 +2,19 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-from .tt_sampling import TTSampling
-from .tt_penalties import TTPenalties, apply_penalties
-from .tt_log_probs import LogProbsCalculator, LogProbsResult
+from ._utils import split_list
 from .generator import (
+    SAMPLING_PARAM_FIELDS,
     SamplingGenerator,
     SamplingParams,
-    SAMPLING_PARAM_FIELDS,
-    format_sampling_params,
+    SeedManager,
     broadcast_sampling_params,
     chunk_sampling_params,
-    SeedManager,
-    should_align_decode_seed_counters,
+    format_sampling_params,
 )
-from ._utils import split_list
+from .tt_log_probs import LogProbsCalculator, LogProbsResult
+from .tt_penalties import TTPenalties, apply_penalties
+from .tt_sampling import TTSampling
 
 __all__ = [
     "TTSampling",
@@ -30,6 +29,5 @@ __all__ = [
     "broadcast_sampling_params",
     "chunk_sampling_params",
     "SeedManager",
-    "should_align_decode_seed_counters",
     "split_list",
 ]

--- a/models/common/sampling/__init__.py
+++ b/models/common/sampling/__init__.py
@@ -13,6 +13,7 @@ from .generator import (
     broadcast_sampling_params,
     chunk_sampling_params,
     SeedManager,
+    should_align_decode_seed_counters,
 )
 from ._utils import split_list
 
@@ -29,5 +30,6 @@ __all__ = [
     "broadcast_sampling_params",
     "chunk_sampling_params",
     "SeedManager",
+    "should_align_decode_seed_counters",
     "split_list",
 ]

--- a/models/common/sampling/generator.py
+++ b/models/common/sampling/generator.py
@@ -23,6 +23,18 @@ DEVICE_SEED_MAX = 1_000_000
 _UINT64_MASK = (1 << 64) - 1
 
 
+def should_align_decode_seed_counters(
+    *,
+    explicit_contract: bool,
+    reset_sampling_state: bool,
+    legacy_alignment: bool,
+) -> bool:
+    """Keep legacy seed-position alignment while honoring explicit state flags."""
+    return reset_sampling_state or (
+        not explicit_contract and legacy_alignment
+    )
+
+
 def _hash_request_seed_to_device_seed(seed: int, counter: int) -> int:
     """Derive a stable per-token device seed from a request seed.
 
@@ -178,45 +190,62 @@ class SamplingGenerator:
         self,
         sampling_params_chunks: list,
         *,
-        reset_batch: bool = False,
+        reload_sampling_params: bool = True,
+        reset_sampling_state: bool = False,
+        reset_batch: bool | None = None,
         prompt_tokens: torch.Tensor | None = None,
         output_tokens: torch.Tensor | None = None,
     ):
-        """Format, merge (if row-sharded), and apply sampling params for one model instance.
+        """Apply the explicitly requested parts of decode sampling state.
 
         Args:
             sampling_params_chunks: List of SamplingParams assigned to this instance.
                 Length-1 for simple cases; >1 for row-sharded (sampling_dp > data_parallel).
-            reset_batch: Also reset prompt tokens and output state (first decode step).
+            reload_sampling_params: Upload temperature/top-k/top-p/etc.
+            reset_sampling_state: Rebuild prompt/output penalty state.
             prompt_tokens: Prompt tokens for penalty tracking.
             output_tokens: Output tokens for penalty tracking.
 
         Does NOT call ``seed_manager.get_new_values()`` — callers manage seed
         advancement separately since generators call it at different points.
         """
-        chunks_per_model = len(sampling_params_chunks)
+        if reset_batch is not None:
+            # Compatibility for demos/executors that predate the split
+            # contract. ``reset_batch`` historically always uploaded params
+            # and optionally rebuilt mutable state.
+            reload_sampling_params = True
+            reset_sampling_state = reset_batch
 
-        max_batch_size = self.tt_sampling.max_batch_size
+        if reload_sampling_params:
+            chunks_per_model = len(sampling_params_chunks)
+            max_batch_size = self.tt_sampling.max_batch_size
 
-        if chunks_per_model == 1:
-            formatted_params = format_sampling_params(sampling_params_chunks[0], max_batch_size)
-            self.reset_sampling_params(formatted_params)
-        else:
-            # Row-sharded case: format each chunk to max_batch_size, concatenate.
-            # After (0, None) sharding each row gets its own chunk of max_batch_size entries.
-            # Both TTSampling and TTPenalties use the same concatenated params.
-            formatted_chunks = [format_sampling_params(chunk, max_batch_size) for chunk in sampling_params_chunks]
-            concat_fields = {}
-            for field in SAMPLING_PARAM_FIELDS:
-                lists = [getattr(fc, field) for fc in formatted_chunks]
-                if all(v is None for v in lists):
-                    concat_fields[field] = None
-                else:
-                    concat_fields[field] = sum((v if isinstance(v, list) else [v] for v in lists), [])
-            formatted_params = SamplingParams(**concat_fields)
-            self.reset_sampling_params(formatted_params)
+            if chunks_per_model == 1:
+                formatted_params = format_sampling_params(
+                    sampling_params_chunks[0], max_batch_size
+                )
+                self.reset_sampling_params(formatted_params)
+            else:
+                # Row-sharded case: format each chunk to max_batch_size,
+                # concatenate, then upload one merged parameter set.
+                formatted_chunks = [
+                    format_sampling_params(chunk, max_batch_size)
+                    for chunk in sampling_params_chunks
+                ]
+                concat_fields = {}
+                for field in SAMPLING_PARAM_FIELDS:
+                    lists = [getattr(fc, field) for fc in formatted_chunks]
+                    if all(v is None for v in lists):
+                        concat_fields[field] = None
+                    else:
+                        concat_fields[field] = sum(
+                            (v if isinstance(v, list) else [v] for v in lists),
+                            [],
+                        )
+                formatted_params = SamplingParams(**concat_fields)
+                self.reset_sampling_params(formatted_params)
 
-        if reset_batch:
+        if reset_sampling_state:
             self.reset_prompt_tokens(prompt_tokens)
             self.reset_output_state(output_tokens)
 
@@ -676,6 +705,23 @@ class SeedManager:
                 reset_slots.append(slot)
         if reset_slots:
             self.reset_seed_from_slots(seeds, reset_slots)
+
+    def reset_decode_batch(self, seeds, active_slots) -> None:
+        """Reinitialize RNG ownership for a new decode batch layout.
+
+        Removed slots must not keep an explicit seed that leaves
+        ``_seed_active`` true, and a newly reused identity slot must receive a
+        fresh unseeded RNG even when both the old and new request have
+        ``seed=None``. Continuing explicitly seeded requests are subsequently
+        aligned to absolute positions by the caller.
+        """
+        active_slots = {int(slot) for slot in active_slots}
+        for slot in range(self.max_batch_size):
+            if slot not in active_slots:
+                self.seeds[slot] = None
+                self.seed_counters[slot] = 0
+                self.rngs[slot].seed(self._next_unseeded_rng_seed())
+        self.reset_seed_from_slots(seeds, sorted(active_slots))
 
     def align_seed_counters_to_positions(self, seeds, user_ids, positions, offset: int = 1):
         """Make explicit-seed decode independent of persistent slot lifetime.

--- a/models/common/sampling/generator.py
+++ b/models/common/sampling/generator.py
@@ -706,23 +706,6 @@ class SeedManager:
         if reset_slots:
             self.reset_seed_from_slots(seeds, reset_slots)
 
-    def reset_decode_batch(self, seeds, active_slots) -> None:
-        """Reinitialize RNG ownership for a new decode batch layout.
-
-        Removed slots must not keep an explicit seed that leaves
-        ``_seed_active`` true, and a newly reused identity slot must receive a
-        fresh unseeded RNG even when both the old and new request have
-        ``seed=None``. Continuing explicitly seeded requests are subsequently
-        aligned to absolute positions by the caller.
-        """
-        active_slots = {int(slot) for slot in active_slots}
-        for slot in range(self.max_batch_size):
-            if slot not in active_slots:
-                self.seeds[slot] = None
-                self.seed_counters[slot] = 0
-                self.rngs[slot].seed(self._next_unseeded_rng_seed())
-        self.reset_seed_from_slots(seeds, sorted(active_slots))
-
     def align_seed_counters_to_positions(self, seeds, user_ids, positions, offset: int = 1):
         """Make explicit-seed decode independent of persistent slot lifetime.
 

--- a/models/common/sampling/generator.py
+++ b/models/common/sampling/generator.py
@@ -23,18 +23,6 @@ DEVICE_SEED_MAX = 1_000_000
 _UINT64_MASK = (1 << 64) - 1
 
 
-def should_align_decode_seed_counters(
-    *,
-    explicit_contract: bool,
-    reset_sampling_state: bool,
-    legacy_alignment: bool,
-) -> bool:
-    """Keep legacy seed-position alignment while honoring explicit state flags."""
-    return reset_sampling_state or (
-        not explicit_contract and legacy_alignment
-    )
-
-
 def _hash_request_seed_to_device_seed(seed: int, counter: int) -> int:
     """Derive a stable per-token device seed from a request seed.
 
@@ -190,9 +178,8 @@ class SamplingGenerator:
         self,
         sampling_params_chunks: list,
         *,
-        reload_sampling_params: bool = True,
-        reset_sampling_state: bool = False,
-        reset_batch: bool | None = None,
+        reload_sampling_params: bool,
+        reset_sampling_state: bool,
         prompt_tokens: torch.Tensor | None = None,
         output_tokens: torch.Tensor | None = None,
     ):
@@ -209,29 +196,17 @@ class SamplingGenerator:
         Does NOT call ``seed_manager.get_new_values()`` — callers manage seed
         advancement separately since generators call it at different points.
         """
-        if reset_batch is not None:
-            # Compatibility for demos/executors that predate the split
-            # contract. ``reset_batch`` historically always uploaded params
-            # and optionally rebuilt mutable state.
-            reload_sampling_params = True
-            reset_sampling_state = reset_batch
-
         if reload_sampling_params:
             chunks_per_model = len(sampling_params_chunks)
             max_batch_size = self.tt_sampling.max_batch_size
 
             if chunks_per_model == 1:
-                formatted_params = format_sampling_params(
-                    sampling_params_chunks[0], max_batch_size
-                )
+                formatted_params = format_sampling_params(sampling_params_chunks[0], max_batch_size)
                 self.reset_sampling_params(formatted_params)
             else:
                 # Row-sharded case: format each chunk to max_batch_size,
                 # concatenate, then upload one merged parameter set.
-                formatted_chunks = [
-                    format_sampling_params(chunk, max_batch_size)
-                    for chunk in sampling_params_chunks
-                ]
+                formatted_chunks = [format_sampling_params(chunk, max_batch_size) for chunk in sampling_params_chunks]
                 concat_fields = {}
                 for field in SAMPLING_PARAM_FIELDS:
                     lists = [getattr(fc, field) for fc in formatted_chunks]

--- a/models/common/sampling/generator.py
+++ b/models/common/sampling/generator.py
@@ -140,6 +140,7 @@ class SamplingGenerator:
             max_batch_size=seed_batch_size,
             salt_duplicate_seeds=getattr(args, "salt_duplicate_seeds", True),
         )
+        self._slot_state_requires_authoritative_reload = False
 
     def _new_trace_state(self):
         return {"id": None, "input": None, "output": None, "kwargs": {}}
@@ -185,10 +186,52 @@ class SamplingGenerator:
             return
         self.tt_penalties.reset_prompt_tokens(prompt_tokens, slots=slots)
 
-    def reset_output_state(self, tokens=None):
+    def reset_output_state(self, tokens=None, slots: list[int] | None = None):
         if not self._penalties_active:
             return
-        self.tt_penalties.reset_output_tokens(tokens)
+        self.tt_penalties.reset_output_tokens(tokens, slots=slots)
+
+    def apply_slot_remap(self, remap) -> None:
+        """Move host RNG state and invalidate device state that cannot be permuted safely.
+
+        Sampling parameter and penalty buffers can be sharded across mesh rows, so a
+        scheduler remap is not necessarily a rank-local device gather. The next device
+        sampling step must rebuild those buffers from authoritative host state instead
+        of silently using rows that still belong to the old layout.
+        """
+        remap = [int(slot) for slot in torch.as_tensor(remap).reshape(-1).tolist()]
+        expected_size = self.seed_manager.max_batch_size
+        if len(remap) != expected_size:
+            raise ValueError(f"Sampling slot remap has {len(remap)} entries; expected {expected_size}")
+        if any(slot < 0 or slot >= expected_size for slot in remap):
+            raise ValueError(f"Sampling slot remap must stay within [0, {expected_size}), got {remap}")
+
+        self.seed_manager.apply_slot_remap(remap)
+        if any(source != destination for destination, source in enumerate(remap)):
+            self._slot_state_requires_authoritative_reload = True
+
+    def validate_decode_state_commands(
+        self,
+        *,
+        reload_sampling_params: bool,
+        reset_sampling_state: bool,
+    ) -> None:
+        if self._slot_state_requires_authoritative_reload and not (reload_sampling_params and reset_sampling_state):
+            raise ValueError(
+                "A non-identity slot remap invalidated device sampling parameters and penalty history; "
+                "the next device sampling step requires reload_sampling_params=True and reset_sampling_state=True"
+            )
+
+    def commit_decode_state_commands(
+        self,
+        *,
+        reload_sampling_params: bool,
+        reset_sampling_state: bool,
+        sampling_state_slots: list[int] | None,
+    ) -> None:
+        """Clear whole-device invalidation only after a whole-device rebuild."""
+        if reload_sampling_params and reset_sampling_state and sampling_state_slots is None:
+            self._slot_state_requires_authoritative_reload = False
 
     # ---------------------------------------------------------------------
     # Prefill / decode state helpers
@@ -219,47 +262,65 @@ class SamplingGenerator:
         self,
         sampling_params_chunks: list,
         *,
-        reset_batch: bool = False,
+        reload_sampling_params: bool,
+        reset_sampling_state: bool,
         prompt_tokens: torch.Tensor | None = None,
         output_tokens: torch.Tensor | None = None,
+        sampling_state_slots: list[int] | None = None,
     ):
-        """Format, merge (if row-sharded), and apply sampling params for one model instance.
+        """Apply the explicitly requested parts of decode sampling state.
 
         Args:
             sampling_params_chunks: List of SamplingParams assigned to this instance.
                 Length-1 for simple cases; >1 for row-sharded (sampling_dp > data_parallel).
-            reset_batch: Also reset prompt tokens and output state (first decode step).
+            reload_sampling_params: Upload temperature/top-k/top-p/etc.
+            reset_sampling_state: Rebuild prompt/output penalty state.
             prompt_tokens: Prompt tokens for penalty tracking.
             output_tokens: Output tokens for penalty tracking.
+            sampling_state_slots: If provided, reset penalty history only for
+                these device slots and preserve every other slot.
 
         Does NOT call ``seed_manager.get_new_values()`` — callers manage seed
         advancement separately since generators call it at different points.
         """
-        chunks_per_model = len(sampling_params_chunks)
+        self.validate_decode_state_commands(
+            reload_sampling_params=reload_sampling_params,
+            reset_sampling_state=reset_sampling_state,
+        )
 
-        max_batch_size = self.tt_sampling.max_batch_size
+        if reload_sampling_params:
+            chunks_per_model = len(sampling_params_chunks)
+            max_batch_size = self.tt_sampling.max_batch_size
 
-        if chunks_per_model == 1:
-            formatted_params = format_sampling_params(sampling_params_chunks[0], max_batch_size)
-            self.reset_sampling_params(formatted_params)
-        else:
-            # Row-sharded case: format each chunk to max_batch_size, concatenate.
-            # After (0, None) sharding each row gets its own chunk of max_batch_size entries.
-            # Both TTSampling and TTPenalties use the same concatenated params.
-            formatted_chunks = [format_sampling_params(chunk, max_batch_size) for chunk in sampling_params_chunks]
-            concat_fields = {}
-            for field in SAMPLING_PARAM_FIELDS:
-                lists = [getattr(fc, field) for fc in formatted_chunks]
-                if all(v is None for v in lists):
-                    concat_fields[field] = None
-                else:
-                    concat_fields[field] = sum((v if isinstance(v, list) else [v] for v in lists), [])
-            formatted_params = SamplingParams(**concat_fields)
-            self.reset_sampling_params(formatted_params)
+            if chunks_per_model == 1:
+                formatted_params = format_sampling_params(sampling_params_chunks[0], max_batch_size)
+                self.reset_sampling_params(formatted_params)
+            else:
+                # Row-sharded case: format each chunk to max_batch_size,
+                # concatenate, then upload one merged parameter set.
+                formatted_chunks = [format_sampling_params(chunk, max_batch_size) for chunk in sampling_params_chunks]
+                concat_fields = {}
+                for field in SAMPLING_PARAM_FIELDS:
+                    lists = [getattr(fc, field) for fc in formatted_chunks]
+                    if all(v is None for v in lists):
+                        concat_fields[field] = None
+                    else:
+                        concat_fields[field] = sum(
+                            (v if isinstance(v, list) else [v] for v in lists),
+                            [],
+                        )
+                formatted_params = SamplingParams(**concat_fields)
+                self.reset_sampling_params(formatted_params)
 
-        if reset_batch:
-            self.reset_prompt_tokens(prompt_tokens)
-            self.reset_output_state(output_tokens)
+        if reset_sampling_state:
+            self.reset_prompt_tokens(prompt_tokens, slots=sampling_state_slots)
+            self.reset_output_state(output_tokens, slots=sampling_state_slots)
+
+        self.commit_decode_state_commands(
+            reload_sampling_params=reload_sampling_params,
+            reset_sampling_state=reset_sampling_state,
+            sampling_state_slots=sampling_state_slots,
+        )
 
     # ---------------------------------------------------------------------
     # Sampling helpers

--- a/models/common/sampling/tt_penalties.py
+++ b/models/common/sampling/tt_penalties.py
@@ -263,8 +263,8 @@ class TTPenalties(LightweightModule):
         is prefilling used to zero everyone else's mask: rows outside the call arrive as the -1
         padding and hash to an empty mask. repetition_penalty is the only consumer of prompt_mask, so
         a live request silently stopped penalising its own prompt until something refreshed it.
-        Under vLLM the next decode's reset_batch does refresh it, which is why this stayed hidden;
-        the demo path never sets reset_batch and keeps the wiped mask for the whole generation.
+        A later full sampling-state reset can hide this bug. A demo without that reset keeps the
+        wiped mask for the rest of the generation.
         """
         prompt_tokens_2d = prompt_tokens.reshape(-1, prompt_tokens.shape[-1])
         prompt_tokens_2d = self._pad_batch_to_max(prompt_tokens_2d, pad_value=-1)
@@ -291,7 +291,60 @@ class TTPenalties(LightweightModule):
         prompt_mask = (prompt_counts > 0).to(torch.int32)
         self._copy_int_host_to_device(self.prompt_mask, prompt_mask, self._shard_dims_mask)
 
-    def reset_output_tokens(self, tokens=None):
+    def reset_output_tokens(self, tokens=None, slots: list[int] | None = None):
+        if slots is not None:
+            slots = sorted({int(slot) for slot in slots})
+            if any(slot < 0 or slot >= self._total_batch for slot in slots):
+                raise ValueError(f"Output reset slots must be in [0, {self._total_batch}), got {slots}")
+            if not slots:
+                return
+
+            # Clear only the admitted slots. A [batch, 1] device mask is
+            # replicated across mesh columns and broadcast across vocabulary,
+            # so continuing requests keep their accumulated device counts.
+            keep_rows = torch.ones((self._total_batch, 1), dtype=torch.int32)
+            keep_rows[slots] = 0
+            keep_rows_tt = self._alloc_int_buffer(
+                host=keep_rows,
+                shard_dims=self._shard_dims_gathered,
+            )
+            self.output_mask = ttnn.mul(
+                self.output_mask, keep_rows_tt, output_tensor=self.output_mask, **self._op_kwargs
+            )
+            self.output_counts = ttnn.mul(
+                self.output_counts, keep_rows_tt, output_tensor=self.output_counts, **self._op_kwargs
+            )
+            self.output_counts_gathered = ttnn.mul(
+                self.output_counts_gathered,
+                keep_rows_tt,
+                output_tensor=self.output_counts_gathered,
+                **self._op_kwargs,
+            )
+            keep_rows_tt.deallocate()
+
+            if tokens is None:
+                return
+
+            # Restore any supplied history for the reset slots. Rows outside
+            # ``slots`` are zero here, so adding cannot change live requests.
+            tokens_2d = tokens.reshape(-1, tokens.shape[-1])
+            tokens_2d = self._pad_batch_to_max(tokens_2d, pad_value=-1)
+            output_counts = self._token_counts_host(tokens_2d)
+            reset_rows = torch.zeros((self._total_batch, 1), dtype=torch.int32)
+            reset_rows[slots] = 1
+            output_counts *= reset_rows
+            output_mask = (output_counts > 0).to(torch.int32)
+            updates = (
+                (self.output_counts_gathered, output_counts, self._shard_dims_gathered),
+                (self.output_counts, output_counts, self._shard_dims_mask),
+                (self.output_mask, output_mask, self._shard_dims_mask),
+            )
+            for destination, host_update, shard_dims in updates:
+                update_tt = self._alloc_int_buffer(host=host_update, shard_dims=shard_dims)
+                ttnn.add(destination, update_tt, output_tensor=destination, **self._op_kwargs)
+                update_tt.deallocate()
+            return
+
         # ALWAYS reset output buffers to zero first (this is the core accuracy fix from issue #35731)
         # This ensures penalty statistics are cleared between prefill and decode phases
         self.output_mask = ttnn.mul(self.output_mask, 0, output_tensor=self.output_mask, **self._op_kwargs)

--- a/models/common/tests/test_decode_update_contract.py
+++ b/models/common/tests/test_decode_update_contract.py
@@ -1,15 +1,11 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 # SPDX-License-Identifier: Apache-2.0
-#
-# Unit tests for the sampling half of the explicit vLLM decode update contract.
 
+import inspect
 import random
 from types import SimpleNamespace
 
-from models.common.sampling.generator import (
-    SamplingGenerator,
-    SeedManager,
-    should_align_decode_seed_counters,
-)
+from models.common.sampling.generator import SamplingGenerator, SeedManager
 
 
 def _fake_sampling_generator():
@@ -51,27 +47,12 @@ def test_no_sampling_updates_is_a_true_noop():
     assert calls == []
 
 
-def test_legacy_reset_batch_still_rebuilds_sampling_state(monkeypatch):
-    fake, calls = _fake_sampling_generator()
-    formatted = object()
-    monkeypatch.setattr(
-        "models.common.sampling.generator.format_sampling_params",
-        lambda params, max_batch_size: formatted,
-    )
+def test_sampling_update_commands_are_required_and_have_no_legacy_alias():
+    params = inspect.signature(SamplingGenerator.apply_decode_state).parameters
 
-    SamplingGenerator.apply_decode_state(
-        fake,
-        [object()],
-        reset_batch=True,
-        prompt_tokens="prompt",
-        output_tokens="output",
-    )
-
-    assert calls == [
-        ("params", formatted),
-        ("prompt", "prompt"),
-        ("output", "output"),
-    ]
+    assert params["reload_sampling_params"].default is inspect.Parameter.empty
+    assert params["reset_sampling_state"].default is inspect.Parameter.empty
+    assert "reset_batch" not in params
 
 
 def test_unseeded_decode_reset_loads_fresh_device_seed(monkeypatch):
@@ -112,21 +93,3 @@ def test_unseeded_decode_reset_loads_fresh_device_seed(monkeypatch):
     assert uploads == [(host_seed_tensor, seed_buffer)]
     assert manager._needs_skip
     assert not manager._reseted
-
-
-def test_legacy_seed_alignment_policy_is_preserved():
-    assert should_align_decode_seed_counters(
-        explicit_contract=False,
-        reset_sampling_state=False,
-        legacy_alignment=True,
-    )
-    assert not should_align_decode_seed_counters(
-        explicit_contract=True,
-        reset_sampling_state=False,
-        legacy_alignment=True,
-    )
-    assert should_align_decode_seed_counters(
-        explicit_contract=True,
-        reset_sampling_state=True,
-        legacy_alignment=False,
-    )

--- a/models/common/tests/test_decode_update_contract.py
+++ b/models/common/tests/test_decode_update_contract.py
@@ -8,6 +8,7 @@ from types import SimpleNamespace
 import torch
 
 from models.common.sampling.generator import SamplingGenerator, SeedManager
+from models.tt_transformers.tt.common import Mode
 
 
 def _fake_sampling_generator():
@@ -74,6 +75,93 @@ def test_qwen_vl_slot_remap_moves_persistent_rope_deltas():
         generator_cls.remap_rope_deltas(generator, [3, 1, 2, 3])
 
         assert generator.model.rope_setup.rope_deltas.tolist() == [40, 20, 30, 40]
+
+
+def test_shared_generator_routes_slot_remap_to_exactly_one_sampling_owner():
+    from models.tt_transformers.tt.generator import Generator
+
+    def run(*, sampling_params=None, defer_device_sampling=False, fail_readback=False):
+        events = []
+        fake = SimpleNamespace(
+            mode=Mode.DECODE,
+            model=[SimpleNamespace(switch_mode=lambda mode: None)],
+            data_parallel=1,
+            _decode_forward_trace_text=lambda **kwargs: events.append("decode") or "logits",
+            sample_decode_on_device=lambda output, **kwargs: events.append(("sample", kwargs["slot_remap"]))
+            or "tokens",
+            read_decode_output=lambda output: events.append("read") or output,
+            process_decode_output_host=lambda output, **kwargs: (_ for _ in ()).throw(RuntimeError("readback"))
+            if fail_readback
+            else events.append("process")
+            or output,
+            _apply_sampling_slot_remap=lambda remap: events.append(("host-remap", remap)),
+        )
+
+        try:
+            result = Generator.decode_forward(
+                fake,
+                torch.zeros((1, 1), dtype=torch.int64),
+                torch.zeros((1,), dtype=torch.int64),
+                sampling_params=sampling_params,
+                slot_remap=[0],
+                defer_device_sampling=defer_device_sampling,
+                reload_inputs=True,
+                reload_page_table=False,
+                reload_sampling_params=False,
+                reset_sampling_state=False,
+            )
+        except RuntimeError:
+            result = None
+        return events, result
+
+    host_events, _ = run()
+    device_events, _ = run(sampling_params=object())
+    deferred_events, _ = run(defer_device_sampling=True)
+    failed_host_events, _ = run(fail_readback=True)
+
+    assert host_events == ["decode", "read", "process", ("host-remap", [0])]
+    assert device_events == ["decode", ("sample", [0]), "read", "process"]
+    assert deferred_events == ["decode"]
+    assert failed_host_events == ["decode", "read"]
+
+
+def test_galaxy_generator_routes_slot_remap_to_exactly_one_sampling_owner():
+    from models.demos.llama3_70b_galaxy.tt.generator import Generator
+
+    def run(*, sampling_params=None, defer_device_sampling=False):
+        events = []
+        fake = SimpleNamespace(
+            model=SimpleNamespace(is_decode_setup=True),
+            _decode_easy_trace_text=lambda **kwargs: events.append("decode") or ("logits", None),
+            sample_decode_on_device=lambda output, **kwargs: events.append(("sample", kwargs["slot_remap"]))
+            or ("tokens", "logprobs"),
+            read_decode_output=lambda output, **kwargs: events.append("read") or output,
+            process_decode_output_host=lambda output, **kwargs: events.append("process") or output,
+            _apply_sampling_slot_remap=lambda remap: events.append(("host-remap", remap)),
+        )
+
+        result = Generator.decode_forward(
+            fake,
+            torch.zeros((1, 1), dtype=torch.int64),
+            torch.zeros((1,), dtype=torch.int64),
+            kv_cache=[object()],
+            sampling_params=sampling_params,
+            slot_remap=[0],
+            defer_device_sampling=defer_device_sampling,
+            reload_inputs=True,
+            reload_page_table=False,
+            reload_sampling_params=False,
+            reset_sampling_state=False,
+        )
+        return events, result
+
+    host_events, _ = run()
+    device_events, _ = run(sampling_params=object())
+    deferred_events, _ = run(defer_device_sampling=True)
+
+    assert host_events == ["decode", "read", "process", ("host-remap", [0])]
+    assert device_events == ["decode", ("sample", [0]), "read", "process"]
+    assert deferred_events == ["decode"]
 
 
 def test_unseeded_decode_reset_loads_fresh_device_seed(monkeypatch):

--- a/models/common/tests/test_decode_update_contract.py
+++ b/models/common/tests/test_decode_update_contract.py
@@ -1,0 +1,676 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+import ast
+import inspect
+import random
+from pathlib import Path
+from types import SimpleNamespace
+
+import torch
+
+from models.common.sampling.generator import SamplingGenerator, SamplingParams, SeedManager
+from models.common.warmup.warmup_utils import WarmupForwardMixin
+from models.tt_transformers.tt.common import Mode
+
+
+def _fake_sampling_generator():
+    calls = []
+    fake = SimpleNamespace(
+        tt_sampling=SimpleNamespace(max_batch_size=32),
+        seed_manager=SimpleNamespace(
+            max_batch_size=32,
+            apply_slot_remap=lambda remap: calls.append(("remap", list(remap))),
+        ),
+        _slot_state_requires_authoritative_reload=False,
+        reset_sampling_params=lambda params: calls.append(("params", params)),
+        reset_prompt_tokens=lambda tokens, slots=None: calls.append(("prompt", tokens, slots)),
+        reset_output_state=lambda tokens, slots=None: calls.append(("output", tokens, slots)),
+    )
+    fake.validate_decode_state_commands = lambda **kwargs: SamplingGenerator.validate_decode_state_commands(
+        fake, **kwargs
+    )
+    fake.commit_decode_state_commands = lambda **kwargs: SamplingGenerator.commit_decode_state_commands(fake, **kwargs)
+    return fake, calls
+
+
+def test_sampling_state_can_reset_without_reloading_params():
+    fake, calls = _fake_sampling_generator()
+
+    SamplingGenerator.apply_decode_state(
+        fake,
+        [object()],
+        reload_sampling_params=False,
+        reset_sampling_state=True,
+        prompt_tokens="prompt",
+        output_tokens="output",
+    )
+
+    assert calls == [("prompt", "prompt", None), ("output", "output", None)]
+
+
+def test_sampling_state_reset_can_preserve_unlisted_slots():
+    fake, calls = _fake_sampling_generator()
+
+    SamplingGenerator.apply_decode_state(
+        fake,
+        [object()],
+        reload_sampling_params=False,
+        reset_sampling_state=True,
+        prompt_tokens="prompt",
+        output_tokens=None,
+        sampling_state_slots=[1, 3],
+    )
+
+    assert calls == [("prompt", "prompt", [1, 3]), ("output", None, [1, 3])]
+
+
+def test_non_identity_slot_remap_requires_authoritative_device_state_reload(expect_error):
+    fake, calls = _fake_sampling_generator()
+    remap = [1, 0, *range(2, 32)]
+
+    SamplingGenerator.apply_slot_remap(fake, remap)
+
+    assert calls == [("remap", remap)]
+    assert fake._slot_state_requires_authoritative_reload
+    for reload_sampling_params, reset_sampling_state in ((False, False), (True, False), (False, True)):
+        with expect_error(ValueError, "requires reload_sampling_params=True and reset_sampling_state=True"):
+            SamplingGenerator.apply_decode_state(
+                fake,
+                [object()],
+                reload_sampling_params=reload_sampling_params,
+                reset_sampling_state=reset_sampling_state,
+            )
+
+    params = SamplingParams(temperature=1.0, top_k=1, top_p=1.0)
+    SamplingGenerator.apply_decode_state(
+        fake,
+        [params],
+        reload_sampling_params=True,
+        reset_sampling_state=True,
+        prompt_tokens="prompt",
+        output_tokens="output",
+    )
+
+    assert calls[1][0] == "params"
+    assert calls[2:] == [("prompt", "prompt", None), ("output", "output", None)]
+    assert not fake._slot_state_requires_authoritative_reload
+
+
+def test_partial_sampling_state_rebuild_does_not_clear_slot_remap_invalidation(expect_error):
+    fake, _ = _fake_sampling_generator()
+    remap = [1, 0, *range(2, 32)]
+    params = SamplingParams(temperature=1.0, top_k=1, top_p=1.0)
+
+    SamplingGenerator.apply_slot_remap(fake, remap)
+    SamplingGenerator.apply_decode_state(
+        fake,
+        [params],
+        reload_sampling_params=True,
+        reset_sampling_state=True,
+        prompt_tokens="prompt",
+        output_tokens="output",
+        sampling_state_slots=[1, 3],
+    )
+
+    assert fake._slot_state_requires_authoritative_reload
+    with expect_error(ValueError, "requires reload_sampling_params=True and reset_sampling_state=True"):
+        SamplingGenerator.apply_decode_state(
+            fake,
+            [params],
+            reload_sampling_params=False,
+            reset_sampling_state=False,
+        )
+
+    SamplingGenerator.apply_decode_state(
+        fake,
+        [params],
+        reload_sampling_params=True,
+        reset_sampling_state=True,
+        prompt_tokens="prompt",
+        output_tokens="output",
+    )
+
+    assert not fake._slot_state_requires_authoritative_reload
+
+
+def test_identity_slot_remap_keeps_device_sampling_state_valid():
+    fake, calls = _fake_sampling_generator()
+    remap = list(range(32))
+
+    SamplingGenerator.apply_slot_remap(fake, remap)
+
+    assert calls == [("remap", remap)]
+    assert not fake._slot_state_requires_authoritative_reload
+
+
+def test_output_penalty_reset_masks_only_selected_slots(monkeypatch):
+    from models.common.sampling import tt_penalties
+
+    class FakeTensor:
+        def __init__(self, name):
+            self.name = name
+            self.deallocated = False
+
+        def deallocate(self):
+            self.deallocated = True
+
+    allocated = []
+    multiplies = []
+    penalty_state = SimpleNamespace(
+        _total_batch=4,
+        _shard_dims_gathered=(0, None),
+        _op_kwargs={},
+        output_mask=FakeTensor("mask"),
+        output_counts=FakeTensor("counts"),
+        output_counts_gathered=FakeTensor("gathered"),
+    )
+
+    def allocate(*, host, shard_dims):
+        result = FakeTensor("keep")
+        allocated.append((host.clone(), shard_dims, result))
+        return result
+
+    penalty_state._alloc_int_buffer = allocate
+    monkeypatch.setattr(
+        tt_penalties.ttnn,
+        "mul",
+        lambda value, keep, *, output_tensor, **kwargs: multiplies.append((value, keep, output_tensor))
+        or output_tensor,
+    )
+
+    tt_penalties.TTPenalties.reset_output_tokens(penalty_state, slots=[3, 1])
+
+    assert allocated[0][0].reshape(-1).tolist() == [1, 0, 1, 0]
+    assert allocated[0][1] == (0, None)
+    keep = allocated[0][2]
+    assert [(value.name, mask is keep, output.name) for value, mask, output in multiplies] == [
+        ("mask", True, "mask"),
+        ("counts", True, "counts"),
+        ("gathered", True, "gathered"),
+    ]
+    assert keep.deallocated
+
+
+def test_no_sampling_updates_is_a_true_noop():
+    fake, calls = _fake_sampling_generator()
+
+    SamplingGenerator.apply_decode_state(
+        fake,
+        [object()],
+        reload_sampling_params=False,
+        reset_sampling_state=False,
+    )
+
+    assert calls == []
+
+
+def test_sampling_update_commands_are_required_and_have_no_legacy_alias():
+    params = inspect.signature(SamplingGenerator.apply_decode_state).parameters
+
+    assert params["reload_sampling_params"].default is inspect.Parameter.empty
+    assert params["reset_sampling_state"].default is inspect.Parameter.empty
+    assert "reset_batch" not in params
+
+
+def test_decode_warmup_does_not_reset_absent_request_history():
+    calls = []
+    fake = SimpleNamespace(
+        _create_sampling_params=lambda *args, **kwargs: [object()],
+        _create_decode_warmup_inputs=lambda *args: (
+            torch.zeros((1, 1)),
+            torch.zeros((1,)),
+            torch.zeros((1, 1)),
+        ),
+        decode_forward=lambda **kwargs: calls.append(kwargs),
+    )
+
+    WarmupForwardMixin.warmup_model_decode(
+        fake,
+        kv_cache=object(),
+        enable_trace=True,
+        max_batch_size=1,
+        num_blocks=1,
+        can_sample_on_device=True,
+    )
+
+    assert len(calls) == 1
+    assert calls[0]["reload_sampling_params"] is True
+    assert calls[0]["reset_sampling_state"] is False
+
+
+def test_qwen_vl_slot_remap_moves_persistent_rope_deltas():
+    from models.demos.qwen3_vl.tt.generator import Generator as Qwen3Generator
+    from models.demos.qwen25_vl.tt.generator import Generator as Qwen25Generator
+
+    for generator_cls in (Qwen25Generator, Qwen3Generator):
+        generator = SimpleNamespace(
+            model=SimpleNamespace(
+                rope_setup=SimpleNamespace(
+                    batch_size=4,
+                    rope_deltas=torch.tensor([10, 20, 30, 40]),
+                )
+            )
+        )
+
+        generator_cls.remap_rope_deltas(generator, [3, 1, 2, 3])
+
+        assert generator.model.rope_setup.rope_deltas.tolist() == [40, 20, 30, 40]
+
+
+def test_qwen_vl_generator_forwards_slot_remap_to_shared_sampling_owner():
+    from models.demos.qwen3_vl.tt.generator import Generator as Qwen3Generator
+    from models.demos.qwen25_vl.tt.generator import Generator as Qwen25Generator
+
+    for generator_cls in (Qwen25Generator, Qwen3Generator):
+        calls = []
+        generator = SimpleNamespace(
+            _ttt_generator=SimpleNamespace(decode_forward=lambda **kwargs: calls.append(kwargs) or "output")
+        )
+
+        result = generator_cls.decode_forward(
+            generator,
+            tokens="tokens",
+            start_pos="positions",
+            slot_remap=[3, 1, 2, 3],
+            reload_inputs=True,
+            reload_page_table=False,
+            reload_sampling_params=False,
+            reset_sampling_state=False,
+        )
+
+        assert result == "output"
+        assert calls[0]["slot_remap"] == [3, 1, 2, 3]
+
+
+def test_shared_generator_routes_slot_remap_to_exactly_one_sampling_owner():
+    from models.tt_transformers.tt.generator import Generator
+
+    def run(*, sampling_params=None, defer_device_sampling=False, fail_readback=False):
+        events = []
+        fake = SimpleNamespace(
+            mode=Mode.DECODE,
+            model=[SimpleNamespace(switch_mode=lambda mode: None)],
+            data_parallel=1,
+            _decode_forward_trace_text=lambda **kwargs: events.append("decode") or "logits",
+            sample_decode_on_device=lambda output, **kwargs: events.append(("sample", kwargs["slot_remap"]))
+            or "tokens",
+            read_decode_output=lambda output: events.append("read") or output,
+            process_decode_output_host=lambda output, **kwargs: (_ for _ in ()).throw(RuntimeError("readback"))
+            if fail_readback
+            else events.append("process") or output,
+            _apply_sampling_slot_remap=lambda remap: events.append(("host-remap", remap)),
+        )
+
+        try:
+            result = Generator.decode_forward(
+                fake,
+                torch.zeros((1, 1), dtype=torch.int64),
+                torch.zeros((1,), dtype=torch.int64),
+                sampling_params=sampling_params,
+                slot_remap=[0],
+                defer_device_sampling=defer_device_sampling,
+                reload_inputs=True,
+                reload_page_table=False,
+                reload_sampling_params=False,
+                reset_sampling_state=False,
+            )
+        except RuntimeError:
+            result = None
+        return events, result
+
+    host_events, _ = run()
+    device_events, _ = run(sampling_params=object())
+    deferred_events, _ = run(defer_device_sampling=True)
+    failed_host_events, _ = run(fail_readback=True)
+
+    assert host_events == ["decode", "read", "process", ("host-remap", [0])]
+    assert device_events == ["decode", ("sample", [0]), "read", "process"]
+    assert deferred_events == ["decode"]
+    assert failed_host_events == ["decode", "read"]
+
+
+def test_shared_generator_rebases_and_pads_lane_sampling_remaps():
+    from models.tt_transformers.tt.generator import Generator
+
+    calls = [[], []]
+    models = []
+    for lane in range(2):
+        sampling = SimpleNamespace(
+            seed_manager=SimpleNamespace(max_batch_size=4),
+            apply_slot_remap=lambda remap, lane=lane: calls[lane].append(torch.as_tensor(remap).tolist()),
+        )
+        models.append(SimpleNamespace(sampling=sampling))
+    fake = SimpleNamespace(data_parallel=2, model=models)
+
+    Generator._apply_sampling_slot_remap(fake, torch.tensor([1, 0, 3, 2]))
+
+    assert calls == [[[1, 0, 2, 3]], [[1, 0, 2, 3]]]
+
+
+def test_shared_generator_rejects_cross_lane_sampling_remap(expect_error):
+    from models.tt_transformers.tt.generator import Generator
+
+    sampling = SimpleNamespace(seed_manager=SimpleNamespace(max_batch_size=2), apply_slot_remap=lambda remap: None)
+    fake = SimpleNamespace(
+        data_parallel=2,
+        model=[
+            SimpleNamespace(sampling=sampling),
+            SimpleNamespace(sampling=sampling),
+        ],
+    )
+
+    with expect_error(ValueError, "outside its global range"):
+        Generator._apply_sampling_slot_remap(fake, torch.tensor([0, 2, 2, 3]))
+
+
+def test_sglang_bridge_explicitly_requests_host_authoritative_decode(monkeypatch):
+    from models.tt_transformers.tt.generator import Generator
+    from models.tt_transformers.tt.generator_sglang import LlamaForCausalLM
+
+    calls = []
+    monkeypatch.setattr(
+        Generator,
+        "decode_forward",
+        lambda self, *args, **kwargs: calls.append(kwargs) or "output",
+    )
+
+    result = LlamaForCausalLM.decode_forward(object(), tokens="tokens", start_pos="positions")
+
+    assert result == "output"
+    assert calls == [
+        {
+            "tokens": "tokens",
+            "start_pos": "positions",
+            "reload_inputs": True,
+            "reload_page_table": False,
+            "reload_sampling_params": False,
+            "reset_sampling_state": False,
+        }
+    ]
+
+
+def test_lfm_demo_supplies_every_decode_update_command():
+    source_path = Path("models/demos/multimodal/lfm25_vl/demo/vision_demo.py")
+    tree = ast.parse(source_path.read_text())
+    required = {
+        "reload_inputs",
+        "reload_page_table",
+        "reload_sampling_params",
+        "reset_sampling_state",
+    }
+    calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "decode_forward"
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == "generator"
+    ]
+
+    assert len(calls) == 2
+    for call in calls:
+        assert required <= {keyword.arg for keyword in call.keywords}
+
+
+def test_all_known_shared_generator_callers_supply_every_decode_update_command():
+    required = {
+        "reload_inputs",
+        "reload_page_table",
+        "reload_sampling_params",
+        "reset_sampling_state",
+    }
+    expected_calls = {
+        Path("tt-train/sources/examples/grpo_remote_rollout/utils/ttt_generation_worker.py"): 1,
+        Path("models/experimental/ops/quasar/gpt_oss/demo/text_demo.py"): 2,
+        Path("models/experimental/ops/quasar/gpt_oss/tests/accuracy/test_model.py"): 1,
+        Path("models/experimental/ops/quasar/qwen3_vl/demo/demo.py"): 1,
+    }
+
+    for source_path, expected_count in expected_calls.items():
+        tree = ast.parse(source_path.read_text())
+        calls = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "decode_forward"
+        ]
+        assert len(calls) == expected_count, source_path
+        for call in calls:
+            assert required <= {keyword.arg for keyword in call.keywords}, (source_path, call.lineno)
+
+
+def test_shared_generator_preserves_explicit_commands_after_mainline_seed_fix():
+    source_path = Path("models/tt_transformers/tt/generator.py")
+    source_text = source_path.read_text()
+    tree = ast.parse(source_text)
+    generator = next(node for node in tree.body if isinstance(node, ast.ClassDef) and node.name == "Generator")
+    decode = next(
+        node for node in generator.body if isinstance(node, ast.FunctionDef) and node.name == "decode_forward"
+    )
+    trace_decode = next(
+        node
+        for node in generator.body
+        if isinstance(node, ast.FunctionDef) and node.name == "_decode_forward_trace_text"
+    )
+
+    required = {"reload_inputs", "reload_page_table", "reload_sampling_params", "reset_sampling_state"}
+    assert required <= {arg.arg for arg in decode.args.kwonlyargs}
+    assert {"reload_inputs", "reload_page_table"} <= {arg.arg for arg in trace_decode.args.kwonlyargs}
+
+    decode_source = ast.get_source_segment(source_text, decode)
+    trace_source = ast.get_source_segment(source_text, trace_decode)
+    assert decode_source is not None
+    assert trace_source is not None
+    assert "reset_batch" not in decode_source
+    assert "_prev_on_device_sampling" not in decode_source
+    assert "_tt_vllm_always_refresh_decode_trace_inputs" not in trace_source
+    assert "torch.equal" not in trace_source
+
+
+def test_gemma4_override_uses_only_explicit_decode_update_commands():
+    source_path = Path("models/demos/gemma4/tt/generator.py")
+    tree = ast.parse(source_path.read_text())
+    mixin = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef) and node.name == "ChunkedPrefillPageTableGuardMixin"
+    )
+    decode = next(node for node in mixin.body if isinstance(node, ast.FunctionDef) and node.name == "decode_forward")
+    trace_decode = next(
+        node for node in mixin.body if isinstance(node, ast.FunctionDef) and node.name == "_decode_forward_trace_text"
+    )
+    required = {
+        "reload_inputs",
+        "reload_page_table",
+        "reload_sampling_params",
+        "reset_sampling_state",
+    }
+
+    decode_params = {arg.arg for arg in decode.args.kwonlyargs}
+    trace_params = {arg.arg for arg in trace_decode.args.kwonlyargs}
+    assert required <= decode_params
+    assert {"reload_inputs", "reload_page_table"} <= trace_params
+    assert "reset_batch" not in {arg.arg for arg in decode.args.args}
+    assert "reset_batch" not in {arg.arg for arg in trace_decode.args.args}
+
+    source = ast.get_source_segment(source_path.read_text(), trace_decode)
+    assert source is not None
+    assert "_prev_on_device_sampling" not in source
+    assert "_tt_vllm_always_refresh_decode_trace_inputs" not in source
+    assert "torch.equal" not in source
+
+
+def test_gemma4_pli_explicitly_disables_decode_token_feedback():
+    source = Path("models/demos/gemma4/tt/model.py").read_text()
+
+    assert "_tt_supports_decode_token_feedback = False" in source
+    assert "self._tt_supports_decode_token_feedback = not self._tt_vllm_always_refresh_decode_trace_inputs" in source
+
+
+def test_galaxy_reset_only_formats_seed_slots(monkeypatch):
+    from models.demos.llama3_70b_galaxy.tt import generator as galaxy_generator
+
+    formatted = SimpleNamespace(seed=[17, 17, 17, 17])
+    monkeypatch.setattr(
+        galaxy_generator,
+        "format_sampling_params",
+        lambda params, max_batch_size: formatted,
+    )
+    monkeypatch.setattr(
+        galaxy_generator,
+        "_fill_inactive_params_from_active",
+        lambda params, active_slots, max_batch_size: params,
+    )
+    reset_calls = []
+    seed_manager = SimpleNamespace(
+        max_batch_size=4,
+        deactivate_slots_except=lambda slots: None,
+        reset_seed_from_slots=lambda seeds, slots: reset_calls.append((seeds, slots)),
+        align_seed_counters_to_positions=lambda *args: None,
+        reset_seed_from_slots_if_needed=lambda *args: None,
+        get_new_values=lambda slots: None,
+    )
+    sampling = SimpleNamespace(
+        seed_manager=seed_manager,
+        _slot_state_requires_authoritative_reload=False,
+        reset_sampling_params=lambda params: (_ for _ in ()).throw(
+            AssertionError("reset-only must not upload sampling parameters")
+        ),
+        reset_prompt_tokens=lambda tokens: None,
+        reset_output_state=lambda tokens: None,
+        sample=lambda **kwargs: "tokens",
+    )
+    sampling.validate_decode_state_commands = lambda **kwargs: SamplingGenerator.validate_decode_state_commands(
+        sampling, **kwargs
+    )
+    sampling.commit_decode_state_commands = lambda **kwargs: SamplingGenerator.commit_decode_state_commands(
+        sampling, **kwargs
+    )
+    fake = SimpleNamespace(
+        trace_inputs_decode={True: None},
+        model=SimpleNamespace(sampling=sampling),
+        model_args=SimpleNamespace(max_batch_size=4),
+        _apply_sampling_slot_remap=lambda remap: None,
+    )
+
+    result = galaxy_generator.Generator.sample_decode_on_device(
+        fake,
+        tt_logits="logits",
+        sampling_params=SimpleNamespace(seed=[17]),
+        start_pos=torch.tensor([0, -1, -1, -1]),
+        reload_sampling_params=False,
+        reset_sampling_state=True,
+    )
+
+    assert result == "tokens"
+    assert reset_calls == [([17, 17, 17, 17], [0])]
+
+
+def test_galaxy_generator_routes_slot_remap_to_exactly_one_sampling_owner():
+    from models.demos.llama3_70b_galaxy.tt.generator import Generator
+
+    def run(*, sampling_params=None, defer_device_sampling=False):
+        events = []
+        fake = SimpleNamespace(
+            model=SimpleNamespace(is_decode_setup=True),
+            _decode_easy_trace_text=lambda **kwargs: events.append("decode") or ("logits", None),
+            sample_decode_on_device=lambda output, **kwargs: events.append(("sample", kwargs["slot_remap"]))
+            or ("tokens", "logprobs"),
+            read_decode_output=lambda output, **kwargs: events.append("read") or output,
+            process_decode_output_host=lambda output, **kwargs: events.append("process") or output,
+            _apply_sampling_slot_remap=lambda remap: events.append(("host-remap", remap)),
+        )
+
+        result = Generator.decode_forward(
+            fake,
+            torch.zeros((1, 1), dtype=torch.int64),
+            torch.zeros((1,), dtype=torch.int64),
+            kv_cache=[object()],
+            sampling_params=sampling_params,
+            slot_remap=[0],
+            defer_device_sampling=defer_device_sampling,
+            reload_inputs=True,
+            reload_page_table=False,
+            reload_sampling_params=False,
+            reset_sampling_state=False,
+        )
+        return events, result
+
+    host_events, _ = run()
+    device_events, _ = run(sampling_params=object())
+    deferred_events, _ = run(defer_device_sampling=True)
+
+    assert host_events == ["decode", "read", "process", ("host-remap", [0])]
+    assert device_events == ["decode", ("sample", [0]), "read", "process"]
+    assert deferred_events == ["decode"]
+
+
+def test_galaxy_slot_remap_moves_parameter_shadow_with_seed_state():
+    from models.demos.llama3_70b_galaxy.tt.generator import Generator
+
+    seed_remaps = []
+    fake = SimpleNamespace(
+        model=SimpleNamespace(
+            sampling=SimpleNamespace(
+                seed_manager=SimpleNamespace(max_batch_size=4),
+                apply_slot_remap=lambda remap: seed_remaps.append(remap),
+            )
+        ),
+        model_args=SimpleNamespace(max_batch_size=4),
+        _slot_sampling_params={
+            "temperature": [0.1, 0.2, 0.3, 0.4],
+            "top_k": [1, 2, 3, 4],
+        },
+    )
+
+    Generator._apply_sampling_slot_remap(fake, [2, 0, 1, 3])
+
+    assert seed_remaps == [[2, 0, 1, 3]]
+    assert fake._slot_sampling_params == {
+        "temperature": [0.3, 0.1, 0.2, 0.4],
+        "top_k": [3, 1, 2, 4],
+    }
+
+
+def test_unseeded_decode_reset_loads_fresh_device_seed(monkeypatch):
+    manager = SeedManager.__new__(SeedManager)
+    manager.max_batch_size = 1
+    manager.seeds = [None]
+    manager.seed_counters = [4]
+    manager.seed_salts = [0]
+    manager.rngs = [random.Random(1)]
+    manager._seed_active = False
+    manager._reseted = False
+    manager._needs_skip = False
+    manager._active_request_seed = False
+    manager._seed_mapper = None
+    seed_buffer = object()
+    manager.tt_sampling = SimpleNamespace(seeds_tt_tensor=seed_buffer)
+    before = manager.rngs[0].getstate()
+    host_seed_tensor = object()
+    uploads = []
+
+    monkeypatch.setattr(manager, "_next_unseeded_device_seed", lambda: 123)
+    monkeypatch.setattr(
+        "models.common.sampling.generator.ttnn.from_torch",
+        lambda *args, **kwargs: host_seed_tensor,
+    )
+    monkeypatch.setattr(
+        "models.common.sampling.generator.ttnn.copy_host_to_device_tensor",
+        lambda host, device: uploads.append((host, device)),
+    )
+
+    # The conditional path would see None == None and do nothing. A decode
+    # state reset must be unconditional so the following get_new_values()
+    # enters its init state and uploads a fresh device seed.
+    manager.reset_seed_from_slots([None], [0])
+    manager.get_new_values([0])
+
+    assert manager.seed_counters == [0]
+    assert manager.rngs[0].getstate() != before
+    assert uploads == [(host_seed_tensor, seed_buffer)]
+    assert manager._needs_skip
+    assert not manager._reseted

--- a/models/common/tests/test_decode_update_contract.py
+++ b/models/common/tests/test_decode_update_contract.py
@@ -1,0 +1,111 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Unit tests for the sampling half of the explicit vLLM decode update contract.
+
+import random
+from types import SimpleNamespace
+
+from models.common.sampling.generator import (
+    SamplingGenerator,
+    SeedManager,
+    should_align_decode_seed_counters,
+)
+
+
+def _fake_sampling_generator():
+    calls = []
+    fake = SimpleNamespace(
+        tt_sampling=SimpleNamespace(max_batch_size=4),
+        reset_sampling_params=lambda params: calls.append(("params", params)),
+        reset_prompt_tokens=lambda tokens: calls.append(("prompt", tokens)),
+        reset_output_state=lambda tokens: calls.append(("output", tokens)),
+    )
+    return fake, calls
+
+
+def test_sampling_state_can_reset_without_reloading_params():
+    fake, calls = _fake_sampling_generator()
+
+    SamplingGenerator.apply_decode_state(
+        fake,
+        [object()],
+        reload_sampling_params=False,
+        reset_sampling_state=True,
+        prompt_tokens="prompt",
+        output_tokens="output",
+    )
+
+    assert calls == [("prompt", "prompt"), ("output", "output")]
+
+
+def test_no_sampling_updates_is_a_true_noop():
+    fake, calls = _fake_sampling_generator()
+
+    SamplingGenerator.apply_decode_state(
+        fake,
+        [object()],
+        reload_sampling_params=False,
+        reset_sampling_state=False,
+    )
+
+    assert calls == []
+
+
+def test_legacy_reset_batch_still_rebuilds_sampling_state(monkeypatch):
+    fake, calls = _fake_sampling_generator()
+    formatted = object()
+    monkeypatch.setattr(
+        "models.common.sampling.generator.format_sampling_params",
+        lambda params, max_batch_size: formatted,
+    )
+
+    SamplingGenerator.apply_decode_state(
+        fake,
+        [object()],
+        reset_batch=True,
+        prompt_tokens="prompt",
+        output_tokens="output",
+    )
+
+    assert calls == [
+        ("params", formatted),
+        ("prompt", "prompt"),
+        ("output", "output"),
+    ]
+
+
+def test_decode_batch_reset_clears_removed_and_reseeds_identity_slot():
+    manager = SeedManager.__new__(SeedManager)
+    manager.max_batch_size = 3
+    manager.seeds = [11, None, 22]
+    manager.seed_counters = [5, 6, 7]
+    manager.rngs = [random.Random(1), random.Random(2), random.Random(3)]
+    manager._seed_active = True
+    manager._reseted = False
+    before_identity_state = manager.rngs[1].getstate()
+
+    manager.reset_decode_batch([None, None, None], [1])
+
+    assert manager.seeds == [None, None, None]
+    assert manager.seed_counters == [0, 0, 0]
+    assert manager.rngs[1].getstate() != before_identity_state
+    assert not manager._seed_active
+    assert manager._reseted
+
+
+def test_legacy_seed_alignment_policy_is_preserved():
+    assert should_align_decode_seed_counters(
+        explicit_contract=False,
+        reset_sampling_state=False,
+        legacy_alignment=True,
+    )
+    assert not should_align_decode_seed_counters(
+        explicit_contract=True,
+        reset_sampling_state=False,
+        legacy_alignment=True,
+    )
+    assert should_align_decode_seed_counters(
+        explicit_contract=True,
+        reset_sampling_state=True,
+        legacy_alignment=False,
+    )

--- a/models/common/tests/test_decode_update_contract.py
+++ b/models/common/tests/test_decode_update_contract.py
@@ -74,23 +74,44 @@ def test_legacy_reset_batch_still_rebuilds_sampling_state(monkeypatch):
     ]
 
 
-def test_decode_batch_reset_clears_removed_and_reseeds_identity_slot():
+def test_unseeded_decode_reset_loads_fresh_device_seed(monkeypatch):
     manager = SeedManager.__new__(SeedManager)
-    manager.max_batch_size = 3
-    manager.seeds = [11, None, 22]
-    manager.seed_counters = [5, 6, 7]
-    manager.rngs = [random.Random(1), random.Random(2), random.Random(3)]
-    manager._seed_active = True
+    manager.max_batch_size = 1
+    manager.seeds = [None]
+    manager.seed_counters = [4]
+    manager.rngs = [random.Random(1)]
+    manager._seed_active = False
     manager._reseted = False
-    before_identity_state = manager.rngs[1].getstate()
+    manager._needs_skip = False
+    manager._active_request_seed = False
+    manager._seed_mapper = None
+    seed_buffer = object()
+    manager.tt_sampling = SimpleNamespace(seeds_tt_tensor=seed_buffer)
+    before = manager.rngs[0].getstate()
+    host_seed_tensor = object()
+    uploads = []
 
-    manager.reset_decode_batch([None, None, None], [1])
+    monkeypatch.setattr(manager, "_next_unseeded_device_seed", lambda: 123)
+    monkeypatch.setattr(
+        "models.common.sampling.generator.ttnn.from_torch",
+        lambda *args, **kwargs: host_seed_tensor,
+    )
+    monkeypatch.setattr(
+        "models.common.sampling.generator.ttnn.copy_host_to_device_tensor",
+        lambda host, device: uploads.append((host, device)),
+    )
 
-    assert manager.seeds == [None, None, None]
-    assert manager.seed_counters == [0, 0, 0]
-    assert manager.rngs[1].getstate() != before_identity_state
-    assert not manager._seed_active
-    assert manager._reseted
+    # The conditional path would see None == None and do nothing. A decode
+    # state reset must be unconditional so the following get_new_values()
+    # enters its init state and uploads a fresh device seed.
+    manager.reset_seed_from_slots([None], [0])
+    manager.get_new_values([0])
+
+    assert manager.seed_counters == [0]
+    assert manager.rngs[0].getstate() != before
+    assert uploads == [(host_seed_tensor, seed_buffer)]
+    assert manager._needs_skip
+    assert not manager._reseted
 
 
 def test_legacy_seed_alignment_policy_is_preserved():

--- a/models/common/tests/test_decode_update_contract.py
+++ b/models/common/tests/test_decode_update_contract.py
@@ -5,6 +5,8 @@ import inspect
 import random
 from types import SimpleNamespace
 
+import torch
+
 from models.common.sampling.generator import SamplingGenerator, SeedManager
 
 
@@ -53,6 +55,25 @@ def test_sampling_update_commands_are_required_and_have_no_legacy_alias():
     assert params["reload_sampling_params"].default is inspect.Parameter.empty
     assert params["reset_sampling_state"].default is inspect.Parameter.empty
     assert "reset_batch" not in params
+
+
+def test_qwen_vl_slot_remap_moves_persistent_rope_deltas():
+    from models.demos.qwen25_vl.tt.generator import Generator as Qwen25Generator
+    from models.demos.qwen3_vl.tt.generator import Generator as Qwen3Generator
+
+    for generator_cls in (Qwen25Generator, Qwen3Generator):
+        generator = SimpleNamespace(
+            model=SimpleNamespace(
+                rope_setup=SimpleNamespace(
+                    batch_size=4,
+                    rope_deltas=torch.tensor([10, 20, 30, 40]),
+                )
+            )
+        )
+
+        generator_cls.remap_rope_deltas(generator, [3, 1, 2, 3])
+
+        assert generator.model.rope_setup.rope_deltas.tolist() == [40, 20, 30, 40]
 
 
 def test_unseeded_decode_reset_loads_fresh_device_seed(monkeypatch):

--- a/models/common/tests/test_decode_update_contract.py
+++ b/models/common/tests/test_decode_update_contract.py
@@ -59,8 +59,8 @@ def test_sampling_update_commands_are_required_and_have_no_legacy_alias():
 
 
 def test_qwen_vl_slot_remap_moves_persistent_rope_deltas():
-    from models.demos.qwen25_vl.tt.generator import Generator as Qwen25Generator
     from models.demos.qwen3_vl.tt.generator import Generator as Qwen3Generator
+    from models.demos.qwen25_vl.tt.generator import Generator as Qwen25Generator
 
     for generator_cls in (Qwen25Generator, Qwen3Generator):
         generator = SimpleNamespace(
@@ -92,8 +92,7 @@ def test_shared_generator_routes_slot_remap_to_exactly_one_sampling_owner():
             read_decode_output=lambda output: events.append("read") or output,
             process_decode_output_host=lambda output, **kwargs: (_ for _ in ()).throw(RuntimeError("readback"))
             if fail_readback
-            else events.append("process")
-            or output,
+            else events.append("process") or output,
             _apply_sampling_slot_remap=lambda remap: events.append(("host-remap", remap)),
         )
 

--- a/models/common/tests/test_decode_update_contract.py
+++ b/models/common/tests/test_decode_update_contract.py
@@ -3,13 +3,17 @@
 
 import ast
 import inspect
-import random
 from pathlib import Path
 from types import SimpleNamespace
 
 import torch
 
-from models.common.sampling.generator import SamplingGenerator, SamplingParams, SeedManager
+from models.common.sampling.generator import (
+    SamplingGenerator,
+    SamplingParams,
+    SeedManager,
+    _hash_request_seed_to_device_seed,
+)
 from models.common.warmup.warmup_utils import WarmupForwardMixin
 from models.tt_transformers.tt.common import Mode
 
@@ -211,6 +215,21 @@ def test_sampling_update_commands_are_required_and_have_no_legacy_alias():
     assert params["reload_sampling_params"].default is inspect.Parameter.empty
     assert params["reset_sampling_state"].default is inspect.Parameter.empty
     assert "reset_batch" not in params
+
+
+def test_deepseek_rejects_partial_forward_reload_before_decode(expect_error):
+    from models.demos.deepseek_v3.tt.generator_vllm import DeepseekV3ForCausalLM
+
+    generator = SimpleNamespace(model_run_config_decode=object())
+    for reload_inputs, reload_page_table in ((False, False), (False, True), (True, True)):
+        with expect_error(ValueError, "requires a full host-input reload"):
+            DeepseekV3ForCausalLM.decode_forward(
+                generator,
+                reload_inputs=reload_inputs,
+                reload_page_table=reload_page_table,
+                reload_sampling_params=False,
+                reset_sampling_state=False,
+            )
 
 
 def test_decode_warmup_does_not_reset_absent_request_history():
@@ -510,6 +529,123 @@ def test_gemma4_pli_explicitly_disables_decode_token_feedback():
     assert "self._tt_supports_decode_token_feedback = not self._tt_vllm_always_refresh_decode_trace_inputs" in source
 
 
+def test_explicit_trace_reloads_select_mode_and_gemma4_bucket_buffers(monkeypatch):
+    from models.demos.gemma4.tt import generator as gemma4_generator
+    from models.tt_transformers.tt import common
+    from models.tt_transformers.tt import generator as shared_generator
+
+    copies = []
+
+    def copy_inputs(*, host_tensors, device_tensors):
+        copies.append("full")
+        for host, device in zip(host_tensors, device_tensors):
+            device.copy_(host)
+
+    def copy_page(host, device):
+        copies.append("page")
+        device.copy_(host)
+
+    monkeypatch.setattr(common, "copy_host_to_device", copy_inputs)
+    monkeypatch.setattr(shared_generator, "copy_host_to_device", copy_inputs)
+    monkeypatch.setattr(shared_generator.ttnn, "copy_host_to_device_tensor", copy_page)
+    monkeypatch.setattr(shared_generator.ttnn, "execute_trace", lambda *args, **kwargs: None)
+
+    for cls, buckets in (
+        (shared_generator.Generator, (1,)),
+        (gemma4_generator.ChunkedPrefillPageTableGuardMixin, (1, 32)),
+    ):
+
+        def key(mode, batch):
+            return (mode, batch) if len(buckets) > 1 else mode
+
+        keys = [key(mode, batch) for mode in (False, True) for batch in buckets]
+        buffers = {k: [[torch.full((1,), -1) for _ in range(4)]] for k in keys}
+        fake = SimpleNamespace(
+            data_parallel=1,
+            model=[
+                SimpleNamespace(
+                    prepare_decode_inputs_host=lambda tokens, positions, page: [
+                        tokens[0],
+                        positions[:1],
+                        positions[:1],
+                        page[0],
+                    ]
+                )
+            ],
+            model_args=[SimpleNamespace(mesh_device=object())],
+            trace_ids_decode={k: {0: object()} for k in keys},
+            trace_inputs_decode=buffers,
+            trace_output_decode={k: object() for k in keys},
+        )
+        fake._decode_trace_key = cls._decode_trace_key.__get__(fake)
+        # The plugin commands a full reload on mode/layout transitions. Switch
+        # back to an existing bucket too, where stale resident inputs matter.
+        for mode, batch in [(True, 1), (False, 1), (True, buckets[-1]), (True, 1)]:
+            selected = buffers[key(mode, batch)][0]
+            kwargs = dict(
+                tokens=[torch.full((batch, 1), 11)],
+                current_pos=[torch.full((batch,), 12)],
+                page_table=[torch.full((batch, 1), 13)],
+                on_device_sampling=mode,
+            )
+            copies.clear()
+            cls._decode_forward_trace_text(fake, **kwargs, reload_inputs=True, reload_page_table=False)
+            assert [int(t.item()) for t in selected] == [11, 12, 12, 13]
+            assert copies == ["full"]
+            selected[0].fill_(21)
+            selected[1].fill_(22)
+            copies.clear()
+            cls._decode_forward_trace_text(fake, **kwargs, reload_inputs=False, reload_page_table=True)
+            assert [int(t.item()) for t in selected] == [21, 22, 12, 13]
+            assert copies == ["page"]
+            copies.clear()
+            cls._decode_forward_trace_text(fake, **kwargs, reload_inputs=False, reload_page_table=False)
+            assert [int(t.item()) for t in selected] == [21, 22, 12, 13]
+            assert copies == []
+
+
+def test_gemma4_decode_restores_full_layer_page_tables_after_sequential_prefill():
+    from models.demos.gemma4.tt.generator import ChunkedPrefillPageTableGuardMixin
+
+    full_tables = [torch.tensor([[1], [2]])]
+    model = SimpleNamespace(switch_mode=lambda mode: None)
+
+    def decode(stage, **kwargs):
+        assert model._active_page_tables_per_layer is full_tables
+        assert not hasattr(model, "_sequential_batch_page_tables")
+        return stage
+
+    fake = SimpleNamespace(
+        mode=Mode.PREFILL,
+        model=[model],
+        data_parallel=1,
+        _decode_forward_trace_text=lambda **kwargs: decode("replay", **kwargs),
+        _prepare_decode_trace_variant=lambda **kwargs: decode("prepare", **kwargs),
+        _apply_sampling_slot_remap=lambda remap: None,
+    )
+    fake._clear_sequential_batch_page_tables = (
+        lambda: ChunkedPrefillPageTableGuardMixin._clear_sequential_batch_page_tables(fake)
+    )
+    for enable_trace, prepare_trace, expected in ((True, False, "replay"), (False, True, "prepare")):
+        model._active_page_tables_per_layer = [full_tables[0][:1]]
+        model._sequential_batch_page_tables = full_tables
+        assert (
+            ChunkedPrefillPageTableGuardMixin.decode_forward(
+                fake,
+                tokens=torch.zeros((2, 1), dtype=torch.int32),
+                start_pos=torch.ones(2, dtype=torch.int32),
+                enable_trace=enable_trace,
+                prepare_trace=prepare_trace,
+                read_from_device=False,
+                reload_inputs=True,
+                reload_page_table=False,
+                reload_sampling_params=False,
+                reset_sampling_state=False,
+            )
+            == expected
+        )
+
+
 def test_galaxy_reset_only_formats_seed_slots(monkeypatch):
     from models.demos.llama3_70b_galaxy.tt import generator as galaxy_generator
 
@@ -561,6 +697,7 @@ def test_galaxy_reset_only_formats_seed_slots(monkeypatch):
         tt_logits="logits",
         sampling_params=SimpleNamespace(seed=[17]),
         start_pos=torch.tensor([0, -1, -1, -1]),
+        reload_inputs=True,
         reload_sampling_params=False,
         reset_sampling_state=True,
     )
@@ -597,6 +734,7 @@ def test_galaxy_generator_routes_slot_remap_to_exactly_one_sampling_owner():
             reload_sampling_params=False,
             reset_sampling_state=False,
         )
+        assert fake._decode_reload_inputs is True
         return events, result
 
     host_events, _ = run()
@@ -635,20 +773,60 @@ def test_galaxy_slot_remap_moves_parameter_shadow_with_seed_state():
     }
 
 
+def test_galaxy_seed_stream_realigns_only_on_authoritative_input_reload():
+    from models.demos.llama3_70b_galaxy.tt.generator import Generator
+
+    class RecordingSeedManager(SeedManager):
+        def write_device_seed_values(self, values):
+            pushed.append(values[0])
+
+    pushed = []
+    events = []
+    manager = RecordingSeedManager(SimpleNamespace(_sampling_dp=1), max_batch_size=32)
+    sampling = SimpleNamespace(
+        seed_manager=manager,
+        validate_decode_state_commands=lambda **kwargs: None,
+        commit_decode_state_commands=lambda **kwargs: None,
+        reset_sampling_params=lambda params: events.append("params"),
+        reset_prompt_tokens=lambda tokens: events.append("prompt"),
+        reset_output_state=lambda tokens: events.append("output"),
+        sample=lambda **kwargs: "tokens",
+    )
+    generator = SimpleNamespace(
+        trace_inputs_decode={True: None},
+        model=SimpleNamespace(sampling=sampling),
+        model_args=SimpleNamespace(max_batch_size=32),
+        _apply_sampling_slot_remap=lambda remap: None,
+        _remember_slot_params=lambda params: None,
+    )
+    params = SamplingParams(temperature=[1.0] * 32, top_k=[32] * 32, top_p=[1.0] * 32, seed=[7] + [None] * 31)
+
+    def step(position, *, reload_inputs, reset=False):
+        Generator.sample_decode_on_device(
+            generator,
+            "logits",
+            sampling_params=params,
+            start_pos=torch.tensor([position] + [-1] * 31),
+            reload_inputs=reload_inputs,
+            reload_sampling_params=reset,
+            reset_sampling_state=reset,
+        )
+
+    step(100, reload_inputs=True, reset=True)
+    for stale_position in (100, 101, 101):
+        step(stale_position, reload_inputs=False)
+    # An authoritative full reload can move the position without changing
+    # sampling parameters or resetting penalty history.
+    step(200, reload_inputs=True)
+
+    assert pushed == [_hash_request_seed_to_device_seed(7, pos) for pos in (101, 102, 103, 104, 201)]
+    assert events == ["params", "prompt", "output"]
+
+
 def test_unseeded_decode_reset_loads_fresh_device_seed(monkeypatch):
-    manager = SeedManager.__new__(SeedManager)
-    manager.max_batch_size = 1
-    manager.seeds = [None]
-    manager.seed_counters = [4]
-    manager.seed_salts = [0]
-    manager.rngs = [random.Random(1)]
-    manager._seed_active = False
-    manager._reseted = False
-    manager._needs_skip = False
-    manager._active_request_seed = False
-    manager._seed_mapper = None
     seed_buffer = object()
-    manager.tt_sampling = SimpleNamespace(seeds_tt_tensor=seed_buffer)
+    manager = SeedManager(SimpleNamespace(_sampling_dp=1, seeds_tt_tensor=seed_buffer), max_batch_size=1)
+    manager.seed_counters = [4]
     before = manager.rngs[0].getstate()
     host_seed_tensor = object()
     uploads = []

--- a/models/common/tests/test_sampling.py
+++ b/models/common/tests/test_sampling.py
@@ -465,6 +465,8 @@ def _decode_sampling_step(generator, seeds, positions, reload_inputs, max_batch_
         [None],
         sampling_params=params,
         start_pos=[torch.tensor(positions, dtype=torch.int32)],
+        reload_sampling_params=True,
+        reset_sampling_state=False,
         reload_inputs=reload_inputs,
     )
     return generator.model[0].sampling.seed_manager.pushed[-1]

--- a/models/common/warmup/warmup_utils.py
+++ b/models/common/warmup/warmup_utils.py
@@ -126,6 +126,10 @@ class WarmupForwardMixin:
                 enable_trace=enable_trace,
                 read_from_device=read_from_device,
                 sampling_params=param,
+                reload_inputs=True,
+                reload_page_table=False,
+                reload_sampling_params=param is not None,
+                reset_sampling_state=param is not None,
             )
 
         logger.info("Decode warmup completed")

--- a/models/common/warmup/warmup_utils.py
+++ b/models/common/warmup/warmup_utils.py
@@ -134,6 +134,13 @@ class WarmupForwardMixin:
                 enable_trace=enable_trace,
                 read_from_device=read_from_device,
                 sampling_params=param,
+                reload_inputs=True,
+                reload_page_table=False,
+                reload_sampling_params=param is not None,
+                # Warmup has no request-owned prompt/output history. The old
+                # reset_batch=False path compiled each sampling configuration
+                # without rebuilding penalty state; preserve that behavior.
+                reset_sampling_state=False,
             )
             if skip_trace_precompile:
                 decode_kwargs["skip_trace_precompile"] = True

--- a/models/demos/blackhole/qwen36/demo/text_demo.py
+++ b/models/demos/blackhole/qwen36/demo/text_demo.py
@@ -834,7 +834,11 @@ def _run_tp_generation_batched(model, tokenizer, token_ids, max_generated_tokens
         _greedy_params = SamplingParams(
             temperature=[1.0] * _sbatch, top_k=[1] * _sbatch, top_p=[1.0] * _sbatch, seed=[0] * _sbatch
         )
-        model.sampling.apply_decode_state([_greedy_params], reset_batch=True)
+        model.sampling.apply_decode_state(
+            [_greedy_params],
+            reload_sampling_params=True,
+            reset_sampling_state=True,
+        )
 
     _sharded_logits_mode = _mode in ("shard", "sample")
     trace_id, tt_logits, tt_idx, tt_val, tt_tok = None, None, None, None, None
@@ -994,6 +998,10 @@ def _run_traced_generation(model, tokenizer, device, token_ids, max_generated_to
             kv_cache=None,
             enable_trace=True,
             read_from_device=True,
+            reload_inputs=True,
+            reload_page_table=False,
+            reload_sampling_params=False,
+            reset_sampling_state=False,
         )
         dl = (out[0] if isinstance(out, tuple) else out).squeeze().float()
         next_token = int(dl.argmax())
@@ -1049,6 +1057,10 @@ def _run_paged_generation(model, tokenizer, device, token_ids, max_generated_tok
             kv_cache=None,
             enable_trace=False,
             read_from_device=True,
+            reload_inputs=True,
+            reload_page_table=False,
+            reload_sampling_params=False,
+            reset_sampling_state=False,
         )
         dl = (out[0] if isinstance(out, tuple) else out).squeeze().float()
         next_token = int(dl.argmax())

--- a/models/demos/blackhole/qwen36/demo/vision_demo.py
+++ b/models/demos/blackhole/qwen36/demo/vision_demo.py
@@ -412,6 +412,10 @@ def _run_traced_vision_generation(model, tokenizer, device, token_ids, vision_in
             kv_cache=None,
             enable_trace=True,
             read_from_device=True,
+            reload_inputs=True,
+            reload_page_table=False,
+            reload_sampling_params=False,
+            reset_sampling_state=False,
         )
         decode_times.append(time.time() - t_step)
         dl = (out[0] if isinstance(out, tuple) else out).squeeze().float()
@@ -461,6 +465,10 @@ def _run_paged_vision_generation(model, tokenizer, device, token_ids, vision_inp
             kv_cache=None,
             enable_trace=False,
             read_from_device=True,
+            reload_inputs=True,
+            reload_page_table=False,
+            reload_sampling_params=False,
+            reset_sampling_state=False,
         )
         decode_times.append(time.time() - t_step)
         dl = (out[0] if isinstance(out, tuple) else out).squeeze().float()

--- a/models/demos/blackhole/qwen36/tests/test_decode_bucketing.py
+++ b/models/demos/blackhole/qwen36/tests/test_decode_bucketing.py
@@ -66,6 +66,47 @@ def test_bucket_selection():
     logger.info("PASSED: bucket selection picks smallest pow2 >= num_active and never drops active rows")
 
 
+def test_positional_slot_remap_moves_gdn_state_and_keeps_full_width(monkeypatch):
+    from models.demos.blackhole.qwen36.tt.qwen36_vllm import Qwen36ForCausalLM
+    from models.tt_transformers.tt.generator import Generator
+
+    remaps = []
+    forwarded = []
+    model = SimpleNamespace(
+        num_devices=2,
+        args=SimpleNamespace(max_batch_size=4),
+        sampling=None,
+        _remap_gdn_slots=remaps.append,
+    )
+    wrapper = SimpleNamespace(model=[model])
+    monkeypatch.setenv("TT_DECODE_BUCKETING", "1")
+    monkeypatch.setattr(
+        Generator,
+        "decode_forward",
+        lambda self, *args, **kwargs: forwarded.append((args, kwargs)) or "output",
+    )
+    tokens, positions = _padded_decode_batch(1, 4)
+    slot_remap = [0, 1, 2, 3]
+
+    result = Qwen36ForCausalLM.decode_forward(
+        wrapper,
+        tokens,
+        positions,
+        None,
+        None,
+        True,
+        True,
+        None,
+        None,
+        None,
+        slot_remap,
+    )
+
+    assert result == "output"
+    assert remaps == [slot_remap]
+    assert forwarded[0][0][0].shape[0] == 4
+
+
 def test_unsupported_device_sampling_fails_at_startup(expect_error):
     from models.demos.blackhole.qwen36.tt.qwen36_vllm import Qwen36ForCausalLM
 

--- a/models/demos/blackhole/qwen36/tests/test_decode_bucketing.py
+++ b/models/demos/blackhole/qwen36/tests/test_decode_bucketing.py
@@ -100,6 +100,10 @@ def test_positional_slot_remap_moves_gdn_state_and_keeps_full_width(monkeypatch)
         None,
         None,
         slot_remap,
+        reload_inputs=True,
+        reload_page_table=False,
+        reload_sampling_params=False,
+        reset_sampling_state=False,
     )
 
     assert result == "output"

--- a/models/demos/blackhole/qwen36/tests/test_sampling.py
+++ b/models/demos/blackhole/qwen36/tests/test_sampling.py
@@ -62,7 +62,8 @@ def test_decode_only_unseeded_sampling_initializes_rng(mesh_device, reset_seeds,
 
     This reproduces the vLLM ``sample_on_device_mode=decode_only`` lifecycle:
     device prefill sampling state is deliberately skipped, then the first
-    device decode arrives with ``reset_batch=True`` and no request seed.
+    device decode arrives with ``reset_sampling_state=True`` and no request
+    seed.
     Sampling traces are disabled so this test isolates seed initialization
     from the separate sampling-trace correctness issue.
     """
@@ -95,8 +96,9 @@ def test_decode_only_unseeded_sampling_initializes_rng(mesh_device, reset_seeds,
             [tt_logits],
             sampling_params=params,
             start_pos=[positions],
-            reset_batch=step == 0,
             enable_trace=False,
+            reload_sampling_params=step == 0,
+            reset_sampling_state=step == 0,
         )
         tt_tokens, _ = outputs[0]
         sampled_tokens.append(_extract_user_zero_token(tt_tokens))

--- a/models/demos/blackhole/qwen36/tests/unit/test_model.py
+++ b/models/demos/blackhole/qwen36/tests/unit/test_model.py
@@ -109,7 +109,16 @@ def test_generator_decode_matches_reference(device):
     tok = torch.tensor([[int(pf.argmax())]], dtype=torch.long)
     for i, pos in enumerate(DECODE_POSITIONS):
         out = gen.decode_forward(
-            tok, torch.tensor([pos]), page_table=page_table, kv_cache=None, enable_trace=False, read_from_device=True
+            tok,
+            torch.tensor([pos]),
+            page_table=page_table,
+            kv_cache=None,
+            enable_trace=False,
+            read_from_device=True,
+            reload_inputs=True,
+            reload_page_table=False,
+            reload_sampling_params=False,
+            reset_sampling_state=False,
         )
         dl = out[0].squeeze().float() if isinstance(out, tuple) else out.squeeze().float()
         assert torch.allclose(dl, ref_dec[i], atol=1e-2, rtol=1e-2), f"decode step {i} drifted from decode_paged"
@@ -143,7 +152,16 @@ def test_generator_decode_traced_matches_reference(device):
     prime_decode_trace(gen, model, tok, torch.tensor([16]), page_table)
     for i, pos in enumerate(DECODE_POSITIONS):
         out = gen.decode_forward(
-            tok, torch.tensor([pos]), page_table=page_table, kv_cache=None, enable_trace=True, read_from_device=True
+            tok,
+            torch.tensor([pos]),
+            page_table=page_table,
+            kv_cache=None,
+            enable_trace=True,
+            read_from_device=True,
+            reload_inputs=True,
+            reload_page_table=False,
+            reload_sampling_params=False,
+            reset_sampling_state=False,
         )  # TRACED (trace already captured)
         dl = out[0].squeeze().float() if isinstance(out, tuple) else out.squeeze().float()
         assert torch.allclose(dl, ref_dec[i], atol=1e-2, rtol=1e-2), f"traced decode step {i} drifted from decode_paged"

--- a/models/demos/blackhole/qwen36/tt/generator_interface.py
+++ b/models/demos/blackhole/qwen36/tt/generator_interface.py
@@ -126,6 +126,15 @@ def prime_decode_trace(generator, model, tokens, current_pos, page_table):
     """
     saved = model._save_deltanet_states()
     generator.decode_forward(
-        tokens, current_pos, page_table=page_table, kv_cache=None, enable_trace=True, read_from_device=True
+        tokens,
+        current_pos,
+        page_table=page_table,
+        kv_cache=None,
+        enable_trace=True,
+        read_from_device=True,
+        reload_inputs=True,
+        reload_page_table=False,
+        reload_sampling_params=False,
+        reset_sampling_state=False,
     )
     model._restore_deltanet_states(saved, model.mesh_device)

--- a/models/demos/blackhole/qwen36/tt/generator_interface.py
+++ b/models/demos/blackhole/qwen36/tt/generator_interface.py
@@ -79,6 +79,15 @@ def prime_decode_trace(generator, model, tokens, current_pos, page_table):
     """
     saved = model._save_deltanet_states()
     generator.decode_forward(
-        tokens, current_pos, page_table=page_table, kv_cache=None, enable_trace=True, read_from_device=True
+        tokens,
+        current_pos,
+        page_table=page_table,
+        kv_cache=None,
+        enable_trace=True,
+        read_from_device=True,
+        reload_inputs=True,
+        reload_page_table=False,
+        reload_sampling_params=False,
+        reset_sampling_state=False,
     )
     model._restore_deltanet_states(saved, model.mesh_device)

--- a/models/demos/blackhole/qwen36/tt/model.py
+++ b/models/demos/blackhole/qwen36/tt/model.py
@@ -38,9 +38,10 @@ class Qwen36Model:
             self.tt_ccl = None
         self.configuration = args  # Generator reads model.configuration.max_seq_len
         self.sampling_dp = 1
-        # RoPE is host-recomputed each step, so refresh all decode trace inputs.
-        self._tt_vllm_always_refresh_decode_trace_inputs = True
-        # On-device sampling: allowlist 1x4/1x8 TP only — vocab/TP must fit Top-K's 64K shard limit (TP=2 does not).
+        # Rope is host-recomputed each step, so callers explicitly request a
+        # full input reload. Sampling does not alias the decode token input.
+        self._tt_supports_decode_token_feedback = False
+        # Reuses the vocab-sharded lm_head as the sampler's shard: needs divisible vocab; 64K = top-k limit.
         mesh_shape = tuple(int(dim) for dim in mesh_device.shape)
         self._supports_on_device_sampling = (
             mesh_shape in ((1, 4), (1, 8))

--- a/models/demos/blackhole/qwen36/tt/model.py
+++ b/models/demos/blackhole/qwen36/tt/model.py
@@ -37,8 +37,9 @@ class Qwen36Model:
             self.tt_ccl = None
         self.configuration = args  # Generator reads model.configuration.max_seq_len
         self.sampling_dp = 1
-        # Rope is host-recomputed each step (not advanced on-device) → force the trace to refresh decode inputs (else stale rope).
-        self._tt_vllm_always_refresh_decode_trace_inputs = True
+        # Rope is host-recomputed each step, so callers explicitly request a
+        # full input reload. Sampling does not alias the decode token input.
+        self._tt_supports_decode_token_feedback = False
         # Reuses the vocab-sharded lm_head as the sampler's shard: needs divisible vocab; 64K = top-k limit.
         self._supports_on_device_sampling = (
             self.num_devices > 1

--- a/models/demos/blackhole/qwen36/tt/qwen36_vllm.py
+++ b/models/demos/blackhole/qwen36/tt/qwen36_vllm.py
@@ -51,6 +51,7 @@ class Qwen36ForCausalLM(Generator, SupportsMultiModal):
     # Decode bucketing keeps several traces live and refreshes the selected
     # bucket's inputs before replay, so their I/O buffers may safely overlap.
     _tt_allow_decode_trace_buffer_reuse = True
+    decode_input_update_contract = 1
 
     # supports_async_decode=False: async decode assumes on-device token/position continuity, which
     # corrupts Qwen's GDN scan. supports_sample_on_device=True: on-device sampling is decode-only.
@@ -295,24 +296,6 @@ class Qwen36ForCausalLM(Generator, SupportsMultiModal):
         return logits, torch.zeros(N, dtype=torch.long)
 
     def decode_forward(self, *args, **kwargs):
-        # Traced decode (single-device and TP): trace captured at pos 0 in warmup, replayed here.
-        # Valid for TP — GDN state is in fixed in-place buffers, and prefill only replays pre-warmed programs.
-        if not getattr(self, "_decode_logged", False):
-            self._decode_logged = True
-            logger.info("Decode trace replay active (Qwen)")
-        model = self.model[0]
-        # Batched serving: apply vLLM's condense slot_remap to the per-slot GDN recurrent/conv state
-        # BEFORE the decode trace reads it. The plugin remaps its own buffers (and the seed RNG via
-        # super().decode_forward), but GDN state is model-internal, so mirror the same reindex here.
-        # slot_remap is passed through unchanged so the seed-RNG remap inside super() still runs.
-        if model.num_devices > 1 and model.args.max_batch_size > 1:
-            slot_remap = kwargs.get("slot_remap")
-            if slot_remap is not None:
-                model._remap_gdn_slots(slot_remap)
-        # Decode bucketing (default on; TT_DECODE_BUCKETING=0 off): slice host inputs to the
-        # smallest power-of-2 width >= active prefix [0:num_active) before the base forward.
-        # No runner edit / output re-pad — plugin reads unpadded_batch_size in slot order.
-        # Each width keeps its own trace metadata, inputs, and output.
         args = list(args)
 
         def _read(name, pos):
@@ -326,6 +309,24 @@ class Qwen36ForCausalLM(Generator, SupportsMultiModal):
             elif pos < len(args):
                 args[pos] = val
 
+        # Traced decode (single-device and TP): trace captured at pos 0 in warmup, replayed here.
+        # Valid for TP — GDN state is in fixed in-place buffers, and prefill only replays pre-warmed programs.
+        if not getattr(self, "_decode_logged", False):
+            self._decode_logged = True
+            logger.info("Decode trace replay active (Qwen)")
+        model = self.model[0]
+        # Batched serving: apply vLLM's condense slot_remap to the per-slot GDN recurrent/conv state
+        # BEFORE the decode trace reads it. The plugin remaps its own buffers (and the seed RNG via
+        # super().decode_forward), but GDN state is model-internal, so mirror the same reindex here.
+        # slot_remap is passed through unchanged so the seed-RNG remap inside super() still runs.
+        if model.num_devices > 1 and model.args.max_batch_size > 1:
+            slot_remap = _read("slot_remap", 9)
+            if slot_remap is not None:
+                model._remap_gdn_slots(slot_remap)
+        # Decode bucketing (default on; TT_DECODE_BUCKETING=0 off): slice host inputs to the
+        # smallest power-of-2 width >= active prefix [0:num_active) before the base forward.
+        # No runner edit / output re-pad — plugin reads unpadded_batch_size in slot order.
+        # Each width keeps its own trace metadata, inputs, and output.
         tokens = _read("tokens", 0)
         if os.environ.get("TT_DECODE_BUCKETING", "1") == "1" and tokens is not None:
             start_pos = _read("start_pos", 1)
@@ -334,8 +335,8 @@ class Qwen36ForCausalLM(Generator, SupportsMultiModal):
             num_active = max(1, min(num_active, width))
             bucket = min(width, 1 << max(0, (num_active - 1).bit_length()))  # smallest pow2 >= num_active
             # Keep full width when slot_remap is set: remap indexes the full slot space (tokens /
-            # GDN). Rare (row moves only); bucketing resumes next step. Check kw + positional #10.
-            if _read("slot_remap", 10) is not None:
+            # GDN). Rare (row moves only); bucketing resumes next step. Check kw + positional #9.
+            if _read("slot_remap", 9) is not None:
                 bucket = width
             if bucket < width:
                 _write("tokens", 0, tokens[:bucket])

--- a/models/demos/blackhole/qwen36/tt/qwen36_vllm.py
+++ b/models/demos/blackhole/qwen36/tt/qwen36_vllm.py
@@ -46,6 +46,8 @@ class TT_Qwen3_5ProcessingInfo(Qwen3_5ProcessingInfo):
 class Qwen36ForCausalLM(Generator, SupportsMultiModal):
     """vLLM-compatible wrapper for Qwen3.5-9B on Blackhole P150."""
 
+    decode_input_update_contract = 1
+
     # supports_async_decode=False: async decode assumes on-device token/position continuity, which
     # corrupts Qwen's GDN scan. supports_sample_on_device=True: on-device sampling is decode-only.
     model_capabilities = {

--- a/models/demos/deepseek_v3/tests/test_sampling.py
+++ b/models/demos/deepseek_v3/tests/test_sampling.py
@@ -3,14 +3,16 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import random
 from types import SimpleNamespace
 
 import pytest
 import torch
 
 import ttnn
-from models.common.sampling import SamplingGenerator, SamplingParams, format_sampling_params
+from models.common.sampling import SamplingGenerator, SamplingParams, SeedManager, format_sampling_params
 from models.demos.deepseek_v3.tt.generator import DeepseekGenerator
+from models.demos.deepseek_v3.tt.generator_vllm import DeepseekV3ForCausalLM
 from models.demos.deepseek_v3.utils.config_helpers import USERS_PER_ROW, get_fabric_config, make_deepseek_sampling_args
 
 
@@ -67,8 +69,25 @@ class _FakeSeedManager:
         self.reset_calls = []
         self.new_value_calls = []
 
-    def reset_seed(self, seeds, user_ids):
+        self.conditional_reset_calls = []
+        self.align_calls = []
+        self.remap_calls = []
+        self.deactivate_calls = []
+
+    def reset_seed_from_slots(self, seeds, user_ids):
         self.reset_calls.append((seeds, user_ids))
+
+    def reset_seed_from_slots_if_needed(self, seeds, user_ids):
+        self.conditional_reset_calls.append((seeds, user_ids))
+
+    def align_seed_counters_to_positions(self, seeds, user_ids, positions):
+        self.align_calls.append((seeds, user_ids, positions))
+
+    def apply_slot_remap(self, remap):
+        self.remap_calls.append(remap)
+
+    def deactivate_slots_except(self, live_slots):
+        self.deactivate_calls.append(live_slots)
 
     def get_new_values(self, user_slots):
         self.new_value_calls.append(user_slots)
@@ -80,19 +99,34 @@ class _FakeSamplingGenerator:
         self.seed_manager = _FakeSeedManager(padded_batch_size * sampling_dp)
         self.decode_state_calls = []
 
+    def apply_slot_remap(self, remap):
+        self.seed_manager.apply_slot_remap(remap)
+
+    def validate_decode_state_commands(self, **kwargs):
+        pass
+
     def apply_decode_state(self, sampling_param_chunks, **kwargs):
         self.decode_state_calls.append((sampling_param_chunks, kwargs))
 
 
 def _fake_deepseek_generator(*, batch_size_per_row=8, sampling_dp=2):
     class _FakeDeepseekGenerator:
-        _reset_sampling_state = DeepseekGenerator._reset_sampling_state
+        _apply_sampling_state = DeepseekGenerator._apply_sampling_state
         _sampling_device_slot = DeepseekGenerator._sampling_device_slot
         _sampling_device_slots = DeepseekGenerator._sampling_device_slots
+        _sampling_device_positions = DeepseekGenerator._sampling_device_positions
+        _sampling_params_for_user_slots = DeepseekGenerator._sampling_params_for_user_slots
+        _sampling_history_for_user_slots = DeepseekGenerator._sampling_history_for_user_slots
+        _sampling_device_history = DeepseekGenerator._sampling_device_history
+        _sampling_device_slot_remap = DeepseekGenerator._sampling_device_slot_remap
+        _apply_sampling_slot_remap = DeepseekGenerator._apply_sampling_slot_remap
         _sampling_device_seed_slots = DeepseekGenerator._sampling_device_seed_slots
+        _to_local_sampling_params = DeepseekGenerator._to_local_sampling_params
+        _normalize_sampling_params_for_batch = DeepseekGenerator._normalize_sampling_params_for_batch
 
         def __init__(self):
             self.batch_size_per_row = batch_size_per_row
+            self.batch_size = batch_size_per_row * sampling_dp
             self.sampling_generator = _FakeSamplingGenerator(padded_batch_size=32, sampling_dp=sampling_dp)
 
     return _FakeDeepseekGenerator()
@@ -110,7 +144,14 @@ def test_deepseek_reset_sampling_state_does_not_preformat_sampling_params():
         seed=[1234] * batch_size,
     )
 
-    DeepseekGenerator._reset_sampling_state(generator, sampling_params, batch_size, batch_size_per_row)
+    DeepseekGenerator._apply_sampling_state(
+        generator,
+        sampling_params,
+        batch_size,
+        batch_size_per_row,
+        reload_sampling_params=True,
+        reset_sampling_state=True,
+    )
 
     [(sampling_param_chunks, kwargs)] = sampling_generator.decode_state_calls
     assert len(sampling_param_chunks) == 2
@@ -120,9 +161,11 @@ def test_deepseek_reset_sampling_state_does_not_preformat_sampling_params():
         sampling_param_chunks[0], max_batch_size=batch_size_per_row
     ).temperature[0]
     assert first_chunk_temperature == pytest.approx(1 / 0.6)
-    assert kwargs["reset_batch"] is True
-    assert kwargs["prompt_tokens"].shape == (batch_size_per_row, 1)
-    assert kwargs["output_tokens"].shape == (batch_size_per_row, 1)
+    assert kwargs["reload_sampling_params"] is True
+    assert kwargs["reset_sampling_state"] is True
+    assert kwargs["prompt_tokens"].shape == (batch_size, 1)
+    assert torch.all(kwargs["prompt_tokens"] == -1)
+    assert kwargs["output_tokens"] is None
     [seed_reset] = sampling_generator.seed_manager.reset_calls
     assert seed_reset == ([1234] * batch_size, list(range(batch_size)))
 
@@ -143,7 +186,14 @@ def test_deepseek_sampling_seed_reset_uses_row_padded_device_slots():
         seed=list(range(100, 100 + batch_size)),
     )
 
-    DeepseekGenerator._reset_sampling_state(generator, sampling_params, batch_size, generator.batch_size_per_row)
+    DeepseekGenerator._apply_sampling_state(
+        generator,
+        sampling_params,
+        batch_size,
+        generator.batch_size_per_row,
+        reload_sampling_params=True,
+        reset_sampling_state=True,
+    )
 
     [(seeds, user_ids)] = generator.sampling_generator.seed_manager.reset_calls
     assert user_ids == list(range(128))
@@ -155,6 +205,418 @@ def test_deepseek_sampling_seed_reset_uses_row_padded_device_slots():
     assert seeds[72:96] == [None] * 24
     assert seeds[96:104] == list(range(124, 132))
     assert seeds[104:] == [None] * 24
+
+
+def test_deepseek_unseeded_sampling_reset_initializes_all_device_slots():
+    batch_size = 32
+    generator = _fake_deepseek_generator(batch_size_per_row=16, sampling_dp=2)
+    sampling_params = SamplingParams(
+        temperature=[0.6] * batch_size,
+        top_k=[32] * batch_size,
+        top_p=[0.95] * batch_size,
+        seed=None,
+    )
+
+    DeepseekGenerator._apply_sampling_state(
+        generator,
+        sampling_params,
+        batch_size,
+        generator.batch_size_per_row,
+        reload_sampling_params=True,
+        reset_sampling_state=True,
+    )
+
+    [(seeds, user_ids)] = generator.sampling_generator.seed_manager.reset_calls
+    assert seeds == [None] * 64
+    assert user_ids == list(range(64))
+
+
+def test_deepseek_sampling_reset_aligns_active_row_padded_seed_positions():
+    batch_size = 32
+    generator = _fake_deepseek_generator(batch_size_per_row=16, sampling_dp=2)
+    sampling_params = SamplingParams(
+        temperature=[0.6] * batch_size,
+        top_k=[32] * batch_size,
+        top_p=[0.95] * batch_size,
+        seed=list(range(100, 100 + batch_size)),
+    )
+    positions = torch.tensor([10] + [-1] * 15 + [20] + [-1] * 15)
+
+    DeepseekGenerator._apply_sampling_state(
+        generator,
+        sampling_params,
+        batch_size,
+        generator.batch_size_per_row,
+        reload_sampling_params=False,
+        reset_sampling_state=True,
+        user_slots=[0, 16],
+        positions=positions,
+    )
+
+    [(seeds, user_ids)] = generator.sampling_generator.seed_manager.reset_calls
+    assert user_ids == [0, 32]
+    [(aligned_seeds, aligned_user_ids, device_positions)] = generator.sampling_generator.seed_manager.align_calls
+    assert aligned_seeds == seeds
+    assert aligned_user_ids == [0, 32]
+    assert device_positions[0] == 10
+    assert device_positions[32] == 20
+    assert device_positions[1:32] == [-1] * 31
+
+
+def test_deepseek_sampling_histories_use_row_padded_device_layout():
+    generator = _fake_deepseek_generator(batch_size_per_row=2, sampling_dp=2)
+    compact = torch.tensor([[10, 11], [20, 21], [30, 31], [40, 41]])
+
+    padded = DeepseekGenerator._sampling_device_history(generator, compact)
+
+    assert padded.shape == (64, 2)
+    assert padded[0].tolist() == [10, 11]
+    assert padded[1].tolist() == [20, 21]
+    assert padded[32].tolist() == [30, 31]
+    assert padded[33].tolist() == [40, 41]
+    assert torch.all(padded[2:32] == -1)
+    assert torch.all(padded[34:] == -1)
+
+
+def test_deepseek_prefill_sampling_state_uses_nonidentity_stable_slots():
+    generator = _fake_deepseek_generator(batch_size_per_row=16, sampling_dp=2)
+    generator.sampling_params = SamplingParams(
+        temperature=[1.0] * generator.batch_size,
+        top_k=[1] * generator.batch_size,
+        top_p=[1.0] * generator.batch_size,
+        seed=[None] * generator.batch_size,
+    )
+    sampling_params = SamplingParams(
+        temperature=[0.6, 0.8],
+        top_k=[16, 32],
+        top_p=[0.9, 0.95],
+        seed=[111, 222],
+    )
+    stable_slots = [17, 0]
+    prompt_tokens = torch.tensor([[10, 11], [20, -1]])
+
+    stable_params = DeepseekGenerator._sampling_params_for_user_slots(
+        generator,
+        sampling_params,
+        stable_slots,
+    )
+    stable_history = DeepseekGenerator._sampling_history_for_user_slots(
+        generator,
+        prompt_tokens,
+        stable_slots,
+    )
+    DeepseekGenerator._apply_sampling_state(
+        generator,
+        stable_params,
+        generator.batch_size,
+        generator.batch_size_per_row,
+        reload_sampling_params=True,
+        reset_sampling_state=True,
+        user_slots=stable_slots,
+        prompt_tokens=stable_history,
+        preserve_unlisted_slots=True,
+    )
+
+    [(seeds, active_slots)] = generator.sampling_generator.seed_manager.reset_calls
+    assert active_slots == [33, 0]
+    assert seeds[33] == 111
+    assert seeds[0] == 222
+    [(_, commands)] = generator.sampling_generator.decode_state_calls
+    assert commands["prompt_tokens"][33].tolist() == [10, 11]
+    assert commands["prompt_tokens"][0].tolist() == [20, -1]
+    assert commands["sampling_state_slots"] == [33, 0]
+    assert generator.sampling_generator.seed_manager.deactivate_calls == []
+
+
+def test_deepseek_prefill_preserves_live_slots_when_admitting_new_request():
+    generator = _fake_deepseek_generator(batch_size_per_row=4, sampling_dp=2)
+    generator.sampling_params = SamplingParams(
+        temperature=[0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8],
+        top_k=[1, 2, 3, 4, 5, 6, 7, 8],
+        top_p=[0.51, 0.52, 0.53, 0.54, 0.55, 0.56, 0.57, 0.58],
+        presence_penalty=[0.01, 0.02, 0.03, 0.04, 0.05, 0.06, 0.07, 0.08],
+        frequency_penalty=[0.11, 0.12, 0.13, 0.14, 0.15, 0.16, 0.17, 0.18],
+        repetition_penalty=[1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8],
+        seed=list(range(100, 108)),
+        enable_log_probs=[False, True, False, True, False, True, False, True],
+        num_logprobs=list(range(8)),
+    )
+    incoming = SamplingParams(
+        temperature=[0.95],
+        top_k=[42],
+        top_p=[0.99],
+        presence_penalty=[0.25],
+        frequency_penalty=[0.35],
+        repetition_penalty=[1.95],
+        seed=[999],
+        enable_log_probs=[False],
+        num_logprobs=[9],
+    )
+
+    stable = DeepseekGenerator._sampling_params_for_user_slots(generator, incoming, [5])
+
+    assert stable.temperature == [0.1, 0.2, 0.3, 0.4, 0.5, 0.95, 0.7, 0.8]
+    assert stable.top_k == [1, 2, 3, 4, 5, 42, 7, 8]
+    assert stable.top_p == [0.51, 0.52, 0.53, 0.54, 0.55, 0.99, 0.57, 0.58]
+    assert stable.presence_penalty == [0.01, 0.02, 0.03, 0.04, 0.05, 0.25, 0.07, 0.08]
+    assert stable.frequency_penalty == [0.11, 0.12, 0.13, 0.14, 0.15, 0.35, 0.17, 0.18]
+    assert stable.repetition_penalty == [1.1, 1.2, 1.3, 1.4, 1.5, 1.95, 1.7, 1.8]
+    assert stable.seed == [100, 101, 102, 103, 104, 999, 106, 107]
+    assert stable.enable_log_probs == [False, True, False, True, False, False, False, True]
+    assert stable.num_logprobs == [0, 1, 2, 3, 4, 9, 6, 7]
+
+
+def test_deepseek_prompt_history_excludes_padding_tokens():
+    tokens = torch.tensor([[10, 11, 99, 99], [20, 21, 22, 99]])
+    lengths = torch.tensor([2, 3])
+
+    history = DeepseekGenerator._prompt_history(tokens, lengths)
+
+    assert history.tolist() == [[10, 11, -1, -1], [20, 21, 22, -1]]
+
+
+def test_deepseek_sampling_reset_uses_vllm_penalty_histories():
+    batch_size = 32
+    generator = _fake_deepseek_generator(batch_size_per_row=16, sampling_dp=2)
+    sampling_params = SamplingParams(
+        temperature=[0.6] * batch_size,
+        top_k=[32] * batch_size,
+        top_p=[0.95] * batch_size,
+        presence_penalty=[0.5] * batch_size,
+        seed=[1234] * batch_size,
+    )
+    prompt_tokens = torch.arange(batch_size * 2).reshape(batch_size, 2)
+    output_tokens = torch.arange(batch_size).reshape(batch_size, 1)
+
+    DeepseekGenerator._apply_sampling_state(
+        generator,
+        sampling_params,
+        batch_size,
+        generator.batch_size_per_row,
+        reload_sampling_params=True,
+        reset_sampling_state=True,
+        prompt_tokens=prompt_tokens,
+        output_tokens=output_tokens,
+    )
+
+    [(_, commands)] = generator.sampling_generator.decode_state_calls
+    assert commands["prompt_tokens"][[0, 1, 32, 33]].tolist() == prompt_tokens[[0, 1, 16, 17]].tolist()
+    assert commands["output_tokens"][[0, 1, 32, 33]].tolist() == output_tokens[[0, 1, 16, 17]].tolist()
+
+
+def test_deepseek_sampling_params_can_reload_without_state_reset():
+    batch_size = 32
+    generator = _fake_deepseek_generator(batch_size_per_row=16, sampling_dp=2)
+    sampling_params = SamplingParams(
+        temperature=[0.7] * batch_size,
+        top_k=[16] * batch_size,
+        top_p=[0.9] * batch_size,
+        seed=[1234] * batch_size,
+    )
+
+    DeepseekGenerator._apply_sampling_state(
+        generator,
+        sampling_params,
+        batch_size,
+        generator.batch_size_per_row,
+        reload_sampling_params=True,
+        reset_sampling_state=False,
+        user_slots=[0, 16],
+    )
+
+    [(_, commands)] = generator.sampling_generator.decode_state_calls
+    assert commands["reload_sampling_params"] is True
+    assert commands["reset_sampling_state"] is False
+    assert generator.sampling_generator.seed_manager.reset_calls == []
+    [(_, user_ids)] = generator.sampling_generator.seed_manager.conditional_reset_calls
+    assert user_ids == [0, 32]
+
+
+def test_deepseek_sampling_retires_finished_tail_slot_seed_state():
+    generator = _fake_deepseek_generator(batch_size_per_row=16, sampling_dp=2)
+    sampling_params = SamplingParams(
+        temperature=[0.7] * 32,
+        top_k=[16] * 32,
+        top_p=[0.9] * 32,
+        seed=[1234] * 32,
+    )
+
+    DeepseekGenerator._apply_sampling_state(
+        generator,
+        sampling_params,
+        32,
+        generator.batch_size_per_row,
+        reload_sampling_params=True,
+        reset_sampling_state=True,
+        user_slots=[0, 16],
+    )
+
+    assert generator.sampling_generator.seed_manager.deactivate_calls == [[0, 32]]
+
+
+def test_deepseek_sampling_update_obeys_explicit_commands_without_value_comparison():
+    sampling_params = SamplingParams(temperature=0.6, top_k=32, top_p=0.95, seed=None)
+    update_calls = []
+    generator = SimpleNamespace(
+        batch_size=1,
+        batch_size_per_row=1,
+        sampling_params=sampling_params,
+        sampling_generator=object(),
+        _to_local_sampling_params=lambda params: params,
+        _normalize_sampling_params_for_batch=lambda params, batch_size: params,
+        _get_sampling_value=lambda value, index: value[index] if isinstance(value, list) else value,
+        _apply_sampling_state=lambda params, batch_size, batch_size_per_row, **commands: update_calls.append(
+            (params, batch_size, batch_size_per_row, commands)
+        ),
+    )
+
+    DeepseekGenerator._validate_and_initialize_sampling(
+        generator,
+        sampling_params,
+        sample_on_device=True,
+        reload_sampling_params=False,
+        reset_sampling_state=True,
+    )
+
+    assert update_calls == [
+        (
+            sampling_params,
+            1,
+            1,
+            {
+                "reload_sampling_params": False,
+                "reset_sampling_state": True,
+                "user_slots": None,
+                "positions": None,
+                "prompt_tokens": None,
+                "output_tokens": None,
+                "preserve_unlisted_slots": False,
+            },
+        )
+    ]
+
+
+def test_deepseek_slot_remap_maps_users_to_row_padded_seed_slots():
+    generator = _fake_deepseek_generator(batch_size_per_row=2, sampling_dp=2)
+
+    remap = DeepseekGenerator._sampling_device_slot_remap(generator, [3, 1, 2, 3])
+
+    assert len(remap) == 64
+    assert remap[0] == 33
+    assert remap[1] == 1
+    assert remap[32] == 32
+    assert remap[33] == 33
+    assert remap[2:32] == list(range(2, 32))
+
+
+def test_deepseek_slot_remap_moves_seeded_state_across_padded_rows():
+    generator = _fake_deepseek_generator(batch_size_per_row=2, sampling_dp=2)
+    manager = SeedManager.__new__(SeedManager)
+    manager.max_batch_size = 64
+    manager.seeds = [None] * 64
+    manager.seed_counters = [0] * 64
+    manager.seed_salts = [0] * 64
+    manager.rngs = [random.Random(i) for i in range(64)]
+    manager._seed_active = True
+    manager.seeds[33] = 1234
+    manager.seed_counters[33] = 17
+    manager.seed_salts[33] = 2
+    old_rng_state = manager.rngs[33].getstate()
+    generator.sampling_generator.seed_manager = manager
+
+    DeepseekGenerator._apply_sampling_slot_remap(generator, [3, 1, 2, 3])
+
+    assert manager.seeds[0] == 1234
+    assert manager.seed_counters[0] == 17
+    assert manager.seed_salts[0] == 2
+    assert manager.rngs[0].getstate() == old_rng_state
+    assert manager.seeds[33] is None
+    assert manager.seed_counters[33] == 0
+    assert manager.seed_salts[33] == 0
+
+
+def test_deepseek_host_sampling_remap_is_noop_without_device_sampler():
+    generator = SimpleNamespace(sampling_generator=None)
+
+    DeepseekGenerator._apply_sampling_slot_remap(generator, [0])
+
+
+def test_deepseek_sampling_applies_remap_before_update_and_advance():
+    events = []
+    sampling_params = SamplingParams(temperature=0.6, top_k=32, top_p=0.95, seed=1234)
+    generator = SimpleNamespace(
+        sampling_generator=SimpleNamespace(
+            validate_decode_state_commands=lambda **kwargs: events.append(("validate", kwargs))
+        ),
+        _apply_sampling_slot_remap=lambda remap: events.append(("remap", remap)),
+        _validate_and_initialize_sampling=lambda *args, **kwargs: events.append(("update", kwargs)),
+        _sample_tokens_device=lambda *args, **kwargs: events.append(("advance", kwargs)) or "tokens",
+    )
+
+    result = DeepseekGenerator.sample_decode_on_device(
+        generator,
+        "logits",
+        sampling_params=sampling_params,
+        slot_remap=[1, 1],
+        user_slots=[0],
+        reload_sampling_params=True,
+        reset_sampling_state=True,
+    )
+
+    assert result == "tokens"
+    assert [event[0] for event in events] == ["remap", "update", "validate", "advance"]
+
+
+def test_deepseek_host_sampling_applies_dormant_remap_after_success(monkeypatch):
+    events = []
+    generator = DeepseekV3ForCausalLM.__new__(DeepseekV3ForCausalLM)
+    generator.model_run_config_decode = object()
+    generator._apply_sampling_slot_remap = lambda remap: events.append(("remap", remap))
+    monkeypatch.setattr(
+        DeepseekGenerator,
+        "decode_forward",
+        lambda *args, **kwargs: events.append("decode") or torch.zeros((1, 1, 1, 8)),
+    )
+
+    output = generator.decode_forward(
+        tokens=torch.zeros((1, 1), dtype=torch.int64),
+        start_pos=torch.zeros((1,), dtype=torch.int64),
+        read_from_device=False,
+        slot_remap=[0],
+        reload_inputs=True,
+        reload_page_table=False,
+        reload_sampling_params=False,
+        reset_sampling_state=False,
+    )
+
+    assert output.shape == (1, 1, 8)
+    assert events == ["decode", ("remap", [0])]
+
+
+def test_deepseek_host_sampling_does_not_consume_remap_on_failure(monkeypatch, expect_error):
+    events = []
+    generator = DeepseekV3ForCausalLM.__new__(DeepseekV3ForCausalLM)
+    generator.model_run_config_decode = object()
+    generator._apply_sampling_slot_remap = lambda remap: events.append(("remap", remap))
+    monkeypatch.setattr(
+        DeepseekGenerator,
+        "decode_forward",
+        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("decode")),
+    )
+
+    with expect_error(RuntimeError, "decode"):
+        generator.decode_forward(
+            tokens=torch.zeros((1, 1), dtype=torch.int64),
+            start_pos=torch.zeros((1,), dtype=torch.int64),
+            read_from_device=False,
+            slot_remap=[0],
+            reload_inputs=True,
+            reload_page_table=False,
+            reload_sampling_params=False,
+            reset_sampling_state=False,
+        )
+
+    assert events == []
 
 
 @torch.no_grad()

--- a/models/demos/deepseek_v3/tests/test_sampling.py
+++ b/models/demos/deepseek_v3/tests/test_sampling.py
@@ -3,13 +3,14 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import random
 from types import SimpleNamespace
 
 import pytest
 import torch
 
 import ttnn
-from models.common.sampling import SamplingGenerator, SamplingParams, format_sampling_params
+from models.common.sampling import SamplingGenerator, SamplingParams, SeedManager, format_sampling_params
 from models.demos.deepseek_v3.tt.generator import DeepseekGenerator
 from models.demos.deepseek_v3.utils.config_helpers import USERS_PER_ROW, get_fabric_config, make_deepseek_sampling_args
 
@@ -67,8 +68,21 @@ class _FakeSeedManager:
         self.reset_calls = []
         self.new_value_calls = []
 
-    def reset_seed(self, seeds, user_ids):
+        self.conditional_reset_calls = []
+        self.align_calls = []
+        self.remap_calls = []
+
+    def reset_seed_from_slots(self, seeds, user_ids):
         self.reset_calls.append((seeds, user_ids))
+
+    def reset_seed_from_slots_if_needed(self, seeds, user_ids):
+        self.conditional_reset_calls.append((seeds, user_ids))
+
+    def align_seed_counters_to_positions(self, seeds, user_ids, positions):
+        self.align_calls.append((seeds, user_ids, positions))
+
+    def apply_slot_remap(self, remap):
+        self.remap_calls.append(remap)
 
     def get_new_values(self, user_slots):
         self.new_value_calls.append(user_slots)
@@ -86,13 +100,20 @@ class _FakeSamplingGenerator:
 
 def _fake_deepseek_generator(*, batch_size_per_row=8, sampling_dp=2):
     class _FakeDeepseekGenerator:
-        _reset_sampling_state = DeepseekGenerator._reset_sampling_state
+        _apply_sampling_state = DeepseekGenerator._apply_sampling_state
         _sampling_device_slot = DeepseekGenerator._sampling_device_slot
         _sampling_device_slots = DeepseekGenerator._sampling_device_slots
+        _sampling_device_positions = DeepseekGenerator._sampling_device_positions
+        _sampling_params_for_user_slots = DeepseekGenerator._sampling_params_for_user_slots
+        _sampling_history_for_user_slots = DeepseekGenerator._sampling_history_for_user_slots
+        _sampling_device_history = DeepseekGenerator._sampling_device_history
+        _sampling_device_slot_remap = DeepseekGenerator._sampling_device_slot_remap
+        _apply_sampling_slot_remap = DeepseekGenerator._apply_sampling_slot_remap
         _sampling_device_seed_slots = DeepseekGenerator._sampling_device_seed_slots
 
         def __init__(self):
             self.batch_size_per_row = batch_size_per_row
+            self.batch_size = batch_size_per_row * sampling_dp
             self.sampling_generator = _FakeSamplingGenerator(padded_batch_size=32, sampling_dp=sampling_dp)
 
     return _FakeDeepseekGenerator()
@@ -110,7 +131,14 @@ def test_deepseek_reset_sampling_state_does_not_preformat_sampling_params():
         seed=[1234] * batch_size,
     )
 
-    DeepseekGenerator._reset_sampling_state(generator, sampling_params, batch_size, batch_size_per_row)
+    DeepseekGenerator._apply_sampling_state(
+        generator,
+        sampling_params,
+        batch_size,
+        batch_size_per_row,
+        reload_sampling_params=True,
+        reset_sampling_state=True,
+    )
 
     [(sampling_param_chunks, kwargs)] = sampling_generator.decode_state_calls
     assert len(sampling_param_chunks) == 2
@@ -120,9 +148,11 @@ def test_deepseek_reset_sampling_state_does_not_preformat_sampling_params():
         sampling_param_chunks[0], max_batch_size=batch_size_per_row
     ).temperature[0]
     assert first_chunk_temperature == pytest.approx(1 / 0.6)
-    assert kwargs["reset_batch"] is True
-    assert kwargs["prompt_tokens"].shape == (batch_size_per_row, 1)
-    assert kwargs["output_tokens"].shape == (batch_size_per_row, 1)
+    assert kwargs["reload_sampling_params"] is True
+    assert kwargs["reset_sampling_state"] is True
+    assert kwargs["prompt_tokens"].shape == (batch_size, 1)
+    assert torch.all(kwargs["prompt_tokens"] == -1)
+    assert kwargs["output_tokens"] is None
     [seed_reset] = sampling_generator.seed_manager.reset_calls
     assert seed_reset == ([1234] * batch_size, list(range(batch_size)))
 
@@ -143,7 +173,14 @@ def test_deepseek_sampling_seed_reset_uses_row_padded_device_slots():
         seed=list(range(100, 100 + batch_size)),
     )
 
-    DeepseekGenerator._reset_sampling_state(generator, sampling_params, batch_size, generator.batch_size_per_row)
+    DeepseekGenerator._apply_sampling_state(
+        generator,
+        sampling_params,
+        batch_size,
+        generator.batch_size_per_row,
+        reload_sampling_params=True,
+        reset_sampling_state=True,
+    )
 
     [(seeds, user_ids)] = generator.sampling_generator.seed_manager.reset_calls
     assert user_ids == list(range(128))
@@ -158,8 +195,8 @@ def test_deepseek_sampling_seed_reset_uses_row_padded_device_slots():
 
 
 def test_deepseek_unseeded_sampling_reset_initializes_all_device_slots():
-    batch_size = 16
-    generator = _fake_deepseek_generator(batch_size_per_row=8, sampling_dp=2)
+    batch_size = 32
+    generator = _fake_deepseek_generator(batch_size_per_row=16, sampling_dp=2)
     sampling_params = SamplingParams(
         temperature=[0.6] * batch_size,
         top_k=[32] * batch_size,
@@ -167,16 +204,177 @@ def test_deepseek_unseeded_sampling_reset_initializes_all_device_slots():
         seed=None,
     )
 
-    DeepseekGenerator._reset_sampling_state(generator, sampling_params, batch_size, generator.batch_size_per_row)
+    DeepseekGenerator._apply_sampling_state(
+        generator,
+        sampling_params,
+        batch_size,
+        generator.batch_size_per_row,
+        reload_sampling_params=True,
+        reset_sampling_state=True,
+    )
 
     [(seeds, user_ids)] = generator.sampling_generator.seed_manager.reset_calls
     assert seeds == [None] * 64
     assert user_ids == list(range(64))
 
 
-def test_deepseek_force_reset_rebuilds_unchanged_sampling_state():
+def test_deepseek_sampling_reset_aligns_active_row_padded_seed_positions():
+    batch_size = 32
+    generator = _fake_deepseek_generator(batch_size_per_row=16, sampling_dp=2)
+    sampling_params = SamplingParams(
+        temperature=[0.6] * batch_size,
+        top_k=[32] * batch_size,
+        top_p=[0.95] * batch_size,
+        seed=list(range(100, 100 + batch_size)),
+    )
+    positions = torch.tensor([10] + [-1] * 15 + [20] + [-1] * 15)
+
+    DeepseekGenerator._apply_sampling_state(
+        generator,
+        sampling_params,
+        batch_size,
+        generator.batch_size_per_row,
+        reload_sampling_params=False,
+        reset_sampling_state=True,
+        user_slots=[0, 16],
+        positions=positions,
+    )
+
+    [(seeds, user_ids)] = generator.sampling_generator.seed_manager.reset_calls
+    assert user_ids == [0, 32]
+    [(aligned_seeds, aligned_user_ids, device_positions)] = generator.sampling_generator.seed_manager.align_calls
+    assert aligned_seeds == seeds
+    assert aligned_user_ids == [0, 32]
+    assert device_positions[0] == 10
+    assert device_positions[32] == 20
+    assert device_positions[1:32] == [-1] * 31
+
+
+def test_deepseek_sampling_histories_use_row_padded_device_layout():
+    generator = _fake_deepseek_generator(batch_size_per_row=2, sampling_dp=2)
+    compact = torch.tensor([[10, 11], [20, 21], [30, 31], [40, 41]])
+
+    padded = DeepseekGenerator._sampling_device_history(generator, compact)
+
+    assert padded.shape == (64, 2)
+    assert padded[0].tolist() == [10, 11]
+    assert padded[1].tolist() == [20, 21]
+    assert padded[32].tolist() == [30, 31]
+    assert padded[33].tolist() == [40, 41]
+    assert torch.all(padded[2:32] == -1)
+    assert torch.all(padded[34:] == -1)
+
+
+def test_deepseek_prefill_sampling_state_uses_nonidentity_stable_slots():
+    generator = _fake_deepseek_generator(batch_size_per_row=16, sampling_dp=2)
+    sampling_params = SamplingParams(
+        temperature=[0.6, 0.8],
+        top_k=[16, 32],
+        top_p=[0.9, 0.95],
+        seed=[111, 222],
+    )
+    stable_slots = [17, 0]
+    prompt_tokens = torch.tensor([[10, 11], [20, -1]])
+
+    stable_params = DeepseekGenerator._sampling_params_for_user_slots(
+        generator,
+        sampling_params,
+        stable_slots,
+    )
+    stable_history = DeepseekGenerator._sampling_history_for_user_slots(
+        generator,
+        prompt_tokens,
+        stable_slots,
+    )
+    DeepseekGenerator._apply_sampling_state(
+        generator,
+        stable_params,
+        generator.batch_size,
+        generator.batch_size_per_row,
+        reload_sampling_params=True,
+        reset_sampling_state=True,
+        user_slots=stable_slots,
+        prompt_tokens=stable_history,
+    )
+
+    [(seeds, active_slots)] = generator.sampling_generator.seed_manager.reset_calls
+    assert active_slots == [33, 0]
+    assert seeds[33] == 111
+    assert seeds[0] == 222
+    [(_, commands)] = generator.sampling_generator.decode_state_calls
+    assert commands["prompt_tokens"][33].tolist() == [10, 11]
+    assert commands["prompt_tokens"][0].tolist() == [20, -1]
+
+
+def test_deepseek_prompt_history_excludes_padding_tokens():
+    tokens = torch.tensor([[10, 11, 99, 99], [20, 21, 22, 99]])
+    lengths = torch.tensor([2, 3])
+
+    history = DeepseekGenerator._prompt_history(tokens, lengths)
+
+    assert history.tolist() == [[10, 11, -1, -1], [20, 21, 22, -1]]
+
+
+def test_deepseek_sampling_reset_uses_vllm_penalty_histories():
+    batch_size = 32
+    generator = _fake_deepseek_generator(batch_size_per_row=16, sampling_dp=2)
+    sampling_params = SamplingParams(
+        temperature=[0.6] * batch_size,
+        top_k=[32] * batch_size,
+        top_p=[0.95] * batch_size,
+        presence_penalty=[0.5] * batch_size,
+        seed=[1234] * batch_size,
+    )
+    prompt_tokens = torch.arange(batch_size * 2).reshape(batch_size, 2)
+    output_tokens = torch.arange(batch_size).reshape(batch_size, 1)
+
+    DeepseekGenerator._apply_sampling_state(
+        generator,
+        sampling_params,
+        batch_size,
+        generator.batch_size_per_row,
+        reload_sampling_params=True,
+        reset_sampling_state=True,
+        prompt_tokens=prompt_tokens,
+        output_tokens=output_tokens,
+    )
+
+    [(_, commands)] = generator.sampling_generator.decode_state_calls
+    assert commands["prompt_tokens"][[0, 1, 32, 33]].tolist() == prompt_tokens[[0, 1, 16, 17]].tolist()
+    assert commands["output_tokens"][[0, 1, 32, 33]].tolist() == output_tokens[[0, 1, 16, 17]].tolist()
+
+
+def test_deepseek_sampling_params_can_reload_without_state_reset():
+    batch_size = 32
+    generator = _fake_deepseek_generator(batch_size_per_row=16, sampling_dp=2)
+    sampling_params = SamplingParams(
+        temperature=[0.7] * batch_size,
+        top_k=[16] * batch_size,
+        top_p=[0.9] * batch_size,
+        seed=[1234] * batch_size,
+    )
+
+    DeepseekGenerator._apply_sampling_state(
+        generator,
+        sampling_params,
+        batch_size,
+        generator.batch_size_per_row,
+        reload_sampling_params=True,
+        reset_sampling_state=False,
+        user_slots=[0, 16],
+    )
+
+    [(_, commands)] = generator.sampling_generator.decode_state_calls
+    assert commands["reload_sampling_params"] is True
+    assert commands["reset_sampling_state"] is False
+    assert generator.sampling_generator.seed_manager.reset_calls == []
+    [(_, user_ids)] = generator.sampling_generator.seed_manager.conditional_reset_calls
+    assert user_ids == [0, 32]
+
+
+def test_deepseek_sampling_update_obeys_explicit_commands_without_value_comparison():
     sampling_params = SamplingParams(temperature=0.6, top_k=32, top_p=0.95, seed=None)
-    reset_calls = []
+    update_calls = []
     generator = SimpleNamespace(
         batch_size=1,
         batch_size_per_row=1,
@@ -184,10 +382,9 @@ def test_deepseek_force_reset_rebuilds_unchanged_sampling_state():
         sampling_generator=object(),
         _to_local_sampling_params=lambda params: params,
         _normalize_sampling_params_for_batch=lambda params, batch_size: params,
-        _are_sampling_params_same=lambda new, previous: True,
         _get_sampling_value=lambda value, index: value[index] if isinstance(value, list) else value,
-        _reset_sampling_state=lambda params, batch_size, batch_size_per_row: reset_calls.append(
-            (params, batch_size, batch_size_per_row)
+        _apply_sampling_state=lambda params, batch_size, batch_size_per_row, **commands: update_calls.append(
+            (params, batch_size, batch_size_per_row, commands)
         ),
     )
 
@@ -195,10 +392,83 @@ def test_deepseek_force_reset_rebuilds_unchanged_sampling_state():
         generator,
         sampling_params,
         sample_on_device=True,
-        force_reset=True,
+        reload_sampling_params=False,
+        reset_sampling_state=True,
     )
 
-    assert reset_calls == [(sampling_params, 1, 1)]
+    assert update_calls == [
+        (
+            sampling_params,
+            1,
+            1,
+            {
+                "reload_sampling_params": False,
+                "reset_sampling_state": True,
+                "user_slots": None,
+                "positions": None,
+                "prompt_tokens": None,
+                "output_tokens": None,
+            },
+        )
+    ]
+
+
+def test_deepseek_slot_remap_maps_users_to_row_padded_seed_slots():
+    generator = _fake_deepseek_generator(batch_size_per_row=2, sampling_dp=2)
+
+    remap = DeepseekGenerator._sampling_device_slot_remap(generator, [3, 1, 2, 3])
+
+    assert len(remap) == 64
+    assert remap[0] == 33
+    assert remap[1] == 1
+    assert remap[32] == 32
+    assert remap[33] == 33
+    assert remap[2:32] == list(range(2, 32))
+
+
+def test_deepseek_slot_remap_moves_seeded_state_across_padded_rows():
+    generator = _fake_deepseek_generator(batch_size_per_row=2, sampling_dp=2)
+    manager = SeedManager.__new__(SeedManager)
+    manager.max_batch_size = 64
+    manager.seeds = [None] * 64
+    manager.seed_counters = [0] * 64
+    manager.rngs = [random.Random(i) for i in range(64)]
+    manager._seed_active = True
+    manager.seeds[33] = 1234
+    manager.seed_counters[33] = 17
+    old_rng_state = manager.rngs[33].getstate()
+    generator.sampling_generator.seed_manager = manager
+
+    DeepseekGenerator._apply_sampling_slot_remap(generator, [3, 1, 2, 3])
+
+    assert manager.seeds[0] == 1234
+    assert manager.seed_counters[0] == 17
+    assert manager.rngs[0].getstate() == old_rng_state
+    assert manager.seeds[33] is None
+    assert manager.seed_counters[33] == 0
+
+
+def test_deepseek_sampling_applies_remap_before_update_and_advance():
+    events = []
+    sampling_params = SamplingParams(temperature=0.6, top_k=32, top_p=0.95, seed=1234)
+    generator = SimpleNamespace(
+        _apply_sampling_slot_remap=lambda remap: events.append(("remap", remap)),
+        _validate_and_initialize_sampling=lambda *args, **kwargs: events.append(("update", kwargs)),
+        _sample_tokens_device=lambda *args, **kwargs: events.append(("advance", kwargs)) or "tokens",
+    )
+
+    result = DeepseekGenerator.sample_decode_on_device(
+        generator,
+        "logits",
+        sampling_params=sampling_params,
+        slot_remap=[1, 1],
+        user_slots=[0],
+        reload_sampling_params=True,
+        reset_sampling_state=True,
+    )
+
+    assert result == "tokens"
+    assert [event[0] for event in events] == ["remap", "update", "advance"]
 
 
 @torch.no_grad()

--- a/models/demos/deepseek_v3/tests/test_sampling.py
+++ b/models/demos/deepseek_v3/tests/test_sampling.py
@@ -157,6 +157,50 @@ def test_deepseek_sampling_seed_reset_uses_row_padded_device_slots():
     assert seeds[104:] == [None] * 24
 
 
+def test_deepseek_unseeded_sampling_reset_initializes_all_device_slots():
+    batch_size = 16
+    generator = _fake_deepseek_generator(batch_size_per_row=8, sampling_dp=2)
+    sampling_params = SamplingParams(
+        temperature=[0.6] * batch_size,
+        top_k=[32] * batch_size,
+        top_p=[0.95] * batch_size,
+        seed=None,
+    )
+
+    DeepseekGenerator._reset_sampling_state(generator, sampling_params, batch_size, generator.batch_size_per_row)
+
+    [(seeds, user_ids)] = generator.sampling_generator.seed_manager.reset_calls
+    assert seeds == [None] * 64
+    assert user_ids == list(range(64))
+
+
+def test_deepseek_force_reset_rebuilds_unchanged_sampling_state():
+    sampling_params = SamplingParams(temperature=0.6, top_k=32, top_p=0.95, seed=None)
+    reset_calls = []
+    generator = SimpleNamespace(
+        batch_size=1,
+        batch_size_per_row=1,
+        sampling_params=sampling_params,
+        sampling_generator=object(),
+        _to_local_sampling_params=lambda params: params,
+        _normalize_sampling_params_for_batch=lambda params, batch_size: params,
+        _are_sampling_params_same=lambda new, previous: True,
+        _get_sampling_value=lambda value, index: value[index] if isinstance(value, list) else value,
+        _reset_sampling_state=lambda params, batch_size, batch_size_per_row: reset_calls.append(
+            (params, batch_size, batch_size_per_row)
+        ),
+    )
+
+    DeepseekGenerator._validate_and_initialize_sampling(
+        generator,
+        sampling_params,
+        sample_on_device=True,
+        force_reset=True,
+    )
+
+    assert reset_calls == [(sampling_params, 1, 1)]
+
+
 @torch.no_grad()
 @pytest.mark.parametrize(
     "sampling_params",

--- a/models/demos/deepseek_v3/tests/test_sampling.py
+++ b/models/demos/deepseek_v3/tests/test_sampling.py
@@ -498,7 +498,7 @@ def test_deepseek_host_sampling_applies_dormant_remap_after_success(monkeypatch)
     assert events == ["decode", ("remap", [0])]
 
 
-def test_deepseek_host_sampling_does_not_consume_remap_on_failure(monkeypatch):
+def test_deepseek_host_sampling_does_not_consume_remap_on_failure(monkeypatch, expect_error):
     events = []
     generator = DeepseekV3ForCausalLM.__new__(DeepseekV3ForCausalLM)
     generator.model_run_config_decode = object()
@@ -509,7 +509,7 @@ def test_deepseek_host_sampling_does_not_consume_remap_on_failure(monkeypatch):
         lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("decode")),
     )
 
-    with pytest.raises(RuntimeError, match="decode"):
+    with expect_error(RuntimeError, "decode"):
         generator.decode_forward(
             tokens=torch.zeros((1, 1), dtype=torch.int64),
             start_pos=torch.zeros((1,), dtype=torch.int64),

--- a/models/demos/deepseek_v3/tests/test_sampling.py
+++ b/models/demos/deepseek_v3/tests/test_sampling.py
@@ -12,6 +12,7 @@ import torch
 import ttnn
 from models.common.sampling import SamplingGenerator, SamplingParams, SeedManager, format_sampling_params
 from models.demos.deepseek_v3.tt.generator import DeepseekGenerator
+from models.demos.deepseek_v3.tt.generator_vllm import DeepseekV3ForCausalLM
 from models.demos.deepseek_v3.utils.config_helpers import USERS_PER_ROW, get_fabric_config, make_deepseek_sampling_args
 
 
@@ -469,6 +470,58 @@ def test_deepseek_sampling_applies_remap_before_update_and_advance():
 
     assert result == "tokens"
     assert [event[0] for event in events] == ["remap", "update", "advance"]
+
+
+def test_deepseek_host_sampling_applies_dormant_remap_after_success(monkeypatch):
+    events = []
+    generator = DeepseekV3ForCausalLM.__new__(DeepseekV3ForCausalLM)
+    generator.model_run_config_decode = object()
+    generator._apply_sampling_slot_remap = lambda remap: events.append(("remap", remap))
+    monkeypatch.setattr(
+        DeepseekGenerator,
+        "decode_forward",
+        lambda *args, **kwargs: events.append("decode") or torch.zeros((1, 1, 1, 8)),
+    )
+
+    output = generator.decode_forward(
+        tokens=torch.zeros((1, 1), dtype=torch.int64),
+        start_pos=torch.zeros((1,), dtype=torch.int64),
+        read_from_device=False,
+        slot_remap=[0],
+        reload_inputs=True,
+        reload_page_table=False,
+        reload_sampling_params=False,
+        reset_sampling_state=False,
+    )
+
+    assert output.shape == (1, 1, 8)
+    assert events == ["decode", ("remap", [0])]
+
+
+def test_deepseek_host_sampling_does_not_consume_remap_on_failure(monkeypatch):
+    events = []
+    generator = DeepseekV3ForCausalLM.__new__(DeepseekV3ForCausalLM)
+    generator.model_run_config_decode = object()
+    generator._apply_sampling_slot_remap = lambda remap: events.append(("remap", remap))
+    monkeypatch.setattr(
+        DeepseekGenerator,
+        "decode_forward",
+        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("decode")),
+    )
+
+    with pytest.raises(RuntimeError, match="decode"):
+        generator.decode_forward(
+            tokens=torch.zeros((1, 1), dtype=torch.int64),
+            start_pos=torch.zeros((1,), dtype=torch.int64),
+            read_from_device=False,
+            slot_remap=[0],
+            reload_inputs=True,
+            reload_page_table=False,
+            reload_sampling_params=False,
+            reset_sampling_state=False,
+        )
+
+    assert events == []
 
 
 @torch.no_grad()

--- a/models/demos/deepseek_v3/tests/test_sampling.py
+++ b/models/demos/deepseek_v3/tests/test_sampling.py
@@ -122,7 +122,7 @@ def _fake_deepseek_generator(*, batch_size_per_row=8, sampling_dp=2):
         _apply_sampling_slot_remap = DeepseekGenerator._apply_sampling_slot_remap
         _sampling_device_seed_slots = DeepseekGenerator._sampling_device_seed_slots
         _to_local_sampling_params = DeepseekGenerator._to_local_sampling_params
-        _normalize_sampling_params_for_batch = DeepseekGenerator._normalize_sampling_params_for_batch
+        _normalize_sampling_params_for_batch = staticmethod(DeepseekGenerator._normalize_sampling_params_for_batch)
 
         def __init__(self):
             self.batch_size_per_row = batch_size_per_row

--- a/models/demos/deepseek_v3/tt/generator.py
+++ b/models/demos/deepseek_v3/tt/generator.py
@@ -453,6 +453,7 @@ class DeepseekGenerator(ModelCapabilitiesMixin, WarmupForwardMixin):
         sample_on_device: bool,
         enable_trace: bool = False,
         enable_mtp: bool = False,
+        force_reset: bool = False,
     ) -> None:
         if enable_mtp and sample_on_device:
             raise SystemExit("MTP with sampling on device is not supported. Disable MTP or sample on host.")
@@ -483,8 +484,9 @@ class DeepseekGenerator(ModelCapabilitiesMixin, WarmupForwardMixin):
                 )
 
             if hasattr(self, "sampling_generator") and self.sampling_generator is not None:
-                # sampling generator exists; reset if params are different
-                if not params_same:
+                # vLLM can require a state reset even when the values are
+                # unchanged, for example on first decode after a layout change.
+                if force_reset or not params_same:
                     self._reset_sampling_state(normalized_sampling_params, self.batch_size, self.batch_size_per_row)
             else:
                 # create new sampling generator
@@ -955,9 +957,12 @@ class DeepseekGenerator(ModelCapabilitiesMixin, WarmupForwardMixin):
         # the chunks raw here, and only format a copy to preserve seed padding.
         seed_params = format_sampling_params(sampling_params, max_batch_size=batch_size)
         seed = getattr(seed_params, "seed", None)
-        if seed is not None:
-            seed_slots = self._sampling_device_seed_slots(seed, batch_size)
-            self.sampling_generator.seed_manager.reset_seed(seed_slots, list(range(len(seed_slots))))
+        if seed is None:
+            seed = [None] * batch_size
+        seed_slots = self._sampling_device_seed_slots(seed, batch_size)
+        # This must be unconditional: when both requested and cached seeds are
+        # None, a conditional reset would skip the fresh device-seed upload.
+        self.sampling_generator.seed_manager.reset_seed(seed_slots, list(range(len(seed_slots))))
         self.sampling_generator.apply_decode_state(
             sampling_param_chunks,
             reset_batch=True,
@@ -1083,10 +1088,11 @@ class DeepseekGenerator(ModelCapabilitiesMixin, WarmupForwardMixin):
 
         Contract differences vs the tt_transformers base (deferred reconciliation):
         - Deepseek applies sampling *state* (params/seeds, lazy generator
-          creation) in :meth:`_validate_and_initialize_sampling`, gated on
-          param change — not unconditionally per step. Passing ``sampling_params``
-          here refreshes that state (idempotent when unchanged); the vLLM bridge
-          already initialises it before the forward, so it passes ``None``.
+          creation) in :meth:`_validate_and_initialize_sampling`. The vLLM
+          bridge passes ``force_reset=True`` when its explicit state-reset
+          command is set, including when parameter values are unchanged, then
+          passes ``None`` here because it already applied the state before the
+          forward.
         - ``prompt_tokens`` / ``output_tokens`` / ``slot_remap`` are not yet
           threaded into deepseek's penalty/seed state (see
           :meth:`_reset_sampling_state` TODO); accepted for signature

--- a/models/demos/deepseek_v3/tt/generator.py
+++ b/models/demos/deepseek_v3/tt/generator.py
@@ -15,6 +15,7 @@ from transformers import AutoConfig
 import ttnn
 from models.common.model_capabilities import ModelCapabilitiesMixin
 from models.common.sampling.generator import (
+    SAMPLING_PARAM_FIELDS,
     SamplingGenerator,
     SamplingParams,
     chunk_sampling_params,
@@ -271,7 +272,14 @@ class DeepseekGenerator(ModelCapabilitiesMixin, WarmupForwardMixin):
         self.batch_size = self.batch_size_per_row * self.mesh_device.shape[0]
 
         # Configure sampling
-        self._validate_and_initialize_sampling(sampling_params, sample_on_device, enable_trace, enable_mtp)
+        self._validate_and_initialize_sampling(
+            sampling_params,
+            sample_on_device,
+            enable_trace,
+            enable_mtp,
+            reload_sampling_params=sample_on_device,
+            reset_sampling_state=sample_on_device,
+        )
 
         # Weight cache to avoid loading weights multiple times
         self._weight_ttnn_cache: dict[str, ttnn.Tensor] = {}
@@ -453,13 +461,20 @@ class DeepseekGenerator(ModelCapabilitiesMixin, WarmupForwardMixin):
         sample_on_device: bool,
         enable_trace: bool = False,
         enable_mtp: bool = False,
-        force_reset: bool = False,
+        *,
+        reload_sampling_params: bool,
+        reset_sampling_state: bool,
+        user_slots: list[int] | None = None,
+        positions: torch.Tensor | list[int] | None = None,
+        prompt_tokens: torch.Tensor | None = None,
+        output_tokens: torch.Tensor | None = None,
     ) -> None:
         if enable_mtp and sample_on_device:
             raise SystemExit("MTP with sampling on device is not supported. Disable MTP or sample on host.")
+        if not sample_on_device and (reload_sampling_params or reset_sampling_state):
+            raise ValueError("DeepSeek sampling update commands require device sampling")
 
         self.sample_on_device = sample_on_device
-        previous_sampling_params = getattr(self, "sampling_params", None)
 
         # sampling params of all users are assumed to be the same default values if not provided.
         local_sampling_params = (
@@ -474,21 +489,17 @@ class DeepseekGenerator(ModelCapabilitiesMixin, WarmupForwardMixin):
         normalized_sampling_params = self._normalize_sampling_params_for_batch(local_sampling_params, self.batch_size)
 
         if self.sample_on_device:
-            params_same = previous_sampling_params is not None and self._are_sampling_params_same(
-                normalized_sampling_params, previous_sampling_params
-            )
-
             if self._get_sampling_value(normalized_sampling_params.top_k, 0) == 0:
                 raise SystemExit(
                     "top-k=0 is not supported when sampling on device. Sampling on host instead. See https://github.com/tenstorrent/tt-metal/issues/40236"
                 )
 
-            if hasattr(self, "sampling_generator") and self.sampling_generator is not None:
-                # vLLM can require a state reset even when the values are
-                # unchanged, for example on first decode after a layout change.
-                if force_reset or not params_same:
-                    self._reset_sampling_state(normalized_sampling_params, self.batch_size, self.batch_size_per_row)
-            else:
+            if not hasattr(self, "sampling_generator") or self.sampling_generator is None:
+                if not reload_sampling_params or not reset_sampling_state:
+                    raise ValueError(
+                        "Initializing DeepSeek device sampling requires both "
+                        "reload_sampling_params and reset_sampling_state"
+                    )
                 # create new sampling generator
                 self.sampling_args = make_deepseek_sampling_args(
                     self.mesh_device,
@@ -501,9 +512,26 @@ class DeepseekGenerator(ModelCapabilitiesMixin, WarmupForwardMixin):
                     mesh_device=self.mesh_device,
                     tt_ccl=self.ccl,
                 )
-                self._reset_sampling_state(normalized_sampling_params, self.batch_size, self.batch_size_per_row)
+            if reload_sampling_params or reset_sampling_state:
+                state_params = (
+                    normalized_sampling_params if reload_sampling_params else getattr(self, "sampling_params", None)
+                )
+                if state_params is None:
+                    raise ValueError("Cannot reset DeepSeek sampling state before sampling parameters are initialized")
+                self._apply_sampling_state(
+                    state_params,
+                    self.batch_size,
+                    self.batch_size_per_row,
+                    reload_sampling_params=reload_sampling_params,
+                    reset_sampling_state=reset_sampling_state,
+                    user_slots=user_slots,
+                    positions=positions,
+                    prompt_tokens=prompt_tokens,
+                    output_tokens=output_tokens,
+                )
 
-        self.sampling_params = normalized_sampling_params
+        if reload_sampling_params or not sample_on_device:
+            self.sampling_params = normalized_sampling_params
 
     def _to_local_sampling_params(self, params_obj) -> SamplingParams:
         """Project duck-typed sampling params to local SamplingParams fields."""
@@ -566,21 +594,6 @@ class DeepseekGenerator(ModelCapabilitiesMixin, WarmupForwardMixin):
             enable_log_probs=_normalize_field(sampling_params.enable_log_probs, fallback_if_none=False),
             num_logprobs=_normalize_field(sampling_params.num_logprobs, fallback_if_none=0),
         )
-
-    def _are_sampling_params_same(self, new_sampling_params, current_sampling_params) -> bool:
-        """Return True when both sampling params are equivalent after formatting.
-
-        Inputs may be local ``SamplingParams`` or vLLM duck-typed sampling params.
-        We first project each object to the local ``SamplingParams`` fields and then
-        normalize with ``format_sampling_params`` for an apples-to-apples comparison.
-        """
-        normalized_new = format_sampling_params(
-            self._to_local_sampling_params(new_sampling_params), max_batch_size=self.batch_size
-        )
-        normalized_current = format_sampling_params(
-            self._to_local_sampling_params(current_sampling_params), max_batch_size=self.batch_size
-        )
-        return normalized_new == normalized_current
 
     @staticmethod
     def _shape_or_type(value):
@@ -949,8 +962,19 @@ class DeepseekGenerator(ModelCapabilitiesMixin, WarmupForwardMixin):
             layout=ttnn.ROW_MAJOR_LAYOUT,
         )
 
-    def _reset_sampling_state(self, sampling_params: SamplingParams, batch_size: int, batch_size_per_row: int) -> None:
-        # TODO(vllm): Thread prompt/output token state into sampling resets for penalty correctness.
+    def _apply_sampling_state(
+        self,
+        sampling_params: SamplingParams,
+        batch_size: int,
+        batch_size_per_row: int,
+        *,
+        reload_sampling_params: bool,
+        reset_sampling_state: bool,
+        user_slots: list[int] | None = None,
+        positions: torch.Tensor | list[int] | None = None,
+        prompt_tokens: torch.Tensor | None = None,
+        output_tokens: torch.Tensor | None = None,
+    ) -> None:
         sampling_dp = self.sampling_generator.tt_sampling._sampling_dp
         sampling_param_chunks = chunk_sampling_params(sampling_params, sampling_dp)
         # apply_decode_state() formats user-facing params for TT sampling. Keep
@@ -960,15 +984,39 @@ class DeepseekGenerator(ModelCapabilitiesMixin, WarmupForwardMixin):
         if seed is None:
             seed = [None] * batch_size
         seed_slots = self._sampling_device_seed_slots(seed, batch_size)
-        # This must be unconditional: when both requested and cached seeds are
-        # None, a conditional reset would skip the fresh device-seed upload.
-        self.sampling_generator.seed_manager.reset_seed(seed_slots, list(range(len(seed_slots))))
+        prompt_tokens_device = (
+            self._sampling_device_history(prompt_tokens)
+            if prompt_tokens is not None
+            else torch.full(
+                (self.sampling_generator.seed_manager.max_batch_size, 1),
+                -1,
+                dtype=torch.int64,
+            )
+        )
+        output_tokens_device = self._sampling_device_history(output_tokens) if output_tokens is not None else None
         self.sampling_generator.apply_decode_state(
             sampling_param_chunks,
-            reset_batch=True,
-            prompt_tokens=torch.zeros((batch_size_per_row, 1), dtype=torch.int64),
-            output_tokens=torch.zeros((batch_size_per_row, 1), dtype=torch.int64),
+            reload_sampling_params=reload_sampling_params,
+            reset_sampling_state=reset_sampling_state,
+            prompt_tokens=prompt_tokens_device,
+            output_tokens=output_tokens_device,
         )
+        seed_manager = self.sampling_generator.seed_manager
+        active_seed_slots = self._sampling_device_slots(user_slots)
+        if active_seed_slots is None:
+            active_seed_slots = list(range(seed_manager.max_batch_size))
+        if reset_sampling_state:
+            # This must be unconditional: when both requested and cached seeds
+            # are None, a conditional reset would skip the fresh device upload.
+            seed_manager.reset_seed_from_slots(seed_slots, active_seed_slots)
+            if positions is not None:
+                seed_manager.align_seed_counters_to_positions(
+                    seed_slots,
+                    active_seed_slots,
+                    self._sampling_device_positions(positions),
+                )
+        elif reload_sampling_params:
+            seed_manager.reset_seed_from_slots_if_needed(seed_slots, active_seed_slots)
 
     def _sampling_device_slot(self, user_id: int) -> int:
         row = int(user_id) // self.batch_size_per_row
@@ -987,6 +1035,111 @@ class DeepseekGenerator(ModelCapabilitiesMixin, WarmupForwardMixin):
         if user_slots is None:
             return None
         return [self._sampling_device_slot(user_id) for user_id in user_slots]
+
+    def _sampling_device_positions(self, positions: torch.Tensor | list[int]) -> list[int]:
+        user_positions = torch.as_tensor(positions).reshape(-1).tolist()
+        device_positions = [-1] * self.sampling_generator.seed_manager.max_batch_size
+        for user_id, position in enumerate(user_positions[: self.batch_size]):
+            device_positions[self._sampling_device_slot(user_id)] = int(position)
+        return device_positions
+
+    def _sampling_params_for_user_slots(
+        self,
+        sampling_params: SamplingParams,
+        user_slots: list[int],
+    ) -> SamplingParams:
+        """Place front-packed request parameters into stable model slots."""
+        if not user_slots:
+            raise ValueError("DeepSeek sampling parameter slots cannot be empty")
+        if len(set(user_slots)) != len(user_slots) or any(slot < 0 or slot >= self.batch_size for slot in user_slots):
+            raise ValueError(f"DeepSeek sampling parameter slots must be unique values in [0, {self.batch_size})")
+        compact = self._normalize_sampling_params_for_batch(
+            self._to_local_sampling_params(sampling_params),
+            len(user_slots),
+        )
+        stable_fields = {}
+        for field_name in SAMPLING_PARAM_FIELDS:
+            compact_values = list(getattr(compact, field_name))
+            stable_values = [compact_values[-1]] * self.batch_size
+            for request_index, stable_slot in enumerate(user_slots):
+                stable_values[stable_slot] = compact_values[request_index]
+            stable_fields[field_name] = stable_values
+        return SamplingParams(**stable_fields)
+
+    def _sampling_history_for_user_slots(
+        self,
+        tokens: torch.Tensor,
+        user_slots: list[int],
+    ) -> torch.Tensor:
+        """Place front-packed request history into stable model slots."""
+        compact_tokens = torch.as_tensor(tokens)
+        if compact_tokens.ndim == 1:
+            compact_tokens = compact_tokens.unsqueeze(1)
+        else:
+            compact_tokens = compact_tokens.reshape(compact_tokens.shape[0], -1)
+        if compact_tokens.shape[0] != len(user_slots):
+            raise ValueError(
+                f"DeepSeek sampling history has {compact_tokens.shape[0]} rows " f"but {len(user_slots)} stable slots"
+            )
+        stable_tokens = torch.full(
+            (self.batch_size, compact_tokens.shape[1]),
+            -1,
+            dtype=compact_tokens.dtype,
+            device=compact_tokens.device,
+        )
+        for request_index, stable_slot in enumerate(user_slots):
+            stable_tokens[stable_slot] = compact_tokens[request_index]
+        return stable_tokens
+
+    def _sampling_device_history(self, tokens: torch.Tensor) -> torch.Tensor:
+        compact_tokens = torch.as_tensor(tokens)
+        if compact_tokens.ndim == 1:
+            compact_tokens = compact_tokens.unsqueeze(1)
+        else:
+            compact_tokens = compact_tokens.reshape(compact_tokens.shape[0], -1)
+        if compact_tokens.shape[0] > self.batch_size:
+            raise ValueError(
+                f"DeepSeek sampling history has {compact_tokens.shape[0]} rows, " f"but batch size is {self.batch_size}"
+            )
+        device_tokens = torch.full(
+            (self.sampling_generator.seed_manager.max_batch_size, compact_tokens.shape[1]),
+            -1,
+            dtype=compact_tokens.dtype,
+            device=compact_tokens.device,
+        )
+        for user_id in range(compact_tokens.shape[0]):
+            device_tokens[self._sampling_device_slot(user_id)] = compact_tokens[user_id]
+        return device_tokens
+
+    @staticmethod
+    def _prompt_history(tokens: torch.Tensor, lengths: torch.Tensor | list[int]) -> torch.Tensor:
+        prompt_tokens = torch.as_tensor(tokens).clone()
+        if prompt_tokens.ndim != 2:
+            raise ValueError(f"DeepSeek prompt history expects [B, S], got {tuple(prompt_tokens.shape)}")
+        prompt_lengths = torch.as_tensor(lengths, device=prompt_tokens.device).reshape(-1)
+        if prompt_lengths.numel() != prompt_tokens.shape[0]:
+            raise ValueError(
+                f"DeepSeek prompt history has {prompt_tokens.shape[0]} rows " f"but {prompt_lengths.numel()} lengths"
+            )
+        positions = torch.arange(prompt_tokens.shape[1], device=prompt_tokens.device).unsqueeze(0)
+        return prompt_tokens.masked_fill(positions >= prompt_lengths.unsqueeze(1), -1)
+
+    def _sampling_device_slot_remap(self, slot_remap: torch.Tensor | list[int]) -> list[int]:
+        user_remap = torch.as_tensor(slot_remap).reshape(-1).tolist()
+        if len(user_remap) != self.batch_size:
+            raise ValueError(f"DeepSeek slot_remap must have {self.batch_size} entries, got {len(user_remap)}")
+        device_remap = list(range(self.sampling_generator.seed_manager.max_batch_size))
+        for new_user, old_user_value in enumerate(user_remap):
+            old_user = int(old_user_value)
+            if old_user < 0 or old_user >= self.batch_size:
+                raise ValueError(f"DeepSeek slot_remap[{new_user}]={old_user} is outside [0, {self.batch_size})")
+            device_remap[self._sampling_device_slot(new_user)] = self._sampling_device_slot(old_user)
+        return device_remap
+
+    def _apply_sampling_slot_remap(self, slot_remap: torch.Tensor | list[int] | None) -> None:
+        if slot_remap is None:
+            return
+        self.sampling_generator.seed_manager.apply_slot_remap(self._sampling_device_slot_remap(slot_remap))
 
     def _sampling_device_seed_slots(self, seeds: list[int | None], batch_size: int) -> list[int | None]:
         seed_slot_count = self.sampling_generator.seed_manager.max_batch_size
@@ -1071,12 +1224,14 @@ class DeepseekGenerator(ModelCapabilitiesMixin, WarmupForwardMixin):
         self,
         tt_logits,
         sampling_params=None,
-        reset_batch=False,
         prompt_tokens=None,
         output_tokens=None,
         slot_remap=None,
         enable_trace=False,
         user_slots=None,
+        *,
+        reload_sampling_params: bool,
+        reset_sampling_state: bool,
     ):
         """Public on-device decode-sampling entry point.
 
@@ -1086,20 +1241,23 @@ class DeepseekGenerator(ModelCapabilitiesMixin, WarmupForwardMixin):
         returned by ``decode_forward(sample_on_device=True)``, return sampled
         token ids on device.
 
-        Contract differences vs the tt_transformers base (deferred reconciliation):
-        - Deepseek applies sampling *state* (params/seeds, lazy generator
-          creation) in :meth:`_validate_and_initialize_sampling`. The vLLM
-          bridge passes ``force_reset=True`` when its explicit state-reset
-          command is set, including when parameter values are unchanged, then
-          passes ``None`` here because it already applied the state before the
-          forward.
-        - ``prompt_tokens`` / ``output_tokens`` / ``slot_remap`` are not yet
-          threaded into deepseek's penalty/seed state (see
-          :meth:`_reset_sampling_state` TODO); accepted for signature
-          compatibility and currently ignored.
+        Sampling update commands are mandatory. Slot remaps are applied before
+        parameter/state updates and seed advancement.
         """
+        self._apply_sampling_slot_remap(slot_remap)
         if sampling_params is not None:
-            self._validate_and_initialize_sampling(sampling_params, sample_on_device=True, enable_trace=enable_trace)
+            self._validate_and_initialize_sampling(
+                sampling_params,
+                sample_on_device=True,
+                enable_trace=enable_trace,
+                reload_sampling_params=reload_sampling_params,
+                reset_sampling_state=reset_sampling_state,
+                user_slots=user_slots,
+                prompt_tokens=prompt_tokens,
+                output_tokens=output_tokens,
+            )
+        elif reload_sampling_params or reset_sampling_state:
+            raise ValueError("DeepSeek sampling updates require sampling_params")
         return self._sample_tokens_device(
             tt_logits, enable_trace=enable_trace, user_slots=user_slots, skip_precompile=True
         )
@@ -2133,10 +2291,13 @@ class DeepseekGenerator(ModelCapabilitiesMixin, WarmupForwardMixin):
             if self.sample_on_device:
                 # reset sampling state for each repeat batch, o/p tokens will be different for each repeat batch
                 assert self.sampling_params is not None, "sampling_params must be set when sampling on device"
-                self._reset_sampling_state(
+                self._apply_sampling_state(
                     self.sampling_params,
                     self.batch_size,
                     self.batch_size_per_row,
+                    reload_sampling_params=True,
+                    reset_sampling_state=True,
+                    prompt_tokens=self._prompt_history(tokens_batched, lengths),
                 )
             # Reset teacher-forcing state per batch.
             if teacher_forcing is not None:
@@ -3277,6 +3438,8 @@ class DeepseekGenerator(ModelCapabilitiesMixin, WarmupForwardMixin):
                         original_sampling_params,
                         sample_on_device,
                         enable_trace=enable_trace,
+                        reload_sampling_params=True,
+                        reset_sampling_state=True,
                     )
 
                     # Warmup precompile happens at this flow; skip sampling-module precompile.
@@ -3300,6 +3463,8 @@ class DeepseekGenerator(ModelCapabilitiesMixin, WarmupForwardMixin):
                 original_sampling_params,
                 original_sample_on_device,
                 enable_trace=enable_trace,
+                reload_sampling_params=original_sample_on_device,
+                reset_sampling_state=original_sample_on_device,
             )
         # Warmup creates temporary page tables; clean them up to free memory.
         try:

--- a/models/demos/deepseek_v3/tt/generator.py
+++ b/models/demos/deepseek_v3/tt/generator.py
@@ -15,6 +15,7 @@ from transformers import AutoConfig
 import ttnn
 from models.common.model_capabilities import ModelCapabilitiesMixin
 from models.common.sampling.generator import (
+    SAMPLING_PARAM_FIELDS,
     SamplingGenerator,
     SamplingParams,
     chunk_sampling_params,
@@ -271,7 +272,14 @@ class DeepseekGenerator(ModelCapabilitiesMixin, WarmupForwardMixin):
         self.batch_size = self.batch_size_per_row * self.mesh_device.shape[0]
 
         # Configure sampling
-        self._validate_and_initialize_sampling(sampling_params, sample_on_device, enable_trace, enable_mtp)
+        self._validate_and_initialize_sampling(
+            sampling_params,
+            sample_on_device,
+            enable_trace,
+            enable_mtp,
+            reload_sampling_params=sample_on_device,
+            reset_sampling_state=sample_on_device,
+        )
 
         # Weight cache to avoid loading weights multiple times
         self._weight_ttnn_cache: dict[str, ttnn.Tensor] = {}
@@ -453,12 +461,21 @@ class DeepseekGenerator(ModelCapabilitiesMixin, WarmupForwardMixin):
         sample_on_device: bool,
         enable_trace: bool = False,
         enable_mtp: bool = False,
+        *,
+        reload_sampling_params: bool,
+        reset_sampling_state: bool,
+        user_slots: list[int] | None = None,
+        positions: torch.Tensor | list[int] | None = None,
+        prompt_tokens: torch.Tensor | None = None,
+        output_tokens: torch.Tensor | None = None,
+        preserve_unlisted_slots: bool = False,
     ) -> None:
         if enable_mtp and sample_on_device:
             raise SystemExit("MTP with sampling on device is not supported. Disable MTP or sample on host.")
+        if not sample_on_device and (reload_sampling_params or reset_sampling_state):
+            raise ValueError("DeepSeek sampling update commands require device sampling")
 
         self.sample_on_device = sample_on_device
-        previous_sampling_params = getattr(self, "sampling_params", None)
 
         # sampling params of all users are assumed to be the same default values if not provided.
         local_sampling_params = (
@@ -473,20 +490,17 @@ class DeepseekGenerator(ModelCapabilitiesMixin, WarmupForwardMixin):
         normalized_sampling_params = self._normalize_sampling_params_for_batch(local_sampling_params, self.batch_size)
 
         if self.sample_on_device:
-            params_same = previous_sampling_params is not None and self._are_sampling_params_same(
-                normalized_sampling_params, previous_sampling_params
-            )
-
             if self._get_sampling_value(normalized_sampling_params.top_k, 0) == 0:
                 raise SystemExit(
                     "top-k=0 is not supported when sampling on device. Sampling on host instead. See https://github.com/tenstorrent/tt-metal/issues/40236"
                 )
 
-            if hasattr(self, "sampling_generator") and self.sampling_generator is not None:
-                # sampling generator exists; reset if params are different
-                if not params_same:
-                    self._reset_sampling_state(normalized_sampling_params, self.batch_size, self.batch_size_per_row)
-            else:
+            if not hasattr(self, "sampling_generator") or self.sampling_generator is None:
+                if not reload_sampling_params or not reset_sampling_state:
+                    raise ValueError(
+                        "Initializing DeepSeek device sampling requires both "
+                        "reload_sampling_params and reset_sampling_state"
+                    )
                 # create new sampling generator
                 self.sampling_args = make_deepseek_sampling_args(
                     self.mesh_device,
@@ -499,9 +513,27 @@ class DeepseekGenerator(ModelCapabilitiesMixin, WarmupForwardMixin):
                     mesh_device=self.mesh_device,
                     tt_ccl=self.ccl,
                 )
-                self._reset_sampling_state(normalized_sampling_params, self.batch_size, self.batch_size_per_row)
+            if reload_sampling_params or reset_sampling_state:
+                state_params = (
+                    normalized_sampling_params if reload_sampling_params else getattr(self, "sampling_params", None)
+                )
+                if state_params is None:
+                    raise ValueError("Cannot reset DeepSeek sampling state before sampling parameters are initialized")
+                self._apply_sampling_state(
+                    state_params,
+                    self.batch_size,
+                    self.batch_size_per_row,
+                    reload_sampling_params=reload_sampling_params,
+                    reset_sampling_state=reset_sampling_state,
+                    user_slots=user_slots,
+                    positions=positions,
+                    prompt_tokens=prompt_tokens,
+                    output_tokens=output_tokens,
+                    preserve_unlisted_slots=preserve_unlisted_slots,
+                )
 
-        self.sampling_params = normalized_sampling_params
+        if reload_sampling_params or not sample_on_device:
+            self.sampling_params = normalized_sampling_params
 
     def _to_local_sampling_params(self, params_obj) -> SamplingParams:
         """Project duck-typed sampling params to local SamplingParams fields."""
@@ -564,21 +596,6 @@ class DeepseekGenerator(ModelCapabilitiesMixin, WarmupForwardMixin):
             enable_log_probs=_normalize_field(sampling_params.enable_log_probs, fallback_if_none=False),
             num_logprobs=_normalize_field(sampling_params.num_logprobs, fallback_if_none=0),
         )
-
-    def _are_sampling_params_same(self, new_sampling_params, current_sampling_params) -> bool:
-        """Return True when both sampling params are equivalent after formatting.
-
-        Inputs may be local ``SamplingParams`` or vLLM duck-typed sampling params.
-        We first project each object to the local ``SamplingParams`` fields and then
-        normalize with ``format_sampling_params`` for an apples-to-apples comparison.
-        """
-        normalized_new = format_sampling_params(
-            self._to_local_sampling_params(new_sampling_params), max_batch_size=self.batch_size
-        )
-        normalized_current = format_sampling_params(
-            self._to_local_sampling_params(current_sampling_params), max_batch_size=self.batch_size
-        )
-        return normalized_new == normalized_current
 
     @staticmethod
     def _shape_or_type(value):
@@ -947,23 +964,72 @@ class DeepseekGenerator(ModelCapabilitiesMixin, WarmupForwardMixin):
             layout=ttnn.ROW_MAJOR_LAYOUT,
         )
 
-    def _reset_sampling_state(self, sampling_params: SamplingParams, batch_size: int, batch_size_per_row: int) -> None:
-        # TODO(vllm): Thread prompt/output token state into sampling resets for penalty correctness.
+    def _apply_sampling_state(
+        self,
+        sampling_params: SamplingParams,
+        batch_size: int,
+        batch_size_per_row: int,
+        *,
+        reload_sampling_params: bool,
+        reset_sampling_state: bool,
+        user_slots: list[int] | None = None,
+        positions: torch.Tensor | list[int] | None = None,
+        prompt_tokens: torch.Tensor | None = None,
+        output_tokens: torch.Tensor | None = None,
+        preserve_unlisted_slots: bool = False,
+    ) -> None:
         sampling_dp = self.sampling_generator.tt_sampling._sampling_dp
         sampling_param_chunks = chunk_sampling_params(sampling_params, sampling_dp)
         # apply_decode_state() formats user-facing params for TT sampling. Keep
         # the chunks raw here, and only format a copy to preserve seed padding.
         seed_params = format_sampling_params(sampling_params, max_batch_size=batch_size)
         seed = getattr(seed_params, "seed", None)
-        if seed is not None:
-            seed_slots = self._sampling_device_seed_slots(seed, batch_size)
-            self.sampling_generator.seed_manager.reset_seed(seed_slots, list(range(len(seed_slots))))
+        if seed is None:
+            seed = [None] * batch_size
+        seed_slots = self._sampling_device_seed_slots(seed, batch_size)
+        prompt_tokens_device = (
+            self._sampling_device_history(prompt_tokens)
+            if prompt_tokens is not None
+            else torch.full(
+                (self.sampling_generator.seed_manager.max_batch_size, 1),
+                -1,
+                dtype=torch.int64,
+            )
+        )
+        output_tokens_device = self._sampling_device_history(output_tokens) if output_tokens is not None else None
+        seed_manager = self.sampling_generator.seed_manager
+        active_seed_slots = self._sampling_device_slots(user_slots)
+        if active_seed_slots is None:
+            if preserve_unlisted_slots:
+                raise ValueError("Partial DeepSeek sampling updates require explicit user_slots")
+            active_seed_slots = list(range(seed_manager.max_batch_size))
         self.sampling_generator.apply_decode_state(
             sampling_param_chunks,
-            reset_batch=True,
-            prompt_tokens=torch.zeros((batch_size_per_row, 1), dtype=torch.int64),
-            output_tokens=torch.zeros((batch_size_per_row, 1), dtype=torch.int64),
+            reload_sampling_params=reload_sampling_params,
+            reset_sampling_state=reset_sampling_state,
+            prompt_tokens=prompt_tokens_device,
+            output_tokens=output_tokens_device,
+            sampling_state_slots=active_seed_slots if preserve_unlisted_slots else None,
         )
+        # A request finishing at the batch tail produces no non-identity
+        # remap, so retire seed/salt state that no longer belongs to a live
+        # row before assigning salts to newly admitted requests. A prefill
+        # only lists new requests, not the full live set, so it must not retire
+        # any unlisted slots.
+        if not preserve_unlisted_slots:
+            seed_manager.deactivate_slots_except(active_seed_slots)
+        if reset_sampling_state:
+            # This must be unconditional: when both requested and cached seeds
+            # are None, a conditional reset would skip the fresh device upload.
+            seed_manager.reset_seed_from_slots(seed_slots, active_seed_slots)
+            if positions is not None:
+                seed_manager.align_seed_counters_to_positions(
+                    seed_slots,
+                    active_seed_slots,
+                    self._sampling_device_positions(positions),
+                )
+        elif reload_sampling_params:
+            seed_manager.reset_seed_from_slots_if_needed(seed_slots, active_seed_slots)
 
     def _sampling_device_slot(self, user_id: int) -> int:
         row = int(user_id) // self.batch_size_per_row
@@ -982,6 +1048,128 @@ class DeepseekGenerator(ModelCapabilitiesMixin, WarmupForwardMixin):
         if user_slots is None:
             return None
         return [self._sampling_device_slot(user_id) for user_id in user_slots]
+
+    def _sampling_device_positions(self, positions: torch.Tensor | list[int]) -> list[int]:
+        user_positions = torch.as_tensor(positions).reshape(-1).tolist()
+        device_positions = [-1] * self.sampling_generator.seed_manager.max_batch_size
+        for user_id, position in enumerate(user_positions[: self.batch_size]):
+            device_positions[self._sampling_device_slot(user_id)] = int(position)
+        return device_positions
+
+    def _sampling_params_for_user_slots(
+        self,
+        sampling_params: SamplingParams,
+        user_slots: list[int],
+    ) -> SamplingParams:
+        """Place front-packed request parameters into stable model slots."""
+        if not user_slots:
+            raise ValueError("DeepSeek sampling parameter slots cannot be empty")
+        if len(set(user_slots)) != len(user_slots) or any(slot < 0 or slot >= self.batch_size for slot in user_slots):
+            raise ValueError(f"DeepSeek sampling parameter slots must be unique values in [0, {self.batch_size})")
+        compact = self._normalize_sampling_params_for_batch(
+            self._to_local_sampling_params(sampling_params),
+            len(user_slots),
+        )
+        cached = getattr(self, "sampling_params", None)
+        if cached is None:
+            if len(user_slots) != self.batch_size:
+                raise ValueError(
+                    "DeepSeek cannot update a subset of stable sampling slots "
+                    "before full-batch sampling parameters are initialized"
+                )
+            cached = self._normalize_sampling_params_for_batch(
+                self._to_local_sampling_params(sampling_params),
+                self.batch_size,
+            )
+        else:
+            cached = self._normalize_sampling_params_for_batch(
+                self._to_local_sampling_params(cached),
+                self.batch_size,
+            )
+        stable_fields = {}
+        for field_name in SAMPLING_PARAM_FIELDS:
+            compact_values = list(getattr(compact, field_name))
+            stable_values = list(getattr(cached, field_name))
+            for request_index, stable_slot in enumerate(user_slots):
+                stable_values[stable_slot] = compact_values[request_index]
+            stable_fields[field_name] = stable_values
+        return SamplingParams(**stable_fields)
+
+    def _sampling_history_for_user_slots(
+        self,
+        tokens: torch.Tensor,
+        user_slots: list[int],
+    ) -> torch.Tensor:
+        """Place front-packed request history into stable model slots."""
+        compact_tokens = torch.as_tensor(tokens)
+        if compact_tokens.ndim == 1:
+            compact_tokens = compact_tokens.unsqueeze(1)
+        else:
+            compact_tokens = compact_tokens.reshape(compact_tokens.shape[0], -1)
+        if compact_tokens.shape[0] != len(user_slots):
+            raise ValueError(
+                f"DeepSeek sampling history has {compact_tokens.shape[0]} rows " f"but {len(user_slots)} stable slots"
+            )
+        stable_tokens = torch.full(
+            (self.batch_size, compact_tokens.shape[1]),
+            -1,
+            dtype=compact_tokens.dtype,
+            device=compact_tokens.device,
+        )
+        for request_index, stable_slot in enumerate(user_slots):
+            stable_tokens[stable_slot] = compact_tokens[request_index]
+        return stable_tokens
+
+    def _sampling_device_history(self, tokens: torch.Tensor) -> torch.Tensor:
+        compact_tokens = torch.as_tensor(tokens)
+        if compact_tokens.ndim == 1:
+            compact_tokens = compact_tokens.unsqueeze(1)
+        else:
+            compact_tokens = compact_tokens.reshape(compact_tokens.shape[0], -1)
+        if compact_tokens.shape[0] > self.batch_size:
+            raise ValueError(
+                f"DeepSeek sampling history has {compact_tokens.shape[0]} rows, " f"but batch size is {self.batch_size}"
+            )
+        device_tokens = torch.full(
+            (self.sampling_generator.seed_manager.max_batch_size, compact_tokens.shape[1]),
+            -1,
+            dtype=compact_tokens.dtype,
+            device=compact_tokens.device,
+        )
+        for user_id in range(compact_tokens.shape[0]):
+            device_tokens[self._sampling_device_slot(user_id)] = compact_tokens[user_id]
+        return device_tokens
+
+    @staticmethod
+    def _prompt_history(tokens: torch.Tensor, lengths: torch.Tensor | list[int]) -> torch.Tensor:
+        prompt_tokens = torch.as_tensor(tokens).clone()
+        if prompt_tokens.ndim != 2:
+            raise ValueError(f"DeepSeek prompt history expects [B, S], got {tuple(prompt_tokens.shape)}")
+        prompt_lengths = torch.as_tensor(lengths, device=prompt_tokens.device).reshape(-1)
+        if prompt_lengths.numel() != prompt_tokens.shape[0]:
+            raise ValueError(
+                f"DeepSeek prompt history has {prompt_tokens.shape[0]} rows " f"but {prompt_lengths.numel()} lengths"
+            )
+        positions = torch.arange(prompt_tokens.shape[1], device=prompt_tokens.device).unsqueeze(0)
+        return prompt_tokens.masked_fill(positions >= prompt_lengths.unsqueeze(1), -1)
+
+    def _sampling_device_slot_remap(self, slot_remap: torch.Tensor | list[int]) -> list[int]:
+        user_remap = torch.as_tensor(slot_remap).reshape(-1).tolist()
+        if len(user_remap) != self.batch_size:
+            raise ValueError(f"DeepSeek slot_remap must have {self.batch_size} entries, got {len(user_remap)}")
+        device_remap = list(range(self.sampling_generator.seed_manager.max_batch_size))
+        for new_user, old_user_value in enumerate(user_remap):
+            old_user = int(old_user_value)
+            if old_user < 0 or old_user >= self.batch_size:
+                raise ValueError(f"DeepSeek slot_remap[{new_user}]={old_user} is outside [0, {self.batch_size})")
+            device_remap[self._sampling_device_slot(new_user)] = self._sampling_device_slot(old_user)
+        return device_remap
+
+    def _apply_sampling_slot_remap(self, slot_remap: torch.Tensor | list[int] | None) -> None:
+        sampling_generator = getattr(self, "sampling_generator", None)
+        if slot_remap is None or sampling_generator is None:
+            return
+        sampling_generator.apply_slot_remap(self._sampling_device_slot_remap(slot_remap))
 
     def _sampling_device_seed_slots(self, seeds: list[int | None], batch_size: int) -> list[int | None]:
         seed_slot_count = self.sampling_generator.seed_manager.max_batch_size
@@ -1066,12 +1254,14 @@ class DeepseekGenerator(ModelCapabilitiesMixin, WarmupForwardMixin):
         self,
         tt_logits,
         sampling_params=None,
-        reset_batch=False,
         prompt_tokens=None,
         output_tokens=None,
         slot_remap=None,
         enable_trace=False,
         user_slots=None,
+        *,
+        reload_sampling_params: bool,
+        reset_sampling_state: bool,
     ):
         """Public on-device decode-sampling entry point.
 
@@ -1081,19 +1271,28 @@ class DeepseekGenerator(ModelCapabilitiesMixin, WarmupForwardMixin):
         returned by ``decode_forward(sample_on_device=True)``, return sampled
         token ids on device.
 
-        Contract differences vs the tt_transformers base (deferred reconciliation):
-        - Deepseek applies sampling *state* (params/seeds, lazy generator
-          creation) in :meth:`_validate_and_initialize_sampling`, gated on
-          param change — not unconditionally per step. Passing ``sampling_params``
-          here refreshes that state (idempotent when unchanged); the vLLM bridge
-          already initialises it before the forward, so it passes ``None``.
-        - ``prompt_tokens`` / ``output_tokens`` / ``slot_remap`` are not yet
-          threaded into deepseek's penalty/seed state (see
-          :meth:`_reset_sampling_state` TODO); accepted for signature
-          compatibility and currently ignored.
+        Sampling update commands are mandatory. Slot remaps are applied before
+        parameter/state updates and seed advancement.
         """
+        self._apply_sampling_slot_remap(slot_remap)
         if sampling_params is not None:
-            self._validate_and_initialize_sampling(sampling_params, sample_on_device=True, enable_trace=enable_trace)
+            self._validate_and_initialize_sampling(
+                sampling_params,
+                sample_on_device=True,
+                enable_trace=enable_trace,
+                reload_sampling_params=reload_sampling_params,
+                reset_sampling_state=reset_sampling_state,
+                user_slots=user_slots,
+                prompt_tokens=prompt_tokens,
+                output_tokens=output_tokens,
+            )
+        elif reload_sampling_params or reset_sampling_state:
+            raise ValueError("DeepSeek sampling updates require sampling_params")
+        if self.sampling_generator is not None:
+            self.sampling_generator.validate_decode_state_commands(
+                reload_sampling_params=reload_sampling_params,
+                reset_sampling_state=reset_sampling_state,
+            )
         return self._sample_tokens_device(
             tt_logits, enable_trace=enable_trace, user_slots=user_slots, skip_precompile=True
         )
@@ -2127,10 +2326,13 @@ class DeepseekGenerator(ModelCapabilitiesMixin, WarmupForwardMixin):
             if self.sample_on_device:
                 # reset sampling state for each repeat batch, o/p tokens will be different for each repeat batch
                 assert self.sampling_params is not None, "sampling_params must be set when sampling on device"
-                self._reset_sampling_state(
+                self._apply_sampling_state(
                     self.sampling_params,
                     self.batch_size,
                     self.batch_size_per_row,
+                    reload_sampling_params=True,
+                    reset_sampling_state=True,
+                    prompt_tokens=self._prompt_history(tokens_batched, lengths),
                 )
             # Reset teacher-forcing state per batch.
             if teacher_forcing is not None:
@@ -3271,6 +3473,8 @@ class DeepseekGenerator(ModelCapabilitiesMixin, WarmupForwardMixin):
                         original_sampling_params,
                         sample_on_device,
                         enable_trace=enable_trace,
+                        reload_sampling_params=True,
+                        reset_sampling_state=True,
                     )
 
                     # Warmup precompile happens at this flow; skip sampling-module precompile.
@@ -3294,6 +3498,8 @@ class DeepseekGenerator(ModelCapabilitiesMixin, WarmupForwardMixin):
                 original_sampling_params,
                 original_sample_on_device,
                 enable_trace=enable_trace,
+                reload_sampling_params=original_sample_on_device,
+                reset_sampling_state=original_sample_on_device,
             )
         # Warmup creates temporary page tables; clean them up to free memory.
         try:

--- a/models/demos/deepseek_v3/tt/generator_vllm.py
+++ b/models/demos/deepseek_v3/tt/generator_vllm.py
@@ -39,6 +39,8 @@ def _pad_tokens(tokens: torch.Tensor, pad_value: int = 0, block_size: int = USER
 
 
 class DeepseekV3ForCausalLM(DeepseekGenerator):
+    decode_input_update_contract = 1
+
     # Class-level capabilities
     model_capabilities = {
         "supports_prefix_caching": False,
@@ -154,10 +156,27 @@ class DeepseekV3ForCausalLM(DeepseekGenerator):
         )
         num_of_users = tokens.shape[0]
         if sample_on_device:
+            sampling_user_slots = list(empty_slots) if empty_slots is not None else list(range(num_of_users))
+            if len(sampling_user_slots) != num_of_users:
+                raise ValueError(
+                    f"DeepSeek prefill has {num_of_users} requests but " f"{len(sampling_user_slots)} stable slots"
+                )
+            prompt_history = self._sampling_history_for_user_slots(
+                self._prompt_history(tokens, lengths),
+                sampling_user_slots,
+            )
             self._validate_and_initialize_sampling(
-                sampling_params,
+                self._sampling_params_for_user_slots(
+                    sampling_params,
+                    sampling_user_slots,
+                ),
                 sample_on_device,
                 enable_trace=False,
+                reload_sampling_params=True,
+                reset_sampling_state=True,
+                user_slots=sampling_user_slots,
+                prompt_tokens=prompt_history,
+                preserve_unlisted_slots=True,
             )
 
         user_outputs = []
@@ -220,7 +239,16 @@ class DeepseekV3ForCausalLM(DeepseekGenerator):
 
         return prefill_output
 
-    def decode_forward(self, *args, **kwargs):
+    def decode_forward(
+        self,
+        *args,
+        reload_inputs: bool,
+        reload_page_table: bool,
+        reload_sampling_params: bool,
+        reset_sampling_state: bool,
+        slot_remap=None,
+        **kwargs,
+    ):
         assert self.model_run_config_decode is not None, "Model run config decode is not initialized"
 
         page_tables = kwargs.get("page_table", None)
@@ -229,26 +257,38 @@ class DeepseekV3ForCausalLM(DeepseekGenerator):
         read_from_device = kwargs.get("read_from_device", True)
         sampling_params = kwargs.get("sampling_params", None)
         sample_on_device = bool(sampling_params is not None)
-        reset_batch = kwargs.get("reset_batch", False)
-        # NOTE: vLLM also passes `slot_remap` (the seed-slot reindex map from batch
-        # condense) in kwargs, but deepseek does not consume it — so per-request
-        # seeded determinism is not preserved across condense. Tracked by
-        # https://github.com/tenstorrent/tt-metal/issues/46350.
+        prompt_tokens = kwargs.get("prompt_tokens")
+        output_tokens = kwargs.get("output_tokens")
+        if not reload_inputs or reload_page_table:
+            raise ValueError("DeepSeek vLLM decode requires a full host-input reload")
+        if not sample_on_device and (reload_sampling_params or reset_sampling_state):
+            raise ValueError("DeepSeek sampling update commands require device sampling")
 
         # Set kv_cache if provided and all entries are valid
         if kv_cache is not None and not any(entry is None for entry in kv_cache):
             self.set_kv_cache(kv_cache)
 
         tokens_step = kwargs["tokens"].squeeze(1)
-        if sample_on_device and reset_batch:
+        start_pos = kwargs["start_pos"]
+        active_user_slots = [
+            idx for idx, position in enumerate(torch.as_tensor(start_pos).reshape(-1).tolist()) if int(position) >= 0
+        ]
+        if sample_on_device:
+            self._apply_sampling_slot_remap(slot_remap)
             self._validate_and_initialize_sampling(
                 sampling_params,
                 sample_on_device,
                 enable_trace=enable_trace,
+                reload_sampling_params=reload_sampling_params,
+                reset_sampling_state=reset_sampling_state,
+                user_slots=active_user_slots,
+                positions=start_pos,
+                prompt_tokens=prompt_tokens,
+                output_tokens=output_tokens,
             )
         decode_step_output = super().decode_forward(
             tokens=tokens_step,
-            start_pos=kwargs["start_pos"],
+            start_pos=start_pos,
             enable_trace=enable_trace,
             page_table=page_tables,
             sample_on_device=sample_on_device,
@@ -258,6 +298,9 @@ class DeepseekV3ForCausalLM(DeepseekGenerator):
             decode_output = self.sample_decode_on_device(
                 decode_step_output,
                 enable_trace=enable_trace,
+                user_slots=active_user_slots,
+                reload_sampling_params=False,
+                reset_sampling_state=False,
             )
             if read_from_device:
                 decode_output = self._tokens_from_device(
@@ -277,6 +320,11 @@ class DeepseekV3ForCausalLM(DeepseekGenerator):
                     f"Unexpected decode logits rank for host sampling: {tuple(decode_step_output.shape)}"
                 )
             decode_output = decode_step_output.unsqueeze(1)
+            # Host sampling bypasses the device sampler, but its dormant
+            # per-slot state must still follow the layout. Apply after the
+            # decode/output path succeeds so retries cannot consume the same
+            # non-idempotent remap twice.
+            self._apply_sampling_slot_remap(slot_remap)
 
         # decode_output semantics:
         # - sample_on_device=True  -> sampled token ids

--- a/models/demos/deepseek_v3/tt/generator_vllm.py
+++ b/models/demos/deepseek_v3/tt/generator_vllm.py
@@ -154,10 +154,26 @@ class DeepseekV3ForCausalLM(DeepseekGenerator):
         )
         num_of_users = tokens.shape[0]
         if sample_on_device:
+            sampling_user_slots = list(empty_slots) if empty_slots is not None else list(range(num_of_users))
+            if len(sampling_user_slots) != num_of_users:
+                raise ValueError(
+                    f"DeepSeek prefill has {num_of_users} requests but " f"{len(sampling_user_slots)} stable slots"
+                )
+            prompt_history = self._sampling_history_for_user_slots(
+                self._prompt_history(tokens, lengths),
+                sampling_user_slots,
+            )
             self._validate_and_initialize_sampling(
-                sampling_params,
+                self._sampling_params_for_user_slots(
+                    sampling_params,
+                    sampling_user_slots,
+                ),
                 sample_on_device,
                 enable_trace=False,
+                reload_sampling_params=True,
+                reset_sampling_state=True,
+                user_slots=sampling_user_slots,
+                prompt_tokens=prompt_history,
             )
 
         user_outputs = []
@@ -220,7 +236,16 @@ class DeepseekV3ForCausalLM(DeepseekGenerator):
 
         return prefill_output
 
-    def decode_forward(self, *args, **kwargs):
+    def decode_forward(
+        self,
+        *args,
+        reload_inputs: bool,
+        reload_page_table: bool,
+        reload_sampling_params: bool,
+        reset_sampling_state: bool,
+        slot_remap=None,
+        **kwargs,
+    ):
         assert self.model_run_config_decode is not None, "Model run config decode is not initialized"
 
         page_tables = kwargs.get("page_table", None)
@@ -229,38 +254,38 @@ class DeepseekV3ForCausalLM(DeepseekGenerator):
         read_from_device = kwargs.get("read_from_device", True)
         sampling_params = kwargs.get("sampling_params", None)
         sample_on_device = bool(sampling_params is not None)
-        reload_inputs = kwargs.pop("reload_inputs")
-        reload_page_table = kwargs.pop("reload_page_table")
-        reload_sampling_params = kwargs.pop("reload_sampling_params")
-        reset_sampling_state = kwargs.pop("reset_sampling_state")
+        prompt_tokens = kwargs.get("prompt_tokens")
+        output_tokens = kwargs.get("output_tokens")
         if not reload_inputs or reload_page_table:
-            raise ValueError(
-                "DeepSeek vLLM decode requires a full host-input reload"
-            )
-        if reload_sampling_params != reset_sampling_state:
-            raise ValueError(
-                "DeepSeek sampling parameters and state must reload together"
-            )
-        # NOTE: vLLM also passes `slot_remap` (the seed-slot reindex map from batch
-        # condense) in kwargs, but deepseek does not consume it — so per-request
-        # seeded determinism is not preserved across condense. Tracked by
-        # https://github.com/tenstorrent/tt-metal/issues/46350.
+            raise ValueError("DeepSeek vLLM decode requires a full host-input reload")
+        if not sample_on_device and (reload_sampling_params or reset_sampling_state):
+            raise ValueError("DeepSeek sampling update commands require device sampling")
 
         # Set kv_cache if provided and all entries are valid
         if kv_cache is not None and not any(entry is None for entry in kv_cache):
             self.set_kv_cache(kv_cache)
 
         tokens_step = kwargs["tokens"].squeeze(1)
-        if sample_on_device and reload_sampling_params:
+        start_pos = kwargs["start_pos"]
+        active_user_slots = [
+            idx for idx, position in enumerate(torch.as_tensor(start_pos).reshape(-1).tolist()) if int(position) >= 0
+        ]
+        if sample_on_device:
+            self._apply_sampling_slot_remap(slot_remap)
             self._validate_and_initialize_sampling(
                 sampling_params,
                 sample_on_device,
                 enable_trace=enable_trace,
-                force_reset=reset_sampling_state,
+                reload_sampling_params=reload_sampling_params,
+                reset_sampling_state=reset_sampling_state,
+                user_slots=active_user_slots,
+                positions=start_pos,
+                prompt_tokens=prompt_tokens,
+                output_tokens=output_tokens,
             )
         decode_step_output = super().decode_forward(
             tokens=tokens_step,
-            start_pos=kwargs["start_pos"],
+            start_pos=start_pos,
             enable_trace=enable_trace,
             page_table=page_tables,
             sample_on_device=sample_on_device,
@@ -270,6 +295,9 @@ class DeepseekV3ForCausalLM(DeepseekGenerator):
             decode_output = self.sample_decode_on_device(
                 decode_step_output,
                 enable_trace=enable_trace,
+                user_slots=active_user_slots,
+                reload_sampling_params=False,
+                reset_sampling_state=False,
             )
             if read_from_device:
                 decode_output = self._tokens_from_device(

--- a/models/demos/deepseek_v3/tt/generator_vllm.py
+++ b/models/demos/deepseek_v3/tt/generator_vllm.py
@@ -39,6 +39,8 @@ def _pad_tokens(tokens: torch.Tensor, pad_value: int = 0, block_size: int = USER
 
 
 class DeepseekV3ForCausalLM(DeepseekGenerator):
+    decode_input_update_contract = 1
+
     # Class-level capabilities
     model_capabilities = {
         "supports_prefix_caching": False,

--- a/models/demos/deepseek_v3/tt/generator_vllm.py
+++ b/models/demos/deepseek_v3/tt/generator_vllm.py
@@ -229,7 +229,18 @@ class DeepseekV3ForCausalLM(DeepseekGenerator):
         read_from_device = kwargs.get("read_from_device", True)
         sampling_params = kwargs.get("sampling_params", None)
         sample_on_device = bool(sampling_params is not None)
-        reset_batch = kwargs.get("reset_batch", False)
+        reload_inputs = kwargs.pop("reload_inputs")
+        reload_page_table = kwargs.pop("reload_page_table")
+        reload_sampling_params = kwargs.pop("reload_sampling_params")
+        reset_sampling_state = kwargs.pop("reset_sampling_state")
+        if not reload_inputs or reload_page_table:
+            raise ValueError(
+                "DeepSeek vLLM decode requires a full host-input reload"
+            )
+        if reload_sampling_params != reset_sampling_state:
+            raise ValueError(
+                "DeepSeek sampling parameters and state must reload together"
+            )
         # NOTE: vLLM also passes `slot_remap` (the seed-slot reindex map from batch
         # condense) in kwargs, but deepseek does not consume it — so per-request
         # seeded determinism is not preserved across condense. Tracked by
@@ -240,7 +251,7 @@ class DeepseekV3ForCausalLM(DeepseekGenerator):
             self.set_kv_cache(kv_cache)
 
         tokens_step = kwargs["tokens"].squeeze(1)
-        if sample_on_device and reset_batch:
+        if sample_on_device and reload_sampling_params:
             self._validate_and_initialize_sampling(
                 sampling_params,
                 sample_on_device,

--- a/models/demos/deepseek_v3/tt/generator_vllm.py
+++ b/models/demos/deepseek_v3/tt/generator_vllm.py
@@ -256,6 +256,7 @@ class DeepseekV3ForCausalLM(DeepseekGenerator):
                 sampling_params,
                 sample_on_device,
                 enable_trace=enable_trace,
+                force_reset=reset_sampling_state,
             )
         decode_step_output = super().decode_forward(
             tokens=tokens_step,

--- a/models/demos/deepseek_v3/tt/generator_vllm.py
+++ b/models/demos/deepseek_v3/tt/generator_vllm.py
@@ -319,6 +319,11 @@ class DeepseekV3ForCausalLM(DeepseekGenerator):
                     f"Unexpected decode logits rank for host sampling: {tuple(decode_step_output.shape)}"
                 )
             decode_output = decode_step_output.unsqueeze(1)
+            # Host sampling bypasses the device sampler, but its dormant
+            # per-slot state must still follow the layout. Apply after the
+            # decode/output path succeeds so retries cannot consume the same
+            # non-idempotent remap twice.
+            self._apply_sampling_slot_remap(slot_remap)
 
         # decode_output semantics:
         # - sample_on_device=True  -> sampled token ids

--- a/models/demos/gemma4/demo/text_demo.py
+++ b/models/demos/gemma4/demo/text_demo.py
@@ -477,7 +477,10 @@ def run_batch_generation(
                 page_table=page_table,
                 kv_cache=tt_kv_cache,
                 enable_trace=enable_decode_trace,
-                reset_batch=(iteration == 0),
+                reload_inputs=True,
+                reload_page_table=False,
+                reload_sampling_params=False,
+                reset_sampling_state=False,
             )
             if isinstance(decode_out, tuple):
                 logits = decode_out[0]
@@ -654,6 +657,10 @@ def _run_generation_via_generator(
             page_table=page_table,
             kv_cache=tt_kv_cache,
             sampling_params=None,
+            reload_inputs=True,
+            reload_page_table=False,
+            reload_sampling_params=False,
+            reset_sampling_state=False,
         )
         out_tok = _host_sample_greedy(logits)
         profiler.end(f"inference_decode_time_{iteration}")

--- a/models/demos/gemma4/demo/text_demo.py
+++ b/models/demos/gemma4/demo/text_demo.py
@@ -526,7 +526,10 @@ def run_batch_generation(
                 page_table=page_table,
                 kv_cache=tt_kv_cache,
                 enable_trace=enable_decode_trace,
-                reset_batch=(iteration == 0),
+                reload_inputs=True,
+                reload_page_table=False,
+                reload_sampling_params=False,
+                reset_sampling_state=False,
             )
             if isinstance(decode_out, tuple):
                 logits = decode_out[0]
@@ -722,6 +725,10 @@ def _run_generation_via_generator(
             page_table=page_table,
             kv_cache=tt_kv_cache,
             sampling_params=device_sampling_params,
+            reload_inputs=True,
+            reload_page_table=False,
+            reload_sampling_params=False,
+            reset_sampling_state=False,
         )
         if device_sampling_params is not None:
             out_tok = decode_out.long().view(batch_size, 1)

--- a/models/demos/gemma4/demo/text_demo_v2.py
+++ b/models/demos/gemma4/demo/text_demo_v2.py
@@ -540,6 +540,10 @@ def test_demo_text(
             page_table=page_table,
             kv_cache=tt_kv_cache,
             sampling_params=None,  # host sampling
+            reload_inputs=True,
+            reload_page_table=False,
+            reload_sampling_params=False,
+            reset_sampling_state=False,
         )
         out_tok = _host_sample(logits, temperature, top_p)
         profiler.end(f"inference_decode_time_{iteration}")

--- a/models/demos/gemma4/demo/text_demo_v2.py
+++ b/models/demos/gemma4/demo/text_demo_v2.py
@@ -686,6 +686,10 @@ def test_demo_text(
             page_table=page_table,
             kv_cache=tt_kv_cache,
             sampling_params=device_sampling_params,
+            reload_inputs=True,
+            reload_page_table=False,
+            reload_sampling_params=False,
+            reset_sampling_state=False,
         )
         if device_sampling_params is not None:
             out_tok = decode_out.long().view(batch_size, 1)

--- a/models/demos/gemma4/tests/unit/test_vllm_parity.py
+++ b/models/demos/gemma4/tests/unit/test_vllm_parity.py
@@ -1700,7 +1700,10 @@ def test_full_model_parity_decode_trace(layer_set, decode_steps, pli, mesh_devic
             enable_trace=True,
             read_from_device=False,
             sampling_params=None,
-            reset_batch=(step == 0),
+            reload_inputs=True,
+            reload_page_table=False,
+            reload_sampling_params=False,
+            reset_sampling_state=False,
         )
 
         # vLLM path: refresh persistent per-layer page tables + stash
@@ -1720,7 +1723,10 @@ def test_full_model_parity_decode_trace(layer_set, decode_steps, pli, mesh_devic
                 enable_trace=True,
                 read_from_device=False,
                 sampling_params=None,
-                reset_batch=(step == 0),
+                reload_inputs=True,
+                reload_page_table=False,
+                reload_sampling_params=False,
+                reset_sampling_state=False,
             )
         finally:
             # Bridge would do this via context manager — mirror that.
@@ -1988,7 +1994,10 @@ def test_full_model_parity_warmup_then_inference(layer_set, decode_steps, pli, m
             enable_trace=True,
             read_from_device=False,
             sampling_params=None,
-            reset_batch=(step == 0),
+            reload_inputs=True,
+            reload_page_table=False,
+            reload_sampling_params=False,
+            reset_sampling_state=False,
         )
 
         pool.reserve_decode_token(req)
@@ -2004,7 +2013,10 @@ def test_full_model_parity_warmup_then_inference(layer_set, decode_steps, pli, m
                 enable_trace=True,
                 read_from_device=False,
                 sampling_params=None,
-                reset_batch=(step == 0),
+                reload_inputs=True,
+                reload_page_table=False,
+                reload_sampling_params=False,
+                reset_sampling_state=False,
             )
         finally:
             if hasattr(tt_model_vllm, "_active_page_tables_per_layer"):

--- a/models/demos/gemma4/tests/unit/test_vllm_parity.py
+++ b/models/demos/gemma4/tests/unit/test_vllm_parity.py
@@ -1700,7 +1700,10 @@ def test_full_model_parity_decode_trace(layer_set, decode_steps, pli, mesh_devic
             enable_trace=True,
             read_from_device=False,
             sampling_params=None,
-            reset_batch=(step == 0),
+            reload_inputs=True,
+            reload_page_table=False,
+            reload_sampling_params=False,
+            reset_sampling_state=False,
         )
 
         # vLLM path: refresh persistent per-layer page tables + stash
@@ -1720,7 +1723,10 @@ def test_full_model_parity_decode_trace(layer_set, decode_steps, pli, mesh_devic
                 enable_trace=True,
                 read_from_device=False,
                 sampling_params=None,
-                reset_batch=(step == 0),
+                reload_inputs=True,
+                reload_page_table=False,
+                reload_sampling_params=False,
+                reset_sampling_state=False,
             )
         finally:
             # Bridge would do this via context manager — mirror that.
@@ -1984,7 +1990,10 @@ def test_full_model_parity_warmup_then_inference(layer_set, decode_steps, pli, m
             enable_trace=True,
             read_from_device=False,
             sampling_params=None,
-            reset_batch=(step == 0),
+            reload_inputs=True,
+            reload_page_table=False,
+            reload_sampling_params=False,
+            reset_sampling_state=False,
         )
 
         pool.reserve_decode_token(req)
@@ -2000,7 +2009,10 @@ def test_full_model_parity_warmup_then_inference(layer_set, decode_steps, pli, m
                 enable_trace=True,
                 read_from_device=False,
                 sampling_params=None,
-                reset_batch=(step == 0),
+                reload_inputs=True,
+                reload_page_table=False,
+                reload_sampling_params=False,
+                reset_sampling_state=False,
             )
         finally:
             if hasattr(tt_model_vllm, "_active_page_tables_per_layer"):

--- a/models/demos/gemma4/tt/generator.py
+++ b/models/demos/gemma4/tt/generator.py
@@ -11,7 +11,6 @@ from transformers import AutoTokenizer
 
 import ttnn
 from models.common.sampling import SamplingParams, slice_sampling_params
-from models.demos.gemma4.tt.async_decode import merge_async_ahead_decode_tokens
 from models.demos.gemma4.tt.common import create_tt_model
 from models.demos.gemma4.tt.generator_trace import (
     apply_gemma4_prefill_trace_policy,
@@ -1225,11 +1224,15 @@ class ChunkedPrefillPageTableGuardMixin:
         tt_logits,
         sampling_params,
         start_pos=None,
-        reset_batch=False,
         prompt_tokens=None,
         output_tokens=None,
         slot_remap=None,
         enable_trace=False,
+        *,
+        reload_sampling_params: bool,
+        reset_sampling_state: bool,
+        reload_inputs: bool | None = None,
+        skip_precompile: bool = False,
     ):
         """Eager ``tt_out_tok`` inject for padded decode feedback (#51186).
 
@@ -1284,11 +1287,14 @@ class ChunkedPrefillPageTableGuardMixin:
                 tt_logits,
                 sampling_params,
                 start_pos=start_pos,
-                reset_batch=reset_batch,
                 prompt_tokens=prompt_tokens,
                 output_tokens=output_tokens,
                 slot_remap=slot_remap,
                 enable_trace=enable_trace,
+                reload_sampling_params=reload_sampling_params,
+                reset_sampling_state=reset_sampling_state,
+                reload_inputs=reload_inputs,
+                skip_precompile=skip_precompile,
             )
             if host_commit:
                 try:
@@ -1330,101 +1336,43 @@ class ChunkedPrefillPageTableGuardMixin:
         enable_trace=True,
         read_from_device=True,
         sampling_params: SamplingParams = None,
-        reset_batch=False,
         prompt_tokens: torch.Tensor | None = None,
         output_tokens: torch.Tensor | None = None,
         slot_remap=None,
         defer_device_sampling: bool = False,
+        *,
+        reload_inputs: bool,
+        reload_page_table: bool,
+        reload_sampling_params: bool,
+        reset_sampling_state: bool,
+        skip_trace_precompile: bool = False,
         prepare_trace: bool = False,
         **kwargs,
     ):
-        """Gemma4 decode with safe async-ahead merge (no ``tt_transformers`` edits).
-
-        Same control flow as ``Generator.decode_forward``, but merges host/device
-        tokens via :func:`merge_async_ahead_decode_tokens` so bucket changes and
-        OOB ``slot_remap`` fall back instead of ``IndexError``.
-        """
-        del kwargs  # Generator accepts extras; Gemma4 path ignores them.
-        # Sequential per-user prefill narrows the per-layer tables to one row and
-        # not every prefill entry point unwinds it; decode always needs the full
-        # batch back or paged_update_cache TT_FATALs (1 row vs B users).
+        """Gemma4 decode with batch-keyed traces and explicit reload commands."""
+        if "reset_batch" in kwargs:
+            raise TypeError("reset_batch is not supported by decode input update contract v1")
+        # Sequential prefill narrows per-layer tables to one row; decode needs
+        # the full batch even when the prefill entry point did not restore it.
         self._clear_sequential_batch_page_tables()
-        mode_switched = False
         if self.mode != Mode.DECODE:
             self.mode = Mode.DECODE
-            mode_switched = True
 
         for i in range(len(self.model)):
             self.model[i].switch_mode(Mode.DECODE)
 
         on_device_sampling = (sampling_params is not None) or defer_device_sampling
+        if not enable_trace and not reload_inputs:
+            raise ValueError("Non-traced decode rebuilds all forward inputs and requires reload_inputs=True")
+        self._decode_reload_inputs = reload_inputs
 
         tokens = torch.chunk(tokens, self.data_parallel, 0)
         start_pos = torch.chunk(start_pos, self.data_parallel, 0)
         page_table = torch.chunk(page_table, self.data_parallel, 0) if page_table is not None else None
-        # Match _decode_forward_trace_text: (sampling, per-DP chunk batch).
-        decode_trace_key = (
-            on_device_sampling,
-            int(tokens[0].shape[0]) if tokens else 1,
-        )
-
-        # Only merge device token/pos feedback when async decode is actually
-        # enabled. ``model_capabilities["supports_async_decode"]`` is the single
-        # source of truth (tt-inference-server llm.yaml -> GEMMA4_SUPPORTS_ASYNC_DECODE
-        # -> capability, resolved once in Gemma4ForCausalLM); previously this path
-        # ran regardless, so disabling async in config turned off vLLM's async
-        # scheduler while Gemma4 kept doing async-ahead device feedback. With async
-        # off the host tokens are authoritative and there is nothing to merge.
-        async_decode_enabled = bool(getattr(self, "model_capabilities", {}).get("supports_async_decode", False))
-        if (
-            async_decode_enabled
-            and on_device_sampling
-            and (reset_batch or mode_switched)
-            and enable_trace
-            and self.trace_inputs_decode[decode_trace_key]
-        ):
-            new_tokens = []
-            new_start_pos = []
-            for i, tok_chunk in enumerate(tokens):
-                trace_in = self.trace_inputs_decode[decode_trace_key][i]
-                host_pos = start_pos[i].reshape(-1).to(torch.int64)
-                host_toks = tok_chunk.reshape(-1)
-                host_b = int(host_toks.shape[0])
-                # Read the full device buffer before truncating. Nearest-bucket
-                # B changes and mesh-row sharding can make shard-0 narrower than
-                # host_b; the gemma4 helper falls back before any gather.
-                dev_toks_full = ttnn.to_torch(ttnn.get_device_tensors(trace_in[0])[0]).reshape(-1).to(tok_chunk.dtype)
-                dev_pos_full = ttnn.to_torch(ttnn.get_device_tensors(trace_in[1])[0]).reshape(-1).to(torch.int64)
-                slot_remap_local = None
-                if slot_remap is not None:
-                    remap = slot_remap[i * host_b : (i + 1) * host_b]
-                    remap_t = (remap if isinstance(remap, torch.Tensor) else torch.tensor(remap)).long()
-                    slot_remap_local = remap_t - i * host_b
-                prefilled = getattr(self, "_slots_prefilled_since_decode", None)
-                prefilled_local = None
-                if prefilled:
-                    bs = tok_chunk.shape[0]
-                    prefilled_local = {slot - i * bs for slot in prefilled if i * bs <= slot < (i + 1) * bs}
-                merged, merged_pos, src = merge_async_ahead_decode_tokens(
-                    host_toks,
-                    host_pos,
-                    dev_toks_full,
-                    dev_pos_full,
-                    slot_remap_local=slot_remap_local,
-                    prefilled_local=prefilled_local,
-                )
-                if src != "merged" or int(dev_toks_full.shape[0]) != int(host_toks.shape[0]):
-                    logger.info(
-                        "async_ahead_merge src={} host_b={} dev_len={}",
-                        src,
-                        int(host_toks.shape[0]),
-                        int(dev_toks_full.shape[0]),
-                    )
-                new_tokens.append(merged.view(tok_chunk.shape).to(tok_chunk.dtype))
-                new_start_pos.append(merged_pos.view(start_pos[i].shape).to(start_pos[i].dtype))
-            tokens = new_tokens
-            start_pos = new_start_pos
-        self._slots_prefilled_since_decode = set()
+        # Gemma4 keeps a trace for each sampling mode and decode bucket. This
+        # records the current trace key for its token-feedback buffer; it does
+        # not decide whether any input is reloaded.
+        self._prev_decode_batch = int(tokens[0].shape[0]) if tokens else 1
 
         decode_kwargs = {
             "current_pos": start_pos,
@@ -1437,7 +1385,9 @@ class ChunkedPrefillPageTableGuardMixin:
         if enable_trace:
             tt_decode_output = self._decode_forward_trace_text(
                 **decode_kwargs,
-                reset_batch=reset_batch or mode_switched,
+                reload_inputs=reload_inputs,
+                reload_page_table=reload_page_table,
+                skip_precompile=skip_trace_precompile,
             )
         elif prepare_trace:
             tt_decode_output = self._prepare_decode_trace_variant(**decode_kwargs)
@@ -1453,15 +1403,23 @@ class ChunkedPrefillPageTableGuardMixin:
                 tt_decode_output,
                 sampling_params=sampling_params,
                 start_pos=start_pos,
-                reset_batch=reset_batch,
                 prompt_tokens=prompt_tokens,
                 output_tokens=output_tokens,
                 slot_remap=slot_remap,
                 enable_trace=enable_trace,
+                reload_sampling_params=reload_sampling_params,
+                reset_sampling_state=reset_sampling_state,
+                reload_inputs=reload_inputs,
+                skip_precompile=skip_trace_precompile,
             )
         if read_from_device:
             to_host = self.read_decode_output(tt_decode_output)
-            return self.process_decode_output_host(to_host, is_tokens=(sampling_params is not None))
+            output = self.process_decode_output_host(to_host, is_tokens=(sampling_params is not None))
+            if sampling_params is None:
+                self._apply_sampling_slot_remap(slot_remap)
+            return output
+        if sampling_params is None:
+            self._apply_sampling_slot_remap(slot_remap)
         return tt_decode_output
 
     def _decode_trace_key(self, on_device_sampling, tokens):
@@ -1491,15 +1449,17 @@ class ChunkedPrefillPageTableGuardMixin:
         page_table=None,
         kv_cache=None,
         on_device_sampling=False,
-        reset_batch=False,
-        skip_precompile=False,
+        *,
+        reload_inputs: bool,
+        reload_page_table: bool,
+        skip_precompile: bool = False,
     ):
         """Gemma4 decode traces keyed by ``(on_device_sampling, batch)``.
 
         Shared ``Generator`` keys traces by sampling mode only. Gemma4 warms
         B=1 and B=max separately (vLLM nearest-bucket / P150x8), so the key
-        must include per-DP chunk batch or async-ahead keep and replay hit the
-        wrong Metal graph. Kept local to this mixin — no ``tt_transformers`` edits.
+        must include the per-DP chunk batch or replay hits the wrong Metal
+        graph. Reload decisions are supplied by the caller.
         """
         from models.tt_transformers.tt.common import copy_host_to_device
         from models.tt_transformers.tt.generator import DECODE_PAGE_TABLE_INPUT_IDX
@@ -1519,39 +1479,22 @@ class ChunkedPrefillPageTableGuardMixin:
             self.trace_inputs_decode[decode_trace_key] = device_inputs
             self.trace_output_decode[decode_trace_key] = tt_out_trace
 
-        prev_on_device_sampling = getattr(self, "_prev_on_device_sampling", None)
-        self._prev_on_device_sampling = on_device_sampling
-        prev_decode_batch = getattr(self, "_prev_decode_batch", None)
-        self._prev_decode_batch = batch
-        sampling_mode_changed = prev_on_device_sampling is not None and prev_on_device_sampling != on_device_sampling
-        batch_changed = prev_decode_batch is not None and prev_decode_batch != batch
-        reset_inputs = reset_batch or not on_device_sampling or sampling_mode_changed or batch_changed
-        page_table_changed = page_table is not None and (
-            self.prev_page_table is None
-            or any(not torch.equal(prev, curr) for prev, curr in zip(self.prev_page_table, page_table))
-        )
-
         for i in range(self.data_parallel):
-            refresh_trace_inputs = reset_inputs or getattr(
-                self.model[i], "_tt_vllm_always_refresh_decode_trace_inputs", False
-            )
             user_page_table = page_table[i] if page_table is not None else None
 
-            if refresh_trace_inputs:
+            if reload_inputs:
                 host_inputs_i = self.model[i].prepare_decode_inputs_host(tokens[i], current_pos[i], user_page_table)
                 copy_host_to_device(
                     host_tensors=host_inputs_i,
                     device_tensors=self.trace_inputs_decode[decode_trace_key][i],
                 )
-            elif page_table_changed:
+            elif reload_page_table:
                 host_inputs_i = self.model[i].prepare_decode_inputs_host(tokens[i], current_pos[i], user_page_table)
                 host_page_table = host_inputs_i[DECODE_PAGE_TABLE_INPUT_IDX]
                 device_page_table = self.trace_inputs_decode[decode_trace_key][i][DECODE_PAGE_TABLE_INPUT_IDX]
                 if host_page_table is not None:
                     ttnn.copy_host_to_device_tensor(host_page_table, device_page_table)
 
-        if page_table_changed:
-            self.prev_page_table = tuple(pt.clone() for pt in page_table)
         for i, trace_id in self.trace_ids_decode[decode_trace_key].items():
             ttnn.execute_trace(self.model_args[i].mesh_device, trace_id, cq_id=0, blocking=False)
         return self.trace_output_decode[decode_trace_key]

--- a/models/demos/gemma4/tt/generator_vllm.py
+++ b/models/demos/gemma4/tt/generator_vllm.py
@@ -113,6 +113,8 @@ class Gemma4ForCausalLM(ChunkedPrefillPageTableGuardMixin, HybridAttentionForCau
     ttnn_decode_forward}`` (mirrors the gpt-oss bridge).
     """
 
+    decode_input_update_contract = 1
+
     model_capabilities = {
         "supports_prefix_caching": False,
         "supports_async_decode": False,

--- a/models/demos/gemma4/tt/generator_vllm.py
+++ b/models/demos/gemma4/tt/generator_vllm.py
@@ -693,7 +693,7 @@ class Gemma4ForCausalLM(ChunkedPrefillPageTableGuardMixin, HybridAttentionForCau
         page_tables_per_layer = self._build_per_layer_page_tables(page_tables_per_layer, kwargs.get("page_table"))
         page_tables_per_layer = self._pad_sliding_page_tables_for_bounded(page_tables_per_layer, kwargs.get("kv_cache"))
         per_submesh = self._chunk_page_tables_per_dp(page_tables_per_layer)
-        if per_submesh is not None:
+        if per_submesh is not None and self._reload_per_layer_page_tables(kwargs):
             for m, pt_for_submesh in zip(self.model, per_submesh):
                 m.update_persistent_per_layer_page_tables(pt_for_submesh)
         with self._route_per_layer_page_tables(per_submesh):

--- a/models/demos/gemma4/tt/generator_vllm.py
+++ b/models/demos/gemma4/tt/generator_vllm.py
@@ -218,6 +218,8 @@ class Gemma4ForCausalLM(ChunkedPrefillPageTableGuardMixin, HybridAttentionForCau
     ttnn_decode_forward}`` (mirrors the gpt-oss bridge).
     """
 
+    decode_input_update_contract = 1
+
     # Async decode closes the ~15–20% metal↔server B=1 gap (#51186): with
     # ``async_scheduling`` the plugin overlaps CPU scheduling with the previous
     # device step via ``decode_forward(read_from_device=False)`` +
@@ -225,8 +227,8 @@ class Gemma4ForCausalLM(ChunkedPrefillPageTableGuardMixin, HybridAttentionForCau
     # Requires on-device token feedback + position plus_one (non-PLI only;
     # see ``Gemma4Model._tt_vllm_always_refresh_decode_trace_inputs``).
     #
-    # Default ON for non-PLI. Token-doubling under async is mitigated by
-    # ``merge_async_ahead_decode_tokens`` + vLLM preempt bookkeeping. Kill-switch:
+    # Default ON for non-PLI. The plugin drains and applies pending results
+    # before commanding a host-authoritative reload. Kill-switch:
     # ``GEMMA4_SUPPORTS_ASYNC_DECODE=0``. PLI models narrow the instance dict
     # in ``__init__``; that does not reach the platform, so PLI still needs
     # the kill-switch to disable async_scheduling.
@@ -1355,7 +1357,7 @@ class Gemma4ForCausalLM(ChunkedPrefillPageTableGuardMixin, HybridAttentionForCau
         # Do *not* pad decode page tables to max_batch — keep the plugin's
         # nearest-bucket batch so B=1 uses the B=1 decode trace / SDPA grid.
         per_submesh = self._chunk_page_tables_per_dp(page_tables_per_layer)
-        if per_submesh is not None:
+        if per_submesh is not None and self._reload_per_layer_page_tables(kwargs):
             for m, pt_for_submesh in zip(self.model, per_submesh):
                 m.update_persistent_per_layer_page_tables(pt_for_submesh)
         # If persistent page-table buffers grew after decode-trace capture,
@@ -1381,10 +1383,9 @@ class Gemma4ForCausalLM(ChunkedPrefillPageTableGuardMixin, HybridAttentionForCau
         t0 = time.perf_counter()
         with self._route_per_layer_page_tables(per_submesh):
             # Route through ``ChunkedPrefillPageTableGuardMixin.decode_forward``
-            # (Gemma4-safe async-ahead merge). Do not call
-            # ``super(HybridAttentionForCausalLM, ...)`` — that skips the mixin
-            # and hits shared ``Generator.decode_forward`` (OOB slot_remap /
-            # bucket IndexError under concurrent vLLM). Also avoid plain
+            # (Gemma4's batch-keyed trace path). Do not call
+            # ``super(HybridAttentionForCausalLM, ...)`` because that skips the
+            # mixin and loses the decode-bucket trace key. Also avoid plain
             # ``HybridAttentionForCausalLM.decode_forward`` (NotImplementedError).
             out = super().decode_forward(*args, **kwargs)
         self._perf_decode_tokens += 1

--- a/models/demos/gemma4/tt/model.py
+++ b/models/demos/gemma4/tt/model.py
@@ -219,11 +219,8 @@ def _inject_missing_kv_shared_attention_weights(state_dict, hf_config, kv_shared
 
 
 class Gemma4Model:
-    # Generator-interface flags. Decode inputs are recomputed on host every
-    # token (host embedding + PLI), so the captured trace's input buffers
-    # have to be refreshed on every replay rather than just on the first
-    # call after a token-shape change.
-    _tt_vllm_always_refresh_decode_trace_inputs = True
+    # The rank-2 decode token input cannot alias ttnn.sampling's rank-4 output.
+    _tt_supports_decode_token_feedback = False
     # NOTE: This is a runtime capability (depends on mesh shape / per-device vocab).
     # It is set during __init__ after the sampling module is constructed.
     _supports_on_device_sampling = False

--- a/models/demos/gemma4/tt/model.py
+++ b/models/demos/gemma4/tt/model.py
@@ -228,6 +228,9 @@ class Gemma4Model:
     # the previous token ("TheThe user user...").
     # Overridden in ``__init__`` from ``hidden_size_per_layer_input``.
     _tt_vllm_always_refresh_decode_trace_inputs = True
+    # PLI is the safe class-level default. ``__init__`` enables feedback only
+    # for variants whose token input has the rank-4 sampling output layout.
+    _tt_supports_decode_token_feedback = False
     # Sampling writes a tile-aligned [1,1,1,32] token vector; decode embeds only
     # the active batch. Non-PLI prepare_decode pads tokens to this width so the
     # sampled ids can be written straight back into the trace input buffer.
@@ -296,6 +299,7 @@ class Gemma4Model:
             "yes",
         )
         self._tt_vllm_always_refresh_decode_trace_inputs = bool(self.hidden_size_per_layer_input) or force_refresh
+        self._tt_supports_decode_token_feedback = not self._tt_vllm_always_refresh_decode_trace_inputs
         n_layers = num_layers or hf_config.num_hidden_layers
 
         # Per-module dtype resolution. ``precision`` (Gemma4Precision) holds

--- a/models/demos/gpt_oss/demo/text_demo.py
+++ b/models/demos/gpt_oss/demo/text_demo.py
@@ -863,6 +863,7 @@ def test_gpt_oss_demo(
             # Decode forward — on-device sampling when available, host-side
             # greedy argmax otherwise (1×1 Blackhole, etc.)
             if on_device_sampling_supported:
+                reload_decode_inputs = iteration == 0 or not enable_decode_trace
                 out_tok, _ = generator.decode_forward(
                     out_tok,
                     current_pos,
@@ -870,6 +871,10 @@ def test_gpt_oss_demo(
                     page_table=page_table,
                     kv_cache=tt_kv_cache,
                     sampling_params=device_sampling_params,
+                    reload_inputs=reload_decode_inputs,
+                    reload_page_table=False,
+                    reload_sampling_params=True,
+                    reset_sampling_state=iteration == 0,
                 )
             else:
                 # decode_forward returns (logits, log_probs) when sampling_params=None.
@@ -880,6 +885,10 @@ def test_gpt_oss_demo(
                     page_table=page_table,
                     kv_cache=tt_kv_cache,
                     sampling_params=None,
+                    reload_inputs=True,
+                    reload_page_table=False,
+                    reload_sampling_params=False,
+                    reset_sampling_state=False,
                 )
                 out_tok = torch.argmax(logits, dim=-1).view(-1)
 

--- a/models/demos/gpt_oss/tests/accuracy/test_model.py
+++ b/models/demos/gpt_oss/tests/accuracy/test_model.py
@@ -110,6 +110,10 @@ def run_accuracy(
                 enable_trace=False,  # enable_trace
                 page_table=None,  # page_table
                 kv_cache=tt_kv_cache,  # kv_cache
+                reload_inputs=True,
+                reload_page_table=False,
+                reload_sampling_params=False,
+                reset_sampling_state=False,
             )
 
         # Get predicted token

--- a/models/demos/llama3_70b_galaxy/demo/text_demo.py
+++ b/models/demos/llama3_70b_galaxy/demo/text_demo.py
@@ -1348,6 +1348,7 @@ def test_demo_text(
                 # Save logits only for PCC check when tracing is disabled
                 tt_out_logits_saved = torch.zeros(vocab_size) if (pcc_check and not is_enable_trace) else None
                 decode_async_read = not token_accuracy
+                reload_decode_inputs = iteration == 0 or not is_enable_trace or device_sampling_params is None
                 decode_output = generator.decode_forward(
                     out_tok,
                     current_pos,
@@ -1357,12 +1358,15 @@ def test_demo_text(
                     read_from_device=True,
                     async_read=decode_async_read,
                     sampling_params=device_sampling_params,
-                    reset_inputs=iteration == 0,
                     tt_out_logits_saved=tt_out_logits_saved,
                     is_cur_pos_sharded=is_cur_pos_sharded,
                     is_page_table_sharded=is_page_table_sharded,
                     prompt_tokens=input_tokens_prefill_pt,
                     output_tokens=prefilled_token,
+                    reload_inputs=reload_decode_inputs,
+                    reload_page_table=False,
+                    reload_sampling_params=(device_sampling_params is not None and reload_decode_inputs),
+                    reset_sampling_state=(device_sampling_params is not None and iteration == 0),
                 )
                 if decode_async_read:
                     tt_out_tok, read_event = decode_output

--- a/models/demos/llama3_70b_galaxy/demo/text_demo.py
+++ b/models/demos/llama3_70b_galaxy/demo/text_demo.py
@@ -1405,6 +1405,7 @@ def test_demo_text(
                 # Save logits only for PCC check when tracing is disabled
                 tt_out_logits_saved = torch.zeros(vocab_size) if (pcc_check and not is_enable_trace) else None
                 decode_async_read = not token_accuracy
+                reload_decode_inputs = iteration == 0 or not is_enable_trace or device_sampling_params is None
                 decode_output = generator.decode_forward(
                     out_tok,
                     current_pos,
@@ -1414,12 +1415,15 @@ def test_demo_text(
                     read_from_device=True,
                     async_read=decode_async_read,
                     sampling_params=device_sampling_params,
-                    reset_inputs=iteration == 0,
                     tt_out_logits_saved=tt_out_logits_saved,
                     is_cur_pos_sharded=is_cur_pos_sharded,
                     is_page_table_sharded=is_page_table_sharded,
                     prompt_tokens=input_tokens_prefill_pt,
                     output_tokens=prefilled_token,
+                    reload_inputs=reload_decode_inputs,
+                    reload_page_table=False,
+                    reload_sampling_params=(device_sampling_params is not None and reload_decode_inputs),
+                    reset_sampling_state=(device_sampling_params is not None and iteration == 0),
                 )
                 if decode_async_read:
                     tt_out_tok, read_event = decode_output

--- a/models/demos/llama3_70b_galaxy/demo/text_qwen_demo.py
+++ b/models/demos/llama3_70b_galaxy/demo/text_qwen_demo.py
@@ -913,6 +913,7 @@ def test_qwen_demo_text(
                 # Save logits only for PCC check when tracing is disabled
                 tt_out_logits_saved = torch.zeros(vocab_size) if (pcc_check and not is_enable_trace) else None
                 decode_async_read = not token_accuracy
+                reload_decode_inputs = iteration == 0 or not is_enable_trace or device_sampling_params is None
                 decode_output = generator.decode_forward(
                     out_tok,
                     current_pos,
@@ -922,10 +923,13 @@ def test_qwen_demo_text(
                     read_from_device=True,
                     async_read=decode_async_read,
                     sampling_params=device_sampling_params,
-                    reset_inputs=iteration == 0,
                     tt_out_logits_saved=tt_out_logits_saved,
                     is_cur_pos_sharded=is_cur_pos_sharded,
                     is_page_table_sharded=is_page_table_sharded,
+                    reload_inputs=reload_decode_inputs,
+                    reload_page_table=False,
+                    reload_sampling_params=(device_sampling_params is not None and reload_decode_inputs),
+                    reset_sampling_state=(device_sampling_params is not None and iteration == 0),
                 )
                 if decode_async_read:
                     tt_out_tok, read_event = decode_output

--- a/models/demos/llama3_70b_galaxy/demo/text_qwen_demo.py
+++ b/models/demos/llama3_70b_galaxy/demo/text_qwen_demo.py
@@ -925,6 +925,7 @@ def test_qwen_demo_text(
                 # Save logits only for PCC check when tracing is disabled
                 tt_out_logits_saved = torch.zeros(vocab_size) if (pcc_check and not is_enable_trace) else None
                 decode_async_read = not token_accuracy
+                reload_decode_inputs = iteration == 0 or not is_enable_trace or device_sampling_params is None
                 decode_output = generator.decode_forward(
                     out_tok,
                     current_pos,
@@ -934,10 +935,13 @@ def test_qwen_demo_text(
                     read_from_device=True,
                     async_read=decode_async_read,
                     sampling_params=device_sampling_params,
-                    reset_inputs=iteration == 0,
                     tt_out_logits_saved=tt_out_logits_saved,
                     is_cur_pos_sharded=is_cur_pos_sharded,
                     is_page_table_sharded=is_page_table_sharded,
+                    reload_inputs=reload_decode_inputs,
+                    reload_page_table=False,
+                    reload_sampling_params=(device_sampling_params is not None and reload_decode_inputs),
+                    reset_sampling_state=(device_sampling_params is not None and iteration == 0),
                 )
                 if decode_async_read:
                     tt_out_tok, read_event = decode_output

--- a/models/demos/llama3_70b_galaxy/tt/generator.py
+++ b/models/demos/llama3_70b_galaxy/tt/generator.py
@@ -170,10 +170,6 @@ def _pad_or_create_page_table(table, target_blocks: int):
 
 
 class Generator(WarmupForwardMixin):
-    # Versioned vLLM decode update contract. See
-    # plugins/vllm-tt-plugin/model_input.py in tenstorrent/vllm.
-    decode_input_update_contract = 1
-
     def __init__(self, model, model_args, mesh_device, tokenizer=None, formatter=None):
         """
         Creating a LlamaVision wrapper requires only a mesh_device and model_args.

--- a/models/demos/llama3_70b_galaxy/tt/generator.py
+++ b/models/demos/llama3_70b_galaxy/tt/generator.py
@@ -1312,10 +1312,19 @@ class Generator(WarmupForwardMixin):
             tt_out_for_read = (tt_tok, tt_log_probs) if tt_log_probs is not None else tt_tok
             tt_out = self.read_decode_output(tt_out_for_read, async_read=async_read)
             if async_read:
+                if sampling_params is None:
+                    self._apply_sampling_slot_remap(slot_remap)
                 return tt_out
             else:
-                return self.process_decode_output_host(tt_out, is_tokens=on_device_logits)
+                output = self.process_decode_output_host(tt_out, is_tokens=on_device_logits)
+                if sampling_params is None:
+                    # Consume the dormant sampler remap only after decode and
+                    # readback succeed, preserving retry semantics.
+                    self._apply_sampling_slot_remap(slot_remap)
+                return output
 
+        if sampling_params is None:
+            self._apply_sampling_slot_remap(slot_remap)
         return tt_tok, tt_log_probs
 
     def _decode_forward_no_trace_text(
@@ -1484,6 +1493,16 @@ class Generator(WarmupForwardMixin):
 
         return trace_tok_rm
 
+    def _apply_sampling_slot_remap(self, slot_remap) -> None:
+        if slot_remap is None:
+            return
+        sampling_module = getattr(self.model, "sampling", None)
+        if sampling_module is None:
+            return
+        seed_manager = sampling_module.seed_manager
+        sm_bs = seed_manager.max_batch_size
+        seed_manager.apply_slot_remap(slot_remap[0:sm_bs])
+
     def sample_decode_on_device(
         self,
         tt_logits,
@@ -1501,17 +1520,15 @@ class Generator(WarmupForwardMixin):
         sampling_module = self.model.sampling
         seed_manager = sampling_module.seed_manager
 
+        # Keep separated sampling independently usable.
+        self._apply_sampling_slot_remap(slot_remap)
+
         active_seed_slots = None
         if start_pos is not None:
             active_seed_slots = [
                 idx for idx, pos in enumerate(torch.as_tensor(start_pos).reshape(-1).tolist()) if int(pos) >= 0
             ]
 
-        # Apply slot remap from condense before advancing seeds.
-        if slot_remap is not None:
-            sm_bs = seed_manager.max_batch_size
-            rank_remap = slot_remap[0:sm_bs]
-            seed_manager.apply_slot_remap(rank_remap)
         if reload_sampling_params and sampling_params is not None:
             sampling_params = format_sampling_params(sampling_params, self.model_args.max_batch_size)
             if active_seed_slots is not None:

--- a/models/demos/llama3_70b_galaxy/tt/generator.py
+++ b/models/demos/llama3_70b_galaxy/tt/generator.py
@@ -1628,7 +1628,9 @@ class Generator(WarmupForwardMixin):
         if sampling_params is not None and (active_seed_slots is None or active_seed_slots):
             seed_values = getattr(sampling_params, "seed", None)
             if reset_sampling_state:
-                seed_manager.reset_decode_batch(seed_values, active_seed_slots)
+                # Reset unconditionally, including seed=None, so decode-only
+                # sampling uploads fresh device seeds for the new state.
+                seed_manager.reset_seed_from_slots(seed_values, active_seed_slots)
                 seed_manager.align_seed_counters_to_positions(seed_values, active_seed_slots, start_pos)
             elif reload_sampling_params:
                 seed_manager.reset_seed_from_slots_if_needed(

--- a/models/demos/llama3_70b_galaxy/tt/generator.py
+++ b/models/demos/llama3_70b_galaxy/tt/generator.py
@@ -19,7 +19,6 @@ from models.common.sampling import (
     SamplingParams,
     broadcast_sampling_params,
     format_sampling_params,
-    should_align_decode_seed_counters,
 )
 from models.common.warmup import WarmupForwardMixin
 from models.demos.llama3_70b_galaxy.tt.model_config import SDPA_CHUNK_ALIGN
@@ -205,7 +204,6 @@ class Generator(WarmupForwardMixin):
             for _ in range(self.model_args.max_batch_size)
         ]
         self.tt_logits_accumulated_batched = []  # Temporary list for batched prefill
-        self.prev_page_table = None
         self.already_warmed_up_prefill = False
         self.warming_up_prefill = False
         self.trace_ids_decode = defaultdict(lambda: None)  # {on_device_logits: {device_id: trace_id}}
@@ -213,7 +211,6 @@ class Generator(WarmupForwardMixin):
         self.trace_output_decode = defaultdict(lambda: None)
         self._disable_prefill_tracing = False  # Whether to disable prefill traces
         self._disable_decode_tracing = False  # Whether to disable decode traces
-        self._decode_inputs_need_reset = False
 
     def _set_prefill_column_mask(self, tt_column_mask):
         # Keep mask available on whichever TT_CCL instance attention currently uses.
@@ -843,8 +840,6 @@ class Generator(WarmupForwardMixin):
                     log_probs_torch = ttnn.to_torch(ttnn.get_device_tensors(tt_lp)[0])
                     prefill_log_probs = log_probs_torch[0, 0, 0, :][empty_slots]
 
-        self._decode_inputs_need_reset = True
-
         if return_logits:
             # TODO: the current solution runs the argmax even if we are returning logits
             # This is inefficient and should be fixed
@@ -1243,97 +1238,33 @@ class Generator(WarmupForwardMixin):
         read_from_device=True,
         async_read=False,
         sampling_params: SamplingParams = None,  # None means returning logits and host sampling.
-        reset_inputs=False,  # If false, skip loading inputs, because it's next step of the batch we last had and sampled on device
         tt_out_logits_saved=None,
         is_cur_pos_sharded=False,
         is_page_table_sharded=False,
-        reset_batch=False,
         prompt_tokens: torch.Tensor | None = None,
         output_tokens: torch.Tensor | None = None,
         slot_remap=None,
         defer_device_sampling: bool = False,
-        reload_inputs: bool | None = None,
-        reload_page_table: bool | None = None,
-        reload_sampling_params: bool | None = None,
-        reset_sampling_state: bool | None = None,
+        *,
+        reload_inputs: bool,
+        reload_page_table: bool,
+        reload_sampling_params: bool,
+        reset_sampling_state: bool,
     ):
         if getattr(self, "_disable_decode_tracing", False):
             enable_trace = False
+        if not enable_trace and not reload_inputs:
+            raise ValueError("Non-traced Galaxy decode rebuilds all forward inputs and requires reload_inputs=True")
 
-        contract_flags = (
-            reload_inputs,
-            reload_page_table,
-            reload_sampling_params,
-            reset_sampling_state,
-        )
-        explicit_contract = any(flag is not None for flag in contract_flags)
-        if explicit_contract and not all(flag is not None for flag in contract_flags):
-            raise ValueError(
-                "decode update contract requires reload_inputs, "
-                "reload_page_table, reload_sampling_params, and "
-                "reset_sampling_state together"
-            )
-
-        reset_reasons = []
         if sampling_params is None and not defer_device_sampling:
             on_device_logits = False
-            if not explicit_contract:
-                reset_inputs = True
-                reset_reasons.append("host_sampling")
         else:
             on_device_logits = True
 
-        on_device_sampling = (sampling_params is not None) or defer_device_sampling
-        if explicit_contract:
-            effective_reload_inputs = bool(reload_inputs)
-            page_table_changed = bool(reload_page_table)
-        else:
-            # Legacy vLLM/demos retain the historical model-local heuristics.
-            prev_on_device_sampling = getattr(
-                self, "_prev_on_device_sampling", None
-            )
-            self._prev_on_device_sampling = on_device_sampling
-            if (
-                prev_on_device_sampling is not None
-                and prev_on_device_sampling != on_device_sampling
-            ):
-                reset_inputs = True
-                reset_reasons.append("sampling_mode_changed")
-            if self._decode_inputs_need_reset:
-                reset_inputs = True
-                reset_reasons.append("decode_inputs_need_reset")
-                self._decode_inputs_need_reset = False
-            page_table_changed = False
-            if page_table is not None:
-                page_table_changed = self.prev_page_table is None or torch.any(
-                    self.prev_page_table != page_table
-                ).item()
-                if page_table_changed and not on_device_sampling:
-                    reset_inputs = True
-                    reset_reasons.append("page_table_changed")
-                elif page_table_changed:
-                    reset_reasons.append("page_table_changed_devres")
-            effective_reload_inputs = reset_inputs
-
         if self.model.is_decode_setup is False:
             self.model.switch_mode("decode")
-            if not explicit_contract:
-                effective_reload_inputs = True
-                reset_reasons.append("mode_switch_to_decode")
-
-        if reset_batch and not explicit_contract:
-            # A new batch layout (real reset or slot remap) leaves the device
-            # token/current_pos buffers holding the previous batch's values, so
-            # host inputs are authoritative again and must be fully reloaded.
-            effective_reload_inputs = True
-            reset_reasons.append("reset_batch")
 
         kv_cache = kv_cache[0]
-        active_seed_slots = None
-        if start_pos is not None:
-            active_seed_slots = [
-                idx for idx, pos in enumerate(torch.as_tensor(start_pos).reshape(-1).tolist()) if int(pos) >= 0
-            ]
         decode_kwargs = {
             "current_pos": start_pos,
             "tokens": tokens,
@@ -1348,8 +1279,8 @@ class Generator(WarmupForwardMixin):
         if enable_trace:
             tt_tok, tt_log_probs = self._decode_easy_trace_text(
                 **decode_kwargs,
-                reset_inputs=effective_reload_inputs,
-                page_table_changed=page_table_changed,
+                reload_inputs=reload_inputs,
+                reload_page_table=reload_page_table,
                 on_device_logits=on_device_logits,
             )
         else:
@@ -1365,29 +1296,12 @@ class Generator(WarmupForwardMixin):
                 tt_tok,
                 sampling_params=sampling_params,
                 start_pos=start_pos,
-                reset_inputs=effective_reload_inputs,
-                reset_batch=reset_batch,
                 prompt_tokens=prompt_tokens,
                 output_tokens=output_tokens,
                 slot_remap=slot_remap,
                 enable_trace=enable_trace,
-                reload_sampling_params=(
-                    bool(reload_sampling_params)
-                    if explicit_contract
-                    else effective_reload_inputs
-                ),
-                reset_sampling_state=(
-                    bool(reset_sampling_state)
-                    if explicit_contract
-                    else reset_batch
-                ),
-                align_seed_counters=should_align_decode_seed_counters(
-                    explicit_contract=explicit_contract,
-                    reset_sampling_state=bool(reset_sampling_state),
-                    # Galaxy historically aligned only when forward inputs
-                    # were reset (including host→device trace switches).
-                    legacy_alignment=effective_reload_inputs,
-                ),
+                reload_sampling_params=reload_sampling_params,
+                reset_sampling_state=reset_sampling_state,
             )
 
         if read_from_device:
@@ -1507,11 +1421,12 @@ class Generator(WarmupForwardMixin):
         current_pos,
         page_table=None,
         kv_cache=None,
-        reset_inputs=False,
-        page_table_changed=False,
         is_cur_pos_sharded=False,
         is_page_table_sharded=False,
         on_device_logits=False,
+        *,
+        reload_inputs: bool,
+        reload_page_table: bool,
     ):
         """
         Run decode forward text with tracing
@@ -1531,7 +1446,7 @@ class Generator(WarmupForwardMixin):
             self.trace_ids_decode[on_device_logits] = trace_id
             self.trace_inputs_decode[on_device_logits] = device_inputs
             self.trace_output_decode[on_device_logits] = tt_out_tok
-        if reset_inputs:
+        if reload_inputs:
             # Full resets are required when host token/position inputs are
             # authoritative again (host sampling, trace switch, or batch reset).
             host_inputs = self.model.prepare_decode_inputs_host(
@@ -1543,7 +1458,7 @@ class Generator(WarmupForwardMixin):
                 device_tensors=self.trace_inputs_decode[on_device_logits],
                 shard_specs=shard_specs,
             )
-        elif page_table_changed:
+        elif reload_page_table:
             # With async device sampling, token/position inputs may intentionally
             # be stale on host: the previous decode updates them on device. Page
             # tables still need refreshing when new KV blocks are allocated, so
@@ -1555,9 +1470,6 @@ class Generator(WarmupForwardMixin):
             device_page_table = self.trace_inputs_decode[on_device_logits][DECODE_PAGE_TABLE_INPUT_IDX]
             if host_page_table is not None:
                 ttnn.copy_host_to_device_tensor(host_page_table, device_page_table)
-        if page_table_changed:
-            self.prev_page_table = page_table.clone()
-
         trace_tok_rm = self._decode_forward_trace_text(
             self.trace_ids_decode[on_device_logits],
             self.trace_inputs_decode[on_device_logits],
@@ -1577,23 +1489,14 @@ class Generator(WarmupForwardMixin):
         tt_logits,
         sampling_params,
         start_pos=None,
-        reset_inputs=False,
-        reset_batch=False,
         prompt_tokens: torch.Tensor | None = None,
         output_tokens: torch.Tensor | None = None,
         slot_remap=None,
         enable_trace=False,
-        reload_sampling_params: bool | None = None,
-        reset_sampling_state: bool | None = None,
-        align_seed_counters: bool | None = None,
+        *,
+        reload_sampling_params: bool,
+        reset_sampling_state: bool,
     ):
-        if reload_sampling_params is None:
-            reload_sampling_params = reset_inputs
-        if reset_sampling_state is None:
-            reset_sampling_state = reset_batch
-        if align_seed_counters is None:
-            # Direct callers without explicit flags retain legacy behavior.
-            align_seed_counters = reset_inputs
         tt_out_tok = self.trace_inputs_decode[True][0] if enable_trace and self.trace_inputs_decode[True] else None
         sampling_module = self.model.sampling
         seed_manager = sampling_module.seed_manager
@@ -1633,13 +1536,7 @@ class Generator(WarmupForwardMixin):
                 seed_manager.reset_seed_from_slots(seed_values, active_seed_slots)
                 seed_manager.align_seed_counters_to_positions(seed_values, active_seed_slots, start_pos)
             elif reload_sampling_params:
-                seed_manager.reset_seed_from_slots_if_needed(
-                    seed_values, active_seed_slots
-                )
-                if align_seed_counters:
-                    seed_manager.align_seed_counters_to_positions(
-                        seed_values, active_seed_slots, start_pos
-                    )
+                seed_manager.reset_seed_from_slots_if_needed(seed_values, active_seed_slots)
 
         # Advance seeds after parameter copies so seeded sampling observes
         # one ordered params/seed state for this token.

--- a/models/demos/llama3_70b_galaxy/tt/generator.py
+++ b/models/demos/llama3_70b_galaxy/tt/generator.py
@@ -15,7 +15,12 @@ from models.common.llama_models import (
     CompletionPrediction,
     StopReason,
 )
-from models.common.sampling import SamplingParams, broadcast_sampling_params, format_sampling_params
+from models.common.sampling import (
+    SamplingParams,
+    broadcast_sampling_params,
+    format_sampling_params,
+    should_align_decode_seed_counters,
+)
 from models.common.warmup import WarmupForwardMixin
 from models.demos.llama3_70b_galaxy.tt.model_config import SDPA_CHUNK_ALIGN
 from models.tt_transformers.tt.common import (
@@ -165,6 +170,10 @@ def _pad_or_create_page_table(table, target_blocks: int):
 
 
 class Generator(WarmupForwardMixin):
+    # Versioned vLLM decode update contract. See
+    # plugins/vllm-tt-plugin/model_input.py in tenstorrent/vllm.
+    decode_input_update_contract = 1
+
     def __init__(self, model, model_args, mesh_device, tokenizer=None, formatter=None):
         """
         Creating a LlamaVision wrapper requires only a mesh_device and model_args.
@@ -1247,74 +1256,80 @@ class Generator(WarmupForwardMixin):
         output_tokens: torch.Tensor | None = None,
         slot_remap=None,
         defer_device_sampling: bool = False,
+        reload_inputs: bool | None = None,
+        reload_page_table: bool | None = None,
+        reload_sampling_params: bool | None = None,
+        reset_sampling_state: bool | None = None,
     ):
         if getattr(self, "_disable_decode_tracing", False):
             enable_trace = False
 
+        contract_flags = (
+            reload_inputs,
+            reload_page_table,
+            reload_sampling_params,
+            reset_sampling_state,
+        )
+        explicit_contract = any(flag is not None for flag in contract_flags)
+        if explicit_contract and not all(flag is not None for flag in contract_flags):
+            raise ValueError(
+                "decode update contract requires reload_inputs, "
+                "reload_page_table, reload_sampling_params, and "
+                "reset_sampling_state together"
+            )
+
         reset_reasons = []
         if sampling_params is None and not defer_device_sampling:
             on_device_logits = False
-            reset_inputs = True  # We didn't sample on device, so we need to load inputs.
-            reset_reasons.append("host_sampling")
+            if not explicit_contract:
+                reset_inputs = True
+                reset_reasons.append("host_sampling")
         else:
             on_device_logits = True
 
-        # Track sampling mode changes to reset inputs when switching
-        # between host sampling and device sampling (different trace has stale inputs)
         on_device_sampling = (sampling_params is not None) or defer_device_sampling
-        prev_on_device_sampling = getattr(self, "_prev_on_device_sampling", None)
-        self._prev_on_device_sampling = on_device_sampling
-        if prev_on_device_sampling is not None and prev_on_device_sampling != on_device_sampling:
-            reset_inputs = True
-            reset_reasons.append("sampling_mode_changed")
-        if self._decode_inputs_need_reset:
-            # Prefill on-device sampling switches the model to decode mode, so the
-            # is_decode_setup check below won't fire; force a reset here so the
-            # first decode after such a prefill reloads host inputs.
-            reset_inputs = True
-            reset_reasons.append("decode_inputs_need_reset")
-            self._decode_inputs_need_reset = False
-        # TEMP FIX (tenstorrent/vllm#449): reload decisions belong in vLLM, which is the
-        # only side that knows when host inputs are valid under async draining. Until then
-        # the model decides here, and the rules below are the model-side half.
-        #
-        # Mixed greedy+random batches use device-resident tokens/positions like all-greedy
-        # batches: the sampled token is fed back on-device and current_pos is advanced
-        # in-trace, so no per-step host input reload is needed here. Per-request sampling
-        # params are fixed for a request's lifetime (uploaded at batch setup / refreshed on
-        # reset_batch).
-        page_table_changed = False
-        if page_table is not None:
-            page_table_changed = self.prev_page_table is None or torch.any(self.prev_page_table != page_table).item()
-            if page_table_changed and not on_device_sampling:
-                # Host sampling: tokens/positions are host-authoritative every step,
-                # so a page-table change (new KV block) needs a full input reload.
+        if explicit_contract:
+            effective_reload_inputs = bool(reload_inputs)
+            page_table_changed = bool(reload_page_table)
+        else:
+            # Legacy vLLM/demos retain the historical model-local heuristics.
+            prev_on_device_sampling = getattr(
+                self, "_prev_on_device_sampling", None
+            )
+            self._prev_on_device_sampling = on_device_sampling
+            if (
+                prev_on_device_sampling is not None
+                and prev_on_device_sampling != on_device_sampling
+            ):
                 reset_inputs = True
-                reset_reasons.append("page_table_changed")
-            elif page_table_changed:
-                # Device-resident decode (on-device sampling): tokens/positions live
-                # on device (fed back + plus_one in-trace) and the host copy is
-                # intentionally stale. A page-table change must NOT force a full
-                # reload -- under async overlap the stale host current_pos would
-                # clobber the device's advanced position and the slot would
-                # re-decode its previous token (the greedy "doubling"). Instead fall
-                # through to the page_table_changed branch in _decode_easy_trace_text,
-                # which refreshes ONLY the page-table trace input and preserves the
-                # device-produced tokens/positions. (Genuine (re)inits -- first
-                # decode, mode switch, reset_batch, slot remap -- still set
-                # reset_inputs via their own reasons and take the full-reload path.)
-                reset_reasons.append("page_table_changed_devres")
+                reset_reasons.append("sampling_mode_changed")
+            if self._decode_inputs_need_reset:
+                reset_inputs = True
+                reset_reasons.append("decode_inputs_need_reset")
+                self._decode_inputs_need_reset = False
+            page_table_changed = False
+            if page_table is not None:
+                page_table_changed = self.prev_page_table is None or torch.any(
+                    self.prev_page_table != page_table
+                ).item()
+                if page_table_changed and not on_device_sampling:
+                    reset_inputs = True
+                    reset_reasons.append("page_table_changed")
+                elif page_table_changed:
+                    reset_reasons.append("page_table_changed_devres")
+            effective_reload_inputs = reset_inputs
 
         if self.model.is_decode_setup is False:
             self.model.switch_mode("decode")
-            reset_inputs = True  # Last step wasn't decode, so we definitely need to load inputs.
-            reset_reasons.append("mode_switch_to_decode")
+            if not explicit_contract:
+                effective_reload_inputs = True
+                reset_reasons.append("mode_switch_to_decode")
 
-        if reset_batch:
+        if reset_batch and not explicit_contract:
             # A new batch layout (real reset or slot remap) leaves the device
             # token/current_pos buffers holding the previous batch's values, so
             # host inputs are authoritative again and must be fully reloaded.
-            reset_inputs = True
+            effective_reload_inputs = True
             reset_reasons.append("reset_batch")
 
         kv_cache = kv_cache[0]
@@ -1337,7 +1352,7 @@ class Generator(WarmupForwardMixin):
         if enable_trace:
             tt_tok, tt_log_probs = self._decode_easy_trace_text(
                 **decode_kwargs,
-                reset_inputs=reset_inputs,
+                reset_inputs=effective_reload_inputs,
                 page_table_changed=page_table_changed,
                 on_device_logits=on_device_logits,
             )
@@ -1354,12 +1369,29 @@ class Generator(WarmupForwardMixin):
                 tt_tok,
                 sampling_params=sampling_params,
                 start_pos=start_pos,
-                reset_inputs=reset_inputs,
+                reset_inputs=effective_reload_inputs,
                 reset_batch=reset_batch,
                 prompt_tokens=prompt_tokens,
                 output_tokens=output_tokens,
                 slot_remap=slot_remap,
                 enable_trace=enable_trace,
+                reload_sampling_params=(
+                    bool(reload_sampling_params)
+                    if explicit_contract
+                    else effective_reload_inputs
+                ),
+                reset_sampling_state=(
+                    bool(reset_sampling_state)
+                    if explicit_contract
+                    else reset_batch
+                ),
+                align_seed_counters=should_align_decode_seed_counters(
+                    explicit_contract=explicit_contract,
+                    reset_sampling_state=bool(reset_sampling_state),
+                    # Galaxy historically aligned only when forward inputs
+                    # were reset (including host→device trace switches).
+                    legacy_alignment=effective_reload_inputs,
+                ),
             )
 
         if read_from_device:
@@ -1555,7 +1587,17 @@ class Generator(WarmupForwardMixin):
         output_tokens: torch.Tensor | None = None,
         slot_remap=None,
         enable_trace=False,
+        reload_sampling_params: bool | None = None,
+        reset_sampling_state: bool | None = None,
+        align_seed_counters: bool | None = None,
     ):
+        if reload_sampling_params is None:
+            reload_sampling_params = reset_inputs
+        if reset_sampling_state is None:
+            reset_sampling_state = reset_batch
+        if align_seed_counters is None:
+            # Direct callers without explicit flags retain legacy behavior.
+            align_seed_counters = reset_inputs
         tt_out_tok = self.trace_inputs_decode[True][0] if enable_trace and self.trace_inputs_decode[True] else None
         sampling_module = self.model.sampling
         seed_manager = sampling_module.seed_manager
@@ -1571,8 +1613,7 @@ class Generator(WarmupForwardMixin):
             sm_bs = seed_manager.max_batch_size
             rank_remap = slot_remap[0:sm_bs]
             seed_manager.apply_slot_remap(rank_remap)
-        if reset_inputs and sampling_params is not None:
-            # If we have new inputs, we need to set up the sampling module again
+        if reload_sampling_params and sampling_params is not None:
             sampling_params = format_sampling_params(sampling_params, self.model_args.max_batch_size)
             if active_seed_slots is not None:
                 seed_values = _as_list(getattr(sampling_params, "seed", None))
@@ -1584,15 +1625,23 @@ class Generator(WarmupForwardMixin):
                         sampling_params, active_seed_slots, self.model_args.max_batch_size
                     )
             sampling_module.reset_sampling_params(sampling_params)
-            if reset_batch:
-                sampling_module.reset_prompt_tokens(prompt_tokens)
-                sampling_module.reset_output_state(output_tokens)
+        if reset_sampling_state:
+            sampling_module.reset_prompt_tokens(prompt_tokens)
+            sampling_module.reset_output_state(output_tokens)
 
         if sampling_params is not None and (active_seed_slots is None or active_seed_slots):
             seed_values = getattr(sampling_params, "seed", None)
-            seed_manager.reset_seed_from_slots_if_needed(seed_values, active_seed_slots)
-            if reset_inputs:
+            if reset_sampling_state:
+                seed_manager.reset_decode_batch(seed_values, active_seed_slots)
                 seed_manager.align_seed_counters_to_positions(seed_values, active_seed_slots, start_pos)
+            elif reload_sampling_params:
+                seed_manager.reset_seed_from_slots_if_needed(
+                    seed_values, active_seed_slots
+                )
+                if align_seed_counters:
+                    seed_manager.align_seed_counters_to_positions(
+                        seed_values, active_seed_slots, start_pos
+                    )
 
         # Advance seeds after parameter copies so seeded sampling observes
         # one ordered params/seed state for this token.

--- a/models/demos/llama3_70b_galaxy/tt/generator.py
+++ b/models/demos/llama3_70b_galaxy/tt/generator.py
@@ -15,7 +15,11 @@ from models.common.llama_models import (
     CompletionPrediction,
     StopReason,
 )
-from models.common.sampling import SamplingParams, broadcast_sampling_params, format_sampling_params
+from models.common.sampling import (
+    SamplingParams,
+    broadcast_sampling_params,
+    format_sampling_params,
+)
 from models.common.warmup import WarmupForwardMixin
 from models.demos.llama3_70b_galaxy.tt.model_config import SDPA_CHUNK_ALIGN
 from models.tt_transformers.tt.common import (
@@ -219,7 +223,6 @@ class Generator(WarmupForwardMixin):
             for _ in range(self.model_args.max_batch_size)
         ]
         self.tt_logits_accumulated_batched = []  # Temporary list for batched prefill
-        self.prev_page_table = None
         self.already_warmed_up_prefill = False
         self.warming_up_prefill = False
         self.trace_ids_decode = defaultdict(lambda: None)  # {on_device_logits: {device_id: trace_id}}
@@ -230,7 +233,6 @@ class Generator(WarmupForwardMixin):
         self.trace_output_decode = defaultdict(lambda: None)
         self._disable_prefill_tracing = False  # Whether to disable prefill traces
         self._disable_decode_tracing = False  # Whether to disable decode traces
-        self._decode_inputs_need_reset = False
         # Deferred trace recording. While set, _easy_trace_prefill compiles and stages a
         # variant's buffers but records nothing, stashing the prepared state here. Warmup
         # sweeps every variant first and then records them back to back, so no compile and
@@ -969,8 +971,6 @@ class Generator(WarmupForwardMixin):
                     log_probs_torch = ttnn.to_torch(ttnn.get_device_tensors(tt_lp)[0])
                     prefill_log_probs = log_probs_torch.reshape(-1)[empty_slots]
 
-        self._decode_inputs_need_reset = True
-
         if return_logits:
             # TODO: the current solution runs the argmax even if we are returning logits
             # This is inefficient and should be fixed
@@ -1494,91 +1494,33 @@ class Generator(WarmupForwardMixin):
         read_from_device=True,
         async_read=False,
         sampling_params: SamplingParams = None,  # None means returning logits and host sampling.
-        reset_inputs=False,  # If false, skip loading inputs, because it's next step of the batch we last had and sampled on device
         tt_out_logits_saved=None,
         is_cur_pos_sharded=False,
         is_page_table_sharded=False,
-        reset_batch=False,
         prompt_tokens: torch.Tensor | None = None,
         output_tokens: torch.Tensor | None = None,
         slot_remap=None,
         defer_device_sampling: bool = False,
+        *,
+        reload_inputs: bool,
+        reload_page_table: bool,
+        reload_sampling_params: bool,
+        reset_sampling_state: bool,
     ):
         if getattr(self, "_disable_decode_tracing", False):
             enable_trace = False
+        if not enable_trace and not reload_inputs:
+            raise ValueError("Non-traced Galaxy decode rebuilds all forward inputs and requires reload_inputs=True")
 
-        reset_reasons = []
         if sampling_params is None and not defer_device_sampling:
             on_device_logits = False
-            reset_inputs = True  # We didn't sample on device, so we need to load inputs.
-            reset_reasons.append("host_sampling")
         else:
             on_device_logits = True
 
-        # Track sampling mode changes to reset inputs when switching
-        # between host sampling and device sampling (different trace has stale inputs)
-        on_device_sampling = (sampling_params is not None) or defer_device_sampling
-        prev_on_device_sampling = getattr(self, "_prev_on_device_sampling", None)
-        self._prev_on_device_sampling = on_device_sampling
-        if prev_on_device_sampling is not None and prev_on_device_sampling != on_device_sampling:
-            reset_inputs = True
-            reset_reasons.append("sampling_mode_changed")
-        if self._decode_inputs_need_reset:
-            # Prefill on-device sampling switches the model to decode mode, so the
-            # is_decode_setup check below won't fire; force a reset here so the
-            # first decode after such a prefill reloads host inputs.
-            reset_inputs = True
-            reset_reasons.append("decode_inputs_need_reset")
-            self._decode_inputs_need_reset = False
-        # TEMP FIX (tenstorrent/vllm#449): reload decisions belong in vLLM, which is the
-        # only side that knows when host inputs are valid under async draining. Until then
-        # the model decides here, and the rules below are the model-side half.
-        #
-        # Mixed greedy+random batches use device-resident tokens/positions like all-greedy
-        # batches: the sampled token is fed back on-device and current_pos is advanced
-        # in-trace, so no per-step host input reload is needed here. Per-request sampling
-        # params are fixed for a request's lifetime (uploaded at batch setup / refreshed on
-        # reset_batch).
-        page_table_changed = False
-        if page_table is not None:
-            page_table_changed = self.prev_page_table is None or torch.any(self.prev_page_table != page_table).item()
-            if page_table_changed and not on_device_sampling:
-                # Host sampling: tokens/positions are host-authoritative every step,
-                # so a page-table change (new KV block) needs a full input reload.
-                reset_inputs = True
-                reset_reasons.append("page_table_changed")
-            elif page_table_changed:
-                # Device-resident decode (on-device sampling): tokens/positions live
-                # on device (fed back + plus_one in-trace) and the host copy is
-                # intentionally stale. A page-table change must NOT force a full
-                # reload -- under async overlap the stale host current_pos would
-                # clobber the device's advanced position and the slot would
-                # re-decode its previous token (the greedy "doubling"). Instead fall
-                # through to the page_table_changed branch in _decode_easy_trace_text,
-                # which refreshes ONLY the page-table trace input and preserves the
-                # device-produced tokens/positions. (Genuine (re)inits -- first
-                # decode, mode switch, reset_batch, slot remap -- still set
-                # reset_inputs via their own reasons and take the full-reload path.)
-                reset_reasons.append("page_table_changed_devres")
-
         if self.model.is_decode_setup is False:
             self.model.switch_mode("decode")
-            reset_inputs = True  # Last step wasn't decode, so we definitely need to load inputs.
-            reset_reasons.append("mode_switch_to_decode")
-
-        if reset_batch:
-            # A new batch layout (real reset or slot remap) leaves the device
-            # token/current_pos buffers holding the previous batch's values, so
-            # host inputs are authoritative again and must be fully reloaded.
-            reset_inputs = True
-            reset_reasons.append("reset_batch")
 
         kv_cache = kv_cache[0]
-        active_seed_slots = None
-        if start_pos is not None:
-            active_seed_slots = [
-                idx for idx, pos in enumerate(torch.as_tensor(start_pos).reshape(-1).tolist()) if int(pos) >= 0
-            ]
         decode_kwargs = {
             "current_pos": start_pos,
             "tokens": tokens,
@@ -1593,8 +1535,8 @@ class Generator(WarmupForwardMixin):
         if enable_trace:
             tt_tok, tt_log_probs = self._decode_easy_trace_text(
                 **decode_kwargs,
-                reset_inputs=reset_inputs,
-                page_table_changed=page_table_changed,
+                reload_inputs=reload_inputs,
+                reload_page_table=reload_page_table,
                 on_device_logits=on_device_logits,
             )
         else:
@@ -1610,12 +1552,12 @@ class Generator(WarmupForwardMixin):
                 tt_tok,
                 sampling_params=sampling_params,
                 start_pos=start_pos,
-                reset_inputs=reset_inputs,
-                reset_batch=reset_batch,
                 prompt_tokens=prompt_tokens,
                 output_tokens=output_tokens,
                 slot_remap=slot_remap,
                 enable_trace=enable_trace,
+                reload_sampling_params=reload_sampling_params,
+                reset_sampling_state=reset_sampling_state,
             )
 
         if read_from_device:
@@ -1626,10 +1568,19 @@ class Generator(WarmupForwardMixin):
             tt_out_for_read = (tt_tok, tt_log_probs) if tt_log_probs is not None else tt_tok
             tt_out = self.read_decode_output(tt_out_for_read, async_read=async_read)
             if async_read:
+                if sampling_params is None:
+                    self._apply_sampling_slot_remap(slot_remap)
                 return tt_out
             else:
-                return self.process_decode_output_host(tt_out, is_tokens=on_device_logits)
+                output = self.process_decode_output_host(tt_out, is_tokens=on_device_logits)
+                if sampling_params is None:
+                    # Consume the dormant sampler remap only after decode and
+                    # readback succeed, preserving retry semantics.
+                    self._apply_sampling_slot_remap(slot_remap)
+                return output
 
+        if sampling_params is None:
+            self._apply_sampling_slot_remap(slot_remap)
         return tt_tok, tt_log_probs
 
     def _decode_forward_no_trace_text(
@@ -1839,11 +1790,12 @@ class Generator(WarmupForwardMixin):
         current_pos,
         page_table=None,
         kv_cache=None,
-        reset_inputs=False,
-        page_table_changed=False,
         is_cur_pos_sharded=False,
         is_page_table_sharded=False,
         on_device_logits=False,
+        *,
+        reload_inputs: bool,
+        reload_page_table: bool,
     ):
         """
         Run decode forward text with tracing
@@ -1863,7 +1815,7 @@ class Generator(WarmupForwardMixin):
             self.trace_ids_decode[on_device_logits] = trace_id
             self.trace_inputs_decode[on_device_logits] = device_inputs
             self.trace_output_decode[on_device_logits] = tt_out_tok
-        if reset_inputs:
+        if reload_inputs:
             # Full resets are required when host token/position inputs are
             # authoritative again (host sampling, trace switch, or batch reset).
             host_inputs = self.model.prepare_decode_inputs_host(
@@ -1875,7 +1827,7 @@ class Generator(WarmupForwardMixin):
                 device_tensors=self.trace_inputs_decode[on_device_logits],
                 shard_specs=shard_specs,
             )
-        elif page_table_changed:
+        elif reload_page_table:
             # With async device sampling, token/position inputs may intentionally
             # be stale on host: the previous decode updates them on device. Page
             # tables still need refreshing when new KV blocks are allocated, so
@@ -1887,9 +1839,6 @@ class Generator(WarmupForwardMixin):
             device_page_table = self.trace_inputs_decode[on_device_logits][DECODE_PAGE_TABLE_INPUT_IDX]
             if host_page_table is not None:
                 ttnn.copy_host_to_device_tensor(host_page_table, device_page_table)
-        if page_table_changed:
-            self.prev_page_table = page_table.clone()
-
         trace_tok_rm = self._decode_forward_trace_text(
             self.trace_ids_decode[on_device_logits],
             self.trace_inputs_decode[on_device_logits],
@@ -1912,61 +1861,103 @@ class Generator(WarmupForwardMixin):
             if isinstance(value, list) and len(value) == self.model_args.max_batch_size:
                 self._slot_sampling_params[f.name] = list(value)
 
+    def _apply_sampling_slot_remap(self, slot_remap) -> None:
+        if slot_remap is None:
+            return
+        sampling_module = getattr(self.model, "sampling", None)
+        if sampling_module is None:
+            return
+        seed_manager = sampling_module.seed_manager
+        sm_bs = seed_manager.max_batch_size
+        shadow_bs = self.model_args.max_batch_size
+        required_size = max(sm_bs, shadow_bs)
+        if len(slot_remap) < required_size:
+            raise ValueError(f"Sampling slot remap has {len(slot_remap)} entries; expected at least {required_size}")
+        seed_remap = [int(slot) for slot in slot_remap[0:sm_bs]]
+        if any(slot < 0 or slot >= sm_bs for slot in seed_remap):
+            raise ValueError(f"Seed slot remap must stay within [0, {sm_bs}), got {seed_remap}")
+        shadow_remap = [int(slot) for slot in slot_remap[0:shadow_bs]]
+        if any(slot < 0 or slot >= shadow_bs for slot in shadow_remap):
+            raise ValueError(f"Sampling slot remap must stay within [0, {shadow_bs}), got {shadow_remap}")
+
+        # Use snapshots because a remap can swap or duplicate sources. These
+        # vectors are the source of truth for later partial-prefill uploads and
+        # must move with the same requests as the seed manager.
+        remapped_params = {
+            name: [values[source] for source in shadow_remap] for name, values in self._slot_sampling_params.items()
+        }
+        sampling_module.apply_slot_remap(seed_remap)
+        self._slot_sampling_params.update(remapped_params)
+
     def sample_decode_on_device(
         self,
         tt_logits,
         sampling_params,
         start_pos=None,
-        reset_inputs=False,
-        reset_batch=False,
         prompt_tokens: torch.Tensor | None = None,
         output_tokens: torch.Tensor | None = None,
         slot_remap=None,
         enable_trace=False,
+        *,
+        reload_sampling_params: bool,
+        reset_sampling_state: bool,
     ):
         tt_out_tok = self.trace_inputs_decode[True][0] if enable_trace and self.trace_inputs_decode[True] else None
         sampling_module = self.model.sampling
         seed_manager = sampling_module.seed_manager
+
+        # Keep separated sampling independently usable.
+        self._apply_sampling_slot_remap(slot_remap)
+        sampling_module.validate_decode_state_commands(
+            reload_sampling_params=reload_sampling_params,
+            reset_sampling_state=reset_sampling_state,
+        )
 
         active_seed_slots = None
         if start_pos is not None:
             active_seed_slots = [
                 idx for idx, pos in enumerate(torch.as_tensor(start_pos).reshape(-1).tolist()) if int(pos) >= 0
             ]
-
-        # Apply slot remap from condense before advancing seeds.
-        if slot_remap is not None:
-            sm_bs = seed_manager.max_batch_size
-            rank_remap = slot_remap[0:sm_bs]
-            seed_manager.apply_slot_remap(rank_remap)
-        # Drop seed state of slots no longer live (a request finishing at
-        # the batch tail is never vacated by condense), so its ghost seed
-        # cannot inflate a later request's salt.
+        # A request finishing at the batch tail produces no non-identity
+        # remap, so retire seed state that no longer belongs to a live row.
         if active_seed_slots is not None:
             seed_manager.deactivate_slots_except(active_seed_slots)
-        if reset_inputs and sampling_params is not None:
-            # If we have new inputs, we need to set up the sampling module again
-            sampling_params = format_sampling_params(sampling_params, self.model_args.max_batch_size)
+
+        formatted_sampling_params = sampling_params
+        if reload_sampling_params and sampling_params is None:
+            raise ValueError("Galaxy sampling parameter reload requires sampling_params")
+        if sampling_params is not None and (reload_sampling_params or reset_sampling_state):
+            formatted_sampling_params = format_sampling_params(sampling_params, self.model_args.max_batch_size)
             if active_seed_slots is not None:
-                seed_values = _as_list(getattr(sampling_params, "seed", None))
+                seed_values = _as_list(getattr(formatted_sampling_params, "seed", None))
                 has_active_seed = any(
                     slot < len(seed_values) and seed_values[slot] is not None for slot in active_seed_slots
                 )
                 if has_active_seed:
-                    sampling_params = _fill_inactive_params_from_active(
-                        sampling_params, active_seed_slots, self.model_args.max_batch_size
+                    formatted_sampling_params = _fill_inactive_params_from_active(
+                        formatted_sampling_params, active_seed_slots, self.model_args.max_batch_size
                     )
-            sampling_module.reset_sampling_params(sampling_params)
-            self._remember_slot_params(sampling_params)
-            if reset_batch:
-                sampling_module.reset_prompt_tokens(prompt_tokens)
-                sampling_module.reset_output_state(output_tokens)
+        if reload_sampling_params and formatted_sampling_params is not None:
+            sampling_module.reset_sampling_params(formatted_sampling_params)
+            self._remember_slot_params(formatted_sampling_params)
+        if reset_sampling_state:
+            sampling_module.reset_prompt_tokens(prompt_tokens)
+            sampling_module.reset_output_state(output_tokens)
+        sampling_module.commit_decode_state_commands(
+            reload_sampling_params=reload_sampling_params,
+            reset_sampling_state=reset_sampling_state,
+            sampling_state_slots=None,
+        )
 
-        if sampling_params is not None and (active_seed_slots is None or active_seed_slots):
-            seed_values = getattr(sampling_params, "seed", None)
-            seed_manager.reset_seed_from_slots_if_needed(seed_values, active_seed_slots)
-            if reset_inputs:
+        if formatted_sampling_params is not None and (active_seed_slots is None or active_seed_slots):
+            seed_values = getattr(formatted_sampling_params, "seed", None)
+            if reset_sampling_state:
+                # Reset unconditionally, including seed=None, so decode-only
+                # sampling uploads fresh device seeds for the new state.
+                seed_manager.reset_seed_from_slots(seed_values, active_seed_slots)
                 seed_manager.align_seed_counters_to_positions(seed_values, active_seed_slots, start_pos)
+            elif reload_sampling_params:
+                seed_manager.reset_seed_from_slots_if_needed(seed_values, active_seed_slots)
 
         # Advance seeds after parameter copies so seeded sampling observes
         # one ordered params/seed state for this token.

--- a/models/demos/llama3_70b_galaxy/tt/generator.py
+++ b/models/demos/llama3_70b_galaxy/tt/generator.py
@@ -1511,6 +1511,9 @@ class Generator(WarmupForwardMixin):
             enable_trace = False
         if not enable_trace and not reload_inputs:
             raise ValueError("Non-traced Galaxy decode rebuilds all forward inputs and requires reload_inputs=True")
+        # Separated sampling consumes the same input-authority command as the
+        # forward that produced its logits.
+        self._decode_reload_inputs = reload_inputs
 
         if sampling_params is None and not defer_device_sampling:
             on_device_logits = False
@@ -1558,6 +1561,7 @@ class Generator(WarmupForwardMixin):
                 enable_trace=enable_trace,
                 reload_sampling_params=reload_sampling_params,
                 reset_sampling_state=reset_sampling_state,
+                reload_inputs=reload_inputs,
             )
 
         if read_from_device:
@@ -1901,7 +1905,10 @@ class Generator(WarmupForwardMixin):
         *,
         reload_sampling_params: bool,
         reset_sampling_state: bool,
+        reload_inputs: bool | None = None,
     ):
+        if reload_inputs is None:
+            reload_inputs = self._decode_reload_inputs
         tt_out_tok = self.trace_inputs_decode[True][0] if enable_trace and self.trace_inputs_decode[True] else None
         sampling_module = self.model.sampling
         seed_manager = sampling_module.seed_manager
@@ -1926,7 +1933,7 @@ class Generator(WarmupForwardMixin):
         formatted_sampling_params = sampling_params
         if reload_sampling_params and sampling_params is None:
             raise ValueError("Galaxy sampling parameter reload requires sampling_params")
-        if sampling_params is not None and (reload_sampling_params or reset_sampling_state):
+        if sampling_params is not None and (reload_inputs or reload_sampling_params or reset_sampling_state):
             formatted_sampling_params = format_sampling_params(sampling_params, self.model_args.max_batch_size)
             if active_seed_slots is not None:
                 seed_values = _as_list(getattr(formatted_sampling_params, "seed", None))
@@ -1955,9 +1962,13 @@ class Generator(WarmupForwardMixin):
                 # Reset unconditionally, including seed=None, so decode-only
                 # sampling uploads fresh device seeds for the new state.
                 seed_manager.reset_seed_from_slots(seed_values, active_seed_slots)
-                seed_manager.align_seed_counters_to_positions(seed_values, active_seed_slots, start_pos)
             elif reload_sampling_params:
                 seed_manager.reset_seed_from_slots_if_needed(seed_values, active_seed_slots)
+            if reload_inputs:
+                # A full reload makes host positions authoritative even when
+                # no sampling reset was commanded. Steady async positions lag;
+                # their resident counters must simply advance once per token.
+                seed_manager.align_seed_counters_to_positions(seed_values, active_seed_slots, start_pos)
 
         # Advance seeds after parameter copies so seeded sampling observes
         # one ordered params/seed state for this token.

--- a/models/demos/llama3_70b_galaxy/tt/generator_vllm.py
+++ b/models/demos/llama3_70b_galaxy/tt/generator_vllm.py
@@ -161,6 +161,8 @@ def input_processor_for_qwen_text(ctx, inputs):
 
 # @INPUT_REGISTRY.register_input_processor(input_processor_for_llama_text)
 class LlamaForCausalLM(Generator):
+    decode_input_update_contract = 1
+
     # Class-level capabilities
     model_capabilities = {
         "supports_async_decode": True,
@@ -213,6 +215,8 @@ class LlamaForCausalLM(Generator):
 
 # @INPUT_REGISTRY.register_input_processor(input_processor_for_qwen_text)
 class QwenForCausalLM(Generator):
+    decode_input_update_contract = 1
+
     # Class-level capabilities
     model_capabilities = {
         "supports_sample_on_device": True,

--- a/models/demos/llama3_70b_galaxy/tt/generator_vllm.py
+++ b/models/demos/llama3_70b_galaxy/tt/generator_vllm.py
@@ -162,6 +162,8 @@ def input_processor_for_qwen_text(ctx, inputs):
 
 # @INPUT_REGISTRY.register_input_processor(input_processor_for_llama_text)
 class LlamaForCausalLM(Generator):
+    decode_input_update_contract = 1
+
     # Class-level capabilities
     model_capabilities = {
         "supports_async_decode": True,
@@ -215,6 +217,8 @@ class LlamaForCausalLM(Generator):
 
 # @INPUT_REGISTRY.register_input_processor(input_processor_for_qwen_text)
 class QwenForCausalLM(Generator):
+    decode_input_update_contract = 1
+
     # Class-level capabilities
     model_capabilities = {
         "supports_sample_on_device": True,

--- a/models/demos/multimodal/gemma3/demo/text_demo.py
+++ b/models/demos/multimodal/gemma3/demo/text_demo.py
@@ -1168,6 +1168,10 @@ def test_demo_text(
                 page_table=page_table,
                 kv_cache=tt_kv_cache,
                 sampling_params=device_sampling_params,
+                reload_inputs=iteration == 0 or not enable_trace or device_sampling_params is None,
+                reload_page_table=False,
+                reload_sampling_params=device_sampling_params is not None,
+                reset_sampling_state=device_sampling_params is not None and iteration == 0,
             )
 
             if device_sampling_params is not None:

--- a/models/demos/multimodal/gemma3/demo/text_demo.py
+++ b/models/demos/multimodal/gemma3/demo/text_demo.py
@@ -1132,6 +1132,10 @@ def test_demo_text(
                 page_table=page_table,
                 kv_cache=tt_kv_cache,
                 sampling_params=device_sampling_params,
+                reload_inputs=iteration == 0 or not enable_trace or device_sampling_params is None,
+                reload_page_table=False,
+                reload_sampling_params=device_sampling_params is not None,
+                reset_sampling_state=device_sampling_params is not None and iteration == 0,
             )
 
             if device_sampling_params is not None:

--- a/models/demos/multimodal/gemma3/demo/vision_demo.py
+++ b/models/demos/multimodal/gemma3/demo/vision_demo.py
@@ -451,6 +451,10 @@ def test_multimodal_demo_text(
                             position_id,
                             enable_trace=enable_trace,
                             sampling_params=device_sampling_params,
+                            reload_inputs=gen_idx == 0 or not enable_trace,
+                            reload_page_table=False,
+                            reload_sampling_params=True,
+                            reset_sampling_state=gen_idx == 0,
                         )
                         next_tokens = tok.long().reshape(-1)[:max_batch_size]
                     else:
@@ -458,6 +462,10 @@ def test_multimodal_demo_text(
                             next_token_tensor,
                             position_id,
                             enable_trace=enable_trace,
+                            reload_inputs=True,
+                            reload_page_table=False,
+                            reload_sampling_params=False,
+                            reset_sampling_state=False,
                         )
                         next_tokens, next_texts = sampler(logits)
                     # Update next token

--- a/models/demos/multimodal/gemma3/demo/vision_demo.py
+++ b/models/demos/multimodal/gemma3/demo/vision_demo.py
@@ -419,6 +419,10 @@ def test_multimodal_demo_text(
                             position_id,
                             enable_trace=enable_trace,
                             sampling_params=device_sampling_params,
+                            reload_inputs=gen_idx == 0 or not enable_trace,
+                            reload_page_table=False,
+                            reload_sampling_params=True,
+                            reset_sampling_state=gen_idx == 0,
                         )
                         next_tokens = tok.long().reshape(-1)[:max_batch_size]
                     else:
@@ -426,6 +430,10 @@ def test_multimodal_demo_text(
                             next_token_tensor,
                             position_id,
                             enable_trace=enable_trace,
+                            reload_inputs=True,
+                            reload_page_table=False,
+                            reload_sampling_params=False,
+                            reset_sampling_state=False,
                         )
                         next_tokens, next_texts = sampler(logits)
                     # Update next token

--- a/models/demos/multimodal/lfm25_vl/demo/vision_demo.py
+++ b/models/demos/multimodal/lfm25_vl/demo/vision_demo.py
@@ -306,11 +306,26 @@ def test_multimodal_demo_text(
             next_token_tensor = next_tokens.reshape(max_batch_size, 1)
             if device_sampling_params is not None:
                 tok, _ = generator.decode_forward(
-                    next_token_tensor, position_id, enable_trace=enable_trace, sampling_params=device_sampling_params
+                    next_token_tensor,
+                    position_id,
+                    enable_trace=enable_trace,
+                    sampling_params=device_sampling_params,
+                    reload_inputs=gen_idx == 0 or not enable_trace,
+                    reload_page_table=False,
+                    reload_sampling_params=True,
+                    reset_sampling_state=gen_idx == 0,
                 )
                 next_tokens = tok.long().reshape(-1)[:max_batch_size]
             else:
-                logits, _ = generator.decode_forward(next_token_tensor, position_id, enable_trace=enable_trace)
+                logits, _ = generator.decode_forward(
+                    next_token_tensor,
+                    position_id,
+                    enable_trace=enable_trace,
+                    reload_inputs=True,
+                    reload_page_table=False,
+                    reload_sampling_params=False,
+                    reset_sampling_state=False,
+                )
                 next_tokens, _ = sampler(logits)
             tokens[torch.arange(max_batch_size), position_id + 1] = next_tokens
             if tokenizer.eos_token_id is not None and any(t == tokenizer.eos_token_id for t in next_tokens):

--- a/models/demos/qwen25_vl/demo/demo.py
+++ b/models/demos/qwen25_vl/demo/demo.py
@@ -568,6 +568,12 @@ def test_demo(
                 page_table=page_table,
                 kv_cache=tt_kv_cache,
                 sampling_params=device_sampling_params,
+                # Qwen2.5-VL sampling does not feed the sampled token back into
+                # its traced decode input, so the demo must restage it each step.
+                reload_inputs=True,
+                reload_page_table=False,
+                reload_sampling_params=device_sampling_params is not None,
+                reset_sampling_state=device_sampling_params is not None and iteration == 0,
             )
 
             # Get the next token

--- a/models/demos/qwen25_vl/demo/demo.py
+++ b/models/demos/qwen25_vl/demo/demo.py
@@ -556,6 +556,12 @@ def test_demo(
                 page_table=page_table,
                 kv_cache=tt_kv_cache,
                 sampling_params=device_sampling_params,
+                # Qwen2.5-VL sampling does not feed the sampled token back into
+                # its traced decode input, so the demo must restage it each step.
+                reload_inputs=True,
+                reload_page_table=False,
+                reload_sampling_params=device_sampling_params is not None,
+                reset_sampling_state=device_sampling_params is not None and iteration == 0,
             )
 
             # Get the next token

--- a/models/demos/qwen25_vl/tt/generator.py
+++ b/models/demos/qwen25_vl/tt/generator.py
@@ -103,10 +103,11 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         enable_trace=True,
         read_from_device=True,
         sampling_params=None,
-        reload_inputs: bool | None = None,
-        reload_page_table: bool | None = None,
-        reload_sampling_params: bool | None = None,
-        reset_sampling_state: bool | None = None,
+        *,
+        reload_inputs: bool,
+        reload_page_table: bool,
+        reload_sampling_params: bool,
+        reset_sampling_state: bool,
     ):
         return self._ttt_generator.decode_forward(
             tokens=tokens,

--- a/models/demos/qwen25_vl/tt/generator.py
+++ b/models/demos/qwen25_vl/tt/generator.py
@@ -100,9 +100,7 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         batch_size = rope_setup.batch_size
         indices = torch.as_tensor(slot_remap, dtype=torch.long).reshape(-1)
         if indices.numel() < batch_size:
-            raise ValueError(
-                f"slot_remap has {indices.numel()} entries, expected at least {batch_size}"
-            )
+            raise ValueError(f"slot_remap has {indices.numel()} entries, expected at least {batch_size}")
         indices = indices[:batch_size]
         if torch.any(indices < 0) or torch.any(indices >= batch_size):
             raise ValueError(f"slot_remap entries must be in [0, {batch_size})")

--- a/models/demos/qwen25_vl/tt/generator.py
+++ b/models/demos/qwen25_vl/tt/generator.py
@@ -94,6 +94,18 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         # convert to torch tensor
         self.model.rope_setup.rope_deltas = torch.tensor(rope_deltas_list)
 
+    def remap_rope_deltas(self, slot_remap):
+        """Move persistent per-slot RoPE state after vLLM condenses a batch."""
+        rope_setup = self.model.rope_setup
+        batch_size = rope_setup.batch_size
+        indices = torch.as_tensor(slot_remap, dtype=torch.long).reshape(-1)
+        if indices.numel() < batch_size:
+            raise ValueError(f"slot_remap has {indices.numel()} entries, expected at least {batch_size}")
+        indices = indices[:batch_size]
+        if torch.any(indices < 0) or torch.any(indices >= batch_size):
+            raise ValueError(f"slot_remap entries must be in [0, {batch_size})")
+        rope_setup.rope_deltas = rope_setup.rope_deltas.index_select(0, indices).clone()
+
     def decode_forward(
         self,
         tokens,
@@ -103,7 +115,12 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         enable_trace=True,
         read_from_device=True,
         sampling_params=None,
-        **kwargs,
+        slot_remap=None,
+        *,
+        reload_inputs: bool,
+        reload_page_table: bool,
+        reload_sampling_params: bool,
+        reset_sampling_state: bool,
     ):
         return self._ttt_generator.decode_forward(
             tokens=tokens,
@@ -113,7 +130,11 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
             enable_trace=enable_trace,
             read_from_device=read_from_device,
             sampling_params=sampling_params,
-            **kwargs,
+            slot_remap=slot_remap,
+            reload_inputs=reload_inputs,
+            reload_page_table=reload_page_table,
+            reload_sampling_params=reload_sampling_params,
+            reset_sampling_state=reset_sampling_state,
         )
 
     def __prefill_forward_single_user_text(self, tokens, page_table, user_id, last_token_idx, rot_mats, kv_cache=None):

--- a/models/demos/qwen25_vl/tt/generator.py
+++ b/models/demos/qwen25_vl/tt/generator.py
@@ -94,6 +94,20 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         # convert to torch tensor
         self.model.rope_setup.rope_deltas = torch.tensor(rope_deltas_list)
 
+    def remap_rope_deltas(self, slot_remap):
+        """Move persistent per-slot RoPE state after vLLM condenses a batch."""
+        rope_setup = self.model.rope_setup
+        batch_size = rope_setup.batch_size
+        indices = torch.as_tensor(slot_remap, dtype=torch.long).reshape(-1)
+        if indices.numel() < batch_size:
+            raise ValueError(
+                f"slot_remap has {indices.numel()} entries, expected at least {batch_size}"
+            )
+        indices = indices[:batch_size]
+        if torch.any(indices < 0) or torch.any(indices >= batch_size):
+            raise ValueError(f"slot_remap entries must be in [0, {batch_size})")
+        rope_setup.rope_deltas = rope_setup.rope_deltas.index_select(0, indices).clone()
+
     def decode_forward(
         self,
         tokens,

--- a/models/demos/qwen25_vl/tt/generator.py
+++ b/models/demos/qwen25_vl/tt/generator.py
@@ -103,6 +103,10 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         enable_trace=True,
         read_from_device=True,
         sampling_params=None,
+        reload_inputs: bool | None = None,
+        reload_page_table: bool | None = None,
+        reload_sampling_params: bool | None = None,
+        reset_sampling_state: bool | None = None,
     ):
         return self._ttt_generator.decode_forward(
             tokens=tokens,
@@ -112,6 +116,10 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
             enable_trace=enable_trace,
             read_from_device=read_from_device,
             sampling_params=sampling_params,
+            reload_inputs=reload_inputs,
+            reload_page_table=reload_page_table,
+            reload_sampling_params=reload_sampling_params,
+            reset_sampling_state=reset_sampling_state,
         )
 
     def __prefill_forward_single_user_text(self, tokens, page_table, user_id, last_token_idx, rot_mats, kv_cache=None):

--- a/models/demos/qwen25_vl/tt/generator_vllm.py
+++ b/models/demos/qwen25_vl/tt/generator_vllm.py
@@ -307,7 +307,15 @@ class Qwen2_5_VLForConditionalGeneration(QwenVLGenerator, SupportsMultiModal):
         rope_deltas_list: list = kwargs.pop(
             "rope_deltas_all_users", None
         )  # [INFO] update the cos/sin matrices for the current users in the batch
+        slot_remap = kwargs.pop("slot_remap", None)
         if rope_deltas_list is not None:
+            # This is an authoritative list in the new compacted layout, so a
+            # further remap would apply the move twice.
             super().update_rope_deltas(rope_deltas_list)
+        elif slot_remap is not None:
+            # With no new request, vLLM may only provide the old->new layout
+            # mapping. RoPE deltas are persistent per-slot model state and must
+            # move before decode uses them, including during host sampling.
+            super().remap_rope_deltas(slot_remap)
 
         return super().decode_forward(*args, **kwargs)

--- a/models/demos/qwen25_vl/tt/generator_vllm.py
+++ b/models/demos/qwen25_vl/tt/generator_vllm.py
@@ -114,10 +114,12 @@ class TT_Qwen2_5_VLProcessingInfo(Qwen2_5_VLProcessingInfo):
     dummy_inputs=Qwen2_5_VLDummyInputsBuilder,
 )
 class Qwen2_5_VLForConditionalGeneration(QwenVLGenerator, SupportsMultiModal):
+    decode_input_update_contract = 1
+
     # Class-level capabilities
     model_capabilities = {
         "supports_prefix_caching": False,
-        "supports_async_decode": True,
+        "supports_async_decode": False,
     }
 
     def __init__(self, *args, **kwargs):
@@ -305,7 +307,19 @@ class Qwen2_5_VLForConditionalGeneration(QwenVLGenerator, SupportsMultiModal):
         rope_deltas_list: list = kwargs.pop(
             "rope_deltas_all_users", None
         )  # [INFO] update the cos/sin matrices for the current users in the batch
+        slot_remap = kwargs.pop("slot_remap", None)
         if rope_deltas_list is not None:
+            # This is an authoritative list in the new compacted layout, so a
+            # further remap would apply the move twice.
             super().update_rope_deltas(rope_deltas_list)
+        elif slot_remap is not None:
+            # With no new request, vLLM may only provide the old->new layout
+            # mapping. RoPE deltas are persistent per-slot model state and must
+            # move before decode uses them, including during host sampling.
+            super().remap_rope_deltas(slot_remap)
+        if slot_remap is not None:
+            # RoPE consumes the mapping above, while the shared generator must
+            # independently move dormant/on-device sampling RNG state.
+            kwargs["slot_remap"] = slot_remap
 
         return super().decode_forward(*args, **kwargs)

--- a/models/demos/qwen25_vl/tt/generator_vllm.py
+++ b/models/demos/qwen25_vl/tt/generator_vllm.py
@@ -117,7 +117,7 @@ class Qwen2_5_VLForConditionalGeneration(QwenVLGenerator, SupportsMultiModal):
     # Class-level capabilities
     model_capabilities = {
         "supports_prefix_caching": False,
-        "supports_async_decode": True,
+        "supports_async_decode": False,
     }
 
     def __init__(self, *args, **kwargs):

--- a/models/demos/qwen25_vl/tt/generator_vllm.py
+++ b/models/demos/qwen25_vl/tt/generator_vllm.py
@@ -114,6 +114,8 @@ class TT_Qwen2_5_VLProcessingInfo(Qwen2_5_VLProcessingInfo):
     dummy_inputs=Qwen2_5_VLDummyInputsBuilder,
 )
 class Qwen2_5_VLForConditionalGeneration(QwenVLGenerator, SupportsMultiModal):
+    decode_input_update_contract = 1
+
     # Class-level capabilities
     model_capabilities = {
         "supports_prefix_caching": False,

--- a/models/demos/qwen25_vl/tt/model.py
+++ b/models/demos/qwen25_vl/tt/model.py
@@ -344,11 +344,10 @@ class Transformer(TTTransformer):
     # multi-all-gather sampling pipeline, which is what corrupts at batch-32, rather than
     # the simple single-gather argmax path.
     #
-    # Fix: route greedy decode through the force-argmax path (enabled in __init__ below),
-    # and re-stage the decode trace inputs from host every step + run the sampling op
-    # eagerly so the all-gather re-acquires a fresh multi_device_global_semaphore each
-    # step instead of reusing a stale one frozen into a captured trace.
-    _tt_vllm_always_refresh_decode_trace_inputs = True
+    # Fix: route greedy decode through the force-argmax path (enabled in
+    # __init__ below) and run sampling eagerly so the all-gather re-acquires a
+    # fresh semaphore. The decode token input cannot alias the sampling output.
+    _tt_supports_decode_token_feedback = False
     _tt_disable_sampling_trace = True
 
     def __init__(

--- a/models/demos/qwen3_vl/demo/demo.py
+++ b/models/demos/qwen3_vl/demo/demo.py
@@ -634,6 +634,12 @@ def test_demo(
                 page_table=page_table,
                 kv_cache=tt_kv_cache,
                 sampling_params=device_sampling_params,
+                # Qwen3-VL sampling does not feed the sampled token back into
+                # its traced decode input, so the demo must restage it each step.
+                reload_inputs=True,
+                reload_page_table=False,
+                reload_sampling_params=device_sampling_params is not None,
+                reset_sampling_state=device_sampling_params is not None and iteration == 0,
             )
 
             # Get the next token

--- a/models/demos/qwen3_vl/demo/demo.py
+++ b/models/demos/qwen3_vl/demo/demo.py
@@ -622,6 +622,12 @@ def test_demo(
                 page_table=page_table,
                 kv_cache=tt_kv_cache,
                 sampling_params=device_sampling_params,
+                # Qwen3-VL sampling does not feed the sampled token back into
+                # its traced decode input, so the demo must restage it each step.
+                reload_inputs=True,
+                reload_page_table=False,
+                reload_sampling_params=device_sampling_params is not None,
+                reset_sampling_state=device_sampling_params is not None and iteration == 0,
             )
 
             # Get the next token

--- a/models/demos/qwen3_vl/tt/generator.py
+++ b/models/demos/qwen3_vl/tt/generator.py
@@ -110,9 +110,7 @@ class Generator(WarmupForwardMixin):
         batch_size = rope_setup.batch_size
         indices = torch.as_tensor(slot_remap, dtype=torch.long).reshape(-1)
         if indices.numel() < batch_size:
-            raise ValueError(
-                f"slot_remap has {indices.numel()} entries, expected at least {batch_size}"
-            )
+            raise ValueError(f"slot_remap has {indices.numel()} entries, expected at least {batch_size}")
         indices = indices[:batch_size]
         if torch.any(indices < 0) or torch.any(indices >= batch_size):
             raise ValueError(f"slot_remap entries must be in [0, {batch_size})")

--- a/models/demos/qwen3_vl/tt/generator.py
+++ b/models/demos/qwen3_vl/tt/generator.py
@@ -113,10 +113,11 @@ class Generator(WarmupForwardMixin):
         enable_trace=True,
         read_from_device=True,
         sampling_params=None,
-        reload_inputs: bool | None = None,
-        reload_page_table: bool | None = None,
-        reload_sampling_params: bool | None = None,
-        reset_sampling_state: bool | None = None,
+        *,
+        reload_inputs: bool,
+        reload_page_table: bool,
+        reload_sampling_params: bool,
+        reset_sampling_state: bool,
     ):
         return self._ttt_generator.decode_forward(
             tokens=tokens,

--- a/models/demos/qwen3_vl/tt/generator.py
+++ b/models/demos/qwen3_vl/tt/generator.py
@@ -104,6 +104,18 @@ class Generator(WarmupForwardMixin):
         # convert to torch tensor
         self.model.rope_setup.rope_deltas = torch.tensor(rope_deltas_list)
 
+    def remap_rope_deltas(self, slot_remap):
+        """Move persistent per-slot RoPE state after vLLM condenses a batch."""
+        rope_setup = self.model.rope_setup
+        batch_size = rope_setup.batch_size
+        indices = torch.as_tensor(slot_remap, dtype=torch.long).reshape(-1)
+        if indices.numel() < batch_size:
+            raise ValueError(f"slot_remap has {indices.numel()} entries, expected at least {batch_size}")
+        indices = indices[:batch_size]
+        if torch.any(indices < 0) or torch.any(indices >= batch_size):
+            raise ValueError(f"slot_remap entries must be in [0, {batch_size})")
+        rope_setup.rope_deltas = rope_setup.rope_deltas.index_select(0, indices).clone()
+
     def decode_forward(
         self,
         tokens,
@@ -113,7 +125,12 @@ class Generator(WarmupForwardMixin):
         enable_trace=True,
         read_from_device=True,
         sampling_params=None,
-        **kwargs,
+        slot_remap=None,
+        *,
+        reload_inputs: bool,
+        reload_page_table: bool,
+        reload_sampling_params: bool,
+        reset_sampling_state: bool,
     ):
         return self._ttt_generator.decode_forward(
             tokens=tokens,
@@ -123,7 +140,11 @@ class Generator(WarmupForwardMixin):
             enable_trace=enable_trace,
             read_from_device=read_from_device,
             sampling_params=sampling_params,
-            **kwargs,
+            slot_remap=slot_remap,
+            reload_inputs=reload_inputs,
+            reload_page_table=reload_page_table,
+            reload_sampling_params=reload_sampling_params,
+            reset_sampling_state=reset_sampling_state,
         )
 
     def prefill_forward_single_user_text(

--- a/models/demos/qwen3_vl/tt/generator.py
+++ b/models/demos/qwen3_vl/tt/generator.py
@@ -104,6 +104,20 @@ class Generator(WarmupForwardMixin):
         # convert to torch tensor
         self.model.rope_setup.rope_deltas = torch.tensor(rope_deltas_list)
 
+    def remap_rope_deltas(self, slot_remap):
+        """Move persistent per-slot RoPE state after vLLM condenses a batch."""
+        rope_setup = self.model.rope_setup
+        batch_size = rope_setup.batch_size
+        indices = torch.as_tensor(slot_remap, dtype=torch.long).reshape(-1)
+        if indices.numel() < batch_size:
+            raise ValueError(
+                f"slot_remap has {indices.numel()} entries, expected at least {batch_size}"
+            )
+        indices = indices[:batch_size]
+        if torch.any(indices < 0) or torch.any(indices >= batch_size):
+            raise ValueError(f"slot_remap entries must be in [0, {batch_size})")
+        rope_setup.rope_deltas = rope_setup.rope_deltas.index_select(0, indices).clone()
+
     def decode_forward(
         self,
         tokens,

--- a/models/demos/qwen3_vl/tt/generator.py
+++ b/models/demos/qwen3_vl/tt/generator.py
@@ -113,6 +113,10 @@ class Generator(WarmupForwardMixin):
         enable_trace=True,
         read_from_device=True,
         sampling_params=None,
+        reload_inputs: bool | None = None,
+        reload_page_table: bool | None = None,
+        reload_sampling_params: bool | None = None,
+        reset_sampling_state: bool | None = None,
     ):
         return self._ttt_generator.decode_forward(
             tokens=tokens,
@@ -122,6 +126,10 @@ class Generator(WarmupForwardMixin):
             enable_trace=enable_trace,
             read_from_device=read_from_device,
             sampling_params=sampling_params,
+            reload_inputs=reload_inputs,
+            reload_page_table=reload_page_table,
+            reload_sampling_params=reload_sampling_params,
+            reset_sampling_state=reset_sampling_state,
         )
 
     def prefill_forward_single_user_text(

--- a/models/demos/qwen3_vl/tt/generator_vllm.py
+++ b/models/demos/qwen3_vl/tt/generator_vllm.py
@@ -134,9 +134,11 @@ class TT_Qwen3VLProcessingInfo(Qwen3VLProcessingInfo):
     Qwen3VLMultiModalProcessor, info=TT_Qwen3VLProcessingInfo, dummy_inputs=Qwen3VLDummyInputsBuilder
 )
 class Qwen3VLForConditionalGeneration(QwenVLGenerator, SupportsMultiModal):
+    decode_input_update_contract = 1
+
     model_capabilities = {
         "supports_prefix_caching": False,
-        "supports_async_decode": True,
+        "supports_async_decode": False,
     }
 
     def __init__(self, *args, **kwargs):
@@ -370,7 +372,19 @@ class Qwen3VLForConditionalGeneration(QwenVLGenerator, SupportsMultiModal):
         rope_deltas_list: list = kwargs.pop(
             "rope_deltas_all_users", None
         )  # [INFO] update the cos/sin matrices for the current users in the batch
+        slot_remap = kwargs.pop("slot_remap", None)
         if rope_deltas_list is not None:
+            # This is an authoritative list in the new compacted layout, so a
+            # further remap would apply the move twice.
             super().update_rope_deltas(rope_deltas_list)
+        elif slot_remap is not None:
+            # With no new request, vLLM may only provide the old->new layout
+            # mapping. RoPE deltas are persistent per-slot model state and must
+            # move before decode uses them, including during host sampling.
+            super().remap_rope_deltas(slot_remap)
+        if slot_remap is not None:
+            # RoPE consumes the mapping above, while the shared generator must
+            # independently move dormant/on-device sampling RNG state.
+            kwargs["slot_remap"] = slot_remap
 
         return super().decode_forward(*args, **kwargs)

--- a/models/demos/qwen3_vl/tt/generator_vllm.py
+++ b/models/demos/qwen3_vl/tt/generator_vllm.py
@@ -136,7 +136,7 @@ class TT_Qwen3VLProcessingInfo(Qwen3VLProcessingInfo):
 class Qwen3VLForConditionalGeneration(QwenVLGenerator, SupportsMultiModal):
     model_capabilities = {
         "supports_prefix_caching": False,
-        "supports_async_decode": True,
+        "supports_async_decode": False,
     }
 
     def __init__(self, *args, **kwargs):

--- a/models/demos/qwen3_vl/tt/generator_vllm.py
+++ b/models/demos/qwen3_vl/tt/generator_vllm.py
@@ -134,6 +134,8 @@ class TT_Qwen3VLProcessingInfo(Qwen3VLProcessingInfo):
     Qwen3VLMultiModalProcessor, info=TT_Qwen3VLProcessingInfo, dummy_inputs=Qwen3VLDummyInputsBuilder
 )
 class Qwen3VLForConditionalGeneration(QwenVLGenerator, SupportsMultiModal):
+    decode_input_update_contract = 1
+
     model_capabilities = {
         "supports_prefix_caching": False,
         "supports_async_decode": False,

--- a/models/demos/qwen3_vl/tt/generator_vllm.py
+++ b/models/demos/qwen3_vl/tt/generator_vllm.py
@@ -372,7 +372,15 @@ class Qwen3VLForConditionalGeneration(QwenVLGenerator, SupportsMultiModal):
         rope_deltas_list: list = kwargs.pop(
             "rope_deltas_all_users", None
         )  # [INFO] update the cos/sin matrices for the current users in the batch
+        slot_remap = kwargs.pop("slot_remap", None)
         if rope_deltas_list is not None:
+            # This is an authoritative list in the new compacted layout, so a
+            # further remap would apply the move twice.
             super().update_rope_deltas(rope_deltas_list)
+        elif slot_remap is not None:
+            # With no new request, vLLM may only provide the old->new layout
+            # mapping. RoPE deltas are persistent per-slot model state and must
+            # move before decode uses them, including during host sampling.
+            super().remap_rope_deltas(slot_remap)
 
         return super().decode_forward(*args, **kwargs)

--- a/models/demos/qwen3_vl/tt/model.py
+++ b/models/demos/qwen3_vl/tt/model.py
@@ -465,11 +465,10 @@ class Transformer(TTTransformer):
     # multi-all-gather sampling pipeline, which is what corrupts at batch-32, rather than
     # the simple single-gather argmax path.
     #
-    # Fix: route greedy decode through the force-argmax path (enabled in __init__ below),
-    # and re-stage the decode trace inputs from host every step + run the sampling op
-    # eagerly so the all-gather re-acquires a fresh multi_device_global_semaphore each
-    # step instead of reusing a stale one frozen into a captured trace.
-    _tt_vllm_always_refresh_decode_trace_inputs = True
+    # Fix: route greedy decode through the force-argmax path (enabled in
+    # __init__ below) and run sampling eagerly so the all-gather re-acquires a
+    # fresh semaphore. The decode token input cannot alias the sampling output.
+    _tt_supports_decode_token_feedback = False
     _tt_disable_sampling_trace = True
 
     def __init__(

--- a/models/demos/t3000/llama2_70b/tt/generator_vllm.py
+++ b/models/demos/t3000/llama2_70b/tt/generator_vllm.py
@@ -71,6 +71,27 @@ class TtLlamaForCausalLM(TtLlamaModelForGeneration):
     def prefill_forward(self, tokens: torch.Tensor, page_table, kv_cache, prompt_lens):
         return super().prefill_forward(tokens, 0, page_table, kv_cache, prompt_lens)
 
+    def decode_forward(
+        self,
+        *args,
+        reload_inputs: bool,
+        reload_page_table: bool,
+        reload_sampling_params: bool,
+        reset_sampling_state: bool,
+        **kwargs,
+    ):
+        if (
+            not reload_inputs
+            or reload_page_table
+            or reload_sampling_params
+            or reset_sampling_state
+        ):
+            raise ValueError(
+                "T3000 Llama requires a full host-input reload and has no "
+                "device sampling state"
+            )
+        return super().decode_forward(*args, **kwargs)
+
     def allocate_kv_cache(self, kv_cache_shape, dtype, num_layers):
         cache_kv = torch.zeros(kv_cache_shape, dtype=dtype)
         kv_tt = []

--- a/models/demos/t3000/llama2_70b/tt/generator_vllm.py
+++ b/models/demos/t3000/llama2_70b/tt/generator_vllm.py
@@ -16,6 +16,8 @@ from models.demos.t3000.llama2_70b.tt.llama_generation import TtLlamaModelForGen
 
 
 class TtLlamaForCausalLM(TtLlamaModelForGeneration):
+    decode_input_update_contract = 1
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 

--- a/models/demos/t3000/llama2_70b/tt/generator_vllm.py
+++ b/models/demos/t3000/llama2_70b/tt/generator_vllm.py
@@ -80,10 +80,15 @@ class TtLlamaForCausalLM(TtLlamaModelForGeneration):
         reload_page_table: bool,
         reload_sampling_params: bool,
         reset_sampling_state: bool,
+        slot_remap=None,
         **kwargs,
     ):
         if not reload_inputs or reload_page_table or reload_sampling_params or reset_sampling_state:
             raise ValueError("T3000 Llama requires a full host-input reload and has no " "device sampling state")
+        # This host-only adapter has no persistent model state keyed by vLLM's
+        # condensed batch slots. Contract v1 still delivers the layout remap on
+        # every decode so stateful adapters can consume it; accepting and
+        # ignoring it here is therefore intentional.
         return super().decode_forward(*args, **kwargs)
 
     def allocate_kv_cache(self, kv_cache_shape, dtype, num_layers):

--- a/models/demos/t3000/llama2_70b/tt/generator_vllm.py
+++ b/models/demos/t3000/llama2_70b/tt/generator_vllm.py
@@ -80,16 +80,8 @@ class TtLlamaForCausalLM(TtLlamaModelForGeneration):
         reset_sampling_state: bool,
         **kwargs,
     ):
-        if (
-            not reload_inputs
-            or reload_page_table
-            or reload_sampling_params
-            or reset_sampling_state
-        ):
-            raise ValueError(
-                "T3000 Llama requires a full host-input reload and has no "
-                "device sampling state"
-            )
+        if not reload_inputs or reload_page_table or reload_sampling_params or reset_sampling_state:
+            raise ValueError("T3000 Llama requires a full host-input reload and has no " "device sampling state")
         return super().decode_forward(*args, **kwargs)
 
     def allocate_kv_cache(self, kv_cache_shape, dtype, num_layers):

--- a/models/experimental/mistral_24b/tests/pipeline_tests/test_end2end.py
+++ b/models/experimental/mistral_24b/tests/pipeline_tests/test_end2end.py
@@ -309,6 +309,10 @@ def run_generation_exactly_like_test_end2end(
             enable_trace=False,
             page_table=page_table,
             kv_cache=tt_kv_cache,
+            reload_inputs=True,
+            reload_page_table=False,
+            reload_sampling_params=False,
+            reset_sampling_state=False,
         )
 
         # decode_forward returns (logits, log_probs) tuple when read_from_device=True

--- a/models/experimental/openvla/tt/open_vla.py
+++ b/models/experimental/openvla/tt/open_vla.py
@@ -535,6 +535,10 @@ class OpenVLALanguageModel(GenerationMixin):
                 page_table=self.page_table,
                 kv_cache=self.tt_kv_cache,
                 sampling_params=device_sampling_params,
+                reload_inputs=True,
+                reload_page_table=False,
+                reload_sampling_params=False,
+                reset_sampling_state=False,
             )
             # decode_forward returns (logits, log_probs) tuple
             logits = decode_output[0] if isinstance(decode_output, tuple) else decode_output
@@ -702,6 +706,10 @@ class OpenVLALanguageModel(GenerationMixin):
                 kv_cache=[self.tt_kv_cache[0]],
                 sampling_params=None,
                 enable_trace=False,
+                reload_inputs=True,
+                reload_page_table=False,
+                reload_sampling_params=False,
+                reset_sampling_state=False,
             )
             # decode_forward returns (logits, log_probs) tuple
             logits = decode_output[0] if isinstance(decode_output, tuple) else decode_output

--- a/models/experimental/ops/quasar/gpt_oss/demo/text_demo.py
+++ b/models/experimental/ops/quasar/gpt_oss/demo/text_demo.py
@@ -902,6 +902,7 @@ def test_gpt_oss_demo(
             # Decode forward — on-device sampling when available, host-side
             # greedy argmax otherwise (1×1 Blackhole, etc.)
             if on_device_sampling_supported:
+                reload_decode_inputs = iteration == 0 or not enable_decode_trace
                 out_tok, _ = generator.decode_forward(
                     out_tok,
                     current_pos,
@@ -909,6 +910,10 @@ def test_gpt_oss_demo(
                     page_table=page_table,
                     kv_cache=tt_kv_cache,
                     sampling_params=device_sampling_params,
+                    reload_inputs=reload_decode_inputs,
+                    reload_page_table=False,
+                    reload_sampling_params=True,
+                    reset_sampling_state=iteration == 0,
                 )
             else:
                 # decode_forward returns (logits, log_probs) when sampling_params=None.
@@ -919,6 +924,10 @@ def test_gpt_oss_demo(
                     page_table=page_table,
                     kv_cache=tt_kv_cache,
                     sampling_params=None,
+                    reload_inputs=True,
+                    reload_page_table=False,
+                    reload_sampling_params=False,
+                    reset_sampling_state=False,
                 )
                 out_tok = torch.argmax(logits, dim=-1).view(-1)
 

--- a/models/experimental/ops/quasar/gpt_oss/tests/accuracy/test_model.py
+++ b/models/experimental/ops/quasar/gpt_oss/tests/accuracy/test_model.py
@@ -110,6 +110,10 @@ def run_accuracy(
                 enable_trace=False,  # enable_trace
                 page_table=None,  # page_table
                 kv_cache=tt_kv_cache,  # kv_cache
+                reload_inputs=True,
+                reload_page_table=False,
+                reload_sampling_params=False,
+                reset_sampling_state=False,
             )
 
         # Get predicted token

--- a/models/experimental/ops/quasar/qwen3_vl/demo/demo.py
+++ b/models/experimental/ops/quasar/qwen3_vl/demo/demo.py
@@ -634,6 +634,12 @@ def test_demo(
                 page_table=page_table,
                 kv_cache=tt_kv_cache,
                 sampling_params=device_sampling_params,
+                # Qwen3-VL does not feed sampling output into the traced token
+                # input, so the demo supplies the current token every step.
+                reload_inputs=True,
+                reload_page_table=False,
+                reload_sampling_params=device_sampling_params is not None,
+                reset_sampling_state=device_sampling_params is not None and iteration == 0,
             )
 
             # Get the next token

--- a/models/experimental/ops/quasar/qwen3_vl/tt/model.py
+++ b/models/experimental/ops/quasar/qwen3_vl/tt/model.py
@@ -495,6 +495,7 @@ class Transformer(TTTransformer):
     # eagerly so the all-gather re-acquires a fresh multi_device_global_semaphore each
     # step instead of reusing a stale one frozen into a captured trace.
     _tt_vllm_always_refresh_decode_trace_inputs = True
+    _tt_supports_decode_token_feedback = False
     _tt_disable_sampling_trace = True
 
     def __init__(

--- a/models/tt_transformers/demo/simple_text_demo.py
+++ b/models/tt_transformers/demo/simple_text_demo.py
@@ -1186,7 +1186,6 @@ def test_demo_text(
                     k_cache, v_cache = layer.attention.layer_past
                     k_cache = ttnn.mul(k_cache, 0, output_tensor=k_cache)
                     v_cache = ttnn.mul(v_cache, 0, output_tensor=v_cache)
-            generator.prev_page_table = None
 
         input_tokens_prefill_pt = torch.stack(input_tokens_prefill_pt).view(global_batch_size, -1)
         # Use device sampling for all cases when supported (prefill + decode)
@@ -1304,16 +1303,20 @@ def test_demo_text(
                 out_tok[0] = token_acc.collect_predicted_tokens(out_tok[0].item())
 
             # Run decode forward
+            reload_decode_inputs = iteration == 0 or not enable_trace or device_sampling_params is None
             logits, log_probs = generator.decode_forward(
                 out_tok,
                 current_pos,
                 enable_trace=enable_trace,
                 page_table=page_table,
                 kv_cache=tt_kv_cache,
-                reset_batch=(iteration == 0),
                 sampling_params=device_sampling_params,
                 prompt_tokens=input_tokens_prefill_pt,
                 output_tokens=out_tok,
+                reload_inputs=reload_decode_inputs,
+                reload_page_table=False,
+                reload_sampling_params=device_sampling_params is not None,
+                reset_sampling_state=device_sampling_params is not None and iteration == 0,
             )
 
             # Get the next token

--- a/models/tt_transformers/demo/simple_text_demo.py
+++ b/models/tt_transformers/demo/simple_text_demo.py
@@ -1178,7 +1178,6 @@ def test_demo_text(
                     k_cache, v_cache = layer.attention.layer_past
                     k_cache = ttnn.mul(k_cache, 0, output_tensor=k_cache)
                     v_cache = ttnn.mul(v_cache, 0, output_tensor=v_cache)
-            generator.prev_page_table = None
 
         input_tokens_prefill_pt = torch.stack(input_tokens_prefill_pt).view(global_batch_size, -1)
         # Use device sampling for all cases when supported (prefill + decode)
@@ -1301,16 +1300,20 @@ def test_demo_text(
                 out_tok[0] = token_acc.collect_predicted_tokens(out_tok[0].item())
 
             # Run decode forward
+            reload_decode_inputs = iteration == 0 or not enable_trace or device_sampling_params is None
             logits, log_probs = generator.decode_forward(
                 out_tok,
                 current_pos,
                 enable_trace=enable_trace,
                 page_table=page_table,
                 kv_cache=tt_kv_cache,
-                reset_batch=(iteration == 0),
                 sampling_params=device_sampling_params,
                 prompt_tokens=input_tokens_prefill_pt,
                 output_tokens=out_tok,
+                reload_inputs=reload_decode_inputs,
+                reload_page_table=False,
+                reload_sampling_params=device_sampling_params is not None,
+                reset_sampling_state=device_sampling_params is not None and iteration == 0,
             )
 
             # Get the next token

--- a/models/tt_transformers/demo/simple_vision_demo.py
+++ b/models/tt_transformers/demo/simple_vision_demo.py
@@ -504,6 +504,10 @@ def test_multimodal_demo_text(
                             page_table=None,
                             kv_cache=None,
                             enable_trace=enable_trace,
+                            reload_inputs=True,
+                            reload_page_table=False,
+                            reload_sampling_params=False,
+                            reset_sampling_state=False,
                         )
                     else:
                         logits = generator.decode_forward_llama_vision(

--- a/models/tt_transformers/demo/simple_vision_demo.py
+++ b/models/tt_transformers/demo/simple_vision_demo.py
@@ -514,6 +514,10 @@ def test_multimodal_demo_text(
                             page_table=None,
                             kv_cache=None,
                             enable_trace=enable_trace,
+                            reload_inputs=True,
+                            reload_page_table=False,
+                            reload_sampling_params=False,
+                            reset_sampling_state=False,
                         )
                     else:
                         logits = generator.decode_forward_llama_vision(

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -1318,7 +1318,16 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         # Host sampling
         if read_from_device:
             to_host = self.read_decode_output(tt_decode_output)
-            return self.process_decode_output_host(to_host, is_tokens=(sampling_params is not None))
+            output = self.process_decode_output_host(to_host, is_tokens=(sampling_params is not None))
+            if sampling_params is None:
+                # Host sampling does not invoke the device sampler, but its
+                # dormant per-slot state must still follow the new layout.
+                # Apply only after decode/readback succeeds so a failed call
+                # can be retried with the still-pending, non-idempotent remap.
+                self._apply_sampling_slot_remap(slot_remap)
+            return output
+        if sampling_params is None:
+            self._apply_sampling_slot_remap(slot_remap)
         return tt_decode_output
 
     def _decode_forward_no_trace_text(
@@ -1506,6 +1515,17 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
             ttnn.execute_trace(self.model_args[i].mesh_device, trace_id, cq_id=0, blocking=False)
         return self.trace_output_decode[on_device_sampling]
 
+    def _apply_sampling_slot_remap(self, slot_remap) -> None:
+        if slot_remap is None:
+            return
+        for i in range(self.data_parallel):
+            sampling_module = getattr(self.model[i], "sampling", None)
+            if sampling_module is None:
+                continue
+            sm_bs = sampling_module.seed_manager.max_batch_size
+            rank_remap = slot_remap[i * sm_bs : (i + 1) * sm_bs]
+            sampling_module.seed_manager.apply_slot_remap(rank_remap)
+
     def sample_decode_on_device(
         self,
         tt_logits,
@@ -1519,6 +1539,9 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         reload_sampling_params: bool,
         reset_sampling_state: bool,
     ):
+        # Keep this entry point independently usable by immediate and
+        # separated-sampling callers.
+        self._apply_sampling_slot_remap(slot_remap)
         # sampling_dp may differ from data_parallel for models that internally
         # shard users across mesh rows (users_row_sharded) — each row samples
         # 32 users independently, so sampling params must be chunked by the
@@ -1559,12 +1582,6 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                 else None
             )
 
-            # Reindex continuing per-slot state before params/history are
-            # refreshed for the new layout.
-            if slot_remap is not None:
-                sm_bs = sampling_module.seed_manager.max_batch_size
-                rank_remap = slot_remap[i * sm_bs : (i + 1) * sm_bs]
-                sampling_module.seed_manager.apply_slot_remap(rank_remap)
             sampling_module.apply_decode_state(
                 model_chunks,
                 reload_sampling_params=reload_sampling_params,

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -1774,9 +1774,10 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                         s = format_sampling_params(chunk, seed_bs).seed
                         seed_values += s if isinstance(s, list) else [s] * seed_bs
                 if reset_sampling_state:
-                    # A layout/mode transition reinitializes every active slot,
-                    # including unseeded requests reusing an identity slot.
-                    sampling_module.seed_manager.reset_decode_batch(
+                    # A state reset is unconditional even for seed=None:
+                    # reset_if_needed would see None == None and skip the
+                    # fresh device-seed upload in decode-only sampling mode.
+                    sampling_module.seed_manager.reset_seed_from_slots(
                         seed_values, active_seed_slots
                     )
                     sampling_module.seed_manager.align_seed_counters_to_positions(

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -24,7 +24,6 @@ from models.common.sampling import (
     broadcast_sampling_params,
     chunk_sampling_params,
     format_sampling_params,
-    should_align_decode_seed_counters,
 )
 from models.common.sampling.tt_log_probs import LogProbsResult, reformat_logprobs
 from models.common.warmup import WarmupForwardMixin
@@ -92,7 +91,6 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         self.processor = processor
         self.tokenizer = tokenizer
         self.data_parallel = len(self.model)
-        self.prev_page_table = None
         self.trace_id_prefill = defaultdict(lambda: None)
         self.trace_inputs_prefill = defaultdict(lambda: None)
         self.trace_output_prefill = defaultdict(lambda: None)
@@ -547,15 +545,6 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         else:
             # Only paged attention is supported for prefill
             enable_trace = False
-
-        # Track slots refreshed by this prefill so the next decode reset keeps
-        # device-fed tokens for all other slots (their host token is one step
-        # stale under vLLM async scheduling).
-        if not hasattr(self, "_slots_prefilled_since_decode"):
-            self._slots_prefilled_since_decode = set()
-        self._slots_prefilled_since_decode.update(
-            range(tokens.shape[0]) if empty_slots is None else [int(s) for s in empty_slots]
-        )
 
         on_device_sampling_requested = sampling_params is not None
 
@@ -1265,127 +1254,31 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         enable_trace=True,
         read_from_device=True,
         sampling_params: SamplingParams = None,  # Should be None if not greedy decoding / sampling on device.
-        reset_batch=False,
         prompt_tokens: torch.Tensor | None = None,
         output_tokens: torch.Tensor | None = None,
         slot_remap=None,
         defer_device_sampling: bool = False,
-        reload_inputs: bool | None = None,
-        reload_page_table: bool | None = None,
-        reload_sampling_params: bool | None = None,
-        reset_sampling_state: bool | None = None,
+        *,
+        reload_inputs: bool,
+        reload_page_table: bool,
+        reload_sampling_params: bool,
+        reset_sampling_state: bool,
         **kwargs,
     ):
-        mode_switched = False
         if self.mode != Mode.DECODE:
             self.mode = Mode.DECODE
-            mode_switched = True
 
         # Switch to decode mode for prefetcher to reintialize sub devices
         for i in range(len(self.model)):
             self.model[i].switch_mode(Mode.DECODE)
 
         on_device_sampling = (sampling_params is not None) or defer_device_sampling
-        contract_flags = (
-            reload_inputs,
-            reload_page_table,
-            reload_sampling_params,
-            reset_sampling_state,
-        )
-        explicit_contract = any(flag is not None for flag in contract_flags)
-        if explicit_contract and not all(flag is not None for flag in contract_flags):
-            raise ValueError(
-                "decode update contract requires reload_inputs, "
-                "reload_page_table, reload_sampling_params, and "
-                "reset_sampling_state together"
-            )
-        B = tokens.shape[0]
+        if not enable_trace and not reload_inputs:
+            raise ValueError("Non-traced decode rebuilds all forward inputs and requires reload_inputs=True")
 
         tokens = torch.chunk(tokens, self.data_parallel, 0)
         start_pos = torch.chunk(start_pos, self.data_parallel, 0)
         page_table = torch.chunk(page_table, self.data_parallel, 0) if page_table is not None else None
-
-        # vLLM under async scheduling supplies a one-step-stale last token at
-        # reset steps (its host state lags device sampling). The device token
-        # buffer holds the authoritative token sampled at the previous decode
-        # step, so on a reset keep it: permute per slot_remap (condense moves),
-        # only taking host tokens for slots freshly prefilled since the last
-        # decode submit (their last token came from prefill, not decode).
-        if (
-            not explicit_contract
-            and
-            on_device_sampling
-            and (reset_batch or mode_switched)
-            and enable_trace
-            and self.trace_inputs_decode[on_device_sampling]
-        ):
-            new_tokens = []
-            new_start_pos = []
-            # When we take the device's async-ahead token for a continuing slot,
-            # the token sits at position dev_pos; staging the lagging host position
-            # (=dev_pos-1) would re-process that token at the wrong position
-            # (overwriting KV / regenerating a position -> duplicate/flipped tokens
-            # under concurrency). Pair the device token with the device position.
-            for i, tok_chunk in enumerate(tokens):
-                trace_in = self.trace_inputs_decode[on_device_sampling][i]
-                dev_toks = (
-                    ttnn.to_torch(ttnn.get_device_tensors(trace_in[0])[0])
-                    .reshape(-1)[: tok_chunk.shape[0]]
-                    .to(tok_chunk.dtype)
-                )
-                dev_pos = (
-                    ttnn.to_torch(ttnn.get_device_tensors(trace_in[1])[0])
-                    .reshape(-1)[: tok_chunk.shape[0]]
-                    .to(torch.int64)
-                )
-                if slot_remap is not None:
-                    chunk = dev_toks.shape[0]
-                    remap = slot_remap[i * chunk : (i + 1) * chunk]
-                    remap_t = (remap if isinstance(remap, torch.Tensor) else torch.tensor(remap)).long()
-                    # slot_remap holds GLOBAL slot indices: the vLLM plugin offsets
-                    # each DP rank's local [0,B) remap by rank*B for the row-sharded
-                    # SeedManager. dev_toks/dev_pos are this rank's *local* size-B
-                    # tensors, so rebase the global indices back to [0,B) before
-                    # gathering -- otherwise rank i>=1 indexes past the end (e.g.
-                    # value 32 into a size-32 tensor).
-                    remap_t = remap_t - i * chunk
-                    dev_toks = dev_toks[remap_t]
-                    dev_pos = dev_pos[remap_t]
-                # The device token is authoritative only for slots whose device
-                # position chain is continuous with the host view; slots that
-                # were re-added, resumed, or freshly prefilled take host tokens.
-                # The host position itself may lag the device by one step under
-                # async scheduling, so accept both.
-                host_pos = start_pos[i].reshape(-1).to(torch.int64)
-                # The device token/position buffers are read from a single device
-                # shard (get_device_tensors(...)[0]). That holds the full per-chunk
-                # batch only when the decode inputs are replicated across the mesh
-                # (e.g. Llama-3.1-8B, which this async-ahead keep was designed for).
-                # Models that shard the decode batch across mesh devices
-                # (users_row_sharded, e.g. GPT-OSS) expose only B/num_shards entries
-                # on shard 0, so dev_toks/dev_pos are shorter than the full host
-                # chunk. Reconstructing the full batch needs the model's mesh layout,
-                # which the shared generator doesn't have; rather than crash on the
-                # mismatched comparison, fall back to the host-provided tokens and
-                # positions for this chunk (the pre-fix behaviour).
-                if dev_pos.shape[0] != host_pos.shape[0] or dev_toks.shape[0] != tok_chunk.reshape(-1).shape[0]:
-                    new_tokens.append(tok_chunk)
-                    new_start_pos.append(start_pos[i])
-                    continue
-                use_dev = (dev_pos == host_pos) | (dev_pos == host_pos + 1)
-                prefilled = getattr(self, "_slots_prefilled_since_decode", None)
-                if prefilled:
-                    bs = tok_chunk.shape[0]
-                    for slot in prefilled:
-                        if i * bs <= slot < (i + 1) * bs:
-                            use_dev[slot - i * bs] = False
-                merged = torch.where(use_dev, dev_toks.view(-1), tok_chunk.view(-1)).view(tok_chunk.shape)
-                new_tokens.append(merged.to(tok_chunk.dtype))
-                merged_pos = torch.where(use_dev, dev_pos, host_pos)
-                new_start_pos.append(merged_pos.view(start_pos[i].shape).to(start_pos[i].dtype))
-            tokens = new_tokens
-            start_pos = new_start_pos
-        self._slots_prefilled_since_decode = set()
 
         decode_kwargs = {
             "current_pos": start_pos,
@@ -1396,12 +1289,8 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         }
 
         if enable_trace:
-            # A real batch reset / slot remap (reset_batch) also makes the device
-            # token/current_pos trace buffers stale, not just a prefill->decode
-            # mode switch, so both must force a full traced-input reset.
             tt_decode_output = self._decode_forward_trace_text(
                 **decode_kwargs,
-                reset_batch=reset_batch or mode_switched,
                 reload_inputs=reload_inputs,
                 reload_page_table=reload_page_table,
             )
@@ -1419,28 +1308,12 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                 tt_decode_output,
                 sampling_params=sampling_params,
                 start_pos=start_pos,
-                reset_batch=reset_batch,
                 prompt_tokens=prompt_tokens,
                 output_tokens=output_tokens,
                 slot_remap=slot_remap,
                 enable_trace=enable_trace,
-                reload_sampling_params=(
-                    bool(reload_sampling_params)
-                    if explicit_contract
-                    else True
-                ),
-                reset_sampling_state=(
-                    bool(reset_sampling_state)
-                    if explicit_contract
-                    else reset_batch
-                ),
-                align_seed_counters=should_align_decode_seed_counters(
-                    explicit_contract=explicit_contract,
-                    reset_sampling_state=bool(reset_sampling_state),
-                    # This generator historically aligned active seeded slots
-                    # on every legacy decode.
-                    legacy_alignment=True,
-                ),
+                reload_sampling_params=reload_sampling_params,
+                reset_sampling_state=reset_sampling_state,
             )
         # Host sampling
         if read_from_device:
@@ -1572,12 +1445,10 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                 # this traces only for the current ones.
                 # tt_out_tok feeds the sampled token back into the decode token
                 # buffer (device_inputs[0]) for the next traced step. Only do this
-                # for models that rely on on-device token feedback. Models that
-                # re-stage decode inputs from host every step (e.g. gemma4, via
-                # _tt_vllm_always_refresh_decode_trace_inputs) don't, and their
-                # token buffer is not shaped as a sampling output (gemma4's is
-                # rank-2; ttnn.sampling requires a rank-4 preallocated output) —
-                # pass None so sampling allocates its own output.
+                # for models that rely on on-device token feedback. Some token
+                # input buffers are not shaped as sampling outputs (gemma4's is
+                # rank-2; ttnn.sampling requires a rank-4 preallocated output),
+                # so those models opt out and sampling allocates its own output.
                 tt_out_tok = self._decode_token_feedback_buffer(self.model[i], device_inputs[i])
                 sampling_module.capture_trace(logits=tt_out_trace[i], tt_out_tok=tt_out_tok)
         logger.info("Done Capturing Decode Trace")
@@ -1591,9 +1462,9 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         page_table=None,
         kv_cache=None,
         on_device_sampling=False,
-        reset_batch=False,
-        reload_inputs: bool | None = None,
-        reload_page_table: bool | None = None,
+        *,
+        reload_inputs: bool,
+        reload_page_table: bool,
     ):
         """
         Run decode forward text with tracing
@@ -1607,49 +1478,10 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
             self.trace_inputs_decode[on_device_sampling] = device_inputs
             self.trace_output_decode[on_device_sampling] = tt_out_trace
 
-        explicit_contract = (
-            reload_inputs is not None or reload_page_table is not None
-        )
-        if explicit_contract:
-            if reload_inputs is None or reload_page_table is None:
-                raise ValueError(
-                    "reload_inputs and reload_page_table must be provided together"
-                )
-            reset_inputs = reload_inputs
-            page_table_changed = reload_page_table
-        else:
-            # Legacy callers retain the previous generator-local policy.
-            prev_on_device_sampling = getattr(
-                self, "_prev_on_device_sampling", None
-            )
-            self._prev_on_device_sampling = on_device_sampling
-            sampling_mode_changed = (
-                prev_on_device_sampling is not None
-                and prev_on_device_sampling != on_device_sampling
-            )
-            reset_inputs = (
-                reset_batch or not on_device_sampling or sampling_mode_changed
-            )
-            page_table_changed = page_table is not None and (
-                self.prev_page_table is None
-                or any(
-                    not torch.equal(prev, curr)
-                    for prev, curr in zip(self.prev_page_table, page_table)
-                )
-            )
-
         for i in range(self.data_parallel):
-            refresh_trace_inputs = reset_inputs or (
-                not explicit_contract
-                and getattr(
-                    self.model[i],
-                    "_tt_vllm_always_refresh_decode_trace_inputs",
-                    False,
-                )
-            )
             user_page_table = page_table[i] if page_table is not None else None
 
-            if refresh_trace_inputs:
+            if reload_inputs:
                 # Full resets are required when host token/position inputs are
                 # authoritative again, or for models that explicitly opt out of
                 # partial decode trace input refreshes.
@@ -1658,7 +1490,7 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                     host_tensors=host_inputs_i,
                     device_tensors=self.trace_inputs_decode[on_device_sampling][i],
                 )
-            elif page_table_changed:
+            elif reload_page_table:
                 # With async device sampling, token/position inputs may
                 # intentionally be stale on host: the previous decode updates
                 # them on device. Page tables still need refreshing when new KV
@@ -1670,8 +1502,6 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                 if host_page_table is not None:
                     ttnn.copy_host_to_device_tensor(host_page_table, device_page_table)
 
-        if page_table_changed:
-            self.prev_page_table = tuple(pt.clone() for pt in page_table)
         for i, trace_id in self.trace_ids_decode[on_device_sampling].items():
             ttnn.execute_trace(self.model_args[i].mesh_device, trace_id, cq_id=0, blocking=False)
         return self.trace_output_decode[on_device_sampling]
@@ -1681,20 +1511,14 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         tt_logits,
         sampling_params,
         start_pos=None,
-        reset_batch=False,
         prompt_tokens: torch.Tensor | None = None,
         output_tokens: torch.Tensor | None = None,
         slot_remap=None,
         enable_trace=False,
-        reload_sampling_params: bool = True,
-        reset_sampling_state: bool | None = None,
-        align_seed_counters: bool | None = None,
+        *,
+        reload_sampling_params: bool,
+        reset_sampling_state: bool,
     ):
-        if reset_sampling_state is None:
-            reset_sampling_state = reset_batch
-        if align_seed_counters is None:
-            # Direct callers without explicit flags retain legacy behavior.
-            align_seed_counters = True
         # sampling_dp may differ from data_parallel for models that internally
         # shard users across mesh rows (users_row_sharded) — each row samples
         # 32 users independently, so sampling params must be chunked by the
@@ -1762,9 +1586,7 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
             # flow). Position alignment then keeps the stream reproducible even
             # when vLLM evicts a running request and re-admits it in a different
             # slot under async scheduling. Mirrors the llama3_70b_galaxy decode path.
-            if active_seed_slots is not None and (
-                reload_sampling_params or reset_sampling_state
-            ):
+            if active_seed_slots is not None and (reload_sampling_params or reset_sampling_state):
                 seed_bs = sampling_module.tt_sampling.max_batch_size
                 if len(model_chunks) == 1:
                     seed_values = format_sampling_params(model_chunks[0], seed_bs).seed
@@ -1777,20 +1599,12 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                     # A state reset is unconditional even for seed=None:
                     # reset_if_needed would see None == None and skip the
                     # fresh device-seed upload in decode-only sampling mode.
-                    sampling_module.seed_manager.reset_seed_from_slots(
-                        seed_values, active_seed_slots
-                    )
+                    sampling_module.seed_manager.reset_seed_from_slots(seed_values, active_seed_slots)
                     sampling_module.seed_manager.align_seed_counters_to_positions(
                         seed_values, active_seed_slots, start_values
                     )
                 else:
-                    sampling_module.seed_manager.reset_seed_from_slots_if_needed(
-                        seed_values, active_seed_slots
-                    )
-                    if align_seed_counters:
-                        sampling_module.seed_manager.align_seed_counters_to_positions(
-                            seed_values, active_seed_slots, start_values
-                        )
+                    sampling_module.seed_manager.reset_seed_from_slots_if_needed(seed_values, active_seed_slots)
             sampling_module.seed_manager.get_new_values(active_seed_slots)
 
         sampled_outputs = []
@@ -1832,14 +1646,12 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         the next traced decode step, or None if the model doesn't use on-device
         token feedback.
 
-        Models that re-stage all decode trace inputs from host every step (e.g.
-        gemma4, ``_tt_vllm_always_refresh_decode_trace_inputs=True``) don't rely
-        on the device feedback and their token buffer (``device_inputs[0]``) may
-        not be a valid sampling output (gemma4's is rank-2; ``ttnn.sampling``
-        requires a rank-4 preallocated output). Returning None makes sampling
-        allocate its own output instead of writing into ``device_inputs[0]``.
+        Some models' token input buffer is not a valid sampling output
+        (gemma4's is rank-2; ``ttnn.sampling`` requires a rank-4 preallocated
+        output). Returning None makes sampling allocate its own output instead
+        of writing into ``device_inputs[0]``.
         """
-        if getattr(model, "_tt_vllm_always_refresh_decode_trace_inputs", False):
+        if not getattr(model, "_tt_supports_decode_token_feedback", True):
             return None
         return device_inputs[0]
 

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -24,6 +24,7 @@ from models.common.sampling import (
     broadcast_sampling_params,
     chunk_sampling_params,
     format_sampling_params,
+    should_align_decode_seed_counters,
 )
 from models.common.sampling.tt_log_probs import LogProbsResult, reformat_logprobs
 from models.common.warmup import WarmupForwardMixin
@@ -1269,6 +1270,10 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         output_tokens: torch.Tensor | None = None,
         slot_remap=None,
         defer_device_sampling: bool = False,
+        reload_inputs: bool | None = None,
+        reload_page_table: bool | None = None,
+        reload_sampling_params: bool | None = None,
+        reset_sampling_state: bool | None = None,
         **kwargs,
     ):
         mode_switched = False
@@ -1281,6 +1286,19 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
             self.model[i].switch_mode(Mode.DECODE)
 
         on_device_sampling = (sampling_params is not None) or defer_device_sampling
+        contract_flags = (
+            reload_inputs,
+            reload_page_table,
+            reload_sampling_params,
+            reset_sampling_state,
+        )
+        explicit_contract = any(flag is not None for flag in contract_flags)
+        if explicit_contract and not all(flag is not None for flag in contract_flags):
+            raise ValueError(
+                "decode update contract requires reload_inputs, "
+                "reload_page_table, reload_sampling_params, and "
+                "reset_sampling_state together"
+            )
         B = tokens.shape[0]
 
         tokens = torch.chunk(tokens, self.data_parallel, 0)
@@ -1294,6 +1312,8 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         # only taking host tokens for slots freshly prefilled since the last
         # decode submit (their last token came from prefill, not decode).
         if (
+            not explicit_contract
+            and
             on_device_sampling
             and (reset_batch or mode_switched)
             and enable_trace
@@ -1382,6 +1402,8 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
             tt_decode_output = self._decode_forward_trace_text(
                 **decode_kwargs,
                 reset_batch=reset_batch or mode_switched,
+                reload_inputs=reload_inputs,
+                reload_page_table=reload_page_table,
             )
         else:
             tt_decode_output = self._decode_forward_no_trace_text(
@@ -1402,6 +1424,23 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                 output_tokens=output_tokens,
                 slot_remap=slot_remap,
                 enable_trace=enable_trace,
+                reload_sampling_params=(
+                    bool(reload_sampling_params)
+                    if explicit_contract
+                    else True
+                ),
+                reset_sampling_state=(
+                    bool(reset_sampling_state)
+                    if explicit_contract
+                    else reset_batch
+                ),
+                align_seed_counters=should_align_decode_seed_counters(
+                    explicit_contract=explicit_contract,
+                    reset_sampling_state=bool(reset_sampling_state),
+                    # This generator historically aligned active seeded slots
+                    # on every legacy decode.
+                    legacy_alignment=True,
+                ),
             )
         # Host sampling
         if read_from_device:
@@ -1553,6 +1592,8 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         kv_cache=None,
         on_device_sampling=False,
         reset_batch=False,
+        reload_inputs: bool | None = None,
+        reload_page_table: bool | None = None,
     ):
         """
         Run decode forward text with tracing
@@ -1566,20 +1607,45 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
             self.trace_inputs_decode[on_device_sampling] = device_inputs
             self.trace_output_decode[on_device_sampling] = tt_out_trace
 
-        # reset inputs when mode switches from prefill to decode,
-        # or when sampling mode changes (different trace has stale inputs)
-        prev_on_device_sampling = getattr(self, "_prev_on_device_sampling", None)
-        self._prev_on_device_sampling = on_device_sampling
-        sampling_mode_changed = prev_on_device_sampling is not None and prev_on_device_sampling != on_device_sampling
-        reset_inputs = reset_batch or not on_device_sampling or sampling_mode_changed
-        page_table_changed = page_table is not None and (
-            self.prev_page_table is None
-            or any(not torch.equal(prev, curr) for prev, curr in zip(self.prev_page_table, page_table))
+        explicit_contract = (
+            reload_inputs is not None or reload_page_table is not None
         )
+        if explicit_contract:
+            if reload_inputs is None or reload_page_table is None:
+                raise ValueError(
+                    "reload_inputs and reload_page_table must be provided together"
+                )
+            reset_inputs = reload_inputs
+            page_table_changed = reload_page_table
+        else:
+            # Legacy callers retain the previous generator-local policy.
+            prev_on_device_sampling = getattr(
+                self, "_prev_on_device_sampling", None
+            )
+            self._prev_on_device_sampling = on_device_sampling
+            sampling_mode_changed = (
+                prev_on_device_sampling is not None
+                and prev_on_device_sampling != on_device_sampling
+            )
+            reset_inputs = (
+                reset_batch or not on_device_sampling or sampling_mode_changed
+            )
+            page_table_changed = page_table is not None and (
+                self.prev_page_table is None
+                or any(
+                    not torch.equal(prev, curr)
+                    for prev, curr in zip(self.prev_page_table, page_table)
+                )
+            )
 
         for i in range(self.data_parallel):
-            refresh_trace_inputs = reset_inputs or getattr(
-                self.model[i], "_tt_vllm_always_refresh_decode_trace_inputs", False
+            refresh_trace_inputs = reset_inputs or (
+                not explicit_contract
+                and getattr(
+                    self.model[i],
+                    "_tt_vllm_always_refresh_decode_trace_inputs",
+                    False,
+                )
             )
             user_page_table = page_table[i] if page_table is not None else None
 
@@ -1620,7 +1686,15 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         output_tokens: torch.Tensor | None = None,
         slot_remap=None,
         enable_trace=False,
+        reload_sampling_params: bool = True,
+        reset_sampling_state: bool | None = None,
+        align_seed_counters: bool | None = None,
     ):
+        if reset_sampling_state is None:
+            reset_sampling_state = reset_batch
+        if align_seed_counters is None:
+            # Direct callers without explicit flags retain legacy behavior.
+            align_seed_counters = True
         # sampling_dp may differ from data_parallel for models that internally
         # shard users across mesh rows (users_row_sharded) — each row samples
         # 32 users independently, so sampling params must be chunked by the
@@ -1661,9 +1735,16 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                 else None
             )
 
+            # Reindex continuing per-slot state before params/history are
+            # refreshed for the new layout.
+            if slot_remap is not None:
+                sm_bs = sampling_module.seed_manager.max_batch_size
+                rank_remap = slot_remap[i * sm_bs : (i + 1) * sm_bs]
+                sampling_module.seed_manager.apply_slot_remap(rank_remap)
             sampling_module.apply_decode_state(
                 model_chunks,
-                reset_batch=reset_batch,
+                reload_sampling_params=reload_sampling_params,
+                reset_sampling_state=reset_sampling_state,
                 prompt_tokens=model_prompt,
                 output_tokens=model_output,
             )
@@ -1672,11 +1753,6 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                 max_seed_slots = sampling_module.seed_manager.max_batch_size
                 start_values = torch.as_tensor(start_pos[i]).reshape(-1).tolist()
                 active_seed_slots = [idx for idx, pos in enumerate(start_values[:max_seed_slots]) if int(pos) >= 0]
-            # Apply slot remap from condense before advancing seeds.
-            if slot_remap is not None:
-                sm_bs = sampling_module.seed_manager.max_batch_size
-                rank_remap = slot_remap[i * sm_bs : (i + 1) * sm_bs]
-                sampling_module.seed_manager.apply_slot_remap(rank_remap)
             # Register each request's explicit seed into the seed manager and
             # tie its RNG counter to the absolute decode position before
             # advancing. Without registration the per-request seed never reaches
@@ -1686,7 +1762,9 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
             # flow). Position alignment then keeps the stream reproducible even
             # when vLLM evicts a running request and re-admits it in a different
             # slot under async scheduling. Mirrors the llama3_70b_galaxy decode path.
-            if active_seed_slots:
+            if active_seed_slots is not None and (
+                reload_sampling_params or reset_sampling_state
+            ):
                 seed_bs = sampling_module.tt_sampling.max_batch_size
                 if len(model_chunks) == 1:
                     seed_values = format_sampling_params(model_chunks[0], seed_bs).seed
@@ -1695,10 +1773,23 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                     for chunk in model_chunks:
                         s = format_sampling_params(chunk, seed_bs).seed
                         seed_values += s if isinstance(s, list) else [s] * seed_bs
-                sampling_module.seed_manager.reset_seed_from_slots_if_needed(seed_values, active_seed_slots)
-                sampling_module.seed_manager.align_seed_counters_to_positions(
-                    seed_values, active_seed_slots, start_values
-                )
+                if reset_sampling_state:
+                    # A layout/mode transition reinitializes every active slot,
+                    # including unseeded requests reusing an identity slot.
+                    sampling_module.seed_manager.reset_decode_batch(
+                        seed_values, active_seed_slots
+                    )
+                    sampling_module.seed_manager.align_seed_counters_to_positions(
+                        seed_values, active_seed_slots, start_values
+                    )
+                else:
+                    sampling_module.seed_manager.reset_seed_from_slots_if_needed(
+                        seed_values, active_seed_slots
+                    )
+                    if align_seed_counters:
+                        sampling_module.seed_manager.align_seed_counters_to_positions(
+                            seed_values, active_seed_slots, start_values
+                        )
             sampling_module.seed_manager.get_new_values(active_seed_slots)
 
         sampled_outputs = []

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -165,7 +165,6 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         self.processor = processor
         self.tokenizer = tokenizer
         self.data_parallel = len(self.model)
-        self.prev_page_table = None
         self.trace_id_prefill = defaultdict(lambda: None)
         self.trace_inputs_prefill = defaultdict(lambda: None)
         self.trace_output_prefill = defaultdict(lambda: None)
@@ -518,8 +517,9 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
             return None
 
         batch_size = page_table.shape[0]
-        # Values do not matter: the trace inputs are refreshed from host on the first real decode step
-        # (reset_batch=True). Only the shapes have to match what decode_forward will supply.
+        # Values do not matter: the first real decode explicitly requests a
+        # full input reload. Only the shapes have to match what
+        # decode_forward will supply.
         tokens = torch.chunk(torch.zeros(batch_size, 1, dtype=torch.int64), self.data_parallel, 0)
         current_pos = torch.chunk(torch.zeros(batch_size, dtype=torch.int64), self.data_parallel, 0)
         chunked_page_table = torch.chunk(page_table, self.data_parallel, 0)
@@ -1093,15 +1093,6 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         else:
             # Only paged attention is supported for prefill
             enable_trace = False
-
-        # Track slots refreshed by this prefill so the next decode reset keeps
-        # device-fed tokens for all other slots (their host token is one step
-        # stale under vLLM async scheduling).
-        if not hasattr(self, "_slots_prefilled_since_decode"):
-            self._slots_prefilled_since_decode = set()
-        self._slots_prefilled_since_decode.update(
-            range(tokens.shape[0]) if empty_slots is None else [int(s) for s in empty_slots]
-        )
 
         on_device_sampling_requested = sampling_params is not None
 
@@ -2026,136 +2017,37 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         enable_trace=True,
         read_from_device=True,
         sampling_params: SamplingParams = None,  # Should be None if not greedy decoding / sampling on device.
-        reset_batch=False,
         prompt_tokens: torch.Tensor | None = None,
         output_tokens: torch.Tensor | None = None,
         slot_remap=None,
         defer_device_sampling: bool = False,
+        *,
+        reload_inputs: bool,
+        reload_page_table: bool,
+        reload_sampling_params: bool,
+        reset_sampling_state: bool,
         skip_trace_precompile: bool = False,
         prepare_trace: bool = False,
         **kwargs,
     ):
-        mode_switched = False
         if self.mode != Mode.DECODE:
             self.mode = Mode.DECODE
-            mode_switched = True
 
         # Switch to decode mode for prefetcher to reintialize sub devices
         for i in range(len(self.model)):
             self.model[i].switch_mode(Mode.DECODE)
 
         on_device_sampling = (sampling_params is not None) or defer_device_sampling
-        B = tokens.shape[0]
+        if not enable_trace and not reload_inputs:
+            raise ValueError("Non-traced decode rebuilds all forward inputs and requires reload_inputs=True")
 
-        # Are the host tokens/positions authoritative this step, or is the device
-        # copy ahead? Trace reload and seed alignment must agree, so compute it
-        # once here instead of privately in the trace path (#51981).
-        prev_on_device_sampling = getattr(self, "_prev_on_device_sampling", None)
-        self._prev_on_device_sampling = on_device_sampling
-        sampling_mode_changed = prev_on_device_sampling is not None and prev_on_device_sampling != on_device_sampling
-        reload_inputs = (
-            not enable_trace
-            or not self.trace_ids_decode[on_device_sampling]
-            or not on_device_sampling
-            or reset_batch
-            or mode_switched
-            or sampling_mode_changed
-            or any(
-                getattr(self.model[i], "_tt_vllm_always_refresh_decode_trace_inputs", False)
-                for i in range(self.data_parallel)
-            )
-        )
-        # vLLM sees re-admissions the model cannot (tenstorrent/vllm#456), so
-        # either side asserting authority is enough.
-        if kwargs.get("reload_inputs"):
-            reload_inputs = True
         # Deferred sampling calls sample_decode_on_device() out of band; stash the
-        # flag so that call need not thread it.
+        # caller's explicit command so that call need not thread it separately.
         self._decode_reload_inputs = reload_inputs
 
         tokens = torch.chunk(tokens, self.data_parallel, 0)
         start_pos = torch.chunk(start_pos, self.data_parallel, 0)
         page_table = torch.chunk(page_table, self.data_parallel, 0) if page_table is not None else None
-
-        # vLLM under async scheduling supplies a one-step-stale last token at
-        # reset steps (its host state lags device sampling). The device token
-        # buffer holds the authoritative token sampled at the previous decode
-        # step, so on a reset keep it: permute per slot_remap (condense moves),
-        # only taking host tokens for slots freshly prefilled since the last
-        # decode submit (their last token came from prefill, not decode).
-        if (
-            on_device_sampling
-            and (reset_batch or mode_switched)
-            and enable_trace
-            and self.trace_inputs_decode[on_device_sampling]
-        ):
-            new_tokens = []
-            new_start_pos = []
-            # When we take the device's async-ahead token for a continuing slot,
-            # the token sits at position dev_pos; staging the lagging host position
-            # (=dev_pos-1) would re-process that token at the wrong position
-            # (overwriting KV / regenerating a position -> duplicate/flipped tokens
-            # under concurrency). Pair the device token with the device position.
-            for i, tok_chunk in enumerate(tokens):
-                trace_in = self.trace_inputs_decode[on_device_sampling][i]
-                dev_toks = (
-                    ttnn.to_torch(ttnn.get_device_tensors(trace_in[0])[0])
-                    .reshape(-1)[: tok_chunk.shape[0]]
-                    .to(tok_chunk.dtype)
-                )
-                dev_pos = (
-                    ttnn.to_torch(ttnn.get_device_tensors(trace_in[1])[0])
-                    .reshape(-1)[: tok_chunk.shape[0]]
-                    .to(torch.int64)
-                )
-                if slot_remap is not None:
-                    chunk = dev_toks.shape[0]
-                    remap = slot_remap[i * chunk : (i + 1) * chunk]
-                    remap_t = (remap if isinstance(remap, torch.Tensor) else torch.tensor(remap)).long()
-                    # slot_remap holds GLOBAL slot indices: the vLLM plugin offsets
-                    # each DP rank's local [0,B) remap by rank*B for the row-sharded
-                    # SeedManager. dev_toks/dev_pos are this rank's *local* size-B
-                    # tensors, so rebase the global indices back to [0,B) before
-                    # gathering -- otherwise rank i>=1 indexes past the end (e.g.
-                    # value 32 into a size-32 tensor).
-                    remap_t = remap_t - i * chunk
-                    dev_toks = dev_toks[remap_t]
-                    dev_pos = dev_pos[remap_t]
-                # The device token is authoritative only for slots whose device
-                # position chain is continuous with the host view; slots that
-                # were re-added, resumed, or freshly prefilled take host tokens.
-                # The host position itself may lag the device by one step under
-                # async scheduling, so accept both.
-                host_pos = start_pos[i].reshape(-1).to(torch.int64)
-                # The device token/position buffers are read from a single device
-                # shard (get_device_tensors(...)[0]). That holds the full per-chunk
-                # batch only when the decode inputs are replicated across the mesh
-                # (e.g. Llama-3.1-8B, which this async-ahead keep was designed for).
-                # Models that shard the decode batch across mesh devices
-                # (users_row_sharded, e.g. GPT-OSS) expose only B/num_shards entries
-                # on shard 0, so dev_toks/dev_pos are shorter than the full host
-                # chunk. Reconstructing the full batch needs the model's mesh layout,
-                # which the shared generator doesn't have; rather than crash on the
-                # mismatched comparison, fall back to the host-provided tokens and
-                # positions for this chunk (the pre-fix behaviour).
-                if dev_pos.shape[0] != host_pos.shape[0] or dev_toks.shape[0] != tok_chunk.reshape(-1).shape[0]:
-                    new_tokens.append(tok_chunk)
-                    new_start_pos.append(start_pos[i])
-                    continue
-                use_dev = (dev_pos == host_pos) | (dev_pos == host_pos + 1)
-                prefilled = getattr(self, "_slots_prefilled_since_decode", None)
-                if prefilled:
-                    bs = tok_chunk.shape[0]
-                    for slot in prefilled:
-                        if i * bs <= slot < (i + 1) * bs:
-                            use_dev[slot - i * bs] = False
-                merged = torch.where(use_dev, dev_toks.view(-1), tok_chunk.view(-1)).view(tok_chunk.shape)
-                new_tokens.append(merged.to(tok_chunk.dtype))
-                merged_pos = torch.where(use_dev, dev_pos, host_pos)
-                new_start_pos.append(merged_pos.view(start_pos[i].shape).to(start_pos[i].dtype))
-            tokens = new_tokens
-            start_pos = new_start_pos
-        self._slots_prefilled_since_decode = set()
 
         decode_kwargs = {
             "current_pos": start_pos,
@@ -2166,11 +2058,10 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         }
 
         if enable_trace:
-            # reset_batch (real reset / slot remap) and a prefill->decode switch
-            # both stale the device buffers; both are folded into reload_inputs.
             tt_decode_output = self._decode_forward_trace_text(
                 **decode_kwargs,
                 reload_inputs=reload_inputs,
+                reload_page_table=reload_page_table,
                 skip_precompile=skip_trace_precompile,
             )
         elif prepare_trace:
@@ -2189,18 +2080,28 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                 tt_decode_output,
                 sampling_params=sampling_params,
                 start_pos=start_pos,
-                reset_batch=reset_batch,
                 prompt_tokens=prompt_tokens,
                 output_tokens=output_tokens,
                 slot_remap=slot_remap,
                 enable_trace=enable_trace,
+                reload_sampling_params=reload_sampling_params,
+                reset_sampling_state=reset_sampling_state,
                 skip_precompile=skip_trace_precompile,
                 reload_inputs=reload_inputs,
             )
         # Host sampling
         if read_from_device:
             to_host = self.read_decode_output(tt_decode_output)
-            return self.process_decode_output_host(to_host, is_tokens=(sampling_params is not None))
+            output = self.process_decode_output_host(to_host, is_tokens=(sampling_params is not None))
+            if sampling_params is None:
+                # Host sampling does not invoke the device sampler, but its
+                # dormant per-slot state must still follow the new layout.
+                # Apply only after decode/readback succeeds so a failed call
+                # can be retried with the still-pending, non-idempotent remap.
+                self._apply_sampling_slot_remap(slot_remap)
+            return output
+        if sampling_params is None:
+            self._apply_sampling_slot_remap(slot_remap)
         return tt_decode_output
 
     def _decode_forward_no_trace_text(
@@ -2404,12 +2305,10 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                 # this traces only for the current ones.
                 # tt_out_tok feeds the sampled token back into the decode token
                 # buffer (device_inputs[0]) for the next traced step. Only do this
-                # for models that rely on on-device token feedback. Models that
-                # re-stage decode inputs from host every step (e.g. gemma4, via
-                # _tt_vllm_always_refresh_decode_trace_inputs) don't, and their
-                # token buffer is not shaped as a sampling output (gemma4's is
-                # rank-2; ttnn.sampling requires a rank-4 preallocated output) —
-                # pass None so sampling allocates its own output.
+                # for models that rely on on-device token feedback. Some token
+                # input buffers are not shaped as sampling outputs (gemma4's is
+                # rank-2; ttnn.sampling requires a rank-4 preallocated output),
+                # so those models opt out and sampling allocates its own output.
                 tt_out_tok = self._decode_token_feedback_buffer(self.model[i], device_inputs[i])
                 # skip_precompile=True in both cases: either _prepare_decode_trace_text pre-compiled the
                 # sampling pipeline (before any trace was live), or the caller passed skip_precompile and
@@ -2504,14 +2403,18 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         page_table=None,
         kv_cache=None,
         on_device_sampling=False,
-        reload_inputs=False,
-        skip_precompile=False,
+        *,
+        reload_inputs: bool,
+        reload_page_table: bool,
+        skip_precompile: bool = False,
     ):
         """
         Run decode forward text with tracing
 
         ``reload_inputs`` (from decode_forward): host token/position inputs are
-        authoritative this step and must overwrite the device-resident ones.
+        authoritative this step and must overwrite every device-resident input.
+        ``reload_page_table`` refreshes only the page table while preserving
+        device-produced token and position state.
         """
         # The trace is different depending on whether we are doing device sampling or not
         if not self.trace_ids_decode[on_device_sampling]:
@@ -2527,18 +2430,10 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
             self.trace_inputs_decode[on_device_sampling] = device_inputs
             self.trace_output_decode[on_device_sampling] = tt_out_trace
 
-        page_table_changed = page_table is not None and (
-            self.prev_page_table is None
-            or any(not torch.equal(prev, curr) for prev, curr in zip(self.prev_page_table, page_table))
-        )
-
         for i in range(self.data_parallel):
-            refresh_trace_inputs = reload_inputs or getattr(
-                self.model[i], "_tt_vllm_always_refresh_decode_trace_inputs", False
-            )
             user_page_table = page_table[i] if page_table is not None else None
 
-            if refresh_trace_inputs:
+            if reload_inputs:
                 # Full resets are required when host token/position inputs are
                 # authoritative again, or for models that explicitly opt out of
                 # partial decode trace input refreshes.
@@ -2547,7 +2442,7 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                     host_tensors=host_inputs_i,
                     device_tensors=self.trace_inputs_decode[on_device_sampling][i],
                 )
-            elif page_table_changed:
+            elif reload_page_table:
                 # With async device sampling, token/position inputs may
                 # intentionally be stale on host: the previous decode updates
                 # them on device. Page tables still need refreshing when new KV
@@ -2559,33 +2454,66 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                 if host_page_table is not None:
                     ttnn.copy_host_to_device_tensor(host_page_table, device_page_table)
 
-        if page_table_changed:
-            self.prev_page_table = tuple(pt.clone() for pt in page_table)
         for i, trace_id in self.trace_ids_decode[on_device_sampling].items():
             ttnn.execute_trace(self.model_args[i].mesh_device, trace_id, cq_id=0, blocking=False)
         return self.trace_output_decode[on_device_sampling]
+
+    def _apply_sampling_slot_remap(self, slot_remap) -> None:
+        if slot_remap is None:
+            return
+        global_remap = torch.as_tensor(slot_remap, dtype=torch.long).reshape(-1)
+        if global_remap.numel() % self.data_parallel != 0:
+            raise ValueError(
+                f"slot_remap has {global_remap.numel()} entries, which cannot be "
+                f"split across {self.data_parallel} data-parallel lanes"
+            )
+        lane_stride = global_remap.numel() // self.data_parallel
+        for i in range(self.data_parallel):
+            sampling_module = getattr(self.model[i], "sampling", None)
+            if sampling_module is None:
+                continue
+            sm_bs = sampling_module.seed_manager.max_batch_size
+            if lane_stride > sm_bs:
+                raise ValueError(
+                    f"slot_remap lane width {lane_stride} exceeds sampling state " f"width {sm_bs} for lane {i}"
+                )
+            lane_base = i * lane_stride
+            lane_remap = global_remap[lane_base : lane_base + lane_stride] - lane_base
+            if torch.any(lane_remap < 0) or torch.any(lane_remap >= lane_stride):
+                raise ValueError(
+                    f"slot_remap lane {i} references a slot outside its global "
+                    f"range [{lane_base}, {lane_base + lane_stride})"
+                )
+            rank_remap = torch.arange(sm_bs, dtype=torch.long)
+            rank_remap[:lane_stride] = lane_remap
+            sampling_module.apply_slot_remap(rank_remap)
 
     def sample_decode_on_device(
         self,
         tt_logits,
         sampling_params,
         start_pos=None,
-        reset_batch=False,
         prompt_tokens: torch.Tensor | None = None,
         output_tokens: torch.Tensor | None = None,
         slot_remap=None,
         enable_trace=False,
-        skip_precompile=False,
-        reload_inputs=None,
+        *,
+        reload_sampling_params: bool,
+        reset_sampling_state: bool,
+        reload_inputs: bool | None = None,
+        skip_precompile: bool = False,
     ):
         """Sample this decode step's tokens on device.
 
-        ``reload_inputs``: host inputs are authoritative, so ``start_pos`` may
-        re-anchor the seed counters. ``None`` takes the last decode_forward's
-        value (the deferred path calls this out of band).
+        ``reload_inputs`` identifies authoritative host positions for seed
+        counter alignment. Deferred callers may omit it after ``decode_forward``;
+        the explicit command from that call is retained for this purpose.
         """
         if reload_inputs is None:
             reload_inputs = getattr(self, "_decode_reload_inputs", True)
+        # Keep this entry point independently usable by immediate and
+        # separated-sampling callers.
+        self._apply_sampling_slot_remap(slot_remap)
         # sampling_dp may differ from data_parallel for models that internally
         # shard users across mesh rows (users_row_sharded) — each row samples
         # 32 users independently, so sampling params must be chunked by the
@@ -2628,7 +2556,8 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
 
             sampling_module.apply_decode_state(
                 model_chunks,
-                reset_batch=reset_batch,
+                reload_sampling_params=reload_sampling_params,
+                reset_sampling_state=reset_sampling_state,
                 prompt_tokens=model_prompt,
                 output_tokens=model_output,
             )
@@ -2637,14 +2566,8 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                 max_seed_slots = sampling_module.seed_manager.max_batch_size
                 start_values = torch.as_tensor(start_pos[i]).reshape(-1).tolist()
                 active_seed_slots = [idx for idx, pos in enumerate(start_values[:max_seed_slots]) if int(pos) >= 0]
-            # Apply slot remap from condense before advancing seeds.
-            if slot_remap is not None:
-                sm_bs = sampling_module.seed_manager.max_batch_size
-                rank_remap = slot_remap[i * sm_bs : (i + 1) * sm_bs]
-                sampling_module.seed_manager.apply_slot_remap(rank_remap)
-            # Drop seed state of slots no longer live (a request finishing at
-            # the batch tail is never vacated by condense), so its ghost seed
-            # cannot inflate a later request's salt.
+            # A request finishing at the batch tail produces no non-identity
+            # remap, so retire seed state that no longer belongs to a live row.
             if active_seed_slots is not None:
                 sampling_module.seed_manager.deactivate_slots_except(active_seed_slots)
             # Register each request's explicit seed into the seed manager and
@@ -2659,9 +2582,9 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
             #
             # Align only from a trustworthy position (#51981): the counter
             # self-advances per token, so re-anchoring to a lagging host start_pos
-            # is what breaks reproducibility. Trustworthy = reload_inputs, or a
-            # slot just reseeded (freshly admitted, position from its prefill).
-            if active_seed_slots:
+            # is what breaks reproducibility. Trustworthy means the caller
+            # commanded reload_inputs, or the slot was explicitly reset/reseeded.
+            if active_seed_slots is not None and (reload_inputs or reload_sampling_params or reset_sampling_state):
                 seed_bs = sampling_module.tt_sampling.max_batch_size
                 if len(model_chunks) == 1:
                     seed_values = format_sampling_params(model_chunks[0], seed_bs).seed
@@ -2670,16 +2593,18 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                     for chunk in model_chunks:
                         s = format_sampling_params(chunk, seed_bs).seed
                         seed_values += s if isinstance(s, list) else [s] * seed_bs
-                # reset_batch = first decode after prefill or a layout change: seed unconditionally,
-                # even for seed=None. ``decode_only`` mode never seeded the device, so the if_needed
-                # path matches the manager's initial None, early-returns, and replays one draw.
-                if reset_batch:
+                if reset_sampling_state:
+                    # A state reset is unconditional even for seed=None:
+                    # reset_if_needed would see None == None and skip the
+                    # fresh device-seed upload in decode-only sampling mode.
                     sampling_module.seed_manager.reset_seed_from_slots(seed_values, active_seed_slots)
                     reseeded_slots = list(active_seed_slots)
-                else:
+                elif reload_sampling_params:
                     reseeded_slots = sampling_module.seed_manager.reset_seed_from_slots_if_needed(
                         seed_values, active_seed_slots
                     )
+                else:
+                    reseeded_slots = []
                 align_slots = active_seed_slots if reload_inputs else reseeded_slots
                 if align_slots:
                     sampling_module.seed_manager.align_seed_counters_to_positions(
@@ -2727,14 +2652,12 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         the next traced decode step, or None if the model doesn't use on-device
         token feedback.
 
-        Models that re-stage all decode trace inputs from host every step (e.g.
-        gemma4, ``_tt_vllm_always_refresh_decode_trace_inputs=True``) don't rely
-        on the device feedback and their token buffer (``device_inputs[0]``) may
-        not be a valid sampling output (gemma4's is rank-2; ``ttnn.sampling``
-        requires a rank-4 preallocated output). Returning None makes sampling
-        allocate its own output instead of writing into ``device_inputs[0]``.
+        Some models' token input buffer is not a valid sampling output
+        (gemma4's is rank-2; ``ttnn.sampling`` requires a rank-4 preallocated
+        output). Returning None makes sampling allocate its own output instead
+        of writing into ``device_inputs[0]``.
         """
-        if getattr(model, "_tt_vllm_always_refresh_decode_trace_inputs", False):
+        if not getattr(model, "_tt_supports_decode_token_feedback", True):
             return None
         return device_inputs[0]
 

--- a/models/tt_transformers/tt/generator_sglang.py
+++ b/models/tt_transformers/tt/generator_sglang.py
@@ -152,7 +152,7 @@ class LlamaForCausalLM(Generator):
         return super().prefill_forward_text(*args, **kwargs)
 
     def decode_forward(self, *args, **kwargs):
-        return super().decode_forward_text(*args, **kwargs)
+        return super().decode_forward(*args, **kwargs)
 
     def allocate_kv_cache(self, *args, **kwargs):
         return allocate_sglang_kv_cache(*args, **kwargs, dp_model=self.model, tt_cache_path=self.cache_path)
@@ -195,7 +195,7 @@ class QwenForCausalLM(Generator):
         return super().prefill_forward_text(*args, **kwargs)
 
     def decode_forward(self, *args, **kwargs):
-        return super().decode_forward_text(*args, **kwargs)
+        return super().decode_forward(*args, **kwargs)
 
     def allocate_kv_cache(self, *args, **kwargs):
         return allocate_sglang_kv_cache(*args, **kwargs, dp_model=self.model, tt_cache_path=self.cache_path)
@@ -238,7 +238,7 @@ class MistralForCausalLM(Generator):
         return super().prefill_forward_text(*args, **kwargs)
 
     def decode_forward(self, *args, **kwargs):
-        return super().decode_forward_text(*args, **kwargs)
+        return super().decode_forward(*args, **kwargs)
 
     def allocate_kv_cache(self, *args, **kwargs):
         return allocate_sglang_kv_cache(*args, **kwargs, dp_model=self.model, tt_cache_path=self.cache_path)
@@ -302,7 +302,7 @@ class GptOssForCausalLM(Generator):
         return super().prefill_forward_text(*args, **kwargs)
 
     def decode_forward(self, *args, **kwargs):
-        return super().decode_forward_text(*args, **kwargs)
+        return super().decode_forward(*args, **kwargs)
 
     def allocate_kv_cache(self, *args, **kwargs):
         return allocate_sglang_kv_cache(*args, **kwargs, dp_model=self.model, tt_cache_path=self.cache_path)

--- a/models/tt_transformers/tt/generator_sglang.py
+++ b/models/tt_transformers/tt/generator_sglang.py
@@ -102,6 +102,30 @@ def initialize_sglang_text_transformer(
     return tt_model, model_args
 
 
+def _decode_forward_sglang_host_sampling(generator: Generator, *args, **kwargs):
+    """Bridge SGLang's host-sampled decode contract to explicit TT commands.
+
+    SGLang supplies the authoritative token, position, and page table every
+    step and samples returned logits on the host. It therefore requests a full
+    input reload and no device-sampling updates on every decode.
+    """
+    if kwargs.get("sampling_params") is not None:
+        raise ValueError("The TT SGLang bridge supports host sampling only")
+    commands = {
+        "reload_inputs": True,
+        "reload_page_table": False,
+        "reload_sampling_params": False,
+        "reset_sampling_state": False,
+    }
+    already_supplied = commands.keys() & kwargs.keys()
+    if already_supplied:
+        raise TypeError(
+            "The TT SGLang bridge owns decode update commands; remove "
+            f"caller-supplied values for {sorted(already_supplied)}"
+        )
+    return Generator.decode_forward(generator, *args, **kwargs, **commands)
+
+
 class LlamaForCausalLM(Generator):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -152,7 +176,7 @@ class LlamaForCausalLM(Generator):
         return super().prefill_forward_text(*args, **kwargs)
 
     def decode_forward(self, *args, **kwargs):
-        return super().decode_forward_text(*args, **kwargs)
+        return _decode_forward_sglang_host_sampling(self, *args, **kwargs)
 
     def allocate_kv_cache(self, *args, **kwargs):
         return allocate_sglang_kv_cache(*args, **kwargs, dp_model=self.model, tt_cache_path=self.cache_path)
@@ -195,7 +219,7 @@ class QwenForCausalLM(Generator):
         return super().prefill_forward_text(*args, **kwargs)
 
     def decode_forward(self, *args, **kwargs):
-        return super().decode_forward_text(*args, **kwargs)
+        return _decode_forward_sglang_host_sampling(self, *args, **kwargs)
 
     def allocate_kv_cache(self, *args, **kwargs):
         return allocate_sglang_kv_cache(*args, **kwargs, dp_model=self.model, tt_cache_path=self.cache_path)
@@ -238,7 +262,7 @@ class MistralForCausalLM(Generator):
         return super().prefill_forward_text(*args, **kwargs)
 
     def decode_forward(self, *args, **kwargs):
-        return super().decode_forward_text(*args, **kwargs)
+        return _decode_forward_sglang_host_sampling(self, *args, **kwargs)
 
     def allocate_kv_cache(self, *args, **kwargs):
         return allocate_sglang_kv_cache(*args, **kwargs, dp_model=self.model, tt_cache_path=self.cache_path)
@@ -302,7 +326,7 @@ class GptOssForCausalLM(Generator):
         return super().prefill_forward_text(*args, **kwargs)
 
     def decode_forward(self, *args, **kwargs):
-        return super().decode_forward_text(*args, **kwargs)
+        return _decode_forward_sglang_host_sampling(self, *args, **kwargs)
 
     def allocate_kv_cache(self, *args, **kwargs):
         return allocate_sglang_kv_cache(*args, **kwargs, dp_model=self.model, tt_cache_path=self.cache_path)

--- a/models/tt_transformers/tt/generator_vllm.py
+++ b/models/tt_transformers/tt/generator_vllm.py
@@ -241,6 +241,19 @@ class HybridAttentionForCausalLM(Generator):
     def allocate_kv_cache_per_layer(self, per_layer_specs):
         return allocate_vllm_kv_cache_per_layer(per_layer_specs, dp_model=self.model, tt_cache_path=self.cache_path)
 
+    @staticmethod
+    def _reload_per_layer_page_tables(kwargs) -> bool:
+        """Honor the explicit decode update contract, with legacy fallback."""
+        reload_inputs = kwargs.get("reload_inputs")
+        reload_page_table = kwargs.get("reload_page_table")
+        if reload_inputs is None and reload_page_table is None:
+            return True
+        if reload_inputs is None or reload_page_table is None:
+            raise ValueError(
+                "reload_inputs and reload_page_table must be provided together"
+            )
+        return bool(reload_inputs or reload_page_table)
+
     def _ensure_page_tables_per_layer(self, page_tables_per_layer, page_table):
         """When invoked outside the vLLM hybrid plugin (e.g. by warmup
         which only knows about the legacy single ``page_table``), optionally
@@ -625,6 +638,8 @@ class MllamaForConditionalGeneration(Generator, SupportsMultiModal):
 
 
 class LlamaForCausalLM(Generator):
+    decode_input_update_contract = 1
+
     # Class-level capabilities
     model_capabilities = {
         "supports_prefix_caching": True,
@@ -710,6 +725,8 @@ class LlamaForCausalLM(Generator):
 
 
 class QwenForCausalLM(Generator):
+    decode_input_update_contract = 1
+
     # Class-level capabilities
     model_capabilities = {
         "supports_prefix_caching": True,
@@ -789,6 +806,8 @@ class QwenForCausalLM(Generator):
 
 
 class MistralForCausalLM(Generator):
+    decode_input_update_contract = 1
+
     # Class-level capabilities
     model_capabilities = {
         "supports_prefix_caching": True,
@@ -886,6 +905,8 @@ class Gemma3ForConditionalGeneration(HybridAttentionForCausalLM, SupportsMultiMo
     picks up the stash via ``_active_page_tables_per_layer`` and routes
     each layer's attention to its own page table.
     """
+
+    decode_input_update_contract = 1
 
     # Class-level capabilities
     model_capabilities = {
@@ -993,7 +1014,7 @@ class Gemma3ForConditionalGeneration(HybridAttentionForCausalLM, SupportsMultiMo
             return super(HybridAttentionForCausalLM, self).decode_forward(*args, **kwargs)
         page_tables_per_layer = self._ensure_page_tables_per_layer(page_tables_per_layer, kwargs.get("page_table"))
         per_submesh = self._chunk_page_tables_per_dp(page_tables_per_layer)
-        if per_submesh is not None:
+        if per_submesh is not None and self._reload_per_layer_page_tables(kwargs):
             for m, pt_for_submesh in zip(self.model, per_submesh):
                 m.update_persistent_per_layer_page_tables(pt_for_submesh)
         with self._route_per_layer_page_tables(per_submesh):
@@ -1025,6 +1046,8 @@ class GptOssForCausalLM(HybridAttentionForCausalLM):
     cleared on the way out so a subsequent legacy single-page-table call
     isn't accidentally affected.
     """
+
+    decode_input_update_contract = 1
 
     # Class-level capabilities
     model_capabilities = {
@@ -1066,7 +1089,7 @@ class GptOssForCausalLM(HybridAttentionForCausalLM):
             return super(HybridAttentionForCausalLM, self).decode_forward(*args, **kwargs)
         page_tables_per_layer = self._ensure_page_tables_per_layer(page_tables_per_layer, kwargs.get("page_table"))
         per_submesh = self._chunk_page_tables_per_dp(page_tables_per_layer)
-        if per_submesh is not None:
+        if per_submesh is not None and self._reload_per_layer_page_tables(kwargs):
             for m, pt_for_submesh in zip(self.model, per_submesh):
                 m.update_persistent_per_layer_page_tables(pt_for_submesh)
         with self._route_per_layer_page_tables(per_submesh):

--- a/models/tt_transformers/tt/generator_vllm.py
+++ b/models/tt_transformers/tt/generator_vllm.py
@@ -627,6 +627,10 @@ class MllamaForConditionalGeneration(Generator, SupportsMultiModal):
         reload_page_table = kwargs.pop("reload_page_table")
         reload_sampling_params = kwargs.pop("reload_sampling_params")
         reset_sampling_state = kwargs.pop("reset_sampling_state")
+        # Mllama has no persistent model state keyed by vLLM's condensed
+        # decode slots. Contract v1 nevertheless supplies slot_remap for every
+        # decode so adapters with recurrent state can consume it.
+        kwargs.pop("slot_remap", None)
         if not reload_inputs or reload_page_table or reload_sampling_params or reset_sampling_state:
             raise ValueError("Mllama requires a full host-input reload and has no " "device sampling state")
         logits = super().decode_forward_llama_vision(*args, **kwargs)

--- a/models/tt_transformers/tt/generator_vllm.py
+++ b/models/tt_transformers/tt/generator_vllm.py
@@ -627,6 +627,20 @@ class MllamaForConditionalGeneration(Generator, SupportsMultiModal):
         )
 
     def decode_forward(self, *args, **kwargs):
+        reload_inputs = kwargs.pop("reload_inputs")
+        reload_page_table = kwargs.pop("reload_page_table")
+        reload_sampling_params = kwargs.pop("reload_sampling_params")
+        reset_sampling_state = kwargs.pop("reset_sampling_state")
+        if (
+            not reload_inputs
+            or reload_page_table
+            or reload_sampling_params
+            or reset_sampling_state
+        ):
+            raise ValueError(
+                "Mllama requires a full host-input reload and has no "
+                "device sampling state"
+            )
         logits = super().decode_forward_llama_vision(*args, **kwargs)
         if isinstance(logits, tuple):
             return logits[0]
@@ -638,8 +652,6 @@ class MllamaForConditionalGeneration(Generator, SupportsMultiModal):
 
 
 class LlamaForCausalLM(Generator):
-    decode_input_update_contract = 1
-
     # Class-level capabilities
     model_capabilities = {
         "supports_prefix_caching": True,
@@ -725,8 +737,6 @@ class LlamaForCausalLM(Generator):
 
 
 class QwenForCausalLM(Generator):
-    decode_input_update_contract = 1
-
     # Class-level capabilities
     model_capabilities = {
         "supports_prefix_caching": True,
@@ -806,8 +816,6 @@ class QwenForCausalLM(Generator):
 
 
 class MistralForCausalLM(Generator):
-    decode_input_update_contract = 1
-
     # Class-level capabilities
     model_capabilities = {
         "supports_prefix_caching": True,
@@ -905,8 +913,6 @@ class Gemma3ForConditionalGeneration(HybridAttentionForCausalLM, SupportsMultiMo
     picks up the stash via ``_active_page_tables_per_layer`` and routes
     each layer's attention to its own page table.
     """
-
-    decode_input_update_contract = 1
 
     # Class-level capabilities
     model_capabilities = {
@@ -1046,8 +1052,6 @@ class GptOssForCausalLM(HybridAttentionForCausalLM):
     cleared on the way out so a subsequent legacy single-page-table call
     isn't accidentally affected.
     """
-
-    decode_input_update_contract = 1
 
     # Class-level capabilities
     model_capabilities = {

--- a/models/tt_transformers/tt/generator_vllm.py
+++ b/models/tt_transformers/tt/generator_vllm.py
@@ -415,6 +415,8 @@ class CustomNamespace(SimpleNamespace):
     dummy_inputs=Mistral3DummyInputsBuilder,
 )
 class Mistral3ForConditionalGeneration(Generator, SupportsMultiModal):
+    decode_input_update_contract = 1
+
     model_capabilities = {
         "supports_prefix_caching": False,
         "supports_sample_on_device": True,
@@ -506,6 +508,8 @@ class Mistral3ForConditionalGeneration(Generator, SupportsMultiModal):
 #     MllamaMultiModalProcessor, info=TT_MllamaProcessingInfo, dummy_inputs=DummyInputsBuilder
 # )
 class MllamaForConditionalGeneration(Generator, SupportsMultiModal):
+    decode_input_update_contract = 1
+
     # Class-level capabilities
     # Note: Mllama doesn't support prefix caching (it's V0 only)
     # decode_forward calls decode_forward_llama_vision and discards anything
@@ -636,6 +640,8 @@ class MllamaForConditionalGeneration(Generator, SupportsMultiModal):
 
 
 class LlamaForCausalLM(Generator):
+    decode_input_update_contract = 1
+
     # Class-level capabilities
     model_capabilities = {
         "supports_prefix_caching": True,
@@ -721,6 +727,8 @@ class LlamaForCausalLM(Generator):
 
 
 class QwenForCausalLM(Generator):
+    decode_input_update_contract = 1
+
     # Class-level capabilities
     model_capabilities = {
         "supports_prefix_caching": True,
@@ -800,6 +808,8 @@ class QwenForCausalLM(Generator):
 
 
 class MistralForCausalLM(Generator):
+    decode_input_update_contract = 1
+
     # Class-level capabilities
     model_capabilities = {
         "supports_prefix_caching": True,
@@ -897,6 +907,8 @@ class Gemma3ForConditionalGeneration(HybridAttentionForCausalLM, SupportsMultiMo
     picks up the stash via ``_active_page_tables_per_layer`` and routes
     each layer's attention to its own page table.
     """
+
+    decode_input_update_contract = 1
 
     # Class-level capabilities
     model_capabilities = {
@@ -1036,6 +1048,8 @@ class GptOssForCausalLM(HybridAttentionForCausalLM):
     cleared on the way out so a subsequent legacy single-page-table call
     isn't accidentally affected.
     """
+
+    decode_input_update_contract = 1
 
     # Class-level capabilities
     model_capabilities = {

--- a/models/tt_transformers/tt/generator_vllm.py
+++ b/models/tt_transformers/tt/generator_vllm.py
@@ -243,16 +243,8 @@ class HybridAttentionForCausalLM(Generator):
 
     @staticmethod
     def _reload_per_layer_page_tables(kwargs) -> bool:
-        """Honor the explicit decode update contract, with legacy fallback."""
-        reload_inputs = kwargs.get("reload_inputs")
-        reload_page_table = kwargs.get("reload_page_table")
-        if reload_inputs is None and reload_page_table is None:
-            return True
-        if reload_inputs is None or reload_page_table is None:
-            raise ValueError(
-                "reload_inputs and reload_page_table must be provided together"
-            )
-        return bool(reload_inputs or reload_page_table)
+        """Whether the explicit contract requests per-layer page-table upload."""
+        return bool(kwargs["reload_inputs"] or kwargs["reload_page_table"])
 
     def _ensure_page_tables_per_layer(self, page_tables_per_layer, page_table):
         """When invoked outside the vLLM hybrid plugin (e.g. by warmup
@@ -521,7 +513,7 @@ class MllamaForConditionalGeneration(Generator, SupportsMultiModal):
     # declare on-device sampling unsupported.
     model_capabilities = {
         "supports_prefix_caching": False,
-        "supports_async_decode": True,
+        "supports_async_decode": False,
         "supports_sample_on_device": False,
     }
 
@@ -631,16 +623,8 @@ class MllamaForConditionalGeneration(Generator, SupportsMultiModal):
         reload_page_table = kwargs.pop("reload_page_table")
         reload_sampling_params = kwargs.pop("reload_sampling_params")
         reset_sampling_state = kwargs.pop("reset_sampling_state")
-        if (
-            not reload_inputs
-            or reload_page_table
-            or reload_sampling_params
-            or reset_sampling_state
-        ):
-            raise ValueError(
-                "Mllama requires a full host-input reload and has no "
-                "device sampling state"
-            )
+        if not reload_inputs or reload_page_table or reload_sampling_params or reset_sampling_state:
+            raise ValueError("Mllama requires a full host-input reload and has no " "device sampling state")
         logits = super().decode_forward_llama_vision(*args, **kwargs)
         if isinstance(logits, tuple):
             return logits[0]

--- a/models/tt_transformers/tt/generator_vllm.py
+++ b/models/tt_transformers/tt/generator_vllm.py
@@ -241,6 +241,11 @@ class HybridAttentionForCausalLM(Generator):
     def allocate_kv_cache_per_layer(self, per_layer_specs):
         return allocate_vllm_kv_cache_per_layer(per_layer_specs, dp_model=self.model, tt_cache_path=self.cache_path)
 
+    @staticmethod
+    def _reload_per_layer_page_tables(kwargs) -> bool:
+        """Whether the explicit contract requests per-layer page-table upload."""
+        return bool(kwargs["reload_inputs"] or kwargs["reload_page_table"])
+
     def _ensure_page_tables_per_layer(self, page_tables_per_layer, page_table):
         """When invoked outside the vLLM hybrid plugin (e.g. by warmup
         which only knows about the legacy single ``page_table``), optionally
@@ -410,6 +415,8 @@ class CustomNamespace(SimpleNamespace):
     dummy_inputs=Mistral3DummyInputsBuilder,
 )
 class Mistral3ForConditionalGeneration(Generator, SupportsMultiModal):
+    decode_input_update_contract = 1
+
     model_capabilities = {
         "supports_prefix_caching": False,
         "supports_sample_on_device": True,
@@ -502,6 +509,8 @@ class Mistral3ForConditionalGeneration(Generator, SupportsMultiModal):
 #     MllamaMultiModalProcessor, info=TT_MllamaProcessingInfo, dummy_inputs=DummyInputsBuilder
 # )
 class MllamaForConditionalGeneration(Generator, SupportsMultiModal):
+    decode_input_update_contract = 1
+
     # Class-level capabilities
     # Note: Mllama doesn't support prefix caching (it's V0 only)
     # decode_forward calls decode_forward_llama_vision and discards anything
@@ -509,7 +518,7 @@ class MllamaForConditionalGeneration(Generator, SupportsMultiModal):
     # declare on-device sampling unsupported.
     model_capabilities = {
         "supports_prefix_caching": False,
-        "supports_async_decode": True,
+        "supports_async_decode": False,
         "supports_sample_on_device": False,
     }
 
@@ -615,6 +624,16 @@ class MllamaForConditionalGeneration(Generator, SupportsMultiModal):
         )
 
     def decode_forward(self, *args, **kwargs):
+        reload_inputs = kwargs.pop("reload_inputs")
+        reload_page_table = kwargs.pop("reload_page_table")
+        reload_sampling_params = kwargs.pop("reload_sampling_params")
+        reset_sampling_state = kwargs.pop("reset_sampling_state")
+        # Mllama has no persistent model state keyed by vLLM's condensed
+        # decode slots. Contract v1 nevertheless supplies slot_remap for every
+        # decode so adapters with recurrent state can consume it.
+        kwargs.pop("slot_remap", None)
+        if not reload_inputs or reload_page_table or reload_sampling_params or reset_sampling_state:
+            raise ValueError("Mllama requires a full host-input reload and has no " "device sampling state")
         logits = super().decode_forward_llama_vision(*args, **kwargs)
         if isinstance(logits, tuple):
             return logits[0]
@@ -626,6 +645,8 @@ class MllamaForConditionalGeneration(Generator, SupportsMultiModal):
 
 
 class LlamaForCausalLM(Generator):
+    decode_input_update_contract = 1
+
     # Class-level capabilities
     model_capabilities = {
         "supports_prefix_caching": True,
@@ -718,6 +739,8 @@ class LlamaForCausalLM(Generator):
 
 
 class QwenForCausalLM(Generator):
+    decode_input_update_contract = 1
+
     # Class-level capabilities
     model_capabilities = {
         "supports_prefix_caching": True,
@@ -804,6 +827,8 @@ class QwenForCausalLM(Generator):
 
 
 class MistralForCausalLM(Generator):
+    decode_input_update_contract = 1
+
     # Class-level capabilities
     model_capabilities = {
         "supports_prefix_caching": True,
@@ -908,6 +933,8 @@ class Gemma3ForConditionalGeneration(HybridAttentionForCausalLM, SupportsMultiMo
     picks up the stash via ``_active_page_tables_per_layer`` and routes
     each layer's attention to its own page table.
     """
+
+    decode_input_update_contract = 1
 
     # Class-level capabilities
     model_capabilities = {
@@ -1016,7 +1043,7 @@ class Gemma3ForConditionalGeneration(HybridAttentionForCausalLM, SupportsMultiMo
             return super(HybridAttentionForCausalLM, self).decode_forward(*args, **kwargs)
         page_tables_per_layer = self._ensure_page_tables_per_layer(page_tables_per_layer, kwargs.get("page_table"))
         per_submesh = self._chunk_page_tables_per_dp(page_tables_per_layer)
-        if per_submesh is not None:
+        if per_submesh is not None and self._reload_per_layer_page_tables(kwargs):
             for m, pt_for_submesh in zip(self.model, per_submesh):
                 m.update_persistent_per_layer_page_tables(pt_for_submesh)
         with self._route_per_layer_page_tables(per_submesh):
@@ -1156,6 +1183,8 @@ class GptOssForCausalLM(HybridAttentionForCausalLM):
     isn't accidentally affected.
     """
 
+    decode_input_update_contract = 1
+
     # Class-level capabilities
     model_capabilities = {
         "supports_prefix_caching": False,  # Sliding window => no prefix caching
@@ -1197,7 +1226,7 @@ class GptOssForCausalLM(HybridAttentionForCausalLM):
             return super(HybridAttentionForCausalLM, self).decode_forward(*args, **kwargs)
         page_tables_per_layer = self._ensure_page_tables_per_layer(page_tables_per_layer, kwargs.get("page_table"))
         per_submesh = self._chunk_page_tables_per_dp(page_tables_per_layer)
-        if per_submesh is not None:
+        if per_submesh is not None and self._reload_per_layer_page_tables(kwargs):
             for m, pt_for_submesh in zip(self.model, per_submesh):
                 m.update_persistent_per_layer_page_tables(pt_for_submesh)
         with self._route_per_layer_page_tables(per_submesh):

--- a/tests/emule/models/test_tt_transformers_text_demo.py
+++ b/tests/emule/models/test_tt_transformers_text_demo.py
@@ -1237,16 +1237,20 @@ def test_demo_text(
                 out_tok[0] = token_acc.collect_predicted_tokens(out_tok[0].item())
 
             # Run decode forward
+            reload_decode_inputs = iteration == 0 or not enable_trace or device_sampling_params is None
             logits, log_probs = generator.decode_forward(
                 out_tok,
                 current_pos,
                 enable_trace=enable_trace,
                 page_table=page_table,
                 kv_cache=tt_kv_cache,
-                reset_batch=(iteration == 0),
                 sampling_params=device_sampling_params,
                 prompt_tokens=input_tokens_prefill_pt,
                 output_tokens=out_tok,
+                reload_inputs=reload_decode_inputs,
+                reload_page_table=False,
+                reload_sampling_params=device_sampling_params is not None,
+                reset_sampling_state=device_sampling_params is not None and iteration == 0,
             )
 
             # Get the next token

--- a/tests/emule/models/test_tt_transformers_text_demo.py
+++ b/tests/emule/models/test_tt_transformers_text_demo.py
@@ -1233,16 +1233,20 @@ def test_demo_text(
                 out_tok[0] = token_acc.collect_predicted_tokens(out_tok[0].item())
 
             # Run decode forward
+            reload_decode_inputs = iteration == 0 or not enable_trace or device_sampling_params is None
             logits, log_probs = generator.decode_forward(
                 out_tok,
                 current_pos,
                 enable_trace=enable_trace,
                 page_table=page_table,
                 kv_cache=tt_kv_cache,
-                reset_batch=(iteration == 0),
                 sampling_params=device_sampling_params,
                 prompt_tokens=input_tokens_prefill_pt,
                 output_tokens=out_tok,
+                reload_inputs=reload_decode_inputs,
+                reload_page_table=False,
+                reload_sampling_params=device_sampling_params is not None,
+                reset_sampling_state=device_sampling_params is not None and iteration == 0,
             )
 
             # Get the next token

--- a/tt-train/sources/examples/grpo_remote_rollout/utils/ttt_generation_worker.py
+++ b/tt-train/sources/examples/grpo_remote_rollout/utils/ttt_generation_worker.py
@@ -245,7 +245,15 @@ class TttGenerationWorker:
                 kv_cache=self.tt_kv_cache,
                 enable_trace=enable_trace,
                 sampling_params=self._sampling_params,
-                reset_batch=(step == 0),
+                # Prefill supplies the first token. On the first decode, load
+                # that token and start a new sampling state. A traced decode
+                # then feeds its sampled token and next position back on device.
+                reload_inputs=step == 0 or not enable_trace,
+                reload_page_table=False,
+                # Preserve the old worker behavior: it uploaded params on
+                # every decode, while sampling history reset only at step 0.
+                reload_sampling_params=True,
+                reset_sampling_state=step == 0,
                 prompt_tokens=input_tokens_prefill_pt,
                 output_tokens=out_tok,
                 read_from_device=False,


### PR DESCRIPTION
## Summary

- implement the strict version-1 decode update contract: every refactored call supplies `reload_inputs`, `reload_page_table`, `reload_sampling_params`, and `reset_sampling_state`
- advertise `decode_input_update_contract = 1` on production adapters consumed by the standalone plugin
- remove model-side reload heuristics and move standalone demo and SGLang policy to explicit call sites
- preserve Gemma4 batch-keyed traces, hybrid page-table routing, and padded token feedback while making mode and layout reloads plugin-owned
- apply each `slot_remap` exactly once to persistent slot-indexed state, including dormant sampling state; split lane-DP mappings into rank-local permutations
- preserve continuing DeepSeek parameters, penalty history, and seed state during partial prefill
- keep Galaxy parameter shadows aligned with slot remaps and align seed counters only from authoritative host positions
- avoid warmup penalty-state resets when no request-owned history exists
- initialize and upload first-lifecycle seeds directly, including `seed=None`, without relying on tenstorrent/tt-metal#51556

## Negotiation and rollout

The paired standalone-plugin change, tenstorrent/vllm-tt-plugin#78, is merged. The plugin preserves the legacy `reset_batch` call shape, with a warning, for unmarked version-0 adapters. Marked adapters receive the explicit version-1 commands from this PR. Refactored model APIs remain strict: direct callers provide all four commands and no model-side fallback heuristics are restored.

`model_capabilities["supports_async_decode"]` is a separate residency gate. A wrapper may enable it only when sampled-token feedback remains device-resident and persistent position advances exactly once. Other wrappers receive explicit full-input reload commands from the plugin.

## Design specification

- [tt-metal sampling and decode contract](https://github.com/tenstorrent/tt-metal/blob/tcheda/issue-449-reload-contract/models/common/sampling/README.md)
- [merged plugin reload-contract specification](https://github.com/tenstorrent/vllm-tt-plugin/blob/main/docs/DECODE_RELOAD_CONTRACT.md)

These documents define the command semantics, transition requirements, remap and sampling-state rules, warmup and SGLang policies, and the model-author checklist.

## Rebase and review fixes

Rebased onto tt-metal `main` at `68107a0c9b14f3922c53371f0e69a877168ac2d6`; PR head is `8b263d2239f5283c9ddef991032235afbe729c5b`.

- the removed T3000 vLLM adapter remains deleted
- mode changes and decode layout or batch changes cause a plugin-planned full reload before selecting another trace buffer
- Galaxy separated sampling now receives the forward input-authority command; seed counters realign only when host positions are authoritative
- DeepSeek partial admission preserves unlisted live slots and resets penalty state only for incoming slots
- Galaxy slot remaps move the per-slot parameter shadow and sampler state together

## Validation

- repository pre-commit hooks passed locally over the complete PR diff after the final rebase
- Python syntax compilation and `git diff --check` passed after the final rebase
- focused regressions cover strict direct callers, mode and Gemma4 batch trace selection, DeepSeek partial-admission state preservation, lane-DP remapping, Galaxy seed and parameter remapping, reset-only seeds, warmup behavior, and Gemma4 PLI token feedback
- current PR CI: [checks for this branch](https://github.com/tenstorrent/tt-metal/actions?query=branch%3Atcheda%2Fissue-449-reload-contract)
- refreshed all-model, all-SKU, all-tier vLLM branch nightly against merged plugin main `7250ddfaa988cc7417f518266dce52e425745472`: [run 35680811729](https://github.com/tenstorrent/tt-metal/actions/runs/35680811729) (running)

Related to tenstorrent/vllm#449

### CI Status

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=tcheda/issue-449-reload-contract)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:tcheda/issue-449-reload-contract)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=tcheda/issue-449-reload-contract)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:tcheda/issue-449-reload-contract)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=tcheda/issue-449-reload-contract)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:tcheda/issue-449-reload-contract)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=tcheda/issue-449-reload-contract)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:tcheda/issue-449-reload-contract)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=tcheda/issue-449-reload-contract)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:tcheda/issue-449-reload-contract)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=tcheda/issue-449-reload-contract)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:tcheda/issue-449-reload-contract)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=tcheda/issue-449-reload-contract)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:tcheda/issue-449-reload-contract)