### PR TITLE
[skip ci] [Feature] Add perf-report skill for generating and validating LLK performance reports

### DIFF
--- a/tt_metal/tt-llk/.claude/CLAUDE.md
+++ b/tt_metal/tt-llk/.claude/CLAUDE.md
@@ -43,6 +43,7 @@ Execution model: RISC-V cores push instructions to corresponding coprocessor thr
 | Debugging kernel errors | `debug-kernel` (`.claude/skills/debug-kernel/SKILL.md`) | Dispatches llk-debugger with inferred arch/kernel type |
 | Porting kernels between architectures | `port-kernel` (`.claude/skills/port-kernel/SKILL.md`) | Launches source + target sages, reads test harness |
 | Creating or repairing Quasar perf tests | `quasar-perf-test` (`.claude/skills/quasar-perf-test/SKILL.md`) | Reuses correctness tests, wires `PerfConfig`, and implements balanced `PerfRunType` paths |
+| Generating or refreshing a performance report | `perf-report` (`.claude/skills/perf-report/SKILL.md`) | Runs the producer/consumer perf sweep, combines `perf_data` CSVs, and validates schema, coverage, and metric plausibility |
 | Analyzing performance-report CSV parameter impact | `perf-parameter-impact` (`.claude/skills/perf-parameter-impact/SKILL.md`) | Builds paired, bottleneck-aware Canvas reports for formats, fidelity, dimensions, accumulation, indexing, and related parameters |
 | TensorShape / tile-size API conversion or coverage | `tensor-shape` (`.claude/skills/tensor-shape/SKILL.md`) | Plumbs `TensorShape` through lib/API, TRISC coverage, review checklist |
 

--- a/tt_metal/tt-llk/.claude/skills/perf-report/SKILL.md
+++ b/tt_metal/tt-llk/.claude/skills/perf-report/SKILL.md
@@ -63,8 +63,9 @@ Rules:
   reduces `ZONE_SCOPED` to metadata only: the run emits no wall-clock
   `mean(<run type>)` columns, only `<RUN_TYPE>_..._pct` efficiency columns.
   It also writes to the same `<module>.csv` path, overwriting the timing
-  report. Copy the timing report aside first, run counters as a separate
-  sweep, and validate the result as a counter report. `--dump-csv-counters`
+  report. Move the timing report out of the way first (see Refresh and
+  compare), run counters as a separate sweep, and validate the result as a
+  counter report. `--dump-csv-counters`
   additionally writes raw counter values to `<module>.counters.csv`.
 - Perf counters are unavailable on Quasar. The build gate keeps the define off
   there and `counters.h` `#error`s if it ever slips through, so the flag
@@ -102,10 +103,15 @@ finish, or every selected test was skipped.
 1. **Schema.** A `PerfSchemaError` means one test emits different columns
    across its sweep — usually a parameter that is `None` for some values — or
    two ops share one module. Fix the test; do not work around it.
-2. **Row count.** Expect `variants × markers` rows: markers `INIT`, `KERNEL`,
-   and `TILE_LOOP` in a timing report, and only `INIT` and `TILE_LOOP` in a
-   counter report, which has no profiler-derived `KERNEL` row. A short file
-   means an aborted or partly skipped sweep.
+2. **Row count.** Reconcile rather than assert equality. Start from
+   `selected variants × markers`, then subtract skipped or deselected
+   variants and any rows merged by duplicate-key collapse. Markers are the
+   zones the kernel declares — `INIT` and `TILE_LOOP` in the perf sources,
+   plus the `KERNEL` zone that `trisc.cpp` wraps around every profiler build.
+   A counter report has no profiler-derived rows, so expect only the counter
+   zones `INIT` and `TILE_LOOP` there. An unexplained shortfall means an
+   aborted or partly skipped sweep; a shortfall you can attribute to skips or
+   collapse is fine.
 3. **Duplicate keys.** `combine_perf_reports()` warns when it collapses rows
    sharing a (sweep, marker) key. Differing metrics on a collapsed key are
    either run-to-run noise or a parameter that changes the kernel without
@@ -144,9 +150,15 @@ Report back, and keep alongside the CSV when it is archived:
 
 ## Refresh and compare
 
-- Copy an existing report elsewhere before rerunning; combined files are
-  overwritten in place. This applies with full force to a counter run, which
-  replaces the timing report for the same module.
+- Move the existing `perf_data/<module>/` aside before rerunning — copy it out
+  and delete the original, rather than just copying. `combine_perf_reports()`
+  returns early when no worker files were produced and writes each output only
+  when that class has inputs, so a rerun that skips everything or dies before
+  the consumer phase leaves the previous CSV sitting there looking like the new
+  result. Deleting first makes a no-op rerun visibly empty. Confirm the output
+  timestamps are from the run you just did.
+- A counter run replaces the timing report for the same module, so move the
+  timing report out of the way first for the same reason.
 - Compare like with like: same architecture, same speed-of-light setting, same
   `loop_factor` and marker, and the same report kind. Timing and counter
   reports measure different things and share no metric columns.
