### PR TITLE
ttop-await-resource: don't merge stderr into the polled value; re-mint on any error

### DIFF
--- a/.github/actions/ttop-await-resource/action.yaml
+++ b/.github/actions/ttop-await-resource/action.yaml
@@ -44,11 +44,8 @@ runs:
         RETRIES: ${{ inputs.retries }}
       run: |
         POLL_INTERVAL=5
-        # Consecutive failed calls before giving up. Was MAX_AUTH_FAILURES=3, which
-        # was right when only confirmed auth failures reached that branch; now that
-        # ANY failure counts (see the error path below), 3 would abort on a 15s API
-        # blip. 60 x 5s rides out a real blip while still bounding a hopeless case
-        # to ~5 min instead of the caller's timeoutSeconds (999m for allocations).
+        # Was MAX_AUTH_FAILURES=3; any failure now counts, and 3 would abort on a
+        # 15s blip. Bounds a hopeless case to ~5 min vs timeoutSeconds (999m).
         MAX_CONSECUTIVE_ERRORS=60
         # Default 5 min: long enough to ride out a token expiry / transient blip,
         # short enough not to pin a runner. Override via the timeoutSeconds input.
@@ -88,7 +85,6 @@ runs:
         errors=0
         start=$SECONDS
         errfile=$(mktemp)
-        trap 'rm -f "$errfile"' EXIT
         while true; do
           if (( SECONDS - start >= OVERALL_TIMEOUT )); then
             echo "::error::Timed out after $((OVERALL_TIMEOUT / 60))m waiting for ${RESOURCE} to be (${MODE})."
@@ -108,12 +104,8 @@ runs:
             fi
           fi
 
-          # stderr is captured SEPARATELY, never merged into $output. Merging it
-          # (the previous `2>&1`) put kubectl's warnings into the value compared
-          # against $EXPECTED on an otherwise-SUCCESSFUL call, so a ready resource
-          # read as not-ready. Seen in tt-blaze run 30573758666, where
-          # `E0730 ... memcache.go:265] "Unhandled Error" ...` arrived where a phase
-          # belonged while rc was 0.
+          # stderr to a file, NOT 2>&1: merged, a warning on a successful call lands
+          # in $output and the $EXPECTED compare below fails on a ready resource.
           case "$MODE" in
             delete)
               output=$(kubectl --token "$IDTOKEN" -n "$NAMESPACE" delete "$RESOURCE" --ignore-not-found 2>"$errfile") && rc=0 || rc=$?
@@ -126,7 +118,6 @@ runs:
               output=$(kubectl --token "$IDTOKEN" -n "$NAMESPACE" get "$RESOURCE" -o jsonpath="$JSONPATH" 2>"$errfile") && rc=0 || rc=$?
               if (( rc == 0 )); then
                 errors=0                                         # successful read → reset the failure streak
-                output="${output//[[:space:]]/}"                 # jsonpath can carry stray whitespace
                 if [[ "$output" == "$EXPECTED" ]]; then
                   echo "::notice::$RESOURCE is ready ($EXPECTED) after $(( (SECONDS - start) / 60 ))m."; exit 0
                 fi
@@ -136,22 +127,11 @@ runs:
               ;;                                                 # rc != 0 falls through to the shared error path
           esac
 
