### PR TITLE
2-galaxy high_bw_all_gather + D2D + all_gather

### DIFF
--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -368,8 +368,8 @@ models:
     wh_galaxy: 345
     wh_galaxy_perf: 150
     bh_galaxy: 470
-    # blaze_models_prefill_tests.yaml sum of bh_sc1 job timeouts (tightened from 840)
-    bh_sc1: 480
+    # blaze_models_prefill_tests.yaml sum of bh_sc1 job timeouts (includes high_bw_all_gather perf)
+    bh_sc1: 505
     wh_n150: 500
     wh_n150_civ2: 300
     wh_n300: 600

--- a/.github/workflows/blaze-models-prefill-tests.yaml
+++ b/.github/workflows/blaze-models-prefill-tests.yaml
@@ -12,9 +12,10 @@ on:
           Empty or "all" runs every stage. Valid stages: moe_gate, mla, mla_chunked,
           kv_cache_table, prefill_block, prefill_transformer, kimi_mla, kimi_moe,
           kimi_prefill_block, kimi_chunked, glm_chunked, dsa_mla, dsa_mla_glm, glm_moe, glm_prefill_block, glm_chunked_accuracy, prefill_block_determinism,
-          prefill_transformer_determinism.
+          prefill_transformer_determinism, high_bw_all_gather_perf.
           The "module" group also runs every stage; the "sdpa_perf" group runs the
-          ring joint SDPA perf checks.
+          ring joint SDPA perf checks; the "ccl_perf" group runs the Galaxy CCL
+          performance checks.
         required: false
         type: string
         default: "all"

--- a/models/demos/common/prefill/runners/run_allgather_d2d_probe.sh
+++ b/models/demos/common/prefill/runners/run_allgather_d2d_probe.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# 2-galaxy all_gather + D2D + all_gather probe, launched as a pytest under tt-run.
+#
+#   rank 0 = RANK0_HOST (mesh 0): high_bw_all_gather -> D2D send
+#   rank 1 = RANK1_HOST (mesh 1): D2D recv          -> high_bw_all_gather
+#
+# Reuses the connected-2-galaxy MGD + FABRIC_2D via the existing D2D rank binding (topology only; the
+# test sets fabric itself from device_params). ttrun wraps mpirun around `pytest` — the same launch
+# shape the dual-galaxy CCL suite uses. Requires Pavle's high_bw_all_gather (PR #51134) in the build.
+#
+#   RANK0_HOST=bh-glx-110-c10u02 RANK1_HOST=bh-glx-110-c10u08 ./run_allgather_d2d_probe.sh
+set -euo pipefail
+
+RANK0_HOST="${RANK0_HOST:-bh-glx-110-c10u02}"
+RANK1_HOST="${RANK1_HOST:-bh-glx-110-c10u08}"
+TCP_IFACE="${TCP_IFACE:-ens5f0np0}"
+
+# TT_METAL_HOME = the tt-metal tree this script lives in (runners dir -> 5 levels up).
+TT_METAL_HOME="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../.." && pwd)"
+export TT_METAL_HOME PYTHONPATH="$TT_METAL_HOME"
+# Per-host local JIT cache (/tmp), same rationale as run_pipeline_prefill.sh.
+export TT_METAL_CACHE="${PP_TT_METAL_CACHE:-/tmp/tt-metal-cache-probe-${USER}}"
+cd "$TT_METAL_HOME"
+source python_env/bin/activate
+
+BINDING="models/demos/common/prefill/runners/topology_configuration/pipeline_prefill_rank_binding_2rank_d2d.yaml"
+TEST="tests/ttnn/unit_tests/operations/experimental/deepseek_prefill/test_allgather_d2d_probe.py"
+
+exec python3 ttnn/ttnn/distributed/ttrun.py \
+  --tcp-interface "$TCP_IFACE" \
+  --rank-binding "$BINDING" \
+  --mpi-args "--host ${RANK0_HOST}:1,${RANK1_HOST}:1 --map-by slot --bind-to none --tag-output --allow-run-as-root -x PATH -x LD_LIBRARY_PATH" \
+  pytest -svv "$TEST"

--- a/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
+++ b/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
@@ -351,6 +351,31 @@
   team: models
   sp_config: sc1
 
+- name: "Blaze - High-bandwidth all-gather Galaxy perf"
+  # Production sparse-MLA transport shape: four independent 8-device SP rings execute concurrently
+  # on the full 8x4 Blackhole Galaxy while FABRIC_2D_TORUS_XY keeps both physical axes wrapped.
+  # The test characterizes 55k and 512k global sequence lengths for all four supported formats,
+  # reports median program duration and per-device effective receive bandwidth, and checks exact
+  # gather output on a smaller tensor for each format.
+  cmd: |
+    export MESH_DEVICE=TG
+    export TT_METAL_HIGH_BW_ALL_GATHER_RUN_GALAXY_PERF=1
+
+    mpirun --bind-to none --pernode --tag-output bash -lc '
+      export OMP_NUM_THREADS=$(nproc)
+      python3 -m pytest \
+        tests/ttnn/unit_tests/operations/experimental/deepseek_prefill/test_high_bw_all_gather.py::test_high_bw_all_gather_galaxy_perf \
+        -svv --tb=short
+    '
+  test_type: high_bw_all_gather_perf
+  test_group: ccl_perf
+  skus:
+    bh_sc1:
+      timeout: 25
+  owner_id: U08RL15T4N8
+  team: models
+  sp_config: sc1
+
 - name: "Blaze - Chunked Kimi (code_debug 55k)"
   # 55k-ISL chunked-prefill perf/smoke for Kimi: full 61 layers, 11 chunks x 5120 = 56320 tokens
   # (the full code_debug trace), 10 iterations. No-PCC: it drives the real chunked-prefill path end to

--- a/tests/ttnn/unit_tests/gtests/ccl/test_high_bw_all_gather_scheduler.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_high_bw_all_gather_scheduler.cpp
@@ -1,0 +1,126 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "ttnn/operations/experimental/deepseek_prefill/high_bw_all_gather/device/high_bw_all_gather_scheduler.hpp"
+
+namespace scheduler = ttnn::operations::experimental::deepseek_prefill::high_bw_all_gather::scheduler;
+
+namespace {
+
+struct ScheduleCase {
+    uint32_t num_pages;
+    uint32_t num_links;
+    uint32_t workers_per_direction;
+    uint32_t num_banks;
+};
+
+constexpr std::array schedule_cases = {
+    ScheduleCase{1003, 2, 4, 7},   // harvested Blackhole
+    ScheduleCase{1024, 2, 4, 8},   // full Blackhole
+    ScheduleCase{1013, 2, 6, 11},  // harvested Wormhole
+    ScheduleCase{1031, 2, 6, 12},  // full Wormhole
+    ScheduleCase{997, 1, 12, 12},  // one-link Wormhole
+    ScheduleCase{509, 4, 2, 7},    // harvested Blackhole with four links
+};
+
+}  // namespace
+
+TEST(HighBwAllGatherScheduler, BankOwnedSlicesCoverEveryPageExactlyOnce) {
+    for (const auto& test : schedule_cases) {
+        ASSERT_TRUE(scheduler::can_partition_workers_by_bank(
+            test.num_pages, test.num_links, test.workers_per_direction, test.num_banks));
+
+        std::vector<uint32_t> page_owners(test.num_pages, 0);
+        std::vector<uint32_t> bank_owners(test.num_banks, 0);
+        std::vector<uint32_t> pages_per_link(test.num_links, 0);
+
+        for (uint32_t link = 0; link < test.num_links; ++link) {
+            for (uint32_t worker = 0; worker < test.workers_per_direction; ++worker) {
+                const auto slice = scheduler::derive_bank_owned_slice(
+                    test.num_pages, test.num_links, test.workers_per_direction, test.num_banks, link, worker);
+                ASSERT_LT(slice.bank, test.num_banks);
+                ASSERT_EQ(slice.input_page_start % test.num_banks, slice.bank);
+                ++bank_owners[slice.bank];
+                pages_per_link[link] += slice.page_count;
+
+                for (uint32_t i = 0; i < slice.page_count; ++i) {
+                    const uint32_t page = slice.input_page_start + i * test.num_banks;
+                    ASSERT_LT(page, test.num_pages);
+                    ++page_owners[page];
+                }
+            }
+        }
+
+        EXPECT_TRUE(std::all_of(page_owners.begin(), page_owners.end(), [](uint32_t owners) { return owners == 1; }));
+        EXPECT_TRUE(std::all_of(bank_owners.begin(), bank_owners.end(), [](uint32_t owners) { return owners >= 1; }));
+
+        const auto [min_pages, max_pages] = std::minmax_element(pages_per_link.begin(), pages_per_link.end());
+        const uint32_t largest_bank = (test.num_pages + test.num_banks - 1) / test.num_banks;
+        EXPECT_LE(*max_pages - *min_pages, largest_bank);
+    }
+}
+
+TEST(HighBwAllGatherScheduler, EligibilityRequiresEnoughWorkersAndPages) {
+    EXPECT_FALSE(scheduler::can_partition_workers_by_bank(1024, 2, 2, 7));
+    EXPECT_TRUE(scheduler::can_partition_workers_by_bank(1024, 2, 4, 7));
+    EXPECT_FALSE(scheduler::can_partition_workers_by_bank(1024, 2, 4, 11));
+    EXPECT_TRUE(scheduler::can_partition_workers_by_bank(1024, 2, 6, 11));
+    EXPECT_FALSE(scheduler::can_partition_workers_by_bank(7, 2, 4, 7));
+    EXPECT_FALSE(scheduler::can_partition_workers_by_bank(1024, 0, 4, 7));
+}
+
+TEST(HighBwAllGatherScheduler, BankOwnedSliceRejectsInvalidInputs) {
+    EXPECT_ANY_THROW(scheduler::derive_bank_owned_slice(1024, 0, 4, 8, 0, 0));
+    EXPECT_ANY_THROW(scheduler::derive_bank_owned_slice(1024, 2, 0, 8, 0, 0));
+    EXPECT_ANY_THROW(scheduler::derive_bank_owned_slice(1024, 2, 4, 0, 0, 0));
+    EXPECT_ANY_THROW(scheduler::derive_bank_owned_slice(1024, 2, 4, 8, 2, 0));
+    EXPECT_ANY_THROW(scheduler::derive_bank_owned_slice(1024, 2, 4, 8, 0, 4));
+    EXPECT_ANY_THROW(scheduler::derive_bank_owned_slice(1024, 2, 2, 8, 0, 0));
+}
+
+TEST(HighBwAllGatherScheduler, PreservesExistingEightBankLinkMapping) {
+    constexpr std::array expected_banks = {
+        std::array<uint32_t, 8>{0, 0, 2, 2, 4, 4, 6, 6},
+        std::array<uint32_t, 8>{1, 1, 3, 3, 5, 5, 7, 7},
+    };
+    for (uint32_t link = 0; link < expected_banks.size(); ++link) {
+        for (uint32_t worker = 0; worker < expected_banks[link].size(); ++worker) {
+            const auto slice = scheduler::derive_bank_owned_slice(1024, 2, 8, 8, link, worker);
+            EXPECT_EQ(slice.bank, expected_banks[link][worker]);
+        }
+    }
+}
+
+TEST(HighBwAllGatherScheduler, WorkerCountCoversFullAndHarvestedDevices) {
+    EXPECT_EQ(scheduler::workers_per_direction_to_cover_banks(2, 7), 4);
+    EXPECT_EQ(scheduler::workers_per_direction_to_cover_banks(2, 8), 4);
+    EXPECT_EQ(scheduler::workers_per_direction_to_cover_banks(2, 11), 6);
+    EXPECT_EQ(scheduler::workers_per_direction_to_cover_banks(2, 12), 6);
+    EXPECT_EQ(scheduler::workers_per_direction_to_cover_banks(1, 12), 12);
+    EXPECT_EQ(scheduler::workers_per_direction_to_cover_banks(4, 7), 2);
+}
+
+TEST(HighBwAllGatherScheduler, WorkerCountAccountsForMuxCores) {
+    // Two directions, each containing W workers and one mux, on every link.
+    EXPECT_TRUE(scheduler::worker_count_fits(6, 2, 28));
+    EXPECT_FALSE(scheduler::worker_count_fits(6, 2, 27));
+    EXPECT_TRUE(scheduler::worker_count_fits(12, 1, 26));
+    EXPECT_FALSE(scheduler::worker_count_fits(12, 1, 25));
+}
+
+TEST(HighBwAllGatherScheduler, RestrictedGridUsesMeasuredWorkerTiers) {
+    constexpr std::array blackhole_tiers{8u, 4u, 2u, 1u};
+    constexpr std::array harvested_wormhole_tiers{8u, 6u, 2u, 1u};
+
+    EXPECT_EQ(scheduler::select_fitting_worker_count(8, 2, 35, blackhole_tiers), 4);
+    EXPECT_EQ(scheduler::select_fitting_worker_count(4, 2, 19, blackhole_tiers), 2);
+    EXPECT_EQ(scheduler::select_fitting_worker_count(8, 2, 28, harvested_wormhole_tiers), 6);
+    EXPECT_EQ(scheduler::select_fitting_worker_count(6, 2, 11, harvested_wormhole_tiers), 1);
+}

--- a/tests/ttnn/unit_tests/gtests/sources.cmake
+++ b/tests/ttnn/unit_tests/gtests/sources.cmake
@@ -47,6 +47,7 @@ set(UNIT_TESTS_TTNN_CCL_SOURCES
     ccl/test_ccl_tensor_slicers.cpp
     ccl/test_erisc_data_mover_with_workers.cpp
     ccl/test_fabric_erisc_data_mover_loopback_with_workers.cpp
+    ccl/test_high_bw_all_gather_scheduler.cpp
     ccl/test_sharded_address_generators.cpp
     ccl/test_sharded_address_generators_new.cpp
 )