@@ -157,9 +169,11 @@ Report back, and keep alongside the CSV when it is archived:
 - [ ] Test, architecture, and intended scope confirmed.
 - [ ] Producer and consumer phases both completed without aborting.
 - [ ] Coverage off; speed-of-light setting deliberate and uniform.
+- [ ] Any previous `perf_data/<module>/` was moved aside and deleted before the
+      run, and the new files carry this run's timestamps.
 - [ ] `perf_data/<module>/` holds the raw and `.post.csv` files, plus counters
-      when requested, and no earlier report was overwritten unintentionally.
-- [ ] Single schema, expected row count, duplicate warnings reviewed.
+      when requested.
+- [ ] Single schema, row count reconciled, duplicate warnings reviewed.
 - [ ] Column expectations applied for the report kind actually produced.
 - [ ] `TILE_LOOP` metrics inspected for plausibility.
 - [ ] Columns match the current test sweep.

--- a/tt_metal/tt-llk/.claude/skills/perf-report/SKILL.md
+++ b/tt_metal/tt-llk/.claude/skills/perf-report/SKILL.md
@@ -58,8 +58,17 @@ Rules:
   changes measured cycles. CI passes it. Match CI when the report will be
   compared with CI numbers, and never mix speed-of-light and normal rows in
   one report.
-- `--enable-perf-counters` adds efficiency-metric columns;
-  `--dump-csv-counters` additionally writes `<module>.counters.csv`.
+- `--enable-perf-counters` produces a different, mutually exclusive kind of
+  report. It compiles with `-DPERF_COUNTERS_COMPILED` (the WC build), which
+  reduces `ZONE_SCOPED` to metadata only: the run emits no wall-clock
+  `mean(<run type>)` columns, only `<RUN_TYPE>_..._pct` efficiency columns.
+  It also writes to the same `<module>.csv` path, overwriting the timing
+  report. Copy the timing report aside first, run counters as a separate
+  sweep, and validate the result as a counter report. `--dump-csv-counters`
+  additionally writes raw counter values to `<module>.counters.csv`.
+- Perf counters are unavailable on Quasar. The build gate keeps the define off
+  there and `counters.h` `#error`s if it ever slips through, so the flag
+  yields no counter columns.
 - SFPU sweep modules need `--mode perf`; the selector defaults to `accuracy`
   and deselects the perf sweep.
 - Do not pass `--coverage`. Instrumentation invalidates perf numbers.
@@ -70,8 +79,11 @@ Rules:
 ## 3. Know where the files come from
 
 - Each worker writes `<module>.<worker>.csv` and `<module>.<worker>.post.csv`
-  into `$ARTEFACTS/temp_perf_data/` when the module-scoped `perf_report`
-  fixture tears down — `gw0`, `gw1`, … under `-n`, otherwise `master`.
+  into `/tmp/tt-llk-build/temp_perf_data/` when the module-scoped
+  `perf_report` fixture tears down. Under GitHub Actions the root is
+  `$RUNNER_TEMP/tt-llk-build` instead. The worker is `gw0`, `gw1`, … under
+  `-n`, otherwise `master`. Look there for partial artifacts after an
+  aborted run.
 - `pytest_sessionfinish` calls `combine_perf_reports()`, which merges the
   per-worker files into `perf_data/<module>/<module>.csv`,
   `<module>.post.csv`, and `<module>.counters.csv`, sorts them, and deletes
@@ -90,9 +102,10 @@ finish, or every selected test was skipped.
 1. **Schema.** A `PerfSchemaError` means one test emits different columns
    across its sweep — usually a parameter that is `None` for some values — or
    two ops share one module. Fix the test; do not work around it.
-2. **Row count.** Expect `variants × markers` rows, with markers `INIT`,
-   `KERNEL`, and `TILE_LOOP`. A short file means an aborted or partly skipped
-   sweep.
+2. **Row count.** Expect `variants × markers` rows: markers `INIT`, `KERNEL`,
+   and `TILE_LOOP` in a timing report, and only `INIT` and `TILE_LOOP` in a
+   counter report, which has no profiler-derived `KERNEL` row. A short file
+   means an aborted or partly skipped sweep.
 3. **Duplicate keys.** `combine_perf_reports()` warns when it collapses rows
    sharing a (sweep, marker) key. Differing metrics on a collapsed key are
    either run-to-run noise or a parameter that changes the kernel without
@@ -104,8 +117,16 @@ finish, or every selected test was skipped.
    `quasar-perf-test`.
 5. **Freshness.** Compare CSV columns with the current test axes. Missing axes
    mean the report predates the test; regenerate instead of analyzing.
