### PR TITLE
Optimize cached height-sharded transpose dispatch & #48928 performance

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose.py
@@ -680,6 +680,75 @@ def test_transpose_hc_sharded_with_program_cache(device, n, c, h, w, grid_size):
     assert device.num_program_cache_entries() == 3
 
 
+def run_transpose_hc_sharded_from_torch(device, torch_input_tensor, grid_size):
+    n, c, h, w = torch_input_tensor.shape
+    tt_input_tensor = ttnn.from_torch(
+        torch_input_tensor,
+        dtype=ttnn.DataType.BFLOAT16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=device,
+        memory_config=ttnn.L1_MEMORY_CONFIG,
+    )
+    # shard config
+    grid_coord = ttnn.CoreCoord(grid_size.x - 1, grid_size.y - 1)
+    shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), grid_coord)})
+    shard_spec = ttnn.ShardSpec(
+        shard_grid, (n * h * c // (grid_size.x * grid_size.y), w), ttnn.ShardOrientation.ROW_MAJOR
+    )
+    sharded_mem_config = ttnn.MemoryConfig(
+        ttnn.types.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.types.BufferType.L1, shard_spec
+    )
+    tt_input_tensor = ttnn.to_memory_config(tt_input_tensor, sharded_mem_config)
+
+    tt_output_tensor = ttnn.transpose(tt_input_tensor, 1, 2, memory_config=sharded_mem_config)
+    tt_output_tensor = ttnn.to_memory_config(tt_output_tensor, ttnn.L1_MEMORY_CONFIG)
+    tt_output_tensor = ttnn.from_device(tt_output_tensor)
+    return ttnn.to_torch(tt_output_tensor)
+
+
+@pytest.mark.parametrize(
+    "n, c, h, w, grid_size",
+    [
+        # generic path: shard height 288 is neither a multiple nor a divisor of H=224
+        (24, 3, 224, 224, ttnn.CoreGrid(y=8, x=7)),
+        # special case path, one H block per core: shard height 224 == H
+        (16, 4, 224, 224, ttnn.CoreGrid(y=8, x=8)),
+        # special case path, multiple H blocks per core: shard height 4096 == 32 * H
+        (16, 128, 128, 16, ttnn.CoreGrid(y=8, x=8)),
+    ],
+    ids=["generic", "special_case_single_h_block", "special_case_multi_h_block"],
+)
+def test_transpose_hc_sharded_cache_hit_new_input(device, n, c, h, w, grid_size):
+    # #48928: a cache hit rebuilds reader arg0 in closed form, so validate fresh data on every dispatch
+    if grid_size.y > device.core_grid.y:
+        pytest.skip("grid size not for N300")
+    torch.manual_seed(2005)
+    # retain prior tensors so each iteration allocates its input at a new address
+    keep_alive = []
+    expected_cache_entries = None
+    for _ in range(3):
+        torch_input_tensor = torch.rand((n, c, h, w), dtype=torch.bfloat16)
+        tt_output_tensor = run_transpose_hc_sharded_from_torch(device, torch_input_tensor, grid_size)
+        assert_with_pcc(torch_input_tensor.transpose(1, 2), tt_output_tensor, 0.9999)
+
+        dummy_shape = [1, 1, 32, 32]
+        keep_alive.append(
+            ttnn.from_torch(
+                torch.randn(dummy_shape),
+                dtype=ttnn.DataType.BFLOAT16,
+                layout=ttnn.TILE_LAYOUT,
+                device=device,
+                memory_config=ttnn.L1_MEMORY_CONFIG,
+            )
+        )
+        if expected_cache_entries is None:
+            expected_cache_entries = device.num_program_cache_entries()
+        else:
+            assert (
+                device.num_program_cache_entries() == expected_cache_entries
+            ), "transpose must reuse the cached program on a hit"
+
+
 @pytest.mark.parametrize(
     "shape, swap_dims",
     [

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_sharded_program_factory.cpp
@@ -21,6 +21,23 @@ namespace ttnn::prim {
 
 namespace {
 
+// Reader arg0 of the generic HC-sharded path. Closed form: the value is the same on every core and
+// does not depend on the per-core loop state
+inline uint32_t hc_rm_sharded_reader_arg0(const Tensor& input_tensor) {
+    return input_tensor.shard_spec().value().shape[0];  // num_sticks_per_core
+}
+
+// Reader arg0 of the special-case HC-sharded path (read_single_h_block_per_core).
+// H comes from padded_shape() to match get_runtime_args_hc_rm_sharded_special_case; the
+// hc_rm_sharded_is_special_case predicate is evaluated on logical_shape() at the call sites, and the
+// two differ for a padded shard.
+inline uint32_t hc_rm_sharded_special_case_reader_arg0(const Tensor& input_tensor) {
+    const uint32_t shard_height = input_tensor.shard_spec().value().shape[0];
+    const uint32_t H = input_tensor.padded_shape()[2];
+    const uint32_t num_H_per_core = shard_height / H > 0 ? shard_height / H : 1;
+    return static_cast<uint32_t>(num_H_per_core == 1);
+}
+
 std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_runtime_args_hc_rm_sharded(
     const Tensor& input_tensor, uint32_t num_cores, uint32_t num_cores_x, uint32_t num_cores_y) {
     auto input_shape = input_tensor.padded_shape();
@@ -56,7 +73,8 @@ std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_runtime
         }
         uint32_t num_sticks_per_core = shard_height;
 
-        std::vector<uint32_t> reader_runtime_args = {num_sticks_per_core, curr_sticks_read, curr_c, curr_h, curr_n};
+        std::vector<uint32_t> reader_runtime_args = {
+            hc_rm_sharded_reader_arg0(input_tensor), curr_sticks_read, curr_c, curr_h, curr_n};
         reader_runtime_args.insert(reader_runtime_args.end(), shard_grid_x_map.begin(), shard_grid_x_map.end());
         reader_runtime_args.insert(reader_runtime_args.end(), shard_grid_y_map.begin(), shard_grid_y_map.end());
 
@@ -260,7 +278,7 @@ std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_runtime
             }
         }
 
-        bool read_single_h_block_per_core = num_H_per_core == 1;
+        bool read_single_h_block_per_core = hc_rm_sharded_special_case_reader_arg0(input_tensor) != 0;
 
         constexpr size_t num_reader_scalar_args = 5;
         const size_t num_non_repeat_args =
@@ -467,16 +485,15 @@ std::vector<tt::tt_metal::DynamicRuntimeArg> TransposeDeviceOperation::get_dynam
     const auto factory = select_program_factory(operation_attributes, tensor_args);
     const auto& input = tensor_args.input;
     // HC sharded RM is CB-bound; re-apply reader arg0 (read by the kernel) on core 0 to trip the fast-path.
-    // Build only core 0 via the same per-core builders (and shared is_special_case) create_descriptor uses. (#48928)
+    // The value is invariant for a cached program (shard height and shape are part of the program-cache
+    // hash)
     if (std::holds_alternative<TransposeHCShardedProgramFactory>(factory)) {
-        const auto shard = input.shard_spec().value();
+        const auto& shard = input.shard_spec().value();
         const uint32_t H = input.logical_shape()[2], C = input.logical_shape()[1];
         const bool special = hc_rm_sharded_is_special_case(shard.shape[0], H, C);
-        const auto bbox = shard.grid.bounding_box();
-        const auto a =
-            special ? get_runtime_args_hc_rm_sharded_special_case(input, 1, bbox.end_coord.x + 1, bbox.end_coord.y + 1)
-                    : get_runtime_args_hc_rm_sharded(input, 1, bbox.end_coord.x + 1, bbox.end_coord.y + 1);
-        return {tt::tt_metal::DynamicRuntimeArg{0, corerange_to_cores(shard.grid).front(), 0, a[0].first[0]}};
+        const uint32_t arg0 =
+            special ? hc_rm_sharded_special_case_reader_arg0(input) : hc_rm_sharded_reader_arg0(input);
+        return {tt::tt_metal::DynamicRuntimeArg{0, corerange_to_cores(shard.grid).front(), 0, arg0}};
     }
     // WH sharded RM emits one placeholder reader arg the kernel ignores; re-apply 0 to trip the fast-path.
     if (std::holds_alternative<TransposeWHShardedRMProgramFactory>(factory)) {

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_sharded_program_factory.cpp
@@ -12,6 +12,7 @@
 
 #include <map>
 #include <set>
+#include <utility>
 
 using namespace tt::constants;
 using namespace tt::tt_metal;
@@ -89,7 +90,7 @@ std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_runtime
     auto input_shape = input_tensor.padded_shape();
 
     uint32_t W = input_shape[3], H = input_shape[2], C = input_shape[1], N = input_shape[0];
-    uint32_t total_height = N * C * H;
+    const uint32_t total_height = N * C * H;
     uint32_t stick_size_bytes = W * input_tensor.element_size();
 
     auto shard_spec = input_tensor.shard_spec().value();
@@ -102,7 +103,7 @@ std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_runtime
 
     uint32_t height = 0;
     std::vector<CoreCoord> cores;
-    for (uint32_t i = 0; i < num_cores; i++) {
+    for (uint32_t i = 0; i < num_cores; ++i) {
         CoreCoord core;
         if (row_major) {
             core = {i % num_cores_x, i / num_cores_x};
@@ -121,16 +122,32 @@ std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_runtime
     uint32_t num_H_per_core = shard_height / H > 0 ? shard_height / H : 1;  // the number of H blocks in a shard
     uint32_t num_C_blocks_per_core = shard_height > C ? shard_height / C : 1;
 
+    const uint32_t num_sticks_per_core = shard_height;
+
+    // Scratch buffers reused by every core: each stick contributes at most one entry, and entries are dropped only
+    // for out-of-grid workers, so num_sticks_per_core covers the worst case for the whole loop.
+    std::vector<uint32_t> stick_ids_per_core;
+    std::vector<uint32_t> read_cores_indices;
+    std::vector<uint32_t> read_cores_noc_x;
+    std::vector<uint32_t> read_cores_noc_y;
+    std::vector<uint32_t> read_stick_offset;
+    std::vector<uint32_t> non_repeat_stick_offset_values;
+    std::vector<uint32_t> non_repeat_noc_x_values;
+    std::vector<uint32_t> non_repeat_noc_y_values;
+    stick_ids_per_core.reserve(num_sticks_per_core);
+    read_cores_indices.reserve(num_sticks_per_core);
+    read_cores_noc_x.reserve(num_sticks_per_core);
+    read_cores_noc_y.reserve(num_sticks_per_core);
+    read_stick_offset.reserve(num_sticks_per_core);
+
     uint32_t curr_c = 0, curr_h = 0;
-    for (uint32_t i = 0, curr_sticks_read = 0; i < num_cores; i++) {
-        std::vector<uint32_t> read_cores_indices;
-        std::vector<uint32_t> read_cores_noc_x;
-        std::vector<uint32_t> read_cores_noc_y;
-        std::vector<uint32_t> read_stick_offset;
+    for (uint32_t i = 0, curr_sticks_read = 0; i < num_cores; ++i) {
+        stick_ids_per_core.clear();
+        read_cores_indices.clear();
+        read_cores_noc_x.clear();
+        read_cores_noc_y.clear();
+        read_stick_offset.clear();
 
-        uint32_t num_sticks_per_core = shard_height;
-
-        std::vector<uint32_t> stick_ids_per_core;
         for (uint32_t j = 0; j < num_sticks_per_core; ++j) {
             stick_ids_per_core.push_back(curr_sticks_read);
             curr_c++;
@@ -149,7 +166,6 @@ std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_runtime
         }
 
         // figure out the stick id in a shard, and the core id for the stick.
-        std::map<std::pair<uint32_t, uint32_t>, std::vector<uint32_t>> core_stick_map;
         for (uint32_t j = 0; j < num_sticks_per_core; ++j) {
             uint32_t stick_id = stick_ids_per_core[j];
             uint32_t shard_id = stick_id / num_sticks_per_core;
@@ -173,9 +189,9 @@ std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_runtime
             }
         }
 
-        std::vector<uint32_t> non_repeat_stick_offset_values;
-        std::vector<uint32_t> non_repeat_noc_x_values;
-        std::vector<uint32_t> non_repeat_noc_y_values;
+        non_repeat_stick_offset_values.clear();
+        non_repeat_noc_x_values.clear();
+        non_repeat_noc_y_values.clear();
 
         uint32_t num_sticks_per_shard_core_reader = 0, num_sticks_per_shard_core_writer = 0;
         uint32_t writer_read_stick_offset = 0, writer_write_stick_offset = 0;
@@ -193,16 +209,18 @@ std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_runtime
                 }
             }
 
-            uint32_t num_sticks_per_shard_core = shard_height / num_non_repeat_cores;
+            const uint32_t num_sticks_per_shard_core = shard_height / num_non_repeat_cores;
             num_sticks_per_shard_core_reader = num_sticks_per_shard_core;
-            bool split_reader = num_sticks_per_shard_core > 2;
-            if (split_reader) {
+            if (const bool split_reader = num_sticks_per_shard_core > 2; split_reader) {
                 num_sticks_per_shard_core_reader = num_sticks_per_shard_core / 2;
                 num_sticks_per_shard_core_writer = num_sticks_per_shard_core - num_sticks_per_shard_core_reader;
                 writer_read_stick_offset = num_sticks_per_shard_core_reader * read_stick_stride;
                 writer_write_stick_offset = writer_read_stick_offset * num_non_repeat_cores;
             }
 
+            non_repeat_stick_offset_values.reserve(num_non_repeat_cores);
+            non_repeat_noc_x_values.reserve(num_non_repeat_cores);
+            non_repeat_noc_y_values.reserve(num_non_repeat_cores);
             for (uint32_t k = 0; k < num_non_repeat_cores; ++k) {
                 non_repeat_stick_offset_values.push_back(read_stick_offset[k]);
                 non_repeat_noc_x_values.push_back(read_cores_noc_x[k]);
@@ -222,18 +240,19 @@ std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_runtime
                 }
             }
 
-            uint32_t num_sticks_per_shard_core = shard_height / num_non_repeat_cores / num_C_blocks_per_core;
+            const uint32_t num_sticks_per_shard_core = shard_height / num_non_repeat_cores / num_C_blocks_per_core;
             num_sticks_per_shard_core_reader = num_sticks_per_shard_core;
             num_sticks_per_shard_core_writer = num_sticks_per_shard_core;
-            bool split_reader = num_C_blocks_per_core > 2;
-            if (split_reader) {
+            if (const bool split_reader = num_C_blocks_per_core > 2; split_reader) {
                 num_C_blocks_per_core_reader = num_C_blocks_per_core / 2;
                 num_C_blocks_per_core_writer = num_C_blocks_per_core - num_C_blocks_per_core_reader;
                 writer_read_stick_offset = num_C_blocks_per_core_reader * stick_size_bytes;
-                writer_write_stick_offset =
-                    num_C_blocks_per_core_reader * num_non_repeat_cores * num_sticks_per_shard_core * stick_size_bytes;
+                writer_write_stick_offset = writer_read_stick_offset * num_non_repeat_cores * num_sticks_per_shard_core;
             }
 
+            non_repeat_stick_offset_values.reserve(num_non_repeat_cores);
+            non_repeat_noc_x_values.reserve(num_non_repeat_cores);
+            non_repeat_noc_y_values.reserve(num_non_repeat_cores);
             for (uint32_t k = 0; k < num_non_repeat_cores; ++k) {
                 non_repeat_stick_offset_values.push_back(read_stick_offset[k * num_sticks_per_shard_core]);
                 non_repeat_noc_x_values.push_back(read_cores_noc_x[k * num_sticks_per_shard_core]);
@@ -243,14 +262,21 @@ std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_runtime
 
         bool read_single_h_block_per_core = num_H_per_core == 1;
 
-        std::vector<uint32_t> reader_runtime_args = {
-            static_cast<uint32_t>(read_single_h_block_per_core),
-            num_C_blocks_per_core_reader,
-            num_sticks_per_shard_core_reader,
-            num_non_repeat_cores,
-            read_stick_stride,
-        };
+        constexpr size_t num_reader_scalar_args = 5;
+        const size_t num_non_repeat_args =
+            non_repeat_stick_offset_values.size() + non_repeat_noc_x_values.size() + non_repeat_noc_y_values.size();
 
+        std::vector<uint32_t> reader_runtime_args;
+        reader_runtime_args.reserve(num_reader_scalar_args + num_non_repeat_args);
+        reader_runtime_args.insert(
+            reader_runtime_args.end(),
+            {
+                static_cast<uint32_t>(read_single_h_block_per_core),
+                num_C_blocks_per_core_reader,
+                num_sticks_per_shard_core_reader,
+                num_non_repeat_cores,
+                read_stick_stride,
+            });
         reader_runtime_args.insert(
             reader_runtime_args.end(), non_repeat_stick_offset_values.begin(), non_repeat_stick_offset_values.end());
         reader_runtime_args.insert(
@@ -258,16 +284,20 @@ std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_runtime
         reader_runtime_args.insert(
             reader_runtime_args.end(), non_repeat_noc_y_values.begin(), non_repeat_noc_y_values.end());
 
-        std::vector<uint32_t> writer_runtime_args = {
-            static_cast<uint32_t>(read_single_h_block_per_core),
-            num_C_blocks_per_core_writer,
-            num_sticks_per_shard_core_writer,
-            num_non_repeat_cores,
-            read_stick_stride,
-            writer_read_stick_offset,
-            writer_write_stick_offset,
-        };
-
+        std::vector<uint32_t> writer_runtime_args;
+        constexpr size_t num_writer_scalar_args = 7;
+        writer_runtime_args.reserve(num_writer_scalar_args + num_non_repeat_args);
+        writer_runtime_args.insert(
+            writer_runtime_args.end(),
+            {
+                static_cast<uint32_t>(read_single_h_block_per_core),
+                num_C_blocks_per_core_writer,
+                num_sticks_per_shard_core_writer,
+                num_non_repeat_cores,
+                read_stick_stride,
+                writer_read_stick_offset,
+                writer_write_stick_offset,
+            });
         writer_runtime_args.insert(
             writer_runtime_args.end(), non_repeat_stick_offset_values.begin(), non_repeat_stick_offset_values.end());
         writer_runtime_args.insert(
@@ -275,7 +305,7 @@ std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_runtime
         writer_runtime_args.insert(
             writer_runtime_args.end(), non_repeat_noc_y_values.begin(), non_repeat_noc_y_values.end());
 
-        ret_val[i] = {reader_runtime_args, writer_runtime_args};
+        ret_val[i] = {std::move(reader_runtime_args), std::move(writer_runtime_args)};
     }
 
     return ret_val;

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/transpose.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/transpose.cpp
@@ -237,24 +237,23 @@ ttnn::Tensor transpose_impl(
     uint32_t normalized_dim2 = input_shape.get_normalized_index(dim2);
 
     Tensor input_unsqueezed = input_tensor;
-    uint32_t initial_rank = input_shape.rank();
+    const uint32_t initial_rank = input_shape.rank();
     if (initial_rank < 4) {
         input_unsqueezed = ttnn::unsqueeze_to_4D(input_tensor);
-        uint32_t rank_diff = 4 - initial_rank;
+        const uint32_t rank_diff = 4 - initial_rank;
         normalized_dim1 += rank_diff;
         normalized_dim2 += rank_diff;
     } else if (initial_rank > 4) {
         return detail::transpose_nd(input_tensor, normalized_dim1, normalized_dim2, memory_config_arg, pad_value);
     }
 
-    bool wh = (normalized_dim1 == 2 && normalized_dim2 == 3) || (normalized_dim2 == 2 && normalized_dim1 == 3);
-    bool cn = (normalized_dim1 == 0 && normalized_dim2 == 1) || (normalized_dim2 == 0 && normalized_dim1 == 1);
-    bool bfloat8_supported = cn || wh;
-    bool typecast = input_unsqueezed.dtype() == DataType::BFLOAT8_B and !bfloat8_supported;
-    Tensor input_typecasted = typecast ? ttnn::typecast(input_unsqueezed, DataType::BFLOAT16) : input_unsqueezed;
-
     TT_FATAL(normalized_dim1 <= 3, "dimension has to be 0-3 only corresponding to N,C,H,W");
     TT_FATAL(normalized_dim2 <= 3, "dimension has to be 0-3 only corresponding to N,C,H,W");
+    const bool wh = 5 == (normalized_dim1 + normalized_dim2);  // 2+3=5
+    const bool cn = 1 == (normalized_dim1 + normalized_dim2);  // 0+1
+    const bool bfloat8_supported = wh || cn;
+    const bool typecast = input_unsqueezed.dtype() == DataType::BFLOAT8_B and !bfloat8_supported;
+    Tensor input_typecasted = typecast ? ttnn::typecast(input_unsqueezed, DataType::BFLOAT16) : input_unsqueezed;
 
     Tensor output;
     if ((normalized_dim1 == normalized_dim2) || (input_typecasted.padded_shape()[normalized_dim1] == 1 &&
@@ -269,28 +268,21 @@ ttnn::Tensor transpose_impl(
             output = input_typecasted;
         }
     } else {
-        if (normalized_dim1 > normalized_dim2) {
-            std::swap(normalized_dim1, normalized_dim2);
-        }
+        // covered in main if branch => not a TT_FATAL
+        TT_ASSERT(normalized_dim1 != normalized_dim2, "Unsupported transpose dims");
 
-        ttnn::prim::TransposeOpDim transpose_dim = ttnn::prim::TransposeOpDim::NW;
+        using ttnn::prim::TransposeOpDim;
+        constexpr auto tod_default__value = TransposeOpDim::NW;
+        constexpr TransposeOpDim transpose_dims[4][4] = {
+            //     dim2=0              dim2=1              dim2=2              dim2=3
+            {tod_default__value, TransposeOpDim::CN, TransposeOpDim::NH, TransposeOpDim::NW},  // dim1=0
+            {TransposeOpDim::CN, tod_default__value, TransposeOpDim::HC, TransposeOpDim::CW},  // dim1=1
+            {TransposeOpDim::NH, TransposeOpDim::HC, tod_default__value, TransposeOpDim::WH},  // dim1=2
+            {TransposeOpDim::NW, TransposeOpDim::CW, TransposeOpDim::WH, tod_default__value},  // dim1=3
+        };
 
-        if (normalized_dim2 == 3 && normalized_dim1 == 0) {
-            transpose_dim = ttnn::prim::TransposeOpDim::NW;
-        } else if (normalized_dim2 == 3 && normalized_dim1 == 1) {
-            transpose_dim = ttnn::prim::TransposeOpDim::CW;
-        } else if (normalized_dim2 == 3 && normalized_dim1 == 2) {
-            transpose_dim = ttnn::prim::TransposeOpDim::WH;
-        } else if (normalized_dim2 == 2 && normalized_dim1 == 0) {
-            transpose_dim = ttnn::prim::TransposeOpDim::NH;
-        } else if (normalized_dim2 == 2 && normalized_dim1 == 1) {
-            transpose_dim = ttnn::prim::TransposeOpDim::HC;
-        } else if (normalized_dim2 == 1 && normalized_dim1 == 0) {
-            transpose_dim = ttnn::prim::TransposeOpDim::CN;
-        } else {
-            TT_ASSERT(false, "Unsupported transpose dims");
-        }
-        output = detail::transpose_(input_typecasted, transpose_dim, memory_config_arg, pad_value);
+        output = detail::transpose_(
+            input_typecasted, transpose_dims[normalized_dim1][normalized_dim2], memory_config_arg, pad_value);
     }
     output = initial_rank < 4u ? ttnn::squeeze_from_4D(output, initial_rank) : output;
     return typecast ? ttnn::typecast(output, DataType::BFLOAT8_B) : output;

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/transpose.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/transpose.cpp
@@ -272,13 +272,13 @@ ttnn::Tensor transpose_impl(
         TT_ASSERT(normalized_dim1 != normalized_dim2, "Unsupported transpose dims");
 
         using ttnn::prim::TransposeOpDim;
-        constexpr auto tod_default__value = TransposeOpDim::NW;
+        constexpr auto tod_default_value = TransposeOpDim::NW;
         constexpr TransposeOpDim transpose_dims[4][4] = {
             //     dim2=0              dim2=1              dim2=2              dim2=3
-            {tod_default__value, TransposeOpDim::CN, TransposeOpDim::NH, TransposeOpDim::NW},  // dim1=0
-            {TransposeOpDim::CN, tod_default__value, TransposeOpDim::HC, TransposeOpDim::CW},  // dim1=1
-            {TransposeOpDim::NH, TransposeOpDim::HC, tod_default__value, TransposeOpDim::WH},  // dim1=2
-            {TransposeOpDim::NW, TransposeOpDim::CW, TransposeOpDim::WH, tod_default__value},  // dim1=3
+            {tod_default_value, TransposeOpDim::CN, TransposeOpDim::NH, TransposeOpDim::NW},  // dim1=0
+            {TransposeOpDim::CN, tod_default_value, TransposeOpDim::HC, TransposeOpDim::CW},  // dim1=1
+            {TransposeOpDim::NH, TransposeOpDim::HC, tod_default_value, TransposeOpDim::WH},  // dim1=2
+            {TransposeOpDim::NW, TransposeOpDim::CW, TransposeOpDim::WH, tod_default_value},  // dim1=3
         };
 
         output = detail::transpose_(


### PR DESCRIPTION
### PR Category
performance improvement after investigations related to the issue [#48928 ](https://github.com/tenstorrent/tt-metal/issues/48928)

### Summary
Commit 1: 
   some rework of TT_FATAL placement and reworking sequential ifs in logic
Commit 2:
  memory allocation reworked. std::vector.reserve used instead of copying and reallocation.
Commit 3:
transpose: make get_dynamic_runtime_args O(1) for HC sharded (#48928)
TransposeDeviceOperation::get_dynamic_runtime_args runs on every dispatch
that hits the program cache. For the HC-sharded RM factory it called a full
per-core runtime-args builder for core 0 and then discarded everything
except reader arg 0, a single uint32_t. Building that one value walked a
shard_height-iteration stick-offset loop (224 for ResNet50 batch 16), issued
num_cores_x + num_cores_y worker_core_from_logical_core() lookups, filled
several scratch vectors and heap-allocated a vector<pair<vector, vector>>
that was freed immediately after one scalar was read.
Reader arg 0 does not depend on the per-core loop state, so extract it into
two closed-form helpers and have both the per-core builders and the fast
path read from them. That removes the loop from the per-dispatch path rather
than making its allocations cheaper, and keeps one definition so the rebuild
path and the cache-hit path cannot drift. The special-case helper computes H
from padded_shape() to match the builder; the is_special_case predicate is
evaluated on logical_shape() at the call sites and the two differ for a
padded shard.


### Notes for reviewers
* commit 1 is ambivalent - nonetheless, it makes code faster (a little)
* commit 2 is improvement. (code is faster for first run for specific cases, since later it will work in cached branch)
* commit 3 is essential:
Measured on 1x Blackhole p150a, Release (clang++-20, -O3), against main
(95f6851b8bf) with the two builds interleaved per round: host dispatch cost
for a ResNet50-shaped ROW_MAJOR height-sharded transpose(1,2) on a warm
program cache drops 77.14 us -> 73.21 us, -5.10% (Welch p < 0.0001, 95% CI
[-6.64%, -4.54%], 70 samples per variant; faster in 10 of 10 rounds, paired
mean -5.25%). Five control cases that select a different program factory
stay within +-0.3% with no significant movement, and the same cases under
NO_DISPATCH graph capture -- where the fast path is never reached -- show no
improvement, so the win comes from the edited code and not from drift.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/48928_perf_try)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/48928_perf_try)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/48928_perf_try)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/48928_perf_try)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/48928_perf_try)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/48928_perf_try)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=AlexeyZaytsev-epam/48928_perf_try)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:AlexeyZaytsev-epam/48928_perf_try)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/48928_perf_try)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:AlexeyZaytsev-epam/48928_perf_try)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=AlexeyZaytsev-epam/48928_perf_try)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:AlexeyZaytsev-epam/48928_perf_try)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=AlexeyZaytsev-epam/48928_perf_try)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:AlexeyZaytsev-epam/48928_perf_try)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=AlexeyZaytsev-epam/48928_perf_try)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:AlexeyZaytsev-epam/48928_perf_try)