### PR TITLE
Implement CSV -> Parquet conversion

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/helpers/perf_parquet.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/perf_parquet.py
@@ -17,11 +17,25 @@ physical schema is the shared wide schema (perf_wide_schema.DB_SCHEMA):
 Needs pyarrow, but no device libraries — builds and validates without hardware.
 """
 
+import re
+from pathlib import Path
+
 import pandas as pd
 import pyarrow as pa
 import pyarrow.parquet as pq
 
 from .perf_wide_schema import DB_SCHEMA, MANDATORY
+
+_BOOL_MAP = {
+    True: True,
+    False: False,
+    "True": True,
+    "False": False,
+    "true": True,
+    "false": False,
+    1: True,
+    0: False,
+}
 
 _ARROW_TYPES = {
     "int64": pa.int64(),
@@ -52,10 +66,14 @@ def to_table(df, columns=DB_SCHEMA) -> pa.Table:
     """
     schema = arrow_schema(columns)
     aligned = align_to_schema(df, columns)
-    arrays = [
-        pa.array(aligned[field.name], type=field.type, from_pandas=True)
-        for field in schema
-    ]
+    arrays = []
+    for field in schema:
+        col = aligned[field.name]
+        # A "string" column may hold non-strings (a bool unpack_to_dest, an enum
+        # dest_acc); stringify non-null values so Arrow accepts them, keep nulls.
+        if field.type == pa.string():
+            col = col.map(lambda v: v if pd.isna(v) else str(v))
+        arrays.append(pa.array(col, type=field.type, from_pandas=True))
     return pa.Table.from_arrays(arrays, schema=schema)
 
 
@@ -134,3 +152,70 @@ def write_run_batch(test_frames, path, *, compression="zstd", **provenance):
     pq.write_table(
         build_run_batch(test_frames, **provenance), path, compression=compression
     )
+
+
+# ── CSV -> Parquet conversion (also the historical-migration path, Milestone 3) ─
+
+
+def _test_name_from_csv(path) -> str:
+    """perf_fast_untilize[.post|.counters].csv -> perf_fast_untilize."""
+    name = Path(path).name
+    return re.sub(r"\.(?:post|counters)?\.?csv$", "", name).rstrip(".")
+
+
+def _coerce_frame_to_schema(df, schema_by_name):
+    """Coerce each known column to its declared type. A value that does not fit
+    (e.g. value_bits "2.0f" in an int column) becomes NULL and is reported, so a
+    dirty CSV converts instead of crashing. Returns (coerced_df, report)."""
+    out = df.copy()
+    report = {}
+    for col in out.columns:
+        spec = schema_by_name.get(col)
+        if spec is None:
+            continue  # unknown column; align_to_schema drops it
+        before = out[col]
+        if spec.dtype in ("int64", "float64"):
+            after = pd.to_numeric(before, errors="coerce")
+        elif spec.dtype == "bool":
+            after = before.map(_BOOL_MAP)
+        else:
+            continue  # string: cast happens at Arrow conversion
+        bad = before.notna() & after.isna()
+        if bad.any():
+            report[col] = {
+                "type": spec.dtype,
+                "bad": int(bad.sum()),
+                "example": before[bad].iloc[0],
+            }
+        out[col] = after
+    return out, report
+
+
+def convert_csvs_to_parquet(csv_paths, out_path, *, compression="zstd", **provenance):
+    """Convert a run's per-test CSVs into one typed Parquet batch.
+
+    Reads each CSV, coerces its columns to the schema types, and reuses
+    build_run_batch to align + stamp provenance + compact. Returns diagnostics:
+    per test, columns dropped (not in the schema) and values coerced to NULL.
+    """
+    schema_by_name = {c.name: c for c in DB_SCHEMA}
+    frames = {}
+    diagnostics = {"unknown_columns": {}, "coerced_values": {}}
+    for path in csv_paths:
+        name = _test_name_from_csv(path)
+        df = pd.read_csv(path)
+        unknown = sorted(set(df.columns) - set(schema_by_name))
+        if unknown:
+            diagnostics["unknown_columns"][name] = unknown
+        coerced, report = _coerce_frame_to_schema(df, schema_by_name)
+        if report:
+            diagnostics["coerced_values"].setdefault(name, {}).update(report)
+        # Same test can appear across arch dirs / shards: accumulate its rows.
+        if name in frames:
+            frames[name] = pd.concat([frames[name], coerced], ignore_index=True)
+        else:
+            frames[name] = coerced
+
+    table = build_run_batch(frames, **provenance)
+    pq.write_table(table, out_path, compression=compression)
+    return diagnostics

--- a/tt_metal/tt-llk/tests/python_tests/helpers/perf_parquet.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/perf_parquet.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Typed Parquet output for LLK performance reports (Milestone 2).
+"""Parquet output for LLK performance reports
 
 Publishes a run's per-test reports as one immutable, typed Parquet batch whose
 physical schema is the shared wide schema (perf_wide_schema.DB_SCHEMA).
@@ -104,7 +104,7 @@ def to_table(df, columns=DB_SCHEMA) -> pa.Table:
     arrays = []
     for field in schema:
         col = aligned[field.name]
-        # A "string" column may hold non-strings (a bool unpack_to_dest, an enum
+        # A string column may hold non strings (a bool unpack_to_dest, an enum
         # dest_acc); stringify non-null values so Arrow accepts them, keep nulls.
         if field.type == pa.string():
             col = col.map(lambda v: v if pd.isna(v) else str(v))
@@ -117,7 +117,7 @@ def write_parquet(df, path, columns=DB_SCHEMA, compression="zstd"):
     pq.write_table(to_table(df, columns), path, compression=compression)
 
 
-# ── Run-level publication ─────────────────────────────────────────────────────
+#  Run-level publication
 
 
 def stamp_provenance(
@@ -189,7 +189,7 @@ def write_run_batch(test_frames, path, *, compression="zstd", **provenance):
     )
 
 
-# ── CSV -> Parquet conversion (also the historical-migration path, Milestone 3) ─
+#  CSV -> Parquet conversion
 
 
 def _test_name_from_csv(path) -> str:
@@ -226,12 +226,35 @@ def _coerce_frame_to_schema(df, schema_by_name):
     return out, report
 
 
-def convert_csvs_to_parquet(csv_paths, out_path, *, compression="zstd", **provenance):
+def _lossy_conversion_message(diagnostics) -> str:
+    lines = ["CSV -> Parquet conversion is not lossless (strict mode):"]
+    for test, cols in sorted(diagnostics["unknown_columns"].items()):
+        lines.append(f"  {test}: columns not in schema, would be DROPPED: {cols}")
+    for test, report in sorted(diagnostics["coerced_values"].items()):
+        for col, info in sorted(report.items()):
+            lines.append(
+                f"  {test}: {col} ({info['type']}) has {info['bad']} value(s) that "
+                f"don't fit (e.g. {info['example']!r}), would become NULL"
+            )
+    lines.append(
+        "Fix the schema (add the column / correct the type), or pass strict=False."
+    )
+    return "\n".join(lines)
+
+
+def convert_csvs_to_parquet(
+    csv_paths, out_path, *, compression="zstd", strict=True, **provenance
+):
     """Convert a run's per-test CSVs into one typed Parquet batch.
 
     Reads each CSV, coerces its columns to the schema types, and reuses