-6. **Completeness.** Confirm a `mean(...)` and `TEXT_SIZE(...)` column exists
-   for every requested run type.
+6. **Completeness, by report kind.** A timing report carries a
+   `mean(<run type>)` column for every requested run type, and a
+   `TEXT_SIZE(<run type>)` column only for `L1_TO_L1`, `UNPACK_ISOLATE`,
+   `MATH_ISOLATE`, and `PACK_ISOLATE`. `L1_CONGESTION` is deliberately absent
+   from the code-size map, so a missing `TEXT_SIZE(L1_CONGESTION)` is correct
+   rather than a defect. A counter report has no wall-clock means at all:
+   check its `<RUN_TYPE>_..._pct` columns, expect only the `INIT` and
+   `TILE_LOOP` markers, and note that its `.post.csv` is identical to the raw
+   file because normalization only rescales columns named `mean(...)` and
+   `std(...)`.
 
 Never present metrics from a run whose pytest phase failed.
 
@@ -124,9 +145,11 @@ Report back, and keep alongside the CSV when it is archived:
 ## Refresh and compare
 
 - Copy an existing report elsewhere before rerunning; combined files are
-  overwritten in place.
+  overwritten in place. This applies with full force to a counter run, which
+  replaces the timing report for the same module.
 - Compare like with like: same architecture, same speed-of-light setting, same
-  `loop_factor` and marker.
+  `loop_factor` and marker, and the same report kind. Timing and counter
+  reports measure different things and share no metric columns.
 - Repeat a run before attributing a small delta to a code change.
 
 ## Checklist
@@ -135,8 +158,9 @@ Report back, and keep alongside the CSV when it is archived:
 - [ ] Producer and consumer phases both completed without aborting.
 - [ ] Coverage off; speed-of-light setting deliberate and uniform.
 - [ ] `perf_data/<module>/` holds the raw and `.post.csv` files, plus counters
-      when requested.
+      when requested, and no earlier report was overwritten unintentionally.
 - [ ] Single schema, expected row count, duplicate warnings reviewed.
+- [ ] Column expectations applied for the report kind actually produced.
 - [ ] `TILE_LOOP` metrics inspected for plausibility.
 - [ ] Columns match the current test sweep.
 - [ ] Provenance recorded.

