### PR TITLE
[Cleanup] Conv2d: use CB FIFO semantics for partial accumulation

### DIFF
--- a/models/demos/vision/segmentation/vgg_unet/common/ttnn/model_preprocessing.py
+++ b/models/demos/vision/segmentation/vgg_unet/common/ttnn/model_preprocessing.py
@@ -327,7 +327,7 @@ def create_vgg_unet_model_parameters(model: UNetVGG19, input_tensor: torch.Tenso
     parameters.conv_args.d4.up["enable_act_double_buffer"] = True
     parameters.conv_args.d4.up["deallocate_activation"] = True
     parameters.conv_args.d4.up["reshard_if_not_optimal"] = True
-    parameters.conv_args.d4.up["shard_layout"] = None
+    parameters.conv_args.d4.up["shard_layout"] = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
     parameters.conv_args.d4.up["dtype"] = ttnn.bfloat16
 
     parameters.conv_args.d4.conv_block.conv1["act_block_h"] = 32 * 4

--- a/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/test_conv2d.py
@@ -652,6 +652,33 @@ def test_conv_features_multi_device(
 
 
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
+def test_conv_packer_l1_acc_untilize_activation_without_bias(device, torch_tensor_map):
+    run_conv(
+        device,
+        torch_tensor_map,
+        ttnn.MathFidelity.HiFi4,
+        ttnn.bfloat16,
+        ttnn.bfloat16,
+        2,
+        128,
+        128,
+        32,
+        32,
+        3,
+        3,
+        1,
+        1,
+        (1, 1),
+        None,
+        shard_layout=BS,
+        output_layout=ttnn.ROW_MAJOR_LAYOUT,
+        has_bias=False,
+        packer_l1_acc=True,
+        activation=ttnn.UnaryWithParam(ttnn.UnaryOpType.GELU),
+    )
+
+
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 16384}], indirect=True)
 @pytest.mark.parametrize("stride", [2])
 @pytest.mark.parametrize("batch_size", [2])
 @pytest.mark.parametrize(
@@ -828,6 +855,14 @@ def test_conv_dram(
 
     if input_channels > 1024 and input_dtype == ttnn.bfloat8_b:
         pytest.skip("Skipping tests with large accumulation due to bfloat8 accuracy issues.")
+
+    if input_layout == ttnn.ROW_MAJOR_LAYOUT:
+        pytest.skip(
+            "Row-major DRAM auto-slicing underestimates peak L1 for simultaneous interleaved-to-row-major "
+            "untilize staging buffers and can select an oversized slice; tiled DRAM-slicing coverage remains "
+            "enabled. See https://github.com/tenstorrent/tt-metal/issues/51672"
+        )
+
     batch_size = 1
     config = {}
     config["act_block_h"] = act_block_h_override

--- a/tests/ttnn/nightly/unit_tests/operations/conv/test_conv_transpose2d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/test_conv_transpose2d.py
@@ -281,6 +281,13 @@ def test_convt2d_dram(
     if device.core_grid.y != 8 and is_wormhole_b0():
         pytest.skip("Needs 8x8 Grid for Wormhole_b0")
 
+    if layout == ttnn.ROW_MAJOR_LAYOUT:
+        pytest.skip(
+            "Row-major DRAM auto-slicing underestimates peak L1 for simultaneous interleaved-to-row-major "
+            "untilize staging buffers and can select an oversized slice; tiled DRAM-slicing coverage remains "
+            "enabled. See https://github.com/tenstorrent/tt-metal/issues/51672"
+        )
+
     # for TILE layout, the maximum number of slices for the (16,  16,  16, 256, 128) test case is 1 due to tile boundary constraints
     adjusted_num_slices = num_slices
     if (

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.cpp
@@ -212,19 +212,31 @@ std::vector<CBInfo> get_cb_info(
 
     // Matmul partials CB. 1D depthwise compute uses dest-reuse accumulation.
     //  - Single height block: it reuses out_cb directly for the read-back, so no partials CB
-    //    (0-page entry; allocate_cbs skips the device allocation).
+    //    (the 0-page entry is not emitted).
     //  - Multiple height blocks, non-coalesced: out_cb is the persistent sharded output and cannot
     //    double as the dest-reuse scratch across blocks, so allocate a dedicated scratch CB in the
     //    output data format.
     const bool depthwise_dest_reuse_scratch = is_1d_depthwise_conv &&
                                               sharding_scheme == TensorMemoryLayout::HEIGHT_SHARDED &&
                                               !coalesce_1d_depthwise_kw_reads && num_blocks_act_h > 1;
+    const bool partials_use_output_cb = !untilize_out && partial_dtype == output_datatype && !is_1d_depthwise_conv;
+    // This must match the compute kernel's out_block_num_tiles. Both factories pass one full per-core output-width
+    // block to compute, so dedicated partials storage is exactly one output block reused through ordinary CB FIFO
+    // wraparound. When formats allow output aliasing, only the final block of the existing output allocation is used.
+    const uint32_t output_block_num_tiles = block_config.act_block_h_ntiles * per_core_out_matrix_width_ntiles;
+    TT_FATAL(
+        is_1d_depthwise_conv || output_block_num_tiles <= per_core_out_ntiles,
+        "Conv2d output block size {} exceeds the per-core output size {}",
+        output_block_num_tiles,
+        per_core_out_ntiles);
     cb_info.emplace_back(CBInfo{
         .name = Conv2dCb::MATMUL_PARTIALS,
         .num_pages =
-            depthwise_dest_reuse_scratch ? act_block_num_tiles : (is_1d_depthwise_conv ? 0 : per_core_out_ntiles),
+            depthwise_dest_reuse_scratch ? act_block_num_tiles : (is_1d_depthwise_conv ? 0 : output_block_num_tiles),
         .page_size = depthwise_dest_reuse_scratch ? output_tile_size : partial_tile_size,
-        .is_globally_allocated = (!untilize_out && partial_dtype == output_datatype && !is_1d_depthwise_conv),
+        .is_globally_allocated = partials_use_output_cb,
+        .address_offset =
+            partials_use_output_cb ? (per_core_out_ntiles - output_block_num_tiles) * output_tile_size : 0,
         .data_format = depthwise_dest_reuse_scratch ? output_df : partial_df});
 
     const bool overlap_im2col_cb =
@@ -346,58 +358,6 @@ std::vector<CBInfo> get_cb_info(
 
     TT_FATAL(cb_info.size() == num_cbs, "Expected info for {} cbs  by got {}!", num_cbs, cb_info.size());
     return cb_info;
-}
-
-void allocate_cbs(
-    std::vector<CBInfo>& cb_info,
-    tt::tt_metal::Program& program,
-    const std::variant<CoreCoord, CoreRange, CoreRangeSet>& all_cores,
-    const Tensor& input_tensor,
-    const Tensor& output_tensor,
-    const Tensor& l1_indices_tensor) {
-    uint32_t cb_index = 0;
-    for (auto& cb : cb_info) {
-        if (cb.num_pages == 0) {
-            // Skip circular buffers with zero pages
-            continue;
-        }
-
-        // cbs for sharded tensors.
-        Buffer* buffer = nullptr;
-        if (cb.is_globally_allocated) {
-            if (cb.name == Conv2dCb::ACT_SHARDED) {
-                buffer = input_tensor.buffer();
-            } else if (cb.name == Conv2dCb::OUT || cb.name == Conv2dCb::MATMUL_PARTIALS) {
-                buffer = output_tensor.buffer();
-            } else if (cb.name == Conv2dCb::READER_INDICES) {
-                buffer = l1_indices_tensor.buffer();
-            } else {
-                TT_THROW(
-                    "Unexpected circular buffer name {}. Expected one of: SHARDED_ACT_CB, OUT0_CB, READER_INDICES_CB",
-                    enchantum::to_string(cb.name));
-            }
-        }
-
-        std::tie(cb.index, cb.handle) =
-            tt::tt_metal::create_cb(cb_index++, program, all_cores, cb.page_size, cb.num_pages, cb.data_format, buffer);
-        log_trace(
-            tt::LogOp,
-            "Allocated circular buffer {} with index {}, num pages {}, page size {}, globally allocated: {}",
-            enchantum::to_string(cb.name),
-            cb.index,
-            cb.num_pages,
-            cb.page_size,
-            cb.is_globally_allocated);
-    }
-
-    for (auto& cb : cb_info) {
-        if (cb.overlapped_by_cb.has_value()) {
-            // If this CB is overlapped by another CB, set the handle to the overlapped CB's handle
-            const CBInfo& overlapped_cb = get_cb_info_by_name(cb_info, cb.overlapped_by_cb.value());
-            cb.handle = overlapped_cb.handle;
-            cb.index = overlapped_cb.index;
-        }
-    }
 }
 
 const CBInfo& get_cb_info_by_name(const std::vector<CBInfo>& cb_info, Conv2dCb cb_name) {
@@ -779,7 +739,6 @@ void emit_cb_descriptors(
     uint32_t cb_index = 0;
     for (auto& cb : cb_info) {
         if (cb.num_pages == 0) {
-            // Skip circular buffers with zero pages (matches allocate_cbs behavior).
             continue;
         }
 
@@ -800,7 +759,7 @@ void emit_cb_descriptors(
 
         cb.index = cb_index++;
         desc.cbs.push_back(tt::tt_metal::CBDescriptor{
-            .total_size = cb.num_pages * cb.page_size,
+            .total_size = cb.cb_size_per_core(),
             .core_ranges = all_cores_set,
             .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
                 .buffer_index = static_cast<uint8_t>(cb.index),
@@ -808,6 +767,7 @@ void emit_cb_descriptors(
                 .page_size = cb.page_size,
             }}},
             .buffer = buffer,
+            .address_offset = cb.address_offset,
         });
     }
 

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.hpp
@@ -39,8 +39,6 @@ enum class Conv2dCb {
 struct CBInfo {
     // Index of CB that will be passed in to the kernel.
     uint32_t index = kInvalidCBIndex;
-    // CB handle
-    tt::tt_metal::CBHandle handle{};
     // Type of the CB
     Conv2dCb name{Conv2dCb::COUNT};
     // Number of pages in the circular buffer.
@@ -49,6 +47,8 @@ struct CBInfo {
     uint32_t page_size{};
     // Whether this CB is globally allocated (true for sharded tensors).
     bool is_globally_allocated = false;
+    // Byte offset within a globally allocated backing buffer.
+    uint32_t address_offset = 0;
     // Data format of the circular buffer.
     tt::DataFormat data_format = tt::DataFormat::Invalid;
     // Optional: If this CB is overlapped by another CB, this will hold the name of that CB.
@@ -59,7 +59,7 @@ struct CBInfo {
 
 // Returns a vector of CBInfo objects for the Conv2d operation.
 // The vector will contain information about all circular buffers used in the Conv2d operation.
-// CBInfo::index and CBInfo::handle won't be valid until allocate_cbs() is called.
+// CBInfo::index won't be valid until emit_cb_descriptors() is called.
 // When the program factory has the real reader indices DRAM buffer, it can pass its actual page
 // size so the predicted READER_INDICES CB footprint matches the CB the factory creates. Auto-shard
 // L1 estimation passes std::nullopt and falls back to the worst case (1 uint16 index per output row).
@@ -81,17 +81,6 @@ std::vector<CBInfo> get_cb_info(
     bool skip_act_cb_create,
     uint32_t input_channels_padded,
     std::optional<uint32_t> reader_indices_actual_page_size = std::nullopt);
-
-// Allocates circular buffers for the Conv2d operation.
-// This function will populate index and handle fields of each CBInfo in the cb_info vector,
-// and add these circular buffers to the provided program.
-void allocate_cbs(
-    std::vector<CBInfo>& cb_info,
-    tt::tt_metal::Program& program,
-    const std::variant<CoreCoord, CoreRange, CoreRangeSet>& all_cores,
-    const Tensor& input_tensor,
-    const Tensor& output_tensor,
-    const Tensor& l1_indices_tensor);
 
 const CBInfo& get_cb_info_by_name(const std::vector<CBInfo>& cb_info, Conv2dCb cb_name);
 CBInfo& access_cb_info_by_name(const std::vector<CBInfo>& cb_info, Conv2dCb cb_name);
@@ -127,8 +116,7 @@ void post_conv2d_op_memory_checks(
     std::optional<uint32_t> reader_indices_actual_page_size = std::nullopt);
 
 // Builds CBDescriptor entries from a vector of CBInfo onto the supplied
-// ProgramDescriptor, mirroring allocate_cbs() but emitting onto the descriptor
-// data structures instead of a realised Program.  The set of globally-allocated
+// ProgramDescriptor. The set of globally-allocated
 // CBs (ACT_SHARDED/OUT/MATMUL_PARTIALS/READER_INDICES) is wired to the supplied
 // raw Buffer*s, which is what the framework's fast cache-hit path patches.
 // This single helper is used by both the sharded and width-sharded conv2d

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
@@ -768,11 +768,6 @@ tt::tt_metal::ProgramDescriptor build_program_descriptor_sharded(
         }
     }
 
-    // 1D depthwise compute uses dest-reuse for accumulation — no MATMUL_PARTIALS CB is allocated.
-    const bool partials_cb_uses_output =
-        !is_conv_1d_depthwise_conv && get_cb_info_by_name(cb_info, Conv2dCb::MATMUL_PARTIALS).is_globally_allocated;
-    log_debug(tt::LogOp, "partials_cb_uses_output: {}", partials_cb_uses_output);
-
     std::string reader_kernel;
     std::string compute_kernel = "ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_bmm_tilize.cpp";
     std::string writer_mcast_sender_kernel =
@@ -870,7 +865,8 @@ tt::tt_metal::ProgramDescriptor build_program_descriptor_sharded(
         reader_defines["CONFIG_TENSOR_IN_DRAM"] = "1";
         writer_defines["CONFIG_TENSOR_IN_DRAM"] = "1";               // Needed for split reader
         writer_mcast_sender_defines["CONFIG_TENSOR_IN_DRAM"] = "1";  // Needed for split reader
-        reader_compile_time_args.push_back(conv_reader_indices_buffer->address());
+        reader_compile_time_args.push_back(
+            conv_reader_indices_buffer->address());  // smuggled-rta-ok: compile-time workload-owned buffer
         reader_compile_time_args.push_back(conv_reader_indices_buffer->page_size());
         tt::tt_metal::TensorAccessorArgs(conv_reader_indices_buffer).append_to(reader_compile_time_args);
     } else {
@@ -1096,7 +1092,6 @@ tt::tt_metal::ProgramDescriptor build_program_descriptor_sharded(
             get_cb_info_by_name(cb_info, Conv2dCb::MATMUL_PARTIALS).index,
             get_cb_info_by_name(cb_info, Conv2dCb::ACT_TILIZED).index,
             get_cb_info_by_name(cb_info, Conv2dCb::OUT).index,
-            partials_cb_uses_output,
             conv_act_c_blocks,
             check_skip_compute,
             pack_relu,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
@@ -466,12 +466,6 @@ tt::tt_metal::ProgramDescriptor build_program_descriptor(
     // override needed.
     const CoreRangeSet all_reader_cores_set(all_reader_cores);
     emit_cb_descriptors(cb_info, desc, all_reader_cores_set, a.buffer(), output.buffer(), conv_reader_indices_buffer);
-    // partials_cb_uses_output is still consumed by compute_kernel_args below; the
-    // CB-on-output wiring is handled inline by emit_cb_descriptors (MATMUL_PARTIALS
-    // is mapped to output_buffer when is_globally_allocated is true), so we no
-    // longer need to call UpdateDynamicCircularBufferAddress on cache hit.
-    const bool partials_cb_uses_output = get_cb_info_by_name(cb_info, Conv2dCb::MATMUL_PARTIALS).is_globally_allocated;
-
     std::vector<uint32_t> compute_kernel_args = {
         act_block_w_ntiles,                         // in0_block_w
         act_num_subblocks,                          // in0_num_sublocks
@@ -503,7 +497,6 @@ tt::tt_metal::ProgramDescriptor build_program_descriptor(
         get_cb_info_by_name(cb_info, Conv2dCb::MATMUL_PARTIALS).index,
         get_cb_info_by_name(cb_info, Conv2dCb::ACT_TILIZED).index,
         get_cb_info_by_name(cb_info, Conv2dCb::OUT).index,
-        partials_cb_uses_output,
         input_num_cores,  // in0_nblocks_w_tilize. Repeat tilize after all cores have done one round of MCAST.
         false,            // check_skip_compute; not used in width sharded
         pack_relu,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_bmm_tilize.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_bmm_tilize.cpp
@@ -228,25 +228,23 @@ void kernel_main() {
     constexpr uint32_t matmul_partials_cb = get_compile_time_arg_val(22);
     constexpr uint32_t tilized_in0_cb_id = get_compile_time_arg_val(23);
     constexpr uint32_t out_cb_id = get_compile_time_arg_val(24);
-    constexpr bool partials_cb_uses_output = get_compile_time_arg_val(25);
-    constexpr uint32_t in0_nblocks_w_tilize = get_compile_time_arg_val(26);
-    constexpr bool check_skip_compute = get_compile_time_arg_val(27);
-    constexpr bool pack_relu = get_compile_time_arg_val(28);
-    constexpr bool packer_untilize = get_compile_time_arg_val(29);
-    constexpr bool packer_l1_acc = get_compile_time_arg_val(30);
-    constexpr bool fuse_bias = get_compile_time_arg_val(31);
-    constexpr bool split_reader = get_compile_time_arg_val(32);
-    constexpr bool activation_reuse = get_compile_time_arg_val(33);
+    constexpr uint32_t in0_nblocks_w_tilize = get_compile_time_arg_val(25);
+    constexpr bool check_skip_compute = get_compile_time_arg_val(26);
+    constexpr bool pack_relu = get_compile_time_arg_val(27);
+    constexpr bool packer_untilize = get_compile_time_arg_val(28);
+    constexpr bool packer_l1_acc = get_compile_time_arg_val(29);
+    constexpr bool fuse_bias = get_compile_time_arg_val(30);
+    constexpr bool split_reader = get_compile_time_arg_val(31);
+    constexpr bool activation_reuse = get_compile_time_arg_val(32);
 
-    constexpr uint32_t image_width_in_tiles = get_compile_time_arg_val(34);
-    constexpr uint32_t window_reuse_offset = get_compile_time_arg_val(35);
-    constexpr uint32_t tilized_cb_row_offset = get_compile_time_arg_val(36);
-    constexpr uint32_t tilized_cb_second_reader_offset = get_compile_time_arg_val(37);
-    constexpr bool split_reader_cb_shared = get_compile_time_arg_val(38) == 1;
+    constexpr uint32_t image_width_in_tiles = get_compile_time_arg_val(33);
+    constexpr uint32_t window_reuse_offset = get_compile_time_arg_val(34);
+    constexpr uint32_t tilized_cb_row_offset = get_compile_time_arg_val(35);
+    constexpr uint32_t tilized_cb_second_reader_offset = get_compile_time_arg_val(36);
+    constexpr bool split_reader_cb_shared = get_compile_time_arg_val(37) == 1;
 
     constexpr uint32_t out_block_num_tiles = in0_num_subblocks * in1_num_subblocks * out_subblock_num_tiles;
     constexpr uint32_t out_block_w = in1_block_w;
-    constexpr bool spill = in0_num_blocks_w > 1;
 
     constexpr uint32_t untilize_mode_out_cb_id = untilize_out ? matmul_partials_cb : out_cb_id;
 
@@ -296,24 +294,19 @@ void kernel_main() {
 #ifdef SFPU_OP_INIT_ACTIVATION
     SFPU_OP_INIT_ACTIVATION
 #endif
-    UNPACK(uint32_t partials_cb_read_ptr = get_local_cb_interface(matmul_partials_cb).fifo_rd_ptr;)
-    PACK(uint32_t partials_cb_write_ptr = get_local_cb_interface(matmul_partials_cb).fifo_wr_ptr;)
     // in1 num blocks w is the outer loop. Output blocks are computed in col major order.
     for (uint32_t in1_block_w_i = 0; in1_block_w_i < in1_num_blocks_w; ++in1_block_w_i) {
         for (uint32_t in0_block_h_i = 0; in0_block_h_i < in0_num_blocks_h; ++in0_block_h_i) {
-            bool enable_reload = false;
-
             if constexpr (pack_relu) {
                 // for each output block we start we relu disabled so that intermediate results are not relu'd
                 PACK((llk_pack_relu_config(ReluConfig::none())));
             }
-            if constexpr (partials_cb_uses_output) {
-                UNPACK(partials_cb_read_ptr = get_local_cb_interface(matmul_partials_cb).fifo_rd_ptr;)
-                PACK(partials_cb_write_ptr = get_local_cb_interface(matmul_partials_cb).fifo_wr_ptr;)
-            }
-            uint32_t curr_matmul_out_cb = matmul_partials_cb;
             for (uint32_t in0_block_w_i = 0; in0_block_w_i < in0_num_blocks_w; ++in0_block_w_i) {
-                bool last_inner_dim_block = (in0_block_w_i == in0_num_blocks_w - 1);
+                const bool last_inner_dim_block = (in0_block_w_i == in0_num_blocks_w - 1);
+                const bool reload_partials =
+                    in0_block_w_i > 0 && (!packer_l1_acc || (!fuse_bias && last_inner_dim_block));
+                const uint32_t curr_matmul_out_cb =
+                    last_inner_dim_block && !fuse_bias ? mm_out_cb_id : matmul_partials_cb;
                 if constexpr (!height_sharded) {
                     if (in0_block_w_i % in0_nblocks_w_tilize == 0) {
                         if constexpr (pack_relu && !fuse_bias) {
@@ -405,7 +398,6 @@ void kernel_main() {
                             // if last block we pack the final result with relu enabled
                             PACK((llk_pack_relu_config(ReluConfig::zero())));
                         }
-                        curr_matmul_out_cb = mm_out_cb_id;
                     }
                 }
 
@@ -415,7 +407,7 @@ void kernel_main() {
                 for (uint32_t in0_subblock_i = 0; in0_subblock_i < in0_num_subblocks; ++in0_subblock_i) {
                     uint32_t in1_index_subblock_offset = 0;
                     for (uint32_t in1_subblock_i = 0; in1_subblock_i < in1_num_subblocks; ++in1_subblock_i) {
-                        if (enable_reload) {
+                        if (reload_partials) {
                             // Reconfigure input
                             copy_tile_to_dst_init_short_with_dt(in1_cb_id, matmul_partials_cb);
                             dfb_matmul_partials.wait_front(out_subblock_num_tiles);
@@ -477,15 +469,7 @@ void kernel_main() {
                         tile_regs_wait();
 
                         if constexpr (packer_l1_acc) {
-                            // no accumulation for first iteration, last iteration
-                            // accumulation happens with copying tiles to dst
-                            if (in0_block_w_i == 0) {
-                                pack_reconfig_l1_acc(0);
-                            } else if (last_inner_dim_block) {
-                                pack_reconfig_l1_acc(fuse_bias ? 1 : 0);
-                            } else {
-                                pack_reconfig_l1_acc(1);
-                            }
+                            pack_reconfig_l1_acc(in0_block_w_i == 0 || reload_partials ? 0 : 1);
                         }
 
                         uint32_t start_dst_index = 0;
@@ -498,66 +482,20 @@ void kernel_main() {
                     }  // for in1_num_subblocks
                     in0_index_subblock_offset += in0_subblock_num_tiles;
                 }
-                if (curr_matmul_out_cb == matmul_partials_cb) {
-                    if constexpr (!partials_cb_uses_output) {
-                        UNPACK(get_local_cb_interface(matmul_partials_cb).fifo_rd_ptr = partials_cb_read_ptr;)
-                        PACK(get_local_cb_interface(matmul_partials_cb).fifo_wr_ptr = partials_cb_write_ptr;)
-                    }
-                }
                 if constexpr (packer_l1_acc) {
-                    if constexpr (fuse_bias) {
-                        if (in0_block_w_i < in0_num_blocks_w - 1) {
-                            // Wait for l1 accumulation to populate interm buffer,
-                            // then pop to update fifo rd pointer
-                            dfb_matmul_partials.wait_front(out_block_num_tiles);
-                            dfb_matmul_partials.pop_front(out_block_num_tiles);
-                            if constexpr (spill) {
-                                UNPACK(get_local_cb_interface(matmul_partials_cb).fifo_rd_ptr = partials_cb_read_ptr);
-                                PACK(get_local_cb_interface(matmul_partials_cb).fifo_wr_ptr = partials_cb_write_ptr);
-                            }
-                        }
-                        // never reload when with bias, bias uses interm buffer
-                        enable_reload = false;
-                    } else {
-                        // Last iteration does spill and reload to output buffer
-                        if (in0_block_w_i < in0_num_blocks_w - 2) {
-                            dfb_matmul_partials.wait_front(out_block_num_tiles);
-                            dfb_matmul_partials.pop_front(out_block_num_tiles);
-                            if constexpr (spill) {
-                                UNPACK(get_local_cb_interface(matmul_partials_cb).fifo_rd_ptr = partials_cb_read_ptr);
-                                PACK(get_local_cb_interface(matmul_partials_cb).fifo_wr_ptr = partials_cb_write_ptr);
-                            }
-                        }
-                        if (in0_block_w_i == in0_num_blocks_w - 2) {
-                            enable_reload = true;
-                        }
-                    }
-                } else {
-                    if constexpr (spill) {
-                        enable_reload = true;
-
-                        if constexpr (fuse_bias) {
-                            if (!last_inner_dim_block) {
-                                UNPACK(get_local_cb_interface(matmul_partials_cb).fifo_rd_ptr = partials_cb_read_ptr);
-                                PACK(get_local_cb_interface(matmul_partials_cb).fifo_wr_ptr = partials_cb_write_ptr);
-                            }
-                        } else {
-                            if (!last_inner_dim_block) {
-                                UNPACK(get_local_cb_interface(matmul_partials_cb).fifo_rd_ptr = partials_cb_read_ptr);
-                            }
-                            if (in0_block_w_i < in0_num_blocks_w - 2) {
-                                PACK(get_local_cb_interface(matmul_partials_cb).fifo_wr_ptr = partials_cb_write_ptr);
-                            }
-                        }
+                    const bool keep_partials =
+                        last_inner_dim_block || (!fuse_bias && in0_block_w_i == in0_num_blocks_w - 2);
+                    if (curr_matmul_out_cb == matmul_partials_cb && !keep_partials) {
+                        // The logical partials FIFO is exactly one output block. Releasing the completed block makes
+                        // the next K pass wrap naturally to the same physical addresses for packer accumulation.
+                        dfb_matmul_partials.wait_front(out_block_num_tiles);
+                        dfb_matmul_partials.pop_front(out_block_num_tiles);
                     }
                 }
 
                 dfb_mm_in0.pop_front(in0_block_num_tiles);
                 dfb_in1.pop_front(in1_block_num_tiles);
             }  // for in0_num_blocks_w
-            if constexpr (matmul_partials_cb == mm_out_cb_id && partials_cb_uses_output) {
-                UNPACK(get_local_cb_interface(matmul_partials_cb).fifo_rd_ptr = partials_cb_read_ptr);
-            }
             if constexpr (check_skip_compute) {
                 if (skip_compute) {
                     continue;
@@ -611,10 +549,6 @@ void kernel_main() {
                         in1_index_subblock_offset += out_subblock_w;
                     }  // for in1_num_subblocks
                 }  // in0_num_subblocks
-                if constexpr (untilize_out) {
-                    UNPACK(get_local_cb_interface(matmul_partials_cb).fifo_rd_ptr = partials_cb_read_ptr);
-                    PACK(get_local_cb_interface(matmul_partials_cb).fifo_wr_ptr = partials_cb_write_ptr);
-                }
             }
             if constexpr (untilize_out) {
                 if constexpr (packer_l1_acc) {


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
Remove manual circular-buffer pointer save/restore from conv2d partial accumulation.

- Size `MATMUL_PARTIALS` to one output block and reuse it through ordinary `reserve_back`, `push_back`, `wait_front`, and `pop_front` wrap.
- Express tiled OUT/PARTIALS overlap in the program factory with distinct CB descriptors over the output allocation and a tail-block `address_offset`.
- Use private one-block partial storage for untilized output or data-format mismatch.
- Make the reduced footprint visible to auto-shard planning: dedicated partials storage drops from the full per-core output to one output block, saving every block after the first in L1.
- Keep the compute schedule and reader/writer contracts unchanged; no data-movement kernels are modified.

#### Design presentation
[Open the interactive HTML presentation](https://htmlpreview.github.io/?https://gist.githubusercontent.com/pavlejosipovic/2953b20a49c0354e959f8e08485be6e6/raw/conv2d_cb_refactor_presentation.html)

[View the presentation source Gist](https://gist.github.com/pavlejosipovic/2953b20a49c0354e959f8e08485be6e6)

#### CI workflows
[![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/conv2d-cb-fifo-refactor)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch%3Apjosipovic%2Fconv2d-cb-fifo-refactor)

[![Blackhole sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=pjosipovic/conv2d-cb-fifo-refactor)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch%3Apjosipovic%2Fconv2d-cb-fifo-refactor)

[![Nightly L2 conv tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/conv2d-cb-fifo-refactor)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch%3Apjosipovic%2Fconv2d-cb-fifo-refactor)

[![Single-card device performance](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml/badge.svg?branch=pjosipovic/conv2d-cb-fifo-refactor)](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-device-models.yaml?query=branch%3Apjosipovic%2Fconv2d-cb-fifo-refactor)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/conv2d-cb-fifo-refactor)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/conv2d-cb-fifo-refactor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/conv2d-cb-fifo-refactor)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/conv2d-cb-fifo-refactor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=pjosipovic/conv2d-cb-fifo-refactor)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:pjosipovic/conv2d-cb-fifo-refactor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/conv2d-cb-fifo-refactor)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/conv2d-cb-fifo-refactor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/conv2d-cb-fifo-refactor)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/conv2d-cb-fifo-refactor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/conv2d-cb-fifo-refactor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/conv2d-cb-fifo-refactor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/conv2d-cb-fifo-refactor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/conv2d-cb-fifo-refactor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/conv2d-cb-fifo-refactor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/conv2d-cb-fifo-refactor)