-    build_run_batch to align + stamp provenance + compact. Returns diagnostics:
-    per test, columns dropped (not in the schema) and values coerced to NULL.
+    build_run_batch to align + stamp provenance + compact.
+
+    With strict=True (default) the conversion must be lossless: if any column
+    would be dropped (not in the schema) or any value coerced to NULL, it raises
+    BEFORE writing and no file is produced. Pass strict=False for a best-effort
+    conversion that writes anyway. Either way it returns the diagnostics: per
+    test, the dropped columns and the coerced values.
     """
     schema_by_name = {c.name: c for c in DB_SCHEMA}
     frames = {}
@@ -245,11 +268,14 @@ def convert_csvs_to_parquet(csv_paths, out_path, *, compression="zstd", **proven
         coerced, report = _coerce_frame_to_schema(df, schema_by_name)
         if report:
             diagnostics["coerced_values"].setdefault(name, {}).update(report)
-        # Same test can appear across arch dirs / shards: accumulate its rows.
+        # Same test can appear across arch dirs / shards: accumulate its rows..
         if name in frames:
             frames[name] = pd.concat([frames[name], coerced], ignore_index=True)
         else:
             frames[name] = coerced
+
+    if strict and (diagnostics["unknown_columns"] or diagnostics["coerced_values"]):
+        raise ValueError(_lossy_conversion_message(diagnostics))
 
     table = build_run_batch(frames, **provenance)
     pq.write_table(table, out_path, compression=compression)

--- a/tt_metal/tt-llk/tests/python_tests/helpers/perf_parquet.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/perf_parquet.py
@@ -44,6 +44,7 @@ shared core (build_run_batch):
 Entry points:
   write_run_batch          = build_run_batch + write        (frames in memory)
   convert_csvs_to_parquet  = read + coerce + build + write  (csv files on disk)
+  parquet_to_csvs          = split a batch back into per-test CSVs (reverse)
 
 Notes:
   * One file per RUN, not per test: build_run_batch compacts every test's rows.
@@ -59,7 +60,7 @@ import pandas as pd
 import pyarrow as pa
 import pyarrow.parquet as pq
 
-from .perf_wide_schema import DB_SCHEMA, MANDATORY
+from .perf_wide_schema import DB_SCHEMA, MANDATORY, PROVENANCE
 
 _BOOL_MAP = {
     True: True,
@@ -280,3 +281,29 @@ def convert_csvs_to_parquet(
     table = build_run_batch(frames, **provenance)
     pq.write_table(table, out_path, compression=compression)
     return diagnostics
+
+
+def parquet_to_csvs(parquet_path, out_dir, *, drop_provenance=True, drop_empty=True):
+    """Split a run-level Parquet batch back into per-test CSVs (the reverse of
+    convert_csvs_to_parquet). One CSV per test_name, written to out_dir.
+
+    By default the CI-added provenance columns and the columns a test left
+    entirely NULL are dropped, so each CSV matches the shape of the original
+    per-test CSV. With both defaults, re-running convert_csvs_to_parquet on the
+    output reproduces the same batch. Returns {test_name: written_path}.
+    """
+    df = pq.read_table(parquet_path).to_pandas()
+    provenance_cols = {c.name for c in PROVENANCE}
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    written = {}
+    for test_name, group in df.groupby("test_name"):
+        if drop_provenance:
+            group = group[[c for c in group.columns if c not in provenance_cols]]
+        if drop_empty:
+            group = group.dropna(axis=1, how="all")
+        path = out_dir / f"{test_name}.csv"
+        group.to_csv(path, index=False)
+        written[test_name] = path
+    return written

--- a/tt_metal/tt-llk/tests/python_tests/helpers/perf_parquet.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/perf_parquet.py
@@ -5,16 +5,51 @@
 """Typed Parquet output for LLK performance reports (Milestone 2).
 
 Publishes a run's per-test reports as one immutable, typed Parquet batch whose
-physical schema is the shared wide schema (perf_wide_schema.DB_SCHEMA):
+physical schema is the shared wide schema (perf_wide_schema.DB_SCHEMA).
 
-  - stamp_provenance adds the run-context columns CI knows (commit, arch, ...).
-  - build_run_batch aligns every per-test frame to the schema (columns a test
-    did not emit become NULL), stamps provenance, and compacts them into ONE
-    run-level table. One file per run, not per test.
-  - align_to_schema / to_table fill missing columns with NULL and cast each
-    column to its declared Arrow type (nullable-int safe).
+Data flow
+---------
+Two entry points both produce {test_name: DataFrame}, then hand it to one
+shared core (build_run_batch):
 
