### PR TITLE
[fuser] add pack_matmul kernel to fuser

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/fuser/fused_loop.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/fused_loop.py
@@ -112,6 +112,26 @@ class LoopBlock(FusedLoop):
         block.tile_id_block = "0"
         return compute_unit.fpu.calculate(operation, config, compute_unit, block)
 
+    def pack_loop(
+        self,
+        operation: "FusedOperation",
+        config: "GlobalConfig",
+        pack_node: "PackNode",
+        block: "BlockData",
+    ) -> str:
+        code = ""
+        if config.perf_run_type in (
+            PerfRunType.UNPACK_ISOLATE,
+            PerfRunType.MATH_ISOLATE,
+        ):
+            return code
+        block.tile_id_global = (
+            f"{block.tile_count_x} * {block.block_y} + {block.block_x}"
+        )
+        block.tile_id_block = "0"
+        code += pack_node.packer.pack(pack_node, operation, config, block)
+        return code
+
 
 class LoopBlockRow(FusedLoop):
     def unpack_loop(

--- a/tt_metal/tt-llk/tests/python_tests/fuser/fused_math.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/fused_math.py
@@ -398,9 +398,15 @@ class ComputePipeline:
             init_code += pack_only[0].reconfig(operation, config)
         init_code += pack_common.pack_reduce_mask_config(operation)
         init_code += self._pack_dest_init(operation, config)
-        if hoist:
+        if hoist and not pack_only[0].packer.per_block_init:
             init_code += pack_only[0].configure(operation, config, None)
         code += self._zone(config, "INIT", init_code)
+
+        init_fn = None
+        uninit_fn = None
+        if hoist and pack_only[0].packer.per_block_init:
+            init_fn = lambda block: pack_only[0].configure(operation, config, block)
+            uninit_fn = lambda block: pack_only[0].uninit(operation, config)
 
         def batch_body(block: BlockData):
             body = self._packer_wait_for_math(config)
@@ -428,11 +434,13 @@ class ComputePipeline:
             return body
 
         code += self._zone_loop(
-            config, "TILE_LOOP", self._batch_loop(operation, config, batch_body)
+            config,
+            "TILE_LOOP",
+            self._batch_loop(operation, config, batch_body, init_fn, uninit_fn),
         )
 
         uninit_code = self.packer_sync_with_unpacker(operation, config)
-        if hoist:
+        if hoist and not pack_only[0].packer.per_block_init:
             uninit_code += pack_only[0].uninit(operation, config)
         uninit_code += pack_common.pack_reduce_mask_clear(operation)
         code += self._zone(config, "INIT", uninit_code)

--- a/tt_metal/tt-llk/tests/python_tests/fuser/fused_packer.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/fused_packer.py
@@ -39,6 +39,10 @@ class Packer:
     # Controls the tile iteration pattern for the pack loop.
     loop: FusedLoop = FusedLoop()
 
+    # Set `per_block_init = True` if init() needs block dimensions and must
+    # be called per-block inside the batch loop rather than hoisted out.
+    per_block_init: bool = False
+
     @staticmethod
     def _l1_acc_golden(
         tensor: torch.Tensor,

--- a/tt_metal/tt-llk/tests/python_tests/fuser/quasar/packer/matmul.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/quasar/packer/matmul.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import List
+
+from fuser.block_data import BlockData
+from fuser.fused_loop import FusedLoop, LoopBlock
+from fuser.fused_operation import FusedOperation
+from fuser.fuser_config import GlobalConfig
+from fuser.pack_node import PackNode
+
+from .packer import Packer
+
+
+class MatmulPacker(Packer):
+    loop: FusedLoop = LoopBlock()
+    per_block_init = True
+
+    def get_headers(self) -> List[str]:
+        return [
+            "llk_pack.h",
+            "llk_pack_matmul.h",
+        ]
+
+    def init(
+        self,
+        pack_node: PackNode,
+        operation: FusedOperation,
+        config: GlobalConfig,
+        block: BlockData,
+    ) -> str:
+        buf_desc_id = pack_node.output.buf_desc_id
+        subblock_r_dim = block.block_tiles_y
+        subblock_c_dim = block.block_tiles_x
+        num_subblocks_c_dim = block.tile_count_x // subblock_c_dim
+        return f"_llk_pack_matmul_init_({buf_desc_id}, {subblock_r_dim}, {subblock_c_dim}, {num_subblocks_c_dim});\n"
+
+    def pack(
+        self,
+        pack_node: PackNode,
+        operation: FusedOperation,
+        config: GlobalConfig,
+        block: BlockData,
+    ) -> str:
+        return f"_llk_pack_matmul_(0, {block.tile_id_global});\n"

--- a/tt_metal/tt-llk/tests/python_tests/fuser/quasar/parser.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/quasar/parser.py
@@ -35,6 +35,7 @@ from .fpu.datacopy import DatacopyFpu
 from .fpu.eltwise import EltwiseFpu
 from .fpu.matmul import MatmulFpu
 from .fpu.reduce import ReduceFpu
+from .packer.matmul import MatmulPacker
 from .packer.packer import Packer
 from .sfpu.binary import BinarySfpu
 from .sfpu.unary import UnarySfpu
@@ -212,6 +213,7 @@ _l1_acc_format = (
 
 PACKER_MAP = {
     "Packer": (Packer, [_l1_acc_format]),
+    "MatmulPacker": (MatmulPacker, [_l1_acc_format]),
 }
 
 _eltwise_dims = lambda a, b: (min(a[0], b[0]), min(a[1], b[1]))

--- a/tt_metal/tt-llk/tests/python_tests/fuser/tests/quasar/matmul_pack.yaml
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/tests/quasar/matmul_pack.yaml
@@ -1,0 +1,28 @@
+# Matmul with the MatmulPacker.
+# A 64x64 block (2x2 tiles) tiles the 8x8 output tile grid exactly, so the
+# MOP's L1 row stride (block_tiles_x * num_subblocks_c_dim = tile_count_x)
+# matches the dense row-major L1 layout the fuser golden expects.
+
+operands:
+  - name: "input_A"
+    dims: [256, 256]
+    format: "Float16_b"
+  - name: "input_B"
+    dims: [256, 256]
+    format: "Float16_b"
+  - name: "matmul_out"
+    dims: [256, 256]
+    format: "Float16_b"
+
+operations:
+  - math:
+      - type: "Fpu"
+        src_a: "input_A"
+        src_b: "input_B"
+        operation: "Matmul"
+        unpacker: "MatmulUnpacker"
+        math_fidelity: "HiFi2"
+    block_size: [64, 64]
+    pack:
+      - output: "matmul_out"
+        packer: "MatmulPacker"


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->
Test Only

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->
Relates to #51480

Add a `MatmulPacker` for Quasar fuser that packs a whole block of tiles with a single `_llk_pack_matmul_` call instead of per-tile `_llk_pack_`, and a new `matmul_pack.yaml` test.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=marko/fuser-pack-matmul)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:marko/fuser-pack-matmul)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=marko/fuser-pack-matmul)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:marko/fuser-pack-matmul)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=marko/fuser-pack-matmul)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:marko/fuser-pack-matmul)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=marko/fuser-pack-matmul)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:marko/fuser-pack-matmul)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=marko/fuser-pack-matmul)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:marko/fuser-pack-matmul)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=marko/fuser-pack-matmul)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:marko/fuser-pack-matmul)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=marko/fuser-pack-matmul)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:marko/fuser-pack-matmul)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=marko/fuser-pack-matmul)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:marko/fuser-pack-matmul)