--- a/tests/ttnn/unit_tests/operations/experimental/deepseek_prefill/test_allgather_d2d_probe.py
+++ b/tests/ttnn/unit_tests/operations/experimental/deepseek_prefill/test_allgather_d2d_probe.py
@@ -1,0 +1,190 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Two-galaxy probe: high_bw_all_gather -> D2D socket hop -> high_bw_all_gather.
+
+Exercises the large-message all_gather collective while a device-to-device (inter-galaxy) transfer is
+in flight, to later characterise all_gather bandwidth under concurrent D2D traffic. Launched as two MPI
+ranks under tt-run, one 8x4 galaxy each (mesh 0 / mesh 1) over the connected 2-galaxy MGD:
+
+    rank 0 (mesh 0): build a sharded input -> all_gather (intra-mesh) -> ship the gathered result to
+                     rank 1 over the D2D MeshSocket.
+    rank 1 (mesh 1): receive the gathered tensor -> all_gather it again (intra-mesh).
+
+The D2D transport mirrors the pipeline prefill runner's ttnn.D2DStreamService usage (create_sender /
+create_receiver, outbound_/inbound_socket_service_sync, share_fabric_links lease). Semantics of the
+second gather are not meaningful (its input is replicated, not sharded) — the point is the traffic.
+"""
+
+import os
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+
+# num_links=2 keeps the collective portable across galaxy link counts (matches the op's own tests).
+_NUM_LINKS = 2
+# One tile of rows per device, narrow width: enough to move real data over both fabrics, small enough
+# to stay well clear of L1/fifo limits. Override to scale the message up for bandwidth runs.
+_ROWS_PER_DEVICE = int(os.environ.get("PROBE_ROWS_PER_DEVICE", 32))
+_WIDTH = int(os.environ.get("PROBE_WIDTH", 512))
+# all_gather along the 8-long mesh dim (dim_types LINE); a line schedule under FABRIC_2D.
+_CLUSTER_AXIS = 0
+
+# D2D socket knobs, same shape as the prefill runner's endpoints.
+_SYNC_WORKER_CORES = ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))
+_METADATA_SIZE_BYTES = 12
+_FIFO_SIZE_BYTES = int(os.environ.get("PROBE_D2D_FIFO_BYTES", 64 * 1024))
+_REPLICATE_2D = ttnn.MeshMapperConfig(placements=[ttnn.PlacementReplicate(), ttnn.PlacementReplicate()])
+
+
+def _fabric_router_config():
+    config = ttnn.FabricRouterConfig()
+    config.max_packet_payload_size_bytes = 14 * 1024
+    return config
+
+
+_DEVICE_PARAMS = {
+    "fabric_config": ttnn.FabricConfig.FABRIC_2D,
+    "fabric_router_config": _fabric_router_config(),
+    "reliability_mode": ttnn.FabricReliabilityMode.RELAXED_INIT,
+    "l1_small_size": 2048,
+}
+
+
+def _data_valid_semaphore(mesh_device):
+    grid = mesh_device.compute_with_storage_grid_size()
+    cores = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid.x - 1, grid.y - 1))})
+    return ttnn.create_global_semaphore(mesh_device, cores, 0, buffer_type=ttnn.BufferType.L1_SMALL)
+
+
+def _gathered_spec(gathered_rows):
+    return ttnn.TensorSpec(
+        shape=ttnn.Shape([1, 1, gathered_rows, _WIDTH]),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        buffer_type=ttnn.BufferType.DRAM,
+    )
+
+
+def _persistent_replica(mesh_device, rows):
+    return ttnn.from_torch(
+        torch.zeros((1, 1, rows, _WIDTH), dtype=torch.bfloat16),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+        device=mesh_device,
+    )
+
+
+def _all_gather(mesh_device, device_input, semaphore):
+    """high_bw_all_gather along _CLUSTER_AXIS into a fresh persistent replicated output; returns it."""
+    local_padded = ttnn.get_device_tensors(device_input)[0].padded_shape
+    gathered_rows = local_padded[2] * mesh_device.shape[_CLUSTER_AXIS]
+    output = _persistent_replica(mesh_device, gathered_rows)
+    ttnn.experimental.deepseek_prefill.high_bw_all_gather(
+        device_input,
+        dim=2,
+        output_tensor=output,
+        cluster_axis=_CLUSTER_AXIS,
+        data_valid_semaphore=semaphore,
+        num_links=_NUM_LINKS,
+    )
+    ttnn.synchronize_device(mesh_device)
+    return output, gathered_rows
+
+
+def _socket_common(mesh_device, gathered_rows):
+    # Fresh mapper per call: create_sender/create_receiver MOVE the mapper (std::unique_ptr).
+    return dict(
+        global_spec=_gathered_spec(gathered_rows),
+        mapper=ttnn.create_mesh_mapper(mesh_device, _REPLICATE_2D),
+        fifo_size_bytes=_FIFO_SIZE_BYTES,
+        sender_worker_cores=_SYNC_WORKER_CORES,
+        receiver_worker_cores=_SYNC_WORKER_CORES,
+        metadata_size_bytes=_METADATA_SIZE_BYTES,
+        share_fabric_links=True,
+        socket_buffer_type=ttnn.BufferType.L1,
+    )
+
+
+def _send(outbound, tensor):
+    backing = outbound.get_backing_tensor()
+    md = ttnn.from_torch(
+        torch.zeros((1, 1, 1, 3), dtype=torch.int32),
+        dtype=ttnn.uint32,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=backing.device(),
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        mesh_mapper=ttnn.create_mesh_mapper(backing.device(), _REPLICATE_2D),
+    )
+    ttnn.experimental.deepseek_prefill.outbound_socket_service_sync(outbound, tensor, metadata=md)
+
+
+@pytest.mark.parametrize("device_params", [_DEVICE_PARAMS], indirect=True)
+@pytest.mark.parametrize("mesh_device", [(8, 4)], indirect=True)
+def test_allgather_d2d_probe(mesh_device):
+    if not ttnn.distributed_context_is_initialized():
+        ttnn.init_distributed_context()
+    rank = int(ttnn.distributed_context_get_rank())
+    num_ranks = int(ttnn.distributed_context_get_size())
+    assert num_ranks == 2, f"probe needs exactly 2 ranks (2 galaxies), got {num_ranks}"
+
+    axis = mesh_device.shape[_CLUSTER_AXIS]
+    gathered_rows = _ROWS_PER_DEVICE * axis
+    logger.info(f"[probe rank {rank}] mesh={tuple(mesh_device.shape)} axis={axis} gathered_rows={gathered_rows}")
+
+    # Both ranks create their D2D endpoint first: create_sender/create_receiver rendezvous point-to-point
+    # and each MeshSocket ctor blocks until its peer's, so this is the sync point before any compute.
+    common = _socket_common(mesh_device, gathered_rows)
+    if rank == 0:
+        outbound = ttnn.D2DStreamService.create_sender(
+            sender_mesh=mesh_device, sender_rank=0, receiver_rank=1, **common
+        )
+        logger.info("[probe rank 0] D2D sender up")
+    else:
+        inbound = ttnn.D2DStreamService.create_receiver(
+            receiver_mesh=mesh_device, sender_rank=0, receiver_rank=1, **common
+        )
+        logger.info("[probe rank 1] D2D receiver up")
+
+    semaphore = _data_valid_semaphore(mesh_device)
+
+    if rank == 0:
+        host_input = torch.rand((1, 1, gathered_rows, _WIDTH), dtype=torch.bfloat16)
+        device_input = ttnn.from_torch(
+            host_input,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=(2, None), mesh_shape=tuple(mesh_device.shape)),
+            device=mesh_device,
+        )
+
+        # Lease mode: the sender holds no fabric link until granted, so all_gather has the links to
+        # itself. wait_for_fabric_links() here just confirms the link is free (no grant outstanding).
+        outbound.wait_for_fabric_links()
+        gathered, _ = _all_gather(mesh_device, device_input, semaphore)
+        logger.info(f"[probe rank 0] all_gather done -> {tuple(gathered.shape)}; shipping over D2D")
+
+        _send(outbound, gathered)
+        outbound.release_fabric_links()  # grant the one transfer; the service ships now
+        outbound.wait_for_fabric_links()  # block until the transfer is off the link
+        logger.info("[probe rank 0] D2D send complete")
+    else:
+        inbound.release_fabric_links()  # grant the receive turn
+        received, _ = ttnn.experimental.deepseek_prefill.inbound_socket_service_sync(
+            inbound, metadata_size_bytes=_METADATA_SIZE_BYTES
+        )
+        inbound.wait_for_fabric_links()  # block until off the link before the next fabric op
+        logger.info(f"[probe rank 1] D2D recv done -> {tuple(received.shape)}; second all_gather")
+
+        gathered2, rows2 = _all_gather(mesh_device, received, semaphore)
+        logger.info(f"[probe rank 1] second all_gather done -> {tuple(gathered2.shape)}")
+        assert gathered2.shape[2] == rows2
+
+    ttnn.distributed_context_barrier()
+    logger.info(f"[probe rank {rank}] done")

--- a/tests/ttnn/unit_tests/operations/experimental/deepseek_prefill/test_high_bw_all_gather.py
+++ b/tests/ttnn/unit_tests/operations/experimental/deepseek_prefill/test_high_bw_all_gather.py
@@ -1,0 +1,882 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Production-shaped correctness and bandwidth coverage for high_bw_all_gather."""
+
+import csv
+import gc
+import math
+import os
+import statistics
+from pathlib import Path
+
+import pytest
+import torch
+
+import ttnn
+from tests.ttnn.profiling.realtime_profiler_utils import profile_realtime_program
+
+
+def _fabric_router_config():
+    config = ttnn.FabricRouterConfig()
+    config.max_packet_payload_size_bytes = 14 * 1024
+    return config
+
+
+def _device_params(fabric_config):
+    return {
+        "fabric_config": fabric_config,
+        "fabric_router_config": _fabric_router_config(),
+        "reliability_mode": ttnn.FabricReliabilityMode.RELAXED_INIT,
+        "l1_small_size": 2048,
+    }
+
+
+# A line has boundary ranks and fewer usable paths than the bidirectional ring
+# schedule, so its qualification floor is half the ring floor.
+_PERF_DEVICE_PARAMS = [
+    pytest.param(
+        _device_params(ttnn.FabricConfig.FABRIC_1D),
+        45.0,
+        id="fabric_1d_line",
+    ),
+    pytest.param(
+        _device_params(ttnn.FabricConfig.FABRIC_1D_RING),
+        90.0,
+        id="fabric_1d_ring",
+    ),
+    pytest.param(
+        _device_params(ttnn.FabricConfig.FABRIC_2D),
+        45.0,
+        id="fabric_2d",
+    ),
+    pytest.param(_device_params(ttnn.FabricConfig.FABRIC_2D_TORUS_X), 45.0, id="fabric_2d_torus_x_line"),
+    pytest.param(_device_params(ttnn.FabricConfig.FABRIC_2D_TORUS_Y), 90.0, id="fabric_2d_torus_y_ring"),
+    pytest.param(_device_params(ttnn.FabricConfig.FABRIC_2D_TORUS_XY), 90.0, id="fabric_2d_torus_xy_ring"),
+]
+
+_AXIS_1_PERF_DEVICE_PARAMS = [
+    pytest.param(_device_params(ttnn.FabricConfig.FABRIC_2D), 45.0, id="fabric_2d"),
+    pytest.param(_device_params(ttnn.FabricConfig.FABRIC_2D_TORUS_X), 90.0, id="fabric_2d_torus_x_ring"),
+    pytest.param(_device_params(ttnn.FabricConfig.FABRIC_2D_TORUS_Y), 45.0, id="fabric_2d_torus_y_line"),
+    pytest.param(_device_params(ttnn.FabricConfig.FABRIC_2D_TORUS_XY), 90.0, id="fabric_2d_torus_xy_ring"),
+]
+
+_FABRIC_2D_LINE_DEVICE_PARAMS = pytest.param(
+    _device_params(ttnn.FabricConfig.FABRIC_2D),
+    id="fabric_2d_line",
+)
+
+_FABRIC_1D_RING_DEVICE_PARAMS = pytest.param(
+    _device_params(ttnn.FabricConfig.FABRIC_1D_RING),
+    id="fabric_1d_ring",
+)
+
+_FABRIC_2D_TORUS_XY_DEVICE_PARAMS = pytest.param(
+    _device_params(ttnn.FabricConfig.FABRIC_2D_TORUS_XY),
+    id="fabric_2d_torus_xy",
+)
+
+_TEST_CASES = [
+    ("bf16_1152b_rows", ttnn.bfloat16, 576, ttnn.ROW_MAJOR_LAYOUT, 1152),
+    ("scaled_fp8_704b_rows", ttnn.fp8_e4m3, 656, ttnn.ROW_MAJOR_LAYOUT, 704),
+    ("bf16_tiles", ttnn.bfloat16, 576, ttnn.TILE_LAYOUT, 2048),
+    ("bfloat8_b_tiles", ttnn.bfloat8_b, 576, ttnn.TILE_LAYOUT, 1088),
+]
+
+_PERF_ROWS_PER_DEVICE = 65536
+_ACCURACY_ROWS_PER_DEVICE = 1024
+_MEDIUM_BF16_ROWS_PER_DEVICE = 1200  # 5.5296 MB/link on the 8-device, 2-link qualification mesh.
+_NUM_LINKS = 2
+# Model sequence-length labels use binary K: the 55K code-debug trace is 11 * 5120 = 56,320 tokens.
+_GALAXY_PERF_GLOBAL_TOKENS = (55 * 1024, 512 * 1024)
+_GALAXY_PERF_PROFILE_SAMPLES = 7
+
+
+def _create_data_valid_semaphore(mesh_device):
+    compute_grid = mesh_device.compute_with_storage_grid_size()
+    cores = ttnn.CoreRangeSet(
+        {
+            ttnn.CoreRange(
+                ttnn.CoreCoord(0, 0),
+                ttnn.CoreCoord(compute_grid.x - 1, compute_grid.y - 1),
+            )
+        }
+    )
+    return ttnn.create_global_semaphore(
+        mesh_device,
+        cores,
+        0,
+        buffer_type=ttnn.BufferType.L1_SMALL,
+    )
+
+
+def _make_tensor(mesh_device, host_tensor, dtype, layout, mesh_mapper):
+    tensor = ttnn.from_torch(
+        host_tensor,
+        dtype=ttnn.bfloat16 if dtype == ttnn.fp8_e4m3 else dtype,
+        layout=layout,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        mesh_mapper=mesh_mapper,
+        device=mesh_device,
+    )
+    return ttnn.typecast(tensor, dtype) if dtype == ttnn.fp8_e4m3 else tensor
+
+
+def _fp8_payloads(tensor, mesh_device):
+    assert tensor.dtype == ttnn.fp8_e4m3
+    device_tensors = ttnn.get_device_tensors(tensor)
+    local_shape = tuple(device_tensors[0].shape)
+    host_bytes = (
+        ttnn.to_torch(tensor, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=0)).contiguous().view(torch.uint8)
+    )
+    return host_bytes.reshape(len(device_tensors), *local_shape)
+
+
+def _profile_high_bw_all_gather(mesh_device, run):
+    _, records = profile_realtime_program(mesh_device, run, collect_all=True, record_timeout_seconds=5.0)
+    programs = {}
+    for record in records:
+        sources = [source.replace("\\", "/") for source in record["kernel_sources"]]
+        if not any("/experimental/deepseek_prefill/high_bw_all_gather/" in source for source in sources):
+            continue
+        assert any(source.endswith("/unicast_writer.cpp") for source in sources)
+        runtime_id = record["runtime_id"]
+        programs[runtime_id] = max(programs.get(runtime_id, 0.0), record["duration_ns"])
+    assert programs, "realtime profiler returned no high_bw_all_gather program"
+    return sum(programs.values())
+
+
+def _to_torch_with_device_padding(tensor):
+    host_tensor = ttnn.to_torch(tensor)
+    padded_shape = tuple(tensor.padded_shape)
+    padding = []
+    for logical_extent, padded_extent in reversed(list(zip(host_tensor.shape, padded_shape))):
+        padding.extend((0, padded_extent - logical_extent))
+    return torch.nn.functional.pad(host_tensor, padding)
+
+
+def _assert_exact_all_gather(device_input, persistent_output, mesh_device, dtype, cluster_axis):
+    """The collective performs no arithmetic, so compare the gathered device values exactly."""
+    if dtype == ttnn.fp8_e4m3:
+        input_payloads = list(_fp8_payloads(device_input, mesh_device))
+        actual_outputs = _fp8_payloads(persistent_output, mesh_device)
+    else:
+        # Compare the device representation so quantized types and padding inserted
+        # independently into each local tile shard are both represented exactly.
+        input_payloads = [_to_torch_with_device_padding(tensor) for tensor in ttnn.get_device_tensors(device_input)]
+        actual_outputs = [ttnn.to_torch(tensor) for tensor in ttnn.get_device_tensors(persistent_output)]
+
+    mesh_rows, mesh_columns = mesh_device.shape
+    for output_index, actual in enumerate(actual_outputs):
+        mesh_row, mesh_column = divmod(output_index, mesh_columns)
+        if cluster_axis == 0:
+            ring_indices = [row * mesh_columns + mesh_column for row in range(mesh_rows)]
+        else:
+            ring_indices = [mesh_row * mesh_columns + column for column in range(mesh_columns)]
+        expected = torch.cat([input_payloads[index] for index in ring_indices], dim=2)
+        assert torch.equal(actual, expected)
+
+
+def _assert_exact_replicated_output(host_input, persistent_output, mesh_device, dtype, layout):
+    """Compare rank-local outputs with an independently quantized replicated host reference."""
+    expected_output = _make_tensor(
+        mesh_device,
+        host_input,
+        dtype,
+        layout,
+        ttnn.ReplicateTensorToMesh(mesh_device),
+    )
+    if dtype == ttnn.fp8_e4m3:
+        expected_outputs = _fp8_payloads(expected_output, mesh_device)
+        actual_outputs = _fp8_payloads(persistent_output, mesh_device)
+    else:
+        expected_outputs = [ttnn.to_torch(tensor) for tensor in ttnn.get_device_tensors(expected_output)]
+        actual_outputs = [ttnn.to_torch(tensor) for tensor in ttnn.get_device_tensors(persistent_output)]
+    assert len(actual_outputs) == len(expected_outputs)
+    for actual, expected in zip(actual_outputs, expected_outputs):
+        assert torch.equal(actual, expected)
+
+
+def _run_high_bw_all_gather_accuracy(
+    mesh_device,
+    dtype,
+    width,
+    layout,
+    expected_page_size,
+    cluster_axis,
+    rows_per_device,
+    data_valid_semaphore,
+    *,
+    compare_against_host_replica=False,
+):
+    global_shape = (1, 1, rows_per_device * mesh_device.shape[cluster_axis], width)
+    torch.manual_seed(0)
+    host_input = torch.rand(global_shape, dtype=torch.bfloat16)
+    device_input = _make_tensor(
+        mesh_device,
+        host_input,
+        dtype,
+        layout,
+        ttnn.ShardTensor2dMesh(
+            mesh_device, dims=(2, None) if cluster_axis == 0 else (None, 2), mesh_shape=tuple(mesh_device.shape)
+        ),
+    )
+    local_padded_shape = ttnn.get_device_tensors(device_input)[0].padded_shape
+    output_shape = list(local_padded_shape)
+    output_shape[2] *= mesh_device.shape[cluster_axis]
+    persistent_output = _make_tensor(
+        mesh_device,
+        torch.zeros(output_shape, dtype=torch.bfloat16),
+        dtype,
+        layout,
+        ttnn.ReplicateTensorToMesh(mesh_device),
+    )
+    assert ttnn.get_device_tensors(device_input)[0].buffer_aligned_page_size() == expected_page_size
+
+    ttnn.experimental.deepseek_prefill.high_bw_all_gather(
+        device_input,
+        dim=2,
+        output_tensor=persistent_output,
+        cluster_axis=cluster_axis,
+        data_valid_semaphore=data_valid_semaphore,
+        num_links=_NUM_LINKS,
+    )
+    ttnn.synchronize_device(mesh_device)
+
+    if compare_against_host_replica:
+        assert layout != ttnn.TILE_LAYOUT or rows_per_device % 32 == 0
+        _assert_exact_replicated_output(host_input, persistent_output, mesh_device, dtype, layout)
+    else:
+        _assert_exact_all_gather(device_input, persistent_output, mesh_device, dtype, cluster_axis)
+
+
+@pytest.mark.parametrize("device_params", [_FABRIC_2D_TORUS_XY_DEVICE_PARAMS], indirect=True)
+@pytest.mark.parametrize("mesh_device", [(2, 4)], indirect=True)
+def test_high_bw_all_gather_preserves_same_dim_sharding_on_other_axis(mesh_device, expect_error):
+    """Gathering TP must preserve SP when both mesh axes shard the same tensor dimension."""
+    global_shape = (1, 4, 256, 32)
+    torch.manual_seed(0)
+    host_input = torch.rand(global_shape, dtype=torch.bfloat16)
+    source_placements = [ttnn.PlacementShard(2), ttnn.PlacementShard(1)]
+    gathered_placements = [ttnn.PlacementShard(2), ttnn.PlacementReplicate()]
+    sp_gathered_placements = [ttnn.PlacementReplicate(), ttnn.PlacementShard(1)]
+    duplicate_placements = [ttnn.PlacementShard(2), ttnn.PlacementShard(2)]
+    data_valid_semaphore = _create_data_valid_semaphore(mesh_device)
+
+    source = _make_tensor(
+        mesh_device,
+        host_input,
+        ttnn.bfloat16,
+        ttnn.TILE_LAYOUT,
+        ttnn.create_mesh_mapper(mesh_device, ttnn.MeshMapperConfig(source_placements, mesh_device.shape)),
+    )
+    inverse_output = _make_tensor(
+        mesh_device,
+        torch.zeros(global_shape, dtype=torch.bfloat16),
+        ttnn.bfloat16,
+        ttnn.TILE_LAYOUT,
+        ttnn.create_mesh_mapper(mesh_device, ttnn.MeshMapperConfig(gathered_placements, mesh_device.shape)),
+    )
+    flattened_source = _make_tensor(
+        mesh_device,
+        host_input,
+        ttnn.bfloat16,
+        ttnn.TILE_LAYOUT,
+        ttnn.ShardTensorToMesh(mesh_device, dim=2),
+    )
+    with expect_error(RuntimeError, "tensor distribution axes to match the device mesh axes"):
+        ttnn.experimental.deepseek_prefill.high_bw_all_gather(
+            flattened_source,
+            dim=2,
+            output_tensor=inverse_output,
+            cluster_axis=1,
+            data_valid_semaphore=data_valid_semaphore,
+        )
+
+    inverse_output = ttnn.experimental.deepseek_prefill.high_bw_all_gather(
+        source,
+        dim=1,
+        output_tensor=inverse_output,
+        cluster_axis=1,
+        data_valid_semaphore=data_valid_semaphore,
+    )
+    duplicate_sharded_input = ttnn.mesh_partition(
+        inverse_output,
+        dim=2,
+        cluster_axis=1,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    duplicate_topology = duplicate_sharded_input.tensor_topology()
+    duplicate_sharded_input.update_tensor_topology(
+        ttnn.TensorTopology(
+            duplicate_topology.distribution_shape(),
+            duplicate_placements,
+            duplicate_topology.mesh_coords(),
+        )
+    )
+    assert [
+        placement.dim if isinstance(placement, ttnn.PlacementShard) else None
+        for placement in duplicate_sharded_input.tensor_topology().placements()
+    ] == [2, 2]
+
+    persistent_output = _make_tensor(
+        mesh_device,
+        torch.zeros(global_shape, dtype=torch.bfloat16),
+        ttnn.bfloat16,
+        ttnn.TILE_LAYOUT,
+        ttnn.create_mesh_mapper(mesh_device, ttnn.MeshMapperConfig(gathered_placements, mesh_device.shape)),
+    )
+    gathered = ttnn.experimental.deepseek_prefill.high_bw_all_gather(
+        duplicate_sharded_input,
+        dim=2,
+        output_tensor=persistent_output,
+        cluster_axis=1,
+        data_valid_semaphore=data_valid_semaphore,
+    )
+    ttnn.synchronize_device(mesh_device)
+
+    assert [
+        placement.dim if isinstance(placement, ttnn.PlacementShard) else None
+        for placement in gathered.tensor_topology().placements()
+    ] == [2, None]
+    local_outputs = [ttnn.to_torch(tensor) for tensor in ttnn.get_device_tensors(gathered)]
+    rows_per_sp_shard = global_shape[2] // mesh_device.shape[0]
+    for device_idx, actual in enumerate(local_outputs):
+        sp_rank = device_idx // mesh_device.shape[1]
+        expected = host_input[
+            :,
+            :,
+            sp_rank * rows_per_sp_shard : (sp_rank + 1) * rows_per_sp_shard,
+            :,
+        ]
+        assert torch.equal(actual, expected)
+
+    # A size-two Torus dimension is a line, not a ring. Exercise that schedule
+    # with one link while preserving the independent TP shard.
+    sp_output = _make_tensor(
+        mesh_device,
+        torch.zeros(global_shape, dtype=torch.bfloat16),
+        ttnn.bfloat16,
+        ttnn.TILE_LAYOUT,
+        ttnn.create_mesh_mapper(mesh_device, ttnn.MeshMapperConfig(sp_gathered_placements, mesh_device.shape)),
+    )
+    # Queue a burst without host synchronization to cover persistent semaphore
+    # reuse across adjacent invocations. The first call is a cache miss and the
+    # remainder are cache hits.
+    for _ in range(16):
+        sp_gathered = ttnn.experimental.deepseek_prefill.high_bw_all_gather(
+            source,
+            dim=2,
+            output_tensor=sp_output,
+            cluster_axis=0,
+            data_valid_semaphore=data_valid_semaphore,
+            num_links=1,
+        )
+    ttnn.synchronize_device(mesh_device)
+    assert [
+        placement.dim if isinstance(placement, ttnn.PlacementShard) else None
+        for placement in sp_gathered.tensor_topology().placements()
+    ] == [None, 1]
+    columns = mesh_device.shape[1]
+    for device_idx, actual in enumerate(ttnn.get_device_tensors(sp_gathered)):
+        tp_rank = device_idx % columns
+        expected = host_input[:, tp_rank : tp_rank + 1, :, :]
+        assert torch.equal(ttnn.to_torch(actual), expected)
+
+    # Gathering the innermost dimension in row-major layout exercises the
+    # concat path, where several input chunks share one output page.
+    concat_host = torch.rand((1, 1, 32, 128), dtype=torch.bfloat16)
+    concat_input = _make_tensor(
+        mesh_device,
+        concat_host,
+        ttnn.bfloat16,
+        ttnn.ROW_MAJOR_LAYOUT,
+        ttnn.create_mesh_mapper(
+            mesh_device,
+            ttnn.MeshMapperConfig(
+                [ttnn.PlacementReplicate(), ttnn.PlacementShard(3)],
+                mesh_device.shape,
+            ),
+        ),
+    )
+    concat_output = _make_tensor(
+        mesh_device,
+        torch.zeros_like(concat_host),
+        ttnn.bfloat16,
+        ttnn.ROW_MAJOR_LAYOUT,
+        ttnn.ReplicateTensorToMesh(mesh_device),
+    )
+    concat_output = ttnn.experimental.deepseek_prefill.high_bw_all_gather(
+        concat_input,
+        dim=3,
+        output_tensor=concat_output,
+        cluster_axis=1,
+        data_valid_semaphore=data_valid_semaphore,
+        num_links=1,
+    )
+    ttnn.synchronize_device(mesh_device)
+    _assert_exact_replicated_output(
+        concat_host,
+        concat_output,
+        mesh_device,
+        ttnn.bfloat16,
+        ttnn.ROW_MAJOR_LAYOUT,
+    )
+
+
+def _run_high_bw_all_gather_perf(
+    mesh_device,
+    dtype,
+    width,
+    layout,
+    expected_page_size,
+    min_bandwidth_gbps,
+    cluster_axis,
+    data_valid_semaphore,
+    rows_per_device=_PERF_ROWS_PER_DEVICE,
+    profile_samples=7,
+):
+    if not ttnn.device.IsProgramRealtimeProfilerActive():
+        pytest.skip("high_bw_all_gather bandwidth test requires the realtime device profiler")
+
+    axis_size = mesh_device.shape[cluster_axis]
+    global_shape = (1, 1, rows_per_device * axis_size, width)
+    torch.manual_seed(0)
+    host_input = torch.rand(global_shape, dtype=torch.bfloat16)
+    device_input = _make_tensor(
+        mesh_device,
+        host_input,
+        dtype,
+        layout,
+        ttnn.ShardTensor2dMesh(
+            mesh_device, dims=(2, None) if cluster_axis == 0 else (None, 2), mesh_shape=tuple(mesh_device.shape)
+        ),
+    )
+    # The op gathers each device tensor's padded shape. For TILE layout, a logical shard whose height is not a
+    # multiple of 32 therefore produces a correspondingly padded gathered output (for example, 625 rows/device
+    # produces 640 * ring_size output rows).
+    local_padded_shape = ttnn.get_device_tensors(device_input)[0].padded_shape
+    output_shape = list(local_padded_shape)
+    output_shape[2] *= axis_size
+    persistent_output = _make_tensor(
+        mesh_device,
+        torch.zeros(output_shape, dtype=torch.bfloat16),
+        dtype,
+        layout,
+        ttnn.ReplicateTensorToMesh(mesh_device),
+    )
+    page_size = ttnn.get_device_tensors(device_input)[0].buffer_aligned_page_size()
+    assert page_size == expected_page_size
+    assert ttnn.get_tt_fabric_max_payload_size_bytes() == 14 * 1024
+
+    def run():
+        return ttnn.experimental.deepseek_prefill.high_bw_all_gather(
+            device_input,
+            dim=2,
+            output_tensor=persistent_output,
+            cluster_axis=cluster_axis,
+            data_valid_semaphore=data_valid_semaphore,
+            num_links=_NUM_LINKS,
+        )
+
+    run()
+    ttnn.synchronize_device(mesh_device)
+    run()
+    ttnn.synchronize_device(mesh_device)
+    _profile_high_bw_all_gather(mesh_device, run)
+    durations_ns = [_profile_high_bw_all_gather(mesh_device, run) for _ in range(profile_samples)]
+
+    median_ns = statistics.median(durations_ns)
+    if layout == ttnn.TILE_LAYOUT:
+        pages_per_device = math.prod(local_padded_shape) // (32 * 32)
+    else:
+        pages_per_device = rows_per_device
+    bandwidth_gbps = pages_per_device * page_size * (axis_size - 1) / median_ns
+    assert bandwidth_gbps >= min_bandwidth_gbps
+    print(
+        f"HIGH_BW_ALL_GATHER fabric={ttnn.get_fabric_config()} dtype={dtype} "
+        f"layout={layout} num_links={_NUM_LINKS} rows_per_device={rows_per_device} page_size={page_size}B "
+        f"median={median_ns / 1e6:.3f}ms effective_receive_bw={bandwidth_gbps:.3f}GB/s "
+        f"samples_ms={[round(duration / 1e6, 3) for duration in durations_ns]}"
+    )
+    return bandwidth_gbps, median_ns
+
+
+def _run_high_bw_all_gather(
+    mesh_device,
+    dtype,
+    width,
+    layout,
+    expected_page_size,
+    min_bandwidth_gbps,
+    cluster_axis,
+    data_valid_semaphore,
+):
+    if ttnn.device.IsProgramRealtimeProfilerActive():
+        _run_high_bw_all_gather_perf(
+            mesh_device,
+            dtype,
+            width,
+            layout,
+            expected_page_size,
+            min_bandwidth_gbps,
+            cluster_axis,
+            data_valid_semaphore,
+        )
+        _run_high_bw_all_gather_accuracy(
+            mesh_device,
+            dtype,
+            width,
+            layout,
+            expected_page_size,
+            cluster_axis,
+            rows_per_device=_ACCURACY_ROWS_PER_DEVICE,
+            data_valid_semaphore=data_valid_semaphore,
+            compare_against_host_replica=True,
+        )
+    else:
+        _run_high_bw_all_gather_accuracy(
+            mesh_device,
+            dtype,
+            width,
+            layout,
+            expected_page_size,
+            cluster_axis,
+            rows_per_device=int(
+                os.getenv("TT_METAL_HIGH_BW_ALL_GATHER_ACCURACY_ROWS_PER_DEVICE", _PERF_ROWS_PER_DEVICE)
+            ),
+            data_valid_semaphore=data_valid_semaphore,
+        )
+
+
+def _run_high_bw_all_gather_test_cases(mesh_device, min_bandwidth_gbps, cluster_axis, data_valid_semaphore):
+    selected_formats = set(
+        os.getenv(
+            "TT_METAL_HIGH_BW_ALL_GATHER_TEST_FORMATS",
+            ",".join(case_name for case_name, *_ in _TEST_CASES),
+        ).split(",")
+    )
+    for case_name, dtype, width, layout, expected_page_size in _TEST_CASES:
+        if case_name not in selected_formats:
+            continue
+        print(f"HIGH_BW_ALL_GATHER_CASE {case_name}")
+        _run_high_bw_all_gather(
+            mesh_device,
+            dtype,
+            width,
+            layout,
+            expected_page_size,
+            min_bandwidth_gbps,
+            cluster_axis,
+            data_valid_semaphore,
+        )
+
+
+@pytest.mark.parametrize("device_params,min_bandwidth_gbps", _PERF_DEVICE_PARAMS, indirect=["device_params"])
+@pytest.mark.parametrize("mesh_device", [(8, 1)], indirect=True)
+def test_high_bw_all_gather_512k(mesh_device, min_bandwidth_gbps):
+    data_valid_semaphore = _create_data_valid_semaphore(mesh_device)
+    _run_high_bw_all_gather_test_cases(
+        mesh_device, min_bandwidth_gbps, cluster_axis=0, data_valid_semaphore=data_valid_semaphore
+    )
+    if ttnn.get_fabric_config() == ttnn.FabricConfig.FABRIC_1D_RING:
+        # Cover the Blackhole four-worker region without another device setup. The old 4.5 MB/link heuristic chose
+        # eight workers here and measured below this floor; four bank-owning workers sustain more than 60 GB/s.
+        if ttnn.device.IsProgramRealtimeProfilerActive():
+            _run_high_bw_all_gather_perf(
+                mesh_device,
+                ttnn.bfloat16,
+                576,
+                ttnn.ROW_MAJOR_LAYOUT,
+                1152,
+                min_bandwidth_gbps=60.0,
+                cluster_axis=0,
+                data_valid_semaphore=data_valid_semaphore,
+                rows_per_device=_MEDIUM_BF16_ROWS_PER_DEVICE,
+            )
+        _run_high_bw_all_gather_accuracy(
+            mesh_device,
+            ttnn.bfloat16,
+            576,
+            ttnn.ROW_MAJOR_LAYOUT,
+            1152,
+            cluster_axis=0,
+            rows_per_device=_MEDIUM_BF16_ROWS_PER_DEVICE,
+            data_valid_semaphore=data_valid_semaphore,
+        )
+
+
+@pytest.mark.parametrize("device_params,min_bandwidth_gbps", _AXIS_1_PERF_DEVICE_PARAMS, indirect=["device_params"])
+@pytest.mark.parametrize("mesh_device", [(1, 8)], indirect=True)
+def test_high_bw_all_gather_512k_axis_1(mesh_device, min_bandwidth_gbps):
+    data_valid_semaphore = _create_data_valid_semaphore(mesh_device)
+    _run_high_bw_all_gather_test_cases(
+        mesh_device,
+        min_bandwidth_gbps,
+        cluster_axis=1,
+        data_valid_semaphore=data_valid_semaphore,
+    )
+
+
+@pytest.mark.parametrize("device_params", [_FABRIC_1D_RING_DEVICE_PARAMS], indirect=True)
+@pytest.mark.parametrize("mesh_device", [(8, 1)], indirect=True)
+def test_high_bw_all_gather_large_bank_owned_page(mesh_device):
+    """Cover large bank-owned pages and semaphore reuse across cached shapes."""
+    data_valid_semaphore = _create_data_valid_semaphore(mesh_device)
+    for rows_per_device in (_ACCURACY_ROWS_PER_DEVICE, _ACCURACY_ROWS_PER_DEVICE + 1):
+        _run_high_bw_all_gather_accuracy(
+            mesh_device,
+            ttnn.bfloat16,
+            4096,
+            ttnn.ROW_MAJOR_LAYOUT,
+            expected_page_size=8192,
+            cluster_axis=0,
+            rows_per_device=rows_per_device,
+            data_valid_semaphore=data_valid_semaphore,
+            compare_against_host_replica=True,
+        )
+
+
+@pytest.mark.parametrize("device_params", [_FABRIC_2D_LINE_DEVICE_PARAMS], indirect=True)
+@pytest.mark.parametrize("mesh_device", [(8, 1)], indirect=True)
+def test_high_bw_all_gather_512k_fabric_2d_line(mesh_device):
+    # The 8-device parent initializes the complete physical Fabric. Its 4-device slice deliberately omits the
+    # physical wraparound edge, exercising the Fabric2D direct-line admission path.
+    line_mesh = mesh_device.create_submesh(ttnn.MeshShape(4, 1))
+    data_valid_semaphore = _create_data_valid_semaphore(line_mesh)
+    _run_high_bw_all_gather_test_cases(
+        line_mesh,
+        min_bandwidth_gbps=45.0,
+        cluster_axis=0,
+        data_valid_semaphore=data_valid_semaphore,
+    )
+
+
+@pytest.mark.parametrize("device_params", [_FABRIC_2D_TORUS_XY_DEVICE_PARAMS], indirect=True)
+@pytest.mark.parametrize("mesh_device", [(8, 1)], indirect=True)
+def test_high_bw_all_gather_ragged_accuracy(mesh_device):
+    if os.getenv("TT_METAL_HIGH_BW_ALL_GATHER_RUN_RAGGED_ACCURACY") != "1":
+        pytest.skip("set TT_METAL_HIGH_BW_ALL_GATHER_RUN_RAGGED_ACCURACY=1 to run local ragged-slice accuracy")
+
+    selected_formats = set(
+        os.getenv(
+            "TT_METAL_HIGH_BW_ALL_GATHER_TEST_FORMATS",
+            "bf16_1152b_rows,scaled_fp8_704b_rows",
+        ).split(",")
+    )
+    rows_per_device_values = [
+        int(value)
+        for value in os.getenv(
+            "TT_METAL_HIGH_BW_ALL_GATHER_RAGGED_ACCURACY_ROWS",
+            "1003,6951",
+        ).split(",")
+    ]
+    data_valid_semaphore = _create_data_valid_semaphore(mesh_device)
+    for rows_per_device in rows_per_device_values:
+        for case_name, dtype, width, layout, expected_page_size in _TEST_CASES:
+            if case_name not in selected_formats:
+                continue
+            _run_high_bw_all_gather_accuracy(
+                mesh_device,
+                dtype,
+                width,
+                layout,
+                expected_page_size,
+                cluster_axis=0,
+                rows_per_device=rows_per_device,
+                data_valid_semaphore=data_valid_semaphore,
+            )
+
+
+def _token_sweep_sizes():
+    return [*range(5_000, 100_001, 5_000), *range(150_000, 500_001, 50_000)]
+
+
+def _print_high_bw_all_gather_perf_summary(mesh_device, cluster_axis, profile_samples, records):
+    axis_size = mesh_device.shape[cluster_axis]
+    lines = [
+        "",
+        "=== HIGH_BW_ALL_GATHER PERF SUMMARY ===",
+        (
+            f"fabric={str(ttnn.get_fabric_config()).removeprefix('FabricConfig.')} "
+            f"mesh={mesh_device.shape[0]}x{mesh_device.shape[1]} cluster_axis={cluster_axis} "
+            f"axis_size={axis_size} num_links={_NUM_LINKS} samples={profile_samples}"
+        ),
+        "Bandwidth is effective receive bandwidth per device; duration is the median device-program runtime.",
+        (
+            f"{'seq_len':>9}  {'effective':>9}  {'format':<23}  {'layout':<11}  "
+            f"{'page_B':>6}  {'duration_ms':>11}  {'BW_GB/s':>8}"
+        ),
+        f"{'-' * 9}  {'-' * 9}  {'-' * 23}  {'-' * 11}  {'-' * 6}  {'-' * 11}  {'-' * 8}",
+    ]
+    for record in records:
+        lines.append(
+            f"{record['global_tokens']:>9,}  {record['effective_global_tokens']:>9,}  "
+            f"{record['case']:<23}  {record['layout']:<11}  {record['page_size_bytes']:>6}  "
+            f"{record['median_us'] / 1e3:>11.3f}  {record['bandwidth_gbps']:>8.3f}"
+        )
+    lines.append("=== END HIGH_BW_ALL_GATHER PERF SUMMARY ===")
+    print("\n".join(lines), flush=True)
+
+
+def _run_high_bw_all_gather_token_sweep(
+    mesh_device,
+    min_bandwidth_gbps,
+    cluster_axis,
+    *,
+    token_sizes=None,
+    profile_samples=None,
+    require_opt_in=True,
+    output_path=None,
+    data_valid_semaphore=None,
+):
+    if require_opt_in and os.getenv("TT_METAL_HIGH_BW_ALL_GATHER_RUN_TOKEN_SWEEP") != "1":
+        pytest.skip("set TT_METAL_HIGH_BW_ALL_GATHER_RUN_TOKEN_SWEEP=1 to run the local token sweep")
+    if not ttnn.device.IsProgramRealtimeProfilerActive():
+        pytest.skip("the local token sweep requires the realtime device profiler")
+    if data_valid_semaphore is None:
+        data_valid_semaphore = _create_data_valid_semaphore(mesh_device)
+
+    if output_path is None:
+        output_path = Path(
+            os.getenv("TT_METAL_HIGH_BW_ALL_GATHER_TOKEN_SWEEP_CSV", "/tmp/high_bw_all_gather_token_sweep.csv")
+        )
+    selected_formats = set(
+        os.getenv(
+            "TT_METAL_HIGH_BW_ALL_GATHER_TOKEN_SWEEP_FORMATS",
+            ",".join(case_name for case_name, *_ in _TEST_CASES),
+        ).split(",")
+    )
+    if profile_samples is None:
+        profile_samples = int(os.getenv("TT_METAL_HIGH_BW_ALL_GATHER_TOKEN_SWEEP_SAMPLES", "3"))
+    if token_sizes is None:
+        token_sizes = [
+            int(value)
+            for value in os.getenv(
+                "TT_METAL_HIGH_BW_ALL_GATHER_TOKEN_SWEEP_TOKENS",
+                ",".join(str(value) for value in _token_sweep_sizes()),
+            ).split(",")
+        ]
+    axis_size = mesh_device.shape[cluster_axis]
+    fabric_config = str(ttnn.get_fabric_config()).removeprefix("FabricConfig.")
+    records = []
+
+    for global_tokens in token_sizes:
+        assert global_tokens % axis_size == 0
+        rows_per_device = global_tokens // axis_size
+        for case_name, dtype, width, layout, expected_page_size in _TEST_CASES:
+            if case_name not in selected_formats:
+                continue
+
+            effective_rows_per_device = (
+                math.ceil(rows_per_device / 32) * 32 if layout == ttnn.TILE_LAYOUT else rows_per_device
+            )
+
+            bandwidth_gbps, median_ns = _run_high_bw_all_gather_perf(
+                mesh_device,
+                dtype,
+                width,
+                layout,
+                expected_page_size,
+                min_bandwidth_gbps=0.0,
+                cluster_axis=cluster_axis,
+                data_valid_semaphore=data_valid_semaphore,
+                rows_per_device=rows_per_device,
+                profile_samples=profile_samples,
+            )
+            record = {
+                "fabric_config": fabric_config,
+                "cluster_axis": cluster_axis,
+                "case": case_name,
+                "layout": "tile" if layout == ttnn.TILE_LAYOUT else "row_major",
+                "global_tokens": global_tokens,
+                "rows_per_device": rows_per_device,
+                "effective_global_tokens": effective_rows_per_device * axis_size,
+                "page_size_bytes": expected_page_size,
+                "bandwidth_gbps": bandwidth_gbps,
+                "median_us": median_ns / 1e3,
+                "required_bandwidth_gbps": min_bandwidth_gbps,
+                "meets_floor": int(bandwidth_gbps >= min_bandwidth_gbps),
+            }
+            records.append(record)
+            write_header = not output_path.exists()
+            with output_path.open("a", newline="") as output_file:
+                writer = csv.DictWriter(output_file, fieldnames=record)
+                if write_header:
+                    writer.writeheader()
+                writer.writerow(record)
+            print(f"HIGH_BW_ALL_GATHER_TOKEN_SWEEP {record}")
+
+            # The caller-owned semaphore is reused by every cached shape; only
+            # dead tensor references need to be collected between points.
+            gc.collect()
+
+    _print_high_bw_all_gather_perf_summary(mesh_device, cluster_axis, profile_samples, records)
+    return records
+
+
+@pytest.mark.parametrize("device_params", [_FABRIC_2D_TORUS_XY_DEVICE_PARAMS], indirect=True)
+@pytest.mark.parametrize(
+    "mesh_device",
+    [pytest.param((8, 4), id="mesh-8x4")],
+    indirect=True,
+)
+@pytest.mark.timeout(1800)
+def test_high_bw_all_gather_galaxy_perf(mesh_device):
+    """Measure the four production formats on the SP rings of a Torus-XY Blackhole Galaxy."""
+    if os.getenv("TT_METAL_HIGH_BW_ALL_GATHER_RUN_GALAXY_PERF") != "1":
+        pytest.skip("set TT_METAL_HIGH_BW_ALL_GATHER_RUN_GALAXY_PERF=1 to run the Galaxy perf matrix")
+    if not ttnn.device.IsProgramRealtimeProfilerActive():
+        pytest.fail("the Galaxy perf matrix requires the realtime device profiler")
+
+    output_path = Path(
+        os.getenv(
+            "TT_METAL_HIGH_BW_ALL_GATHER_GALAXY_PERF_CSV",
+            "/tmp/high_bw_all_gather_galaxy_perf.csv",
+        )
+    )
+    output_path.unlink(missing_ok=True)
+    data_valid_semaphore = _create_data_valid_semaphore(mesh_device)
+    _run_high_bw_all_gather_token_sweep(
+        mesh_device,
+        min_bandwidth_gbps=0.0,
+        cluster_axis=0,
+        token_sizes=_GALAXY_PERF_GLOBAL_TOKENS,
+        profile_samples=_GALAXY_PERF_PROFILE_SAMPLES,
+        require_opt_in=False,
+        output_path=output_path,
+        data_valid_semaphore=data_valid_semaphore,
+    )
+
+    for case_name, dtype, width, layout, expected_page_size in _TEST_CASES:
+        _run_high_bw_all_gather_accuracy(
+            mesh_device,
+            dtype,
+            width,
+            layout,
+            expected_page_size,
+            cluster_axis=0,
+            rows_per_device=_ACCURACY_ROWS_PER_DEVICE,
+            data_valid_semaphore=data_valid_semaphore,
+            compare_against_host_replica=True,
+        )
+        print(
+            f"HIGH_BW_ALL_GATHER_GALAXY_ACCURACY case={case_name} "
+            f"rows_per_device={_ACCURACY_ROWS_PER_DEVICE} exact_match=PASS",
+            flush=True,
+        )
+
+
+@pytest.mark.parametrize("device_params,min_bandwidth_gbps", _PERF_DEVICE_PARAMS, indirect=["device_params"])
+@pytest.mark.parametrize("mesh_device", [(8, 1)], indirect=True)
+@pytest.mark.timeout(1800)
+def test_high_bw_all_gather_token_sweep(mesh_device, min_bandwidth_gbps):
+    _run_high_bw_all_gather_token_sweep(mesh_device, min_bandwidth_gbps, cluster_axis=0)
+
+
+@pytest.mark.parametrize("device_params,min_bandwidth_gbps", _AXIS_1_PERF_DEVICE_PARAMS, indirect=["device_params"])
+@pytest.mark.parametrize("mesh_device", [(1, 8)], indirect=True)
+@pytest.mark.timeout(1800)
+def test_high_bw_all_gather_token_sweep_axis_1(mesh_device, min_bandwidth_gbps):
+    _run_high_bw_all_gather_token_sweep(mesh_device, min_bandwidth_gbps, cluster_axis=1)

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/CMakeLists.txt
@@ -3,6 +3,7 @@
 add_subdirectory(combine)
 add_subdirectory(dispatch)
 add_subdirectory(extract)
+add_subdirectory(high_bw_all_gather)
 add_subdirectory(inbound_socket_service_sync)
 add_subdirectory(insert)
 add_subdirectory(masked_bincount)
@@ -29,6 +30,7 @@ target_link_libraries(
         TTNN::Ops::Experimental::DeepSeekPrefill::Combine
         TTNN::Ops::Experimental::DeepSeekPrefill::Dispatch
         TTNN::Ops::Experimental::DeepSeekPrefill::Extract
+        TTNN::Ops::Experimental::DeepSeekPrefill::HighBwAllGather
         TTNN::Ops::Experimental::DeepSeekPrefill::H2dSocketSync
         TTNN::Ops::Experimental::DeepSeekPrefill::Insert
         TTNN::Ops::Experimental::DeepSeekPrefill::MaskedBincount
@@ -62,6 +64,7 @@ target_sources(
         $<TARGET_OBJECTS:TTNN::Ops::Experimental::DeepSeekPrefill::Combine>
         $<TARGET_OBJECTS:TTNN::Ops::Experimental::DeepSeekPrefill::Dispatch>
         $<TARGET_OBJECTS:TTNN::Ops::Experimental::DeepSeekPrefill::Extract>
+        $<TARGET_OBJECTS:TTNN::Ops::Experimental::DeepSeekPrefill::HighBwAllGather>
         $<TARGET_OBJECTS:TTNN::Ops::Experimental::DeepSeekPrefill::H2dSocketSync>
         $<TARGET_OBJECTS:TTNN::Ops::Experimental::DeepSeekPrefill::Insert>
         $<TARGET_OBJECTS:TTNN::Ops::Experimental::DeepSeekPrefill::MaskedBincount>

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/high_bw_all_gather/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/high_bw_all_gather/CMakeLists.txt
@@ -1,0 +1,58 @@
+include(sources.cmake)
+
+add_library(ttnn_op_experimental_deepseek_prefill_high_bw_all_gather ${LIB_TYPE})
+add_library(
+    TTNN::Ops::Experimental::DeepSeekPrefill::HighBwAllGather
+    ALIAS ttnn_op_experimental_deepseek_prefill_high_bw_all_gather
+)
+
+target_precompile_headers(ttnn_op_experimental_deepseek_prefill_high_bw_all_gather REUSE_FROM TTNN::PCHFull)
+TT_ENABLE_UNITY_BUILD(ttnn_op_experimental_deepseek_prefill_high_bw_all_gather)
+
+set_target_properties(
+    ttnn_op_experimental_deepseek_prefill_high_bw_all_gather
+    PROPERTIES
+        INTERFACE_HEADER_SETS_TO_VERIFY
+            api
+)
+
+file(
+    GLOB_RECURSE kernels
+    device/kernels/*.cpp
+    device/kernels/*.hpp
+)
+target_sources(
+    ttnn_op_experimental_deepseek_prefill_high_bw_all_gather
+    PUBLIC
+        FILE_SET api
+        TYPE HEADERS
+        BASE_DIRS ${FixmeOpAPIDir}
+        FILES ${TTNN_OP_EXPERIMENTAL_DEEPSEEK_PREFILL_HIGH_BW_ALL_GATHER_API_HEADERS}
+        FILE_SET kernels
+        TYPE HEADERS
+        BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}
+        FILES ${kernels}
+    PRIVATE
+        ${TTNN_OP_EXPERIMENTAL_DEEPSEEK_PREFILL_HIGH_BW_ALL_GATHER_SRCS}
+)
+
+target_link_libraries(ttnn_op_experimental_deepseek_prefill_high_bw_all_gather PRIVATE TT::Metalium PUBLIC TTNN::Core)
+
+install(
+    TARGETS
+        ttnn_op_experimental_deepseek_prefill_high_bw_all_gather
+    FILE_SET
+    kernels
+        DESTINATION
+            ${CMAKE_INSTALL_LIBEXECDIR}/tt-metalium/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/high_bw_all_gather
+        COMPONENT ttnn-runtime
+    FILE_SET
+    api
+        COMPONENT ttnn-dev
+    LIBRARY
+        COMPONENT tar
+)
+
+if(TARGET ttnn)
+    target_sources(ttnn PRIVATE ${TTNN_OP_EXPERIMENTAL_DEEPSEEK_PREFILL_HIGH_BW_ALL_GATHER_NANOBIND_SRCS})
+endif()

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/high_bw_all_gather/README.md
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/high_bw_all_gather/README.md
@@ -1,0 +1,237 @@
+# High-bandwidth all-gather
+
+`ttnn.experimental.deepseek_prefill.high_bw_all_gather` is a dedicated
+large-message collective for the sparse-MLA prefill path. It is independent of
+`ttnn.all_gather`: there is no composite fallback and no environment-variable
+selection.
+
+## Contract
+
+- row-major or tile-layout DRAM input;
+- preallocated, persistent, interleaved-DRAM output;
+- required `cluster_axis` (0 for N/S or 1 for E/W) selecting one mesh axis
+  with at least two devices and at least one Fabric link;
+- tensor distribution axes aligned with the physical device-mesh axes;
+- optional `num_links`; by default the op uses the number of links discovered
+  usable across the complete selected axis. An override must be greater than
+  zero and no larger than that discovered count;
+- a one-dimensional all-gather only: devices on the orthogonal mesh axis run
+  independent collectives, and gathering across both axes is unsupported;
+- Fabric1D line/ring, or Fabric2D on a direct physical line/ring;
+- Fabric2D Torus can wrap `cluster_axis` when the axis has a distinct wrap
+  neighbor and every ring edge is a direct physical hop; a size-two torus axis
+  uses the line schedule because its ordinary and wrap neighbors coincide;
+- required caller-owned `data_valid_semaphore`, initialized to zero and
+  covering every candidate worker core. Allocate it in L1-small when that
+  region is configured and reuse it across tensor shapes/program-cache entries;
+- worker and mux cores must be exclusive to this program for its duration. On
+  the qualified two-link Blackhole ring, the large-message path uses 32
+  reader/writer workers plus four mux cores. Each active mux owns its
+  `FabricMuxConfig` region starting at the L1 allocator base (about 230 KiB for
+  eight full-size, double-buffered channels); program creation rejects a mux
+  map that exceeds the physical per-core L1 capacity. Use `sub_core_grid` to
+  keep unrelated L1-resident tensors and concurrent programs off those cores.
+
+Fabric2D eligibility is intentionally strict. The host resolves each directed
+line or ring neighbor, verifies every requested link index, and hashes the
+complete physical route plan into the program-cache key. A topology that would
+require Fabric forwarding is rejected rather than silently taking a slower or
+unsafe path. Fabric handles a size-two torus dimension specially: because the
+ordinary and wrap neighbors collapse onto the same physical connection, the
+axis retains mesh directionality and the operation uses its line schedule.
+Genuine torus dimensions retain wrap routing and deadlock avoidance.
+
+`cluster_axis` is the device-mesh dimension, while `dim` is the tensor
+dimension concatenated by the collective. On an `(R, C)` mesh, axis 0 produces
+independent `R`-device gathers in each column; axis 1 produces independent
+`C`-device gathers in each row. The output extent at `dim` must be multiplied
+by the selected axis size, not by `R * C`.
+
+Link discovery chooses a uniform count supported by every participating
+device and direction. Set `num_links=2` when results should be comparable
+across QuietBox (four available links), LoudBox, and Galaxy (two available
+links). This is a cap on discovered hardware capacity: requesting more links
+than Fabric reports fails before program construction.
+
+Create the synchronization semaphore once, before the shape loop:
+
+```python
+grid = mesh_device.compute_with_storage_grid_size()
+worker_cores = ttnn.CoreRangeSet(
+    {
+        ttnn.CoreRange(
+            ttnn.CoreCoord(0, 0),
+            ttnn.CoreCoord(grid.x - 1, grid.y - 1),
+        )
+    }
+)
+data_valid_semaphore = ttnn.create_global_semaphore(
+    mesh_device,
+    worker_cores,
+    0,
+    buffer_type=ttnn.BufferType.L1_SMALL,
+)
+
+output = ttnn.experimental.deepseek_prefill.high_bw_all_gather(
+    input,
+    dim=2,
+    output_tensor=persistent_output,
+    cluster_axis=0,
+    data_valid_semaphore=data_valid_semaphore,
+    num_links=2,
+)
+```
+
+The op checks the semaphore's device and core coverage on every invocation and
+runtime-patches its address on program-cache hits. Structurally equivalent
+semaphores therefore share compiled programs. Reuse one semaphore for
+serialized invocations; concurrent invocations need distinct semaphores.
+
+## Data flow
+
+```text
+local DRAM pages
+      |
+      | bank-owned readers (2 links x 8 workers/direction on Blackhole)
+      v
+  Tensix CBs -- full-packet coalescing --> Fabric mux --> adjacent ERISC
+                                                        |
+                                                        | terminal one-hop packet
+                                                        v
+                                                neighbor output DRAM
+                                                        |
+                                                        | next relay iteration
+                                                        v
+                                                neighbor Tensix readers
+```
+
+Forward and backward halves run concurrently. A shard reaches a distant
+logical rank through store-and-forward iterations: each transfer is terminal
+at the adjacent physical device, and the next device rereads the received rows
+from its persistent output before sending the next hop. This avoids multi-hop
+Fabric2D packets, corner forwarding, dateline handling, and router-side
+terminal delivery changes.
+
+Small sparse-MLA rows and tiles are assigned by destination DRAM bank. Each
+writer can therefore combine consecutive bank-local pages into large Fabric
+packets rather than issuing small scatter packets. One L1-small `data_valid`
+semaphore per worker grid gates relay reads and records completion; persistent
+output removes the separate allocation-readiness handshake. Program creation
+also reports the required circular-buffer bytes and available L1 headroom
+explicitly when the fixed three-entry worker CB cannot fit below live L1
+allocations.
+
+## Minimal Fabric requirements
+
+### One-hop validation
+
+The op proves that each logical line/ring edge is one physical hop by combining the
+existing `pipeline_get_forwarding_direction` and `pipeline_get_chip_neighbors`
+control-plane queries. This is a host-side safety check with no firmware or
+performance effect and requires no Fabric change.
+
+The operation follows the configured topology rather than opportunistically
+upgrading a plain `FABRIC_2D` mesh to a ring. `FABRIC_2D_TORUS_X` wraps axis 1,
+`FABRIC_2D_TORUS_Y` wraps axis 0, and `FABRIC_2D_TORUS_XY` can wrap either axis.
+If the configured Fabric does not wrap `cluster_axis`, the operation uses its
+direct-line schedule.
+
+### Worker-injection spare slots
+
+The Fabric2D static allocator selects a uniform packet-slot depth per virtual
+channel. On this topology that discrete choice consumes 20 of 25 available
+slots and leaves five whole slots unused. The change assigns only those five
+stranded slots to the live VC0 local-worker injection channel:
+
+- local-worker sender depth: 2 -> 7;
+- forwarding and receive depths: unchanged;
+- total allocation: still exactly the existing L1 capacity;
+- Fabric1D Ring allocation: unchanged and covered by a host unit test.
+
+This cannot be recovered by more op-level packet coalescing. The op already
+emits large packets through the mux; the two-slot sender credit window is owned
+by the ERISC Fabric allocator and limits how many packets the workers can have
+in flight. An op-only workaround would require smaller packets or topology- and
+format-specific throttling, reducing link efficiency without exposing the
+unused buffer capacity.
+
+No other Fabric changes are required. In particular, this implementation does
+not need router firmware changes, corner forwarding, dateline escape VCs,
+terminal offload, a channel-trimming profile, or runtime tuning variables.
+
+### Channel-trimming compatibility
+
+Channel trimming is configured when Fabric is initialized and applies to the
+entire workload, not to an individual CCL. A captured profile must therefore
+cover every CCL and shape that the process will run.
+
+Until the Fabric trim-derived speedy-VC0 eligibility distinguishes this
+high-rate, multi-worker all-gather from a simple source/terminal flow, use the
+VC0 override below with any channel-trimming profile for a workload that
+contains this op. The op remains correct without the override, but can suffer a
+substantial performance regression.
+
+```bash
+TT_METAL_FABRIC_TRIMMING_PROFILE=/path/to/channel_trimming_capture.yaml \
+TT_METAL_FABRIC_TRIMMING_OVERRIDE=/path/to/enable_vc0_all_channels.yaml \
+scripts/run_safe_pytest.sh \
+  tests/ttnn/unit_tests/operations/experimental/deepseek_prefill/test_high_bw_all_gather.py
+```
+
+Create `enable_vc0_all_channels.yaml` with:
+
+```yaml
+channel_trimming_overrides:
+  vc0:
+    force_enable_all_sender_channels: true
+    force_enable_all_receiver_channels: true
+```
+
+The override force-enables all VC0 sender and receiver channels for the Fabric
+instance. It is a workload-level compatibility setting: it prevents the
+problematic trim-derived VC0 fast path, but also gives up VC0 channel-service
+trimming for every op in that Fabric instance. Use a separate process/Fabric
+instance if another workload needs a different trimming policy.
+
+## Measured contribution
+
+Measurements use firmware `19.10.99`, an 8x1 mesh, two links, a 14,336-byte
+Fabric payload, 65,536 rows per device (512K rows globally), persistent output,
+and seven cached device-profiler samples. Effective receive bandwidth is
+`local_bytes * (axis_size - 1) / device_program_time`.
+
+| Format | Fabric | Schedule | Median | Effective receive BW |
+| --- | --- | ---: | ---: | ---: |
+| BF16, 1,152-B row | Fabric1D | line | 10.901 ms | 48.480 GB/s |
+| BF16, 1,152-B row | Fabric1D Ring | ring | 5.565 ms | 94.969 GB/s |
+| BF16, 1,152-B row | Fabric2D | direct physical line | 10.973 ms | 48.162 GB/s |
+
+The Fabric2D line is therefore expected to provide line bandwidth, not the
+two-direction ring bandwidth. Fabric2D Torus uses the ring schedule only when
+the active axis has at least three devices and a direct physical wrap edge; a
+size-two dimension such as the Y axis of the 2x4 LoudBox remains a line.
+
+## Qualification
+
+Run the host allocator invariants:
+
+```bash
+build_Release/test/tt_metal/tt_fabric/fabric_unit_tests \
+  --gtest_filter='FabricStaticSizedChannelsAllocatorTest.*'
+```
+
+Run exact correctness and performance for all supported Fabric configurations,
+both layouts, and all four format/layout combinations:
+
+```bash
+TT_METAL_DISABLE_PRECOMPILED_FW=1 \
+scripts/run_safe_pytest.sh \
+  tests/ttnn/unit_tests/operations/experimental/deepseek_prefill/test_high_bw_all_gather.py \
+  -x -s -v
+```
+
+Do not add `--dev`: watcher and LLK assertions increase firmware code size for
+this test. The test requires the standalone unicast kernel in profiler records,
+compares every gathered replica exactly (including opaque FP8 payload bytes and
+decoded BFP8_B tiles), and enforces a 90 GB/s regression floor for Fabric1D
+Ring and active-axis Fabric2D Torus, and a 45 GB/s floor for line schedules.

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/high_bw_all_gather/device/high_bw_all_gather_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/high_bw_all_gather/device/high_bw_all_gather_device_operation.cpp
@@ -1,0 +1,395 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "high_bw_all_gather_device_operation.hpp"
+#include "high_bw_all_gather_device_operation_types.hpp"
+
+#include "ttnn/device_operation.hpp"
+#include "ttnn/tensor/tensor_ops.hpp"
+#include "ttnn/operations/ccl/ccl_common.hpp"
+#include "ttnn/operations/ccl/common/host/moe_utils.hpp"
+
+#include <tt-metalium/experimental/fabric/pipeline_builder.hpp>
+
+#include <algorithm>
+
+namespace ttnn::operations::experimental::deepseek_prefill::high_bw_all_gather {
+
+namespace {
+
+tt::tt_metal::TensorTopology derive_output_topology(const Tensor& input_tensor, uint32_t cluster_axis) {
+    const auto& input_topology = input_tensor.tensor_topology();
+    auto output_placements = input_topology.placements();
+    TT_FATAL(
+        cluster_axis < output_placements.size() && cluster_axis < input_topology.distribution_shape().dims(),
+        "high_bw_all_gather requires the tensor distribution axes to match the device mesh axes; "
+        "cluster_axis={}, distribution rank={}, placement count={}",
+        cluster_axis,
+        input_topology.distribution_shape().dims(),
+        output_placements.size());
+
+    // This is a one-dimensional collective: only the participating mesh axis becomes replicated.
+    // Another mesh axis may independently shard the same tensor dimension and must remain sharded.
+    output_placements[cluster_axis] = tt::tt_metal::distributed::MeshMapperConfig::Replicate{};
+    return tt::tt_metal::TensorTopology(
+        input_topology.distribution_shape(), std::move(output_placements), input_topology.mesh_coords());
+}
+
+// Proves that every neighbor edge used by the unicast implementation is a single physical Fabric hop and has all
+// requested links. A Fabric2D logical axis must not be admitted merely because a route exists: this program only
+// emits one-hop sends to its immediate mesh neighbors.
+std::optional<uint64_t> resolve_direct_neighbor_route_hash(
+    const Tensor& tensor, uint32_t axis, uint32_t num_links, tt::tt_fabric::Topology topology) {
+    auto* mesh_device = tensor.device();
+    const auto shape = mesh_device->shape();
+    if (shape[axis] < 2 || num_links == 0) {
+        return std::nullopt;
+    }
+
+    const bool is_ring = topology == tt::tt_fabric::Topology::Ring;
+    auto hash = ttsl::hash::hash_objects_with_default_seed(axis, num_links, shape[axis], shape[1 - axis], topology);
+    for (uint32_t group = 0; group < shape[1 - axis]; ++group) {
+        for (uint32_t rank = 0; rank < shape[axis]; ++rank) {
+            const auto source_coord = axis == 0 ? MeshCoordinate(rank, group) : MeshCoordinate(group, rank);
+            const auto source = mesh_device->get_fabric_node_id(source_coord);
+            for (const int32_t offset : {-1, 1}) {
+                const int32_t destination_rank_signed = static_cast<int32_t>(rank) + offset;
+                if (!is_ring && (destination_rank_signed < 0 || destination_rank_signed >= shape[axis])) {
+                    continue;  // A linear endpoint has no neighbor in this direction.
+                }
+                const auto destination_rank = static_cast<uint32_t>(
+                    (destination_rank_signed + static_cast<int32_t>(shape[axis])) % static_cast<int32_t>(shape[axis]));
+                const auto destination_coord =
+                    axis == 0 ? MeshCoordinate(destination_rank, group) : MeshCoordinate(group, destination_rank);
+                const auto destination = mesh_device->get_fabric_node_id(destination_coord);
+                const auto direction = tt::tt_fabric::pipeline_get_forwarding_direction(source, destination);
+                if (!direction.has_value()) {
+                    return std::nullopt;
+                }
+                const auto neighbors = tt::tt_fabric::pipeline_get_chip_neighbors(source, *direction);
+                const auto mesh_it = neighbors.find(*destination.mesh_id);
+                if (mesh_it == neighbors.end() ||
+                    std::find(mesh_it->second.begin(), mesh_it->second.end(), destination.chip_id) ==
+                        mesh_it->second.end()) {
+                    return std::nullopt;
+                }
+                const auto link_indices = tt::tt_fabric::get_forwarding_link_indices(source, destination);
+                for (uint32_t link = 0; link < num_links; ++link) {
+                    if (std::find(link_indices.begin(), link_indices.end(), link) == link_indices.end()) {
+                        return std::nullopt;
+                    }
+                }
+                hash = ttsl::hash::hash_objects(
+                    hash,
+                    source.mesh_id,
+                    source.chip_id,
+                    destination.mesh_id,
+                    destination.chip_id,
+                    group,
+                    rank,
+                    destination_rank,
+                    link_indices);
+            }
+        }
+    }
+    return hash;
+}
+
+CoreRangeSet candidate_worker_cores(
+    const HighBwAllGatherParams& args, tt::tt_metal::distributed::MeshDevice* mesh_device) {
+    const auto subdevice_id = args.subdevice_id.value_or(mesh_device->get_sub_device_ids().at(0));
+    auto cores = mesh_device->worker_cores(tt::tt_metal::HalProgrammableCoreType::TENSIX, subdevice_id);
+    if (args.sub_core_grid.has_value()) {
+        cores = cores.intersection(*args.sub_core_grid);
+    }
+    return cores;
+}
+
+void validate_data_valid_semaphore(const HighBwAllGatherParams& args, const HighBwAllGatherInputs& tensor_args) {
+    TT_FATAL(args.data_valid_semaphore.has_value(), "high_bw_all_gather requires a data_valid_semaphore");
+    const auto& semaphore = *args.data_valid_semaphore;
+    auto* mesh_device = tensor_args.input_tensor.device();
+    TT_FATAL(
+        semaphore.device() == mesh_device,
+        "high_bw_all_gather data_valid_semaphore must be allocated on the input tensor's mesh device");
+    const auto semaphore_cores = std::get<0>(semaphore.attribute_values());
+    const auto required_cores = candidate_worker_cores(args, mesh_device);
+    TT_FATAL(
+        required_cores.num_cores() > 0,
+        "high_bw_all_gather has no candidate worker cores in the selected subdevice/sub_core_grid");
+    TT_FATAL(
+        semaphore_cores.contains(required_cores),
+        "high_bw_all_gather data_valid_semaphore must cover every candidate worker core; required {}, semaphore {}",
+        required_cores,
+        semaphore_cores);
+}
+
+}  // namespace
+
+void HighBwAllGatherDeviceOperation::validate_on_program_cache_miss(
+    const HighBwAllGatherParams& args, const HighBwAllGatherInputs& tensor_args) {
+    const auto& input_tensor = tensor_args.input_tensor;
+
+    // Constraints on input tensor
+    TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "Input tensor must to be on device!");
+    TT_FATAL(input_tensor.buffer() != nullptr, "Input tensor must be allocated in buffers on device!");
+
+    // Constraints on other inputs
+    int32_t rank = static_cast<int32_t>(input_tensor.logical_shape().rank());
+    TT_FATAL(args.dim >= -rank && args.dim < rank, "Invalid gather dim {} for {}D input tensor", args.dim, rank);
+    TT_FATAL(
+        args.num_devices > 1,
+        "high_bw_all_gather collective will only work for num_devices > 1, got {}",
+        args.num_devices);
+
+    // This op implements a single direct-neighbor line/ring, never a 2D collective.
+    const auto mesh_shape = input_tensor.device()->shape();
+    TT_FATAL(
+        args.cluster_axis < 2 && args.cluster_axis < mesh_shape.dims() && mesh_shape[args.cluster_axis] > 1,
+        "high_bw_all_gather requires cluster_axis to select a mesh axis with at least two devices; "
+        "cluster_axis={}, mesh_shape={}",
+        args.cluster_axis,
+        mesh_shape);
+    TT_FATAL(
+        (args.axis_num_devices[0] > 1) != (args.axis_num_devices[1] > 1),
+        "high_bw_all_gather is a one-dimensional all-gather along cluster_axis {}; it cannot gather across both "
+        "mesh axes",
+        args.cluster_axis);
+
+    TT_FATAL(
+        input_tensor.layout() == ttnn::ROW_MAJOR_LAYOUT || input_tensor.layout() == ttnn::TILE_LAYOUT,
+        "high_bw_all_gather requires row-major or tile-layout input");
+    TT_FATAL(input_tensor.buffer()->is_dram(), "high_bw_all_gather requires DRAM input");
+    TT_FATAL(
+        args.neighbor_unicast_eligible,
+        "high_bw_all_gather requires a one-dimensional direct-neighbor line/ring; devices={}, links={}, topology={}, "
+        "route_hash={}",
+        args.axis_num_devices,
+        args.axis_num_links,
+        args.axis_topology,
+        args.neighbor_route_plan_hash);
+
+    {
+        const auto& output_tensor = tensor_args.output_tensor;
+
+        TT_FATAL(output_tensor.storage_type() == StorageType::DEVICE, "Output tensor must be on device!");
+        TT_FATAL(
+            output_tensor.layout() == input_tensor.layout(),
+            "Output tensor layout {} should be same as input tensor layout {}",
+            output_tensor.layout(),
+            input_tensor.layout());
+        TT_FATAL(
+            output_tensor.dtype() == input_tensor.dtype(),
+            "Output tensor dtype {} should be same as input tensor dtype {}",
+            output_tensor.dtype(),
+            input_tensor.dtype());
+        TT_FATAL(
+            output_tensor.tensor_spec().page_config() == input_tensor.tensor_spec().page_config(),
+            "Output tensor page config {} should be same as input tensor page config {}",
+            output_tensor.tensor_spec().page_config(),
+            input_tensor.tensor_spec().page_config());
+
+        // Check the output tensor size
+        auto output_shape = output_tensor.padded_shape();
+        auto input_padded_shape = input_tensor.padded_shape();
+        auto expected_output_shape = input_padded_shape;
+        expected_output_shape[args.dim] = input_padded_shape[args.dim] * args.num_devices;
+        TT_FATAL(
+            output_shape.size() == input_padded_shape.size(),
+            "Output tensor shape should have same number of dimensions as input tensor but has {}",
+            output_shape.size());
+        TT_FATAL(
+            output_shape == expected_output_shape,
+            "Output tensor shape must be {}, got {}",
+            expected_output_shape,
+            output_shape);
+    }
+
+    TT_FATAL(
+        args.output_mem_config.memory_layout() == TensorMemoryLayout::INTERLEAVED &&
+            args.output_mem_config.buffer_type() == BufferType::DRAM,
+        "high_bw_all_gather requires interleaved DRAM output");
+
+    validate_data_valid_semaphore(args, tensor_args);
+}
+
+void HighBwAllGatherDeviceOperation::validate_on_program_cache_hit(
+    const HighBwAllGatherParams& args, const HighBwAllGatherInputs& tensor_args) {
+    // The semaphore address is deliberately runtime-patched and excluded from
+    // the structural cache identity, so validate its device and core coverage
+    // on every invocation.
+    validate_data_valid_semaphore(args, tensor_args);
+}
+
+HighBwAllGatherDeviceOperation::spec_return_value_t HighBwAllGatherDeviceOperation::compute_output_specs(
+    const HighBwAllGatherParams& args, const HighBwAllGatherInputs& tensor_args) {
+    const auto& input_tensor = tensor_args.input_tensor;
+    // The kernels gather complete device pages. A tile shard whose logical
+    // gather extent is not tile-aligned therefore exposes the gathered padded
+    // extent, matching the required preallocated output tensor.
+    auto shape = input_tensor.padded_shape();
+    shape[args.dim] *= args.num_devices;
+    return tt::tt_metal::TensorSpec(
+        shape,
+        tt::tt_metal::TensorLayout(
+            input_tensor.dtype(), input_tensor.tensor_spec().page_config(), args.output_mem_config));
+}
+
+HighBwAllGatherDeviceOperation::topology_return_value_t HighBwAllGatherDeviceOperation::compute_output_topologies(
+    const HighBwAllGatherParams& args, const HighBwAllGatherInputs& tensor_args) {
+    return {derive_output_topology(tensor_args.input_tensor, args.cluster_axis)};
+}
+
+HighBwAllGatherDeviceOperation::tensor_return_value_t HighBwAllGatherDeviceOperation::create_output_tensors(
+    const HighBwAllGatherParams&, const HighBwAllGatherInputs& tensor_args) {
+    return tensor_args.output_tensor;
+}
+
+HighBwAllGatherDeviceOperation::program_factory_t HighBwAllGatherDeviceOperation::select_program_factory(
+    const HighBwAllGatherParams&, const HighBwAllGatherInputs&) {
+    return program_factory_t{HighBwAllGatherUnicastFactory{}};
+}
+
+std::tuple<HighBwAllGatherParams, HighBwAllGatherInputs> high_bw_all_gather_build_operation_args(
+    const Tensor& input_tensor,
+    const ttnn::Tensor& output_tensor,
+    int32_t dim,
+    uint32_t cluster_axis,
+    const GlobalSemaphore& data_valid_semaphore,
+    const std::optional<tt::tt_metal::SubDeviceId>& subdevice_id,
+    const std::optional<CoreRangeSet>& sub_core_grid,
+    std::optional<uint32_t> num_links) {
+    // Query the machine and Fabric setup info.
+    // This info is also effectively part of CCL args and hence should be in the program-cache hash,
+    // so we include it in HighBwAllGatherParams.
+    auto* mesh_device = input_tensor.device();
+    TT_FATAL(mesh_device != nullptr, "Input tensor should be on device for high_bw_all_gather operation");
+    const auto mesh_shape = mesh_device->shape();
+    TT_FATAL(
+        mesh_shape.dims() == 2, "high_bw_all_gather requires a two-dimensional device mesh shape, got {}", mesh_shape);
+    TT_FATAL(
+        cluster_axis < 2 && cluster_axis < mesh_shape.dims(),
+        "high_bw_all_gather cluster_axis must be 0 or 1, got {} for mesh shape {}",
+        cluster_axis,
+        mesh_shape);
+    TT_FATAL(
+        mesh_shape[cluster_axis] > 1,
+        "high_bw_all_gather cluster_axis {} selects a singleton mesh axis in mesh shape {}",
+        cluster_axis,
+        mesh_shape);
+    TT_FATAL(
+        output_tensor.device() == mesh_device,
+        "high_bw_all_gather input and output tensors must be on the same mesh device");
+
+    const auto fabric_config = tt::tt_fabric::GetFabricConfig();
+    // Axis 0 is N/S, and axis 1 is E/W.
+    // An inactive axis has num_devices = 1, num_links = 0, Linear topology.
+    std::array<tt::tt_fabric::Topology, 2> axis_topology{
+        tt::tt_fabric::Topology::Linear, tt::tt_fabric::Topology::Linear};
+    std::array<uint32_t, 2> axis_num_devices{1u, 1u};
+    std::array<uint32_t, 2> axis_num_links{0u, 0u};
+    for (uint32_t axis = 0; axis < 2; ++axis) {
+        const bool is_axis_active = mesh_shape[axis] > 1 && cluster_axis == axis;
+        if (!is_axis_active) {
+            continue;
+        }
+        axis_topology[axis] = ::ttnn::ccl::get_axis_topology(input_tensor, fabric_config, axis);
+        axis_num_devices[axis] = ::ttnn::ccl::get_topological_dimension(input_tensor, axis);
+        const auto discovered_num_links =
+            static_cast<uint32_t>(ttnn::operations::ccl::common::get_num_links(*mesh_device, axis));
+        if (num_links.has_value()) {
+            TT_FATAL(
+                *num_links > 0,
+                "high_bw_all_gather num_links must be greater than 0 when specified, got {}",
+                *num_links);
+            TT_FATAL(
+                *num_links <= discovered_num_links,
+                "high_bw_all_gather requested {} links, but only {} usable links were discovered on cluster_axis {}",
+                *num_links,
+                discovered_num_links,
+                cluster_axis);
+        }
+        axis_num_links[axis] = num_links.value_or(discovered_num_links);
+    }
+    const uint32_t num_devices = axis_num_devices[0] * axis_num_devices[1];  // devices partaking in the collective
+    const size_t packet_size = tt::tt_fabric::get_tt_fabric_max_payload_size_bytes();
+    const bool one_active_axis = (axis_num_devices[0] > 1) != (axis_num_devices[1] > 1);
+    const uint32_t active_axis = axis_num_devices[0] > 1 ? 0 : 1;
+    const auto active_topology = axis_topology[active_axis];
+    const bool topology_supports_neighbor_unicast =
+        active_topology == tt::tt_fabric::Topology::Linear || active_topology == tt::tt_fabric::Topology::Ring;
+    const bool fabric_is_2d = ::tt::tt_fabric::is_2d_fabric_config(fabric_config);
+    // A direct physical line or ring is supported. The full edge proof keeps routed multi-hop logical rings out of
+    // this native one-hop implementation.
+    const auto direct_neighbor_route_hash =
+        one_active_axis && fabric_is_2d ? resolve_direct_neighbor_route_hash(
+                                              input_tensor, active_axis, axis_num_links[active_axis], active_topology)
+                                        : std::nullopt;
+    const bool neighbor_unicast_eligible =
+        one_active_axis && axis_num_links[active_axis] > 0 &&
+        ((!fabric_is_2d && topology_supports_neighbor_unicast) || direct_neighbor_route_hash.has_value());
+
+    log_debug(
+        tt::LogOp,
+        "fabric_config: {}, axis_topology: {}, axis_num_devices: {}, axis_num_links: {}, num_links override: {}, "
+        "packet_size: {} B",
+        fabric_config,
+        axis_topology,
+        axis_num_devices,
+        axis_num_links,
+        num_links,
+        packet_size);
+
+    // Resolve negative gather dim
+    uint32_t rank = input_tensor.logical_shape().rank();
+    int32_t gather_dim = (dim < 0) ? rank + dim : dim;
+
+    return {
+        HighBwAllGatherParams{
+            .dim = gather_dim,
+            .output_mem_config = output_tensor.memory_config(),
+            .cluster_axis = cluster_axis,
+            .fabric_config = fabric_config,
+            .axis_topology = axis_topology,
+            .axis_num_devices = axis_num_devices,
+            .axis_num_links = axis_num_links,
+            .num_devices = num_devices,
+            .packet_size = packet_size,
+            .neighbor_unicast_eligible = neighbor_unicast_eligible,
+            .neighbor_route_plan_hash = direct_neighbor_route_hash.value_or(0),
+            .subdevice_id = subdevice_id,
+            .sub_core_grid = sub_core_grid,
+            .data_valid_semaphore = data_valid_semaphore},
+        HighBwAllGatherInputs{.input_tensor = input_tensor, .output_tensor = output_tensor}};
+}
+
+}  // namespace ttnn::operations::experimental::deepseek_prefill::high_bw_all_gather
+
+namespace ttnn::prim {
+
+Tensor high_bw_all_gather(
+    const Tensor& input_tensor,
+    const ttnn::Tensor& output_tensor,
+    int32_t dim,
+    uint32_t cluster_axis,
+    const GlobalSemaphore& data_valid_semaphore,
+    const std::optional<tt::tt_metal::SubDeviceId>& subdevice_id,
+    const std::optional<CoreRangeSet>& sub_core_grid,
+    std::optional<uint32_t> num_links) {
+    auto [params, inputs] =
+        ttnn::operations::experimental::deepseek_prefill::high_bw_all_gather::high_bw_all_gather_build_operation_args(
+            input_tensor,
+            output_tensor,
+            dim,
+            cluster_axis,
+            data_valid_semaphore,
+            subdevice_id,
+            sub_core_grid,
+            num_links);
+    return ttnn::device_operation::launch<
+        ttnn::operations::experimental::deepseek_prefill::high_bw_all_gather::HighBwAllGatherDeviceOperation>(
+        params, inputs);
+}
+
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/high_bw_all_gather/device/high_bw_all_gather_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/high_bw_all_gather/device/high_bw_all_gather_device_operation.hpp
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <tuple>
+#include <variant>
+#include <tt-metalium/sub_device_types.hpp>
+#include "ttnn/device_operation.hpp"
+#include "high_bw_all_gather_device_operation_types.hpp"
+#include "high_bw_all_gather_unicast_factory.hpp"
+
+namespace ttnn::operations::experimental::deepseek_prefill::high_bw_all_gather {
+
+struct HighBwAllGatherDeviceOperation {
+    using operation_attributes_t = HighBwAllGatherParams;
+    using tensor_args_t = HighBwAllGatherInputs;
+    using spec_return_value_t = tt::tt_metal::TensorSpec;
+    using tensor_return_value_t = Tensor;
+    using topology_return_value_t = std::vector<tt::tt_metal::TensorTopology>;
+    using program_factory_t = std::variant<HighBwAllGatherUnicastFactory>;
+
+    static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
+    static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
+
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
+    static topology_return_value_t compute_output_topologies(const operation_attributes_t&, const tensor_args_t&);
+    static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
+
+    static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
+};
+
+}  // namespace ttnn::operations::experimental::deepseek_prefill::high_bw_all_gather
+
+namespace ttnn::prim {
+
+Tensor high_bw_all_gather(
+    const Tensor& input_tensor,
+    const ttnn::Tensor& output_tensor,
+    int32_t dim,
+    uint32_t cluster_axis,
+    const GlobalSemaphore& data_valid_semaphore,
+    const std::optional<tt::tt_metal::SubDeviceId>& subdevice_id = std::nullopt,
+    const std::optional<CoreRangeSet>& sub_core_grid = std::nullopt,
+    std::optional<uint32_t> num_links = std::nullopt);
+
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/high_bw_all_gather/device/high_bw_all_gather_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/high_bw_all_gather/device/high_bw_all_gather_device_operation_types.hpp
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+#include <tt_stl/reflection.hpp>
+
+#include <array>
+#include <cstdint>
+#include <optional>
+
+#include <tt-metalium/experimental/fabric/fabric.hpp>
+#include <tt-metalium/sub_device_types.hpp>
+#include "ttnn/global_semaphore.hpp"
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/types.hpp"
+
+namespace ttnn::operations::experimental::deepseek_prefill::high_bw_all_gather {
+
+// The device-operation framework reflects over this aggregate for the default
+// program-cache key. GlobalSemaphore hashes its core set and buffer type, not
+// its runtime address, so structurally equivalent semaphores share a program.
+struct HighBwAllGatherParams {
+    int32_t dim = 0;
+    MemoryConfig output_mem_config;
+    uint32_t cluster_axis = 0;
+
+    // Fabric setup info
+    tt::tt_fabric::FabricConfig fabric_config = tt::tt_fabric::FabricConfig::DISABLED;
+    // Per-axis info (an inactive axis has num_devices = 1, num_links = 0, and Linear topology)
+    std::array<tt::tt_fabric::Topology, 2> axis_topology{};
+    std::array<uint32_t, 2> axis_num_devices{};
+    std::array<uint32_t, 2> axis_num_links{};
+    uint32_t num_devices = 0;  // number of devices participating in the collective
+    size_t packet_size = 0;
+    // Host-proved structural eligibility for the native store-and-forward
+    // transport. Under Fabric2D every logical edge, including ring wrap, must
+    // be one direct physical neighbor hop.
+    bool neighbor_unicast_eligible = false;
+    // Hash of the complete directed physical neighbor plan. Fabric routing
+    // arguments are baked into cached programs, so eligibility alone is not a
+    // sufficient cache discriminator when the physical plan changes.
+    uint64_t neighbor_route_plan_hash = 0;
+
+    // Worker-core selection.
+    std::optional<tt::tt_metal::SubDeviceId> subdevice_id;
+    std::optional<CoreRangeSet> sub_core_grid;
+
+    // Caller-owned and reusable across shapes. Optional only keeps this
+    // aggregate default-constructible; the public operation requires it.
+    std::optional<GlobalSemaphore> data_valid_semaphore;
+};
+
+struct HighBwAllGatherInputs {
+    Tensor input_tensor;
+    Tensor output_tensor;
+};
+
+}  // namespace ttnn::operations::experimental::deepseek_prefill::high_bw_all_gather

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/high_bw_all_gather/device/high_bw_all_gather_scheduler.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/high_bw_all_gather/device/high_bw_all_gather_scheduler.hpp
@@ -1,0 +1,134 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+
+#include <tt_stl/assert.hpp>
+
+namespace ttnn::operations::experimental::deepseek_prefill::high_bw_all_gather::scheduler {
+
+// These helpers assume interleaved DRAM page p maps to allocator bank
+// p % num_dram_banks at bank-local page offset p / num_dram_banks.
+struct BankOwnedSlice {
+    uint32_t bank;
+    uint32_t input_page_start;
+    uint32_t page_count;
+};
+
+// Assign the flat (link, worker) set round-robin across logical DRAM banks.
+// When workers do not divide evenly across banks, a bank may be shared by
+// multiple links; each worker still receives one disjoint, contiguous range
+// within exactly one bank.
+inline BankOwnedSlice derive_bank_owned_slice(
+    uint32_t num_input_pages,
+    uint32_t num_links,
+    uint32_t workers_per_direction,
+    uint32_t num_dram_banks,
+    uint32_t link,
+    uint32_t worker) {
+    TT_FATAL(num_links > 0, "derive_bank_owned_slice requires num_links > 0");
+    TT_FATAL(workers_per_direction > 0, "derive_bank_owned_slice requires workers_per_direction > 0");
+    TT_FATAL(num_dram_banks > 0, "derive_bank_owned_slice requires num_dram_banks > 0");
+    TT_FATAL(link < num_links, "derive_bank_owned_slice link {} is outside [0, {})", link, num_links);
+    TT_FATAL(
+        worker < workers_per_direction,
+        "derive_bank_owned_slice worker {} is outside [0, {})",
+        worker,
+        workers_per_direction);
+    const uint64_t total_workers_wide = static_cast<uint64_t>(num_links) * workers_per_direction;
+    TT_FATAL(
+        total_workers_wide <= std::numeric_limits<uint32_t>::max(),
+        "derive_bank_owned_slice worker count {} exceeds uint32_t",
+        total_workers_wide);
+    const uint32_t total_workers = static_cast<uint32_t>(total_workers_wide);
+    TT_FATAL(
+        total_workers >= num_dram_banks,
+        "derive_bank_owned_slice requires at least one worker per DRAM bank; workers={}, banks={}",
+        total_workers,
+        num_dram_banks);
+    uint32_t bank;
+    uint32_t worker_in_bank;
+    uint32_t workers_for_bank;
+    if (num_dram_banks % num_links == 0 && workers_per_direction % (num_dram_banks / num_links) == 0) {
+        // Preserve the original placement exactly for evenly divisible devices:
+        // each link owns interleaved banks and adjacent workers split a bank.
+        const uint32_t banks_per_link = num_dram_banks / num_links;
+        workers_for_bank = workers_per_direction / banks_per_link;
+        bank = link + (worker / workers_for_bank) * num_links;
+        worker_in_bank = worker % workers_for_bank;
+    } else {
+        // Interleave links in the flat order so harvested configurations retain
+        // the same link-to-bank pattern as closely as possible.
+        const uint32_t global_worker = worker * num_links + link;
+        bank = global_worker % num_dram_banks;
+        worker_in_bank = global_worker / num_dram_banks;
+        workers_for_bank = total_workers <= bank ? 0 : 1 + (total_workers - 1 - bank) / num_dram_banks;
+    }
+    TT_FATAL(workers_for_bank > 0, "derive_bank_owned_slice assigned bank {} no workers", bank);
+
+    // Interleaved logical page IDs owned by `bank` are:
+    //   bank, bank + num_dram_banks, bank + 2 * num_dram_banks, ...
+    // Divide that bank-local sequence evenly between its workers. The first
+    // `remainder` workers receive one extra page, so arbitrary tensor sizes
+    // remain bank-owned without dropping or duplicating a tail.
+    const uint32_t bank_page_count = num_input_pages <= bank ? 0 : 1 + (num_input_pages - 1 - bank) / num_dram_banks;
+    const uint32_t pages_per_worker = bank_page_count / workers_for_bank;
+    const uint32_t remainder = bank_page_count % workers_for_bank;
+    const uint32_t worker_page_offset = worker_in_bank * pages_per_worker + std::min(worker_in_bank, remainder);
+    const uint32_t worker_page_count = pages_per_worker + (worker_in_bank < remainder ? 1u : 0u);
+
+    return {
+        bank,
+        bank + worker_page_offset * num_dram_banks,
+        worker_page_count,
+    };
+}
+
+inline bool can_partition_workers_by_bank(
+    uint32_t num_input_pages, uint32_t num_links, uint32_t workers_per_direction, uint32_t num_dram_banks) {
+    if (num_links == 0 || workers_per_direction == 0 || num_dram_banks == 0) {
+        return false;
+    }
+    const uint32_t total_workers = num_links * workers_per_direction;
+    return total_workers >= num_dram_banks && num_input_pages >= total_workers;
+}
+
+inline uint32_t workers_per_direction_to_cover_banks(uint32_t num_links, uint32_t num_dram_banks) {
+    if (num_links == 0) {
+        return 0;
+    }
+    return (num_dram_banks + num_links - 1) / num_links;
+}
+
+inline bool worker_count_fits(uint32_t workers_per_direction, uint32_t num_links, uint32_t available_worker_cores) {
+    if (workers_per_direction == 0 || num_links == 0) {
+        return false;
+    }
+    const uint32_t cores_per_direction = workers_per_direction + (workers_per_direction > 1 ? 1u : 0u);
+    return num_links * 2 * cores_per_direction <= available_worker_cores;
+}
+
+template <std::size_t NumTiers>
+inline uint32_t select_fitting_worker_count(
+    uint32_t preferred_workers_per_direction,
+    uint32_t num_links,
+    uint32_t available_worker_cores,
+    const std::array<uint32_t, NumTiers>& descending_tiers) {
+    for (const uint32_t candidate : descending_tiers) {
+        if (candidate <= preferred_workers_per_direction &&
+            worker_count_fits(candidate, num_links, available_worker_cores)) {
+            return candidate;
+        }
+    }
+    // Let the caller's capacity check report the minimum one-worker failure.
+    return 1;
+}
+
+}  // namespace ttnn::operations::experimental::deepseek_prefill::high_bw_all_gather::scheduler

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/high_bw_all_gather/device/high_bw_all_gather_unicast_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/high_bw_all_gather/device/high_bw_all_gather_unicast_factory.cpp
@@ -1,0 +1,759 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "high_bw_all_gather_unicast_factory.hpp"
+#include "high_bw_all_gather_scheduler.hpp"
+#include "kernels/runtime_args.hpp"
+
+#include <array>
+#include <cstddef>
+#include <optional>
+
+#include <tt-metalium/tensor_accessor_args.hpp>
+#include "ttnn/operations/ccl/ccl_common.hpp"
+
+namespace ttnn::operations::experimental::deepseek_prefill::high_bw_all_gather {
+
+using namespace ::ttnn::ccl;
+using ::high_bw_all_gather::ReaderRuntimeArg;
+using ::high_bw_all_gather::runtime_arg_index;
+using ::high_bw_all_gather::WriterRuntimeArg;
+
+namespace {
+
+struct PageGeometry {
+    uint32_t input_page_size;
+    uint32_t output_chunk_size;
+    uint32_t output_chunks_per_page;
+    uint32_t split_factor;
+    uint32_t num_input_pages;
+    uint32_t num_output_chunks;
+    uint32_t output_chunks_per_stripe;
+};
+
+PageGeometry derive_page_geometry(const Tensor& input_tensor, const Tensor& output_tensor, int32_t gather_dim) {
+    const uint32_t input_page_size = input_tensor.buffer()->aligned_page_size();
+    const uint32_t input_unaligned_page_size = input_tensor.buffer()->page_size();
+    const uint32_t output_unaligned_page_size = output_tensor.buffer()->page_size();
+    const bool is_split = input_unaligned_page_size > output_unaligned_page_size;
+    const uint32_t output_chunk_size = is_split ? output_unaligned_page_size : input_page_size;
+    const uint32_t output_chunks_per_page = is_split ? 1u : output_unaligned_page_size / input_unaligned_page_size;
+    const uint32_t split_factor = is_split ? input_unaligned_page_size / output_unaligned_page_size : 1u;
+    TT_FATAL(
+        output_chunks_per_page == 1 || input_page_size == input_unaligned_page_size,
+        "concat requires an unpadded input page");
+
+    const uint32_t num_input_pages = input_tensor.buffer()->num_pages();
+    const uint32_t num_output_chunks = num_input_pages * split_factor;
+    const auto input_shape = input_tensor.padded_shape();
+    const uint32_t rank = input_shape.rank();
+    if (gather_dim < 0) {
+        gather_dim += rank;
+    }
+
+    const auto tile_spec =
+        input_tensor.layout() == Layout::TILE ? input_tensor.tensor_spec().tile() : tt::tt_metal::Tile();
+    uint32_t input_pages_per_stripe = 1;
+    for (int32_t i = gather_dim; i < rank; i++) {
+        uint32_t extent;
+        if (i == rank - 1) {
+            extent = input_tensor.layout() == Layout::TILE
+                         ? input_shape[i] / tile_spec.get_width()
+                         : (input_shape[i] * input_tensor.element_size()) / input_unaligned_page_size;
+        } else if (input_tensor.layout() == Layout::TILE && i == rank - 2) {
+            extent = input_shape[i] / tile_spec.get_height();
+        } else {
+            extent = input_shape[i];
+        }
+        input_pages_per_stripe *= extent;
+    }
+
+    const uint32_t output_chunks_per_stripe = input_pages_per_stripe * split_factor;
+    TT_FATAL(output_chunks_per_stripe > 0, "output_chunks_per_stripe must be > 0");
+    return {
+        input_page_size,
+        output_chunk_size,
+        output_chunks_per_page,
+        split_factor,
+        num_input_pages,
+        num_output_chunks,
+        output_chunks_per_stripe};
+}
+
+bool can_use_output_bank_owned_schedule(
+    const Tensor& input_tensor,
+    const Tensor& output_tensor,
+    const PageGeometry& geometry,
+    uint32_t num_links,
+    uint32_t workers_per_direction,
+    uint32_t num_dram_banks) {
+    return input_tensor.buffer()->is_dram() && output_tensor.buffer()->is_dram() &&
+           output_tensor.buffer()->buffer_layout() == tt::tt_metal::TensorMemoryLayout::INTERLEAVED &&
+           geometry.output_chunks_per_page == 1 && geometry.split_factor == 1 &&
+           geometry.output_chunks_per_stripe == geometry.num_input_pages &&
+           scheduler::can_partition_workers_by_bank(
+               geometry.num_input_pages, num_links, workers_per_direction, num_dram_banks);
+}
+
+}  // namespace
+
+////////////////////////////////////////////////////////////////
+// Store-and-forward HighBwAllGather (Fabric1D or direct-neighbor Fabric2D line/ring)
+//
+// Every device relays stripes to its neighbor one hop at a time; a shard reaches far devices by being
+// re-forwarded at each hop. Forward and backward directions run on separate cores. Per direction: the reader
+// (CB producer, no fabric) reads iteration 0 from local input and later iterations from what upstream relayed
+// into our output; the writer (CB consumer) unicasts each stripe one hop to the neighbor's output (same
+// address on every device). Direction/topology are runtime args, so both kernels compile once and run on all
+// cores. data_valid_sem gates relays and tracks completion.
+////////////////////////////////////////////////////////////////
+
+HighBwAllGatherUnicastFactory::cached_mesh_workload_t HighBwAllGatherUnicastFactory::create_mesh_workload(
+    const HighBwAllGatherParams& operation_attributes,
+    const ttnn::MeshCoordinateRangeSet& tensor_coords,
+    const HighBwAllGatherInputs& tensor_args,
+    Tensor& output_tensor) {
+    tt::tt_metal::distributed::MeshWorkload workload;
+    std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
+
+    const auto& data_valid_sem = operation_attributes.data_valid_semaphore.value();
+
+    for (const auto& coord : tensor_coords.coords()) {
+        auto cached_program = create_at(operation_attributes, coord, tensor_args, output_tensor, data_valid_sem);
+        workload.add_program(ttnn::MeshCoordinateRange(coord), std::move(cached_program.program));
+        shared_variables.emplace(ttnn::MeshCoordinateRange(coord), std::move(cached_program.shared_variables));
+    }
+
+    return cached_mesh_workload_t{std::move(workload), std::move(shared_variables)};
+}
+
+HighBwAllGatherUnicastFactory::cached_program_t HighBwAllGatherUnicastFactory::create_at(
+    const HighBwAllGatherParams& operation_attributes,
+    const ttnn::MeshCoordinate& sender_device_coord,
+    const HighBwAllGatherInputs& tensor_args,
+    const Tensor& output_tensor,
+    const tt::tt_metal::GlobalSemaphore& data_valid_sem) {
+    const auto& input_tensor = tensor_args.input_tensor;
+    tt::tt_metal::Program program{};
+    auto* mesh_device = input_tensor.device();
+
+    ////////////////////////////////////////////////////////////////
+    // Fabric setup
+    //
+    // Glossary:
+    //   relay          -- re-forward a received stripe from upstream one hop to downstream.
+    //   slice          -- portion of tensor stripes allocated to this (link, worker)
+    //   sink direction -- a direction that forwards nothing (num_iters == 0), e.g. a line endpoint's dead side.
+    //   sink stripe    -- a stripe consumed here, not relayed onward (a line endpoint's incoming, or a ring
+    //                     antipode).
+    //   antipode       -- on a ring, the device N/2 hops away.
+    ////////////////////////////////////////////////////////////////
+
+    const bool fabric_is_2d = ::tt::tt_fabric::is_2d_fabric_config(operation_attributes.fabric_config);
+    TT_FATAL(
+        !fabric_is_2d || operation_attributes.neighbor_unicast_eligible,
+        "Fabric2D high_bw_all_gather neighbor unicast requires a host-proved direct physical line/ring");
+
+    const uint32_t axis = operation_attributes.cluster_axis;
+    const auto topology = operation_attributes.axis_topology[axis];
+    const bool is_ring = tt::tt_fabric::is_ring_or_torus(topology);
+
+    const uint32_t num_devices = operation_attributes.num_devices;
+    TT_FATAL(
+        !is_ring || num_devices > 2,
+        "high_bw_all_gather ring schedule requires more than two devices on cluster_axis {}; "
+        "a size-two axis has no distinct wrap edge",
+        axis);
+    const uint32_t device_idx = ::ttnn::ccl::get_linearized_index_from_physical_coord(
+        input_tensor, sender_device_coord, std::optional<uint32_t>{operation_attributes.cluster_axis});
+
+    auto fwd_coord =
+        ::ttnn::ccl::get_physical_neighbor_from_physical_coord(input_tensor, sender_device_coord, 1, topology, axis);
+    auto bwd_coord =
+        ::ttnn::ccl::get_physical_neighbor_from_physical_coord(input_tensor, sender_device_coord, -1, topology, axis);
+
+    // Stripes a direction sends from a device: ring -> N/2; line fwd -> d+1, bwd -> N-d; 0 at a dead endpoint.
+    // Also queried for the downstream device to choose granular vs single data_valid signalling.
+    auto relay_iters = [&](uint32_t idx, bool is_forward) -> uint32_t {
+        if (is_ring) {
+            return num_devices / 2;
+        }
+        return is_forward ? (idx + 1 < num_devices ? idx + 1 : 0) : (idx > 0 ? num_devices - idx : 0);
+    };
+    const uint32_t fwd_iters = relay_iters(device_idx, true);
+    const uint32_t bwd_iters = relay_iters(device_idx, false);
+    TT_FATAL(fwd_iters > 0 || bwd_iters > 0, "device participates in neither direction");
+
+    // Even-sized ring: for load balancing, the antipode device receives the antipode stripe as halves from both
+    // forward and backward directions.
+    const bool ring_even_split = is_ring && (num_devices % 2 == 0);
+    const uint32_t packet_size = operation_attributes.packet_size;
+
+    ////////////////////////////////////////////////////////////////
+    // Core selection
+    //
+    // Each link runs two directions: forward (dir 0) and backward (dir 1). With NUM_WORKERS_PER_LINK == 1 each
+    // direction is a single core connected directly to its neighbor's ERISC. With > 1 the workers of a direction
+    // can't each open a direct connection (an ERISC exposes one worker sender channel per direction), so they
+    // share a fabric mux: one mux core per direction per link owns the connection and multiplexes their traffic.
+    //
+    // Flat layout from choose_worker_cores(num_links, num_cores_per_link), per link:
+    //   [dir 0: (mux?) worker 0 .. worker W-1][dir 1: (mux?) worker 0 .. worker W-1]
+    ////////////////////////////////////////////////////////////////
+
+    // Num worker cores per direction per link. >1 requires an additional fabric mux core to own the fabric
+    // connection and multiplex traffic.
+    // This is a major perf knob, below heuristic was determined from extensive test sweeps.
+    const uint32_t num_links = operation_attributes.axis_num_links[axis];
+    const auto page_geometry = derive_page_geometry(input_tensor, output_tensor, operation_attributes.dim);
+    const uint32_t input_page_size = page_geometry.input_page_size;
+    const uint32_t num_dram_banks = mesh_device->allocator()->get_num_banks(tt::tt_metal::BufferType::DRAM);
+    TT_FATAL(num_dram_banks > 0, "high_bw_all_gather requires at least one allocator-managed DRAM bank");
+    const uint64_t total_output_bytes =
+        (uint64_t)output_tensor.buffer()->num_pages() * output_tensor.buffer()->aligned_page_size();
+    const uint64_t per_link_bytes = total_output_bytes / std::max(1u, num_links);
+    constexpr uint64_t bank_owned_min_link_bytes = 1500000ULL;
+    constexpr uint64_t high_parallelism_min_link_bytes = 32000000ULL;
+    uint32_t workers_per_dir = 1;
+    if (input_tensor.device()->arch() == tt::ARCH::WORMHOLE_B0) {
+        workers_per_dir = 2;
+
+        // Wormhole has 12 DRAM banks (11 when one is harvested). For sufficiently large messages, use enough
+        // workers to retain bank-local packet coalescing instead of forcing these configurations through the
+        // scatter fallback. Keep two workers for small messages, where additional core/mux setup is not amortized.
+        const uint32_t bank_covering_workers =
+            scheduler::workers_per_direction_to_cover_banks(num_links, num_dram_banks);
+        if (per_link_bytes >= bank_owned_min_link_bytes &&
+            can_use_output_bank_owned_schedule(
+                input_tensor, output_tensor, page_geometry, num_links, bank_covering_workers, num_dram_banks)) {
+            workers_per_dir = bank_covering_workers;
+        }
+
+        // Large messages benefit from additional in-flight DRAM reads after every bank is covered.
+        const uint32_t high_parallelism_workers = std::max(8u, bank_covering_workers);
+        if (per_link_bytes >= high_parallelism_min_link_bytes &&
+            can_use_output_bank_owned_schedule(
+                input_tensor, output_tensor, page_geometry, num_links, high_parallelism_workers, num_dram_banks)) {
+            workers_per_dir = high_parallelism_workers;
+        }
+    } else if (input_tensor.device()->arch() == tt::ARCH::BLACKHOLE) {
+        // Measured on Blackhole across every qualified page format and line/ring schedules. Four workers amortize
+        // their mux/core overhead once a bank-owned message reaches roughly 1.5 MB/link. Eight workers do not
+        // consistently pull ahead of four until roughly 32 MB/link.
+        const bool four_workers_bank_owned = can_use_output_bank_owned_schedule(
+            input_tensor, output_tensor, page_geometry, num_links, 4, num_dram_banks);
+        const bool eight_workers_bank_owned = can_use_output_bank_owned_schedule(
+            input_tensor, output_tensor, page_geometry, num_links, 8, num_dram_banks);
+
+        workers_per_dir = 2;
+        if (per_link_bytes >= bank_owned_min_link_bytes && four_workers_bank_owned) {
+            workers_per_dir = 4;
+        }
+        if (per_link_bytes >= high_parallelism_min_link_bytes && eight_workers_bank_owned) {
+            workers_per_dir = 8;
+        } else if (
+            per_link_bytes >= high_parallelism_min_link_bytes && !four_workers_bank_owned && input_page_size >= 2048) {
+            // Large 2 KB-page shapes still benefit from parallel injection when slice divisibility prevents
+            // bank ownership. Smaller fallback packets did not recover the additional worker/mux overhead.
+            workers_per_dir = 8;
+        }
+    }
+
+    // A restricted sub-core grid may not fit the preferred count. Snap to a measured worker tier rather than
+    // walking through unqualified intermediate counts; bank ownership is re-evaluated with the selected tier.
+    const auto subdevice_id = operation_attributes.subdevice_id.value_or(mesh_device->get_sub_device_ids().at(0));
+    auto available_worker_cores =
+        mesh_device->worker_cores(tt::tt_metal::HalProgrammableCoreType::TENSIX, subdevice_id);
+    if (operation_attributes.sub_core_grid.has_value()) {
+        available_worker_cores = available_worker_cores.intersection(operation_attributes.sub_core_grid.value());
+    }
+    const uint32_t preferred_workers_per_dir = workers_per_dir;
+    const bool preferred_schedule_is_bank_owned = can_use_output_bank_owned_schedule(
+        input_tensor, output_tensor, page_geometry, num_links, preferred_workers_per_dir, num_dram_banks);
+    const auto count_fits = [&](uint32_t count) {
+        return scheduler::worker_count_fits(
+            count, num_links, static_cast<uint32_t>(available_worker_cores.num_cores()));
+    };
+    if (!count_fits(workers_per_dir)) {
+        const uint32_t bank_covering_workers =
+            scheduler::workers_per_direction_to_cover_banks(num_links, num_dram_banks);
+        const std::array<uint32_t, 4> reduction_tiers =
+            input_tensor.device()->arch() == tt::ARCH::WORMHOLE_B0
+                // The first two entries intentionally coincide when bank coverage
+                // already needs at least eight workers; selection is idempotent.
+                ? std::array<uint32_t, 4>{std::max(8u, bank_covering_workers), bank_covering_workers, 2u, 1u}
+                : std::array<uint32_t, 4>{8u, 4u, 2u, 1u};
+        workers_per_dir = scheduler::select_fitting_worker_count(
+            preferred_workers_per_dir,
+            num_links,
+            static_cast<uint32_t>(available_worker_cores.num_cores()),
+            reduction_tiers);
+    }
+    if (preferred_schedule_is_bank_owned &&
+        !can_use_output_bank_owned_schedule(
+            input_tensor, output_tensor, page_geometry, num_links, workers_per_dir, num_dram_banks)) {
+        // Do not spend almost as many cores on the scatter fallback when a restricted grid falls just short of
+        // covering every bank.
+        workers_per_dir = std::min(2u, workers_per_dir);
+    }
+    TT_FATAL(
+        count_fits(workers_per_dir),
+        "high_bw_all_gather needs at least {} worker cores for {} link(s), but only {} are available",
+        num_links * 2 * (workers_per_dir + (workers_per_dir > 1 ? 1u : 0u)),
+        num_links,
+        available_worker_cores.num_cores());
+    if (workers_per_dir != preferred_workers_per_dir) {
+        log_warning(
+            tt::LogOp,
+            "high_bw_all_gather reduced workers per direction from {} to {} because only {} worker cores are "
+            "available; this may disable bank-owned packet coalescing",
+            preferred_workers_per_dir,
+            workers_per_dir,
+            available_worker_cores.num_cores());
+    }
+    constexpr uint32_t num_directions = 2;  // 0 = forward, 1 = backward
+    const bool use_mux = workers_per_dir > 1;
+    const uint32_t mux_per_dir = use_mux ? 1u : 0u;
+    const uint32_t cores_per_dir = workers_per_dir + mux_per_dir;
+    const uint32_t num_cores_per_link = num_directions * cores_per_dir;
+
+    // all_cores contains workers + mux
+    [[maybe_unused]] auto [all_core_range, all_cores] = ttnn::ccl::choose_worker_cores(
+        num_links,
+        num_cores_per_link,
+        mesh_device,
+        operation_attributes.subdevice_id,
+        /*core_grid_offset=*/CoreCoord{0, 0},
+        operation_attributes.sub_core_grid);
+    TT_FATAL(
+        all_cores.size() == static_cast<size_t>(num_links) * num_cores_per_link,
+        "high_bw_all_gather needs {} worker cores ({} links x {} cores/link) but only {} are available; provide a "
+        "larger "
+        "sub_core_grid.",
+        static_cast<size_t>(num_links) * num_cores_per_link,
+        num_links,
+        num_cores_per_link,
+        all_cores.size());
+
+    // Helpers to index into the flat core vector (dir: 0 = forward, 1 = backward).
+    auto core_at = [&](uint32_t link, uint32_t dir, uint32_t idx_in_dir) -> const CoreCoord& {
+        return all_cores[(link * num_cores_per_link) + (dir * cores_per_dir) + idx_in_dir];
+    };
+    auto mux_core = [&](uint32_t link, uint32_t dir) -> const CoreCoord& { return core_at(link, dir, 0); };
+    auto worker_core = [&](uint32_t link, uint32_t dir, uint32_t w) -> const CoreCoord& {
+        return core_at(link, dir, mux_per_dir + w);
+    };
+    auto dir_neighbor = [&](uint32_t dir) { return dir == 0 ? fwd_coord : bwd_coord; };
+    auto dir_active = [&](uint32_t dir) { return dir_neighbor(dir).has_value(); };
+
+    // Reader/writer kernels + CB run on worker cores only; the mux kernel runs on its own cores (created only
+    // for a direction that has a neighbor).
+    std::vector<CoreCoord> worker_cores;
+    worker_cores.reserve(num_links * num_directions * workers_per_dir);
+    std::set<CoreRange> worker_core_set;
+    std::set<CoreRange> mux_core_set;
+    for (uint32_t link = 0; link < num_links; ++link) {
+        for (uint32_t dir = 0; dir < num_directions; ++dir) {
+            if (use_mux && dir_active(dir)) {
+                mux_core_set.emplace(mux_core(link, dir));
+            }
+            for (uint32_t w = 0; w < workers_per_dir; ++w) {
+                worker_cores.push_back(worker_core(link, dir, w));
+                worker_core_set.emplace(worker_core(link, dir, w));
+            }
+        }
+    }
+    const CoreRangeSet worker_core_range(worker_core_set);
+    const CoreRangeSet mux_core_range(mux_core_set);
+
+    // Fabric mux config
+    constexpr uint8_t num_buffers_per_channel = 2;  // hardcoded since no observable impact on performance
+    tt::tt_fabric::FabricMuxConfig mux_config(
+        /*num_full_size_channels=*/workers_per_dir,
+        /*num_header_only_channels=*/0,
+        /*num_buffers_full_size_channel=*/num_buffers_per_channel,
+        /*num_buffers_header_only_channel=*/0,
+        /*buffer_size_bytes_full_size_channel=*/tt::tt_fabric::get_tt_fabric_channel_buffer_size_bytes(),
+        /*base_l1_address=*/mesh_device->allocator()->get_base_allocator_addr(tt::tt_metal::HalMemType::L1));
+    if (use_mux) {
+        TT_FATAL(
+            mux_config.get_memory_map_end_address() <= mesh_device->l1_size_per_core(),
+            "high_bw_all_gather Fabric mux requires L1 through address {:#x}, but each Tensix core has only "
+            "{:#x} bytes",
+            mux_config.get_memory_map_end_address(),
+            mesh_device->l1_size_per_core());
+    }
+
+    tt::tt_metal::KernelHandle mux_kernel_id = 0;
+    if (use_mux && mux_core_range.num_cores() > 0) {
+        mux_kernel_id = tt::tt_metal::CreateKernel(
+            program,
+            "tt_metal/fabric/impl/kernels/tt_fabric_mux.cpp",
+            mux_core_range,
+            tt::tt_metal::DataMovementConfig{
+                .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
+                .noc = tt::tt_metal::NOC::RISCV_0_default,
+                .compile_args = mux_config.get_fabric_mux_compile_time_args(),
+                .opt_level = tt::tt_metal::KernelBuildOptLevel::O3});
+    }
+
+    ////////////////////////////////////////////////////////////////
+    // Page indexing
+    //
+    // Glossary:
+    //   input page     -- one page of the input tensor.
+    //   output page    -- one page of the output tensor (the real buffer page).
+    //   chunk          -- one NOC write = min(input_page, output_page) bytes. An input
+    //                     page = split_factor chunks; an output page = output_chunks_per_page
+    //                     chunks. The kernel iterator walks chunks.
+    //   stripe         -- a run of consecutive chunks this device writes before
+    //                     jumping past other devices' contributions.
+    //   stripe jump    -- value the kernel adds to output_page_id at the stripe
+    //                     boundary.
+    //
+    // Three copy modes, picked by input vs output page sizes:
+    //   matched (in == out): 1 chunk per input page, output_chunks_per_page = 1.
+    //   concat  (out > in) : 1 chunk per input page, output_chunks_per_page > 1; each
+    //                        chunk lands at a byte offset within a shared output page.
+    //   split   (in > out) : split_factor chunks per input page, output_chunks_per_page = 1.
+    //
+    // Kernel is a dumb chunk iterator. Iteration pattern is:
+    //   byte_offset++ within an output page -> chunk++ -> stripe+=jump
+    //
+    // Host supplies the requisite geometry constants + each worker's slice; the kernel's
+    // OutputStripeIterator derives the remaining iterator parameters at compile-time.
+    ////////////////////////////////////////////////////////////////
+
+    // --- Copy mode ---
+    // The kernel always reads whole *aligned* input pages into L1 (required by the input's NoC
+    // read alignment, DRAM or L1) but writes at output *content* (unaligned) granularity, so
+    // chunk sizing differs by mode:
+    //   matched (in == out): 1 chunk per input page, output_chunks_per_page = 1.
+    //   concat  (out > in) : 1 chunk per input page, output_chunks_per_page > 1; each chunk
+    //                        lands at a byte offset within a shared output page.
+    //   split   (in > out) : split_factor chunks per input page, output_chunks_per_page = 1.
+    const uint32_t output_chunk_size = page_geometry.output_chunk_size;
+    const uint32_t output_chunks_per_page = page_geometry.output_chunks_per_page;
+    const uint32_t num_input_pages = page_geometry.num_input_pages;
+    const uint32_t num_output_chunks = page_geometry.num_output_chunks;
+    const uint32_t output_chunks_per_stripe = page_geometry.output_chunks_per_stripe;
+
+    ::ttnn::ccl::validate_packet_size(input_tensor.device()->arch(), packet_size, output_chunk_size);
+
+    // --- CB sizing ---
+    // cb_page_size is a multiple of input_page_size, which is itself a multiple of
+    // output_chunk_size = min(input, output), so the kernel increments both
+    // the cb_read_ptr and cb_write_ptr cleanly.
+    const uint32_t pages_per_packet = std::max(1u, packet_size / input_page_size);
+    const uint32_t cb_page_size = input_page_size * pages_per_packet;
+    constexpr uint32_t cb_depth = 3;
+    const uint64_t cb_size = static_cast<uint64_t>(cb_depth) * cb_page_size;
+    const uint64_t l1_base = mesh_device->allocator()->get_base_allocator_addr(tt::tt_metal::HalMemType::L1);
+    const std::array subdevice_ids{subdevice_id};
+    const uint64_t l1_ceiling =
+        mesh_device->lowest_occupied_compute_l1_address(ttsl::Span<const tt::tt_metal::SubDeviceId>(subdevice_ids))
+            .value_or(mesh_device->l1_size_per_core());
+    TT_FATAL(
+        l1_ceiling >= l1_base && cb_size <= l1_ceiling - l1_base,
+        "high_bw_all_gather worker circular buffer requires {} bytes from L1 base {:#x}, but only {} bytes are "
+        "available below the lowest live L1 allocation at {:#x}",
+        cb_size,
+        l1_base,
+        l1_ceiling >= l1_base ? l1_ceiling - l1_base : 0,
+        l1_ceiling);
+
+    const uint32_t total_slices = num_links * workers_per_dir;
+    // Assign logical pages by destination DRAM bank whenever the output is
+    // interleaved. TensorAccessor still resolves each source page correctly
+    // when the input uses an ND-sharded/block-cyclic DRAM layout. Keeping the
+    // destination pages bank-local lets the writer coalesce small pages into a
+    // full Fabric packet instead of falling back to four-entry scatter writes.
+    const bool output_bank_owned_schedule = can_use_output_bank_owned_schedule(
+        input_tensor, output_tensor, page_geometry, num_links, workers_per_dir, num_dram_banks);
+    const uint32_t slice_step = output_bank_owned_schedule ? num_dram_banks : 1;
+
+    ////////////////////////////////////////////////////////////////
+    // Circular Buffer and Kernel creation
+    ////////////////////////////////////////////////////////////////
+
+    // Input and relay CB
+    uint32_t cb0_id = tt::CB::c_in0;
+    tt::DataFormat df = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
+    tt::tt_metal::CircularBufferConfig cb_src0_config =
+        tt::tt_metal::CircularBufferConfig(cb_depth * cb_page_size, {{cb0_id, df}}).set_page_size(cb0_id, cb_page_size);
+    CreateCircularBuffer(program, worker_core_range, cb_src0_config);
+
+    // data_valid_granularity:
+    // data_valid is signalled once per this many CB pages so a downstream can start relaying before the whole
+    // stripe arrives. Larger = fewer syncs, smaller = finer pipelining.
+    // This is a minor perf knob, below heuristic was determined from extensive test sweeps.
+    // Auto-selected to half the per-worker stripe: enough pipelining without the over-signalling that hurts
+    // small-page tensors at scale. Kept as a fraction of the stripe so it self-scales with tensor size, links,
+    // and workers.
+    const uint32_t outputs_per_cb_page = std::max(1u, cb_page_size / output_chunk_size);
+    const uint32_t cb_pages_per_stripe = std::max(1u, (num_output_chunks / total_slices) / outputs_per_cb_page);
+    const uint32_t data_valid_granularity = std::max(1u, cb_pages_per_stripe / 2u);
+
+    // KERNEL CREATION
+    // Reader
+    std::vector<uint32_t> reader_compile_args = {
+        input_page_size,           // input tensor page size
+        output_chunk_size,         // NOC write size = min(input, output)
+        output_chunks_per_page,    // chunks per output page (1 unless concat)
+        output_chunks_per_stripe,  // stripe length in chunks
+        num_devices,               // device count (stripe indexing)
+        cb0_id,                    // cb id
+        cb_page_size,              // cb entry size
+        slice_step,                // one means contiguous slices; >1 owns one interleaved DRAM bank
+    };
+    tt::tt_metal::TensorAccessorArgs(input_tensor.buffer()).append_to(reader_compile_args);
+    tt::tt_metal::TensorAccessorArgs(output_tensor.buffer()).append_to(reader_compile_args);
+
+    // Writer
+    std::vector<uint32_t> writer_compile_args = {
+        output_chunk_size,         // NOC write size = min(input, output)
+        output_chunks_per_page,    // chunks per output page (1 unless concat)
+        output_chunks_per_stripe,  // stripe length in chunks
+        num_devices,               // device count (stripe indexing)
+        cb0_id,                    // cb id
+        cb_page_size,              // cb entry size
+        packet_size,               // packet_size
+        data_valid_granularity,    // signal data_valid once per this many CB pages
+        slice_step,                // one means scatter packets; >1 enables contiguous full packets
+    };
+    tt::tt_metal::TensorAccessorArgs(output_tensor.buffer()).append_to(writer_compile_args);
+
+    // When multiple workers share a fabric mux, the writer connects through it: append the mux geometry (after
+    // the tensor-accessor args) and switch the kernel onto its USE_WORKER_MUX path.
+    std::map<std::string, std::string> writer_defines;
+    if (fabric_is_2d) {
+        writer_defines["FABRIC_2D"] = "1";
+        writer_defines["API_TYPE_Mesh"] = "1";
+    }
+    if (use_mux) {
+        ttnn::ccl::fabric_mux_connection_ct_args(
+            workers_per_dir, tt::tt_fabric::FabricMuxChannelType::FULL_SIZE_CHANNEL, mux_config, writer_compile_args);
+        writer_defines["USE_WORKER_MUX"] = "1";
+    }
+
+    auto reader_kernel_id = tt::tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/high_bw_all_gather/device/kernels/unicast_reader.cpp",
+        worker_core_range,
+        tt::tt_metal::ReaderDataMovementConfig(reader_compile_args));
+    auto writer_kernel_id = tt::tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/high_bw_all_gather/device/kernels/unicast_writer.cpp",
+        worker_core_range,
+        tt::tt_metal::WriterDataMovementConfig(writer_compile_args, writer_defines));
+
+    ////////////////////////////////////////////////////////////////
+    // Runtime args
+    //
+    // The page split is per (link, worker) -- num_links * workers_per_dir slices -- and direction-independent,
+    // so a (link, worker)'s forward and backward directions relay the same slice. Core assignment is
+    // deterministic, so worker w has the same coords on every device: data_valid signals target the mirror
+    // worker w on the neighbor.
+    ////////////////////////////////////////////////////////////////
+
+    const auto sender_fabric_node_id = mesh_device->get_fabric_node_id(sender_device_coord);
+    const uint32_t input_addr = input_tensor.buffer()->address();
+    const uint32_t output_addr = output_tensor.buffer()->address();
+
+    // Mux runtime args: one fabric connection per active direction per link, to that direction's neighbor. The
+    // direction's workers all feed this one connection.
+    if (use_mux) {
+        for (uint32_t link = 0; link < num_links; ++link) {
+            for (uint32_t dir = 0; dir < num_directions; ++dir) {
+                if (!dir_active(dir)) {
+                    continue;
+                }
+                const CoreCoord mux_core_coord = mux_core(link, dir);
+                const auto dst_node = mesh_device->get_fabric_node_id(*dir_neighbor(dir));
+                auto mux_rt_args = mux_config.get_fabric_mux_run_time_args(
+                    sender_fabric_node_id, dst_node, link, program, mux_core_coord);
+                tt::tt_metal::SetRuntimeArgs(program, mux_kernel_id, {mux_core_coord}, mux_rt_args);
+            }
+        }
+    }
+
+    for (uint32_t link = 0; link < num_links; ++link) {
+        for (uint32_t w = 0; w < workers_per_dir; ++w) {
+            const uint32_t slice_idx = (link * workers_per_dir) + w;
+            const uint32_t input_pages_per_slice = num_input_pages / total_slices;
+            const uint32_t remainder = num_input_pages % total_slices;
+            uint32_t input_tile_id_start = (slice_idx * input_pages_per_slice) + std::min(slice_idx, remainder);
+            uint32_t worker_input_page_count = input_pages_per_slice + (slice_idx < remainder ? 1u : 0u);
+            if (output_bank_owned_schedule) {
+                const auto bank_owned_slice = scheduler::derive_bank_owned_slice(
+                    num_input_pages, num_links, workers_per_dir, num_dram_banks, link, w);
+                input_tile_id_start = bank_owned_slice.input_page_start;
+                worker_input_page_count = bank_owned_slice.page_count;
+            }
+            const uint32_t input_tile_id_end =
+                output_bank_owned_schedule
+                    ? input_tile_id_start + worker_input_page_count * num_dram_banks
+                    : ((slice_idx + 1) * input_pages_per_slice) + std::min(slice_idx + 1, remainder);
+            const uint32_t local_output_start =
+                output_bank_owned_schedule
+                    ? input_tile_id_start
+                    : (static_cast<uint64_t>(input_tile_id_start) * num_output_chunks) / num_input_pages;
+            const uint32_t local_output_end =
+                output_bank_owned_schedule
+                    ? local_output_start + worker_input_page_count
+                    : (static_cast<uint64_t>(input_tile_id_end) * num_output_chunks) / num_input_pages;
+            const uint32_t num_worker_output_chunks = local_output_end - local_output_start;
+            const uint32_t half = num_worker_output_chunks / 2;
+
+            // Both directions (dir: 0 = forward, 1 = backward). mirror_core is this core's coords, reused as the
+            // data_valid_sem target on the neighbor's mirror core.
+            for (uint32_t dir = 0; dir < num_directions; ++dir) {
+                const bool is_forward = (dir == 0);
+                const CoreCoord core = worker_core(link, dir, w);
+                const CoreCoord mirror_core = mesh_device->worker_core_from_logical_core(core);
+                const auto neighbor = dir_neighbor(dir);
+                const auto neighbor_node =
+                    neighbor.has_value() ? mesh_device->get_fabric_node_id(*neighbor) : sender_fabric_node_id;
+
+                const uint32_t stripe_step = is_forward ? num_devices - 1 : 1;
+                const uint32_t num_iters = is_forward ? fwd_iters : bwd_iters;
+                TT_FATAL(
+                    dir_active(dir) == (num_iters > 0),
+                    "high_bw_all_gather direction {} has inconsistent neighbor and iteration state",
+                    dir);
+                const uint32_t num_recv =
+                    is_ring ? num_devices / 2 : (is_forward ? device_idx : num_devices - 1 - device_idx);
+                const bool do_local_write = is_forward ? (fwd_iters > 0) : (fwd_iters == 0);
+
+                // data_valid sem is granularly incremented when downstream needs to relay the stripe.
+                // data_valid sem is incremented just once when downstream is a sink (doesn't need to relay).
+                uint32_t num_granular = 0;
+                if (num_iters > 0) {
+                    const uint32_t downstream_iters =
+                        is_ring ? num_devices / 2
+                                : relay_iters(is_forward ? device_idx + 1 : device_idx - 1, is_forward);
+                    num_granular = downstream_iters > 0 ? downstream_iters - 1 : 0;
+                }
+
+                uint32_t final_start = local_output_start;
+                uint32_t final_count = num_worker_output_chunks;
+                if (ring_even_split) {
+                    final_start = is_forward ? local_output_start : (local_output_start + half * slice_step);
+                    final_count = is_forward ? half : (num_worker_output_chunks - half);
+                }
+
+                // Chunks the upstream delivers into our output (relayed full stripes + sink). The even-ring
+                // antipode arrives as a half, so it contributes final_count instead of a full stripe.
+                const uint32_t total_chunks = num_recv * num_worker_output_chunks -
+                                              (ring_even_split ? (num_worker_output_chunks - final_count) : 0);
+
+                std::vector<uint32_t> reader_rt_args(runtime_arg_index(ReaderRuntimeArg::Count));
+                reader_rt_args[runtime_arg_index(ReaderRuntimeArg::InputAddress)] = input_addr;
+                reader_rt_args[runtime_arg_index(ReaderRuntimeArg::OutputAddress)] = output_addr;
+                reader_rt_args[runtime_arg_index(ReaderRuntimeArg::InitialStripe)] = device_idx;
+                reader_rt_args[runtime_arg_index(ReaderRuntimeArg::StripeStep)] = stripe_step;
+                reader_rt_args[runtime_arg_index(ReaderRuntimeArg::NumIters)] = num_iters;
+                reader_rt_args[runtime_arg_index(ReaderRuntimeArg::TotalChunks)] = total_chunks;
+                reader_rt_args[runtime_arg_index(ReaderRuntimeArg::SliceStart)] = local_output_start;
+                reader_rt_args[runtime_arg_index(ReaderRuntimeArg::SliceCount)] = num_worker_output_chunks;
+                reader_rt_args[runtime_arg_index(ReaderRuntimeArg::FinalStart)] = final_start;
+                reader_rt_args[runtime_arg_index(ReaderRuntimeArg::FinalCount)] = final_count;
+                reader_rt_args[runtime_arg_index(ReaderRuntimeArg::InputPageStart)] = input_tile_id_start;
+                reader_rt_args[runtime_arg_index(ReaderRuntimeArg::InputPageEnd)] = input_tile_id_end;
+                reader_rt_args[runtime_arg_index(ReaderRuntimeArg::DataValidSemaphore)] = data_valid_sem.address();
+                tt::tt_metal::SetRuntimeArgs(program, reader_kernel_id, {core}, reader_rt_args);
+
+                std::vector<uint32_t> writer_rt_args(runtime_arg_index(WriterRuntimeArg::Count));
+                writer_rt_args[runtime_arg_index(WriterRuntimeArg::OutputAddress)] = output_addr;
+                writer_rt_args[runtime_arg_index(WriterRuntimeArg::InitialStripe)] = device_idx;
+                writer_rt_args[runtime_arg_index(WriterRuntimeArg::StripeStep)] = stripe_step;
+                writer_rt_args[runtime_arg_index(WriterRuntimeArg::NumIters)] = num_iters;
+                writer_rt_args[runtime_arg_index(WriterRuntimeArg::SliceStart)] = local_output_start;
+                writer_rt_args[runtime_arg_index(WriterRuntimeArg::SliceCount)] = num_worker_output_chunks;
+                writer_rt_args[runtime_arg_index(WriterRuntimeArg::FinalStart)] = final_start;
+                writer_rt_args[runtime_arg_index(WriterRuntimeArg::FinalCount)] = final_count;
+                writer_rt_args[runtime_arg_index(WriterRuntimeArg::DoLocalWrite)] = do_local_write ? 1u : 0u;
+                writer_rt_args[runtime_arg_index(WriterRuntimeArg::DataValidSemaphore)] = data_valid_sem.address();
+                writer_rt_args[runtime_arg_index(WriterRuntimeArg::DataValidNocX)] =
+                    static_cast<uint32_t>(mirror_core.x);
+                writer_rt_args[runtime_arg_index(WriterRuntimeArg::DataValidNocY)] =
+                    static_cast<uint32_t>(mirror_core.y);
+                writer_rt_args[runtime_arg_index(WriterRuntimeArg::NumGranularSends)] = num_granular;
+                writer_rt_args[runtime_arg_index(WriterRuntimeArg::NeighborDeviceId)] =
+                    static_cast<uint32_t>(neighbor_node.chip_id);
+                writer_rt_args[runtime_arg_index(WriterRuntimeArg::NeighborMeshId)] =
+                    static_cast<uint32_t>(*neighbor_node.mesh_id);
+                if (num_iters > 0) {
+                    if (use_mux) {
+                        // Connect this worker to its channel (== worker index w) on the direction's mux.
+                        const CoreCoord mux_vc = mesh_device->worker_core_from_logical_core(mux_core(link, dir));
+                        const CoreCoord term_master_vc =
+                            mesh_device->worker_core_from_logical_core(worker_core(link, dir, 0));
+                        ttnn::ccl::fabric_mux_connection_rt_args(
+                            /*mux_connection_valid=*/true,
+                            /*is_termination_master=*/w == 0,
+                            tt::tt_fabric::FabricMuxChannelType::FULL_SIZE_CHANNEL,
+                            mux_vc,
+                            /*worker_id=*/w,
+                            core,
+                            mux_config,
+                            program,
+                            term_master_vc,
+                            writer_rt_args);
+                    } else {
+                        std::vector<tt::tt_fabric::FabricNodeId> dst = {neighbor_node};
+                        append_routing_plane_connection_manager_rt_args(
+                            sender_fabric_node_id,
+                            dst,
+                            {link},
+                            program,
+                            writer_kernel_id,
+                            {core},
+                            writer_rt_args,
+                            fabric_is_2d ? tt::tt_fabric::FabricApiType::Mesh : tt::tt_fabric::FabricApiType::Linear);
+                    }
+                }
+                tt::tt_metal::SetRuntimeArgs(program, writer_kernel_id, {core}, writer_rt_args);
+            }
+        }
+    }
+
+    shared_variables_t shared_variables{
+        .worker_cores = worker_cores,
+        .reader_kernel_id = reader_kernel_id,
+        .writer_kernel_id = writer_kernel_id,
+        .data_valid_sem = data_valid_sem,
+    };
+
+    return {std::move(program), std::move(shared_variables)};
+}
+
+void HighBwAllGatherUnicastFactory::override_runtime_arguments(
+    cached_mesh_workload_t& cached_workload,
+    const HighBwAllGatherParams& operation_attributes,
+    const HighBwAllGatherInputs& tensor_args,
+    Tensor& output_tensor) {
+    const uint32_t input_addr = tensor_args.input_tensor.buffer()->address();
+    const uint32_t output_addr = output_tensor.buffer()->address();
+
+    for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
+        auto& shared_vars = cached_workload.shared_variables.at(coordinate_range);
+        shared_vars.data_valid_sem = operation_attributes.data_valid_semaphore.value();
+        const uint32_t data_valid_addr = shared_vars.data_valid_sem.address();
+
+        auto& reader_args_by_core = GetRuntimeArgs(program, shared_vars.reader_kernel_id);
+        auto& writer_args_by_core = GetRuntimeArgs(program, shared_vars.writer_kernel_id);
+        for (const auto& core : shared_vars.worker_cores) {
+            auto& reader_args = reader_args_by_core[core.x][core.y];
+            reader_args.at(runtime_arg_index(ReaderRuntimeArg::InputAddress)) = input_addr;
+            reader_args.at(runtime_arg_index(ReaderRuntimeArg::OutputAddress)) = output_addr;
+            reader_args.at(runtime_arg_index(ReaderRuntimeArg::DataValidSemaphore)) = data_valid_addr;
+            auto& writer_args = writer_args_by_core[core.x][core.y];
+            writer_args.at(runtime_arg_index(WriterRuntimeArg::OutputAddress)) = output_addr;
+            writer_args.at(runtime_arg_index(WriterRuntimeArg::DataValidSemaphore)) = data_valid_addr;
+        }
+    }
+}
+
+}  // namespace ttnn::operations::experimental::deepseek_prefill::high_bw_all_gather

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/high_bw_all_gather/device/high_bw_all_gather_unicast_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/high_bw_all_gather/device/high_bw_all_gather_unicast_factory.hpp
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "high_bw_all_gather_device_operation_types.hpp"
+
+#include "ttnn/device_operation.hpp"
+
+#include <tt-metalium/global_semaphore.hpp>
+
+namespace ttnn::operations::experimental::deepseek_prefill::high_bw_all_gather {
+
+struct HighBwAllGatherUnicastFactory {
+    struct shared_variables_t {
+        std::vector<tt::tt_metal::CoreCoord> worker_cores;
+        tt::tt_metal::KernelHandle reader_kernel_id{};
+        tt::tt_metal::KernelHandle writer_kernel_id{};
+        tt::tt_metal::GlobalSemaphore data_valid_sem;
+    };
+
+    using cached_mesh_workload_t = ttnn::device_operation::AdaptedCachedMeshWorkload<shared_variables_t>;
+
+    static cached_mesh_workload_t create_mesh_workload(
+        const HighBwAllGatherParams& operation_attributes,
+        const ttnn::MeshCoordinateRangeSet& tensor_coords,
+        const HighBwAllGatherInputs& tensor_args,
+        Tensor& output_tensor);
+
+    static void override_runtime_arguments(
+        cached_mesh_workload_t& cached_workload,
+        const HighBwAllGatherParams& operation_attributes,
+        const HighBwAllGatherInputs& tensor_args,
+        Tensor& output_tensor);
+
+private:
+    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
+
+    static cached_program_t create_at(
+        const HighBwAllGatherParams& operation_attributes,
+        const ttnn::MeshCoordinate& sender_device_coord,
+        const HighBwAllGatherInputs& tensor_args,
+        const Tensor& output_tensor,
+        const tt::tt_metal::GlobalSemaphore& data_valid_sem);
+};
+
+}  // namespace ttnn::operations::experimental::deepseek_prefill::high_bw_all_gather

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/high_bw_all_gather/device/kernels/runtime_args.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/high_bw_all_gather/device/kernels/runtime_args.hpp
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+namespace high_bw_all_gather {
+
+enum class ReaderRuntimeArg : uint32_t {
+    InputAddress,
+    OutputAddress,
+    InitialStripe,
+    StripeStep,
+    NumIters,
+    TotalChunks,
+    SliceStart,
+    SliceCount,
+    FinalStart,
+    FinalCount,
+    InputPageStart,
+    InputPageEnd,
+    DataValidSemaphore,
+    Count,
+};
+
+enum class WriterRuntimeArg : uint32_t {
+    OutputAddress,
+    InitialStripe,
+    StripeStep,
+    NumIters,
+    SliceStart,
+    SliceCount,
+    FinalStart,
+    FinalCount,
+    DoLocalWrite,
+    DataValidSemaphore,
+    DataValidNocX,
+    DataValidNocY,
+    NumGranularSends,
+    NeighborDeviceId,
+    NeighborMeshId,
+    Count,
+};
+
+template <typename Enum>
+constexpr uint32_t runtime_arg_index(Enum value) {
+    return static_cast<uint32_t>(value);
+}
+
+}  // namespace high_bw_all_gather

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/high_bw_all_gather/device/kernels/unicast_common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/high_bw_all_gather/device/kernels/unicast_common.hpp
@@ -1,0 +1,312 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "tt_metal/fabric/hw/inc/packet_header_pool.h"
+
+#ifdef FABRIC_2D
+#include "tt_metal/fabric/hw/inc/mesh/api.h"
+namespace fabric_api = tt::tt_fabric::mesh::experimental;
+#else
+#include "tt_metal/fabric/hw/inc/linear/api.h"
+namespace fabric_api = tt::tt_fabric::linear::experimental;
+#endif
+
+#include <array>
+#include <cstdint>
+#include <utility>
+
+// Store-and-forward HighBwAllGather always terminates at the immediate physical
+// neighbor. Fabric1D encodes that as num_hops=1; Fabric2D encodes the resolved
+// neighbor node as a terminal mesh unicast destination.
+
+////////////////////////////////////////////////////////////////
+// data_valid semaphore protocol
+//
+// data_valid counts the chunks upstream has relayed into our output -- cumulative over the op, reset at
+// completion. A chunk's absolute position is base_chunk + within-slice offset, with base_chunk = (iter-1) *
+// slice_count. The writer maintains the count (atomic-inc per chunks delivered); the reader waits on it with
+// noc_semaphore_wait_min at the last chunk of each batch it reads, then a final wait for total_chunks before
+// reset.
+//
+// Waiting on an absolute position (not a signal count) lets one reader path cover every case with no alignment
+// or per-topology special-casing:
+//   - full relay, and even-ring split prefix half (offset 0) / suffix half (offset = half): same per-batch
+//     wait, differing only in base_chunk/count;
+//   - sink stripe (a line endpoint's incoming, or a ring antipode): no relay wait, covered by the final
+//     total_chunks wait;
+//   - sink direction (num_iters == 0): only the total_chunks wait runs.
+// So data_valid_granularity is a pure writer-side perf knob: the reader auto-paces to the writer's cadence.
+////////////////////////////////////////////////////////////////
+
+// Walks the output-tensor chunks of one stripe. Templated on the geometry so per-stripe starts are computed
+// here and the matched/split fast path (output_chunks_per_page == 1) folds away. Re-pointed to any stripe each
+// relay iteration via init(). A stripe's src address on this device equals its dst address on the neighbor, so
+// reader and writer share this iterator unchanged.
+template <
+    uint32_t output_chunks_per_stripe,
+    uint32_t output_chunks_per_page,
+    uint32_t output_chunk_size,
+    uint32_t num_devices,
+    uint32_t slice_step>
+class OutputStripeIterator {
+    static constexpr uint32_t output_page_size = output_chunks_per_page * output_chunk_size;
+    static constexpr uint32_t stripe_distance_chunks = num_devices * output_chunks_per_stripe;
+    static constexpr uint32_t output_pages_per_row = stripe_distance_chunks / output_chunks_per_page;
+
+public:
+    // Point at `stripe` for the chunk range [start, start + count).
+    FORCE_INLINE void init(uint32_t stripe, uint32_t start, uint32_t count) {
+        if constexpr (slice_step > 1) {
+            static_assert(output_chunks_per_page == 1, "strided bank-owned schedule requires matched output pages");
+            stripe_ = stripe;
+            start_ = start;
+            sent_ = 0;
+            count_ = count;
+            return;
+        }
+        const uint32_t s_start = (start / output_chunks_per_stripe) * stripe_distance_chunks +
+                                 (start % output_chunks_per_stripe) + stripe * output_chunks_per_stripe;
+        page_id_ = s_start / output_chunks_per_page;
+        byte_off_ = (s_start % output_chunks_per_page) * output_chunk_size;
+        if constexpr (output_chunks_per_page == 1) {
+            phase_ = 0;
+            stripe_jump_ = output_pages_per_row - (output_chunks_per_stripe - 1);
+        } else {
+            // In concat mode the page phase (and hence the stripe jump) depends on the stripe.
+            const uint32_t off = (stripe * output_chunks_per_stripe) % output_chunks_per_page;
+            phase_ = off * output_chunk_size;
+            stripe_jump_ = output_pages_per_row - (off + output_chunks_per_stripe - 1) / output_chunks_per_page;
+        }
+        chunk_in_stripe_ = start % output_chunks_per_stripe;
+        sent_ = 0;
+        count_ = count;
+    }
+
+    FORCE_INLINE bool valid() const { return sent_ < count_; }
+
+    // Return {output_page_id, byte_offset} of the current chunk, then advance.
+    FORCE_INLINE std::pair<uint32_t, uint32_t> next() {
+        if constexpr (slice_step > 1) {
+            const uint32_t local_chunk = start_ + sent_ * slice_step;
+            const uint32_t stripe_group = local_chunk / output_chunks_per_stripe;
+            const uint32_t chunk_in_stripe = local_chunk % output_chunks_per_stripe;
+            ++sent_;
+            return {stripe_group * stripe_distance_chunks + stripe_ * output_chunks_per_stripe + chunk_in_stripe, 0};
+        }
+        std::pair<uint32_t, uint32_t> loc{page_id_, byte_off_};
+        sent_++;
+        if (++chunk_in_stripe_ == output_chunks_per_stripe) {
+            chunk_in_stripe_ = 0;
+            page_id_ += stripe_jump_;
+            byte_off_ = phase_;
+        } else {
+            byte_off_ += output_chunk_size;
+            if (byte_off_ == output_page_size) {
+                byte_off_ = 0;
+                page_id_++;
+            }
+        }
+        return loc;
+    }
+
+private:
+    uint32_t page_id_, byte_off_, chunk_in_stripe_, sent_, count_, phase_, stripe_jump_, stripe_, start_;
+};
+
+// Unicasts pages one hop to the single neighbor. Handles packetization (pack several pages into one
+// scatter-write packet when they fit, else split a big page across packets).
+//
+// Templated on the sender type (SenderT*) so the same writer drives either a direct WorkerToFabricEdmSender
+// (one worker per direction) or a WorkerToFabricMuxSender (workers sharing a fabric mux). The send calls are
+// base sender-pointer overloads that accept either. Fabric1D targets one hop;
+// Fabric2D encodes the direct neighbor node in each stateful packet header.
+// FabricWriter owns its packet headers directly.
+template <uint32_t page_size, uint32_t packet_size, bool coalesce_contiguous_pages, typename SenderT>
+class FabricWriter {
+public:
+    FabricWriter(
+        const Noc& noc, SenderT* sender, [[maybe_unused]] uint8_t dst_dev_id, [[maybe_unused]] uint16_t dst_mesh_id) :
+        noc{noc},
+        sender{sender},
+        scatter_packet_header{PacketHeaderPool::allocate_header(1)},
+        unicast_packet_header{PacketHeaderPool::allocate_header(1)},
+        fused_unicast_packet_header{PacketHeaderPool::allocate_header(1)},
+        scatter_header({}, {}),
+        chunk_count{0},
+        chunks_are_contiguous{true} {
+        std::array<uint64_t, max_pages_per_packet> dummy_addrs{};  // init to 0s
+        std::array<uint16_t, max_pages_per_packet - 1> chunk_sizes{};
+        chunk_sizes.fill(page_size);
+        // The scatter command has fixed-size address/chunk arrays even when the
+        // contiguous-page path below uses a larger terminal unicast payload.
+        // Only initialize the entries the scatter command can represent.
+        constexpr uint32_t scatter_header_pages_per_packet = std::min(pages_per_packet, max_pages_per_packet);
+#ifdef FABRIC_2D
+        fabric_api::fabric_unicast_noc_scatter_write_set_state<UnicastScatterWriteUpdateMask::ChunkSizes>(
+            scatter_packet_header,
+            dst_dev_id,
+            dst_mesh_id,
+            NocUnicastScatterCommandHeader(dummy_addrs.data(), chunk_sizes.data(), scatter_header_pages_per_packet));
+
+        fabric_api::fabric_unicast_noc_unicast_write_set_state<UnicastWriteUpdateMask::None>(
+            unicast_packet_header, dst_dev_id, dst_mesh_id);
+        fabric_api::fabric_unicast_noc_fused_unicast_with_atomic_inc_set_state<UnicastFusedAtomicIncUpdateMask::None>(
+            fused_unicast_packet_header, dst_dev_id, dst_mesh_id);
+#else
+        constexpr uint8_t num_hops = 1;
+        fabric_api::fabric_unicast_noc_scatter_write_set_state<UnicastScatterWriteUpdateMask::ChunkSizes>(
+            scatter_packet_header,
+            num_hops,
+            NocUnicastScatterCommandHeader(dummy_addrs.data(), chunk_sizes.data(), scatter_header_pages_per_packet));
+
+        fabric_api::fabric_unicast_noc_unicast_write_set_state<UnicastWriteUpdateMask::None>(
+            unicast_packet_header, num_hops);
+        fabric_api::fabric_unicast_noc_fused_unicast_with_atomic_inc_set_state<UnicastFusedAtomicIncUpdateMask::None>(
+            fused_unicast_packet_header, num_hops);
+#endif
+    }
+
+    ~FabricWriter() {
+        ASSERT(chunk_count == 0);  // outstanding chunks! flush() not called correctly
+    }
+
+    void async_write(uint32_t l1_addr, uint64_t remote_noc_addr) {
+        static_assert(
+            !(use_scatter_write && coalesce_contiguous_pages),
+            "bank-owned callers must submit their already contiguous CB batch with async_write_contiguous");
+        if constexpr (use_scatter_write) {
+            // Queue up multiple pages to send in a single packet.
+            // Assumption: pages are contiguous in local memory (L1).
+            // Note: currently, scatter_write necessitates chunk_count >= 2.
+            if (chunk_count == 0) {
+                start_l1_addr = l1_addr;
+                chunks_are_contiguous = true;
+            } else {
+                chunks_are_contiguous &= remote_noc_addr == scatter_header.noc_address[chunk_count - 1] + page_size;
+            }
+            scatter_header.noc_address[chunk_count++] = remote_noc_addr;
+            if (chunk_count == pages_per_packet) {
+                send_queued_chunks();
+            }
+        } else {
+            // Page larger than a packet: split across packets.
+            for (uint32_t packet = 0; packet < packets_per_page; ++packet) {
+                noc.async_writes_flushed();
+                fabric_api::fabric_unicast_noc_unicast_write_with_state<
+                    UnicastWriteUpdateMask::DstAddr | UnicastWriteUpdateMask::PayloadSize>(
+                    sender,
+                    unicast_packet_header,
+                    l1_addr,
+                    tt::tt_fabric::NocUnicastCommandHeader{remote_noc_addr},
+                    (packet < packets_per_page - 1) ? payload_size : last_payload_size);
+                l1_addr += payload_size;
+                remote_noc_addr += payload_size;
+            }
+        }
+    }
+
+    // Writes the final page of a readiness granule and, when the destination pages form one contiguous packet,
+    // folds the downstream data-valid increment into that packet. Other packetization modes retain the regular
+    // write and tell the caller to emit its standalone atomic.
+    bool async_write_and_signal(uint32_t l1_addr, uint64_t remote_noc_addr, uint64_t semaphore_noc_addr, uint32_t val) {
+        static_assert(
+            !(use_scatter_write && coalesce_contiguous_pages),
+            "bank-owned callers must use async_write_contiguous_and_signal for fused signaling");
+        async_write(l1_addr, remote_noc_addr);
+        return false;
+    }
+
+    // A bank-owned schedule maps each worker's strided logical pages to one physically contiguous DRAM range.
+    // The caller has already formed a contiguous CB batch, so submit it directly instead of rediscovering the
+    // same contiguity page by page.
+    void async_write_contiguous(uint32_t l1_addr, uint64_t remote_noc_addr, uint32_t size) {
+        static_assert(
+            use_scatter_write && coalesce_contiguous_pages,
+            "contiguous batch writes require multiple bank-owned pages per packet");
+        ASSERT(chunk_count == 0);
+        ASSERT(size <= packet_size);
+        noc.async_writes_flushed();
+        fabric_api::fabric_unicast_noc_unicast_write_with_state<
+            UnicastWriteUpdateMask::DstAddr | UnicastWriteUpdateMask::PayloadSize>(
+            sender, unicast_packet_header, l1_addr, tt::tt_fabric::NocUnicastCommandHeader{remote_noc_addr}, size);
+    }
+
+    void async_write_contiguous_and_signal(
+        uint32_t l1_addr, uint64_t remote_noc_addr, uint32_t size, uint64_t semaphore_noc_addr, uint32_t val) {
+        static_assert(
+            use_scatter_write && coalesce_contiguous_pages,
+            "contiguous batch writes require multiple bank-owned pages per packet");
+        ASSERT(chunk_count == 0);
+        ASSERT(size <= packet_size);
+        noc.async_writes_flushed();
+        fabric_api::fabric_unicast_noc_fused_unicast_with_atomic_inc_with_state<UnicastFusedAtomicIncUpdateMask::All>(
+            sender,
+            fused_unicast_packet_header,
+            l1_addr,
+            tt::tt_fabric::NocUnicastAtomicIncFusedCommandHeader{remote_noc_addr, semaphore_noc_addr, val, true},
+            size);
+    }
+
+    // Call this before popping CB entry
+    void async_writes_flushed() {
+        if constexpr (use_scatter_write && !coalesce_contiguous_pages) {
+            static_assert(min_pages_per_packet == 2, "hardcoded to assume scatter_write min_pages_per_packet == 2");
+            if (chunk_count > 0) {
+                send_queued_chunks();
+            }
+        }
+        // Wait for Fabric writes to be sent out before popping CB entry
+        noc.async_writes_flushed();
+    }
+
+private:
+    void send_queued_chunks() {
+        static_assert(
+            !(use_scatter_write && coalesce_contiguous_pages), "bank-owned writes bypass the scatter accumulator");
+        noc.async_writes_flushed();
+        if (chunk_count == 1 || chunks_are_contiguous) {
+            fabric_api::fabric_unicast_noc_unicast_write_with_state<
+                UnicastWriteUpdateMask::DstAddr | UnicastWriteUpdateMask::PayloadSize>(
+                sender,
+                unicast_packet_header,
+                start_l1_addr,
+                tt::tt_fabric::NocUnicastCommandHeader{scatter_header.noc_address[0]},
+                chunk_count * page_size);
+        } else {
+            scatter_header.chunk_count = chunk_count;
+            fabric_api::fabric_unicast_noc_scatter_write_with_state<
+                UnicastScatterWriteUpdateMask::DstAddrs | UnicastScatterWriteUpdateMask::PayloadSize>(
+                sender, scatter_packet_header, start_l1_addr, scatter_header, chunk_count * page_size);
+        }
+        chunk_count = 0;
+    }
+
+    // Fabric limits
+    static constexpr uint32_t max_pages_per_packet = NOC_SCATTER_WRITE_MAX_CHUNKS;
+    static constexpr uint32_t min_pages_per_packet = NOC_SCATTER_WRITE_MIN_CHUNKS;
+    // When page_size < packet_size
+    static constexpr uint32_t pages_per_packet =
+        coalesce_contiguous_pages ? packet_size / page_size
+                                  : std::min(packet_size / page_size, max_pages_per_packet);  // div_down
+    // When page_size > packet_size
+    static constexpr uint32_t packets_per_page = (page_size + packet_size - 1) / packet_size;  // div_up
+    // Use scatter_write or unicast_write (currently scatter_write imposes a min chunk_count)
+    static constexpr bool use_scatter_write = pages_per_packet >= min_pages_per_packet;
+    // Steady-state payload size. Note (pages_per_packet * page_size) may not equal packet_size.
+    static constexpr uint32_t payload_size = use_scatter_write ? (pages_per_packet * page_size) : packet_size;
+    // Last payload for the page_size >= packet_size case (a page sent as multiple packets).
+    static constexpr uint32_t last_payload_size = page_size - ((packets_per_page - 1) * packet_size);
+
+    const Noc& noc;
+    SenderT* sender;  // direct or mux sender
+    volatile tt_l1_ptr PACKET_HEADER_TYPE* scatter_packet_header;
+    volatile tt_l1_ptr PACKET_HEADER_TYPE* unicast_packet_header;
+    volatile tt_l1_ptr PACKET_HEADER_TYPE* fused_unicast_packet_header;
+    NocUnicastScatterCommandHeader scatter_header;
+    uint32_t chunk_count;    // accumulated chunks not yet sent in a packet
+    uint32_t start_l1_addr;  // start address of the accumulated contiguous chunks
+    bool chunks_are_contiguous;
+};

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/high_bw_all_gather/device/kernels/unicast_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/high_bw_all_gather/device/kernels/unicast_reader.cpp
@@ -1,0 +1,148 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+#include "api/core_local_mem.h"
+
+#include <cstdint>
+#include <utility>
+
+#include "runtime_args.hpp"
+#include "unicast_common.hpp"
+
+using address_t = uint32_t;
+using high_bw_all_gather::ReaderRuntimeArg;
+using high_bw_all_gather::runtime_arg_index;
+
+// Store-and-forward reader: CB producer, no fabric. It owns every data_valid wait (see the protocol note in
+// unicast_common.hpp). Iteration 0 fills the CB from this device's local data; later iterations relay the
+// stripe upstream delivered into our output, gated on data_valid.
+void kernel_main() {
+    ///////////////////////////////////////////////////
+    // COMPILE TIME ARGS
+    ///////////////////////////////////////////////////
+    constexpr uint32_t input_page_size = get_compile_time_arg_val(0);
+    constexpr uint32_t output_chunk_size = get_compile_time_arg_val(1);
+    constexpr uint32_t output_chunks_per_page = get_compile_time_arg_val(2);
+    constexpr uint32_t output_chunks_per_stripe = get_compile_time_arg_val(3);
+    constexpr uint32_t num_devices = get_compile_time_arg_val(4);
+    constexpr uint32_t cb0_id = get_compile_time_arg_val(5);
+    constexpr uint32_t cb_page_size = get_compile_time_arg_val(6);
+    constexpr uint32_t slice_step = get_compile_time_arg_val(7);
+    constexpr auto input_tensor_args = TensorAccessorArgs<8>();
+    constexpr auto output_tensor_args = TensorAccessorArgs<input_tensor_args.next_compile_time_args_offset()>();
+
+    constexpr uint32_t inputs_per_cb_page = cb_page_size / input_page_size;
+    constexpr uint32_t outputs_per_cb_page = cb_page_size / output_chunk_size;
+
+    ///////////////////////////////////////////////////
+    // RUNTIME ARGS
+    ///////////////////////////////////////////////////
+    const address_t input_tensor_address = get_arg_val<address_t>(runtime_arg_index(ReaderRuntimeArg::InputAddress));
+    const address_t output_tensor_address = get_arg_val<address_t>(runtime_arg_index(ReaderRuntimeArg::OutputAddress));
+    const uint32_t initial_stripe = get_arg_val<uint32_t>(runtime_arg_index(ReaderRuntimeArg::InitialStripe));
+    const uint32_t stripe_step = get_arg_val<uint32_t>(runtime_arg_index(ReaderRuntimeArg::StripeStep));
+    const uint32_t num_iters = get_arg_val<uint32_t>(runtime_arg_index(ReaderRuntimeArg::NumIters));
+    const uint32_t total_chunks = get_arg_val<uint32_t>(runtime_arg_index(ReaderRuntimeArg::TotalChunks));
+    const uint32_t slice_start = get_arg_val<uint32_t>(runtime_arg_index(ReaderRuntimeArg::SliceStart));
+    const uint32_t slice_count = get_arg_val<uint32_t>(runtime_arg_index(ReaderRuntimeArg::SliceCount));
+    const uint32_t final_start = get_arg_val<uint32_t>(runtime_arg_index(ReaderRuntimeArg::FinalStart));
+    const uint32_t final_count = get_arg_val<uint32_t>(runtime_arg_index(ReaderRuntimeArg::FinalCount));
+    const uint32_t input_page_id_start = get_arg_val<uint32_t>(runtime_arg_index(ReaderRuntimeArg::InputPageStart));
+    const uint32_t input_page_id_end = get_arg_val<uint32_t>(runtime_arg_index(ReaderRuntimeArg::InputPageEnd));
+    const address_t data_valid_sem = get_arg_val<uint32_t>(runtime_arg_index(ReaderRuntimeArg::DataValidSemaphore));
+
+    auto input_tensor_accessor = TensorAccessor(input_tensor_args, input_tensor_address);
+    auto output_tensor_accessor = TensorAccessor(output_tensor_args, output_tensor_address);
+
+    Noc noc;
+    CircularBuffer cb(cb0_id);
+    auto* data_valid_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(data_valid_sem);
+
+    OutputStripeIterator<output_chunks_per_stripe, output_chunks_per_page, output_chunk_size, num_devices, slice_step>
+        it;
+
+    ///////////////////////////////////////////////////
+    // MAIN
+    ///////////////////////////////////////////////////
+
+    uint32_t stripe = initial_stripe;
+    for (uint32_t iter = 0; iter < num_iters; ++iter) {
+        if (iter == 0) {
+            // Local data (our own input tensor)
+            uint32_t page = input_page_id_start;
+            while (page < input_page_id_end) {
+                cb.reserve_back(1);
+                uint32_t l1_write_addr = cb.get_write_ptr();
+                for (uint32_t i = 0; i < inputs_per_cb_page && page < input_page_id_end; ++i) {
+                    noc.async_read(
+                        input_tensor_accessor,
+                        CoreLocalMem<uint32_t>(l1_write_addr),
+                        input_page_size,
+                        {.page_id = page},
+                        {},
+                        {});
+                    l1_write_addr += input_page_size;
+                    page += slice_step;
+                }
+                noc.async_read_barrier();
+                cb.push_back(1);
+            }
+        } else {
+            // Relay: read the stripe upstream delivered into our output, waiting per CB-page batch for its
+            // chunks to arrive. base_chunk is where this read begins in the delivered-chunk stream: 0 for a full
+            // stripe or an even-ring prefix half, `half` for a suffix half.
+            const bool last = (iter == num_iters - 1);
+            const uint32_t start = last ? final_start : slice_start;
+            const uint32_t count = last ? final_count : slice_count;
+            const uint32_t base_chunk = (iter - 1) * slice_count + (start - slice_start) / slice_step;
+            it.init(stripe, start, count);
+            for (uint32_t chunks_read = 0; chunks_read < count;) {
+                const uint32_t batch = std::min(outputs_per_cb_page, count - chunks_read);
+                noc_semaphore_wait_min(data_valid_ptr, base_chunk + chunks_read + batch);
+
+                cb.reserve_back(1);
+                uint32_t l1_write_addr = cb.get_write_ptr();
+                if constexpr (slice_step > 1 && outputs_per_cb_page > 1) {
+                    // In a bank-owned schedule, stepping by the DRAM-bank count advances to the next physically
+                    // contiguous chunk in the same bank. Read the complete CB batch with one NOC transaction.
+                    auto [first_page_id, first_byte_off] = it.next();
+                    const uint64_t first_noc_addr =
+                        output_tensor_accessor.get_noc_addr(first_page_id, first_byte_off, noc.get_noc_id());
+                    for (uint32_t i = 1; i < batch; ++i) {
+                        (void)it.next();
+                    }
+                    noc_async_read(first_noc_addr, l1_write_addr, batch * output_chunk_size, noc.get_noc_id());
+                } else {
+                    for (uint32_t i = 0; i < batch; ++i) {
+                        auto [page_id, byte_off] = it.next();
+                        noc.async_read(
+                            output_tensor_accessor,
+                            CoreLocalMem<uint32_t>(l1_write_addr),
+                            output_chunk_size,
+                            {.page_id = page_id, .offset_bytes = byte_off},
+                            {},
+                            {});
+                        l1_write_addr += output_chunk_size;
+                    }
+                }
+                noc.async_read_barrier();
+                cb.push_back(1);
+                chunks_read += batch;
+            }
+        }
+        stripe = (stripe + stripe_step) % num_devices;
+    }
+
+    ///////////////////////////////////////////////////
+    // CLEANUP
+    ///////////////////////////////////////////////////
+
+    // Completion: wait for every chunk upstream delivers (relayed + sink), then reset for reuse.
+    noc_semaphore_wait_min(data_valid_ptr, total_chunks);
+    noc_semaphore_set(data_valid_ptr, 0);
+}

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/high_bw_all_gather/device/kernels/unicast_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/high_bw_all_gather/device/kernels/unicast_writer.cpp
@@ -1,0 +1,304 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+#include "api/core_local_mem.h"
+#include "tt_metal/fabric/hw/inc/noc_addr.h"
+#include "tt_metal/fabric/hw/inc/packet_header_pool.h"
+#include "tt_metal/fabric/hw/inc/edm_fabric/routing_plane_connection_manager.hpp"
+#include "cpp/ttnn/operations/ccl/common/kernels/minimal_ccl_common.hpp"
+
+#include <cstdint>
+#include <utility>
+
+#include "runtime_args.hpp"
+#include "unicast_common.hpp"
+
+using address_t = uint32_t;
+using high_bw_all_gather::runtime_arg_index;
+using high_bw_all_gather::WriterRuntimeArg;
+
+// Store-and-forward writer: CB consumer, owns all fabric. It only ever sends (never waits on a semaphore --
+// its sole backpressure is wait_front). Each iteration drains the CB and unicasts the stripe one hop to the
+// neighbor's output (same address); iteration 0 also writes this device's local data into local output.
+// Maintains the downstream reader's data_valid (= chunks delivered; see the note in unicast_common.hpp), and
+// signals downstream readiness only after the corresponding payload is visible.
+void kernel_main() {
+    ///////////////////////////////////////////////////
+    // COMPILE TIME ARGS
+    ///////////////////////////////////////////////////
+    constexpr uint32_t output_chunk_size = get_compile_time_arg_val(0);
+    constexpr uint32_t output_chunks_per_page = get_compile_time_arg_val(1);
+    constexpr uint32_t output_chunks_per_stripe = get_compile_time_arg_val(2);
+    constexpr uint32_t num_devices = get_compile_time_arg_val(3);
+    constexpr uint32_t cb0_id = get_compile_time_arg_val(4);
+    constexpr uint32_t cb_page_size = get_compile_time_arg_val(5);
+    constexpr uint32_t packet_size = get_compile_time_arg_val(6);
+    constexpr uint32_t data_valid_granularity = get_compile_time_arg_val(7);
+    constexpr uint32_t slice_step = get_compile_time_arg_val(8);
+    constexpr auto output_tensor_args = TensorAccessorArgs<9>();
+
+#ifdef USE_WORKER_MUX
+    // Fabric-mux geometry, appended by ccl::fabric_mux_connection_ct_args (after the tensor-accessor args).
+    constexpr uint32_t mux_ct_base = output_tensor_args.next_compile_time_args_offset();
+    constexpr uint8_t fabric_mux_num_buffers_per_channel = get_compile_time_arg_val(mux_ct_base + 0);
+    constexpr size_t fabric_mux_channel_buffer_size_bytes = get_compile_time_arg_val(mux_ct_base + 1);
+    constexpr size_t fabric_mux_status_address = get_compile_time_arg_val(mux_ct_base + 2);
+    constexpr size_t fabric_mux_termination_signal_address = get_compile_time_arg_val(mux_ct_base + 3);
+    constexpr uint32_t num_mux_clients = get_compile_time_arg_val(mux_ct_base + 4);
+#endif
+
+    constexpr uint32_t outputs_per_cb_page = cb_page_size / output_chunk_size;
+
+    ///////////////////////////////////////////////////
+    // RUNTIME ARGS
+    ///////////////////////////////////////////////////
+    const address_t output_tensor_address = get_arg_val<address_t>(runtime_arg_index(WriterRuntimeArg::OutputAddress));
+    const uint32_t initial_stripe = get_arg_val<uint32_t>(runtime_arg_index(WriterRuntimeArg::InitialStripe));
+    const uint32_t stripe_step = get_arg_val<uint32_t>(runtime_arg_index(WriterRuntimeArg::StripeStep));
+    const uint32_t num_iters = get_arg_val<uint32_t>(runtime_arg_index(WriterRuntimeArg::NumIters));
+    const uint32_t slice_start = get_arg_val<uint32_t>(runtime_arg_index(WriterRuntimeArg::SliceStart));
+    const uint32_t slice_count = get_arg_val<uint32_t>(runtime_arg_index(WriterRuntimeArg::SliceCount));
+    const uint32_t final_start = get_arg_val<uint32_t>(runtime_arg_index(WriterRuntimeArg::FinalStart));
+    const uint32_t final_count = get_arg_val<uint32_t>(runtime_arg_index(WriterRuntimeArg::FinalCount));
+    const uint32_t do_local_write = get_arg_val<uint32_t>(runtime_arg_index(WriterRuntimeArg::DoLocalWrite));
+    const address_t data_valid_sem = get_arg_val<uint32_t>(runtime_arg_index(WriterRuntimeArg::DataValidSemaphore));
+    const uint8_t data_valid_sem_noc_x = get_arg_val<uint32_t>(runtime_arg_index(WriterRuntimeArg::DataValidNocX));
+    const uint8_t data_valid_sem_noc_y = get_arg_val<uint32_t>(runtime_arg_index(WriterRuntimeArg::DataValidNocY));
+    const uint32_t num_granular_sends = get_arg_val<uint32_t>(runtime_arg_index(WriterRuntimeArg::NumGranularSends));
+    [[maybe_unused]] const uint8_t neighbor_dev_id =
+        get_arg_val<uint32_t>(runtime_arg_index(WriterRuntimeArg::NeighborDeviceId));
+    [[maybe_unused]] const uint16_t neighbor_mesh_id =
+        get_arg_val<uint32_t>(runtime_arg_index(WriterRuntimeArg::NeighborMeshId));
+    [[maybe_unused]] size_t arg_for_fab =
+        runtime_arg_index(WriterRuntimeArg::Count);  // fabric connection args start here (non-mux path)
+    size_t arg_idx = runtime_arg_index(WriterRuntimeArg::Count);
+
+    // A direction with no neighbor (a line endpoint) relays nothing; no fabric/mux connection was appended.
+    if (num_iters == 0) {
+        return;
+    }
+
+#ifdef USE_WORKER_MUX
+    // Fabric-mux connection RT args, appended by ccl::fabric_mux_connection_rt_args (17 args). Only appended
+    // for an active direction, so we always have a live connection here (num_iters > 0 implies a neighbor).
+    [[maybe_unused]] const bool mux_connection_valid = get_arg_val<uint32_t>(arg_idx++) == 1;
+    const bool is_termination_master = get_arg_val<uint32_t>(arg_idx++) != 0;
+    const uint8_t fabric_mux_x = get_arg_val<uint32_t>(arg_idx++);
+    const uint8_t fabric_mux_y = get_arg_val<uint32_t>(arg_idx++);
+    const size_t fabric_mux_channel_base_address = get_arg_val<uint32_t>(arg_idx++);
+    const size_t fabric_mux_connection_info_address = get_arg_val<uint32_t>(arg_idx++);
+    const size_t fabric_mux_connection_handshake_address = get_arg_val<uint32_t>(arg_idx++);
+    const size_t fabric_mux_flow_control_address = get_arg_val<uint32_t>(arg_idx++);
+    const size_t fabric_mux_buffer_index_address = get_arg_val<uint32_t>(arg_idx++);
+    const uint8_t fabric_mux_channel_id = get_arg_val<uint32_t>(arg_idx++);
+    const uint32_t termination_sync_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
+    const uint32_t local_fabric_mux_status_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
+    const uint32_t local_flow_control_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
+    const uint32_t local_teardown_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
+    const uint32_t local_buffer_index_address = get_semaphore(get_arg_val<uint32_t>(arg_idx++));
+    const uint8_t termination_master_noc_x = get_arg_val<uint32_t>(arg_idx++);
+    const uint8_t termination_master_noc_y = get_arg_val<uint32_t>(arg_idx++);
+#endif
+
+    auto output_tensor_accessor = TensorAccessor(output_tensor_args, output_tensor_address);
+
+    Noc noc;
+    CircularBuffer cb(cb0_id);
+
+    ///////////////////////////////////////////////////
+    // FABRIC INIT
+    ///////////////////////////////////////////////////
+
+#ifdef USE_WORKER_MUX
+    // Multiple workers per direction share one fabric link through a fabric mux. Connect to our channel on the
+    // mux instead of opening a direct connection to the neighbor's ERISC.
+    using SenderT = tt::tt_fabric::WorkerToFabricMuxSender<fabric_mux_num_buffers_per_channel>;
+    SenderT mux_connection = tt::tt_fabric::build_connection_to_fabric_endpoint<fabric_mux_num_buffers_per_channel>(
+        fabric_mux_x,
+        fabric_mux_y,
+        fabric_mux_channel_id,
+        fabric_mux_num_buffers_per_channel,
+        fabric_mux_channel_buffer_size_bytes,
+        fabric_mux_channel_base_address,
+        fabric_mux_connection_info_address,
+        fabric_mux_connection_handshake_address,
+        fabric_mux_flow_control_address,
+        fabric_mux_buffer_index_address,
+        local_flow_control_address,
+        local_teardown_address,
+        local_buffer_index_address);
+    tt::tt_fabric::wait_for_fabric_endpoint_ready(
+        fabric_mux_x, fabric_mux_y, fabric_mux_status_address, local_fabric_mux_status_address);
+    tt::tt_fabric::fabric_client_connect(mux_connection);
+    SenderT* sender = &mux_connection;
+#else
+    // Single worker per direction: connect directly to the neighbor's ERISC.
+    tt::tt_fabric::RoutingPlaneConnectionManager fabric_connection;
+    open_connections(fabric_connection, 1, arg_for_fab);
+    using SenderT = tt::tt_fabric::WorkerToFabricEdmSender;
+    SenderT* sender = &fabric_connection.get(0).sender;
+#endif
+
+    FabricWriter<output_chunk_size, packet_size, (slice_step > 1), SenderT> fabric(
+        noc, sender, neighbor_dev_id, neighbor_mesh_id);
+
+    // One 1-hop atomic-inc header for data_valid signals. Flush keeps each
+    // increment ordered after the payload it announces.
+    auto sem_packet_header = PacketHeaderPool::allocate_header(1);
+#ifdef FABRIC_2D
+    fabric_api::fabric_unicast_noc_unicast_atomic_inc_set_state<
+        UnicastAtomicIncUpdateMask::Val | UnicastAtomicIncUpdateMask::Flush>(
+        sem_packet_header, neighbor_dev_id, neighbor_mesh_id, tt::tt_fabric::NocUnicastAtomicIncCommandHeader{0u, 1u});
+#else
+    fabric_api::fabric_unicast_noc_unicast_atomic_inc_set_state<
+        UnicastAtomicIncUpdateMask::Val | UnicastAtomicIncUpdateMask::Flush>(
+        sem_packet_header, /*num_hops=*/1, tt::tt_fabric::NocUnicastAtomicIncCommandHeader{0u, 1u});
+#endif
+    auto atomic_inc = [&](uint64_t addr, uint32_t val) {
+        fabric_api::fabric_unicast_noc_unicast_atomic_inc_with_state<
+            UnicastAtomicIncUpdateMask::DstAddr | UnicastAtomicIncUpdateMask::Val>(
+            sender, sem_packet_header, tt::tt_fabric::NocUnicastAtomicIncCommandHeader{addr, val});
+    };
+
+    const uint64_t downstream_data_valid_addr =
+        safe_get_noc_addr(data_valid_sem_noc_x, data_valid_sem_noc_y, data_valid_sem, 0);
+    auto signal = [&](uint32_t chunks) { atomic_inc(downstream_data_valid_addr, chunks); };
+
+    ///////////////////////////////////////////////////
+    // MAIN
+    ///////////////////////////////////////////////////
+
+    OutputStripeIterator<output_chunks_per_stripe, output_chunks_per_page, output_chunk_size, num_devices, slice_step>
+        it;
+
+    uint32_t stripe = initial_stripe;
+    for (uint32_t iter = 0; iter < num_iters; ++iter) {
+        const bool last = (iter == num_iters - 1);
+        const uint32_t start = last ? final_start : slice_start;
+        const uint32_t count = last ? final_count : slice_count;
+        const bool granular = (iter < num_granular_sends);  // downstream relays this stripe -> signal fine-grained
+        const bool local_copy = (iter == 0) && (do_local_write != 0);
+        it.init(stripe, start, count);
+
+        uint32_t pending_chunks = 0, pending_pages = 0;
+        for (uint32_t chunks_sent = 0; chunks_sent < count;) {
+            const uint32_t batch = std::min(outputs_per_cb_page, count - chunks_sent);
+            const bool signal_after_page =
+                (granular && pending_pages + 1 == data_valid_granularity) || (chunks_sent + batch == count);
+            const uint32_t chunks_to_signal = pending_chunks + batch;
+            cb.wait_front(1);
+            uint32_t l1_read_addr = cb.get_read_ptr();
+            bool signal_fused = false;
+            if constexpr (slice_step > 1 && outputs_per_cb_page > 1) {
+                // Bank-owned logical pages are physically contiguous. Send the complete CB batch as one Fabric
+                // packet and use the same contiguous address for the optional local output copy.
+                auto [first_page_id, first_byte_off] = it.next();
+                const uint64_t neighbor_addr = tt::tt_fabric::addrgen_detail::get_noc_address(
+                    output_tensor_accessor, first_page_id, first_byte_off);
+                for (uint32_t i = 1; i < batch; ++i) {
+                    (void)it.next();
+                }
+
+                const uint32_t batch_size = batch * output_chunk_size;
+                if (signal_after_page) {
+                    fabric.async_write_contiguous_and_signal(
+                        l1_read_addr, neighbor_addr, batch_size, downstream_data_valid_addr, chunks_to_signal);
+                    signal_fused = true;
+                } else {
+                    fabric.async_write_contiguous(l1_read_addr, neighbor_addr, batch_size);
+                }
+
+                if (local_copy) {
+                    const uint64_t local_output_noc_addr =
+                        output_tensor_accessor.get_noc_addr(first_page_id, first_byte_off, noc.get_noc_id());
+                    noc_async_write<NOC_MAX_BURST_SIZE + 1, true, true>(
+                        l1_read_addr, local_output_noc_addr, batch_size, noc.get_noc_id(), NOC_UNICAST_WRITE_VC + 1);
+                }
+            } else {
+                for (uint32_t i = 0; i < batch; ++i) {
+                    auto [page_id, byte_off] = it.next();
+                    uint64_t neighbor_addr =
+                        tt::tt_fabric::addrgen_detail::get_noc_address(output_tensor_accessor, page_id, byte_off);
+                    if (signal_after_page && i == batch - 1) {
+                        signal_fused = fabric.async_write_and_signal(
+                            l1_read_addr, neighbor_addr, downstream_data_valid_addr, chunks_to_signal);
+                    } else {
+                        fabric.async_write(l1_read_addr, neighbor_addr);
+                    }
+
+                    if (local_copy) {
+                        // Local data -> our output stripe (same address). Posted write on a separate VC so it
+                        // doesn't contend with the fabric writes on the same NOC.
+                        noc.async_write<NocOptions::POSTED | NocOptions::CUSTOM_VC>(
+                            CoreLocalMem<uint32_t>(l1_read_addr),
+                            output_tensor_accessor,
+                            output_chunk_size,
+                            {},
+                            {.page_id = page_id, .offset_bytes = byte_off},
+                            {.vc = NOC_UNICAST_WRITE_VC + 1});
+                    }
+                    l1_read_addr += output_chunk_size;
+                }
+            }
+            if (local_copy) {
+                noc.async_writes_flushed<NocOptions::POSTED>();
+            }
+            fabric.async_writes_flushed();
+            cb.pop_front(1);
+
+            if (signal_after_page) {
+                if (!signal_fused) {
+                    signal(chunks_to_signal);
+                }
+                pending_chunks = 0;
+                pending_pages = 0;
+            } else {
+                pending_chunks += batch;
+                if (granular) {
+                    ++pending_pages;
+                }
+            }
+            chunks_sent += batch;
+        }
+        stripe = (stripe + stripe_step) % num_devices;
+    }
+
+    ///////////////////////////////////////////////////
+    // CLEANUP
+    ///////////////////////////////////////////////////
+
+    // Commit our own NOC writes (the iter-0 local copy, plus the packet writes into the mux buffer) before
+    // teardown.
+    noc_async_write_barrier();
+    noc_async_atomic_barrier();
+
+#ifdef USE_WORKER_MUX
+    // The mux forwards our buffered packets asynchronously, and close()/graceful-termination do NOT wait for
+    // in-flight packets to drain. Spin until the mux has forwarded everything (all channel slots freed).
+    // get_num_free_write_slots() invalidates the L1 cache internally.
+    while (mux_connection.get_num_free_write_slots() != fabric_mux_num_buffers_per_channel) {
+    }
+
+    // Disconnect from the mux. Worker 0 (termination master) waits for every peer to disconnect, then tells the
+    // mux to gracefully terminate (drain, then exit); the rest just signal the master.
+    tt::tt_fabric::fabric_client_disconnect(mux_connection);
+    if (is_termination_master) {
+        auto* termination_sync_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(termination_sync_address);
+        noc_semaphore_wait(termination_sync_ptr, num_mux_clients - 1);
+        tt::tt_fabric::fabric_endpoint_terminate(fabric_mux_x, fabric_mux_y, fabric_mux_termination_signal_address);
+    } else {
+        uint64_t master_sync_addr =
+            safe_get_noc_addr(termination_master_noc_x, termination_master_noc_y, termination_sync_address, 0);
+        noc_semaphore_inc(master_sync_addr, 1);
+        noc_async_atomic_barrier();
+    }
+#else
+    close_connections(fabric_connection);
+#endif
+    noc.async_write_barrier();
+}

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/high_bw_all_gather/high_bw_all_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/high_bw_all_gather/high_bw_all_gather.cpp
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "high_bw_all_gather.hpp"
+
+#include "device/high_bw_all_gather_device_operation.hpp"
+
+namespace ttnn::operations::experimental::deepseek_prefill::high_bw_all_gather {
+
+Tensor high_bw_all_gather(
+    const Tensor& input_tensor,
+    int32_t dim,
+    const Tensor& output_tensor,
+    uint32_t cluster_axis,
+    const GlobalSemaphore& data_valid_semaphore,
+    const std::optional<tt::tt_metal::SubDeviceId>& subdevice_id,
+    const std::optional<CoreRangeSet>& sub_core_grid,
+    std::optional<uint32_t> num_links) {
+    return ttnn::prim::high_bw_all_gather(
+        input_tensor, output_tensor, dim, cluster_axis, data_valid_semaphore, subdevice_id, sub_core_grid, num_links);
+}
+
+}  // namespace ttnn::operations::experimental::deepseek_prefill::high_bw_all_gather

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/high_bw_all_gather/high_bw_all_gather.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/high_bw_all_gather/high_bw_all_gather.hpp
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <optional>
+
+#include <tt-metalium/sub_device_types.hpp>
+#include "ttnn/global_semaphore.hpp"
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/types.hpp"
+
+namespace ttnn::operations::experimental::deepseek_prefill::high_bw_all_gather {
+
+Tensor high_bw_all_gather(
+    const Tensor& input_tensor,
+    int32_t dim,
+    const Tensor& output_tensor,
+    uint32_t cluster_axis,
+    const GlobalSemaphore& data_valid_semaphore,
+    const std::optional<tt::tt_metal::SubDeviceId>& subdevice_id = std::nullopt,
+    const std::optional<CoreRangeSet>& sub_core_grid = std::nullopt,
+    std::optional<uint32_t> num_links = std::nullopt);
+
+}  // namespace ttnn::operations::experimental::deepseek_prefill::high_bw_all_gather
+
+namespace ttnn::experimental::deepseek_prefill {
+using operations::experimental::deepseek_prefill::high_bw_all_gather::high_bw_all_gather;
+}  // namespace ttnn::experimental::deepseek_prefill

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/high_bw_all_gather/high_bw_all_gather_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/high_bw_all_gather/high_bw_all_gather_nanobind.cpp
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "high_bw_all_gather_nanobind.hpp"
+
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/optional.h>
+
+#include "high_bw_all_gather.hpp"
+#include "ttnn-nanobind/bind_function.hpp"
+
+namespace ttnn::operations::experimental::deepseek_prefill::high_bw_all_gather::detail {
+
+void bind_experimental_high_bw_all_gather_operation(nb::module_& mod) {
+    ttnn::bind_function<"high_bw_all_gather", "ttnn.experimental.deepseek_prefill.">(
+        mod,
+        R"doc(
+            Gathers a large row-major or tile-layout DRAM tensor over one required
+            device-mesh axis. This is a one-dimensional direct-neighbor Fabric line or
+            ring collective: it does not gather across both axes of a 2D mesh. The
+            operation uses a native one-hop store-and-forward transport and does not
+            provide a composite fallback.
+
+            Fabric2D supports a direct physical line or ring. A Torus may wrap
+            ``cluster_axis`` when the axis has a distinct wrap neighbor and every
+            ring edge is one physical hop. A size-two torus axis is treated as a
+            line because its ordinary and wrap neighbors are the same device.
+            Plain ``FABRIC_2D`` uses the direct-line schedule; only a Torus
+            configuration that wraps ``cluster_axis`` selects the ring schedule.
+
+            Channel trimming compatibility:
+                Channel trimming is selected during Fabric initialization and is shared
+                by all CCLs in the workload; it is not configurable per operation. A
+                trimming capture must cover every CCL and shape that will run. When
+                using a trimming profile with this operation, set
+                ``TT_METAL_FABRIC_TRIMMING_OVERRIDE`` to an override that force-enables
+                all VC0 sender and receiver channels. This avoids a trim-derived VC0
+                fast path that can substantially regress this high-rate, multi-worker
+                collective while preserving correctness. See this operation's README
+                for the YAML and launch example.
+
+            Args:
+                input_tensor: Row-major or tile-layout device tensor in DRAM.
+                dim: Tensor dimension along which device shards are concatenated.
+                output_tensor: Preallocated persistent output tensor.
+
+            Keyword Args:
+                cluster_axis: Required device-mesh axis (0 or 1) participating in the
+                    one-dimensional collective. The selected axis must contain at least
+                    two devices, and the tensor distribution axes must match the device
+                    mesh axes. Other mesh axes run independent all-gathers.
+                data_valid_semaphore: Caller-owned synchronization semaphore, initialized
+                    to zero and covering every candidate worker core. Allocate it once and
+                    reuse it across shapes to avoid one L1 allocation per program-cache
+                    entry. Concurrent invocations must use distinct semaphores.
+                num_links: Optional number of Fabric links to use. ``None`` uses every
+                    link reported usable across the selected axis. An explicit value
+                    must be greater than zero and cannot exceed that discovered count;
+                    use ``2`` to keep the same link count across QuietBox, LoudBox, and
+                    Galaxy.
+                subdevice_id: Subdevice containing the worker cores.
+                sub_core_grids: Optional worker-core restriction.
+        )doc",
+        &high_bw_all_gather,
+        nb::arg("input_tensor").noconvert(),
+        nb::arg("dim"),
+        nb::arg("output_tensor").noconvert(),
+        nb::kw_only(),
+        nb::arg("cluster_axis"),
+        nb::arg("data_valid_semaphore"),
+        nb::arg("subdevice_id") = nb::none(),
+        nb::arg("sub_core_grids") = nb::none(),
+        nb::arg("num_links") = nb::none());
+}
+
+}  // namespace ttnn::operations::experimental::deepseek_prefill::high_bw_all_gather::detail

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/high_bw_all_gather/high_bw_all_gather_nanobind.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/high_bw_all_gather/high_bw_all_gather_nanobind.hpp
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn-nanobind/nanobind_fwd.hpp"
+
+namespace ttnn::operations::experimental::deepseek_prefill::high_bw_all_gather::detail {
+
+namespace nb = nanobind;
+void bind_experimental_high_bw_all_gather_operation(nb::module_& mod);
+
+}  // namespace ttnn::operations::experimental::deepseek_prefill::high_bw_all_gather::detail

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/high_bw_all_gather/sources.cmake
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/high_bw_all_gather/sources.cmake
@@ -1,0 +1,9 @@
+set(TTNN_OP_EXPERIMENTAL_DEEPSEEK_PREFILL_HIGH_BW_ALL_GATHER_API_HEADERS high_bw_all_gather.hpp)
+
+set(TTNN_OP_EXPERIMENTAL_DEEPSEEK_PREFILL_HIGH_BW_ALL_GATHER_SRCS
+    device/high_bw_all_gather_device_operation.cpp
+    device/high_bw_all_gather_unicast_factory.cpp
+    high_bw_all_gather.cpp
+)
+
+set(TTNN_OP_EXPERIMENTAL_DEEPSEEK_PREFILL_HIGH_BW_ALL_GATHER_NANOBIND_SRCS high_bw_all_gather_nanobind.cpp)

