### PR TITLE
Reservation of memory for vector beforehand

### DIFF
--- a/tt_stl/tests/test_cleanup.cpp
+++ b/tt_stl/tests/test_cleanup.cpp
@@ -25,6 +25,7 @@ TEST(CleanupTest, Basic) {
 
 TEST(CleanupTest, MultipleCleanupsInOrder) {
     std::vector<int> log;
+    log.reserve(3);
     {
         auto cleanup1 = make_cleanup([&log]() { log.push_back(1); });
         auto cleanup2 = make_cleanup([&log]() { log.push_back(2); });

--- a/tt_stl/tests/test_hash.cpp
+++ b/tt_stl/tests/test_hash.cpp
@@ -230,7 +230,9 @@ TEST(CanonicalKeyTest, DistinguishesVectorBool) {
     // For each length 1..10, an all-true vector and an all-false vector (opposite at every index)
     // must encode differently.
     std::vector<bool> mixed_left;
+    mixed_left.reserve(10);
     std::vector<bool> mixed_right;
+    mixed_right.reserve(10);
     for (std::size_t len = 1; len <= 10; ++len) {
         const std::vector<bool> all_true(len, true);
         const std::vector<bool> all_false(len, false);

--- a/tt_stl/tt_stl/reflection.hpp
+++ b/tt_stl/tt_stl/reflection.hpp
@@ -1772,6 +1772,7 @@ template <typename T>
 struct from_json_t<std::vector<T>> {
     std::vector<T> operator()(const nlohmann::json& json_object) noexcept {
         std::vector<T> vector;
+        vector.reserve(json_object.size());
         for (const auto& element : json_object) {
             vector.push_back(from_json<T>(element));
         }


### PR DESCRIPTION
PR Cathegory:
memory work optimization
Summary:
Preallocate memory for further usage to avoid possible sequential reallocation.
Notes for reviewers:
NA