### PR TITLE
Extend validate_program_args CI gating to pr-gate/merge-gate/sanity-tests impls

### DIFF
--- a/.github/workflows/basic.yaml
+++ b/.github/workflows/basic.yaml
@@ -92,6 +92,7 @@ jobs:
         ASAN_OPTIONS: "color=always"
         TSAN_OPTIONS: "color=always"
         UBSAN_OPTIONS: "color=always:print_stacktrace=1:halt_on_error=1"
+        TTNN_CONFIG_OVERRIDES: '{"validate_program_args": true}'
       volumes:
         - /work
         - ${{ (!contains(join(matrix.test-group.runs_on, ','), 'viommu') && '/dev/hugepages-1G:/dev/hugepages-1G') || '/no_hugepages' }}

--- a/.github/workflows/galaxy-sanity-impl.yaml
+++ b/.github/workflows/galaxy-sanity-impl.yaml
@@ -64,6 +64,7 @@ jobs:
         LD_LIBRARY_PATH: /work/build/lib
         LOGURU_LEVEL: INFO
         GTEST_OUTPUT: xml:/work/generated/test_reports/
+        TTNN_CONFIG_OVERRIDES: '{"validate_program_run_args": true}'
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G

--- a/.github/workflows/galaxy-sanity-impl.yaml
+++ b/.github/workflows/galaxy-sanity-impl.yaml
@@ -64,7 +64,7 @@ jobs:
         LD_LIBRARY_PATH: /work/build/lib
         LOGURU_LEVEL: INFO
         GTEST_OUTPUT: xml:/work/generated/test_reports/
-        TTNN_CONFIG_OVERRIDES: '{"validate_program_run_args": true}'
+        TTNN_CONFIG_OVERRIDES: '{"validate_program_args": true}'
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G

--- a/.github/workflows/models-smoke-tests-impl.yaml
+++ b/.github/workflows/models-smoke-tests-impl.yaml
@@ -115,6 +115,7 @@ jobs:
         LOGURU_LEVEL: INFO
         GTEST_OUTPUT: xml:/work/generated/test_reports/
         MLPERF_READ_ONLY: ${{ inputs.mlperf-read-only }}
+        TTNN_CONFIG_OVERRIDES: '{"validate_program_args": true}'
       volumes:
         - ${{ github.workspace }}/docker-job:/work
         - /dev/hugepages-1G:/dev/hugepages-1G

--- a/.github/workflows/ops-sanity-impl.yaml
+++ b/.github/workflows/ops-sanity-impl.yaml
@@ -88,6 +88,7 @@ jobs:
         ARCH_NAME: ${{ (contains(matrix.test-group.sku, 'bh_') || contains(matrix.test-group.sku, 'blackhole')) && 'blackhole' || 'wormhole_b0' }}
         LOGURU_LEVEL: INFO
         PYTHONPATH: /work
+        TTNN_CONFIG_OVERRIDES: '{"validate_program_run_args": true}'
       volumes:
         - ${{ github.workspace }}/docker-job:/work
         - /dev/hugepages-1G:/dev/hugepages-1G

--- a/.github/workflows/ops-sanity-impl.yaml
+++ b/.github/workflows/ops-sanity-impl.yaml
@@ -88,7 +88,7 @@ jobs:
         ARCH_NAME: ${{ (contains(matrix.test-group.sku, 'bh_') || contains(matrix.test-group.sku, 'blackhole')) && 'blackhole' || 'wormhole_b0' }}
         LOGURU_LEVEL: INFO
         PYTHONPATH: /work
-        TTNN_CONFIG_OVERRIDES: '{"validate_program_run_args": true}'
+        TTNN_CONFIG_OVERRIDES: '{"validate_program_args": true}'
       volumes:
         - ${{ github.workspace }}/docker-job:/work
         - /dev/hugepages-1G:/dev/hugepages-1G

--- a/.github/workflows/runtime-sanity-tests-impl.yaml
+++ b/.github/workflows/runtime-sanity-tests-impl.yaml
@@ -120,6 +120,7 @@ jobs:
         LOGURU_LEVEL: INFO
         GTEST_OUTPUT: xml:/work/generated/test_reports/
         LSAN_OPTIONS: suppressions=/usr/share/tt-metalium/lsan.supp
+        TTNN_CONFIG_OVERRIDES: '{"validate_program_run_args": true}'
       volumes:
         - ${{ github.workspace }}/docker-job:/work
         - /dev/hugepages-1G:/dev/hugepages-1G