--- a/ttnn/cpp/ttnn/operations/experimental/experimental_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/experimental_nanobind.cpp
@@ -79,6 +79,7 @@
 #include "ttnn/operations/experimental/deepseek_moe_post_combine_tilize/deepseek_moe_post_combine_tilize_nanobind.hpp"
 #include "ttnn/operations/experimental/deepseek_prefill/post_combine_reduce/post_combine_reduce_nanobind.hpp"
 #include "ttnn/operations/experimental/deepseek_prefill/masked_bincount/masked_bincount_nanobind.hpp"
+#include "ttnn/operations/experimental/deepseek_prefill/high_bw_all_gather/high_bw_all_gather_nanobind.hpp"
 #include "ttnn/operations/experimental/deepseek_prefill/offset_cumsum/offset_cumsum_nanobind.hpp"
 #include "ttnn/operations/experimental/deepseek_prefill/outbound_socket_service_sync/outbound_socket_service_sync_nanobind.hpp"
 #include "ttnn/operations/experimental/deepseek_prefill/per_token_cast_to_fp8/per_token_cast_to_fp8_nanobind.hpp"
@@ -151,6 +152,7 @@ void py_module(nb::module_& mod) {
     matmul::detail::bind_attn_matmul_from_cache(mod);
     matmul::detail::bind_group_attn_matmul(mod);
     deepseek_prefill::masked_bincount::detail::bind_experimental_masked_bincount_operation(mod);
+    deepseek_prefill::high_bw_all_gather::detail::bind_experimental_high_bw_all_gather_operation(mod);
     deepseek_prefill::offset_cumsum::detail::bind_experimental_offset_cumsum_operation(mod);
     deepseek_prefill::detail::bind_outbound_socket_service_sync(mod);
     deepseek_prefill::detail::bind_post_combine_reduce(mod);


### PR DESCRIPTION
- build metal on both hosts, hosts need to be adjacent in the same quad

- if needed to change iface: `ip route get "$(getent hosts bh-glx-110-c10u08 | awk '{print $1}')" | grep -oP 'dev \K\S+'`

- default hosts are set in `models/demos/common/prefill/runners/run_allgather_d2d_probe.sh`, please edit for the reserved hosts

- `RANK0_HOST=bh-glx-xxx RANK1_HOST=bh-glx-yyy ./models/demos/common/prefill/runners/run_allgather_d2d_probe.sh`