### PR TITLE
[LLK] Exempt reduce_block_max_row negative controls from the bit-exact check

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/fuser/fuser_config.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/fuser_config.py
@@ -97,6 +97,8 @@ class FuserConfig(TestConfig):
             "pipeline",
             "global_config",
             "operand_registry",
+            # Host-side determinism-check opt-out; does not affect the compiled kernel.
+            "expected_nondeterministic",
         ]
 
         temp_str = [

--- a/tt_metal/tt-llk/tests/python_tests/helpers/test_config.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/test_config.py
@@ -622,6 +622,7 @@ class TestConfig:
         skip_build_header: bool = False,
         compile_time_formats: bool = False,
         requires_device_print: bool = False,
+        expected_nondeterministic: bool = False,
     ):
         self.coverage_build = (
             CoverageBuild.Yes if TestConfig.WITH_COVERAGE else CoverageBuild.No
@@ -654,6 +655,7 @@ class TestConfig:
         self.compile_time_formats = compile_time_formats
         self.dest_acc = dest_acc
         self.requires_device_print = requires_device_print
+        self.expected_nondeterministic = expected_nondeterministic
 
         TILE_SIZES = {
             DataFormat.Bfp8_b: 68,
@@ -873,6 +875,8 @@ class TestConfig:
             "passed_runtimes",
             "current_run_type",
             "temp_elfs",
+            # Host-side determinism-check opt-out; does not affect the compiled kernel.
+            "expected_nondeterministic",
         ]
 
         if not TestConfig.SPEED_OF_LIGHT:
@@ -1707,6 +1711,13 @@ class TestConfig:
             # accumulates onto the previous one. Re-runs are legitimately
             # expected to differ and comparing them would be meaningless.
             return "L1 accumulation makes every run add onto the previous result"
+        if self.expected_nondeterministic:
+            # Negative controls that deliberately run with a corrupt HW config
+            # (e.g. a zeroed addrmod) leave DEST addressing undefined, so the
+            # result is not bit-reproducible by contract. The functional check
+            # (expect_mismatch) still validates the single run; only the
+            # bit-exact re-run comparison is meaningless here.
+            return "variant intentionally exercises undefined hardware state"
         return None
 
     def _bit_exact_check_applies(self) -> bool:

--- a/tt_metal/tt-llk/tests/python_tests/test_reduce_block_max.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_reduce_block_max.py
@@ -102,12 +102,19 @@ def _run_reduce_block_max(
     respect_trigger=False,
     overlap_first_half=False,
     expect_mismatch=False,
+    expected_nondeterministic=False,
 ):
     """Run one reduce_block_max_row variant and validate column [0] against golden.
 
     ``expect_mismatch`` inverts the verdict: the run must diverge from golden. Used by
     the negative controls, which pin that a clobber left un-repaired really does corrupt
     the reduce (so the reinit cases are not passing for free).
+
+    ``expected_nondeterministic`` exempts the variant from the --bit-exact-runs
+    determinism check: a run with a deliberately corrupt HW config leaves DEST
+    addressing undefined, so its output is not bit-reproducible by contract (and is
+    arch-dependent: stable on Wormhole, a coin-flip on Blackhole). The single-run
+    functional check above still applies.
     """
     dest_acc = _dest_acc(formats.output_format)
 
@@ -166,6 +173,7 @@ def _run_reduce_block_max(
             sfpu=False,
         ),
         dest_acc=dest_acc,
+        expected_nondeterministic=expected_nondeterministic,
     )
 
     res_from_L1 = configuration.run().result
@@ -312,6 +320,7 @@ def test_reduce_block_max_reinit_negative_control(block_ct_dim, reinit):
         reinit=reinit,
         clobber="addrmod_all",
         expect_mismatch=True,
+        expected_nondeterministic=True,
     )
 
 


### PR DESCRIPTION
## Problem
The nightly **LLK bit-exact** job fails ~every other run on four `test_reduce_block_max_reinit_negative_control` variants (`712b834c2b16`, `d213d3114979`, `6ab602b37d60`, `9ee091cded79`), e.g. `Non-deterministic hardware output ...: 250 of 499 re-runs differed from run 0`.