--- a/.github/workflows/runtime-sanity-tests-impl.yaml
+++ b/.github/workflows/runtime-sanity-tests-impl.yaml
@@ -120,7 +120,7 @@ jobs:
         LOGURU_LEVEL: INFO
         GTEST_OUTPUT: xml:/work/generated/test_reports/
         LSAN_OPTIONS: suppressions=/usr/share/tt-metalium/lsan.supp
-        TTNN_CONFIG_OVERRIDES: '{"validate_program_run_args": true}'
+        TTNN_CONFIG_OVERRIDES: '{"validate_program_args": true}'
       volumes:
         - ${{ github.workspace }}/docker-job:/work
         - /dev/hugepages-1G:/dev/hugepages-1G

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -114,6 +114,7 @@ jobs:
         TSAN_OPTIONS: "color=always"
         UBSAN_OPTIONS: "color=always:print_stacktrace=1:halt_on_error=1"
         LLVM_PROFILE_FILE: "/work/coverage/%p-%m.profraw"
+        TTNN_CONFIG_OVERRIDES: '{"validate_program_args": true}'
       volumes:
         - /work
         - ${{ (!contains(join(matrix.test-group.runs_on, ','), 'viommu') && '/dev/hugepages-1G:/dev/hugepages-1G') || '/no_hugepages' }}

--- a/.github/workflows/t3000-sanity-tests-impl.yaml
+++ b/.github/workflows/t3000-sanity-tests-impl.yaml
@@ -95,6 +95,7 @@ jobs:
         ARCH_NAME: wormhole_b0
         LOGURU_LEVEL: INFO
         GTEST_OUTPUT: xml:/work/generated/test_reports/
+        TTNN_CONFIG_OVERRIDES: '{"validate_program_run_args": true}'
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G

--- a/.github/workflows/t3000-sanity-tests-impl.yaml
+++ b/.github/workflows/t3000-sanity-tests-impl.yaml
@@ -95,7 +95,7 @@ jobs:
         ARCH_NAME: wormhole_b0
         LOGURU_LEVEL: INFO
         GTEST_OUTPUT: xml:/work/generated/test_reports/
-        TTNN_CONFIG_OVERRIDES: '{"validate_program_run_args": true}'
+        TTNN_CONFIG_OVERRIDES: '{"validate_program_args": true}'
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G

--- a/.github/workflows/ttnn-sanity-tests-impl.yaml
+++ b/.github/workflows/ttnn-sanity-tests-impl.yaml
@@ -182,6 +182,7 @@ jobs:
         LOGURU_LEVEL: INFO
         PYTHONPATH: /work
         TT_LOGGER_LEVEL: warn
+        TTNN_CONFIG_OVERRIDES: '{"validate_program_run_args": true}'
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
@@ -241,7 +242,7 @@ jobs:
       - name: Set ttnn fast runtime if exists in config
         if: ${{ matrix.test-group.fast_runtime_mode_off }}
         run: |
-          echo "TTNN_CONFIG_OVERRIDES={\"enable_fast_runtime_mode\": false}" >> $GITHUB_ENV
+          echo "TTNN_CONFIG_OVERRIDES={\"enable_fast_runtime_mode\": false, \"validate_program_run_args\": true}" >> $GITHUB_ENV
 
       - name: Set up coverage profiling
         if: ${{ inputs.collect-coverage }}

--- a/.github/workflows/ttnn-sanity-tests-impl.yaml
+++ b/.github/workflows/ttnn-sanity-tests-impl.yaml
@@ -182,7 +182,7 @@ jobs:
         LOGURU_LEVEL: INFO
         PYTHONPATH: /work
         TT_LOGGER_LEVEL: warn
-        TTNN_CONFIG_OVERRIDES: '{"validate_program_run_args": true}'
+        TTNN_CONFIG_OVERRIDES: '{"validate_program_args": true}'
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
@@ -242,7 +242,7 @@ jobs:
       - name: Set ttnn fast runtime if exists in config
         if: ${{ matrix.test-group.fast_runtime_mode_off }}
         run: |
-          echo "TTNN_CONFIG_OVERRIDES={\"enable_fast_runtime_mode\": false, \"validate_program_run_args\": true}" >> $GITHUB_ENV
+          echo "TTNN_CONFIG_OVERRIDES={\"enable_fast_runtime_mode\": false, \"validate_program_args\": true}" >> $GITHUB_ENV
 
       - name: Set up coverage profiling
         if: ${{ inputs.collect-coverage }}

--- a/.github/workflows/ttnn-smoke-tests-impl.yaml
+++ b/.github/workflows/ttnn-smoke-tests-impl.yaml
@@ -177,6 +177,7 @@ jobs:
         LOGURU_LEVEL: INFO
         PYTHONPATH: /work
         TT_LOGGER_LEVEL: warn
