### PR TITLE
[UNTESTED potential improvement] Redundant per-mesh-coordinate work in cache-hit runtime-arg patching (#50932)

### DIFF
--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -544,18 +544,19 @@ KernelHandle detail::ProgramImpl::add_kernel(
     return id;
 }
 
-std::shared_ptr<Kernel> detail::ProgramImpl::get_kernel(KernelHandle kernel_id) const {
+const std::shared_ptr<Kernel>& detail::ProgramImpl::get_kernel(KernelHandle kernel_id) const {
     // TT_ASSERT(kernel_id < this->kernels_.size(), "Expected Kernel with ID {} to be in Program {}", kernel_id,
     // this->id);
     //  find coretype based on kernel_id
     for (const auto& kernels : this->kernels_) {
-        if (kernels.contains(kernel_id)) {
-            return kernels.at(kernel_id);
+        if (auto it = kernels.find(kernel_id); it != kernels.end()) {
+            return it->second;
         }
     }
 
     TT_ASSERT(false, "Did not find kernel id across all core types!");
-    return nullptr;
+    static const std::shared_ptr<Kernel> not_found;
+    return not_found;
 }
 
 // ============================================================================

--- a/tt_metal/impl/program/program_impl.hpp
+++ b/tt_metal/impl/program/program_impl.hpp
@@ -245,7 +245,9 @@ public:
     void set_cached(uint64_t device_hash) { this->cached_device_hash_ = device_hash; }
     const std::optional<uint64_t>& get_cached() const { return this->cached_device_hash_; }
     void set_program_binary_status(ChipId device_id, ProgramBinaryStatus status);
-    std::shared_ptr<Kernel> get_kernel(KernelHandle kernel_id) const;
+    // Returns a reference into kernels_ so the hot runtime-arg patch path doesn't pay a shared_ptr
+    // refcount round trip per lookup. Stable: unordered_map values don't move on rehash.
+    const std::shared_ptr<Kernel>& get_kernel(KernelHandle kernel_id) const;
     ProgramConfig& get_program_config(uint32_t programmable_core_type_index);
     const ProgramConfig& get_program_config(uint32_t programmable_core_type_index) const;
     const std::vector<SubDeviceId>& determine_sub_device_ids(const IDevice* device);

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -374,9 +374,11 @@ public:
             // The mesh workload descriptor — built ONCE per workload (cache
             // miss) by create_workload_descriptor() and held here so its resource
             // members (semaphores, buffers) outlive the cached workload via
-            // the program cache.  Default-constructed (empty vectors) for
-            // ProgramDescriptor-variant factories.
-            tt::tt_metal::WorkloadDescriptor workload_descriptor;
+            // the program cache.  Shared, not copied: every coordinate's entry
+            // points at the one descriptor the factory built, so a 32-coordinate
+            // workload holds one copy instead of 32.  Null for
+            // ProgramDescriptor-variant factories, which have no descriptor.
+            std::shared_ptr<const tt::tt_metal::WorkloadDescriptor> workload_descriptor;
             // Resolved buffer bindings for the fast cache-hit path.
             // Non-empty when the factory used emplace_runtime_args() with
             // Buffer* args (or, for the WorkloadDescriptor variant, declared any CB buffer binding).
@@ -418,6 +420,14 @@ public:
                 buffers.push_back(wb.buffer);
             }
             return collected;
+        }
+
+        // ProgramDescriptor-variant factories have no WorkloadDescriptor, so their buffer
+        // enumeration sees an empty one.
+        static const tt::tt_metal::WorkloadDescriptor& descriptor_or_empty(
+            const std::shared_ptr<const tt::tt_metal::WorkloadDescriptor>& workload_descriptor) {
+            static const tt::tt_metal::WorkloadDescriptor kEmpty;
+            return workload_descriptor ? *workload_descriptor : kEmpty;
         }
 
         // Whether create_descriptor (the ProgramDescriptor variant) wants the per-coord MeshCoordinate.
@@ -537,15 +547,18 @@ public:
                 // populate the cached MeshWorkload.
                 //
                 // `programs` is moved out before the loop — each per-range
-                // shared_variables copy only needs to carry the resources
+                // shared_variables entry only needs to carry the resources
                 // (semaphores, buffers) and resolved bindings.  The per-coord
                 // ProgramDescriptors have already been consumed into Programs.
-                tt::tt_metal::WorkloadDescriptor workload_descriptor = DescriptorFactory::create_workload_descriptor(
-                    attrs, tensor_args, tensor_return_value, tensor_coords);
-                auto programs = std::move(workload_descriptor.programs);
+                auto owned_descriptor =
+                    std::make_shared<tt::tt_metal::WorkloadDescriptor>(DescriptorFactory::create_workload_descriptor(
+                        attrs, tensor_args, tensor_return_value, tensor_coords));
+                auto programs = std::move(owned_descriptor->programs);
+                // Coordinate-invariant: tensor_args and the descriptor's workload buffers are the same
+                // for every program, so enumerate once rather than per coordinate.
+                auto collected = collect_tensor_buffers(tensor_args, tensor_return_value, *owned_descriptor);
                 for (auto& [device_range, desc] : programs) {
                     tt::tt_metal::Program program{desc};
-                    auto collected = collect_tensor_buffers(tensor_args, tensor_return_value, workload_descriptor);
                     // The WorkloadDescriptor variant has NO slow-path rebuild (apply_descriptor only
                     // re-applies resolved bindings + dynamic args), so it must ALWAYS allow the in-place
                     // output_tensor alias — otherwise resolve_bindings bails to an EMPTY ResolvedBindings
@@ -561,7 +574,7 @@ public:
                         /*allow_inplace_output_tensor_alias=*/true);
                     mesh_workload.add_program(device_range, std::move(program));
                     shared_variables[device_range] = shared_variables_t{
-                        .workload_descriptor = workload_descriptor, .resolved_bindings = std::move(bindings)};
+                        .workload_descriptor = owned_descriptor, .resolved_bindings = std::move(bindings)};
                 }
                 return cached_mesh_workload_t{std::move(mesh_workload), std::move(shared_variables)};
             } else {
@@ -635,6 +648,11 @@ public:
             const operation_attributes_t& attrs,
             const tensor_args_t& tensor_args,
             tensor_return_value_t& tensor_return_value) {
+            // WorkloadDescriptor variant: the buffer enumeration is coordinate-invariant — the tensors
+            // are the same and every coordinate shares one descriptor — so fill it on the first
+            // coordinate that needs it and reuse it for the rest.
+            std::optional<CollectedTensorBuffers> shared_collected;
+
             for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
                 auto& sv = cached_workload.shared_variables.at(coordinate_range);
 
@@ -646,9 +664,11 @@ public:
                     // fast path covers cache hits even when the factory only sets
                     // `desc.cbs[i].buffer` and declares no rt-arg buffer bindings.
                     if (!sv.resolved_bindings.empty()) {
-                        auto collected =
-                            collect_tensor_buffers(tensor_args, tensor_return_value, sv.workload_descriptor);
-                        tt::tt_metal::apply_resolved_bindings(program, sv.resolved_bindings, collected.buffers);
+                        if (!shared_collected.has_value()) {
+                            shared_collected = collect_tensor_buffers(
+                                tensor_args, tensor_return_value, descriptor_or_empty(sv.workload_descriptor));
+                        }
+                        tt::tt_metal::apply_resolved_bindings(program, sv.resolved_bindings, shared_collected->buffers);
                     }
                     // The WorkloadDescriptor variant never rebuilds, so a value a custom hash
                     // excluded would stay frozen at first miss — re-apply declared dynamic args.
@@ -725,8 +745,8 @@ public:
                     }
                     if (!sv.resolved_bindings.rt_args.empty() ||
                         (!dynamic_args.empty() && !sv.resolved_bindings.empty())) {
-                        auto collected =
-                            collect_tensor_buffers(tensor_args, tensor_return_value, sv.workload_descriptor);
+                        auto collected = collect_tensor_buffers(
+                            tensor_args, tensor_return_value, descriptor_or_empty(sv.workload_descriptor));
                         tt::tt_metal::apply_resolved_bindings(program, sv.resolved_bindings, collected.buffers);
                         tt::tt_metal::apply_dynamic_runtime_args(program, dynamic_args);
 #ifdef TT_DESCRIPTOR_PATCHING_PARITY_CHECK

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -410,24 +410,18 @@ public:
         static CollectedTensorBuffers collect_tensor_buffers(
             const tensor_args_t& tensor_args,
             const tensor_return_value_t& tensor_return_value,
-            const tt::tt_metal::WorkloadDescriptor& workload_descriptor) {
+            const tt::tt_metal::WorkloadDescriptor* workload_descriptor = nullptr) {
             CollectedTensorBuffers collected;
             auto& buffers = collected.buffers;
             extract_tensor_buffers_into(tensor_args, buffers);
             collected.num_input_buffers = buffers.size();
             extract_tensor_buffers_into(tensor_return_value, buffers);
-            for (const auto& wb : workload_descriptor.buffers) {
-                buffers.push_back(wb.buffer);
+            if (workload_descriptor != nullptr) {
+                for (const auto& wb : workload_descriptor->buffers) {
+                    buffers.push_back(wb.buffer);
+                }
             }
             return collected;
-        }
-
-        // ProgramDescriptor-variant factories have no WorkloadDescriptor, so their buffer
-        // enumeration sees an empty one.
-        static const tt::tt_metal::WorkloadDescriptor& descriptor_or_empty(
-            const std::shared_ptr<const tt::tt_metal::WorkloadDescriptor>& workload_descriptor) {
-            static const tt::tt_metal::WorkloadDescriptor kEmpty;
-            return workload_descriptor ? *workload_descriptor : kEmpty;
         }
 
         // Whether create_descriptor (the ProgramDescriptor variant) wants the per-coord MeshCoordinate.
@@ -550,13 +544,13 @@ public:
                 // shared_variables entry only needs to carry the resources
                 // (semaphores, buffers) and resolved bindings.  The per-coord
                 // ProgramDescriptors have already been consumed into Programs.
-                auto owned_descriptor =
+                auto shared_descriptor =
                     std::make_shared<tt::tt_metal::WorkloadDescriptor>(DescriptorFactory::create_workload_descriptor(
                         attrs, tensor_args, tensor_return_value, tensor_coords));
-                auto programs = std::move(owned_descriptor->programs);
+                auto programs = std::move(shared_descriptor->programs);
                 // Coordinate-invariant: tensor_args and the descriptor's workload buffers are the same
                 // for every program, so enumerate once rather than per coordinate.
-                auto collected = collect_tensor_buffers(tensor_args, tensor_return_value, *owned_descriptor);
+                auto collected = collect_tensor_buffers(tensor_args, tensor_return_value, shared_descriptor.get());
                 for (auto& [device_range, desc] : programs) {
                     tt::tt_metal::Program program{desc};
                     // The WorkloadDescriptor variant has NO slow-path rebuild (apply_descriptor only
@@ -574,13 +568,11 @@ public:
                         /*allow_inplace_output_tensor_alias=*/true);
                     mesh_workload.add_program(device_range, std::move(program));
                     shared_variables[device_range] = shared_variables_t{
-                        .workload_descriptor = owned_descriptor, .resolved_bindings = std::move(bindings)};
+                        .workload_descriptor = shared_descriptor, .resolved_bindings = std::move(bindings)};
                 }
                 return cached_mesh_workload_t{std::move(mesh_workload), std::move(shared_variables)};
             } else {
                 // ProgramDescriptor variant — simple per-coord create_descriptor.
-                tt::tt_metal::WorkloadDescriptor empty_descriptor;
-
                 const auto build_and_add_program =
                     [&](const ttnn::MeshCoordinateRange& device_range,
                         const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate) {
@@ -597,7 +589,7 @@ public:
                             mesh_workload.add_program(device_range, std::move(program));
                             shared_variables[device_range] = shared_variables_t{};
                         } else {
-                            auto collected = collect_tensor_buffers(tensor_args, tensor_return_value, empty_descriptor);
+                            auto collected = collect_tensor_buffers(tensor_args, tensor_return_value);
                             auto bindings = tt::tt_metal::resolve_bindings(
                                 program, desc, collected.buffers, collected.num_input_buffers);
                             mesh_workload.add_program(device_range, std::move(program));
@@ -665,8 +657,8 @@ public:
                     // `desc.cbs[i].buffer` and declares no rt-arg buffer bindings.
                     if (!sv.resolved_bindings.empty()) {
                         if (!shared_collected.has_value()) {
-                            shared_collected = collect_tensor_buffers(
-                                tensor_args, tensor_return_value, descriptor_or_empty(sv.workload_descriptor));
+                            shared_collected =
+                                collect_tensor_buffers(tensor_args, tensor_return_value, sv.workload_descriptor.get());
                         }
                         tt::tt_metal::apply_resolved_bindings(program, sv.resolved_bindings, shared_collected->buffers);
                     }
@@ -745,8 +737,7 @@ public:
                     }
                     if (!sv.resolved_bindings.rt_args.empty() ||
                         (!dynamic_args.empty() && !sv.resolved_bindings.empty())) {
-                        auto collected = collect_tensor_buffers(
-                            tensor_args, tensor_return_value, descriptor_or_empty(sv.workload_descriptor));
+                        auto collected = collect_tensor_buffers(tensor_args, tensor_return_value);
                         tt::tt_metal::apply_resolved_bindings(program, sv.resolved_bindings, collected.buffers);
                         tt::tt_metal::apply_dynamic_runtime_args(program, dynamic_args);
 #ifdef TT_DESCRIPTOR_PATCHING_PARITY_CHECK

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_moe_reduce_scatter/device/deepseek_moe_reduce_scatter_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/deepseek_moe_reduce_scatter/device/deepseek_moe_reduce_scatter_program_factory.cpp
@@ -532,13 +532,14 @@ void deepseek_moe_reduce_scatter_helper_override_runtime_arguments(
     UpdateDynamicCircularBufferAddress(
         program, intermediate_cb_handles.at(7), *intermediate_slice_tensors.at(7).buffer());
 
+    auto& reader_runtime_args = GetRuntimeArgs(program, reader_kernel_id);
+    auto& writer_runtime_args = GetRuntimeArgs(program, writer_kernel_id);
+
     // update senders
     for (uint32_t link = 0; link < clamped_num_links; link++) {
         for (uint32_t direction = 0; direction < num_directions_per_link; direction++) {
             uint32_t worker_id = (link * num_directions_per_link) + direction;
             CoreCoord core = all_cores[worker_id];
-            std::vector<std::vector<RuntimeArgsData>> reader_runtime_args = GetRuntimeArgs(program, reader_kernel_id);
-            std::vector<std::vector<RuntimeArgsData>> writer_runtime_args = GetRuntimeArgs(program, writer_kernel_id);
 
             // reader
             auto& reader_rt_args = reader_runtime_args[core.x][core.y];

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/reduce_scatter_minimal_async/device/reduce_scatter_minimal_async_program.cpp
@@ -887,6 +887,9 @@ void ring_reduce_scatter_minimal_async_helper_override_runtime_arguments(
     const Tensor& input,
     const Tensor& intermed,
     const Tensor& output) {
+    auto& reader_runtime_args = GetRuntimeArgs(program, reader_kernel_id);
+    auto& writer_runtime_args = GetRuntimeArgs(program, writer_kernel_id);
+
     // update senders
     for (uint32_t link = 0; link < num_links; link++) {
         for (uint32_t dir = 0; dir < num_directions_per_link; dir++) {
@@ -894,10 +897,6 @@ void ring_reduce_scatter_minimal_async_helper_override_runtime_arguments(
                 uint32_t mux_core_offset = (link * num_cores_per_link) +
                                            (dir * (num_mux_cores_per_direction_per_link + num_workers_per_direction));
                 CoreCoord core = all_cores[mux_core_offset + num_mux_cores_per_direction_per_link + worker];
-                std::vector<std::vector<RuntimeArgsData>> reader_runtime_args =
-                    GetRuntimeArgs(program, reader_kernel_id);
-                std::vector<std::vector<RuntimeArgsData>> writer_runtime_args =
-                    GetRuntimeArgs(program, writer_kernel_id);
 
                 // sender reader
                 auto& worker_reader_sender_runtime_args = reader_runtime_args[core.x][core.y];
@@ -1538,6 +1537,9 @@ void line_reduce_scatter_minimal_async_helper_override_runtime_arguments(
     const Tensor& input,
     const Tensor& intermed,
     const Tensor& output) {
+    auto& reader_runtime_args = GetRuntimeArgs(program, reader_kernel_id);
+    auto& writer_runtime_args = GetRuntimeArgs(program, writer_kernel_id);
+
     // update senders
     for (uint32_t link = 0; link < num_links; link++) {
         for (uint32_t dir = 0; dir < num_directions_per_link; dir++) {
@@ -1545,10 +1547,6 @@ void line_reduce_scatter_minimal_async_helper_override_runtime_arguments(
                 uint32_t mux_core_offset = (link * num_cores_per_link) +
                                            (dir * (num_mux_cores_per_direction_per_link + num_workers_per_direction));
                 CoreCoord core = all_cores[mux_core_offset + num_mux_cores_per_direction_per_link + worker];
-                std::vector<std::vector<RuntimeArgsData>> reader_runtime_args =
-                    GetRuntimeArgs(program, reader_kernel_id);
-                std::vector<std::vector<RuntimeArgsData>> writer_runtime_args =
-                    GetRuntimeArgs(program, writer_kernel_id);
 
                 // sender reader
                 auto& worker_reader_sender_runtime_args = reader_runtime_args[core.x][core.y];

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_reduce_scatter_async/device/strided_reduce_scatter_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_reduce_scatter_async/device/strided_reduce_scatter_async_program.cpp
@@ -765,6 +765,9 @@ void ring_strided_reduce_scatter_async_helper_override_runtime_arguments(
     uint32_t reader_addcmul_rt_arg_offset,
     const std::optional<const Tensor>& addcmul_a,
     const std::optional<const Tensor>& addcmul_b) {
+    auto& reader_runtime_args = GetRuntimeArgs(program, reader_kernel_id);
+    auto& writer_runtime_args = GetRuntimeArgs(program, writer_kernel_id);
+
     // update senders
     for (uint32_t link = 0; link < num_links; link++) {
         for (uint32_t dir = 0; dir < num_directions_per_link; dir++) {
@@ -772,10 +775,6 @@ void ring_strided_reduce_scatter_async_helper_override_runtime_arguments(
                 uint32_t mux_core_offset = (link * num_cores_per_link) +
                                            (dir * (num_mux_cores_per_direction_per_link + num_workers_per_direction));
                 CoreCoord core = all_cores[mux_core_offset + num_mux_cores_per_direction_per_link + worker];
-                std::vector<std::vector<RuntimeArgsData>> reader_runtime_args =
-                    GetRuntimeArgs(program, reader_kernel_id);
-                std::vector<std::vector<RuntimeArgsData>> writer_runtime_args =
-                    GetRuntimeArgs(program, writer_kernel_id);
 
                 // sender reader
                 auto& worker_reader_sender_runtime_args = reader_runtime_args[core.x][core.y];

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
@@ -508,35 +508,6 @@ void apply_ring_joint_scalar_runtime_args(
     const std::array<const Tensor*, 2> ag_inputs = {
         &input_k, tensor_args.input_v.has_value() ? &tensor_args.input_v.value() : &input_k};
 
-    // Re-patch the fused all-gather readers to gather the single cache slot `kv_cache_batch_idx`.
-    // input_batch_base is uniform across all gather cores/links, so patch every core that runs the
-    // reader. Mirrors the helper's create-time arithmetic so miss and hit paths agree.
-    if (patch_indexed_kv_cache) {
-        const auto patch_all_gather_reader = [&](uint32_t kernel_id) {
-            auto& grid_args = GetRuntimeArgs(program, kernel_id);  // [x][y] per-core args
-            for (auto& col_args : grid_args) {
-                for (auto& core_args : col_args) {
-                    for (uint32_t in = 0; in < num_ag_inputs; ++in) {
-                        const auto& shape = ag_inputs[in]->padded_shape();
-                        const uint32_t num_heads = shape[1];
-                        const uint32_t Ht = shape[2] / tt::constants::TILE_WIDTH;
-                        const uint32_t Wt = shape[3] / tt::constants::TILE_WIDTH;
-                        const uint32_t input_batch_base =
-                            ag_rt::input_batch_base_pages(kv_cache_batch_idx, num_heads, Ht, Wt);
-                        const uint32_t idx = ag_rt::kReaderRuntimeArgHeaderCount +
-                                             in * ag_rt::kTensorDescriptorFieldCount +
-                                             ag_rt::kInputBatchBaseFieldOffset;
-                        if (core_args.size() > idx) {  // skip cores that don't run this kernel
-                            write_runtime_arg(core_args, idx, input_batch_base, "all_gather_reader.input_batch_base");
-                        }
-                    }
-                }
-            }
-        };
-        patch_all_gather_reader(kAllGatherReaderForwardKernelIndex);
-        patch_all_gather_reader(kAllGatherReaderBackwardKernelIndex);
-    }
-
     // Bound the fused all-gather to the logical_n-valid slab prefix so an oversized (growing) KV
     // cache only moves kv_actual-sized data instead of the whole physical buffer. The cache is
     // block-cyclic / slab-major per device, so the valid tokens are the first
@@ -545,31 +516,76 @@ void apply_ring_joint_scalar_runtime_args(
     // matched (the AG kernels clamp input_tile_id_end to it). Patch readers AND writers — both key
     // their loops off input_tile_id_end — at their respective header offsets (3 vs 5).
     const std::optional<uint32_t> gather_valid_Ht = compute_gather_valid_Ht(args, tensor_args);
-    if (gather_valid_Ht.has_value()) {
-        const auto patch_all_gather_valid_pages = [&](uint32_t kernel_id, uint32_t header_count) {
-            auto& grid_args = GetRuntimeArgs(program, kernel_id);  // [x][y] per-core args
-            for (auto& col_args : grid_args) {
-                for (auto& core_args : col_args) {
-                    for (uint32_t in = 0; in < num_ag_inputs; ++in) {
-                        const auto& shape = ag_inputs[in]->padded_shape();
-                        const uint32_t Ht = shape[2] / tt::constants::TILE_HEIGHT;
-                        const uint32_t Wt = shape[3] / tt::constants::TILE_WIDTH;
-                        const uint32_t valid_Ht = std::min(*gather_valid_Ht, Ht);
-                        const uint32_t valid_pages = valid_Ht * Wt;
+
+    // Both patched fields are uniform across gather cores/links, so derive them per gather input
+    // once rather than per core. input_batch_base mirrors the helper's create-time arithmetic so
+    // miss and hit paths agree.
+    struct AgInputPatch {
+        uint32_t input_batch_base = 0;
+        uint32_t valid_pages = 0;
+    };
+    std::array<AgInputPatch, 2> ag_patches{};
+    for (uint32_t in = 0; in < num_ag_inputs; ++in) {
+        const auto& shape = ag_inputs[in]->padded_shape();
+        const uint32_t Wt = shape[3] / tt::constants::TILE_WIDTH;
+        if (patch_indexed_kv_cache) {
+            ag_patches[in].input_batch_base =
+                ag_rt::input_batch_base_pages(kv_cache_batch_idx, shape[1], shape[2] / tt::constants::TILE_WIDTH, Wt);
+        }
+        if (gather_valid_Ht.has_value()) {
+            ag_patches[in].valid_pages = std::min(*gather_valid_Ht, shape[2] / tt::constants::TILE_HEIGHT) * Wt;
+        }
+    }
+
+    // One sweep per all-gather kernel writing every field that applies, instead of a separate
+    // full-grid sweep per field.
+    const auto patch_all_gather = [&](uint32_t kernel_id, uint32_t header_count, bool patch_batch_base) {
+        auto& grid_args = GetRuntimeArgs(program, kernel_id);  // [x][y] per-core args
+        for (auto& col_args : grid_args) {
+            for (auto& core_args : col_args) {
+                for (uint32_t in = 0; in < num_ag_inputs; ++in) {
+                    const uint32_t field_base = in * ag_rt::kTensorDescriptorFieldCount;
+                    if (patch_batch_base) {
                         const uint32_t idx =
-                            header_count + in * ag_rt::kTensorDescriptorFieldCount + ag_rt::kValidPagesFieldOffset;
+                            ag_rt::kReaderRuntimeArgHeaderCount + field_base + ag_rt::kInputBatchBaseFieldOffset;
                         if (core_args.size() > idx) {  // skip cores that don't run this kernel
-                            write_runtime_arg(core_args, idx, valid_pages, "all_gather.valid_pages");
+                            write_runtime_arg(
+                                core_args, idx, ag_patches[in].input_batch_base, "all_gather_reader.input_batch_base");
+                        }
+                    }
+                    if (gather_valid_Ht.has_value()) {
+                        const uint32_t idx = header_count + field_base + ag_rt::kValidPagesFieldOffset;
+                        if (core_args.size() > idx) {  // skip cores that don't run this kernel
+                            write_runtime_arg(core_args, idx, ag_patches[in].valid_pages, "all_gather.valid_pages");
                         }
                     }
                 }
             }
-        };
-        patch_all_gather_valid_pages(kAllGatherReaderForwardKernelIndex, ag_rt::kReaderRuntimeArgHeaderCount);
-        patch_all_gather_valid_pages(kAllGatherReaderBackwardKernelIndex, ag_rt::kReaderRuntimeArgHeaderCount);
-        patch_all_gather_valid_pages(kAllGatherWriterForwardKernelIndex, ag_rt::kWriterRuntimeArgHeaderCount);
-        patch_all_gather_valid_pages(kAllGatherWriterBackwardKernelIndex, ag_rt::kWriterRuntimeArgHeaderCount);
+        }
+    };
+
+    if (patch_indexed_kv_cache || gather_valid_Ht.has_value()) {
+        patch_all_gather(
+            kAllGatherReaderForwardKernelIndex, ag_rt::kReaderRuntimeArgHeaderCount, patch_indexed_kv_cache);
+        patch_all_gather(
+            kAllGatherReaderBackwardKernelIndex, ag_rt::kReaderRuntimeArgHeaderCount, patch_indexed_kv_cache);
     }
+    if (gather_valid_Ht.has_value()) {
+        patch_all_gather(kAllGatherWriterForwardKernelIndex, ag_rt::kWriterRuntimeArgHeaderCount, false);
+        patch_all_gather(kAllGatherWriterBackwardKernelIndex, ag_rt::kWriterRuntimeArgHeaderCount, false);
+    }
+
+    // Fetch the three per-core grids once; the per-(kernel, core) GetRuntimeArgs overload re-resolves
+    // the kernel out of the program on every call, which costs more than the writes below.
+    auto& compute_grid = GetRuntimeArgs(program, kComputeKernelIndex);
+    auto& reader_grid = GetRuntimeArgs(program, kReaderKernelIndex);
+    auto& writer_grid = GetRuntimeArgs(program, kWriterKernelIndex);
+    TT_FATAL(
+        std::min({compute_grid.size(), reader_grid.size(), writer_grid.size()}) >= layout.grid_size.x &&
+            std::min({compute_grid[0].size(), reader_grid[0].size(), writer_grid[0].size()}) >= layout.grid_size.y,
+        "RingJointSDPA runtime-arg grids are narrower than the {}x{} layout grid",
+        layout.grid_size.x,
+        layout.grid_size.y);
 
     for (uint32_t i = 0; i < num_cores; ++i) {
         const CoreCoord core = {i % layout.grid_size.x, i / layout.grid_size.x};
@@ -585,9 +601,9 @@ void apply_ring_joint_scalar_runtime_args(
         // logical_n. When logical_n grows across dispatches that reuse one cached program (chunked-prefill
         // accumulation), the create-miss mask is stale for later hits, deadlocking the mcast handshake
         // (RingJointSDPA hang, all-gather eth reads left undrained).
-        auto& compute_args = GetRuntimeArgs(program, kComputeKernelIndex, core);
+        auto& compute_args = compute_grid[core.x][core.y];
 
-        auto& reader_args = GetRuntimeArgs(program, kReaderKernelIndex, core);
+        auto& reader_args = reader_grid[core.x][core.y];
         if (patch_indexed_kv_cache) {
             write_runtime_arg(
                 reader_args, layout.reader_kv_cache_batch_idx, kv_cache_batch_idx, "reader.kv_cache_batch_idx");
@@ -603,7 +619,7 @@ void apply_ring_joint_scalar_runtime_args(
             values.active_ring_iter_mask,
             "reader.active_ring_iter_mask");
 
-        auto& writer_args = GetRuntimeArgs(program, kWriterKernelIndex, core);
+        auto& writer_args = writer_grid[core.x][core.y];
         write_runtime_arg(writer_args, layout.writer_logical_nt, values.logical_nt, "writer.logical_nt");
         write_runtime_arg(
             writer_args,


### PR DESCRIPTION
> ## ⚠️ UNTESTED POTENTIAL IMPROVEMENT — NOT A FIX
>
> This is a **hypothesis**, not a validated change. Specifically:
>
> - **Never compiled.** Not on my machine, not anywhere. CI is the first build of these commits.
> - **Never run.** Zero tests executed — no unit test, no op test, no PCC check, no sweep.
> - **Never measured.** No before/after number exists. I do not know whether this improves anything.
> - **Correctness is argued from reading source only.** No runtime evidence of any kind.
> - **No claim that it addresses the underlying problem.** It removes work I can show is redundant by
>   inspection. Whether that redundant work is a material share of the observed host time is exactly
>   the thing that is untested.
>
> Draft, and **do not merge**. Treat every number below as the *pre-change baseline from #50932*, never
> as a result of this branch.

### What the #50932 host data shows (baseline, not a result)

In the Kimi chunked-prefill host breakdown, `TTNN Op update cached workload` is the largest host stage:
**26.4 ms over 45 op calls** (mean 586 µs, max 7.2 ms), ahead of `EnqueueProgram` (17.8 ms).

That zone wraps the `apply_descriptor` / `override_runtime_arguments` branch in
`ttnn/api/ttnn/device_operation.hpp`. Every op there loops over mesh coordinates, so on the 8×4 mesh
everything inside is ×32. Normalizing the per-op column by 32 coordinates shows the cost is not spread
across ops at all:

| op | update ms | calls | µs / coordinate |
|---|---|---|---|
| LayerNormPreAllGather | 0.058 | 3 | **0.60** |
| Matmul | 0.425 | 10 | **1.33** |
| AllGather | 0.665 | 5 | 4.2 |
| Slice | 1.146 | 4 | 8.9 |
| AllGatherAsync | 1.583 | 2 | 24.7 |
| RotaryEmbeddingIndexed | 4.558 | 2 | 71.2 |
| ReduceScatterMinimalAsync | 5.574 | 2 | **87.1** |
| ReduceScatter | 2.847 | 1 | **89.0** |
| RingJointSDPA | 7.165 | 1 | **223.9** |

Matmul and LayerNorm run the descriptor-framework fast path at 0.6–1.3 µs/coordinate. 8 of the 45 op
calls hold 82% (21.7 ms) of the zone, all in hand-written CCL / SDPA patch code.

Caveat on the baseline itself: these are Tracy-instrumented host times, so the absolutes are inflated.
The 0.6 µs/coordinate floor is the control that makes the *ratios* meaningful, not the absolutes.

### What the commits change

Four independent commits, each droppable on its own. Each removes work that is redundant by
inspection. None is backed by a measurement.

**1. `ccl:` stop deep-copying the runtime-args grid per worker** — 8 sites, 4 files.

`GetRuntimeArgs(program, kernel_id)` returns a reference to the kernel's whole per-core arg grid. Four
reduce-scatter override helpers bound it to a **by-value** local inside the innermost
`link × direction × worker` loop:

```cpp
std::vector<std::vector<RuntimeArgsData>> reader_runtime_args = GetRuntimeArgs(program, reader_kernel_id);
```

That deep-copies the grid — `(max_x + 2)` heap allocations — twice per iteration, to write ~10 uint32s.
`RuntimeArgsData` is a `{uint32_t*, size_t}` view, so writes through the copy always reached the
kernel's real storage: the copies were redundant, and no test would have caught them. Hoisted above the
loops, bound by reference.

`ttnn/operations/ccl/reduce_scatter` reuses the two minimal-async helpers, which is consistent with
`ReduceScatterDeviceOperation` and `ReduceScatterMinimalAsyncDeviceOperation` measuring the same
87–89 µs/coordinate. Both change together. `strided_reduce_scatter_async` and
`deepseek_moe_reduce_scatter` carry the same pattern and are included, though neither appears in this
workload — so they are even less validated than the rest.

**2. `ring_joint_sdpa:` hoist core-invariant work out of the cache-hit patch** — the 224 µs/coordinate op.

- `input_batch_base` / `valid_pages` are uniform across gather cores but were re-derived per core: a
  `padded_shape()` lookup, three divisions and an `input_batch_base_pages()` call, per core per gather
  input. Now derived once per gather input.
- Readers were swept twice, once per patched field. Merged into one sweep per kernel, taking the
  reader/writer grid walks from six to four.
- The per-core scalar loop called the per-`(kernel, core)` `GetRuntimeArgs` overload three times per
  core, each re-resolving the kernel out of the program. Fetch the three grids once and index them.

This is the commit I'd scrutinize hardest: it restructures a patch path with a documented hang history
(stale `active_ring_iter_mask` deadlocking the mcast handshake), and I have not run it.

**3. `metal:` `ProgramImpl::get_kernel` — single lookup, return a reference.**

Every `GetRuntimeArgs` / `SetRuntimeArgs` / `GetCommonRuntimeArgs` resolves through `get_kernel`, which
scanned the per-core-type maps doing `contains()` then `at()` (two hash lookups per probed map) and
returned the `shared_ptr` **by value**, so each lookup also paid a refcount round trip. Now a single
`find()` returning `const std::shared_ptr<Kernel>&`. References into an `unordered_map`'s values are
stable across rehash and kernels are never erased. All ~55 callers copy into a `shared_ptr`, bind a
`const auto&`, or chain `->`; by inspection none needed changing — the compiler has not confirmed that.

Only commit touching Metal internals. Signature-only change to an internal header, no public API.

**4. `descriptors:` share one `WorkloadDescriptor` across coordinates, enumerate buffers once.**

The `WorkloadDescriptor` variant copied the whole descriptor into every coordinate's
`shared_variables` entry — 32 copies of the same semaphore/buffer lists per workload. Held by
`shared_ptr` now: one copy, same lifetime guarantee (it outlives the cached workload via the program
cache). With a single shared descriptor, `collect_tensor_buffers` becomes coordinate-invariant and moves
out of the per-coordinate loop on both the miss and hit paths.

This one changes descriptor-framework state shared by every WD-variant op, so its blast radius is the
widest of the four while being just as unmeasured.

### Status of testing (2026-08-03)

**It compiles.** `./build_metal.sh` EXIT 0 on this branch (it had never been built before).

**Correctness, real 32-chip Galaxy.** `(Galaxy) DeepSeek tests` (the #50932 workload): **65 passed, 9
skipped, 1 failed** — and the one failure is a missing test fixture, not code:
`FileNotFoundError: Reference IO cache file not found at .../CI/test_io_cache/decode.model.embed_tokens.pt`.
Nothing attributable to these commits.

**Perf: still not quantified, and here is why both channels are unavailable.**

- `(Galaxy) perf tests` fails on this branch — but it fails **identically on `main`** (same 6 model jobs:
  Llama 8B, DeepSeek V3 decode, DiT Motif, DiT Wan2.2, Mochi, TinyLlama), so it is a pre-existing
  pipeline failure and it produces no metrics to compare.
- ttsim cannot host it: enabling `FabricConfig::FABRIC_1D` aborts the simulator with
  `UnimplementedFunctionality: eth_txq_regs_wr32`, so none of the CCL commits can run there.

**What the local sim runs did say, with the caveat that makes them inconclusive.** 32-coordinate ttsim,
graph-capture NO_DISPATCH, branch vs `HEAD~4`: `pad` +3.8 us, `reshape_view` -16.0 us, against ~+-7-12 us
run noise — signs disagree, no signal. The reason is structural: `pad`'s
`create_workload_descriptor` pushes **one program per coordinate *range***
(`wd.programs.push_back({ranges[i], desc})`), and a replicated tensor on a contiguous 1x32 mesh is a
*single* range. So that probe exercised a one-iteration loop, which is exactly the case this PR cannot
improve.

**Scoping the claim honestly:** the saving is proportional to the number of coordinate **ranges** N, not
the device count.

| | saved |
|---|---|
| enumerate-once | `N-1` buffer enumerations (nothing at N=1) |
| shared descriptor | `N` `WorkloadDescriptor` copies (still one at N=1) |

Ops with many ranges are the per-coordinate CCL ones — precisely those that need fabric. So a real
number needs either a working Galaxy perf pipeline or a manual run on 32-chip hardware
(`measure_51732.py`, `FABRIC=1`).

### If someone wants to evaluate it

`analyze_op2op_host.py` against this branch: `update cached workload` is where any delta would land;
`EnqueueProgram` and the tracy zone should not move. The commits are independent, so which of the four
(if any) pays can be bisected.
