### PR TITLE
Allow descriptor-only kernels without watcher on simulator

### DIFF
--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -182,10 +182,10 @@ Kernel::Kernel(
 void Kernel::register_kernel_with_watcher() {
     auto& watcher = MetalContext::instance().watcher_server();
     if (!watcher) {
-        // Null for mock and emulated targets (no watcher created); nothing to register.
+        // Null for non-silicon targets without a watcher; nothing to register.
         TT_FATAL(
-            MetalContext::instance().get_cluster().is_mock_or_emulated(),
-            "Watcher server is unavailable, and the target is not a mock or emulated device");
+            MetalContext::instance().get_cluster().get_target_device_type() != tt::TargetDevice::Silicon,
+            "Watcher server is unavailable for a silicon target");
         this->watcher_kernel_id_ = -1;
         return;
     }


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
The `NamedArgsDescriptorCacheHit` API tests failed on WH simulator before reaching the named-runtime-arg checks because constructing a `Program` from a `ProgramDescriptor` registers each kernel with the watcher, but this descriptor-only path can have no watcher server available. The registration code only accepted a missing watcher for mock/emulated targets, so simulator runs fatally errored even though there is no device launch and no watcher state required. This change treats a missing watcher as valid for any non-silicon target and only preserves the fatal on silicon, leaving `watcher_kernel_id_` unset when there is nothing to register. That restores the host-only descriptor tests on simulator while keeping the silicon consistency check intact.

### Notes for reviewers
none

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mcraighead/sim-watcher-missing)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mcraighead/sim-watcher-missing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mcraighead/sim-watcher-missing)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mcraighead/sim-watcher-missing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mcraighead/sim-watcher-missing)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mcraighead/sim-watcher-missing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mcraighead/sim-watcher-missing)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mcraighead/sim-watcher-missing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mcraighead/sim-watcher-missing)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mcraighead/sim-watcher-missing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mcraighead/sim-watcher-missing)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mcraighead/sim-watcher-missing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mcraighead/sim-watcher-missing)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mcraighead/sim-watcher-missing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mcraighead/sim-watcher-missing)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mcraighead/sim-watcher-missing)