### PR TITLE
[Bug] Fixing Quasar DE assignment so related FD kernels are always co-located

### DIFF
--- a/tt_metal/llrt/dispatch_engine_cores.cpp
+++ b/tt_metal/llrt/dispatch_engine_cores.cpp
@@ -40,19 +40,26 @@ std::vector<tt::tt_metal::CoreCoord> get_quasar_tensix_fallback_dispatch_cores_f
     return core_desc.logical_dispatch_cores;
 }
 
-// Quasar 1CQ fast dispatch places prefetch and dispatch HD on the same dispatch-engine tile.
-// dispatch_s shares that tile; dispatch_core_manager assigns prefetch/dispatch via separate pool
-// pops, mirroring interim Tensix YAML that lists the same logical coord twice. Free DMs are
-// auto-assigned at CreateDispatchEngineKernel time (same policy as Quasar Tensix CreateKernel).
+// Quasar FD places prefetch, dispatch HD, and dispatch_s on the same dispatch-engine tile
+// (one tile per CQ). dispatch_core_manager assigns prefetch/dispatch via separate pool pops;
+// dispatch_s is forced onto the dispatcher tile. Rebuild the soc DE list as
+// [DE0, DE0, DE1, DE1, ...] so each CQ's prefetch+dispatch share a tile. Extra DEs beyond
+// num_hw_cqs are unused; if fewer DEs than CQs, later CQs reuse the last available DE.
+// Free DMs are auto-assigned at CreateDispatchEngineKernel time.
 void expand_quasar_dispatch_engine_pool_for_fd_assignment(
     std::vector<tt::tt_metal::CoreCoord>& logical_cores, uint8_t num_hw_cqs) {
-    if (logical_cores.size() != 1) {
+    if (logical_cores.empty() || num_hw_cqs == 0) {
         return;
     }
-    const size_t min_pool_entries = static_cast<size_t>(num_hw_cqs) * 2;
-    logical_cores.reserve(min_pool_entries);
-    while (logical_cores.size() < min_pool_entries) {
-        logical_cores.push_back(logical_cores.front());
+    const std::vector<tt::tt_metal::CoreCoord> available_des = std::move(logical_cores);
+    logical_cores.clear();
+    logical_cores.reserve(static_cast<size_t>(num_hw_cqs) * 2);
+    for (uint8_t cq_id = 0; cq_id < num_hw_cqs; ++cq_id) {
+        const size_t de_index =
+            (static_cast<size_t>(cq_id) < available_des.size()) ? cq_id : available_des.size() - 1;
+        const auto& de = available_des[de_index];
+        logical_cores.push_back(de);
+        logical_cores.push_back(de);
     }
 }
 

--- a/tt_metal/llrt/dispatch_engine_cores.cpp
+++ b/tt_metal/llrt/dispatch_engine_cores.cpp
@@ -44,7 +44,7 @@ std::vector<tt::tt_metal::CoreCoord> get_quasar_tensix_fallback_dispatch_cores_f
 // (one tile per CQ). dispatch_core_manager assigns prefetch/dispatch via separate pool pops;
 // dispatch_s is forced onto the dispatcher tile. Rebuild the soc DE list as
 // [DE0, DE0, DE1, DE1, ...] so each CQ's prefetch+dispatch share a tile. Extra DEs beyond
-// num_hw_cqs are unused; if fewer DEs than CQs, later CQs reuse the last available DE.
+// num_hw_cqs are unused; if fewer DEs than CQs, later CQs cycle through the DEs again.
 // Free DMs are auto-assigned at CreateDispatchEngineKernel time.
 void expand_quasar_dispatch_engine_pool_for_fd_assignment(
     std::vector<tt::tt_metal::CoreCoord>& logical_cores, uint8_t num_hw_cqs) {
@@ -55,8 +55,7 @@ void expand_quasar_dispatch_engine_pool_for_fd_assignment(
     logical_cores.clear();
     logical_cores.reserve(static_cast<size_t>(num_hw_cqs) * 2);
     for (uint8_t cq_id = 0; cq_id < num_hw_cqs; ++cq_id) {
-        const size_t de_index =
-            (static_cast<size_t>(cq_id) < available_des.size()) ? cq_id : available_des.size() - 1;
+        const size_t de_index = static_cast<size_t>(cq_id) % available_des.size();
         const auto& de = available_des[de_index];
         logical_cores.push_back(de);
         logical_cores.push_back(de);


### PR DESCRIPTION
### PR Category
[Bug] #51738 

### Summary
When running on a device with 2 DEs enabled, current code hangs. There was a bug in the allocation, that was splitting the dispatch engine kernels (i.e. prefetch & dispatch) across DEs instead of co-locating them and splitting CQs across DEs.

This change fixes the allocation, so now prefetch, dispatch & dispatch_s associated with a single CQ are always assigned to the same DE. The allocation today is random/first seen order but can be updated in this same function later if desired.

### Notes for reviewers

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=kstevens/issue_51738)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:kstevens/issue_51738)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=kstevens/issue_51738)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:kstevens/issue_51738)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=kstevens/issue_51738)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:kstevens/issue_51738)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=kstevens/issue_51738)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:kstevens/issue_51738)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=kstevens/issue_51738)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:kstevens/issue_51738)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=kstevens/issue_51738)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:kstevens/issue_51738)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=kstevens/issue_51738)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:kstevens/issue_51738)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=kstevens/issue_51738)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:kstevens/issue_51738)