-Needs pyarrow, but no device libraries — builds and validates without hardware.
+  A) live run   -->  {test_name: DataFrame}              (already in memory)
+
+  B) CSV files  -->  convert_csvs_to_parquet(paths, out, **prov)
+                       for each csv:
+                         _test_name_from_csv      name from filename
+                         pd.read_csv              read the text table
+                         cols not in schema    -> diagnostics: DROPPED
+                         _coerce_frame_to_schema
+                           text -> int / float / bool
+                           won't parse         -> NULL, diagnostics: COERCED
+                     -->  {test_name: cleaned DataFrame}
+
+                                   |  (both paths)
+                                   v
+  build_run_batch(frames, **provenance)                        <-- CORE
+      1  stamp_provenance      add test_name + run-context columns
+      2  pd.concat             stack every test's rows into one frame
+      3  to_table              enforce the schema (align + cast; below)
+      4  validate_batch        mandatory columns must not be NULL
+                                   |
+                                   v
+  to_table(df)
+      align_to_schema          missing cols -> NULL, drop extras, order
+      arrow_schema             column types, via _ARROW_TYPES
+      pa.array per column      cast to type; string cols stringify values
+                                   |
+                                   v
+  pq.write_table(..., zstd)     -->     one immutable  run.parquet
+
+Entry points:
+  write_run_batch          = build_run_batch + write        (frames in memory)
+  convert_csvs_to_parquet  = read + coerce + build + write  (csv files on disk)
+
+Notes:
+  * One file per RUN, not per test: build_run_batch compacts every test's rows.
+  * A test emits only its own columns; align_to_schema fills the rest with NULL.
+  * Provenance (commit/arch/run_id/...) is added by CI here, not by the test.
+  * No device libraries (pandas + pyarrow only): builds and tests hardware-free.
 """
 
 import re

--- a/tt_metal/tt-llk/tests/python_tests/helpers/perf_parquet.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/perf_parquet.py
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Typed Parquet output for LLK performance reports (Milestone 2).
+
+Writes a report DataFrame to an immutable, typed Parquet file whose physical
+schema is the shared wide schema (perf_wide_schema.DB_SCHEMA). ``align_to_schema``
+fills columns a test did not emit with NULL and orders them, so every published
+Parquet file carries one identical schema regardless of which test produced the
+rows.
+
+Needs pyarrow, but no device libraries — builds and validates without hardware.
+"""
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+from .perf_wide_schema import DB_SCHEMA
+
+_ARROW_TYPES = {
+    "int64": pa.int64(),
+    "float64": pa.float64(),
+    "bool": pa.bool_(),
+    "string": pa.string(),
+}
+
+
+def arrow_schema(columns=DB_SCHEMA) -> pa.Schema:
+    """pyarrow schema from the wide-schema Column list (name, type, nullability)."""
+    return pa.schema(
+        [pa.field(c.name, _ARROW_TYPES[c.dtype], nullable=c.nullable) for c in columns]
+    )
+
+
+def align_to_schema(df, columns=DB_SCHEMA):
+    """Reindex df to the schema: add missing columns as NULL, drop extras, order."""
+    return df.reindex(columns=[c.name for c in columns])
+
+
+def to_table(df, columns=DB_SCHEMA) -> pa.Table:
+    """Build a typed Arrow table: align, then cast each column to its schema type.
+
+    Building column-by-column with ``from_pandas=True`` maps NaN/None to null and
+    coerces to the declared type, which handles nullable ints (a pandas int column
+    with a NULL is float64) that a whole-frame conversion would reject.
+    """
+    schema = arrow_schema(columns)
+    aligned = align_to_schema(df, columns)
+    arrays = [
+        pa.array(aligned[field.name], type=field.type, from_pandas=True)
+        for field in schema
+    ]
+    return pa.Table.from_arrays(arrays, schema=schema)
+
+
+def write_parquet(df, path, columns=DB_SCHEMA, compression="zstd"):
+    """Align df to the schema and write one immutable typed Parquet file."""
+    pq.write_table(to_table(df, columns), path, compression=compression)

--- a/tt_metal/tt-llk/tests/python_tests/helpers/perf_parquet.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/perf_parquet.py
@@ -4,19 +4,24 @@
 
 """Typed Parquet output for LLK performance reports (Milestone 2).
 
-Writes a report DataFrame to an immutable, typed Parquet file whose physical
-schema is the shared wide schema (perf_wide_schema.DB_SCHEMA). ``align_to_schema``
-fills columns a test did not emit with NULL and orders them, so every published
-Parquet file carries one identical schema regardless of which test produced the
-rows.
+Publishes a run's per-test reports as one immutable, typed Parquet batch whose
+physical schema is the shared wide schema (perf_wide_schema.DB_SCHEMA):
+
+  - stamp_provenance adds the run-context columns CI knows (commit, arch, ...).
+  - build_run_batch aligns every per-test frame to the schema (columns a test
+    did not emit become NULL), stamps provenance, and compacts them into ONE
+    run-level table. One file per run, not per test.
+  - align_to_schema / to_table fill missing columns with NULL and cast each
+    column to its declared Arrow type (nullable-int safe).
 
 Needs pyarrow, but no device libraries — builds and validates without hardware.
 """
 
+import pandas as pd
 import pyarrow as pa
 import pyarrow.parquet as pq
 
