### PR TITLE
Reservation of memory for vector beforehand

### DIFF
--- a/ttnn/core/device_operation_detail.cpp
+++ b/ttnn/core/device_operation_detail.cpp
@@ -55,6 +55,7 @@ compute_output_placements_and_shape(const std::vector<std::reference_wrapper<con
     TT_FATAL(!tensors.empty(), "Cannot compute output placements and shape with no tensors");
 
     std::vector<std::reference_wrapper<const Tensor>> sharded_tensors;
+    sharded_tensors.reserve(tensors.size());
     for (const auto& tensor_ref : tensors) {
         if (!is_fully_replicated(tensor_ref.get())) {
             sharded_tensors.push_back(tensor_ref);
@@ -141,7 +142,7 @@ compute_output_placements_and_shape(const std::vector<std::reference_wrapper<con
             "Input tensors have different distribution ranks, only imputing output tensor topology with tensors that "
             "have the max distribution rank");
     }
-    return {result_placements, tt::tt_metal::distributed::MeshShape(result_strides)};
+    return {std::move(result_placements), tt::tt_metal::distributed::MeshShape(std::move(result_strides))};
 }
 
 // ─────────────────────────────────────────────────────────────────────
@@ -191,6 +192,7 @@ std::vector<MeshCoordinate> extract_tensor_coordinates_impl(
 
     const Tensor& first_tensor = tensors.front().get();
     std::vector<ttnn::MeshCoordinate> tensor_coordinates;
+    tensor_coordinates.reserve(first_tensor.device_storage().get_coords().size());
     std::transform(
         first_tensor.device_storage().get_coords().begin(),
         first_tensor.device_storage().get_coords().end(),
@@ -203,6 +205,7 @@ std::vector<MeshCoordinate> extract_tensor_coordinates_impl(
         const Tensor& tensor = tensor_ref.get();
         if (tensor.device_storage().get_coords().size() != tensor_coordinates.size()) {
             std::vector<ttnn::MeshCoordinate> tensor_mesh_coords;
+            tensor_mesh_coords.reserve(tensor.device_storage().get_coords().size());
             std::transform(
                 tensor.device_storage().get_coords().begin(),
                 tensor.device_storage().get_coords().end(),


### PR DESCRIPTION
PR Cathegory:
memory work optimization
Summary:
Preallocate memory for further usage to avoid possible sequential reallocation.
Notes for reviewers:
NA

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/memory_work_optimization_28)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/memory_work_optimization_28)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/memory_work_optimization_28)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/memory_work_optimization_28)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/memory_work_optimization_28)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/memory_work_optimization_28)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=AlexeyZaytsev-epam/memory_work_optimization_28)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:AlexeyZaytsev-epam/memory_work_optimization_28)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/memory_work_optimization_28)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:AlexeyZaytsev-epam/memory_work_optimization_28)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=AlexeyZaytsev-epam/memory_work_optimization_28)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:AlexeyZaytsev-epam/memory_work_optimization_28)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=AlexeyZaytsev-epam/memory_work_optimization_28)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:AlexeyZaytsev-epam/memory_work_optimization_28)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=AlexeyZaytsev-epam/memory_work_optimization_28)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:AlexeyZaytsev-epam/memory_work_optimization_28)