--- a/tt_metal/tt-llk/.claude/skills/perf-report/SKILL.md
+++ b/tt_metal/tt-llk/.claude/skills/perf-report/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: perf-report
+description: Generate, refresh, and validate an LLK performance report by running a perf sweep end to end and checking the resulting perf_data CSV. Use when asked to produce or refresh a perf report for an op, run a perf sweep, or when a report is missing, partial, stale, or implausible.
+user_invocable: true
+---
+
+# Perf Report
+
+## Goal
+
+Produce a trustworthy performance report for one LLK perf test and hand it to
+analysis with enough provenance to reproduce it.
+
+A report is a build artifact, not a repository file: `perf_data/` is
+gitignored. What identifies a report is the test, the architecture, the
+commit, and the exact command that produced it. Record all four.
+
+## Related skills
+
+- `quasar-perf-test` — create or repair the perf test and its `PerfRunType`
+  paths. Use it first when the test does not exist, hangs, or reports
+  implausible metrics.
+- `perf-parameter-impact` — analyze a finished `.post.csv`.
+- `run-test` — the repository test-runner workflow.
+
+## 1. Establish the sweep
+
+Read the perf test — `tests/python_tests/perf_[op].py` or
+`tests/python_tests/quasar/perf_[op]_quasar.py` — and determine:
+
+- which `run_types` the test actually reports;
+- `loop_factor`, `tile_cnt`, and the other axes recorded as columns;
+- how many variants `@parametrize` produces;
+- the architecture: the `quasar/` directory or a `*_[arch].py` suffix implies
+  it, otherwise ask.
+
+Decide scope before running. A narrowed sweep (`-k`, `--op`) is right for
+debugging; a report meant for analysis must cover the full intended sweep.
+Never narrow the sweep in the test file to make a run finish.
+
+## 2. Run the sweep
+
+Use the two-phase producer/consumer flow, never a single serial invocation:
+
+```bash
+cd tests
+CHIP_ARCH=<arch> pytest --compile-producer -n 10 -m perf ./python_tests/perf_[op].py
+CHIP_ARCH=<arch> pytest --compile-consumer -n 15 -m perf ./python_tests/perf_[op].py
+```
+
+Prefer the `run-test` workflow where it applies; it serializes simulator
+access and diagnoses hangs. `tests/run_llk_perf_wormhole.sh` and
+`tests/run_llk_perf_blackhole.sh` show the exact CI invocation.
+
+Rules:
+
+- `--speed-of-light` turns runtime parameters into compile-time constants and
+  changes measured cycles. CI passes it. Match CI when the report will be
+  compared with CI numbers, and never mix speed-of-light and normal rows in
+  one report.
+- `--enable-perf-counters` adds efficiency-metric columns;
+  `--dump-csv-counters` additionally writes `<module>.counters.csv`.
+- SFPU sweep modules need `--mode perf`; the selector defaults to `accuracy`
+  and deselects the perf sweep.
+- Do not pass `--coverage`. Instrumentation invalidates perf numbers.
+- Avoid `-x` on a report run. It aborts mid-sweep and the combined CSV is
+  silently partial. Use it only while debugging.
+- Never hand-edit a CSV. Fix the test or rerun.
+
+## 3. Know where the files come from
+
+- Each worker writes `<module>.<worker>.csv` and `<module>.<worker>.post.csv`
+  into `$ARTEFACTS/temp_perf_data/` when the module-scoped `perf_report`
+  fixture tears down — `gw0`, `gw1`, … under `-n`, otherwise `master`.
+- `pytest_sessionfinish` calls `combine_perf_reports()`, which merges the
+  per-worker files into `perf_data/<module>/<module>.csv`,
+  `<module>.post.csv`, and `<module>.counters.csv`, sorts them, and deletes
+  the per-worker files. Combined files are overwritten in place.
+- The producer phase writes no report and skips combining.
+- The raw CSV holds per-marker means. The `.post.csv` divides the `mean(...)`
+  and `std(...)` columns of `TILE_LOOP` rows by `loop_factor * tile_cnt`,
+  giving cycles per tile; `INIT` and `KERNEL` rows are left unnormalized.
+  Analysis uses `.post.csv`.
+
+No report at all usually means the consumer phase never reached session
+finish, or every selected test was skipped.
+
+## 4. Validate the artifact
+
+1. **Schema.** A `PerfSchemaError` means one test emits different columns
+   across its sweep — usually a parameter that is `None` for some values — or
+   two ops share one module. Fix the test; do not work around it.
+2. **Row count.** Expect `variants × markers` rows, with markers `INIT`,
+   `KERNEL`, and `TILE_LOOP`. A short file means an aborted or partly skipped
+   sweep.
+3. **Duplicate keys.** `combine_perf_reports()` warns when it collapses rows
+   sharing a (sweep, marker) key. Differing metrics on a collapsed key are
+   either run-to-run noise or a parameter that changes the kernel without
+   being recorded as a column. Resolve which before shipping the report.
+4. **Plausibility.** Inspect `marker == TILE_LOOP`. Each `L1_CONGESTION` stage
+   should sit near its isolate. Values near 2048, 4096, or 8192, an isolate
+   orders of magnitude above the real stage, or a healthy first variant
+   followed by slow ones all indicate handshake or wait-mask bugs — switch to
+   `quasar-perf-test`.
+5. **Freshness.** Compare CSV columns with the current test axes. Missing axes
+   mean the report predates the test; regenerate instead of analyzing.
+6. **Completeness.** Confirm a `mean(...)` and `TEXT_SIZE(...)` column exists
+   for every requested run type.
+
+Never present metrics from a run whose pytest phase failed.
+
+## 5. Record provenance
+
+Report back, and keep alongside the CSV when it is archived:
+
+- test file and module name;
+- architecture and `CHIP_ARCH`;
+- repository commit;
+- the exact producer and consumer commands, including worker counts,
+  `--speed-of-light`, and counter flags;
+- run types and markers present;
+- row count and output paths.
+
+## Refresh and compare
+
+- Copy an existing report elsewhere before rerunning; combined files are
+  overwritten in place.
+- Compare like with like: same architecture, same speed-of-light setting, same
+  `loop_factor` and marker.
+- Repeat a run before attributing a small delta to a code change.
+
+## Checklist
+
+- [ ] Test, architecture, and intended scope confirmed.
+- [ ] Producer and consumer phases both completed without aborting.
+- [ ] Coverage off; speed-of-light setting deliberate and uniform.
+- [ ] `perf_data/<module>/` holds the raw and `.post.csv` files, plus counters
+      when requested.
+- [ ] Single schema, expected row count, duplicate warnings reviewed.
+- [ ] `TILE_LOOP` metrics inspected for plausibility.
+- [ ] Columns match the current test sweep.
+- [ ] Provenance recorded.
+- [ ] Report handed to `perf-parameter-impact` for analysis.
+
+## Example triggers
+
+- “Generate a perf report for `perf_matmul_quasar.py`.”
+- “Refresh the SFPU unary report and tell me what changed.”
+- “Why is there no `.post.csv` for this test?”
+- “Is this report stale?”