-from .perf_wide_schema import DB_SCHEMA
+from .perf_wide_schema import DB_SCHEMA, MANDATORY
 
 _ARROW_TYPES = {
     "int64": pa.int64(),
@@ -57,3 +62,75 @@ def to_table(df, columns=DB_SCHEMA) -> pa.Table:
 def write_parquet(df, path, columns=DB_SCHEMA, compression="zstd"):
     """Align df to the schema and write one immutable typed Parquet file."""
     pq.write_table(to_table(df, columns), path, compression=compression)
+
+
+# ── Run-level publication ─────────────────────────────────────────────────────
+
+
+def stamp_provenance(
+    df, *, test_name, commit_sha, arch, run_id, timestamp, pipeline, pr_number=None
+):
+    """Add the run-context columns (added by CI, not produced by the test).
+
+    ``test_name`` is per test; the rest identify the run. ``pipeline`` ("PR" or
+    "nightly") is how PR and nightly rows share one schema but stay distinguishable.
+    """
+    out = df.copy()
+    out["test_name"] = test_name
+    out["commit_sha"] = commit_sha
+    out["arch"] = arch
+    out["run_id"] = run_id
+    out["timestamp"] = timestamp
+    out["pipeline"] = pipeline
+    out["pr_number"] = pr_number
+    return out
+
+
+def validate_batch(table):
+    """Every mandatory (non-nullable) column must be fully populated."""
+    for name in MANDATORY:
+        null_count = table.column(name).null_count
+        if null_count:
+            raise ValueError(
+                f"run batch has {null_count} NULL(s) in mandatory column '{name}'"
+            )
+
+
+def build_run_batch(
+    test_frames, *, commit_sha, arch, run_id, timestamp, pipeline, pr_number=None
+):
+    """Compact a run's per-test frames into one run-level table.
+
+    ``test_frames`` maps test_name -> that test's report DataFrame. Each frame is
+    stamped with run provenance and concatenated; ``to_table`` then aligns the
+    union to DB_SCHEMA (missing columns -> NULL) and casts types. One row is one
+    test configuration in one execution context.
+    """
+    stamped = [
+        stamp_provenance(
+            df,
+            test_name=name,
+            commit_sha=commit_sha,
+            arch=arch,
+            run_id=run_id,
+            timestamp=timestamp,
+            pipeline=pipeline,
+            pr_number=pr_number,
+        )
+        for name, df in test_frames.items()
+    ]
+    combined = (
+        pd.concat(stamped, ignore_index=True, sort=False)
+        if stamped
+        else pd.DataFrame(columns=[c.name for c in DB_SCHEMA])
+    )
+    table = to_table(combined)
+    validate_batch(table)
+    return table
+
+
+def write_run_batch(test_frames, path, *, compression="zstd", **provenance):
+    """Write a run's per-test frames as one immutable typed Parquet batch."""
+    pq.write_table(
+        build_run_batch(test_frames, **provenance), path, compression=compression
+    )

--- a/tt_metal/tt-llk/tests/python_tests/helpers/perf_parquet.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/perf_parquet.py
@@ -60,7 +60,7 @@ import pandas as pd
 import pyarrow as pa
 import pyarrow.parquet as pq
 
-from .perf_wide_schema import DB_SCHEMA, MANDATORY, PROVENANCE
+from .perf_wide_schema import DB_SCHEMA, MANDATORY, PROVENANCE, REDUNDANT_COLUMNS
 
 _BOOL_MAP = {
     True: True,
@@ -263,6 +263,10 @@ def convert_csvs_to_parquet(
     for path in csv_paths:
         name = _test_name_from_csv(path)
         df = pd.read_csv(path)
+        # Drop columns the published table intentionally omits (provably equal to
+        # a kept column — see perf_wide_schema.REDUNDANT_COLUMNS). Dropped before
+        # the unknown-column check so they are not flagged as accidental drift.
+        df = df.drop(columns=[c for c in REDUNDANT_COLUMNS if c in df.columns])
         unknown = sorted(set(df.columns) - set(schema_by_name))
         if unknown:
             diagnostics["unknown_columns"][name] = unknown

--- a/tt_metal/tt-llk/tests/python_tests/helpers/perf_parquet.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/perf_parquet.py
@@ -60,7 +60,7 @@ import pandas as pd
 import pyarrow as pa
 import pyarrow.parquet as pq
 
-from .perf_wide_schema import DB_SCHEMA, MANDATORY, PROVENANCE, REDUNDANT_COLUMNS
+from .perf_wide_schema import DB_SCHEMA, DROPPED_COLUMNS, MANDATORY, PROVENANCE
 
 _BOOL_MAP = {
     True: True,
@@ -263,10 +263,10 @@ def convert_csvs_to_parquet(
     for path in csv_paths:
         name = _test_name_from_csv(path)
         df = pd.read_csv(path)
-        # Drop columns the published table intentionally omits (provably equal to
-        # a kept column — see perf_wide_schema.REDUNDANT_COLUMNS). Dropped before
-        # the unknown-column check so they are not flagged as accidental drift.
-        df = df.drop(columns=[c for c in REDUNDANT_COLUMNS if c in df.columns])
+        # Drop columns the published table intentionally omits (see
+        # perf_wide_schema.DROPPED_COLUMNS), before the unknown-column check so
+        # they are not flagged as accidental drift.
+        df = df.drop(columns=[c for c in DROPPED_COLUMNS if c in df.columns])
         unknown = sorted(set(df.columns) - set(schema_by_name))
         if unknown:
             diagnostics["unknown_columns"][name] = unknown

--- a/tt_metal/tt-llk/tests/python_tests/test_perf_parquet.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_perf_parquet.py
@@ -16,6 +16,7 @@ from helpers.perf_parquet import (
     align_to_schema,
     arrow_schema,
     build_run_batch,
+    convert_csvs_to_parquet,
     stamp_provenance,
     to_table,
     write_parquet,
@@ -149,3 +150,60 @@ def test_write_run_batch_is_one_file_per_run(tmp_path):
     table = pq.read_table(path)
     assert table.schema.names == [c.name for c in DB_SCHEMA]
     assert table.num_rows == 4
+
+
+# ── CSV -> Parquet conversion ─────────────────────────────────────────────────
+
+
+def _write_csv(tmp_path, name, df):
+    path = tmp_path / name
+    df.to_csv(path, index=False)
+    return path
+
+
+def test_convert_compacts_multiple_csvs(tmp_path):
+    a = _write_csv(tmp_path, "perf_a.csv", _output_row())
+    b = _write_csv(tmp_path, "perf_b.csv", _output_row_b())
+    out = tmp_path / "run.parquet"
+
+    convert_csvs_to_parquet([a, b], out, **_RUN_PROV)
+
+    table = pq.read_table(out)
+    assert table.schema.names == [c.name for c in DB_SCHEMA]
+    assert set(table.to_pandas()["test_name"]) == {"perf_a", "perf_b"}
+
+
+def test_convert_drops_and_reports_unknown_columns(tmp_path):
+    df = pd.DataFrame({"marker": ["INIT"], "tile_cnt": [4], "made_up_col": [9]})
+    p = _write_csv(tmp_path, "perf_x.csv", df)
+
+    diag = convert_csvs_to_parquet([p], tmp_path / "out.parquet", **_RUN_PROV)
+
+    assert diag["unknown_columns"]["perf_x"] == ["made_up_col"]
+    assert "made_up_col" not in pq.read_table(tmp_path / "out.parquet").schema.names
+
+
+def test_convert_coerces_and_reports_bad_values(tmp_path):
+    # value_bits is int64 in the schema; "2.0f" can't parse -> NULL, and reported.
+    df = pd.DataFrame({"marker": ["INIT"], "value_bits": ["2.0f"], "tile_cnt": [4]})
+    p = _write_csv(tmp_path, "perf_x.csv", df)
+
+    diag = convert_csvs_to_parquet([p], tmp_path / "out.parquet", **_RUN_PROV)
+
+    assert "value_bits" in diag["coerced_values"]["perf_x"]
+    table = pq.read_table(tmp_path / "out.parquet")
+    idx = table.schema.get_field_index("value_bits")
+    assert table.column(idx).null_count == 1
+
+
+def test_convert_stringifies_bool_valued_string_column(tmp_path):
+    # unpack_to_dest is "string" in the schema but a bool in the CSV -> "True"/"False".
+    df = pd.DataFrame(
+        {"marker": ["INIT", "TILE_LOOP"], "unpack_to_dest": [True, False]}
+    )
+    p = _write_csv(tmp_path, "perf_x.csv", df)
+
+    convert_csvs_to_parquet([p], tmp_path / "out.parquet", **_RUN_PROV)
+
+    back = pq.read_table(tmp_path / "out.parquet").to_pandas()
+    assert list(back["unpack_to_dest"]) == ["True", "False"]

--- a/tt_metal/tt-llk/tests/python_tests/test_perf_parquet.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_perf_parquet.py
@@ -173,27 +173,53 @@ def test_convert_compacts_multiple_csvs(tmp_path):
     assert set(table.to_pandas()["test_name"]) == {"perf_a", "perf_b"}
 
 
-def test_convert_drops_and_reports_unknown_columns(tmp_path):
+def test_convert_lenient_drops_and_reports_unknown_columns(tmp_path):
     df = pd.DataFrame({"marker": ["INIT"], "tile_cnt": [4], "made_up_col": [9]})
     p = _write_csv(tmp_path, "perf_x.csv", df)
 
-    diag = convert_csvs_to_parquet([p], tmp_path / "out.parquet", **_RUN_PROV)
+    diag = convert_csvs_to_parquet(
+        [p], tmp_path / "out.parquet", strict=False, **_RUN_PROV
+    )
 
     assert diag["unknown_columns"]["perf_x"] == ["made_up_col"]
     assert "made_up_col" not in pq.read_table(tmp_path / "out.parquet").schema.names
 
 
-def test_convert_coerces_and_reports_bad_values(tmp_path):
+def test_convert_lenient_coerces_and_reports_bad_values(tmp_path):
     # value_bits is int64 in the schema; "2.0f" can't parse -> NULL, and reported.
     df = pd.DataFrame({"marker": ["INIT"], "value_bits": ["2.0f"], "tile_cnt": [4]})
     p = _write_csv(tmp_path, "perf_x.csv", df)
 
-    diag = convert_csvs_to_parquet([p], tmp_path / "out.parquet", **_RUN_PROV)
+    diag = convert_csvs_to_parquet(
+        [p], tmp_path / "out.parquet", strict=False, **_RUN_PROV
+    )
 
     assert "value_bits" in diag["coerced_values"]["perf_x"]
     table = pq.read_table(tmp_path / "out.parquet")
     idx = table.schema.get_field_index("value_bits")
     assert table.column(idx).null_count == 1
+
+
+def test_convert_strict_raises_on_unknown_column(tmp_path):
+    # Default strict=True: a column not in the schema is data loss -> fail loud.
+    df = pd.DataFrame({"marker": ["INIT"], "tile_cnt": [4], "made_up_col": [9]})
+    p = _write_csv(tmp_path, "perf_x.csv", df)
+    out = tmp_path / "out.parquet"
+
+    with pytest.raises(ValueError, match="made_up_col"):
+        convert_csvs_to_parquet([p], out, **_RUN_PROV)
+    assert not out.exists()  # nothing written on a lossy conversion
+
+
+def test_convert_strict_raises_on_bad_value(tmp_path):
+    # Default strict=True: an unparsable value would become NULL -> fail loud.
+    df = pd.DataFrame({"marker": ["INIT"], "value_bits": ["2.0f"], "tile_cnt": [4]})
+    p = _write_csv(tmp_path, "perf_x.csv", df)
+    out = tmp_path / "out.parquet"
+
+    with pytest.raises(ValueError, match="value_bits"):
+        convert_csvs_to_parquet([p], out, **_RUN_PROV)
+    assert not out.exists()
 
 
 def test_convert_stringifies_bool_valued_string_column(tmp_path):

--- a/tt_metal/tt-llk/tests/python_tests/test_perf_parquet.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_perf_parquet.py
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Hardware-free Parquet output tests (Milestone 2 / #51249).
+
+Checks that a report DataFrame writes to a typed Parquet file whose schema is the
+shared wide schema (DB_SCHEMA), that columns a test did not emit become NULL
+(not dropped), and that CSV and Parquet carry the same data. Needs pyarrow, no chip.
+"""
+
+import pandas as pd
+import pyarrow.parquet as pq
+from helpers.perf_parquet import align_to_schema, arrow_schema, to_table, write_parquet
+from helpers.perf_wide_schema import DB_SCHEMA
+
+
+def _output_row():
+    """What one perf test emits: a few OUTPUT columns, the rest absent."""
+    return pd.DataFrame(
+        {
+            "marker": ["INIT", "TILE_LOOP"],
+            "mean(MATH_ISOLATE)": [10.5, 20.0],
+            "std(MATH_ISOLATE)": [1.0, 2.0],
+            "tile_cnt": [4, 4],
+            "loop_factor": [1, 1],
+            "approx_mode": ["No", "No"],
+        }
+    )
+
+
+def _stamp_provenance(df):
+    df = df.copy()
+    df["test_name"] = "perf_x"
+    df["commit_sha"] = "abc123"
+    df["arch"] = "wormhole"
+    df["run_id"] = "42"
+    df["timestamp"] = "2026-01-01T00:00:00"
+    df["pipeline"] = "PR"
+    df["pr_number"] = "7"
+    return df
+
+
+def test_arrow_schema_matches_db_schema():
+    schema = arrow_schema()
+    assert schema.names == [c.name for c in DB_SCHEMA]
+    for field, col in zip(schema, DB_SCHEMA):
+        assert field.nullable == col.nullable
+
+
+def test_report_round_trips_through_parquet(tmp_path):
+    df = _stamp_provenance(_output_row())
+    path = tmp_path / "batch.parquet"
+    write_parquet(df, path)
+
+    table = pq.read_table(path)
+    assert table.schema.names == [c.name for c in DB_SCHEMA]
+
+    back = table.to_pandas()
+    assert list(back["mean(MATH_ISOLATE)"].dropna()) == [10.5, 20.0]
+    assert set(back["arch"]) == {"wormhole"}
+
+
+def test_missing_columns_are_null_not_dropped():
+    df = _stamp_provenance(_output_row())
+    table = to_table(df)
+    # a config column this test never emits is present, and entirely NULL
+    idx = table.schema.get_field_index("num_faces")
+    assert idx != -1
+    assert table.column(idx).null_count == len(df)
+
+
+def test_csv_and_parquet_agree(tmp_path):
+    df = _stamp_provenance(_output_row())
+    aligned = align_to_schema(df)
+
+    csv_path = tmp_path / "r.csv"
+    aligned.to_csv(csv_path, index=False)
+    pq_path = tmp_path / "r.parquet"
+    write_parquet(df, pq_path)
+
+    from_csv = pd.read_csv(csv_path)
+    from_pq = pq.read_table(pq_path).to_pandas()
+    assert list(from_csv.columns) == list(from_pq.columns)
+    assert list(from_csv["mean(MATH_ISOLATE)"].dropna()) == list(
+        from_pq["mean(MATH_ISOLATE)"].dropna()
+    )

--- a/tt_metal/tt-llk/tests/python_tests/test_perf_parquet.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_perf_parquet.py
@@ -11,8 +11,26 @@ shared wide schema (DB_SCHEMA), that columns a test did not emit become NULL
 
 import pandas as pd
 import pyarrow.parquet as pq
-from helpers.perf_parquet import align_to_schema, arrow_schema, to_table, write_parquet
+import pytest
+from helpers.perf_parquet import (
+    align_to_schema,
+    arrow_schema,
+    build_run_batch,
+    stamp_provenance,
+    to_table,
+    write_parquet,
+    write_run_batch,
+)
 from helpers.perf_wide_schema import DB_SCHEMA
+
+_RUN_PROV = dict(
+    commit_sha="abc123",
+    arch="wormhole",
+    run_id="42",
+    timestamp="2026-01-01T00:00:00",
+    pipeline="PR",
+    pr_number="7",
+)
 
 
 def _output_row():
@@ -30,15 +48,7 @@ def _output_row():
 
 
 def _stamp_provenance(df):
-    df = df.copy()
-    df["test_name"] = "perf_x"
-    df["commit_sha"] = "abc123"
-    df["arch"] = "wormhole"
-    df["run_id"] = "42"
-    df["timestamp"] = "2026-01-01T00:00:00"
-    df["pipeline"] = "PR"
-    df["pr_number"] = "7"
-    return df
+    return stamp_provenance(df, test_name="perf_x", **_RUN_PROV)
 
 
 def test_arrow_schema_matches_db_schema():
@@ -85,3 +95,57 @@ def test_csv_and_parquet_agree(tmp_path):
     assert list(from_csv["mean(MATH_ISOLATE)"].dropna()) == list(
         from_pq["mean(MATH_ISOLATE)"].dropna()
     )
+
+
+# ── Run-level publication ─────────────────────────────────────────────────────
+
+
+def _output_row_b():
+    """A second test emitting a different column set (no MATH_ISOLATE)."""
+    return pd.DataFrame(
+        {
+            "marker": ["INIT", "TILE_LOOP"],
+            "mean(PACK_ISOLATE)": [5.0, 6.0],
+            "num_faces": [4, 4],
+            "tile_cnt": [2, 2],
+        }
+    )
+
+
+def test_run_batch_compacts_multiple_tests():
+    # Two tests with different columns -> one batch, one schema, rows summed.
+    table = build_run_batch(
+        {"perf_a": _output_row(), "perf_b": _output_row_b()}, **_RUN_PROV
+    )
+    assert table.schema.names == [c.name for c in DB_SCHEMA]
+
+    df = table.to_pandas()
+    assert len(df) == 4  # 2 markers x 2 tests
+    assert set(df["test_name"]) == {"perf_a", "perf_b"}
+    # A column only one test emits is NULL on the other test's rows.
+    assert df[df["test_name"] == "perf_b"]["mean(MATH_ISOLATE)"].isna().all()
+    assert df[df["test_name"] == "perf_a"]["num_faces"].isna().all()
+
+
+def test_run_batch_rejects_missing_mandatory_provenance():
+    prov = dict(_RUN_PROV, commit_sha=None)
+    with pytest.raises(ValueError, match="commit_sha"):
+        build_run_batch({"perf_a": _output_row()}, **prov)
+
+
+def test_pipeline_column_distinguishes_pr_and_nightly():
+    # PR and nightly share the schema; only execution metadata differs.
+    prov = dict(_RUN_PROV, pipeline="nightly", pr_number=None)
+    table = build_run_batch({"perf_a": _output_row()}, **prov)
+    assert set(table.to_pandas()["pipeline"]) == {"nightly"}
+
+
+def test_write_run_batch_is_one_file_per_run(tmp_path):
+    path = tmp_path / "run_42.parquet"
+    write_run_batch(
+        {"perf_a": _output_row(), "perf_b": _output_row_b()}, path, **_RUN_PROV
+    )
+    assert path.exists()
+    table = pq.read_table(path)
+    assert table.schema.names == [c.name for c in DB_SCHEMA]
+    assert table.num_rows == 4

--- a/tt_metal/tt-llk/tests/python_tests/test_perf_parquet.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_perf_parquet.py
@@ -17,6 +17,7 @@ from helpers.perf_parquet import (
     arrow_schema,
     build_run_batch,
     convert_csvs_to_parquet,
+    parquet_to_csvs,
     stamp_provenance,
     to_table,
     write_parquet,
@@ -233,3 +234,42 @@ def test_convert_stringifies_bool_valued_string_column(tmp_path):
 
     back = pq.read_table(tmp_path / "out.parquet").to_pandas()
     assert list(back["unpack_to_dest"]) == ["True", "False"]
+
+
+# ── Parquet -> CSV (reverse conversion) ───────────────────────────────────────
+
+
+def test_parquet_to_csvs_splits_by_test(tmp_path):
+    batch = tmp_path / "batch.parquet"
+    write_run_batch(
+        {"perf_a": _output_row(), "perf_b": _output_row_b()}, batch, **_RUN_PROV
+    )
+
+    written = parquet_to_csvs(batch, tmp_path / "csvs")
+
+    assert set(written) == {"perf_a", "perf_b"}
+    a = pd.read_csv(written["perf_a"])
+    assert "commit_sha" not in a.columns  # provenance dropped
+    assert "mean(MATH_ISOLATE)" in a.columns  # this test's own column kept
+    assert "num_faces" not in a.columns  # only perf_b emits it -> NULL -> dropped
+
+
+def test_round_trip_parquet_csv_parquet(tmp_path):
+    # Parquet -> per-test CSVs -> Parquet reproduces the same batch.
+    batch1 = tmp_path / "batch1.parquet"
+    write_run_batch(
+        {"perf_a": _output_row(), "perf_b": _output_row_b()}, batch1, **_RUN_PROV
+    )
+
+    written = parquet_to_csvs(batch1, tmp_path / "csvs")
+    batch2 = tmp_path / "batch2.parquet"
+    convert_csvs_to_parquet(list(written.values()), batch2, **_RUN_PROV)
+
+    t1 = pq.read_table(batch1)
+    t2 = pq.read_table(batch2)
+    assert t1.schema.names == t2.schema.names
+
+    key = ["test_name", "marker"]
+    d1 = t1.to_pandas().sort_values(key).reset_index(drop=True)
+    d2 = t2.to_pandas().sort_values(key)[d1.columns].reset_index(drop=True)
+    pd.testing.assert_frame_equal(d1, d2)

--- a/tt_metal/tt-llk/tests/python_tests/test_perf_parquet.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_perf_parquet.py
@@ -37,14 +37,16 @@ _RUN_PROV = dict(
 
 def _output_row():
     """What one perf test emits: a few OUTPUT columns, the rest absent."""
+    # Real perf reports carry three profiler markers per config: INIT, KERNEL,
+    # TILE_LOOP (see the marker values in nightly CSVs).
     return pd.DataFrame(
         {
-            "marker": ["INIT", "TILE_LOOP"],
-            "mean(MATH_ISOLATE)": [10.5, 20.0],
-            "std(MATH_ISOLATE)": [1.0, 2.0],
-            "tile_cnt": [4, 4],
-            "loop_factor": [1, 1],
-            "approx_mode": ["No", "No"],
+            "marker": ["INIT", "KERNEL", "TILE_LOOP"],
+            "mean(MATH_ISOLATE)": [10.5, 15.0, 20.0],
+            "std(MATH_ISOLATE)": [1.0, 1.5, 2.0],
+            "tile_cnt": [4, 4, 4],
+            "loop_factor": [1, 1, 1],
+            "approx_mode": ["No", "No", "No"],
         }
     )
 
@@ -69,8 +71,14 @@ def test_report_round_trips_through_parquet(tmp_path):
     assert table.schema.names == [c.name for c in DB_SCHEMA]
 
     back = table.to_pandas()
-    assert list(back["mean(MATH_ISOLATE)"].dropna()) == [10.5, 20.0]
+    # every source row survives, values intact, provenance stamped on each row.
+    assert table.num_rows == len(df)
+    assert list(back["marker"]) == ["INIT", "KERNEL", "TILE_LOOP"]
+    assert list(back["mean(MATH_ISOLATE)"].dropna()) == [10.5, 15.0, 20.0]
     assert set(back["arch"]) == {"wormhole"}
+    assert set(back["commit_sha"]) == {"abc123"}
+    assert set(back["test_name"]) == {"perf_x"}
+    # tmp_path is torn down by pytest, so the file needs no manual cleanup.
 
 
 def test_missing_columns_are_null_not_dropped():
@@ -106,10 +114,10 @@ def _output_row_b():
     """A second test emitting a different column set (no MATH_ISOLATE)."""
     return pd.DataFrame(
         {
-            "marker": ["INIT", "TILE_LOOP"],
-            "mean(PACK_ISOLATE)": [5.0, 6.0],
-            "num_faces": [4, 4],
-            "tile_cnt": [2, 2],
+            "marker": ["INIT", "KERNEL", "TILE_LOOP"],
+            "mean(PACK_ISOLATE)": [5.0, 5.5, 6.0],
+            "num_faces": [4, 4, 4],
+            "tile_cnt": [2, 2, 2],
         }
     )
 
@@ -122,7 +130,7 @@ def test_run_batch_compacts_multiple_tests():
     assert table.schema.names == [c.name for c in DB_SCHEMA]
 
     df = table.to_pandas()
-    assert len(df) == 4  # 2 markers x 2 tests
+    assert len(df) == 6  # 3 markers x 2 tests
     assert set(df["test_name"]) == {"perf_a", "perf_b"}
     # A column only one test emits is NULL on the other test's rows.
     assert df[df["test_name"] == "perf_b"]["mean(MATH_ISOLATE)"].isna().all()
@@ -150,7 +158,7 @@ def test_write_run_batch_is_one_file_per_run(tmp_path):
     assert path.exists()
     table = pq.read_table(path)
     assert table.schema.names == [c.name for c in DB_SCHEMA]
-    assert table.num_rows == 4
+    assert table.num_rows == 6
 
 
 # ── CSV -> Parquet conversion ─────────────────────────────────────────────────

--- a/tt_metal/tt-llk/tests/python_tests/test_perf_parquet.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_perf_parquet.py
@@ -139,7 +139,9 @@ def test_run_batch_compacts_multiple_tests():
 
 def test_run_batch_rejects_missing_mandatory_provenance():
     prov = dict(_RUN_PROV, commit_sha=None)
-    with pytest.raises(ValueError, match="commit_sha"):
+    with pytest.raises(  # allow-pytest.raises: no expect_error fixture in LLK suite
+        ValueError, match="commit_sha"
+    ):
         build_run_batch({"perf_a": _output_row()}, **prov)
 
 
@@ -215,7 +217,9 @@ def test_convert_strict_raises_on_unknown_column(tmp_path):
     p = _write_csv(tmp_path, "perf_x.csv", df)
     out = tmp_path / "out.parquet"
 
-    with pytest.raises(ValueError, match="made_up_col"):
+    with pytest.raises(  # allow-pytest.raises: no expect_error fixture in LLK suite
+        ValueError, match="made_up_col"
+    ):
         convert_csvs_to_parquet([p], out, **_RUN_PROV)
     assert not out.exists()  # nothing written on a lossy conversion
 
@@ -226,7 +230,9 @@ def test_convert_strict_raises_on_bad_value(tmp_path):
     p = _write_csv(tmp_path, "perf_x.csv", df)
     out = tmp_path / "out.parquet"
 
-    with pytest.raises(ValueError, match="value_bits"):
+    with pytest.raises(  # allow-pytest.raises: no expect_error fixture in LLK suite
+        ValueError, match="value_bits"
+    ):
         convert_csvs_to_parquet([p], out, **_RUN_PROV)
     assert not out.exists()
 

--- a/tt_metal/tt-llk/tests/python_tests/test_perf_parquet.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_perf_parquet.py
@@ -245,7 +245,7 @@ def test_convert_stringifies_bool_valued_string_column(tmp_path):
 
 
 def test_convert_drops_redundant_columns_strict_safe(tmp_path):
-    # input_/output_num_blocks are provably == num_blocks (REDUNDANT_COLUMNS): the
+    # input_/output_num_blocks are provably == num_blocks (DROPPED_COLUMNS): the
     # converter drops them and does NOT trip the strict unknown-column guard.
     df = pd.DataFrame(
         {

--- a/tt_metal/tt-llk/tests/python_tests/test_perf_parquet.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_perf_parquet.py
@@ -244,9 +244,31 @@ def test_convert_stringifies_bool_valued_string_column(tmp_path):
     assert list(back["unpack_to_dest"]) == ["True", "False"]
 
 
-def test_convert_drops_redundant_columns_strict_safe(tmp_path):
-    # input_/output_num_blocks are provably == num_blocks (DROPPED_COLUMNS): the
-    # converter drops them and does NOT trip the strict unknown-column guard.
+def test_convert_drops_dropped_columns_strict_safe(tmp_path):
+    # TEXT_SIZE(...) columns are in DROPPED_COLUMNS (per-stage ELF code size, not
+    # used by the gate): the converter drops them and does NOT trip the strict
+    # unknown-column guard.
+    df = pd.DataFrame(
+        {
+            "marker": ["INIT"],
+            "num_blocks": [4],
+            "TEXT_SIZE(MATH_ISOLATE)": [2048],
+            "tile_cnt": [2],
+        }
+    )
+    p = _write_csv(tmp_path, "perf_x.csv", df)
+
+    diag = convert_csvs_to_parquet([p], tmp_path / "out.parquet", **_RUN_PROV)
+
+    assert diag["unknown_columns"] == {}  # not flagged as drift
+    names = pq.read_table(tmp_path / "out.parquet").schema.names
+    assert "num_blocks" in names
+    assert "TEXT_SIZE(MATH_ISOLATE)" not in names
+
+
+def test_convert_keeps_num_blocks_columns(tmp_path):
+    # input_/output_num_blocks are real schema columns now: they must survive the
+    # round-trip, not be dropped.
     df = pd.DataFrame(
         {
             "marker": ["INIT"],
@@ -260,11 +282,10 @@ def test_convert_drops_redundant_columns_strict_safe(tmp_path):
 
     diag = convert_csvs_to_parquet([p], tmp_path / "out.parquet", **_RUN_PROV)
 
-    assert diag["unknown_columns"] == {}  # not flagged as drift
+    assert diag["unknown_columns"] == {}
     names = pq.read_table(tmp_path / "out.parquet").schema.names
-    assert "num_blocks" in names
-    assert "input_num_blocks" not in names
-    assert "output_num_blocks" not in names
+    assert "input_num_blocks" in names
+    assert "output_num_blocks" in names
 
 
 # ── Parquet -> CSV (reverse conversion) ───────────────────────────────────────

--- a/tt_metal/tt-llk/tests/python_tests/test_perf_parquet.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_perf_parquet.py
@@ -244,6 +244,29 @@ def test_convert_stringifies_bool_valued_string_column(tmp_path):
     assert list(back["unpack_to_dest"]) == ["True", "False"]
 
 
+def test_convert_drops_redundant_columns_strict_safe(tmp_path):
+    # input_/output_num_blocks are provably == num_blocks (REDUNDANT_COLUMNS): the
+    # converter drops them and does NOT trip the strict unknown-column guard.
+    df = pd.DataFrame(
+        {
+            "marker": ["INIT"],
+            "num_blocks": [4],
+            "input_num_blocks": [4],
+            "output_num_blocks": [4],
+            "tile_cnt": [2],
+        }
+    )
+    p = _write_csv(tmp_path, "perf_x.csv", df)
+
+    diag = convert_csvs_to_parquet([p], tmp_path / "out.parquet", **_RUN_PROV)
+
+    assert diag["unknown_columns"] == {}  # not flagged as drift
+    names = pq.read_table(tmp_path / "out.parquet").schema.names
+    assert "num_blocks" in names
+    assert "input_num_blocks" not in names
+    assert "output_num_blocks" not in names
+
+
 # ── Parquet -> CSV (reverse conversion) ───────────────────────────────────────
 
 


### PR DESCRIPTION
Implemented conversion of CSV perf test outputs into Parquet format for easier data handling.
In comparison to CSV files, parquet files proved to take up up to 17.7x less space.

Results produced on a nightly run:

| Arch      | Tests | Rows    | CSV       | Parquet (zstd) | Saved          |
|-----------|------:|--------:|----------:|---------------:|----------------|
| Wormhole  |    23 | 101,436 |  22.42 MB |        1.39 MB | 93.8% (16.1×)  |
| Blackhole |    22 | 108,752 |  23.32 MB |        1.18 MB | 94.9% (19.8×)  |
| **Both**  |    45 | 210,188 | **45.74 MB** |   **2.57 MB** | **94.4% (17.8×)** |

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nstojictt/perf-parquet)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nstojictt/perf-parquet)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nstojictt/perf-parquet)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nstojictt/perf-parquet)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=nstojictt/perf-parquet)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:nstojictt/perf-parquet)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nstojictt/perf-parquet)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nstojictt/perf-parquet)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nstojictt/perf-parquet)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nstojictt/perf-parquet)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nstojictt/perf-parquet)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nstojictt/perf-parquet)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nstojictt/perf-parquet)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nstojictt/perf-parquet)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nstojictt/perf-parquet)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nstojictt/perf-parquet)