-          # Re-mint on ANY failed call rather than only on ones matching an auth
-          # regex. The previous `grep -qiE 'unauthorized|must be logged in|401'`
-          # sent everything else to a warn-and-retry branch that never re-minted,
-          # so an expired-but-non-empty token whose message did not match kept
-          # being used forever — the empty-token guard above cannot catch that,
-          # because the token is not empty, just dead. Observed text that matches
-          # none of the three:
-          #   "couldn't get current server API group list: the server has asked
-          #    for the client to provide credentials"
-          # Minting is cheap, retried in-place and idempotent, so there is nothing
-          # to gain by classifying first and a hang to lose by getting it wrong.
-          #
-          # This is not a rare path: on a 64-minute placement wait measured in
-          # tt-blaze run 30585556114 the token expired 12 times, every ~308s
-          # (min 301, max 316). Expiry recovery runs on essentially every
-          # non-trivial wait, so it must not depend on error-message matching.
+          # Re-mint on ANY failure, no error-message classifier. An expired token
+          # often says "the server has asked for the client to provide credentials",
+          # which the old auth regex missed, so it kept polling with a dead token.
+          # The empty-token guard above can't catch it: not empty, just dead.
+          # The token lives ~5 min, so this path runs on every non-trivial wait.
           errors=$((errors + 1))
           echo "::warning::${MODE} failed on ${RESOURCE} (${errors}/${MAX_CONSECUTIVE_ERRORS}, rc=${rc}); reissuing token: $(tr '\n' ' ' < "$errfile" | cut -c1-300)"
           if (( errors >= MAX_CONSECUTIVE_ERRORS )); then

--- a/.github/actions/ttop-await-resource/action.yaml
+++ b/.github/actions/ttop-await-resource/action.yaml
@@ -44,7 +44,12 @@ runs:
         RETRIES: ${{ inputs.retries }}
       run: |
         POLL_INTERVAL=5
-        MAX_AUTH_FAILURES=3
+        # Consecutive failed calls before giving up. Was MAX_AUTH_FAILURES=3, which
+        # was right when only confirmed auth failures reached that branch; now that
+        # ANY failure counts (see the error path below), 3 would abort on a 15s API
+        # blip. 60 x 5s rides out a real blip while still bounding a hopeless case
+        # to ~5 min instead of the caller's timeoutSeconds (999m for allocations).
+        MAX_CONSECUTIVE_ERRORS=60
         # Default 5 min: long enough to ride out a token expiry / transient blip,
         # short enough not to pin a runner. Override via the timeoutSeconds input.
         OVERALL_TIMEOUT="${OVERALL_TIMEOUT:-300}"
@@ -80,8 +85,10 @@ runs:
 
         mint_token || true
 
-        auth_failures=0
+        errors=0
         start=$SECONDS
+        errfile=$(mktemp)
+        trap 'rm -f "$errfile"' EXIT
         while true; do
           if (( SECONDS - start >= OVERALL_TIMEOUT )); then
             echo "::error::Timed out after $((OVERALL_TIMEOUT / 60))m waiting for ${RESOURCE} to be (${MODE})."
@@ -101,37 +108,56 @@ runs:
             fi
           fi
 
+          # stderr is captured SEPARATELY, never merged into $output. Merging it
+          # (the previous `2>&1`) put kubectl's warnings into the value compared
+          # against $EXPECTED on an otherwise-SUCCESSFUL call, so a ready resource
+          # read as not-ready. Seen in tt-blaze run 30573758666, where
+          # `E0730 ... memcache.go:265] "Unhandled Error" ...` arrived where a phase
+          # belonged while rc was 0.
           case "$MODE" in
             delete)
-              output=$(kubectl --token "$IDTOKEN" -n "$NAMESPACE" delete "$RESOURCE" --ignore-not-found 2>&1) && rc=0 || rc=$?
+              output=$(kubectl --token "$IDTOKEN" -n "$NAMESPACE" delete "$RESOURCE" --ignore-not-found 2>"$errfile") && rc=0 || rc=$?
               if ((rc==0)); then
                 echo "::notice::$RESOURCE is deleted."
                 exit 0
               fi
               ;;
             poll)
-              output=$(kubectl --token "$IDTOKEN" -n "$NAMESPACE" get "$RESOURCE" -o jsonpath="$JSONPATH" 2>&1) && rc=0 || rc=$?
+              output=$(kubectl --token "$IDTOKEN" -n "$NAMESPACE" get "$RESOURCE" -o jsonpath="$JSONPATH" 2>"$errfile") && rc=0 || rc=$?
               if (( rc == 0 )); then
