### PR TITLE
[Quasar] Unary broadcast: Fix ALU data format config at init and perf test dvalids

### DIFF
--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_unary_datacopy_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_unary_datacopy_api.h
@@ -41,9 +41,10 @@ inline void llk_math_eltwise_unary_datacopy_init(const std::uint32_t operand) {
 
     const DataFormat srcA_format = static_cast<DataFormat>(get_operand_dst_format(operand_id));
     const DataFormat srcB_format = static_cast<DataFormat>(get_operand_dst_format(operand_id));
-    _configure_default_alu_data_format_state_<false /* IMPLIED_MATH_FORMAT */, EN_32BIT_DEST>(srcA_format, srcB_format);
 
     if constexpr (src_b_bcast_type == BroadcastType::NONE) {
+        _configure_default_alu_data_format_state_<false /* IMPLIED_MATH_FORMAT */, EN_32BIT_DEST>(
+            srcA_format, srcB_format);
         // 32-bit unpack-to-dest: math is a sync-only forwarder (unpacker wrrites DEST), no MOP to run.
         if constexpr (!unpack_to_dest) {
             _llk_math_eltwise_unary_datacopy_init_<type, EN_32BIT_DEST>(
@@ -61,6 +62,12 @@ inline void llk_math_eltwise_unary_datacopy_init(const std::uint32_t operand) {
                 tensor_shape.num_faces_c_dim == MAX_NUM_FACES_C_DIM,
             "Unary broadcast currently only supports 32x32 tiles (face_r_dim=16, 2x2 faces)");
 
+        if constexpr (unpack_to_dest) {
+            _configure_mov_ops_explicit_alu_data_format_state_<EN_32BIT_DEST>(srcA_format, srcB_format);
+        } else {
+            _configure_default_alu_data_format_state_<false /* IMPLIED_MATH_FORMAT */, EN_32BIT_DEST>(
+                srcA_format, srcB_format);
+        }
         _llk_math_eltwise_unary_broadcast_init_<src_b_bcast_type, false /*unpack_to_dest*/>(tensor_shape);
     }
 }

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_unary_datacopy_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_unary_datacopy_api.h
@@ -41,10 +41,9 @@ inline void llk_math_eltwise_unary_datacopy_init(const std::uint32_t operand) {
 
     const DataFormat srcA_format = static_cast<DataFormat>(get_operand_dst_format(operand_id));
     const DataFormat srcB_format = static_cast<DataFormat>(get_operand_dst_format(operand_id));
+    _configure_default_alu_data_format_state_<false /* IMPLIED_MATH_FORMAT */, EN_32BIT_DEST>(srcA_format, srcB_format);
 
     if constexpr (src_b_bcast_type == BroadcastType::NONE) {
-        _configure_default_alu_data_format_state_<false /* IMPLIED_MATH_FORMAT */, EN_32BIT_DEST>(
-            srcA_format, srcB_format);
         // 32-bit unpack-to-dest: math is a sync-only forwarder (unpacker wrrites DEST), no MOP to run.
         if constexpr (!unpack_to_dest) {
             _llk_math_eltwise_unary_datacopy_init_<type, EN_32BIT_DEST>(
@@ -63,12 +62,6 @@ inline void llk_math_eltwise_unary_datacopy_init(const std::uint32_t operand) {
                 tensor_shape.num_faces_c_dim == MAX_NUM_FACES_C_DIM,
             "Unary broadcast currently only supports 32x32 tiles (face_r_dim=16, 2x2 faces)");
 
-        if constexpr (unpack_to_dest) {
-            _configure_mov_ops_explicit_alu_data_format_state_<EN_32BIT_DEST>(srcA_format, srcB_format);
-        } else {
-            _configure_default_alu_data_format_state_<false /* IMPLIED_MATH_FORMAT */, EN_32BIT_DEST>(
-                srcA_format, srcB_format);
-        }
         _llk_math_eltwise_unary_broadcast_init_<src_b_bcast_type, false /*unpack_to_dest*/>(tensor_shape);
     }
 }

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_unary_datacopy_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_unary_datacopy_api.h
@@ -55,6 +55,7 @@ inline void llk_math_eltwise_unary_datacopy_init(const std::uint32_t operand) {
         static_assert(
             !(EN_32BIT_DEST && !unpack_to_dest),
             "32BIT_DEST is not supported for broadcast when unpack_to_dest is false");
+        static_assert(!unpack_to_dest, "unpack_to_dest is not supported for unary broadcast");
 
         const ckernel::TensorShape tensor_shape = get_operand_tensor_shape(operand);
         LLK_ASSERT(

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_broadcast_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_broadcast_quasar_test.cpp
@@ -26,17 +26,16 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const FormatConfig& formats = params.formats;
 #endif
 #ifndef SPEED_OF_LIGHT
-    const std::uint32_t LOOP_FACTOR              = params.LOOP_FACTOR;
-    const std::uint32_t TILE_CNT                 = params.TILE_CNT;
-    const std::uint32_t num_blocks               = params.INPUT_NUM_BLOCKS;
-    const std::uint32_t tiles_in_block       = params.INPUT_NUM_TILES_IN_BLOCK;
-    const int num_faces_r_dim_A                  = params.num_faces_r_dim_A;
-    const int num_faces_c_dim_A                  = params.num_faces_c_dim_A;
-    const Operand& buffer_B                      = params.buffer_B;
+    const std::uint32_t LOOP_FACTOR    = params.LOOP_FACTOR;
+    const std::uint32_t num_blocks     = params.INPUT_NUM_BLOCKS;
+    const std::uint32_t tiles_in_block = params.INPUT_NUM_TILES_IN_BLOCK;
+    const int num_faces_r_dim_A        = params.num_faces_r_dim_A;
+    const int num_faces_c_dim_A        = params.num_faces_c_dim_A;
+    const Operand& buffer_B            = params.buffer_B;
 #endif
     tdma_descriptor_t td_val_A, td_val_B;
-    const std::uint32_t buf_desc_id_a        = 0;
-    const std::uint32_t buf_desc_id_b        = 1;
+    const std::uint32_t buf_desc_id_a = 0;
+    const std::uint32_t buf_desc_id_b = 1;
     // Unpack to dest must use the num tiles per unpack parameter in order to unpack multiple tiles per Dest bank
     const std::uint32_t num_tiles_per_unpack = unpack_to_dest ? tiles_in_block : 1;
 
@@ -68,17 +67,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
         _configure_buf_desc_table_(td_val_A.buf_desc_id, td_val_A.buf_desc);
         _configure_buf_desc_table_(td_val_B.buf_desc_id, td_val_B.buf_desc);
 
-        if constexpr (is_fp32_dest_acc_en && !unpack_to_dest)
-        {
-            // If Dst fmt is 32b and operation is Mov2D, we need both SrcA/B fmts to be configured since Mov2D will be implemented via ELWADD
-            _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(td_val_A, td_val_B);
-        }
-        else
-        {
-            _llk_unpack_configure_unary_<UNPACKER_ENGINE_SEL>(unpack_to_dest ? td_val_A : td_val_B);
-        }
+        _llk_unpack_configure_unary_<UNPACKER_ENGINE_SEL>(unpack_to_dest ? td_val_A : td_val_B);
         _llk_unpack_unary_broadcast_operands_init_<UNPACKER_ENGINE_SEL, BROADCAST_TYPE, unpack_to_dest>(
-                unpack_to_dest ? buf_desc_id_a : buf_desc_id_b, num_tiles_per_unpack);
+            unpack_to_dest ? buf_desc_id_a : buf_desc_id_b, num_tiles_per_unpack);
 
         PROFILER_SYNC();
     }
@@ -93,7 +84,12 @@ void run_kernel(RUNTIME_PARAMETERS params)
             {
                 const std::uint32_t dvalids_per_tile =
                     (BROADCAST_TYPE == BroadcastType::SCALAR) ? 1u : static_cast<std::uint32_t>(num_faces_r_dim_A * num_faces_c_dim_A);
-                _perf_unpack_loop_set_valid<false /*set_a*/, true /*set_b*/>(LOOP_FACTOR * TILE_CNT * dvalids_per_tile);
+                _perf_unpack_loop_set_valid<false /*set_a*/, true /*set_b*/>(LOOP_FACTOR * num_blocks * tiles_in_block * dvalids_per_tile);
+            }
+            else
+            {
+                // SrcB dummy dvalid needed for the unpack to dest path
+                _perf_unpack_loop_set_valid<false /*set_a*/, true /*set_b*/>(LOOP_FACTOR * num_blocks * tiles_in_block);
             }
         }
         else if constexpr (unpack_to_dest)
@@ -150,13 +146,13 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const FormatConfig& formats = params.formats;
 #endif
 #ifndef SPEED_OF_LIGHT
-    const std::uint32_t LOOP_FACTOR               = params.LOOP_FACTOR;
-    const std::uint32_t num_faces                 = params.num_faces;
+    const std::uint32_t LOOP_FACTOR    = params.LOOP_FACTOR;
+    const std::uint32_t num_faces      = params.num_faces;
     const std::uint32_t tiles_in_block = params.OUTPUT_NUM_TILES_IN_BLOCK;
-    const std::uint32_t num_blocks          = params.INPUT_NUM_BLOCKS;
+    const std::uint32_t num_blocks     = params.INPUT_NUM_BLOCKS;
 #endif
-    const DataFormat math_format     = static_cast<DataFormat>(formats.math);
-    const DataFormat pack_src_format = static_cast<DataFormat>(formats.pack_src);
+    const DataFormat math_format            = static_cast<DataFormat>(formats.math);
+    const DataFormat pack_src_format        = static_cast<DataFormat>(formats.pack_src);
     const ckernel::TensorShape tensor_shape = TENSOR_SHAPE_FROM_PARAMS(params);
 
     {
@@ -189,7 +185,14 @@ void run_kernel(RUNTIME_PARAMETERS params)
         {
             _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en, false /*int32_dest*/>(math_format, math_format);
         }
-        _configure_mov_ops_explicit_alu_data_format_state_<is_fp32_dest_acc_en>(math_format, math_format);
+        if (unpack_to_dest)
+        {
+            _configure_mov_ops_explicit_alu_data_format_state_<is_fp32_dest_acc_en>(math_format, math_format);
+        }
+        else
+        {
+            _configure_default_alu_data_format_state_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en>(math_format, math_format);
+        }
         _llk_math_eltwise_unary_broadcast_init_<BROADCAST_TYPE, unpack_to_dest>(tensor_shape);
 
         PROFILER_SYNC();
@@ -202,8 +205,15 @@ void run_kernel(RUNTIME_PARAMETERS params)
         }
         else if constexpr (PERF_RUN_TYPE == PerfRunType::UNPACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
         {
-            const std::uint32_t dvalids_per_tile = (BROADCAST_TYPE == BroadcastType::SCALAR) ? 1u : num_faces;
-            _perf_math_loop_clear_valid<false /*clear_a*/, true /*clear_b*/>(LOOP_FACTOR * num_blocks * tiles_in_block * dvalids_per_tile);
+            if (!unpack_to_dest)
+            {
+                const std::uint32_t dvalids_per_tile = (BROADCAST_TYPE == BroadcastType::SCALAR) ? 1u : num_faces;
+                _perf_math_loop_clear_valid<false /*clear_a*/, true /*clear_b*/>(LOOP_FACTOR * num_blocks * tiles_in_block * dvalids_per_tile);
+            }
+            else
+            {
+                _perf_math_loop_clear_valid<false /*clear_a*/, true /*clear_b*/>(LOOP_FACTOR * num_blocks * tiles_in_block);
+            }
         }
         else if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
         {
@@ -250,10 +260,10 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const FormatConfig& formats = params.formats;
 #endif
 #ifndef SPEED_OF_LIGHT
-    const std::uint32_t LOOP_FACTOR               = params.LOOP_FACTOR;
-    const std::uint32_t output_num_blocks         = params.OUTPUT_NUM_BLOCKS;
+    const std::uint32_t LOOP_FACTOR           = params.LOOP_FACTOR;
+    const std::uint32_t output_num_blocks     = params.OUTPUT_NUM_BLOCKS;
     const std::uint32_t output_tiles_in_block = params.OUTPUT_NUM_TILES_IN_BLOCK;
-    const Operand& buffer_Res                     = params.buffer_Res;
+    const Operand& buffer_Res                 = params.buffer_Res;
 #endif
 
     constexpr std::uint32_t buf_desc_id    = 8;

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_broadcast_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_broadcast_quasar_test.cpp
@@ -185,7 +185,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         {
             _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en, false /*int32_dest*/>(math_format, math_format);
         }
-        if (unpack_to_dest)
+        if constexpr (unpack_to_dest)
         {
             _configure_mov_ops_explicit_alu_data_format_state_<is_fp32_dest_acc_en>(math_format, math_format);
         }
@@ -205,7 +205,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         }
         else if constexpr (PERF_RUN_TYPE == PerfRunType::UNPACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
         {
-            if (!unpack_to_dest)
+            if constexpr (!unpack_to_dest)
             {
                 const std::uint32_t dvalids_per_tile = (BROADCAST_TYPE == BroadcastType::SCALAR) ? 1u : num_faces;
                 _perf_math_loop_clear_valid<false /*clear_a*/, true /*clear_b*/>(LOOP_FACTOR * num_blocks * tiles_in_block * dvalids_per_tile);


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Uses default ALU data config when !unpack_to_dest. Default can be used since only MOV2D is used, and there is no MOV2D MOVD2 sequence.
Accounts for srcB dummy dvalid (for the unpack to dest path) when issuing dvalids in the perf isolate paths.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amokan/unary_bcast_test_fixup)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amokan/unary_bcast_test_fixup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amokan/unary_bcast_test_fixup)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amokan/unary_bcast_test_fixup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=amokan/unary_bcast_test_fixup)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:amokan/unary_bcast_test_fixup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amokan/unary_bcast_test_fixup)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amokan/unary_bcast_test_fixup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amokan/unary_bcast_test_fixup)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amokan/unary_bcast_test_fixup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amokan/unary_bcast_test_fixup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amokan/unary_bcast_test_fixup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amokan/unary_bcast_test_fixup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amokan/unary_bcast_test_fixup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amokan/unary_bcast_test_fixup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amokan/unary_bcast_test_fixup)