### PR TITLE
Enable Quasar selection in LLK ttsim regression script

### DIFF
--- a/tt_metal/tt-llk/tests/run_ttsim_regression.sh
+++ b/tt_metal/tt-llk/tests/run_ttsim_regression.sh
@@ -3,10 +3,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-# Run the LLK pytest suite against the ttsim functional simulator, excluding
-# tests marked `quasar`, `nightly`, or `perf`. Each test runs in a forked
-# subprocess so that ttsim's `_Exit(1)` on UnimplementedFunctionality (and
-# similar) only kills that one test and the suite continues.
+# Run the LLK pytest suite against the ttsim functional simulator. For
+# Wormhole/Blackhole this excludes Quasar-only tests; for Quasar it selects
+# Quasar-only tests. Each test runs in a forked subprocess so that ttsim's
+# `_Exit(1)` on UnimplementedFunctionality (and similar) only kills that one
+# test and the suite continues.
 #
 # Generates:
 #   - JUnit XML at python_tests/ttsim_results/ttsim_<timestamp>.xml
@@ -25,10 +26,6 @@ COLLECTED_PATH="${RESULTS_DIR}/ttsim_${TIMESTAMP}.collected.txt"
 LATEST_XML="${RESULTS_DIR}/latest.xml"
 LATEST_HTML="${RESULTS_DIR}/latest.html"
 LATEST_COLLECTED="${RESULTS_DIR}/latest.collected.txt"
-
-# Marker expression shared by the collection pass and the real run so the
-# "expected" denominator and the "recorded" results select the exact same set.
-MARKER_EXPR="not quasar and not nightly and not perf and not accuracy"
 
 WORKERS="${WORKERS:-10}"
 TIMEOUT="${TIMEOUT:-300}"
