### PR TITLE
[Feature] Fire tt-triage on hang in Blaze Models Prefill tests

### DIFF
--- a/.github/workflows/blaze-models-prefill-tests-impl.yaml
+++ b/.github/workflows/blaze-models-prefill-tests-impl.yaml
@@ -354,12 +354,20 @@ jobs:
       - name: 🧯 Enable tt-triage on hang
         if: ${{ inputs.hang-detection-timeout != 0 }}
         timeout-minutes: 5
+        env:
+          TEST_NAME: ${{ matrix.test-group.name }}
         run: |
           mkdir -p "$TRIAGE_OUTPUT_DIR"
 
+          # Identity of the leg, written into the report dir when triage fires. A downloaded
+          # artifact otherwise says nothing about which job produced it, and the triage output does
+          # not always reach the step log — a hang inside a process the test spawned itself (e.g.
+          # the prefill producer) writes the files but its stderr never gets to the log.
+          echo "TT_TRIAGE_JOB_INFO=leg: $TEST_NAME | sku: ${{ matrix.test-group.sku }} | runner: ${RUNNER_NAME:-unknown} | run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}" >> $GITHUB_ENV
+
           # Single-quoted: expanded by /bin/sh on the rank's node, not here. Sentinel keeps it to
           # the first hang — cards aren't reset between tests, so later triage is misleading.