-                auth_failures=0                                  # successful read → auth is fine, reset streak
+                errors=0                                         # successful read → reset the failure streak
+                output="${output//[[:space:]]/}"                 # jsonpath can carry stray whitespace
                 if [[ "$output" == "$EXPECTED" ]]; then
-                  echo "::notice::$RESOURCE is ready ($EXPECTED)."; exit 0
+                  echo "::notice::$RESOURCE is ready ($EXPECTED) after $(( (SECONDS - start) / 60 ))m."; exit 0
                 fi
                 echo "[info] $RESOURCE not ready (got '${output:-<empty>}', want '$EXPECTED') — waiting..."
                 sleep "$POLL_INTERVAL"; continue                 # <-- the "waiting" case: loop, DON'T fall into errors
               fi
-              ;;                                                 # rc != 0 falls through to shared auth/transient
+              ;;                                                 # rc != 0 falls through to the shared error path
           esac
 
-          if echo "$output" | grep -qiE 'unauthorized|must be logged in|401'; then
-            auth_failures=$((auth_failures + 1))
-            echo "::warning::Auth failure (${auth_failures}/${MAX_AUTH_FAILURES}) on ${RESOURCE}; reissuing token."
-            if (( auth_failures >= MAX_AUTH_FAILURES )); then
-              echo "::error::Repeated auth failures despite token reissue; failing."
-              exit 1
-            fi
-            mint_token || true
-          else
-            echo "::warning::Transient error on ${RESOURCE} (rc=${rc}): ${output}"
+          # Re-mint on ANY failed call rather than only on ones matching an auth
+          # regex. The previous `grep -qiE 'unauthorized|must be logged in|401'`
+          # sent everything else to a warn-and-retry branch that never re-minted,
+          # so an expired-but-non-empty token whose message did not match kept
+          # being used forever — the empty-token guard above cannot catch that,
+          # because the token is not empty, just dead. Observed text that matches
+          # none of the three:
+          #   "couldn't get current server API group list: the server has asked
+          #    for the client to provide credentials"
+          # Minting is cheap, retried in-place and idempotent, so there is nothing
+          # to gain by classifying first and a hang to lose by getting it wrong.
+          #
+          # This is not a rare path: on a 64-minute placement wait measured in
+          # tt-blaze run 30585556114 the token expired 12 times, every ~308s
+          # (min 301, max 316). Expiry recovery runs on essentially every
+          # non-trivial wait, so it must not depend on error-message matching.
+          errors=$((errors + 1))
+          echo "::warning::${MODE} failed on ${RESOURCE} (${errors}/${MAX_CONSECUTIVE_ERRORS}, rc=${rc}); reissuing token: $(tr '\n' ' ' < "$errfile" | cut -c1-300)"
+          if (( errors >= MAX_CONSECUTIVE_ERRORS )); then
+            echo "::error::Giving up on ${RESOURCE} after ${errors} consecutive failures ($(( errors * POLL_INTERVAL ))s). Last error: $(tr '\n' ' ' < "$errfile" | cut -c1-300)"
+            exit 1
           fi
+          mint_token || true
           sleep "$POLL_INTERVAL"
         done


### PR DESCRIPTION
### PR Category
Bug fix

## What to do

Review 43 added / 17 removed lines in one file: `.github/actions/ttop-await-resource/action.yaml`. ~10 minutes.

Three changes. Number 3 is the only judgement call.

1. **Remove `2>&1` from the kubectl capture.** stderr was landing in the value compared against `$EXPECTED`, so a ready resource read as not-ready. stderr now goes to a temp file for diagnostics only.
2. **Delete the auth regex.** Any failed poll now re-mints the token instead of only errors matching `unauthorized|must be logged in|401`.
3. **`MAX_AUTH_FAILURES=3` → `MAX_CONSECUTIVE_ERRORS=60`.** ← the call I want checked. 3 was correct when only confirmed auth failures reached that branch. Now that any failure counts, 3 consecutive would abort on a 15-second API blip. 60 × 5s rides out a blip, still bounds a hopeless case to ~5 min instead of the caller's `timeoutSeconds` (999m for allocations).

