### PR TITLE
[Bug fix] Add scheduler-owned GDN state for Qwen serving

### DIFF
--- a/models/demos/blackhole/qwen36/tt/gdn/tp.py
+++ b/models/demos/blackhole/qwen36/tt/gdn/tp.py
@@ -202,6 +202,14 @@ class TPGatedDeltaNet:
         self._fused_const_tiles = build_fused_const_tiles(mesh, _FUSED_CHUNK_SIZE)
         self.conv_states = None
         self.rec_state = None
+        # Optional vLLM-managed recurrent-state storage. vLLM's MambaSpec
+        # supplies logical state ownership independently of decode batch rows;
+        # these compact pools hold the live states while rec_state/conv_states
+        # remain fixed-address decode work buffers captured by the trace.
+        self.managed_rec_state_pool = None
+        self.managed_conv_state_pool = None
+        self.managed_state_indices = None
+        self.managed_state_pool_slots = 0
         # In-place state updates for decode/prefill traces (set by model allocate_kv_caches)
         self._stable_state = False
         self.conv_carry = None  # cross-chunk prefill conv carry [1, K-1, qkv_dim_tp]
@@ -268,6 +276,192 @@ class TPGatedDeltaNet:
         ttnn.copy(self._zero_rec, self.rec_state)
         # Zero cross-chunk conv carry for new sequence
         ttnn.copy(self._zero_conv_carry, self.conv_carry)
