### PR TITLE
Fix moe_routing_remap expert_parallel_size vs mesh-axis validation 

### DIFF
--- a/models/demos/gpt_oss/config.py
+++ b/models/demos/gpt_oss/config.py
@@ -87,6 +87,14 @@ class MeshConfig:
         if config.tp > tp_dim_size:
             raise ValueError(f"{mode.value}: TP({config.tp}) > mesh_{self.tp_axis}_size({tp_dim_size})")
 
+        # EP>1 makes the expert dimension sharded across ep_axis, and ttnn.moe_routing_remap
+        # requires expert_parallel_size to equal that axis extent exactly. Catch it here rather
+        # than as a device-side TT_FATAL mid-forward. EP=1 is unconstrained: prefill runs EP=1
+        # on multi-row meshes and never reaches the remap.
+        ep_dim_size = self.mesh_shape[self.ep_axis]
+        if config.ep > 1 and config.ep != ep_dim_size:
+            raise ValueError(f"{mode.value}: EP({config.ep}) != mesh_{self.ep_axis}_size({ep_dim_size})")
+
     def get_config(self, mode: Mode) -> ModeConfig:
         """Type-safe mode config access"""
         return self.decode if mode == Mode.DECODE else self.prefill

--- a/models/demos/gpt_oss/tests/unit/test_expert_parallel_config.py
+++ b/models/demos/gpt_oss/tests/unit/test_expert_parallel_config.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 """Host-only regressions for expert-parallel / mesh-axis agreement.

--- a/models/demos/gpt_oss/tests/unit/test_expert_parallel_config.py
+++ b/models/demos/gpt_oss/tests/unit/test_expert_parallel_config.py
@@ -1,0 +1,118 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Host-only regressions for expert-parallel / mesh-axis agreement.
+
+``ttnn.moe_routing_remap`` requires ``expert_parallel_size == mesh_shape[cluster_axis]``.
+Two places have to hold that up: ``MeshConfig`` must not accept an EP that disagrees with
+its own ``ep_axis``, and the decode expert path must forward the configured EP and axis
+instead of hardcoded literals. Neither needs a device to check.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from models.demos.gpt_oss.config import MeshConfig, ModeConfig, mesh_1x8, mesh_2x4, mesh_4x4, mesh_4x8
+from models.demos.gpt_oss.tt.experts.config import ExpertConfig
+from models.demos.gpt_oss.tt.experts.decode import decode_forward
+
+
+class _RemapCallCaptured(Exception):
+    """Unwinds decode_forward once the call under test has been recorded."""
+
+    def __init__(self, args, kwargs):
+        super().__init__("captured moe_routing_remap call")
+        self.captured_args = args
+        self.captured_kwargs = kwargs
+
+
+@pytest.mark.parametrize(
+    "mesh_config_factory, expected_ep",
+    [
+        # 2x4 is the mesh the old hardcoded (nnz=4, ep=4, axis=0) call broke on: it declared
+        # 4 partitions while running on 2 rows, and now trips the live mesh-axis TT_FATAL.
+        (mesh_2x4, 2),
+        # 4x8/4x4 are where the hardcoded literals happened to be right; asserting them here
+        # pins that this change is a no-op on the meshes gpt_oss runs on today.
+        (mesh_4x8, 4),
+        (mesh_4x4, 4),
+    ],
+    ids=["mesh_2x4", "mesh_4x8", "mesh_4x4"],
+)
+def test_decode_forward_forwards_configured_ep_and_axis(mesh_config_factory, expected_ep):
+    """decode_forward must pass the configured EP and ep_axis to moe_routing_remap.
+
+    Reverting either argument to a literal leaves the operator-level tests green, so assert
+    the arguments directly. ttnn is patched out, which stops the forward at the call we care
+    about and keeps this runnable without a device.
+    """
+    mesh_config = mesh_config_factory()
+    assert expected_ep == mesh_config.mesh_shape[mesh_config.ep_axis]
+
+    config = ExpertConfig(
+        intermediate_size=64,
+        num_experts=32,
+        hidden_size=64,
+        num_experts_per_tok=4,
+        swiglu_limit=7.0,
+    )
+    reshaped_sparsity = object()
+
+    with patch("models.demos.gpt_oss.tt.experts.decode.ttnn") as mock_ttnn:
+        mock_ttnn.reshape.return_value = reshaped_sparsity
+
+        def capture(*args, **kwargs):
+            raise _RemapCallCaptured(args, kwargs)
+
+        mock_ttnn.moe_routing_remap.side_effect = capture
+
+        with pytest.raises(_RemapCallCaptured) as exc_info:  # allow-pytest.raises: control-flow sentinel
+            decode_forward(
+                hidden_states=SimpleNamespace(shape=[1, 1, 1, config.hidden_size]),
+                routing_weights=MagicMock(),
+                weights=MagicMock(),
+                config=config,
+                mesh_config=mesh_config,
+                mesh_device=MagicMock(),
+                ccl_manager=MagicMock(),
+                program_config=MagicMock(),
+            )
+
+    assert exc_info.value.captured_args == (
+        reshaped_sparsity,
+        config.num_experts_per_tok,
+        expected_ep,
+        mesh_config.ep_axis,
+    )
+    assert exc_info.value.captured_kwargs == {}
+
+
+def test_mesh_config_rejects_ep_not_matching_ep_axis(expect_error):
+    """EP must agree with its own axis at construction, not as a TT_FATAL mid-forward.
+
+    tp x dp x ep == total_devices and tp <= mesh_shape[tp_axis] both pass here, so before
+    the EP check this config built fine and then hard-failed inside moe_routing_remap on the
+    first decode step.
+    """
+    with expect_error(ValueError, r"decode: EP\(2\) != mesh_0_size\(4\)"):
+        MeshConfig((4, 8), decode=ModeConfig(tp=8, ep=2))
+
+
+@pytest.mark.parametrize(
+    "mesh_config_factory",
+    [mesh_1x8, mesh_2x4, mesh_4x4, mesh_4x8],
+    ids=["mesh_1x8", "mesh_2x4", "mesh_4x4", "mesh_4x8"],
+)
+def test_mesh_config_factories_satisfy_ep_axis_constraint(mesh_config_factory):
+    """The EP check must not reject any shipped config.
+
+    Prefill runs EP=1 on multi-row meshes and never reaches the remap, so EP=1 stays
+    unconstrained; only EP>1 has to match the axis extent.
+    """
+    mesh_config = mesh_config_factory()
+    ep_dim_size = mesh_config.mesh_shape[mesh_config.ep_axis]
+
+    for mode_config in (mesh_config.decode, mesh_config.prefill):
+        assert mode_config.ep == 1 or mode_config.ep == ep_dim_size

--- a/models/demos/gpt_oss/tt/experts/decode.py
+++ b/models/demos/gpt_oss/tt/experts/decode.py
@@ -58,7 +58,9 @@ def decode_forward(
 
     # EP-specific routing remap for sparsity
     if ep > 1:
-        sparsity = ttnn.moe_routing_remap(ttnn.reshape(sparsity, (1, sparsity.shape[-1])), 4, 4, 0)
+        sparsity = ttnn.moe_routing_remap(
+            ttnn.reshape(sparsity, (1, sparsity.shape[-1])), config.num_experts_per_tok, ep, 0
+        )
         routing_weights = ttnn.tilize_with_zero_padding(sparsity, use_multicore=True)
 
     num_experts_per_tok = config.num_experts_per_tok // ep

--- a/models/demos/gpt_oss/tt/experts/decode.py
+++ b/models/demos/gpt_oss/tt/experts/decode.py
@@ -59,7 +59,10 @@ def decode_forward(
     # EP-specific routing remap for sparsity
     if ep > 1:
         sparsity = ttnn.moe_routing_remap(
-            ttnn.reshape(sparsity, (1, sparsity.shape[-1])), config.num_experts_per_tok, ep, 0
+            ttnn.reshape(sparsity, (1, sparsity.shape[-1])),
+            config.num_experts_per_tok,
+            ep,
+            mesh_config.ep_axis,
         )
         routing_weights = ttnn.tilize_with_zero_padding(sparsity, use_multicore=True)
 

--- a/tests/nightly/t3000/ccl/test_moe_routing_remap.py
+++ b/tests/nightly/t3000/ccl/test_moe_routing_remap.py
@@ -136,3 +136,77 @@ def test_gen_tensors(mesh_device, non_zero_size, expert_parallel_size, num_clust
             idx = tuple(i[1] for i in idx.tolist())
             idxs.add(idx)
         assert len(idxs) == 1
+
+
+@pytest.mark.parametrize("mesh_device", [(2, 4)], indirect=["mesh_device"])
+@pytest.mark.parametrize(
+    "cluster_axis, invalid_expert_parallel_size",
+    [
+        # Issue #51214 bug 11: on main the TT_FATAL parsed as
+        # (expert_parallel_size == (cluster_axis == 0)) ? num_cols : num_rows,
+        # so mismatched sizes were never rejected. A 2x4 mesh has 2 rows / 4 cols.
+        # Use sizes that divide num_cluster_experts=32 so we reach the mesh-axis check
+        # (not the earlier "evenly divisible by cluster" TT_FATAL).
+        (0, 4),  # axis 0 = rows (size 2), 4 != 2
+        (1, 2),  # axis 1 = cols (size 4), 2 != 4
+    ],
+    ids=["cluster_axis0_rows", "cluster_axis1_cols"],
+)
+def test_moe_routing_remap_rejects_mismatched_expert_parallel_size(
+    mesh_device, cluster_axis, invalid_expert_parallel_size, expect_error
+):
+    """Regression for #51214 item 11: expert_parallel_size must match the cluster axis extent.
+
+    On main the validation TT_FATAL is dead code due to operator precedence, so this call
+    silently runs with a bogus per-device partition. With the fix it must fail loudly.
+    """
+    mesh_shape = tuple(mesh_device.shape)
+    assert invalid_expert_parallel_size != mesh_shape[cluster_axis]
+
+    routing_weights_torch = _gen_input_routing_weights(non_zero_size=8, num_cluster_experts=32)
+    tt_routing_weights = ttnn.from_torch(
+        routing_weights_torch,
+        device=mesh_device,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        dtype=ttnn.bfloat16,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+    )
+
+    with expect_error(RuntimeError, "expert parallel size .* should be the same as size of cluster axis"):
+        ttnn.moe_routing_remap(
+            tt_routing_weights,
+            non_zero_weight_size=8,
+            expert_parallel_size=invalid_expert_parallel_size,
+            cluster_axis=cluster_axis,
+        )
+
+
+@pytest.mark.parametrize("mesh_device", [(2, 4)], indirect=["mesh_device"])
+@pytest.mark.parametrize("cluster_axis", [0, 1])
+def test_moe_routing_remap_accepts_matching_expert_parallel_size(mesh_device, cluster_axis):
+    """Companion to the rejection test: the tightened check must not reject legal sizes.
+
+    The happy-path test above pytest.skips on mismatch, so without this there is no assertion
+    that expert_parallel_size == cluster-axis extent is still accepted after the fix.
+    """
+    mesh_shape = tuple(mesh_device.shape)
+    expert_parallel_size = mesh_shape[cluster_axis]
+
+    routing_weights_torch = _gen_input_routing_weights(non_zero_size=8, num_cluster_experts=32)
+    tt_routing_weights = ttnn.from_torch(
+        routing_weights_torch,
+        device=mesh_device,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        dtype=ttnn.bfloat16,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+    )
+
+    tt_output = ttnn.moe_routing_remap(
+        tt_routing_weights,
+        non_zero_weight_size=8,
+        expert_parallel_size=expert_parallel_size,
+        cluster_axis=cluster_axis,
+    )
+    assert tt_output.shape == tt_routing_weights.shape

--- a/tests/nightly/t3000/ccl/test_moe_routing_remap.py
+++ b/tests/nightly/t3000/ccl/test_moe_routing_remap.py
@@ -240,14 +240,41 @@ def test_moe_routing_remap_rejects_zero_expert_parallel_size(mesh_device, expect
 
 
 @pytest.mark.parametrize("mesh_device", [(2, 4)], indirect=["mesh_device"])
-def test_moe_routing_remap_gpt_oss_decode_call_on_2x4(mesh_device):
-    """Covers the corrected gpt_oss decode call pattern on a 2x4 mesh.
+def test_moe_routing_remap_rejects_zero_non_zero_weight_size(mesh_device, expect_error):
+    """Regression for the non_zero_weight_size > 0 guard.
 
-    decode.py previously hardcoded (nnz=4, ep=4, axis=0). On a 2-row mesh that is now
-    rejected by the live mesh-axis check. The fixed caller uses
-    (config.num_experts_per_tok=4, ep=mesh_shape[0]=2, mesh_config.ep_axis=0). This test
-    executes that exact call and checks per-device outputs against the torch reference —
-    catching a revert of either ep or axis without requiring the full GPT-OSS module suite.
+    nnz=0 satisfies both `<= num_cluster_experts` and `0 % eps == 0`, so without an explicit
+    guard it reaches the program factory as non_zero_per_device=0 and builds the c_1 index CB
+    with a zero page size and total size.
+    """
+    routing_weights_torch = _gen_input_routing_weights(non_zero_size=8, num_cluster_experts=32)
+    tt_routing_weights = ttnn.from_torch(
+        routing_weights_torch,
+        device=mesh_device,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        dtype=ttnn.bfloat16,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+    )
+
+    with expect_error(RuntimeError, "Number of non zero weights must be non-zero"):
+        ttnn.moe_routing_remap(
+            tt_routing_weights,
+            non_zero_weight_size=0,
+            expert_parallel_size=2,
+            cluster_axis=0,
+        )
+
+
+@pytest.mark.parametrize("mesh_device", [(2, 4)], indirect=["mesh_device"])
+def test_moe_routing_remap_gpt_oss_decode_call_on_2x4(mesh_device):
+    """Numeric coverage of the gpt_oss decode argument triple on a 2x4 mesh.
+
+    decode.py previously hardcoded (nnz=4, ep=4, axis=0), which the live mesh-axis check now
+    rejects on a 2-row mesh; the fixed caller produces (nnz=4, ep=2, axis=0). This asserts
+    that triple routes correctly on device. That decode.py actually passes those values is a
+    separate, host-only assertion in
+    models/demos/gpt_oss/tests/unit/test_expert_parallel_config.py.
     """
     mesh_shape = tuple(mesh_device.shape)
     assert mesh_shape == (2, 4)