--- a/tt_metal/tt-llk/.cursor/skills/perf-report/SKILL.md
+++ b/tt_metal/tt-llk/.cursor/skills/perf-report/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: perf-report
+description: Generate, refresh, and validate an LLK performance report by running a perf sweep end to end and checking the resulting perf_data CSV. Use when asked to produce or refresh a perf report for an op, run a perf sweep, or when a report is missing, partial, stale, or implausible.
+---
+
+# Perf Report
+
+## Goal
+
+Produce a trustworthy performance report for one LLK perf test and hand it to
+analysis with enough provenance to reproduce it.
+
+A report is a build artifact, not a repository file: `perf_data/` is
+gitignored. What identifies a report is the test, the architecture, the
+commit, and the exact command that produced it. Record all four.
+
+## Related skills
+
+- `quasar-perf-test` — create or repair the perf test and its `PerfRunType`
+  paths. Use it first when the test does not exist, hangs, or reports
+  implausible metrics.
+- `perf-parameter-impact` — analyze a finished `.post.csv`.
+- `run-test` — the repository test-runner workflow.
+
+## 1. Establish the sweep
+
+Read the perf test — `tests/python_tests/perf_[op].py` or
+`tests/python_tests/quasar/perf_[op]_quasar.py` — and determine:
+
+- which `run_types` the test actually reports;
+- `loop_factor`, `tile_cnt`, and the other axes recorded as columns;
+- how many variants `@parametrize` produces;
+- the architecture: the `quasar/` directory or a `*_[arch].py` suffix implies
+  it, otherwise ask.
+
+Decide scope before running. A narrowed sweep (`-k`, `--op`) is right for
+debugging; a report meant for analysis must cover the full intended sweep.
+Never narrow the sweep in the test file to make a run finish.
+
+## 2. Run the sweep
+
+Use the two-phase producer/consumer flow, never a single serial invocation:
+
+```bash
+cd tests
+CHIP_ARCH=<arch> pytest --compile-producer -n 10 -m perf ./python_tests/perf_[op].py
+CHIP_ARCH=<arch> pytest --compile-consumer -n 15 -m perf ./python_tests/perf_[op].py
+```
+
+Prefer the `run-test` workflow where it applies; it serializes simulator
+access and diagnoses hangs. `tests/run_llk_perf_wormhole.sh` and
+`tests/run_llk_perf_blackhole.sh` show the exact CI invocation.
+
+Rules:
+
+- `--speed-of-light` turns runtime parameters into compile-time constants and
+  changes measured cycles. CI passes it. Match CI when the report will be
+  compared with CI numbers, and never mix speed-of-light and normal rows in
+  one report.
+- `--enable-perf-counters` adds efficiency-metric columns;
+  `--dump-csv-counters` additionally writes `<module>.counters.csv`.
+- SFPU sweep modules need `--mode perf`; the selector defaults to `accuracy`
+  and deselects the perf sweep.
+- Do not pass `--coverage`. Instrumentation invalidates perf numbers.
+- Avoid `-x` on a report run. It aborts mid-sweep and the combined CSV is
+  silently partial. Use it only while debugging.
+- Never hand-edit a CSV. Fix the test or rerun.
+
+## 3. Know where the files come from
+
+- Each worker writes `<module>.<worker>.csv` and `<module>.<worker>.post.csv`
+  into `$ARTEFACTS/temp_perf_data/` when the module-scoped `perf_report`
+  fixture tears down — `gw0`, `gw1`, … under `-n`, otherwise `master`.
+- `pytest_sessionfinish` calls `combine_perf_reports()`, which merges the
+  per-worker files into `perf_data/<module>/<module>.csv`,
+  `<module>.post.csv`, and `<module>.counters.csv`, sorts them, and deletes
+  the per-worker files. Combined files are overwritten in place.
+- The producer phase writes no report and skips combining.
+- The raw CSV holds per-marker means. The `.post.csv` divides the `mean(...)`
+  and `std(...)` columns of `TILE_LOOP` rows by `loop_factor * tile_cnt`,
+  giving cycles per tile; `INIT` and `KERNEL` rows are left unnormalized.
+  Analysis uses `.post.csv`.
+
+No report at all usually means the consumer phase never reached session
+finish, or every selected test was skipped.
+
+## 4. Validate the artifact
+
+1. **Schema.** A `PerfSchemaError` means one test emits different columns
+   across its sweep — usually a parameter that is `None` for some values — or
+   two ops share one module. Fix the test; do not work around it.
+2. **Row count.** Expect `variants × markers` rows, with markers `INIT`,
+   `KERNEL`, and `TILE_LOOP`. A short file means an aborted or partly skipped
+   sweep.
+3. **Duplicate keys.** `combine_perf_reports()` warns when it collapses rows
+   sharing a (sweep, marker) key. Differing metrics on a collapsed key are
+   either run-to-run noise or a parameter that changes the kernel without
+   being recorded as a column. Resolve which before shipping the report.
+4. **Plausibility.** Inspect `marker == TILE_LOOP`. Each `L1_CONGESTION` stage
+   should sit near its isolate. Values near 2048, 4096, or 8192, an isolate
+   orders of magnitude above the real stage, or a healthy first variant
+   followed by slow ones all indicate handshake or wait-mask bugs — switch to
+   `quasar-perf-test`.
+5. **Freshness.** Compare CSV columns with the current test axes. Missing axes
+   mean the report predates the test; regenerate instead of analyzing.
+6. **Completeness.** Confirm a `mean(...)` and `TEXT_SIZE(...)` column exists
+   for every requested run type.
+
+Never present metrics from a run whose pytest phase failed.
+
+## 5. Record provenance
+
+Report back, and keep alongside the CSV when it is archived:
+
+- test file and module name;
+- architecture and `CHIP_ARCH`;
+- repository commit;
+- the exact producer and consumer commands, including worker counts,
+  `--speed-of-light`, and counter flags;
+- run types and markers present;
+- row count and output paths.
+
+## Refresh and compare
+
+- Copy an existing report elsewhere before rerunning; combined files are
+  overwritten in place.
+- Compare like with like: same architecture, same speed-of-light setting, same
+  `loop_factor` and marker.
+- Repeat a run before attributing a small delta to a code change.
+
+## Checklist
+
+- [ ] Test, architecture, and intended scope confirmed.
+- [ ] Producer and consumer phases both completed without aborting.
+- [ ] Coverage off; speed-of-light setting deliberate and uniform.
+- [ ] `perf_data/<module>/` holds the raw and `.post.csv` files, plus counters
+      when requested.
+- [ ] Single schema, expected row count, duplicate warnings reviewed.
+- [ ] `TILE_LOOP` metrics inspected for plausibility.
+- [ ] Columns match the current test sweep.
+- [ ] Provenance recorded.
+- [ ] Report handed to `perf-parameter-impact` for analysis.
+
+## Example triggers
+
+- “Generate a perf report for `perf_matmul_quasar.py`.”
+- “Refresh the SFPU unary report and tell me what changed.”
+- “Why is there no `.post.csv` for this test?”
+- “Is this report stale?”