+        TTNN_CONFIG_OVERRIDES: '{"validate_program_args": true}'
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
@@ -236,7 +237,7 @@ jobs:
       - name: Set ttnn fast runtime if exists in config
         if: ${{ matrix.test-group.fast_runtime_mode_off }}
         run: |
-          echo "TTNN_CONFIG_OVERRIDES={\"enable_fast_runtime_mode\": false}" >> $GITHUB_ENV
+          echo "TTNN_CONFIG_OVERRIDES={\"enable_fast_runtime_mode\": false, \"validate_program_args\": true}" >> $GITHUB_ENV
 
       - name: Set up coverage profiling
         if: ${{ inputs.collect-coverage }}

--- a/.github/workflows/ttsim-sanity-tests-impl.yaml
+++ b/.github/workflows/ttsim-sanity-tests-impl.yaml
@@ -110,6 +110,7 @@ jobs:
       # ttsim installs under TT_METAL_HOME; setup-ttsim is invoked with root=$TT_METAL_HOME
       # so it copies the soc descriptor from the installed package's tt_metal/soc_descriptors/.
       TT_METAL_HOME: /usr/libexec/tt-metalium
+      TTNN_CONFIG_OVERRIDES: '{"validate_program_args": true}'
     steps:
       - name: Checkout actions
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/ttnn/api/ttnn/config.hpp
+++ b/ttnn/api/ttnn/config.hpp
@@ -26,6 +26,8 @@ struct Config {
         std::filesystem::path tmp_dir = "/tmp/ttnn";
         bool enable_model_cache = false;
         bool enable_fast_runtime_mode = true;
+        // Validate Metal 2.0 ProgramRunArgs on Set/UpdateProgramRunArgs. Off by default; CI turns it on.
+        bool validate_program_run_args = false;
         bool throw_exception_on_fallback = false;
         bool enable_logging = false;
         bool enable_graph_report = false;

--- a/ttnn/api/ttnn/config.hpp
+++ b/ttnn/api/ttnn/config.hpp
@@ -26,8 +26,9 @@ struct Config {
         std::filesystem::path tmp_dir = "/tmp/ttnn";
         bool enable_model_cache = false;
         bool enable_fast_runtime_mode = true;
-        // Validate Metal 2.0 ProgramRunArgs on Set/UpdateProgramRunArgs. Off by default; CI turns it on.
-        bool validate_program_run_args = false;
+        // Validate the Metal 2.0 host-side program args: the ProgramSpec on MakeProgramFromSpec and the
+        // ProgramRunArgs on Set/UpdateProgramRunArgs. Off by default; CI turns it on.
+        bool validate_program_args = false;
         bool throw_exception_on_fallback = false;
         bool enable_logging = false;
         bool enable_graph_report = false;

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -28,6 +28,7 @@
 #include <tuple>
 #include "ttnn/distributed/types.hpp"
 #include "ttnn/mesh_device_operation_utils.hpp"
+#include "ttnn/config.hpp"
 #include "ttnn/metal_v2_artifacts.hpp"
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
 #include "ttnn/operation_concepts.hpp"
@@ -905,11 +906,12 @@ public:
             auto op_owned_tensors =
                 std::make_shared<std::vector<tt::tt_metal::MeshTensor>>(std::move(artifacts.op_owned_tensors));
 
+            const bool skip_validation = !ttnn::CONFIG.get<"validate_program_run_args">();
             tt::tt_metal::distributed::MeshWorkload mesh_workload;
             std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
             for (const auto& range : tensor_coords.ranges()) {
                 auto program = tt::tt_metal::experimental::MakeProgramFromSpec(*mesh_device, artifacts.spec);
-                tt::tt_metal::experimental::SetProgramRunArgs(program, artifacts.run_params);
+                tt::tt_metal::experimental::SetProgramRunArgs(program, artifacts.run_params, skip_validation);
                 shared_variables.emplace(
                     range, shared_variables_t{.bindings = bindings, .op_owned_tensors = op_owned_tensors});
                 mesh_workload.add_program(range, std::move(program));
@@ -962,13 +964,14 @@ public:
             const operation_attributes_t& attrs,
             const tensor_args_t& tensor_args,
             tensor_return_value_t& tensor_return_value) {
+            const bool skip_validation = !ttnn::CONFIG.get<"validate_program_run_args">();
             for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
                 auto run_args = CustomSpecFactory::override_runtime_arguments(
                     attrs,
                     tensor_args,
                     tensor_return_value,
                     std::optional<ttnn::MeshCoordinate>(coordinate_range.start_coord()));
-                tt::tt_metal::experimental::UpdateProgramRunArgs(program, run_args);
+                tt::tt_metal::experimental::UpdateProgramRunArgs(program, run_args, skip_validation);
             }
         }
     };

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -906,11 +906,12 @@ public:
             auto op_owned_tensors =
                 std::make_shared<std::vector<tt::tt_metal::MeshTensor>>(std::move(artifacts.op_owned_tensors));
 
