### PR TITLE
Reservation of memory for vector beforehand

### DIFF
--- a/ttnn/core/global_semaphore.cpp
+++ b/ttnn/core/global_semaphore.cpp
@@ -64,6 +64,7 @@ MultiDeviceGlobalSemaphore create_global_semaphore_with_same_address(
             auto& global_semaphore = multi_device_global_semaphore.global_semaphores[i];
             size_t attempt = 0;
             std::vector<GlobalSemaphore> garbage;
+            garbage.reserve(attempts);
             log_debug(tt::LogTTNN, "global_semaphore->address(): {}", get_global_semaphore_address(global_semaphore));
             while (get_global_semaphore_address(global_semaphore) != target_addr) {
                 auto sem = create_global_semaphore(device, cores, initial_value, buffer_type);

--- a/ttnn/core/global_semaphore.cpp
+++ b/ttnn/core/global_semaphore.cpp
@@ -64,7 +64,7 @@ MultiDeviceGlobalSemaphore create_global_semaphore_with_same_address(
             auto& global_semaphore = multi_device_global_semaphore.global_semaphores[i];
             size_t attempt = 0;
             std::vector<GlobalSemaphore> garbage;
-            garbage.reserve(attempts);
+            garbage.reserve(attempts + 1);
             log_debug(tt::LogTTNN, "global_semaphore->address(): {}", get_global_semaphore_address(global_semaphore));
             while (get_global_semaphore_address(global_semaphore) != target_addr) {
                 auto sem = create_global_semaphore(device, cores, initial_value, buffer_type);


### PR DESCRIPTION
PR Cathegory:
memory work optimization
Summary:
Preallocate memory for further usage to avoid possible sequential reallocation.
Notes for reviewers:
NA

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/memory_work_optimization_32)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/memory_work_optimization_32)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/memory_work_optimization_32)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/memory_work_optimization_32)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/memory_work_optimization_32)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/memory_work_optimization_32)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=AlexeyZaytsev-epam/memory_work_optimization_32)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:AlexeyZaytsev-epam/memory_work_optimization_32)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/memory_work_optimization_32)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:AlexeyZaytsev-epam/memory_work_optimization_32)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=AlexeyZaytsev-epam/memory_work_optimization_32)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:AlexeyZaytsev-epam/memory_work_optimization_32)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=AlexeyZaytsev-epam/memory_work_optimization_32)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:AlexeyZaytsev-epam/memory_work_optimization_32)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=AlexeyZaytsev-epam/memory_work_optimization_32)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:AlexeyZaytsev-epam/memory_work_optimization_32)