--- a/tt_metal/tt-llk/.cursor/skills/perf-report/SKILL.md
+++ b/tt_metal/tt-llk/.cursor/skills/perf-report/SKILL.md
@@ -57,8 +57,17 @@ Rules:
   changes measured cycles. CI passes it. Match CI when the report will be
   compared with CI numbers, and never mix speed-of-light and normal rows in
   one report.
-- `--enable-perf-counters` adds efficiency-metric columns;
-  `--dump-csv-counters` additionally writes `<module>.counters.csv`.
+- `--enable-perf-counters` produces a different, mutually exclusive kind of
+  report. It compiles with `-DPERF_COUNTERS_COMPILED` (the WC build), which
+  reduces `ZONE_SCOPED` to metadata only: the run emits no wall-clock
+  `mean(<run type>)` columns, only `<RUN_TYPE>_..._pct` efficiency columns.
+  It also writes to the same `<module>.csv` path, overwriting the timing
+  report. Copy the timing report aside first, run counters as a separate
+  sweep, and validate the result as a counter report. `--dump-csv-counters`
+  additionally writes raw counter values to `<module>.counters.csv`.
+- Perf counters are unavailable on Quasar. The build gate keeps the define off
+  there and `counters.h` `#error`s if it ever slips through, so the flag
+  yields no counter columns.
 - SFPU sweep modules need `--mode perf`; the selector defaults to `accuracy`
   and deselects the perf sweep.
 - Do not pass `--coverage`. Instrumentation invalidates perf numbers.
@@ -69,8 +78,11 @@ Rules:
 ## 3. Know where the files come from
 
 - Each worker writes `<module>.<worker>.csv` and `<module>.<worker>.post.csv`
-  into `$ARTEFACTS/temp_perf_data/` when the module-scoped `perf_report`
-  fixture tears down — `gw0`, `gw1`, … under `-n`, otherwise `master`.
+  into `/tmp/tt-llk-build/temp_perf_data/` when the module-scoped
+  `perf_report` fixture tears down. Under GitHub Actions the root is
+  `$RUNNER_TEMP/tt-llk-build` instead. The worker is `gw0`, `gw1`, … under
+  `-n`, otherwise `master`. Look there for partial artifacts after an
+  aborted run.
 - `pytest_sessionfinish` calls `combine_perf_reports()`, which merges the
   per-worker files into `perf_data/<module>/<module>.csv`,
   `<module>.post.csv`, and `<module>.counters.csv`, sorts them, and deletes
@@ -89,9 +101,10 @@ finish, or every selected test was skipped.
 1. **Schema.** A `PerfSchemaError` means one test emits different columns
    across its sweep — usually a parameter that is `None` for some values — or
    two ops share one module. Fix the test; do not work around it.
-2. **Row count.** Expect `variants × markers` rows, with markers `INIT`,
-   `KERNEL`, and `TILE_LOOP`. A short file means an aborted or partly skipped
-   sweep.
+2. **Row count.** Expect `variants × markers` rows: markers `INIT`, `KERNEL`,
+   and `TILE_LOOP` in a timing report, and only `INIT` and `TILE_LOOP` in a
+   counter report, which has no profiler-derived `KERNEL` row. A short file
+   means an aborted or partly skipped sweep.
 3. **Duplicate keys.** `combine_perf_reports()` warns when it collapses rows
    sharing a (sweep, marker) key. Differing metrics on a collapsed key are
    either run-to-run noise or a parameter that changes the kernel without
@@ -103,8 +116,16 @@ finish, or every selected test was skipped.
    `quasar-perf-test`.
 5. **Freshness.** Compare CSV columns with the current test axes. Missing axes
    mean the report predates the test; regenerate instead of analyzing.
