### PR TITLE
Fix the mock-migration deadlock, make the CI leg readable

### DIFF
--- a/models/demos/common/prefill/runners/prefill_runner.py
+++ b/models/demos/common/prefill/runners/prefill_runner.py
@@ -1067,6 +1067,18 @@ def _serve_request(runtime, kv_caches, mesh_device, hf_config, rank: int, num_ra
         # is OFF. One level deeper it was an elif of `if is_first_rank:`, so reaching it needed
         # _migration_enabled AND a non-first rank: unreachable in single-rank, and the runner then
         # entered the request loop having never published the table/device map its consumer waits on.
+        # Single-rank only, and loudly so. Dedenting it out of `if _migration_enabled:` also took it
+        # out of the pre-#48826 `if single_rank:` wrapper, so with num_ranks>1 every rank would build
+        # a table covering only ITS layer slice and publish over the same paths -- and co-located
+        # ranks would race serialize_device_map's `<path>.tmp` -> os.replace as well. Only the real
+        # migration path merges stages (deliver_device_map_and_gather_stage_layout), and that needs
+        # the worker. Same guard #48826 removed for PREFILL_ENABLE_MIGRATION, kept for the mock path.
+        if not single_rank:
+            raise ValueError(
+                f"PREFILL_MOCK_MIGRATION=1 is unsupported for num_ranks={num_ranks} (each rank would "
+                "publish a table covering only its own layer slice; a merged mock table is not "
+                "implemented); run single-rank or unset PREFILL_MOCK_MIGRATION."
+            )
         table_path = os.environ.get("PREFILL_MIGRATION_TABLE_PATH", "/tmp/prefill_kv_chunk_table.pb")
         runtime.build_kv_chunk_table(kv_caches, path=table_path)
         # Also publish the fabric_node -> ASIC unique_id device map so the producer can resolve chips

--- a/models/demos/common/prefill/runners/prefill_runner.py
+++ b/models/demos/common/prefill/runners/prefill_runner.py
@@ -1051,27 +1051,32 @@ def _serve_request(runtime, kv_caches, mesh_device, hf_config, rank: int, num_ra
                 table_path=table_path,
                 wait_ready_timeout_ms=wait_ready_ms,
             )
-        elif os.environ.get("PREFILL_MOCK_MIGRATION", "0") == "1":
-            # Mock integration (prefill_producer.py): serialize the KV chunk table so an external
-            # producer can read it back via ttnn.experimental.disaggregation.import_from_protobuf_file
-            # and locate each chunk — WITHOUT the migration_endpoint worker (no MigrationLayerClient,
-            # no WORKER_READY). One galaxy => one complete table spanning all NUM_LAYERS / NUM_USERS
-            # (both caches, merged, for a sparse model).
-            table_path = os.environ.get("PREFILL_MIGRATION_TABLE_PATH", "/tmp/prefill_kv_chunk_table.pb")
-            runtime.build_kv_chunk_table(kv_caches, path=table_path)
-            # Also publish the fabric_node -> ASIC unique_id device map so the producer can resolve chips
-            # for its device-less UMD read (read_dram_umd) without touching the ControlPlane.
-            device_map_path = os.environ.get("PREFILL_MIGRATION_DEVICE_MAP_PATH", "/tmp/prefill_kv_device_map.json")
-            serialize_device_map(mesh_device, device_map_path)
-            logger.info(
-                f"[mock-migration] KV chunk table -> {table_path}, device map -> {device_map_path} "
-                f"(no migration worker); prefill_producer can import them"
-            )
         else:
             logger.info(
                 f"[migration] rank {rank}: delivered local device map + contributed stage "
                 f"(first_layer={first_layer_idx}, count={num_my_layers}); rank 0 sends the merged table."
             )
+
+    elif os.environ.get("PREFILL_MOCK_MIGRATION", "0") == "1":
+        # Mock integration (prefill_producer.py): serialize the KV chunk table so an external
+        # producer can read it back via ttnn.experimental.disaggregation.import_from_protobuf_file
+        # and locate each chunk — WITHOUT the migration_endpoint worker (no MigrationLayerClient,
+        # no WORKER_READY). One galaxy => one complete table spanning all NUM_LAYERS / NUM_USERS
+        # (both caches, merged, for a sparse model).
+        # Sibling of `if _migration_enabled:` ON PURPOSE -- the mock path is what runs when migration
+        # is OFF. One level deeper it was an elif of `if is_first_rank:`, so reaching it needed
+        # _migration_enabled AND a non-first rank: unreachable in single-rank, and the runner then
+        # entered the request loop having never published the table/device map its consumer waits on.
+        table_path = os.environ.get("PREFILL_MIGRATION_TABLE_PATH", "/tmp/prefill_kv_chunk_table.pb")
+        runtime.build_kv_chunk_table(kv_caches, path=table_path)
+        # Also publish the fabric_node -> ASIC unique_id device map so the producer can resolve chips
+        # for its device-less UMD read (read_dram_umd) without touching the ControlPlane.
+        device_map_path = os.environ.get("PREFILL_MIGRATION_DEVICE_MAP_PATH", "/tmp/prefill_kv_device_map.json")
+        serialize_device_map(mesh_device, device_map_path)
+        logger.info(
+            f"[mock-migration] KV chunk table -> {table_path}, device map -> {device_map_path} "
+            f"(no migration worker); prefill_producer can import them"
+        )
 
     if single_rank and enable_layer_ack:
         # Direct path: the runtime owns + inject()s the scheduler counter channel.

--- a/models/demos/common/prefill/tests/test_producer_runner_e2e.py
+++ b/models/demos/common/prefill/tests/test_producer_runner_e2e.py
@@ -16,6 +16,7 @@ import os
 import signal
 import subprocess
 import sys
+import threading
 import time
 
 import pytest
@@ -27,8 +28,9 @@ NUM_LAYERS = int(os.environ.get("PREFILL_NUM_LAYERS", "2"))
 SERVICE_ID = "ci_ds_prefill"
 TABLE_PATH = "/tmp/ci_prefill_kv_table.pb"  # IPC rendezvous files; cleaned up around each scenario
 DEVMAP_PATH = "/tmp/ci_prefill_kv_devmap.json"
-# Logs live under generated/test_reports/ so the workflow's upload-artifact-with-job-uuid step
-# (path /work/generated/test_reports/, prefix "test_reports_") uploads them as a downloadable artifact.
+# Full logs are kept under generated/test_reports/ on the pod. NOTE: no workflow step uploads that
+# directory today (blaze-models-prefill-tests-impl.yaml only uploads PREFILL_SUMMARIES/**/*.md), so
+# in CI these files die with the pod -- what survives is the live stream (see _ChildStream below).
 _REPORT_DIR = os.path.join(os.environ.get("TT_METAL_HOME", os.getcwd()), "generated", "test_reports")
 
 _RUNNER_MODULE = "models.demos.common.prefill.runners.prefill_runner"
@@ -37,7 +39,10 @@ _PRODUCER_MODULE = "models.demos.common.prefill.runners.prefill_producer"
 _READY_TIMEOUT_S = int(os.environ.get("PREFILL_CI_RUNNER_READY_TIMEOUT_S", "1200"))  # 20 min for load + JIT
 _PRODUCER_TIMEOUT_S = int(os.environ.get("PREFILL_CI_PRODUCER_TIMEOUT_S", "900"))
 _LOG_TAIL_LINES = int(os.environ.get("PREFILL_CI_LOG_TAIL_LINES", "200"))
+_STREAM_LOGS = os.environ.get("PREFILL_CI_STREAM_LOGS", "1") == "1"  # live child output; see _ChildStream
+_HEARTBEAT_S = float(os.environ.get("PREFILL_CI_HEARTBEAT_S", "30"))
 _DESCRIPTOR = f"/dev/shm/tt_h2d_stream_service_{SERVICE_ID}.bin"
+_T0 = time.monotonic()
 
 # --- launch mode: standard (bare pytest) vs CI (under an MPI launcher) --------------------------
 # This test runs in one of two ways, and ONLY the child-process environment differs between them:
@@ -186,8 +191,8 @@ def _tail(path: str, n: int = _LOG_TAIL_LINES) -> str:
 
 def _emit_log_group(title: str, path: str, n: int = _LOG_TAIL_LINES) -> None:
     """Echo the tail of `path` to stdout so it shows inline in the GitHub Actions step log, wrapped in
-    a collapsible ::group:: when running under Actions. The FULL file is uploaded as an artifact
-    (generated/test_reports/), so this is only the bounded inline view."""
+    a collapsible ::group:: when running under Actions. Post-mortem fallback for PREFILL_CI_STREAM_LOGS=0;
+    with streaming on (the default) the whole log is already in the step log, so this is skipped."""
     if not os.path.exists(path):
         return
     in_gha = os.environ.get("GITHUB_ACTIONS") == "true"
@@ -195,6 +200,122 @@ def _emit_log_group(title: str, path: str, n: int = _LOG_TAIL_LINES) -> None:
     print(_tail(path, n), flush=True)
     if in_gha:
         print("::endgroup::", flush=True)
+
+
+# --- live child output --------------------------------------------------------------------------
+# Both children are launched detached with their output going into a file, so in CI the runner used
+# to be invisible until the post-mortem tail in `finally` -- and a step killed by the workflow's
+# `timeout-minutes` never reaches that tail, nor is generated/test_reports/ uploaded anywhere, so a
+# timed-out run yielded NOTHING about what the runner was doing. Each child's output is now pumped
+# onto this process's stdout line by line as it is produced (pytest.ini's addopts carry -s, so
+# nothing here is captured or deferred), which puts it in the CI step log while the test is still
+# running: the runner and the producer show up interleaved and tagged, and whatever was printed
+# before a kill survives the kill. Set PREFILL_CI_STREAM_LOGS=0 for the old file-only behaviour.
+def _elapsed() -> str:
+    return f"+{time.monotonic() - _T0:7.1f}s"
+
+
+class _ChildStream:
+    """One child's merged stdout+stderr, pumped by a daemon thread into `log_path` AND onto our own
+    stdout, tagged with `tag` and the elapsed test time.
+
+    The pump being a thread is what makes the runner visible while the main thread sits blocked in
+    the producer's wait: both children stream concurrently, and the tags tell them apart.
+    """
+
+    def __init__(self, tag: str, log_path: str):
+        self.tag = tag
+        self.log_path = log_path
+        self.lines = 0
+        self.last_output = time.monotonic()
+        self._thread = None
+
+    def start(self, proc: subprocess.Popen) -> "_ChildStream":
+        self._thread = threading.Thread(target=self._pump, args=(proc,), name=f"stream-{self.tag}", daemon=True)
+        self._thread.start()
+        return self
+
+    def _pump(self, proc: subprocess.Popen) -> None:
+        try:
+            log = open(self.log_path, "w", buffering=1)  # line-buffered, so the tail survives a SIGKILL
+        except OSError:
+            log = None
+        try:
+            for line in proc.stdout:  # text mode, line at a time; ends at child EOF
+                self.lines += 1
+                self.last_output = time.monotonic()
+                try:
+                    if log is not None:
+                        log.write(line)
+                    if _STREAM_LOGS:
+                        # Single write: a streamed line can't tear against the main thread's output.
+                        print(f"[{self.tag} {_elapsed()}] {line.rstrip()}\n", end="", flush=True)
+                except Exception:
+                    pass  # never stop draining -- the child blocks as soon as the 64K pipe fills
+        except Exception:
+            # Same reason: whatever went wrong reading the pipe, keep emptying it so that a child
+            # holding the mesh can never wedge on a full pipe. The log/stream just stops here.
+            with contextlib.suppress(Exception):
+                while proc.stdout.read(65536):
+                    pass
+        finally:
+            with contextlib.suppress(Exception):
+                proc.stdout.close()
+            if log is not None:
+                with contextlib.suppress(Exception):
+                    log.close()
+
+    def status(self) -> str:
+        return f"{self.tag}: {self.lines} lines, last output {time.monotonic() - self.last_output:.0f}s ago"
+
+    def finish(self, timeout: float = 30.0) -> None:
+        """Let the pump drain what is left in the pipe after the child exits, so the log is whole."""
+        if self._thread is not None:
+            self._thread.join(timeout=timeout)
+
+
+def _spawn(module: str, env: dict, stream: _ChildStream) -> subprocess.Popen:
+    """Launch a child with its output piped into `stream`. `-u` stops the child block-buffering 8K at
+    a time, which is what makes the stream live rather than arriving in bursts."""
+    proc = subprocess.Popen(
+        [sys.executable, "-u", "-m", module],
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        errors="replace",  # device logs are not guaranteed UTF-8; a decode error must not stop the pump
+        bufsize=1,
+    )
+    stream.start(proc)
+    return proc
+
+
+@contextlib.contextmanager
+def _heartbeat(note):
+    """Print `note()` every _HEARTBEAT_S for as long as the body runs, so a long wait can be told
+    apart from a hang. The runner logs only twice between launch and readiness (its banner, then the
+    descriptor), so the readiness wait is otherwise minutes of silence with the model load in it."""
+    stop = threading.Event()
+
+    def _beat() -> None:
+        while not stop.wait(_HEARTBEAT_S):
+            print(f"[e2e {_elapsed()}] {note()}", flush=True)
+
+    thread = threading.Thread(target=_beat, name="e2e-heartbeat", daemon=True)
+    thread.start()
+    try:
+        yield
+    finally:
+        stop.set()
+        thread.join(timeout=5)
+
+
+def _readiness_gates() -> str:
+    """Which of the three files the runner publishes to signal 'serving' are there yet."""
+    return " ".join(
+        f"{name}={'ok' if os.path.exists(path) else 'pending'}"
+        for name, path in (("descriptor", _DESCRIPTOR), ("kv_table", TABLE_PATH), ("device_map", DEVMAP_PATH))
+    )
 
 
 @contextlib.contextmanager
@@ -214,19 +335,23 @@ def _running_runner(tag: str, num_users: int, max_seq_len: int, **extra):
         )
     else:
         print("[producer-runner-e2e] launch mode=standard (bare pytest; children inherit env)", flush=True)
-    with open(log_path, "w") as log:
-        proc = subprocess.Popen([sys.executable, "-m", _RUNNER_MODULE], env=env, stdout=log, stderr=subprocess.STDOUT)
+    stream = _ChildStream("runner", log_path)
+    proc = _spawn(_RUNNER_MODULE, env, stream)
+    print(f"[e2e {_elapsed()}] runner [{tag}] launched (pid={proc.pid}); its output follows, tagged", flush=True)
     try:
         deadline = time.monotonic() + _READY_TIMEOUT_S
-        while not (os.path.exists(_DESCRIPTOR) and os.path.exists(TABLE_PATH) and os.path.exists(DEVMAP_PATH)):
-            if proc.poll() is not None:
-                raise RuntimeError(
-                    f"runner [{tag}] exited early (rc={proc.returncode}) during startup:\n{_tail(log_path)}"
-                )
-            if time.monotonic() > deadline:
-                raise TimeoutError(f"runner [{tag}] not ready within {_READY_TIMEOUT_S}s:\n{_tail(log_path)}")
-            time.sleep(2.0)
-        yield log_path
+        with _heartbeat(lambda: f"runner [{tag}] not ready yet: {_readiness_gates()} | {stream.status()}"):
+            while not (os.path.exists(_DESCRIPTOR) and os.path.exists(TABLE_PATH) and os.path.exists(DEVMAP_PATH)):
+                if proc.poll() is not None:
+                    stream.finish()
+                    raise RuntimeError(
+                        f"runner [{tag}] exited early (rc={proc.returncode}) during startup:\n{_tail(log_path)}"
+                    )
+                if time.monotonic() > deadline:
+                    raise TimeoutError(f"runner [{tag}] not ready within {_READY_TIMEOUT_S}s:\n{_tail(log_path)}")
+                time.sleep(2.0)
+        print(f"[e2e {_elapsed()}] runner [{tag}] ready ({_readiness_gates()}); starting producer", flush=True)
+        yield stream
     finally:
         if proc.poll() is None:
             proc.send_signal(signal.SIGINT)  # graceful; SIGKILL is the hard fallback
@@ -235,7 +360,9 @@ def _running_runner(tag: str, num_users: int, max_seq_len: int, **extra):
             except subprocess.TimeoutExpired:
                 proc.kill()
                 proc.wait(timeout=30)
-        _emit_log_group(f"runner log [{tag}]", log_path)  # inline tail; the artifact has the full log
+        stream.finish()
+        if not _STREAM_LOGS:  # otherwise it was already streamed live, line by line
+            _emit_log_group(f"runner log [{tag}]", log_path)
         _cleanup_ipc()
 
 
@@ -268,22 +395,30 @@ def test_producer_runner_pcc(scenario, tmp_path):
             trace_dir = str(tmp_path / "prompt_trace")
             _generate_prompt_trace(trace_dir, sc["isl"], sc["prompt_file"], model)
         trace_env["PREFILL_TRACE_DIR"] = trace_dir
-    with _running_runner(scenario, sc["users"], sc["max_seq_len"], **trace_env) as runner_log:
+    with _running_runner(scenario, sc["users"], sc["max_seq_len"], **trace_env) as runner_stream:
         env = _transport_env(
             sc["users"], sc["max_seq_len"], PREFILL_PRODUCER_CHECK_PCC="1", **trace_env, **sc["producer"]
         )
+        producer_stream = _ChildStream("producer", prod_log)
+
+        def _both_running() -> str:
+            return f"producer [{scenario}] running | {producer_stream.status()} | {runner_stream.status()}"
+
         try:
-            with open(prod_log, "w") as f:
-                result = subprocess.run(
-                    [sys.executable, "-m", _PRODUCER_MODULE],
-                    env=env,
-                    stdout=f,
-                    stderr=subprocess.STDOUT,
-                    timeout=_PRODUCER_TIMEOUT_S,
-                )
+            producer = _spawn(_PRODUCER_MODULE, env, producer_stream)
+            print(f"[e2e {_elapsed()}] producer [{scenario}] launched (pid={producer.pid})", flush=True)
+            with _heartbeat(_both_running):
+                try:
+                    returncode = producer.wait(timeout=_PRODUCER_TIMEOUT_S)
+                except subprocess.TimeoutExpired:
+                    producer.kill()  # match subprocess.run(timeout=...): kill, then surface the timeout
+                    producer.wait(timeout=30)
+                    raise
         finally:
-            _emit_log_group(f"producer log [{scenario}]", prod_log)  # inline tail; the artifact has the full log
-        assert result.returncode == 0, (
-            f"producer scenario {scenario!r} failed (rc={result.returncode}; PCC below threshold or error). "
-            f"See the grouped producer log above and the test_reports_* artifact. Runner tail:\n{_tail(runner_log)}"
+            producer_stream.finish()
+            if not _STREAM_LOGS:  # otherwise it was already streamed live, line by line
+                _emit_log_group(f"producer log [{scenario}]", prod_log)
+        assert returncode == 0, (
+            f"producer scenario {scenario!r} failed (rc={returncode}; PCC below threshold or error). "
+            f"See the [producer]-tagged output above in this step log. Runner tail:\n{_tail(runner_stream.log_path)}"
         )

--- a/models/demos/common/prefill/tests/test_producer_runner_e2e.py
+++ b/models/demos/common/prefill/tests/test_producer_runner_e2e.py
@@ -353,7 +353,8 @@ def _running_runner(tag: str, num_users: int, max_seq_len: int, **extra):
         print(f"[e2e {_elapsed()}] runner [{tag}] ready ({_readiness_gates()}); starting producer", flush=True)
         yield stream
     finally:
-        if proc.poll() is None:
+        died_rc = proc.poll()  # not None => the runner exited on its OWN, before our teardown signal
+        if died_rc is None:
             proc.send_signal(signal.SIGINT)  # graceful; SIGKILL is the hard fallback
             try:
                 proc.wait(timeout=120)
@@ -364,6 +365,12 @@ def _running_runner(tag: str, num_users: int, max_seq_len: int, **extra):
         if not _STREAM_LOGS:  # otherwise it was already streamed live, line by line
             _emit_log_group(f"runner log [{tag}]", log_path)
         _cleanup_ipc()
+        # A runner that died mid-run is a broken run, not a passing one, and nothing else makes the test
+        # red: the producer reads KV that is already in DRAM, PCCs it, and exits 0. Only a NONZERO
+        # self-exit counts, since with PREFILL_SEND_SHUTDOWN=1 the runner is *meant* to drain and exit 0;
+        # and only with no exception in flight, so a real failure from the body is never masked by this.
+        if died_rc not in (None, 0) and sys.exc_info()[0] is None:
+            raise RuntimeError(f"runner [{tag}] died mid-run (rc={died_rc}); results are not trustworthy")
 
 
 def _generate_prompt_trace(out_dir: str, isl: int, prompt_file: str, model: str) -> None:
@@ -420,5 +427,10 @@ def test_producer_runner_pcc(scenario, tmp_path):
                 _emit_log_group(f"producer log [{scenario}]", prod_log)
         assert returncode == 0, (
             f"producer scenario {scenario!r} failed (rc={returncode}; PCC below threshold or error). "
-            f"See the [producer]-tagged output above in this step log. Runner tail:\n{_tail(runner_stream.log_path)}"
+            f"See the [producer]-tagged output above in this step log."
+            # The runner tail is appended ONLY when the live stream is off. pytest renders an assertion
+            # message three times on failure -- the ::error annotation, the FAILURES section, and (via
+            # -rA in pytest.ini) the short test summary -- so with streaming on, a 200-line tail that is
+            # already in the log verbatim would land in it four times over, ~800 lines of pure noise.
+            + ("" if _STREAM_LOGS else f" Runner tail:\n{_tail(runner_stream.log_path)}")
         )

--- a/models/demos/common/prefill/tests/test_producer_runner_e2e.py
+++ b/models/demos/common/prefill/tests/test_producer_runner_e2e.py
@@ -244,14 +244,24 @@ class _ChildStream:
             for line in proc.stdout:  # text mode, line at a time; ends at child EOF
                 self.lines += 1
                 self.last_output = time.monotonic()
-                try:
-                    if log is not None:
+                # File and stdout fail INDEPENDENTLY on purpose. Sharing one try meant that once
+                # log.write() started failing (a full report volume, say), it raised before every
+                # later print() and silently took the live stream with it -- and the step log is
+                # exactly the view you still have when storage is the thing that broke. Neither may
+                # stop the drain either: the child blocks as soon as the 64K pipe fills.
+                if log is not None:
+                    try:
                         log.write(line)
-                    if _STREAM_LOGS:
+                    except Exception:
+                        with contextlib.suppress(Exception):
+                            log.close()
+                        log = None  # a broken handle is dropped, not retried once per remaining line
+                        with contextlib.suppress(Exception):
+                            print(f"[{self.tag}] file log stopped ({self.log_path}); stream continues", flush=True)
+                if _STREAM_LOGS:
+                    with contextlib.suppress(Exception):
                         # Single write: a streamed line can't tear against the main thread's output.
                         print(f"[{self.tag} {_elapsed()}] {line.rstrip()}\n", end="", flush=True)
-                except Exception:
-                    pass  # never stop draining -- the child blocks as soon as the 64K pipe fills
         except Exception:
             # Same reason: whatever went wrong reading the pipe, keep emptying it so that a child
             # holding the mesh can never wedge on a full pipe. The log/stream just stops here.
@@ -411,17 +421,22 @@ def test_producer_runner_pcc(scenario, tmp_path):
         def _both_running() -> str:
             return f"producer [{scenario}] running | {producer_stream.status()} | {runner_stream.status()}"
 
+        producer = None  # so the finally can tell "never spawned" from "spawned and still alive"
         try:
             producer = _spawn(_PRODUCER_MODULE, env, producer_stream)
             print(f"[e2e {_elapsed()}] producer [{scenario}] launched (pid={producer.pid})", flush=True)
             with _heartbeat(_both_running):
-                try:
-                    returncode = producer.wait(timeout=_PRODUCER_TIMEOUT_S)
-                except subprocess.TimeoutExpired:
-                    producer.kill()  # match subprocess.run(timeout=...): kill, then surface the timeout
-                    producer.wait(timeout=30)
-                    raise
+                returncode = producer.wait(timeout=_PRODUCER_TIMEOUT_S)  # raises TimeoutExpired
         finally:
+            # Reap on EVERY exit where the producer is still alive, not just our own timeout: a
+            # pytest-timeout signal or a Ctrl-C would otherwise leave it running, holding the transport
+            # into the next scenario. subprocess.run() guaranteed this (bare `except: kill`) and the
+            # rewrite has to as well. Kill BEFORE draining -- with a live pipe the pump is still blocked
+            # in its read, so finish() would burn its whole join timeout before we got here.
+            if producer is not None and producer.poll() is None:
+                producer.kill()
+                with contextlib.suppress(Exception):
+                    producer.wait(timeout=30)
             producer_stream.finish()
             if not _STREAM_LOGS:  # otherwise it was already streamed live, line by line
                 _emit_log_group(f"producer log [{scenario}]", prod_log)

--- a/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
+++ b/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
@@ -449,6 +449,7 @@
     export PREFILL_CI_PRODUCER_TIMEOUT_S=1800
     export PREFILL_CI_RUNNER_READY_TIMEOUT_S=1800
     export PREFILL_RUNNER_LAUNCH=ci
+    export LOGURU_LEVEL=INFO  # as every other prefill entry; keeps per-layer progress, drops per-op DEBUG
 
     mpirun --bind-to none --pernode --tag-output bash -lc '
       export OMP_NUM_THREADS=$(nproc)


### PR DESCRIPTION
### PR Category

Bug fix / CI

### Summary

The Kimi prefill runner leg in Blaze was burning its whole 30-minute step budget and getting killed, with a log that ended mid-run and never said what it had been waiting for. This PR fixes the bug that hung it, and reworks the e2e test so the next failure in this leg is diagnosable from the step log alone. Four changes, in descending order of how much they matter.

### 1. The bug: the mock publish could never run

Mock migration is the mode with no migration worker in the picture. The runner writes the KV chunk table and the fabric-node→ASIC device map to two files, and an external producer reads them back to find the caches in DRAM by itself. The e2e test treats those two files, plus the transport descriptor, as the signal that the runner is serving — so they are what everything downstream waits on.

The code that writes them sat in the wrong branch:

```python
if _migration_enabled:                    # PREFILL_ENABLE_MIGRATION=1
    ...                                   # collective: every rank delivers its device map
    if is_first_rank:
        ...                               # real migration: publish to the worker, wait WORKER_READY
    elif PREFILL_MOCK_MIGRATION == "1":   # <-- the mock publish lived here
        runtime.build_kv_chunk_table(...)
        serialize_device_map(...)
    else:
        ...                               # other ranks just log
```

Read the two conditions guarding it: migration has to be **enabled**, and this rank has to **not be rank 0**. Mock mode is precisely the case where migration is *disabled* — that is what makes it mock — and the leg runs a *single* rank, which is rank 0. Both guards were the inverse of the situation they were meant to catch, so the branch was dead code: with `PREFILL_ENABLE_MIGRATION` unset the outer `if` is skipped whole, and even with it set, a single rank means `is_first_rank` wins and the `elif` is never evaluated. It needed migration to be off and on at the same time.

Nothing errored, which is why this was invisible. The runner loaded the model, compiled, entered its request loop and reported healthy — having written neither file. The producer waited on files that were never coming, the test waited on the producer, and CI killed the step at 30 minutes. That is the entire timeout.

This is a regression, and the leg was green until it landed. Before #48826 the same `elif` was paired with the migration gate itself — *migration, else mock* — which is exactly right. That PR lifted the bring-up out of `if single_rank:` for pipeline parallelism and split it by rank, and the mock branch was left in place, so it re-attached to the new `if is_first_rank:` and ended up inside the block it used to be the alternative to. Its indentation never changed, only which `if` it belonged to, which is why the diff looks innocuous. So the fix below is a restoration of the old behaviour inside the new structure, not a new idea.

### The fix: pair the branch with what it is actually an alternative to

```python
if _migration_enabled:
    ...                                   # real migration, unchanged
elif PREFILL_MOCK_MIGRATION == "1":
    runtime.build_kv_chunk_table(...)     # same statements, moved out one level
    serialize_device_map(...)
```

Mock is an alternative to migration, not an alternative to being rank 0. The body is byte-identical; the diff is indentation plus a comment recording why the branch belongs at this level so it cannot drift back down. `main` has the same bug, so this unblocks the mock path in general, not just this CI leg.

### 2. Both children stream their output live

Runner and producer were launched detached with their output redirected into files under `generated/test_reports/`, which no workflow step uploads, and the only inline view was a bounded tail printed at teardown — code a step killed by `timeout-minutes` never reaches. So a timed-out run yielded nothing at all about the runner. Each child is now launched on a pipe and drained by a daemon thread that writes every line to both the log file and the test's own stdout, tagged with the child's name and the elapsed test time. The runner and producer interleave in the step log while the test is still running, and whatever was printed before a kill survives the kill. The thread keeps draining no matter what goes wrong, since a child that fills its 64K pipe would otherwise wedge while holding the mesh. `PREFILL_CI_STREAM_LOGS=0` restores the old file-only behaviour.

### 3. The two long waits report progress

Waiting for the runner to come up spans a model load plus JIT compile, during which the runner logs twice; the producer run is a similarly long silence. Both are now wrapped in a heartbeat that prints every 30 seconds which of the three rendezvous files exist yet, and how many lines each child has produced and how long since its last one. That is what separates "slow" from "hung", and it turns "the job is stuck" into "the runner published the descriptor but never the KV table".

### 4. A runner that dies mid-run now fails the test

Nothing used to make that red. The producer reads whatever KV is already resident in DRAM, PCCs it, and exits zero, so the test went green on a run that had actually broken. Teardown now distinguishes a runner that exited on its own from one we signalled, and raises on a nonzero self-exit — only when no real failure from the test body is already in flight, so a genuine PCC failure is never masked by it.

Also here: the teardown log dumps are gated off whenever streaming is on, since they re-print output that is already in the log verbatim, and the runner tail is dropped from the assertion message for the same reason — pytest renders that message three times on failure, so the tail was landing four times over. And the CI leg exports `LOGURU_LEVEL=INFO`, as every other prefill entry does, which keeps per-layer progress and drops per-op DEBUG.

### Testing

The leg now reaches the end of the run and reports a PCC verdict instead of dying at the step cap; several runs of `bh_sc1 / single_user_full_depth` (Kimi, 61 layers, 11×5120 tokens) have completed green at 13–14 minutes of test time.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nbabin/runner_test_debug)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nbabin/runner_test_debug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nbabin/runner_test_debug)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nbabin/runner_test_debug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=nbabin/runner_test_debug)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:nbabin/runner_test_debug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nbabin/runner_test_debug)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nbabin/runner_test_debug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nbabin/runner_test_debug)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nbabin/runner_test_debug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nbabin/runner_test_debug)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nbabin/runner_test_debug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nbabin/runner_test_debug)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nbabin/runner_test_debug)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nbabin/runner_test_debug)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nbabin/runner_test_debug)