### PR TITLE
[Bug fix] Fix OOB write in FreeListOpt::shrink_size when the shrunk block has no successor

### DIFF
--- a/tests/tt_metal/tt_metal/api/allocator/test_free_list_opt_allocator.cpp
+++ b/tests/tt_metal/tt_metal/api/allocator/test_free_list_opt_allocator.cpp
@@ -148,6 +148,20 @@ TEST(FreeListOptTest, ShrinkAndReset) {
     ASSERT_TRUE(e.has_value());
 }
 
+// Shrinking away the whole pool consumes the only block, which leaves it with no next block to relink
+TEST(FreeListOptTest, ShrinkEntirePoolAndReset) {
+    auto allocator = tt::tt_metal::allocator::FreeListOpt(1_GiB, 0, 1_KiB, 1_KiB);
+
+    allocator.shrink_size(1_GiB);
+    auto a = allocator.allocate(1_KiB);
+    ASSERT_FALSE(a.has_value());
+
+    allocator.reset_size();
+    auto b = allocator.allocate(1_GiB);
+    ASSERT_TRUE(b.has_value());
+    ASSERT_EQ(b.value(), 0);
+}
+
 TEST(FreeListOptTest, Statistics) {
     auto allocator = tt::tt_metal::allocator::FreeListOpt(1_GiB, 0, 1_KiB, 1_KiB);
     auto a = allocator.allocate(1_KiB);

--- a/tests/tt_metal/tt_metal/api/allocator/test_free_list_opt_allocator.cpp
+++ b/tests/tt_metal/tt_metal/api/allocator/test_free_list_opt_allocator.cpp
@@ -164,6 +164,26 @@ TEST(FreeListOptTest, CPU_RejectFullCapacityShrink) {
     EXPECT_EQ(allocator.get_memory_block_table(), blocks);
 }
 
+// Full-capacity shrink is rejected, so pin 1_KiB at the top and consume the entire leading free
+// block. That takes the size-becomes-0 unlink path (the original OOB wrote through a -1 next-block
+// sentinel when that block also had no successor).
+TEST(FreeListOptTest, CPU_ShrinkEntireLeadingFreeBlockAndReset) {
+    auto allocator = tt::tt_metal::allocator::FreeListOpt(1_GiB, 0, 1_KiB, 1_KiB);
+
+    auto pinned = allocator.allocate(1_KiB, /*bottom_up=*/false);
+    ASSERT_TRUE(pinned.has_value());
+    ASSERT_EQ(pinned.value(), 1_GiB - 1_KiB);
+
+    allocator.shrink_size(1_GiB - 1_KiB);
+    auto a = allocator.allocate(1_KiB);
+    ASSERT_FALSE(a.has_value());
+
+    allocator.reset_size();
+    auto b = allocator.allocate(1_GiB - 1_KiB);
+    ASSERT_TRUE(b.has_value());
+    ASSERT_EQ(b.value(), 0);
+}
+
 TEST(FreeListOptTest, CPU_Statistics) {
     auto allocator = tt::tt_metal::allocator::FreeListOpt(1_GiB, 0, 1_KiB, 1_KiB);
     auto a = allocator.allocate(1_KiB);

--- a/tt_metal/impl/allocator/algorithms/free_list_opt.cpp
+++ b/tt_metal/impl/allocator/algorithms/free_list_opt.cpp
@@ -12,7 +12,6 @@
 #include <functional>
 #include <optional>
 #include <string>
-#include <type_traits>
 #include <unordered_map>
 #include <vector>
 
@@ -30,11 +29,11 @@ inline size_t intlg2(size_t n) {
 
 inline size_t num_segerated_classes(size_t max_size_bytes, size_t size_segregated_base) {
     size_t n = max_size_bytes / size_segregated_base;
-    ssize_t count = intlg2(n);
+    size_t count = intlg2(n);
     // 128MB as the last seggregated class size should be enough
     // avoid having too many classes as iterating them is not free
-    ssize_t max_count = intlg2(128 * 1024 * 1024 / size_segregated_base);
-    return std::clamp(count, ssize_t{2}, max_count);
+    size_t max_count = intlg2(128 * 1024 * 1024 / size_segregated_base);
+    return std::clamp(count, size_t{2}, max_count);
 }
 
 namespace tt::tt_metal::allocator {
@@ -104,7 +103,7 @@ std::optional<DeviceAddr> FreeListOpt::allocate(DeviceAddr size_bytes, bool bott
     // we can be confident that it's the best block to allocate from. Else, look at the next size class. However the
     // blocks within a size class are not sorted by size, so we may not always find the best block.
 
-    ssize_t target_block_index = no_block;
+    std::optional<size_t> target_block_index;
     size_t size_segregated_index = get_size_segregated_index(alloc_size);
     TT_ASSERT(size_segregated_index < size_segregated_count, "Size segregated index out of bounds");
     std::vector<size_t>* segregated_list = nullptr;
@@ -113,9 +112,11 @@ std::optional<DeviceAddr> FreeListOpt::allocate(DeviceAddr size_bytes, bool bott
 
     for (size_t i = size_segregated_index; i < free_blocks_segregated_by_size_.size(); i++) {
         auto& free_blocks = free_blocks_segregated_by_size_[i];
-        ssize_t increment = bottom_up ? 1 : -1;
-        for (ssize_t j = bottom_up ? 0 : free_blocks.size() - 1; j >= 0 && j < free_blocks.size(); j += increment) {
-            size_t block_index = free_blocks[j];
+        for (size_t n = 0; n < free_blocks.size(); n++) {
+            // Bottom-up walks front to back, top-down back to front. Deriving j from an unsigned
+            // counter avoids an empty list underflowing the start index.
+            const size_t j = bottom_up ? n : free_blocks.size() - 1 - n;
+            const size_t block_index = free_blocks[j];
             if (policy_ == SearchPolicy::BEST) {
                 if (block_size_[block_index] == alloc_size) {
                     target_block_index = block_index;
@@ -124,12 +125,12 @@ std::optional<DeviceAddr> FreeListOpt::allocate(DeviceAddr size_bytes, bool bott
                     break;
                 }
                 if (block_size_[block_index] >= alloc_size &&
-                    (target_block_index == no_block || block_size_[block_index] < block_size_[target_block_index])) {
+                    (!target_block_index.has_value() || block_size_[block_index] < block_size_[*target_block_index])) {
                     target_block_index = block_index;
                     segregated_list = &free_blocks;
                     segregated_item_index = j;
                 }
-                if (target_block_index != no_block) {
+                if (target_block_index.has_value()) {
                     break;
                 }
             } else {
@@ -139,7 +140,7 @@ std::optional<DeviceAddr> FreeListOpt::allocate(DeviceAddr size_bytes, bool bott
 
                 bool address_better =
                     bottom_up ? block_address_[block_index] < best_address : block_address_[block_index] > best_address;
-                if (target_block_index == no_block || address_better) {
+                if (!target_block_index.has_value() || address_better) {
                     target_block_index = block_index;
                     segregated_list = &free_blocks;
                     segregated_item_index = j;
@@ -150,21 +151,21 @@ std::optional<DeviceAddr> FreeListOpt::allocate(DeviceAddr size_bytes, bool bott
         }
     }
 
-    if (target_block_index == no_block) {
+    if (!target_block_index.has_value()) {
         return std::nullopt;
     }
     TT_ASSERT(segregated_list != nullptr, "Segregated list is null");
     TT_ASSERT(segregated_item_index < segregated_list->size(), "Segregated item index out of bounds");
     TT_ASSERT(
-        block_is_allocated_[target_block_index] == false, "Block we are trying allocate from is already allocated");
-    segregated_list->erase(segregated_list->begin() + segregated_item_index);
+        block_is_allocated_[*target_block_index] == false, "Block we are trying allocate from is already allocated");
+    segregated_list->erase(segregated_list->begin() + static_cast<std::ptrdiff_t>(segregated_item_index));
 
     // Allocate the block
     size_t offset = 0;
     if (!bottom_up) {
-        offset = block_size_[target_block_index] - alloc_size;
+        offset = block_size_[*target_block_index] - alloc_size;
     }
-    size_t allocated_block_index = allocate_in_block(target_block_index, alloc_size, offset);
+    size_t allocated_block_index = allocate_in_block(*target_block_index, alloc_size, offset);
     DeviceAddr start_address = block_address_[allocated_block_index];
     if (start_address + offset_bytes_ < address_limit) {
         TT_THROW(
@@ -179,7 +180,7 @@ std::optional<DeviceAddr> FreeListOpt::allocate(DeviceAddr size_bytes, bool bott
 std::optional<DeviceAddr> FreeListOpt::allocate_at_address(DeviceAddr absolute_start_address, DeviceAddr size_bytes) {
     // Nothing we can do but scan the free list
     size_t alloc_size = align(std::max(size_bytes, min_allocation_size_));
-    ssize_t target_block_index = no_block;
+    std::optional<size_t> target_block_index;
     DeviceAddr start_address = absolute_start_address - offset_bytes_;
     for (size_t i = 0; i < block_address_.size(); i++) {
         if (meta_block_is_allocated_[i]) {
@@ -192,12 +193,12 @@ std::optional<DeviceAddr> FreeListOpt::allocate_at_address(DeviceAddr absolute_s
         }
     }
 
-    if (target_block_index == no_block || block_is_allocated_[target_block_index]) {
+    if (!target_block_index.has_value() || block_is_allocated_[*target_block_index]) {
         return std::nullopt;
     }
 
     // Find the relevant size segregated list
-    size_t size_segregated_index = get_size_segregated_index(block_size_[target_block_index]);
+    size_t size_segregated_index = get_size_segregated_index(block_size_[*target_block_index]);
     std::vector<size_t>& segregated_list = free_blocks_segregated_by_size_[size_segregated_index];
     // Precondition: insert_block_to_segregated_list() keeps each list sorted ascending by block
     // address, which the lower_bound below relies on. Assert it (debug-only) instead of silently
@@ -206,15 +207,15 @@ std::optional<DeviceAddr> FreeListOpt::allocate_at_address(DeviceAddr absolute_s
     TT_ASSERT(
         std::is_sorted(segregated_list.begin(), segregated_list.end(), by_address),
         "Size segregated list must be sorted by block address");
-    auto it = std::lower_bound(segregated_list.begin(), segregated_list.end(), target_block_index, by_address);
-    TT_ASSERT(it != segregated_list.end() && *it == target_block_index, "Block not found in size segregated list");
-    if (it != segregated_list.end() && *it == target_block_index) {
+    auto it = std::lower_bound(segregated_list.begin(), segregated_list.end(), *target_block_index, by_address);
+    TT_ASSERT(it != segregated_list.end() && *it == *target_block_index, "Block not found in size segregated list");
+    if (it != segregated_list.end() && *it == *target_block_index) {
         segregated_list.erase(it);
     }
 
-    size_t offset = start_address - block_address_[target_block_index];
+    size_t offset = start_address - block_address_[*target_block_index];
     // Allocated addresses cache is invalidated by allocate_in_block
-    allocate_in_block(target_block_index, alloc_size, offset);
+    allocate_in_block(*target_block_index, alloc_size, offset);
     update_lowest_occupied_address(start_address);
     return absolute_start_address;
 }
@@ -233,7 +234,7 @@ size_t FreeListOpt::allocate_in_block(size_t block_index, DeviceAddr alloc_size,
     if (!left_aligned) {
         size_t free_block_size = offset;
         DeviceAddr free_block_address = block_address_[block_index];
-        ssize_t prev_block = block_prev_block_[block_index];
+        size_t prev_block = block_prev_block_[block_index];
         block_size_[block_index] -= offset;
         block_address_[block_index] += offset;
         size_t new_block_index = alloc_meta_block(free_block_address, free_block_size, prev_block, block_index, false);
@@ -248,8 +249,8 @@ size_t FreeListOpt::allocate_in_block(size_t block_index, DeviceAddr alloc_size,
     if (!right_aligned) {
         size_t free_block_size = block_size_[block_index] - alloc_size;
         DeviceAddr free_block_address = block_address_[block_index] + alloc_size;
-        ssize_t prev_block = block_index;
-        ssize_t next_block = block_next_block_[block_index];
+        size_t prev_block = block_index;
+        size_t next_block = block_next_block_[block_index];
         block_size_[block_index] -= free_block_size;
         size_t new_block_index = alloc_meta_block(free_block_address, free_block_size, prev_block, next_block, false);
         if (next_block != no_block) {
@@ -276,8 +277,8 @@ void FreeListOpt::deallocate(DeviceAddr absolute_address) {
     }
     size_t block_index = *block_index_opt;
     block_is_allocated_[block_index] = false;
-    ssize_t prev_block = block_prev_block_[block_index];
-    ssize_t next_block = block_next_block_[block_index];
+    size_t prev_block = block_prev_block_[block_index];
+    size_t next_block = block_next_block_[block_index];
 
     // Merge with previous block if it's free
     if (prev_block != no_block && !block_is_allocated_[prev_block]) {
@@ -321,7 +322,7 @@ void FreeListOpt::deallocate(DeviceAddr absolute_address) {
     TT_ASSERT(lowest_occupied_address_.has_value(), "Lowest occupied address should have a value");
     if (addr <= *lowest_occupied_address_) {
         lowest_occupied_address_ = std::nullopt;
-        ssize_t curr_block_index = block_next_block_[block_index];
+        size_t curr_block_index = block_next_block_[block_index];
         while (curr_block_index != no_block) {
             if (block_is_allocated_[curr_block_index]) {
                 lowest_occupied_address_ = block_address_[curr_block_index];
@@ -381,7 +382,7 @@ std::optional<DeviceAddr> FreeListOpt::get_allocation_size(DeviceAddr absolute_a
 }
 
 size_t FreeListOpt::alloc_meta_block(
-    DeviceAddr address, DeviceAddr size, ssize_t prev_block, ssize_t next_block, bool is_allocated) {
+    DeviceAddr address, DeviceAddr size, size_t prev_block, size_t next_block, bool is_allocated) {
     size_t idx;
     if (free_meta_block_indices_.empty()) {
         idx = block_address_.size();
@@ -405,8 +406,8 @@ size_t FreeListOpt::alloc_meta_block(
 }
 
 void FreeListOpt::unlink_block(size_t block_index) {
-    const ssize_t prev_block = block_prev_block_[block_index];
-    const ssize_t next_block = block_next_block_[block_index];
+    const size_t prev_block = block_prev_block_[block_index];
+    const size_t next_block = block_next_block_[block_index];
     if (prev_block != no_block) {
         block_next_block_[prev_block] = next_block;
     }
@@ -484,15 +485,10 @@ void FreeListOpt::dump_blocks(std::ostream& out) const {
         }
         return std::string(width - str.size(), ' ') + str;
     };
-    auto leftpad_num = [leftpad](auto num, size_t width) {
-        // Only the prev/next link columns carry the sentinel; the unsigned columns must not be compared
-        // against it, or an address of SIZE_MAX would print as "none"
-        if constexpr (std::is_signed_v<decltype(num)>) {
-            if (num == no_block) {
-                return leftpad("none", width);
-            }
-        }
-        return leftpad(std::to_string(num), width);
+    auto leftpad_num = [leftpad](auto num, size_t width) { return leftpad(std::to_string(num), width); };
+    // Only the link columns can hold the sentinel; a size or address equal to no_block is a real value
+    auto leftpad_link = [leftpad](size_t link, size_t width) {
+        return leftpad(link == no_block ? "none" : std::to_string(link), width);
     };
     const size_t pad = 12;
     std::array<std::string, 6> headers = {"Block", "Address", "Size", "PrevID", "NextID", "Allocated"};
@@ -505,8 +501,8 @@ void FreeListOpt::dump_blocks(std::ostream& out) const {
             continue;
         }
         out << leftpad_num(i, pad) << " " << leftpad_num(block_address_[i], pad) << " "
-            << leftpad_num(block_size_[i], pad) << " " << leftpad_num(block_prev_block_[i], pad) << " "
-            << leftpad_num(block_next_block_[i], pad) << " " << leftpad(block_is_allocated_[i] ? "yes" : "no", pad)
+            << leftpad_num(block_size_[i], pad) << " " << leftpad_link(block_prev_block_[i], pad) << " "
+            << leftpad_link(block_next_block_[i], pad) << " " << leftpad(block_is_allocated_[i] ? "yes" : "no", pad)
             << std::endl;
     }
 }
@@ -542,7 +538,7 @@ size_t FreeListOpt::find_block_to_shrink(DeviceAddr shrink_size, bool bottom_up)
         max_size_bytes_);
 
     // loop and scan the block list to find if the shrink cut into any allocated block
-    ssize_t found_block = no_block;
+    std::optional<size_t> found_block;
     const DeviceAddr shrunk_address = shrink_size_ + shrink_size;
     // TODO: There must be a way to force the beginning of all blocks be at index 0
     for (size_t i = 0; i < block_address_.size(); i++) {
@@ -561,9 +557,8 @@ size_t FreeListOpt::find_block_to_shrink(DeviceAddr shrink_size, bool bottom_up)
     }
 
     TT_FATAL(
-        found_block != no_block, "Shrink size {} does not align with any block. This must be a bug", shrunk_address);
-    // Validated above, so it is safe to narrow to an index for the rest of the function
-    return static_cast<size_t>(found_block);
+        found_block.has_value(), "Shrink size {} does not align with any block. This must be a bug", shrunk_address);
+    return *found_block;
 }
 
 void FreeListOpt::validate_shrink_size(DeviceAddr shrink_size, bool bottom_up) const {
@@ -612,7 +607,7 @@ void FreeListOpt::reset_size() {
     }
 
     // Create a new block, mark it as allocated and deallocate the old block so coalescing can happen
-    ssize_t lowest_block_index = no_block;
+    std::optional<size_t> lowest_block_index;
     bool has_live_block = false;
     for (size_t i = 0; i < block_address_.size(); i++) {
         if (!meta_block_is_allocated_[i]) {
@@ -625,32 +620,32 @@ void FreeListOpt::reset_size() {
         }
     }
 
-    TT_FATAL(!has_live_block || lowest_block_index != no_block, "Lowest block not found during reset size");
+    TT_FATAL(!has_live_block || lowest_block_index.has_value(), "Lowest block not found during reset size");
 
-    // There 3 cases to consider:
+    // There are 3 cases to consider:
     // 1. Every block was consumed by the shrink, which means there is nothing to grow back into and the
     //    restored range has to be rebuilt the way init() does it
-    // 2. The lowest block is is free, which means we can just modify it's attributes
+    // 2. The lowest block is free, which means we can just modify its attributes
     // 3. The lowest block is allocated, which means we need to create a new block and deallocate the old one
-    if (lowest_block_index == no_block) {
+    if (!lowest_block_index.has_value()) {
         size_t new_block_index = alloc_meta_block(0, shrink_size_, no_block, no_block, false);
         insert_block_to_segregated_list(new_block_index);
-    } else if (!block_is_allocated_[lowest_block_index]) {
+    } else if (!block_is_allocated_[*lowest_block_index]) {
         auto* segregated_list =
-            &free_blocks_segregated_by_size_[get_size_segregated_index(block_size_[lowest_block_index])];
+            &free_blocks_segregated_by_size_[get_size_segregated_index(block_size_[*lowest_block_index])];
         for (size_t i = 0; i < segregated_list->size(); i++) {
-            if ((*segregated_list)[i] == lowest_block_index) {
-                segregated_list->erase(segregated_list->begin() + i);
+            if ((*segregated_list)[i] == *lowest_block_index) {
+                segregated_list->erase(segregated_list->begin() + static_cast<std::ptrdiff_t>(i));
                 break;
             }
         }
-        block_size_[lowest_block_index] += shrink_size_;
-        block_address_[lowest_block_index] = 0;
-        insert_block_to_segregated_list(lowest_block_index);
+        block_size_[*lowest_block_index] += shrink_size_;
+        block_address_[*lowest_block_index] = 0;
+        insert_block_to_segregated_list(*lowest_block_index);
     } else {
-        size_t new_block_index = alloc_meta_block(0, shrink_size_, no_block, lowest_block_index, false);
-        TT_ASSERT(!has_prev_block(lowest_block_index), "Lowest block should not have a previous block");
-        block_prev_block_[lowest_block_index] = new_block_index;
+        size_t new_block_index = alloc_meta_block(0, shrink_size_, no_block, *lowest_block_index, false);
+        TT_ASSERT(!has_prev_block(*lowest_block_index), "Lowest block should not have a previous block");
+        block_prev_block_[*lowest_block_index] = new_block_index;
         insert_block_to_segregated_list(new_block_index);
     }
 
@@ -711,10 +706,11 @@ std::optional<size_t> FreeListOpt::get_block_index_from_alloc_table(DeviceAddr a
 std::optional<size_t> FreeListOpt::get_and_remove_from_alloc_table(DeviceAddr address) {
     size_t bucket = hash_device_address(address);
     // It's common to deallocate the last allocated block, so search from the back
-    for (ssize_t i = allocated_block_table_[bucket].size() - 1; i >= 0; i--) {
+    for (size_t i = allocated_block_table_[bucket].size(); i-- > 0;) {
         if (allocated_block_table_[bucket][i].first == address) {
             auto res = allocated_block_table_[bucket][i].second;
-            allocated_block_table_[bucket].erase(allocated_block_table_[bucket].begin() + i);
+            allocated_block_table_[bucket].erase(
+                allocated_block_table_[bucket].begin() + static_cast<std::ptrdiff_t>(i));
             return res;
         }
     }

--- a/tt_metal/impl/allocator/algorithms/free_list_opt.cpp
+++ b/tt_metal/impl/allocator/algorithms/free_list_opt.cpp
@@ -585,7 +585,14 @@ void FreeListOpt::shrink_size(DeviceAddr shrink_size, bool bottom_up) {
     max_size_bytes_ -= shrink_size;
     shrink_size_ += shrink_size;
     if (block_size_[block_to_shrink] == 0) {
-        block_prev_block_[block_next_block_[block_to_shrink]] = block_prev_block_[block_to_shrink];
+        const ssize_t prev_block = block_prev_block_[block_to_shrink];
+        const ssize_t next_block = block_next_block_[block_to_shrink];
+        if (next_block != -1) {
+            block_prev_block_[next_block] = prev_block;
+        }
+        if (prev_block != -1) {
+            block_next_block_[prev_block] = next_block;
+        }
         free_meta_block(block_to_shrink);
     } else {
         block_address_[block_to_shrink] += shrink_size;
@@ -600,21 +607,29 @@ void FreeListOpt::reset_size() {
 
     // Create a new block, mark it as allocated and deallocate the old block so coalescing can happen
     ssize_t lowest_block_index = -1;
+    bool has_live_block = false;
     for (size_t i = 0; i < block_address_.size(); i++) {
         if (!meta_block_is_allocated_[i]) {
             continue;
         }
+        has_live_block = true;
         if (block_address_[i] == shrink_size_) {
             lowest_block_index = i;
             break;
         }
     }
-    TT_ASSERT(lowest_block_index != -1, "Lowest block not found during reset size");
 
-    // There 2 cases to consider:
-    // 1. The lowest block is is free, which means we can just modify it's attributes
-    // 2. The lowest block is allocated, which means we need to create a new block and deallocate the old one
-    if (!block_is_allocated_[lowest_block_index]) {
+    TT_FATAL(!has_live_block || lowest_block_index != -1, "Lowest block not found during reset size");
+
+    // There 3 cases to consider:
+    // 1. Every block was consumed by the shrink, which means there is nothing to grow back into and the
+    //    restored range has to be rebuilt the way init() does it
+    // 2. The lowest block is is free, which means we can just modify it's attributes
+    // 3. The lowest block is allocated, which means we need to create a new block and deallocate the old one
+    if (lowest_block_index == -1) {
+        size_t new_block_index = alloc_meta_block(0, shrink_size_, -1, -1, false);
+        insert_block_to_segregated_list(new_block_index);
+    } else if (!block_is_allocated_[lowest_block_index]) {
         auto* segregated_list =
             &free_blocks_segregated_by_size_[get_size_segregated_index(block_size_[lowest_block_index])];
         for (size_t i = 0; i < segregated_list->size(); i++) {

--- a/tt_metal/impl/allocator/algorithms/free_list_opt.cpp
+++ b/tt_metal/impl/allocator/algorithms/free_list_opt.cpp
@@ -12,6 +12,7 @@
 #include <functional>
 #include <optional>
 #include <string>
+#include <type_traits>
 #include <unordered_map>
 #include <vector>
 
@@ -89,8 +90,8 @@ void FreeListOpt::init() {
     // Create a single block that spans the entire memory
     block_address_.push_back(0);
     block_size_.push_back(max_size_bytes_);
-    block_prev_block_.push_back(-1);
-    block_next_block_.push_back(-1);
+    block_prev_block_.push_back(no_block);
+    block_next_block_.push_back(no_block);
     block_is_allocated_.push_back(false);
     meta_block_is_allocated_.push_back(true);
     free_blocks_segregated_by_size_[get_size_segregated_index(max_size_bytes_)].push_back(0);
@@ -103,7 +104,7 @@ std::optional<DeviceAddr> FreeListOpt::allocate(DeviceAddr size_bytes, bool bott
     // we can be confident that it's the best block to allocate from. Else, look at the next size class. However the
     // blocks within a size class are not sorted by size, so we may not always find the best block.
 
-    ssize_t target_block_index = -1;
+    ssize_t target_block_index = no_block;
     size_t size_segregated_index = get_size_segregated_index(alloc_size);
     TT_ASSERT(size_segregated_index < size_segregated_count, "Size segregated index out of bounds");
     std::vector<size_t>* segregated_list = nullptr;
@@ -123,12 +124,12 @@ std::optional<DeviceAddr> FreeListOpt::allocate(DeviceAddr size_bytes, bool bott
                     break;
                 }
                 if (block_size_[block_index] >= alloc_size &&
-                    (target_block_index == -1 || block_size_[block_index] < block_size_[target_block_index])) {
+                    (target_block_index == no_block || block_size_[block_index] < block_size_[target_block_index])) {
                     target_block_index = block_index;
                     segregated_list = &free_blocks;
                     segregated_item_index = j;
                 }
-                if (target_block_index != -1) {
+                if (target_block_index != no_block) {
                     break;
                 }
             } else {
@@ -138,7 +139,7 @@ std::optional<DeviceAddr> FreeListOpt::allocate(DeviceAddr size_bytes, bool bott
 
                 bool address_better =
                     bottom_up ? block_address_[block_index] < best_address : block_address_[block_index] > best_address;
-                if (target_block_index == -1 || address_better) {
+                if (target_block_index == no_block || address_better) {
                     target_block_index = block_index;
                     segregated_list = &free_blocks;
                     segregated_item_index = j;
@@ -149,7 +150,7 @@ std::optional<DeviceAddr> FreeListOpt::allocate(DeviceAddr size_bytes, bool bott
         }
     }
 
-    if (target_block_index == -1) {
+    if (target_block_index == no_block) {
         return std::nullopt;
     }
     TT_ASSERT(segregated_list != nullptr, "Segregated list is null");
@@ -178,7 +179,7 @@ std::optional<DeviceAddr> FreeListOpt::allocate(DeviceAddr size_bytes, bool bott
 std::optional<DeviceAddr> FreeListOpt::allocate_at_address(DeviceAddr absolute_start_address, DeviceAddr size_bytes) {
     // Nothing we can do but scan the free list
     size_t alloc_size = align(std::max(size_bytes, min_allocation_size_));
-    ssize_t target_block_index = -1;
+    ssize_t target_block_index = no_block;
     DeviceAddr start_address = absolute_start_address - offset_bytes_;
     for (size_t i = 0; i < block_address_.size(); i++) {
         if (meta_block_is_allocated_[i]) {
@@ -191,7 +192,7 @@ std::optional<DeviceAddr> FreeListOpt::allocate_at_address(DeviceAddr absolute_s
         }
     }
 
-    if (target_block_index == -1 || block_is_allocated_[target_block_index]) {
+    if (target_block_index == no_block || block_is_allocated_[target_block_index]) {
         return std::nullopt;
     }
 
@@ -236,7 +237,7 @@ size_t FreeListOpt::allocate_in_block(size_t block_index, DeviceAddr alloc_size,
         block_size_[block_index] -= offset;
         block_address_[block_index] += offset;
         size_t new_block_index = alloc_meta_block(free_block_address, free_block_size, prev_block, block_index, false);
-        if (prev_block != -1) {
+        if (prev_block != no_block) {
             block_next_block_[prev_block] = new_block_index;
         }
         block_prev_block_[block_index] = new_block_index;
@@ -251,7 +252,7 @@ size_t FreeListOpt::allocate_in_block(size_t block_index, DeviceAddr alloc_size,
         ssize_t next_block = block_next_block_[block_index];
         block_size_[block_index] -= free_block_size;
         size_t new_block_index = alloc_meta_block(free_block_address, free_block_size, prev_block, next_block, false);
-        if (next_block != -1) {
+        if (next_block != no_block) {
             block_prev_block_[next_block] = new_block_index;
         }
         block_next_block_[block_index] = new_block_index;
@@ -279,7 +280,7 @@ void FreeListOpt::deallocate(DeviceAddr absolute_address) {
     ssize_t next_block = block_next_block_[block_index];
 
     // Merge with previous block if it's free
-    if (prev_block != -1 && !block_is_allocated_[prev_block]) {
+    if (prev_block != no_block && !block_is_allocated_[prev_block]) {
         // Look into the size segregated list to remove the block
         size_t size_segregated_index = get_size_segregated_index(block_size_[prev_block]);
         std::vector<size_t>& segregated_list = free_blocks_segregated_by_size_[size_segregated_index];
@@ -292,16 +293,13 @@ void FreeListOpt::deallocate(DeviceAddr absolute_address) {
         segregated_list.erase(it);
 
         block_size_[prev_block] += block_size_[block_index];
-        block_next_block_[prev_block] = next_block;
-        if (next_block != -1) {
-            block_prev_block_[next_block] = prev_block;
-        }
+        unlink_block(block_index);
         free_meta_block(block_index);
         block_index = prev_block;
     }
 
     // Merge with next block if it's free
-    if (next_block != -1 && !block_is_allocated_[next_block]) {
+    if (next_block != no_block && !block_is_allocated_[next_block]) {
         // Look into the size segregated list to remove the block
         size_t size_segregated_index = get_size_segregated_index(block_size_[next_block]);
         std::vector<size_t>& segregated_list = free_blocks_segregated_by_size_[size_segregated_index];
@@ -314,10 +312,9 @@ void FreeListOpt::deallocate(DeviceAddr absolute_address) {
         segregated_list.erase(it);
 
         block_size_[block_index] += block_size_[next_block];
-        block_next_block_[block_index] = block_next_block_[next_block];
-        if (block_next_block_[next_block] != -1) {
-            block_prev_block_[block_next_block_[next_block]] = block_index;
-        }
+        // block_prev_block_[next_block] == block_index here, so unlinking next_block is what rewires
+        // block_index's forward link onto next_block's successor
+        unlink_block(next_block);
         free_meta_block(next_block);
     }
 
@@ -325,7 +322,7 @@ void FreeListOpt::deallocate(DeviceAddr absolute_address) {
     if (addr <= *lowest_occupied_address_) {
         lowest_occupied_address_ = std::nullopt;
         ssize_t curr_block_index = block_next_block_[block_index];
-        while (curr_block_index != -1) {
+        while (curr_block_index != no_block) {
             if (block_is_allocated_[curr_block_index]) {
                 lowest_occupied_address_ = block_address_[curr_block_index];
                 break;
@@ -407,6 +404,17 @@ size_t FreeListOpt::alloc_meta_block(
     return idx;
 }
 
+void FreeListOpt::unlink_block(size_t block_index) {
+    const ssize_t prev_block = block_prev_block_[block_index];
+    const ssize_t next_block = block_next_block_[block_index];
+    if (prev_block != no_block) {
+        block_next_block_[prev_block] = next_block;
+    }
+    if (next_block != no_block) {
+        block_prev_block_[next_block] = prev_block;
+    }
+}
+
 void FreeListOpt::free_meta_block(size_t block_index) {
     free_meta_block_indices_.push_back(block_index);
     meta_block_is_allocated_[block_index] = false;
@@ -477,9 +485,12 @@ void FreeListOpt::dump_blocks(std::ostream& out) const {
         return std::string(width - str.size(), ' ') + str;
     };
     auto leftpad_num = [leftpad](auto num, size_t width) {
-        // HACK: -1 for us means none
-        if (num == -1) {
-            return leftpad("none", width);
+        // Only the prev/next link columns carry the sentinel; the unsigned columns must not be compared
+        // against it, or an address of SIZE_MAX would print as "none"
+        if constexpr (std::is_signed_v<decltype(num)>) {
+            if (num == no_block) {
+                return leftpad("none", width);
+            }
         }
         return leftpad(std::to_string(num), width);
     };
@@ -531,7 +542,7 @@ size_t FreeListOpt::find_block_to_shrink(DeviceAddr shrink_size, bool bottom_up)
         max_size_bytes_);
 
     // loop and scan the block list to find if the shrink cut into any allocated block
-    size_t block_to_shrink = -1;
+    ssize_t found_block = no_block;
     const DeviceAddr shrunk_address = shrink_size_ + shrink_size;
     // TODO: There must be a way to force the beginning of all blocks be at index 0
     for (size_t i = 0; i < block_address_.size(); i++) {
@@ -545,12 +556,14 @@ size_t FreeListOpt::find_block_to_shrink(DeviceAddr shrink_size, bool bottom_up)
                 shrunk_address,
                 block_address_[i]);
         } else if (block_address_[i] <= shrunk_address && block_address_[i] + block_size_[i] >= shrunk_address) {
-            block_to_shrink = i;
+            found_block = i;
         }
     }
 
-    TT_FATAL(block_to_shrink != -1, "Shrink size {} does not align with any block. This must be a bug", shrunk_address);
-    return block_to_shrink;
+    TT_FATAL(
+        found_block != no_block, "Shrink size {} does not align with any block. This must be a bug", shrunk_address);
+    // Validated above, so it is safe to narrow to an index for the rest of the function
+    return static_cast<size_t>(found_block);
 }
 
 void FreeListOpt::validate_shrink_size(DeviceAddr shrink_size, bool bottom_up) const {
@@ -585,14 +598,7 @@ void FreeListOpt::shrink_size(DeviceAddr shrink_size, bool bottom_up) {
     max_size_bytes_ -= shrink_size;
     shrink_size_ += shrink_size;
     if (block_size_[block_to_shrink] == 0) {
-        const ssize_t prev_block = block_prev_block_[block_to_shrink];
-        const ssize_t next_block = block_next_block_[block_to_shrink];
-        if (next_block != -1) {
-            block_prev_block_[next_block] = prev_block;
-        }
-        if (prev_block != -1) {
-            block_next_block_[prev_block] = next_block;
-        }
+        unlink_block(block_to_shrink);
         free_meta_block(block_to_shrink);
     } else {
         block_address_[block_to_shrink] += shrink_size;
@@ -606,7 +612,7 @@ void FreeListOpt::reset_size() {
     }
 
     // Create a new block, mark it as allocated and deallocate the old block so coalescing can happen
-    ssize_t lowest_block_index = -1;
+    ssize_t lowest_block_index = no_block;
     bool has_live_block = false;
     for (size_t i = 0; i < block_address_.size(); i++) {
         if (!meta_block_is_allocated_[i]) {
@@ -619,15 +625,15 @@ void FreeListOpt::reset_size() {
         }
     }
 
-    TT_FATAL(!has_live_block || lowest_block_index != -1, "Lowest block not found during reset size");
+    TT_FATAL(!has_live_block || lowest_block_index != no_block, "Lowest block not found during reset size");
 
     // There 3 cases to consider:
     // 1. Every block was consumed by the shrink, which means there is nothing to grow back into and the
     //    restored range has to be rebuilt the way init() does it
     // 2. The lowest block is is free, which means we can just modify it's attributes
     // 3. The lowest block is allocated, which means we need to create a new block and deallocate the old one
-    if (lowest_block_index == -1) {
-        size_t new_block_index = alloc_meta_block(0, shrink_size_, -1, -1, false);
+    if (lowest_block_index == no_block) {
+        size_t new_block_index = alloc_meta_block(0, shrink_size_, no_block, no_block, false);
         insert_block_to_segregated_list(new_block_index);
     } else if (!block_is_allocated_[lowest_block_index]) {
         auto* segregated_list =
@@ -642,8 +648,8 @@ void FreeListOpt::reset_size() {
         block_address_[lowest_block_index] = 0;
         insert_block_to_segregated_list(lowest_block_index);
     } else {
-        size_t new_block_index = alloc_meta_block(0, shrink_size_, -1, lowest_block_index, false);
-        TT_ASSERT(block_prev_block_[lowest_block_index] == -1, "Lowest block should not have a previous block");
+        size_t new_block_index = alloc_meta_block(0, shrink_size_, no_block, lowest_block_index, false);
+        TT_ASSERT(!has_prev_block(lowest_block_index), "Lowest block should not have a previous block");
         block_prev_block_[lowest_block_index] = new_block_index;
         insert_block_to_segregated_list(new_block_index);
     }

--- a/tt_metal/impl/allocator/algorithms/free_list_opt.cpp
+++ b/tt_metal/impl/allocator/algorithms/free_list_opt.cpp
@@ -12,7 +12,6 @@
 #include <functional>
 #include <optional>
 #include <string>
-#include <type_traits>
 #include <unordered_map>
 #include <vector>
 
@@ -30,11 +29,11 @@ inline size_t intlg2(size_t n) {
 
 inline size_t num_segerated_classes(size_t max_size_bytes, size_t size_segregated_base) {
     size_t n = max_size_bytes / size_segregated_base;
-    ssize_t count = intlg2(n);
+    size_t count = intlg2(n);
     // 128MB as the last seggregated class size should be enough
     // avoid having too many classes as iterating them is not free
-    ssize_t max_count = intlg2(128 * 1024 * 1024 / size_segregated_base);
-    return std::clamp(count, ssize_t{2}, max_count);
+    size_t max_count = intlg2(128 * 1024 * 1024 / size_segregated_base);
+    return std::clamp(count, size_t{2}, max_count);
 }
 
 namespace tt::tt_metal::allocator {
@@ -104,7 +103,7 @@ std::optional<DeviceAddr> FreeListOpt::allocate(DeviceAddr size_bytes, bool bott
     // we can be confident that it's the best block to allocate from. Else, look at the next size class. However the
     // blocks within a size class are not sorted by size, so we may not always find the best block.
 
-    ssize_t target_block_index = no_block;
+    std::optional<size_t> target_block_index;
     size_t size_segregated_index = get_size_segregated_index(alloc_size);
     TT_ASSERT(size_segregated_index < size_segregated_count, "Size segregated index out of bounds");
     std::vector<size_t>* segregated_list = nullptr;
@@ -113,9 +112,11 @@ std::optional<DeviceAddr> FreeListOpt::allocate(DeviceAddr size_bytes, bool bott
 
     for (size_t i = size_segregated_index; i < free_blocks_segregated_by_size_.size(); i++) {
         auto& free_blocks = free_blocks_segregated_by_size_[i];
-        ssize_t increment = bottom_up ? 1 : -1;
-        for (ssize_t j = bottom_up ? 0 : free_blocks.size() - 1; j >= 0 && j < free_blocks.size(); j += increment) {
-            size_t block_index = free_blocks[j];
+        for (size_t n = 0; n < free_blocks.size(); n++) {
+            // Bottom-up walks front to back, top-down back to front. Deriving j from an unsigned
+            // counter avoids an empty list underflowing the start index.
+            const size_t j = bottom_up ? n : free_blocks.size() - 1 - n;
+            const size_t block_index = free_blocks[j];
             if (policy_ == SearchPolicy::BEST) {
                 if (block_size_[block_index] == alloc_size) {
                     target_block_index = block_index;
@@ -124,12 +125,12 @@ std::optional<DeviceAddr> FreeListOpt::allocate(DeviceAddr size_bytes, bool bott
                     break;
                 }
                 if (block_size_[block_index] >= alloc_size &&
-                    (target_block_index == no_block || block_size_[block_index] < block_size_[target_block_index])) {
+                    (!target_block_index.has_value() || block_size_[block_index] < block_size_[*target_block_index])) {
                     target_block_index = block_index;
                     segregated_list = &free_blocks;
                     segregated_item_index = j;
                 }
-                if (target_block_index != no_block) {
+                if (target_block_index.has_value()) {
                     break;
                 }
             } else {
@@ -139,7 +140,7 @@ std::optional<DeviceAddr> FreeListOpt::allocate(DeviceAddr size_bytes, bool bott
 
                 bool address_better =
                     bottom_up ? block_address_[block_index] < best_address : block_address_[block_index] > best_address;
-                if (target_block_index == no_block || address_better) {
+                if (!target_block_index.has_value() || address_better) {
                     target_block_index = block_index;
                     segregated_list = &free_blocks;
                     segregated_item_index = j;
@@ -150,21 +151,21 @@ std::optional<DeviceAddr> FreeListOpt::allocate(DeviceAddr size_bytes, bool bott
         }
     }
 
-    if (target_block_index == no_block) {
+    if (!target_block_index.has_value()) {
         return std::nullopt;
     }
     TT_ASSERT(segregated_list != nullptr, "Segregated list is null");
     TT_ASSERT(segregated_item_index < segregated_list->size(), "Segregated item index out of bounds");
     TT_ASSERT(
-        block_is_allocated_[target_block_index] == false, "Block we are trying allocate from is already allocated");
-    segregated_list->erase(segregated_list->begin() + segregated_item_index);
+        block_is_allocated_[*target_block_index] == false, "Block we are trying allocate from is already allocated");
+    segregated_list->erase(segregated_list->begin() + static_cast<std::ptrdiff_t>(segregated_item_index));
 
     // Allocate the block
     size_t offset = 0;
     if (!bottom_up) {
-        offset = block_size_[target_block_index] - alloc_size;
+        offset = block_size_[*target_block_index] - alloc_size;
     }
-    size_t allocated_block_index = allocate_in_block(target_block_index, alloc_size, offset);
+    size_t allocated_block_index = allocate_in_block(*target_block_index, alloc_size, offset);
     DeviceAddr start_address = block_address_[allocated_block_index];
     if (start_address + offset_bytes_ < address_limit) {
         TT_THROW(
@@ -179,7 +180,7 @@ std::optional<DeviceAddr> FreeListOpt::allocate(DeviceAddr size_bytes, bool bott
 std::optional<DeviceAddr> FreeListOpt::allocate_at_address(DeviceAddr absolute_start_address, DeviceAddr size_bytes) {
     // Nothing we can do but scan the free list
     size_t alloc_size = align(std::max(size_bytes, min_allocation_size_));
-    ssize_t target_block_index = no_block;
+    std::optional<size_t> target_block_index;
     DeviceAddr start_address = absolute_start_address - offset_bytes_;
     for (size_t i = 0; i < block_address_.size(); i++) {
         if (meta_block_is_allocated_[i]) {
@@ -192,12 +193,12 @@ std::optional<DeviceAddr> FreeListOpt::allocate_at_address(DeviceAddr absolute_s
         }
     }
 
-    if (target_block_index == no_block || block_is_allocated_[target_block_index]) {
+    if (!target_block_index.has_value() || block_is_allocated_[*target_block_index]) {
         return std::nullopt;
     }
 
     // Find the relevant size segregated list
-    size_t size_segregated_index = get_size_segregated_index(block_size_[target_block_index]);
+    size_t size_segregated_index = get_size_segregated_index(block_size_[*target_block_index]);
     std::vector<size_t>& segregated_list = free_blocks_segregated_by_size_[size_segregated_index];
     // Precondition: insert_block_to_segregated_list() keeps each list sorted ascending by block
     // address, which the lower_bound below relies on. Assert it (debug-only) instead of silently
@@ -206,15 +207,15 @@ std::optional<DeviceAddr> FreeListOpt::allocate_at_address(DeviceAddr absolute_s
     TT_ASSERT(
         std::is_sorted(segregated_list.begin(), segregated_list.end(), by_address),
         "Size segregated list must be sorted by block address");
-    auto it = std::lower_bound(segregated_list.begin(), segregated_list.end(), target_block_index, by_address);
-    TT_ASSERT(it != segregated_list.end() && *it == target_block_index, "Block not found in size segregated list");
-    if (it != segregated_list.end() && *it == target_block_index) {
+    auto it = std::lower_bound(segregated_list.begin(), segregated_list.end(), *target_block_index, by_address);
+    TT_ASSERT(it != segregated_list.end() && *it == *target_block_index, "Block not found in size segregated list");
+    if (it != segregated_list.end() && *it == *target_block_index) {
         segregated_list.erase(it);
     }
 
-    size_t offset = start_address - block_address_[target_block_index];
+    size_t offset = start_address - block_address_[*target_block_index];
     // Allocated addresses cache is invalidated by allocate_in_block
-    allocate_in_block(target_block_index, alloc_size, offset);
+    allocate_in_block(*target_block_index, alloc_size, offset);
     update_lowest_occupied_address(start_address);
     return absolute_start_address;
 }
@@ -233,7 +234,7 @@ size_t FreeListOpt::allocate_in_block(size_t block_index, DeviceAddr alloc_size,
     if (!left_aligned) {
         size_t free_block_size = offset;
         DeviceAddr free_block_address = block_address_[block_index];
-        ssize_t prev_block = block_prev_block_[block_index];
+        size_t prev_block = block_prev_block_[block_index];
         block_size_[block_index] -= offset;
         block_address_[block_index] += offset;
         size_t new_block_index = alloc_meta_block(free_block_address, free_block_size, prev_block, block_index, false);
@@ -248,8 +249,8 @@ size_t FreeListOpt::allocate_in_block(size_t block_index, DeviceAddr alloc_size,
     if (!right_aligned) {
         size_t free_block_size = block_size_[block_index] - alloc_size;
         DeviceAddr free_block_address = block_address_[block_index] + alloc_size;
-        ssize_t prev_block = block_index;
-        ssize_t next_block = block_next_block_[block_index];
+        size_t prev_block = block_index;
+        size_t next_block = block_next_block_[block_index];
         block_size_[block_index] -= free_block_size;
         size_t new_block_index = alloc_meta_block(free_block_address, free_block_size, prev_block, next_block, false);
         if (next_block != no_block) {
@@ -276,8 +277,8 @@ void FreeListOpt::deallocate(DeviceAddr absolute_address) {
     }
     size_t block_index = *block_index_opt;
     block_is_allocated_[block_index] = false;
-    ssize_t prev_block = block_prev_block_[block_index];
-    ssize_t next_block = block_next_block_[block_index];
+    size_t prev_block = block_prev_block_[block_index];
+    size_t next_block = block_next_block_[block_index];
 
     // Merge with previous block if it's free
     if (prev_block != no_block && !block_is_allocated_[prev_block]) {
@@ -321,7 +322,7 @@ void FreeListOpt::deallocate(DeviceAddr absolute_address) {
     TT_ASSERT(lowest_occupied_address_.has_value(), "Lowest occupied address should have a value");
     if (addr <= *lowest_occupied_address_) {
         lowest_occupied_address_ = std::nullopt;
-        ssize_t curr_block_index = block_next_block_[block_index];
+        size_t curr_block_index = block_next_block_[block_index];
         while (curr_block_index != no_block) {
             if (block_is_allocated_[curr_block_index]) {
                 lowest_occupied_address_ = block_address_[curr_block_index];
@@ -381,7 +382,7 @@ std::optional<DeviceAddr> FreeListOpt::get_allocation_size(DeviceAddr absolute_a
 }
 
 size_t FreeListOpt::alloc_meta_block(
-    DeviceAddr address, DeviceAddr size, ssize_t prev_block, ssize_t next_block, bool is_allocated) {
+    DeviceAddr address, DeviceAddr size, size_t prev_block, size_t next_block, bool is_allocated) {
     size_t idx;
     if (free_meta_block_indices_.empty()) {
         idx = block_address_.size();
@@ -405,8 +406,8 @@ size_t FreeListOpt::alloc_meta_block(
 }
 
 void FreeListOpt::unlink_block(size_t block_index) {
-    const ssize_t prev_block = block_prev_block_[block_index];
-    const ssize_t next_block = block_next_block_[block_index];
+    const size_t prev_block = block_prev_block_[block_index];
+    const size_t next_block = block_next_block_[block_index];
     if (prev_block != no_block) {
         block_next_block_[prev_block] = next_block;
     }
@@ -484,15 +485,10 @@ void FreeListOpt::dump_blocks(std::ostream& out) const {
         }
         return std::string(width - str.size(), ' ') + str;
     };
-    auto leftpad_num = [leftpad](auto num, size_t width) {
-        // Only the prev/next link columns carry the sentinel; the unsigned columns must not be compared
-        // against it, or an address of SIZE_MAX would print as "none"
-        if constexpr (std::is_signed_v<decltype(num)>) {
-            if (num == no_block) {
-                return leftpad("none", width);
-            }
-        }
-        return leftpad(std::to_string(num), width);
+    auto leftpad_num = [leftpad](auto num, size_t width) { return leftpad(std::to_string(num), width); };
+    // Only the link columns can hold the sentinel; a size or address equal to no_block is a real value
+    auto leftpad_link = [leftpad](size_t link, size_t width) {
+        return leftpad(link == no_block ? "none" : std::to_string(link), width);
     };
     const size_t pad = 12;
     std::array<std::string, 6> headers = {"Block", "Address", "Size", "PrevID", "NextID", "Allocated"};
@@ -505,8 +501,8 @@ void FreeListOpt::dump_blocks(std::ostream& out) const {
             continue;
         }
         out << leftpad_num(i, pad) << " " << leftpad_num(block_address_[i], pad) << " "
-            << leftpad_num(block_size_[i], pad) << " " << leftpad_num(block_prev_block_[i], pad) << " "
-            << leftpad_num(block_next_block_[i], pad) << " " << leftpad(block_is_allocated_[i] ? "yes" : "no", pad)
+            << leftpad_num(block_size_[i], pad) << " " << leftpad_link(block_prev_block_[i], pad) << " "
+            << leftpad_link(block_next_block_[i], pad) << " " << leftpad(block_is_allocated_[i] ? "yes" : "no", pad)
             << std::endl;
     }
 }
@@ -545,7 +541,7 @@ void FreeListOpt::shrink_size(DeviceAddr shrink_size, bool bottom_up) {
         max_size_bytes_);
 
     // loop and scan the block list to find if the shrink cut into any allocated block
-    ssize_t found_block = no_block;
+    std::optional<size_t> found_block;
     DeviceAddr shrunk_address = shrink_size_ + shrink_size;
     // TODO: There must be a way to force the beginning of all blocks be at index 0
     for (size_t i = 0; i < block_address_.size(); i++) {
@@ -565,9 +561,8 @@ void FreeListOpt::shrink_size(DeviceAddr shrink_size, bool bottom_up) {
     }
 
     TT_FATAL(
-        found_block != no_block, "Shrink size {} does not align with any block. This must be a bug", shrunk_address);
-    // Validated above, so it is safe to narrow to an index for the rest of the function
-    const size_t block_to_shrink = static_cast<size_t>(found_block);
+        found_block.has_value(), "Shrink size {} does not align with any block. This must be a bug", shrunk_address);
+    const size_t block_to_shrink = *found_block;
 
     // Find the relevant size segregated list
     size_t size_segregated_index = get_size_segregated_index(block_size_[block_to_shrink]);
@@ -603,7 +598,7 @@ void FreeListOpt::reset_size() {
     }
 
     // Create a new block, mark it as allocated and deallocate the old block so coalescing can happen
-    ssize_t lowest_block_index = no_block;
+    std::optional<size_t> lowest_block_index;
     bool has_live_block = false;
     for (size_t i = 0; i < block_address_.size(); i++) {
         if (!meta_block_is_allocated_[i]) {
@@ -616,32 +611,32 @@ void FreeListOpt::reset_size() {
         }
     }
 
-    TT_FATAL(!has_live_block || lowest_block_index != no_block, "Lowest block not found during reset size");
+    TT_FATAL(!has_live_block || lowest_block_index.has_value(), "Lowest block not found during reset size");
 
-    // There 3 cases to consider:
+    // There are 3 cases to consider:
     // 1. Every block was consumed by the shrink, which means there is nothing to grow back into and the
     //    restored range has to be rebuilt the way init() does it
-    // 2. The lowest block is is free, which means we can just modify it's attributes
+    // 2. The lowest block is free, which means we can just modify its attributes
     // 3. The lowest block is allocated, which means we need to create a new block and deallocate the old one
-    if (lowest_block_index == no_block) {
+    if (!lowest_block_index.has_value()) {
         size_t new_block_index = alloc_meta_block(0, shrink_size_, no_block, no_block, false);
         insert_block_to_segregated_list(new_block_index);
-    } else if (!block_is_allocated_[lowest_block_index]) {
+    } else if (!block_is_allocated_[*lowest_block_index]) {
         auto* segregated_list =
-            &free_blocks_segregated_by_size_[get_size_segregated_index(block_size_[lowest_block_index])];
+            &free_blocks_segregated_by_size_[get_size_segregated_index(block_size_[*lowest_block_index])];
         for (size_t i = 0; i < segregated_list->size(); i++) {
-            if ((*segregated_list)[i] == lowest_block_index) {
-                segregated_list->erase(segregated_list->begin() + i);
+            if ((*segregated_list)[i] == *lowest_block_index) {
+                segregated_list->erase(segregated_list->begin() + static_cast<std::ptrdiff_t>(i));
                 break;
             }
         }
-        block_size_[lowest_block_index] += shrink_size_;
-        block_address_[lowest_block_index] = 0;
-        insert_block_to_segregated_list(lowest_block_index);
+        block_size_[*lowest_block_index] += shrink_size_;
+        block_address_[*lowest_block_index] = 0;
+        insert_block_to_segregated_list(*lowest_block_index);
     } else {
-        size_t new_block_index = alloc_meta_block(0, shrink_size_, no_block, lowest_block_index, false);
-        TT_ASSERT(!has_prev_block(lowest_block_index), "Lowest block should not have a previous block");
-        block_prev_block_[lowest_block_index] = new_block_index;
+        size_t new_block_index = alloc_meta_block(0, shrink_size_, no_block, *lowest_block_index, false);
+        TT_ASSERT(!has_prev_block(*lowest_block_index), "Lowest block should not have a previous block");
+        block_prev_block_[*lowest_block_index] = new_block_index;
         insert_block_to_segregated_list(new_block_index);
     }
 
@@ -702,10 +697,11 @@ std::optional<size_t> FreeListOpt::get_block_index_from_alloc_table(DeviceAddr a
 std::optional<size_t> FreeListOpt::get_and_remove_from_alloc_table(DeviceAddr address) {
     size_t bucket = hash_device_address(address);
     // It's common to deallocate the last allocated block, so search from the back
-    for (ssize_t i = allocated_block_table_[bucket].size() - 1; i >= 0; i--) {
+    for (size_t i = allocated_block_table_[bucket].size(); i-- > 0;) {
         if (allocated_block_table_[bucket][i].first == address) {
             auto res = allocated_block_table_[bucket][i].second;
-            allocated_block_table_[bucket].erase(allocated_block_table_[bucket].begin() + i);
+            allocated_block_table_[bucket].erase(
+                allocated_block_table_[bucket].begin() + static_cast<std::ptrdiff_t>(i));
             return res;
         }
     }

--- a/tt_metal/impl/allocator/algorithms/free_list_opt.cpp
+++ b/tt_metal/impl/allocator/algorithms/free_list_opt.cpp
@@ -575,7 +575,14 @@ void FreeListOpt::shrink_size(DeviceAddr shrink_size, bool bottom_up) {
     max_size_bytes_ -= shrink_size;
     shrink_size_ += shrink_size;
     if (block_size_[block_to_shrink] == 0) {
-        block_prev_block_[block_next_block_[block_to_shrink]] = block_prev_block_[block_to_shrink];
+        const ssize_t prev_block = block_prev_block_[block_to_shrink];
+        const ssize_t next_block = block_next_block_[block_to_shrink];
+        if (next_block != -1) {
+            block_prev_block_[next_block] = prev_block;
+        }
+        if (prev_block != -1) {
+            block_next_block_[prev_block] = next_block;
+        }
         free_meta_block(block_to_shrink);
     } else {
         block_address_[block_to_shrink] += shrink_size;
@@ -590,21 +597,29 @@ void FreeListOpt::reset_size() {
 
     // Create a new block, mark it as allocated and deallocate the old block so coalescing can happen
     ssize_t lowest_block_index = -1;
+    bool has_live_block = false;
     for (size_t i = 0; i < block_address_.size(); i++) {
         if (!meta_block_is_allocated_[i]) {
             continue;
         }
+        has_live_block = true;
         if (block_address_[i] == shrink_size_) {
             lowest_block_index = i;
             break;
         }
     }
-    TT_ASSERT(lowest_block_index != -1, "Lowest block not found during reset size");
 
-    // There 2 cases to consider:
-    // 1. The lowest block is is free, which means we can just modify it's attributes
-    // 2. The lowest block is allocated, which means we need to create a new block and deallocate the old one
-    if (!block_is_allocated_[lowest_block_index]) {
+    TT_FATAL(!has_live_block || lowest_block_index != -1, "Lowest block not found during reset size");
+
+    // There 3 cases to consider:
+    // 1. Every block was consumed by the shrink, which means there is nothing to grow back into and the
+    //    restored range has to be rebuilt the way init() does it
+    // 2. The lowest block is is free, which means we can just modify it's attributes
+    // 3. The lowest block is allocated, which means we need to create a new block and deallocate the old one
+    if (lowest_block_index == -1) {
+        size_t new_block_index = alloc_meta_block(0, shrink_size_, -1, -1, false);
+        insert_block_to_segregated_list(new_block_index);
+    } else if (!block_is_allocated_[lowest_block_index]) {
         auto* segregated_list =
             &free_blocks_segregated_by_size_[get_size_segregated_index(block_size_[lowest_block_index])];
         for (size_t i = 0; i < segregated_list->size(); i++) {

--- a/tt_metal/impl/allocator/algorithms/free_list_opt.cpp
+++ b/tt_metal/impl/allocator/algorithms/free_list_opt.cpp
@@ -12,6 +12,7 @@
 #include <functional>
 #include <optional>
 #include <string>
+#include <type_traits>
 #include <unordered_map>
 #include <vector>
 
@@ -89,8 +90,8 @@ void FreeListOpt::init() {
     // Create a single block that spans the entire memory
     block_address_.push_back(0);
     block_size_.push_back(max_size_bytes_);
-    block_prev_block_.push_back(-1);
-    block_next_block_.push_back(-1);
+    block_prev_block_.push_back(no_block);
+    block_next_block_.push_back(no_block);
     block_is_allocated_.push_back(false);
     meta_block_is_allocated_.push_back(true);
     free_blocks_segregated_by_size_[get_size_segregated_index(max_size_bytes_)].push_back(0);
@@ -103,7 +104,7 @@ std::optional<DeviceAddr> FreeListOpt::allocate(DeviceAddr size_bytes, bool bott
     // we can be confident that it's the best block to allocate from. Else, look at the next size class. However the
     // blocks within a size class are not sorted by size, so we may not always find the best block.
 
-    ssize_t target_block_index = -1;
+    ssize_t target_block_index = no_block;
     size_t size_segregated_index = get_size_segregated_index(alloc_size);
     TT_ASSERT(size_segregated_index < size_segregated_count, "Size segregated index out of bounds");
     std::vector<size_t>* segregated_list = nullptr;
@@ -123,12 +124,12 @@ std::optional<DeviceAddr> FreeListOpt::allocate(DeviceAddr size_bytes, bool bott
                     break;
                 }
                 if (block_size_[block_index] >= alloc_size &&
-                    (target_block_index == -1 || block_size_[block_index] < block_size_[target_block_index])) {
+                    (target_block_index == no_block || block_size_[block_index] < block_size_[target_block_index])) {
                     target_block_index = block_index;
                     segregated_list = &free_blocks;
                     segregated_item_index = j;
                 }
-                if (target_block_index != -1) {
+                if (target_block_index != no_block) {
                     break;
                 }
             } else {
@@ -138,7 +139,7 @@ std::optional<DeviceAddr> FreeListOpt::allocate(DeviceAddr size_bytes, bool bott
 
                 bool address_better =
                     bottom_up ? block_address_[block_index] < best_address : block_address_[block_index] > best_address;
-                if (target_block_index == -1 || address_better) {
+                if (target_block_index == no_block || address_better) {
                     target_block_index = block_index;
                     segregated_list = &free_blocks;
                     segregated_item_index = j;
@@ -149,7 +150,7 @@ std::optional<DeviceAddr> FreeListOpt::allocate(DeviceAddr size_bytes, bool bott
         }
     }
 
-    if (target_block_index == -1) {
+    if (target_block_index == no_block) {
         return std::nullopt;
     }
     TT_ASSERT(segregated_list != nullptr, "Segregated list is null");
@@ -178,7 +179,7 @@ std::optional<DeviceAddr> FreeListOpt::allocate(DeviceAddr size_bytes, bool bott
 std::optional<DeviceAddr> FreeListOpt::allocate_at_address(DeviceAddr absolute_start_address, DeviceAddr size_bytes) {
     // Nothing we can do but scan the free list
     size_t alloc_size = align(std::max(size_bytes, min_allocation_size_));
-    ssize_t target_block_index = -1;
+    ssize_t target_block_index = no_block;
     DeviceAddr start_address = absolute_start_address - offset_bytes_;
     for (size_t i = 0; i < block_address_.size(); i++) {
         if (meta_block_is_allocated_[i]) {
@@ -191,7 +192,7 @@ std::optional<DeviceAddr> FreeListOpt::allocate_at_address(DeviceAddr absolute_s
         }
     }
 
-    if (target_block_index == -1 || block_is_allocated_[target_block_index]) {
+    if (target_block_index == no_block || block_is_allocated_[target_block_index]) {
         return std::nullopt;
     }
 
@@ -236,7 +237,7 @@ size_t FreeListOpt::allocate_in_block(size_t block_index, DeviceAddr alloc_size,
         block_size_[block_index] -= offset;
         block_address_[block_index] += offset;
         size_t new_block_index = alloc_meta_block(free_block_address, free_block_size, prev_block, block_index, false);
-        if (prev_block != -1) {
+        if (prev_block != no_block) {
             block_next_block_[prev_block] = new_block_index;
         }
         block_prev_block_[block_index] = new_block_index;
@@ -251,7 +252,7 @@ size_t FreeListOpt::allocate_in_block(size_t block_index, DeviceAddr alloc_size,
         ssize_t next_block = block_next_block_[block_index];
         block_size_[block_index] -= free_block_size;
         size_t new_block_index = alloc_meta_block(free_block_address, free_block_size, prev_block, next_block, false);
-        if (next_block != -1) {
+        if (next_block != no_block) {
             block_prev_block_[next_block] = new_block_index;
         }
         block_next_block_[block_index] = new_block_index;
@@ -279,7 +280,7 @@ void FreeListOpt::deallocate(DeviceAddr absolute_address) {
     ssize_t next_block = block_next_block_[block_index];
 
     // Merge with previous block if it's free
-    if (prev_block != -1 && !block_is_allocated_[prev_block]) {
+    if (prev_block != no_block && !block_is_allocated_[prev_block]) {
         // Look into the size segregated list to remove the block
         size_t size_segregated_index = get_size_segregated_index(block_size_[prev_block]);
         std::vector<size_t>& segregated_list = free_blocks_segregated_by_size_[size_segregated_index];
@@ -292,16 +293,13 @@ void FreeListOpt::deallocate(DeviceAddr absolute_address) {
         segregated_list.erase(it);
 
         block_size_[prev_block] += block_size_[block_index];
-        block_next_block_[prev_block] = next_block;
-        if (next_block != -1) {
-            block_prev_block_[next_block] = prev_block;
-        }
+        unlink_block(block_index);
         free_meta_block(block_index);
         block_index = prev_block;
     }
 
     // Merge with next block if it's free
-    if (next_block != -1 && !block_is_allocated_[next_block]) {
+    if (next_block != no_block && !block_is_allocated_[next_block]) {
         // Look into the size segregated list to remove the block
         size_t size_segregated_index = get_size_segregated_index(block_size_[next_block]);
         std::vector<size_t>& segregated_list = free_blocks_segregated_by_size_[size_segregated_index];
@@ -314,10 +312,9 @@ void FreeListOpt::deallocate(DeviceAddr absolute_address) {
         segregated_list.erase(it);
 
         block_size_[block_index] += block_size_[next_block];
-        block_next_block_[block_index] = block_next_block_[next_block];
-        if (block_next_block_[next_block] != -1) {
-            block_prev_block_[block_next_block_[next_block]] = block_index;
-        }
+        // block_prev_block_[next_block] == block_index here, so unlinking next_block is what rewires
+        // block_index's forward link onto next_block's successor
+        unlink_block(next_block);
         free_meta_block(next_block);
     }
 
@@ -325,7 +322,7 @@ void FreeListOpt::deallocate(DeviceAddr absolute_address) {
     if (addr <= *lowest_occupied_address_) {
         lowest_occupied_address_ = std::nullopt;
         ssize_t curr_block_index = block_next_block_[block_index];
-        while (curr_block_index != -1) {
+        while (curr_block_index != no_block) {
             if (block_is_allocated_[curr_block_index]) {
                 lowest_occupied_address_ = block_address_[curr_block_index];
                 break;
@@ -407,6 +404,17 @@ size_t FreeListOpt::alloc_meta_block(
     return idx;
 }
 
+void FreeListOpt::unlink_block(size_t block_index) {
+    const ssize_t prev_block = block_prev_block_[block_index];
+    const ssize_t next_block = block_next_block_[block_index];
+    if (prev_block != no_block) {
+        block_next_block_[prev_block] = next_block;
+    }
+    if (next_block != no_block) {
+        block_prev_block_[next_block] = prev_block;
+    }
+}
+
 void FreeListOpt::free_meta_block(size_t block_index) {
     free_meta_block_indices_.push_back(block_index);
     meta_block_is_allocated_[block_index] = false;
@@ -477,9 +485,12 @@ void FreeListOpt::dump_blocks(std::ostream& out) const {
         return std::string(width - str.size(), ' ') + str;
     };
     auto leftpad_num = [leftpad](auto num, size_t width) {
-        // HACK: -1 for us means none
-        if (num == -1) {
-            return leftpad("none", width);
+        // Only the prev/next link columns carry the sentinel; the unsigned columns must not be compared
+        // against it, or an address of SIZE_MAX would print as "none"
+        if constexpr (std::is_signed_v<decltype(num)>) {
+            if (num == no_block) {
+                return leftpad("none", width);
+            }
         }
         return leftpad(std::to_string(num), width);
     };
@@ -534,7 +545,7 @@ void FreeListOpt::shrink_size(DeviceAddr shrink_size, bool bottom_up) {
         max_size_bytes_);
 
     // loop and scan the block list to find if the shrink cut into any allocated block
-    size_t block_to_shrink = -1;
+    ssize_t found_block = no_block;
     DeviceAddr shrunk_address = shrink_size_ + shrink_size;
     // TODO: There must be a way to force the beginning of all blocks be at index 0
     for (size_t i = 0; i < block_address_.size(); i++) {
@@ -548,12 +559,15 @@ void FreeListOpt::shrink_size(DeviceAddr shrink_size, bool bottom_up) {
                 shrunk_address,
                 block_address_[i]);
         } else if (block_address_[i] <= shrunk_address && block_address_[i] + block_size_[i] >= shrunk_address) {
-            block_to_shrink = i;
+            found_block = i;
             break;
         }
     }
 
-    TT_FATAL(block_to_shrink != -1, "Shrink size {} does not align with any block. This must be a bug", shrunk_address);
+    TT_FATAL(
+        found_block != no_block, "Shrink size {} does not align with any block. This must be a bug", shrunk_address);
+    // Validated above, so it is safe to narrow to an index for the rest of the function
+    const size_t block_to_shrink = static_cast<size_t>(found_block);
 
     // Find the relevant size segregated list
     size_t size_segregated_index = get_size_segregated_index(block_size_[block_to_shrink]);
@@ -575,14 +589,7 @@ void FreeListOpt::shrink_size(DeviceAddr shrink_size, bool bottom_up) {
     max_size_bytes_ -= shrink_size;
     shrink_size_ += shrink_size;
     if (block_size_[block_to_shrink] == 0) {
-        const ssize_t prev_block = block_prev_block_[block_to_shrink];
-        const ssize_t next_block = block_next_block_[block_to_shrink];
-        if (next_block != -1) {
-            block_prev_block_[next_block] = prev_block;
-        }
-        if (prev_block != -1) {
-            block_next_block_[prev_block] = next_block;
-        }
+        unlink_block(block_to_shrink);
         free_meta_block(block_to_shrink);
     } else {
         block_address_[block_to_shrink] += shrink_size;
@@ -596,7 +603,7 @@ void FreeListOpt::reset_size() {
     }
 
     // Create a new block, mark it as allocated and deallocate the old block so coalescing can happen
-    ssize_t lowest_block_index = -1;
+    ssize_t lowest_block_index = no_block;
     bool has_live_block = false;
     for (size_t i = 0; i < block_address_.size(); i++) {
         if (!meta_block_is_allocated_[i]) {
@@ -609,15 +616,15 @@ void FreeListOpt::reset_size() {
         }
     }
 
-    TT_FATAL(!has_live_block || lowest_block_index != -1, "Lowest block not found during reset size");
+    TT_FATAL(!has_live_block || lowest_block_index != no_block, "Lowest block not found during reset size");
 
     // There 3 cases to consider:
     // 1. Every block was consumed by the shrink, which means there is nothing to grow back into and the
     //    restored range has to be rebuilt the way init() does it
     // 2. The lowest block is is free, which means we can just modify it's attributes
     // 3. The lowest block is allocated, which means we need to create a new block and deallocate the old one
-    if (lowest_block_index == -1) {
-        size_t new_block_index = alloc_meta_block(0, shrink_size_, -1, -1, false);
+    if (lowest_block_index == no_block) {
+        size_t new_block_index = alloc_meta_block(0, shrink_size_, no_block, no_block, false);
         insert_block_to_segregated_list(new_block_index);
     } else if (!block_is_allocated_[lowest_block_index]) {
         auto* segregated_list =
@@ -632,8 +639,8 @@ void FreeListOpt::reset_size() {
         block_address_[lowest_block_index] = 0;
         insert_block_to_segregated_list(lowest_block_index);
     } else {
-        size_t new_block_index = alloc_meta_block(0, shrink_size_, -1, lowest_block_index, false);
-        TT_ASSERT(block_prev_block_[lowest_block_index] == -1, "Lowest block should not have a previous block");
+        size_t new_block_index = alloc_meta_block(0, shrink_size_, no_block, lowest_block_index, false);
+        TT_ASSERT(!has_prev_block(lowest_block_index), "Lowest block should not have a previous block");
         block_prev_block_[lowest_block_index] = new_block_index;
         insert_block_to_segregated_list(new_block_index);
     }

--- a/tt_metal/impl/allocator/algorithms/free_list_opt.hpp
+++ b/tt_metal/impl/allocator/algorithms/free_list_opt.hpp
@@ -73,6 +73,12 @@ public:
     void reset_size() override;
 
 private:
+    // Sentinel meaning "no such block", used both in the prev/next vectors below and for local block
+    // indices before a block has been found. Must stay signed: assigning it to a size_t silently turns
+    // it into SIZE_MAX, which still compares equal to a literal -1 but is not a value anyone can reason
+    // about.
+    static constexpr ssize_t no_block = -1;
+
     // SoA free list components
     std::vector<DeviceAddr> block_address_;
     std::vector<DeviceAddr> block_size_;
@@ -120,6 +126,15 @@ private:
     // Put the block at block_index into the size segregated list at the appropriate index (data taken from
     // the SoA vectors)
     void insert_block_to_segregated_list(size_t block_index);
+
+    // Sentinel-aware accessor for the prev/next links, so callers never index the SoA vectors with a
+    // link that may hold no_block
+    bool has_prev_block(size_t block_index) const { return block_prev_block_[block_index] != no_block; }
+
+    // Remove block_index from the prev/next chain, healing both neighbours' links. Does not touch the
+    // block's own links, its size, or the segregated lists. This is the single place that knows how to
+    // take a block out of the list; every caller that drops a block should go through it.
+    void unlink_block(size_t block_index);
 
     // Allocate a new block and return the index to the block
     size_t alloc_meta_block(

--- a/tt_metal/impl/allocator/algorithms/free_list_opt.hpp
+++ b/tt_metal/impl/allocator/algorithms/free_list_opt.hpp
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <limits>
 #include <optional>
 #include <ostream>
 #include <utility>
@@ -75,17 +76,16 @@ public:
     void reset_size() override;
 
 private:
-    // Sentinel meaning "no such block", used both in the prev/next vectors below and for local block
-    // indices before a block has been found. Must stay signed: assigning it to a size_t silently turns
-    // it into SIZE_MAX, which still compares equal to a literal -1 but is not a value anyone can reason
-    // about.
-    static constexpr ssize_t no_block = -1;
+    // Sentinel meaning "no such block", stored in the prev/next link vectors below. Anything that
+    // hands "no block" back to a caller uses std::optional<size_t> instead; the links cannot, because
+    // they are hot SoA data and an optional would double their size.
+    static constexpr size_t no_block = std::numeric_limits<size_t>::max();
 
     // SoA free list components
     std::vector<DeviceAddr> block_address_;
     std::vector<DeviceAddr> block_size_;
-    std::vector<ssize_t> block_prev_block_;
-    std::vector<ssize_t> block_next_block_;
+    std::vector<size_t> block_prev_block_;
+    std::vector<size_t> block_next_block_;
     std::vector<uint8_t> block_is_allocated_;       // not using bool to avoid compacting
     std::vector<uint8_t> meta_block_is_allocated_;  // not using bool to avoid compacting
 
@@ -131,18 +131,15 @@ private:
     // the SoA vectors)
     void insert_block_to_segregated_list(size_t block_index);
 
-    // Sentinel-aware accessor for the prev/next links, so callers never index the SoA vectors with a
-    // link that may hold no_block
     bool has_prev_block(size_t block_index) const { return block_prev_block_[block_index] != no_block; }
 
     // Remove block_index from the prev/next chain, healing both neighbours' links. Does not touch the
-    // block's own links, its size, or the segregated lists. This is the single place that knows how to
-    // take a block out of the list; every caller that drops a block should go through it.
+    // block's own links, its size, or the segregated lists.
     void unlink_block(size_t block_index);
 
     // Allocate a new block and return the index to the block
     size_t alloc_meta_block(
-        DeviceAddr address, DeviceAddr size, ssize_t prev_block, ssize_t next_block, bool is_allocated);
+        DeviceAddr address, DeviceAddr size, size_t prev_block, size_t next_block, bool is_allocated);
     // Free the block at block_index and mark it as free
     void free_meta_block(size_t block_index);
 

--- a/tt_metal/impl/allocator/algorithms/free_list_opt.hpp
+++ b/tt_metal/impl/allocator/algorithms/free_list_opt.hpp
@@ -75,6 +75,12 @@ public:
     void reset_size() override;
 
 private:
+    // Sentinel meaning "no such block", used both in the prev/next vectors below and for local block
+    // indices before a block has been found. Must stay signed: assigning it to a size_t silently turns
+    // it into SIZE_MAX, which still compares equal to a literal -1 but is not a value anyone can reason
+    // about.
+    static constexpr ssize_t no_block = -1;
+
     // SoA free list components
     std::vector<DeviceAddr> block_address_;
     std::vector<DeviceAddr> block_size_;
@@ -124,6 +130,15 @@ private:
     // Put the block at block_index into the size segregated list at the appropriate index (data taken from
     // the SoA vectors)
     void insert_block_to_segregated_list(size_t block_index);
+
+    // Sentinel-aware accessor for the prev/next links, so callers never index the SoA vectors with a
+    // link that may hold no_block
+    bool has_prev_block(size_t block_index) const { return block_prev_block_[block_index] != no_block; }
+
+    // Remove block_index from the prev/next chain, healing both neighbours' links. Does not touch the
+    // block's own links, its size, or the segregated lists. This is the single place that knows how to
+    // take a block out of the list; every caller that drops a block should go through it.
+    void unlink_block(size_t block_index);
 
     // Allocate a new block and return the index to the block
     size_t alloc_meta_block(

--- a/tt_metal/impl/allocator/algorithms/free_list_opt.hpp
+++ b/tt_metal/impl/allocator/algorithms/free_list_opt.hpp
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <limits>
 #include <optional>
 #include <ostream>
 #include <utility>
@@ -73,17 +74,16 @@ public:
     void reset_size() override;
 
 private:
-    // Sentinel meaning "no such block", used both in the prev/next vectors below and for local block
-    // indices before a block has been found. Must stay signed: assigning it to a size_t silently turns
-    // it into SIZE_MAX, which still compares equal to a literal -1 but is not a value anyone can reason
-    // about.
-    static constexpr ssize_t no_block = -1;
+    // Sentinel meaning "no such block", stored in the prev/next link vectors below. Anything that
+    // hands "no block" back to a caller uses std::optional<size_t> instead; the links cannot, because
+    // they are hot SoA data and an optional would double their size.
+    static constexpr size_t no_block = std::numeric_limits<size_t>::max();
 
     // SoA free list components
     std::vector<DeviceAddr> block_address_;
     std::vector<DeviceAddr> block_size_;
-    std::vector<ssize_t> block_prev_block_;
-    std::vector<ssize_t> block_next_block_;
+    std::vector<size_t> block_prev_block_;
+    std::vector<size_t> block_next_block_;
     std::vector<uint8_t> block_is_allocated_;       // not using bool to avoid compacting
     std::vector<uint8_t> meta_block_is_allocated_;  // not using bool to avoid compacting
 
@@ -127,18 +127,15 @@ private:
     // the SoA vectors)
     void insert_block_to_segregated_list(size_t block_index);
 
-    // Sentinel-aware accessor for the prev/next links, so callers never index the SoA vectors with a
-    // link that may hold no_block
     bool has_prev_block(size_t block_index) const { return block_prev_block_[block_index] != no_block; }
 
     // Remove block_index from the prev/next chain, healing both neighbours' links. Does not touch the
-    // block's own links, its size, or the segregated lists. This is the single place that knows how to
-    // take a block out of the list; every caller that drops a block should go through it.
+    // block's own links, its size, or the segregated lists.
     void unlink_block(size_t block_index);
 
     // Allocate a new block and return the index to the block
     size_t alloc_meta_block(
-        DeviceAddr address, DeviceAddr size, ssize_t prev_block, ssize_t next_block, bool is_allocated);
+        DeviceAddr address, DeviceAddr size, size_t prev_block, size_t next_block, bool is_allocated);
     // Free the block at block_index and mark it as free
     void free_meta_block(size_t block_index);
 


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

`FreeListOpt::shrink_size()` unlinked a fully-consumed block by indexing `block_prev_block_` with `block_next_block_[block_to_shrink]`, without checking the `-1` "no next block" sentinel. When a shrink consumes a trailing free block that has no successor, that index is `-1`, so the write lands at index `SIZE_MAX` of a `std::vector<ssize_t>`. Every other traversal in the file already guards the sentinel; this was the only site that did not.

The failure mode is worse than a clean crash: `SIZE_MAX * sizeof(ssize_t)` wraps to `-8`, so the write corrupts the malloc chunk header just before the vector's buffer. Nothing faults at the point of the bug, and glibc aborts later at an unrelated `free()`, which makes it hard to attribute.

The fix latches the two links into locals and repairs each direction only when it points at a real block, so the sentinel is never used as an index: `if (next_block != -1) { block_prev_block_[next_block] = prev_block; }` and `if (prev_block != -1) { block_next_block_[prev_block] = next_block; }`, then `free_meta_block(block_to_shrink)` as before. The second of those also repairs the predecessor's forward link, which the original statement never touched, so a predecessor no longer keeps pointing at a recycled meta block.

Fixing the unlink makes an empty block list reachable for the first time, and `reset_size()` could not handle that: its scan leaves `lowest_block_index == -1`, `TT_ASSERT` compiles out in release builds, and it would then index with `-1` itself. So `reset_size()` gains a third case that rebuilds the restored range the way `init()` does, and its assert is promoted to `TT_FATAL`.

Verified by reverting only the source fix and keeping the new test: it fails its assertion and the process aborts with `munmap_chunk(): invalid pointer` (exit 134). With the fix, all 22 `FreeListOptTest` cases pass, along with the 13 in `OverlappedAllocators` and `TxnIdAllocatorTest` that also exercise this allocator. The new case is `FreeListOptTest.ShrinkEntirePoolAndReset`.

Relates to #51127 (defect 1). Closes #51266.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=msudumbrekar/fix-free-list-opt-shrink-oob)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:msudumbrekar/fix-free-list-opt-shrink-oob)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=msudumbrekar/fix-free-list-opt-shrink-oob)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:msudumbrekar/fix-free-list-opt-shrink-oob)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=msudumbrekar/fix-free-list-opt-shrink-oob)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:msudumbrekar/fix-free-list-opt-shrink-oob)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=msudumbrekar/fix-free-list-opt-shrink-oob)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:msudumbrekar/fix-free-list-opt-shrink-oob)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=msudumbrekar/fix-free-list-opt-shrink-oob)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:msudumbrekar/fix-free-list-opt-shrink-oob)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=msudumbrekar/fix-free-list-opt-shrink-oob)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:msudumbrekar/fix-free-list-opt-shrink-oob)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=msudumbrekar/fix-free-list-opt-shrink-oob)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:msudumbrekar/fix-free-list-opt-shrink-oob)