@@ -49,9 +46,9 @@ usage() {
     cat <<EOF
 Usage: $(basename "$0") [OPTIONS] [TEST_PATH...] [-- PYTEST_EXTRA_ARGS...]
 
-Runs the LLK pytest suite on ttsim, excluding tests marked
-'quasar', 'nightly', or 'perf'. Per-test process isolation via
-pytest-forked converts ttsim _Exit(1) crashes into normal pytest
+Runs the LLK pytest suite on ttsim. Wormhole/Blackhole runs exclude
+Quasar-only tests; Quasar runs select Quasar-only tests. Per-test
+process isolation via pytest-forked converts ttsim _Exit(1) crashes into normal pytest
 failures; junit XML + HTML report are produced in:
 
   ${RESULTS_DIR}
@@ -60,10 +57,12 @@ Options:
   -n, --workers N       Number of xdist workers (default: 10; env: WORKERS).
                         Use 0 to disable xdist (serial, --forked only).
   -t, --timeout SEC     Per-test timeout in seconds (default: 300; env: TIMEOUT).
-  -a, --architecture A  ttsim architecture to auto-provision: 'blackhole'
-                        or 'wormhole' (default: blackhole;
-                        env: TTSIM_ARCHITECTURE). Ignored when
-                        TT_METAL_SIMULATOR is already set.
+  -a, --architecture A  ttsim architecture: 'blackhole', 'wormhole', or
+                        'quasar' (default: blackhole; env: TTSIM_ARCHITECTURE).
+                        Controls test selection and collection. Also controls
+                        auto-provisioning for blackhole/wormhole when
+                        TT_METAL_SIMULATOR is unset. Quasar currently requires
+                        TT_METAL_SIMULATOR to be set by the caller.
   -h, --help            Show this help message.
 
 Environment:
@@ -76,6 +75,7 @@ Environment:
 Examples:
   $(basename "$0")                              # blackhole, auto-downloads simulator
   $(basename "$0") -a wormhole                  # wormhole variant
+  TT_METAL_SIMULATOR=~/sim/libttsim.so $(basename "$0") -a quasar
   $(basename "$0") -n 16 test_eltwise_unary_datacopy.py
   $(basename "$0") -- -k Float16_b
   WORKERS=8 $(basename "$0")
@@ -97,6 +97,33 @@ while [[ $# -gt 0 ]]; do
         *)            TEST_PATHS+=("$1"); shift ;;
     esac
 done
+
+
+# Normalize architecture aliases once so provisioning, collection, marker
+# selection, and reporting all agree.
+case "$ARCHITECTURE" in
+    blackhole|bh)                 ARCHITECTURE=blackhole ;;
+    wormhole|wormhole_b0|wh)      ARCHITECTURE=wormhole ;;
+    quasar|qsr)                   ARCHITECTURE=quasar ;;
+    *)
+        echo "ERROR: unknown --architecture '$ARCHITECTURE' (expected 'blackhole', 'wormhole', or 'quasar')" >&2
+        exit 1
+        ;;
+esac
+
+# Marker expression shared by the collection pass and the real run so the
+# "expected" denominator and the "recorded" results select the exact same set.
+case "$ARCHITECTURE" in
+    quasar) MARKER_EXPR="quasar and not nightly and not perf and not accuracy" ;;
+    *)      MARKER_EXPR="not quasar and not nightly and not perf and not accuracy" ;;
+esac
+
+# Quasar tests live under python_tests/quasar. Restrict the default path so
+# xdist workers do not collect the full WH/BH LLK suite just to marker-deselect
+# it. Explicit test paths from the caller are still honored as-is.
+if [[ "$ARCHITECTURE" == "quasar" && ${#TEST_PATHS[@]} -eq 0 ]]; then
+    TEST_PATHS=(quasar)
+fi
 
 # ──────────────────────────────────────────────────────────────
 # Auto-provision ttsim (libttsim_<arch>.so + soc_descriptor.yaml)
@@ -123,8 +150,12 @@ provision_ttsim() {
             soc_src="${REPO_ROOT}/tt_metal/soc_descriptors/wormhole_b0_80_arch.yaml"
             hash_var=ttsim_wh_so_hash
             ;;
+        quasar)
+            echo "ERROR: Quasar auto-provisioning is not available yet; set TT_METAL_SIMULATOR" >&2
+            exit 1
+            ;;
         *)
-            echo "ERROR: unknown --architecture '$architecture' (expected 'blackhole' or 'wormhole')" >&2
+            echo "ERROR: unknown --architecture '$architecture' (expected 'blackhole', 'wormhole', or 'quasar')" >&2
             exit 1
             ;;
     esac
@@ -279,14 +310,10 @@ fi
 #   * --compile-producer puts conftest in BuildMode.PRODUCE, which is the only
 #     mode that skips *both* check_context() calls in pytest_configure
 #     (override_gprs_used_by_tensix_dump and the device/simulator init block).
-# --collect-only never executes a test, so producer mode compiles nothing and
-# the selected set matches the real run (build mode / run_simulator only affect
-# runtime, never collection).
-case "$ARCHITECTURE" in
-    blackhole|bh)                 COLLECT_CHIP_ARCH=blackhole ;;
-    wormhole|wormhole_b0|wh)      COLLECT_CHIP_ARCH=wormhole ;;
-    *)                            COLLECT_CHIP_ARCH="$ARCHITECTURE" ;;
-esac
+# --collect-only never executes a test, so producer mode compiles nothing. Note
+# that producer mode collapses runtime-only axes, so this is a stable compile
+# denominator, not necessarily the full runtime test count.
+COLLECT_CHIP_ARCH="$ARCHITECTURE"
 COLLECT_CMD=(
     "pytest"
     --collect-only
@@ -323,9 +350,10 @@ fi
 # Banner
 # ──────────────────────────────────────────────────────────────
 echo "============================================================"
-echo " ttsim LLK regression (excludes: quasar, nightly, perf)"
+echo " ttsim LLK regression"
 echo "============================================================"
 echo " Architecture   : ${ARCHITECTURE}"
+echo " Marker expr    : ${MARKER_EXPR}"
 echo " Simulator      : ${TT_METAL_SIMULATOR}"
 echo " SoC descriptor : $(dirname "$TT_METAL_SIMULATOR")/soc_descriptor.yaml"
 echo " SFPLOADMACRO   : disabled=${TT_METAL_DISABLE_SFPLOADMACRO}"

--- a/tt_metal/tt-llk/tests/run_ttsim_regression.sh
+++ b/tt_metal/tt-llk/tests/run_ttsim_regression.sh
@@ -111,8 +111,8 @@ case "$ARCHITECTURE" in
         ;;
 esac
 
-# Marker expression shared by the collection pass and the real run so the
-# "expected" denominator and the "recorded" results select the exact same set.
+# Marker expression shared by the collection pass and the real run so both
+# apply the same architecture, nightly, performance, and accuracy filtering.
 case "$ARCHITECTURE" in
     quasar) MARKER_EXPR="quasar and not nightly and not perf and not accuracy" ;;
     *)      MARKER_EXPR="not quasar and not nightly and not perf and not accuracy" ;;


### PR DESCRIPTION
### PR Category
Test Only

### Summary
`run_ttsim_regression.sh` could not run the Quasar LLK suite because its fixed marker expression always excluded `quasar` tests and the default path forced Quasar runs to collect the broader LLK tree before deselection. The script now normalizes `--architecture` including `quasar`/`qsr`, uses the Quasar marker expression and `quasar` test path for Quasar runs while preserving the existing WH/BH selection, and reports the selected marker in the banner. The collection comment was also corrected to note that the producer collection is a compile-collapsed denominator, since runtime-only axes can make the actual runtime test count much larger.

### Notes for reviewers
none

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mcraighead/qsr-ttsim-llk-script)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mcraighead/qsr-ttsim-llk-script)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mcraighead/qsr-ttsim-llk-script)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mcraighead/qsr-ttsim-llk-script)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mcraighead/qsr-ttsim-llk-script)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mcraighead/qsr-ttsim-llk-script)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mcraighead/qsr-ttsim-llk-script)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mcraighead/qsr-ttsim-llk-script)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mcraighead/qsr-ttsim-llk-script)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mcraighead/qsr-ttsim-llk-script)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mcraighead/qsr-ttsim-llk-script)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mcraighead/qsr-ttsim-llk-script)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mcraighead/qsr-ttsim-llk-script)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mcraighead/qsr-ttsim-llk-script)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mcraighead/qsr-ttsim-llk-script)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mcraighead/qsr-ttsim-llk-script)