-6. **Completeness.** Confirm a `mean(...)` and `TEXT_SIZE(...)` column exists
-   for every requested run type.
+6. **Completeness, by report kind.** A timing report carries a
+   `mean(<run type>)` column for every requested run type, and a
+   `TEXT_SIZE(<run type>)` column only for `L1_TO_L1`, `UNPACK_ISOLATE`,
+   `MATH_ISOLATE`, and `PACK_ISOLATE`. `L1_CONGESTION` is deliberately absent
+   from the code-size map, so a missing `TEXT_SIZE(L1_CONGESTION)` is correct
+   rather than a defect. A counter report has no wall-clock means at all:
+   check its `<RUN_TYPE>_..._pct` columns, expect only the `INIT` and
+   `TILE_LOOP` markers, and note that its `.post.csv` is identical to the raw
+   file because normalization only rescales columns named `mean(...)` and
+   `std(...)`.
 
 Never present metrics from a run whose pytest phase failed.
 
@@ -123,9 +144,11 @@ Report back, and keep alongside the CSV when it is archived:
 ## Refresh and compare
 
 - Copy an existing report elsewhere before rerunning; combined files are
-  overwritten in place.
+  overwritten in place. This applies with full force to a counter run, which
+  replaces the timing report for the same module.
 - Compare like with like: same architecture, same speed-of-light setting, same
-  `loop_factor` and marker.
+  `loop_factor` and marker, and the same report kind. Timing and counter
+  reports measure different things and share no metric columns.
 - Repeat a run before attributing a small delta to a code change.
 
 ## Checklist
@@ -134,8 +157,9 @@ Report back, and keep alongside the CSV when it is archived:
 - [ ] Producer and consumer phases both completed without aborting.
 - [ ] Coverage off; speed-of-light setting deliberate and uniform.
 - [ ] `perf_data/<module>/` holds the raw and `.post.csv` files, plus counters
-      when requested.
+      when requested, and no earlier report was overwritten unintentionally.
 - [ ] Single schema, expected row count, duplicate warnings reviewed.
+- [ ] Column expectations applied for the report kind actually produced.
 - [ ] `TILE_LOOP` metrics inspected for plausibility.
 - [ ] Columns match the current test sweep.
 - [ ] Provenance recorded.

--- a/tt_metal/tt-llk/.cursor/skills/perf-report/SKILL.md
+++ b/tt_metal/tt-llk/.cursor/skills/perf-report/SKILL.md
@@ -62,8 +62,9 @@ Rules:
   reduces `ZONE_SCOPED` to metadata only: the run emits no wall-clock
   `mean(<run type>)` columns, only `<RUN_TYPE>_..._pct` efficiency columns.
   It also writes to the same `<module>.csv` path, overwriting the timing
-  report. Copy the timing report aside first, run counters as a separate
-  sweep, and validate the result as a counter report. `--dump-csv-counters`
+  report. Move the timing report out of the way first (see Refresh and
+  compare), run counters as a separate sweep, and validate the result as a
+  counter report. `--dump-csv-counters`
   additionally writes raw counter values to `<module>.counters.csv`.
 - Perf counters are unavailable on Quasar. The build gate keeps the define off
   there and `counters.h` `#error`s if it ever slips through, so the flag
@@ -101,10 +102,15 @@ finish, or every selected test was skipped.
 1. **Schema.** A `PerfSchemaError` means one test emits different columns
    across its sweep — usually a parameter that is `None` for some values — or
    two ops share one module. Fix the test; do not work around it.
-2. **Row count.** Expect `variants × markers` rows: markers `INIT`, `KERNEL`,
-   and `TILE_LOOP` in a timing report, and only `INIT` and `TILE_LOOP` in a
-   counter report, which has no profiler-derived `KERNEL` row. A short file
-   means an aborted or partly skipped sweep.
+2. **Row count.** Reconcile rather than assert equality. Start from
+   `selected variants × markers`, then subtract skipped or deselected
+   variants and any rows merged by duplicate-key collapse. Markers are the
+   zones the kernel declares — `INIT` and `TILE_LOOP` in the perf sources,
+   plus the `KERNEL` zone that `trisc.cpp` wraps around every profiler build.
+   A counter report has no profiler-derived rows, so expect only the counter
+   zones `INIT` and `TILE_LOOP` there. An unexplained shortfall means an
+   aborted or partly skipped sweep; a shortfall you can attribute to skips or
+   collapse is fine.
 3. **Duplicate keys.** `combine_perf_reports()` warns when it collapses rows
    sharing a (sweep, marker) key. Differing metrics on a collapsed key are
    either run-to-run noise or a parameter that changes the kernel without
@@ -143,9 +149,15 @@ Report back, and keep alongside the CSV when it is archived:
 
 ## Refresh and compare
 
-- Copy an existing report elsewhere before rerunning; combined files are
-  overwritten in place. This applies with full force to a counter run, which
-  replaces the timing report for the same module.
+- Move the existing `perf_data/<module>/` aside before rerunning — copy it out
+  and delete the original, rather than just copying. `combine_perf_reports()`
+  returns early when no worker files were produced and writes each output only
+  when that class has inputs, so a rerun that skips everything or dies before
+  the consumer phase leaves the previous CSV sitting there looking like the new
+  result. Deleting first makes a no-op rerun visibly empty. Confirm the output
+  timestamps are from the run you just did.
+- A counter run replaces the timing report for the same module, so move the
+  timing report out of the way first for the same reason.
 - Compare like with like: same architecture, same speed-of-light setting, same
   `loop_factor` and marker, and the same report kind. Timing and counter
   reports measure different things and share no metric columns.