--- a/tests/nightly/t3000/ccl/test_moe_routing_remap.py
+++ b/tests/nightly/t3000/ccl/test_moe_routing_remap.py
@@ -183,15 +183,16 @@ def test_moe_routing_remap_rejects_mismatched_expert_parallel_size(
 
 
 @pytest.mark.parametrize("mesh_device", [(2, 4)], indirect=["mesh_device"])
-@pytest.mark.parametrize("cluster_axis", [0, 1])
-def test_moe_routing_remap_accepts_matching_expert_parallel_size(mesh_device, cluster_axis):
-    """Companion to the rejection test: the tightened check must not reject legal sizes.
+def test_moe_routing_remap_rejects_non_divisible_non_zero_weight_size(mesh_device, expect_error):
+    """Regression for the non_zero_weight_size % expert_parallel_size guard.
 
-    The happy-path test above pytest.skips on mismatch, so without this there is no assertion
-    that expert_parallel_size == cluster-axis extent is still accepted after the fix.
+    The program factory integer-divides these (`non_zero_per_device = nnz / ep`); without the
+    check a remainder is silently truncated. Use a matching axis size (rows=2) so we reach this
+    TT_FATAL rather than the mesh-axis mismatch check.
     """
-    mesh_shape = tuple(mesh_device.shape)
-    expert_parallel_size = mesh_shape[cluster_axis]
+    cluster_axis = 0
+    expert_parallel_size = 2  # matches mesh rows
+    non_zero_weight_size = 3  # 3 % 2 != 0
 
     routing_weights_torch = _gen_input_routing_weights(non_zero_size=8, num_cluster_experts=32)
     tt_routing_weights = ttnn.from_torch(
@@ -203,10 +204,82 @@ def test_moe_routing_remap_accepts_matching_expert_parallel_size(mesh_device, cl
         mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
     )
 
-    tt_output = ttnn.moe_routing_remap(
-        tt_routing_weights,
-        non_zero_weight_size=8,
-        expert_parallel_size=expert_parallel_size,
+    with expect_error(RuntimeError, "Number of non zero weights .* must be evenly divisible by expert parallel size"):
+        ttnn.moe_routing_remap(
+            tt_routing_weights,
+            non_zero_weight_size=non_zero_weight_size,
+            expert_parallel_size=expert_parallel_size,
+            cluster_axis=cluster_axis,
+        )
+
+
+@pytest.mark.parametrize("mesh_device", [(2, 4)], indirect=["mesh_device"])
+def test_moe_routing_remap_rejects_zero_expert_parallel_size(mesh_device, expect_error):
+    """Regression for expert_parallel_size > 0 guard ordering.
+
+    Without this check, `num_cluster_experts % expert_parallel_size` with eps=0 is a SIGFPE
+    rather than a catchable RuntimeError. The guard must run before any modulo on eps.
+    """
+    routing_weights_torch = _gen_input_routing_weights(non_zero_size=8, num_cluster_experts=32)
+    tt_routing_weights = ttnn.from_torch(
+        routing_weights_torch,
+        device=mesh_device,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        dtype=ttnn.bfloat16,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+    )
+
+    with expect_error(RuntimeError, "expert parallel size must be non-zero"):
+        ttnn.moe_routing_remap(
+            tt_routing_weights,
+            non_zero_weight_size=8,
+            expert_parallel_size=0,
+            cluster_axis=0,
+        )
+
+
+@pytest.mark.parametrize("mesh_device", [(2, 4)], indirect=["mesh_device"])
+def test_moe_routing_remap_gpt_oss_decode_call_on_2x4(mesh_device):
+    """Covers the corrected gpt_oss decode call pattern on a 2x4 mesh.
+
+    decode.py previously hardcoded (nnz=4, ep=4, axis=0). On a 2-row mesh that is now
+    rejected by the live mesh-axis check. The fixed caller uses
+    (config.num_experts_per_tok=4, ep=mesh_shape[0]=2, mesh_config.ep_axis=0). This test
+    executes that exact call and checks per-device outputs against the torch reference —
+    catching a revert of either ep or axis without requiring the full GPT-OSS module suite.
+    """
+    mesh_shape = tuple(mesh_device.shape)
+    assert mesh_shape == (2, 4)
+
+    # Mirrors gpt_oss decode: num_experts_per_tok=4, ep=rows, cluster_axis=ep_axis=0
+    non_zero_weight_size = 4
+    expert_parallel_size = mesh_shape[0]
+    cluster_axis = 0
+
+    routing_weights_torch, reference_outputs_torch = _gen_tensors(
+        non_zero_weight_size,
+        expert_parallel_size,
+        num_cluster_experts=32,
+        mesh_shape=mesh_shape,
         cluster_axis=cluster_axis,
     )
-    assert tt_output.shape == tt_routing_weights.shape
+    tt_routing_weights = ttnn.from_torch(
+        routing_weights_torch,
+        device=mesh_device,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        dtype=ttnn.bfloat16,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+    )
+
+    tt_output = ttnn.moe_routing_remap(
+        tt_routing_weights,
+        non_zero_weight_size,
+        expert_parallel_size,
+        cluster_axis,
+    )
+    tt_outputs = ttnn.get_device_tensors(tt_output)
+    assert len(tt_outputs) == len(reference_outputs_torch)
+    for test, ref in zip(tt_outputs, reference_outputs_torch):
+        assert_with_pcc(ttnn.to_torch(test), ref)

--- a/ttnn/cpp/ttnn/operations/data_movement/moe_routing_remap/device/moe_routing_remap_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/moe_routing_remap/device/moe_routing_remap_device_operation.cpp
@@ -23,6 +23,9 @@ void MoeRoutingRemapDeviceOperation::validate_on_program_cache_miss(
         input_routing_weights_shape.rank() == 2 && input_routing_weights_shape[0] == 1, "expected input shape [1,E]");
     const auto num_cluster_experts = input_routing_weights_shape[1];
 
+    // A zero count reaches the factory as non_zero_per_device == 0, which builds the c_1 index CB
+    // with a zero page size and total size instead of failing here.
+    TT_FATAL(operation_attributes.non_zero_weight_size > 0, "Number of non zero weights must be non-zero");
     TT_FATAL(
         operation_attributes.non_zero_weight_size <= num_cluster_experts,
         "Number of non Zero weights must be less than or equal to weights");

--- a/ttnn/cpp/ttnn/operations/data_movement/moe_routing_remap/device/moe_routing_remap_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/moe_routing_remap/device/moe_routing_remap_device_operation.cpp
@@ -28,15 +28,30 @@ void MoeRoutingRemapDeviceOperation::validate_on_program_cache_miss(
         "Number of non Zero weights must be less than or equal to weights");
 
     const auto& expert_parallel_size = operation_attributes.expert_parallel_size;
-    TT_FATAL(num_cluster_experts % expert_parallel_size == 0, "Number of experts must be evenly divisible by cluster");
+    TT_FATAL(expert_parallel_size > 0, "expert parallel size must be non-zero");
+    TT_FATAL(
+        num_cluster_experts % expert_parallel_size == 0,
+        "Number of experts ({}) must be evenly divisible by cluster ({})",
+        num_cluster_experts,
+        expert_parallel_size);
+    // The program factory divides these to get non_zero_per_device; a remainder would be truncated.
+    TT_FATAL(
+        operation_attributes.non_zero_weight_size % expert_parallel_size == 0,
+        "Number of non zero weights ({}) must be evenly divisible by expert parallel size ({})",
+        operation_attributes.non_zero_weight_size,
+        expert_parallel_size);
 
     const auto cluster_axis = operation_attributes.cluster_axis;
     TT_FATAL(cluster_axis == 0 || cluster_axis == 1, "Invalid cluster axis, should be 0 (rows), or 1 (cols)");
 
     const auto mesh_view = input_routing_weights.device()->get_view();
+    const auto cluster_axis_size = (cluster_axis == 0) ? mesh_view.num_rows() : mesh_view.num_cols();
     TT_FATAL(
-        expert_parallel_size == (cluster_axis == 0) ? mesh_view.num_cols() : mesh_view.num_rows(),
-        "expert parallel size should be the same as size of cluster axis");
+        expert_parallel_size == cluster_axis_size,
+        "expert parallel size ({}) should be the same as size of cluster axis {} ({})",
+        expert_parallel_size,
+        cluster_axis,
+        cluster_axis_size);
 
     const auto& optional_output_routing_weights = tensor_args.optional_output_routing_weights;
     if (optional_output_routing_weights.has_value()) {

--- a/ttnn/cpp/ttnn/operations/data_movement/moe_routing_remap/moe_routing_remap_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/moe_routing_remap/moe_routing_remap_nanobind.cpp
@@ -39,7 +39,7 @@ Args:
     routing_weights_tensor (ttnn.Tensor): tensor of weights for selected experts, replicated on all devices `[1, total_experts]`
     non_zero_weight_size (integer): Total number of selected experts, non-zero weights in routing_weights_tensor.
     expert_parallel_size (integer): Number of devices in a cluster.
-    cluster_axis (integer): Device mesh axis of cluster, 0: columns, 1: rows.
+    cluster_axis (integer): Device mesh axis of cluster, 0: rows, 1: columns.
 
 Keyword Args:
     memory_config (ttnn.MemoryConfig, optional): Optional memory configuration for the output. Defaults to `None`.


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/tt-metal/issues/51757,  #51860

## Summary
- Fixes operator-precedence bug in `MoeRoutingRemapDeviceOperation` validation: `==` bound tighter than `?:`, so the `TT_FATAL` condition was always a non-zero mesh dimension and never rejected bad `expert_parallel_size`.
- Hoists the mesh extent into a named local (`cluster_axis_size`) with fmt args, matching precedent sites and making the precedence bug structurally hard to reintroduce. Also maps `cluster_axis == 0` → `num_rows()` (was swapped).
- Adds `expert_parallel_size > 0` (before the modulo, so `eps=0` raises instead of SIGFPE) and `non_zero_weight_size % expert_parallel_size == 0` (factory integer-divides these and truncated).
- Updates `gpt_oss` decode caller from hardcoded `(..., 4, 4, 0)` to `(config.num_experts_per_tok, ep, mesh_config.ep_axis)`.
- Adds a rejection regression test for mismatched `expert_parallel_size` vs cluster-axis extent.

## gpt_oss caller impact (`num_experts_per_tok=4`, `ep = mesh_shape[0]`)

| mesh | rows | ep | old call | new call | effect |
|------|------|----|----------|----------|--------|
| (4,8) Galaxy | 4 | 4 | `(4, 4, 0)` | `(4, 4, 0)` | identical |
| (4,4) | 4 | 4 | `(4, 4, 0)` | `(4, 4, 0)` | identical |
| (1,x) | 1 | 1 | not reached | not reached | — |
| (2,4) | 2 | 2 | `(4, 4, 0)` → would now fatal | `(4, 2, 0)` → passes | fixes silent misroute |

Byte-identical on every mesh gpt_oss is exercised on today; only differs on 2-row meshes, which previously declared 4 partitions while running with 2.

### Pipeline status

- [x] Sanity
- [x] (Runtime) Sanity Test
- [x] BHPC
- [x] Nightly for all categories
- [x] All model test
- [x] Single card
- [x] T3K
- [x] Galaxy

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=virdhatchani/fix-moe-routing-remap-expert-parallel-validation)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:virdhatchani/fix-moe-routing-remap-expert-parallel-validation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=virdhatchani/fix-moe-routing-remap-expert-parallel-validation)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:virdhatchani/fix-moe-routing-remap-expert-parallel-validation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=virdhatchani/fix-moe-routing-remap-expert-parallel-validation)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:virdhatchani/fix-moe-routing-remap-expert-parallel-validation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=virdhatchani/fix-moe-routing-remap-expert-parallel-validation)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:virdhatchani/fix-moe-routing-remap-expert-parallel-validation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=virdhatchani/fix-moe-routing-remap-expert-parallel-validation)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:virdhatchani/fix-moe-routing-remap-expert-parallel-validation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=virdhatchani/fix-moe-routing-remap-expert-parallel-validation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:virdhatchani/fix-moe-routing-remap-expert-parallel-validation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=virdhatchani/fix-moe-routing-remap-expert-parallel-validation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:virdhatchani/fix-moe-routing-remap-expert-parallel-validation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=virdhatchani/fix-moe-routing-remap-expert-parallel-validation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:virdhatchani/fix-moe-routing-remap-expert-parallel-validation)