### PR TITLE
[Cleanup] Split custom-Alignment APIs & distributed utilities out of experimental/tensor

### DIFF
--- a/tests/tt_metal/tt_metal/api/tensor/test_create_tensor.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_create_tensor.cpp
@@ -22,6 +22,7 @@
 
 #include "tt_metal/tt_metal/common/multi_device_fixture.hpp"
 #include "common_tensor_test_utils.hpp"
+#include <tt-metalium/experimental/tensor_layout_apis_with_custom_alignment.hpp>
 
 namespace tt::tt_metal {
 namespace {
@@ -99,7 +100,7 @@ TEST_P(EmptyTensorTest, Combinations) {
         GTEST_SKIP() << "Skipping test with ROW_MAJOR layout and BFLOAT8_B dtype!";
     }
 
-    auto tensor_layout = TensorLayout::fromPaddedShape(
+    auto tensor_layout = tensor_layout_from_padded_shape(
         dtype, PageConfig(layout), memory_config, /* logical */ shape, /* padded */ shape);
 
     auto tensor = MeshTensor::allocate_on_device(

--- a/tests/tt_metal/tt_metal/api/tensor/test_create_tensor.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_create_tensor.cpp
@@ -100,7 +100,7 @@ TEST_P(EmptyTensorTest, Combinations) {
         GTEST_SKIP() << "Skipping test with ROW_MAJOR layout and BFLOAT8_B dtype!";
     }
 
-    auto tensor_layout = tensor_layout_from_padded_shape(
+    auto tensor_layout = experimental::tensor_layout_from_padded_shape(
         dtype, PageConfig(layout), memory_config, /* logical */ shape, /* padded */ shape);
 
     auto tensor = MeshTensor::allocate_on_device(

--- a/tests/tt_metal/tt_metal/api/tensor/test_create_tensor.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_create_tensor.cpp
@@ -100,7 +100,7 @@ TEST_P(EmptyTensorTest, Combinations) {
         GTEST_SKIP() << "Skipping test with ROW_MAJOR layout and BFLOAT8_B dtype!";
     }
 
-    auto tensor_layout = experimental::tensor_layout_from_padded_shape(
+    auto tensor_layout = tt::tt_metal::experimental::tensor_layout_from_padded_shape(
         dtype, PageConfig(layout), memory_config, /* logical */ shape, /* padded */ shape);
 
     auto tensor = MeshTensor::allocate_on_device(

--- a/tests/tt_metal/tt_metal/api/tensor/test_host_tensor_spec_preservation.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_host_tensor_spec_preservation.cpp
@@ -22,6 +22,7 @@
 #include <tt-metalium/host_buffer.hpp>
 #include <tt-metalium/shape.hpp>
 #include <tt-metalium/tile.hpp>
+#include <tt-metalium/experimental/tensor_layout_apis_with_custom_alignment.hpp>
 
 namespace tt::tt_metal {
 namespace {
@@ -61,12 +62,16 @@ TEST(HostTensorSpecPreservation, ToLayoutInterleavedRmTileRoundTrip) {
     auto alignment = Alignment({32, 32});
     auto tile = Tile({16, 16});
 
-    auto tile_source_spec =
-        TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
+    auto tile_source_spec = TensorSpec(
+        shape,
+        tensor_layout_with_custom_alignment(
+            DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
     auto tile_source = HostTensor::from_vector<float>(data, tile_source_spec);
 
-    auto expected_rm_spec =
-        TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config, alignment));
+    auto expected_rm_spec = TensorSpec(
+        shape,
+        tensor_layout_with_custom_alignment(
+            DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config, alignment));
     auto rm = to_tensor_spec<float>(tile_source, expected_rm_spec);
     EXPECT_TRUE(CMAKE_UNIQUE_NAMESPACE::exact_spec_match(rm.tensor_spec(), expected_rm_spec));
     EXPECT_EQ(rm.memory_config().buffer_type(), BufferType::DRAM);
@@ -74,8 +79,10 @@ TEST(HostTensorSpecPreservation, ToLayoutInterleavedRmTileRoundTrip) {
     CMAKE_UNIQUE_NAMESPACE::expect_packed_sizes(rm);
 
     // RM PageConfig does not carry a non-default tile; restore TILE with explicit tile.
-    auto expected_tile_spec =
-        TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
+    auto expected_tile_spec = TensorSpec(
+        shape,
+        tensor_layout_with_custom_alignment(
+            DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
     auto tiled_back = to_tensor_spec<float>(rm, expected_tile_spec);
     EXPECT_TRUE(CMAKE_UNIQUE_NAMESPACE::exact_spec_match(tiled_back.tensor_spec(), expected_tile_spec));
     EXPECT_EQ(tiled_back.memory_config().buffer_type(), BufferType::DRAM);
@@ -99,8 +106,10 @@ TEST(HostTensorSpecPreservation, ToLayoutShardedPreservesShardSpecAndPackedSizes
     auto alignment = Alignment({32, 64});
     auto tile = Tile({16, 16});
 
-    auto source_spec =
-        TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
+    auto source_spec = TensorSpec(
+        shape,
+        tensor_layout_with_custom_alignment(
+            DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
 
     auto topology = TensorTopology::create_fully_replicated_tensor_topology(distributed::MeshShape(1, 2));
     auto distributed_buffer = DistributedHostBuffer::create(distributed::MeshShape(1, 2));
@@ -115,8 +124,10 @@ TEST(HostTensorSpecPreservation, ToLayoutShardedPreservesShardSpecAndPackedSizes
         distributed::MeshCoordinate(0, 1), [&]() { return HostBuffer(std::vector<float>(data_1)); });
     auto source = host_tensor_from_buffer_with_topology(std::move(distributed_buffer), source_spec, topology);
 
-    auto expected_spec =
-        TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config, alignment));
+    auto expected_spec = TensorSpec(
+        shape,
+        tensor_layout_with_custom_alignment(
+            DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config, alignment));
     auto result = to_tensor_spec<float>(source, expected_spec);
     EXPECT_TRUE(CMAKE_UNIQUE_NAMESPACE::exact_spec_match(result.tensor_spec(), expected_spec));
     EXPECT_TRUE(result.memory_config().shard_spec().has_value());
@@ -139,8 +150,10 @@ TEST(HostTensorSpecPreservation, ToLayoutPhysicalMismatchThrows) {
     auto alignment = Alignment({32, 24});
     auto tile = Tile({16, 16});
 
-    auto source_spec =
-        TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config, alignment));
+    auto source_spec = TensorSpec(
+        shape,
+        tensor_layout_with_custom_alignment(
+            DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config, alignment));
     auto source = HostTensor::from_vector<float>(data, source_spec);
 
     EXPECT_ANY_THROW(std::ignore = to_tile_layout(source, tile));
@@ -182,7 +195,7 @@ TEST(HostTensorSpecPreservation, DISABLED_PadUnpadDropsMemoryConfigToDefault) {
 
     auto expected_pad_spec = TensorSpec(
         logical,
-        TensorLayout::fromPaddedShape(
+        tensor_layout_from_padded_shape(
             DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), MemoryConfig{}, logical, padded));
     EXPECT_TRUE(CMAKE_UNIQUE_NAMESPACE::exact_spec_match(padded_tensor.tensor_spec(), expected_pad_spec));
     EXPECT_EQ(padded_tensor.memory_config(), MemoryConfig{});

--- a/tests/tt_metal/tt_metal/api/tensor/test_host_tensor_spec_preservation.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_host_tensor_spec_preservation.cpp
@@ -64,13 +64,13 @@ TEST(HostTensorSpecPreservation, ToLayoutInterleavedRmTileRoundTrip) {
 
     auto tile_source_spec = TensorSpec(
         shape,
-        tensor_layout_with_custom_alignment(
+        experimental::tensor_layout_with_custom_alignment(
             DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
     auto tile_source = HostTensor::from_vector<float>(data, tile_source_spec);
 
     auto expected_rm_spec = TensorSpec(
         shape,
-        tensor_layout_with_custom_alignment(
+        experimental::tensor_layout_with_custom_alignment(
             DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config, alignment));
     auto rm = to_tensor_spec<float>(tile_source, expected_rm_spec);
     EXPECT_TRUE(CMAKE_UNIQUE_NAMESPACE::exact_spec_match(rm.tensor_spec(), expected_rm_spec));
@@ -81,7 +81,7 @@ TEST(HostTensorSpecPreservation, ToLayoutInterleavedRmTileRoundTrip) {
     // RM PageConfig does not carry a non-default tile; restore TILE with explicit tile.
     auto expected_tile_spec = TensorSpec(
         shape,
-        tensor_layout_with_custom_alignment(
+        experimental::tensor_layout_with_custom_alignment(
             DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
     auto tiled_back = to_tensor_spec<float>(rm, expected_tile_spec);
     EXPECT_TRUE(CMAKE_UNIQUE_NAMESPACE::exact_spec_match(tiled_back.tensor_spec(), expected_tile_spec));
@@ -108,7 +108,7 @@ TEST(HostTensorSpecPreservation, ToLayoutShardedPreservesShardSpecAndPackedSizes
 
     auto source_spec = TensorSpec(
         shape,
-        tensor_layout_with_custom_alignment(
+        experimental::tensor_layout_with_custom_alignment(
             DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
 
     auto topology = TensorTopology::create_fully_replicated_tensor_topology(distributed::MeshShape(1, 2));
@@ -126,7 +126,7 @@ TEST(HostTensorSpecPreservation, ToLayoutShardedPreservesShardSpecAndPackedSizes
 
     auto expected_spec = TensorSpec(
         shape,
-        tensor_layout_with_custom_alignment(
+        experimental::tensor_layout_with_custom_alignment(
             DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config, alignment));
     auto result = to_tensor_spec<float>(source, expected_spec);
     EXPECT_TRUE(CMAKE_UNIQUE_NAMESPACE::exact_spec_match(result.tensor_spec(), expected_spec));
@@ -152,7 +152,7 @@ TEST(HostTensorSpecPreservation, ToLayoutPhysicalMismatchThrows) {
 
     auto source_spec = TensorSpec(
         shape,
-        tensor_layout_with_custom_alignment(
+        experimental::tensor_layout_with_custom_alignment(
             DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config, alignment));
     auto source = HostTensor::from_vector<float>(data, source_spec);
 
@@ -195,7 +195,7 @@ TEST(HostTensorSpecPreservation, DISABLED_PadUnpadDropsMemoryConfigToDefault) {
 
     auto expected_pad_spec = TensorSpec(
         logical,
-        tensor_layout_from_padded_shape(
+        experimental::tensor_layout_from_padded_shape(
             DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), MemoryConfig{}, logical, padded));
     EXPECT_TRUE(CMAKE_UNIQUE_NAMESPACE::exact_spec_match(padded_tensor.tensor_spec(), expected_pad_spec));
     EXPECT_EQ(padded_tensor.memory_config(), MemoryConfig{});

--- a/tests/tt_metal/tt_metal/api/tensor/test_host_tensor_spec_preservation.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_host_tensor_spec_preservation.cpp
@@ -64,13 +64,13 @@ TEST(HostTensorSpecPreservation, ToLayoutInterleavedRmTileRoundTrip) {
 
     auto tile_source_spec = TensorSpec(
         shape,
-        experimental::tensor_layout_with_custom_alignment(
+        tt::tt_metal::experimental::tensor_layout_with_custom_alignment(
             DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
     auto tile_source = HostTensor::from_vector<float>(data, tile_source_spec);
 
     auto expected_rm_spec = TensorSpec(
         shape,
-        experimental::tensor_layout_with_custom_alignment(
+        tt::tt_metal::experimental::tensor_layout_with_custom_alignment(
             DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config, alignment));
     auto rm = to_tensor_spec<float>(tile_source, expected_rm_spec);
     EXPECT_TRUE(CMAKE_UNIQUE_NAMESPACE::exact_spec_match(rm.tensor_spec(), expected_rm_spec));
@@ -81,7 +81,7 @@ TEST(HostTensorSpecPreservation, ToLayoutInterleavedRmTileRoundTrip) {
     // RM PageConfig does not carry a non-default tile; restore TILE with explicit tile.
     auto expected_tile_spec = TensorSpec(
         shape,
-        experimental::tensor_layout_with_custom_alignment(
+        tt::tt_metal::experimental::tensor_layout_with_custom_alignment(
             DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
     auto tiled_back = to_tensor_spec<float>(rm, expected_tile_spec);
     EXPECT_TRUE(CMAKE_UNIQUE_NAMESPACE::exact_spec_match(tiled_back.tensor_spec(), expected_tile_spec));
@@ -108,7 +108,7 @@ TEST(HostTensorSpecPreservation, ToLayoutShardedPreservesShardSpecAndPackedSizes
 
     auto source_spec = TensorSpec(
         shape,
-        experimental::tensor_layout_with_custom_alignment(
+        tt::tt_metal::experimental::tensor_layout_with_custom_alignment(
             DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
 
     auto topology = TensorTopology::create_fully_replicated_tensor_topology(distributed::MeshShape(1, 2));
@@ -126,7 +126,7 @@ TEST(HostTensorSpecPreservation, ToLayoutShardedPreservesShardSpecAndPackedSizes
 
     auto expected_spec = TensorSpec(
         shape,
-        experimental::tensor_layout_with_custom_alignment(
+        tt::tt_metal::experimental::tensor_layout_with_custom_alignment(
             DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config, alignment));
     auto result = to_tensor_spec<float>(source, expected_spec);
     EXPECT_TRUE(CMAKE_UNIQUE_NAMESPACE::exact_spec_match(result.tensor_spec(), expected_spec));
@@ -152,7 +152,7 @@ TEST(HostTensorSpecPreservation, ToLayoutPhysicalMismatchThrows) {
 
     auto source_spec = TensorSpec(
         shape,
-        experimental::tensor_layout_with_custom_alignment(
+        tt::tt_metal::experimental::tensor_layout_with_custom_alignment(
             DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config, alignment));
     auto source = HostTensor::from_vector<float>(data, source_spec);
 
@@ -195,7 +195,7 @@ TEST(HostTensorSpecPreservation, DISABLED_PadUnpadDropsMemoryConfigToDefault) {
 
     auto expected_pad_spec = TensorSpec(
         logical,
-        experimental::tensor_layout_from_padded_shape(
+        tt::tt_metal::experimental::tensor_layout_from_padded_shape(
             DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), MemoryConfig{}, logical, padded));
     EXPECT_TRUE(CMAKE_UNIQUE_NAMESPACE::exact_spec_match(padded_tensor.tensor_spec(), expected_pad_spec));
     EXPECT_EQ(padded_tensor.memory_config(), MemoryConfig{});

--- a/tests/tt_metal/tt_metal/api/tensor/test_host_tensor_to_dtype.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_host_tensor_to_dtype.cpp
@@ -20,6 +20,7 @@
 #include <tt-metalium/host_buffer.hpp>
 #include <tt-metalium/shape.hpp>
 #include <tt-metalium/tile.hpp>
+#include <tt-metalium/experimental/tensor_layout_apis_with_custom_alignment.hpp>
 
 namespace tt::tt_metal {
 namespace {
@@ -104,14 +105,18 @@ TEST(HostTensorToDtype, NonBfpPreservesMetadata) {
     auto alignment = tt::tt_metal::Alignment({32, 32});
     auto tile = Tile({16, 16});
 
-    auto source_spec =
-        TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
+    auto source_spec = TensorSpec(
+        shape,
+        tensor_layout_with_custom_alignment(
+            DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
     auto source = HostTensor::from_vector<float>(data, source_spec);
 
     auto result = to_dtype(source, DataType::BFLOAT16);
 
-    auto expected_spec =
-        TensorSpec(shape, TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE, tile), memory_config, alignment));
+    auto expected_spec = TensorSpec(
+        shape,
+        tensor_layout_with_custom_alignment(
+            DataType::BFLOAT16, PageConfig(Layout::TILE, tile), memory_config, alignment));
 
     EXPECT_TRUE(CMAKE_UNIQUE_NAMESPACE::exact_spec_match(result.tensor_spec(), expected_spec));
     EXPECT_EQ(result.dtype(), DataType::BFLOAT16);
@@ -126,14 +131,18 @@ TEST(HostTensorToDtype, TileBfp8ToFloat32ValueCheck) {
     const auto tile = Tile({16, 16});
     const auto& [packed, unpacked_golden] = CMAKE_UNIQUE_NAMESPACE::generate_bfp8_dataset(shape, tile);
 
-    auto source_spec =
-        TensorSpec(shape, TensorLayout(DataType::BFLOAT8_B, PageConfig(Layout::TILE, tile), memory_config, alignment));
+    auto source_spec = TensorSpec(
+        shape,
+        tensor_layout_with_custom_alignment(
+            DataType::BFLOAT8_B, PageConfig(Layout::TILE, tile), memory_config, alignment));
     auto source = CMAKE_UNIQUE_NAMESPACE::make_host_tensor(packed, source_spec);
 
     auto result = to_dtype(source, DataType::FLOAT32);
 
-    auto expected_spec =
-        TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
+    auto expected_spec = TensorSpec(
+        shape,
+        tensor_layout_with_custom_alignment(
+            DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
     EXPECT_TRUE(CMAKE_UNIQUE_NAMESPACE::exact_spec_match(result.tensor_spec(), expected_spec));
     EXPECT_EQ(result.dtype(), DataType::FLOAT32);
     EXPECT_EQ(result.layout(), Layout::TILE);
@@ -149,14 +158,18 @@ TEST(HostTensorToDtype, Float32ToTileBfp8ValueCheck) {
     const auto tile = Tile({16, 16});
     const auto& [floats, packed_golden] = CMAKE_UNIQUE_NAMESPACE::generate_float_to_bfp8_dataset(shape, tile);
 
-    auto source_spec =
-        TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
+    auto source_spec = TensorSpec(
+        shape,
+        tensor_layout_with_custom_alignment(
+            DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
     auto source = CMAKE_UNIQUE_NAMESPACE::make_host_tensor(floats, source_spec);
 
     auto result = to_dtype(source, DataType::BFLOAT8_B);
 
-    auto expected_spec =
-        TensorSpec(shape, TensorLayout(DataType::BFLOAT8_B, PageConfig(Layout::TILE, tile), memory_config, alignment));
+    auto expected_spec = TensorSpec(
+        shape,
+        tensor_layout_with_custom_alignment(
+            DataType::BFLOAT8_B, PageConfig(Layout::TILE, tile), memory_config, alignment));
     EXPECT_TRUE(CMAKE_UNIQUE_NAMESPACE::exact_spec_match(result.tensor_spec(), expected_spec));
     EXPECT_EQ(result.dtype(), DataType::BFLOAT8_B);
     EXPECT_EQ(result.layout(), Layout::TILE);
@@ -172,14 +185,18 @@ TEST(HostTensorToDtype, TileBfp4ToFloat32ValueCheck) {
     const auto tile = Tile({16, 16});
     const auto& [packed, unpacked_golden] = CMAKE_UNIQUE_NAMESPACE::generate_bfp4_dataset(shape, tile);
 
-    auto source_spec =
-        TensorSpec(shape, TensorLayout(DataType::BFLOAT4_B, PageConfig(Layout::TILE, tile), memory_config, alignment));
+    auto source_spec = TensorSpec(
+        shape,
+        tensor_layout_with_custom_alignment(
+            DataType::BFLOAT4_B, PageConfig(Layout::TILE, tile), memory_config, alignment));
     auto source = CMAKE_UNIQUE_NAMESPACE::make_host_tensor(packed, source_spec);
 
     auto result = to_dtype(source, DataType::FLOAT32);
 
-    auto expected_spec =
-        TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
+    auto expected_spec = TensorSpec(
+        shape,
+        tensor_layout_with_custom_alignment(
+            DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
     EXPECT_TRUE(CMAKE_UNIQUE_NAMESPACE::exact_spec_match(result.tensor_spec(), expected_spec));
     EXPECT_EQ(result.dtype(), DataType::FLOAT32);
     EXPECT_EQ(result.layout(), Layout::TILE);
@@ -195,14 +212,18 @@ TEST(HostTensorToDtype, Float32ToTileBfp4ValueCheck) {
     const auto tile = Tile({16, 16});
     const auto& [floats, packed_golden] = CMAKE_UNIQUE_NAMESPACE::generate_float_to_bfp4_dataset(shape, tile);
 
-    auto source_spec =
-        TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
+    auto source_spec = TensorSpec(
+        shape,
+        tensor_layout_with_custom_alignment(
+            DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
     auto source = CMAKE_UNIQUE_NAMESPACE::make_host_tensor(floats, source_spec);
 
     auto result = to_dtype(source, DataType::BFLOAT4_B);
 
-    auto expected_spec =
-        TensorSpec(shape, TensorLayout(DataType::BFLOAT4_B, PageConfig(Layout::TILE, tile), memory_config, alignment));
+    auto expected_spec = TensorSpec(
+        shape,
+        tensor_layout_with_custom_alignment(
+            DataType::BFLOAT4_B, PageConfig(Layout::TILE, tile), memory_config, alignment));
     EXPECT_TRUE(CMAKE_UNIQUE_NAMESPACE::exact_spec_match(result.tensor_spec(), expected_spec));
     EXPECT_EQ(result.dtype(), DataType::BFLOAT4_B);
     EXPECT_EQ(result.layout(), Layout::TILE);
@@ -280,14 +301,18 @@ TEST(HostTensorToDtype, PerCoreAllocationPreserved) {
     auto alignment = tt::tt_metal::Alignment({32, 64});
     auto tile = Tile({32, 32});
 
-    auto source_spec =
-        TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
+    auto source_spec = TensorSpec(
+        shape,
+        tensor_layout_with_custom_alignment(
+            DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
     auto source = HostTensor::from_vector<float>(data, source_spec);
 
     auto result = to_dtype(source, DataType::BFLOAT16);
 
-    auto expected_spec =
-        TensorSpec(shape, TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE, tile), memory_config, alignment));
+    auto expected_spec = TensorSpec(
+        shape,
+        tensor_layout_with_custom_alignment(
+            DataType::BFLOAT16, PageConfig(Layout::TILE, tile), memory_config, alignment));
 
     EXPECT_TRUE(CMAKE_UNIQUE_NAMESPACE::exact_spec_match(result.tensor_spec(), expected_spec));
     EXPECT_TRUE(experimental::per_core_allocation::is_per_core_allocation(result.tensor_spec().memory_config()));
@@ -345,8 +370,10 @@ TEST(HostTensorToDtype, RowMajorToBfpPhysicalMismatchThrows) {
     // Alignment that is NOT a multiple of the default tile width
     auto alignment = tt::tt_metal::Alignment({32, 24});
 
-    auto source_spec =
-        TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config, alignment));
+    auto source_spec = TensorSpec(
+        shape,
+        tensor_layout_with_custom_alignment(
+            DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config, alignment));
     auto source = HostTensor::from_vector<float>(data, source_spec);
 
     // This should throw because BFLOAT8_B forces TILE layout, which forces alignment to be

--- a/tests/tt_metal/tt_metal/api/tensor/test_host_tensor_to_dtype.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_host_tensor_to_dtype.cpp
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include <tt-metalium/experimental/tensor/host_tensor.hpp>
+#include <tt-metalium/experimental/distributed_tensor/distributed_tensor_apis.hpp>
 #include <tt-metalium/experimental/tensor/tensor_apis.hpp>
 #include <tt-metalium/experimental/tensor/spec/tensor_spec.hpp>
 #include <tt-metalium/experimental/tensor/spec/layout/tensor_layout.hpp>
@@ -107,7 +108,7 @@ TEST(HostTensorToDtype, NonBfpPreservesMetadata) {
 
     auto source_spec = TensorSpec(
         shape,
-        tensor_layout_with_custom_alignment(
+        experimental::tensor_layout_with_custom_alignment(
             DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
     auto source = HostTensor::from_vector<float>(data, source_spec);
 
@@ -115,7 +116,7 @@ TEST(HostTensorToDtype, NonBfpPreservesMetadata) {
 
     auto expected_spec = TensorSpec(
         shape,
-        tensor_layout_with_custom_alignment(
+        experimental::tensor_layout_with_custom_alignment(
             DataType::BFLOAT16, PageConfig(Layout::TILE, tile), memory_config, alignment));
 
     EXPECT_TRUE(CMAKE_UNIQUE_NAMESPACE::exact_spec_match(result.tensor_spec(), expected_spec));
@@ -133,7 +134,7 @@ TEST(HostTensorToDtype, TileBfp8ToFloat32ValueCheck) {
 
     auto source_spec = TensorSpec(
         shape,
-        tensor_layout_with_custom_alignment(
+        experimental::tensor_layout_with_custom_alignment(
             DataType::BFLOAT8_B, PageConfig(Layout::TILE, tile), memory_config, alignment));
     auto source = CMAKE_UNIQUE_NAMESPACE::make_host_tensor(packed, source_spec);
 
@@ -141,7 +142,7 @@ TEST(HostTensorToDtype, TileBfp8ToFloat32ValueCheck) {
 
     auto expected_spec = TensorSpec(
         shape,
-        tensor_layout_with_custom_alignment(
+        experimental::tensor_layout_with_custom_alignment(
             DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
     EXPECT_TRUE(CMAKE_UNIQUE_NAMESPACE::exact_spec_match(result.tensor_spec(), expected_spec));
     EXPECT_EQ(result.dtype(), DataType::FLOAT32);
@@ -160,7 +161,7 @@ TEST(HostTensorToDtype, Float32ToTileBfp8ValueCheck) {
 
     auto source_spec = TensorSpec(
         shape,
-        tensor_layout_with_custom_alignment(
+        experimental::tensor_layout_with_custom_alignment(
             DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
     auto source = CMAKE_UNIQUE_NAMESPACE::make_host_tensor(floats, source_spec);
 
@@ -168,7 +169,7 @@ TEST(HostTensorToDtype, Float32ToTileBfp8ValueCheck) {
 
     auto expected_spec = TensorSpec(
         shape,
-        tensor_layout_with_custom_alignment(
+        experimental::tensor_layout_with_custom_alignment(
             DataType::BFLOAT8_B, PageConfig(Layout::TILE, tile), memory_config, alignment));
     EXPECT_TRUE(CMAKE_UNIQUE_NAMESPACE::exact_spec_match(result.tensor_spec(), expected_spec));
     EXPECT_EQ(result.dtype(), DataType::BFLOAT8_B);
@@ -187,7 +188,7 @@ TEST(HostTensorToDtype, TileBfp4ToFloat32ValueCheck) {
 
     auto source_spec = TensorSpec(
         shape,
-        tensor_layout_with_custom_alignment(
+        experimental::tensor_layout_with_custom_alignment(
             DataType::BFLOAT4_B, PageConfig(Layout::TILE, tile), memory_config, alignment));
     auto source = CMAKE_UNIQUE_NAMESPACE::make_host_tensor(packed, source_spec);
 
@@ -195,7 +196,7 @@ TEST(HostTensorToDtype, TileBfp4ToFloat32ValueCheck) {
 
     auto expected_spec = TensorSpec(
         shape,
-        tensor_layout_with_custom_alignment(
+        experimental::tensor_layout_with_custom_alignment(
             DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
     EXPECT_TRUE(CMAKE_UNIQUE_NAMESPACE::exact_spec_match(result.tensor_spec(), expected_spec));
     EXPECT_EQ(result.dtype(), DataType::FLOAT32);
@@ -214,7 +215,7 @@ TEST(HostTensorToDtype, Float32ToTileBfp4ValueCheck) {
 
     auto source_spec = TensorSpec(
         shape,
-        tensor_layout_with_custom_alignment(
+        experimental::tensor_layout_with_custom_alignment(
             DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
     auto source = CMAKE_UNIQUE_NAMESPACE::make_host_tensor(floats, source_spec);
 
@@ -222,7 +223,7 @@ TEST(HostTensorToDtype, Float32ToTileBfp4ValueCheck) {
 
     auto expected_spec = TensorSpec(
         shape,
-        tensor_layout_with_custom_alignment(
+        experimental::tensor_layout_with_custom_alignment(
             DataType::BFLOAT4_B, PageConfig(Layout::TILE, tile), memory_config, alignment));
     EXPECT_TRUE(CMAKE_UNIQUE_NAMESPACE::exact_spec_match(result.tensor_spec(), expected_spec));
     EXPECT_EQ(result.dtype(), DataType::BFLOAT4_B);
@@ -303,7 +304,7 @@ TEST(HostTensorToDtype, PerCoreAllocationPreserved) {
 
     auto source_spec = TensorSpec(
         shape,
-        tensor_layout_with_custom_alignment(
+        experimental::tensor_layout_with_custom_alignment(
             DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
     auto source = HostTensor::from_vector<float>(data, source_spec);
 
@@ -311,7 +312,7 @@ TEST(HostTensorToDtype, PerCoreAllocationPreserved) {
 
     auto expected_spec = TensorSpec(
         shape,
-        tensor_layout_with_custom_alignment(
+        experimental::tensor_layout_with_custom_alignment(
             DataType::BFLOAT16, PageConfig(Layout::TILE, tile), memory_config, alignment));
 
     EXPECT_TRUE(CMAKE_UNIQUE_NAMESPACE::exact_spec_match(result.tensor_spec(), expected_spec));
@@ -372,7 +373,7 @@ TEST(HostTensorToDtype, RowMajorToBfpPhysicalMismatchThrows) {
 
     auto source_spec = TensorSpec(
         shape,
-        tensor_layout_with_custom_alignment(
+        experimental::tensor_layout_with_custom_alignment(
             DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config, alignment));
     auto source = HostTensor::from_vector<float>(data, source_spec);
 

--- a/tests/tt_metal/tt_metal/api/tensor/test_host_tensor_to_dtype.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_host_tensor_to_dtype.cpp
@@ -108,7 +108,7 @@ TEST(HostTensorToDtype, NonBfpPreservesMetadata) {
 
     auto source_spec = TensorSpec(
         shape,
-        experimental::tensor_layout_with_custom_alignment(
+        tt::tt_metal::experimental::tensor_layout_with_custom_alignment(
             DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
     auto source = HostTensor::from_vector<float>(data, source_spec);
 
@@ -116,7 +116,7 @@ TEST(HostTensorToDtype, NonBfpPreservesMetadata) {
 
     auto expected_spec = TensorSpec(
         shape,
-        experimental::tensor_layout_with_custom_alignment(
+        tt::tt_metal::experimental::tensor_layout_with_custom_alignment(
             DataType::BFLOAT16, PageConfig(Layout::TILE, tile), memory_config, alignment));
 
     EXPECT_TRUE(CMAKE_UNIQUE_NAMESPACE::exact_spec_match(result.tensor_spec(), expected_spec));
@@ -134,7 +134,7 @@ TEST(HostTensorToDtype, TileBfp8ToFloat32ValueCheck) {
 
     auto source_spec = TensorSpec(
         shape,
-        experimental::tensor_layout_with_custom_alignment(
+        tt::tt_metal::experimental::tensor_layout_with_custom_alignment(
             DataType::BFLOAT8_B, PageConfig(Layout::TILE, tile), memory_config, alignment));
     auto source = CMAKE_UNIQUE_NAMESPACE::make_host_tensor(packed, source_spec);
 
@@ -142,7 +142,7 @@ TEST(HostTensorToDtype, TileBfp8ToFloat32ValueCheck) {
 
     auto expected_spec = TensorSpec(
         shape,
-        experimental::tensor_layout_with_custom_alignment(
+        tt::tt_metal::experimental::tensor_layout_with_custom_alignment(
             DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
     EXPECT_TRUE(CMAKE_UNIQUE_NAMESPACE::exact_spec_match(result.tensor_spec(), expected_spec));
     EXPECT_EQ(result.dtype(), DataType::FLOAT32);
@@ -161,7 +161,7 @@ TEST(HostTensorToDtype, Float32ToTileBfp8ValueCheck) {
 
     auto source_spec = TensorSpec(
         shape,
-        experimental::tensor_layout_with_custom_alignment(
+        tt::tt_metal::experimental::tensor_layout_with_custom_alignment(
             DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
     auto source = CMAKE_UNIQUE_NAMESPACE::make_host_tensor(floats, source_spec);
 
@@ -169,7 +169,7 @@ TEST(HostTensorToDtype, Float32ToTileBfp8ValueCheck) {
 
     auto expected_spec = TensorSpec(
         shape,
-        experimental::tensor_layout_with_custom_alignment(
+        tt::tt_metal::experimental::tensor_layout_with_custom_alignment(
             DataType::BFLOAT8_B, PageConfig(Layout::TILE, tile), memory_config, alignment));
     EXPECT_TRUE(CMAKE_UNIQUE_NAMESPACE::exact_spec_match(result.tensor_spec(), expected_spec));
     EXPECT_EQ(result.dtype(), DataType::BFLOAT8_B);
@@ -188,7 +188,7 @@ TEST(HostTensorToDtype, TileBfp4ToFloat32ValueCheck) {
 
     auto source_spec = TensorSpec(
         shape,
-        experimental::tensor_layout_with_custom_alignment(
+        tt::tt_metal::experimental::tensor_layout_with_custom_alignment(
             DataType::BFLOAT4_B, PageConfig(Layout::TILE, tile), memory_config, alignment));
     auto source = CMAKE_UNIQUE_NAMESPACE::make_host_tensor(packed, source_spec);
 
@@ -196,7 +196,7 @@ TEST(HostTensorToDtype, TileBfp4ToFloat32ValueCheck) {
 
     auto expected_spec = TensorSpec(
         shape,
-        experimental::tensor_layout_with_custom_alignment(
+        tt::tt_metal::experimental::tensor_layout_with_custom_alignment(
             DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
     EXPECT_TRUE(CMAKE_UNIQUE_NAMESPACE::exact_spec_match(result.tensor_spec(), expected_spec));
     EXPECT_EQ(result.dtype(), DataType::FLOAT32);
@@ -215,7 +215,7 @@ TEST(HostTensorToDtype, Float32ToTileBfp4ValueCheck) {
 
     auto source_spec = TensorSpec(
         shape,
-        experimental::tensor_layout_with_custom_alignment(
+        tt::tt_metal::experimental::tensor_layout_with_custom_alignment(
             DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
     auto source = CMAKE_UNIQUE_NAMESPACE::make_host_tensor(floats, source_spec);
 
@@ -223,7 +223,7 @@ TEST(HostTensorToDtype, Float32ToTileBfp4ValueCheck) {
 
     auto expected_spec = TensorSpec(
         shape,
-        experimental::tensor_layout_with_custom_alignment(
+        tt::tt_metal::experimental::tensor_layout_with_custom_alignment(
             DataType::BFLOAT4_B, PageConfig(Layout::TILE, tile), memory_config, alignment));
     EXPECT_TRUE(CMAKE_UNIQUE_NAMESPACE::exact_spec_match(result.tensor_spec(), expected_spec));
     EXPECT_EQ(result.dtype(), DataType::BFLOAT4_B);
@@ -304,7 +304,7 @@ TEST(HostTensorToDtype, PerCoreAllocationPreserved) {
 
     auto source_spec = TensorSpec(
         shape,
-        experimental::tensor_layout_with_custom_alignment(
+        tt::tt_metal::experimental::tensor_layout_with_custom_alignment(
             DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
     auto source = HostTensor::from_vector<float>(data, source_spec);
 
@@ -312,7 +312,7 @@ TEST(HostTensorToDtype, PerCoreAllocationPreserved) {
 
     auto expected_spec = TensorSpec(
         shape,
-        experimental::tensor_layout_with_custom_alignment(
+        tt::tt_metal::experimental::tensor_layout_with_custom_alignment(
             DataType::BFLOAT16, PageConfig(Layout::TILE, tile), memory_config, alignment));
 
     EXPECT_TRUE(CMAKE_UNIQUE_NAMESPACE::exact_spec_match(result.tensor_spec(), expected_spec));
@@ -373,7 +373,7 @@ TEST(HostTensorToDtype, RowMajorToBfpPhysicalMismatchThrows) {
 
     auto source_spec = TensorSpec(
         shape,
-        experimental::tensor_layout_with_custom_alignment(
+        tt::tt_metal::experimental::tensor_layout_with_custom_alignment(
             DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config, alignment));
     auto source = HostTensor::from_vector<float>(data, source_spec);
 

--- a/tests/tt_metal/tt_metal/api/tensor/test_host_tensor_to_layout.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_host_tensor_to_layout.cpp
@@ -24,6 +24,7 @@
 #include <vector>
 
 #include <tt-metalium/experimental/tensor/host_tensor.hpp>
+#include <tt-metalium/experimental/distributed_tensor/distributed_tensor_apis.hpp>
 #include <tt-metalium/experimental/tensor/tensor_apis.hpp>
 #include <tt-metalium/experimental/tensor/spec/tensor_spec.hpp>
 #include <tt-metalium/experimental/tensor/spec/layout/tensor_layout.hpp>

--- a/tests/tt_metal/tt_metal/api/tensor/test_host_tensor_to_tensor_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_host_tensor_to_tensor_spec.cpp
@@ -27,6 +27,7 @@
 #include <tt-metalium/shape.hpp>
 #include <tt-metalium/tilize_utils.hpp>
 #include <tt-metalium/tile.hpp>
+#include <tt-metalium/experimental/tensor_layout_apis_with_custom_alignment.hpp>
 
 namespace tt::tt_metal {
 namespace {
@@ -134,7 +135,8 @@ TensorSpec make_tile_spec(
     const Tile& tile = Tile({32, 32}),
     const MemoryConfig& memory_config = MemoryConfig{},
     const Alignment& alignment = {}) {
-    return TensorSpec(shape, TensorLayout(dtype, PageConfig(Layout::TILE, tile), memory_config, alignment));
+    return TensorSpec(
+        shape, tensor_layout_with_custom_alignment(dtype, PageConfig(Layout::TILE, tile), memory_config, alignment));
 }
 
 }  // namespace CMAKE_UNIQUE_NAMESPACE
@@ -148,8 +150,10 @@ TEST(HostTensorToTensorSpec, EarlyOutExactSpecMatch) {
     auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
     auto alignment = Alignment({32, 32});
     auto tile = Tile({16, 16});
-    auto spec =
-        TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
+    auto spec = TensorSpec(
+        shape,
+        tensor_layout_with_custom_alignment(
+            DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
     auto source = HostTensor::from_vector<float>(data, spec);
 
     auto result = to_tensor_spec<float>(source, spec);
@@ -172,14 +176,18 @@ TEST(HostTensorToTensorSpec, PerCoreOnlyMismatchFullRewrite) {
         ShardSpec{CoreRangeSet({CoreRange({0, 0}, {0, 0})}), {32, 32}, ShardOrientation::ROW_MAJOR}};
 
     auto src_spec = TensorSpec(
-        shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config, Alignment({32, 32})));
+        shape,
+        tensor_layout_with_custom_alignment(
+            DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config, Alignment({32, 32})));
     auto source = host_tensor_from_vector_with_pad_value<float>(data, src_spec, /*pad_value=*/99.f);
     EXPECT_FALSE(experimental::per_core_allocation::is_per_core_allocation(source.tensor_spec().memory_config()));
 
     auto dest_memory = memory_config;
     experimental::per_core_allocation::set_per_core_allocation(dest_memory, true);
     auto dest_spec = TensorSpec(
-        shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), dest_memory, Alignment({32, 32})));
+        shape,
+        tensor_layout_with_custom_alignment(
+            DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), dest_memory, Alignment({32, 32})));
 
     // Spec equality ignores per_core, but exact-spec predicate must not early-out.
     EXPECT_TRUE(source.tensor_spec() == dest_spec);
@@ -245,8 +253,10 @@ TEST(HostTensorToTensorSpec, CustomTileAndAlignment) {
     auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
 
     auto src_spec = TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config));
-    auto dest_spec =
-        TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
+    auto dest_spec = TensorSpec(
+        shape,
+        tensor_layout_with_custom_alignment(
+            DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
 
     auto source = HostTensor::from_vector<float>(data, src_spec);
     auto result = to_tensor_spec<float>(source, dest_spec);
@@ -267,10 +277,14 @@ TEST(HostTensorToTensorSpec, Float32ToBfloat16PreservesMetadata) {
     auto alignment = Alignment({32, 32});
     auto tile = Tile({16, 16});
 
-    auto src_spec =
-        TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
-    auto dest_spec =
-        TensorSpec(shape, TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE, tile), memory_config, alignment));
+    auto src_spec = TensorSpec(
+        shape,
+        tensor_layout_with_custom_alignment(
+            DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
+    auto dest_spec = TensorSpec(
+        shape,
+        tensor_layout_with_custom_alignment(
+            DataType::BFLOAT16, PageConfig(Layout::TILE, tile), memory_config, alignment));
     auto source = HostTensor::from_vector<float>(data, src_spec);
 
     auto result = to_tensor_spec<float>(source, dest_spec);
@@ -323,10 +337,14 @@ TEST(HostTensorToTensorSpec, Float32TileToBfp8ValueCheck) {
     const auto tile = Tile({16, 16});
     const auto& [floats, packed_golden] = CMAKE_UNIQUE_NAMESPACE::generate_float_to_bfp8_dataset(shape, tile);
 
-    auto src_spec =
-        TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
-    auto dest_spec =
-        TensorSpec(shape, TensorLayout(DataType::BFLOAT8_B, PageConfig(Layout::TILE, tile), memory_config, alignment));
+    auto src_spec = TensorSpec(
+        shape,
+        tensor_layout_with_custom_alignment(
+            DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
+    auto dest_spec = TensorSpec(
+        shape,
+        tensor_layout_with_custom_alignment(
+            DataType::BFLOAT8_B, PageConfig(Layout::TILE, tile), memory_config, alignment));
     auto source = CMAKE_UNIQUE_NAMESPACE::make_host_tensor(floats, src_spec);
 
     auto result = host_tensor_to_tensor_spec_with_pad_value<float>(source, dest_spec, /*pad_value=*/0.f);
@@ -346,10 +364,14 @@ TEST(HostTensorToTensorSpec, Float32TileToBfp4ValueCheck) {
     const auto tile = Tile({16, 16});
     const auto& [floats, packed_golden] = CMAKE_UNIQUE_NAMESPACE::generate_float_to_bfp4_dataset(shape, tile);
 
-    auto src_spec =
-        TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
-    auto dest_spec =
-        TensorSpec(shape, TensorLayout(DataType::BFLOAT4_B, PageConfig(Layout::TILE, tile), memory_config, alignment));
+    auto src_spec = TensorSpec(
+        shape,
+        tensor_layout_with_custom_alignment(
+            DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
+    auto dest_spec = TensorSpec(
+        shape,
+        tensor_layout_with_custom_alignment(
+            DataType::BFLOAT4_B, PageConfig(Layout::TILE, tile), memory_config, alignment));
     auto source = CMAKE_UNIQUE_NAMESPACE::make_host_tensor(floats, src_spec);
 
     auto result = host_tensor_to_tensor_spec_with_pad_value<float>(source, dest_spec, /*pad_value=*/0.f);
@@ -369,8 +391,10 @@ TEST(HostTensorToTensorSpec, Bfp8TileToFloat32RowMajorValueCheck) {
     const auto tile = Tile({16, 16});
     const auto& [packed, unpacked_golden] = CMAKE_UNIQUE_NAMESPACE::generate_bfp8_dataset(shape, tile);
 
-    auto src_spec =
-        TensorSpec(shape, TensorLayout(DataType::BFLOAT8_B, PageConfig(Layout::TILE, tile), memory_config, alignment));
+    auto src_spec = TensorSpec(
+        shape,
+        tensor_layout_with_custom_alignment(
+            DataType::BFLOAT8_B, PageConfig(Layout::TILE, tile), memory_config, alignment));
     auto dest_spec = TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config));
     auto source = CMAKE_UNIQUE_NAMESPACE::make_host_tensor(packed, src_spec);
 
@@ -394,8 +418,10 @@ TEST(HostTensorToTensorSpec, Bfp4TileToFloat32RowMajorValueCheck) {
     const auto tile = Tile({16, 16});
     const auto& [packed, unpacked_golden] = CMAKE_UNIQUE_NAMESPACE::generate_bfp4_dataset(shape, tile);
 
-    auto src_spec =
-        TensorSpec(shape, TensorLayout(DataType::BFLOAT4_B, PageConfig(Layout::TILE, tile), memory_config, alignment));
+    auto src_spec = TensorSpec(
+        shape,
+        tensor_layout_with_custom_alignment(
+            DataType::BFLOAT4_B, PageConfig(Layout::TILE, tile), memory_config, alignment));
     auto dest_spec = TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config));
     auto source = CMAKE_UNIQUE_NAMESPACE::make_host_tensor(packed, src_spec);
 
@@ -418,10 +444,14 @@ TEST(HostTensorToTensorSpec, RowMajorToBfp8ChangesLayoutAndPreservesTile) {
     auto alignment = Alignment({32, 32});
     auto tile = Tile({16, 16});
 
-    auto src_spec =
-        TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config, alignment));
-    auto dest_spec =
-        TensorSpec(shape, TensorLayout(DataType::BFLOAT8_B, PageConfig(Layout::TILE, tile), memory_config, alignment));
+    auto src_spec = TensorSpec(
+        shape,
+        tensor_layout_with_custom_alignment(
+            DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config, alignment));
+    auto dest_spec = TensorSpec(
+        shape,
+        tensor_layout_with_custom_alignment(
+            DataType::BFLOAT8_B, PageConfig(Layout::TILE, tile), memory_config, alignment));
     auto source = HostTensor::from_vector<float>(data, src_spec);
 
     auto result = host_tensor_to_tensor_spec_with_pad_value<float>(source, dest_spec, /*pad_value=*/0.f);
@@ -548,7 +578,9 @@ TEST(HostTensorToTensorSpec, EqualPaddedDifferentPackingRoundTrip) {
     auto data = CMAKE_UNIQUE_NAMESPACE::make_ramp<float>(shape.volume());
     auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
     auto rm_spec = TensorSpec(
-        shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config, Alignment({16, 16})));
+        shape,
+        tensor_layout_with_custom_alignment(
+            DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config, Alignment({16, 16})));
     auto tile_spec =
         TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::TILE, Tile({16, 16})), memory_config));
 

--- a/tests/tt_metal/tt_metal/api/tensor/test_host_tensor_to_tensor_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_host_tensor_to_tensor_spec.cpp
@@ -27,6 +27,7 @@
 #include <tt-metalium/shape.hpp>
 #include <tt-metalium/tilize_utils.hpp>
 #include <tt-metalium/tile.hpp>
+#include <tt-metalium/experimental/tensor_layout_apis_with_custom_alignment.hpp>
 
 namespace tt::tt_metal {
 namespace {
@@ -134,7 +135,8 @@ TensorSpec make_tile_spec(
     const Tile& tile = Tile({32, 32}),
     const MemoryConfig& memory_config = MemoryConfig{},
     const Alignment& alignment = {}) {
-    return TensorSpec(shape, TensorLayout(dtype, PageConfig(Layout::TILE, tile), memory_config, alignment));
+    return TensorSpec(
+        shape, tensor_layout_with_custom_alignment(dtype, PageConfig(Layout::TILE, tile), memory_config, alignment));
 }
 
 }  // namespace CMAKE_UNIQUE_NAMESPACE
@@ -148,8 +150,10 @@ TEST(HostTensorToTensorSpec, EarlyOutExactSpecMatch) {
     auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
     auto alignment = Alignment({32, 32});
     auto tile = Tile({16, 16});
-    auto spec =
-        TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
+    auto spec = TensorSpec(
+        shape,
+        tensor_layout_with_custom_alignment(
+            DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
     auto source = HostTensor::from_vector<float>(data, spec);
 
     auto result = to_tensor_spec<float>(source, spec);
@@ -172,14 +176,18 @@ TEST(HostTensorToTensorSpec, PerCoreOnlyMismatchFullRewrite) {
         ShardSpec{CoreRangeSet({CoreRange({0, 0}, {0, 0})}), {32, 32}, ShardOrientation::ROW_MAJOR}};
 
     auto src_spec = TensorSpec(
-        shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config, Alignment({32, 32})));
+        shape,
+        tensor_layout_with_custom_alignment(
+            DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config, Alignment({32, 32})));
     auto source = host_tensor_from_vector_with_pad_value<float>(data, src_spec, /*pad_value=*/99.f);
     EXPECT_FALSE(experimental::per_core_allocation::is_per_core_allocation(source.tensor_spec().memory_config()));
 
     auto dest_memory = memory_config;
     experimental::per_core_allocation::set_per_core_allocation(dest_memory, true);
     auto dest_spec = TensorSpec(
-        shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), dest_memory, Alignment({32, 32})));
+        shape,
+        tensor_layout_with_custom_alignment(
+            DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), dest_memory, Alignment({32, 32})));
 
     // Spec equality must include per_core_allocation because it changes allocator semantics.
     EXPECT_FALSE(source.tensor_spec() == dest_spec);
@@ -245,8 +253,10 @@ TEST(HostTensorToTensorSpec, CustomTileAndAlignment) {
     auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
 
     auto src_spec = TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config));
-    auto dest_spec =
-        TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
+    auto dest_spec = TensorSpec(
+        shape,
+        tensor_layout_with_custom_alignment(
+            DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
 
     auto source = HostTensor::from_vector<float>(data, src_spec);
     auto result = to_tensor_spec<float>(source, dest_spec);
@@ -267,10 +277,14 @@ TEST(HostTensorToTensorSpec, Float32ToBfloat16PreservesMetadata) {
     auto alignment = Alignment({32, 32});
     auto tile = Tile({16, 16});
 
-    auto src_spec =
-        TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
-    auto dest_spec =
-        TensorSpec(shape, TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE, tile), memory_config, alignment));
+    auto src_spec = TensorSpec(
+        shape,
+        tensor_layout_with_custom_alignment(
+            DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
+    auto dest_spec = TensorSpec(
+        shape,
+        tensor_layout_with_custom_alignment(
+            DataType::BFLOAT16, PageConfig(Layout::TILE, tile), memory_config, alignment));
     auto source = HostTensor::from_vector<float>(data, src_spec);
 
     auto result = to_tensor_spec<float>(source, dest_spec);
@@ -323,10 +337,14 @@ TEST(HostTensorToTensorSpec, Float32TileToBfp8ValueCheck) {
     const auto tile = Tile({16, 16});
     const auto& [floats, packed_golden] = CMAKE_UNIQUE_NAMESPACE::generate_float_to_bfp8_dataset(shape, tile);
 
-    auto src_spec =
-        TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
-    auto dest_spec =
-        TensorSpec(shape, TensorLayout(DataType::BFLOAT8_B, PageConfig(Layout::TILE, tile), memory_config, alignment));
+    auto src_spec = TensorSpec(
+        shape,
+        tensor_layout_with_custom_alignment(
+            DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
+    auto dest_spec = TensorSpec(
+        shape,
+        tensor_layout_with_custom_alignment(
+            DataType::BFLOAT8_B, PageConfig(Layout::TILE, tile), memory_config, alignment));
     auto source = CMAKE_UNIQUE_NAMESPACE::make_host_tensor(floats, src_spec);
 
     auto result = host_tensor_to_tensor_spec_with_pad_value<float>(source, dest_spec, /*pad_value=*/0.f);
@@ -346,10 +364,14 @@ TEST(HostTensorToTensorSpec, Float32TileToBfp4ValueCheck) {
     const auto tile = Tile({16, 16});
     const auto& [floats, packed_golden] = CMAKE_UNIQUE_NAMESPACE::generate_float_to_bfp4_dataset(shape, tile);
 
-    auto src_spec =
-        TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
-    auto dest_spec =
-        TensorSpec(shape, TensorLayout(DataType::BFLOAT4_B, PageConfig(Layout::TILE, tile), memory_config, alignment));
+    auto src_spec = TensorSpec(
+        shape,
+        tensor_layout_with_custom_alignment(
+            DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
+    auto dest_spec = TensorSpec(
+        shape,
+        tensor_layout_with_custom_alignment(
+            DataType::BFLOAT4_B, PageConfig(Layout::TILE, tile), memory_config, alignment));
     auto source = CMAKE_UNIQUE_NAMESPACE::make_host_tensor(floats, src_spec);
 
     auto result = host_tensor_to_tensor_spec_with_pad_value<float>(source, dest_spec, /*pad_value=*/0.f);
@@ -369,8 +391,10 @@ TEST(HostTensorToTensorSpec, Bfp8TileToFloat32RowMajorValueCheck) {
     const auto tile = Tile({16, 16});
     const auto& [packed, unpacked_golden] = CMAKE_UNIQUE_NAMESPACE::generate_bfp8_dataset(shape, tile);
 
-    auto src_spec =
-        TensorSpec(shape, TensorLayout(DataType::BFLOAT8_B, PageConfig(Layout::TILE, tile), memory_config, alignment));
+    auto src_spec = TensorSpec(
+        shape,
+        tensor_layout_with_custom_alignment(
+            DataType::BFLOAT8_B, PageConfig(Layout::TILE, tile), memory_config, alignment));
     auto dest_spec = TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config));
     auto source = CMAKE_UNIQUE_NAMESPACE::make_host_tensor(packed, src_spec);
 
@@ -394,8 +418,10 @@ TEST(HostTensorToTensorSpec, Bfp4TileToFloat32RowMajorValueCheck) {
     const auto tile = Tile({16, 16});
     const auto& [packed, unpacked_golden] = CMAKE_UNIQUE_NAMESPACE::generate_bfp4_dataset(shape, tile);
 
-    auto src_spec =
-        TensorSpec(shape, TensorLayout(DataType::BFLOAT4_B, PageConfig(Layout::TILE, tile), memory_config, alignment));
+    auto src_spec = TensorSpec(
+        shape,
+        tensor_layout_with_custom_alignment(
+            DataType::BFLOAT4_B, PageConfig(Layout::TILE, tile), memory_config, alignment));
     auto dest_spec = TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config));
     auto source = CMAKE_UNIQUE_NAMESPACE::make_host_tensor(packed, src_spec);
 
@@ -418,10 +444,14 @@ TEST(HostTensorToTensorSpec, RowMajorToBfp8ChangesLayoutAndPreservesTile) {
     auto alignment = Alignment({32, 32});
     auto tile = Tile({16, 16});
 
-    auto src_spec =
-        TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config, alignment));
-    auto dest_spec =
-        TensorSpec(shape, TensorLayout(DataType::BFLOAT8_B, PageConfig(Layout::TILE, tile), memory_config, alignment));
+    auto src_spec = TensorSpec(
+        shape,
+        tensor_layout_with_custom_alignment(
+            DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config, alignment));
+    auto dest_spec = TensorSpec(
+        shape,
+        tensor_layout_with_custom_alignment(
+            DataType::BFLOAT8_B, PageConfig(Layout::TILE, tile), memory_config, alignment));
     auto source = HostTensor::from_vector<float>(data, src_spec);
 
     auto result = host_tensor_to_tensor_spec_with_pad_value<float>(source, dest_spec, /*pad_value=*/0.f);
@@ -588,7 +618,9 @@ TEST(HostTensorToTensorSpec, EqualPaddedDifferentPackingRoundTrip) {
     auto data = CMAKE_UNIQUE_NAMESPACE::make_ramp<float>(shape.volume());
     auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
     auto rm_spec = TensorSpec(
-        shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config, Alignment({16, 16})));
+        shape,
+        tensor_layout_with_custom_alignment(
+            DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config, Alignment({16, 16})));
     auto tile_spec =
         TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::TILE, Tile({16, 16})), memory_config));
 

--- a/tests/tt_metal/tt_metal/api/tensor/test_host_tensor_to_tensor_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_host_tensor_to_tensor_spec.cpp
@@ -137,7 +137,7 @@ TensorSpec make_tile_spec(
     const Alignment& alignment = {}) {
     return TensorSpec(
         shape,
-        experimental::tensor_layout_with_custom_alignment(
+        tt::tt_metal::experimental::tensor_layout_with_custom_alignment(
             dtype, PageConfig(Layout::TILE, tile), memory_config, alignment));
 }
 
@@ -154,7 +154,7 @@ TEST(HostTensorToTensorSpec, EarlyOutExactSpecMatch) {
     auto tile = Tile({16, 16});
     auto spec = TensorSpec(
         shape,
-        experimental::tensor_layout_with_custom_alignment(
+        tt::tt_metal::experimental::tensor_layout_with_custom_alignment(
             DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
     auto source = HostTensor::from_vector<float>(data, spec);
 
@@ -179,7 +179,7 @@ TEST(HostTensorToTensorSpec, PerCoreOnlyMismatchFullRewrite) {
 
     auto src_spec = TensorSpec(
         shape,
-        experimental::tensor_layout_with_custom_alignment(
+        tt::tt_metal::experimental::tensor_layout_with_custom_alignment(
             DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config, Alignment({32, 32})));
     auto source = host_tensor_from_vector_with_pad_value<float>(data, src_spec, /*pad_value=*/99.f);
     EXPECT_FALSE(experimental::per_core_allocation::is_per_core_allocation(source.tensor_spec().memory_config()));
@@ -188,7 +188,7 @@ TEST(HostTensorToTensorSpec, PerCoreOnlyMismatchFullRewrite) {
     experimental::per_core_allocation::set_per_core_allocation(dest_memory, true);
     auto dest_spec = TensorSpec(
         shape,
-        experimental::tensor_layout_with_custom_alignment(
+        tt::tt_metal::experimental::tensor_layout_with_custom_alignment(
             DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), dest_memory, Alignment({32, 32})));
 
     // Spec equality ignores per_core, but exact-spec predicate must not early-out.
@@ -257,7 +257,7 @@ TEST(HostTensorToTensorSpec, CustomTileAndAlignment) {
     auto src_spec = TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config));
     auto dest_spec = TensorSpec(
         shape,
-        experimental::tensor_layout_with_custom_alignment(
+        tt::tt_metal::experimental::tensor_layout_with_custom_alignment(
             DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
 
     auto source = HostTensor::from_vector<float>(data, src_spec);
@@ -281,11 +281,11 @@ TEST(HostTensorToTensorSpec, Float32ToBfloat16PreservesMetadata) {
 
     auto src_spec = TensorSpec(
         shape,
-        experimental::tensor_layout_with_custom_alignment(
+        tt::tt_metal::experimental::tensor_layout_with_custom_alignment(
             DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
     auto dest_spec = TensorSpec(
         shape,
-        experimental::tensor_layout_with_custom_alignment(
+        tt::tt_metal::experimental::tensor_layout_with_custom_alignment(
             DataType::BFLOAT16, PageConfig(Layout::TILE, tile), memory_config, alignment));
     auto source = HostTensor::from_vector<float>(data, src_spec);
 
@@ -341,11 +341,11 @@ TEST(HostTensorToTensorSpec, Float32TileToBfp8ValueCheck) {
 
     auto src_spec = TensorSpec(
         shape,
-        experimental::tensor_layout_with_custom_alignment(
+        tt::tt_metal::experimental::tensor_layout_with_custom_alignment(
             DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
     auto dest_spec = TensorSpec(
         shape,
-        experimental::tensor_layout_with_custom_alignment(
+        tt::tt_metal::experimental::tensor_layout_with_custom_alignment(
             DataType::BFLOAT8_B, PageConfig(Layout::TILE, tile), memory_config, alignment));
     auto source = CMAKE_UNIQUE_NAMESPACE::make_host_tensor(floats, src_spec);
 
@@ -368,11 +368,11 @@ TEST(HostTensorToTensorSpec, Float32TileToBfp4ValueCheck) {
 
     auto src_spec = TensorSpec(
         shape,
-        experimental::tensor_layout_with_custom_alignment(
+        tt::tt_metal::experimental::tensor_layout_with_custom_alignment(
             DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
     auto dest_spec = TensorSpec(
         shape,
-        experimental::tensor_layout_with_custom_alignment(
+        tt::tt_metal::experimental::tensor_layout_with_custom_alignment(
             DataType::BFLOAT4_B, PageConfig(Layout::TILE, tile), memory_config, alignment));
     auto source = CMAKE_UNIQUE_NAMESPACE::make_host_tensor(floats, src_spec);
 
@@ -395,7 +395,7 @@ TEST(HostTensorToTensorSpec, Bfp8TileToFloat32RowMajorValueCheck) {
 
     auto src_spec = TensorSpec(
         shape,
-        experimental::tensor_layout_with_custom_alignment(
+        tt::tt_metal::experimental::tensor_layout_with_custom_alignment(
             DataType::BFLOAT8_B, PageConfig(Layout::TILE, tile), memory_config, alignment));
     auto dest_spec = TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config));
     auto source = CMAKE_UNIQUE_NAMESPACE::make_host_tensor(packed, src_spec);
@@ -422,7 +422,7 @@ TEST(HostTensorToTensorSpec, Bfp4TileToFloat32RowMajorValueCheck) {
 
     auto src_spec = TensorSpec(
         shape,
-        experimental::tensor_layout_with_custom_alignment(
+        tt::tt_metal::experimental::tensor_layout_with_custom_alignment(
             DataType::BFLOAT4_B, PageConfig(Layout::TILE, tile), memory_config, alignment));
     auto dest_spec = TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config));
     auto source = CMAKE_UNIQUE_NAMESPACE::make_host_tensor(packed, src_spec);
@@ -448,11 +448,11 @@ TEST(HostTensorToTensorSpec, RowMajorToBfp8ChangesLayoutAndPreservesTile) {
 
     auto src_spec = TensorSpec(
         shape,
-        experimental::tensor_layout_with_custom_alignment(
+        tt::tt_metal::experimental::tensor_layout_with_custom_alignment(
             DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config, alignment));
     auto dest_spec = TensorSpec(
         shape,
-        experimental::tensor_layout_with_custom_alignment(
+        tt::tt_metal::experimental::tensor_layout_with_custom_alignment(
             DataType::BFLOAT8_B, PageConfig(Layout::TILE, tile), memory_config, alignment));
     auto source = HostTensor::from_vector<float>(data, src_spec);
 
@@ -581,7 +581,7 @@ TEST(HostTensorToTensorSpec, EqualPaddedDifferentPackingRoundTrip) {
     auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
     auto rm_spec = TensorSpec(
         shape,
-        experimental::tensor_layout_with_custom_alignment(
+        tt::tt_metal::experimental::tensor_layout_with_custom_alignment(
             DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config, Alignment({16, 16})));
     auto tile_spec =
         TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::TILE, Tile({16, 16})), memory_config));

--- a/tests/tt_metal/tt_metal/api/tensor/test_host_tensor_to_tensor_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_host_tensor_to_tensor_spec.cpp
@@ -137,7 +137,7 @@ TensorSpec make_tile_spec(
     const Alignment& alignment = {}) {
     return TensorSpec(
         shape,
-        experimental::tensor_layout_with_custom_alignment(
+        tt::tt_metal::experimental::tensor_layout_with_custom_alignment(
             dtype, PageConfig(Layout::TILE, tile), memory_config, alignment));
 }
 
@@ -154,7 +154,7 @@ TEST(HostTensorToTensorSpec, EarlyOutExactSpecMatch) {
     auto tile = Tile({16, 16});
     auto spec = TensorSpec(
         shape,
-        experimental::tensor_layout_with_custom_alignment(
+        tt::tt_metal::experimental::tensor_layout_with_custom_alignment(
             DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
     auto source = HostTensor::from_vector<float>(data, spec);
 
@@ -179,7 +179,7 @@ TEST(HostTensorToTensorSpec, PerCoreOnlyMismatchFullRewrite) {
 
     auto src_spec = TensorSpec(
         shape,
-        experimental::tensor_layout_with_custom_alignment(
+        tt::tt_metal::experimental::tensor_layout_with_custom_alignment(
             DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config, Alignment({32, 32})));
     auto source = host_tensor_from_vector_with_pad_value<float>(data, src_spec, /*pad_value=*/99.f);
     EXPECT_FALSE(experimental::per_core_allocation::is_per_core_allocation(source.tensor_spec().memory_config()));
@@ -188,7 +188,7 @@ TEST(HostTensorToTensorSpec, PerCoreOnlyMismatchFullRewrite) {
     experimental::per_core_allocation::set_per_core_allocation(dest_memory, true);
     auto dest_spec = TensorSpec(
         shape,
-        experimental::tensor_layout_with_custom_alignment(
+        tt::tt_metal::experimental::tensor_layout_with_custom_alignment(
             DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), dest_memory, Alignment({32, 32})));
 
     // Spec equality must include per_core_allocation because it changes allocator semantics.
@@ -257,7 +257,7 @@ TEST(HostTensorToTensorSpec, CustomTileAndAlignment) {
     auto src_spec = TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config));
     auto dest_spec = TensorSpec(
         shape,
-        experimental::tensor_layout_with_custom_alignment(
+        tt::tt_metal::experimental::tensor_layout_with_custom_alignment(
             DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
 
     auto source = HostTensor::from_vector<float>(data, src_spec);
@@ -281,11 +281,11 @@ TEST(HostTensorToTensorSpec, Float32ToBfloat16PreservesMetadata) {
 
     auto src_spec = TensorSpec(
         shape,
-        experimental::tensor_layout_with_custom_alignment(
+        tt::tt_metal::experimental::tensor_layout_with_custom_alignment(
             DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
     auto dest_spec = TensorSpec(
         shape,
-        experimental::tensor_layout_with_custom_alignment(
+        tt::tt_metal::experimental::tensor_layout_with_custom_alignment(
             DataType::BFLOAT16, PageConfig(Layout::TILE, tile), memory_config, alignment));
     auto source = HostTensor::from_vector<float>(data, src_spec);
 
@@ -341,11 +341,11 @@ TEST(HostTensorToTensorSpec, Float32TileToBfp8ValueCheck) {
 
     auto src_spec = TensorSpec(
         shape,
-        experimental::tensor_layout_with_custom_alignment(
+        tt::tt_metal::experimental::tensor_layout_with_custom_alignment(
             DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
     auto dest_spec = TensorSpec(
         shape,
-        experimental::tensor_layout_with_custom_alignment(
+        tt::tt_metal::experimental::tensor_layout_with_custom_alignment(
             DataType::BFLOAT8_B, PageConfig(Layout::TILE, tile), memory_config, alignment));
     auto source = CMAKE_UNIQUE_NAMESPACE::make_host_tensor(floats, src_spec);
 
@@ -368,11 +368,11 @@ TEST(HostTensorToTensorSpec, Float32TileToBfp4ValueCheck) {
 
     auto src_spec = TensorSpec(
         shape,
-        experimental::tensor_layout_with_custom_alignment(
+        tt::tt_metal::experimental::tensor_layout_with_custom_alignment(
             DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
     auto dest_spec = TensorSpec(
         shape,
-        experimental::tensor_layout_with_custom_alignment(
+        tt::tt_metal::experimental::tensor_layout_with_custom_alignment(
             DataType::BFLOAT4_B, PageConfig(Layout::TILE, tile), memory_config, alignment));
     auto source = CMAKE_UNIQUE_NAMESPACE::make_host_tensor(floats, src_spec);
 
@@ -395,7 +395,7 @@ TEST(HostTensorToTensorSpec, Bfp8TileToFloat32RowMajorValueCheck) {
 
     auto src_spec = TensorSpec(
         shape,
-        experimental::tensor_layout_with_custom_alignment(
+        tt::tt_metal::experimental::tensor_layout_with_custom_alignment(
             DataType::BFLOAT8_B, PageConfig(Layout::TILE, tile), memory_config, alignment));
     auto dest_spec = TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config));
     auto source = CMAKE_UNIQUE_NAMESPACE::make_host_tensor(packed, src_spec);
@@ -422,7 +422,7 @@ TEST(HostTensorToTensorSpec, Bfp4TileToFloat32RowMajorValueCheck) {
 
     auto src_spec = TensorSpec(
         shape,
-        experimental::tensor_layout_with_custom_alignment(
+        tt::tt_metal::experimental::tensor_layout_with_custom_alignment(
             DataType::BFLOAT4_B, PageConfig(Layout::TILE, tile), memory_config, alignment));
     auto dest_spec = TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config));
     auto source = CMAKE_UNIQUE_NAMESPACE::make_host_tensor(packed, src_spec);
@@ -448,11 +448,11 @@ TEST(HostTensorToTensorSpec, RowMajorToBfp8ChangesLayoutAndPreservesTile) {
 
     auto src_spec = TensorSpec(
         shape,
-        experimental::tensor_layout_with_custom_alignment(
+        tt::tt_metal::experimental::tensor_layout_with_custom_alignment(
             DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config, alignment));
     auto dest_spec = TensorSpec(
         shape,
-        experimental::tensor_layout_with_custom_alignment(
+        tt::tt_metal::experimental::tensor_layout_with_custom_alignment(
             DataType::BFLOAT8_B, PageConfig(Layout::TILE, tile), memory_config, alignment));
     auto source = HostTensor::from_vector<float>(data, src_spec);
 
@@ -621,7 +621,7 @@ TEST(HostTensorToTensorSpec, EqualPaddedDifferentPackingRoundTrip) {
     auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
     auto rm_spec = TensorSpec(
         shape,
-        experimental::tensor_layout_with_custom_alignment(
+        tt::tt_metal::experimental::tensor_layout_with_custom_alignment(
             DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config, Alignment({16, 16})));
     auto tile_spec =
         TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::TILE, Tile({16, 16})), memory_config));

--- a/tests/tt_metal/tt_metal/api/tensor/test_host_tensor_to_tensor_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_host_tensor_to_tensor_spec.cpp
@@ -136,7 +136,9 @@ TensorSpec make_tile_spec(
     const MemoryConfig& memory_config = MemoryConfig{},
     const Alignment& alignment = {}) {
     return TensorSpec(
-        shape, tensor_layout_with_custom_alignment(dtype, PageConfig(Layout::TILE, tile), memory_config, alignment));
+        shape,
+        experimental::tensor_layout_with_custom_alignment(
+            dtype, PageConfig(Layout::TILE, tile), memory_config, alignment));
 }
 
 }  // namespace CMAKE_UNIQUE_NAMESPACE
@@ -152,7 +154,7 @@ TEST(HostTensorToTensorSpec, EarlyOutExactSpecMatch) {
     auto tile = Tile({16, 16});
     auto spec = TensorSpec(
         shape,
-        tensor_layout_with_custom_alignment(
+        experimental::tensor_layout_with_custom_alignment(
             DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
     auto source = HostTensor::from_vector<float>(data, spec);
 
@@ -177,7 +179,7 @@ TEST(HostTensorToTensorSpec, PerCoreOnlyMismatchFullRewrite) {
 
     auto src_spec = TensorSpec(
         shape,
-        tensor_layout_with_custom_alignment(
+        experimental::tensor_layout_with_custom_alignment(
             DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config, Alignment({32, 32})));
     auto source = host_tensor_from_vector_with_pad_value<float>(data, src_spec, /*pad_value=*/99.f);
     EXPECT_FALSE(experimental::per_core_allocation::is_per_core_allocation(source.tensor_spec().memory_config()));
@@ -186,7 +188,7 @@ TEST(HostTensorToTensorSpec, PerCoreOnlyMismatchFullRewrite) {
     experimental::per_core_allocation::set_per_core_allocation(dest_memory, true);
     auto dest_spec = TensorSpec(
         shape,
-        tensor_layout_with_custom_alignment(
+        experimental::tensor_layout_with_custom_alignment(
             DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), dest_memory, Alignment({32, 32})));
 
     // Spec equality must include per_core_allocation because it changes allocator semantics.
@@ -255,7 +257,7 @@ TEST(HostTensorToTensorSpec, CustomTileAndAlignment) {
     auto src_spec = TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config));
     auto dest_spec = TensorSpec(
         shape,
-        tensor_layout_with_custom_alignment(
+        experimental::tensor_layout_with_custom_alignment(
             DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
 
     auto source = HostTensor::from_vector<float>(data, src_spec);
@@ -279,11 +281,11 @@ TEST(HostTensorToTensorSpec, Float32ToBfloat16PreservesMetadata) {
 
     auto src_spec = TensorSpec(
         shape,
-        tensor_layout_with_custom_alignment(
+        experimental::tensor_layout_with_custom_alignment(
             DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
     auto dest_spec = TensorSpec(
         shape,
-        tensor_layout_with_custom_alignment(
+        experimental::tensor_layout_with_custom_alignment(
             DataType::BFLOAT16, PageConfig(Layout::TILE, tile), memory_config, alignment));
     auto source = HostTensor::from_vector<float>(data, src_spec);
 
@@ -339,11 +341,11 @@ TEST(HostTensorToTensorSpec, Float32TileToBfp8ValueCheck) {
 
     auto src_spec = TensorSpec(
         shape,
-        tensor_layout_with_custom_alignment(
+        experimental::tensor_layout_with_custom_alignment(
             DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
     auto dest_spec = TensorSpec(
         shape,
-        tensor_layout_with_custom_alignment(
+        experimental::tensor_layout_with_custom_alignment(
             DataType::BFLOAT8_B, PageConfig(Layout::TILE, tile), memory_config, alignment));
     auto source = CMAKE_UNIQUE_NAMESPACE::make_host_tensor(floats, src_spec);
 
@@ -366,11 +368,11 @@ TEST(HostTensorToTensorSpec, Float32TileToBfp4ValueCheck) {
 
     auto src_spec = TensorSpec(
         shape,
-        tensor_layout_with_custom_alignment(
+        experimental::tensor_layout_with_custom_alignment(
             DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
     auto dest_spec = TensorSpec(
         shape,
-        tensor_layout_with_custom_alignment(
+        experimental::tensor_layout_with_custom_alignment(
             DataType::BFLOAT4_B, PageConfig(Layout::TILE, tile), memory_config, alignment));
     auto source = CMAKE_UNIQUE_NAMESPACE::make_host_tensor(floats, src_spec);
 
@@ -393,7 +395,7 @@ TEST(HostTensorToTensorSpec, Bfp8TileToFloat32RowMajorValueCheck) {
 
     auto src_spec = TensorSpec(
         shape,
-        tensor_layout_with_custom_alignment(
+        experimental::tensor_layout_with_custom_alignment(
             DataType::BFLOAT8_B, PageConfig(Layout::TILE, tile), memory_config, alignment));
     auto dest_spec = TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config));
     auto source = CMAKE_UNIQUE_NAMESPACE::make_host_tensor(packed, src_spec);
@@ -420,7 +422,7 @@ TEST(HostTensorToTensorSpec, Bfp4TileToFloat32RowMajorValueCheck) {
 
     auto src_spec = TensorSpec(
         shape,
-        tensor_layout_with_custom_alignment(
+        experimental::tensor_layout_with_custom_alignment(
             DataType::BFLOAT4_B, PageConfig(Layout::TILE, tile), memory_config, alignment));
     auto dest_spec = TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config));
     auto source = CMAKE_UNIQUE_NAMESPACE::make_host_tensor(packed, src_spec);
@@ -446,11 +448,11 @@ TEST(HostTensorToTensorSpec, RowMajorToBfp8ChangesLayoutAndPreservesTile) {
 
     auto src_spec = TensorSpec(
         shape,
-        tensor_layout_with_custom_alignment(
+        experimental::tensor_layout_with_custom_alignment(
             DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config, alignment));
     auto dest_spec = TensorSpec(
         shape,
-        tensor_layout_with_custom_alignment(
+        experimental::tensor_layout_with_custom_alignment(
             DataType::BFLOAT8_B, PageConfig(Layout::TILE, tile), memory_config, alignment));
     auto source = HostTensor::from_vector<float>(data, src_spec);
 
@@ -619,7 +621,7 @@ TEST(HostTensorToTensorSpec, EqualPaddedDifferentPackingRoundTrip) {
     auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
     auto rm_spec = TensorSpec(
         shape,
-        tensor_layout_with_custom_alignment(
+        experimental::tensor_layout_with_custom_alignment(
             DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config, Alignment({16, 16})));
     auto tile_spec =
         TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::TILE, Tile({16, 16})), memory_config));

--- a/tests/tt_metal/tt_metal/api/tensor/test_host_tensor_to_tensor_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_host_tensor_to_tensor_spec.cpp
@@ -136,7 +136,9 @@ TensorSpec make_tile_spec(
     const MemoryConfig& memory_config = MemoryConfig{},
     const Alignment& alignment = {}) {
     return TensorSpec(
-        shape, tensor_layout_with_custom_alignment(dtype, PageConfig(Layout::TILE, tile), memory_config, alignment));
+        shape,
+        experimental::tensor_layout_with_custom_alignment(
+            dtype, PageConfig(Layout::TILE, tile), memory_config, alignment));
 }
 
 }  // namespace CMAKE_UNIQUE_NAMESPACE
@@ -152,7 +154,7 @@ TEST(HostTensorToTensorSpec, EarlyOutExactSpecMatch) {
     auto tile = Tile({16, 16});
     auto spec = TensorSpec(
         shape,
-        tensor_layout_with_custom_alignment(
+        experimental::tensor_layout_with_custom_alignment(
             DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
     auto source = HostTensor::from_vector<float>(data, spec);
 
@@ -177,7 +179,7 @@ TEST(HostTensorToTensorSpec, PerCoreOnlyMismatchFullRewrite) {
 
     auto src_spec = TensorSpec(
         shape,
-        tensor_layout_with_custom_alignment(
+        experimental::tensor_layout_with_custom_alignment(
             DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config, Alignment({32, 32})));
     auto source = host_tensor_from_vector_with_pad_value<float>(data, src_spec, /*pad_value=*/99.f);
     EXPECT_FALSE(experimental::per_core_allocation::is_per_core_allocation(source.tensor_spec().memory_config()));
@@ -186,7 +188,7 @@ TEST(HostTensorToTensorSpec, PerCoreOnlyMismatchFullRewrite) {
     experimental::per_core_allocation::set_per_core_allocation(dest_memory, true);
     auto dest_spec = TensorSpec(
         shape,
-        tensor_layout_with_custom_alignment(
+        experimental::tensor_layout_with_custom_alignment(
             DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), dest_memory, Alignment({32, 32})));
 
     // Spec equality ignores per_core, but exact-spec predicate must not early-out.
@@ -255,7 +257,7 @@ TEST(HostTensorToTensorSpec, CustomTileAndAlignment) {
     auto src_spec = TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config));
     auto dest_spec = TensorSpec(
         shape,
-        tensor_layout_with_custom_alignment(
+        experimental::tensor_layout_with_custom_alignment(
             DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
 
     auto source = HostTensor::from_vector<float>(data, src_spec);
@@ -279,11 +281,11 @@ TEST(HostTensorToTensorSpec, Float32ToBfloat16PreservesMetadata) {
 
     auto src_spec = TensorSpec(
         shape,
-        tensor_layout_with_custom_alignment(
+        experimental::tensor_layout_with_custom_alignment(
             DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
     auto dest_spec = TensorSpec(
         shape,
-        tensor_layout_with_custom_alignment(
+        experimental::tensor_layout_with_custom_alignment(
             DataType::BFLOAT16, PageConfig(Layout::TILE, tile), memory_config, alignment));
     auto source = HostTensor::from_vector<float>(data, src_spec);
 
@@ -339,11 +341,11 @@ TEST(HostTensorToTensorSpec, Float32TileToBfp8ValueCheck) {
 
     auto src_spec = TensorSpec(
         shape,
-        tensor_layout_with_custom_alignment(
+        experimental::tensor_layout_with_custom_alignment(
             DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
     auto dest_spec = TensorSpec(
         shape,
-        tensor_layout_with_custom_alignment(
+        experimental::tensor_layout_with_custom_alignment(
             DataType::BFLOAT8_B, PageConfig(Layout::TILE, tile), memory_config, alignment));
     auto source = CMAKE_UNIQUE_NAMESPACE::make_host_tensor(floats, src_spec);
 
@@ -366,11 +368,11 @@ TEST(HostTensorToTensorSpec, Float32TileToBfp4ValueCheck) {
 
     auto src_spec = TensorSpec(
         shape,
-        tensor_layout_with_custom_alignment(
+        experimental::tensor_layout_with_custom_alignment(
             DataType::FLOAT32, PageConfig(Layout::TILE, tile), memory_config, alignment));
     auto dest_spec = TensorSpec(
         shape,
-        tensor_layout_with_custom_alignment(
+        experimental::tensor_layout_with_custom_alignment(
             DataType::BFLOAT4_B, PageConfig(Layout::TILE, tile), memory_config, alignment));
     auto source = CMAKE_UNIQUE_NAMESPACE::make_host_tensor(floats, src_spec);
 
@@ -393,7 +395,7 @@ TEST(HostTensorToTensorSpec, Bfp8TileToFloat32RowMajorValueCheck) {
 
     auto src_spec = TensorSpec(
         shape,
-        tensor_layout_with_custom_alignment(
+        experimental::tensor_layout_with_custom_alignment(
             DataType::BFLOAT8_B, PageConfig(Layout::TILE, tile), memory_config, alignment));
     auto dest_spec = TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config));
     auto source = CMAKE_UNIQUE_NAMESPACE::make_host_tensor(packed, src_spec);
@@ -420,7 +422,7 @@ TEST(HostTensorToTensorSpec, Bfp4TileToFloat32RowMajorValueCheck) {
 
     auto src_spec = TensorSpec(
         shape,
-        tensor_layout_with_custom_alignment(
+        experimental::tensor_layout_with_custom_alignment(
             DataType::BFLOAT4_B, PageConfig(Layout::TILE, tile), memory_config, alignment));
     auto dest_spec = TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config));
     auto source = CMAKE_UNIQUE_NAMESPACE::make_host_tensor(packed, src_spec);
@@ -446,11 +448,11 @@ TEST(HostTensorToTensorSpec, RowMajorToBfp8ChangesLayoutAndPreservesTile) {
 
     auto src_spec = TensorSpec(
         shape,
-        tensor_layout_with_custom_alignment(
+        experimental::tensor_layout_with_custom_alignment(
             DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config, alignment));
     auto dest_spec = TensorSpec(
         shape,
-        tensor_layout_with_custom_alignment(
+        experimental::tensor_layout_with_custom_alignment(
             DataType::BFLOAT8_B, PageConfig(Layout::TILE, tile), memory_config, alignment));
     auto source = HostTensor::from_vector<float>(data, src_spec);
 
@@ -579,7 +581,7 @@ TEST(HostTensorToTensorSpec, EqualPaddedDifferentPackingRoundTrip) {
     auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
     auto rm_spec = TensorSpec(
         shape,
-        tensor_layout_with_custom_alignment(
+        experimental::tensor_layout_with_custom_alignment(
             DataType::FLOAT32, PageConfig(Layout::ROW_MAJOR), memory_config, Alignment({16, 16})));
     auto tile_spec =
         TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::TILE, Tile({16, 16})), memory_config));

--- a/tests/tt_metal/tt_metal/api/tensor/test_tensor_layout.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_tensor_layout.cpp
@@ -19,6 +19,7 @@
 #include <tt-metalium/experimental/tensor/spec/tensor_spec.hpp>
 #include <tt-metalium/experimental/tensor/tensor_types.hpp>
 #include <tt_metal/impl/tensor/spec/layout/tensor_layout_impl.hpp>
+#include <tt-metalium/experimental/tensor_layout_apis_with_custom_alignment.hpp>
 
 namespace tt::tt_metal {
 namespace {
@@ -182,7 +183,7 @@ class TensorLayoutLegacyPaddingRoundtipTests : public ::testing::TestWithParam<L
 
 TEST_P(TensorLayoutLegacyPaddingRoundtipTests, Tensor_LagacyPaddingRoundtrip) {
     const auto& params = GetParam();
-    TensorLayout layout = TensorLayout::fromPaddedShape(
+    TensorLayout layout = tensor_layout_from_padded_shape(
         DataType::BFLOAT16, Layout::ROW_MAJOR, DefaultMemoryConfig, params.shape, params.padded_shape);
     EXPECT_EQ(layout.compute_padded_shape(params.shape), params.padded_shape);
 
@@ -279,7 +280,7 @@ class TensorLayoutRowMajorPaddedShapeAlignmentTests
 
 TEST_P(TensorLayoutRowMajorPaddedShapeAlignmentTests, FromPaddedShape_ComputesFullAlignment) {
     const auto& params = GetParam();
-    TensorLayout layout = TensorLayout::fromPaddedShape(
+    TensorLayout layout = tensor_layout_from_padded_shape(
         DataType::BFLOAT16, PageConfig(Layout::ROW_MAJOR), DefaultMemoryConfig, params.shape, params.padded_shape);
 
     EXPECT_EQ(layout.get_alignment(), params.expected_alignment);
@@ -333,7 +334,7 @@ class TensorLayoutTilePaddedAlignmentTests : public ::testing::TestWithParam<Til
 
 TEST_P(TensorLayoutTilePaddedAlignmentTests, Tensor_TilePaddedAlignmentRegression) {
     const auto& params = GetParam();
-    TensorLayout layout = TensorLayout::fromPaddedShape(
+    TensorLayout layout = tensor_layout_from_padded_shape(
         params.dtype, Layout::TILE, DefaultMemoryConfig, params.shape, params.padded_shape);
 
     EXPECT_EQ(layout.get_alignment(), params.expected_alignment);
@@ -411,7 +412,7 @@ class TensorLayoutTile2DInterleavedAlignmentTests
 
 TEST_P(TensorLayoutTile2DInterleavedAlignmentTests, FromPaddedShape_TileAlignmentUsesTileUnlessOverpadded) {
     const auto& params = GetParam();
-    TensorLayout layout = TensorLayout::fromPaddedShape(
+    TensorLayout layout = tensor_layout_from_padded_shape(
         DataType::BFLOAT16,
         PageConfig(Layout::TILE, params.tile),
         DefaultMemoryConfig,

--- a/tests/tt_metal/tt_metal/api/tensor/test_tensor_layout.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_tensor_layout.cpp
@@ -183,7 +183,7 @@ class TensorLayoutLegacyPaddingRoundtipTests : public ::testing::TestWithParam<L
 
 TEST_P(TensorLayoutLegacyPaddingRoundtipTests, Tensor_LagacyPaddingRoundtrip) {
     const auto& params = GetParam();
-    TensorLayout layout = tensor_layout_from_padded_shape(
+    TensorLayout layout = experimental::tensor_layout_from_padded_shape(
         DataType::BFLOAT16, Layout::ROW_MAJOR, DefaultMemoryConfig, params.shape, params.padded_shape);
     EXPECT_EQ(layout.compute_padded_shape(params.shape), params.padded_shape);
 
@@ -280,7 +280,7 @@ class TensorLayoutRowMajorPaddedShapeAlignmentTests
 
 TEST_P(TensorLayoutRowMajorPaddedShapeAlignmentTests, FromPaddedShape_ComputesFullAlignment) {
     const auto& params = GetParam();
-    TensorLayout layout = tensor_layout_from_padded_shape(
+    TensorLayout layout = experimental::tensor_layout_from_padded_shape(
         DataType::BFLOAT16, PageConfig(Layout::ROW_MAJOR), DefaultMemoryConfig, params.shape, params.padded_shape);
 
     EXPECT_EQ(layout.get_alignment(), params.expected_alignment);
@@ -334,7 +334,7 @@ class TensorLayoutTilePaddedAlignmentTests : public ::testing::TestWithParam<Til
 
 TEST_P(TensorLayoutTilePaddedAlignmentTests, Tensor_TilePaddedAlignmentRegression) {
     const auto& params = GetParam();
-    TensorLayout layout = tensor_layout_from_padded_shape(
+    TensorLayout layout = experimental::tensor_layout_from_padded_shape(
         params.dtype, Layout::TILE, DefaultMemoryConfig, params.shape, params.padded_shape);
 
     EXPECT_EQ(layout.get_alignment(), params.expected_alignment);
@@ -412,7 +412,7 @@ class TensorLayoutTile2DInterleavedAlignmentTests
 
 TEST_P(TensorLayoutTile2DInterleavedAlignmentTests, FromPaddedShape_TileAlignmentUsesTileUnlessOverpadded) {
     const auto& params = GetParam();
-    TensorLayout layout = tensor_layout_from_padded_shape(
+    TensorLayout layout = experimental::tensor_layout_from_padded_shape(
         DataType::BFLOAT16,
         PageConfig(Layout::TILE, params.tile),
         DefaultMemoryConfig,

--- a/tests/tt_metal/tt_metal/api/tensor/test_tensor_layout.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_tensor_layout.cpp
@@ -183,7 +183,7 @@ class TensorLayoutLegacyPaddingRoundtipTests : public ::testing::TestWithParam<L
 
 TEST_P(TensorLayoutLegacyPaddingRoundtipTests, Tensor_LagacyPaddingRoundtrip) {
     const auto& params = GetParam();
-    TensorLayout layout = experimental::tensor_layout_from_padded_shape(
+    TensorLayout layout = tt::tt_metal::experimental::tensor_layout_from_padded_shape(
         DataType::BFLOAT16, Layout::ROW_MAJOR, DefaultMemoryConfig, params.shape, params.padded_shape);
     EXPECT_EQ(layout.compute_padded_shape(params.shape), params.padded_shape);
 
@@ -280,7 +280,7 @@ class TensorLayoutRowMajorPaddedShapeAlignmentTests
 
 TEST_P(TensorLayoutRowMajorPaddedShapeAlignmentTests, FromPaddedShape_ComputesFullAlignment) {
     const auto& params = GetParam();
-    TensorLayout layout = experimental::tensor_layout_from_padded_shape(
+    TensorLayout layout = tt::tt_metal::experimental::tensor_layout_from_padded_shape(
         DataType::BFLOAT16, PageConfig(Layout::ROW_MAJOR), DefaultMemoryConfig, params.shape, params.padded_shape);
 
     EXPECT_EQ(layout.get_alignment(), params.expected_alignment);
@@ -334,7 +334,7 @@ class TensorLayoutTilePaddedAlignmentTests : public ::testing::TestWithParam<Til
 
 TEST_P(TensorLayoutTilePaddedAlignmentTests, Tensor_TilePaddedAlignmentRegression) {
     const auto& params = GetParam();
-    TensorLayout layout = experimental::tensor_layout_from_padded_shape(
+    TensorLayout layout = tt::tt_metal::experimental::tensor_layout_from_padded_shape(
         params.dtype, Layout::TILE, DefaultMemoryConfig, params.shape, params.padded_shape);
 
     EXPECT_EQ(layout.get_alignment(), params.expected_alignment);
@@ -412,7 +412,7 @@ class TensorLayoutTile2DInterleavedAlignmentTests
 
 TEST_P(TensorLayoutTile2DInterleavedAlignmentTests, FromPaddedShape_TileAlignmentUsesTileUnlessOverpadded) {
     const auto& params = GetParam();
-    TensorLayout layout = experimental::tensor_layout_from_padded_shape(
+    TensorLayout layout = tt::tt_metal::experimental::tensor_layout_from_padded_shape(
         DataType::BFLOAT16,
         PageConfig(Layout::TILE, params.tile),
         DefaultMemoryConfig,

--- a/tests/tt_metal/tt_metal/api/tensor/test_tensor_nd_sharding.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_tensor_nd_sharding.cpp
@@ -44,6 +44,7 @@
 
 #include <tt-metalium/experimental/tensor/mesh_tensor.hpp>
 #include <tt-metalium/experimental/tensor/host_tensor.hpp>
+#include <tt-metalium/experimental/distributed_tensor/distributed_tensor_apis.hpp>
 #include <tt-metalium/experimental/tensor/tensor_apis.hpp>
 #include <tt-metalium/mesh_device.hpp>
 #include <tt-metalium/distributed.hpp>

--- a/tests/tt_metal/tt_metal/api/tensor/test_vector_conversion.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_vector_conversion.cpp
@@ -31,6 +31,7 @@
 #include <tt-metalium/experimental/tensor/mesh_tensor.hpp>
 #include <tt-metalium/mesh_device.hpp>
 #include "tt_metal/tt_metal/common/multi_device_fixture.hpp"
+#include <tt-metalium/experimental/tensor_layout_apis_with_custom_alignment.hpp>
 
 namespace tt::tt_metal {
 namespace {
@@ -308,8 +309,10 @@ TEST(VectorConversionTest, ExactSpecPredicateCustomAlignment) {
 
     auto alignment = tt::tt_metal::Alignment({64, 64});
     auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
-    auto spec =
-        TensorSpec(shape, TensorLayout(DataType::BFLOAT16, PageConfig(Layout::ROW_MAJOR), memory_config, alignment));
+    auto spec = TensorSpec(
+        shape,
+        tensor_layout_with_custom_alignment(
+            DataType::BFLOAT16, PageConfig(Layout::ROW_MAJOR), memory_config, alignment));
 
     auto host_tensor = HostTensor::from_vector(input, spec);
 
@@ -323,8 +326,10 @@ TEST(VectorConversionTest, ExactSpecPredicateCustomAlignmentRvalueVector) {
 
     auto alignment = tt::tt_metal::Alignment({64, 64});
     auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
-    auto spec =
-        TensorSpec(shape, TensorLayout(DataType::BFLOAT16, PageConfig(Layout::ROW_MAJOR), memory_config, alignment));
+    auto spec = TensorSpec(
+        shape,
+        tensor_layout_with_custom_alignment(
+            DataType::BFLOAT16, PageConfig(Layout::ROW_MAJOR), memory_config, alignment));
 
     auto host_tensor = HostTensor::from_vector(std::move(input), spec);
 
@@ -337,8 +342,10 @@ TEST(VectorConversionTest, ExactSpecPredicateCustomAlignmentFromSpan) {
 
     auto alignment = tt::tt_metal::Alignment({64, 64});
     auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
-    auto spec =
-        TensorSpec(shape, TensorLayout(DataType::BFLOAT16, PageConfig(Layout::ROW_MAJOR), memory_config, alignment));
+    auto spec = TensorSpec(
+        shape,
+        tensor_layout_with_custom_alignment(
+            DataType::BFLOAT16, PageConfig(Layout::ROW_MAJOR), memory_config, alignment));
 
     auto host_tensor = HostTensor::from_span<float>(std::span<float>(input), spec);
 
@@ -355,8 +362,10 @@ TEST(VectorConversionTest, ExactSpecShardedPackedSizes) {
         ShardSpec{CoreRangeSet({CoreRange({0, 0}, {0, 1})}), {32, 64}, ShardOrientation::ROW_MAJOR}};
     experimental::per_core_allocation::set_per_core_allocation(memory_config, true);
     auto alignment = tt::tt_metal::Alignment({64, 64});
-    auto spec =
-        TensorSpec(shape, TensorLayout(DataType::BFLOAT16, PageConfig(Layout::ROW_MAJOR), memory_config, alignment));
+    auto spec = TensorSpec(
+        shape,
+        tensor_layout_with_custom_alignment(
+            DataType::BFLOAT16, PageConfig(Layout::ROW_MAJOR), memory_config, alignment));
 
     auto host_tensor = HostTensor::from_vector(input, spec);
 

--- a/tests/tt_metal/tt_metal/api/tensor/test_vector_conversion.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_vector_conversion.cpp
@@ -335,7 +335,7 @@ TEST(VectorConversionTest, ExactSpecPredicateCustomAlignment) {
     auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
     auto spec = TensorSpec(
         shape,
-        experimental::tensor_layout_with_custom_alignment(
+        tt::tt_metal::experimental::tensor_layout_with_custom_alignment(
             DataType::BFLOAT16, PageConfig(Layout::ROW_MAJOR), memory_config, alignment));
 
     auto host_tensor = HostTensor::from_vector(input, spec);
@@ -352,7 +352,7 @@ TEST(VectorConversionTest, ExactSpecPredicateCustomAlignmentRvalueVector) {
     auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
     auto spec = TensorSpec(
         shape,
-        experimental::tensor_layout_with_custom_alignment(
+        tt::tt_metal::experimental::tensor_layout_with_custom_alignment(
             DataType::BFLOAT16, PageConfig(Layout::ROW_MAJOR), memory_config, alignment));
 
     auto host_tensor = HostTensor::from_vector(std::move(input), spec);
@@ -368,7 +368,7 @@ TEST(VectorConversionTest, ExactSpecPredicateCustomAlignmentFromSpan) {
     auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
     auto spec = TensorSpec(
         shape,
-        experimental::tensor_layout_with_custom_alignment(
+        tt::tt_metal::experimental::tensor_layout_with_custom_alignment(
             DataType::BFLOAT16, PageConfig(Layout::ROW_MAJOR), memory_config, alignment));
 
     auto host_tensor = HostTensor::from_span<float>(std::span<float>(input), spec);
@@ -388,7 +388,7 @@ TEST(VectorConversionTest, ExactSpecShardedPackedSizes) {
     auto alignment = tt::tt_metal::Alignment({64, 64});
     auto spec = TensorSpec(
         shape,
-        experimental::tensor_layout_with_custom_alignment(
+        tt::tt_metal::experimental::tensor_layout_with_custom_alignment(
             DataType::BFLOAT16, PageConfig(Layout::ROW_MAJOR), memory_config, alignment));
 
     auto host_tensor = HostTensor::from_vector(input, spec);

--- a/tests/tt_metal/tt_metal/api/tensor/test_vector_conversion.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_vector_conversion.cpp
@@ -311,7 +311,7 @@ TEST(VectorConversionTest, ExactSpecPredicateCustomAlignment) {
     auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
     auto spec = TensorSpec(
         shape,
-        experimental::tensor_layout_with_custom_alignment(
+        tt::tt_metal::experimental::tensor_layout_with_custom_alignment(
             DataType::BFLOAT16, PageConfig(Layout::ROW_MAJOR), memory_config, alignment));
 
     auto host_tensor = HostTensor::from_vector(input, spec);
@@ -328,7 +328,7 @@ TEST(VectorConversionTest, ExactSpecPredicateCustomAlignmentRvalueVector) {
     auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
     auto spec = TensorSpec(
         shape,
-        experimental::tensor_layout_with_custom_alignment(
+        tt::tt_metal::experimental::tensor_layout_with_custom_alignment(
             DataType::BFLOAT16, PageConfig(Layout::ROW_MAJOR), memory_config, alignment));
 
     auto host_tensor = HostTensor::from_vector(std::move(input), spec);
@@ -344,7 +344,7 @@ TEST(VectorConversionTest, ExactSpecPredicateCustomAlignmentFromSpan) {
     auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
     auto spec = TensorSpec(
         shape,
-        experimental::tensor_layout_with_custom_alignment(
+        tt::tt_metal::experimental::tensor_layout_with_custom_alignment(
             DataType::BFLOAT16, PageConfig(Layout::ROW_MAJOR), memory_config, alignment));
 
     auto host_tensor = HostTensor::from_span<float>(std::span<float>(input), spec);
@@ -364,7 +364,7 @@ TEST(VectorConversionTest, ExactSpecShardedPackedSizes) {
     auto alignment = tt::tt_metal::Alignment({64, 64});
     auto spec = TensorSpec(
         shape,
-        experimental::tensor_layout_with_custom_alignment(
+        tt::tt_metal::experimental::tensor_layout_with_custom_alignment(
             DataType::BFLOAT16, PageConfig(Layout::ROW_MAJOR), memory_config, alignment));
 
     auto host_tensor = HostTensor::from_vector(input, spec);

--- a/tests/tt_metal/tt_metal/api/tensor/test_vector_conversion.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_vector_conversion.cpp
@@ -311,7 +311,7 @@ TEST(VectorConversionTest, ExactSpecPredicateCustomAlignment) {
     auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
     auto spec = TensorSpec(
         shape,
-        tensor_layout_with_custom_alignment(
+        experimental::tensor_layout_with_custom_alignment(
             DataType::BFLOAT16, PageConfig(Layout::ROW_MAJOR), memory_config, alignment));
 
     auto host_tensor = HostTensor::from_vector(input, spec);
@@ -328,7 +328,7 @@ TEST(VectorConversionTest, ExactSpecPredicateCustomAlignmentRvalueVector) {
     auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
     auto spec = TensorSpec(
         shape,
-        tensor_layout_with_custom_alignment(
+        experimental::tensor_layout_with_custom_alignment(
             DataType::BFLOAT16, PageConfig(Layout::ROW_MAJOR), memory_config, alignment));
 
     auto host_tensor = HostTensor::from_vector(std::move(input), spec);
@@ -344,7 +344,7 @@ TEST(VectorConversionTest, ExactSpecPredicateCustomAlignmentFromSpan) {
     auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
     auto spec = TensorSpec(
         shape,
-        tensor_layout_with_custom_alignment(
+        experimental::tensor_layout_with_custom_alignment(
             DataType::BFLOAT16, PageConfig(Layout::ROW_MAJOR), memory_config, alignment));
 
     auto host_tensor = HostTensor::from_span<float>(std::span<float>(input), spec);
@@ -364,7 +364,7 @@ TEST(VectorConversionTest, ExactSpecShardedPackedSizes) {
     auto alignment = tt::tt_metal::Alignment({64, 64});
     auto spec = TensorSpec(
         shape,
-        tensor_layout_with_custom_alignment(
+        experimental::tensor_layout_with_custom_alignment(
             DataType::BFLOAT16, PageConfig(Layout::ROW_MAJOR), memory_config, alignment));
 
     auto host_tensor = HostTensor::from_vector(input, spec);

--- a/tests/tt_metal/tt_metal/api/tensor/test_vector_conversion.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_vector_conversion.cpp
@@ -335,7 +335,7 @@ TEST(VectorConversionTest, ExactSpecPredicateCustomAlignment) {
     auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
     auto spec = TensorSpec(
         shape,
-        tensor_layout_with_custom_alignment(
+        experimental::tensor_layout_with_custom_alignment(
             DataType::BFLOAT16, PageConfig(Layout::ROW_MAJOR), memory_config, alignment));
 
     auto host_tensor = HostTensor::from_vector(input, spec);
@@ -352,7 +352,7 @@ TEST(VectorConversionTest, ExactSpecPredicateCustomAlignmentRvalueVector) {
     auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
     auto spec = TensorSpec(
         shape,
-        tensor_layout_with_custom_alignment(
+        experimental::tensor_layout_with_custom_alignment(
             DataType::BFLOAT16, PageConfig(Layout::ROW_MAJOR), memory_config, alignment));
 
     auto host_tensor = HostTensor::from_vector(std::move(input), spec);
@@ -368,7 +368,7 @@ TEST(VectorConversionTest, ExactSpecPredicateCustomAlignmentFromSpan) {
     auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
     auto spec = TensorSpec(
         shape,
-        tensor_layout_with_custom_alignment(
+        experimental::tensor_layout_with_custom_alignment(
             DataType::BFLOAT16, PageConfig(Layout::ROW_MAJOR), memory_config, alignment));
 
     auto host_tensor = HostTensor::from_span<float>(std::span<float>(input), spec);
@@ -388,7 +388,7 @@ TEST(VectorConversionTest, ExactSpecShardedPackedSizes) {
     auto alignment = tt::tt_metal::Alignment({64, 64});
     auto spec = TensorSpec(
         shape,
-        tensor_layout_with_custom_alignment(
+        experimental::tensor_layout_with_custom_alignment(
             DataType::BFLOAT16, PageConfig(Layout::ROW_MAJOR), memory_config, alignment));
 
     auto host_tensor = HostTensor::from_vector(input, spec);

--- a/tests/tt_metal/tt_metal/api/tensor/test_vector_conversion.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_vector_conversion.cpp
@@ -31,6 +31,7 @@
 #include <tt-metalium/experimental/tensor/mesh_tensor.hpp>
 #include <tt-metalium/mesh_device.hpp>
 #include "tt_metal/tt_metal/common/multi_device_fixture.hpp"
+#include <tt-metalium/experimental/tensor_layout_apis_with_custom_alignment.hpp>
 
 namespace tt::tt_metal {
 namespace {
@@ -332,8 +333,10 @@ TEST(VectorConversionTest, ExactSpecPredicateCustomAlignment) {
 
     auto alignment = tt::tt_metal::Alignment({64, 64});
     auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
-    auto spec =
-        TensorSpec(shape, TensorLayout(DataType::BFLOAT16, PageConfig(Layout::ROW_MAJOR), memory_config, alignment));
+    auto spec = TensorSpec(
+        shape,
+        tensor_layout_with_custom_alignment(
+            DataType::BFLOAT16, PageConfig(Layout::ROW_MAJOR), memory_config, alignment));
 
     auto host_tensor = HostTensor::from_vector(input, spec);
 
@@ -347,8 +350,10 @@ TEST(VectorConversionTest, ExactSpecPredicateCustomAlignmentRvalueVector) {
 
     auto alignment = tt::tt_metal::Alignment({64, 64});
     auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
-    auto spec =
-        TensorSpec(shape, TensorLayout(DataType::BFLOAT16, PageConfig(Layout::ROW_MAJOR), memory_config, alignment));
+    auto spec = TensorSpec(
+        shape,
+        tensor_layout_with_custom_alignment(
+            DataType::BFLOAT16, PageConfig(Layout::ROW_MAJOR), memory_config, alignment));
 
     auto host_tensor = HostTensor::from_vector(std::move(input), spec);
 
@@ -361,8 +366,10 @@ TEST(VectorConversionTest, ExactSpecPredicateCustomAlignmentFromSpan) {
 
     auto alignment = tt::tt_metal::Alignment({64, 64});
     auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
-    auto spec =
-        TensorSpec(shape, TensorLayout(DataType::BFLOAT16, PageConfig(Layout::ROW_MAJOR), memory_config, alignment));
+    auto spec = TensorSpec(
+        shape,
+        tensor_layout_with_custom_alignment(
+            DataType::BFLOAT16, PageConfig(Layout::ROW_MAJOR), memory_config, alignment));
 
     auto host_tensor = HostTensor::from_span<float>(std::span<float>(input), spec);
 
@@ -379,8 +386,10 @@ TEST(VectorConversionTest, ExactSpecShardedPackedSizes) {
         ShardSpec{CoreRangeSet({CoreRange({0, 0}, {0, 1})}), {32, 64}, ShardOrientation::ROW_MAJOR}};
     experimental::per_core_allocation::set_per_core_allocation(memory_config, true);
     auto alignment = tt::tt_metal::Alignment({64, 64});
-    auto spec =
-        TensorSpec(shape, TensorLayout(DataType::BFLOAT16, PageConfig(Layout::ROW_MAJOR), memory_config, alignment));
+    auto spec = TensorSpec(
+        shape,
+        tensor_layout_with_custom_alignment(
+            DataType::BFLOAT16, PageConfig(Layout::ROW_MAJOR), memory_config, alignment));
 
     auto host_tensor = HostTensor::from_vector(input, spec);
 

--- a/tt_metal/api/tt-metalium/experimental/distributed_tensor/distributed_tensor_apis.hpp
+++ b/tt_metal/api/tt-metalium/experimental/distributed_tensor/distributed_tensor_apis.hpp
@@ -175,4 +175,21 @@ std::vector<distributed::MeshCoordinate> enqueue_write_tensor(
 
 }  // namespace non_uniform_data_movement
 
+// ======================================================================================
+//                                  Utility functions
+// ======================================================================================
+
+namespace host_buffer {
+
+// TODO(#40348): This function has single device assumptions over inheritely multi-device constructs.
+HostBuffer get_host_buffer(const HostTensor& tensor);
+
+template <typename T>
+ttsl::Span<const T> get_as(const HostTensor& tensor);
+
+template <typename T>
+ttsl::Span<T> get_as(HostTensor& tensor);
+
+}  // namespace host_buffer
+
 }  // namespace tt::tt_metal

--- a/tt_metal/api/tt-metalium/experimental/tensor/spec/layout/tensor_layout.hpp
+++ b/tt_metal/api/tt-metalium/experimental/tensor/spec/layout/tensor_layout.hpp
@@ -31,26 +31,15 @@ using Strides = std::vector<size_t>;
 // shape) And provides information required to physically lay out the tensor in memory
 class TensorLayout {
 public:
-    TensorLayout(
-        DataType dtype,
-        const PageConfig& page_config,
-        const MemoryConfig& memory_config,
-        const Alignment& alignment = {});
+    // The Alignment is derived from page_config, dtype and memory_config; it is not a parameter.
+    // Overriding it is outside this API, see experimental/tensor_layout_apis_with_custom_alignment.hpp.
+    TensorLayout(DataType dtype, const PageConfig& page_config, const MemoryConfig& memory_config);
 
     ~TensorLayout();
     TensorLayout(const TensorLayout& other);
     TensorLayout& operator=(const TensorLayout& other);
     TensorLayout(TensorLayout&& other) noexcept;
     TensorLayout& operator=(TensorLayout&& other) noexcept;
-
-    // static method makes it easy to find and remove all of its usages in the codebase - that's why it is not a
-    // constructor
-    [[deprecated("Use of Padded Shape is deprecated")]] static TensorLayout fromPaddedShape(
-        DataType dtype,
-        const PageConfig& page_config,
-        const MemoryConfig& memory_config,
-        const tt::tt_metal::Shape& logical_shape,
-        const tt::tt_metal::Shape& padded_shape);
 
     Layout get_layout() const;
     Tile get_tile() const;
@@ -70,7 +59,6 @@ public:
 
     bool operator==(const TensorLayout& other) const;
     bool operator!=(const TensorLayout& other) const;
-
 
     static constexpr auto attribute_names = std::forward_as_tuple("dtype", "page_config", "memory_config", "alignment");
     std::tuple<const DataType&, const PageConfig&, const MemoryConfig&, const Alignment&> attribute_values() const;

--- a/tt_metal/api/tt-metalium/experimental/tensor/spec/layout/tensor_layout.hpp
+++ b/tt_metal/api/tt-metalium/experimental/tensor/spec/layout/tensor_layout.hpp
@@ -35,6 +35,10 @@ public:
     // Overriding it is outside this API, see experimental/tensor_layout_apis_with_custom_alignment.hpp.
     TensorLayout(DataType dtype, const PageConfig& page_config, const MemoryConfig& memory_config);
 
+    // Wraps an already-built TensorLayoutImpl. Used by experimental custom-alignment factories
+    // that construct TensorLayoutImpl with a caller-supplied Alignment.
+    explicit TensorLayout(std::unique_ptr<TensorLayoutImpl> impl);
+
     ~TensorLayout();
     TensorLayout(const TensorLayout& other);
     TensorLayout& operator=(const TensorLayout& other);

--- a/tt_metal/api/tt-metalium/experimental/tensor/tensor_apis.hpp
+++ b/tt_metal/api/tt-metalium/experimental/tensor/tensor_apis.hpp
@@ -70,20 +70,11 @@ HostTensor to_tensor_spec(const HostTensor& tensor, const TensorSpec& dest_spec)
 
 namespace host_buffer {
 
-// TODO(#40348): This function has single device assumptions over inheritely multi-device constructs.
-HostBuffer get_host_buffer(const HostTensor& tensor);
-
 template <typename T>
 ttsl::Span<const T> get_as(const HostBuffer& buffer);
 
 template <typename T>
 ttsl::Span<T> get_as(HostBuffer& buffer);
-
-template <typename T>
-ttsl::Span<const T> get_as(const HostTensor& tensor);
-
-template <typename T>
-ttsl::Span<T> get_as(HostTensor& tensor);
 
 }  // namespace host_buffer
 

--- a/tt_metal/api/tt-metalium/experimental/tensor_layout_apis_with_custom_alignment.hpp
+++ b/tt_metal/api/tt-metalium/experimental/tensor_layout_apis_with_custom_alignment.hpp
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <tt-metalium/shape.hpp>
+
+#include <tt-metalium/experimental/tensor/spec/layout/alignment.hpp>
+#include <tt-metalium/experimental/tensor/spec/layout/page_config.hpp>
+#include <tt-metalium/experimental/tensor/spec/layout/tensor_layout.hpp>
+#include <tt-metalium/experimental/tensor/spec/memory_config/memory_config.hpp>
+#include <tt-metalium/experimental/tensor/tensor_types.hpp>
+
+namespace tt::tt_metal {
+
+// ======================================================================================
+//                    TensorLayout APIs with a caller-supplied Alignment
+// ======================================================================================
+//
+// Outside the Runtime Tensor graduation surface. A TensorLayout derives its Alignment
+// from its PageConfig, DataType and MemoryConfig; that derived Alignment is the only one
+// Runtime intends to support. These APIs let a caller override it with an arbitrary
+// Alignment, which is then merged with the derived one by rounding each dimension up.
+//
+// These functions are in the experimental stage because a caller-supplied Alignment is a
+// way to spell a padded shape without saying so: it decouples the physical footprint of
+// a tensor from its logical shape for reasons the Tensor itself cannot describe. New code
+// should let TensorLayout derive its own Alignment.
+
+/**
+ * Same as constructing a TensorLayout, but the derived Alignment is merged with
+ * **alignment** — each dimension of **alignment** is rounded up to a multiple of the
+ * corresponding derived dimension, right-aligned when the ranks differ.
+ *
+ * pre-conditions:
+ * - **alignment** has rank <= 2, or **memory_config** is interleaved.
+ * - **alignment** is compatible with **page_config** / **dtype** / **memory_config**
+ *   (same validation the derived Alignment is subject to).
+ */
+TensorLayout tensor_layout_with_custom_alignment(
+    DataType dtype, const PageConfig& page_config, const MemoryConfig& memory_config, const Alignment& alignment);
+
+/**
+ * Construct a TensorLayout whose padded shape for **logical_shape** reproduces
+ * **padded_shape**, by reverse-engineering an Alignment from the two shapes.
+ *
+ * This is the bridge for call sites that still carry a legacy padded shape around
+ * instead of a logical shape plus a layout.
+ *
+ * pre-conditions:
+ * - If **memory_config** is sharded, **logical_shape** and **padded_shape** may only
+ *   differ in their last two dimensions.
+ */
+[[deprecated("Use of Padded Shape is deprecated")]] TensorLayout tensor_layout_from_padded_shape(
+    DataType dtype,
+    const PageConfig& page_config,
+    const MemoryConfig& memory_config,
+    const tt::tt_metal::Shape& logical_shape,
+    const tt::tt_metal::Shape& padded_shape);
+
+}  // namespace tt::tt_metal

--- a/tt_metal/api/tt-metalium/experimental/tensor_layout_apis_with_custom_alignment.hpp
+++ b/tt_metal/api/tt-metalium/experimental/tensor_layout_apis_with_custom_alignment.hpp
@@ -12,7 +12,7 @@
 #include <tt-metalium/experimental/tensor/spec/memory_config/memory_config.hpp>
 #include <tt-metalium/experimental/tensor/tensor_types.hpp>
 
-namespace tt::tt_metal {
+namespace tt::tt_metal::experimental {
 
 // ======================================================================================
 //                    TensorLayout APIs with a caller-supplied Alignment
@@ -59,4 +59,4 @@ TensorLayout tensor_layout_with_custom_alignment(
     const tt::tt_metal::Shape& logical_shape,
     const tt::tt_metal::Shape& padded_shape);
 
-}  // namespace tt::tt_metal
+}  // namespace tt::tt_metal::experimental

--- a/tt_metal/impl/sources.cmake
+++ b/tt_metal/impl/sources.cmake
@@ -143,6 +143,7 @@ set(IMPL_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/tensor/spec/layout/layout.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/tensor/spec/layout/page_config.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/tensor/spec/layout/tensor_layout.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/tensor/spec/layout/tensor_layout_apis_with_custom_alignment.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/tensor/spec/memory_config/memory_config.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/tensor/topology/distributed_tensor_configs.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/tensor/topology/tensor_topology.cpp

--- a/tt_metal/impl/tensor/distributed_tensor_apis.cpp
+++ b/tt_metal/impl/tensor/distributed_tensor_apis.cpp
@@ -16,6 +16,7 @@
 #include <tt-metalium/mesh_device.hpp>
 #include "tt_metal/distributed/pinned_memory_cache.hpp"
 #include "tt_metal/distributed/mesh_device_view_impl.hpp"
+#include <tt-metalium/experimental/tensor_layout_apis_with_custom_alignment.hpp>
 
 namespace tt::tt_metal {
 
@@ -178,7 +179,7 @@ std::pair<MeshTensor, std::vector<distributed::MeshCoordinate>> enqueue_write_te
         const auto& old_spec = host_tensor.tensor_spec();
         tensor_spec_overriden_memory_config = TensorSpec(
             old_spec.logical_shape(),
-            TensorLayout(
+            tensor_layout_with_custom_alignment(
                 old_spec.tensor_layout().get_data_type(),
                 old_spec.tensor_layout().get_page_config(),
                 *memory_config,
@@ -260,7 +261,7 @@ void h2d_as_replicate_tensor_on_1x1_mesh(
         std::move(*mesh_buffer),
         TensorSpec(
             old_spec.logical_shape(),
-            TensorLayout(
+            tensor_layout_with_custom_alignment(
                 old_spec.tensor_layout().get_data_type(),
                 old_spec.tensor_layout().get_page_config(),
                 device_tensor.memory_config(),
@@ -364,7 +365,7 @@ std::vector<distributed::MeshCoordinate> enqueue_write_tensor(
         std::move(*mesh_buffer),
         TensorSpec(
             old_spec.logical_shape(),
-            TensorLayout(
+            tensor_layout_with_custom_alignment(
                 old_spec.tensor_layout().get_data_type(),
                 old_spec.tensor_layout().get_page_config(),
                 device_tensor.memory_config(),

--- a/tt_metal/impl/tensor/distributed_tensor_apis.cpp
+++ b/tt_metal/impl/tensor/distributed_tensor_apis.cpp
@@ -185,7 +185,7 @@ std::pair<MeshTensor, std::vector<distributed::MeshCoordinate>> enqueue_write_te
         const auto& old_spec = host_tensor.tensor_spec();
         tensor_spec_overriden_memory_config = TensorSpec(
             old_spec.logical_shape(),
-            tensor_layout_with_custom_alignment(
+            experimental::tensor_layout_with_custom_alignment(
                 old_spec.tensor_layout().get_data_type(),
                 old_spec.tensor_layout().get_page_config(),
                 *memory_config,
@@ -268,7 +268,7 @@ void h2d_as_replicate_tensor_on_1x1_mesh(
         std::move(*mesh_buffer),
         TensorSpec(
             old_spec.logical_shape(),
-            tensor_layout_with_custom_alignment(
+            experimental::tensor_layout_with_custom_alignment(
                 old_spec.tensor_layout().get_data_type(),
                 old_spec.tensor_layout().get_page_config(),
                 device_tensor.memory_config(),
@@ -372,7 +372,7 @@ std::vector<distributed::MeshCoordinate> enqueue_write_tensor(
         std::move(*mesh_buffer),
         TensorSpec(
             old_spec.logical_shape(),
-            tensor_layout_with_custom_alignment(
+            experimental::tensor_layout_with_custom_alignment(
                 old_spec.tensor_layout().get_data_type(),
                 old_spec.tensor_layout().get_page_config(),
                 device_tensor.memory_config(),

--- a/tt_metal/impl/tensor/distributed_tensor_apis.cpp
+++ b/tt_metal/impl/tensor/distributed_tensor_apis.cpp
@@ -185,7 +185,7 @@ std::pair<MeshTensor, std::vector<distributed::MeshCoordinate>> enqueue_write_te
         const auto& old_spec = host_tensor.tensor_spec();
         tensor_spec_overriden_memory_config = TensorSpec(
             old_spec.logical_shape(),
-            tensor_layout_with_custom_alignment(
+            experimental::tensor_layout_with_custom_alignment(
                 old_spec.tensor_layout().get_data_type(),
                 old_spec.tensor_layout().get_page_config(),
                 *memory_config,
@@ -267,7 +267,7 @@ void h2d_as_replicate_tensor_on_1x1_mesh(
         std::move(*mesh_buffer),
         TensorSpec(
             old_spec.logical_shape(),
-            tensor_layout_with_custom_alignment(
+            experimental::tensor_layout_with_custom_alignment(
                 old_spec.tensor_layout().get_data_type(),
                 old_spec.tensor_layout().get_page_config(),
                 device_tensor.memory_config(),
@@ -371,7 +371,7 @@ std::vector<distributed::MeshCoordinate> enqueue_write_tensor(
         std::move(*mesh_buffer),
         TensorSpec(
             old_spec.logical_shape(),
-            tensor_layout_with_custom_alignment(
+            experimental::tensor_layout_with_custom_alignment(
                 old_spec.tensor_layout().get_data_type(),
                 old_spec.tensor_layout().get_page_config(),
                 device_tensor.memory_config(),

--- a/tt_metal/impl/tensor/distributed_tensor_apis.cpp
+++ b/tt_metal/impl/tensor/distributed_tensor_apis.cpp
@@ -5,18 +5,24 @@
 #include <algorithm>
 #include <cstring>
 #include <functional>
+#include <type_traits>
 #include <unordered_set>
+#include <vector>
 
 #include "host_tensor_impl.hpp"
 #include "mesh_tensor_impl.hpp"
 #include "tensor_impl.hpp"
 
+#include <tt-metalium/bfloat16.hpp>
 #include <tt-metalium/experimental/distributed_tensor/distributed_tensor_apis.hpp>
 #include <tt-metalium/experimental/pinned_memory.hpp>
+#include <tt-metalium/experimental/tensor/tensor_types.hpp>
+#include <tt-metalium/host_buffer.hpp>
 #include <tt-metalium/mesh_device.hpp>
 #include "tt_metal/distributed/pinned_memory_cache.hpp"
 #include "tt_metal/distributed/mesh_device_view_impl.hpp"
 #include <tt-metalium/experimental/tensor_layout_apis_with_custom_alignment.hpp>
+#include <tt_stl/span.hpp>
 
 namespace tt::tt_metal {
 
@@ -377,5 +383,85 @@ std::vector<distributed::MeshCoordinate> enqueue_write_tensor(
 }
 
 }  // namespace non_uniform_data_movement
+
+// ======================================================================================
+//                                  Utility functions
+// ======================================================================================
+
+namespace host_buffer {
+
+namespace {
+namespace CMAKE_UNIQUE_NAMESPACE {
+
+template <typename T>
+void validate_datatype(DataType dtype) {
+    using BaseType = std::remove_cvref_t<T>;
+    if constexpr (std::is_same_v<BaseType, uint32_t>) {
+        TT_FATAL(
+            dtype == DataType::UINT32 or dtype == DataType::BFLOAT8_B or dtype == DataType::BFLOAT4_B,
+            "Incorrect data type {}",
+            dtype);
+    } else if constexpr (std::is_same_v<BaseType, int32_t>) {
+        TT_FATAL(dtype == DataType::INT32, "Incorrect data type {}", dtype);
+    } else if constexpr (std::is_same_v<BaseType, int8_t>) {
+        TT_FATAL(dtype == DataType::INT8, "Incorrect data type {}", dtype);
+    } else if constexpr (std::is_same_v<BaseType, float>) {
+        TT_FATAL(dtype == DataType::FLOAT32, "Incorrect data type {}", dtype);
+    } else if constexpr (std::is_same_v<BaseType, bfloat16>) {
+        TT_FATAL(dtype == DataType::BFLOAT16, "Incorrect data type {}", dtype);
+    } else if constexpr (std::is_same_v<BaseType, uint16_t>) {
+        TT_FATAL(dtype == DataType::UINT16, "Incorrect data type {}", dtype);
+    } else if constexpr (std::is_same_v<BaseType, uint8_t>) {
+        TT_FATAL(dtype == DataType::UINT8, "Incorrect data type {}", dtype);
+    } else {
+        static_assert(sizeof(BaseType) == 0, "Unsupported DataType");
+    }
+}
+
+}  // namespace CMAKE_UNIQUE_NAMESPACE
+}  // namespace
+
+HostBuffer get_host_buffer(const HostTensor& tensor) {
+    std::vector<HostBuffer> buffers;
+    tensor.buffer().apply([&buffers](const HostBuffer& shard) { buffers.push_back(shard); });
+    TT_FATAL(
+        buffers.size() == 1,
+        "Can't get a single buffer from host storage distributed over mesh shape {}",
+        tensor.buffer().shape());
+    return buffers.front();
+}
+
+template <typename T>
+ttsl::Span<const T> get_as(const HostTensor& tensor) {
+    CMAKE_UNIQUE_NAMESPACE::validate_datatype<T>(tensor.dtype());
+    HostBuffer buffer = get_host_buffer(tensor);
+    return buffer.template view_as<T>();
+}
+
+template <typename T>
+ttsl::Span<T> get_as(HostTensor& tensor) {
+    CMAKE_UNIQUE_NAMESPACE::validate_datatype<T>(tensor.dtype());
+    HostBuffer buffer = get_host_buffer(tensor);
+    return buffer.template view_as<T>();
+}
+
+// Explicit template instantiations
+#define INSTANTIATE_HOST_BUFFER_FUNCTIONS(T)                         \
+    template ttsl::Span<const T> get_as<T>(const HostTensor&);       \
+    template ttsl::Span<const T> get_as<const T>(const HostTensor&); \
+    template ttsl::Span<T> get_as<T>(HostTensor&);                   \
+    template ttsl::Span<const T> get_as<const T>(HostTensor&);
+
+INSTANTIATE_HOST_BUFFER_FUNCTIONS(uint32_t)
+INSTANTIATE_HOST_BUFFER_FUNCTIONS(int32_t)
+INSTANTIATE_HOST_BUFFER_FUNCTIONS(float)
+INSTANTIATE_HOST_BUFFER_FUNCTIONS(bfloat16)
+INSTANTIATE_HOST_BUFFER_FUNCTIONS(uint16_t)
+INSTANTIATE_HOST_BUFFER_FUNCTIONS(uint8_t)
+INSTANTIATE_HOST_BUFFER_FUNCTIONS(int8_t)
+
+#undef INSTANTIATE_HOST_BUFFER_FUNCTIONS
+
+}  // namespace host_buffer
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/tensor/distributed_tensor_apis.cpp
+++ b/tt_metal/impl/tensor/distributed_tensor_apis.cpp
@@ -5,18 +5,24 @@
 #include <algorithm>
 #include <cstring>
 #include <functional>
+#include <type_traits>
 #include <unordered_set>
+#include <vector>
 
 #include "host_tensor_impl.hpp"
 #include "mesh_tensor_impl.hpp"
 #include "tensor_impl.hpp"
 
+#include <tt-metalium/bfloat16.hpp>
 #include <tt-metalium/experimental/distributed_tensor/distributed_tensor_apis.hpp>
 #include <tt-metalium/experimental/pinned_memory.hpp>
+#include <tt-metalium/experimental/tensor/tensor_types.hpp>
+#include <tt-metalium/host_buffer.hpp>
 #include <tt-metalium/mesh_device.hpp>
 #include "tt_metal/distributed/pinned_memory_cache.hpp"
 #include "tt_metal/distributed/mesh_device_view_impl.hpp"
 #include <tt-metalium/experimental/tensor_layout_apis_with_custom_alignment.hpp>
+#include <tt_stl/span.hpp>
 
 namespace tt::tt_metal {
 
@@ -376,5 +382,82 @@ std::vector<distributed::MeshCoordinate> enqueue_write_tensor(
 }
 
 }  // namespace non_uniform_data_movement
+
+// ======================================================================================
+//                                  Utility functions
+// ======================================================================================
+
+namespace host_buffer {
+
+namespace {
+namespace CMAKE_UNIQUE_NAMESPACE {
+
+template <typename T>
+void validate_datatype(DataType dtype) {
+    using BaseType = std::remove_cvref_t<T>;
+    if constexpr (std::is_same_v<BaseType, uint32_t>) {
+        TT_FATAL(
+            dtype == DataType::UINT32 or dtype == DataType::BFLOAT8_B or dtype == DataType::BFLOAT4_B,
+            "Incorrect data type {}",
+            dtype);
+    } else if constexpr (std::is_same_v<BaseType, int32_t>) {
+        TT_FATAL(dtype == DataType::INT32, "Incorrect data type {}", dtype);
+    } else if constexpr (std::is_same_v<BaseType, float>) {
+        TT_FATAL(dtype == DataType::FLOAT32, "Incorrect data type {}", dtype);
+    } else if constexpr (std::is_same_v<BaseType, bfloat16>) {
+        TT_FATAL(dtype == DataType::BFLOAT16, "Incorrect data type {}", dtype);
+    } else if constexpr (std::is_same_v<BaseType, uint16_t>) {
+        TT_FATAL(dtype == DataType::UINT16, "Incorrect data type {}", dtype);
+    } else if constexpr (std::is_same_v<BaseType, uint8_t>) {
+        TT_FATAL(dtype == DataType::UINT8, "Incorrect data type {}", dtype);
+    } else {
+        static_assert(sizeof(BaseType) == 0, "Unsupported DataType");
+    }
+}
+
+}  // namespace CMAKE_UNIQUE_NAMESPACE
+}  // namespace
+
+HostBuffer get_host_buffer(const HostTensor& tensor) {
+    std::vector<HostBuffer> buffers;
+    tensor.buffer().apply([&buffers](const HostBuffer& shard) { buffers.push_back(shard); });
+    TT_FATAL(
+        buffers.size() == 1,
+        "Can't get a single buffer from host storage distributed over mesh shape {}",
+        tensor.buffer().shape());
+    return buffers.front();
+}
+
+template <typename T>
+ttsl::Span<const T> get_as(const HostTensor& tensor) {
+    CMAKE_UNIQUE_NAMESPACE::validate_datatype<T>(tensor.dtype());
+    HostBuffer buffer = get_host_buffer(tensor);
+    return buffer.template view_as<T>();
+}
+
+template <typename T>
+ttsl::Span<T> get_as(HostTensor& tensor) {
+    CMAKE_UNIQUE_NAMESPACE::validate_datatype<T>(tensor.dtype());
+    HostBuffer buffer = get_host_buffer(tensor);
+    return buffer.template view_as<T>();
+}
+
+// Explicit template instantiations
+#define INSTANTIATE_HOST_BUFFER_FUNCTIONS(T)                         \
+    template ttsl::Span<const T> get_as<T>(const HostTensor&);       \
+    template ttsl::Span<const T> get_as<const T>(const HostTensor&); \
+    template ttsl::Span<T> get_as<T>(HostTensor&);                   \
+    template ttsl::Span<const T> get_as<const T>(HostTensor&);
+
+INSTANTIATE_HOST_BUFFER_FUNCTIONS(uint32_t)
+INSTANTIATE_HOST_BUFFER_FUNCTIONS(int32_t)
+INSTANTIATE_HOST_BUFFER_FUNCTIONS(float)
+INSTANTIATE_HOST_BUFFER_FUNCTIONS(bfloat16)
+INSTANTIATE_HOST_BUFFER_FUNCTIONS(uint16_t)
+INSTANTIATE_HOST_BUFFER_FUNCTIONS(uint8_t)
+
+#undef INSTANTIATE_HOST_BUFFER_FUNCTIONS
+
+}  // namespace host_buffer
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/tensor/distributed_tensor_apis.cpp
+++ b/tt_metal/impl/tensor/distributed_tensor_apis.cpp
@@ -16,6 +16,7 @@
 #include <tt-metalium/mesh_device.hpp>
 #include "tt_metal/distributed/pinned_memory_cache.hpp"
 #include "tt_metal/distributed/mesh_device_view_impl.hpp"
+#include <tt-metalium/experimental/tensor_layout_apis_with_custom_alignment.hpp>
 
 namespace tt::tt_metal {
 
@@ -178,7 +179,7 @@ std::pair<MeshTensor, std::vector<distributed::MeshCoordinate>> enqueue_write_te
         const auto& old_spec = host_tensor.tensor_spec();
         tensor_spec_overriden_memory_config = TensorSpec(
             old_spec.logical_shape(),
-            TensorLayout(
+            tensor_layout_with_custom_alignment(
                 old_spec.tensor_layout().get_data_type(),
                 old_spec.tensor_layout().get_page_config(),
                 *memory_config,
@@ -261,7 +262,7 @@ void h2d_as_replicate_tensor_on_1x1_mesh(
         std::move(*mesh_buffer),
         TensorSpec(
             old_spec.logical_shape(),
-            TensorLayout(
+            tensor_layout_with_custom_alignment(
                 old_spec.tensor_layout().get_data_type(),
                 old_spec.tensor_layout().get_page_config(),
                 device_tensor.memory_config(),
@@ -365,7 +366,7 @@ std::vector<distributed::MeshCoordinate> enqueue_write_tensor(
         std::move(*mesh_buffer),
         TensorSpec(
             old_spec.logical_shape(),
-            TensorLayout(
+            tensor_layout_with_custom_alignment(
                 old_spec.tensor_layout().get_data_type(),
                 old_spec.tensor_layout().get_page_config(),
                 device_tensor.memory_config(),

--- a/tt_metal/impl/tensor/host_pad_apis.cpp
+++ b/tt_metal/impl/tensor/host_pad_apis.cpp
@@ -19,6 +19,7 @@
 
 #include <tt_stl/small_vector.hpp>
 #include <tt_stl/span.hpp>
+#include <tt-metalium/experimental/tensor_layout_apis_with_custom_alignment.hpp>
 
 #include "tensor_impl.hpp"
 
@@ -49,7 +50,7 @@ HostTensor pad_bfloat8_b(
         std::move(input_float_buffer),
         TensorSpec(
             tensor.logical_shape(),
-            TensorLayout::fromPaddedShape(
+            tensor_layout_from_padded_shape(
                 DataType::FLOAT32,
                 PageConfig(tensor.layout(), tile),
                 MemoryConfig{},
@@ -65,7 +66,7 @@ HostTensor pad_bfloat8_b(
     auto output_uint32_buffer = HostBuffer(std::move(output_packed_data));
     TensorSpec output_spec(
         float_tensor.logical_shape(),
-        TensorLayout::fromPaddedShape(
+        tensor_layout_from_padded_shape(
             DataType::BFLOAT8_B,
             tensor.tensor_spec().page_config(),
             MemoryConfig{},
@@ -93,7 +94,7 @@ HostTensor unpad_bfloat8_b(
         std::move(input_float_buffer),
         TensorSpec(
             tensor.logical_shape(),
-            TensorLayout::fromPaddedShape(
+            tensor_layout_from_padded_shape(
                 DataType::FLOAT32,
                 PageConfig(tensor.layout(), tile),
                 MemoryConfig{},
@@ -111,7 +112,7 @@ HostTensor unpad_bfloat8_b(
         std::move(output_uint32_buffer),
         TensorSpec(
             float_tensor.logical_shape(),
-            TensorLayout::fromPaddedShape(
+            tensor_layout_from_padded_shape(
                 DataType::BFLOAT8_B,
                 PageConfig(tensor.layout(), tile),
                 MemoryConfig{},
@@ -138,7 +139,7 @@ HostTensor pad_bfloat4_b(
         std::move(input_float_buffer),
         TensorSpec(
             tensor.logical_shape(),
-            TensorLayout::fromPaddedShape(
+            tensor_layout_from_padded_shape(
                 DataType::FLOAT32,
                 PageConfig(tensor.layout(), tile),
                 MemoryConfig{},
@@ -154,7 +155,7 @@ HostTensor pad_bfloat4_b(
     auto output_uint32_buffer = HostBuffer(std::move(output_packed_data));
     TensorSpec output_spec(
         float_tensor.logical_shape(),
-        TensorLayout::fromPaddedShape(
+        tensor_layout_from_padded_shape(
             DataType::BFLOAT4_B,
             tensor.tensor_spec().page_config(),
             MemoryConfig{},
@@ -181,7 +182,7 @@ HostTensor unpad_bfloat4_b(
         std::move(input_float_buffer),
         TensorSpec(
             tensor.logical_shape(),
-            TensorLayout::fromPaddedShape(
+            tensor_layout_from_padded_shape(
                 DataType::FLOAT32,
                 PageConfig(tensor.layout(), tile),
                 MemoryConfig{},
@@ -199,7 +200,7 @@ HostTensor unpad_bfloat4_b(
         std::move(output_uint32_buffer),
         TensorSpec(
             float_tensor.logical_shape(),
-            TensorLayout::fromPaddedShape(
+            tensor_layout_from_padded_shape(
                 DataType::BFLOAT4_B,
                 PageConfig(tensor.layout(), tile),
                 MemoryConfig{},
@@ -299,7 +300,7 @@ HostTensor pad_impl(
         std::move(transformed_buffer),
         TensorSpec(
             tensor.logical_shape(),
-            TensorLayout::fromPaddedShape(
+            tensor_layout_from_padded_shape(
                 tensor.dtype(),
                 PageConfig(tensor.layout(), tile),
                 MemoryConfig{},

--- a/tt_metal/impl/tensor/host_pad_apis.cpp
+++ b/tt_metal/impl/tensor/host_pad_apis.cpp
@@ -50,7 +50,7 @@ HostTensor pad_bfloat8_b(
         std::move(input_float_buffer),
         TensorSpec(
             tensor.logical_shape(),
-            tensor_layout_from_padded_shape(
+            experimental::tensor_layout_from_padded_shape(
                 DataType::FLOAT32,
                 PageConfig(tensor.layout(), tile),
                 MemoryConfig{},
@@ -66,7 +66,7 @@ HostTensor pad_bfloat8_b(
     auto output_uint32_buffer = HostBuffer(std::move(output_packed_data));
     TensorSpec output_spec(
         float_tensor.logical_shape(),
-        tensor_layout_from_padded_shape(
+        experimental::tensor_layout_from_padded_shape(
             DataType::BFLOAT8_B,
             tensor.tensor_spec().page_config(),
             MemoryConfig{},
@@ -94,7 +94,7 @@ HostTensor unpad_bfloat8_b(
         std::move(input_float_buffer),
         TensorSpec(
             tensor.logical_shape(),
-            tensor_layout_from_padded_shape(
+            experimental::tensor_layout_from_padded_shape(
                 DataType::FLOAT32,
                 PageConfig(tensor.layout(), tile),
                 MemoryConfig{},
@@ -112,7 +112,7 @@ HostTensor unpad_bfloat8_b(
         std::move(output_uint32_buffer),
         TensorSpec(
             float_tensor.logical_shape(),
-            tensor_layout_from_padded_shape(
+            experimental::tensor_layout_from_padded_shape(
                 DataType::BFLOAT8_B,
                 PageConfig(tensor.layout(), tile),
                 MemoryConfig{},
@@ -139,7 +139,7 @@ HostTensor pad_bfloat4_b(
         std::move(input_float_buffer),
         TensorSpec(
             tensor.logical_shape(),
-            tensor_layout_from_padded_shape(
+            experimental::tensor_layout_from_padded_shape(
                 DataType::FLOAT32,
                 PageConfig(tensor.layout(), tile),
                 MemoryConfig{},
@@ -155,7 +155,7 @@ HostTensor pad_bfloat4_b(
     auto output_uint32_buffer = HostBuffer(std::move(output_packed_data));
     TensorSpec output_spec(
         float_tensor.logical_shape(),
-        tensor_layout_from_padded_shape(
+        experimental::tensor_layout_from_padded_shape(
             DataType::BFLOAT4_B,
             tensor.tensor_spec().page_config(),
             MemoryConfig{},
@@ -182,7 +182,7 @@ HostTensor unpad_bfloat4_b(
         std::move(input_float_buffer),
         TensorSpec(
             tensor.logical_shape(),
-            tensor_layout_from_padded_shape(
+            experimental::tensor_layout_from_padded_shape(
                 DataType::FLOAT32,
                 PageConfig(tensor.layout(), tile),
                 MemoryConfig{},
@@ -200,7 +200,7 @@ HostTensor unpad_bfloat4_b(
         std::move(output_uint32_buffer),
         TensorSpec(
             float_tensor.logical_shape(),
-            tensor_layout_from_padded_shape(
+            experimental::tensor_layout_from_padded_shape(
                 DataType::BFLOAT4_B,
                 PageConfig(tensor.layout(), tile),
                 MemoryConfig{},
@@ -300,7 +300,7 @@ HostTensor pad_impl(
         std::move(transformed_buffer),
         TensorSpec(
             tensor.logical_shape(),
-            tensor_layout_from_padded_shape(
+            experimental::tensor_layout_from_padded_shape(
                 tensor.dtype(),
                 PageConfig(tensor.layout(), tile),
                 MemoryConfig{},

--- a/tt_metal/impl/tensor/host_tensor_factory.cpp
+++ b/tt_metal/impl/tensor/host_tensor_factory.cpp
@@ -20,6 +20,7 @@
 #include <tt_stl/fmt.hpp>
 
 #include <algorithm>
+#include <tt-metalium/experimental/tensor_layout_apis_with_custom_alignment.hpp>
 
 namespace tt::tt_metal {
 
@@ -31,7 +32,8 @@ HostTensor from_span_impl(std::span<const T> buffer, const TensorSpec& spec, T p
     auto buffer_dtype = convert_to_data_type<T>();
     auto buffer_spec = TensorSpec(
         spec.logical_shape(),
-        TensorLayout(buffer_dtype, spec.page_config(), spec.memory_config(), spec.tensor_layout().get_alignment()));
+        tensor_layout_with_custom_alignment(
+            buffer_dtype, spec.page_config(), spec.memory_config(), spec.tensor_layout().get_alignment()));
 
     size_t volume = spec.logical_shape().volume();
 
@@ -100,7 +102,8 @@ HostTensor host_tensor_from_vector_with_pad_value(std::vector<T>&& buffer, Tenso
     auto buffer_dtype = convert_to_data_type<T>();
     auto buffer_spec = TensorSpec(
         spec.logical_shape(),
-        TensorLayout(buffer_dtype, spec.page_config(), spec.memory_config(), spec.tensor_layout().get_alignment()));
+        tensor_layout_with_custom_alignment(
+            buffer_dtype, spec.page_config(), spec.memory_config(), spec.tensor_layout().get_alignment()));
 
     auto host_buffer =
         buffer_spec.layout() == Layout::ROW_MAJOR && buffer_spec.logical_2d_shape() == buffer_spec.physical_shape()

--- a/tt_metal/impl/tensor/host_tensor_factory.cpp
+++ b/tt_metal/impl/tensor/host_tensor_factory.cpp
@@ -7,6 +7,7 @@
 #include <tt-metalium/bfloat8.hpp>
 #include <tt-metalium/distributed_host_buffer.hpp>
 #include <tt-metalium/experimental/tensor/host_tensor.hpp>
+#include <tt-metalium/experimental/distributed_tensor/distributed_tensor_apis.hpp>
 #include <tt-metalium/experimental/tensor/tensor_apis.hpp>
 #include <tt-metalium/experimental/tensor_apis_with_pad_values.hpp>
 #include <tt-metalium/host_buffer.hpp>

--- a/tt_metal/impl/tensor/host_tensor_factory.cpp
+++ b/tt_metal/impl/tensor/host_tensor_factory.cpp
@@ -33,7 +33,7 @@ HostTensor from_span_impl(std::span<const T> buffer, const TensorSpec& spec, T p
     auto buffer_dtype = convert_to_data_type<T>();
     auto buffer_spec = TensorSpec(
         spec.logical_shape(),
-        tensor_layout_with_custom_alignment(
+        experimental::tensor_layout_with_custom_alignment(
             buffer_dtype, spec.page_config(), spec.memory_config(), spec.tensor_layout().get_alignment()));
 
     size_t volume = spec.logical_shape().volume();
@@ -103,7 +103,7 @@ HostTensor host_tensor_from_vector_with_pad_value(std::vector<T>&& buffer, Tenso
     auto buffer_dtype = convert_to_data_type<T>();
     auto buffer_spec = TensorSpec(
         spec.logical_shape(),
-        tensor_layout_with_custom_alignment(
+        experimental::tensor_layout_with_custom_alignment(
             buffer_dtype, spec.page_config(), spec.memory_config(), spec.tensor_layout().get_alignment()));
 
     auto host_buffer =

--- a/tt_metal/impl/tensor/host_to_tensor_spec_apis.cpp
+++ b/tt_metal/impl/tensor/host_to_tensor_spec_apis.cpp
@@ -17,6 +17,7 @@
 #include <tt-metalium/host_buffer.hpp>
 
 #include <tt_stl/span.hpp>
+#include <tt-metalium/experimental/tensor_layout_apis_with_custom_alignment.hpp>
 
 #include "tensor_impl.hpp"
 
@@ -129,7 +130,7 @@ HostTensor host_tensor_to_tensor_spec_with_pad_value(
     const TensorSpec& decode_spec = source_for_decode.tensor_spec();
     const TensorSpec working_spec(
         dest_spec.logical_shape(),
-        TensorLayout(
+        tensor_layout_with_custom_alignment(
             working_encode_dtype,
             dest_spec.page_config(),
             dest_spec.memory_config(),

--- a/tt_metal/impl/tensor/host_to_tensor_spec_apis.cpp
+++ b/tt_metal/impl/tensor/host_to_tensor_spec_apis.cpp
@@ -130,7 +130,7 @@ HostTensor host_tensor_to_tensor_spec_with_pad_value(
     const TensorSpec& decode_spec = source_for_decode.tensor_spec();
     const TensorSpec working_spec(
         dest_spec.logical_shape(),
-        tensor_layout_with_custom_alignment(
+        experimental::tensor_layout_with_custom_alignment(
             working_encode_dtype,
             dest_spec.page_config(),
             dest_spec.memory_config(),

--- a/tt_metal/impl/tensor/host_to_tensor_spec_apis.cpp
+++ b/tt_metal/impl/tensor/host_to_tensor_spec_apis.cpp
@@ -17,6 +17,7 @@
 #include <tt-metalium/host_buffer.hpp>
 
 #include <tt_stl/span.hpp>
+#include <tt-metalium/experimental/tensor_layout_apis_with_custom_alignment.hpp>
 
 #include "tensor_impl.hpp"
 
@@ -130,7 +131,7 @@ HostTensor host_tensor_to_tensor_spec_with_pad_value(
     const TensorSpec& decode_spec = source_for_decode.tensor_spec();
     const TensorSpec working_spec(
         dest_spec.logical_shape(),
-        TensorLayout(
+        tensor_layout_with_custom_alignment(
             working_encode_dtype,
             dest_spec.page_config(),
             dest_spec.memory_config(),

--- a/tt_metal/impl/tensor/host_to_tensor_spec_apis.cpp
+++ b/tt_metal/impl/tensor/host_to_tensor_spec_apis.cpp
@@ -131,7 +131,7 @@ HostTensor host_tensor_to_tensor_spec_with_pad_value(
     const TensorSpec& decode_spec = source_for_decode.tensor_spec();
     const TensorSpec working_spec(
         dest_spec.logical_shape(),
-        tensor_layout_with_custom_alignment(
+        experimental::tensor_layout_with_custom_alignment(
             working_encode_dtype,
             dest_spec.page_config(),
             dest_spec.memory_config(),

--- a/tt_metal/impl/tensor/spec/layout/tensor_layout.cpp
+++ b/tt_metal/impl/tensor/spec/layout/tensor_layout.cpp
@@ -26,92 +26,6 @@ size_t round_up(size_t value, size_t multiple) {
     return ((value + multiple - 1) / multiple) * multiple;
 };
 
-std::tuple<bool, bool> get_inner_hw_overpadded(
-    const tt::tt_metal::Shape& logical_shape,
-    const tt::tt_metal::Shape& legacy_padded_shape,
-    const PageConfig& page_config) {
-    if (page_config.get_layout() == Layout::TILE) {
-        const auto& tile = page_config.get_tile();
-        const uint32_t min_padded_h = round_up(logical_shape[-2], tile.get_height());
-        const uint32_t min_padded_w = round_up(logical_shape[-1], tile.get_width());
-        return {legacy_padded_shape[-2] > min_padded_h, legacy_padded_shape[-1] > min_padded_w};
-    }
-    // Always true for non-tile layouts; alignment is the standard padding mechanism for row-major tensors
-    return {true, true};
-}
-
-Alignment legacyShapeToAlignment(
-    const tt::tt_metal::Shape& logical_shape,
-    const tt::tt_metal::Shape& legacy_padded_shape,
-    const PageConfig& page_config,
-    const MemoryConfig& memory_config) {
-    if (logical_shape == legacy_padded_shape) {
-        return Alignment{};
-    }
-
-    const int padded_rank = legacy_padded_shape.rank();
-    bool alignment_can_be_2D = true;
-    for (int i = -3; i >= -padded_rank; i--) {
-        alignment_can_be_2D &= logical_shape[i] == legacy_padded_shape[i];
-    }
-
-    // 2D SHARDED
-    if (memory_config.shard_spec().has_value()) {
-        TT_FATAL(
-            alignment_can_be_2D,
-            "Tensor with shape {} ({}) cannot be sharded because alignment will have rank greater than 2!",
-            logical_shape,
-            legacy_padded_shape);
-        if (page_config.get_layout() == Layout::ROW_MAJOR) {
-            const auto& shard_spec = memory_config.shard_spec().value();
-            return Alignment{shard_spec.shape[1]};
-        }
-        return Alignment{};
-    }
-
-    const auto [height_overpadded, width_overpadded] =
-        get_inner_hw_overpadded(logical_shape, legacy_padded_shape, page_config);
-    // INTERLEAVED with only height/width padding
-    if (alignment_can_be_2D) {
-        ttsl::SmallVector<uint32_t> values(std::min((int)padded_rank, 2));
-        const auto alignment_size = values.size();
-        if (alignment_size >= 1) {
-            values[alignment_size - 1] =
-                width_overpadded ? legacy_padded_shape[-1] : page_config.get_tile().get_width();
-        }
-        if (alignment_size == 2) {
-            values[alignment_size - 2] =
-                height_overpadded ? legacy_padded_shape[-2] : page_config.get_tile().get_height();
-        }
-        Alignment result(std::move(values));
-        return result;
-    }
-
-    // INTERLEAVED with (deprecated) non-height/width padding
-    // NOTE: Rank > 2 is guaranteed in this case
-    ttsl::SmallVector<uint32_t> values(padded_rank);
-
-    // When the inner dimensions are not over-padded beyond the logical H/W, use the tile width and height
-    // for the innermost alignment; otherwise use the legacy padded H/W.
-    values[padded_rank - 1] = width_overpadded ? legacy_padded_shape[-1] : page_config.get_tile().get_width();
-    values[padded_rank - 2] = height_overpadded ? legacy_padded_shape[-2] : page_config.get_tile().get_height();
-
-    uint32_t cumulative_padded_volume = legacy_padded_shape[-2];
-    for (int dim = padded_rank - 3; dim >= 0; dim--) {
-        cumulative_padded_volume *= legacy_padded_shape[dim];
-        values[dim] = cumulative_padded_volume;
-    }
-
-    for (auto& value : values) {
-        if (value == 0) {
-            value = 1;
-        }
-    }
-
-    Alignment result(std::move(values));
-    return result;
-}
-
 void validate_alignment(const TensorLayoutImpl& tensor_layout) {
     const auto& alignment = tensor_layout.get_alignment();
     const auto& memory_config = tensor_layout.get_memory_config();
@@ -156,9 +70,8 @@ bool can_shard_align(const MemoryConfig& memory_config, const Layout& layout, co
 // TensorLayoutImpl: the internal layout-computation API, reachable from within tt_metal via impl().
 // ------------------------------------------------------------------------------------------------
 
-TensorLayoutImpl::TensorLayoutImpl(
-    DataType dtype, const PageConfig& page_config, const MemoryConfig& memory_config, const Alignment& alignment) :
-    dtype_(dtype), page_config_(page_config), memory_config_(memory_config), alignment_(alignment) {
+TensorLayoutImpl::TensorLayoutImpl(DataType dtype, const PageConfig& page_config, const MemoryConfig& memory_config) :
+    dtype_(dtype), page_config_(page_config), memory_config_(memory_config) {
     initialize_alignment();
     CMAKE_UNIQUE_NAMESPACE::validate_alignment(*this);
 
@@ -167,6 +80,14 @@ TensorLayoutImpl::TensorLayoutImpl(
             CMAKE_UNIQUE_NAMESPACE::get_shard_align_error(memory_config_, get_layout(), get_tile());
         TT_FATAL(!shard_align_error.has_value(), "{}", shard_align_error);
     }
+}
+
+void TensorLayoutImpl::set_custom_alignment(const Alignment& alignment) {
+    // initialize_alignment() merges alignment_ into the Alignment derived from page_config_ / dtype_ /
+    // memory_config_, so overwriting alignment_ first yields the same result as constructing with **alignment**.
+    alignment_ = alignment;
+    initialize_alignment();
+    CMAKE_UNIQUE_NAMESPACE::validate_alignment(*this);
 }
 
 void TensorLayoutImpl::initialize_alignment() {
@@ -429,9 +350,8 @@ tt::tt_metal::Shape TensorLayoutImpl::compute_padded_shape(const tt::tt_metal::S
 // TensorLayout: public facade forwarding to TensorLayoutImpl.
 // ------------------------------------------------------------------------------------------------
 
-TensorLayout::TensorLayout(
-    DataType dtype, const PageConfig& page_config, const MemoryConfig& memory_config, const Alignment& alignment) :
-    impl_(std::make_unique<TensorLayoutImpl>(dtype, page_config, memory_config, alignment)) {}
+TensorLayout::TensorLayout(DataType dtype, const PageConfig& page_config, const MemoryConfig& memory_config) :
+    impl_(std::make_unique<TensorLayoutImpl>(dtype, page_config, memory_config)) {}
 
 TensorLayout::~TensorLayout() = default;
 
@@ -457,19 +377,6 @@ TensorLayoutImpl& TensorLayout::impl() {
 const TensorLayoutImpl& TensorLayout::impl() const {
     TT_FATAL(impl_ != nullptr, "TensorLayout is in a moved-from state.");
     return *impl_;
-}
-
-TensorLayout TensorLayout::fromPaddedShape(
-    DataType dtype,
-    const PageConfig& page_config,
-    const MemoryConfig& memory_config,
-    const tt::tt_metal::Shape& logical_shape,
-    const tt::tt_metal::Shape& padded_shape) {
-    return TensorLayout(
-        dtype,
-        page_config,
-        memory_config,
-        CMAKE_UNIQUE_NAMESPACE::legacyShapeToAlignment(logical_shape, padded_shape, page_config, memory_config));
 }
 
 Layout TensorLayout::get_layout() const { return impl().get_layout(); }

--- a/tt_metal/impl/tensor/spec/layout/tensor_layout.cpp
+++ b/tt_metal/impl/tensor/spec/layout/tensor_layout.cpp
@@ -70,8 +70,9 @@ bool can_shard_align(const MemoryConfig& memory_config, const Layout& layout, co
 // TensorLayoutImpl: the internal layout-computation API, reachable from within tt_metal via impl().
 // ------------------------------------------------------------------------------------------------
 
-TensorLayoutImpl::TensorLayoutImpl(DataType dtype, const PageConfig& page_config, const MemoryConfig& memory_config) :
-    dtype_(dtype), page_config_(page_config), memory_config_(memory_config) {
+TensorLayoutImpl::TensorLayoutImpl(
+    DataType dtype, const PageConfig& page_config, const MemoryConfig& memory_config, const Alignment& alignment) :
+    dtype_(dtype), page_config_(page_config), memory_config_(memory_config), alignment_(alignment) {
     initialize_alignment();
     CMAKE_UNIQUE_NAMESPACE::validate_alignment(*this);
 
@@ -80,14 +81,6 @@ TensorLayoutImpl::TensorLayoutImpl(DataType dtype, const PageConfig& page_config
             CMAKE_UNIQUE_NAMESPACE::get_shard_align_error(memory_config_, get_layout(), get_tile());
         TT_FATAL(!shard_align_error.has_value(), "{}", shard_align_error);
     }
-}
-
-void TensorLayoutImpl::set_custom_alignment(const Alignment& alignment) {
-    // initialize_alignment() merges alignment_ into the Alignment derived from page_config_ / dtype_ /
-    // memory_config_, so overwriting alignment_ first yields the same result as constructing with **alignment**.
-    alignment_ = alignment;
-    initialize_alignment();
-    CMAKE_UNIQUE_NAMESPACE::validate_alignment(*this);
 }
 
 void TensorLayoutImpl::initialize_alignment() {
@@ -351,7 +344,11 @@ tt::tt_metal::Shape TensorLayoutImpl::compute_padded_shape(const tt::tt_metal::S
 // ------------------------------------------------------------------------------------------------
 
 TensorLayout::TensorLayout(DataType dtype, const PageConfig& page_config, const MemoryConfig& memory_config) :
-    impl_(std::make_unique<TensorLayoutImpl>(dtype, page_config, memory_config)) {}
+    TensorLayout(std::make_unique<TensorLayoutImpl>(dtype, page_config, memory_config)) {}
+
+TensorLayout::TensorLayout(std::unique_ptr<TensorLayoutImpl> impl) : impl_(std::move(impl)) {
+    TT_FATAL(impl_ != nullptr, "TensorLayout requires a non-null TensorLayoutImpl.");
+}
 
 TensorLayout::~TensorLayout() = default;
 

--- a/tt_metal/impl/tensor/spec/layout/tensor_layout_apis_with_custom_alignment.cpp
+++ b/tt_metal/impl/tensor/spec/layout/tensor_layout_apis_with_custom_alignment.cpp
@@ -1,0 +1,135 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <tt_stl/fmt.hpp>
+#include <tt-metalium/experimental/tensor_layout_apis_with_custom_alignment.hpp>
+
+#include <tt_stl/assert.hpp>
+
+#include "page_config_impl.hpp"
+#include "tensor_layout_impl.hpp"
+
+namespace tt::tt_metal {
+
+namespace {
+namespace CMAKE_UNIQUE_NAMESPACE {
+
+size_t round_up(size_t value, size_t multiple) {
+    if (multiple == 0) {
+        return value;
+    }
+
+    return ((value + multiple - 1) / multiple) * multiple;
+};
+
+std::tuple<bool, bool> get_inner_hw_overpadded(
+    const tt::tt_metal::Shape& logical_shape,
+    const tt::tt_metal::Shape& legacy_padded_shape,
+    const PageConfig& page_config) {
+    if (page_config.get_layout() == Layout::TILE) {
+        const auto& tile = page_config.get_tile();
+        const uint32_t min_padded_h = round_up(logical_shape[-2], tile.get_height());
+        const uint32_t min_padded_w = round_up(logical_shape[-1], tile.get_width());
+        return {legacy_padded_shape[-2] > min_padded_h, legacy_padded_shape[-1] > min_padded_w};
+    }
+    // Always true for non-tile layouts; alignment is the standard padding mechanism for row-major tensors
+    return {true, true};
+}
+
+Alignment legacyShapeToAlignment(
+    const tt::tt_metal::Shape& logical_shape,
+    const tt::tt_metal::Shape& legacy_padded_shape,
+    const PageConfig& page_config,
+    const MemoryConfig& memory_config) {
+    if (logical_shape == legacy_padded_shape) {
+        return Alignment{};
+    }
+
+    const int padded_rank = legacy_padded_shape.rank();
+    bool alignment_can_be_2D = true;
+    for (int i = -3; i >= -padded_rank; i--) {
+        alignment_can_be_2D &= logical_shape[i] == legacy_padded_shape[i];
+    }
+
+    // 2D SHARDED
+    if (memory_config.shard_spec().has_value()) {
+        TT_FATAL(
+            alignment_can_be_2D,
+            "Tensor with shape {} ({}) cannot be sharded because alignment will have rank greater than 2!",
+            logical_shape,
+            legacy_padded_shape);
+        if (page_config.get_layout() == Layout::ROW_MAJOR) {
+            const auto& shard_spec = memory_config.shard_spec().value();
+            return Alignment{shard_spec.shape[1]};
+        }
+        return Alignment{};
+    }
+
+    const auto [height_overpadded, width_overpadded] =
+        get_inner_hw_overpadded(logical_shape, legacy_padded_shape, page_config);
+    // INTERLEAVED with only height/width padding
+    if (alignment_can_be_2D) {
+        ttsl::SmallVector<uint32_t> values(std::min((int)padded_rank, 2));
+        const auto alignment_size = values.size();
+        if (alignment_size >= 1) {
+            values[alignment_size - 1] =
+                width_overpadded ? legacy_padded_shape[-1] : page_config.get_tile().get_width();
+        }
+        if (alignment_size == 2) {
+            values[alignment_size - 2] =
+                height_overpadded ? legacy_padded_shape[-2] : page_config.get_tile().get_height();
+        }
+        Alignment result(std::move(values));
+        return result;
+    }
+
+    // INTERLEAVED with (deprecated) non-height/width padding
+    // NOTE: Rank > 2 is guaranteed in this case
+    ttsl::SmallVector<uint32_t> values(padded_rank);
+
+    // When the inner dimensions are not over-padded beyond the logical H/W, use the tile width and height
+    // for the innermost alignment; otherwise use the legacy padded H/W.
+    values[padded_rank - 1] = width_overpadded ? legacy_padded_shape[-1] : page_config.get_tile().get_width();
+    values[padded_rank - 2] = height_overpadded ? legacy_padded_shape[-2] : page_config.get_tile().get_height();
+
+    uint32_t cumulative_padded_volume = legacy_padded_shape[-2];
+    for (int dim = padded_rank - 3; dim >= 0; dim--) {
+        cumulative_padded_volume *= legacy_padded_shape[dim];
+        values[dim] = cumulative_padded_volume;
+    }
+
+    for (auto& value : values) {
+        if (value == 0) {
+            value = 1;
+        }
+    }
+
+    Alignment result(std::move(values));
+    return result;
+}
+
+}  // namespace CMAKE_UNIQUE_NAMESPACE
+}  // namespace
+
+TensorLayout tensor_layout_with_custom_alignment(
+    DataType dtype, const PageConfig& page_config, const MemoryConfig& memory_config, const Alignment& alignment) {
+    TensorLayout result(dtype, page_config, memory_config);
+    result.impl().set_custom_alignment(alignment);
+    return result;
+}
+
+TensorLayout tensor_layout_from_padded_shape(
+    DataType dtype,
+    const PageConfig& page_config,
+    const MemoryConfig& memory_config,
+    const tt::tt_metal::Shape& logical_shape,
+    const tt::tt_metal::Shape& padded_shape) {
+    return tensor_layout_with_custom_alignment(
+        dtype,
+        page_config,
+        memory_config,
+        CMAKE_UNIQUE_NAMESPACE::legacyShapeToAlignment(logical_shape, padded_shape, page_config, memory_config));
+}
+
+}  // namespace tt::tt_metal

--- a/tt_metal/impl/tensor/spec/layout/tensor_layout_apis_with_custom_alignment.cpp
+++ b/tt_metal/impl/tensor/spec/layout/tensor_layout_apis_with_custom_alignment.cpp
@@ -10,7 +10,7 @@
 #include "page_config_impl.hpp"
 #include "tensor_layout_impl.hpp"
 
-namespace tt::tt_metal {
+namespace tt::tt_metal::experimental {
 
 namespace {
 namespace CMAKE_UNIQUE_NAMESPACE {
@@ -132,4 +132,4 @@ TensorLayout tensor_layout_from_padded_shape(
         CMAKE_UNIQUE_NAMESPACE::legacyShapeToAlignment(logical_shape, padded_shape, page_config, memory_config));
 }
 
-}  // namespace tt::tt_metal
+}  // namespace tt::tt_metal::experimental

--- a/tt_metal/impl/tensor/spec/layout/tensor_layout_apis_with_custom_alignment.cpp
+++ b/tt_metal/impl/tensor/spec/layout/tensor_layout_apis_with_custom_alignment.cpp
@@ -114,9 +114,7 @@ Alignment legacyShapeToAlignment(
 
 TensorLayout tensor_layout_with_custom_alignment(
     DataType dtype, const PageConfig& page_config, const MemoryConfig& memory_config, const Alignment& alignment) {
-    TensorLayout result(dtype, page_config, memory_config);
-    result.impl().set_custom_alignment(alignment);
-    return result;
+    return TensorLayout(std::make_unique<TensorLayoutImpl>(dtype, page_config, memory_config, alignment));
 }
 
 TensorLayout tensor_layout_from_padded_shape(

--- a/tt_metal/impl/tensor/spec/layout/tensor_layout_impl.hpp
+++ b/tt_metal/impl/tensor/spec/layout/tensor_layout_impl.hpp
@@ -13,8 +13,7 @@ namespace tt::tt_metal {
 
 class TensorLayoutImpl {
 public:
-    TensorLayoutImpl(
-        DataType dtype, const PageConfig& page_config, const MemoryConfig& memory_config, const Alignment& alignment);
+    TensorLayoutImpl(DataType dtype, const PageConfig& page_config, const MemoryConfig& memory_config);
 
     TensorLayoutImpl(const TensorLayoutImpl&) = default;
     TensorLayoutImpl(TensorLayoutImpl&&) noexcept = default;
@@ -33,6 +32,10 @@ public:
     const Alignment& get_alignment() const { return alignment_; }
 
     void set_memory_config(MemoryConfig memory_config) { memory_config_ = std::move(memory_config); }
+
+    // Replaces the derived Alignment with **alignment** merged into it, and re-validates.
+    // Only for experimental/tensor_layout_apis_with_custom_alignment.hpp; see the reasoning there.
+    void set_custom_alignment(const Alignment& alignment);
 
     Strides compute_strides(const tt::tt_metal::Shape& shape) const;
 

--- a/tt_metal/impl/tensor/spec/layout/tensor_layout_impl.hpp
+++ b/tt_metal/impl/tensor/spec/layout/tensor_layout_impl.hpp
@@ -13,7 +13,14 @@ namespace tt::tt_metal {
 
 class TensorLayoutImpl {
 public:
-    TensorLayoutImpl(DataType dtype, const PageConfig& page_config, const MemoryConfig& memory_config);
+    // **alignment** is merged with the Alignment derived from page_config / dtype / memory_config.
+    // Prefer the three-argument overload unless intentionally overriding Alignment
+    // (see experimental/tensor_layout_apis_with_custom_alignment.hpp).
+    TensorLayoutImpl(
+        DataType dtype, const PageConfig& page_config, const MemoryConfig& memory_config, const Alignment& alignment);
+
+    TensorLayoutImpl(DataType dtype, const PageConfig& page_config, const MemoryConfig& memory_config) :
+        TensorLayoutImpl(dtype, page_config, memory_config, Alignment{}) {}
 
     TensorLayoutImpl(const TensorLayoutImpl&) = default;
     TensorLayoutImpl(TensorLayoutImpl&&) noexcept = default;
@@ -32,10 +39,6 @@ public:
     const Alignment& get_alignment() const { return alignment_; }
 
     void set_memory_config(MemoryConfig memory_config) { memory_config_ = std::move(memory_config); }
-
-    // Replaces the derived Alignment with **alignment** merged into it, and re-validates.
-    // Only for experimental/tensor_layout_apis_with_custom_alignment.hpp; see the reasoning there.
-    void set_custom_alignment(const Alignment& alignment);
 
     Strides compute_strides(const tt::tt_metal::Shape& shape) const;
 

--- a/tt_metal/impl/tensor/spec/tensor_spec.cpp
+++ b/tt_metal/impl/tensor/spec/tensor_spec.cpp
@@ -10,6 +10,7 @@
 
 #include "layout/page_config_impl.hpp"
 #include "layout/tensor_layout_impl.hpp"
+#include <tt-metalium/experimental/tensor_layout_apis_with_custom_alignment.hpp>
 
 namespace tt::tt_metal {
 
@@ -262,14 +263,14 @@ TensorSpec TensorSpec::sharded(
 void TensorSpec::populate_sharding_specs() {
     if (memory_config().created_with_nd_shard_spec()) {
         if (auto upd_mem_config = populate_legacy_shard_spec_from_nd()) {
-            tensor_layout_ = TensorLayout(
+            tensor_layout_ = tensor_layout_with_custom_alignment(
                 tensor_layout_.get_data_type(),
                 tensor_layout_.get_page_config(),
                 *upd_mem_config,
                 tensor_layout_.get_alignment());
         }
     } else if (memory_config().shard_spec()) {
-        tensor_layout_ = TensorLayout(
+        tensor_layout_ = tensor_layout_with_custom_alignment(
             tensor_layout_.get_data_type(),
             tensor_layout_.get_page_config(),
             populate_nd_shard_spec_from_legacy(),

--- a/tt_metal/impl/tensor/spec/tensor_spec.cpp
+++ b/tt_metal/impl/tensor/spec/tensor_spec.cpp
@@ -10,6 +10,7 @@
 
 #include "layout/page_config_impl.hpp"
 #include "layout/tensor_layout_impl.hpp"
+#include <tt-metalium/experimental/tensor_layout_apis_with_custom_alignment.hpp>
 
 namespace tt::tt_metal {
 
@@ -265,14 +266,14 @@ TensorSpec TensorSpec::sharded(
 void TensorSpec::populate_sharding_specs() {
     if (memory_config().created_with_nd_shard_spec()) {
         if (auto upd_mem_config = populate_legacy_shard_spec_from_nd()) {
-            tensor_layout_ = TensorLayout(
+            tensor_layout_ = tensor_layout_with_custom_alignment(
                 tensor_layout_.get_data_type(),
                 tensor_layout_.get_page_config(),
                 *upd_mem_config,
                 tensor_layout_.get_alignment());
         }
     } else if (memory_config().shard_spec()) {
-        tensor_layout_ = TensorLayout(
+        tensor_layout_ = tensor_layout_with_custom_alignment(
             tensor_layout_.get_data_type(),
             tensor_layout_.get_page_config(),
             populate_nd_shard_spec_from_legacy(),

--- a/tt_metal/impl/tensor/spec/tensor_spec.cpp
+++ b/tt_metal/impl/tensor/spec/tensor_spec.cpp
@@ -263,14 +263,14 @@ TensorSpec TensorSpec::sharded(
 void TensorSpec::populate_sharding_specs() {
     if (memory_config().created_with_nd_shard_spec()) {
         if (auto upd_mem_config = populate_legacy_shard_spec_from_nd()) {
-            tensor_layout_ = tensor_layout_with_custom_alignment(
+            tensor_layout_ = experimental::tensor_layout_with_custom_alignment(
                 tensor_layout_.get_data_type(),
                 tensor_layout_.get_page_config(),
                 *upd_mem_config,
                 tensor_layout_.get_alignment());
         }
     } else if (memory_config().shard_spec()) {
-        tensor_layout_ = tensor_layout_with_custom_alignment(
+        tensor_layout_ = experimental::tensor_layout_with_custom_alignment(
             tensor_layout_.get_data_type(),
             tensor_layout_.get_page_config(),
             populate_nd_shard_spec_from_legacy(),

--- a/tt_metal/impl/tensor/spec/tensor_spec.cpp
+++ b/tt_metal/impl/tensor/spec/tensor_spec.cpp
@@ -266,14 +266,14 @@ TensorSpec TensorSpec::sharded(
 void TensorSpec::populate_sharding_specs() {
     if (memory_config().created_with_nd_shard_spec()) {
         if (auto upd_mem_config = populate_legacy_shard_spec_from_nd()) {
-            tensor_layout_ = tensor_layout_with_custom_alignment(
+            tensor_layout_ = experimental::tensor_layout_with_custom_alignment(
                 tensor_layout_.get_data_type(),
                 tensor_layout_.get_page_config(),
                 *upd_mem_config,
                 tensor_layout_.get_alignment());
         }
     } else if (memory_config().shard_spec()) {
-        tensor_layout_ = tensor_layout_with_custom_alignment(
+        tensor_layout_ = experimental::tensor_layout_with_custom_alignment(
             tensor_layout_.get_data_type(),
             tensor_layout_.get_page_config(),
             populate_nd_shard_spec_from_legacy(),

--- a/tt_metal/impl/tensor/tensor_apis.cpp
+++ b/tt_metal/impl/tensor/tensor_apis.cpp
@@ -30,6 +30,7 @@
 #include <tt_stl/reflection.hpp>
 #include <tt_stl/small_vector.hpp>
 #include <tt_stl/span.hpp>
+#include <tt-metalium/experimental/tensor_layout_apis_with_custom_alignment.hpp>
 
 namespace tt::tt_metal {
 
@@ -89,7 +90,7 @@ MeshTensor enqueue_write_tensor(
         const auto& old_spec = host_tensor.tensor_spec();
         tensor_spec_overriden_memory_config = TensorSpec(
             old_spec.logical_shape(),
-            TensorLayout(
+            tensor_layout_with_custom_alignment(
                 old_spec.tensor_layout().get_data_type(),
                 old_spec.tensor_layout().get_page_config(),
                 *memory_config,
@@ -219,7 +220,7 @@ void enqueue_write_tensor(distributed::MeshCommandQueue& cq, const HostTensor& h
         std::move(*mesh_buffer),
         TensorSpec(
             host_tensor.tensor_spec().logical_shape(),
-            TensorLayout(
+            tensor_layout_with_custom_alignment(
                 host_tensor.tensor_spec().tensor_layout().get_data_type(),
                 host_tensor.tensor_spec().tensor_layout().get_page_config(),
                 device_tensor.memory_config(),
@@ -260,7 +261,7 @@ HostTensor to_row_major_layout_impl(const HostTensor& tensor) {
     // Construct the new tensor spec first to verify that this is a supported Tensor configuration
     TensorSpec new_tensor_spec(
         tensor.logical_shape(),
-        TensorLayout::fromPaddedShape(
+        tensor_layout_from_padded_shape(
             tensor.dtype(),
             PageConfig(Layout::ROW_MAJOR),
             MemoryConfig{},
@@ -296,7 +297,7 @@ HostTensor to_tile_layout_impl(const HostTensor& tensor, Tile tile) {
 
         auto output_spec = TensorSpec(
             tensor.logical_shape(),
-            TensorLayout(
+            tensor_layout_with_custom_alignment(
                 tensor.dtype(),
                 PageConfig(Layout::TILE, tile),
                 tensor.memory_config(),
@@ -510,7 +511,7 @@ HostTensor to_dtype(const HostTensor& input_tensor, DataType dtype) {
 
     auto output_spec = TensorSpec(
         input_tensor.logical_shape(),
-        tt::tt_metal::TensorLayout(
+        tt::tt_metal::tensor_layout_with_custom_alignment(
             dtype,
             page_config,
             input_tensor.tensor_spec().memory_config(),

--- a/tt_metal/impl/tensor/tensor_apis.cpp
+++ b/tt_metal/impl/tensor/tensor_apis.cpp
@@ -90,7 +90,7 @@ MeshTensor enqueue_write_tensor(
         const auto& old_spec = host_tensor.tensor_spec();
         tensor_spec_overriden_memory_config = TensorSpec(
             old_spec.logical_shape(),
-            tensor_layout_with_custom_alignment(
+            experimental::tensor_layout_with_custom_alignment(
                 old_spec.tensor_layout().get_data_type(),
                 old_spec.tensor_layout().get_page_config(),
                 *memory_config,
@@ -220,7 +220,7 @@ void enqueue_write_tensor(distributed::MeshCommandQueue& cq, const HostTensor& h
         std::move(*mesh_buffer),
         TensorSpec(
             host_tensor.tensor_spec().logical_shape(),
-            tensor_layout_with_custom_alignment(
+            experimental::tensor_layout_with_custom_alignment(
                 host_tensor.tensor_spec().tensor_layout().get_data_type(),
                 host_tensor.tensor_spec().tensor_layout().get_page_config(),
                 device_tensor.memory_config(),
@@ -261,7 +261,7 @@ HostTensor to_row_major_layout_impl(const HostTensor& tensor) {
     // Construct the new tensor spec first to verify that this is a supported Tensor configuration
     TensorSpec new_tensor_spec(
         tensor.logical_shape(),
-        tensor_layout_from_padded_shape(
+        experimental::tensor_layout_from_padded_shape(
             tensor.dtype(),
             PageConfig(Layout::ROW_MAJOR),
             MemoryConfig{},
@@ -297,7 +297,7 @@ HostTensor to_tile_layout_impl(const HostTensor& tensor, Tile tile) {
 
         auto output_spec = TensorSpec(
             tensor.logical_shape(),
-            tensor_layout_with_custom_alignment(
+            experimental::tensor_layout_with_custom_alignment(
                 tensor.dtype(),
                 PageConfig(Layout::TILE, tile),
                 tensor.memory_config(),
@@ -511,7 +511,7 @@ HostTensor to_dtype(const HostTensor& input_tensor, DataType dtype) {
 
     auto output_spec = TensorSpec(
         input_tensor.logical_shape(),
-        tt::tt_metal::tensor_layout_with_custom_alignment(
+        tt::tt_metal::experimental::tensor_layout_with_custom_alignment(
             dtype,
             page_config,
             input_tensor.tensor_spec().memory_config(),

--- a/tt_metal/impl/tensor/tensor_apis.cpp
+++ b/tt_metal/impl/tensor/tensor_apis.cpp
@@ -587,45 +587,6 @@ HostTensor to_dtype(const HostTensor& input_tensor, DataType dtype) {
 
 namespace host_buffer {
 
-namespace {
-namespace CMAKE_UNIQUE_NAMESPACE {
-
-template <typename T>
-void validate_datatype(DataType dtype) {
-    using BaseType = std::remove_cvref_t<T>;
-    if constexpr (std::is_same_v<BaseType, uint32_t>) {
-        TT_FATAL(
-            dtype == DataType::UINT32 or dtype == DataType::BFLOAT8_B or dtype == DataType::BFLOAT4_B,
-            "Incorrect data type {}",
-            dtype);
-    } else if constexpr (std::is_same_v<BaseType, int32_t>) {
-        TT_FATAL(dtype == DataType::INT32, "Incorrect data type {}", dtype);
-    } else if constexpr (std::is_same_v<BaseType, float>) {
-        TT_FATAL(dtype == DataType::FLOAT32, "Incorrect data type {}", dtype);
-    } else if constexpr (std::is_same_v<BaseType, bfloat16>) {
-        TT_FATAL(dtype == DataType::BFLOAT16, "Incorrect data type {}", dtype);
-    } else if constexpr (std::is_same_v<BaseType, uint16_t>) {
-        TT_FATAL(dtype == DataType::UINT16, "Incorrect data type {}", dtype);
-    } else if constexpr (std::is_same_v<BaseType, uint8_t>) {
-        TT_FATAL(dtype == DataType::UINT8, "Incorrect data type {}", dtype);
-    } else {
-        static_assert(sizeof(BaseType) == 0, "Unsupported DataType");
-    }
-}
-
-}  // namespace CMAKE_UNIQUE_NAMESPACE
-}  // namespace
-
-HostBuffer get_host_buffer(const HostTensor& tensor) {
-    std::vector<HostBuffer> buffers;
-    tensor.buffer().apply([&buffers](const HostBuffer& shard) { buffers.push_back(shard); });
-    TT_FATAL(
-        buffers.size() == 1,
-        "Can't get a single buffer from host storage distributed over mesh shape {}",
-        tensor.buffer().shape());
-    return buffers.front();
-}
-
 template <typename T>
 ttsl::Span<const T> get_as(const HostBuffer& buffer) {
     return buffer.view_as<T>();
@@ -636,30 +597,12 @@ ttsl::Span<T> get_as(HostBuffer& buffer) {
     return buffer.view_as<T>();
 }
 
-template <typename T>
-ttsl::Span<const T> get_as(const HostTensor& tensor) {
-    CMAKE_UNIQUE_NAMESPACE::validate_datatype<T>(tensor.dtype());
-    HostBuffer buffer = get_host_buffer(tensor);
-    return buffer.template view_as<T>();
-}
-
-template <typename T>
-ttsl::Span<T> get_as(HostTensor& tensor) {
-    CMAKE_UNIQUE_NAMESPACE::validate_datatype<T>(tensor.dtype());
-    HostBuffer buffer = get_host_buffer(tensor);
-    return buffer.template view_as<T>();
-}
-
 // Explicit template instantiations
 #define INSTANTIATE_HOST_BUFFER_FUNCTIONS(T)                         \
     template ttsl::Span<const T> get_as<T>(const HostBuffer&);       \
     template ttsl::Span<const T> get_as<const T>(const HostBuffer&); \
     template ttsl::Span<T> get_as<T>(HostBuffer&);                   \
-    template ttsl::Span<const T> get_as<const T>(HostBuffer&);       \
-    template ttsl::Span<const T> get_as<T>(const HostTensor&);       \
-    template ttsl::Span<const T> get_as<const T>(const HostTensor&); \
-    template ttsl::Span<T> get_as<T>(HostTensor&);                   \
-    template ttsl::Span<const T> get_as<const T>(HostTensor&);
+    template ttsl::Span<const T> get_as<const T>(HostBuffer&);
 
 INSTANTIATE_HOST_BUFFER_FUNCTIONS(uint32_t)
 INSTANTIATE_HOST_BUFFER_FUNCTIONS(int32_t)

--- a/tt_metal/impl/tensor/tensor_apis.cpp
+++ b/tt_metal/impl/tensor/tensor_apis.cpp
@@ -589,47 +589,6 @@ HostTensor to_dtype(const HostTensor& input_tensor, DataType dtype) {
 
 namespace host_buffer {
 
-namespace {
-namespace CMAKE_UNIQUE_NAMESPACE {
-
-template <typename T>
-void validate_datatype(DataType dtype) {
-    using BaseType = std::remove_cvref_t<T>;
-    if constexpr (std::is_same_v<BaseType, uint32_t>) {
-        TT_FATAL(
-            dtype == DataType::UINT32 or dtype == DataType::BFLOAT8_B or dtype == DataType::BFLOAT4_B,
-            "Incorrect data type {}",
-            dtype);
-    } else if constexpr (std::is_same_v<BaseType, int32_t>) {
-        TT_FATAL(dtype == DataType::INT32, "Incorrect data type {}", dtype);
-    } else if constexpr (std::is_same_v<BaseType, int8_t>) {
-        TT_FATAL(dtype == DataType::INT8, "Incorrect data type {}", dtype);
-    } else if constexpr (std::is_same_v<BaseType, float>) {
-        TT_FATAL(dtype == DataType::FLOAT32, "Incorrect data type {}", dtype);
-    } else if constexpr (std::is_same_v<BaseType, bfloat16>) {
-        TT_FATAL(dtype == DataType::BFLOAT16, "Incorrect data type {}", dtype);
-    } else if constexpr (std::is_same_v<BaseType, uint16_t>) {
-        TT_FATAL(dtype == DataType::UINT16, "Incorrect data type {}", dtype);
-    } else if constexpr (std::is_same_v<BaseType, uint8_t>) {
-        TT_FATAL(dtype == DataType::UINT8, "Incorrect data type {}", dtype);
-    } else {
-        static_assert(sizeof(BaseType) == 0, "Unsupported DataType");
-    }
-}
-
-}  // namespace CMAKE_UNIQUE_NAMESPACE
-}  // namespace
-
-HostBuffer get_host_buffer(const HostTensor& tensor) {
-    std::vector<HostBuffer> buffers;
-    tensor.buffer().apply([&buffers](const HostBuffer& shard) { buffers.push_back(shard); });
-    TT_FATAL(
-        buffers.size() == 1,
-        "Can't get a single buffer from host storage distributed over mesh shape {}",
-        tensor.buffer().shape());
-    return buffers.front();
-}
-
 template <typename T>
 ttsl::Span<const T> get_as(const HostBuffer& buffer) {
     return buffer.view_as<T>();
@@ -640,30 +599,12 @@ ttsl::Span<T> get_as(HostBuffer& buffer) {
     return buffer.view_as<T>();
 }
 
-template <typename T>
-ttsl::Span<const T> get_as(const HostTensor& tensor) {
-    CMAKE_UNIQUE_NAMESPACE::validate_datatype<T>(tensor.dtype());
-    HostBuffer buffer = get_host_buffer(tensor);
-    return buffer.template view_as<T>();
-}
-
-template <typename T>
-ttsl::Span<T> get_as(HostTensor& tensor) {
-    CMAKE_UNIQUE_NAMESPACE::validate_datatype<T>(tensor.dtype());
-    HostBuffer buffer = get_host_buffer(tensor);
-    return buffer.template view_as<T>();
-}
-
 // Explicit template instantiations
 #define INSTANTIATE_HOST_BUFFER_FUNCTIONS(T)                         \
     template ttsl::Span<const T> get_as<T>(const HostBuffer&);       \
     template ttsl::Span<const T> get_as<const T>(const HostBuffer&); \
     template ttsl::Span<T> get_as<T>(HostBuffer&);                   \
-    template ttsl::Span<const T> get_as<const T>(HostBuffer&);       \
-    template ttsl::Span<const T> get_as<T>(const HostTensor&);       \
-    template ttsl::Span<const T> get_as<const T>(const HostTensor&); \
-    template ttsl::Span<T> get_as<T>(HostTensor&);                   \
-    template ttsl::Span<const T> get_as<const T>(HostTensor&);
+    template ttsl::Span<const T> get_as<const T>(HostBuffer&);
 
 INSTANTIATE_HOST_BUFFER_FUNCTIONS(uint32_t)
 INSTANTIATE_HOST_BUFFER_FUNCTIONS(int32_t)

--- a/tt_metal/impl/tensor/tensor_serialization_support.cpp
+++ b/tt_metal/impl/tensor/tensor_serialization_support.cpp
@@ -3,12 +3,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <tt-metalium/experimental/tensor_serialization_support.hpp>
+#include <tt-metalium/experimental/tensor_layout_apis_with_custom_alignment.hpp>
 
 namespace tt::tt_metal {
 
 TensorLayout restore_tensor_layout_from_serialized(
     DataType dtype, const PageConfig& page_config, const MemoryConfig& memory_config, const Alignment& alignment) {
-    return TensorLayout(dtype, page_config, memory_config, alignment);
+    return tensor_layout_with_custom_alignment(dtype, page_config, memory_config, alignment);
 }
 
 MemoryConfig create_memory_config_with_prepopulated_shard_specs(

--- a/tt_metal/impl/tensor/tensor_serialization_support.cpp
+++ b/tt_metal/impl/tensor/tensor_serialization_support.cpp
@@ -9,7 +9,7 @@ namespace tt::tt_metal {
 
 TensorLayout restore_tensor_layout_from_serialized(
     DataType dtype, const PageConfig& page_config, const MemoryConfig& memory_config, const Alignment& alignment) {
-    return tensor_layout_with_custom_alignment(dtype, page_config, memory_config, alignment);
+    return experimental::tensor_layout_with_custom_alignment(dtype, page_config, memory_config, alignment);
 }
 
 MemoryConfig create_memory_config_with_prepopulated_shard_specs(

--- a/tt_metal/sources.cmake
+++ b/tt_metal/sources.cmake
@@ -100,6 +100,7 @@ set(TT_METAL_PUBLIC_API
     api/tt-metalium/experimental/tensor_apis_with_pad_values.hpp
     api/tt-metalium/experimental/tensor_host_pad_apis.hpp
     api/tt-metalium/experimental/tensor_serialization_support.hpp
+    api/tt-metalium/experimental/tensor_layout_apis_with_custom_alignment.hpp
     api/tt-metalium/experimental/tensor/host_tensor.hpp
     api/tt-metalium/experimental/tensor/mesh_tensor.hpp
     api/tt-metalium/experimental/tensor/spec/layout/alignment.hpp

--- a/ttnn/api/ttnn/tensor/host_buffer/functions.hpp
+++ b/ttnn/api/ttnn/tensor/host_buffer/functions.hpp
@@ -6,7 +6,7 @@
 
 #include "ttnn/tensor/tensor.hpp"
 
-#include <tt-metalium/experimental/tensor/tensor_apis.hpp>
+#include <tt-metalium/experimental/distributed_tensor/distributed_tensor_apis.hpp>
 
 namespace tt::tt_metal::host_buffer {
 

--- a/ttnn/api/ttnn/tensor/tensor_utils.hpp
+++ b/ttnn/api/ttnn/tensor/tensor_utils.hpp
@@ -11,6 +11,7 @@
 #include <tt-metalium/program_descriptors.hpp>
 
 // Exports symbols
+#include <tt-metalium/experimental/distributed_tensor/distributed_tensor_apis.hpp>
 #include <tt-metalium/experimental/tensor/tensor_apis.hpp>
 
 namespace ttnn {

--- a/ttnn/core/tensor/flatbuffer/tensor_spec_flatbuffer.cpp
+++ b/ttnn/core/tensor/flatbuffer/tensor_spec_flatbuffer.cpp
@@ -13,7 +13,8 @@ CoreRangeSet from_flatbuffer(const flatbuffer::CoreRangeSet* core_range_set) {
     std::vector<CoreRange> ranges;
     for (const auto* range : *core_range_set->ranges()) {
         ranges.emplace_back(
-            tt::tt_metal::CoreCoord{range->start()->x(), range->start()->y()}, tt::tt_metal::CoreCoord{range->end()->x(), range->end()->y()});
+            tt::tt_metal::CoreCoord{range->start()->x(), range->start()->y()},
+            tt::tt_metal::CoreCoord{range->end()->x(), range->end()->y()});
     }
     return CoreRangeSet{ranges};
 }

--- a/ttnn/core/tensor/flatbuffer/tensor_spec_flatbuffer.cpp
+++ b/ttnn/core/tensor/flatbuffer/tensor_spec_flatbuffer.cpp
@@ -14,7 +14,8 @@ CoreRangeSet from_flatbuffer(const flatbuffer::CoreRangeSet* core_range_set) {
     ranges.reserve(core_range_set->ranges()->size());
     for (const auto* range : *core_range_set->ranges()) {
         ranges.emplace_back(
-            tt::tt_metal::CoreCoord{range->start()->x(), range->start()->y()}, tt::tt_metal::CoreCoord{range->end()->x(), range->end()->y()});
+            tt::tt_metal::CoreCoord{range->start()->x(), range->start()->y()},
+            tt::tt_metal::CoreCoord{range->end()->x(), range->end()->y()});
     }
     return CoreRangeSet{std::move(ranges)};
 }

--- a/ttnn/core/tensor/tensor.cpp
+++ b/ttnn/core/tensor/tensor.cpp
@@ -40,6 +40,7 @@
 #include <memory>
 #include <utility>
 #include <atomic>
+#include <tt-metalium/experimental/tensor_layout_apis_with_custom_alignment.hpp>
 
 namespace ttnn {
 
@@ -80,7 +81,7 @@ Tensor::Tensor(
         std::move(buffer),
         TensorSpec(
             logical_shape,
-            tt::tt_metal::TensorLayout::fromPaddedShape(
+            tt::tt_metal::tensor_layout_from_padded_shape(
                 dtype,
                 tt::tt_metal::PageConfig(layout, tile),
                 tt::tt_metal::MemoryConfig{},

--- a/ttnn/core/tensor/tensor.cpp
+++ b/ttnn/core/tensor/tensor.cpp
@@ -81,7 +81,7 @@ Tensor::Tensor(
         std::move(buffer),
         TensorSpec(
             logical_shape,
-            tt::tt_metal::tensor_layout_from_padded_shape(
+            tt::tt_metal::experimental::tensor_layout_from_padded_shape(
                 dtype,
                 tt::tt_metal::PageConfig(layout, tile),
                 tt::tt_metal::MemoryConfig{},

--- a/ttnn/core/tensor/tensor_impl.cpp
+++ b/ttnn/core/tensor/tensor_impl.cpp
@@ -39,6 +39,7 @@
 
 #include <tracy/Tracy.hpp>
 #include <tt-metalium/experimental/distributed_tensor/distributed_tensor_apis.hpp>
+#include <tt-metalium/experimental/tensor_layout_apis_with_custom_alignment.hpp>
 
 namespace ttnn::tensor_impl {
 
@@ -424,7 +425,7 @@ tt::tt_metal::HostTensor view(
 
     auto new_spec = tt::tt_metal::TensorSpec(
         new_logical_shape,
-        tt::tt_metal::TensorLayout::fromPaddedShape(
+        tt::tt_metal::tensor_layout_from_padded_shape(
             tensor.dtype(),
             tensor.tensor_spec().page_config(),
             output_memory_config,

--- a/ttnn/core/tensor/tensor_impl.cpp
+++ b/ttnn/core/tensor/tensor_impl.cpp
@@ -425,7 +425,7 @@ tt::tt_metal::HostTensor view(
 
     auto new_spec = tt::tt_metal::TensorSpec(
         new_logical_shape,
-        tt::tt_metal::tensor_layout_from_padded_shape(
+        tt::tt_metal::experimental::tensor_layout_from_padded_shape(
             tensor.dtype(),
             tensor.tensor_spec().page_config(),
             output_memory_config,

--- a/ttnn/core/tensor/tensor_impl.cpp
+++ b/ttnn/core/tensor/tensor_impl.cpp
@@ -39,6 +39,7 @@
 
 #include <tracy/Tracy.hpp>
 #include <tt-metalium/experimental/distributed_tensor/distributed_tensor_apis.hpp>
+#include <tt-metalium/experimental/tensor_layout_apis_with_custom_alignment.hpp>
 
 namespace ttnn::tensor_impl {
 
@@ -430,7 +431,7 @@ tt::tt_metal::HostTensor view(
 
     auto new_spec = tt::tt_metal::TensorSpec(
         new_logical_shape,
-        tt::tt_metal::TensorLayout::fromPaddedShape(
+        tt::tt_metal::tensor_layout_from_padded_shape(
             tensor.dtype(),
             tensor.tensor_spec().page_config(),
             output_memory_config,

--- a/ttnn/core/tensor/tensor_impl.cpp
+++ b/ttnn/core/tensor/tensor_impl.cpp
@@ -431,7 +431,7 @@ tt::tt_metal::HostTensor view(
 
     auto new_spec = tt::tt_metal::TensorSpec(
         new_logical_shape,
-        tt::tt_metal::tensor_layout_from_padded_shape(
+        tt::tt_metal::experimental::tensor_layout_from_padded_shape(
             tensor.dtype(),
             tensor.tensor_spec().page_config(),
             output_memory_config,

--- a/ttnn/core/tensor/tensor_ops.cpp
+++ b/ttnn/core/tensor/tensor_ops.cpp
@@ -25,6 +25,7 @@
 #include <tt-metalium/experimental/distributed_tensor/distributed_tensor_apis.hpp>
 #include <tt-metalium/experimental/tensor_host_pad_apis.hpp>
 #include <tt-metalium/experimental/byte_based_tensor_transfers.hpp>
+#include <tt-metalium/experimental/tensor_layout_apis_with_custom_alignment.hpp>
 
 using tt::tt_metal::BufferRegion;
 using tt::tt_metal::DataType;
@@ -228,8 +229,9 @@ Tensor cpu(const Tensor& input_tensor, bool blocking, std::optional<QueueId> cq_
         output = Tensor(enqueue_read_tensor(cq, input_tensor.mesh_tensor(), blocking));
     } else {
         auto coords = input_tensor.device_storage().get_coords();
-        output = Tensor(tt::tt_metal::non_uniform_data_movement::enqueue_read_tensor(
-            cq, input_tensor.mesh_tensor(), coords, blocking));
+        output = Tensor(
+            tt::tt_metal::non_uniform_data_movement::enqueue_read_tensor(
+                cq, input_tensor.mesh_tensor(), coords, blocking));
     }
     output = ttnn::set_tensor_id(output);
     GraphTracker::instance().track_function_end(output);
@@ -382,7 +384,7 @@ Tensor view_device(const Tensor& input_tensor, const Shape& new_logical_shape, c
 
     auto new_spec = TensorSpec(
         new_logical_shape,
-        TensorLayout::fromPaddedShape(
+        tensor_layout_from_padded_shape(
             input_tensor.dtype(),
             input_tensor.tensor_spec().page_config(),
             output_memory_config,

--- a/ttnn/core/tensor/tensor_ops.cpp
+++ b/ttnn/core/tensor/tensor_ops.cpp
@@ -384,7 +384,7 @@ Tensor view_device(const Tensor& input_tensor, const Shape& new_logical_shape, c
 
     auto new_spec = TensorSpec(
         new_logical_shape,
-        tensor_layout_from_padded_shape(
+        experimental::tensor_layout_from_padded_shape(
             input_tensor.dtype(),
             input_tensor.tensor_spec().page_config(),
             output_memory_config,

--- a/ttnn/core/tensor/tensor_ops.cpp
+++ b/ttnn/core/tensor/tensor_ops.cpp
@@ -384,7 +384,7 @@ Tensor view_device(const Tensor& input_tensor, const Shape& new_logical_shape, c
 
     auto new_spec = TensorSpec(
         new_logical_shape,
-        experimental::tensor_layout_from_padded_shape(
+        tt::tt_metal::experimental::tensor_layout_from_padded_shape(
             input_tensor.dtype(),
             input_tensor.tensor_spec().page_config(),
             output_memory_config,

--- a/ttnn/cpp/ttnn-nanobind/pytensor.cpp
+++ b/ttnn/cpp/ttnn-nanobind/pytensor.cpp
@@ -61,6 +61,7 @@
 
 #include <tracy/Tracy.hpp>
 #include <tt-metalium/experimental/distributed_tensor/distributed_tensor_apis.hpp>
+#include <tt-metalium/experimental/tensor_layout_apis_with_custom_alignment.hpp>
 
 using namespace tt::tt_metal;
 
@@ -211,7 +212,7 @@ RowMajorHostBuffer convert_block_float_to_logical_row_major(const HostBuffer& bu
     // Buffer is float tiles; TensorSpec must match so to_vector only untilizes / strips padding.
     TensorSpec decode_spec(
         tensor_spec.logical_shape(),
-        TensorLayout::fromPaddedShape(
+        tensor_layout_from_padded_shape(
             DataType::FLOAT32,
             tensor_spec.page_config(),
             MemoryConfig{},

--- a/ttnn/cpp/ttnn-nanobind/pytensor.cpp
+++ b/ttnn/cpp/ttnn-nanobind/pytensor.cpp
@@ -212,7 +212,7 @@ RowMajorHostBuffer convert_block_float_to_logical_row_major(const HostBuffer& bu
     // Buffer is float tiles; TensorSpec must match so to_vector only untilizes / strips padding.
     TensorSpec decode_spec(
         tensor_spec.logical_shape(),
-        tensor_layout_from_padded_shape(
+        experimental::tensor_layout_from_padded_shape(
             DataType::FLOAT32,
             tensor_spec.page_config(),
             MemoryConfig{},

--- a/ttnn/cpp/ttnn-nanobind/pytensor.cpp
+++ b/ttnn/cpp/ttnn-nanobind/pytensor.cpp
@@ -212,7 +212,7 @@ RowMajorHostBuffer convert_block_float_to_logical_row_major(const HostBuffer& bu
     // Buffer is float tiles; TensorSpec must match so to_vector only untilizes / strips padding.
     TensorSpec decode_spec(
         tensor_spec.logical_shape(),
-        experimental::tensor_layout_from_padded_shape(
+        tt::tt_metal::experimental::tensor_layout_from_padded_shape(
             DataType::FLOAT32,
             tensor_spec.page_config(),
             MemoryConfig{},

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
@@ -30,6 +30,7 @@
 #include "ttnn/operations/data_movement/move/move.hpp"
 #include "ttnn/operations/data_movement/pad/pad.hpp"
 #include "ttnn/types.hpp"
+#include <tt-metalium/experimental/tensor_layout_apis_with_custom_alignment.hpp>
 
 namespace ttnn::operations::conv {
 using sliding_window::ParallelConfig;
@@ -873,7 +874,7 @@ std::tuple<ttnn::Tensor, ParallelConfig, ParallelConfig> shard_or_reshard_tensor
                 Tensor resharded_input_tensor = ttnn::create_device_tensor(
                     tt::tt_metal::TensorSpec(
                         input_tensor.logical_shape(),
-                        tt::tt_metal::TensorLayout(
+                        tt::tt_metal::tensor_layout_with_custom_alignment(
                             input_tensor.dtype(),
                             tt::tt_metal::PageConfig(input_tensor.layout()),
                             input_tensor_sharded_memory_config_to_layout,
@@ -921,7 +922,7 @@ std::tuple<ttnn::Tensor, ParallelConfig, ParallelConfig> shard_or_reshard_tensor
                 Tensor resharded_input_tensor = ttnn::create_device_tensor(
                     tt::tt_metal::TensorSpec(
                         input_tensor.logical_shape(),
-                        tt::tt_metal::TensorLayout(
+                        tt::tt_metal::tensor_layout_with_custom_alignment(
                             input_tensor.dtype(),
                             tt::tt_metal::PageConfig(input_tensor.layout()),
                             input_tensor_sharded_memory_config_to_layout,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
@@ -874,7 +874,7 @@ std::tuple<ttnn::Tensor, ParallelConfig, ParallelConfig> shard_or_reshard_tensor
                 Tensor resharded_input_tensor = ttnn::create_device_tensor(
                     tt::tt_metal::TensorSpec(
                         input_tensor.logical_shape(),
-                        tt::tt_metal::tensor_layout_with_custom_alignment(
+                        tt::tt_metal::experimental::tensor_layout_with_custom_alignment(
                             input_tensor.dtype(),
                             tt::tt_metal::PageConfig(input_tensor.layout()),
                             input_tensor_sharded_memory_config_to_layout,
@@ -922,7 +922,7 @@ std::tuple<ttnn::Tensor, ParallelConfig, ParallelConfig> shard_or_reshard_tensor
                 Tensor resharded_input_tensor = ttnn::create_device_tensor(
                     tt::tt_metal::TensorSpec(
                         input_tensor.logical_shape(),
-                        tt::tt_metal::tensor_layout_with_custom_alignment(
+                        tt::tt_metal::experimental::tensor_layout_with_custom_alignment(
                             input_tensor.dtype(),
                             tt::tt_metal::PageConfig(input_tensor.layout()),
                             input_tensor_sharded_memory_config_to_layout,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_device_operation.cpp
@@ -25,6 +25,7 @@
 
 #include "ttnn/operations/sliding_window/sliding_window.hpp"
 #include "ttnn/tensor/shape/shape.hpp"
+#include <tt-metalium/experimental/tensor_layout_apis_with_custom_alignment.hpp>
 
 namespace ttnn::prim {
 
@@ -69,7 +70,7 @@ tt::tt_metal::TensorSpec Conv2dDeviceOperation::compute_output_specs(
             args.memory_config.memory_layout(), args.memory_config.buffer_type(), shard_spec);
         return tt::tt_metal::TensorSpec(
             output_shape,
-            tt::tt_metal::TensorLayout(
+            tt::tt_metal::tensor_layout_with_custom_alignment(
                 args.dtype,
                 tt::tt_metal::PageConfig(output_layout),
                 mem_config,
@@ -81,7 +82,7 @@ tt::tt_metal::TensorSpec Conv2dDeviceOperation::compute_output_specs(
     }
     return tt::tt_metal::TensorSpec(
         output_shape,
-        tt::tt_metal::TensorLayout::fromPaddedShape(
+        tt::tt_metal::tensor_layout_from_padded_shape(
             args.dtype,
             tt::tt_metal::PageConfig(output_layout),
             args.memory_config,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_device_operation.cpp
@@ -70,7 +70,7 @@ tt::tt_metal::TensorSpec Conv2dDeviceOperation::compute_output_specs(
             args.memory_config.memory_layout(), args.memory_config.buffer_type(), shard_spec);
         return tt::tt_metal::TensorSpec(
             output_shape,
-            tt::tt_metal::tensor_layout_with_custom_alignment(
+            tt::tt_metal::experimental::tensor_layout_with_custom_alignment(
                 args.dtype,
                 tt::tt_metal::PageConfig(output_layout),
                 mem_config,
@@ -82,7 +82,7 @@ tt::tt_metal::TensorSpec Conv2dDeviceOperation::compute_output_specs(
     }
     return tt::tt_metal::TensorSpec(
         output_shape,
-        tt::tt_metal::tensor_layout_from_padded_shape(
+        tt::tt_metal::experimental::tensor_layout_from_padded_shape(
             args.dtype,
             tt::tt_metal::PageConfig(output_layout),
             args.memory_config,

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_device_operation.cpp
@@ -10,6 +10,7 @@
 #include "ttnn/operations/data_movement/common/common.hpp"
 #include "ttnn/tensor/shape/shape.hpp"
 #include "ttnn/tensor/tensor_ops.hpp"
+#include <tt-metalium/experimental/tensor_layout_apis_with_custom_alignment.hpp>
 
 namespace ttnn::prim {
 
@@ -198,7 +199,7 @@ tt::tt_metal::TensorSpec BcastDeviceOperation::compute_output_specs(
             shard_spec);
         return tt::tt_metal::TensorSpec(
             input_tensor.logical_shape(),
-            TensorLayout::fromPaddedShape(
+            tensor_layout_from_padded_shape(
                 input_tensor.dtype(),
                 PageConfig(Layout::TILE),
                 mem_config,
@@ -208,7 +209,7 @@ tt::tt_metal::TensorSpec BcastDeviceOperation::compute_output_specs(
 
     return tt::tt_metal::TensorSpec(
         input_tensor.logical_shape(),
-        TensorLayout::fromPaddedShape(
+        tensor_layout_from_padded_shape(
             input_tensor.dtype(),
             PageConfig(Layout::TILE),
             operation_attributes.output_mem_config,

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_device_operation.cpp
@@ -199,7 +199,7 @@ tt::tt_metal::TensorSpec BcastDeviceOperation::compute_output_specs(
             shard_spec);
         return tt::tt_metal::TensorSpec(
             input_tensor.logical_shape(),
-            experimental::tensor_layout_from_padded_shape(
+            tt::tt_metal::experimental::tensor_layout_from_padded_shape(
                 input_tensor.dtype(),
                 PageConfig(Layout::TILE),
                 mem_config,
@@ -209,7 +209,7 @@ tt::tt_metal::TensorSpec BcastDeviceOperation::compute_output_specs(
 
     return tt::tt_metal::TensorSpec(
         input_tensor.logical_shape(),
-        experimental::tensor_layout_from_padded_shape(
+        tt::tt_metal::experimental::tensor_layout_from_padded_shape(
             input_tensor.dtype(),
             PageConfig(Layout::TILE),
             operation_attributes.output_mem_config,

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/bcast_device_operation.cpp
@@ -199,7 +199,7 @@ tt::tt_metal::TensorSpec BcastDeviceOperation::compute_output_specs(
             shard_spec);
         return tt::tt_metal::TensorSpec(
             input_tensor.logical_shape(),
-            tensor_layout_from_padded_shape(
+            experimental::tensor_layout_from_padded_shape(
                 input_tensor.dtype(),
                 PageConfig(Layout::TILE),
                 mem_config,
@@ -209,7 +209,7 @@ tt::tt_metal::TensorSpec BcastDeviceOperation::compute_output_specs(
 
     return tt::tt_metal::TensorSpec(
         input_tensor.logical_shape(),
-        tensor_layout_from_padded_shape(
+        experimental::tensor_layout_from_padded_shape(
             input_tensor.dtype(),
             PageConfig(Layout::TILE),
             operation_attributes.output_mem_config,

--- a/ttnn/cpp/ttnn/operations/data_movement/clone/device/clone_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/clone/device/clone_device_operation.cpp
@@ -6,6 +6,7 @@
 #include "ttnn/device_operation.hpp"
 #include "ttnn/operations/data_movement/common/common.hpp"
 #include "ttnn/tensor/tensor_ops.hpp"
+#include <tt-metalium/experimental/tensor_layout_apis_with_custom_alignment.hpp>
 
 namespace ttnn::operations::data_movement::clone {
 void CloneOperation::validate_inputs(
@@ -53,7 +54,7 @@ CloneOperation::spec_return_value_t CloneOperation::compute_output_specs(
     const auto& input = tensor_args.input;
     return tt::tt_metal::TensorSpec(
         input.logical_shape(),
-        tt::tt_metal::TensorLayout::fromPaddedShape(
+        tt::tt_metal::tensor_layout_from_padded_shape(
             operation_attributes.dtype,
             tt::tt_metal::PageConfig(input.layout()),
             operation_attributes.memory_config,
@@ -90,7 +91,8 @@ ttnn::Tensor clone(
         OperationType::operation_attributes_t{
             dtype.value_or(input.dtype()),
             memory_config.value_or(input.memory_config()),
-            init_device_compute_kernel_config(input.device()->arch(), compute_kernel_config, tt::tt_metal::MathFidelity::HiFi4),
+            init_device_compute_kernel_config(
+                input.device()->arch(), compute_kernel_config, tt::tt_metal::MathFidelity::HiFi4),
         },
         OperationType::tensor_args_t{input});
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/clone/device/clone_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/clone/device/clone_device_operation.cpp
@@ -54,7 +54,7 @@ CloneOperation::spec_return_value_t CloneOperation::compute_output_specs(
     const auto& input = tensor_args.input;
     return tt::tt_metal::TensorSpec(
         input.logical_shape(),
-        tt::tt_metal::tensor_layout_from_padded_shape(
+        tt::tt_metal::experimental::tensor_layout_from_padded_shape(
             operation_attributes.dtype,
             tt::tt_metal::PageConfig(input.layout()),
             operation_attributes.memory_config,

--- a/ttnn/cpp/ttnn/operations/data_movement/copy/device/copy_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/copy/device/copy_device_operation.cpp
@@ -9,6 +9,7 @@
 
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/tt_align.hpp>
+#include <tt-metalium/experimental/tensor_layout_apis_with_custom_alignment.hpp>
 
 namespace ttnn::prim {
 
@@ -167,7 +168,7 @@ CopyDeviceOperation::spec_return_value_t CopyDeviceOperation::compute_output_spe
                                         // padded_shape due to having a different shard_spec.
     return {tt::tt_metal::TensorSpec(
         input_tensor.logical_shape(),
-        tt::tt_metal::TensorLayout::fromPaddedShape(
+        tt::tt_metal::tensor_layout_from_padded_shape(
             operation_attributes.output_dtype,
             tt::tt_metal::PageConfig(input_tensor.layout()),
             operation_attributes.output_mem_config,

--- a/ttnn/cpp/ttnn/operations/data_movement/copy/device/copy_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/copy/device/copy_device_operation.cpp
@@ -168,7 +168,7 @@ CopyDeviceOperation::spec_return_value_t CopyDeviceOperation::compute_output_spe
                                         // padded_shape due to having a different shard_spec.
     return {tt::tt_metal::TensorSpec(
         input_tensor.logical_shape(),
-        tt::tt_metal::tensor_layout_from_padded_shape(
+        tt::tt_metal::experimental::tensor_layout_from_padded_shape(
             operation_attributes.output_dtype,
             tt::tt_metal::PageConfig(input_tensor.layout()),
             operation_attributes.output_mem_config,

--- a/ttnn/cpp/ttnn/operations/data_movement/moe_routing_remap/device/moe_routing_remap_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/moe_routing_remap/device/moe_routing_remap_device_operation.cpp
@@ -76,7 +76,7 @@ MoeRoutingRemapDeviceOperation::spec_return_value_t MoeRoutingRemapDeviceOperati
     const auto& old_spec = routing_weights.tensor_spec();
     return tt::tt_metal::TensorSpec(
         old_spec.logical_shape(),
-        tensor_layout_with_custom_alignment(
+        experimental::tensor_layout_with_custom_alignment(
             old_spec.tensor_layout().get_data_type(),
             old_spec.tensor_layout().get_page_config(),
             mem_config,

--- a/ttnn/cpp/ttnn/operations/data_movement/moe_routing_remap/device/moe_routing_remap_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/moe_routing_remap/device/moe_routing_remap_device_operation.cpp
@@ -9,6 +9,7 @@
 #include "moe_routing_remap_device_operation.hpp"
 #include "ttnn/device_operation.hpp"
 #include "ttnn/tensor/tensor_ops.hpp"
+#include <tt-metalium/experimental/tensor_layout_apis_with_custom_alignment.hpp>
 
 namespace ttnn::operations::data_movement {
 
@@ -75,7 +76,7 @@ MoeRoutingRemapDeviceOperation::spec_return_value_t MoeRoutingRemapDeviceOperati
     const auto& old_spec = routing_weights.tensor_spec();
     return tt::tt_metal::TensorSpec(
         old_spec.logical_shape(),
-        TensorLayout(
+        tensor_layout_with_custom_alignment(
             old_spec.tensor_layout().get_data_type(),
             old_spec.tensor_layout().get_page_config(),
             mem_config,

--- a/ttnn/cpp/ttnn/operations/data_movement/moe_routing_remap/device/moe_routing_remap_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/moe_routing_remap/device/moe_routing_remap_device_operation.cpp
@@ -76,7 +76,7 @@ MoeRoutingRemapDeviceOperation::spec_return_value_t MoeRoutingRemapDeviceOperati
     const auto& old_spec = routing_weights.tensor_spec();
     return tt::tt_metal::TensorSpec(
         old_spec.logical_shape(),
-        experimental::tensor_layout_with_custom_alignment(
+        tt::tt_metal::experimental::tensor_layout_with_custom_alignment(
             old_spec.tensor_layout().get_data_type(),
             old_spec.tensor_layout().get_page_config(),
             mem_config,

--- a/ttnn/cpp/ttnn/operations/data_movement/move/move.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/move/move.cpp
@@ -13,6 +13,7 @@
 #include <tt-metalium/hal.hpp>
 #include <tt-metalium/allocator.hpp>
 #include <tt-metalium/experimental/distributed_tensor/distributed_tensor_apis.hpp>
+#include <tt-metalium/experimental/tensor_layout_apis_with_custom_alignment.hpp>
 
 using namespace tt::tt_metal;
 
@@ -51,7 +52,7 @@ inline Tensor move_impl(const Tensor& input_tensor, const std::optional<MemoryCo
     if (mem_config) {
         output_tensor_spec = tt::tt_metal::TensorSpec(
             output_tensor_spec.logical_shape(),
-            TensorLayout(
+            tensor_layout_with_custom_alignment(
                 output_tensor_spec.tensor_layout().get_data_type(),
                 output_tensor_spec.tensor_layout().get_page_config(),
                 *mem_config,
@@ -145,7 +146,7 @@ inline Tensor move_sharded(const Tensor& input_tensor, const std::optional<Memor
         auto output_mem_config = MemoryConfig(mem_config->memory_layout(), mem_config->buffer_type(), shard_spec);
         output_tensor_spec = tt::tt_metal::TensorSpec(
             output_tensor_spec.logical_shape(),
-            TensorLayout(
+            tensor_layout_with_custom_alignment(
                 output_tensor_spec.tensor_layout().get_data_type(),
                 output_tensor_spec.tensor_layout().get_page_config(),
                 output_mem_config,

--- a/ttnn/cpp/ttnn/operations/data_movement/move/move.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/move/move.cpp
@@ -52,7 +52,7 @@ inline Tensor move_impl(const Tensor& input_tensor, const std::optional<MemoryCo
     if (mem_config) {
         output_tensor_spec = tt::tt_metal::TensorSpec(
             output_tensor_spec.logical_shape(),
-            tensor_layout_with_custom_alignment(
+            experimental::tensor_layout_with_custom_alignment(
                 output_tensor_spec.tensor_layout().get_data_type(),
                 output_tensor_spec.tensor_layout().get_page_config(),
                 *mem_config,
@@ -146,7 +146,7 @@ inline Tensor move_sharded(const Tensor& input_tensor, const std::optional<Memor
         auto output_mem_config = MemoryConfig(mem_config->memory_layout(), mem_config->buffer_type(), shard_spec);
         output_tensor_spec = tt::tt_metal::TensorSpec(
             output_tensor_spec.logical_shape(),
-            tensor_layout_with_custom_alignment(
+            experimental::tensor_layout_with_custom_alignment(
                 output_tensor_spec.tensor_layout().get_data_type(),
                 output_tensor_spec.tensor_layout().get_page_config(),
                 output_mem_config,

--- a/ttnn/cpp/ttnn/operations/data_movement/move/move.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/move/move.cpp
@@ -52,7 +52,7 @@ inline Tensor move_impl(const Tensor& input_tensor, const std::optional<MemoryCo
     if (mem_config) {
         output_tensor_spec = tt::tt_metal::TensorSpec(
             output_tensor_spec.logical_shape(),
-            experimental::tensor_layout_with_custom_alignment(
+            tt::tt_metal::experimental::tensor_layout_with_custom_alignment(
                 output_tensor_spec.tensor_layout().get_data_type(),
                 output_tensor_spec.tensor_layout().get_page_config(),
                 *mem_config,
@@ -146,7 +146,7 @@ inline Tensor move_sharded(const Tensor& input_tensor, const std::optional<Memor
         auto output_mem_config = MemoryConfig(mem_config->memory_layout(), mem_config->buffer_type(), shard_spec);
         output_tensor_spec = tt::tt_metal::TensorSpec(
             output_tensor_spec.logical_shape(),
-            experimental::tensor_layout_with_custom_alignment(
+            tt::tt_metal::experimental::tensor_layout_with_custom_alignment(
                 output_tensor_spec.tensor_layout().get_data_type(),
                 output_tensor_spec.tensor_layout().get_page_config(),
                 output_mem_config,

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_device_operation.cpp
@@ -18,6 +18,7 @@
 #include "ttnn/operations/data_movement/pad/device/pad_rm_sharded_width_only_program_factory.hpp"
 #include "ttnn/operations/data_movement/pad/device/pad_tile_multicore_program_factory.hpp"
 #include "ttnn/operations/data_movement/pad/device/pad_tile_program_factory.hpp"
+#include <tt-metalium/experimental/tensor_layout_apis_with_custom_alignment.hpp>
 
 using namespace tt::tt_metal;
 namespace ttnn::prim {
@@ -215,7 +216,7 @@ tt::tt_metal::TensorSpec PadDeviceOperation::compute_output_specs(
     const auto& input_tensor = tensor_args.input;
     return tt::tt_metal::TensorSpec(
         operation_attributes.output_logical_shape,
-        TensorLayout::fromPaddedShape(
+        tensor_layout_from_padded_shape(
             input_tensor.dtype(),
             PageConfig(input_tensor.layout()),
             operation_attributes.output_mem_config,

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_device_operation.cpp
@@ -216,7 +216,7 @@ tt::tt_metal::TensorSpec PadDeviceOperation::compute_output_specs(
     const auto& input_tensor = tensor_args.input;
     return tt::tt_metal::TensorSpec(
         operation_attributes.output_logical_shape,
-        tensor_layout_from_padded_shape(
+        experimental::tensor_layout_from_padded_shape(
             input_tensor.dtype(),
             PageConfig(input_tensor.layout()),
             operation_attributes.output_mem_config,

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_device_operation.cpp
@@ -216,7 +216,7 @@ tt::tt_metal::TensorSpec PadDeviceOperation::compute_output_specs(
     const auto& input_tensor = tensor_args.input;
     return tt::tt_metal::TensorSpec(
         operation_attributes.output_logical_shape,
-        experimental::tensor_layout_from_padded_shape(
+        tt::tt_metal::experimental::tensor_layout_from_padded_shape(
             input_tensor.dtype(),
             PageConfig(input_tensor.layout()),
             operation_attributes.output_mem_config,

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/reshape_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/reshape_op.cpp
@@ -10,6 +10,7 @@
 #include "ttnn/tensor/tensor_ops.hpp"
 #include "ttnn/tensor/tensor_utils.hpp"
 #include "ttnn/operations/data_movement/common/common.hpp"
+#include <tt-metalium/experimental/tensor_layout_apis_with_custom_alignment.hpp>
 
 using namespace tt::constants;
 using namespace tt::tt_metal;
@@ -67,7 +68,7 @@ ReshapeDeviceOperation::spec_return_value_t ReshapeDeviceOperation::compute_outp
     const auto& input_tensor = tensor_args.input_tensor;
     return tt::tt_metal::TensorSpec(
         operation_attributes.logical_output_shape,
-        TensorLayout::fromPaddedShape(
+        tensor_layout_from_padded_shape(
             input_tensor.dtype(),
             input_tensor.tensor_spec().page_config(),
             operation_attributes.output_mem_config,

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/reshape_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/reshape_op.cpp
@@ -68,7 +68,7 @@ ReshapeDeviceOperation::spec_return_value_t ReshapeDeviceOperation::compute_outp
     const auto& input_tensor = tensor_args.input_tensor;
     return tt::tt_metal::TensorSpec(
         operation_attributes.logical_output_shape,
-        tensor_layout_from_padded_shape(
+        experimental::tensor_layout_from_padded_shape(
             input_tensor.dtype(),
             input_tensor.tensor_spec().page_config(),
             operation_attributes.output_mem_config,

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/reshape_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/device/reshape_op.cpp
@@ -68,7 +68,7 @@ ReshapeDeviceOperation::spec_return_value_t ReshapeDeviceOperation::compute_outp
     const auto& input_tensor = tensor_args.input_tensor;
     return tt::tt_metal::TensorSpec(
         operation_attributes.logical_output_shape,
-        experimental::tensor_layout_from_padded_shape(
+        tt::tt_metal::experimental::tensor_layout_from_padded_shape(
             input_tensor.dtype(),
             input_tensor.tensor_spec().page_config(),
             operation_attributes.output_mem_config,

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/reshape.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/reshape.cpp
@@ -15,6 +15,7 @@
 #include "ttnn/operations/experimental/reshape/view.hpp"
 #include "ttnn/operations/data_movement/reshape_view/reshape_common.hpp"
 #include <tt-metalium/experimental/distributed_tensor/distributed_tensor_apis.hpp>
+#include <tt-metalium/experimental/tensor_layout_apis_with_custom_alignment.hpp>
 
 namespace ttnn::operations::data_movement::detail {
 
@@ -33,10 +34,11 @@ static Tensor manual_insertion(
     auto cpu_tensor = input_tensor.cpu();
     auto output_spec = tt::tt_metal::TensorSpec(
         logical_shape,
-        TensorLayout::fromPaddedShape(
+        tt::tt_metal::tensor_layout_from_padded_shape(
             DataType::BFLOAT16, PageConfig(Layout::ROW_MAJOR), MemoryConfig{}, logical_shape, padded_shape));
-    auto output = Tensor(tt::tt_metal::host_tensor_from_buffer_with_topology(
-                             cpu_tensor.host_storage().buffer(), std::move(output_spec), cpu_tensor.tensor_topology()))
+    auto output = Tensor(
+                      tt::tt_metal::host_tensor_from_buffer_with_topology(
+                          cpu_tensor.host_storage().buffer(), std::move(output_spec), cpu_tensor.tensor_topology()))
                       .to_layout(Layout::ROW_MAJOR);
     if (device != nullptr) {
         output = output.to_device(device, output_mem_config);

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/reshape.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/reshape.cpp
@@ -34,7 +34,7 @@ static Tensor manual_insertion(
     auto cpu_tensor = input_tensor.cpu();
     auto output_spec = tt::tt_metal::TensorSpec(
         logical_shape,
-        tt::tt_metal::tensor_layout_from_padded_shape(
+        tt::tt_metal::experimental::tensor_layout_from_padded_shape(
             DataType::BFLOAT16, PageConfig(Layout::ROW_MAJOR), MemoryConfig{}, logical_shape, padded_shape));
     auto output = Tensor(
                       tt::tt_metal::host_tensor_from_buffer_with_topology(

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_device_operation.cpp
@@ -6,6 +6,7 @@
 #include "ttnn/device_operation.hpp"
 #include "ttnn/operations/data_movement/common/common.hpp"
 #include "ttnn/tensor/tensor_ops.hpp"
+#include <tt-metalium/experimental/tensor_layout_apis_with_custom_alignment.hpp>
 
 namespace ttnn::prim {
 
@@ -32,7 +33,7 @@ ReshapeViewDeviceOperation::spec_return_value_t ReshapeViewDeviceOperation::comp
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     return tt::tt_metal::TensorSpec(
         operation_attributes.logical_output_shape,
-        tt::tt_metal::TensorLayout::fromPaddedShape(
+        tt::tt_metal::tensor_layout_from_padded_shape(
             tensor_args.input.dtype(),
             tt::tt_metal::PageConfig(tensor_args.input.layout()),
             operation_attributes.output_mem_config,

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_device_operation.cpp
@@ -33,7 +33,7 @@ ReshapeViewDeviceOperation::spec_return_value_t ReshapeViewDeviceOperation::comp
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     return tt::tt_metal::TensorSpec(
         operation_attributes.logical_output_shape,
-        tt::tt_metal::tensor_layout_from_padded_shape(
+        tt::tt_metal::experimental::tensor_layout_from_padded_shape(
             tensor_args.input.dtype(),
             tt::tt_metal::PageConfig(tensor_args.input.layout()),
             operation_attributes.output_mem_config,

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
@@ -31,6 +31,7 @@
 #include "reshape.hpp"
 #include "reshape_common.hpp"
 #include "device/reshape_device_operation.hpp"
+#include <tt-metalium/experimental/tensor_layout_apis_with_custom_alignment.hpp>
 
 namespace ttnn::operations::data_movement {
 namespace detail {
@@ -446,7 +447,7 @@ ttnn::Tensor reshape_tiled(
             MemoryConfig interleaved_output_mem_config{TensorMemoryLayout::INTERLEAVED, memory_config.buffer_type()};
             auto interleaved_output_spec = tt::tt_metal::TensorSpec(
                 requested_shape_3d,
-                tt::tt_metal::TensorLayout::fromPaddedShape(
+                tt::tt_metal::tensor_layout_from_padded_shape(
                     tensor3d.dtype(),
                     tensor3d.tensor_spec().page_config(),
                     interleaved_output_mem_config,
@@ -510,7 +511,7 @@ ttnn::Tensor reshape_tiled(
         // passed here ends up baked into the layout's alignment, so synthetic_spec.physical_shape()
         // exactly matches the requested padded shape, even if compute_padded_shape ever produced
         // dimensions that exceed tile alignment (e.g., due to shard-aware padding).
-        auto synthetic_layout = tt::tt_metal::TensorLayout::fromPaddedShape(
+        auto synthetic_layout = tt::tt_metal::tensor_layout_from_padded_shape(
             tensor3d.dtype(),
             tensor3d.tensor_spec().page_config(),
             MemoryConfig(updated_mem_config.buffer_type()),

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/reshape.cpp
@@ -447,7 +447,7 @@ ttnn::Tensor reshape_tiled(
             MemoryConfig interleaved_output_mem_config{TensorMemoryLayout::INTERLEAVED, memory_config.buffer_type()};
             auto interleaved_output_spec = tt::tt_metal::TensorSpec(
                 requested_shape_3d,
-                tt::tt_metal::tensor_layout_from_padded_shape(
+                tt::tt_metal::experimental::tensor_layout_from_padded_shape(
                     tensor3d.dtype(),
                     tensor3d.tensor_spec().page_config(),
                     interleaved_output_mem_config,
@@ -511,7 +511,7 @@ ttnn::Tensor reshape_tiled(
         // passed here ends up baked into the layout's alignment, so synthetic_spec.physical_shape()
         // exactly matches the requested padded shape, even if compute_padded_shape ever produced
         // dimensions that exceed tile alignment (e.g., due to shard-aware padding).
-        auto synthetic_layout = tt::tt_metal::tensor_layout_from_padded_shape(
+        auto synthetic_layout = tt::tt_metal::experimental::tensor_layout_from_padded_shape(
             tensor3d.dtype(),
             tensor3d.tensor_spec().page_config(),
             MemoryConfig(updated_mem_config.buffer_type()),

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_to_interleaved/device/sharded_to_interleaved_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_to_interleaved/device/sharded_to_interleaved_device_operation.cpp
@@ -7,6 +7,7 @@
 #include <tt-metalium/hal.hpp>
 #include "ttnn/operations/data_movement/common/common.hpp"
 #include "ttnn/tensor/tensor_ops.hpp"
+#include <tt-metalium/experimental/tensor_layout_apis_with_custom_alignment.hpp>
 
 using namespace tt::tt_metal;
 
@@ -108,7 +109,7 @@ tt::tt_metal::TensorSpec ShardedToInterleavedDeviceOperation::compute_output_spe
     // inter-stick byte overlap and data corruption.
     return tt::tt_metal::TensorSpec(
         input_tensor.logical_shape(),
-        tt::tt_metal::TensorLayout::fromPaddedShape(
+        tt::tt_metal::tensor_layout_from_padded_shape(
             args.output_dtype,
             tt::tt_metal::PageConfig(input_tensor.layout()),
             args.output_mem_config,

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_to_interleaved/device/sharded_to_interleaved_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/sharded_to_interleaved/device/sharded_to_interleaved_device_operation.cpp
@@ -109,7 +109,7 @@ tt::tt_metal::TensorSpec ShardedToInterleavedDeviceOperation::compute_output_spe
     // inter-stick byte overlap and data corruption.
     return tt::tt_metal::TensorSpec(
         input_tensor.logical_shape(),
-        tt::tt_metal::tensor_layout_from_padded_shape(
+        tt::tt_metal::experimental::tensor_layout_from_padded_shape(
             args.output_dtype,
             tt::tt_metal::PageConfig(input_tensor.layout()),
             args.output_mem_config,

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_device_operation.cpp
@@ -253,7 +253,7 @@ TilizeDeviceOperation::spec_return_value_t TilizeDeviceOperation::compute_output
                                                          // factory, the output has the same shard spec as the input.
         return {tt::tt_metal::TensorSpec(
             input_tensor.logical_shape(),
-            experimental::tensor_layout_from_padded_shape(
+            tt::tt_metal::experimental::tensor_layout_from_padded_shape(
                 operation_attributes.output_dtype,
                 PageConfig(Layout::TILE, operation_attributes.tile),
                 mem_config,

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_device_operation.cpp
@@ -16,6 +16,7 @@
 #include <tt-metalium/hal.hpp>
 #include "ttnn/operations/core/work_split/work_split_tilize.hpp"
 #include "ttnn/tensor/tensor_ops.hpp"
+#include <tt-metalium/experimental/tensor_layout_apis_with_custom_alignment.hpp>
 using namespace tt::tt_metal;
 
 namespace ttnn::prim {
@@ -252,7 +253,7 @@ TilizeDeviceOperation::spec_return_value_t TilizeDeviceOperation::compute_output
                                                          // factory, the output has the same shard spec as the input.
         return {tt::tt_metal::TensorSpec(
             input_tensor.logical_shape(),
-            TensorLayout::fromPaddedShape(
+            tensor_layout_from_padded_shape(
                 operation_attributes.output_dtype,
                 PageConfig(Layout::TILE, operation_attributes.tile),
                 mem_config,

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_device_operation.cpp
@@ -17,6 +17,7 @@
 #include "ttnn/operations/core/work_split/work_split_tilize.hpp"
 #include "ttnn/tensor/tensor_ops.hpp"
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/experimental/tensor_layout_apis_with_custom_alignment.hpp>
 using namespace tt::tt_metal;
 
 namespace ttnn::prim {
@@ -253,7 +254,7 @@ TilizeDeviceOperation::spec_return_value_t TilizeDeviceOperation::compute_output
                                                          // factory, the output has the same shard spec as the input.
         return {tt::tt_metal::TensorSpec(
             input_tensor.logical_shape(),
-            TensorLayout::fromPaddedShape(
+            tensor_layout_from_padded_shape(
                 operation_attributes.output_dtype,
                 PageConfig(Layout::TILE, operation_attributes.tile),
                 mem_config,

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_device_operation.cpp
@@ -254,7 +254,7 @@ TilizeDeviceOperation::spec_return_value_t TilizeDeviceOperation::compute_output
                                                          // factory, the output has the same shard spec as the input.
         return {tt::tt_metal::TensorSpec(
             input_tensor.logical_shape(),
-            tensor_layout_from_padded_shape(
+            experimental::tensor_layout_from_padded_shape(
                 operation_attributes.output_dtype,
                 PageConfig(Layout::TILE, operation_attributes.tile),
                 mem_config,

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_device_operation.cpp
@@ -253,7 +253,7 @@ TilizeDeviceOperation::spec_return_value_t TilizeDeviceOperation::compute_output
                                                          // factory, the output has the same shard spec as the input.
         return {tt::tt_metal::TensorSpec(
             input_tensor.logical_shape(),
-            tensor_layout_from_padded_shape(
+            experimental::tensor_layout_from_padded_shape(
                 operation_attributes.output_dtype,
                 PageConfig(Layout::TILE, operation_attributes.tile),
                 mem_config,

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_device_operation.cpp
@@ -254,7 +254,7 @@ TilizeDeviceOperation::spec_return_value_t TilizeDeviceOperation::compute_output
                                                          // factory, the output has the same shard spec as the input.
         return {tt::tt_metal::TensorSpec(
             input_tensor.logical_shape(),
-            experimental::tensor_layout_from_padded_shape(
+            tt::tt_metal::experimental::tensor_layout_from_padded_shape(
                 operation_attributes.output_dtype,
                 PageConfig(Layout::TILE, operation_attributes.tile),
                 mem_config,

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_device_operation.cpp
@@ -8,6 +8,7 @@
 #include <tt-metalium/hal.hpp>
 #include <tt-metalium/constants.hpp>
 #include "ttnn/operations/core/work_split/work_split_tilize.hpp"
+#include <tt-metalium/experimental/tensor_layout_apis_with_custom_alignment.hpp>
 
 using namespace tt::tt_metal;
 using namespace tt::constants;
@@ -186,7 +187,7 @@ tt::tt_metal::TensorSpec TilizeWithValPaddingDeviceOperation::compute_output_spe
                           // factory, the output has the same shard spec as the input.
         return tt::tt_metal::TensorSpec(
             input_shape,
-            TensorLayout::fromPaddedShape(
+            tensor_layout_from_padded_shape(
                 operation_attributes.output_dtype,
                 PageConfig(Layout::TILE),
                 mem_config,
@@ -196,7 +197,7 @@ tt::tt_metal::TensorSpec TilizeWithValPaddingDeviceOperation::compute_output_spe
 
     return tt::tt_metal::TensorSpec(
         input_shape,
-        TensorLayout::fromPaddedShape(
+        tensor_layout_from_padded_shape(
             operation_attributes.output_dtype,
             PageConfig(Layout::TILE),
             operation_attributes.output_mem_config,

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_device_operation.cpp
@@ -187,7 +187,7 @@ tt::tt_metal::TensorSpec TilizeWithValPaddingDeviceOperation::compute_output_spe
                           // factory, the output has the same shard spec as the input.
         return tt::tt_metal::TensorSpec(
             input_shape,
-            experimental::tensor_layout_from_padded_shape(
+            tt::tt_metal::experimental::tensor_layout_from_padded_shape(
                 operation_attributes.output_dtype,
                 PageConfig(Layout::TILE),
                 mem_config,
@@ -197,7 +197,7 @@ tt::tt_metal::TensorSpec TilizeWithValPaddingDeviceOperation::compute_output_spe
 
     return tt::tt_metal::TensorSpec(
         input_shape,
-        experimental::tensor_layout_from_padded_shape(
+        tt::tt_metal::experimental::tensor_layout_from_padded_shape(
             operation_attributes.output_dtype,
             PageConfig(Layout::TILE),
             operation_attributes.output_mem_config,

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/tilize_with_val_padding_device_operation.cpp
@@ -187,7 +187,7 @@ tt::tt_metal::TensorSpec TilizeWithValPaddingDeviceOperation::compute_output_spe
                           // factory, the output has the same shard spec as the input.
         return tt::tt_metal::TensorSpec(
             input_shape,
-            tensor_layout_from_padded_shape(
+            experimental::tensor_layout_from_padded_shape(
                 operation_attributes.output_dtype,
                 PageConfig(Layout::TILE),
                 mem_config,
@@ -197,7 +197,7 @@ tt::tt_metal::TensorSpec TilizeWithValPaddingDeviceOperation::compute_output_spe
 
     return tt::tt_metal::TensorSpec(
         input_shape,
-        tensor_layout_from_padded_shape(
+        experimental::tensor_layout_from_padded_shape(
             operation_attributes.output_dtype,
             PageConfig(Layout::TILE),
             operation_attributes.output_mem_config,

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_device_operation.cpp
@@ -8,6 +8,7 @@
 
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/hal.hpp>
+#include <tt-metalium/experimental/tensor_layout_apis_with_custom_alignment.hpp>
 
 using namespace tt::constants;
 using namespace tt::tt_metal;
@@ -213,7 +214,7 @@ tt::tt_metal::TensorSpec TransposeDeviceOperation::compute_output_specs(
 
     return tt::tt_metal::TensorSpec(
         output_shape,
-        TensorLayout::fromPaddedShape(
+        tensor_layout_from_padded_shape(
             input_tensor.dtype(),
             PageConfig(input_tensor.layout()),
             output_mem_config,

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_device_operation.cpp
@@ -214,7 +214,7 @@ tt::tt_metal::TensorSpec TransposeDeviceOperation::compute_output_specs(
 
     return tt::tt_metal::TensorSpec(
         output_shape,
-        experimental::tensor_layout_from_padded_shape(
+        tt::tt_metal::experimental::tensor_layout_from_padded_shape(
             input_tensor.dtype(),
             PageConfig(input_tensor.layout()),
             output_mem_config,

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_device_operation.cpp
@@ -214,7 +214,7 @@ tt::tt_metal::TensorSpec TransposeDeviceOperation::compute_output_specs(
 
     return tt::tt_metal::TensorSpec(
         output_shape,
-        tensor_layout_from_padded_shape(
+        experimental::tensor_layout_from_padded_shape(
             input_tensor.dtype(),
             PageConfig(input_tensor.layout()),
             output_mem_config,

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_device_operation.cpp
@@ -20,6 +20,7 @@
 #include "ttnn/operations/core/work_split/work_split_tilize.hpp"
 #include "ttnn/common/constants.hpp"
 #include <tt-metalium/buffer_distribution_spec.hpp>
+#include <tt-metalium/experimental/tensor_layout_apis_with_custom_alignment.hpp>
 
 using namespace tt::tt_metal;
 
@@ -263,7 +264,7 @@ UntilizeDeviceOperation::spec_return_value_t UntilizeDeviceOperation::compute_ou
 
     return {tt::tt_metal::TensorSpec(
         input_tensor.logical_shape(),
-        TensorLayout::fromPaddedShape(
+        tensor_layout_from_padded_shape(
             output_dtype,
             PageConfig(Layout::ROW_MAJOR),
             operation_attributes.output_mem_config,

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_device_operation.cpp
@@ -264,7 +264,7 @@ UntilizeDeviceOperation::spec_return_value_t UntilizeDeviceOperation::compute_ou
 
     return {tt::tt_metal::TensorSpec(
         input_tensor.logical_shape(),
-        experimental::tensor_layout_from_padded_shape(
+        tt::tt_metal::experimental::tensor_layout_from_padded_shape(
             output_dtype,
             PageConfig(Layout::ROW_MAJOR),
             operation_attributes.output_mem_config,

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_device_operation.cpp
@@ -264,7 +264,7 @@ UntilizeDeviceOperation::spec_return_value_t UntilizeDeviceOperation::compute_ou
 
     return {tt::tt_metal::TensorSpec(
         input_tensor.logical_shape(),
-        tensor_layout_from_padded_shape(
+        experimental::tensor_layout_from_padded_shape(
             output_dtype,
             PageConfig(Layout::ROW_MAJOR),
             operation_attributes.output_mem_config,

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation.cpp
@@ -8,6 +8,7 @@
 #include "ttnn/operation.hpp"
 #include "ttnn/tensor/tensor_utils.hpp"
 #include "ttnn/tensor/tensor_ops.hpp"
+#include <tt-metalium/experimental/tensor_layout_apis_with_custom_alignment.hpp>
 
 using namespace tt::tt_metal;
 
@@ -127,7 +128,7 @@ tt::tt_metal::TensorSpec UnaryDeviceOperation::compute_output_specs(
     const auto output_layout = tensor_args.input.layout();
     return tt::tt_metal::TensorSpec(
         output_shape,
-        TensorLayout::fromPaddedShape(
+        tensor_layout_from_padded_shape(
             args.output_dtype,
             PageConfig(output_layout),
             args.memory_config,

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation.cpp
@@ -128,7 +128,7 @@ tt::tt_metal::TensorSpec UnaryDeviceOperation::compute_output_specs(
     const auto output_layout = tensor_args.input.layout();
     return tt::tt_metal::TensorSpec(
         output_shape,
-        tensor_layout_from_padded_shape(
+        experimental::tensor_layout_from_padded_shape(
             args.output_dtype,
             PageConfig(output_layout),
             args.memory_config,

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_device_operation.cpp
@@ -128,7 +128,7 @@ tt::tt_metal::TensorSpec UnaryDeviceOperation::compute_output_specs(
     const auto output_layout = tensor_args.input.layout();
     return tt::tt_metal::TensorSpec(
         output_shape,
-        experimental::tensor_layout_from_padded_shape(
+        tt::tt_metal::experimental::tensor_layout_from_padded_shape(
             args.output_dtype,
             PageConfig(output_layout),
             args.memory_config,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/rms_allgather_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/rms_allgather_device_operation.cpp
@@ -12,6 +12,7 @@
 
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/experimental/tensor_layout_apis_with_custom_alignment.hpp>
 
 using namespace tt::tt_metal;
 using namespace tt::constants;
@@ -247,7 +248,7 @@ tt::tt_metal::TensorSpec RMSAllGatherDeviceOperation::compute_output_specs(
 
     return tt::tt_metal::TensorSpec(
         output_shape,
-        TensorLayout::fromPaddedShape(
+        tensor_layout_from_padded_shape(
             args.dtype.value_or(input_tensor.dtype()),
             PageConfig(Layout::TILE),
             mem_config,
@@ -318,8 +319,8 @@ ttnn::experimental::prim::RMSAllGatherDeviceOperation::tensor_return_value_t rms
     bool use_noc1_only) {
     using OperationType = ttnn::experimental::prim::RMSAllGatherDeviceOperation;
     auto arch = is_device_tensor(input_tensor) ? input_tensor.device()->arch() : ttnn::GetDefaultDevice()->arch();
-    auto kernel_config_val =
-        init_device_compute_kernel_config(arch, compute_kernel_config, tt::tt_metal::MathFidelity::HiFi4, true, false, false);
+    auto kernel_config_val = init_device_compute_kernel_config(
+        arch, compute_kernel_config, tt::tt_metal::MathFidelity::HiFi4, true, false, false);
     const auto& mesh_view = mesh_device.get_view();
     std::size_t num_devices = (cluster_axis == 0) ? mesh_view.num_rows() : mesh_view.num_cols();
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/rms_allgather_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/rms_allgather_device_operation.cpp
@@ -248,7 +248,7 @@ tt::tt_metal::TensorSpec RMSAllGatherDeviceOperation::compute_output_specs(
 
     return tt::tt_metal::TensorSpec(
         output_shape,
-        tensor_layout_from_padded_shape(
+        experimental::tensor_layout_from_padded_shape(
             args.dtype.value_or(input_tensor.dtype()),
             PageConfig(Layout::TILE),
             mem_config,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/rms_allgather_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/rms_allgather_device_operation.cpp
@@ -248,7 +248,7 @@ tt::tt_metal::TensorSpec RMSAllGatherDeviceOperation::compute_output_specs(
 
     return tt::tt_metal::TensorSpec(
         output_shape,
-        experimental::tensor_layout_from_padded_shape(
+        tt::tt_metal::experimental::tensor_layout_from_padded_shape(
             args.dtype.value_or(input_tensor.dtype()),
             PageConfig(Layout::TILE),
             mem_config,

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_device_operation.cpp
@@ -14,6 +14,7 @@
 #include "ttnn/tensor/tensor_ops.hpp"
 #include <tt-metalium/hal.hpp>
 #include "ttnn/tensor/tensor_utils.hpp"
+#include <tt-metalium/experimental/tensor_layout_apis_with_custom_alignment.hpp>
 
 using namespace tt::constants;
 using namespace tt::tt_metal;
@@ -238,7 +239,7 @@ tt::tt_metal::TensorSpec Conv3dDeviceOperation::compute_output_specs(
 
     return tt::tt_metal::TensorSpec(
         output_shape,
-        tt::tt_metal::TensorLayout::fromPaddedShape(
+        tt::tt_metal::tensor_layout_from_padded_shape(
             dtype, tt::tt_metal::PageConfig(Layout::ROW_MAJOR), memory_config, output_shape, padded_output_shape));
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_device_operation.cpp
@@ -239,7 +239,7 @@ tt::tt_metal::TensorSpec Conv3dDeviceOperation::compute_output_specs(
 
     return tt::tt_metal::TensorSpec(
         output_shape,
-        tt::tt_metal::tensor_layout_from_padded_shape(
+        tt::tt_metal::experimental::tensor_layout_from_padded_shape(
             dtype, tt::tt_metal::PageConfig(Layout::ROW_MAJOR), memory_config, output_shape, padded_output_shape));
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/conv2d.cpp
@@ -40,6 +40,7 @@
 #include "ttnn/operations/experimental/quasar/to_memory_config/to_memory_config_op.hpp"
 #include "ttnn/operations/experimental/quasar/to_device/to_device.hpp"
 #include "ttnn/operations/sliding_window/sliding_window.hpp"
+#include <tt-metalium/experimental/tensor_layout_apis_with_custom_alignment.hpp>
 
 namespace ttnn::operations::conv {
 // get_conv_padded_input_shape_and_mem_config has external linkage but is not declared in
@@ -61,8 +62,8 @@ namespace ttnn::operations::experimental::quasar::detail {
 
 // Shared conv host infrastructure (conv2d_utils.hpp, prepare_conv2d_weights.hpp) is reused from the
 // original conv namespaces; bring it into scope so this impl's bare references resolve unchanged.
-using namespace ttnn::operations::conv;          // conv2d_utils helpers (get_conv_configs, determine_*, ...)
-using namespace ttnn::operations::conv::conv2d;  // prepare_conv2d_weights helpers, get_conv2d_slice_attr
+using namespace ttnn::operations::conv;                  // conv2d_utils helpers (get_conv_configs, determine_*, ...)
+using namespace ttnn::operations::conv::conv2d;          // prepare_conv2d_weights helpers, get_conv2d_slice_attr
 using ttnn::operations::sliding_window::ParallelConfig;  // return/locals of shard_or_reshard fork
 
 using ttnn::operations::experimental::quasar::Conv2dResult;
@@ -234,7 +235,7 @@ static std::tuple<ttnn::Tensor, ParallelConfig, ParallelConfig> shard_or_reshard
                 Tensor resharded_input_tensor = ttnn::create_device_tensor(
                     tt::tt_metal::TensorSpec(
                         input_tensor.logical_shape(),
-                        tt::tt_metal::TensorLayout(
+                        tt::tt_metal::tensor_layout_with_custom_alignment(
                             input_tensor.dtype(),
                             tt::tt_metal::PageConfig(input_tensor.layout()),
                             input_tensor_sharded_memory_config_to_layout,

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/conv2d.cpp
@@ -41,6 +41,7 @@
 #include "ttnn/operations/experimental/quasar/to_device/to_device.hpp"
 #include "ttnn/operations/experimental/quasar/op_slicing/op_slicing.hpp"
 #include "ttnn/operations/sliding_window/sliding_window.hpp"
+#include <tt-metalium/experimental/tensor_layout_apis_with_custom_alignment.hpp>
 
 namespace ttnn::operations::conv {
 // get_conv_padded_input_shape_and_mem_config has external linkage but is not declared in
@@ -62,8 +63,8 @@ namespace ttnn::operations::experimental::quasar::detail {
 
 // Shared conv host infrastructure (conv2d_utils.hpp, prepare_conv2d_weights.hpp) is reused from the
 // original conv namespaces; bring it into scope so this impl's bare references resolve unchanged.
-using namespace ttnn::operations::conv;          // conv2d_utils helpers (get_conv_configs, determine_*, ...)
-using namespace ttnn::operations::conv::conv2d;  // prepare_conv2d_weights helpers, get_conv2d_slice_attr
+using namespace ttnn::operations::conv;                  // conv2d_utils helpers (get_conv_configs, determine_*, ...)
+using namespace ttnn::operations::conv::conv2d;          // prepare_conv2d_weights helpers, get_conv2d_slice_attr
 using ttnn::operations::sliding_window::ParallelConfig;  // return/locals of shard_or_reshard fork
 
 using ttnn::operations::experimental::quasar::Conv2dResult;
@@ -237,7 +238,7 @@ static std::tuple<ttnn::Tensor, ParallelConfig, ParallelConfig> shard_or_reshard
                 Tensor resharded_input_tensor = ttnn::create_device_tensor(
                     tt::tt_metal::TensorSpec(
                         input_tensor.logical_shape(),
-                        tt::tt_metal::TensorLayout(
+                        tt::tt_metal::tensor_layout_with_custom_alignment(
                             input_tensor.dtype(),
                             tt::tt_metal::PageConfig(input_tensor.layout()),
                             input_tensor_sharded_memory_config_to_layout,

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/conv2d.cpp
@@ -238,7 +238,7 @@ static std::tuple<ttnn::Tensor, ParallelConfig, ParallelConfig> shard_or_reshard
                 Tensor resharded_input_tensor = ttnn::create_device_tensor(
                     tt::tt_metal::TensorSpec(
                         input_tensor.logical_shape(),
-                        tt::tt_metal::tensor_layout_with_custom_alignment(
+                        tt::tt_metal::experimental::tensor_layout_with_custom_alignment(
                             input_tensor.dtype(),
                             tt::tt_metal::PageConfig(input_tensor.layout()),
                             input_tensor_sharded_memory_config_to_layout,

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/conv2d.cpp
@@ -235,7 +235,7 @@ static std::tuple<ttnn::Tensor, ParallelConfig, ParallelConfig> shard_or_reshard
                 Tensor resharded_input_tensor = ttnn::create_device_tensor(
                     tt::tt_metal::TensorSpec(
                         input_tensor.logical_shape(),
-                        tt::tt_metal::tensor_layout_with_custom_alignment(
+                        tt::tt_metal::experimental::tensor_layout_with_custom_alignment(
                             input_tensor.dtype(),
                             tt::tt_metal::PageConfig(input_tensor.layout()),
                             input_tensor_sharded_memory_config_to_layout,

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/conv2d_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/conv2d_device_operation.cpp
@@ -26,6 +26,7 @@
 
 #include "ttnn/operations/sliding_window/sliding_window.hpp"
 #include "ttnn/tensor/shape/shape.hpp"
+#include <tt-metalium/experimental/tensor_layout_apis_with_custom_alignment.hpp>
 
 namespace ttnn::prim::qsr {
 
@@ -97,8 +98,9 @@ tt::tt_metal::TensorSpec Conv2dDeviceOperation::compute_output_specs(
         tt::tt_metal::CoreRangeSet shard_grid;
         if (in_mem.memory_layout() == TensorMemoryLayout::BLOCK_SHARDED) {
             const auto bbox = in_mem.shard_spec().value().grid.bounding_box();
-            shard_grid = tt::tt_metal::CoreRangeSet(tt::tt_metal::CoreRange(
-                bbox.start_coord, CoreCoord(bbox.start_coord.x, bbox.start_coord.y + num_cores_nhw - 1)));
+            shard_grid = tt::tt_metal::CoreRangeSet(
+                tt::tt_metal::CoreRange(
+                    bbox.start_coord, CoreCoord(bbox.start_coord.x, bbox.start_coord.y + num_cores_nhw - 1)));
         } else {
             shard_grid = in_mem.shard_spec().value().grid;
         }
@@ -107,7 +109,7 @@ tt::tt_metal::TensorSpec Conv2dDeviceOperation::compute_output_specs(
             tt::tt_metal::MemoryConfig(TensorMemoryLayout::HEIGHT_SHARDED, tt::tt_metal::BufferType::L1, shard_spec);
         return tt::tt_metal::TensorSpec(
             tilized_shape,
-            tt::tt_metal::TensorLayout(
+            tt::tt_metal::tensor_layout_with_custom_alignment(
                 args.dtype,
                 tt::tt_metal::PageConfig(Layout::TILE),
                 mem_config,
@@ -149,7 +151,7 @@ tt::tt_metal::TensorSpec Conv2dDeviceOperation::compute_output_specs(
             args.memory_config.memory_layout(), args.memory_config.buffer_type(), shard_spec);
         return tt::tt_metal::TensorSpec(
             output_shape,
-            tt::tt_metal::TensorLayout(
+            tt::tt_metal::tensor_layout_with_custom_alignment(
                 args.dtype,
                 tt::tt_metal::PageConfig(output_layout),
                 mem_config,
@@ -161,7 +163,7 @@ tt::tt_metal::TensorSpec Conv2dDeviceOperation::compute_output_specs(
     }
     return tt::tt_metal::TensorSpec(
         output_shape,
-        tt::tt_metal::TensorLayout::fromPaddedShape(
+        tt::tt_metal::tensor_layout_from_padded_shape(
             args.dtype,
             tt::tt_metal::PageConfig(output_layout),
             args.memory_config,

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/conv2d_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/conv2d/device/conv2d_device_operation.cpp
@@ -109,7 +109,7 @@ tt::tt_metal::TensorSpec Conv2dDeviceOperation::compute_output_specs(
             tt::tt_metal::MemoryConfig(TensorMemoryLayout::HEIGHT_SHARDED, tt::tt_metal::BufferType::L1, shard_spec);
         return tt::tt_metal::TensorSpec(
             tilized_shape,
-            tt::tt_metal::tensor_layout_with_custom_alignment(
+            tt::tt_metal::experimental::tensor_layout_with_custom_alignment(
                 args.dtype,
                 tt::tt_metal::PageConfig(Layout::TILE),
                 mem_config,
@@ -151,7 +151,7 @@ tt::tt_metal::TensorSpec Conv2dDeviceOperation::compute_output_specs(
             args.memory_config.memory_layout(), args.memory_config.buffer_type(), shard_spec);
         return tt::tt_metal::TensorSpec(
             output_shape,
-            tt::tt_metal::tensor_layout_with_custom_alignment(
+            tt::tt_metal::experimental::tensor_layout_with_custom_alignment(
                 args.dtype,
                 tt::tt_metal::PageConfig(output_layout),
                 mem_config,
@@ -163,7 +163,7 @@ tt::tt_metal::TensorSpec Conv2dDeviceOperation::compute_output_specs(
     }
     return tt::tt_metal::TensorSpec(
         output_shape,
-        tt::tt_metal::tensor_layout_from_padded_shape(
+        tt::tt_metal::experimental::tensor_layout_from_padded_shape(
             args.dtype,
             tt::tt_metal::PageConfig(output_layout),
             args.memory_config,

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/halo/device/halo_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/halo/device/halo_device_operation.cpp
@@ -8,6 +8,7 @@
 #include "ttnn/operations/experimental/quasar/halo/device/halo_device_operation.hpp"
 #include "ttnn/device_operation.hpp"
 #include <array>
+#include <tt-metalium/experimental/tensor_layout_apis_with_custom_alignment.hpp>
 
 namespace ttnn::prim::qsr {
 
@@ -91,7 +92,7 @@ HaloDeviceOperation::spec_return_value_t HaloDeviceOperation::compute_output_spe
     padded_output_shape[-1] = tt::round_up(padded_output_shape[-1], shard_shape[1]);
     return tt::tt_metal::TensorSpec(
         output_shape,
-        TensorLayout::fromPaddedShape(
+        tensor_layout_from_padded_shape(
             output_dtype, PageConfig(Layout::ROW_MAJOR), out_mem_config, output_shape, padded_output_shape));
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/halo/device/halo_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/halo/device/halo_device_operation.cpp
@@ -92,7 +92,7 @@ HaloDeviceOperation::spec_return_value_t HaloDeviceOperation::compute_output_spe
     padded_output_shape[-1] = tt::round_up(padded_output_shape[-1], shard_shape[1]);
     return tt::tt_metal::TensorSpec(
         output_shape,
-        experimental::tensor_layout_from_padded_shape(
+        tt::tt_metal::experimental::tensor_layout_from_padded_shape(
             output_dtype, PageConfig(Layout::ROW_MAJOR), out_mem_config, output_shape, padded_output_shape));
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/halo/device/halo_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/halo/device/halo_device_operation.cpp
@@ -92,7 +92,7 @@ HaloDeviceOperation::spec_return_value_t HaloDeviceOperation::compute_output_spe
     padded_output_shape[-1] = tt::round_up(padded_output_shape[-1], shard_shape[1]);
     return tt::tt_metal::TensorSpec(
         output_shape,
-        tensor_layout_from_padded_shape(
+        experimental::tensor_layout_from_padded_shape(
             output_dtype, PageConfig(Layout::ROW_MAJOR), out_mem_config, output_shape, padded_output_shape));
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/move/move.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/move/move.cpp
@@ -13,6 +13,7 @@
 #include <tt-metalium/hal.hpp>
 #include <tt-metalium/allocator.hpp>
 #include <tt-metalium/experimental/distributed_tensor/distributed_tensor_apis.hpp>
+#include <tt-metalium/experimental/tensor_layout_apis_with_custom_alignment.hpp>
 
 using namespace tt::tt_metal;
 
@@ -51,7 +52,7 @@ inline Tensor move_impl(const Tensor& input_tensor, const std::optional<MemoryCo
     if (mem_config) {
         output_tensor_spec = tt::tt_metal::TensorSpec(
             output_tensor_spec.logical_shape(),
-            TensorLayout(
+            tensor_layout_with_custom_alignment(
                 output_tensor_spec.tensor_layout().get_data_type(),
                 output_tensor_spec.tensor_layout().get_page_config(),
                 *mem_config,
@@ -146,7 +147,7 @@ inline Tensor move_sharded(const Tensor& input_tensor, const std::optional<Memor
         auto output_mem_config = MemoryConfig(mem_config->memory_layout(), mem_config->buffer_type(), shard_spec);
         output_tensor_spec = tt::tt_metal::TensorSpec(
             output_tensor_spec.logical_shape(),
-            TensorLayout(
+            tensor_layout_with_custom_alignment(
                 output_tensor_spec.tensor_layout().get_data_type(),
                 output_tensor_spec.tensor_layout().get_page_config(),
                 output_mem_config,

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/move/move.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/move/move.cpp
@@ -52,7 +52,7 @@ inline Tensor move_impl(const Tensor& input_tensor, const std::optional<MemoryCo
     if (mem_config) {
         output_tensor_spec = tt::tt_metal::TensorSpec(
             output_tensor_spec.logical_shape(),
-            tensor_layout_with_custom_alignment(
+            experimental::tensor_layout_with_custom_alignment(
                 output_tensor_spec.tensor_layout().get_data_type(),
                 output_tensor_spec.tensor_layout().get_page_config(),
                 *mem_config,
@@ -147,7 +147,7 @@ inline Tensor move_sharded(const Tensor& input_tensor, const std::optional<Memor
         auto output_mem_config = MemoryConfig(mem_config->memory_layout(), mem_config->buffer_type(), shard_spec);
         output_tensor_spec = tt::tt_metal::TensorSpec(
             output_tensor_spec.logical_shape(),
-            tensor_layout_with_custom_alignment(
+            experimental::tensor_layout_with_custom_alignment(
                 output_tensor_spec.tensor_layout().get_data_type(),
                 output_tensor_spec.tensor_layout().get_page_config(),
                 output_mem_config,

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/move/move.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/move/move.cpp
@@ -52,7 +52,7 @@ inline Tensor move_impl(const Tensor& input_tensor, const std::optional<MemoryCo
     if (mem_config) {
         output_tensor_spec = tt::tt_metal::TensorSpec(
             output_tensor_spec.logical_shape(),
-            experimental::tensor_layout_with_custom_alignment(
+            tt::tt_metal::experimental::tensor_layout_with_custom_alignment(
                 output_tensor_spec.tensor_layout().get_data_type(),
                 output_tensor_spec.tensor_layout().get_page_config(),
                 *mem_config,
@@ -147,7 +147,7 @@ inline Tensor move_sharded(const Tensor& input_tensor, const std::optional<Memor
         auto output_mem_config = MemoryConfig(mem_config->memory_layout(), mem_config->buffer_type(), shard_spec);
         output_tensor_spec = tt::tt_metal::TensorSpec(
             output_tensor_spec.logical_shape(),
-            experimental::tensor_layout_with_custom_alignment(
+            tt::tt_metal::experimental::tensor_layout_with_custom_alignment(
                 output_tensor_spec.tensor_layout().get_data_type(),
                 output_tensor_spec.tensor_layout().get_page_config(),
                 output_mem_config,

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/pad_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/pad_device_operation.cpp
@@ -18,6 +18,7 @@
 #include "ttnn/operations/experimental/quasar/pad/device/pad_rm_sharded_width_only_program_factory.hpp"
 #include "ttnn/operations/experimental/quasar/pad/device/pad_tile_multicore_program_factory.hpp"
 #include "ttnn/operations/experimental/quasar/pad/device/pad_tile_program_factory.hpp"
+#include <tt-metalium/experimental/tensor_layout_apis_with_custom_alignment.hpp>
 
 using namespace tt::tt_metal;
 namespace ttnn::prim::qsr {
@@ -215,7 +216,7 @@ tt::tt_metal::TensorSpec PadDeviceOperation::compute_output_specs(
     const auto& input_tensor = tensor_args.input;
     return tt::tt_metal::TensorSpec(
         operation_attributes.output_logical_shape,
-        TensorLayout::fromPaddedShape(
+        tensor_layout_from_padded_shape(
             input_tensor.dtype(),
             PageConfig(input_tensor.layout()),
             operation_attributes.output_mem_config,

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/pad_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/pad_device_operation.cpp
@@ -216,7 +216,7 @@ tt::tt_metal::TensorSpec PadDeviceOperation::compute_output_specs(
     const auto& input_tensor = tensor_args.input;
     return tt::tt_metal::TensorSpec(
         operation_attributes.output_logical_shape,
-        tensor_layout_from_padded_shape(
+        experimental::tensor_layout_from_padded_shape(
             input_tensor.dtype(),
             PageConfig(input_tensor.layout()),
             operation_attributes.output_mem_config,

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/pad_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pad/device/pad_device_operation.cpp
@@ -216,7 +216,7 @@ tt::tt_metal::TensorSpec PadDeviceOperation::compute_output_specs(
     const auto& input_tensor = tensor_args.input;
     return tt::tt_metal::TensorSpec(
         operation_attributes.output_logical_shape,
-        experimental::tensor_layout_from_padded_shape(
+        tt::tt_metal::experimental::tensor_layout_from_padded_shape(
             input_tensor.dtype(),
             PageConfig(input_tensor.layout()),
             operation_attributes.output_mem_config,

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pool_generic/device/pool_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pool_generic/device/pool_op.cpp
@@ -10,6 +10,7 @@
 
 #include <tt-metalium/math.hpp>
 #include <utility>
+#include <tt-metalium/experimental/tensor_layout_apis_with_custom_alignment.hpp>
 
 /**
  * Generic pool implementation that uses the new sliding window infrastructure.
@@ -141,7 +142,7 @@ Pool2D::spec_return_value_t Pool2D::compute_output_specs(
 
     return tt::tt_metal::TensorSpec(
         output_shape,
-        tt::tt_metal::TensorLayout::fromPaddedShape(
+        tt::tt_metal::tensor_layout_from_padded_shape(
             output_dtype, op_attr.output_layout_, mem_config, output_shape, padded_output_shape));
 }
 
@@ -153,7 +154,7 @@ Pool2D::tensor_return_value_t Pool2D::create_output_tensors(
             op_attr.sliding_window_config_.input_hw.first, op_attr.sliding_window_config_.input_hw.second);
 
         // the index output spec is the same as the input spec just with a different data type
-        tt::tt_metal::TensorLayout output_layout_ind(
+        auto output_layout_ind = tt::tt_metal::tensor_layout_with_custom_alignment(
             index_dtype,
             output_spec_data.page_config(),
             output_spec_data.memory_config(),

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pool_generic/device/pool_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pool_generic/device/pool_op.cpp
@@ -142,7 +142,7 @@ Pool2D::spec_return_value_t Pool2D::compute_output_specs(
 
     return tt::tt_metal::TensorSpec(
         output_shape,
-        tt::tt_metal::tensor_layout_from_padded_shape(
+        tt::tt_metal::experimental::tensor_layout_from_padded_shape(
             output_dtype, op_attr.output_layout_, mem_config, output_shape, padded_output_shape));
 }
 
@@ -154,7 +154,7 @@ Pool2D::tensor_return_value_t Pool2D::create_output_tensors(
             op_attr.sliding_window_config_.input_hw.first, op_attr.sliding_window_config_.input_hw.second);
 
         // the index output spec is the same as the input spec just with a different data type
-        auto output_layout_ind = tt::tt_metal::tensor_layout_with_custom_alignment(
+        auto output_layout_ind = tt::tt_metal::experimental::tensor_layout_with_custom_alignment(
             index_dtype,
             output_spec_data.page_config(),
             output_spec_data.memory_config(),

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/reshape_view/device/reshape_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/reshape_view/device/reshape_device_operation.cpp
@@ -6,6 +6,7 @@
 #include "ttnn/device_operation.hpp"
 #include "ttnn/operations/data_movement/common/common.hpp"
 #include "ttnn/tensor/tensor_ops.hpp"
+#include <tt-metalium/experimental/tensor_layout_apis_with_custom_alignment.hpp>
 
 namespace ttnn::prim::qsr {
 
@@ -44,7 +45,7 @@ ReshapeViewDeviceOperation::spec_return_value_t ReshapeViewDeviceOperation::comp
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     return tt::tt_metal::TensorSpec(
         operation_attributes.logical_output_shape,
-        tt::tt_metal::TensorLayout::fromPaddedShape(
+        tt::tt_metal::tensor_layout_from_padded_shape(
             tensor_args.input.dtype(),
             tt::tt_metal::PageConfig(tensor_args.input.layout()),
             operation_attributes.output_mem_config,

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/reshape_view/device/reshape_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/reshape_view/device/reshape_device_operation.cpp
@@ -45,7 +45,7 @@ ReshapeViewDeviceOperation::spec_return_value_t ReshapeViewDeviceOperation::comp
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     return tt::tt_metal::TensorSpec(
         operation_attributes.logical_output_shape,
-        tt::tt_metal::tensor_layout_from_padded_shape(
+        tt::tt_metal::experimental::tensor_layout_from_padded_shape(
             tensor_args.input.dtype(),
             tt::tt_metal::PageConfig(tensor_args.input.layout()),
             operation_attributes.output_mem_config,

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/reshape_view/reshape.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/reshape_view/reshape.cpp
@@ -31,6 +31,7 @@
 #include "reshape.hpp"
 #include "reshape_common.hpp"
 #include "device/reshape_device_operation.hpp"
+#include <tt-metalium/experimental/tensor_layout_apis_with_custom_alignment.hpp>
 
 namespace ttnn::operations::experimental::quasar {
 
@@ -457,7 +458,7 @@ ttnn::Tensor reshape_tiled(
             MemoryConfig interleaved_output_mem_config{TensorMemoryLayout::INTERLEAVED, memory_config.buffer_type()};
             auto interleaved_output_spec = tt::tt_metal::TensorSpec(
                 requested_shape_3d,
-                tt::tt_metal::TensorLayout::fromPaddedShape(
+                tt::tt_metal::tensor_layout_from_padded_shape(
                     tensor3d.dtype(),
                     tensor3d.tensor_spec().page_config(),
                     interleaved_output_mem_config,
@@ -524,7 +525,7 @@ ttnn::Tensor reshape_tiled(
         // passed here ends up baked into the layout's alignment, so synthetic_spec.physical_shape()
         // exactly matches the requested padded shape, even if compute_padded_shape ever produced
         // dimensions that exceed tile alignment (e.g., due to shard-aware padding).
-        auto synthetic_layout = tt::tt_metal::TensorLayout::fromPaddedShape(
+        auto synthetic_layout = tt::tt_metal::tensor_layout_from_padded_shape(
             tensor3d.dtype(),
             tensor3d.tensor_spec().page_config(),
             MemoryConfig(updated_mem_config.buffer_type()),

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/reshape_view/reshape.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/reshape_view/reshape.cpp
@@ -458,7 +458,7 @@ ttnn::Tensor reshape_tiled(
             MemoryConfig interleaved_output_mem_config{TensorMemoryLayout::INTERLEAVED, memory_config.buffer_type()};
             auto interleaved_output_spec = tt::tt_metal::TensorSpec(
                 requested_shape_3d,
-                tt::tt_metal::tensor_layout_from_padded_shape(
+                tt::tt_metal::experimental::tensor_layout_from_padded_shape(
                     tensor3d.dtype(),
                     tensor3d.tensor_spec().page_config(),
                     interleaved_output_mem_config,
@@ -525,7 +525,7 @@ ttnn::Tensor reshape_tiled(
         // passed here ends up baked into the layout's alignment, so synthetic_spec.physical_shape()
         // exactly matches the requested padded shape, even if compute_padded_shape ever produced
         // dimensions that exceed tile alignment (e.g., due to shard-aware padding).
-        auto synthetic_layout = tt::tt_metal::tensor_layout_from_padded_shape(
+        auto synthetic_layout = tt::tt_metal::experimental::tensor_layout_from_padded_shape(
             tensor3d.dtype(),
             tensor3d.tensor_spec().page_config(),
             MemoryConfig(updated_mem_config.buffer_type()),

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/sharded_to_interleaved/device/sharded_to_interleaved_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/sharded_to_interleaved/device/sharded_to_interleaved_device_operation.cpp
@@ -7,6 +7,7 @@
 #include <tt-metalium/hal.hpp>
 #include "ttnn/operations/data_movement/common/common.hpp"
 #include "ttnn/tensor/tensor_ops.hpp"
+#include <tt-metalium/experimental/tensor_layout_apis_with_custom_alignment.hpp>
 
 using namespace tt::tt_metal;
 
@@ -108,7 +109,7 @@ tt::tt_metal::TensorSpec ShardedToInterleavedDeviceOperation::compute_output_spe
     // inter-stick byte overlap and data corruption.
     return tt::tt_metal::TensorSpec(
         input_tensor.logical_shape(),
-        tt::tt_metal::TensorLayout::fromPaddedShape(
+        tt::tt_metal::tensor_layout_from_padded_shape(
             args.output_dtype,
             tt::tt_metal::PageConfig(input_tensor.layout()),
             args.output_mem_config,

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/sharded_to_interleaved/device/sharded_to_interleaved_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/sharded_to_interleaved/device/sharded_to_interleaved_device_operation.cpp
@@ -109,7 +109,7 @@ tt::tt_metal::TensorSpec ShardedToInterleavedDeviceOperation::compute_output_spe
     // inter-stick byte overlap and data corruption.
     return tt::tt_metal::TensorSpec(
         input_tensor.logical_shape(),
-        tt::tt_metal::tensor_layout_from_padded_shape(
+        tt::tt_metal::experimental::tensor_layout_from_padded_shape(
             args.output_dtype,
             tt::tt_metal::PageConfig(input_tensor.layout()),
             args.output_mem_config,

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/tilize_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/tilize_device_operation.cpp
@@ -14,6 +14,7 @@
 #include <tt-metalium/hal.hpp>
 #include "ttnn/operations/core/work_split/work_split_tilize.hpp"
 #include "ttnn/tensor/tensor_ops.hpp"
+#include <tt-metalium/experimental/tensor_layout_apis_with_custom_alignment.hpp>
 using namespace tt::tt_metal;
 
 namespace ttnn::prim::qsr {
@@ -156,7 +157,7 @@ TilizeDeviceOperation::spec_return_value_t TilizeDeviceOperation::compute_output
                                                          // factory, the output has the same shard spec as the input.
         return {tt::tt_metal::TensorSpec(
             input_tensor.logical_shape(),
-            TensorLayout::fromPaddedShape(
+            tensor_layout_from_padded_shape(
                 operation_attributes.output_dtype,
                 PageConfig(Layout::TILE),
                 mem_config,

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/tilize_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/tilize_device_operation.cpp
@@ -157,7 +157,7 @@ TilizeDeviceOperation::spec_return_value_t TilizeDeviceOperation::compute_output
                                                          // factory, the output has the same shard spec as the input.
         return {tt::tt_metal::TensorSpec(
             input_tensor.logical_shape(),
-            tensor_layout_from_padded_shape(
+            experimental::tensor_layout_from_padded_shape(
                 operation_attributes.output_dtype,
                 PageConfig(Layout::TILE),
                 mem_config,

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/tilize_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/tilize_device_operation.cpp
@@ -157,7 +157,7 @@ TilizeDeviceOperation::spec_return_value_t TilizeDeviceOperation::compute_output
                                                          // factory, the output has the same shard spec as the input.
         return {tt::tt_metal::TensorSpec(
             input_tensor.logical_shape(),
-            experimental::tensor_layout_from_padded_shape(
+            tt::tt_metal::experimental::tensor_layout_from_padded_shape(
                 operation_attributes.output_dtype,
                 PageConfig(Layout::TILE),
                 mem_config,

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/tilize_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/tilize_device_operation.cpp
@@ -14,6 +14,7 @@
 #include <tt-metalium/hal.hpp>
 #include "ttnn/operations/core/work_split/work_split_tilize.hpp"
 #include "ttnn/tensor/tensor_ops.hpp"
+#include <tt-metalium/experimental/tensor_layout_apis_with_custom_alignment.hpp>
 using namespace tt::tt_metal;
 
 namespace ttnn::prim::qsr {
@@ -172,7 +173,7 @@ TilizeDeviceOperation::spec_return_value_t TilizeDeviceOperation::compute_output
                                                          // factory, the output has the same shard spec as the input.
         return {tt::tt_metal::TensorSpec(
             input_tensor.logical_shape(),
-            TensorLayout::fromPaddedShape(
+            tensor_layout_from_padded_shape(
                 operation_attributes.output_dtype,
                 PageConfig(Layout::TILE),
                 mem_config,

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/tilize_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/tilize_device_operation.cpp
@@ -173,7 +173,7 @@ TilizeDeviceOperation::spec_return_value_t TilizeDeviceOperation::compute_output
                                                          // factory, the output has the same shard spec as the input.
         return {tt::tt_metal::TensorSpec(
             input_tensor.logical_shape(),
-            experimental::tensor_layout_from_padded_shape(
+            tt::tt_metal::experimental::tensor_layout_from_padded_shape(
                 operation_attributes.output_dtype,
                 PageConfig(Layout::TILE),
                 mem_config,

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/tilize_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/tilize/device/tilize_device_operation.cpp
@@ -173,7 +173,7 @@ TilizeDeviceOperation::spec_return_value_t TilizeDeviceOperation::compute_output
                                                          // factory, the output has the same shard spec as the input.
         return {tt::tt_metal::TensorSpec(
             input_tensor.logical_shape(),
-            tensor_layout_from_padded_shape(
+            experimental::tensor_layout_from_padded_shape(
                 operation_attributes.output_dtype,
                 PageConfig(Layout::TILE),
                 mem_config,

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/tilize_with_val_padding/device/tilize_with_val_padding_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/tilize_with_val_padding/device/tilize_with_val_padding_device_operation.cpp
@@ -8,6 +8,7 @@
 #include <tt-metalium/hal.hpp>
 #include <tt-metalium/constants.hpp>
 #include "ttnn/operations/core/work_split/work_split_tilize.hpp"
+#include <tt-metalium/experimental/tensor_layout_apis_with_custom_alignment.hpp>
 
 using namespace tt::tt_metal;
 using namespace tt::constants;
@@ -192,7 +193,7 @@ tt::tt_metal::TensorSpec TilizeWithValPaddingDeviceOperation::compute_output_spe
                           // factory, the output has the same shard spec as the input.
         return tt::tt_metal::TensorSpec(
             input_shape,
-            TensorLayout::fromPaddedShape(
+            tensor_layout_from_padded_shape(
                 operation_attributes.output_dtype,
                 PageConfig(Layout::TILE),
                 mem_config,
@@ -202,7 +203,7 @@ tt::tt_metal::TensorSpec TilizeWithValPaddingDeviceOperation::compute_output_spe
 
     return tt::tt_metal::TensorSpec(
         input_shape,
-        TensorLayout::fromPaddedShape(
+        tensor_layout_from_padded_shape(
             operation_attributes.output_dtype,
             PageConfig(Layout::TILE),
             operation_attributes.output_mem_config,

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/tilize_with_val_padding/device/tilize_with_val_padding_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/tilize_with_val_padding/device/tilize_with_val_padding_device_operation.cpp
@@ -193,7 +193,7 @@ tt::tt_metal::TensorSpec TilizeWithValPaddingDeviceOperation::compute_output_spe
                           // factory, the output has the same shard spec as the input.
         return tt::tt_metal::TensorSpec(
             input_shape,
-            tensor_layout_from_padded_shape(
+            experimental::tensor_layout_from_padded_shape(
                 operation_attributes.output_dtype,
                 PageConfig(Layout::TILE),
                 mem_config,
@@ -203,7 +203,7 @@ tt::tt_metal::TensorSpec TilizeWithValPaddingDeviceOperation::compute_output_spe
 
     return tt::tt_metal::TensorSpec(
         input_shape,
-        tensor_layout_from_padded_shape(
+        experimental::tensor_layout_from_padded_shape(
             operation_attributes.output_dtype,
             PageConfig(Layout::TILE),
             operation_attributes.output_mem_config,

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/tilize_with_val_padding/device/tilize_with_val_padding_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/tilize_with_val_padding/device/tilize_with_val_padding_device_operation.cpp
@@ -193,7 +193,7 @@ tt::tt_metal::TensorSpec TilizeWithValPaddingDeviceOperation::compute_output_spe
                           // factory, the output has the same shard spec as the input.
         return tt::tt_metal::TensorSpec(
             input_shape,
-            experimental::tensor_layout_from_padded_shape(
+            tt::tt_metal::experimental::tensor_layout_from_padded_shape(
                 operation_attributes.output_dtype,
                 PageConfig(Layout::TILE),
                 mem_config,
@@ -203,7 +203,7 @@ tt::tt_metal::TensorSpec TilizeWithValPaddingDeviceOperation::compute_output_spe
 
     return tt::tt_metal::TensorSpec(
         input_shape,
-        experimental::tensor_layout_from_padded_shape(
+        tt::tt_metal::experimental::tensor_layout_from_padded_shape(
             operation_attributes.output_dtype,
             PageConfig(Layout::TILE),
             operation_attributes.output_mem_config,

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_device_operation.cpp
@@ -8,6 +8,7 @@
 
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/hal.hpp>
+#include <tt-metalium/experimental/tensor_layout_apis_with_custom_alignment.hpp>
 
 using namespace tt::constants;
 using namespace tt::tt_metal;
@@ -229,7 +230,7 @@ tt::tt_metal::TensorSpec TransposeDeviceOperation::compute_output_specs(
 
     return tt::tt_metal::TensorSpec(
         output_shape,
-        TensorLayout::fromPaddedShape(
+        tensor_layout_from_padded_shape(
             input_tensor.dtype(),
             PageConfig(input_tensor.layout()),
             output_mem_config,

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_device_operation.cpp
@@ -230,7 +230,7 @@ tt::tt_metal::TensorSpec TransposeDeviceOperation::compute_output_specs(
 
     return tt::tt_metal::TensorSpec(
         output_shape,
-        experimental::tensor_layout_from_padded_shape(
+        tt::tt_metal::experimental::tensor_layout_from_padded_shape(
             input_tensor.dtype(),
             PageConfig(input_tensor.layout()),
             output_mem_config,

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/transpose/device/transpose_device_operation.cpp
@@ -230,7 +230,7 @@ tt::tt_metal::TensorSpec TransposeDeviceOperation::compute_output_specs(
 
     return tt::tt_metal::TensorSpec(
         output_shape,
-        tensor_layout_from_padded_shape(
+        experimental::tensor_layout_from_padded_shape(
             input_tensor.dtype(),
             PageConfig(input_tensor.layout()),
             output_mem_config,

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/untilize/device/untilize_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/untilize/device/untilize_device_operation.cpp
@@ -20,6 +20,7 @@
 #include "ttnn/operations/core/work_split/work_split_tilize.hpp"
 #include "ttnn/common/constants.hpp"
 #include <tt-metalium/buffer_distribution_spec.hpp>
+#include <tt-metalium/experimental/tensor_layout_apis_with_custom_alignment.hpp>
 
 using namespace tt::tt_metal;
 
@@ -263,7 +264,7 @@ UntilizeDeviceOperation::spec_return_value_t UntilizeDeviceOperation::compute_ou
 
     return {tt::tt_metal::TensorSpec(
         input_tensor.logical_shape(),
-        TensorLayout::fromPaddedShape(
+        tensor_layout_from_padded_shape(
             output_dtype,
             PageConfig(Layout::ROW_MAJOR),
             operation_attributes.output_mem_config,

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/untilize/device/untilize_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/untilize/device/untilize_device_operation.cpp
@@ -264,7 +264,7 @@ UntilizeDeviceOperation::spec_return_value_t UntilizeDeviceOperation::compute_ou
 
     return {tt::tt_metal::TensorSpec(
         input_tensor.logical_shape(),
-        experimental::tensor_layout_from_padded_shape(
+        tt::tt_metal::experimental::tensor_layout_from_padded_shape(
             output_dtype,
             PageConfig(Layout::ROW_MAJOR),
             operation_attributes.output_mem_config,

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/untilize/device/untilize_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/untilize/device/untilize_device_operation.cpp
@@ -264,7 +264,7 @@ UntilizeDeviceOperation::spec_return_value_t UntilizeDeviceOperation::compute_ou
 
     return {tt::tt_metal::TensorSpec(
         input_tensor.logical_shape(),
-        tensor_layout_from_padded_shape(
+        experimental::tensor_layout_from_padded_shape(
             output_dtype,
             PageConfig(Layout::ROW_MAJOR),
             operation_attributes.output_mem_config,

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/prefix_scan_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/prefix_scan_device_operation.cpp
@@ -8,6 +8,7 @@
 #include "ttnn/device_operation.hpp"
 #include "ttnn/tensor/tensor_utils.hpp"
 #include "ttnn/tensor/tensor_ops.hpp"
+#include <tt-metalium/experimental/tensor_layout_apis_with_custom_alignment.hpp>
 
 using namespace tt::tt_metal;
 
@@ -53,7 +54,7 @@ tt::tt_metal::TensorSpec PrefixScanDeviceOperation::compute_output_specs(
     const auto& a = tensor_args.a;
     return tt::tt_metal::TensorSpec(
         a.logical_shape(),
-        TensorLayout::fromPaddedShape(
+        tensor_layout_from_padded_shape(
             args.dtype, PageConfig(Layout::TILE), args.memory_config, a.logical_shape(), a.padded_shape()));
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/prefix_scan_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/prefix_scan_device_operation.cpp
@@ -54,7 +54,7 @@ tt::tt_metal::TensorSpec PrefixScanDeviceOperation::compute_output_specs(
     const auto& a = tensor_args.a;
     return tt::tt_metal::TensorSpec(
         a.logical_shape(),
-        tensor_layout_from_padded_shape(
+        experimental::tensor_layout_from_padded_shape(
             args.dtype, PageConfig(Layout::TILE), args.memory_config, a.logical_shape(), a.padded_shape()));
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/prefix_scan_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ssm/prefix_scan/device/prefix_scan_device_operation.cpp
@@ -54,7 +54,7 @@ tt::tt_metal::TensorSpec PrefixScanDeviceOperation::compute_output_specs(
     const auto& a = tensor_args.a;
     return tt::tt_metal::TensorSpec(
         a.logical_shape(),
-        experimental::tensor_layout_from_padded_shape(
+        tt::tt_metal::experimental::tensor_layout_from_padded_shape(
             args.dtype, PageConfig(Layout::TILE), args.memory_config, a.logical_shape(), a.padded_shape()));
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotate_half/device/rotate_half_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotate_half/device/rotate_half_device_operation.cpp
@@ -7,6 +7,7 @@
 
 #include "ttnn/tensor/tensor_utils.hpp"
 #include "ttnn/device_operation.hpp"
+#include <tt-metalium/experimental/tensor_layout_apis_with_custom_alignment.hpp>
 
 namespace ttnn::experimental::prim {
 
@@ -33,7 +34,7 @@ tt::tt_metal::TensorSpec RotateHalfDeviceOperation::compute_output_specs(
     const Tensor& input_tensor = tensor_args;
     return tt::tt_metal::TensorSpec(
         input_tensor.logical_shape(),
-        TensorLayout::fromPaddedShape(
+        tensor_layout_from_padded_shape(
             input_tensor.dtype(),
             PageConfig(Layout::TILE),
             operation_attributes.output_mem_config,

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotate_half/device/rotate_half_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotate_half/device/rotate_half_device_operation.cpp
@@ -34,7 +34,7 @@ tt::tt_metal::TensorSpec RotateHalfDeviceOperation::compute_output_specs(
     const Tensor& input_tensor = tensor_args;
     return tt::tt_metal::TensorSpec(
         input_tensor.logical_shape(),
-        experimental::tensor_layout_from_padded_shape(
+        tt::tt_metal::experimental::tensor_layout_from_padded_shape(
             input_tensor.dtype(),
             PageConfig(Layout::TILE),
             operation_attributes.output_mem_config,

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotate_half/device/rotate_half_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotate_half/device/rotate_half_device_operation.cpp
@@ -34,7 +34,7 @@ tt::tt_metal::TensorSpec RotateHalfDeviceOperation::compute_output_specs(
     const Tensor& input_tensor = tensor_args;
     return tt::tt_metal::TensorSpec(
         input_tensor.logical_shape(),
-        tensor_layout_from_padded_shape(
+        experimental::tensor_layout_from_padded_shape(
             input_tensor.dtype(),
             PageConfig(Layout::TILE),
             operation_attributes.output_mem_config,

--- a/ttnn/cpp/ttnn/operations/functions.hpp
+++ b/ttnn/cpp/ttnn/operations/functions.hpp
@@ -16,6 +16,7 @@
 #include <ttnn/tensor/types.hpp>
 #include <ttnn/tensor/tensor_impl.hpp>
 #include "ttnn/common/constants.hpp"
+#include <tt-metalium/experimental/tensor_layout_apis_with_custom_alignment.hpp>
 
 namespace ttnn {
 
@@ -42,7 +43,8 @@ inline TensorLayout legacy_tensor_layout_from_padded_shape(
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
-    auto layout = TensorLayout::fromPaddedShape(dtype, page_config, memory_config, logical_shape, padded_shape);
+    auto layout =
+        tt::tt_metal::tensor_layout_from_padded_shape(dtype, page_config, memory_config, logical_shape, padded_shape);
 #if defined(__clang__)
 #pragma clang diagnostic pop
 #elif defined(__GNUC__)

--- a/ttnn/cpp/ttnn/operations/functions.hpp
+++ b/ttnn/cpp/ttnn/operations/functions.hpp
@@ -43,8 +43,8 @@ inline TensorLayout legacy_tensor_layout_from_padded_shape(
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
-    auto layout =
-        tt::tt_metal::tensor_layout_from_padded_shape(dtype, page_config, memory_config, logical_shape, padded_shape);
+    auto layout = tt::tt_metal::experimental::tensor_layout_from_padded_shape(
+        dtype, page_config, memory_config, logical_shape, padded_shape);
 #if defined(__clang__)
 #pragma clang diagnostic pop
 #elif defined(__GNUC__)

--- a/ttnn/cpp/ttnn/operations/index_fill/device/index_fill_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/index_fill/device/index_fill_device_operation.cpp
@@ -6,6 +6,7 @@
 #include "ttnn/tensor/tensor_ops.hpp"
 #include "ttnn/device_operation.hpp"
 #include "ttnn/tensor/tensor.hpp"
+#include <tt-metalium/experimental/tensor_layout_apis_with_custom_alignment.hpp>
 
 namespace ttnn::operations::index_fill {
 
@@ -62,12 +63,8 @@ void IndexFillOperation::validate(
     TT_FATAL(index.buffer() != nullptr, "Index fill: Index tensor must be allocated in buffer on device");
     TT_FATAL(index.logical_shape().rank() == 1, "Index fill: Index tensor must be 1D");
     TT_FATAL(
-        index.dtype() == DataType::UINT32,
-        "Index fill: Index tensor must have UINT32 dtype; got {}",
-        index.dtype());
-    TT_FATAL(
-        index.device() == input.device(),
-        "Index fill: Index tensor must be on the same device as input");
+        index.dtype() == DataType::UINT32, "Index fill: Index tensor must have UINT32 dtype; got {}", index.dtype());
+    TT_FATAL(index.device() == input.device(), "Index fill: Index tensor must be on the same device as input");
 
     TT_FATAL(dim < input.logical_shape().rank() && dim >= 0, "Index fill: Invalid dimension");
 
@@ -100,7 +97,7 @@ IndexFillOperation::spec_return_value_t IndexFillOperation::compute_output_specs
     const auto& old_spec = tensor_args.input.tensor_spec();
     return tt::tt_metal::TensorSpec(
         old_spec.logical_shape(),
-        tt::tt_metal::TensorLayout(
+        tt::tt_metal::tensor_layout_with_custom_alignment(
             old_spec.tensor_layout().get_data_type(),
             old_spec.tensor_layout().get_page_config(),
             operation_attributes.memory_config,

--- a/ttnn/cpp/ttnn/operations/index_fill/device/index_fill_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/index_fill/device/index_fill_device_operation.cpp
@@ -97,7 +97,7 @@ IndexFillOperation::spec_return_value_t IndexFillOperation::compute_output_specs
     const auto& old_spec = tensor_args.input.tensor_spec();
     return tt::tt_metal::TensorSpec(
         old_spec.logical_shape(),
-        tt::tt_metal::tensor_layout_with_custom_alignment(
+        tt::tt_metal::experimental::tensor_layout_with_custom_alignment(
             old_spec.tensor_layout().get_data_type(),
             old_spec.tensor_layout().get_page_config(),
             operation_attributes.memory_config,

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_matmul/device/moreh_matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_matmul/device/moreh_matmul_device_operation.cpp
@@ -9,6 +9,7 @@
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 #include "ttnn/operations/moreh/moreh_helper_functions.hpp"
 #include "ttnn/tensor/tensor.hpp"
+#include <tt-metalium/experimental/tensor_layout_apis_with_custom_alignment.hpp>
 
 namespace ttnn::operations::moreh::moreh_matmul {
 
@@ -153,7 +154,7 @@ MorehMatmulOperation::spec_return_value_t MorehMatmulOperation::compute_output_s
     output_shape_wo_padding[output_rank - 1] = w_wo_padding;
     return tt::tt_metal::TensorSpec(
         output_shape_wo_padding,
-        TensorLayout::fromPaddedShape(
+        tt::tt_metal::tensor_layout_from_padded_shape(
             tensor_args.input.dtype(),
             PageConfig(Layout::TILE),
             operation_attributes.output_memory_config,

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_matmul/device/moreh_matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_matmul/device/moreh_matmul_device_operation.cpp
@@ -154,7 +154,7 @@ MorehMatmulOperation::spec_return_value_t MorehMatmulOperation::compute_output_s
     output_shape_wo_padding[output_rank - 1] = w_wo_padding;
     return tt::tt_metal::TensorSpec(
         output_shape_wo_padding,
-        tt::tt_metal::tensor_layout_from_padded_shape(
+        tt::tt_metal::experimental::tensor_layout_from_padded_shape(
             tensor_args.input.dtype(),
             PageConfig(Layout::TILE),
             operation_attributes.output_memory_config,

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_device_operation.cpp
@@ -7,6 +7,7 @@
 #include "ttnn/device_operation.hpp"
 #include "ttnn/operations/normalization/groupnorm/groupnorm_grid_utils.hpp"
 #include "ttnn/operations/normalization/shard_spec_validation.hpp"
+#include <tt-metalium/experimental/tensor_layout_apis_with_custom_alignment.hpp>
 
 using namespace tt::tt_metal;
 
@@ -204,8 +205,7 @@ void GroupNormDeviceOperation::validate_on_program_cache_miss(
             negative_mask.value().storage_type() == StorageType::DEVICE,
             "Negative mask must be on device, got storage type: {}",
             negative_mask.value().storage_type());
-        TT_FATAL(
-            negative_mask.value().buffer() != nullptr, "Negative mask must be allocated in buffers on device!");
+        TT_FATAL(negative_mask.value().buffer() != nullptr, "Negative mask must be allocated in buffers on device!");
         TT_FATAL(
             a.device() == negative_mask.value().device(), "Input and negative mask tensors must be on same device");
         TT_FATAL(
@@ -292,7 +292,7 @@ tt::tt_metal::TensorSpec GroupNormDeviceOperation::compute_output_specs(
             auto mem_config = args.output_mem_config;
             return tt::tt_metal::TensorSpec(
                 input_tensor.logical_shape(),
-                TensorLayout::fromPaddedShape(
+                tensor_layout_from_padded_shape(
                     program_config.out_data_format,
                     PageConfig(program_config.output_layout),
                     mem_config,
@@ -339,9 +339,9 @@ Tensor group_norm(
             negative_mask.value().storage_type() == StorageType::DEVICE,
             "Negative mask must be on device, got storage type: {}",
             negative_mask.value().storage_type());
+        TT_FATAL(negative_mask.value().buffer() != nullptr, "Negative mask must be allocated in buffers on device!");
         TT_FATAL(
-            negative_mask.value().buffer() != nullptr, "Negative mask must be allocated in buffers on device!");
-        TT_FATAL(input.device() == negative_mask.value().device(), "Input and negative mask tensors must be on same device");
+            input.device() == negative_mask.value().device(), "Input and negative mask tensors must be on same device");
     }
     using OperationType = GroupNormDeviceOperation;
     auto operation_attributes = OperationType::operation_attributes_t{

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_device_operation.cpp
@@ -292,7 +292,7 @@ tt::tt_metal::TensorSpec GroupNormDeviceOperation::compute_output_specs(
             auto mem_config = args.output_mem_config;
             return tt::tt_metal::TensorSpec(
                 input_tensor.logical_shape(),
-                experimental::tensor_layout_from_padded_shape(
+                tt::tt_metal::experimental::tensor_layout_from_padded_shape(
                     program_config.out_data_format,
                     PageConfig(program_config.output_layout),
                     mem_config,

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_device_operation.cpp
@@ -312,7 +312,7 @@ tt::tt_metal::TensorSpec GroupNormDeviceOperation::compute_output_specs(
             auto mem_config = args.output_mem_config;
             return tt::tt_metal::TensorSpec(
                 input_tensor.logical_shape(),
-                experimental::tensor_layout_from_padded_shape(
+                tt::tt_metal::experimental::tensor_layout_from_padded_shape(
                     program_config.out_data_format,
                     PageConfig(program_config.output_layout),
                     mem_config,

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_device_operation.cpp
@@ -7,6 +7,7 @@
 #include "ttnn/device_operation.hpp"
 #include "ttnn/operations/normalization/groupnorm/groupnorm_grid_utils.hpp"
 #include "ttnn/operations/normalization/shard_spec_validation.hpp"
+#include <tt-metalium/experimental/tensor_layout_apis_with_custom_alignment.hpp>
 
 using namespace tt::tt_metal;
 
@@ -224,8 +225,7 @@ void GroupNormDeviceOperation::validate_on_program_cache_miss(
             negative_mask.value().storage_type() == StorageType::DEVICE,
             "Negative mask must be on device, got storage type: {}",
             negative_mask.value().storage_type());
-        TT_FATAL(
-            negative_mask.value().buffer() != nullptr, "Negative mask must be allocated in buffers on device!");
+        TT_FATAL(negative_mask.value().buffer() != nullptr, "Negative mask must be allocated in buffers on device!");
         TT_FATAL(
             a.device() == negative_mask.value().device(), "Input and negative mask tensors must be on same device");
         TT_FATAL(
@@ -312,7 +312,7 @@ tt::tt_metal::TensorSpec GroupNormDeviceOperation::compute_output_specs(
             auto mem_config = args.output_mem_config;
             return tt::tt_metal::TensorSpec(
                 input_tensor.logical_shape(),
-                TensorLayout::fromPaddedShape(
+                tensor_layout_from_padded_shape(
                     program_config.out_data_format,
                     PageConfig(program_config.output_layout),
                     mem_config,
@@ -359,9 +359,9 @@ Tensor group_norm(
             negative_mask.value().storage_type() == StorageType::DEVICE,
             "Negative mask must be on device, got storage type: {}",
             negative_mask.value().storage_type());
+        TT_FATAL(negative_mask.value().buffer() != nullptr, "Negative mask must be allocated in buffers on device!");
         TT_FATAL(
-            negative_mask.value().buffer() != nullptr, "Negative mask must be allocated in buffers on device!");
-        TT_FATAL(input.device() == negative_mask.value().device(), "Input and negative mask tensors must be on same device");
+            input.device() == negative_mask.value().device(), "Input and negative mask tensors must be on same device");
     }
     using OperationType = GroupNormDeviceOperation;
     auto operation_attributes = OperationType::operation_attributes_t{

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_device_operation.cpp
@@ -312,7 +312,7 @@ tt::tt_metal::TensorSpec GroupNormDeviceOperation::compute_output_specs(
             auto mem_config = args.output_mem_config;
             return tt::tt_metal::TensorSpec(
                 input_tensor.logical_shape(),
-                tensor_layout_from_padded_shape(
+                experimental::tensor_layout_from_padded_shape(
                     program_config.out_data_format,
                     PageConfig(program_config.output_layout),
                     mem_config,

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_device_operation.cpp
@@ -292,7 +292,7 @@ tt::tt_metal::TensorSpec GroupNormDeviceOperation::compute_output_specs(
             auto mem_config = args.output_mem_config;
             return tt::tt_metal::TensorSpec(
                 input_tensor.logical_shape(),
-                tensor_layout_from_padded_shape(
+                experimental::tensor_layout_from_padded_shape(
                     program_config.out_data_format,
                     PageConfig(program_config.output_layout),
                     mem_config,

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_device_operation.cpp
@@ -9,6 +9,7 @@
 #include "ttnn/tensor/tensor_utils.hpp"
 #include "ttnn/operations/math.hpp"
 #include "ttnn/operations/normalization/shard_spec_validation.hpp"
+#include <tt-metalium/experimental/tensor_layout_apis_with_custom_alignment.hpp>
 using uint32_t = std::uint32_t;
 using namespace tt::tt_metal;
 
@@ -437,7 +438,7 @@ tt::tt_metal::TensorSpec LayerNormDeviceOperation::compute_output_specs(
 
                 return tt::tt_metal::TensorSpec(
                     output_shape,
-                    TensorLayout::fromPaddedShape(
+                    tensor_layout_from_padded_shape(
                         operation_attributes.dtype.value_or(input_tensor.dtype()),
                         PageConfig(Layout::TILE),
                         mem_config,

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_device_operation.cpp
@@ -438,7 +438,7 @@ tt::tt_metal::TensorSpec LayerNormDeviceOperation::compute_output_specs(
 
                 return tt::tt_metal::TensorSpec(
                     output_shape,
-                    tensor_layout_from_padded_shape(
+                    experimental::tensor_layout_from_padded_shape(
                         operation_attributes.dtype.value_or(input_tensor.dtype()),
                         PageConfig(Layout::TILE),
                         mem_config,

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_device_operation.cpp
@@ -463,7 +463,7 @@ tt::tt_metal::TensorSpec LayerNormDeviceOperation::compute_output_specs(
 
                 return tt::tt_metal::TensorSpec(
                     output_shape,
-                    experimental::tensor_layout_from_padded_shape(
+                    tt::tt_metal::experimental::tensor_layout_from_padded_shape(
                         operation_attributes.dtype.value_or(input_tensor.dtype()),
                         PageConfig(Layout::TILE),
                         mem_config,

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_device_operation.cpp
@@ -463,7 +463,7 @@ tt::tt_metal::TensorSpec LayerNormDeviceOperation::compute_output_specs(
 
                 return tt::tt_metal::TensorSpec(
                     output_shape,
-                    tensor_layout_from_padded_shape(
+                    experimental::tensor_layout_from_padded_shape(
                         operation_attributes.dtype.value_or(input_tensor.dtype()),
                         PageConfig(Layout::TILE),
                         mem_config,

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_device_operation.cpp
@@ -438,7 +438,7 @@ tt::tt_metal::TensorSpec LayerNormDeviceOperation::compute_output_specs(
 
                 return tt::tt_metal::TensorSpec(
                     output_shape,
-                    experimental::tensor_layout_from_padded_shape(
+                    tt::tt_metal::experimental::tensor_layout_from_padded_shape(
                         operation_attributes.dtype.value_or(input_tensor.dtype()),
                         PageConfig(Layout::TILE),
                         mem_config,

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_device_operation.cpp
@@ -10,6 +10,7 @@
 #include "ttnn/operations/math.hpp"
 #include "ttnn/operations/normalization/shard_spec_validation.hpp"
 #include <tt-metalium/work_split.hpp>
+#include <tt-metalium/experimental/tensor_layout_apis_with_custom_alignment.hpp>
 using uint32_t = std::uint32_t;
 using namespace tt::tt_metal;
 
@@ -462,7 +463,7 @@ tt::tt_metal::TensorSpec LayerNormDeviceOperation::compute_output_specs(
 
                 return tt::tt_metal::TensorSpec(
                     output_shape,
-                    TensorLayout::fromPaddedShape(
+                    tensor_layout_from_padded_shape(
                         operation_attributes.dtype.value_or(input_tensor.dtype()),
                         PageConfig(Layout::TILE),
                         mem_config,

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.cpp
@@ -9,6 +9,7 @@
 
 #include <tt-metalium/math.hpp>
 #include <utility>
+#include <tt-metalium/experimental/tensor_layout_apis_with_custom_alignment.hpp>
 
 /**
  * Generic pool implementation that uses the new sliding window infrastructure.
@@ -140,7 +141,7 @@ Pool2D::spec_return_value_t Pool2D::compute_output_specs(
 
     return tt::tt_metal::TensorSpec(
         output_shape,
-        tt::tt_metal::TensorLayout::fromPaddedShape(
+        tt::tt_metal::tensor_layout_from_padded_shape(
             output_dtype, op_attr.output_layout_, mem_config, output_shape, padded_output_shape));
 }
 
@@ -152,7 +153,7 @@ Pool2D::tensor_return_value_t Pool2D::create_output_tensors(
             op_attr.sliding_window_config_.input_hw.first, op_attr.sliding_window_config_.input_hw.second);
 
         // the index output spec is the same as the input spec just with a different data type
-        tt::tt_metal::TensorLayout output_layout_ind(
+        auto output_layout_ind = tt::tt_metal::tensor_layout_with_custom_alignment(
             index_dtype,
             output_spec_data.page_config(),
             output_spec_data.memory_config(),

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.cpp
@@ -141,7 +141,7 @@ Pool2D::spec_return_value_t Pool2D::compute_output_specs(
 
     return tt::tt_metal::TensorSpec(
         output_shape,
-        tt::tt_metal::tensor_layout_from_padded_shape(
+        tt::tt_metal::experimental::tensor_layout_from_padded_shape(
             output_dtype, op_attr.output_layout_, mem_config, output_shape, padded_output_shape));
 }
 
@@ -153,7 +153,7 @@ Pool2D::tensor_return_value_t Pool2D::create_output_tensors(
             op_attr.sliding_window_config_.input_hw.first, op_attr.sliding_window_config_.input_hw.second);
 
         // the index output spec is the same as the input spec just with a different data type
-        auto output_layout_ind = tt::tt_metal::tensor_layout_with_custom_alignment(
+        auto output_layout_ind = tt::tt_metal::experimental::tensor_layout_with_custom_alignment(
             index_dtype,
             output_spec_data.page_config(),
             output_spec_data.memory_config(),

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_device_operation.cpp
@@ -6,6 +6,7 @@
 #include "ttnn/tensor/tensor_ops.hpp"
 #include "ttnn/device_operation.hpp"
 #include <tt-metalium/work_split.hpp>
+#include <tt-metalium/experimental/tensor_layout_apis_with_custom_alignment.hpp>
 
 namespace ttnn::prim {
 using namespace tt;
@@ -287,7 +288,7 @@ tt::tt_metal::TensorSpec GridSampleOperation::compute_output_specs(
 
     return tt::tt_metal::TensorSpec(
         output_logical_shape,
-        TensorLayout::fromPaddedShape(
+        tensor_layout_from_padded_shape(
             output_data_type,
             PageConfig(output_layout),
             output_memory_config,

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_device_operation.cpp
@@ -288,7 +288,7 @@ tt::tt_metal::TensorSpec GridSampleOperation::compute_output_specs(
 
     return tt::tt_metal::TensorSpec(
         output_logical_shape,
-        tensor_layout_from_padded_shape(
+        experimental::tensor_layout_from_padded_shape(
             output_data_type,
             PageConfig(output_layout),
             output_memory_config,

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/device/grid_sample_device_operation.cpp
@@ -288,7 +288,7 @@ tt::tt_metal::TensorSpec GridSampleOperation::compute_output_specs(
 
     return tt::tt_metal::TensorSpec(
         output_logical_shape,
-        experimental::tensor_layout_from_padded_shape(
+        tt::tt_metal::experimental::tensor_layout_from_padded_shape(
             output_data_type,
             PageConfig(output_layout),
             output_memory_config,

--- a/ttnn/cpp/ttnn/operations/pool/rotate/device/rotate_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/rotate/device/rotate_device_operation.cpp
@@ -8,6 +8,7 @@
 #include <ttnn/tensor/types.hpp>
 #include <ttnn/tensor/tensor_spec.hpp>
 #include <tt-metalium/constants.hpp>
+#include <tt-metalium/experimental/tensor_layout_apis_with_custom_alignment.hpp>
 
 namespace ttnn::operations::rotate {
 
@@ -113,7 +114,7 @@ RotateDeviceOperation::spec_return_value_t RotateDeviceOperation::compute_output
 
     return tt::tt_metal::TensorSpec(
         output_shape,
-        tt::tt_metal::TensorLayout::fromPaddedShape(
+        tt::tt_metal::tensor_layout_from_padded_shape(
             input.dtype(),
             tt::tt_metal::PageConfig(Layout::ROW_MAJOR),
             operation_attributes.memory_config,

--- a/ttnn/cpp/ttnn/operations/pool/rotate/device/rotate_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/rotate/device/rotate_device_operation.cpp
@@ -114,7 +114,7 @@ RotateDeviceOperation::spec_return_value_t RotateDeviceOperation::compute_output
 
     return tt::tt_metal::TensorSpec(
         output_shape,
-        tt::tt_metal::tensor_layout_from_padded_shape(
+        tt::tt_metal::experimental::tensor_layout_from_padded_shape(
             input.dtype(),
             tt::tt_metal::PageConfig(Layout::ROW_MAJOR),
             operation_attributes.memory_config,

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/device/ema_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/device/ema_device_operation.cpp
@@ -7,6 +7,7 @@
 #include "ttnn/device_operation.hpp"
 
 #include <cmath>
+#include <tt-metalium/experimental/tensor_layout_apis_with_custom_alignment.hpp>
 
 namespace ttnn::prim {
 
@@ -81,7 +82,7 @@ tt::tt_metal::TensorSpec EmaDeviceOperation::compute_output_specs(
     const auto& old_spec = tensor_args.input.tensor_spec();
     return tt::tt_metal::TensorSpec(
         old_spec.logical_shape(),
-        TensorLayout(
+        tensor_layout_with_custom_alignment(
             old_spec.tensor_layout().get_data_type(),
             old_spec.tensor_layout().get_page_config(),
             operation_attributes.output_mem_config,

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/device/ema_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/device/ema_device_operation.cpp
@@ -82,7 +82,7 @@ tt::tt_metal::TensorSpec EmaDeviceOperation::compute_output_specs(
     const auto& old_spec = tensor_args.input.tensor_spec();
     return tt::tt_metal::TensorSpec(
         old_spec.logical_shape(),
-        experimental::tensor_layout_with_custom_alignment(
+        tt::tt_metal::experimental::tensor_layout_with_custom_alignment(
             old_spec.tensor_layout().get_data_type(),
             old_spec.tensor_layout().get_page_config(),
             operation_attributes.output_mem_config,

--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/device/ema_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/device/ema_device_operation.cpp
@@ -82,7 +82,7 @@ tt::tt_metal::TensorSpec EmaDeviceOperation::compute_output_specs(
     const auto& old_spec = tensor_args.input.tensor_spec();
     return tt::tt_metal::TensorSpec(
         old_spec.logical_shape(),
-        tensor_layout_with_custom_alignment(
+        experimental::tensor_layout_with_custom_alignment(
             old_spec.tensor_layout().get_data_type(),
             old_spec.tensor_layout().get_page_config(),
             operation_attributes.output_mem_config,

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/halo_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/halo_device_operation.cpp
@@ -8,6 +8,7 @@
 #include "ttnn/operations/sliding_window/halo/device/halo_device_operation.hpp"
 #include "ttnn/device_operation.hpp"
 #include <array>
+#include <tt-metalium/experimental/tensor_layout_apis_with_custom_alignment.hpp>
 
 namespace ttnn::prim {
 
@@ -86,7 +87,7 @@ HaloDeviceOperation::spec_return_value_t HaloDeviceOperation::compute_output_spe
     padded_output_shape[-1] = tt::round_up(padded_output_shape[-1], shard_shape[1]);
     return tt::tt_metal::TensorSpec(
         output_shape,
-        TensorLayout::fromPaddedShape(
+        tensor_layout_from_padded_shape(
             output_dtype, PageConfig(Layout::ROW_MAJOR), out_mem_config, output_shape, padded_output_shape));
 }
 

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/halo_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/halo_device_operation.cpp
@@ -87,7 +87,7 @@ HaloDeviceOperation::spec_return_value_t HaloDeviceOperation::compute_output_spe
     padded_output_shape[-1] = tt::round_up(padded_output_shape[-1], shard_shape[1]);
     return tt::tt_metal::TensorSpec(
         output_shape,
-        experimental::tensor_layout_from_padded_shape(
+        tt::tt_metal::experimental::tensor_layout_from_padded_shape(
             output_dtype, PageConfig(Layout::ROW_MAJOR), out_mem_config, output_shape, padded_output_shape));
 }
 

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/halo_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/halo_device_operation.cpp
@@ -87,7 +87,7 @@ HaloDeviceOperation::spec_return_value_t HaloDeviceOperation::compute_output_spe
     padded_output_shape[-1] = tt::round_up(padded_output_shape[-1], shard_shape[1]);
     return tt::tt_metal::TensorSpec(
         output_shape,
-        tensor_layout_from_padded_shape(
+        experimental::tensor_layout_from_padded_shape(
             output_dtype, PageConfig(Layout::ROW_MAJOR), out_mem_config, output_shape, padded_output_shape));
 }
 


### PR DESCRIPTION
### PR Category

Cleanup

### Summary

Following https://github.com/tenstorrent/tt-metal/pull/50628, this PR splits out more APIs that need more design review and considerations before graduation. There's no net semantic change.

### APIs that allow custom alignment

There's a set of APIs that allow construction of a `TensorSpec` with a custom `Alignment` from `experimental/tensor`.

A `TensorSpec` with a custom `Alignment` is not generalizable and hard to reason about. Current usages of this functionality are exclusively as an op's intermediate state to allow over-padding.

What leaves Runtime Tensor, into (new) `experimental/tensor_layout_apis_with_custom_alignment.hpp`:

- **`TensorLayout(..., Alignment)`** → `experimental::tensor_layout_with_custom_alignment`
- **`TensorLayout::fromPaddedShape`** (already deprecated long before) → `experimental::tensor_layout_from_padded_shape`

### APIs that allow conversion from `HostTensor` to `span<T>`

`HostTensor` is an inherently multi-device container and cannot be collapsed to a single continuous byte space.
Currently, an attempt for this conversion results in `TT_FATAL`; the design needs more thought.

What leaves Runtime Tensor, into `experimental/distributed_tensor/distributed_tensor_apis.hpp`:

- **`host_buffer::get_host_buffer(const HostTensor&)`**
- **`host_buffer::get_as<T>(HostTensor&)` / `get_as<T>(const HostTensor&)`**

`host_buffer::get_as` overloads for `HostBuffer` remain in `experimental/tensor/tensor_apis.hpp`.

### Notes for reviewers

- `fromPaddedShape` has been deprecated a long time in favor of the alignment constructor, however use site migration has been tricky and is still in progress.
- Use sites have been updated.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=riverwu/no-custom-alignment)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:riverwu/no-custom-alignment)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=riverwu/no-custom-alignment)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:riverwu/no-custom-alignment)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=riverwu/no-custom-alignment)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:riverwu/no-custom-alignment)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=riverwu/no-custom-alignment)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:riverwu/no-custom-alignment)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=riverwu/no-custom-alignment)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:riverwu/no-custom-alignment)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=riverwu/no-custom-alignment)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:riverwu/no-custom-alignment)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=riverwu/no-custom-alignment)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:riverwu/no-custom-alignment)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=riverwu/no-custom-alignment)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:riverwu/no-custom-alignment)