## Root cause
These are **negative controls**: they deliberately run the reduce with a zeroed `ADDR_MOD_3`, leaving DEST addressing corrupt (that is the whole point — proving the reinit paths don't pass vacuously). With `dest.incr = 0` every row-max collides onto DEST row 0 and the unwritten rows expose **undefined DEST state**. That output is not bit-reproducible by contract, and it is **arch-specific**: stable on Wormhole (verified locally — 500/500 identical on the exact CI variants and seed) but a coin-flip on Blackhole (nightly CI: 250/499 re-runs differ). The same variant being deterministic on one arch and flaky on another is the signature of undefined behavior, not a determinism property worth gating CI on.

This is fine for the **functional** (`expect_mismatch`) check — a corrupt run reliably diverges from golden — but it is illegitimate input to the `--bit-exact-runs` determinism harness.

## Fix
Add an `expected_nondeterministic` opt-out on `TestConfig`, joining the existing bit-exact exemptions (coverage builds, L1 accumulation) in `_bit_exact_unsupported_reason`, and set it on the negative control. The single-run functional assertion still runs; only the meaningless byte-for-byte re-run comparison is skipped. The flag is host-side and does not affect the compiled kernel, so it is excluded from the variant hash (variant IDs unchanged).

## CI evidence (Blackhole `bh_p150b`, `LLK bit-exact`, 500 runs, group 2/2)
- **Before the fix** — [run 30491828679](https://github.com/tenstorrent/tt-metal/actions/runs/30491828679/job/90711555801): `4 failed, 16643 passed, 4074 skipped, 3 xfailed` — the 4 failures are the negative-control variants (`Non-deterministic hardware output ...`).
- **After the fix** — [run 30627760357](https://github.com/tenstorrent/tt-metal/actions/runs/30627760357) (this branch): `0 failed, 16647 passed, 4074 skipped, 3 xfailed` — the same 4 variants now run and pass; every other variant keeps its determinism check.

`16643 + 4 = 16647`: exactly the four negative controls flip from failed → passed, with skips/xfails unchanged and no other regressions.

## Why not just make it bit-exact (e.g. pre-load DEST with known values)?
Short answer: there is nothing correct to be bit-exact *about*.

A bit-exact check is only meaningful when the kernel is supposed to produce one specific, correct result. This test does the opposite on purpose: it runs the reduce with a broken address register (`ADDR_MOD_3 = 0`) so the hardware writes to the wrong place. The output is **garbage by design** — that is the entire point of the negative control (it proves that skipping the repair really does break the op).

We *could* force that garbage to come out identical every time (e.g. by pre-filling DEST). But then we'd be pinning the exact bytes of a wrong, meaningless result. That check would not test correctness — it would be a tripwire that goes red whenever anything downstream shifts (a compiler tweak, a default register value, the other arch), even though nothing is actually broken. And it wouldn't be honest: making broken behavior look reproducible just so it can pass a *reproducibility* gate is gaming the gate, not adding coverage. (It also may not even fully work: for `reinit=none` the source-operand addressing is broken too, so the value folded onto row 0 can itself be timing-dependent — preloading DEST wouldn't touch that.)

The property that actually matters is already tested: the run **must differ from golden** (`expect_mismatch`). Whether the wrong answer is the *same* wrong answer every time is irrelevant — so this variant **must** be marked non-bit-exact. It belongs in the exact bucket the harness already has for "cannot be compared run-to-run" (coverage builds, L1 accumulation): we assert the thing with meaning (wrong vs golden) and skip the thing without (identical bytes of undefined output).

## Validation (Wormhole, local)
- Exemption fires only for the negative controls: `Bit-exactness check skipped for 712b834c2b16: variant intentionally exercises undefined hardware state`.
- Functional check still passes for those variants.
- Full-file sweep with `--bit-exact-runs=20`: the other variants still run the determinism check (bit-identical), only the negative controls are exempted, and 0 spurious non-determinism reports.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ncvetkovic/llk-reduce-block-max-negctrl-bitexact)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ncvetkovic/llk-reduce-block-max-negctrl-bitexact)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ncvetkovic/llk-reduce-block-max-negctrl-bitexact)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ncvetkovic/llk-reduce-block-max-negctrl-bitexact)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ncvetkovic/llk-reduce-block-max-negctrl-bitexact)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ncvetkovic/llk-reduce-block-max-negctrl-bitexact)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ncvetkovic/llk-reduce-block-max-negctrl-bitexact)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ncvetkovic/llk-reduce-block-max-negctrl-bitexact)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ncvetkovic/llk-reduce-block-max-negctrl-bitexact)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ncvetkovic/llk-reduce-block-max-negctrl-bitexact)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ncvetkovic/llk-reduce-block-max-negctrl-bitexact)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ncvetkovic/llk-reduce-block-max-negctrl-bitexact)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ncvetkovic/llk-reduce-block-max-negctrl-bitexact)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ncvetkovic/llk-reduce-block-max-negctrl-bitexact)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ncvetkovic/llk-reduce-block-max-negctrl-bitexact)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ncvetkovic/llk-reduce-block-max-negctrl-bitexact)