### PR TITLE
emule: fix __emule_fabric_route_follow key truncation (uint32 -> uint64)

### DIFF
--- a/tt_metal/impl/emulation/emulated_program_runner.cpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.cpp
@@ -2285,21 +2285,28 @@ extern "C" void __emule_fabric_set_route_dir(
 // Carry a stamped route from a source header address to a destination when the header bytes are copied
 // (a worker staging a packet header into a forwarder relay slot). On silicon the routing fields ride inside
 // the header, so a byte copy carries them for free; emule keeps them in the address-keyed side-table, so the
-// copy must replicate the entry. No-op when src carries no route. src_key/dst_key are 0-based L1 offsets
-// (the fabric shim passes bridge_l1-relative offsets); widen through emule_route_key to match the set/read
-// sides. See tt-emule docs/fabric-ccl-emulation.md.
-extern "C" void __emule_fabric_route_follow(uint32_t src_key, uint32_t dst_key) {
-    emule_require_self(__func__);  // keys through __emule_self->bridge_l1 via emule_route_key
+// copy must replicate the entry. No-op when src carries no route. src_key/dst_key are FULL host-pointer
+// values (bridge_l1 + offset) in the same key space as the set/read sides — NOT bridge_l1-relative uint32
+// offsets (see the ABI note in the body for why the widening was removed). See tt-emule
+// docs/fabric-ccl-emulation.md.
+extern "C" void __emule_fabric_route_follow(uint64_t src_key, uint64_t dst_key) {
+    // src_key/dst_key are FULL host-pointer values (bridge_l1 + offset) — the same key space as
+    // emule_route_key and the set + teleport-read sides. They MUST be full 64-bit pointers, not
+    // bridge_l1-relative uint32 offsets: a forwarder's relay slot lives on a DIFFERENT core whose L1
+    // mmap can be >4 GB from the writer's bridge_l1, so (dst - writer_bridge_l1) overflows uint32 and
+    // mis-keys the copy → the forwarder's teleport lookup misses → kind UNSET → wrong-neighbor route
+    // → many-to-one converge deadlock (reduce_to_one column dimension). See tt-emule
+    // docs/fabric-ccl-emulation.md.
     if (src_key == dst_key) {
         return;
     }
     std::lock_guard<std::mutex> lk(g_route_meta_mu);
-    auto it = g_route_meta.find(emule_route_key(src_key));
+    auto it = g_route_meta.find(src_key);
     if (it == g_route_meta.end()) {
         return;  // src carries no route — not a packet-header copy; nothing to follow.
     }
     const EmuleRoute r = it->second;  // copy before the insert below can rehash/invalidate `it`.
-    g_route_meta[emule_route_key(dst_key)] = r;
+    g_route_meta[dst_key] = r;
 }
 
 // Fabric connection routes recorded host-side by append_fabric_connection_rt_args: for 1D the dst chip is


### PR DESCRIPTION
## What

Runner-side fix for the emule fabric route-follow key truncation (#166 / #72).

`__emule_fabric_route_follow` keyed `g_route_meta` by a `bridge_l1`-relative value cast to `uint32`. A forwarder's relay slot lives on a **different core** whose L1 mmap can be **>4 GB** from the writer's `bridge_l1`, so the cross-core delta overflowed `uint32` → the route was stored at a garbage key → the teleport lookup missed → `kind` UNSET → `__emule_fabric_neighbor` misroute → ReduceToOne many-to-one converge **deadlock** (composed-MoE, DeepSeek-V3 decoder layer).

Fix: take and key **full 64-bit host pointers** — the same key space as `emule_route_key` and the set + teleport-read sides.

## ABI coupling

The jit_hw caller decls + call sites change to `uint64` in **tt-emule-blaze#185**; the two land together via the tt-emule-blaze `tt-metal-pin.txt`. This is an emule-only runner file, so nothing in non-emule builds is affected.

## Supersedes

Replaces **#51516**, which targeted `emule-blaze-metal-fork` directly on the pre-uplift lineage. This lands on `main` (source of truth) per the main-first process; the fork then cherry-picks it.

## Verification

`test_deepseek_moe_catalog_models[blackhole-True-DeepSeek V3-fabric_2d]` → **PCC 0.9921** (reproduced the deadlock on the pre-fix build). Fabric resolve `kind=0` (UNSET / misrouted) went **22 → 0**; all sends now `kind=2` (correct 2D routing).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mkamran/2417-route-follow-uint64-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mkamran/2417-route-follow-uint64-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mkamran/2417-route-follow-uint64-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mkamran/2417-route-follow-uint64-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mkamran/2417-route-follow-uint64-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mkamran/2417-route-follow-uint64-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mkamran/2417-route-follow-uint64-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mkamran/2417-route-follow-uint64-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mkamran/2417-route-follow-uint64-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mkamran/2417-route-follow-uint64-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mkamran/2417-route-follow-uint64-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mkamran/2417-route-follow-uint64-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mkamran/2417-route-follow-uint64-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mkamran/2417-route-follow-uint64-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mkamran/2417-route-follow-uint64-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mkamran/2417-route-follow-uint64-main)