-            const bool skip_validation = !ttnn::CONFIG.get<"validate_program_run_args">();
+            const bool skip_validation = !ttnn::CONFIG.get<"validate_program_args">();
             tt::tt_metal::distributed::MeshWorkload mesh_workload;
             std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
             for (const auto& range : tensor_coords.ranges()) {
-                auto program = tt::tt_metal::experimental::MakeProgramFromSpec(*mesh_device, artifacts.spec);
+                auto program =
+                    tt::tt_metal::experimental::MakeProgramFromSpec(*mesh_device, artifacts.spec, skip_validation);
                 tt::tt_metal::experimental::SetProgramRunArgs(program, artifacts.run_params, skip_validation);
                 shared_variables.emplace(
                     range, shared_variables_t{.bindings = bindings, .op_owned_tensors = op_owned_tensors});
@@ -964,7 +965,7 @@ public:
             const operation_attributes_t& attrs,
             const tensor_args_t& tensor_args,
             tensor_return_value_t& tensor_return_value) {
-            const bool skip_validation = !ttnn::CONFIG.get<"validate_program_run_args">();
+            const bool skip_validation = !ttnn::CONFIG.get<"validate_program_args">();
             for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
                 auto run_args = CustomSpecFactory::override_runtime_arguments(
                     attrs,


### PR DESCRIPTION
### What

Follow-up on #50945. That PR turned on `validate_program_args` (via
`TTNN_CONFIG_OVERRIDES='{"validate_program_args": true}'`) in the five
device-sanity impl workflows. This extends the same wiring to the other
test-running impl workflows invoked by `pr-gate.yaml`, `merge-gate.yaml`, and
`sanity-tests.yaml`.

`pr-gate.yaml`, `merge-gate.yaml`, and `sanity-tests.yaml` themselves are pure
orchestrators (`uses:` other reusable workflows) with no job-level `env:`
block of their own, so the flag is added where it's actually read — the
job-level container `env:` of the impl workflows they call:

| impl workflow | invoked by |
|---|---|
| `smoke.yaml` | `pr-gate.yaml`, `merge-gate.yaml` |
| `basic.yaml` | `merge-gate.yaml` |
| `ttnn-smoke-tests-impl.yaml` (also merges the flag into the existing `fast_runtime_mode_off` `$GITHUB_ENV` step, same pattern as `ttnn-sanity-tests-impl.yaml` in #50945) | `merge-gate.yaml` |
| `models-smoke-tests-impl.yaml` | `merge-gate.yaml` |
| `ttsim-sanity-tests-impl.yaml` | `sanity-tests.yaml` (its only impl not already covered by #50945) |

Not touched: docs/SDK-examples/static-analysis/LLK/fabric/tt-train/triage impl
workflows called by these three gates — they're outside the ttnn Program-Spec
validation path, so the flag wouldn't do anything there. Happy to extend if
that's wrong.

### Why

Targets @dgomez's branch per request, so this rides along with #50945 rather
than needing to be rebased after it lands.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/ttnn-validate-program-run-args-add-pr-merge-gate-env)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/ttnn-validate-program-run-args-add-pr-merge-gate-env)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/ttnn-validate-program-run-args-add-pr-merge-gate-env)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/ttnn-validate-program-run-args-add-pr-merge-gate-env)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=dgomez/ttnn-validate-program-run-args-add-pr-merge-gate-env)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:dgomez/ttnn-validate-program-run-args-add-pr-merge-gate-env)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/ttnn-validate-program-run-args-add-pr-merge-gate-env)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/ttnn-validate-program-run-args-add-pr-merge-gate-env)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/ttnn-validate-program-run-args-add-pr-merge-gate-env)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/ttnn-validate-program-run-args-add-pr-merge-gate-env)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/ttnn-validate-program-run-args-add-pr-merge-gate-env)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/ttnn-validate-program-run-args-add-pr-merge-gate-env)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/ttnn-validate-program-run-args-add-pr-merge-gate-env)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/ttnn-validate-program-run-args-add-pr-merge-gate-env)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/ttnn-validate-program-run-args-add-pr-merge-gate-env)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/ttnn-validate-program-run-args-add-pr-merge-gate-env)