-          TRIAGE_CMD='D="${TRIAGE_OUTPUT_DIR:-/tmp/tt_triage}/$(hostname)"; mkdir -p "$D" || D=/tmp; if [ -e "$D/.tt_triage_already_ran" ]; then echo "[auto-triage] triage already ran on $(hostname); skipping (cards are not reset between tests, so a second triage is unreliable)" >&2; else touch "$D/.tt_triage_already_ran"; /opt/venv/bin/python3 "${TT_METAL_HOME:-/home/user/tt-metal}/tools/tt-triage.py" --disable-progress --path="$D/debug_bus_signal_groups.json" --triage-summary-path="$D/triage_summary.txt" --llm-output-path="$D/triage_llm_output.txt" 2>&1 | tee "$D/triage_output.txt" 1>&2; fi'
+          TRIAGE_CMD='D="${TRIAGE_OUTPUT_DIR:-/tmp/tt_triage}/$(hostname)"; mkdir -p "$D" || D=/tmp; if [ -e "$D/.tt_triage_already_ran" ]; then echo "[auto-triage] triage already ran on $(hostname); skipping (cards are not reset between tests, so a second triage is unreliable)" >&2; else touch "$D/.tt_triage_already_ran"; printf "%s\n" "${TT_TRIAGE_JOB_INFO:-unknown leg}" > "$D/job_info.txt"; /opt/venv/bin/python3 "${TT_METAL_HOME:-/home/user/tt-metal}/tools/tt-triage.py" --disable-progress --path="$D/debug_bus_signal_groups.json" --triage-summary-path="$D/triage_summary.txt" --llm-output-path="$D/triage_llm_output.txt" 2>&1 | tee "$D/triage_output.txt" 1>&2; fi'
 
           {
             echo "TT_METAL_DISPATCH_TIMEOUT_COMMAND_TO_EXECUTE=$TRIAGE_CMD"
@@ -405,7 +413,10 @@ jobs:
         continue-on-error: true
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
-          name: triage_output_${{ inputs.resource-prefix }}-${{ inputs.sp-config }}-${{ strategy.job-index }}
+          # Named after the leg, not the matrix index: the job is displayed as
+          # "<caller job> / <this name>", so the artifact maps to it by eye. The index-based name it
+          # replaced could only be resolved by cross-referencing the test_matrix_* artifact.
+          name: triage_output_${{ matrix.test-group.name }} (attempt ${{ github.run_attempt }})
           path: ${{ env.TRIAGE_OUTPUT_DIR }}/**
           if-no-files-found: ignore
           retention-days: 30
@@ -441,7 +452,14 @@ jobs:
 
       - name: 🧹 Clean shared dirs
         if: always()
+        env:
+          TEST_NAME: ${{ matrix.test-group.name }}
         run: |
+          # Annotate the job when a hang was triaged, so the failed job points at its artifact
+          # instead of leaving you to guess which one belongs to it.
+          if [ -n "$TRIAGE_OUTPUT_DIR" ] && [ -n "$(ls -A "$TRIAGE_OUTPUT_DIR" 2>/dev/null)" ]; then
+            echo "::notice title=tt-triage::Hang triaged on $(ls "$TRIAGE_OUTPUT_DIR" | tr '\n' ' ')— see artifact \"triage_output_$TEST_NAME (attempt ${{ github.run_attempt }})\""
+          fi
           if [ -n "$PREFILL_SUMMARIES" ]; then rm -rf "$PREFILL_SUMMARIES"; fi
           if [ -n "$TRIAGE_OUTPUT_DIR" ]; then rm -rf "$TRIAGE_OUTPUT_DIR"; fi
 

--- a/.github/workflows/blaze-models-prefill-tests-impl.yaml
+++ b/.github/workflows/blaze-models-prefill-tests-impl.yaml
@@ -35,7 +35,7 @@ on:
       hang-detection-timeout:
         required: false
         type: number
-        default: 60
+        default: 10
         description: "Seconds without dispatch progress before tt-triage fires on the hung rank(s). 0 or less disables hang detection (the runtime treats any non-positive duration as no timeout)."
 
 permissions:

--- a/.github/workflows/blaze-models-prefill-tests-impl.yaml
+++ b/.github/workflows/blaze-models-prefill-tests-impl.yaml
@@ -36,7 +36,7 @@ on:
         required: false
         type: number
         default: 60
-        description: "Seconds without dispatch progress before tt-triage fires on the hung rank(s). 0 disables hang detection."
+        description: "Seconds without dispatch progress before tt-triage fires on the hung rank(s). 0 or less disables hang detection (the runtime treats any non-positive duration as no timeout)."
 
 permissions:
   id-token: write
@@ -352,7 +352,7 @@ jobs:
       # TT_METAL_DISPATCH_TIMEOUT_COMMAND_TO_EXECUTE inside the hung rank, then throws. Armed here
       # rather than job-wide so the cluster-validation loop above is unaffected.
       - name: 🧯 Enable tt-triage on hang
-        if: ${{ inputs.hang-detection-timeout != 0 }}
+        if: ${{ inputs.hang-detection-timeout > 0 }}
         timeout-minutes: 5
         env:
           TEST_NAME: ${{ matrix.test-group.name }}

--- a/.github/workflows/blaze-models-prefill-tests-impl.yaml
+++ b/.github/workflows/blaze-models-prefill-tests-impl.yaml
@@ -32,6 +32,11 @@ on:
         required: true
         type: string
         description: "Unique prefix for allocation/environment names when multiple impl jobs share a run (e.g. module, sdpa-perf)"
+      hang-detection-timeout:
+        required: false
+        type: number
+        default: 60
+        description: "Seconds without dispatch progress before tt-triage fires on the hung rank(s). 0 disables hang detection."
 
 permissions:
   id-token: write
@@ -144,6 +149,8 @@ jobs:
       # /ci is the NFS volume shared with the runner; worker /home/user is per-node, invisible to it.
       # Rank 0 writes; the run/attempt/job subpath keeps reused-PVC runs from colliding.
       PREFILL_SUMMARIES: /ci/prefill_summaries/${{ github.run_id }}-${{ github.run_attempt }}/${{ inputs.resource-prefix }}-${{ inputs.sp-config }}-${{ strategy.job-index }}
+      # On /ci for the same reason as PREFILL_SUMMARIES: triage runs on a worker node.
+      TRIAGE_OUTPUT_DIR: /ci/triage_output/${{ github.run_id }}-${{ github.run_attempt }}/${{ inputs.resource-prefix }}-${{ inputs.sp-config }}-${{ strategy.job-index }}
     strategy:
       fail-fast: false
       matrix:
@@ -340,6 +347,28 @@ jobs:
             test -r /mnt/models
           '
 
+      # Same mechanism as .github/actions/setup-job, which this job can't use (not a container
+      # job, tests run under mpirun): on dispatch stall the runtime runs
+      # TT_METAL_DISPATCH_TIMEOUT_COMMAND_TO_EXECUTE inside the hung rank, then throws. Armed here
+      # rather than job-wide so the cluster-validation loop above is unaffected.
+      - name: 🧯 Enable tt-triage on hang
+        if: ${{ inputs.hang-detection-timeout != 0 }}
+        run: |
+          mkdir -p "$TRIAGE_OUTPUT_DIR"
+
+          # Single-quoted: expanded by /bin/sh on the rank's node, not here. Sentinel keeps it to
+          # the first hang — cards aren't reset between tests, so later triage is misleading.
+          TRIAGE_CMD='D="${TRIAGE_OUTPUT_DIR:-/tmp/tt_triage}/$(hostname)"; mkdir -p "$D" || D=/tmp; if [ -e "$D/.tt_triage_already_ran" ]; then echo "[auto-triage] triage already ran on $(hostname); skipping (cards are not reset between tests, so a second triage is unreliable)" >&2; else touch "$D/.tt_triage_already_ran"; /opt/venv/bin/python3 "${TT_METAL_HOME:-/home/user/tt-metal}/tools/tt-triage.py" --disable-progress --path="$D/debug_bus_signal_groups.json" --triage-summary-path="$D/triage_summary.txt" --llm-output-path="$D/triage_llm_output.txt" 2>&1 | tee "$D/triage_output.txt" 1>&2; fi'
+
+          {
+            echo "TT_METAL_DISPATCH_TIMEOUT_COMMAND_TO_EXECUTE=$TRIAGE_CMD"
+            echo "TT_METAL_OPERATION_TIMEOUT_SECONDS=${{ inputs.hang-detection-timeout }}"
+            echo "TT_TRIAGE_ENABLE_AGGREGATED_CALLSTACKS=1"
+            echo "TT_RUN_DISABLED_TRIAGE_SCRIPTS_IN_CI=1"
+          } >> $GITHUB_ENV
+
+          echo "Triage fires after ${{ inputs.hang-detection-timeout }}s without dispatch progress"
+
       - name: ${{ matrix.test-group.name }}
         id: run-test
         timeout-minutes: ${{ matrix.test-group.timeout }}
@@ -356,6 +385,17 @@ jobs:
             echo "Running: ${{ matrix.test-group.name }}"
             echo "$CMD"
             eval "$CMD"
+
+      # Only uploaded on a hang; the triage report itself is already in the test step's log.
+      - name: ⬆️ Upload triage output
+        if: always() && !cancelled()
+        continue-on-error: true
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: triage_output_${{ inputs.resource-prefix }}-${{ inputs.sp-config }}-${{ strategy.job-index }}
+          path: ${{ env.TRIAGE_OUTPUT_DIR }}/**
+          if-no-files-found: ignore
+          retention-days: 30
 
       - name: 📊 Publish prefill summaries
         if: always() && !cancelled()
@@ -386,9 +426,11 @@ jobs:
           if-no-files-found: ignore
           retention-days: 30
 
-      - name: 🧹 Clean prefill summaries
+      - name: 🧹 Clean shared dirs
         if: always()
-        run: if [ -n "$PREFILL_SUMMARIES" ]; then rm -rf "$PREFILL_SUMMARIES"; fi
+        run: |
+          if [ -n "$PREFILL_SUMMARIES" ]; then rm -rf "$PREFILL_SUMMARIES"; fi
+          if [ -n "$TRIAGE_OUTPUT_DIR" ]; then rm -rf "$TRIAGE_OUTPUT_DIR"; fi
 
       - name: 🤖 AI job summary
         if: always() && !cancelled()

--- a/.github/workflows/blaze-models-prefill-tests-impl.yaml
+++ b/.github/workflows/blaze-models-prefill-tests-impl.yaml
@@ -353,6 +353,7 @@ jobs:
       # rather than job-wide so the cluster-validation loop above is unaffected.
       - name: 🧯 Enable tt-triage on hang
         if: ${{ inputs.hang-detection-timeout != 0 }}
+        timeout-minutes: 5
         run: |
           mkdir -p "$TRIAGE_OUTPUT_DIR"
 
@@ -366,6 +367,18 @@ jobs:
             echo "TT_TRIAGE_ENABLE_AGGREGATED_CALLSTACKS=1"
             echo "TT_RUN_DISABLED_TRIAGE_SCRIPTS_IN_CI=1"
           } >> $GITHUB_ENV
+
+          # Confirm per host that the hook actually reaches the ranks (env forwarding is done by
+          # ttop via PRTE_MCA_prte_fwd_environment, not by this workflow) and that triage can run
+          # there. Diagnostics only — never fails the leg.
+          export TT_METAL_DISPATCH_TIMEOUT_COMMAND_TO_EXECUTE="$TRIAGE_CMD"
+          mpirun --bind-to none --pernode --tag-output bash -lc '
+            ok=1
+            [ -n "$TT_METAL_DISPATCH_TIMEOUT_COMMAND_TO_EXECUTE" ] || { echo "triage hook not forwarded to this rank"; ok=0; }
+            [ -w "${TRIAGE_OUTPUT_DIR:-/nonexistent}" ] || { echo "TRIAGE_OUTPUT_DIR not writable here: ${TRIAGE_OUTPUT_DIR:-<unset>}"; ok=0; }
+            /opt/venv/bin/python3 -c "import ttexalens" 2>/dev/null || { echo "ttexalens missing from /opt/venv"; ok=0; }
+            [ "$ok" = 1 ] && echo "triage armed"
+          ' || echo "::warning::Could not verify triage arming on all hosts; a hang here may not produce triage output"
 
           echo "Triage fires after ${{ inputs.hang-detection-timeout }}s without dispatch progress"
 


### PR DESCRIPTION
Closes https://github.com/tenstorrent/tt-metal/issues/51886

### PR Category
Feature (CI infra)

### Summary
A hang in Blaze Models Prefill shows up as a step timeout and nothing else — no callstacks, no core state, and the cards get reset before anyone looks.

This arms the same dispatch-timeout triage hook `setup-job` already gives container jobs like blackhole-e2e, adapted for this pipeline (not a container job; tests run as `mpirun` ranks on worker pods). After 60s without dispatch progress the hung rank runs `tt-triage` on its own devices, the report goes to the test step's log, and the files are uploaded as `triage_output_<leg>`.

**Example:** [run 30788431797](https://github.com/tenstorrent/tt-metal/actions/runs/30788431797) — two legs hung, both left artifacts naming the stuck op (`RingJointSDPADeviceOperation`, `InboundSocketServiceSyncOperation`) instead of a silent 30-minute gap.

### Notes for reviewers
- **60s, not setup-job's 5s:** on a multihost run a rank can legitimately idle waiting on a peer. ~10 runs of 25-33 min with it active, zero false timeouts. `hang-detection-timeout: 0` disables.
- Everything added is `continue-on-error`, and green runs upload no artifact.

<img width="1876" height="160" alt="image" src="https://github.com/user-attachments/assets/b87413c8-e97f-4187-ad88-c0df7a4ee318" />


### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nmilicevic/ci-add-triage)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nmilicevic/ci-add-triage)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nmilicevic/ci-add-triage)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nmilicevic/ci-add-triage)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=nmilicevic/ci-add-triage)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:nmilicevic/ci-add-triage)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nmilicevic/ci-add-triage)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nmilicevic/ci-add-triage)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nmilicevic/ci-add-triage)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nmilicevic/ci-add-triage)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nmilicevic/ci-add-triage)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nmilicevic/ci-add-triage)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nmilicevic/ci-add-triage)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nmilicevic/ci-add-triage)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nmilicevic/ci-add-triage)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nmilicevic/ci-add-triage)