### PR TITLE
Reservation of memory for vector beforehand

### DIFF
--- a/ttnn/core/reports.cpp
+++ b/ttnn/core/reports.cpp
@@ -44,6 +44,7 @@ std::vector<BufferInfo> get_buffers(const std::vector<tt::tt_metal::distributed:
     std::vector<BufferInfo> buffer_infos;
     for (auto* device : devices) {
         const auto allocated_buffers = device->allocator()->get_allocated_buffers();
+        buffer_infos.reserve(buffer_infos.size() + allocated_buffers.size());
         // NOLINTNEXTLINE(bugprone-nondeterministic-pointer-iteration-order)
         for (const auto& buffer : allocated_buffers) {
             auto device_id = device->id();
@@ -113,6 +114,8 @@ std::vector<BufferPageInfo> get_buffer_pages(const std::vector<tt::tt_metal::dis
             auto num_pages = buffer->num_pages();
             auto num_banks = device->allocator()->get_num_banks(buffer->buffer_type());
             auto buffer_type = buffer->buffer_type();
+
+            buffer_page_infos.reserve(buffer_page_infos.size() + num_pages);
 
             if (is_sharded(buffer->buffer_layout())) {
                 const auto& buffer_page_mapping = *buffer->get_buffer_page_mapping();

--- a/ttnn/core/reports.cpp
+++ b/ttnn/core/reports.cpp
@@ -44,7 +44,11 @@ std::vector<BufferInfo> get_buffers(const std::vector<tt::tt_metal::distributed:
     std::vector<BufferInfo> buffer_infos;
     for (auto* device : devices) {
         const auto allocated_buffers = device->allocator()->get_allocated_buffers();
-        buffer_infos.reserve(buffer_infos.size() + allocated_buffers.size());
+        // Keep the geometric growth of the vector while making sure the buffers of this device fit.
+        const size_t required_size = buffer_infos.size() + allocated_buffers.size();
+        if (required_size > buffer_infos.capacity()) {
+            buffer_infos.reserve(std::max(required_size, buffer_infos.capacity() * 2));
+        }
         // NOLINTNEXTLINE(bugprone-nondeterministic-pointer-iteration-order)
         for (const auto& buffer : allocated_buffers) {
             auto device_id = device->id();
@@ -115,7 +119,11 @@ std::vector<BufferPageInfo> get_buffer_pages(const std::vector<tt::tt_metal::dis
             auto num_banks = device->allocator()->get_num_banks(buffer->buffer_type());
             auto buffer_type = buffer->buffer_type();
 
-            buffer_page_infos.reserve(buffer_page_infos.size() + num_pages);
+            // Keep the geometric growth of the vector while making sure the pages of this buffer fit.
+            const size_t required_size = buffer_page_infos.size() + num_pages;
+            if (required_size > buffer_page_infos.capacity()) {
+                buffer_page_infos.reserve(std::max(required_size, buffer_page_infos.capacity() * 2));
+            }
 
             if (is_sharded(buffer->buffer_layout())) {
                 const auto& buffer_page_mapping = *buffer->get_buffer_page_mapping();


### PR DESCRIPTION
PR Cathegory:
memory work optimization
Summary:
Preallocate memory for further usage to avoid possible sequential reallocation.
Notes for reviewers:
NA

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/memory_work_optimization_29)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/memory_work_optimization_29)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/memory_work_optimization_29)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/memory_work_optimization_29)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/memory_work_optimization_29)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/memory_work_optimization_29)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=AlexeyZaytsev-epam/memory_work_optimization_29)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:AlexeyZaytsev-epam/memory_work_optimization_29)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/memory_work_optimization_29)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:AlexeyZaytsev-epam/memory_work_optimization_29)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=AlexeyZaytsev-epam/memory_work_optimization_29)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:AlexeyZaytsev-epam/memory_work_optimization_29)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=AlexeyZaytsev-epam/memory_work_optimization_29)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:AlexeyZaytsev-epam/memory_work_optimization_29)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=AlexeyZaytsev-epam/memory_work_optimization_29)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:AlexeyZaytsev-epam/memory_work_optimization_29)