## Why this is critical

Every allocation wait longer than ~5 minutes is a coin flip on whether CI hangs. Measured, not theoretical.

- The OIDC token dies every **308 seconds** (min 301, max 316, 12 expiries in one 64-minute wait). Comments elsewhere in these actions assume 10-15 min. They are wrong.
- On each expiry, re-mint fires only if the error text matches the regex. Real text is often `"the server has asked for the client to provide credentials"` — no match. Token stays dead. Loop polls forever.
- tt-blaze run [30573758666](https://github.com/tenstorrent/tt-blaze/actions/runs/30573758666/job/90979661911): **578 dead polls, 79 minutes, holding a 16-node SC16 superpod.** The allocation had been `Allocated` for the last 20 of those minutes.
- That same run logged **7 successful recoveries** from matched errors. So it works most of the time and then silently eats an hour. Worse than a clean break, because nothing looks wrong.

Cost per incident: ~1 superpod-hour plus everyone queued behind it. Only 2 SC16 groups carry `ci.tenstorrent.com/enabled`, so contention is structural.

## The two bugs, concretely

**1. `2>&1` corrupted the comparison**

```bash
output=$(kubectl ... -o jsonpath="$JSONPATH" 2>&1)   # stderr merged in
[[ "$output" == "$EXPECTED" ]]                        # compares warnings vs "Allocated"
```

Fired live in run 30573758666 at 19:41 and 19:46, where the compared value was `E0730 ... memcache.go:265] "Unhandled Error" ...` while `rc` was 0.

**2. The regex was fail-open**

`grep -qiE 'unauthorized|must be logged in|401'` matched, else warn-and-retry **without re-minting**. An expired-but-non-empty token is invisible to the empty-token guard from #50729 — the token is not empty, just dead.

Classifier removed rather than extended. Minting is cheap, retried in-place, idempotent. Nothing to gain by classifying first; a hang to lose by getting it wrong.

## Proof

Fake `kubectl`, `poll` mode:

| scenario | main today | this PR |
|---|---|---|
| resource becomes ready | `exit 0` | `exit 0` |
| warning on a successful call | **HANGS** | `exit 0` |
| token expires, text unmatched | **HANGS** | `exit 0` |
| permanent hard failure | **HANGS** | `exit 1` |

`delete` mode gets the same stderr split and re-mint path. Its output was never compared against anything, so behaviour is unchanged apart from re-minting on failure.

## Related

1. #50729 — introduced this action, fixed the empty-token root cause. This PR fixes what remained.
2. #51645 — backports #50729 to `blaze-metal-main-uplift-july-15-rev0`, which tt-blaze pins. Necessary but **not sufficient alone**: verified that the expiry path still hangs without this PR. I will port these two lines there once this lands.
3. #51634 — my earlier patch against the old inline loop. Closed; that loop no longer exists on main.

## Not in this PR

The test harness (~120 lines, fakes for `kubectl`/`curl`/`jq`, no cluster needed). Left out to keep the diff to the two defects. It needs `_unit-tests-infra.yaml` extended to `paths: .github/actions/**` to actually run. Say the word and I will add both.

**Next: approve, or push back on item 3 above.**

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ci/ttop-await-resource-poll-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ci/ttop-await-resource-poll-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ci/ttop-await-resource-poll-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ci/ttop-await-resource-poll-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ci/ttop-await-resource-poll-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ci/ttop-await-resource-poll-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ci/ttop-await-resource-poll-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ci/ttop-await-resource-poll-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ci/ttop-await-resource-poll-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ci/ttop-await-resource-poll-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ci/ttop-await-resource-poll-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ci/ttop-await-resource-poll-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ci/ttop-await-resource-poll-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ci/ttop-await-resource-poll-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ci/ttop-await-resource-poll-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ci/ttop-await-resource-poll-fixes)