+
+    def allocate_managed_state_pool(self, num_live_slots):
+        """Allocate compact vLLM state pools plus per-row dummy slots.
+
+        The scheduler's Mamba block IDs can range over the global KV block
+        pool, but cache mode ``none`` has at most ``num_live_slots`` live
+        request states. The plugin maps those logical blocks to compact slots.
+        A second bank of ``num_live_slots`` slots is reserved for padded decode
+        rows and warmup so trace capture never mutates a future request slot.
+        """
+        assert self.rec_state is not None and self.conv_states is not None, "reset_state must run first"
+        assert num_live_slots == self.B, f"managed state slots {num_live_slots} must match decode batch {self.B}"
+        if self.managed_rec_state_pool is not None:
+            return
+
+        slots = 2 * num_live_slots
+        mapper = ttnn.ReplicateTensorToMesh(self.mesh)
+        rec_torch_dtype = torch.float32 if self.rec_state.dtype == ttnn.float32 else torch.bfloat16
+        self.managed_rec_state_pool = ttnn.from_torch(
+            torch.zeros(slots, self.Nv, self.Dk, self.Dv, dtype=rec_torch_dtype),
+            dtype=self.rec_state.dtype,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            device=self.mesh,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=mapper,
+        )
+        self.managed_conv_state_pool = ttnn.from_torch(
+            # conv_states[0] is the shifted-out tap and is overwritten from
+            # conv_states[1] before every decode. Persist only the K-1 values
+            # that are part of upstream's logical GDN convolution state.
+            torch.zeros(slots, 1, self.K - 1, self.qkv_dim_tp, dtype=torch.bfloat16),
+            dtype=ttnn.bfloat16,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            device=self.mesh,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=mapper,
+        )
+        self.managed_state_pool_slots = slots
+
+    @property
+    def uses_managed_state_pool(self):
+        return self.managed_rec_state_pool is not None
+
+    def bind_managed_state_indices(self, state_indices):
+        """Bind the persistent runtime index tensor used by the decode trace."""
+        if self.uses_managed_state_pool:
+            self.managed_state_indices = state_indices
+
+    def _load_managed_state(self):
+        """Gather scheduler-owned state into fixed decode work buffers."""
+        if not self.uses_managed_state_pool:
+            return
+        assert self.managed_state_indices is not None, "managed state indices were not bound"
+
+        rec_table = ttnn.reshape(
+            self.managed_rec_state_pool,
+            (self.managed_state_pool_slots, self.Nv * self.Dk * self.Dv),
+        )
+        rec = ttnn.embedding(
+            self.managed_state_indices,
+            rec_table,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+        rec = ttnn.reshape(rec, (self.B, self.Nv, self.Dk, self.Dv))
+        rec_tiled = ttnn.to_layout(rec, ttnn.TILE_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        ttnn.copy(rec_tiled, self.rec_state)
+        ttnn.deallocate(rec_tiled)
+        ttnn.deallocate(rec)
+
+        conv_table = ttnn.reshape(
+            self.managed_conv_state_pool,
+            (self.managed_state_pool_slots, (self.K - 1) * self.qkv_dim_tp),
+        )
+        conv = ttnn.embedding(
+            self.managed_state_indices,
+            conv_table,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+        conv = ttnn.reshape(conv, (self.B, self.K - 1, self.qkv_dim_tp))
+        for stored_tap, tap in enumerate(range(1, self.K)):
+            tap_state = ttnn.slice(
+                conv,
+                (0, stored_tap, 0),
+                (self.B, stored_tap + 1, self.qkv_dim_tp),
+            )
+            tap_state = ttnn.reshape(tap_state, (1, self.B, self.qkv_dim_tp))
+            tap_tiled = ttnn.to_layout(
+                tap_state,
+                ttnn.TILE_LAYOUT,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            )
+            ttnn.copy(tap_tiled, self.conv_states[tap])
+            ttnn.deallocate(tap_tiled)
+            ttnn.deallocate(tap_state)
+        ttnn.deallocate(conv)
+
+    def _store_managed_state(self):
+        """Scatter updated decode work state back to its compact pool slots."""
+        if not self.uses_managed_state_pool:
+            return
+        assert self.managed_state_indices is not None, "managed state indices were not bound"
+
+        rec_rm = ttnn.to_layout(
+            self.rec_state,
+            ttnn.ROW_MAJOR_LAYOUT,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+        updated_rec_pool = ttnn.indexed_fill(
+            self.managed_state_indices,
+            self.managed_rec_state_pool,
+            rec_rm,
+            dim=0,
+        )
+        ttnn.copy(updated_rec_pool, self.managed_rec_state_pool)
+        ttnn.deallocate(updated_rec_pool)
+        ttnn.deallocate(rec_rm)
+
+        conv_taps = []
+        for tap in range(1, self.K):
+            tap_rm = ttnn.to_layout(
+                self.conv_states[tap],
+                ttnn.ROW_MAJOR_LAYOUT,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            )
+            conv_taps.append(ttnn.reshape(tap_rm, (self.B, 1, 1, self.qkv_dim_tp)))
+        conv_rm = ttnn.concat(conv_taps, dim=2)
+        updated_conv_pool = ttnn.indexed_fill(
+            self.managed_state_indices,
+            self.managed_conv_state_pool,
+            conv_rm,
+            dim=0,
+        )
+        ttnn.copy(updated_conv_pool, self.managed_conv_state_pool)
+        ttnn.deallocate(updated_conv_pool)
+        ttnn.deallocate(conv_rm)
+        for tap in conv_taps:
+            ttnn.deallocate(tap)
+
+    def store_managed_prefill_state(self, state_index):
+        """Write the currently bound B=1 prefill scratch into one pool slot.
+
+        ``state_index`` is a persistent one-element device tensor whose content
+        is refreshed per request. The indexed programs therefore compile once
+        and do not bake a Python slot number into a parked trace.
+        """
+        if not self.uses_managed_state_pool:
+            return
+        assert self.rec_state.shape[0] == 1, "prefill state write requires the B=1 scratch binding"
+
+        rec_rm = ttnn.to_layout(
+            self.rec_state,
+            ttnn.ROW_MAJOR_LAYOUT,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+        updated_rec_pool = ttnn.indexed_fill(
+            state_index,
+            self.managed_rec_state_pool,
+            rec_rm,
+            dim=0,
+        )
+        ttnn.copy(updated_rec_pool, self.managed_rec_state_pool)
+        ttnn.deallocate(updated_rec_pool)
+        ttnn.deallocate(rec_rm)
+
+        conv_taps = []
+        for tap in range(1, self.K):
+            tap_rm = ttnn.to_layout(
+                self.conv_states[tap],
+                ttnn.ROW_MAJOR_LAYOUT,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            )
+            conv_taps.append(ttnn.reshape(tap_rm, (1, 1, 1, self.qkv_dim_tp)))
+        conv_rm = ttnn.concat(conv_taps, dim=2)
+        updated_conv_pool = ttnn.indexed_fill(
+            state_index,
+            self.managed_conv_state_pool,
+            conv_rm,
+            dim=0,
+        )
+        ttnn.copy(updated_conv_pool, self.managed_conv_state_pool)
+        ttnn.deallocate(updated_conv_pool)
+        ttnn.deallocate(conv_rm)
+        for tap in conv_taps:
+            ttnn.deallocate(tap)
 
     def _col_proj(self, x, weight, decode_progcfg, out_memory_config=ttnn.DRAM_MEMORY_CONFIG):
         """Column-parallel qkvz projection; DRAM-sharded decode matmul when enabled.
@@ -975,6 +1169,7 @@ class TPGatedDeltaNet:
         _L1 = ttnn.L1_MEMORY_CONFIG  # keep decode conv→recurrence→norm/gate chain L1-resident
         if self.conv_states is None:
             self.reset_state()
+        self._load_managed_state()
         if len(x.shape) == 4:
             x = ttnn.reshape(x, (1, x.shape[-2], x.shape[-1]))
 
@@ -1032,6 +1227,7 @@ class TPGatedDeltaNet:
             ttnn.deallocate(new_rec)
         else:
             self.rec_state = new_rec
+        self._store_managed_state()
 
         out_r = ttnn.reshape(o, (B, Nv, Dv))
         out_n = ttnn.rms_norm(out_r, weight=tw["norm_w"], epsilon=1e-6, memory_config=_L1)  # gated norm (no +1)

--- a/models/demos/blackhole/qwen36/tt/model.py
+++ b/models/demos/blackhole/qwen36/tt/model.py
@@ -174,6 +174,14 @@ class Qwen36Model:
         # addresses are baked into the chunk-prefill trace and reused by every prefill_paged_slots
         # replay, so it is never freed/reallocated (only zeroed in place). See _bind_gdn_prefill_scratch.
         self._gdn_prefill_scratch = None
+        # vLLM MambaSpec lowering: compact scheduler-owned state pools are
+        # indexed through these persistent device tensors. They are allocated
+        # with the caches, before any trace can be captured, and only their
+        # contents change while serving.
+        self._managed_gdn_state = False
+        self._gdn_state_indices_device = None
+        self._gdn_prefill_state_index_device = None
+        self._paged_kv_block_size = None
 
         # Optional vision tower (DropInVisionTransformer), attached lazily by
         # init_vision_model() for the multimodal serving path. None on the text-only path.
@@ -824,7 +832,7 @@ class Qwen36Model:
                     # (slices the staged per-request table for multimodal; 1D RoPE otherwise).
                     cos, sin = self.rope.get_prefill_rot_mats(chunk_start, chunk_end - chunk_start)
 
-                    block_size = 64
+                    block_size = self._paged_kv_block_size or 64
                     chunk_blocks_end = math.ceil(chunk_end / block_size)
                     chunk_page_table = page_table[:, chunk_start // block_size : chunk_blocks_end]
                     chunk_page_table_tt = ttnn.from_torch(
@@ -1036,7 +1044,40 @@ class Qwen36Model:
         assert chunk_size % 128 == 0, f"chunk_size {chunk_size} must be a multiple of 128"
         B = 1
         block_size = get_block_size(self._paged_kv_caches)
+        assert chunk_size % block_size == 0, (
+            f"chunk_size {chunk_size} must be a multiple of paged-KV block_size {block_size}; "
+            "paged_fill_cache cannot encode an in-page chunk offset"
+        )
         blocks_per_chunk = chunk_size // block_size
+
+        # Phase-1 warmup may already have allocated and compiled this exact
+        # path. Reuse those persistent addresses during phase-2 capture:
+        # allocating replacements after the decode trace is parked is unsafe.
+        if self._chunk_token_buf is not None:
+            assert self._chunked_chunk_size == chunk_size
+            assert self._chunk_full_page_table_buf.shape[-1] == page_table.shape[-1]
+            if not capture_chunk_trace:
+                return
+            if self._chunked_trace_id is not None:
+                ttnn.release_trace(device, self._chunked_trace_id)
+            self._reset_dn_state_inplace()
+            self._chunked_trace_id = ttnn.begin_trace_capture(device, cq_id=0)
+            self._chunked_trace_output = self._forward_prefill_chunk(
+                self._chunk_token_buf,
+                self._chunk_cos_buf,
+                self._chunk_sin_buf,
+                self._chunk_start_idx_tensor,
+                self._chunk_full_page_table_buf,
+                self._chunk_page_table_buf,
+            )
+            ttnn.end_trace_capture(device, self._chunked_trace_id, cq_id=0)
+            if hasattr(ttnn, "mark_corruptible"):
+                # A later replay of the coexisting decode trace may overwrite
+                # this allocation. That is intentional: every prefill replay
+                # rewrites it before it is read.
+                ttnn.mark_corruptible(self._chunked_trace_output)
+            logger.info("Chunked prefill trace captured from prepared buffers!")
+            return
 
         if self._chunked_trace_id is not None:
             ttnn.release_trace(device, self._chunked_trace_id)
@@ -1114,6 +1155,11 @@ class Qwen36Model:
         if warmup_masked_buckets:
             self.warmup_prefill_masked_buckets(page_table)
 
+        if not capture_chunk_trace:
+            self._reset_dn_state_inplace()
+            logger.info("Chunked prefill buffers/programs prepared; trace capture deferred.")
+            return
+
         # Capture trace.
         self._reset_dn_state_inplace()
         self._chunked_trace_id = ttnn.begin_trace_capture(device, cq_id=0)
@@ -1126,6 +1172,8 @@ class Qwen36Model:
             self._chunk_page_table_buf,
         )
         ttnn.end_trace_capture(device, self._chunked_trace_id, cq_id=0)
+        if hasattr(ttnn, "mark_corruptible"):
+            ttnn.mark_corruptible(self._chunked_trace_output)
         logger.info("Chunked prefill trace captured successfully!")
 
     def _capture_prefill_trace_chunked_tp(
@@ -1138,7 +1186,40 @@ class Qwen36Model:
         assert self._deltanet_external_states is not None, "Call allocate_kv_caches first"
         assert chunk_size % 128 == 0, f"chunk_size {chunk_size} must be a multiple of 128"
         block_size = get_block_size(self._paged_kv_caches)
+        assert chunk_size % block_size == 0, (
+            f"chunk_size {chunk_size} must be a multiple of paged-KV block_size {block_size}; "
+            "paged_fill_cache cannot encode an in-page chunk offset"
+        )
         blocks_per_chunk = chunk_size // block_size
+
+        # Phase-1 warmup may already have allocated and compiled this exact
+        # path. Reuse those persistent addresses during phase-2 capture:
+        # allocating replacements after the decode trace is parked is unsafe.
+        if self._chunk_token_buf is not None:
+            assert self._chunked_chunk_size == chunk_size
+            assert self._chunk_full_page_table_buf.shape[-1] == page_table.shape[-1]
+            if not capture_chunk_trace:
+                return
+            if self._chunked_trace_id is not None:
+                ttnn.release_trace(device, self._chunked_trace_id)
+            self._reset_gdn_state_for_new_sequence()
+            self._chunked_trace_id = ttnn.begin_trace_capture(device, cq_id=0)
+            self._chunked_trace_output = self._forward_prefill_chunk_tp(
+                self._chunk_token_buf,
+                self._chunk_cos_buf,
+                self._chunk_sin_buf,
+                self._chunk_start_idx_tensor,
+                self._chunk_full_page_table_buf,
+                self._chunk_page_table_buf,
+            )
+            ttnn.end_trace_capture(device, self._chunked_trace_id, cq_id=0)
+            if hasattr(ttnn, "mark_corruptible"):
+                # A later replay of the coexisting decode trace may overwrite
+                # this allocation. That is intentional: every prefill replay
+                # rewrites it before it is read.
+                ttnn.mark_corruptible(self._chunked_trace_output)
+            logger.info("Chunked prefill trace (TP) captured from prepared buffers!")
+            return
 
         if self._chunked_trace_id is not None:
             ttnn.release_trace(device, self._chunked_trace_id)
@@ -1223,6 +1304,8 @@ class Qwen36Model:
             self._chunk_page_table_buf,
         )
         ttnn.end_trace_capture(device, self._chunked_trace_id, cq_id=0)
+        if hasattr(ttnn, "mark_corruptible"):
+            ttnn.mark_corruptible(self._chunked_trace_output)
         logger.info("Chunked prefill trace (TP) captured successfully!")
 
     # ----------------------------------------------------------------------- #
@@ -1571,7 +1654,6 @@ class Qwen36Model:
         per_user_rec = []
         per_user_conv = []
         comp = ttnn.ConcatMeshToTensor(self.mesh_device, dim=0)
-        dn_states = [layer.attention for layer in self.layers if not layer.is_full_attention]
 
         try:
             for u in range(B):
@@ -1744,8 +1826,6 @@ class Qwen36Model:
         # long-prompt path replays correctly; short prompts use the masked bucket on the same scratch.
         prev = self._bind_gdn_prefill_scratch()
         host_logits = []
-        per_user_rec = []
-        per_user_conv = []
         try:
             for u in range(N):
                 toks = token_ids_list[u]
@@ -1759,21 +1839,59 @@ class Qwen36Model:
                     ttnn.to_torch(lg, mesh_composer=comp).reshape(-1, self.args.vocab_size)[:1].float().view(1, 1, -1)
                 )
                 ttnn.deallocate(lg)
-                # Snapshot this user's B=1 scratch state (host round trip — the next user's reset
-                # overwrites the scratch in place; see prefill_traced_bucket_batched for why not clone).
-                per_user_rec.append([ttnn.to_torch(dn.rec_state, mesh_composer=comp) for dn in dn_states])
-                per_user_conv.append(
-                    [[ttnn.to_torch(c, mesh_composer=comp) for c in dn.conv_states] for dn in dn_states]
-                )
+                if self._managed_gdn_state:
+                    # Finalize directly on device into the scheduler-owned
+                    # compact slot before the next request resets the scratch.
+                    self._store_gdn_prefill_state(int(empty_slots[u]))
+                else:
+                    raise RuntimeError(
+                        "continuous-batching prefill requires managed GDN state; "
+                        "allocate caches with managed_gdn_state=True"
+                    )
         finally:
             # Always rebind the batched decode buffers (a mid-loop assert must not leave GDN on scratch).
             # Does NOT free the scratch — it persists for the next request and keeps the trace valid.
             self._unbind_gdn_prefill_scratch(prev)
 
-        # Write each user's snapshot into its decode slot, preserving the other live rows.
-        for u in range(N):
-            self._write_gdn_slot(int(empty_slots[u]), per_user_rec[u], per_user_conv[u])
         return host_logits
+
+    def set_gdn_state_indices(self, state_indices):
+        """Refresh the decode trace's runtime state-index input.
+
+        ``state_indices`` contains compact live slots in decode row order.
+        Missing rows are mapped to row-specific dummy slots in the disjoint
+        second half of each layer's managed pool.
+        """
+        if not self._managed_gdn_state:
+            return
+        assert self._gdn_state_indices_device is not None
+        B = self.args.max_batch_size
+        indices = torch.as_tensor(state_indices, dtype=torch.int32).reshape(-1)
+        assert indices.numel() <= B, f"{indices.numel()} state indices exceed decode batch {B}"
+        padded = torch.arange(B, 2 * B, dtype=torch.int32)
+        padded[: indices.numel()] = indices
+        host = ttnn.from_torch(
+            padded.reshape(1, 1, 1, B),
+            dtype=ttnn.uint32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(self.device),
+        )
+        ttnn.copy_host_to_device_tensor(host, self._gdn_state_indices_device)
+
+    def _store_gdn_prefill_state(self, state_slot):
+        """Copy the bound B=1 prefill scratch into one managed state slot."""
+        assert self._managed_gdn_state and self._gdn_prefill_state_index_device is not None
+        assert 0 <= state_slot < 2 * self.args.max_batch_size
+        host = ttnn.from_torch(
+            torch.tensor([[[[state_slot]]]], dtype=torch.int32),
+            dtype=ttnn.uint32,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            mesh_mapper=ttnn.ReplicateTensorToMesh(self.device),
+        )
+        ttnn.copy_host_to_device_tensor(host, self._gdn_prefill_state_index_device)
+        for layer in self.layers:
+            if not layer.is_full_attention:
+                layer.attention.store_managed_prefill_state(self._gdn_prefill_state_index_device)
 
     def _write_gdn_slot(self, slot, rec_snap, conv_snap):
         """Upload one request's B=1 GDN state snapshot (host torch, per GDN layer) and write it
@@ -1899,7 +2017,7 @@ class Qwen36Model:
         """Eager final partial-chunk prefill (< chunk_size). GDN zero-pads to 128-multiple internally
         (not bucket padding). Returns hidden [1,T_tail_padded,hidden_size]."""
         T_tail = token_slice.shape[1]
-        block_size = 64
+        block_size = self._paged_kv_block_size or 64
         tok = ttnn.from_torch(
             token_slice.to(torch.int32), dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT, device=self.device
         )
@@ -1968,7 +2086,7 @@ class Qwen36Model:
         cos, sin = self.rope.get_prefill_rot_mats(chunk_start, bucket)
         full_pt = ttnn.from_torch(page_table, dtype=ttnn.int32, layout=ttnn.ROW_MAJOR_LAYOUT, device=self.device)
         blk0 = chunk_start // block_size
-        # Fill K/V only for real blocks (ceil(valid_len/64)); padded writes would corrupt block 0.
+        # Fill K/V only for real cache blocks; padded writes would corrupt block 0.
         blkN = num_blocks_in_seq(chunk_start + valid_len, block_size)
         chunk_pt = ttnn.from_torch(
             page_table[:, blk0:blkN].contiguous(), dtype=ttnn.int32, layout=ttnn.ROW_MAJOR_LAYOUT, device=self.device
@@ -2671,14 +2789,22 @@ class Qwen36Model:
             k_cache, v_cache = kv_caches[cache_idx]
             self.layers[layer_idx].attention.set_paged_kv_cache(k_cache, v_cache)
 
-    def allocate_kv_caches(self, kv_cache_shape, dtype, batch_size=1):
+    def allocate_kv_caches(self, kv_cache_shape, dtype, batch_size=1, managed_gdn_state=False):
         """Allocate caches for all 32 layers. Returns only the attention KV caches (for vLLM)."""
         assert self._deltanet_external_states is None, "allocate_kv_caches already called; deallocate first"
+        self._paged_kv_block_size = int(kv_cache_shape[2])
         # QWEN_SDPA_BF8: bf8 paged KV for SDPA; halves KV memory (gated — validate PCC at long ctx).
         if os.environ.get("QWEN_SDPA_BF8", "0") == "1":
             dtype = ttnn.bfloat8_b
         if self.num_devices > 1:
-            return self._allocate_kv_caches_tp(kv_cache_shape, dtype, batch_size)
+            return self._allocate_kv_caches_tp(
+                kv_cache_shape,
+                dtype,
+                batch_size,
+                managed_gdn_state=managed_gdn_state,
+            )
+        if managed_gdn_state and batch_size > 1:
+            raise NotImplementedError("managed batched GDN state is currently implemented for the TP path")
 
         kv_caches = []
         for idx in self._attention_layer_indices:
@@ -2724,13 +2850,33 @@ class Qwen36Model:
             ttnn.deallocate(rec)
             ttnn.deallocate(conv)
         self._deltanet_external_states = None
+        if self._managed_gdn_state:
+            for layer in self.layers:
+                if layer.is_full_attention:
+                    continue
+                dn = layer.attention
+                if dn.managed_rec_state_pool is not None:
+                    ttnn.deallocate(dn.managed_rec_state_pool)
+                    dn.managed_rec_state_pool = None
+                if dn.managed_conv_state_pool is not None:
+                    ttnn.deallocate(dn.managed_conv_state_pool)
+                    dn.managed_conv_state_pool = None
+                dn.managed_state_indices = None
+                dn.managed_state_pool_slots = 0
+            if self._gdn_state_indices_device is not None:
+                ttnn.deallocate(self._gdn_state_indices_device)
+                self._gdn_state_indices_device = None
+            if self._gdn_prefill_state_index_device is not None:
+                ttnn.deallocate(self._gdn_prefill_state_index_device)
+                self._gdn_prefill_state_index_device = None
+            self._managed_gdn_state = False
         if getattr(self, "_paged_kv_caches", None) is not None:
             for k_cache, v_cache in self._paged_kv_caches:
                 ttnn.deallocate(k_cache)
                 ttnn.deallocate(v_cache)
             self._paged_kv_caches = None
 
-    def _allocate_kv_caches_tp(self, kv_cache_shape, dtype, batch_size):
+    def _allocate_kv_caches_tp(self, kv_cache_shape, dtype, batch_size, managed_gdn_state=False):
         """TP paged KV allocation (B=1). Replicated per device; GDN self-manages state."""
 
         def _mk():
@@ -2751,6 +2897,32 @@ class Qwen36Model:
                 layer.attention.reset_state()
                 # Fixed-address GDN state for decode trace compatibility.
                 layer.attention._stable_state = True
+                if managed_gdn_state:
+                    layer.attention.allocate_managed_state_pool(batch_size)
+        self._managed_gdn_state = managed_gdn_state
+        if managed_gdn_state:
+            mapper = ttnn.ReplicateTensorToMesh(self.device)
+            # Warmup and padded rows use the disjoint dummy bank [B, 2B).
+            dummy_indices = torch.arange(batch_size, 2 * batch_size, dtype=torch.int32).reshape(1, 1, 1, batch_size)
+            self._gdn_state_indices_device = ttnn.from_torch(
+                dummy_indices,
+                dtype=ttnn.uint32,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+                device=self.device,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                mesh_mapper=mapper,
+            )
+            self._gdn_prefill_state_index_device = ttnn.from_torch(
+                torch.tensor([[[[batch_size]]]], dtype=torch.int32),
+                dtype=ttnn.uint32,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+                device=self.device,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                mesh_mapper=mapper,
+            )
+            for layer in self.layers:
+                if not layer.is_full_attention:
+                    layer.attention.bind_managed_state_indices(self._gdn_state_indices_device)
         # Marker for re-entry assert; TP GDN state lives in module, not external buffers.
         self._deltanet_external_states = []
         return kv_caches

--- a/models/demos/blackhole/qwen36/tt/qwen36_vllm.py
+++ b/models/demos/blackhole/qwen36/tt/qwen36_vllm.py
@@ -55,6 +55,152 @@ class Qwen36ForCausalLM(Generator, SupportsMultiModal):
     }
 
     @classmethod
+    def get_mamba_state_shape_from_config(cls, vllm_config):
+        """Logical per-request GDN state shape used by upstream's block manager."""
+        from vllm.model_executor.layers.mamba.mamba_utils import MambaStateShapeCalculator
+
+        text_config = vllm_config.model_config.hf_text_config
+        return MambaStateShapeCalculator.gated_delta_net_state_shape(
+            vllm_config.parallel_config.tensor_parallel_size,
+            text_config.linear_num_key_heads,
+            text_config.linear_num_value_heads,
+            text_config.linear_key_head_dim,
+            text_config.linear_value_head_dim,
+            text_config.linear_conv_kernel_dim,
+        )
+
+    @classmethod
+    def get_mamba_state_dtype_from_config(cls, vllm_config):
+        # This describes upstream's logical shared raw slab. TT lowers it to
+        # separate typed pools and may retain its recurrent accumulator in fp32.
+        from vllm.model_executor.layers.mamba.mamba_utils import MambaStateDtypeCalculator
+
+        mamba_state_dtype = getattr(
+            vllm_config.model_config.hf_text_config,
+            "mamba_ssm_dtype",
+            vllm_config.cache_config.mamba_cache_dtype,
+        )
+        return MambaStateDtypeCalculator.gated_delta_net_state_dtype(
+            vllm_config.model_config.dtype,
+            mamba_state_dtype,
+        )
+
+    @classmethod
+    def get_managed_state_pool_bytes(cls, vllm_config, max_batch_size: int) -> int:
+        """Incremental per-device DRAM used by TT's managed GDN pools."""
+        if int(max_batch_size) <= 1:
+            return 0
+        conv_shape, recurrent_shape = cls.get_mamba_state_shape_from_config(vllm_config)
+        conv_elements = math.prod(conv_shape)
+        recurrent_elements = math.prod(recurrent_shape)
+        recurrent_element_bytes = 2 if os.environ.get("QWEN35_GDN_STATE_BF16") == "1" else 4
+        num_gdn_layers = vllm_config.model_config.hf_text_config.layer_types.count("linear_attention")
+        # One live bank and one row-unique dummy bank are allocated per layer.
+        return (
+            2
+            * int(max_batch_size)
+            * num_gdn_layers
+            * (conv_elements * 2 + recurrent_elements * recurrent_element_bytes)
+        )
+
+    @staticmethod
+    def _trace_compatible_block_size(minimum_block_size: int) -> int:
+        """Round a hybrid-cache block up to a page boundary used by TT prefill.
+
+        Upstream may enlarge the attention block until one attention page can
+        share a KV-cache group with one Mamba page.  TT's traced paged prefill
+        writes fixed 2048-token chunks and its fill operation has no in-page
+        destination offset, so every chunk start must also start a cache page.
+        """
+        block_size = 1 << (int(minimum_block_size) - 1).bit_length()
+        if block_size > _PREFILL_WARMUP_CHUNK:
+            raise ValueError(
+                "Qwen hybrid-cache state requires an attention block of at least "
+                f"{minimum_block_size} tokens, but TT's {_PREFILL_WARMUP_CHUNK}-token "
+                "traced prefill cannot page-align that layout"
+            )
+        assert _PREFILL_WARMUP_CHUNK % block_size == 0
+        return block_size
+
+    @classmethod
+    def get_kv_cache_spec(cls, vllm_config):
+        """Expose full-attention KV and GDN recurrent state to vLLM."""
+        from vllm.utils.torch_utils import STR_DTYPE_TO_TORCH_DTYPE
+        from vllm.v1.kv_cache_interface import FullAttentionSpec, MambaSpec
+
+        cache_config = vllm_config.cache_config
+        if cache_config.mamba_cache_mode != "none":
+            raise NotImplementedError(
+                "TT Qwen currently supports MambaSpec cache mode 'none'; "
+                "'align'/'all' require token-chunked prefill and state-copy support"
+            )
+        if vllm_config.speculative_config is not None:
+            raise NotImplementedError("TT Qwen MambaSpec does not yet support speculative state blocks")
+
+        model_config = vllm_config.model_config
+        text_config = model_config.hf_text_config
+        layer_types = text_config.layer_types
+        dtype = (
+            model_config.dtype
+            if cache_config.cache_dtype == "auto"
+            else STR_DTYPE_TO_TORCH_DTYPE[cache_config.cache_dtype]
+        )
+
+        # HybridAttentionMambaModelConfig has already raised block_size enough
+        # for the raw GDN page.  Round it to a divisor of the traced prefill
+        # chunk before materializing either spec.  Merely accepting an arbitrary
+        # enlarged block would corrupt chunks after the first: paged_fill_cache
+        # starts at the beginning of chunk_page_table[0] and cannot express the
+        # in-page offset of (2048 % block_size).
+        minimum_block_size = cache_config.block_size or _BLOCK_SIZE
+        block_size = cls._trace_compatible_block_size(minimum_block_size)
+        if block_size != cache_config.block_size:
+            logger.info(
+                "Rounding Qwen attention block size from {} to {} tokens for TT traced-prefill page alignment",
+                cache_config.block_size,
+                block_size,
+            )
+            cache_config.block_size = block_size
+
+        attention = FullAttentionSpec(
+            block_size=block_size,
+            num_kv_heads=model_config.get_num_kv_heads(vllm_config.parallel_config),
+            head_size=model_config.get_head_size(),
+            dtype=dtype,
+        )
+        raw_mamba = MambaSpec(
+            shapes=cls.get_mamba_state_shape_from_config(vllm_config),
+            dtypes=cls.get_mamba_state_dtype_from_config(vllm_config),
+            block_size=cache_config.mamba_block_size or model_config.max_model_len,
+            mamba_type="gdn_attention",
+            mamba_cache_mode="none",
+        )
+        if raw_mamba.page_size_bytes > attention.page_size_bytes:
+            raise ValueError(
+                f"Qwen GDN page ({raw_mamba.page_size_bytes} bytes) does not fit the "
+                f"trace-compatible attention page ({attention.page_size_bytes} bytes)"
+            )
+        cache_config.mamba_page_size_padded = attention.page_size_bytes
+        mamba = MambaSpec(
+            shapes=raw_mamba.shapes,
+            dtypes=raw_mamba.dtypes,
+            block_size=raw_mamba.block_size,
+            page_size_padded=attention.page_size_bytes,
+            mamba_type=raw_mamba.mamba_type,
+            mamba_cache_mode=raw_mamba.mamba_cache_mode,
+        )
+
+        specs = {}
+        for i, layer_type in enumerate(layer_types):
+            if layer_type == "full_attention":
+                specs[f"model.layers.{i}.self_attn"] = attention
+            elif layer_type == "linear_attention":
+                specs[f"model.layers.{i}.linear_attn"] = mamba
+            else:
+                raise ValueError(f"Unsupported Qwen layer type {layer_type!r} at layer {i}")
+        return specs
+
+    @classmethod
     def get_max_tokens_all_users(
         cls,
         model_name: str = "",
@@ -129,7 +275,37 @@ class Qwen36ForCausalLM(Generator, SupportsMultiModal):
         the paged KV blocks (kv_cache_shape) already cover all users, and this sizes the per-slot
         GDN recurrent/conv state [B,...] + the decode kv grid. B==1 is the single-sequence path."""
         batch_size = self.model[0].args.max_batch_size
-        return self.model[0].allocate_kv_caches(kv_cache_shape, ttnn.bfloat16, batch_size=batch_size)
+        return self.model[0].allocate_kv_caches(
+            kv_cache_shape,
+            ttnn.bfloat16,
+            batch_size=batch_size,
+            managed_gdn_state=batch_size > 1,
+        )
+
+    def allocate_kv_cache_per_layer(self, per_layer_specs):
+        """Lower heterogeneous vLLM cache descriptors to the Qwen TT model.
+
+        Attention layers share one uniform paged-KV geometry. Mamba descriptors
+        establish scheduler ownership, while their physical state is lowered to
+        the compact concurrency-sized pools allocated by ``Qwen36Model``.
+        """
+        attention_specs = [
+            spec for spec in per_layer_specs
+            if isinstance(spec, dict) and spec.get("type") == "attention"
+        ]
+        if not attention_specs:
+            raise ValueError("Qwen cache config contains no full-attention layers")
+        shape = attention_specs[0]["shape"]
+        dtype = attention_specs[0]["dtype"]
+        if any((spec["shape"], spec["dtype"]) != (shape, dtype) for spec in attention_specs[1:]):
+            raise NotImplementedError("Qwen full-attention layers require one uniform TT KV geometry")
+        batch_size = self.model[0].args.max_batch_size
+        return self.model[0].allocate_kv_caches(
+            shape,
+            ttnn.bfloat16,
+            batch_size=batch_size,
+            managed_gdn_state=batch_size > 1,
+        )
 
     @staticmethod
     def _has_visual(kwargs, pixel_key):
@@ -182,6 +358,10 @@ class Qwen36ForCausalLM(Generator, SupportsMultiModal):
     def prefill_forward(self, tokens, page_table, kv_cache, prompt_lens, **kwargs):
         """All prefill is model-owned (Generator drives decode only)."""
         model = self.model[0]
+        page_tables_per_layer = kwargs.get("page_tables_per_layer")
+        if page_tables_per_layer is not None:
+            attention_layer = next(i for i, layer in enumerate(model.layers) if layer.is_full_attention)
+            page_table = page_tables_per_layer[attention_layer]
         if model.num_devices > 1 and model.args.max_batch_size > 1:
             # Batched serving (max_num_seqs > 1): prefill each request in this step into its decode
             # slot. Text-only — multimodal is single-sequence (get_supported_mm_limits: B=1). Check
@@ -283,39 +463,59 @@ class Qwen36ForCausalLM(Generator, SupportsMultiModal):
             self._decode_logged = True
             logger.info("Decode trace replay active (Qwen)")
         model = self.model[0]
-        # Batched serving: apply vLLM's condense slot_remap to the per-slot GDN recurrent/conv state
-        # BEFORE the decode trace reads it. The plugin remaps its own buffers (and the seed RNG via
-        # super().decode_forward), but GDN state is model-internal, so mirror the same reindex here.
-        # slot_remap is passed through unchanged so the seed-RNG remap inside super() still runs.
+        page_tables_per_layer = kwargs.pop("page_tables_per_layer", None)
+        if page_tables_per_layer is not None:
+            attention_layer = next(i for i, layer in enumerate(model.layers) if layer.is_full_attention)
+            kwargs["page_table"] = page_tables_per_layer[attention_layer]
+        state_indices = kwargs.pop("gdn_state_indices", None)
         if model.num_devices > 1 and model.args.max_batch_size > 1:
-            slot_remap = kwargs.get("slot_remap")
-            if slot_remap is not None:
-                model._remap_gdn_slots(slot_remap)
+            if state_indices is None:
+                if not getattr(self, "_warming_managed_gdn", False):
+                    raise ValueError("managed Qwen decode requires gdn_state_indices")
+            else:
+                model.set_gdn_state_indices(state_indices)
         return super().decode_forward(*args, **kwargs)
 
     def warmup_model_prefill(self, kv_cache, enable_trace, *args, **kwargs):
         # Capture the chunk-prefill trace + warm the masked-bucket set so requests only replay
         # pre-compiled programs (compile-clobbers-trace fix). Guard name must match the plugin's reset.
-        if not enable_trace:
-            return
-        if getattr(self, "already_warmed_up_prefill", False):
-            return
-        self.already_warmed_up_prefill = True
-        # Size the chunk-trace page table to the full KV cache (not a hardcoded 4096) so served ISL
-        # isn't capped; still captures one chunk — just a bigger page-table tensor.
+        model = self.model[0]
+        batched = model.num_devices > 1 and model.args.max_batch_size > 1
+        # Use one identical page-table shape for prepare and capture so phase 2
+        # can reuse every phase-1 persistent buffer.
         if kv_cache:
             # Round to a multiple of 32: paged/chunked SDPA needs the page-table stick % 32 == 0.
             num_blocks = math.ceil(int(kv_cache[0][0].shape[0]) / 32) * 32
         else:
-            num_blocks = math.ceil(_PREFILL_WARMUP_BUCKET / _BLOCK_SIZE)
+            block_size = model._paged_kv_block_size or _BLOCK_SIZE
+            num_blocks = math.ceil(_PREFILL_WARMUP_BUCKET / block_size)
         page_table = torch.arange(num_blocks, dtype=torch.int32).reshape(1, num_blocks)
-        model = self.model[0]
+
+        if not enable_trace:
+            # Allocate every persistent prefill input and compile the exact
+            # chunk/masked/finalization paths before any trace is parked.
+            prev = model._bind_gdn_prefill_scratch() if batched else None
+            try:
+                if batched and model._managed_gdn_state:
+                    model._store_gdn_prefill_state(model.args.max_batch_size)
+                model.capture_prefill_trace_chunked(
+                    self.mesh_device,
+                    page_table,
+                    chunk_size=_PREFILL_WARMUP_CHUNK,
+                    capture_chunk_trace=False,
+                )
+            finally:
+                if prev is not None:
+                    model._unbind_gdn_prefill_scratch(prev)
+            return
+        if getattr(self, "already_warmed_up_prefill", False):
+            return
+        self.already_warmed_up_prefill = True
         # Batched serving (max_num_seqs>1): the decode buffers are [B,...], but prefill runs B=1. Bind
         # the PERSISTENT B=1 GDN prefill scratch and capture the chunk trace against IT, so long prompts
         # (>chunk_size) replay the traced chunk-outer path per user instead of the slower eager fallback.
         # The scratch is not freed (prefill_paged_slots rebinds it per request); the batched decode
         # buffers are restored before the decode-trace warmup captures at [B,...].
-        batched = model.num_devices > 1 and model.args.max_batch_size > 1
         logger.info(
             f"Starting Qwen prefill warmup: chunk-prefill trace{' (batched, B=1 scratch)' if batched else ''} "
             f"(chunk={_PREFILL_WARMUP_CHUNK}, page_table_blocks={num_blocks})..."
@@ -333,4 +533,8 @@ class Qwen36ForCausalLM(Generator, SupportsMultiModal):
         # Defer to WarmupForwardMixin, which captures the paged-SDPA + GDN decode trace at pos 0.
         # Drop stale `non_greedy_decoding_on_device` from the old vLLM plugin; no-op for Qwen.
         kwargs.pop("non_greedy_decoding_on_device", None)
-        return super().warmup_model_decode(*args, **kwargs)
+        self._warming_managed_gdn = True
+        try:
+            return super().warmup_model_decode(*args, **kwargs)
+        finally:
+            self._warming_managed_gdn = False

--- a/tests/ttnn/unit_tests/operations/data_movement/test_embedding.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_embedding.py
@@ -22,6 +22,38 @@ def test_base_case(device):
     assert_equal(expected_embeddings, embeddings)
 
 
+def test_float32_row_major_embedding(device):
+    """Embedding also serves as a runtime-indexed state gather.
+
+    Recurrent model state is kept in fp32, so the row-major data-movement
+    path must preserve fp32 values rather than forcing state through bf16.
+    """
+    torch.manual_seed(1234)
+    torch_indices = torch.tensor([[3, 0, 5, 1]], dtype=torch.int32)
+    torch_weights = torch.randn(8, 128, dtype=torch.float32)
+
+    indices = ttnn.from_torch(
+        torch_indices,
+        dtype=ttnn.uint32,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=device,
+    )
+    weights = ttnn.from_torch(
+        torch_weights,
+        dtype=ttnn.float32,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=device,
+    )
+
+    output = ttnn.embedding(
+        indices,
+        weights,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    assert_equal(torch.nn.functional.embedding(torch_indices.long(), torch_weights), ttnn.to_torch(output))
+
+
 @pytest.mark.parametrize("batch_size", [1, 8, 9])
 @pytest.mark.parametrize("sentence_size", [32, 256, 512])
 @pytest.mark.parametrize("hidden_embedding_dim", [768, 4096])  # Bert_Num_Cols_768, Llama_Num_Cols

--- a/tests/ttnn/unit_tests/operations/data_movement/test_indexed_fill.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_indexed_fill.py
@@ -57,6 +57,39 @@ def test_indexed_fill_tile_layout(device, input_a_shape, input_b_shape):
     assert_with_pcc(golden, ttnn.to_torch(output_tensor), 0.9999)
 
 
+def test_indexed_fill_float32_row_major(device):
+    """The managed recurrent-state pool scatters fp32 rows at runtime."""
+    batch_id = torch.tensor([[[[3, 0]]]], dtype=torch.int32)
+    torch_a = torch.randn((6, 2, 4, 32), dtype=torch.float32)
+    torch_b = torch.randn((2, 2, 4, 32), dtype=torch.float32)
+
+    batch_id_ttnn = ttnn.from_torch(
+        batch_id,
+        dtype=ttnn.uint32,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=device,
+    )
+    input_a = ttnn.from_torch(
+        torch_a,
+        dtype=ttnn.float32,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=device,
+    )
+    input_b = ttnn.from_torch(
+        torch_b,
+        dtype=ttnn.float32,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=device,
+    )
+    output = ttnn.indexed_fill(batch_id_ttnn, input_a, input_b)
+
+    assert_with_pcc(
+        golden_indexed_fill(torch_a, torch_b, batch_id, dim=0),
+        ttnn.to_torch(output),
+        0.99999,
+    )
+
+
 @pytest.mark.parametrize(
     "B, b, D",
     [

--- a/ttnn/cpp/ttnn/operations/embedding/device/embedding_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding/device/embedding_device_operation.cpp
@@ -33,7 +33,9 @@ void EmbeddingsDeviceOperation::validate_on_program_cache_miss(
     TT_FATAL(
         weights.layout() == Layout::ROW_MAJOR, "Weights tensor layout must be ROW_MAJOR but got {}", weights.layout());
     TT_FATAL(a.dtype() == DataType::UINT32 or a.dtype() == DataType::BFLOAT16, "Input must be UINT32 or BFLOAT16");
-    TT_FATAL(weights.dtype() == DataType::BFLOAT16, "Weights tensor must have BFLOAT16 dtype");
+    TT_FATAL(
+        weights.dtype() == DataType::BFLOAT16 or weights.dtype() == DataType::FLOAT32,
+        "Weights tensor must have BFLOAT16 or FLOAT32 dtype");
     TT_FATAL(
         a.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED,
         "Embedding does not currently support sharded inputs");


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

Add upstream-compatible MambaSpec storage semantics for Qwen GDN serving on TT.

The scheduler owns logical Mamba blocks, while the model lowers live state to compact typed pools. Decode gathers recurrent and convolution state into fixed-address trace work buffers in decode row order, then scatters the updated state back. Prefill finalizes directly into the assigned compact slot.

This also:
- enables FLOAT32 row-major embedding for recurrent-state gather;
- exposes hybrid attention and GDN cache specs;
- aligns hybrid cache pages to the fixed 2048-token prefill trace;
- prepares all persistent prefill buffers and program variants before capture;
- captures decode before the larger prefill trace;
- accounts for model-owned managed-state DRAM.

Companion PRs:
- embedded plugin: https://github.com/tenstorrent/vllm/pull/457
- standalone plugin: https://github.com/tenstorrent/vllm-tt-plugin/pull/22

### Notes for reviewers

Please focus on the trace lifecycle and the gather/decode/scatter ordering in `gdn/tp.py`.

Static Python compilation and `git diff --check` pass. New TTNN device tests cover FLOAT32 row-major embedding and indexed fill, but they have not been run because no suitable Blackhole IRD reservation was available.

Remaining device validation:
- run with `TT_METAL_TRACE_ALLOC_TRACKING=1`;
- repeat prefill, reordered decode, dummy-row decode, and scatter;
- test maximum configured batch memory.