@@ -156,9 +168,11 @@ Report back, and keep alongside the CSV when it is archived:
 - [ ] Test, architecture, and intended scope confirmed.
 - [ ] Producer and consumer phases both completed without aborting.
 - [ ] Coverage off; speed-of-light setting deliberate and uniform.
+- [ ] Any previous `perf_data/<module>/` was moved aside and deleted before the
+      run, and the new files carry this run's timestamps.
 - [ ] `perf_data/<module>/` holds the raw and `.post.csv` files, plus counters
-      when requested, and no earlier report was overwritten unintentionally.
-- [ ] Single schema, expected row count, duplicate warnings reviewed.
+      when requested.
+- [ ] Single schema, row count reconciled, duplicate warnings reviewed.
 - [ ] Column expectations applied for the report kind actually produced.
 - [ ] `TILE_LOOP` metrics inspected for plausibility.
 - [ ] Columns match the current test sweep.


### PR DESCRIPTION
### PR Category

Feature

### Summary

Closes #51670.

TT-LLK already has a skill for *writing* a perf test (`quasar-perf-test`) and one for *analyzing* a finished report (`perf-parameter-impact`). The step in between — actually running the sweep and confirming the resulting CSV is trustworthy — is tribal knowledge spread across `helpers/perf.py`, `conftest.py`, the `run_llk_perf_*.sh` scripts, and the perf tests themselves.

That gap matters because the failure modes are quiet. An aborted consumer phase yields a silently partial CSV; a `--speed-of-light` mismatch makes two reports incomparable; a stale report whose columns predate the current sweep still looks perfectly well-formed. Each one produces a plausible-looking artifact that a reader has no obvious reason to distrust.

This PR adds a `perf-report` skill that documents the workflow end to end:

- establishing the sweep from the test (`run_types`, `loop_factor`, `tile_cnt`, variant count, architecture);
- running the two-phase compile-producer / compile-consumer flow, including when `--speed-of-light` must match CI, the perf-counter flags, the SFPU `--mode perf` selector, and why `--coverage` and `-x` do not belong in a report run;
- where the artifacts come from — per-worker files in `temp_perf_data/`, `combine_perf_reports()` at session finish, and the `TILE_LOOP` normalization that distinguishes `<module>.csv` from `<module>.post.csv`;
- validating the result: single-schema enforcement, expected row count across the `INIT` / `KERNEL` / `TILE_LOOP` markers, collapsed duplicate-key warnings, metric plausibility against the isolate and congestion relationships, stale-column detection, and per-run-type column completeness;
- recording provenance, then handing the report to `perf-parameter-impact`.

Files:

- `tt_metal/tt-llk/.claude/skills/perf-report/SKILL.md`
- `tt_metal/tt-llk/.cursor/skills/perf-report/SKILL.md` (identical apart from the `user_invocable` key, matching how the other skills are mirrored)
- `tt_metal/tt-llk/.claude/CLAUDE.md` — registers the skill in the trigger table

### Notes for reviewers

Documentation only; no test, infrastructure, or library code is touched.

Stacked on #51681 (branch `ndivnic/add_perf_parameter_impact_analysis_skill`), so the diff should be read against that branch rather than `main`. Merging #51681 first will retarget this PR onto `main`.

Worth a close read: the skill asserts a number of specific mechanics about the perf infrastructure, and those assertions are the whole value of the document. The claims to check are that `combine_perf_reports()` overwrites the combined files in place and deletes the per-worker inputs; that the producer phase writes no report; that post-processing normalizes only `TILE_LOOP` rows by `loop_factor * tile_cnt`, leaving `INIT` and `KERNEL` untouched; and that `-x` on a consumer run still reaches session finish and therefore writes a partial combined CSV rather than none at all.

One framing decision to sanity-check: since `perf_data/` is gitignored, the skill treats a report as a build artifact identified by the command that produced it, and requires provenance to be reported rather than committed. If the intent is for reports to eventually be tracked or uploaded somewhere durable, that section should change.

Made with [Cursor](https://cursor.com)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ndivnic/add_perf_report_skill)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ndivnic/add_perf_report_skill)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ndivnic/add_perf_report_skill)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ndivnic/add_perf_report_skill)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ndivnic/add_perf_report_skill)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ndivnic/add_perf_report_skill)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ndivnic/add_perf_report_skill)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ndivnic/add_perf_report_skill)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ndivnic/add_perf_report_skill)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ndivnic/add_perf_report_skill)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ndivnic/add_perf_report_skill)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ndivnic/add_perf_report_skill)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ndivnic/add_perf_report_skill)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ndivnic/add_perf_report_skill)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ndivnic/add_perf_report_skill)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ndivnic/add_perf_report_skill)